### PR TITLE
[Merged by Bors] - chore: remove some `maxHeartbeats` bumps that are no longer needed

### DIFF
--- a/Mathlib/CategoryTheory/GradedObject/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Trifunctor.lean
@@ -215,11 +215,6 @@ noncomputable def mapTrifunctorMapFunctorObj (X₁ : GradedObject I₁ C₁)
       NatTrans.id_app, categoryOfGradedObjects_comp, Functor.map_comp, NatTrans.comp_app,
       id_comp, assoc, ι_mapTrifunctorMapMap_assoc]
 
-#adaptation_note
-/--
-At nightly-2024-08-08 we needed to significantly increase the maxHeartbeats here.
--/
-set_option maxHeartbeats 800000 in
 /-- Given a trifunctor `F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄` and a map `p : I₁ × I₂ × I₃ → J`,
 this is the functor
 `GradedObject I₁ C₁ ⥤ GradedObject I₂ C₂ ⥤ GradedObject I₃ C₃ ⥤ GradedObject J C₄`

--- a/Mathlib/CategoryTheory/Idempotents/FunctorExtension.lean
+++ b/Mathlib/CategoryTheory/Idempotents/FunctorExtension.lean
@@ -106,11 +106,6 @@ def functorExtension₁CompWhiskeringLeftToKaroubiIso :
       (fun {X Y} f => by aesop_cat))
     (by aesop_cat)
 
-#adaptation_note
-/--
-At nightly-2024-08-08 we needed to increase the maxHeartbeats here.
--/
-set_option maxHeartbeats 400000 in
 /-- The counit isomorphism of the equivalence `(C ⥤ Karoubi D) ≌ (Karoubi C ⥤ Karoubi D)`. -/
 def KaroubiUniversal₁.counitIso :
     (whiskeringLeft C (Karoubi C) (Karoubi D)).obj (toKaroubi C) ⋙ functorExtension₁ C D ≅ 𝟭 _ :=

--- a/Mathlib/CategoryTheory/Linear/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Linear/FunctorCategory.lean
@@ -21,11 +21,6 @@ open CategoryTheory.Limits Linear
 variable {R : Type*} [Semiring R]
 variable {C D : Type*} [Category C] [Category D] [Preadditive D] [Linear R D]
 
-#adaptation_note
-/--
-At nightly-2024-08-08 we needed to significantly increase the maxHeartbeats here.
--/
-set_option maxHeartbeats 800000 in
 instance functorCategoryLinear : Linear R (C ⥤ D) where
   homModule F G :=
     { smul := fun r α =>

--- a/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
@@ -109,10 +109,6 @@ def toComon_ : Bimon_ C ⥤ Comon_ C := (Mon_.forgetMonoidal C).toOplaxMonoidalF
 @[simp]
 theorem toComon_forget : toComon_ C ⋙ Comon_.forget C = forget C := rfl
 
--- TODO: the `set_option` is not strictly necessary, but the declaration is just a heartbeat
--- away from using too many heartbeats.  Squeezing `(d)simp` improves the situation, but pulls
--- out too many lemmas
-set_option maxHeartbeats 400000 in
 /-- The object level part of the forward direction of `Comon_ (Mon_ C) ≌ Mon_ (Comon_ C)` -/
 def toMon_Comon_obj (M : Bimon_ C) : Mon_ (Comon_ C) where
   X := (toComon_ C).obj M

--- a/Mathlib/CategoryTheory/Triangulated/Functor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Functor.lean
@@ -71,11 +71,6 @@ section Additive
 
 variable [Preadditive C] [Preadditive D] [F.Additive]
 
-#adaptation_note
-/--
-At nightly-2024-08-08 we needed to increase the maxHeartbeats here.
--/
-set_option maxHeartbeats 400000 in
 /-- The functor `F.mapTriangle` commutes with the shift. -/
 noncomputable def mapTriangleCommShiftIso (n : ℤ) :
     Triangle.shiftFunctor C n ⋙ F.mapTriangle ≅ F.mapTriangle ⋙ Triangle.shiftFunctor D n :=


### PR DESCRIPTION
I was looking at the tech debt counters and these caught my eye. Went with a very naïve approach of replacing all `set_option maxHeartbeats` calls with `countHeartbeats`, then deleted all that are comfortably below the default limit.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
