### PR TITLE
[Merged by Bors] - feat(Topology/Group): Open normal subgroup in clopen nhds of one

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4601,6 +4601,7 @@ import Mathlib.Topology.Algebra.Affine
 import Mathlib.Topology.Algebra.Algebra
 import Mathlib.Topology.Algebra.Algebra.Rat
 import Mathlib.Topology.Algebra.Category.ProfiniteGrp.Basic
+import Mathlib.Topology.Algebra.ClopenNhdofOne
 import Mathlib.Topology.Algebra.ClosedSubgroup
 import Mathlib.Topology.Algebra.ConstMulAction
 import Mathlib.Topology.Algebra.Constructions

--- a/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
+++ b/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
@@ -16,27 +16,14 @@ This file is split out from the file `OpenSubgroup` because the need of more imp
 
 namespace TopologicalGroup
 
-/-- An arbitrary normal subgroup contained in a clopen nhd of `1` in a compact topological group. -/
-noncomputable def OpenNormalSubgroupSubClopenNhdsOfOne {G : Type*} [Group G] [TopologicalSpace G]
-    [TopologicalGroup G] [CompactSpace G] {U : Set G} (UClopen : IsClopen U) :
-    OpenNormalSubgroup G :=
-  let H := OpenSubgroupSubClopenNhdsOfOne UClopen
+theorem existOpenNormalSubgroupSubClopenNhdsOfOne {G : Type*} [Group G] [TopologicalSpace G]
+    [TopologicalGroup G] [CompactSpace G] {W : Set G} (WClopen : IsClopen W) (einW : 1 ∈ W) :
+    ∃ H : OpenNormalSubgroup G, (H : Set G) ⊆ W := by
+  rcases existOpenSubgroupSubClopenNhdsOfOne WClopen einW with ⟨H, hH⟩
   letI : Subgroup.FiniteIndex H.1 := Subgroup.finiteIndex_of_finite_quotient H.1
