### PR TITLE
[Merged by Bors] - chore(Data): use newly introduced finset notation

### DIFF
--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -1061,10 +1061,9 @@ end Real
 namespace Complex
 
 theorem sum_div_factorial_le {α : Type*} [LinearOrderedField α] (n j : ℕ) (hn : 0 < n) :
-    (∑ m ∈ filter (fun k => n ≤ k) (range j),
-      (1 / m.factorial : α)) ≤ n.succ / (n.factorial * n) :=
+    (∑ m ∈ range j with n ≤ m, (1 / m.factorial : α)) ≤ n.succ / (n.factorial * n) :=
   calc
-    (∑ m ∈ filter (fun k => n ≤ k) (range j), (1 / m.factorial : α)) =
+    (∑ m ∈ range j with n ≤ m, (1 / m.factorial : α)) =
         ∑ m ∈ range (j - n), (1 / ((m + n).factorial : α)) := by
         refine sum_nbij' (· - n) (· + n) ?_ ?_ ?_ ?_ ?_ <;>
           simp (config := { contextual := true }) [lt_tsub_iff_right, tsub_add_cancel_of_le]
@@ -1098,20 +1097,19 @@ theorem exp_bound {x : ℂ} (hx : abs x ≤ 1) {n : ℕ} (hn : 0 < n) :
       abs x ^ n * ((n.succ : ℝ) * (n.factorial * n : ℝ)⁻¹)
   rw [sum_range_sub_sum_range hj]
   calc
-    abs (∑ m ∈ (range j).filter fun k => n ≤ k, (x ^ m / m.factorial : ℂ)) =
-      abs (∑ m ∈ (range j).filter fun k => n ≤ k,
-        (x ^ n * (x ^ (m - n) / m.factorial) : ℂ)) := by
+    abs (∑ m ∈ range j with n ≤ m, (x ^ m / m.factorial : ℂ))
+      = abs (∑ m ∈ range j with n ≤ m, (x ^ n * (x ^ (m - n) / m.factorial) : ℂ)) := by
       refine congr_arg abs (sum_congr rfl fun m hm => ?_)
       rw [mem_filter, mem_range] at hm
       rw [← mul_div_assoc, ← pow_add, add_tsub_cancel_of_le hm.2]
-    _ ≤ ∑ m ∈ filter (fun k => n ≤ k) (range j), abs (x ^ n * (x ^ (m - n) / m.factorial)) :=
-      (IsAbsoluteValue.abv_sum Complex.abs _ _)
-    _ ≤ ∑ m ∈ filter (fun k => n ≤ k) (range j), abs x ^ n * (1 / m.factorial) := by
+    _ ≤ ∑ m ∈ range j with n ≤ m, abs (x ^ n * (x ^ (m - n) / m.factorial)) :=
+      IsAbsoluteValue.abv_sum Complex.abs ..
+    _ ≤ ∑ m ∈ range j with n ≤ m, abs x ^ n * (1 / m.factorial) := by
       simp_rw [map_mul, map_pow, map_div₀, abs_natCast]
       gcongr
       rw [abv_pow abs]
       exact pow_le_one₀ (abs.nonneg _) hx
-    _ = abs x ^ n * ∑ m ∈ (range j).filter fun k => n ≤ k, (1 / m.factorial : ℝ) := by
+    _ = abs x ^ n * ∑ m ∈ range j with n ≤ m, (1 / m.factorial : ℝ) := by
       simp [abs_mul, abv_pow abs, abs_div, ← mul_sum]
     _ ≤ abs x ^ n * (n.succ * (n.factorial * n : ℝ)⁻¹) := by
       gcongr

--- a/Mathlib/Data/DFinsupp/Basic.lean
+++ b/Mathlib/Data/DFinsupp/Basic.lean
@@ -1120,7 +1120,7 @@ theorem filter_def (f : Π₀ i, β i) : f.filter p = mk (f.support.filter p) fu
   ext i; by_cases h1 : p i <;> by_cases h2 : f i ≠ 0 <;> simp at h2 <;> simp [h1, h2]
 
 @[simp]
-theorem support_filter (f : Π₀ i, β i) : (f.filter p).support = f.support.filter p := by
+theorem support_filter (f : Π₀ i, β i) : (f.filter p).support = {x ∈ f.support | p x} := by
   ext i; by_cases h : p i <;> simp [h]
 
 theorem subtypeDomain_def (f : Π₀ i, β i) :
