### PR TITLE
[Merged by Bors] - fix: add minImport tests in test file

### DIFF
--- a/test/MinImports.lean
+++ b/test/MinImports.lean
@@ -75,6 +75,7 @@ import Mathlib.Data.Nat.Notation
 lemma hi (n : ℕ) : n = n := by extract_goal; rfl
 
 set_option linter.minImports.increases false
+set_option linter.minImports true
 /--
 warning: Imports increased to
 [Init.Guard, Mathlib.Data.Int.Notation]


### PR DESCRIPTION
Fixes #18333.

This change is not needed on `master`, but is used in `bump/nightly-2024-10-28`.  Adding it to `master` does not really affect much.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
