### PR TITLE
[Merged by Bors] - feat: trivial nontrivialities for free (constructions)

### DIFF
--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -67,6 +67,9 @@ instance : CancelMonoid (FreeMonoid α) where
 @[to_additive]
 instance : Inhabited (FreeMonoid α) := ⟨1⟩
 
+@[to_additive]
+instance [IsEmpty α] : Unique (FreeMonoid α) := inferInstanceAs <| Unique (List α)
+
 @[to_additive (attr := simp)]
 theorem toList_one : toList (1 : FreeMonoid α) = [] := rfl
 
@@ -137,11 +140,14 @@ theorem length_eq_two {v : FreeMonoid α} :
 theorem length_mul (a b : FreeMonoid α) : (a * b).length = a.length + b.length :=
   List.length_append _ _
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem of_ne_one (a : α) : of a ≠ 1 := by
   intro h
   have := congrArg FreeMonoid.length h
   simp only [length_of, length_one, Nat.succ_ne_self] at this
+
+@[to_additive (attr := simp)]
+theorem one_ne_of (a : α) : 1 ≠ of a := of_ne_one _ |>.symm
 
 end Length
 

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -542,6 +542,9 @@ theorem singleton_ne_zero (a : α) : ({a} : Multiset α) ≠ 0 :=
   ne_of_gt (lt_cons_self _ _)
 
 @[simp]
+theorem zero_ne_singleton (a : α) : 0 ≠ ({a} : Multiset α) := singleton_ne_zero _ |>.symm
+
+@[simp]
 theorem singleton_le {a : α} {s : Multiset α} : {a} ≤ s ↔ a ∈ s :=
   ⟨fun h => mem_of_le h (mem_singleton_self _), fun h =>
     let ⟨_t, e⟩ := exists_cons_of_mem h

--- a/Mathlib/GroupTheory/FreeAbelianGroup.lean
+++ b/Mathlib/GroupTheory/FreeAbelianGroup.lean
@@ -139,15 +139,15 @@ theorem of_injective : Function.Injective (of : α → FreeAbelianGroup α) :=
     one_ne_zero <| hfy1.symm.trans hfy0
 
 @[simp]
-theorem zero_ne_of (x : α) : 0 ≠ of x := by
+theorem of_ne_zero (x : α) : of x ≠ 0 := by
   intro h
   let f : FreeAbelianGroup α →+ ℤ := lift 1
   have hfx : f (of x) = 1 := lift.of _ _
-  have hf0 : f (of x) = 0 := congr(f $h.symm).trans <| map_zero f
+  have hf0 : f (of x) = 0 := by rw [h, map_zero]
   exact one_ne_zero <| hfx.symm.trans hf0
 
 @[simp]
-theorem of_ne_zero (x : α) : of x ≠ 0 := zero_ne_of _ |>.symm
+theorem zero_ne_of (x : α) : 0 ≠ of x := of_ne_zero _ |>.symm
 
 instance [Nonempty α] : Nontrivial (FreeAbelianGroup α) where
   exists_pair_ne := let ⟨x⟩ := ‹Nonempty α›; ⟨0, of x, zero_ne_of _⟩

--- a/Mathlib/GroupTheory/FreeAbelianGroup.lean
+++ b/Mathlib/GroupTheory/FreeAbelianGroup.lean
@@ -87,7 +87,7 @@ namespace FreeAbelianGroup
 
 /-- The canonical map from `α` to `FreeAbelianGroup α`. -/
 def of (x : α) : FreeAbelianGroup α :=
-  Abelianization.of <| FreeGroup.of x
+  Additive.ofMul <| Abelianization.of <| FreeGroup.of x
 
 /-- The map `FreeAbelianGroup α →+ A` induced by a map of types `α → A`. -/
 def lift {β : Type v} [AddCommGroup β] : (α → β) ≃ (FreeAbelianGroup α →+ β) :=
@@ -137,6 +137,20 @@ theorem of_injective : Function.Injective (of : α → FreeAbelianGroup α) :=
     have hfy1 : f (of y) = 1 := hoxy ▸ hfx1
     have hfy0 : f (of y) = 0 := (lift.of _ _).trans <| if_neg hxy
     one_ne_zero <| hfy1.symm.trans hfy0
+
+@[simp]
+theorem zero_ne_of (x : α) : 0 ≠ of x := by
+  intro h
+  let f : FreeAbelianGroup α →+ ℤ := lift 1
+  have hfx : f (of x) = 1 := lift.of _ _
+  have hf0 : f (of x) = 0 := congr(f $h.symm).trans <| map_zero f
+  exact one_ne_zero <| hfx.symm.trans hf0
+
+@[simp]
+theorem of_ne_zero (x : α) : of x ≠ 0 := zero_ne_of _ |>.symm
+
+instance [Nonempty α] : Nontrivial (FreeAbelianGroup α) where
+  exists_pair_ne := let ⟨x⟩ := ‹Nonempty α›; ⟨0, of x, zero_ne_of _⟩
 
 end
 

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -1054,6 +1054,10 @@ theorem toWord_mk : (mk L₁).toWord = reduce L₁ :=
   rfl
 
 @[to_additive (attr := simp)]
