### PR TITLE
[Merged by Bors] - feat(Complex/Order): add some results about multiplication of a real and a complex

### DIFF
--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -874,13 +874,13 @@ scoped[ComplexOrder] attribute [instance] StarModule.instOrderedSMul
 
 theorem ofReal_mul_pos_iff (x : ℝ) (z : K) :
     0 < x * z ↔ (x < 0 ∧ z < 0) ∨ (0 < x ∧ 0 < z) := by
-   simp_rw [pos_iff (z := x * z), pos_iff (z := z), neg_iff (z := z), re_ofReal_mul, im_ofReal_mul]
-   obtain hx | hx | hx := lt_trichotomy x 0
-   · simp_rw [mul_pos_iff, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne, false_and, true_and,
-      false_or, or_false]
-   · simp_rw [hx, zero_mul, lt_self_iff_false, false_and, false_or]
-   · simp_rw [mul_pos_iff, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne', false_and, true_and,
-      false_or, or_false]
+  simp_rw [pos_iff (z := x * z), pos_iff (z := z), neg_iff (z := z), re_ofReal_mul, im_ofReal_mul]
+  obtain hx | hx | hx := lt_trichotomy x 0
+  · simp only [mul_pos_iff, not_lt_of_gt hx, false_and, hx, true_and, false_or, mul_eq_zero, hx.ne,
+      or_false]
+  · simp only [hx, zero_mul, lt_self_iff_false, false_and, false_or]
+  · simp only [mul_pos_iff, hx, true_and, not_lt_of_gt hx, false_and, or_false, mul_eq_zero,
+      hx.ne', false_or]
 
 theorem ofReal_mul_neg_iff (x : ℝ) (z : K) :
     x * z < 0 ↔ (x < 0 ∧ 0 < z) ∨ (0 < x ∧ z < 0) := by

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -874,7 +874,7 @@ scoped[ComplexOrder] attribute [instance] StarModule.instOrderedSMul
 
 theorem ofReal_mul_pos_iff (x : ℝ) (z : K) :
     0 < x * z ↔ (x < 0 ∧ z < 0) ∨ (0 < x ∧ 0 < z) := by
-  simp_rw [pos_iff (z := x * z), pos_iff (z := z), neg_iff (z := z), re_ofReal_mul, im_ofReal_mul]
+  simp only [pos_iff (K := K), neg_iff (K := K), re_ofReal_mul, im_ofReal_mul]
   obtain hx | hx | hx := lt_trichotomy x 0
   · simp only [mul_pos_iff, not_lt_of_gt hx, false_and, hx, true_and, false_or, mul_eq_zero, hx.ne,
       or_false]

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -873,14 +873,14 @@ instance {A : Type*} [NonUnitalRing A] [StarRing A] [PartialOrder A] [StarOrdere
 scoped[ComplexOrder] attribute [instance] StarModule.instOrderedSMul
 
 theorem ofReal_mul_pos_iff (x : ℝ) (z : K) :
-     0 < x * z ↔ (x < 0 ∧ z < 0) ∨ (0 < x ∧ 0 < z) := by
+    0 < x * z ↔ (x < 0 ∧ z < 0) ∨ (0 < x ∧ 0 < z) := by
    simp_rw [pos_iff (z := x * z), pos_iff (z := z), neg_iff (z := z), re_ofReal_mul, im_ofReal_mul]
    obtain hx | hx | hx := lt_trichotomy x 0
    · simp_rw [mul_pos_iff, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne, false_and, true_and,
-       false_or, or_false]
+      false_or, or_false]
    · simp_rw [hx, zero_mul, lt_self_iff_false, false_and, false_or]
    · simp_rw [mul_pos_iff, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne', false_and, true_and,
-       false_or, or_false]
+      false_or, or_false]
 
 theorem ofReal_mul_neg_iff (x : ℝ) (z : K) :
     x * z < 0 ↔ (x < 0 ∧ 0 < z) ∨ (0 < x ∧ z < 0) := by

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -872,6 +872,20 @@ instance {A : Type*} [NonUnitalRing A] [StarRing A] [PartialOrder A] [StarOrdere
 
 scoped[ComplexOrder] attribute [instance] StarModule.instOrderedSMul
 
+theorem ofReal_mul_pos_iff (x : ℝ) (z : K) :
+     0 < x * z ↔ (x < 0 ∧ z < 0) ∨ (0 < x ∧ 0 < z) := by
+   simp_rw [pos_iff (z := x * z), pos_iff (z := z), neg_iff (z := z), re_ofReal_mul, im_ofReal_mul]
+   obtain hx | hx | hx := lt_trichotomy x 0
+   · simp_rw [mul_pos_iff, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne, false_and, true_and,
+       false_or, or_false]
+   · simp_rw [hx, zero_mul, lt_self_iff_false, false_and, false_or]
+   · simp_rw [mul_pos_iff, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne', false_and, true_and,
+       false_or, or_false]
+
+theorem ofReal_mul_neg_iff (x : ℝ) (z : K) :
+    x * z < 0 ↔ (x < 0 ∧ 0 < z) ∨ (0 < x ∧ z < 0) := by
+  simpa only [mul_neg, neg_pos, neg_neg_iff_pos] using ofReal_mul_pos_iff x (-z)
+
 end Order
 
 section CleanupLemmas

--- a/Mathlib/Data/Complex/Order.lean
+++ b/Mathlib/Data/Complex/Order.lean
@@ -63,6 +63,32 @@ theorem nonneg_iff {z : ℂ} : 0 ≤ z ↔ 0 ≤ z.re ∧ 0 = z.im :=
 theorem pos_iff {z : ℂ} : 0 < z ↔ 0 < z.re ∧ 0 = z.im :=
   lt_def
 
+theorem nonpos_iff {z : ℂ} : z ≤ 0 ↔ z.re ≤ 0 ∧ z.im = 0 :=
+  le_def
+
+theorem neg_iff {z : ℂ} : z < 0 ↔ z.re < 0 ∧ z.im = 0 :=
+  lt_def
+
+theorem ofReal_mul_pos_iff (x : ℝ) (z : ℂ) :
+    0 < x * z ↔ (x < 0 ∧ z < 0) ∨ (0 < x ∧ 0 < z) := by
+  simp_rw [pos_iff, neg_iff, re_ofReal_mul, im_ofReal_mul]
+  obtain hx | hx | hx := lt_trichotomy x 0
+  · simp_rw [mul_pos_iff, eq_comm, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne, false_and, true_and,
+      false_or, or_false]
+  · simp_rw [hx, zero_mul, lt_self_iff_false, false_and, false_or]
+  · simp_rw [mul_pos_iff, eq_comm, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne', false_and, true_and,
+      false_or, or_false]
+
+theorem ofReal_mul_neg_iff (x : ℝ) (z : ℂ) :
+    x * z < 0 ↔ (x < 0 ∧ 0 < z) ∨ (0 < x ∧ z < 0) := by
+  simp_rw [pos_iff, neg_iff, re_ofReal_mul, im_ofReal_mul]
+  obtain hx | hx | hx := lt_trichotomy x 0
+  · simp_rw [mul_neg_iff, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne, false_and, true_and, false_or,
+      or_false, eq_comm]
+  · simp_rw [hx, zero_mul, lt_self_iff_false, false_and, false_or]
+  · simp_rw [mul_neg_iff, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne', false_and, true_and, false_or,
+      or_false]
+
 @[simp, norm_cast]
 theorem real_le_real {x y : ℝ} : (x : ℂ) ≤ (y : ℂ) ↔ x ≤ y := by simp [le_def, ofReal]
 

--- a/Mathlib/Data/Complex/Order.lean
+++ b/Mathlib/Data/Complex/Order.lean
@@ -69,26 +69,6 @@ theorem nonpos_iff {z : ℂ} : z ≤ 0 ↔ z.re ≤ 0 ∧ z.im = 0 :=
 theorem neg_iff {z : ℂ} : z < 0 ↔ z.re < 0 ∧ z.im = 0 :=
   lt_def
 
-theorem ofReal_mul_pos_iff (x : ℝ) (z : ℂ) :
-    0 < x * z ↔ (x < 0 ∧ z < 0) ∨ (0 < x ∧ 0 < z) := by
-  simp_rw [pos_iff, neg_iff, re_ofReal_mul, im_ofReal_mul]
-  obtain hx | hx | hx := lt_trichotomy x 0
-  · simp_rw [mul_pos_iff, eq_comm, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne, false_and, true_and,
-      false_or, or_false]
-  · simp_rw [hx, zero_mul, lt_self_iff_false, false_and, false_or]
-  · simp_rw [mul_pos_iff, eq_comm, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne', false_and, true_and,
-      false_or, or_false]
-
-theorem ofReal_mul_neg_iff (x : ℝ) (z : ℂ) :
-    x * z < 0 ↔ (x < 0 ∧ 0 < z) ∨ (0 < x ∧ z < 0) := by
-  simp_rw [pos_iff, neg_iff, re_ofReal_mul, im_ofReal_mul]
-  obtain hx | hx | hx := lt_trichotomy x 0
-  · simp_rw [mul_neg_iff, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne, false_and, true_and, false_or,
-      or_false, eq_comm]
-  · simp_rw [hx, zero_mul, lt_self_iff_false, false_and, false_or]
-  · simp_rw [mul_neg_iff, mul_eq_zero, hx, not_lt_of_gt hx, hx.ne', false_and, true_and, false_or,
-      or_false]
-
 @[simp, norm_cast]
 theorem real_le_real {x y : ℝ} : (x : ℂ) ≤ (y : ℂ) ↔ x ≤ y := by simp [le_def, ofReal]
 


### PR DESCRIPTION
This PR is part of the proof of the Analytic Class Number Formula.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
