### PR TITLE
[Merged by Bors] - refactor(Group/Pointwise/Finset): state `mul_singleton`/`singleton_mul` using `•`

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -286,6 +286,164 @@ lemma inv_inter (s t : Finset α) : (s ∩ t)⁻¹ = s⁻¹ ∩ t⁻¹ := coe_in
 
 end InvolutiveInv
 
+/-! ### Scalar addition/multiplication of finsets -/
+
+section SMul
+variable [DecidableEq β] [SMul α β] {s s₁ s₂ : Finset α} {t t₁ t₂ u : Finset β} {a : α} {b : β}
+
+/-- The pointwise product of two finsets `s` and `t`: `s • t = {x • y | x ∈ s, y ∈ t}`. -/
+@[to_additive "The pointwise sum of two finsets `s` and `t`: `s +ᵥ t = {x +ᵥ y | x ∈ s, y ∈ t}`."]
+protected def smul : SMul (Finset α) (Finset β) := ⟨image₂ (· • ·)⟩
+
+scoped[Pointwise] attribute [instance] Finset.smul Finset.vadd
+
+@[to_additive] lemma smul_def : s • t = (s ×ˢ t).image fun p : α × β => p.1 • p.2 := rfl
+
+@[to_additive]
+lemma image_smul_product : ((s ×ˢ t).image fun x : α × β => x.fst • x.snd) = s • t := rfl
+
+@[to_additive] lemma mem_smul {x : β} : x ∈ s • t ↔ ∃ y ∈ s, ∃ z ∈ t, y • z = x := mem_image₂
+
+@[to_additive (attr := simp, norm_cast)]
+lemma coe_smul (s : Finset α) (t : Finset β) : ↑(s • t) = (s : Set α) • (t : Set β) := coe_image₂ ..
+
+@[to_additive] lemma smul_mem_smul : a ∈ s → b ∈ t → a • b ∈ s • t := mem_image₂_of_mem
+
+@[to_additive] lemma smul_card_le : (s • t).card ≤ s.card • t.card := card_image₂_le ..
+
+@[to_additive (attr := simp)]
+lemma empty_smul (t : Finset β) : (∅ : Finset α) • t = ∅ := image₂_empty_left
+
+@[to_additive (attr := simp)]
+lemma smul_empty (s : Finset α) : s • (∅ : Finset β) = ∅ := image₂_empty_right
+
+@[to_additive (attr := simp)]
+lemma smul_eq_empty : s • t = ∅ ↔ s = ∅ ∨ t = ∅ := image₂_eq_empty_iff
+
+@[to_additive (attr := simp)]
+lemma smul_nonempty_iff : (s • t).Nonempty ↔ s.Nonempty ∧ t.Nonempty := image₂_nonempty_iff
+
+@[to_additive (attr := aesop safe apply (rule_sets := [finsetNonempty]))]
+lemma Nonempty.smul : s.Nonempty → t.Nonempty → (s • t).Nonempty := .image₂
+
+@[to_additive] lemma Nonempty.of_smul_left : (s • t).Nonempty → s.Nonempty := .of_image₂_left
+@[to_additive] lemma Nonempty.of_smul_right : (s • t).Nonempty → t.Nonempty := .of_image₂_right
+
+@[to_additive]
+lemma smul_singleton (b : β) : s • ({b} : Finset β) = s.image (· • b) := image₂_singleton_right
+
+@[to_additive]
+lemma singleton_smul_singleton (a : α) (b : β) : ({a} : Finset α) • ({b} : Finset β) = {a • b} :=
+  image₂_singleton
+
+@[to_additive (attr := mono, gcongr)]
+lemma smul_subset_smul : s₁ ⊆ s₂ → t₁ ⊆ t₂ → s₁ • t₁ ⊆ s₂ • t₂ := image₂_subset
+
+@[to_additive] lemma smul_subset_smul_left : t₁ ⊆ t₂ → s • t₁ ⊆ s • t₂ := image₂_subset_left
+@[to_additive] lemma smul_subset_smul_right : s₁ ⊆ s₂ → s₁ • t ⊆ s₂ • t := image₂_subset_right
+@[to_additive] lemma smul_subset_iff : s • t ⊆ u ↔ ∀ a ∈ s, ∀ b ∈ t, a • b ∈ u := image₂_subset_iff
+
+@[to_additive]
+lemma union_smul [DecidableEq α] : (s₁ ∪ s₂) • t = s₁ • t ∪ s₂ • t := image₂_union_left
+
+@[to_additive]
+lemma smul_union : s • (t₁ ∪ t₂) = s • t₁ ∪ s • t₂ := image₂_union_right
+
+@[to_additive]
+lemma inter_smul_subset [DecidableEq α] : (s₁ ∩ s₂) • t ⊆ s₁ • t ∩ s₂ • t :=
+  image₂_inter_subset_left
+
+@[to_additive]
+lemma smul_inter_subset : s • (t₁ ∩ t₂) ⊆ s • t₁ ∩ s • t₂ := image₂_inter_subset_right
+
+@[to_additive]
+lemma inter_smul_union_subset_union [DecidableEq α] : (s₁ ∩ s₂) • (t₁ ∪ t₂) ⊆ s₁ • t₁ ∪ s₂ • t₂ :=
+  image₂_inter_union_subset_union
+
+@[to_additive]
+lemma union_smul_inter_subset_union [DecidableEq α] : (s₁ ∪ s₂) • (t₁ ∩ t₂) ⊆ s₁ • t₁ ∪ s₂ • t₂ :=
+  image₂_union_inter_subset_union
+
+/-- If a finset `u` is contained in the scalar product of two sets `s • t`, we can find two finsets
+`s'`, `t'` such that `s' ⊆ s`, `t' ⊆ t` and `u ⊆ s' • t'`. -/
+@[to_additive
+"If a finset `u` is contained in the scalar sum of two sets `s +ᵥ t`, we can find two
+finsets `s'`, `t'` such that `s' ⊆ s`, `t' ⊆ t` and `u ⊆ s' +ᵥ t'`."]
+lemma subset_smul {s : Set α} {t : Set β} :
+    ↑u ⊆ s • t → ∃ (s' : Finset α) (t' : Finset β), ↑s' ⊆ s ∧ ↑t' ⊆ t ∧ u ⊆ s' • t' :=
+  subset_set_image₂
+
+end SMul
+
+/-! ### Translation/scaling of finsets -/
+
+section SMul
+variable [DecidableEq β] [SMul α β] {s s₁ s₂ t : Finset β} {a : α} {b : β}
+
+/-- The scaling of a finset `s` by a scalar `a`: `a • s = {a • x | x ∈ s}`. -/
+@[to_additive "The translation of a finset `s` by a vector `a`: `a +ᵥ s = {a +ᵥ x | x ∈ s}`."]
+protected def smulFinset : SMul α (Finset β) where smul a := image <| (a • ·)
+
+scoped[Pointwise] attribute [instance] Finset.smulFinset Finset.vaddFinset
+
+@[to_additive] lemma smul_finset_def : a • s = s.image (a • ·) := rfl
+
+@[to_additive] lemma image_smul : s.image (a • ·) = a • s := rfl
+
+@[to_additive]
+lemma mem_smul_finset {x : β} : x ∈ a • s ↔ ∃ y, y ∈ s ∧ a • y = x := by
+  simp only [Finset.smul_finset_def, and_assoc, mem_image, exists_prop, Prod.exists, mem_product]
+
+@[to_additive (attr := simp, norm_cast)]
+lemma coe_smul_finset (a : α) (s : Finset β) : ↑(a • s) = a • (↑s : Set β) := coe_image
+
+@[to_additive] lemma smul_mem_smul_finset : b ∈ s → a • b ∈ a • s := mem_image_of_mem _
+
+@[to_additive] lemma smul_finset_card_le : (a • s).card ≤ s.card := card_image_le
+
+@[to_additive (attr := simp)]
+lemma smul_finset_empty (a : α) : a • (∅ : Finset β) = ∅ := image_empty _
+
+@[to_additive (attr := simp)]
+lemma smul_finset_eq_empty : a • s = ∅ ↔ s = ∅ := image_eq_empty
+
+@[to_additive (attr := simp)]
+lemma smul_finset_nonempty : (a • s).Nonempty ↔ s.Nonempty := image_nonempty
+
+@[to_additive (attr := aesop safe apply (rule_sets := [finsetNonempty]))]
+lemma Nonempty.smul_finset (hs : s.Nonempty) : (a • s).Nonempty :=
+  hs.image _
+
+@[to_additive (attr := simp)]
+lemma singleton_smul (a : α) : ({a} : Finset α) • t = a • t := image₂_singleton_left
+
+@[to_additive (attr := mono, gcongr)]
+lemma smul_finset_subset_smul_finset : s ⊆ t → a • s ⊆ a • t := image_subset_image
+
+@[to_additive (attr := simp)]
+lemma smul_finset_singleton (b : β) : a • ({b} : Finset β) = {a • b} := image_singleton ..
+
+@[to_additive]
+lemma smul_finset_union : a • (s₁ ∪ s₂) = a • s₁ ∪ a • s₂ := image_union _ _
+
+@[to_additive]
+lemma smul_finset_insert (a : α) (b : β) (s : Finset β) : a • insert b s = insert (a • b) (a • s) :=
+  image_insert ..
+
+@[to_additive]
+lemma smul_finset_inter_subset : a • (s₁ ∩ s₂) ⊆ a • s₁ ∩ a • s₂ := image_inter_subset _ _ _
+
+@[to_additive]
+lemma smul_finset_subset_smul {s : Finset α} : a ∈ s → a • t ⊆ s • t := image_subset_image₂_right
+
+@[to_additive (attr := simp)]
+lemma biUnion_smul_finset (s : Finset α) (t : Finset β) : s.biUnion (· • t) = s • t :=
+  biUnion_image_left
+
+end SMul
+
+open scoped Pointwise
+
 /-! ### Finset addition/multiplication -/
 
 
@@ -360,13 +518,9 @@ theorem Nonempty.of_mul_left : (s * t).Nonempty → s.Nonempty :=
 theorem Nonempty.of_mul_right : (s * t).Nonempty → t.Nonempty :=
   Nonempty.of_image₂_right
 
-@[to_additive]
-theorem mul_singleton (a : α) : s * {a} = s.image (· * a) :=
-  image₂_singleton_right
-
-@[to_additive]
-theorem singleton_mul (a : α) : {a} * s = s.image (a * ·) :=
-  image₂_singleton_left
+open scoped RightActions in
+@[to_additive] lemma mul_singleton (a : α) : s * {a} = s <• a := image₂_singleton_right
+@[to_additive] lemma singleton_mul (a : α) : {a} * s = a • s := image₂_singleton_left
 
 @[to_additive (attr := simp)]
 theorem singleton_mul_singleton (a b : α) : ({a} : Finset α) * {b} = {a * b} :=
@@ -1011,131 +1165,6 @@ theorem preimage_mul_right_one' : preimage 1 (· * b⁻¹) (mul_left_injective _
 
 end Group
 
-/-! ### Scalar addition/multiplication of finsets -/
-
-
-section SMul
-
-variable [DecidableEq β] [SMul α β] {s s₁ s₂ : Finset α} {t t₁ t₂ u : Finset β} {a : α} {b : β}
-
-/-- The pointwise product of two finsets `s` and `t`: `s • t = {x • y | x ∈ s, y ∈ t}`. -/
-@[to_additive "The pointwise sum of two finsets `s` and `t`: `s +ᵥ t = {x +ᵥ y | x ∈ s, y ∈ t}`."]
-protected def smul : SMul (Finset α) (Finset β) :=
-  ⟨image₂ (· • ·)⟩
-
-scoped[Pointwise] attribute [instance] Finset.smul Finset.vadd
-
-@[to_additive]
-theorem smul_def : s • t = (s ×ˢ t).image fun p : α × β => p.1 • p.2 :=
-  rfl
-
-@[to_additive]
-theorem image_smul_product : ((s ×ˢ t).image fun x : α × β => x.fst • x.snd) = s • t :=
-  rfl
-
-@[to_additive]
-theorem mem_smul {x : β} : x ∈ s • t ↔ ∃ y ∈ s, ∃ z ∈ t, y • z = x :=
-  mem_image₂
-
-@[to_additive (attr := simp, norm_cast)]
-theorem coe_smul (s : Finset α) (t : Finset β) : ↑(s • t) = (s : Set α) • (t : Set β) :=
-  coe_image₂ _ _ _
-
-@[to_additive]
-theorem smul_mem_smul : a ∈ s → b ∈ t → a • b ∈ s • t :=
-  mem_image₂_of_mem
-
-@[to_additive]
-theorem smul_card_le : (s • t).card ≤ s.card • t.card :=
-  card_image₂_le _ _ _
-
-@[to_additive (attr := simp)]
-theorem empty_smul (t : Finset β) : (∅ : Finset α) • t = ∅ :=
-  image₂_empty_left
-
-@[to_additive (attr := simp)]
-theorem smul_empty (s : Finset α) : s • (∅ : Finset β) = ∅ :=
-  image₂_empty_right
-
-@[to_additive (attr := simp)]
-theorem smul_eq_empty : s • t = ∅ ↔ s = ∅ ∨ t = ∅ :=
-  image₂_eq_empty_iff
-
-@[to_additive (attr := simp)]
-theorem smul_nonempty_iff : (s • t).Nonempty ↔ s.Nonempty ∧ t.Nonempty :=
-  image₂_nonempty_iff
-
-@[to_additive (attr := aesop safe apply (rule_sets := [finsetNonempty]))]
-theorem Nonempty.smul : s.Nonempty → t.Nonempty → (s • t).Nonempty :=
-  Nonempty.image₂
-
-@[to_additive]
-theorem Nonempty.of_smul_left : (s • t).Nonempty → s.Nonempty :=
-  Nonempty.of_image₂_left
-
-@[to_additive]
-theorem Nonempty.of_smul_right : (s • t).Nonempty → t.Nonempty :=
-  Nonempty.of_image₂_right
-
-@[to_additive]
-theorem smul_singleton (b : β) : s • ({b} : Finset β) = s.image (· • b) :=
-  image₂_singleton_right
-
-@[to_additive]
-theorem singleton_smul_singleton (a : α) (b : β) : ({a} : Finset α) • ({b} : Finset β) = {a • b} :=
-  image₂_singleton
-
-@[to_additive (attr := mono, gcongr)]
-theorem smul_subset_smul : s₁ ⊆ s₂ → t₁ ⊆ t₂ → s₁ • t₁ ⊆ s₂ • t₂ :=
-  image₂_subset
-
-@[to_additive]
-theorem smul_subset_smul_left : t₁ ⊆ t₂ → s • t₁ ⊆ s • t₂ :=
-  image₂_subset_left
-
-@[to_additive]
-theorem smul_subset_smul_right : s₁ ⊆ s₂ → s₁ • t ⊆ s₂ • t :=
-  image₂_subset_right
-
-@[to_additive]
-theorem smul_subset_iff : s • t ⊆ u ↔ ∀ a ∈ s, ∀ b ∈ t, a • b ∈ u :=
-  image₂_subset_iff
-
-@[to_additive]
-theorem union_smul [DecidableEq α] : (s₁ ∪ s₂) • t = s₁ • t ∪ s₂ • t :=
-  image₂_union_left
-
-@[to_additive]
-theorem smul_union : s • (t₁ ∪ t₂) = s • t₁ ∪ s • t₂ :=
-  image₂_union_right
-
-@[to_additive]
-theorem inter_smul_subset [DecidableEq α] : (s₁ ∩ s₂) • t ⊆ s₁ • t ∩ s₂ • t :=
-  image₂_inter_subset_left
-
-@[to_additive]
-theorem smul_inter_subset : s • (t₁ ∩ t₂) ⊆ s • t₁ ∩ s • t₂ :=
-  image₂_inter_subset_right
-
-@[to_additive]
-theorem inter_smul_union_subset_union [DecidableEq α] : (s₁ ∩ s₂) • (t₁ ∪ t₂) ⊆ s₁ • t₁ ∪ s₂ • t₂ :=
-  image₂_inter_union_subset_union
-
-@[to_additive]
-theorem union_smul_inter_subset_union [DecidableEq α] : (s₁ ∪ s₂) • (t₁ ∩ t₂) ⊆ s₁ • t₁ ∪ s₂ • t₂ :=
-  image₂_union_inter_subset_union
-
-/-- If a finset `u` is contained in the scalar product of two sets `s • t`, we can find two finsets
-`s'`, `t'` such that `s' ⊆ s`, `t' ⊆ t` and `u ⊆ s' • t'`. -/
-@[to_additive
-      "If a finset `u` is contained in the scalar sum of two sets `s +ᵥ t`, we can find two
-      finsets `s'`, `t'` such that `s' ⊆ s`, `t' ⊆ t` and `u ⊆ s' +ᵥ t'`."]
-theorem subset_smul {s : Set α} {t : Set β} :
-    ↑u ⊆ s • t → ∃ (s' : Finset α) (t' : Finset β), ↑s' ⊆ s ∧ ↑t' ⊆ t ∧ u ⊆ s' • t' :=
-  subset_set_image₂
-
-end SMul
-
 /-! ### Scalar subtraction of finsets -/
 
 
@@ -1245,98 +1274,6 @@ theorem subset_vsub {s t : Set β} :
   subset_set_image₂
 
 end VSub
-
-open Pointwise
-
-/-! ### Translation/scaling of finsets -/
-
-
-section SMul
-
-variable [DecidableEq β] [SMul α β] {s s₁ s₂ t : Finset β} {a : α} {b : β}
-
-/-- The scaling of a finset `s` by a scalar `a`: `a • s = {a • x | x ∈ s}`. -/
-@[to_additive "The translation of a finset `s` by a vector `a`: `a +ᵥ s = {a +ᵥ x | x ∈ s}`."]
-protected def smulFinset : SMul α (Finset β) :=
-  ⟨fun a => image <| (a • ·)⟩
-
-scoped[Pointwise] attribute [instance] Finset.smulFinset Finset.vaddFinset
-
-@[to_additive]
-theorem smul_finset_def : a • s = s.image (a • ·) :=
-  rfl
-
-@[to_additive]
-theorem image_smul : (s.image fun x => a • x) = a • s :=
-  rfl
-
-@[to_additive]
-theorem mem_smul_finset {x : β} : x ∈ a • s ↔ ∃ y, y ∈ s ∧ a • y = x := by
-  simp only [Finset.smul_finset_def, and_assoc, mem_image, exists_prop, Prod.exists, mem_product]
-
-@[to_additive (attr := simp, norm_cast)]
-theorem coe_smul_finset (a : α) (s : Finset β) : ↑(a • s) = a • (↑s : Set β) :=
-  coe_image
-
-@[to_additive]
-theorem smul_mem_smul_finset : b ∈ s → a • b ∈ a • s :=
-  mem_image_of_mem _
-
-@[to_additive]
-theorem smul_finset_card_le : (a • s).card ≤ s.card :=
-  card_image_le
-
-@[to_additive (attr := simp)]
-theorem smul_finset_empty (a : α) : a • (∅ : Finset β) = ∅ :=
-  image_empty _
-
-@[to_additive (attr := simp)]
-theorem smul_finset_eq_empty : a • s = ∅ ↔ s = ∅ :=
-  image_eq_empty
-
-@[to_additive (attr := simp)]
-theorem smul_finset_nonempty : (a • s).Nonempty ↔ s.Nonempty :=
-  image_nonempty
-
-@[to_additive (attr := aesop safe apply (rule_sets := [finsetNonempty]))]
-theorem Nonempty.smul_finset (hs : s.Nonempty) : (a • s).Nonempty :=
-  hs.image _
-
-@[to_additive (attr := simp)]
-theorem singleton_smul (a : α) : ({a} : Finset α) • t = a • t :=
-  image₂_singleton_left
-
-@[to_additive (attr := mono, gcongr)]
-theorem smul_finset_subset_smul_finset : s ⊆ t → a • s ⊆ a • t :=
-  image_subset_image
-
-@[to_additive (attr := simp)]
-theorem smul_finset_singleton (b : β) : a • ({b} : Finset β) = {a • b} :=
-  image_singleton _ _
-
-@[to_additive]
-theorem smul_finset_union : a • (s₁ ∪ s₂) = a • s₁ ∪ a • s₂ :=
-  image_union _ _
-
-@[to_additive]
-lemma smul_finset_insert (a : α) (b : β) (s : Finset β) : a • insert b s = insert (a • b) (a • s) :=
-  image_insert ..
-
-@[to_additive]
-theorem smul_finset_inter_subset : a • (s₁ ∩ s₂) ⊆ a • s₁ ∩ a • s₂ :=
-  image_inter_subset _ _ _
-
-@[to_additive]
-theorem smul_finset_subset_smul {s : Finset α} : a ∈ s → a • t ⊆ s • t :=
-  image_subset_image₂_right
-
-@[to_additive (attr := simp)]
-theorem biUnion_smul_finset (s : Finset α) (t : Finset β) : s.biUnion (· • t) = s • t :=
-  biUnion_image_left
-
-end SMul
-
-open Pointwise
 
 section Instances
 

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -689,7 +689,7 @@ theorem coeff_mul_monomial' (m) (s : σ →₀ ℕ) (r : R) (p : MvPolynomial σ
   · contrapose! h
     rw [← mem_support_iff] at h
     obtain ⟨j, -, rfl⟩ : ∃ j ∈ support p, j + s = m := by
-      simpa [Finset.add_singleton]
+      simpa [Finset.mem_add]
         using Finset.add_subset_add_left support_monomial_subset <| support_mul _ _ h
     exact le_add_left le_rfl
 


### PR DESCRIPTION
This is much more useful in practice than the `image` spelling. Move the `smul`/`vadd` sections higher to allow for that spelling.

From LeanCamCombi

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
