### PR TITLE
[Merged by Bors] - feat(CategoryTheory) : (Co)structured arrow as a functor to Cat

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1546,6 +1546,7 @@ import Mathlib.CategoryTheory.Comma.Over
 import Mathlib.CategoryTheory.Comma.Presheaf.Basic
 import Mathlib.CategoryTheory.Comma.Presheaf.Colimit
 import Mathlib.CategoryTheory.Comma.StructuredArrow.Basic
+import Mathlib.CategoryTheory.Comma.StructuredArrow.Functor
 import Mathlib.CategoryTheory.Comma.StructuredArrow.Small
 import Mathlib.CategoryTheory.ComposableArrows
 import Mathlib.CategoryTheory.ConcreteCategory.Basic

--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Functor.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Functor.lean
@@ -30,6 +30,8 @@ def functor (T : C ⥤ D) : Dᵒᵖ ⥤ Cat where
   map_id d := Functor.ext (fun ⟨_, _, _⟩ => by simp [CostructuredArrow.map, Comma.mapRight])
   map_comp f g := Functor.ext (fun _ => by simp [CostructuredArrow.map, Comma.mapRight])
 
+end StructuredArrow
+
 namespace CostructuredArrow
 
 @[simps]
@@ -38,6 +40,28 @@ def functor (T : C ⥤ D) : D ⥤ Cat where
   map f := CostructuredArrow.map f
   map_id d := Functor.ext (fun ⟨_, _, _⟩ => by simp [CostructuredArrow.map, Comma.mapRight])
   map_comp f g := Functor.ext (fun _ => by simp [CostructuredArrow.map, Comma.mapRight])
+
+variable {E : Type u₃} [Category.{v₃} E]
+variable (L : C ⥤ D) (R : E ⥤ D)
+
+@[simps]
+def grothendieckPrecompFunctorToComma : Grothendieck (R ⋙ functor L) ⥤ Comma L R where
+  obj := fun P => ⟨P.fiber.left, P.base, P.fiber.hom⟩
+  map := fun f => ⟨f.fiber.left, f.base, by simp⟩
+
+@[simps]
+def commaToGrothendieckPrecompFunctor : Comma L R ⥤ Grothendieck (R ⋙ functor L) where
+  obj := fun X => ⟨X.right, mk X.hom⟩
+  map := fun f => ⟨f.right, homMk f.left⟩
+  map_id X := Grothendieck.ext _ _ rfl (by simp)
+  map_comp f g := Grothendieck.ext _ _ rfl (by simp)
+
+@[simps]
+def grothendieckPrecompFunctorEquivalence : Grothendieck (R ⋙ functor L) ≌ Comma L R where
+  functor := grothendieckPrecompFunctorToComma _ _
+  inverse := commaToGrothendieckPrecompFunctor _ _
+  unitIso := NatIso.ofComponents (fun _ => Iso.refl _)
+  counitIso := NatIso.ofComponents (fun _ => Iso.refl _)
 
 end CostructuredArrow
 

--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Functor.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Functor.lean
@@ -9,10 +9,10 @@ import Mathlib.CategoryTheory.Grothendieck
 /-!
 # Structured Arrow Categories as strict functor to Cat
 
-Forming a structured arrow category `StructuredArrow S T` with `S : D` and `T : C ⥤ D` is stictly
+Forming a structured arrow category `StructuredArrow d T` with `d : D` and `T : C ⥤ D` is stictly
 functorial in `S`, inducing a functor `Dᵒᵖ ⥤ Cat`. This file constructs said functor and proves
-that we can precompose it with another functor `L : E ⥤ D` to obtain a category equivalent to
-`Comma L T`.
+that, in the dual case, we can precompose it with another functor `L : E ⥤ D` to obtain a category
+equivalent to `Comma L T`.
 -/
 
 namespace CategoryTheory
@@ -23,6 +23,8 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 
 namespace StructuredArrow
 
