### PR TITLE
feat(SetTheory/Ordinal/Basic): linear order instance on `WellOrder.α`

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -89,9 +89,8 @@ instance inhabited : Inhabited WellOrder :=
 instance hasWellFounded (o : WellOrder) : WellFoundedRelation o.α :=
   ⟨o.r, o.wo.wf⟩
 
-open Classical in
 instance linearOrder (o : WellOrder) : LinearOrder o.α :=
-  linearOrderOfSTO o.r
+  o.wo.linearOrder
 
 @[simp]
 theorem eta (o : WellOrder) : mk o.α o.r o.wo = o :=

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -69,7 +69,6 @@ variable {α : Type u} {β : Type*} {γ : Type*} {r : α → α → Prop} {s : �
 
 /-! ### Definition of ordinals -/
 
-
 /-- Bundled structure registering a well order on a type. Ordinals will be defined as a quotient
 of this type. -/
 structure WellOrder : Type (u + 1) where
@@ -85,11 +84,17 @@ attribute [instance] WellOrder.wo
 namespace WellOrder
 
 instance inhabited : Inhabited WellOrder :=
-  ⟨⟨PEmpty, _, inferInstanceAs (IsWellOrder PEmpty EmptyRelation)⟩⟩
+  ⟨⟨PEmpty, EmptyRelation, inferInstance⟩⟩ 
+
+instance hasWellFounded (o : WellOrder) : WellFoundedRelation o.α :=
+  ⟨o.r, o.wo.wf⟩
+
+open Classical in
+instance linearOrder (o : WellOrder) : LinearOrder o.α :=
+  linearOrderOfSTO o.r
 
 @[simp]
-theorem eta (o : WellOrder) : mk o.α o.r o.wo = o := by
-  cases o
+theorem eta (o : WellOrder) : mk o.α o.r o.wo = o :=
   rfl
 
 end WellOrder
@@ -114,10 +119,10 @@ def Ordinal.toType (o : Ordinal.{u}) : Type u :=
   o.out.α
 
 instance hasWellFounded_toType (o : Ordinal) : WellFoundedRelation o.toType :=
-  ⟨o.out.r, o.out.wo.wf⟩
+  o.out.hasWellFounded
 
 instance linearOrder_toType (o : Ordinal) : LinearOrder o.toType :=
-  @IsWellOrder.linearOrder _ o.out.r o.out.wo
+  o.out.linearOrder
 
 instance isWellOrder_toType_lt (o : Ordinal) : IsWellOrder o.toType (· < ·) :=
   o.out.wo

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -84,7 +84,7 @@ attribute [instance] WellOrder.wo
 namespace WellOrder
 
 instance inhabited : Inhabited WellOrder :=
-  ⟨⟨PEmpty, EmptyRelation, inferInstance⟩⟩ 
+  ⟨⟨PEmpty, EmptyRelation, inferInstance⟩⟩
 
 instance hasWellFounded (o : WellOrder) : WellFoundedRelation o.α :=
   ⟨o.r, o.wo.wf⟩
@@ -145,8 +145,7 @@ instance one : One Ordinal :=
   ⟨type <| @EmptyRelation PUnit⟩
 
 @[simp]
-theorem type_def' (w : WellOrder) : ⟦w⟧ = type w.r := by
-  cases w
+theorem type_def' (w : WellOrder) : ⟦w⟧ = type w.r :=
   rfl
 
 @[simp]


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

The intention of this is that we can switch to using `<` / `≤` rather than unbundled relations in the definition of [`Order.cof`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/SetTheory/Cardinal/Cofinality.html#Order.cof). Particularly, we can define `Ordinal.cof ⟦w⟧ = Order.cof w.α` rather than `Ordinal.cof ⟦w⟧ = StrictOrder.cof w.r`

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
