### PR TITLE
[Merged by Bors] - feat(CategoryTheory/PathCategory): induction principles for morphisms in path categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1839,7 +1839,8 @@ import Mathlib.CategoryTheory.Noetherian
 import Mathlib.CategoryTheory.Opposites
 import Mathlib.CategoryTheory.PEmpty
 import Mathlib.CategoryTheory.PUnit
-import Mathlib.CategoryTheory.PathCategory
+import Mathlib.CategoryTheory.PathCategory.Basic
+import Mathlib.CategoryTheory.PathCategory.MorphismProperty
 import Mathlib.CategoryTheory.Pi.Basic
 import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
 import Mathlib.CategoryTheory.Preadditive.Basic

--- a/Mathlib/CategoryTheory/Bicategory/Coherence.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Coherence.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yuma Mizuno. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yuma Mizuno, Junyan Xu
 -/
-import Mathlib.CategoryTheory.PathCategory
+import Mathlib.CategoryTheory.PathCategory.Basic
 import Mathlib.CategoryTheory.Functor.FullyFaithful
 import Mathlib.CategoryTheory.Bicategory.Free
 import Mathlib.CategoryTheory.Bicategory.LocallyDiscrete

--- a/Mathlib/CategoryTheory/Category/Quiv.lean
+++ b/Mathlib/CategoryTheory/Category/Quiv.lean
@@ -5,7 +5,7 @@ Authors: Kim Morrison
 -/
 import Mathlib.CategoryTheory.Adjunction.Basic
 import Mathlib.CategoryTheory.Category.Cat
-import Mathlib.CategoryTheory.PathCategory
+import Mathlib.CategoryTheory.PathCategory.Basic
 
 /-!
 # The category of quivers

--- a/Mathlib/CategoryTheory/Groupoid/FreeGroupoid.lean
+++ b/Mathlib/CategoryTheory/Groupoid/FreeGroupoid.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémi Bottinelli
 -/
 import Mathlib.CategoryTheory.Groupoid
-import Mathlib.CategoryTheory.PathCategory
+import Mathlib.CategoryTheory.PathCategory.Basic
 
 /-!
 # Free groupoid on a quiver

--- a/Mathlib/CategoryTheory/Groupoid/VertexGroup.lean
+++ b/Mathlib/CategoryTheory/Groupoid/VertexGroup.lean
@@ -5,7 +5,7 @@ Authors: Rémi Bottinelli
 -/
 import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.CategoryTheory.Groupoid
-import Mathlib.CategoryTheory.PathCategory
+import Mathlib.CategoryTheory.PathCategory.Basic
 import Mathlib.Combinatorics.Quiver.Path
 
 /-!

--- a/Mathlib/CategoryTheory/PathCategory.lean
+++ b/Mathlib/CategoryTheory/PathCategory.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison, Robin Carlier
 import Mathlib.CategoryTheory.EqToHom
 import Mathlib.CategoryTheory.Quotient
 import Mathlib.Combinatorics.Quiver.Path
+import Mathlib.CategoryTheory.MorphismProperty.Basic
 
 /-!
 # The category paths on a quiver.
