### PR TITLE
[Merged by Bors] - chore(Combinatorics): use newly introduced finset notation

### DIFF
--- a/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
@@ -92,15 +92,14 @@ def box (n d : ℕ) : Finset (Fin n → ℕ) :=
 theorem mem_box : x ∈ box n d ↔ ∀ i, x i < d := by simp only [box, Fintype.mem_piFinset, mem_range]
 
 @[simp]
-theorem card_box : (box n d).card = d ^ n := by simp [box]
+theorem card_box : #(box n d) = d ^ n := by simp [box]
 
 @[simp]
 theorem box_zero : box (n + 1) 0 = ∅ := by simp [box]
 
 /-- The intersection of the sphere of radius `√k` with the integer points in the positive
 quadrant. -/
-def sphere (n d k : ℕ) : Finset (Fin n → ℕ) :=
-  (box n d).filter fun x => ∑ i, x i ^ 2 = k
+def sphere (n d k : ℕ) : Finset (Fin n → ℕ) := {x ∈ box n d | ∑ i, x i ^ 2 = k}
 
 theorem sphere_zero_subset : sphere n d 0 ⊆ 0 := fun x => by simp [sphere, funext_iff]
 
@@ -204,7 +203,7 @@ theorem sum_lt : (∑ i : Fin n, d * (2 * d + 1) ^ (i : ℕ)) < (2 * d + 1) ^ n 
   sum_eq.trans_lt <| (Nat.div_le_self _ 2).trans_lt <| pred_lt (pow_pos (succ_pos _) _).ne'
 
 theorem card_sphere_le_rothNumberNat (n d k : ℕ) :
-    (sphere n d k).card ≤ rothNumberNat ((2 * d - 1) ^ n) := by
+    #(sphere n d k) ≤ rothNumberNat ((2 * d - 1) ^ n) := by
   cases n
   · dsimp; refine (card_le_univ _).trans_eq ?_; rfl
   cases d
@@ -229,7 +228,7 @@ that we then optimize by tweaking the parameters. The (almost) optimal parameter
 
 
 theorem exists_large_sphere_aux (n d : ℕ) : ∃ k ∈ range (n * (d - 1) ^ 2 + 1),
-    (↑(d ^ n) / ((n * (d - 1) ^ 2 :) + 1) : ℝ) ≤ (sphere n d k).card := by
+    (↑(d ^ n) / ((n * (d - 1) ^ 2 :) + 1) : ℝ) ≤ #(sphere n d k) := by
   refine exists_le_card_fiber_of_nsmul_le_card_of_maps_to (fun x hx => ?_) nonempty_range_succ ?_
   · rw [mem_range, Nat.lt_succ_iff]
     exact sum_sq_le_of_mem_box hx
@@ -238,7 +237,7 @@ theorem exists_large_sphere_aux (n d : ℕ) : ∃ k ∈ range (n * (d - 1) ^ 2 +
     exact (cast_add_one_pos _).ne'
 
 theorem exists_large_sphere (n d : ℕ) :
-    ∃ k, ((d ^ n :) / (n * d ^ 2 :) : ℝ) ≤ (sphere n d k).card := by
+    ∃ k, ((d ^ n :) / (n * d ^ 2 :) : ℝ) ≤ #(sphere n d k) := by
   obtain ⟨k, -, hk⟩ := exists_large_sphere_aux n d
   refine ⟨k, ?_⟩
   obtain rfl | hn := n.eq_zero_or_pos

--- a/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
@@ -253,31 +253,31 @@ subset.
 
 The usual Roth number corresponds to `addRothNumber (Finset.range n)`, see `rothNumberNat`."]
 def mulRothNumber : Finset α →o ℕ :=
-  ⟨fun s ↦ Nat.findGreatest (fun m ↦ ∃ t ⊆ s, t.card = m ∧ ThreeGPFree (t : Set α)) s.card, by
+  ⟨fun s ↦ Nat.findGreatest (fun m ↦ ∃ t ⊆ s, #t = m ∧ ThreeGPFree (t : Set α)) #s, by
     rintro t u htu
     refine Nat.findGreatest_mono (fun m => ?_) (card_le_card htu)
     rintro ⟨v, hvt, hv⟩
     exact ⟨v, hvt.trans htu, hv⟩⟩
 
 @[to_additive]
-theorem mulRothNumber_le : mulRothNumber s ≤ s.card := Nat.findGreatest_le s.card
+theorem mulRothNumber_le : mulRothNumber s ≤ #s := Nat.findGreatest_le #s
 
 @[to_additive]
 theorem mulRothNumber_spec :
-    ∃ t ⊆ s, t.card = mulRothNumber s ∧ ThreeGPFree (t : Set α) :=
-  Nat.findGreatest_spec (P := fun m ↦ ∃ t ⊆ s, t.card = m ∧ ThreeGPFree (t : Set α))
+    ∃ t ⊆ s, #t = mulRothNumber s ∧ ThreeGPFree (t : Set α) :=
+  Nat.findGreatest_spec (P := fun m ↦ ∃ t ⊆ s, #t = m ∧ ThreeGPFree (t : Set α))
     (Nat.zero_le _) ⟨∅, empty_subset _, card_empty, by norm_cast; exact threeGPFree_empty⟩
 
 variable {s t} {n : ℕ}
 
 @[to_additive]
 theorem ThreeGPFree.le_mulRothNumber (hs : ThreeGPFree (s : Set α)) (h : s ⊆ t) :
-    s.card ≤ mulRothNumber t :=
+    #s ≤ mulRothNumber t :=
   Nat.le_findGreatest (card_le_card h) ⟨s, h, rfl, hs⟩
 
 @[to_additive]
 theorem ThreeGPFree.mulRothNumber_eq (hs : ThreeGPFree (s : Set α)) :
-    mulRothNumber s = s.card :=
+    mulRothNumber s = #s :=
   (mulRothNumber_le _).antisymm <| hs.le_mulRothNumber <| Subset.refl _
 
 @[to_additive (attr := simp)]
@@ -295,9 +295,9 @@ theorem mulRothNumber_union_le (s t : Finset α) :
     mulRothNumber (s ∪ t) ≤ mulRothNumber s + mulRothNumber t :=
   let ⟨u, hus, hcard, hu⟩ := mulRothNumber_spec (s ∪ t)
   calc
-    mulRothNumber (s ∪ t) = u.card := hcard.symm
-    _ = (u ∩ s ∪ u ∩ t).card := by rw [← inter_union_distrib_left, inter_eq_left.2 hus]
-    _ ≤ (u ∩ s).card + (u ∩ t).card := card_union_le _ _
+    mulRothNumber (s ∪ t) = #u := hcard.symm
+    _ = #(u ∩ s ∪ u ∩ t) := by rw [← inter_union_distrib_left, inter_eq_left.2 hus]
+    _ ≤ #(u ∩ s) + #(u ∩ t) := card_union_le _ _
     _ ≤ mulRothNumber s + mulRothNumber t := _root_.add_le_add
       ((hu.mono inter_subset_left).le_mulRothNumber inter_subset_right)
       ((hu.mono inter_subset_left).le_mulRothNumber inter_subset_right)
@@ -407,13 +407,13 @@ theorem rothNumberNat_le (N : ℕ) : rothNumberNat N ≤ N :=
   (addRothNumber_le _).trans (card_range _).le
 
 theorem rothNumberNat_spec (n : ℕ) :
-    ∃ t ⊆ range n, t.card = rothNumberNat n ∧ ThreeAPFree (t : Set ℕ) :=
+    ∃ t ⊆ range n, #t = rothNumberNat n ∧ ThreeAPFree (t : Set ℕ) :=
   addRothNumber_spec _
 
 /-- A verbose specialization of `threeAPFree.le_addRothNumber`, sometimes convenient in
 practice. -/
 theorem ThreeAPFree.le_rothNumberNat (s : Finset ℕ) (hs : ThreeAPFree (s : Set ℕ))
-    (hsn : ∀ x ∈ s, x < n) (hsk : s.card = k) : k ≤ rothNumberNat n :=
+    (hsn : ∀ x ∈ s, x < n) (hsk : #s = k) : k ≤ rothNumberNat n :=
   hsk.ge.trans <| hs.le_addRothNumber fun x hx => mem_range.2 <| hsn x hx
 
 /-- The Roth number is a subadditive function. Note that by Fekete's lemma this shows that

--- a/Mathlib/Combinatorics/Additive/Corner/Roth.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Roth.lean
@@ -40,7 +40,7 @@ private lemma mk_mem_triangleIndices : (a, b, c) ∈ triangleIndices A ↔ (a, b
   rintro ⟨_, _, h₁, rfl, rfl, h₂⟩
   exact ⟨h₁, h₂⟩
 
-@[simp] private lemma card_triangleIndices : (triangleIndices A).card = A.card := card_map _
+@[simp] private lemma card_triangleIndices : #(triangleIndices A) = #A := card_map _
 
 private instance triangleIndices.instExplicitDisjoint : ExplicitDisjoint (triangleIndices A) := by
   constructor
@@ -55,7 +55,7 @@ private lemma noAccidental (hs : IsCornerFree (A : Set (G × G))) :
     simp only [mk_mem_triangleIndices] at ha hb hc
     exact .inl <| hs ⟨hc.1, hb.1, ha.1, hb.2.symm.trans ha.2⟩
 
-private lemma farFromTriangleFree_graph [Fintype G] [DecidableEq G] (hε : ε * card G ^ 2 ≤ A.card) :
+private lemma farFromTriangleFree_graph [Fintype G] [DecidableEq G] (hε : ε * card G ^ 2 ≤ #A) :
     (graph <| triangleIndices A).FarFromTriangleFree (ε / 9) := by
   refine farFromTriangleFree _ ?_
   simp_rw [card_triangleIndices, mul_comm_div, Nat.cast_pow, Nat.cast_add]
@@ -79,7 +79,7 @@ noncomputable def cornersTheoremBound (ε : ℝ) : ℕ := ⌊(triangleRemovalBou
 
 The maximum density of a corner-free set in `G × G` goes to zero as `|G|` tends to infinity. -/
 theorem corners_theorem (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound ε ≤ card G)
-    (A : Finset (G × G)) (hAε : ε * card G ^ 2 ≤ A.card) : ¬ IsCornerFree (A : Set (G × G)) := by
+    (A : Finset (G × G)) (hAε : ε * card G ^ 2 ≤ #A) : ¬ IsCornerFree (A : Set (G × G)) := by
   rintro hA
   rw [cornersTheoremBound, Nat.add_one_le_iff] at hG
   have hε₁ : ε ≤ 1 := by
@@ -103,7 +103,7 @@ theorem corners_theorem (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound ε �
 The maximum density of a corner-free set in `{1, ..., n} × {1, ..., n}` goes to zero as `n` tends to
 infinity. -/
 theorem corners_theorem_nat (hε : 0 < ε) (hn : cornersTheoremBound (ε / 9) ≤ n)
-    (A : Finset (ℕ × ℕ)) (hAn : A ⊆ range n ×ˢ range n) (hAε : ε * n ^ 2 ≤ A.card) :
+    (A : Finset (ℕ × ℕ)) (hAn : A ⊆ range n ×ˢ range n) (hAε : ε * n ^ 2 ≤ #A) :
     ¬ IsCornerFree (A : Set (ℕ × ℕ)) := by
   rintro hA
   rw [← coe_subset, coe_product] at hAn
@@ -128,7 +128,7 @@ theorem corners_theorem_nat (hε : 0 < ε) (hn : cornersTheoremBound (ε / 9) �
     _ = ε / 9 * (2 * n + 1) ^ 2 := by simp
     _ ≤ ε / 9 * (2 * n + n) ^ 2 := by gcongr; simp; unfold cornersTheoremBound at hn; omega
     _ = ε * n ^ 2 := by ring
-    _ ≤ A.card := hAε
+    _ ≤ #A := hAε
     _ = _ := by
       rw [card_image_of_injOn]
       have : Set.InjOn Nat.cast (range n) :=
@@ -139,15 +139,15 @@ theorem corners_theorem_nat (hε : 0 < ε) (hn : cornersTheoremBound (ε / 9) �
 
 The maximum density of a 3AP-free set in `G` goes to zero as `|G|` tends to infinity. -/
 theorem roth_3ap_theorem (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound ε ≤ card G)
-    (A : Finset G) (hAε : ε * card G ≤ A.card) : ¬ ThreeAPFree (A : Set G) := by
+    (A : Finset G) (hAε : ε * card G ≤ #A) : ¬ ThreeAPFree (A : Set G) := by
   rintro hA
   classical
   let B : Finset (G × G) := univ.filter fun (x, y) ↦ y - x ∈ A
-  have : ε * card G ^ 2 ≤ B.card := by
+  have : ε * card G ^ 2 ≤ #B := by
     calc
       _ = card G * (ε * card G) := by ring
-      _ ≤ card G * A.card := by gcongr
-      _ = B.card := ?_
+      _ ≤ card G * #A := by gcongr
+      _ = #B := ?_
     norm_cast
     rw [← card_univ, ← card_product]
     exact card_equiv ((Equiv.refl _).prodShear fun a ↦ Equiv.addLeft a) (by simp [B])
@@ -164,7 +164,7 @@ theorem roth_3ap_theorem (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound ε 
 
 The maximum density of a 3AP-free set in `{1, ..., n}` goes to zero as `n` tends to infinity. -/
 theorem roth_3ap_theorem_nat (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound (ε / 3) ≤ n)
-    (A : Finset ℕ) (hAn : A ⊆ range n) (hAε : ε * n ≤ A.card) : ¬ ThreeAPFree (A : Set ℕ) := by
+    (A : Finset ℕ) (hAn : A ⊆ range n) (hAε : ε * n ≤ #A) : ¬ ThreeAPFree (A : Set ℕ) := by
   rintro hA
   rw [← coe_subset, coe_range] at hAn
   have : A = Fin.val '' (Nat.cast '' A : Set (Fin (2 * n).succ)) := by
@@ -185,7 +185,7 @@ theorem roth_3ap_theorem_nat (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound
     _ = ε / 3 * (2 * n + 1) := by simp
     _ ≤ ε / 3 * (2 * n + n) := by gcongr; simp; unfold cornersTheoremBound at hG; omega
     _ = ε * n := by ring
-    _ ≤ A.card := hAε
+    _ ≤ #A := hAε
     _ = _ := by
       rw [card_image_of_injOn]
       exact (CharP.natCast_injOn_Iio (Fin (2 * n).succ) (2 * n).succ).mono <| hAn.trans <| by

--- a/Mathlib/Combinatorics/Additive/DoublingConst.lean
+++ b/Mathlib/Combinatorics/Additive/DoublingConst.lean
@@ -30,7 +30,7 @@ The notation `σₘ[A, B]` is available in scope `Combinatorics.Additive`. -/
 "The doubling constant `σ[A, B]` of two finsets `A` and `B` in a group is `|A + B| / |A|`.
 
 The notation `σ[A, B]` is available in scope `Combinatorics.Additive`."]
-def mulConst (A B : Finset G) : ℚ≥0 := (A * B).card / A.card
+def mulConst (A B : Finset G) : ℚ≥0 := #(A * B) / #A
 
 /-- The difference constant `δₘ[A, B]` of two finsets `A` and `B` in a group is `|A / B| / |A|`.
 
@@ -39,7 +39,7 @@ The notation `δₘ[A, B]` is available in scope `Combinatorics.Additive`. -/
 "The difference constant `σ[A, B]` of two finsets `A` and `B` in a group is `|A - B| / |A|`.
 
 The notation `δ[A, B]` is available in scope `Combinatorics.Additive`."]
-def divConst (A B : Finset G) : ℚ≥0 := (A / B).card / A.card
+def divConst (A B : Finset G) : ℚ≥0 := #(A / B) / #A
 
 /-- The doubling constant `σₘ[A, B]` of two finsets `A` and `B` in a group is `|A * B| / |A|`. -/
 scoped[Combinatorics.Additive] notation3:max "σₘ[" A ", " B "]" => Finset.mulConst A B
@@ -68,23 +68,23 @@ scoped[Combinatorics.Additive] notation3:max "δ[" A "]" => Finset.subConst A A
 open scoped Combinatorics.Additive
 
 @[to_additive (attr := simp) addConst_mul_card]
-lemma mulConst_mul_card (A B : Finset G) : σₘ[A, B] * A.card = (A * B).card := by
+lemma mulConst_mul_card (A B : Finset G) : σₘ[A, B] * #A = #(A * B) := by
   obtain rfl | hA := A.eq_empty_or_nonempty
   · simp
   · exact div_mul_cancel₀ _ (by positivity)
 
 @[to_additive (attr := simp) subConst_mul_card]
-lemma divConst_mul_card (A B : Finset G) : δₘ[A, B] * A.card = (A / B).card := by
+lemma divConst_mul_card (A B : Finset G) : δₘ[A, B] * #A = #(A / B) := by
   obtain rfl | hA := A.eq_empty_or_nonempty
   · simp
   · exact div_mul_cancel₀ _ (by positivity)
 
 @[to_additive (attr := simp) card_mul_addConst]
-lemma card_mul_mulConst (A B : Finset G) : A.card * σₘ[A, B] = (A * B).card := by
+lemma card_mul_mulConst (A B : Finset G) : #A * σₘ[A, B] = #(A * B) := by
   rw [mul_comm, mulConst_mul_card]
 
 @[to_additive (attr := simp) card_mul_subConst]
-lemma card_mul_divConst (A B : Finset G) : A.card * δₘ[A, B] = (A / B).card := by
+lemma card_mul_divConst (A B : Finset G) : #A * δₘ[A, B] = #(A / B) := by
   rw [mul_comm, divConst_mul_card]
 
 @[to_additive (attr := simp)]
@@ -124,44 +124,44 @@ end Fintype
 
 variable {𝕜 : Type*} [Semifield 𝕜] [CharZero 𝕜]
 
-lemma cast_addConst (A B : Finset G') : (σ[A, B] : 𝕜) = (A + B).card / A.card := by
+lemma cast_addConst (A B : Finset G') : (σ[A, B] : 𝕜) = #(A + B) / #A := by
   simp [addConst]
 
-lemma cast_subConst (A B : Finset G') : (δ[A, B] : 𝕜) = (A - B).card / A.card := by
+lemma cast_subConst (A B : Finset G') : (δ[A, B] : 𝕜) = #(A - B) / #A := by
   simp [subConst]
 
 @[to_additive existing]
-lemma cast_mulConst (A B : Finset G) : (σₘ[A, B] : 𝕜) = (A * B).card / A.card := by simp [mulConst]
+lemma cast_mulConst (A B : Finset G) : (σₘ[A, B] : 𝕜) = #(A * B) / #A := by simp [mulConst]
 
 @[to_additive existing]
-lemma cast_divConst (A B : Finset G) : (δₘ[A, B] : 𝕜) = (A / B).card / A.card := by simp [divConst]
+lemma cast_divConst (A B : Finset G) : (δₘ[A, B] : 𝕜) = #(A / B) / #A := by simp [divConst]
 
-lemma cast_addConst_mul_card (A B : Finset G') : (σ[A, B] * A.card : 𝕜) = (A + B).card := by
+lemma cast_addConst_mul_card (A B : Finset G') : (σ[A, B] * #A : 𝕜) = #(A + B) := by
   norm_cast; exact addConst_mul_card _ _
 
-lemma cast_subConst_mul_card (A B : Finset G') : (δ[A, B] * A.card : 𝕜) = (A - B).card := by
+lemma cast_subConst_mul_card (A B : Finset G') : (δ[A, B] * #A : 𝕜) = #(A - B) := by
   norm_cast; exact subConst_mul_card _ _
 
-lemma card_mul_cast_addConst (A B : Finset G') : (A.card * σ[A, B] : 𝕜) = (A + B).card := by
+lemma card_mul_cast_addConst (A B : Finset G') : (#A * σ[A, B] : 𝕜) = #(A + B) := by
   norm_cast; exact card_mul_addConst _ _
 
-lemma card_mul_cast_subConst (A B : Finset G') : (A.card * δ[A, B] : 𝕜) = (A - B).card := by
+lemma card_mul_cast_subConst (A B : Finset G') : (#A * δ[A, B] : 𝕜) = #(A - B) := by
   norm_cast; exact card_mul_subConst _ _
 
 @[to_additive (attr := simp) existing cast_addConst_mul_card]
-lemma cast_mulConst_mul_card (A B : Finset G) : (σₘ[A, B] * A.card : 𝕜) = (A * B).card := by
+lemma cast_mulConst_mul_card (A B : Finset G) : (σₘ[A, B] * #A : 𝕜) = #(A * B) := by
   norm_cast; exact mulConst_mul_card _ _
 
 @[to_additive (attr := simp) existing cast_subConst_mul_card]
-lemma cast_divConst_mul_card (A B : Finset G) : (δₘ[A, B] * A.card : 𝕜) = (A / B).card := by
+lemma cast_divConst_mul_card (A B : Finset G) : (δₘ[A, B] * #A : 𝕜) = #(A / B) := by
   norm_cast; exact divConst_mul_card _ _
 
 @[to_additive (attr := simp) existing card_mul_cast_addConst]
-lemma card_mul_cast_mulConst (A B : Finset G) : (A.card * σₘ[A, B] : 𝕜) = (A * B).card := by
+lemma card_mul_cast_mulConst (A B : Finset G) : (#A * σₘ[A, B] : 𝕜) = #(A * B) := by
   norm_cast; exact card_mul_mulConst _ _
 
 @[to_additive (attr := simp) existing card_mul_cast_subConst]
-lemma card_mul_cast_divConst (A B : Finset G) : (A.card * δₘ[A, B] : 𝕜) = (A / B).card := by
+lemma card_mul_cast_divConst (A B : Finset G) : (#A * δₘ[A, B] : 𝕜) = #(A / B) := by
   norm_cast; exact card_mul_divConst _ _
 
 end Group
@@ -189,10 +189,10 @@ This is a consequence of the Ruzsa triangle inequality."]
 lemma mulConst_le_divConst_sq : σₘ[A] ≤ δₘ[A] ^ 2 := by
   obtain rfl | hA' := A.eq_empty_or_nonempty
   · simp
-  refine le_of_mul_le_mul_right ?_ (by positivity : (0 : ℚ≥0) < A.card * A.card)
+  refine le_of_mul_le_mul_right ?_ (by positivity : (0 : ℚ≥0) < #A * #A)
   calc
-    _ = (A * A).card * (A.card : ℚ≥0) := by rw [← mul_assoc, mulConst_mul_card]
-    _ ≤ (A / A).card * (A / A).card := by norm_cast; exact ruzsa_triangle_inequality_mul_div_div ..
+    _ = #(A * A) * (#A : ℚ≥0) := by rw [← mul_assoc, mulConst_mul_card]
+    _ ≤ #(A / A) * #(A / A) := by norm_cast; exact ruzsa_triangle_inequality_mul_div_div ..
     _ = _ := by rw [← divConst_mul_card]; ring
 
 /-- If `A` has small doubling, then it has small difference, with the constant squared.
@@ -205,10 +205,10 @@ This is a consequence of the Ruzsa triangle inequality."]
 lemma divConst_le_mulConst_sq : δₘ[A] ≤ σₘ[A] ^ 2 := by
   obtain rfl | hA' := A.eq_empty_or_nonempty
   · simp
-  refine le_of_mul_le_mul_right ?_ (by positivity : (0 : ℚ≥0) < A.card * A.card)
+  refine le_of_mul_le_mul_right ?_ (by positivity : (0 : ℚ≥0) < #A * #A)
   calc
-    _ = (A / A).card * (A.card : ℚ≥0) := by rw [← mul_assoc, divConst_mul_card]
-    _ ≤ (A * A).card * (A * A).card := by norm_cast; exact ruzsa_triangle_inequality_div_mul_mul ..
+    _ = #(A / A) * (#A : ℚ≥0) := by rw [← mul_assoc, divConst_mul_card]
+    _ ≤ #(A * A) * #(A * A) := by norm_cast; exact ruzsa_triangle_inequality_div_mul_mul ..
     _ = _ := by rw [← mulConst_mul_card]; ring
 
 end CommGroup

--- a/Mathlib/Combinatorics/Additive/ErdosGinzburgZiv.lean
+++ b/Mathlib/Combinatorics/Additive/ErdosGinzburgZiv.lean
@@ -50,8 +50,8 @@ private lemma totalDegree_f₁_add_totalDegree_f₂ {a : ι → ZMod p} :
 
 Any sequence of `2 * p - 1` elements of `ZMod p` contains a subsequence of `p` elements whose sum is
 zero. -/
-private theorem ZMod.erdos_ginzburg_ziv_prime (a : ι → ZMod p) (hs : s.card = 2 * p - 1) :
-    ∃ t ⊆ s, t.card = p ∧ ∑ i ∈ t, a i = 0 := by
+private theorem ZMod.erdos_ginzburg_ziv_prime (a : ι → ZMod p) (hs : #s = 2 * p - 1) :
+    ∃ t ⊆ s, #t = p ∧ ∑ i ∈ t, a i = 0 := by
   haveI : NeZero p := inferInstance
   classical
   -- Let `N` be the number of common roots of our polynomials `f₁` and `f₂` (`f s ff` and `f s tt`).
@@ -69,7 +69,7 @@ private theorem ZMod.erdos_ginzburg_ziv_prime (a : ι → ZMod p) (hs : s.card =
   obtain ⟨x, hx⟩ := Fintype.exists_ne_of_one_lt_card ((Fact.out : p.Prime).one_lt.trans_le <|
     Nat.le_of_dvd hN₀ hpN) zero_sol
   -- This common root gives us the required subsequence, namely the `i ∈ s` such that `x i ≠ 0`.
-  refine ⟨(s.attach.filter fun a ↦ x.1 a ≠ 0).map ⟨(↑), Subtype.val_injective⟩, ?_, ?_, ?_⟩
+  refine ⟨({a | x.1 a ≠ 0} : Finset _).map ⟨(↑), Subtype.val_injective⟩, ?_, ?_, ?_⟩
   · simp (config := { contextual := true }) [subset_iff]
   -- From `f₁ x = 0`, we get that `p` divides the number of `a` such that `x a ≠ 0`.
   · rw [card_map]
@@ -81,7 +81,7 @@ private theorem ZMod.erdos_ginzburg_ziv_prime (a : ι → ZMod p) (hs : s.card =
     · rw [← CharP.cast_eq_zero_iff (ZMod p), ← Finset.sum_boole]
       simpa only [f₁, map_sum, ZMod.pow_card_sub_one, map_pow, eval_X] using x.2.1
     -- And it is at most `2 * p - 1`, so it must be `p`.
-    · rw [Finset.card_attach, hs]
+    · rw [univ_eq_attach, card_attach, hs]
       exact tsub_lt_self (mul_pos zero_lt_two (Fact.out : p.Prime).pos) zero_lt_one
   -- From `f₂ x = 0`, we get that `p` divides the sum of the `a ∈ s` such that `x a ≠ 0`.
   · simpa [f₂, ZMod.pow_card_sub_one, Finset.sum_filter] using x.2.2
@@ -90,8 +90,8 @@ private theorem ZMod.erdos_ginzburg_ziv_prime (a : ι → ZMod p) (hs : s.card =
 
 Any sequence of `2 * p - 1` elements of `ℤ` contains a subsequence of `p` elements whose sum is
 divisible by `p`. -/
-private theorem Int.erdos_ginzburg_ziv_prime (a : ι → ℤ) (hs : s.card = 2 * p - 1) :
-    ∃ t ⊆ s, t.card = p ∧ ↑p ∣ ∑ i ∈ t, a i := by
+private theorem Int.erdos_ginzburg_ziv_prime (a : ι → ℤ) (hs : #s = 2 * p - 1) :
+    ∃ t ⊆ s, #t = p ∧ ↑p ∣ ∑ i ∈ t, a i := by
   simpa [← Int.cast_sum, ZMod.intCast_zmod_eq_zero_iff_dvd]
     using ZMod.erdos_ginzburg_ziv_prime (Int.cast ∘ a) hs
 
@@ -104,8 +104,8 @@ variable {n : ℕ} {s : Finset ι}
 
 Any sequence of at least `2 * n - 1` elements of `ℤ` contains a subsequence of `n` elements whose
 sum is divisible by `n`. -/
-theorem Int.erdos_ginzburg_ziv (a : ι → ℤ) (hs : 2 * n - 1 ≤ s.card) :
-    ∃ t ⊆ s, t.card = n ∧ ↑n ∣ ∑ i ∈ t, a i := by
+theorem Int.erdos_ginzburg_ziv (a : ι → ℤ) (hs : 2 * n - 1 ≤ #s) :
+    ∃ t ⊆ s, #t = n ∧ ↑n ∣ ∑ i ∈ t, a i := by
   classical
   -- Do induction on the prime factorisation of `n`. Note that we will apply the induction
   -- hypothesis with `ι := Finset ι`, so we need to generalise.
@@ -125,9 +125,9 @@ theorem Int.erdos_ginzburg_ziv (a : ι → ℤ) (hs : 2 * n - 1 ≤ s.card) :
   -- these sets whose sum is divisible by `m * n`.
   | composite m hm ihm n hn ihn =>
      -- First, show that it is enough to have those `2 * m - 1` sets.
-    suffices ∀ k ≤ 2 * m - 1, ∃ 𝒜 : Finset (Finset ι), 𝒜.card = k ∧
+    suffices ∀ k ≤ 2 * m - 1, ∃ 𝒜 : Finset (Finset ι), #𝒜 = k ∧
       (𝒜 : Set (Finset ι)).Pairwise _root_.Disjoint ∧
-        ∀ ⦃t⦄, t ∈ 𝒜 → t ⊆ s ∧ t.card = n ∧ ↑n ∣ ∑ i ∈ t, a i by
+        ∀ ⦃t⦄, t ∈ 𝒜 → t ⊆ s ∧ #t = n ∧ ↑n ∣ ∑ i ∈ t, a i by
      -- Assume `𝒜` is a family of `2 * m - 1` sets, each of size `n` and sum divisible by `n`.
       obtain ⟨𝒜, h𝒜card, h𝒜disj, h𝒜⟩ := this _ le_rfl
       -- By induction hypothesis on `m`, find a subfamily `ℬ` of size `m` such that the sum over
@@ -150,13 +150,13 @@ theorem Int.erdos_ginzburg_ziv (a : ι → ℤ) (hs : 2 * n - 1 ≤ s.card) :
     obtain ⟨𝒜, h𝒜card, h𝒜disj, h𝒜⟩ := ih (Nat.le_of_succ_le hk)
     -- There are at least `2 * (m * n) - 1 - k * n ≥ 2 * m - 1` elements in `s` that have not been
     -- taken in any element of `𝒜`.
-    have : 2 * n - 1 ≤ (s \ 𝒜.biUnion id).card := by
+    have : 2 * n - 1 ≤ #(s \ 𝒜.biUnion id) := by
       calc
         _ ≤ (2 * m - k) * n - 1 := by gcongr; omega
-        _ = (2 * (m * n) - 1) - ∑ t ∈ 𝒜, t.card := by
+        _ = (2 * (m * n) - 1) - ∑ t ∈ 𝒜, #t := by
           rw [tsub_mul, mul_assoc, tsub_right_comm, sum_const_nat fun t ht ↦ (h𝒜 ht).2.1, h𝒜card]
-        _ ≤ s.card - (𝒜.biUnion id).card := by gcongr; exact card_biUnion_le
-        _ ≤ (s \ 𝒜.biUnion id).card := le_card_sdiff ..
+        _ ≤ #s - #(𝒜.biUnion id) := by gcongr; exact card_biUnion_le
+        _ ≤ #(s \ 𝒜.biUnion id) := le_card_sdiff ..
     -- So by the induction hypothesis on `n` we can find a new set `t` of size `n` and sum divisible
     -- by `n`.
     obtain ⟨t₀, ht₀, ht₀card, ht₀sum⟩ := ihn a this
@@ -177,8 +177,8 @@ theorem Int.erdos_ginzburg_ziv (a : ι → ℤ) (hs : 2 * n - 1 ≤ s.card) :
 
 Any sequence of at least `2 * n - 1` elements of `ZMod n` contains a subsequence of `n` elements
 whose sum is zero. -/
-theorem ZMod.erdos_ginzburg_ziv (a : ι → ZMod n) (hs : 2 * n - 1 ≤ s.card) :
-    ∃ t ⊆ s, t.card = n ∧ ∑ i ∈ t, a i = 0 := by
+theorem ZMod.erdos_ginzburg_ziv (a : ι → ZMod n) (hs : 2 * n - 1 ≤ #s) :
+    ∃ t ⊆ s, #t = n ∧ ∑ i ∈ t, a i = 0 := by
   simpa [← ZMod.intCast_zmod_eq_zero_iff_dvd] using Int.erdos_ginzburg_ziv (ZMod.cast ∘ a) hs
 
 /-- The **Erdős–Ginzburg–Ziv theorem** for `ℤ` for multiset.

--- a/Mathlib/Combinatorics/Colex.lean
+++ b/Mathlib/Combinatorics/Colex.lean
@@ -102,7 +102,7 @@ instance instLE : LE (Colex α) where
 private lemma trans_aux (hst : toColex s ≤ toColex t) (htu : toColex t ≤ toColex u)
     (has : a ∈ s) (hat : a ∉ t) : ∃ b, b ∈ u ∧ b ∉ s ∧ a ≤ b := by
   classical
-  let s' : Finset α := s.filter fun b ↦ b ∉ t ∧ a ≤ b
+  let s' : Finset α := {b ∈ s | b ∉ t ∧ a ≤ b}
   have ⟨b, hb, hbmax⟩ := exists_maximal s' ⟨a, by simp [s', has, hat]⟩
   simp only [s', mem_filter, and_imp] at hb hbmax
   have ⟨c, hct, hcs, hbc⟩ := hst hb.1 hb.2.1
@@ -338,10 +338,10 @@ lemma lt_iff_max'_mem {s t : Colex α} :
   rw [lt_iff_le_and_ne, le_iff_max'_mem]; aesop
 
 lemma lt_iff_exists_filter_lt :
-    toColex s < toColex t ↔ ∃ w ∈ t \ s, s.filter (w < ·) = t.filter (w < ·) := by
+    toColex s < toColex t ↔ ∃ w ∈ t \ s, {a ∈ s | w < a} = {a ∈ t | w < a} := by
   simp only [lt_iff_exists_forall_lt, mem_sdiff, filter_inj, and_assoc]
   refine ⟨fun h ↦ ?_, ?_⟩
-  · let u := (t \ s).filter fun w ↦ ∀ a ∈ s, a ∉ t → a < w
+  · let u := {w ∈ t \ s | ∀ a ∈ s, a ∉ t → a < w}
     have mem_u {w : α} : w ∈ u ↔ w ∈ t ∧ w ∉ s ∧ ∀ a ∈ s, a ∉ t → a < w := by simp [u, and_assoc]
     have hu : u.Nonempty := h.imp fun _ ↦ mem_u.2
     let m := max' _ hu
@@ -355,8 +355,8 @@ lemma lt_iff_exists_filter_lt :
     by_contra! hwa
     exact hat <| (hw <| hwa.lt_of_ne <| ne_of_mem_of_not_mem hwt hat).1 has
 
-/-- If `s ≤ t` in colex and `s.card ≤ t.card`, then `s \ {a} ≤ t \ {min t}` for any `a ∈ s`. -/
-lemma erase_le_erase_min' (hst : toColex s ≤ toColex t) (hcard : s.card ≤ t.card) (ha : a ∈ s) :
+/-- If `s ≤ t` in colex and `#s ≤ #t`, then `s \ {a} ≤ t \ {min t}` for any `a ∈ s`. -/
+lemma erase_le_erase_min' (hst : toColex s ≤ toColex t) (hcard : #s ≤ #t) (ha : a ∈ s) :
     toColex (s.erase a) ≤
       toColex (t.erase <| min' t <| card_pos.1 <| (card_pos.2 ⟨a, ha⟩).trans_le hcard) := by
   generalize_proofs ht
@@ -434,7 +434,7 @@ end Fintype
 downwards closed with respect to colex among sets of size `r`. -/
 def IsInitSeg (𝒜 : Finset (Finset α)) (r : ℕ) : Prop :=
   (𝒜 : Set (Finset α)).Sized r ∧
-    ∀ ⦃s t : Finset α⦄, s ∈ 𝒜 → toColex t < toColex s ∧ t.card = r → t ∈ 𝒜
+    ∀ ⦃s t : Finset α⦄, s ∈ 𝒜 → toColex t < toColex s ∧ #t = r → t ∈ 𝒜
 
 @[simp] lemma isInitSeg_empty : IsInitSeg (∅ : Finset (Finset α)) r := by simp [IsInitSeg]
 
@@ -454,24 +454,23 @@ lemma IsInitSeg.total (h₁ : IsInitSeg 𝒜₁ r) (h₂ : IsInitSeg 𝒜₂ r) 
 
 variable [Fintype α]
 
-/-- The initial segment of the colexicographic order on sets with `s.card` elements and ending at
+/-- The initial segment of the colexicographic order on sets with `#s` elements and ending at
 `s`. -/
-def initSeg (s : Finset α) : Finset (Finset α) :=
-  univ.filter fun t ↦ s.card = t.card ∧ toColex t ≤ toColex s
+def initSeg (s : Finset α) : Finset (Finset α) := {t | #s = #t ∧ toColex t ≤ toColex s}
 
 @[simp]
-lemma mem_initSeg : t ∈ initSeg s ↔ s.card = t.card ∧ toColex t ≤ toColex s := by simp [initSeg]
+lemma mem_initSeg : t ∈ initSeg s ↔ #s = #t ∧ toColex t ≤ toColex s := by simp [initSeg]
 
 lemma mem_initSeg_self : s ∈ initSeg s := by simp
 @[simp] lemma initSeg_nonempty : (initSeg s).Nonempty := ⟨s, mem_initSeg_self⟩
 
-lemma isInitSeg_initSeg : IsInitSeg (initSeg s) s.card := by
+lemma isInitSeg_initSeg : IsInitSeg (initSeg s) #s := by
   refine ⟨fun t ht => (mem_initSeg.1 ht).1.symm, fun t₁ t₂ ht₁ ht₂ ↦ mem_initSeg.2 ⟨ht₂.2.symm, ?_⟩⟩
   rw [mem_initSeg] at ht₁
   exact ht₂.1.le.trans ht₁.2
 
 lemma IsInitSeg.exists_initSeg (h𝒜 : IsInitSeg 𝒜 r) (h𝒜₀ : 𝒜.Nonempty) :
-    ∃ s : Finset α, s.card = r ∧ 𝒜 = initSeg s := by
+    ∃ s : Finset α, #s = r ∧ 𝒜 = initSeg s := by
   have hs := sup'_mem (ofColex ⁻¹' 𝒜) (LinearOrder.supClosed _) 𝒜 h𝒜₀ toColex
     (fun a ha ↦ by simpa using ha)
   refine ⟨_, h𝒜.1 hs, ?_⟩
@@ -487,7 +486,7 @@ lemma IsInitSeg.exists_initSeg (h𝒜 : IsInitSeg 𝒜 r) (h𝒜₀ : 𝒜.Nonem
 
 /-- Being a nonempty initial segment of colex is equivalent to being an `initSeg`. -/
 lemma isInitSeg_iff_exists_initSeg :
-    IsInitSeg 𝒜 r ∧ 𝒜.Nonempty ↔ ∃ s : Finset α, s.card = r ∧ 𝒜 = initSeg s := by
+    IsInitSeg 𝒜 r ∧ 𝒜.Nonempty ↔ ∃ s : Finset α, #s = r ∧ 𝒜 = initSeg s := by
   refine ⟨fun h𝒜 ↦ h𝒜.1.exists_initSeg h𝒜.2, ?_⟩
   rintro ⟨s, rfl, rfl⟩
   exact ⟨isInitSeg_initSeg, initSeg_nonempty⟩

--- a/Mathlib/Combinatorics/Configuration.lean
+++ b/Mathlib/Combinatorics/Configuration.lean
@@ -117,27 +117,27 @@ theorem Nondegenerate.exists_injective_of_card_le [Nondegenerate P L] [Fintype P
     (h : Fintype.card L ≤ Fintype.card P) : ∃ f : L → P, Function.Injective f ∧ ∀ l, f l ∉ l := by
   classical
     let t : L → Finset P := fun l => Set.toFinset { p | p ∉ l }
-    suffices ∀ s : Finset L, s.card ≤ (s.biUnion t).card by
+    suffices ∀ s : Finset L, #s ≤ (s.biUnion t).card by
       -- Hall's marriage theorem
       obtain ⟨f, hf1, hf2⟩ := (Finset.all_card_le_biUnion_card_iff_exists_injective t).mp this
       exact ⟨f, hf1, fun l => Set.mem_toFinset.mp (hf2 l)⟩
     intro s
-    by_cases hs₀ : s.card = 0
-    -- If `s = ∅`, then `s.card = 0 ≤ (s.bUnion t).card`
+    by_cases hs₀ : #s = 0
+    -- If `s = ∅`, then `#s = 0 ≤ #(s.bUnion t)`
     · simp_rw [hs₀, zero_le]
-    by_cases hs₁ : s.card = 1
+    by_cases hs₁ : #s = 1
     -- If `s = {l}`, then pick a point `p ∉ l`
     · obtain ⟨l, rfl⟩ := Finset.card_eq_one.mp hs₁
       obtain ⟨p, hl⟩ := exists_point (P := P) l
       rw [Finset.card_singleton, Finset.singleton_biUnion, Nat.one_le_iff_ne_zero]
       exact Finset.card_ne_zero_of_mem (Set.mem_toFinset.mpr hl)
-    suffices (s.biUnion t)ᶜ.card ≤ sᶜ.card by
+    suffices #(s.biUnion t)ᶜ ≤ #sᶜ by
       -- Rephrase in terms of complements (uses `h`)
       rw [Finset.card_compl, Finset.card_compl, tsub_le_iff_left] at this
       replace := h.trans this
       rwa [← add_tsub_assoc_of_le s.card_le_univ, le_tsub_iff_left (le_add_left s.card_le_univ),
         add_le_add_iff_right] at this
-    have hs₂ : (s.biUnion t)ᶜ.card ≤ 1 := by
+    have hs₂ : #(s.biUnion t)ᶜ ≤ 1 := by
       -- At most one line through two points of `s`
       refine Finset.card_le_one_iff.mpr @fun p₁ p₂ hp₁ hp₂ => ?_
       simp_rw [t, Finset.mem_compl, Finset.mem_biUnion, not_exists, not_and,
@@ -145,7 +145,7 @@ theorem Nondegenerate.exists_injective_of_card_le [Nondegenerate P L] [Fintype P
       obtain ⟨l₁, l₂, hl₁, hl₂, hl₃⟩ :=
         Finset.one_lt_card_iff.mp (Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hs₀, hs₁⟩)
       exact (eq_or_eq (hp₁ l₁ hl₁) (hp₂ l₁ hl₁) (hp₁ l₂ hl₂) (hp₂ l₂ hl₂)).resolve_right hl₃
-    by_cases hs₃ : sᶜ.card = 0
+    by_cases hs₃ : #sᶜ = 0
     · rw [hs₃, Nat.le_zero]
       rw [Finset.card_compl, tsub_eq_zero_iff_le, LE.le.le_iff_eq (Finset.card_le_univ _), eq_comm,
         Finset.card_eq_iff_eq_univ] at hs₃ ⊢

--- a/Mathlib/Combinatorics/Enumerative/Catalan.lean
+++ b/Mathlib/Combinatorics/Enumerative/Catalan.lean
@@ -186,7 +186,7 @@ theorem coe_treesOfNumNodesEq (n : ℕ) :
     ↑(treesOfNumNodesEq n) = { x : Tree Unit | x.numNodes = n } :=
   Set.ext (by simp)
 
-theorem treesOfNumNodesEq_card_eq_catalan (n : ℕ) : (treesOfNumNodesEq n).card = catalan n := by
+theorem treesOfNumNodesEq_card_eq_catalan (n : ℕ) : #(treesOfNumNodesEq n) = catalan n := by
   induction' n using Nat.case_strong_induction_on with n ih
   · simp
   rw [treesOfNumNodesEq_succ, card_biUnion, catalan_succ']

--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -44,10 +44,10 @@ variable (r : α → β → Prop) (s : Finset α) (t : Finset β) (a : α) (b : 
   [DecidablePred (r a)] [∀ a, Decidable (r a b)] {m n : ℕ}
 
 /-- Elements of `s` which are "below" `b` according to relation `r`. -/
-def bipartiteBelow : Finset α := s.filter fun a ↦ r a b
+def bipartiteBelow : Finset α := {a ∈ s | r a b}
 
 /-- Elements of `t` which are "above" `a` according to relation `r`. -/
-def bipartiteAbove : Finset β := t.filter (r a)
+def bipartiteAbove : Finset β := {b ∈ t | r a b}
 
 theorem bipartiteBelow_swap : t.bipartiteBelow (swap r) a = t.bipartiteAbove r a := rfl
 
@@ -75,7 +75,7 @@ theorem prod_prod_bipartiteAbove_eq_prod_prod_bipartiteBelow
   exact prod_comm
 
 theorem sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow [∀ a b, Decidable (r a b)] :
-    (∑ a ∈ s, (t.bipartiteAbove r a).card) = ∑ b ∈ t, (s.bipartiteBelow r b).card := by
+    (∑ a ∈ s, #(t.bipartiteAbove r a)) = ∑ b ∈ t, #(s.bipartiteBelow r b) := by
   simp_rw [card_eq_sum_ones, sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow]
 
 section OrderedSemiring
@@ -86,11 +86,11 @@ variable [OrderedSemiring R] {m n : R}
 Considering `r` as a bipartite graph, the LHS is a lower bound on the number of edges while the RHS
 is an upper bound. -/
 theorem card_nsmul_le_card_nsmul [∀ a b, Decidable (r a b)]
-    (hm : ∀ a ∈ s, m ≤ (t.bipartiteAbove r a).card)
-    (hn : ∀ b ∈ t, (s.bipartiteBelow r b).card ≤ n) : s.card • m ≤ t.card • n :=
+    (hm : ∀ a ∈ s, m ≤ #(t.bipartiteAbove r a))
+    (hn : ∀ b ∈ t, #(s.bipartiteBelow r b) ≤ n) : #s • m ≤ #t • n :=
   calc
-    _ ≤ ∑ a in s, ((t.bipartiteAbove r a).card : R) := s.card_nsmul_le_sum _ _ hm
-    _ = ∑ b in t, ((s.bipartiteBelow r b).card : R) := by
+    _ ≤ ∑ a in s, (#(t.bipartiteAbove r a) : R) := s.card_nsmul_le_sum _ _ hm
+    _ = ∑ b in t, (#(s.bipartiteBelow r b) : R) := by
       norm_cast; rw [sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow]
     _ ≤ _ := t.sum_le_card_nsmul _ _ hn
 
@@ -99,8 +99,8 @@ theorem card_nsmul_le_card_nsmul [∀ a b, Decidable (r a b)]
 Considering `r` as a bipartite graph, the LHS is a lower bound on the number of edges while the RHS
 is an upper bound. -/
 theorem card_nsmul_le_card_nsmul' [∀ a b, Decidable (r a b)]
-    (hn : ∀ b ∈ t, n ≤ (s.bipartiteBelow r b).card)
-    (hm : ∀ a ∈ s, (t.bipartiteAbove r a).card ≤ m) : t.card • n ≤ s.card • m :=
+    (hn : ∀ b ∈ t, n ≤ #(s.bipartiteBelow r b))
+    (hm : ∀ a ∈ s, #(t.bipartiteAbove r a) ≤ m) : #t • n ≤ #s • m :=
   card_nsmul_le_card_nsmul (swap r) hn hm
 
 end OrderedSemiring
@@ -114,12 +114,12 @@ variable [StrictOrderedSemiring R] (r : α → β → Prop) {s : Finset α} {t :
 Considering `r` as a bipartite graph, the LHS is a strict lower bound on the number of edges while
 the RHS is an upper bound. -/
 theorem card_nsmul_lt_card_nsmul_of_lt_of_le [∀ a b, Decidable (r a b)] (hs : s.Nonempty)
-    (hm : ∀ a ∈ s, m < (t.bipartiteAbove r a).card)
-    (hn : ∀ b ∈ t, (s.bipartiteBelow r b).card ≤ n) : s.card • m < t.card • n :=
+    (hm : ∀ a ∈ s, m < #(t.bipartiteAbove r a))
+    (hn : ∀ b ∈ t, #(s.bipartiteBelow r b) ≤ n) : #s • m < #t • n :=
   calc
     _ = ∑ _a ∈ s, m := by rw [sum_const]
-    _ < ∑ a ∈ s, ((t.bipartiteAbove r a).card : R) := sum_lt_sum_of_nonempty hs hm
-    _ = ∑ b in t, ((s.bipartiteBelow r b).card : R) := by
+    _ < ∑ a ∈ s, (#(t.bipartiteAbove r a) : R) := sum_lt_sum_of_nonempty hs hm
+    _ = ∑ b in t, (#(s.bipartiteBelow r b) : R) := by
       norm_cast; rw [sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow]
     _ ≤ _ := t.sum_le_card_nsmul _ _ hn
 
@@ -128,11 +128,11 @@ theorem card_nsmul_lt_card_nsmul_of_lt_of_le [∀ a b, Decidable (r a b)] (hs : 
 Considering `r` as a bipartite graph, the LHS is a lower bound on the number of edges while the RHS
 is a strict upper bound. -/
 theorem card_nsmul_lt_card_nsmul_of_le_of_lt [∀ a b, Decidable (r a b)] (ht : t.Nonempty)
-    (hm : ∀ a ∈ s, m ≤ (t.bipartiteAbove r a).card)
-    (hn : ∀ b ∈ t, (s.bipartiteBelow r b).card < n) : s.card • m < t.card • n :=
+    (hm : ∀ a ∈ s, m ≤ #(t.bipartiteAbove r a))
+    (hn : ∀ b ∈ t, #(s.bipartiteBelow r b) < n) : #s • m < #t • n :=
   calc
-    _ ≤ ∑ a in s, ((t.bipartiteAbove r a).card : R) := s.card_nsmul_le_sum _ _ hm
-    _ = ∑ b in t, ((s.bipartiteBelow r b).card : R) := by
+    _ ≤ ∑ a in s, (#(t.bipartiteAbove r a) : R) := s.card_nsmul_le_sum _ _ hm
+    _ = ∑ b in t, (#(s.bipartiteBelow r b) : R) := by
       norm_cast; rw [sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow]
     _ < ∑ _b ∈ t, n := sum_lt_sum_of_nonempty ht hn
     _ = _ := sum_const _
@@ -142,8 +142,8 @@ theorem card_nsmul_lt_card_nsmul_of_le_of_lt [∀ a b, Decidable (r a b)] (ht : 
 Considering `r` as a bipartite graph, the LHS is a strict lower bound on the number of edges while
 the RHS is an upper bound. -/
 theorem card_nsmul_lt_card_nsmul_of_lt_of_le' [∀ a b, Decidable (r a b)] (ht : t.Nonempty)
-    (hn : ∀ b ∈ t, n < (s.bipartiteBelow r b).card)
-    (hm : ∀ a ∈ s, (t.bipartiteAbove r a).card ≤ m) : t.card • n < s.card • m :=
+    (hn : ∀ b ∈ t, n < #(s.bipartiteBelow r b))
+    (hm : ∀ a ∈ s, #(t.bipartiteAbove r a) ≤ m) : #t • n < #s • m :=
   card_nsmul_lt_card_nsmul_of_lt_of_le (swap r) ht hn hm
 
 /-- **Double counting** argument.
@@ -151,8 +151,8 @@ theorem card_nsmul_lt_card_nsmul_of_lt_of_le' [∀ a b, Decidable (r a b)] (ht :
 Considering `r` as a bipartite graph, the LHS is a lower bound on the number of edges while the RHS
 is a strict upper bound. -/
 theorem card_nsmul_lt_card_nsmul_of_le_of_lt' [∀ a b, Decidable (r a b)] (hs : s.Nonempty)
-    (hn : ∀ b ∈ t, n ≤ (s.bipartiteBelow r b).card)
-    (hm : ∀ a ∈ s, (t.bipartiteAbove r a).card < m) : t.card • n < s.card • m :=
+    (hn : ∀ b ∈ t, n ≤ #(s.bipartiteBelow r b))
+    (hm : ∀ a ∈ s, #(t.bipartiteAbove r a) < m) : #t • n < #s • m :=
   card_nsmul_lt_card_nsmul_of_le_of_lt (swap r) hs hn hm
 
 end StrictOrderedSemiring
@@ -162,25 +162,25 @@ end StrictOrderedSemiring
 Considering `r` as a bipartite graph, the LHS is a lower bound on the number of edges while the RHS
 is an upper bound. -/
 theorem card_mul_le_card_mul [∀ a b, Decidable (r a b)]
-    (hm : ∀ a ∈ s, m ≤ (t.bipartiteAbove r a).card)
-    (hn : ∀ b ∈ t, (s.bipartiteBelow r b).card ≤ n) : s.card * m ≤ t.card * n :=
+    (hm : ∀ a ∈ s, m ≤ #(t.bipartiteAbove r a))
+    (hn : ∀ b ∈ t, #(s.bipartiteBelow r b) ≤ n) : #s * m ≤ #t * n :=
   card_nsmul_le_card_nsmul _ hm hn
 
 theorem card_mul_le_card_mul' [∀ a b, Decidable (r a b)]
-    (hn : ∀ b ∈ t, n ≤ (s.bipartiteBelow r b).card)
-    (hm : ∀ a ∈ s, (t.bipartiteAbove r a).card ≤ m) : t.card * n ≤ s.card * m :=
+    (hn : ∀ b ∈ t, n ≤ #(s.bipartiteBelow r b))
+    (hm : ∀ a ∈ s, #(t.bipartiteAbove r a) ≤ m) : #t * n ≤ #s * m :=
   card_nsmul_le_card_nsmul' _ hn hm
 
 theorem card_mul_eq_card_mul [∀ a b, Decidable (r a b)]
-    (hm : ∀ a ∈ s, (t.bipartiteAbove r a).card = m)
-    (hn : ∀ b ∈ t, (s.bipartiteBelow r b).card = n) : s.card * m = t.card * n :=
+    (hm : ∀ a ∈ s, #(t.bipartiteAbove r a) = m)
+    (hn : ∀ b ∈ t, #(s.bipartiteBelow r b) = n) : #s * m = #t * n :=
   (card_mul_le_card_mul _ (fun a ha ↦ (hm a ha).ge) fun b hb ↦ (hn b hb).le).antisymm <|
     card_mul_le_card_mul' _ (fun a ha ↦ (hn a ha).ge) fun b hb ↦ (hm b hb).le
 
 theorem card_le_card_of_forall_subsingleton (hs : ∀ a ∈ s, ∃ b, b ∈ t ∧ r a b)
-    (ht : ∀ b ∈ t, ({ a ∈ s | r a b } : Set α).Subsingleton) : s.card ≤ t.card := by
+    (ht : ∀ b ∈ t, ({ a ∈ s | r a b } : Set α).Subsingleton) : #s ≤ #t := by
   classical
-    rw [← mul_one s.card, ← mul_one t.card]
+    rw [← mul_one #s, ← mul_one #t]
     exact card_mul_le_card_mul r
       (fun a h ↦ card_pos.2 (by
         rw [← coe_nonempty, coe_bipartiteAbove]
@@ -190,7 +190,7 @@ theorem card_le_card_of_forall_subsingleton (hs : ∀ a ∈ s, ∃ b, b ∈ t �
         exact ht _ h))
 
 theorem card_le_card_of_forall_subsingleton' (ht : ∀ b ∈ t, ∃ a, a ∈ s ∧ r a b)
-    (hs : ∀ a ∈ s, ({ b ∈ t | r a b } : Set β).Subsingleton) : t.card ≤ s.card :=
+    (hs : ∀ a ∈ s, ({ b ∈ t | r a b } : Set β).Subsingleton) : #t ≤ #s :=
   card_le_card_of_forall_subsingleton (swap r) ht hs
 
 end Bipartite

--- a/Mathlib/Combinatorics/Hall/Basic.lean
+++ b/Mathlib/Combinatorics/Hall/Basic.lean
@@ -50,8 +50,7 @@ The core of this module is constructing the inverse system: for every finite sub
 Hall's Marriage Theorem, indexed families
 -/
 
-
-open Finset CategoryTheory
+open Finset Function CategoryTheory
 
 universe u v
 
@@ -71,7 +70,7 @@ def hallMatchingsOn.restrict {ι : Type u} {α : Type v} (t : ι → Finset α) 
 /-- When the Hall condition is satisfied, the set of matchings on a finite set is nonempty.
 This is where `Finset.all_card_le_biUnion_card_iff_existsInjective'` comes into the argument. -/
 theorem hallMatchingsOn.nonempty {ι : Type u} {α : Type v} [DecidableEq α] (t : ι → Finset α)
-    (h : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card) (ι' : Finset ι) :
+    (h : ∀ s : Finset ι, #s ≤ #(s.biUnion t)) (ι' : Finset ι) :
     Nonempty (hallMatchingsOn t ι') := by
   classical
     refine ⟨Classical.indefiniteDescription _ ?_⟩
@@ -115,7 +114,7 @@ which has the additional constraint that `ι` is a `Fintype`.
 -/
 theorem Finset.all_card_le_biUnion_card_iff_exists_injective {ι : Type u} {α : Type v}
     [DecidableEq α] (t : ι → Finset α) :
-    (∀ s : Finset ι, s.card ≤ (s.biUnion t).card) ↔
+    (∀ s : Finset ι, #s ≤ #(s.biUnion t)) ↔
       ∃ f : ι → α, Function.Injective f ∧ ∀ x, f x ∈ t x := by
   constructor
   · intro h
@@ -178,10 +177,10 @@ Note: if `[Fintype β]`, then there exist instances for `[∀ (a : α), Fintype 
 -/
 theorem Fintype.all_card_le_rel_image_card_iff_exists_injective {α : Type u} {β : Type v}
     [DecidableEq β] (r : α → β → Prop) [∀ a : α, Fintype (Rel.image r {a})] :
-    (∀ A : Finset α, A.card ≤ Fintype.card (Rel.image r A)) ↔
+    (∀ A : Finset α, #A ≤ Fintype.card (Rel.image r A)) ↔
       ∃ f : α → β, Function.Injective f ∧ ∀ x, r x (f x) := by
   let r' a := (Rel.image r {a}).toFinset
-  have h : ∀ A : Finset α, Fintype.card (Rel.image r A) = (A.biUnion r').card := by
+  have h : ∀ A : Finset α, Fintype.card (Rel.image r A) = #(A.biUnion r') := by
     intro A
     rw [← Set.toFinset_card]
     apply congr_arg
@@ -203,11 +202,10 @@ rather than `Rel.image`.
 -/
 theorem Fintype.all_card_le_filter_rel_iff_exists_injective {α : Type u} {β : Type v} [Fintype β]
     (r : α → β → Prop) [∀ a, DecidablePred (r a)] :
-    (∀ A : Finset α, A.card ≤ (univ.filter fun b : β => ∃ a ∈ A, r a b).card) ↔
-      ∃ f : α → β, Function.Injective f ∧ ∀ x, r x (f x) := by
+    (∀ A : Finset α, #A ≤ #{b | ∃ a ∈ A, r a b}) ↔ ∃ f : α → β, Injective f ∧ ∀ x, r x (f x) := by
   haveI := Classical.decEq β
-  let r' a := univ.filter fun b => r a b
-  have h : ∀ A : Finset α, (univ.filter fun b : β => ∃ a ∈ A, r a b) = A.biUnion r' := by
+  let r' a : Finset β := {b | r a b}
+  have h : ∀ A : Finset α, ({b | ∃ a ∈ A, r a b} : Finset _) = A.biUnion r' := by
     intro A
     ext b
     simp [r']

--- a/Mathlib/Combinatorics/Hall/Finite.lean
+++ b/Mathlib/Combinatorics/Hall/Finite.lean
@@ -46,13 +46,13 @@ section Fintype
 variable [Fintype ι]
 
 theorem hall_cond_of_erase {x : ι} (a : α)
-    (ha : ∀ s : Finset ι, s.Nonempty → s ≠ univ → s.card < (s.biUnion t).card)
-    (s' : Finset { x' : ι | x' ≠ x }) : s'.card ≤ (s'.biUnion fun x' => (t x').erase a).card := by
+    (ha : ∀ s : Finset ι, s.Nonempty → s ≠ univ → #s < #(s.biUnion t))
+    (s' : Finset { x' : ι | x' ≠ x }) : #s' ≤ #(s'.biUnion fun x' => (t x').erase a) := by
   haveI := Classical.decEq ι
   specialize ha (s'.image fun z => z.1)
   rw [image_nonempty, Finset.card_image_of_injective s' Subtype.coe_injective] at ha
   by_cases he : s'.Nonempty
-  · have ha' : s'.card < (s'.biUnion fun x => t x).card := by
+  · have ha' : #s' < #(s'.biUnion fun x => t x) := by
       convert ha he fun h => by simpa [← h] using mem_univ x using 2
       ext x
       simp only [mem_image, mem_biUnion, exists_prop, SetCoe.exists, exists_and_right,
@@ -68,18 +68,18 @@ theorem hall_cond_of_erase {x : ι} (a : α)
     simp
 
 /-- First case of the inductive step: assuming that
-`∀ (s : Finset ι), s.Nonempty → s ≠ univ → s.card < (s.biUnion t).card`
+`∀ (s : Finset ι), s.Nonempty → s ≠ univ → #s < #(s.biUnion t)`
 and that the statement of **Hall's Marriage Theorem** is true for all
 `ι'` of cardinality ≤ `n`, then it is true for `ι` of cardinality `n + 1`.
 -/
 theorem hall_hard_inductive_step_A {n : ℕ} (hn : Fintype.card ι = n + 1)
-    (ht : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card)
+    (ht : ∀ s : Finset ι, #s ≤ #(s.biUnion t))
     (ih :
       ∀ {ι' : Type u} [Fintype ι'] (t' : ι' → Finset α),
         Fintype.card ι' ≤ n →
-          (∀ s' : Finset ι', s'.card ≤ (s'.biUnion t').card) →
+          (∀ s' : Finset ι', #s' ≤ #(s'.biUnion t')) →
             ∃ f : ι' → α, Function.Injective f ∧ ∀ x, f x ∈ t' x)
-    (ha : ∀ s : Finset ι, s.Nonempty → s ≠ univ → s.card < (s.biUnion t).card) :
+    (ha : ∀ s : Finset ι, s.Nonempty → s ≠ univ → #s < #(s.biUnion t)) :
     ∃ f : ι → α, Function.Injective f ∧ ∀ x, f x ∈ t x := by
   haveI : Nonempty ι := Fintype.card_pos_iff.mp (hn.symm ▸ Nat.succ_pos _)
   haveI := Classical.decEq ι
@@ -89,7 +89,7 @@ theorem hall_hard_inductive_step_A {n : ℕ} (hn : Fintype.card ι = n + 1)
     rw [← Finset.card_pos]
     calc
       0 < 1 := Nat.one_pos
-      _ ≤ (Finset.biUnion {x} t).card := ht {x}
+      _ ≤ #(.biUnion {x} t) := ht {x}
       _ = (t x).card := by rw [Finset.singleton_biUnion]
 
   choose y hy using tx_ne
@@ -118,8 +118,8 @@ theorem hall_hard_inductive_step_A {n : ℕ} (hn : Fintype.card ι = n + 1)
       exact hfr.2
 
 theorem hall_cond_of_restrict {ι : Type u} {t : ι → Finset α} {s : Finset ι}
-    (ht : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card) (s' : Finset (s : Set ι)) :
-    s'.card ≤ (s'.biUnion fun a' => t a').card := by
+    (ht : ∀ s : Finset ι, #s ≤ #(s.biUnion t)) (s' : Finset (s : Set ι)) :
+    #s' ≤ #(s'.biUnion fun a' => t a') := by
   classical
     rw [← card_image_of_injective s' Subtype.coe_injective]
     convert ht (s'.image fun z => z.1) using 1
@@ -128,15 +128,15 @@ theorem hall_cond_of_restrict {ι : Type u} {t : ι → Finset α} {s : Finset �
     simp
 
 theorem hall_cond_of_compl {ι : Type u} {t : ι → Finset α} {s : Finset ι}
-    (hus : s.card = (s.biUnion t).card) (ht : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card)
-    (s' : Finset (sᶜ : Set ι)) : s'.card ≤ (s'.biUnion fun x' => t x' \ s.biUnion t).card := by
+    (hus : #s = #(s.biUnion t)) (ht : ∀ s : Finset ι, #s ≤ #(s.biUnion t))
+    (s' : Finset (sᶜ : Set ι)) : #s' ≤ #(s'.biUnion fun x' => t x' \ s.biUnion t) := by
   haveI := Classical.decEq ι
   have disj : Disjoint s (s'.image fun z => z.1) := by
     simp only [disjoint_left, not_exists, mem_image, exists_prop, SetCoe.exists, exists_and_right,
       exists_eq_right, Subtype.coe_mk]
     intro x hx hc _
     exact absurd hx hc
-  have : s'.card = (s ∪ s'.image fun z => z.1).card - s.card := by
+  have : #s' = #(s ∪ s'.image fun z => z.1) - #s := by
     simp [disj, card_image_of_injective _ Subtype.coe_injective, Nat.add_sub_cancel_left]
   rw [this, hus]
   refine (Nat.sub_le_sub_right (ht _) _).trans ?_
@@ -152,18 +152,18 @@ theorem hall_cond_of_compl {ι : Type u} {t : ι → Finset α} {s : Finset ι}
     apply subset_union_left
 
 /-- Second case of the inductive step: assuming that
-`∃ (s : Finset ι), s ≠ univ → s.card = (s.biUnion t).card`
+`∃ (s : Finset ι), s ≠ univ → #s = #(s.biUnion t)`
 and that the statement of **Hall's Marriage Theorem** is true for all
 `ι'` of cardinality ≤ `n`, then it is true for `ι` of cardinality `n + 1`.
 -/
 theorem hall_hard_inductive_step_B {n : ℕ} (hn : Fintype.card ι = n + 1)
-    (ht : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card)
+    (ht : ∀ s : Finset ι, #s ≤ #(s.biUnion t))
     (ih :
       ∀ {ι' : Type u} [Fintype ι'] (t' : ι' → Finset α),
         Fintype.card ι' ≤ n →
-          (∀ s' : Finset ι', s'.card ≤ (s'.biUnion t').card) →
+          (∀ s' : Finset ι', #s' ≤ #(s'.biUnion t')) →
             ∃ f : ι' → α, Function.Injective f ∧ ∀ x, f x ∈ t' x)
-    (s : Finset ι) (hs : s.Nonempty) (hns : s ≠ univ) (hus : s.card = (s.biUnion t).card) :
+    (s : Finset ι) (hs : s.Nonempty) (hns : s ≠ univ) (hus : #s = #(s.biUnion t)) :
     ∃ f : ι → α, Function.Injective f ∧ ∀ x, f x ∈ t x := by
   haveI := Classical.decEq ι
   -- Restrict to `s`
@@ -171,7 +171,7 @@ theorem hall_hard_inductive_step_B {n : ℕ} (hn : Fintype.card ι = n + 1)
   have card_ι'_le : Fintype.card s ≤ n := by
     apply Nat.le_of_lt_succ
     calc
-      Fintype.card s = s.card := Fintype.card_coe _
+      Fintype.card s = #s := Fintype.card_coe _
       _ < Fintype.card ι := (card_lt_iff_ne_univ _).mpr hns
       _ = n.succ := hn
   let t' : s → Finset α := fun x' => t x'
@@ -214,7 +214,7 @@ variable [Finite ι]
 /-- Here we combine the two inductive steps into a full strong induction proof,
 completing the proof the harder direction of **Hall's Marriage Theorem**.
 -/
-theorem hall_hard_inductive (ht : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card) :
+theorem hall_hard_inductive (ht : ∀ s : Finset ι, #s ≤ #(s.biUnion t)) :
     ∃ f : ι → α, Function.Injective f ∧ ∀ x, f x ∈ t x := by
   cases nonempty_fintype ι
   induction' hn : Fintype.card ι using Nat.strong_induction_on with n ih generalizing ι
@@ -222,11 +222,11 @@ theorem hall_hard_inductive (ht : ∀ s : Finset ι, s.card ≤ (s.biUnion t).ca
   · rw [Fintype.card_eq_zero_iff] at hn
     exact ⟨isEmptyElim, isEmptyElim, isEmptyElim⟩
   · have ih' : ∀ (ι' : Type u) [Fintype ι'] (t' : ι' → Finset α), Fintype.card ι' ≤ n →
-        (∀ s' : Finset ι', s'.card ≤ (s'.biUnion t').card) →
+        (∀ s' : Finset ι', #s' ≤ #(s'.biUnion t')) →
         ∃ f : ι' → α, Function.Injective f ∧ ∀ x, f x ∈ t' x := by
       intro ι' _ _ hι' ht'
       exact ih _ (Nat.lt_succ_of_le hι') ht' _ rfl
-    by_cases h : ∀ s : Finset ι, s.Nonempty → s ≠ univ → s.card < (s.biUnion t).card
+    by_cases h : ∀ s : Finset ι, s.Nonempty → s ≠ univ → #s < #(s.biUnion t)
     · refine hall_hard_inductive_step_A hn ht (@fun ι' => ih' ι') h
     · push_neg at h
       rcases h with ⟨s, sne, snu, sle⟩
@@ -245,7 +245,7 @@ where the `Finite ι` constraint is removed.
 -/
 theorem Finset.all_card_le_biUnion_card_iff_existsInjective' {ι α : Type*} [Finite ι]
     [DecidableEq α] (t : ι → Finset α) :
-    (∀ s : Finset ι, s.card ≤ (s.biUnion t).card) ↔
+    (∀ s : Finset ι, #s ≤ #(s.biUnion t)) ↔
       ∃ f : ι → α, Function.Injective f ∧ ∀ x, f x ∈ t x := by
   constructor
   · exact HallMarriageTheorem.hall_hard_inductive

--- a/Mathlib/Combinatorics/Pigeonhole.lean
+++ b/Mathlib/Combinatorics/Pigeonhole.lean
@@ -32,14 +32,14 @@ The versions vary by:
 
 * using a function between `Fintype`s or a function between possibly infinite types restricted to
   `Finset`s;
-* counting pigeons by a general weight function (`∑ x ∈ s, w x`) or by heads (`Finset.card s`);
+* counting pigeons by a general weight function (`∑ x ∈ s, w x`) or by heads (`#s`);
 * using strict or non-strict inequalities;
 * establishing upper or lower estimate on the number (or the total weight) of the pigeons in one
   pigeonhole;
 * in case when we count pigeons by some weight function `w` and consider a function `f` between
   `Finset`s `s` and `t`, we can either assume that each pigeon is in one of the pigeonholes
   (`∀ x ∈ s, f x ∈ t`), or assume that for `y ∉ t`, the total weight of the pigeons in this
-  pigeonhole `∑ x ∈ s.filter (fun x ↦ f x = y), w x` is nonpositive or nonnegative depending on
+  pigeonhole `∑ x ∈ s with f x = y, w x` is nonpositive or nonnegative depending on
   the inequality we are proving.
 
 Lemma names follow `mathlib` convention (e.g.,
@@ -80,15 +80,14 @@ variations of this theorem.
 
 The principle is formalized in the following way, see
 `Finset.exists_lt_sum_fiber_of_maps_to_of_nsmul_lt_sum`: if `f : α → β` is a function which maps all
-elements of `s : Finset α` to `t : Finset β` and `card t • b < ∑ x ∈ s, w x`, where `w : α → M` is
+elements of `s : Finset α` to `t : Finset β` and `#t • b < ∑ x ∈ s, w x`, where `w : α → M` is
 a weight function taking values in a `LinearOrderedCancelAddCommMonoid`, then for
 some `y ∈ t`, the sum of the weights of all `x ∈ s` such that `f x = y` is greater than `b`.
 
 There are a few bits we can change in this theorem:
 
 * reverse all inequalities, with obvious adjustments to the name;
-* replace the assumption `∀ a ∈ s, f a ∈ t` with
-  `∀ y ∉ t, (∑ x ∈ s.filter (fun x ↦ f x = y), w x) ≤ 0`,
+* replace the assumption `∀ a ∈ s, f a ∈ t` with `∀ y ∉ t, ∑ x ∈ s with f x = y, w x ≤ 0`,
   and replace `of_maps_to` with `of_sum_fiber_nonpos` in the name;
 * use non-strict inequalities assuming `t` is nonempty.
 
@@ -109,7 +108,7 @@ if the total weight of a finite set of pigeons is greater than `n • b`, and th
 `n` pigeonholes, then for some pigeonhole, the total weight of the pigeons in this pigeonhole is
 greater than `b`. -/
 theorem exists_lt_sum_fiber_of_maps_to_of_nsmul_lt_sum (hf : ∀ a ∈ s, f a ∈ t)
-    (hb : t.card • b < ∑ x ∈ s, w x) : ∃ y ∈ t, b < ∑ x ∈ s.filter fun x => f x = y, w x :=
+    (hb : #t • b < ∑ x ∈ s, w x) : ∃ y ∈ t, b < ∑ x ∈ s with f x = y, w x :=
   exists_lt_of_sum_lt <| by simpa only [sum_fiberwise_of_maps_to hf, sum_const]
 
 /-- The pigeonhole principle for finitely many pigeons counted by weight, strict inequality version:
@@ -117,7 +116,7 @@ if the total weight of a finite set of pigeons is less than `n • b`, and they 
 pigeonholes, then for some pigeonhole, the total weight of the pigeons in this pigeonhole is less
 than `b`. -/
 theorem exists_sum_fiber_lt_of_maps_to_of_sum_lt_nsmul (hf : ∀ a ∈ s, f a ∈ t)
-    (hb : ∑ x ∈ s, w x < t.card • b) : ∃ y ∈ t, ∑ x ∈ s.filter fun x => f x = y, w x < b :=
+    (hb : ∑ x ∈ s, w x < #t • b) : ∃ y ∈ t, ∑ x ∈ s with f x = y, w x < b :=
   exists_lt_sum_fiber_of_maps_to_of_nsmul_lt_sum (M := Mᵒᵈ) hf hb
 
 /-- The pigeonhole principle for finitely many pigeons counted by weight, strict inequality version:
@@ -126,13 +125,12 @@ pigeonholes, and for all but `n` pigeonholes the total weight of the pigeons the
 then for at least one of these `n` pigeonholes, the total weight of the pigeons in this pigeonhole
 is greater than `b`. -/
 theorem exists_lt_sum_fiber_of_sum_fiber_nonpos_of_nsmul_lt_sum
-    (ht : ∀ y ∉ t, ∑ x ∈ s.filter fun x => f x = y, w x ≤ 0)
-    (hb : t.card • b < ∑ x ∈ s, w x) : ∃ y ∈ t, b < ∑ x ∈ s.filter fun x => f x = y, w x :=
+    (ht : ∀ y ∉ t, ∑ x ∈ s with f x = y, w x ≤ 0)
+    (hb : #t • b < ∑ x ∈ s, w x) : ∃ y ∈ t, b < ∑ x ∈ s with f x = y, w x :=
   exists_lt_of_sum_lt <|
     calc
       ∑ _y ∈ t, b < ∑ x ∈ s, w x := by simpa
-      _ ≤ ∑ y ∈ t, ∑ x ∈ s.filter fun x => f x = y, w x :=
-        sum_le_sum_fiberwise_of_sum_fiber_nonpos ht
+      _ ≤ ∑ y ∈ t, ∑ x ∈ s with f x = y, w x := sum_le_sum_fiberwise_of_sum_fiber_nonpos ht
 
 /-- The pigeonhole principle for finitely many pigeons counted by weight, strict inequality version:
 if the total weight of a finite set of pigeons is less than `n • b`, they are sorted into some
@@ -140,8 +138,8 @@ pigeonholes, and for all but `n` pigeonholes the total weight of the pigeons the
 then for at least one of these `n` pigeonholes, the total weight of the pigeons in this pigeonhole
 is less than `b`. -/
 theorem exists_sum_fiber_lt_of_sum_fiber_nonneg_of_sum_lt_nsmul
-    (ht : ∀ y ∉ t, (0 : M) ≤ ∑ x ∈ s.filter fun x => f x = y, w x)
-    (hb : ∑ x ∈ s, w x < t.card • b) : ∃ y ∈ t, ∑ x ∈ s.filter fun x => f x = y, w x < b :=
+    (ht : ∀ y ∉ t, (0 : M) ≤ ∑ x ∈ s with f x = y, w x) (hb : ∑ x ∈ s, w x < #t • b) :
+    ∃ y ∈ t, ∑ x ∈ s with f x = y, w x < b :=
   exists_lt_sum_fiber_of_sum_fiber_nonpos_of_nsmul_lt_sum (M := Mᵒᵈ) ht hb
 
 /-!
@@ -154,7 +152,7 @@ version: if the total weight of a finite set of pigeons is greater than or equal
 they are sorted into `n > 0` pigeonholes, then for some pigeonhole, the total weight of the pigeons
 in this pigeonhole is greater than or equal to `b`. -/
 theorem exists_le_sum_fiber_of_maps_to_of_nsmul_le_sum (hf : ∀ a ∈ s, f a ∈ t) (ht : t.Nonempty)
-    (hb : t.card • b ≤ ∑ x ∈ s, w x) : ∃ y ∈ t, b ≤ ∑ x ∈ s.filter fun x => f x = y, w x :=
+    (hb : #t • b ≤ ∑ x ∈ s, w x) : ∃ y ∈ t, b ≤ ∑ x ∈ s with f x = y, w x :=
   exists_le_of_sum_le ht <| by simpa only [sum_fiberwise_of_maps_to hf, sum_const]
 
 /-- The pigeonhole principle for finitely many pigeons counted by weight, non-strict inequality
@@ -162,7 +160,7 @@ version: if the total weight of a finite set of pigeons is less than or equal to
 are sorted into `n > 0` pigeonholes, then for some pigeonhole, the total weight of the pigeons in
 this pigeonhole is less than or equal to `b`. -/
 theorem exists_sum_fiber_le_of_maps_to_of_sum_le_nsmul (hf : ∀ a ∈ s, f a ∈ t) (ht : t.Nonempty)
-    (hb : ∑ x ∈ s, w x ≤ t.card • b) : ∃ y ∈ t, ∑ x ∈ s.filter fun x => f x = y, w x ≤ b :=
+    (hb : ∑ x ∈ s, w x ≤ #t • b) : ∃ y ∈ t, ∑ x ∈ s with f x = y, w x ≤ b :=
   exists_le_sum_fiber_of_maps_to_of_nsmul_le_sum (M := Mᵒᵈ) hf ht hb
 
 /-- The pigeonhole principle for finitely many pigeons counted by weight, non-strict inequality
@@ -171,12 +169,12 @@ are sorted into some pigeonholes, and for all but `n > 0` pigeonholes the total 
 pigeons there is nonpositive, then for at least one of these `n` pigeonholes, the total weight of
 the pigeons in this pigeonhole is greater than or equal to `b`. -/
 theorem exists_le_sum_fiber_of_sum_fiber_nonpos_of_nsmul_le_sum
-    (hf : ∀ y ∉ t, ∑ x ∈ s.filter fun x => f x = y, w x ≤ 0) (ht : t.Nonempty)
-    (hb : t.card • b ≤ ∑ x ∈ s, w x) : ∃ y ∈ t, b ≤ ∑ x ∈ s.filter fun x => f x = y, w x :=
+    (hf : ∀ y ∉ t, ∑ x ∈ s with f x = y, w x ≤ 0) (ht : t.Nonempty)
+    (hb : #t • b ≤ ∑ x ∈ s, w x) : ∃ y ∈ t, b ≤ ∑ x ∈ s with f x = y, w x :=
   exists_le_of_sum_le ht <|
     calc
       ∑ _y ∈ t, b ≤ ∑ x ∈ s, w x := by simpa
-      _ ≤ ∑ y ∈ t, ∑ x ∈ s.filter fun x => f x = y, w x :=
+      _ ≤ ∑ y ∈ t, ∑ x ∈ s with f x = y, w x :=
         sum_le_sum_fiberwise_of_sum_fiber_nonpos hf
 
 /-- The pigeonhole principle for finitely many pigeons counted by weight, non-strict inequality
@@ -185,8 +183,8 @@ sorted into some pigeonholes, and for all but `n > 0` pigeonholes the total weig
 there is nonnegative, then for at least one of these `n` pigeonholes, the total weight of the
 pigeons in this pigeonhole is less than or equal to `b`. -/
 theorem exists_sum_fiber_le_of_sum_fiber_nonneg_of_sum_le_nsmul
-    (hf : ∀ y ∉ t, (0 : M) ≤ ∑ x ∈ s.filter fun x => f x = y, w x) (ht : t.Nonempty)
-    (hb : ∑ x ∈ s, w x ≤ t.card • b) : ∃ y ∈ t, ∑ x ∈ s.filter fun x => f x = y, w x ≤ b :=
+    (hf : ∀ y ∉ t, (0 : M) ≤ ∑ x ∈ s with f x = y, w x) (ht : t.Nonempty)
+    (hb : ∑ x ∈ s, w x ≤ #t • b) : ∃ y ∈ t, ∑ x ∈ s with f x = y, w x ≤ b :=
   exists_le_sum_fiber_of_sum_fiber_nonpos_of_nsmul_le_sum (M := Mᵒᵈ) hf ht hb
 
 end
@@ -214,7 +212,7 @@ So, we prove four theorems: `Finset.exists_lt_card_fiber_of_maps_to_of_mul_lt_ca
 /-- The pigeonhole principle for finitely many pigeons counted by heads: there is a pigeonhole with
 at least as many pigeons as the ceiling of the average number of pigeons across all pigeonholes. -/
 theorem exists_lt_card_fiber_of_nsmul_lt_card_of_maps_to (hf : ∀ a ∈ s, f a ∈ t)
-    (ht : t.card • b < s.card) : ∃ y ∈ t, b < (s.filter fun x => f x = y).card := by
+    (ht : #t • b < #s) : ∃ y ∈ t, b < #{x ∈ s | f x = y} := by
   simp_rw [cast_card] at ht ⊢
   exact exists_lt_sum_fiber_of_maps_to_of_nsmul_lt_sum hf ht
 
@@ -223,16 +221,16 @@ at least as many pigeons as the ceiling of the average number of pigeons across 
 ("The maximum is at least the mean" specialized to integers.)
 
 More formally, given a function between finite sets `s` and `t` and a natural number `n` such that
-`card t * n < card s`, there exists `y ∈ t` such that its preimage in `s` has more than `n`
+`#t * n < #s`, there exists `y ∈ t` such that its preimage in `s` has more than `n`
 elements. -/
 theorem exists_lt_card_fiber_of_mul_lt_card_of_maps_to (hf : ∀ a ∈ s, f a ∈ t)
-    (hn : t.card * n < s.card) : ∃ y ∈ t, n < (s.filter fun x => f x = y).card :=
+    (hn : #t * n < #s) : ∃ y ∈ t, n < #{x ∈ s | f x = y} :=
   exists_lt_card_fiber_of_nsmul_lt_card_of_maps_to hf hn
 
 /-- The pigeonhole principle for finitely many pigeons counted by heads: there is a pigeonhole with
 at most as many pigeons as the floor of the average number of pigeons across all pigeonholes. -/
-theorem exists_card_fiber_lt_of_card_lt_nsmul (ht : ↑s.card < t.card • b) :
-    ∃ y ∈ t, ↑(s.filter fun x => f x = y).card < b := by
+theorem exists_card_fiber_lt_of_card_lt_nsmul (ht : #s < #t • b) :
+    ∃ y ∈ t, #{x ∈ s | f x = y} < b := by
   simp_rw [cast_card] at ht ⊢
   exact
     exists_sum_fiber_lt_of_sum_fiber_nonneg_of_sum_lt_nsmul
@@ -243,35 +241,34 @@ at most as many pigeons as the floor of the average number of pigeons across all
 minimum is at most the mean" specialized to integers.)
 
 More formally, given a function `f`, a finite sets `s` in its domain, a finite set `t` in its
-codomain, and a natural number `n` such that `card s < card t * n`, there exists `y ∈ t` such that
+codomain, and a natural number `n` such that `#s < #t * n`, there exists `y ∈ t` such that
 its preimage in `s` has less than `n` elements. -/
-theorem exists_card_fiber_lt_of_card_lt_mul (hn : s.card < t.card * n) :
-    ∃ y ∈ t, (s.filter fun x => f x = y).card < n :=
+theorem exists_card_fiber_lt_of_card_lt_mul (hn : #s < #t * n) : ∃ y ∈ t, #{x ∈ s | f x = y} < n :=
   exists_card_fiber_lt_of_card_lt_nsmul hn
 
 /-- The pigeonhole principle for finitely many pigeons counted by heads: given a function between
-finite sets `s` and `t` and a number `b` such that `card t • b ≤ card s`, there exists `y ∈ t` such
+finite sets `s` and `t` and a number `b` such that `#t • b ≤ #s`, there exists `y ∈ t` such
 that its preimage in `s` has at least `b` elements.
 See also `Finset.exists_lt_card_fiber_of_nsmul_lt_card_of_maps_to` for a stronger statement. -/
 theorem exists_le_card_fiber_of_nsmul_le_card_of_maps_to (hf : ∀ a ∈ s, f a ∈ t) (ht : t.Nonempty)
-    (hb : t.card • b ≤ s.card) : ∃ y ∈ t, b ≤ (s.filter fun x => f x = y).card := by
+    (hb : #t • b ≤ #s) : ∃ y ∈ t, b ≤ #{x ∈ s | f x = y} := by
   simp_rw [cast_card] at hb ⊢
   exact exists_le_sum_fiber_of_maps_to_of_nsmul_le_sum hf ht hb
 
 /-- The pigeonhole principle for finitely many pigeons counted by heads: given a function between
-finite sets `s` and `t` and a natural number `b` such that `card t * n ≤ card s`, there exists
+finite sets `s` and `t` and a natural number `b` such that `#t * n ≤ #s`, there exists
 `y ∈ t` such that its preimage in `s` has at least `n` elements. See also
 `Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to` for a stronger statement. -/
 theorem exists_le_card_fiber_of_mul_le_card_of_maps_to (hf : ∀ a ∈ s, f a ∈ t) (ht : t.Nonempty)
-    (hn : t.card * n ≤ s.card) : ∃ y ∈ t, n ≤ (s.filter fun x => f x = y).card :=
+    (hn : #t * n ≤ #s) : ∃ y ∈ t, n ≤ #{x ∈ s | f x = y} :=
   exists_le_card_fiber_of_nsmul_le_card_of_maps_to hf ht hn
 
 /-- The pigeonhole principle for finitely many pigeons counted by heads: given a function `f`, a
-finite sets `s` and `t`, and a number `b` such that `card s ≤ card t • b`, there exists `y ∈ t` such
+finite sets `s` and `t`, and a number `b` such that `#s ≤ #t • b`, there exists `y ∈ t` such
 that its preimage in `s` has no more than `b` elements.
 See also `Finset.exists_card_fiber_lt_of_card_lt_nsmul` for a stronger statement. -/
-theorem exists_card_fiber_le_of_card_le_nsmul (ht : t.Nonempty) (hb : ↑s.card ≤ t.card • b) :
-    ∃ y ∈ t, ↑(s.filter fun x => f x = y).card ≤ b := by
+theorem exists_card_fiber_le_of_card_le_nsmul (ht : t.Nonempty) (hb : #s ≤ #t • b) :
+    ∃ y ∈ t, #{x ∈ s | f x = y} ≤ b := by
   simp_rw [cast_card] at hb ⊢
   refine
     exists_sum_fiber_le_of_sum_fiber_nonneg_of_sum_le_nsmul
@@ -279,10 +276,10 @@ theorem exists_card_fiber_le_of_card_le_nsmul (ht : t.Nonempty) (hb : ↑s.card 
 
 /-- The pigeonhole principle for finitely many pigeons counted by heads: given a function `f`, a
 finite sets `s` in its domain, a finite set `t` in its codomain, and a natural number `n` such that
-`card s ≤ card t * n`, there exists `y ∈ t` such that its preimage in `s` has no more than `n`
+`#s ≤ #t * n`, there exists `y ∈ t` such that its preimage in `s` has no more than `n`
 elements. See also `Finset.exists_card_fiber_lt_of_card_lt_mul` for a stronger statement. -/
-theorem exists_card_fiber_le_of_card_le_mul (ht : t.Nonempty) (hn : s.card ≤ t.card * n) :
-    ∃ y ∈ t, (s.filter fun x => f x = y).card ≤ n :=
+theorem exists_card_fiber_le_of_card_le_mul (ht : t.Nonempty) (hn : #s ≤ #t * n) :
+    ∃ y ∈ t, #{x ∈ s | f x = y} ≤ n :=
   exists_card_fiber_le_of_card_le_nsmul ht hn
 
 end Finset
@@ -309,7 +306,7 @@ holds, so we have four theorems instead of eight. -/
 version: there is a pigeonhole with the total weight of pigeons in it greater than `b` provided that
 the total number of pigeonholes times `b` is less than the total weight of all pigeons. -/
 theorem exists_lt_sum_fiber_of_nsmul_lt_sum (hb : card β • b < ∑ x, w x) :
-    ∃ y, b < ∑ x ∈ univ.filter fun x => f x = y, w x :=
+    ∃ y, b < ∑ x with f x = y, w x :=
   let ⟨y, _, hy⟩ := exists_lt_sum_fiber_of_maps_to_of_nsmul_lt_sum (fun _ _ => mem_univ _) hb
   ⟨y, hy⟩
 
@@ -318,7 +315,7 @@ version: there is a pigeonhole with the total weight of pigeons in it greater th
 provided that the total number of pigeonholes times `b` is less than or equal to the total weight of
 all pigeons. -/
 theorem exists_le_sum_fiber_of_nsmul_le_sum [Nonempty β] (hb : card β • b ≤ ∑ x, w x) :
-    ∃ y, b ≤ ∑ x ∈ univ.filter fun x => f x = y, w x :=
+    ∃ y, b ≤ ∑ x with f x = y, w x :=
   let ⟨y, _, hy⟩ :=
     exists_le_sum_fiber_of_maps_to_of_nsmul_le_sum (fun _ _ => mem_univ _) univ_nonempty hb
   ⟨y, hy⟩
@@ -327,7 +324,7 @@ theorem exists_le_sum_fiber_of_nsmul_le_sum [Nonempty β] (hb : card β • b �
 version: there is a pigeonhole with the total weight of pigeons in it less than `b` provided that
 the total number of pigeonholes times `b` is greater than the total weight of all pigeons. -/
 theorem exists_sum_fiber_lt_of_sum_lt_nsmul (hb : ∑ x, w x < card β • b) :
-    ∃ y, ∑ x ∈ univ.filter fun x => f x = y, w x < b :=
+    ∃ y, ∑ x with f x = y, w x < b :=
   exists_lt_sum_fiber_of_nsmul_lt_sum (M := Mᵒᵈ) _ hb
 
 /-- The pigeonhole principle for finitely many pigeons of different weights, non-strict inequality
@@ -335,7 +332,7 @@ version: there is a pigeonhole with the total weight of pigeons in it less than 
 provided that the total number of pigeonholes times `b` is greater than or equal to the total weight
 of all pigeons. -/
 theorem exists_sum_fiber_le_of_sum_le_nsmul [Nonempty β] (hb : ∑ x, w x ≤ card β • b) :
-    ∃ y, ∑ x ∈ univ.filter fun x => f x = y, w x ≤ b :=
+    ∃ y, ∑ x with f x = y, w x ≤ b :=
   exists_le_sum_fiber_of_nsmul_le_sum (M := Mᵒᵈ) _ hb
 
 end
@@ -346,7 +343,7 @@ variable [LinearOrderedCommSemiring M]
 with at least as many pigeons as the ceiling of the average number of pigeons across all
 pigeonholes. -/
 theorem exists_lt_card_fiber_of_nsmul_lt_card (hb : card β • b < card α) :
-    ∃ y : β, b < (univ.filter fun x => f x = y).card :=
+    ∃ y : β, b < #{x | f x = y} :=
   let ⟨y, _, h⟩ := exists_lt_card_fiber_of_nsmul_lt_card_of_maps_to (fun _ _ => mem_univ _) hb
   ⟨y, h⟩
 
@@ -359,14 +356,14 @@ More formally, given a function `f` between finite types `α` and `β` and a num
 `card β * n < card α`, there exists an element `y : β` such that its preimage has more than `n`
 elements. -/
 theorem exists_lt_card_fiber_of_mul_lt_card (hn : card β * n < card α) :
-    ∃ y : β, n < (univ.filter fun x => f x = y).card :=
+    ∃ y : β, n < #{x | f x = y} :=
   exists_lt_card_fiber_of_nsmul_lt_card _ hn
 
 /-- The strong pigeonhole principle for finitely many pigeons and pigeonholes. There is a pigeonhole
 with at most as many pigeons as the floor of the average number of pigeons across all pigeonholes.
 -/
 theorem exists_card_fiber_lt_of_card_lt_nsmul (hb : ↑(card α) < card β • b) :
-    ∃ y : β, ↑(univ.filter fun x => f x = y).card < b :=
+    ∃ y : β, #{x | f x = y} < b :=
   let ⟨y, _, h⟩ := Finset.exists_card_fiber_lt_of_card_lt_nsmul (f := f) hb
   ⟨y, h⟩
 
@@ -379,7 +376,7 @@ More formally, given a function `f` between finite types `α` and `β` and a num
 `card α < card β * n`, there exists an element `y : β` such that its preimage has less than `n`
 elements. -/
 theorem exists_card_fiber_lt_of_card_lt_mul (hn : card α < card β * n) :
-    ∃ y : β, (univ.filter fun x => f x = y).card < n :=
+    ∃ y : β, #{x | f x = y} < n :=
   exists_card_fiber_lt_of_card_lt_nsmul _ hn
 
 /-- The strong pigeonhole principle for finitely many pigeons and pigeonholes.  Given a function `f`
@@ -387,7 +384,7 @@ between finite types `α` and `β` and a number `b` such that `card β • b ≤
 element `y : β` such that its preimage has at least `b` elements.
 See also `Fintype.exists_lt_card_fiber_of_nsmul_lt_card` for a stronger statement. -/
 theorem exists_le_card_fiber_of_nsmul_le_card [Nonempty β] (hb : card β • b ≤ card α) :
-    ∃ y : β, b ≤ (univ.filter fun x => f x = y).card :=
+    ∃ y : β, b ≤ #{x | f x = y} :=
   let ⟨y, _, h⟩ :=
     exists_le_card_fiber_of_nsmul_le_card_of_maps_to (fun _ _ => mem_univ _) univ_nonempty hb
   ⟨y, h⟩
@@ -397,7 +394,7 @@ between finite types `α` and `β` and a number `n` such that `card β * n ≤ c
 element `y : β` such that its preimage has at least `n` elements. See also
 `Fintype.exists_lt_card_fiber_of_mul_lt_card` for a stronger statement. -/
 theorem exists_le_card_fiber_of_mul_le_card [Nonempty β] (hn : card β * n ≤ card α) :
-    ∃ y : β, n ≤ (univ.filter fun x => f x = y).card :=
+    ∃ y : β, n ≤ #{x | f x = y} :=
   exists_le_card_fiber_of_nsmul_le_card _ hn
 
 /-- The strong pigeonhole principle for finitely many pigeons and pigeonholes.  Given a function `f`
@@ -405,7 +402,7 @@ between finite types `α` and `β` and a number `b` such that `card α ≤ card 
 element `y : β` such that its preimage has at most `b` elements.
 See also `Fintype.exists_card_fiber_lt_of_card_lt_nsmul` for a stronger statement. -/
 theorem exists_card_fiber_le_of_card_le_nsmul [Nonempty β] (hb : ↑(card α) ≤ card β • b) :
-    ∃ y : β, ↑(univ.filter fun x => f x = y).card ≤ b :=
+    ∃ y : β, #{x | f x = y} ≤ b :=
   let ⟨y, _, h⟩ := Finset.exists_card_fiber_le_of_card_le_nsmul univ_nonempty hb
   ⟨y, h⟩
 
@@ -414,7 +411,7 @@ between finite types `α` and `β` and a number `n` such that `card α ≤ card 
 element `y : β` such that its preimage has at most `n` elements. See also
 `Fintype.exists_card_fiber_lt_of_card_lt_mul` for a stronger statement. -/
 theorem exists_card_fiber_le_of_card_le_mul [Nonempty β] (hn : card α ≤ card β * n) :
-    ∃ y : β, (univ.filter fun x => f x = y).card ≤ n :=
+    ∃ y : β, #{x | f x = y} ≤ n :=
   exists_card_fiber_le_of_card_le_nsmul _ hn
 
 end Fintype

--- a/Mathlib/Combinatorics/Schnirelmann.lean
+++ b/Mathlib/Combinatorics/Schnirelmann.lean
@@ -47,7 +47,7 @@ open Finset
 /-- The Schnirelmann density is defined as the infimum of |A ∩ {1, ..., n}| / n as n ranges over
 the positive naturals. -/
 noncomputable def schnirelmannDensity (A : Set ℕ) [DecidablePred (· ∈ A)] : ℝ :=
-  ⨅ n : {n : ℕ // 0 < n}, ((Ioc (0 : ℕ) n).filter (· ∈ A)).card / n
+  ⨅ n : {n : ℕ // 0 < n}, #{a ∈ Ioc 0 n | a ∈ A} / n
 
 section
 
@@ -57,7 +57,7 @@ lemma schnirelmannDensity_nonneg : 0 ≤ schnirelmannDensity A :=
   Real.iInf_nonneg (fun _ => by positivity)
 
 lemma schnirelmannDensity_le_div {n : ℕ} (hn : n ≠ 0) :
-    schnirelmannDensity A ≤ ((Ioc 0 n).filter (· ∈ A)).card / n :=
+    schnirelmannDensity A ≤ #{a ∈ Ioc 0 n | a ∈ A} / n :=
   ciInf_le ⟨0, fun _ ⟨_, hx⟩ => hx ▸ by positivity⟩ (⟨n, hn.bot_lt⟩ : {n : ℕ // 0 < n})
 
 /--
@@ -65,7 +65,7 @@ For any natural `n`, the Schnirelmann density multiplied by `n` is bounded by `|
 Note this property fails for the natural density.
 -/
 lemma schnirelmannDensity_mul_le_card_filter {n : ℕ} :
-    schnirelmannDensity A * n ≤ ((Ioc 0 n).filter (· ∈ A)).card := by
+    schnirelmannDensity A * n ≤ #{a ∈ Ioc 0 n | a ∈ A} := by
   rcases eq_or_ne n 0 with rfl | hn
   · simp
   exact (le_div_iff₀ (by positivity)).1 (schnirelmannDensity_le_div hn)
@@ -78,7 +78,7 @@ We provide `n` explicitly here to make this lemma more easily usable in `apply` 
 This lemma is analogous to `ciInf_le_of_le`.
 -/
 lemma schnirelmannDensity_le_of_le {x : ℝ} (n : ℕ) (hn : n ≠ 0)
-    (hx : ((Ioc 0 n).filter (· ∈ A)).card / n ≤ x) : schnirelmannDensity A ≤ x :=
+    (hx : #{a ∈ Ioc 0 n | a ∈ A} / n ≤ x) : schnirelmannDensity A ≤ x :=
   (schnirelmannDensity_le_div hn).trans hx
 
 lemma schnirelmannDensity_le_one : schnirelmannDensity A ≤ 1 :=
@@ -96,7 +96,7 @@ lemma schnirelmannDensity_le_of_not_mem {k : ℕ} (hk : k ∉ A) :
   rw [← one_div, one_sub_div (Nat.cast_pos.2 hk').ne']
   gcongr
   rw [← Nat.cast_pred hk', Nat.cast_le]
-  suffices (Ioc 0 k).filter (· ∈ A) ⊆ Ioo 0 k from (card_le_card this).trans_eq (by simp)
+  suffices {a ∈ Ioc 0 k | a ∈ A} ⊆ Ioo 0 k from (card_le_card this).trans_eq (by simp)
   rw [← Ioo_insert_right hk', filter_insert, if_neg hk]
   exact filter_subset _ _
 
@@ -138,16 +138,16 @@ lemma schnirelmannDensity_eq_one_iff_of_zero_mem (hA : 0 ∈ A) :
     exact Set.subset_univ {0}ᶜ
 
 lemma le_schnirelmannDensity_iff {x : ℝ} :
-    x ≤ schnirelmannDensity A ↔ ∀ n : ℕ, 0 < n → x ≤ ((Ioc 0 n).filter (· ∈ A)).card / n :=
+    x ≤ schnirelmannDensity A ↔ ∀ n : ℕ, 0 < n → x ≤ #{a ∈ Ioc 0 n | a ∈ A} / n :=
   (le_ciInf_iff ⟨0, fun _ ⟨_, hx⟩ => hx ▸ by positivity⟩).trans Subtype.forall
 
 lemma schnirelmannDensity_lt_iff {x : ℝ} :
-    schnirelmannDensity A < x ↔ ∃ n : ℕ, 0 < n ∧ ((Ioc 0 n).filter (· ∈ A)).card / n < x := by
+    schnirelmannDensity A < x ↔ ∃ n : ℕ, 0 < n ∧ #{a ∈ Ioc 0 n | a ∈ A} / n < x := by
   rw [← not_le, le_schnirelmannDensity_iff]; simp
 
 lemma schnirelmannDensity_le_iff_forall {x : ℝ} :
     schnirelmannDensity A ≤ x ↔
-      ∀ ε : ℝ, 0 < ε → ∃ n : ℕ, 0 < n ∧ ((Ioc 0 n).filter (· ∈ A)).card / n < x + ε := by
+      ∀ ε : ℝ, 0 < ε → ∃ n : ℕ, 0 < n ∧ #{a ∈ Ioc 0 n | a ∈ A} / n < x + ε := by
   rw [le_iff_forall_pos_lt_add]
   simp only [schnirelmannDensity_lt_iff]
 
@@ -175,7 +175,7 @@ If the Schnirelmann density is `0`, there is a positive natural for which
 Note this cannot be improved to `∃ᶠ n : ℕ in atTop`, as can be seen by `A = {1}ᶜ`.
 -/
 lemma exists_of_schnirelmannDensity_eq_zero {ε : ℝ} (hε : 0 < ε) (hA : schnirelmannDensity A = 0) :
-    ∃ n, 0 < n ∧ ((Ioc 0 n).filter (· ∈ A)).card / n < ε := by
+    ∃ n, 0 < n ∧ #{a ∈ Ioc 0 n | a ∈ A} / n < ε := by
   by_contra! h
   rw [← le_schnirelmannDensity_iff] at h
   linarith
@@ -193,7 +193,7 @@ lemma schnirelmannDensity_finset (A : Finset ℕ) : schnirelmannDensity A = 0 :=
   wlog hε₁ : ε ≤ 1 generalizing ε
   · obtain ⟨n, hn, hn'⟩ := this 1 zero_lt_one le_rfl
     exact ⟨n, hn, hn'.trans_le (le_of_not_le hε₁)⟩
-  let n : ℕ := ⌊A.card / ε⌋₊ + 1
+  let n : ℕ := ⌊#A / ε⌋₊ + 1
   have hn : 0 < n := Nat.succ_pos _
   use n, hn
   rw [div_lt_iff₀ (Nat.cast_pos.2 hn), ← div_lt_iff₀' hε, Nat.cast_add_one]
@@ -236,7 +236,7 @@ lemma schnirelmannDensity_setOf_mod_eq_one {m : ℕ} (hm : m ≠ 1) :
   rw [le_schnirelmannDensity_iff]
   intro n hn
   simp only [Set.mem_setOf_eq]
-  have : (Icc 0 ((n - 1) / m)).image (· * m + 1) ⊆ (Ioc 0 n).filter (· % m = 1) := by
+  have : (Icc 0 ((n - 1) / m)).image (· * m + 1) ⊆ {x ∈ Ioc 0 n | x % m = 1} := by
     simp only [subset_iff, mem_image, forall_exists_index, mem_filter, mem_Ioc, mem_Icc, and_imp]
     rintro _ y _ hy' rfl
     have hm : 2 ≤ m := hm.lt_of_le' hm'

--- a/Mathlib/Combinatorics/SetFamily/AhlswedeZhang.lean
+++ b/Mathlib/Combinatorics/SetFamily/AhlswedeZhang.lean
@@ -69,11 +69,11 @@ private lemma binomial_sum_eq (h : n < m) :
   ring
 
 private lemma Fintype.sum_div_mul_card_choose_card :
-    ∑ s : Finset α, (card α / ((card α - s.card) * (card α).choose s.card) : ℚ) =
+    ∑ s : Finset α, (card α / ((card α - #s) * (card α).choose #s) : ℚ) =
       card α * ∑ k ∈ range (card α), (↑k)⁻¹ + 1 := by
   rw [← powerset_univ, powerset_card_disjiUnion, sum_disjiUnion]
   have : ∀ {x : ℕ}, ∀ s ∈ powersetCard x (univ : Finset α),
-    (card α / ((card α - Finset.card s) * (card α).choose (Finset.card s)) : ℚ) =
+    (card α / ((card α - #s) * (card α).choose #s) : ℚ) =
       card α / ((card α - x) * (card α).choose x) := by
     intros n s hs
     rw [mem_powersetCard_univ.1 hs]
@@ -103,8 +103,7 @@ section SemilatticeSup
 variable [SemilatticeSup α] [SemilatticeSup β]
   [BoundedOrder β] {s t : Finset α} {a b : α}
 
-private lemma sup_aux [@DecidableRel α (· ≤ ·)] :
-    a ∈ lowerClosure s → (s.filter fun b ↦ a ≤ b).Nonempty :=
+private lemma sup_aux [@DecidableRel α (· ≤ ·)] : a ∈ lowerClosure s → {b ∈ s | a ≤ b}.Nonempty :=
   fun ⟨b, hb, hab⟩ ↦ ⟨b, mem_filter.2 ⟨hb, hab⟩⟩
 
 private lemma lower_aux [DecidableEq α] :
@@ -115,10 +114,10 @@ variable [@DecidableRel α (· ≤ ·)] [OrderTop α]
 
 /-- The supremum of the elements of `s` less than `a` if there are some, otherwise `⊤`. -/
 def truncatedSup (s : Finset α) (a : α) : α :=
-  if h : a ∈ lowerClosure s then (s.filter fun b ↦ a ≤ b).sup' (sup_aux h) id else ⊤
+  if h : a ∈ lowerClosure s then {b ∈ s | a ≤ b}.sup' (sup_aux h) id else ⊤
 
 lemma truncatedSup_of_mem (h : a ∈ lowerClosure s) :
-    truncatedSup s a = (s.filter fun b ↦ a ≤ b).sup' (sup_aux h) id := dif_pos h
+    truncatedSup s a = {b ∈ s | a ≤ b}.sup' (sup_aux h) id := dif_pos h
 
 lemma truncatedSup_of_not_mem (h : a ∉ lowerClosure s) : truncatedSup s a = ⊤ := dif_neg h
 
@@ -177,7 +176,7 @@ section SemilatticeInf
 variable [SemilatticeInf α] [SemilatticeInf β]
   [BoundedOrder β] [@DecidableRel β (· ≤ ·)] {s t : Finset α} {a : α}
 
-private lemma inf_aux [@DecidableRel α (· ≤ ·)]: a ∈ upperClosure s → (s.filter (· ≤ a)).Nonempty :=
+private lemma inf_aux [@DecidableRel α (· ≤ ·)]: a ∈ upperClosure s → {b ∈ s | b ≤ a}.Nonempty :=
   fun ⟨b, hb, hab⟩ ↦ ⟨b, mem_filter.2 ⟨hb, hab⟩⟩
 
 private lemma upper_aux [DecidableEq α] :
@@ -188,10 +187,10 @@ variable [@DecidableRel α (· ≤ ·)] [BoundedOrder α]
 
 /-- The infimum of the elements of `s` less than `a` if there are some, otherwise `⊥`. -/
 def truncatedInf (s : Finset α) (a : α) : α :=
-  if h : a ∈ upperClosure s then (s.filter (· ≤ a)).inf' (inf_aux h) id else ⊥
+  if h : a ∈ upperClosure s then {b ∈ s | b ≤ a}.inf' (inf_aux h) id else ⊥
 
 lemma truncatedInf_of_mem (h : a ∈ upperClosure s) :
-    truncatedInf s a = (s.filter (· ≤ a)).inf' (inf_aux h) id := dif_pos h
+    truncatedInf s a = {b ∈ s | b ≤ a}.inf' (inf_aux h) id := dif_pos h
 
 lemma truncatedInf_of_not_mem (h : a ∉ upperClosure s) : truncatedInf s a = ⊥ := dif_neg h
 
@@ -297,8 +296,8 @@ end BooleanAlgebra
 variable [DecidableEq α] [Fintype α]
 
 lemma card_truncatedSup_union_add_card_truncatedSup_infs (𝒜 ℬ : Finset (Finset α)) (s : Finset α) :
-    (truncatedSup (𝒜 ∪ ℬ) s).card + (truncatedSup (𝒜 ⊼ ℬ) s).card =
-      (truncatedSup 𝒜 s).card + (truncatedSup ℬ s).card := by
+    #(truncatedSup (𝒜 ∪ ℬ) s) + #(truncatedSup (𝒜 ⊼ ℬ) s) =
+      #(truncatedSup 𝒜 s) + #(truncatedSup ℬ s) := by
   by_cases h𝒜 : s ∈ lowerClosure (𝒜 : Set <| Finset α) <;>
     by_cases hℬ : s ∈ lowerClosure (ℬ : Set <| Finset α)
   · rw [truncatedSup_union h𝒜 hℬ, truncatedSup_infs h𝒜 hℬ]
@@ -311,8 +310,8 @@ lemma card_truncatedSup_union_add_card_truncatedSup_infs (𝒜 ℬ : Finset (Fin
       truncatedSup_union_of_not_mem h𝒜 hℬ, truncatedSup_infs_of_not_mem fun h ↦ h𝒜 h.1]
 
 lemma card_truncatedInf_union_add_card_truncatedInf_sups (𝒜 ℬ : Finset (Finset α)) (s : Finset α) :
-    (truncatedInf (𝒜 ∪ ℬ) s).card + (truncatedInf (𝒜 ⊻ ℬ) s).card =
-      (truncatedInf 𝒜 s).card + (truncatedInf ℬ s).card := by
+    #(truncatedInf (𝒜 ∪ ℬ) s) + #(truncatedInf (𝒜 ⊻ ℬ) s) =
+      #(truncatedInf 𝒜 s) + #(truncatedInf ℬ s) := by
   by_cases h𝒜 : s ∈ upperClosure (𝒜 : Set <| Finset α) <;>
     by_cases hℬ : s ∈ upperClosure (ℬ : Set <| Finset α)
   · rw [truncatedInf_union h𝒜 hℬ, truncatedInf_sups h𝒜 hℬ]
@@ -335,12 +334,12 @@ variable {α : Type*} [Fintype α] [DecidableEq α] {𝒜 ℬ : Finset (Finset �
 /-- Weighted sum of the size of the truncated infima of a set family. Relevant to the
 Ahlswede-Zhang identity. -/
 def infSum (𝒜 : Finset (Finset α)) : ℚ :=
-  ∑ s, (truncatedInf 𝒜 s).card / (s.card * (card α).choose s.card)
+  ∑ s, #(truncatedInf 𝒜 s) / (#s * (card α).choose #s)
 
 /-- Weighted sum of the size of the truncated suprema of a set family. Relevant to the
 Ahlswede-Zhang identity. -/
 def supSum (𝒜 : Finset (Finset α)) : ℚ :=
-  ∑ s, (truncatedSup 𝒜 s).card / ((card α - s.card) * (card α).choose s.card)
+  ∑ s, #(truncatedSup 𝒜 s) / ((card α - #s) * (card α).choose #s)
 
 lemma supSum_union_add_supSum_infs (𝒜 ℬ : Finset (Finset α)) :
     supSum (𝒜 ∪ ℬ) + supSum (𝒜 ⊼ ℬ) = supSum 𝒜 + supSum ℬ := by
@@ -357,9 +356,9 @@ lemma infSum_union_add_infSum_sups (𝒜 ℬ : Finset (Finset α)) :
   simp
 
 lemma IsAntichain.le_infSum (h𝒜 : IsAntichain (· ⊆ ·) (𝒜 : Set (Finset α))) (h𝒜₀ : ∅ ∉ 𝒜) :
-    ∑ s ∈ 𝒜, ((card α).choose s.card : ℚ)⁻¹ ≤ infSum 𝒜 := by
+    ∑ s ∈ 𝒜, ((card α).choose #s : ℚ)⁻¹ ≤ infSum 𝒜 := by
   calc
-    _ = ∑ s ∈ 𝒜, (truncatedInf 𝒜 s).card / (s.card * (card α).choose s.card : ℚ) := ?_
+    _ = ∑ s ∈ 𝒜, #(truncatedInf 𝒜 s) / (#s * (card α).choose #s : ℚ) := ?_
     _ ≤ _ := sum_le_univ_sum_of_nonneg fun s ↦ by positivity
   refine sum_congr rfl fun s hs ↦ ?_
   rw [truncatedInf_of_isAntichain h𝒜 hs, div_mul_cancel_left₀]
@@ -371,8 +370,8 @@ variable [Nonempty α]
 @[simp] lemma supSum_singleton (hs : s ≠ univ) :
     supSum ({s} : Finset (Finset α)) = card α * ∑ k ∈ range (card α), (k : ℚ)⁻¹ := by
   have : ∀ t : Finset α,
-    (card α - (truncatedSup {s} t).card : ℚ) / ((card α - t.card) * (card α).choose t.card) =
-    if t ⊆ s then (card α - s.card : ℚ) / ((card α - t.card) * (card α).choose t.card) else 0 := by
+    (card α - #(truncatedSup {s} t) : ℚ) / ((card α - #t) * (card α).choose #t) =
+    if t ⊆ s then (card α - #s : ℚ) / ((card α - #t) * (card α).choose #t) else 0 := by
     rintro t
     simp_rw [truncatedSup_singleton, le_iff_subset]
     split_ifs <;> simp [card_univ]
@@ -382,7 +381,7 @@ variable [Nonempty α]
     sum_powerset, ← binomial_sum_eq ((card_lt_iff_ne_univ _).2 hs), eq_comm]
   refine sum_congr rfl fun n _ ↦ ?_
   rw [mul_div_assoc, ← nsmul_eq_mul]
-  exact sum_powersetCard n s fun m ↦ (card α - s.card : ℚ) / ((card α - m) * (card α).choose m)
+  exact sum_powersetCard n s fun m ↦ (card α - #s : ℚ) / ((card α - m) * (card α).choose m)
 
 /-- The **Ahlswede-Zhang Identity**. -/
 lemma infSum_compls_add_supSum (𝒜 : Finset (Finset α)) :

--- a/Mathlib/Combinatorics/SetFamily/CauchyDavenport.lean
+++ b/Mathlib/Combinatorics/SetFamily/CauchyDavenport.lean
@@ -71,27 +71,24 @@ variable [Group α] [DecidableEq α] {x y : Finset α × Finset α} {s t : Finse
 * or `|s₁ + t₁| = |s₂ + t₂|` and `|s₂| + |t₂| < |s₁| + |t₁|`
 * or `|s₁ + t₁| = |s₂ + t₂|` and `|s₁| + |t₁| = |s₂| + |t₂|` and `|s₁| < |s₂|`."]
 private def DevosMulRel : Finset α × Finset α → Finset α × Finset α → Prop :=
-  Prod.Lex (· < ·) (Prod.Lex (· > ·) (· < ·)) on fun x ↦
-    ((x.1 * x.2).card, x.1.card + x.2.card, x.1.card)
+  Prod.Lex (· < ·) (Prod.Lex (· > ·) (· < ·)) on fun x ↦ (#(x.1 * x.2), #x.1 + #x.2, #x.1)
 
 @[to_additive]
 private lemma devosMulRel_iff :
     DevosMulRel x y ↔
-      (x.1 * x.2).card < (y.1 * y.2).card ∨
-        (x.1 * x.2).card = (y.1 * y.2).card ∧ y.1.card + y.2.card < x.1.card + x.2.card ∨
-          (x.1 * x.2).card = (y.1 * y.2).card ∧
-            x.1.card + x.2.card = y.1.card + y.2.card ∧ x.1.card < y.1.card := by
+      #(x.1 * x.2) < #(y.1 * y.2) ∨
+        #(x.1 * x.2) = #(y.1 * y.2) ∧ #y.1 + #y.2 < #x.1 + #x.2 ∨
+          #(x.1 * x.2) = #(y.1 * y.2) ∧ #x.1 + #x.2 = #y.1 + #y.2 ∧ #x.1 < #y.1 := by
   simp [DevosMulRel, Prod.lex_iff, and_or_left]
 
 @[to_additive]
-private lemma devosMulRel_of_le (mul : (x.1 * x.2).card ≤ (y.1 * y.2).card)
-    (hadd : y.1.card + y.2.card < x.1.card + x.2.card) : DevosMulRel x y :=
+private lemma devosMulRel_of_le (mul : #(x.1 * x.2) ≤ #(y.1 * y.2))
+    (hadd : #y.1 + #y.2 < #x.1 + #x.2) : DevosMulRel x y :=
   devosMulRel_iff.2 <| mul.lt_or_eq.imp_right fun h ↦ Or.inl ⟨h, hadd⟩
 
 @[to_additive]
-private lemma devosMulRel_of_le_of_le (mul : (x.1 * x.2).card ≤ (y.1 * y.2).card)
-    (hadd : y.1.card + y.2.card ≤ x.1.card + x.2.card) (hone : x.1.card < y.1.card) :
-    DevosMulRel x y :=
+private lemma devosMulRel_of_le_of_le (mul : #(x.1 * x.2) ≤ #(y.1 * y.2))
+    (hadd : #y.1 + #y.2 ≤ #x.1 + #x.2) (hone : #x.1 < #y.1) : DevosMulRel x y :=
   devosMulRel_iff.2 <|
     mul.lt_or_eq.imp_right fun h ↦ hadd.gt_or_eq.imp (And.intro h) fun h' ↦ ⟨h, h', hone⟩
 
@@ -113,20 +110,20 @@ subgroup. -/
 `s + t` is lower-bounded by `|s| + |t| - 1` unless this quantity is greater than the size of the
 smallest subgroup."]
 lemma Finset.min_le_card_mul (hs : s.Nonempty) (ht : t.Nonempty) :
-    min (minOrder α) ↑(s.card + t.card - 1) ≤ (s * t).card := by
+    min (minOrder α) ↑(#s + #t - 1) ≤ #(s * t) := by
   -- Set up the induction on `x := (s, t)` along the `DevosMulRel` relation.
   set x := (s, t) with hx
   clear_value x
   simp only [Prod.ext_iff] at hx
   obtain ⟨rfl, rfl⟩ := hx
   refine wellFoundedOn_devosMulRel.induction (P := fun x : Finset α × Finset α ↦
-    min (minOrder α) ↑(card x.1 + card x.2 - 1) ≤ card (x.1 * x.2)) ⟨hs, ht⟩ ?_
+    min (minOrder α) ↑(#x.1 + #x.2 - 1) ≤ #(x.1 * x.2)) ⟨hs, ht⟩ ?_
   clear! x
   rintro ⟨s, t⟩ ⟨hs, ht⟩ ih
   simp only [min_le_iff, tsub_le_iff_right, Prod.forall, Set.mem_setOf_eq, and_imp,
     Nat.cast_le] at *
-  -- If `t.card < s.card`, we're done by the induction hypothesis on `(t⁻¹, s⁻¹)`.
-  obtain hts | hst := lt_or_le t.card s.card
+  -- If `#t < #s`, we're done by the induction hypothesis on `(t⁻¹, s⁻¹)`.
+  obtain hts | hst := lt_or_le #t #s
   · simpa only [← mul_inv_rev, add_comm, card_inv] using
       ih _ _ ht.inv hs.inv
         (devosMulRel_iff.2 <| Or.inr <| Or.inr <| by
@@ -159,7 +156,7 @@ lemma Finset.min_le_card_mul (hs : s.Nonempty) (ht : t.Nonempty) :
     simp [-coe_smul_finset]
   -- Else, we can transform `s`, `t` to `s'`, `t'` and `s''`, `t''`, such that one of `(s', t')` and
   -- `(s'', t'')` is strictly smaller than `(s, t)` according to `DevosMulRel`.
-  replace hsg : (s ∩ op g • s).card < s.card := card_lt_card ⟨inter_subset_left, fun h ↦
+  replace hsg : #(s ∩ op g • s) < #s := card_lt_card ⟨inter_subset_left, fun h ↦
     hsg <| eq_of_superset_of_card_ge (h.trans inter_subset_right) (card_smul_finset _ _).le⟩
   replace aux1 := card_mono <| mulETransformLeft.fst_mul_snd_subset g (s, t)
   replace aux2 := card_mono <| mulETransformRight.fst_mul_snd_subset g (s, t)
@@ -184,7 +181,7 @@ by `|s| + |t| - 1`. -/
 @[to_additive "The **Cauchy-Davenport theorem** for torsion-free groups. The size of `s + t` is
 lower-bounded by `|s| + |t| - 1`."]
 lemma Monoid.IsTorsionFree.card_add_card_sub_one_le_card_mul (h : IsTorsionFree α)
-    (hs : s.Nonempty) (ht : t.Nonempty) : s.card + t.card - 1 ≤ (s * t).card := by
+    (hs : s.Nonempty) (ht : t.Nonempty) : #s + #t - 1 ≤ #(s * t) := by
   simpa only [h.minOrder, min_eq_right, le_top, Nat.cast_le] using Finset.min_le_card_mul hs ht
 
 end General
@@ -194,7 +191,7 @@ end General
 /-- The **Cauchy-Davenport Theorem**. If `s`, `t` are nonempty sets in $$ℤ/pℤ$$, then the size of
 `s + t` is lower-bounded by `|s| + |t| - 1`, unless this quantity is greater than `p`. -/
 lemma ZMod.min_le_card_add {p : ℕ} (hp : p.Prime) {s t : Finset (ZMod p)} (hs : s.Nonempty)
-    (ht : t.Nonempty) : min p (s.card + t.card - 1) ≤ (s + t).card := by
+    (ht : t.Nonempty) : min p (#s + #t - 1) ≤ #(s + t) := by
   simpa only [ZMod.minOrder_of_prime hp, min_le_iff, Nat.cast_le] using Finset.min_le_card_add hs ht
 
 /-! ### Linearly ordered cancellative semigroups -/
@@ -206,7 +203,7 @@ lemma ZMod.min_le_card_add {p : ℕ} (hp : p.Prime) {s t : Finset (ZMod p)} (hs 
 `s + t` is lower-bounded by `|s| + |t| - 1`."]
 lemma Finset.card_add_card_sub_one_le_card_mul [LinearOrder α] [Semigroup α] [IsCancelMul α]
     [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)]
-    {s t : Finset α} (hs : s.Nonempty) (ht : t.Nonempty) : s.card + t.card - 1 ≤ (s * t).card := by
+    {s t : Finset α} (hs : s.Nonempty) (ht : t.Nonempty) : #s + #t - 1 ≤ #(s * t) := by
   suffices s * {t.min' ht} ∩ ({s.max' hs} * t) = {s.max' hs * t.min' ht} by
     rw [← card_singleton_mul t (s.max' hs), ← card_mul_singleton s (t.min' ht),
       ← card_union_add_card_inter, ← card_singleton _, ← this, Nat.add_sub_cancel]

--- a/Mathlib/Combinatorics/SetFamily/Compression/Down.lean
+++ b/Mathlib/Combinatorics/SetFamily/Compression/Down.lean
@@ -40,13 +40,12 @@ variable {α : Type*} [DecidableEq α] {𝒜 : Finset (Finset α)} {s : Finset �
 namespace Finset
 
 /-- Elements of `𝒜` that do not contain `a`. -/
-def nonMemberSubfamily (a : α) (𝒜 : Finset (Finset α)) : Finset (Finset α) :=
-  𝒜.filter fun s => a ∉ s
+def nonMemberSubfamily (a : α) (𝒜 : Finset (Finset α)) : Finset (Finset α) := {s ∈ 𝒜 | a ∉ s}
 
 /-- Image of the elements of `𝒜` which contain `a` under removing `a`. Finsets that do not contain
 `a` such that `insert a s ∈ 𝒜`. -/
 def memberSubfamily (a : α) (𝒜 : Finset (Finset α)) : Finset (Finset α) :=
-  (𝒜.filter fun s => a ∈ s).image fun s => erase s a
+  {s ∈ 𝒜 | a ∈ s}.image fun s => erase s a
 
 @[simp]
 theorem mem_nonMemberSubfamily : s ∈ 𝒜.nonMemberSubfamily a ↔ s ∈ 𝒜 ∧ a ∉ s := by
@@ -79,7 +78,7 @@ theorem memberSubfamily_union (a : α) (𝒜 ℬ : Finset (Finset α)) :
   simp_rw [memberSubfamily, filter_union, image_union]
 
 theorem card_memberSubfamily_add_card_nonMemberSubfamily (a : α) (𝒜 : Finset (Finset α)) :
-    (𝒜.memberSubfamily a).card + (𝒜.nonMemberSubfamily a).card = 𝒜.card := by
+    #(𝒜.memberSubfamily a) + #(𝒜.nonMemberSubfamily a) = #𝒜 := by
   rw [memberSubfamily, nonMemberSubfamily, card_image_of_injOn]
   · conv_rhs => rw [← filter_card_add_filter_neg_card_eq_card (fun s => (a ∈ s))]
   · apply (erase_injOn' _).mono
@@ -136,7 +135,7 @@ lemma memberSubfamily_image_insert (h𝒜 : ∀ s ∈ 𝒜, a ∉ s) :
     (ne_of_mem_of_not_mem' (mem_insert_self _ _) (not_mem_erase _ _)).symm]
 
 lemma image_insert_memberSubfamily (𝒜 : Finset (Finset α)) (a : α) :
-    (𝒜.memberSubfamily a).image (insert a) = 𝒜.filter (a ∈ ·) := by
+    (𝒜.memberSubfamily a).image (insert a) = {s ∈ 𝒜 | a ∈ s} := by
   ext s
   simp only [mem_memberSubfamily, mem_image, mem_filter]
   refine ⟨?_, fun ⟨hs, ha⟩ ↦ ⟨erase s a, ⟨?_, not_mem_erase _ _⟩, insert_erase ha⟩⟩
@@ -182,7 +181,7 @@ it suffices to prove it for
 * `ℬ ∪ 𝒞` assuming the property for `ℬ` and `𝒞`, where `a` is an element of the ground type and
   `ℬ`is a family of finsets not containing `a` and `𝒞` a family of finsets containing `a`.
   Note that instead of giving `ℬ` and `𝒞`, the `subfamily` case gives you `𝒜 = ℬ ∪ 𝒞`, so that
-  `ℬ = 𝒜.filter (a ∉ ·)` and `𝒞 = 𝒜.filter (a ∈ ·)`.
+  `ℬ = {s ∈ 𝒜 | a ∉ s}` and `𝒞 = {s ∈ 𝒜 | a ∈ s}`.
 
 This is a way of formalising induction on `n` where `𝒜` is a finset family on `n` elements.
 
@@ -193,7 +192,7 @@ protected lemma family_induction_on {p : Finset (Finset α) → Prop}
     (image_insert : ∀ (a : α) ⦃𝒜 : Finset (Finset α)⦄,
       (∀ s ∈ 𝒜, a ∉ s) → p 𝒜 → p (𝒜.image <| insert a))
     (subfamily : ∀ (a : α) ⦃𝒜 : Finset (Finset α)⦄,
-      p (𝒜.filter (a ∉ ·)) → p (𝒜.filter (a ∈ ·)) → p 𝒜) : p 𝒜 := by
+      p {s ∈ 𝒜 | a ∉ s} → p {s ∈ 𝒜 | a ∈ s} → p 𝒜) : p 𝒜 := by
   refine memberFamily_induction_on 𝒜 empty singleton_empty fun a 𝒜 h𝒜₀ h𝒜₁ ↦ subfamily a h𝒜₀ ?_
   rw [← image_insert_memberSubfamily]
   exact image_insert _ (by simp) h𝒜₁
@@ -208,11 +207,8 @@ namespace Down
 /-- `a`-down-compressing `𝒜` means removing `a` from the elements of `𝒜` that contain it, when the
 resulting Finset is not already in `𝒜`. -/
 def compression (a : α) (𝒜 : Finset (Finset α)) : Finset (Finset α) :=
-  (𝒜.filter fun s => erase s a ∈ 𝒜).disjUnion
-      ((𝒜.image fun s => erase s a).filter fun s => s ∉ 𝒜) <|
-    disjoint_left.2 fun s h₁ h₂ => by
-      have := (mem_filter.1 h₂).2
-      exact this (mem_filter.1 h₁).1
+  {s ∈ 𝒜 | erase s a ∈ 𝒜}.disjUnion {s ∈ 𝒜.image fun s ↦ erase s a | s ∉ 𝒜} <|
+    disjoint_left.2 fun _s h₁ h₂ ↦ (mem_filter.1 h₂).2 (mem_filter.1 h₁).1
 
 @[inherit_doc]
 scoped[FinsetFamily] notation "𝓓 " => Down.compression
@@ -258,7 +254,7 @@ theorem compression_idem (a : α) (𝒜 : Finset (Finset α)) : 𝓓 a (𝓓 a �
 
 /-- Down-compressing a family doesn't change its size. -/
 @[simp]
-theorem card_compression (a : α) (𝒜 : Finset (Finset α)) : (𝓓 a 𝒜).card = 𝒜.card := by
+theorem card_compression (a : α) (𝒜 : Finset (Finset α)) : #(𝓓 a 𝒜) = #𝒜 := by
   rw [compression, card_disjUnion, filter_image,
     card_image_of_injOn ((erase_injOn' _).mono fun s hs => _), ← card_union_of_disjoint]
   · conv_rhs => rw [← filter_union_filter_neg_eq (fun s => (erase s a ∈ 𝒜)) 𝒜]

--- a/Mathlib/Combinatorics/SetFamily/Compression/UV.lean
+++ b/Mathlib/Combinatorics/SetFamily/Compression/UV.lean
@@ -116,7 +116,7 @@ variable [DecidableEq α]
 /-- To UV-compress a set family, we compress each of its elements, except that we don't want to
 reduce the cardinality, so we keep all elements whose compression is already present. -/
 def compression (u v : α) (s : Finset α) :=
-  (s.filter (compress u v · ∈ s)) ∪ (s.image <| compress u v).filter (· ∉ s)
+  {a ∈ s | compress u v a ∈ s} ∪ {a ∈ s.image <| compress u v | a ∉ s}
 
 @[inherit_doc]
 scoped[FinsetFamily] notation "𝓒 " => UV.compression
@@ -128,7 +128,7 @@ def IsCompressed (u v : α) (s : Finset α) :=
   𝓒 u v s = s
 
 /-- UV-compression is injective on the sets that are not UV-compressed. -/
-theorem compress_injOn : Set.InjOn (compress u v) ↑(s.filter (compress u v · ∉ s)) := by
+theorem compress_injOn : Set.InjOn (compress u v) ↑{a ∈ s | compress u v a ∉ s} := by
   intro a ha b hb hab
   rw [mem_coe, mem_filter] at ha hb
   rw [compress] at ha hab
@@ -162,7 +162,7 @@ theorem compression_self (u : α) (s : Finset α) : 𝓒 u u s = s := by
 theorem isCompressed_self (u : α) (s : Finset α) : IsCompressed u u s := compression_self u s
 
 theorem compress_disjoint :
-    Disjoint (s.filter (compress u v · ∈ s)) ((s.image <| compress u v).filter (· ∉ s)) :=
+    Disjoint {a ∈ s | compress u v a ∈ s} {a ∈ s.image <| compress u v | a ∉ s} :=
   disjoint_left.2 fun _a ha₁ ha₂ ↦ (mem_filter.1 ha₂).2 (mem_filter.1 ha₁).1
 
 theorem compress_mem_compression (ha : a ∈ s) : compress u v a ∈ 𝓒 u v s := by
@@ -184,14 +184,14 @@ theorem compress_mem_compression_of_mem_compression (ha : a ∈ 𝓒 u v s) :
 /-- Compressing a family is idempotent. -/
 @[simp]
 theorem compression_idem (u v : α) (s : Finset α) : 𝓒 u v (𝓒 u v s) = 𝓒 u v s := by
-  have h : filter (compress u v · ∉ 𝓒 u v s) (𝓒 u v s) = ∅ :=
+  have h : {a ∈ 𝓒 u v s | compress u v a ∉ 𝓒 u v s} = ∅ :=
     filter_false_of_mem fun a ha h ↦ h <| compress_mem_compression_of_mem_compression ha
   rw [compression, filter_image, h, image_empty, ← h]
   exact filter_union_filter_neg_eq _ (compression u v s)
 
 /-- Compressing a family doesn't change its size. -/
 @[simp]
-theorem card_compression (u v : α) (s : Finset α) : (𝓒 u v s).card = s.card := by
+theorem card_compression (u v : α) (s : Finset α) : #(𝓒 u v s) = #s := by
   rw [compression, card_union_of_disjoint compress_disjoint, filter_image,
     card_image_of_injOn compress_injOn, ← card_union_of_disjoint (disjoint_filter_filter_neg s _ _),
     filter_union_filter_neg_eq]
@@ -268,14 +268,14 @@ open FinsetFamily
 variable [DecidableEq α] {𝒜 : Finset (Finset α)} {u v a : Finset α} {r : ℕ}
 
 /-- Compressing a finset doesn't change its size. -/
-theorem card_compress (huv : u.card = v.card) (a : Finset α) : (compress u v a).card = a.card := by
+theorem card_compress (huv : #u = #v) (a : Finset α) : #(compress u v a) = #a := by
   unfold compress
   split_ifs with h
   · rw [card_sdiff (h.2.trans le_sup_left), sup_eq_union, card_union_of_disjoint h.1.symm, huv,
       add_tsub_cancel_right]
   · rfl
 
-lemma _root_.Set.Sized.uvCompression (huv : u.card = v.card) (h𝒜 : (𝒜 : Set (Finset α)).Sized r) :
+lemma _root_.Set.Sized.uvCompression (huv : #u = #v) (h𝒜 : (𝒜 : Set (Finset α)).Sized r) :
     (𝓒 u v 𝒜 : Set (Finset α)).Sized r := by
   simp_rw [Set.Sized, mem_coe, mem_compression]
   rintro s (hs | ⟨huvt, t, ht, rfl⟩)
@@ -397,7 +397,7 @@ such that `𝒜` is `(u.erase x, v.erase y)`-compressed. This is the key UV-comp
 Kruskal-Katona. -/
 theorem card_shadow_compression_le (u v : Finset α)
     (huv : ∀ x ∈ u, ∃ y ∈ v, IsCompressed (u.erase x) (v.erase y) 𝒜) :
-    (∂ (𝓒 u v 𝒜)).card ≤ (∂ 𝒜).card :=
+    #(∂ (𝓒 u v 𝒜)) ≤ #(∂ 𝒜) :=
   (card_le_card <| shadow_compression_subset_compression_shadow _ _ huv).trans
     (card_compression _ _ _).le
 

--- a/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
+++ b/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
@@ -87,7 +87,7 @@ private lemma ineq [ExistsAddOfLE β] {a₀ a₁ b₀ b₁ c₀ c₁ d₀ d₁ :
     _ = (c₀ * d₁ + c₁ * d₀) * (c₀ * d₁) := by ring
 
 private def collapse (𝒜 : Finset (Finset α)) (a : α) (f : Finset α → β) (s : Finset α) : β :=
-  ∑ t ∈ 𝒜.filter fun t ↦ t.erase a = s, f t
+  ∑ t ∈ 𝒜 with t.erase a = s, f t
 
 private lemma erase_eq_iff (hs : a ∉ s) : t.erase a = s ↔ t = s ∨ t = insert a s := by
   by_cases ht : a ∈ t <;>
@@ -95,7 +95,7 @@ private lemma erase_eq_iff (hs : a ∉ s) : t.erase a = s ↔ t = s ∨ t = inse
     aesop
 
 private lemma filter_collapse_eq (ha : a ∉ s) (𝒜 : Finset (Finset α)) :
-    (𝒜.filter fun t ↦ t.erase a = s) =
+    {t ∈ 𝒜 | t.erase a = s} =
       if s ∈ 𝒜 then
         (if insert a s ∈ 𝒜 then {s, insert a s} else {s})
       else
@@ -304,7 +304,7 @@ lemma four_functions_theorem [DecidableEq α] (h₁ : 0 ≤ f₁) (h₂ : 0 ≤ 
 /-- An inequality of Daykin. Interestingly, any lattice in which this inequality holds is
 distributive. -/
 lemma Finset.le_card_infs_mul_card_sups [DecidableEq α] (s t : Finset α) :
-    s.card * t.card ≤ (s ⊼ t).card * (s ⊻ t).card := by
+    #s * #t ≤ #(s ⊼ t) * #(s ⊻ t) := by
   simpa using four_functions_theorem (1 : α → ℕ) 1 1 1 zero_le_one zero_le_one zero_le_one
     zero_le_one (fun _ _ ↦ le_rfl) s t
 
@@ -353,7 +353,7 @@ variable [DecidableEq α] [GeneralizedBooleanAlgebra α]
 
 /-- A slight generalisation of the **Marica-Schönheim Inequality**. -/
 lemma Finset.le_card_diffs_mul_card_diffs (s t : Finset α) :
-    s.card * t.card ≤ (s \\ t).card * (t \\ s).card := by
+    #s * #t ≤ #(s \\ t) * #(t \\ s) := by
   have : ∀ s t : Finset α, (s \\ t).map ⟨_, liftLatticeHom_injective⟩ =
       s.map ⟨_, liftLatticeHom_injective⟩ \\ t.map ⟨_, liftLatticeHom_injective⟩ := by
     rintro s t
@@ -364,6 +364,6 @@ lemma Finset.le_card_diffs_mul_card_diffs (s t : Finset α) :
       (t.map ⟨_, liftLatticeHom_injective⟩)ᶜˢ
 
 /-- The **Marica-Schönheim Inequality**. -/
-lemma Finset.card_le_card_diffs (s : Finset α) : s.card ≤ (s \\ s).card :=
+lemma Finset.card_le_card_diffs (s : Finset α) : #s ≤ #(s \\ s) :=
   le_of_pow_le_pow_left two_ne_zero (zero_le _) <| by
     simpa [← sq] using s.le_card_diffs_mul_card_diffs s

--- a/Mathlib/Combinatorics/SetFamily/HarrisKleitman.lean
+++ b/Mathlib/Combinatorics/SetFamily/HarrisKleitman.lean
@@ -11,8 +11,8 @@ import Mathlib.Data.Fintype.Powerset
 /-!
 # Harris-Kleitman inequality
 
-This file proves the Harris-Kleitman inequality. This relates `𝒜.card * ℬ.card` and
-`2 ^ card α * (𝒜 ∩ ℬ).card` where `𝒜` and `ℬ` are upward- or downcard-closed finite families of
+This file proves the Harris-Kleitman inequality. This relates `#𝒜 * #ℬ` and
+`2 ^ card α * #(𝒜 ∩ ℬ)` where `𝒜` and `ℬ` are upward- or downcard-closed finite families of
 finsets. This can be interpreted as saying that any two lower sets (resp. any two upper sets)
 correlate in the uniform measure.
 
@@ -49,7 +49,7 @@ theorem IsLowerSet.memberSubfamily_subset_nonMemberSubfamily (h : IsLowerSet (�
 /-- **Harris-Kleitman inequality**: Any two lower sets of finsets correlate. -/
 theorem IsLowerSet.le_card_inter_finset' (h𝒜 : IsLowerSet (𝒜 : Set (Finset α)))
     (hℬ : IsLowerSet (ℬ : Set (Finset α))) (h𝒜s : ∀ t ∈ 𝒜, t ⊆ s) (hℬs : ∀ t ∈ ℬ, t ⊆ s) :
-    𝒜.card * ℬ.card ≤ 2 ^ s.card * (𝒜 ∩ ℬ).card := by
+    #𝒜 * #ℬ ≤ 2 ^ #s * #(𝒜 ∩ ℬ) := by
   induction' s using Finset.induction with a s hs ih generalizing 𝒜 ℬ
   · simp_rw [subset_empty, ← subset_singleton_iff', subset_singleton_iff] at h𝒜s hℬs
     obtain rfl | rfl := h𝒜s
@@ -89,13 +89,13 @@ variable [Fintype α]
 
 /-- **Harris-Kleitman inequality**: Any two lower sets of finsets correlate. -/
 theorem IsLowerSet.le_card_inter_finset (h𝒜 : IsLowerSet (𝒜 : Set (Finset α)))
-    (hℬ : IsLowerSet (ℬ : Set (Finset α))) : 𝒜.card * ℬ.card ≤ 2 ^ Fintype.card α * (𝒜 ∩ ℬ).card :=
+    (hℬ : IsLowerSet (ℬ : Set (Finset α))) : #𝒜 * #ℬ ≤ 2 ^ Fintype.card α * #(𝒜 ∩ ℬ) :=
 h𝒜.le_card_inter_finset' hℬ (fun _ _ => subset_univ _) fun _ _ => subset_univ _
 
 /-- **Harris-Kleitman inequality**: Upper sets and lower sets of finsets anticorrelate. -/
 theorem IsUpperSet.card_inter_le_finset (h𝒜 : IsUpperSet (𝒜 : Set (Finset α)))
     (hℬ : IsLowerSet (ℬ : Set (Finset α))) :
-    2 ^ Fintype.card α * (𝒜 ∩ ℬ).card ≤ 𝒜.card * ℬ.card := by
+    2 ^ Fintype.card α * #(𝒜 ∩ ℬ) ≤ #𝒜 * #ℬ := by
   rw [← isLowerSet_compl, ← coe_compl] at h𝒜
   have := h𝒜.le_card_inter_finset hℬ
   rwa [card_compl, Fintype.card_finset, tsub_mul, tsub_le_iff_tsub_le, ← mul_tsub, ←
@@ -105,14 +105,14 @@ theorem IsUpperSet.card_inter_le_finset (h𝒜 : IsUpperSet (𝒜 : Set (Finset 
 /-- **Harris-Kleitman inequality**: Lower sets and upper sets of finsets anticorrelate. -/
 theorem IsLowerSet.card_inter_le_finset (h𝒜 : IsLowerSet (𝒜 : Set (Finset α)))
     (hℬ : IsUpperSet (ℬ : Set (Finset α))) :
-    2 ^ Fintype.card α * (𝒜 ∩ ℬ).card ≤ 𝒜.card * ℬ.card := by
-  rw [inter_comm, mul_comm 𝒜.card]
+    2 ^ Fintype.card α * #(𝒜 ∩ ℬ) ≤ #𝒜 * #ℬ := by
+  rw [inter_comm, mul_comm #𝒜]
   exact hℬ.card_inter_le_finset h𝒜
 
 /-- **Harris-Kleitman inequality**: Any two upper sets of finsets correlate. -/
 theorem IsUpperSet.le_card_inter_finset (h𝒜 : IsUpperSet (𝒜 : Set (Finset α)))
     (hℬ : IsUpperSet (ℬ : Set (Finset α))) :
-    𝒜.card * ℬ.card ≤ 2 ^ Fintype.card α * (𝒜 ∩ ℬ).card := by
+    #𝒜 * #ℬ ≤ 2 ^ Fintype.card α * #(𝒜 ∩ ℬ) := by
   rw [← isLowerSet_compl, ← coe_compl] at h𝒜
   have := h𝒜.card_inter_le_finset hℬ
   rwa [card_compl, Fintype.card_finset, tsub_mul, le_tsub_iff_le_tsub, ← mul_tsub, ←

--- a/Mathlib/Combinatorics/SetFamily/Intersecting.lean
+++ b/Mathlib/Combinatorics/SetFamily/Intersecting.lean
@@ -141,7 +141,7 @@ theorem Intersecting.disjoint_map_compl {s : Finset α} (hs : (s : Set α).Inter
   exact hs.not_compl_mem hx' hx
 
 theorem Intersecting.card_le [Fintype α] {s : Finset α} (hs : (s : Set α).Intersecting) :
-    2 * s.card ≤ Fintype.card α := by
+    2 * #s ≤ Fintype.card α := by
   classical
     refine (s.disjUnion _ hs.disjoint_map_compl).card_le_univ.trans_eq' ?_
     rw [Nat.two_mul, card_disjUnion, card_map]
@@ -150,7 +150,7 @@ variable [Nontrivial α] [Fintype α] {s : Finset α}
 
 -- Note, this lemma is false when `α` has exactly one element and boring when `α` is empty.
 theorem Intersecting.is_max_iff_card_eq (hs : (s : Set α).Intersecting) :
-    (∀ t : Finset α, (t : Set α).Intersecting → s ⊆ t → s = t) ↔ 2 * s.card = Fintype.card α := by
+    (∀ t : Finset α, (t : Set α).Intersecting → s ⊆ t → s = t) ↔ 2 * #s = Fintype.card α := by
   classical
     refine ⟨fun h ↦ ?_, fun h t ht hst ↦ Finset.eq_of_subset_of_card_le hst <|
       Nat.le_of_mul_le_mul_left (ht.card_le.trans_eq h.symm) Nat.two_pos⟩
@@ -171,7 +171,7 @@ theorem Intersecting.is_max_iff_card_eq (hs : (s : Set α).Intersecting) :
     exact Finset.singleton_ne_empty _ (this <| Finset.empty_subset _).symm
 
 theorem Intersecting.exists_card_eq (hs : (s : Set α).Intersecting) :
-    ∃ t, s ⊆ t ∧ 2 * t.card = Fintype.card α ∧ (t : Set α).Intersecting := by
+    ∃ t, s ⊆ t ∧ 2 * #t = Fintype.card α ∧ (t : Set α).Intersecting := by
   have := hs.card_le
   rw [mul_comm, ← Nat.le_div_iff_mul_le' Nat.two_pos] at this
   revert hs

--- a/Mathlib/Combinatorics/SetFamily/Kleitman.lean
+++ b/Mathlib/Combinatorics/SetFamily/Kleitman.lean
@@ -34,11 +34,11 @@ variable {ι α : Type*} [Fintype α] [DecidableEq α] [Nonempty α]
 each further intersecting family takes at most half of the sets that are in no previous family. -/
 theorem Finset.card_biUnion_le_of_intersecting (s : Finset ι) (f : ι → Finset (Finset α))
     (hf : ∀ i ∈ s, (f i : Set (Finset α)).Intersecting) :
-    (s.biUnion f).card ≤ 2 ^ Fintype.card α - 2 ^ (Fintype.card α - s.card) := by
+    #(s.biUnion f) ≤ 2 ^ Fintype.card α - 2 ^ (Fintype.card α - #s) := by
   have : DecidableEq ι := by
     classical
     infer_instance
-  obtain hs | hs := le_total (Fintype.card α) s.card
+  obtain hs | hs := le_total (Fintype.card α) #s
   · rw [tsub_eq_zero_of_le hs, pow_zero]
     refine (card_le_card <| biUnion_subset.2 fun i hi a ha ↦
       mem_compl.2 <| not_mem_singleton.2 <| (hf _ hi).ne_bot ha).trans_eq ?_
@@ -47,7 +47,7 @@ theorem Finset.card_biUnion_le_of_intersecting (s : Finset ι) (f : ι → Finse
   · simp
   set f' : ι → Finset (Finset α) :=
     fun j ↦ if hj : j ∈ cons i s hi then (hf j hj).exists_card_eq.choose else ∅
-  have hf₁ : ∀ j, j ∈ cons i s hi → f j ⊆ f' j ∧ 2 * (f' j).card =
+  have hf₁ : ∀ j, j ∈ cons i s hi → f j ⊆ f' j ∧ 2 * #(f' j) =
       2 ^ Fintype.card α ∧ (f' j : Set (Finset α)).Intersecting := by
     rintro j hj
     simp_rw [f', dif_pos hj, ← Fintype.card_finset]

--- a/Mathlib/Combinatorics/SetFamily/KruskalKatona.lean
+++ b/Mathlib/Combinatorics/SetFamily/KruskalKatona.lean
@@ -78,8 +78,8 @@ lemma shadow_initSeg [Fintype α] (hs : s.Nonempty) :
   -- Assume first t < s - min s, and take k as the colex witness for this
   have hjk : j ≤ k := min'_le _ _ (mem_compl.2 ‹k ∉ t›)
   have : j ∉ t := mem_compl.1 (min'_mem _ _)
-  have hcard : card s = card (insert j t) := by
-    rw [card_insert_of_not_mem ‹j ∉ t›, ← ‹_ = card t›, card_erase_add_one (min'_mem _ _)]
+  have hcard : #s = #(insert j t) := by
+    rw [card_insert_of_not_mem ‹j ∉ t›, ← ‹_ = #t›, card_erase_add_one (min'_mem _ _)]
   refine ⟨j, ‹_›, hcard, ?_⟩
   -- Cases on j < k or j = k
   obtain hjk | r₁ := hjk.lt_or_eq
@@ -139,7 +139,7 @@ lemma toColex_compress_lt_toColex {hU : U.Nonempty} {hV : V.Nonempty} (h : max' 
 
 /-- These are the compressions which we will apply to decrease the "measure" of a family of sets.-/
 private def UsefulCompression (U V : Finset α) : Prop :=
-  Disjoint U V ∧ U.card = V.card ∧ ∃ (HU : U.Nonempty) (HV : V.Nonempty), max' U HU < max' V HV
+  Disjoint U V ∧ #U = #V ∧ ∃ (HU : U.Nonempty) (HV : V.Nonempty), max' U HU < max' V HV
 
 private instance UsefulCompression.instDecidableRel : @DecidableRel (Finset α) UsefulCompression :=
   fun _ _ ↦ inferInstanceAs (Decidable (_ ∧ _))
@@ -148,8 +148,8 @@ private instance UsefulCompression.instDecidableRel : @DecidableRel (Finset α) 
 shadow. In particular, 'good' means it's useful, and every smaller compression won't make a
 difference. -/
 private lemma compression_improved (𝒜 : Finset (Finset α)) (h₁ : UsefulCompression U V)
-    (h₂ : ∀ ⦃U₁ V₁⦄, UsefulCompression U₁ V₁ → U₁.card < U.card → IsCompressed U₁ V₁ 𝒜) :
-    (∂ (𝓒 U V 𝒜)).card ≤ (∂ 𝒜).card := by
+    (h₂ : ∀ ⦃U₁ V₁⦄, UsefulCompression U₁ V₁ → #U₁ < #U → IsCompressed U₁ V₁ 𝒜) :
+    #(∂ (𝓒 U V 𝒜)) ≤ #(∂ 𝒜) := by
   obtain ⟨UVd, same_size, hU, hV, max_lt⟩ := h₁
   refine card_shadow_compression_le _ _ fun x Hx ↦ ⟨min' V hV, min'_mem _ _, ?_⟩
   obtain hU' | hU' := eq_or_lt_of_le (succ_le_iff.2 hU.card_pos)
@@ -174,7 +174,7 @@ lemma isInitSeg_of_compressed {ℬ : Finset (Finset α)} {r : ℕ} (h₁ : (ℬ 
   rintro A B hA ⟨hBA, sizeA⟩
   by_contra hB
   have hAB : A ≠ B := ne_of_mem_of_not_mem hA hB
-  have hAB' : A.card = B.card := (h₁ hA).trans sizeA.symm
+  have hAB' : #A = #B := (h₁ hA).trans sizeA.symm
   have hU : (A \ B).Nonempty := sdiff_nonempty.2 fun h ↦ hAB <| eq_of_subset_of_card_le h hAB'.ge
   have hV : (B \ A).Nonempty :=
     sdiff_nonempty.2 fun h ↦ hAB.symm <| eq_of_subset_of_card_le h hAB'.le
@@ -203,14 +203,14 @@ private lemma familyMeasure_compression_lt_familyMeasure {U V : Finset (Fin n)} 
     {hV : V.Nonempty} (h : max' U hU < max' V hV) {𝒜 : Finset (Finset (Fin n))} (a : 𝓒 U V 𝒜 ≠ 𝒜) :
     familyMeasure (𝓒 U V 𝒜) < familyMeasure 𝒜 := by
   rw [compression] at a ⊢
-  have q : ∀ Q ∈ 𝒜.filter fun A ↦ compress U V A ∉ 𝒜, compress U V Q ≠ Q := by
+  have q : ∀ Q ∈ {A ∈ 𝒜 | compress U V A ∉ 𝒜}, compress U V Q ≠ Q := by
     simp_rw [mem_filter]
     intro Q hQ h
     rw [h] at hQ
     exact hQ.2 hQ.1
-  have uA : (𝒜.filter fun A => compress U V A ∈ 𝒜) ∪ 𝒜.filter (fun A ↦ compress U V A ∉ 𝒜) = 𝒜 :=
+  have uA : {A ∈ 𝒜 | compress U V A ∈ 𝒜} ∪ {A ∈ 𝒜 | compress U V A ∉ 𝒜} = 𝒜 :=
     filter_union_filter_neg_eq _ _
-  have ne₂ : (𝒜.filter fun A ↦ compress U V A ∉ 𝒜).Nonempty := by
+  have ne₂ : {A ∈ 𝒜 | compress U V A ∉ 𝒜}.Nonempty := by
     refine nonempty_iff_ne_empty.2 fun z ↦ a ?_
     rw [filter_image, z, image_empty, union_empty]
     rwa [z, union_empty] at uA
@@ -229,12 +229,12 @@ we can't any more, which gives a set family which is fully compressed and has th
 want. -/
 private lemma kruskal_katona_helper {r : ℕ} (𝒜 : Finset (Finset (Fin n)))
     (h : (𝒜 : Set (Finset (Fin n))).Sized r) :
-    ∃ ℬ : Finset (Finset (Fin n)), (∂ ℬ).card ≤ (∂ 𝒜).card ∧ 𝒜.card = ℬ.card ∧
+    ∃ ℬ : Finset (Finset (Fin n)), #(∂ ℬ) ≤ #(∂ 𝒜) ∧ #𝒜 = #ℬ ∧
       (ℬ : Set (Finset (Fin n))).Sized r ∧ ∀ U V, UsefulCompression U V → IsCompressed U V ℬ := by
   classical
   -- Are there any compressions we can make now?
   set usable : Finset (Finset (Fin n) × Finset (Fin n)) :=
-    univ.filter fun t ↦ UsefulCompression t.1 t.2 ∧ ¬ IsCompressed t.1 t.2 𝒜
+    {t | UsefulCompression t.1 t.2 ∧ ¬ IsCompressed t.1 t.2 𝒜}
   obtain husable | husable := usable.eq_empty_or_nonempty
   -- No. Then where we are is the required set family.
   · refine ⟨𝒜, le_rfl, rfl, h, fun U V hUV ↦ ?_⟩
@@ -242,13 +242,13 @@ private lemma kruskal_katona_helper {r : ℕ} (𝒜 : Finset (Finset (Fin n)))
     by_contra h
     exact husable ⟨U, V⟩ <| mem_filter.2 ⟨mem_univ _, hUV, h⟩
   -- Yes. Then apply the smallest compression, then keep going
-  obtain ⟨⟨U, V⟩, hUV, t⟩ := exists_min_image usable (fun t ↦ t.1.card) husable
+  obtain ⟨⟨U, V⟩, hUV, t⟩ := exists_min_image usable (fun t ↦ #t.1) husable
   rw [mem_filter] at hUV
-  have h₂ : ∀ U₁ V₁, UsefulCompression U₁ V₁ → U₁.card < U.card → IsCompressed U₁ V₁ 𝒜 := by
+  have h₂ : ∀ U₁ V₁, UsefulCompression U₁ V₁ → #U₁ < #U → IsCompressed U₁ V₁ 𝒜 := by
     rintro U₁ V₁ huseful hUcard
     by_contra h
     exact hUcard.not_le <| t ⟨U₁, V₁⟩ <| mem_filter.2 ⟨mem_univ _, huseful, h⟩
-  have p1 : (∂ (𝓒 U V 𝒜)).card ≤ (∂ 𝒜).card := compression_improved _ hUV.2.1 h₂
+  have p1 : #(∂ (𝓒 U V 𝒜)) ≤ #(∂ 𝒜) := compression_improved _ hUV.2.1 h₂
   obtain ⟨-, hUV', hu, hv, hmax⟩ := hUV.2.1
   have := familyMeasure_compression_lt_familyMeasure hmax hUV.2.2
   obtain ⟨t, q1, q2, q3, q4⟩ := UV.kruskal_katona_helper (𝓒 U V 𝒜) (h.uvCompression hUV')
@@ -266,8 +266,8 @@ variable {r k i : ℕ} {𝒜 𝒞 : Finset <| Finset <| Fin n}
 Given a set family `𝒜` consisting of `r`-sets, and `𝒞` an initial segment of the colex order of the
 same size, the shadow of `𝒞` is smaller than the shadow of `𝒜`. In particular, this gives that the
 minimum shadow size is achieved by initial segments of colex. -/
-theorem kruskal_katona (h𝒜r : (𝒜 : Set (Finset (Fin n))).Sized r) (h𝒞𝒜 : 𝒞.card ≤ 𝒜.card)
-    (h𝒞 : IsInitSeg 𝒞 r) : (∂ 𝒞).card ≤ (∂ 𝒜).card := by
+theorem kruskal_katona (h𝒜r : (𝒜 : Set (Finset (Fin n))).Sized r) (h𝒞𝒜 : #𝒞 ≤ #𝒜)
+    (h𝒞 : IsInitSeg 𝒞 r) : #(∂ 𝒞) ≤ #(∂ 𝒜) := by
   -- WLOG `|𝒜| = |𝒞|`
   obtain ⟨𝒜', h𝒜, h𝒜𝒞⟩ := exists_subset_card_eq h𝒞𝒜
   -- By `kruskal_katona_helper`, we find a fully compressed family `ℬ` of the same size as `𝒜`
@@ -276,15 +276,15 @@ theorem kruskal_katona (h𝒜r : (𝒜 : Set (Finset (Fin n))).Sized r) (h𝒞�
   -- This means that `ℬ` is an initial segment of the same size as `𝒞`. Hence they are equal and
   -- we are done.
   suffices ℬ = 𝒞 by subst 𝒞; exact hℬ𝒜.trans (by gcongr)
-  have hcard : card ℬ = card 𝒞 := h𝒜ℬ.symm.trans h𝒜𝒞
+  have hcard : #ℬ = #𝒞 := h𝒜ℬ.symm.trans h𝒜𝒞
   obtain h𝒞ℬ | hℬ𝒞 := h𝒞.total (UV.isInitSeg_of_compressed hℬr hℬ)
   · exact (eq_of_subset_of_card_le h𝒞ℬ hcard.le).symm
   · exact eq_of_subset_of_card_le hℬ𝒞 hcard.ge
 
 /-- An iterated form of the Kruskal-Katona theorem. In particular, the minimum possible iterated
 shadow size is attained by initial segments. -/
-theorem iterated_kk (h₁ : (𝒜 : Set (Finset (Fin n))).Sized r) (h₂ : 𝒞.card ≤ 𝒜.card)
-    (h₃ : IsInitSeg 𝒞 r) : (∂^[k] 𝒞).card ≤ (∂^[k] 𝒜).card := by
+theorem iterated_kk (h₁ : (𝒜 : Set (Finset (Fin n))).Sized r) (h₂ : #𝒞 ≤ #𝒜) (h₃ : IsInitSeg 𝒞 r) :
+    #(∂^[k] 𝒞) ≤ #(∂^[k] 𝒜) := by
   induction' k with _k ih generalizing r 𝒜 𝒞
   · simpa
   · refine ih h₁.shadow (kruskal_katona h₁ h₂ h₃) ?_

--- a/Mathlib/Combinatorics/SetFamily/LYM.lean
+++ b/Mathlib/Combinatorics/SetFamily/LYM.lean
@@ -61,7 +61,7 @@ variable [DecidableEq α] [Fintype α]
 /-- The downward **local LYM inequality**, with cancelled denominators. `𝒜` takes up less of `α^(r)`
 (the finsets of card `r`) than `∂𝒜` takes up of `α^(r - 1)`. -/
 theorem card_mul_le_card_shadow_mul (h𝒜 : (𝒜 : Set (Finset α)).Sized r) :
-    𝒜.card * r ≤ (∂ 𝒜).card * (Fintype.card α - r + 1) := by
+    #𝒜 * r ≤ #(∂ 𝒜) * (Fintype.card α - r + 1) := by
   let i : DecidableRel ((· ⊆ ·) : Finset α → Finset α → Prop) := fun _ _ => Classical.dec _
   refine card_mul_le_card_mul' (· ⊆ ·) (fun s hs => ?_) (fun s hs => ?_)
   · rw [← h𝒜 hs, ← card_image_of_injOn s.erase_injOn]
@@ -87,8 +87,8 @@ theorem card_mul_le_card_shadow_mul (h𝒜 : (𝒜 : Set (Finset α)).Sized r) :
 /-- The downward **local LYM inequality**. `𝒜` takes up less of `α^(r)` (the finsets of card `r`)
 than `∂𝒜` takes up of `α^(r - 1)`. -/
 theorem card_div_choose_le_card_shadow_div_choose (hr : r ≠ 0)
-    (h𝒜 : (𝒜 : Set (Finset α)).Sized r) : (𝒜.card : 𝕜) / (Fintype.card α).choose r
-    ≤ (∂ 𝒜).card / (Fintype.card α).choose (r - 1) := by
+    (h𝒜 : (𝒜 : Set (Finset α)).Sized r) : (#𝒜 : 𝕜) / (Fintype.card α).choose r
+    ≤ #(∂ 𝒜) / (Fintype.card α).choose (r - 1) := by
   obtain hr' | hr' := lt_or_le (Fintype.card α) r
   · rw [choose_eq_zero_of_lt hr', cast_zero, div_zero]
     exact div_nonneg (cast_nonneg _) (cast_nonneg _)
@@ -122,7 +122,7 @@ def falling : Finset (Finset α) :=
 
 variable {𝒜 k} {s : Finset α}
 
-theorem mem_falling : s ∈ falling k 𝒜 ↔ (∃ t ∈ 𝒜, s ⊆ t) ∧ s.card = k := by
+theorem mem_falling : s ∈ falling k 𝒜 ↔ (∃ t ∈ 𝒜, s ⊆ t) ∧ #s = k := by
   simp_rw [falling, mem_sup, mem_powersetCard]
   aesop
 
@@ -169,7 +169,7 @@ theorem IsAntichain.disjoint_slice_shadow_falling {m n : ℕ}
 theorem le_card_falling_div_choose [Fintype α] (hk : k ≤ Fintype.card α)
     (h𝒜 : IsAntichain (· ⊆ ·) (𝒜 : Set (Finset α))) :
     (∑ r ∈ range (k + 1),
-        ((𝒜 # (Fintype.card α - r)).card : 𝕜) / (Fintype.card α).choose (Fintype.card α - r)) ≤
+        (#(𝒜 # (Fintype.card α - r)) : 𝕜) / (Fintype.card α).choose (Fintype.card α - r)) ≤
       (falling (Fintype.card α - k) 𝒜).card / (Fintype.card α).choose (Fintype.card α - k) := by
   induction' k with k ih
   · simp only [tsub_zero, cast_one, cast_le, sum_singleton, div_one, choose_self, range_one,
@@ -194,7 +194,7 @@ variable {𝒜 : Finset (Finset α)} {s : Finset α} {k : ℕ}
 proportion of elements it takes from each layer is less than `1`. -/
 theorem sum_card_slice_div_choose_le_one [Fintype α]
     (h𝒜 : IsAntichain (· ⊆ ·) (𝒜 : Set (Finset α))) :
-    (∑ r ∈ range (Fintype.card α + 1), ((𝒜 # r).card : 𝕜) / (Fintype.card α).choose r) ≤ 1 := by
+    (∑ r ∈ range (Fintype.card α + 1), (#(𝒜 # r) : 𝕜) / (Fintype.card α).choose r) ≤ 1 := by
   classical
     rw [← sum_flip]
     refine (le_card_falling_div_choose le_rfl h𝒜).trans ?_
@@ -213,10 +213,10 @@ end LYM
 maximal layer in `Finset α`. This precisely means that `Finset α` is a Sperner order. -/
 theorem IsAntichain.sperner [Fintype α] {𝒜 : Finset (Finset α)}
     (h𝒜 : IsAntichain (· ⊆ ·) (𝒜 : Set (Finset α))) :
-    𝒜.card ≤ (Fintype.card α).choose (Fintype.card α / 2) := by
+    #𝒜 ≤ (Fintype.card α).choose (Fintype.card α / 2) := by
   classical
     suffices (∑ r ∈ Iic (Fintype.card α),
-        ((𝒜 # r).card : ℚ) / (Fintype.card α).choose (Fintype.card α / 2)) ≤ 1 by
+        (#(𝒜 # r) : ℚ) / (Fintype.card α).choose (Fintype.card α / 2)) ≤ 1 by
       rw [← sum_div, ← Nat.cast_sum, div_le_one] at this
       · simp only [cast_le] at this
         rwa [sum_card_slice] at this

--- a/Mathlib/Combinatorics/SetFamily/Shadow.lean
+++ b/Mathlib/Combinatorics/SetFamily/Shadow.lean
@@ -97,7 +97,7 @@ theorem erase_mem_shadow (hs : s ∈ 𝒜) (ha : a ∈ s) : erase s a ∈ ∂ �
 /-- `t ∈ ∂𝒜` iff `t` is exactly one element less than something from `𝒜`.
 
 See also `Finset.mem_shadow_iff_exists_mem_card_add_one`. -/
-lemma mem_shadow_iff_exists_sdiff : t ∈ ∂ 𝒜 ↔ ∃ s ∈ 𝒜, t ⊆ s ∧ (s \ t).card = 1 := by
+lemma mem_shadow_iff_exists_sdiff : t ∈ ∂ 𝒜 ↔ ∃ s ∈ 𝒜, t ⊆ s ∧ #(s \ t) = 1 := by
   simp_rw [mem_shadow_iff, ← covBy_iff_card_sdiff_eq_one, covBy_iff_exists_erase]
 
 /-- `t` is in the shadow of `𝒜` iff we can add an element to it so that the resulting finset is in
@@ -109,15 +109,14 @@ lemma mem_shadow_iff_insert_mem : t ∈ ∂ 𝒜 ↔ ∃ a ∉ t, insert a t ∈
 /-- `s ∈ ∂ 𝒜` iff `s` is exactly one element less than something from `𝒜`.
 
 See also `Finset.mem_shadow_iff_exists_sdiff`. -/
-lemma mem_shadow_iff_exists_mem_card_add_one :
-    t ∈ ∂ 𝒜 ↔ ∃ s ∈ 𝒜, t ⊆ s ∧ s.card = t.card + 1 := by
+lemma mem_shadow_iff_exists_mem_card_add_one : t ∈ ∂ 𝒜 ↔ ∃ s ∈ 𝒜, t ⊆ s ∧ #s = #t + 1 := by
   refine mem_shadow_iff_exists_sdiff.trans <| exists_congr fun t ↦ and_congr_right fun _ ↦
     and_congr_right fun hst ↦ ?_
   rw [card_sdiff hst, tsub_eq_iff_eq_add_of_le, add_comm]
   exact card_mono hst
 
 lemma mem_shadow_iterate_iff_exists_card :
-    t ∈ ∂^[k] 𝒜 ↔ ∃ u : Finset α, u.card = k ∧ Disjoint t u ∧ t ∪ u ∈ 𝒜 := by
+    t ∈ ∂^[k] 𝒜 ↔ ∃ u : Finset α, #u = k ∧ Disjoint t u ∧ t ∪ u ∈ 𝒜 := by
   induction' k with k ih generalizing t
   · simp
   set_option tactic.skipAssignedInstances false in
@@ -127,7 +126,7 @@ lemma mem_shadow_iterate_iff_exists_card :
 /-- `t ∈ ∂^k 𝒜` iff `t` is exactly `k` elements less than something from `𝒜`.
 
 See also `Finset.mem_shadow_iff_exists_mem_card_add`. -/
-lemma mem_shadow_iterate_iff_exists_sdiff : t ∈ ∂^[k] 𝒜 ↔ ∃ s ∈ 𝒜, t ⊆ s ∧ (s \ t).card = k := by
+lemma mem_shadow_iterate_iff_exists_sdiff : t ∈ ∂^[k] 𝒜 ↔ ∃ s ∈ 𝒜, t ⊆ s ∧ #(s \ t) = k := by
   rw [mem_shadow_iterate_iff_exists_card]
   constructor
   · rintro ⟨u, rfl, htu, hsuA⟩
@@ -140,7 +139,7 @@ lemma mem_shadow_iterate_iff_exists_sdiff : t ∈ ∂^[k] 𝒜 ↔ ∃ s ∈ �
 
 See also `Finset.mem_shadow_iterate_iff_exists_sdiff`. -/
 lemma mem_shadow_iterate_iff_exists_mem_card_add :
-    t ∈ ∂^[k] 𝒜 ↔ ∃ s ∈ 𝒜, t ⊆ s ∧ s.card = t.card + k := by
+    t ∈ ∂^[k] 𝒜 ↔ ∃ s ∈ 𝒜, t ⊆ s ∧ #s = #t + k := by
   refine mem_shadow_iterate_iff_exists_sdiff.trans <| exists_congr fun t ↦ and_congr_right fun _ ↦
     and_congr_right fun hst ↦ ?_
   rw [card_sdiff hst, tsub_eq_iff_eq_add_of_le, add_comm]
@@ -209,7 +208,7 @@ theorem insert_mem_upShadow (hs : s ∈ 𝒜) (ha : a ∉ s) : insert a s ∈ �
 /-- `t` is in the upper shadow of `𝒜` iff `t` is exactly one element more than something from `𝒜`.
 
 See also `Finset.mem_upShadow_iff_exists_mem_card_add_one`. -/
-lemma mem_upShadow_iff_exists_sdiff : t ∈ ∂⁺ 𝒜 ↔ ∃ s ∈ 𝒜, s ⊆ t ∧ (t \ s).card = 1 := by
+lemma mem_upShadow_iff_exists_sdiff : t ∈ ∂⁺ 𝒜 ↔ ∃ s ∈ 𝒜, s ⊆ t ∧ #(t \ s) = 1 := by
   simp_rw [mem_upShadow_iff, ← covBy_iff_card_sdiff_eq_one, covBy_iff_exists_insert]
 
 /-- `t` is in the upper shadow of `𝒜` iff we can remove an element from it so that the resulting
@@ -222,14 +221,14 @@ lemma mem_upShadow_iff_erase_mem : t ∈ ∂⁺ 𝒜 ↔ ∃ a, a ∈ t ∧ eras
 
 See also `Finset.mem_upShadow_iff_exists_sdiff`. -/
 lemma mem_upShadow_iff_exists_mem_card_add_one :
-    t ∈ ∂⁺ 𝒜 ↔ ∃ s ∈ 𝒜, s ⊆ t ∧ t.card = s.card + 1 := by
+    t ∈ ∂⁺ 𝒜 ↔ ∃ s ∈ 𝒜, s ⊆ t ∧ #t = #s + 1 := by
   refine mem_upShadow_iff_exists_sdiff.trans <| exists_congr fun t ↦ and_congr_right fun _ ↦
     and_congr_right fun hst ↦ ?_
   rw [card_sdiff hst, tsub_eq_iff_eq_add_of_le, add_comm]
   exact card_mono hst
 
 lemma mem_upShadow_iterate_iff_exists_card :
-    t ∈ ∂⁺^[k] 𝒜 ↔ ∃ u : Finset α, u.card = k ∧ u ⊆ t ∧ t \ u ∈ 𝒜 := by
+    t ∈ ∂⁺^[k] 𝒜 ↔ ∃ u : Finset α, #u = k ∧ u ⊆ t ∧ t \ u ∈ 𝒜 := by
   induction' k with k ih generalizing t
   · simp
   simp only [mem_upShadow_iff_erase_mem, ih, Function.iterate_succ_apply', card_eq_succ,
@@ -244,8 +243,7 @@ lemma mem_upShadow_iterate_iff_exists_card :
 /-- `t` is in the upper shadow of `𝒜` iff `t` is exactly `k` elements less than something from `𝒜`.
 
 See also `Finset.mem_upShadow_iff_exists_mem_card_add`. -/
-lemma mem_upShadow_iterate_iff_exists_sdiff :
-    t ∈ ∂⁺^[k] 𝒜 ↔ ∃ s ∈ 𝒜, s ⊆ t ∧ (t \ s).card = k := by
+lemma mem_upShadow_iterate_iff_exists_sdiff : t ∈ ∂⁺^[k] 𝒜 ↔ ∃ s ∈ 𝒜, s ⊆ t ∧ #(t \ s) = k := by
   rw [mem_upShadow_iterate_iff_exists_card]
   constructor
   · rintro ⟨u, rfl, hut, htu⟩
@@ -257,7 +255,7 @@ lemma mem_upShadow_iterate_iff_exists_sdiff :
 
 See also `Finset.mem_upShadow_iterate_iff_exists_sdiff`. -/
 lemma mem_upShadow_iterate_iff_exists_mem_card_add :
-    t ∈ ∂⁺^[k] 𝒜 ↔ ∃ s ∈ 𝒜, s ⊆ t ∧ t.card = s.card + k := by
+    t ∈ ∂⁺^[k] 𝒜 ↔ ∃ s ∈ 𝒜, s ⊆ t ∧ #t = #s + k := by
   refine mem_upShadow_iterate_iff_exists_sdiff.trans <| exists_congr fun t ↦ and_congr_right fun _ ↦
     and_congr_right fun hst ↦ ?_
   rw [card_sdiff hst, tsub_eq_iff_eq_add_of_le, add_comm]
@@ -277,7 +275,7 @@ theorem exists_subset_of_mem_upShadow (hs : s ∈ ∂⁺ 𝒜) : ∃ t ∈ 𝒜,
 
 /-- `t ∈ ∂^k 𝒜` iff `t` is exactly `k` elements more than something in `𝒜`. -/
 theorem mem_upShadow_iff_exists_mem_card_add :
-    s ∈ ∂⁺ ^[k] 𝒜 ↔ ∃ t ∈ 𝒜, t ⊆ s ∧ t.card + k = s.card := by
+    s ∈ ∂⁺ ^[k] 𝒜 ↔ ∃ t ∈ 𝒜, t ⊆ s ∧ #t + k = #s := by
   induction' k with k ih generalizing 𝒜 s
   · refine ⟨fun hs => ⟨s, hs, Subset.refl _, rfl⟩, ?_⟩
     rintro ⟨t, ht, hst, hcard⟩

--- a/Mathlib/Combinatorics/SetFamily/Shatter.lean
+++ b/Mathlib/Combinatorics/SetFamily/Shatter.lean
@@ -72,7 +72,8 @@ lemma univ_shatters [Fintype α] : univ.Shatters s :=
   rw [shatters_iff, powerset_univ]; simp_rw [univ_inter, image_id']
 
 /-- The set family of sets that are shattered by `𝒜`. -/
-def shatterer (𝒜 : Finset (Finset α)) : Finset (Finset α) := (𝒜.biUnion powerset).filter 𝒜.Shatters
+def shatterer (𝒜 : Finset (Finset α)) : Finset (Finset α) :=
+  {s ∈ 𝒜.biUnion powerset | 𝒜.Shatters s}
 
 @[simp] lemma mem_shatterer : s ∈ 𝒜.shatterer ↔ 𝒜.Shatters s := by
   refine mem_filter.trans <| and_iff_right_of_imp fun h ↦ ?_
@@ -106,15 +107,14 @@ private lemma aux (h : ∀ t ∈ 𝒜, a ∉ t) (ht : 𝒜.Shatters t) : a ∉ t
   obtain ⟨u, hu, htu⟩ := ht.exists_superset; exact not_mem_mono htu <| h u hu
 
 /-- Pajor's variant of the **Sauer-Shelah lemma**. -/
-lemma card_le_card_shatterer (𝒜 : Finset (Finset α)) : 𝒜.card ≤ 𝒜.shatterer.card := by
+lemma card_le_card_shatterer (𝒜 : Finset (Finset α)) : #𝒜 ≤ #𝒜.shatterer := by
   refine memberFamily_induction_on 𝒜 ?_ ?_ ?_
   · simp
   · rfl
   intros a 𝒜 ih₀ ih₁
   set ℬ : Finset (Finset α) :=
     ((memberSubfamily a 𝒜).shatterer ∩ (nonMemberSubfamily a 𝒜).shatterer).image (insert a)
-  have hℬ :
-      ℬ.card = ((memberSubfamily a 𝒜).shatterer ∩ (nonMemberSubfamily a 𝒜).shatterer).card := by
+  have hℬ : #ℬ = #((memberSubfamily a 𝒜).shatterer ∩ (nonMemberSubfamily a 𝒜).shatterer) := by
     refine card_image_of_injOn <| insert_erase_invOn.2.injOn.mono ?_
     simp only [coe_inter, Set.subset_def, Set.mem_inter_iff, mem_coe, Set.mem_setOf_eq, and_imp,
       mem_shatterer]
@@ -183,7 +183,7 @@ def vcDim (𝒜 : Finset (Finset α)) : ℕ := 𝒜.shatterer.sup card
 
 @[gcongr] lemma vcDim_mono (h𝒜ℬ : 𝒜 ⊆ ℬ) : 𝒜.vcDim ≤ ℬ.vcDim := by unfold vcDim; gcongr
 
-lemma Shatters.card_le_vcDim (hs : 𝒜.Shatters s) : s.card ≤ 𝒜.vcDim := le_sup <| mem_shatterer.2 hs
+lemma Shatters.card_le_vcDim (hs : 𝒜.Shatters s) : #s ≤ 𝒜.vcDim := le_sup <| mem_shatterer.2 hs
 
 /-- Down-compressing decreases the VC-dimension. -/
 lemma vcDim_compress_le (a : α) (𝒜 : Finset (Finset α)) : (𝓓 a 𝒜).vcDim ≤ 𝒜.vcDim :=
@@ -191,9 +191,9 @@ lemma vcDim_compress_le (a : α) (𝒜 : Finset (Finset α)) : (𝓓 a 𝒜).vcD
 
 /-- The **Sauer-Shelah lemma**. -/
 lemma card_shatterer_le_sum_vcDim [Fintype α] :
-    𝒜.shatterer.card ≤ ∑ k ∈ Iic 𝒜.vcDim, (Fintype.card α).choose k := by
+    #𝒜.shatterer ≤ ∑ k ∈ Iic 𝒜.vcDim, (Fintype.card α).choose k := by
   simp_rw [← card_univ, ← card_powersetCard]
-  refine (card_le_card fun s hs ↦ mem_biUnion.2 ⟨card s, ?_⟩).trans card_biUnion_le
+  refine (card_le_card fun s hs ↦ mem_biUnion.2 ⟨#s, ?_⟩).trans card_biUnion_le
   exact ⟨mem_Iic.2 (mem_shatterer.1 hs).card_le_vcDim, mem_powersetCard_univ.2 rfl⟩
 
 end Finset

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -709,7 +709,7 @@ theorem neighborSet_union_compl_neighborSet_eq (G : SimpleGraph V) (v : V) :
 
 theorem card_neighborSet_union_compl_neighborSet [Fintype V] (G : SimpleGraph V) (v : V)
     [Fintype (G.neighborSet v ∪ Gᶜ.neighborSet v : Set V)] :
-    (Set.toFinset (G.neighborSet v ∪ Gᶜ.neighborSet v)).card = Fintype.card V - 1 := by
+    #(G.neighborSet v ∪ Gᶜ.neighborSet v).toFinset = Fintype.card V - 1 := by
   classical simp_rw [neighborSet_union_compl_neighborSet_eq, Set.toFinset_compl,
       Finset.card_compl, Set.toFinset_card, Set.card_singleton]
 

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -140,8 +140,8 @@ theorem isClique_map_finset_iff_of_nontrivial (ht : t.Nontrivial) :
   simpa using hs.map (f := f)
 
 theorem isClique_map_finset_iff :
-    (G.map f).IsClique t ↔ t.card ≤ 1 ∨ ∃ (s : Finset α), G.IsClique s ∧ s.map f = t := by
-  obtain (ht | ht) := le_or_lt t.card 1
+    (G.map f).IsClique t ↔ #t ≤ 1 ∨ ∃ (s : Finset α), G.IsClique s ∧ s.map f = t := by
+  obtain (ht | ht) := le_or_lt #t 1
   · simp only [ht, true_or, iff_true]
     exact IsClique.of_subsingleton <| card_le_one.1 ht
   rw [isClique_map_finset_iff_of_nontrivial, ← not_lt]
@@ -164,9 +164,9 @@ variable {n : ℕ} {s : Finset α}
 /-- An `n`-clique in a graph is a set of `n` vertices which are pairwise connected. -/
 structure IsNClique (n : ℕ) (s : Finset α) : Prop where
   clique : G.IsClique s
-  card_eq : s.card = n
+  card_eq : #s = n
 
-theorem isNClique_iff : G.IsNClique n s ↔ G.IsClique s ∧ s.card = n :=
+theorem isNClique_iff : G.IsNClique n s ↔ G.IsClique s ∧ #s = n :=
   ⟨fun h ↦ ⟨h.1, h.2⟩, fun h ↦ ⟨h.1, h.2⟩⟩
 
 instance [DecidableEq α] [DecidableRel G.Adj] {n : ℕ} {s : Finset α} :
@@ -199,7 +199,7 @@ theorem isNClique_map_iff (hn : 1 < n) {t : Finset β} {f : α ↪ β} :
   simp [hs.card_eq, hs.clique]
 
 @[simp]
-theorem isNClique_bot_iff : (⊥ : SimpleGraph α).IsNClique n s ↔ n ≤ 1 ∧ s.card = n := by
+theorem isNClique_bot_iff : (⊥ : SimpleGraph α).IsNClique n s ↔ n ≤ 1 ∧ #s = n := by
   rw [isNClique_iff, isClique_bot_iff]
   refine and_congr_left ?_
   rintro rfl
@@ -286,7 +286,7 @@ noncomputable def topEmbeddingOfNotCliqueFree {n : ℕ} (h : ¬G.CliqueFree n) :
     (⊤ : SimpleGraph (Fin n)) ↪g G := by
   simp only [CliqueFree, isNClique_iff, isClique_iff_induce_eq, not_forall, Classical.not_not] at h
   obtain ⟨ha, hb⟩ := h.choose_spec
-  have : (⊤ : SimpleGraph (Fin h.choose.card)) ≃g (⊤ : SimpleGraph h.choose) := by
+  have : (⊤ : SimpleGraph (Fin #h.choose)) ≃g (⊤ : SimpleGraph h.choose) := by
     apply Iso.completeGraph
     simpa using (Fintype.equivFin h.choose).symm
   rw [← ha] at this
@@ -446,7 +446,7 @@ theorem cliqueFreeOn_univ : G.CliqueFreeOn Set.univ n ↔ G.CliqueFree n := by
 protected theorem CliqueFree.cliqueFreeOn (hG : G.CliqueFree n) : G.CliqueFreeOn s n :=
   fun _t _ ↦ hG _
 
-theorem cliqueFreeOn_of_card_lt {s : Finset α} (h : s.card < n) : G.CliqueFreeOn s n :=
+theorem cliqueFreeOn_of_card_lt {s : Finset α} (h : #s < n) : G.CliqueFreeOn s n :=
   fun _t hts ht => h.not_le <| ht.2.symm.trans_le <| card_mono hts
 
 -- TODO: Restate using `SimpleGraph.IndepSet` once we have it
@@ -548,8 +548,7 @@ section CliqueFinset
 variable [Fintype α] [DecidableEq α] [DecidableRel G.Adj] {n : ℕ} {a b c : α} {s : Finset α}
 
 /-- The `n`-cliques in a graph as a finset. -/
-def cliqueFinset (n : ℕ) : Finset (Finset α) :=
-  univ.filter <| G.IsNClique n
+def cliqueFinset (n : ℕ) : Finset (Finset α) := {s | G.IsNClique n s}
 
 variable {G} in
 @[simp]
@@ -568,7 +567,7 @@ theorem cliqueFinset_eq_empty_iff : G.cliqueFinset n = ∅ ↔ G.CliqueFree n :=
 
 protected alias ⟨_, CliqueFree.cliqueFinset⟩ := cliqueFinset_eq_empty_iff
 
-theorem card_cliqueFinset_le : (G.cliqueFinset n).card ≤ (card α).choose n := by
+theorem card_cliqueFinset_le : #(G.cliqueFinset n) ≤ (card α).choose n := by
   rw [← card_univ, ← card_powersetCard]
   refine card_mono fun s => ?_
   simpa [mem_powersetCard_univ] using IsNClique.card_eq

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkCounting.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkCounting.lean
@@ -21,7 +21,7 @@ can also be useful as a recursive description of this set when `V` is finite.
 TODO: should this be extended further?
 -/
 
-open Function
+open Finset Function
 
 universe u v w
 
@@ -152,7 +152,7 @@ theorem set_walk_length_toFinset_eq (n : ℕ) (u v : V) :
 /- See `SimpleGraph.adjMatrix_pow_apply_eq_card_walk` for the cardinality in terms of the `n`th
 power of the adjacency matrix. -/
 theorem card_set_walk_length_eq (u v : V) (n : ℕ) :
-    Fintype.card {p : G.Walk u v | p.length = n} = (G.finsetWalkLength n u v).card :=
+    Fintype.card {p : G.Walk u v | p.length = n} = #(G.finsetWalkLength n u v) :=
   Fintype.card_ofFinset (G.finsetWalkLength n u v) fun p => by
     rw [← Finset.mem_coe, coe_finsetWalkLength_eq]
 
@@ -165,7 +165,7 @@ instance fintypeSubtypeWalkLengthLT (u v : V) (n : ℕ) : Fintype {p : G.Walk u 
 
 instance fintypeSetPathLength (u v : V) (n : ℕ) :
     Fintype {p : G.Walk u v | p.IsPath ∧ p.length = n} :=
-  Fintype.ofFinset ((G.finsetWalkLength n u v).filter Walk.IsPath) <| by
+  Fintype.ofFinset {w ∈ G.finsetWalkLength n u v | w.IsPath} <| by
     simp [mem_finsetWalkLength_iff, and_comm]
 
 instance fintypeSubtypePathLength (u v : V) (n : ℕ) :
@@ -174,7 +174,7 @@ instance fintypeSubtypePathLength (u v : V) (n : ℕ) :
 
 instance fintypeSetPathLengthLT (u v : V) (n : ℕ) :
     Fintype {p : G.Walk u v | p.IsPath ∧ p.length < n} :=
-  Fintype.ofFinset ((G.finsetWalkLengthLT n u v).filter Walk.IsPath) <| by
+  Fintype.ofFinset {w ∈ G.finsetWalkLengthLT n u v | w.IsPath} <| by
     simp [mem_finsetWalkLengthLT_iff, and_comm]
 
 instance fintypeSubtypePathLengthLT (u v : V) (n : ℕ) :
@@ -210,7 +210,6 @@ instance : Decidable G.Connected := by
   rw [connected_iff, ← Finset.univ_nonempty_iff]
   infer_instance
 
-open Finset in
 instance Path.instFintype {u v : V} : Fintype (G.Path u v) where
   elems := (univ (α := { p : G.Walk u v | p.IsPath ∧ p.length < Fintype.card V })).map
     ⟨fun p ↦ { val := p.val, property := p.prop.left },

--- a/Mathlib/Combinatorics/SimpleGraph/Density.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Density.lean
@@ -41,12 +41,10 @@ variable [LinearOrderedField 𝕜] (r : α → β → Prop) [∀ a, DecidablePre
   {t t₁ t₂ : Finset β} {a : α} {b : β} {δ : 𝕜}
 
 /-- Finset of edges of a relation between two finsets of vertices. -/
-def interedges (s : Finset α) (t : Finset β) : Finset (α × β) :=
-  (s ×ˢ t).filter fun e ↦ r e.1 e.2
+def interedges (s : Finset α) (t : Finset β) : Finset (α × β) := {e ∈ s ×ˢ t | r e.1 e.2}
 
 /-- Edge density of a relation between two finsets of vertices. -/
-def edgeDensity (s : Finset α) (t : Finset β) : ℚ :=
-  (interedges r s t).card / (s.card * t.card)
+def edgeDensity (s : Finset α) (t : Finset β) : ℚ := #(interedges r s t) / (#s * #t)
 
 variable {r}
 
@@ -68,7 +66,7 @@ theorem interedges_mono (hs : s₂ ⊆ s₁) (ht : t₂ ⊆ t₁) : interedges r
 variable (r)
 
 theorem card_interedges_add_card_interedges_compl (s : Finset α) (t : Finset β) :
-    (interedges r s t).card + (interedges (fun x y ↦ ¬r x y) s t).card = s.card * t.card := by
+    #(interedges r s t) + #(interedges (fun x y ↦ ¬r x y) s t) = #s * #t := by
   classical
   rw [← card_product, interedges, interedges, ← card_union_of_disjoint, filter_union_filter_neg_eq]
   exact disjoint_filter.2 fun _ _ ↦ Classical.not_not.2
@@ -92,7 +90,7 @@ section DecidableEq
 variable [DecidableEq α] [DecidableEq β]
 
 lemma interedges_eq_biUnion :
-    interedges r s t = s.biUnion (fun x ↦ (t.filter (r x)).map ⟨(x, ·), Prod.mk.inj_left x⟩) := by
+    interedges r s t = s.biUnion fun x ↦ {y ∈ t | r x y}.map ⟨(x, ·), Prod.mk.inj_left x⟩ := by
   ext ⟨x, y⟩; simp [mem_interedges_iff]
 
 theorem interedges_biUnion_left (s : Finset ι) (t : Finset β) (f : ι → Finset α) :
@@ -115,7 +113,7 @@ theorem interedges_biUnion (s : Finset ι) (t : Finset κ) (f : ι → Finset α
 end DecidableEq
 
 theorem card_interedges_le_mul (s : Finset α) (t : Finset β) :
-    (interedges r s t).card ≤ s.card * t.card :=
+    #(interedges r s t) ≤ #s * #t :=
   (card_filter_le _ _).trans (card_product _ _).le
 
 theorem edgeDensity_nonneg (s : Finset α) (t : Finset β) : 0 ≤ edgeDensity r s t := by
@@ -141,14 +139,14 @@ theorem edgeDensity_empty_right (s : Finset α) : edgeDensity r s ∅ = 0 := by
   rw [edgeDensity, Finset.card_empty, Nat.cast_zero, mul_zero, div_zero]
 
 theorem card_interedges_finpartition_left [DecidableEq α] (P : Finpartition s) (t : Finset β) :
-    (interedges r s t).card = ∑ a ∈ P.parts, (interedges r a t).card := by
+    #(interedges r s t) = ∑ a ∈ P.parts, #(interedges r a t) := by
   classical
   simp_rw [← P.biUnion_parts, interedges_biUnion_left, id]
   rw [card_biUnion]
   exact fun x hx y hy h ↦ interedges_disjoint_left r (P.disjoint hx hy h) _
 
 theorem card_interedges_finpartition_right [DecidableEq β] (s : Finset α) (P : Finpartition t) :
-    (interedges r s t).card = ∑ b ∈ P.parts, (interedges r s b).card := by
+    #(interedges r s t) = ∑ b ∈ P.parts, #(interedges r s b) := by
   classical
   simp_rw [← P.biUnion_parts, interedges_biUnion_right, id]
   rw [card_biUnion]
@@ -156,22 +154,22 @@ theorem card_interedges_finpartition_right [DecidableEq β] (s : Finset α) (P :
 
 theorem card_interedges_finpartition [DecidableEq α] [DecidableEq β] (P : Finpartition s)
     (Q : Finpartition t) :
-    (interedges r s t).card = ∑ ab ∈ P.parts ×ˢ Q.parts, (interedges r ab.1 ab.2).card := by
+    #(interedges r s t) = ∑ ab ∈ P.parts ×ˢ Q.parts, #(interedges r ab.1 ab.2) := by
   rw [card_interedges_finpartition_left _ P, sum_product]
   congr; ext
   rw [card_interedges_finpartition_right]
 
 theorem mul_edgeDensity_le_edgeDensity (hs : s₂ ⊆ s₁) (ht : t₂ ⊆ t₁) (hs₂ : s₂.Nonempty)
     (ht₂ : t₂.Nonempty) :
-    (s₂.card : ℚ) / s₁.card * (t₂.card / t₁.card) * edgeDensity r s₂ t₂ ≤ edgeDensity r s₁ t₁ := by
-  have hst : (s₂.card : ℚ) * t₂.card ≠ 0 := by simp [hs₂.ne_empty, ht₂.ne_empty]
+    (#s₂ : ℚ) / #s₁ * (#t₂ / #t₁) * edgeDensity r s₂ t₂ ≤ edgeDensity r s₁ t₁ := by
+  have hst : (#s₂ : ℚ) * #t₂ ≠ 0 := by simp [hs₂.ne_empty, ht₂.ne_empty]
   rw [edgeDensity, edgeDensity, div_mul_div_comm, mul_comm, div_mul_div_cancel₀ hst]
   gcongr
   exact interedges_mono hs ht
 
 theorem edgeDensity_sub_edgeDensity_le_one_sub_mul (hs : s₂ ⊆ s₁) (ht : t₂ ⊆ t₁) (hs₂ : s₂.Nonempty)
     (ht₂ : t₂.Nonempty) :
-    edgeDensity r s₂ t₂ - edgeDensity r s₁ t₁ ≤ 1 - s₂.card / s₁.card * (t₂.card / t₁.card) := by
+    edgeDensity r s₂ t₂ - edgeDensity r s₁ t₁ ≤ 1 - #s₂ / #s₁ * (#t₂ / #t₁) := by
   refine (sub_le_sub_left (mul_edgeDensity_le_edgeDensity r hs ht hs₂ ht₂) _).trans ?_
   refine le_trans ?_ (mul_le_of_le_one_right ?_ (edgeDensity_le_one r s₂ t₂))
   · rw [sub_mul, one_mul]
@@ -182,7 +180,7 @@ theorem edgeDensity_sub_edgeDensity_le_one_sub_mul (hs : s₂ ⊆ s₁) (ht : t�
 
 theorem abs_edgeDensity_sub_edgeDensity_le_one_sub_mul (hs : s₂ ⊆ s₁) (ht : t₂ ⊆ t₁)
     (hs₂ : s₂.Nonempty) (ht₂ : t₂.Nonempty) :
-    |edgeDensity r s₂ t₂ - edgeDensity r s₁ t₁| ≤ 1 - s₂.card / s₁.card * (t₂.card / t₁.card) := by
+    |edgeDensity r s₂ t₂ - edgeDensity r s₁ t₁| ≤ 1 - #s₂ / #s₁ * (#t₂ / #t₁) := by
   refine abs_sub_le_iff.2 ⟨edgeDensity_sub_edgeDensity_le_one_sub_mul r hs ht hs₂ ht₂, ?_⟩
   rw [← add_sub_cancel_right (edgeDensity r s₁ t₁) (edgeDensity (fun x y ↦ ¬r x y) s₁ t₁),
     ← add_sub_cancel_right (edgeDensity r s₂ t₂) (edgeDensity (fun x y ↦ ¬r x y) s₂ t₂),
@@ -191,8 +189,8 @@ theorem abs_edgeDensity_sub_edgeDensity_le_one_sub_mul (hs : s₂ ⊆ s₁) (ht 
   exact edgeDensity_sub_edgeDensity_le_one_sub_mul _ hs ht hs₂ ht₂
 
 theorem abs_edgeDensity_sub_edgeDensity_le_two_mul_sub_sq (hs : s₂ ⊆ s₁) (ht : t₂ ⊆ t₁)
-    (hδ₀ : 0 ≤ δ) (hδ₁ : δ < 1) (hs₂ : (1 - δ) * s₁.card ≤ s₂.card)
-    (ht₂ : (1 - δ) * t₁.card ≤ t₂.card) :
+    (hδ₀ : 0 ≤ δ) (hδ₁ : δ < 1) (hs₂ : (1 - δ) * #s₁ ≤ #s₂)
+    (ht₂ : (1 - δ) * #t₁ ≤ #t₂) :
     |(edgeDensity r s₂ t₂ : 𝕜) - edgeDensity r s₁ t₁| ≤ 2 * δ - δ ^ 2 := by
   have hδ' : 0 ≤ 2 * δ - δ ^ 2 := by
     rw [sub_nonneg, sq]
@@ -222,7 +220,7 @@ theorem abs_edgeDensity_sub_edgeDensity_le_two_mul_sub_sq (hs : s₂ ⊆ s₁) (
 /-- If `s₂ ⊆ s₁`, `t₂ ⊆ t₁` and they take up all but a `δ`-proportion, then the difference in edge
 densities is at most `2 * δ`. -/
 theorem abs_edgeDensity_sub_edgeDensity_le_two_mul (hs : s₂ ⊆ s₁) (ht : t₂ ⊆ t₁) (hδ : 0 ≤ δ)
-    (hscard : (1 - δ) * s₁.card ≤ s₂.card) (htcard : (1 - δ) * t₁.card ≤ t₂.card) :
+    (hscard : (1 - δ) * #s₁ ≤ #s₂) (htcard : (1 - δ) * #t₁ ≤ #t₂) :
     |(edgeDensity r s₂ t₂ : 𝕜) - edgeDensity r s₁ t₁| ≤ 2 * δ := by
   cases' lt_or_le δ 1 with h h
   · exact (abs_edgeDensity_sub_edgeDensity_le_two_mul_sub_sq r hs ht hδ h hscard htcard).trans
@@ -250,7 +248,7 @@ theorem mk_mem_interedges_comm (hr : Symmetric r) :
   @swap_mem_interedges_iff _ _ _ _ _ hr (b, a)
 
 theorem card_interedges_comm (hr : Symmetric r) (s t : Finset α) :
-    (interedges r s t).card = (interedges r t s).card :=
+    #(interedges r s t) = #(interedges r t s) :=
   Finset.card_bij (fun (x : α × α) _ ↦ x.swap) (fun _ ↦ (swap_mem_interedges_iff hr).2)
     (fun _ _ _ _ h ↦ Prod.swap_injective h) fun x h ↦
     ⟨x.swap, (swap_mem_interedges_iff hr).2 h, x.swap_swap⟩
@@ -280,16 +278,12 @@ def interedges (s t : Finset α) : Finset (α × α) :=
 def edgeDensity : Finset α → Finset α → ℚ :=
   Rel.edgeDensity G.Adj
 
-theorem interedges_def (s t : Finset α) :
-    G.interedges s t = (s ×ˢ t).filter fun e ↦ G.Adj e.1 e.2 :=
-  rfl
+lemma interedges_def (s t : Finset α) : G.interedges s t = {e ∈ s ×ˢ t | G.Adj e.1 e.2} := rfl
 
-theorem edgeDensity_def (s t : Finset α) :
-    G.edgeDensity s t = (G.interedges s t).card / (s.card * t.card) :=
-  rfl
+lemma edgeDensity_def (s t : Finset α) : G.edgeDensity s t = #(G.interedges s t) / (#s * #t) := rfl
 
 theorem card_interedges_div_card (s t : Finset α) :
-    ((G.interedges s t).card : ℚ) / (s.card * t.card) = G.edgeDensity s t :=
+    (#(G.interedges s t) : ℚ) / (#s * #t) = G.edgeDensity s t :=
   rfl
 
 theorem mem_interedges_iff {x : α × α} : x ∈ G.interedges s t ↔ x.1 ∈ s ∧ x.2 ∈ t ∧ G.Adj x.1 x.2 :=
@@ -331,9 +325,9 @@ theorem interedges_biUnion (s : Finset ι) (t : Finset κ) (f : ι → Finset α
   Rel.interedges_biUnion _ _ _ _ _
 
 theorem card_interedges_add_card_interedges_compl (h : Disjoint s t) :
-    (G.interedges s t).card + (Gᶜ.interedges s t).card = s.card * t.card := by
+    #(G.interedges s t) + #(Gᶜ.interedges s t) = #s * #t := by
   rw [← card_product, interedges_def, interedges_def]
-  have : ((s ×ˢ t).filter fun e ↦ Gᶜ.Adj e.1 e.2) = (s ×ˢ t).filter fun e ↦ ¬G.Adj e.1 e.2 := by
+  have : {e ∈ s ×ˢ t | Gᶜ.Adj e.1 e.2} = {e ∈ s ×ˢ t | ¬G.Adj e.1 e.2} := by
     refine filter_congr fun x hx ↦ ?_
     rw [mem_product] at hx
     rw [compl_adj, and_iff_right (h.forall_ne_finset hx.1 hx.2)]
@@ -349,7 +343,7 @@ theorem edgeDensity_add_edgeDensity_compl (hs : s.Nonempty) (ht : t.Nonempty) (h
 
 end DecidableEq
 
-theorem card_interedges_le_mul (s t : Finset α) : (G.interedges s t).card ≤ s.card * t.card :=
+theorem card_interedges_le_mul (s t : Finset α) : #(G.interedges s t) ≤ #s * #t :=
   Rel.card_interedges_le_mul _ _ _
 
 theorem edgeDensity_nonneg (s t : Finset α) : 0 ≤ G.edgeDensity s t :=

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -101,27 +101,26 @@ lemma edgeFinset_eq_empty : G.edgeFinset = ∅ ↔ G = ⊥ := by
 lemma edgeFinset_nonempty : G.edgeFinset.Nonempty ↔ G ≠ ⊥ := by
   rw [Finset.nonempty_iff_ne_empty, edgeFinset_eq_empty.ne]
 
-theorem edgeFinset_card : G.edgeFinset.card = Fintype.card G.edgeSet :=
+theorem edgeFinset_card : #G.edgeFinset = Fintype.card G.edgeSet :=
   Set.toFinset_card _
 
 @[simp]
-theorem edgeSet_univ_card : (univ : Finset G.edgeSet).card = G.edgeFinset.card :=
+theorem edgeSet_univ_card : #(univ : Finset G.edgeSet) = #G.edgeFinset :=
   Fintype.card_of_subtype G.edgeFinset fun _ => mem_edgeFinset
 
 variable [Fintype V]
 
 @[simp]
 theorem edgeFinset_top [DecidableEq V] :
-    (⊤ : SimpleGraph V).edgeFinset = univ.filter fun e => ¬e.IsDiag := by
-  rw [← coe_inj]; simp
+    (⊤ : SimpleGraph V).edgeFinset = ({e | ¬e.IsDiag} : Finset _) := by simp [← coe_inj]
 
 /-- The complete graph on `n` vertices has `n.choose 2` edges. -/
 theorem card_edgeFinset_top_eq_card_choose_two [DecidableEq V] :
-    (⊤ : SimpleGraph V).edgeFinset.card = (Fintype.card V).choose 2 := by
+    #(⊤ : SimpleGraph V).edgeFinset = (Fintype.card V).choose 2 := by
   simp_rw [Set.toFinset_card, edgeSet_top, Set.coe_setOf, ← Sym2.card_subtype_not_diag]
 
 /-- Any graph on `n` vertices has at most `n.choose 2` edges. -/
-theorem card_edgeFinset_le_card_choose_two : G.edgeFinset.card ≤ (Fintype.card V).choose 2 := by
+theorem card_edgeFinset_le_card_choose_two : #G.edgeFinset ≤ (Fintype.card V).choose 2 := by
   classical
   rw [← card_edgeFinset_top_eq_card_choose_two]
   exact card_le_card (edgeFinset_mono le_top)
@@ -143,13 +142,13 @@ variable {𝕜 : Type*} [OrderedRing 𝕜]
 /-- A graph is `r`-*delete-far* from a property `p` if we must delete at least `r` edges from it to
 get a graph with the property `p`. -/
 def DeleteFar (p : SimpleGraph V → Prop) (r : 𝕜) : Prop :=
-  ∀ ⦃s⦄, s ⊆ G.edgeFinset → p (G.deleteEdges s) → r ≤ s.card
+  ∀ ⦃s⦄, s ⊆ G.edgeFinset → p (G.deleteEdges s) → r ≤ #s
 
 variable {G}
 
 theorem deleteFar_iff [Fintype (Sym2 V)] :
     G.DeleteFar p r ↔ ∀ ⦃H : SimpleGraph _⦄ [DecidableRel H.Adj],
-      H ≤ G → p H → r ≤ G.edgeFinset.card - H.edgeFinset.card := by
+      H ≤ G → p H → r ≤ #G.edgeFinset - #H.edgeFinset := by
   classical
   refine ⟨fun h H _ hHG hH ↦ ?_, fun h s hs hG ↦ ?_⟩
   · have := h (sdiff_subset (t := H.edgeFinset))
@@ -203,15 +202,14 @@ theorem singleton_disjoint_neighborFinset : Disjoint {v} (G.neighborFinset v) :=
   Finset.disjoint_singleton_left.mpr <| not_mem_neighborFinset_self _ _
 
 /-- `G.degree v` is the number of vertices adjacent to `v`. -/
-def degree : ℕ :=
-  (G.neighborFinset v).card
+def degree : ℕ := #(G.neighborFinset v)
 
 -- Porting note: in Lean 3 we could do `simp [← degree]`, but that gives
 -- "invalid '←' modifier, 'SimpleGraph.degree' is a declaration name to be unfolded".
 -- In any case, having this lemma is good since there's no guarantee we won't still change
 -- the definition of `degree`.
 @[simp]
-theorem card_neighborFinset_eq_degree : (G.neighborFinset v).card = G.degree v := rfl
+theorem card_neighborFinset_eq_degree : #(G.neighborFinset v) = G.degree v := rfl
 
 @[simp]
 theorem card_neighborSet_eq_degree : Fintype.card (G.neighborSet v) = G.degree v :=
@@ -240,8 +238,7 @@ theorem card_incidenceSet_eq_degree [DecidableEq V] :
   simp
 
 @[simp]
-theorem card_incidenceFinset_eq_degree [DecidableEq V] :
-    (G.incidenceFinset v).card = G.degree v := by
+theorem card_incidenceFinset_eq_degree [DecidableEq V] : #(G.incidenceFinset v) = G.degree v := by
   rw [← G.card_incidenceSet_eq_degree]
   apply Set.toFinset_card
 
@@ -251,7 +248,7 @@ theorem mem_incidenceFinset [DecidableEq V] (e : Sym2 V) :
   Set.mem_toFinset
 
 theorem incidenceFinset_eq_filter [DecidableEq V] [Fintype G.edgeSet] :
-    G.incidenceFinset v = G.edgeFinset.filter (v ∈ ·) := by
+    G.incidenceFinset v = {e ∈ G.edgeFinset | v ∈ e} := by
   ext e
   induction e
   simp [mk'_mem_incidenceSet_iff]
@@ -294,9 +291,7 @@ instance neighborSetFintype [DecidableRel G.Adj] (v : V) : Fintype (G.neighborSe
     _
 
 theorem neighborFinset_eq_filter {v : V} [DecidableRel G.Adj] :
-    G.neighborFinset v = Finset.univ.filter (G.Adj v) := by
-  ext
-  simp
+    G.neighborFinset v = ({w | G.Adj v w} : Finset _) := by ext; simp
 
 theorem neighborFinset_compl [DecidableEq V] [DecidableRel G.Adj] (v : V) :
     Gᶜ.neighborFinset v = (G.neighborFinset v)ᶜ \ {v} := by

--- a/Mathlib/Combinatorics/SimpleGraph/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Operations.lean
@@ -34,7 +34,7 @@ variable {G} {W : Type*} {G' : SimpleGraph W} (f : G ≃g G')
 
 include f in
 theorem card_edgeFinset_eq [Fintype G.edgeSet] [Fintype G'.edgeSet] :
-    G.edgeFinset.card = G'.edgeFinset.card := by
+    #G.edgeFinset = #G'.edgeFinset := by
   apply Finset.card_eq_of_equiv
   simp only [Set.mem_toFinset]
   exact f.mapEdgeSet
@@ -116,7 +116,7 @@ lemma disjoint_sdiff_neighborFinset_image :
   aesop
 
 theorem card_edgeFinset_replaceVertex_of_not_adj (hn : ¬G.Adj s t) :
-    (G.replaceVertex s t).edgeFinset.card = G.edgeFinset.card + G.degree s - G.degree t := by
+    #(G.replaceVertex s t).edgeFinset = #G.edgeFinset + G.degree s - G.degree t := by
   have inc : G.incidenceFinset t ⊆ G.edgeFinset := by simp [incidenceFinset, incidenceSet_subset]
   rw [G.edgeFinset_replaceVertex_of_not_adj hn,
     card_union_of_disjoint G.disjoint_sdiff_neighborFinset_image, card_sdiff inc,
@@ -127,7 +127,7 @@ theorem card_edgeFinset_replaceVertex_of_not_adj (hn : ¬G.Adj s t) :
   aesop
 
 theorem card_edgeFinset_replaceVertex_of_adj (ha : G.Adj s t) :
-    (G.replaceVertex s t).edgeFinset.card = G.edgeFinset.card + G.degree s - G.degree t - 1 := by
+    #(G.replaceVertex s t).edgeFinset = #G.edgeFinset + G.degree s - G.degree t - 1 := by
   have inc : G.incidenceFinset t ⊆ G.edgeFinset := by simp [incidenceFinset, incidenceSet_subset]
   rw [G.edgeFinset_replaceVertex_of_adj ha, card_sdiff (by simp [ha]),
     card_union_of_disjoint G.disjoint_sdiff_neighborFinset_image, card_sdiff inc,
@@ -180,7 +180,7 @@ theorem edgeFinset_sup_edge [Fintype (edgeSet (G ⊔ edge s t))] (hn : ¬G.Adj s
   simp_rw [edgeFinset, edge_edgeSet_of_ne h]; rfl
 
 theorem card_edgeFinset_sup_edge [Fintype (edgeSet (G ⊔ edge s t))] (hn : ¬G.Adj s t) (h : s ≠ t) :
-    (G ⊔ edge s t).edgeFinset.card = G.edgeFinset.card + 1 := by
+    #(G ⊔ edge s t).edgeFinset = #G.edgeFinset + 1 := by
   rw [G.edgeFinset_sup_edge hn h, card_cons]
 
 end AddEdge

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Bound.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Bound.lean
@@ -58,9 +58,9 @@ open SzemerediRegularity
 variable {α : Type*} [DecidableEq α] [Fintype α] {P : Finpartition (univ : Finset α)}
   {u : Finset α} {ε : ℝ}
 
-local notation3 "m" => (card α / stepBound P.parts.card : ℕ)
+local notation3 "m" => (card α / stepBound #P.parts : ℕ)
 
-local notation3 "a" => (card α / P.parts.card - m * 4 ^ P.parts.card : ℕ)
+local notation3 "a" => (card α / #P.parts - m * 4 ^ #P.parts : ℕ)
 
 namespace SzemerediRegularity.Positivity
 
@@ -68,7 +68,7 @@ private theorem eps_pos {ε : ℝ} {n : ℕ} (h : 100 ≤ (4 : ℝ) ^ n * ε ^ 5
   (Odd.pow_pos_iff (by decide)).mp
     (pos_of_mul_pos_right ((show 0 < (100 : ℝ) by norm_num).trans_le h) (by positivity))
 
-private theorem m_pos [Nonempty α] (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) : 0 < m :=
+private theorem m_pos [Nonempty α] (hPα : #P.parts * 16 ^ #P.parts ≤ card α) : 0 < m :=
   Nat.div_pos ((Nat.mul_le_mul_left _ <| Nat.pow_le_pow_left (by norm_num) _).trans hPα) <|
     stepBound_pos (P.parts_nonempty <| univ_nonempty.ne_empty).card_pos
 
@@ -101,49 +101,48 @@ namespace SzemerediRegularity
 
 open scoped SzemerediRegularity.Positivity
 
-theorem m_pos [Nonempty α] (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) : 0 < m := by
+theorem m_pos [Nonempty α] (hPα : #P.parts * 16 ^ #P.parts ≤ card α) : 0 < m := by
   sz_positivity
 
 theorem coe_m_add_one_pos : 0 < (m : ℝ) + 1 := by positivity
 
-theorem one_le_m_coe [Nonempty α] (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) : (1 : ℝ) ≤ m :=
+theorem one_le_m_coe [Nonempty α] (hPα : #P.parts * 16 ^ #P.parts ≤ card α) : (1 : ℝ) ≤ m :=
   Nat.one_le_cast.2 <| m_pos hPα
 
-theorem eps_pow_five_pos (hPε : 100 ≤ (4 : ℝ) ^ P.parts.card * ε ^ 5) : ↑0 < ε ^ 5 :=
+theorem eps_pow_five_pos (hPε : 100 ≤ (4 : ℝ) ^ #P.parts * ε ^ 5) : ↑0 < ε ^ 5 :=
   pos_of_mul_pos_right ((by norm_num : (0 : ℝ) < 100).trans_le hPε) <| pow_nonneg (by norm_num) _
 
-theorem eps_pos (hPε : 100 ≤ (4 : ℝ) ^ P.parts.card * ε ^ 5) : 0 < ε :=
+theorem eps_pos (hPε : 100 ≤ (4 : ℝ) ^ #P.parts * ε ^ 5) : 0 < ε :=
   (Odd.pow_pos_iff (by decide)).mp (eps_pow_five_pos hPε)
 
-theorem hundred_div_ε_pow_five_le_m [Nonempty α] (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α)
-    (hPε : 100 ≤ (4 : ℝ) ^ P.parts.card * ε ^ 5) : 100 / ε ^ 5 ≤ m :=
+theorem hundred_div_ε_pow_five_le_m [Nonempty α] (hPα : #P.parts * 16 ^ #P.parts ≤ card α)
+    (hPε : 100 ≤ (4 : ℝ) ^ #P.parts * ε ^ 5) : 100 / ε ^ 5 ≤ m :=
   (div_le_of_le_mul₀ (eps_pow_five_pos hPε).le (by positivity) hPε).trans <| by
     norm_cast
     rwa [Nat.le_div_iff_mul_le' (stepBound_pos (P.parts_nonempty <|
       univ_nonempty.ne_empty).card_pos), stepBound, mul_left_comm, ← mul_pow]
 
-theorem hundred_le_m [Nonempty α] (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α)
-    (hPε : 100 ≤ (4 : ℝ) ^ P.parts.card * ε ^ 5) (hε : ε ≤ 1) : 100 ≤ m :=
+theorem hundred_le_m [Nonempty α] (hPα : #P.parts * 16 ^ #P.parts ≤ card α)
+    (hPε : 100 ≤ (4 : ℝ) ^ #P.parts * ε ^ 5) (hε : ε ≤ 1) : 100 ≤ m :=
   mod_cast
     (hundred_div_ε_pow_five_le_m hPα hPε).trans'
       (le_div_self (by norm_num) (by sz_positivity) <| pow_le_one₀ (by sz_positivity) hε)
 
-theorem a_add_one_le_four_pow_parts_card : a + 1 ≤ 4 ^ P.parts.card := by
-  have h : 1 ≤ 4 ^ P.parts.card := one_le_pow₀ (by norm_num)
+theorem a_add_one_le_four_pow_parts_card : a + 1 ≤ 4 ^ #P.parts := by
+  have h : 1 ≤ 4 ^ #P.parts := one_le_pow₀ (by norm_num)
   rw [stepBound, ← Nat.div_div_eq_div_mul]
   conv_rhs => rw [← Nat.sub_add_cancel h]
   rw [add_le_add_iff_right, tsub_le_iff_left, ← Nat.add_sub_assoc h]
   exact Nat.le_sub_one_of_lt (Nat.lt_div_mul_add h)
 
-theorem card_aux₁ (hucard : u.card = m * 4 ^ P.parts.card + a) :
-    (4 ^ P.parts.card - a) * m + a * (m + 1) = u.card := by
+theorem card_aux₁ (hucard : #u = m * 4 ^ #P.parts + a) :
+    (4 ^ #P.parts - a) * m + a * (m + 1) = #u := by
   rw [hucard, mul_add, mul_one, ← add_assoc, ← add_mul,
     Nat.sub_add_cancel ((Nat.le_succ _).trans a_add_one_le_four_pow_parts_card), mul_comm]
 
-theorem card_aux₂ (hP : P.IsEquipartition) (hu : u ∈ P.parts)
-    (hucard : ¬u.card = m * 4 ^ P.parts.card + a) :
-    (4 ^ P.parts.card - (a + 1)) * m + (a + 1) * (m + 1) = u.card := by
-  have : m * 4 ^ P.parts.card ≤ card α / P.parts.card := by
+theorem card_aux₂ (hP : P.IsEquipartition) (hu : u ∈ P.parts) (hucard : #u ≠ m * 4 ^ #P.parts + a) :
+    (4 ^ #P.parts - (a + 1)) * m + (a + 1) * (m + 1) = #u := by
+  have : m * 4 ^ #P.parts ≤ card α / #P.parts := by
     rw [stepBound, ← Nat.div_div_eq_div_mul]
     exact Nat.div_mul_le_self _ _
   rw [Nat.add_sub_of_le this] at hucard
@@ -152,7 +151,7 @@ theorem card_aux₂ (hP : P.IsEquipartition) (hu : u ∈ P.parts)
     Nat.add_sub_of_le this, card_univ]
 
 theorem pow_mul_m_le_card_part (hP : P.IsEquipartition) (hu : u ∈ P.parts) :
-    (4 : ℝ) ^ P.parts.card * m ≤ u.card := by
+    (4 : ℝ) ^ #P.parts * m ≤ #u := by
   norm_cast
   rw [stepBound, ← Nat.div_div_eq_div_mul]
   exact (Nat.mul_div_le _ _).trans (hP.average_le_card_part hu)
@@ -200,35 +199,34 @@ theorem bound_pos : 0 < bound ε l :=
 variable {ι 𝕜 : Type*} [LinearOrderedField 𝕜] (r : ι → ι → Prop) [DecidableRel r] {s t : Finset ι}
   {x : 𝕜}
 
-theorem mul_sq_le_sum_sq (hst : s ⊆ t) (f : ι → 𝕜) (hs : x ^ 2 ≤ ((∑ i ∈ s, f i) / s.card) ^ 2)
-    (hs' : (s.card : 𝕜) ≠ 0) : (s.card : 𝕜) * x ^ 2 ≤ ∑ i ∈ t, f i ^ 2 :=
+theorem mul_sq_le_sum_sq (hst : s ⊆ t) (f : ι → 𝕜) (hs : x ^ 2 ≤ ((∑ i ∈ s, f i) / #s) ^ 2)
+    (hs' : (#s : 𝕜) ≠ 0) : (#s : 𝕜) * x ^ 2 ≤ ∑ i ∈ t, f i ^ 2 :=
   (mul_le_mul_of_nonneg_left (hs.trans sum_div_card_sq_le_sum_sq_div_card) <|
     Nat.cast_nonneg _).trans <| (mul_div_cancel₀ _ hs').le.trans <|
       sum_le_sum_of_subset_of_nonneg hst fun _ _ _ => sq_nonneg _
 
 theorem add_div_le_sum_sq_div_card (hst : s ⊆ t) (f : ι → 𝕜) (d : 𝕜) (hx : 0 ≤ x)
-    (hs : x ≤ |(∑ i ∈ s, f i) / s.card - (∑ i ∈ t, f i) / t.card|)
-    (ht : d ≤ ((∑ i ∈ t, f i) / t.card) ^ 2) :
-    d + s.card / t.card * x ^ 2 ≤ (∑ i ∈ t, f i ^ 2) / t.card := by
-  obtain hscard | hscard := (s.card.cast_nonneg : (0 : 𝕜) ≤ s.card).eq_or_lt
+    (hs : x ≤ |(∑ i ∈ s, f i) / #s - (∑ i ∈ t, f i) / #t|) (ht : d ≤ ((∑ i ∈ t, f i) / #t) ^ 2) :
+    d + #s / #t * x ^ 2 ≤ (∑ i ∈ t, f i ^ 2) / #t := by
+  obtain hscard | hscard := ((#s).cast_nonneg : (0 : 𝕜) ≤ #s).eq_or_lt
   · simpa [← hscard] using ht.trans sum_div_card_sq_le_sum_sq_div_card
-  have htcard : (0 : 𝕜) < t.card := hscard.trans_le (Nat.cast_le.2 (card_le_card hst))
-  have h₁ : x ^ 2 ≤ ((∑ i ∈ s, f i) / s.card - (∑ i ∈ t, f i) / t.card) ^ 2 :=
+  have htcard : (0 : 𝕜) < #t := hscard.trans_le (Nat.cast_le.2 (card_le_card hst))
+  have h₁ : x ^ 2 ≤ ((∑ i ∈ s, f i) / #s - (∑ i ∈ t, f i) / #t) ^ 2 :=
     sq_le_sq.2 (by rwa [abs_of_nonneg hx])
-  have h₂ : x ^ 2 ≤ ((∑ i ∈ s, (f i - (∑ j ∈ t, f j) / t.card)) / s.card) ^ 2 := by
+  have h₂ : x ^ 2 ≤ ((∑ i ∈ s, (f i - (∑ j ∈ t, f j) / #t)) / #s) ^ 2 := by
     apply h₁.trans
     rw [sum_sub_distrib, sum_const, nsmul_eq_mul, sub_div, mul_div_cancel_left₀ _ hscard.ne']
   apply (add_le_add_right ht _).trans
   rw [← mul_div_right_comm, le_div_iff₀ htcard, add_mul, div_mul_cancel₀ _ htcard.ne']
-  have h₃ := mul_sq_le_sum_sq hst (fun i => (f i - (∑ j ∈ t, f j) / t.card)) h₂ hscard.ne'
+  have h₃ := mul_sq_le_sum_sq hst (fun i => (f i - (∑ j ∈ t, f j) / #t)) h₂ hscard.ne'
   apply (add_le_add_left h₃ _).trans
   -- Porting note: was
-  -- `simp [← mul_div_right_comm _ (t.card : 𝕜), sub_div' _ _ _ htcard.ne', ← sum_div, ← add_div,`
+  -- `simp [← mul_div_right_comm _ (#t : 𝕜), sub_div' _ _ _ htcard.ne', ← sum_div, ← add_div,`
   -- `  mul_pow, div_le_iff₀ (sq_pos_of_ne_zero htcard.ne'), sub_sq, sum_add_distrib, ← sum_mul,`
   -- `  ← mul_sum]`
   simp_rw [sub_div' _ _ _ htcard.ne']
   conv_lhs => enter [2, 2, x]; rw [div_pow]
-  rw [div_pow, ← sum_div, ← mul_div_right_comm _ (t.card : 𝕜), ← add_div,
+  rw [div_pow, ← sum_div, ← mul_div_right_comm _ (#t : 𝕜), ← add_div,
     div_le_iff₀ (sq_pos_of_ne_zero htcard.ne')]
   simp_rw [sub_sq, sum_add_distrib, sum_const, nsmul_eq_mul, sum_sub_distrib, mul_pow, ← sum_mul,
     ← mul_sum, ← sum_mul]

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
@@ -44,7 +44,7 @@ variable {α : Type*} [Fintype α] [DecidableEq α] {P : Finpartition (univ : Fi
   (hP : P.IsEquipartition) (G : SimpleGraph α) [DecidableRel G.Adj] (ε : ℝ) {U : Finset α}
   (hU : U ∈ P.parts) (V : Finset α)
 
-local notation3 "m" => (card α / stepBound P.parts.card : ℕ)
+local notation3 "m" => (card α / stepBound #P.parts : ℕ)
 
 /-!
 ### Definitions
@@ -56,16 +56,16 @@ contained in the corresponding witness of non-uniformity.
 
 /-- The portion of `SzemerediRegularity.increment` which partitions `U`. -/
 noncomputable def chunk : Finpartition U :=
-  if hUcard : U.card = m * 4 ^ P.parts.card + (card α / P.parts.card - m * 4 ^ P.parts.card) then
+  if hUcard : #U = m * 4 ^ #P.parts + (card α / #P.parts - m * 4 ^ #P.parts) then
     (atomise U <| P.nonuniformWitnesses G ε U).equitabilise <| card_aux₁ hUcard
   else (atomise U <| P.nonuniformWitnesses G ε U).equitabilise <| card_aux₂ hP hU hUcard
 
 -- `hP` and `hU` are used to get that `U` has size
--- `m * 4 ^ P.parts.card + a or m * 4 ^ P.parts.card + a + 1`
+-- `m * 4 ^ #P.parts + a or m * 4 ^ #P.parts + a + 1`
 /-- The portion of `SzemerediRegularity.chunk` which is contained in the witness of non-uniformity
 of `U` and `V`. -/
 noncomputable def star (V : Finset α) : Finset (Finset α) :=
-  (chunk hP G ε hU).parts.filter (· ⊆ G.nonuniformWitness ε U V)
+  {A ∈ (chunk hP G ε hU).parts | A ⊆ G.nonuniformWitness ε U V}
 
 /-!
 ### Density estimates
@@ -85,14 +85,13 @@ theorem star_subset_chunk : star hP G ε hU V ⊆ (chunk hP G ε hU).parts :=
 
 private theorem card_nonuniformWitness_sdiff_biUnion_star (hV : V ∈ P.parts) (hUV : U ≠ V)
     (h₂ : ¬G.IsUniform ε U V) :
-    (G.nonuniformWitness ε U V \ (star hP G ε hU V).biUnion id).card ≤
-    2 ^ (P.parts.card - 1) * m := by
+    #(G.nonuniformWitness ε U V \ (star hP G ε hU V).biUnion id) ≤ 2 ^ (#P.parts - 1) * m := by
   have hX : G.nonuniformWitness ε U V ∈ P.nonuniformWitnesses G ε U :=
     nonuniformWitness_mem_nonuniformWitnesses h₂ hV hUV
   have q : G.nonuniformWitness ε U V \ (star hP G ε hU V).biUnion id ⊆
-      ((atomise U <| P.nonuniformWitnesses G ε U).parts.filter fun B =>
-        B ⊆ G.nonuniformWitness ε U V ∧ B.Nonempty).biUnion
-        fun B => B \ ((chunk hP G ε hU).parts.filter (· ⊆ B)).biUnion id := by
+      {B ∈ (atomise U <| P.nonuniformWitnesses G ε U).parts |
+        B ⊆ G.nonuniformWitness ε U V ∧ B.Nonempty}.biUnion
+        fun B => B \ {A ∈ (chunk hP G ε hU).parts | A ⊆ B}.biUnion id := by
     intro x hx
     rw [← biUnion_filter_atomise hX (G.nonuniformWitness_subset h₂), star, mem_sdiff,
       mem_biUnion] at hx
@@ -101,10 +100,10 @@ private theorem card_nonuniformWitness_sdiff_biUnion_star (hV : V ∈ P.parts) (
     obtain ⟨⟨B, hB₁, hB₂⟩, hx⟩ := hx
     exact ⟨B, hB₁, hB₂, fun A hA AB => hx A hA <| AB.trans hB₁.2.1⟩
   apply (card_le_card q).trans (card_biUnion_le.trans _)
-  trans ∑ _i in (atomise U <| P.nonuniformWitnesses G ε U).parts.filter fun B =>
+  trans ∑ B ∈ (atomise U <| P.nonuniformWitnesses G ε U).parts with
     B ⊆ G.nonuniformWitness ε U V ∧ B.Nonempty, m
   · suffices ∀ B ∈ (atomise U <| P.nonuniformWitnesses G ε U).parts,
-        (B \ ((chunk hP G ε hU).parts.filter (· ⊆ B)).biUnion id).card ≤ m by
+        #(B \ {A ∈ (chunk hP G ε hU).parts | A ⊆ B}.biUnion id) ≤ m by
       exact sum_le_sum fun B hB => this B <| filter_subset _ _ hB
     intro B hB
     unfold chunk
@@ -118,43 +117,43 @@ private theorem card_nonuniformWitness_sdiff_biUnion_star (hV : V ∈ P.parts) (
   exact card_image_le.trans (card_le_card <| filter_subset _ _)
 
 private theorem one_sub_eps_mul_card_nonuniformWitness_le_card_star (hV : V ∈ P.parts)
-    (hUV : U ≠ V) (hunif : ¬G.IsUniform ε U V) (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5)
+    (hUV : U ≠ V) (hunif : ¬G.IsUniform ε U V) (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5)
     (hε₁ : ε ≤ 1) :
-    (1 - ε / 10) * (G.nonuniformWitness ε U V).card ≤ ((star hP G ε hU V).biUnion id).card := by
-  have hP₁ : 0 < P.parts.card := Finset.card_pos.2 ⟨_, hU⟩
-  have : (↑2 ^ P.parts.card : ℝ) * m / (U.card * ε) ≤ ε / 10 := by
+    (1 - ε / 10) * #(G.nonuniformWitness ε U V) ≤ #((star hP G ε hU V).biUnion id) := by
+  have hP₁ : 0 < #P.parts := Finset.card_pos.2 ⟨_, hU⟩
+  have : (↑2 ^ #P.parts : ℝ) * m / (#U * ε) ≤ ε / 10 := by
     rw [← div_div, div_le_iff₀']
     swap
     · sz_positivity
-    refine le_of_mul_le_mul_left ?_ (pow_pos zero_lt_two P.parts.card)
+    refine le_of_mul_le_mul_left ?_ (pow_pos zero_lt_two #P.parts)
     calc
-      ↑2 ^ P.parts.card * ((↑2 ^ P.parts.card * m : ℝ) / U.card) =
-          ((2 : ℝ) * 2) ^ P.parts.card * m / U.card := by
+      ↑2 ^ #P.parts * ((↑2 ^ #P.parts * m : ℝ) / #U) =
+          ((2 : ℝ) * 2) ^ #P.parts * m / #U := by
         rw [mul_pow, ← mul_div_assoc, mul_assoc]
-      _ = ↑4 ^ P.parts.card * m / U.card := by norm_num
+      _ = ↑4 ^ #P.parts * m / #U := by norm_num
       _ ≤ 1 := div_le_one_of_le₀ (pow_mul_m_le_card_part hP hU) (cast_nonneg _)
-      _ ≤ ↑2 ^ P.parts.card * ε ^ 2 / 10 := by
+      _ ≤ ↑2 ^ #P.parts * ε ^ 2 / 10 := by
         refine (one_le_sq_iff <| by positivity).1 ?_
         rw [div_pow, mul_pow, pow_right_comm, ← pow_mul ε,
           one_le_div (sq_pos_of_ne_zero <| by norm_num)]
         calc
           (↑10 ^ 2) = 100 := by norm_num
-          _ ≤ ↑4 ^ P.parts.card * ε ^ 5 := hPε
-          _ ≤ ↑4 ^ P.parts.card * ε ^ 4 :=
+          _ ≤ ↑4 ^ #P.parts * ε ^ 5 := hPε
+          _ ≤ ↑4 ^ #P.parts * ε ^ 4 :=
             (mul_le_mul_of_nonneg_left (pow_le_pow_of_le_one (by sz_positivity) hε₁ <| le_succ _)
               (by positivity))
-          _ = (↑2 ^ 2) ^ P.parts.card * ε ^ (2 * 2) := by norm_num
-      _ = ↑2 ^ P.parts.card * (ε * (ε / 10)) := by rw [mul_div_assoc, sq, mul_div_assoc]
+          _ = (↑2 ^ 2) ^ #P.parts * ε ^ (2 * 2) := by norm_num
+      _ = ↑2 ^ #P.parts * (ε * (ε / 10)) := by rw [mul_div_assoc, sq, mul_div_assoc]
   calc
-    (↑1 - ε / 10) * (G.nonuniformWitness ε U V).card ≤
-        (↑1 - ↑2 ^ P.parts.card * m / (U.card * ε)) * (G.nonuniformWitness ε U V).card :=
+    (↑1 - ε / 10) * #(G.nonuniformWitness ε U V) ≤
+        (↑1 - ↑2 ^ #P.parts * m / (#U * ε)) * #(G.nonuniformWitness ε U V) :=
       mul_le_mul_of_nonneg_right (sub_le_sub_left this _) (cast_nonneg _)
-    _ = (G.nonuniformWitness ε U V).card -
-        ↑2 ^ P.parts.card * m / (U.card * ε) * (G.nonuniformWitness ε U V).card := by
+    _ = #(G.nonuniformWitness ε U V) -
+        ↑2 ^ #P.parts * m / (#U * ε) * #(G.nonuniformWitness ε U V) := by
       rw [sub_mul, one_mul]
-    _ ≤ (G.nonuniformWitness ε U V).card - ↑2 ^ (P.parts.card - 1) * m := by
+    _ ≤ #(G.nonuniformWitness ε U V) - ↑2 ^ (#P.parts - 1) * m := by
       refine sub_le_sub_left ?_ _
-      have : (2 : ℝ) ^ P.parts.card = ↑2 ^ (P.parts.card - 1) * 2 := by
+      have : (2 : ℝ) ^ #P.parts = ↑2 ^ (#P.parts - 1) * 2 := by
         rw [← _root_.pow_succ, tsub_add_cancel_of_le (succ_le_iff.2 hP₁)]
       rw [← mul_div_right_comm, this, mul_right_comm _ (2 : ℝ), mul_assoc, le_div_iff₀]
       · refine mul_le_mul_of_nonneg_left ?_ (by positivity)
@@ -162,7 +161,7 @@ private theorem one_sub_eps_mul_card_nonuniformWitness_le_card_star (hV : V ∈ 
           (le_mul_of_one_le_left (cast_nonneg _) one_le_two)
       have := Finset.card_pos.mpr (P.nonempty_of_mem_parts hU)
       sz_positivity
-    _ ≤ ((star hP G ε hU V).biUnion id).card := by
+    _ ≤ #((star hP G ε hU V).biUnion id) := by
       rw [sub_le_comm, ←
         cast_sub (card_le_card <| biUnion_star_subset_nonuniformWitness hP G ε hU V), ←
         card_sdiff (biUnion_star_subset_nonuniformWitness hP G ε hU V)]
@@ -171,7 +170,7 @@ private theorem one_sub_eps_mul_card_nonuniformWitness_le_card_star (hV : V ∈ 
 /-! ### `chunk` -/
 
 
-theorem card_chunk (hm : m ≠ 0) : (chunk hP G ε hU).parts.card = 4 ^ P.parts.card := by
+theorem card_chunk (hm : m ≠ 0) : #(chunk hP G ε hU).parts = 4 ^ #P.parts := by
   unfold chunk
   split_ifs
   · rw [card_parts_equitabilise _ _ hm, tsub_add_cancel_of_le]
@@ -179,23 +178,23 @@ theorem card_chunk (hm : m ≠ 0) : (chunk hP G ε hU).parts.card = 4 ^ P.parts.
   · rw [card_parts_equitabilise _ _ hm, tsub_add_cancel_of_le a_add_one_le_four_pow_parts_card]
 
 theorem card_eq_of_mem_parts_chunk (hs : s ∈ (chunk hP G ε hU).parts) :
-    s.card = m ∨ s.card = m + 1 := by
+    #s = m ∨ #s = m + 1 := by
   unfold chunk at hs
   split_ifs at hs <;> exact card_eq_of_mem_parts_equitabilise hs
 
-theorem m_le_card_of_mem_chunk_parts (hs : s ∈ (chunk hP G ε hU).parts) : m ≤ s.card :=
+theorem m_le_card_of_mem_chunk_parts (hs : s ∈ (chunk hP G ε hU).parts) : m ≤ #s :=
   (card_eq_of_mem_parts_chunk hs).elim ge_of_eq fun i => by simp [i]
 
-theorem card_le_m_add_one_of_mem_chunk_parts (hs : s ∈ (chunk hP G ε hU).parts) : s.card ≤ m + 1 :=
+theorem card_le_m_add_one_of_mem_chunk_parts (hs : s ∈ (chunk hP G ε hU).parts) : #s ≤ m + 1 :=
   (card_eq_of_mem_parts_chunk hs).elim (fun i => by simp [i]) fun i => i.le
 
 theorem card_biUnion_star_le_m_add_one_card_star_mul :
-    (((star hP G ε hU V).biUnion id).card : ℝ) ≤ (star hP G ε hU V).card * (m + 1) :=
+    (#((star hP G ε hU V).biUnion id) : ℝ) ≤ #(star hP G ε hU V) * (m + 1) :=
   mod_cast card_biUnion_le_card_mul _ _ _ fun _ hs =>
     card_le_m_add_one_of_mem_chunk_parts <| star_subset_chunk hs
 
 private theorem le_sum_card_subset_chunk_parts (h𝒜 : 𝒜 ⊆ (chunk hP G ε hU).parts) (hs : s ∈ 𝒜) :
-    (𝒜.card : ℝ) * s.card * (m / (m + 1)) ≤ (𝒜.sup id).card := by
+    (#𝒜 : ℝ) * #s * (m / (m + 1)) ≤ #(𝒜.sup id) := by
   rw [mul_div_assoc', div_le_iff₀ coe_m_add_one_pos, mul_right_comm]
   refine mul_le_mul ?_ ?_ (cast_nonneg _) (cast_nonneg _)
   · rw [← (ofSubset _ h𝒜 rfl).sum_card_parts, ofSubset_parts, ← cast_mul, cast_le]
@@ -204,7 +203,7 @@ private theorem le_sum_card_subset_chunk_parts (h𝒜 : 𝒜 ⊆ (chunk hP G ε 
 
 private theorem sum_card_subset_chunk_parts_le (m_pos : (0 : ℝ) < m)
     (h𝒜 : 𝒜 ⊆ (chunk hP G ε hU).parts) (hs : s ∈ 𝒜) :
-    ((𝒜.sup id).card : ℝ) ≤ 𝒜.card * s.card * ((m + 1) / m) := by
+    (#(𝒜.sup id) : ℝ) ≤ #𝒜 * #s * ((m + 1) / m) := by
   rw [sup_eq_biUnion, mul_div_assoc', le_div_iff₀ m_pos, mul_right_comm]
   refine mul_le_mul ?_ ?_ (cast_nonneg _) (by positivity)
   · norm_cast
@@ -213,7 +212,7 @@ private theorem sum_card_subset_chunk_parts_le (m_pos : (0 : ℝ) < m)
   · exact mod_cast m_le_card_of_mem_chunk_parts (h𝒜 hs)
 
 private theorem one_sub_le_m_div_m_add_one_sq [Nonempty α]
-    (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5) :
+    (hPα : #P.parts * 16 ^ #P.parts ≤ card α) (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5) :
     ↑1 - ε ^ 5 / ↑50 ≤ (m / (m + 1 : ℝ)) ^ 2 := by
   have : (m : ℝ) / (m + 1) = 1 - 1 / (m + 1) := by
     rw [one_sub_div coe_m_add_one_pos.ne', add_sub_cancel_right]
@@ -227,7 +226,7 @@ private theorem one_sub_le_m_div_m_add_one_sq [Nonempty α]
   sz_positivity
 
 private theorem m_add_one_div_m_le_one_add [Nonempty α]
-    (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5)
+    (hPα : #P.parts * 16 ^ #P.parts ≤ card α) (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5)
     (hε₁ : ε ≤ 1) : ((m + 1 : ℝ) / m) ^ 2 ≤ ↑1 + ε ^ 5 / 49 := by
   rw [same_add_div]
   swap; · sz_positivity
@@ -243,11 +242,11 @@ private theorem m_add_one_div_m_le_one_add [Nonempty α]
   exact (pow_le_one₀ (by sz_positivity) hε₁).trans (by norm_num)
 
 private theorem density_sub_eps_le_sum_density_div_card [Nonempty α]
-    (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5)
+    (hPα : #P.parts * 16 ^ #P.parts ≤ card α) (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5)
     {hU : U ∈ P.parts} {hV : V ∈ P.parts} {A B : Finset (Finset α)}
     (hA : A ⊆ (chunk hP G ε hU).parts) (hB : B ⊆ (chunk hP G ε hV).parts) :
     (G.edgeDensity (A.biUnion id) (B.biUnion id)) - ε ^ 5 / 50 ≤
-    (∑ ab ∈ A.product B, (G.edgeDensity ab.1 ab.2 : ℝ)) / (A.card * B.card) := by
+    (∑ ab ∈ A.product B, (G.edgeDensity ab.1 ab.2 : ℝ)) / (#A * #B) := by
   have : ↑(G.edgeDensity (A.biUnion id) (B.biUnion id)) - ε ^ 5 / ↑50 ≤
       (↑1 - ε ^ 5 / 50) * G.edgeDensity (A.biUnion id) (B.biUnion id) := by
     rw [sub_mul, one_mul, sub_le_sub_iff_left]
@@ -266,7 +265,7 @@ private theorem density_sub_eps_le_sum_density_div_card [Nonempty α]
   apply sum_le_sum
   simp only [and_imp, Prod.forall, mem_product]
   rintro x y hx hy
-  rw [mul_mul_mul_comm, mul_comm (x.card : ℝ), mul_comm (y.card : ℝ), le_div_iff₀, mul_assoc]
+  rw [mul_mul_mul_comm, mul_comm (#x : ℝ), mul_comm (#y : ℝ), le_div_iff₀, mul_assoc]
   · refine mul_le_of_le_one_right (cast_nonneg _) ?_
     rw [div_mul_eq_mul_div, ← mul_assoc, mul_assoc]
     refine div_le_one_of_le₀ ?_ (by positivity)
@@ -281,10 +280,10 @@ private theorem density_sub_eps_le_sum_density_div_card [Nonempty α]
   exacts [⟨_, hx⟩, nonempty_of_mem_parts _ (hA hx), ⟨_, hy⟩, nonempty_of_mem_parts _ (hB hy)]
 
 private theorem sum_density_div_card_le_density_add_eps [Nonempty α]
-    (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5)
+    (hPα : #P.parts * 16 ^ #P.parts ≤ card α) (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5)
     (hε₁ : ε ≤ 1) {hU : U ∈ P.parts} {hV : V ∈ P.parts} {A B : Finset (Finset α)}
     (hA : A ⊆ (chunk hP G ε hU).parts) (hB : B ⊆ (chunk hP G ε hV).parts) :
-    (∑ ab ∈ A.product B, G.edgeDensity ab.1 ab.2 : ℝ) / (A.card * B.card) ≤
+    (∑ ab ∈ A.product B, G.edgeDensity ab.1 ab.2 : ℝ) / (#A * #B) ≤
     G.edgeDensity (A.biUnion id) (B.biUnion id) + ε ^ 5 / 49 := by
   have : (↑1 + ε ^ 5 / ↑49) * G.edgeDensity (A.biUnion id) (B.biUnion id) ≤
       G.edgeDensity (A.biUnion id) (B.biUnion id) + ε ^ 5 / 49 := by
@@ -303,7 +302,7 @@ private theorem sum_density_div_card_le_density_add_eps [Nonempty α]
   apply sum_le_sum
   simp only [and_imp, Prod.forall, mem_product, show A.product B = A ×ˢ B by rfl]
   intro x y hx hy
-  rw [mul_mul_mul_comm, mul_comm (x.card : ℝ), mul_comm (y.card : ℝ), div_le_iff₀, mul_assoc]
+  rw [mul_mul_mul_comm, mul_comm (#x : ℝ), mul_comm (#y : ℝ), div_le_iff₀, mul_assoc]
   · refine le_mul_of_one_le_right (cast_nonneg _) ?_
     rw [div_mul_eq_mul_div, one_le_div]
     · refine le_trans ?_ (mul_le_mul_of_nonneg_right (m_add_one_div_m_le_one_add hPα hPε hε₁) ?_)
@@ -319,28 +318,28 @@ private theorem sum_density_div_card_le_density_add_eps [Nonempty α]
   exacts [⟨_, hx⟩, nonempty_of_mem_parts _ (hA hx), ⟨_, hy⟩, nonempty_of_mem_parts _ (hB hy)]
 
 private theorem average_density_near_total_density [Nonempty α]
-    (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5)
+    (hPα : #P.parts * 16 ^ #P.parts ≤ card α) (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5)
     (hε₁ : ε ≤ 1) {hU : U ∈ P.parts} {hV : V ∈ P.parts} {A B : Finset (Finset α)}
     (hA : A ⊆ (chunk hP G ε hU).parts) (hB : B ⊆ (chunk hP G ε hV).parts) :
-    |(∑ ab ∈ A.product B, G.edgeDensity ab.1 ab.2 : ℝ) / (A.card * B.card) -
+    |(∑ ab ∈ A.product B, G.edgeDensity ab.1 ab.2 : ℝ) / (#A * #B) -
       G.edgeDensity (A.biUnion id) (B.biUnion id)| ≤ ε ^ 5 / 49 := by
   rw [abs_sub_le_iff]
   constructor
   · rw [sub_le_iff_le_add']
     exact sum_density_div_card_le_density_add_eps hPα hPε hε₁ hA hB
   suffices (G.edgeDensity (A.biUnion id) (B.biUnion id) : ℝ) -
-      (∑ ab ∈ A.product B, (G.edgeDensity ab.1 ab.2 : ℝ)) / (A.card * B.card) ≤ ε ^ 5 / 50 by
+      (∑ ab ∈ A.product B, (G.edgeDensity ab.1 ab.2 : ℝ)) / (#A * #B) ≤ ε ^ 5 / 50 by
     apply this.trans
     gcongr <;> [sz_positivity; norm_num]
   rw [sub_le_iff_le_add, ← sub_le_iff_le_add']
   apply density_sub_eps_le_sum_density_div_card hPα hPε hA hB
 
 private theorem edgeDensity_chunk_aux [Nonempty α]
-    (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5)
+    (hPα : #P.parts * 16 ^ #P.parts ≤ card α) (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5)
     (hU : U ∈ P.parts) (hV : V ∈ P.parts) :
     (G.edgeDensity U V : ℝ) ^ 2 - ε ^ 5 / ↑25 ≤
     ((∑ ab ∈ (chunk hP G ε hU).parts.product (chunk hP G ε hV).parts,
-      (G.edgeDensity ab.1 ab.2 : ℝ)) / ↑16 ^ P.parts.card) ^ 2 := by
+      (G.edgeDensity ab.1 ab.2 : ℝ)) / ↑16 ^ #P.parts) ^ 2 := by
   obtain hGε | hGε := le_total (G.edgeDensity U V : ℝ) (ε ^ 5 / 50)
   · refine (sub_nonpos_of_le <| (sq_le ?_ ?_).trans <| hGε.trans ?_).trans (sq_nonneg _)
     · exact mod_cast G.edgeDensity_nonneg _ _
@@ -349,7 +348,7 @@ private theorem edgeDensity_chunk_aux [Nonempty α]
   rw [← sub_nonneg] at hGε
   have : ↑(G.edgeDensity U V) - ε ^ 5 / ↑50 ≤
       (∑ ab ∈ (chunk hP G ε hU).parts.product (chunk hP G ε hV).parts,
-        (G.edgeDensity ab.1 ab.2 : ℝ)) / ↑16 ^ P.parts.card := by
+        (G.edgeDensity ab.1 ab.2 : ℝ)) / ↑16 ^ #P.parts := by
     have rflU := Set.Subset.refl (chunk hP G ε hU).parts.toSet
     have rflV := Set.Subset.refl (chunk hP G ε hV).parts.toSet
     refine (le_trans ?_ <| density_sub_eps_le_sum_density_div_card hPα hPε rflU rflV).trans ?_
@@ -363,7 +362,7 @@ private theorem edgeDensity_chunk_aux [Nonempty α]
     show (2 : ℝ) / 50 = 25⁻¹ by norm_num]
   exact mul_le_of_le_one_right (by sz_positivity) (mod_cast G.edgeDensity_le_one _ _)
 
-private theorem abs_density_star_sub_density_le_eps (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5)
+private theorem abs_density_star_sub_density_le_eps (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5)
     (hε₁ : ε ≤ 1) {hU : U ∈ P.parts} {hV : V ∈ P.parts} (hUV' : U ≠ V) (hUV : ¬G.IsUniform ε U V) :
     |(G.edgeDensity ((star hP G ε hU V).biUnion id) ((star hP G ε hV U).biUnion id) : ℝ) -
       G.edgeDensity (G.nonuniformWitness ε U V) (G.nonuniformWitness ε V U)| ≤ ε / 5 := by
@@ -375,33 +374,33 @@ private theorem abs_density_star_sub_density_le_eps (hPε : ↑100 ≤ ↑4 ^ P.
       hPε hε₁) using 1
   linarith
 
-private theorem eps_le_card_star_div [Nonempty α] (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α)
-    (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5) (hε₁ : ε ≤ 1) (hU : U ∈ P.parts) (hV : V ∈ P.parts)
+private theorem eps_le_card_star_div [Nonempty α] (hPα : #P.parts * 16 ^ #P.parts ≤ card α)
+    (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5) (hε₁ : ε ≤ 1) (hU : U ∈ P.parts) (hV : V ∈ P.parts)
     (hUV : U ≠ V) (hunif : ¬G.IsUniform ε U V) :
-    ↑4 / ↑5 * ε ≤ (star hP G ε hU V).card / ↑4 ^ P.parts.card := by
+    ↑4 / ↑5 * ε ≤ #(star hP G ε hU V) / ↑4 ^ #P.parts := by
   have hm : (0 : ℝ) ≤ 1 - (↑m)⁻¹ := sub_nonneg_of_le (inv_le_one_of_one_le₀ <| one_le_m_coe hPα)
   have hε : 0 ≤ 1 - ε / 10 :=
     sub_nonneg_of_le (div_le_one_of_le₀ (hε₁.trans <| by norm_num) <| by norm_num)
   have hε₀ : 0 < ε := by sz_positivity
   calc
     4 / 5 * ε = (1 - 1 / 10) * (1 - 9⁻¹) * ε := by norm_num
-    _ ≤ (1 - ε / 10) * (1 - (↑m)⁻¹) * ((G.nonuniformWitness ε U V).card / U.card) := by
+    _ ≤ (1 - ε / 10) * (1 - (↑m)⁻¹) * (#(G.nonuniformWitness ε U V) / #U) := by
         gcongr
         exacts [mod_cast (show 9 ≤ 100 by norm_num).trans (hundred_le_m hPα hPε hε₁),
           (le_div_iff₀' <| cast_pos.2 (P.nonempty_of_mem_parts hU).card_pos).2 <|
            G.le_card_nonuniformWitness hunif]
-    _ = (1 - ε / 10) * (G.nonuniformWitness ε U V).card * ((1 - (↑m)⁻¹) / U.card) := by
+    _ = (1 - ε / 10) * #(G.nonuniformWitness ε U V) * ((1 - (↑m)⁻¹) / #U) := by
       rw [mul_assoc, mul_assoc, mul_div_left_comm]
-    _ ≤ ((star hP G ε hU V).biUnion id).card * ((1 - (↑m)⁻¹) / U.card) :=
+    _ ≤ #((star hP G ε hU V).biUnion id) * ((1 - (↑m)⁻¹) / #U) :=
       (mul_le_mul_of_nonneg_right
         (one_sub_eps_mul_card_nonuniformWitness_le_card_star hV hUV hunif hPε hε₁) (by positivity))
-    _ ≤ (star hP G ε hU V).card * (m + 1) * ((1 - (↑m)⁻¹) / U.card) :=
+    _ ≤ #(star hP G ε hU V) * (m + 1) * ((1 - (↑m)⁻¹) / #U) :=
       (mul_le_mul_of_nonneg_right card_biUnion_star_le_m_add_one_card_star_mul (by positivity))
-    _ ≤ (star hP G ε hU V).card * (m + ↑1) * ((↑1 - (↑m)⁻¹) / (↑4 ^ P.parts.card * m)) :=
+    _ ≤ #(star hP G ε hU V) * (m + ↑1) * ((↑1 - (↑m)⁻¹) / (↑4 ^ #P.parts * m)) :=
       (mul_le_mul_of_nonneg_left (div_le_div_of_nonneg_left hm (by sz_positivity) <|
         pow_mul_m_le_card_part hP hU) (by positivity))
-    _ ≤ (star hP G ε hU V).card / ↑4 ^ P.parts.card := by
-      rw [mul_assoc, mul_comm ((4 : ℝ) ^ P.parts.card), ← div_div, ← mul_div_assoc, ← mul_comm_div]
+    _ ≤ #(star hP G ε hU V) / ↑4 ^ #P.parts := by
+      rw [mul_assoc, mul_comm ((4 : ℝ) ^ #P.parts), ← div_div, ← mul_div_assoc, ← mul_comm_div]
       refine mul_le_of_le_one_right (by positivity) ?_
       have hm : (0 : ℝ) < m := by sz_positivity
       rw [mul_div_assoc', div_le_one hm, ← one_div, one_sub_div hm.ne', mul_div_assoc',
@@ -417,20 +416,20 @@ Those inequalities are the end result of all this hard work.
 
 /-- Lower bound on the edge densities between non-uniform parts of `SzemerediRegularity.star`. -/
 private theorem edgeDensity_star_not_uniform [Nonempty α]
-    (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5)
+    (hPα : #P.parts * 16 ^ #P.parts ≤ card α) (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5)
     (hε₁ : ε ≤ 1) {hU : U ∈ P.parts} {hV : V ∈ P.parts} (hUVne : U ≠ V) (hUV : ¬G.IsUniform ε U V) :
     ↑3 / ↑4 * ε ≤
     |(∑ ab ∈ (star hP G ε hU V).product (star hP G ε hV U), (G.edgeDensity ab.1 ab.2 : ℝ)) /
-      ((star hP G ε hU V).card * (star hP G ε hV U).card) -
+      (#(star hP G ε hU V) * #(star hP G ε hV U)) -
         (∑ ab ∈ (chunk hP G ε hU).parts.product (chunk hP G ε hV).parts,
-          (G.edgeDensity ab.1 ab.2 : ℝ)) / (16 : ℝ) ^ P.parts.card| := by
+          (G.edgeDensity ab.1 ab.2 : ℝ)) / (16 : ℝ) ^ #P.parts| := by
   rw [show (16 : ℝ) = ↑4 ^ 2 by norm_num, pow_right_comm, sq ((4 : ℝ) ^ _)]
   set p : ℝ :=
     (∑ ab ∈ (star hP G ε hU V).product (star hP G ε hV U), (G.edgeDensity ab.1 ab.2 : ℝ)) /
-      ((star hP G ε hU V).card * (star hP G ε hV U).card)
+      (#(star hP G ε hU V) * #(star hP G ε hV U))
   set q : ℝ :=
     (∑ ab ∈ (chunk hP G ε hU).parts.product (chunk hP G ε hV).parts,
-      (G.edgeDensity ab.1 ab.2 : ℝ)) / (↑4 ^ P.parts.card * ↑4 ^ P.parts.card)
+      (G.edgeDensity ab.1 ab.2 : ℝ)) / (↑4 ^ #P.parts * ↑4 ^ #P.parts)
   change _ ≤ |p - q|
   set r : ℝ := ↑(G.edgeDensity ((star hP G ε hU V).biUnion id) ((star hP G ε hV U).biUnion id))
   set s : ℝ := ↑(G.edgeDensity (G.nonuniformWitness ε U V) (G.nonuniformWitness ε V U))
@@ -458,20 +457,20 @@ private theorem edgeDensity_star_not_uniform [Nonempty α]
 
 /-- Lower bound on the edge densities between non-uniform parts of `SzemerediRegularity.increment`.
 -/
-theorem edgeDensity_chunk_not_uniform [Nonempty α] (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α)
-    (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5) (hε₁ : ε ≤ 1) {hU : U ∈ P.parts} {hV : V ∈ P.parts}
+theorem edgeDensity_chunk_not_uniform [Nonempty α] (hPα : #P.parts * 16 ^ #P.parts ≤ card α)
+    (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5) (hε₁ : ε ≤ 1) {hU : U ∈ P.parts} {hV : V ∈ P.parts}
     (hUVne : U ≠ V) (hUV : ¬G.IsUniform ε U V) :
     (G.edgeDensity U V : ℝ) ^ 2 - ε ^ 5 / ↑25 + ε ^ 4 / ↑3 ≤
     (∑ ab ∈ (chunk hP G ε hU).parts.product (chunk hP G ε hV).parts,
-      (G.edgeDensity ab.1 ab.2 : ℝ) ^ 2) / ↑16 ^ P.parts.card :=
+      (G.edgeDensity ab.1 ab.2 : ℝ) ^ 2) / ↑16 ^ #P.parts :=
   calc
     ↑(G.edgeDensity U V) ^ 2 - ε ^ 5 / 25 + ε ^ 4 / ↑3 ≤ ↑(G.edgeDensity U V) ^ 2 - ε ^ 5 / ↑25 +
-        (star hP G ε hU V).card * (star hP G ε hV U).card / ↑16 ^ P.parts.card *
+        #(star hP G ε hU V) * #(star hP G ε hV U) / ↑16 ^ #P.parts *
           (↑9 / ↑16) * ε ^ 2 := by
       apply add_le_add_left
-      have Ul : 4 / 5 * ε ≤ (star hP G ε hU V).card / _ :=
+      have Ul : 4 / 5 * ε ≤ #(star hP G ε hU V) / _ :=
         eps_le_card_star_div hPα hPε hε₁ hU hV hUVne hUV
-      have Vl : 4 / 5 * ε ≤ (star hP G ε hV U).card / _ :=
+      have Vl : 4 / 5 * ε ≤ #(star hP G ε hV U) / _ :=
         eps_le_card_star_div hPα hPε hε₁ hV hU hUVne.symm fun h => hUV h.symm
       rw [show (16 : ℝ) = ↑4 ^ 2 by norm_num, pow_right_comm, sq ((4 : ℝ) ^ _), ←
         _root_.div_mul_div_comm, mul_assoc]
@@ -487,7 +486,7 @@ theorem edgeDensity_chunk_not_uniform [Nonempty α] (hPα : P.parts.card * 16 ^ 
       · norm_num
         positivity
     _ ≤ (∑ ab ∈ (chunk hP G ε hU).parts.product (chunk hP G ε hV).parts,
-        (G.edgeDensity ab.1 ab.2 : ℝ) ^ 2) / ↑16 ^ P.parts.card := by
+        (G.edgeDensity ab.1 ab.2 : ℝ) ^ 2) / ↑16 ^ #P.parts := by
       have t : (star hP G ε hU V).product (star hP G ε hV U) ⊆
           (chunk hP G ε hU).parts.product (chunk hP G ε hV).parts :=
         product_subset_product star_subset_chunk star_subset_chunk
@@ -510,14 +509,13 @@ theorem edgeDensity_chunk_not_uniform [Nonempty α] (hPα : P.parts.card * 16 ^ 
 
 /-- Lower bound on the edge densities between parts of `SzemerediRegularity.increment`. This is the
 blanket lower bound used the uniform parts. -/
-theorem edgeDensity_chunk_uniform [Nonempty α] (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α)
-    (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5) (hU : U ∈ P.parts) (hV : V ∈ P.parts) :
+theorem edgeDensity_chunk_uniform [Nonempty α] (hPα : #P.parts * 16 ^ #P.parts ≤ card α)
+    (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5) (hU : U ∈ P.parts) (hV : V ∈ P.parts) :
     (G.edgeDensity U V : ℝ) ^ 2 - ε ^ 5 / ↑25 ≤
     (∑ ab ∈ (chunk hP G ε hU).parts.product (chunk hP G ε hV).parts,
-      (G.edgeDensity ab.1 ab.2 : ℝ) ^ 2) / ↑16 ^ P.parts.card := by
+      (G.edgeDensity ab.1 ab.2 : ℝ) ^ 2) / ↑16 ^ #P.parts := by
   apply (edgeDensity_chunk_aux (hP := hP) hPα hPε hU hV).trans
-  have key : ↑16 ^ P.parts.card =
-      (((chunk hP G ε hU).parts ×ˢ (chunk hP G ε hV).parts).card : ℝ) := by
+  have key : (16 : ℝ) ^ #P.parts = #((chunk hP G ε hU).parts ×ˢ (chunk hP G ε hV).parts) := by
     rw [card_product, cast_mul, card_chunk (m_pos hPα).ne', card_chunk (m_pos hPα).ne', ←
       cast_mul, ← mul_pow]; norm_cast
   simp_rw [key]

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
@@ -33,7 +33,7 @@ namespace Finpartition
 /-- The energy of a partition, also known as index. Auxiliary quantity for Szemerédi's regularity
 lemma. -/
 def energy : ℚ :=
-  ((∑ uv ∈ P.parts.offDiag, G.edgeDensity uv.1 uv.2 ^ 2) : ℚ) / (P.parts.card : ℚ) ^ 2
+  ((∑ uv ∈ P.parts.offDiag, G.edgeDensity uv.1 uv.2 ^ 2) : ℚ) / (#P.parts : ℚ) ^ 2
 
 theorem energy_nonneg : 0 ≤ P.energy G := by
   exact div_nonneg (Finset.sum_nonneg fun _ _ => sq_nonneg _) <| sq_nonneg _
@@ -41,10 +41,10 @@ theorem energy_nonneg : 0 ≤ P.energy G := by
 theorem energy_le_one : P.energy G ≤ 1 :=
   div_le_of_le_mul₀ (sq_nonneg _) zero_le_one <|
     calc
-      ∑ uv ∈ P.parts.offDiag, G.edgeDensity uv.1 uv.2 ^ 2 ≤ P.parts.offDiag.card • (1 : ℚ) :=
+      ∑ uv ∈ P.parts.offDiag, G.edgeDensity uv.1 uv.2 ^ 2 ≤ #P.parts.offDiag • (1 : ℚ) :=
         sum_le_card_nsmul _ _ 1 fun _ _ =>
           (sq_le_one_iff <| G.edgeDensity_nonneg _ _).2 <| G.edgeDensity_le_one _ _
-      _ = P.parts.offDiag.card := Nat.smul_one_eq_cast _
+      _ = #P.parts.offDiag := Nat.smul_one_eq_cast _
       _ ≤ _ := by
         rw [offDiag_card, one_mul]
         norm_cast
@@ -53,7 +53,7 @@ theorem energy_le_one : P.energy G ≤ 1 :=
 
 @[simp, norm_cast]
 theorem coe_energy {𝕜 : Type*} [LinearOrderedField 𝕜] : (P.energy G : 𝕜) =
-    (∑ uv ∈ P.parts.offDiag, (G.edgeDensity uv.1 uv.2 : 𝕜) ^ 2) / (P.parts.card : 𝕜) ^ 2 := by
+    (∑ uv ∈ P.parts.offDiag, (G.edgeDensity uv.1 uv.2 : 𝕜) ^ 2) / (#P.parts : 𝕜) ^ 2 := by
   rw [energy]; norm_cast
 
 end Finpartition

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Equitabilise.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Equitabilise.lean
@@ -32,16 +32,16 @@ namespace Finpartition
 
 variable {α : Type*} [DecidableEq α] {s t : Finset α} {m n a b : ℕ} {P : Finpartition s}
 
-/-- Given a partition `P` of `s`, as well as a proof that `a * m + b * (m + 1) = s.card`, we can
+/-- Given a partition `P` of `s`, as well as a proof that `a * m + b * (m + 1) = #s`, we can
 find a new partition `Q` of `s` where each part has size `m` or `m + 1`, every part of `P` is the
 union of parts of `Q` plus at most `m` extra elements, there are `b` parts of size `m + 1` and
 (provided `m > 0`, because a partition does not have parts of size `0`) there are `a` parts of size
 `m` and hence `a + b` parts in total. -/
-theorem equitabilise_aux (hs : a * m + b * (m + 1) = s.card) :
+theorem equitabilise_aux (hs : a * m + b * (m + 1) = #s) :
     ∃ Q : Finpartition s,
-      (∀ x : Finset α, x ∈ Q.parts → x.card = m ∨ x.card = m + 1) ∧
-        (∀ x, x ∈ P.parts → (x \ (Q.parts.filter fun y => y ⊆ x).biUnion id).card ≤ m) ∧
-          (Q.parts.filter fun i => card i = m + 1).card = b := by
+      (∀ x : Finset α, x ∈ Q.parts → #x = m ∨ #x = m + 1) ∧
+        (∀ x, x ∈ P.parts → #(x \ {y ∈ Q.parts | y ⊆ x}.biUnion id) ≤ m) ∧
+          #{i ∈ Q.parts | #i = m + 1} = b := by
   -- Get rid of the easy case `m = 0`
   obtain rfl | m_pos := m.eq_zero_or_pos
   · refine ⟨⊥, by simp, ?_, by simpa [Finset.filter_true_of_mem] using hs.symm⟩
@@ -63,7 +63,7 @@ theorem equitabilise_aux (hs : a * m + b * (m + 1) = s.card) :
   set n := if 0 < a then m else m + 1 with hn
   -- Some easy facts about it
   obtain ⟨hn₀, hn₁, hn₂, hn₃⟩ : 0 < n ∧ n ≤ m + 1 ∧ n ≤ a * m + b * (m + 1) ∧
-      ite (0 < a) (a - 1) a * m + ite (0 < a) b (b - 1) * (m + 1) = s.card - n := by
+      ite (0 < a) (a - 1) a * m + ite (0 < a) b (b - 1) * (m + 1) = #s - n := by
     rw [hn, ← hs]
     split_ifs with h <;> rw [tsub_mul, one_mul]
     · refine ⟨m_pos, le_succ _, le_add_right (Nat.le_mul_of_pos_left _ ‹0 < a›), ?_⟩
@@ -77,10 +77,10 @@ theorem equitabilise_aux (hs : a * m + b * (m + 1) = s.card) :
     least one part `u` of `P` has size `m + 1` (in which case we take `t` to be an arbitrary subset
     of `u` of size `n`). The rest of each branch is just tedious calculations to satisfy the
     induction hypothesis. -/
-  by_cases h : ∀ u ∈ P.parts, card u < m + 1
+  by_cases h : ∀ u ∈ P.parts, #u < m + 1
   · obtain ⟨t, hts, htn⟩ := exists_subset_card_eq (hn₂.trans_eq hs)
     have ht : t.Nonempty := by rwa [← card_pos, htn]
-    have hcard : ite (0 < a) (a - 1) a * m + ite (0 < a) b (b - 1) * (m + 1) = (s \ t).card := by
+    have hcard : ite (0 < a) (a - 1) a * m + ite (0 < a) b (b - 1) * (m + 1) = #(s \ t) := by
       rw [card_sdiff ‹t ⊆ s›, htn, hn₃]
     obtain ⟨R, hR₁, _, hR₃⟩ :=
       @ih (s \ t) (sdiff_ssubset hts ‹t.Nonempty›) (if 0 < a then a - 1 else a)
@@ -99,7 +99,7 @@ theorem equitabilise_aux (hs : a * m + b * (m + 1) = s.card) :
   obtain ⟨u, hu₁, hu₂⟩ := h
   obtain ⟨t, htu, htn⟩ := exists_subset_card_eq (hn₁.trans hu₂)
   have ht : t.Nonempty := by rwa [← card_pos, htn]
-  have hcard : ite (0 < a) (a - 1) a * m + ite (0 < a) b (b - 1) * (m + 1) = (s \ t).card := by
+  have hcard : ite (0 < a) (a - 1) a * m + ite (0 < a) b (b - 1) * (m + 1) = #(s \ t) := by
     rw [card_sdiff (htu.trans <| P.le hu₁), htn, hn₃]
   obtain ⟨R, hR₁, hR₂, hR₃⟩ :=
     @ih (s \ t) (sdiff_ssubset (htu.trans <| P.le hu₁) ht) (if 0 < a then a - 1 else a)
@@ -136,9 +136,9 @@ theorem equitabilise_aux (hs : a * m + b * (m + 1) = s.card) :
   · rw [card_insert_of_not_mem, hR₃, if_neg h, Nat.sub_add_cancel (hab.resolve_left h)]
     intro H; exact ht.ne_empty (le_sdiff_iff.1 <| R.le <| filter_subset _ _ H)
 
-variable (h : a * m + b * (m + 1) = s.card)
+variable (h : a * m + b * (m + 1) = #s)
 
-/-- Given a partition `P` of `s`, as well as a proof that `a * m + b * (m + 1) = s.card`, build a
+/-- Given a partition `P` of `s`, as well as a proof that `a * m + b * (m + 1) = #s`, build a
 new partition `Q` of `s` where each part has size `m` or `m + 1`, every part of `P` is the union of
 parts of `Q` plus at most `m` extra elements, there are `b` parts of size `m + 1` and (provided
 `m > 0`, because a partition does not have parts of size `0`) there are `a` parts of size `m` and
@@ -149,7 +149,7 @@ noncomputable def equitabilise : Finpartition s :=
 variable {h}
 
 theorem card_eq_of_mem_parts_equitabilise :
-    t ∈ (P.equitabilise h).parts → t.card = m ∨ t.card = m + 1 :=
+    t ∈ (P.equitabilise h).parts → #t = m ∨ #t = m + 1 :=
   (P.equitabilise_aux h).choose_spec.1 _
 
 theorem equitabilise_isEquipartition : (P.equitabilise h).IsEquipartition :=
@@ -157,18 +157,16 @@ theorem equitabilise_isEquipartition : (P.equitabilise h).IsEquipartition :=
 
 variable (P h)
 
-theorem card_filter_equitabilise_big :
-    ((P.equitabilise h).parts.filter fun u : Finset α => u.card = m + 1).card = b :=
+theorem card_filter_equitabilise_big : #{u ∈ (P.equitabilise h).parts | #u = m + 1} = b :=
   (P.equitabilise_aux h).choose_spec.2.2
 
 theorem card_filter_equitabilise_small (hm : m ≠ 0) :
-    ((P.equitabilise h).parts.filter fun u : Finset α => u.card = m).card = a := by
+    #{u ∈ (P.equitabilise h).parts | #u = m} = a := by
   refine (mul_eq_mul_right_iff.1 <| (add_left_inj (b * (m + 1))).1 ?_).resolve_right hm
   rw [h, ← (P.equitabilise h).sum_card_parts]
   have hunion :
     (P.equitabilise h).parts =
-      ((P.equitabilise h).parts.filter fun u => u.card = m) ∪
-        (P.equitabilise h).parts.filter fun u => u.card = m + 1 := by
+      {u ∈ (P.equitabilise h).parts | #u = m} ∪ {u ∈ (P.equitabilise h).parts | #u = m + 1} := by
     rw [← filter_or, filter_true_of_mem]
     exact fun x => card_eq_of_mem_parts_equitabilise
   nth_rw 2 [hunion]
@@ -179,23 +177,23 @@ theorem card_filter_equitabilise_small (hm : m ≠ 0) :
   apply succ_ne_self m _
   exact (hb i h).symm.trans (ha i h)
 
-theorem card_parts_equitabilise (hm : m ≠ 0) : (P.equitabilise h).parts.card = a + b := by
+theorem card_parts_equitabilise (hm : m ≠ 0) : #(P.equitabilise h).parts = a + b := by
   rw [← filter_true_of_mem fun x => card_eq_of_mem_parts_equitabilise, filter_or,
     card_union_of_disjoint, P.card_filter_equitabilise_small _ hm, P.card_filter_equitabilise_big]
   -- Porting note (#11187): was `infer_instance`
   exact disjoint_filter.2 fun x _ h₀ h₁ => Nat.succ_ne_self m <| h₁.symm.trans h₀
 
 theorem card_parts_equitabilise_subset_le :
-    t ∈ P.parts → (t \ ((P.equitabilise h).parts.filter fun u => u ⊆ t).biUnion id).card ≤ m :=
+    t ∈ P.parts → #(t \ {u ∈ (P.equitabilise h).parts | u ⊆ t}.biUnion id) ≤ m :=
   (Classical.choose_spec <| P.equitabilise_aux h).2.1 t
 
 variable (s)
 
 /-- We can find equipartitions of arbitrary size. -/
-theorem exists_equipartition_card_eq (hn : n ≠ 0) (hs : n ≤ s.card) :
-    ∃ P : Finpartition s, P.IsEquipartition ∧ P.parts.card = n := by
+theorem exists_equipartition_card_eq (hn : n ≠ 0) (hs : n ≤ #s) :
+    ∃ P : Finpartition s, P.IsEquipartition ∧ #P.parts = n := by
   rw [← pos_iff_ne_zero] at hn
-  have : (n - s.card % n) * (s.card / n) + s.card % n * (s.card / n + 1) = s.card := by
+  have : (n - #s % n) * (#s / n) + #s % n * (#s / n + 1) = #s := by
     rw [tsub_mul, mul_add, ← add_assoc,
       tsub_add_cancel_of_le (Nat.mul_le_mul_right _ (mod_lt _ hn).le), mul_one, add_comm,
       mod_add_div]

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
@@ -41,7 +41,7 @@ open scoped SzemerediRegularity.Positivity
 variable {α : Type*} [Fintype α] [DecidableEq α] {P : Finpartition (univ : Finset α)}
   (hP : P.IsEquipartition) (G : SimpleGraph α) [DecidableRel G.Adj] (ε : ℝ)
 
-local notation3 "m" => (card α / stepBound P.parts.card : ℕ)
+local notation3 "m" => (card α / stepBound #P.parts : ℕ)
 
 namespace SzemerediRegularity
 
@@ -59,11 +59,11 @@ open Finpartition Finpartition.IsEquipartition
 variable {hP G ε}
 
 /-- The increment partition has a prescribed (very big) size in terms of the original partition. -/
-theorem card_increment (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) (hPG : ¬P.IsUniform G ε) :
-    (increment hP G ε).parts.card = stepBound P.parts.card := by
-  have hPα' : stepBound P.parts.card ≤ card α :=
+theorem card_increment (hPα : #P.parts * 16 ^ #P.parts ≤ card α) (hPG : ¬P.IsUniform G ε) :
+    #(increment hP G ε).parts = stepBound #P.parts := by
+  have hPα' : stepBound #P.parts ≤ card α :=
     (mul_le_mul_left' (pow_le_pow_left' (by norm_num) _) _).trans hPα
-  have hPpos : 0 < stepBound P.parts.card := stepBound_pos (nonempty_of_not_uniform hPG).card_pos
+  have hPpos : 0 < stepBound #P.parts := stepBound_pos (nonempty_of_not_uniform hPG).card_pos
   rw [increment, card_bind]
   simp_rw [chunk, apply_dite Finpartition.parts, apply_dite card, sum_dite]
   rw [sum_const_nat, sum_const_nat, univ_eq_attach, univ_eq_attach, card_attach, card_attach]
@@ -119,10 +119,10 @@ private lemma pairwiseDisjoint_distinctPairs :
 variable [Nonempty α]
 
 lemma le_sum_distinctPairs_edgeDensity_sq (x : {i // i ∈ P.parts.offDiag}) (hε₁ : ε ≤ 1)
-    (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) (hPε : ↑100 ≤ ↑4 ^ P.parts.card * ε ^ 5) :
+    (hPα : #P.parts * 16 ^ #P.parts ≤ card α) (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5) :
     (G.edgeDensity x.1.1 x.1.2 : ℝ) ^ 2 +
       ((if G.IsUniform ε x.1.1 x.1.2 then 0 else ε ^ 4 / 3) - ε ^ 5 / 25) ≤
-    (∑ i ∈ distinctPairs hP G ε x, G.edgeDensity i.1 i.2 ^ 2 : ℝ) / 16 ^ P.parts.card := by
+    (∑ i ∈ distinctPairs hP G ε x, G.edgeDensity i.1 i.2 ^ 2 : ℝ) / 16 ^ #P.parts := by
   rw [distinctPairs, ← add_sub_assoc, add_sub_right_comm]
   split_ifs with h
   · rw [add_zero]
@@ -130,18 +130,18 @@ lemma le_sum_distinctPairs_edgeDensity_sq (x : {i // i ∈ P.parts.offDiag}) (h�
   · exact edgeDensity_chunk_not_uniform hPα hPε hε₁ (mem_offDiag.1 x.2).2.2 h
 
 /-- The increment partition has energy greater than the original one by a known fixed amount. -/
-theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ P.parts.card)
-    (hPε : 100 ≤ 4 ^ P.parts.card * ε ^ 5) (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α)
+theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ #P.parts)
+    (hPε : 100 ≤ 4 ^ #P.parts * ε ^ 5) (hPα : #P.parts * 16 ^ #P.parts ≤ card α)
     (hPG : ¬P.IsUniform G ε) (hε₀ : 0 ≤ ε) (hε₁ : ε ≤ 1) :
     ↑(P.energy G) + ε ^ 5 / 4 ≤ (increment hP G ε).energy G := by
   calc
     _ = (∑ x ∈ P.parts.offDiag, (G.edgeDensity x.1 x.2 : ℝ) ^ 2 +
-          P.parts.card ^ 2 * (ε ^ 5 / 4) : ℝ) / P.parts.card ^ 2 := by
+          #P.parts ^ 2 * (ε ^ 5 / 4) : ℝ) / #P.parts ^ 2 := by
         rw [coe_energy, add_div, mul_div_cancel_left₀]; positivity
     _ ≤ (∑ x ∈ P.parts.offDiag.attach, (∑ i ∈ distinctPairs hP G ε x,
-          G.edgeDensity i.1 i.2 ^ 2 : ℝ) / 16 ^ P.parts.card) / P.parts.card ^ 2 := ?_
+          G.edgeDensity i.1 i.2 ^ 2 : ℝ) / 16 ^ #P.parts) / #P.parts ^ 2 := ?_
     _ = (∑ x ∈ P.parts.offDiag.attach, ∑ i ∈ distinctPairs hP G ε x,
-          G.edgeDensity i.1 i.2 ^ 2 : ℝ) / (increment hP G ε).parts.card ^ 2 := by
+          G.edgeDensity i.1 i.2 ^ 2 : ℝ) / #(increment hP G ε).parts ^ 2 := by
         rw [card_increment hPα hPG, coe_stepBound, mul_pow, pow_right_comm,
           div_mul_eq_div_div_swap, ← sum_div]; norm_num
     _ ≤ _ := by
@@ -153,7 +153,7 @@ theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ P.parts.card)
   rw [Finpartition.IsUniform, not_le, mul_tsub, mul_one, ← offDiag_card] at hPG
   calc
     _ ≤ ∑ x ∈ P.parts.offDiag, (edgeDensity G x.1 x.2 : ℝ) ^ 2 +
-        ((nonUniforms P G ε).card * (ε ^ 4 / 3) - P.parts.offDiag.card * (ε ^ 5 / 25)) :=
+        (#(nonUniforms P G ε) * (ε ^ 4 / 3) - #P.parts.offDiag * (ε ^ 5 / 25)) :=
         add_le_add_left ?_ _
     _ = ∑ x ∈ P.parts.offDiag, ((G.edgeDensity x.1 x.2 : ℝ) ^ 2 +
         ((if G.IsUniform ε x.1 x.2 then (0 : ℝ) else ε ^ 4 / 3) - ε ^ 5 / 25) : ℝ) := by
@@ -163,8 +163,8 @@ theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ P.parts.card)
     _ = _ := (sum_attach ..).symm
     _ ≤ _ := sum_le_sum fun i _ ↦ le_sum_distinctPairs_edgeDensity_sq i hε₁ hPα hPε
   calc
-    _ = (6/7 * P.parts.card ^ 2) * ε ^ 5 * (7 / 24) := by ring
-    _ ≤ P.parts.offDiag.card * ε ^ 5 * (22 / 75) := by
+    _ = (6/7 * #P.parts ^ 2) * ε ^ 5 * (7 / 24) := by ring
+    _ ≤ #P.parts.offDiag * ε ^ 5 * (22 / 75) := by
         gcongr ?_ * _ * ?_
         · rw [← mul_div_right_comm, div_le_iff₀ (by norm_num), offDiag_card]
           norm_cast
@@ -172,7 +172,7 @@ theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ P.parts.card)
           refine le_tsub_of_add_le_left ?_
           nlinarith
         · norm_num
-    _ = (P.parts.offDiag.card * ε * (ε ^ 4 / 3) - P.parts.offDiag.card * (ε ^ 5 / 25)) := by ring
-    _ ≤ ((nonUniforms P G ε).card * (ε ^ 4 / 3) - P.parts.offDiag.card * (ε ^ 5 / 25)) := by gcongr
+    _ = (#P.parts.offDiag * ε * (ε ^ 4 / 3) - #P.parts.offDiag * (ε ^ 5 / 25)) := by ring
+    _ ≤ (#(nonUniforms P G ε) * (ε ^ 4 / 3) - #P.parts.offDiag * (ε ^ 5 / 25)) := by gcongr
 
 end SzemerediRegularity

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Lemma.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Lemma.lean
@@ -71,7 +71,7 @@ variable {α : Type*} [DecidableEq α] [Fintype α] (G : SimpleGraph α) [Decida
 `ε`-uniform equipartition of bounded size (where the bound does not depend on the graph). -/
 theorem szemeredi_regularity (hε : 0 < ε) (hl : l ≤ card α) :
     ∃ P : Finpartition univ,
-      P.IsEquipartition ∧ l ≤ P.parts.card ∧ P.parts.card ≤ bound ε l ∧ P.IsUniform G ε := by
+      P.IsEquipartition ∧ l ≤ #P.parts ∧ #P.parts ≤ bound ε l ∧ P.IsUniform G ε := by
   obtain hα | hα := le_total (card α) (bound ε l)
   -- If `card α ≤ bound ε l`, then the partition into singletons is acceptable.
   · refine ⟨⊥, bot_isEquipartition _, ?_⟩
@@ -79,7 +79,7 @@ theorem szemeredi_regularity (hε : 0 < ε) (hl : l ≤ card α) :
     exact ⟨hl, hα, bot_isUniform _ hε⟩
   -- Else, let's start from a dummy equipartition of size `initialBound ε l`.
   let t := initialBound ε l
-  have htα : t ≤ (univ : Finset α).card :=
+  have htα : t ≤ #(univ : Finset α) :=
     (initialBound_le_bound _ _).trans (by rwa [Finset.card_univ])
   obtain ⟨dum, hdum₁, hdum₂⟩ :=
     exists_equipartition_card_eq (univ : Finset α) (initialBound_pos _ _).ne' htα
@@ -93,8 +93,8 @@ theorem szemeredi_regularity (hε : 0 < ε) (hl : l ≤ card α) :
   have : Nonempty α := by
     rw [← Fintype.card_pos_iff]
     exact (bound_pos _ _).trans_le hα
-  suffices h : ∀ i, ∃ P : Finpartition (univ : Finset α), P.IsEquipartition ∧ t ≤ P.parts.card ∧
-    P.parts.card ≤ stepBound^[i] t ∧ (P.IsUniform G ε ∨ ε ^ 5 / 4 * i ≤ P.energy G) by
+  suffices h : ∀ i, ∃ P : Finpartition (univ : Finset α), P.IsEquipartition ∧ t ≤ #P.parts ∧
+    #P.parts ≤ stepBound^[i] t ∧ (P.IsUniform G ε ∨ ε ^ 5 / 4 * i ≤ P.energy G) by
   -- For `i > 4 / ε ^ 5` we know that the partition we get can't have energy `≥ ε ^ 5 / 4 * i > 1`,
   -- so it must instead be `ε`-uniform and we won.
     obtain ⟨P, hP₁, hP₂, hP₃, hP₄⟩ := h (⌊4 / ε ^ 5⌋₊ + 1)
@@ -126,7 +126,7 @@ theorem szemeredi_regularity (hε : 0 < ε) (hl : l ≤ card α) :
   -- Else, `P` must instead have energy at least `ε ^ 5 / 4 * i`.
   replace hP₄ := hP₄.resolve_left huniform
   -- We gather a few numerical facts.
-  have hεl' : 100 ≤ 4 ^ P.parts.card * ε ^ 5 :=
+  have hεl' : 100 ≤ 4 ^ #P.parts * ε ^ 5 :=
     (hundred_lt_pow_initialBound_mul hε l).le.trans
       (mul_le_mul_of_nonneg_right (pow_right_mono₀ (by norm_num) hP₂) <| by positivity)
   have hi : (i : ℝ) ≤ 4 / ε ^ 5 := by
@@ -134,9 +134,9 @@ theorem szemeredi_regularity (hε : 0 < ε) (hl : l ≤ card α) :
     rw [div_mul_eq_mul_div, div_le_iff₀ (show (0 : ℝ) < 4 by norm_num)] at hi
     norm_num at hi
     rwa [le_div_iff₀' (pow_pos hε _)]
-  have hsize : P.parts.card ≤ stepBound^[⌊4 / ε ^ 5⌋₊] t :=
+  have hsize : #P.parts ≤ stepBound^[⌊4 / ε ^ 5⌋₊] t :=
     hP₃.trans (monotone_iterate_of_id_le le_stepBound (Nat.le_floor hi) _)
-  have hPα : P.parts.card * 16 ^ P.parts.card ≤ card α :=
+  have hPα : #P.parts * 16 ^ #P.parts ≤ card α :=
     (Nat.mul_le_mul hsize (Nat.pow_le_pow_of_le_right (by norm_num) hsize)).trans hα
   -- We return the increment equipartition of `P`, which has energy `≥ ε ^ 5 / 4 * (i + 1)`.
   refine ⟨increment hP₁ G ε, increment_isEquipartition hP₁ G ε, ?_, ?_, Or.inr <| le_trans ?_ <|

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
@@ -55,8 +55,8 @@ variable (G : SimpleGraph α) [DecidableRel G.Adj] (ε : 𝕜) {s t : Finset α}
 to the density of any big enough pair of subsets. Intuitively, the edges between them are
 random-like. -/
 def IsUniform (s t : Finset α) : Prop :=
-  ∀ ⦃s'⦄, s' ⊆ s → ∀ ⦃t'⦄, t' ⊆ t → (s.card : 𝕜) * ε ≤ s'.card →
-    (t.card : 𝕜) * ε ≤ t'.card → |(G.edgeDensity s' t' : 𝕜) - (G.edgeDensity s t : 𝕜)| < ε
+  ∀ ⦃s'⦄, s' ⊆ s → ∀ ⦃t'⦄, t' ⊆ t → (#s : 𝕜) * ε ≤ #s' →
+    (#t : 𝕜) * ε ≤ #t' → |(G.edgeDensity s' t' : 𝕜) - (G.edgeDensity s t : 𝕜)| < ε
 
 variable {G ε}
 
@@ -105,8 +105,8 @@ theorem not_isUniform_zero : ¬G.IsUniform (0 : 𝕜) s t := fun h =>
   (abs_nonneg _).not_lt <| h (empty_subset _) (empty_subset _) (by simp) (by simp)
 
 theorem not_isUniform_iff :
-    ¬G.IsUniform ε s t ↔ ∃ s', s' ⊆ s ∧ ∃ t', t' ⊆ t ∧ ↑s.card * ε ≤ s'.card ∧
-      ↑t.card * ε ≤ t'.card ∧ ε ≤ |G.edgeDensity s' t' - G.edgeDensity s t| := by
+    ¬G.IsUniform ε s t ↔ ∃ s', s' ⊆ s ∧ ∃ t', t' ⊆ t ∧ #s * ε ≤ #s' ∧
+      #t * ε ≤ #t' ∧ ε ≤ |G.edgeDensity s' t' - G.edgeDensity s t| := by
   unfold IsUniform
   simp only [not_forall, not_lt, exists_prop, exists_and_left, Rat.cast_abs, Rat.cast_sub]
 
@@ -128,7 +128,7 @@ theorem left_nonuniformWitnesses_subset (h : ¬G.IsUniform ε s t) :
   exact (not_isUniform_iff.1 h).choose_spec.1
 
 theorem left_nonuniformWitnesses_card (h : ¬G.IsUniform ε s t) :
-    (s.card : 𝕜) * ε ≤ (G.nonuniformWitnesses ε s t).1.card := by
+    #s * ε ≤ #(G.nonuniformWitnesses ε s t).1 := by
   rw [nonuniformWitnesses, dif_pos h]
   exact (not_isUniform_iff.1 h).choose_spec.2.choose_spec.2.1
 
@@ -138,7 +138,7 @@ theorem right_nonuniformWitnesses_subset (h : ¬G.IsUniform ε s t) :
   exact (not_isUniform_iff.1 h).choose_spec.2.choose_spec.1
 
 theorem right_nonuniformWitnesses_card (h : ¬G.IsUniform ε s t) :
-    (t.card : 𝕜) * ε ≤ (G.nonuniformWitnesses ε s t).2.card := by
+    #t * ε ≤ #(G.nonuniformWitnesses ε s t).2 := by
   rw [nonuniformWitnesses, dif_pos h]
   exact (not_isUniform_iff.1 h).choose_spec.2.choose_spec.2.2.1
 
@@ -162,7 +162,7 @@ theorem nonuniformWitness_subset (h : ¬G.IsUniform ε s t) : G.nonuniformWitnes
   · exact G.right_nonuniformWitnesses_subset fun i => h i.symm
 
 theorem le_card_nonuniformWitness (h : ¬G.IsUniform ε s t) :
-    (s.card : 𝕜) * ε ≤ (G.nonuniformWitness ε s t).card := by
+    #s * ε ≤ #(G.nonuniformWitness ε s t) := by
   unfold nonuniformWitness
   split_ifs
   · exact G.left_nonuniformWitnesses_card h
@@ -224,7 +224,7 @@ theorem nonUniforms_bot (hε : 0 < ε) : (⊥ : Finpartition A).nonUniforms G ε
 /-- A finpartition of a graph's vertex set is `ε`-uniform (aka `ε`-regular) iff the proportion of
 its pairs of parts that are not `ε`-uniform is at most `ε`. -/
 def IsUniform (ε : 𝕜) : Prop :=
-  ((P.nonUniforms G ε).card : 𝕜) ≤ (P.parts.card * (P.parts.card - 1) : ℕ) * ε
+  (#(P.nonUniforms G ε) : 𝕜) ≤ (#P.parts * (#P.parts - 1) : ℕ) * ε
 
 lemma bot_isUniform (hε : 0 < ε) : (⊥ : Finpartition A).IsUniform G ε := by
   rw [Finpartition.IsUniform, Finpartition.card_bot, nonUniforms_bot _ hε, Finset.card_empty,
@@ -252,7 +252,7 @@ variable (P G ε) (s : Finset α)
 
 /-- A choice of witnesses of non-uniformity among the parts of a finpartition. -/
 noncomputable def nonuniformWitnesses : Finset (Finset α) :=
-  (P.parts.filter fun t => s ≠ t ∧ ¬G.IsUniform ε s t).image (G.nonuniformWitness ε s)
+  {t ∈ P.parts | s ≠ t ∧ ¬G.IsUniform ε s t}.image (G.nonuniformWitness ε s)
 
 variable {P G ε s} {t : Finset α}
 
@@ -265,11 +265,10 @@ theorem nonuniformWitness_mem_nonuniformWitnesses (h : ¬G.IsUniform ε s t) (ht
 open SimpleGraph in
 lemma IsEquipartition.card_interedges_sparsePairs_le' (hP : P.IsEquipartition)
     (hε : 0 ≤ ε) :
-    ((P.sparsePairs G ε).biUnion fun (U, V) ↦ G.interedges U V).card ≤
-      ε * (A.card + P.parts.card) ^ 2 := by
+    #((P.sparsePairs G ε).biUnion fun (U, V) ↦ G.interedges U V) ≤ ε * (#A + #P.parts) ^ 2 := by
   calc
-    _ ≤ ∑ UV ∈ P.sparsePairs G ε, ((G.interedges UV.1 UV.2).card : 𝕜) := mod_cast card_biUnion_le
-    _ ≤ ∑ UV ∈ P.sparsePairs G ε, ε * (UV.1.card * UV.2.card) := ?_
+    _ ≤ ∑ UV ∈ P.sparsePairs G ε, (#(G.interedges UV.1 UV.2) : 𝕜) := mod_cast card_biUnion_le
+    _ ≤ ∑ UV ∈ P.sparsePairs G ε, ε * (#UV.1 * #UV.2) := ?_
     _ ≤ _ := sum_le_sum_of_subset_of_nonneg (filter_subset _ _) fun i _ _ ↦ by positivity
     _ = _ := (mul_sum _ _ _).symm
     _ ≤ _ := mul_le_mul_of_nonneg_left ?_ hε
@@ -281,9 +280,9 @@ lemma IsEquipartition.card_interedges_sparsePairs_le' (hP : P.IsEquipartition)
       (Nat.cast_pos.2 (P.nonempty_of_mem_parts hUV.2.1).card_pos)
   norm_cast
   calc
-    (_ : ℕ) ≤ _ := sum_le_card_nsmul P.parts.offDiag (fun i ↦ i.1.card * i.2.card)
-            ((A.card / P.parts.card + 1)^2 : ℕ) ?_
-    _ ≤ (P.parts.card * (A.card / P.parts.card) + P.parts.card) ^ 2 := ?_
+    (_ : ℕ) ≤ _ := sum_le_card_nsmul P.parts.offDiag (fun i ↦ #i.1 * #i.2)
+            ((#A / #P.parts + 1)^2 : ℕ) ?_
+    _ ≤ (#P.parts * (#A / #P.parts) + #P.parts) ^ 2 := ?_
     _ ≤ _ := Nat.pow_le_pow_of_le_left (add_le_add_right (Nat.mul_div_le _ _) _) _
   · simp only [Prod.forall, Finpartition.mk_mem_nonUniforms, and_imp, mem_offDiag, sq]
     rintro U V hU hV -
@@ -293,10 +292,10 @@ lemma IsEquipartition.card_interedges_sparsePairs_le' (hP : P.IsEquipartition)
     exact Nat.sub_le _ _
 
 lemma IsEquipartition.card_interedges_sparsePairs_le (hP : P.IsEquipartition) (hε : 0 ≤ ε) :
-    ((P.sparsePairs G ε).biUnion fun (U, V) ↦ G.interedges U V).card ≤ 4 * ε * A.card ^ 2 := by
+    #((P.sparsePairs G ε).biUnion fun (U, V) ↦ G.interedges U V) ≤ 4 * ε * #A ^ 2 := by
   calc
     _ ≤ _ := hP.card_interedges_sparsePairs_le' hε
-    _ ≤ ε * (A.card + A.card)^2 := by gcongr; exact P.card_parts_le_card
+    _ ≤ ε * (#A + #A)^2 := by gcongr; exact P.card_parts_le_card
     _ = _ := by ring
 
 private lemma aux {i j : ℕ} (hj : 0 < j) : j * (j - 1) * (i / j + 1) ^ 2 < (i + j) ^ 2 := by
@@ -307,44 +306,44 @@ private lemma aux {i j : ℕ} (hj : 0 < j) : j * (j - 1) * (i / j + 1) ^ 2 < (i 
   exact Nat.pow_le_pow_of_le_left (add_le_add_right (Nat.mul_div_le i j) _) _
 
 lemma IsEquipartition.card_biUnion_offDiag_le' (hP : P.IsEquipartition) :
-    ((P.parts.biUnion offDiag).card : 𝕜) ≤ A.card * (A.card + P.parts.card) / P.parts.card := by
+    (#(P.parts.biUnion offDiag) : 𝕜) ≤ #A * (#A + #P.parts) / #P.parts := by
   obtain h | h := P.parts.eq_empty_or_nonempty
   · simp [h]
   calc
-    _ ≤ (P.parts.card : 𝕜) * (↑(A.card / P.parts.card) * ↑(A.card / P.parts.card + 1)) :=
+    _ ≤ (#P.parts : 𝕜) * (↑(#A / #P.parts) * ↑(#A / #P.parts + 1)) :=
         mod_cast card_biUnion_le_card_mul _ _ _ fun U hU ↦ ?_
-    _ = P.parts.card * ↑(A.card / P.parts.card) * ↑(A.card / P.parts.card + 1) := by rw [mul_assoc]
-    _ ≤ A.card * (A.card / P.parts.card + 1) :=
+    _ = #P.parts * ↑(#A / #P.parts) * ↑(#A / #P.parts + 1) := by rw [mul_assoc]
+    _ ≤ #A * (#A / #P.parts + 1) :=
         mul_le_mul (mod_cast Nat.mul_div_le _ _) ?_ (by positivity) (by positivity)
     _ = _ := by rw [← div_add_same (mod_cast h.card_pos.ne'), mul_div_assoc]
   · simpa using Nat.cast_div_le
-  suffices (U.card - 1) * U.card ≤ A.card / P.parts.card * (A.card / P.parts.card + 1) by
+  suffices (#U - 1) * #U ≤ #A / #P.parts * (#A / #P.parts + 1) by
     rwa [Nat.mul_sub_right_distrib, one_mul, ← offDiag_card] at this
   have := hP.card_part_le_average_add_one hU
   refine Nat.mul_le_mul ((Nat.sub_le_sub_right this 1).trans ?_) this
   simp only [Nat.add_succ_sub_one, add_zero, card_univ, le_rfl]
 
 lemma IsEquipartition.card_biUnion_offDiag_le (hε : 0 < ε) (hP : P.IsEquipartition)
-    (hP' : 4 / ε ≤ P.parts.card) : (P.parts.biUnion offDiag).card ≤ ε / 2 * A.card ^ 2 := by
+    (hP' : 4 / ε ≤ #P.parts) : #(P.parts.biUnion offDiag) ≤ ε / 2 * #A ^ 2 := by
   obtain rfl | hA : A = ⊥ ∨ _ := A.eq_empty_or_nonempty
   · simp [Subsingleton.elim P ⊥]
   apply hP.card_biUnion_offDiag_le'.trans
   rw [div_le_iff₀ (Nat.cast_pos.2 (P.parts_nonempty hA.ne_empty).card_pos)]
-  have : (A.card : 𝕜) + P.parts.card ≤ 2 * A.card := by
+  have : (#A : 𝕜) + #P.parts ≤ 2 * #A := by
     rw [two_mul]; exact add_le_add_left (Nat.cast_le.2 P.card_parts_le_card) _
   refine (mul_le_mul_of_nonneg_left this <| by positivity).trans ?_
-  suffices 1 ≤ ε/4 * P.parts.card by
+  suffices 1 ≤ ε/4 * #P.parts by
     rw [mul_left_comm, ← sq]
-    convert mul_le_mul_of_nonneg_left this (mul_nonneg zero_le_two <| sq_nonneg (A.card : 𝕜))
+    convert mul_le_mul_of_nonneg_left this (mul_nonneg zero_le_two <| sq_nonneg (#A : 𝕜))
       using 1 <;> ring
   rwa [← div_le_iff₀', one_div_div]
   positivity
 
 lemma IsEquipartition.sum_nonUniforms_lt' (hA : A.Nonempty) (hε : 0 < ε) (hP : P.IsEquipartition)
     (hG : P.IsUniform G ε) :
-    ∑ i ∈ P.nonUniforms G ε, (i.1.card * i.2.card : 𝕜) < ε * (A.card + P.parts.card) ^ 2 := by
+    ∑ i ∈ P.nonUniforms G ε, (#i.1 * #i.2 : 𝕜) < ε * (#A + #P.parts) ^ 2 := by
   calc
-    _ ≤ (P.nonUniforms G ε).card • (↑(A.card / P.parts.card + 1) : 𝕜) ^ 2 :=
+    _ ≤ #(P.nonUniforms G ε) • (↑(#A / #P.parts + 1) : 𝕜) ^ 2 :=
       sum_le_card_nsmul _ _ _ ?_
     _ = _ := nsmul_eq_mul _ _
     _ ≤ _ := mul_le_mul_of_nonneg_right hG <| by positivity
@@ -361,12 +360,12 @@ lemma IsEquipartition.sum_nonUniforms_lt' (hA : A.Nonempty) (hε : 0 < ε) (hP :
 
 lemma IsEquipartition.sum_nonUniforms_lt (hA : A.Nonempty) (hε : 0 < ε) (hP : P.IsEquipartition)
     (hG : P.IsUniform G ε) :
-    ((P.nonUniforms G ε).biUnion fun (U, V) ↦ U ×ˢ V).card < 4 * ε * A.card ^ 2 := by
+    #((P.nonUniforms G ε).biUnion fun (U, V) ↦ U ×ˢ V) < 4 * ε * #A ^ 2 := by
   calc
-    _ ≤ ∑ i ∈ P.nonUniforms G ε, (i.1.card * i.2.card : 𝕜) := by
+    _ ≤ ∑ i ∈ P.nonUniforms G ε, (#i.1 * #i.2 : 𝕜) := by
         norm_cast; simp_rw [← card_product]; exact card_biUnion_le
     _ < _ := hP.sum_nonUniforms_lt' hA hε hG
-    _ ≤ ε * (A.card + A.card) ^ 2 := by gcongr; exact P.card_parts_le_card
+    _ ≤ ε * (#A + #A) ^ 2 := by gcongr; exact P.card_parts_le_card
     _ = _ := by ring
 
 end Finpartition

--- a/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
@@ -77,7 +77,7 @@ theorem IsSRGWith.top :
   of_not_adj := fun v w h h' => False.elim (h' ((top_adj v w).2 h))
 
 theorem IsSRGWith.card_neighborFinset_union_eq {v w : V} (h : G.IsSRGWith n k ℓ μ) :
-    (G.neighborFinset v ∪ G.neighborFinset w).card =
+    #(G.neighborFinset v ∪ G.neighborFinset w) =
       2 * k - Fintype.card (G.commonNeighbors v w) := by
   apply Nat.add_right_cancel (m := Fintype.card (G.commonNeighbors v w))
   rw [Nat.sub_add_cancel, ← Set.toFinset_card]
@@ -94,12 +94,12 @@ adjacent to either `v` or `w` when `¬G.Adj v w`. So it's the cardinality of
 `G.neighborSet v ∪ G.neighborSet w`. -/
 theorem IsSRGWith.card_neighborFinset_union_of_not_adj {v w : V} (h : G.IsSRGWith n k ℓ μ)
     (hne : v ≠ w) (ha : ¬G.Adj v w) :
-    (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - μ := by
+    #(G.neighborFinset v ∪ G.neighborFinset w) = 2 * k - μ := by
   rw [← h.of_not_adj hne ha]
   apply h.card_neighborFinset_union_eq
 
 theorem IsSRGWith.card_neighborFinset_union_of_adj {v w : V} (h : G.IsSRGWith n k ℓ μ)
-    (ha : G.Adj v w) : (G.neighborFinset v ∪ G.neighborFinset w).card = 2 * k - ℓ := by
+    (ha : G.Adj v w) : #(G.neighborFinset v ∪ G.neighborFinset w) = 2 * k - ℓ := by
   rw [← h.of_adj v w ha]
   apply h.card_neighborFinset_union_eq
 
@@ -172,11 +172,7 @@ theorem IsSRGWith.param_eq
   · simp [h.compl.regular v]
   · intro w hw
     rw [mem_neighborFinset] at hw
-    simp_rw [bipartiteAbove]
-    -- This used to be part of the enclosing `simp_rw` chain,
-    -- but after leanprover/lean4#3124 it caused a maximum recursion depth error.
-    change Finset.card (filter (fun a => Adj G w a) _) = _
-    simp_rw [← mem_neighborFinset, filter_mem_eq_inter]
+    simp_rw [bipartiteAbove, ← mem_neighborFinset, filter_mem_eq_inter]
     have s : {v} ⊆ G.neighborFinset w \ G.neighborFinset v := by
       rw [singleton_subset_iff, mem_sdiff, mem_neighborFinset]
       exact ⟨hw.symm, G.not_mem_neighborFinset_self v⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
@@ -133,19 +133,19 @@ alias ⟨EdgeDisjointTriangles.mem_sym2_subsingleton, _⟩ :=
 variable [DecidableEq α] [Fintype α] [DecidableRel G.Adj]
 
 instance EdgeDisjointTriangles.instDecidable : Decidable G.EdgeDisjointTriangles :=
-  decidable_of_iff ((G.cliqueFinset 3 : Set (Finset α)).Pairwise fun x y ↦ ((x ∩ y).card ≤ 1)) <| by
+  decidable_of_iff ((G.cliqueFinset 3 : Set (Finset α)).Pairwise fun x y ↦ (#(x ∩ y) ≤ 1)) <| by
     simp only [coe_cliqueFinset, EdgeDisjointTriangles, Finset.card_le_one, ← coe_inter]; rfl
 
 instance LocallyLinear.instDecidable : Decidable G.LocallyLinear :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 lemma EdgeDisjointTriangles.card_edgeFinset_le (hG : G.EdgeDisjointTriangles) :
-    3 * (G.cliqueFinset 3).card ≤ G.edgeFinset.card := by
-  rw [mul_comm, ← mul_one G.edgeFinset.card]
+    3 * #(G.cliqueFinset 3) ≤ #G.edgeFinset := by
+  rw [mul_comm, ← mul_one #G.edgeFinset]
   refine card_mul_le_card_mul (fun s e ↦ e ∈ s.sym2) ?_ (fun e he ↦ ?_)
   · simp only [is3Clique_iff, mem_cliqueFinset_iff, mem_sym2_iff, forall_exists_index, and_imp]
     rintro _ a b c hab hac hbc rfl
-    have : Finset.card ({s(a, b), s(a, c), s(b, c)} : Finset (Sym2 α)) = 3 := by
+    have : #{s(a, b), s(a, c), s(b, c)} = 3 := by
       refine card_eq_three.2 ⟨_, _, _, ?_, ?_, ?_, rfl⟩ <;> simp [hab.ne, hac.ne, hbc.ne]
     rw [← this]
     refine card_mono ?_
@@ -155,9 +155,9 @@ lemma EdgeDisjointTriangles.card_edgeFinset_le (hG : G.EdgeDisjointTriangles) :
       using hG.mem_sym2_subsingleton (G.not_isDiag_of_mem_edgeSet <| mem_edgeFinset.1 he)
 
 lemma LocallyLinear.card_edgeFinset (hG : G.LocallyLinear) :
-    G.edgeFinset.card = 3 * (G.cliqueFinset 3).card := by
+    #G.edgeFinset = 3 * #(G.cliqueFinset 3) := by
   refine hG.edgeDisjointTriangles.card_edgeFinset_le.antisymm' ?_
-  rw [← mul_comm, ← mul_one (Finset.card _)]
+  rw [← mul_comm, ← mul_one #_]
   refine card_mul_le_card_mul (fun e s ↦ e ∈ s.sym2) ?_ ?_
   · simpa [Sym2.forall, Nat.one_le_iff_ne_zero, -Finset.card_eq_zero, Finset.card_ne_zero,
         Finset.Nonempty]
@@ -165,7 +165,7 @@ lemma LocallyLinear.card_edgeFinset (hG : G.LocallyLinear) :
   simp only [mem_cliqueFinset_iff, is3Clique_iff, forall_exists_index, and_imp]
   rintro _ a b c hab hac hbc rfl
   calc
-    _ ≤ ({s(a, b), s(a, c), s(b, c)} : Finset _).card := card_le_card ?_
+    _ ≤ #{s(a, b), s(a, c), s(b, c)} := card_le_card ?_
     _ ≤ 3 := (card_insert_le _ _).trans (succ_le_succ <| (card_insert_le _ _).trans_eq <| by
       rw [card_singleton])
   simp only [subset_iff, Sym2.forall, mem_sym2_iff, le_eq_subset, mem_bipartiteBelow, mem_insert,
@@ -186,7 +186,7 @@ variable {G ε}
 
 theorem farFromTriangleFree_iff :
     G.FarFromTriangleFree ε ↔ ∀ ⦃H : SimpleGraph α⦄, [DecidableRel H.Adj] → H ≤ G → H.CliqueFree 3 →
-      ε * (card α ^ 2 : ℕ) ≤ G.edgeFinset.card - H.edgeFinset.card := deleteFar_iff
+      ε * (card α ^ 2 : ℕ) ≤ #G.edgeFinset - #H.edgeFinset := deleteFar_iff
 
 alias ⟨farFromTriangleFree.le_card_sub_card, _⟩ := farFromTriangleFree_iff
 
@@ -198,7 +198,7 @@ section DecidableEq
 variable [DecidableEq α]
 
 theorem FarFromTriangleFree.cliqueFinset_nonempty' (hH : H ≤ G) (hG : G.FarFromTriangleFree ε)
-    (hcard : G.edgeFinset.card - H.edgeFinset.card < ε * (card α ^ 2 : ℕ)) :
+    (hcard : #G.edgeFinset - #H.edgeFinset < ε * (card α ^ 2 : ℕ)) :
     (H.cliqueFinset 3).Nonempty :=
   nonempty_of_ne_empty <|
     cliqueFinset_eq_empty_iff.not.2 fun hH' => (hG.le_card_sub_card hH hH').not_lt hcard
@@ -206,7 +206,7 @@ theorem FarFromTriangleFree.cliqueFinset_nonempty' (hH : H ≤ G) (hG : G.FarFro
 private lemma farFromTriangleFree_of_disjoint_triangles_aux {tris : Finset (Finset α)}
     (htris : tris ⊆ G.cliqueFinset 3)
     (pd : (tris : Set (Finset α)).Pairwise fun x y ↦ (x ∩ y : Set α).Subsingleton) (hHG : H ≤ G)
-    (hH : H.CliqueFree 3) : tris.card ≤ G.edgeFinset.card - H.edgeFinset.card := by
+    (hH : H.CliqueFree 3) : #tris ≤ #G.edgeFinset - #H.edgeFinset := by
   rw [← card_sdiff (edgeFinset_mono hHG), ← card_attach]
   by_contra! hG
   have ⦃t⦄ (ht : t ∈ tris) :
@@ -234,7 +234,7 @@ triangle-free. -/
 lemma farFromTriangleFree_of_disjoint_triangles (tris : Finset (Finset α))
     (htris : tris ⊆ G.cliqueFinset 3)
     (pd : (tris : Set (Finset α)).Pairwise fun x y ↦ (x ∩ y : Set α).Subsingleton)
-    (tris_big : ε * (card α ^ 2 : ℕ) ≤ tris.card) :
+    (tris_big : ε * (card α ^ 2 : ℕ) ≤ #tris) :
     G.FarFromTriangleFree ε := by
   rw [farFromTriangleFree_iff]
   intros H _ hG hH
@@ -243,7 +243,7 @@ lemma farFromTriangleFree_of_disjoint_triangles (tris : Finset (Finset α))
     (Nat.cast_le.2 <| farFromTriangleFree_of_disjoint_triangles_aux htris pd hG hH)
 
 protected lemma EdgeDisjointTriangles.farFromTriangleFree (hG : G.EdgeDisjointTriangles)
-    (tris_big : ε * (card α ^ 2 : ℕ) ≤ (G.cliqueFinset 3).card) :
+    (tris_big : ε * (card α ^ 2 : ℕ) ≤ #(G.cliqueFinset 3)) :
     G.FarFromTriangleFree ε :=
   farFromTriangleFree_of_disjoint_triangles _ Subset.rfl (by simpa using hG) tris_big
 
@@ -258,16 +258,16 @@ lemma FarFromTriangleFree.lt_half (hG : G.FarFromTriangleFree ε) : ε < 2⁻¹ 
   have hε₀ : 0 < ε := hε.trans_lt' (by norm_num)
   rw [inv_le_iff_one_le_mul₀ (zero_lt_two' 𝕜)] at hε
   calc
-    _ ≤ (G.edgeFinset.card : 𝕜) := by
+    _ ≤ (#G.edgeFinset : 𝕜) := by
       simpa using hG.le_card_sub_card bot_le (cliqueFree_bot (le_succ _))
-    _ ≤ ε * 2 * (edgeFinset G).card := le_mul_of_one_le_left (by positivity) (by assumption)
+    _ ≤ ε * 2 * #G.edgeFinset := le_mul_of_one_le_left (by positivity) (by assumption)
     _ < ε * card α ^ 2 := ?_
   rw [mul_assoc, mul_lt_mul_left hε₀]
   norm_cast
   calc
     _ ≤ 2 * (⊤ : SimpleGraph α).edgeFinset.card := by gcongr; exact le_top
     _ < card α ^ 2 := ?_
-  rw [edgeFinset_top, filter_not, card_sdiff (subset_univ _), card_univ, Sym2.card,]
+  rw [edgeFinset_top, filter_not, card_sdiff (subset_univ _), card_univ, Sym2.card]
   simp_rw [choose_two_right, Nat.add_sub_cancel, Nat.mul_comm _ (card α),
     funext (propext <| Sym2.isDiag_iff_mem_range_diag ·), univ_filter_mem_range, mul_tsub,
     Nat.mul_div_cancel' (card α).even_mul_succ_self.two_dvd]

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Counting.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Counting.lean
@@ -29,15 +29,15 @@ namespace SimpleGraph
 
 /-- The vertices of `s` whose density in `t` is `ε` less than expected. -/
 private noncomputable def badVertices (ε : ℝ) (s t : Finset α) : Finset α :=
-  s.filter fun x ↦ (t.filter <| G.Adj x).card < (G.edgeDensity s t - ε) * t.card
+  {x ∈ s | #{y ∈ t | G.Adj x y} < (G.edgeDensity s t - ε) * #t}
 
 private lemma card_interedges_badVertices_le :
-    (Rel.interedges G.Adj (badVertices G ε s t) t).card ≤
-      (badVertices G ε s t).card * t.card * (G.edgeDensity s t - ε) := by
+    #(Rel.interedges G.Adj (badVertices G ε s t) t) ≤
+      #(badVertices G ε s t) * #t * (G.edgeDensity s t - ε) := by
   classical
   refine (Nat.cast_le.2 <| (card_le_card <| subset_of_eq (Rel.interedges_eq_biUnion _)).trans
     card_biUnion_le).trans ?_
-  simp_rw [Nat.cast_sum, card_map, ← nsmul_eq_mul, smul_mul_assoc, mul_comm (t.card : ℝ)]
+  simp_rw [Nat.cast_sum, card_map, ← nsmul_eq_mul, smul_mul_assoc, mul_comm (#t : ℝ)]
   exact sum_le_card_nsmul _ _ _ fun x hx ↦ (mem_filter.1 hx).2.le
 
 private lemma edgeDensity_badVertices_le (hε : 0 ≤ ε) (dst : 2 * ε ≤ G.edgeDensity s t) :
@@ -49,7 +49,7 @@ private lemma edgeDensity_badVertices_le (hε : 0 ≤ ε) (dst : 2 * ε ≤ G.ed
   exact G.card_interedges_badVertices_le
 
 private lemma card_badVertices_le (dst : 2 * ε ≤ G.edgeDensity s t) (hst : G.IsUniform ε s t) :
-    (badVertices G ε s t).card ≤ s.card * ε := by
+    #(badVertices G ε s t) ≤ #s * ε := by
   have hε : ε ≤ 1 := (le_mul_of_one_le_of_le_of_nonneg (by norm_num) le_rfl hst.pos.le).trans
     (dst.trans <| by exact_mod_cast edgeDensity_le_one _ _ _)
   by_contra! h
@@ -61,7 +61,7 @@ private lemma card_badVertices_le (dst : 2 * ε ≤ G.edgeDensity s t) (hst : G.
 /-- A subset of the triangles constructed in a weird way to make them easy to count. -/
 private lemma triangle_split_helper [DecidableEq α] :
     (s \ (badVertices G ε s t ∪ badVertices G ε s u)).biUnion
-      (fun x ↦ (G.interedges (t.filter <| G.Adj x) (u.filter <| G.Adj x)).image (x, ·)) ⊆
+      (fun x ↦ (G.interedges {y ∈ t | G.Adj x y} {y ∈ u | G.Adj x y}).image (x, ·)) ⊆
       (s ×ˢ t ×ˢ u).filter (fun (x, y, z) ↦ G.Adj x y ∧ G.Adj x z ∧ G.Adj y z) := by
   rintro ⟨x, y, z⟩
   simp only [mem_filter, mem_product, mem_biUnion, mem_sdiff, exists_prop, mem_union,
@@ -72,19 +72,19 @@ private lemma triangle_split_helper [DecidableEq α] :
 private lemma good_vertices_triangle_card [DecidableEq α] (dst : 2 * ε ≤ G.edgeDensity s t)
     (dsu : 2 * ε ≤ G.edgeDensity s u) (dtu : 2 * ε ≤ G.edgeDensity t u) (utu : G.IsUniform ε t u)
     (x : α) (hx : x ∈ s \ (badVertices G ε s t ∪ badVertices G ε s u)) :
-    ε ^ 3 * t.card * u.card ≤ (((t.filter (G.Adj x) ×ˢ u.filter (G.Adj x)).filter
-        fun (y, z) ↦ G.Adj y z).image (x, ·)).card := by
+    ε ^ 3 * #t * #u ≤ #((({y ∈ t | G.Adj x y} ×ˢ {y ∈ u | G.Adj x y}).filter
+        fun (y, z) ↦ G.Adj y z).image (x, ·)) := by
   simp only [mem_sdiff, badVertices, mem_union, not_or, mem_filter, not_and_or, not_lt] at hx
   rw [← or_and_left, and_or_left] at hx
   simp only [false_or, and_not_self, mul_comm (_ - _)] at hx
   obtain ⟨-, hxY, hsu⟩ := hx
-  have hY : t.card * ε ≤ (filter (G.Adj x) t).card :=
+  have hY : #t * ε ≤ #{y ∈ t | G.Adj x y} :=
     (mul_le_mul_of_nonneg_left (by linarith) (Nat.cast_nonneg _)).trans hxY
-  have hZ : u.card * ε ≤ (filter (G.Adj x) u).card :=
+  have hZ : #u * ε ≤ #{y ∈ u | G.Adj x y} :=
     (mul_le_mul_of_nonneg_left (by linarith) (Nat.cast_nonneg _)).trans hsu
   rw [card_image_of_injective _ (Prod.mk.inj_left _)]
   have := utu (filter_subset (G.Adj x) _) (filter_subset (G.Adj x) _) hY hZ
-  have : ε ≤ G.edgeDensity (filter (G.Adj x) t) (filter (G.Adj x) u) := by
+  have : ε ≤ G.edgeDensity {y ∈ t | G.Adj x y} {y ∈ u | G.Adj x y} := by
     rw [abs_sub_lt_iff] at this; linarith
   rw [edgeDensity_def] at this
   push_cast at this
@@ -101,11 +101,11 @@ lemma triangle_counting'
     (dst : 2 * ε ≤ G.edgeDensity s t) (hst : G.IsUniform ε s t)
     (dsu : 2 * ε ≤ G.edgeDensity s u) (usu : G.IsUniform ε s u)
     (dtu : 2 * ε ≤ G.edgeDensity t u) (utu : G.IsUniform ε t u) :
-    (1 - 2 * ε) * ε ^ 3 * s.card * t.card * u.card ≤
-      ((s ×ˢ t ×ˢ u).filter fun (a, b, c) ↦ G.Adj a b ∧ G.Adj a c ∧ G.Adj b c).card := by
+    (1 - 2 * ε) * ε ^ 3 * #s * #t * #u ≤
+      #((s ×ˢ t ×ˢ u).filter fun (a, b, c) ↦ G.Adj a b ∧ G.Adj a c ∧ G.Adj b c) := by
   classical
-  have h₁ : (badVertices G ε s t).card ≤ s.card * ε := G.card_badVertices_le dst hst
-  have h₂ : (badVertices G ε s u).card ≤ s.card * ε := G.card_badVertices_le dsu usu
+  have h₁ : #(badVertices G ε s t) ≤ #s * ε := G.card_badVertices_le dst hst
+  have h₂ : #(badVertices G ε s u) ≤ #s * ε := G.card_badVertices_le dsu usu
   let X' := s \ (badVertices G ε s t ∪ badVertices G ε s u)
   have : X'.biUnion _ ⊆ (s ×ˢ t ×ˢ u).filter fun (a, b, c) ↦ G.Adj a b ∧ G.Adj a c ∧ G.Adj b c :=
     triangle_split_helper _
@@ -114,7 +114,7 @@ lemma triangle_counting'
   · apply le_trans _ (card_nsmul_le_sum X' _ _ <| G.good_vertices_triangle_card dst dsu dtu utu)
     rw [nsmul_eq_mul]
     have := hst.pos.le
-    suffices hX' : (1 - 2 * ε) * s.card ≤ X'.card by
+    suffices hX' : (1 - 2 * ε) * #s ≤ #X' by
       exact Eq.trans_le (by ring) (mul_le_mul_of_nonneg_right hX' <| by positivity)
     have i : badVertices G ε s t ∪ badVertices G ε s u ⊆ s :=
       union_subset (filter_subset _ _) (filter_subset _ _)
@@ -155,7 +155,7 @@ lemma triangle_counting
     (dst : 2 * ε ≤ G.edgeDensity s t) (ust : G.IsUniform ε s t) (hst : Disjoint s t)
     (dsu : 2 * ε ≤ G.edgeDensity s u) (usu : G.IsUniform ε s u) (hsu : Disjoint s u)
     (dtu : 2 * ε ≤ G.edgeDensity t u) (utu : G.IsUniform ε t u) (htu : Disjoint t u) :
-    (1 - 2 * ε) * ε ^ 3 * s.card * t.card * u.card ≤ (G.cliqueFinset 3).card := by
+    (1 - 2 * ε) * ε ^ 3 * #s * #t * #u ≤ #(G.cliqueFinset 3) := by
   apply (G.triangle_counting' dst ust dsu usu dtu utu).trans _
   rw [Nat.cast_le]
   refine card_le_card_of_injOn (fun (x, y, z) ↦ {x, y, z}) ?_ ?_

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
@@ -53,21 +53,21 @@ private lemma aux {n k : ℕ} (hk : 0 < k) (hn : k ≤ n) : n < 2 * k * (n / k) 
   apply (mod_lt n hk).trans_le
   simpa using Nat.mul_le_mul_left k ((Nat.one_le_div_iff hk).2 hn)
 
-private lemma card_bound (hP₁ : P.IsEquipartition) (hP₃ : P.parts.card ≤ bound (ε / 8) ⌈4/ε⌉₊)
-    (hX : s ∈ P.parts) : card α / (2 * bound (ε / 8) ⌈4 / ε⌉₊ : ℝ) ≤ s.card := by
+private lemma card_bound (hP₁ : P.IsEquipartition) (hP₃ : #P.parts ≤ bound (ε / 8) ⌈4/ε⌉₊)
+    (hX : s ∈ P.parts) : card α / (2 * bound (ε / 8) ⌈4 / ε⌉₊ : ℝ) ≤ #s := by
   cases isEmpty_or_nonempty α
   · simp [Fintype.card_eq_zero]
   have := Finset.Nonempty.card_pos ⟨_, hX⟩
   calc
-    _ ≤ card α / (2 * P.parts.card : ℝ) := by gcongr
-    _ ≤ ↑(card α / P.parts.card) :=
+    _ ≤ card α / (2 * #P.parts : ℝ) := by gcongr
+    _ ≤ ↑(card α / #P.parts) :=
       (div_le_iff₀' (by positivity)).2 <| mod_cast (aux ‹_› P.card_parts_le_card).le
-    _ ≤ (s.card : ℝ) := mod_cast hP₁.average_le_card_part hX
+    _ ≤ (#s : ℝ) := mod_cast hP₁.average_le_card_part hX
 
 private lemma triangle_removal_aux (hε : 0 < ε) (hP₁ : P.IsEquipartition)
-    (hP₃ : P.parts.card ≤ bound (ε / 8) ⌈4/ε⌉₊)
+    (hP₃ : #P.parts ≤ bound (ε / 8) ⌈4/ε⌉₊)
     (ht : t ∈ (G.regularityReduced P (ε/8) (ε/4)).cliqueFinset 3) :
-    triangleRemovalBound ε * card α ^ 3 ≤ (G.cliqueFinset 3).card := by
+    triangleRemovalBound ε * card α ^ 3 ≤ #(G.cliqueFinset 3) := by
   rw [mem_cliqueFinset_iff, is3Clique_iff] at ht
   obtain ⟨x, y, z, ⟨-, s, hX, Y, hY, xX, yY, nXY, uXY, dXY⟩,
                    ⟨-, X', hX', Z, hZ, xX', zZ, nXZ, uXZ, dXZ⟩,
@@ -87,28 +87,28 @@ private lemma triangle_removal_aux (hε : 0 < ε) (hP₁ : P.IsEquipartition)
     _ = (1 - 2 * (ε / 8)) * (ε / 8) ^ 3 * (card α / (2 * bound (ε / 8) ⌈4 / ε⌉₊)) *
           (card α / (2 * bound (ε / 8) ⌈4 / ε⌉₊)) * (card α / (2 * bound (ε / 8) ⌈4 / ε⌉₊)) := by
       ring
-    _ ≤ (1 - 2 * (ε / 8)) * (ε / 8) ^ 3 * s.card * Y.card * Z.card := by
+    _ ≤ (1 - 2 * (ε / 8)) * (ε / 8) ^ 3 * #s * #Y * #Z := by
       gcongr <;> exact card_bound hP₁ hP₃ ‹_›
     _ ≤ _ :=
       triangle_counting G (by rwa [that]) uXY dXY (by rwa [that]) uXZ dXZ (by rwa [that]) uYZ dYZ
 
 lemma regularityReduced_edges_card_aux [Nonempty α] (hε : 0 < ε) (hP : P.IsEquipartition)
-    (hPε : P.IsUniform G (ε/8)) (hP' : 4 / ε ≤ P.parts.card) :
-    2 * (G.edgeFinset.card - (G.regularityReduced P (ε/8) (ε/4)).edgeFinset.card : ℝ)
+    (hPε : P.IsUniform G (ε/8)) (hP' : 4 / ε ≤ #P.parts) :
+    2 * (#G.edgeFinset - #(G.regularityReduced P (ε/8) (ε/4)).edgeFinset : ℝ)
       < 2 * ε * (card α ^ 2 : ℕ) := by
   let A := (P.nonUniforms G (ε/8)).biUnion fun (U, V) ↦ U ×ˢ V
   let B := P.parts.biUnion offDiag
   let C := (P.sparsePairs G (ε/4)).biUnion fun (U, V) ↦ G.interedges U V
   calc
-    _ = ↑((univ ×ˢ univ).filter fun (x, y) ↦
-        G.Adj x y ∧ ¬(G.regularityReduced P (ε / 8) (ε /4)).Adj x y).card := by
+    _ = (#((univ ×ˢ univ).filter fun (x, y) ↦
+          G.Adj x y ∧ ¬(G.regularityReduced P (ε / 8) (ε /4)).Adj x y) : ℝ) := by
       rw [univ_product_univ, mul_sub, filter_and_not, cast_card_sdiff]
       · norm_cast
         rw [two_mul_card_edgeFinset, two_mul_card_edgeFinset]
       · exact monotone_filter_right _ fun xy hxy ↦ regularityReduced_le hxy
-    _ ≤ ((A ∪ B ∪ C).card : ℝ) := by gcongr; exact unreduced_edges_subset
-    _ ≤ ((A ∪ B).card + C.card : ℝ) := mod_cast (card_union_le _ _)
-    _ ≤ (A.card + B.card + C.card : ℝ) := by gcongr; exact mod_cast card_union_le _ _
+    _ ≤ #(A ∪ B ∪ C) := by gcongr; exact unreduced_edges_subset
+    _ ≤ #(A ∪ B) + #C := mod_cast (card_union_le _ _)
+    _ ≤ #A + #B + #C := by gcongr; exact mod_cast card_union_le _ _
     _ < 4 * (ε / 8) * card α ^ 2 + _ + _ := by
       gcongr; exact hP.sum_nonUniforms_lt univ_nonempty (by positivity) hPε
     _ ≤ _ + ε / 2 * card α ^ 2 + 4 * (ε / 4) * card α ^ 2 := by
@@ -121,7 +121,7 @@ lemma regularityReduced_edges_card_aux [Nonempty α] (hε : 0 < ε) (hP : P.IsEq
 order of `(card α)^2`), then there were many triangles to start with (on the order of
 `(card α)^3`). -/
 lemma FarFromTriangleFree.le_card_cliqueFinset (hG : G.FarFromTriangleFree ε) :
-    triangleRemovalBound ε * card α ^ 3 ≤ (G.cliqueFinset 3).card := by
+    triangleRemovalBound ε * card α ^ 3 ≤ #(G.cliqueFinset 3) := by
   cases isEmpty_or_nonempty α
   · simp [Fintype.card_eq_zero]
   obtain hε | hε := le_or_lt ε 0
@@ -135,7 +135,7 @@ lemma FarFromTriangleFree.le_card_cliqueFinset (hG : G.FarFromTriangleFree ε) :
       _ ≤ (1 : ℝ) := (triangleRemovalBound_mul_cube_lt hε).le
       _ ≤ _ := by simpa [one_le_iff_ne_zero] using (hG.cliqueFinset_nonempty hε).card_pos.ne'
   obtain ⟨P, hP₁, hP₂, hP₃, hP₄⟩ := szemeredi_regularity G (by positivity : 0 < ε / 8) hl'
-  have : 4/ε ≤ P.parts.card := hl.trans (cast_le.2 hP₂)
+  have : 4/ε ≤ #P.parts := hl.trans (cast_le.2 hP₂)
   have k := regularityReduced_edges_card_aux hε hP₁ hP₄ this
   rw [mul_assoc] at k
   replace k := lt_of_mul_lt_mul_left k zero_le_two
@@ -144,9 +144,9 @@ lemma FarFromTriangleFree.le_card_cliqueFinset (hG : G.FarFromTriangleFree ε) :
 
 /-- **Triangle Removal Lemma**. If there are not too many triangles (on the order of `(card α)^3`)
 then they can all be removed by removing a few edges (on the order of `(card α)^2`). -/
-lemma triangle_removal (hG : (G.cliqueFinset 3).card < triangleRemovalBound ε * card α ^ 3) :
+lemma triangle_removal (hG : #(G.cliqueFinset 3) < triangleRemovalBound ε * card α ^ 3) :
     ∃ G' ≤ G, ∃ _ : DecidableRel G'.Adj,
-      (G.edgeFinset.card - G'.edgeFinset.card : ℝ) < ε * (card α^2 : ℕ) ∧ G'.CliqueFree 3 := by
+      (#G.edgeFinset - #G'.edgeFinset : ℝ) < ε * (card α^2 : ℕ) ∧ G'.CliqueFree 3 := by
   by_contra! h
   refine hG.not_le (farFromTriangleFree_iff.2 ?_).le_card_cliqueFinset
   intros G' _ hG hG'

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean
@@ -216,11 +216,11 @@ lemma cliqueFinset_eq_image [NoAccidental t] : (graph t).cliqueFinset 3 = t.imag
 lemma cliqueFinset_eq_map [NoAccidental t] : (graph t).cliqueFinset 3 = t.map toTriangle := by
   simp [cliqueFinset_eq_image, map_eq_image]
 
-@[simp] lemma card_triangles [NoAccidental t] : ((graph t).cliqueFinset 3).card = t.card := by
+@[simp] lemma card_triangles [NoAccidental t] : #((graph t).cliqueFinset 3) = #t := by
   rw [cliqueFinset_eq_map, card_map]
 
 lemma farFromTriangleFree [ExplicitDisjoint t] {ε : 𝕜}
-    (ht : ε * ((Fintype.card α + Fintype.card β + Fintype.card γ) ^ 2 : ℕ) ≤ t.card) :
+    (ht : ε * ((Fintype.card α + Fintype.card β + Fintype.card γ) ^ 2 : ℕ) ≤ #t) :
     (graph t).FarFromTriangleFree ε :=
   farFromTriangleFree_of_disjoint_triangles (t.map toTriangle)
     (map_subset_iff_subset_preimage.2 fun x hx ↦ by simpa using toTriangle_is3Clique hx)

--- a/Mathlib/Combinatorics/SimpleGraph/Turan.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Turan.lean
@@ -49,7 +49,7 @@ variable (G) in
 the same vertex set has the same or fewer number of edges. -/
 def IsTuranMaximal (r : ℕ) : Prop :=
   G.CliqueFree (r + 1) ∧ ∀ (H : SimpleGraph V) [DecidableRel H.Adj],
-    H.CliqueFree (r + 1) → H.edgeFinset.card ≤ G.edgeFinset.card
+    H.CliqueFree (r + 1) → #H.edgeFinset ≤ #G.edgeFinset
 
 section Defs
 
@@ -111,7 +111,7 @@ lemma exists_isTuranMaximal (hr : 0 < r):
   have cn : c.toFinset.Nonempty := ⟨⊥, by
     simp only [Set.toFinset_setOf, mem_filter, mem_univ, true_and, c]
     exact cliqueFree_bot (by omega)⟩
-  obtain ⟨S, Sm, Sl⟩ := exists_max_image c.toFinset (·.edgeFinset.card) cn
+  obtain ⟨S, Sm, Sl⟩ := exists_max_image c.toFinset (#·.edgeFinset) cn
   use S, inferInstance
   rw [Set.mem_toFinset] at Sm
   refine ⟨Sm, fun I _ cf ↦ ?_⟩
@@ -195,11 +195,11 @@ lemma not_adj_iff_part_eq [DecidableEq V] :
   rw [fp.mem_part_iff_part_eq_part (mem_univ t) (mem_univ s), eq_comm]
 
 lemma degree_eq_card_sub_part_card [DecidableEq V] :
-    G.degree s = Fintype.card V - (h.finpartition.part s).card :=
+    G.degree s = Fintype.card V - #(h.finpartition.part s) :=
   calc
-    _ = (univ.filter (G.Adj s)).card := by
+    _ = #{t | G.Adj s t} := by
       simp [← card_neighborFinset_eq_degree, neighborFinset]
-    _ = Fintype.card V - (univ.filter (¬G.Adj s ·)).card :=
+    _ = Fintype.card V - #{t | ¬G.Adj s t} :=
       eq_tsub_of_add_eq (filter_card_add_filter_neg_card_eq_card _)
     _ = _ := by
       congr; ext; rw [mem_filter]
@@ -224,13 +224,13 @@ theorem isEquipartition [DecidableEq V] : h.finpartition.IsEquipartition := by
     rw [hn] at ineq; omega
   rw [G.card_edgeFinset_replaceVertex_of_adj ha,
     degree_eq_card_sub_part_card h, small_eq, degree_eq_card_sub_part_card h, large_eq]
-  have : large.card ≤ Fintype.card V := by simpa using card_le_card large.subset_univ
+  have : #large ≤ Fintype.card V := by simpa using card_le_card large.subset_univ
   omega
 
-lemma card_parts_le [DecidableEq V] : h.finpartition.parts.card ≤ r := by
+lemma card_parts_le [DecidableEq V] : #h.finpartition.parts ≤ r := by
   by_contra! l
   obtain ⟨z, -, hz⟩ := h.finpartition.exists_subset_part_bijOn
-  have ncf : ¬G.CliqueFree z.card := by
+  have ncf : ¬G.CliqueFree #z := by
     refine IsNClique.not_cliqueFree ⟨fun v hv w hw hn ↦ ?_, rfl⟩
     contrapose! hn
     exact hz.injOn hv hw (by rwa [← h.not_adj_iff_part_eq])
@@ -240,7 +240,7 @@ lemma card_parts_le [DecidableEq V] : h.finpartition.parts.card ≤ r := by
 /-- There are `min n r` parts in a graph on `n` vertices satisfying `G.IsTuranMaximal r`.
 `min` handles the `n < r` case, when `G` is complete but still `r + 1`-cliquefree
 for having insufficiently many vertices. -/
-theorem card_parts [DecidableEq V] : h.finpartition.parts.card = min (Fintype.card V) r := by
+theorem card_parts [DecidableEq V] : #h.finpartition.parts = min (Fintype.card V) r := by
   set fp := h.finpartition
   apply le_antisymm (le_min fp.card_parts_le_card h.card_parts_le)
   by_contra! l
@@ -255,7 +255,7 @@ theorem card_parts [DecidableEq V] : h.finpartition.parts.card = min (Fintype.ca
     intro z zc; push_neg; simp_rw [h.not_adj_iff_part_eq]
     exact exists_ne_map_eq_of_card_lt_of_maps_to (zc.symm ▸ l.2) fun a _ ↦ fp.part_mem (mem_univ a)
   use G ⊔ edge x y, inferInstance, cf.sup_edge x y
-  convert Nat.lt.base G.edgeFinset.card
+  convert Nat.lt.base #G.edgeFinset
   convert G.card_edgeFinset_sup_edge _ hn
   rwa [h.not_adj_iff_part_eq]
 


### PR DESCRIPTION
For `s : Finset α`, replace `s.card` with `#s`, `s.filter p` with `{x ∈ s | p x}`, `∑ x ∈ s.filter p, f x` with `∑ x ∈ s with p x, f x`. Rewrap lines around and open the `Finset` locale where necessary.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
