### PR TITLE
[Merged by Bors] - refactor(SetTheory/Cardinal/Aleph): `aleph'` → `preAleph`

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Aleph.lean
+++ b/Mathlib/SetTheory/Cardinal/Aleph.lean
@@ -456,7 +456,7 @@ theorem aleph'_pos {o : Ordinal} (ho : 0 < o) : 0 < aleph' o := by
 
 @[deprecated preAleph_isNormal (since := "2024-10-22")]
 theorem aleph'_isNormal : IsNormal (ord ∘ aleph') :=
-  preAleph_isNormal 
+  preAleph_isNormal
 
 -- TODO: these lemmas should be stated in terms of the `ω` function and of an `IsInitial` predicate,
 -- neither of which currently exist.

--- a/Mathlib/SetTheory/Cardinal/Aleph.lean
+++ b/Mathlib/SetTheory/Cardinal/Aleph.lean
@@ -10,8 +10,8 @@ import Mathlib.SetTheory.Ordinal.Arithmetic
 /-!
 # Aleph and beth functions
 
-* The function `Cardinal.aleph'` gives the cardinals listed by their ordinal index.
-  `aleph' n = n`, `aleph' ω = ℵ₀`, `aleph' (ω + 1) = succ ℵ₀`, etc.
+* The function `Cardinal.preAleph` gives the cardinals listed by their ordinal index.
+  `preAleph n = n`, `preAleph ω = ℵ₀`, `preAleph (ω + 1) = succ ℵ₀`, etc.
   It is an order isomorphism between ordinals and cardinals.
 * The function `Cardinal.aleph` gives the infinite cardinals listed by their
   ordinal index. `aleph 0 = ℵ₀`, `aleph 1 = succ ℵ₀` is the first
@@ -100,11 +100,11 @@ end Ordinal
 
 namespace Cardinal
 
-/-- The `aleph'` function gives the cardinals listed by their ordinal index. `aleph' n = n`,
-`aleph' ω = ℵ₀`, `aleph' (ω + 1) = succ ℵ₀`, etc.
+/-- The "pre-aleph" function gives the cardinals listed by their ordinal index. `preAleph n = n`,
+`preAleph ω = ℵ₀`, `preAleph (ω + 1) = succ ℵ₀`, etc.
 
 For the more common aleph function skipping over finite cardinals, see `Cardinal.aleph`. -/
-def aleph' : Ordinal.{u} ≃o Cardinal.{u} := by
+def preAleph : Ordinal.{u} ≃o Cardinal.{u} := by
   let f := RelEmbedding.collapse Cardinal.ord.orderEmbedding.ltEmbedding.{u}
   refine (OrderIso.ofRelIsoLT <| RelIso.ofSurjective f ?_).symm
   apply f.eq_or_principal.resolve_right
@@ -120,159 +120,74 @@ def aleph' : Ordinal.{u} ≃o Cardinal.{u} := by
       (Cardinal.bddAbove_range.{u, u} fun a : α => invFun f (Ordinal.typein r a))
       (Ordinal.enum r ⟨_, h (succ s)⟩)
 
