### PR TITLE
[Merged by Bors] - feat(Analysis/Complex/AbsMax): add two lemmas

### DIFF
--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -325,22 +325,16 @@ lemma eq_const_of_exists_max {f : E → F} {b : ℝ} (h_an : DifferentiableOn �
 /-- If `f` is a function differentiable on the open unit ball, and there exists an `r < 1` such that
 any value of `‖f‖` on the open ball is bounded above by some value on the closed ball of radius `r`,
 then `f` is constant. -/
-lemma eq_const_of_exists_le {f : ℂ → F} {r b : ℝ} (h_an : DifferentiableOn ℂ f (ball 0 b))
+lemma eq_const_of_exists_le [ProperSpace E] {f : E → F} {r b : ℝ} (h_an : DifferentiableOn ℂ f (ball 0 b))
     (hr_nn : 0 ≤ r) (hr_lt : r < b)
     (hr : ∀ z, z ∈ (ball 0 b) → ∃ w, w ∈ closedBall 0 r ∧ ‖f z‖ ≤ ‖f w‖) :
-    Set.EqOn f (Function.const ℂ (f 0)) (ball 0 b) := by
-  let V : Set ℂ := closedBall 0 r
-  have hVc : IsCompact V := isCompact_closedBall (0 : ℂ) r
-  have : ContinuousOn f V := by
-    apply h_an.continuousOn.mono
-    simpa only [V] using fun _ ha ↦ ha.trans_lt hr_lt
-  obtain ⟨x, hx_mem, hx_max⟩ := hVc.exists_isMaxOn (nonempty_closedBall.mpr hr_nn) this.norm
-  suffices Set.EqOn f (Function.const ℂ (f x)) (ball 0 b) by
-    refine this.trans fun y _ ↦ ?_
-    simp only [Function.const_apply]
-    have h0 : (0 : ℂ) ∈ ball 0 b := by simp only [mem_ball, dist_self, zero_lt_one]; linarith
-    simpa using (this h0).symm
-  apply eq_const_of_exists_max h_an (lt_of_le_of_lt hx_mem hr_lt) (fun z hz ↦ ?_)
+    Set.EqOn f (Function.const E (f 0)) (ball 0 b) := by
+  obtain ⟨x, hx_mem, hx_max⟩ := isCompact_closedBall (0 : E) r |>.exists_isMaxOn
+    (nonempty_closedBall.mpr hr_nn) 
+    (h_an.continuousOn.mono <| closedBall_subset_ball hr_lt).norm
+  suffices Set.EqOn f (Function.const E (f x)) (ball 0 b) by
+    rwa [this (mem_ball_self (hr_nn.trans_lt hr_lt))]
+  apply eq_const_of_exists_max h_an (closedBall_subset_ball hr_lt hx_mem) (fun z hz ↦ ?_)↦ ?_)
   obtain ⟨w, hw, hw'⟩ := hr z hz
   exact hw'.trans (hx_max hw)
 

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -315,19 +315,17 @@ theorem eqOn_closedBall_of_isMaxOn_norm {f : E → F} {z : E} {r : ℝ}
 /-- If `f` is differentiable on the open unit ball `{z : ℂ | ‖z‖ < 1}`, and `‖f‖` attains a maximum
 in this open ball, then `f` is constant.-/
 lemma eq_const_of_exists_max {f : E → F} {b : ℝ} (h_an : DifferentiableOn ℂ f (ball 0 b))
-    {v : E} (hv : v ∈ (ball 0 b)) (hv_max : IsMaxOn (norm ∘ f) (ball 0 b) v) :
-    Set.EqOn f (Function.const E (f v)) (ball 0 b) := by
-  refine Complex.eqOn_of_isPreconnected_of_isMaxOn_norm ?_ ?_ h_an hv hv_max
-  · apply Convex.isPreconnected
-    simpa only [ball_zero_eq] using convex_ball (0 : E) b
-  · simpa only [← ball_zero_eq] using Metric.isOpen_ball
+    {v : E} (hv : v ∈ ball 0 b) (hv_max : IsMaxOn (norm ∘ f) (ball 0 b) v) :
+    Set.EqOn f (Function.const E (f v)) (ball 0 b) :=
+  Complex.eqOn_of_isPreconnected_of_isMaxOn_norm (convex_ball 0 b).isPreconnected
+    isOpen_ball h_an hv hv_max
 
 /-- If `f` is a function differentiable on the open unit ball, and there exists an `r < 1` such that
 any value of `‖f‖` on the open ball is bounded above by some value on the closed ball of radius `r`,
 then `f` is constant. -/
 lemma eq_const_of_exists_le {f : ℂ → F} {r b : ℝ} (h_an : DifferentiableOn ℂ f (ball 0 b))
     (hr_nn : 0 ≤ r) (hr_lt : r < b)
