### PR TITLE
[Merged by Bors] - chore(GroupTheory/Coset): split off `Defs` file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2929,6 +2929,7 @@ import Mathlib.GroupTheory.Coprod.Basic
 import Mathlib.GroupTheory.CoprodI
 import Mathlib.GroupTheory.Coset.Basic
 import Mathlib.GroupTheory.Coset.Card
+import Mathlib.GroupTheory.Coset.Defs
 import Mathlib.GroupTheory.CosetCover
 import Mathlib.GroupTheory.Coxeter.Basic
 import Mathlib.GroupTheory.Coxeter.Inversion

--- a/Mathlib/GroupTheory/Coset/Basic.lean
+++ b/Mathlib/GroupTheory/Coset/Basic.lean
@@ -4,8 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mitchell Rowett, Kim Morrison
 -/
 import Mathlib.Algebra.Group.Subgroup.MulOpposite
+import Mathlib.Algebra.Quotient
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.Data.Setoid.Basic
 import Mathlib.GroupTheory.Coset.Defs
-import Mathlib.GroupTheory.GroupAction.Basic
 
 /-!
 # Cosets

--- a/Mathlib/GroupTheory/Coset/Basic.lean
+++ b/Mathlib/GroupTheory/Coset/Basic.lean
@@ -4,11 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mitchell Rowett, Kim Morrison
 -/
 import Mathlib.Algebra.Group.Subgroup.MulOpposite
-import Mathlib.Algebra.Quotient
-import Mathlib.Data.Fintype.Card
-import Mathlib.Data.Set.Pointwise.SMul
-import Mathlib.Data.Setoid.Basic
-import Mathlib.GroupTheory.GroupAction.Defs
+import Mathlib.GroupTheory.Coset.Defs
+import Mathlib.GroupTheory.GroupAction.Basic
 
 /-!
 # Cosets
