### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Comma): subcategory defined by morphism properties

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1804,6 +1804,7 @@ import Mathlib.CategoryTheory.Monoidal.Types.Basic
 import Mathlib.CategoryTheory.Monoidal.Types.Coyoneda
 import Mathlib.CategoryTheory.Monoidal.Types.Symmetric
 import Mathlib.CategoryTheory.MorphismProperty.Basic
+import Mathlib.CategoryTheory.MorphismProperty.Comma
 import Mathlib.CategoryTheory.MorphismProperty.Composition
 import Mathlib.CategoryTheory.MorphismProperty.Concrete
 import Mathlib.CategoryTheory.MorphismProperty.Factorization

--- a/Mathlib/CategoryTheory/Comma/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Basic.lean
@@ -165,6 +165,34 @@ theorem eqToHom_right (X Y : Comma L R) (H : X = Y) :
 
 section
 
+variable {X Y : Comma L R} (e : X ⟶ Y)
+
+instance [IsIso e] : IsIso e.left :=
+  (Comma.fst L R).map_isIso e
+
+instance [IsIso e] : IsIso e.right :=
+  (Comma.snd L R).map_isIso e
+
+@[simp]
+lemma inv_left [IsIso e] : (inv e).left = inv e.left := by
+  apply IsIso.eq_inv_of_hom_inv_id
+  rw [← Comma.comp_left, IsIso.hom_inv_id, id_left]
+
+@[simp]
+lemma inv_right [IsIso e] : (inv e).right = inv e.right := by
+  apply IsIso.eq_inv_of_hom_inv_id
+  rw [← Comma.comp_right, IsIso.hom_inv_id, id_right]
+
+lemma left_hom_inv_right [IsIso e] : L.map (e.left) ≫ Y.hom ≫ R.map (inv e.right) = X.hom := by
+  simp
+
+lemma inv_left_hom_right [IsIso e] : L.map (inv e.left) ≫ X.hom ≫ R.map e.right = Y.hom := by
+  simp
+
+end
+
+section
+
 variable {L₁ L₂ L₃ : A ⥤ T} {R₁ R₂ R₃ : B ⥤ T}
 
 /-- Extract the isomorphism between the left objects from an isomorphism in the comma category. -/

