### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry) define rational maps

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -904,6 +904,7 @@ import Mathlib.AlgebraicGeometry.ProjectiveSpectrum.StructureSheaf
 import Mathlib.AlgebraicGeometry.ProjectiveSpectrum.Topology
 import Mathlib.AlgebraicGeometry.Properties
 import Mathlib.AlgebraicGeometry.Pullbacks
+import Mathlib.AlgebraicGeometry.RationalMap
 import Mathlib.AlgebraicGeometry.ResidueField
 import Mathlib.AlgebraicGeometry.Restrict
 import Mathlib.AlgebraicGeometry.Scheme

--- a/Mathlib/AlgebraicGeometry/RationalMap.lean
+++ b/Mathlib/AlgebraicGeometry/RationalMap.lean
@@ -74,8 +74,23 @@ def restrict (f : X.PartialMap Y) (U : X.Opens)
 
 @[simp]
 lemma restrict_id (f : X.PartialMap Y) : f.restrict f.domain f.dense_domain le_rfl = f := by
-  ext1
-  · rfl
+  ext1 <;> simp [restrict_domain]
+
+lemma restrict_id_hom (f : X.PartialMap Y) :
+    (f.restrict f.domain f.dense_domain le_rfl).hom = f.hom := by
+  simp
+
+@[simp]
+lemma restrict_restrict (f : X.PartialMap Y)
+    (U : X.Opens) (hU : Dense (U : Set X)) (hU' : U ≤ f.domain)
+    (V : X.Opens) (hV : Dense (V : Set X)) (hV' : V ≤ U) :
+    (f.restrict U hU hU').restrict V hV hV' = f.restrict V hV (hV'.trans hU') := by
+  ext1 <;> simp [restrict_domain]
+
+lemma restrict_restrict_hom (f : X.PartialMap Y)
+    (U : X.Opens) (hU : Dense (U : Set X)) (hU' : U ≤ f.domain)
+    (V : X.Opens) (hV : Dense (V : Set X)) (hV' : V ≤ U) :
+    ((f.restrict U hU hU').restrict V hV hV').hom = (f.restrict V hV (hV'.trans hU')).hom := by
   simp
 
 /-- The composition of a partial map and a morphism on the right. -/
@@ -187,6 +202,11 @@ lemma iseqv_rel : Equivalence (@Scheme.PartialMap.equiv X Y) where
 
 instance : Setoid (X.PartialMap Y) := ⟨@PartialMap.equiv X Y, iseqv_rel⟩
 
+lemma restrict_equiv (f : X.PartialMap Y) (U : X.Opens)
+    (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) : (f.restrict U hU hU').equiv f :=
+  ⟨U, hU, le_rfl, hU', by simp⟩
+
+
 lemma equiv_of_fromSpecStalkOfMem_eq [IrreducibleSpace X]
     {x : X} [X.IsGermInjectiveAt x] (f g : X.PartialMap Y)
     (hxf : x ∈ f.domain) (hxg : x ∈ g.domain)
@@ -237,6 +257,12 @@ lemma PartialMap.toRationalMap_eq_iff {f g : X.PartialMap Y} :
     f.toRationalMap = g.toRationalMap ↔ f.equiv g :=
   Quotient.eq
 
+@[simp]
+lemma PartialMap.restrict_toRationalMap (f : X.PartialMap Y) (U : X.Opens)
+      (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) :
+    (f.restrict U hU hU').toRationalMap = f.toRationalMap :=
+  toRationalMap_eq_iff.mpr (f.restrict_equiv U hU hU')
+
 /-- The composition of a rational map and a morphism on the right. -/
 def RationalMap.compHom (f : X ⤏ Y) (g : Y ⟶ Z) : X ⤏ Z := by
   refine Quotient.map (PartialMap.compHom · g) ?_ f
@@ -248,7 +274,7 @@ def RationalMap.compHom (f : X ⤏ Y) (g : Y ⟶ Z) : X ⤏ Z := by
 
 @[simp]
 lemma RationalMap.compHom_toRationalMap (f : X.PartialMap Y) (g : Y ⟶ Z) :
-    f.toRationalMap.compHom g = (f.compHom g).toRationalMap := rfl
+    (f.compHom g).toRationalMap = f.toRationalMap.compHom g := rfl
 
 /-- A rational map restricts to a map from `Spec K(X)`. -/
 noncomputable

--- a/Mathlib/AlgebraicGeometry/RationalMap.lean
+++ b/Mathlib/AlgebraicGeometry/RationalMap.lean
@@ -290,7 +290,7 @@ Given `S`-schemes `X` and `Y` such that `Y` is locally of finite type and `X` is
 -/
 noncomputable
 def RationalMap.equivFunctionField [IsIntegral X] [LocallyOfFiniteType sY] :
-    { f : Spec X.functionField ⟶ Y // f ≫ sY = X.fromSpecStalk _ ≫ sX} ≃
+    { f : Spec X.functionField ⟶ Y // f ≫ sY = X.fromSpecStalk _ ≫ sX } ≃
       { f : X ⤏ Y // f.compHom sY = sX.toRationalMap } where
   toFun f := ⟨.ofFunctionField sX sY f f.2, PartialMap.toRationalMap_eq_iff.mpr
       ⟨_, PartialMap.dense_domain _, le_rfl, le_top, by simp [PartialMap.ofFromSpecStalk_comp]⟩⟩

--- a/Mathlib/AlgebraicGeometry/RationalMap.lean
+++ b/Mathlib/AlgebraicGeometry/RationalMap.lean
@@ -185,7 +185,7 @@ def equiv (f g : X.PartialMap Y) : Prop :=
   ∃ (W : X.Opens) (hW : Dense (W : Set X)) (hWl : W ≤ f.domain) (hWr : W ≤ g.domain),
     (f.restrict W hW hWl).hom = (g.restrict W hW hWr).hom
 
-lemma iseqv_rel : Equivalence (@Scheme.PartialMap.equiv X Y) where
+lemma equivalence_rel : Equivalence (@Scheme.PartialMap.equiv X Y) where
   refl f := ⟨f.domain, f.dense_domain, by simp⟩
   symm {f g} := by
     intro ⟨W, hW, hWl, hWr, e⟩
@@ -200,7 +200,7 @@ lemma iseqv_rel : Equivalence (@Scheme.PartialMap.equiv X Y) where
       Category.assoc, e₁, ← X.homOfLE_homOfLE (U := W₁ ⊓ W₂) inf_le_right hW₂r, ← e₂]
     simp only [homOfLE_homOfLE_assoc]
 
-instance : Setoid (X.PartialMap Y) := ⟨@PartialMap.equiv X Y, iseqv_rel⟩
+instance : Setoid (X.PartialMap Y) := ⟨@PartialMap.equiv X Y, equivalence_rel⟩
 
 lemma restrict_equiv (f : X.PartialMap Y) (U : X.Opens)
     (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) : (f.restrict U hU hU').equiv f :=

--- a/Mathlib/AlgebraicGeometry/RationalMap.lean
+++ b/Mathlib/AlgebraicGeometry/RationalMap.lean
@@ -1,0 +1,312 @@
+/-
+Copyright (c) 2024 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang
+-/
+import Mathlib.CategoryTheory.Limits.Constructions.Over.Connected
+import Mathlib.CategoryTheory.Limits.Constructions.Over.Products
+import Mathlib.CategoryTheory.Limits.Constructions.Over.Basic
+import Mathlib.AlgebraicGeometry.Morphisms.Separated
+import Mathlib.AlgebraicGeometry.SpreadingOut
+import Mathlib.AlgebraicGeometry.FunctionField
+/-!
+
+# Rational maps between schemes
+
+## Main definitions
+
+* `AlgebraicGeometry.Scheme.PartialMap`: A partial map from `X` to `Y` (`X.PartialMap Y`) is
+  a morphism into `Y` defined on a dense open subscheme of `X`.
+* `AlgebraicGeometry.Scheme.PartialMap.equiv`:
+  Two partial maps are equivalent if they are equal on a dense open subscheme.
+* `AlgebraicGeometry.Scheme.RationalMap`:
+  A rational map from `X` to `Y` (`X ⤏ Y`) is an equivalence class of partial maps.
+* `AlgebraicGeometry.Scheme.RationalMap.equivFunctionField`:
+  Given `S`-schemes `X` and `Y` such that `Y` is locally of finite type and `X` is integral,
+  `S`-morphism `Spec K(X) ⟶ Y` corresponds bijectively to `S`-rational map from `X` to `Y`.
+
+-/
+
+universe u
+
+open CategoryTheory
+
+namespace AlgebraicGeometry
+
+variable {X Y Z S : Scheme.{u}} (sX : X ⟶ S) (sY : Y ⟶ S)
+
+namespace Scheme
+
+/--
+A partial map from `X` to `Y` (`X.PartialMap Y`) is a morphism into `Y`
+defined on a dense open subscheme of `X`.
+-/
+structure PartialMap (X Y : Scheme.{u}) where
+  /-- The domain of definition of a partial map. -/
+  domain : X.Opens
+  dense_domain : Dense (domain : Set X)
+  /-- The underlying morphism of a partial map. -/
+  hom : ↑domain ⟶ Y
+
+namespace PartialMap
+
+lemma ext_iff (f g : X.PartialMap Y) :
+    f = g ↔ ∃ e : f.domain = g.domain, f.hom = (X.isoOfEq e).hom ≫ g.hom := by
+  constructor
+  · rintro rfl
+    simp only [exists_true_left, Scheme.isoOfEq_rfl, Iso.refl_hom, Category.id_comp]
+  · obtain ⟨U, hU, f⟩ := f
+    obtain ⟨V, hV, g⟩ := g
+    rintro ⟨rfl : U = V, e⟩
+    congr 1
+    simpa using e
+
+@[ext]
+lemma ext (f g : X.PartialMap Y) (e : f.domain = g.domain)
+    (H : f.hom = (X.isoOfEq e).hom ≫ g.hom) : f = g := by
+  rw [ext_iff]
+  exact ⟨e, H⟩
+
+/-- The restriction of a partial map to a smaller domain. -/
+@[simps domain hom]
+noncomputable
+def restrict (f : X.PartialMap Y) (U : X.Opens)
+    (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) : X.PartialMap Y where
+  domain := U
+  dense_domain := hU
+  hom := X.homOfLE hU' ≫ f.hom
+
+@[simp]
+lemma restrict_id (f : X.PartialMap Y) : f.restrict f.domain f.dense_domain le_rfl = f := by
+  ext1
+  · rfl
+  simp
+
+/-- The composition of a partial map and a morphism on the right. -/
+@[simps]
+def compHom (f : X.PartialMap Y) (g : Y ⟶ Z) : X.PartialMap Z where
+  domain := f.domain
+  dense_domain := f.dense_domain
+  hom := f.hom ≫ g
+
+/-- A scheme morphism as a partial map. -/
+@[simps]
+def _root_.AlgebraicGeometry.Scheme.Hom.toPartialMap (f : X.Hom Y) :
+    X.PartialMap Y := ⟨⊤, dense_univ, X.topIso.hom ≫ f⟩
+
+/-- If `x` is in the domain of a partial map `f`, then `f` restricts to a map from `Spec 𝒪_x`. -/
+noncomputable
+def fromSpecStalkOfMem (f : X.PartialMap Y) {x} (hx : x ∈ f.domain) :
+    Spec (X.presheaf.stalk x) ⟶ Y :=
+  f.domain.fromSpecStalkOfMem x hx ≫ f.hom
+
+/-- A partial map restricts to a map from `Spec K(X)`. -/
+noncomputable
+abbrev fromFunctionField [IrreducibleSpace X] (f : X.PartialMap Y) :
+    Spec X.functionField ⟶ Y :=
+  f.fromSpecStalkOfMem
+    ((genericPoint_specializes _).mem_open f.domain.2 f.dense_domain.nonempty.choose_spec)
+
+lemma fromSpecStalkOfMem_restrict (f : X.PartialMap Y)
+    (U : X.Opens) (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) {x} (hx : x ∈ U) :
+    (f.restrict U hU hU').fromSpecStalkOfMem hx = f.fromSpecStalkOfMem (hU' hx) := by
+  dsimp only [fromSpecStalkOfMem, restrict, Scheme.Opens.fromSpecStalkOfMem]
+  have e : ⟨x, hU' hx⟩ = (X.homOfLE hU').base ⟨x, hx⟩ := by
+    rw [Scheme.homOfLE_base]
+    rfl
+  rw [Category.assoc, ← Spec_map_stalkMap_fromSpecStalk_assoc,
+    ← Spec_map_stalkSpecializes_fromSpecStalk (Inseparable.of_eq e).specializes,
+    ← TopCat.Presheaf.stalkCongr_inv _ (Inseparable.of_eq e)]
+  simp only [← Category.assoc, ← Spec.map_comp]
+  congr 3
+  rw [Iso.eq_inv_comp, ← Category.assoc, IsIso.comp_inv_eq, IsIso.eq_inv_comp,
+    stalkMap_congr_hom _ _ (X.homOfLE_ι hU').symm]
+  simp only [restrictFunctor_obj_left, homOfLE_leOfHom, TopCat.Presheaf.stalkCongr_hom]
+  rw [← stalkSpecializes_stalkMap_assoc, stalkMap_comp]
+
+lemma fromFunctionField_restrict (f : X.PartialMap Y) [IrreducibleSpace X]
+    (U : X.Opens) (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) :
+    (f.restrict U hU hU').fromFunctionField = f.fromFunctionField :=
+  fromSpecStalkOfMem_restrict f _ _ _ _
+
+/--
+Given `S`-schemes `X` and `Y` such that `Y` is locally of finite type and
+`X` is irreducible and "germ-injective" (e.g. when `X` is integral),
+any `S`-morphism `Spec 𝒪ₓ ⟶ Y` spreads out to a partial map from `X` to `Y`.
+-/
+noncomputable
+def ofFromSpecStalk [IrreducibleSpace X] [LocallyOfFiniteType sY] {x : X} [X.IsGermInjectiveAt x]
+    (φ : Spec (X.presheaf.stalk x) ⟶ Y) (h : φ ≫ sY = X.fromSpecStalk x ≫ sX) : X.PartialMap Y where
+  hom := (spread_out_of_isGermInjective' sX sY φ h).choose_spec.choose_spec.choose
+  dense_domain := (spread_out_of_isGermInjective' sX sY φ h).choose.2.dense
+    ⟨_, (spread_out_of_isGermInjective' sX sY φ h).choose_spec.choose⟩
+
+lemma ofFromSpecStalk_comp [IrreducibleSpace X] [LocallyOfFiniteType sY]
+    {x : X} [X.IsGermInjectiveAt x] (φ : Spec (X.presheaf.stalk x) ⟶ Y)
+    (h : φ ≫ sY = X.fromSpecStalk x ≫ sX) :
+    (ofFromSpecStalk sX sY φ h).hom ≫ sY = (ofFromSpecStalk sX sY φ h).domain.ι ≫ sX :=
+  (spread_out_of_isGermInjective' sX sY φ h).choose_spec.choose_spec.choose_spec.2
+
+lemma mem_domain_ofFromSpecStalk [IrreducibleSpace X] [LocallyOfFiniteType sY]
+    {x : X} [X.IsGermInjectiveAt x] (φ : Spec (X.presheaf.stalk x) ⟶ Y)
+    (h : φ ≫ sY = X.fromSpecStalk x ≫ sX) : x ∈ (ofFromSpecStalk sX sY φ h).domain :=
+  (spread_out_of_isGermInjective' sX sY φ h).choose_spec.choose
+
+lemma fromSpecStalkOfMem_ofFromSpecStalk [IrreducibleSpace X] [LocallyOfFiniteType sY]
+    {x : X} [X.IsGermInjectiveAt x] (φ : Spec (X.presheaf.stalk x) ⟶ Y)
+    (h : φ ≫ sY = X.fromSpecStalk x ≫ sX) :
+    (ofFromSpecStalk sX sY φ h).fromSpecStalkOfMem (mem_domain_ofFromSpecStalk sX sY φ h) = φ :=
+  (spread_out_of_isGermInjective' sX sY φ h).choose_spec.choose_spec.choose_spec.1.symm
+
+@[simp]
+lemma fromSpecStalkOfMem_compHom (f : X.PartialMap Y) (g : Y ⟶ Z) (x) (hx) :
+    (f.compHom g).fromSpecStalkOfMem (x := x) hx = f.fromSpecStalkOfMem hx ≫ g := by
+  simp [fromSpecStalkOfMem]
+
+@[simp]
+lemma fromSpecStalkOfMem_toPartialMap (f : X ⟶ Y) (x) :
+    f.toPartialMap.fromSpecStalkOfMem (x := x) trivial = X.fromSpecStalk x ≫ f := by
+  simp [fromSpecStalkOfMem]
+
+/-- Two partial maps are equivalent if they are equal on a dense open subscheme. -/
+protected noncomputable
+def equiv (f g : X.PartialMap Y) : Prop :=
+  ∃ (W : X.Opens) (hW : Dense (W : Set X)) (hWl : W ≤ f.domain) (hWr : W ≤ g.domain),
+    (f.restrict W hW hWl).hom = (g.restrict W hW hWr).hom
+
+lemma iseqv_rel : _root_.Equivalence (@Scheme.PartialMap.equiv X Y) where
+  refl f := ⟨f.domain, f.dense_domain, by simp⟩
+  symm {f g} := by
+    intro ⟨W, hW, hWl, hWr, e⟩
+    exact ⟨W, hW, hWr, hWl, e.symm⟩
+  trans {f g h} := by
+    intro ⟨W₁, hW₁, hW₁l, hW₁r, e₁⟩ ⟨W₂, hW₂, hW₂l, hW₂r, e₂⟩
+    refine ⟨W₁ ⊓ W₂, hW₁.inter_of_isOpen_left hW₂ W₁.2, inf_le_left.trans hW₁l,
+      inf_le_right.trans hW₂r, ?_⟩
+    dsimp at e₁ e₂
+    simp only [restrict_domain, restrict_hom, restrictFunctor_obj_left, homOfLE_leOfHom,
+      ← X.homOfLE_homOfLE (U := W₁ ⊓ W₂) inf_le_left hW₁l, Functor.map_comp, Over.comp_left,
+      Category.assoc, e₁, ← X.homOfLE_homOfLE (U := W₁ ⊓ W₂) inf_le_right hW₂r, ← e₂]
+    simp only [homOfLE_homOfLE_assoc]
+
+instance : Setoid (X.PartialMap Y) := ⟨@PartialMap.equiv X Y, iseqv_rel⟩
+
+lemma equiv_of_fromSpecStalkOfMem_eq [IrreducibleSpace X]
+    {x : X} [X.IsGermInjectiveAt x] (f g : X.PartialMap Y)
+    (hxf : x ∈ f.domain) (hxg : x ∈ g.domain)
+    (H : f.fromSpecStalkOfMem hxf = g.fromSpecStalkOfMem hxg) : f.equiv g := by
+  have hdense : Dense ((f.domain ⊓ g.domain) : Set X) :=
+    f.dense_domain.inter_of_isOpen_left g.dense_domain f.domain.2
+  have := (isGermInjectiveAt_iff_of_isOpenImmersion (f := (f.domain ⊓ g.domain).ι)
+    (x := ⟨x, hxf, hxg⟩)).mp ‹_›
+  have := spread_out_unique_of_isGermInjective' (X := (f.domain ⊓ g.domain).toScheme)
+    (X.homOfLE inf_le_left ≫ f.hom) (X.homOfLE inf_le_right ≫ g.hom) (x := ⟨x, hxf, hxg⟩) ?_
+  · obtain ⟨U, hxU, e⟩ := this
+    refine ⟨(f.domain ⊓ g.domain).ι ''ᵁ U, ((f.domain ⊓ g.domain).ι ''ᵁ U).2.dense
+      ⟨_, ⟨_, hxU, rfl⟩⟩,
+      ((Set.image_subset_range _ _).trans_eq (Subtype.range_val)).trans inf_le_left,
+      ((Set.image_subset_range _ _).trans_eq (Subtype.range_val)).trans inf_le_right, ?_⟩
+    rw [← cancel_epi (Scheme.Hom.isoImage _ _).hom]
+    simp only [TopologicalSpace.Opens.carrier_eq_coe, IsOpenMap.functor_obj_coe,
+      TopologicalSpace.Opens.coe_inf, restrict_hom, ← Category.assoc] at e ⊢
+    convert e using 2 <;> rw [← cancel_mono (Scheme.Opens.ι _)] <;> simp
+  · rw [← f.fromSpecStalkOfMem_restrict _ hdense inf_le_left ⟨hxf, hxg⟩,
+      ← g.fromSpecStalkOfMem_restrict _ hdense inf_le_right ⟨hxf, hxg⟩] at H
+    simpa only [fromSpecStalkOfMem, restrict_domain, Opens.fromSpecStalkOfMem, Spec.map_inv,
+      restrict_hom, Category.assoc, IsIso.eq_inv_comp, IsIso.hom_inv_id_assoc] using H
+
+end PartialMap
+
+/-- A rational map from `X` to `Y` (`X ⤏ Y`) is an equivalence class of partial maps,
+where two partial maps are equivalent if they are equal on a dense open subscheme.  -/
+def RationalMap (X Y : Scheme.{u}) : Type u :=
+  @_root_.Quotient (X.PartialMap Y) inferInstance
+
+scoped[AlgebraicGeometry] infix:10 " ⤏ " => Scheme.RationalMap
+
+/-- A partial map as a rational map. -/
+def PartialMap.toRationalMap (f : X.PartialMap Y) : X ⤏ Y := Quotient.mk _ f
+
+/-- A scheme morphism as a rational map. -/
+abbrev Hom.toRationalMap (f : X.Hom Y) : X ⤏ Y := f.toPartialMap.toRationalMap
+
+lemma PartialMap.toRationalMap_surjective : Function.Surjective (@toRationalMap X Y) :=
+  _root_.Quotient.exists_rep
+
+lemma RationalMap.exists_rep (f : X ⤏ Y) : ∃ g : X.PartialMap Y, g.toRationalMap = f :=
+  _root_.Quotient.exists_rep f
+
+lemma PartialMap.toRationalMap_eq_iff {f g : X.PartialMap Y} :
+    f.toRationalMap = g.toRationalMap ↔ f.equiv g :=
+  Quotient.eq
+
+/-- A rational map restricts to a map from `Spec K(X)`. -/
+def RationalMap.compHom (f : X ⤏ Y) (g : Y ⟶ Z) : X ⤏ Z := by
+  refine Quotient.map (PartialMap.compHom · g) ?_ f
+  intro f₁ f₂ ⟨W, hW, hWl, hWr, e⟩
+  refine ⟨W, hW, hWl, hWr, ?_⟩
+  simp only [PartialMap.restrict_domain, PartialMap.restrict_hom, PartialMap.compHom_domain,
+    PartialMap.compHom_hom] at e ⊢
+  rw [reassoc_of% e]
+
+@[simp]
+lemma RationalMap.compHom_toRationalMap (f : X.PartialMap Y) (g : Y ⟶ Z) :
+    f.toRationalMap.compHom g = (f.compHom g).toRationalMap := rfl
+
+/-- The composition of a rational map and a morphism on the right. -/
+noncomputable
+def RationalMap.fromFunctionField [IrreducibleSpace X] (f : X ⤏ Y) :
+    Spec X.functionField ⟶ Y := by
+  refine Quotient.lift PartialMap.fromFunctionField ?_ f
+  intro f g ⟨W, hW, hWl, hWr, e⟩
+  have : f.restrict W hW hWl = g.restrict W hW hWr := by ext1; rfl; rw [e]; simp
+  rw [← f.fromFunctionField_restrict W hW hWl, this, g.fromFunctionField_restrict]
+
+@[simp]
+lemma RationalMap.fromFunctionField_toRationalMap [IrreducibleSpace X] (f : X.PartialMap Y) :
+  f.toRationalMap.fromFunctionField = f.fromFunctionField := rfl
+
+/--
+Given `S`-schemes `X` and `Y` such that `Y` is locally of finite type and `X` is integral,
+any `S`-morphism `Spec K(X) ⟶ Y` spreads out to a rational map from `X` to `Y`.
+-/
+noncomputable
+def RationalMap.ofFunctionField [IsIntegral X] [LocallyOfFiniteType sY]
+    (f : Spec X.functionField ⟶ Y) (h : f ≫ sY = X.fromSpecStalk _ ≫ sX) : X ⤏ Y :=
+  (PartialMap.ofFromSpecStalk sX sY f h).toRationalMap
+
+lemma RationalMap.fromFunctionField_ofFunctionField [IsIntegral X] [LocallyOfFiniteType sY]
+    (f : Spec X.functionField ⟶ Y) (h : f ≫ sY = X.fromSpecStalk _ ≫ sX) :
+    (ofFunctionField sX sY f h).fromFunctionField = f :=
+  PartialMap.fromSpecStalkOfMem_ofFromSpecStalk sX sY _ _
+
+lemma RationalMap.eq_of_fromFunctionField_eq [IsIntegral X]
+    {x : X} [X.IsGermInjectiveAt x] (f g : X.RationalMap Y)
+    (H : f.fromFunctionField = g.fromFunctionField) : f = g := by
+    obtain ⟨f, rfl⟩ := f.exists_rep
+    obtain ⟨g, rfl⟩ := g.exists_rep
+    refine PartialMap.toRationalMap_eq_iff.mpr ?_
+    exact PartialMap.equiv_of_fromSpecStalkOfMem_eq _ _ _ _ H
+
+/--
+Given `S`-schemes `X` and `Y` such that `Y` is locally of finite type and `X` is integral,
+`S`-morphism `Spec K(X) ⟶ Y` corresponds bijectively to `S`-rational map from `X` to `Y`.
+-/
+noncomputable
+def RationalMap.equivFunctionField [IsIntegral X] [LocallyOfFiniteType sY] :
+    { f : Spec X.functionField ⟶ Y // f ≫ sY = X.fromSpecStalk _ ≫ sX} ≃
+      { f : X ⤏ Y // f.compHom sY = sX.toRationalMap } where
+  toFun f := ⟨.ofFunctionField sX sY f f.2, PartialMap.toRationalMap_eq_iff.mpr
+      ⟨_, PartialMap.dense_domain _, le_rfl, le_top, by simp [PartialMap.ofFromSpecStalk_comp]⟩⟩
+  invFun f := ⟨f.1.fromFunctionField, by
+    obtain ⟨f, hf⟩ := f
+    obtain ⟨f, rfl⟩ := f.exists_rep
+    simpa [fromFunctionField_toRationalMap] using congr(RationalMap.fromFunctionField $hf)⟩
+  left_inv f := Subtype.ext (RationalMap.fromFunctionField_ofFunctionField _ _ _ _)
+  right_inv f := Subtype.ext (RationalMap.eq_of_fromFunctionField_eq
+      (ofFunctionField sX sY f.1.fromFunctionField _) f
+      (x := genericPoint X) (RationalMap.fromFunctionField_ofFunctionField _ _ _ _))
+
+end Scheme
+
+end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/RationalMap.lean
+++ b/Mathlib/AlgebraicGeometry/RationalMap.lean
@@ -306,4 +306,3 @@ def RationalMap.equivFunctionField [IsIntegral X] [LocallyOfFiniteType sY] :
 end Scheme
 
 end AlgebraicGeometry
-#min_imports

--- a/Mathlib/AlgebraicGeometry/RationalMap.lean
+++ b/Mathlib/AlgebraicGeometry/RationalMap.lean
@@ -259,7 +259,7 @@ lemma PartialMap.toRationalMap_eq_iff {f g : X.PartialMap Y} :
 
 @[simp]
 lemma PartialMap.restrict_toRationalMap (f : X.PartialMap Y) (U : X.Opens)
-      (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) :
+    (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) :
     (f.restrict U hU hU').toRationalMap = f.toRationalMap :=
   toRationalMap_eq_iff.mpr (f.restrict_equiv U hU hU')
 

--- a/Mathlib/AlgebraicGeometry/RationalMap.lean
+++ b/Mathlib/AlgebraicGeometry/RationalMap.lean
@@ -206,7 +206,6 @@ lemma restrict_equiv (f : X.PartialMap Y) (U : X.Opens)
     (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) : (f.restrict U hU hU').equiv f :=
   ⟨U, hU, le_rfl, hU', by simp⟩
 
-
 lemma equiv_of_fromSpecStalkOfMem_eq [IrreducibleSpace X]
     {x : X} [X.IsGermInjectiveAt x] (f g : X.PartialMap Y)
     (hxf : x ∈ f.domain) (hxg : x ∈ g.domain)

--- a/Mathlib/AlgebraicGeometry/RationalMap.lean
+++ b/Mathlib/AlgebraicGeometry/RationalMap.lean
@@ -222,6 +222,7 @@ where two partial maps are equivalent if they are equal on a dense open subschem
 def RationalMap (X Y : Scheme.{u}) : Type u :=
   @_root_.Quotient (X.PartialMap Y) inferInstance
 
+/-- The notation for rational maps. -/
 scoped[AlgebraicGeometry] infix:10 " ⤏ " => Scheme.RationalMap
 
 /-- A partial map as a rational map. -/
@@ -264,7 +265,7 @@ def RationalMap.fromFunctionField [IrreducibleSpace X] (f : X ⤏ Y) :
 
 @[simp]
 lemma RationalMap.fromFunctionField_toRationalMap [IrreducibleSpace X] (f : X.PartialMap Y) :
-  f.toRationalMap.fromFunctionField = f.fromFunctionField := rfl
+    f.toRationalMap.fromFunctionField = f.fromFunctionField := rfl
 
 /--
 Given `S`-schemes `X` and `Y` such that `Y` is locally of finite type and `X` is integral,
@@ -280,8 +281,7 @@ lemma RationalMap.fromFunctionField_ofFunctionField [IsIntegral X] [LocallyOfFin
     (ofFunctionField sX sY f h).fromFunctionField = f :=
   PartialMap.fromSpecStalkOfMem_ofFromSpecStalk sX sY _ _
 
-lemma RationalMap.eq_of_fromFunctionField_eq [IsIntegral X]
-    {x : X} [X.IsGermInjectiveAt x] (f g : X.RationalMap Y)
+lemma RationalMap.eq_of_fromFunctionField_eq [IsIntegral X] (f g : X.RationalMap Y)
     (H : f.fromFunctionField = g.fromFunctionField) : f = g := by
     obtain ⟨f, rfl⟩ := f.exists_rep
     obtain ⟨g, rfl⟩ := g.exists_rep
@@ -305,7 +305,7 @@ def RationalMap.equivFunctionField [IsIntegral X] [LocallyOfFiniteType sY] :
   left_inv f := Subtype.ext (RationalMap.fromFunctionField_ofFunctionField _ _ _ _)
   right_inv f := Subtype.ext (RationalMap.eq_of_fromFunctionField_eq
       (ofFunctionField sX sY f.1.fromFunctionField _) f
-      (x := genericPoint X) (RationalMap.fromFunctionField_ofFunctionField _ _ _ _))
+      (RationalMap.fromFunctionField_ofFunctionField _ _ _ _))
 
 end Scheme
 

--- a/Mathlib/AlgebraicGeometry/RationalMap.lean
+++ b/Mathlib/AlgebraicGeometry/RationalMap.lean
@@ -19,13 +19,13 @@ import Mathlib.AlgebraicGeometry.FunctionField
   A rational map from `X` to `Y` (`X ⤏ Y`) is an equivalence class of partial maps.
 * `AlgebraicGeometry.Scheme.RationalMap.equivFunctionField`:
   Given `S`-schemes `X` and `Y` such that `Y` is locally of finite type and `X` is integral,
-  `S`-morphism `Spec K(X) ⟶ Y` corresponds bijectively to `S`-rational map from `X` to `Y`.
+  `S`-morphisms `Spec K(X) ⟶ Y` correspond bijectively to `S`-rational maps from `X` to `Y`.
 
 -/
 
 universe u
 
-open CategoryTheory
+open CategoryTheory hiding Quotient
 
 namespace AlgebraicGeometry
 
@@ -64,7 +64,7 @@ lemma ext (f g : X.PartialMap Y) (e : f.domain = g.domain)
   exact ⟨e, H⟩
 
 /-- The restriction of a partial map to a smaller domain. -/
-@[simps domain hom]
+@[simps hom, simps (config := .lemmasOnly) domain]
 noncomputable
 def restrict (f : X.PartialMap Y) (U : X.Opens)
     (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) : X.PartialMap Y where
@@ -104,7 +104,7 @@ abbrev fromFunctionField [IrreducibleSpace X] (f : X.PartialMap Y) :
     ((genericPoint_specializes _).mem_open f.domain.2 f.dense_domain.nonempty.choose_spec)
 
 lemma fromSpecStalkOfMem_restrict (f : X.PartialMap Y)
-    (U : X.Opens) (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) {x} (hx : x ∈ U) :
+    {U : X.Opens} (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) {x} (hx : x ∈ U) :
     (f.restrict U hU hU').fromSpecStalkOfMem hx = f.fromSpecStalkOfMem (hU' hx) := by
   dsimp only [fromSpecStalkOfMem, restrict, Scheme.Opens.fromSpecStalkOfMem]
   have e : ⟨x, hU' hx⟩ = (X.homOfLE hU').base ⟨x, hx⟩ := by
@@ -121,13 +121,13 @@ lemma fromSpecStalkOfMem_restrict (f : X.PartialMap Y)
   rw [← stalkSpecializes_stalkMap_assoc, stalkMap_comp]
 
 lemma fromFunctionField_restrict (f : X.PartialMap Y) [IrreducibleSpace X]
-    (U : X.Opens) (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) :
+    {U : X.Opens} (hU : Dense (U : Set X)) (hU' : U ≤ f.domain) :
     (f.restrict U hU hU').fromFunctionField = f.fromFunctionField :=
-  fromSpecStalkOfMem_restrict f _ _ _ _
+  fromSpecStalkOfMem_restrict f _ _ _
 
 /--
 Given `S`-schemes `X` and `Y` such that `Y` is locally of finite type and
-`X` is irreducible and "germ-injective" (e.g. when `X` is integral),
+`X` is irreducible germ-injective at `x` (e.g. when `X` is integral),
 any `S`-morphism `Spec 𝒪ₓ ⟶ Y` spreads out to a partial map from `X` to `Y`.
 -/
 noncomputable
@@ -170,7 +170,7 @@ def equiv (f g : X.PartialMap Y) : Prop :=
   ∃ (W : X.Opens) (hW : Dense (W : Set X)) (hWl : W ≤ f.domain) (hWr : W ≤ g.domain),
     (f.restrict W hW hWl).hom = (g.restrict W hW hWr).hom
 
-lemma iseqv_rel : _root_.Equivalence (@Scheme.PartialMap.equiv X Y) where
+lemma iseqv_rel : Equivalence (@Scheme.PartialMap.equiv X Y) where
   refl f := ⟨f.domain, f.dense_domain, by simp⟩
   symm {f g} := by
     intro ⟨W, hW, hWl, hWr, e⟩
@@ -206,8 +206,8 @@ lemma equiv_of_fromSpecStalkOfMem_eq [IrreducibleSpace X]
     simp only [TopologicalSpace.Opens.carrier_eq_coe, IsOpenMap.functor_obj_coe,
       TopologicalSpace.Opens.coe_inf, restrict_hom, ← Category.assoc] at e ⊢
     convert e using 2 <;> rw [← cancel_mono (Scheme.Opens.ι _)] <;> simp
-  · rw [← f.fromSpecStalkOfMem_restrict _ hdense inf_le_left ⟨hxf, hxg⟩,
-      ← g.fromSpecStalkOfMem_restrict _ hdense inf_le_right ⟨hxf, hxg⟩] at H
+  · rw [← f.fromSpecStalkOfMem_restrict hdense inf_le_left ⟨hxf, hxg⟩,
+      ← g.fromSpecStalkOfMem_restrict hdense inf_le_right ⟨hxf, hxg⟩] at H
     simpa only [fromSpecStalkOfMem, restrict_domain, Opens.fromSpecStalkOfMem, Spec.map_inv,
       restrict_hom, Category.assoc, IsIso.eq_inv_comp, IsIso.hom_inv_id_assoc] using H
 
@@ -216,7 +216,7 @@ end PartialMap
 /-- A rational map from `X` to `Y` (`X ⤏ Y`) is an equivalence class of partial maps,
 where two partial maps are equivalent if they are equal on a dense open subscheme.  -/
 def RationalMap (X Y : Scheme.{u}) : Type u :=
-  @_root_.Quotient (X.PartialMap Y) inferInstance
+  @Quotient (X.PartialMap Y) inferInstance
 
 /-- The notation for rational maps. -/
 scoped[AlgebraicGeometry] infix:10 " ⤏ " => Scheme.RationalMap
@@ -228,16 +228,16 @@ def PartialMap.toRationalMap (f : X.PartialMap Y) : X ⤏ Y := Quotient.mk _ f
 abbrev Hom.toRationalMap (f : X.Hom Y) : X ⤏ Y := f.toPartialMap.toRationalMap
 
 lemma PartialMap.toRationalMap_surjective : Function.Surjective (@toRationalMap X Y) :=
-  _root_.Quotient.exists_rep
+  Quotient.exists_rep
 
 lemma RationalMap.exists_rep (f : X ⤏ Y) : ∃ g : X.PartialMap Y, g.toRationalMap = f :=
-  _root_.Quotient.exists_rep f
+  Quotient.exists_rep f
 
 lemma PartialMap.toRationalMap_eq_iff {f g : X.PartialMap Y} :
     f.toRationalMap = g.toRationalMap ↔ f.equiv g :=
   Quotient.eq
 
-/-- A rational map restricts to a map from `Spec K(X)`. -/
+/-- The composition of a rational map and a morphism on the right. -/
 def RationalMap.compHom (f : X ⤏ Y) (g : Y ⟶ Z) : X ⤏ Z := by
   refine Quotient.map (PartialMap.compHom · g) ?_ f
   intro f₁ f₂ ⟨W, hW, hWl, hWr, e⟩
@@ -250,14 +250,14 @@ def RationalMap.compHom (f : X ⤏ Y) (g : Y ⟶ Z) : X ⤏ Z := by
 lemma RationalMap.compHom_toRationalMap (f : X.PartialMap Y) (g : Y ⟶ Z) :
     f.toRationalMap.compHom g = (f.compHom g).toRationalMap := rfl
 
-/-- The composition of a rational map and a morphism on the right. -/
+/-- A rational map restricts to a map from `Spec K(X)`. -/
 noncomputable
 def RationalMap.fromFunctionField [IrreducibleSpace X] (f : X ⤏ Y) :
     Spec X.functionField ⟶ Y := by
   refine Quotient.lift PartialMap.fromFunctionField ?_ f
   intro f g ⟨W, hW, hWl, hWr, e⟩
   have : f.restrict W hW hWl = g.restrict W hW hWr := by ext1; rfl; rw [e]; simp
-  rw [← f.fromFunctionField_restrict W hW hWl, this, g.fromFunctionField_restrict]
+  rw [← f.fromFunctionField_restrict hW hWl, this, g.fromFunctionField_restrict]
 
 @[simp]
 lemma RationalMap.fromFunctionField_toRationalMap [IrreducibleSpace X] (f : X.PartialMap Y) :
@@ -286,7 +286,7 @@ lemma RationalMap.eq_of_fromFunctionField_eq [IsIntegral X] (f g : X.RationalMap
 
 /--
 Given `S`-schemes `X` and `Y` such that `Y` is locally of finite type and `X` is integral,
-`S`-morphism `Spec K(X) ⟶ Y` corresponds bijectively to `S`-rational map from `X` to `Y`.
+`S`-morphisms `Spec K(X) ⟶ Y` correspond bijectively to `S`-rational maps from `X` to `Y`.
 -/
 noncomputable
 def RationalMap.equivFunctionField [IsIntegral X] [LocallyOfFiniteType sY] :

--- a/Mathlib/AlgebraicGeometry/RationalMap.lean
+++ b/Mathlib/AlgebraicGeometry/RationalMap.lean
@@ -3,10 +3,6 @@ Copyright (c) 2024 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.CategoryTheory.Limits.Constructions.Over.Connected
-import Mathlib.CategoryTheory.Limits.Constructions.Over.Products
-import Mathlib.CategoryTheory.Limits.Constructions.Over.Basic
-import Mathlib.AlgebraicGeometry.Morphisms.Separated
 import Mathlib.AlgebraicGeometry.SpreadingOut
 import Mathlib.AlgebraicGeometry.FunctionField
 /-!
@@ -310,3 +306,4 @@ def RationalMap.equivFunctionField [IsIntegral X] [LocallyOfFiniteType sY] :
 end Scheme
 
 end AlgebraicGeometry
+#min_imports

--- a/Mathlib/AlgebraicGeometry/SpreadingOut.lean
+++ b/Mathlib/AlgebraicGeometry/SpreadingOut.lean
@@ -216,6 +216,20 @@ lemma spread_out_unique_of_isGermInjective {x : X} [X.IsGermInjectiveAt x]
   simp only [Scheme.Hom.appLE, Category.assoc, X.presheaf.germ_res', ← Scheme.stalkMap_germ, H]
   simp only [TopCat.Presheaf.germ_stalkSpecializes_assoc, Scheme.stalkMap_germ]
 
+/--
+A variant of `spread_out_unique_of_isGermInjective`
+whose condition is an equality of scheme morphisms instead of ring homomorphisms.
+-/
+lemma spread_out_unique_of_isGermInjective' {x : X} [X.IsGermInjectiveAt x]
+    (f g : X ⟶ Y)
+    (e : X.fromSpecStalk x ≫ f = X.fromSpecStalk x ≫ g) :
+    ∃ (U : X.Opens), x ∈ U ∧ U.ι ≫ f = U.ι ≫ g := by
+  fapply spread_out_unique_of_isGermInjective
+  · simpa using congr(($e).base (LocalRing.closedPoint _))
+  · apply Spec.map_injective
+    rw [← cancel_mono (Y.fromSpecStalk _)]
+    simpa [Scheme.Spec_map_stalkSpecializes_fromSpecStalk]
+
 lemma exists_lift_of_germInjective_aux {U : X.Opens} {x : X} (hxU)
     (φ : A ⟶ X.presheaf.stalk x) (φRA : R ⟶ A) (φRX : R ⟶ Γ(X, U))
     (hφRA : RingHom.FiniteType φRA)
@@ -333,5 +347,27 @@ lemma spread_out_of_isGermInjective [LocallyOfFiniteType sY] {x : X} [X.IsGermIn
     rw [← IsAffineOpen.Spec_map_appLE_fromSpec sY hU hV iVU, ← Spec.map_comp_assoc, ← h₂,
       ← Scheme.Hom.appLE, ← hW.isoSpec_hom, IsAffineOpen.Spec_map_appLE_fromSpec sX hU hW i,
       ← Iso.eq_inv_comp, IsAffineOpen.isoSpec_inv_ι_assoc]
+
+/--
+Given `S`-schemes `X Y` and points `x : X`, and a `S`-morphism `φ : Spec 𝒪_{X, x} ⟶ Y`,
+we may spread it out to a morphism `S`-morphism `f : U ⟶ Y`
+provided that `Y` is locally of finite type over `S` and
+`X` is "germ-injective" at `x` (e.g. when it's integral or locally noetherian).
+
+TODO: The condition on `X` is unnecessary when `Y` is locally of finite presentation.
+-/
+lemma spread_out_of_isGermInjective' [LocallyOfFiniteType sY] {x : X} [X.IsGermInjectiveAt x]
+    (φ : Spec (X.presheaf.stalk x) ⟶ Y)
+    (h : φ ≫ sY = X.fromSpecStalk x ≫ sX) :
+    ∃ (U : X.Opens) (hxU : x ∈ U) (f : U.toScheme ⟶ Y),
+      φ = U.fromSpecStalkOfMem x hxU ≫ f ∧ f ≫ sY = U.ι ≫ sX := by
+  have := spread_out_of_isGermInjective sX sY ?_ (Scheme.stalkClosedPointTo φ) ?_
+  · simpa only [Scheme.Spec_stalkClosedPointTo_fromSpecStalk] using this
+  · rw [← Scheme.comp_base_apply, h, Scheme.comp_base_apply, Scheme.fromSpecStalk_closedPoint]
+  · apply Spec.map_injective
+    rw [← cancel_mono (S.fromSpecStalk _)]
+    simpa only [Spec.map_comp, Category.assoc, Scheme.Spec_map_stalkMap_fromSpecStalk,
+      Scheme.Spec_stalkClosedPointTo_fromSpecStalk_assoc,
+      Scheme.Spec_map_stalkSpecializes_fromSpecStalk]
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/SpreadingOut.lean
+++ b/Mathlib/AlgebraicGeometry/SpreadingOut.lean
@@ -349,8 +349,8 @@ lemma spread_out_of_isGermInjective [LocallyOfFiniteType sY] {x : X} [X.IsGermIn
       ← Iso.eq_inv_comp, IsAffineOpen.isoSpec_inv_ι_assoc]
 
 /--
-Given `S`-schemes `X Y` and points `x : X`, and a `S`-morphism `φ : Spec 𝒪_{X, x} ⟶ Y`,
-we may spread it out to a morphism `S`-morphism `f : U ⟶ Y`
+Given `S`-schemes `X Y`, a point `x : X`, and a `S`-morphism `φ : Spec 𝒪_{X, x} ⟶ Y`,
+we may spread it out to an `S`-morphism `f : U ⟶ Y`
 provided that `Y` is locally of finite type over `S` and
 `X` is "germ-injective" at `x` (e.g. when it's integral or locally noetherian).
 

--- a/Mathlib/AlgebraicGeometry/Stalk.lean
+++ b/Mathlib/AlgebraicGeometry/Stalk.lean
@@ -161,6 +161,12 @@ def Opens.fromSpecStalkOfMem {X : Scheme.{u}} (U : X.Opens) (x : X) (hxU : x ∈
     Spec (X.presheaf.stalk x) ⟶ U :=
   Spec.map (inv (U.ι.stalkMap ⟨x, hxU⟩)) ≫ U.toScheme.fromSpecStalk ⟨x, hxU⟩
 
+@[reassoc (attr := simp)]
+lemma Opens.fromSpecStalkOfMem_ι {X : Scheme.{u}} (U : X.Opens) (x : X) (hxU : x ∈ U) :
+    U.fromSpecStalkOfMem x hxU ≫ U.ι = X.fromSpecStalk x := by
+  simp only [Opens.fromSpecStalkOfMem, Spec.map_inv, Category.assoc, IsIso.inv_comp_eq]
+  exact (Scheme.Spec_map_stalkMap_fromSpecStalk U.ι (x := ⟨x, hxU⟩)).symm
+
 @[reassoc]
 lemma fromSpecStalk_toSpecΓ (X : Scheme.{u}) (x : X) :
     X.fromSpecStalk x ≫ X.toSpecΓ = Spec.map (X.presheaf.germ ⊤ x trivial) := by


### PR DESCRIPTION
and show that they are equivalent to `Spec X.functionField ⟶ Y`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
