### PR TITLE
[Merged by Bors] - chore(Nat.Factorization): rename `ord_proj/compl` -> `ordProj/Compl` 

### DIFF
--- a/Mathlib/Algebra/CharP/LocalRing.lean
+++ b/Mathlib/Algebra/CharP/LocalRing.lean
@@ -32,8 +32,8 @@ theorem charP_zero_or_prime_power (R : Type*) [CommRing R] [LocalRing R] (q : �
   rcases CharP.char_is_prime_or_zero K r with r_prime | r_zero
   · let a := q / r ^ n
     -- If `r` is prime, we can write it as `r = a * q^n` ...
-    have q_eq_a_mul_rn : q = r ^ n * a := by rw [Nat.mul_div_cancel' (Nat.ord_proj_dvd q r)]
-    have r_ne_dvd_a := Nat.not_dvd_ord_compl r_prime q_pos
+    have q_eq_a_mul_rn : q = r ^ n * a := by rw [Nat.mul_div_cancel' (Nat.ordProj_dvd q r)]
+    have r_ne_dvd_a := Nat.not_dvd_ordCompl r_prime q_pos
     have rn_dvd_q : r ^ n ∣ q := ⟨a, q_eq_a_mul_rn⟩
     rw [mul_comm] at q_eq_a_mul_rn
     -- ... where `a` is a unit.

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -90,50 +90,50 @@ theorem factorizationEquiv_inv_apply {f : ℕ →₀ ℕ} (hf : ∀ p ∈ f.supp
   rfl
 
 @[simp]
-theorem ord_proj_of_not_prime (n p : ℕ) (hp : ¬p.Prime) : ord_proj[p] n = 1 := by
+theorem ordProj_of_not_prime (n p : ℕ) (hp : ¬p.Prime) : ordProj[p] n = 1 := by
   simp [factorization_eq_zero_of_non_prime n hp]
 
 @[simp]
-theorem ord_compl_of_not_prime (n p : ℕ) (hp : ¬p.Prime) : ord_compl[p] n = n := by
+theorem ordCompl_of_not_prime (n p : ℕ) (hp : ¬p.Prime) : ordCompl[p] n = n := by
   simp [factorization_eq_zero_of_non_prime n hp]
 
-theorem ord_compl_dvd (n p : ℕ) : ord_compl[p] n ∣ n :=
-  div_dvd_of_dvd (ord_proj_dvd n p)
+theorem ordCompl_dvd (n p : ℕ) : ordCompl[p] n ∣ n :=
+  div_dvd_of_dvd (ordProj_dvd n p)
 
-theorem ord_proj_pos (n p : ℕ) : 0 < ord_proj[p] n := by
+theorem ordProj_pos (n p : ℕ) : 0 < ordProj[p] n := by
   if pp : p.Prime then simp [pow_pos pp.pos] else simp [pp]
 
-theorem ord_proj_le {n : ℕ} (p : ℕ) (hn : n ≠ 0) : ord_proj[p] n ≤ n :=
-  le_of_dvd hn.bot_lt (Nat.ord_proj_dvd n p)
+theorem ordProj_le {n : ℕ} (p : ℕ) (hn : n ≠ 0) : ordProj[p] n ≤ n :=
+  le_of_dvd hn.bot_lt (Nat.ordProj_dvd n p)
 
-theorem ord_compl_pos {n : ℕ} (p : ℕ) (hn : n ≠ 0) : 0 < ord_compl[p] n := by
+theorem ordCompl_pos {n : ℕ} (p : ℕ) (hn : n ≠ 0) : 0 < ordCompl[p] n := by
   if pp : p.Prime then
-    exact Nat.div_pos (ord_proj_le p hn) (ord_proj_pos n p)
+    exact Nat.div_pos (ordProj_le p hn) (ordProj_pos n p)
   else
     simpa [Nat.factorization_eq_zero_of_non_prime n pp] using hn.bot_lt
 
-theorem ord_compl_le (n p : ℕ) : ord_compl[p] n ≤ n :=
+theorem ordCompl_le (n p : ℕ) : ordCompl[p] n ≤ n :=
   Nat.div_le_self _ _
 
-theorem ord_proj_mul_ord_compl_eq_self (n p : ℕ) : ord_proj[p] n * ord_compl[p] n = n :=
-  Nat.mul_div_cancel' (ord_proj_dvd n p)
+theorem ordProj_mul_ordCompl_eq_self (n p : ℕ) : ordProj[p] n * ordCompl[p] n = n :=
+  Nat.mul_div_cancel' (ordProj_dvd n p)
 
-theorem ord_proj_mul {a b : ℕ} (p : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
-    ord_proj[p] (a * b) = ord_proj[p] a * ord_proj[p] b := by
+theorem ordProj_mul {a b : ℕ} (p : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
+    ordProj[p] (a * b) = ordProj[p] a * ordProj[p] b := by
   simp [factorization_mul ha hb, pow_add]
 
-theorem ord_compl_mul (a b p : ℕ) : ord_compl[p] (a * b) = ord_compl[p] a * ord_compl[p] b := by
+theorem ordCompl_mul (a b p : ℕ) : ordCompl[p] (a * b) = ordCompl[p] a * ordCompl[p] b := by
   if ha : a = 0 then simp [ha] else
   if hb : b = 0 then simp [hb] else
-  simp only [ord_proj_mul p ha hb]
-  rw [div_mul_div_comm (ord_proj_dvd a p) (ord_proj_dvd b p)]
+  simp only [ordProj_mul p ha hb]
+  rw [div_mul_div_comm (ordProj_dvd a p) (ordProj_dvd b p)]
 
 /-! ### Factorization and divisibility -/
 
 /-- A crude upper bound on `n.factorization p` -/
 theorem factorization_lt {n : ℕ} (p : ℕ) (hn : n ≠ 0) : n.factorization p < n := by
   by_cases pp : p.Prime
-  · exact (pow_lt_pow_iff_right pp.one_lt).1 <| (ord_proj_le p hn).trans_lt <|
+  · exact (pow_lt_pow_iff_right pp.one_lt).1 <| (ordProj_le p hn).trans_lt <|
       lt_pow_self pp.one_lt _
   · simpa only [factorization_eq_zero_of_non_prime n pp] using hn.bot_lt
 
@@ -141,7 +141,7 @@ theorem factorization_lt {n : ℕ} (p : ℕ) (hn : n ≠ 0) : n.factorization p 
 theorem factorization_le_of_le_pow {n p b : ℕ} (hb : n ≤ p ^ b) : n.factorization p ≤ b := by
   if hn : n = 0 then simp [hn] else
   if pp : p.Prime then
-    exact (pow_le_pow_iff_right pp.one_lt).1 ((ord_proj_le p hn).trans hb)
+    exact (pow_le_pow_iff_right pp.one_lt).1 ((ordProj_le p hn).trans hb)
   else
     simp [factorization_eq_zero_of_non_prime n pp]
 
@@ -168,8 +168,8 @@ theorem Prime.pow_dvd_iff_le_factorization {p k n : ℕ} (pp : Prime p) (hn : n 
     p ^ k ∣ n ↔ k ≤ n.factorization p := by
   rw [← factorization_le_iff_dvd (pow_pos pp.pos k).ne' hn, pp.factorization_pow, single_le_iff]
 
-theorem Prime.pow_dvd_iff_dvd_ord_proj {p k n : ℕ} (pp : Prime p) (hn : n ≠ 0) :
-    p ^ k ∣ n ↔ p ^ k ∣ ord_proj[p] n := by
+theorem Prime.pow_dvd_iff_dvd_ordProj {p k n : ℕ} (pp : Prime p) (hn : n ≠ 0) :
+    p ^ k ∣ n ↔ p ^ k ∣ ordProj[p] n := by
   rw [pow_dvd_pow_iff_le_right pp.one_lt, pp.pow_dvd_iff_le_factorization hn]
 
 theorem Prime.dvd_iff_one_le_factorization {p n : ℕ} (pp : Prime p) (hn : n ≠ 0) :
@@ -194,36 +194,36 @@ theorem factorization_div {d n : ℕ} (h : d ∣ n) :
     Nat.factorization_mul (Nat.div_pos (Nat.le_of_dvd hn.bot_lt h) hd.bot_lt).ne' hd,
     Nat.div_mul_cancel h]
 
-theorem dvd_ord_proj_of_dvd {n p : ℕ} (hn : n ≠ 0) (pp : p.Prime) (h : p ∣ n) : p ∣ ord_proj[p] n :=
+theorem dvd_ordProj_of_dvd {n p : ℕ} (hn : n ≠ 0) (pp : p.Prime) (h : p ∣ n) : p ∣ ordProj[p] n :=
   dvd_pow_self p (Prime.factorization_pos_of_dvd pp hn h).ne'
 
-theorem not_dvd_ord_compl {n p : ℕ} (hp : Prime p) (hn : n ≠ 0) : ¬p ∣ ord_compl[p] n := by
-  rw [Nat.Prime.dvd_iff_one_le_factorization hp (ord_compl_pos p hn).ne']
-  rw [Nat.factorization_div (Nat.ord_proj_dvd n p)]
+theorem not_dvd_ordCompl {n p : ℕ} (hp : Prime p) (hn : n ≠ 0) : ¬p ∣ ordCompl[p] n := by
+  rw [Nat.Prime.dvd_iff_one_le_factorization hp (ordCompl_pos p hn).ne']
+  rw [Nat.factorization_div (Nat.ordProj_dvd n p)]
   simp [hp.factorization]
 
-theorem coprime_ord_compl {n p : ℕ} (hp : Prime p) (hn : n ≠ 0) : Coprime p (ord_compl[p] n) :=
-  (or_iff_left (not_dvd_ord_compl hp hn)).mp <| coprime_or_dvd_of_prime hp _
+theorem coprime_ordCompl {n p : ℕ} (hp : Prime p) (hn : n ≠ 0) : Coprime p (ordCompl[p] n) :=
+  (or_iff_left (not_dvd_ordCompl hp hn)).mp <| coprime_or_dvd_of_prime hp _
 
-theorem factorization_ord_compl (n p : ℕ) :
-    (ord_compl[p] n).factorization = n.factorization.erase p := by
+theorem factorization_ordCompl (n p : ℕ) :
+    (ordCompl[p] n).factorization = n.factorization.erase p := by
   if hn : n = 0 then simp [hn] else
   if pp : p.Prime then ?_ else
     -- Porting note: needed to solve side goal explicitly
     rw [Finsupp.erase_of_not_mem_support] <;> simp [pp]
   ext q
   rcases eq_or_ne q p with (rfl | hqp)
-  · simp only [Finsupp.erase_same, factorization_eq_zero_iff, not_dvd_ord_compl pp hn]
+  · simp only [Finsupp.erase_same, factorization_eq_zero_iff, not_dvd_ordCompl pp hn]
     simp
-  · rw [Finsupp.erase_ne hqp, factorization_div (ord_proj_dvd n p)]
+  · rw [Finsupp.erase_ne hqp, factorization_div (ordProj_dvd n p)]
     simp [pp.factorization, hqp.symm]
 
--- `ord_compl[p] n` is the largest divisor of `n` not divisible by `p`.
-theorem dvd_ord_compl_of_dvd_not_dvd {p d n : ℕ} (hdn : d ∣ n) (hpd : ¬p ∣ d) :
-    d ∣ ord_compl[p] n := by
+-- `ordCompl[p] n` is the largest divisor of `n` not divisible by `p`.
+theorem dvd_ordCompl_of_dvd_not_dvd {p d n : ℕ} (hdn : d ∣ n) (hpd : ¬p ∣ d) :
+    d ∣ ordCompl[p] n := by
   if hn0 : n = 0 then simp [hn0] else
   if hd0 : d = 0 then simp [hd0] at hpd else
-  rw [← factorization_le_iff_dvd hd0 (ord_compl_pos p hn0).ne', factorization_ord_compl]
+  rw [← factorization_le_iff_dvd hd0 (ordCompl_pos p hn0).ne', factorization_ordCompl]
   intro q
   if hqp : q = p then
     simp [factorization_eq_zero_iff, hqp, hpd]
@@ -257,42 +257,42 @@ theorem dvd_iff_div_factorization_eq_tsub {d n : ℕ} (hd : d ≠ 0) (hdn : d �
   rwa [factorization_mul h1 hd, add_apply, ← lt_tsub_iff_right, h, tsub_apply,
    lt_self_iff_false] at hp
 
-theorem ord_proj_dvd_ord_proj_of_dvd {a b : ℕ} (hb0 : b ≠ 0) (hab : a ∣ b) (p : ℕ) :
-    ord_proj[p] a ∣ ord_proj[p] b := by
+theorem ordProj_dvd_ordProj_of_dvd {a b : ℕ} (hb0 : b ≠ 0) (hab : a ∣ b) (p : ℕ) :
+    ordProj[p] a ∣ ordProj[p] b := by
   rcases em' p.Prime with (pp | pp); · simp [pp]
   rcases eq_or_ne a 0 with (rfl | ha0); · simp
   rw [pow_dvd_pow_iff_le_right pp.one_lt]
   exact (factorization_le_iff_dvd ha0 hb0).2 hab p
 
-theorem ord_proj_dvd_ord_proj_iff_dvd {a b : ℕ} (ha0 : a ≠ 0) (hb0 : b ≠ 0) :
-    (∀ p : ℕ, ord_proj[p] a ∣ ord_proj[p] b) ↔ a ∣ b := by
-  refine ⟨fun h => ?_, fun hab p => ord_proj_dvd_ord_proj_of_dvd hb0 hab p⟩
+theorem ordProj_dvd_ordProj_iff_dvd {a b : ℕ} (ha0 : a ≠ 0) (hb0 : b ≠ 0) :
+    (∀ p : ℕ, ordProj[p] a ∣ ordProj[p] b) ↔ a ∣ b := by
+  refine ⟨fun h => ?_, fun hab p => ordProj_dvd_ordProj_of_dvd hb0 hab p⟩
   rw [← factorization_le_iff_dvd ha0 hb0]
   intro q
   rcases le_or_lt q 1 with (hq_le | hq1)
   · interval_cases q <;> simp
   exact (pow_dvd_pow_iff_le_right hq1).1 (h q)
 
-theorem ord_compl_dvd_ord_compl_of_dvd {a b : ℕ} (hab : a ∣ b) (p : ℕ) :
-    ord_compl[p] a ∣ ord_compl[p] b := by
+theorem ordCompl_dvd_ordCompl_of_dvd {a b : ℕ} (hab : a ∣ b) (p : ℕ) :
+    ordCompl[p] a ∣ ordCompl[p] b := by
   rcases em' p.Prime with (pp | pp)
   · simp [pp, hab]
   rcases eq_or_ne b 0 with (rfl | hb0)
   · simp
   rcases eq_or_ne a 0 with (rfl | ha0)
   · cases hb0 (zero_dvd_iff.1 hab)
-  have ha := (Nat.div_pos (ord_proj_le p ha0) (ord_proj_pos a p)).ne'
-  have hb := (Nat.div_pos (ord_proj_le p hb0) (ord_proj_pos b p)).ne'
-  rw [← factorization_le_iff_dvd ha hb, factorization_ord_compl a p, factorization_ord_compl b p]
+  have ha := (Nat.div_pos (ordProj_le p ha0) (ordProj_pos a p)).ne'
+  have hb := (Nat.div_pos (ordProj_le p hb0) (ordProj_pos b p)).ne'
+  rw [← factorization_le_iff_dvd ha hb, factorization_ordCompl a p, factorization_ordCompl b p]
   intro q
   rcases eq_or_ne q p with (rfl | hqp)
   · simp
   simp_rw [erase_ne hqp]
   exact (factorization_le_iff_dvd ha0 hb0).2 hab q
 
-theorem ord_compl_dvd_ord_compl_iff_dvd (a b : ℕ) :
-    (∀ p : ℕ, ord_compl[p] a ∣ ord_compl[p] b) ↔ a ∣ b := by
-  refine ⟨fun h => ?_, fun hab p => ord_compl_dvd_ord_compl_of_dvd hab p⟩
+theorem ordCompl_dvd_ordCompl_iff_dvd (a b : ℕ) :
+    (∀ p : ℕ, ordCompl[p] a ∣ ordCompl[p] b) ↔ a ∣ b := by
+  refine ⟨fun h => ?_, fun hab p => ordCompl_dvd_ordCompl_of_dvd hab p⟩
   rcases eq_or_ne b 0 with (rfl | hb0)
   · simp
   if pa : a.Prime then ?_ else simpa [pa] using h a
@@ -314,7 +314,7 @@ theorem dvd_iff_prime_pow_dvd_dvd (n d : ℕ) :
   rw [← factorization_prime_le_iff_dvd hd hn]
   intro h p pp
   simp_rw [← pp.pow_dvd_iff_le_factorization hn]
-  exact h p _ pp (ord_proj_dvd _ _)
+  exact h p _ pp (ordProj_dvd _ _)
 
 theorem prod_primeFactors_dvd (n : ℕ) : ∏ p ∈ n.primeFactors, p ∣ n := by
   by_cases hn : n = 0

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -93,18 +93,28 @@ theorem factorizationEquiv_inv_apply {f : ℕ →₀ ℕ} (hf : ∀ p ∈ f.supp
 theorem ordProj_of_not_prime (n p : ℕ) (hp : ¬p.Prime) : ordProj[p] n = 1 := by
   simp [factorization_eq_zero_of_non_prime n hp]
 
+@[deprecated (since := "2024-10-24")] alias ord_proj_of_not_prime := ordProj_of_not_prime
+
 @[simp]
 theorem ordCompl_of_not_prime (n p : ℕ) (hp : ¬p.Prime) : ordCompl[p] n = n := by
   simp [factorization_eq_zero_of_non_prime n hp]
 
+@[deprecated (since := "2024-10-24")] alias ord_compl_of_not_prime := ordCompl_of_not_prime
+
 theorem ordCompl_dvd (n p : ℕ) : ordCompl[p] n ∣ n :=
   div_dvd_of_dvd (ordProj_dvd n p)
+
+@[deprecated (since := "2024-10-24")] alias ord_compl_dvd := ordCompl_dvd
 
 theorem ordProj_pos (n p : ℕ) : 0 < ordProj[p] n := by
   if pp : p.Prime then simp [pow_pos pp.pos] else simp [pp]
 
+@[deprecated (since := "2024-10-24")] alias ord_proj_pos := ordProj_pos
+
 theorem ordProj_le {n : ℕ} (p : ℕ) (hn : n ≠ 0) : ordProj[p] n ≤ n :=
   le_of_dvd hn.bot_lt (Nat.ordProj_dvd n p)
+
+@[deprecated (since := "2024-10-24")] alias ord_proj_le := ordProj_le
 
 theorem ordCompl_pos {n : ℕ} (p : ℕ) (hn : n ≠ 0) : 0 < ordCompl[p] n := by
   if pp : p.Prime then
@@ -112,21 +122,32 @@ theorem ordCompl_pos {n : ℕ} (p : ℕ) (hn : n ≠ 0) : 0 < ordCompl[p] n := b
   else
     simpa [Nat.factorization_eq_zero_of_non_prime n pp] using hn.bot_lt
 
+@[deprecated (since := "2024-10-24")] alias ord_compl_pos := ordCompl_pos
+
 theorem ordCompl_le (n p : ℕ) : ordCompl[p] n ≤ n :=
   Nat.div_le_self _ _
+
+@[deprecated (since := "2024-10-24")] alias ord_compl_le := ordCompl_le
 
 theorem ordProj_mul_ordCompl_eq_self (n p : ℕ) : ordProj[p] n * ordCompl[p] n = n :=
   Nat.mul_div_cancel' (ordProj_dvd n p)
 
+@[deprecated (since := "2024-10-24")]
+alias ord_proj_mul_ord_compl_eq_self := ordProj_mul_ordCompl_eq_self
+
 theorem ordProj_mul {a b : ℕ} (p : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
     ordProj[p] (a * b) = ordProj[p] a * ordProj[p] b := by
   simp [factorization_mul ha hb, pow_add]
+
+@[deprecated (since := "2024-10-24")] alias ord_proj_mul := ordProj_mul
 
 theorem ordCompl_mul (a b p : ℕ) : ordCompl[p] (a * b) = ordCompl[p] a * ordCompl[p] b := by
   if ha : a = 0 then simp [ha] else
   if hb : b = 0 then simp [hb] else
   simp only [ordProj_mul p ha hb]
   rw [div_mul_div_comm (ordProj_dvd a p) (ordProj_dvd b p)]
+
+@[deprecated (since := "2024-10-24")] alias ord_compl_mul := ordCompl_mul
 
 /-! ### Factorization and divisibility -/
 
@@ -172,6 +193,9 @@ theorem Prime.pow_dvd_iff_dvd_ordProj {p k n : ℕ} (pp : Prime p) (hn : n ≠ 0
     p ^ k ∣ n ↔ p ^ k ∣ ordProj[p] n := by
   rw [pow_dvd_pow_iff_le_right pp.one_lt, pp.pow_dvd_iff_le_factorization hn]
 
+@[deprecated (since := "2024-10-24")]
+alias Prime.pow_dvd_iff_dvd_ord_proj := Prime.pow_dvd_iff_dvd_ordProj
+
 theorem Prime.dvd_iff_one_le_factorization {p n : ℕ} (pp : Prime p) (hn : n ≠ 0) :
     p ∣ n ↔ 1 ≤ n.factorization p :=
   Iff.trans (by simp) (pp.pow_dvd_iff_le_factorization hn)
@@ -197,13 +221,19 @@ theorem factorization_div {d n : ℕ} (h : d ∣ n) :
 theorem dvd_ordProj_of_dvd {n p : ℕ} (hn : n ≠ 0) (pp : p.Prime) (h : p ∣ n) : p ∣ ordProj[p] n :=
   dvd_pow_self p (Prime.factorization_pos_of_dvd pp hn h).ne'
 
+@[deprecated (since := "2024-10-24")] alias dvd_ord_proj_of_dvd := dvd_ordProj_of_dvd
+
 theorem not_dvd_ordCompl {n p : ℕ} (hp : Prime p) (hn : n ≠ 0) : ¬p ∣ ordCompl[p] n := by
   rw [Nat.Prime.dvd_iff_one_le_factorization hp (ordCompl_pos p hn).ne']
   rw [Nat.factorization_div (Nat.ordProj_dvd n p)]
   simp [hp.factorization]
 
+@[deprecated (since := "2024-10-24")] alias not_dvd_ord_compl := not_dvd_ordCompl
+
 theorem coprime_ordCompl {n p : ℕ} (hp : Prime p) (hn : n ≠ 0) : Coprime p (ordCompl[p] n) :=
   (or_iff_left (not_dvd_ordCompl hp hn)).mp <| coprime_or_dvd_of_prime hp _
+
+@[deprecated (since := "2024-10-24")] alias coprime_ord_compl := coprime_ordCompl
 
 theorem factorization_ordCompl (n p : ℕ) :
     (ordCompl[p] n).factorization = n.factorization.erase p := by
@@ -218,6 +248,8 @@ theorem factorization_ordCompl (n p : ℕ) :
   · rw [Finsupp.erase_ne hqp, factorization_div (ordProj_dvd n p)]
     simp [pp.factorization, hqp.symm]
 
+@[deprecated (since := "2024-10-24")] alias factorization_ord_compl := factorization_ordCompl
+
 -- `ordCompl[p] n` is the largest divisor of `n` not divisible by `p`.
 theorem dvd_ordCompl_of_dvd_not_dvd {p d n : ℕ} (hdn : d ∣ n) (hpd : ¬p ∣ d) :
     d ∣ ordCompl[p] n := by
@@ -229,6 +261,9 @@ theorem dvd_ordCompl_of_dvd_not_dvd {p d n : ℕ} (hdn : d ∣ n) (hpd : ¬p ∣
     simp [factorization_eq_zero_iff, hqp, hpd]
   else
     simp [hqp, (factorization_le_iff_dvd hd0 hn0).2 hdn q]
+
+@[deprecated (since := "2024-10-24")]
+alias dvd_ord_compl_of_dvd_not_dvd := dvd_ordCompl_of_dvd_not_dvd
 
 /-- If `n` is a nonzero natural number and `p ≠ 1`, then there are natural numbers `e`
 and `n'` such that `n'` is not divisible by `p` and `n = p^e * n'`. -/
@@ -264,6 +299,9 @@ theorem ordProj_dvd_ordProj_of_dvd {a b : ℕ} (hb0 : b ≠ 0) (hab : a ∣ b) (
   rw [pow_dvd_pow_iff_le_right pp.one_lt]
   exact (factorization_le_iff_dvd ha0 hb0).2 hab p
 
+@[deprecated (since := "2024-10-24")]
+alias ord_proj_dvd_ord_proj_of_dvd := ordProj_dvd_ordProj_of_dvd
+
 theorem ordProj_dvd_ordProj_iff_dvd {a b : ℕ} (ha0 : a ≠ 0) (hb0 : b ≠ 0) :
     (∀ p : ℕ, ordProj[p] a ∣ ordProj[p] b) ↔ a ∣ b := by
   refine ⟨fun h => ?_, fun hab p => ordProj_dvd_ordProj_of_dvd hb0 hab p⟩
@@ -272,6 +310,9 @@ theorem ordProj_dvd_ordProj_iff_dvd {a b : ℕ} (ha0 : a ≠ 0) (hb0 : b ≠ 0) 
   rcases le_or_lt q 1 with (hq_le | hq1)
   · interval_cases q <;> simp
   exact (pow_dvd_pow_iff_le_right hq1).1 (h q)
+
+@[deprecated (since := "2024-10-24")]
+alias ord_proj_dvd_ord_proj_iff_dvd := ordProj_dvd_ordProj_iff_dvd
 
 theorem ordCompl_dvd_ordCompl_of_dvd {a b : ℕ} (hab : a ∣ b) (p : ℕ) :
     ordCompl[p] a ∣ ordCompl[p] b := by
@@ -290,6 +331,9 @@ theorem ordCompl_dvd_ordCompl_of_dvd {a b : ℕ} (hab : a ∣ b) (p : ℕ) :
   simp_rw [erase_ne hqp]
   exact (factorization_le_iff_dvd ha0 hb0).2 hab q
 
+@[deprecated (since := "2024-10-24")]
+alias ord_compl_dvd_ord_compl_of_dvd := ordCompl_dvd_ordCompl_of_dvd
+
 theorem ordCompl_dvd_ordCompl_iff_dvd (a b : ℕ) :
     (∀ p : ℕ, ordCompl[p] a ∣ ordCompl[p] b) ↔ a ∣ b := by
   refine ⟨fun h => ?_, fun hab p => ordCompl_dvd_ordCompl_of_dvd hab p⟩
@@ -302,6 +346,9 @@ theorem ordCompl_dvd_ordCompl_iff_dvd (a b : ℕ) :
   apply pa.ne_one
   rw [← Nat.dvd_one, ← Nat.mul_dvd_mul_iff_left hb0.bot_lt, mul_one]
   simpa [Prime.factorization_self pb, Prime.factorization pa, hab] using h b
+
+@[deprecated (since := "2024-10-24")]
+alias ord_compl_dvd_ord_compl_iff_dvd := ordCompl_dvd_ordCompl_iff_dvd
 
 theorem dvd_iff_prime_pow_dvd_dvd (n d : ℕ) :
     d ∣ n ↔ ∀ p k : ℕ, Prime p → p ^ k ∣ d → p ^ k ∣ n := by

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -249,9 +249,6 @@ the $p$-adic order/valuation of a number, and `proj` and `compl` are for the pro
 complementary projection. The term `n.factorization p` is the $p$-adic order itself.
 For example, `ord_proj[2] n` is the even part of `n` and `ord_compl[2] n` is the odd part. -/
 
-
--- Porting note: Lean 4 thinks we need `HPow` without this
-set_option quotPrecheck false in
 notation "ord_proj[" p "] " n:arg => p ^ Nat.factorization n p
 
 notation "ord_compl[" p "] " n:arg => n / ord_proj[p] n

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -261,6 +261,8 @@ theorem ordProj_dvd (n p : ℕ) : ordProj[p] n ∣ n := by
   intro q hq
   simp [List.eq_of_mem_replicate hq]
 
+@[deprecated (since := "2024-10-24")] alias ord_proj_dvd := ordProj_dvd
+
 /-! ### Factorization LCM definitions -/
 
 

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -243,17 +243,17 @@ theorem factorization_mul_of_coprime {a b : ℕ} (hab : Coprime a b) :
 
 /-! ### Generalisation of the "even part" and "odd part" of a natural number
 
-We introduce the notations `ord_proj[p] n` for the largest power of the prime `p` that
-divides `n` and `ord_compl[p] n` for the complementary part. The `ord` naming comes from
+We introduce the notations `ordProj[p] n` for the largest power of the prime `p` that
+divides `n` and `ordCompl[p] n` for the complementary part. The `ord` naming comes from
 the $p$-adic order/valuation of a number, and `proj` and `compl` are for the projection and
 complementary projection. The term `n.factorization p` is the $p$-adic order itself.
-For example, `ord_proj[2] n` is the even part of `n` and `ord_compl[2] n` is the odd part. -/
+For example, `ordProj[2] n` is the even part of `n` and `ordCompl[2] n` is the odd part. -/
 
-notation "ord_proj[" p "] " n:arg => p ^ Nat.factorization n p
+notation "ordProj[" p "] " n:arg => p ^ Nat.factorization n p
 
-notation "ord_compl[" p "] " n:arg => n / ord_proj[p] n
+notation "ordCompl[" p "] " n:arg => n / ordProj[p] n
 
-theorem ord_proj_dvd (n p : ℕ) : ord_proj[p] n ∣ n := by
+theorem ordProj_dvd (n p : ℕ) : ordProj[p] n ∣ n := by
   if hp : p.Prime then ?_ else simp [hp]
   rw [← primeFactorsList_count_eq]
   apply dvd_of_primeFactorsList_subperm (pow_ne_zero _ hp.ne_zero)

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -241,16 +241,16 @@ theorem factorization_mul_of_coprime {a b : ℕ} (hab : Coprime a b) :
   ext q
   rw [Finsupp.add_apply, factorization_mul_apply_of_coprime hab]
 
-/-! ### Generalisation of the "even part" and "odd part" of a natural number
+/-! ### Generalisation of the "even part" and "odd part" of a natural number -/
 
-We introduce the notations `ordProj[p] n` for the largest power of the prime `p` that
+/-- We introduce the notations `ordProj[p] n` for the largest power of the prime `p` that
 divides `n` and `ordCompl[p] n` for the complementary part. The `ord` naming comes from
 the $p$-adic order/valuation of a number, and `proj` and `compl` are for the projection and
 complementary projection. The term `n.factorization p` is the $p$-adic order itself.
 For example, `ordProj[2] n` is the even part of `n` and `ordCompl[2] n` is the odd part. -/
-
 notation "ordProj[" p "] " n:arg => p ^ Nat.factorization n p
 
+@[inherit_doc «termOrdProj[_]_»]
 notation "ordCompl[" p "] " n:arg => n / ordProj[p] n
 
 theorem ordProj_dvd (n p : ℕ) : ordProj[p] n ∣ n := by

--- a/Mathlib/Data/Nat/Factorization/Induction.lean
+++ b/Mathlib/Data/Nat/Factorization/Induction.lean
@@ -30,7 +30,7 @@ def recOnPrimePow {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1)
       letI p := (k + 2).minFac
       haveI hp : Prime p := minFac_prime (succ_succ_ne_one k)
       letI t := (k + 2).factorization p
-      haveI hpt : p ^ t ∣ k + 2 := ord_proj_dvd _ _
+      haveI hpt : p ^ t ∣ k + 2 := ordProj_dvd _ _
       haveI htp : 0 < t := hp.factorization_pos_of_dvd (k + 1).succ_ne_zero (k + 2).minFac_dvd
       convert h ((k + 2) / p ^ t) p t hp _ htp (hk _ (Nat.div_lt_of_lt_mul _)) using 1
       · rw [Nat.mul_div_cancel' hpt]

--- a/Mathlib/Data/Nat/Factorization/PrimePow.lean
+++ b/Mathlib/Data/Nat/Factorization/PrimePow.lean
@@ -65,6 +65,9 @@ theorem IsPrimePow.exists_ordCompl_eq_one {n : ℕ} (h : IsPrimePow n) :
   rw [Nat.factorization_ordCompl n p, h1]
   simp
 
+@[deprecated (since := "2024-10-24")]
+alias IsPrimePow.exists_ord_compl_eq_one := IsPrimePow.exists_ordCompl_eq_one
+
 theorem exists_ordCompl_eq_one_iff_isPrimePow {n : ℕ} (hn : n ≠ 1) :
     IsPrimePow n ↔ ∃ p : ℕ, p.Prime ∧ ordCompl[p] n = 1 := by
   refine ⟨fun h => IsPrimePow.exists_ordCompl_eq_one h, fun h => ?_⟩
@@ -74,6 +77,9 @@ theorem exists_ordCompl_eq_one_iff_isPrimePow {n : ℕ} (hn : n ≠ 1) :
   refine ⟨p, n.factorization p, pp, ?_, by simp⟩
   contrapose! hn
   simp [Nat.le_zero.1 hn]
+
+@[deprecated (since := "2024-10-24")]
+alias exists_ord_compl_eq_one_iff_isPrimePow := exists_ordCompl_eq_one_iff_isPrimePow
 
 /-- An equivalent definition for prime powers: `n` is a prime power iff there is a unique prime
 dividing it. -/

--- a/Mathlib/Data/Nat/Factorization/PrimePow.lean
+++ b/Mathlib/Data/Nat/Factorization/PrimePow.lean
@@ -53,24 +53,24 @@ theorem isPrimePow_iff_card_primeFactors_eq_one {n : ℕ} :
   simp_rw [isPrimePow_iff_factorization_eq_single, ← Nat.support_factorization,
     Finsupp.card_support_eq_one', pos_iff_ne_zero]
 
-theorem IsPrimePow.exists_ord_compl_eq_one {n : ℕ} (h : IsPrimePow n) :
-    ∃ p : ℕ, p.Prime ∧ ord_compl[p] n = 1 := by
+theorem IsPrimePow.exists_ordCompl_eq_one {n : ℕ} (h : IsPrimePow n) :
+    ∃ p : ℕ, p.Prime ∧ ordCompl[p] n = 1 := by
   rcases eq_or_ne n 0 with (rfl | hn0); · cases not_isPrimePow_zero h
   rcases isPrimePow_iff_factorization_eq_single.mp h with ⟨p, k, hk0, h1⟩
   rcases em' p.Prime with (pp | pp)
   · refine absurd ?_ hk0.ne'
     simp [← Nat.factorization_eq_zero_of_non_prime n pp, h1]
   refine ⟨p, pp, ?_⟩
-  refine Nat.eq_of_factorization_eq (Nat.ord_compl_pos p hn0).ne' (by simp) fun q => ?_
-  rw [Nat.factorization_ord_compl n p, h1]
+  refine Nat.eq_of_factorization_eq (Nat.ordCompl_pos p hn0).ne' (by simp) fun q => ?_
+  rw [Nat.factorization_ordCompl n p, h1]
   simp
 
-theorem exists_ord_compl_eq_one_iff_isPrimePow {n : ℕ} (hn : n ≠ 1) :
-    IsPrimePow n ↔ ∃ p : ℕ, p.Prime ∧ ord_compl[p] n = 1 := by
-  refine ⟨fun h => IsPrimePow.exists_ord_compl_eq_one h, fun h => ?_⟩
+theorem exists_ordCompl_eq_one_iff_isPrimePow {n : ℕ} (hn : n ≠ 1) :
+    IsPrimePow n ↔ ∃ p : ℕ, p.Prime ∧ ordCompl[p] n = 1 := by
+  refine ⟨fun h => IsPrimePow.exists_ordCompl_eq_one h, fun h => ?_⟩
   rcases h with ⟨p, pp, h⟩
   rw [isPrimePow_nat_iff]
-  rw [← Nat.eq_of_dvd_of_div_eq_one (Nat.ord_proj_dvd n p) h] at hn ⊢
+  rw [← Nat.eq_of_dvd_of_div_eq_one (Nat.ordProj_dvd n p) h] at hn ⊢
   refine ⟨p, n.factorization p, pp, ?_, by simp⟩
   contrapose! hn
   simp [Nat.le_zero.1 hn]
@@ -89,7 +89,7 @@ theorem isPrimePow_iff_unique_prime_dvd {n : ℕ} : IsPrimePow n ↔ ∃! p : �
   · cases (hq 2 ⟨Nat.prime_two, dvd_zero 2⟩).trans (hq 3 ⟨Nat.prime_three, dvd_zero 3⟩).symm
   refine ⟨p, n.factorization p, hp, hp.factorization_pos_of_dvd hn₀ hn, ?_⟩
   simp only [and_imp] at hq
-  apply Nat.dvd_antisymm (Nat.ord_proj_dvd _ _)
+  apply Nat.dvd_antisymm (Nat.ordProj_dvd _ _)
   -- We need to show n ∣ p ^ n.factorization p
   apply Nat.dvd_of_primeFactorsList_subperm hn₀
   rw [hp.primeFactorsList_pow, List.subperm_ext_iff]

--- a/Mathlib/GroupTheory/Exponent.lean
+++ b/Mathlib/GroupTheory/Exponent.lean
@@ -243,7 +243,7 @@ theorem _root_.Nat.Prime.exists_orderOf_eq_pow_factorization_exponent {p : ℕ} 
       hp.one_lt.not_le
         ((mul_le_iff_le_one_left he).mp <|
           Nat.le_of_dvd he <| Nat.mul_dvd_of_dvd_div (Nat.dvd_of_mem_primeFactors h) hd)
-  obtain ⟨k, hk : exponent G = p ^ _ * k⟩ := Nat.ord_proj_dvd _ _
+  obtain ⟨k, hk : exponent G = p ^ _ * k⟩ := Nat.ordProj_dvd _ _
   obtain ⟨t, ht⟩ := Nat.exists_eq_succ_of_ne_zero (Finsupp.mem_support_iff.mp h)
   refine ⟨g ^ k, ?_⟩
   rw [ht]
@@ -435,7 +435,7 @@ theorem exists_orderOf_eq_exponent (hG : ExponentExists G) : ∃ g : G, orderOf 
   suffices orderOf t < orderOf (t ^ p ^ k * g) by
     rw [ht] at this
     exact this.not_le (le_csSup hfin.bddAbove <| Set.mem_range_self _)
-  have hpk : p ^ k ∣ orderOf t := Nat.ord_proj_dvd _ _
+  have hpk : p ^ k ∣ orderOf t := Nat.ordProj_dvd _ _
   have hpk' : orderOf (t ^ p ^ k) = orderOf t / p ^ k := by
     rw [orderOf_pow' t (pow_ne_zero k hp.ne_zero), Nat.gcd_eq_right hpk]
   obtain ⟨a, ha⟩ := Nat.exists_eq_add_of_lt hpe

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -627,8 +627,8 @@ theorem ne_bot_of_dvd_card [Finite G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow p
 theorem card_eq_multiplicity [Finite G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow p G) :
     Nat.card P = p ^ Nat.factorization (Nat.card G) p := by
   obtain ⟨n, heq : Nat.card P = _⟩ := IsPGroup.iff_card.mp P.isPGroup'
-  refine Nat.dvd_antisymm ?_ (P.pow_dvd_card_of_pow_dvd_card (Nat.ord_proj_dvd _ p))
-  rw [heq, ← hp.out.pow_dvd_iff_dvd_ord_proj (show Nat.card G ≠ 0 from Nat.card_pos.ne'), ← heq]
+  refine Nat.dvd_antisymm ?_ (P.pow_dvd_card_of_pow_dvd_card (Nat.ordProj_dvd _ p))
+  rw [heq, ← hp.out.pow_dvd_iff_dvd_ordProj (show Nat.card G ≠ 0 from Nat.card_pos.ne'), ← heq]
   exact P.1.card_subgroup_dvd_card
 
 /-- A subgroup with cardinality `p ^ n` is a Sylow subgroup

--- a/scripts/nolints.json
+++ b/scripts/nolints.json
@@ -263,8 +263,6 @@
  ["docBlame", "Nat.rfindOpt"],
  ["docBlame", "Nat.rfindX"],
  ["docBlame", "Nat.subInduction"],
- ["docBlame", "Nat.«termOrd_compl[_]_»"],
- ["docBlame", "Nat.«termOrd_proj[_]_»"],
  ["docBlame", "One.one"],
  ["docBlame", "OptionT.callCC"],
  ["docBlame", "OptionT.mkLabel"],


### PR DESCRIPTION
Since both `ord_proj` and `ord_compl` expand to data (a `Nat`), they should be camelCased. This PR renames them to `ordProj` and `ordCompl` respectively and deprecates the old names in declarations.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
