### PR TITLE
[Merged by Bors] - chore(GroupTheory/GroupAction): split off `Defs` file 

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2951,6 +2951,7 @@ import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.GroupTheory.GroupAction.Blocks
 import Mathlib.GroupTheory.GroupAction.CardCommute
 import Mathlib.GroupTheory.GroupAction.ConjAct
+import Mathlib.GroupTheory.GroupAction.Defs
 import Mathlib.GroupTheory.GroupAction.DomAct.ActionHom
 import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 import Mathlib.GroupTheory.GroupAction.Embedding

--- a/Mathlib/Algebra/Module/Submodule/Basic.lean
+++ b/Mathlib/Algebra/Module/Submodule/Basic.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.Group.Subgroup.Basic
 import Mathlib.Algebra.Group.Submonoid.Membership
+import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 import Mathlib.GroupTheory.GroupAction.SubMulAction
 
 /-!

--- a/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
+++ b/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
@@ -7,6 +7,7 @@ import Mathlib.CategoryTheory.Galois.Basic
 import Mathlib.CategoryTheory.Limits.FintypeCat
 import Mathlib.CategoryTheory.Limits.Preserves.Limits
 import Mathlib.CategoryTheory.Limits.Shapes.SingleObj
+import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.Logic.Equiv.TransferInstance
 
 /-!

--- a/Mathlib/CategoryTheory/Limits/Shapes/SingleObj.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/SingleObj.lean
@@ -5,7 +5,8 @@ Authors: Christian Merten
 -/
 import Mathlib.CategoryTheory.Limits.Types
 import Mathlib.CategoryTheory.SingleObj
-import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Data.Setoid.Basic
+import Mathlib.GroupTheory.GroupAction.Defs
 
 /-!
 # (Co)limits of functors out of `SingleObj M`

--- a/Mathlib/Dynamics/Minimal.lean
+++ b/Mathlib/Dynamics/Minimal.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.Topology.Algebra.ConstMulAction
 
 /-!

--- a/Mathlib/GroupTheory/Coset/Basic.lean
+++ b/Mathlib/GroupTheory/Coset/Basic.lean
@@ -3,9 +3,12 @@ Copyright (c) 2018 Mitchell Rowett. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mitchell Rowett, Kim Morrison
 -/
-import Mathlib.Algebra.Quotient
 import Mathlib.Algebra.Group.Subgroup.MulOpposite
-import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Algebra.Quotient
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.Data.Setoid.Basic
+import Mathlib.GroupTheory.GroupAction.Defs
 
 /-!
 # Cosets

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -4,11 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import Mathlib.Algebra.Group.Subgroup.Basic
-import Mathlib.Algebra.GroupWithZero.Action.Defs
-import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Set.Finite
 import Mathlib.Data.Set.Pointwise.SMul
-import Mathlib.Data.Setoid.Basic
+import Mathlib.GroupTheory.GroupAction.Defs
 
 /-!
 # Basic properties of group actions
@@ -39,62 +37,7 @@ variable (M : Type u) [Monoid M] (α : Type v) [MulAction M α] {β : Type*} [Mu
 
 section Orbit
 
-variable {α}
-
-/-- The orbit of an element under an action. -/
-@[to_additive "The orbit of an element under an action."]
-def orbit (a : α) :=
-  Set.range fun m : M => m • a
-
-variable {M}
-
-@[to_additive]
-theorem mem_orbit_iff {a₁ a₂ : α} : a₂ ∈ orbit M a₁ ↔ ∃ x : M, x • a₁ = a₂ :=
-  Iff.rfl
-
-@[to_additive (attr := simp)]
-theorem mem_orbit (a : α) (m : M) : m • a ∈ orbit M a :=
-  ⟨m, rfl⟩
-
-@[to_additive (attr := simp)]
-theorem mem_orbit_self (a : α) : a ∈ orbit M a :=
-  ⟨1, by simp [MulAction.one_smul]⟩
-
-@[to_additive]
-theorem orbit_nonempty (a : α) : Set.Nonempty (orbit M a) :=
-  Set.range_nonempty _
-
-@[to_additive]
-theorem mapsTo_smul_orbit (m : M) (a : α) : Set.MapsTo (m • ·) (orbit M a) (orbit M a) :=
-  Set.range_subset_iff.2 fun m' => ⟨m * m', mul_smul _ _ _⟩
-
-@[to_additive]
-theorem smul_orbit_subset (m : M) (a : α) : m • orbit M a ⊆ orbit M a :=
-  (mapsTo_smul_orbit m a).image_subset
-
-@[to_additive]
-theorem orbit_smul_subset (m : M) (a : α) : orbit M (m • a) ⊆ orbit M a :=
-  Set.range_subset_iff.2 fun m' => mul_smul m' m a ▸ mem_orbit _ _
-
-@[to_additive]
-instance {a : α} : MulAction M (orbit M a) where
-  smul m := (mapsTo_smul_orbit m a).restrict _ _ _
-  one_smul m := Subtype.ext (one_smul M (m : α))
-  mul_smul m m' a' := Subtype.ext (mul_smul m m' (a' : α))
-
-@[to_additive (attr := simp)]
-theorem orbit.coe_smul {a : α} {m : M} {a' : orbit M a} : ↑(m • a') = m • (a' : α) :=
-  rfl
-
-@[to_additive]
-lemma orbit_submonoid_subset (S : Submonoid M) (a : α) : orbit S a ⊆ orbit M a := by
-  rintro b ⟨g, rfl⟩
-  exact mem_orbit _ _
-
-@[to_additive]
-lemma mem_orbit_of_mem_orbit_submonoid {S : Submonoid M} {a b : α} (h : a ∈ orbit S b) :
-    a ∈ orbit M b :=
-  orbit_submonoid_subset S _ h
+variable {α M}
 
 @[to_additive]
 lemma fst_mem_orbit_of_mem_orbit {x y : α × β} (h : x ∈ MulAction.orbit M y) :
@@ -122,41 +65,7 @@ end Orbit
 
 section FixedPoints
 
-/-- The set of elements fixed under the whole action. -/
-@[to_additive "The set of elements fixed under the whole action."]
-def fixedPoints : Set α :=
-  { a : α | ∀ m : M, m • a = a }
-
-variable {M}
-
-/-- `fixedBy m` is the set of elements fixed by `m`. -/
-@[to_additive "`fixedBy m` is the set of elements fixed by `m`."]
-def fixedBy (m : M) : Set α :=
-  { x | m • x = x }
-
-variable (M)
-
-@[to_additive]
-theorem fixed_eq_iInter_fixedBy : fixedPoints M α = ⋂ m : M, fixedBy α m :=
-  Set.ext fun _ =>
-    ⟨fun hx => Set.mem_iInter.2 fun m => hx m, fun hx m => (Set.mem_iInter.1 hx m : _)⟩
-
 variable {M α}
-
-@[to_additive (attr := simp)]
-theorem mem_fixedPoints {a : α} : a ∈ fixedPoints M α ↔ ∀ m : M, m • a = a :=
-  Iff.rfl
-
-@[to_additive (attr := simp)]
-theorem mem_fixedBy {m : M} {a : α} : a ∈ fixedBy α m ↔ m • a = a :=
-  Iff.rfl
-
-@[to_additive]
-theorem mem_fixedPoints' {a : α} : a ∈ fixedPoints M α ↔ ∀ a', a' ∈ orbit M a → a' = a :=
-  ⟨fun h _ h₁ =>
-    let ⟨m, hm⟩ := mem_orbit_iff.1 h₁
-    hm ▸ h m,
-    fun h _ => h _ (mem_orbit _ _)⟩
 
 @[to_additive mem_fixedPoints_iff_card_orbit_eq_one]
 theorem mem_fixedPoints_iff_card_orbit_eq_one {a : α} [Fintype (orbit M a)] :
@@ -172,114 +81,7 @@ theorem mem_fixedPoints_iff_card_orbit_eq_one {a : α} [Fintype (orbit M a)] :
 
 end FixedPoints
 
-section Stabilizers
-
-variable {α}
-
-/-- The stabilizer of a point `a` as a submonoid of `M`. -/
-@[to_additive "The stabilizer of a point `a` as an additive submonoid of `M`."]
-def stabilizerSubmonoid (a : α) : Submonoid M where
-  carrier := { m | m • a = a }
-  one_mem' := one_smul _ a
-  mul_mem' {m m'} (ha : m • a = a) (hb : m' • a = a) :=
-    show (m * m') • a = a by rw [← smul_smul, hb, ha]
-
-variable {M}
-
-@[to_additive]
-instance [DecidableEq α] (a : α) : DecidablePred (· ∈ stabilizerSubmonoid M a) :=
-  fun _ => inferInstanceAs <| Decidable (_ = _)
-
-@[to_additive (attr := simp)]
-theorem mem_stabilizerSubmonoid_iff {a : α} {m : M} : m ∈ stabilizerSubmonoid M a ↔ m • a = a :=
-  Iff.rfl
-
-end Stabilizers
-
 end MulAction
-
-section FixedPoints
-
-variable (M : Type u) (α : Type v) [Monoid M]
-
-section Monoid
-
-variable [Monoid α] [MulDistribMulAction M α]
-
-/-- The submonoid of elements fixed under the whole action. -/
-def FixedPoints.submonoid : Submonoid α where
-  carrier := MulAction.fixedPoints M α
-  one_mem' := smul_one
-  mul_mem' ha hb _ := by rw [smul_mul', ha, hb]
-
-@[simp]
-lemma FixedPoints.mem_submonoid (a : α) : a ∈ submonoid M α ↔ ∀ m : M, m • a = a :=
-  Iff.rfl
-
-end Monoid
-
-section Group
-namespace FixedPoints
-variable [Group α] [MulDistribMulAction M α]
-
-/-- The subgroup of elements fixed under the whole action. -/
-def subgroup : Subgroup α where
-  __ := submonoid M α
-  inv_mem' ha _ := by rw [smul_inv', ha]
-
-/-- The notation for `FixedPoints.subgroup`, chosen to resemble `αᴹ`. -/
-scoped notation α "^*" M:51 => FixedPoints.subgroup M α
-
-@[simp]
-lemma mem_subgroup (a : α) : a ∈ α^*M ↔ ∀ m : M, m • a = a :=
-  Iff.rfl
-
-@[simp]
-lemma subgroup_toSubmonoid : (α^*M).toSubmonoid = submonoid M α :=
-  rfl
-
-end FixedPoints
-end Group
-
-section AddMonoid
-
-variable [AddMonoid α] [DistribMulAction M α]
-
-/-- The additive submonoid of elements fixed under the whole action. -/
-def FixedPoints.addSubmonoid : AddSubmonoid α where
-  carrier := MulAction.fixedPoints M α
-  zero_mem' := smul_zero
-  add_mem' ha hb _ := by rw [smul_add, ha, hb]
-
-@[simp]
-lemma FixedPoints.mem_addSubmonoid (a : α) : a ∈ addSubmonoid M α ↔ ∀ m : M, m • a = a :=
-  Iff.rfl
-
-end AddMonoid
-
-section AddGroup
-
-variable [AddGroup α] [DistribMulAction M α]
-
-/-- The additive subgroup of elements fixed under the whole action. -/
-def FixedPoints.addSubgroup : AddSubgroup α where
-  __ := addSubmonoid M α
-  neg_mem' ha _ := by rw [smul_neg, ha]
-
-/-- The notation for `FixedPoints.addSubgroup`, chosen to resemble `αᴹ`. -/
-notation α "^+" M:51 => FixedPoints.addSubgroup M α
-
-@[simp]
-lemma FixedPoints.mem_addSubgroup (a : α) : a ∈ α^+M ↔ ∀ m : M, m • a = a :=
-  Iff.rfl
-
-@[simp]
-lemma FixedPoints.addSubgroup_toAddSubmonoid : (α^+M).toAddSubmonoid = addSubmonoid M α :=
-  rfl
-
-end AddGroup
-
-end FixedPoints
 
 /-- `smul` by a `k : M` over a ring is injective, if `k` is not a zero divisor.
 The general theory of such `k` is elaborated by `IsSMulRegular`.
