### PR TITLE
[Merged by Bors] - feat(Order/Cover): `covBy_iff_lt_iff_le`

### DIFF
--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -412,6 +412,26 @@ theorem CovBy.eq_of_between {x : α} (hab : a ⋖ b) (hbc : b ⋖ c) (hax : a < 
     x = b :=
   le_antisymm (le_of_not_lt fun h => hbc.2 h hxc) (le_of_not_lt <| hab.2 hax)
 
+theorem covBy_iff_lt_iff_le_left {x y : α} : x ⋖ y ↔ ∀ {z}, z < y ↔ z ≤ x where
+  mp := fun hx _z ↦ ⟨hx.le_of_lt, fun hz ↦ hz.trans_lt hx.lt⟩
+  mpr := fun H ↦ ⟨H.2 le_rfl, fun _z hx hz ↦ (H.1 hz).not_lt hx⟩
+
+theorem covBy_iff_le_iff_lt_left {x y : α} : x ⋖ y ↔ ∀ {z}, z ≤ x ↔ z < y := by
+  simp_rw [covBy_iff_lt_iff_le_left, iff_comm]
+
+theorem covBy_iff_lt_iff_le_right {x y : α} : x ⋖ y ↔ ∀ {z}, x < z ↔ y ≤ z := by
+  trans ∀ {z}, ¬ z ≤ x ↔ ¬ z < y
+  · simp_rw [covBy_iff_le_iff_lt_left, not_iff_not]
+  · simp
+
+theorem covBy_iff_le_iff_lt_right {x y : α} : x ⋖ y ↔ ∀ {z}, y ≤ z ↔ x < z := by
+  simp_rw [covBy_iff_lt_iff_le_right, iff_comm]
+
+alias ⟨CovBy.lt_iff_le_left, _⟩ := covBy_iff_lt_iff_le_left
+alias ⟨CovBy.le_iff_lt_left, _⟩ := covBy_iff_le_iff_lt_left
+alias ⟨CovBy.lt_iff_le_right, _⟩ := covBy_iff_lt_iff_le_right
+alias ⟨CovBy.le_iff_lt_right, _⟩ := covBy_iff_le_iff_lt_right
+
 /-- If `a < b` then there exist `a' > a` and `b' < b` such that `Set.Iio a'` is strictly to the left
 of `Set.Ioi b'`. -/
 lemma LT.lt.exists_disjoint_Iio_Ioi (h : a < b) :
@@ -420,19 +440,6 @@ lemma LT.lt.exists_disjoint_Iio_Ioi (h : a < b) :
   · exact ⟨b, h, a, h, fun x hx y hy => hx.trans_le <| h'.ge_of_gt hy⟩
   · rcases h.exists_lt_lt h' with ⟨c, ha, hb⟩
     exact ⟨c, ha, c, hb, fun _ h₁ _ => lt_trans h₁⟩
-
-theorem covBy_iff_lt_iff_le {x y : α} : x ⋖ y ↔ ∀ z, z < y ↔ z ≤ x where
-  mp := fun hx _z ↦ ⟨hx.le_of_lt, fun hz ↦ hz.trans_lt hx.lt⟩
-  mpr := fun H ↦ ⟨(H _).2 le_rfl, fun _z hx hz ↦ ((H _).1 hz).not_lt hx⟩
-
-theorem covBy_iff_le_iff_lt {x y : α} : x ⋖ y ↔ ∀ z, z ≤ x ↔ z < y := by
-  simp_rw [covBy_iff_lt_iff_le, iff_comm]
-
-theorem CovBy.lt_iff_le {x y z : α} (h : x ⋖ y) : z < y ↔ z ≤ x :=
-  covBy_iff_lt_iff_le.1 h z
-
-theorem CovBy.le_iff_lt {x y z : α} (h : x ⋖ y) : z ≤ x ↔ z < y :=
-  covBy_iff_le_iff_lt.1 h z
 
 end LinearOrder
 

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -421,6 +421,19 @@ lemma LT.lt.exists_disjoint_Iio_Ioi (h : a < b) :
   · rcases h.exists_lt_lt h' with ⟨c, ha, hb⟩
     exact ⟨c, ha, c, hb, fun _ h₁ _ => lt_trans h₁⟩
 
+theorem covBy_iff_lt_iff_le {x y : α} : x ⋖ y ↔ ∀ z, z < y ↔ z ≤ x where
+  mp := fun hx _z ↦ ⟨hx.le_of_lt, fun hz ↦ hz.trans_lt hx.lt⟩
+  mpr := fun H ↦ ⟨(H _).2 le_rfl, fun _z hx hz ↦ ((H _).1 hz).not_lt hx⟩
+
+theorem covBy_iff_le_iff_lt {x y : α} : x ⋖ y ↔ ∀ z, z ≤ x ↔ z < y := by
+  simp_rw [covBy_iff_lt_iff_le, iff_comm]
+
+theorem CovBy.lt_iff_le {x y z : α} (h : x ⋖ y) : z < y ↔ z ≤ x :=
+  covBy_iff_lt_iff_le.1 h z
+
+theorem CovBy.le_iff_lt {x y z : α} (h : x ⋖ y) : z ≤ x ↔ z < y :=
+  covBy_iff_le_iff_lt.1 h z
+
 end LinearOrder
 
 namespace Set


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