@@ -25,10 +22,6 @@ If instead `G` is an additive group, we can write (with  `open scoped Pointwise`
 
 ## Main definitions
 
-* `QuotientGroup.quotient s`: the quotient type representing the left cosets with respect to a
-  subgroup `s`, for an `AddGroup` this is `QuotientAddGroup.quotient s`.
-* `QuotientGroup.mk`: the canonical map from `α` to `α/s` for a subgroup `s` of `α`, for an
-  `AddGroup` this is `QuotientAddGroup.mk`.
 * `Subgroup.leftCosetEquivSubgroup`: the natural bijection between a left coset and the subgroup,
   for an `AddGroup` this is `AddSubgroup.leftCosetEquivAddSubgroup`.
 
@@ -221,49 +214,15 @@ theorem rightCoset_eq_iff {x y : α} : op x • (s : Set α) = op y • s ↔ y 
 
 end CosetSubgroup
 
--- Porting note: see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.E2.9C.94.20to_additive.2Emap_namespace
-run_cmd Lean.Elab.Command.liftCoreM <| ToAdditive.insertTranslation `QuotientGroup `QuotientAddGroup
-
 namespace QuotientGroup
 
 variable [Group α] (s : Subgroup α)
-
-/-- The equivalence relation corresponding to the partition of a group by left cosets
-of a subgroup. -/
-@[to_additive "The equivalence relation corresponding to the partition of a group by left cosets
- of a subgroup."]
-def leftRel : Setoid α :=
-  MulAction.orbitRel s.op α
-
-variable {s}
-
-@[to_additive]
-theorem leftRel_apply {x y : α} : leftRel s x y ↔ x⁻¹ * y ∈ s :=
-  calc
-    (∃ a : s.op, y * MulOpposite.unop a = x) ↔ ∃ a : s, y * a = x :=
-      s.equivOp.symm.exists_congr_left
-    _ ↔ ∃ a : s, x⁻¹ * y = a⁻¹ := by
-      simp only [inv_mul_eq_iff_eq_mul, Subgroup.coe_inv, eq_mul_inv_iff_mul_eq]
-    _ ↔ x⁻¹ * y ∈ s := by simp [exists_inv_mem_iff_exists_mem]
-
-variable (s)
-
-@[to_additive]
-theorem leftRel_eq : ⇑(leftRel s) = fun x y => x⁻¹ * y ∈ s :=
-  funext₂ <| by
-    simp only [eq_iff_iff]
-    apply leftRel_apply
 
 theorem leftRel_r_eq_leftCosetEquivalence :
     ⇑(QuotientGroup.leftRel s) = LeftCosetEquivalence s := by
   ext
   rw [leftRel_eq]
   exact (leftCoset_eq_iff s).symm
-
-@[to_additive]
-instance leftRelDecidable [DecidablePred (· ∈ s)] : DecidableRel (leftRel s).r := fun x y => by
-  rw [leftRel_eq]
-  exact ‹DecidablePred (· ∈ s)› _
 
 @[to_additive]
 lemma leftRel_prod {β : Type*} [Group β] (s' : Subgroup β) :
@@ -279,47 +238,11 @@ lemma leftRel_pi {ι : Type*} {β : ι → Type*} [∀ i, Group (β i)] (s' : �
   refine Setoid.ext fun x y ↦ ?_
   simp [Setoid.piSetoid_apply, leftRel_apply, Subgroup.mem_pi]
 
-/-- `α ⧸ s` is the quotient type representing the left cosets of `s`.
-  If `s` is a normal subgroup, `α ⧸ s` is a group -/
-@[to_additive "`α ⧸ s` is the quotient type representing the left cosets of `s`.  If `s` is a normal
- subgroup, `α ⧸ s` is a group"]
-instance instHasQuotientSubgroup : HasQuotient α (Subgroup α) :=
-  ⟨fun s => Quotient (leftRel s)⟩
-
-/-- The equivalence relation corresponding to the partition of a group by right cosets of a
-subgroup. -/
-@[to_additive "The equivalence relation corresponding to the partition of a group by right cosets
- of a subgroup."]
-def rightRel : Setoid α :=
-  MulAction.orbitRel s α
-
-variable {s}
-
-@[to_additive]
-theorem rightRel_apply {x y : α} : rightRel s x y ↔ y * x⁻¹ ∈ s :=
-  calc
-    (∃ a : s, (a : α) * y = x) ↔ ∃ a : s, y * x⁻¹ = a⁻¹ := by
-      simp only [mul_inv_eq_iff_eq_mul, Subgroup.coe_inv, eq_inv_mul_iff_mul_eq]
-    _ ↔ y * x⁻¹ ∈ s := by simp [exists_inv_mem_iff_exists_mem]
-
-variable (s)
-
-@[to_additive]
-theorem rightRel_eq : ⇑(rightRel s) = fun x y => y * x⁻¹ ∈ s :=
-  funext₂ <| by
-    simp only [eq_iff_iff]
-    apply rightRel_apply
-
 theorem rightRel_r_eq_rightCosetEquivalence :
     ⇑(QuotientGroup.rightRel s) = RightCosetEquivalence s := by
   ext
   rw [rightRel_eq]
   exact (rightCoset_eq_iff s).symm
-
-@[to_additive]
-instance rightRelDecidable [DecidablePred (· ∈ s)] : DecidableRel (rightRel s).r := fun x y => by
-  rw [rightRel_eq]
-  exact ‹DecidablePred (· ∈ s)› _
 
 @[to_additive]
 lemma rightRel_prod {β : Type*} [Group β] (s' : Subgroup β) :
@@ -334,32 +257,6 @@ lemma rightRel_pi {ι : Type*} {β : ι → Type*} [∀ i, Group (β i)] (s' : �
     rightRel (Subgroup.pi Set.univ s') = @piSetoid _ _ fun i ↦ rightRel (s' i) := by
   refine Setoid.ext fun x y ↦ ?_
   simp [Setoid.piSetoid_apply, rightRel_apply, Subgroup.mem_pi]
-
-/-- Right cosets are in bijection with left cosets. -/
-@[to_additive "Right cosets are in bijection with left cosets."]
-def quotientRightRelEquivQuotientLeftRel : Quotient (QuotientGroup.rightRel s) ≃ α ⧸ s where
-  toFun :=
-    Quotient.map' (fun g => g⁻¹) fun a b => by
-      rw [leftRel_apply, rightRel_apply]
-      exact fun h => (congr_arg (· ∈ s) (by simp [mul_assoc])).mp (s.inv_mem h)
-      -- Porting note: replace with `by group`
-  invFun :=
-    Quotient.map' (fun g => g⁻¹) fun a b => by
-      rw [leftRel_apply, rightRel_apply]
-      exact fun h => (congr_arg (· ∈ s) (by simp [mul_assoc])).mp (s.inv_mem h)
-      -- Porting note: replace with `by group`
-  left_inv g :=
-    Quotient.inductionOn' g fun g =>
-      Quotient.sound'
-        (by
-          simp only [inv_inv]
-          exact Quotient.exact' rfl)
-  right_inv g :=
-    Quotient.inductionOn' g fun g =>
-      Quotient.sound'
-        (by
-          simp only [inv_inv]
-          exact Quotient.exact' rfl)
 
 @[to_additive]
 instance fintypeQuotientRightRel [Fintype (α ⧸ s)] :
@@ -381,56 +278,6 @@ variable [Group α] {s : Subgroup α}
 instance fintype [Fintype α] (s : Subgroup α) [DecidableRel (leftRel s).r] : Fintype (α ⧸ s) :=
   Quotient.fintype (leftRel s)
 
-/-- The canonical map from a group `α` to the quotient `α ⧸ s`. -/
-@[to_additive (attr := coe) "The canonical map from an `AddGroup` `α` to the quotient `α ⧸ s`."]
-abbrev mk (a : α) : α ⧸ s :=
-  Quotient.mk'' a
-
-@[to_additive]
-theorem mk_surjective : Function.Surjective <| @mk _ _ s :=
-  Quotient.surjective_Quotient_mk''
-
-@[to_additive (attr := simp)]
-lemma range_mk : range (QuotientGroup.mk (s := s)) = univ := range_iff_surjective.mpr mk_surjective
-
-@[to_additive (attr := elab_as_elim)]
-theorem induction_on {C : α ⧸ s → Prop} (x : α ⧸ s) (H : ∀ z, C (QuotientGroup.mk z)) : C x :=
-  Quotient.inductionOn' x H
-
-@[to_additive]
-instance : Coe α (α ⧸ s) :=
-  ⟨mk⟩
-
-@[to_additive (attr := deprecated (since := "2024-08-04"))] alias induction_on' := induction_on
-
-@[to_additive (attr := simp)]
-theorem quotient_liftOn_mk {β} (f : α → β) (h) (x : α) : Quotient.liftOn' (x : α ⧸ s) f h = f x :=
-  rfl
-
-@[to_additive]
-theorem forall_mk {C : α ⧸ s → Prop} : (∀ x : α ⧸ s, C x) ↔ ∀ x : α, C x :=
-  mk_surjective.forall
-
-@[to_additive]
-theorem exists_mk {C : α ⧸ s → Prop} : (∃ x : α ⧸ s, C x) ↔ ∃ x : α, C x :=
-  mk_surjective.exists
-
-@[to_additive]
-instance (s : Subgroup α) : Inhabited (α ⧸ s) :=
-  ⟨((1 : α) : α ⧸ s)⟩
-
-@[to_additive]
-protected theorem eq {a b : α} : (a : α ⧸ s) = b ↔ a⁻¹ * b ∈ s :=
-  calc
-    _ ↔ leftRel s a b := Quotient.eq''
-    _ ↔ _ := by rw [leftRel_apply]
-
-@[to_additive (attr := deprecated (since := "2024-08-04"))] alias eq' := QuotientGroup.eq
-
-@[to_additive]
-theorem out_eq' (a : α ⧸ s) : mk a.out' = a :=
-  Quotient.out_eq' a
-
 variable (s)
 
 /-- Given a subgroup `s`, the function that sends a subgroup `t` to the pair consisting of
@@ -448,46 +295,13 @@ theorem strictMono_comap_prod_image :
   convert ← t₁.mul_mem h' (@le1 ⟨_, QuotientGroup.eq.1 eq⟩ <| t₂.mul_mem (t₂.inv_mem <| h.1 h') ha)
   apply mul_inv_cancel_left
 
-/- It can be useful to write `obtain ⟨h, H⟩ := mk_out'_eq_mul ...`, and then `rw [H]` or
-  `simp_rw [H]` or `simp only [H]`. In order for `simp_rw` and `simp only` to work, this lemma is
-  stated in terms of an arbitrary `h : s`, rather than the specific `h = g⁻¹ * (mk g).out'`. -/
-@[to_additive QuotientAddGroup.mk_out'_eq_mul]
-theorem mk_out'_eq_mul (g : α) : ∃ h : s, (mk g : α ⧸ s).out' = g * h :=
-  ⟨⟨g⁻¹ * (mk g).out', QuotientGroup.eq.mp (mk g).out_eq'.symm⟩, by rw [mul_inv_cancel_left]⟩
-
 variable {s} {a b : α}
-
-@[to_additive (attr := simp)]
-theorem mk_mul_of_mem (a : α) (hb : b ∈ s) : (mk (a * b) : α ⧸ s) = mk a := by
-  rwa [QuotientGroup.eq, mul_inv_rev, inv_mul_cancel_right, s.inv_mem_iff]
 
 @[to_additive]
 theorem eq_class_eq_leftCoset (s : Subgroup α) (g : α) :
     { x : α | (x : α ⧸ s) = g } = g • s :=
   Set.ext fun z => by
     rw [mem_leftCoset_iff, Set.mem_setOf_eq, eq_comm, QuotientGroup.eq, SetLike.mem_coe]
-
-@[to_additive]
-theorem preimage_image_mk (N : Subgroup α) (s : Set α) :
-    mk ⁻¹' ((mk : α → α ⧸ N) '' s) = ⋃ x : N, (· * (x : α)) ⁻¹' s := by
-  ext x
-  simp only [QuotientGroup.eq, SetLike.exists, exists_prop, Set.mem_preimage, Set.mem_iUnion,
-    Set.mem_image, ← eq_inv_mul_iff_mul_eq]
-  exact
-    ⟨fun ⟨y, hs, hN⟩ => ⟨_, N.inv_mem hN, by simpa using hs⟩, fun ⟨z, hz, hxz⟩ =>
-      ⟨x * z, hxz, by simpa using hz⟩⟩
-
-@[to_additive]
-theorem preimage_image_mk_eq_iUnion_image (N : Subgroup α) (s : Set α) :
-    mk ⁻¹' ((mk : α → α ⧸ N) '' s) = ⋃ x : N, (· * (x : α)) '' s := by
-  rw [preimage_image_mk, iUnion_congr_of_surjective (·⁻¹) inv_surjective]
-  exact fun x ↦ image_mul_right'
-
-@[to_additive]
-theorem preimage_image_mk_eq_mul (N : Subgroup α) (s : Set α) :
-    mk ⁻¹' ((mk : α → α ⧸ N) '' s) = s * N := by
-  rw [preimage_image_mk_eq_iUnion_image, iUnion_subtype, ← image2_mul, ← iUnion_image_right]
-  simp only [SetLike.mem_coe]
 
 open MulAction in
 @[to_additive]
@@ -539,18 +353,6 @@ noncomputable def groupEquivQuotientProdSubgroup : α ≃ (α ⧸ s) × s :=
     _ ≃ (α ⧸ s) × s := Equiv.sigmaEquivProd _ _
 
 variable {t : Subgroup α}
-
-/-- If two subgroups `M` and `N` of `G` are equal, their quotients are in bijection. -/
-@[to_additive "If two subgroups `M` and `N` of `G` are equal, their quotients are in bijection."]
-def quotientEquivOfEq (h : s = t) : α ⧸ s ≃ α ⧸ t where
-  toFun := Quotient.map' id fun _a _b h' => h ▸ h'
-  invFun := Quotient.map' id fun _a _b h' => h.symm ▸ h'
-  left_inv q := induction_on q fun _g => rfl
-  right_inv q := induction_on q fun _g => rfl
-
-theorem quotientEquivOfEq_mk (h : s = t) (a : α) :
-    quotientEquivOfEq h (QuotientGroup.mk a) = QuotientGroup.mk a :=
-  rfl
 
 /-- If `H ≤ K`, then `G/H ≃ G/K × K/H` constructively, using the provided right inverse
 of the quotient map `G → G/K`. The classical version is `Subgroup.quotientEquivProdOfLE`. -/

--- a/Mathlib/GroupTheory/Coset/Defs.lean
+++ b/Mathlib/GroupTheory/Coset/Defs.lean
@@ -1,0 +1,261 @@
+/-
+Copyright (c) 2018 Mitchell Rowett. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mitchell Rowett, Kim Morrison
+-/
+import Mathlib.Algebra.Quotient
+import Mathlib.Algebra.Group.Subgroup.MulOpposite
+import Mathlib.GroupTheory.GroupAction.Defs
+
+/-!
+# Cosets
+
+This file develops the basic theory of left and right cosets.
+
+When `G` is a group and `a : G`, `s : Set G`, with  `open scoped Pointwise` we can write:
+* the left coset of `s` by `a` as `a • s`
+* the right coset of `s` by `a` as `MulOpposite.op a • s` (or `op a • s` with `open MulOpposite`)
+
+If instead `G` is an additive group, we can write (with  `open scoped Pointwise` still)
+* the left coset of `s` by `a` as `a +ᵥ s`
+* the right coset of `s` by `a` as `AddOpposite.op a +ᵥ s` (or `op a • s` with `open AddOpposite`)
+
+## Main definitions
+
+* `QuotientGroup.quotient s`: the quotient type representing the left cosets with respect to a
+  subgroup `s`, for an `AddGroup` this is `QuotientAddGroup.quotient s`.
+* `QuotientGroup.mk`: the canonical map from `α` to `α/s` for a subgroup `s` of `α`, for an
+  `AddGroup` this is `QuotientAddGroup.mk`.
+
+## Notation
+
+* `G ⧸ H` is the quotient of the (additive) group `G` by the (additive) subgroup `H`
+
+## TODO
+
+Properly merge with pointwise actions on sets, by renaming and deduplicating lemmas as appropriate.
+-/
+
+assert_not_exists Cardinal
+
+open Function Set
+open scoped Pointwise
+
+variable {α : Type*}
+
+-- Porting note: see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.E2.9C.94.20to_additive.2Emap_namespace
+run_cmd Lean.Elab.Command.liftCoreM <| ToAdditive.insertTranslation `QuotientGroup `QuotientAddGroup
+
+namespace QuotientGroup
+
+variable [Group α] (s : Subgroup α)
+
+/-- The equivalence relation corresponding to the partition of a group by left cosets
+of a subgroup. -/
+@[to_additive "The equivalence relation corresponding to the partition of a group by left cosets
+ of a subgroup."]
+def leftRel : Setoid α :=
+  MulAction.orbitRel s.op α
+
+variable {s}
+
+@[to_additive]
+theorem leftRel_apply {x y : α} : leftRel s x y ↔ x⁻¹ * y ∈ s :=
+  calc
+    (∃ a : s.op, y * MulOpposite.unop a = x) ↔ ∃ a : s, y * a = x :=
+      s.equivOp.symm.exists_congr_left
+    _ ↔ ∃ a : s, x⁻¹ * y = a⁻¹ := by
+      simp only [inv_mul_eq_iff_eq_mul, Subgroup.coe_inv, eq_mul_inv_iff_mul_eq]
+    _ ↔ x⁻¹ * y ∈ s := by simp [exists_inv_mem_iff_exists_mem]
+
+variable (s)
+
+@[to_additive]
+theorem leftRel_eq : ⇑(leftRel s) = fun x y => x⁻¹ * y ∈ s :=
+  funext₂ <| by
+    simp only [eq_iff_iff]
+    apply leftRel_apply
+
+@[to_additive]
+instance leftRelDecidable [DecidablePred (· ∈ s)] : DecidableRel (leftRel s).r := fun x y => by
+  rw [leftRel_eq]
+  exact ‹DecidablePred (· ∈ s)› _
+
+/-- `α ⧸ s` is the quotient type representing the left cosets of `s`.
+  If `s` is a normal subgroup, `α ⧸ s` is a group -/
+@[to_additive "`α ⧸ s` is the quotient type representing the left cosets of `s`.  If `s` is a normal
+ subgroup, `α ⧸ s` is a group"]
+instance instHasQuotientSubgroup : HasQuotient α (Subgroup α) :=
+  ⟨fun s => Quotient (leftRel s)⟩
+
+/-- The equivalence relation corresponding to the partition of a group by right cosets of a
+subgroup. -/
+@[to_additive "The equivalence relation corresponding to the partition of a group by right cosets
+ of a subgroup."]
+def rightRel : Setoid α :=
+  MulAction.orbitRel s α
+
+variable {s}
+
+@[to_additive]
+theorem rightRel_apply {x y : α} : rightRel s x y ↔ y * x⁻¹ ∈ s :=
+  calc
+    (∃ a : s, (a : α) * y = x) ↔ ∃ a : s, y * x⁻¹ = a⁻¹ := by
+      simp only [mul_inv_eq_iff_eq_mul, Subgroup.coe_inv, eq_inv_mul_iff_mul_eq]
+    _ ↔ y * x⁻¹ ∈ s := by simp [exists_inv_mem_iff_exists_mem]
+
+variable (s)
+
+@[to_additive]
+theorem rightRel_eq : ⇑(rightRel s) = fun x y => y * x⁻¹ ∈ s :=
+  funext₂ <| by
+    simp only [eq_iff_iff]
+    apply rightRel_apply
+
+@[to_additive]
+instance rightRelDecidable [DecidablePred (· ∈ s)] : DecidableRel (rightRel s).r := fun x y => by
+  rw [rightRel_eq]
+  exact ‹DecidablePred (· ∈ s)› _
+
+/-- Right cosets are in bijection with left cosets. -/
+@[to_additive "Right cosets are in bijection with left cosets."]
+def quotientRightRelEquivQuotientLeftRel : Quotient (QuotientGroup.rightRel s) ≃ α ⧸ s where
+  toFun :=
+    Quotient.map' (fun g => g⁻¹) fun a b => by
+      rw [leftRel_apply, rightRel_apply]
+      exact fun h => (congr_arg (· ∈ s) (by simp [mul_assoc])).mp (s.inv_mem h)
+      -- Porting note: replace with `by group`
+  invFun :=
+    Quotient.map' (fun g => g⁻¹) fun a b => by
+      rw [leftRel_apply, rightRel_apply]
+      exact fun h => (congr_arg (· ∈ s) (by simp [mul_assoc])).mp (s.inv_mem h)
+      -- Porting note: replace with `by group`
+  left_inv g :=
+    Quotient.inductionOn' g fun g =>
+      Quotient.sound'
+        (by
+          simp only [inv_inv]
+          exact Quotient.exact' rfl)
+  right_inv g :=
+    Quotient.inductionOn' g fun g =>
+      Quotient.sound'
+        (by
+          simp only [inv_inv]
+          exact Quotient.exact' rfl)
+
+end QuotientGroup
+
+namespace QuotientGroup
+
+variable [Group α] {s : Subgroup α}
+
+/-- The canonical map from a group `α` to the quotient `α ⧸ s`. -/
+@[to_additive (attr := coe) "The canonical map from an `AddGroup` `α` to the quotient `α ⧸ s`."]
+abbrev mk (a : α) : α ⧸ s :=
+  Quotient.mk'' a
+
+@[to_additive]
+theorem mk_surjective : Function.Surjective <| @mk _ _ s :=
+  Quotient.surjective_Quotient_mk''
+
+@[to_additive (attr := simp)]
+lemma range_mk : range (QuotientGroup.mk (s := s)) = univ := range_iff_surjective.mpr mk_surjective
+
+@[to_additive (attr := elab_as_elim)]
+theorem induction_on {C : α ⧸ s → Prop} (x : α ⧸ s) (H : ∀ z, C (QuotientGroup.mk z)) : C x :=
+  Quotient.inductionOn' x H
+
+@[to_additive]
+instance : Coe α (α ⧸ s) :=
+  ⟨mk⟩
+
+@[to_additive (attr := deprecated (since := "2024-08-04"))] alias induction_on' := induction_on
+
+@[to_additive (attr := simp)]
+theorem quotient_liftOn_mk {β} (f : α → β) (h) (x : α) : Quotient.liftOn' (x : α ⧸ s) f h = f x :=
+  rfl
+
+@[to_additive]
+theorem forall_mk {C : α ⧸ s → Prop} : (∀ x : α ⧸ s, C x) ↔ ∀ x : α, C x :=
+  mk_surjective.forall
+
+@[to_additive]
+theorem exists_mk {C : α ⧸ s → Prop} : (∃ x : α ⧸ s, C x) ↔ ∃ x : α, C x :=
+  mk_surjective.exists
+
+@[to_additive]
+instance (s : Subgroup α) : Inhabited (α ⧸ s) :=
+  ⟨((1 : α) : α ⧸ s)⟩
+
+@[to_additive]
+protected theorem eq {a b : α} : (a : α ⧸ s) = b ↔ a⁻¹ * b ∈ s :=
+  calc
+    _ ↔ leftRel s a b := Quotient.eq''
+    _ ↔ _ := by rw [leftRel_apply]
+
+@[to_additive (attr := deprecated (since := "2024-08-04"))] alias eq' := QuotientGroup.eq
+
+@[to_additive]
+theorem out_eq' (a : α ⧸ s) : mk a.out' = a :=
+  Quotient.out_eq' a
+
+variable (s)
+
+/- It can be useful to write `obtain ⟨h, H⟩ := mk_out'_eq_mul ...`, and then `rw [H]` or
+  `simp_rw [H]` or `simp only [H]`. In order for `simp_rw` and `simp only` to work, this lemma is
+  stated in terms of an arbitrary `h : s`, rather than the specific `h = g⁻¹ * (mk g).out'`. -/
+@[to_additive QuotientAddGroup.mk_out'_eq_mul]
+theorem mk_out'_eq_mul (g : α) : ∃ h : s, (mk g : α ⧸ s).out' = g * h :=
+  ⟨⟨g⁻¹ * (mk g).out', QuotientGroup.eq.mp (mk g).out_eq'.symm⟩, by rw [mul_inv_cancel_left]⟩
+
+variable {s} {a b : α}
+
+@[to_additive (attr := simp)]
+theorem mk_mul_of_mem (a : α) (hb : b ∈ s) : (mk (a * b) : α ⧸ s) = mk a := by
+  rwa [QuotientGroup.eq, mul_inv_rev, inv_mul_cancel_right, s.inv_mem_iff]
+
+@[to_additive]
+theorem preimage_image_mk (N : Subgroup α) (s : Set α) :
+    mk ⁻¹' ((mk : α → α ⧸ N) '' s) = ⋃ x : N, (· * (x : α)) ⁻¹' s := by
+  ext x
+  simp only [QuotientGroup.eq, SetLike.exists, exists_prop, Set.mem_preimage, Set.mem_iUnion,
+    Set.mem_image, ← eq_inv_mul_iff_mul_eq]
+  exact
+    ⟨fun ⟨y, hs, hN⟩ => ⟨_, N.inv_mem hN, by simpa using hs⟩, fun ⟨z, hz, hxz⟩ =>
+      ⟨x * z, hxz, by simpa using hz⟩⟩
+
+@[to_additive]
+theorem preimage_image_mk_eq_iUnion_image (N : Subgroup α) (s : Set α) :
+    mk ⁻¹' ((mk : α → α ⧸ N) '' s) = ⋃ x : N, (· * (x : α)) '' s := by
+  rw [preimage_image_mk, iUnion_congr_of_surjective (·⁻¹) inv_surjective]
+  exact fun x ↦ image_mul_right'
+
+@[to_additive]
+theorem preimage_image_mk_eq_mul (N : Subgroup α) (s : Set α) :
+    mk ⁻¹' ((mk : α → α ⧸ N) '' s) = s * N := by
+  rw [preimage_image_mk_eq_iUnion_image, iUnion_subtype, ← image2_mul, ← iUnion_image_right]
+  simp only [SetLike.mem_coe]
+
+end QuotientGroup
+
+namespace Subgroup
+
+open QuotientGroup
+
+variable [Group α] {s : Subgroup α}
+
+variable {t : Subgroup α}
+
+/-- If two subgroups `M` and `N` of `G` are equal, their quotients are in bijection. -/
+@[to_additive "If two subgroups `M` and `N` of `G` are equal, their quotients are in bijection."]
+def quotientEquivOfEq (h : s = t) : α ⧸ s ≃ α ⧸ t where
+  toFun := Quotient.map' id fun _a _b h' => h ▸ h'
+  invFun := Quotient.map' id fun _a _b h' => h.symm ▸ h'
+  left_inv q := induction_on q fun _g => rfl
+  right_inv q := induction_on q fun _g => rfl
+
+theorem quotientEquivOfEq_mk (h : s = t) (a : α) :
+    quotientEquivOfEq h (QuotientGroup.mk a) = QuotientGroup.mk a :=
+  rfl
+
+end Subgroup

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Emilie Burgun
 -/
 import Mathlib.Algebra.Group.Commute.Basic
-import Mathlib.Dynamics.PeriodicPts
 import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.Dynamics.PeriodicPts
 import Mathlib.GroupTheory.GroupAction.Defs
 
 /-!

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -4,13 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Data.Finset.Update
+import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.Data.Prod.TProd
+import Mathlib.Data.Set.UnionLift
+import Mathlib.GroupTheory.Coset.Defs
 import Mathlib.Logic.Equiv.Fin
 import Mathlib.MeasureTheory.MeasurableSpace.Instances
-import Mathlib.Order.LiminfLimsup
-import Mathlib.Data.Set.UnionLift
 import Mathlib.Order.Filter.SmallSets
-import Mathlib.GroupTheory.Coset.Basic
+import Mathlib.Order.LiminfLimsup
 
 /-!
 # Measurable spaces and measurable functions


### PR DESCRIPTION
The goal of this PR is to have a file with the definitions for the quotient of a group, in terms of cosets. We include enough theory to put a group structure on the quotient by a normal group.

---

- [ ] depends on: #18345

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
