### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry/Morphisms): affine + ring hom property

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -887,6 +887,7 @@ import Mathlib.AlgebraicGeometry.Modules.Presheaf
 import Mathlib.AlgebraicGeometry.Modules.Sheaf
 import Mathlib.AlgebraicGeometry.Modules.Tilde
 import Mathlib.AlgebraicGeometry.Morphisms.Affine
+import Mathlib.AlgebraicGeometry.Morphisms.AffineAnd
 import Mathlib.AlgebraicGeometry.Morphisms.Basic
 import Mathlib.AlgebraicGeometry.Morphisms.ClosedImmersion
 import Mathlib.AlgebraicGeometry.Morphisms.Constructors

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -574,6 +574,35 @@ lemma appLE_eq_away_map {X Y : Scheme.{u}} (f : X ⟶ Y) {U : Y.Opens} (hU : IsA
     RingHom.algebraMap_toAlgebra, RingHom.algebraMap_toAlgebra, ← CommRingCat.comp_eq_ring_hom_comp,
     Scheme.Hom.appLE_map, Scheme.Hom.map_appLE]
 
+lemma app_basicOpen_eq_away_map {X Y : Scheme.{u}} (f : X ⟶ Y) {U : Y.Opens}
+    (hU : IsAffineOpen U) (h : IsAffineOpen (f ⁻¹ᵁ U)) (r : Γ(Y, U)) :
+    haveI := hU.isLocalization_basicOpen r
+    haveI := h.isLocalization_basicOpen (f.app U r)
+    f.app (Y.basicOpen r) =
+      IsLocalization.Away.map Γ(Y, Y.basicOpen r) Γ(X, X.basicOpen (f.app U r)) (f.app U) r ≫
+        X.presheaf.map (eqToHom (by simp)).op := by
+  haveI := hU.isLocalization_basicOpen r
+  haveI := h.isLocalization_basicOpen (f.app U r)
+  apply IsLocalization.ringHom_ext (.powers r)
+  rw [← CommRingCat.comp_eq_ring_hom_comp, ← CommRingCat.comp_eq_ring_hom_comp,
+    IsLocalization.Away.map, ← Category.assoc]
+  nth_rw 3 [CommRingCat.comp_eq_ring_hom_comp]
+  rw [IsLocalization.map_comp, RingHom.algebraMap_toAlgebra, ← CommRingCat.comp_eq_ring_hom_comp,
+    RingHom.algebraMap_toAlgebra, Category.assoc, ← X.presheaf.map_comp]
+  simp
+
+/-- `f.app (Y.basicOpen r)` is isomorphic to map induced on localizations
+`Γ(Y, Y.basicOpen r) ⟶ Γ(X, X.basicOpen (f.app U r))` -/
+def appBasicOpenIsoAwayMap {X Y : Scheme.{u}} (f : X ⟶ Y) {U : Y.Opens}
+    (hU : IsAffineOpen U) (h : IsAffineOpen (f ⁻¹ᵁ U)) (r : Γ(Y, U)) :
+    haveI := hU.isLocalization_basicOpen r
+    haveI := h.isLocalization_basicOpen (f.app U r)
+    Arrow.mk (f.app (Y.basicOpen r)) ≅
+      Arrow.mk (IsLocalization.Away.map Γ(Y, Y.basicOpen r)
+        Γ(X, X.basicOpen (f.app U r)) (f.app U) r) :=
+  Arrow.isoMk (Iso.refl _) (X.presheaf.mapIso (eqToIso (by simp)).op) <| by
+    simp [hU.app_basicOpen_eq_away_map f h]
+
 include hU in
 theorem isLocalization_of_eq_basicOpen {V : X.Opens} (i : V ⟶ U) (e : V = X.basicOpen f) :
     @IsLocalization.Away _ _ f Γ(X, V) _ (X.presheaf.map i.op).toAlgebra := by

--- a/Mathlib/AlgebraicGeometry/Morphisms/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Affine.lean
@@ -45,12 +45,6 @@ the preimage of any affine open subset of `Y` is affine. -/
 class IsAffineHom {X Y : Scheme} (f : X ⟶ Y) : Prop where
   isAffine_preimage : ∀ U : Y.Opens, IsAffineOpen U → IsAffineOpen (f ⁻¹ᵁ U)
 
