### PR TITLE
feat(Algebra/Category/ModuleCat): exterior power functors on `ModuleCat`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -101,6 +101,7 @@ import Mathlib.Algebra.Category.ModuleCat.Colimits
 import Mathlib.Algebra.Category.ModuleCat.Differentials.Basic
 import Mathlib.Algebra.Category.ModuleCat.Differentials.Presheaf
 import Mathlib.Algebra.Category.ModuleCat.EpiMono
+import Mathlib.Algebra.Category.ModuleCat.ExteriorPower
 import Mathlib.Algebra.Category.ModuleCat.FilteredColimits
 import Mathlib.Algebra.Category.ModuleCat.Free
 import Mathlib.Algebra.Category.ModuleCat.Images

--- a/Mathlib/Algebra/Category/ModuleCat/ExteriorPower.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ExteriorPower.lean
@@ -12,16 +12,6 @@ import Mathlib.LinearAlgebra.ExteriorAlgebra.Basic
 
 universe w v u
 
-namespace LinearMap
-
-variable {R R₂ M M₂ : Type*} [Semiring R] [Semiring R₂]
-  [AddCommMonoid M] [AddCommMonoid M₂] [Module R M]
-  [Module R₂ M₂] {τ₁₂ : R →+* R₂}
-  {F : Type*} [FunLike F M M₂] [SemilinearMapClass F τ₁₂ M M₂]
-  [RingHomSurjective τ₁₂] (f : F)
-
-end LinearMap
-
 namespace ExteriorAlgebra
 
 variable (R : Type u) [CommRing R] (n : ℕ) (M : Type v) [AddCommGroup M] [Module R M]

--- a/Mathlib/Algebra/Category/ModuleCat/ExteriorPower.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ExteriorPower.lean
@@ -10,27 +10,46 @@ import Mathlib.LinearAlgebra.ExteriorAlgebra.Basic
 
 -/
 
-universe v u
+universe w v u
+
+namespace LinearMap
+
+variable {R R₂ M M₂ : Type*} [Semiring R] [Semiring R₂]
+  [AddCommMonoid M] [AddCommMonoid M₂] [Module R M]
+  [Module R₂ M₂] {τ₁₂ : R →+* R₂}
+  {F : Type*} [FunLike F M M₂] [SemilinearMapClass F τ₁₂ M M₂]
+  [RingHomSurjective τ₁₂] (f : F)
+
+end LinearMap
 
 namespace ExteriorAlgebra
 
-variable (R : Type u) [CommRing R] {n : ℕ} {M : Type v} [AddCommGroup M] [Module R M]
-
-lemma ιMulti_apply_mem_exteriorPower (m : Fin n → M) :
-    ιMulti R n m ∈ exteriorPower R n M := by
-      sorry
-
-variable (n M)
+variable (R : Type u) [CommRing R] (n : ℕ) (M : Type v) [AddCommGroup M] [Module R M]
 
 def exteriorProduct : AlternatingMap R M (exteriorPower R n M) (Fin n) where
