### PR TITLE
[Merged by Bors] - feat(Bicategory/Oplax): Fix simp lemmas and renaming

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Modification/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Modification/Oplax.lean
@@ -42,7 +42,7 @@ for each 1-morphism `f : a ⟶ b`.
 -/
 @[ext]
 structure Modification (η θ : F ⟶ G) where
-  /-- The underlying family of 2-morphism. -/
+  /-- The underlying family of 2-morphisms. -/
   app (a : B) : η.app a ⟶ θ.app a
   /-- The naturality condition. -/
   naturality :

--- a/Mathlib/CategoryTheory/Bicategory/Modification/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Modification/Oplax.lean
@@ -9,10 +9,9 @@ import Mathlib.CategoryTheory.Bicategory.NaturalTransformation.Oplax
 /-!
 # Modifications between oplax transformations
 
-A modification `Γ` between oplax transformations `η` and `θ` consists of a family of
-2-morphisms `Γ.app a : η.app a ⟶ θ.app a`, which satisfies the equation
-`(F.map f ◁ app b) ≫ θ.naturality f = η.naturality f ≫ (app a ▷ G.map f)`
-for each 1-morphism `f : a ⟶ b`.
+A modification `Γ` between oplax transformations `η` and `θ` consists of a family of 2-morphisms
+`Γ.app a : η.app a ⟶ θ.app a`, which for all 1-morphisms `f : a ⟶ b` satisfies the equation
+`(F.map f ◁ app b) ≫ θ.naturality f = η.naturality f ≫ app a ▷ G.map f`.
 
 ## Main definitions
 

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
@@ -123,37 +123,43 @@ theorem whiskerRight_naturality_id (f : G.obj a ⟶ a') :
 
 end
 
-@[simps id_app id_naturality comp_app comp_naturality]
-instance : CategoryStruct (OplaxFunctor B C) where
-  Hom := OplaxTrans
-  id F := {
-    app := fun a ↦ 𝟙 (F.obj a)
-    naturality := fun {_ _} f ↦ (ρ_ (F.map f)).hom ≫ (λ_ (F.map f)).inv
-  }
-  comp {F G H} η θ := {
-    app := fun a ↦ η.app a ≫ θ.app a
-    naturality := fun {a b} f ↦
-      (α_ _ _ _).inv ≫
-        η.naturality f ▷ θ.app b ≫ (α_ _ _ _).hom ≫ η.app a ◁ θ.naturality f ≫ (α_ _ _ _).inv
-    naturality_comp := fun {a b c} f g ↦
-      calc
-        _ =
-          (α_ _ _ _).inv ≫
-            F.mapComp f g ▷ η.app c ▷ θ.app c ≫
-              (α_ _ _ _).hom ▷ _ ≫ (α_ _ _ _).hom ≫
-                F.map f ◁ η.naturality g ▷ θ.app c ≫
-                  _ ◁ (α_ _ _ _).hom ≫ (α_ _ _ _).inv ≫
-                    (F.map f ≫ η.app b) ◁ θ.naturality g ≫
-                      η.naturality f ▷ (θ.app b ≫ H.map g) ≫
-                        (α_ _ _ _).hom ≫ _ ◁ (α_ _ _ _).inv ≫
-                          η.app a ◁ θ.naturality f ▷ H.map g ≫
-                            _ ◁ (α_ _ _ _).hom ≫ (α_ _ _ _).inv := by
-          rw [whisker_exchange_assoc]; simp
-        _ = _ := by simp
-  }
+variable (F) in
+/-- The identity oplax transformation. -/
+def id : OplaxTrans F F where
+  app a := 𝟙 (F.obj a)
+  naturality {_ _} f := (ρ_ (F.map f)).hom ≫ (λ_ (F.map f)).inv
 
 instance : Inhabited (OplaxTrans F F) :=
-  ⟨𝟙 F⟩
+  ⟨id F⟩
+
+/-- Vertical composition of oplax transformations. -/
+def vcomp : OplaxTrans F H where
+  app a := η.app a ≫ θ.app a
+  naturality {a b} f :=
+    (α_ _ _ _).inv ≫
+      η.naturality f ▷ θ.app b ≫ (α_ _ _ _).hom ≫ η.app a ◁ θ.naturality f ≫ (α_ _ _ _).inv
+  naturality_comp {a b c} f g :=
+    calc
+      _ =
+        (α_ _ _ _).inv ≫
+          F.mapComp f g ▷ η.app c ▷ θ.app c ≫
+            (α_ _ _ _).hom ▷ _ ≫ (α_ _ _ _).hom ≫
+              F.map f ◁ η.naturality g ▷ θ.app c ≫
+                _ ◁ (α_ _ _ _).hom ≫ (α_ _ _ _).inv ≫
+                  (F.map f ≫ η.app b) ◁ θ.naturality g ≫
+                    η.naturality f ▷ (θ.app b ≫ H.map g) ≫
+                      (α_ _ _ _).hom ≫ _ ◁ (α_ _ _ _).inv ≫
+                        η.app a ◁ θ.naturality f ▷ H.map g ≫
+                          _ ◁ (α_ _ _ _).hom ≫ (α_ _ _ _).inv := by
+        rw [whisker_exchange_assoc]; simp
+      _ = _ := by simp
+
+
+@[simps! id_app id_naturality comp_app comp_naturality]
+instance : CategoryStruct (OplaxFunctor B C) where
+  Hom := OplaxTrans
+  id := OplaxTrans.id
+  comp := OplaxTrans.vcomp
 
 end OplaxTrans
 

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
@@ -1,25 +1,31 @@
 /-
 Copyright (c) 2022 Yuma Mizuno. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yuma Mizuno
+Authors: Yuma Mizuno, Calle Sönne
 -/
 import Mathlib.CategoryTheory.Bicategory.Functor.Oplax
 
 /-!
-# Oplax natural transformations
+# Oplax transformations between oplax functors
 
-Just as there are natural transformations between functors, there are oplax natural transformations
+Just as there are natural transformations between functors, there are oplax transformations
 between oplax functors. The equality in the naturality of natural transformations is replaced by a
 specified 2-morphism `F.map f ≫ app b ⟶ app a ≫ G.map f` in the case of oplax natural
 transformations.
 
 ## Main definitions
 
-* `OplaxNatTrans F G` : oplax natural transformations between oplax functors `F` and `G`
-* `OplaxNatTrans.vcomp η θ` : the vertical composition of oplax natural transformations `η`
-  and `θ`
-* `OplaxNatTrans.category F G` : the category structure on the oplax natural transformations
-  between `F` and `G`
+* `OplaxTrans F G` : oplax transformations between oplax functors `F` and `G`
+* `OplaxTrans.vcomp η θ` : the vertical composition of oplax transformations `η` and `θ`
+* `StrongCore F G`: a structure on an oplax transformation between pseudofunctors (TODO)
+that promotes it to a strong transformation (TODO: PUT IN OTHER FILE...!)
+
+NAMESPACES:
+* All of this should be in an oplax namespace
+
+# TODO
+This file could also include lax and strong transformations between oplax functors.
+
 -/
 
 namespace CategoryTheory
@@ -32,58 +38,44 @@ universe w₁ w₂ v₁ v₂ u₁ u₂
 
 variable {B : Type u₁} [Bicategory.{w₁, v₁} B] {C : Type u₂} [Bicategory.{w₂, v₂} C]
 
-/-- If `η` is an oplax natural transformation between `F` and `G`, we have a 1-morphism
+/-- If `η` is an oplax transformation between `F` and `G`, we have a 1-morphism
 `η.app a : F.obj a ⟶ G.obj a` for each object `a : B`. We also have a 2-morphism
 `η.naturality f : F.map f ≫ app b ⟶ app a ≫ G.map f` for each 1-morphism `f : a ⟶ b`.
 These 2-morphisms satisfies the naturality condition, and preserve the identities and
 the compositions modulo some adjustments of domains and codomains of 2-morphisms.
 -/
-structure OplaxNatTrans (F G : OplaxFunctor B C) where
+structure OplaxTrans (F G : OplaxFunctor B C) where
+  /-- The component 1-morphisms of an oplax transformation. -/
   app (a : B) : F.obj a ⟶ G.obj a
+  /-- The 2-morphisms underlying the oplax naturality constraint. -/
   naturality {a b : B} (f : a ⟶ b) : F.map f ≫ app b ⟶ app a ≫ G.map f
+  /-- Naturality of the oplax naturality constraint. -/
   naturality_naturality :
     ∀ {a b : B} {f g : a ⟶ b} (η : f ⟶ g),
       F.map₂ η ▷ app b ≫ naturality g = naturality f ≫ app a ◁ G.map₂ η := by
     aesop_cat
+  /-- Oplax unity. -/
   naturality_id :
     ∀ a : B,
       naturality (𝟙 a) ≫ app a ◁ G.mapId a =
         F.mapId a ▷ app a ≫ (λ_ (app a)).hom ≫ (ρ_ (app a)).inv := by
     aesop_cat
+  /-- Oplax functoriality. -/
   naturality_comp :
     ∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c),
       naturality (f ≫ g) ≫ app a ◁ G.mapComp f g =
