### PR TITLE
[Merged by Bors] - chore: import `Tactic.Positivity.Finset` in `Tactic.Positivity`

### DIFF
--- a/Mathlib/Algebra/AddConstMap/Basic.lean
+++ b/Mathlib/Algebra/AddConstMap/Basic.lean
@@ -28,6 +28,8 @@ We use parameters `a` and `b` instead of `1` to accommodate for two use cases:
   including orientation-reversing maps.
 -/
 
+assert_not_exists Finset
+
 open Function Set
 
 /-- A bundled map `f : G → H` such that `f (x + a) = f x + b` for all `x`.

--- a/Mathlib/Algebra/AddConstMap/Equiv.lean
+++ b/Mathlib/Algebra/AddConstMap/Equiv.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.AddConstMap.Basic
 import Mathlib.GroupTheory.Perm.Basic
+
 /-!
 # Equivalences conjugating `(· + a)` to `(· + b)`
 
@@ -13,6 +14,8 @@ to be the type of equivalences such that `∀ x, f (x + a) = f x + b`.
 
 We also define the corresponding typeclass and prove some basic properties.
 -/
+
+assert_not_exists Finset
 
 open Function
 open scoped AddConstMap

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Basic.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Basic.lean
@@ -58,6 +58,7 @@ with a head term (`seq1`) is then transformed to a generalized continued fractio
 numerics, number theory, approximations, fractions
 -/
 
+assert_not_exists Finset
 
 namespace GenContFract
 

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Translations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Translations.lean
@@ -37,6 +37,7 @@ of three sections:
   parts.
 -/
 
+assert_not_exists Finset
 
 namespace GenContFract
 

--- a/Mathlib/Algebra/Order/Archimedean/Basic.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Basic.lean
@@ -29,6 +29,8 @@ number `n` such that `x ≤ n • y`.
 * `ℕ`, `ℤ`, and `ℚ` are archimedean.
 -/
 
+assert_not_exists Finset
+
 open Int Set
 
 variable {α : Type*}

--- a/Mathlib/Algebra/Order/Archimedean/Hom.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Hom.lean
@@ -14,6 +14,8 @@ ordered field. Reciprocally, such an ordered ring homomorphism exists when the c
 conditionally complete.
 -/
 
+assert_not_exists Finset
+
 variable {α β : Type*}
 
 /-- There is at most one ordered ring homomorphism from a linear ordered field to an archimedean

--- a/Mathlib/Algebra/Order/Archimedean/Submonoid.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Submonoid.lean
@@ -22,6 +22,8 @@ submonoid of the ambient group.
   submonoid.
 -/
 
+assert_not_exists Finset
+
 @[to_additive]
 instance SubmonoidClass.instMulArchimedean {M S : Type*} [SetLike S M] [OrderedCommMonoid M]
     [SubmonoidClass S M] [MulArchimedean M] (H : S) : MulArchimedean H := by

--- a/Mathlib/Algebra/Order/Chebyshev.lean
+++ b/Mathlib/Algebra/Order/Chebyshev.lean
@@ -7,8 +7,7 @@ import Mathlib.Algebra.Order.Monovary
 import Mathlib.Algebra.Order.Rearrangement
 import Mathlib.GroupTheory.Perm.Cycle.Basic
 import Mathlib.Tactic.GCongr
-import Mathlib.Tactic.Positivity.Basic
-import Mathlib.Tactic.Positivity.Finset
+import Mathlib.Tactic.Positivity
 
 /-!
 # Chebyshev's sum inequality

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -13,7 +13,7 @@ import Mathlib.Order.GaloisConnection
 import Mathlib.Tactic.Abel
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
-import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Positivity.Basic
 
 /-!
 # Floor and ceil
@@ -53,6 +53,8 @@ many lemmas.
 
 rounding, floor, ceil
 -/
+
+assert_not_exists Finset
 
 open Set
 

