### PR TITLE
[Merged by Bors] - chore: delay importing ultrafilters

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4785,6 +4785,7 @@ import Mathlib.Topology.Defs.Basic
 import Mathlib.Topology.Defs.Filter
 import Mathlib.Topology.Defs.Induced
 import Mathlib.Topology.Defs.Sequences
+import Mathlib.Topology.Defs.Ultrafilter
 import Mathlib.Topology.DenseEmbedding
 import Mathlib.Topology.DerivedSet
 import Mathlib.Topology.DiscreteQuotient
@@ -4989,6 +4990,7 @@ import Mathlib.Topology.Spectral.Hom
 import Mathlib.Topology.StoneCech
 import Mathlib.Topology.Support
 import Mathlib.Topology.TietzeExtension
+import Mathlib.Topology.Ultrafilter
 import Mathlib.Topology.UniformSpace.AbsoluteValue
 import Mathlib.Topology.UniformSpace.AbstractCompletion
 import Mathlib.Topology.UniformSpace.Ascoli

--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -6,6 +6,8 @@ Authors: Johannes Hölzl, Mario Carneiro, Jeremy Avigad
 import Mathlib.Algebra.Group.Support
 import Mathlib.Order.Filter.Lift
 import Mathlib.Topology.Defs.Filter
+import Mathlib.Topology.Defs.Basic
+import Mathlib.Data.Set.Lattice
 
 /-!
 # Basic theory of topological spaces.
@@ -941,13 +943,6 @@ theorem ClusterPt.of_inf_right {f g : Filter X} (H : ClusterPt x <| f ⊓ g) :
     ClusterPt x g :=
   H.mono inf_le_right
 
-theorem Ultrafilter.clusterPt_iff {f : Ultrafilter X} : ClusterPt x f ↔ ↑f ≤ 𝓝 x :=
-  ⟨f.le_of_inf_neBot', fun h => ClusterPt.of_le_nhds h⟩
-
-theorem clusterPt_iff_ultrafilter {f : Filter X} : ClusterPt x f ↔
-    ∃ u : Ultrafilter X, u ≤ f ∧ u ≤ 𝓝 x := by
-  simp_rw [ClusterPt, ← le_inf_iff, exists_ultrafilter_iff, inf_comm]
-
 section MapClusterPt
 
 variable {F : Filter α} {u : α → X} {x : X}
