### PR TITLE
feat (LinearAlgebra/TensorProduct/Quotient): add lemma `quotTensorEquivQuotSMul'`

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Quotient.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Quotient.lean
@@ -9,6 +9,7 @@ import Mathlib.LinearAlgebra.TensorProduct.Basic
 import Mathlib.LinearAlgebra.Quotient
 import Mathlib.LinearAlgebra.Prod
 import Mathlib.RingTheory.Ideal.Quotient
+import Mathlib.Algebra.Module.Torsion
 
 /-!
 
@@ -171,6 +172,17 @@ noncomputable def quotTensorEquivQuotSMul (I : Ideal R) :
       refine Submodule.subset_span ?_
       simp only [Set.mem_image, Set.mem_setOf_eq]
       exact ⟨r ⊗ₜ m, ⟨r, hr, m, rfl⟩, rfl⟩)
+
+/-- As a module of the quotient ring, left tensoring a module with a quotient of the ring
+is the same as quotienting that module by the corresponding submodule. -/
+noncomputable def quotTensorEquivQuotSMul' (I : Ideal R) :
+    ((R ⧸ I) ⊗[R] M) ≃ₗ[R ⧸ I] (M ⧸ I • (⊤ : Submodule R M)) :=
+AddEquiv.toLinearEquiv (quotTensorEquivQuotSMul M I).toAddEquiv <| by
+    intro c x
+    refine Quotient.inductionOn c (fun c ↦ ?_)
+    show (quotTensorEquivQuotSMul M I).toLinearMap (c • x) =
+      c • (quotTensorEquivQuotSMul M I).toLinearMap x
+    rw [LinearMap.CompatibleSMul.map_smul]
 
 variable (M) in
 /-- Right tensoring a module with a quotient of the ring is the same as


### PR DESCRIPTION
This adds the lemma `quotTensorEquivQuotSMul'`, i.e. that _as a module of the quotient ring_, left tensoring a module with a quotient of the ring is the same as quotienting that module by the corresponding submodule.

Used in project Formalization of the Bruhat-Tits Tree.
Co-authored-by: Christian Merten [christian@merten.dev](mailto:christian@merten.dev)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
