### PR TITLE
feat: add trace_isNilpotent_of_isNilpotent

### DIFF
--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -483,3 +483,22 @@ lemma traceForm_dualBasis_powerBasis_eq [FiniteDimensional K L] [Algebra.IsSepar
   ring
 
 end DetNeZero
+
+section isNilpotent
+
+namespace Algebra
+
+/-- The trace of a nilpotent element is nilpotent. -/
+lemma trace_isNilpotent_of_isNilpotent {R S : Type*} [CommRing R] [CommRing S] [Algebra R S] {x : S}
+  (hx : IsNilpotent x) : IsNilpotent (trace R S x) := by
+  by_cases hS : ∃ s : Finset S, Nonempty (Basis s R S)
+  · obtain ⟨s, ⟨b⟩⟩ := hS
+    have := Module.Finite.of_basis b
+    have := (Module.free_def R S).mpr ⟨s, ⟨b⟩⟩
+    apply LinearMap.isNilpotent_trace_of_isNilpotent (hx.map (lmul R S))
+  · rw [trace_eq_zero_of_not_exists_basis _ hS, LinearMap.zero_apply]
+    exact IsNilpotent.zero
+
+end Algebra
+
+end isNilpotent

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -490,7 +490,7 @@ namespace Algebra
 
 /-- The trace of a nilpotent element is nilpotent. -/
 lemma trace_isNilpotent_of_isNilpotent {R S : Type*} [CommRing R] [CommRing S] [Algebra R S] {x : S}
-  (hx : IsNilpotent x) : IsNilpotent (trace R S x) := by
+    (hx : IsNilpotent x) : IsNilpotent (trace R S x) := by
   by_cases hS : ∃ s : Finset S, Nonempty (Basis s R S)
   · obtain ⟨s, ⟨b⟩⟩ := hS
     have := Module.Finite.of_basis b


### PR DESCRIPTION
From flt-regular.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