@@ -74,32 +75,13 @@ lemma induction_fixed_target {b : Paths V} (P : ∀ {a : Paths V}, (a ⟶ b) →
   | zero => cases f with
     | nil => exact id
     | cons _ _ => simp at h
-  | succ k h' => cases f with
-    | nil => simp at h
-    | @cons c _ u q =>
-      change 𝓠.Hom c b at q
-      obtain ⟨x, q', p, h''⟩ : ∃ (x : V) (q' : 𝓠.Hom (a : V) x) (p : (of.obj x) ⟶ b),
-        (@Quiver.Path.cons V _ a c b u q)= of.map q' ≫ p := by
-        clear h; clear comp; clear id; clear h'; clear P
-        induction u generalizing b with
-        | nil => use b, q, (𝟙 _); rfl
-        | @cons c₁ d p' q' h'' =>
-          obtain ⟨x, q'', p'', e⟩ := h'' q'
-          use x, q'', p''.cons q
-          rw [e]
-          rfl
-      rw [h''] at h |-
-      apply comp
-      apply h'
-      conv at h => lhs; congr; change Quiver.Path.comp (of.map q') p
-      rw [Quiver.Path.length_comp] at h; change (1 + _ = k + 1) at h
-      simp only [of_obj] at h
-      rw [Nat.add_comm] at h
-      cases h; rfl
+  | succ k h' =>
+    obtain ⟨c, f, q, hq, rfl⟩ := f.eq_toPath_comp_of_length_eq_succ h
+    exact comp _ _ (h' _ hq)
 
 /-- To prove a property on morphisms of a path category, it suffices to prove it for the identity
-and prove that the properity is preserved under composition on the right with length 1 paths. -/
-lemma induction (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
+and prove that the property is preserved under composition on the right with length 1 paths. -/
+lemma induction (P : MorphismProperty (Paths V))
     (id : ∀ {v : V}, P (𝟙 (of.obj v)))
     (comp : ∀ {u v w : V} (p : of.obj u ⟶ of.obj v) (q : v ⟶ w), P p → P (p ≫ of.map q)) :
     ∀ {a b : Paths V} (f : a ⟶ b), P f := by
@@ -112,7 +94,7 @@ lemma induction (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
 
 /-- To prove a property on morphisms of a path category, it suffices to prove it for the identity
 and prove that the property is preserved under composition on the left with length 1 paths. -/
-lemma induction' (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
+lemma induction' (P : MorphismProperty (Paths V))
     (id : ∀ {v : V}, P (𝟙 (of.obj v)))
     (comp : ∀ {u v w : V} (p : u ⟶ v) (q : of.obj v ⟶ of.obj w), P q → P (of.map p ≫ q)) :
     ∀ {a b : Paths V} (f : a ⟶ b), P f := by

--- a/Mathlib/CategoryTheory/PathCategory.lean
+++ b/Mathlib/CategoryTheory/PathCategory.lean
@@ -32,7 +32,7 @@ def Paths (V : Type u₁) : Type u₁ := V
 
 instance (V : Type u₁) [Inhabited V] : Inhabited (Paths V) := ⟨(default : V)⟩
 
-variable (V : Type u₁) [𝓠 : Quiver.{v₁ + 1} V]
+variable (V : Type u₁) [Quiver.{v₁ + 1} V]
 
 namespace Paths
 

--- a/Mathlib/CategoryTheory/PathCategory.lean
+++ b/Mathlib/CategoryTheory/PathCategory.lean
@@ -50,7 +50,7 @@ def of : V ⥤q Paths V where
   map f := f.toPath
 
 /-- To prove a property on morphisms of a path category with given source `a`, it suffices to
-prove it for the identity and prove that the properity is preserved under composition on the right
+prove it for the identity and prove that the property is preserved under composition on the right
 with length 1 paths. -/
 lemma induction_fixed_source {a : Paths V} (P : ∀ {b : Paths V}, (a ⟶ b) → Prop)
     (id : P (𝟙 a))
@@ -62,7 +62,7 @@ lemma induction_fixed_source {a : Paths V} (P : ∀ {b : Paths V}, (a ⟶ b) →
   | @cons a b f w h => exact comp f w h
 
 /-- To prove a property on morphisms of a path category with given target `b`, it suffices to prove
-it for the identity and prove that the properity is preserved under composition on the left
+it for the identity and prove that the property is preserved under composition on the left
 with length 1 paths. -/
 lemma induction_fixed_target {b : Paths V} (P : ∀ {a : Paths V}, (a ⟶ b) → Prop)
     (id : P (𝟙 b))

--- a/Mathlib/CategoryTheory/PathCategory.lean
+++ b/Mathlib/CategoryTheory/PathCategory.lean
@@ -49,8 +49,8 @@ def of : V ⥤q Paths V where
   obj X := X
   map f := f.toPath
 
-/-- To prove a property on morphisms of a path category, it suffices to prove it for the indentity
-and prove that it is preserved by composition on the right by length 1 paths. -/
+/-- To prove a property on morphisms of a path category, it suffices to prove it for the identity
+and prove that the properity is preserved under composition on the right with length 1 paths. -/
 lemma induction (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
     (id : ∀ {v : V}, P (𝟙 (of.obj v)))
     (comp : ∀ {u v w : V} (p : of.obj u ⟶ of.obj v) (q : v ⟶ w), P p → P (p ≫ of.map q)) :
@@ -60,8 +60,8 @@ lemma induction (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
   | nil => exact id
   | @cons a b f w h => exact comp f w h
 
-/-- To prove a property on morphisms of a path category, it suffices to prove it for the indentity
-and prove that it is preserved by composition on the left by length 1 paths. -/
+/-- To prove a property on morphisms of a path category, it suffices to prove it for the identity
+and prove that the property is preserved under composition on the left with length 1 paths. -/
 lemma induction' (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
     (id : ∀ {v : V}, P (𝟙 (of.obj v)))
     (comp : ∀ {u v w : V} (p : u ⟶ v) (q : of.obj v ⟶ of.obj w), P q → P (of.map p ≫ q)) :

--- a/Mathlib/CategoryTheory/PathCategory.lean
+++ b/Mathlib/CategoryTheory/PathCategory.lean
@@ -60,7 +60,7 @@ lemma induction_fixed_source {a : Paths V} (P : ∀ {b : Paths V}, (a ⟶ b) →
   intro _ f
   induction f with
   | nil => exact id
-  | @cons a b f w h => exact comp f w h
+  | cons _ _ h => exact comp _ w h
 
 /-- To prove a property on morphisms of a path category with given target `b`, it suffices to prove
 it for the identity and prove that the property is preserved under composition on the left

--- a/Mathlib/CategoryTheory/PathCategory.lean
+++ b/Mathlib/CategoryTheory/PathCategory.lean
@@ -60,7 +60,7 @@ lemma induction_fixed_source {a : Paths V} (P : ∀ {b : Paths V}, (a ⟶ b) →
   intro _ f
   induction f with
   | nil => exact id
-  | cons _ _ h => exact comp _ w h
+  | cons _ w h => exact comp _ w h
 
 /-- To prove a property on morphisms of a path category with given target `b`, it suffices to prove
 it for the identity and prove that the property is preserved under composition on the left
@@ -84,13 +84,8 @@ and prove that the property is preserved under composition on the right with len
 lemma induction (P : MorphismProperty (Paths V))
     (id : ∀ {v : V}, P (𝟙 (of.obj v)))
     (comp : ∀ {u v w : V} (p : of.obj u ⟶ of.obj v) (q : v ⟶ w), P p → P (p ≫ of.map q)) :
-    ∀ {a b : Paths V} (f : a ⟶ b), P f := by
-  intro a
-  apply induction_fixed_source
-  · exact id
-  · intro _ _ _ _ h
-    apply comp
-    exact h
+    ∀ {a b : Paths V} (f : a ⟶ b), P f :=
+  fun {_} ↦ induction_fixed_source _ id comp
 
 /-- To prove a property on morphisms of a path category, it suffices to prove it for the identity
 and prove that the property is preserved under composition on the left with length 1 paths. -/
@@ -100,11 +95,7 @@ lemma induction' (P : MorphismProperty (Paths V))
     ∀ {a b : Paths V} (f : a ⟶ b), P f := by
   intro a b
   revert a
-  apply induction_fixed_target
-  · exact id
-  · intro _ _ _ _ h
-    apply comp
-    exact h
+  exact induction_fixed_target (P := fun f ↦ P f) id (fun _ _ ↦ comp _ _)
 
 attribute [local ext (iff := false)] Functor.ext
 

--- a/Mathlib/CategoryTheory/PathCategory.lean
+++ b/Mathlib/CategoryTheory/PathCategory.lean
@@ -49,26 +49,28 @@ def of : V ⥤q Paths V where
   obj X := X
   map f := f.toPath
 
-/-- To prove a property on morphisms of a path category, it suffices to prove it for the identity
-and prove that the properity is preserved under composition on the right with length 1 paths. -/
-lemma induction (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
-    (id : ∀ {v : V}, P (𝟙 (of.obj v)))
-    (comp : ∀ {u v w : V} (p : of.obj u ⟶ of.obj v) (q : v ⟶ w), P p → P (p ≫ of.map q)) :
-    ∀ {a b : Paths V} (f : a ⟶ b), P f := by
-  intro _ _ f
+/-- To prove a property on morphisms of a path category with given source `a`, it suffices to
+prove it for the identity and prove that the properity is preserved under composition on the right
+with length 1 paths. -/
+lemma induction_fixed_source {a : Paths V} (P : ∀ {b : Paths V}, (a ⟶ b) → Prop)
+    (id : P (𝟙 a))
+    (comp : ∀ {u v : V} (p : a ⟶ of.obj u) (q : u ⟶ v), P p → P (p ≫ of.map q)) :
+    ∀ {b : Paths V} (f : a ⟶ b), P f := by
+  intro _ f
   induction f with
   | nil => exact id
   | @cons a b f w h => exact comp f w h
 
-/-- To prove a property on morphisms of a path category, it suffices to prove it for the identity
-and prove that the property is preserved under composition on the left with length 1 paths. -/
-lemma induction' (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
-    (id : ∀ {v : V}, P (𝟙 (of.obj v)))
-    (comp : ∀ {u v w : V} (p : u ⟶ v) (q : of.obj v ⟶ of.obj w), P q → P (of.map p ≫ q)) :
-    ∀ {a b : Paths V} (f : a ⟶ b), P f := by
-  intro a b f
+/-- To prove a property on morphisms of a path category with given target `b`, it suffices to prove
+it for the identity and prove that the properity is preserved under composition on the left
+with length 1 paths. -/
+lemma induction_fixed_target {b : Paths V} (P : ∀ {a : Paths V}, (a ⟶ b) → Prop)
+    (id : P (𝟙 b))
+    (comp : ∀ {u v : V} (p : of.obj v ⟶ b) (q : u ⟶ v), P p → P (of.map q ≫ p)) :
+    ∀ {a : Paths V} (f : a ⟶ b), P f := by
+  intro a f
   generalize h : f.length = k
-  induction k generalizing f a b with
+  induction k generalizing f a with
   | zero => cases f with
     | nil => exact id
     | cons _ _ => simp at h
@@ -78,7 +80,7 @@ lemma induction' (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
       change 𝓠.Hom c b at q
       obtain ⟨x, q', p, h''⟩ : ∃ (x : V) (q' : 𝓠.Hom (a : V) x) (p : (of.obj x) ⟶ b),
         (@Quiver.Path.cons V _ a c b u q)= of.map q' ≫ p := by
-        clear h
+        clear h; clear comp; clear id; clear h'; clear P
         induction u generalizing b with
         | nil => use b, q, (𝟙 _); rfl
         | @cons c₁ d p' q' h'' =>
@@ -94,6 +96,33 @@ lemma induction' (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
       simp only [of_obj] at h
       rw [Nat.add_comm] at h
       cases h; rfl
+
+/-- To prove a property on morphisms of a path category, it suffices to prove it for the identity
+and prove that the properity is preserved under composition on the right with length 1 paths. -/
+lemma induction (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
+    (id : ∀ {v : V}, P (𝟙 (of.obj v)))
+    (comp : ∀ {u v w : V} (p : of.obj u ⟶ of.obj v) (q : v ⟶ w), P p → P (p ≫ of.map q)) :
+    ∀ {a b : Paths V} (f : a ⟶ b), P f := by
+  intro a
+  apply induction_fixed_source
+  · exact id
+  · intro _ _ _ _ h
+    apply comp
+    exact h
+
+/-- To prove a property on morphisms of a path category, it suffices to prove it for the identity
+and prove that the property is preserved under composition on the left with length 1 paths. -/
+lemma induction' (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
+    (id : ∀ {v : V}, P (𝟙 (of.obj v)))
+    (comp : ∀ {u v w : V} (p : u ⟶ v) (q : of.obj v ⟶ of.obj w), P q → P (of.map p ≫ q)) :
+    ∀ {a b : Paths V} (f : a ⟶ b), P f := by
+  intro a b
+  revert a
+  apply induction_fixed_target
+  · exact id
+  · intro _ _ _ _ h
+    apply comp
+    exact h
 
 attribute [local ext (iff := false)] Functor.ext
 

--- a/Mathlib/CategoryTheory/PathCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/PathCategory/Basic.lean
@@ -6,7 +6,6 @@ Authors: Kim Morrison, Robin Carlier
 import Mathlib.CategoryTheory.EqToHom
 import Mathlib.CategoryTheory.Quotient
 import Mathlib.Combinatorics.Quiver.Path
-import Mathlib.CategoryTheory.MorphismProperty.Basic
 
 /-!
 # The category paths on a quiver.
@@ -81,7 +80,7 @@ lemma induction_fixed_target {b : Paths V} (P : ∀ {a : Paths V}, (a ⟶ b) →
 
 /-- To prove a property on morphisms of a path category, it suffices to prove it for the identity
 and prove that the property is preserved under composition on the right with length 1 paths. -/
-lemma induction (P : MorphismProperty (Paths V))
+lemma induction (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
     (id : ∀ {v : V}, P (𝟙 (of.obj v)))
     (comp : ∀ {u v w : V} (p : of.obj u ⟶ of.obj v) (q : v ⟶ w), P p → P (p ≫ of.map q)) :
     ∀ {a b : Paths V} (f : a ⟶ b), P f :=
@@ -89,7 +88,7 @@ lemma induction (P : MorphismProperty (Paths V))
 
 /-- To prove a property on morphisms of a path category, it suffices to prove it for the identity
 and prove that the property is preserved under composition on the left with length 1 paths. -/
-lemma induction' (P : MorphismProperty (Paths V))
+lemma induction' (P : ∀ {a b : Paths V}, (a ⟶ b) → Prop)
     (id : ∀ {v : V}, P (𝟙 (of.obj v)))
     (comp : ∀ {u v w : V} (p : u ⟶ v) (q : of.obj v ⟶ of.obj w), P q → P (of.map p ≫ q)) :
     ∀ {a b : Paths V} (f : a ⟶ b), P f := by

--- a/Mathlib/CategoryTheory/PathCategory/MorphismProperty.lean
+++ b/Mathlib/CategoryTheory/PathCategory/MorphismProperty.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2024 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+import Mathlib.CategoryTheory.PathCategory.Basic
+import Mathlib.CategoryTheory.MorphismProperty.Basic
+
+/-!
+# Properties of morphisms in a path category.
+
+We provide a formulation of induction principles for morphisms in a path category in terms of
+`MorphismProperty`. This file is separate from `CategoryTheory.PathCategory.Basic` in order to
+reduce transitive imports. -/
+
+
+universe v₁ u₁
+
+namespace CategoryTheory.Paths
+
+variable (V : Type u₁) [Quiver.{v₁ + 1} V]
+
+/-- A reformulation of `CategoryTheory.Paths.induction` in terms of `MorphismProperty`. -/
+lemma morphismProperty_eq_top
+    (P : MorphismProperty (Paths V))
+    (id : ∀ {v : V}, P (𝟙 (of.obj v)))
+    (comp : ∀ {u v w : V} (p : of.obj u ⟶ of.obj v) (q : v ⟶ w), P p → P (p ≫ of.map q)) :
+    P = ⊤ := by
+  ext; constructor
+  · simp
+  · exact fun _ ↦ induction (fun f ↦ P f) id comp _
+
+/-- A reformulation of `CategoryTheory.Paths.induction'` in terms of `MorphismProperty`. -/
+lemma morphismProperty_eq_top'
+    (P : MorphismProperty (Paths V))
+    (id : ∀ {v : V}, P (𝟙 (of.obj v)))
+    (comp : ∀ {u v w : V} (p : u ⟶ v) (q : of.obj v ⟶ of.obj w), P q → P (of.map p ≫ q)) :
+    P = ⊤ := by
+  ext; constructor
+  · simp
+  · exact fun _ ↦ induction' (fun f ↦ P f) id comp _
+
+end CategoryTheory.Paths

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -72,6 +72,11 @@ theorem eq_of_length_zero (p : Path a b) (hzero : p.length = 0) : a = b := by
   · rfl
   · cases Nat.succ_ne_zero _ hzero
 
+theorem eq_nil_of_length_zero (p : Path a a) (hzero : p.length = 0) : p = nil := by
+  cases p
+  · rfl
+  · simp at hzero
+
 /-- Composition of paths. -/
 def comp {a b : V} : ∀ {c}, Path a b → Path b c → Path a c
   | _, p, nil => p
@@ -147,17 +152,13 @@ lemma eq_toPath_comp_of_length_eq_succ (p : Path a b) {n : ℕ}
   | nil => simp at hp
   | @cons c d p q h =>
     cases n
-    · have h' : a = c := eq_of_length_zero p (by simpa using hp)
-      subst h'
-      use d, q, nil, rfl
-      cases p
-      · rfl
-      · simp at hp
+    · rw [length_cons, Nat.zero_add, Nat.add_left_eq_self] at hp
+      obtain rfl := eq_of_length_zero p hp
+      obtain rfl := eq_nil_of_length_zero p hp
+      exact ⟨d, q, nil, rfl, rfl⟩
     · rw [length_cons, Nat.add_right_cancel_iff] at hp
-      obtain ⟨x, q'', p'', hl, e⟩ := h hp
-      use x, q'', p''.cons q, (by simpa)
-      rw [e]
-      rfl
+      obtain ⟨x, q'', p'', hl, rfl⟩ := h hp
+      exact ⟨x, q'', p''.cons q, by simpa, rfl⟩
 
 /-- Turn a path into a list. The list contains `a` at its head, but not `b` a priori. -/
 @[simp]

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -139,6 +139,26 @@ theorem comp_inj_left {p₁ p₂ : Path a b} {q : Path b c} : p₁.comp q = p₂
 theorem comp_inj_right {p : Path a b} {q₁ q₂ : Path b c} : p.comp q₁ = p.comp q₂ ↔ q₁ = q₂ :=
   p.comp_injective_right.eq_iff
 
+lemma eq_toPath_comp_of_length_eq_succ (p : Path a b) {n : ℕ}
+    (hp : p.length = n + 1) :
+    ∃ (c : V) (f : a ⟶ c) (q : Quiver.Path c b) (_ : q.length = n),
+      p = f.toPath.comp q := by
+  induction p generalizing n with
+  | nil => simp at hp
+  | @cons c d p q h =>
+    cases n
+    · have h' : a = c := eq_of_length_zero p (by simpa using hp)
+      subst h'
+      use d, q, nil, rfl
+      cases p
+      · rfl
+      · simp at hp
+    · rw [length_cons, Nat.add_right_cancel_iff] at hp
+      obtain ⟨x, q'', p'', hl, e⟩ := h hp
+      use x, q'', p''.cons q, (by simpa)
+      rw [e]
+      rfl
+
 /-- Turn a path into a list. The list contains `a` at its head, but not `b` a priori. -/
 @[simp]
 def toList : ∀ {b : V}, Path a b → List V


### PR DESCRIPTION
Introduce two induction lemmas to ease proofs on category freely generated on a quiver.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

While experimenting, I found that in practice it’s a bit tedious to work with free categories on a quiver, as the instances get all confused when calling `cases` or `induction` on a morphism. This PR abstracts two induction principles that should ease this a little bit. The proof of `induction'` is admittedly a bit ugly.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
