### PR TITLE
[Merged by Bors] - chore: split Data.Set.Basic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2688,6 +2688,7 @@ import Mathlib.Data.Set.Sigma
 import Mathlib.Data.Set.Subset
 import Mathlib.Data.Set.Subsingleton
 import Mathlib.Data.Set.Sups
+import Mathlib.Data.Set.SymmDiff
 import Mathlib.Data.Set.UnionLift
 import Mathlib.Data.SetLike.Basic
 import Mathlib.Data.SetLike.Fintype

--- a/Mathlib/Algebra/Group/Center.lean
+++ b/Mathlib/Algebra/Group/Center.lean
@@ -5,8 +5,8 @@ Authors: Eric Wieser, Jireh Loreaux
 -/
 import Mathlib.Algebra.Group.Commute.Units
 import Mathlib.Algebra.Group.Invertible.Basic
-import Mathlib.Data.Set.Basic
 import Mathlib.Logic.Basic
+import Mathlib.Data.Set.Basic
 
 /-!
 # Centers of magmas and semigroups

--- a/Mathlib/Algebra/Group/Indicator.lean
+++ b/Mathlib/Algebra/Group/Indicator.lean
@@ -5,6 +5,7 @@ Authors: Zhouhang Zhou
 -/
 import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.Support
+import Mathlib.Data.Set.SymmDiff
 
 /-!
 # Indicator function

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.Multiset.FinsetOps
 import Mathlib.Logic.Equiv.Set
 import Mathlib.Order.Directed
 import Mathlib.Order.Interval.Set.Basic
+import Mathlib.Data.Set.SymmDiff
 
 /-!
 # Finite sets

--- a/Mathlib/Data/PEquiv.lean
+++ b/Mathlib/Data/PEquiv.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import Mathlib.Data.Option.Basic
-import Mathlib.Data.Set.Basic
 import Batteries.Tactic.Congr
+import Mathlib.Data.Set.Basic
+import Mathlib.Tactic.Contrapose
 
 /-!
 

--- a/Mathlib/Data/PNat/Basic.lean
+++ b/Mathlib/Data/PNat/Basic.lean
@@ -5,7 +5,6 @@ Authors: Mario Carneiro, Ralf Stephan, Neil Strickland, Ruben Van de Velde
 -/
 import Mathlib.Data.PNat.Equiv
 import Mathlib.Algebra.Order.Ring.Nat
-import Mathlib.Data.Set.SymmDiff
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.Order.Positive.Ring
 import Mathlib.Order.Hom.Basic

--- a/Mathlib/Data/PNat/Basic.lean
+++ b/Mathlib/Data/PNat/Basic.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro, Ralf Stephan, Neil Strickland, Ruben Van de Velde
 -/
 import Mathlib.Data.PNat.Equiv
 import Mathlib.Algebra.Order.Ring.Nat
-import Mathlib.Data.Set.Basic
+import Mathlib.Data.Set.SymmDiff
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.Order.Positive.Ring
 import Mathlib.Order.Hom.Basic

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -6,10 +6,11 @@ Authors: Jeremy Avigad, Leonardo de Moura
 import Mathlib.Algebra.Group.ZeroOne
 import Mathlib.Data.Set.Operations
 import Mathlib.Order.Basic
-import Mathlib.Order.SymmDiff
+import Mathlib.Order.BooleanAlgebra
 import Mathlib.Tactic.Tauto
 import Mathlib.Tactic.ByContra
 import Mathlib.Util.Delaborators
+import Mathlib.Tactic.Lift
 
 /-!
 # Basic properties of sets
@@ -1694,43 +1695,6 @@ theorem subset_pair_iff_eq {x y : α} : s ⊆ {x, y} ↔ s = ∅ ∨ s = {x} ∨
 theorem Nonempty.subset_pair_iff_eq (hs : s.Nonempty) :
     s ⊆ {a, b} ↔ s = {a} ∨ s = {b} ∨ s = {a, b} := by
   rw [Set.subset_pair_iff_eq, or_iff_right]; exact hs.ne_empty