@@ -305,13 +107,6 @@ theorem smul_orbit (g : G) (a : α) : g • orbit G a = orbit G a :=
       orbit G a = g • g⁻¹ • orbit G a := (smul_inv_smul _ _).symm
       _ ⊆ g • orbit G a := Set.image_subset _ (smul_orbit_subset _ _)
 
-@[to_additive (attr := simp)]
-theorem orbit_smul (g : G) (a : α) : orbit G (g • a) = orbit G a :=
-  (orbit_smul_subset g a).antisymm <|
-    calc
-      orbit G a = orbit G (g⁻¹ • g • a) := by rw [inv_smul_smul]
-      _ ⊆ orbit G (g • a) := orbit_smul_subset _ _
-
 /-- The action of a group on an orbit is transitive. -/
 @[to_additive "The action of an additive group on an orbit is transitive."]
 instance (a : α) : IsPretransitive G (orbit G a) :=
@@ -320,66 +115,6 @@ instance (a : α) : IsPretransitive G (orbit G a) :=
     use h * g⁻¹
     ext1
     simp [mul_smul]⟩
-
-@[to_additive]
-theorem orbit_eq_iff {a b : α} : orbit G a = orbit G b ↔ a ∈ orbit G b :=
-  ⟨fun h => h ▸ mem_orbit_self _, fun ⟨_, hc⟩ => hc ▸ orbit_smul _ _⟩
-
-@[to_additive]
-theorem mem_orbit_smul (g : G) (a : α) : a ∈ orbit G (g • a) := by
-  simp only [orbit_smul, mem_orbit_self]
-
-@[to_additive]
-theorem smul_mem_orbit_smul (g h : G) (a : α) : g • a ∈ orbit G (h • a) := by
-  simp only [orbit_smul, mem_orbit]
-
-@[to_additive]
-instance instMulAction (H : Subgroup G) : MulAction H α :=
-  inferInstanceAs (MulAction H.toSubmonoid α)
-
-@[to_additive]
-lemma orbit_subgroup_subset (H : Subgroup G) (a : α) : orbit H a ⊆ orbit G a :=
-  orbit_submonoid_subset H.toSubmonoid a
-
-@[to_additive]
-lemma mem_orbit_of_mem_orbit_subgroup {H : Subgroup G} {a b : α} (h : a ∈ orbit H b) :
-    a ∈ orbit G b :=
-  orbit_subgroup_subset H _ h
-
-@[to_additive]
-lemma mem_orbit_symm {a₁ a₂ : α} : a₁ ∈ orbit G a₂ ↔ a₂ ∈ orbit G a₁ := by
-  simp_rw [← orbit_eq_iff, eq_comm]
-
-@[to_additive]
-lemma mem_subgroup_orbit_iff {H : Subgroup G} {x : α} {a b : orbit G x} :
-    a ∈ MulAction.orbit H b ↔ (a : α) ∈ MulAction.orbit H (b : α) := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rcases h with ⟨g, rfl⟩
-    exact MulAction.mem_orbit _ g
-  · rcases h with ⟨g, h⟩
-    dsimp at h
-    erw [← orbit.coe_smul, ← Subtype.ext_iff] at h
-    subst h
-    exact MulAction.mem_orbit _ g
-
-variable (G α)
-
-/-- The relation 'in the same orbit'. -/
-@[to_additive "The relation 'in the same orbit'."]
-def orbitRel : Setoid α where
-  r a b := a ∈ orbit G b
-  iseqv :=
-    ⟨mem_orbit_self, fun {a b} => by simp [orbit_eq_iff.symm, eq_comm], fun {a b} => by
-      simp (config := { contextual := true }) [orbit_eq_iff.symm, eq_comm]⟩
-
-variable {G α}
-
-@[to_additive]
-theorem orbitRel_apply {a b : α} : orbitRel G α a b ↔ a ∈ orbit G b :=
-  Iff.rfl
-
-@[to_additive (attr := deprecated (since := "2024-10-18"))]
-alias orbitRel_r_apply := orbitRel_apply
 
 @[to_additive]
 lemma orbitRel_subgroup_le (H : Subgroup G) : orbitRel H α ≤ orbitRel G α :=
@@ -404,60 +139,7 @@ lemma orbitRel_subgroupOf (H K : Subgroup G) :
     · simp only [Subgroup.mem_subgroupOf]
       exact gp.1
 
