### PR TITLE
[Merged by Bors] - refactor(RingTheory/Ideal/Pointwise): Generalize to semirings

### DIFF
--- a/Mathlib/RingTheory/Ideal/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Over.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
+import Mathlib.RingTheory.Ideal.Pointwise
 import Mathlib.RingTheory.Localization.AtPrime
 import Mathlib.RingTheory.Localization.Integral
 
@@ -28,11 +29,8 @@ variable {R : Type*} [CommRing R]
 
 namespace Ideal
 
-open Polynomial
-
-open Polynomial
-
-open Submodule
+open Polynomial Submodule
+open scoped Pointwise
 
 section CommRing
 
@@ -442,6 +440,12 @@ theorem under_def : P.under A = Ideal.comap (algebraMap A B) P := rfl
 
 instance IsPrime.under [hP : P.IsPrime] : (P.under A).IsPrime :=
   hP.comap (algebraMap A B)
+
+@[simp]
+lemma under_smul {G : Type*} [Group G] [MulSemiringAction G B] [SMulCommClass G A B] (g : G) :
+    (g • P : Ideal B).under A = P.under A := by
+  ext a
+  rw [mem_comap, mem_comap, mem_pointwise_smul_iff_inv_smul_mem, smul_algebraMap]
 
 variable {A}
 

--- a/Mathlib/RingTheory/Ideal/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Over.lean
@@ -30,6 +30,7 @@ variable {R : Type*} [CommRing R]
 namespace Ideal
 
 open Polynomial Submodule
+
 open scoped Pointwise
 
 section CommRing

--- a/Mathlib/RingTheory/Ideal/Pointwise.lean
+++ b/Mathlib/RingTheory/Ideal/Pointwise.lean
@@ -33,7 +33,7 @@ variable [Monoid M] [Semiring R] [MulSemiringAction M R]
 /-- The action on an ideal corresponding to applying the action to every element.
 
 This is available as an instance in the `Pointwise` locale. -/
-protected def pointwiseMulAction : DistribMulAction M (Ideal R) where
+protected def pointwiseDistribMulAction : DistribMulAction M (Ideal R) where
   smul a := Ideal.map (MulSemiringAction.toRingHom _ _ a)
   one_smul I :=
     congr_arg (I.map ·) (RingHom.ext <| one_smul M) |>.trans I.map_id
@@ -42,7 +42,7 @@ protected def pointwiseMulAction : DistribMulAction M (Ideal R) where
   smul_zero _ := Ideal.map_bot
   smul_add _ I J := Ideal.map_sup _ I J
 
-scoped[Pointwise] attribute [instance] Ideal.pointwiseMulAction
+scoped[Pointwise] attribute [instance] Ideal.pointwiseDistribMulAction
 
 open Pointwise
 

--- a/Mathlib/RingTheory/Ideal/Pointwise.lean
+++ b/Mathlib/RingTheory/Ideal/Pointwise.lean
@@ -33,12 +33,14 @@ variable [Monoid M] [Semiring R] [MulSemiringAction M R]
 /-- The action on an ideal corresponding to applying the action to every element.
 
 This is available as an instance in the `Pointwise` locale. -/
-protected def pointwiseMulAction : MulAction M (Ideal R) where
+protected def pointwiseMulAction : DistribMulAction M (Ideal R) where
   smul a := Ideal.map (MulSemiringAction.toRingHom _ _ a)
   one_smul I :=
     congr_arg (I.map ·) (RingHom.ext <| one_smul M) |>.trans I.map_id
   mul_smul _ _ I :=
     congr_arg (I.map ·) (RingHom.ext <| mul_smul _ _) |>.trans (I.map_map _ _).symm
+  smul_zero _ := Ideal.map_bot
+  smul_add _ I J := Ideal.map_sup _ I J
 
 scoped[Pointwise] attribute [instance] Ideal.pointwiseMulAction
 
