### PR TITLE
[Merged by Bors] - fix(Util/FormatTable): escape bar characters in formatting tables for markdown

### DIFF
--- a/Mathlib/Util/FormatTable.lean
+++ b/Mathlib/Util/FormatTable.lean
@@ -38,14 +38,17 @@ def formatTable (headers : Array String) (table : Array (Array String))
     String := Id.run do
   -- If no alignments are provided, default to left alignment for all columns.
   let alignments := alignments.getD (Array.mkArray headers.size Alignment.left)
+  -- escape all bar characters
+  let escapedHeaders := headers.map (fun header => header.replace "|" "\\|")
+  let escapedTable := table.map (fun row => row.map (fun cell => cell.replace "|" "\\|"))
   -- Compute the maximum width of each column.
-  let mut widths := headers.map (·.length)
-  for row in table do
+  let mut widths := escapedHeaders.map (·.length)
+  for row in escapedTable do
     for i in [0:widths.size] do
       widths := widths.set! i (max widths[i]! ((row[i]?.map (·.length)).getD 0))
   -- Pad each cell with spaces to match the column width.
-  let paddedHeaders := headers.mapIdx fun i h => h.rightpad widths[i]!
-  let paddedTable := table.map fun row => row.mapIdx fun i cell =>
+  let paddedHeaders := escapedHeaders.mapIdx fun i h => h.rightpad widths[i]!
+  let paddedTable := escapedTable.map fun row => row.mapIdx fun i cell =>
     cell.justify alignments[i]! widths[i]!
   -- Construct the lines of the table
   let headerLine := "| " ++ String.intercalate " | " (paddedHeaders.toList) ++ " |"

--- a/Mathlib/Util/FormatTable.lean
+++ b/Mathlib/Util/FormatTable.lean
@@ -38,7 +38,8 @@ def formatTable (headers : Array String) (table : Array (Array String))
     String := Id.run do
   -- If no alignments are provided, default to left alignment for all columns.
   let alignments := alignments.getD (Array.mkArray headers.size Alignment.left)
-  -- escape all bar characters
+  -- Escape all vertical bar characters inside a table cell,
+  -- otherwise these could get interpreted as starting a new row or column.
   let escapedHeaders := headers.map (fun header => header.replace "|" "\\|")
   let escapedTable := table.map (fun row => row.map (fun cell => cell.replace "|" "\\|"))
   -- Compute the maximum width of each column.

--- a/test/format_table.lean
+++ b/test/format_table.lean
@@ -14,4 +14,4 @@ run_cmd Lean.logInfo ("\n" ++ formatTable
   #[#["item number one", "item two", "item c"],
     #["the fourth item", "the fourth item", "escape | this"],
     #["align left", "align center", "align right"]]
-  (.some #[.left,.center,.right]))
+  (.some #[.left, .center, .right]))

--- a/test/format_table.lean
+++ b/test/format_table.lean
@@ -1,16 +1,5 @@
 import Mathlib.Util.FormatTable
 
-open Lean
-
-/--
-The `#logAsInfo foo` command logs a message `foo` as info directly.
-This circumvents calling repr on strings, meaning instead of `"\\"`,
-the message becomes `\`. This makes it easier to use `#guard_msgs` to verify
-pure string-producing functions.
--/
-macro "#logAsInfo" t:term : command =>
-  `(command|#eval (logInfo <| $t : Lean.Elab.Command.CommandElabM Unit))
-
 /--
 info:
 | first           | second header   | third \| header |
@@ -20,9 +9,9 @@ info:
 | align left      |  align center   |     align right |
 -/
 #guard_msgs in
-#logAsInfo "\n" ++ formatTable
+run_cmd Lean.logInfo ("\n" ++ formatTable
   #["first", "second header", "third | header"]
   #[#["item number one", "item two", "item c"],
     #["the fourth item", "the fourth item", "escape | this"],
     #["align left", "align center", "align right"]]
-  (.some #[.left,.center,.right])
+  (.some #[.left,.center,.right]))

--- a/test/format_table.lean
+++ b/test/format_table.lean
@@ -13,16 +13,16 @@ macro "#logAsInfo" t:term : command =>
 
 /--
 info:
-| first           | second header   | third_header   |
-| :-------------- | :-------------: | -------------: |
-| item number one |    item two     |         item c |
-| the fourth item | the fourth item | escape \| this |
-| align left      |  align center   |    align right |
+| first           | second header   | third \| header |
+| :-------------- | :-------------: | --------------: |
+| item number one |    item two     |          item c |
+| the fourth item | the fourth item |  escape \| this |
+| align left      |  align center   |     align right |
 -/
 #guard_msgs in
 #logAsInfo "\n" ++ formatTable
-  #["first","second header","third_header"]
-  #[#["item number one","item two", "item c"],
-    #["the fourth item","the fourth item", "escape | this"],
-    #["align left","align center","align right"]]
+  #["first", "second header", "third | header"]
+  #[#["item number one", "item two", "item c"],
+    #["the fourth item", "the fourth item", "escape | this"],
+    #["align left", "align center", "align right"]]
   (.some #[.left,.center,.right])

--- a/test/format_table.lean
+++ b/test/format_table.lean
@@ -1,0 +1,28 @@
+import Mathlib.Util.FormatTable
+
+open Lean
+
+/--
+The `#logAsInfo foo` command logs a message `foo` as info directly.
+This circumvents calling repr on strings, meaning instead of `"\\"`,
+the message becomes `\`. This makes it easier to use `#guard_msgs` to verify
+pure string-producing functions.
+-/
+macro "#logAsInfo" t:term : command =>
+  `(command|#eval (logInfo <| $t : Lean.Elab.Command.CommandElabM Unit))
+
+/--
+info:
+| first           | second header   | third_header   |
+| :-------------- | :-------------: | -------------: |
+| item number one |    item two     |         item c |
+| the fourth item | the fourth item | escape \| this |
+| align left      |  align center   |    align right |
+-/
+#guard_msgs in
+#logAsInfo "\n" ++ formatTable
+  #["first","second header","third_header"]
+  #[#["item number one","item two", "item c"],
+    #["the fourth item","the fourth item", "escape | this"],
+    #["align left","align center","align right"]]
+  (.some #[.left,.center,.right])


### PR DESCRIPTION
This PR changes the `formatTable` function to make sure vertical bar (`|`) characters get escaped when formatting strings into markdown tables.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
