### PR TITLE
[Merged by Bors] - refactor: generalise the Ruzsa triangle inequality to non-abelian groups

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -171,6 +171,12 @@ lemma max'_one [LinearOrder α] : (1 : Finset α).max' one_nonempty = 1 := rfl
 @[to_additive (attr := simp)]
 lemma min'_one [LinearOrder α] : (1 : Finset α).min' one_nonempty = 1 := rfl
 
+@[to_additive (attr := simp)]
+lemma image_op_one [DecidableEq α] : (1 : Finset α).image op = 1 := rfl
+
+@[to_additive (attr := simp)]
+lemma map_op_one : (1 : Finset α).map opEquiv.toEmbedding = 1 := rfl
+
 end One
 
 /-! ### Finset negation/inversion -/
@@ -256,6 +262,10 @@ lemma inf'_inv [SemilatticeInf β] {s : Finset α} (hs : s⁻¹.Nonempty) (f : �
 
 @[to_additive] lemma image_op_inv (s : Finset α) : s⁻¹.image op = (s.image op)⁻¹ :=
   image_comm op_inv
+
+@[to_additive]
+lemma map_op_inv (s : Finset α) : s⁻¹.map opEquiv.toEmbedding = (s.map opEquiv.toEmbedding)⁻¹ := by
+  simp [map_eq_image, image_op_inv]
 
 end Inv
 
@@ -580,6 +590,15 @@ theorem subset_mul {s t : Set α} :
 @[to_additive]
 theorem image_mul [DecidableEq β] : (s * t).image (f : α → β) = s.image f * t.image f :=
   image_image₂_distrib <| map_mul f
+
+@[to_additive]
+lemma image_op_mul (s t : Finset α) : (s * t).image op = t.image op * s.image op :=
+  image_image₂_antidistrib op_mul
+
+@[to_additive]
+lemma map_op_mul (s t : Finset α) :
+    (s * t).map opEquiv.toEmbedding = t.map opEquiv.toEmbedding * s.map opEquiv.toEmbedding := by
+  simp [map_eq_image, image_op_mul]
 
 /-- The singleton operation as a `MulHom`. -/
 @[to_additive "The singleton operation as an `AddHom`."]

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -67,8 +67,7 @@ Because the pointwise action can easily be spelled out in such cases, we give hi
 nat and int actions.
 -/
 
-
-open Function
+open Function MulOpposite
 
 variable {F α β γ : Type*}
 
@@ -131,6 +130,8 @@ noncomputable def singletonOneHom : OneHom α (Set α) where
 @[to_additive (attr := simp)]
 theorem coe_singletonOneHom : (singletonOneHom : α → Set α) = singleton :=
   rfl
+
+@[to_additive] lemma image_op_one : (1 : Set α).image op = 1 := image_singleton
 
 end One
 

--- a/Mathlib/Algebra/Opposites.lean
+++ b/Mathlib/Algebra/Opposites.lean
@@ -138,6 +138,12 @@ theorem unop_inj {x y : αᵐᵒᵖ} : unop x = unop y ↔ x = y :=
 
 attribute [nolint simpComm] AddOpposite.unop_inj
 
+@[to_additive (attr := simp)] lemma «forall» {p : αᵐᵒᵖ → Prop} : (∀ a, p a) ↔ ∀ a, p (op a) :=
+  op_surjective.forall
+
+@[to_additive (attr := simp)] lemma «exists» {p : αᵐᵒᵖ → Prop} : (∃ a, p a) ↔ ∃ a, p (op a) :=
+  op_surjective.exists
+
 @[to_additive] instance instNontrivial [Nontrivial α] : Nontrivial αᵐᵒᵖ := op_injective.nontrivial
 
 @[to_additive] instance instInhabited [Inhabited α] : Inhabited αᵐᵒᵖ := ⟨op default⟩

--- a/Mathlib/Algebra/Pointwise/Stabilizer.lean
+++ b/Mathlib/Algebra/Pointwise/Stabilizer.lean
@@ -74,7 +74,7 @@ lemma stabilizer_subgroup (s : Subgroup G) : stabilizer G (s : Set G) = s := by
 @[to_additive (attr := simp)]
 lemma stabilizer_op_subgroup (s : Subgroup G) : stabilizer Gᵐᵒᵖ (s : Set G) = s.op := by
   simp_rw [SetLike.ext_iff, mem_stabilizer_set]
-  simp? says simp only [smul_eq_mul_unop, SetLike.mem_coe, Subgroup.mem_op]
+  simp only [smul_eq_mul_unop, SetLike.mem_coe, Subgroup.mem_op, «forall», unop_op]
   refine fun a ↦ ⟨fun h ↦ ?_, fun ha b ↦ s.mul_mem_cancel_right ha⟩
   simpa only [op_smul_eq_mul, SetLike.mem_coe, one_mul] using (h 1).2 s.one_mem
 

