### PR TITLE
[Merged by Bors] - chore(Submonoid/Inverses): golf

### DIFF
--- a/Mathlib/GroupTheory/Submonoid/Inverses.lean
+++ b/Mathlib/GroupTheory/Submonoid/Inverses.lean
@@ -136,20 +136,15 @@ variable (hS : S ≤ IsUnit.submonoid M)
 `AddEquiv` to `S`."]
 noncomputable def leftInvEquiv : S.leftInv ≃* S :=
   { S.fromCommLeftInv with
-    invFun := fun x ↦ by
-      choose x' hx using hS x.prop
-      exact ⟨x'.inv, x, hx ▸ x'.inv_val⟩
-    left_inv := fun x ↦
-      Subtype.eq <| by
-        dsimp only; generalize_proofs h; rw [← h.choose.mul_left_inj]
-        conv => rhs; rw [h.choose_spec]
-        exact h.choose.inv_val.trans (S.mul_fromLeftInv x).symm
-    right_inv := fun x ↦ by
-      dsimp only [fromCommLeftInv]
+    invFun := fun x ↦ ⟨↑(hS x.2).unit⁻¹, x, by simp⟩
+    left_inv := by
+      intro x
       ext
-      rw [fromLeftInv_eq_iff]
-      convert (hS x.prop).choose.inv_val
-      exact (hS x.prop).choose_spec.symm }
+      simp [← Units.mul_eq_one_iff_inv_eq]
+    right_inv := by
+      rintro ⟨x, hx⟩
+      ext
+      simp [fromLeftInv_eq_iff] }
 
 @[to_additive (attr := simp)]
 theorem fromLeftInv_leftInvEquiv_symm (x : S) : S.fromLeftInv ((S.leftInvEquiv hS).symm x) = x :=


### PR DESCRIPTION
Golf `leftInvEquiv` by using `IsUnit.unit`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