-/-- The `aleph'` index function, which gives the ordinal index of a cardinal.
-  (The `aleph'` part is because unlike `aleph` this counts also the
-  finite stages. So `alephIdx n = n`, `alephIdx ω = ω`,
-  `alephIdx ℵ₁ = ω + 1` and so on.)
-  In this definition, we register additionally that this function is an initial segment,
-  i.e., it is order preserving and its range is an initial segment of the ordinals.
-  For the basic function version, see `alephIdx`.
-  For an upgraded version stating that the range is everything, see `AlephIdx.rel_iso`. -/
-@[deprecated aleph' (since := "2024-08-28")]
-def alephIdx.initialSeg : @InitialSeg Cardinal Ordinal (· < ·) (· < ·) :=
-  @RelEmbedding.collapse Cardinal Ordinal (· < ·) (· < ·) _ Cardinal.ord.orderEmbedding.ltEmbedding
-
-/-- The `aleph'` index function, which gives the ordinal index of a cardinal.
-  (The `aleph'` part is because unlike `aleph` this counts also the
-  finite stages. So `alephIdx n = n`, `alephIdx ℵ₀ = ω`,
-  `alephIdx ℵ₁ = ω + 1` and so on.)
-  In this version, we register additionally that this function is an order isomorphism
-  between cardinals and ordinals.
-  For the basic function version, see `alephIdx`. -/
-@[deprecated aleph' (since := "2024-08-28")]
-def alephIdx.relIso : @RelIso Cardinal.{u} Ordinal.{u} (· < ·) (· < ·) :=
-  aleph'.symm.toRelIsoLT
-
-/-- The `aleph'` index function, which gives the ordinal index of a cardinal.
-  (The `aleph'` part is because unlike `aleph` this counts also the
-  finite stages. So `alephIdx n = n`, `alephIdx ω = ω`,
-  `alephIdx ℵ₁ = ω + 1` and so on.)
-  For an upgraded version stating that the range is everything, see `AlephIdx.rel_iso`. -/
-@[deprecated aleph' (since := "2024-08-28")]
-def alephIdx : Cardinal → Ordinal :=
-  aleph'.symm
-
-set_option linter.deprecated false in
-@[deprecated (since := "2024-08-28")]
-theorem alephIdx.initialSeg_coe : (alephIdx.initialSeg : Cardinal → Ordinal) = alephIdx :=
-  rfl
-
-set_option linter.deprecated false in
-@[deprecated (since := "2024-08-28")]
-theorem alephIdx_lt {a b} : alephIdx a < alephIdx b ↔ a < b :=
-  alephIdx.initialSeg.toRelEmbedding.map_rel_iff
-
-set_option linter.deprecated false in
-@[deprecated (since := "2024-08-28")]
-theorem alephIdx_le {a b} : alephIdx a ≤ alephIdx b ↔ a ≤ b := by
-  rw [← not_lt, ← not_lt, alephIdx_lt]
-
-set_option linter.deprecated false in
-@[deprecated (since := "2024-08-28")]
-theorem alephIdx.init {a b} : b < alephIdx a → ∃ c, alephIdx c = b :=
-  alephIdx.initialSeg.init
-
-set_option linter.deprecated false in
-@[deprecated (since := "2024-08-28")]
-theorem alephIdx.relIso_coe : (alephIdx.relIso : Cardinal → Ordinal) = alephIdx :=
-  rfl
-
 @[simp]
 theorem type_cardinal : @type Cardinal (· < ·) _ = Ordinal.univ.{u, u + 1} := by
   rw [Ordinal.univ_id]
-  exact Quotient.sound ⟨aleph'.symm.toRelIsoLT⟩
+  exact Quotient.sound ⟨preAleph.symm.toRelIsoLT⟩
 
 @[simp]
 theorem mk_cardinal : #Cardinal = univ.{u, u + 1} := by
   simpa only [card_type, card_univ] using congr_arg card type_cardinal
 
-/-- The `aleph'` function gives the cardinals listed by their ordinal
-  index, and is the inverse of `aleph_idx`.
-  `aleph' n = n`, `aleph' ω = ω`, `aleph' (ω + 1) = succ ℵ₀`, etc.
-  In this version, we register additionally that this function is an order isomorphism
-  between ordinals and cardinals.
-  For the basic function version, see `aleph'`. -/
-@[deprecated aleph' (since := "2024-08-28")]
-def Aleph'.relIso :=
-  aleph'
+theorem preAleph_lt_preAleph {o₁ o₂ : Ordinal} : preAleph o₁ < preAleph o₂ ↔ o₁ < o₂ :=
+  preAleph.lt_iff_lt
 
-set_option linter.deprecated false in
-@[deprecated (since := "2024-08-28")]
-theorem aleph'.relIso_coe : (Aleph'.relIso : Ordinal → Cardinal) = aleph' :=
-  rfl
+theorem preAleph_le_preAleph {o₁ o₂ : Ordinal} : preAleph o₁ ≤ preAleph o₂ ↔ o₁ ≤ o₂ :=
+  preAleph.le_iff_le
 
-theorem aleph'_lt {o₁ o₂ : Ordinal} : aleph' o₁ < aleph' o₂ ↔ o₁ < o₂ :=
-  aleph'.lt_iff_lt
-
-theorem aleph'_le {o₁ o₂ : Ordinal} : aleph' o₁ ≤ aleph' o₂ ↔ o₁ ≤ o₂ :=
-  aleph'.le_iff_le
-
-theorem aleph'_max (o₁ o₂ : Ordinal) : aleph' (max o₁ o₂) = max (aleph' o₁) (aleph' o₂) :=
-  aleph'.monotone.map_max
-
-set_option linter.deprecated false in
-@[deprecated (since := "2024-08-28")]
-theorem aleph'_alephIdx (c : Cardinal) : aleph' c.alephIdx = c :=
-  Cardinal.alephIdx.relIso.toEquiv.symm_apply_apply c
-
-set_option linter.deprecated false in
-@[deprecated (since := "2024-08-28")]
-theorem alephIdx_aleph' (o : Ordinal) : (aleph' o).alephIdx = o :=
-  Cardinal.alephIdx.relIso.toEquiv.apply_symm_apply o
+theorem preAleph_max (o₁ o₂ : Ordinal) : preAleph (max o₁ o₂) = max (preAleph o₁) (preAleph o₂) :=
+  preAleph.monotone.map_max
 
 @[simp]
-theorem aleph'_zero : aleph' 0 = 0 :=
-  aleph'.map_bot
+theorem preAleph_zero : preAleph 0 = 0 :=
+  preAleph.map_bot
 
 @[simp]
-theorem aleph'_succ (o : Ordinal) : aleph' (succ o) = succ (aleph' o) :=
-  aleph'.map_succ o
+theorem preAleph_succ (o : Ordinal) : preAleph (succ o) = succ (preAleph o) :=
+  preAleph.map_succ o
 
 @[simp]
-theorem aleph'_nat : ∀ n : ℕ, aleph' n = n
-  | 0 => aleph'_zero
-  | n + 1 => show aleph' (succ n) = n.succ by rw [aleph'_succ, aleph'_nat n, nat_succ]
+theorem preAleph_nat : ∀ n : ℕ, preAleph n = n
+  | 0 => preAleph_zero
+  | n + 1 => show preAleph (succ n) = n.succ by rw [preAleph_succ, preAleph_nat n, nat_succ]
 
-set_option linter.docPrime false in
+theorem preAleph_pos {o : Ordinal} : 0 < preAleph o ↔ 0 < o := by
+  rw [← preAleph_zero, preAleph_lt_preAleph]
+
 @[simp]
-theorem lift_aleph' (o : Ordinal.{u}) : lift.{v} (aleph' o) = aleph' (Ordinal.lift.{v} o) :=
-  ((InitialSeg.ofIso aleph'.toRelIsoLT).trans liftInitialSeg).eq
-    (Ordinal.liftInitialSeg.trans (InitialSeg.ofIso aleph'.toRelIsoLT)) o
+theorem lift_preAleph (o : Ordinal.{u}) : lift.{v} (preAleph o) = preAleph (Ordinal.lift.{v} o) :=
+  ((InitialSeg.ofIso preAleph.toRelIsoLT).trans liftInitialSeg).eq
+    (Ordinal.liftInitialSeg.trans (InitialSeg.ofIso preAleph.toRelIsoLT)) o
 
-theorem aleph'_le_of_limit {o : Ordinal} (l : o.IsLimit) {c} :
-    aleph' o ≤ c ↔ ∀ o' < o, aleph' o' ≤ c :=
-  ⟨fun h o' h' => (aleph'_le.2 <| h'.le).trans h, fun h => by
-    rw [← aleph'.apply_symm_apply c, aleph'_le, limit_le l]
+theorem preAleph_le_of_isLimit {o : Ordinal} (l : o.IsLimit) {c} :
+    preAleph o ≤ c ↔ ∀ o' < o, preAleph o' ≤ c :=
+  ⟨fun h o' h' => (preAleph_le_preAleph.2 <| h'.le).trans h, fun h => by
+    rw [← preAleph.apply_symm_apply c, preAleph_le_preAleph, limit_le l]
     intro x h'
-    rw [← aleph'_le, aleph'.apply_symm_apply]
+    rw [← preAleph_le_preAleph, preAleph.apply_symm_apply]
     exact h _ h'⟩
 
-theorem aleph'_limit {o : Ordinal} (ho : o.IsLimit) : aleph' o = ⨆ a : Iio o, aleph' a := by
-  refine le_antisymm ?_ (ciSup_le' fun i => aleph'_le.2 (le_of_lt i.2))
-  rw [aleph'_le_of_limit ho]
+theorem preAleph_limit {o : Ordinal} (ho : o.IsLimit) : preAleph o = ⨆ a : Iio o, preAleph a := by
+  refine le_antisymm ?_ (ciSup_le' fun i => preAleph_le_preAleph.2 i.2.le)
+  rw [preAleph_le_of_isLimit ho]
   exact fun a ha => le_ciSup (bddAbove_of_small _) (⟨a, ha⟩ : Iio o)
 
 @[simp]
-theorem aleph'_omega0 : aleph' ω = ℵ₀ :=
+theorem preAleph_omega0 : preAleph ω = ℵ₀ :=
   eq_of_forall_ge_iff fun c => by
-    simp only [aleph'_le_of_limit isLimit_omega0, lt_omega0, exists_imp, aleph0_le]
-    exact forall_swap.trans (forall_congr' fun n => by simp only [forall_eq, aleph'_nat])
+    simp only [preAleph_le_of_isLimit isLimit_omega0, lt_omega0, exists_imp, aleph0_le]
+    exact forall_swap.trans (forall_congr' fun n => by simp only [forall_eq, preAleph_nat])
 
-@[deprecated (since := "2024-09-30")]
-alias aleph'_omega := aleph'_omega0
-
-set_option linter.deprecated false in
-/-- `aleph'` and `aleph_idx` form an equivalence between `Ordinal` and `Cardinal` -/
-@[deprecated aleph' (since := "2024-08-28")]
-def aleph'Equiv : Ordinal ≃ Cardinal :=
-  ⟨aleph', alephIdx, alephIdx_aleph', aleph'_alephIdx⟩
+@[simp]
+theorem aleph0_le_preAleph {o : Ordinal} : ℵ₀ ≤ preAleph o ↔ ω ≤ o := by
+  rw [← preAleph_omega0, preAleph_le_preAleph]
 
 /-- The `aleph` function gives the infinite cardinals listed by their ordinal index. `aleph 0 = ℵ₀`,
 `aleph 1 = succ ℵ₀` is the first uncountable cardinal, and so on.
 
 For a version including finite cardinals, see `Cardinal.aleph'`. -/
 def aleph : Ordinal ↪o Cardinal :=
-  (OrderEmbedding.addLeft ω).trans aleph'.toOrderEmbedding
+  (OrderEmbedding.addLeft ω).trans preAleph.toOrderEmbedding
 
 @[inherit_doc]
 scoped notation "ℵ_ " => aleph
@@ -280,14 +195,20 @@ scoped notation "ℵ_ " => aleph
 /-- `ℵ₁` is the first uncountable ordinal. -/
 scoped notation "ℵ₁" => ℵ_ 1
 
-theorem aleph_eq_aleph' (o : Ordinal) : ℵ_ o = aleph' (ω + o) :=
+theorem aleph_eq_preAleph (o : Ordinal) : ℵ_ o = preAleph (ω + o) :=
   rfl
 
-theorem aleph_lt {o₁ o₂ : Ordinal} : ℵ_ o₁ < ℵ_ o₂ ↔ o₁ < o₂ :=
+theorem aleph_lt_aleph {o₁ o₂ : Ordinal} : ℵ_ o₁ < ℵ_ o₂ ↔ o₁ < o₂ :=
   aleph.lt_iff_lt
 
-theorem aleph_le {o₁ o₂ : Ordinal} : ℵ_ o₁ ≤ ℵ_ o₂ ↔ o₁ ≤ o₂ :=
+@[deprecated aleph_lt_aleph (since := "2024-10-22")]
+alias aleph_lt := aleph_lt_aleph
+
+theorem aleph_le_aleph {o₁ o₂ : Ordinal} : ℵ_ o₁ ≤ ℵ_ o₂ ↔ o₁ ≤ o₂ :=
   aleph.le_iff_le
+
+@[deprecated aleph_le_aleph (since := "2024-10-22")]
+alias aleph_le := aleph_le_aleph
 
 theorem aleph_max (o₁ o₂ : Ordinal) : ℵ_ (max o₁ o₂) = max (ℵ_ o₁) (ℵ_ o₂) :=
   aleph.monotone.map_max
@@ -298,34 +219,30 @@ theorem max_aleph_eq (o₁ o₂ : Ordinal) : max (ℵ_ o₁) (ℵ_ o₂) = ℵ_ 
 
 @[simp]
 theorem aleph_succ (o : Ordinal) : ℵ_ (succ o) = succ (ℵ_ o) := by
-  rw [aleph_eq_aleph', add_succ, aleph'_succ, aleph_eq_aleph']
+  rw [aleph_eq_preAleph, add_succ, preAleph_succ, aleph_eq_preAleph]
 
 @[simp]
-theorem aleph_zero : ℵ_ 0 = ℵ₀ := by rw [aleph_eq_aleph', add_zero, aleph'_omega0]
+theorem aleph_zero : ℵ_ 0 = ℵ₀ := by rw [aleph_eq_preAleph, add_zero, preAleph_omega0]
 
 @[simp]
 theorem lift_aleph (o : Ordinal.{u}) : lift.{v} (aleph o) = aleph (Ordinal.lift.{v} o) := by
-  simp [aleph_eq_aleph']
+  simp [aleph_eq_preAleph]
 
 theorem aleph_limit {o : Ordinal} (ho : o.IsLimit) : ℵ_ o = ⨆ a : Iio o, ℵ_ a := by
   apply le_antisymm _ (ciSup_le' _)
-  · rw [aleph_eq_aleph', aleph'_limit (ho.add _)]
+  · rw [aleph_eq_preAleph, preAleph_limit (ho.add _)]
     refine ciSup_mono' (bddAbove_of_small _) ?_
     rintro ⟨i, hi⟩
     cases' lt_or_le i ω with h h
     · rcases lt_omega0.1 h with ⟨n, rfl⟩
       use ⟨0, ho.pos⟩
       simpa using (nat_lt_aleph0 n).le
-    · exact ⟨⟨_, (sub_lt_of_le h).2 hi⟩, aleph'_le.2 (le_add_sub _ _)⟩
-  · exact fun i => aleph_le.2 (le_of_lt i.2)
-
-theorem aleph0_le_aleph' {o : Ordinal} : ℵ₀ ≤ aleph' o ↔ ω ≤ o := by rw [← aleph'_omega0, aleph'_le]
+    · exact ⟨⟨_, (sub_lt_of_le h).2 hi⟩, preAleph_le_preAleph.2 (le_add_sub _ _)⟩
+  · exact fun i => aleph_le_aleph.2 i.2.le
 
 theorem aleph0_le_aleph (o : Ordinal) : ℵ₀ ≤ ℵ_ o := by
-  rw [aleph_eq_aleph', aleph0_le_aleph']
+  rw [aleph_eq_preAleph, aleph0_le_preAleph]
   apply Ordinal.le_add_right
-
-theorem aleph'_pos {o : Ordinal} (ho : 0 < o) : 0 < aleph' o := by rwa [← aleph'_zero, aleph'_lt]
 
 theorem aleph_pos (o : Ordinal) : 0 < ℵ_ o :=
   aleph0_pos.trans_le (aleph0_le_aleph o)
@@ -350,17 +267,17 @@ instance (o : Ordinal) : NoMaxOrder (ℵ_ o).ord.toType :=
 
 theorem exists_aleph {c : Cardinal} : ℵ₀ ≤ c ↔ ∃ o, c = ℵ_ o :=
   ⟨fun h =>
-    ⟨aleph'.symm c - ω, by
-      rw [aleph_eq_aleph', Ordinal.add_sub_cancel_of_le, aleph'.apply_symm_apply]
-      rwa [← aleph0_le_aleph', aleph'.apply_symm_apply]⟩,
+    ⟨preAleph.symm c - ω, by
+      rw [aleph_eq_preAleph, Ordinal.add_sub_cancel_of_le, preAleph.apply_symm_apply]
+      rwa [← aleph0_le_preAleph, preAleph.apply_symm_apply]⟩,
     fun ⟨o, e⟩ => e.symm ▸ aleph0_le_aleph _⟩
 
-theorem aleph'_isNormal : IsNormal (ord ∘ aleph') :=
-  ⟨fun o => ord_lt_ord.2 <| aleph'_lt.2 <| lt_succ o, fun o l a => by
-    simp [ord_le, aleph'_le_of_limit l]⟩
+theorem preAleph_isNormal : IsNormal (ord ∘ preAleph) :=
+  ⟨fun o => ord_lt_ord.2 <| preAleph_lt_preAleph.2 <| lt_succ o, fun o l a => by
+    simp [ord_le, preAleph_le_of_isLimit l]⟩
 
 theorem aleph_isNormal : IsNormal (ord ∘ aleph) :=
-  aleph'_isNormal.trans <| isNormal_add_right ω
+  preAleph_isNormal.trans <| isNormal_add_right ω
 
 theorem succ_aleph0 : succ ℵ₀ = ℵ₁ := by rw [← aleph_zero, ← aleph_succ, Ordinal.succ_zero]
 
@@ -398,6 +315,148 @@ theorem lift_eq_aleph1 {c : Cardinal.{u}} : lift.{v} c = ℵ₁ ↔ c = ℵ₁ :
 section deprecated
 
 set_option linter.deprecated false
+set_option linter.docPrime false
+
+@[deprecated preAleph (since := "2024-10-22")]
+noncomputable alias aleph' := preAleph
+
+/-- The `aleph'` index function, which gives the ordinal index of a cardinal.
+  (The `aleph'` part is because unlike `aleph` this counts also the
+  finite stages. So `alephIdx n = n`, `alephIdx ω = ω`,
+  `alephIdx ℵ₁ = ω + 1` and so on.)
+  In this definition, we register additionally that this function is an initial segment,
+  i.e., it is order preserving and its range is an initial segment of the ordinals.
+  For the basic function version, see `alephIdx`.
+  For an upgraded version stating that the range is everything, see `AlephIdx.rel_iso`. -/
+@[deprecated preAleph (since := "2024-08-28")]
+def alephIdx.initialSeg : @InitialSeg Cardinal Ordinal (· < ·) (· < ·) :=
+  @RelEmbedding.collapse Cardinal Ordinal (· < ·) (· < ·) _ Cardinal.ord.orderEmbedding.ltEmbedding
+
+/-- The `aleph'` index function, which gives the ordinal index of a cardinal.
+  (The `aleph'` part is because unlike `aleph` this counts also the
+  finite stages. So `alephIdx n = n`, `alephIdx ℵ₀ = ω`,
+  `alephIdx ℵ₁ = ω + 1` and so on.)
+  In this version, we register additionally that this function is an order isomorphism
+  between cardinals and ordinals.
+  For the basic function version, see `alephIdx`. -/
+@[deprecated preAleph (since := "2024-08-28")]
+def alephIdx.relIso : @RelIso Cardinal.{u} Ordinal.{u} (· < ·) (· < ·) :=
+  aleph'.symm.toRelIsoLT
+
+/-- The `aleph'` index function, which gives the ordinal index of a cardinal.
+  (The `aleph'` part is because unlike `aleph` this counts also the
+  finite stages. So `alephIdx n = n`, `alephIdx ω = ω`,
+  `alephIdx ℵ₁ = ω + 1` and so on.)
+  For an upgraded version stating that the range is everything, see `AlephIdx.rel_iso`. -/
+@[deprecated aleph' (since := "2024-08-28")]
+def alephIdx : Cardinal → Ordinal :=
+  aleph'.symm
+
+@[deprecated (since := "2024-08-28")]
+theorem alephIdx.initialSeg_coe : (alephIdx.initialSeg : Cardinal → Ordinal) = alephIdx :=
+  rfl
+
+@[deprecated (since := "2024-08-28")]
+theorem alephIdx_lt {a b} : alephIdx a < alephIdx b ↔ a < b :=
+  alephIdx.initialSeg.toRelEmbedding.map_rel_iff
+
+@[deprecated (since := "2024-08-28")]
+theorem alephIdx_le {a b} : alephIdx a ≤ alephIdx b ↔ a ≤ b := by
+  rw [← not_lt, ← not_lt, alephIdx_lt]
+
+@[deprecated (since := "2024-08-28")]
+theorem alephIdx.init {a b} : b < alephIdx a → ∃ c, alephIdx c = b :=
+  alephIdx.initialSeg.init
+
+@[deprecated (since := "2024-08-28")]
+theorem alephIdx.relIso_coe : (alephIdx.relIso : Cardinal → Ordinal) = alephIdx :=
+  rfl
+
+/-- The `aleph'` function gives the cardinals listed by their ordinal
+  index, and is the inverse of `aleph_idx`.
+  `aleph' n = n`, `aleph' ω = ω`, `aleph' (ω + 1) = succ ℵ₀`, etc.
+  In this version, we register additionally that this function is an order isomorphism
+  between ordinals and cardinals.
+  For the basic function version, see `aleph'`. -/
+@[deprecated aleph' (since := "2024-08-28")]
+def Aleph'.relIso :=
+  aleph'
+
+@[deprecated (since := "2024-08-28")]
+theorem aleph'.relIso_coe : (Aleph'.relIso : Ordinal → Cardinal) = aleph' :=
+  rfl
+
+@[deprecated preAleph_lt_preAleph (since := "2024-10-22")]
+theorem aleph'_lt {o₁ o₂ : Ordinal} : aleph' o₁ < aleph' o₂ ↔ o₁ < o₂ :=
+  aleph'.lt_iff_lt
+
+@[deprecated preAleph_le_preAleph (since := "2024-10-22")]
+theorem aleph'_le {o₁ o₂ : Ordinal} : aleph' o₁ ≤ aleph' o₂ ↔ o₁ ≤ o₂ :=
+  aleph'.le_iff_le
+
+@[deprecated preAleph_max (since := "2024-10-22")]
+theorem aleph'_max (o₁ o₂ : Ordinal) : aleph' (max o₁ o₂) = max (aleph' o₁) (aleph' o₂) :=
+  aleph'.monotone.map_max
+
+@[deprecated (since := "2024-08-28")]
+theorem aleph'_alephIdx (c : Cardinal) : aleph' c.alephIdx = c :=
+  Cardinal.alephIdx.relIso.toEquiv.symm_apply_apply c
+
+@[deprecated (since := "2024-08-28")]
+theorem alephIdx_aleph' (o : Ordinal) : (aleph' o).alephIdx = o :=
+  Cardinal.alephIdx.relIso.toEquiv.apply_symm_apply o
+
+@[deprecated preAleph_zero (since := "2024-10-22")]
+theorem aleph'_zero : aleph' 0 = 0 :=
+  aleph'.map_bot
+
+@[deprecated preAleph_succ (since := "2024-10-22")]
+theorem aleph'_succ (o : Ordinal) : aleph' (succ o) = succ (aleph' o) :=
+  aleph'.map_succ o
+
+@[deprecated preAleph_nat (since := "2024-10-22")]
+theorem aleph'_nat : ∀ n : ℕ, aleph' n = n :=
+  preAleph_nat
+
+@[deprecated lift_preAleph (since := "2024-10-22")]
+theorem lift_aleph' (o : Ordinal.{u}) : lift.{v} (aleph' o) = aleph' (Ordinal.lift.{v} o) :=
+  lift_preAleph o
+
+@[deprecated preAleph_le_of_isLimit (since := "2024-10-22")]
+theorem aleph'_le_of_limit {o : Ordinal} (l : o.IsLimit) {c} :
+    aleph' o ≤ c ↔ ∀ o' < o, aleph' o' ≤ c :=
+  preAleph_le_of_isLimit l
+
+@[deprecated preAleph_limit (since := "2024-10-22")]
+theorem aleph'_limit {o : Ordinal} (ho : o.IsLimit) : aleph' o = ⨆ a : Iio o, aleph' a :=
+  preAleph_limit ho
+
+@[deprecated preAleph_omega0 (since := "2024-10-22")]
+theorem aleph'_omega0 : aleph' ω = ℵ₀ :=
+  preAleph_omega0
+
+@[deprecated (since := "2024-09-30")]
+alias aleph'_omega := aleph'_omega0
+
+/-- `aleph'` and `aleph_idx` form an equivalence between `Ordinal` and `Cardinal` -/
+@[deprecated aleph' (since := "2024-08-28")]
+def aleph'Equiv : Ordinal ≃ Cardinal :=
+  ⟨aleph', alephIdx, alephIdx_aleph', aleph'_alephIdx⟩
+
+theorem aleph_eq_aleph' (o : Ordinal) : ℵ_ o = preAleph (ω + o) :=
+  rfl
+
+@[deprecated aleph0_le_preAleph (since := "2024-10-22")]
+theorem aleph0_le_aleph' {o : Ordinal} : ℵ₀ ≤ aleph' o ↔ ω ≤ o := by
+  rw [← aleph'_omega0, aleph'_le]
+
+@[deprecated preAleph_pos (since := "2024-10-22")]
+theorem aleph'_pos {o : Ordinal} (ho : 0 < o) : 0 < aleph' o := by
+  rwa [← aleph'_zero, aleph'_lt]
+
+@[deprecated preAleph_isNormal (since := "2024-10-22")]
+theorem aleph'_isNormal : IsNormal (ord ∘ aleph') :=
+  preAleph_isNormal 
 
 -- TODO: these lemmas should be stated in terms of the `ω` function and of an `IsInitial` predicate,
 -- neither of which currently exist.

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -663,8 +663,8 @@ theorem aleph0_le_cof {o} : ℵ₀ ≤ cof o ↔ IsLimit o := by
 theorem preAleph_cof {o : Ordinal} (ho : o.IsLimit) : (preAleph o).ord.cof = o.cof :=
   preAleph_isNormal.cof_eq ho
 
-@[deprecated preAleph_cof (since := "2024-10-22")]
 set_option linter.deprecated false in
+@[deprecated preAleph_cof (since := "2024-10-22")]
 theorem aleph'_cof {o : Ordinal} (ho : o.IsLimit) : (aleph' o).ord.cof = o.cof :=
   aleph'_isNormal.cof_eq ho
 
@@ -933,8 +933,8 @@ theorem isRegular_preAleph_succ {o : Ordinal} (h : ω ≤ o) : IsRegular (preAle
   rw [preAleph_succ]
   exact isRegular_succ (aleph0_le_preAleph.2 h)
 
-@[deprecated isRegular_preAleph_succ (since := "2024-10-22")]
 set_option linter.deprecated false in
+@[deprecated isRegular_preAleph_succ (since := "2024-10-22")]
 theorem isRegular_aleph'_succ {o : Ordinal} (h : ω ≤ o) : IsRegular (aleph' (succ o)) := by
   rw [aleph'_succ]
   exact isRegular_succ (aleph0_le_aleph'.2 h)

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -660,6 +660,11 @@ theorem aleph0_le_cof {o} : ℵ₀ ≤ cof o ↔ IsLimit o := by
       exact not_succ_isLimit _ l
 
 @[simp]
+theorem preAleph_cof {o : Ordinal} (ho : o.IsLimit) : (preAleph o).ord.cof = o.cof :=
+  preAleph_isNormal.cof_eq ho
+
+@[deprecated preAleph_cof (since := "2024-10-22")]
+set_option linter.deprecated false in
 theorem aleph'_cof {o : Ordinal} (ho : o.IsLimit) : (aleph' o).ord.cof = o.cof :=
   aleph'_isNormal.cof_eq ho
 
@@ -924,6 +929,12 @@ theorem isRegular_aleph_one : IsRegular ℵ₁ := by
   rw [← succ_aleph0]
   exact isRegular_succ le_rfl
 
+theorem isRegular_preAleph_succ {o : Ordinal} (h : ω ≤ o) : IsRegular (preAleph (succ o)) := by
+  rw [preAleph_succ]
+  exact isRegular_succ (aleph0_le_preAleph.2 h)
+
+@[deprecated isRegular_preAleph_succ (since := "2024-10-22")]
+set_option linter.deprecated false in
 theorem isRegular_aleph'_succ {o : Ordinal} (h : ω ≤ o) : IsRegular (aleph' (succ o)) := by
   rw [aleph'_succ]
   exact isRegular_succ (aleph0_le_aleph'.2 h)


### PR DESCRIPTION
This helps us move away from primes in theorems and definitions.

Suggested by Floris van Doorn.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
