### PR TITLE
[Merged by Bors] - refactor: ungeneralize `LinearIndependent`

### DIFF
--- a/Mathlib/LinearAlgebra/Basis/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basis/Basic.lean
@@ -174,7 +174,7 @@ variable [Module R M] [Module R₂ M]
 variable {x y : M}
 variable (b : Basis ι R M)
 
-theorem eq_bot_of_rank_eq_zero [NoZeroDivisors R] (b : Basis ι R M) (N : Submodule R M)
+theorem Basis.eq_bot_of_rank_eq_zero [NoZeroDivisors R] (b : Basis ι R M) (N : Submodule R M)
     (rank_eq : ∀ {m : ℕ} (v : Fin m → N), LinearIndependent R ((↑) ∘ v : Fin m → M) → m = 0) :
     N = ⊥ := by
   rw [Submodule.eq_bot_iff]

--- a/Mathlib/LinearAlgebra/Basis/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basis/Basic.lean
@@ -46,10 +46,8 @@ theorem coe_sumCoords_eq_finsum : (b.sumCoords : M → R) = fun m => ∑ᶠ i, b
 end Coord
 
 protected theorem linearIndependent : LinearIndependent R b :=
-  linearIndependent_iff.mpr fun l hl =>
-    calc
-      l = b.repr (Finsupp.linearCombination _ b l) := (b.repr_linearCombination l).symm
-      _ = 0 := by rw [hl, LinearEquiv.map_zero]
+  fun x y hxy => by
+    rw [← b.repr_linearCombination x, hxy, b.repr_linearCombination y]
 
 protected theorem ne_zero [Nontrivial R] (i) : b i ≠ 0 :=
   b.linearIndependent.ne_zero i
@@ -116,6 +114,7 @@ theorem prod_apply (i) :
 end Prod
 
 section NoZeroSMulDivisors
+variable {R M : Type*} [Ring R] [AddCommGroup M] [Module R M]
 
 -- Can't be an instance because the basis can't be inferred.
 protected theorem noZeroSMulDivisors [NoZeroDivisors R] (b : Basis ι R M) :

--- a/Mathlib/LinearAlgebra/Basis/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basis/Basic.lean
@@ -114,15 +114,15 @@ theorem prod_apply (i) :
 end Prod
 
 section NoZeroSMulDivisors
-variable {R M : Type*} [Ring R] [AddCommGroup M] [Module R M]
 
 -- Can't be an instance because the basis can't be inferred.
 protected theorem noZeroSMulDivisors [NoZeroDivisors R] (b : Basis ι R M) :
     NoZeroSMulDivisors R M :=
   ⟨fun {c x} hcx => by
     exact or_iff_not_imp_right.mpr fun hx => by
-      rw [← b.linearCombination_repr x, ← LinearMap.map_smul] at hcx
-      have := linearIndependent_iff.mp b.linearIndependent (c • b.repr x) hcx
+      rw [← b.linearCombination_repr x, ← LinearMap.map_smul,
+        ← map_zero (linearCombination R b)] at hcx
+      have := b.linearIndependent hcx
       rw [smul_eq_zero] at this
       exact this.resolve_right fun hr => hx (b.repr.map_eq_zero_iff.mp hr)⟩
 