--- a/Mathlib/Algebra/Order/Nonneg/Floor.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Floor.lean
@@ -19,6 +19,8 @@ This is used to derive algebraic structures on `ℝ≥0` and `ℚ≥0` automatic
 * `{x : α // 0 ≤ x}` is a `FloorSemiring` if `α` is.
 -/
 
+assert_not_exists Finset
+
 namespace Nonneg
 
 variable {α : Type*}

--- a/Mathlib/Analysis/Analytic/Inverse.lean
+++ b/Mathlib/Analysis/Analytic/Inverse.lean
@@ -5,7 +5,7 @@ Authors: Sébastien Gouëzel
 -/
 import Mathlib.Analysis.Analytic.Composition
 import Mathlib.Analysis.Analytic.Linear
-import Mathlib.Tactic.Positivity.Finset
+import Mathlib.Tactic.Positivity
 
 /-!
 

--- a/Mathlib/Analysis/Complex/AbelLimit.lean
+++ b/Mathlib/Analysis/Complex/AbelLimit.lean
@@ -6,7 +6,7 @@ Authors: Jeremy Tan
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.Analysis.SpecificLimits.Normed
 import Mathlib.Tactic.Peel
-import Mathlib.Tactic.Positivity.Finset
+import Mathlib.Tactic.Positivity
 
 /-!
 # Abel's limit theorem

--- a/Mathlib/Analysis/Normed/Group/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Group/Seminorm.lean
@@ -44,6 +44,7 @@ having a superfluous `add_le'` field in the resulting structure. The same applie
 norm, seminorm
 -/
 
+assert_not_exists Finset
 
 open Set
 

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -10,7 +10,6 @@ import Mathlib.Combinatorics.Enumerative.DoubleCounting
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.Positivity
-import Mathlib.Tactic.Positivity.Finset
 import Mathlib.Tactic.Ring
 
 /-!

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
@@ -10,7 +10,6 @@ import Mathlib.Combinatorics.SimpleGraph.Clique
 import Mathlib.Data.Finset.Sym
 import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.Positivity
-import Mathlib.Tactic.Positivity.Finset
 
 /-!
 # Triangles in graphs

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -85,6 +85,7 @@ context, or if we have `(f : α → ℝ≥0∞) (hf : ∀ x, f x ≠ ∞)`.
 
 -/
 
+assert_not_exists Finset
 
 open Function Set NNReal
 

--- a/Mathlib/Data/Finset/Density.lean
+++ b/Mathlib/Data/Finset/Density.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Order.Field.Rat
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.NNRat.Order
 import Mathlib.Data.Rat.Cast.CharZero
-import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Positivity.Basic
 
 /-!
 # Density of a finite set

--- a/Mathlib/Data/Int/Log.lean
+++ b/Mathlib/Data/Int/Log.lean
@@ -46,6 +46,7 @@ def digits (b : ℕ) (q : ℚ) (n : ℕ) : ℕ :=
 * `Int.neg_log_inv_eq_clog`, `Int.neg_clog_inv_eq_log`: the link between the two definitions.
 -/
 
+assert_not_exists Finset
 
 variable {R : Type*} [LinearOrderedSemifield R] [FloorSemiring R]
 

--- a/Mathlib/Data/Int/WithZero.lean
+++ b/Mathlib/Data/Int/WithZero.lean
@@ -26,6 +26,8 @@ the morphism `WithZeroMultInt.toNNReal`.
 WithZero, multiplicative, nnreal
 -/
 
+assert_not_exists Finset
+
 noncomputable section
 
 open scoped NNReal

--- a/Mathlib/Data/NNRat/Floor.lean
+++ b/Mathlib/Data/NNRat/Floor.lean
@@ -19,6 +19,8 @@ Note that we cannot talk about `Int.fract`, which currently only works for rings
 nnrat, rationals, ℚ≥0, floor
 -/
 
+assert_not_exists Finset
+
 namespace NNRat
 
 instance : FloorSemiring ℚ≥0 where

