### PR TITLE
[Merged by Bors] - chore: split Topology.Separation

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4923,7 +4923,8 @@ import Mathlib.Topology.QuasiSeparated
 import Mathlib.Topology.RestrictGen
 import Mathlib.Topology.Semicontinuous
 import Mathlib.Topology.SeparatedMap
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
+import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.Separation.NotNormal
 import Mathlib.Topology.Sequences
 import Mathlib.Topology.Sets.Closeds

--- a/Mathlib/Analysis/Convex/Radon.lean
+++ b/Mathlib/Analysis/Convex/Radon.lean
@@ -6,7 +6,7 @@ Authors: Vasily Nesterov
 import Mathlib.Analysis.Convex.Combination
 import Mathlib.Data.Set.Card
 import Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Radon's theorem on convex sets

--- a/Mathlib/Dynamics/FixedPoints/Topology.lean
+++ b/Mathlib/Dynamics/FixedPoints/Topology.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Johannes Hölzl
 -/
 import Mathlib.Dynamics.FixedPoints.Basic
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Topological properties of fixed points

--- a/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.BigOperators.Finprod
 import Mathlib.Order.Filter.AtTopBot.BigOperators
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Infinite sum and product over a topological monoid

--- a/Mathlib/Topology/Algebra/Semigroup.lean
+++ b/Mathlib/Topology/Algebra/Semigroup.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 David Wärn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Wärn
 -/
-import Mathlib.Topology.Separation
 import Mathlib.Algebra.Group.Defs
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Idempotents in topological semigroups

--- a/Mathlib/Topology/Compactification/OnePoint.lean
+++ b/Mathlib/Topology/Compactification/OnePoint.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yourong Zang, Yury Kudryashov
 -/
 import Mathlib.Data.Fintype.Option
-import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.Sets.Opens
 
 /-!

--- a/Mathlib/Topology/Compactification/OnePoint.lean
+++ b/Mathlib/Topology/Compactification/OnePoint.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yourong Zang, Yury Kudryashov
 -/
 import Mathlib.Data.Fintype.Option
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.Sets.Opens
 
 /-!

--- a/Mathlib/Topology/Connected/Separation.lean
+++ b/Mathlib/Topology/Connected/Separation.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson
 -/
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 /-!
 
 # Separation and (dis)connectedness properties of topological spaces.

--- a/Mathlib/Topology/CountableSeparatingOn.lean
+++ b/Mathlib/Topology/CountableSeparatingOn.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Topology.Separation
 import Mathlib.Order.Filter.CountableSeparatingOn
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Countable separating families of sets in topological spaces

--- a/Mathlib/Topology/DenseEmbedding.lean
+++ b/Mathlib/Topology/DenseEmbedding.lean
@@ -3,8 +3,8 @@ Copyright (c) 2019 Reid Barton. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot
 -/
-import Mathlib.Topology.Separation
 import Mathlib.Topology.Bases
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Dense embeddings

--- a/Mathlib/Topology/DiscreteQuotient.lean
+++ b/Mathlib/Topology/DiscreteQuotient.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Calle Sönne, Adam Topaz
 -/
 import Mathlib.Data.Setoid.Partition
-import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.LocallyConstant.Basic
 
 /-!

--- a/Mathlib/Topology/DiscreteQuotient.lean
+++ b/Mathlib/Topology/DiscreteQuotient.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Calle Sönne, Adam Topaz
 -/
 import Mathlib.Data.Setoid.Partition
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.LocallyConstant.Basic
 
 /-!

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash, Bhavik Mehta, Daniel Weber
 -/
 import Mathlib.Topology.Constructions
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Discrete subsets of topological spaces

--- a/Mathlib/Topology/ExtendFrom.lean
+++ b/Mathlib/Topology/ExtendFrom.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Anatole Dedecker. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Anatole Dedecker
 -/
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Extending a function from a subset

--- a/Mathlib/Topology/Filter.lean
+++ b/Mathlib/Topology/Filter.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Order.Filter.Lift
-import Mathlib.Topology.Separation
 import Mathlib.Order.Interval.Set.Monotone
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Topology on the set of filters on a type