@@ -977,11 +972,6 @@ theorem Filter.HasBasis.mapClusterPt_iff_frequently {ι : Sort*} {p : ι → Pro
 
 theorem mapClusterPt_iff : MapClusterPt x F u ↔ ∀ s ∈ 𝓝 x, ∃ᶠ a in F, u a ∈ s :=
   (𝓝 x).basis_sets.mapClusterPt_iff_frequently
-
-theorem mapClusterPt_iff_ultrafilter :
-    MapClusterPt x F u ↔ ∃ U : Ultrafilter α, U ≤ F ∧ Tendsto u U (𝓝 x) := by
-  simp_rw [MapClusterPt, ClusterPt, ← Filter.push_pull', map_neBot_iff, tendsto_iff_comap,
-    ← le_inf_iff, exists_ultrafilter_iff, inf_comm]
 
 theorem mapClusterPt_comp {φ : α → β} {u : β → X} :
     MapClusterPt x F (u ∘ φ) ↔ MapClusterPt x (map φ F) u := Iff.rfl
@@ -1084,10 +1074,6 @@ theorem isOpen_iff_mem_nhds : IsOpen s ↔ ∀ x ∈ s, s ∈ 𝓝 x :=
 theorem isOpen_iff_eventually : IsOpen s ↔ ∀ x, x ∈ s → ∀ᶠ y in 𝓝 x, y ∈ s :=
   isOpen_iff_mem_nhds
 
-theorem isOpen_iff_ultrafilter :
-    IsOpen s ↔ ∀ x ∈ s, ∀ (l : Ultrafilter X), ↑l ≤ 𝓝 x → s ∈ l := by
-  simp_rw [isOpen_iff_mem_nhds, ← mem_iff_ultrafilter]
-
 theorem isOpen_singleton_iff_nhds_eq_pure (x : X) : IsOpen ({x} : Set X) ↔ 𝓝 x = pure x := by
   constructor
   · intro h
@@ -1098,8 +1084,8 @@ theorem isOpen_singleton_iff_nhds_eq_pure (x : X) : IsOpen ({x} : Set X) ↔ �
     simp [isOpen_iff_nhds, h]
 
 theorem isOpen_singleton_iff_punctured_nhds (x : X) : IsOpen ({x} : Set X) ↔ 𝓝[≠] x = ⊥ := by
-  rw [isOpen_singleton_iff_nhds_eq_pure, nhdsWithin, ← mem_iff_inf_principal_compl, ← le_pure_iff,
-    nhds_neBot.le_pure_iff]
+  rw [isOpen_singleton_iff_nhds_eq_pure, nhdsWithin, ← mem_iff_inf_principal_compl, ← le_pure_iff]
+  sorry
 
 theorem mem_closure_iff_frequently : x ∈ closure s ↔ ∃ᶠ x in 𝓝 x, x ∈ s := by
   rw [Filter.Frequently, Filter.Eventually, ← mem_interior_iff_mem_nhds,
@@ -1203,27 +1189,18 @@ theorem clusterPt_iff_lift'_closure {F : Filter X} :
 
 theorem clusterPt_iff_lift'_closure' {F : Filter X} :
     ClusterPt x F ↔ (F.lift' closure ⊓ pure x).NeBot := by
-  rw [clusterPt_iff_lift'_closure, ← Ultrafilter.coe_pure, inf_comm, Ultrafilter.inf_neBot_iff]
+  rw [clusterPt_iff_lift'_closure, inf_comm]
+  sorry
 
 @[simp]
 theorem clusterPt_lift'_closure_iff {F : Filter X} :
     ClusterPt x (F.lift' closure) ↔ ClusterPt x F := by
   simp [clusterPt_iff_lift'_closure, lift'_lift'_assoc (monotone_closure X) (monotone_closure X)]
 
-/-- `x` belongs to the closure of `s` if and only if some ultrafilter
-  supported on `s` converges to `x`. -/
-theorem mem_closure_iff_ultrafilter :
-    x ∈ closure s ↔ ∃ u : Ultrafilter X, s ∈ u ∧ ↑u ≤ 𝓝 x := by
-  simp [closure_eq_cluster_pts, ClusterPt, ← exists_ultrafilter_iff, and_comm]
-
 theorem isClosed_iff_clusterPt : IsClosed s ↔ ∀ a, ClusterPt a (𝓟 s) → a ∈ s :=
   calc
     IsClosed s ↔ closure s ⊆ s := closure_subset_iff_isClosed.symm
     _ ↔ ∀ a, ClusterPt a (𝓟 s) → a ∈ s := by simp only [subset_def, mem_closure_iff_clusterPt]
-
-theorem isClosed_iff_ultrafilter : IsClosed s ↔
-    ∀ x, ∀ u : Ultrafilter X, ↑u ≤ 𝓝 x → s ∈ u → x ∈ s := by
-  simp [isClosed_iff_clusterPt, ClusterPt, ← exists_ultrafilter_iff]
 
 theorem isClosed_iff_nhds :
     IsClosed s ↔ ∀ x, (∀ U ∈ 𝓝 x, (U ∩ s).Nonempty) → x ∈ s := by
@@ -1525,14 +1502,6 @@ theorem mem_closure_image (hf : ContinuousAt f x)
     (hx : x ∈ closure s) : f x ∈ closure (f '' s) :=
   mem_closure_of_frequently_of_tendsto
     ((mem_closure_iff_frequently.1 hx).mono fun _ => mem_image_of_mem _) hf
-
-theorem continuousAt_iff_ultrafilter :
-    ContinuousAt f x ↔ ∀ g : Ultrafilter X, ↑g ≤ 𝓝 x → Tendsto f g (𝓝 (f x)) :=
-  tendsto_iff_ultrafilter f (𝓝 x) (𝓝 (f x))
-
-theorem continuous_iff_ultrafilter :
-    Continuous f ↔ ∀ (x) (g : Ultrafilter X), ↑g ≤ 𝓝 x → Tendsto f g (𝓝 (f x)) := by
-  simp only [continuous_iff_continuousAt, continuousAt_iff_ultrafilter]
 
 theorem Continuous.closure_preimage_subset (hf : Continuous f) (t : Set Y) :
     closure (f ⁻¹' t) ⊆ f ⁻¹' closure t := by

--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -8,6 +8,7 @@ import Mathlib.Order.Filter.Lift
 import Mathlib.Topology.Defs.Filter
 import Mathlib.Topology.Defs.Basic
 import Mathlib.Data.Set.Lattice
+import Mathlib.Order.Filter.AtTopBot
 
 /-!
 # Basic theory of topological spaces.

--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -1085,8 +1085,9 @@ theorem isOpen_singleton_iff_nhds_eq_pure (x : X) : IsOpen ({x} : Set X) ↔ �
     simp [isOpen_iff_nhds, h]
 
 theorem isOpen_singleton_iff_punctured_nhds (x : X) : IsOpen ({x} : Set X) ↔ 𝓝[≠] x = ⊥ := by
-  rw [isOpen_singleton_iff_nhds_eq_pure, nhdsWithin, ← mem_iff_inf_principal_compl, ← le_pure_iff]
-  sorry
+  rw [isOpen_singleton_iff_nhds_eq_pure, nhdsWithin, ← mem_iff_inf_principal_compl,
+      le_antisymm_iff]
+  simp [pure_le_nhds x]
 
 theorem mem_closure_iff_frequently : x ∈ closure s ↔ ∃ᶠ x in 𝓝 x, x ∈ s := by
   rw [Filter.Frequently, Filter.Eventually, ← mem_interior_iff_mem_nhds,
@@ -1191,7 +1192,12 @@ theorem clusterPt_iff_lift'_closure {F : Filter X} :
 theorem clusterPt_iff_lift'_closure' {F : Filter X} :
     ClusterPt x F ↔ (F.lift' closure ⊓ pure x).NeBot := by
   rw [clusterPt_iff_lift'_closure, inf_comm]
-  sorry
+  constructor
+  · intro h
+    simp [h, pure_neBot]
+  · intro h U hU
+    simp_rw [← forall_mem_nonempty_iff_neBot, mem_inf_iff] at h
+    simpa using h ({x} ∩ U) ⟨{x}, by simp, U, hU, rfl⟩
 
 @[simp]
 theorem clusterPt_lift'_closure_iff {F : Filter X} :

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -9,6 +9,7 @@ import Mathlib.Data.Set.Accumulate
 import Mathlib.Topology.Bornology.Basic
 import Mathlib.Topology.LocallyFinite
 import Mathlib.Topology.Ultrafilter
+import Mathlib.Topology.Defs.Ultrafilter
 /-!
 # Compact sets and compact spaces
 

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -8,6 +8,7 @@ import Mathlib.Topology.Bases
 import Mathlib.Data.Set.Accumulate
 import Mathlib.Topology.Bornology.Basic
 import Mathlib.Topology.LocallyFinite
+import Mathlib.Topology.Ultrafilter
 /-!
 # Compact sets and compact spaces
 

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Finset.Piecewise
 import Mathlib.Order.Filter.Curry
 import Mathlib.Topology.Maps.Basic
 import Mathlib.Topology.NhdsSet
+import Mathlib.Order.Filter.Cofinite
 
 /-!
 # Constructions of new topological spaces from old ones

--- a/Mathlib/Topology/Defs/Filter.lean
+++ b/Mathlib/Topology/Defs/Filter.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Jeremy Avigad
 -/
 import Mathlib.Topology.Defs.Basic
-import Mathlib.Order.Filter.Ultrafilter
+import Mathlib.Order.Filter.Cofinite
+import Mathlib.Order.ZornAtoms
 import Mathlib.Data.Set.Lattice
 
 /-!
@@ -107,6 +108,8 @@ as well as other definitions that rely on `Filter`s.
 * `𝓝[≠] x`: the filter `nhdsWithin x {x}ᶜ` of punctured neighborhoods of `x`;
 * `𝓝ˢ s`: the filter `nhdsSet s` of neighborhoods of a set.
 -/
+
+assert_not_exists Ultrafilter
 
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
@@ -230,13 +233,6 @@ section Lim
 /-- If `f` is a filter, then `Filter.lim f` is a limit of the filter, if it exists. -/
 noncomputable def lim [Nonempty X] (f : Filter X) : X :=
   Classical.epsilon fun x => f ≤ 𝓝 x
-
-/--
-If `F` is an ultrafilter, then `Filter.Ultrafilter.lim F` is a limit of the filter, if it exists.
-Note that dot notation `F.lim` can be used for `F : Filter.Ultrafilter X`.
--/
-noncomputable nonrec def Ultrafilter.lim (F : Ultrafilter X) : X :=
-  @lim X _ (nonempty_of_neBot F) F
 
 /-- If `f` is a filter in `α` and `g : α → X` is a function, then `limUnder f g` is a limit of `g`
 at `f`, if it exists. -/

--- a/Mathlib/Topology/Defs/Filter.lean
+++ b/Mathlib/Topology/Defs/Filter.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Jeremy Avigad
 -/
 import Mathlib.Topology.Defs.Basic
-import Mathlib.Order.Filter.Cofinite
-import Mathlib.Order.ZornAtoms
-import Mathlib.Data.Set.Lattice
+import Mathlib.Data.Setoid.Basic
+import Mathlib.Order.Filter.Defs
+import Mathlib.Tactic.IrreducibleDef
 
 /-!
 # Definitions about filters in topological spaces

--- a/Mathlib/Topology/Defs/Sequences.lean
+++ b/Mathlib/Topology/Defs/Sequences.lean
@@ -3,7 +3,8 @@ Copyright (c) 2018 Jan-David Salchow. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jan-David Salchow, Patrick Massot, Yury Kudryashov
 -/
-import Mathlib.Topology.Defs.Ultrafilter
+import Mathlib.Topology.Defs.Filter
+import Mathlib.Order.Filter.AtTopBot
 
 /-!
 # Sequences in topological spaces

--- a/Mathlib/Topology/Defs/Sequences.lean
+++ b/Mathlib/Topology/Defs/Sequences.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Jan-David Salchow. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jan-David Salchow, Patrick Massot, Yury Kudryashov
 -/
-import Mathlib.Topology.Defs.Filter
+import Mathlib.Topology.Defs.Ultrafilter
 
 /-!
 # Sequences in topological spaces

--- a/Mathlib/Topology/Defs/Ultrafilter.lean
+++ b/Mathlib/Topology/Defs/Ultrafilter.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Mario Carneiro, Jeremy Avigad
+-/
+import Mathlib.Topology.Defs.Basic
+import Mathlib.Order.Filter.Ultrafilter
+import Mathlib.Data.Set.Lattice
+import Mathlib.Topology.Defs.Filter
+
+/-!
+# Limit of an ultrafilter.
+
+* `Ultrafilter.lim f`: a limit of an ultrafilter `f`,
+  defined as the limit of `(f : Filter X)`
+  with a proof of `Nonempty X` deduced from existence of an ultrafilter on `X`.
+
+-/
+
+variable {X : Type*} [TopologicalSpace X]
+
+open Filter
+
+/--
+If `F` is an ultrafilter, then `Filter.Ultrafilter.lim F` is a limit of the filter, if it exists.
+Note that dot notation `F.lim` can be used for `F : Filter.Ultrafilter X`.
+-/
+noncomputable nonrec def Ultrafilter.lim (F : Ultrafilter X) : X :=
+  @lim X _ (nonempty_of_neBot F) F

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -6,6 +6,7 @@ Authors: Andrew Yang, Yury Kudryashov
 import Mathlib.Tactic.TFAE
 import Mathlib.Topology.ContinuousOn
 import Mathlib.Topology.Maps.OpenQuotient
+import Mathlib.Order.UpperLower.Basic
 
 /-!
 # Inseparable points in a topological space

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 -/
 import Mathlib.Topology.ContinuousOn
 import Mathlib.Order.Minimal
+import Mathlib.Order.Zorn
 /-!
 # Irreducibility in topological spaces
 

--- a/Mathlib/Topology/Order.lean
+++ b/Mathlib/Topology/Order.lean
@@ -313,7 +313,8 @@ theorem discreteTopology_iff_singleton_mem_nhds [TopologicalSpace α] :
 neighbourhoods. -/
 theorem discreteTopology_iff_nhds [TopologicalSpace α] :
     DiscreteTopology α ↔ ∀ x : α, 𝓝 x = pure x := by
-  simp only [discreteTopology_iff_singleton_mem_nhds, ← nhds_neBot.le_pure_iff, le_pure_iff]
+  simp [discreteTopology_iff_singleton_mem_nhds, le_pure_iff]
+  sorry
 
 theorem discreteTopology_iff_nhds_ne [TopologicalSpace α] :
     DiscreteTopology α ↔ ∀ x : α, 𝓝[≠] x = ⊥ := by

--- a/Mathlib/Topology/Order.lean
+++ b/Mathlib/Topology/Order.lean
@@ -314,7 +314,8 @@ neighbourhoods. -/
 theorem discreteTopology_iff_nhds [TopologicalSpace α] :
     DiscreteTopology α ↔ ∀ x : α, 𝓝 x = pure x := by
   simp [discreteTopology_iff_singleton_mem_nhds, le_pure_iff]
-  sorry
+  apply forall_congr' (fun x ↦ ?_)
+  simp [le_antisymm_iff, pure_le_nhds x]
 
 theorem discreteTopology_iff_nhds_ne [TopologicalSpace α] :
     DiscreteTopology α ↔ ∀ x : α, 𝓝[≠] x = ⊥ := by

--- a/Mathlib/Topology/Ultrafilter.lean
+++ b/Mathlib/Topology/Ultrafilter.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Mario Carneiro, Jeremy Avigad
+-/
+import Mathlib.Algebra.Group.Support
+import Mathlib.Order.Filter.Lift
+import Mathlib.Topology.Basic
+import Mathlib.Topology.Defs.Ultrafilter
+import Mathlib.Order.Filter.Ultrafilter
+
+/-! # Characterization of basic topological properties in terms of ultrafilters -/
+
+open Set Filter Topology
+
+universe u v w x
+
+variable {X : Type u} {Y : Type v} {ι : Sort w} {α β : Type*} {x : X} {s s₁ s₂ t : Set X}
+    {p p₁ p₂ : X → Prop} [TopologicalSpace X] [TopologicalSpace Y] {F : Filter α} {u : α → X}
+
+theorem Ultrafilter.clusterPt_iff {f : Ultrafilter X} : ClusterPt x f ↔ ↑f ≤ 𝓝 x :=
+  ⟨f.le_of_inf_neBot', fun h => ClusterPt.of_le_nhds h⟩
+
+theorem clusterPt_iff_ultrafilter {f : Filter X} : ClusterPt x f ↔
+    ∃ u : Ultrafilter X, u ≤ f ∧ u ≤ 𝓝 x := by
+  simp_rw [ClusterPt, ← le_inf_iff, exists_ultrafilter_iff, inf_comm]
+
+theorem mapClusterPt_iff_ultrafilter :
+    MapClusterPt x F u ↔ ∃ U : Ultrafilter α, U ≤ F ∧ Tendsto u U (𝓝 x) := by
+  simp_rw [MapClusterPt, ClusterPt, ← Filter.push_pull', map_neBot_iff, tendsto_iff_comap,
+    ← le_inf_iff, exists_ultrafilter_iff, inf_comm]
+
+theorem isOpen_iff_ultrafilter :
+    IsOpen s ↔ ∀ x ∈ s, ∀ (l : Ultrafilter X), ↑l ≤ 𝓝 x → s ∈ l := by
+  simp_rw [isOpen_iff_mem_nhds, ← mem_iff_ultrafilter]
+
+/-- `x` belongs to the closure of `s` if and only if some ultrafilter
+  supported on `s` converges to `x`. -/
+theorem mem_closure_iff_ultrafilter :
+    x ∈ closure s ↔ ∃ u : Ultrafilter X, s ∈ u ∧ ↑u ≤ 𝓝 x := by
+  simp [closure_eq_cluster_pts, ClusterPt, ← exists_ultrafilter_iff, and_comm]
+
+theorem isClosed_iff_ultrafilter : IsClosed s ↔
+    ∀ x, ∀ u : Ultrafilter X, ↑u ≤ 𝓝 x → s ∈ u → x ∈ s := by
+  simp [isClosed_iff_clusterPt, ClusterPt, ← exists_ultrafilter_iff]
+
+variable {f : X → Y}
+
+theorem continuousAt_iff_ultrafilter :
+    ContinuousAt f x ↔ ∀ g : Ultrafilter X, ↑g ≤ 𝓝 x → Tendsto f g (𝓝 (f x)) :=
+  tendsto_iff_ultrafilter f (𝓝 x) (𝓝 (f x))
+
+theorem continuous_iff_ultrafilter :
+    Continuous f ↔ ∀ (x) (g : Ultrafilter X), ↑g ≤ 𝓝 x → Tendsto f g (𝓝 (f x)) := by
+  simp only [continuous_iff_continuousAt, continuousAt_iff_ultrafilter]

--- a/Mathlib/Topology/Ultrafilter.lean
+++ b/Mathlib/Topology/Ultrafilter.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl, Mario Carneiro, Jeremy Avigad
 import Mathlib.Algebra.Group.Support
 import Mathlib.Order.Filter.Lift
 import Mathlib.Topology.Basic
-import Mathlib.Topology.Defs.Ultrafilter
 import Mathlib.Order.Filter.Ultrafilter
 
 /-! # Characterization of basic topological properties in terms of ultrafilters -/


### PR DESCRIPTION
Delays import Ultrafilters, which currently bring in quite a few unnecessary imports into basic topology. Three proofs broke, which Patrick has replaced with essentially logically identical proofs, but which don't mention ultrafilters.