-    (hr : ∀ z, z ∈ (ball 0 b) → ∃ w, w ∈ closedBall 0 r ∧ ‖f z‖ ≤ ‖f w‖) :
+    (hr : ∀ z ∈ ball 0 b, ∃ w ∈ closedBall 0 r, ‖f z‖ ≤ ‖f w‖) :
     Set.EqOn f (Function.const ℂ (f 0)) (ball 0 b) := by
   let V : Set ℂ := closedBall 0 r
   have hVc : IsCompact V := isCompact_closedBall (0 : ℂ) r

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -313,7 +313,7 @@ theorem eqOn_closedBall_of_isMaxOn_norm {f : E → F} {z : E} {r : ℝ}
   eq_of_isMaxOn_of_ball_subset hd hz <| ball_subset_ball hx
 
 /-- If `f` is differentiable on the open unit ball `{z : ℂ | ‖z‖ < 1}`, and `‖f‖` attains a maximum
-in  this open ball, then `f` is constant.-/
+in this open ball, then `f` is constant.-/
 lemma eq_const_of_exists_max {f : E → F} (h_an : DifferentiableOn ℂ f {z : E | ‖z‖ < 1})
     {v : E} (hv : ‖v‖ < 1) (hv_max : IsMaxOn (norm ∘ f) {z : E | ‖z‖ < 1} v) :
     Set.EqOn f (Function.const E (f v)) {z : E | ‖z‖ < 1} := by

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -314,32 +314,32 @@ theorem eqOn_closedBall_of_isMaxOn_norm {f : E → F} {z : E} {r : ℝ}
 
 /-- If `f` is differentiable on the open unit ball `{z : ℂ | ‖z‖ < 1}`, and `‖f‖` attains a maximum
 in  this open ball, then `f` is constant.-/
-lemma eq_const_of_exists_max {f : E → F} (h_an : DifferentiableOn ℂ f {z : E | ‖z‖ < 1})
-    {v : E} (hv : ‖v‖ < 1) (hv_max : IsMaxOn (norm ∘ f) {z : E | ‖z‖ < 1} v) :
-    Set.EqOn f (Function.const E (f v)) {z : E | ‖z‖ < 1} := by
+lemma eq_const_of_exists_max {f : E → F} {b : ℝ} (h_an : DifferentiableOn ℂ f (ball 0 b))
+    {v : E} (hv : v ∈ (ball 0 b)) (hv_max : IsMaxOn (norm ∘ f) (ball 0 b) v) :
+    Set.EqOn f (Function.const E (f v)) (ball 0 b) := by
   refine Complex.eqOn_of_isPreconnected_of_isMaxOn_norm ?_ ?_ h_an hv hv_max
   · apply Convex.isPreconnected
-    simpa only [ball_zero_eq] using convex_ball (0 : E) 1
+    simpa only [ball_zero_eq] using convex_ball (0 : E) b
   · simpa only [← ball_zero_eq] using Metric.isOpen_ball
 
 /-- If `f` is a function differentiable on the open unit ball, and there exists an `r < 1` such that
 any value of `‖f‖` on the open ball is bounded above by some value on the closed ball of radius `r`,
 then `f` is constant. -/
-lemma eq_const_of_exists_le {f : ℂ → F} (h_an : DifferentiableOn ℂ f {z : ℂ | ‖z‖ < 1})
-    {r : ℝ} (hr_nn : 0 ≤ r) (hr_lt : r < 1)
-    (hr : ∀ z, ‖z‖ < 1 → ∃ w, ‖w‖ ≤ r ∧ ‖f z‖ ≤ ‖f w‖) :
-    Set.EqOn f (Function.const ℂ (f 0)) {z : ℂ | ‖z‖ < 1} := by
-  let V : Set ℂ := {z | ‖z‖ ≤ r}
-  have hVc : IsCompact V := by simpa only [norm_eq_abs, Metric.closedBall, dist_eq_norm_sub,
-    sub_zero, V] using isCompact_closedBall (0 : ℂ) r
-  have hVne : V.Nonempty := ⟨0, by simp only [norm_eq_abs, Set.mem_setOf_eq, map_zero, hr_nn, V]⟩
+lemma eq_const_of_exists_le {f : ℂ → F} {r b : ℝ} (h_an : DifferentiableOn ℂ f (ball 0 b))
+    (hr_nn : 0 ≤ r) (hr_lt : r < b)
+    (hr : ∀ z, z ∈ (ball 0 b) → ∃ w, w ∈ closedBall 0 r ∧ ‖f z‖ ≤ ‖f w‖) :
+    Set.EqOn f (Function.const ℂ (f 0)) (ball 0 b) := by
+  let V : Set ℂ := closedBall 0 r
+  have hVc : IsCompact V := isCompact_closedBall (0 : ℂ) r
   have : ContinuousOn f V := by
     apply h_an.continuousOn.mono
-    simpa only [norm_eq_abs, Set.setOf_subset_setOf, V] using fun _ ha ↦ ha.trans_lt hr_lt
-  obtain ⟨x, hx_mem, hx_max⟩ := hVc.exists_isMaxOn hVne this.norm
-  suffices Set.EqOn f (Function.const ℂ (f x)) {z : ℂ | ‖z‖ < 1} by
+    simpa only [V] using fun _ ha ↦ ha.trans_lt hr_lt
+  obtain ⟨x, hx_mem, hx_max⟩ := hVc.exists_isMaxOn (nonempty_closedBall.mpr hr_nn) this.norm
+  suffices Set.EqOn f (Function.const ℂ (f x)) (ball 0 b) by
     refine this.trans fun y _ ↦ ?_
