### PR TITLE
[Merged by Bors] - feat(FieldTheory/Fixed): Finite group surjects onto automorphisms fixing the fixed field

### DIFF
--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -801,6 +801,8 @@ theorem toAlgEquiv_injective [FaithfulSMul G A] :
     Function.Injective (MulSemiringAction.toAlgEquiv R A : G → A ≃ₐ[R] A) := fun _ _ h =>
   eq_of_smul_eq_smul fun r => AlgEquiv.ext_iff.1 h r
 
+variable (G)
+
 /-- Each element of the group defines an algebra equivalence.
 
 This is a stronger version of `MulSemiringAction.toRingAut` and

--- a/Mathlib/FieldTheory/Fixed.lean
+++ b/Mathlib/FieldTheory/Fixed.lean
@@ -17,7 +17,7 @@ This is the basis of the Fundamental Theorem of Galois Theory.
 Given a (finite) group `G` that acts on a field `F`, we define `FixedPoints.subfield G F`,
 the subfield consisting of elements of `F` fixed_points by every element of `G`.
 
-This subfield is then normal and separable, and in addition (TODO) if `G` acts faithfully on `F`
+This subfield is then normal and separable, and in addition if `G` acts faithfully on `F`
 then `finrank (FixedPoints.subfield G F) F = Fintype.card G`.
 
 ## Main Definitions