@@ -51,8 +53,6 @@ protected def pointwiseMulSemiringAction {R : Type*} [CommRing R] [MulSemiringAc
     MulSemiringAction M (Ideal R) where
   smul_one a := by simp only [Ideal.one_eq_top]; exact Ideal.map_top _
   smul_mul a I J := Ideal.map_mul (MulSemiringAction.toRingHom _ _ a) I J
-  smul_add _ I J := Ideal.map_sup _ I J
-  smul_zero _ := Ideal.map_bot
 
 scoped[Pointwise] attribute [instance] Ideal.pointwiseMulSemiringAction
 

--- a/Mathlib/RingTheory/Ideal/Pointwise.lean
+++ b/Mathlib/RingTheory/Ideal/Pointwise.lean
@@ -28,25 +28,33 @@ namespace Ideal
 
 section Monoid
 
-variable [Monoid M] [CommRing R] [MulSemiringAction M R]
+variable [Monoid M] [Semiring R] [MulSemiringAction M R]
 
 /-- The action on an ideal corresponding to applying the action to every element.
 
 This is available as an instance in the `Pointwise` locale. -/
-protected def pointwiseMulSemiringAction : MulSemiringAction M (Ideal R) where
+protected def pointwiseMulAction : MulAction M (Ideal R) where
   smul a := Ideal.map (MulSemiringAction.toRingHom _ _ a)
   one_smul I :=
     congr_arg (I.map ·) (RingHom.ext <| one_smul M) |>.trans I.map_id
   mul_smul _ _ I :=
     congr_arg (I.map ·) (RingHom.ext <| mul_smul _ _) |>.trans (I.map_map _ _).symm
+
+scoped[Pointwise] attribute [instance] Ideal.pointwiseMulAction
+
+open Pointwise
+
+/-- The action on an ideal corresponding to applying the action to every element.
+
+This is available as an instance in the `Pointwise` locale. -/
+protected def pointwiseMulSemiringAction {R : Type*} [CommRing R] [MulSemiringAction M R] :
+    MulSemiringAction M (Ideal R) where
   smul_one a := by simp only [Ideal.one_eq_top]; exact Ideal.map_top _
   smul_mul a I J := Ideal.map_mul (MulSemiringAction.toRingHom _ _ a) I J
   smul_add _ I J := Ideal.map_sup _ I J
   smul_zero _ := Ideal.map_bot
 
 scoped[Pointwise] attribute [instance] Ideal.pointwiseMulSemiringAction
-
-open Pointwise
 
 theorem pointwise_smul_def {a : M} (S : Ideal R) :
     a • S = S.map (MulSemiringAction.toRingHom _ _ a) :=
@@ -76,12 +84,25 @@ instance pointwise_central_scalar [MulSemiringAction Mᵐᵒᵖ R] [IsCentralSca
     IsCentralScalar M (Ideal R) :=
   ⟨fun _ S => (congr_arg fun f => S.map f) <| RingHom.ext <| op_smul_eq_smul _⟩
 
+@[simp]
+theorem pointwise_smul_toAddSubmonoid (a : M) (S : Ideal R)
+    (ha : Function.Surjective fun r : R => a • r) :
+    (a • S).toAddSubmonoid = a • S.toAddSubmonoid := by
+  ext
+  exact Ideal.mem_map_iff_of_surjective _ <| by exact ha
+
+@[simp]
+theorem pointwise_smul_toAddSubGroup {R : Type*} [Ring R] [MulSemiringAction M R]
+    (a : M) (S : Ideal R) (ha : Function.Surjective fun r : R => a • r)  :
+    (a • S).toAddSubgroup = a • S.toAddSubgroup := by
+  ext
+  exact Ideal.mem_map_iff_of_surjective _ <| by exact ha
+
 end Monoid
 
 section Group
 
-variable [Group M] [CommRing R] [MulSemiringAction M R]
-
+variable [Group M] [Semiring R] [MulSemiringAction M R]
 
 open Pointwise
 
@@ -99,20 +120,6 @@ theorem mem_pointwise_smul_iff_inv_smul_mem {a : M} {S : Ideal R} {x : R} :
     x ∈ a • S ↔ a⁻¹ • x ∈ S :=
   ⟨fun h => by simpa using smul_mem_pointwise_smul a⁻¹ _ _ h,
     fun h => by simpa using smul_mem_pointwise_smul a _ _ h⟩
-
-@[simp]
-theorem pointwise_smul_toAddSubmonoid (a : M) (S : Ideal R)
-    (ha : Function.Surjective fun r : R => a • r) :
-    (a • S).toAddSubmonoid = a • S.toAddSubmonoid := by
-  ext
-  exact Ideal.mem_map_iff_of_surjective _ <| by exact ha
-
-@[simp]
-theorem pointwise_smul_toAddSubGroup (a : M) (S : Ideal R)
-    (ha : Function.Surjective fun r : R => a • r)  :
-    (a • S).toAddSubgroup = a • S.toAddSubgroup := by
-  ext
-  exact Ideal.mem_map_iff_of_surjective _ <| by exact ha
 
 theorem mem_inv_pointwise_smul_iff {a : M} {S : Ideal R} {x : R} : x ∈ a⁻¹ • S ↔ a • x ∈ S := by
   rw [mem_pointwise_smul_iff_inv_smul_mem, inv_inv]


### PR DESCRIPTION
This PR generalizes much of `RingTheory/Ideal/Pointwise` to semirings. I also moved a couple lemmas from the `Group` section to the `Monoid` section, and added a lemma to `RingTheory/Ideal/Over`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