+theorem toWord_of (a : α) : (of a).toWord = [(a, true)] :=
+  rfl
+
+@[to_additive (attr := simp)]
 theorem reduce_toWord : ∀ x : FreeGroup α, reduce (toWord x) = toWord x := by
   rintro ⟨L⟩
   exact reduce.idem
@@ -1123,6 +1127,16 @@ instance : Fintype { L₂ // Red L₁ L₂ } :=
 
 end Reduce
 
+@[simp]
+theorem one_ne_of (a : α) : 1 ≠ of a :=
+  letI := Classical.decEq α; ne_of_apply_ne toWord <| by simp
+
+@[simp]
+theorem of_ne_one (a : α) : of a ≠ 1 := one_ne_of _ |>.symm
+
+instance [Nonempty α] : Nontrivial (FreeGroup α) where
+  exists_pair_ne := let ⟨x⟩ := ‹Nonempty α›; ⟨1, of x, one_ne_of x⟩
+
 section Metric
 
 variable [DecidableEq α]
@@ -1142,6 +1156,10 @@ theorem norm_eq_zero {x : FreeGroup α} : norm x = 0 ↔ x = 1 := by
 
 @[to_additive (attr := simp)]
 theorem norm_one : norm (1 : FreeGroup α) = 0 :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem norm_of (a : α) : norm (of a) = 1 :=
   rfl
 
 @[to_additive]

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -1127,13 +1127,14 @@ instance : Fintype { L₂ // Red L₁ L₂ } :=
 
 end Reduce
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem one_ne_of (a : α) : 1 ≠ of a :=
   letI := Classical.decEq α; ne_of_apply_ne toWord <| by simp
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem of_ne_one (a : α) : of a ≠ 1 := one_ne_of _ |>.symm
 
+@[to_additive]
 instance [Nonempty α] : Nontrivial (FreeGroup α) where
   exists_pair_ne := let ⟨x⟩ := ‹Nonempty α›; ⟨1, of x, one_ne_of x⟩
 

--- a/Mathlib/RingTheory/FreeCommRing.lean
+++ b/Mathlib/RingTheory/FreeCommRing.lean
@@ -80,6 +80,20 @@ theorem of_injective : Function.Injective (of : α → FreeCommRing α) :=
   FreeAbelianGroup.of_injective.comp fun _ _ =>
     (Multiset.coe_eq_coe.trans List.singleton_perm_singleton).mp
 
+@[simp]
+theorem of_ne_zero (x : α) : of x ≠ 0 := FreeAbelianGroup.of_ne_zero _
+
+@[simp]
+theorem zero_ne_of (x : α) : 0 ≠ of x := FreeAbelianGroup.zero_ne_of _
+
+@[simp]
+theorem of_ne_one (x : α) : of x ≠ 1 :=
+  FreeAbelianGroup.of_injective.ne <| Multiset.singleton_ne_zero _
+
+@[simp]
+theorem one_ne_of (x : α) : 1 ≠ of x :=
+  FreeAbelianGroup.of_injective.ne <| Multiset.zero_ne_singleton _
+
 -- Porting note: added to ease a proof in `Algebra.DirectLimit`
 lemma of_cons (a : α) (m : Multiset α) : (FreeAbelianGroup.of (Multiplicative.ofAdd (a ::ₘ m))) =
     @HMul.hMul _ (FreeCommRing α) (FreeCommRing α) _ (of a)

--- a/Mathlib/RingTheory/FreeRing.lean
+++ b/Mathlib/RingTheory/FreeRing.lean
@@ -40,6 +40,9 @@ instance (α : Type u) : Inhabited (FreeRing α) := by
   dsimp only [FreeRing]
   infer_instance
 
+instance (α : Type u) : Nontrivial (FreeRing α) :=
+  inferInstanceAs <| Nontrivial (FreeAbelianGroup _)
+
 namespace FreeRing
 
 variable {α : Type u}
@@ -50,6 +53,18 @@ def of (x : α) : FreeRing α :=
 
 theorem of_injective : Function.Injective (of : α → FreeRing α) :=
   FreeAbelianGroup.of_injective.comp FreeMonoid.of_injective
+
+@[simp]
+theorem of_ne_zero (x : α) : of x ≠ 0 := FreeAbelianGroup.of_ne_zero _
+
+@[simp]
+theorem zero_ne_of (x : α) : 0 ≠ of x := FreeAbelianGroup.zero_ne_of _
+
+@[simp]
+theorem of_ne_one (x : α) : of x ≠ 1 := FreeAbelianGroup.of_injective.ne <| FreeMonoid.of_ne_one _
+
+@[simp]
+theorem one_ne_of (x : α) : 1 ≠ of x := FreeAbelianGroup.of_injective.ne <| FreeMonoid.one_ne_of _
 
 @[elab_as_elim, induction_eliminator]
 protected theorem induction_on {C : FreeRing α → Prop} (z : FreeRing α) (hn1 : C (-1))


### PR DESCRIPTION
This adds some `Unique` and `Nontrivial` instances for free constructions, and some simp lemmas of the form `of x ≠ 0`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
