### PR TITLE
[Merged by Bors] - chore(Topology): miscellaneous renames

### DIFF
--- a/Mathlib/AlgebraicGeometry/Gluing.lean
+++ b/Mathlib/AlgebraicGeometry/Gluing.lean
@@ -380,8 +380,7 @@ theorem fromGlued_open_map : IsOpenMap 𝒰.fromGlued.base := by
   · exact ⟨hx, 𝒰.covers x⟩
 
 theorem fromGlued_isOpenEmbedding : IsOpenEmbedding 𝒰.fromGlued.base :=
-  isOpenEmbedding_of_continuous_injective_open
-    (by fun_prop) 𝒰.fromGlued_injective 𝒰.fromGlued_open_map
+  .of_continuous_injective_isOpenMap (by fun_prop) 𝒰.fromGlued_injective 𝒰.fromGlued_open_map
 
 @[deprecated (since := "2024-10-18")]
 alias fromGlued_openEmbedding := fromGlued_isOpenEmbedding

--- a/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
@@ -134,7 +134,7 @@ theorem of_comp_isClosedImmersion {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z) [
     simp only [Scheme.comp_coeBase, TopCat.coe_comp] at h
     refine .of_continuous_injective_isClosedMap (Scheme.Hom.continuous f) h.inj.of_comp ?_
     intro Z hZ
-    rw [IsClosedEmbedding.closed_iff_image_closed g.isClosedEmbedding,
+    rw [IsClosedEmbedding.isClosed_iff_image_isClosed g.isClosedEmbedding,
       ← Set.image_comp]
     exact h.isClosedMap _ hZ
   surj_on_stalks x := by

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
@@ -757,7 +757,7 @@ lemma isClosedEmbedding_cfcₙHom_of_cfcHom {a : A} (ha : p a) :
   let f : C(spectrum R a, σₙ R a) :=
     ⟨_, continuous_inclusion <| spectrum_subset_quasispectrum R a⟩
   refine (cfcHom_isClosedEmbedding ha).comp <|
-    (IsUniformInducing.isUniformEmbedding ⟨?_⟩).toIsClosedEmbedding
+    (IsUniformInducing.isUniformEmbedding ⟨?_⟩).isClosedEmbedding
   have := uniformSpace_eq_inf_precomp_of_cover (β := R) f (0 : C(Unit, σₙ R a))
     (map_continuous f).isProperMap (map_continuous 0).isProperMap <| by
       simp only [← Subtype.val_injective.image_injective.eq_iff, f, ContinuousMap.coe_mk,

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
@@ -407,7 +407,7 @@ lemma conjugate_le_norm_smul' {a b : A} (hb : IsSelfAdjoint b := by cfc_tac) :
 /-- The set of nonnegative elements in a C⋆-algebra is closed. -/
 lemma isClosed_nonneg : IsClosed {a : A | 0 ≤ a} := by
   suffices IsClosed {a : A⁺¹ | 0 ≤ a} by
-    rw [Unitization.isometry_inr (𝕜 := ℂ) |>.isClosedEmbedding.closed_iff_image_closed]
+    rw [Unitization.isometry_inr (𝕜 := ℂ) |>.isClosedEmbedding.isClosed_iff_image_isClosed]
     convert this.inter <| (Unitization.isometry_inr (𝕜 := ℂ)).isClosedEmbedding.isClosed_range
     ext a
     simp only [Set.mem_image, Set.mem_setOf_eq, Set.mem_inter_iff, Set.mem_range, ← exists_and_left]

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Restrict.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Restrict.lean
@@ -86,7 +86,7 @@ lemma isClosedEmbedding_starAlgHom {a : A} {φ : C(spectrum S a, S) →⋆ₐ[S]
     (hφ : IsClosedEmbedding φ) {f : C(S, R)} (h : SpectrumRestricts a f)
     (halg : IsUniformEmbedding (algebraMap R S)) :
     IsClosedEmbedding (h.starAlgHom φ) :=
-  hφ.comp <| IsUniformEmbedding.toIsClosedEmbedding <| .comp
+  hφ.comp <| IsUniformEmbedding.isClosedEmbedding <| .comp
     (ContinuousMap.isUniformEmbedding_comp _ halg)
     (UniformEquiv.arrowCongr h.homeomorph.symm (.refl _) |>.isUniformEmbedding)
 
@@ -106,7 +106,7 @@ protected theorem cfc (f : C(S, R)) (halg : IsUniformEmbedding (algebraMap R S))
   compactSpace_spectrum a := by
     have := ContinuousFunctionalCalculus.compactSpace_spectrum (R := S) a
     rw [← isCompact_iff_compactSpace] at this ⊢
-    simpa using halg.toIsClosedEmbedding.isCompact_preimage this
+    simpa using halg.isClosedEmbedding.isCompact_preimage this
   exists_cfc_of_predicate a ha := by
     refine ⟨((h a).mp ha).2.starAlgHom (cfcHom ((h a).mp ha).1 (R := S)),
       ?hom_isClosedEmbedding, ?hom_id, ?hom_map_spectrum, ?predicate_hom⟩
@@ -230,7 +230,7 @@ lemma isClosedEmbedding_nonUnitalStarAlgHom {a : A} {φ : C(σₙ S a, S)₀ →
     (halg : IsUniformEmbedding (algebraMap R S)) :
     IsClosedEmbedding (h.nonUnitalStarAlgHom φ) := by
   have : h.homeomorph.symm 0 = 0 := Subtype.ext (map_zero <| algebraMap _ _)
-  refine hφ.comp <| IsUniformEmbedding.toIsClosedEmbedding <| .comp
+  refine hφ.comp <| IsUniformEmbedding.isClosedEmbedding <| .comp
     (ContinuousMapZero.isUniformEmbedding_comp _ halg)
     (UniformEquiv.arrowCongrLeft₀ h.homeomorph.symm this |>.isUniformEmbedding)
 
@@ -250,7 +250,7 @@ protected theorem cfc (f : C(S, R)) (halg : IsUniformEmbedding (algebraMap R S))
   compactSpace_quasispectrum a := by
     have := NonUnitalContinuousFunctionalCalculus.compactSpace_quasispectrum (R := S) a
     rw [← isCompact_iff_compactSpace] at this ⊢
-    simpa using halg.toIsClosedEmbedding.isCompact_preimage this
+    simpa using halg.isClosedEmbedding.isCompact_preimage this
   exists_cfc_of_predicate a ha := by
     refine ⟨((h a).mp ha).2.nonUnitalStarAlgHom (cfcₙHom ((h a).mp ha).1 (R := S)),
       ?hom_isClosedEmbedding, ?hom_id, ?hom_map_spectrum, ?predicate_hom⟩

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -363,7 +363,7 @@ theorem isUniformEmbedding_ofReal : IsUniformEmbedding ((↑) : ℝ → ℂ) :=
 
 theorem _root_.Filter.tendsto_ofReal_iff {α : Type*} {l : Filter α} {f : α → ℝ} {x : ℝ} :
     Tendsto (fun x ↦ (f x : ℂ)) l (𝓝 (x : ℂ)) ↔ Tendsto f l (𝓝 x) :=
-  isUniformEmbedding_ofReal.toIsClosedEmbedding.tendsto_nhds_iff.symm
+  isUniformEmbedding_ofReal.isClosedEmbedding.tendsto_nhds_iff.symm
 
 lemma _root_.Filter.Tendsto.ofReal {α : Type*} {l : Filter α} {f : α → ℝ} {x : ℝ}
     (hf : Tendsto f l (𝓝 x)) : Tendsto (fun x ↦ (f x : ℂ)) l (𝓝 (x : ℂ)) :=

--- a/Mathlib/CategoryTheory/Galois/Topology.lean
+++ b/Mathlib/CategoryTheory/Galois/Topology.lean
@@ -87,7 +87,7 @@ lemma autEmbedding_isClosedEmbedding : IsClosedEmbedding (autEmbedding F) where
 @[deprecated (since := "2024-10-20")]
 alias autEmbedding_closedEmbedding := autEmbedding_isClosedEmbedding
 
-instance : CompactSpace (Aut F) := IsClosedEmbedding.compactSpace (autEmbedding_isClosedEmbedding F)
+instance : CompactSpace (Aut F) := (autEmbedding_isClosedEmbedding F).compactSpace
 
 instance : T2Space (Aut F) :=
   T2Space.of_injective_continuous (autEmbedding_injective F) continuous_induced_dom

--- a/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
+++ b/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
@@ -855,7 +855,7 @@ theorem sigma_ι_isOpenEmbedding : IsOpenEmbedding (colimit.ι F i).base := by
   -- See https://github.com/leanprover-community/mathlib4/issues/5026
   erw [TopCat.isOpenEmbedding_iff_comp_isIso, TopCat.isOpenEmbedding_iff_comp_isIso,
     TopCat.isOpenEmbedding_iff_comp_isIso, TopCat.isOpenEmbedding_iff_isIso_comp]
-  exact isOpenEmbedding_sigmaMk
+  exact .sigmaMk
 
 @[deprecated (since := "2024-10-18")]
 alias sigma_ι_openEmbedding := sigma_ι_isOpenEmbedding

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
@@ -125,9 +125,7 @@ theorem ι_isOpenEmbedding [HasLimits C] (i : D.J) : IsOpenEmbedding (𝖣.ι i)
   rw [← show _ = (𝖣.ι i).base from 𝖣.ι_gluedIso_inv (PresheafedSpace.forget _) _]
   -- Porting note: added this erewrite
   erw [coe_comp]
-  refine
-    IsOpenEmbedding.comp
-      (TopCat.homeoOfIso (𝖣.gluedIso (PresheafedSpace.forget _)).symm).isOpenEmbedding
+  exact (TopCat.homeoOfIso (𝖣.gluedIso (PresheafedSpace.forget _)).symm).isOpenEmbedding.comp
       (D.toTopGlueData.ι_isOpenEmbedding i)
 
 @[deprecated (since := "2024-10-18")]

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
@@ -713,7 +713,7 @@ alias denseEmbedding := isDenseEmbedding
 
 protected theorem isDenseInducing (hp_ne_top : p ≠ ∞) :
     IsDenseInducing ((↑) : Lp.simpleFunc E p μ → Lp E p μ) :=
-  (simpleFunc.isDenseEmbedding hp_ne_top).toIsDenseInducing
+  (simpleFunc.isDenseEmbedding hp_ne_top).isDenseInducing
 
 protected theorem denseRange (hp_ne_top : p ≠ ∞) :
     DenseRange ((↑) : Lp.simpleFunc E p μ → Lp E p μ) :=

--- a/Mathlib/MeasureTheory/Group/Measure.lean
+++ b/Mathlib/MeasureTheory/Group/Measure.lean
@@ -775,7 +775,7 @@ nonrec theorem _root_.MulEquiv.isHaarMeasure_map [BorelSpace G] [TopologicalGrou
     [TopologicalGroup H] (e : G ≃* H) (he : Continuous e) (hesymm : Continuous e.symm) :
     IsHaarMeasure (Measure.map e μ) :=
   let f : G ≃ₜ H := .mk e
-  isHaarMeasure_map μ (e : G →* H) he e.surjective f.isClosedEmbedding.tendsto_cocompact
+  isHaarMeasure_map μ e he e.surjective f.isClosedEmbedding.tendsto_cocompact
 
 /-- A convenience wrapper for MeasureTheory.Measure.isAddHaarMeasure_map`. -/
 instance _root_.ContinuousLinearEquiv.isAddHaarMeasure_map

--- a/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
@@ -529,7 +529,7 @@ theorem quotientMap_injective' {J : Ideal R} {I : Ideal S} {f : R →+* S} {H : 
   rw [quotientMap_mk, Quotient.eq_zero_iff_mem] at ha
   exact Quotient.eq_zero_iff_mem.mpr (h ha)
 
-/-- If we take `J = I.comap f` then `QuotientMap` is injective automatically. -/
+/-- If we take `J = I.comap f` then `quotientMap` is injective automatically. -/
 theorem quotientMap_injective {I : Ideal S} {f : R →+* S} :
     Function.Injective (quotientMap I f le_rfl) :=
   quotientMap_injective' le_rfl

--- a/Mathlib/Topology/Algebra/Constructions/DomMulAct.lean
+++ b/Mathlib/Topology/Algebra/Constructions/DomMulAct.lean
@@ -111,7 +111,7 @@ instance instNormalSpace [NormalSpace M] : NormalSpace Mᵈᵐᵃ := mkHomeomorp
 
 @[to_additive]
 instance instCompletelyNormalSpace [CompletelyNormalSpace M] : CompletelyNormalSpace Mᵈᵐᵃ :=
-  mkHomeomorph.symm.isEmbedding.completelyNormalSpace
+  isEmbedding_mk_symm.completelyNormalSpace
 
 @[to_additive]
 instance instDiscreteTopology [DiscreteTopology M] : DiscreteTopology Mᵈᵐᵃ :=

--- a/Mathlib/Topology/Bases.lean
+++ b/Mathlib/Topology/Bases.lean
@@ -899,8 +899,8 @@ theorem IsTopologicalBasis.sum {s : Set (Set α)} (hs : IsTopologicalBasis s) {t
     IsTopologicalBasis ((fun u => Sum.inl '' u) '' s ∪ (fun u => Sum.inr '' u) '' t) := by
   apply isTopologicalBasis_of_isOpen_of_nhds
   · rintro u (⟨w, hw, rfl⟩ | ⟨w, hw, rfl⟩)
-    · exact isOpenEmbedding_inl.isOpenMap w (hs.isOpen hw)
-    · exact isOpenEmbedding_inr.isOpenMap w (ht.isOpen hw)
+    · exact IsOpenEmbedding.inl.isOpenMap w (hs.isOpen hw)
+    · exact IsOpenEmbedding.inr.isOpenMap w (ht.isOpen hw)
   · rintro (x | x) u hxu u_open
     · obtain ⟨v, vs, xv, vu⟩ : ∃ v ∈ s, x ∈ v ∧ v ⊆ Sum.inl ⁻¹' u :=
         hs.exists_subset_of_mem_open hxu (isOpen_sum_iff.1 u_open).1

--- a/Mathlib/Topology/Category/CompHausLike/Limits.lean
+++ b/Mathlib/Topology/Category/CompHausLike/Limits.lean
@@ -152,7 +152,7 @@ example : HasFiniteCoproducts (CompHausLike.{u} P) := inferInstance
 /-- The inclusion maps into the explicit finite coproduct are open embeddings. -/
 lemma finiteCoproduct.isOpenEmbedding_ι (a : α) :
     IsOpenEmbedding (finiteCoproduct.ι X a) :=
-  isOpenEmbedding_sigmaMk (σ := fun a ↦ (X a))
+  .sigmaMk (σ := fun a ↦ X a)
 
 @[deprecated (since := "2024-10-18")]
 alias finiteCoproduct.openEmbedding_ι := finiteCoproduct.isOpenEmbedding_ι

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -14,12 +14,8 @@ import Mathlib.Tactic.CategoryTheory.Elementwise
 # Products and coproducts in the category of topological spaces
 -/
 
-
-open TopologicalSpace
-
-open CategoryTheory
-
-open CategoryTheory.Limits
+open CategoryTheory Limits
+open Set TopologicalSpace
 
 universe v u w
 
@@ -286,8 +282,7 @@ def binaryCofanIsColimit (X Y : TopCat.{u}) : IsColimit (TopCat.binaryCofan X Y)
 
 theorem binaryCofan_isColimit_iff {X Y : TopCat} (c : BinaryCofan X Y) :
     Nonempty (IsColimit c) ↔
-      IsOpenEmbedding c.inl ∧ IsOpenEmbedding c.inr ∧
-        IsCompl (Set.range c.inl) (Set.range c.inr) := by
+      IsOpenEmbedding c.inl ∧ IsOpenEmbedding c.inr ∧ IsCompl (range c.inl) (range c.inr) := by
   classical
     constructor
     · rintro ⟨h⟩
@@ -297,9 +292,9 @@ theorem binaryCofan_isColimit_iff {X Y : TopCat} (c : BinaryCofan X Y) :
           h.comp_coconePointUniqueUpToIso_inv (binaryCofanIsColimit X Y) ⟨WalkingPair.right⟩]
       dsimp
       refine ⟨(homeoOfIso <| h.coconePointUniqueUpToIso
-        (binaryCofanIsColimit X Y)).symm.isOpenEmbedding.comp isOpenEmbedding_inl,
+        (binaryCofanIsColimit X Y)).symm.isOpenEmbedding.comp .inl,
           (homeoOfIso <| h.coconePointUniqueUpToIso
-            (binaryCofanIsColimit X Y)).symm.isOpenEmbedding.comp isOpenEmbedding_inr, ?_⟩
+            (binaryCofanIsColimit X Y)).symm.isOpenEmbedding.comp .inr, ?_⟩
       erw [Set.range_comp, ← eq_compl_iff_isCompl, Set.range_comp _ Sum.inr,
         ← Set.image_compl_eq (homeoOfIso <| h.coconePointUniqueUpToIso
             (binaryCofanIsColimit X Y)).symm.bijective, Set.compl_range_inr, Set.image_comp]

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -363,7 +363,7 @@ theorem fst_isOpenEmbedding_of_right {X Y S : TopCat} (f : X ⟶ S) {g : Y ⟶ S
 alias fst_openEmbedding_of_right_openEmbedding := fst_isOpenEmbedding_of_right
 
 /-- If `X ⟶ S`, `Y ⟶ S` are open embeddings, then so is `X ×ₛ Y ⟶ S`. -/
-theorem isOpenEmbedding_of_pullback_open_embeddings {X Y S : TopCat} {f : X ⟶ S} {g : Y ⟶ S}
+theorem isOpenEmbedding_of_pullback {X Y S : TopCat} {f : X ⟶ S} {g : Y ⟶ S}
     (H₁ : IsOpenEmbedding f) (H₂ : IsOpenEmbedding g) :
     IsOpenEmbedding (limit.π (cospan f g) WalkingCospan.one) := by
   convert H₂.comp (snd_isOpenEmbedding_of_left H₁ g)
@@ -371,7 +371,7 @@ theorem isOpenEmbedding_of_pullback_open_embeddings {X Y S : TopCat} {f : X ⟶ 
   rfl
 
 @[deprecated (since := "2024-10-18")]
-alias openEmbedding_of_pullback_open_embeddings := isOpenEmbedding_of_pullback_open_embeddings
+alias openEmbedding_of_pullback_open_embeddings := isOpenEmbedding_of_pullback
 
 theorem fst_iso_of_right_embedding_range_subset {X Y S : TopCat} (f : X ⟶ S) {g : Y ⟶ S}
     (hg : IsEmbedding g) (H : Set.range f ⊆ Set.range g) :

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -370,6 +370,9 @@ theorem isOpenEmbedding_of_pullback {X Y S : TopCat} {f : X ⟶ S} {g : Y ⟶ S}
   rw [← coe_comp, ← limit.w _ WalkingCospan.Hom.inr]
   rfl
 
+@[deprecated (since := "2024-10-30")]
+alias isOpenEmbedding_of_pullback_open_embeddings := isOpenEmbedding_of_pullback
+
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding_of_pullback_open_embeddings := isOpenEmbedding_of_pullback
 

--- a/Mathlib/Topology/Category/TopCat/Opens.lean
+++ b/Mathlib/Topology/Category/TopCat/Opens.lean
@@ -118,7 +118,7 @@ theorem coe_inclusion' {X : TopCat} {U : Opens X} :
     (inclusion' U : U → X) = Subtype.val := rfl
 
 theorem isOpenEmbedding {X : TopCat.{u}} (U : Opens X) : IsOpenEmbedding (inclusion' U) :=
-  IsOpen.isOpenEmbedding_subtypeVal U.2
+  U.2.isOpenEmbedding_subtypeVal
 
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding := isOpenEmbedding

--- a/Mathlib/Topology/Clopen.lean
+++ b/Mathlib/Topology/Clopen.lean
@@ -118,7 +118,7 @@ theorem isClopen_range_inr : IsClopen (range (Sum.inr : Y → X ⊕ Y)) :=
 
 theorem isClopen_range_sigmaMk {X : ι → Type*} [∀ i, TopologicalSpace (X i)] {i : ι} :
     IsClopen (Set.range (@Sigma.mk ι X i)) :=
-  ⟨isClosedEmbedding_sigmaMk.isClosed_range, isOpenEmbedding_sigmaMk.isOpen_range⟩
+  ⟨IsClosedEmbedding.sigmaMk.isClosed_range, IsOpenEmbedding.sigmaMk.isOpen_range⟩
 
 protected theorem IsQuotientMap.isClopen_preimage {f : X → Y} (hf : IsQuotientMap f) {s : Set Y} :
     IsClopen (f ⁻¹' s) ↔ IsClopen s :=

--- a/Mathlib/Topology/Compactification/OnePoint.lean
+++ b/Mathlib/Topology/Compactification/OnePoint.lean
@@ -253,7 +253,7 @@ theorem continuous_coe : Continuous ((↑) : X → OnePoint X) :=
 theorem isOpenMap_coe : IsOpenMap ((↑) : X → OnePoint X) := fun _ => isOpen_image_coe.2
 
 theorem isOpenEmbedding_coe : IsOpenEmbedding ((↑) : X → OnePoint X) :=
-  isOpenEmbedding_of_continuous_injective_open continuous_coe coe_injective isOpenMap_coe
+  .of_continuous_injective_isOpenMap continuous_coe coe_injective isOpenMap_coe
 
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding_coe := isOpenEmbedding_coe
@@ -524,7 +524,7 @@ example [WeaklyLocallyCompactSpace X] [T2Space X] : T4Space (OnePoint X) := infe
 
 /-- If `X` is not a compact space, then `OnePoint X` is a connected space. -/
 instance [PreconnectedSpace X] [NoncompactSpace X] : ConnectedSpace (OnePoint X) where
-  toPreconnectedSpace := isDenseEmbedding_coe.toIsDenseInducing.preconnectedSpace
+  toPreconnectedSpace := isDenseEmbedding_coe.isDenseInducing.preconnectedSpace
   toNonempty := inferInstance
 
 /-- If `X` is an infinite type with discrete topology (e.g., `ℕ`), then the identity map from

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -1007,7 +1007,7 @@ instance (priority := 100) Finite.compactSpace [Finite X] : CompactSpace X where
   isCompact_univ := finite_univ.isCompact
 
 instance ULift.compactSpace [CompactSpace X] : CompactSpace (ULift.{v} X) :=
-  ULift.isClosedEmbedding_down.compactSpace
+  IsClosedEmbedding.uliftDown.compactSpace
 
 /-- The product of two compact spaces is compact. -/
 instance [CompactSpace X] [CompactSpace Y] : CompactSpace (X × Y) :=

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -268,7 +268,7 @@ theorem IsClosed.sigmaCompactSpace {s : Set X} (hs : IsClosed s) : SigmaCompactS
   hs.isClosedEmbedding_subtypeVal.sigmaCompactSpace
 
 instance [SigmaCompactSpace Y] : SigmaCompactSpace (ULift.{u} Y) :=
-  ULift.isClosedEmbedding_down.sigmaCompactSpace
+  IsClosedEmbedding.uliftDown.sigmaCompactSpace
 
 /-- If `X` is a `σ`-compact space, then a locally finite family of nonempty sets of `X` can have
 only countably many elements, `Set.Countable` version. -/

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -1204,7 +1204,7 @@ theorem IsOpenEmbedding.locPathConnectedSpace {e : Y → X} (he : IsOpenEmbeddin
 alias OpenEmbedding.locPathConnectedSpace := IsOpenEmbedding.locPathConnectedSpace
 
 theorem IsOpen.locPathConnectedSpace {U : Set X} (h : IsOpen U) : LocPathConnectedSpace U :=
-  (isOpenEmbedding_subtypeVal h).locPathConnectedSpace
+  h.isOpenEmbedding_subtypeVal.locPathConnectedSpace
 
 @[deprecated (since := "2024-10-17")]
 alias locPathConnected_of_isOpen := IsOpen.locPathConnectedSpace

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -928,29 +928,26 @@ theorem isOpenMap_inl : IsOpenMap (@inl X Y) := fun u hu => by
 theorem isOpenMap_inr : IsOpenMap (@inr X Y) := fun u hu => by
   simpa [isOpen_sum_iff, preimage_image_eq u Sum.inr_injective]
 
-theorem isOpenEmbedding_inl : IsOpenEmbedding (@inl X Y) :=
-  isOpenEmbedding_of_continuous_injective_open continuous_inl inl_injective isOpenMap_inl
+protected lemma IsOpenEmbedding.inl : IsOpenEmbedding (@inl X Y) :=
+  .of_continuous_injective_isOpenMap continuous_inl inl_injective isOpenMap_inl
 
 @[deprecated (since := "2024-10-18")]
-alias openEmbedding_inl := isOpenEmbedding_inl
+alias openEmbedding_inl := IsOpenEmbedding.inl
 
-theorem isOpenEmbedding_inr : IsOpenEmbedding (@inr X Y) :=
-  isOpenEmbedding_of_continuous_injective_open continuous_inr inr_injective isOpenMap_inr
+protected lemma IsOpenEmbedding.inr : IsOpenEmbedding (@inr X Y) :=
+  .of_continuous_injective_isOpenMap continuous_inr inr_injective isOpenMap_inr
 
 @[deprecated (since := "2024-10-18")]
-alias openEmbedding_inr := isOpenEmbedding_inr
+alias openEmbedding_inr := IsOpenEmbedding.inr
 
-protected lemma IsEmbedding.inl : IsEmbedding (@inl X Y) := isOpenEmbedding_inl.1
-protected lemma IsEmbedding.inr : IsEmbedding (@inr X Y) := isOpenEmbedding_inr.1
+protected lemma IsEmbedding.inl : IsEmbedding (@inl X Y) := IsOpenEmbedding.inl.1
+protected lemma IsEmbedding.inr : IsEmbedding (@inr X Y) := IsOpenEmbedding.inr.1
 
 @[deprecated (since := "2024-10-26")]
 alias embedding_inr := IsEmbedding.inr
 
-theorem isOpen_range_inl : IsOpen (range (inl : X → X ⊕ Y)) :=
-  isOpenEmbedding_inl.2
-
-theorem isOpen_range_inr : IsOpen (range (inr : Y → X ⊕ Y)) :=
-  isOpenEmbedding_inr.2
+lemma isOpen_range_inl : IsOpen (range (inl : X → X ⊕ Y)) := IsOpenEmbedding.inl.2
+lemma isOpen_range_inr : IsOpen (range (inr : Y → X ⊕ Y)) := IsOpenEmbedding.inr.2
 
 theorem isClosed_range_inl : IsClosed (range (inl : X → X ⊕ Y)) := by
   rw [← isOpen_compl_iff, compl_range_inl]
@@ -960,23 +957,23 @@ theorem isClosed_range_inr : IsClosed (range (inr : Y → X ⊕ Y)) := by
   rw [← isOpen_compl_iff, compl_range_inr]
   exact isOpen_range_inl
 
-theorem isClosedEmbedding_inl : IsClosedEmbedding (inl : X → X ⊕ Y) :=
+theorem IsClosedEmbedding.inl : IsClosedEmbedding (inl : X → X ⊕ Y) :=
   ⟨.inl, isClosed_range_inl⟩
 
 @[deprecated (since := "2024-10-20")]
-alias closedEmbedding_inl := isClosedEmbedding_inl
+alias closedEmbedding_inl := IsClosedEmbedding.inl
 
-theorem isClosedEmbedding_inr : IsClosedEmbedding (inr : Y → X ⊕ Y) :=
+theorem IsClosedEmbedding.inr : IsClosedEmbedding (inr : Y → X ⊕ Y) :=
   ⟨.inr, isClosed_range_inr⟩
 
 @[deprecated (since := "2024-10-20")]
-alias closedEmbedding_inr := isClosedEmbedding_inr
+alias closedEmbedding_inr := IsClosedEmbedding.inr
 
 theorem nhds_inl (x : X) : 𝓝 (inl x : X ⊕ Y) = map inl (𝓝 x) :=
-  (isOpenEmbedding_inl.map_nhds_eq _).symm
+  (IsOpenEmbedding.inl.map_nhds_eq _).symm
 
 theorem nhds_inr (y : Y) : 𝓝 (inr y : X ⊕ Y) = map inr (𝓝 y) :=
-  (isOpenEmbedding_inr.map_nhds_eq _).symm
+  (IsOpenEmbedding.inr.map_nhds_eq _).symm
 
 @[simp]
 theorem continuous_sum_map {f : X → Y} {g : Z → W} :
@@ -1010,7 +1007,7 @@ theorem isClosedMap_sum {f : X ⊕ Y → Z} :
     IsClosedMap f ↔ (IsClosedMap fun a => f (.inl a)) ∧ IsClosedMap fun b => f (.inr b) := by
   constructor
   · intro h
-    exact ⟨h.comp isClosedEmbedding_inl.isClosedMap, h.comp isClosedEmbedding_inr.isClosedMap⟩
+    exact ⟨h.comp IsClosedEmbedding.inl.isClosedMap, h.comp IsClosedEmbedding.inr.isClosedMap⟩
   · rintro h Z hZ
     rw [isClosed_sum_iff] at hZ
     convert (h.1 _ hZ.1).union (h.2 _ hZ.2)
@@ -1183,8 +1180,8 @@ then its restriction to the preimage of an open set is a quotient map too. -/
 theorem IsQuotientMap.restrictPreimage_isOpen {f : X → Y} (hf : IsQuotientMap f)
     {s : Set Y} (hs : IsOpen s) : IsQuotientMap (s.restrictPreimage f) := by
   refine isQuotientMap_iff.2 ⟨hf.surjective.restrictPreimage _, fun U ↦ ?_⟩
-  rw [hs.isOpenEmbedding_subtypeVal.open_iff_image_open, ← hf.isOpen_preimage,
-    (hs.preimage hf.continuous).isOpenEmbedding_subtypeVal.open_iff_image_open,
+  rw [hs.isOpenEmbedding_subtypeVal.isOpen_iff_image_isOpen, ← hf.isOpen_preimage,
+    (hs.preimage hf.continuous).isOpenEmbedding_subtypeVal.isOpen_iff_image_isOpen,
     image_val_preimage_restrictPreimage]
 
 @[deprecated (since := "2024-10-22")]
@@ -1597,28 +1594,26 @@ theorem isClosedMap_sigmaMk {i : ι} : IsClosedMap (@Sigma.mk ι σ i) := by
 theorem isClosed_range_sigmaMk {i : ι} : IsClosed (range (@Sigma.mk ι σ i)) :=
   isClosedMap_sigmaMk.isClosed_range
 
-theorem isOpenEmbedding_sigmaMk {i : ι} : IsOpenEmbedding (@Sigma.mk ι σ i) :=
-  isOpenEmbedding_of_continuous_injective_open continuous_sigmaMk sigma_mk_injective
-    isOpenMap_sigmaMk
+lemma IsOpenEmbedding.sigmaMk {i : ι} : IsOpenEmbedding (@Sigma.mk ι σ i) :=
+  .of_continuous_injective_isOpenMap continuous_sigmaMk sigma_mk_injective isOpenMap_sigmaMk
 
 @[deprecated (since := "2024-10-18")]
-alias openEmbedding_sigmaMk := isOpenEmbedding_sigmaMk
+alias openEmbedding_sigmaMk := IsOpenEmbedding.sigmaMk
 
-theorem isClosedEmbedding_sigmaMk {i : ι} : IsClosedEmbedding (@Sigma.mk ι σ i) :=
-  .of_continuous_injective_isClosedMap continuous_sigmaMk sigma_mk_injective
-    isClosedMap_sigmaMk
+lemma IsClosedEmbedding.sigmaMk {i : ι} : IsClosedEmbedding (@Sigma.mk ι σ i) :=
+  .of_continuous_injective_isClosedMap continuous_sigmaMk sigma_mk_injective isClosedMap_sigmaMk
 
 @[deprecated (since := "2024-10-20")]
-alias closedEmbedding_sigmaMk := isClosedEmbedding_sigmaMk
+alias closedEmbedding_sigmaMk := IsClosedEmbedding.sigmaMk
 
 lemma IsEmbedding.sigmaMk {i : ι} : IsEmbedding (@Sigma.mk ι σ i) :=
-  isClosedEmbedding_sigmaMk.1
+  IsClosedEmbedding.sigmaMk.1
 
 @[deprecated (since := "2024-10-26")]
 alias embedding_sigmaMk := IsEmbedding.sigmaMk
 
 theorem Sigma.nhds_mk (i : ι) (x : σ i) : 𝓝 (⟨i, x⟩ : Sigma σ) = Filter.map (Sigma.mk i) (𝓝 x) :=
-  (isOpenEmbedding_sigmaMk.map_nhds_eq x).symm
+  (IsOpenEmbedding.sigmaMk.map_nhds_eq x).symm
 
 theorem Sigma.nhds_eq (x : Sigma σ) : 𝓝 x = Filter.map (Sigma.mk x.1) (𝓝 x.2) := by
   cases x
@@ -1679,7 +1674,7 @@ theorem isOpenMap_sigma {f : Sigma σ → X} : IsOpenMap f ↔ ∀ i, IsOpenMap 
 theorem isOpenMap_sigma_map {f₁ : ι → κ} {f₂ : ∀ i, σ i → τ (f₁ i)} :
     IsOpenMap (Sigma.map f₁ f₂) ↔ ∀ i, IsOpenMap (f₂ i) :=
   isOpenMap_sigma.trans <|
-    forall_congr' fun i => (@isOpenEmbedding_sigmaMk _ _ _ (f₁ i)).isOpenMap_iff.symm
+    forall_congr' fun i => (@IsOpenEmbedding.sigmaMk _ _ _ (f₁ i)).isOpenMap_iff.symm
 
 lemma isInducing_sigmaMap {f₁ : ι → κ} {f₂ : ∀ i, σ i → τ (f₁ i)}
     (h₁ : Injective f₁) : IsInducing (Sigma.map f₁ f₂) ↔ ∀ i, IsInducing (f₂ i) := by
@@ -1696,13 +1691,13 @@ lemma isEmbedding_sigmaMap {f₁ : ι → κ} {f₂ : ∀ i, σ i → τ (f₁ i
 @[deprecated (since := "2024-10-26")]
 alias embedding_sigma_map := isEmbedding_sigmaMap
 
-theorem isOpenEmbedding_sigma_map {f₁ : ι → κ} {f₂ : ∀ i, σ i → τ (f₁ i)} (h : Injective f₁) :
+lemma isOpenEmbedding_sigmaMap {f₁ : ι → κ} {f₂ : ∀ i, σ i → τ (f₁ i)} (h : Injective f₁) :
     IsOpenEmbedding (Sigma.map f₁ f₂) ↔ ∀ i, IsOpenEmbedding (f₂ i) := by
   simp only [isOpenEmbedding_iff_isEmbedding_isOpenMap, isOpenMap_sigma_map, isEmbedding_sigmaMap h,
     forall_and]
 
 @[deprecated (since := "2024-10-18")]
-alias openEmbedding_sigma_map := isOpenEmbedding_sigma_map
+alias openEmbedding_sigma_map := isOpenEmbedding_sigmaMap
 
 end Sigma
 
@@ -1730,12 +1725,12 @@ lemma IsEmbedding.uliftDown [TopologicalSpace X] :
 @[deprecated (since := "2024-10-26")]
 alias embedding_uLift_down := IsEmbedding.uliftDown
 
-theorem ULift.isClosedEmbedding_down [TopologicalSpace X] :
+lemma IsClosedEmbedding.uliftDown [TopologicalSpace X] :
     IsClosedEmbedding (ULift.down : ULift.{v, u} X → X) :=
   ⟨.uliftDown, by simp only [ULift.down_surjective.range_eq, isClosed_univ]⟩
 
 @[deprecated (since := "2024-10-20")]
-alias ULift.closedEmbedding_down := ULift.isClosedEmbedding_down
+alias ULift.closedEmbedding_down := IsClosedEmbedding.uliftDown
 
 instance [TopologicalSpace X] [DiscreteTopology X] : DiscreteTopology (ULift X) :=
   IsEmbedding.uliftDown.discreteTopology

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -931,11 +931,15 @@ theorem isOpenMap_inr : IsOpenMap (@inr X Y) := fun u hu => by
 protected lemma IsOpenEmbedding.inl : IsOpenEmbedding (@inl X Y) :=
   .of_continuous_injective_isOpenMap continuous_inl inl_injective isOpenMap_inl
 
+@[deprecated (since := "2024-10-30")] alias isOpenEmbedding_inl := IsOpenEmbedding.inl
+
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding_inl := IsOpenEmbedding.inl
 
 protected lemma IsOpenEmbedding.inr : IsOpenEmbedding (@inr X Y) :=
   .of_continuous_injective_isOpenMap continuous_inr inr_injective isOpenMap_inr
+
+@[deprecated (since := "2024-10-30")] alias isOpenEmbedding_inr := IsOpenEmbedding.inr
 
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding_inr := IsOpenEmbedding.inr
@@ -943,11 +947,15 @@ alias openEmbedding_inr := IsOpenEmbedding.inr
 protected lemma IsEmbedding.inl : IsEmbedding (@inl X Y) := IsOpenEmbedding.inl.1
 protected lemma IsEmbedding.inr : IsEmbedding (@inr X Y) := IsOpenEmbedding.inr.1
 
+@[deprecated (since := "2024-10-30")] alias IsEmbedding.inr := IsEmbedding.inl
+
 @[deprecated (since := "2024-10-26")]
 alias embedding_inr := IsEmbedding.inr
 
 lemma isOpen_range_inl : IsOpen (range (inl : X → X ⊕ Y)) := IsOpenEmbedding.inl.2
 lemma isOpen_range_inr : IsOpen (range (inr : Y → X ⊕ Y)) := IsOpenEmbedding.inr.2
+
+@[deprecated (since := "2024-10-30")] alias isOpen_range_inr := isOpen_range_inl
 
 theorem isClosed_range_inl : IsClosed (range (inl : X → X ⊕ Y)) := by
   rw [← isOpen_compl_iff, compl_range_inl]
@@ -960,11 +968,15 @@ theorem isClosed_range_inr : IsClosed (range (inr : Y → X ⊕ Y)) := by
 theorem IsClosedEmbedding.inl : IsClosedEmbedding (inl : X → X ⊕ Y) :=
   ⟨.inl, isClosed_range_inl⟩
 
+@[deprecated (since := "2024-10-30")] alias isClosedEmbedding_inl := IsClosedEmbedding.inl
+
 @[deprecated (since := "2024-10-20")]
 alias closedEmbedding_inl := IsClosedEmbedding.inl
 
 theorem IsClosedEmbedding.inr : IsClosedEmbedding (inr : Y → X ⊕ Y) :=
   ⟨.inr, isClosed_range_inr⟩
+
+@[deprecated (since := "2024-10-30")] alias isClosedEmbedding_inr := IsClosedEmbedding.inr
 
 @[deprecated (since := "2024-10-20")]
 alias closedEmbedding_inr := IsClosedEmbedding.inr
@@ -1597,11 +1609,15 @@ theorem isClosed_range_sigmaMk {i : ι} : IsClosed (range (@Sigma.mk ι σ i)) :
 lemma IsOpenEmbedding.sigmaMk {i : ι} : IsOpenEmbedding (@Sigma.mk ι σ i) :=
   .of_continuous_injective_isOpenMap continuous_sigmaMk sigma_mk_injective isOpenMap_sigmaMk
 
+@[deprecated (since := "2024-10-30")] alias isOpenEmbedding_sigmaMk := IsOpenEmbedding.sigmaMk
+
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding_sigmaMk := IsOpenEmbedding.sigmaMk
 
 lemma IsClosedEmbedding.sigmaMk {i : ι} : IsClosedEmbedding (@Sigma.mk ι σ i) :=
   .of_continuous_injective_isClosedMap continuous_sigmaMk sigma_mk_injective isClosedMap_sigmaMk
+
+@[deprecated (since := "2024-10-30")] alias isClosedEmbedding_sigmaMk := IsClosedEmbedding.sigmaMk
 
 @[deprecated (since := "2024-10-20")]
 alias closedEmbedding_sigmaMk := IsClosedEmbedding.sigmaMk
@@ -1696,6 +1712,8 @@ lemma isOpenEmbedding_sigmaMap {f₁ : ι → κ} {f₂ : ∀ i, σ i → τ (f�
   simp only [isOpenEmbedding_iff_isEmbedding_isOpenMap, isOpenMap_sigma_map, isEmbedding_sigmaMap h,
     forall_and]
 
+@[deprecated (since := "2024-10-30")] alias isOpenEmbedding_sigma_map := isOpenEmbedding_sigmaMap
+
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding_sigma_map := isOpenEmbedding_sigmaMap
 
@@ -1728,6 +1746,9 @@ alias embedding_uLift_down := IsEmbedding.uliftDown
 lemma IsClosedEmbedding.uliftDown [TopologicalSpace X] :
     IsClosedEmbedding (ULift.down : ULift.{v, u} X → X) :=
   ⟨.uliftDown, by simp only [ULift.down_surjective.range_eq, isClosed_univ]⟩
+
+@[deprecated (since := "2024-10-30")]
+alias ULift.isClosedEmbedding_down := IsClosedEmbedding.uliftDown
 
 @[deprecated (since := "2024-10-20")]
 alias ULift.closedEmbedding_down := IsClosedEmbedding.uliftDown

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -947,15 +947,11 @@ alias openEmbedding_inr := IsOpenEmbedding.inr
 protected lemma IsEmbedding.inl : IsEmbedding (@inl X Y) := IsOpenEmbedding.inl.1
 protected lemma IsEmbedding.inr : IsEmbedding (@inr X Y) := IsOpenEmbedding.inr.1
 
-@[deprecated (since := "2024-10-30")] alias IsEmbedding.inr := IsEmbedding.inl
-
 @[deprecated (since := "2024-10-26")]
 alias embedding_inr := IsEmbedding.inr
 
 lemma isOpen_range_inl : IsOpen (range (inl : X → X ⊕ Y)) := IsOpenEmbedding.inl.2
 lemma isOpen_range_inr : IsOpen (range (inr : Y → X ⊕ Y)) := IsOpenEmbedding.inr.2
-
-@[deprecated (since := "2024-10-30")] alias isOpen_range_inr := isOpen_range_inl
 
 theorem isClosed_range_inl : IsClosed (range (inl : X → X ⊕ Y)) := by
   rw [← isOpen_compl_iff, compl_range_inl]

--- a/Mathlib/Topology/DenseEmbedding.lean
+++ b/Mathlib/Topology/DenseEmbedding.lean
@@ -227,6 +227,8 @@ open TopologicalSpace
 variable [TopologicalSpace α] [TopologicalSpace β] [TopologicalSpace γ] [TopologicalSpace δ]
 variable {e : α → β}
 
+lemma isDenseInducing (de : IsDenseEmbedding e) : IsDenseInducing e := de.toIsDenseInducing
+
 theorem inj_iff (de : IsDenseEmbedding e) {x y} : e x = e y ↔ x = y :=
   de.inj.eq_iff
 
@@ -237,12 +239,12 @@ alias to_embedding := isEmbedding
 
 /-- If the domain of a `IsDenseEmbedding` is a separable space, then so is its codomain. -/
 protected theorem separableSpace [SeparableSpace α] (de : IsDenseEmbedding e) : SeparableSpace β :=
-  de.toIsDenseInducing.separableSpace
+  de.isDenseInducing.separableSpace
 
 /-- The product of two dense embeddings is a dense embedding. -/
 protected theorem prodMap {e₁ : α → β} {e₂ : γ → δ} (de₁ : IsDenseEmbedding e₁)
     (de₂ : IsDenseEmbedding e₂) : IsDenseEmbedding fun p : α × γ => (e₁ p.1, e₂ p.2) :=
-  { de₁.toIsDenseInducing.prodMap de₂.toIsDenseInducing with
+  { de₁.isDenseInducing.prodMap de₂.isDenseInducing with
     inj := de₁.inj.prodMap de₂.inj }
 
 @[deprecated (since := "2024-10-06")] protected alias prod := IsDenseEmbedding.prodMap
@@ -267,7 +269,7 @@ protected theorem subtype (de : IsDenseEmbedding e) (p : α → Prop) :
         Function.comp_def]
 
 theorem dense_image (de : IsDenseEmbedding e) {s : Set α} : Dense (e '' s) ↔ Dense s :=
-  de.toIsDenseInducing.dense_image
+  de.isDenseInducing.dense_image
 
 protected lemma id {α : Type*} [TopologicalSpace α] : IsDenseEmbedding (id : α → α) :=
   { IsEmbedding.id with dense := denseRange_id }

--- a/Mathlib/Topology/Gluing.lean
+++ b/Mathlib/Topology/Gluing.lean
@@ -293,7 +293,7 @@ theorem open_image_open (i : D.J) (U : Opens (𝖣.U i)) : IsOpen (𝖣.ι i '' 
   exact U.isOpen
 
 theorem ι_isOpenEmbedding (i : D.J) : IsOpenEmbedding (𝖣.ι i) :=
-  isOpenEmbedding_of_continuous_injective_open (𝖣.ι i).continuous_toFun (D.ι_injective i) fun U h =>
+  .of_continuous_injective_isOpenMap (𝖣.ι i).continuous_toFun (D.ι_injective i) fun U h =>
     D.open_image_open i ⟨U, h⟩
 
 @[deprecated (since := "2024-10-18")]
@@ -453,7 +453,7 @@ theorem fromOpenSubsetsGlue_isOpenMap : IsOpenMap (fromOpenSubsetsGlue U) := by
     exact Set.mem_range_self _
 
 theorem fromOpenSubsetsGlue_isOpenEmbedding : IsOpenEmbedding (fromOpenSubsetsGlue U) :=
-  isOpenEmbedding_of_continuous_injective_open (ContinuousMap.continuous_toFun _)
+  .of_continuous_injective_isOpenMap (ContinuousMap.continuous_toFun _)
     (fromOpenSubsetsGlue_injective U) (fromOpenSubsetsGlue_isOpenMap U)
 
 @[deprecated (since := "2024-10-18")]

--- a/Mathlib/Topology/Instances/CantorSet.lean
+++ b/Mathlib/Topology/Instances/CantorSet.lean
@@ -85,8 +85,8 @@ lemma isClosed_preCantorSet (n : ℕ) : IsClosed (preCantorSet n) := by
   | zero => exact isClosed_Icc
   | succ n ih =>
     refine IsClosed.union ?_ ?_
-    · simpa [f, div_eq_inv_mul] using f.isClosedEmbedding.closed_iff_image_closed.mp ih
-    · simpa [g, f, div_eq_inv_mul] using g.isClosedEmbedding.closed_iff_image_closed.mp ih
+    · simpa [f, div_eq_inv_mul] using f.isClosedEmbedding.isClosed_iff_image_isClosed.mp ih
+    · simpa [g, f, div_eq_inv_mul] using g.isClosedEmbedding.isClosed_iff_image_isClosed.mp ih
 
 /-- The ternary Cantor set is closed. -/
 lemma isClosed_cantorSet : IsClosed cantorSet :=

--- a/Mathlib/Topology/Instances/RatLemmas.lean
+++ b/Mathlib/Topology/Instances/RatLemmas.lean
@@ -39,7 +39,7 @@ namespace Rat
 variable {p : ℚ} {s : Set ℚ}
 
 theorem interior_compact_eq_empty (hs : IsCompact s) : interior s = ∅ :=
-  isDenseEmbedding_coe_real.toIsDenseInducing.interior_compact_eq_empty dense_irrational hs
+  isDenseEmbedding_coe_real.isDenseInducing.interior_compact_eq_empty dense_irrational hs
 
 theorem dense_compl_compact (hs : IsCompact s) : Dense sᶜ :=
   interior_eq_empty_iff_dense_compl.1 (interior_compact_eq_empty hs)

--- a/Mathlib/Topology/IsLocalHomeomorph.lean
+++ b/Mathlib/Topology/IsLocalHomeomorph.lean
@@ -48,7 +48,7 @@ theorem isLocalHomeomorphOn_iff_isOpenEmbedding_restrict {f : X → Y} :
     have : IsOpenEmbedding ((interior U).restrict f) := by
       refine emb.comp ⟨.inclusion interior_subset, ?_⟩
       rw [Set.range_inclusion]; exact isOpen_induced isOpen_interior
-    obtain ⟨cont, inj, openMap⟩ := isOpenEmbedding_iff_continuous_injective_open.mp this
+    obtain ⟨cont, inj, openMap⟩ := isOpenEmbedding_iff_continuous_injective_isOpenMap.mp this
     haveI : Nonempty X := ⟨x⟩
     exact ⟨PartialHomeomorph.ofContinuousOpenRestrict
       (Set.injOn_iff_injective.mpr inj).toPartialEquiv
@@ -206,7 +206,7 @@ protected theorem comp (hg : IsLocalHomeomorph g) (hf : IsLocalHomeomorph f) :
 /-- An injective local homeomorphism is an open embedding. -/
 theorem isOpenEmbedding_of_injective (hf : IsLocalHomeomorph f) (hi : f.Injective) :
     IsOpenEmbedding f :=
-  isOpenEmbedding_of_continuous_injective_open hf.continuous hi hf.isOpenMap
+  .of_continuous_injective_isOpenMap hf.continuous hi hf.isOpenMap
 
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding_of_injective := isOpenEmbedding_of_injective

--- a/Mathlib/Topology/JacobsonSpace.lean
+++ b/Mathlib/Topology/JacobsonSpace.lean
@@ -47,7 +47,7 @@ lemma preimage_closedPoints_subset (hf : Function.Injective f) (hf' : Continuous
 lemma IsClosedEmbedding.preimage_closedPoints (hf : IsClosedEmbedding f) :
     f ⁻¹' closedPoints Y = closedPoints X := by
   ext x
-  simp [mem_closedPoints_iff, ← Set.image_singleton, hf.closed_iff_image_closed]
+  simp [mem_closedPoints_iff, ← Set.image_singleton, hf.isClosed_iff_image_isClosed]
 
 lemma closedPoints_eq_univ [T2Space X] :
     closedPoints X = Set.univ :=

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -119,7 +119,7 @@ theorem isOpen_iff_coe_preimage_of_iSup_eq_top (s : Set β) :
   -- Porting note: rewrote to avoid ´simp´ issues
   rw [isOpen_iff_inter_of_iSup_eq_top hU s]
   refine forall_congr' fun i => ?_
-  rw [(U _).2.isOpenEmbedding_subtypeVal.open_iff_image_open]
+  rw [(U _).2.isOpenEmbedding_subtypeVal.isOpen_iff_image_isOpen]
   erw [Set.image_preimage_eq_inter_range]
   rw [Subtype.range_coe, Opens.carrier_eq_coe]
 

--- a/Mathlib/Topology/Maps/Basic.lean
+++ b/Mathlib/Topology/Maps/Basic.lean
@@ -560,14 +560,13 @@ theorem IsOpenEmbedding.map_nhds_eq (hf : IsOpenEmbedding f) (x : X) :
 @[deprecated (since := "2024-10-18")]
 alias OpenEmbedding.map_nhds_eq := IsOpenEmbedding.map_nhds_eq
 
-theorem IsOpenEmbedding.open_iff_image_open (hf : IsOpenEmbedding f) {s : Set X} :
-    IsOpen s ↔ IsOpen (f '' s) :=
-  ⟨hf.isOpenMap s, fun h => by
-    convert ← h.preimage hf.isEmbedding.continuous
-    apply preimage_image_eq _ hf.inj⟩
+lemma IsOpenEmbedding.isOpen_iff_image_isOpen (hf : IsOpenEmbedding f) {s : Set X} :
+    IsOpen s ↔ IsOpen (f '' s) where
+  mp := hf.isOpenMap s
+  mpr h := by convert ← h.preimage hf.isEmbedding.continuous; apply preimage_image_eq _ hf.inj
 
 @[deprecated (since := "2024-10-18")]
-alias OpenEmbedding.open_iff_image_open := IsOpenEmbedding.open_iff_image_open
+alias OpenEmbedding.open_iff_image_open := IsOpenEmbedding.isOpen_iff_image_isOpen
 
 theorem IsOpenEmbedding.tendsto_nhds_iff [TopologicalSpace Z] {f : ι → Y} {l : Filter ι} {y : Y}
     (hg : IsOpenEmbedding g) : Tendsto f l (𝓝 y) ↔ Tendsto (g ∘ f) l (𝓝 (g y)) :=
@@ -596,12 +595,12 @@ theorem IsOpenEmbedding.continuous (hf : IsOpenEmbedding f) : Continuous f :=
 @[deprecated (since := "2024-10-18")]
 alias OpenEmbedding.continuous := IsOpenEmbedding.continuous
 
-lemma IsOpenEmbedding.open_iff_preimage_open (hf : IsOpenEmbedding f) {s : Set Y}
+lemma IsOpenEmbedding.isOpen_iff_preimage_isOpen (hf : IsOpenEmbedding f) {s : Set Y}
     (hs : s ⊆ range f) : IsOpen s ↔ IsOpen (f ⁻¹' s) := by
-  rw [hf.open_iff_image_open, image_preimage_eq_inter_range, inter_eq_self_of_subset_left hs]
+  rw [hf.isOpen_iff_image_isOpen, image_preimage_eq_inter_range, inter_eq_self_of_subset_left hs]
 
 @[deprecated (since := "2024-10-18")]
-alias OpenEmbedding.open_iff_preimage_open := IsOpenEmbedding.open_iff_preimage_open
+alias OpenEmbedding.open_iff_preimage_open := IsOpenEmbedding.isOpen_iff_preimage_isOpen
 
 lemma IsOpenEmbedding.of_isEmbedding_isOpenMap (h₁ : IsEmbedding f) (h₂ : IsOpenMap f) :
     IsOpenEmbedding f :=
@@ -635,31 +634,31 @@ alias isOpenEmbedding_iff_embedding_open := isOpenEmbedding_iff_isEmbedding_isOp
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding_iff_embedding_open := isOpenEmbedding_iff_isEmbedding_isOpenMap
 
-theorem isOpenEmbedding_of_continuous_injective_open
+theorem IsOpenEmbedding.of_continuous_injective_isOpenMap
     (h₁ : Continuous f) (h₂ : Injective f) (h₃ : IsOpenMap f) : IsOpenEmbedding f := by
   simp only [isOpenEmbedding_iff_isEmbedding_isOpenMap, isEmbedding_iff, isInducing_iff_nhds, *,
     and_true]
   exact fun x =>
     le_antisymm (h₁.tendsto _).le_comap (@comap_map _ _ (𝓝 x) _ h₂ ▸ comap_mono (h₃.nhds_le _))
 
-theorem isOpenEmbedding_iff_continuous_injective_open :
+lemma isOpenEmbedding_iff_continuous_injective_isOpenMap :
     IsOpenEmbedding f ↔ Continuous f ∧ Injective f ∧ IsOpenMap f :=
   ⟨fun h => ⟨h.continuous, h.inj, h.isOpenMap⟩, fun h =>
-    isOpenEmbedding_of_continuous_injective_open h.1 h.2.1 h.2.2⟩
+    .of_continuous_injective_isOpenMap h.1 h.2.1 h.2.2⟩
 
 @[deprecated (since := "2024-10-18")]
-alias openEmbedding_iff_continuous_injective_open := isOpenEmbedding_iff_continuous_injective_open
-
-theorem isOpenEmbedding_id : IsOpenEmbedding (@id X) :=
-  ⟨.id, IsOpenMap.id.isOpen_range⟩
-
-@[deprecated (since := "2024-10-18")]
-alias openEmbedding_id := isOpenEmbedding_id
+alias openEmbedding_iff_continuous_injective_open :=
+  isOpenEmbedding_iff_continuous_injective_isOpenMap
 
 namespace IsOpenEmbedding
 variable [TopologicalSpace Z]
 
-protected theorem comp (hg : IsOpenEmbedding g)
+protected lemma id : IsOpenEmbedding (@id X) := ⟨.id, IsOpenMap.id.isOpen_range⟩
+
+@[deprecated (since := "2024-10-18")]
+alias _root_.openEmbedding_id := IsOpenEmbedding.id
+
+protected lemma comp (hg : IsOpenEmbedding g)
     (hf : IsOpenEmbedding f) : IsOpenEmbedding (g ∘ f) :=
   ⟨hg.1.comp hf.1, (hg.isOpenMap.comp hf.isOpenMap).isOpen_range⟩
 
@@ -669,12 +668,11 @@ theorem isOpenMap_iff (hg : IsOpenEmbedding g) :
 
 theorem of_comp_iff (f : X → Y) (hg : IsOpenEmbedding g) :
     IsOpenEmbedding (g ∘ f) ↔ IsOpenEmbedding f := by
-  simp only [isOpenEmbedding_iff_continuous_injective_open, ← hg.isOpenMap_iff, ←
+  simp only [isOpenEmbedding_iff_continuous_injective_isOpenMap, ← hg.isOpenMap_iff, ←
     hg.1.continuous_iff, hg.inj.of_comp_iff]
 
-theorem of_comp (f : X → Y) (hg : IsOpenEmbedding g)
-    (h : IsOpenEmbedding (g ∘ f)) : IsOpenEmbedding f :=
-  (IsOpenEmbedding.of_comp_iff f hg).1 h
+lemma of_comp (f : X → Y) (hg : IsOpenEmbedding g) (h : IsOpenEmbedding (g ∘ f)) :
+    IsOpenEmbedding f := (IsOpenEmbedding.of_comp_iff f hg).1 h
 
 theorem of_isEmpty [IsEmpty X] (f : X → Y) : IsOpenEmbedding f :=
   of_isEmbedding_isOpenMap (.of_subsingleton f) (.of_isEmpty f)
@@ -705,15 +703,15 @@ lemma tendsto_nhds_iff {g : ι → X} {l : Filter ι} {x : X} (hf : IsClosedEmbe
 lemma isClosedMap (hf : IsClosedEmbedding f) : IsClosedMap f :=
   hf.isEmbedding.isInducing.isClosedMap hf.isClosed_range
 
-theorem closed_iff_image_closed (hf : IsClosedEmbedding f) {s : Set X} :
+lemma isClosed_iff_image_isClosed (hf : IsClosedEmbedding f) {s : Set X} :
     IsClosed s ↔ IsClosed (f '' s) :=
   ⟨hf.isClosedMap s, fun h => by
     rw [← preimage_image_eq s hf.inj]
     exact h.preimage hf.continuous⟩
 
-theorem closed_iff_preimage_closed (hf : IsClosedEmbedding f) {s : Set Y}
+lemma isClosed_iff_preimage_isClosed (hf : IsClosedEmbedding f) {s : Set Y}
     (hs : s ⊆ range f) : IsClosed s ↔ IsClosed (f ⁻¹' s) := by
-  rw [hf.closed_iff_image_closed, image_preimage_eq_of_subset hs]
+  rw [hf.isClosed_iff_image_isClosed, image_preimage_eq_of_subset hs]
 
 lemma of_isEmbedding_isClosedMap (h₁ : IsEmbedding f) (h₂ : IsClosedMap f) :
     IsClosedEmbedding f :=
@@ -725,8 +723,8 @@ alias _root_.IsClosedEmbedding.of_embedding_closed := of_isEmbedding_isClosedMap
 @[deprecated (since := "2024-10-20")]
 alias _root_.closedEmbedding_of_embedding_closed := of_isEmbedding_isClosedMap
 
-lemma _root_.IsClosedEmbedding.of_continuous_injective_isClosedMap (h₁ : Continuous f)
-    (h₂ : Injective f) (h₃ : IsClosedMap f) : IsClosedEmbedding f := by
+lemma of_continuous_injective_isClosedMap (h₁ : Continuous f) (h₂ : Injective f)
+    (h₃ : IsClosedMap f) : IsClosedEmbedding f := by
   refine .of_isEmbedding_isClosedMap ⟨⟨?_⟩, h₂⟩ h₃
   refine h₁.le_induced.antisymm fun s hs => ?_
   refine ⟨(f '' sᶜ)ᶜ, (h₃ _ hs.isClosed_compl).isOpen_compl, ?_⟩
@@ -736,11 +734,10 @@ lemma _root_.IsClosedEmbedding.of_continuous_injective_isClosedMap (h₁ : Conti
 alias _root_.closedEmbedding_of_continuous_injective_closed :=
   IsClosedEmbedding.of_continuous_injective_isClosedMap
 
-theorem _root_.isClosedEmbedding_id : IsClosedEmbedding (@id X) :=
-  ⟨.id, IsClosedMap.id.isClosed_range⟩
+protected theorem id : IsClosedEmbedding (@id X) := ⟨.id, IsClosedMap.id.isClosed_range⟩
 
 @[deprecated (since := "2024-10-20")]
-alias _root_.closedEmbedding_id := _root_.isClosedEmbedding_id
+alias _root_.closedEmbedding_id := IsClosedEmbedding.id
 
 theorem comp (hg : IsClosedEmbedding g) (hf : IsClosedEmbedding f) :
     IsClosedEmbedding (g ∘ f) :=
@@ -748,7 +745,7 @@ theorem comp (hg : IsClosedEmbedding g) (hf : IsClosedEmbedding f) :
 
 lemma of_comp_iff (hg : IsClosedEmbedding g) : IsClosedEmbedding (g ∘ f) ↔ IsClosedEmbedding f := by
   simp_rw [isClosedEmbedding_iff, hg.isEmbedding.of_comp_iff, Set.range_comp,
-    ← hg.closed_iff_image_closed]
+    ← hg.isClosed_iff_image_isClosed]
 
 @[deprecated (since := "2024-10-26")]
 alias Embedding.of_comp_iff := of_comp_iff

--- a/Mathlib/Topology/Maps/Basic.lean
+++ b/Mathlib/Topology/Maps/Basic.lean
@@ -745,10 +745,6 @@ lemma of_continuous_injective_isClosedMap (h₁ : Continuous f) (h₂ : Injectiv
   refine ⟨(f '' sᶜ)ᶜ, (h₃ _ hs.isClosed_compl).isOpen_compl, ?_⟩
   rw [preimage_compl, preimage_image_eq _ h₂, compl_compl]
 
-@[deprecated (since := "2024-10-30")]
-alias _root_.IsClosedEmbedding.of_continuous_injective_isClosedMap :=
-  of_continuous_injective_isClosedMap
-
 @[deprecated (since := "2024-10-20")]
 alias _root_.closedEmbedding_of_continuous_injective_closed :=
   IsClosedEmbedding.of_continuous_injective_isClosedMap

--- a/Mathlib/Topology/Maps/Basic.lean
+++ b/Mathlib/Topology/Maps/Basic.lean
@@ -565,6 +565,9 @@ lemma IsOpenEmbedding.isOpen_iff_image_isOpen (hf : IsOpenEmbedding f) {s : Set 
   mp := hf.isOpenMap s
   mpr h := by convert ← h.preimage hf.isEmbedding.continuous; apply preimage_image_eq _ hf.inj
 
+@[deprecated (since := "2024-10-30")]
+alias IsOpenEmbedding.open_iff_image_open := IsOpenEmbedding.isOpen_iff_image_isOpen
+
 @[deprecated (since := "2024-10-18")]
 alias OpenEmbedding.open_iff_image_open := IsOpenEmbedding.isOpen_iff_image_isOpen
 
@@ -598,6 +601,9 @@ alias OpenEmbedding.continuous := IsOpenEmbedding.continuous
 lemma IsOpenEmbedding.isOpen_iff_preimage_isOpen (hf : IsOpenEmbedding f) {s : Set Y}
     (hs : s ⊆ range f) : IsOpen s ↔ IsOpen (f ⁻¹' s) := by
   rw [hf.isOpen_iff_image_isOpen, image_preimage_eq_inter_range, inter_eq_self_of_subset_left hs]
+
+@[deprecated (since := "2024-10-30")]
+alias IsOpenEmbedding.open_iff_preimage_open := IsOpenEmbedding.isOpen_iff_preimage_isOpen
 
 @[deprecated (since := "2024-10-18")]
 alias OpenEmbedding.open_iff_preimage_open := IsOpenEmbedding.isOpen_iff_preimage_isOpen
@@ -645,6 +651,10 @@ lemma isOpenEmbedding_iff_continuous_injective_isOpenMap :
     IsOpenEmbedding f ↔ Continuous f ∧ Injective f ∧ IsOpenMap f :=
   ⟨fun h => ⟨h.continuous, h.inj, h.isOpenMap⟩, fun h =>
     .of_continuous_injective_isOpenMap h.1 h.2.1 h.2.2⟩
+
+@[deprecated (since := "2024-10-30")]
+alias isOpenEmbedding_iff_continuous_injective_open :=
+  isOpenEmbedding_iff_continuous_injective_isOpenMap
 
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding_iff_continuous_injective_open :=
@@ -709,9 +719,14 @@ lemma isClosed_iff_image_isClosed (hf : IsClosedEmbedding f) {s : Set X} :
     rw [← preimage_image_eq s hf.inj]
     exact h.preimage hf.continuous⟩
 
+@[deprecated (since := "2024-10-30")] alias closed_iff_image_closed := isClosed_iff_image_isClosed
+
 lemma isClosed_iff_preimage_isClosed (hf : IsClosedEmbedding f) {s : Set Y}
     (hs : s ⊆ range f) : IsClosed s ↔ IsClosed (f ⁻¹' s) := by
   rw [hf.isClosed_iff_image_isClosed, image_preimage_eq_of_subset hs]
+
+@[deprecated (since := "2024-10-30")]
+alias closed_iff_preimage_closed := isClosed_iff_preimage_isClosed
 
 lemma of_isEmbedding_isClosedMap (h₁ : IsEmbedding f) (h₂ : IsClosedMap f) :
     IsClosedEmbedding f :=
@@ -729,6 +744,10 @@ lemma of_continuous_injective_isClosedMap (h₁ : Continuous f) (h₂ : Injectiv
   refine h₁.le_induced.antisymm fun s hs => ?_
   refine ⟨(f '' sᶜ)ᶜ, (h₃ _ hs.isClosed_compl).isOpen_compl, ?_⟩
   rw [preimage_compl, preimage_image_eq _ h₂, compl_compl]
+
+@[deprecated (since := "2024-10-30")]
+alias _root_.IsClosedEmbedding.of_continuous_injective_isClosedMap :=
+  of_continuous_injective_isClosedMap
 
 @[deprecated (since := "2024-10-20")]
 alias _root_.closedEmbedding_of_continuous_injective_closed :=

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1093,7 +1093,7 @@ def toHomeomorphOfSourceEqUnivTargetEqUniv (h : e.source = (univ : Set X)) (h' :
     simpa only [continuous_iff_continuousOn_univ, h'] using e.continuousOn_symm
 
 theorem isOpenEmbedding_restrict : IsOpenEmbedding (e.source.restrict e) := by
-  refine isOpenEmbedding_of_continuous_injective_open (e.continuousOn.comp_continuous
+  refine .of_continuous_injective_isOpenMap (e.continuousOn.comp_continuous
     continuous_subtype_val Subtype.prop) e.injOn.injective fun V hV ↦ ?_
   rw [Set.restrict_eq, Set.image_comp]
   exact e.isOpen_image_of_subset_source (e.open_source.isOpenMap_subtype_val V hV)

--- a/Mathlib/Topology/SeparatedMap.lean
+++ b/Mathlib/Topology/SeparatedMap.lean
@@ -158,7 +158,7 @@ alias IsLocallyInjective_iff_openEmbedding := IsLocallyInjective_iff_isOpenEmbed
 theorem isLocallyInjective_iff_isOpenMap {f : X → Y} :
     IsLocallyInjective f ↔ IsOpenMap (toPullbackDiag f) :=
   IsLocallyInjective_iff_isOpenEmbedding.trans
-    ⟨IsOpenEmbedding.isOpenMap, isOpenEmbedding_of_continuous_injective_open
+    ⟨IsOpenEmbedding.isOpenMap, .of_continuous_injective_isOpenMap
       (IsEmbedding.toPullbackDiag f).continuous (injective_toPullbackDiag f)⟩
 
 theorem discreteTopology_iff_locallyInjective (y : Y) :

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -1584,10 +1584,10 @@ instance [T2Space X] [TopologicalSpace Y] [T2Space Y] :
     T2Space (X ⊕ Y) := by
   constructor
   rintro (x | x) (y | y) h
-  · exact separated_by_isOpenEmbedding isOpenEmbedding_inl <| ne_of_apply_ne _ h
+  · exact separated_by_isOpenEmbedding .inl <| ne_of_apply_ne _ h
   · exact separated_by_continuous continuous_isLeft <| by simp
   · exact separated_by_continuous continuous_isLeft <| by simp
-  · exact separated_by_isOpenEmbedding isOpenEmbedding_inr <| ne_of_apply_ne _ h
+  · exact separated_by_isOpenEmbedding .inr <| ne_of_apply_ne _ h
 
 instance Pi.t2Space {Y : X → Type v} [∀ a, TopologicalSpace (Y a)]
     [∀ a, T2Space (Y a)] : T2Space (∀ a, Y a) :=
@@ -1599,7 +1599,7 @@ instance Sigma.t2Space {ι} {X : ι → Type*} [∀ i, TopologicalSpace (X i)] [
   rintro ⟨i, x⟩ ⟨j, y⟩ neq
   rcases eq_or_ne i j with (rfl | h)
   · replace neq : x ≠ y := ne_of_apply_ne _ neq
-    exact separated_by_isOpenEmbedding isOpenEmbedding_sigmaMk neq
+    exact separated_by_isOpenEmbedding .sigmaMk neq
   · let _ := (⊥ : TopologicalSpace ι); have : DiscreteTopology ι := ⟨rfl⟩
     exact separated_by_continuous (continuous_def.2 fun u _ => isOpen_sigma_fst_preimage u) h
 
@@ -2324,8 +2324,7 @@ protected theorem IsClosedEmbedding.t4Space [TopologicalSpace Y] [T4Space Y] {f 
 @[deprecated (since := "2024-10-20")]
 alias ClosedEmbedding.t4Space := IsClosedEmbedding.t4Space
 
-instance ULift.instT4Space [T4Space X] : T4Space (ULift X) :=
-  ULift.isClosedEmbedding_down.t4Space
+instance ULift.instT4Space [T4Space X] : T4Space (ULift X) := IsClosedEmbedding.uliftDown.t4Space
 
 namespace SeparationQuotient
 
@@ -2563,7 +2562,8 @@ theorem loc_compact_Haus_tot_disc_of_zero_dim [TotallyDisconnectedSpace H] :
   haveI : CompactSpace s := isCompact_iff_compactSpace.1 comp
   obtain ⟨V : Set s, VisClopen, Vx, V_sub⟩ := compact_exists_isClopen_in_isOpen u_open_in_s xs
   have VisClopen' : IsClopen (((↑) : s → H) '' V) := by
-    refine ⟨comp.isClosed.isClosedEmbedding_subtypeVal.closed_iff_image_closed.1 VisClopen.1, ?_⟩
+    refine ⟨comp.isClosed.isClosedEmbedding_subtypeVal.isClosed_iff_image_isClosed.1 VisClopen.1,
+      ?_⟩
     let v : Set u := ((↑) : u → s) ⁻¹' V
     have : ((↑) : u → H) = ((↑) : s → H) ∘ ((↑) : u → s) := rfl
     have f0 : IsEmbedding ((↑) : u → H) := IsEmbedding.subtypeVal.comp IsEmbedding.subtypeVal

--- a/Mathlib/Topology/UniformSpace/CompleteSeparated.lean
+++ b/Mathlib/Topology/UniformSpace/CompleteSeparated.lean
@@ -27,19 +27,19 @@ theorem IsComplete.isClosed [UniformSpace α] [T0Space α] {s : Set α} (h : IsC
     rcases h f this inf_le_right with ⟨y, ys, fy⟩
     rwa [(tendsto_nhds_unique' ha inf_le_left fy : a = y)]
 
-theorem IsUniformEmbedding.toIsClosedEmbedding [UniformSpace α] [UniformSpace β] [CompleteSpace α]
+theorem IsUniformEmbedding.isClosedEmbedding [UniformSpace α] [UniformSpace β] [CompleteSpace α]
     [T0Space β] {f : α → β} (hf : IsUniformEmbedding f) :
     IsClosedEmbedding f :=
   ⟨hf.isEmbedding, hf.isUniformInducing.isComplete_range.isClosed⟩
 
 @[deprecated (since := "2024-10-20")]
-alias IsUniformEmbedding.toClosedEmbedding := IsUniformEmbedding.toIsClosedEmbedding
+alias IsUniformEmbedding.toClosedEmbedding := IsUniformEmbedding.isClosedEmbedding
 
 @[deprecated (since := "2024-10-01")]
-alias UniformEmbedding.toIsClosedEmbedding := IsUniformEmbedding.toIsClosedEmbedding
+alias UniformEmbedding.toIsClosedEmbedding := IsUniformEmbedding.isClosedEmbedding
 
 @[deprecated (since := "2024-10-20")]
-alias UniformEmbedding.toClosedEmbedding := UniformEmbedding.toIsClosedEmbedding
+alias UniformEmbedding.toClosedEmbedding := IsUniformEmbedding.isClosedEmbedding
 
 namespace IsDenseInducing
 

--- a/Mathlib/Topology/UniformSpace/CompleteSeparated.lean
+++ b/Mathlib/Topology/UniformSpace/CompleteSeparated.lean
@@ -32,6 +32,9 @@ theorem IsUniformEmbedding.isClosedEmbedding [UniformSpace α] [UniformSpace β]
     IsClosedEmbedding f :=
   ⟨hf.isEmbedding, hf.isUniformInducing.isComplete_range.isClosed⟩
 
+@[deprecated (since := "2024-10-30")]
+alias IsUniformEmbedding.toIsClosedEmbedding := IsUniformEmbedding.isClosedEmbedding
+
 @[deprecated (since := "2024-10-20")]
 alias IsUniformEmbedding.toClosedEmbedding := IsUniformEmbedding.isClosedEmbedding
 

--- a/Mathlib/Topology/UniformSpace/Completion.lean
+++ b/Mathlib/Topology/UniformSpace/Completion.lean
@@ -197,7 +197,7 @@ alias denseEmbedding_pureCauchy := isDenseEmbedding_pureCauchy
 
 theorem nonempty_cauchyFilter_iff : Nonempty (CauchyFilter α) ↔ Nonempty α := by
   constructor <;> rintro ⟨c⟩
-  · have := eq_univ_iff_forall.1 isDenseEmbedding_pureCauchy.toIsDenseInducing.closure_range c
+  · have := eq_univ_iff_forall.1 isDenseEmbedding_pureCauchy.isDenseInducing.closure_range c
     obtain ⟨_, ⟨_, a, _⟩⟩ := mem_closure_iff.1 this _ isOpen_univ trivial
     exact ⟨a⟩
   · exact ⟨pureCauchy c⟩


### PR DESCRIPTION
A bunch of lemma name improvements that were missed in the prerequisites to #15993

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
