### PR TITLE
[Merged by Bors] - feat: the quotient by a subgroup containing multiples of `n` is `n`-torsion

### DIFF
--- a/Mathlib/Algebra/Module/ZMod.lean
+++ b/Mathlib/Algebra/Module/ZMod.lean
@@ -40,6 +40,13 @@ abbrev AddCommGroup.zmodModule {G : Type*} [AddCommGroup G] (h : ∀ (x : G), n 
   | 0 => AddCommGroup.toIntModule G
   | _ + 1 => AddCommMonoid.zmodModule h
 
+/-- The quotient of an abelian group by a subgroup containing all multiples of `n` is a
+`n`-torsion group. -/
+-- See note [reducible non-instances]
+abbrev QuotientAddGroup.instZModModule {G : Type*} [AddCommGroup G] {H : AddSubgroup G}
+    (hH : ∀ x, n • x ∈ H) : Module (ZMod n) (G ⧸ H) :=
+  AddCommGroup.zmodModule <| by simpa [QuotientAddGroup.forall_mk, ← QuotientAddGroup.mk_nsmul]
+
 variable {F S : Type*} [AddCommGroup M] [AddCommGroup M₁] [FunLike F M M₁]
   [AddMonoidHomClass F M M₁] [Module (ZMod n) M] [Module (ZMod n) M₁] [SetLike S M]
   [AddSubgroupClass S M] {x : M} {K : S}

--- a/Mathlib/Algebra/Module/ZMod.lean
+++ b/Mathlib/Algebra/Module/ZMod.lean
@@ -43,7 +43,7 @@ abbrev AddCommGroup.zmodModule {G : Type*} [AddCommGroup G] (h : ∀ (x : G), n 
 /-- The quotient of an abelian group by a subgroup containing all multiples of `n` is a
 `n`-torsion group. -/
 -- See note [reducible non-instances]
-abbrev QuotientAddGroup.instZModModule {G : Type*} [AddCommGroup G] {H : AddSubgroup G}
+abbrev QuotientAddGroup.zmodModule {G : Type*} [AddCommGroup G] {H : AddSubgroup G}
     (hH : ∀ x, n • x ∈ H) : Module (ZMod n) (G ⧸ H) :=
   AddCommGroup.zmodModule <| by simpa [QuotientAddGroup.forall_mk, ← QuotientAddGroup.mk_nsmul]
 


### PR DESCRIPTION
From PFR

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
