### PR TITLE
[Merged by Bors] - feat(Analysis/Normed/Ring/Seminorm): add lemmas

### DIFF
--- a/Mathlib/Analysis/Normed/Ring/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Ring/Seminorm.lean
@@ -5,6 +5,7 @@ Authors: María Inés de Frutos-Fernández, Yaël Dillies
 -/
 import Mathlib.Analysis.Normed.Field.Lemmas
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Data.Real.IsNonarchimedean
 
 /-!
 # Seminorms and norms on rings
@@ -149,6 +150,19 @@ theorem seminorm_one_eq_one_iff_ne_zero (hp : p 1 ≤ 1) : p 1 = 1 ↔ p ≠ 0 :
 
 end Ring
 
+section CommRing
+
+variable [CommRing R] (p : RingSeminorm R)
+
+theorem exists_index_pow_le (hna : IsNonarchimedean p) (x y : R) (n : ℕ) :
+    ∃ (m : ℕ) (_ : m ∈ Finset.range (n + 1)), p ((x + y) ^ (n : ℕ)) ^ (1 / (n : ℝ)) ≤
+      (p (x ^ m) * p (y ^ (n - m : ℕ))) ^ (1 / (n : ℝ)) := by
+  obtain ⟨m, hm_lt, hm⟩ := IsNonarchimedean.add_pow_le hna n x y
+  exact ⟨m, Finset.mem_range.mpr hm_lt,
+    Real.rpow_le_rpow (apply_nonneg p _) hm (one_div_nonneg.mpr n.cast_nonneg')⟩
+
+end CommRing
+
 end RingSeminorm
 
 /-- If `f` is a ring seminorm on `a`, then `∀ {n : ℕ}, n ≠ 0 → f (a ^ n) ≤ f a ^ n`. -/
@@ -176,6 +190,34 @@ def normRingSeminorm (R : Type*) [NonUnitalSeminormedRing R] : RingSeminorm R :=
   { normAddGroupSeminorm R with
     toFun := norm
     mul_le' := norm_mul_le }
+
+namespace RingSeminorm
+
+variable [Ring R] (p : RingSeminorm R)
+
+open Filter Nat Real
+
+/-- If `f` is a ring seminorm on `R` with `f 1 ≤ 1` and `s : ℕ → ℕ` is bounded by `n`, then
+  `f (x ^ s (ψ n)) ^ (1 / (ψ n : ℝ))` is eventually bounded. -/
+theorem isBoundedUnder (hp : p 1 ≤ 1) {s : ℕ → ℕ} (hs_le : ∀ n : ℕ, s n ≤ n) {x : R} (ψ : ℕ → ℕ) :
+    IsBoundedUnder LE.le atTop fun n : ℕ => p (x ^ s (ψ n)) ^ (1 / (ψ n : ℝ)) := by
+  have h_le : ∀ m : ℕ, p (x ^ s (ψ m)) ^ (1 / (ψ m : ℝ)) ≤ p x ^ ((s (ψ m) : ℝ) / (ψ m : ℝ)) := by
+    intro m
+    rw [← mul_one_div (s (ψ m) : ℝ), rpow_mul (apply_nonneg p x), rpow_natCast]
+    exact rpow_le_rpow (apply_nonneg _ _) (map_pow_le_pow' hp x _)
+      (one_div_nonneg.mpr (cast_nonneg _))
+  apply isBoundedUnder_of
+  by_cases hfx : p x ≤ 1
+  · use 1, fun m => le_trans (h_le m)
+      (rpow_le_one (apply_nonneg _ _) hfx (div_nonneg (cast_nonneg _) (cast_nonneg _)))
+  · use p x
+    intro m
+    apply le_trans (h_le m)
+    conv_rhs => rw [← rpow_one (p x)]
+    exact rpow_le_rpow_of_exponent_le (le_of_lt (not_le.mp hfx))
+      (div_le_one_of_le₀ (cast_le.mpr (hs_le _)) (cast_nonneg _))
+
+end RingSeminorm
 
 namespace RingNorm
 

--- a/Mathlib/Analysis/Normed/Ring/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Ring/Seminorm.lean
@@ -155,11 +155,10 @@ section CommRing
 variable [CommRing R] (p : RingSeminorm R)
 
 theorem exists_index_pow_le (hna : IsNonarchimedean p) (x y : R) (n : ℕ) :
-    ∃ (m : ℕ) (_ : m ∈ Finset.range (n + 1)), p ((x + y) ^ (n : ℕ)) ^ (1 / (n : ℝ)) ≤
+    ∃ (m : ℕ), m < n + 1 ∧ p ((x + y) ^ (n : ℕ)) ^ (1 / (n : ℝ)) ≤
       (p (x ^ m) * p (y ^ (n - m : ℕ))) ^ (1 / (n : ℝ)) := by
   obtain ⟨m, hm_lt, hm⟩ := IsNonarchimedean.add_pow_le hna n x y
-  exact ⟨m, Finset.mem_range.mpr hm_lt,
-    Real.rpow_le_rpow (apply_nonneg p _) hm (one_div_nonneg.mpr n.cast_nonneg')⟩
+  exact ⟨m, hm_lt, Real.rpow_le_rpow (apply_nonneg p _) hm (one_div_nonneg.mpr n.cast_nonneg')⟩
 
 end CommRing
 


### PR DESCRIPTION
Used in #15373.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
