### PR TITLE
[Merged by Bors] - feat(RingTheory/LaurentSeries): finishes the proof that LaurentSeries are the X-adic completion of Rational Functions

### DIFF
--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -80,6 +80,11 @@ equivalence: `LaurentSeries.LaurentSeriesRingEquiv` is the *topological, ring eq
 `RatFunc K` we consider its alias `LaurentSeries.powerSeries_as_subring` as a subring of `K⸨X⸩`,
 that is itself clearly isomorphic (via `LaurentSeries.powerSeriesEquivSubring.symm`) to `K⟦X⟧`.
 
+## To Do
+* The `AdicCompletion` construction is currently done for ideals in rings and does not take into
+account the relation with algebra structures on the ring, hence it does not yield a `K`-algebra
+structure on the `X`-adic completion of `K⸨X⸩`. Once this will be available, we should update
+`LaurentSeries.LaurentSeriesRingEquiv` to an algebra equivalence.
 -/
 universe u
 
@@ -255,6 +260,11 @@ theorem ofPowerSeries_powerSeriesPart (x : R⸨X⸩) :
     ofPowerSeries ℤ R x.powerSeriesPart = single (-x.order) 1 * x := by
   refine Eq.trans ?_ (congr rfl x.single_order_mul_powerSeriesPart)
   rw [← mul_assoc, single_mul_single, neg_add_cancel, mul_one, ← C_apply, C_one, one_mul]
+
+theorem X_order_mul_powerSeriesPart {n : ℕ} {f : R⸨X⸩} (hn : n = f.order) :
+    (PowerSeries.X ^ n * f.powerSeriesPart : R⟦X⟧) = f := by
+  simp only [map_mul, map_pow, ofPowerSeries_X, single_pow, nsmul_eq_mul, mul_one, one_pow, hn,
+    single_order_mul_powerSeriesPart]
 
 end Semiring
 
@@ -930,15 +940,13 @@ theorem exists_ratFunc_val_lt (f : K⸨X⸩) (γ : ℤₘ₀ˣ) :
     · simp only [PowerSeries.coe_pow, pow_ne_zero, PowerSeries.coe_X, ne_eq,
         single_eq_zero_iff, one_ne_zero, not_false_iff]
   · obtain ⟨s, hs⟩ := Int.exists_eq_neg_ofNat (Int.neg_nonpos_of_nonneg (not_lt.mp ord_nonpos))
-    have hf_coe : (PowerSeries.X ^ s * F : K⟦X⟧) = f := by
-      rw [← f.single_order_mul_powerSeriesPart, neg_inj.1 hs, hF, PowerSeries.coe_mul,
-        PowerSeries.coe_pow, PowerSeries.coe_X, single_pow, nsmul_eq_mul, mul_one, one_pow]
     obtain ⟨P, hP⟩ := exists_Polynomial_intValuation_lt (PowerSeries.X ^ s * F) γ
     use P
-    erw [← hf_coe, ← RatFunc.coe_coe, ← coe_sub, ← coe_algebraMap, valuation_of_algebraMap]
+    erw [← X_order_mul_powerSeriesPart (neg_inj.1 hs).symm, ← RatFunc.coe_coe, ← coe_sub,
+      ← coe_algebraMap, valuation_of_algebraMap]
     exact hP
 
