### PR TITLE
[Merged by Bors] - feat: add by how many modules imports grew

### DIFF
--- a/Mathlib/Tactic/Linter/MinImports.lean
+++ b/Mathlib/Tactic/Linter/MinImports.lean
@@ -31,8 +31,8 @@ namespace Mathlib.Linter
 /--
 `ImportState` is the structure keeping track of the data that the `minImports` linter uses.
 * `ig` is the import graph of the current file.
-* `minImps` is the `NameSet` of minimal imports for the file up to the current command to build.
-* `impsSize` is the number of transitive imports for the file up to the current command to build.
+* `minImps` is the `NameSet` of minimal imports to build the file up to the current command.
+* `impsSize` is the number of transitive imports to build the file up to the current command.
 -/
 structure ImportState where
   ig : Option (NameMap (Array Name)) := none
@@ -67,8 +67,8 @@ namespace MinImports
 
 open Mathlib.Command.MinImports
 
-/-- `impsBelow env ms` takes as input an `Environment` `env` and a `NameSet` of module names `ms`.
-It returns the modules that are transitively imported by `ms`.
+/-- `impsBelow ig ms` takes as input an `importGraph` `ig` and a `NameSet` of module names `ms`.
+It returns the modules that are transitively imported by `ms`, using the data in `ig`.
 -/
 def importsBelow (ig : NameMap (Array Name)) (ms : NameSet) : NameSet :=
   (ig.upstreamOf ms).fold (σ := NameSet) (fun _ ↦ ·.insert ·) {}

--- a/Mathlib/Tactic/Linter/MinImports.lean
+++ b/Mathlib/Tactic/Linter/MinImports.lean
@@ -35,8 +35,12 @@ namespace Mathlib.Linter
 * `importSize` is the number of transitive imports to build the file up to the current command.
 -/
 structure ImportState where
+  /-- The transitive closure of the import graph of the current file.  The value is `none` only at
+  initialization time, as the linter immediately sets it to its value for the current file. -/
   transClosure : Option (NameMap NameSet) := none
+  /-- The minimal imports needed to build the file up to the current command. -/
   minImports   : NameSet := {}
+  /-- The number of transitive imports needed to build the file up to the current command. -/
   importSize   : Nat := 0
   deriving Inhabited
 

--- a/test/MinImports.lean
+++ b/test/MinImports.lean
@@ -78,8 +78,6 @@ lemma hi (n : ℕ) : n = n := by extract_goal; rfl
 warning: Imports increased by 398 to
 [Init.Guard, Mathlib.Data.Int.Notation]
 
-Now redundant: []
-
 New imports: [Init.Guard, Mathlib.Data.Int.Notation]
 
 note: this linter can be disabled with `set_option linter.minImports false`
@@ -100,8 +98,6 @@ set_option linter.minImports false in
 warning: Imports increased by 398 to
 [Init.Guard, Mathlib.Data.Int.Notation]
 
-Now redundant: []
-
 New imports: [Init.Guard, Mathlib.Data.Int.Notation]
 
 note: this linter can be disabled with `set_option linter.minImports false`
@@ -120,8 +116,6 @@ set_option linter.minImports true
 warning: Imports increased by 967 to
 [Mathlib.Tactic.Linter.MinImports]
 
-Now redundant: []
-
 New imports: [Mathlib.Tactic.Linter.MinImports]
 
 note: this linter can be disabled with `set_option linter.minImports false`
@@ -133,9 +127,9 @@ note: this linter can be disabled with `set_option linter.minImports false`
 warning: Imports increased by 424 to
 [Mathlib.Tactic.FunProp.Attr, Mathlib.Tactic.NormNum.Basic]
 
-Now redundant: [Mathlib.Tactic.Linter.MinImports]
-
 New imports: [Mathlib.Tactic.FunProp.Attr, Mathlib.Tactic.NormNum.Basic]
+
+Now redundant: [Mathlib.Tactic.Linter.MinImports]
 
 note: this linter can be disabled with `set_option linter.minImports false`
 -/

--- a/test/MinImports.lean
+++ b/test/MinImports.lean
@@ -75,8 +75,13 @@ import Mathlib.Data.Nat.Notation
 lemma hi (n : ℕ) : n = n := by extract_goal; rfl
 
 /--
-warning: Imports increased to
+warning: Imports increased by 398 to
 [Init.Guard, Mathlib.Data.Int.Notation]
+
+Now redundant: []
+
+New imports: [Init.Guard, Mathlib.Data.Int.Notation]
+
 note: this linter can be disabled with `set_option linter.minImports false`
 -/
 #guard_msgs in
@@ -92,8 +97,13 @@ set_option linter.minImports false in
 #reset_min_imports
 
 /--
-warning: Imports increased to
+warning: Imports increased by 398 to
 [Init.Guard, Mathlib.Data.Int.Notation]
+
+Now redundant: []
+
+New imports: [Init.Guard, Mathlib.Data.Int.Notation]
+
 note: this linter can be disabled with `set_option linter.minImports false`
 -/
 #guard_msgs in
@@ -107,16 +117,26 @@ set_option linter.minImports true in
 set_option linter.minImports true
 
 /--
-warning: Imports increased to
+warning: Imports increased by 967 to
 [Mathlib.Tactic.Linter.MinImports]
+
+Now redundant: []
+
+New imports: [Mathlib.Tactic.Linter.MinImports]
+
 note: this linter can be disabled with `set_option linter.minImports false`
 -/
 #guard_msgs in
 #reset_min_imports
 
 /--
-warning: Imports increased to
+warning: Imports increased by 424 to
 [Mathlib.Tactic.FunProp.Attr, Mathlib.Tactic.NormNum.Basic]
+
+Now redundant: [Mathlib.Tactic.Linter.MinImports]
+
+New imports: [Mathlib.Tactic.FunProp.Attr, Mathlib.Tactic.NormNum.Basic]
+
 note: this linter can be disabled with `set_option linter.minImports false`
 -/
 #guard_msgs in


### PR DESCRIPTION
This PR makes the `minImports` linter report more information:
* the number of increase imports,
* which previously minimal imports became redundant,
* which new minimal imports should be added.

Prompted by [this Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/minImports.20linter.20request).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