--- a/Mathlib/Topology/IndicatorConstPointwise.lean
+++ b/Mathlib/Topology/IndicatorConstPointwise.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Kalle Kytölä. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kalle Kytölä
 -/
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Pointwise convergence of indicator functions

--- a/Mathlib/Topology/Instances/Irrational.lean
+++ b/Mathlib/Topology/Instances/Irrational.lean
@@ -6,6 +6,7 @@ Authors: Yury Kudryashov
 import Mathlib.Data.Real.Irrational
 import Mathlib.Data.Rat.Encodable
 import Mathlib.Topology.GDelta
+import Mathlib.Topology.Separation.GDelta
 
 /-!
 # Topology of irrational numbers

--- a/Mathlib/Topology/Order/OrderClosed.lean
+++ b/Mathlib/Topology/Order/OrderClosed.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 -/
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Order-closed topologies

--- a/Mathlib/Topology/Order/Priestley.lean
+++ b/Mathlib/Topology/Order/Priestley.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Order.UpperLower.Basic
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Priestley spaces

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Felix Weilacher
 -/
 
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Perfect Sets

--- a/Mathlib/Topology/QuasiSeparated.lean
+++ b/Mathlib/Topology/QuasiSeparated.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.NoetherianSpace
 
 /-!

--- a/Mathlib/Topology/QuasiSeparated.lean
+++ b/Mathlib/Topology/QuasiSeparated.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.NoetherianSpace
 
 /-!

--- a/Mathlib/Topology/SeparatedMap.lean
+++ b/Mathlib/Topology/SeparatedMap.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Junyan Xu
 -/
 import Mathlib.Topology.Connected.Basic
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 /-!
 # Separated maps and locally injective maps out of a topological space.
 

