### PR TITLE
[Merged by Bors] - feat(RingTheory/UFD): `WfDvdMonoid.of_setOf_isPrincipal_wellFoundedOn_gt`

### DIFF
--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -22,7 +22,7 @@ import Mathlib.RingTheory.Multiplicity
 
 ## Main results
 * `Ideal.setOf_isPrincipal_wellFoundedOn_gt`, `WfDvdMonoid.of_setOf_isPrincipal_wellFoundedOn_gt`
-  in a domain, well-foundedness of the strict verison of ∣ is equivalent to the ascending
+  in a domain, well-foundedness of the strict version of ∣ is equivalent to the ascending
   chain condition on principal ideals.
 
 ## TODO

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -20,6 +20,11 @@ import Mathlib.RingTheory.Multiplicity
 * `UniqueFactorizationMonoid` holds for `WfDvdMonoid`s where
   `Irreducible` is equivalent to `Prime`
 
+## Main results
+* `Ideal.setOf_isPrincipal_wellFoundedOn_gt`, `WfDvdMonoid.of_setOf_isPrincipal_wellFoundedOn_gt`
+  in a domain, well-foundedness of the strict verison of ∣ is equivalent to the ascending
+  chain condition on principal ideals.
+
 ## TODO
 * set up the complete lattice structure on `FactorSet`.
 
@@ -30,7 +35,7 @@ variable {α : Type*}
 
 local infixl:50 " ~ᵤ " => Associated
 
-/-- Well-foundedness of the strict version of |, which is equivalent to the descending chain
+/-- Well-foundedness of the strict version of ∣, which is equivalent to the descending chain
 condition on divisibility and to the ascending chain condition on
 principal ideals in an integral domain.
   -/
@@ -40,14 +45,6 @@ abbrev WfDvdMonoid (α : Type*) [CommMonoidWithZero α] : Prop :=
 theorem wellFounded_dvdNotUnit {α : Type*} [CommMonoidWithZero α] [h : WfDvdMonoid α] :
     WellFounded (DvdNotUnit (α := α)) :=
   h.wf
-
--- see Note [lower instance priority]
-instance (priority := 100) IsNoetherianRing.wfDvdMonoid [CommRing α] [IsDomain α]
-    [h : IsNoetherianRing α] : WfDvdMonoid α :=
-  ⟨by
-    convert InvImage.wf (fun a => Ideal.span ({a} : Set α)) h.wf
-    ext
-    exact Ideal.span_singleton_lt_span_singleton.symm⟩
 
 namespace WfDvdMonoid
 
@@ -1990,5 +1987,36 @@ lemma factors_multiset_prod_of_irreducible {s : Multiset ℕ} (h : ∀ x : ℕ, 
   exact fun con ↦ not_irreducible_zero (h 0 con)
 
 end Nat
+
+section Ideal
+
+/-- The ascending chain condition on principal ideals holds in a `WfDvdMonoid` domain. -/
+lemma Ideal.setOf_isPrincipal_wellFoundedOn_gt [CommSemiring α] [WfDvdMonoid α] [IsDomain α] :
+    {I : Ideal α | I.IsPrincipal}.WellFoundedOn (· > ·) := by
+  have : {I : Ideal α | I.IsPrincipal} = ((fun a ↦ Ideal.span {a}) '' Set.univ) := by
+    ext
+    simp [Submodule.isPrincipal_iff, eq_comm]
+  rw [this, Set.wellFoundedOn_image, Set.wellFoundedOn_univ]
+  convert wellFounded_dvdNotUnit (α := α)
+  ext
+  exact Ideal.span_singleton_lt_span_singleton
+
+/-- The ascending chain condition on principal ideals in a domain is sufficient to prove that
+the domain is `WfDvdMonoid`. -/
+lemma WfDvdMonoid.of_setOf_isPrincipal_wellFoundedOn_gt [CommSemiring α] [IsDomain α]
+    (h : {I : Ideal α | I.IsPrincipal}.WellFoundedOn (· > ·)) :
+    WfDvdMonoid α := by
+  have : WellFounded (α := {I : Ideal α // I.IsPrincipal}) (· > ·) := h
+  constructor
+  convert InvImage.wf (fun a => ⟨Ideal.span ({a} : Set α), _, rfl⟩) this
+  ext
+  exact Ideal.span_singleton_lt_span_singleton.symm
+
+-- see Note [lower instance priority]
+instance (priority := 100) IsNoetherianRing.wfDvdMonoid [CommSemiring α] [IsDomain α]
+    [h : IsNoetherianRing α] : WfDvdMonoid α :=
+  WfDvdMonoid.of_setOf_isPrincipal_wellFoundedOn_gt h.wf.wellFoundedOn
+
+end Ideal
 
 set_option linter.style.longFile 2100


### PR DESCRIPTION
And the reverse `Ideal.setOf_isPrincipal_wellFoundedOn_gt` 

the docstring for `WfDvdMonoid` mentioned the ACCP 
but I didn't see the explicit result anywhere 
I also used it to golf the Noetherian =>  WfDvdMonoid proof 
And generalized to CommSemiring


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