@@ -130,6 +130,8 @@ protected theorem smul_eq_zero [NoZeroDivisors R] (b : Basis ι R M) {c : R} {x 
     c • x = 0 ↔ c = 0 ∨ x = 0 :=
   @smul_eq_zero _ _ _ _ _ b.noZeroSMulDivisors _ _
 
+
+variable {R M : Type*} [Ring R] [AddCommGroup M] [Module R M]
 theorem eq_bot_of_rank_eq_zero [NoZeroDivisors R] (b : Basis ι R M) (N : Submodule R M)
     (rank_eq : ∀ {m : ℕ} (v : Fin m → N), LinearIndependent R ((↑) ∘ v : Fin m → M) → m = 0) :
     N = ⊥ := by

--- a/Mathlib/LinearAlgebra/Basis/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basis/Basic.lean
@@ -130,22 +130,6 @@ protected theorem smul_eq_zero [NoZeroDivisors R] (b : Basis ι R M) {c : R} {x 
     c • x = 0 ↔ c = 0 ∨ x = 0 :=
   @smul_eq_zero _ _ _ _ _ b.noZeroSMulDivisors _ _
 
-
-variable {R M : Type*} [Ring R] [AddCommGroup M] [Module R M]
-theorem eq_bot_of_rank_eq_zero [NoZeroDivisors R] (b : Basis ι R M) (N : Submodule R M)
-    (rank_eq : ∀ {m : ℕ} (v : Fin m → N), LinearIndependent R ((↑) ∘ v : Fin m → M) → m = 0) :
-    N = ⊥ := by
-  rw [Submodule.eq_bot_iff]
-  intro x hx
-  contrapose! rank_eq with x_ne
-  refine ⟨1, fun _ => ⟨x, hx⟩, ?_, one_ne_zero⟩
-  rw [Fintype.linearIndependent_iff]
-  rintro g sum_eq i
-  cases' i with _ hi
-  simp only [Function.const_apply, Fin.default_eq_zero, Submodule.coe_mk, Finset.univ_unique,
-    Function.comp_const, Finset.sum_singleton] at sum_eq
-  convert (b.smul_eq_zero.mp sum_eq).resolve_right x_ne
-
 end NoZeroSMulDivisors
 
 section Singleton
@@ -189,6 +173,20 @@ variable [Ring R] [CommRing R₂] [AddCommGroup M]
 variable [Module R M] [Module R₂ M]
 variable {x y : M}
 variable (b : Basis ι R M)
+
+theorem eq_bot_of_rank_eq_zero [NoZeroDivisors R] (b : Basis ι R M) (N : Submodule R M)
+    (rank_eq : ∀ {m : ℕ} (v : Fin m → N), LinearIndependent R ((↑) ∘ v : Fin m → M) → m = 0) :
+    N = ⊥ := by
+  rw [Submodule.eq_bot_iff]
+  intro x hx
+  contrapose! rank_eq with x_ne
+  refine ⟨1, fun _ => ⟨x, hx⟩, ?_, one_ne_zero⟩
+  rw [Fintype.linearIndependent_iff]
+  rintro g sum_eq i
+  cases' i with _ hi
+  simp only [Function.const_apply, Fin.default_eq_zero, Submodule.coe_mk, Finset.univ_unique,
+    Function.comp_const, Finset.sum_singleton] at sum_eq
+  convert (b.smul_eq_zero.mp sum_eq).resolve_right x_ne
 
 namespace Basis
 

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -96,10 +96,6 @@ noncomputable def constr {S : Type z} [Semiring S] [Module S N] [SMulCommClass R
     (ChooseBasisIndex R M → N) ≃ₗ[S] M →ₗ[R] N :=
   Basis.constr (chooseBasis R M) S
 
-instance (priority := 100) noZeroSMulDivisors [NoZeroDivisors R] : NoZeroSMulDivisors R M :=
-  let ⟨⟨_, b⟩⟩ := exists_basis (R := R) (M := M)
-  b.noZeroSMulDivisors
-
 instance [Nontrivial M] : Nonempty (Module.Free.ChooseBasisIndex R M) :=
   (Module.Free.chooseBasis R M).index_nonempty
 
@@ -179,5 +175,15 @@ instance tensor : Module.Free S (M ⊗[R] N) :=
   of_basis (bM.2.tensorProduct bN.2)
 
 end CommSemiring
+
+section Ring
+
+variable {R : Type*} [Ring R] [AddCommGroup M] [Module R M] [Module.Free R M]
+
+instance (priority := 100) noZeroSMulDivisors [NoZeroDivisors R] : NoZeroSMulDivisors R M :=
+  let ⟨⟨_, b⟩⟩ := exists_basis (R := R) (M := M)
+  b.noZeroSMulDivisors
+
+end Ring
 
 end Module.Free

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -96,6 +96,10 @@ noncomputable def constr {S : Type z} [Semiring S] [Module S N] [SMulCommClass R
     (ChooseBasisIndex R M → N) ≃ₗ[S] M →ₗ[R] N :=
   Basis.constr (chooseBasis R M) S
 
+instance (priority := 100) noZeroSMulDivisors [NoZeroDivisors R] : NoZeroSMulDivisors R M :=
+  let ⟨⟨_, b⟩⟩ := exists_basis (R := R) (M := M)
+  b.noZeroSMulDivisors
+
 instance [Nontrivial M] : Nonempty (Module.Free.ChooseBasisIndex R M) :=
   (Module.Free.chooseBasis R M).index_nonempty
 
@@ -175,15 +179,5 @@ instance tensor : Module.Free S (M ⊗[R] N) :=
   of_basis (bM.2.tensorProduct bN.2)
 
 end CommSemiring
-
-section Ring
-
-variable {R : Type*} [Ring R] [AddCommGroup M] [Module R M] [Module.Free R M]
-
-instance (priority := 100) noZeroSMulDivisors [NoZeroDivisors R] : NoZeroSMulDivisors R M :=
-  let ⟨⟨_, b⟩⟩ := exists_basis (R := R) (M := M)
-  b.noZeroSMulDivisors
-
-end Ring
 
 end Module.Free

--- a/Mathlib/LinearAlgebra/LinearDisjoint.lean
+++ b/Mathlib/LinearAlgebra/LinearDisjoint.lean
@@ -312,7 +312,7 @@ theorem linearIndependent_left_of_flat (H : M.LinearDisjoint N) [Module.Flat R N
   refine LinearMap.ker_eq_bot_of_injective ?_
   classical simp_rw [mulLeftMap_eq_mulMap_comp, LinearMap.coe_comp, LinearEquiv.coe_coe,
     ← Function.comp_assoc, EquivLike.injective_comp]
-  rw [LinearIndependent, LinearMap.ker_eq_bot] at hm
+  rw [LinearIndependent] at hm
   exact H.injective.comp (Module.Flat.rTensor_preserves_injective_linearMap (M := N) _ hm)
 
 /-- If `{ m_i }` is an `R`-basis of `M`, which is also `N`-linearly independent,
@@ -333,7 +333,7 @@ theorem linearIndependent_right_of_flat (H : M.LinearDisjoint N) [Module.Flat R 
   refine LinearMap.ker_eq_bot_of_injective ?_
   classical simp_rw [mulRightMap_eq_mulMap_comp, LinearMap.coe_comp, LinearEquiv.coe_coe,
     ← Function.comp_assoc, EquivLike.injective_comp]
-  rw [LinearIndependent, LinearMap.ker_eq_bot] at hn
+  rw [LinearIndependent] at hn
   exact H.injective.comp (Module.Flat.lTensor_preserves_injective_linearMap (M := M) _ hn)
 
 /-- If `{ n_i }` is an `R`-basis of `N`, which is also `M`-linearly independent,
@@ -352,7 +352,7 @@ also `R`-linearly independent. -/
 theorem linearIndependent_mul_of_flat_left (H : M.LinearDisjoint N) [Module.Flat R M]
     {κ ι : Type*} {m : κ → M} {n : ι → N} (hm : LinearIndependent R m)
     (hn : LinearIndependent R n) : LinearIndependent R fun (i : κ × ι) ↦ (m i.1).1 * (n i.2).1 := by
-  rw [LinearIndependent, LinearMap.ker_eq_bot] at hm hn ⊢
+  rw [LinearIndependent] at hm hn ⊢
   let i0 := (finsuppTensorFinsupp' R κ ι).symm
   let i1 := LinearMap.rTensor (ι →₀ R) (Finsupp.linearCombination R m)
   let i2 := LinearMap.lTensor M (Finsupp.linearCombination R n)
@@ -373,7 +373,7 @@ also `R`-linearly independent. -/
 theorem linearIndependent_mul_of_flat_right (H : M.LinearDisjoint N) [Module.Flat R N]
     {κ ι : Type*} {m : κ → M} {n : ι → N} (hm : LinearIndependent R m)
     (hn : LinearIndependent R n) : LinearIndependent R fun (i : κ × ι) ↦ (m i.1).1 * (n i.2).1 := by
-  rw [LinearIndependent, LinearMap.ker_eq_bot] at hm hn ⊢
+  rw [LinearIndependent] at hm hn ⊢
   let i0 := (finsuppTensorFinsupp' R κ ι).symm
   let i1 := LinearMap.lTensor (κ →₀ R) (Finsupp.linearCombination R n)
   let i2 := LinearMap.rTensor N (Finsupp.linearCombination R m)
@@ -404,7 +404,7 @@ such that the family `{ m_i * n_j }` in `S` is `R`-linearly independent,
 then `M` and `N` are linearly disjoint. -/
 theorem of_basis_mul {κ ι : Type*} (m : Basis κ R M) (n : Basis ι R N)
     (H : LinearIndependent R fun (i : κ × ι) ↦ (m i.1).1 * (n i.2).1) : M.LinearDisjoint N := by
-  rw [LinearIndependent, LinearMap.ker_eq_bot] at H
+  rw [LinearIndependent] at H
   exact of_basis_mul' M N m n H
 
 variable {M N} in

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -155,6 +155,22 @@ theorem LinearIndependent.comp (h : LinearIndependent R v) (f : ι' → ι) (hf 
   simp_rw [Finsupp.linearCombination_comp] at hxy
   exact Finsupp.mapDomain_injective hf (h hxy)
 
+
+/-- A set of linearly independent vectors in a module `M` over a semiring `K` is also linearly
+independent over a subring `R` of `K`.
+The implementation uses minimal assumptions about the relationship between `R`, `K` and `M`.
+The version where `K` is an `R`-algebra is `LinearIndependent.restrict_scalars_algebras`.
+ -/
+theorem LinearIndependent.restrict_scalars [Semiring K] [SMulWithZero R K] [Module K M]
+    [IsScalarTower R K M] (hinj : Function.Injective fun r : R => r • (1 : K))
+    (li : LinearIndependent K v) : LinearIndependent R v := by
+  intro x y hxy
+  let f := fun r : R => r • (1 : K)
+  have := @li (x.mapRange f (by simp [f])) (y.mapRange f (by simp [f])) ?_
+  · ext i
+    exact hinj congr($this i)
+  simpa [Finsupp.linearCombination, f, Finsupp.sum_mapRange_index]
+
 end Semiring
 
 section Module
@@ -368,20 +384,6 @@ theorem LinearIndependent.fin_cons' {m : ℕ} (x : M) (v : Fin m → M) (hli : L
     exact sum_mem fun i _ => smul_mem _ _ (subset_span ⟨i, rfl⟩)
   rw [this, zero_smul, zero_add] at total_eq
   exact Fin.cases this (hli _ total_eq) j
-
-/-- A set of linearly independent vectors in a module `M` over a semiring `K` is also linearly
-independent over a subring `R` of `K`.
-The implementation uses minimal assumptions about the relationship between `R`, `K` and `M`.
-The version where `K` is an `R`-algebra is `LinearIndependent.restrict_scalars_algebras`.
- -/
-theorem LinearIndependent.restrict_scalars [Ring K] [SMulWithZero R K] [Module K M]
-    [IsScalarTower R K M] (hinj : Function.Injective fun r : R => r • (1 : K))
-    (li : LinearIndependent K v) : LinearIndependent R v := by
-  refine linearIndependent_iff'.mpr fun s g hg i hi => hinj ?_
-  dsimp only; rw [zero_smul]
-  refine (linearIndependent_iff'.mp li : _) _ (g · • (1 : K)) ?_ i hi
-  simp_rw [smul_assoc, one_smul]
-  exact hg
 
 /-- Every finite subset of a linearly independent set is linearly independent. -/
 theorem linearIndependent_finset_map_embedding_subtype (s : Set M)

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
@@ -38,7 +38,7 @@ theorem card_linearIndependent {k : ℕ} (hk : k ≤ n) :
       ∏ i : Fin k, (q ^ n - q ^ i.val) := by
   rw [Nat.card_eq_fintype_card]
   induction k with
-  | zero => simp only [LinearIndependent, Finsupp.linearCombination_fin_zero, ker_zero,
+  | zero => simp only [linearIndependent_iff_ker, Finsupp.linearCombination_fin_zero, ker_zero,
       card_ofSubsingleton, Finset.univ_eq_empty, Finset.prod_empty]
   | succ k ih =>
       have (s : { s : Fin k → V // LinearIndependent K s }) :

--- a/Mathlib/RingTheory/AlgebraTower.lean
+++ b/Mathlib/RingTheory/AlgebraTower.lean
@@ -94,7 +94,7 @@ open scoped Classical
 universe v₁ w₁
 
 variable {R S A}
-variable [Semiring R] [Semiring S] [AddCommMonoid A]
+variable [Ring R] [Ring S] [AddCommGroup A]
 variable [Module R S] [Module S A] [Module R A] [IsScalarTower R S A]
 
 theorem linearIndependent_smul {ι : Type v₁} {b : ι → S} {ι' : Type w₁} {c : ι' → A}

--- a/Mathlib/RingTheory/LinearDisjoint.lean
+++ b/Mathlib/RingTheory/LinearDisjoint.lean
@@ -455,7 +455,7 @@ theorem of_finrank_sup_of_free [Module.Free R A] [Module.Free R B]
   nontriviality R
   rw [← Module.finrank_tensorProduct] at H
   obtain ⟨j, hj⟩ := exists_linearIndependent_of_le_finrank H.ge
-  rw [LinearIndependent, LinearMap.ker_eq_bot] at hj
+  rw [LinearIndependent] at hj
   let j' := Finsupp.linearCombination R j ∘ₗ
     (LinearEquiv.ofFinrankEq (A ⊗[R] B) _ (by simp)).toLinearMap
   replace hj : Function.Injective j' := by simpa [j']

--- a/Mathlib/RingTheory/Localization/Module.lean
+++ b/Mathlib/RingTheory/Localization/Module.lean
@@ -29,11 +29,10 @@ open nonZeroDivisors
 
 section Localization
 
-variable {R : Type*} (Rₛ : Type*) [CommSemiring R] (S : Submonoid R)
-
 section IsLocalizedModule
 
 section AddCommMonoid
+variable {R : Type*} (Rₛ : Type*) [CommSemiring R] (S : Submonoid R)
 
 open Submodule
 
@@ -52,6 +51,18 @@ theorem span_eq_top_of_isLocalizedModule {v : Set M} (hv : span R v = ⊤) :
   refine h ▸ smul_mem _ _  (span_subset_span R Rₛ _ ?_)
   rw [← LinearMap.coe_restrictScalars R, ← LinearMap.map_span, hv]
   exact mem_map_of_mem mem_top
+
+end AddCommMonoid
+
+section AddCommGroup
+
+variable {R : Type*} (Rₛ : Type*) [CommRing R] (S : Submonoid R)
+variable [CommRing Rₛ] [Algebra R Rₛ] [hT : IsLocalization S Rₛ]
+variable {M M' : Type*} [AddCommGroup M] [Module R M]
+  [AddCommGroup M'] [Module R M'] [Module Rₛ M'] [IsScalarTower R Rₛ M'] (f : M →ₗ[R] M')
+  [IsLocalizedModule S f]
+
+include S
 
 theorem LinearIndependent.of_isLocalizedModule {ι : Type*} {v : ι → M}
     (hv : LinearIndependent R v) : LinearIndependent Rₛ (f ∘ v) := by
@@ -77,7 +88,10 @@ theorem LinearIndependent.localization {ι : Type*} {b : ι → M} (hli : Linear
   have := isLocalizedModule_id S M Rₛ
   exact hli.of_isLocalizedModule Rₛ S .id
 
-end AddCommMonoid
+end AddCommGroup
+
+
+variable {R : Type*} (Rₛ : Type*) [CommSemiring R] (S : Submonoid R)
 
 section Basis
 

--- a/Mathlib/RingTheory/Localization/Module.lean
+++ b/Mathlib/RingTheory/Localization/Module.lean
@@ -28,11 +28,12 @@ This file contains some results about vector spaces over the field of fractions 
 open nonZeroDivisors
 
 section Localization
+variable {R : Type*} (Rₛ : Type*)
 
 section IsLocalizedModule
 
 section AddCommMonoid
-variable {R : Type*} (Rₛ : Type*) [CommSemiring R] (S : Submonoid R)
+variable [CommSemiring R] (S : Submonoid R)
 
 open Submodule
 
@@ -91,7 +92,7 @@ theorem LinearIndependent.localization {ι : Type*} {b : ι → M} (hli : Linear
 end AddCommGroup
 
 
-variable {R : Type*} (Rₛ : Type*) [CommSemiring R] (S : Submonoid R)
+variable [CommRing R] (S : Submonoid R)
 
 section Basis
 
@@ -137,7 +138,7 @@ end IsLocalizedModule
 
 section LocalizationLocalization
 
-variable [CommRing Rₛ] [Algebra R Rₛ]
+variable [CommRing R] (S : Submonoid R) [CommRing Rₛ] [Algebra R Rₛ]
 variable [hT : IsLocalization S Rₛ]
 variable {A : Type*} [CommRing A] [Algebra R A]
 variable (Aₛ : Type*) [CommRing Aₛ] [Algebra A Aₛ]


### PR DESCRIPTION
The existing definition is nonsense over semirings; this replaces it with a more plausible one, such that:
```lean
example : ¬ LinearIndependent ℕ Nat.succ := by
  intro h
  have := @h (.single 3 1) (.single 1 2)
  simp [Finsupp.single_eq_single_iff] at this
```
which was previously true without the `¬`.
Some of the nonsense semiring results following the definition must then be ungeneralized to rings.

I've been conservative here and only generalized the ones that generalizer trivially, and are used by important downstream
applications such as `Basis` on semirings. Unimportant downstream applications have instead been ungeneralized to `Ring`.
Many more results can likely be generalized in future.

Some context at https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/.E2.9C.94.20.60E.2FL.2FF.60.20and.20.60K.2FL'.2FF.60.20isomorphic.20.3D.3E.20.60.5BE.3AL.5D.3D.5BK.3AL'.5D.60/near/408999160.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