@@ -1717,7 +1717,7 @@ theorem sumAddHom_comp_single [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] (f
 theorem sumAddHom_apply [∀ i, AddZeroClass (β i)] [∀ (i) (x : β i), Decidable (x ≠ 0)]
     [AddCommMonoid γ] (φ : ∀ i, β i →+ γ) (f : Π₀ i, β i) : sumAddHom φ f = f.sum fun x => φ x := by
   rcases f with ⟨f, s, hf⟩
-  change (∑ i ∈ _, _) = ∑ i ∈ Finset.filter _ _, _
+  change (∑ i ∈ _, _) = ∑ i ∈ _ with _, _
   rw [Finset.sum_filter, Finset.sum_congr rfl]
   intro i _
   dsimp only [coe_mk', Subtype.coe_mk] at *

--- a/Mathlib/Data/DFinsupp/Interval.lean
+++ b/Mathlib/Data/DFinsupp/Interval.lean
@@ -35,8 +35,7 @@ def dfinsupp (s : Finset ι) (t : ∀ i, Finset (α i)) : Finset (Π₀ i, α i)
       convert congr_fun h ⟨i, hi⟩⟩
 
 @[simp]
-theorem card_dfinsupp (s : Finset ι) (t : ∀ i, Finset (α i)) :
-    (s.dfinsupp t).card = ∏ i ∈ s, (t i).card :=
+theorem card_dfinsupp (s : Finset ι) (t : ∀ i, Finset (α i)) : #(s.dfinsupp t) = ∏ i ∈ s, #(t i) :=
   (card_map _).trans <| card_pi _ _
 
 variable [∀ i, DecidableEq (α i)]
@@ -134,7 +133,7 @@ theorem mem_pi {f : Π₀ i, Finset (α i)} {g : Π₀ i, α i} : g ∈ f.pi ↔
   mem_dfinsupp_iff_of_support_subset <| Subset.refl _
 
 @[simp]
-theorem card_pi (f : Π₀ i, Finset (α i)) : f.pi.card = f.prod fun i => (f i).card := by
+theorem card_pi (f : Π₀ i, Finset (α i)) : #f.pi = f.prod fun i ↦ #(f i) := by
   rw [pi, card_dfinsupp]
   exact Finset.prod_congr rfl fun i _ => by simp only [Pi.natCast_apply, Nat.cast_id]
 
@@ -157,16 +156,16 @@ variable (f g : Π₀ i, α i)
 
 theorem Icc_eq : Icc f g = (f.support ∪ g.support).dfinsupp (f.rangeIcc g) := rfl
 
-theorem card_Icc : (Icc f g).card = ∏ i ∈ f.support ∪ g.support, (Icc (f i) (g i)).card :=
+lemma card_Icc : #(Icc f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)) :=
   card_dfinsupp _ _
 
-theorem card_Ico : (Ico f g).card = (∏ i ∈ f.support ∪ g.support, (Icc (f i) (g i)).card) - 1 := by
+lemma card_Ico : #(Ico f g) = (∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i))) - 1 := by
   rw [card_Ico_eq_card_Icc_sub_one, card_Icc]
 
-theorem card_Ioc : (Ioc f g).card = (∏ i ∈ f.support ∪ g.support, (Icc (f i) (g i)).card) - 1 := by
+lemma card_Ioc : #(Ioc f g) = (∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i))) - 1 := by
   rw [card_Ioc_eq_card_Icc_sub_one, card_Icc]
 
-theorem card_Ioo : (Ioo f g).card = (∏ i ∈ f.support ∪ g.support, (Icc (f i) (g i)).card) - 2 := by
+lemma card_Ioo : #(Ioo f g) = (∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i))) - 2 := by
   rw [card_Ioo_eq_card_Icc_sub_two, card_Icc]
 
 end PartialOrder
@@ -175,7 +174,7 @@ section Lattice
 variable [DecidableEq ι] [∀ i, DecidableEq (α i)] [∀ i, Lattice (α i)] [∀ i, Zero (α i)]
   [∀ i, LocallyFiniteOrder (α i)] (f g : Π₀ i, α i)
 
-theorem card_uIcc : (uIcc f g).card = ∏ i ∈ f.support ∪ g.support, (uIcc (f i) (g i)).card := by
+lemma card_uIcc : #(uIcc f g) = ∏ i ∈ f.support ∪ g.support, #(uIcc (f i) (g i)) := by
   rw [← support_inf_union_support_sup]; exact card_Icc _ _
 
 end Lattice
@@ -186,11 +185,11 @@ variable [DecidableEq ι] [∀ i, DecidableEq (α i)]
 variable [∀ i, CanonicallyOrderedAddCommMonoid (α i)] [∀ i, LocallyFiniteOrder (α i)]
 variable (f : Π₀ i, α i)
 
-theorem card_Iic : (Iic f).card = ∏ i ∈ f.support, (Iic (f i)).card := by
+lemma card_Iic : #(Iic f) = ∏ i ∈ f.support, #(Iic (f i)) := by
   simp_rw [Iic_eq_Icc, card_Icc, DFinsupp.bot_eq_zero, support_zero, empty_union, zero_apply,
     bot_eq_zero]
 
-theorem card_Iio : (Iio f).card = (∏ i ∈ f.support, (Iic (f i)).card) - 1 := by
+lemma card_Iio : #(Iio f) = (∏ i ∈ f.support, #(Iic (f i))) - 1 := by
   rw [card_Iio_eq_card_Iic_sub_one, card_Iic]
 
 end CanonicallyOrdered

--- a/Mathlib/Data/Finset/Finsupp.lean
+++ b/Mathlib/Data/Finset/Finsupp.lean
@@ -70,8 +70,7 @@ theorem mem_finsupp_iff_of_support_subset {t : ι →₀ Finset α} (ht : t.supp
   · rwa [H, mem_zero] at h
 
 @[simp]
-theorem card_finsupp (s : Finset ι) (t : ι → Finset α) :
-    (s.finsupp t).card = ∏ i ∈ s, (t i).card :=
+theorem card_finsupp (s : Finset ι) (t : ι → Finset α) : #(s.finsupp t) = ∏ i ∈ s, #(t i) :=
   (card_map _).trans <| card_pi _ _
 
 end Finset
@@ -90,7 +89,7 @@ theorem mem_pi {f : ι →₀ Finset α} {g : ι →₀ α} : g ∈ f.pi ↔ ∀
   mem_finsupp_iff_of_support_subset <| Subset.refl _
 
 @[simp]
-theorem card_pi (f : ι →₀ Finset α) : f.pi.card = f.prod fun i => (f i).card := by
+theorem card_pi (f : ι →₀ Finset α) : #f.pi = f.prod fun i ↦ #(f i) := by
   rw [pi, card_finsupp]
   exact Finset.prod_congr rfl fun i _ => by simp only [Pi.natCast_apply, Nat.cast_id]
 

--- a/Mathlib/Data/Finset/NAry.lean
+++ b/Mathlib/Data/Finset/NAry.lean
@@ -46,16 +46,16 @@ theorem coe_image₂ (f : α → β → γ) (s : Finset α) (t : Finset β) :
   Set.ext fun _ => mem_image₂
 
 theorem card_image₂_le (f : α → β → γ) (s : Finset α) (t : Finset β) :
-    (image₂ f s t).card ≤ s.card * t.card :=
+    #(image₂ f s t) ≤ #s * #t :=
   card_image_le.trans_eq <| card_product _ _
 
 theorem card_image₂_iff :
-    (image₂ f s t).card = s.card * t.card ↔ (s ×ˢ t : Set (α × β)).InjOn fun x => f x.1 x.2 := by
+    #(image₂ f s t) = #s * #t ↔ (s ×ˢ t : Set (α × β)).InjOn fun x => f x.1 x.2 := by
   rw [← card_product, ← coe_product]
   exact card_image_iff
 
 theorem card_image₂ (hf : Injective2 f) (s : Finset α) (t : Finset β) :
-    (image₂ f s t).card = s.card * t.card :=
+    #(image₂ f s t) = #s * #t :=
   (card_image_of_injective _ hf.uncurry).trans <| card_product _ _
 
 theorem mem_image₂_of_mem (ha : a ∈ s) (hb : b ∈ t) : f a b ∈ image₂ f s t :=
@@ -196,11 +196,11 @@ theorem image₂_congr' (h : ∀ a b, f a b = f' a b) : image₂ f s t = image�
 
 variable (s t)
 
-theorem card_image₂_singleton_left (hf : Injective (f a)) : (image₂ f {a} t).card = t.card := by
+theorem card_image₂_singleton_left (hf : Injective (f a)) : #(image₂ f {a} t) = #t := by
   rw [image₂_singleton_left, card_image_of_injective _ hf]
 
 theorem card_image₂_singleton_right (hf : Injective fun a => f a b) :
-    (image₂ f s {b}).card = s.card := by rw [image₂_singleton_right, card_image_of_injective _ hf]
+    #(image₂ f s {b}) = #s := by rw [image₂_singleton_right, card_image_of_injective _ hf]
 
 theorem image₂_singleton_inter [DecidableEq β] (t₁ t₂ : Finset β) (hf : Injective (f a)) :
     image₂ f {a} (t₁ ∩ t₂) = image₂ f {a} t₁ ∩ image₂ f {a} t₂ := by
@@ -211,13 +211,13 @@ theorem image₂_inter_singleton [DecidableEq α] (s₁ s₂ : Finset α) (hf : 
   simp_rw [image₂_singleton_right, image_inter _ _ hf]
 
 theorem card_le_card_image₂_left {s : Finset α} (hs : s.Nonempty) (hf : ∀ a, Injective (f a)) :
-    t.card ≤ (image₂ f s t).card := by
+    #t ≤ #(image₂ f s t) := by
   obtain ⟨a, ha⟩ := hs
   rw [← card_image₂_singleton_left _ (hf a)]
   exact card_le_card (image₂_subset_right <| singleton_subset_iff.2 ha)
 
 theorem card_le_card_image₂_right {t : Finset β} (ht : t.Nonempty)
-    (hf : ∀ b, Injective fun a => f a b) : s.card ≤ (image₂ f s t).card := by
+    (hf : ∀ b, Injective fun a => f a b) : #s ≤ #(image₂ f s t) := by
   obtain ⟨b, hb⟩ := ht
   rw [← card_image₂_singleton_right _ (hf b)]
   exact card_le_card (image₂_subset_left <| singleton_subset_iff.2 hb)
@@ -431,7 +431,7 @@ theorem image₂_right_identity {f : γ → β → γ} {b : β} (h : ∀ a, f a 
 applications are disjoint (but not necessarily distinct!), then the size of `t` divides the size of
 `Finset.image₂ f s t`. -/
 theorem card_dvd_card_image₂_right (hf : ∀ a ∈ s, Injective (f a))
-    (hs : ((fun a => t.image <| f a) '' s).PairwiseDisjoint id) : t.card ∣ (image₂ f s t).card := by
+    (hs : ((fun a => t.image <| f a) '' s).PairwiseDisjoint id) : #t ∣ #(image₂ f s t) := by
   classical
   induction' s using Finset.induction with a s _ ih
   · simp
@@ -453,7 +453,7 @@ applications are disjoint (but not necessarily distinct!), then the size of `s` 
 `Finset.image₂ f s t`. -/
 theorem card_dvd_card_image₂_left (hf : ∀ b ∈ t, Injective fun a => f a b)
     (ht : ((fun b => s.image fun a => f a b) '' t).PairwiseDisjoint id) :
-    s.card ∣ (image₂ f s t).card := by rw [← image₂_swap]; exact card_dvd_card_image₂_right hf ht
+    #s ∣ #(image₂ f s t) := by rw [← image₂_swap]; exact card_dvd_card_image₂_right hf ht
 
 /-- If a `Finset` is a subset of the image of two `Set`s under a binary operation,
 then it is a subset of the `Finset.image₂` of two `Finset` subsets of these `Set`s. -/

--- a/Mathlib/Data/Finset/Slice.lean
+++ b/Mathlib/Data/Finset/Slice.lean
@@ -39,13 +39,12 @@ variable {A B : Set (Finset α)} {s : Finset α} {r : ℕ}
 
 
 /-- `Sized r A` means that every Finset in `A` has size `r`. -/
-def Sized (r : ℕ) (A : Set (Finset α)) : Prop :=
-  ∀ ⦃x⦄, x ∈ A → card x = r
+def Sized (r : ℕ) (A : Set (Finset α)) : Prop := ∀ ⦃x⦄, x ∈ A → #x = r
 
 theorem Sized.mono (h : A ⊆ B) (hB : B.Sized r) : A.Sized r := fun _x hx => hB <| h hx
 
 @[simp] lemma sized_empty : (∅ : Set (Finset α)).Sized r := by simp [Sized]
-@[simp] lemma sized_singleton : ({s} : Set (Finset α)).Sized r ↔ s.card = r := by simp [Sized]
+@[simp] lemma sized_singleton : ({s} : Set (Finset α)).Sized r ↔ #s = r := by simp [Sized]
 
 theorem sized_union : (A ∪ B).Sized r ↔ A.Sized r ∧ B.Sized r :=
   ⟨fun hA => ⟨hA.mono subset_union_left, hA.mono subset_union_right⟩, fun hA _x hx =>
@@ -96,7 +95,7 @@ theorem subset_powersetCard_univ_iff : 𝒜 ⊆ powersetCard r univ ↔ (𝒜 : 
 alias ⟨_, _root_.Set.Sized.subset_powersetCard_univ⟩ := subset_powersetCard_univ_iff
 
 theorem _root_.Set.Sized.card_le (h𝒜 : (𝒜 : Set (Finset α)).Sized r) :
-    card 𝒜 ≤ (Fintype.card α).choose r := by
+    #𝒜 ≤ (Fintype.card α).choose r := by
   rw [Fintype.card, ← card_powersetCard]
   exact card_le_card (subset_powersetCard_univ_iff.mpr h𝒜)
 
@@ -110,15 +109,14 @@ section Slice
 variable {𝒜 : Finset (Finset α)} {A A₁ A₂ : Finset α} {r r₁ r₂ : ℕ}
 
 /-- The `r`-th slice of a set family is the subset of its elements which have cardinality `r`. -/
-def slice (𝒜 : Finset (Finset α)) (r : ℕ) : Finset (Finset α) :=
-  𝒜.filter fun i => i.card = r
+def slice (𝒜 : Finset (Finset α)) (r : ℕ) : Finset (Finset α) := {A ∈ 𝒜 | #A = r}
 
 -- Porting note: old code: scoped[FinsetFamily]
 @[inherit_doc]
 scoped[Finset] infixl:90 " # " => Finset.slice
 
 /-- `A` is in the `r`-th slice of `𝒜` iff it's in `𝒜` and has cardinality `r`. -/
-theorem mem_slice : A ∈ 𝒜 # r ↔ A ∈ 𝒜 ∧ A.card = r :=
+theorem mem_slice : A ∈ 𝒜 # r ↔ A ∈ 𝒜 ∧ #A = r :=
   mem_filter
 
 /-- The `r`-th slice of `𝒜` is a subset of `𝒜`. -/
@@ -143,10 +141,10 @@ variable [Fintype α] (𝒜)
 @[simp]
 theorem biUnion_slice [DecidableEq α] : (Iic <| Fintype.card α).biUnion 𝒜.slice = 𝒜 :=
   Subset.antisymm (biUnion_subset.2 fun _r _ => slice_subset) fun s hs =>
-    mem_biUnion.2 ⟨s.card, mem_Iic.2 <| s.card_le_univ, mem_slice.2 <| ⟨hs, rfl⟩⟩
+    mem_biUnion.2 ⟨#s, mem_Iic.2 <| s.card_le_univ, mem_slice.2 <| ⟨hs, rfl⟩⟩
 
 @[simp]
-theorem sum_card_slice : (∑ r ∈ Iic (Fintype.card α), (𝒜 # r).card) = 𝒜.card := by
+theorem sum_card_slice : ∑ r ∈ Iic (Fintype.card α), #(𝒜 # r) = #𝒜 := by
   letI := Classical.decEq α
   rw [← card_biUnion, biUnion_slice]
   exact Finset.pairwiseDisjoint_slice.subset (Set.subset_univ _)

--- a/Mathlib/Data/Finset/Sups.lean
+++ b/Mathlib/Data/Finset/Sups.lean
@@ -67,11 +67,9 @@ variable (s t)
 theorem coe_sups : (↑(s ⊻ t) : Set α) = ↑s ⊻ ↑t :=
   coe_image₂ _ _ _
 
-theorem card_sups_le : (s ⊻ t).card ≤ s.card * t.card :=
-  card_image₂_le _ _ _
+theorem card_sups_le : #(s ⊻ t) ≤ #s * #t := card_image₂_le _ _ _
 
-theorem card_sups_iff :
-    (s ⊻ t).card = s.card * t.card ↔ (s ×ˢ t : Set (α × α)).InjOn fun x => x.1 ⊔ x.2 :=
+theorem card_sups_iff : #(s ⊻ t) = #s * #t ↔ (s ×ˢ t : Set (α × α)).InjOn fun x => x.1 ⊔ x.2 :=
   card_image₂_iff
 
 variable {s s₁ s₂ t t₁ t₂ u}
@@ -162,7 +160,7 @@ lemma sups_subset_self : s ⊻ s ⊆ s ↔ SupClosed (s : Set α) := sups_subset
 @[simp] lemma univ_sups_univ [Fintype α] : (univ : Finset α) ⊻ univ = univ := by simp
 
 lemma filter_sups_le [@DecidableRel α (· ≤ ·)] (s t : Finset α) (a : α) :
-    (s ⊻ t).filter (· ≤ a) = s.filter (· ≤ a) ⊻ t.filter (· ≤ a) := by
+    {b ∈ s ⊻ t | b ≤ a} = {b ∈ s | b ≤ a} ⊻ {b ∈ t | b ≤ a} := by
   simp only [← coe_inj, coe_filter, coe_sups, ← mem_coe, Set.sep_sups_le]
 
 variable (s t u)
@@ -214,11 +212,9 @@ variable (s t)
 theorem coe_infs : (↑(s ⊼ t) : Set α) = ↑s ⊼ ↑t :=
   coe_image₂ _ _ _
 
-theorem card_infs_le : (s ⊼ t).card ≤ s.card * t.card :=
-  card_image₂_le _ _ _
+theorem card_infs_le : #(s ⊼ t) ≤ #s * #t := card_image₂_le _ _ _
 
-theorem card_infs_iff :
-    (s ⊼ t).card = s.card * t.card ↔ (s ×ˢ t : Set (α × α)).InjOn fun x => x.1 ⊓ x.2 :=
+theorem card_infs_iff : #(s ⊼ t) = #s * #t ↔ (s ×ˢ t : Set (α × α)).InjOn fun x => x.1 ⊓ x.2 :=
   card_image₂_iff
 
 variable {s s₁ s₂ t t₁ t₂ u}
@@ -309,7 +305,7 @@ lemma infs_self_subset : s ⊼ s ⊆ s ↔ InfClosed (s : Set α) := infs_subset
 @[simp] lemma univ_infs_univ [Fintype α] : (univ : Finset α) ⊼ univ = univ := by simp
 
 lemma filter_infs_le [@DecidableRel α (· ≤ ·)] (s t : Finset α) (a : α) :
-    (s ⊼ t).filter (a ≤ ·) = s.filter (a ≤ ·) ⊼ t.filter (a ≤ ·) := by
+    {b ∈ s ⊼ t | a ≤ b} = {b ∈ s | a ≤ b} ⊼ {b ∈ t | a ≤ b} := by
   simp only [← coe_inj, coe_filter, coe_infs, ← mem_coe, Set.sep_infs_le]
 
 variable (s t u)
@@ -396,8 +392,7 @@ variable [SemilatticeSup α] [OrderBot α] [@DecidableRel α Disjoint] (s s₁ s
 
 /-- The finset of elements of the form `a ⊔ b` where `a ∈ s`, `b ∈ t` and `a` and `b` are disjoint.
 -/
-def disjSups : Finset α :=
-  ((s ×ˢ t).filter fun ab : α × α => Disjoint ab.1 ab.2).image fun ab => ab.1 ⊔ ab.2
+def disjSups : Finset α := {ab ∈ s ×ˢ t | Disjoint ab.1 ab.2}.image fun ab => ab.1 ⊔ ab.2
 
 @[inherit_doc]
 scoped[FinsetFamily] infixl:74 " ○ " => Finset.disjSups
@@ -416,7 +411,7 @@ theorem disjSups_subset_sups : s ○ t ⊆ s ⊻ t := by
 
 variable (s t)
 
-theorem card_disjSups_le : (s ○ t).card ≤ s.card * t.card :=
+theorem card_disjSups_le : #(s ○ t) ≤ #s * #t :=
   (card_le_card disjSups_subset_sups).trans <| card_sups_le _ _
 
 variable {s s₁ s₂ t t₁ t₂}
@@ -534,10 +529,9 @@ variable (s t)
 @[simp, norm_cast] lemma coe_diffs : (↑(s \\ t) : Set α) = Set.image2 (· \ ·) s t :=
   coe_image₂ _ _ _
 
-lemma card_diffs_le : (s \\ t).card ≤ s.card * t.card := card_image₂_le _ _ _
+lemma card_diffs_le : #(s \\ t) ≤ #s * #t := card_image₂_le _ _ _
 
-lemma card_diffs_iff :
-    (s \\ t).card = s.card * t.card ↔ (s ×ˢ t : Set (α × α)).InjOn fun x ↦ x.1 \ x.2 :=
+lemma card_diffs_iff : #(s \\ t) = #s * #t ↔ (s ×ˢ t : Set (α × α)).InjOn fun x ↦ x.1 \ x.2 :=
   card_image₂_iff
 
 variable {s s₁ s₂ t t₁ t₂ u}
@@ -619,7 +613,7 @@ variable (s t)
 
 @[simp, norm_cast] lemma coe_compls : (↑sᶜˢ : Set α) = compl '' ↑s := coe_map _ _
 
-@[simp] lemma card_compls : sᶜˢ.card = s.card := card_map _
+@[simp] lemma card_compls : #sᶜˢ = #s := card_map _
 
 variable {s s₁ s₂ t t₁ t₂ u}
 

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -799,7 +799,7 @@ theorem filter_apply_pos {a : α} (h : p a) : f.filter p a = f a := if_pos h
 theorem filter_apply_neg {a : α} (h : ¬p a) : f.filter p a = 0 := if_neg h
 
 @[simp]
-theorem support_filter : (f.filter p).support = f.support.filter p := rfl
+theorem support_filter : (f.filter p).support = {x ∈ f.support | p x} := rfl
 
 theorem filter_zero : (0 : α →₀ M).filter p = 0 := by
   classical rw [← support_eq_empty, support_filter, support_zero, Finset.filter_empty]

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -171,7 +171,7 @@ theorem support_eq_empty {f : α →₀ M} : f.support = ∅ ↔ f = 0 :=
 theorem support_nonempty_iff {f : α →₀ M} : f.support.Nonempty ↔ f ≠ 0 := by
   simp only [Finsupp.support_eq_empty, Finset.nonempty_iff_ne_empty, Ne]
 
-theorem card_support_eq_zero {f : α →₀ M} : card f.support = 0 ↔ f = 0 := by simp
+theorem card_support_eq_zero {f : α →₀ M} : #f.support = 0 ↔ f = 0 := by simp
 
 instance instDecidableEq [DecidableEq α] [DecidableEq M] : DecidableEq (α →₀ M) := fun f g =>
   decidable_of_iff (f.support = g.support ∧ ∀ a ∈ f.support, f a = g a) ext_iff'.symm
@@ -388,11 +388,11 @@ theorem support_eq_singleton' {f : α →₀ M} {a : α} :
     fun ⟨_b, hb, hf⟩ => hf.symm ▸ support_single_ne_zero _ hb⟩
 
 theorem card_support_eq_one {f : α →₀ M} :
-    card f.support = 1 ↔ ∃ a, f a ≠ 0 ∧ f = single a (f a) := by
+    #f.support = 1 ↔ ∃ a, f a ≠ 0 ∧ f = single a (f a) := by
   simp only [card_eq_one, support_eq_singleton]
 
 theorem card_support_eq_one' {f : α →₀ M} :
-    card f.support = 1 ↔ ∃ a, ∃ b ≠ 0, f = single a b := by
+    #f.support = 1 ↔ ∃ a, ∃ b ≠ 0, f = single a b := by
   simp only [card_eq_one, support_eq_singleton']
 
 theorem support_subset_singleton {f : α →₀ M} {a : α} : f.support ⊆ {a} ↔ f = single a (f a) :=
@@ -403,11 +403,11 @@ theorem support_subset_singleton' {f : α →₀ M} {a : α} : f.support ⊆ {a}
     rw [hb, support_subset_singleton, single_eq_same]⟩
 
 theorem card_support_le_one [Nonempty α] {f : α →₀ M} :
-    card f.support ≤ 1 ↔ ∃ a, f = single a (f a) := by
+    #f.support ≤ 1 ↔ ∃ a, f = single a (f a) := by
   simp only [card_le_one_iff_subset_singleton, support_subset_singleton]
 
 theorem card_support_le_one' [Nonempty α] {f : α →₀ M} :
-    card f.support ≤ 1 ↔ ∃ a b, f = single a b := by
+    #f.support ≤ 1 ↔ ∃ a b, f = single a b := by
   simp only [card_le_one_iff_subset_singleton, support_subset_singleton']
 
 @[simp]
@@ -622,7 +622,7 @@ otherwise a better set representation is often available. -/
 def onFinset (s : Finset α) (f : α → M) (hf : ∀ a, f a ≠ 0 → a ∈ s) : α →₀ M where
   support :=
     haveI := Classical.decEq M
-    s.filter (f · ≠ 0)
+    {a ∈ s | f a ≠ 0}
   toFun := f
   mem_support_toFun := by classical simpa
 
@@ -644,7 +644,7 @@ theorem mem_support_onFinset {s : Finset α} {f : α → M} (hf : ∀ a : α, f 
 
 theorem support_onFinset [DecidableEq M] {s : Finset α} {f : α → M}
     (hf : ∀ a : α, f a ≠ 0 → a ∈ s) :
-    (Finsupp.onFinset s f hf).support = s.filter fun a => f a ≠ 0 := by
+    (Finsupp.onFinset s f hf).support = {a ∈ s | f a ≠ 0} := by
   dsimp [onFinset]; congr
 
 end OnFinset

--- a/Mathlib/Data/Finsupp/Indicator.lean
+++ b/Mathlib/Data/Finsupp/Indicator.lean
@@ -33,7 +33,7 @@ def indicator (s : Finset ι) (f : ∀ i ∈ s, α) : ι →₀ α where
     if H : i ∈ s then f i H else 0
   support :=
     haveI := Classical.decEq α
-    (s.attach.filter fun i : s => f i.1 i.2 ≠ 0).map (Embedding.subtype _)
+    ({i | f i.1 i.2 ≠ 0} : Finset s).map (Embedding.subtype _)
   mem_support_toFun i := by
     classical simp
 

--- a/Mathlib/Data/Finsupp/Interval.lean
+++ b/Mathlib/Data/Finsupp/Interval.lean
@@ -97,19 +97,19 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder (ι →₀ α) :=
 theorem Icc_eq : Icc f g = (f.support ∪ g.support).finsupp (f.rangeIcc g) := rfl
 
 -- Porting note: removed [DecidableEq ι]
-theorem card_Icc : (Icc f g).card = ∏ i ∈ f.support ∪ g.support, (Icc (f i) (g i)).card := by
+theorem card_Icc : #(Icc f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)):= by
   simp_rw [Icc_eq, card_finsupp, coe_rangeIcc]
 
 -- Porting note: removed [DecidableEq ι]
-theorem card_Ico : (Ico f g).card = (∏ i ∈ f.support ∪ g.support, (Icc (f i) (g i)).card) - 1 := by
+theorem card_Ico : #(Ico f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)) - 1 := by
   rw [card_Ico_eq_card_Icc_sub_one, card_Icc]
 
 -- Porting note: removed [DecidableEq ι]
-theorem card_Ioc : (Ioc f g).card = (∏ i ∈ f.support ∪ g.support, (Icc (f i) (g i)).card) - 1 := by
+theorem card_Ioc : #(Ioc f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)) - 1 := by
   rw [card_Ioc_eq_card_Icc_sub_one, card_Icc]
 
 -- Porting note: removed [DecidableEq ι]
-theorem card_Ioo : (Ioo f g).card = (∏ i ∈ f.support ∪ g.support, (Icc (f i) (g i)).card) - 2 := by
+theorem card_Ioo : #(Ioo f g) = ∏ i ∈ f.support ∪ g.support, #(Icc (f i) (g i)) - 2 := by
   rw [card_Ioo_eq_card_Icc_sub_two, card_Icc]
 
 end PartialOrder
@@ -119,7 +119,7 @@ variable [Lattice α] [Zero α] [LocallyFiniteOrder α] (f g : ι →₀ α)
 
 -- Porting note: removed [DecidableEq ι]
 theorem card_uIcc :
-    (uIcc f g).card = ∏ i ∈ f.support ∪ g.support, (uIcc (f i) (g i)).card := by
+    #(uIcc f g) = ∏ i ∈ f.support ∪ g.support, #(uIcc (f i) (g i)) := by
   rw [← support_inf_union_support_sup]; exact card_Icc (_ : ι →₀ α) _
 
 end Lattice
@@ -129,11 +129,11 @@ section CanonicallyOrdered
 variable [CanonicallyOrderedAddCommMonoid α] [LocallyFiniteOrder α]
 variable (f : ι →₀ α)
 
-theorem card_Iic : (Iic f).card = ∏ i ∈ f.support, (Iic (f i)).card := by
+theorem card_Iic : #(Iic f) = ∏ i ∈ f.support, #(Iic (f i)) := by
   classical simp_rw [Iic_eq_Icc, card_Icc, Finsupp.bot_eq_zero, support_zero, empty_union,
       zero_apply, bot_eq_zero]
 
-theorem card_Iio : (Iio f).card = (∏ i ∈ f.support, (Iic (f i)).card) - 1 := by
+theorem card_Iio : #(Iio f) = ∏ i ∈ f.support, #(Iic (f i)) - 1 := by
   rw [card_Iio_eq_card_Iic_sub_one, card_Iic]
 
 end CanonicallyOrdered

--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -104,20 +104,20 @@ section Pi
 variable {ι κ : Type*} {α : ι → Type*} [DecidableEq ι] [DecidableEq κ]
 
 @[simp] lemma Finset.card_pi (s : Finset ι) (t : ∀ i, Finset (α i)) :
-    (s.pi t).card = ∏ i ∈ s, card (t i) := Multiset.card_pi _ _
+    #(s.pi t) = ∏ i ∈ s, #(t i) := Multiset.card_pi _ _
 
 namespace Fintype
 
 variable [Fintype ι]
 
 @[simp] lemma card_piFinset (s : ∀ i, Finset (α i)) :
-    (piFinset s).card = ∏ i, (s i).card := by simp [piFinset, card_map]
+    #(piFinset s) = ∏ i, #(s i) := by simp [piFinset, card_map]
 
 /-- This lemma is specifically designed to be used backwards, whence the specialisation to `Fin n`
 as the indexing type doesn't matter in practice. The more general forward direction lemma here is
 `Fintype.card_piFinset`. -/
 lemma card_piFinset_const {α : Type*} (s : Finset α) (n : ℕ) :
-    (piFinset fun _ : Fin n ↦ s).card = s.card ^ n := by simp
+    #(piFinset fun _ : Fin n ↦ s) = #s ^ n := by simp
 
 @[simp] lemma card_pi [∀ i, Fintype (α i)] : card (∀ i, α i) = ∏ i, card (α i) :=
   card_piFinset _
@@ -132,37 +132,35 @@ lemma card_pi_const (α : Type*) [Fintype α] (n : ℕ) : card (Fin n → α) = 
     card (Sigma α) = ∑ i, card (α i) := card_sigma _ _
 
 /-- The number of dependent maps `f : Π j, s j` for which the `i` component is `a` is the product
-over all `j ≠ i` of `(s j).card`.
+over all `j ≠ i` of `#(s j)`.
 
 Note that this is just a composition of easier lemmas, but there's some glue missing to make that
 smooth enough not to need this lemma. -/
 lemma card_filter_piFinset_eq_of_mem [∀ i, DecidableEq (α i)]
     (s : ∀ i, Finset (α i)) (i : ι) {a : α i} (ha : a ∈ s i) :
-    ((piFinset s).filter fun f ↦ f i = a).card = ∏ j ∈ univ.erase i, (s j).card := by
+    #{f ∈ piFinset s | f i = a} = ∏ j ∈ univ.erase i, #(s j) := by
   calc
-    _ = ∏ j, (Function.update s i {a} j).card := by
+    _ = ∏ j, #(Function.update s i {a} j) := by
       rw [← piFinset_update_singleton_eq_filter_piFinset_eq _ _ ha, Fintype.card_piFinset]
-    _ = ∏ j, Function.update (fun j ↦ (s j).card) i 1 j :=
+    _ = ∏ j, Function.update (fun j ↦ #(s j)) i 1 j :=
       Fintype.prod_congr _ _ fun j ↦ by obtain rfl | hji := eq_or_ne j i <;> simp [*]
     _ = _ := by simp [prod_update_of_mem, erase_eq]
 
 lemma card_filter_piFinset_const_eq_of_mem (s : Finset κ) (i : ι) {x : κ} (hx : x ∈ s) :
-    ((piFinset fun _ ↦ s).filter fun f ↦ f i = x).card = s.card ^ (card ι - 1) :=
+    #{f ∈ piFinset fun _ ↦ s | f i = x} = #s ^ (card ι - 1) :=
   (card_filter_piFinset_eq_of_mem _ _ hx).trans <| by
-    rw [prod_const s.card, card_erase_of_mem (mem_univ _), card_univ]
+    rw [prod_const #s, card_erase_of_mem (mem_univ _), card_univ]
 
 lemma card_filter_piFinset_eq [∀ i, DecidableEq (α i)] (s : ∀ i, Finset (α i)) (i : ι) (a : α i) :
-    ((piFinset s).filter fun f ↦ f i = a).card =
-      if a ∈ s i then ∏ b ∈ univ.erase i, (s b).card else 0 := by
+    #{f ∈ piFinset s | f i = a} = if a ∈ s i then ∏ b ∈ univ.erase i, #(s b) else 0 := by
   split_ifs with h
   · rw [card_filter_piFinset_eq_of_mem _ _ h]
   · rw [filter_piFinset_of_not_mem _ _ _ h, Finset.card_empty]
 
 lemma card_filter_piFinset_const (s : Finset κ) (i : ι) (j : κ) :
-    ((piFinset fun _ ↦ s).filter fun f ↦ f i = j).card =
-      if j ∈ s then s.card ^ (card ι - 1) else 0 :=
+    #{f ∈ piFinset fun _ ↦ s | f i = j} = if j ∈ s then #s ^ (card ι - 1) else 0 :=
   (card_filter_piFinset_eq _ _ _).trans <| by
-    rw [prod_const s.card, card_erase_of_mem (mem_univ _), card_univ]
+    rw [prod_const #s, card_erase_of_mem (mem_univ _), card_univ]
 
 end Fintype
 end Pi

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -112,21 +112,21 @@ def truncFinBijection (α) [Fintype α] : Trunc { f : Fin (card α) → α // Bi
       mem_univ_val univ.2
 
 theorem subtype_card {p : α → Prop} (s : Finset α) (H : ∀ x : α, x ∈ s ↔ p x) :
-    @card { x // p x } (Fintype.subtype s H) = s.card :=
+    @card { x // p x } (Fintype.subtype s H) = #s :=
   Multiset.card_pmap _ _ _
 
 theorem card_of_subtype {p : α → Prop} (s : Finset α) (H : ∀ x : α, x ∈ s ↔ p x)
-    [Fintype { x // p x }] : card { x // p x } = s.card := by
+    [Fintype { x // p x }] : card { x // p x } = #s := by
   rw [← subtype_card s H]
   congr!
 
 @[simp]
 theorem card_ofFinset {p : Set α} (s : Finset α) (H : ∀ x, x ∈ s ↔ x ∈ p) :
-    @Fintype.card p (ofFinset s H) = s.card :=
+    @Fintype.card p (ofFinset s H) = #s :=
   Fintype.subtype_card s H
 
 theorem card_of_finset' {p : Set α} (s : Finset α) (H : ∀ x, x ∈ s ↔ x ∈ p) [Fintype p] :
-    Fintype.card p = s.card := by rw [← card_ofFinset s H]; congr!
+    Fintype.card p = #s := by rw [← card_ofFinset s H]; congr!
 
 end Fintype
 
@@ -223,50 +223,47 @@ theorem toFinset_card {α : Type*} (s : Set α) [Fintype s] : s.toFinset.card = 
 end Set
 
 @[simp]
-theorem Finset.card_univ [Fintype α] : (Finset.univ : Finset α).card = Fintype.card α :=
-  rfl
+theorem Finset.card_univ [Fintype α] : #(univ : Finset α) = Fintype.card α := rfl
 
-theorem Finset.eq_univ_of_card [Fintype α] (s : Finset α) (hs : s.card = Fintype.card α) :
+theorem Finset.eq_univ_of_card [Fintype α] (s : Finset α) (hs : #s = Fintype.card α) :
     s = univ :=
   eq_of_subset_of_card_le (subset_univ _) <| by rw [hs, Finset.card_univ]
 
-theorem Finset.card_eq_iff_eq_univ [Fintype α] (s : Finset α) :
-    s.card = Fintype.card α ↔ s = Finset.univ :=
+theorem Finset.card_eq_iff_eq_univ [Fintype α] (s : Finset α) : #s = Fintype.card α ↔ s = univ :=
   ⟨s.eq_univ_of_card, by
     rintro rfl
     exact Finset.card_univ⟩
 
-theorem Finset.card_le_univ [Fintype α] (s : Finset α) : s.card ≤ Fintype.card α :=
+theorem Finset.card_le_univ [Fintype α] (s : Finset α) : #s ≤ Fintype.card α :=
   card_le_card (subset_univ s)
 
 theorem Finset.card_lt_univ_of_not_mem [Fintype α] {s : Finset α} {x : α} (hx : x ∉ s) :
-    s.card < Fintype.card α :=
+    #s < Fintype.card α :=
   card_lt_card ⟨subset_univ s, not_forall.2 ⟨x, fun hx' => hx (hx' <| mem_univ x)⟩⟩
 
 theorem Finset.card_lt_iff_ne_univ [Fintype α] (s : Finset α) :
-    s.card < Fintype.card α ↔ s ≠ Finset.univ :=
+    #s < Fintype.card α ↔ s ≠ Finset.univ :=
   s.card_le_univ.lt_iff_ne.trans (not_congr s.card_eq_iff_eq_univ)
 
 theorem Finset.card_compl_lt_iff_nonempty [Fintype α] [DecidableEq α] (s : Finset α) :
-    sᶜ.card < Fintype.card α ↔ s.Nonempty :=
+    #sᶜ < Fintype.card α ↔ s.Nonempty :=
   sᶜ.card_lt_iff_ne_univ.trans s.compl_ne_univ_iff_nonempty
 
 theorem Finset.card_univ_diff [DecidableEq α] [Fintype α] (s : Finset α) :
-    (Finset.univ \ s).card = Fintype.card α - s.card :=
+    #(univ \ s) = Fintype.card α - #s :=
   Finset.card_sdiff (subset_univ s)
 
-theorem Finset.card_compl [DecidableEq α] [Fintype α] (s : Finset α) :
-    sᶜ.card = Fintype.card α - s.card :=
+theorem Finset.card_compl [DecidableEq α] [Fintype α] (s : Finset α) : #sᶜ = Fintype.card α - #s :=
   Finset.card_univ_diff s
 
 @[simp]
 theorem Finset.card_add_card_compl [DecidableEq α] [Fintype α] (s : Finset α) :
-    s.card + sᶜ.card = Fintype.card α := by
+    #s + #sᶜ = Fintype.card α := by
   rw [Finset.card_compl, ← Nat.add_sub_assoc (card_le_univ s), Nat.add_sub_cancel_left]
 
 @[simp]
 theorem Finset.card_compl_add_card [DecidableEq α] [Fintype α] (s : Finset α) :
-    sᶜ.card + s.card = Fintype.card α := by
+    #sᶜ + #s = Fintype.card α := by
   rw [add_comm, card_add_card_compl]
 
 theorem Fintype.card_compl_set [Fintype α] (s : Set α) [Fintype s] [Fintype (↥sᶜ : Sort _)] :
@@ -286,7 +283,7 @@ theorem Fintype.card_fin_lt_of_le {m n : ℕ} (h : m ≤ n) :
           left_inv := fun i ↦ rfl
           right_inv := fun i ↦ rfl }
 
-theorem Finset.card_fin (n : ℕ) : Finset.card (Finset.univ : Finset (Fin n)) = n := by simp
+theorem Finset.card_fin (n : ℕ) : #(univ : Finset (Fin n)) = n := by simp
 
 /-- `Fin` as a map from `ℕ` to `Type` is injective. Note that since this is a statement about
 equality of types, using it should be avoided if possible. -/
@@ -303,7 +300,7 @@ theorem Fin.cast_eq_cast' {n m : ℕ} (h : Fin n = Fin m) :
   cases fin_injective h
   rfl
 
-theorem card_finset_fin_le {n : ℕ} (s : Finset (Fin n)) : s.card ≤ n := by
+theorem card_finset_fin_le {n : ℕ} (s : Finset (Fin n)) : #s ≤ n := by
   simpa only [Fintype.card_fin] using s.card_le_univ
 
 --@[simp] Porting note (#10618): simp can prove it
@@ -531,7 +528,7 @@ theorem card_eq_one_of_forall_eq {i : α} (h : ∀ j, j = i) : card α = 1 :=
   Fintype.card_eq_one_iff.2 ⟨i, h⟩
 
 theorem exists_unique_iff_card_one {α} [Fintype α] (p : α → Prop) [DecidablePred p] :
-    (∃! a : α, p a) ↔ (Finset.univ.filter p).card = 1 := by
+    (∃! a : α, p a) ↔ #{x | p x} = 1 := by
   rw [Finset.card_eq_one]
   refine exists_congr fun x => ?_
   simp only [forall_true_left, Subset.antisymm_iff, subset_singleton_iff', singleton_subset_iff,
@@ -650,36 +647,36 @@ def ofRightInverseOfCardLE (hαβ : card α ≤ card β) (f : α → β) (g : β
 end Equiv
 
 @[simp]
-theorem Fintype.card_coe (s : Finset α) [Fintype s] : Fintype.card s = s.card :=
+theorem Fintype.card_coe (s : Finset α) [Fintype s] : Fintype.card s = #s :=
   @Fintype.card_of_finset' _ _ _ (fun _ => Iff.rfl) (id _)
 
-/-- Noncomputable equivalence between a finset `s` coerced to a type and `Fin s.card`. -/
-noncomputable def Finset.equivFin (s : Finset α) : s ≃ Fin s.card :=
+/-- Noncomputable equivalence between a finset `s` coerced to a type and `Fin #s`. -/
+noncomputable def Finset.equivFin (s : Finset α) : s ≃ Fin #s :=
   Fintype.equivFinOfCardEq (Fintype.card_coe _)
 
 /-- Noncomputable equivalence between a finset `s` as a fintype and `Fin n`, when there is a
-proof that `s.card = n`. -/
-noncomputable def Finset.equivFinOfCardEq {s : Finset α} {n : ℕ} (h : s.card = n) : s ≃ Fin n :=
+proof that `#s = n`. -/
+noncomputable def Finset.equivFinOfCardEq {s : Finset α} {n : ℕ} (h : #s = n) : s ≃ Fin n :=
   Fintype.equivFinOfCardEq ((Fintype.card_coe _).trans h)
 
-theorem Finset.card_eq_of_equiv_fin {s : Finset α} {n : ℕ} (i : s ≃ Fin n) : s.card = n :=
+theorem Finset.card_eq_of_equiv_fin {s : Finset α} {n : ℕ} (i : s ≃ Fin n) : #s = n :=
   Fin.equiv_iff_eq.1 ⟨s.equivFin.symm.trans i⟩
 
 theorem Finset.card_eq_of_equiv_fintype {s : Finset α} [Fintype β] (i : s ≃ β) :
-    s.card = Fintype.card β := card_eq_of_equiv_fin <| i.trans <| Fintype.equivFin β
+    #s = Fintype.card β := card_eq_of_equiv_fin <| i.trans <| Fintype.equivFin β
 
 /-- Noncomputable equivalence between two finsets `s` and `t` as fintypes when there is a proof
-that `s.card = t.card`. -/
-noncomputable def Finset.equivOfCardEq {s : Finset α} {t : Finset β} (h : s.card = t.card) :
+that `#s = #t`. -/
+noncomputable def Finset.equivOfCardEq {s : Finset α} {t : Finset β} (h : #s = #t) :
     s ≃ t := Fintype.equivOfCardEq ((Fintype.card_coe _).trans (h.trans (Fintype.card_coe _).symm))
 
-theorem Finset.card_eq_of_equiv {s : Finset α} {t : Finset β} (i : s ≃ t) : s.card = t.card :=
+theorem Finset.card_eq_of_equiv {s : Finset α} {t : Finset β} (i : s ≃ t) : #s = #t :=
   (card_eq_of_equiv_fintype i).trans (Fintype.card_coe _)
 
 /-- We can inflate a set `s` to any bigger size. -/
-lemma Finset.exists_superset_card_eq [Fintype α] {n : ℕ} {s : Finset α} (hsn : s.card ≤ n)
+lemma Finset.exists_superset_card_eq [Fintype α] {n : ℕ} {s : Finset α} (hsn : #s ≤ n)
     (hnα : n ≤ Fintype.card α) :
-    ∃ t, s ⊆ t ∧ t.card = n := by simpa using exists_subsuperset_card_eq s.subset_univ hsn hnα
+    ∃ t, s ⊆ t ∧ #t = n := by simpa using exists_subsuperset_card_eq s.subset_univ hsn hnα
 
 @[simp]
 theorem Fintype.card_prop : Fintype.card Prop = 2 :=
@@ -730,7 +727,7 @@ theorem nonempty_iff_card_le [Fintype α] [Fintype β] :
     Nonempty (α ↪ β) ↔ Fintype.card α ≤ Fintype.card β :=
   ⟨fun ⟨e⟩ => Fintype.card_le_of_embedding e, nonempty_of_card_le⟩
 
-theorem exists_of_card_le_finset [Fintype α] {s : Finset β} (h : Fintype.card α ≤ s.card) :
+theorem exists_of_card_le_finset [Fintype α] {s : Finset β} (h : Fintype.card α ≤ #s) :
     ∃ f : α ↪ β, Set.range f ⊆ s := by
   rw [← Fintype.card_coe] at h
   rcases nonempty_of_card_le h with ⟨f⟩
@@ -762,7 +759,7 @@ theorem Fintype.card_subtype_lt [Fintype α] {p : α → Prop} [DecidablePred p]
     rwa [Subtype.range_coe_subtype]
 
 theorem Fintype.card_subtype [Fintype α] (p : α → Prop) [DecidablePred p] :
-    Fintype.card { x // p x } = ((Finset.univ : Finset α).filter p).card := by
+    Fintype.card { x // p x } = #{x | p x} := by
   refine Fintype.card_of_subtype _ ?_
   simp
 
@@ -812,9 +809,7 @@ theorem wellFounded_of_trans_of_irrefl (r : α → α → Prop) [IsTrans α r] [
     WellFounded r := by
   classical
   cases nonempty_fintype α
-  have :
-    ∀ x y, r x y → (univ.filter fun z => r z x).card < (univ.filter fun z => r z y).card :=
-    fun x y hxy =>
+  have (x y) (hxy : r x y) : #{z | r z x} < #{z | r z y} :=
     Finset.card_lt_card <| by
       simp only [Finset.lt_iff_ssubset.symm, lt_iff_le_not_le, Finset.le_iff_subset,
           Finset.subset_iff, mem_filter, true_and, mem_univ, hxy]
@@ -886,7 +881,7 @@ theorem of_injective_to_set {s : Set α} (hs : s ≠ Set.univ) {f : α → s} (h
       refine lt_irrefl (Fintype.card α) ?_
       calc
         Fintype.card α ≤ Fintype.card s := Fintype.card_le_of_injective f hf
-        _ = s.toFinset.card := s.toFinset_card.symm
+        _ = #s.toFinset := s.toFinset_card.symm
         _ < Fintype.card α :=
           Finset.card_lt_card <| by rwa [Set.toFinset_ssubset_univ, Set.ssubset_univ_iff]
 
@@ -999,14 +994,14 @@ noncomputable def natEmbedding (α : Type*) [Infinite α] : ℕ ↪ α :=
   ⟨_, natEmbeddingAux_injective α⟩
 
 /-- See `Infinite.exists_superset_card_eq` for a version that, for an `s : Finset α`,
-provides a superset `t : Finset α`, `s ⊆ t` such that `t.card` is fixed. -/
-theorem exists_subset_card_eq (α : Type*) [Infinite α] (n : ℕ) : ∃ s : Finset α, s.card = n :=
+provides a superset `t : Finset α`, `s ⊆ t` such that `#t` is fixed. -/
+theorem exists_subset_card_eq (α : Type*) [Infinite α] (n : ℕ) : ∃ s : Finset α, #s = n :=
   ⟨(range n).map (natEmbedding α), by rw [card_map, card_range]⟩
 
 /-- See `Infinite.exists_subset_card_eq` for a version that provides an arbitrary
 `s : Finset α` for any cardinality. -/
-theorem exists_superset_card_eq [Infinite α] (s : Finset α) (n : ℕ) (hn : s.card ≤ n) :
-    ∃ t : Finset α, s ⊆ t ∧ t.card = n := by
+theorem exists_superset_card_eq [Infinite α] (s : Finset α) (n : ℕ) (hn : #s ≤ n) :
+    ∃ t : Finset α, s ⊆ t ∧ #t = n := by
   induction' n with n IH generalizing s
   · exact ⟨s, subset_refl _, Nat.eq_zero_of_le_zero hn⟩
   · rcases hn.eq_or_lt with hn' | hn'
@@ -1019,7 +1014,7 @@ theorem exists_superset_card_eq [Infinite α] (s : Finset α) (n : ℕ) (hn : s.
 end Infinite
 
 /-- If every finset in a type has bounded cardinality, that type is finite. -/
-noncomputable def fintypeOfFinsetCardLe {ι : Type*} (n : ℕ) (w : ∀ s : Finset ι, s.card ≤ n) :
+noncomputable def fintypeOfFinsetCardLe {ι : Type*} (n : ℕ) (w : ∀ s : Finset ι, #s ≤ n) :
     Fintype ι := by
   apply fintypeOfNotInfinite
   intro i

--- a/Mathlib/Data/Fintype/Fin.lean
+++ b/Mathlib/Data/Fintype/Fin.lean
@@ -53,19 +53,18 @@ theorem Iio_castSucc (i : Fin n) : Iio (castSucc i) = (Iio i).map Fin.castSuccEm
   exact (Fin.map_valEmbedding_Iio i).symm
 
 theorem card_filter_univ_succ (p : Fin (n + 1) → Prop) [DecidablePred p] :
-    (univ.filter p).card =
-    if p 0 then (univ.filter (p ∘ Fin.succ)).card + 1 else (univ.filter (p ∘ Fin.succ)).card := by
+    #{x | p x} = if p 0 then #{x | p (.succ x)} + 1 else #{x | p (.succ x)} := by
   rw [Fin.univ_succ, filter_cons, apply_ite Finset.card, card_cons, filter_map, card_map]; rfl
 
 theorem card_filter_univ_succ' (p : Fin (n + 1) → Prop) [DecidablePred p] :
-    (univ.filter p).card = ite (p 0) 1 0 + (univ.filter (p ∘ Fin.succ)).card := by
+    #{x | p x} = ite (p 0) 1 0 + #{x | p (.succ x)}:= by
   rw [card_filter_univ_succ]; split_ifs <;> simp [add_comm]
 
 theorem card_filter_univ_eq_vector_get_eq_count [DecidableEq α] (a : α) (v : Vector α n) :
-    (univ.filter fun i => v.get i = a).card = v.toList.count a := by
+    #{i | v.get i = a} = v.toList.count a := by
   induction' v with n x xs hxs
   · simp
-  · simp_rw [card_filter_univ_succ', Vector.get_cons_zero, Vector.toList_cons, Function.comp_def,
-      Vector.get_cons_succ, hxs, List.count_cons, add_comm (ite (x = a) 1 0), beq_iff_eq]
+  · simp_rw [card_filter_univ_succ', Vector.get_cons_zero, Vector.toList_cons, Vector.get_cons_succ,
+      hxs, List.count_cons, add_comm (ite (x = a) 1 0), beq_iff_eq]
 
 end Fin

--- a/Mathlib/Data/Fintype/Perm.lean
+++ b/Mathlib/Data/Fintype/Perm.lean
@@ -133,7 +133,7 @@ theorem mem_perms_of_finset_iff :
     ∀ {s : Finset α} {f : Perm α}, f ∈ permsOfFinset s ↔ ∀ {x}, f x ≠ x → x ∈ s := by
   rintro ⟨⟨l⟩, hs⟩ f; exact mem_permsOfList_iff
 
-theorem card_perms_of_finset : ∀ s : Finset α, (permsOfFinset s).card = s.card ! := by
+theorem card_perms_of_finset : ∀ s : Finset α, #(permsOfFinset s) = (#s)! := by
   rintro ⟨⟨l⟩, hs⟩; exact length_permsOfList l
 
 /-- The collection of permutations of a fintype is a fintype. -/

--- a/Mathlib/Data/Fintype/Pi.lean
+++ b/Mathlib/Data/Fintype/Pi.lean
@@ -104,12 +104,12 @@ lemma eval_image_piFinset_const {β} [DecidableEq β] (t : Finset β) (a : α) :
 variable [∀ a, DecidableEq (δ a)]
 
 lemma filter_piFinset_of_not_mem (t : ∀ a, Finset (δ a)) (a : α) (x : δ a) (hx : x ∉ t a) :
-    (piFinset t).filter (· a = x) = ∅ := by
+    {f ∈ piFinset t | f a = x} = ∅ := by
   simp only [filter_eq_empty_iff, mem_piFinset]; rintro f hf rfl; exact hx (hf _)
 
 -- TODO: This proof looks like a good example of something that `aesop` can't do but should
 lemma piFinset_update_eq_filter_piFinset_mem (s : ∀ i, Finset (δ i)) (i : α) {t : Finset (δ i)}
-    (hts : t ⊆ s i) : piFinset (Function.update s i t) = (piFinset s).filter (fun f ↦ f i ∈ t) := by
+    (hts : t ⊆ s i) : piFinset (Function.update s i t) = {f ∈ piFinset s | f i ∈ t} := by
   ext f
   simp only [mem_piFinset, mem_filter]
   refine ⟨fun h ↦ ?_, fun h j ↦ ?_⟩
@@ -124,7 +124,7 @@ lemma piFinset_update_eq_filter_piFinset_mem (s : ∀ i, Finset (δ i)) (i : α)
 
 lemma piFinset_update_singleton_eq_filter_piFinset_eq (s : ∀ i, Finset (δ i)) (i : α) {a : δ i}
     (ha : a ∈ s i) :
-    piFinset (Function.update s i {a}) = (piFinset s).filter (fun f ↦ f i = a) := by
+    piFinset (Function.update s i {a}) = {f ∈ piFinset s | f i = a} := by
   simp [piFinset_update_eq_filter_piFinset_mem, ha]
 
 end Fintype
@@ -172,7 +172,7 @@ namespace Finset
 variable {ι : Type*} [DecidableEq (ι → α)] {s : Finset α} {f : ι → α}
 
 lemma piFinset_filter_const [DecidableEq ι] [Fintype ι] :
-    (Fintype.piFinset fun _ ↦ s).filter (∃ a ∈ s, const ι a = ·) = s.piDiag ι := by aesop
+    {f ∈ Fintype.piFinset fun _ : ι ↦ s | ∃ a ∈ s, const ι a = f} = s.piDiag ι := by aesop
 
 lemma piDiag_subset_piFinset [DecidableEq ι] [Fintype ι] :
     s.piDiag ι ⊆ Fintype.piFinset fun _ ↦ s := by simp [← piFinset_filter_const]

--- a/Mathlib/Data/Fintype/Powerset.lean
+++ b/Mathlib/Data/Fintype/Powerset.lean
@@ -29,30 +29,30 @@ variable [Fintype α] {s : Finset α} {k : ℕ}
   coe_injective <| by simp [-coe_eq_univ]
 
 lemma filter_subset_univ [DecidableEq α] (s : Finset α) :
-    filter (fun t ↦ t ⊆ s) univ = powerset s := by ext; simp
+    ({t | t ⊆ s} : Finset _) = powerset s := by ext; simp
 
 @[simp] lemma powerset_eq_univ : s.powerset = univ ↔ s = univ := by
   rw [← Finset.powerset_univ, powerset_inj]
 
-lemma mem_powersetCard_univ : s ∈ powersetCard k (univ : Finset α) ↔ card s = k :=
+lemma mem_powersetCard_univ : s ∈ powersetCard k (univ : Finset α) ↔ #s = k :=
   mem_powersetCard.trans <| and_iff_right <| subset_univ _
 
 variable (α)
 
 @[simp] lemma univ_filter_card_eq (k : ℕ) :
-    (univ : Finset (Finset α)).filter (fun s ↦ s.card = k) = univ.powersetCard k := by ext; simp
+   ({s | #s = k} : Finset (Finset α)) = univ.powersetCard k := by ext; simp
 
 end Finset
 
 @[simp]
 theorem Fintype.card_finset_len [Fintype α] (k : ℕ) :
-    Fintype.card { s : Finset α // s.card = k } = Nat.choose (Fintype.card α) k := by
+    Fintype.card { s : Finset α // #s = k } = Nat.choose (Fintype.card α) k := by
   simp [Fintype.subtype_card, Finset.card_univ]
 
 instance Set.fintype [Fintype α] : Fintype (Set α) :=
   ⟨(@Finset.univ (Finset α) _).map coeEmb.1, fun s => by
     classical
-    refine mem_map.2 ⟨Finset.univ.filter (· ∈ s), Finset.mem_univ _, (coe_filter _ _).trans ?_⟩
+    refine mem_map.2 ⟨({a | a ∈ s} : Finset _), Finset.mem_univ _, (coe_filter _ _).trans ?_⟩
     simp⟩
 
 -- Not to be confused with `Set.Finite`, the predicate

--- a/Mathlib/Data/Fintype/Sort.lean
+++ b/Mathlib/Data/Fintype/Sort.lean
@@ -32,7 +32,7 @@ variable {α : Type*} [DecidableEq α] [Fintype α] [LinearOrder α] {m n : ℕ}
 cardinality `n`, then `Fin m ⊕ Fin n ≃ α`. The equivalence sends elements of `Fin m` to
 elements of `s` and elements of `Fin n` to elements of `sᶜ` while preserving order on each
 "half" of `Fin m ⊕ Fin n` (using `Set.orderIsoOfFin`). -/
-def finSumEquivOfFinset (hm : s.card = m) (hn : sᶜ.card = n) : Fin m ⊕ Fin n ≃ α :=
+def finSumEquivOfFinset (hm : #s = m) (hn : #sᶜ = n) : Fin m ⊕ Fin n ≃ α :=
   calc
     Fin m ⊕ Fin n ≃ (s : Set α) ⊕ (sᶜ : Set α) :=
       Equiv.sumCongr (s.orderIsoOfFin hm).toEquiv <|
@@ -40,11 +40,11 @@ def finSumEquivOfFinset (hm : s.card = m) (hn : sᶜ.card = n) : Fin m ⊕ Fin n
     _ ≃ α := Equiv.Set.sumCompl _
 
 @[simp]
-theorem finSumEquivOfFinset_inl (hm : s.card = m) (hn : sᶜ.card = n) (i : Fin m) :
+theorem finSumEquivOfFinset_inl (hm : #s = m) (hn : #sᶜ = n) (i : Fin m) :
     finSumEquivOfFinset hm hn (Sum.inl i) = s.orderEmbOfFin hm i :=
   rfl
 
 @[simp]
-theorem finSumEquivOfFinset_inr (hm : s.card = m) (hn : sᶜ.card = n) (i : Fin n) :
+theorem finSumEquivOfFinset_inr (hm : #s = m) (hn : #sᶜ = n) (i : Fin n) :
     finSumEquivOfFinset hm hn (Sum.inr i) = sᶜ.orderEmbOfFin hn i :=
   rfl

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -70,7 +70,7 @@ theorem image_subtype_univ_ssubset_image_univ [Fintype α] [DecidableEq β] (k :
 /-- Any injection from a finset `s` in a fintype `α` to a finset `t` of the same cardinality as `α`
 can be extended to a bijection between `α` and `t`. -/
 theorem Finset.exists_equiv_extend_of_card_eq [Fintype α] [DecidableEq β] {t : Finset β}
-    (hαt : Fintype.card α = t.card) {s : Finset α} {f : α → β} (hfst : Finset.image f s ⊆ t)
+    (hαt : Fintype.card α = #t) {s : Finset α} {f : α → β} (hfst : Finset.image f s ⊆ t)
     (hfs : Set.InjOn f s) : ∃ g : α ≃ t, ∀ i ∈ s, (g i : β) = f i := by
   classical
     induction' s using Finset.induction with a s has H generalizing f
@@ -95,7 +95,7 @@ theorem Finset.exists_equiv_extend_of_card_eq [Fintype α] [DecidableEq β] {t :
 /-- Any injection from a set `s` in a fintype `α` to a finset `t` of the same cardinality as `α`
 can be extended to a bijection between `α` and `t`. -/
 theorem Set.MapsTo.exists_equiv_extend_of_card_eq [Fintype α] {t : Finset β}
-    (hαt : Fintype.card α = t.card) {s : Set α} {f : α → β} (hfst : s.MapsTo f t)
+    (hαt : Fintype.card α = #t) {s : Set α} {f : α → β} (hfst : s.MapsTo f t)
     (hfs : Set.InjOn f s) : ∃ g : α ≃ t, ∀ i ∈ s, (g i : β) = f i := by
   classical
     let s' : Finset α := s.toFinset

--- a/Mathlib/Data/Int/CardIntervalMod.lean
+++ b/Mathlib/Data/Int/CardIntervalMod.lean
@@ -25,14 +25,16 @@ namespace Int
 variable (a b : ℤ) {r : ℤ}
 
 
-lemma Ico_filter_modEq_eq (v : ℤ) : (Ico a b).filter (· ≡ v [ZMOD r]) =
-    ((Ico (a - v) (b - v)).filter (r ∣ ·)).map ⟨(· + v), add_left_injective v⟩ := by
+lemma Ico_filter_modEq_eq (v : ℤ) :
+    {x ∈ Ico a b | x ≡ v [ZMOD r]} =
+    {x ∈ Ico (a - v) (b - v) | r ∣ x}.map ⟨(· + v), add_left_injective v⟩ := by
   ext x
   simp_rw [mem_map, mem_filter, mem_Ico, Function.Embedding.coeFn_mk, ← eq_sub_iff_add_eq,
     exists_eq_right, modEq_comm, modEq_iff_dvd, sub_lt_sub_iff_right, sub_le_sub_iff_right]
 
-lemma Ioc_filter_modEq_eq (v : ℤ) : (Ioc a b).filter (· ≡ v [ZMOD r]) =
-    ((Ioc (a - v) (b - v)).filter (r ∣ ·)).map ⟨(· + v), add_left_injective v⟩ := by
+lemma Ioc_filter_modEq_eq (v : ℤ) :
+    {x ∈ Ioc a b | x ≡ v [ZMOD r]} =
+    {x ∈ Ioc (a - v) (b - v) | r ∣ x}.map ⟨(· + v), add_left_injective v⟩ := by
   ext x
   simp_rw [mem_map, mem_filter, mem_Ioc, Function.Embedding.coeFn_mk, ← eq_sub_iff_add_eq,
     exists_eq_right, modEq_comm, modEq_iff_dvd, sub_lt_sub_iff_right, sub_le_sub_iff_right]
@@ -40,40 +42,40 @@ lemma Ioc_filter_modEq_eq (v : ℤ) : (Ioc a b).filter (· ≡ v [ZMOD r]) =
 variable (hr : 0 < r)
 include hr
 
-lemma Ico_filter_dvd_eq : (Ico a b).filter (r ∣ ·) =
-    (Ico ⌈a / (r : ℚ)⌉ ⌈b / (r : ℚ)⌉).map ⟨(· * r), mul_left_injective₀ hr.ne'⟩ := by
+lemma Ico_filter_dvd_eq :
+    {x ∈ Ico a b | r ∣ x} =
+      (Ico ⌈a / (r : ℚ)⌉ ⌈b / (r : ℚ)⌉).map ⟨(· * r), mul_left_injective₀ hr.ne'⟩ := by
   ext x
   simp only [mem_map, mem_filter, mem_Ico, ceil_le, lt_ceil, div_le_iff₀, lt_div_iff₀,
     dvd_iff_exists_eq_mul_left, cast_pos.2 hr, ← cast_mul, cast_lt, cast_le]
   aesop
 
-lemma Ioc_filter_dvd_eq : (Ioc a b).filter (r ∣ ·) =
-    (Ioc ⌊a / (r : ℚ)⌋ ⌊b / (r : ℚ)⌋).map ⟨(· * r), mul_left_injective₀ hr.ne'⟩ := by
+lemma Ioc_filter_dvd_eq :
+    {x ∈ Ioc a b | r ∣ x} =
+      (Ioc ⌊a / (r : ℚ)⌋ ⌊b / (r : ℚ)⌋).map ⟨(· * r), mul_left_injective₀ hr.ne'⟩ := by
   ext x
   simp only [mem_map, mem_filter, mem_Ioc, floor_lt, le_floor, div_lt_iff₀, le_div_iff₀,
     dvd_iff_exists_eq_mul_left, cast_pos.2 hr, ← cast_mul, cast_lt, cast_le]
   aesop
 
 /-- There are `⌈b / r⌉ - ⌈a / r⌉` multiples of `r` in `[a, b)`, if `a ≤ b`. -/
-theorem Ico_filter_dvd_card : ((Ico a b).filter (r ∣ ·)).card =
-    max (⌈b / (r : ℚ)⌉ - ⌈a / (r : ℚ)⌉) 0 := by
+theorem Ico_filter_dvd_card : #{x ∈ Ico a b | r ∣ x} = max (⌈b / (r : ℚ)⌉ - ⌈a / (r : ℚ)⌉) 0 := by
   rw [Ico_filter_dvd_eq _ _ hr, card_map, card_Ico, toNat_eq_max]
 
 /-- There are `⌊b / r⌋ - ⌊a / r⌋` multiples of `r` in `(a, b]`, if `a ≤ b`. -/
-theorem Ioc_filter_dvd_card : ((Ioc a b).filter (r ∣ ·)).card =
-    max (⌊b / (r : ℚ)⌋ - ⌊a / (r : ℚ)⌋) 0 := by
+theorem Ioc_filter_dvd_card : #{x ∈ Ioc a b | r ∣ x} = max (⌊b / (r : ℚ)⌋ - ⌊a / (r : ℚ)⌋) 0 := by
   rw [Ioc_filter_dvd_eq _ _ hr, card_map, card_Ioc, toNat_eq_max]
 
 /-- There are `⌈(b - v) / r⌉ - ⌈(a - v) / r⌉` numbers congruent to `v` mod `r` in `[a, b)`,
 if `a ≤ b`. -/
-theorem Ico_filter_modEq_card (v : ℤ) : ((Ico a b).filter (· ≡ v [ZMOD r])).card =
-    max (⌈(b - v) / (r : ℚ)⌉ - ⌈(a - v) / (r : ℚ)⌉) 0 := by
+theorem Ico_filter_modEq_card (v : ℤ) :
+    #{x ∈ Ico a b | x ≡ v [ZMOD r]} = max (⌈(b - v) / (r : ℚ)⌉ - ⌈(a - v) / (r : ℚ)⌉) 0 := by
   simp [Ico_filter_modEq_eq, Ico_filter_dvd_eq, toNat_eq_max, hr]
 
 /-- There are `⌊(b - v) / r⌋ - ⌊(a - v) / r⌋` numbers congruent to `v` mod `r` in `(a, b]`,
 if `a ≤ b`. -/
-theorem Ioc_filter_modEq_card (v : ℤ) : ((Ioc a b).filter (· ≡ v [ZMOD r])).card =
-    max (⌊(b - v) / (r : ℚ)⌋ - ⌊(a - v) / (r : ℚ)⌋) 0 := by
+theorem Ioc_filter_modEq_card (v : ℤ) :
+    #{x ∈ Ioc a b | x ≡ v [ZMOD r]} = max (⌊(b - v) / (r : ℚ)⌋ - ⌊(a - v) / (r : ℚ)⌋) 0 := by
   simp [Ioc_filter_modEq_eq, Ioc_filter_dvd_eq, toNat_eq_max, hr]
 
 end Int
@@ -82,16 +84,18 @@ namespace Nat
 
 variable (a b : ℕ) {r : ℕ}
 
-lemma Ico_filter_modEq_cast {v : ℕ} : ((Ico a b).filter (· ≡ v [MOD r])).map castEmbedding =
-    (Ico (a : ℤ) (b : ℤ)).filter (· ≡ v [ZMOD r]) := by
+lemma Ico_filter_modEq_cast {v : ℕ} :
+    {x ∈ Ico a b | x ≡ v [MOD r]}.map castEmbedding =
+      {x ∈ Ico (a : ℤ) (b : ℤ) | x ≡ v [ZMOD r]} := by
   ext x
   simp only [mem_map, mem_filter, mem_Ico, castEmbedding_apply]
   constructor
   · simp_rw [forall_exists_index, ← natCast_modEq_iff]; intro y ⟨h, c⟩; subst c; exact_mod_cast h
   · intro h; lift x to ℕ using (by linarith); exact ⟨x, by simp_all [natCast_modEq_iff]⟩
 
-lemma Ioc_filter_modEq_cast {v : ℕ} : ((Ioc a b).filter (· ≡ v [MOD r])).map castEmbedding =
-    (Ioc (a : ℤ) (b : ℤ)).filter (· ≡ v [ZMOD r]) := by
+lemma Ioc_filter_modEq_cast {v : ℕ} :
+    {x ∈ Ioc a b | x ≡ v [MOD r]}.map castEmbedding =
+      {x ∈ Ioc (a : ℤ) (b : ℤ) | x ≡ v [ZMOD r]} := by
   ext x
   simp only [mem_map, mem_filter, mem_Ioc, castEmbedding_apply]
   constructor
@@ -103,15 +107,15 @@ include hr
 
 /-- There are `⌈(b - v) / r⌉ - ⌈(a - v) / r⌉` numbers congruent to `v` mod `r` in `[a, b)`,
 if `a ≤ b`. `Nat` version of `Int.Ico_filter_modEq_card`. -/
-theorem Ico_filter_modEq_card (v : ℕ) : ((Ico a b).filter (· ≡ v [MOD r])).card =
-    max (⌈(b - v) / (r : ℚ)⌉ - ⌈(a - v) / (r : ℚ)⌉) 0 := by
+theorem Ico_filter_modEq_card (v : ℕ) :
+    #{x ∈ Ico a b | x ≡ v [MOD r]} = max (⌈(b - v) / (r : ℚ)⌉ - ⌈(a - v) / (r : ℚ)⌉) 0 := by
   simp_rw [← Ico_filter_modEq_cast _ _ ▸ card_map _,
     Int.Ico_filter_modEq_card _ _ (cast_lt.mpr hr), Int.cast_natCast]
 
 /-- There are `⌊(b - v) / r⌋ - ⌊(a - v) / r⌋` numbers congruent to `v` mod `r` in `(a, b]`,
 if `a ≤ b`. `Nat` version of `Int.Ioc_filter_modEq_card`. -/
-theorem Ioc_filter_modEq_card (v : ℕ) : ((Ioc a b).filter (· ≡ v [MOD r])).card =
-    max (⌊(b - v) / (r : ℚ)⌋ - ⌊(a - v) / (r : ℚ)⌋) 0 := by
+theorem Ioc_filter_modEq_card (v : ℕ) :
+    #{x ∈ Ioc a b | x ≡ v [MOD r]} = max (⌊(b - v) / (r : ℚ)⌋ - ⌊(a - v) / (r : ℚ)⌋) 0 := by
   simp_rw [← Ioc_filter_modEq_cast _ _ ▸ card_map _,
     Int.Ioc_filter_modEq_card _ _ (cast_lt.mpr hr), Int.cast_natCast]
 

--- a/Mathlib/Data/Int/Interval.lean
+++ b/Mathlib/Data/Int/Interval.lean
@@ -98,35 +98,35 @@ theorem uIcc_eq_finset_map :
       (Nat.castEmbedding.trans <| addLeftEmbedding <| min a b) := rfl
 
 @[simp]
-theorem card_Icc : (Icc a b).card = (b + 1 - a).toNat := (card_map _).trans <| card_range _
+theorem card_Icc : #(Icc a b) = (b + 1 - a).toNat := (card_map _).trans <| card_range _
 
 @[simp]
-theorem card_Ico : (Ico a b).card = (b - a).toNat := (card_map _).trans <| card_range _
+theorem card_Ico : #(Ico a b) = (b - a).toNat := (card_map _).trans <| card_range _
 
 @[simp]
-theorem card_Ioc : (Ioc a b).card = (b - a).toNat := (card_map _).trans <| card_range _
+theorem card_Ioc : #(Ioc a b) = (b - a).toNat := (card_map _).trans <| card_range _
 
 @[simp]
-theorem card_Ioo : (Ioo a b).card = (b - a - 1).toNat := (card_map _).trans <| card_range _
+theorem card_Ioo : #(Ioo a b) = (b - a - 1).toNat := (card_map _).trans <| card_range _
 
 @[simp]
-theorem card_uIcc : (uIcc a b).card = (b - a).natAbs + 1 :=
+theorem card_uIcc : #(uIcc a b) = (b - a).natAbs + 1 :=
   (card_map _).trans <|
     (Nat.cast_inj (R := ℤ)).mp <| by
       rw [card_range, sup_eq_max, inf_eq_min,
         Int.toNat_of_nonneg (sub_nonneg_of_le <| le_add_one min_le_max), Int.ofNat_add,
         Int.natCast_natAbs, add_comm, add_sub_assoc, max_sub_min_eq_abs, add_comm, Int.ofNat_one]
 
-theorem card_Icc_of_le (h : a ≤ b + 1) : ((Icc a b).card : ℤ) = b + 1 - a := by
+theorem card_Icc_of_le (h : a ≤ b + 1) : (#(Icc a b) : ℤ) = b + 1 - a := by
   rw [card_Icc, toNat_sub_of_le h]
 
-theorem card_Ico_of_le (h : a ≤ b) : ((Ico a b).card : ℤ) = b - a := by
+theorem card_Ico_of_le (h : a ≤ b) : (#(Ico a b) : ℤ) = b - a := by
   rw [card_Ico, toNat_sub_of_le h]
 
-theorem card_Ioc_of_le (h : a ≤ b) : ((Ioc a b).card : ℤ) = b - a := by
+theorem card_Ioc_of_le (h : a ≤ b) : (#(Ioc a b) : ℤ) = b - a := by
   rw [card_Ioc, toNat_sub_of_le h]
 
-theorem card_Ioo_of_lt (h : a < b) : ((Ioo a b).card : ℤ) = b - a - 1 := by
+theorem card_Ioo_of_lt (h : a < b) : (#(Ioo a b) : ℤ) = b - a - 1 := by
   rw [card_Ioo, sub_sub, toNat_sub_of_le h]
 
 -- Porting note (#11119): removed `simp` attribute because `simpNF` says it can prove it

--- a/Mathlib/Data/Multiset/Interval.lean
+++ b/Mathlib/Data/Multiset/Interval.lean
@@ -51,20 +51,20 @@ theorem uIcc_eq :
   (Icc_eq _ _).trans <| by simp [uIcc]
 
 theorem card_Icc :
-    (Finset.Icc s t).card = ∏ i ∈ s.toFinset ∪ t.toFinset, (t.count i + 1 - s.count i) := by
+    #(Finset.Icc s t) = ∏ i ∈ s.toFinset ∪ t.toFinset, (t.count i + 1 - s.count i) := by
   simp_rw [Icc_eq, Finset.card_map, DFinsupp.card_Icc, Nat.card_Icc, Multiset.toDFinsupp_apply,
     toDFinsupp_support]
 
 theorem card_Ico :
-    (Finset.Ico s t).card = ∏ i ∈ s.toFinset ∪ t.toFinset, (t.count i + 1 - s.count i) - 1 := by
+    #(Finset.Ico s t) = ∏ i ∈ s.toFinset ∪ t.toFinset, (t.count i + 1 - s.count i) - 1 := by
   rw [Finset.card_Ico_eq_card_Icc_sub_one, card_Icc]
 
 theorem card_Ioc :
-    (Finset.Ioc s t).card = ∏ i ∈ s.toFinset ∪ t.toFinset, (t.count i + 1 - s.count i) - 1 := by
+    #(Finset.Ioc s t) = ∏ i ∈ s.toFinset ∪ t.toFinset, (t.count i + 1 - s.count i) - 1 := by
   rw [Finset.card_Ioc_eq_card_Icc_sub_one, card_Icc]
 
 theorem card_Ioo :
-    (Finset.Ioo s t).card = ∏ i ∈ s.toFinset ∪ t.toFinset, (t.count i + 1 - s.count i) - 2 := by
+    #(Finset.Ioo s t) = ∏ i ∈ s.toFinset ∪ t.toFinset, (t.count i + 1 - s.count i) - 2 := by
   rw [Finset.card_Ioo_eq_card_Icc_sub_two, card_Icc]
 
 theorem card_uIcc :

--- a/Mathlib/Data/Nat/Choose/Sum.lean
+++ b/Mathlib/Data/Nat/Choose/Sum.lean
@@ -168,8 +168,8 @@ theorem Int.alternating_sum_range_choose_of_ne {n : ℕ} (h0 : n ≠ 0) :
 namespace Finset
 
 theorem sum_powerset_apply_card {α β : Type*} [AddCommMonoid α] (f : ℕ → α) {x : Finset β} :
-    ∑ m ∈ x.powerset, f m.card = ∑ m ∈ range (x.card + 1), x.card.choose m • f m := by
-  trans ∑ m ∈ range (x.card + 1), ∑ j ∈ x.powerset.filter fun z ↦ z.card = m, f j.card
+    ∑ m ∈ x.powerset, f #m = ∑ m ∈ range (#x + 1), (#x).choose m • f m := by
+  trans ∑ m ∈ range (#x + 1), ∑ j ∈ x.powerset with #j = m, f #j
   · refine (sum_fiberwise_of_maps_to ?_ _).symm
     intro y hy
     rw [mem_range, Nat.lt_succ_iff]
@@ -181,12 +181,12 @@ theorem sum_powerset_apply_card {α β : Type*} [AddCommMonoid α] (f : ℕ → 
     rw [(mem_powersetCard.1 hz).2]
 
 theorem sum_powerset_neg_one_pow_card {α : Type*} [DecidableEq α] {x : Finset α} :
-    (∑ m ∈ x.powerset, (-1 : ℤ) ^ m.card) = if x = ∅ then 1 else 0 := by
+    (∑ m ∈ x.powerset, (-1 : ℤ) ^ #m) = if x = ∅ then 1 else 0 := by
   rw [sum_powerset_apply_card]
   simp only [nsmul_eq_mul', ← card_eq_zero, Int.alternating_sum_range_choose]
 
 theorem sum_powerset_neg_one_pow_card_of_nonempty {α : Type*} {x : Finset α} (h0 : x.Nonempty) :
-    (∑ m ∈ x.powerset, (-1 : ℤ) ^ m.card) = 0 := by
+    (∑ m ∈ x.powerset, (-1 : ℤ) ^ #m) = 0 := by
   classical
   rw [sum_powerset_neg_one_pow_card]
   exact if_neg (nonempty_iff_ne_empty.mp h0)

--- a/Mathlib/Data/Nat/Count.lean
+++ b/Mathlib/Data/Nat/Count.lean
@@ -36,7 +36,7 @@ theorem count_zero : count p 0 = 0 := by
 
 /-- A fintype instance for the set relevant to `Nat.count`. Locally an instance in locale `count` -/
 def CountSet.fintype (n : ℕ) : Fintype { i // i < n ∧ p i } := by
-  apply Fintype.ofFinset ((Finset.range n).filter p)
+  apply Fintype.ofFinset {x ∈ range n | p x}
   intro x
   rw [mem_filter, mem_range]
   rfl
@@ -45,7 +45,7 @@ scoped[Count] attribute [instance] Nat.CountSet.fintype
 
 open Count
 
-theorem count_eq_card_filter_range (n : ℕ) : count p n = ((range n).filter p).card := by
+theorem count_eq_card_filter_range (n : ℕ) : count p n = #{x ∈ range n | p x} := by
   rw [count, List.countP_eq_length_filter]
   rfl
 
@@ -62,7 +62,7 @@ theorem count_monotone : Monotone (count p) :=
   monotone_nat_of_le_succ fun n ↦ by by_cases h : p n <;> simp [count_succ, h]
 
 theorem count_add (a b : ℕ) : count p (a + b) = count p a + count (fun k ↦ p (a + k)) b := by
-  have : Disjoint ((range a).filter p) (((range b).map <| addLeftEmbedding a).filter p) := by
+  have : Disjoint {x ∈ range a | p x} {x ∈ (range b).map <| addLeftEmbedding a | p x} := by
     apply disjoint_filter_filter
     rw [Finset.disjoint_left]
     simp_rw [mem_map, mem_range, addLeftEmbedding_apply]
@@ -114,11 +114,11 @@ theorem count_injective {m n : ℕ} (hm : p m) (hn : p n) (heq : count p m = cou
   · exact this hn hm heq.symm h.symm (h.lt_or_lt.resolve_left hmn)
   · simpa [heq] using count_strict_mono hm hmn
 
-theorem count_le_card (hp : (setOf p).Finite) (n : ℕ) : count p n ≤ hp.toFinset.card := by
+theorem count_le_card (hp : (setOf p).Finite) (n : ℕ) : count p n ≤ #hp.toFinset := by
   rw [count_eq_card_filter_range]
   exact Finset.card_mono fun x hx ↦ hp.mem_toFinset.2 (mem_filter.1 hx).2
 
-theorem count_lt_card {n : ℕ} (hp : (setOf p).Finite) (hpn : p n) : count p n < hp.toFinset.card :=
+theorem count_lt_card {n : ℕ} (hp : (setOf p).Finite) (hpn : p n) : count p n < #hp.toFinset :=
   (count_lt_count_succ_iff.2 hpn).trans_le (count_le_card hp _)
 
 theorem count_of_forall {n : ℕ} (hp : ∀ n' < n, p n') : count p n = n := by

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -457,7 +457,7 @@ theorem setOf_pow_dvd_eq_Icc_factorization {n p : ℕ} (pp : p.Prime) (hn : n �
 /-- The set of positive powers of prime `p` that divide `n` is exactly the set of
 positive natural numbers up to `n.factorization p`. -/
 theorem Icc_factorization_eq_pow_dvd (n : ℕ) {p : ℕ} (pp : Prime p) :
-    Icc 1 (n.factorization p) = (Ico 1 n).filter fun i : ℕ => p ^ i ∣ n := by
+    Icc 1 (n.factorization p) = {i ∈ Ico 1 n | p ^ i ∣ n} := by
   rcases eq_or_ne n 0 with (rfl | hn)
   · simp
   ext x
@@ -466,11 +466,11 @@ theorem Icc_factorization_eq_pow_dvd (n : ℕ) {p : ℕ} (pp : Prime p) :
   exact fun _ H => lt_of_le_of_lt H (factorization_lt p hn)
 
 theorem factorization_eq_card_pow_dvd (n : ℕ) {p : ℕ} (pp : p.Prime) :
-    n.factorization p = ((Ico 1 n).filter fun i => p ^ i ∣ n).card := by
+    n.factorization p = #{i ∈ Ico 1 n | p ^ i ∣ n} := by
   simp [← Icc_factorization_eq_pow_dvd n pp]
 
 theorem Ico_filter_pow_dvd_eq {n p b : ℕ} (pp : p.Prime) (hn : n ≠ 0) (hb : n ≤ p ^ b) :
-    ((Ico 1 n).filter fun i => p ^ i ∣ n) = (Icc 1 b).filter fun i => p ^ i ∣ n := by
+    {i ∈ Ico 1 n | p ^ i ∣ n} = {i ∈ Icc 1 b | p ^ i ∣ n} := by
   ext x
   simp only [Finset.mem_filter, mem_Ico, mem_Icc, and_congr_left_iff, and_congr_right_iff]
   rintro h1 -
@@ -508,7 +508,7 @@ theorem eq_iff_prime_padicValNat_eq (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
     · simp [factorization_eq_zero_of_non_prime, pp]
 
 theorem prod_pow_prime_padicValNat (n : Nat) (hn : n ≠ 0) (m : Nat) (pr : n < m) :
-    (∏ p ∈ Finset.filter Nat.Prime (Finset.range m), p ^ padicValNat p n) = n := by
+    ∏ p ∈ range m with p.Prime, p ^ padicValNat p n = n := by
   -- Porting note: was `nth_rw_rhs`
   conv =>
     rhs
@@ -530,14 +530,14 @@ theorem prod_pow_prime_padicValNat (n : Nat) (hn : n ≠ 0) (m : Nat) (pr : n < 
 -- TODO: Port lemmas from `Data/Nat/Multiplicity` to here, re-written in terms of `factorization`
 /-- Exactly `n / p` naturals in `[1, n]` are multiples of `p`.
 See `Nat.card_multiples'` for an alternative spelling of the statement. -/
-theorem card_multiples (n p : ℕ) : card ((Finset.range n).filter fun e => p ∣ e + 1) = n / p := by
+theorem card_multiples (n p : ℕ) : #{e ∈ range n | p ∣ e + 1} = n / p := by
   induction' n with n hn
   · simp
   simp [Nat.succ_div, add_ite, add_zero, Finset.range_succ, filter_insert, apply_ite card,
     card_insert_of_not_mem, hn]
 
 /-- Exactly `n / p` naturals in `(0, n]` are multiples of `p`. -/
-theorem Ioc_filter_dvd_card_eq_div (n p : ℕ) : ((Ioc 0 n).filter fun x => p ∣ x).card = n / p := by
+theorem Ioc_filter_dvd_card_eq_div (n p : ℕ) : #{x ∈ Ioc 0 n | p ∣ x} = n / p := by
   induction' n with n IH
   · simp
   -- TODO: Golf away `h1` after Yaël PRs a lemma asserting this
@@ -550,8 +550,7 @@ theorem Ioc_filter_dvd_card_eq_div (n p : ℕ) : ((Ioc 0 n).filter fun x => p �
 
 /-- There are exactly `⌊N/n⌋` positive multiples of `n` that are `≤ N`.
 See `Nat.card_multiples` for a "shifted-by-one" version. -/
-lemma card_multiples' (N n : ℕ) :
-    ((Finset.range N.succ).filter (fun k ↦ k ≠ 0 ∧ n ∣ k)).card = N / n := by
+lemma card_multiples' (N n : ℕ) : #{k ∈ range N.succ | k ≠ 0 ∧ n ∣ k} = N / n := by
   induction N with
     | zero => simp [Finset.filter_false_of_mem]
     | succ N ih =>

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -163,7 +163,7 @@ theorem factorization_le_iff_dvd {d n : ℕ} (hd : d ≠ 0) (hn : n ≠ 0) :
 
 /-- For any `p : ℕ` and any function `g : α → ℕ` that's non-zero on `S : Finset α`,
 the power of `p` in `S.prod g` equals the sum over `x ∈ S` of the powers of `p` in `g x`.
-Generalises `factorization_mul`, which is the special case where `S.card = 2` and `g = id`. -/
+Generalises `factorization_mul`, which is the special case where `#S = 2` and `g = id`. -/
 theorem factorization_prod {α : Type*} {S : Finset α} {g : α → ℕ} (hS : ∀ x ∈ S, g x ≠ 0) :
     (S.prod g).factorization = S.sum fun x => (g x).factorization := by
   classical

--- a/Mathlib/Data/Nat/Multiplicity.lean
+++ b/Mathlib/Data/Nat/Multiplicity.lean
@@ -56,12 +56,12 @@ namespace Nat
 divides `n`. This set is expressed by filtering `Ico 1 b` where `b` is any bound greater than
 `log m n`. -/
 theorem emultiplicity_eq_card_pow_dvd {m n b : ℕ} (hm : m ≠ 1) (hn : 0 < n) (hb : log m n < b) :
-    emultiplicity m n = ↑((Finset.Ico 1 b).filter fun i => m ^ i ∣ n).card :=
+    emultiplicity m n = #{i ∈ Ico 1 b | m ^ i ∣ n} :=
   have fin := Nat.multiplicity_finite_iff.2 ⟨hm, hn⟩
   calc
-    emultiplicity m n = ↑(Ico 1 <| multiplicity m n + 1).card := by
+    emultiplicity m n = #(Ico 1 <| multiplicity m n + 1) := by
       simp [fin.emultiplicity_eq_multiplicity]
-    _ = ↑((Finset.Ico 1 b).filter fun i => m ^ i ∣ n).card :=
+    _ = #{i ∈ Ico 1 b | m ^ i ∣ n} :=
       congr_arg _ <|
         congr_arg card <|
           Finset.ext fun i => by
@@ -107,8 +107,7 @@ theorem emultiplicity_factorial {p : ℕ} (hp : p.Prime) :
     calc
       emultiplicity p (n + 1)! = emultiplicity p n ! + emultiplicity p (n + 1) := by
         rw [factorial_succ, hp.emultiplicity_mul, add_comm]
-      _ = (∑ i ∈ Ico 1 b, n / p ^ i : ℕ) +
-            ((Finset.Ico 1 b).filter fun i => p ^ i ∣ n + 1).card := by
+      _ = (∑ i ∈ Ico 1 b, n / p ^ i : ℕ) + #{i ∈ Ico 1 b | p ^ i ∣ n + 1} := by
         rw [emultiplicity_factorial hp ((log_mono_right <| le_succ _).trans_lt hb), ←
           emultiplicity_eq_card_pow_dvd hp.ne_one (succ_pos _) hb]
       _ = (∑ i ∈ Ico 1 b, (n / p ^ i + if p ^ i ∣ n + 1 then 1 else 0) : ℕ) := by
@@ -177,7 +176,7 @@ theorem emultiplicity_factorial_le_div_pred {p : ℕ} (hp : p.Prime) (n : ℕ) :
 theorem multiplicity_choose_aux {p n b k : ℕ} (hp : p.Prime) (hkn : k ≤ n) :
     ∑ i ∈ Finset.Ico 1 b, n / p ^ i =
       ((∑ i ∈ Finset.Ico 1 b, k / p ^ i) + ∑ i ∈ Finset.Ico 1 b, (n - k) / p ^ i) +
-        ((Finset.Ico 1 b).filter fun i => p ^ i ≤ k % p ^ i + (n - k) % p ^ i).card :=
+        #{i ∈ Ico 1 b | p ^ i ≤ k % p ^ i + (n - k) % p ^ i} :=
   calc
     ∑ i ∈ Finset.Ico 1 b, n / p ^ i = ∑ i ∈ Finset.Ico 1 b, (k + (n - k)) / p ^ i := by
       simp only [add_tsub_cancel_of_le hkn]
@@ -190,12 +189,10 @@ theorem multiplicity_choose_aux {p n b k : ℕ} (hp : p.Prime) (hkn : k ≤ n) :
   are added in base `p`. The set is expressed by filtering `Ico 1 b` where `b`
   is any bound greater than `log p (n + k)`. -/
 theorem emultiplicity_choose' {p n k b : ℕ} (hp : p.Prime) (hnb : log p (n + k) < b) :
-    emultiplicity p (choose (n + k) k) =
-      ((Ico 1 b).filter fun i => p ^ i ≤ k % p ^ i + n % p ^ i).card := by
+    emultiplicity p (choose (n + k) k) = #{i ∈ Ico 1 b | p ^ i ≤ k % p ^ i + n % p ^ i} := by
   have h₁ :
       emultiplicity p (choose (n + k) k) + emultiplicity p (k ! * n !) =
-        ((Finset.Ico 1 b).filter fun i => p ^ i ≤ k % p ^ i + n % p ^ i).card +
-          emultiplicity p (k ! * n !) := by
+        #{i ∈ Ico 1 b | p ^ i ≤ k % p ^ i + n % p ^ i} + emultiplicity p (k ! * n !) := by
     rw [← hp.emultiplicity_mul, ← mul_assoc]
     have := (add_tsub_cancel_right n k) ▸ choose_mul_factorial_mul_factorial (le_add_left k n)
     rw [this, hp.emultiplicity_factorial hnb, hp.emultiplicity_mul,
@@ -211,8 +208,7 @@ theorem emultiplicity_choose' {p n k b : ℕ} (hp : p.Prime) (hnb : log p (n + k
   are added in base `p`. The set is expressed by filtering `Ico 1 b` where `b`
   is any bound greater than `log p n`. -/
 theorem emultiplicity_choose {p n k b : ℕ} (hp : p.Prime) (hkn : k ≤ n) (hnb : log p n < b) :
-    emultiplicity p (choose n k) =
-      ((Ico 1 b).filter fun i => p ^ i ≤ k % p ^ i + (n - k) % p ^ i).card := by
+    emultiplicity p (choose n k) = #{i ∈ Ico 1 b | p ^ i ≤ k % p ^ i + (n - k) % p ^ i} := by
   have := Nat.sub_add_cancel hkn
   convert @emultiplicity_choose' p (n - k) k b hp _
   · rw [this]
@@ -236,8 +232,8 @@ theorem emultiplicity_choose_prime_pow_add_emultiplicity (hp : p.Prime) (hkn : k
   le_antisymm
     (by
       have hdisj :
-        Disjoint ((Ico 1 n.succ).filter fun i => p ^ i ≤ k % p ^ i + (p ^ n - k) % p ^ i)
-          ((Ico 1 n.succ).filter fun i => p ^ i ∣ k) := by
+        Disjoint {i ∈ Ico 1 n.succ | p ^ i ≤ k % p ^ i + (p ^ n - k) % p ^ i}
+          {i ∈ Ico 1 n.succ | p ^ i ∣ k} := by
         simp (config := { contextual := true }) [disjoint_right, *, dvd_iff_mod_eq_zero,
           Nat.mod_lt _ (pow_pos hp.pos _)]
       rw [emultiplicity_choose hp hkn (lt_succ_self _),

--- a/Mathlib/Data/Nat/Nth.lean
+++ b/Mathlib/Data/Nat/Nth.lean
@@ -58,40 +58,40 @@ variable {p}
 -/
 
 
-theorem nth_of_card_le (hf : (setOf p).Finite) {n : ℕ} (hn : hf.toFinset.card ≤ n) :
+theorem nth_of_card_le (hf : (setOf p).Finite) {n : ℕ} (hn : #hf.toFinset ≤ n) :
     nth p n = 0 := by rw [nth, dif_pos hf, List.getD_eq_default]; rwa [Finset.length_sort]
 
 theorem nth_eq_getD_sort (h : (setOf p).Finite) (n : ℕ) :
     nth p n = (h.toFinset.sort (· ≤ ·)).getD n 0 :=
   dif_pos h
 
-theorem nth_eq_orderEmbOfFin (hf : (setOf p).Finite) {n : ℕ} (hn : n < hf.toFinset.card) :
+theorem nth_eq_orderEmbOfFin (hf : (setOf p).Finite) {n : ℕ} (hn : n < #hf.toFinset) :
     nth p n = hf.toFinset.orderEmbOfFin rfl ⟨n, hn⟩ := by
   rw [nth_eq_getD_sort hf, Finset.orderEmbOfFin_apply, List.getD_eq_getElem, Fin.getElem_fin]
 
 theorem nth_strictMonoOn (hf : (setOf p).Finite) :
-    StrictMonoOn (nth p) (Set.Iio hf.toFinset.card) := by
+    StrictMonoOn (nth p) (Set.Iio #hf.toFinset) := by
   rintro m (hm : m < _) n (hn : n < _) h
   simp only [nth_eq_orderEmbOfFin, *]
   exact OrderEmbedding.strictMono _ h
 
 theorem nth_lt_nth_of_lt_card (hf : (setOf p).Finite) {m n : ℕ} (h : m < n)
-    (hn : n < hf.toFinset.card) : nth p m < nth p n :=
+    (hn : n < #hf.toFinset) : nth p m < nth p n :=
   nth_strictMonoOn hf (h.trans hn) hn h
 
 theorem nth_le_nth_of_lt_card (hf : (setOf p).Finite) {m n : ℕ} (h : m ≤ n)
-    (hn : n < hf.toFinset.card) : nth p m ≤ nth p n :=
+    (hn : n < #hf.toFinset) : nth p m ≤ nth p n :=
   (nth_strictMonoOn hf).monotoneOn (h.trans_lt hn) hn h
 
 theorem lt_of_nth_lt_nth_of_lt_card (hf : (setOf p).Finite) {m n : ℕ} (h : nth p m < nth p n)
-    (hm : m < hf.toFinset.card) : m < n :=
+    (hm : m < #hf.toFinset) : m < n :=
   not_le.1 fun hle => h.not_le <| nth_le_nth_of_lt_card hf hle hm
 
 theorem le_of_nth_le_nth_of_lt_card (hf : (setOf p).Finite) {m n : ℕ} (h : nth p m ≤ nth p n)
-    (hm : m < hf.toFinset.card) : m ≤ n :=
+    (hm : m < #hf.toFinset) : m ≤ n :=
   not_lt.1 fun hlt => h.not_lt <| nth_lt_nth_of_lt_card hf hlt hm
 
-theorem nth_injOn (hf : (setOf p).Finite) : (Set.Iio hf.toFinset.card).InjOn (nth p) :=
+theorem nth_injOn (hf : (setOf p).Finite) : (Set.Iio #hf.toFinset).InjOn (nth p) :=
   (nth_strictMonoOn hf).injOn
 
 theorem range_nth_of_finite (hf : (setOf p).Finite) : Set.range (nth p) = insert 0 (setOf p) := by
@@ -99,20 +99,20 @@ theorem range_nth_of_finite (hf : (setOf p).Finite) : Set.range (nth p) = insert
     Set.Finite.mem_toFinset] using Set.range_list_getD (hf.toFinset.sort (· ≤ ·)) 0
 
 @[simp]
-theorem image_nth_Iio_card (hf : (setOf p).Finite) : nth p '' Set.Iio hf.toFinset.card = setOf p :=
+theorem image_nth_Iio_card (hf : (setOf p).Finite) : nth p '' Set.Iio #hf.toFinset = setOf p :=
   calc
-    nth p '' Set.Iio hf.toFinset.card = Set.range (hf.toFinset.orderEmbOfFin rfl) := by
+    nth p '' Set.Iio #hf.toFinset = Set.range (hf.toFinset.orderEmbOfFin rfl) := by
       ext x
       simp only [Set.mem_image, Set.mem_range, Fin.exists_iff, ← nth_eq_orderEmbOfFin hf,
         Set.mem_Iio, exists_prop]
     _ = setOf p := by rw [range_orderEmbOfFin, Set.Finite.coe_toFinset]
 
-theorem nth_mem_of_lt_card {n : ℕ} (hf : (setOf p).Finite) (hlt : n < hf.toFinset.card) :
+theorem nth_mem_of_lt_card {n : ℕ} (hf : (setOf p).Finite) (hlt : n < #hf.toFinset) :
     p (nth p n) :=
   (image_nth_Iio_card hf).subset <| Set.mem_image_of_mem _ hlt
 
 theorem exists_lt_card_finite_nth_eq (hf : (setOf p).Finite) {x} (h : p x) :
-    ∃ n, n < hf.toFinset.card ∧ nth p n = x := by
+    ∃ n, n < #hf.toFinset ∧ nth p n = x := by
   rwa [← @Set.mem_setOf_eq _ _ p, ← image_nth_Iio_card hf] at h
 
 /-!
@@ -158,7 +158,7 @@ theorem nth_mem_of_infinite (hf : (setOf p).Infinite) (n : ℕ) : p (nth p n) :=
 -/
 
 theorem exists_lt_card_nth_eq {x} (h : p x) :
-    ∃ n, (∀ hf : (setOf p).Finite, n < hf.toFinset.card) ∧ nth p n = x := by
+    ∃ n, (∀ hf : (setOf p).Finite, n < #hf.toFinset) ∧ nth p n = x := by
   refine (setOf p).finite_or_infinite.elim (fun hf => ?_) fun hf => ?_
   · rcases exists_lt_card_finite_nth_eq hf h with ⟨n, hn, hx⟩
     exact ⟨n, fun _ => hn, hx⟩
@@ -174,32 +174,32 @@ theorem range_nth_subset : Set.range (nth p) ⊆ insert 0 (setOf p) :=
   (setOf p).finite_or_infinite.elim (fun h => (range_nth_of_finite h).subset) fun h =>
     (range_nth_of_infinite h).trans_subset (Set.subset_insert _ _)
 
-theorem nth_mem (n : ℕ) (h : ∀ hf : (setOf p).Finite, n < hf.toFinset.card) : p (nth p n) :=
+theorem nth_mem (n : ℕ) (h : ∀ hf : (setOf p).Finite, n < #hf.toFinset) : p (nth p n) :=
   (setOf p).finite_or_infinite.elim (fun hf => nth_mem_of_lt_card hf (h hf)) fun h =>
     nth_mem_of_infinite h n
 
-theorem nth_lt_nth' {m n : ℕ} (hlt : m < n) (h : ∀ hf : (setOf p).Finite, n < hf.toFinset.card) :
+theorem nth_lt_nth' {m n : ℕ} (hlt : m < n) (h : ∀ hf : (setOf p).Finite, n < #hf.toFinset) :
     nth p m < nth p n :=
   (setOf p).finite_or_infinite.elim (fun hf => nth_lt_nth_of_lt_card hf hlt (h _)) fun hf =>
     (nth_lt_nth hf).2 hlt
 
-theorem nth_le_nth' {m n : ℕ} (hle : m ≤ n) (h : ∀ hf : (setOf p).Finite, n < hf.toFinset.card) :
+theorem nth_le_nth' {m n : ℕ} (hle : m ≤ n) (h : ∀ hf : (setOf p).Finite, n < #hf.toFinset) :
     nth p m ≤ nth p n :=
   (setOf p).finite_or_infinite.elim (fun hf => nth_le_nth_of_lt_card hf hle (h _)) fun hf =>
     (nth_le_nth hf).2 hle
 
-theorem le_nth {n : ℕ} (h : ∀ hf : (setOf p).Finite, n < hf.toFinset.card) : n ≤ nth p n :=
+theorem le_nth {n : ℕ} (h : ∀ hf : (setOf p).Finite, n < #hf.toFinset) : n ≤ nth p n :=
   (setOf p).finite_or_infinite.elim
     (fun hf => ((nth_strictMonoOn hf).mono <| Set.Iic_subset_Iio.2 (h _)).Iic_id_le _ le_rfl)
     fun hf => (nth_strictMono hf).id_le _
 
-theorem isLeast_nth {n} (h : ∀ hf : (setOf p).Finite, n < hf.toFinset.card) :
+theorem isLeast_nth {n} (h : ∀ hf : (setOf p).Finite, n < #hf.toFinset) :
     IsLeast {i | p i ∧ ∀ k < n, nth p k < i} (nth p n) :=
   ⟨⟨nth_mem n h, fun _k hk => nth_lt_nth' hk h⟩, fun _x hx =>
     let ⟨k, hk, hkx⟩ := exists_lt_card_nth_eq hx.1
     (lt_or_le k n).elim (fun hlt => absurd hkx (hx.2 _ hlt).ne) fun hle => hkx ▸ nth_le_nth' hle hk⟩
 
-theorem isLeast_nth_of_lt_card {n : ℕ} (hf : (setOf p).Finite) (hn : n < hf.toFinset.card) :
+theorem isLeast_nth_of_lt_card {n : ℕ} (hf : (setOf p).Finite) (hn : n < #hf.toFinset) :
     IsLeast {i | p i ∧ ∀ k < n, nth p k < i} (nth p n) :=
   isLeast_nth fun _ => hn
 
@@ -210,9 +210,9 @@ theorem isLeast_nth_of_infinite (hf : (setOf p).Infinite) (n : ℕ) :
 /-- An alternative recursive definition of `Nat.nth`: `Nat.nth s n` is the infimum of `x ∈ s` such
 that `Nat.nth s k < x` for all `k < n`, if this set is nonempty. We do not assume that the set is
 nonempty because we use the same "garbage value" `0` both for `sInf` on `ℕ` and for `Nat.nth s n`
-for `n ≥ card s`. -/
+for `n ≥ #s`. -/
 theorem nth_eq_sInf (p : ℕ → Prop) (n : ℕ) : nth p n = sInf {x | p x ∧ ∀ k < n, nth p k < x} := by
-  by_cases hn : ∀ hf : (setOf p).Finite, n < hf.toFinset.card
+  by_cases hn : ∀ hf : (setOf p).Finite, n < #hf.toFinset
   · exact (isLeast_nth hn).csInf_eq.symm
   · push_neg at hn
     rcases hn with ⟨hf, hn⟩
@@ -230,7 +230,7 @@ theorem nth_zero_of_exists [DecidablePred p] (h : ∃ n, p n) : nth p 0 = Nat.fi
   rw [nth_zero]; convert Nat.sInf_def h
 
 theorem nth_eq_zero {n} :
-    nth p n = 0 ↔ p 0 ∧ n = 0 ∨ ∃ hf : (setOf p).Finite, hf.toFinset.card ≤ n := by
+    nth p n = 0 ↔ p 0 ∧ n = 0 ∨ ∃ hf : (setOf p).Finite, #hf.toFinset ≤ n := by
   refine ⟨fun h => ?_, ?_⟩
   · simp only [or_iff_not_imp_right, not_exists, not_le]
     exact fun hn => ⟨h ▸ nth_mem _ hn, nonpos_iff_eq_zero.1 <| h ▸ le_nth hn⟩
@@ -244,7 +244,7 @@ theorem nth_eq_zero_mono (h₀ : ¬p 0) {a b : ℕ} (hab : a ≤ b) (ha : nth p 
 theorem le_nth_of_lt_nth_succ {k a : ℕ} (h : a < nth p (k + 1)) (ha : p a) : a ≤ nth p k := by
   cases' (setOf p).finite_or_infinite with hf hf
   · rcases exists_lt_card_finite_nth_eq hf ha with ⟨n, hn, rfl⟩
-    cases' lt_or_le (k + 1) hf.toFinset.card with hk hk
+    cases' lt_or_le (k + 1) #hf.toFinset with hk hk
     · rwa [(nth_strictMonoOn hf).lt_iff_lt hn hk, Nat.lt_succ_iff,
         ← (nth_strictMonoOn hf).le_iff_le hn (k.lt_succ_self.trans hk)] at h
     · rw [nth_of_card_le _ hk] at h
@@ -262,7 +262,7 @@ theorem count_nth_zero : count p (nth p 0) = 0 := by
   exact fun n h₁ h₂ => (mem_range.1 h₁).not_le (Nat.sInf_le h₂)
 
 theorem filter_range_nth_subset_insert (k : ℕ) :
-    (range (nth p (k + 1))).filter p ⊆ insert (nth p k) ((range (nth p k)).filter p) := by
+    {n ∈ range (nth p (k + 1)) | p n} ⊆ insert (nth p k) {n ∈ range (nth p k) | p n} := by
   intro a ha
   simp only [mem_insert, mem_filter, mem_range] at ha ⊢
   exact (le_nth_of_lt_nth_succ ha.1 ha.2).eq_or_lt.imp_right fun h => ⟨h, ha.2⟩
@@ -270,8 +270,8 @@ theorem filter_range_nth_subset_insert (k : ℕ) :
 variable {p}
 
 theorem filter_range_nth_eq_insert {k : ℕ}
-    (hlt : ∀ hf : (setOf p).Finite, k + 1 < hf.toFinset.card) :
-    (range (nth p (k + 1))).filter p = insert (nth p k) ((range (nth p k)).filter p) := by
+    (hlt : ∀ hf : (setOf p).Finite, k + 1 < #hf.toFinset) :
+    {n ∈ range (nth p (k + 1)) | p n} = insert (nth p k) {n ∈ range (nth p k) | p n} := by
   refine (filter_range_nth_subset_insert p k).antisymm fun a ha => ?_
   simp only [mem_insert, mem_filter, mem_range] at ha ⊢
   have : nth p k < nth p (k + 1) := nth_lt_nth' k.lt_succ_self hlt
@@ -280,15 +280,15 @@ theorem filter_range_nth_eq_insert {k : ℕ}
   · exact ⟨hlt.trans this, hpa⟩
 
 theorem filter_range_nth_eq_insert_of_finite (hf : (setOf p).Finite) {k : ℕ}
-    (hlt : k + 1 < hf.toFinset.card) :
-    (range (nth p (k + 1))).filter p = insert (nth p k) ((range (nth p k)).filter p) :=
+    (hlt : k + 1 < #hf.toFinset) :
+    {n ∈ range (nth p (k + 1)) | p n} = insert (nth p k) {n ∈ range (nth p k) | p n} :=
   filter_range_nth_eq_insert fun _ => hlt
 
 theorem filter_range_nth_eq_insert_of_infinite (hp : (setOf p).Infinite) (k : ℕ) :
-    (range (nth p (k + 1))).filter p = insert (nth p k) ((range (nth p k)).filter p) :=
+    {n ∈ range (nth p (k + 1)) | p n} = insert (nth p k) {n ∈ range (nth p k) | p n} :=
   filter_range_nth_eq_insert fun hf => absurd hf hp
 
-theorem count_nth {n : ℕ} (hn : ∀ hf : (setOf p).Finite, n < hf.toFinset.card) :
+theorem count_nth {n : ℕ} (hn : ∀ hf : (setOf p).Finite, n < #hf.toFinset) :
     count p (nth p n) = n := by
   induction' n with k ihk
   · exact count_nth_zero _
@@ -296,7 +296,7 @@ theorem count_nth {n : ℕ} (hn : ∀ hf : (setOf p).Finite, n < hf.toFinset.car
       count_eq_card_filter_range, ihk fun hf => lt_of_succ_lt (hn hf)]
     simp
 
-theorem count_nth_of_lt_card_finite {n : ℕ} (hp : (setOf p).Finite) (hlt : n < hp.toFinset.card) :
+theorem count_nth_of_lt_card_finite {n : ℕ} (hp : (setOf p).Finite) (hlt : n < #hp.toFinset) :
     count p (nth p n) = n :=
   count_nth fun _ => hlt
 
@@ -307,12 +307,12 @@ theorem surjective_count_of_infinite_setOf (h : {n | p n}.Infinite) :
     Function.Surjective (Nat.count p) :=
   fun n => ⟨nth p n, count_nth_of_infinite h n⟩
 
-theorem count_nth_succ {n : ℕ} (hn : ∀ hf : (setOf p).Finite, n < hf.toFinset.card) :
+theorem count_nth_succ {n : ℕ} (hn : ∀ hf : (setOf p).Finite, n < #hf.toFinset) :
     count p (nth p n + 1) = n + 1 := by rw [count_succ, count_nth hn, if_pos (nth_mem _ hn)]
 
 @[simp]
 theorem nth_count {n : ℕ} (hpn : p n) : nth p (count p n) = n :=
-  have : ∀ hf : (setOf p).Finite, count p n < hf.toFinset.card := fun hf => count_lt_card hf hpn
+  have : ∀ hf : (setOf p).Finite, count p n < #hf.toFinset := fun hf => count_lt_card hf hpn
   count_injective (nth_mem _ this) hpn (count_nth this)
 
 theorem nth_lt_of_lt_count {n k : ℕ} (h : k < count p n) : nth p k < n := by

--- a/Mathlib/Data/Nat/Squarefree.lean
+++ b/Mathlib/Data/Nat/Squarefree.lean
@@ -245,14 +245,14 @@ theorem squarefree_two : Squarefree 2 := by
   rw [squarefree_iff_nodup_primeFactorsList] <;> simp
 
 theorem divisors_filter_squarefree_of_squarefree {n : ℕ} (hn : Squarefree n) :
-    n.divisors.filter Squarefree = n.divisors :=
+    {d ∈ n.divisors | Squarefree d} = n.divisors :=
   Finset.ext fun d => ⟨@Finset.filter_subset _ _ _ _ d, fun hd =>
     Finset.mem_filter.mpr ⟨hd, hn.squarefree_of_dvd (Nat.dvd_of_mem_divisors hd) ⟩⟩
 
 open UniqueFactorizationMonoid
 
 theorem divisors_filter_squarefree {n : ℕ} (h0 : n ≠ 0) :
-    (n.divisors.filter Squarefree).val =
+    {d ∈ n.divisors | Squarefree d}.val =
       (UniqueFactorizationMonoid.normalizedFactors n).toFinset.powerset.val.map fun x =>
         x.val.prod := by
   rw [(Finset.nodup _).ext ((Finset.nodup _).map_on _)]
@@ -303,7 +303,7 @@ theorem divisors_filter_squarefree {n : ℕ} (h0 : n ≠ 0) :
 
 theorem sum_divisors_filter_squarefree {n : ℕ} (h0 : n ≠ 0) {α : Type*} [AddCommMonoid α]
     {f : ℕ → α} :
-    ∑ i ∈ n.divisors.filter Squarefree, f i =
+    ∑ d ∈ n.divisors with Squarefree d, f d =
       ∑ i ∈ (UniqueFactorizationMonoid.normalizedFactors n).toFinset.powerset, f i.val.prod := by
   rw [Finset.sum_eq_multiset_sum, divisors_filter_squarefree h0, Multiset.map_map,
     Finset.sum_eq_multiset_sum]
@@ -312,7 +312,7 @@ theorem sum_divisors_filter_squarefree {n : ℕ} (h0 : n ≠ 0) {α : Type*} [Ad
 theorem sq_mul_squarefree_of_pos {n : ℕ} (hn : 0 < n) :
     ∃ a b : ℕ, 0 < a ∧ 0 < b ∧ b ^ 2 * a = n ∧ Squarefree a := by
   classical -- Porting note: This line is not needed in Lean 3
-  set S := (Finset.range (n + 1)).filter (fun s => s ∣ n ∧ ∃ x, s = x ^ 2)
+  set S := {s ∈ range (n + 1) | s ∣ n ∧ ∃ x, s = x ^ 2}
   have hSne : S.Nonempty := by
     use 1
     have h1 : 0 < n ∧ ∃ x : ℕ, 1 = x ^ 2 := ⟨hn, ⟨1, (one_pow 2).symm⟩⟩

--- a/Mathlib/Data/Nat/Totient.lean
+++ b/Mathlib/Data/Nat/Totient.lean
@@ -29,8 +29,7 @@ namespace Nat
 
 /-- Euler's totient function. This counts the number of naturals strictly less than `n` which are
 coprime with `n`. -/
-def totient (n : ℕ) : ℕ :=
-  ((range n).filter n.Coprime).card
+def totient (n : ℕ) : ℕ := #{a ∈ range n | n.Coprime a}
 
 @[inherit_doc]
 scoped notation "φ" => Nat.totient
@@ -42,12 +41,11 @@ theorem totient_zero : φ 0 = 0 :=
 @[simp]
 theorem totient_one : φ 1 = 1 := rfl
 
-theorem totient_eq_card_coprime (n : ℕ) : φ n = ((range n).filter n.Coprime).card :=
-  rfl
+theorem totient_eq_card_coprime (n : ℕ) : φ n = #{a ∈ range n | n.Coprime a} := rfl
 
 /-- A characterisation of `Nat.totient` that avoids `Finset`. -/
 theorem totient_eq_card_lt_and_coprime (n : ℕ) : φ n = Nat.card { m | m < n ∧ n.Coprime m } := by
-  let e : { m | m < n ∧ n.Coprime m } ≃ Finset.filter n.Coprime (Finset.range n) :=
+  let e : { m | m < n ∧ n.Coprime m } ≃ {x ∈ range n | n.Coprime x} :=
     { toFun := fun m => ⟨m, by simpa only [Finset.mem_filter, Finset.mem_range] using m.property⟩
       invFun := fun m => ⟨m, by simpa only [Finset.mem_filter, Finset.mem_range] using m.property⟩
       left_inv := fun m => by simp only [Subtype.coe_mk, Subtype.coe_eta]
@@ -70,12 +68,12 @@ theorem totient_eq_zero : ∀ {n : ℕ}, φ n = 0 ↔ n = 0
 @[simp] theorem totient_pos {n : ℕ} : 0 < φ n ↔ 0 < n := by simp [pos_iff_ne_zero]
 
 theorem filter_coprime_Ico_eq_totient (a n : ℕ) :
-    ((Ico n (n + a)).filter (Coprime a)).card = totient a := by
+    #{x ∈ Ico n (n + a) | a.Coprime x} = totient a := by
   rw [totient, filter_Ico_card_eq_of_periodic, count_eq_card_filter_range]
   exact periodic_coprime a
 
 theorem Ico_filter_coprime_le {a : ℕ} (k n : ℕ) (a_pos : 0 < a) :
-    ((Ico k (k + n)).filter (Coprime a)).card ≤ totient a * (n / a + 1) := by
+    #{x ∈ Ico k (k + n) | a.Coprime x} ≤ totient a * (n / a + 1) := by
   conv_lhs => rw [← Nat.mod_add_div n a]
   induction' n / a with i ih
   · rw [← filter_coprime_Ico_eq_totient a k]
@@ -86,14 +84,15 @@ theorem Ico_filter_coprime_le {a : ℕ} (k n : ℕ) (a_pos : 0 < a) :
   simp only [mul_succ]
   simp_rw [← add_assoc] at ih ⊢
   calc
-    (filter a.Coprime (Ico k (k + n % a + a * i + a))).card = (filter a.Coprime
-        (Ico k (k + n % a + a * i) ∪ Ico (k + n % a + a * i) (k + n % a + a * i + a))).card := by
+    #{x ∈ Ico k (k + n % a + a * i + a) | a.Coprime x}
+      = #{x ∈ Ico k (k + n % a + a * i) ∪
+        Ico (k + n % a + a * i) (k + n % a + a * i + a) | a.Coprime x} := by
       congr
       rw [Ico_union_Ico_eq_Ico]
       · rw [add_assoc]
         exact le_self_add
       exact le_self_add
-    _ ≤ (filter a.Coprime (Ico k (k + n % a + a * i))).card + a.totient := by
+    _ ≤ #{x ∈ Ico k (k + n % a + a * i) | a.Coprime x} + a.totient := by
       rw [filter_union, ← filter_coprime_Ico_eq_totient a (k + n % a + a * i)]
       apply card_union_le
     _ ≤ a.totient * i + a.totient + a.totient := add_le_add_right ih (totient a)
@@ -136,7 +135,7 @@ theorem totient_mul {m n : ℕ} (h : m.Coprime n) : φ (m * n) = φ m * φ n :=
 
 /-- For `d ∣ n`, the totient of `n/d` equals the number of values `k < n` such that `gcd n k = d` -/
 theorem totient_div_of_dvd {n d : ℕ} (hnd : d ∣ n) :
-    φ (n / d) = (filter (fun k : ℕ => n.gcd k = d) (range n)).card := by
+    φ (n / d) = #{k ∈ range n | n.gcd k = d} := by
   rcases d.eq_zero_or_pos with (rfl | hd0); · simp [eq_zero_of_zero_dvd hnd]
   rcases hnd with ⟨x, rfl⟩
   rw [Nat.mul_div_cancel_left x hd0]
@@ -158,14 +157,14 @@ theorem sum_totient (n : ℕ) : n.divisors.sum φ = n := by
   rcases n.eq_zero_or_pos with (rfl | hn)
   · simp
   rw [← sum_div_divisors n φ]
-  have : n = ∑ d ∈ n.divisors, (filter (fun k : ℕ => n.gcd k = d) (range n)).card := by
+  have : n = ∑ d ∈ n.divisors, #{k ∈ range n | n.gcd k = d} := by
     nth_rw 1 [← card_range n]
     refine card_eq_sum_card_fiberwise fun x _ => mem_divisors.2 ⟨?_, hn.ne'⟩
     apply gcd_dvd_left
   nth_rw 3 [this]
   exact sum_congr rfl fun x hx => totient_div_of_dvd (dvd_of_mem_divisors hx)
 
-theorem sum_totient' (n : ℕ) : (∑ m ∈ (range n.succ).filter (· ∣ n), φ m) = n := by
+theorem sum_totient' (n : ℕ) : ∑ m ∈ range n.succ with m ∣ n, φ m = n := by
   convert sum_totient _ using 1
   simp only [Nat.divisors, sum_filter, range_eq_Ico]
   rw [sum_eq_sum_Ico_succ_bot] <;> simp
@@ -173,10 +172,10 @@ theorem sum_totient' (n : ℕ) : (∑ m ∈ (range n.succ).filter (· ∣ n), φ
 /-- When `p` is prime, then the totient of `p ^ (n + 1)` is `p ^ n * (p - 1)` -/
 theorem totient_prime_pow_succ {p : ℕ} (hp : p.Prime) (n : ℕ) : φ (p ^ (n + 1)) = p ^ n * (p - 1) :=
   calc
-    φ (p ^ (n + 1)) = ((range (p ^ (n + 1))).filter (Coprime (p ^ (n + 1)))).card :=
+    φ (p ^ (n + 1)) = #{a ∈ range (p ^ (n + 1)) | (p ^ (n + 1)).Coprime a} :=
       totient_eq_card_coprime _
-    _ = (range (p ^ (n + 1)) \ (range (p ^ n)).image (· * p)).card :=
-      (congr_arg card
+    _ = #(range (p ^ (n + 1)) \ (range (p ^ n)).image (· * p)) :=
+      congr_arg card
         (by
           rw [sdiff_eq_filter]
           apply filter_congr
@@ -188,7 +187,7 @@ theorem totient_prime_pow_succ {p : ℕ} (hp : p.Prime) (n : ℕ) : φ (p ^ (n +
             exact hap (dvd_mul_left _ _)
           · rintro h ⟨b, rfl⟩
             rw [pow_succ'] at ha
-            exact h b ⟨lt_of_mul_lt_mul_left ha (zero_le _), mul_comm _ _⟩))
+            exact h b ⟨lt_of_mul_lt_mul_left ha (zero_le _), mul_comm _ _⟩)
     _ = _ := by
       have h1 : Function.Injective (· * p) := mul_left_injective₀ hp.ne_zero
       have h2 : (range (p ^ n)).image (· * p) ⊆ range (p ^ (n + 1)) := fun a => by

--- a/Mathlib/Data/PNat/Interval.lean
+++ b/Mathlib/Data/PNat/Interval.lean
@@ -52,23 +52,23 @@ theorem map_subtype_embedding_uIcc : (uIcc a b).map (Embedding.subtype _) = uIcc
   map_subtype_embedding_Icc _ _
 
 @[simp]
-theorem card_Icc : (Icc a b).card = b + 1 - a := by
+theorem card_Icc : #(Icc a b) = b + 1 - a := by
   rw [← Nat.card_Icc, ← map_subtype_embedding_Icc, card_map]
 
 @[simp]
-theorem card_Ico : (Ico a b).card = b - a := by
+theorem card_Ico : #(Ico a b) = b - a := by
   rw [← Nat.card_Ico, ← map_subtype_embedding_Ico, card_map]
 
 @[simp]
-theorem card_Ioc : (Ioc a b).card = b - a := by
+theorem card_Ioc : #(Ioc a b) = b - a := by
   rw [← Nat.card_Ioc, ← map_subtype_embedding_Ioc, card_map]
 
 @[simp]
-theorem card_Ioo : (Ioo a b).card = b - a - 1 := by
+theorem card_Ioo : #(Ioo a b) = b - a - 1 := by
   rw [← Nat.card_Ioo, ← map_subtype_embedding_Ioo, card_map]
 
 @[simp]
-theorem card_uIcc : (uIcc a b).card = (b - a : ℤ).natAbs + 1 := by
+theorem card_uIcc : #(uIcc a b) = (b - a : ℤ).natAbs + 1 := by
   rw [← Nat.card_uIcc, ← map_subtype_embedding_uIcc, card_map]
 
 -- Porting note: `simpNF` says `simp` can prove this

--- a/Mathlib/Data/Pi/Interval.lean
+++ b/Mathlib/Data/Pi/Interval.lean
@@ -34,16 +34,16 @@ variable (a b : ∀ i, α i)
 theorem Icc_eq : Icc a b = piFinset fun i => Icc (a i) (b i) :=
   rfl
 
-theorem card_Icc : (Icc a b).card = ∏ i, (Icc (a i) (b i)).card :=
+theorem card_Icc : #(Icc a b) = ∏ i, #(Icc (a i) (b i)) :=
   card_piFinset _
 
-theorem card_Ico : (Ico a b).card = (∏ i, (Icc (a i) (b i)).card) - 1 := by
+theorem card_Ico : #(Ico a b) = ∏ i, #(Icc (a i) (b i)) - 1 := by
   rw [card_Ico_eq_card_Icc_sub_one, card_Icc]
 
-theorem card_Ioc : (Ioc a b).card = (∏ i, (Icc (a i) (b i)).card) - 1 := by
+theorem card_Ioc : #(Ioc a b) = ∏ i, #(Icc (a i) (b i)) - 1 := by
   rw [card_Ioc_eq_card_Icc_sub_one, card_Icc]
 
-theorem card_Ioo : (Ioo a b).card = (∏ i, (Icc (a i) (b i)).card) - 2 := by
+theorem card_Ioo : #(Ioo a b) = ∏ i, #(Icc (a i) (b i)) - 2 := by
   rw [card_Ioo_eq_card_Icc_sub_two, card_Icc]
 
 end LocallyFiniteOrder
@@ -55,11 +55,8 @@ instance instLocallyFiniteOrderBot : LocallyFiniteOrderBot (∀ i, α i) :=
   .ofIic _ (fun b => piFinset fun i => Iic (b i)) fun b x => by
     simp_rw [mem_piFinset, mem_Iic, le_def]
 
-theorem card_Iic : (Iic b).card = ∏ i, (Iic (b i)).card :=
-  card_piFinset _
-
-theorem card_Iio : (Iio b).card = (∏ i, (Iic (b i)).card) - 1 := by
-  rw [card_Iio_eq_card_Iic_sub_one, card_Iic]
+lemma card_Iic : #(Iic b) = ∏ i, #(Iic (b i)) := card_piFinset _
+lemma card_Iio : #(Iio b) = ∏ i, #(Iic (b i)) - 1 := by rw [card_Iio_eq_card_Iic_sub_one, card_Iic]
 
 end LocallyFiniteOrderBot
 
@@ -70,11 +67,8 @@ instance instLocallyFiniteOrderTop : LocallyFiniteOrderTop (∀ i, α i) :=
   LocallyFiniteOrderTop.ofIci _ (fun a => piFinset fun i => Ici (a i)) fun a x => by
     simp_rw [mem_piFinset, mem_Ici, le_def]
 
-theorem card_Ici : (Ici a).card = ∏ i, (Ici (a i)).card :=
-  card_piFinset _
-
-theorem card_Ioi : (Ioi a).card = (∏ i, (Ici (a i)).card) - 1 := by
-  rw [card_Ioi_eq_card_Ici_sub_one, card_Ici]
+lemma card_Ici : #(Ici a) = ∏ i, #(Ici (a i)) := card_piFinset _
+lemma card_Ioi : #(Ioi a) = ∏ i, #(Ici (a i)) - 1 := by rw [card_Ioi_eq_card_Ici_sub_one, card_Ici]
 
 end LocallyFiniteOrderTop
 end PartialOrder
@@ -84,7 +78,7 @@ variable [∀ i, Lattice (α i)] [∀ i, LocallyFiniteOrder (α i)] (a b : ∀ i
 
 theorem uIcc_eq : uIcc a b = piFinset fun i => uIcc (a i) (b i) := rfl
 
-theorem card_uIcc : (uIcc a b).card = ∏ i, (uIcc (a i) (b i)).card := card_Icc _ _
+theorem card_uIcc : #(uIcc a b) = ∏ i, #(uIcc (a i) (b i)) := card_Icc _ _
 
 end Lattice
 end Pi

--- a/Mathlib/Data/Sigma/Interval.lean
+++ b/Mathlib/Data/Sigma/Interval.lean
@@ -55,16 +55,16 @@ section
 
 variable (a b : Σ i, α i)
 
-theorem card_Icc : (Icc a b).card = if h : a.1 = b.1 then (Icc (h.rec a.2) b.2).card else 0 :=
+theorem card_Icc : #(Icc a b) = if h : a.1 = b.1 then #(Icc (h.rec a.2) b.2) else 0 :=
   card_sigmaLift (fun _ => Icc) _ _
 
-theorem card_Ico : (Ico a b).card = if h : a.1 = b.1 then (Ico (h.rec a.2) b.2).card else 0 :=
+theorem card_Ico : #(Ico a b) = if h : a.1 = b.1 then #(Ico (h.rec a.2) b.2) else 0 :=
   card_sigmaLift (fun _ => Ico) _ _
 
-theorem card_Ioc : (Ioc a b).card = if h : a.1 = b.1 then (Ioc (h.rec a.2) b.2).card else 0 :=
+theorem card_Ioc : #(Ioc a b) = if h : a.1 = b.1 then #(Ioc (h.rec a.2) b.2) else 0 :=
   card_sigmaLift (fun _ => Ioc) _ _
 
-theorem card_Ioo : (Ioo a b).card = if h : a.1 = b.1 then (Ioo (h.rec a.2) b.2).card else 0 :=
+theorem card_Ioo : #(Ioo a b) = if h : a.1 = b.1 then #(Ioo (h.rec a.2) b.2) else 0 :=
   card_sigmaLift (fun _ => Ioo) _ _
 
 end

--- a/Mathlib/Data/Sign.lean
+++ b/Mathlib/Data/Sign.lean
@@ -486,7 +486,7 @@ because lean4 infers α to live in a different universe u_2 otherwise -/
 private theorem exists_signed_sum_aux {α : Type u_1} [DecidableEq α] (s : Finset α) (f : α → ℤ) :
     ∃ (β : Type u_1) (t : Finset β) (sgn : β → SignType) (g : β → α),
       (∀ b, g b ∈ s) ∧
-        (t.card = ∑ a ∈ s, (f a).natAbs) ∧
+        (#t = ∑ a ∈ s, (f a).natAbs) ∧
           ∀ a ∈ s, (∑ b ∈ t, if g b = a then (sgn b : ℤ) else 0) = f a := by
   refine
     ⟨(Σ _ : { x // x ∈ s }, ℕ), Finset.univ.sigma fun a => range (f a).natAbs,

--- a/Mathlib/Data/Sym/Card.lean
+++ b/Mathlib/Data/Sym/Card.lean
@@ -121,8 +121,8 @@ namespace Sym2
 
 variable [DecidableEq α]
 
-/-- The `diag` of `s : Finset α` is sent on a finset of `Sym2 α` of card `s.card`. -/
-theorem card_image_diag (s : Finset α) : (s.diag.image Sym2.mk).card = s.card := by
+/-- The `diag` of `s : Finset α` is sent on a finset of `Sym2 α` of card `#s`. -/
+theorem card_image_diag (s : Finset α) : #(s.diag.image Sym2.mk) = #s := by
   rw [card_image_of_injOn, diag_card]
   rintro ⟨x₀, x₁⟩ hx _ _ h
   cases Sym2.eq.1 h
@@ -130,8 +130,7 @@ theorem card_image_diag (s : Finset α) : (s.diag.image Sym2.mk).card = s.card :
   · simp only [mem_coe, mem_diag] at hx
     rw [hx.2]
 
-theorem two_mul_card_image_offDiag (s : Finset α) :
-    2 * (s.offDiag.image Sym2.mk).card = s.offDiag.card := by
+lemma two_mul_card_image_offDiag (s : Finset α) : 2 * #(s.offDiag.image Sym2.mk) = #s.offDiag := by
   rw [card_eq_sum_card_image (Sym2.mk : α × α → _), sum_const_nat (Sym2.ind _), mul_comm]
   rintro x y hxy
   simp_rw [mem_image, mem_offDiag] at hxy
@@ -140,7 +139,7 @@ theorem two_mul_card_image_offDiag (s : Finset α) :
   obtain ⟨hx, hy, hxy⟩ : x ∈ s ∧ y ∈ s ∧ x ≠ y := by
     cases h <;> refine ⟨‹_›, ‹_›, ?_⟩ <;> [exact ha; exact ha.symm]
   have hxy' : y ≠ x := hxy.symm
-  have : (s.offDiag.filter fun z => Sym2.mk z = s(x, y)) = ({(x, y), (y, x)} : Finset _) := by
+  have : {z ∈ s.offDiag | Sym2.mk z = s(x, y)} = {(x, y), (y, x)} := by
     ext ⟨x₁, y₁⟩
     rw [mem_filter, mem_insert, mem_singleton, Sym2.eq_iff, Prod.mk.inj_iff, Prod.mk.inj_iff,
       and_iff_right_iff_imp]
@@ -150,11 +149,10 @@ theorem two_mul_card_image_offDiag (s : Finset α) :
   simp only [not_and, Prod.mk.inj_iff, mem_singleton]
   exact fun _ => hxy'
 
-/-- The `offDiag` of `s : Finset α` is sent on a finset of `Sym2 α` of card `s.offDiag.card / 2`.
+/-- The `offDiag` of `s : Finset α` is sent on a finset of `Sym2 α` of card `#s.offDiag / 2`.
 This is because every element `s(x, y)` of `Sym2 α` not on the diagonal comes from exactly two
 pairs: `(x, y)` and `(y, x)`. -/
-theorem card_image_offDiag (s : Finset α) :
-    (s.offDiag.image Sym2.mk).card = s.card.choose 2 := by
+theorem card_image_offDiag (s : Finset α) : #(s.offDiag.image Sym2.mk) = (#s).choose 2 := by
   rw [Nat.choose_two_right, Nat.mul_sub_left_distrib, mul_one, ← offDiag_card,
     Nat.div_eq_of_eq_mul_right Nat.zero_lt_two (two_mul_card_image_offDiag s).symm]
 

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -647,7 +647,7 @@ theorem other_invol {a : α} {z : Sym2 α} (ha : a ∈ z) (hb : Mem.other ha ∈
     apply other_eq_other'
 
 theorem filter_image_mk_isDiag [DecidableEq α] (s : Finset α) :
-    ((s ×ˢ s).image Sym2.mk).filter IsDiag = s.diag.image Sym2.mk := by
+    {a ∈ (s ×ˢ s).image Sym2.mk | a.IsDiag} = s.diag.image Sym2.mk := by
   ext z
   induction' z
   simp only [mem_image, mem_diag, exists_prop, mem_filter, Prod.exists, mem_product]
@@ -660,8 +660,7 @@ theorem filter_image_mk_isDiag [DecidableEq α] (s : Finset α) :
     exact ⟨⟨a, a, ⟨ha, ha⟩, rfl⟩, rfl⟩
 
 theorem filter_image_mk_not_isDiag [DecidableEq α] (s : Finset α) :
-    (((s ×ˢ s).image Sym2.mk).filter fun a : Sym2 α => ¬a.IsDiag) =
-      s.offDiag.image Sym2.mk := by
+    {a ∈ (s ×ˢ s).image Sym2.mk | ¬a.IsDiag} = s.offDiag.image Sym2.mk := by
   ext z
   induction z
   simp only [mem_image, mem_offDiag, mem_filter, Prod.exists, mem_product]


### PR DESCRIPTION
For `s : Finset α`, replace `s.card` with `#s`, `s.filter p` with `{x ∈ s | p x}`, `∑ x ∈ s.filter p, f x` with `∑ x ∈ s with p x, f x`. Rewrap lines around and open the `Finset` locale where necessary.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