@@ -311,8 +311,9 @@ theorem finrank_algHom (K : Type u) (V : Type v) [Field K] [Field V] [Algebra K 
 
 namespace FixedPoints
 
-theorem finrank_eq_card (G : Type u) (F : Type v) [Group G] [Field F] [Fintype G]
-    [MulSemiringAction G F] [FaithfulSMul G F] :
+variable (G F : Type*) [Group G] [Field F] [MulSemiringAction G F]
+
+theorem finrank_eq_card [Fintype G] [FaithfulSMul G F] :
     finrank (FixedPoints.subfield G F) F = Fintype.card G :=
   le_antisymm (FixedPoints.finrank_le_card G F) <|
     calc
@@ -322,8 +323,7 @@ theorem finrank_eq_card (G : Type u) (F : Type v) [Group G] [Field F] [Fintype G
       _ = finrank (FixedPoints.subfield G F) F := finrank_linearMap_self _ _ _
 
 /-- `MulSemiringAction.toAlgHom` is bijective. -/
-theorem toAlgHom_bijective (G : Type u) (F : Type v) [Group G] [Field F] [Finite G]
-    [MulSemiringAction G F] [FaithfulSMul G F] :
+theorem toAlgHom_bijective [Finite G] [FaithfulSMul G F] :
     Function.Bijective (MulSemiringAction.toAlgHom _ _ : G → F →ₐ[subfield G F] F) := by
   cases nonempty_fintype G
   rw [Fintype.bijective_iff_injective_and_card]
@@ -334,9 +334,37 @@ theorem toAlgHom_bijective (G : Type u) (F : Type v) [Group G] [Field F] [Finite
     · rw [← finrank_eq_card G F]
       exact LE.le.trans_eq (finrank_algHom _ F) (finrank_linearMap_self _ _ _)
 
-/-- Bijection between G and algebra homomorphisms that fix the fixed points -/
-def toAlgHomEquiv (G : Type u) (F : Type v) [Group G] [Field F] [Finite G] [MulSemiringAction G F]
-    [FaithfulSMul G F] : G ≃ (F →ₐ[FixedPoints.subfield G F] F) :=
+/-- Bijection between `G` and algebra endomorphisms of `F` that fix the fixed points. -/
+def toAlgHomEquiv [Finite G] [FaithfulSMul G F] : G ≃ (F →ₐ[FixedPoints.subfield G F] F) :=
   Equiv.ofBijective _ (toAlgHom_bijective G F)
+
+/-- `MulSemiringAction.toAlgAut` is bijective. -/
+theorem toAlgAut_bijective [Finite G] [FaithfulSMul G F] :
+    Function.Bijective (MulSemiringAction.toAlgAut G (FixedPoints.subfield G F) F) := by
+  refine ⟨fun _ _ h ↦ (FixedPoints.toAlgHom_bijective G F).injective ?_,
+    fun f ↦ ((FixedPoints.toAlgHom_bijective G F).surjective f).imp (fun _ h ↦ ?_)⟩
+      <;> rwa [DFunLike.ext_iff] at h ⊢
+
+/-- Bijection between `G` and algebra automorphisms of `F` that fix the fixed points. -/
+def toAlgAutMulEquiv [Finite G] [FaithfulSMul G F] : G ≃* (F ≃ₐ[FixedPoints.subfield G F] F) :=
+  MulEquiv.ofBijective _ (toAlgAut_bijective G F)
+
+/-- `MulSemiringAction.toAlgHom` is surjective. -/
+theorem toAlgAut_surjective [Finite G] :
+    Function.Surjective (MulSemiringAction.toAlgAut G (FixedPoints.subfield G F) F) := by
+  let f : G →* F ≃ₐ[FixedPoints.subfield G F] F :=
+    MulSemiringAction.toAlgAut (FixedPoints.subfield G F) F
+  let Q := G ⧸ f.ker
+  let _ : MulSemiringAction Q F := MulSemiringAction.compHom _ (QuotientGroup.kerLift f)
+  have : FaithfulSMul Q F := ⟨by
+    intro q₁ q₂
+    refine Quotient.inductionOn₂' q₁ q₂ (fun g₁ g₂ h ↦ QuotientGroup.eq.mpr ?_)
+    rwa [MonoidHom.mem_ker, map_mul, map_inv, inv_mul_eq_one, AlgEquiv.ext_iff]⟩
+  intro f
+  obtain ⟨q, hq⟩ := (toAlgAut_bijective Q F).surjective
+    (AlgEquiv.ofRingEquiv (f := f) (fun ⟨x, hx⟩ ↦ f.commutes' ⟨x, fun g ↦ hx g⟩))
+  revert hq
+  refine QuotientGroup.induction_on q (fun g hg ↦ ⟨g, ?_⟩)
+  rwa [AlgEquiv.ext_iff] at hg ⊢
 
 end FixedPoints

--- a/Mathlib/FieldTheory/Fixed.lean
+++ b/Mathlib/FieldTheory/Fixed.lean
@@ -349,11 +349,11 @@ theorem toAlgAut_bijective [Finite G] [FaithfulSMul G F] :
 def toAlgAutMulEquiv [Finite G] [FaithfulSMul G F] : G ≃* (F ≃ₐ[FixedPoints.subfield G F] F) :=
   MulEquiv.ofBijective _ (toAlgAut_bijective G F)
 
-/-- `MulSemiringAction.toAlgHom` is surjective. -/
+/-- `MulSemiringAction.toAlgAut` is surjective. -/
 theorem toAlgAut_surjective [Finite G] :
     Function.Surjective (MulSemiringAction.toAlgAut G (FixedPoints.subfield G F) F) := by
   let f : G →* F ≃ₐ[FixedPoints.subfield G F] F :=
-    MulSemiringAction.toAlgAut (FixedPoints.subfield G F) F
+    MulSemiringAction.toAlgAut G (FixedPoints.subfield G F) F
   let Q := G ⧸ f.ker
   let _ : MulSemiringAction Q F := MulSemiringAction.compHom _ (QuotientGroup.kerLift f)
   have : FaithfulSMul Q F := ⟨by

--- a/Mathlib/FieldTheory/Fixed.lean
+++ b/Mathlib/FieldTheory/Fixed.lean
@@ -342,8 +342,8 @@ def toAlgHomEquiv [Finite G] [FaithfulSMul G F] : G ≃ (F →ₐ[FixedPoints.su
 theorem toAlgAut_bijective [Finite G] [FaithfulSMul G F] :
     Function.Bijective (MulSemiringAction.toAlgAut G (FixedPoints.subfield G F) F) := by
   refine ⟨fun _ _ h ↦ (FixedPoints.toAlgHom_bijective G F).injective ?_,
-    fun f ↦ ((FixedPoints.toAlgHom_bijective G F).surjective f).imp (fun _ h ↦ ?_)⟩
-      <;> rwa [DFunLike.ext_iff] at h ⊢
+    fun f ↦ ((FixedPoints.toAlgHom_bijective G F).surjective f).imp (fun _ h ↦ ?_)⟩ <;>
+      rwa [DFunLike.ext_iff] at h ⊢
 
 /-- Bijection between `G` and algebra automorphisms of `F` that fix the fixed points. -/
 def toAlgAutMulEquiv [Finite G] [FaithfulSMul G F] : G ≃* (F ≃ₐ[FixedPoints.subfield G F] F) :=


### PR DESCRIPTION
This PR shows that if a finite group `G` acts on a field `F`, then `G` surjects onto `F ≃ₐ[FixedPoints.subfield G F] F`. We already have this result in the case that `G` acts faithfully, so for the general case it's just a matter of quotienting by the kernel of the action.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
