### PR TITLE
[Merged by Bors] - feat(LSeries/RiemannZeta): versions of the residue computation of the zeta function with tsum and for a real variable

### DIFF
--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -203,7 +203,7 @@ lemma riemannZeta_residue_one : Tendsto (fun s ↦ (s - 1) * riemannZeta s) (�
   exact hurwitzZetaEven_residue_one 0
 
 /-- The residue of `ζ(s)` at `s = 1` is equal to 1, expressed using `tsum`. -/
-theorem riemannZeta_residue_one' :
+theorem tendsto_sub_mul_tsum_nat_cpow :
     Tendsto (fun s : ℂ ↦ (s - 1) * ∑' (n : ℕ), 1 / (n : ℂ) ^ s) (𝓝[{s | 1 < re s}] 1) (𝓝 1) := by
   refine (tendsto_nhdsWithin_mono_left ?_ riemannZeta_residue_one).congr' ?_
   · simp only [subset_compl_singleton_iff, mem_setOf_eq, one_re, not_lt, le_refl]
@@ -212,12 +212,12 @@ theorem riemannZeta_residue_one' :
 
 /-- The residue of `ζ(s)` at `s = 1` is equal to 1 expressed using `tsum` and for a
 real variable. -/
-theorem riemannZeta_residue_one'' :
+theorem tendsto_sub_mul_tsum_nat_rpow :
     Tendsto (fun s : ℝ ↦ (s - 1) * ∑' (n : ℕ), 1 / (n : ℝ) ^ s) (𝓝[>] 1) (𝓝 1) := by
   rw [← tendsto_ofReal_iff, ofReal_one]
   have : Tendsto (fun s : ℝ ↦ (s : ℂ)) (𝓝[>] 1) (𝓝[{s | 1 < re s}] 1) :=
     continuous_ofReal.continuousWithinAt.tendsto_nhdsWithin (fun _ _ ↦ by aesop)
-  apply (riemannZeta_residue_one'.comp this).congr fun s ↦ ?_
+  apply (tendsto_sub_mul_tsum_nat_cpow.comp this).congr fun s ↦ ?_
   simp only [one_div, Function.comp_apply, ofReal_mul, ofReal_sub, ofReal_one, ofReal_tsum,
     ofReal_inv, ofReal_cpow (Nat.cast_nonneg _), ofReal_natCast]
 

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -202,6 +202,19 @@ theorem zeta_nat_eq_tsum_of_gt_one {k : ℕ} (hk : 1 < k) :
 lemma riemannZeta_residue_one : Tendsto (fun s ↦ (s - 1) * riemannZeta s) (𝓝[≠] 1) (𝓝 1) := by
   exact hurwitzZetaEven_residue_one 0
 
+/-- The residue of `ζ(s)` at `s = 1` is equal to 1 expressed using `tsum` and for a
+real variable. -/
+theorem riemannZeta_residue_one' :
+    Tendsto (fun s : ℝ ↦ (s - 1) * ∑' (n : ℕ), 1 / (n : ℝ) ^ s) (𝓝[>] 1) (𝓝 1) := by
+  rw [← tendsto_ofReal_iff, ofReal_one]
+  have : Tendsto (fun s : ℝ ↦ (s : ℂ)) (𝓝[>] 1) (𝓝[≠] 1) :=
+    continuous_ofReal.continuousWithinAt.tendsto_nhdsWithin (fun _ _ ↦ by aesop)
+  refine Tendsto.congr' ?_ (riemannZeta_residue_one.comp this)
+  filter_upwards [eventually_mem_nhdsWithin] with _ _
+  simp_rw [Function.comp_apply, zeta_eq_tsum_one_div_nat_cpow (by rwa [ofReal_re]),
+    ofReal_mul, ofReal_tsum, ofReal_sub, ofReal_one, one_div, ofReal_inv,
+    ofReal_cpow ( Nat.cast_nonneg _), ofReal_natCast]
+
 /- naming scheme was changed from `riemannCompletedZeta` to `completedRiemannZeta`; add
 aliases for the old names -/
 section aliases

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -202,18 +202,24 @@ theorem zeta_nat_eq_tsum_of_gt_one {k : ℕ} (hk : 1 < k) :
 lemma riemannZeta_residue_one : Tendsto (fun s ↦ (s - 1) * riemannZeta s) (𝓝[≠] 1) (𝓝 1) := by
   exact hurwitzZetaEven_residue_one 0
 
+/-- The residue of `ζ(s)` at `s = 1` is equal to 1, expressed using `tsum`. -/
+theorem riemannZeta_residue_one' :
+    Tendsto (fun s : ℂ ↦ (s - 1) * ∑' (n : ℕ), 1 / (n : ℂ) ^ s) (𝓝[{s | 1 < re s}] 1) (𝓝 1) := by
+  refine (tendsto_nhdsWithin_mono_left ?_ riemannZeta_residue_one).congr' ?_
+  · simp only [subset_compl_singleton_iff, mem_setOf_eq, one_re, not_lt, le_refl]
+  · filter_upwards [eventually_mem_nhdsWithin] with s hs using
+      congr_arg _ <| zeta_eq_tsum_one_div_nat_cpow hs
+
 /-- The residue of `ζ(s)` at `s = 1` is equal to 1 expressed using `tsum` and for a
 real variable. -/
-theorem riemannZeta_residue_one' :
+theorem riemannZeta_residue_one'' :
     Tendsto (fun s : ℝ ↦ (s - 1) * ∑' (n : ℕ), 1 / (n : ℝ) ^ s) (𝓝[>] 1) (𝓝 1) := by
   rw [← tendsto_ofReal_iff, ofReal_one]
-  have : Tendsto (fun s : ℝ ↦ (s : ℂ)) (𝓝[>] 1) (𝓝[≠] 1) :=
+  have : Tendsto (fun s : ℝ ↦ (s : ℂ)) (𝓝[>] 1) (𝓝[{s | 1 < re s}] 1) :=
     continuous_ofReal.continuousWithinAt.tendsto_nhdsWithin (fun _ _ ↦ by aesop)
-  refine Tendsto.congr' ?_ (riemannZeta_residue_one.comp this)
-  filter_upwards [eventually_mem_nhdsWithin] with _ _
-  simp_rw [Function.comp_apply, zeta_eq_tsum_one_div_nat_cpow (by rwa [ofReal_re]),
-    ofReal_mul, ofReal_tsum, ofReal_sub, ofReal_one, one_div, ofReal_inv,
-    ofReal_cpow ( Nat.cast_nonneg _), ofReal_natCast]
+  apply (riemannZeta_residue_one'.comp this).congr fun s ↦ ?_
+  simp only [one_div, Function.comp_apply, ofReal_mul, ofReal_sub, ofReal_one, ofReal_tsum,
+    ofReal_inv, ofReal_cpow (Nat.cast_nonneg _), ofReal_natCast]
 
 /- naming scheme was changed from `riemannCompletedZeta` to `completedRiemannZeta`; add
 aliases for the old names -/


### PR DESCRIPTION
The proof of:
```
Tendsto (fun s : ℝ ↦ (s - 1) * ∑' (n : ℕ), 1 / (n : ℝ) ^ s) (𝓝[>] 1) (𝓝 1)
```
using the existing result for the complex variable. 

This PR is part of the proof of the Analytic Class Number Formula.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
