### PR TITLE
[Merged by Bors] - doc(CategoryTheory/Limits/Sifted): remove non-ASCII characters in bibliography key

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Sifted.lean
+++ b/Mathlib/CategoryTheory/Limits/Sifted.lean
@@ -17,7 +17,7 @@ preserves finite products.
 
 ## References
 - [nLab, *Sifted category*](https://ncatlab.org/nlab/show/sifted+category)
-- [*Algebraic Theories*, Chapter 2.][Adámek_Rosický_Vitale_2010]
+- [*Algebraic Theories*, Chapter 2.][Adamek_Rosicky_Vitale_2010]
 -/
 
 universe w v v₁ u u₁

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -21,6 +21,17 @@
   zbl           = {0829.68111}
 }
 
+@Book{            Adamek_Rosicky_Vitale_2010,
+  place         = {Cambridge},
+  series        = {Cambridge Tracts in Mathematics},
+  title         = {Algebraic Theories: A Categorical Introduction to General
+                  Algebra},
+  publisher     = {Cambridge University Press},
+  author        = {Adámek, J. and Rosický, J. and Vitale, E. M.},
+  year          = {2010},
+  collection    = {Cambridge Tracts in Mathematics}
+}
+
 @InProceedings{   adhesive2004,
   author        = {S. Lack and P. Soboci{\'n}ski},
   title         = {Adhesive categories},
@@ -32,17 +43,6 @@
   publisher     = {Springer},
   year          = {2004},
   url           = {https://www.ioc.ee/~pawel/papers/adhesive.pdf}
-}
-
-@Book{            Adámek_Rosický_Vitale_2010,
-  place         = {Cambridge},
-  series        = {Cambridge Tracts in Mathematics},
-  title         = {Algebraic Theories: A Categorical Introduction to General
-                  Algebra},
-  publisher     = {Cambridge University Press},
-  author        = {Adámek, J. and Rosický, J. and Vitale, E. M.},
-  year          = {2010},
-  collection    = {Cambridge Tracts in Mathematics}
 }
 
 @Article{         ahrens2017,


### PR DESCRIPTION
Currently doc-gen4 does not allow non-ASCII characters in bibkey.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
