### PR TITLE
[Merged by Bors] - feat(CategoryTheory): constructor for pseudofunctors from a strict locally discrete category

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1481,6 +1481,7 @@ import Mathlib.CategoryTheory.Bicategory.End
 import Mathlib.CategoryTheory.Bicategory.Extension
 import Mathlib.CategoryTheory.Bicategory.Free
 import Mathlib.CategoryTheory.Bicategory.Functor.Lax
+import Mathlib.CategoryTheory.Bicategory.Functor.LocallyDiscrete
 import Mathlib.CategoryTheory.Bicategory.Functor.Oplax
 import Mathlib.CategoryTheory.Bicategory.Functor.Prelax
 import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -25,6 +25,8 @@ namespace CategoryTheory
 
 open Bicategory
 
+/-- Constructor for pseudofunctors from a strict locally discrete bicategory. In that
+case, we do not need to provide the `map₂` field of pseudofunctors. -/
 @[simps obj map mapId mapComp]
 def pseudofunctorOfIsLocallyDiscrete
     {B C : Type*} [Bicategory B] [IsLocallyDiscrete B] [Bicategory C] [Strict B]
@@ -59,6 +61,8 @@ def pseudofunctorOfIsLocallyDiscrete
 
 namespace LocallyDiscrete
 
+/-- Constructor for pseudofunctors from a strict locally discrete bicategory. In that
+case, we do not need to provide the `map₂` field of pseudofunctors. -/
 @[simps! obj map mapId mapComp]
 def mkPseudofunctor {B₀ C : Type*} [Category B₀] [Bicategory C]
     (obj : B₀ → C)

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -37,8 +37,8 @@ def pseudofunctorOfIsLocallyDiscrete
         (mapComp f g).hom ▷ map h ≫ (α_ (map f) (map g) (map h)).hom ≫
           map f ◁ (mapComp g h).inv ≫ (mapComp f (g ≫ h)).inv = eqToHom (by simp) := by aesop_cat)
     (map₂_left_unitor : ∀ {b₀ b₁ : B} (f : b₀ ⟶ b₁),
-      (mapComp (𝟙 b₀) f).hom ≫ (mapId b₀).hom ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) :=
-        by aesop_cat)
+      (mapComp (𝟙 b₀) f).hom ≫ (mapId b₀).hom ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) := by
+        aesop_cat)
     (map₂_right_unitor : ∀ {b₀ b₁ : B} (f : b₀ ⟶ b₁),
       (mapComp f (𝟙 b₁)).hom ≫ map f ◁ (mapId b₁).hom ≫ (ρ_ (map f)).hom = eqToHom (by simp) :=
         by aesop_cat) :

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -7,19 +7,22 @@ import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
 import Mathlib.CategoryTheory.Bicategory.LocallyDiscrete
 
 /-!
-# Constructor for pseudofunctors from a locally discrete bicategory
+# Pseudofunctors from locally discrete bicategories
 
-In this file, we define a constructor
-`pseudofunctorOfIsLocallyDiscrete` for the type `Pseudofunctor B C`
-when `C` is any bicategory, and `B` is a locally discrete category.
-Indeed, in this situation, we do not need to care about the field `map₂`
-of pseudofunctors because all the `2`-morphisms in `B` are identities.
+This file provides various ways of constructing pseudofunctors from locally discrete
+bicategories.
+
+Firstly, we define the constructors `pseudofunctorOfIsLocallyDiscrete` and
+`oplaxFunctorOfIsLocallyDiscrete` for defining pseudofunctors and oplax functors
+from a locally discrete bicategories. In this situation, we do not need to care about
+the field `map₂`,  because all the `2`-morphisms in `B` are identities.
 
 We also define a specialized constructor `LocallyDiscrete.mkPseudofunctor` when
 the source bicategory is of the form `B := LocallyDiscrete B₀` for a category `B₀`.
 
