### PR TITLE
[Merged by Bors] - chore(Algebra/Module): split `Defs` a bit further

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -478,8 +478,10 @@ import Mathlib.Algebra.Module.Card
 import Mathlib.Algebra.Module.CharacterModule
 import Mathlib.Algebra.Module.DedekindDomain
 import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.Module.End
 import Mathlib.Algebra.Module.Equiv.Basic
 import Mathlib.Algebra.Module.Equiv.Defs
+import Mathlib.Algebra.Module.Equiv.Opposite
 import Mathlib.Algebra.Module.FinitePresentation
 import Mathlib.Algebra.Module.GradedModule
 import Mathlib.Algebra.Module.Hom
@@ -494,7 +496,7 @@ import Mathlib.Algebra.Module.LinearMap.Star
 import Mathlib.Algebra.Module.LocalizedModule
 import Mathlib.Algebra.Module.LocalizedModuleIntegers
 import Mathlib.Algebra.Module.MinimalAxioms
-import Mathlib.Algebra.Module.Opposites
+import Mathlib.Algebra.Module.Opposite
 import Mathlib.Algebra.Module.PID
 import Mathlib.Algebra.Module.Pi
 import Mathlib.Algebra.Module.PointwisePi

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -8,7 +8,7 @@ import Mathlib.Algebra.Algebra.Equiv
 import Mathlib.Algebra.Algebra.Opposite
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
-import Mathlib.Algebra.Module.Opposites
+import Mathlib.Algebra.Module.Opposite
 import Mathlib.Algebra.Module.Submodule.Bilinear
 import Mathlib.Algebra.Module.Submodule.Pointwise
 import Mathlib.Algebra.Order.Kleene

--- a/Mathlib/Algebra/Algebra/Opposite.lean
+++ b/Mathlib/Algebra/Algebra/Opposite.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Algebra.Equiv
-import Mathlib.Algebra.Module.Opposites
+import Mathlib.Algebra.Module.Opposite
 import Mathlib.Algebra.Ring.Opposite
 
 /-!

--- a/Mathlib/Algebra/Algebra/Rat.lean
+++ b/Mathlib/Algebra/Algebra/Rat.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau, Yury Kudryashov
 -/
 import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.GroupWithZero.Action.Basic
+import Mathlib.Algebra.Module.End
 import Mathlib.Data.Rat.Cast.CharZero
 
 /-!

--- a/Mathlib/Algebra/Group/Submonoid/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Pointwise.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
+import Mathlib.Algebra.Group.Hom.End
 import Mathlib.Algebra.Group.Submonoid.Membership
 import Mathlib.Algebra.Order.BigOperators.Group.List
 import Mathlib.Data.Set.Pointwise.SMul

--- a/Mathlib/Algebra/Module/Basic.lean
+++ b/Mathlib/Algebra/Module/Basic.lean
@@ -23,6 +23,12 @@ universe u v
 
 variable {α R M M₂ : Type*}
 
+@[simp]
+theorem invOf_two_smul_add_invOf_two_smul (R) [Semiring R] [AddCommMonoid M] [Module R M]
+    [Invertible (2 : R)] (x : M) :
+    (⅟ 2 : R) • x + (⅟ 2 : R) • x = x :=
+  Convex.combo_self invOf_two_add_invOf_two _
+
 @[deprecated (since := "2024-04-17")]
 alias map_nat_cast_smul := map_natCast_smul
 

--- a/Mathlib/Algebra/Module/Defs.lean
+++ b/Mathlib/Algebra/Module/Defs.lean
@@ -3,10 +3,6 @@ Copyright (c) 2015 Nathaniel Thomas. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
 -/
-import Mathlib.Algebra.Group.Hom.End
-import Mathlib.Algebra.GroupWithZero.Action.Units
-import Mathlib.Algebra.Ring.Invertible
-import Mathlib.Algebra.Ring.Opposite
 import Mathlib.Algebra.SMulWithZero
 import Mathlib.Data.Int.Cast.Lemmas
 
@@ -37,10 +33,11 @@ to use a canonical `Module` typeclass throughout.
 semimodule, module, vector space
 -/
 
-assert_not_exists Multiset
-assert_not_exists Set.indicator
-assert_not_exists Pi.single_smul₀
 assert_not_exists Field
+assert_not_exists Invertible
+assert_not_exists Multiset
+assert_not_exists Pi.single_smul₀
+assert_not_exists Set.indicator
 
 open Function Set
 