-        F.mapComp f g ▷ app c ≫
-          (α_ _ _ _).hom ≫
-            F.map f ◁ naturality g ≫ (α_ _ _ _).inv ≫ naturality f ▷ G.map g ≫ (α_ _ _ _).hom := by
+        F.mapComp f g ▷ app c ≫ (α_ _ _ _).hom ≫ F.map f ◁ naturality g ≫
+          (α_ _ _ _).inv ≫ naturality f ▷ G.map g ≫ (α_ _ _ _).hom := by
     aesop_cat
 
-attribute [nolint docBlame] CategoryTheory.OplaxNatTrans.app
-  CategoryTheory.OplaxNatTrans.naturality
-  CategoryTheory.OplaxNatTrans.naturality_naturality
-  CategoryTheory.OplaxNatTrans.naturality_id
-  CategoryTheory.OplaxNatTrans.naturality_comp
+attribute [reassoc (attr := simp)] OplaxTrans.naturality_naturality OplaxTrans.naturality_id
+  OplaxTrans.naturality_comp
 
-attribute [reassoc (attr := simp)] OplaxNatTrans.naturality_naturality OplaxNatTrans.naturality_id
-  OplaxNatTrans.naturality_comp
-
-namespace OplaxNatTrans
+namespace OplaxTrans
 
 section
 