-/-- When you take a set `U` in `α`, push it down to the quotient, and pull back, you get the union
-of the orbit of `U` under `G`. -/
-@[to_additive
-      "When you take a set `U` in `α`, push it down to the quotient, and pull back, you get the
-      union of the orbit of `U` under `G`."]
-theorem quotient_preimage_image_eq_union_mul (U : Set α) :
-    letI := orbitRel G α
-    Quotient.mk' ⁻¹' (Quotient.mk' '' U) = ⋃ g : G, (g • ·) '' U := by
-  letI := orbitRel G α
-  set f : α → Quotient (MulAction.orbitRel G α) := Quotient.mk'
-  ext a
-  constructor
-  · rintro ⟨b, hb, hab⟩
-    obtain ⟨g, rfl⟩ := Quotient.exact hab
-    rw [Set.mem_iUnion]
-    exact ⟨g⁻¹, g • a, hb, inv_smul_smul g a⟩
-  · intro hx
-    rw [Set.mem_iUnion] at hx
-    obtain ⟨g, u, hu₁, hu₂⟩ := hx
-    rw [Set.mem_preimage, Set.mem_image]
-    refine ⟨g⁻¹ • a, ?_, by simp only [f, Quotient.eq']; use g⁻¹⟩
-    rw [← hu₂]
-    convert hu₁
-    simp only [inv_smul_smul]
-
-@[to_additive]
-theorem disjoint_image_image_iff {U V : Set α} :
-    letI := orbitRel G α
-    Disjoint (Quotient.mk' '' U) (Quotient.mk' '' V) ↔ ∀ x ∈ U, ∀ g : G, g • x ∉ V := by
-  letI := orbitRel G α
-  set f : α → Quotient (MulAction.orbitRel G α) := Quotient.mk'
-  refine
-    ⟨fun h a a_in_U g g_in_V =>
-      h.le_bot ⟨⟨a, a_in_U, Quotient.sound ⟨g⁻¹, ?_⟩⟩, ⟨g • a, g_in_V, rfl⟩⟩, ?_⟩
-  · simp
-  · intro h
-    rw [Set.disjoint_left]
-    rintro _ ⟨b, hb₁, hb₂⟩ ⟨c, hc₁, hc₂⟩
-    obtain ⟨g, rfl⟩ := Quotient.exact (hc₂.trans hb₂.symm)
-    exact h b hb₁ g hc₁
-
-@[to_additive]
-theorem image_inter_image_iff (U V : Set α) :
-    letI := orbitRel G α
-    Quotient.mk' '' U ∩ Quotient.mk' '' V = ∅ ↔ ∀ x ∈ U, ∀ g : G, g • x ∉ V :=
-  Set.disjoint_iff_inter_eq_empty.symm.trans disjoint_image_image_iff
-
 variable (G α)
-
-/-- The quotient by `MulAction.orbitRel`, given a name to enable dot notation. -/
-@[to_additive
-    "The quotient by `AddAction.orbitRel`, given a name to enable dot notation."]
-abbrev orbitRel.Quotient : Type _ :=
-  _root_.Quotient <| orbitRel G α
 
 /-- An action is pretransitive if and only if the quotient by `MulAction.orbitRel` is a
 subsingleton. -/
@@ -482,78 +164,6 @@ theorem pretransitive_iff_unique_quotient_of_nonempty [Nonempty α] :
 
 variable {G α}
 
-/-- The orbit corresponding to an element of the quotient by `MulAction.orbitRel` -/
-@[to_additive "The orbit corresponding to an element of the quotient by `AddAction.orbitRel`"]
-nonrec def orbitRel.Quotient.orbit (x : orbitRel.Quotient G α) : Set α :=
-  Quotient.liftOn' x (orbit G) fun _ _ => MulAction.orbit_eq_iff.2
-
-@[to_additive (attr := simp)]
-theorem orbitRel.Quotient.orbit_mk (a : α) :
-    orbitRel.Quotient.orbit (Quotient.mk'' a : orbitRel.Quotient G α) = MulAction.orbit G a :=
-  rfl
-
-@[to_additive]
-theorem orbitRel.Quotient.mem_orbit {a : α} {x : orbitRel.Quotient G α} :
-    a ∈ x.orbit ↔ Quotient.mk'' a = x := by
-  induction x using Quotient.inductionOn'
-  rw [Quotient.eq'']
-  rfl
-
-/-- Note that `hφ = Quotient.out_eq'` is a useful choice here. -/
-@[to_additive "Note that `hφ = Quotient.out_eq'` is a useful choice here."]
-theorem orbitRel.Quotient.orbit_eq_orbit_out (x : orbitRel.Quotient G α)
-    {φ : orbitRel.Quotient G α → α} (hφ : letI := orbitRel G α; RightInverse φ Quotient.mk') :
-    orbitRel.Quotient.orbit x = MulAction.orbit G (φ x) := by
-  conv_lhs => rw [← hφ x]
-  rfl
-
-@[to_additive]
-lemma orbitRel.Quotient.orbit_injective :
-    Injective (orbitRel.Quotient.orbit : orbitRel.Quotient G α → Set α) := by
-  intro x y h
-  simp_rw [orbitRel.Quotient.orbit_eq_orbit_out _ Quotient.out_eq', orbit_eq_iff,
-    ← orbitRel_apply] at h
-  simpa [← Quotient.eq''] using h
-
-@[to_additive (attr := simp)]
-lemma orbitRel.Quotient.orbit_inj {x y : orbitRel.Quotient G α} : x.orbit = y.orbit ↔ x = y :=
-  orbitRel.Quotient.orbit_injective.eq_iff
-
-@[to_additive]
-lemma orbitRel.quotient_eq_of_quotient_subgroup_eq {H : Subgroup G} {a b : α}
-    (h : (⟦a⟧ : orbitRel.Quotient H α) = ⟦b⟧) : (⟦a⟧ : orbitRel.Quotient G α) = ⟦b⟧ := by
-  rw [@Quotient.eq] at h ⊢
-  exact mem_orbit_of_mem_orbit_subgroup h
-
-@[to_additive]
-lemma orbitRel.quotient_eq_of_quotient_subgroup_eq' {H : Subgroup G} {a b : α}
-    (h : (Quotient.mk'' a : orbitRel.Quotient H α) = Quotient.mk'' b) :
-    (Quotient.mk'' a : orbitRel.Quotient G α) = Quotient.mk'' b :=
-  orbitRel.quotient_eq_of_quotient_subgroup_eq h
-
-@[to_additive]
-nonrec lemma orbitRel.Quotient.orbit_nonempty (x : orbitRel.Quotient G α) :
-    Set.Nonempty x.orbit := by
-  rw [orbitRel.Quotient.orbit_eq_orbit_out x Quotient.out_eq']
-  exact orbit_nonempty _
-
-@[to_additive]
-nonrec lemma orbitRel.Quotient.mapsTo_smul_orbit (g : G) (x : orbitRel.Quotient G α) :
-    Set.MapsTo (g • ·) x.orbit x.orbit := by
-  rw [orbitRel.Quotient.orbit_eq_orbit_out x Quotient.out_eq']
-  exact mapsTo_smul_orbit g x.out'
-
-@[to_additive]
-instance (x : orbitRel.Quotient G α) : MulAction G x.orbit where
-  smul g := (orbitRel.Quotient.mapsTo_smul_orbit g x).restrict _ _ _
-  one_smul a := Subtype.ext (one_smul G (a : α))
-  mul_smul g g' a' := Subtype.ext (mul_smul g g' (a' : α))
-
-@[to_additive (attr := simp)]
-lemma orbitRel.Quotient.orbit.coe_smul {g : G} {x : orbitRel.Quotient G α} {a : x.orbit} :
-    ↑(g • a) = g • (a : α) :=
-  rfl
-
 @[to_additive]
 instance (x : orbitRel.Quotient G α) : IsPretransitive G x.orbit where
   exists_smul_eq := by
@@ -566,79 +176,9 @@ instance (x : orbitRel.Quotient G α) : IsPretransitive G x.orbit where
     ext
     simp [mul_smul]
 
-@[to_additive (attr := norm_cast, simp)]
-lemma orbitRel.Quotient.mem_subgroup_orbit_iff {H : Subgroup G} {x : orbitRel.Quotient G α}
-    {a b : x.orbit} : (a : α) ∈ MulAction.orbit H (b : α) ↔ a ∈ MulAction.orbit H b := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rcases h with ⟨g, h⟩
-    dsimp at h
-    erw [← orbit.coe_smul, ← Subtype.ext_iff] at h
-    subst h
-    exact MulAction.mem_orbit _ g
-  · rcases h with ⟨g, rfl⟩
-    exact MulAction.mem_orbit _ g
-
-@[to_additive]
-lemma orbitRel.Quotient.subgroup_quotient_eq_iff {H : Subgroup G} {x : orbitRel.Quotient G α}
-    {a b : x.orbit} : (⟦a⟧ : orbitRel.Quotient H x.orbit) = ⟦b⟧ ↔
-      (⟦↑a⟧ : orbitRel.Quotient H α) = ⟦↑b⟧ := by
-  simp_rw [← @Quotient.mk''_eq_mk, Quotient.eq'']
-  exact orbitRel.Quotient.mem_subgroup_orbit_iff.symm
-
-@[to_additive]
-lemma orbitRel.Quotient.mem_subgroup_orbit_iff' {H : Subgroup G} {x : orbitRel.Quotient G α}
-    {a b : x.orbit} {c : α} (h : (⟦a⟧ : orbitRel.Quotient H x.orbit) = ⟦b⟧) :
-    (a : α) ∈ MulAction.orbit H c ↔ (b : α) ∈ MulAction.orbit H c := by
-  simp_rw [mem_orbit_symm (a₂ := c)]
-  convert Iff.rfl using 2
-  rw [orbit_eq_iff]
-  suffices hb : ↑b ∈ orbitRel.Quotient.orbit (⟦a⟧ : orbitRel.Quotient H x.orbit) by
-    rw [orbitRel.Quotient.orbit_eq_orbit_out (⟦a⟧ : orbitRel.Quotient H x.orbit) Quotient.out_eq']
-       at hb
-    rw [orbitRel.Quotient.mem_subgroup_orbit_iff]
-    convert hb using 1
-    rw [orbit_eq_iff, ← orbitRel_apply, ← Quotient.eq'', Quotient.out_eq', @Quotient.mk''_eq_mk]
-  rw [orbitRel.Quotient.mem_orbit, h, @Quotient.mk''_eq_mk]
-
 variable (G) (α)
 
 local notation "Ω" => orbitRel.Quotient G α
-
-/-- Decomposition of a type `X` as a disjoint union of its orbits under a group action.
-
-This version is expressed in terms of `MulAction.orbitRel.Quotient.orbit` instead of
-`MulAction.orbit`, to avoid mentioning `Quotient.out'`. -/
-@[to_additive
-      "Decomposition of a type `X` as a disjoint union of its orbits under an additive group action.
-
-      This version is expressed in terms of `AddAction.orbitRel.Quotient.orbit` instead of
-      `AddAction.orbit`, to avoid mentioning `Quotient.out'`. "]
-def selfEquivSigmaOrbits' : α ≃ Σω : Ω, ω.orbit :=
-  letI := orbitRel G α
-  calc
-    α ≃ Σω : Ω, { a // Quotient.mk' a = ω } := (Equiv.sigmaFiberEquiv Quotient.mk').symm
-    _ ≃ Σω : Ω, ω.orbit :=
-      Equiv.sigmaCongrRight fun _ =>
-        Equiv.subtypeEquivRight fun _ => orbitRel.Quotient.mem_orbit.symm
-
-/-- Decomposition of a type `X` as a disjoint union of its orbits under a group action. -/
-@[to_additive
-      "Decomposition of a type `X` as a disjoint union of its orbits under an additive group
-      action."]
-def selfEquivSigmaOrbits : α ≃ Σω : Ω, orbit G ω.out' :=
-  (selfEquivSigmaOrbits' G α).trans <|
-    Equiv.sigmaCongrRight fun _ =>
-      Equiv.Set.ofEq <| orbitRel.Quotient.orbit_eq_orbit_out _ Quotient.out_eq'
-
-/-- Decomposition of a type `X` as a disjoint union of its orbits under a group action.
-Phrased as a set union. See `MulAction.selfEquivSigmaOrbits` for the type isomorphism. -/
-@[to_additive "Decomposition of a type `X` as a disjoint union of its orbits under an additive group
-action. Phrased as a set union. See `AddAction.selfEquivSigmaOrbits` for the type isomorphism."]
-lemma univ_eq_iUnion_orbit :
-    Set.univ (α := α) = ⋃ x : Ω, x.orbit := by
-  ext x
-  simp only [Set.mem_univ, Set.mem_iUnion, true_iff]
-  exact ⟨Quotient.mk'' x, by simp⟩
 
 @[to_additive]
 lemma _root_.Finite.of_finite_mulAction_orbitRel_quotient [Finite G] [Finite Ω] : Finite α := by
@@ -666,57 +206,7 @@ end Orbit
 section Stabilizer
 variable (G)
 
-/-- The stabilizer of an element under an action, i.e. what sends the element to itself.
-A subgroup. -/
-@[to_additive
-      "The stabilizer of an element under an action, i.e. what sends the element to itself.
-      An additive subgroup."]
-def stabilizer (a : α) : Subgroup G :=
-  { stabilizerSubmonoid G a with
-    inv_mem' := fun {m} (ha : m • a = a) => show m⁻¹ • a = a by rw [inv_smul_eq_iff, ha] }
-
 variable {G}
-
-@[to_additive]
-instance [DecidableEq α] (a : α) : DecidablePred (· ∈ stabilizer G a) :=
-  fun _ => inferInstanceAs <| Decidable (_ = _)
-
-@[to_additive (attr := simp)]
-theorem mem_stabilizer_iff {a : α} {g : G} : g ∈ stabilizer G a ↔ g • a = a :=
-  Iff.rfl
-
-@[to_additive]
-lemma le_stabilizer_smul_left [SMul α β] [IsScalarTower G α β] (a : α) (b : β) :
-    stabilizer G a ≤ stabilizer G (a • b) := by
-  simp_rw [SetLike.le_def, mem_stabilizer_iff, ← smul_assoc]; rintro a h; rw [h]
-
--- This lemma does not need `MulAction G α`, only `SMul G α`.
--- We use `G'` instead of `G` to locally reduce the typeclass assumptions.
-@[to_additive]
-lemma le_stabilizer_smul_right {G'} [Group G'] [SMul α β] [MulAction G' β]
-    [SMulCommClass G' α β] (a : α) (b : β) :
-    stabilizer G' b ≤ stabilizer G' (a • b) := by
-  simp_rw [SetLike.le_def, mem_stabilizer_iff, smul_comm]; rintro a h; rw [h]
-
-@[to_additive (attr := simp)]
-lemma stabilizer_smul_eq_left [SMul α β] [IsScalarTower G α β] (a : α) (b : β)
-    (h : Injective (· • b : α → β)) : stabilizer G (a • b) = stabilizer G a := by
-  refine (le_stabilizer_smul_left _ _).antisymm' fun a ha ↦ ?_
-  simpa only [mem_stabilizer_iff, ← smul_assoc, h.eq_iff] using ha
-
-@[to_additive (attr := simp)]
-lemma stabilizer_smul_eq_right {α} [Group α] [MulAction α β] [SMulCommClass G α β] (a : α) (b : β) :
-    stabilizer G (a • b) = stabilizer G b :=
-  (le_stabilizer_smul_right _ _).antisymm' <| (le_stabilizer_smul_right a⁻¹ _).trans_eq <| by
-    rw [inv_smul_smul]
-
-@[to_additive (attr := simp)]
-lemma stabilizer_mul_eq_left [Group α] [IsScalarTower G α α] (a b : α)  :
-    stabilizer G (a * b) = stabilizer G a := stabilizer_smul_eq_left a _ <| mul_left_injective _
-
-@[to_additive (attr := simp)]
-lemma stabilizer_mul_eq_right [Group α] [SMulCommClass G α α] (a b : α) :
-    stabilizer G (a * b) = stabilizer G b := stabilizer_smul_eq_right a _
 
 /-- If the stabilizer of `a` is `S`, then the stabilizer of `g • a` is `gSg⁻¹`. -/
 theorem stabilizer_smul_eq_stabilizer_map_conj (g : G) (a : α) :

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -5,8 +5,10 @@ Authors: Chris Hughes
 -/
 import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Group.Subgroup.ZPowers
+import Mathlib.Algebra.GroupWithZero.Action.Basic
 import Mathlib.Algebra.Ring.Action.Basic
-import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Data.Fintype.Card
+import Mathlib.GroupTheory.GroupAction.Defs
 
 /-!
 # Conjugation action of a group on itself

--- a/Mathlib/GroupTheory/GroupAction/Defs.lean
+++ b/Mathlib/GroupTheory/GroupAction/Defs.lean
@@ -1,0 +1,580 @@
+/-
+Copyright (c) 2018 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes
+-/
+import Mathlib.Algebra.Group.Pointwise.Set.Basic
+import Mathlib.Algebra.Group.Subgroup.Defs
+import Mathlib.Algebra.Group.Submonoid.Operations
+import Mathlib.Algebra.GroupWithZero.Action.Defs
+
+/-!
+# Definition of `orbit`, `fixedPoints` and `stabilizer`
+
+This file defines orbits, stabilizers, and other objects defined in terms of actions.
+
+## Main definitions
+
+* `MulAction.orbit`
+* `MulAction.fixedPoints`
+* `MulAction.fixedBy`
+* `MulAction.stabilizer`
+
+-/
+
+
+universe u v
+
+open Pointwise
+
+open Function
+
+namespace MulAction
+
+variable (M : Type u) [Monoid M] (α : Type v) [MulAction M α] {β : Type*} [MulAction M β]
+
+section Orbit
+
+variable {α}
+
+/-- The orbit of an element under an action. -/
+@[to_additive "The orbit of an element under an action."]
+def orbit (a : α) :=
+  Set.range fun m : M => m • a
+
+variable {M}
+
+@[to_additive]
+theorem mem_orbit_iff {a₁ a₂ : α} : a₂ ∈ orbit M a₁ ↔ ∃ x : M, x • a₁ = a₂ :=
+  Iff.rfl
+
+@[to_additive (attr := simp)]
+theorem mem_orbit (a : α) (m : M) : m • a ∈ orbit M a :=
+  ⟨m, rfl⟩
+
+@[to_additive (attr := simp)]
+theorem mem_orbit_self (a : α) : a ∈ orbit M a :=
+  ⟨1, by simp [MulAction.one_smul]⟩
+
+@[to_additive]
+theorem orbit_nonempty (a : α) : Set.Nonempty (orbit M a) :=
+  Set.range_nonempty _
+
+@[to_additive]
+theorem mapsTo_smul_orbit (m : M) (a : α) : Set.MapsTo (m • ·) (orbit M a) (orbit M a) :=
+  Set.range_subset_iff.2 fun m' => ⟨m * m', mul_smul _ _ _⟩
+
+@[to_additive]
+theorem smul_orbit_subset (m : M) (a : α) : m • orbit M a ⊆ orbit M a :=
+  (mapsTo_smul_orbit m a).image_subset
+
+@[to_additive]
+theorem orbit_smul_subset (m : M) (a : α) : orbit M (m • a) ⊆ orbit M a :=
+  Set.range_subset_iff.2 fun m' => mul_smul m' m a ▸ mem_orbit _ _
+
+@[to_additive]
+instance {a : α} : MulAction M (orbit M a) where
+  smul m := (mapsTo_smul_orbit m a).restrict _ _ _
+  one_smul m := Subtype.ext (one_smul M (m : α))
+  mul_smul m m' a' := Subtype.ext (mul_smul m m' (a' : α))
+
+@[to_additive (attr := simp)]
+theorem orbit.coe_smul {a : α} {m : M} {a' : orbit M a} : ↑(m • a') = m • (a' : α) :=
+  rfl
+
+@[to_additive]
+lemma orbit_submonoid_subset (S : Submonoid M) (a : α) : orbit S a ⊆ orbit M a := by
+  rintro b ⟨g, rfl⟩
+  exact mem_orbit _ _
+
+@[to_additive]
+lemma mem_orbit_of_mem_orbit_submonoid {S : Submonoid M} {a b : α} (h : a ∈ orbit S b) :
+    a ∈ orbit M b :=
+  orbit_submonoid_subset S _ h
+
+end Orbit
+
+section FixedPoints
+
+/-- The set of elements fixed under the whole action. -/
+@[to_additive "The set of elements fixed under the whole action."]
+def fixedPoints : Set α :=
+  { a : α | ∀ m : M, m • a = a }
+
+variable {M}
+
+/-- `fixedBy m` is the set of elements fixed by `m`. -/
+@[to_additive "`fixedBy m` is the set of elements fixed by `m`."]
+def fixedBy (m : M) : Set α :=
+  { x | m • x = x }
+
+variable (M)
+
+@[to_additive]
+theorem fixed_eq_iInter_fixedBy : fixedPoints M α = ⋂ m : M, fixedBy α m :=
+  Set.ext fun _ =>
+    ⟨fun hx => Set.mem_iInter.2 fun m => hx m, fun hx m => (Set.mem_iInter.1 hx m : _)⟩
+
+variable {M α}
+
+@[to_additive (attr := simp)]
+theorem mem_fixedPoints {a : α} : a ∈ fixedPoints M α ↔ ∀ m : M, m • a = a :=
+  Iff.rfl
+
+@[to_additive (attr := simp)]
+theorem mem_fixedBy {m : M} {a : α} : a ∈ fixedBy α m ↔ m • a = a :=
+  Iff.rfl
+
+@[to_additive]
+theorem mem_fixedPoints' {a : α} : a ∈ fixedPoints M α ↔ ∀ a', a' ∈ orbit M a → a' = a :=
+  ⟨fun h _ h₁ =>
+    let ⟨m, hm⟩ := mem_orbit_iff.1 h₁
+    hm ▸ h m,
+    fun h _ => h _ (mem_orbit _ _)⟩
+
+end FixedPoints
+
+section Stabilizers
+
+variable {α}
+
+/-- The stabilizer of a point `a` as a submonoid of `M`. -/
+@[to_additive "The stabilizer of a point `a` as an additive submonoid of `M`."]
+def stabilizerSubmonoid (a : α) : Submonoid M where
+  carrier := { m | m • a = a }
+  one_mem' := one_smul _ a
+  mul_mem' {m m'} (ha : m • a = a) (hb : m' • a = a) :=
+    show (m * m') • a = a by rw [← smul_smul, hb, ha]
+
+variable {M}
+
+@[to_additive]
+instance [DecidableEq α] (a : α) : DecidablePred (· ∈ stabilizerSubmonoid M a) :=
+  fun _ => inferInstanceAs <| Decidable (_ = _)
+
+@[to_additive (attr := simp)]
+theorem mem_stabilizerSubmonoid_iff {a : α} {m : M} : m ∈ stabilizerSubmonoid M a ↔ m • a = a :=
+  Iff.rfl
+
+end Stabilizers
+
+end MulAction
+
+section FixedPoints
+
+variable (M : Type u) (α : Type v) [Monoid M]
+
+section Monoid
+
+variable [Monoid α] [MulDistribMulAction M α]
+
+/-- The submonoid of elements fixed under the whole action. -/
+def FixedPoints.submonoid : Submonoid α where
+  carrier := MulAction.fixedPoints M α
+  one_mem' := smul_one
+  mul_mem' ha hb _ := by rw [smul_mul', ha, hb]
+
+@[simp]
+lemma FixedPoints.mem_submonoid (a : α) : a ∈ submonoid M α ↔ ∀ m : M, m • a = a :=
+  Iff.rfl
+
+end Monoid
+
+section Group
+namespace FixedPoints
+variable [Group α] [MulDistribMulAction M α]
+
+/-- The subgroup of elements fixed under the whole action. -/
+def subgroup : Subgroup α where
+  __ := submonoid M α
+  inv_mem' ha _ := by rw [smul_inv', ha]
+
+/-- The notation for `FixedPoints.subgroup`, chosen to resemble `αᴹ`. -/
+scoped notation α "^*" M:51 => FixedPoints.subgroup M α
+
+@[simp]
+lemma mem_subgroup (a : α) : a ∈ α^*M ↔ ∀ m : M, m • a = a :=
+  Iff.rfl
+
+@[simp]
+lemma subgroup_toSubmonoid : (α^*M).toSubmonoid = submonoid M α :=
+  rfl
+
+end FixedPoints
+end Group
+
+section AddMonoid
+
+variable [AddMonoid α] [DistribMulAction M α]
+
+/-- The additive submonoid of elements fixed under the whole action. -/
+def FixedPoints.addSubmonoid : AddSubmonoid α where
+  carrier := MulAction.fixedPoints M α
+  zero_mem' := smul_zero
+  add_mem' ha hb _ := by rw [smul_add, ha, hb]
+
+@[simp]
+lemma FixedPoints.mem_addSubmonoid (a : α) : a ∈ addSubmonoid M α ↔ ∀ m : M, m • a = a :=
+  Iff.rfl
+
+end AddMonoid
+
+section AddGroup
+
+variable [AddGroup α] [DistribMulAction M α]
+
+/-- The additive subgroup of elements fixed under the whole action. -/
+def FixedPoints.addSubgroup : AddSubgroup α where
+  __ := addSubmonoid M α
+  neg_mem' ha _ := by rw [smul_neg, ha]
+
+/-- The notation for `FixedPoints.addSubgroup`, chosen to resemble `αᴹ`. -/
+notation α "^+" M:51 => FixedPoints.addSubgroup M α
+
+@[simp]
+lemma FixedPoints.mem_addSubgroup (a : α) : a ∈ α^+M ↔ ∀ m : M, m • a = a :=
+  Iff.rfl
+
+@[simp]
+lemma FixedPoints.addSubgroup_toAddSubmonoid : (α^+M).toAddSubmonoid = addSubmonoid M α :=
+  rfl
+
+end AddGroup
+
+end FixedPoints
+
+namespace MulAction
+variable {G α β : Type*} [Group G] [MulAction G α] [MulAction G β]
+
+section Orbit
+
+@[to_additive (attr := simp)]
+theorem orbit_smul (g : G) (a : α) : orbit G (g • a) = orbit G a :=
+  (orbit_smul_subset g a).antisymm <|
+    calc
+      orbit G a = orbit G (g⁻¹ • g • a) := by rw [inv_smul_smul]
+      _ ⊆ orbit G (g • a) := orbit_smul_subset _ _
+
+@[to_additive]
+theorem orbit_eq_iff {a b : α} : orbit G a = orbit G b ↔ a ∈ orbit G b :=
+  ⟨fun h => h ▸ mem_orbit_self _, fun ⟨_, hc⟩ => hc ▸ orbit_smul _ _⟩
+
+@[to_additive]
+theorem mem_orbit_smul (g : G) (a : α) : a ∈ orbit G (g • a) := by
+  simp only [orbit_smul, mem_orbit_self]
+
+@[to_additive]
+theorem smul_mem_orbit_smul (g h : G) (a : α) : g • a ∈ orbit G (h • a) := by
+  simp only [orbit_smul, mem_orbit]
+
+@[to_additive]
+instance instMulAction (H : Subgroup G) : MulAction H α :=
+  inferInstanceAs (MulAction H.toSubmonoid α)
+
+@[to_additive]
+lemma orbit_subgroup_subset (H : Subgroup G) (a : α) : orbit H a ⊆ orbit G a :=
+  orbit_submonoid_subset H.toSubmonoid a
+
+@[to_additive]
+lemma mem_orbit_of_mem_orbit_subgroup {H : Subgroup G} {a b : α} (h : a ∈ orbit H b) :
+    a ∈ orbit G b :=
+  orbit_subgroup_subset H _ h
+
+@[to_additive]
+lemma mem_orbit_symm {a₁ a₂ : α} : a₁ ∈ orbit G a₂ ↔ a₂ ∈ orbit G a₁ := by
+  simp_rw [← orbit_eq_iff, eq_comm]
+
+@[to_additive]
+lemma mem_subgroup_orbit_iff {H : Subgroup G} {x : α} {a b : orbit G x} :
+    a ∈ MulAction.orbit H b ↔ (a : α) ∈ MulAction.orbit H (b : α) := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rcases h with ⟨g, rfl⟩
+    exact MulAction.mem_orbit _ g
+  · rcases h with ⟨g, h⟩
+    dsimp at h
+    erw [← orbit.coe_smul, ← Subtype.ext_iff] at h
+    subst h
+    exact MulAction.mem_orbit _ g
+
+variable (G α)
+
+/-- The relation 'in the same orbit'. -/
+@[to_additive "The relation 'in the same orbit'."]
+def orbitRel : Setoid α where
+  r a b := a ∈ orbit G b
+  iseqv :=
+    ⟨mem_orbit_self, fun {a b} => by simp [orbit_eq_iff.symm, eq_comm], fun {a b} => by
+      simp (config := { contextual := true }) [orbit_eq_iff.symm, eq_comm]⟩
+
+variable {G α}
+
+@[to_additive]
+theorem orbitRel_apply {a b : α} : orbitRel G α a b ↔ a ∈ orbit G b :=
+  Iff.rfl
+
+@[to_additive (attr := deprecated (since := "2024-10-18"))]
+alias orbitRel_r_apply := orbitRel_apply
+
+/-- When you take a set `U` in `α`, push it down to the quotient, and pull back, you get the union
+of the orbit of `U` under `G`. -/
+@[to_additive
+      "When you take a set `U` in `α`, push it down to the quotient, and pull back, you get the
+      union of the orbit of `U` under `G`."]
+theorem quotient_preimage_image_eq_union_mul (U : Set α) :
+    letI := orbitRel G α
+    Quotient.mk' ⁻¹' (Quotient.mk' '' U) = ⋃ g : G, (g • ·) '' U := by
+  letI := orbitRel G α
+  set f : α → Quotient (MulAction.orbitRel G α) := Quotient.mk'
+  ext a
+  constructor
+  · rintro ⟨b, hb, hab⟩
+    obtain ⟨g, rfl⟩ := Quotient.exact hab
+    rw [Set.mem_iUnion]
+    exact ⟨g⁻¹, g • a, hb, inv_smul_smul g a⟩
+  · intro hx
+    rw [Set.mem_iUnion] at hx
+    obtain ⟨g, u, hu₁, hu₂⟩ := hx
+    rw [Set.mem_preimage, Set.mem_image]
+    refine ⟨g⁻¹ • a, ?_, by simp only [f, Quotient.eq']; use g⁻¹⟩
+    rw [← hu₂]
+    convert hu₁
+    simp only [inv_smul_smul]
+
+@[to_additive]
+theorem disjoint_image_image_iff {U V : Set α} :
+    letI := orbitRel G α
+    Disjoint (Quotient.mk' '' U) (Quotient.mk' '' V) ↔ ∀ x ∈ U, ∀ g : G, g • x ∉ V := by
+  letI := orbitRel G α
+  set f : α → Quotient (MulAction.orbitRel G α) := Quotient.mk'
+  refine
+    ⟨fun h a a_in_U g g_in_V =>
+      h.le_bot ⟨⟨a, a_in_U, Quotient.sound ⟨g⁻¹, ?_⟩⟩, ⟨g • a, g_in_V, rfl⟩⟩, ?_⟩
+  · simp
+  · intro h
+    rw [Set.disjoint_left]
+    rintro _ ⟨b, hb₁, hb₂⟩ ⟨c, hc₁, hc₂⟩
+    obtain ⟨g, rfl⟩ := Quotient.exact (hc₂.trans hb₂.symm)
+    exact h b hb₁ g hc₁
+
+@[to_additive]
+theorem image_inter_image_iff (U V : Set α) :
+    letI := orbitRel G α
+    Quotient.mk' '' U ∩ Quotient.mk' '' V = ∅ ↔ ∀ x ∈ U, ∀ g : G, g • x ∉ V :=
+  Set.disjoint_iff_inter_eq_empty.symm.trans disjoint_image_image_iff
+
+variable (G α)
+
+/-- The quotient by `MulAction.orbitRel`, given a name to enable dot notation. -/
+@[to_additive
+    "The quotient by `AddAction.orbitRel`, given a name to enable dot notation."]
+abbrev orbitRel.Quotient : Type _ :=
+  _root_.Quotient <| orbitRel G α
+
+variable {G α}
+
+/-- The orbit corresponding to an element of the quotient by `MulAction.orbitRel` -/
+@[to_additive "The orbit corresponding to an element of the quotient by `AddAction.orbitRel`"]
+nonrec def orbitRel.Quotient.orbit (x : orbitRel.Quotient G α) : Set α :=
+  Quotient.liftOn' x (orbit G) fun _ _ => MulAction.orbit_eq_iff.2
+
+@[to_additive (attr := simp)]
+theorem orbitRel.Quotient.orbit_mk (a : α) :
+    orbitRel.Quotient.orbit (Quotient.mk'' a : orbitRel.Quotient G α) = MulAction.orbit G a :=
+  rfl
+
+@[to_additive]
+theorem orbitRel.Quotient.mem_orbit {a : α} {x : orbitRel.Quotient G α} :
+    a ∈ x.orbit ↔ Quotient.mk'' a = x := by
+  induction x using Quotient.inductionOn'
+  rw [Quotient.eq'']
+  rfl
+
+/-- Note that `hφ = Quotient.out_eq'` is a useful choice here. -/
+@[to_additive "Note that `hφ = Quotient.out_eq'` is a useful choice here."]
+theorem orbitRel.Quotient.orbit_eq_orbit_out (x : orbitRel.Quotient G α)
+    {φ : orbitRel.Quotient G α → α} (hφ : letI := orbitRel G α; RightInverse φ Quotient.mk') :
+    orbitRel.Quotient.orbit x = MulAction.orbit G (φ x) := by
+  conv_lhs => rw [← hφ x]
+  rfl
+
+@[to_additive]
+lemma orbitRel.Quotient.orbit_injective :
+    Injective (orbitRel.Quotient.orbit : orbitRel.Quotient G α → Set α) := by
+  intro x y h
+  simp_rw [orbitRel.Quotient.orbit_eq_orbit_out _ Quotient.out_eq', orbit_eq_iff,
+    ← orbitRel_apply] at h
+  simpa [← Quotient.eq''] using h
+
+@[to_additive (attr := simp)]
+lemma orbitRel.Quotient.orbit_inj {x y : orbitRel.Quotient G α} : x.orbit = y.orbit ↔ x = y :=
+  orbitRel.Quotient.orbit_injective.eq_iff
+
+@[to_additive]
+lemma orbitRel.quotient_eq_of_quotient_subgroup_eq {H : Subgroup G} {a b : α}
+    (h : (⟦a⟧ : orbitRel.Quotient H α) = ⟦b⟧) : (⟦a⟧ : orbitRel.Quotient G α) = ⟦b⟧ := by
+  rw [@Quotient.eq] at h ⊢
+  exact mem_orbit_of_mem_orbit_subgroup h
+
+@[to_additive]
+lemma orbitRel.quotient_eq_of_quotient_subgroup_eq' {H : Subgroup G} {a b : α}
+    (h : (Quotient.mk'' a : orbitRel.Quotient H α) = Quotient.mk'' b) :
+    (Quotient.mk'' a : orbitRel.Quotient G α) = Quotient.mk'' b :=
+  orbitRel.quotient_eq_of_quotient_subgroup_eq h
+
+@[to_additive]
+nonrec lemma orbitRel.Quotient.orbit_nonempty (x : orbitRel.Quotient G α) :
+    Set.Nonempty x.orbit := by
+  rw [orbitRel.Quotient.orbit_eq_orbit_out x Quotient.out_eq']
+  exact orbit_nonempty _
+
+@[to_additive]
+nonrec lemma orbitRel.Quotient.mapsTo_smul_orbit (g : G) (x : orbitRel.Quotient G α) :
+    Set.MapsTo (g • ·) x.orbit x.orbit := by
+  rw [orbitRel.Quotient.orbit_eq_orbit_out x Quotient.out_eq']
+  exact mapsTo_smul_orbit g x.out'
+
+@[to_additive]
+instance (x : orbitRel.Quotient G α) : MulAction G x.orbit where
+  smul g := (orbitRel.Quotient.mapsTo_smul_orbit g x).restrict _ _ _
+  one_smul a := Subtype.ext (one_smul G (a : α))
+  mul_smul g g' a' := Subtype.ext (mul_smul g g' (a' : α))
+
+@[to_additive (attr := simp)]
+lemma orbitRel.Quotient.orbit.coe_smul {g : G} {x : orbitRel.Quotient G α} {a : x.orbit} :
+    ↑(g • a) = g • (a : α) :=
+  rfl
+
+@[to_additive (attr := norm_cast, simp)]
+lemma orbitRel.Quotient.mem_subgroup_orbit_iff {H : Subgroup G} {x : orbitRel.Quotient G α}
+    {a b : x.orbit} : (a : α) ∈ MulAction.orbit H (b : α) ↔ a ∈ MulAction.orbit H b := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rcases h with ⟨g, h⟩
+    dsimp at h
+    erw [← orbit.coe_smul, ← Subtype.ext_iff] at h
+    subst h
+    exact MulAction.mem_orbit _ g
+  · rcases h with ⟨g, rfl⟩
+    exact MulAction.mem_orbit _ g
+
+@[to_additive]
+lemma orbitRel.Quotient.subgroup_quotient_eq_iff {H : Subgroup G} {x : orbitRel.Quotient G α}
+    {a b : x.orbit} : (⟦a⟧ : orbitRel.Quotient H x.orbit) = ⟦b⟧ ↔
+      (⟦↑a⟧ : orbitRel.Quotient H α) = ⟦↑b⟧ := by
+  simp_rw [← @Quotient.mk''_eq_mk, Quotient.eq'']
+  exact orbitRel.Quotient.mem_subgroup_orbit_iff.symm
+
+@[to_additive]
+lemma orbitRel.Quotient.mem_subgroup_orbit_iff' {H : Subgroup G} {x : orbitRel.Quotient G α}
+    {a b : x.orbit} {c : α} (h : (⟦a⟧ : orbitRel.Quotient H x.orbit) = ⟦b⟧) :
+    (a : α) ∈ MulAction.orbit H c ↔ (b : α) ∈ MulAction.orbit H c := by
+  simp_rw [mem_orbit_symm (a₂ := c)]
+  convert Iff.rfl using 2
+  rw [orbit_eq_iff]
+  suffices hb : ↑b ∈ orbitRel.Quotient.orbit (⟦a⟧ : orbitRel.Quotient H x.orbit) by
+    rw [orbitRel.Quotient.orbit_eq_orbit_out (⟦a⟧ : orbitRel.Quotient H x.orbit) Quotient.out_eq']
+       at hb
+    rw [orbitRel.Quotient.mem_subgroup_orbit_iff]
+    convert hb using 1
+    rw [orbit_eq_iff, ← orbitRel_apply, ← Quotient.eq'', Quotient.out_eq', @Quotient.mk''_eq_mk]
+  rw [orbitRel.Quotient.mem_orbit, h, @Quotient.mk''_eq_mk]
+
+variable (G) (α)
+
+local notation "Ω" => orbitRel.Quotient G α
+
+/-- Decomposition of a type `X` as a disjoint union of its orbits under a group action.
+
+This version is expressed in terms of `MulAction.orbitRel.Quotient.orbit` instead of
+`MulAction.orbit`, to avoid mentioning `Quotient.out'`. -/
+@[to_additive
+      "Decomposition of a type `X` as a disjoint union of its orbits under an additive group action.
+
+      This version is expressed in terms of `AddAction.orbitRel.Quotient.orbit` instead of
+      `AddAction.orbit`, to avoid mentioning `Quotient.out'`. "]
+def selfEquivSigmaOrbits' : α ≃ Σω : Ω, ω.orbit :=
+  letI := orbitRel G α
+  calc
+    α ≃ Σω : Ω, { a // Quotient.mk' a = ω } := (Equiv.sigmaFiberEquiv Quotient.mk').symm
+    _ ≃ Σω : Ω, ω.orbit :=
+      Equiv.sigmaCongrRight fun _ =>
+        Equiv.subtypeEquivRight fun _ => orbitRel.Quotient.mem_orbit.symm
+
+/-- Decomposition of a type `X` as a disjoint union of its orbits under a group action. -/
+@[to_additive
+      "Decomposition of a type `X` as a disjoint union of its orbits under an additive group
+      action."]
+def selfEquivSigmaOrbits : α ≃ Σω : Ω, orbit G ω.out' :=
+  (selfEquivSigmaOrbits' G α).trans <|
+    Equiv.sigmaCongrRight fun _ =>
+      Equiv.Set.ofEq <| orbitRel.Quotient.orbit_eq_orbit_out _ Quotient.out_eq'
+
+/-- Decomposition of a type `X` as a disjoint union of its orbits under a group action.
+Phrased as a set union. See `MulAction.selfEquivSigmaOrbits` for the type isomorphism. -/
+@[to_additive "Decomposition of a type `X` as a disjoint union of its orbits under an additive group
+action. Phrased as a set union. See `AddAction.selfEquivSigmaOrbits` for the type isomorphism."]
+lemma univ_eq_iUnion_orbit :
+    Set.univ (α := α) = ⋃ x : Ω, x.orbit := by
+  ext x
+  simp only [Set.mem_univ, Set.mem_iUnion, true_iff]
+  exact ⟨Quotient.mk'' x, by simp⟩
+
+end Orbit
+
+section Stabilizer
+variable (G)
+
+/-- The stabilizer of an element under an action, i.e. what sends the element to itself.
+A subgroup. -/
+@[to_additive
+      "The stabilizer of an element under an action, i.e. what sends the element to itself.
+      An additive subgroup."]
+def stabilizer (a : α) : Subgroup G :=
+  { stabilizerSubmonoid G a with
+    inv_mem' := fun {m} (ha : m • a = a) => show m⁻¹ • a = a by rw [inv_smul_eq_iff, ha] }
+
+variable {G}
+
+@[to_additive]
+instance [DecidableEq α] (a : α) : DecidablePred (· ∈ stabilizer G a) :=
+  fun _ => inferInstanceAs <| Decidable (_ = _)
+
+@[to_additive (attr := simp)]
+theorem mem_stabilizer_iff {a : α} {g : G} : g ∈ stabilizer G a ↔ g • a = a :=
+  Iff.rfl
+
+@[to_additive]
+lemma le_stabilizer_smul_left [SMul α β] [IsScalarTower G α β] (a : α) (b : β) :
+    stabilizer G a ≤ stabilizer G (a • b) := by
+  simp_rw [SetLike.le_def, mem_stabilizer_iff, ← smul_assoc]; rintro a h; rw [h]
+
+-- This lemma does not need `MulAction G α`, only `SMul G α`.
+-- We use `G'` instead of `G` to locally reduce the typeclass assumptions.
+@[to_additive]
+lemma le_stabilizer_smul_right {G'} [Group G'] [SMul α β] [MulAction G' β]
+    [SMulCommClass G' α β] (a : α) (b : β) :
+    stabilizer G' b ≤ stabilizer G' (a • b) := by
+  simp_rw [SetLike.le_def, mem_stabilizer_iff, smul_comm]; rintro a h; rw [h]
+
+@[to_additive (attr := simp)]
+lemma stabilizer_smul_eq_left [SMul α β] [IsScalarTower G α β] (a : α) (b : β)
+    (h : Injective (· • b : α → β)) : stabilizer G (a • b) = stabilizer G a := by
+  refine (le_stabilizer_smul_left _ _).antisymm' fun a ha ↦ ?_
+  simpa only [mem_stabilizer_iff, ← smul_assoc, h.eq_iff] using ha
+
+@[to_additive (attr := simp)]
+lemma stabilizer_smul_eq_right {α} [Group α] [MulAction α β] [SMulCommClass G α β] (a : α) (b : β) :
+    stabilizer G (a • b) = stabilizer G b :=
+  (le_stabilizer_smul_right _ _).antisymm' <| (le_stabilizer_smul_right a⁻¹ _).trans_eq <| by
+    rw [inv_smul_smul]
+
+@[to_additive (attr := simp)]
+lemma stabilizer_mul_eq_left [Group α] [IsScalarTower G α α] (a b : α)  :
+    stabilizer G (a * b) = stabilizer G a := stabilizer_smul_eq_left a _ <| mul_left_injective _
+
+@[to_additive (attr := simp)]
+lemma stabilizer_mul_eq_right [Group α] [SMulCommClass G α α] (a b : α) :
+    stabilizer G (a * b) = stabilizer G b := stabilizer_smul_eq_right a _
+
+end Stabilizer
+
+end MulAction

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Emilie Burgun
 -/
 import Mathlib.Algebra.Group.Commute.Basic
-import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.Dynamics.PeriodicPts
 import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.GroupTheory.GroupAction.Defs
 
 /-!
 # Properties of `fixedPoints` and `fixedBy`

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Antoine Chambert-Loir. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir
 -/
-import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Algebra.Group.Subgroup.Basic
 import Mathlib.GroupTheory.GroupAction.FixedPoints
 
 /-!

--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes, Thomas Browning
 -/
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Dynamics.PeriodicPts
+import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.GroupTheory.GroupAction.ConjAct
 import Mathlib.GroupTheory.GroupAction.Hom
 import Mathlib.GroupTheory.Coset.Basic

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
@@ -5,7 +5,8 @@ Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Module.Defs
 import Mathlib.Data.SetLike.Basic
-import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Data.Setoid.Basic
+import Mathlib.GroupTheory.GroupAction.Defs
 import Mathlib.GroupTheory.GroupAction.Hom
 
 /-!

--- a/Mathlib/GroupTheory/Perm/ClosureSwap.lean
+++ b/Mathlib/GroupTheory/Perm/ClosureSwap.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning, Junyan Xu
 -/
 import Mathlib.Data.Set.Finite
+import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.GroupTheory.GroupAction.FixedPoints
 import Mathlib.GroupTheory.Perm.Support
 

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -3,12 +3,12 @@ Copyright (c) 2023 Junyan Xu, Antoine Chambert-Loir. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Junyan Xu, Antoine Chambert-Loir
 -/
-import Mathlib.Algebra.Group.Subgroup.Basic
-import Mathlib.GroupTheory.GroupAction.DomAct.Basic
-import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Algebra.Group.Action.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Fintype.Perm
 import Mathlib.Data.Set.Card
+import Mathlib.GroupTheory.GroupAction.Defs
+import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 import Mathlib.SetTheory.Cardinal.Finite
 
 /-!  Subgroup of `Equiv.Perm α` preserving a function

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -7,7 +7,7 @@ Authors: Kevin Buzzard, Patrick Massot
 
 import Mathlib.Algebra.Group.Subgroup.Pointwise
 import Mathlib.GroupTheory.Congruence.Hom
-import Mathlib.GroupTheory.Coset.Basic
+import Mathlib.GroupTheory.Coset.Defs
 
 /-!
 # Quotients of groups by normal subgroups

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -7,7 +7,7 @@ Authors: Kevin Buzzard, Patrick Massot
 
 import Mathlib.Algebra.Group.Subgroup.Pointwise
 import Mathlib.GroupTheory.Congruence.Hom
-import Mathlib.GroupTheory.Coset.Defs
+import Mathlib.GroupTheory.Coset.Basic
 
 /-!
 # Quotients of groups by normal subgroups

--- a/Mathlib/Topology/Algebra/ConstMulAction.lean
+++ b/Mathlib/Topology/Algebra/ConstMulAction.lean
@@ -3,12 +3,13 @@ Copyright (c) 2021 Alex Kontorovich, Heather Macbeth. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex Kontorovich, Heather Macbeth
 -/
-import Mathlib.Topology.Algebra.Constructions
-import Mathlib.Topology.Homeomorph
-import Mathlib.GroupTheory.GroupAction.Basic
-import Mathlib.Topology.Bases
-import Mathlib.Topology.Support
 import Mathlib.Algebra.Module.ULift
+import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.GroupTheory.GroupAction.Defs
+import Mathlib.Topology.Algebra.Constructions
+import Mathlib.Topology.Bases
+import Mathlib.Topology.Homeomorph
+import Mathlib.Topology.Support
 
 /-!
 # Monoid actions continuous in the second variable


### PR DESCRIPTION
The goal of this PR is to have a file with the definitions for the orbit and stabilizer of a group, and enough theory to define quotient groups.

---
- [x] depends on: #18340


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