--- a/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.CategoryTheory.Comma.Over
+import Mathlib.CategoryTheory.MorphismProperty.Composition
+
+/-!
+# Subcategories of comma categories defined by morphism properties
+
+Given functors `L : A ⥤ T` and `R : B ⥤ T` and morphism properties `P`, `Q` and `W`
+on `T`, A` and `B` respectively, we define the subcategory `P.Comma L R Q W` of
+`Comma L R` where
+
+- objects are objects of `Comma L R` with the structural morphism satisfying `P`, and
+- morphisms are morphisms of `Comma L R` where the left morphism satisfies `Q` and the
+  right morphism satisfies `W`.
+
+For an object `X : T`, this specializes to `P.Over Q X` which is the subcategory of `Over X`
+where the structural morphism satisfies `P` and where the horizontal morphisms satisfy `Q`.
+Common examples of the latter are e.g. the category of schemes étale (finite, affine, etc.)
+over a base `X`. Here `Q = ⊤`.
+
+## Implementation details
+
+- We provide the general constructor `P.Comma L R Q W` to obtain `Over X` and `Under X` as
+  special cases of the more general setup.
+
+- Most results are developed only in the case where `Q = ⊤` and `W = ⊤`, but the definition
+  is setup in the general case to allow for a later generalization if needed.
+
+-/
+
+namespace CategoryTheory.MorphismProperty
+
+open Limits
+
+section Comma
+
+variable {A : Type*} [Category A] {B : Type*} [Category B] {T : Type*} [Category T]
+  (L : A ⥤ T) (R : B ⥤ T)
+
+variable (P : MorphismProperty T) (Q : MorphismProperty A) (W : MorphismProperty B)
+
+/-- `P.Comma L R Q W` is the subcategory of `Comma L R` consisting of
+objects `X : Comma L R` where `X.hom` satisfies `P`. The morphisms are given by
+morphisms in `Comma L R` where the left one satisfies `Q` and the right one satisfies `W`. -/
+@[ext]
+protected structure Comma (Q : MorphismProperty A) (W : MorphismProperty B) extends Comma L R where
+  prop : P toComma.hom
+
+namespace Comma
+
+variable {L R P Q W}
+
+/-- A morphism in `P.Comma L R Q W` is a morphism in `Comma L R` where the left
+hom satisfies `Q` and the right one satisfies `W`. -/
+@[ext]
+structure Hom (X Y : P.Comma L R Q W) extends CommaMorphism X.toComma Y.toComma where
+  prop_hom_left : Q toCommaMorphism.left
+  prop_hom_right : W toCommaMorphism.right
+
+/-- The underlying morphism of objects in `Comma L R`. -/
+abbrev Hom.hom {X Y : P.Comma L R Q W} (f : Comma.Hom X Y) : X.toComma ⟶ Y.toComma :=
+  f.toCommaMorphism
+
+@[simp, nolint simpVarHead]
+lemma Hom.hom_mk {X Y : P.Comma L R Q W}
+    (f : CommaMorphism X.toComma Y.toComma) (hf) (hg) :
+  Comma.Hom.hom ⟨f, hf, hg⟩ = f := rfl
+
+/-- See Note [custom simps projection] -/
+def Hom.Simps.hom {X Y : P.Comma L R Q W} (f : X.Hom Y) :
+    X.toComma ⟶ Y.toComma :=
+  f.hom
+
+initialize_simps_projections Comma.Hom (toCommaMorphism → hom)
+
+variable [ContainsIdentities Q] [ContainsIdentities W]
+
+/-- The identity morphism of an object in `P.Comma L R Q W`. -/
+@[simps]
+def id (X : P.Comma L R Q W) : Comma.Hom X X where
+  left := 𝟙 X.left
+  prop_hom_left := Q.id_mem X.toComma.left
+  prop_hom_right := W.id_mem X.toComma.right
+
+variable [Q.IsStableUnderComposition] [W.IsStableUnderComposition]
+
+/-- Composition of morphisms in `P.Comma L R Q W`. -/
+@[simps]
+def Hom.comp {X Y Z : P.Comma L R Q W} (f : Comma.Hom X Y) (g : Comma.Hom Y Z) :
+    Comma.Hom X Z where
+  left := f.left ≫ g.left
+  right := f.right ≫ g.right
+  prop_hom_left := Q.comp_mem _ _ f.prop_hom_left g.prop_hom_left
+  prop_hom_right := W.comp_mem _ _ f.prop_hom_right g.prop_hom_right
+
+variable (L R P Q W) in
+instance : Category (P.Comma L R Q W) where
+  Hom X Y := X.Hom Y
+  id X := X.id
+  comp f g := f.comp g
+
+/-- Alternative `ext` lemma for `Comma.Hom`. -/
+@[ext]
+lemma Hom.ext' {X Y : P.Comma L R Q W} {f g : X ⟶ Y} (h : f.hom = g.hom) :
+    f = g := Comma.Hom.ext
+  (congrArg CommaMorphism.left h)
+  (congrArg CommaMorphism.right h)
+
+@[simp]
+lemma id_hom (X : P.Comma L R Q W) : (𝟙 X : X ⟶ X).hom = 𝟙 X.toComma := rfl
+
+@[simp]
+lemma comp_hom {X Y Z : P.Comma L R Q W} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    (f ≫ g).hom = f.hom ≫ g.hom := rfl
+
+/-- If `i` is an isomorphism in `Comma L R`, it is also a morphism in `P.Comma L R Q W`. -/
+@[simps hom]
+def homFromCommaOfIsIso [Q.RespectsIso] [W.RespectsIso] {X Y : P.Comma L R Q W}
+    (i : X.toComma ⟶ Y.toComma) [IsIso i] :
+    X ⟶ Y where
+  __ := i
+  prop_hom_left := Q.of_isIso i.left
+  prop_hom_right := W.of_isIso i.right
+
+instance [Q.RespectsIso] [W.RespectsIso] {X Y : P.Comma L R Q W} (i : X.toComma ⟶ Y.toComma)
+    [IsIso i] : IsIso (homFromCommaOfIsIso i) := by
+  constructor
+  use homFromCommaOfIsIso (inv i)
+  constructor <;> ext : 1 <;> simp
+
+/-- Any isomorphism between objects of `P.Comma L R Q W` in `Comma L R` is also an isomorphism
+in `P.Comma L R Q W`.  -/
+@[simps]
+def isoFromComma [Q.RespectsIso] [W.RespectsIso] {X Y : P.Comma L R Q W}
+    (i : X.toComma ≅ Y.toComma) : X ≅ Y where
+  hom := homFromCommaOfIsIso i.hom
+  inv := homFromCommaOfIsIso i.inv
+
+/-- Constructor for isomorphisms in `P.Comma L R Q W` from isomorphisms of the left and right
+components and naturality in the forward direction. -/
+@[simps!]
+def isoMk [Q.RespectsIso] [W.RespectsIso] {X Y : P.Comma L R Q W} (l : X.left ≅ Y.left)
+    (r : X.right ≅ Y.right) (h : L.map l.hom ≫ Y.hom = X.hom ≫ R.map r.hom := by aesop_cat) :
+    X ≅ Y :=
+  isoFromComma (CategoryTheory.Comma.isoMk l r h)
+
+variable (L R P Q W)
+
+/-- The forgetful functor. -/
+@[simps]
+def forget : P.Comma L R Q W ⥤ Comma L R where
+  obj X := X.toComma
+  map f := f.hom
+
+instance : (forget L R P Q W).Faithful where
+  map_injective := Comma.Hom.ext'
+
+variable {L R P Q W}
+
+instance {X Y : P.Comma L R Q W} (f : X ⟶ Y) [IsIso f] : IsIso f.hom :=
+  (forget L R P Q W).map_isIso f
+
+lemma hom_homFromCommaOfIsIso [Q.RespectsIso] [W.RespectsIso] {X Y : P.Comma L R Q W}
+    (i : X ⟶ Y) [IsIso i.hom] :
+    homFromCommaOfIsIso i.hom = i :=
+  rfl
+
+lemma inv_hom {X Y : P.Comma L R Q W} (f : X ⟶ Y) [IsIso f] : (inv f).hom = inv f.hom := by
+  apply IsIso.eq_inv_of_hom_inv_id
+  rw [← comp_hom, IsIso.hom_inv_id, id_hom]
+
+variable (L R P Q W)
+
+instance [Q.RespectsIso] [W.RespectsIso] : (forget L R P Q W).ReflectsIsomorphisms where
+  reflects f hf := by
+    simp only [forget_obj, forget_map] at hf
+    rw [← hom_homFromCommaOfIsIso f]
+    infer_instance
+
+/-- The forgetful functor from the full subcategory of `Comma L R` defined by `P` is
+fully faithful. -/
+def forgetFullyFaithful : (forget L R P ⊤ ⊤).FullyFaithful where
+  preimage {X Y} f := ⟨f, trivial, trivial⟩
+
+instance : (forget L R P ⊤ ⊤).Full :=
+  Functor.FullyFaithful.full (forgetFullyFaithful L R P)
+
+end Comma
+
+end Comma
+
+section Over
+
+variable {T : Type*} [Category T]
+
+/-- Given a morphism property `P` on a category `C` and an object `X : C`, this is the
+subcategory of `Over X` defined by `P` where morphisms satisfy `Q`. -/
+protected abbrev Over (P Q : MorphismProperty T) (X : T) : Type _ :=
+  P.Comma (Functor.id T) (Functor.fromPUnit X) Q ⊤
+
+variable (P Q : MorphismProperty T) [Q.IsMultiplicative] (X : T)
+
+/-- Construct a morphism in `P.Over Q X` from a morphism in `Over.X`. -/
+@[simps hom]
+def Over.Hom.mk {A B : P.Over Q X} (f : A.toComma ⟶ B.toComma) (hf : Q f.left) : A ⟶ B where
+  __ := f
+  prop_hom_left := hf
+  prop_hom_right := trivial
+
+/-- The forgetful functor from the full subcategory of `Over X` defined by `P` to `Over X`. -/
+protected abbrev Over.forget : P.Over Q X ⥤ Over X :=
+  Comma.forget (Functor.id T) (Functor.fromPUnit X) P Q ⊤
+
+end Over
+
+section Under
+
+variable {T : Type*} [Category T]
+
+/-- Given a morphism property `P` on a category `C` and an object `X : C`, this is the
+subcategory of `Under X` defined by `P` where morphisms satisfy `Q`. -/
+protected abbrev Under (P Q : MorphismProperty T) (X : T) : Type _ :=
+  P.Comma (Functor.fromPUnit X) (Functor.id T) ⊤ Q
+
+variable (P Q : MorphismProperty T) [Q.IsMultiplicative] (X : T)
+
+/-- Construct a morphism in `P.Under Q X` from a morphism in `Under.X`. -/
+@[simps hom]
+def Under.Hom.mk {A B : P.Under Q X} (f : A.toComma ⟶ B.toComma) (hf : Q f.right) : A ⟶ B where
+  __ := f
+  prop_hom_left := trivial
+  prop_hom_right := hf
+
+/-- The forgetful functor from the full subcategory of `Under X` defined by `P` to `Under X`. -/
+protected abbrev Under.forget : P.Under Q X ⥤ Under X :=
+  Comma.forget (Functor.fromPUnit X) (Functor.id T) P ⊤ Q
+
+end Under
+
+end CategoryTheory.MorphismProperty

--- a/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
@@ -77,25 +77,24 @@ def Hom.Simps.hom {X Y : P.Comma L R Q W} (f : X.Hom Y) :
 
 initialize_simps_projections Comma.Hom (toCommaMorphism → hom)
 
-variable [ContainsIdentities Q] [ContainsIdentities W]
-
 /-- The identity morphism of an object in `P.Comma L R Q W`. -/
 @[simps]
-def id (X : P.Comma L R Q W) : Comma.Hom X X where
+def id [Q.ContainsIdentities] [W.ContainsIdentities] (X : P.Comma L R Q W) : Comma.Hom X X where
   left := 𝟙 X.left
   prop_hom_left := Q.id_mem X.toComma.left
   prop_hom_right := W.id_mem X.toComma.right
 
-variable [Q.IsStableUnderComposition] [W.IsStableUnderComposition]
-
 /-- Composition of morphisms in `P.Comma L R Q W`. -/
 @[simps]
-def Hom.comp {X Y Z : P.Comma L R Q W} (f : Comma.Hom X Y) (g : Comma.Hom Y Z) :
+def Hom.comp [Q.IsStableUnderComposition] [W.IsStableUnderComposition] {X Y Z : P.Comma L R Q W}
+    (f : Comma.Hom X Y) (g : Comma.Hom Y Z) :
     Comma.Hom X Z where
   left := f.left ≫ g.left
   right := f.right ≫ g.right
   prop_hom_left := Q.comp_mem _ _ f.prop_hom_left g.prop_hom_left
   prop_hom_right := W.comp_mem _ _ f.prop_hom_right g.prop_hom_right
+
+variable [Q.IsMultiplicative] [W.IsMultiplicative]
 
 variable (L R P Q W) in
 instance : Category (P.Comma L R Q W) where

--- a/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
@@ -203,7 +203,7 @@ protected abbrev Over (P Q : MorphismProperty T) (X : T) : Type _ :=
 
 variable (P Q : MorphismProperty T) [Q.IsMultiplicative] (X : T)
 
-/-- Construct a morphism in `P.Over Q X` from a morphism in `Over.X`. -/
+/-- Construct a morphism in `P.Over Q X` from a morphism in `Over X`. -/
 @[simps hom]
 def Over.Hom.mk {A B : P.Over Q X} (f : A.toComma ⟶ B.toComma) (hf : Q f.left) : A ⟶ B where
   __ := f

--- a/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
@@ -163,6 +163,10 @@ lemma of_op (W : MorphismProperty C) [IsMultiplicative W.op] : IsMultiplicative 
 lemma of_unop (W : MorphismProperty Cᵒᵖ) [IsMultiplicative W.unop] : IsMultiplicative W :=
   (inferInstance : IsMultiplicative W.unop.op)
 
+instance : MorphismProperty.IsMultiplicative (⊤ : MorphismProperty C) where
+  comp_mem _ _ _ _ := trivial
+  id_mem _ := trivial
+
 instance : (isomorphisms C).IsMultiplicative where
   id_mem _ := isomorphisms.infer_property _
   comp_mem f g hf hg := by


### PR DESCRIPTION
Given functors `L : A ⥤ T` and `R : B ⥤ T` and morphism properties `P`, `Q` and `W`
on `T`, `A` and `B` respectively, we define the subcategory `P.Comma L R Q W` of
`Comma L R` where

- objects are objects of `Comma L R` with the structural morphism satisfying `P`, and
- morphisms are morphisms of `Comma L R` where the left morphism satisfies `Q` and the
  right morphism satisfies `W`.

For an object `X : T`, this specializes to `P.Over Q X` which is the subcategory of `Over X`
where the structural morphism satisfies `P` and where the horizontal morphisms satisfy `Q`.
Common examples of the latter are e.g. the category of schemes étale (finite, affine, etc.)
over a base `X`. Here `Q = ⊤`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
