### PR TITLE
[Merged by Bors] - refactor(HasPDF): use structure fields

### DIFF
--- a/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
@@ -547,23 +547,21 @@ lemma setLIntegral_rnDeriv_mul [HaveLebesgueDecomposition μ ν] (hμν : μ ≪
 @[deprecated (since := "2024-06-29")]
 alias set_lintegral_rnDeriv_mul := setLIntegral_rnDeriv_mul
 
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [HaveLebesgueDecomposition μ ν]
+  [SigmaFinite μ] {f : α → E}
 
-theorem integrable_rnDeriv_smul_iff [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν)
-    [SigmaFinite μ] {f : α → E} :
+theorem integrable_rnDeriv_smul_iff (hμν : μ ≪ ν) :
     Integrable (fun x ↦ (μ.rnDeriv ν x).toReal • f x) ν ↔ Integrable f μ := by
   nth_rw 2 [← withDensity_rnDeriv_eq μ ν hμν]
   rw [← integrable_withDensity_iff_integrable_smul' (E := E)
     (measurable_rnDeriv μ ν) (rnDeriv_lt_top μ ν)]
 
-theorem withDensityᵥ_rnDeriv_smul [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν)
-    [SigmaFinite μ] {f : α → E} (hf : Integrable f μ) :
+theorem withDensityᵥ_rnDeriv_smul (hμν : μ ≪ ν) (hf : Integrable f μ) :
     ν.withDensityᵥ (fun x ↦ (rnDeriv μ ν x).toReal • f x) = μ.withDensityᵥ f := by
   rw [withDensityᵥ_smul_eq_withDensityᵥ_withDensity' (measurable_rnDeriv μ ν).aemeasurable
     (rnDeriv_lt_top μ ν) ((integrable_rnDeriv_smul_iff hμν).mpr hf), withDensity_rnDeriv_eq μ ν hμν]
 
-theorem integral_rnDeriv_smul [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν)
-    [SigmaFinite μ] {f : α → E} :
+theorem integral_rnDeriv_smul (hμν : μ ≪ ν) :
     ∫ x, (μ.rnDeriv ν x).toReal • f x ∂ν = ∫ x, f x ∂μ := by
   by_cases hf : Integrable f μ
   · rw [← setIntegral_univ, ← withDensityᵥ_apply ((integrable_rnDeriv_smul_iff hμν).mpr hf) .univ,
@@ -572,8 +570,7 @@ theorem integral_rnDeriv_smul [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ 
     contrapose! hf
     exact (integrable_rnDeriv_smul_iff hμν).mp hf
 
-lemma setIntegral_rnDeriv_smul [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν)
-    [SigmaFinite μ] {f : α → E} {s : Set α} (hs : MeasurableSet s) :
+lemma setIntegral_rnDeriv_smul (hμν : μ ≪ ν) {s : Set α} (hs : MeasurableSet s) :
     ∫ x in s, (μ.rnDeriv ν x).toReal • f x ∂ν = ∫ x in s, f x ∂μ := by
   simp_rw [← integral_indicator hs, Set.indicator_smul, integral_rnDeriv_smul hμν]
 

--- a/Mathlib/Probability/Density.lean
+++ b/Mathlib/Probability/Density.lean
@@ -60,59 +60,56 @@ namespace MeasureTheory
 
 variable {Ω E : Type*} [MeasurableSpace E]
 
-/-- A random variable `X : Ω → E` is said to `HasPDF` with respect to the measure `ℙ` on `Ω` and
-`μ` on `E` if the push-forward measure of `ℙ` along `X` is absolutely continuous with respect to
-`μ` and they `HaveLebesgueDecomposition`. -/
-class HasPDF {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
-    (μ : Measure E := by volume_tac) : Prop where
-  pdf' : AEMeasurable X ℙ ∧ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ
+/-- A random variable `X : Ω → E` is said to have a probability density function (`HasPDF`)
+with respect to the measure `ℙ` on `Ω` and `μ` on `E`
+if the push-forward measure of `ℙ` along `X` is absolutely continuous with respect to `μ`
+and they have a Lebesgue decomposition (`HaveLebesgueDecomposition`). -/
+class HasPDF {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E := by volume_tac) :
+    Prop where
+  protected aemeasurable' : AEMeasurable X ℙ
+  protected haveLebesgueDecomposition' : (map X ℙ).HaveLebesgueDecomposition μ
+  protected absolutelyContinuous' : map X ℙ ≪ μ
 
 section HasPDF
 
-variable {_ : MeasurableSpace Ω}
+variable {_ : MeasurableSpace Ω} {X Y : Ω → E} {ℙ : Measure Ω} {μ : Measure E}
 
-theorem hasPDF_iff {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E} :
+theorem hasPDF_iff :
     HasPDF X ℙ μ ↔ AEMeasurable X ℙ ∧ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ :=
-  ⟨@HasPDF.pdf' _ _ _ _ _ _ _, HasPDF.mk⟩
+  ⟨fun ⟨h₁, h₂, h₃⟩ ↦ ⟨h₁, h₂, h₃⟩, fun ⟨h₁, h₂, h₃⟩ ↦ ⟨h₁, h₂, h₃⟩⟩
 
-theorem hasPDF_iff_of_aemeasurable {X : Ω → E} {ℙ : Measure Ω}
-    {μ : Measure E} (hX : AEMeasurable X ℙ) :
+theorem hasPDF_iff_of_aemeasurable (hX : AEMeasurable X ℙ) :
     HasPDF X ℙ μ ↔ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ := by
   rw [hasPDF_iff]
   simp only [hX, true_and]
 
+variable (X ℙ μ) in
 @[measurability]
-theorem HasPDF.aemeasurable (X : Ω → E) (ℙ : Measure Ω)
-    (μ : Measure E) [hX : HasPDF X ℙ μ] : AEMeasurable X ℙ :=
-  hX.pdf'.1
+theorem HasPDF.aemeasurable [HasPDF X ℙ μ] : AEMeasurable X ℙ := HasPDF.aemeasurable' μ
 
-instance HasPDF.haveLebesgueDecomposition {X : Ω → E} {ℙ : Measure Ω}
-    {μ : Measure E} [hX : HasPDF X ℙ μ] : (map X ℙ).HaveLebesgueDecomposition μ :=
-  hX.pdf'.2.1
+instance HasPDF.haveLebesgueDecomposition [HasPDF X ℙ μ] : (map X ℙ).HaveLebesgueDecomposition μ :=
+  HasPDF.haveLebesgueDecomposition'
 
-theorem HasPDF.absolutelyContinuous {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E}
-    [hX : HasPDF X ℙ μ] : map X ℙ ≪ μ :=
-  hX.pdf'.2.2
+theorem HasPDF.absolutelyContinuous [HasPDF X ℙ μ] : map X ℙ ≪ μ := HasPDF.absolutelyContinuous'
 
 /-- A random variable that `HasPDF` is quasi-measure preserving. -/
 theorem HasPDF.quasiMeasurePreserving_of_measurable (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E)
     [HasPDF X ℙ μ] (h : Measurable X) : QuasiMeasurePreserving X ℙ μ :=
   { measurable := h
-    absolutelyContinuous := HasPDF.absolutelyContinuous }
+    absolutelyContinuous := HasPDF.absolutelyContinuous .. }
 
-theorem HasPDF.congr {X Y : Ω → E} {ℙ : Measure Ω} {μ : Measure E} (hXY : X =ᵐ[ℙ] Y)
-    [hX : HasPDF X ℙ μ] : HasPDF Y ℙ μ :=
+theorem HasPDF.congr (hXY : X =ᵐ[ℙ] Y) [hX : HasPDF X ℙ μ] : HasPDF Y ℙ μ :=
   ⟨(HasPDF.aemeasurable X ℙ μ).congr hXY, ℙ.map_congr hXY ▸ hX.haveLebesgueDecomposition,
     ℙ.map_congr hXY ▸ hX.absolutelyContinuous⟩
 
-theorem HasPDF.congr' {X Y : Ω → E} {ℙ : Measure Ω} {μ : Measure E} (hXY : X =ᵐ[ℙ] Y) :
-    HasPDF X ℙ μ ↔ HasPDF Y ℙ μ :=
+theorem HasPDF.congr_iff (hXY : X =ᵐ[ℙ] Y) : HasPDF X ℙ μ ↔ HasPDF Y ℙ μ :=
   ⟨fun _ ↦ HasPDF.congr hXY, fun _ ↦ HasPDF.congr hXY.symm⟩
 
+@[deprecated (since := "2024-10-28")] alias HasPDF.congr' := HasPDF.congr_iff
+
 /-- X `HasPDF` if there is a pdf `f` such that `map X ℙ = μ.withDensity f`. -/
-theorem hasPDF_of_map_eq_withDensity {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E}
-    (hX : AEMeasurable X ℙ) (f : E → ℝ≥0∞) (hf : AEMeasurable f μ) (h : map X ℙ = μ.withDensity f) :
-    HasPDF X ℙ μ := by
+theorem hasPDF_of_map_eq_withDensity (hX : AEMeasurable X ℙ) (f : E → ℝ≥0∞) (hf : AEMeasurable f μ)
+    (h : map X ℙ = μ.withDensity f) : HasPDF X ℙ μ := by
   refine ⟨hX, ?_, ?_⟩ <;> rw [h]
   · rw [withDensity_congr_ae hf.ae_eq_mk]
     exact haveLebesgueDecomposition_withDensity μ hf.measurable_mk
@@ -120,8 +117,8 @@ theorem hasPDF_of_map_eq_withDensity {X : Ω → E} {ℙ : Measure Ω} {μ : Mea
 
 end HasPDF
 
-/-- If `X` is a random variable, then `pdf X` is the Radon–Nikodym derivative of the push-forward
-measure of `ℙ` along `X` with respect to `μ`. -/
+/-- If `X` is a random variable, then `pdf X ℙ μ`
+is the Radon–Nikodym derivative of the push-forward measure of `ℙ` along `X` with respect to `μ`. -/
 def pdf {_ : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E := by volume_tac) :
     E → ℝ≥0∞ :=
   (map X ℙ).rnDeriv μ
@@ -238,8 +235,7 @@ theorem integrable_pdf_smul_iff [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X �
 /-- **The Law of the Unconscious Statistician**: Given a random variable `X` and a measurable
 function `f`, `f ∘ X` is a random variable with expectation `∫ x, pdf X x • f x ∂μ`
 where `μ` is a measure on the codomain of `X`. -/
-theorem integral_pdf_smul [IsFiniteMeasure ℙ]
-    {X : Ω → E} [HasPDF X ℙ μ] {f : E → F}
+theorem integral_pdf_smul [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X ℙ μ] {f : E → F}
     (hf : AEStronglyMeasurable f μ) : ∫ x, (pdf X ℙ μ x).toReal • f x ∂μ = ∫ x, f (X x) ∂ℙ := by
   rw [← integral_map (HasPDF.aemeasurable X ℙ μ) (hf.mono_ac HasPDF.absolutelyContinuous),
     map_eq_withDensity_pdf X ℙ μ, pdf_def, integral_rnDeriv_smul HasPDF.absolutelyContinuous,
@@ -249,53 +245,41 @@ end IntegralPDFMul
 
 section
 
-variable {F : Type*} [MeasurableSpace F] {ν : Measure F}
+variable {F : Type*} [MeasurableSpace F] {ν : Measure F} (X : Ω → E) [HasPDF X ℙ μ] {g : E → F}
 
 /-- A random variable that `HasPDF` transformed under a `QuasiMeasurePreserving`
 map also `HasPDF` if `(map g (map X ℙ)).HaveLebesgueDecomposition μ`.
 
 `quasiMeasurePreserving_hasPDF` is more useful in the case we are working with a
 probability measure and a real-valued random variable. -/
-theorem quasiMeasurePreserving_hasPDF {X : Ω → E} [HasPDF X ℙ μ] (hX : AEMeasurable X ℙ) {g : E → F}
-    (hg : QuasiMeasurePreserving g μ ν) (hmap : (map g (map X ℙ)).HaveLebesgueDecomposition ν) :
-    HasPDF (g ∘ X) ℙ ν := by
-  wlog hmX : Measurable X
-  · have hae : g ∘ X =ᵐ[ℙ] g ∘ hX.mk := hX.ae_eq_mk.mono fun x h ↦ by dsimp; rw [h]
-    have hXmk : HasPDF hX.mk ℙ μ := HasPDF.congr hX.ae_eq_mk
-    apply (HasPDF.congr' hae).mpr
-    exact this hX.measurable_mk.aemeasurable hg (map_congr hX.ae_eq_mk ▸ hmap) hX.measurable_mk
-  rw [hasPDF_iff, ← map_map hg.measurable hmX]
-  refine ⟨(hg.measurable.comp hmX).aemeasurable, hmap, ?_⟩
-  rw [map_eq_withDensity_pdf X ℙ μ]
-  refine AbsolutelyContinuous.mk fun s hsm hs => ?_
-  rw [map_apply hg.measurable hsm, withDensity_apply _ (hg.measurable hsm)]
-  have := hg.absolutelyContinuous hs
-  rw [map_apply hg.measurable hsm] at this
-  exact setLIntegral_measure_zero _ _ this
+theorem quasiMeasurePreserving_hasPDF (hg : QuasiMeasurePreserving g μ ν)
+    (hmap : (map g (map X ℙ)).HaveLebesgueDecomposition ν) : HasPDF (g ∘ X) ℙ ν := by
+  have hgm : AEMeasurable g (map X ℙ) := hg.aemeasurable.mono_ac HasPDF.absolutelyContinuous
+  rw [hasPDF_iff, ← AEMeasurable.map_map_of_aemeasurable hgm (HasPDF.aemeasurable X ℙ μ)]
+  refine ⟨hg.measurable.comp_aemeasurable (HasPDF.aemeasurable _ _ μ), hmap, ?_⟩
+  exact (HasPDF.absolutelyContinuous.map hg.1).trans hg.2
 
-theorem quasiMeasurePreserving_hasPDF' [IsFiniteMeasure ℙ] [SigmaFinite ν] {X : Ω → E}
-    [HasPDF X ℙ μ] (hX : AEMeasurable X ℙ) {g : E → F} (hg : QuasiMeasurePreserving g μ ν) :
-    HasPDF (g ∘ X) ℙ ν :=
-  quasiMeasurePreserving_hasPDF hX hg inferInstance
+theorem quasiMeasurePreserving_hasPDF' [SFinite ℙ] [SigmaFinite ν]
+    (hg : QuasiMeasurePreserving g μ ν) : HasPDF (g ∘ X) ℙ ν :=
+  quasiMeasurePreserving_hasPDF X hg inferInstance
 
 end
 
 section Real
 
-variable [IsFiniteMeasure ℙ] {X : Ω → ℝ}
+variable {X : Ω → ℝ}
+
+nonrec theorem _root_.Real.hasPDF_iff [SFinite ℙ] :
+    HasPDF X ℙ ↔ AEMeasurable X ℙ ∧ map X ℙ ≪ volume := by
+  rw [hasPDF_iff, and_iff_right (inferInstance : HaveLebesgueDecomposition _ _)]
 
 /-- A real-valued random variable `X` `HasPDF X ℙ λ` (where `λ` is the Lebesgue measure) if and
 only if the push-forward measure of `ℙ` along `X` is absolutely continuous with respect to `λ`. -/
-nonrec theorem _root_.Real.hasPDF_iff_of_aemeasurable (hX : AEMeasurable X ℙ) :
+nonrec theorem _root_.Real.hasPDF_iff_of_aemeasurable [SFinite ℙ] (hX : AEMeasurable X ℙ) :
     HasPDF X ℙ ↔ map X ℙ ≪ volume := by
-  rw [hasPDF_iff_of_aemeasurable hX]
-  exact and_iff_right inferInstance
+  rw [Real.hasPDF_iff, and_iff_right hX]
 
-theorem _root_.Real.hasPDF_iff : HasPDF X ℙ ↔ AEMeasurable X ℙ ∧ map X ℙ ≪ volume := by
-  by_cases hX : AEMeasurable X ℙ
-  · rw [Real.hasPDF_iff_of_aemeasurable hX, iff_and_self]
-    exact fun _ => hX
-  · exact ⟨fun h => False.elim (hX h.pdf'.1), fun h => False.elim (hX h.1)⟩
+variable [IsFiniteMeasure ℙ]
 
 /-- If `X` is a real-valued random variable that has pdf `f`, then the expectation of `X` equals
 `∫ x, x * f x ∂λ` where `λ` is the Lebesgue measure. -/
@@ -329,10 +313,10 @@ theorem indepFun_iff_pdf_prod_eq_pdf_mul_pdf
     [IsFiniteMeasure ℙ] [SigmaFinite μ] [SigmaFinite ν] [HasPDF (fun ω ↦ (X ω, Y ω)) ℙ (μ.prod ν)] :
     IndepFun X Y ℙ ↔
       pdf (fun ω ↦ (X ω, Y ω)) ℙ (μ.prod ν) =ᵐ[μ.prod ν] fun z ↦ pdf X ℙ μ z.1 * pdf Y ℙ ν z.2 := by
-  have : HasPDF X ℙ μ := quasiMeasurePreserving_hasPDF' (μ := μ.prod ν)
-    (HasPDF.aemeasurable (fun ω ↦ (X ω, Y ω)) ℙ (μ.prod ν)) quasiMeasurePreserving_fst
-  have : HasPDF Y ℙ ν := quasiMeasurePreserving_hasPDF' (μ := μ.prod ν)
-    (HasPDF.aemeasurable (fun ω ↦ (X ω, Y ω)) ℙ (μ.prod ν)) quasiMeasurePreserving_snd
+  have : HasPDF X ℙ μ := quasiMeasurePreserving_hasPDF' (μ := μ.prod ν) (fun ω ↦ (X ω, Y ω))
+    quasiMeasurePreserving_fst
+  have : HasPDF Y ℙ ν := quasiMeasurePreserving_hasPDF' (μ := μ.prod ν) (fun ω ↦ (X ω, Y ω))
+    quasiMeasurePreserving_snd
   have h₀ : (ℙ.map X).prod (ℙ.map Y) =
       (μ.prod ν).withDensity fun z ↦ pdf X ℙ μ z.1 * pdf Y ℙ ν z.2 :=
     prod_eq fun s t hs ht ↦ by rw [withDensity_apply _ (hs.prod ht), ← prod_restrict,


### PR DESCRIPTION
... instead of a single field with `And`s.

Also drop an `AEMeasurable` assumption that follows from `HasPDF`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