-A functor `F : I ⥤ B` with `B` a strict bicategory can also be promoted to a pseudofunctor
-(`Functor.toPseudofunctor`).
+We also prove that a functor `F : I ⥤ B` with `B` a strict bicategory can be promoted
+to a pseudofunctor (or oplax functor) (`Functor.toPseudofunctor`) with domain
+`LocallyDiscrete I`.
 
 -/
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -121,7 +121,7 @@ be promoted to an oplax functor from `LocallyDiscrete I` to `B`.
 -/
 @[simps! obj map mapId mapComp]
 def Functor.toOplaxFunctor : OplaxFunctor (LocallyDiscrete I) B :=
-  oplaxfunctorOfIsLocallyDiscrete
+  oplaxFunctorOfIsLocallyDiscrete
     (fun ⟨X⟩ ↦ F.obj X) (fun ⟨f⟩ ↦ F.map f)
     (fun ⟨X⟩ ↦ eqToHom (by simp)) (fun f g ↦ eqToHom (by simp))
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -5,7 +5,6 @@ Authors: Joël Riou
 -/
 import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
 import Mathlib.CategoryTheory.Bicategory.LocallyDiscrete
-import Mathlib.CategoryTheory.Category.Cat
 
 /-!
 # Constructor for pseudofunctors from a locally discrete bicategory
@@ -19,13 +18,16 @@ of pseudofunctors because all the `2`-morphisms in `B` are identities.
 We also define a specialized constructor `LocallyDiscrete.mkPseudofunctor` when
 the source bicategory is of the form `B := LocallyDiscrete B₀` for a category `B₀`.
 
+A functor `F : I ⥤ B` with `B` a strict bicategory can also be promoted to a pseudofunctor
+(`Functor.toPseudofunctor`).
+
 -/
 
 namespace CategoryTheory
 
 open Bicategory
 
-/-- Constructor for pseudofunctors from a strict locally discrete bicategory. In that
+/-- Constructor for pseudofunctors from a locally discrete bicategory. In that
 case, we do not need to provide the `map₂` field of pseudofunctors. -/
 @[simps obj map mapId mapComp]
 def pseudofunctorOfIsLocallyDiscrete
@@ -58,6 +60,69 @@ def pseudofunctorOfIsLocallyDiscrete
   map₂_whisker_right η _ := by
     obtain rfl := obj_ext_of_isDiscrete η
     simp