--- a/Mathlib/Topology/Separation/GDelta.lean
+++ b/Mathlib/Topology/Separation/GDelta.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Mario Carneiro
+-/
+import Mathlib.Topology.Compactness.Lindelof
+import Mathlib.Topology.Compactness.SigmaCompact
+import Mathlib.Topology.Connected.TotallyDisconnected
+import Mathlib.Topology.Inseparable
+import Mathlib.Topology.GDelta
+import Mathlib.Topology.Separation.Basic
+
+/-!
+# Separation properties of topological spaces.
+
+## Main definitions
+
+* `PerfectlyNormalSpace`: A perfectly normal space is a normal space such that
+  closed sets are Gδ.
+* `T6Space`: A T₆ space is a Perfectly normal T₁ space. T₆ implies T₅.
+
+Note that `mathlib` adopts the modern convention that `m ≤ n` if and only if `T_m → T_n`, but
+occasionally the literature swaps definitions for e.g. T₃ and regular.
+
+### TODO
+
+* Use `hasSeparatingCovers_iff_separatedNhds` to prove that perfectly normal spaces
+  are completely normal.
+
+-/
+
+open Function Set Filter Topology TopologicalSpace
+
+universe u v
+
+variable {X : Type*} {Y : Type*} [TopologicalSpace X]
+
+section Separation
+
+theorem IsGδ.compl_singleton (x : X) [T1Space X] : IsGδ ({x}ᶜ : Set X) :=
+  isOpen_compl_singleton.isGδ
+
+@[deprecated (since := "2024-02-15")] alias isGδ_compl_singleton := IsGδ.compl_singleton
+
+theorem Set.Countable.isGδ_compl {s : Set X} [T1Space X] (hs : s.Countable) : IsGδ sᶜ := by
+  rw [← biUnion_of_singleton s, compl_iUnion₂]
+  exact .biInter hs fun x _ => .compl_singleton x
+
+theorem Set.Finite.isGδ_compl {s : Set X} [T1Space X] (hs : s.Finite) : IsGδ sᶜ :=
+  hs.countable.isGδ_compl
+
+theorem Set.Subsingleton.isGδ_compl {s : Set X} [T1Space X] (hs : s.Subsingleton) : IsGδ sᶜ :=
+  hs.finite.isGδ_compl
+
+theorem Finset.isGδ_compl [T1Space X] (s : Finset X) : IsGδ (sᶜ : Set X) :=
+  s.finite_toSet.isGδ_compl
+
+protected theorem IsGδ.singleton [FirstCountableTopology X] [T1Space X] (x : X) :
+    IsGδ ({x} : Set X) := by
+  rcases (nhds_basis_opens x).exists_antitone_subbasis with ⟨U, hU, h_basis⟩
+  rw [← biInter_basis_nhds h_basis.toHasBasis]
+  exact .biInter (to_countable _) fun n _ => (hU n).2.isGδ
+
+@[deprecated (since := "2024-02-15")] alias isGδ_singleton := IsGδ.singleton
+
+theorem Set.Finite.isGδ [FirstCountableTopology X] {s : Set X} [T1Space X] (hs : s.Finite) :
+    IsGδ s :=
+  Finite.induction_on hs .empty fun _ _ ↦ .union (.singleton _)
+
+
+section PerfectlyNormal
+
+/-- A topological space `X` is a *perfectly normal space* provided it is normal and
+closed sets are Gδ. -/
+class PerfectlyNormalSpace (X : Type u) [TopologicalSpace X] extends NormalSpace X : Prop where
+    closed_gdelta : ∀ ⦃h : Set X⦄, IsClosed h → IsGδ h
+
+/-- Lemma that allows the easy conclusion that perfectly normal spaces are completely normal. -/
+theorem Disjoint.hasSeparatingCover_closed_gdelta_right {s t : Set X} [NormalSpace X]
+    (st_dis : Disjoint s t) (t_cl : IsClosed t) (t_gd : IsGδ t) : HasSeparatingCover s t := by
+  obtain ⟨T, T_open, T_count, T_int⟩ := t_gd
+  rcases T.eq_empty_or_nonempty with rfl | T_nonempty
+  · rw [T_int, sInter_empty] at st_dis
+    rw [(s.disjoint_univ).mp st_dis]
+    exact t.hasSeparatingCover_empty_left
+  obtain ⟨g, g_surj⟩ := T_count.exists_surjective T_nonempty
+  choose g' g'_open clt_sub_g' clg'_sub_g using fun n ↦ by
+    apply normal_exists_closure_subset t_cl (T_open (g n).1 (g n).2)
+    rw [T_int]
+    exact sInter_subset_of_mem (g n).2
+  have clg'_int : t = ⋂ i, closure (g' i) := by
+    apply (subset_iInter fun n ↦ (clt_sub_g' n).trans subset_closure).antisymm
+    rw [T_int]
+    refine subset_sInter fun t tinT ↦ ?_
+    obtain ⟨n, gn⟩ := g_surj ⟨t, tinT⟩
+    refine iInter_subset_of_subset n <| (clg'_sub_g n).trans ?_
+    rw [gn]
+  use fun n ↦ (closure (g' n))ᶜ
+  constructor
+  · rw [← compl_iInter, subset_compl_comm, ← clg'_int]
+    exact st_dis.subset_compl_left
+  · refine fun n ↦ ⟨isOpen_compl_iff.mpr isClosed_closure, ?_⟩
+    simp only [closure_compl, disjoint_compl_left_iff_subset]
+    rw [← closure_eq_iff_isClosed.mpr t_cl] at clt_sub_g'
+    exact subset_closure.trans <| (clt_sub_g' n).trans <| (g'_open n).subset_interior_closure
+
+instance (priority := 100) PerfectlyNormalSpace.toCompletelyNormalSpace
+    [PerfectlyNormalSpace X] : CompletelyNormalSpace X where
+  completely_normal _ _ hd₁ hd₂ := separatedNhds_iff_disjoint.mp <|
+    hasSeparatingCovers_iff_separatedNhds.mp
+      ⟨(hd₂.hasSeparatingCover_closed_gdelta_right isClosed_closure <|
+         closed_gdelta isClosed_closure).mono (fun ⦃_⦄ a ↦ a) subset_closure,
+       ((Disjoint.symm hd₁).hasSeparatingCover_closed_gdelta_right isClosed_closure <|
+         closed_gdelta isClosed_closure).mono (fun ⦃_⦄ a ↦ a) subset_closure⟩
+
+/-- A T₆ space is a perfectly normal T₁ space. -/
+class T6Space (X : Type u) [TopologicalSpace X] extends T1Space X, PerfectlyNormalSpace X : Prop
+
+-- see Note [lower instance priority]
+/-- A `T₆` space is a `T₅` space. -/
+instance (priority := 100) T6Space.toT5Space [T6Space X] : T5Space X where
+  -- follows from type-class inference
+end PerfectlyNormal
+
+end Separation

--- a/Mathlib/Topology/Separation/NotNormal.lean
+++ b/Mathlib/Topology/Separation/NotNormal.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Data.Real.Cardinality
-import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.TietzeExtension
 /-!
 # Not normal topological spaces

--- a/Mathlib/Topology/Separation/NotNormal.lean
+++ b/Mathlib/Topology/Separation/NotNormal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Data.Real.Cardinality
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.TietzeExtension
 /-!
 # Not normal topological spaces

--- a/Mathlib/Topology/ShrinkingLemma.lean
+++ b/Mathlib/Topology/ShrinkingLemma.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Reid Barton
 -/
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # The shrinking lemma

--- a/Mathlib/Topology/Sober.lean
+++ b/Mathlib/Topology/Sober.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.Sets.Closeds
 
 /-!

--- a/Mathlib/Topology/Sober.lean
+++ b/Mathlib/Topology/Sober.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.Sets.Closeds
 
 /-!

--- a/Mathlib/Topology/Specialization.lean
+++ b/Mathlib/Topology/Specialization.lean
@@ -6,7 +6,7 @@ Authors: Yaël Dillies
 import Mathlib.Order.Category.Preord
 import Mathlib.Topology.Category.TopCat.Basic
 import Mathlib.Topology.ContinuousMap.Basic
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.Order.UpperLowerSetTopology
 
 /-!

--- a/Mathlib/Topology/Specialization.lean
+++ b/Mathlib/Topology/Specialization.lean
@@ -6,7 +6,6 @@ Authors: Yaël Dillies
 import Mathlib.Order.Category.Preord
 import Mathlib.Topology.Category.TopCat.Basic
 import Mathlib.Topology.ContinuousMap.Basic
-import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.Order.UpperLowerSetTopology
 
 /-!

--- a/Mathlib/Topology/Support.lean
+++ b/Mathlib/Topology/Support.lean
@@ -6,7 +6,7 @@ Authors: Floris van Doorn, Patrick Massot
 import Mathlib.Algebra.GroupWithZero.Indicator
 import Mathlib.Algebra.Order.Group.Unbundled.Abs
 import Mathlib.Algebra.Module.Basic
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # The topological support of a function

--- a/Mathlib/Topology/UniformSpace/Compact.lean
+++ b/Mathlib/Topology/UniformSpace/Compact.lean
@@ -5,7 +5,6 @@ Authors: Patrick Massot, Yury Kudryashov
 -/
 import Mathlib.Topology.UniformSpace.UniformConvergence
 import Mathlib.Topology.UniformSpace.Equicontinuity
-import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.Support
 
 /-!

--- a/Mathlib/Topology/UniformSpace/Compact.lean
+++ b/Mathlib/Topology/UniformSpace/Compact.lean
@@ -5,7 +5,7 @@ Authors: Patrick Massot, Yury Kudryashov
 -/
 import Mathlib.Topology.UniformSpace.UniformConvergence
 import Mathlib.Topology.UniformSpace.Equicontinuity
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.Support
 
 /-!

--- a/Mathlib/Topology/UniformSpace/Separation.lean
+++ b/Mathlib/Topology/UniformSpace/Separation.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Patrick Massot, Yury Kudryashov
 -/
 import Mathlib.Tactic.ApplyFun
 import Mathlib.Topology.UniformSpace.Basic
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.Basic
 
 /-!
 # Hausdorff properties of uniform spaces. Separation quotient.

--- a/Mathlib/Topology/UniformSpace/UniformConvergence.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergence.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.UniformSpace.Basic
 import Mathlib.Topology.UniformSpace.Cauchy
 

--- a/Mathlib/Topology/UniformSpace/UniformConvergence.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergence.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import Mathlib.Topology.Separation
+import Mathlib.Topology.Separation.GDelta
 import Mathlib.Topology.UniformSpace.Basic
 import Mathlib.Topology.UniformSpace.Cauchy
 


### PR DESCRIPTION
Avoids needing GDelta / UniformSpace in many later files.

(Identified using #18156)