### PR TITLE
[Merged by Bors] - feat(Combinatorics/Additive): small tripling implies small powers

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2030,6 +2030,7 @@ import Mathlib.Combinatorics.Additive.ErdosGinzburgZiv
 import Mathlib.Combinatorics.Additive.FreimanHom
 import Mathlib.Combinatorics.Additive.PluenneckeRuzsa
 import Mathlib.Combinatorics.Additive.RuzsaCovering
+import Mathlib.Combinatorics.Additive.SmallTripling
 import Mathlib.Combinatorics.Colex
 import Mathlib.Combinatorics.Configuration
 import Mathlib.Combinatorics.Derangements.Basic

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -1022,6 +1022,17 @@ theorem univ_pow [Fintype α] (hn : n ≠ 0) : (univ : Finset α) ^ n = univ :=
 protected theorem _root_.IsUnit.finset : IsUnit a → IsUnit ({a} : Finset α) :=
   IsUnit.map (singletonMonoidHom : α →* Finset α)
 
+@[to_additive]
+lemma image_op_pow (s : Finset α) : ∀ n : ℕ, (s ^ n).image op = s.image op ^ n
+  | 0 => by simp [singleton_one]
+  | n + 1 => by rw [pow_succ, pow_succ', image_op_mul, image_op_pow]
+
+@[to_additive]
+lemma map_op_pow (s : Finset α) :
+    ∀ n : ℕ, (s ^ n).map opEquiv.toEmbedding = s.map opEquiv.toEmbedding ^ n
+  | 0 => by simp [singleton_one]
+  | n + 1 => by rw [pow_succ, pow_succ', map_op_mul, map_op_pow]
+
 end Monoid
 
 section CommMonoid

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -31,6 +31,11 @@ inequality.
 
 * [Giorgis Petridis, *The Plünnecke-Ruzsa inequality: an overview*][petridis2014]
 * [Terrence Tao, Van Vu, *Additive Combinatorics][tao-vu]
+
+## See also
+
+In general non-abelian groups, small doubling doesn't imply small powers anymore, but small tripling
+does. See `Mathlib.Combinatorics.Additive.SmallTripling`.
 -/
 
 open MulOpposite Nat

--- a/Mathlib/Combinatorics/Additive/SmallTripling.lean
+++ b/Mathlib/Combinatorics/Additive/SmallTripling.lean
@@ -7,6 +7,7 @@ import Mathlib.Combinatorics.Additive.PluenneckeRuzsa
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.Real.Basic
 import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.Positivity.Finset
 import Mathlib.Tactic.Ring
@@ -60,14 +61,15 @@ private lemma inductive_claim (hm : 3 ≤ m)
       · exact ih (Fin.cons 1 <| tail <| tail ε) <| Fin.cons (by simp) (by simp [hε, Fin.tail])
     _ = #A * (k ^ m * #A) := by rw [← pow_sub_one_mul hm₀]; ring
 
-private lemma small_neg_pos_pos (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A ^ 2) ≤ K ^ 2 * #A := by
+private lemma small_neg_pos_pos (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A * A) ≤ K ^ 2 * #A := by
   obtain rfl | hA₀ := A.eq_empty_or_nonempty
   · simp
   have : 0 ≤ K := nonneg_of_mul_nonneg_left (hA.trans' <| by positivity) (by positivity)
   refine le_of_mul_le_mul_left ?_ (by positivity : (0 : ℝ) < #A)
   calc
-    (#A * #(A⁻¹ * A ^ 2) : ℝ) ≤ #(A * A) * #(A * A ^ 2) := by
-      norm_cast; exact ruzsa_triangle_inequality_invMul_mul_mul A A (A ^ 2)
+    (#A * #(A⁻¹ * A * A) : ℝ) = #A * #(A⁻¹ * (A * A)) := by rw [mul_assoc]
+    _ ≤ #(A * A) * #(A * (A * A)) := by
+      norm_cast; exact ruzsa_triangle_inequality_invMul_mul_mul A A (A * A)
     _ = #(A ^ 2) * #(A ^ 3) := by simp [pow_succ']
     _ ≤ (K * #A) * (K * #A) := by
       gcongr
@@ -76,19 +78,20 @@ private lemma small_neg_pos_pos (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A ^ 2) �
         _ ≤ K * #A := hA
     _ = #A * (K ^ 2 * #A) := by ring
 
-private lemma small_neg_neg_pos (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ ^ 2 * A) ≤ K ^ 2 * #A := by
+private lemma small_neg_neg_pos (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A⁻¹ * A) ≤ K ^ 2 * #A := by
   rw [← card_inv]
-  simpa using small_neg_pos_pos (A := A) (K := K) (by simpa)
+  simpa [mul_assoc] using small_neg_pos_pos (A := A) (K := K) (by simpa)
 
-private lemma small_pos_neg_neg (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ ^ 2) ≤ K ^ 2 * #A := by
+private lemma small_pos_neg_neg (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ * A⁻¹) ≤ K ^ 2 * #A := by
   obtain rfl | hA₀ := A.eq_empty_or_nonempty
   · simp
   have : 0 ≤ K := nonneg_of_mul_nonneg_left (hA.trans' <| by positivity) (by positivity)
   refine le_of_mul_le_mul_left ?_ (by positivity : (0 : ℝ) < #A)
   calc
-    (#A * #(A * A⁻¹ ^ 2) : ℝ) ≤ #(A * A) * #(A ^ 2 * A) := by
+    (#A * #(A * A⁻¹ * A⁻¹) : ℝ) = (#A * #(A * (A⁻¹ * A⁻¹)) : ℝ) := by rw [mul_assoc]
+    _ ≤ #(A * A) * #(A * A * A) := by
       norm_cast
-      have := ruzsa_triangle_inequality_invMul_mul_mul A⁻¹ A⁻¹ (A⁻¹ ^ 2)
+      have := ruzsa_triangle_inequality_invMul_mul_mul A⁻¹ A⁻¹ (A⁻¹ * A⁻¹)
       simpa only [card_inv, inv_inv, inv_pow, ← mul_inv_rev] using this
     _ = #(A ^ 2) * #(A ^ 3) := by simp [pow_succ]
     _ ≤ (K * #A) * (K * #A) := by
@@ -98,9 +101,9 @@ private lemma small_pos_neg_neg (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ ^ 2) �
         _ ≤ K * #A := hA
     _ = #A * (K ^ 2 * #A) := by ring
 
-private lemma small_pos_pos_neg (hA : #(A ^ 3) ≤ K * #A) : #(A ^ 2 * A⁻¹) ≤ K ^ 2 * #A := by
+private lemma small_pos_pos_neg (hA : #(A ^ 3) ≤ K * #A) : #(A * A * A⁻¹) ≤ K ^ 2 * #A := by
   rw [← card_inv]
-  simpa using small_pos_neg_neg (A := A) (K := K) (by simpa)
+  simpa [mul_assoc] using small_pos_neg_neg (A := A) (K := K) (by simpa)
 
 private lemma small_pos_neg_pos (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ * A) ≤ K ^ 3 * #A := by
   obtain rfl | hA₀ := A.eq_empty_or_nonempty
@@ -110,7 +113,7 @@ private lemma small_pos_neg_pos (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ * A) �
   calc
     (#A * #(A * A⁻¹ * A) : ℝ) ≤ #(A * (A * A⁻¹)) * #(A * A) := by
       norm_cast; simpa using ruzsa_triangle_inequality_invMul_mul_mul (A * A⁻¹) A A
-    _ = #(A ^ 2 * A⁻¹) * #(A ^ 2) := by simp [pow_succ, mul_assoc]
+    _ = #(A  * A * A⁻¹) * #(A ^ 2) := by simp [pow_succ, mul_assoc]
     _ ≤ (K ^ 2 * #A) * (K * #A) := by
       gcongr
       · exact small_pos_pos_neg hA
@@ -145,48 +148,22 @@ lemma small_alternating_pow_of_small_tripling (hm : 3 ≤ m) (hA : #(A ^ 3) ≤ 
     succ_zero_eq_one, succ_one_eq_two, List.prod_cons, prod_nil, mul_one, ← mul_assoc]
   simp only [zero_le_one, abs_eq, Int.reduceNeg, forall_iff_succ, isValue, succ_zero_eq_one,
     succ_one_eq_two, IsEmpty.forall_iff, and_true] at hδ
-  have aux₁₃ : K * #A ≤ K ^ 3 * #A :=
-    calc
-      _ = K ^ 1 * #A := by simp
-      _ ≤ K ^ 3 * #A := by
-        gcongr
-        · exact hK₁
-        · norm_num
-  have aux₂₃ : K ^ 2 * #A ≤ K ^ 3 * #A := by
+  have : K ≤ K ^ 3 := le_self_pow₀ hK₁ (by omega)
+  have : K ^ 2 ≤ K ^ 3 := by
     gcongr
     · exact hK₁
     · norm_num
-  obtain ⟨hδ₀ | hδ₀, hδ₁ | hδ₁, hδ₂ | hδ₂⟩ := hδ
-  · calc
-      _ = (#(A ^ 3) : ℝ) := by simp [*, pow_succ]
-      _ ≤ K * #A := hA
-      _ ≤ K ^ 3 * #A := aux₁₃
-  · calc
-      _ = (#(A ^ 2 * A⁻¹) : ℝ) := by simp [*, sq]
-      _ ≤ K ^ 2 * #A := small_pos_pos_neg hA
-      _ ≤ K ^ 3 * #A := aux₂₃
-  · calc
-      _ = (#(A * A⁻¹ * A) : ℝ) := by simp [*]
-      _ ≤ K ^ 3 * #A := small_pos_neg_pos hA
-  · calc
-      _ = (#(A * A⁻¹ ^ 2) : ℝ) := by simp [*, sq, mul_assoc]
-      _ ≤ K ^ 2 * #A := small_pos_neg_neg hA
-      _ ≤ K ^ 3 * #A := aux₂₃
-  · calc
-      _ = (#(A⁻¹ * A ^ 2) : ℝ) := by simp [*, sq, mul_assoc]
-      _ ≤ K ^ 2 * #A := small_neg_pos_pos hA
-      _ ≤ K ^ 3 * #A := aux₂₃
-  · calc
-      _ = (#(A⁻¹ * A * A⁻¹) : ℝ) := by simp [*]
-      _ ≤ K ^ 3 * #A := small_neg_pos_neg hA
-  · calc
-      _ = (#(A⁻¹ ^ 2 * A) : ℝ) := by simp [*, sq]
-      _ ≤ K ^ 2 * #A := small_neg_neg_pos hA
-      _ ≤ K ^ 3 * #A := aux₂₃
-  · calc
-      _ = (#(A ^ 3) : ℝ) := by simp [*, pow_succ', ← mul_inv_rev]
-      _ ≤ K * #A := hA
-      _ ≤ K ^ 3 * #A := aux₁₃
+  obtain ⟨hδ₀ | hδ₀, hδ₁ | hδ₁, hδ₂ | hδ₂⟩ := hδ <;> simp [hδ₀, hδ₁, hδ₂]
+  · simp [pow_succ] at hA
+    nlinarith
+  · nlinarith [small_pos_pos_neg hA]
+  · nlinarith [small_pos_neg_pos hA]
+  · nlinarith [small_pos_neg_neg hA]
+  · nlinarith [small_neg_pos_pos hA]
+  · nlinarith [small_neg_pos_neg hA]
+  · nlinarith [small_neg_neg_pos hA]
+  · simp [*, pow_succ', ← mul_inv_rev] at hA ⊢
+    nlinarith
 
 /-- If `A` is symmetric (`A⁻¹ = A`) and has small tripling, then `A` has small powers,
 in the sense that `|A ^ m|` is at most `|A|` times a constant exponential in `m`.

--- a/Mathlib/Combinatorics/Additive/SmallTripling.lean
+++ b/Mathlib/Combinatorics/Additive/SmallTripling.lean
@@ -15,6 +15,11 @@ import Mathlib.Tactic.Ring
 # Small tripling implies small powers
 
 This file shows that a set with small tripling has small powers, even in non-abelian groups.
+
+## See also
+
+In abelian groups, the Plünnecke-Ruzsa inequality is the stronger statement that small doubling
+implies small powers. See `Mathlib.Combinatorics.Additive.PluenneckeRuzsa`.
 -/
 
 open Fin

--- a/Mathlib/Combinatorics/Additive/SmallTripling.lean
+++ b/Mathlib/Combinatorics/Additive/SmallTripling.lean
@@ -23,7 +23,7 @@ In abelian groups, the Plünnecke-Ruzsa inequality is the stronger statement tha
 implies small powers. See `Mathlib.Combinatorics.Additive.PluenneckeRuzsa`.
 -/
 
-open Fin
+open Fin MulOpposite
 open List hiding tail
 open scoped Pointwise
 
@@ -83,23 +83,7 @@ private lemma small_neg_neg_pos (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A⁻¹ *
   simpa [mul_assoc] using small_neg_pos_pos (A := A) (K := K) (by simpa)
 
 private lemma small_pos_neg_neg (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ * A⁻¹) ≤ K ^ 2 * #A := by
-  obtain rfl | hA₀ := A.eq_empty_or_nonempty
-  · simp
-  have : 0 ≤ K := nonneg_of_mul_nonneg_left (hA.trans' <| by positivity) (by positivity)
-  refine le_of_mul_le_mul_left ?_ (by positivity : (0 : ℝ) < #A)
-  calc
-    (#A * #(A * A⁻¹ * A⁻¹) : ℝ) = (#A * #(A * (A⁻¹ * A⁻¹)) : ℝ) := by rw [mul_assoc]
-    _ ≤ #(A * A) * #(A * A * A) := by
-      norm_cast
-      have := ruzsa_triangle_inequality_invMul_mul_mul A⁻¹ A⁻¹ (A⁻¹ * A⁻¹)
-      simpa only [card_inv, inv_inv, inv_pow, ← mul_inv_rev] using this
-    _ = #(A ^ 2) * #(A ^ 3) := by simp [pow_succ]
-    _ ≤ (K * #A) * (K * #A) := by
-      gcongr
-      calc
-        (#(A ^ 2) : ℝ) ≤ #(A ^ 3) := mod_cast hA₀.card_pow_mono (by norm_num)
-        _ ≤ K * #A := hA
-    _ = #A * (K ^ 2 * #A) := by ring
+  simpa using small_neg_pos_pos (A := A⁻¹) (by simpa)
 
 private lemma small_pos_pos_neg (hA : #(A ^ 3) ≤ K * #A) : #(A * A * A⁻¹) ≤ K ^ 2 * #A := by
   rw [← card_inv]

--- a/Mathlib/Combinatorics/Additive/SmallTripling.lean
+++ b/Mathlib/Combinatorics/Additive/SmallTripling.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Combinatorics.Additive.PluenneckeRuzsa
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Positivity.Finset
+import Mathlib.Tactic.Ring
+
+/-!
+# Small tripling implies small powers
+
+This file shows that a set with small tripling has small powers.
+
+## TODO
+
+Generalise to non-commutative group. This involves generalising Plünnecke-Ruzsa first.
+-/
+
+open Fin
+open List hiding tail
+open scoped Pointwise
+
+namespace Finset
+variable {G : Type*} [DecidableEq G] [CommGroup G] {A : Finset G} {k K : ℝ} {m : ℕ}
+
+private lemma pluennecke_ruzsa (U V W : Finset G) : #U * #(V⁻¹ * W) ≤ #(U * V) * #(U * W) := by
+  rw [mul_comm, inv_mul_eq_div, mul_comm _ W, mul_comm #(U * V)]
+  exact ruzsa_triangle_inequality_div_mul_mul ..
+
+private lemma inductive_claim (hm : 3 ≤ m)
+    (h : ∀ ε : Fin 3 → ℤ, (∀ i, |ε i| = 1) → #((finRange 3).map fun i ↦ A ^ ε i).prod ≤ k * #A)
+    (ε : Fin m → ℤ) (hε : ∀ i, |ε i| = 1) :
+    #((finRange m).map fun i ↦ A ^ ε i).prod ≤ k ^ (m - 2) * #A := by
+  induction' m, hm using Nat.le_induction with m hm ih
+  · simpa using h ε hε
+  obtain _ | m := m
+  · simp at hm
+  have hm₀ : m ≠ 0 := by simp at hm; positivity
+  have hε₀ i : ε i ≠ 0 := fun h ↦ by simpa [h] using hε i
+  obtain rfl | hA := A.eq_empty_or_nonempty
+  · simp [hε₀]
+  have hk : 0 ≤ k :=
+    nonneg_of_mul_nonneg_left ((h 1 (by simp)).trans' (by positivity)) (by positivity)
+  let π {n} (δ : Fin n → ℤ) : Finset G := ((finRange _).map fun i ↦ A ^ δ i).prod
+  let V : Finset G := π ![-ε 1, -ε 0]
+  let W : Finset G := π <| tail <| tail ε
+  refine le_of_mul_le_mul_left ?_ (by positivity : (0 : ℝ) < #A)
+  calc
+    (#A * #(π ε) : ℝ)
+      = #A * #(V⁻¹ * W) := by
+      simp [π, V, W, List.finRange_succ_eq_map, Fin.tail, Function.comp_def, mul_assoc]
+    _ ≤ #(A * V) * #(A * W) := by norm_cast; exact pluennecke_ruzsa ..
+    _ = #(π ![1, -ε 1, -ε 0]) * #(π <| Fin.cons 1 <| tail <| tail ε) := by
+      simp [π, V, W, List.finRange_succ_eq_map, Fin.tail, Function.comp_def]
+    _ ≤ (k * #A) * (k ^ (m - 1) * #A) := by
+      gcongr
+      · exact h ![1, -ε 1, -ε 0] fun i ↦ by fin_cases i <;> simp [hε]
+      · exact ih (Fin.cons 1 <| tail <| tail ε) <| Fin.cons (by simp) (by simp [hε, Fin.tail])
+    _ = #A * (k ^ m * #A) := by rw [← pow_sub_one_mul hm₀]; ring
+
+private lemma small_neg_pos_pos (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A ^ 2) ≤ K ^ 2 * #A := by
+  obtain rfl | hA₀ := A.eq_empty_or_nonempty
+  · simp
+  have : 0 ≤ K := nonneg_of_mul_nonneg_left (hA.trans' <| by positivity) (by positivity)
+  refine le_of_mul_le_mul_left ?_ (by positivity : (0 : ℝ) < #A)
+  calc
+    (#A * #(A⁻¹ * A ^ 2) : ℝ) ≤ #(A * A) * #(A * A ^ 2) := by
+      norm_cast; exact pluennecke_ruzsa A A (A ^ 2)
+    _ = #(A ^ 2) * #(A ^ 3) := by simp [pow_succ']
+    _ ≤ (K * #A) * (K * #A) := by
+      gcongr
+      calc
+        (#(A ^ 2) : ℝ) ≤ #(A ^ 3) := mod_cast hA₀.card_pow_mono (by norm_num)
+        _ ≤ K * #A := hA
+    _ = #A * (K ^ 2 * #A) := by ring
+
+private lemma small_neg_neg_pos (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ ^ 2 * A) ≤ K ^ 2 * #A := by
+  rw [← card_inv]
+  simpa using small_neg_pos_pos (A := A) (K := K) (by simpa)
+
+private lemma small_pos_neg_neg (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ ^ 2) ≤ K ^ 2 * #A := by
+  obtain rfl | hA₀ := A.eq_empty_or_nonempty
+  · simp
+  have : 0 ≤ K := nonneg_of_mul_nonneg_left (hA.trans' <| by positivity) (by positivity)
+  refine le_of_mul_le_mul_left ?_ (by positivity : (0 : ℝ) < #A)
+  calc
+    (#A * #(A * A⁻¹ ^ 2) : ℝ) ≤ #(A * A) * #(A ^ 2 * A) := by
+      norm_cast
+      have := pluennecke_ruzsa A⁻¹ A⁻¹ (A⁻¹ ^ 2)
+      simpa only [card_inv, inv_inv, inv_pow, ← mul_inv_rev] using this
+    _ = #(A ^ 2) * #(A ^ 3) := by simp [pow_succ]
+    _ ≤ (K * #A) * (K * #A) := by
+      gcongr
+      calc
+        (#(A ^ 2) : ℝ) ≤ #(A ^ 3) := mod_cast hA₀.card_pow_mono (by norm_num)
+        _ ≤ K * #A := hA
+    _ = #A * (K ^ 2 * #A) := by ring
+
+private lemma small_pos_pos_neg (hA : #(A ^ 3) ≤ K * #A) : #(A ^ 2 * A⁻¹) ≤ K ^ 2 * #A := by
+  rw [← card_inv]
+  simpa using small_pos_neg_neg (A := A) (K := K) (by simpa)
+
+private lemma small_pos_neg_pos (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ * A) ≤ K ^ 3 * #A := by
+  obtain rfl | hA₀ := A.eq_empty_or_nonempty
+  · simp
+  have : 0 ≤ K := nonneg_of_mul_nonneg_left (hA.trans' <| by positivity) (by positivity)
+  refine le_of_mul_le_mul_left ?_ (by positivity : (0 : ℝ) < #A)
+  calc
+    (#A * #(A * A⁻¹ * A) : ℝ) ≤ #(A * (A * A⁻¹)) * #(A * A) := by
+      norm_cast; simpa using pluennecke_ruzsa A (A * A⁻¹) A
+    _ = #(A ^ 2 * A⁻¹) * #(A ^ 2) := by simp [pow_succ, mul_assoc]
+    _ ≤ (K ^ 2 * #A) * (K * #A) := by
+      gcongr
+      · exact small_pos_pos_neg hA
+      calc
+        (#(A ^ 2) : ℝ) ≤ #(A ^ 3) := mod_cast hA₀.card_pow_mono (by norm_num)
+        _ ≤ K * #A := hA
+    _ = #A * (K ^ 3 * #A) := by ring
+
+private lemma small_neg_pos_neg (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A * A⁻¹) ≤ K ^ 3 * #A := by
+  rw [← card_inv]
+  simpa [mul_assoc] using small_pos_neg_pos (A := A) (K := K) (by simpa)
+
+/-- If `A` has small tripling, say with constant `K`, then `A` has small alternating powers, in the
+sense that `|A^±1 * ... * A^±1|` is at most `|A|` times a constant exponential in the number of
+terms in the product.
+
+When `A` is symmetric (`A⁻¹ = A`), the base of the exponential can be lowered from `K ^ 3` to `K`,
+where `K` is the tripling constant. See `Finset.small_pow_of_small_tripling`. -/
+lemma small_alternating_pow_of_small_tripling (hm : 3 ≤ m) (hA : #(A ^ 3) ≤ K * #A) (ε : Fin m → ℤ)
+    (hε : ∀ i, |ε i| = 1) :
+    #((finRange m).map fun i ↦ A ^ ε i).prod ≤ K ^ (3 * (m - 2)) * #A := by
+  have hm₀ : m ≠ 0 := by positivity
+  have hε₀ i : ε i ≠ 0 := fun h ↦ by simpa [h] using hε i
+  obtain rfl | hA₀ := A.eq_empty_or_nonempty
+  · simp [hm₀, hε₀]
+  have hK₁ : 1 ≤ K :=
+    one_le_of_le_mul_right₀ (by positivity)
+      (hA.trans' <| by norm_cast; exact card_le_card_pow (by norm_num))
+  rw [pow_mul]
+  refine inductive_claim hm (fun δ hδ ↦ ?_) ε hε
+  simp only [finRange_succ_eq_map, Nat.reduceAdd, isValue, finRange_zero, map_nil, List.map_cons,
+    succ_zero_eq_one, succ_one_eq_two, List.prod_cons, prod_nil, mul_one, ← mul_assoc]
+  simp only [zero_le_one, abs_eq, Int.reduceNeg, forall_iff_succ, isValue, succ_zero_eq_one,
+    succ_one_eq_two, IsEmpty.forall_iff, and_true] at hδ
+  have aux₁₃ : K * #A ≤ K ^ 3 * #A :=
+    calc
+      _ = K ^ 1 * #A := by simp
+      _ ≤ K ^ 3 * #A := by
+        gcongr
+        · exact hK₁
+        · norm_num
+  have aux₂₃ : K ^ 2 * #A ≤ K ^ 3 * #A := by
+    gcongr
+    · exact hK₁
+    · norm_num
+  obtain ⟨hδ₀ | hδ₀, hδ₁ | hδ₁, hδ₂ | hδ₂⟩ := hδ
+  · calc
+      _ = (#(A ^ 3) : ℝ) := by simp [*, pow_succ]
+      _ ≤ K * #A := hA
+      _ ≤ K ^ 3 * #A := aux₁₃
+  · calc
+      _ = (#(A ^ 2 * A⁻¹) : ℝ) := by simp [*, sq]
+      _ ≤ K ^ 2 * #A := small_pos_pos_neg hA
+      _ ≤ K ^ 3 * #A := aux₂₃
+  · calc
+      _ = (#(A * A⁻¹ * A) : ℝ) := by simp [*]
+      _ ≤ K ^ 3 * #A := small_pos_neg_pos hA
+  · calc
+      _ = (#(A * A⁻¹ ^ 2) : ℝ) := by simp [*, sq, mul_assoc]
+      _ ≤ K ^ 2 * #A := small_pos_neg_neg hA
+      _ ≤ K ^ 3 * #A := aux₂₃
+  · calc
+      _ = (#(A⁻¹ * A ^ 2) : ℝ) := by simp [*, sq, mul_assoc]
+      _ ≤ K ^ 2 * #A := small_neg_pos_pos hA
+      _ ≤ K ^ 3 * #A := aux₂₃
+  · calc
+      _ = (#(A⁻¹ * A * A⁻¹) : ℝ) := by simp [*]
+      _ ≤ K ^ 3 * #A := small_neg_pos_neg hA
+  · calc
+      _ = (#(A⁻¹ ^ 2 * A) : ℝ) := by simp [*, sq]
+      _ ≤ K ^ 2 * #A := small_neg_neg_pos hA
+      _ ≤ K ^ 3 * #A := aux₂₃
+  · calc
+      _ = (#(A ^ 3) : ℝ) := by simp [*, pow_succ', ← mul_inv_rev]
+      _ ≤ K * #A := hA
+      _ ≤ K ^ 3 * #A := aux₁₃
+
+/-- If `A` is symmetric (`A⁻¹ = A`) and has small tripling, then `A` has small powers,
+in the sense that `|A ^ m|` is at most `|A|` times a constant exponential in `m`.
+
+See also `Finset.small_alternating_pow_of_small_tripling` for a version with a weaker constant but
+which encompasses non-symmetric sets. -/
+lemma small_pow_of_small_tripling (hm : 3 ≤ m) (hA : #(A ^ 3) ≤ K * #A) (hAsymm : A⁻¹ = A) :
+    #(A ^ m) ≤ K ^ (m - 2) * #A := by
+  have (ε : ℤ) (hε : |ε| = 1) : A ^ ε = A := by
+    obtain rfl | rfl := eq_or_eq_neg_of_abs_eq hε <;> simp [hAsymm]
+  calc
+    (#(A ^ m) : ℝ) = #((finRange m).map fun i ↦ A ^ 1).prod := by simp
+    _ ≤ K ^ (m - 2) * #A :=
+      inductive_claim hm (fun δ hδ ↦ by simpa [this _ (hδ _), pow_succ'] using hA) _
+        (by simp)
+
+end Finset

--- a/Mathlib/Combinatorics/Additive/SmallTripling.lean
+++ b/Mathlib/Combinatorics/Additive/SmallTripling.lean
@@ -14,11 +14,7 @@ import Mathlib.Tactic.Ring
 /-!
 # Small tripling implies small powers
 
-This file shows that a set with small tripling has small powers.
-
-## TODO
-
-Generalise to non-commutative group. This involves generalising Plünnecke-Ruzsa first.
+This file shows that a set with small tripling has small powers, even in non-abelian groups.
 -/
 
 open Fin
@@ -26,11 +22,7 @@ open List hiding tail
 open scoped Pointwise
 
 namespace Finset
-variable {G : Type*} [DecidableEq G] [CommGroup G] {A : Finset G} {k K : ℝ} {m : ℕ}
-
-private lemma pluennecke_ruzsa (U V W : Finset G) : #U * #(V⁻¹ * W) ≤ #(U * V) * #(U * W) := by
-  rw [mul_comm, inv_mul_eq_div, mul_comm _ W, mul_comm #(U * V)]
-  exact ruzsa_triangle_inequality_div_mul_mul ..
+variable {G : Type*} [DecidableEq G] [Group G] {A : Finset G} {k K : ℝ} {m : ℕ}
 
 private lemma inductive_claim (hm : 3 ≤ m)
     (h : ∀ ε : Fin 3 → ℤ, (∀ i, |ε i| = 1) → #((finRange 3).map fun i ↦ A ^ ε i).prod ≤ k * #A)
@@ -54,7 +46,7 @@ private lemma inductive_claim (hm : 3 ≤ m)
     (#A * #(π ε) : ℝ)
       = #A * #(V⁻¹ * W) := by
       simp [π, V, W, List.finRange_succ_eq_map, Fin.tail, Function.comp_def, mul_assoc]
-    _ ≤ #(A * V) * #(A * W) := by norm_cast; exact pluennecke_ruzsa ..
+    _ ≤ #(A * V) * #(A * W) := by norm_cast; exact ruzsa_triangle_inequality_invMul_mul_mul ..
     _ = #(π ![1, -ε 1, -ε 0]) * #(π <| Fin.cons 1 <| tail <| tail ε) := by
       simp [π, V, W, List.finRange_succ_eq_map, Fin.tail, Function.comp_def]
     _ ≤ (k * #A) * (k ^ (m - 1) * #A) := by
@@ -70,7 +62,7 @@ private lemma small_neg_pos_pos (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A ^ 2) �
   refine le_of_mul_le_mul_left ?_ (by positivity : (0 : ℝ) < #A)
   calc
     (#A * #(A⁻¹ * A ^ 2) : ℝ) ≤ #(A * A) * #(A * A ^ 2) := by
-      norm_cast; exact pluennecke_ruzsa A A (A ^ 2)
+      norm_cast; exact ruzsa_triangle_inequality_invMul_mul_mul A A (A ^ 2)
     _ = #(A ^ 2) * #(A ^ 3) := by simp [pow_succ']
     _ ≤ (K * #A) * (K * #A) := by
       gcongr
@@ -91,7 +83,7 @@ private lemma small_pos_neg_neg (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ ^ 2) �
   calc
     (#A * #(A * A⁻¹ ^ 2) : ℝ) ≤ #(A * A) * #(A ^ 2 * A) := by
       norm_cast
-      have := pluennecke_ruzsa A⁻¹ A⁻¹ (A⁻¹ ^ 2)
+      have := ruzsa_triangle_inequality_invMul_mul_mul A⁻¹ A⁻¹ (A⁻¹ ^ 2)
       simpa only [card_inv, inv_inv, inv_pow, ← mul_inv_rev] using this
     _ = #(A ^ 2) * #(A ^ 3) := by simp [pow_succ]
     _ ≤ (K * #A) * (K * #A) := by
@@ -112,7 +104,7 @@ private lemma small_pos_neg_pos (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ * A) �
   refine le_of_mul_le_mul_left ?_ (by positivity : (0 : ℝ) < #A)
   calc
     (#A * #(A * A⁻¹ * A) : ℝ) ≤ #(A * (A * A⁻¹)) * #(A * A) := by
-      norm_cast; simpa using pluennecke_ruzsa A (A * A⁻¹) A
+      norm_cast; simpa using ruzsa_triangle_inequality_invMul_mul_mul (A * A⁻¹) A A
     _ = #(A ^ 2 * A⁻¹) * #(A ^ 2) := by simp [pow_succ, mul_assoc]
     _ ≤ (K ^ 2 * #A) * (K * #A) := by
       gcongr


### PR DESCRIPTION
From GrowthInGroups


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #18145

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