-/-- Alternative of `isAffineHom_iff` with bundled affine opens. -/
-lemma isAffineHom_iff' {X Y : Scheme.{u}} (f : X ⟶ Y) :
-    IsAffineHom f ↔ ∀ (U : Y.affineOpens), IsAffineOpen (f ⁻¹ᵁ U) := by
-  rw [isAffineHom_iff, Subtype.forall]
-  rfl
-
 lemma IsAffineOpen.preimage {X Y : Scheme} {U : Y.Opens} (hU : IsAffineOpen U)
     (f : X ⟶ Y) [IsAffineHom f] :
     IsAffineOpen (f ⁻¹ᵁ U) :=

--- a/Mathlib/AlgebraicGeometry/Morphisms/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Affine.lean
@@ -45,6 +45,12 @@ the preimage of any affine open subset of `Y` is affine. -/
 class IsAffineHom {X Y : Scheme} (f : X ⟶ Y) : Prop where
   isAffine_preimage : ∀ U : Y.Opens, IsAffineOpen U → IsAffineOpen (f ⁻¹ᵁ U)
 
+/-- Alternative of `isAffineHom_iff` with bundled affine opens. -/
+lemma isAffineHom_iff' {X Y : Scheme.{u}} (f : X ⟶ Y) :
+    IsAffineHom f ↔ ∀ (U : Y.affineOpens), IsAffineOpen (f ⁻¹ᵁ U) := by
+  rw [isAffineHom_iff, Subtype.forall]
+  rfl
+
 lemma IsAffineOpen.preimage {X Y : Scheme} {U : Y.Opens} (hU : IsAffineOpen U)
     (f : X ⟶ Y) [IsAffineHom f] :
     IsAffineOpen (f ⁻¹ᵁ U) :=

--- a/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
@@ -100,15 +100,15 @@ lemma affineAnd_stableUnderBaseChange (hQi : RingHom.RespectsIso Q)
 
 lemma targetAffineLocally_affineAnd_iff (hQi : RingHom.RespectsIso Q)
     {X Y : Scheme.{u}} (f : X ⟶ Y) :
-    targetAffineLocally (affineAnd Q) f ↔ ∀ (U : Y.affineOpens),
+    targetAffineLocally (affineAnd Q) f ↔ ∀ U : Y.Opens, IsAffineOpen U →
       IsAffineOpen (f ⁻¹ᵁ U) ∧ Q (f.app U) := by
   simp only [targetAffineLocally, affineAnd_apply, morphismRestrict_app, hQi.cancel_right_isIso]
-  refine ⟨fun hf U ↦ ?_, fun h U ↦ ?_⟩
-  · obtain ⟨hfU, hf⟩ := hf U
+  refine ⟨fun hf U hU ↦ ?_, fun h U ↦ ?_⟩
+  · obtain ⟨hfU, hf⟩ := hf ⟨U, hU⟩
     exact ⟨hfU, by rwa [Scheme.Opens.ι_image_top] at hf⟩
-  · refine ⟨(h U).1, ?_⟩
+  · refine ⟨(h U U.2).1, ?_⟩
     rw [Scheme.Opens.ι_image_top]
-    exact (h U).2
+    exact (h U U.2).2
 
 end
 