-theorem coe_range_dense : DenseRange (Coe.coe : RatFunc K → K⸨X⸩) := by
+theorem coe_range_dense : DenseRange ((↑) : RatFunc K → K⸨X⸩) := by
   rw [denseRange_iff_closure_range]
   ext f
   simp only [UniformSpace.mem_closure_iff_symm_ball, Set.mem_univ, iff_true, Set.Nonempty,
@@ -959,7 +967,7 @@ section Comparison
 
 open RatFunc AbstractCompletion IsDedekindDomain.HeightOneSpectrum
 
-theorem inducing_coe : IsUniformInducing (Coe.coe : RatFunc K → K⸨X⸩) := by
+theorem inducing_coe : IsUniformInducing ((↑) : RatFunc K → K⸨X⸩) := by
   rw [isUniformInducing_iff, Filter.comap]
   ext S
   simp only [exists_prop, Filter.mem_mk, Set.mem_setOf_eq, uniformity_eq_comap_nhds_zero,
@@ -987,7 +995,7 @@ theorem inducing_coe : IsUniformInducing (Coe.coe : RatFunc K → K⸨X⸩) := b
         coe_sub]
       assumption
 
-theorem continuous_coe : Continuous (Coe.coe : RatFunc K → K⸨X⸩) :=
+theorem continuous_coe : Continuous ((↑) : RatFunc K → K⸨X⸩) :=
   (isUniformInducing_iff'.1 (inducing_coe)).1.continuous
 
 /-- The `X`-adic completion as an abstract completion of `RatFunc K`-/
@@ -999,7 +1007,7 @@ variable (K)
 subspace, it gives rise to an abstract completion of `RatFunc K`.-/
 noncomputable def LaurentSeriesPkg : AbstractCompletion (RatFunc K) where
   space := K⸨X⸩
-  coe := Coe.coe
+  coe := (↑)
   uniformStruct := inferInstance
   complete := inferInstance
   separation := inferInstance
@@ -1010,7 +1018,7 @@ instance : TopologicalSpace (LaurentSeriesPkg K).space :=
   (LaurentSeriesPkg K).uniformStruct.toTopologicalSpace
 
 @[simp]
-theorem LaurentSeries_coe (x : RatFunc K) : (LaurentSeriesPkg K).coe x = (↑x : K⸨X⸩) :=
+theorem LaurentSeries_coe (x : RatFunc K) : (LaurentSeriesPkg K).coe x = (x : K⸨X⸩) :=
   rfl
 
 /-- Reintrerpret the extension of `coe : RatFunc K → K⸨X⸩` as ring homomorphism -/
@@ -1018,7 +1026,7 @@ abbrev extensionAsRingHom :=
   UniformSpace.Completion.extensionHom (coeAlgHom K).toRingHom
 
 /-- An abbreviation for the `X`-adic completion of `RatFunc K` -/
-abbrev RatFuncAdicCompl := adicCompletion (RatFunc K) (Polynomial.idealX K)
+abbrev RatFuncAdicCompl := adicCompletion (RatFunc K) (idealX K)
 
 /- The two instances below make `comparePkg` and `comparePkg_eq_extension` slightly faster-/
 instance : UniformSpace (RatFuncAdicCompl K) := inferInstance
@@ -1059,7 +1067,7 @@ theorem coe_X_compare :
   rw [PowerSeries.coe_X, ← RatFunc.coe_X, ← LaurentSeries_coe, ← compare_coe]
   rfl
 
-open Filter AbstractCompletion LaurentSeries WithZero
+open Filter WithZero
 
 open scoped WithZeroTopology Topology Multiplicative
 
@@ -1071,10 +1079,10 @@ theorem valuation_LaurentSeries_equal_extension :
     rfl
   · exact Valued.continuous_valuation (K := K⸨X⸩)
 
-theorem tendsto_valuation (a : (Polynomial.idealX K).adicCompletion (RatFunc K)) :
-    Tendsto (Valued.v : RatFunc K → ℤₘ₀) (comap Coe.coe (𝓝 a)) (𝓝 (Valued.v a : ℤₘ₀)) := by
+theorem tendsto_valuation (a : (idealX K).adicCompletion (RatFunc K)) :
+    Tendsto (Valued.v : RatFunc K → ℤₘ₀) (comap (↑) (𝓝 a)) (𝓝 (Valued.v a : ℤₘ₀)) := by
   set ψ := (Valued.v : RatFunc K → ℤₘ₀) with hψ
-  have := Valued.is_topological_valuation (R := (Polynomial.idealX K).adicCompletion (RatFunc K))
+  have := Valued.is_topological_valuation (R := (idealX K).adicCompletion (RatFunc K))
   by_cases ha : a = 0
   · rw [tendsto_def]
     intro S hS
@@ -1131,7 +1139,7 @@ abbrev powerSeriesEquivSubring : K⟦X⟧ ≃+* powerSeries_as_subring K := by
 /- Through the isomorphism `LaurentSeriesRingEquiv`, power series land in the unit ball inside the
 completion of `RatFunc K`. -/
 theorem mem_integers_of_powerSeries (F : K⟦X⟧) :
-    (LaurentSeriesRingEquiv K) F ∈ (Polynomial.idealX K).adicCompletionIntegers (RatFunc K) := by
+    (LaurentSeriesRingEquiv K) F ∈ (idealX K).adicCompletionIntegers (RatFunc K) := by
   have : (LaurentSeriesRingEquiv K) F =
     (LaurentSeriesPkg K).compare ratfuncAdicComplPkg (F : K⸨X⸩) := rfl
   simp only [Subring.mem_map, exists_prop, ValuationSubring.mem_toSubring,
@@ -1141,7 +1149,7 @@ theorem mem_integers_of_powerSeries (F : K⟦X⟧) :
 /- Conversely, all elements in the unit ball inside the completion of `RatFunc K` come from a power
 series through the isomorphism `LaurentSeriesRingEquiv`. -/
 theorem exists_powerSeries_of_memIntegers {x : RatFuncAdicCompl K}
-    (hx : x ∈ (Polynomial.idealX K).adicCompletionIntegers (RatFunc K)) :
+    (hx : x ∈ (idealX K).adicCompletionIntegers (RatFunc K)) :
     ∃ F : K⟦X⟧, (LaurentSeriesRingEquiv K) F = x := by
   set f := (ratfuncAdicComplRingEquiv K) x with hf
   have H_x : (LaurentSeriesPkg K).compare ratfuncAdicComplPkg ((ratfuncAdicComplRingEquiv K) x) =
@@ -1152,7 +1160,7 @@ theorem exists_powerSeries_of_memIntegers {x : RatFuncAdicCompl K}
 
 theorem powerSeries_ext_subring :
     Subring.map (LaurentSeriesRingEquiv K).toRingHom (powerSeries_as_subring K) =
-      ((Polynomial.idealX K).adicCompletionIntegers (RatFunc K)).toSubring := by
+      ((idealX K).adicCompletionIntegers (RatFunc K)).toSubring := by
   ext x
   refine ⟨fun ⟨f, ⟨F, coe_F⟩, hF⟩ ↦ ?_, fun H ↦ ?_⟩
   · simp only [ValuationSubring.mem_toSubring, ← hF, ← coe_F]
@@ -1164,7 +1172,7 @@ theorem powerSeries_ext_subring :
 
 /-- The ring isomorphism between `K⟦X⟧` and the unit ball inside the `X`-adic completion of
 `RatFunc K`. -/
-abbrev powerSeriesRingEquiv : K⟦X⟧ ≃+* (Polynomial.idealX K).adicCompletionIntegers (RatFunc K) :=
+abbrev powerSeriesRingEquiv : K⟦X⟧ ≃+* (idealX K).adicCompletionIntegers (RatFunc K) :=
   ((powerSeriesEquivSubring K).trans (LaurentSeriesRingEquiv K).subringMap).trans
     <| RingEquiv.subringCongr (powerSeries_ext_subring K)
 

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -912,7 +912,7 @@ theorem exists_ratFunc_val_lt (f : K⸨X⸩) (γ : ℤₘ₀ˣ) :
     ∃ Q : RatFunc K, Valued.v (f - Q) < γ := by
   set F := f.powerSeriesPart with hF
   by_cases ord_nonpos : f.order < 0
-  · set η : ℤₘ₀ˣ := Units.mk0 (Multiplicative.ofAdd f.order : Multiplicative ℤ) (coe_ne_zero)
+  · set η : ℤₘ₀ˣ := Units.mk0 (Multiplicative.ofAdd f.order : Multiplicative ℤ) coe_ne_zero
       with hη
     obtain ⟨P, hP⟩ := exists_Polynomial_intValuation_lt F (η * γ)
     use RatFunc.X ^ f.order * (P : RatFunc K)

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -852,4 +852,332 @@ instance instLaurentSeriesComplete : CompleteSpace K⸨X⸩ :=
 
 end Complete
 
+section Dense
+
+open scoped Multiplicative
+
+open HahnSeries LaurentSeries
+
+theorem exists_pol_int_val_lt (F : PowerSeries K) (η : ℤₘ₀ˣ) :
+    ∃ P : Polynomial K, (PowerSeries.idealX K).intValuation (F - P) < η := by
+  by_cases h_neg' : 1 < η
+  · use 0
+    rw [Polynomial.coe_zero, sub_zero]
+    apply lt_of_le_of_lt (intValuation_le_one (PowerSeries.idealX K) F)
+    rwa [← Units.val_one, Units.val_lt_val]
+  · set D := Multiplicative.toAdd (WithZero.unzero η.ne_zero) with hD
+    rw [not_lt, ← Units.val_le_val, Units.val_one, ← WithZero.coe_one, ←
+      WithZero.coe_unzero η.ne_zero, WithZero.coe_le_coe, ← Multiplicative.toAdd_le, ← hD,
+      toAdd_one] at h_neg'
+    obtain ⟨d, hd⟩ := Int.exists_eq_neg_ofNat h_neg'
+    use F.trunc (d + 1)
+    have trunc_prop : ∀ m : ℕ, m < d + 1 → PowerSeries.coeff K m (F - ↑(F.trunc (d + 1))) = 0 :=
+      by
+      intro m hm
+      rw [map_sub, sub_eq_zero, Polynomial.coeff_coe, coeff_trunc, if_pos hm]
+    have := (LaurentSeries.intValuation_le_iff_coeff_lt_eq_zero K _).mpr trunc_prop
+    rw [Nat.cast_add, neg_add, ofAdd_add, ← hd, hD, ofAdd_toAdd, WithZero.coe_mul,
+      WithZero.coe_unzero, ← LaurentSeries.coe_algebraMap] at this
+    rw [← @valuation_of_algebraMap (PowerSeries K) _ _ (K⸨X⸩) _ _ _
+      (PowerSeries.idealX K) (F - ↑(F.trunc (d + 1)))]
+    apply lt_of_le_of_lt this
+    rw [← mul_one (η : ℤₘ₀), mul_assoc, one_mul]
+    apply mul_lt_mul_of_lt_of_le₀ (le_refl _) η.ne_zero
+    rw [← WithZero.coe_one, WithZero.coe_lt_coe, ofAdd_neg, Right.inv_lt_one_iff, ← ofAdd_zero,
+      Multiplicative.ofAdd_lt]
+    apply Int.zero_lt_one
+
+theorem exists_ratFunc_val_lt (f : K⸨X⸩) (γ : ℤₘ₀ˣ) :
+    ∃ Q : RatFunc K, Valued.v (f - Q) < γ := by
+  set F := f.powerSeriesPart with hF
+  by_cases ord_nonpos : f.order < 0
+  · have h₀ : ((Multiplicative.ofAdd f.order : Multiplicative ℤ) : ℤₘ₀) ≠ 0 := WithZero.coe_ne_zero
+    set η : ℤₘ₀ˣ := Units.mk0 (Multiplicative.ofAdd f.order : Multiplicative ℤ) h₀ with hη
+    obtain ⟨P, hP⟩ := exists_pol_int_val_lt K F (η * γ)
+    use RatFunc.X ^ f.order * (P : RatFunc K)
+    have F_mul := f.ofPowerSeries_powerSeriesPart
+    obtain ⟨s, hs⟩ := Int.exists_eq_neg_ofNat (le_of_lt ord_nonpos)
+    rw [← hF, hs, neg_neg, ← HahnSeries.ofPowerSeries_X_pow s, ← inv_mul_eq_iff_eq_mul₀] at F_mul
+    erw [hs, ← F_mul, PowerSeries.coe_pow, PowerSeries.coe_X, RatFunc.coe_mul, zpow_neg, zpow_ofNat,
+      inv_eq_one_div (RatFunc.X ^ s), RatFunc.coe_div, RatFunc.coe_pow, RatFunc.coe_X,
+      RatFunc.coe_one, ← inv_eq_one_div, ← mul_sub, map_mul, map_inv₀, ← PowerSeries.coe_X,
+      valuation_X_pow, ← hs, ← RatFunc.coe_coe, ← coe_sub, ← LaurentSeries.coe_algebraMap,
+        valuation_of_algebraMap, ← Units.val_mk0 h₀, ← hη]
+    apply inv_mul_lt_of_lt_mul₀
+    rwa [← Units.val_mul]
+    · simp only [PowerSeries.coe_pow, pow_ne_zero, PowerSeries.coe_X, ne_eq,
+        HahnSeries.single_eq_zero_iff, one_ne_zero, not_false_iff]
+  · obtain ⟨s, hs⟩ := Int.exists_eq_neg_ofNat (Int.neg_nonpos_of_nonneg (not_lt.mp ord_nonpos))
+    simp only [neg_inj] at hs
+    have hf_coe : (PowerSeries.X ^ s * F : PowerSeries K) = f := by
+      rw [← f.single_order_mul_powerSeriesPart, hs, hF, PowerSeries.coe_mul, PowerSeries.coe_pow,
+        PowerSeries.coe_X, single_pow, nsmul_eq_mul, mul_one, one_pow]
+    rw [← hf_coe]
+    obtain ⟨P, hP⟩ := exists_pol_int_val_lt K (PowerSeries.X ^ s * F) γ
+    use ↑P
+    erw [← RatFunc.coe_coe, ← coe_sub, ← LaurentSeries.coe_algebraMap, valuation_of_algebraMap]
+    exact hP
+
+theorem coe_range_dense : DenseRange (Coe.coe : RatFunc K → K⸨X⸩) := by
+  letI : Ring (K⸨X⸩) := inferInstance
+  rw [denseRange_iff_closure_range]
+  ext f
+  simp only [UniformSpace.mem_closure_iff_symm_ball, Set.mem_univ, iff_true, Set.Nonempty,
+    Set.mem_inter_iff, Set.mem_range, Set.mem_setOf_eq, exists_exists_eq_and]
+  intro V hV h_symm
+  rw [uniformity_eq_comap_neg_add_nhds_zero_swapped] at hV
+  obtain ⟨T, hT₀, hT₁⟩ := hV
+  obtain ⟨γ, hγ⟩ := Valued.mem_nhds_zero.mp hT₀
+  obtain ⟨P, hP⟩ := exists_ratFunc_val_lt K f γ
+  use P
+  apply hT₁
+  apply hγ
+  simpa only [add_comm, ← sub_eq_add_neg, gt_iff_lt, Set.mem_setOf_eq]
+
+end Dense
+
+section Comparison
+
+
+open RatFunc AbstractCompletion
+
+theorem inducing_coe : IsUniformInducing (Coe.coe : RatFunc K → K⸨X⸩) := by
+  letI : Ring (K⸨X⸩) := inferInstance -- Porting note: I had to add this
+  rw [isUniformInducing_iff, Filter.comap]
+  ext S
+  simp only [exists_prop, Filter.mem_mk, Set.mem_setOf_eq, uniformity_eq_comap_nhds_zero,
+    Filter.mem_comap]
+  constructor
+  · rintro ⟨T, ⟨⟨R, ⟨hR, pre_R⟩⟩, pre_T⟩⟩
+    obtain ⟨d, hd⟩ := Valued.mem_nhds.mp hR
+    use {P : RatFunc K | Valued.v P < ↑d}
+    · simp only [Valued.mem_nhds, sub_zero]
+      constructor
+      · use d
+      · refine subset_trans ?_ pre_T
+        intro _ _
+        apply pre_R
+        apply hd
+        simp only [sub_zero, Set.mem_setOf_eq]
+        erw [← RatFunc.coe_sub, ← RatFunc.valuation_eq_LaurentSeries_valuation]
+        assumption
+  · rintro ⟨T, ⟨hT, pre_T⟩⟩
+    obtain ⟨d, hd⟩ := Valued.mem_nhds.mp hT
+    let X := {f : K⸨X⸩ | Valued.v f < ↑d}
+    refine ⟨(fun x : K⸨X⸩ × K⸨X⸩ ↦ x.snd - x.fst) ⁻¹' X, ⟨X, ?_⟩, ?_⟩
+    · refine ⟨?_, Set.Subset.refl _⟩
+      · simp only [Valued.mem_nhds, sub_zero]
+        use d
+    · refine subset_trans (fun _ _ ↦ ?_) pre_T
+      apply hd
+      erw [Set.mem_setOf_eq, sub_zero, RatFunc.valuation_eq_LaurentSeries_valuation,
+        RatFunc.coe_sub]
+      assumption
+
+theorem continuous_coe : Continuous (Coe.coe : RatFunc K → K⸨X⸩) :=
+  (isUniformInducing_iff'.1 (inducing_coe K)).1.continuous
+
+/-- The `X`-adic completion as an abstract completion of `RatFunc K`-/
+abbrev ratfuncAdicComplPkg : AbstractCompletion (RatFunc K) :=
+  UniformSpace.Completion.cPkg
+
+/-- Having established that the `LaurentSeries K` is complete and contains `RatFunc K` as a dense
+subspace, it gives rise to an abstract completion of `RatFunc K`.-/
+noncomputable def LaurentSeriesPkg : AbstractCompletion (RatFunc K) where
+  space := K⸨X⸩
+  coe := Coe.coe
+  uniformStruct := inferInstance
+  complete := inferInstance
+  separation := inferInstance
+  isUniformInducing := inducing_coe K
+  dense := coe_range_dense K
+
+instance : TopologicalSpace (LaurentSeriesPkg K).space :=
+  (LaurentSeriesPkg K).uniformStruct.toTopologicalSpace
+
+@[simp]
+theorem LaurentSeries_coe (x : RatFunc K) : (LaurentSeriesPkg K).coe x = (↑x : K⸨X⸩) :=
+  rfl
+
+
+/-- Reintrerpret the extension of `coe : RatFunc K → K⸨X⸩` as ring homomorphism -/
+abbrev extensionAsRingHom :=
+  UniformSpace.Completion.extensionHom (coeAlgHom K).toRingHom
+
+/-- An abbreviation for the `X`-adic completion of `RatFunc K` -/
+abbrev RatFuncAdicCompl := adicCompletion (RatFunc K) (Polynomial.idealX K)
+
+/-The two instances below make `comparePkg` and `comparePkg_eq_extension` slightly faster-/
+
+instance : UniformSpace (RatFuncAdicCompl K) := inferInstance
+
+instance : UniformSpace K⸨X⸩ := inferInstance
+
+/-- The uniform space isomorphism between two abstract completions of `ratfunc K` -/
+abbrev comparePkg : RatFuncAdicCompl K ≃ᵤ K⸨X⸩ :=
+  compareEquiv (ratfuncAdicComplPkg K) (LaurentSeriesPkg K)
+
+lemma comparePkg_eq_extension (x : UniformSpace.Completion (RatFunc K)) :
+    (comparePkg K).toFun x = (extensionAsRingHom K (continuous_coe K)).toFun x := rfl
+
+/-- The uniform space equivalence between two abstract completions of `ratfunc K` as a ring
+equivalence: this will be the *inverse* of the fundamental one.-/
+abbrev ratfuncAdicComplRingEquiv : RatFuncAdicCompl K ≃+* K⸨X⸩ :=
+  {comparePkg K with
+    map_mul' := by
+      intro x y
+      rw [comparePkg_eq_extension, (extensionAsRingHom K (continuous_coe K)).map_mul']
+      rfl
+    map_add' := by
+      intro x y
+      rw [comparePkg_eq_extension, (extensionAsRingHom K (continuous_coe K)).map_add']
+      rfl }
+
+-- **NEW**
+/-- The uniform space equivalence between two abstract completions of `ratfunc K` as a ring
+equivalence: it goes from `K⸨X⸩` to `RatFuncAdicCompl K` -/
+abbrev LaurentSeriesRingEquiv : K⸨X⸩ ≃+* RatFuncAdicCompl K :=
+  (ratfuncAdicComplRingEquiv K).symm
+
+-- *FAE** ToDo : rajouter que l'equiv d'anneaux n' a pas oublié qu'elle est continue et une equiv d'espaces
+-- uniformes
+
+-- Porting note: times out
+/- theorem LaurentSeriesRingEquiv_apply (x : K⸨X⸩) :
+    (LaurentSeriesRingEquiv K) x = compareEquiv (LaurentSeriesPkg K) (ratfuncAdicComplPkg K) x := by
+  simpa only [RingEquiv.apply_symm_apply]  -/
+
+theorem ratfuncAdicComplRingEquiv_apply (x : RatFuncAdicCompl K) :
+    ratfuncAdicComplRingEquiv K x = (ratfuncAdicComplPkg K).compare (LaurentSeriesPkg K) x :=
+  rfl
+
+theorem coe_X_compare :
+    (ratfuncAdicComplRingEquiv K) (↑(@RatFunc.X K _ _) : RatFuncAdicCompl K) =
+      (↑(@PowerSeries.X K _) : K⸨X⸩) := by
+  rw [PowerSeries.coe_X, ← RatFunc.coe_X, ← LaurentSeries_coe, ← AbstractCompletion.compare_coe]
+  rfl
+
+open Filter AbstractCompletion LaurentSeries
+
+open scoped WithZeroTopology Topology Multiplicative
+
+theorem valuation_LaurentSeries_equal_extension :
+    (LaurentSeriesPkg K).isDenseInducing.extend Valued.v =
+      (@Valued.v (K⸨X⸩) _ ℤₘ₀ _ _ : K⸨X⸩ → ℤₘ₀) := by
+  apply IsDenseInducing.extend_unique
+  · intro x
+    erw [valuation_eq_LaurentSeries_valuation K x]
+    rfl
+  · exact @Valued.continuous_valuation (K⸨X⸩) _ ℤₘ₀ _ _
+
+theorem tendsto_valuation (a : (Polynomial.idealX K).adicCompletion (RatFunc K)) :
+    Tendsto (@Valued.v (RatFunc K) _ ℤₘ₀ _ _) (comap Coe.coe (𝓝 a)) (𝓝 (Valued.v a : ℤₘ₀)) := by
+  set ψ := @Valued.v (RatFunc K) _ ℤₘ₀ _ _ with hψ
+  let this := @Valued.is_topological_valuation
+    ((Polynomial.idealX K).adicCompletion (RatFunc K)) _ ℤₘ₀ _ _
+  by_cases ha : a = 0
+  · rw [tendsto_def]
+    intro S hS
+    simp only [mem_comap, exists_prop]
+    rw [ha, map_zero, WithZeroTopology.hasBasis_nhds_zero.1 S] at hS
+    obtain ⟨γ, γ_ne_zero, γ_le⟩ := hS
+    use{t | Valued.v t < γ}
+    constructor
+    · rw [ha, this]
+      use Units.mk0 γ γ_ne_zero
+      rw [Units.val_mk0]
+    · refine Set.Subset.trans (fun a _ ↦ ?_) (Set.preimage_mono γ_le)
+      rwa [Set.mem_preimage, Set.mem_Iio, ← Valued.valuedCompletion_apply a]
+  · rw [WithZeroTopology.tendsto_of_ne_zero ((Valuation.ne_zero_iff Valued.v).mpr ha), hψ,
+      Filter.eventually_comap, Filter.Eventually, Valued.mem_nhds]
+    simp only [Set.setOf_subset_setOf]
+    set γ := Valued.v a / (↑(Multiplicative.ofAdd (1 : ℤ)) : ℤₘ₀) with h_aγ
+    have γ_ne_zero : γ ≠ 0 := by
+      rw [ne_eq, _root_.div_eq_zero_iff, Valuation.zero_iff]
+      simpa only [WithZero.coe_ne_zero, or_false]
+    use Units.mk0 γ γ_ne_zero
+    intro y val_y b diff_b_y
+    replace val_y : Valued.v y = Valued.v a := by
+      refine Valuation.map_eq_of_sub_lt _ (val_y.trans ?_)
+      rw [Units.val_mk0, h_aγ, ← WithZero.coe_unzero ((Valuation.ne_zero_iff Valued.v).mpr ha), ←
+        WithZero.coe_div, WithZero.coe_lt_coe, div_lt_self_iff, ← ofAdd_zero,
+        Multiplicative.ofAdd_lt]
+      exact Int.zero_lt_one
+    rw [← Valued.extension_extends, ← val_y, ← diff_b_y]
+    congr
+
+theorem valuation_compare (f : K⸨X⸩) :
+    (@Valued.v (RatFuncAdicCompl K) _ ℤₘ₀ _ _)
+        (AbstractCompletion.compare (LaurentSeriesPkg K) (ratfuncAdicComplPkg K) f) =
+      Valued.v f := by
+  rw [← valuation_LaurentSeries_equal_extension, ← compare_comp_eq_compare
+    (pkg := (ratfuncAdicComplPkg K)) (cont_f := Valued.continuous_valuation)]
+  · rfl
+  exact (tendsto_valuation K)
+
+section PowerSeries
+
+/-- In order to compare `PowerSeries K` with the valuation subring in the `X`-adic completion of
+`RatFunc K` we regard it as a subring of `K⸨X⸩`. -/
+abbrev powerSeries_as_subring : Subring (K⸨X⸩) :=
+  RingHom.range (HahnSeries.ofPowerSeries ℤ K)
+
+/-- The ring `power_series K` is isomorphic to the subring `power series_as_subring K` -/
+abbrev powerSeriesEquivSubring : PowerSeries K ≃+* powerSeries_as_subring K := by
+  rw [powerSeries_as_subring, RingHom.range_eq_map]
+  exact ((Subring.topEquiv).symm).trans (Subring.equivMapOfInjective ⊤ (HahnSeries.ofPowerSeries ℤ K)
+    HahnSeries.ofPowerSeries_injective)
+
+theorem mem_integers_of_powerSeries (F : PowerSeries K) :
+    (LaurentSeriesRingEquiv K) F ∈ (Polynomial.idealX K).adicCompletionIntegers (RatFunc K) := by
+  have : (LaurentSeriesRingEquiv K) F =
+    (LaurentSeriesPkg K).compare (ratfuncAdicComplPkg K) (F : K⸨X⸩) := rfl
+  simp only [Subring.mem_map, exists_prop, ValuationSubring.mem_toSubring,
+    mem_adicCompletionIntegers, this,  valuation_compare K F, val_le_one_iff_eq_coe]
+  exact ⟨F, rfl⟩
+
+theorem exists_powerSeries_of_memIntegers {x : RatFuncAdicCompl K}
+    (hx : x ∈ (Polynomial.idealX K).adicCompletionIntegers (RatFunc K)) :
+    ∃ F : PowerSeries K, (LaurentSeriesRingEquiv K) F = x := by
+  set f := (ratfuncAdicComplRingEquiv K) x with hf
+  have := valuation_compare K f
+  have H_x :
+    (LaurentSeriesPkg K).compare (ratfuncAdicComplPkg K)
+        ((ratfuncAdicComplRingEquiv K) x) =
+      x :=
+    congr_fun (inverse_compare (LaurentSeriesPkg K) (ratfuncAdicComplPkg K)) x
+  simp only [Subring.mem_map, exists_prop, ValuationSubring.mem_toSubring,
+    mem_adicCompletionIntegers, this] at hx
+  rw [H_x] at this
+  rw [this] at hx
+  obtain ⟨F, h_fF⟩ := (val_le_one_iff_eq_coe K f).mp hx
+  use F
+  rw [h_fF, hf, RingEquiv.symm_apply_apply]
+
+theorem power_series_ext_subring :
+    Subring.map (LaurentSeriesRingEquiv K).toRingHom (powerSeries_as_subring K) =
+      ((Polynomial.idealX K).adicCompletionIntegers (RatFunc K)).toSubring := by
+  ext x
+  constructor
+  · rintro ⟨f, ⟨F, coe_F⟩, h_fF⟩
+    simp only [ValuationSubring.mem_toSubring, ← h_fF, ← coe_F]
+    apply mem_integers_of_powerSeries
+  · intro H
+    obtain ⟨F, hF⟩ := exists_powerSeries_of_memIntegers K H
+    simp only [Equiv.toFun_as_coe, UniformEquiv.coe_toEquiv, exists_exists_eq_and,
+      UniformEquiv.coe_symm_toEquiv, Subring.mem_map, Equiv.invFun_as_coe]
+    exact ⟨F, ⟨F, rfl⟩, hF⟩
+
+/-- The ring isomorphism between `(PowerSeries K)` and the unit ball inside the `X`-adic
+completion of `RatFunc`. -/
+abbrev powerSeriesRingEquiv : PowerSeries K ≃+*
+    (Polynomial.idealX K).adicCompletionIntegers (RatFunc K) :=
+  ((powerSeriesEquivSubring K).trans
+        (@RingEquiv.subringMap _ _ _ _ (powerSeries_as_subring K) (LaurentSeriesRingEquiv K))).trans
+    (RingEquiv.subringCongr (power_series_ext_subring K))
+
+end PowerSeries
+
+end Comparison
+
 end LaurentSeries

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -904,7 +904,7 @@ theorem exists_Polynomial_intValuation_lt (F : K⟦X⟧) (η : ℤₘ₀ˣ) :
     apply mul_lt_mul_of_lt_of_le₀ (le_refl _) η.ne_zero
     rw [← WithZero.coe_one, coe_lt_coe, ofAdd_neg, Right.inv_lt_one_iff, ← ofAdd_zero,
       Multiplicative.ofAdd_lt]
-    apply Int.zero_lt_one
+    exact Int.zero_lt_one
 
 /-- For every Laurent series `f` and every `γ : ℤₘ₀` one can find a rational function `Q` such
 that the `X`-adic valuation `v` satifies `v (f - Q) < γ`. -/

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -687,14 +687,17 @@ theorem val_le_one_iff_eq_coe (f : K⸨X⸩) : Valued.v f ≤ (1 : ℤₘ₀) �
 end LaurentSeries
 
 end AdicValuation
+
 namespace LaurentSeries
+
+variable {K : Type*} [Field K]
+
 section Complete
 
 open Filter
 
 open scoped Multiplicative
 
-variable {K : Type*} [Field K]
 
 /- Sending a Laurent series to its `d`-th coefficient is uniformly continuous (independently of the
  uniformity with which `K` is endowed). -/

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -1132,7 +1132,7 @@ abbrev powerSeriesEquivSubring : K⟦X⟧ ≃+* powerSeries_as_subring K := by
 completion of `RatFunc K`. -/
 theorem mem_integers_of_powerSeries (F : K⟦X⟧) :
     (LaurentSeriesRingEquiv K) F ∈ (Polynomial.idealX K).adicCompletionIntegers (RatFunc K) := by
-    (LaurentSeriesRingEquiv K) F ∈ (idealX K).adicCompletionIntegers (RatFunc K) := by
+  have : (LaurentSeriesRingEquiv K) F =
     (LaurentSeriesPkg K).compare ratfuncAdicComplPkg (F : K⸨X⸩) := rfl
   simp only [Subring.mem_map, exists_prop, ValuationSubring.mem_toSubring,
     mem_adicCompletionIntegers, this,  valuation_compare, val_le_one_iff_eq_coe]

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -1132,7 +1132,7 @@ abbrev powerSeriesEquivSubring : K⟦X⟧ ≃+* powerSeries_as_subring K := by
 completion of `RatFunc K`. -/
 theorem mem_integers_of_powerSeries (F : K⟦X⟧) :
     (LaurentSeriesRingEquiv K) F ∈ (Polynomial.idealX K).adicCompletionIntegers (RatFunc K) := by
-  have : (LaurentSeriesRingEquiv K) F =
+    (LaurentSeriesRingEquiv K) F ∈ (idealX K).adicCompletionIntegers (RatFunc K) := by
     (LaurentSeriesPkg K).compare ratfuncAdicComplPkg (F : K⸨X⸩) := rfl
   simp only [Subring.mem_map, exists_prop, ValuationSubring.mem_toSubring,
     mem_adicCompletionIntegers, this,  valuation_compare, val_le_one_iff_eq_coe]

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -891,7 +891,7 @@ theorem exists_Polynomial_intValuation_lt (F : K⟦X⟧) (η : ℤₘ₀ˣ) :
       coe_le_coe, ← Multiplicative.toAdd_le, toAdd_one] at h_neg
     obtain ⟨d, hd⟩ := Int.exists_eq_neg_ofNat h_neg
     use F.trunc (d + 1)
-    have : Valued.v ((ofPowerSeries ℤ K) (F - ↑(trunc (d + 1) F))) ≤
+    have : Valued.v ((ofPowerSeries ℤ K) (F - (trunc (d + 1) F))) ≤
       (Multiplicative.ofAdd (-(d + 1 : ℤ))) := by
       apply (intValuation_le_iff_coeff_lt_eq_zero K _).mpr
       simpa only [map_sub, sub_eq_zero, Polynomial.coeff_coe, coeff_trunc] using

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -854,7 +854,7 @@ end Complete
 
 section Dense
 
-open scoped Multiplicative
+-- open scoped Multiplicative
 
 open HahnSeries LaurentSeries
 
@@ -871,8 +871,7 @@ theorem exists_pol_int_val_lt (F : PowerSeries K) (η : ℤₘ₀ˣ) :
       toAdd_one] at h_neg'
     obtain ⟨d, hd⟩ := Int.exists_eq_neg_ofNat h_neg'
     use F.trunc (d + 1)
-    have trunc_prop : ∀ m : ℕ, m < d + 1 → PowerSeries.coeff K m (F - ↑(F.trunc (d + 1))) = 0 :=
-      by
+    have trunc_prop : ∀ m : ℕ, m < d + 1 → PowerSeries.coeff K m (F - ↑(F.trunc (d + 1))) = 0 := by
       intro m hm
       rw [map_sub, sub_eq_zero, Polynomial.coeff_coe, coeff_trunc, if_pos hm]
     have := (LaurentSeries.intValuation_le_iff_coeff_lt_eq_zero K _).mpr trunc_prop

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -48,7 +48,6 @@ series to which the filter `ℱ` converges.
 `LaurentSeries.val_le_one_iff_eq_coe`.
 * The uniform space of `LaurentSeries` over a field is complete, formalized in the instance
 `instLaurentSeriesComplete`.
-************************************************************************************************************************
 * The field of rational functions is dense in `LaurentSeries`: this is the declaration
 `LaurentSeries.coe_range_dense` and relies principally upon `LaurentSeries.exists_ratFunc_val_lt`,
 stating that for every Laurent series `f` and every `γ : ℤₘ₀` one can find a rational function `Q`

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -886,9 +886,7 @@ theorem exists_Polynomial_intValuation_lt (F : K⟦X⟧) (η : ℤₘ₀ˣ) :
     ∃ P : K[X], (PowerSeries.idealX K).intValuation (F - P) < η := by
   by_cases h_neg : 1 < η
   · use 0
-    rw [Polynomial.coe_zero, sub_zero]
-    apply lt_of_le_of_lt (intValuation_le_one (PowerSeries.idealX K) F)
-    rwa [← Units.val_one, Units.val_lt_val]
+    simpa using (intValuation_le_one (PowerSeries.idealX K) F).trans_lt h_neg
   · rw [not_lt, ← Units.val_le_val, Units.val_one, ← WithZero.coe_one, ← coe_unzero η.ne_zero,
       coe_le_coe, ← Multiplicative.toAdd_le, toAdd_one] at h_neg
     obtain ⟨d, hd⟩ := Int.exists_eq_neg_ofNat h_neg

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -696,9 +696,6 @@ section Complete
 
 open Filter
 
-open scoped Multiplicative
-
-
 /- Sending a Laurent series to its `d`-th coefficient is uniformly continuous (independently of the
  uniformity with which `K` is endowed). -/
 theorem uniformContinuous_coeff {uK : UniformSpace K} (d : ℤ) :
@@ -829,7 +826,6 @@ theorem Cauchy.coeff_eventually_equal {ℱ : Filter K⸨X⸩} (hℱ : Cauchy ℱ
       apply coeff_tendsto hℱ
       simp only [principal_singleton, mem_pure]; rfl
 
-
 open scoped Topology
 
 /- The main result showing that the Cauchy filter tends to the `Cauchy.limit`-/
@@ -857,7 +853,7 @@ end Complete
 
 section Dense
 
--- open scoped Multiplicative
+open scoped Multiplicative
 
 open HahnSeries LaurentSeries
 


### PR DESCRIPTION
We add two sections to the file `RingTheory/LaurentSeries`: 
* `Dense`, proving that the rational functions are dense in the Laurent Series
* Comparison, providing the isomorphism between the `X`-adic completion of rational functions with Laurent Series, and then specializing this to an isomorphism between the unit ball in the former with power series.



Co-authored-by: María Inés de Frutós Fernandez @mariainesdff 