### PR TITLE
feat(Testing/SlimCheck): add support for `Sum` in `slim_check`

### DIFF
--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -109,6 +109,11 @@ def prodOf {α : Type u} {β : Type v} (x : Gen α) (y : Gen β) : Gen (α × β
   let ⟨b⟩ ← ULiftable.up.{max u v} y
   pure (a, b)
 
+/-- Given two generators randomly choose one to produce a `Sum` -/
+def sumOf {α : Type u} {β : Type v} (x : Gen α) (y : Gen β) : Gen (α ⊕ β) :=
+  oneOf #[(do let ⟨a⟩ ← ULiftable.up.{max u v} x; return .inl a),
+    (do let ⟨b⟩ ← ULiftable.up.{max u v} y; return .inr b)] (pos := by simp)
+
 end Gen
 
 /-- Execute a `Gen` inside the `IO` monad using `size` as the example size -/

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -175,6 +175,11 @@ instance Prod.shrinkable [shrA : Shrinkable α] [shrB : Shrinkable β] :
     let shrink2 := shrB.shrink snd |>.map fun x ↦ (fst, x)
     shrink1 ++ shrink2
 
+instance Sum.shrinkable [shrA : Shrinkable α] [shrB : Shrinkable β] :
+    Shrinkable (α ⊕ β) where
+  shrink := fun v ↦
+    (v.map shrA.shrink shrB.shrink).elim (·.map .inl) (·.map .inr)
+
 instance Sigma.shrinkable [shrA : Shrinkable α] [shrB : Shrinkable β] :
     Shrinkable ((_ : α) × β) where
   shrink := fun ⟨fst,snd⟩ ↦
@@ -242,6 +247,14 @@ instance Prod.sampleableExt {α : Type u} {β : Type v} [SampleableExt α] [Samp
   shrink := inferInstance
   sample := prodOf sample sample
   interp := Prod.map interp interp
+
+instance Sum.sampleableExt {α : Type u} {β : Type v} [SampleableExt α] [SampleableExt β] :
+    SampleableExt (α ⊕ β) where
+  proxy := (proxy α) ⊕ (proxy β)
+  proxyRepr := inferInstance
+  shrink := inferInstance
+  sample := sumOf sample sample
+  interp := Sum.map interp interp
 
 instance Prop.sampleableExt : SampleableExt Prop where
   proxy := Bool


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