+/-- The structured arrow category `StructuredArrow d T` depends on the chosen domain `d : D` in a
+functorial way, inducing a functor `Dᵒᵖ ⥤ Cat`. -/
 @[simps]
 def functor (T : C ⥤ D) : Dᵒᵖ ⥤ Cat where
   obj d := .of <| StructuredArrow d.unop T
@@ -34,6 +36,8 @@ end StructuredArrow
 
 namespace CostructuredArrow
 
+/-- The costructured arrow category `CostructuredArrow T d` depends on the chosen codomain `d : D`
+in a functorial way, inducing a functor `D ⥤ Cat`. -/
 @[simps]
 def functor (T : C ⥤ D) : D ⥤ Cat where
   obj d := .of <| CostructuredArrow T d
@@ -44,11 +48,15 @@ def functor (T : C ⥤ D) : D ⥤ Cat where
 variable {E : Type u₃} [Category.{v₃} E]
 variable (L : C ⥤ D) (R : E ⥤ D)
 
+/-- The functor used to establish the equivalence `grothendieckPrecompFunctorEquivalence` between
+the Grothendieck construction on `CostructuredArrow.functor` and the comma category. -/
 @[simps]
 def grothendieckPrecompFunctorToComma : Grothendieck (R ⋙ functor L) ⥤ Comma L R where
   obj := fun P => ⟨P.fiber.left, P.base, P.fiber.hom⟩
   map := fun f => ⟨f.fiber.left, f.base, by simp⟩
 
+/-- The inverse functor used to establish the equivalence `grothendieckPrecompFunctorEquivalence`
+between the Grothendieck construction on `CostructuredArrow.functor` and the comma category. -/
 @[simps]
 def commaToGrothendieckPrecompFunctor : Comma L R ⥤ Grothendieck (R ⋙ functor L) where
   obj := fun X => ⟨X.right, mk X.hom⟩
