### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Grothendieck): Functors from the Grothendieck construction

### DIFF
--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -332,11 +332,33 @@ def apply (H : Grothendieck F ⥤ E) (c : C) : F.obj c ⥤ E where
     simp only [eqToHom_comp_iff, Category.assoc, eqToHom_trans_assoc]
     apply Functor.congr_hom (F.map_id _).symm
 
-def functorFrom (fib : ∀ c, F.obj c ⥤ E)
-    (hom : ∀ {c c' : C} (f : c ⟶ c'), ((fib c).hom _).obj _ ⟶ _) :
+variable (fib : ∀ c, F.obj c ⥤ E) (hom : ∀ {c c' : C} (f : c ⟶ c'), fib c ⟶ F.map f ⋙ fib c')
+variable (hom_id : ∀ c, hom (𝟙 c) = eqToHom (by simp only [Functor.map_id]; rfl))
+variable (hom_comp : ∀ c₁ c₂ c₃ (f : c₁ ⟶ c₂) (g : c₂ ⟶ c₃), hom (f ≫ g) =
+  hom f ≫ whiskerLeft (F.map f) (hom g) ≫ eqToHom (by simp only [Functor.map_comp]; rfl))
+
+/-- Construct a functor from `Grothendieck F` to another category `E` by providing a family of
+functors on the fibers of `Grothendieck F`, a family of natural transformations on morphisms in the
+base of `Grothendieck F` and coherence data for this family of natural transformations. -/
+@[simps]
+def functorFrom  :
     Grothendieck F ⥤ E where
-  obj := fun X => (fib X.base).obj X.fiber
-  map := _
+  obj X := (fib X.base).obj X.fiber
+  map {X Y} f := (hom f.base).app X.fiber ≫ (fib Y.base).map f.fiber
+  map_id X := by
+    dsimp
+    erw [hom_id]
+    simp
+  map_comp f g := by
+    dsimp
+    erw [hom_comp]
+    simp
+
+theorem apply_functorFrom (c : C) : apply (functorFrom fib hom hom_id hom_comp) c = fib c := by
+  refine Functor.ext (fun _ => by rfl) ?_
+  intro X Y f
+  simp
+  sorry
 
 end FunctorFrom
 

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -314,21 +314,18 @@ section FunctorFrom
 
 variable {E : Type*} [Category E]
 
-/-- Partially apply a functor `H` on the Grothendieck construction of a functor `F : C ⥤ Cat` to
-an object `c : C` to obtain a functor `F.obj c ⥤ E` on the fiber over `c`. -/
+/-- The inclusion of a fiber `F.obj c` of a functor `F : C ⥤ Cat` into its Grothendieck
+construction.-/
 @[simps]
-def apply (H : Grothendieck F ⥤ E) (c : C) : F.obj c ⥤ E where
-  obj d := H.obj ⟨c, d⟩
-  map f := H.map ⟨𝟙 _, eqToHom (by simp) ≫ f⟩
+def ι (c : C) : F.obj c ⥤ Grothendieck F where
+  obj d := ⟨c, d⟩
+  map f := ⟨𝟙 _, eqToHom (by simp) ≫ f⟩
   map_id d := by
-    rw [← H.map_id]
     dsimp
     congr
     simp only [Category.comp_id]
   map_comp f g := by
-    dsimp
-    rw [← H.map_comp]
-    congr 1
+    simp
     apply Grothendieck.ext _ _ (by simp)
     simp only [comp_base, ← Category.assoc, eqToHom_trans, comp_fiber, Functor.map_comp,
       eqToHom_map]
@@ -353,7 +350,7 @@ def functorFrom : Grothendieck F ⥤ E where
 
 /-- `Grothendieck.apply` and `Grothendieck.functorFrom` fulfill a kind of "β reduction", in which
 application and abstraction cancel each other out. -/
-theorem apply_functorFrom (c : C) : apply (functorFrom fib hom hom_id hom_comp) c = fib c := by
+theorem ι_functorFrom (c : C) : ι c ⋙ (functorFrom fib hom hom_id hom_comp) = fib c := by
   refine Functor.ext (fun _ => by rfl) ?_
   intro X Y f
   simp [hom_id]

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -356,7 +356,7 @@ def functorFrom : Grothendieck F ⥤ E where
 
 /-- `Grothendieck.apply` and `Grothendieck.functorFrom` fulfill a kind of "β reduction", in which
 application and abstraction cancel each other out. -/
-theorem ι_functorFrom (c : C) : ι c ⋙ (functorFrom fib hom hom_id hom_comp) = fib c := by
+theorem ι_functorFrom (c : C) : ι F c ⋙ (functorFrom fib hom hom_id hom_comp) = fib c := by
   refine Functor.ext (fun _ => by rfl) ?_
   intro X Y f
   simp [hom_id]

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -352,6 +352,8 @@ def functorFrom  :
   map_id X := by simp [hom_id]
   map_comp f g := by simp [hom_comp]
 
+/-- `Grothendieck.apply` and `Grothendieck.functorFrom` fulfill a kind of "β reduction", in which
+application and abstraction cancel each other out. -/
 theorem apply_functorFrom (c : C) : apply (functorFrom fib hom hom_id hom_comp) c = fib c := by
   refine Functor.ext (fun _ => by rfl) ?_
   intro X Y f

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -345,8 +345,7 @@ variable (hom_comp : ∀ c₁ c₂ c₃ (f : c₁ ⟶ c₂) (g : c₂ ⟶ c₃),
 functors on the fibers of `Grothendieck F`, a family of natural transformations on morphisms in the
 base of `Grothendieck F` and coherence data for this family of natural transformations. -/
 @[simps]
-def functorFrom  :
-    Grothendieck F ⥤ E where
+def functorFrom : Grothendieck F ⥤ E where
   obj X := (fib X.base).obj X.fiber
   map {X Y} f := (hom f.base).app X.fiber ≫ (fib Y.base).map f.fiber
   map_id X := by simp [hom_id]

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -84,7 +84,6 @@ theorem ext {X Y : Grothendieck F} (f g : Hom X Y) (w_base : f.base = g.base)
 
 /-- The identity morphism in the Grothendieck category.
 -/
-@[simps]
 def id (X : Grothendieck F) : Hom X X where
   base := 𝟙 X.base
   fiber := eqToHom (by erw [CategoryTheory.Functor.map_id, Functor.id_obj X.fiber])
@@ -107,22 +106,27 @@ instance : Category (Grothendieck F) where
   comp := @fun _ _ _ f g => Grothendieck.comp f g
   comp_id := @fun X Y f => by
     dsimp; ext
-    · simp [comp]
-    · dsimp [comp]
+    · simp [comp, id]
+    · dsimp [comp, id]
       rw [← NatIso.naturality_2 (eqToIso (F.map_id Y.base)) f.fiber]
       simp
-  id_comp := @fun X Y f => by dsimp; ext <;> simp [comp]
+  id_comp := @fun X Y f => by dsimp; ext <;> simp [comp, id]
   assoc := @fun W X Y Z f g h => by
     dsimp; ext
-    · simp [comp]
-    · dsimp [comp]
+    · simp [comp, id]
+    · dsimp [comp, id]
       rw [← NatIso.naturality_2 (eqToIso (F.map_comp _ _)) f.fiber]
       simp
 
 @[simp]
-theorem id_fiber' (X : Grothendieck F) :
+theorem id_base (X : Grothendieck F) :
+    Hom.base (𝟙 X) = 𝟙 X.base := by
+  rfl
+
+@[simp]
+theorem id_fiber (X : Grothendieck F) :
     Hom.fiber (𝟙 X) = eqToHom (by erw [CategoryTheory.Functor.map_id, Functor.id_obj X.fiber]) :=
-  id_fiber X
+  rfl
 
 @[simp]
 theorem comp_base {X Y Z : Grothendieck F} (f : X ⟶ Y) (g : Y ⟶ Z) :
@@ -170,7 +174,7 @@ def map (α : F ⟶ G) : Grothendieck F ⥤ Grothendieck G where
   map {X Y} f :=
   { base := f.base
     fiber := (eqToHom (α.naturality f.base).symm).app X.fiber ≫ (α.app Y.base).map f.fiber }
-  map_id X := by simp only [Cat.eqToHom_app, id_fiber', eqToHom_map, eqToHom_trans]; rfl
+  map_id X := by simp only [Cat.eqToHom_app, id_fiber, eqToHom_map, eqToHom_trans]; rfl
   map_comp {X Y Z} f g := by
     dsimp
     congr 1
@@ -345,14 +349,8 @@ def functorFrom  :
     Grothendieck F ⥤ E where
   obj X := (fib X.base).obj X.fiber
   map {X Y} f := (hom f.base).app X.fiber ≫ (fib Y.base).map f.fiber
-  map_id X := by
-    dsimp
-    erw [hom_id]
-    simp
-  map_comp f g := by
-    dsimp
-    erw [hom_comp]
-    simp
+  map_id X := by simp [hom_id]
+  map_comp f g := by simp [hom_comp]
 
 theorem apply_functorFrom (c : C) : apply (functorFrom fib hom hom_id hom_comp) c = fib c := by
   refine Functor.ext (fun _ => by rfl) ?_

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -353,12 +353,10 @@ def functorFrom : Grothendieck F ⥤ E where
   map_id X := by simp [hom_id]
   map_comp f g := by simp [hom_comp]
 
-/-- `Grothendieck.apply` and `Grothendieck.functorFrom` fulfill a kind of "β reduction", in which
-application and abstraction cancel each other out. -/
-theorem ι_functorFrom (c : C) : ι F c ⋙ (functorFrom fib hom hom_id hom_comp) = fib c := by
-  refine Functor.ext (fun _ => by rfl) ?_
-  intro X Y f
-  simp [hom_id]
+/-- `Grothendieck.ι F c` composed with `Grothendieck.functorFrom` is isomorphic a functor on a fiber
+on `F` supplied as the first argument to `Grothendieck.functorFrom`. -/
+def ιFunctorFromIso (c : C) : ι F c ⋙ (functorFrom fib hom hom_id hom_comp) ≅ fib c :=
+  NatIso.ofComponents (fun _ => Iso.refl _) (fun f => by simp [hom_id])
 
 end FunctorFrom
 

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -357,8 +357,7 @@ def functorFrom  :
 theorem apply_functorFrom (c : C) : apply (functorFrom fib hom hom_id hom_comp) c = fib c := by
   refine Functor.ext (fun _ => by rfl) ?_
   intro X Y f
-  simp
-  sorry
+  simp [hom_id]
 
 end FunctorFrom
 

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -355,7 +355,7 @@ def functorFrom : Grothendieck F ⥤ E where
 
 /-- `Grothendieck.ι F c` composed with `Grothendieck.functorFrom` is isomorphic a functor on a fiber
 on `F` supplied as the first argument to `Grothendieck.functorFrom`. -/
-def ιFunctorFromIso (c : C) : ι F c ⋙ (functorFrom fib hom hom_id hom_comp) ≅ fib c :=
+def ιCompFunctorFrom (c : C) : ι F c ⋙ (functorFrom fib hom hom_id hom_comp) ≅ fib c :=
   NatIso.ofComponents (fun _ => Iso.refl _) (fun f => by simp [hom_id])
 
 end FunctorFrom

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -314,6 +314,7 @@ section FunctorFrom
 
 variable {E : Type*} [Category E]
 
+variable (F) in
 /-- The inclusion of a fiber `F.obj c` of a functor `F : C ⥤ Cat` into its Grothendieck
 construction.-/
 @[simps]
@@ -332,6 +333,11 @@ def ι (c : C) : F.obj c ⥤ Grothendieck F where
     congr 1
     simp only [eqToHom_comp_iff, Category.assoc, eqToHom_trans_assoc]
     apply Functor.congr_hom (F.map_id _).symm
+
+instance faithful_ι (c : C) : (ι F c).Faithful where
+  map_injective f := by
+    injection f with _ f
+    rwa [cancel_epi] at f
 
 variable (fib : ∀ c, F.obj c ⥤ E) (hom : ∀ {c c' : C} (f : c ⟶ c'), fib c ⟶ F.map f ⋙ fib c')
 variable (hom_id : ∀ c, hom (𝟙 c) = eqToHom (by simp only [Functor.map_id]; rfl))

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -306,6 +306,40 @@ def pre (G : D ⥤ C) : Grothendieck (G ⋙ F) ⥤ Grothendieck F where
   map_id X := Grothendieck.ext _ _ (G.map_id _) (by simp)
   map_comp f g := Grothendieck.ext _ _ (G.map_comp _ _) (by simp)
 
+section FunctorFrom
+
+variable {E : Type*} [Category E]
+
+/-- Partially apply a functor `H` on the Grothendieck construction of a functor `F : C ⥤ Cat` to
+an object `c : C` to obtain a functor `F.obj c ⥤ E` on the fiber over `c`. -/
+@[simps]
+def apply (H : Grothendieck F ⥤ E) (c : C) : F.obj c ⥤ E where
+  obj d := H.obj ⟨c, d⟩
+  map f := H.map ⟨𝟙 _, eqToHom (by simp) ≫ f⟩
+  map_id d := by
+    rw [← H.map_id]
+    dsimp
+    congr
+    simp only [Category.comp_id]
+  map_comp f g := by
+    dsimp
+    rw [← H.map_comp]
+    congr 1
+    apply Grothendieck.ext _ _ (by simp)
+    simp only [comp_base, ← Category.assoc, eqToHom_trans, comp_fiber, Functor.map_comp,
+      eqToHom_map]
+    congr 1
+    simp only [eqToHom_comp_iff, Category.assoc, eqToHom_trans_assoc]
+    apply Functor.congr_hom (F.map_id _).symm
+
+def functorFrom (fib : ∀ c, F.obj c ⥤ E)
+    (hom : ∀ {c c' : C} (f : c ⟶ c'), ((fib c).hom _).obj _ ⟶ _) :
+    Grothendieck F ⥤ E where
+  obj := fun X => (fib X.base).obj X.fiber
+  map := _
+
+end FunctorFrom
+
 end Grothendieck
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -326,7 +326,6 @@ def ι (c : C) : F.obj c ⥤ Grothendieck F where
     congr
     simp only [Category.comp_id]
   map_comp f g := by
-    simp
     apply Grothendieck.ext _ _ (by simp)
     simp only [comp_base, ← Category.assoc, eqToHom_trans, comp_fiber, Functor.map_comp,
       eqToHom_map]


### PR DESCRIPTION
Provides a constructor lemmas for functors `Grothendieck F ⥤ E` as well as the of fibers of `F` into `Grothendieck F`.

Also improves the simp behaviour for the identity morphism on the Grothendieck construction.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
