### PR TITLE
[Merged by Bors] - chore(Tactic/rename_bvar): silence unused tactic linter and add tests

### DIFF
--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -93,6 +93,7 @@ initialize allowedRef : IO.Ref (Std.HashSet SyntaxNodeKind) ←
     |>.insert `change?
     |>.insert `«tactic#adaptation_note_»
     |>.insert `tacticSleep_heartbeats_
+    |>.insert `Mathlib.Tactic.«tacticRename_bvar_→__»
 
 /-- `#allow_unused_tactic` takes an input a space-separated list of identifiers.
 These identifiers are then allowed by the unused tactic linter:

--- a/Mathlib/Tactic/RenameBVar.lean
+++ b/Mathlib/Tactic/RenameBVar.lean
@@ -29,13 +29,13 @@ def renameBVarTarget (mvarId : MVarId) (old new : Name) : MetaM Unit :=
   modifyTarget mvarId fun e ↦ e.renameBVar old new
 
 /--
-* `rename_bvar old new` renames all bound variables named `old` to `new` in the target.
-* `rename_bvar old new at h` does the same in hypothesis `h`.
+* `rename_bvar old → new` renames all bound variables named `old` to `new` in the target.
+* `rename_bvar old → new at h` does the same in hypothesis `h`.
 
 ```lean
 example (P : ℕ → ℕ → Prop) (h : ∀ n, ∃ m, P n m) : ∀ l, ∃ m, P l m := by
-  rename_bvar n q at h -- h is now ∀ (q : ℕ), ∃ (m : ℕ), P q m,
-  rename_bvar m n -- target is now ∀ (l : ℕ), ∃ (n : ℕ), P k n,
+  rename_bvar n → q at h -- h is now ∀ (q : ℕ), ∃ (m : ℕ), P q m,
+  rename_bvar m → n -- target is now ∀ (l : ℕ), ∃ (n : ℕ), P k n,
   exact h -- Lean does not care about those bound variable names
 ```
 Note: name clashes are resolved automatically.

--- a/test/renameBvar.lean
+++ b/test/renameBvar.lean
@@ -1,0 +1,34 @@
+import Mathlib.Tactic.RenameBvar
+
+/- This test is somewhat flaky since it depends on the pretty printer. -/
+/--
+info: ℕ : Sort u_1
+P : ℕ → ℕ → Prop
+h : ∀ (n : ℕ), ∃ m, P n m
+⊢ ∀ (l : ℕ), ∃ m, P l m
+---
+info: ℕ : Sort u_1
+P : ℕ → ℕ → Prop
+h : ∀ (q : ℕ), ∃ m, P q m
+⊢ ∀ (l : ℕ), ∃ m, P l m
+---
+info: ℕ : Sort u_1
+P : ℕ → ℕ → Prop
+h : ∀ (q : ℕ), ∃ m, P q m
+⊢ ∀ (l : ℕ), ∃ n, P l n
+---
+info: ℕ : Sort u_1
+P : ℕ → ℕ → Prop
+h : ∀ (q : ℕ), ∃ m, P q m
+⊢ ∀ (m : ℕ), ∃ n, P m n
+-/
+#guard_msgs in
+example (P : ℕ → ℕ → Prop) (h : ∀ n, ∃ m, P n m) : ∀ l, ∃ m, P l m := by
+  trace_state
+  rename_bvar n → q at h -- h is now ∀ (q : ℕ), ∃ (m : ℕ), P q m,
+  trace_state
+  rename_bvar m → n -- target is now ∀ (l : ℕ), ∃ (n : ℕ), P k n,
+  trace_state
+  rename_bvar l → m
+  trace_state
+  exact h -- Lean does not care about those bound variable names

--- a/test/renameBvar.lean
+++ b/test/renameBvar.lean
@@ -25,10 +25,10 @@ h : ∀ (q : ℕ), ∃ m, P q m
 #guard_msgs in
 example (P : ℕ → ℕ → Prop) (h : ∀ n, ∃ m, P n m) : ∀ l, ∃ m, P l m := by
   trace_state
-  rename_bvar n → q at h -- h is now ∀ (q : ℕ), ∃ (m : ℕ), P q m,
+  rename_bvar n → q at h
   trace_state
-  rename_bvar m → n -- target is now ∀ (l : ℕ), ∃ (n : ℕ), P k n,
+  rename_bvar m → n
   trace_state
   rename_bvar l → m
   trace_state
-  exact h -- Lean does not care about those bound variable names
+  exact h

--- a/test/renameBvar.lean
+++ b/test/renameBvar.lean
@@ -1,4 +1,4 @@
-import Mathlib.Tactic.RenameBvar
+import Mathlib.Tactic.RenameBVar
 
 /- This test is somewhat flaky since it depends on the pretty printer. -/
 /--


### PR DESCRIPTION
`rename_bvar` exists only to rename bound variables inside either the goal state or a local hypothesis. This by definition does not change the current goal at all, so the unused tactic linter should be silenced.

Add some tests to document this (and the current behaviour).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
