### PR TITLE
[Merged by Bors] - refactor: make `Set.fintypeMul`/`Set.fintypeDiv` instances

### DIFF
--- a/Mathlib/Data/Set/Pointwise/Finite.lean
+++ b/Mathlib/Data/Set/Pointwise/Finite.lean
@@ -36,7 +36,7 @@ theorem Finite.mul : s.Finite → t.Finite → (s * t).Finite :=
 
 /-- Multiplication preserves finiteness. -/
 @[to_additive "Addition preserves finiteness."]
-def fintypeMul [DecidableEq α] (s t : Set α) [Fintype s] [Fintype t] : Fintype (s * t : Set α) :=
+instance fintypeMul [DecidableEq α] (s t : Set α) [Fintype s] [Fintype t] : Fintype (s * t) :=
   Set.fintypeImage2 _ _ _
 
 end Mul
@@ -127,7 +127,7 @@ variable [Div α] {s t : Set α}
 
 /-- Division preserves finiteness. -/
 @[to_additive "Subtraction preserves finiteness."]
-def fintypeDiv [DecidableEq α] (s t : Set α) [Fintype s] [Fintype t] : Fintype (s / t) :=
+instance fintypeDiv [DecidableEq α] (s t : Set α) [Fintype s] [Fintype t] : Fintype (s / t) :=
   Set.fintypeImage2 _ _ _
 
 end Div


### PR DESCRIPTION
Looks like `Set.fintypeMul` was not made an instance in https://github.com/leanprover-community/mathlib3/pull/3240 out of fear that they would make the `Mul (Set α)` instance globally accessible.

From LeanCamCombi

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