@@ -152,8 +152,8 @@ lemma HasAffineProperty.affineAnd_containsIdentities {P : MorphismProperty Schem
     P.ContainsIdentities where
   id_mem X := by
     rw [eq_targetAffineLocally P, targetAffineLocally_affineAnd_iff hQi]
-    intro U
-    exact ⟨U.2, hQ _⟩
+    intro U hU
+    exact ⟨hU, hQ _⟩
 
 /-- A convenience constructor for `HasAffineProperty P (affineAnd Q)`. The `IsAffineHom` is bundled,
 since this goes well with defining morphism properties via `extends IsAffineHom`. -/
@@ -162,12 +162,14 @@ lemma HasAffineProperty.affineAnd_iff (P : MorphismProperty Scheme.{u})
     (hQs : RingHom.OfLocalizationSpan Q) :
     HasAffineProperty P (affineAnd Q) ↔
       ∀ {X Y : Scheme.{u}} (f : X ⟶ Y), P f ↔
-        (IsAffineHom f ∧ ∀ (U : Y.affineOpens), Q (f.app U)) := by
-  simp_rw [isAffineHom_iff']
+        (IsAffineHom f ∧ ∀ U : Y.Opens, IsAffineOpen U → Q (f.app U)) := by
+  simp_rw [isAffineHom_iff]
   refine ⟨fun h X Y f ↦ ?_, fun h ↦ ⟨affineAnd_isLocal hQi hQl hQs, ?_⟩⟩
-  · rw [eq_targetAffineLocally P, targetAffineLocally_affineAnd_iff hQi, forall_and]
+  · rw [eq_targetAffineLocally P, targetAffineLocally_affineAnd_iff hQi]
+    aesop
   · ext X Y f
-    rw [targetAffineLocally_affineAnd_iff hQi, h f, forall_and]
+    rw [targetAffineLocally_affineAnd_iff hQi, h f]
+    aesop
 
 lemma HasAffineProperty.affineAnd_le_isAffineHom (P : MorphismProperty Scheme.{u})
     (hA : HasAffineProperty P (affineAnd Q)) : P ≤ @IsAffineHom := by

--- a/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
@@ -80,7 +80,7 @@ lemma affineAnd_isLocal (hPi : RingHom.RespectsIso Q) (hQl : RingHom.Localizatio
       · rintro - ⟨r, hr, rfl⟩
         simp_rw [Scheme.preimage_basicOpen] at hf
         exact (hf ⟨r, hr⟩).left
-    refine ⟨inferInstance, hQs.ofIsLocalization hPi (f.app ⊤) s hs fun a ↦ ?_⟩
+    refine ⟨inferInstance, hQs.ofIsLocalization' hPi (f.app ⊤) s hs fun a ↦ ?_⟩
     refine ⟨Γ(Y, Y.basicOpen a.val), Γ(X, X.basicOpen (f.app ⊤ a.val)), inferInstance,
       inferInstance, inferInstance, inferInstance, inferInstance, ?_, ?_⟩
     · exact (isAffineOpen_top X).isLocalization_basicOpen (f.app ⊤ a.val)
@@ -119,14 +119,15 @@ variable {Q : ∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop
 /-- If `P` is a morphism property affine locally defined by `affineAnd Q`, `P` is stable under
 composition if `Q` is. -/
 lemma HasAffineProperty.affineAnd_isStableUnderComposition {P : MorphismProperty Scheme.{u}}
-    [HasAffineProperty P (affineAnd Q)] (hQ : RingHom.StableUnderComposition Q) :
+    (hA : HasAffineProperty P (affineAnd Q)) (hQ : RingHom.StableUnderComposition Q) :
     P.IsStableUnderComposition where
   comp_mem {X Y Z} f g hf hg := by
+    haveI := hA
     wlog hZ : IsAffine Z
     · rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := P) _ (iSup_affineOpens_eq_top _)]
       intro U
       rw [morphismRestrict_comp]
-      exact this hQ _ _ (IsLocalAtTarget.restrict hf _) (IsLocalAtTarget.restrict hg _) U.2
+      exact this hA hQ _ _ (IsLocalAtTarget.restrict hf _) (IsLocalAtTarget.restrict hg _) hA U.2
     rw [HasAffineProperty.iff_of_isAffine (P := P) (Q := (affineAnd Q))] at hg
     obtain ⟨hY, hg⟩ := hg
     rw [HasAffineProperty.iff_of_isAffine (P := P) (Q := (affineAnd Q))] at hf
@@ -137,7 +138,7 @@ lemma HasAffineProperty.affineAnd_isStableUnderComposition {P : MorphismProperty
 /-- If `P` is a morphism property affine locally defined by `affineAnd Q`, `P` is stable under
 base change if `Q` is. -/
 lemma HasAffineProperty.affineAnd_stableUnderBaseChange {P : MorphismProperty Scheme.{u}}
-    [HasAffineProperty P (affineAnd Q)] (hQi : RingHom.RespectsIso Q)
+    (_ : HasAffineProperty P (affineAnd Q)) (hQi : RingHom.RespectsIso Q)
     (hQb : RingHom.StableUnderBaseChange Q) :
     P.StableUnderBaseChange :=
   HasAffineProperty.stableUnderBaseChange
@@ -146,7 +147,7 @@ lemma HasAffineProperty.affineAnd_stableUnderBaseChange {P : MorphismProperty Sc
 /-- If `Q` contains identities and respects isomorphisms (i.e. is satisfied by isomorphisms),
 and `P` is affine locally defined by `affineAnd Q`, then `P` contains identities. -/
 lemma HasAffineProperty.affineAnd_containsIdentities {P : MorphismProperty Scheme.{u}}
-    [HasAffineProperty P (affineAnd Q)] (hQi : RingHom.RespectsIso Q)
+    (hA : HasAffineProperty P (affineAnd Q)) (hQi : RingHom.RespectsIso Q)
     (hQ : RingHom.ContainsIdentities Q) :
     P.ContainsIdentities where
   id_mem X := by
@@ -169,12 +170,12 @@ lemma HasAffineProperty.affineAnd_iff (P : MorphismProperty Scheme.{u})
     rw [targetAffineLocally_affineAnd_iff hQi, h f, forall_and]
 
 lemma HasAffineProperty.affineAnd_le_isAffineHom (P : MorphismProperty Scheme.{u})
-    [HasAffineProperty P (affineAnd Q)] : P ≤ @IsAffineHom := by
+    (hA : HasAffineProperty P (affineAnd Q)) : P ≤ @IsAffineHom := by
   intro X Y f hf
   wlog hY : IsAffine Y
   · rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := @IsAffineHom) _ (iSup_affineOpens_eq_top _)]
     intro U
-    exact this P _ (IsLocalAtTarget.restrict hf _) U.2
+    exact this P hA _ (IsLocalAtTarget.restrict hf _) U.2
   rw [HasAffineProperty.iff_of_isAffine (P := P) (Q := (affineAnd Q))] at hf
   rw [HasAffineProperty.iff_of_isAffine (P := @IsAffineHom)]
   exact hf.1

--- a/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.AlgebraicGeometry.Morphisms.Affine
+import Mathlib.AlgebraicGeometry.Morphisms.RingHomProperties
+
+/-!
+# Affine morphisms with additional ring hom property
+
+In this file we define a constructor `affineAnd Q` for affine target morphism properties of schemes
+from a property of ring homomorphisms `Q`: A morphism `f : X ⟶ Y` with affine target satisfies
+`affineAnd Q` if it is an affine morphim (i.e. `X` is affine) and the induced ring map on global
+sections satisfies `Q`.
+
+`affineAnd Q` inherits most stability properties of `Q` and is local at the target if `Q` is local
+at the (algebraic) source.
+
+Typical examples of this are affine morphisms (where `Q` is trivial), finite morphisms
+(where `Q` is module finite) or closed immersions (where `Q` is being surjective).
+
+-/
+
+universe v u
+
+open CategoryTheory TopologicalSpace Opposite MorphismProperty
+
+namespace AlgebraicGeometry
+
+section
+
+variable (Q : ∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop)
+
+/-- This is the affine target morphism property where the source is affine and
+the induced map of rings on global sections satisfies `P`. -/
+def affineAnd : AffineTargetMorphismProperty :=
+  fun X _ f ↦ IsAffine X ∧ Q (f.app ⊤)
+
+@[simp]
+lemma affineAnd_apply {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffine Y] :
+    affineAnd Q f ↔ IsAffine X ∧ Q (f.app ⊤) :=
+  Iff.rfl
+
+attribute [local simp] AffineTargetMorphismProperty.toProperty_apply
+
+variable {Q}
+
+/-- If `P` respects isos, also `affineAnd P` respects isomorphisms. -/
+lemma affineAnd_respectsIso (hP : RingHom.RespectsIso Q) :
+    (affineAnd Q).toProperty.RespectsIso := by
+  refine RespectsIso.mk _ ?_ ?_
+  · intro X Y Z e f ⟨hZ, ⟨hY, hf⟩⟩
+    simpa [hP.cancel_right_isIso, isAffine_of_isIso e.hom]
+  · intro X Y Z e f ⟨hZ, hf⟩
+    simpa [AffineTargetMorphismProperty.toProperty, isAffine_of_isIso e.inv, hP.cancel_left_isIso]
+
+/-- `affineAnd P` is local if `P` is local on the (algebraic) source. -/
+lemma affineAnd_isLocal (hPi : RingHom.RespectsIso Q) (hQl : RingHom.LocalizationPreserves Q)
+    (hQs : RingHom.OfLocalizationSpan Q) : (affineAnd Q).IsLocal where
+  respectsIso := affineAnd_respectsIso hPi
+  to_basicOpen {X Y _} f r := fun ⟨hX, hf⟩ ↦ by
+    simp only [Opens.map_top] at hf
+    constructor
+    · simp only [Scheme.preimage_basicOpen, Opens.map_top]
+      exact (isAffineOpen_top X).basicOpen _
+    · dsimp only [Opens.map_top]
+      rw [morphismRestrict_app, hPi.cancel_right_isIso, Scheme.Opens.ι_image_top]
+      rw [(isAffineOpen_top Y).app_basicOpen_eq_away_map f (isAffineOpen_top X),
+        hPi.cancel_right_isIso]
+      haveI := (isAffineOpen_top X).isLocalization_basicOpen (f.app ⊤ r)
+      apply hQl
+      exact hf
+  of_basicOpenCover {X Y _} f s hs hf := by
+    dsimp [affineAnd] at hf
+    haveI : IsAffine X := by
+      apply isAffine_of_isAffineOpen_basicOpen (f.app ⊤ '' s)
+      · apply_fun Ideal.map (f.app ⊤) at hs
+        rwa [Ideal.map_span, Ideal.map_top] at hs
+      · rintro - ⟨r, hr, rfl⟩
+        simp_rw [Scheme.preimage_basicOpen] at hf
+        exact (hf ⟨r, hr⟩).left
+    refine ⟨inferInstance, hQs.ofIsLocalization hPi (f.app ⊤) s hs fun a ↦ ?_⟩ 
+    refine ⟨Γ(Y, Y.basicOpen a.val), Γ(X, X.basicOpen (f.app ⊤ a.val)), inferInstance,
+      inferInstance, inferInstance, inferInstance, inferInstance, ?_, ?_⟩
+    · exact (isAffineOpen_top X).isLocalization_basicOpen (f.app ⊤ a.val)
+    · obtain ⟨_, hf⟩ := hf a
+      rw [morphismRestrict_app, hPi.cancel_right_isIso, Scheme.Opens.ι_image_top] at hf
+      rw [(isAffineOpen_top Y).app_basicOpen_eq_away_map _ (isAffineOpen_top X)] at hf
+      rwa [hPi.cancel_right_isIso] at hf
+
+/-- If `P` is stable under base change, so is `affineAnd P`. -/
+lemma affineAnd_stableUnderBaseChange (hQi : RingHom.RespectsIso Q)
+    (hQb : RingHom.StableUnderBaseChange Q) :
+    (affineAnd Q).StableUnderBaseChange := by
+  haveI : (affineAnd Q).toProperty.RespectsIso := affineAnd_respectsIso hQi
+  apply AffineTargetMorphismProperty.StableUnderBaseChange.mk
+  intro X Y S _ _ f g ⟨hY, hg⟩
+  exact ⟨inferInstance, hQb.pullback_fst_app_top _ hQi f _ hg⟩
+
+lemma targetAffineLocally_affineAnd_iff (hQi : RingHom.RespectsIso Q)
+    {X Y : Scheme.{u}} (f : X ⟶ Y) :
+    targetAffineLocally (affineAnd Q) f ↔ ∀ (U : Y.affineOpens),
+      IsAffineOpen (f ⁻¹ᵁ U) ∧ Q (f.app U) := by
+  simp only [targetAffineLocally, affineAnd_apply, morphismRestrict_app, hQi.cancel_right_isIso]
+  refine ⟨fun hf U ↦ ?_, fun h U ↦ ?_⟩
+  · obtain ⟨hfU, hf⟩ := hf U
+    exact ⟨hfU, by rwa [Scheme.Opens.ι_image_top] at hf⟩
+  · refine ⟨(h U).1, ?_⟩
+    rw [Scheme.Opens.ι_image_top]
+    exact (h U).2
+
+end
+
+section
+
+variable {Q : ∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop}
+
+/-- If `P` is a morphism property affine locally defined by `affineAnd Q`, `P` is stable under
+composition if `Q` is. -/
+lemma HasAffineProperty.affineAnd_isStableUnderComposition {P : MorphismProperty Scheme.{u}}
+    [HasAffineProperty P (affineAnd Q)] (hQ : RingHom.StableUnderComposition Q) :
+    P.IsStableUnderComposition where
+  comp_mem {X Y Z} f g hf hg := by
+    wlog hZ : IsAffine Z
+    · rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := P) _ (iSup_affineOpens_eq_top _)]
+      intro U
+      rw [morphismRestrict_comp]
+      exact this hQ _ _ (IsLocalAtTarget.restrict hf _) (IsLocalAtTarget.restrict hg _) U.2
+    rw [HasAffineProperty.iff_of_isAffine (P := P) (Q := (affineAnd Q))] at hg
+    obtain ⟨hY, hg⟩ := hg
+    rw [HasAffineProperty.iff_of_isAffine (P := P) (Q := (affineAnd Q))] at hf
+    obtain ⟨hX, hf⟩ := hf
+    rw [HasAffineProperty.iff_of_isAffine (P := P) (Q := (affineAnd Q))]
+    exact ⟨hX, hQ _ _ hg hf⟩
+
+/-- If `P` is a morphism property affine locally defined by `affineAnd Q`, `P` is stable under
+base change if `Q` is. -/
+lemma HasAffineProperty.affineAnd_stableUnderBaseChange {P : MorphismProperty Scheme.{u}}
+    [HasAffineProperty P (affineAnd Q)] (hQi : RingHom.RespectsIso Q)
+    (hQb : RingHom.StableUnderBaseChange Q) :
+    P.StableUnderBaseChange :=
+  HasAffineProperty.stableUnderBaseChange
+    (AlgebraicGeometry.affineAnd_stableUnderBaseChange hQi hQb)
+
+/-- If `Q` contains identities and respects isomorphisms (i.e. is satisfied by isomorphisms),
+and `P` is affine locally defined by `affineAnd Q`, then `P` contains identities. -/
+lemma HasAffineProperty.affineAnd_containsIdentities {P : MorphismProperty Scheme.{u}}
+    [HasAffineProperty P (affineAnd Q)] (hQi : RingHom.RespectsIso Q)
+    (hQ : RingHom.ContainsIdentities Q) :
+    P.ContainsIdentities where
+  id_mem X := by
+    rw [eq_targetAffineLocally P, targetAffineLocally_affineAnd_iff hQi]
+    intro U
+    exact ⟨U.2, hQ _⟩
+
+/-- A convenience constructor for `HasAffineProperty P (affineAnd Q)`. The `IsAffineHom` is bundled,
+since this goes well with defining morphism properties via `extends IsAffineHom`. -/
+lemma HasAffineProperty.affineAnd_iff (P : MorphismProperty Scheme.{u})
+    (hQi : RingHom.RespectsIso Q) (hQl : RingHom.LocalizationPreserves Q)
+    (hQs : RingHom.OfLocalizationSpan Q) :
+    HasAffineProperty P (affineAnd Q) ↔
+      ∀ {X Y : Scheme.{u}} (f : X ⟶ Y), P f ↔
+        (IsAffineHom f ∧ ∀ (U : Y.affineOpens), Q (f.app U)) := by
+  simp_rw [isAffineHom_iff']
+  refine ⟨fun h X Y f ↦ ?_, fun h ↦ ⟨affineAnd_isLocal hQi hQl hQs, ?_⟩⟩
+  · rw [eq_targetAffineLocally P, targetAffineLocally_affineAnd_iff hQi, forall_and]
+  · ext X Y f
+    rw [targetAffineLocally_affineAnd_iff hQi, h f, forall_and]
+
+lemma HasAffineProperty.affineAnd_le_isAffineHom (P : MorphismProperty Scheme.{u})
+    [HasAffineProperty P (affineAnd Q)] : P ≤ @IsAffineHom := by
+  intro X Y f hf
+  wlog hY : IsAffine Y
+  · rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := @IsAffineHom) _ (iSup_affineOpens_eq_top _)]
+    intro U
+    exact this P _ (IsLocalAtTarget.restrict hf _) U.2
+  rw [HasAffineProperty.iff_of_isAffine (P := P) (Q := (affineAnd Q))] at hf
+  rw [HasAffineProperty.iff_of_isAffine (P := @IsAffineHom)]
+  exact hf.1
+
+end
+
+end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
@@ -80,7 +80,7 @@ lemma affineAnd_isLocal (hPi : RingHom.RespectsIso Q) (hQl : RingHom.Localizatio
       · rintro - ⟨r, hr, rfl⟩
         simp_rw [Scheme.preimage_basicOpen] at hf
         exact (hf ⟨r, hr⟩).left
-    refine ⟨inferInstance, hQs.ofIsLocalization hPi (f.app ⊤) s hs fun a ↦ ?_⟩ 
+    refine ⟨inferInstance, hQs.ofIsLocalization hPi (f.app ⊤) s hs fun a ↦ ?_⟩
     refine ⟨Γ(Y, Y.basicOpen a.val), Γ(X, X.basicOpen (f.app ⊤ a.val)), inferInstance,
       inferInstance, inferInstance, inferInstance, inferInstance, ?_, ?_⟩
     · exact (isAffineOpen_top X).isLocalization_basicOpen (f.app ⊤ a.val)

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -16,15 +16,15 @@ of ring homs. For `P` a property of ring homs, we have two ways of defining a pr
 morphisms:
 
 Let `f : X ⟶ Y`,
-- `targetAffineLocally (affine_and P)`: the preimage of an affine open `U = Spec A` is affine
-  (`= Spec B`) and `A ⟶ B` satisfies `P`. (TODO)
+- `targetAffineLocally (affineAnd P)`: the preimage of an affine open `U = Spec A` is affine
+  (`= Spec B`) and `A ⟶ B` satisfies `P`. (in `Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean`)
 - `affineLocally P`: For each pair of affine open `U = Spec A ⊆ X` and `V = Spec B ⊆ f ⁻¹' U`,
   the ring hom `A ⟶ B` satisfies `P`.
 
 For these notions to be well defined, we require `P` be a sufficient local property. For the former,
 `P` should be local on the source (`RingHom.RespectsIso P`, `RingHom.LocalizationPreserves P`,
 `RingHom.OfLocalizationSpan`), and `targetAffineLocally (affine_and P)` will be local on
-the target. (TODO)
+the target.
 
 For the latter `P` should be local on the target (`RingHom.PropertyIsLocal P`), and
 `affineLocally P` will be local on both the source and the target.

--- a/Mathlib/RingTheory/LocalProperties/Basic.lean
+++ b/Mathlib/RingTheory/LocalProperties/Basic.lean
@@ -248,6 +248,29 @@ theorem RingHom.PropertyIsLocal.ofLocalizationSpan (hP : RingHom.PropertyIsLocal
   · apply hP.StableUnderCompositionWithLocalizationAway.right _ r
     exact hs' ⟨r, hr⟩
 
+lemma RingHom.OfLocalizationSpan.ofIsLocalization
+    (hP : RingHom.OfLocalizationSpan P) (hPi : RingHom.RespectsIso P)
+    {R S : Type u} [CommRing R] [CommRing S] (f : R →+* S) (s : Set R) (hs : Ideal.span s = ⊤)
+    (hT : ∀ r : s, ∃ (Rᵣ Sᵣ : Type u) (_ : CommRing Rᵣ) (_ : CommRing Sᵣ)
+      (_ : Algebra R Rᵣ) (_ : Algebra S Sᵣ) (_ : IsLocalization.Away r.val Rᵣ)
+      (_ : IsLocalization.Away (f r.val) Sᵣ),
+        P (IsLocalization.Away.map Rᵣ Sᵣ f r)) : P f := by
+  apply hP _ s hs
+  intro r
+  obtain ⟨Rᵣ, Sᵣ, _, _, _, _, _, _, hf⟩ := hT r
+  let e₁ := (Localization.algEquiv (.powers r.val) Rᵣ).toRingEquiv
+  let e₂ := (IsLocalization.algEquiv (.powers (f r.val))
+    (Localization (.powers (f r.val))) Sᵣ).symm.toRingEquiv
+  have : Localization.awayMap f r.val =
+      (e₂.toRingHom.comp (IsLocalization.Away.map Rᵣ Sᵣ f r.val)).comp e₁.toRingHom := by
+    apply IsLocalization.ringHom_ext (.powers r.val)
+    ext x
+    simp [-AlgEquiv.symm_toRingEquiv, e₂, e₁, Localization.awayMap, IsLocalization.Away.map]
+  rw [this]
+  apply hPi.right
+  apply hPi.left
+  exact hf
+
 lemma RingHom.OfLocalizationSpanTarget.ofIsLocalization
     (hP : RingHom.OfLocalizationSpanTarget P) (hP' : RingHom.RespectsIso P)
     {R S : Type u} [CommRing R] [CommRing S] (f : R →+* S) (s : Set S) (hs : Ideal.span s = ⊤)

--- a/Mathlib/RingTheory/LocalProperties/Basic.lean
+++ b/Mathlib/RingTheory/LocalProperties/Basic.lean
@@ -253,23 +253,41 @@ lemma RingHom.OfLocalizationSpan.ofIsLocalization
     {R S : Type u} [CommRing R] [CommRing S] (f : R →+* S) (s : Set R) (hs : Ideal.span s = ⊤)
     (hT : ∀ r : s, ∃ (Rᵣ Sᵣ : Type u) (_ : CommRing Rᵣ) (_ : CommRing Sᵣ)
       (_ : Algebra R Rᵣ) (_ : Algebra S Sᵣ) (_ : IsLocalization.Away r.val Rᵣ)
-      (_ : IsLocalization.Away (f r.val) Sᵣ),
-        P (IsLocalization.Away.map Rᵣ Sᵣ f r)) : P f := by
+      (_ : IsLocalization.Away (f r.val) Sᵣ) (fᵣ : Rᵣ →+* Sᵣ)
+      (_ : fᵣ.comp (algebraMap R Rᵣ) = (algebraMap S Sᵣ).comp f),
+        P fᵣ) : P f := by
   apply hP _ s hs
   intro r
-  obtain ⟨Rᵣ, Sᵣ, _, _, _, _, _, _, hf⟩ := hT r
+  obtain ⟨Rᵣ, Sᵣ, _, _, _, _, _, _, fᵣ, hfᵣ, hf⟩ := hT r
   let e₁ := (Localization.algEquiv (.powers r.val) Rᵣ).toRingEquiv
   let e₂ := (IsLocalization.algEquiv (.powers (f r.val))
     (Localization (.powers (f r.val))) Sᵣ).symm.toRingEquiv
   have : Localization.awayMap f r.val =
-      (e₂.toRingHom.comp (IsLocalization.Away.map Rᵣ Sᵣ f r.val)).comp e₁.toRingHom := by
+      (e₂.toRingHom.comp fᵣ).comp e₁.toRingHom := by
     apply IsLocalization.ringHom_ext (.powers r.val)
     ext x
-    simp [-AlgEquiv.symm_toRingEquiv, e₂, e₁, Localization.awayMap, IsLocalization.Away.map]
+    have : fᵣ ((algebraMap R Rᵣ) x) = algebraMap S Sᵣ (f x) := by
+      rw [← RingHom.comp_apply, hfᵣ, RingHom.comp_apply]
+    simp [-AlgEquiv.symm_toRingEquiv, e₂, e₁, Localization.awayMap, IsLocalization.Away.map, this]
   rw [this]
   apply hPi.right
   apply hPi.left
   exact hf
+
+/-- Variant of `RingHom.OfLocalizationSpan.ofIsLocalization` where
+`fᵣ = IsLocalization.Away.map`. -/
+lemma RingHom.OfLocalizationSpan.ofIsLocalization'
+    (hP : RingHom.OfLocalizationSpan P) (hPi : RingHom.RespectsIso P)
+    {R S : Type u} [CommRing R] [CommRing S] (f : R →+* S) (s : Set R) (hs : Ideal.span s = ⊤)
+    (hT : ∀ r : s, ∃ (Rᵣ Sᵣ : Type u) (_ : CommRing Rᵣ) (_ : CommRing Sᵣ)
+      (_ : Algebra R Rᵣ) (_ : Algebra S Sᵣ) (_ : IsLocalization.Away r.val Rᵣ)
+      (_ : IsLocalization.Away (f r.val) Sᵣ),
+        P (IsLocalization.Away.map Rᵣ Sᵣ f r)) : P f := by
+  apply hP.ofIsLocalization hPi _ s hs
+  intro r
+  obtain ⟨Rᵣ, Sᵣ, _, _, _, _, _, _, hf⟩ := hT r
+  exact ⟨Rᵣ, Sᵣ, inferInstance, inferInstance, inferInstance, inferInstance,
+    inferInstance, inferInstance, IsLocalization.Away.map Rᵣ Sᵣ f r, IsLocalization.map_comp _, hf⟩
 
 lemma RingHom.OfLocalizationSpanTarget.ofIsLocalization
     (hP : RingHom.OfLocalizationSpanTarget P) (hP' : RingHom.RespectsIso P)


### PR DESCRIPTION
We add a constructor for properties of affine morphisms of schemes satisfying a given property of ring homomorphisms on sections.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
