### PR TITLE
[Merged by Bors] - feat(RingTheory/AlgebraicIndependent): add some results on `AlgebraicIndependent`

### DIFF
--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -986,6 +986,24 @@ theorem forall_mem_insert {P : α → Prop} {a : α} {s : Set α} :
   forall₂_or_left.trans <| and_congr_left' forall_eq
 @[deprecated (since := "2024-03-23")] alias ball_insert_iff := forall_mem_insert
 
+/-- Inserting an element to a set is equivalent to the option type. -/
+def subtypeInsertEquivOption
+    [DecidableEq α] {t : Set α} {x : α} (h : x ∉ t) :
+    { i // i ∈ insert x t } ≃ Option { i // i ∈ t } where
+  toFun y := if h : ↑y = x then none else some ⟨y, (mem_insert_iff.mp y.2).resolve_left h⟩
+  invFun y := (y.elim ⟨x, mem_insert _ _⟩) fun z => ⟨z, mem_insert_of_mem _ z.2⟩
+  left_inv y := by
+    by_cases h : ↑y = x
+    · simp only [Subtype.ext_iff, h, Option.elim, dif_pos, Subtype.coe_mk]
+    · simp only [h, Option.elim, dif_neg, not_false_iff, Subtype.coe_eta, Subtype.coe_mk]
+  right_inv := by
+    rintro (_ | y)
+    · simp only [Option.elim, dif_pos]
+    · have : ↑y ≠ x := by
+        rintro ⟨⟩
+        exact h y.2
+      simp only [this, Option.elim, Subtype.eta, dif_neg, not_false_iff, Subtype.coe_mk]
+
 /-! ### Lemmas about singletons -/
 
 /- porting note: instance was in core in Lean3 -/

--- a/Mathlib/RingTheory/AlgebraicIndependent.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent.lean
@@ -83,20 +83,23 @@ theorem algebraicIndependent_empty_type_iff [IsEmpty ι] :
     AlgebraicIndependent R x ↔ Injective (algebraMap R A) := by
   rw [algebraicIndependent_iff_injective_aeval, MvPolynomial.aeval_injective_iff_of_isEmpty]
 
-/-- An element `x` is transcendental if and only if the one-element family `![x]` is
-algebraically independent. -/
-theorem transcendental_iff_algebraicIndependent {x : A} :
-    Transcendental R x ↔ AlgebraicIndependent R ![x] := by
+/-- A one-element family `x` is algebraically independent if and only if
+its element is transcendental. -/
+@[simp]
+theorem algebraicIndependent_unique_type_iff [Unique ι] :
+    AlgebraicIndependent R x ↔ Transcendental R (x default) := by
   rw [transcendental_iff_injective, algebraicIndependent_iff_injective_aeval]
-  let i := (finSuccEquiv R 0).toRingEquiv.trans <|
-    Polynomial.mapEquiv (isEmptyAlgEquiv R (Fin 0)).toRingEquiv
-  have key : (MvPolynomial.aeval (R := R) ![x]).toRingHom =
-      (Polynomial.aeval (R := R) x).toRingHom.comp i.toRingHom := by
+  let i := (renameEquiv R (Equiv.equivPUnit.{_, 1} ι)).trans (pUnitAlgEquiv R)
+  have key : aeval (R := R) x = (Polynomial.aeval (R := R) (x default)).comp i := by
     ext y
-    · simp [i]
-    · fin_cases y; simp [i]
-  change _ ↔ Injective (MvPolynomial.aeval (R := R) ![x]).toRingHom
-  rw [key]; simp
+    simp [i, Subsingleton.elim y default]
+  simp [key]
+
+/-- The one-element family `![x]` is algebraically independent if and only if
+`x` is transcendental. -/
+theorem algebraicIndependent_iff_transcendental {x : A} :
+    AlgebraicIndependent R ![x] ↔ Transcendental R x := by
+  simp
 
 namespace AlgebraicIndependent
 
@@ -158,7 +161,7 @@ theorem map' {f : A →ₐ[R] A'} (hf_inj : Injective f) : AlgebraicIndependent 
 theorem transcendental (i : ι) : Transcendental R (x i) := by
   have := hx.comp ![i] (Function.injective_of_subsingleton _)
   have : AlgebraicIndependent R ![x i] := by rwa [← FinVec.map_eq] at this
-  rwa [transcendental_iff_algebraicIndependent]
+  rwa [← algebraicIndependent_iff_transcendental]
 
 end AlgebraicIndependent
 


### PR DESCRIPTION
- `algebraicIndependent_unique_type_iff`, `algebraicIndependent_iff_transcendental`: equivalency of `AlgebraicIndependent` and `Transcendental` for one-element family
- `AlgebraicIndependent.transcendental`: f a family `x` is algebraically independent, then any of its element is transcendental
- `MvPolynomial.(algebraicIndependent|transcendental)_X`: algebraic independent properties of intermediates of `MvPolynomial`
- `algebraicIndependent_of_finite'`: variant of `algebraicIndependent_of_finite` using `Transcendental`
- `exists_isTranscendenceBasis'`: `Type` version of `exists_isTranscendenceBasis`

Also changed one `¬IsAlgebraic` to `Transcendental`.

Also add `Set.subtypeInsertEquivOption` (used in the proof of `algebraicIndependent_of_finite'`) which is similar to `Finset.subtypeInsertEquivOption`. Note that it does not have simp lemmas yet, as the existing `Finset` one has no simp lemmas, either.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This PR towards the result that if `E/F` is transcendental, then there are infinitely many `F`-embeddings from `E` to its algebraic closure.