-  toFun m := ⟨ιMulti R n m, ιMulti_apply_mem_exteriorPower R m⟩
+  toFun m := ⟨ιMulti R n m, ιMulti_range _ _ (by simp)⟩
   map_add' m i x y := Subtype.ext (by simp)
   map_smul' m i c x := Subtype.ext (by simp)
   map_eq_zero_of_eq' v i j hij hij' :=
     Subtype.ext ((ιMulti R (M := M) n).map_eq_zero_of_eq v hij hij')
 
-end ExteriorAlgebra
+namespace exteriorPower
 
+variable {R n M} {N : Type w} [AddCommGroup N] [Module R N]
+  (φ : AlternatingMap R M N (Fin n))
+
+def desc : exteriorPower R n M →ₗ[R] N := by
+  have := φ
+  sorry
+
+@[simp]
+lemma desc_exteriorProduct (m : Fin n → M) :
+    desc φ (exteriorProduct R n M m) = φ m := by
+  sorry
+
+end exteriorPower
+
+end ExteriorAlgebra
 
 open CategoryTheory
 
@@ -119,7 +138,14 @@ variable (M n)
 def univ (M : ModuleCat.{u} R) (n : ℕ) : M.AlternatingMap (M.exteriorPower n) n :=
   ExteriorAlgebra.exteriorProduct _ _ _
 
-def univUniversal : (univ M n).Universal := sorry
+def univUniversal : (univ M n).Universal where
+  desc {N} φ := ExteriorAlgebra.exteriorPower.desc φ
+  fac {N} φ := by
+    ext m
+    apply ExteriorAlgebra.exteriorPower.desc_exteriorProduct
+  postcomp_injective {N f g} h:= by
+    rw [← sub_eq_zero]
+    sorry
 
 namespace Universal
 
@@ -134,7 +160,7 @@ lemma hom_ext (hφ : φ.Universal) {N : ModuleCat.{u} R} {f g : N₀ ⟶ N}
 variable (hφ : φ.Universal)
 
 @[simp]
-lemma fac_apply {N : ModuleCat.{u} R} (ψ : M.AlternatingMap N n) (m : Fin n → M) :
+lemma desc_apply {N : ModuleCat.{u} R} (ψ : M.AlternatingMap N n) (m : Fin n → M) :
     hφ.desc ψ (φ m) = ψ m := by
   conv_rhs => rw [← hφ.fac ψ]
   rfl
@@ -195,8 +221,7 @@ def equiv₀ : M.AlternatingMap N 0 ≃ N :=
 def corepresentableBy₀ :
     (M.alternatingMapFunctor 0).CorepresentableBy (ModuleCat.of R R) where
   homEquiv {N} := N.homEquivOfSelf.trans (equiv₀ M N).symm
-  homEquiv_comp := by
-    sorry
+  homEquiv_comp _ _ := rfl
 
 def exteriorPower₀Iso : M.exteriorPower 0 ≅ of R R :=
   (AlternatingMap.universalOfCorepresentableBy M.corepresentableBy₀).iso
@@ -227,8 +252,7 @@ def equiv₁ : M.AlternatingMap N 1 ≃ (M ⟶ N) where
 def corepresentableBy₁ :
     (M.alternatingMapFunctor 1).CorepresentableBy M where
   homEquiv {N} := (equiv₁ M N).symm
-  homEquiv_comp := by
-    sorry
+  homEquiv_comp _ _ := rfl
 
 def exteriorPower₁Iso : M.exteriorPower 1 ≅ M :=
   (AlternatingMap.universalOfCorepresentableBy M.corepresentableBy₁).iso

--- a/Mathlib/Algebra/Category/ModuleCat/ExteriorPower.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ExteriorPower.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.Algebra.Category.ModuleCat.ChangeOfRings
+import Mathlib.LinearAlgebra.ExteriorAlgebra.Basic
+
+/-!
+
+-/
+
+universe u
+
+open CategoryTheory
+
+namespace ModuleCat
+
+section
+
+variable {R : Type u} [CommRing R] (M : ModuleCat.{u} R)
+
+def homEquivOfSelf :
+    (of R R ⟶ M) ≃ M :=
+  (LinearMap.ringLmapEquivSelf R R M).toEquiv
+
+@[simp] lemma homEquivOfSelf_apply (φ : of R R ⟶ M) : M.homEquivOfSelf φ = φ (1 : R) := rfl
+@[simp] lemma homEquivOfSelf_symm_apply (m : M) (r : R) : M.homEquivOfSelf.symm m r = r • m := rfl
+
+end
+
+def exteriorPower {R : Type u} [CommRing R] (M : ModuleCat.{u} R) (n : ℕ) : ModuleCat.{u} R :=
+  ModuleCat.of R (⋀[R]^n M)
+
+def AlternatingMap {R : Type u} [CommRing R] (M N : ModuleCat.{u} R) (n : ℕ) :=
+  M [⋀^Fin n]→ₗ[R] N
+
+instance {R : Type u} [CommRing R] {M N : ModuleCat.{u} R} {n : ℕ} :
+    FunLike (M.AlternatingMap N n) (Fin n → M) N :=
+  inferInstanceAs (FunLike (M [⋀^Fin n]→ₗ[R] N) (Fin n → M) N)
+
+@[ext]
+lemma AlternatingMap.ext {R : Type u} [CommRing R] {M N : ModuleCat.{u} R} {n : ℕ}
+    {φ φ' : M.AlternatingMap N n} (h : ∀ (m : Fin n → M), φ m = φ' m) : φ = φ' :=
+  DFunLike.coe_injective (by funext; apply h)
+
+@[ext 1100]
+lemma AlternatingMap.ext₀ {R : Type u} [CommRing R] {M N : ModuleCat.{u} R}
+    {φ φ' : M.AlternatingMap N 0} (h : φ 0 = φ' 0) : φ = φ' := by
+  ext m
+  obtain rfl : m = 0 := by funext x; fin_cases x
+  exact h
+
+def AlternatingMap.postcomp {R : Type u} [CommRing R] {M N N' : ModuleCat.{u} R} {n : ℕ}
+    (φ : M.AlternatingMap N n) (f : N ⟶ N') :
+    M.AlternatingMap N' n :=
+  f.compAlternatingMap φ
+
+@[simp]
+lemma AlternatingMap.postcomp_apply {R : Type u} [CommRing R] {M N N' : ModuleCat.{u} R} {n : ℕ}
+    (φ : M.AlternatingMap N n) (f : N ⟶ N') (m : Fin n → M) :
+    φ.postcomp f m = f (φ m) := rfl
+
+@[simps]
+def alternatingMapFunctor {R : Type u} [CommRing R] (M : ModuleCat.{u} R) (n : ℕ) :
+    ModuleCat.{u} R ⥤ Type u where
+  obj N := M.AlternatingMap N n
+  map {N N'} f φ := φ.postcomp f
+
+namespace AlternatingMap
+
+variable {R : Type u} [CommRing R] {M N₀ : ModuleCat.{u} R} {n : ℕ}
+  (φ : M.AlternatingMap N₀ n)
+
+structure Universal where
+  desc {N : ModuleCat.{u} R} (ψ : M.AlternatingMap N n) : N₀ ⟶ N
+  fac {N : ModuleCat.{u} R} (ψ : M.AlternatingMap N n) : φ.postcomp (desc ψ) = ψ
+  postcomp_injective {N : ModuleCat.{u} R} {f g : N₀ ⟶ N}
+    (h : φ.postcomp f = φ.postcomp g) : f = g
+
+variable {φ}
+
+def Universal.iso (hφ : φ.Universal) : M.exteriorPower n ≅ N₀ := by
+  sorry
+
+section
+
+variable (r : (M.alternatingMapFunctor n).CorepresentableBy N₀)
+
+def ofCorepresentableBy : M.AlternatingMap N₀ n := r.homEquiv (𝟙 _)
+
+def universalOfCorepresentableBy : (ofCorepresentableBy r).Universal where
+  desc ψ := r.homEquiv.symm ψ
+  fac ψ := by
+    obtain ⟨φ, rfl⟩ := r.homEquiv.surjective ψ
+    dsimp [ofCorepresentableBy]
+    simp only [Equiv.symm_apply_apply]
+    erw [r.homEquiv_eq φ]
+    rfl
+  postcomp_injective {N f g} h := by
+    apply r.homEquiv.injective
+    rw [r.homEquiv_eq f, r.homEquiv_eq g]
+    exact h
+
+end
+
+variable (M)
+
+@[simps]
+def zero : M.AlternatingMap (ModuleCat.of R R) 0 where
+  toFun _ := (1 : R)
+  map_add' _ x := by fin_cases x
+  map_smul' _ x := by fin_cases x
+  map_eq_zero_of_eq' _ x := by fin_cases x
+
+def equiv₀ (N : ModuleCat.{u} R) : M.AlternatingMap N 0 ≃ N :=
+  AlternatingMap.constLinearEquivOfIsEmpty.toEquiv.symm
+
+def corepresentableBy₀ :
+    (M.alternatingMapFunctor 0).CorepresentableBy (ModuleCat.of R R) where
+  homEquiv {N} := N.homEquivOfSelf.trans (equiv₀ M N).symm
+  homEquiv_comp := by
+    sorry
+
+def one : M.AlternatingMap M 1 where
+  toFun f := f 0
+  map_add' _ n _ _:= by fin_cases n; simp
+  map_smul' _ n _ _ := by fin_cases n; simp
+  map_eq_zero_of_eq' _ i j := by fin_cases i; fin_cases j; tauto
+
+def oneUniversal : (one M).Universal := sorry
+
+end AlternatingMap
+
+namespace exteriorPower
+
+section
+
+variable {R : Type u} [CommRing R] {M : ModuleCat.{u} R}
+
+def lift {n : ℕ} {N : ModuleCat.{u} R} (φ : M.AlternatingMap N n) :
+    M.exteriorPower n ⟶ N := by
+  sorry
+
+def mk {n : ℕ} (m : Fin n → M) : M.exteriorPower n := sorry
+
+@[simps]
+def mkAlternatingMap (n : ℕ) : M.AlternatingMap (M.exteriorPower n) n where
+  toFun := mk
+  map_add' := sorry
+  map_smul' := sorry
+  map_eq_zero_of_eq' := sorry
+
+@[simp]
+lemma lift_mk {n : ℕ} {N : ModuleCat.{u} R} (φ : M [⋀^Fin n]→ₗ[R] N)
+    (m : Fin n → M) :
+    lift φ (mk m) = φ m := by
+  sorry
+
+@[ext]
+lemma hom_ext {n : ℕ} {N : ModuleCat.{u} R} {f g : M.exteriorPower n ⟶ N}
+    (h : ∀ (m : Fin n → M), f (mk m) = g (mk m)) :
+    f = g := by
+  sorry
+
+def map {N : ModuleCat.{u} R} (f : M ⟶ N) (n : ℕ) : M.exteriorPower n ⟶ N.exteriorPower n :=
+  lift (AlternatingMap.compLinearMap (mkAlternatingMap n) f)
+
+@[simp]
+lemma map_mk {N : ModuleCat.{u} R} (f : M ⟶ N) {n : ℕ} (m : Fin n → M) :
+    map f n (mk m) = mk (Function.comp f m) := by
+  simp only [map, lift_mk, AlternatingMap.compLinearMap_apply, mkAlternatingMap_apply]
+  rfl
+
+variable (M)
+
+def iso₀ : M.exteriorPower 0 ≅ ModuleCat.of R R :=
+  (AlternatingMap.universalOfCorepresentableBy
+    (AlternatingMap.corepresentableBy₀ M)).iso
+
+def iso₁ : M.exteriorPower 1 ≅ M := (AlternatingMap.oneUniversal M).iso
+
+variable (R)
+
+@[simps]
+def functor (n : ℕ): ModuleCat.{u} R ⥤ ModuleCat.{u} R where
+  obj M := M.exteriorPower n
+  map f := map f n
+
+end
+
+section ChangeOfRings
+
+variable {R S : Type u} [CommRing R] [CommRing S] (f : R →+* S)
+
+def fromRestrictScalarsObjExteriorPower (M : ModuleCat.{u} S) (n : ℕ) :
+    ((restrictScalars f).obj M).exteriorPower n ⟶
+      (restrictScalars f).obj (M.exteriorPower n) :=
+  lift
+    { toFun := fun m ↦ mk m
+      map_add' := fun m i x y ↦ by
+        dsimp
+        sorry
+      map_smul' := sorry
+      map_eq_zero_of_eq' := sorry }
+
+@[simp]
+lemma fromRestrictScalarsObjExteriorPower_mk (M : ModuleCat.{u} S) (n : ℕ)
+    (m : Fin n → M) :
+    fromRestrictScalarsObjExteriorPower f M n (mk m) = mk m := by
+  apply lift_mk
+
+@[simps]
+def restrictScalarsCompFunctorNatTrans (n : ℕ) :
+    restrictScalars f ⋙ functor R n ⟶ functor S n ⋙ restrictScalars f where
+  app M := fromRestrictScalarsObjExteriorPower f M n
+
+end ChangeOfRings
+
+end exteriorPower
+
+end ModuleCat

--- a/Mathlib/Algebra/Category/ModuleCat/ExteriorPower.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ExteriorPower.lean
@@ -29,37 +29,54 @@ def homEquivOfSelf :
 
 end
 
-def exteriorPower {R : Type u} [CommRing R] (M : ModuleCat.{u} R) (n : ℕ) : ModuleCat.{u} R :=
+section
+
+variable {R : Type u} [CommRing R]
+
+def exteriorPower (M : ModuleCat.{u} R) (n : ℕ) : ModuleCat.{u} R :=
   ModuleCat.of R (⋀[R]^n M)
 
-def AlternatingMap {R : Type u} [CommRing R] (M N : ModuleCat.{u} R) (n : ℕ) :=
+def AlternatingMap (M N : ModuleCat.{u} R) (n : ℕ) :=
   M [⋀^Fin n]→ₗ[R] N
 
-instance {R : Type u} [CommRing R] {M N : ModuleCat.{u} R} {n : ℕ} :
+instance {M N : ModuleCat.{u} R} {n : ℕ} :
     FunLike (M.AlternatingMap N n) (Fin n → M) N :=
   inferInstanceAs (FunLike (M [⋀^Fin n]→ₗ[R] N) (Fin n → M) N)
 
+end
+
+namespace AlternatingMap
+
+variable {R : Type u} [CommRing R] {M N N' : ModuleCat.{u} R} {n : ℕ}
+
 @[ext]
-lemma AlternatingMap.ext {R : Type u} [CommRing R] {M N : ModuleCat.{u} R} {n : ℕ}
-    {φ φ' : M.AlternatingMap N n} (h : ∀ (m : Fin n → M), φ m = φ' m) : φ = φ' :=
+lemma ext {φ φ' : M.AlternatingMap N n} (h : ∀ (m : Fin n → M), φ m = φ' m) : φ = φ' :=
   DFunLike.coe_injective (by funext; apply h)
 
 @[ext 1100]
-lemma AlternatingMap.ext₀ {R : Type u} [CommRing R] {M N : ModuleCat.{u} R}
-    {φ φ' : M.AlternatingMap N 0} (h : φ 0 = φ' 0) : φ = φ' := by
+lemma ext₀ {φ φ' : M.AlternatingMap N 0} (h : φ 0 = φ' 0) : φ = φ' := by
   ext m
   obtain rfl : m = 0 := by funext x; fin_cases x
   exact h
 
-def AlternatingMap.postcomp {R : Type u} [CommRing R] {M N N' : ModuleCat.{u} R} {n : ℕ}
-    (φ : M.AlternatingMap N n) (f : N ⟶ N') :
+def postcomp (φ : M.AlternatingMap N n) (f : N ⟶ N') :
     M.AlternatingMap N' n :=
   f.compAlternatingMap φ
 
 @[simp]
-lemma AlternatingMap.postcomp_apply {R : Type u} [CommRing R] {M N N' : ModuleCat.{u} R} {n : ℕ}
-    (φ : M.AlternatingMap N n) (f : N ⟶ N') (m : Fin n → M) :
+lemma postcomp_apply (φ : M.AlternatingMap N n) (f : N ⟶ N') (m : Fin n → M) :
     φ.postcomp f m = f (φ m) := rfl
+
+@[simp]
+lemma postcomp_id (φ : M.AlternatingMap N n) :
+    φ.postcomp (𝟙 _) = φ := rfl
+
+@[simp]
+lemma postcomp_comp (φ : M.AlternatingMap N n)
+    (f : N ⟶ N') {N'' : ModuleCat.{u} R} (g : N' ⟶ N'') :
+    φ.postcomp (f ≫ g) = (φ.postcomp f).postcomp g := rfl
+
+end AlternatingMap
 
 @[simps]
 def alternatingMapFunctor {R : Type u} [CommRing R] (M : ModuleCat.{u} R) (n : ℕ) :
@@ -69,23 +86,68 @@ def alternatingMapFunctor {R : Type u} [CommRing R] (M : ModuleCat.{u} R) (n : �
 
 namespace AlternatingMap
 
-variable {R : Type u} [CommRing R] {M N₀ : ModuleCat.{u} R} {n : ℕ}
-  (φ : M.AlternatingMap N₀ n)
+variable {R : Type u} [CommRing R] {M N₀ N₁ : ModuleCat.{u} R} {n : ℕ}
 
-structure Universal where
+structure Universal (φ : M.AlternatingMap N₀ n) where
   desc {N : ModuleCat.{u} R} (ψ : M.AlternatingMap N n) : N₀ ⟶ N
   fac {N : ModuleCat.{u} R} (ψ : M.AlternatingMap N n) : φ.postcomp (desc ψ) = ψ
   postcomp_injective {N : ModuleCat.{u} R} {f g : N₀ ⟶ N}
     (h : φ.postcomp f = φ.postcomp g) : f = g
 
-variable {φ}
+variable (M n)
 
-def Universal.iso (hφ : φ.Universal) : M.exteriorPower n ≅ N₀ := by
-  sorry
+def univ (M : ModuleCat.{u} R) (n : ℕ) : M.AlternatingMap (M.exteriorPower n) n where
+  toFun := sorry
+  map_add' := sorry
+  map_smul' := sorry
+  map_eq_zero_of_eq' := sorry
+
+def univUniversal : (univ M n).Universal := sorry
+
+namespace Universal
+
+attribute [simp] fac
+
+variable {M n} {φ : M.AlternatingMap N₀ n}
+
+lemma hom_ext (hφ : φ.Universal) {N : ModuleCat.{u} R} {f g : N₀ ⟶ N}
+    (h : ∀ (m : Fin n → M), f (φ m) = g (φ m)) : f = g :=
+  hφ.postcomp_injective (by ext; apply h)
+
+variable (hφ : φ.Universal)
+
+@[simp]
+lemma fac_apply {N : ModuleCat.{u} R} (ψ : M.AlternatingMap N n) (m : Fin n → M) :
+    hφ.desc ψ (φ m) = ψ m := by
+  conv_rhs => rw [← hφ.fac ψ]
+  rfl
 
 section
 
-variable (r : (M.alternatingMapFunctor n).CorepresentableBy N₀)
+variable {ψ : M.AlternatingMap N₁ n} (hψ : ψ.Universal)
+
+def uniq : N₀ ≅ N₁ where
+  hom := hφ.desc ψ
+  inv := hψ.desc φ
+  hom_inv_id := hφ.postcomp_injective (by simp)
+  inv_hom_id := hψ.postcomp_injective (by simp)
+
+@[simp] lemma postcomp_uniq_hom : φ.postcomp (uniq hφ hψ).hom = ψ := by simp [uniq]
+@[simp] lemma postcomp_uniq_inv : ψ.postcomp (uniq hφ hψ).inv = φ := by simp [uniq]
+
+end
+
+def iso : M.exteriorPower n ≅ N₀ :=
+  (univUniversal M n).uniq hφ
+
+@[simp] lemma postcomp_iso_hom : (univ M n).postcomp hφ.iso.hom = φ := by simp [iso]
+@[simp] lemma postcomp_iso_inv : φ.postcomp hφ.iso.inv = univ M n := by simp [iso]
+
+end Universal
+
+section
+
+variable {M n} (r : (M.alternatingMapFunctor n).CorepresentableBy N₀)
 
 def ofCorepresentableBy : M.AlternatingMap N₀ n := r.homEquiv (𝟙 _)
 
@@ -104,16 +166,13 @@ def universalOfCorepresentableBy : (ofCorepresentableBy r).Universal where
 
 end
 
-variable (M)
+end AlternatingMap
 
-@[simps]
-def zero : M.AlternatingMap (ModuleCat.of R R) 0 where
-  toFun _ := (1 : R)
-  map_add' _ x := by fin_cases x
-  map_smul' _ x := by fin_cases x
-  map_eq_zero_of_eq' _ x := by fin_cases x
+section
 
-def equiv₀ (N : ModuleCat.{u} R) : M.AlternatingMap N 0 ≃ N :=
+variable {R : Type u} [CommRing R] (M N : ModuleCat.{u} R)
+
+def equiv₀ : M.AlternatingMap N 0 ≃ N :=
   AlternatingMap.constLinearEquivOfIsEmpty.toEquiv.symm
 
 def corepresentableBy₀ :
@@ -122,15 +181,42 @@ def corepresentableBy₀ :
   homEquiv_comp := by
     sorry
 
-def one : M.AlternatingMap M 1 where
-  toFun f := f 0
-  map_add' _ n _ _:= by fin_cases n; simp
-  map_smul' _ n _ _ := by fin_cases n; simp
-  map_eq_zero_of_eq' _ i j := by fin_cases i; fin_cases j; tauto
+def exteriorPower₀Iso : M.exteriorPower 0 ≅ of R R :=
+  (AlternatingMap.universalOfCorepresentableBy M.corepresentableBy₀).iso
 
-def oneUniversal : (one M).Universal := sorry
+@[simp]
+lemma _root_.Function.update_apply_of_subsingleton
+    {M : Type*} (φ : Fin 1 → M) (x : Fin 1) (m : M) (i : Fin 1) :
+    Function.update φ x m i = m := by
+  obtain rfl := Subsingleton.elim x i
+  simp
 
-end AlternatingMap
+def equiv₁ : M.AlternatingMap N 1 ≃ (M ⟶ N) where
+  toFun φ :=
+    { toFun := fun x ↦ φ (fun _ ↦ x)
+      map_add' := fun x y ↦ by convert φ.map_add 0 0 x y <;> simp
+      map_smul' := fun r x ↦ by convert φ.map_smul 0 0 r x <;> simp }
+  invFun f :=
+    { toFun := fun x ↦ f (x 0)
+      map_add' := fun _ i x y ↦ by fin_cases i; convert f.map_add x y <;> simp
+      map_smul' := fun _ i r x ↦ by fin_cases i; convert f.map_smul r x <;> simp
+      map_eq_zero_of_eq' := fun _ i j ↦ by fin_cases i; fin_cases j; tauto }
+  left_inv φ := by
+    ext m
+    obtain ⟨x, rfl⟩ : ∃ x, m = fun _ ↦ x := ⟨m 0, by ext i; fin_cases i; rfl⟩
+    rfl
+  right_inv f := rfl
+
+def corepresentableBy₁ :
+    (M.alternatingMapFunctor 1).CorepresentableBy M where
+  homEquiv {N} := (equiv₁ M N).symm
+  homEquiv_comp := by
+    sorry
+
+def exteriorPower₁Iso : M.exteriorPower 1 ≅ M :=
+  (AlternatingMap.universalOfCorepresentableBy M.corepresentableBy₁).iso
+
+end
 
 namespace exteriorPower
 
@@ -138,47 +224,35 @@ section
 
 variable {R : Type u} [CommRing R] {M : ModuleCat.{u} R}
 
-def lift {n : ℕ} {N : ModuleCat.{u} R} (φ : M.AlternatingMap N n) :
-    M.exteriorPower n ⟶ N := by
-  sorry
+def desc {n : ℕ} {N : ModuleCat.{u} R} (φ : M.AlternatingMap N n) :
+    M.exteriorPower n ⟶ N :=
+  (AlternatingMap.univUniversal M n).desc φ
 
-def mk {n : ℕ} (m : Fin n → M) : M.exteriorPower n := sorry
-
-@[simps]
-def mkAlternatingMap (n : ℕ) : M.AlternatingMap (M.exteriorPower n) n where
-  toFun := mk
-  map_add' := sorry
-  map_smul' := sorry
-  map_eq_zero_of_eq' := sorry
+def mk {n : ℕ} (m : Fin n → M) : M.exteriorPower n :=
+  AlternatingMap.univ M n m
 
 @[simp]
-lemma lift_mk {n : ℕ} {N : ModuleCat.{u} R} (φ : M [⋀^Fin n]→ₗ[R] N)
+lemma desc_mk {n : ℕ} {N : ModuleCat.{u} R} (φ : M [⋀^Fin n]→ₗ[R] N)
     (m : Fin n → M) :
-    lift φ (mk m) = φ m := by
-  sorry
+    desc φ (mk m) = φ m := by
+  simp [desc, mk]
 
 @[ext]
 lemma hom_ext {n : ℕ} {N : ModuleCat.{u} R} {f g : M.exteriorPower n ⟶ N}
     (h : ∀ (m : Fin n → M), f (mk m) = g (mk m)) :
-    f = g := by
-  sorry
+    f = g :=
+  (AlternatingMap.univUniversal M n).hom_ext h
 
 def map {N : ModuleCat.{u} R} (f : M ⟶ N) (n : ℕ) : M.exteriorPower n ⟶ N.exteriorPower n :=
-  lift (AlternatingMap.compLinearMap (mkAlternatingMap n) f)
+  desc (AlternatingMap.compLinearMap (AlternatingMap.univ N n) f)
 
 @[simp]
 lemma map_mk {N : ModuleCat.{u} R} (f : M ⟶ N) {n : ℕ} (m : Fin n → M) :
     map f n (mk m) = mk (Function.comp f m) := by
-  simp only [map, lift_mk, AlternatingMap.compLinearMap_apply, mkAlternatingMap_apply]
+  simp only [map, desc_mk, AlternatingMap.compLinearMap_apply]
   rfl
 
 variable (M)
-
-def iso₀ : M.exteriorPower 0 ≅ ModuleCat.of R R :=
-  (AlternatingMap.universalOfCorepresentableBy
-    (AlternatingMap.corepresentableBy₀ M)).iso
-
-def iso₁ : M.exteriorPower 1 ≅ M := (AlternatingMap.oneUniversal M).iso
 
 variable (R)
 
@@ -193,25 +267,24 @@ section ChangeOfRings
 
 variable {R S : Type u} [CommRing R] [CommRing S] (f : R →+* S)
 
-def fromRestrictScalarsObjExteriorPower (M : ModuleCat.{u} S) (n : ℕ) :
+noncomputable def fromRestrictScalarsObjExteriorPower (M : ModuleCat.{u} S) (n : ℕ) :
     ((restrictScalars f).obj M).exteriorPower n ⟶
       (restrictScalars f).obj (M.exteriorPower n) :=
-  lift
+  desc
     { toFun := fun m ↦ mk m
-      map_add' := fun m i x y ↦ by
-        dsimp
-        sorry
-      map_smul' := sorry
-      map_eq_zero_of_eq' := sorry }
+      map_add' := fun m i x y ↦ (AlternatingMap.univ M n).map_add m i x y
+      map_smul' := fun m i r x ↦ (AlternatingMap.univ M n).map_smul m i (f r) x
+      map_eq_zero_of_eq' := fun m _ _ hm hij ↦
+        (AlternatingMap.univ M n).map_eq_zero_of_eq m hm hij }
 
 @[simp]
 lemma fromRestrictScalarsObjExteriorPower_mk (M : ModuleCat.{u} S) (n : ℕ)
     (m : Fin n → M) :
     fromRestrictScalarsObjExteriorPower f M n (mk m) = mk m := by
-  apply lift_mk
+  apply desc_mk
 
 @[simps]
-def restrictScalarsCompFunctorNatTrans (n : ℕ) :
+noncomputable def restrictScalarsCompFunctorNatTrans (n : ℕ) :
     restrictScalars f ⋙ functor R n ⟶ functor S n ⋙ restrictScalars f where
   app M := fromRestrictScalarsObjExteriorPower f M n
 

--- a/Mathlib/Algebra/Category/ModuleCat/ExteriorPower.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ExteriorPower.lean
@@ -10,7 +10,27 @@ import Mathlib.LinearAlgebra.ExteriorAlgebra.Basic
 
 -/
 
-universe u
+universe v u
+
+namespace ExteriorAlgebra
+
+variable (R : Type u) [CommRing R] {n : ℕ} {M : Type v} [AddCommGroup M] [Module R M]
+
+lemma ιMulti_apply_mem_exteriorPower (m : Fin n → M) :
+    ιMulti R n m ∈ exteriorPower R n M := by
+      sorry
+
+variable (n M)
+
+def exteriorProduct : AlternatingMap R M (exteriorPower R n M) (Fin n) where
+  toFun m := ⟨ιMulti R n m, ιMulti_apply_mem_exteriorPower R m⟩
+  map_add' m i x y := Subtype.ext (by simp)
+  map_smul' m i c x := Subtype.ext (by simp)
+  map_eq_zero_of_eq' v i j hij hij' :=
+    Subtype.ext ((ιMulti R (M := M) n).map_eq_zero_of_eq v hij hij')
+
+end ExteriorAlgebra
+
 
 open CategoryTheory
 
@@ -96,11 +116,8 @@ structure Universal (φ : M.AlternatingMap N₀ n) where
 
 variable (M n)
 
-def univ (M : ModuleCat.{u} R) (n : ℕ) : M.AlternatingMap (M.exteriorPower n) n where
-  toFun := sorry
-  map_add' := sorry
-  map_smul' := sorry
-  map_eq_zero_of_eq' := sorry
+def univ (M : ModuleCat.{u} R) (n : ℕ) : M.AlternatingMap (M.exteriorPower n) n :=
+  ExteriorAlgebra.exteriorProduct _ _ _
 
 def univUniversal : (univ M n).Universal := sorry
 


### PR DESCRIPTION
---

This should be refactored after #10654 is merged.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