-
-/-! ### Symmetric difference -/
-
-section
-
-open scoped symmDiff
-
-theorem mem_symmDiff : a ∈ s ∆ t ↔ a ∈ s ∧ a ∉ t ∨ a ∈ t ∧ a ∉ s :=
-  Iff.rfl
-
-protected theorem symmDiff_def (s t : Set α) : s ∆ t = s \ t ∪ t \ s :=
-  rfl
-
-theorem symmDiff_subset_union : s ∆ t ⊆ s ∪ t :=
-  @symmDiff_le_sup (Set α) _ _ _
-
-@[simp]
-theorem symmDiff_eq_empty : s ∆ t = ∅ ↔ s = t :=
-  symmDiff_eq_bot
-
-@[simp]
-theorem symmDiff_nonempty : (s ∆ t).Nonempty ↔ s ≠ t :=
-  nonempty_iff_ne_empty.trans symmDiff_eq_empty.not
-
-theorem inter_symmDiff_distrib_left (s t u : Set α) : s ∩ t ∆ u = (s ∩ t) ∆ (s ∩ u) :=
-  inf_symmDiff_distrib_left _ _ _
-
-theorem inter_symmDiff_distrib_right (s t u : Set α) : s ∆ t ∩ u = (s ∩ u) ∆ (t ∩ u) :=
-  inf_symmDiff_distrib_right _ _ _
-
-theorem subset_symmDiff_union_symmDiff_left (h : Disjoint s t) : u ⊆ s ∆ u ∪ t ∆ u :=
-  h.le_symmDiff_sup_symmDiff_left
-
-theorem subset_symmDiff_union_symmDiff_right (h : Disjoint t u) : s ⊆ s ∆ t ∪ s ∆ u :=
-  h.le_symmDiff_sup_symmDiff_right
-
-end
 
 /-! ### Powerset -/
 

--- a/Mathlib/Data/Set/Enumerate.lean
+++ b/Mathlib/Data/Set/Enumerate.lean
@@ -5,8 +5,8 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Nat
-import Mathlib.Data.Set.Basic
 import Mathlib.Tactic.Common
+import Mathlib.Data.Set.Basic
 
 /-!
 # Set enumeration

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -8,6 +8,7 @@ import Mathlib.Tactic.Use
 import Batteries.Tactic.Congr
 import Mathlib.Order.TypeTags
 import Mathlib.Data.Option.Basic
+import Mathlib.Data.Set.SymmDiff
 
 /-!
 # Images and preimages of sets

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -8,7 +8,7 @@ import Mathlib.Tactic.Use
 import Batteries.Tactic.Congr
 import Mathlib.Order.TypeTags
 import Mathlib.Data.Option.Basic
-import Mathlib.Data.Set.SymmDiff
+import Mathlib.Order.SymmDiff
 
 /-!
 # Images and preimages of sets

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -8,7 +8,7 @@ import Mathlib.Tactic.Use
 import Batteries.Tactic.Congr
 import Mathlib.Order.TypeTags
 import Mathlib.Data.Option.Basic
-import Mathlib.Order.SymmDiff
+import Mathlib.Data.Set.SymmDiff
 
 /-!
 # Images and preimages of sets