+
+/-- Constructor for oplax functors from a locally discrete bicategory. In that
+case, we do not need to provide the `map₂` field of oplax functors. -/
+@[simps obj map mapId mapComp]
+def oplaxfunctorOfIsLocallyDiscrete
+    {B C : Type*} [Bicategory B] [IsLocallyDiscrete B] [Bicategory C]
+    (obj : B → C)
+    (map : ∀ {b b' : B}, (b ⟶ b') → (obj b ⟶ obj b'))
+    (mapId : ∀ (b : B), map (𝟙 b) ⟶ 𝟙 _)
+    (mapComp : ∀ {b₀ b₁ b₂ : B} (f : b₀ ⟶ b₁) (g : b₁ ⟶ b₂), map (f ≫ g) ⟶ map f ≫ map g)
+    (map₂_associator : ∀ {b₀ b₁ b₂ b₃ : B} (f : b₀ ⟶ b₁) (g : b₁ ⟶ b₂) (h : b₂ ⟶ b₃),
+      eqToHom (by simp) ≫ mapComp f (g ≫ h) ≫ map f ◁ mapComp g h =
+        mapComp (f ≫ g) h ≫ mapComp f g ▷ map h ≫ (α_ (map f) (map g) (map h)).hom := by
+          aesop_cat)
+    (map₂_left_unitor : ∀ {b₀ b₁ : B} (f : b₀ ⟶ b₁),
+      mapComp (𝟙 b₀) f ≫ mapId b₀ ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) := by
+        aesop_cat)
+    (map₂_right_unitor : ∀ {b₀ b₁ : B} (f : b₀ ⟶ b₁),
+      mapComp f (𝟙 b₁) ≫ map f ◁ mapId b₁ ≫ (ρ_ (map f)).hom = eqToHom (by simp) := by
+        aesop_cat) :
+    OplaxFunctor B C where
+  obj := obj
+  map := map
+  map₂ φ := eqToHom (by
+    obtain rfl := obj_ext_of_isDiscrete φ
+    dsimp)
+  mapId := mapId
+  mapComp := mapComp
+  mapComp_naturality_left η := by
+    obtain rfl := obj_ext_of_isDiscrete η
+    simp
+  mapComp_naturality_right _ _ _ η := by
+    obtain rfl := obj_ext_of_isDiscrete η
+    simp
+
+section
+
+variable {I B : Type*} [Category I] [Bicategory B] [Strict B] (F : I ⥤ B)
+
+attribute [local simp]
+  Strict.leftUnitor_eqToIso Strict.rightUnitor_eqToIso Strict.associator_eqToIso
+
+/--
+If `B` is a strict bicategory and `I` is a (1-)category, any functor (of 1-categories) `I ⥤ B` can
+be promoted to a pseudofunctor from `LocallyDiscrete I` to `B`.
+-/
+@[simps! obj map mapId mapComp]
+def Functor.toPseudoFunctor : Pseudofunctor (LocallyDiscrete I) B :=
+  pseudofunctorOfIsLocallyDiscrete
+    (fun ⟨X⟩ ↦ F.obj X) (fun ⟨f⟩ ↦ F.map f)
+    (fun ⟨X⟩ ↦ eqToIso (by simp)) (fun f g ↦ eqToIso (by simp))
+
+/--
+If `B` is a strict bicategory and `I` is a (1-)category, any functor (of 1-categories) `I ⥤ B` can
+be promoted to an oplax functor from `LocallyDiscrete I` to `B`.
+-/
+@[simps! obj map mapId mapComp]
+def Functor.toOplaxFunctor : OplaxFunctor (LocallyDiscrete I) B :=
+  oplaxfunctorOfIsLocallyDiscrete
+    (fun ⟨X⟩ ↦ F.obj X) (fun ⟨f⟩ ↦ F.map f)
+    (fun ⟨X⟩ ↦ eqToHom (by simp)) (fun f g ↦ eqToHom (by simp))
+
+end
 
 namespace LocallyDiscrete
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -8,11 +8,11 @@ import Mathlib.CategoryTheory.Bicategory.LocallyDiscrete
 import Mathlib.CategoryTheory.Category.Cat
 
 /-!
-# Constructor for pseudofunctors from a strict locally discrete bicategory
+# Constructor for pseudofunctors from a locally discrete bicategory
 
 In this file, we define a constructor
 `pseudofunctorOfIsLocallyDiscrete` for the type `Pseudofunctor B C`
-when `C` is any bicategory, and `B` is a strict locally discrete category.
+when `C` is any bicategory, and `B` is a locally discrete category.
 Indeed, in this situation, we do not need to care about the field `map₂`
 of pseudofunctors because all the `2`-morphisms in `B` are identities.
 
@@ -29,7 +29,7 @@ open Bicategory
 case, we do not need to provide the `map₂` field of pseudofunctors. -/
 @[simps obj map mapId mapComp]
 def pseudofunctorOfIsLocallyDiscrete
-    {B C : Type*} [Bicategory B] [IsLocallyDiscrete B] [Bicategory C] [Strict B]
+    {B C : Type*} [Bicategory B] [IsLocallyDiscrete B] [Bicategory C]
     (obj : B → C)
     (map : ∀ {b b' : B}, (b ⟶ b') → (obj b ⟶ obj b'))
     (mapId : ∀ (b : B), map (𝟙 b) ≅ 𝟙 _)
@@ -61,7 +61,7 @@ def pseudofunctorOfIsLocallyDiscrete
 
 namespace LocallyDiscrete
 
-/-- Constructor for pseudofunctors from a strict locally discrete bicategory. In that
+/-- Constructor for pseudofunctors from a locally discrete bicategory. In that
 case, we do not need to provide the `map₂` field of pseudofunctors. -/
 @[simps! obj map mapId mapComp]
 def mkPseudofunctor {B₀ C : Type*} [Category B₀] [Bicategory C]

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -70,8 +70,8 @@ def mkPseudofunctor {B₀ C : Type*} [Category B₀] [Bicategory C]
         (mapComp f g).hom ▷ map h ≫ (α_ (map f) (map g) (map h)).hom ≫
           map f ◁ (mapComp g h).inv ≫ (mapComp f (g ≫ h)).inv = eqToHom (by simp) := by aesop_cat)
     (map₂_left_unitor : ∀ {b₀ b₁ : B₀} (f : b₀ ⟶ b₁),
-      (mapComp (𝟙 b₀) f).hom ≫ (mapId b₀).hom ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) :=
-        by aesop_cat)
+      (mapComp (𝟙 b₀) f).hom ≫ (mapId b₀).hom ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) := by
+        aesop_cat)
     (map₂_right_unitor : ∀ {b₀ b₁ : B₀} (f : b₀ ⟶ b₁),
       (mapComp f (𝟙 b₁)).hom ≫ map f ◁ (mapId b₁).hom ≫ (ρ_ (map f)).hom = eqToHom (by simp) :=
         by aesop_cat) :

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -64,7 +64,7 @@ def pseudofunctorOfIsLocallyDiscrete
 /-- Constructor for oplax functors from a locally discrete bicategory. In that
 case, we do not need to provide the `map₂` field of oplax functors. -/
 @[simps obj map mapId mapComp]
