### PR TITLE
[Merged by Bors] - fix(LongestPole): windows paths compatibility

### DIFF
--- a/LongestPole/Main.lean
+++ b/LongestPole/Main.lean
@@ -122,9 +122,8 @@ open System in
 def countLOC (modules : List Name) : IO (NameMap Float) := do
   let mut r := {}
   for m in modules do
-    let fp := FilePath.mk ((← findOLean m).toString.replace ".lake/build/lib/" "")
-      |>.withExtension "lean"
-    if ← fp.pathExists then
+    if let .some fp ← Lean.SearchPath.findModuleWithExt [s!".{FilePath.pathSeparator}"] "lean" m
+    then
       let src ← IO.FS.readFile fp
       r := r.insert m (src.toList.count '\n').toFloat
   return r


### PR DESCRIPTION
`lake exe pole --loc` now no longer uses string manipulation to create paths to the `.lean` files.
As a result, it is able to find the files even on windows devices, in order to count LoC numbers.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
