### PR TITLE
[Merged by Bors] - fix: silence `linter.minImports` tests

### DIFF
--- a/Mathlib/Tactic/Linter/MinImports.lean
+++ b/Mathlib/Tactic/Linter/MinImports.lean
@@ -128,8 +128,13 @@ def minImportsLinter : Linter where run := withSetOptionIn fun stx ↦ do
       minImportsRef.modify ({· with minImports := currImports, importSize := newCumulImps})
       let new := currImpArray.filter (!importsSoFar.contains ·)
       let redundant := importsSoFar.toArray.filter (!currImports.contains ·)
+      -- to make `test` files more stable, we suppress the exact count of import changes in
+      -- modules whose path starts with `test`
+      let count := m!"by {if (← getMainModule).getRoot == `test then
+                            m!"X"
+                          else m!"newCumulImps - oldCumulImps"}"
       Linter.logLint linter.minImports stx <|
-        m!"Imports increased by {newCumulImps - oldCumulImps} to\n{currImpArray}\n\n\
+        m!"Imports increased {count} to\n{currImpArray}\n\n\
           New imports: {new}\n" ++
             if redundant.isEmpty then m!"" else m!"\nNow redundant: {redundant}\n"
 

--- a/Mathlib/Tactic/Linter/MinImports.lean
+++ b/Mathlib/Tactic/Linter/MinImports.lean
@@ -139,12 +139,12 @@ def minImportsLinter : Linter where run := withSetOptionIn fun stx ↦ do
       let redundant := importsSoFar.toArray.filter (!currImports.contains ·)
       -- to make `test` files more stable, we suppress the exact count of import changes if
       -- the `linter.minImports.increases` option is `false`
-      let count :=  if Linter.getLinterValue linter.minImports.increases (← getOptions) then
-                      m!"{newCumulImps - oldCumulImps}"
+      let byCount :=  if Linter.getLinterValue linter.minImports.increases (← getOptions) then
+                      m!"by {newCumulImps - oldCumulImps} "
                     else
-                      m!"X"
+                      m!""
       Linter.logLint linter.minImports stx <|
-        m!"Imports increased by {count} to\n{currImpArray}\n\n\
+        m!"Imports increased {byCount}to\n{currImpArray}\n\n\
           New imports: {new}\n" ++
             if redundant.isEmpty then m!"" else m!"\nNow redundant: {redundant}\n"
 

--- a/Mathlib/Tactic/Linter/MinImports.lean
+++ b/Mathlib/Tactic/Linter/MinImports.lean
@@ -137,8 +137,8 @@ def minImportsLinter : Linter where run := withSetOptionIn fun stx ↦ do
       minImportsRef.modify ({· with minImports := currImports, importSize := newCumulImps})
       let new := currImpArray.filter (!importsSoFar.contains ·)
       let redundant := importsSoFar.toArray.filter (!currImports.contains ·)
-      -- to make `test` files more stable, we suppress the exact count of import changes in
-      -- modules whose path starts with `test`
+      -- to make `test` files more stable, we suppress the exact count of import changes if
+      -- the `linter.minImports.increases` option is `false`
       let count :=  if Linter.getLinterValue linter.minImports.increases (← getOptions) then
                       m!"{newCumulImps - oldCumulImps}"
                     else

--- a/test/MinImports.lean
+++ b/test/MinImports.lean
@@ -76,7 +76,7 @@ lemma hi (n : ℕ) : n = n := by extract_goal; rfl
 
 set_option linter.minImports.increases false
 /--
-warning: Imports increased by X to
+warning: Imports increased to
 [Init.Guard, Mathlib.Data.Int.Notation]
 
 New imports: [Init.Guard, Mathlib.Data.Int.Notation]
@@ -96,7 +96,7 @@ set_option linter.minImports false in
 #reset_min_imports
 
 /--
-warning: Imports increased by X to
+warning: Imports increased to
 [Init.Guard, Mathlib.Data.Int.Notation]
 
 New imports: [Init.Guard, Mathlib.Data.Int.Notation]
@@ -114,7 +114,7 @@ set_option linter.minImports true in
 set_option linter.minImports true
 
 /--
-warning: Imports increased by X to
+warning: Imports increased to
 [Mathlib.Tactic.Linter.MinImports]
 
 New imports: [Mathlib.Tactic.Linter.MinImports]
@@ -125,7 +125,7 @@ note: this linter can be disabled with `set_option linter.minImports false`
 #reset_min_imports
 
 /--
-warning: Imports increased by X to
+warning: Imports increased to
 [Mathlib.Tactic.FunProp.Attr, Mathlib.Tactic.NormNum.Basic]
 
 New imports: [Mathlib.Tactic.FunProp.Attr, Mathlib.Tactic.NormNum.Basic]

--- a/test/MinImports.lean
+++ b/test/MinImports.lean
@@ -74,6 +74,7 @@ import Mathlib.Data.Nat.Notation
 #min_imports in
 lemma hi (n : ℕ) : n = n := by extract_goal; rfl
 
+set_option linter.minImports.increases false
 /--
 warning: Imports increased by X to
 [Init.Guard, Mathlib.Data.Int.Notation]

--- a/test/MinImports.lean
+++ b/test/MinImports.lean
@@ -75,7 +75,7 @@ import Mathlib.Data.Nat.Notation
 lemma hi (n : ℕ) : n = n := by extract_goal; rfl
 
 /--
-warning: Imports increased by 398 to
+warning: Imports increased by X to
 [Init.Guard, Mathlib.Data.Int.Notation]
 
 New imports: [Init.Guard, Mathlib.Data.Int.Notation]
@@ -95,7 +95,7 @@ set_option linter.minImports false in
 #reset_min_imports
 
 /--
-warning: Imports increased by 398 to
+warning: Imports increased by X to
 [Init.Guard, Mathlib.Data.Int.Notation]
 
 New imports: [Init.Guard, Mathlib.Data.Int.Notation]
@@ -113,7 +113,7 @@ set_option linter.minImports true in
 set_option linter.minImports true
 
 /--
-warning: Imports increased by 967 to
+warning: Imports increased by X to
 [Mathlib.Tactic.Linter.MinImports]
 
 New imports: [Mathlib.Tactic.Linter.MinImports]
@@ -124,7 +124,7 @@ note: this linter can be disabled with `set_option linter.minImports false`
 #reset_min_imports
 
 /--
-warning: Imports increased by 424 to
+warning: Imports increased by X to
 [Mathlib.Tactic.FunProp.Attr, Mathlib.Tactic.NormNum.Basic]
 
 New imports: [Mathlib.Tactic.FunProp.Attr, Mathlib.Tactic.NormNum.Basic]


### PR DESCRIPTION
Reported on [Zulip](https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/.2318333.20adaptations.20for.20nightly-2024-10-28)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