-def oplaxfunctorOfIsLocallyDiscrete
+def oplaxFunctorOfIsLocallyDiscrete
     {B C : Type*} [Bicategory B] [IsLocallyDiscrete B] [Bicategory C]
     (obj : B → C)
     (map : ∀ {b b' : B}, (b ⟶ b') → (obj b ⟶ obj b'))

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -40,8 +40,8 @@ def pseudofunctorOfIsLocallyDiscrete
       (mapComp (𝟙 b₀) f).hom ≫ (mapId b₀).hom ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) := by
         aesop_cat)
     (map₂_right_unitor : ∀ {b₀ b₁ : B} (f : b₀ ⟶ b₁),
-      (mapComp f (𝟙 b₁)).hom ≫ map f ◁ (mapId b₁).hom ≫ (ρ_ (map f)).hom = eqToHom (by simp) :=
-        by aesop_cat) :
+      (mapComp f (𝟙 b₁)).hom ≫ map f ◁ (mapId b₁).hom ≫ (ρ_ (map f)).hom = eqToHom (by simp) := by
+        aesop_cat) :
     Pseudofunctor B C where
   obj := obj
   map := map

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -73,8 +73,8 @@ def mkPseudofunctor {B₀ C : Type*} [Category B₀] [Bicategory C]
       (mapComp (𝟙 b₀) f).hom ≫ (mapId b₀).hom ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) := by
         aesop_cat)
     (map₂_right_unitor : ∀ {b₀ b₁ : B₀} (f : b₀ ⟶ b₁),
-      (mapComp f (𝟙 b₁)).hom ≫ map f ◁ (mapId b₁).hom ≫ (ρ_ (map f)).hom = eqToHom (by simp) :=
-        by aesop_cat) :
+      (mapComp f (𝟙 b₁)).hom ≫ map f ◁ (mapId b₁).hom ≫ (ρ_ (map f)).hom = eqToHom (by simp) := by
+        aesop_cat) :
     Pseudofunctor (LocallyDiscrete B₀) C :=
   pseudofunctorOfIsLocallyDiscrete (fun b ↦ obj b.as) (fun f ↦ map f.as)
     (fun _ ↦ mapId _) (fun _ _ ↦ mapComp _ _) (fun _ _ _ ↦ map₂_associator _ _ _)

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
+import Mathlib.CategoryTheory.Bicategory.LocallyDiscrete
+import Mathlib.CategoryTheory.Category.Cat
+
+/-!
+# Constructor for pseudofunctors from a strict locally discrete bicategory
+
+In this file, we define a constructor
+`pseudofunctorOfIsLocallyDiscrete` for the type `Pseudofunctor B C`
+when `C` is any bicategory, and `B` is a strict locally discrete category.
+Indeed, in this situation, we do not need to care about the field `map₂`
+of pseudofunctors because all the `2`-morphisms in `B` are identities.
+
+We also define a specialized constructor `LocallyDiscrete.mkPseudofunctor` when
+the source bicategory is of the form `B := LocallyDiscrete B₀` for a category `B₀`.
+
+-/
+
+namespace CategoryTheory
+
+open Bicategory
+
+@[simps obj map mapId mapComp]
+def pseudofunctorOfIsLocallyDiscrete
+    {B C : Type*} [Bicategory B] [IsLocallyDiscrete B] [Bicategory C] [Strict B]
+    (obj : B → C)
+    (map : ∀ {b b' : B}, (b ⟶ b') → (obj b ⟶ obj b'))
+    (mapId : ∀ (b : B), map (𝟙 b) ≅ 𝟙 _)
+    (mapComp : ∀ {b₀ b₁ b₂ : B} (f : b₀ ⟶ b₁) (g : b₁ ⟶ b₂), map (f ≫ g) ≅ map f ≫ map g)
+    (map₂_associator : ∀ {b₀ b₁ b₂ b₃ : B} (f : b₀ ⟶ b₁) (g : b₁ ⟶ b₂) (h : b₂ ⟶ b₃),
+      (mapComp (f ≫ g) h).hom ≫
+        (mapComp f g).hom ▷ map h ≫ (α_ (map f) (map g) (map h)).hom ≫
+          map f ◁ (mapComp g h).inv ≫ (mapComp f (g ≫ h)).inv = eqToHom (by simp) := by aesop_cat)
+    (map₂_left_unitor : ∀ {b₀ b₁ : B} (f : b₀ ⟶ b₁),
+      (mapComp (𝟙 b₀) f).hom ≫ (mapId b₀).hom ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) :=
+        by aesop_cat)
+    (map₂_right_unitor : ∀ {b₀ b₁ : B} (f : b₀ ⟶ b₁),
+      (mapComp f (𝟙 b₁)).hom ≫ map f ◁ (mapId b₁).hom ≫ (ρ_ (map f)).hom = eqToHom (by simp) :=
+        by aesop_cat) :
+    Pseudofunctor B C where
+  obj := obj
+  map := map
+  map₂ φ := eqToHom (by
+    obtain rfl := obj_ext_of_isDiscrete φ
+    dsimp)
+  mapId := mapId
+  mapComp := mapComp
+  map₂_whisker_left _ _ _ η := by
+    obtain rfl := obj_ext_of_isDiscrete η
+    simp
+  map₂_whisker_right η _ := by
+    obtain rfl := obj_ext_of_isDiscrete η
+    simp
+
+namespace LocallyDiscrete
+
+@[simps! obj map mapId mapComp]
+def mkPseudofunctor {B₀ C : Type*} [Category B₀] [Bicategory C]
+    (obj : B₀ → C)
+    (map : ∀ {b b' : B₀}, (b ⟶ b') → (obj b ⟶ obj b'))
+    (mapId : ∀ (b : B₀), map (𝟙 b) ≅ 𝟙 _)
+    (mapComp : ∀ {b₀ b₁ b₂ : B₀} (f : b₀ ⟶ b₁) (g : b₁ ⟶ b₂), map (f ≫ g) ≅ map f ≫ map g)
+    (map₂_associator : ∀ {b₀ b₁ b₂ b₃ : B₀} (f : b₀ ⟶ b₁) (g : b₁ ⟶ b₂) (h : b₂ ⟶ b₃),
+      (mapComp (f ≫ g) h).hom ≫
+        (mapComp f g).hom ▷ map h ≫ (α_ (map f) (map g) (map h)).hom ≫
+          map f ◁ (mapComp g h).inv ≫ (mapComp f (g ≫ h)).inv = eqToHom (by simp) := by aesop_cat)
+    (map₂_left_unitor : ∀ {b₀ b₁ : B₀} (f : b₀ ⟶ b₁),
+      (mapComp (𝟙 b₀) f).hom ≫ (mapId b₀).hom ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) :=
+        by aesop_cat)
+    (map₂_right_unitor : ∀ {b₀ b₁ : B₀} (f : b₀ ⟶ b₁),
+      (mapComp f (𝟙 b₁)).hom ≫ map f ◁ (mapId b₁).hom ≫ (ρ_ (map f)).hom = eqToHom (by simp) :=
+        by aesop_cat) :
+    Pseudofunctor (LocallyDiscrete B₀) C :=
+  pseudofunctorOfIsLocallyDiscrete (fun b ↦ obj b.as) (fun f ↦ map f.as)
+    (fun _ ↦ mapId _) (fun _ _ ↦ mapComp _ _) (fun _ _ _ ↦ map₂_associator _ _ _)
+    (fun _ ↦ map₂_left_unitor _) (fun _ ↦ map₂_right_unitor _)
+
+end LocallyDiscrete
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -5,6 +5,7 @@ Authors: Calle Sönne
 -/
 
 import Mathlib.CategoryTheory.Bicategory.LocallyDiscrete
+import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
 
 /-!
 # The Grothendieck construction

--- a/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
@@ -104,35 +104,6 @@ instance locallyDiscreteBicategory.strict : Strict (LocallyDiscrete C) where
   comp_id _ := Discrete.ext (Category.comp_id _)
   assoc _ _ _ := Discrete.ext (Category.assoc _ _ _)
 
-attribute [local simp]
-  Strict.leftUnitor_eqToIso Strict.rightUnitor_eqToIso Strict.associator_eqToIso
-
-variable {I : Type u₁} [Category.{v₁} I] {B : Type u₂} [Bicategory.{w₂, v₂} B] [Strict B]
-
-/--
-If `B` is a strict bicategory and `I` is a (1-)category, any functor (of 1-categories) `I ⥤ B` can
-be promoted to a pseudofunctor from `LocallyDiscrete I` to `B`.
--/
-@[simps]
-def Functor.toPseudoFunctor (F : I ⥤ B) : Pseudofunctor (LocallyDiscrete I) B where
-  obj i := F.obj i.as
-  map f := F.map f.as
-  map₂ η := eqToHom (congr_arg _ (LocallyDiscrete.eq_of_hom η))
-  mapId i := eqToIso (F.map_id i.as)
-  mapComp f g := eqToIso (F.map_comp f.as g.as)
-
-/--
-If `B` is a strict bicategory and `I` is a (1-)category, any functor (of 1-categories) `I ⥤ B` can
-be promoted to an oplax functor from `LocallyDiscrete I` to `B`.
--/
-@[simps]
-def Functor.toOplaxFunctor (F : I ⥤ B) : OplaxFunctor (LocallyDiscrete I) B where
-  obj i := F.obj i.as
-  map f := F.map f.as
-  map₂ η := eqToHom (congr_arg _ (LocallyDiscrete.eq_of_hom η))
-  mapId i := eqToHom (F.map_id i.as)
-  mapComp f g := eqToHom (F.map_comp f.as g.as)
-
 end
 
 section

--- a/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yuma Mizuno, Calle Sönne
 -/
 import Mathlib.CategoryTheory.DiscreteCategory
-import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
+import Mathlib.CategoryTheory.Bicategory.Functor.Prelax
 import Mathlib.CategoryTheory.Bicategory.Strict
 
 /-!

--- a/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
@@ -151,8 +151,7 @@ namespace Bicategory
 /-- A bicategory is locally discrete if the categories of 1-morphisms are discrete. -/
 abbrev IsLocallyDiscrete (B : Type*) [Bicategory B] := ∀ (b c : B), IsDiscrete (b ⟶ c)
 
-instance (C : Type*) [Category C] :
-    IsLocallyDiscrete (LocallyDiscrete C) :=
+instance (C : Type*) [Category C] : IsLocallyDiscrete (LocallyDiscrete C) :=
   fun _ _ ↦ Discrete.isDiscrete _
 
 end Bicategory

--- a/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
@@ -21,8 +21,6 @@ namespace CategoryTheory
 
 open Bicategory Discrete
 
-open Bicategory
-
 universe w₂ w₁ v₂ v₁ v u₂ u₁ u
 
 section
@@ -147,6 +145,17 @@ lemma PrelaxFunctor.map₂_eqToHom (F : PrelaxFunctor B C) {a b : B} {f g : a �
   subst h; simp only [eqToHom_refl, PrelaxFunctor.map₂_id]
 
 end
+
+namespace Bicategory
+
+/-- A bicategory is locally discrete if the categories of 1-morphisms are discrete. -/
+abbrev IsLocallyDiscrete (B : Type*) [Bicategory B] := ∀ (b c : B), IsDiscrete (b ⟶ c)
+
+instance (C : Type*) [Category C] :
+    IsLocallyDiscrete (LocallyDiscrete C) :=
+  fun _ _ ↦ Discrete.isDiscrete _
+
+end Bicategory
 
 end CategoryTheory
 

--- a/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
@@ -154,6 +154,11 @@ abbrev IsLocallyDiscrete (B : Type*) [Bicategory B] := ∀ (b c : B), IsDiscrete
 instance (C : Type*) [Category C] : IsLocallyDiscrete (LocallyDiscrete C) :=
   fun _ _ ↦ Discrete.isDiscrete _
 
+instance (B : Type*) [Bicategory B] [IsLocallyDiscrete B] : Strict B where
+  id_comp f := obj_ext_of_isDiscrete (leftUnitor f).hom
+  comp_id f := obj_ext_of_isDiscrete (rightUnitor f).hom
+  assoc f g h := obj_ext_of_isDiscrete (associator f g h).hom
+
 end Bicategory
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/DiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/DiscreteCategory.lean
@@ -304,4 +304,24 @@ def piEquivalenceFunctorDiscrete (J : Type u₂) (C : Type u₁) [Category.{v₁
       obtain rfl : f = 𝟙 _ := rfl
       simp))) (by aesop_cat)
 
+/-- A category is discrete when there is at most one morphism between two objects,
+in which case they are equal. -/
+class IsDiscrete (C : Type*) [Category C] : Prop where
+  subsingleton (X Y : C) : Subsingleton (X ⟶ Y) := by infer_instance
+  eq_of_hom {X Y : C} (f : X ⟶ Y) : X = Y
+
+attribute [instance] IsDiscrete.subsingleton
+
+lemma obj_ext_of_isDiscrete {C : Type*} [Category C] [IsDiscrete C]
+    {X Y : C} (f : X ⟶ Y) : X = Y := IsDiscrete.eq_of_hom f
+
+instance Discrete.isDiscrete (C : Type*) : IsDiscrete (Discrete C) where
+  eq_of_hom := by rintro ⟨_⟩ ⟨_⟩ ⟨⟨rfl⟩⟩; rfl
+
+instance (C : Type*) [Category C] [IsDiscrete C] : IsDiscrete Cᵒᵖ where
+  eq_of_hom := by
+    rintro ⟨_⟩ ⟨_⟩ ⟨f⟩
+    obtain rfl := obj_ext_of_isDiscrete f
+    rfl
+
 end CategoryTheory


### PR DESCRIPTION
In this file, we define a constructor `pseudofunctorOfIsLocallyDiscrete` for the type `Pseudofunctor B C` when `C` is any bicategory, and `B` is a strict locally discrete category. Indeed, in this situation, we do not need to care about the field `map₂` of pseudofunctors because all the `2`-morphisms in `B` are identities.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