--- a/Mathlib/Data/Set/SymmDiff.lean
+++ b/Mathlib/Data/Set/SymmDiff.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura
+-/
+import Mathlib.Algebra.Group.ZeroOne
+import Mathlib.Data.Set.Operations
+import Mathlib.Order.Basic
+import Mathlib.Order.BooleanAlgebra
+import Mathlib.Logic.Equiv.Basic
+import Mathlib.Tactic.Tauto
+import Mathlib.Tactic.ByContra
+import Mathlib.Util.Delaborators
+import Mathlib.Order.SymmDiff
+import Mathlib.Data.Set.Basic
+
+/-! # Symmetric differences of sets -/
+
+namespace Set
+
+universe u v
+variable {α : Type u} {β : Type v} {a b : α} {s s₁ s₂ t t₁ t₂ u : Set α}
+
+open scoped symmDiff
+
+theorem mem_symmDiff : a ∈ s ∆ t ↔ a ∈ s ∧ a ∉ t ∨ a ∈ t ∧ a ∉ s :=
+  Iff.rfl
+
+protected theorem symmDiff_def (s t : Set α) : s ∆ t = s \ t ∪ t \ s :=
+  rfl
+
+theorem symmDiff_subset_union : s ∆ t ⊆ s ∪ t :=
+  @symmDiff_le_sup (Set α) _ _ _
+
+@[simp]
+theorem symmDiff_eq_empty : s ∆ t = ∅ ↔ s = t :=
+  symmDiff_eq_bot
+
+@[simp]
+theorem symmDiff_nonempty : (s ∆ t).Nonempty ↔ s ≠ t :=
+  nonempty_iff_ne_empty.trans symmDiff_eq_empty.not
+
+theorem inter_symmDiff_distrib_left (s t u : Set α) : s ∩ t ∆ u = (s ∩ t) ∆ (s ∩ u) :=
+  inf_symmDiff_distrib_left _ _ _
+
+theorem inter_symmDiff_distrib_right (s t u : Set α) : s ∆ t ∩ u = (s ∩ u) ∆ (t ∩ u) :=
+  inf_symmDiff_distrib_right _ _ _
+
+theorem subset_symmDiff_union_symmDiff_left (h : Disjoint s t) : u ⊆ s ∆ u ∪ t ∆ u :=
+  h.le_symmDiff_sup_symmDiff_left
+
+theorem subset_symmDiff_union_symmDiff_right (h : Disjoint t u) : s ⊆ s ∆ t ∪ s ∆ u :=
+  h.le_symmDiff_sup_symmDiff_right
+
+end Set

--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -3,9 +3,9 @@ Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Data.Set.Basic
 import Mathlib.Tactic.Monotonicity.Attr
 import Mathlib.Tactic.SetLike
+import Mathlib.Data.Set.Basic
 
 /-!
 # Typeclass for types with a set-like extensionality property

--- a/Mathlib/Order/Filter/Defs.lean
+++ b/Mathlib/Order/Filter/Defs.lean
@@ -3,9 +3,9 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jeremy Avigad
 -/
-import Mathlib.Data.Set.Basic
 import Mathlib.Order.SetNotation
 import Mathlib.Order.Bounds.Defs
+import Mathlib.Data.Set.Basic
 
 /-!
 # Definitions about filters

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy
 import Mathlib.Order.MinMax
 import Mathlib.Data.Set.Subsingleton
 import Mathlib.Tactic.Says
+import Mathlib.Tactic.Contrapose
 
 /-!
 # Intervals

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 -/
-import Mathlib.Data.Set.Basic
+import Mathlib.Data.Set.SymmDiff
 import Mathlib.Order.SuccPred.Relation
 import Mathlib.Topology.Irreducible
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -219,7 +219,8 @@
   "Mathlib.Tactic.ProxyType": ["Mathlib.Logic.Equiv.Defs"],
   "Mathlib.Tactic.ProdAssoc": ["Mathlib.Logic.Equiv.Defs"],
   "Mathlib.Tactic.Positivity.Finset":
-  ["Mathlib.Algebra.Order.BigOperators.Group.Finset", "Mathlib.Data.Finset.Density"],
+  ["Mathlib.Algebra.Order.BigOperators.Group.Finset",
+   "Mathlib.Data.Finset.Density"],
   "Mathlib.Tactic.Positivity.Basic":
   ["Mathlib.Algebra.GroupPower.Order",
    "Mathlib.Algebra.Order.Group.PosPart",
@@ -350,7 +351,8 @@
   "Mathlib.Deprecated.MinMax": ["Mathlib.Order.MinMax"],
   "Mathlib.Deprecated.ByteArray": ["Batteries.Data.ByteSubarray"],
   "Mathlib.Data.Vector.Basic": ["Mathlib.Control.Applicative"],
-  "Mathlib.Data.Set.Image": ["Batteries.Tactic.Congr"],
+  "Mathlib.Data.Set.Image":
+  ["Batteries.Tactic.Congr", "Mathlib.Data.Set.SymmDiff"],
   "Mathlib.Data.Seq.Parallel": ["Mathlib.Init.Data.Prod"],
   "Mathlib.Data.PEquiv": ["Batteries.Tactic.Congr"],
   "Mathlib.Data.Ordmap.Ordnode": ["Mathlib.Data.Option.Basic"],


### PR DESCRIPTION
Delay imports of `Data.Order.SymmDiff`, as many things downstream don't need it.