@@ -56,6 +64,9 @@ def commaToGrothendieckPrecompFunctor : Comma L R ⥤ Grothendieck (R ⋙ functo
   map_id X := Grothendieck.ext _ _ rfl (by simp)
   map_comp f g := Grothendieck.ext _ _ rfl (by simp)
 
+/-- For `L : C ⥤ D`, taking the Grothendieck construction of `CostructuredArrow.functor L`
+precomposed with another functor `R : E ⥤ D` results in a category which is equivalent to
+the comma category `Comma L R`. -/
 @[simps]
 def grothendieckPrecompFunctorEquivalence : Grothendieck (R ⋙ functor L) ≌ Comma L R where
   functor := grothendieckPrecompFunctorToComma _ _

--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Functor.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Functor.lean
@@ -9,7 +9,7 @@ import Mathlib.CategoryTheory.Grothendieck
 /-!
 # Structured Arrow Categories as strict functor to Cat
 
-Forming a structured arrow category `StructuredArrow d T` with `d : D` and `T : C ⥤ D` is stictly
+Forming a structured arrow category `StructuredArrow d T` with `d : D` and `T : C ⥤ D` is strictly
 functorial in `S`, inducing a functor `Dᵒᵖ ⥤ Cat`. This file constructs said functor and proves
 that, in the dual case, we can precompose it with another functor `L : E ⥤ D` to obtain a category
 equivalent to `Comma L T`.
@@ -52,15 +52,15 @@ variable (L : C ⥤ D) (R : E ⥤ D)
 the Grothendieck construction on `CostructuredArrow.functor` and the comma category. -/
 @[simps]
 def grothendieckPrecompFunctorToComma : Grothendieck (R ⋙ functor L) ⥤ Comma L R where
-  obj := fun P => ⟨P.fiber.left, P.base, P.fiber.hom⟩
-  map := fun f => ⟨f.fiber.left, f.base, by simp⟩
+  obj P := ⟨P.fiber.left, P.base, P.fiber.hom⟩
+  map f := ⟨f.fiber.left, f.base, by simp⟩
 
 /-- The inverse functor used to establish the equivalence `grothendieckPrecompFunctorEquivalence`
 between the Grothendieck construction on `CostructuredArrow.functor` and the comma category. -/
 @[simps]
 def commaToGrothendieckPrecompFunctor : Comma L R ⥤ Grothendieck (R ⋙ functor L) where
-  obj := fun X => ⟨X.right, mk X.hom⟩
-  map := fun f => ⟨f.right, homMk f.left⟩
+  obj X := ⟨X.right, mk X.hom⟩
+  map f := ⟨f.right, homMk f.left⟩
   map_id X := Grothendieck.ext _ _ rfl (by simp)
   map_comp f g := Grothendieck.ext _ _ rfl (by simp)
 

--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Functor.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Functor.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2024 Jakob von Raumer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jakob von Raumer
+-/
+import Mathlib.CategoryTheory.Comma.StructuredArrow.Basic
+import Mathlib.CategoryTheory.Grothendieck
+
+/-!
+# Structured Arrow Categories as strict functor to Cat
+
+Forming a structured arrow category `StructuredArrow S T` with `S : D` and `T : C ⥤ D` is stictly
+functorial in `S`, inducing a functor `Dᵒᵖ ⥤ Cat`. This file constructs said functor and proves
+that we can precompose it with another functor `L : E ⥤ D` to obtain a category equivalent to
+`Comma L T`.
+-/
+
+namespace CategoryTheory
+
+namespace CostructuredArrow
+
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+
+@[simps]
+def functor (T : C ⥤ D) : D ⥤ Cat where
+  obj d := .of <| CostructuredArrow T d
+  map f := CostructuredArrow.map f
+  map_id d := Functor.ext (fun _ => by simp only [map, Comma.mapRight, Functor.const_obj_obj,
+    Functor.const_map_app, right_eq_id, Cat.of_α, Category.comp_id, Cat.id_obj]; rfl)
+  map_comp f g := Functor.ext (fun _ => by simp [CostructuredArrow.map, Comma.mapRight])
+
+end CostructuredArrow
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Functor.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Functor.lean
@@ -17,18 +17,26 @@ that we can precompose it with another functor `L : E ⥤ D` to obtain a categor
 
 namespace CategoryTheory
 
-namespace CostructuredArrow
-
 universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+
+namespace StructuredArrow
+
+@[simps]
+def functor (T : C ⥤ D) : Dᵒᵖ ⥤ Cat where
+  obj d := .of <| StructuredArrow d.unop T
+  map f := map f.unop
+  map_id d := Functor.ext (fun ⟨_, _, _⟩ => by simp [CostructuredArrow.map, Comma.mapRight])
+  map_comp f g := Functor.ext (fun _ => by simp [CostructuredArrow.map, Comma.mapRight])
+
+namespace CostructuredArrow
 
 @[simps]
 def functor (T : C ⥤ D) : D ⥤ Cat where
   obj d := .of <| CostructuredArrow T d
   map f := CostructuredArrow.map f
-  map_id d := Functor.ext (fun _ => by simp only [map, Comma.mapRight, Functor.const_obj_obj,
-    Functor.const_map_app, right_eq_id, Cat.of_α, Category.comp_id, Cat.id_obj]; rfl)
+  map_id d := Functor.ext (fun ⟨_, _, _⟩ => by simp [CostructuredArrow.map, Comma.mapRight])
   map_comp f g := Functor.ext (fun _ => by simp [CostructuredArrow.map, Comma.mapRight])
 
 end CostructuredArrow


### PR DESCRIPTION
Defines a `StructuredArrow.functor ` which presents the formation of structured arrow categories as a functor to `Cat`. Then proves that taking the Grothendieck construction on this and precomposing it with another functor yields a category equivalent to a comma category.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
