### PR TITLE
[Merged by Bors] - feat(Logic/Embedding/Basic): `setValue_eq_of_ne`

### DIFF
--- a/Mathlib/Logic/Embedding/Basic.lean
+++ b/Mathlib/Logic/Embedding/Basic.lean
@@ -184,6 +184,10 @@ lemma setValue_eq_of_ne {α β} {f : α ↪ β} {a : α} {b : β} {c : α} [∀ 
     [∀ a', Decidable (f a' = b)] (hc : c ≠ a) (hb : f c ≠ b) : setValue f a b c = f c := by
   simp [setValue, hc, hb]
 
+@[simp]
+lemma setValue_right_apply_eq {α β} (f : α ↪ β) (a c : α) : setValue f a (f c) c = f a := by
+  simp [setValue]
+
 /-- Embedding into `Option α` using `some`. -/
 @[simps (config := .asFn)]
 protected def some {α} : α ↪ Option α :=

--- a/Mathlib/Logic/Embedding/Basic.lean
+++ b/Mathlib/Logic/Embedding/Basic.lean
@@ -185,7 +185,8 @@ lemma setValue_eq_of_ne {α β} {f : α ↪ β} {a : α} {b : β} {c : α} [∀ 
   simp [setValue, hc, hb]
 
 @[simp]
-lemma setValue_right_apply_eq {α β} (f : α ↪ β) (a c : α) : setValue f a (f c) c = f a := by
+lemma setValue_right_apply_eq {α β} (f : α ↪ β) (a c : α) [∀ a', Decidable (a' = a)]
+    [∀ a', Decidable (f a' = f c)] : setValue f a (f c) c = f a := by
   simp [setValue]
 
 /-- Embedding into `Option α` using `some`. -/

--- a/Mathlib/Logic/Embedding/Basic.lean
+++ b/Mathlib/Logic/Embedding/Basic.lean
@@ -180,6 +180,10 @@ theorem setValue_eq_iff {α β} (f : α ↪ β) {a a' : α} {b : β} [∀ a', De
     [∀ a', Decidable (f a' = b)] : setValue f a b a' = b ↔ a' = a :=
   (setValue f a b).injective.eq_iff' <| setValue_eq ..
 
+lemma setValue_eq_of_ne {α β} {f : α ↪ β} {a : α} {b : β} {c : α} [∀ a', Decidable (a' = a)]
+    [∀ a', Decidable (f a' = b)] (hc : c ≠ a) (hb : f c ≠ b) : setValue f a b c = f c := by
+  simp [setValue, hc, hb]
+
 /-- Embedding into `Option α` using `some`. -/
 @[simps (config := .asFn)]
 protected def some {α} : α ↪ Option α :=


### PR DESCRIPTION
Add a lemma giving the value of `Function.Embedding.setValue` at a point where `setValue` does not change the value.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
