### PR TITLE
[Merged by Bors] - feat: dividing an element of a euclidean domain by its radical

### DIFF
--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -31,8 +31,8 @@ This is different from the radical of an ideal.
 
 ### For Euclidean domains
 
-- `divRadical`: For an element `a` in an Euclidean domain, `a / radical a`.
-- `divRadical_mul`: `divRadical` of a product is the product of `divRadical`s.
+- `EuclideanDomain.divRadical`: For an element `a` in an Euclidean domain, `a / radical a`.
+- `EuclideanDomain.divRadical_mul`: `divRadical` of a product is the product of `divRadical`s.
 - `IsCoprime.divRadical`: `divRadical` of coprime elements are coprime.
 
 ## TODO

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -218,7 +218,7 @@ theorem divRadical_mul {a b : E} (hab : IsCoprime a b) :
 theorem divRadical_dvd_self (a : E) : divRadical a ∣ a := by
   exact Dvd.intro (radical a) (divRadical_mul_radical a)
 
-protected theorem IsCoprime.divRadical {a b : E} (h : IsCoprime a b) :
+theorem _root_.IsCoprime.divRadical {a b : E} (h : IsCoprime a b) :
     IsCoprime (divRadical a) (divRadical b) := by
   rw [← radical_mul_divRadical a] at h
   rw [← radical_mul_divRadical b] at h

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -194,6 +194,10 @@ theorem radical_mul_divRadical (a : E) : radical a * divRadical a = a := by
   ·refine mul_div_cancel_left₀ _ (radical_ne_zero a)
   exact radical_dvd_self a
 
+theorem divRadical_mul_radical (a : E) : divRadical a * radical a = a := by
+  rw [mul_comm]
+  exact radical_mul_divRadical a
+
 theorem divRadical_ne_zero {a : E} (ha : a ≠ 0) : divRadical a ≠ 0 := by
   rw [← radical_mul_divRadical a] at ha
   exact right_ne_zero_of_mul ha
@@ -212,9 +216,7 @@ theorem divRadical_mul {a b : E} (hab : IsCoprime a b) :
   rw [mul_mul_mul_comm, radical_mul_divRadical, radical_mul_divRadical]
 
 theorem divRadical_dvd_self (a : E) : divRadical a ∣ a := by
-  rw [divRadical]
-  apply EuclideanDomain.div_dvd_of_dvd
-  exact radical_dvd_self a
+  exact Dvd.intro (radical a) (divRadical_mul_radical a)
 
 theorem IsCoprime.divRadical {a b : E} (h : IsCoprime a b) :
     IsCoprime (divRadical a) (divRadical b) := by

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -188,14 +188,14 @@ variable {E : Type*} [EuclideanDomain E] [NormalizationMonoid E] [UniqueFactoriz
 /-- For an element `a` in an Euclidean domain, `a / radical a`. -/
 def divRadical (a : E) : E := a / radical a
 
-theorem mul_radical_divRadical (a : E) : radical a * divRadical a = a := by
+theorem radical_mul_divRadical (a : E) : radical a * divRadical a = a := by
   rw [divRadical]
   rw [← EuclideanDomain.mul_div_assoc]
   ·refine mul_div_cancel_left₀ _ (radical_ne_zero a)
   exact radical_dvd_self a
 
 theorem divRadical_ne_zero {a : E} (ha : a ≠ 0) : divRadical a ≠ 0 := by
-  rw [← mul_radical_divRadical a] at ha
+  rw [← radical_mul_divRadical a] at ha
   exact right_ne_zero_of_mul ha
 
 theorem divRadical_isUnit {u : E} (hu : IsUnit u) : IsUnit (divRadical u) := by
@@ -205,15 +205,11 @@ theorem eq_divRadical {a x : E} (h : radical a * x = a) : x = divRadical a := by
   apply EuclideanDomain.eq_div_of_mul_eq_left (radical_ne_zero a)
   rwa [mul_comm]
 
-theorem divRadical_mul {a b : E} (hc : IsCoprime a b) :
+theorem divRadical_mul {a b : E} (hab : IsCoprime a b) :
     divRadical (a * b) = divRadical a * divRadical b := by
-  by_cases ha : a = 0
-  · rw [ha, MulZeroClass.zero_mul, divRadical, EuclideanDomain.zero_div, MulZeroClass.zero_mul]
-  by_cases hb : b = 0
-  · rw [hb, MulZeroClass.mul_zero, divRadical, EuclideanDomain.zero_div, MulZeroClass.mul_zero]
   symm; apply eq_divRadical
-  rw [radical_mul hc]
-  rw [mul_mul_mul_comm, mul_radical_divRadical, mul_radical_divRadical]
+  rw [radical_mul hab]
+  rw [mul_mul_mul_comm, radical_mul_divRadical, radical_mul_divRadical]
 
 theorem divRadical_dvd_self (a : E) : divRadical a ∣ a := by
   rw [divRadical]
@@ -222,8 +218,8 @@ theorem divRadical_dvd_self (a : E) : divRadical a ∣ a := by
 
 theorem IsCoprime.divRadical {a b : E} (h : IsCoprime a b) :
     IsCoprime (divRadical a) (divRadical b) := by
-  rw [← mul_radical_divRadical a] at h
-  rw [← mul_radical_divRadical b] at h
+  rw [← radical_mul_divRadical a] at h
+  rw [← radical_mul_divRadical b] at h
   exact h.of_mul_left_right.of_mul_right_right
 
 end EuclideanDomain

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -185,6 +185,7 @@ namespace EuclideanDomain
 
 variable {E : Type*} [EuclideanDomain E] [NormalizationMonoid E] [UniqueFactorizationMonoid E]
 
+/-- For an element `a` in an Euclidean domain, `a / radical a`. -/
 def divRadical (a : E) : E := a / radical a
 
 theorem mul_radical_divRadical (a : E) : radical a * divRadical a = a := by

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -218,7 +218,7 @@ theorem divRadical_mul {a b : E} (hab : IsCoprime a b) :
 theorem divRadical_dvd_self (a : E) : divRadical a ∣ a := by
   exact Dvd.intro (radical a) (divRadical_mul_radical a)
 
-theorem IsCoprime.divRadical {a b : E} (h : IsCoprime a b) :
+protected theorem IsCoprime.divRadical {a b : E} (h : IsCoprime a b) :
     IsCoprime (divRadical a) (divRadical b) := by
   rw [← radical_mul_divRadical a] at h
   rw [← radical_mul_divRadical b] at h

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -185,7 +185,7 @@ namespace EuclideanDomain
 
 variable {E : Type*} [EuclideanDomain E] [NormalizationMonoid E] [UniqueFactorizationMonoid E]
 
-/-- For an element `a` in an Euclidean domain, `a / radical a`. -/
+/-- Division of an element by its radical in an Euclidean domain. -/
 def divRadical (a : E) : E := a / radical a
 
 theorem radical_mul_divRadical (a : E) : radical a * divRadical a = a := by


### PR DESCRIPTION
For `a` in a `EuclideanDomain`, define `divRadical a` as `a / radical a`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Prove some related theorems.
This is needed in the proof of Mason-Stothers theorem, and also a part of PR #15706.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
