### PR TITLE
[Merged by Bors] - chore (FieldTheory) : lower priority of instance about IsScalarTower and subtype

### DIFF
--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -323,9 +323,9 @@ instance smulCommClass_right [SMul X Y] [SMul L Y] [SMulCommClass X L Y]
     (F : IntermediateField K L) : SMulCommClass X F Y :=
   inferInstanceAs (SMulCommClass X F.toSubfield Y)
 
---Porting note: setting this istance the default priority may trigger trouble to synthize instance
---for field extension with more than one intermedaitefield, example : `IsScalarTower K₁ K₂ E` where
---`K₁ ≤ K₂` are of `intermediatefield F E`
+--note: setting this istance the default priority may trigger trouble to synthize instance
+--for field extension with more than one intermedaite field, example : in a field extension `F/E`,
+--`K₁ ≤ K₂` are of type `intermediatefield F E`, the instance `IsScalarTower K₁ K₂ E`
 /-- Note that this provides `IsScalarTower F K K` which is needed by `smul_mul_assoc`. -/
 instance (priority := 900) [SMul X Y] [SMul L X] [SMul L Y] [IsScalarTower L X Y]
     (F : IntermediateField K L) : IsScalarTower F X Y :=

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -323,9 +323,12 @@ instance smulCommClass_right [SMul X Y] [SMul L Y] [SMulCommClass X L Y]
     (F : IntermediateField K L) : SMulCommClass X F Y :=
   inferInstanceAs (SMulCommClass X F.toSubfield Y)
 
+--Porting note: setting this istance the default priority may trigger trouble to synthize instance
+--for field extension with more than one intermedaitefield, example : `IsScalarTower K₁ K₂ E` where
+--`K₁ ≤ K₂` are of `intermediatefield F E`
 /-- Note that this provides `IsScalarTower F K K` which is needed by `smul_mul_assoc`. -/
-instance [SMul X Y] [SMul L X] [SMul L Y] [IsScalarTower L X Y] (F : IntermediateField K L) :
-    IsScalarTower F X Y :=
+instance (priority := 900) [SMul X Y] [SMul L X] [SMul L Y] [IsScalarTower L X Y]
+    (F : IntermediateField K L) : IsScalarTower F X Y :=
   inferInstanceAs (IsScalarTower F.toSubfield X Y)
 
 instance [SMul L X] [FaithfulSMul L X] (F : IntermediateField K L) : FaithfulSMul F X :=


### PR DESCRIPTION
Lower the priority of instance `IntermediateField.instIsScalarTowerSubtypeMem` to `900`
Because it would cause trouble when synthize instance `IsScalarTower K L E` where `K < L` are `IntermediateField F E`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
