### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/Module): linear maps are continuous for the module topology

### DIFF
--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -97,7 +97,8 @@ end
 section LatticeOps
 
 variable {R M₁ M₂ : Type*} [SMul R M₁] [SMul R M₂] [u : TopologicalSpace R]
-  {t : TopologicalSpace M₂} [ContinuousSMul R M₂] (f : M₁ →[R] M₂)
+  {t : TopologicalSpace M₂} [ContinuousSMul R M₂]
+  {F : Type*} [FunLike F M₁ M₂] [MulActionHomClass F R M₁ M₂] (f : F)
 
 theorem continuousSMul_induced : @ContinuousSMul R M₁ _ u (t.induced f) :=
   let _ : TopologicalSpace M₁ := t.induced f

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -96,9 +96,8 @@ end
 
 section LatticeOps
 
-variable {ι R M₁ M₂ : Type*} [Semiring R] [AddCommMonoid M₁] [AddCommMonoid M₂] [Module R M₁]
-  [Module R M₂] [u : TopologicalSpace R] {t : TopologicalSpace M₂} [ContinuousSMul R M₂]
-  (f : M₁ →ₗ[R] M₂)
+variable {R M₁ M₂ : Type*} [SMul R M₁] [SMul R M₂] [u : TopologicalSpace R]
+  {t : TopologicalSpace M₂} [ContinuousSMul R M₂] (f : M₁ →[R] M₂)
 
 theorem continuousSMul_induced : @ContinuousSMul R M₁ _ u (t.induced f) :=
   let _ : TopologicalSpace M₁ := t.induced f

--- a/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
@@ -157,7 +157,7 @@ theorem LinearMap.continuous_of_isClosed_ker (l : E →ₗ[𝕜] 𝕜)
     -- Hence, we know that it is equal to the topology induced by the norm.
     have : induced φ.toEquiv.symm inferInstance = hnorm.toUniformSpace.toTopologicalSpace := by
       refine unique_topology_of_t2 (topologicalAddGroup_induced φ.symm.toLinearMap)
-        (continuousSMul_induced φ.symm.toLinearMap) ?_
+        (continuousSMul_induced φ.symm.toMulActionHom) ?_
       -- Porting note: was `rw [t2Space_iff]`
       refine (@t2Space_iff 𝕜 (induced (↑(LinearEquiv.toEquiv φ).symm) inferInstance)).mpr ?_
       exact fun x y hxy =>

--- a/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
@@ -198,11 +198,11 @@ theorem iso (e : A ≃L[R] B) : IsModuleTopology R B where
     rw [Set.mem_image]
     constructor
     · rintro ⟨σ, ⟨hσ1, hσ2⟩, rfl⟩
-      exact ⟨continuousSMul_induced g', continuousAdd_induced h'⟩
+      exact ⟨continuousSMul_induced g'.toMulActionHom, continuousAdd_induced h'⟩
     · rintro ⟨h1, h2⟩
       use τ.induced e
       rw [induced_compose]
-      refine ⟨⟨continuousSMul_induced g, continuousAdd_induced h⟩, ?_⟩
+      refine ⟨⟨continuousSMul_induced g.toMulActionHom, continuousAdd_induced h⟩, ?_⟩
       nth_rw 2 [← induced_id (t := τ)]
       simp
 
@@ -261,5 +261,37 @@ instance _root_.TopologicalSemiring.toOppositeIsModuleTopology : IsModuleTopolog
   .iso (MulOpposite.opContinuousLinearEquiv Rᵐᵒᵖ).symm
 
 end MulOpposite
+
+section function
+
+variable {R : Type*} [τR : TopologicalSpace R] [Semiring R]
+variable {A : Type*} [AddCommMonoid A] [Module R A] [aA : TopologicalSpace A] [IsModuleTopology R A]
+variable {B : Type*} [AddCommMonoid B] [Module R B] [aB : TopologicalSpace B]
+    [ContinuousAdd B] [ContinuousSMul R B]
+
+/-- Every `R`-linear map between two topological `R`-modules, where the source has the module
+topology, is continuous. -/
+@[fun_prop, continuity]
+theorem continuous_of_distribMulActionHom (φ : A →+[R] B) : Continuous φ := by
+  -- the proof: We know that `+ : B × B → B` and `• : R × B → B` are continuous for the module
+  -- topology on `B`, and two earlier theorems (`continuousSMul_induced` and
+  -- `continuousAdd_induced`) say that hence `+` and `•` on `A` are continuous if `A`
+  -- is given the topology induced from `φ`. Hence the module topology is finer than
+  -- the induced topology, and so the function is continuous.
+  rw [eq_moduleTopology R A, continuous_iff_le_induced]
+  exact sInf_le <| ⟨continuousSMul_induced (φ.toMulActionHom),
+    continuousAdd_induced φ.toAddMonoidHom⟩
+
+@[fun_prop, continuity]
+theorem continuous_of_linearMap (φ : A →ₗ[R] B) : Continuous φ :=
+  continuous_of_distribMulActionHom φ.toDistribMulActionHom
+
+variable (R) in
+theorem continuous_neg (C : Type*) [AddCommGroup C] [Module R C] [TopologicalSpace C]
+    [IsModuleTopology R C] : Continuous (fun a ↦ -a : C → C) :=
+  haveI : ContinuousAdd C := IsModuleTopology.toContinuousAdd R C
+  continuous_of_linearMap (LinearEquiv.neg R).toLinearMap
+
+end function
 
 end IsModuleTopology


### PR DESCRIPTION
If M and N are modules over a topological ring and if we give them both the module topology, then any linear map from M to N is automatically continuous. More generally if M has the module topology and N is any topological module, all linear maps from M to N are continuous.

From the FLT project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

In fact a version of this result for DistribMulActionHoms is true, and this is what I prove. On the way I noticed that Mathlib's `continuousSMul_induced` is proved for `LinearMap`s but it's also true for `MulActionHom`s with exactly the same proof, so I generalise it in this PR (and even to `MulActionHomClass`, thanks Ruben) and fix mathlib in the process.
