### PR TITLE
[Merged by Bors] - feat(FieldTheory/IntermediateField): add instances for intermediate fields inherited from the extension

### DIFF
--- a/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
@@ -40,6 +40,12 @@ def algebraicClosure : IntermediateField K L :=
 
 namespace IntermediateField
 
+instance isAlgebraic_tower_bot [Algebra.IsAlgebraic K L] : Algebra.IsAlgebraic K S :=
+  Algebra.IsAlgebraic.of_injective S.val S.val.injective
+
+instance isAlgebraic_tower_top [Algebra.IsAlgebraic K L] : Algebra.IsAlgebraic S L :=
+  Algebra.IsAlgebraic.tower_top (K := K) S
+
 section FiniteDimensional
 
 variable (F E : IntermediateField K L)
@@ -111,12 +117,6 @@ theorem isIntegral_iff {x : S} : IsIntegral K x ↔ IsIntegral K (x : L) :=
 
 theorem minpoly_eq (x : S) : minpoly K x = minpoly K (x : L) :=
   (minpoly.algebraMap_eq (algebraMap S L).injective x).symm
-
-instance isAlgebraic [Algebra.IsAlgebraic K L] : Algebra.IsAlgebraic K F := by
-  constructor
-  intro x
-  rw [← isAlgebraic_iff, ← isAlgebraic_iff]
-  exact Algebra.IsAlgebraic.isAlgebraic x
 
 end IntermediateField
 

--- a/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
@@ -112,6 +112,12 @@ theorem isIntegral_iff {x : S} : IsIntegral K x ↔ IsIntegral K (x : L) :=
 theorem minpoly_eq (x : S) : minpoly K x = minpoly K (x : L) :=
   (minpoly.algebraMap_eq (algebraMap S L).injective x).symm
 
+instance isAlgebraic [Algebra.IsAlgebraic K L] : Algebra.IsAlgebraic K F := by
+  constructor
+  intro x
+  rw [← isAlgebraic_iff, ← isAlgebraic_iff]
+  exact Algebra.IsAlgebraic.isAlgebraic x
+
 end IntermediateField
 
 /-- If `L/K` is algebraic, the `K`-subalgebras of `L` are all fields. -/

--- a/Mathlib/FieldTheory/PurelyInseparable.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable.lean
@@ -456,6 +456,18 @@ theorem IsPurelyInseparable.trans [Algebra E K] [IsScalarTower F E K]
   refine ⟨n + m, z, ?_⟩
   rw [IsScalarTower.algebraMap_apply F E K, h1, map_pow, h2, ← pow_mul, ← pow_add]
 
+namespace IntermediateField
+
+variable (M : IntermediateField F K)
+
+instance isPurelyInseparable_tower_bot [IsPurelyInseparable F K] : IsPurelyInseparable F M :=
+  IsPurelyInseparable.tower_bot F M K
+
+instance isPurelyInseparable_tower_top [IsPurelyInseparable F K] : IsPurelyInseparable M K :=
+  IsPurelyInseparable.tower_top F M K
+
+end IntermediateField
+
 variable {E}
 
 /-- A field extension `E / F` is purely inseparable if and only if for every element `x` of `E`,

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Polynomial.Splits
 import Mathlib.Algebra.Squarefree.Basic
 import Mathlib.FieldTheory.Minpoly.Field
 import Mathlib.RingTheory.PowerBasis
+import Mathlib.FieldTheory.IntermediateField.Basic
 
 /-!
 
@@ -695,6 +696,18 @@ theorem Algebra.IsSeparable.of_algHom [Algebra.IsSeparable F E'] : Algebra.IsSep
   ⟨fun x => (Algebra.IsSeparable.isSeparable F (f x)).of_algHom⟩
 
 end
+
+namespace IntermediateField
+
+variable [Field K] [Algebra F K] (M : IntermediateField F K)
+
+instance isSeparable_tower_bot [Algebra.IsSeparable F K] : Algebra.IsSeparable F M :=
+  Algebra.isSeparable_tower_bot_of_isSeparable F M K
+
+instance isSeparable_tower_top [Algebra.IsSeparable F K] : Algebra.IsSeparable M K :=
+  Algebra.isSeparable_tower_top_of_isSeparable F M K
+
+end IntermediateField
 
 end Field
 


### PR DESCRIPTION
For p = `Algebra.IsAlgebraic`, `Algebra.IsSeparable`, `IsPurelyInseparable`, we show that if p holds for `L/K`, then p also holds for `M/K` and `L/M` for any intermediate field `M`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
