### PR TITLE
[Merged by Bors] - chore: remove a `Monad` assumption and a linked `do`

### DIFF
--- a/Mathlib/Util/Tactic.lean
+++ b/Mathlib/Util/Tactic.lean
@@ -16,7 +16,7 @@ namespace Mathlib.Tactic
 
 open Lean Meta Tactic
 
-variable {m : Type → Type} [Monad m]
+variable {m : Type → Type}
 
 /--
 `modifyMetavarDecl mvarId f` updates the `MetavarDecl` for `mvarId` with `f`.
@@ -31,7 +31,7 @@ Conditions on `f`:
 If `mvarId` does not refer to a declared metavariable, nothing happens.
 -/
 def modifyMetavarDecl [MonadMCtx m] (mvarId : MVarId)
-    (f : MetavarDecl → MetavarDecl) : m Unit := do
+    (f : MetavarDecl → MetavarDecl) : m Unit :=
   modifyMCtx fun mctx ↦
     match mctx.decls.find? mvarId with
     | none => mctx


### PR DESCRIPTION
#17715 and see also [this Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Monad.20variable.20puzzle).

Note that removing just the `Monad m` assumption would disallow `do`-notation in the following definition.  However, removing both is allowed, since `do` is only used in elaboration, but does not appear in the final type.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