-  { toSubgroup := Subgroup.normalCore H
-    isOpen' := Subgroup.isOpen_of_isClosed_of_finiteIndex _ <|
-      Subgroup.normalCore_isClosed H.1 <| OpenSubgroup.isClosed H }
-
-theorem openNormalSubgroupSubClopenNhdsOfOne_spec {G : Type*} [Group G] [TopologicalSpace G]
-    [TopologicalGroup G] [CompactSpace G] {U : Set G}
-    (UClopen : IsClopen U) (einU : 1 ∈ U) :
-    ((OpenNormalSubgroupSubClopenNhdsOfOne UClopen) : Set G) ⊆ U :=
-    fun _ b ↦ openSubgroupSubClopenNhdsOfOne_spec UClopen einU
-      (Subgroup.normalCore_le (OpenSubgroupSubClopenNhdsOfOne UClopen).1 b)
-
-theorem openNormalSubgroupSubClopenNhdsOfOne_nonempty {G : Type*} [Group G] [TopologicalSpace G]
-    [TopologicalGroup G] [CompactSpace G] {U : Set G} (UClopen : IsClopen U) (einU : 1 ∈ U) :
-    Nonempty {H : OpenNormalSubgroup G // (H : Set G) ⊆ U} :=
-  Nonempty.intro ⟨OpenNormalSubgroupSubClopenNhdsOfOne UClopen,
-    openNormalSubgroupSubClopenNhdsOfOne_spec UClopen einU⟩
+  use { toSubgroup := Subgroup.normalCore H
+        isOpen' := Subgroup.isOpen_of_isClosed_of_finiteIndex _ <|
+          Subgroup.normalCore_isClosed H.1 <| OpenSubgroup.isClosed H }
+  exact fun _ b ↦ hH (Subgroup.normalCore_le H.1 b)
 
 end TopologicalGroup

--- a/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
+++ b/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
@@ -7,20 +7,20 @@ import Mathlib.GroupTheory.Index
 import Mathlib.Topology.Algebra.ClosedSubgroup
 import Mathlib.Topology.Algebra.OpenSubgroup
 /-!
-# Open normal subgroup in a clopen neighborhood of One
+# Existence of an open normal subgroup in any clopen neighborhood of the neutral element
 This file proves the lemma `TopologicalGroup.existOpenNormalSubgroupSubClopenNhdsOfOne`, which
 states that in a compact topological group, for any clopen neighborhood of 1,
 there exists an open normal subgroup contained within it.
 
-This file is split out from the file `OpenSubgroup` because the need of more imports.
+This file is split out from the file `OpenSubgroup` because it needs more imports.
 -/
 
 namespace TopologicalGroup
 
-theorem existOpenNormalSubgroupSubClopenNhdsOfOne {G : Type*} [Group G] [TopologicalSpace G]
+theorem exist_openNormalSubgroup_sub_clopen_nhd_of_one {G : Type*} [Group G] [TopologicalSpace G]
     [TopologicalGroup G] [CompactSpace G] {W : Set G} (WClopen : IsClopen W) (einW : 1 ∈ W) :
     ∃ H : OpenNormalSubgroup G, (H : Set G) ⊆ W := by
-  rcases existOpenSubgroupSubClopenNhdsOfOne WClopen einW with ⟨H, hH⟩
+  rcases exist_openSubgroup_sub_clopen_nhd_of_one WClopen einW with ⟨H, hH⟩
   have : Subgroup.FiniteIndex H := H.finiteIndex_of_finite_quotient
   use { toSubgroup := Subgroup.normalCore H
         isOpen' := Subgroup.isOpen_of_isClosed_of_finiteIndex _ (H.normalCore_isClosed H.isClosed) }

--- a/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
+++ b/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2024 Nailin Guan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nailin Guan, Yi Song, Xuchun Li
+-/
+import Mathlib.GroupTheory.Index
+import Mathlib.Topology.Algebra.ClosedSubgroup
+import Mathlib.Topology.Algebra.OpenSubgroup
+/-!
+# Open normal subgroup in a clopen neighborhood of One
+This file defines `OpenNormalSubgroupSubClopenNhdsOfOne`, which strengthens the result of
+`OpenSubgroupSubClopenNhdsOfOne` into open *normal* subgroups.
+
+This file is split out from the file `OpenSubgroup` because the need of more imports.
+-/
+
+namespace TopologicalGroup
+
+/-- An arbitrary normal subgroup contained in a clopen nhd of `1` in a compact topological group. -/
+noncomputable def OpenNormalSubgroupSubClopenNhdsOfOne {G : Type*} [Group G] [TopologicalSpace G]
+    [TopologicalGroup G] [CompactSpace G] {U : Set G} (UClopen : IsClopen U) :
+    OpenNormalSubgroup G :=
+  let H := OpenSubgroupSubClopenNhdsOfOne UClopen
+  letI : Subgroup.FiniteIndex H.1 := Subgroup.finiteIndex_of_finite_quotient H.1
+  { toSubgroup := Subgroup.normalCore H
+    isOpen' := Subgroup.isOpen_of_isClosed_of_finiteIndex _ <|
+      Subgroup.normalCore_isClosed H.1 <| OpenSubgroup.isClosed H }
+
+theorem openNormalSubgroupSubClopenNhdsOfOne_spec {G : Type*} [Group G] [TopologicalSpace G]
+    [TopologicalGroup G] [CompactSpace G] {U : Set G}
+    (UClopen : IsClopen U) (einU : 1 ∈ U) :
+    ((OpenNormalSubgroupSubClopenNhdsOfOne UClopen) : Set G) ⊆ U :=
+    fun _ b ↦ openSubgroupSubClopenNhdsOfOne_spec UClopen einU
+      (Subgroup.normalCore_le (OpenSubgroupSubClopenNhdsOfOne UClopen).1 b)
+
+theorem openNormalSubgroupSubClopenNhdsOfOne_nonempty {G : Type*} [Group G] [TopologicalSpace G]
+    [TopologicalGroup G] [CompactSpace G] {U : Set G} (UClopen : IsClopen U) (einU : 1 ∈ U) :
+    Nonempty {H : OpenNormalSubgroup G // (H : Set G) ⊆ U} :=
+  Nonempty.intro ⟨OpenNormalSubgroupSubClopenNhdsOfOne UClopen,
+    openNormalSubgroupSubClopenNhdsOfOne_spec UClopen einU⟩
+
+end TopologicalGroup

--- a/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
+++ b/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
@@ -8,8 +8,9 @@ import Mathlib.Topology.Algebra.ClosedSubgroup
 import Mathlib.Topology.Algebra.OpenSubgroup
 /-!
 # Open normal subgroup in a clopen neighborhood of One
-This file defines `OpenNormalSubgroupSubClopenNhdsOfOne`, which strengthens the result of
-`OpenSubgroupSubClopenNhdsOfOne` into open *normal* subgroups.
+This file proved the lemma `TopologicalGroup.existOpenNormalSubgroupSubClopenNhdsOfOne`, which
+states that for any clopen neighborhood of 1, there exists an open normal subgroup
+contained within it.
 
 This file is split out from the file `OpenSubgroup` because the need of more imports.
 -/
@@ -20,10 +21,9 @@ theorem existOpenNormalSubgroupSubClopenNhdsOfOne {G : Type*} [Group G] [Topolog
     [TopologicalGroup G] [CompactSpace G] {W : Set G} (WClopen : IsClopen W) (einW : 1 ∈ W) :
     ∃ H : OpenNormalSubgroup G, (H : Set G) ⊆ W := by
   rcases existOpenSubgroupSubClopenNhdsOfOne WClopen einW with ⟨H, hH⟩
-  letI : Subgroup.FiniteIndex H.1 := Subgroup.finiteIndex_of_finite_quotient H.1
+  haveI : Subgroup.FiniteIndex H := H.finiteIndex_of_finite_quotient
   use { toSubgroup := Subgroup.normalCore H
-        isOpen' := Subgroup.isOpen_of_isClosed_of_finiteIndex _ <|
-          Subgroup.normalCore_isClosed H.1 <| OpenSubgroup.isClosed H }
-  exact fun _ b ↦ hH (Subgroup.normalCore_le H.1 b)
+        isOpen' := Subgroup.isOpen_of_isClosed_of_finiteIndex _ (H.normalCore_isClosed H.isClosed) }
+  exact fun _ b ↦ hH (H.normalCore_le b)
 
 end TopologicalGroup

--- a/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
+++ b/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
@@ -8,9 +8,9 @@ import Mathlib.Topology.Algebra.ClosedSubgroup
 import Mathlib.Topology.Algebra.OpenSubgroup
 /-!
 # Open normal subgroup in a clopen neighborhood of One
-This file proved the lemma `TopologicalGroup.existOpenNormalSubgroupSubClopenNhdsOfOne`, which
-states that for any clopen neighborhood of 1, there exists an open normal subgroup
-contained within it.
+This file proves the lemma `TopologicalGroup.existOpenNormalSubgroupSubClopenNhdsOfOne`, which
+states that in a compact topological group, for any clopen neighborhood of 1,
+there exists an open normal subgroup contained within it.
 
 This file is split out from the file `OpenSubgroup` because the need of more imports.
 -/
@@ -21,7 +21,7 @@ theorem existOpenNormalSubgroupSubClopenNhdsOfOne {G : Type*} [Group G] [Topolog
     [TopologicalGroup G] [CompactSpace G] {W : Set G} (WClopen : IsClopen W) (einW : 1 ∈ W) :
     ∃ H : OpenNormalSubgroup G, (H : Set G) ⊆ W := by
   rcases existOpenSubgroupSubClopenNhdsOfOne WClopen einW with ⟨H, hH⟩
-  haveI : Subgroup.FiniteIndex H := H.finiteIndex_of_finite_quotient
+  have : Subgroup.FiniteIndex H := H.finiteIndex_of_finite_quotient
   use { toSubgroup := Subgroup.normalCore H
         isOpen' := Subgroup.isOpen_of_isClosed_of_finiteIndex _ (H.normalCore_isClosed H.isClosed) }
   exact fun _ b ↦ hH (H.normalCore_le b)

--- a/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
+++ b/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
@@ -8,7 +8,8 @@ import Mathlib.Topology.Algebra.ClosedSubgroup
 import Mathlib.Topology.Algebra.OpenSubgroup
 /-!
 # Existence of an open normal subgroup in any clopen neighborhood of the neutral element
-This file proves the lemma `TopologicalGroup.existOpenNormalSubgroupSubClopenNhdsOfOne`, which
+
+This file proves the lemma `TopologicalGroup.exist_openNormalSubgroup_sub_clopen_nhd_of_one`, which
 states that in a compact topological group, for any clopen neighborhood of 1,
 there exists an open normal subgroup contained within it.
 

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -457,8 +457,8 @@ end
 
 /-!
 ## The Open Subgroup in a Clopen Neighborhood of One
-This section define `OpenSubgroupSubClopenNhdsOfOne` (`OpenNormalSubgroupSubClopenNhdsOfOne`),
-which can pick an open subgroup contained in a clopen neighborhood of `1`.
+This section proved the lemma `TopologicalGroup.existOpenSubgroupSubClopenNhdsOfOne`, which
+states that for any clopen neighborhood of 1, there exists an open subgroup contained within it.
 -/
 
 open scoped Pointwise
@@ -467,9 +467,9 @@ variable {G : Type*} [TopologicalSpace G]
 
 structure TopologicalAddGroup.addNegClosureNhd (T W : Set G) [AddGroup G] : Prop where
   nhd : T ∈ 𝓝 0
-  inv : -T = T
+  neg : -T = T
   isOpen : IsOpen T
-  mul : W + T ⊆ W
+  add : W + T ⊆ W
 
 /--For a set W, the neighborhood of `1` which is open, self inverse and satisfying `T * W ⊆ W` -/
 @[to_additive
@@ -490,31 +490,30 @@ open Set Filter
 lemma exist_mul_closure_nhd {W : Set G} (WClopen : IsClopen W) : ∃ T ∈ 𝓝 (1 : G), W * T ⊆ W := by
   apply WClopen.isClosed.isCompact.induction_on (p := fun S ↦ ∃ T ∈ 𝓝 (1 : G), S * T ⊆ W)
     ⟨Set.univ ,by simp only [univ_mem, empty_mul, empty_subset, and_self]⟩
-    (fun _ _ huv ⟨T, hT, mem⟩ ↦ ⟨T, ⟨hT, (mul_subset_mul_right huv).trans mem⟩⟩)
-    fun U V ⟨T₁, hT₁, mem1⟩ ⟨T₂, hT₂, mem2⟩ ↦ ⟨T₁ ∩ T₂, ⟨inter_mem hT₁ hT₂, by
+    (fun _ _ huv ⟨T, hT, mem⟩ ↦ ⟨T, hT, (mul_subset_mul_right huv).trans mem⟩)
+    fun U V ⟨T₁, hT₁, mem1⟩ ⟨T₂, hT₂, mem2⟩ ↦ ⟨T₁ ∩ T₂, inter_mem hT₁ hT₂, by
       rw [union_mul]
       exact union_subset (mul_subset_mul_left inter_subset_left |>.trans mem1)
-        (mul_subset_mul_left inter_subset_right |>.trans mem2)⟩⟩
+        (mul_subset_mul_left inter_subset_right |>.trans mem2) ⟩
   intro x memW
   have : (x, 1) ∈ (fun p ↦ p.1 * p.2) ⁻¹' W := by simp only [mem_preimage, mul_one, memW]
   rcases isOpen_prod_iff.mp (continuous_mul.isOpen_preimage W <| WClopen.2) x 1 this with
-    ⟨U, V, h1, h2, h3, h4, h5⟩
-  have h6 : U * V ⊆ W := mul_subset_iff.mpr (fun _ hx _ hy ↦ h5 (mk_mem_prod hx hy))
-  exact ⟨U ∩ W, ⟨⟨U, ⟨IsOpen.mem_nhds h1 h3, ⟨W, ⟨fun _ a ↦ a, rfl⟩⟩⟩⟩,
-    ⟨V, ⟨IsOpen.mem_nhds h2 h4, fun _ a ↦ h6 ((mul_subset_mul_right inter_subset_left) a)⟩⟩⟩⟩
+    ⟨U, V, Uopen, Vopen, xmemU, onememV, prodsub⟩
+  have h6 : U * V ⊆ W := mul_subset_iff.mpr (fun _ hx _ hy ↦ prodsub (mk_mem_prod hx hy))
+  exact ⟨U ∩ W, ⟨U, Uopen.mem_nhds xmemU, W, fun _ a ↦ a, rfl⟩,
+    V, IsOpen.mem_nhds Vopen onememV, fun _ a ↦ h6 ((mul_subset_mul_right inter_subset_left) a)⟩
 
 @[to_additive]
 lemma exists_mulInvClosureNhd {W : Set G} (WClopen : IsClopen W) :
     ∃ T, mulInvClosureNhd T W := by
-  rcases exist_mul_closure_nhd WClopen with ⟨S, hS, h⟩
-  rcases mem_nhds_iff.mp hS with ⟨U, h1, h2, h3⟩
+  rcases exist_mul_closure_nhd WClopen with ⟨S, Smemnhds, mulclose⟩
+  rcases mem_nhds_iff.mp Smemnhds with ⟨U, UsubS, Uopen, onememU⟩
   use U ∩ U⁻¹
   constructor
-  · exact IsOpen.mem_nhds (h2.inter h2.inv) (by simp only [mem_inter_iff, h3, Set.mem_inv, inv_one,
-    and_self])
+  · simp only [inter_mem_iff, Uopen.mem_nhds onememU, inv_mem_nhds_one, and_self]
   · simp only [inter_inv, inv_inv, inter_comm]
-  · exact h2.inter h2.inv
-  · exact fun a ha ↦ h (mul_subset_mul_left h1 (mul_subset_mul_left inter_subset_left ha))
+  · exact Uopen.inter Uopen.inv
+  · exact fun a ha ↦ mulclose (mul_subset_mul_left UsubS (mul_subset_mul_left inter_subset_left ha))
 
 @[to_additive]
 theorem existOpenSubgroupSubClopenNhdsOfOne {G : Type*} [Group G] [TopologicalSpace G]
@@ -543,13 +542,13 @@ theorem existOpenSubgroupSubClopenNhdsOfOne {G : Type*} [Group G] [TopologicalSp
   have : IsOpen (⋃ n , V ^ (n + 1)) := by
     refine isOpen_iUnion (fun n ↦ ?_)
     rw [pow_succ]
-    exact IsOpen.mul_left hV.isOpen
+    exact hV.isOpen.mul_left
   use ⟨S, this⟩
   have mulVpow (n : ℕ) : W * V ^ (n + 1) ⊆ W := by
     induction' n with n ih
     · simp only [zero_add, pow_one, hV.mul]
     · rw [pow_succ, ← mul_assoc]
-      exact le_trans (Set.mul_subset_mul_right ih) <| hV.mul
+      exact (Set.mul_subset_mul_right ih).trans hV.mul
   have (n : ℕ) : V ^ (n + 1) ⊆ W * V ^ (n + 1) := by
     intro x xin
     rw [Set.mem_mul]

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -456,7 +456,7 @@ end OpenNormalSubgroup
 end
 
 /-!
-## The Open Subgroup in a Clopen Neighborhood of One
+# Existence of an open subgroup in any clopen neighborhood of the neutral element
 This section proves the lemma `TopologicalGroup.existOpenSubgroupSubClopenNhdsOfOne`, which
 states that in a compact topological group, for any clopen neighborhood of 1,
 there exists an open subgroup contained within it.
@@ -517,7 +517,7 @@ lemma exists_mulInvClosureNhd {W : Set G} (WClopen : IsClopen W) :
   · exact fun a ha ↦ mulclose (mul_subset_mul_left UsubS (mul_subset_mul_left inter_subset_left ha))
 
 @[to_additive]
-theorem existOpenSubgroupSubClopenNhdsOfOne {G : Type*} [Group G] [TopologicalSpace G]
+theorem exist_openSubgroup_sub_clopen_nhd_of_one {G : Type*} [Group G] [TopologicalSpace G]
     [TopologicalGroup G] [CompactSpace G] {W : Set G} (WClopen : IsClopen W) (einW : 1 ∈ W) :
     ∃ H : OpenSubgroup G, (H : Set G) ⊆ W := by
   rcases exists_mulInvClosureNhd WClopen with ⟨V, hV⟩

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -497,7 +497,7 @@ lemma exist_mul_closure_nhd {W : Set G} (WClopen : IsClopen W) : ∃ T ∈ 𝓝 
       exact union_subset (mul_subset_mul_left inter_subset_left |>.trans mem1)
         (mul_subset_mul_left inter_subset_right |>.trans mem2) ⟩
   intro x memW
-  have : (x, 1) ∈ (fun p ↦ p.1 * p.2) ⁻¹' W := by simp only [mem_preimage, mul_one, memW]
+  have : (x, 1) ∈ (fun p ↦ p.1 * p.2) ⁻¹' W := by simp [memW]
   rcases isOpen_prod_iff.mp (continuous_mul.isOpen_preimage W <| WClopen.2) x 1 this with
     ⟨U, V, Uopen, Vopen, xmemU, onememV, prodsub⟩
   have h6 : U * V ⊆ W := mul_subset_iff.mpr (fun _ hx _ hy ↦ prodsub (mk_mem_prod hx hy))
@@ -511,8 +511,8 @@ lemma exists_mulInvClosureNhd {W : Set G} (WClopen : IsClopen W) :
   rcases mem_nhds_iff.mp Smemnhds with ⟨U, UsubS, Uopen, onememU⟩
   use U ∩ U⁻¹
   constructor
-  · simp only [inter_mem_iff, Uopen.mem_nhds onememU, inv_mem_nhds_one, and_self]
-  · simp only [inter_inv, inv_inv, inter_comm]
+  · simp [Uopen.mem_nhds onememU, inv_mem_nhds_one]
+  · simp [inter_comm]
   · exact Uopen.inter Uopen.inv
   · exact fun a ha ↦ mulclose (mul_subset_mul_left UsubS (mul_subset_mul_left inter_subset_left ha))
 
@@ -533,7 +533,7 @@ theorem existOpenSubgroupSubClopenNhdsOfOne {G : Type*} [Group G] [TopologicalSp
     one_mem' := by
       apply mem_iUnion.mpr
       use 0
-      simp only [zero_add, pow_one, mem_of_mem_nhds hV.nhd]
+      simp [mem_of_mem_nhds hV.nhd]
     inv_mem' := fun ha ↦ by
       rcases mem_iUnion.mp ha with ⟨k, hk⟩
       apply mem_iUnion.mpr
@@ -547,7 +547,7 @@ theorem existOpenSubgroupSubClopenNhdsOfOne {G : Type*} [Group G] [TopologicalSp
   use ⟨S, this⟩
   have mulVpow (n : ℕ) : W * V ^ (n + 1) ⊆ W := by
     induction' n with n ih
-    · simp only [zero_add, pow_one, hV.mul]
+    · simp [hV.mul]
     · rw [pow_succ, ← mul_assoc]
       exact (Set.mul_subset_mul_right ih).trans hV.mul
   have (n : ℕ) : V ^ (n + 1) ⊆ W * V ^ (n + 1) := by

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -457,8 +457,9 @@ end
 
 /-!
 ## The Open Subgroup in a Clopen Neighborhood of One
-This section proved the lemma `TopologicalGroup.existOpenSubgroupSubClopenNhdsOfOne`, which
-states that for any clopen neighborhood of 1, there exists an open subgroup contained within it.
+This section proves the lemma `TopologicalGroup.existOpenSubgroupSubClopenNhdsOfOne`, which
+states that in a compact topological group, for any clopen neighborhood of 1,
+there exists an open subgroup contained within it.
 -/
 
 open scoped Pointwise

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -457,7 +457,8 @@ end
 
 /-!
 # Existence of an open subgroup in any clopen neighborhood of the neutral element
-This section proves the lemma `TopologicalGroup.existOpenSubgroupSubClopenNhdsOfOne`, which
+
+This section proves the lemma `TopologicalGroup.exist_openSubgroup_sub_clopen_nhd_of_one`, which
 states that in a compact topological group, for any clopen neighborhood of 1,
 there exists an open subgroup contained within it.
 -/
@@ -472,9 +473,11 @@ structure TopologicalAddGroup.addNegClosureNhd (T W : Set G) [AddGroup G] : Prop
   isOpen : IsOpen T
   add : W + T ⊆ W
 
-/--For a set W, the neighborhood of `1` which is open, self inverse and satisfying `T * W ⊆ W` -/
+/-- For a set `W`, `T` is a neighborhood of `1` which is open, statble under inverse and satisfies
+`T * W ⊆ W`. -/
 @[to_additive
-"For a set W, the neighborhood of `0` which is open, self negative and satisfying `T + W ⊆ W`"]
+"For a set `W`, `T` is a neighborhood of `0` which is open, stable under negation and satisfies
+`T + W ⊆ W`. "]
 structure TopologicalGroup.mulInvClosureNhd (T W : Set G) [Group G] : Prop where
   nhd : T ∈ 𝓝 1
   inv : T⁻¹ = T


### PR DESCRIPTION
Proving that there is always an open normal subgroup in a clopen nhd of compact topological group

Co-authored-by: NailinGuan <3571819596@qq.com> Yi Song <sif4delta0@mail.ustc.edu.cn> Xuchun Li <li.xuchun@qq.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
