### PR TITLE
[Merged by Bors] - golf(Wiedijk/InverseTriangleSum): cleanup

### DIFF
--- a/Archive/Wiedijk100Theorems/InverseTriangleSum.lean
+++ b/Archive/Wiedijk100Theorems/InverseTriangleSum.lean
@@ -27,8 +27,8 @@ open Finset
 /-- **Sum of the Reciprocals of the Triangular Numbers** -/
 theorem Theorems100.inverse_triangle_sum :
     ∀ n, ∑ k ∈ range n, (2 : ℚ) / (k * (k + 1)) = if n = 0 then 0 else 2 - (2 : ℚ) / n := by
-  refine sum_range_induction _ _ (if_pos rfl) ?_
-  rintro (_ | n)
-  · rw [if_neg, if_pos] <;> norm_num
+  refine sum_range_induction _ _ rfl ?_
+  rintro (_ | _)
+  · norm_num
   field_simp
   ring


### PR DESCRIPTION
After #18100, the `is_pos` and `is_neg` cases don't need to be separate any more, and `n` is not referenced explicitly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