@@ -81,10 +78,6 @@ instance AddCommGroup.toNatModule : Module ℕ M where
   zero_smul := zero_nsmul
   add_smul r s x := add_nsmul x r s
 
-theorem AddMonoid.End.natCast_def (n : ℕ) :
-    (↑n : AddMonoid.End M) = DistribMulAction.toAddMonoidEnd ℕ M n :=
-  rfl
-
 theorem add_smul : (r + s) • x = r • x + s • x :=
   Module.add_smul r s x
 
@@ -95,11 +88,6 @@ variable (R)
 
 -- Porting note: this is the letter of the mathlib3 version, but not really the spirit
 theorem two_smul : (2 : R) • x = x + x := by rw [← one_add_one_eq_two, add_smul, one_smul]
-
-@[simp]
-theorem invOf_two_smul_add_invOf_two_smul [Invertible (2 : R)] (x : M) :
-    (⅟ 2 : R) • x + (⅟ 2 : R) • x = x :=
-  Convex.combo_self invOf_two_add_invOf_two _
 
 /-- Pullback a `Module` structure along an injective additive monoid homomorphism.
 See note [reducible non-instances]. -/
@@ -145,32 +133,7 @@ abbrev Module.compHom [Semiring S] (f : S →+* R) : Module S M :=
     -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Heterogeneous.20scalar.20multiplication
     add_smul := fun r s x => show f (r + s) • x = f r • x + f s • x by simp [add_smul] }
 
-variable (R)
-
-/-- `(•)` as an `AddMonoidHom`.
-
-This is a stronger version of `DistribMulAction.toAddMonoidEnd` -/
-@[simps! apply_apply]
-def Module.toAddMonoidEnd : R →+* AddMonoid.End M :=
-  { DistribMulAction.toAddMonoidEnd R M with
-    -- Porting note: the two `show`s weren't needed in mathlib3.
-    -- Somehow, now that `SMul` is heterogeneous, it can't unfold earlier fields of a definition for
-    -- use in later fields.  See
-    -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Heterogeneous.20scalar.20multiplication
-    map_zero' := AddMonoidHom.ext fun r => show (0 : R) • r = 0 by simp
-    map_add' := fun x y =>
-      AddMonoidHom.ext fun r => show (x + y) • r = x • r + y • r by simp [add_smul] }
-
-/-- A convenience alias for `Module.toAddMonoidEnd` as an `AddMonoidHom`, usually to allow the
-use of `AddMonoidHom.flip`. -/
-def smulAddHom : R →+ M →+ M :=
-  (Module.toAddMonoidEnd R M).toAddMonoidHom
-
-variable {R M}
-
-@[simp]
-theorem smulAddHom_apply (r : R) (x : M) : smulAddHom R M r x = r • x :=
-  rfl
+variable {M}
 
 theorem Module.eq_zero_of_zero_eq_one (zero_eq_one : (0 : R) = 1) : x = 0 := by
   rw [← one_smul R x, ← zero_eq_one, zero_smul]
@@ -193,10 +156,6 @@ instance AddCommGroup.toIntModule : Module ℤ M where
   smul_zero := zsmul_zero
   zero_smul := zero_zsmul
   add_smul r s x := add_zsmul x r s
-
-theorem AddMonoid.End.intCast_def (z : ℤ) :
-    (↑z : AddMonoid.End M) = DistribMulAction.toAddMonoidEnd ℤ M z :=
-  rfl
 
 variable {R M}
 
@@ -281,13 +240,6 @@ instance (priority := 910) Semiring.toModule [Semiring R] : Module R R where
   zero_smul := zero_mul
   smul_zero := mul_zero
 
--- see Note [lower instance priority]
-/-- Like `Semiring.toModule`, but multiplies on the right. -/
-instance (priority := 910) Semiring.toOppositeModule [Semiring R] : Module Rᵐᵒᵖ R :=
-  { MonoidWithZero.toOppositeMulActionWithZero R with
-    smul_add := fun _ _ _ => add_mul _ _ _
-    add_smul := fun _ _ _ => mul_add _ _ _ }
-
 /-- A ring homomorphism `f : R →+* M` defines a module structure by `r • x = f r * x`. -/
 def RingHom.toModule [Semiring R] [Semiring S] (f : R →+* S) : Module R S :=
   Module.compHom S f
