### PR TITLE
[Merged by Bors] - refactor: avoid passing both directions of a lemma to simp

### DIFF
--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp/Kernels.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp/Kernels.lean
@@ -349,8 +349,8 @@ theorem ExplicitCoker.map_desc {A B C D B' D' : SemiNormedGrp.{u}}
     (h' : fbb' ≫ g = fbd ≫ fdd') :
     explicitCokernelDesc condb ≫ g = explicitCokernel.map h ≫ explicitCokernelDesc condd := by
   delta explicitCokernel.map
-  simp [← cancel_epi (explicitCokernelπ fab), ← Category.assoc, Category.assoc,
-    explicitCokernelπ_desc, h']
+  simp only [← Category.assoc, ← cancel_epi (explicitCokernelπ fab)]
+  simp [Category.assoc, explicitCokernelπ_desc, h']
 
 end ExplicitCokernel
 

--- a/Mathlib/CategoryTheory/Abelian/InjectiveResolution.lean
+++ b/Mathlib/CategoryTheory/Abelian/InjectiveResolution.lean
@@ -65,7 +65,7 @@ lemma exact₀ {Z : C} (I : InjectiveResolution Z) :
 def descFOne {Y Z : C} (f : Z ⟶ Y) (I : InjectiveResolution Y) (J : InjectiveResolution Z) :
     J.cocomplex.X 1 ⟶ I.cocomplex.X 1 :=
   J.exact₀.descToInjective (descFZero f I J ≫ I.cocomplex.d 0 1)
-    (by dsimp; simp [← assoc, assoc, descFZero])
+    (by dsimp; simp only [← assoc, descFZero]; simp [assoc])
 
 @[simp]
 theorem descFOne_zero_comm {Y Z : C} (f : Z ⟶ Y) (I : InjectiveResolution Y)

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -161,7 +161,9 @@ def homEquiv {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G) (X : C) (Y : D) :
     rw [F.map_comp, assoc, ← Functor.comp_map, adj.counit.naturality, ← assoc]
     simp
   right_inv := fun g => by
-    simp [← assoc, ← Functor.comp_map, ← adj.unit.naturality, assoc]
+    simp only [Functor.comp_obj, Functor.map_comp]
+    rw [← assoc, ← Functor.comp_map, ← adj.unit.naturality]
+    simp
 
 alias homEquiv_unit := homEquiv_apply
 alias homEquiv_counit := homEquiv_symm_apply

--- a/Mathlib/CategoryTheory/EffectiveEpi/Comp.lean
+++ b/Mathlib/CategoryTheory/EffectiveEpi/Comp.lean
@@ -32,7 +32,9 @@ def effectiveEpiFamilyStructCompOfEffectiveEpiSplitEpi' {α : Type*} {B : C} {X 
   desc e w := EffectiveEpiFamily.desc _ f (fun a ↦ i a ≫ e a) fun a₁ a₂ g₁ g₂ _ ↦ (by
     simp only [← Category.assoc]
     apply w _ _ (g₁ ≫ i a₁) (g₂ ≫ i a₂)
-    simpa [← Category.assoc, Category.assoc, hi])
+    simp only [Category.assoc, hi]
+    simp only [← Category.assoc, hi]
+    simpa)
   fac e w a := by
     simp only [Category.assoc, EffectiveEpiFamily.fac]
     rw [← Category.id_comp (e a), ← Category.assoc, ← Category.assoc]

--- a/Mathlib/NumberTheory/Bernoulli.lean
+++ b/Mathlib/NumberTheory/Bernoulli.lean
@@ -181,7 +181,7 @@ def bernoulli (n : ℕ) : ℚ :=
   (-1) ^ n * bernoulli' n
 
 theorem bernoulli'_eq_bernoulli (n : ℕ) : bernoulli' n = (-1) ^ n * bernoulli n := by
-  simp [bernoulli, ← mul_assoc, ← sq, ← pow_mul, mul_comm n 2, pow_mul]
+  simp [bernoulli, ← mul_assoc, ← sq, ← pow_mul, mul_comm n 2]
 
 @[simp]
 theorem bernoulli_zero : bernoulli 0 = 1 := by simp [bernoulli]


### PR DESCRIPTION
this only works by chance, in a way, and will break when
https://github.com/leanprover/lean4/pull/5870 lands
