### PR TITLE
[Merged by Bors] - feat: another composition of `ContinuousOn` and `Continuous`

### DIFF
--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -862,8 +862,8 @@ theorem ContinuousOn.comp_continuous {g : β → γ} {f : α → β} {s : Set β
   exact hg.comp hf fun x _ => hs x
 
 theorem ContinuousOn.image_comp_continuous {g : β → γ} {f : α → β} {s : Set α}
-    (conton : ContinuousOn g (f '' s)) (cont : Continuous f) : ContinuousOn (g ∘ f) s :=
-  conton.comp cont.continuousOn (s.mapsTo_image f)
+    (hg : ContinuousOn g (f '' s)) (hf : Continuous f) : ContinuousOn (g ∘ f) s :=
+  hg.comp hf.continuousOn (s.mapsTo_image f)
 
 theorem ContinuousAt.comp₂_continuousWithinAt {f : β × γ → δ} {g : α → β} {h : α → γ} {x : α}
     {s : Set α} (hf : ContinuousAt f (g x, h x)) (hg : ContinuousWithinAt g s x)

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -861,6 +861,10 @@ theorem ContinuousOn.comp_continuous {g : β → γ} {f : α → β} {s : Set β
   rw [continuous_iff_continuousOn_univ] at *
   exact hg.comp hf fun x _ => hs x
 
+theorem ContinuousOn.image_comp_continuous {g : β → γ} {f : α → β} {s : Set α}
+    (conton : ContinuousOn g (f '' s)) (cont : Continuous f) : ContinuousOn (g ∘ f) s :=
+  conton.comp cont.continuousOn (s.mapsTo_image f)
+
 theorem ContinuousAt.comp₂_continuousWithinAt {f : β × γ → δ} {g : α → β} {h : α → γ} {x : α}
     {s : Set α} (hf : ContinuousAt f (g x, h x)) (hg : ContinuousWithinAt g s x)
     (hh : ContinuousWithinAt h s x) :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