--- a/Mathlib/Combinatorics/Additive/DoublingConst.lean
+++ b/Mathlib/Combinatorics/Additive/DoublingConst.lean
@@ -5,9 +5,6 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Combinatorics.Additive.PluenneckeRuzsa
 import Mathlib.Data.Finset.Density
-import Mathlib.Tactic.Positivity.Basic
-import Mathlib.Tactic.Positivity.Finset
-import Mathlib.Tactic.Ring
 
 /-!
 # Doubling and difference constants

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -237,7 +237,7 @@ theorem pluennecke_ruzsa_inequality_pow_div_pow_mul (hA : A.Nonempty) (B : Finse
     _ ≤ ((#(C * B) / #C) ^ m * #C) * ((#(C * B) / #C : ℚ≥0) ^ n * #C) := by
       gcongr <;> exact card_mul_pow_le (mul_aux hC hCA hCmin) _
     _ = (#(C * B) / #C) ^ (m + n) * #C * #C := by ring
-    _ ≤ (#(A * B) / #A) ^ (m + n) * #A * #C := by gcongr ((?_ ^ _) * #?_) * _; exact hCmin _ hA'
+    _ ≤ (#(A * B) / #A) ^ (m + n) * #A * #C := by gcongr (?_ ^ _) * #?_ * _; exact hCmin _ hA'
 
 /-- The **Plünnecke-Ruzsa inequality**. Division version. -/
 @[to_additive "The **Plünnecke-Ruzsa inequality**. Subtraction version."]

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -8,7 +8,11 @@ import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Order.Field.Rat
 import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Combinatorics.Enumerative.DoubleCounting
+import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Positivity.Finset
+import Mathlib.Tactic.Ring
 
 /-!
 # The Plünnecke-Ruzsa inequality
@@ -29,18 +33,20 @@ inequality.
 * [Terrence Tao, Van Vu, *Additive Combinatorics][tao-vu]
 -/
 
-open Nat
+open MulOpposite Nat
 open scoped Pointwise
 namespace Finset
+variable {G : Type*} [DecidableEq G]
 
-variable {α : Type*} [CommGroup α] [DecidableEq α] {A B C : Finset α}
+section Group
+variable [Group G] {A B C : Finset G}
 
 /-- **Ruzsa's triangle inequality**. Division version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Subtraction version."]
-theorem ruzsa_triangle_inequality_div_div_div (A B C : Finset α) :
-    (A / C).card * B.card ≤ (A / B).card * (B / C).card := by
-  rw [← card_product (A / B), ← mul_one ((A / B) ×ˢ (B / C)).card]
-  refine card_mul_le_card_mul (fun b ac ↦ ac.1 * ac.2 = b) (fun x hx ↦ ?_)
+theorem ruzsa_triangle_inequality_div_div_div (A B C : Finset G) :
+    #(A / C) * #B ≤ #(A / B) * #(B / C) := by
+  rw [← card_product (A / B), ← mul_one #((A / B) ×ˢ (B / C))]
+  refine card_mul_le_card_mul (fun b (a, c) ↦ a * c = b) (fun x hx ↦ ?_)
     fun x _ ↦ card_le_one_iff.2 fun hu hv ↦
       ((mem_bipartiteBelow _).1 hu).2.symm.trans ?_
   · obtain ⟨a, ha, c, hc, rfl⟩ := mem_div.1 hx
@@ -50,31 +56,67 @@ theorem ruzsa_triangle_inequality_div_div_div (A B C : Finset α) :
     · exact div_right_injective (Prod.ext_iff.1 h).1
   · exact ((mem_bipartiteBelow _).1 hv).2
 
+/-- **Ruzsa's triangle inequality**. Invmul-invmul-invmul version. -/
+@[to_additive "**Ruzsa's triangle inequality**. Negadd-negadd-negadd version."]
+theorem ruzsa_triangle_inequality_inv_mul_inv_mul_inv_mul (A B C : Finset G) :
+    #(C⁻¹ * A) * #B ≤ #(B⁻¹ * A) * #(C⁻¹ * B) := by
+  simpa [div_eq_mul_inv, ← map_op_mul, ← map_op_inv] using
+    ruzsa_triangle_inequality_div_div_div (G := Gᵐᵒᵖ) (A.map opEquiv.toEmbedding)
+      (B.map opEquiv.toEmbedding) (C.map opEquiv.toEmbedding)
+
 /-- **Ruzsa's triangle inequality**. Div-mul-mul version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Sub-add-add version."]
-theorem ruzsa_triangle_inequality_div_mul_mul (A B C : Finset α) :
-    (A / C).card * B.card ≤ (A * B).card * (B * C).card := by
-  rw [← div_inv_eq_mul, ← card_inv B, ← card_inv (B * C), mul_inv, ← div_eq_mul_inv]
+theorem ruzsa_triangle_inequality_div_mul_mul (A B C : Finset G) :
+    #(A / C) * #B ≤ #(A * B) * #(C * B) := by
+  rw [← div_inv_eq_mul, ← card_inv B, ← card_inv (C * B), mul_inv_rev, ← div_eq_mul_inv]
   exact ruzsa_triangle_inequality_div_div_div _ _ _
+
+/-- **Ruzsa's triangle inequality**. Invmul-mul-mul version. -/
+@[to_additive "**Ruzsa's triangle inequality**. Negadd-add-add version."]
+theorem ruzsa_triangle_inequality_inv_mul_mul_mul (A B C : Finset G) :
+    #(C⁻¹ * A) * #B ≤ #(B * A) * #(B * C) := by
+  simpa [div_eq_mul_inv, ← map_op_mul, ← map_op_inv] using
+    ruzsa_triangle_inequality_div_mul_mul (G := Gᵐᵒᵖ) (A.map opEquiv.toEmbedding)
+      (B.map opEquiv.toEmbedding) (C.map opEquiv.toEmbedding)
 
 /-- **Ruzsa's triangle inequality**. Mul-div-mul version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Add-sub-add version."]
-theorem ruzsa_triangle_inequality_mul_div_mul (A B C : Finset α) :
-    (A * C).card * B.card ≤ (A / B).card * (B * C).card := by
+theorem ruzsa_triangle_inequality_mul_div_mul (A B C : Finset G) :
+    #(A * C) * #B ≤ #(A / B) * #(B * C) := by
   rw [← div_inv_eq_mul, ← div_inv_eq_mul B]
   exact ruzsa_triangle_inequality_div_div_div _ _ _
 
+/-- **Ruzsa's triangle inequality**. Mul-invmul-mul version. -/
+@[to_additive "**Ruzsa's triangle inequality**. Add-negadd-add version."]
+theorem ruzsa_triangle_inequality_mul_inv_mul_mul (A B C : Finset G) :
+    #(C * A) * #B ≤ #(B⁻¹ * A) * #(C * B) := by
+  simpa [div_eq_mul_inv, ← map_op_mul, ← map_op_inv] using
+    ruzsa_triangle_inequality_mul_div_mul (G := Gᵐᵒᵖ) (A.map opEquiv.toEmbedding)
+      (B.map opEquiv.toEmbedding) (C.map opEquiv.toEmbedding)
+
 /-- **Ruzsa's triangle inequality**. Mul-mul-div version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Add-add-sub version."]
-theorem ruzsa_triangle_inequality_mul_mul_div (A B C : Finset α) :
-    (A * C).card * B.card ≤ (A * B).card * (B / C).card := by
-  rw [← div_inv_eq_mul, div_eq_mul_inv B]
-  exact ruzsa_triangle_inequality_div_mul_mul _ _ _
+theorem ruzsa_triangle_inequality_mul_mul_div (A B C : Finset G) :
+    #(C * A) * #B ≤ #(B * A) * #(B / C) := by
+  simpa [div_eq_mul_inv] using ruzsa_triangle_inequality_inv_mul_mul_mul A B C⁻¹
+
+/-- **Ruzsa's triangle inequality**. Mul-mul-invmul version. -/
+@[to_additive "**Ruzsa's triangle inequality**. Add-add-negadd version."]
+theorem ruzsa_triangle_inequality_mul_mul_inv_mul (A B C : Finset G) :
+    #(A * C) * #B ≤ #(A * B) * #(C⁻¹ * B) := by
+  simpa [div_eq_mul_inv, ← map_op_mul, ← map_op_inv] using
+    ruzsa_triangle_inequality_mul_mul_div (G := Gᵐᵒᵖ) (A.map opEquiv.toEmbedding)
+      (B.map opEquiv.toEmbedding) (C.map opEquiv.toEmbedding)
+
+end Group
+
+section CommGroup
+variable [CommGroup G] {A B C : Finset G}
 
 @[to_additive]
-theorem pluennecke_petridis_inequality_mul (C : Finset α)
-    (hA : ∀ A' ⊆ A, (A * B).card * A'.card ≤ (A' * B).card * A.card) :
-    (A * B * C).card * A.card ≤ (A * B).card * (A * C).card := by
+theorem pluennecke_petridis_inequality_mul (C : Finset G)
+    (hA : ∀ A' ⊆ A, #(A * B) * #A' ≤ #(A' * B) * #A) :
+    #(A * B * C) * #A ≤ #(A * B) * #(A * C) := by
   induction' C using Finset.induction_on with x C _ ih
   · simp
   set A' := A ∩ (A * C / {x}) with hA'
@@ -88,7 +130,7 @@ theorem pluennecke_petridis_inequality_mul (C : Finset α)
     exact mul_subset_mul_right inter_subset_right
   have h₂ : A' * B * {x} ⊆ A * B * {x} :=
     mul_subset_mul_right (mul_subset_mul_right inter_subset_left)
-  have h₃ : (A * B * C').card ≤ (A * B * C).card + (A * B).card - (A' * B).card := by
+  have h₃ : #(A * B * C') ≤ #(A * B * C) + #(A * B) - #(A' * B) := by
     rw [h₁]
     refine (card_union_le _ _).trans_eq ?_
     rw [card_sdiff h₂, ← add_tsub_assoc_of_le (card_le_card h₂), card_mul_singleton,
@@ -97,7 +139,7 @@ theorem pluennecke_petridis_inequality_mul (C : Finset α)
   rw [tsub_mul, add_mul]
   refine (tsub_le_tsub (add_le_add_right ih _) <| hA _ inter_subset_left).trans_eq ?_
   rw [← mul_add, ← mul_tsub, ← hA', hC', insert_eq, mul_union, ← card_mul_singleton A x, ←
-    card_mul_singleton A' x, add_comm (card _), h₀,
+    card_mul_singleton A' x, add_comm #_, h₀,
     eq_tsub_of_add_eq (card_union_add_card_inter _ _)]
 
 /-! ### Sum triangle inequality -/
@@ -106,26 +148,26 @@ theorem pluennecke_petridis_inequality_mul (C : Finset α)
 -- Auxiliary lemma for Ruzsa's triangle sum inequality, and the Plünnecke-Ruzsa inequality.
 @[to_additive]
 private theorem mul_aux (hA : A.Nonempty) (hAB : A ⊆ B)
-    (h : ∀ A' ∈ B.powerset.erase ∅, ((A * C).card : ℚ≥0) / ↑A.card ≤ (A' * C).card / ↑A'.card) :
-    ∀ A' ⊆ A, (A * C).card * A'.card ≤ (A' * C).card * A.card := by
+    (h : ∀ A' ∈ B.powerset.erase ∅, (#(A * C) : ℚ≥0) / #A ≤ #(A' * C) / #A') :
+    ∀ A' ⊆ A, #(A * C) * #A' ≤ #(A' * C) * #A := by
   rintro A' hAA'
   obtain rfl | hA' := A'.eq_empty_or_nonempty
   · simp
-  have hA₀ : (0 : ℚ≥0) < A.card := cast_pos.2 hA.card_pos
-  have hA₀' : (0 : ℚ≥0) < A'.card := cast_pos.2 hA'.card_pos
+  have hA₀ : (0 : ℚ≥0) < #A := cast_pos.2 hA.card_pos
+  have hA₀' : (0 : ℚ≥0) < #A' := cast_pos.2 hA'.card_pos
   exact mod_cast
     (div_le_div_iff hA₀ hA₀').1
       (h _ <| mem_erase_of_ne_of_mem hA'.ne_empty <| mem_powerset.2 <| hAA'.trans hAB)
 
 /-- **Ruzsa's triangle inequality**. Multiplication version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Addition version."]
-theorem ruzsa_triangle_inequality_mul_mul_mul (A B C : Finset α) :
-    (A * C).card * B.card ≤ (A * B).card * (B * C).card := by
+theorem ruzsa_triangle_inequality_mul_mul_mul (A B C : Finset G) :
+    #(A * C) * #B ≤ #(A * B) * #(B * C) := by
   obtain rfl | hB := B.eq_empty_or_nonempty
   · simp
   have hB' : B ∈ B.powerset.erase ∅ := mem_erase_of_ne_of_mem hB.ne_empty (mem_powerset_self _)
   obtain ⟨U, hU, hUA⟩ :=
-    exists_min_image (B.powerset.erase ∅) (fun U ↦ (U * A).card / U.card : _ → ℚ≥0) ⟨B, hB'⟩
+    exists_min_image (B.powerset.erase ∅) (fun U ↦ #(U * A) / #U : _ → ℚ≥0) ⟨B, hB'⟩
   rw [mem_erase, mem_powerset, ← nonempty_iff_ne_empty] at hU
   refine cast_le.1 (?_ : (_ : ℚ≥0) ≤ _)
   push_cast
@@ -141,80 +183,80 @@ theorem ruzsa_triangle_inequality_mul_mul_mul (A B C : Finset α) :
 
 /-- **Ruzsa's triangle inequality**. Mul-div-div version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Add-sub-sub version."]
-theorem ruzsa_triangle_inequality_mul_div_div (A B C : Finset α) :
-    (A * C).card * B.card ≤ (A / B).card * (B / C).card := by
+theorem ruzsa_triangle_inequality_mul_div_div (A B C : Finset G) :
+    #(A * C) * #B ≤ #(A / B) * #(B / C) := by
   rw [div_eq_mul_inv, ← card_inv B, ← card_inv (B / C), inv_div', div_inv_eq_mul]
   exact ruzsa_triangle_inequality_mul_mul_mul _ _ _
 
 /-- **Ruzsa's triangle inequality**. Div-mul-div version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Sub-add-sub version."]
-theorem ruzsa_triangle_inequality_div_mul_div (A B C : Finset α) :
-    (A / C).card * B.card ≤ (A * B).card * (B / C).card := by
+theorem ruzsa_triangle_inequality_div_mul_div (A B C : Finset G) :
+    #(A / C) * #B ≤ #(A * B) * #(B / C) := by
   rw [div_eq_mul_inv, div_eq_mul_inv]
   exact ruzsa_triangle_inequality_mul_mul_mul _ _ _
 
 /-- **Ruzsa's triangle inequality**. Div-div-mul version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Sub-sub-add version."]
-theorem card_div_mul_le_card_div_mul_card_mul (A B C : Finset α) :
-    (A / C).card * B.card ≤ (A / B).card * (B * C).card := by
+theorem card_div_mul_le_card_div_mul_card_mul (A B C : Finset G) :
+    #(A / C) * #B ≤ #(A / B) * #(B * C) := by
   rw [← div_inv_eq_mul, div_eq_mul_inv]
   exact ruzsa_triangle_inequality_mul_div_div _ _ _
 
 -- Auxiliary lemma towards the Plünnecke-Ruzsa inequality
 @[to_additive]
-private lemma card_mul_pow_le (hAB : ∀ A' ⊆ A, (A * B).card * A'.card ≤ (A' * B).card * A.card)
-    (n : ℕ) : (A * B ^ n).card ≤ ((A * B).card / A.card : ℚ≥0) ^ n * A.card := by
+private lemma card_mul_pow_le (hAB : ∀ A' ⊆ A, #(A * B) * #A' ≤ #(A' * B) * #A) (n : ℕ) :
+    #(A * B ^ n) ≤ (#(A * B) / #A : ℚ≥0) ^ n * #A := by
   obtain rfl | hA := A.eq_empty_or_nonempty
   · simp
   induction' n with n ih
   · simp
-  rw [_root_.pow_succ', ← mul_assoc, _root_.pow_succ', @mul_assoc ℚ≥0, ← mul_div_right_comm,
-    le_div_iff₀, ← cast_mul]
-  swap
-  · exact cast_pos.2 hA.card_pos
-  refine (Nat.cast_le.2 <| pluennecke_petridis_inequality_mul _ hAB).trans ?_
-  rw [cast_mul]
-  gcongr
+  refine le_of_mul_le_mul_right ?_ (by positivity : (0 : ℚ≥0) < #A)
+  calc
+    ((#(A * B ^ (n + 1))) * #A : ℚ≥0)
+      = #(A * B * B ^ n) * #A := by rw [_root_.pow_succ', ← mul_assoc]
+    _ ≤ #(A * B) * #(A * B ^ n) := mod_cast pluennecke_petridis_inequality_mul _ hAB
+    _ ≤ #(A * B) * ((#(A * B) / #A) ^ n * #A) := by gcongr
+    _ = (#(A * B) / #A) ^ (n + 1) * #A * #A := by field_simp; ring
 
 /-- The **Plünnecke-Ruzsa inequality**. Multiplication version. Note that this is genuinely harder
 than the division version because we cannot use a double counting argument. -/
 @[to_additive "The **Plünnecke-Ruzsa inequality**. Addition version. Note that this is genuinely
 harder than the subtraction version because we cannot use a double counting argument."]
-theorem pluennecke_ruzsa_inequality_pow_div_pow_mul (hA : A.Nonempty) (B : Finset α) (m n : ℕ) :
-    ((B ^ m / B ^ n).card) ≤ ((A * B).card / A.card : ℚ≥0) ^ (m + n) * A.card := by
+theorem pluennecke_ruzsa_inequality_pow_div_pow_mul (hA : A.Nonempty) (B : Finset G) (m n : ℕ) :
+    #(B ^ m / B ^ n) ≤ (#(A * B) / #A : ℚ≥0) ^ (m + n) * #A := by
   have hA' : A ∈ A.powerset.erase ∅ := mem_erase_of_ne_of_mem hA.ne_empty (mem_powerset_self _)
-  obtain ⟨C, hC, hCA⟩ :=
-    exists_min_image (A.powerset.erase ∅) (fun C ↦ (C * B).card / C.card : _ → ℚ≥0) ⟨A, hA'⟩
+  obtain ⟨C, hC, hCmin⟩ :=
+    exists_min_image (A.powerset.erase ∅) (fun C ↦ #(C * B) / #C : _ → ℚ≥0) ⟨A, hA'⟩
   rw [mem_erase, mem_powerset, ← nonempty_iff_ne_empty] at hC
-  refine (_root_.mul_le_mul_right <| cast_pos.2 hC.1.card_pos).1 ?_
-  norm_cast
-  refine (Nat.cast_le.2 <| ruzsa_triangle_inequality_div_mul_mul _ _ _).trans ?_
-  push_cast
-  rw [mul_comm _ C]
-  refine (mul_le_mul (card_mul_pow_le (mul_aux hC.1 hC.2 hCA) _)
-    (card_mul_pow_le (mul_aux hC.1 hC.2 hCA) _) (zero_le _) (zero_le _)).trans ?_
-  rw [mul_mul_mul_comm, ← pow_add, ← mul_assoc]
-  gcongr ((?_ ^ _) * Nat.cast ?_) * _
-  · exact hCA _ hA'
-  · exact card_le_card hC.2
+  obtain ⟨hC, hCA⟩ := hC
+  refine le_of_mul_le_mul_right ?_ (by positivity : (0 : ℚ≥0) < #C)
+  calc
+    (#(B ^ m / B ^ n) * #C : ℚ≥0)
+      ≤ #(B ^ m * C) * #(B ^ n * C) := mod_cast ruzsa_triangle_inequality_div_mul_mul ..
+    _ = #(C * B ^ m) * #(C * B ^ n) := by simp_rw [mul_comm]
+    _ ≤ ((#(C * B) / #C) ^ m * #C) * ((#(C * B) / #C : ℚ≥0) ^ n * #C) := by
+      gcongr <;> exact card_mul_pow_le (mul_aux hC hCA hCmin) _
+    _ = (#(C * B) / #C) ^ (m + n) * #C * #C := by ring
+    _ ≤ (#(A * B) / #A) ^ (m + n) * #A * #C := by gcongr ((?_ ^ _) * #?_) * _; exact hCmin _ hA'
 
 /-- The **Plünnecke-Ruzsa inequality**. Division version. -/
 @[to_additive "The **Plünnecke-Ruzsa inequality**. Subtraction version."]
-theorem pluennecke_ruzsa_inequality_pow_div_pow_div (hA : A.Nonempty) (B : Finset α) (m n : ℕ) :
-    (B ^ m / B ^ n).card ≤ ((A / B).card / A.card : ℚ≥0) ^ (m + n) * A.card := by
+theorem pluennecke_ruzsa_inequality_pow_div_pow_div (hA : A.Nonempty) (B : Finset G) (m n : ℕ) :
+    #(B ^ m / B ^ n) ≤ (#(A / B) / #A : ℚ≥0) ^ (m + n) * #A := by
   rw [← card_inv, inv_div', ← inv_pow, ← inv_pow, div_eq_mul_inv A]
   exact pluennecke_ruzsa_inequality_pow_div_pow_mul hA _ _ _
 
 /-- Special case of the **Plünnecke-Ruzsa inequality**. Multiplication version. -/
 @[to_additive "Special case of the **Plünnecke-Ruzsa inequality**. Addition version."]
-theorem pluennecke_ruzsa_inequality_pow_mul (hA : A.Nonempty) (B : Finset α) (n : ℕ) :
-    (B ^ n).card ≤ ((A * B).card / A.card : ℚ≥0) ^ n * A.card := by
+theorem pluennecke_ruzsa_inequality_pow_mul (hA : A.Nonempty) (B : Finset G) (n : ℕ) :
+    #(B ^ n) ≤ (#(A * B) / #A : ℚ≥0) ^ n * #A := by
   simpa only [_root_.pow_zero, div_one] using pluennecke_ruzsa_inequality_pow_div_pow_mul hA _ _ 0
 
 /-- Special case of the **Plünnecke-Ruzsa inequality**. Division version. -/
 @[to_additive "Special case of the **Plünnecke-Ruzsa inequality**. Subtraction version."]
-theorem pluennecke_ruzsa_inequality_pow_div (hA : A.Nonempty) (B : Finset α) (n : ℕ) :
-    (B ^ n).card ≤ ((A / B).card / A.card : ℚ≥0) ^ n * A.card := by
+theorem pluennecke_ruzsa_inequality_pow_div (hA : A.Nonempty) (B : Finset G) (n : ℕ) :
+    #(B ^ n) ≤ (#(A / B) / #A : ℚ≥0) ^ n * #A := by
   simpa only [_root_.pow_zero, div_one] using pluennecke_ruzsa_inequality_pow_div_pow_div hA _ _ 0
 
+end CommGroup
 end Finset

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -41,77 +41,81 @@ variable {G : Type*} [DecidableEq G]
 section Group
 variable [Group G] {A B C : Finset G}
 
+/-! ### Noncommutative Ruzsa triangle inequality -/
+
 /-- **Ruzsa's triangle inequality**. Division version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Subtraction version."]
 theorem ruzsa_triangle_inequality_div_div_div (A B C : Finset G) :
-    #(A / C) * #B ≤ #(A / B) * #(B / C) := by
-  rw [← card_product (A / B), ← mul_one #((A / B) ×ˢ (B / C))]
-  refine card_mul_le_card_mul (fun b (a, c) ↦ a * c = b) (fun x hx ↦ ?_)
+    #(A / C) * #B ≤ #(A / B) * #(C / B) := by
+  rw [← card_product (A / B), ← mul_one #((A / B) ×ˢ (C / B))]
+  refine card_mul_le_card_mul (fun b (a, c) ↦ a / c = b) (fun x hx ↦ ?_)
     fun x _ ↦ card_le_one_iff.2 fun hu hv ↦
       ((mem_bipartiteBelow _).1 hu).2.symm.trans ?_
   · obtain ⟨a, ha, c, hc, rfl⟩ := mem_div.1 hx
-    refine card_le_card_of_injOn (fun b ↦ (a / b, b / c)) (fun b hb ↦ ?_) fun b₁ _ b₂ _ h ↦ ?_
+    refine card_le_card_of_injOn (fun b ↦ (a / b, c / b)) (fun b hb ↦ ?_) fun b₁ _ b₂ _ h ↦ ?_
     · rw [mem_bipartiteAbove]
-      exact ⟨mk_mem_product (div_mem_div ha hb) (div_mem_div hb hc), div_mul_div_cancel _ _ _⟩
+      exact ⟨mk_mem_product (div_mem_div ha hb) (div_mem_div hc hb), div_div_div_cancel_right ..⟩
     · exact div_right_injective (Prod.ext_iff.1 h).1
   · exact ((mem_bipartiteBelow _).1 hv).2
 
+/-- **Ruzsa's triangle inequality**. Mulinv-mulinv-mulinv version. -/
+@[to_additive "**Ruzsa's triangle inequality**. Addneg-addneg-addneg version."]
+theorem ruzsa_triangle_inequality_mulInv_mulInv_mulInv (A B C : Finset G) :
+    #(A * C⁻¹) * #B ≤ #(A * B⁻¹) * #(C * B⁻¹) := by
+  simpa [div_eq_mul_inv] using ruzsa_triangle_inequality_div_div_div A B C
+
 /-- **Ruzsa's triangle inequality**. Invmul-invmul-invmul version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Negadd-negadd-negadd version."]
-theorem ruzsa_triangle_inequality_inv_mul_inv_mul_inv_mul (A B C : Finset G) :
-    #(C⁻¹ * A) * #B ≤ #(B⁻¹ * A) * #(C⁻¹ * B) := by
-  simpa [div_eq_mul_inv, ← map_op_mul, ← map_op_inv] using
-    ruzsa_triangle_inequality_div_div_div (G := Gᵐᵒᵖ) (A.map opEquiv.toEmbedding)
-      (B.map opEquiv.toEmbedding) (C.map opEquiv.toEmbedding)
+theorem ruzsa_triangle_inequality_invMul_invMul_invMul (A B C : Finset G) :
+    #B * #(A⁻¹ * C) ≤ #(B⁻¹ * A) * #(B⁻¹ * C) := by
+  simpa [mul_comm, div_eq_mul_inv, ← map_op_mul, ← map_op_inv] using
+    ruzsa_triangle_inequality_div_div_div (G := Gᵐᵒᵖ) (C.map opEquiv.toEmbedding)
+      (B.map opEquiv.toEmbedding) (A.map opEquiv.toEmbedding)
+
 
 /-- **Ruzsa's triangle inequality**. Div-mul-mul version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Sub-add-add version."]
 theorem ruzsa_triangle_inequality_div_mul_mul (A B C : Finset G) :
     #(A / C) * #B ≤ #(A * B) * #(C * B) := by
-  rw [← div_inv_eq_mul, ← card_inv B, ← card_inv (C * B), mul_inv_rev, ← div_eq_mul_inv]
-  exact ruzsa_triangle_inequality_div_div_div _ _ _
+  simpa using ruzsa_triangle_inequality_div_div_div A B⁻¹ C
+
+/-- **Ruzsa's triangle inequality**. Mulinv-mul-mul version. -/
+@[to_additive "**Ruzsa's triangle inequality**. Addneg-add-add version."]
+theorem ruzsa_triangle_inequality_mulInv_mul_mul (A B C : Finset G) :
+    #(A * C⁻¹) * #B ≤ #(A * B) * #(C * B) := by
+  simpa using ruzsa_triangle_inequality_mulInv_mulInv_mulInv A B⁻¹ C
 
 /-- **Ruzsa's triangle inequality**. Invmul-mul-mul version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Negadd-add-add version."]
-theorem ruzsa_triangle_inequality_inv_mul_mul_mul (A B C : Finset G) :
-    #(C⁻¹ * A) * #B ≤ #(B * A) * #(B * C) := by
-  simpa [div_eq_mul_inv, ← map_op_mul, ← map_op_inv] using
-    ruzsa_triangle_inequality_div_mul_mul (G := Gᵐᵒᵖ) (A.map opEquiv.toEmbedding)
-      (B.map opEquiv.toEmbedding) (C.map opEquiv.toEmbedding)
+theorem ruzsa_triangle_inequality_invMul_mul_mul (A B C : Finset G) :
+    #B * #(A⁻¹ * C) ≤ #(B * A) * #(B * C) := by
+  simpa using ruzsa_triangle_inequality_invMul_invMul_invMul A B⁻¹ C
+
 
 /-- **Ruzsa's triangle inequality**. Mul-div-mul version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Add-sub-add version."]
 theorem ruzsa_triangle_inequality_mul_div_mul (A B C : Finset G) :
-    #(A * C) * #B ≤ #(A / B) * #(B * C) := by
-  rw [← div_inv_eq_mul, ← div_inv_eq_mul B]
-  exact ruzsa_triangle_inequality_div_div_div _ _ _
+    #B * #(A * C) ≤ #(B / A) * #(B * C) := by
+  simpa [div_eq_mul_inv] using ruzsa_triangle_inequality_invMul_mul_mul A⁻¹ B C
 
-/-- **Ruzsa's triangle inequality**. Mul-invmul-mul version. -/
-@[to_additive "**Ruzsa's triangle inequality**. Add-negadd-add version."]
-theorem ruzsa_triangle_inequality_mul_inv_mul_mul (A B C : Finset G) :
-    #(C * A) * #B ≤ #(B⁻¹ * A) * #(C * B) := by
-  simpa [div_eq_mul_inv, ← map_op_mul, ← map_op_inv] using
-    ruzsa_triangle_inequality_mul_div_mul (G := Gᵐᵒᵖ) (A.map opEquiv.toEmbedding)
-      (B.map opEquiv.toEmbedding) (C.map opEquiv.toEmbedding)
-
-/-- **Ruzsa's triangle inequality**. Mul-mul-div version. -/
-@[to_additive "**Ruzsa's triangle inequality**. Add-add-sub version."]
-theorem ruzsa_triangle_inequality_mul_mul_div (A B C : Finset G) :
-    #(C * A) * #B ≤ #(B * A) * #(B / C) := by
-  simpa [div_eq_mul_inv] using ruzsa_triangle_inequality_inv_mul_mul_mul A B C⁻¹
+/-- **Ruzsa's triangle inequality**. Mul-mulinv-mul version. -/
+@[to_additive "**Ruzsa's triangle inequality**. Add-addneg-add version."]
+theorem ruzsa_triangle_inequality_mul_mulInv_mul (A B C : Finset G) :
+    #B * #(A * C) ≤ #(B * A⁻¹) * #(B * C) := by
+  simpa [div_eq_mul_inv] using ruzsa_triangle_inequality_mul_div_mul A B C
 
 /-- **Ruzsa's triangle inequality**. Mul-mul-invmul version. -/
 @[to_additive "**Ruzsa's triangle inequality**. Add-add-negadd version."]
-theorem ruzsa_triangle_inequality_mul_mul_inv_mul (A B C : Finset G) :
+theorem ruzsa_triangle_inequality_mul_mul_invMul (A B C : Finset G) :
     #(A * C) * #B ≤ #(A * B) * #(C⁻¹ * B) := by
-  simpa [div_eq_mul_inv, ← map_op_mul, ← map_op_inv] using
-    ruzsa_triangle_inequality_mul_mul_div (G := Gᵐᵒᵖ) (A.map opEquiv.toEmbedding)
-      (B.map opEquiv.toEmbedding) (C.map opEquiv.toEmbedding)
+  simpa using ruzsa_triangle_inequality_mulInv_mul_mul A B C⁻¹
 
 end Group
 
 section CommGroup
 variable [CommGroup G] {A B C : Finset G}
+
+/-! ### Plünnecke-Petridis inequality -/
 
 @[to_additive]
 theorem pluennecke_petridis_inequality_mul (C : Finset G)
@@ -142,8 +146,7 @@ theorem pluennecke_petridis_inequality_mul (C : Finset G)
     card_mul_singleton A' x, add_comm #_, h₀,
     eq_tsub_of_add_eq (card_union_add_card_inter _ _)]
 
-/-! ### Sum triangle inequality -/
-
+/-! ### Commutative Ruzsa triangle inequality -/
 
 -- Auxiliary lemma for Ruzsa's triangle sum inequality, and the Plünnecke-Ruzsa inequality.
 @[to_additive]


### PR DESCRIPTION
The proof works just fine, and the other statements too, up to turning some `*` around. Add supporting lemmas of the form `op '' (s * t) = op '' t * op '' s`. Use the new `#` notation for `Finset.card`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
