### PR TITLE
chore(scripts/bench): use env, not `--lean`

### DIFF
--- a/scripts/bench/fake-root/bin/lean
+++ b/scripts/bench/fake-root/bin/lean
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export LEAN_SYSROOT=$LEAN_REAL_SYSROOT
+unset LEAN_SYSROOT
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if [[ "$@" == "--print-prefix" ]]; then echo "$DIR/.."; exit; fi

--- a/scripts/bench/fake-root/bin/lean
+++ b/scripts/bench/fake-root/bin/lean
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export LEAN_SYSROOT=$LEAN_REAL_SYSROOT
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if [[ "$@" == "--print-prefix" ]]; then echo "$DIR/.."; exit; fi
 if [[ "$@" == "--githash" ]]; then exec lean "$@"; fi

--- a/scripts/bench/fake-root/bin/leanc
+++ b/scripts/bench/fake-root/bin/leanc
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export LEAN_SYSROOT=$LEAN_REAL_SYSROOT
+unset LEAN_SYSROOT
 
 MODE=linking
 for arg in "$@"; do

--- a/scripts/bench/fake-root/bin/leanc
+++ b/scripts/bench/fake-root/bin/leanc
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export LEAN_SYSROOT=$LEAN_REAL_SYSROOT
+
 MODE=linking
 for arg in "$@"; do
     if [[ "$arg" == "-c" ]]; then

--- a/scripts/bench/temci-config.run.yml
+++ b/scripts/bench/temci-config.run.yml
@@ -7,7 +7,7 @@
     rusage_properties: ['maxrss']
     cmd: |
       # use build cache for proofwidgets, but not for anything else
-      bash -c 'set -eo pipefail; lake clean 1>&2 && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets 1>&2 && rm -f .lake/packages/batteries/.lake/build/bin/runLinter 1>&2 && LEAN_SYSROOT=$(readlink -m ./scripts/bench/fake-root) lake build --no-cache -v | ./scripts/bench/accumulate_profile.py | grep -v took'
+      bash -c 'set -eo pipefail; lake clean 1>&2 && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets 1>&2 && rm -f .lake/packages/batteries/.lake/build/bin/runLinter 1>&2 && LEAN_REAL_SYSROOT=$(lean --print-prefix) LEAN_SYSROOT=$(readlink -m ./scripts/bench/fake-root) lake build --no-cache -v | ./scripts/bench/accumulate_profile.py | grep -v took'
     parse_output: true
     runs: 1
 - attributes:

--- a/scripts/bench/temci-config.run.yml
+++ b/scripts/bench/temci-config.run.yml
@@ -7,7 +7,7 @@
     rusage_properties: ['maxrss']
     cmd: |
       # use build cache for proofwidgets, but not for anything else
-      bash -c 'set -eo pipefail; lake clean 1>&2 && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets 1>&2 && rm -f .lake/packages/batteries/.lake/build/bin/runLinter 1>&2 && LEAN_REAL_SYSROOT=$(lean --print-prefix) LEAN_SYSROOT=$(readlink -m ./scripts/bench/fake-root) lake build --no-cache -v | ./scripts/bench/accumulate_profile.py | grep -v took'
+      bash -c 'set -eo pipefail; lake clean 1>&2 && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets 1>&2 && rm -f .lake/packages/batteries/.lake/build/bin/runLinter 1>&2 && LEAN_SYSROOT=$(readlink -m ./scripts/bench/fake-root) lake build --no-cache -v | ./scripts/bench/accumulate_profile.py | grep -v took'
     parse_output: true
     runs: 1
 - attributes:

--- a/scripts/bench/temci-config.run.yml
+++ b/scripts/bench/temci-config.run.yml
@@ -7,7 +7,7 @@
     rusage_properties: ['maxrss']
     cmd: |
       # use build cache for proofwidgets, but not for anything else
-      bash -c 'set -eo pipefail; lake clean 1>&2 && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets 1>&2 && rm -f .lake/packages/batteries/.lake/build/bin/runLinter 1>&2 && lake build --no-cache -v --lean ./scripts/bench/fake-root/bin/lean | ./scripts/bench/accumulate_profile.py | grep -v took'
+      bash -c 'set -eo pipefail; lake clean 1>&2 && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets 1>&2 && rm -f .lake/packages/batteries/.lake/build/bin/runLinter 1>&2 && LEAN_SYSROOT=$(readlink -m ./scripts/bench/fake-root) lake build --no-cache -v | ./scripts/bench/accumulate_profile.py | grep -v took'
     parse_output: true
     runs: 1
 - attributes:


### PR DESCRIPTION
Uses the `LEAN_SYSROOT` environment variable rather than Lake's `--lean` option to configure the benchmark's fake root. This adaption is needed because the `--lean` option will be removed by leanprover/lean4#5684.