### PR TITLE
[Merged by Bors] - chore(Data/Matroid/Basic): document suffix convention

### DIFF
--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -133,7 +133,7 @@ There are a few design decisions worth discussing.
   so our notation mirrors common practice.
 
 ### Notation
-  We use a couple of nonstandard conventions in theorem names that are related to the above.
+  We use a few nonstandard conventions in theorem names that are related to the above.
   First, we mirror common informal practice by referring explicitly to the `ground` set rather
   than the notation `E`. (Writing `ground` everywhere in a proof term would be unwieldy, and
   writing `E` in theorem names would be unnatural to read.)

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -146,6 +146,10 @@ There are a few design decisions worth discussing.
   with respect to the ground set, rather than a complement within a type. The lemma
   `compl_base_dual` is one of the many examples of this.
 
+  Finally, in theorem names, matroid predicates that apply to sets
+  (such as `Base`, `Indep`, `Basis`) are typically used as suffixes rather than prefixes.
+  For instance, we have `ground_indep_iff_base` rather than `indep_ground_iff_base`.
+
 ## References
 
 [1] The standard text on matroid theory


### PR DESCRIPTION
We add a few lines to the docstring for `Matroid` indicating the fact that theorem names use matroid predicates on sets as suffixes rather than prefixes. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
