### PR TITLE
[Merged by Bors] - chore(Order): delete "`simp` can prove this" porting notes

### DIFF
--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -1283,11 +1283,9 @@ theorem max_eq : max a b = unit :=
 theorem min_eq : min a b = unit :=
   rfl
 
--- Porting note (#10618): simp can prove this @[simp]
 protected theorem le : a ≤ b :=
   trivial
 
--- Porting note (#10618): simp can prove this @[simp]
 theorem not_lt : ¬a < b :=
   not_false
 

--- a/Mathlib/Order/Chain.lean
+++ b/Mathlib/Order/Chain.lean
@@ -279,8 +279,6 @@ instance : SetLike (Flag α) α where
 theorem ext : (s : Set α) = t → s = t :=
   SetLike.ext'
 
--- Porting note (#10618): `simp` can now prove this
--- @[simp]
 theorem mem_coe_iff : a ∈ (s : Set α) ↔ a ∈ s :=
   Iff.rfl
 

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -755,8 +755,6 @@ protected theorem injective (e : α ≃o β) : Function.Injective e :=
 protected theorem surjective (e : α ≃o β) : Function.Surjective e :=
   e.toEquiv.surjective
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem apply_eq_iff_eq (e : α ≃o β) {x y : α} : e x = e y ↔ x = y :=
   e.toEquiv.apply_eq_iff_eq
 
@@ -920,7 +918,6 @@ section LE
 
 variable [LE α] [LE β]
 
---@[simp] Porting note (#10618): simp can prove it
 theorem le_iff_le (e : α ≃o β) {x y : α} : e x ≤ e y ↔ x ≤ y :=
   e.map_rel_iff
 

--- a/Mathlib/Order/Ideal.lean
+++ b/Mathlib/Order/Ideal.lean
@@ -134,11 +134,9 @@ theorem mem_compl_of_ge {x y : P} : x ≤ y → x ∈ (I : Set P)ᶜ → y ∈ (
 instance instPartialOrderIdeal : PartialOrder (Ideal P) :=
   PartialOrder.lift SetLike.coe SetLike.coe_injective
 
--- @[simp] -- Porting note (#10618): simp can prove this
 theorem coe_subset_coe : (s : Set P) ⊆ t ↔ s ≤ t :=
   Iff.rfl
 
--- @[simp] -- Porting note (#10618): simp can prove this
 theorem coe_ssubset_coe : (s : Set P) ⊂ t ↔ s < t :=
   Iff.rfl
 

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -120,36 +120,20 @@ theorem Ioc_eq_empty_of_le (h : b ≤ a) : Ioc a b = ∅ :=
 theorem Ioo_eq_empty_of_le (h : b ≤ a) : Ioo a b = ∅ :=
   Ioo_eq_empty h.not_lt
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem left_mem_Icc : a ∈ Icc a b ↔ a ≤ b := by simp only [mem_Icc, true_and, le_rfl]
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem left_mem_Ico : a ∈ Ico a b ↔ a < b := by simp only [mem_Ico, true_and, le_refl]
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem right_mem_Icc : b ∈ Icc a b ↔ a ≤ b := by simp only [mem_Icc, and_true, le_rfl]
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem right_mem_Ioc : b ∈ Ioc a b ↔ a < b := by simp only [mem_Ioc, and_true, le_rfl]
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem left_not_mem_Ioc : a ∉ Ioc a b := fun h => lt_irrefl _ (mem_Ioc.1 h).1
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem left_not_mem_Ioo : a ∉ Ioo a b := fun h => lt_irrefl _ (mem_Ioo.1 h).1
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem right_not_mem_Ico : b ∉ Ico a b := fun h => lt_irrefl _ (mem_Ico.1 h).2
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem right_not_mem_Ioo : b ∉ Ioo a b := fun h => lt_irrefl _ (mem_Ioo.1 h).2
 
 theorem Icc_subset_Icc (ha : a₂ ≤ a₁) (hb : b₁ ≤ b₂) : Icc a₁ b₁ ⊆ Icc a₂ b₂ := by
@@ -244,18 +228,12 @@ theorem Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b�
 
 variable (a)
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem Ico_self : Ico a a = ∅ :=
   Ico_eq_empty <| lt_irrefl _
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem Ioc_self : Ioc a a = ∅ :=
   Ioc_eq_empty <| lt_irrefl _
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem Ioo_self : Ioo a a = ∅ :=
   Ioo_eq_empty <| lt_irrefl _
 
@@ -592,8 +570,6 @@ theorem Ioi_insert [DecidableEq α] (a : α) : insert a (Ioi a) = Ici a := by
   ext
   simp_rw [Finset.mem_insert, mem_Ici, mem_Ioi, le_iff_lt_or_eq, or_comm, eq_comm]
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem not_mem_Ioi_self {b : α} : b ∉ Ioi b := fun h => lt_irrefl _ (mem_Ioi.1 h)
 
 -- Purposefully written the other way around
@@ -620,8 +596,6 @@ theorem Iio_insert [DecidableEq α] (b : α) : insert b (Iio b) = Iic b := by
   ext
   simp_rw [Finset.mem_insert, mem_Iic, mem_Iio, le_iff_lt_or_eq, or_comm]
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem not_mem_Iio_self {b : α} : b ∉ Iio b := fun h => lt_irrefl _ (mem_Iio.1 h)
 
 -- Purposefully written the other way around
@@ -788,8 +762,6 @@ theorem uIcc_of_ge (h : b ≤ a) : [[a, b]] = Icc b a := by
 theorem uIcc_comm (a b : α) : [[a, b]] = [[b, a]] := by
   rw [uIcc, uIcc, inf_comm, sup_comm]
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem uIcc_self : [[a, a]] = {a} := by simp [uIcc]
 
 @[simp]
@@ -802,13 +774,9 @@ theorem Icc_subset_uIcc : Icc a b ⊆ [[a, b]] :=
 theorem Icc_subset_uIcc' : Icc b a ⊆ [[a, b]] :=
   Icc_subset_Icc inf_le_right le_sup_left
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem left_mem_uIcc : a ∈ [[a, b]] :=
   mem_Icc.2 ⟨inf_le_left, le_sup_left⟩
 
--- porting note (#10618): simp can prove this
--- @[simp]
 theorem right_mem_uIcc : b ∈ [[a, b]] :=
   mem_Icc.2 ⟨inf_le_right, le_sup_right⟩
 

--- a/Mathlib/Order/Interval/Finset/Fin.lean
+++ b/Mathlib/Order/Interval/Finset/Fin.lean
@@ -100,23 +100,15 @@ lemma card_Ioo : #(Ioo a b) = b - a - 1 := by rw [← Nat.card_Ioo, ← map_valE
 theorem card_uIcc : #(uIcc a b) = (b - a : ℤ).natAbs + 1 := by
   rw [← Nat.card_uIcc, ← map_subtype_embedding_uIcc, card_map]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIcc : Fintype.card (Set.Icc a b) = b + 1 - a := by
   rw [← card_Icc, Fintype.card_ofFinset]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIco : Fintype.card (Set.Ico a b) = b - a := by
   rw [← card_Ico, Fintype.card_ofFinset]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIoc : Fintype.card (Set.Ioc a b) = b - a := by
   rw [← card_Ioc, Fintype.card_ofFinset]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIoo : Fintype.card (Set.Ioo a b) = b - a - 1 := by
   rw [← card_Ioo, Fintype.card_ofFinset]
 
@@ -183,23 +175,15 @@ theorem card_Iic : #(Iic b) = b + 1 := by rw [← Nat.card_Iic b, ← map_valEmb
 @[simp]
 theorem card_Iio : #(Iio b) = b := by rw [← Nat.card_Iio b, ← map_valEmbedding_Iio, card_map]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIci : Fintype.card (Set.Ici a) = n - a := by
   rw [Fintype.card_ofFinset, card_Ici]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIoi : Fintype.card (Set.Ioi a) = n - 1 - a := by
   rw [Fintype.card_ofFinset, card_Ioi]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIic : Fintype.card (Set.Iic b) = b + 1 := by
   rw [Fintype.card_ofFinset, card_Iic]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIio : Fintype.card (Set.Iio b) = b := by
   rw [Fintype.card_ofFinset, card_Iio]
 

--- a/Mathlib/Order/Interval/Finset/Nat.lean
+++ b/Mathlib/Order/Interval/Finset/Nat.lean
@@ -80,33 +80,21 @@ lemma card_Iic : #(Iic b) = b + 1 := by rw [Iic_eq_Icc, card_Icc, Nat.bot_eq_zer
 @[simp]
 theorem card_Iio : #(Iio b) = b := by rw [Iio_eq_Ico, card_Ico, Nat.bot_eq_zero, Nat.sub_zero]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIcc : Fintype.card (Set.Icc a b) = b + 1 - a := by
   rw [Fintype.card_ofFinset, card_Icc]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIco : Fintype.card (Set.Ico a b) = b - a := by
   rw [Fintype.card_ofFinset, card_Ico]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIoc : Fintype.card (Set.Ioc a b) = b - a := by
   rw [Fintype.card_ofFinset, card_Ioc]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIoo : Fintype.card (Set.Ioo a b) = b - a - 1 := by
   rw [Fintype.card_ofFinset, card_Ioo]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIic : Fintype.card (Set.Iic b) = b + 1 := by
   rw [Fintype.card_ofFinset, card_Iic]
 
--- Porting note (#10618): simp can prove this
--- @[simp]
 theorem card_fintypeIio : Fintype.card (Set.Iio b) = b := by rw [Fintype.card_ofFinset, card_Iio]
 
 -- TODO@Yaël: Generalize all the following lemmas to `SuccOrder`

--- a/Mathlib/Order/Interval/Multiset.lean
+++ b/Mathlib/Order/Interval/Multiset.lean
@@ -156,13 +156,10 @@ theorem Ioo_eq_zero_of_le (h : b ≤ a) : Ioo a b = 0 :=
 
 variable (a)
 
--- Porting note (#10618): simp can prove this -- @[simp]
 theorem Ico_self : Ico a a = 0 := by rw [Ico, Finset.Ico_self, Finset.empty_val]
 
--- Porting note (#10618): simp can prove this -- @[simp]
 theorem Ioc_self : Ioc a a = 0 := by rw [Ioc, Finset.Ioc_self, Finset.empty_val]
 
--- Porting note (#10618): simp can prove this -- @[simp]
 theorem Ioo_self : Ioo a a = 0 := by rw [Ioo, Finset.Ioo_self, Finset.empty_val]
 
 variable {a}
@@ -179,19 +176,15 @@ theorem right_mem_Icc : b ∈ Icc a b ↔ a ≤ b :=
 theorem right_mem_Ioc : b ∈ Ioc a b ↔ a < b :=
   Finset.right_mem_Ioc
 
--- Porting note (#10618): simp can prove this -- @[simp]
 theorem left_not_mem_Ioc : a ∉ Ioc a b :=
   Finset.left_not_mem_Ioc
 
--- Porting note (#10618): simp can prove this -- @[simp]
 theorem left_not_mem_Ioo : a ∉ Ioo a b :=
   Finset.left_not_mem_Ioo
 
--- Porting note (#10618): simp can prove this -- @[simp]
 theorem right_not_mem_Ico : b ∉ Ico a b :=
   Finset.right_not_mem_Ico
 
--- Porting note (#10618): simp can prove this -- @[simp]
 theorem right_not_mem_Ioo : b ∉ Ioo a b :=
   Finset.right_not_mem_Ioo
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -142,38 +142,22 @@ instance decidableMemIci [Decidable (a ≤ x)] : Decidable (x ∈ Ici a) := by a
 
 instance decidableMemIoi [Decidable (a < x)] : Decidable (x ∈ Ioi a) := by assumption
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem left_mem_Ioo : a ∈ Ioo a b ↔ False := by simp [lt_irrefl]
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem left_mem_Ico : a ∈ Ico a b ↔ a < b := by simp [le_refl]
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem left_mem_Icc : a ∈ Icc a b ↔ a ≤ b := by simp [le_refl]
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem left_mem_Ioc : a ∈ Ioc a b ↔ False := by simp [lt_irrefl]
 
 theorem left_mem_Ici : a ∈ Ici a := by simp
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem right_mem_Ioo : b ∈ Ioo a b ↔ False := by simp [lt_irrefl]
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem right_mem_Ico : b ∈ Ico a b ↔ False := by simp [lt_irrefl]
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem right_mem_Icc : b ∈ Icc a b ↔ a ≤ b := by simp [le_refl]
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem right_mem_Ioc : b ∈ Ioc a b ↔ a < b := by simp [le_refl]
 
 theorem right_mem_Iic : a ∈ Iic a := by simp
@@ -318,18 +302,12 @@ theorem Ioc_eq_empty_of_le (h : b ≤ a) : Ioc a b = ∅ :=
 theorem Ioo_eq_empty_of_le (h : b ≤ a) : Ioo a b = ∅ :=
   Ioo_eq_empty h.not_lt
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem Ico_self (a : α) : Ico a a = ∅ :=
   Ico_eq_empty <| lt_irrefl _
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem Ioc_self (a : α) : Ioc a a = ∅ :=
   Ioc_eq_empty <| lt_irrefl _
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem Ioo_self (a : α) : Ioo a a = ∅ :=
   Ioo_eq_empty <| lt_irrefl _
 
@@ -585,12 +563,8 @@ theorem not_mem_Ico_of_lt (ha : c < a) : c ∉ Ico a b := fun h => ha.not_le h.1
 
 theorem not_mem_Ioc_of_gt (hb : b < c) : c ∉ Ioc a b := fun h => hb.not_le h.2
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem not_mem_Ioi_self : a ∉ Ioi a := lt_irrefl _
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem not_mem_Iio_self : b ∉ Iio b := lt_irrefl _
 
 theorem not_mem_Ioc_of_le (ha : c ≤ a) : c ∉ Ioc a b := fun h => lt_irrefl _ <| h.1.trans_le ha
@@ -693,13 +667,9 @@ theorem Ici_diff_Ioi_same : Ici a \ Ioi a = {a} := by
 theorem Iic_diff_Iio_same : Iic a \ Iio a = {a} := by
   rw [← Iic_diff_right, diff_diff_cancel_left (singleton_subset_iff.2 right_mem_Iic)]
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem Ioi_union_left : Ioi a ∪ {a} = Ici a :=
   ext fun x => by simp [eq_comm, le_iff_eq_or_lt]
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 theorem Iio_union_right : Iio a ∪ {a} = Iic a :=
   ext fun _ => le_iff_lt_or_eq.symm
 

--- a/Mathlib/Order/Interval/Set/UnorderedInterval.lean
+++ b/Mathlib/Order/Interval/Set/UnorderedInterval.lean
@@ -74,8 +74,6 @@ lemma uIcc_comm (a b : α) : [[a, b]] = [[b, a]] := by simp_rw [uIcc, inf_comm, 
 lemma uIcc_of_lt (h : a < b) : [[a, b]] = Icc a b := uIcc_of_le h.le
 lemma uIcc_of_gt (h : b < a) : [[a, b]] = Icc b a := uIcc_of_ge h.le
 
--- Porting note (#10618): `simp` can prove this
--- @[simp]
 lemma uIcc_self : [[a, a]] = {a} := by simp [uIcc]
 
 @[simp] lemma nonempty_uIcc : [[a, b]].Nonempty := nonempty_Icc.2 inf_le_sup

--- a/Mathlib/Order/Irreducible.lean
+++ b/Mathlib/Order/Irreducible.lean
@@ -161,11 +161,9 @@ theorem InfPrime.inf_le (ha : InfPrime a) : b ⊓ c ≤ a ↔ b ≤ a ∨ c ≤ 
 
 variable [OrderTop α] {s : Finset ι} {f : ι → α}
 
--- @[simp] Porting note (#10618): simp can prove this.
 theorem not_infIrred_top : ¬InfIrred (⊤ : α) :=
   isMax_top.not_infIrred
 
--- @[simp] Porting note (#10618): simp can prove this.
 theorem not_infPrime_top : ¬InfPrime (⊤ : α) :=
   isMax_top.not_infPrime
 
@@ -275,11 +273,9 @@ section LinearOrder
 
 variable [LinearOrder α] {a : α}
 
--- @[simp] Porting note (#10618): simp can prove this
 theorem supPrime_iff_not_isMin : SupPrime a ↔ ¬IsMin a :=
   and_iff_left <| by simp
 
--- @[simp] Porting note (#10618): simp can prove thisrove this
 theorem infPrime_iff_not_isMax : InfPrime a ↔ ¬IsMax a :=
   and_iff_left <| by simp
 

--- a/Mathlib/Order/PartialSups.lean
+++ b/Mathlib/Order/PartialSups.lean
@@ -174,7 +174,6 @@ lemma partialSups_eq_biUnion_range (s : ℕ → Set α) (n : ℕ) :
 
 variable [CompleteLattice α]
 
--- Porting note (#10618): simp can prove this @[simp]
 theorem iSup_partialSups_eq (f : ℕ → α) : ⨆ n, partialSups f n = ⨆ n, f n :=
   ciSup_partialSups_eq <| OrderTop.bddAbove _
 


### PR DESCRIPTION
This PR checks all porting notes of the form "`simp` can prove this" and if this is indeed the case (and the proof appears to make sense), removes the associated porting note.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
