### PR TITLE
[Merged by Bors] - feat(Topology/ContinuousMap/*): add some simp lemmas

### DIFF
--- a/Mathlib/Topology/ContinuousMap/Algebra.lean
+++ b/Mathlib/Topology/ContinuousMap/Algebra.lean
@@ -815,7 +815,7 @@ instance instSMul' : SMul C(α, R) C(α, M) :=
 
 /-- Evaluation of a scalar-valued continuous map multiplying a vector-valued one
 (as opposed to `ContinuousMap.smul_apply` which is multiplication by a constant scalar). -/
--- (this doesn't need to be @[simp] since it can be derived from `coe_smul'` and `Pi.smul_apply`)
+-- (this doesn't need to be @[simp] since it can be derived from `coe_smul'` and `Pi.smul_apply'`)
 lemma smul_apply' (f : C(α, R)) (g : C(α, M)) (x : α) :
     (f • g) x = f x • g x :=
   rfl

--- a/Mathlib/Topology/ContinuousMap/Algebra.lean
+++ b/Mathlib/Topology/ContinuousMap/Algebra.lean
@@ -797,17 +797,31 @@ section ModuleOverContinuousFunctions
 If `M` is a module over `R`, then we show that the space of continuous functions from `α` to `M`
 is naturally a module over the ring of continuous functions from `α` to `R`. -/
 
-
 namespace ContinuousMap
 
-instance instSMul' {α : Type*} [TopologicalSpace α] {R : Type*} [Semiring R] [TopologicalSpace R]
-    {M : Type*} [TopologicalSpace M] [AddCommMonoid M] [Module R M] [ContinuousSMul R M] :
-    SMul C(α, R) C(α, M) :=
+variable
+  {α : Type*} [TopologicalSpace α]
+  {R : Type*} [Semiring R] [TopologicalSpace R]
+  {M : Type*} [TopologicalSpace M] [AddCommMonoid M] [Module R M] [ContinuousSMul R M]
+
+instance instSMul' : SMul C(α, R) C(α, M) :=
   ⟨fun f g => ⟨fun x => f x • g x, Continuous.smul f.2 g.2⟩⟩
 
-instance module' {α : Type*} [TopologicalSpace α] (R : Type*) [Semiring R] [TopologicalSpace R]
-    [TopologicalSemiring R] (M : Type*) [TopologicalSpace M] [AddCommMonoid M] [ContinuousAdd M]
-    [Module R M] [ContinuousSMul R M] : Module C(α, R) C(α, M) where
+/-- Coercion to a function for a scalar-valued continuous map multiplying a vector-valued one
+(as opposed to `ContinuousMap.coe_smul` which is multiplication by a constant scalar). -/
+@[simp] lemma coe_smul' (f : C(α, R)) (g : C(α, M)) :
+    ⇑(f • g) = ⇑f • ⇑g :=
+  rfl
+
+/-- Evaluation of a scalar-valued continuous map multiplying a vector-valued one
+(as opposed to `ContinuousMap.smul_apply` which is multiplication by a constant scalar). -/
+-- (this doesn't need to be @[simp] since it can be derived from `coe_smul'` and `Pi.smul_apply`)
+lemma smul_apply' (f : C(α, R)) (g : C(α, M)) (x : α) :
+    (f • g) x = f x • g x :=
+  rfl
+
+instance module' [TopologicalSemiring R] [ContinuousAdd M] :
+    Module C(α, R) C(α, M) where
   smul := (· • ·)
   smul_add c f g := by ext x; exact smul_add (c x) (f x) (g x)
   add_smul c₁ c₂ f := by ext x; exact add_smul (c₁ x) (c₂ x) (f x)

--- a/Mathlib/Topology/ContinuousMap/Compact.lean
+++ b/Mathlib/Topology/ContinuousMap/Compact.lean
@@ -337,6 +337,12 @@ theorem linearIsometryBoundedOfCompact_of_compact_toEquiv :
 
 end
 
+@[simp] lemma norm_smul_const {R β : Type*} [NormedAddCommGroup β] [NormedDivisionRing R]
+    [Module R β] [BoundedSMul R β] (f : C(α, R)) (b : β) :
+    ‖f • const α b‖ = ‖f‖ * ‖b‖ := by
+  simp_rw [norm_eq_iSup_norm, ← coe_nnnorm, ← coe_iSup, ← NNReal.coe_mul, iSup_mul, smul_apply',
+    const_apply, nnnorm_smul]
+
 section
 
 variable {𝕜 : Type*} {γ : Type*} [NormedField 𝕜] [SeminormedRing γ] [NormedAlgebra 𝕜 γ]

--- a/Mathlib/Topology/ContinuousMap/Compact.lean
+++ b/Mathlib/Topology/ContinuousMap/Compact.lean
@@ -222,6 +222,9 @@ theorem apply_le_norm (f : C(α, ℝ)) (x : α) : f x ≤ ‖f‖ :=
 theorem neg_norm_le_apply (f : C(α, ℝ)) (x : α) : -‖f‖ ≤ f x :=
   le_trans (neg_le_neg (f.norm_coe_le_norm x)) (neg_le.mp (neg_le_abs (f x)))
 
+theorem nnnorm_eq_iSup_nnnorm : ‖f‖₊ = ⨆ x : α, ‖f x‖₊ :=
+  (mkOfCompact f).nnnorm_eq_iSup_nnnorm
+
 theorem norm_eq_iSup_norm : ‖f‖ = ⨆ x : α, ‖f x‖ :=
   (mkOfCompact f).norm_eq_iSup_norm
 
@@ -337,11 +340,15 @@ theorem linearIsometryBoundedOfCompact_of_compact_toEquiv :
 
 end
 
+@[simp] lemma nnnorm_smul_const {R β : Type*} [NormedAddCommGroup β] [NormedDivisionRing R]
+    [Module R β] [BoundedSMul R β] (f : C(α, R)) (b : β) :
+    ‖f • const α b‖₊ = ‖f‖₊ * ‖b‖₊ := by
+  simp only [nnnorm_eq_iSup_nnnorm, smul_apply', const_apply, nnnorm_smul, iSup_mul]
+
 @[simp] lemma norm_smul_const {R β : Type*} [NormedAddCommGroup β] [NormedDivisionRing R]
     [Module R β] [BoundedSMul R β] (f : C(α, R)) (b : β) :
     ‖f • const α b‖ = ‖f‖ * ‖b‖ := by
-  simp_rw [norm_eq_iSup_norm, ← coe_nnnorm, ← coe_iSup, ← NNReal.coe_mul, iSup_mul, smul_apply',
-    const_apply, nnnorm_smul]
+  simp only [← coe_nnnorm, NNReal.coe_mul, nnnorm_smul_const]
 
 section
 

--- a/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
+++ b/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
@@ -96,6 +96,13 @@ theorem coe_toContinuousMap (f : C₀(α, β)) : (f.toContinuousMap : α → β)
 theorem ext {f g : C₀(α, β)} (h : ∀ x, f x = g x) : f = g :=
   DFunLike.ext _ _ h
 
+@[simp]
+lemma coe_mk {f : α → β} (hf : Continuous f) (hf' : Tendsto f (cocompact α) (𝓝 0)) :
+    { toFun := f,
+      continuous_toFun := hf,
+      zero_at_infty' := hf' : ZeroAtInftyContinuousMap α β} = f :=
+  rfl
+
 /-- Copy of a `ZeroAtInftyContinuousMap` with a new `toFun` equal to the old one. Useful
 to fix definitional equalities. -/
 protected def copy (f : C₀(α, β)) (f' : α → β) (h : f' = f) : C₀(α, β) where


### PR DESCRIPTION
This PR adds some easy lemmas about `ContinuousMap` and its relatives, intended to be used by `simp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