--- a/Mathlib/Data/NNReal/Star.lean
+++ b/Mathlib/Data/NNReal/Star.lean
@@ -10,6 +10,8 @@ import Mathlib.Data.Real.Star
 # The non-negative real numbers are a `*`-ring, with the trivial `*`-structure
 -/
 
+assert_not_exists Finset
+
 open scoped NNReal
 
 instance : StarRing ℝ≥0 := starRingOfComm

--- a/Mathlib/Data/Rat/Floor.lean
+++ b/Mathlib/Data/Rat/Floor.lean
@@ -21,6 +21,7 @@ division and modulo arithmetic are derived as well as some simple inequalities.
 rat, rationals, ℚ, floor
 -/
 
+assert_not_exists Finset
 
 open Int
 

--- a/Mathlib/Data/Real/Archimedean.lean
+++ b/Mathlib/Data/Real/Archimedean.lean
@@ -14,6 +14,8 @@ import Mathlib.Order.Interval.Set.Disjoint
 
 -/
 
+assert_not_exists Finset
+
 open scoped Classical
 open Pointwise CauSeq
 

--- a/Mathlib/Data/Real/ENatENNReal.lean
+++ b/Mathlib/Data/Real/ENatENNReal.lean
@@ -12,6 +12,7 @@ import Mathlib.Data.ENNReal.Basic
 In this file we define a coercion from `ℕ∞` to `ℝ≥0∞` and prove some basic lemmas about this map.
 -/
 
+assert_not_exists Finset
 
 open scoped Classical
 open NNReal ENNReal

--- a/Mathlib/Data/Real/Pointwise.lean
+++ b/Mathlib/Data/Real/Pointwise.lean
@@ -22,6 +22,7 @@ This is true more generally for conditionally complete linear order whose defaul
 don't have those yet.
 -/
 
+assert_not_exists Finset
 
 open Set
 

--- a/Mathlib/GroupTheory/Archimedean.lean
+++ b/Mathlib/GroupTheory/Archimedean.lean
@@ -31,6 +31,8 @@ The result is also used in `Topology.Instances.Real` as an ingredient in the cla
 subgroups of `ℝ`.
 -/
 
+assert_not_exists Finset
+
 open Set
 variable {G : Type*} [LinearOrderedCommGroup G] [MulArchimedean G]
 

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -6,7 +6,7 @@ Authors: Joseph Myers
 import Mathlib.Algebra.Order.Module.Algebra
 import Mathlib.LinearAlgebra.LinearIndependent
 import Mathlib.Algebra.Ring.Subring.Units
-import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Positivity.Basic
 
 /-!
 # Rays in modules

--- a/Mathlib/NumberTheory/Harmonic/Defs.lean
+++ b/Mathlib/NumberTheory/Harmonic/Defs.lean
@@ -5,7 +5,7 @@ Authors: Koundinya Vajjha, Thomas Browning
 -/
 import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Algebra.Order.Field.Basic
-import Mathlib.Tactic.Positivity.Finset
+import Mathlib.Tactic.Positivity
 
 /-!
 

--- a/Mathlib/Tactic/Positivity.lean
+++ b/Mathlib/Tactic/Positivity.lean
@@ -1,3 +1,4 @@
 import Mathlib.Tactic.Positivity.Basic
+import Mathlib.Tactic.Positivity.Finset
 import Mathlib.Tactic.NormNum.Basic
 import Mathlib.Data.Int.Order.Basic

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -1,10 +1,10 @@
+import Mathlib.Tactic.Positivity
 import Mathlib.Data.Complex.Exponential
 import Mathlib.Data.Real.Sqrt
 import Mathlib.Analysis.Normed.Group.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.MeasureTheory.Integral.Bochner
-import Mathlib.Tactic.Positivity.Finset
 
 /-! # Tests for the `positivity` tactic
 


### PR DESCRIPTION
I keep on getting bitten by the missing import.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
