### PR TITLE
[Merged by Bors] - chore(Algebra): re-add `@[simp]` attributes lost in the port

### DIFF
--- a/Mathlib/Algebra/AddTorsor.lean
+++ b/Mathlib/Algebra/AddTorsor.lean
@@ -165,7 +165,6 @@ namespace Set
 
 open Pointwise
 
-@[simp]
 theorem singleton_vsub_self (p : P) : ({p} : Set P) -ᵥ {p} = {(0 : G)} := by
   rw [Set.singleton_vsub_singleton, vsub_self]
 

--- a/Mathlib/Algebra/AddTorsor.lean
+++ b/Mathlib/Algebra/AddTorsor.lean
@@ -165,8 +165,7 @@ namespace Set
 
 open Pointwise
 
--- porting note (#10618): simp can prove this
---@[simp]
+@[simp]
 theorem singleton_vsub_self (p : P) : ({p} : Set P) -ᵥ {p} = {(0 : G)} := by
   rw [Set.singleton_vsub_singleton, vsub_self]
 

--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -288,13 +288,13 @@ def symm (e : A₁ ≃ₐ[R] A₂) : A₂ ≃ₐ[R] A₁ :=
 theorem invFun_eq_symm {e : A₁ ≃ₐ[R] A₂} : e.invFun = e.symm :=
   rfl
 
---@[simp] -- Porting note (#10618): simp can prove this once symm_mk is introduced
+@[simp]
 theorem coe_apply_coe_coe_symm_apply {F : Type*} [EquivLike F A₁ A₂] [AlgEquivClass F R A₁ A₂]
     (f : F) (x : A₂) :
     f ((f : A₁ ≃ₐ[R] A₂).symm x) = x :=
   EquivLike.right_inv f x
 
---@[simp] -- Porting note (#10618): simp can prove this once symm_mk is introduced
+@[simp]
 theorem coe_coe_symm_apply_coe_apply {F : Type*} [EquivLike F A₁ A₂] [AlgEquivClass F R A₁ A₂]
     (f : F) (x : A₁) :
     (f : A₁ ≃ₐ[R] A₂).symm (f x) = x :=

--- a/Mathlib/Algebra/Algebra/Hom.lean
+++ b/Mathlib/Algebra/Algebra/Hom.lean
@@ -49,7 +49,7 @@ class AlgHomClass (F : Type*) (R A B : outParam Type*)
 -- attribute [nolint dangerousInstance] AlgHomClass.toRingHomClass
 
 -- Porting note (#10618): simp can prove this
--- attribute [simp] AlgHomClass.commutes
+attribute [simp] AlgHomClass.commutes
 
 namespace AlgHomClass
 

--- a/Mathlib/Algebra/Algebra/Hom.lean
+++ b/Mathlib/Algebra/Algebra/Hom.lean
@@ -49,7 +49,7 @@ class AlgHomClass (F : Type*) (R A B : outParam Type*)
 -- attribute [nolint dangerousInstance] AlgHomClass.toRingHomClass
 
 -- Porting note (#10618): simp can prove this
-attribute [simp] AlgHomClass.commutes
+-- attribute [simp] AlgHomClass.commutes
 
 namespace AlgHomClass
 

--- a/Mathlib/Algebra/Algebra/NonUnitalHom.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalHom.lean
@@ -245,7 +245,7 @@ theorem coe_mulHom_mk (f : A →ₛₙₐ[φ] B) (h₁ h₂ h₃ h₄) :
     ((⟨⟨⟨f, h₁⟩, h₂, h₃⟩, h₄⟩ : A →ₛₙₐ[φ] B) : A →ₙ* B) = ⟨f, h₄⟩ := by
   rfl
 
--- @[simp] -- Porting note (#10618) : simp can prove this
+@[simp] -- Marked as `@[simp]` because `MulActionSemiHomClass.map_smulₛₗ` can't be.
 protected theorem map_smul (f : A →ₛₙₐ[φ] B) (c : R) (x : A) : f (c • x) = (φ c) • f x :=
   map_smulₛₗ _ _ _
 

--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -472,11 +472,13 @@ end Mul
 section MulOneClass
 variable [MulOneClass M] [MulOneClass N] [MulOneClass P]
 
--- Porting note (#10618): `simp` can prove this
+-- Porting note (#10618): `simp` can prove this but it is a valid `dsimp` lemma.
+-- However, we would need to redesign the the `dsimp` set to make this `@[simp]`.
 @[to_additive]
 theorem coe_monoidHom_refl : (refl M : M →* M) = MonoidHom.id M := rfl
 
--- Porting note (#10618): `simp` can prove this
+-- Porting note (#10618): `simp` can prove this but it is a valid `dsimp` lemma.
+-- However, we would need to redesign the the `dsimp` set to make this `@[simp]`.
 @[to_additive]
 lemma coe_monoidHom_trans (e₁ : M ≃* N) (e₂ : N ≃* P) :
     (e₁.trans e₂ : M →* P) = (e₂ : N →* P).comp ↑e₁ := rfl

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -531,7 +531,7 @@ theorem div_singleton : s / {b} = (· / b) '' s :=
 theorem singleton_div : {a} / t = (· / ·) a '' t :=
   image2_singleton_left
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem singleton_div_singleton : ({a} : Set α) / {b} = {a / b} :=
   image2_singleton
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -531,8 +531,7 @@ theorem div_singleton : s / {b} = (· / b) '' s :=
 theorem singleton_div : {a} / t = (· / ·) a '' t :=
   image2_singleton_left
 
--- Porting note (#10618): simp can prove this
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem singleton_div_singleton : ({a} : Set α) / {b} = {a / b} :=
   image2_singleton
 

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -1969,7 +1969,7 @@ theorem normalCore_eq_iSup (H : Subgroup G) :
 theorem normalCore_eq_self (H : Subgroup G) [H.Normal] : H.normalCore = H :=
   le_antisymm H.normalCore_le (normal_le_normalCore.mpr le_rfl)
 
--- @[simp] -- Porting note (#10618): simp can prove this
+@[simp]
 theorem normalCore_idempotent (H : Subgroup G) : H.normalCore.normalCore = H.normalCore :=
   H.normalCore.normalCore_eq_self
 

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -1969,7 +1969,6 @@ theorem normalCore_eq_iSup (H : Subgroup G) :
 theorem normalCore_eq_self (H : Subgroup G) [H.Normal] : H.normalCore = H :=
   le_antisymm H.normalCore_le (normal_le_normalCore.mpr le_rfl)
 
-@[simp]
 theorem normalCore_idempotent (H : Subgroup G) : H.normalCore.normalCore = H.normalCore :=
   H.normalCore.normalCore_eq_self
 

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -56,7 +56,7 @@ theorem coe_multiset_prod {M} [CommMonoid M] [SetLike B M] [SubmonoidClass B M] 
     (m.prod : M) = (m.map (↑)).prod :=
   (SubmonoidClass.subtype S : _ →* M).map_multiset_prod m
 
-@[to_additive (attr := norm_cast)] -- Porting note (#10618): removed `simp`, `simp` can prove it
+@[to_additive (attr := norm_cast, simp)]
 theorem coe_finset_prod {ι M} [CommMonoid M] [SetLike B M] [SubmonoidClass B M] (f : ι → S)
     (s : Finset ι) : ↑(∏ i ∈ s, f i) = (∏ i ∈ s, f i : M) :=
   map_prod (SubmonoidClass.subtype S) f s
@@ -97,11 +97,11 @@ namespace Submonoid
 
 variable (s : Submonoid M)
 
-@[to_additive (attr := norm_cast)] -- Porting note (#10618): removed `simp`, `simp` can prove it
+@[to_additive (attr := norm_cast)]
 theorem coe_list_prod (l : List s) : (l.prod : M) = (l.map (↑)).prod :=
   map_list_prod s.subtype l
 
-@[to_additive (attr := norm_cast)] -- Porting note (#10618): removed `simp`, `simp` can prove it
+@[to_additive (attr := norm_cast)]
 theorem coe_multiset_prod {M} [CommMonoid M] (S : Submonoid M) (m : Multiset S) :
     (m.prod : M) = (m.map (↑)).prod :=
   S.subtype.map_multiset_prod m

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -106,7 +106,7 @@ theorem coe_multiset_prod {M} [CommMonoid M] (S : Submonoid M) (m : Multiset S) 
     (m.prod : M) = (m.map (↑)).prod :=
   S.subtype.map_multiset_prod m
 
-@[to_additive (attr := norm_cast, simp)]
+@[to_additive (attr := norm_cast)]
 theorem coe_finset_prod {ι M} [CommMonoid M] (S : Submonoid M) (f : ι → S) (s : Finset ι) :
     ↑(∏ i ∈ s, f i) = (∏ i ∈ s, f i : M) :=
   map_prod S.subtype f s

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -83,7 +83,7 @@ instance (priority := mid) coeSubmodule : CoeOut (LieSubmodule R L M) (Submodule
 theorem coe_toSubmodule : ((N : Submodule R M) : Set M) = N :=
   rfl
 
--- Porting note (#10618): `simp` can prove this after `mem_coeSubmodule` is added to the simp set,
+-- `simp` can prove this after `mem_coeSubmodule` is added to the simp set,
 -- but `dsimp` can't.
 @[simp, nolint simpNF]
 theorem mem_carrier {x : M} : x ∈ N.carrier ↔ x ∈ (N : Set M) :=

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -759,7 +759,9 @@ protected noncomputable def opRingEquiv [Monoid G] :
       erw [unop_op, unop_op, single_mul_single]
       simp }
 
--- @[simp] -- Porting note (#10618): simp can prove this
+-- @[simp] -- Porting note (#10618): simp can prove this.
+-- More specifically, the LHS simplifies to `Finsupp.single`, which implies there's some
+-- defeq abuse going on.
 theorem opRingEquiv_single [Monoid G] (r : k) (x : G) :
     MonoidAlgebra.opRingEquiv (op (single x r)) = single (op x) (op r) := by simp
 
@@ -1417,7 +1419,9 @@ protected noncomputable def opRingEquiv [AddCommMonoid G] :
       erw [mapRange_single, single_mul_single, mapRange_single, mapRange_single]
       simp only [mapRange_single, single_mul_single, ← op_mul, add_comm] }
 
--- @[simp] -- Porting note (#10618): simp can prove this
+-- @[simp] -- Porting note (#10618): simp can prove this.
+-- More specifically, the LHS simplifies to `Finsupp.single`, which implies there's some
+-- defeq abuse going on.
 theorem opRingEquiv_single [AddCommMonoid G] (r : k) (x : G) :
     AddMonoidAlgebra.opRingEquiv (op (single x r)) = single x (op r) := by simp
 

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -191,10 +191,10 @@ theorem monomial_left_inj {s t : σ →₀ ℕ} {r : R} (hr : r ≠ 0) :
 theorem C_apply : (C a : MvPolynomial σ R) = monomial 0 a :=
   rfl
 
--- Porting note (#10618): `simp` can prove this
+@[simp]
 theorem C_0 : C 0 = (0 : MvPolynomial σ R) := map_zero _
 
--- Porting note (#10618): `simp` can prove this
+@[simp]
 theorem C_1 : C 1 = (1 : MvPolynomial σ R) :=
   rfl
 
@@ -203,15 +203,15 @@ theorem C_mul_monomial : C a * monomial s a' = monomial s (a * a') := by
   show AddMonoidAlgebra.single _ _ * AddMonoidAlgebra.single _ _ = AddMonoidAlgebra.single _ _
   simp [C_apply, single_mul_single]
 
--- Porting note (#10618): `simp` can prove this
+@[simp]
 theorem C_add : (C (a + a') : MvPolynomial σ R) = C a + C a' :=
   Finsupp.single_add _ _ _
 
--- Porting note (#10618): `simp` can prove this
+@[simp]
 theorem C_mul : (C (a * a') : MvPolynomial σ R) = C a * C a' :=
   C_mul_monomial.symm
 
--- Porting note (#10618): `simp` can prove this
+@[simp]
 theorem C_pow (a : R) (n : ℕ) : (C (a ^ n) : MvPolynomial σ R) = C a ^ n :=
   map_pow _ _ _
 
@@ -303,7 +303,7 @@ theorem C_mul_X_pow_eq_monomial {s : σ} {a : R} {n : ℕ} :
 theorem C_mul_X_eq_monomial {s : σ} {a : R} : C a * X s = monomial (Finsupp.single s 1) a := by
   rw [← C_mul_X_pow_eq_monomial, pow_one]
 
--- Porting note (#10618): `simp` can prove this
+@[simp]
 theorem monomial_zero {s : σ →₀ ℕ} : monomial s (0 : R) = 0 :=
   Finsupp.single_zero _
 

--- a/Mathlib/Algebra/MvPolynomial/CommRing.lean
+++ b/Mathlib/Algebra/MvPolynomial/CommRing.lean
@@ -55,11 +55,11 @@ instance instCommRingMvPolynomial : CommRing (MvPolynomial σ R) :=
 
 variable (σ a a')
 
--- @[simp] -- Porting note (#10618): simp can prove this
+@[simp]
 theorem C_sub : (C (a - a') : MvPolynomial σ R) = C a - C a' :=
   RingHom.map_sub _ _ _
 
--- @[simp] -- Porting note (#10618): simp can prove this
+@[simp]
 theorem C_neg : (C (-a) : MvPolynomial σ R) = -C a :=
   RingHom.map_neg _ _
 

--- a/Mathlib/Algebra/Order/AbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue.lean
@@ -93,7 +93,7 @@ protected theorem eq_zero {x : R} : abv x = 0 ↔ x = 0 :=
 protected theorem add_le (x y : R) : abv (x + y) ≤ abv x + abv y :=
   abv.add_le' x y
 
--- Porting note (#10618): was `@[simp]` but `simp` can prove it
+@[simp]
 protected theorem map_mul (x y : R) : abv (x * y) = abv x * abv y :=
   abv.map_mul' x y
 
@@ -113,7 +113,7 @@ protected theorem ne_zero {x : R} (hx : x ≠ 0) : abv x ≠ 0 :=
 theorem map_one_of_isLeftRegular (h : IsLeftRegular (abv 1)) : abv 1 = 1 :=
   h <| by simp [← abv.map_mul]
 
--- Porting note (#10618): was `@[simp]` but `simp` can prove it
+@[simp]
 protected theorem map_zero : abv 0 = 0 :=
   abv.eq_zero.2 rfl
 
@@ -145,7 +145,7 @@ section IsDomain
 variable {R S : Type*} [Semiring R] [OrderedRing S] (abv : AbsoluteValue R S)
 variable [IsDomain S] [Nontrivial R]
 
--- Porting note (#10618): was `@[simp]` but `simp` can prove it
+@[simp]
 protected theorem map_one : abv 1 = 1 :=
   abv.map_one_of_isLeftRegular (isRegular_of_ne_zero <| abv.ne_zero one_ne_zero).left
 
@@ -170,7 +170,7 @@ def toMonoidHom : R →* S :=
 theorem coe_toMonoidHom : ⇑abv.toMonoidHom = abv :=
   rfl
 
--- Porting note (#10618): was `@[simp]` but `simp` can prove it
+@[simp]
 protected theorem map_pow (a : R) (n : ℕ) : abv (a ^ n) = abv a ^ n :=
   abv.toMonoidHom.map_pow a n
 

--- a/Mathlib/Algebra/PUnitInstances/GCDMonoid.lean
+++ b/Mathlib/Algebra/PUnitInstances/GCDMonoid.lean
@@ -32,11 +32,11 @@ instance normalizedGCDMonoid : NormalizedGCDMonoid PUnit where
   normalize_gcd := by intros; rfl
   normalize_lcm := by intros; rfl
 
--- Porting note (#10618): simpNF lint: simp can prove this @[simp]
+@[simp]
 theorem gcd_eq {x y : PUnit} : gcd x y = unit :=
   rfl
 
--- Porting note (#10618): simpNF lint: simp can prove this @[simp]
+@[simp]
 theorem lcm_eq {x y : PUnit} : lcm x y = unit :=
   rfl
 

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -379,7 +379,7 @@ theorem toFinsupp_monomial (n : ℕ) (r : R) : (monomial n r).toFinsupp = Finsup
 theorem ofFinsupp_single (n : ℕ) (r : R) : (⟨Finsupp.single n r⟩ : R[X]) = monomial n r := by
   simp [monomial]
 
--- @[simp] -- Porting note (#10618): simp can prove this
+@[simp]
 theorem monomial_zero_right (n : ℕ) : monomial n (0 : R) = 0 :=
   (monomial n).map_zero
 
@@ -1028,7 +1028,7 @@ theorem coeff_sub (p q : R[X]) (n : ℕ) : coeff (p - q) n = coeff p n - coeff q
   -- Porting note: The last rule should be `apply`ed.
   rw [← ofFinsupp_sub, coeff, coeff, coeff]; apply Finsupp.sub_apply
 
--- @[simp] -- Porting note (#10618): simp can prove this
+@[simp]
 theorem monomial_neg (n : ℕ) (a : R) : monomial n (-a) = -monomial n a := by
   rw [eq_neg_iff_add_eq_zero, ← monomial_add, neg_add_cancel, monomial_zero_right]
 

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -71,7 +71,7 @@ theorem coeff_derivative (p : R[X]) (n : ℕ) :
     push_neg at h
     simp [h]
 
--- Porting note (#10618): removed `simp`: `simp` can prove it.
+@[simp]
 theorem derivative_zero : derivative (0 : R[X]) = 0 :=
   derivative.map_zero
 
@@ -116,7 +116,7 @@ theorem derivative_X : derivative (X : R[X]) = 1 :=
 theorem derivative_one : derivative (1 : R[X]) = 0 :=
   derivative_C
 
--- Porting note (#10618): removed `simp`: `simp` can prove it.
+@[simp]
 theorem derivative_add {f g : R[X]} : derivative (f + g) = derivative f + derivative g :=
   derivative.map_add f g
 
@@ -560,14 +560,14 @@ section Ring
 
 variable [Ring R]
 
--- Porting note (#10618): removed `simp`: `simp` can prove it.
+@[simp]
 theorem derivative_neg (f : R[X]) : derivative (-f) = -derivative f :=
   LinearMap.map_neg derivative f
 
 theorem iterate_derivative_neg {f : R[X]} {k : ℕ} : derivative^[k] (-f) = -derivative^[k] f :=
   iterate_map_neg derivative k f
 
--- Porting note (#10618): removed `simp`: `simp` can prove it.
+@[simp]
 theorem derivative_sub {f g : R[X]} : derivative (f - g) = derivative f - derivative g :=
   LinearMap.map_sub derivative f g
 

--- a/Mathlib/Algebra/Polynomial/Laurent.lean
+++ b/Mathlib/Algebra/Polynomial/Laurent.lean
@@ -205,16 +205,16 @@ theorem _root_.Polynomial.toLaurent_X : (toLaurent Polynomial.X : R[T;T⁻¹]) =
   have : (Polynomial.X : R[X]) = monomial 1 1 := by simp [← C_mul_X_pow_eq_monomial]
   simp [this, Polynomial.toLaurent_C_mul_T]
 
--- @[simp] -- Porting note (#10618): simp can prove this
+@[simp]
 theorem _root_.Polynomial.toLaurent_one : (Polynomial.toLaurent : R[X] → R[T;T⁻¹]) 1 = 1 :=
   map_one Polynomial.toLaurent
 
--- @[simp] -- Porting note (#10618): simp can prove this
+@[simp]
 theorem _root_.Polynomial.toLaurent_C_mul_eq (r : R) (f : R[X]) :
     toLaurent (Polynomial.C r * f) = C r * toLaurent f := by
   simp only [_root_.map_mul, Polynomial.toLaurent_C]
 
--- @[simp] -- Porting note (#10618): simp can prove this
+@[simp]
 theorem _root_.Polynomial.toLaurent_X_pow (n : ℕ) : toLaurent (X ^ n : R[X]) = T n := by
   simp only [map_pow, Polynomial.toLaurent_X, T_pow, mul_one]
 

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -605,7 +605,7 @@ section Ring
 
 variable [NonAssocRing R] [NonAssocRing S] (f : R ≃+* S)
 
--- Porting note (#10618): `simp` can now prove that, so we remove the `@[simp]` tag
+@[simp]
 theorem map_neg_one : f (-1) = -1 :=
   f.map_one ▸ f.map_neg 1
 

--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -649,8 +649,7 @@ theorem coe_fn_mkRingHomOfMulSelfOfTwoNeZero (h h_two h_one) :
     (f.mkRingHomOfMulSelfOfTwoNeZero h h_two h_one : β → α) = f :=
   rfl
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
+@[simp]
 theorem coe_addMonoidHom_mkRingHomOfMulSelfOfTwoNeZero (h h_two h_one) :
     (f.mkRingHomOfMulSelfOfTwoNeZero h h_two h_one : β →+ α) = f := by
   ext

--- a/Mathlib/Algebra/Ring/Int.lean
+++ b/Mathlib/Algebra/Ring/Int.lean
@@ -166,15 +166,13 @@ lemma even_mul_succ_self (n : ℤ) : Even (n * (n + 1)) := by
 lemma even_mul_pred_self (n : ℤ) : Even (n * (n - 1)) := by
   simpa [even_mul, parity_simps] using n.even_or_odd
 
--- Porting note (#10618): was simp. simp can prove this.
-@[norm_cast] lemma odd_coe_nat (n : ℕ) : Odd (n : ℤ) ↔ Odd n := by
+@[simp, norm_cast] lemma odd_coe_nat (n : ℕ) : Odd (n : ℤ) ↔ Odd n := by
   rw [← not_even_iff_odd, ← Nat.not_even_iff_odd, even_coe_nat]
 
 @[simp] lemma natAbs_even : Even n.natAbs ↔ Even n := by
   simp [even_iff_two_dvd, dvd_natAbs, natCast_dvd.symm]
 
--- Porting note (#10618): was simp. simp can prove this.
---@[simp]
+@[simp]
 lemma natAbs_odd : Odd n.natAbs ↔ Odd n := by
   rw [← not_even_iff_odd, ← Nat.not_even_iff_odd, natAbs_even]
 

--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -387,11 +387,11 @@ def subtype (s : Subring R) : s →+* R :=
 theorem coeSubtype : ⇑s.subtype = ((↑) : s → R) :=
   rfl
 
-@[norm_cast] -- Porting note (#10618): simp can prove this (removed `@[simp]`)
+@[norm_cast]
 theorem coe_natCast : ∀ n : ℕ, ((n : s) : R) = n :=
   map_natCast s.subtype
 
-@[norm_cast] -- Porting note (#10618): simp can prove this (removed `@[simp]`)
+@[norm_cast]
 theorem coe_intCast : ∀ n : ℤ, ((n : s) : R) = n :=
   map_intCast s.subtype
 

--- a/Mathlib/Algebra/Star/Subalgebra.lean
+++ b/Mathlib/Algebra/Star/Subalgebra.lean
@@ -73,7 +73,6 @@ instance algebra (s : StarSubalgebra R A) : Algebra R s :=
 instance starModule (s : StarSubalgebra R A) : StarModule R s where
   star_smul r a := Subtype.ext (star_smul r (a : A))
 
-@[simp, nolint simpNF] -- porting note (#10618): `simpNF` says `simp` can prove this, but it can't
 theorem mem_carrier {s : StarSubalgebra R A} {x : A} : x ∈ s.carrier ↔ x ∈ s :=
   Iff.rfl
 

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -288,7 +288,7 @@ namespace IntermediateField
 instance toField : Field S :=
   S.toSubfield.toField
 
-@[simp, norm_cast]
+@[norm_cast]
 theorem coe_sum {ι : Type*} [Fintype ι] (f : ι → S) : (↑(∑ i, f i) : L) = ∑ i, (f i : L) := by
   classical
     induction' (Finset.univ : Finset ι) using Finset.induction_on with i s hi H


### PR DESCRIPTION
This PR re-adds the `@[simp]` attributes that had a porting note that they could be proved by `@[simp]`, but where that does not appear to be the case currently.

Of course, the `simp` set may have changed sufficiently to require un`@[simp]`ing some of these anyway, but we should add a more up to date comment in that case.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
