### PR TITLE
[Merged by Bors] - chore(Algebra/Group/Action): reduce theory included with `Group.Action.Defs`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -227,12 +227,16 @@ import Mathlib.Algebra.GradedMonoid
 import Mathlib.Algebra.GradedMulAction
 import Mathlib.Algebra.Group.Action.Basic
 import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.Action.End
+import Mathlib.Algebra.Group.Action.Faithful
 import Mathlib.Algebra.Group.Action.Opposite
 import Mathlib.Algebra.Group.Action.Option
 import Mathlib.Algebra.Group.Action.Pi
+import Mathlib.Algebra.Group.Action.Pretransitive
 import Mathlib.Algebra.Group.Action.Prod
 import Mathlib.Algebra.Group.Action.Sigma
 import Mathlib.Algebra.Group.Action.Sum
+import Mathlib.Algebra.Group.Action.TypeTags
 import Mathlib.Algebra.Group.Action.Units
 import Mathlib.Algebra.Group.AddChar
 import Mathlib.Algebra.Group.Aut

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -4,9 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Commute.Defs
-import Mathlib.Algebra.Group.TypeTags
 import Mathlib.Algebra.Opposites
+import Mathlib.Data.FunLike.Basic
 import Mathlib.Logic.Embedding.Basic
+import Mathlib.Logic.Function.Iterate
+import Mathlib.Logic.Nontrivial.Basic
+import Mathlib.Tactic.Spread
 
 /-!
 # Definitions of group actions
@@ -22,8 +25,7 @@ notation classes `SMul` and its additive version `VAdd`:
 
 The hierarchy is extended further by `Module`, defined elsewhere.
 
-Also provided are typeclasses for faithful and transitive actions, and typeclasses regarding the
-interaction of different group actions,
+Also provided are typeclasses regarding the interaction of different group actions,
 
 * `SMulCommClass M N α` and its additive version `VAddCommClass M N α`;
 * `IsScalarTower M N α` and its additive version `VAddAssocClass M N α`;
@@ -50,26 +52,6 @@ open Function (Injective Surjective)
 
 variable {M N G H α β γ δ : Type*}
 
-/-! ### Faithful actions -/
-
-/-- Typeclass for faithful actions. -/
-class FaithfulVAdd (G : Type*) (P : Type*) [VAdd G P] : Prop where
-  /-- Two elements `g₁` and `g₂` are equal whenever they act in the same way on all points. -/
-  eq_of_vadd_eq_vadd : ∀ {g₁ g₂ : G}, (∀ p : P, g₁ +ᵥ p = g₂ +ᵥ p) → g₁ = g₂
-
-/-- Typeclass for faithful actions. -/
-@[to_additive]
-class FaithfulSMul (M : Type*) (α : Type*) [SMul M α] : Prop where
-  /-- Two elements `m₁` and `m₂` are equal whenever they act in the same way on all points. -/
-  eq_of_smul_eq_smul : ∀ {m₁ m₂ : M}, (∀ a : α, m₁ • a = m₂ • a) → m₁ = m₂
-
-export FaithfulSMul (eq_of_smul_eq_smul)
-export FaithfulVAdd (eq_of_vadd_eq_vadd)
-
-@[to_additive]
-lemma smul_left_injective' [SMul M α] [FaithfulSMul M α] : Injective ((· • ·) : M → α → α) :=
-  fun _ _ h ↦ FaithfulSMul.eq_of_smul_eq_smul (congr_fun h)
-
 -- see Note [lower instance priority]
 /-- See also `Monoid.toMulAction` and `MulZeroClass.toSMulWithZero`. -/
 @[to_additive "See also `AddMonoid.toAddAction`"]