-variable (F : OplaxFunctor B C)
-
-/-- The identity oplax natural transformation. -/
-@[simps]
-def id : OplaxNatTrans F F where
-  app a := 𝟙 (F.obj a)
-  naturality {_ _} f := (ρ_ (F.map f)).hom ≫ (λ_ (F.map f)).inv
-
-instance : Inhabited (OplaxNatTrans F F) :=
-  ⟨id F⟩
-
-variable {F} {G H : OplaxFunctor B C} (η : OplaxNatTrans F G) (θ : OplaxNatTrans G H)
-
+variable {F : OplaxFunctor B C} {G H : OplaxFunctor B C} (η : OplaxTrans F G) (θ : OplaxTrans G H)
 section
 
 variable {a b c : B} {a' : C}
@@ -135,42 +127,37 @@ theorem whiskerRight_naturality_id (f : G.obj a ⟶ a') :
 
 end
 
-/-- Vertical composition of oplax natural transformations. -/
-@[simps]
-def vcomp (η : OplaxNatTrans F G) (θ : OplaxNatTrans G H) : OplaxNatTrans F H where
-  app a := η.app a ≫ θ.app a
-  naturality {a b} f :=
-    (α_ _ _ _).inv ≫
-      η.naturality f ▷ θ.app b ≫ (α_ _ _ _).hom ≫ η.app a ◁ θ.naturality f ≫ (α_ _ _ _).inv
-  naturality_comp {a b c} f g := by
-    calc
-      _ =
-          ?_ ≫
+@[simps id_app id_naturality comp_app comp_naturality]
+instance : CategoryStruct (OplaxFunctor B C) where
+  Hom := OplaxTrans
+  id F := {
+    app := fun a ↦ 𝟙 (F.obj a)
+    naturality := fun {_ _} f ↦ (ρ_ (F.map f)).hom ≫ (λ_ (F.map f)).inv
+  }
+  comp {F G H} η θ := {
+    app := fun a ↦ η.app a ≫ θ.app a
+    naturality := fun {a b} f ↦
+      (α_ _ _ _).inv ≫
+        η.naturality f ▷ θ.app b ≫ (α_ _ _ _).hom ≫ η.app a ◁ θ.naturality f ≫ (α_ _ _ _).inv
+    naturality_comp := fun {a b c} f g ↦
+      calc
+        _ =
+          (α_ _ _ _).inv ≫
             F.mapComp f g ▷ η.app c ▷ θ.app c ≫
-              ?_ ≫
+              (α_ _ _ _).hom ▷ _ ≫ (α_ _ _ _).hom ≫
                 F.map f ◁ η.naturality g ▷ θ.app c ≫
-                  ?_ ≫
+                  _ ◁ (α_ _ _ _).hom ≫ (α_ _ _ _).inv ≫
                     (F.map f ≫ η.app b) ◁ θ.naturality g ≫
                       η.naturality f ▷ (θ.app b ≫ H.map g) ≫
-                        ?_ ≫ η.app a ◁ θ.naturality f ▷ H.map g ≫ ?_ :=
-        ?_
-      _ = _ := ?_
-    · exact (α_ _ _ _).inv
-    · exact (α_ _ _ _).hom ▷ _ ≫ (α_ _ _ _).hom
-    · exact _ ◁ (α_ _ _ _).hom ≫ (α_ _ _ _).inv
-    · exact (α_ _ _ _).hom ≫ _ ◁ (α_ _ _ _).inv
-    · exact _ ◁ (α_ _ _ _).hom ≫ (α_ _ _ _).inv
-    · rw [whisker_exchange_assoc]
-      simp
-    · simp
+                        (α_ _ _ _).hom ≫ _ ◁ (α_ _ _ _).inv ≫
+                          η.app a ◁ θ.naturality f ▷ H.map g ≫
+                            _ ◁ (α_ _ _ _).hom ≫ (α_ _ _ _).inv := by
+          rw [whisker_exchange_assoc]; simp
+        _ = _ := by simp
+  }
 
-variable (B C)
-
-@[simps id comp]
-instance : CategoryStruct (OplaxFunctor B C) where
-  Hom := OplaxNatTrans
-  id := OplaxNatTrans.id
-  comp := OplaxNatTrans.vcomp
+instance : Inhabited (OplaxTrans F F) :=
+  ⟨𝟙 F⟩
 
 end
 
@@ -178,15 +165,15 @@ end
 transformation.
 
 See `StrongNatTrans.mkOfOplax`. -/
-structure StrongCore {F G : OplaxFunctor B C} (η : OplaxNatTrans F G) where
+structure StrongCore {F G : OplaxFunctor B C} (η : OplaxTrans F G) where
   naturality {a b : B} (f : a ⟶ b) : F.map f ≫ η.app b ≅ η.app a ≫ G.map f
   naturality_hom {a b : B} (f : a ⟶ b) : (naturality f).hom = η.naturality f := by aesop_cat
 
-attribute [nolint docBlame] CategoryTheory.OplaxNatTrans.StrongCore.naturality
-  CategoryTheory.OplaxNatTrans.StrongCore.naturality_hom
+attribute [nolint docBlame] CategoryTheory.OplaxTrans.StrongCore.naturality
+  CategoryTheory.OplaxTrans.StrongCore.naturality_hom
 
 attribute [simp] StrongCore.naturality_hom
 
-end OplaxNatTrans
+end OplaxTrans
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
@@ -16,7 +16,9 @@ transformations.
 ## Main definitions
 
 * `OplaxTrans F G` : oplax transformations between oplax functors `F` and `G`
-* `OplaxTrans.vcomp η θ` : the vertical composition of oplax transformations `η` and `θ`
+
+Using this, we define a category instance on `OplaxTrans F G`, with composition given by vertical
+composition of oplax transformations.
 
 # TODO
 This file could also include lax and strong transformations between oplax functors.

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
@@ -17,18 +17,13 @@ transformations.
 
 * `OplaxTrans F G` : oplax transformations between oplax functors `F` and `G`
 * `OplaxTrans.vcomp η θ` : the vertical composition of oplax transformations `η` and `θ`
-* `StrongCore F G`: a structure on an oplax transformation between pseudofunctors (TODO)
-that promotes it to a strong transformation (TODO: PUT IN OTHER FILE...!)
-
-NAMESPACES:
-* All of this should be in an oplax namespace
 
 # TODO
 This file could also include lax and strong transformations between oplax functors.
 
 -/
 
-namespace CategoryTheory
+namespace CategoryTheory.Oplax
 
 open Category Bicategory
 
@@ -73,9 +68,8 @@ attribute [reassoc (attr := simp)] OplaxTrans.naturality_naturality OplaxTrans.n
 
 namespace OplaxTrans
 
-section
-
 variable {F : OplaxFunctor B C} {G H : OplaxFunctor B C} (η : OplaxTrans F G) (θ : OplaxTrans G H)
+
 section
 
 variable {a b c : B} {a' : C}
@@ -159,21 +153,6 @@ instance : CategoryStruct (OplaxFunctor B C) where
 instance : Inhabited (OplaxTrans F F) :=
   ⟨𝟙 F⟩
 
-end
-
-/-- A structure on an Oplax natural transformation that promotes it to a strong natural
-transformation.
-
-See `StrongNatTrans.mkOfOplax`. -/
-structure StrongCore {F G : OplaxFunctor B C} (η : OplaxTrans F G) where
-  naturality {a b : B} (f : a ⟶ b) : F.map f ≫ η.app b ≅ η.app a ≫ G.map f
-  naturality_hom {a b : B} (f : a ⟶ b) : (naturality f).hom = η.naturality f := by aesop_cat
-
-attribute [nolint docBlame] CategoryTheory.OplaxTrans.StrongCore.naturality
-  CategoryTheory.OplaxTrans.StrongCore.naturality_hom
-
-attribute [simp] StrongCore.naturality_hom
-
 end OplaxTrans
 
-end CategoryTheory
+end CategoryTheory.Oplax

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
@@ -68,6 +68,8 @@ structure OplaxTrans (F G : OplaxFunctor B C) where
 attribute [reassoc (attr := simp)] OplaxTrans.naturality_naturality OplaxTrans.naturality_id
   OplaxTrans.naturality_comp
 
+@[deprecated (since := "2025-04-23")] alias _root_.CategoryTheory.OplaxNatTrans := OplaxTrans
+
 namespace OplaxTrans
 
 variable {F : OplaxFunctor B C} {G H : OplaxFunctor B C} (η : OplaxTrans F G) (θ : OplaxTrans G H)
@@ -153,7 +155,6 @@ def vcomp : OplaxTrans F H where
                           _ ◁ (α_ _ _ _).hom ≫ (α_ _ _ _).inv := by
         rw [whisker_exchange_assoc]; simp
       _ = _ := by simp
-
 
 @[simps! id_app id_naturality comp_app comp_naturality]
 instance : CategoryStruct (OplaxFunctor B C) where

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Strong.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Strong.lean
@@ -79,11 +79,10 @@ structure StrongOplaxTrans (F G : OplaxFunctor B C) where
         (α_ _ _ _).inv ≫ (naturality f).hom ▷ G.map g ≫ (α_ _ _ _).hom := by
     aesop_cat
 
+@[deprecated (since := "2025-04-23")] alias StrongOplaxNatTrans := StrongOplaxTrans
+
 attribute [nolint docBlame] CategoryTheory.StrongOplaxTrans.app
   CategoryTheory.StrongOplaxTrans.naturality
-  CategoryTheory.StrongOplaxTrans.naturality_naturality
-  CategoryTheory.StrongOplaxTrans.naturality_id
-  CategoryTheory.StrongOplaxTrans.naturality_comp
 
 attribute [reassoc (attr := simp)] StrongOplaxTrans.naturality_naturality
   StrongOplaxTrans.naturality_id StrongOplaxTrans.naturality_comp

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Strong.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Strong.lean
@@ -15,12 +15,14 @@ is an isomorphism.
 
 ## Main definitions
 
-* `StrongOplaxNatTrans F G` : strong natural transformations between oplax functors `F` and `G`.
+* `StrongOplaxTrans F G` : strong natural transformations between oplax functors `F` and `G`.
+* `StrongCore F G`: a structure on an oplax transformation between pseudofunctors that promotes
+it to a strong transformation.
 * `mkOfOplax η η'` : given an oplax natural transformation `η` such that each component 2-cell
   is an isomorphism, `mkOfOplax` gives the corresponding strong natural transformation.
-* `StrongOplaxNatTrans.vcomp η θ` : the vertical composition of strong natural transformations `η`
+* `StrongOplaxTrans.vcomp η θ` : the vertical composition of strong natural transformations `η`
   and `θ`.
-* `StrongOplaxNatTrans.category F G` : a category structure on pseudofunctors between `F` and `G`,
+* `StrongOplaxTrans.category F G` : a category structure on pseudofunctors between `F` and `G`,
   where the morphisms are strong natural transformations.
 
 ## TODO
@@ -40,7 +42,7 @@ transformations:
 
 namespace CategoryTheory
 
-open Category Bicategory
+open Category Bicategory Oplax
 
 open scoped Bicategory
 
@@ -58,7 +60,7 @@ More precisely, it consists of the following:
 * These 2-isomorphisms satisfy the naturality condition, and preserve the identities and the
   compositions modulo some adjustments of domains and codomains of 2-morphisms.
 -/
-structure StrongOplaxNatTrans (F G : OplaxFunctor B C) where
+structure StrongOplaxTrans (F G : OplaxFunctor B C) where
   app (a : B) : F.obj a ⟶ G.obj a
   naturality {a b : B} (f : a ⟶ b) : F.map f ≫ app b ≅ app a ≫ G.map f
   naturality_naturality :
@@ -77,36 +79,47 @@ structure StrongOplaxNatTrans (F G : OplaxFunctor B C) where
         (α_ _ _ _).inv ≫ (naturality f).hom ▷ G.map g ≫ (α_ _ _ _).hom := by
     aesop_cat
 
-attribute [nolint docBlame] CategoryTheory.StrongOplaxNatTrans.app
-  CategoryTheory.StrongOplaxNatTrans.naturality
-  CategoryTheory.StrongOplaxNatTrans.naturality_naturality
-  CategoryTheory.StrongOplaxNatTrans.naturality_id
-  CategoryTheory.StrongOplaxNatTrans.naturality_comp
+attribute [nolint docBlame] CategoryTheory.StrongOplaxTrans.app
+  CategoryTheory.StrongOplaxTrans.naturality
+  CategoryTheory.StrongOplaxTrans.naturality_naturality
+  CategoryTheory.StrongOplaxTrans.naturality_id
+  CategoryTheory.StrongOplaxTrans.naturality_comp
 
-attribute [reassoc (attr := simp)] StrongOplaxNatTrans.naturality_naturality
-  StrongOplaxNatTrans.naturality_id StrongOplaxNatTrans.naturality_comp
+attribute [reassoc (attr := simp)] StrongOplaxTrans.naturality_naturality
+  StrongOplaxTrans.naturality_id StrongOplaxTrans.naturality_comp
 
-namespace StrongOplaxNatTrans
+/-- A structure on an oplax transformation that promotes it to a strong transformation.
+
+See `Pseudofunctor.StrongTrans.mkOfOplax`. -/
+structure OplaxTrans.StrongCore {F G : OplaxFunctor B C} (η : F ⟶ G) where
+  /-- The underlying 2-isomorphisms of the naturality constraint. -/
+  naturality {a b : B} (f : a ⟶ b) : F.map f ≫ η.app b ≅ η.app a ≫ G.map f
+  /-- The 2-isomorphisms agree with the underlying 2-morphism of the oplax transformation. -/
+  naturality_hom {a b : B} (f : a ⟶ b) : (naturality f).hom = η.naturality f := by aesop_cat
+
+attribute [simp] OplaxTrans.StrongCore.naturality_hom
+
+namespace StrongOplaxTrans
 
 section
 
 /-- The underlying oplax natural transformation of a strong natural transformation. -/
 @[simps]
-def toOplax {F G : OplaxFunctor B C} (η : StrongOplaxNatTrans F G) : OplaxNatTrans F G where
+def toOplax {F G : OplaxFunctor B C} (η : StrongOplaxTrans F G) : F ⟶ G where
   app := η.app
   naturality f := (η.naturality f).hom
 
 /-- Construct a strong natural transformation from an oplax natural transformation whose
 naturality 2-cell is an isomorphism. -/
-def mkOfOplax {F G : OplaxFunctor B C} (η : OplaxNatTrans F G) (η' : OplaxNatTrans.StrongCore η) :
-    StrongOplaxNatTrans F G where
+def mkOfOplax {F G : OplaxFunctor B C} (η : F ⟶ G) (η' : OplaxTrans.StrongCore η) :
+    StrongOplaxTrans F G where
   app := η.app
   naturality := η'.naturality
 
 /-- Construct a strong natural transformation from an oplax natural transformation whose
 naturality 2-cell is an isomorphism. -/
-noncomputable def mkOfOplax' {F G : OplaxFunctor B C} (η : OplaxNatTrans F G)
-    [∀ a b (f : a ⟶ b), IsIso (η.naturality f)] : StrongOplaxNatTrans F G where
+noncomputable def mkOfOplax' {F G : OplaxFunctor B C} (η : F ⟶ G)
+    [∀ a b (f : a ⟶ b), IsIso (η.naturality f)] : StrongOplaxTrans F G where
   app := η.app
   naturality := fun _ => asIso (η.naturality _)
 
@@ -115,17 +128,17 @@ variable (F : OplaxFunctor B C)
 
 /-- The identity strong natural transformation. -/
 @[simps!]
-def id : StrongOplaxNatTrans F F :=
-  mkOfOplax (OplaxNatTrans.id F) { naturality := fun f ↦ (ρ_ (F.map f)) ≪≫ (λ_ (F.map f)).symm }
+def id : StrongOplaxTrans F F :=
+  mkOfOplax (𝟙 F) { naturality := fun f ↦ (ρ_ (F.map f)) ≪≫ (λ_ (F.map f)).symm }
 
 @[simp]
-lemma id.toOplax : (id F).toOplax = OplaxNatTrans.id F :=
+lemma id.toOplax : (id F).toOplax = 𝟙 F :=
   rfl
 
-instance : Inhabited (StrongOplaxNatTrans F F) :=
+instance : Inhabited (StrongOplaxTrans F F) :=
   ⟨id F⟩
 
-variable {F} {G H : OplaxFunctor B C} (η : StrongOplaxNatTrans F G) (θ : StrongOplaxNatTrans G H)
+variable {F} {G H : OplaxFunctor B C} (η : StrongOplaxTrans F G) (θ : StrongOplaxTrans G H)
 
 section
 
@@ -181,22 +194,23 @@ end
 
 /-- Vertical composition of strong natural transformations. -/
 @[simps!]
-def vcomp (η : StrongOplaxNatTrans F G) (θ : StrongOplaxNatTrans G H) : StrongOplaxNatTrans F H :=
-  mkOfOplax (OplaxNatTrans.vcomp η.toOplax θ.toOplax)
+def vcomp (η : StrongOplaxTrans F G) (θ : StrongOplaxTrans G H) : StrongOplaxTrans F H :=
+  mkOfOplax (η.toOplax ≫ θ.toOplax : OplaxTrans F H)
     { naturality := fun {a b} f ↦
         (α_ _ _ _).symm ≪≫ whiskerRightIso (η.naturality f) (θ.app b) ≪≫
         (α_ _ _ _) ≪≫ whiskerLeftIso (η.app a) (θ.naturality f) ≪≫ (α_ _ _ _).symm }
+
 end
 
-end StrongOplaxNatTrans
+end StrongOplaxTrans
 
 variable (B C)
 
 @[simps id comp]
 instance Pseudofunctor.categoryStruct : CategoryStruct (Pseudofunctor B C) where
-  Hom F G := StrongOplaxNatTrans F.toOplax G.toOplax
-  id F := StrongOplaxNatTrans.id F.toOplax
-  comp := StrongOplaxNatTrans.vcomp
+  Hom F G := StrongOplaxTrans F.toOplax G.toOplax
+  id F := StrongOplaxTrans.id F.toOplax
+  comp := StrongOplaxTrans.vcomp
 
 
 end CategoryTheory


### PR DESCRIPTION
This PR renames `OplaxNatTrans` to `OplaxTrans` and puts it in the `Oplax` namespace (as there should also be oplax natural transformations between lax functors, so this is more fitting).

It also removes `@[simp]` from `OplaxTrans.id` and `OplaxTrans.vcomp`, and instead adds `@[simp!]` to the `CategoryStruct` instance. This is needed as for example, right now, in order to prove that `(η ≫ θ).app a = η.app a ≫ θ.app a` simp needs to first convert this to `(OplaxTrans.vcomp η θ).app a` which is not ideal (in particular it converts `(η ≫ θ)` to `OplaxTrans.vcomp η θ`).

This is part of some of the restructuring that I want to do before constructing the bicategory of pseudofunctors.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #18250

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