@@ -358,55 +310,10 @@ instance AddCommMonoid.nat_isScalarTower : IsScalarTower ℕ R M where
 
 end AddCommMonoid
 
-section AddCommGroup
-
-variable [Ring R] [AddCommGroup M] [Module R M]
-
-section
-
-variable (R)
-
-/-- `zsmul` is equal to any other module structure via a cast. -/
-lemma Int.cast_smul_eq_zsmul (n : ℤ) (b : M) : (n : R) • b = n • b :=
-  have : ((smulAddHom R M).flip b).comp (Int.castAddHom R) = (smulAddHom ℤ M).flip b := by
-    apply AddMonoidHom.ext_int
-    simp
-  DFunLike.congr_fun this n
-
-@[deprecated (since := "2024-07-23")] alias intCast_smul := Int.cast_smul_eq_zsmul
-
-/-- `zsmul` is equal to any other module structure via a cast. -/
-@[deprecated Int.cast_smul_eq_zsmul (since := "2024-07-23")]
-theorem zsmul_eq_smul_cast (n : ℤ) (b : M) : n • b = (n : R) • b := (Int.cast_smul_eq_zsmul ..).symm
-
-end
-
-/-- Convert back any exotic `ℤ`-smul to the canonical instance. This should not be needed since in
-mathlib all `AddCommGroup`s should normally have exactly one `ℤ`-module structure by design. -/
-theorem int_smul_eq_zsmul (h : Module ℤ M) (n : ℤ) (x : M) : @SMul.smul ℤ M h.toSMul n x = n • x :=
-  Int.cast_smul_eq_zsmul ..
-
-/-- All `ℤ`-module structures are equal. Not an instance since in mathlib all `AddCommGroup`
-should normally have exactly one `ℤ`-module structure by design. -/
-def AddCommGroup.uniqueIntModule : Unique (Module ℤ M) where
-  default := by infer_instance
-  uniq P := (Module.ext' P _) fun n => by convert int_smul_eq_zsmul P n
-
-end AddCommGroup
-
-theorem map_intCast_smul [AddCommGroup M] [AddCommGroup M₂] {F : Type*} [FunLike F M M₂]
-    [AddMonoidHomClass F M M₂] (f : F) (R S : Type*) [Ring R] [Ring S] [Module R M] [Module S M₂]
-    (x : ℤ) (a : M) :
-    f ((x : R) • a) = (x : S) • f a := by simp only [Int.cast_smul_eq_zsmul, map_zsmul]
-
 theorem map_natCast_smul [AddCommMonoid M] [AddCommMonoid M₂] {F : Type*} [FunLike F M M₂]
     [AddMonoidHomClass F M M₂] (f : F) (R S : Type*) [Semiring R] [Semiring S] [Module R M]
     [Module S M₂] (x : ℕ) (a : M) : f ((x : R) • a) = (x : S) • f a := by
   simp only [Nat.cast_smul_eq_nsmul, AddMonoidHom.map_nsmul, map_nsmul]
-
-instance AddCommGroup.intIsScalarTower {R : Type u} {M : Type v} [Ring R] [AddCommGroup M]
-    [Module R M] : IsScalarTower ℤ R M where
-  smul_assoc n x y := ((smulAddHom R M).flip y).map_zsmul x n
 
 -- Porting note (#10618): simp can prove this
 --@[simp]

--- a/Mathlib/Algebra/Module/End.lean
+++ b/Mathlib/Algebra/Module/End.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2015 Nathaniel Thomas. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
+-/
+import Mathlib.Algebra.Group.Hom.End
+import Mathlib.Algebra.Module.Defs
+
+/-!
+# Module structure and endomorphisms
+
+In this file, we define `Module.toAddMonoidEnd`, which is `(•)` as a monoid homomorphism.
+We use this to prove some results on scalar multiplication by integers.
+-/
+
+assert_not_exists Multiset
+assert_not_exists Set.indicator
+assert_not_exists Pi.single_smul₀
+assert_not_exists Field
+
+open Function Set
+
+universe u v
+
+variable {R S M M₂ : Type*}
+
+section AddCommMonoid
+
+variable [Semiring R] [AddCommMonoid M] [Module R M] (r s : R) (x : M)
+
+theorem AddMonoid.End.natCast_def (n : ℕ) :
+    (↑n : AddMonoid.End M) = DistribMulAction.toAddMonoidEnd ℕ M n :=
+  rfl
+
+variable (R M)
+
+/-- `(•)` as an `AddMonoidHom`.
+
+This is a stronger version of `DistribMulAction.toAddMonoidEnd` -/
+@[simps! apply_apply]
+def Module.toAddMonoidEnd : R →+* AddMonoid.End M :=
+  { DistribMulAction.toAddMonoidEnd R M with
+    -- Porting note: the two `show`s weren't needed in mathlib3.
+    -- Somehow, now that `SMul` is heterogeneous, it can't unfold earlier fields of a definition for
+    -- use in later fields.  See
+    -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Heterogeneous.20scalar.20multiplication
+    map_zero' := AddMonoidHom.ext fun r => show (0 : R) • r = 0 by simp
+    map_add' := fun x y =>
+      AddMonoidHom.ext fun r => show (x + y) • r = x • r + y • r by simp [add_smul] }
+
+/-- A convenience alias for `Module.toAddMonoidEnd` as an `AddMonoidHom`, usually to allow the
+use of `AddMonoidHom.flip`. -/
+def smulAddHom : R →+ M →+ M :=
+  (Module.toAddMonoidEnd R M).toAddMonoidHom
+
+variable {R M}
+
+@[simp]
+theorem smulAddHom_apply (r : R) (x : M) : smulAddHom R M r x = r • x :=
+  rfl
+
+end AddCommMonoid
+
+section AddCommGroup
+
+variable (R M) [Semiring R] [AddCommGroup M]
+
+theorem AddMonoid.End.intCast_def (z : ℤ) :
+    (↑z : AddMonoid.End M) = DistribMulAction.toAddMonoidEnd ℤ M z :=
+  rfl
+
+end AddCommGroup
+
+section AddCommGroup
+
+variable [Ring R] [AddCommGroup M] [Module R M]
+
+section
+
+variable (R)
+
+/-- `zsmul` is equal to any other module structure via a cast. -/
+lemma Int.cast_smul_eq_zsmul (n : ℤ) (b : M) : (n : R) • b = n • b :=
+  have : ((smulAddHom R M).flip b).comp (Int.castAddHom R) = (smulAddHom ℤ M).flip b := by
+    apply AddMonoidHom.ext_int
+    simp
+  DFunLike.congr_fun this n
+
+@[deprecated (since := "2024-07-23")] alias intCast_smul := Int.cast_smul_eq_zsmul
+
+/-- `zsmul` is equal to any other module structure via a cast. -/
+@[deprecated Int.cast_smul_eq_zsmul (since := "2024-07-23")]
+theorem zsmul_eq_smul_cast (n : ℤ) (b : M) : n • b = (n : R) • b := (Int.cast_smul_eq_zsmul ..).symm
+
+end
+
+/-- Convert back any exotic `ℤ`-smul to the canonical instance. This should not be needed since in
+mathlib all `AddCommGroup`s should normally have exactly one `ℤ`-module structure by design. -/
+theorem int_smul_eq_zsmul (h : Module ℤ M) (n : ℤ) (x : M) : @SMul.smul ℤ M h.toSMul n x = n • x :=
+  Int.cast_smul_eq_zsmul ..
+
+/-- All `ℤ`-module structures are equal. Not an instance since in mathlib all `AddCommGroup`
+should normally have exactly one `ℤ`-module structure by design. -/
+def AddCommGroup.uniqueIntModule : Unique (Module ℤ M) where
+  default := by infer_instance
+  uniq P := (Module.ext' P _) fun n => by convert int_smul_eq_zsmul P n
+
+end AddCommGroup
+
+theorem map_intCast_smul [AddCommGroup M] [AddCommGroup M₂] {F : Type*} [FunLike F M M₂]
+    [AddMonoidHomClass F M M₂] (f : F) (R S : Type*) [Ring R] [Ring S] [Module R M] [Module S M₂]
+    (x : ℤ) (a : M) :
+    f ((x : R) • a) = (x : S) • f a := by simp only [Int.cast_smul_eq_zsmul, map_zsmul]
+
+instance AddCommGroup.intIsScalarTower {R : Type u} {M : Type v} [Ring R] [AddCommGroup M]
+    [Module R M] : IsScalarTower ℤ R M where
+  smul_assoc n x y := ((smulAddHom R M).flip y).map_zsmul x n

--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -6,6 +6,7 @@ Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro, Anne 
 -/
 import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.GroupWithZero.Action.Basic
+import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.Module.Equiv.Defs
 import Mathlib.Algebra.Module.Hom
 import Mathlib.Algebra.Module.LinearMap.End

--- a/Mathlib/Algebra/Module/Equiv/Opposite.lean
+++ b/Mathlib/Algebra/Module/Equiv/Opposite.lean
@@ -3,8 +3,8 @@ Copyright (c) 2020 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Algebra.GroupWithZero.Action.Opposite
 import Mathlib.Algebra.Module.Equiv.Defs
+import Mathlib.Algebra.Module.Opposite
 
 /-!
 # Module operations on `Mᵐᵒᵖ`
@@ -13,17 +13,29 @@ This file contains definitions that build on top of the group action definitions
 `Mathlib.Algebra.GroupWithZero.Action.Opposite`.
 -/
 
+section
+
+variable {R S M : Type*} [Semiring R] [Semiring S] [AddCommMonoid M] [Module S M]
+
+@[ext high]
+theorem LinearMap.ext_ring_op
+    {σ : Rᵐᵒᵖ →+* S} {f g : R →ₛₗ[σ] M} (h : f (1 : R) = g (1 : R)) :
+    f = g :=
+  ext fun x ↦ by
+    -- Porting note: replaced the oneliner `rw` proof with a partially term-mode proof
+    -- because `rw` was giving "motive is type incorrect" errors
+    rw [← one_mul x, ← op_smul_eq_mul]
+    refine (f.map_smulₛₗ (MulOpposite.op x) 1).trans ?_
+    rw [h]
+    exact (g.map_smulₛₗ (MulOpposite.op x) 1).symm
+
+end
 
 namespace MulOpposite
 
 universe u v
 
 variable (R : Type u) {M : Type v} [Semiring R] [AddCommMonoid M] [Module R M]
-
-/-- `MulOpposite.distribMulAction` extends to a `Module` -/
-instance instModule : Module R Mᵐᵒᵖ where
-  add_smul _ _ _ := unop_injective <| add_smul _ _ _
-  zero_smul _ := unop_injective <| zero_smul _ _
 
 /-- The function `op` is a linear equivalence. -/
 def opLinearEquiv : M ≃ₗ[R] Mᵐᵒᵖ :=

--- a/Mathlib/Algebra/Module/Hom.lean
+++ b/Mathlib/Algebra/Module/Hom.lean
@@ -3,8 +3,9 @@ Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Group.Hom.Instances
+import Mathlib.Algebra.Module.End
+import Mathlib.Algebra.Ring.Opposite
 import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 
 /-!

--- a/Mathlib/Algebra/Module/LinearMap/Basic.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Basic.lean
@@ -6,6 +6,7 @@ Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro, Anne 
 -/
 import Mathlib.Algebra.Module.LinearMap.Defs
 import Mathlib.Algebra.NoZeroSMulDivisors.Pi
+import Mathlib.Algebra.Ring.Opposite
 import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 
 /-!

--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro, Anne Baanen,
   Frédéric Dupuis, Heather Macbeth
 -/
-import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.Group.Hom.Instances
 import Mathlib.Algebra.Ring.CompTypeclasses
 import Mathlib.GroupTheory.GroupAction.Hom
 
@@ -447,17 +447,6 @@ theorem toAddMonoidHom_injective :
 @[ext high]
 theorem ext_ring {f g : R →ₛₗ[σ] M₃} (h : f 1 = g 1) : f = g :=
   ext fun x ↦ by rw [← mul_one x, ← smul_eq_mul, f.map_smulₛₗ, g.map_smulₛₗ, h]
-
-@[ext high]
-theorem ext_ring_op {σ : Rᵐᵒᵖ →+* S} {f g : R →ₛₗ[σ] M₃} (h : f (1 : R) = g (1 : R)) :
-    f = g :=
-  ext fun x ↦ by
-    -- Porting note: replaced the oneliner `rw` proof with a partially term-mode proof
-    -- because `rw` was giving "motive is type incorrect" errors
-    rw [← one_mul x, ← op_smul_eq_mul]
-    refine (f.map_smulₛₗ (MulOpposite.op x) 1).trans ?_
-    rw [h]
-    exact (g.map_smulₛₗ (MulOpposite.op x) 1).symm
 
 end
 

--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -6,6 +6,7 @@ Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro, Anne 
 -/
 import Mathlib.Algebra.GroupPower.IterateHom
 import Mathlib.Algebra.Module.LinearMap.Defs
+import Mathlib.Algebra.Module.Equiv.Opposite
 import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 
 /-!

--- a/Mathlib/Algebra/Module/Opposite.lean
+++ b/Mathlib/Algebra/Module/Opposite.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2020 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.Algebra.GroupWithZero.Action.Opposite
+import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.Ring.Opposite
+
+/-!
+# Module operations on `Mᵐᵒᵖ`
+
+This file contains definitions that build on top of the group action definitions in
+`Mathlib.Algebra.GroupWithZero.Action.Opposite`.
+-/
+
+assert_not_exists LinearMap
+
+section
+
+variable {R S M : Type*} [Semiring R] [Semiring S] [AddCommMonoid M] [Module S M]
+
+-- see Note [lower instance priority]
+/-- Like `Semiring.toModule`, but multiplies on the right. -/
+instance (priority := 910) Semiring.toOppositeModule [Semiring R] : Module Rᵐᵒᵖ R :=
+  { MonoidWithZero.toOppositeMulActionWithZero R with
+    smul_add := fun _ _ _ => add_mul _ _ _
+    add_smul := fun _ _ _ => mul_add _ _ _ }
+
+end
+
+namespace MulOpposite
+
+universe u v
+
+variable (R : Type u) {M : Type v} [Semiring R] [AddCommMonoid M] [Module R M]
+
+/-- `MulOpposite.distribMulAction` extends to a `Module` -/
+instance instModule : Module R Mᵐᵒᵖ where
+  add_smul _ _ _ := unop_injective <| add_smul _ _ _
+  zero_smul _ := unop_injective <| zero_smul _ _
+
+end MulOpposite

--- a/Mathlib/Algebra/NoZeroSMulDivisors/Basic.lean
+++ b/Mathlib/Algebra/NoZeroSMulDivisors/Basic.lean
@@ -3,7 +3,8 @@ Copyright (c) 2015 Nathaniel Thomas. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen, Yury Kudryashov, Joseph Myers, Heather Macbeth, Kim Morrison, Yaël Dillies
 -/
-import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.GroupWithZero.Action.Units
+import Mathlib.Algebra.Module.End
 import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 
 /-!

--- a/Mathlib/Algebra/Periodic.lean
+++ b/Mathlib/Algebra/Periodic.lean
@@ -6,8 +6,9 @@ Authors: Benjamin Davidson
 import Mathlib.Algebra.Field.Opposite
 import Mathlib.Algebra.Group.Subgroup.ZPowers
 import Mathlib.Algebra.Group.Submonoid.Membership
-import Mathlib.Algebra.Ring.NegOnePow
+import Mathlib.Algebra.Module.Opposite
 import Mathlib.Algebra.Order.Archimedean.Basic
+import Mathlib.Algebra.Ring.NegOnePow
 import Mathlib.GroupTheory.Coset.Card
 
 /-!

--- a/Mathlib/Algebra/Ring/AddAut.lean
+++ b/Mathlib/Algebra/Ring/AddAut.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.GroupWithZero.Action.Basic
-import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.GroupWithZero.Action.Units
+import Mathlib.Algebra.Module.Opposite
 
 /-!
 # Multiplication on the left/right as additive automorphisms

--- a/Mathlib/Algebra/Ring/Subsemiring/MulOpposite.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/MulOpposite.lean
@@ -5,6 +5,7 @@ Authors: Jz Pan
 -/
 import Mathlib.Algebra.Group.Submonoid.MulOpposite
 import Mathlib.Algebra.Ring.Subsemiring.Basic
+import Mathlib.Algebra.Ring.Opposite
 
 /-!
 

--- a/Mathlib/CategoryTheory/Linear/Basic.lean
+++ b/Mathlib/CategoryTheory/Linear/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Algebra.Defs
+import Mathlib.Algebra.Group.Invertible.Defs
 import Mathlib.Algebra.Module.Equiv.Defs
 import Mathlib.CategoryTheory.Preadditive.Basic
 

--- a/Mathlib/CategoryTheory/Preadditive/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Basic.lean
@@ -5,7 +5,7 @@ Authors: Markus Himmel, Jakob von Raumer
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset
 import Mathlib.Algebra.Group.Hom.Defs
-import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.Module.End
 import Mathlib.CategoryTheory.Endomorphism
 import Mathlib.CategoryTheory.Limits.Shapes.Kernels
 

--- a/Mathlib/Data/Set/Pointwise/SMul.lean
+++ b/Mathlib/Data/Set/Pointwise/SMul.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.GroupWithZero.Action.Basic
 import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.Ring.Opposite
 import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 import Mathlib.Data.Set.Pairwise.Basic
 

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+import Mathlib.Algebra.Module.End
 import Mathlib.Algebra.Ring.Prod
 import Mathlib.GroupTheory.GroupAction.SubMulAction
 import Mathlib.GroupTheory.OrderOfElement

--- a/Mathlib/LinearAlgebra/AffineSpace/Midpoint.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Midpoint.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
+import Mathlib.Algebra.Module.Basic
 import Mathlib.LinearAlgebra.AffineSpace.AffineEquiv
 
 /-!

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.LinearAlgebra.CliffordAlgebra.Grading
-import Mathlib.Algebra.Module.Opposites
+import Mathlib.Algebra.Module.Opposite
 
 /-!
 # Conjugations

--- a/Mathlib/RingTheory/OreLocalization/Ring.lean
+++ b/Mathlib/RingTheory/OreLocalization/Ring.lean
@@ -4,9 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jakob von Raumer, Kevin Klinge, Andrew Yang
 -/
 
-import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
+import Mathlib.Algebra.Module.End
 import Mathlib.RingTheory.OreLocalization.Basic
 
 /-!

--- a/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
@@ -8,6 +8,7 @@ import Mathlib.Tactic.Abel
 import Mathlib.GroupTheory.GroupAction.SubMulAction
 import Mathlib.RingTheory.Congruence.Basic
 import Mathlib.Algebra.Module.LinearMap.Defs
+import Mathlib.Algebra.Module.Opposite
 
 /-!
 # Two Sided Ideals

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -4,15 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jan-David Salchow, Sébastien Gouëzel, Jean Lo, Yury Kudryashov, Frédéric Dupuis,
   Heather Macbeth
 -/
-import Mathlib.Topology.Algebra.Ring.Basic
+import Mathlib.Algebra.Algebra.Defs
+import Mathlib.Algebra.Module.Opposite
+import Mathlib.LinearAlgebra.Finsupp
+import Mathlib.LinearAlgebra.Pi
+import Mathlib.LinearAlgebra.Projection
 import Mathlib.Topology.Algebra.MulAction
+import Mathlib.Topology.Algebra.Ring.Basic
 import Mathlib.Topology.Algebra.UniformGroup
 import Mathlib.Topology.UniformSpace.UniformEmbedding
-import Mathlib.Algebra.Algebra.Defs
-import Mathlib.LinearAlgebra.Projection
-import Mathlib.LinearAlgebra.Pi
-import Mathlib.LinearAlgebra.Finsupp
-import Mathlib.Algebra.Module.Opposites
 
 /-!
 # Theory of topological modules and continuous linear maps.

--- a/Mathlib/Topology/Algebra/UniformMulAction.lean
+++ b/Mathlib/Topology/Algebra/UniformMulAction.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
+import Mathlib.Algebra.Module.Opposite
 import Mathlib.Topology.Algebra.UniformGroup
 import Mathlib.Topology.UniformSpace.Completion
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -378,6 +378,7 @@
   ["Mathlib.Algebra.Order.Field.Basic"],
   "Mathlib.CategoryTheory.Sites.IsSheafFor":
   ["Mathlib.CategoryTheory.Limits.Shapes.Pullback.Mono"],
+  "Mathlib.CategoryTheory.Preadditive.Basic": ["Mathlib.Algebra.Module.End"],
   "Mathlib.CategoryTheory.Monoidal.Rigid.Basic":
   ["Mathlib.Tactic.CategoryTheory.Monoidal.Basic"],
   "Mathlib.CategoryTheory.Monoidal.Braided.Basic":


### PR DESCRIPTION
There are quite a few imports in `Module/Defs.lean` that are not needed for defining modules. So this PR rearranges the results in the file to postpone those imports.

Changes:
 * The result involving `Invertible` go to `Module/Basic.lean`
 * The results involving `AddMonoid.End` goes to the new file `Module/End.lean`
 * The results involving `Opposite` go to the new file `Module/Opposite.lean`; the previous `Module/Opposites.lean` is now `Module/Equiv/Opposite.lean` (note: now in singular to match the other `Opposite` file)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