@@ -77,11 +59,6 @@ instance (priority := 910) Mul.toSMul (α : Type*) [Mul α] : SMul α α := ⟨(
 
 @[to_additive (attr := simp)]
 lemma smul_eq_mul (α : Type*) [Mul α] {a a' : α} : a • a' = a * a' := rfl
-
-/-- `Monoid.toMulAction` is faithful on cancellative monoids. -/
-@[to_additive " `AddMonoid.toAddAction` is faithful on additive cancellative monoids. "]
-instance RightCancelMonoid.faithfulSMul [RightCancelMonoid α] : FaithfulSMul α α :=
-  ⟨fun h ↦ mul_right_cancel (h 1)⟩
 
 /-- Type class for additive monoid actions. -/
 class AddAction (G : Type*) (P : Type*) [AddMonoid G] extends VAdd G P where
@@ -97,48 +74,6 @@ class MulAction (α : Type*) (β : Type*) [Monoid α] extends SMul α β where
   protected one_smul : ∀ b : β, (1 : α) • b = b
   /-- Associativity of `•` and `*` -/
   mul_smul : ∀ (x y : α) (b : β), (x * y) • b = x • y • b
-
-/-!
-### (Pre)transitive action
-
-`M` acts pretransitively on `α` if for any `x y` there is `g` such that `g • x = y` (or `g +ᵥ x = y`
-for an additive action). A transitive action should furthermore have `α` nonempty.
-
-In this section we define typeclasses `MulAction.IsPretransitive` and
-`AddAction.IsPretransitive` and provide `MulAction.exists_smul_eq`/`AddAction.exists_vadd_eq`,
-`MulAction.surjective_smul`/`AddAction.surjective_vadd` as public interface to access this
-property. We do not provide typeclasses `*Action.IsTransitive`; users should assume
-`[MulAction.IsPretransitive M α] [Nonempty α]` instead.
--/
-
-/-- `M` acts pretransitively on `α` if for any `x y` there is `g` such that `g +ᵥ x = y`.
-  A transitive action should furthermore have `α` nonempty. -/
-class AddAction.IsPretransitive (M α : Type*) [VAdd M α] : Prop where
-  /-- There is `g` such that `g +ᵥ x = y`. -/
-  exists_vadd_eq : ∀ x y : α, ∃ g : M, g +ᵥ x = y
-
-/-- `M` acts pretransitively on `α` if for any `x y` there is `g` such that `g • x = y`.
-  A transitive action should furthermore have `α` nonempty. -/
-@[to_additive]
-class MulAction.IsPretransitive (M α : Type*) [SMul M α] : Prop where
-  /-- There is `g` such that `g • x = y`. -/
-  exists_smul_eq : ∀ x y : α, ∃ g : M, g • x = y
-
-namespace MulAction
-variable (M) [SMul M α] [IsPretransitive M α]
-
-@[to_additive]
-lemma exists_smul_eq (x y : α) : ∃ m : M, m • x = y := IsPretransitive.exists_smul_eq x y
-
-@[to_additive]
-lemma surjective_smul (x : α) : Surjective fun c : M ↦ c • x := exists_smul_eq M x
-
-/-- The regular action of a group on itself is transitive. -/
-@[to_additive "The regular action of a group on itself is transitive."]
-instance Regular.isPretransitive [Group G] : IsPretransitive G G :=
-  ⟨fun x y ↦ ⟨y * x⁻¹, inv_mul_cancel_right _ _⟩⟩
-
-end MulAction
 
 /-! ### Scalar tower and commuting actions -/
 
@@ -427,19 +362,6 @@ protected abbrev Function.Surjective.mulAction [SMul M β] (f : α → β) (hf :
   one_smul := by simp [hf.forall, ← smul]
   mul_smul := by simp [hf.forall, ← smul, mul_smul]
 
-/-- Push forward the action of `R` on `M` along a compatible surjective map `f : R →* S`.
-
-See also `Function.Surjective.distribMulActionLeft` and `Function.Surjective.moduleLeft`.
--/
-@[to_additive
-"Push forward the action of `R` on `M` along a compatible surjective map `f : R →+ S`."]
-abbrev Function.Surjective.mulActionLeft {R S M : Type*} [Monoid R] [MulAction R M] [Monoid S]
-    [SMul S M] (f : R →* S) (hf : Surjective f) (hsmul : ∀ (c) (x : M), f c • x = c • x) :
-    MulAction S M where
-  smul := (· • ·)
-  one_smul b := by rw [← f.map_one, hsmul, one_smul]
-  mul_smul := hf.forall₂.mpr fun a b x ↦ by simp only [← f.map_mul, hsmul, mul_smul]
-
 section
 variable (M)
 
@@ -528,55 +450,6 @@ def toFun : α ↪ M → α :=
 @[to_additive (attr := simp)]
 lemma toFun_apply (x : M) (y : α) : MulAction.toFun M α y x = x • y := rfl
 
-variable (α)
-
-/-- A multiplicative action of `M` on `α` and a monoid homomorphism `N → M` induce
-a multiplicative action of `N` on `α`.
-
-See note [reducible non-instances]. -/
-@[to_additive]
-abbrev compHom [Monoid N] (g : N →* M) : MulAction N α where
-  smul := SMul.comp.smul g
-  -- Porting note: was `by simp [g.map_one, MulAction.one_smul]`
-  one_smul _ := by simpa [(· • ·)] using MulAction.one_smul ..
-  -- Porting note: was `by simp [g.map_mul, MulAction.mul_smul]`
-  mul_smul _ _ _ := by simpa [(· • ·)] using MulAction.mul_smul ..
-
-/-- An additive action of `M` on `α` and an additive monoid homomorphism `N → M` induce
-an additive action of `N` on `α`.
-
-See note [reducible non-instances]. -/
-add_decl_doc AddAction.compHom
-
-@[to_additive]
-lemma compHom_smul_def
-    {E F G : Type*} [Monoid E] [Monoid F] [MulAction F G] (f : E →* F) (a : E) (x : G) :
-    letI : MulAction E G := MulAction.compHom _ f
-    a • x = (f a) • x := rfl
-
-/-- If an action is transitive, then composing this action with a surjective homomorphism gives
-again a transitive action. -/
-@[to_additive]
-lemma isPretransitive_compHom {E F G : Type*} [Monoid E] [Monoid F] [MulAction F G]
-    [IsPretransitive F G] {f : E →* F} (hf : Surjective f) :
-    letI : MulAction E G := MulAction.compHom _ f
-    IsPretransitive E G := by
-  let _ : MulAction E G := MulAction.compHom _ f
-  refine ⟨fun x y ↦ ?_⟩
-  obtain ⟨m, rfl⟩ : ∃ m : F, m • x = y := exists_smul_eq F x y
-  obtain ⟨e, rfl⟩ : ∃ e, f e = m := hf m
-  exact ⟨e, rfl⟩
-
-@[to_additive]
-lemma IsPretransitive.of_smul_eq {M N α : Type*} [SMul M α] [SMul N α] [IsPretransitive M α]
-    (f : M → N) (hf : ∀ {c : M} {x : α}, f c • x = c • x) : IsPretransitive N α where
-  exists_smul_eq x y := (exists_smul_eq x y).elim fun m h ↦ ⟨f m, hf.trans h⟩
-
-@[to_additive]
-lemma IsPretransitive.of_compHom {M N α : Type*} [Monoid M] [Monoid N] [MulAction N α]
-    (f : M →* N) [h : letI := compHom α f; IsPretransitive M α] : IsPretransitive N α :=
-  letI := compHom α f; h.of_smul_eq f rfl
-
 end MulAction
 end
 
@@ -586,11 +459,6 @@ section CompatibleScalar
 lemma smul_one_smul {M} (N) [Monoid N] [SMul M N] [MulAction N α] [SMul M α]
     [IsScalarTower M N α] (x : M) (y : α) : (x • (1 : N)) • y = x • y := by
   rw [smul_assoc, one_smul]
-
-@[to_additive]
-lemma MulAction.IsPretransitive.of_isScalarTower (M : Type*) {N α : Type*} [Monoid N] [SMul M N]
-    [MulAction N α] [SMul M α] [IsScalarTower M N α] [IsPretransitive M α] : IsPretransitive N α :=
-  of_smul_eq (fun x : M ↦ x • 1) (smul_one_smul N _ _)
 
 @[to_additive (attr := simp)]
 lemma smul_one_mul {M N} [MulOneClass N] [SMul M N] [IsScalarTower M N N] (x : M) (y : N) :
@@ -610,153 +478,4 @@ lemma SMulCommClass.of_mul_smul_one {M N} [Monoid N] [SMul M N]
     (H : ∀ (x : M) (y : N), y * x • (1 : N) = x • y) : SMulCommClass M N N :=
   ⟨fun x y z ↦ by rw [← H x z, smul_eq_mul, ← H, smul_eq_mul, mul_assoc]⟩
 
-/-- If the multiplicative action of `M` on `N` is compatible with multiplication on `N`, then
-`fun x ↦ x • 1` is a monoid homomorphism from `M` to `N`. -/
-@[to_additive (attr := simps)
-"If the additive action of `M` on `N` is compatible with addition on `N`, then
-`fun x ↦ x +ᵥ 0` is an additive monoid homomorphism from `M` to `N`."]
-def MonoidHom.smulOneHom {M N} [Monoid M] [MulOneClass N] [MulAction M N] [IsScalarTower M N N] :
-    M →* N where
-  toFun x := x • (1 : N)
-  map_one' := one_smul _ _
-  map_mul' x y := by rw [smul_one_mul, smul_smul]
-
-/-- A monoid homomorphism between two monoids M and N can be equivalently specified by a
-multiplicative action of M on N that is compatible with the multiplication on N. -/
-@[to_additive
-"A monoid homomorphism between two additive monoids M and N can be equivalently
-specified by an additive action of M on N that is compatible with the addition on N."]
-def monoidHomEquivMulActionIsScalarTower (M N) [Monoid M] [Monoid N] :
-    (M →* N) ≃ {_inst : MulAction M N // IsScalarTower M N N} where
-  toFun f := ⟨MulAction.compHom N f, SMul.comp.isScalarTower _⟩
-  invFun := fun ⟨_, _⟩ ↦ MonoidHom.smulOneHom
-  left_inv f := MonoidHom.ext fun m ↦ mul_one (f m)
-  right_inv := fun ⟨_, _⟩ ↦ Subtype.ext <| MulAction.ext <| funext₂ <| smul_one_smul N
-
 end CompatibleScalar
-
-variable (α)
-
-/-- The monoid of endomorphisms.
-
-Note that this is generalized by `CategoryTheory.End` to categories other than `Type u`. -/
-protected def Function.End := α → α
-
-instance : Monoid (Function.End α) where
-  one := id
-  mul := (· ∘ ·)
-  mul_assoc _ _ _ := rfl
-  mul_one _ := rfl
-  one_mul _ := rfl
-  npow n f := f^[n]
-  npow_succ _ _ := Function.iterate_succ _ _
-
-instance : Inhabited (Function.End α) := ⟨1⟩
-
-variable {α}
-
-/-- The tautological action by `Function.End α` on `α`.
-
-This is generalized to bundled endomorphisms by:
-* `Equiv.Perm.applyMulAction`
-* `AddMonoid.End.applyDistribMulAction`
-* `AddMonoid.End.applyModule`
-* `AddAut.applyDistribMulAction`
-* `MulAut.applyMulDistribMulAction`
-* `LinearEquiv.applyDistribMulAction`
-* `LinearMap.applyModule`
-* `RingHom.applyMulSemiringAction`
-* `RingAut.applyMulSemiringAction`
-* `AlgEquiv.applyMulSemiringAction`
--/
-instance Function.End.applyMulAction : MulAction (Function.End α) α where
-  smul := (· <| ·)
-  one_smul _ := rfl
-  mul_smul _ _ _ := rfl
-
-@[simp] lemma Function.End.smul_def (f : Function.End α) (a : α) : f • a = f a := rfl
-
---TODO - This statement should be somethting like `toFun (f * g) = toFun f ∘ toFun g`
-lemma Function.End.mul_def (f g : Function.End α) : (f * g) = f ∘ g := rfl
-
---TODO - This statement should be somethting like `toFun 1 = id`
-lemma Function.End.one_def : (1 : Function.End α) = id := rfl
-
-/-- `Function.End.applyMulAction` is faithful. -/
-instance Function.End.apply_FaithfulSMul : FaithfulSMul (Function.End α) α :=
-  ⟨fun {_ _} ↦ funext⟩
-
-/-- The monoid hom representing a monoid action.
-
-When `M` is a group, see `MulAction.toPermHom`. -/
-def MulAction.toEndHom [Monoid M] [MulAction M α] : M →* Function.End α where
-  toFun := (· • ·)
-  map_one' := funext (one_smul M)
-  map_mul' x y := funext (mul_smul x y)
-
-/-- The monoid action induced by a monoid hom to `Function.End α`
-
-See note [reducible non-instances]. -/
-abbrev MulAction.ofEndHom [Monoid M] (f : M →* Function.End α) : MulAction M α :=
-  MulAction.compHom α f
-
-/-! ### `Additive`, `Multiplicative` -/
-
-section
-
-open Additive Multiplicative
-
-instance Additive.vadd [SMul α β] : VAdd (Additive α) β where vadd a := (toMul a • ·)
-
-instance Multiplicative.smul [VAdd α β] : SMul (Multiplicative α) β where smul a := (toAdd a +ᵥ ·)
-
-@[simp] lemma toMul_smul [SMul α β] (a) (b : β) : (toMul a : α) • b = a +ᵥ b := rfl
-
-@[simp] lemma ofMul_vadd [SMul α β] (a : α) (b : β) : ofMul a +ᵥ b = a • b := rfl
-
-@[simp] lemma toAdd_vadd [VAdd α β] (a) (b : β) : (toAdd a : α) +ᵥ b = a • b := rfl
-
-@[simp] lemma ofAdd_smul [VAdd α β] (a : α) (b : β) : ofAdd a • b = a +ᵥ b := rfl
-
--- Porting note: I don't know why `one_smul` can do without an explicit α and `mul_smul` can't.
-instance Additive.addAction [Monoid α] [MulAction α β] : AddAction (Additive α) β where
-  zero_vadd := MulAction.one_smul
-  add_vadd := MulAction.mul_smul (α := α)
-
-instance Multiplicative.mulAction [AddMonoid α] [AddAction α β] :
-    MulAction (Multiplicative α) β where
-  one_smul := AddAction.zero_vadd
-  mul_smul := AddAction.add_vadd (G := α)
-
-instance Additive.addAction_isPretransitive [Monoid α] [MulAction α β]
-    [MulAction.IsPretransitive α β] : AddAction.IsPretransitive (Additive α) β :=
-  ⟨@MulAction.exists_smul_eq α _ _ _⟩
-
-instance Multiplicative.mulAction_isPretransitive [AddMonoid α] [AddAction α β]
-    [AddAction.IsPretransitive α β] : MulAction.IsPretransitive (Multiplicative α) β :=
-  ⟨@AddAction.exists_vadd_eq α _ _ _⟩
-
-instance Additive.vaddCommClass [SMul α γ] [SMul β γ] [SMulCommClass α β γ] :
-    VAddCommClass (Additive α) (Additive β) γ :=
-  ⟨@smul_comm α β _ _ _ _⟩
-
-instance Multiplicative.smulCommClass [VAdd α γ] [VAdd β γ] [VAddCommClass α β γ] :
-    SMulCommClass (Multiplicative α) (Multiplicative β) γ :=
-  ⟨@vadd_comm α β _ _ _ _⟩
-
-end
-
-/-- The tautological additive action by `Additive (Function.End α)` on `α`. -/
-instance AddAction.functionEnd : AddAction (Additive (Function.End α)) α := inferInstance
-
-/-- The additive monoid hom representing an additive monoid action.
-
-When `M` is a group, see `AddAction.toPermHom`. -/
-def AddAction.toEndHom [AddMonoid M] [AddAction M α] : M →+ Additive (Function.End α) :=
-  MonoidHom.toAdditive'' MulAction.toEndHom
-
-/-- The additive action induced by a hom to `Additive (Function.End α)`
-
-See note [reducible non-instances]. -/
-abbrev AddAction.ofEndHom [AddMonoid M] (f : M →+ Additive (Function.End α)) : AddAction M α :=
-  AddAction.compHom α f

--- a/Mathlib/Algebra/Group/Action/End.lean
+++ b/Mathlib/Algebra/Group/Action/End.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2018 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes, Yury Kudryashov
+-/
+import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.Hom.Defs
+
+/-!
+# Endomorphisms, homomorphisms and group actions
+
+This file defines `Function.End` as the monoid of endomorphisms on a type,
+and provides results relating group actions with these endomorphisms.
+
+## Notation
+
+- `a • b` is used as notation for `SMul.smul a b`.
+- `a +ᵥ b` is used as notation for `VAdd.vadd a b`.
+
+## Implementation details
+
+This file should avoid depending on other parts of `GroupTheory`, to avoid import cycles.
+More sophisticated lemmas belong in `GroupTheory.GroupAction`.
+
+## Tags
+
+group action
+-/
+
+assert_not_exists MonoidWithZero
+
+open Function (Injective Surjective)
+
+variable {M N G H α β γ δ : Type*}
+
+section
+variable [Monoid M] [MulAction M α]
+
+/-- Push forward the action of `R` on `M` along a compatible surjective map `f : R →* S`.
+
+See also `Function.Surjective.distribMulActionLeft` and `Function.Surjective.moduleLeft`.
+-/
+@[to_additive
+"Push forward the action of `R` on `M` along a compatible surjective map `f : R →+ S`."]
+abbrev Function.Surjective.mulActionLeft {R S M : Type*} [Monoid R] [MulAction R M] [Monoid S]
+    [SMul S M] (f : R →* S) (hf : Surjective f) (hsmul : ∀ (c) (x : M), f c • x = c • x) :
+    MulAction S M where
+  smul := (· • ·)
+  one_smul b := by rw [← f.map_one, hsmul, one_smul]
+  mul_smul := hf.forall₂.mpr fun a b x ↦ by simp only [← f.map_mul, hsmul, mul_smul]
+
+namespace MulAction
+
+variable (α)
+
+/-- A multiplicative action of `M` on `α` and a monoid homomorphism `N → M` induce
+a multiplicative action of `N` on `α`.
+
+See note [reducible non-instances]. -/
+@[to_additive]
+abbrev compHom [Monoid N] (g : N →* M) : MulAction N α where
+  smul := SMul.comp.smul g
+  -- Porting note: was `by simp [g.map_one, MulAction.one_smul]`
+  one_smul _ := by simpa [(· • ·)] using MulAction.one_smul ..
+  -- Porting note: was `by simp [g.map_mul, MulAction.mul_smul]`
+  mul_smul _ _ _ := by simpa [(· • ·)] using MulAction.mul_smul ..
+
+/-- An additive action of `M` on `α` and an additive monoid homomorphism `N → M` induce
+an additive action of `N` on `α`.
+
+See note [reducible non-instances]. -/
+add_decl_doc AddAction.compHom
+
+@[to_additive]
+lemma compHom_smul_def
+    {E F G : Type*} [Monoid E] [Monoid F] [MulAction F G] (f : E →* F) (a : E) (x : G) :
+    letI : MulAction E G := MulAction.compHom _ f
+    a • x = (f a) • x := rfl
+
+end MulAction
+end
+
+section CompatibleScalar
+
+/-- If the multiplicative action of `M` on `N` is compatible with multiplication on `N`, then
+`fun x ↦ x • 1` is a monoid homomorphism from `M` to `N`. -/
+@[to_additive (attr := simps)
+"If the additive action of `M` on `N` is compatible with addition on `N`, then
+`fun x ↦ x +ᵥ 0` is an additive monoid homomorphism from `M` to `N`."]
+def MonoidHom.smulOneHom {M N} [Monoid M] [MulOneClass N] [MulAction M N] [IsScalarTower M N N] :
+    M →* N where
+  toFun x := x • (1 : N)
+  map_one' := one_smul _ _
+  map_mul' x y := by rw [smul_one_mul, smul_smul]
+
+/-- A monoid homomorphism between two monoids M and N can be equivalently specified by a
+multiplicative action of M on N that is compatible with the multiplication on N. -/
+@[to_additive
+"A monoid homomorphism between two additive monoids M and N can be equivalently
+specified by an additive action of M on N that is compatible with the addition on N."]
+def monoidHomEquivMulActionIsScalarTower (M N) [Monoid M] [Monoid N] :
+    (M →* N) ≃ {_inst : MulAction M N // IsScalarTower M N N} where
+  toFun f := ⟨MulAction.compHom N f, SMul.comp.isScalarTower _⟩
+  invFun := fun ⟨_, _⟩ ↦ MonoidHom.smulOneHom
+  left_inv f := MonoidHom.ext fun m ↦ mul_one (f m)
+  right_inv := fun ⟨_, _⟩ ↦ Subtype.ext <| MulAction.ext <| funext₂ <| smul_one_smul N
+
+end CompatibleScalar
+
+variable (α)
+
+/-- The monoid of endomorphisms.
+
+Note that this is generalized by `CategoryTheory.End` to categories other than `Type u`. -/
+protected def Function.End := α → α
+
+instance : Monoid (Function.End α) where
+  one := id
+  mul := (· ∘ ·)
+  mul_assoc _ _ _ := rfl
+  mul_one _ := rfl
+  one_mul _ := rfl
+  npow n f := f^[n]
+  npow_succ _ _ := Function.iterate_succ _ _
+
+instance : Inhabited (Function.End α) := ⟨1⟩
+
+variable {α}
+
+/-- The tautological action by `Function.End α` on `α`.
+
+This is generalized to bundled endomorphisms by:
+* `Equiv.Perm.applyMulAction`
+* `AddMonoid.End.applyDistribMulAction`
+* `AddMonoid.End.applyModule`
+* `AddAut.applyDistribMulAction`
+* `MulAut.applyMulDistribMulAction`
+* `LinearEquiv.applyDistribMulAction`
+* `LinearMap.applyModule`
+* `RingHom.applyMulSemiringAction`
+* `RingAut.applyMulSemiringAction`
+* `AlgEquiv.applyMulSemiringAction`
+-/
+instance Function.End.applyMulAction : MulAction (Function.End α) α where
+  smul := (· <| ·)
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
+
+@[simp] lemma Function.End.smul_def (f : Function.End α) (a : α) : f • a = f a := rfl
+
+--TODO - This statement should be somethting like `toFun (f * g) = toFun f ∘ toFun g`
+lemma Function.End.mul_def (f g : Function.End α) : (f * g) = f ∘ g := rfl
+
+--TODO - This statement should be somethting like `toFun 1 = id`
+lemma Function.End.one_def : (1 : Function.End α) = id := rfl
+
+/-- The monoid hom representing a monoid action.
+
+When `M` is a group, see `MulAction.toPermHom`. -/
+def MulAction.toEndHom [Monoid M] [MulAction M α] : M →* Function.End α where
+  toFun := (· • ·)
+  map_one' := funext (one_smul M)
+  map_mul' x y := funext (mul_smul x y)
+
+/-- The monoid action induced by a monoid hom to `Function.End α`
+
+See note [reducible non-instances]. -/
+abbrev MulAction.ofEndHom [Monoid M] (f : M →* Function.End α) : MulAction M α :=
+  MulAction.compHom α f

--- a/Mathlib/Algebra/Group/Action/Faithful.lean
+++ b/Mathlib/Algebra/Group/Action/Faithful.lean
@@ -51,6 +51,11 @@ export FaithfulVAdd (eq_of_vadd_eq_vadd)
 lemma smul_left_injective' [SMul M α] [FaithfulSMul M α] : Injective ((· • ·) : M → α → α) :=
   fun _ _ h ↦ FaithfulSMul.eq_of_smul_eq_smul (congr_fun h)
 
+/-- `Monoid.toMulAction` is faithful on cancellative monoids. -/
+@[to_additive " `AddMonoid.toAddAction` is faithful on additive cancellative monoids. "]
+instance RightCancelMonoid.faithfulSMul [RightCancelMonoid α] : FaithfulSMul α α :=
+  ⟨fun h ↦ mul_right_cancel (h 1)⟩
+
 /-- `Function.End.applyMulAction` is faithful. -/
 instance Function.End.apply_FaithfulSMul : FaithfulSMul (Function.End α) α :=
   ⟨fun {_ _} ↦ funext⟩

--- a/Mathlib/Algebra/Group/Action/Faithful.lean
+++ b/Mathlib/Algebra/Group/Action/Faithful.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2018 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes, Yury Kudryashov
+-/
+import Mathlib.Algebra.Group.Action.End
+
+/-!
+# Faithful group actions
+
+This file provides typeclasses for faithful actions.
+
+## Notation
+
+- `a • b` is used as notation for `SMul.smul a b`.
+- `a +ᵥ b` is used as notation for `VAdd.vadd a b`.
+
+## Implementation details
+
+This file should avoid depending on other parts of `GroupTheory`, to avoid import cycles.
+More sophisticated lemmas belong in `GroupTheory.GroupAction`.
+
+## Tags
+
+group action
+-/
+
+assert_not_exists MonoidWithZero
+
+open Function (Injective Surjective)
+
+variable {M N G H α β γ δ : Type*}
+
+/-! ### Faithful actions -/
+
+/-- Typeclass for faithful actions. -/
+class FaithfulVAdd (G : Type*) (P : Type*) [VAdd G P] : Prop where
+  /-- Two elements `g₁` and `g₂` are equal whenever they act in the same way on all points. -/
+  eq_of_vadd_eq_vadd : ∀ {g₁ g₂ : G}, (∀ p : P, g₁ +ᵥ p = g₂ +ᵥ p) → g₁ = g₂
+
+/-- Typeclass for faithful actions. -/
+@[to_additive]
+class FaithfulSMul (M : Type*) (α : Type*) [SMul M α] : Prop where
+  /-- Two elements `m₁` and `m₂` are equal whenever they act in the same way on all points. -/
+  eq_of_smul_eq_smul : ∀ {m₁ m₂ : M}, (∀ a : α, m₁ • a = m₂ • a) → m₁ = m₂
+
+export FaithfulSMul (eq_of_smul_eq_smul)
+export FaithfulVAdd (eq_of_vadd_eq_vadd)
+
+@[to_additive]
+lemma smul_left_injective' [SMul M α] [FaithfulSMul M α] : Injective ((· • ·) : M → α → α) :=
+  fun _ _ h ↦ FaithfulSMul.eq_of_smul_eq_smul (congr_fun h)
+
+/-- `Function.End.applyMulAction` is faithful. -/
+instance Function.End.apply_FaithfulSMul : FaithfulSMul (Function.End α) α :=
+  ⟨fun {_ _} ↦ funext⟩

--- a/Mathlib/Algebra/Group/Action/Opposite.lean
+++ b/Mathlib/Algebra/Group/Action/Opposite.lean
@@ -3,7 +3,8 @@ Copyright (c) 2020 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.Action.Faithful
+import Mathlib.Algebra.Group.Action.Pretransitive
 import Mathlib.Algebra.Group.Opposite
 
 /-!

--- a/Mathlib/Algebra/Group/Action/Option.lean
+++ b/Mathlib/Algebra/Group/Action/Option.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.Action.Faithful
 
 /-!
 # Option instances for additive and multiplicative actions

--- a/Mathlib/Algebra/Group/Action/Pi.lean
+++ b/Mathlib/Algebra/Group/Action/Pi.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 -/
-import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.Action.Faithful
 import Mathlib.Data.Set.Function
 
 /-!

--- a/Mathlib/Algebra/Group/Action/Pretransitive.lean
+++ b/Mathlib/Algebra/Group/Action/Pretransitive.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2018 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes, Yury Kudryashov
+-/
+import Mathlib.Algebra.Group.Action.TypeTags
+
+/-!
+# Pretransitive group actions
+
+This file defines a typeclass for pretransitive group actions.
+
+## Notation
+
+- `a • b` is used as notation for `SMul.smul a b`.
+- `a +ᵥ b` is used as notation for `VAdd.vadd a b`.
+
+## Implementation details
+
+This file should avoid depending on other parts of `GroupTheory`, to avoid import cycles.
+More sophisticated lemmas belong in `GroupTheory.GroupAction`.
+
+## Tags
+
+group action
+-/
+
+assert_not_exists MonoidWithZero
+
+open Function (Injective Surjective)
+
+variable {M N G H α β γ δ : Type*}
+
+/-!
+### (Pre)transitive action
+
+`M` acts pretransitively on `α` if for any `x y` there is `g` such that `g • x = y` (or `g +ᵥ x = y`
+for an additive action). A transitive action should furthermore have `α` nonempty.
+
+In this section we define typeclasses `MulAction.IsPretransitive` and
+`AddAction.IsPretransitive` and provide `MulAction.exists_smul_eq`/`AddAction.exists_vadd_eq`,
+`MulAction.surjective_smul`/`AddAction.surjective_vadd` as public interface to access this
+property. We do not provide typeclasses `*Action.IsTransitive`; users should assume
+`[MulAction.IsPretransitive M α] [Nonempty α]` instead.
+-/
+
+/-- `M` acts pretransitively on `α` if for any `x y` there is `g` such that `g +ᵥ x = y`.
+  A transitive action should furthermore have `α` nonempty. -/
+class AddAction.IsPretransitive (M α : Type*) [VAdd M α] : Prop where
+  /-- There is `g` such that `g +ᵥ x = y`. -/
+  exists_vadd_eq : ∀ x y : α, ∃ g : M, g +ᵥ x = y
+
+/-- `M` acts pretransitively on `α` if for any `x y` there is `g` such that `g • x = y`.
+  A transitive action should furthermore have `α` nonempty. -/
+@[to_additive]
+class MulAction.IsPretransitive (M α : Type*) [SMul M α] : Prop where
+  /-- There is `g` such that `g • x = y`. -/
+  exists_smul_eq : ∀ x y : α, ∃ g : M, g • x = y
+
+namespace MulAction
+variable (M) [SMul M α] [IsPretransitive M α]
+
+@[to_additive]
+lemma exists_smul_eq (x y : α) : ∃ m : M, m • x = y := IsPretransitive.exists_smul_eq x y
+
+@[to_additive]
+lemma surjective_smul (x : α) : Surjective fun c : M ↦ c • x := exists_smul_eq M x
+
+/-- The regular action of a group on itself is transitive. -/
+@[to_additive "The regular action of a group on itself is transitive."]
+instance Regular.isPretransitive [Group G] : IsPretransitive G G :=
+  ⟨fun x y ↦ ⟨y * x⁻¹, inv_mul_cancel_right _ _⟩⟩
+
+end MulAction
+
+namespace MulAction
+
+variable [Monoid M] [MulAction M α]
+
+variable (α)
+
+/-- If an action is transitive, then composing this action with a surjective homomorphism gives
+again a transitive action. -/
+@[to_additive]
+lemma isPretransitive_compHom {E F G : Type*} [Monoid E] [Monoid F] [MulAction F G]
+    [IsPretransitive F G] {f : E →* F} (hf : Surjective f) :
+    letI : MulAction E G := MulAction.compHom _ f
+    IsPretransitive E G := by
+  let _ : MulAction E G := MulAction.compHom _ f
+  refine ⟨fun x y ↦ ?_⟩
+  obtain ⟨m, rfl⟩ : ∃ m : F, m • x = y := exists_smul_eq F x y
+  obtain ⟨e, rfl⟩ : ∃ e, f e = m := hf m
+  exact ⟨e, rfl⟩
+
+@[to_additive]
+lemma IsPretransitive.of_smul_eq {M N α : Type*} [SMul M α] [SMul N α] [IsPretransitive M α]
+    (f : M → N) (hf : ∀ {c : M} {x : α}, f c • x = c • x) : IsPretransitive N α where
+  exists_smul_eq x y := (exists_smul_eq x y).elim fun m h ↦ ⟨f m, hf.trans h⟩
+
+@[to_additive]
+lemma IsPretransitive.of_compHom {M N α : Type*} [Monoid M] [Monoid N] [MulAction N α]
+    (f : M →* N) [h : letI := compHom α f; IsPretransitive M α] : IsPretransitive N α :=
+  letI := compHom α f; h.of_smul_eq f rfl
+
+end MulAction
+
+section CompatibleScalar
+
+@[to_additive]
+lemma MulAction.IsPretransitive.of_isScalarTower (M : Type*) {N α : Type*} [Monoid N] [SMul M N]
+    [MulAction N α] [SMul M α] [IsScalarTower M N α] [IsPretransitive M α] : IsPretransitive N α :=
+  of_smul_eq (fun x : M ↦ x • 1) (smul_one_smul N _ _)
+
+end CompatibleScalar
+
+/-! ### `Additive`, `Multiplicative` -/
+
+section
+
+open Additive Multiplicative
+
+instance Additive.addAction_isPretransitive [Monoid α] [MulAction α β]
+    [MulAction.IsPretransitive α β] : AddAction.IsPretransitive (Additive α) β :=
+  ⟨@MulAction.exists_smul_eq α _ _ _⟩
+
+instance Multiplicative.mulAction_isPretransitive [AddMonoid α] [AddAction α β]
+    [AddAction.IsPretransitive α β] : MulAction.IsPretransitive (Multiplicative α) β :=
+  ⟨@AddAction.exists_vadd_eq α _ _ _⟩
+
+end

--- a/Mathlib/Algebra/Group/Action/Prod.lean
+++ b/Mathlib/Algebra/Group/Action/Prod.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot, Eric Wieser
 -/
-import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.Action.Faithful
 import Mathlib.Algebra.Group.Prod
 
 /-!

--- a/Mathlib/Algebra/Group/Action/Sigma.lean
+++ b/Mathlib/Algebra/Group/Action/Sigma.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.Action.Faithful
 
 /-!
 # Sigma instances for additive and multiplicative actions

--- a/Mathlib/Algebra/Group/Action/Sum.lean
+++ b/Mathlib/Algebra/Group/Action/Sum.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.Action.Faithful
 
 /-!
 # Sum instances for additive and multiplicative actions

--- a/Mathlib/Algebra/Group/Action/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Action/TypeTags.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2018 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes, Yury Kudryashov
+-/
+import Mathlib.Algebra.Group.Action.End
+import Mathlib.Algebra.Group.TypeTags
+
+/-!
+# Additive and Multiplicative for group actions
+
+## Tags
+
+group action
+-/
+
+assert_not_exists MonoidWithZero
+
+open Function (Injective Surjective)
+
+variable {M N G H α β γ δ : Type*}
+
+section
+
+open Additive Multiplicative
+
+instance Additive.vadd [SMul α β] : VAdd (Additive α) β where vadd a := (toMul a • ·)
+
+instance Multiplicative.smul [VAdd α β] : SMul (Multiplicative α) β where smul a := (toAdd a +ᵥ ·)
+
+@[simp] lemma toMul_smul [SMul α β] (a) (b : β) : (toMul a : α) • b = a +ᵥ b := rfl
+
+@[simp] lemma ofMul_vadd [SMul α β] (a : α) (b : β) : ofMul a +ᵥ b = a • b := rfl
+
+@[simp] lemma toAdd_vadd [VAdd α β] (a) (b : β) : (toAdd a : α) +ᵥ b = a • b := rfl
+
+@[simp] lemma ofAdd_smul [VAdd α β] (a : α) (b : β) : ofAdd a • b = a +ᵥ b := rfl
+
+-- Porting note: I don't know why `one_smul` can do without an explicit α and `mul_smul` can't.
+instance Additive.addAction [Monoid α] [MulAction α β] : AddAction (Additive α) β where
+  zero_vadd := MulAction.one_smul
+  add_vadd := MulAction.mul_smul (α := α)
+
+instance Multiplicative.mulAction [AddMonoid α] [AddAction α β] :
+    MulAction (Multiplicative α) β where
+  one_smul := AddAction.zero_vadd
+  mul_smul := AddAction.add_vadd (G := α)
+
+instance Additive.vaddCommClass [SMul α γ] [SMul β γ] [SMulCommClass α β γ] :
+    VAddCommClass (Additive α) (Additive β) γ :=
+  ⟨@smul_comm α β _ _ _ _⟩
+
+instance Multiplicative.smulCommClass [VAdd α γ] [VAdd β γ] [VAddCommClass α β γ] :
+    SMulCommClass (Multiplicative α) (Multiplicative β) γ :=
+  ⟨@vadd_comm α β _ _ _ _⟩
+
+end
+
+/-- The tautological additive action by `Additive (Function.End α)` on `α`. -/
+instance AddAction.functionEnd : AddAction (Additive (Function.End α)) α := inferInstance
+
+/-- The additive monoid hom representing an additive monoid action.
+
+When `M` is a group, see `AddAction.toPermHom`. -/
+def AddAction.toEndHom [AddMonoid M] [AddAction M α] : M →+ Additive (Function.End α) :=
+  MonoidHom.toAdditive'' MulAction.toEndHom
+
+/-- The additive action induced by a hom to `Additive (Function.End α)`
+
+See note [reducible non-instances]. -/
+abbrev AddAction.ofEndHom [AddMonoid M] (f : M →+ Additive (Function.End α)) : AddAction M α :=
+  AddAction.compHom α f

--- a/Mathlib/Algebra/Group/Action/Units.lean
+++ b/Mathlib/Algebra/Group/Action/Units.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.Action.Faithful
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Units.Defs
 

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau, Johan Commelin, Mario Carneiro, Kevin Buzzard,
 Amelia Livingston, Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.Action.Faithful
 import Mathlib.Algebra.Group.Nat
 import Mathlib.Algebra.Group.Submonoid.Basic
 import Mathlib.Algebra.Group.Subsemigroup.Operations


### PR DESCRIPTION
The `Group/Action/Defs.lean` file depends on a bit of theory and in turn defines some results not needed for e.g. modules. This PR tries to ensure that the focus is on the definitions of `MulAction`, `SMulCommClass` and `IsScalarTower`.

In the process, I made the following moves:

 * `Action/End.lean` now contains the definition of `Function.End` and some results relating homomorphisms with multiplication
 * `Action/Faithful.lean` now contains the definition of `FaithfulAction`
 * `Action/Pretransitive.lean` now contains the definition of `PretransitiveAction`
 * `Action/TypeTags.lean` now contains the `Additive`/`Multiplicative` instances.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