-    simp only [Function.const_apply, this (by simp only [norm_zero, zero_lt_one] : ‖(0 : ℂ)‖ < 1)]
+    simp only [Function.const_apply]
+    have h0 : (0 : ℂ) ∈ ball 0 b := by simp only [mem_ball, dist_self, zero_lt_one]; linarith
+    simpa using (this h0).symm
   apply eq_const_of_exists_max h_an (lt_of_le_of_lt hx_mem hr_lt) (fun z hz ↦ ?_)
   obtain ⟨w, hw, hw'⟩ := hr z hz
   exact hw'.trans (hx_max hw)

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -312,6 +312,38 @@ theorem eqOn_closedBall_of_isMaxOn_norm {f : E → F} {z : E} {r : ℝ}
     EqOn f (const E (f z)) (closedBall z r) := fun _x hx =>
   eq_of_isMaxOn_of_ball_subset hd hz <| ball_subset_ball hx
 
+/-- If `f` is differentiable on the open unit ball `{z : ℂ | ‖z‖ < 1}`, and `‖f‖` attains a maximum
+in  this open ball, then `f` is constant.-/
+lemma eq_const_of_exists_max {f : E → F} (h_an : DifferentiableOn ℂ f {z : E | ‖z‖ < 1})
+    {v : E} (hv : ‖v‖ < 1) (hv_max : IsMaxOn (norm ∘ f) {z : E | ‖z‖ < 1} v) :
+    Set.EqOn f (Function.const E (f v)) {z : E | ‖z‖ < 1} := by
+  refine Complex.eqOn_of_isPreconnected_of_isMaxOn_norm ?_ ?_ h_an hv hv_max
+  · apply Convex.isPreconnected
+    simpa only [ball_zero_eq] using convex_ball (0 : E) 1
+  · simpa only [← ball_zero_eq] using Metric.isOpen_ball
+
+/-- If `f` is a function differentiable on the open unit ball, and there exists an `r < 1` such that
+any value of `‖f‖` on the open ball is bounded above by some value on the closed ball of radius `r`,
+then `f` is constant. -/
+lemma eq_const_of_exists_le {f : ℂ → F} (h_an : DifferentiableOn ℂ f {z : ℂ | ‖z‖ < 1})
+    {r : ℝ} (hr_nn : 0 ≤ r) (hr_lt : r < 1)
+    (hr : ∀ z, ‖z‖ < 1 → ∃ w, ‖w‖ ≤ r ∧ ‖f z‖ ≤ ‖f w‖) :
+    Set.EqOn f (Function.const ℂ (f 0)) {z : ℂ | ‖z‖ < 1} := by
+  let V : Set ℂ := {z | ‖z‖ ≤ r}
+  have hVc : IsCompact V := by simpa only [norm_eq_abs, Metric.closedBall, dist_eq_norm_sub,
+    sub_zero, V] using isCompact_closedBall (0 : ℂ) r
+  have hVne : V.Nonempty := ⟨0, by simp only [norm_eq_abs, Set.mem_setOf_eq, map_zero, hr_nn, V]⟩
+  have : ContinuousOn f V := by
+    apply h_an.continuousOn.mono
+    simpa only [norm_eq_abs, Set.setOf_subset_setOf, V] using fun _ ha ↦ ha.trans_lt hr_lt
+  obtain ⟨x, hx_mem, hx_max⟩ := hVc.exists_isMaxOn hVne this.norm
+  suffices Set.EqOn f (Function.const ℂ (f x)) {z : ℂ | ‖z‖ < 1} by
+    refine this.trans fun y _ ↦ ?_
+    simp only [Function.const_apply, this (by simp only [norm_zero, zero_lt_one] : ‖(0 : ℂ)‖ < 1)]
+  apply eq_const_of_exists_max h_an (lt_of_le_of_lt hx_mem hr_lt) (fun z hz ↦ ?_)
+  obtain ⟨w, hw, hw'⟩ := hr z hz
+  exact hw'.trans (hx_max hw)
+
 /-- **Maximum modulus principle**: if `f : E → F` is complex differentiable in a neighborhood of `c`
 and the norm `‖f z‖` has a local maximum at `c`, then `f` is locally constant in a neighborhood
 of `c`. -/


### PR DESCRIPTION
add two results:

-  If `f` is differentiable on the open unit ball `{z : ℂ | ‖z‖ < 1}`, and `‖f‖` attains a maximum
in  this open ball, then `f` is constant 

-   If `f` is a function differentiable on the open unit ball, and there exists an `r < 1` such that
any value of `‖f‖` on the open ball is bounded above by some value on the closed ball of radius `r`,
then `f` is constant. 

These lemmas together with #18192 will be used to prove some dimension results for spaces of modular forms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
