### PR TITLE
[Merged by Bors] - feat(Algebra/Category/ModuleCat/Presheaf): epi and mono in the category of presheaves of modules

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -114,6 +114,7 @@ import Mathlib.Algebra.Category.ModuleCat.Presheaf
 import Mathlib.Algebra.Category.ModuleCat.Presheaf.Abelian
 import Mathlib.Algebra.Category.ModuleCat.Presheaf.ChangeOfRings
 import Mathlib.Algebra.Category.ModuleCat.Presheaf.Colimits
+import Mathlib.Algebra.Category.ModuleCat.Presheaf.EpiMono
 import Mathlib.Algebra.Category.ModuleCat.Presheaf.Free
 import Mathlib.Algebra.Category.ModuleCat.Presheaf.Limits
 import Mathlib.Algebra.Category.ModuleCat.Presheaf.Pushforward

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/EpiMono.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/EpiMono.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import Mathlib.Algebra.Category.ModuleCat.Presheaf.Abelian
+
+/-!
+# Epimorphisms and monomorphisms in the category of presheaves of modules
+
+In this file, we give characterizations of epimorphisms and monomorphisms
+in the category of presheaves of modules.
+
+-/
+
+universe v v₁ u₁ u
+
+open CategoryTheory
+
+namespace PresheafOfModules
+
+variable {C : Type u₁} [Category.{v₁} C] {R : Cᵒᵖ ⥤ RingCat.{u}}
+  {M₁ M₂ : PresheafOfModules.{v} R} {f : M₁ ⟶ M₂}
+
+lemma epi_of_surjective (hf : ∀ ⦃X : Cᵒᵖ⦄, Function.Surjective (f.app X)) : Epi f where
+  left_cancellation g₁ g₂ hg := by
+    ext X m₂
+    obtain ⟨m₁, rfl⟩ := hf m₂
+    exact congr_fun ((evaluation R X ⋙ forget _).congr_map hg) m₁
+
+lemma mono_of_injective (hf : ∀ ⦃X : Cᵒᵖ⦄, Function.Injective (f.app X)) : Mono f where
+  right_cancellation {M} g₁ g₂ hg := by
+    ext X m
+    exact hf (congr_fun ((evaluation R X ⋙ forget _).congr_map hg) m)
+
+variable (f)
+
+instance [Epi f] (X : Cᵒᵖ) : Epi (f.app X) :=
+  inferInstanceAs (Epi ((evaluation R X).map f))
+
+instance [Mono f] (X : Cᵒᵖ) : Mono (f.app X) :=
+  inferInstanceAs (Mono ((evaluation R X).map f))
+
+lemma surjective_of_epi [Epi f] (X : Cᵒᵖ) :
+    Function.Surjective (f.app X) := by
+  rw [← ModuleCat.epi_iff_surjective]
+  infer_instance
+
+lemma injective_of_mono [Mono f] (X : Cᵒᵖ) :
+    Function.Injective (f.app X) := by
+  rw [← ModuleCat.mono_iff_injective]
+  infer_instance
+
+lemma epi_iff_surjective :
+    Epi f ↔ ∀ ⦃X : Cᵒᵖ⦄, Function.Surjective (f.app X) :=
+  ⟨fun _ ↦ surjective_of_epi f, epi_of_surjective⟩
+
+lemma mono_iff_surjective :
+    Mono f ↔ ∀ ⦃X : Cᵒᵖ⦄, Function.Injective (f.app X) :=
+  ⟨fun _ ↦ injective_of_mono f, mono_of_injective⟩
+
+end PresheafOfModules

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/EpiMono.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/EpiMono.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 
-import Mathlib.Algebra.Category.ModuleCat.Presheaf.Abelian
+import Mathlib.Algebra.Category.ModuleCat.Presheaf.Colimits
+import Mathlib.Algebra.Category.ModuleCat.Presheaf.Limits
 
 /-!
 # Epimorphisms and monomorphisms in the category of presheaves of modules


### PR DESCRIPTION
In the category of presheaves of modules, epi and mono can be characterized in terms of surjective/injective maps.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
