### PR TITLE
[Merged by Bors] - feat(MvPolynomial/Degrees): add `degreeOf` theorems for -,^,∑,∏

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/CommRing.lean
+++ b/Mathlib/Algebra/MvPolynomial/CommRing.lean
@@ -92,6 +92,17 @@ theorem degrees_sub [DecidableEq σ] (p q : MvPolynomial σ R) :
 
 end Degrees
 
+section Degrees
+
+theorem degreeOf_neg (i : σ) (p : MvPolynomial σ R) : degreeOf i (-p) = degreeOf i p := by
+  rw [degreeOf, degreeOf, degrees_neg]
+
+theorem degreeOf_sub_le [DecidableEq σ] (i : σ) (p q : MvPolynomial σ R) :
+    degreeOf i (p - q) ≤ max (degreeOf i p) (degreeOf i q) := by
+  simpa only [sub_eq_add_neg, degreeOf_neg] using degreeOf_add_le i p (-q)
+
+end Degrees
+
 section Vars
 
 @[simp]

--- a/Mathlib/Algebra/MvPolynomial/CommRing.lean
+++ b/Mathlib/Algebra/MvPolynomial/CommRing.lean
@@ -99,7 +99,7 @@ section Degrees
 theorem degreeOf_neg (i : σ) (p : MvPolynomial σ R) : degreeOf i (-p) = degreeOf i p := by
   rw [degreeOf, degreeOf, degrees_neg]
 
-theorem degreeOf_sub_le [DecidableEq σ] (i : σ) (p q : MvPolynomial σ R) :
+theorem degreeOf_sub_le (i : σ) (p q : MvPolynomial σ R) :
     degreeOf i (p - q) ≤ max (degreeOf i p) (degreeOf i q) := by
   simpa only [sub_eq_add_neg, degreeOf_neg] using degreeOf_add_le i p (-q)
 

--- a/Mathlib/Algebra/MvPolynomial/CommRing.lean
+++ b/Mathlib/Algebra/MvPolynomial/CommRing.lean
@@ -83,6 +83,7 @@ variable {σ} (p)
 
 section Degrees
 
+@[simp]
 theorem degrees_neg (p : MvPolynomial σ R) : (-p).degrees = p.degrees := by
   rw [degrees, support_neg]; rfl
 
@@ -94,6 +95,7 @@ end Degrees
 
 section Degrees
 
+@[simp]
 theorem degreeOf_neg (i : σ) (p : MvPolynomial σ R) : degreeOf i (-p) = degreeOf i p := by
   rw [degreeOf, degreeOf, degrees_neg]
 

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -253,38 +253,35 @@ theorem monomial_le_degreeOf (i : σ) {f : MvPolynomial σ R} {m : σ →₀ ℕ
   rw [degreeOf_eq_sup i]
   apply Finset.le_sup h_m
 
--- TODO we can prove equality here if R is a domain
+-- TODO we can prove equality with `NoZeroDivisors R`
 theorem degreeOf_mul_le (i : σ) (f g : MvPolynomial σ R) :
     degreeOf i (f * g) ≤ degreeOf i f + degreeOf i g := by
   classical
-  repeat' rw [degreeOf]
+  repeat rw [degreeOf]
   convert Multiset.count_le_of_le i (degrees_mul f g)
   rw [Multiset.count_add]
-
--- TODO we can prove equality here with `NoZeroDivisors R`
-theorem degreeOf_pow_le [NoZeroDivisors R](i : σ) (p : MvPolynomial σ R) (n : ℕ) :
-    degreeOf i (p ^ n) ≤ n * degreeOf i p := by
-  classical
-  repeat' rw [degreeOf]
-  convert Multiset.count_le_of_le i (degrees_pow p n)
-  rw [Multiset.count_nsmul]
 
 theorem degreeOf_sum_le {ι : Type*} (i : σ) (s : Finset ι) (f : ι → MvPolynomial σ R) :
     degreeOf i (∑ j ∈ s, f j) ≤ s.sup fun j => degreeOf i (f j) := by
   simp_rw [degreeOf_eq_sup]
   exact supDegree_sum_le
 
--- TODO we can prove equality here if R is a domain
+-- TODO we can prove equality with `NoZeroDivisors R`
 theorem degreeOf_prod_le {ι : Type*} (i : σ) (s : Finset ι) (f : ι → MvPolynomial σ R) :
     degreeOf i (∏ j ∈ s, f j) ≤ ∑ j ∈ s, (f j).degreeOf i := by
   simp_rw [degreeOf_eq_sup]
   exact supDegree_prod_le (by simp only [coe_zero, Pi.zero_apply])
     (fun _ _ => by simp only [coe_add, Pi.add_apply])
 
+-- TODO we can prove equality with `NoZeroDivisors R`
+theorem degreeOf_pow_le (i : σ) (p : MvPolynomial σ R) (n : ℕ) :
+    degreeOf i (p ^ n) ≤ n * degreeOf i p := by
+  simpa using degreeOf_prod_le i (Finset.range n) (fun _ => p)
+
 theorem degreeOf_mul_X_ne {i j : σ} (f : MvPolynomial σ R) (h : i ≠ j) :
     degreeOf i (f * X j) = degreeOf i f := by
   classical
-  repeat' rw [degreeOf_eq_sup (R := R) i]
+  repeat rw [degreeOf_eq_sup i]
   rw [support_mul_X]
   simp only [Finset.sup_map]
   congr
@@ -292,11 +289,11 @@ theorem degreeOf_mul_X_ne {i j : σ} (f : MvPolynomial σ R) (h : i ≠ j) :
   simp only [Finsupp.single, Nat.one_ne_zero, add_right_eq_self, addRightEmbedding_apply, coe_mk,
     Pi.add_apply, comp_apply, ite_eq_right_iff, Finsupp.coe_add, Pi.single_eq_of_ne h]
 
--- TODO in the following we have equality iff f ≠ 0
+-- TODO in the following we have equality iff `f ≠ 0` and `Nontrivial R`
 theorem degreeOf_mul_X_eq (j : σ) (f : MvPolynomial σ R) :
     degreeOf j (f * X j) ≤ degreeOf j f + 1 := by
   classical
-  repeat' rw [degreeOf]
+  repeat rw [degreeOf]
   apply (Multiset.count_le_of_le j (degrees_mul f (X j))).trans
   simp only [Multiset.count_add, add_le_add_iff_left]
   convert Multiset.count_le_of_le j (degrees_X' (R := R) j)

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -269,12 +269,12 @@ theorem degreeOf_pow_le (i : σ) (p : MvPolynomial σ R) (n : ℕ) :
   rw [Multiset.count_nsmul]
 
 theorem degreeOf_sum_le {ι : Type*} (i : σ) (s : Finset ι) (f : ι → MvPolynomial σ R) :
-    degreeOf i (∑ j in s, f j) ≤ s.sup fun j => degreeOf i (f j) := by
+    degreeOf i (∑ j ∈ s, f j) ≤ s.sup fun j => degreeOf i (f j) := by
   simp_rw [degreeOf_eq_sup]
   exact supDegree_sum_le
 
 theorem degreeOf_prod_le {ι : Type*} (i : σ) (s : Finset ι) (f : ι → MvPolynomial σ R) :
-    degreeOf i (∏ j in s, f j) ≤ ∑ j in s, (f j).degreeOf i := by
+    degreeOf i (∏ j ∈ s, f j) ≤ ∑ j ∈ s, (f j).degreeOf i := by
   simp_rw [degreeOf_eq_sup]
   exact supDegree_prod_le (by simp only [coe_zero, Pi.zero_apply])
     (fun _ _ => by simp only [coe_add, Pi.add_apply])

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -261,7 +261,8 @@ theorem degreeOf_mul_le (i : σ) (f g : MvPolynomial σ R) :
   convert Multiset.count_le_of_le i (degrees_mul f g)
   rw [Multiset.count_add]
 
-theorem degreeOf_pow_le (i : σ) (p : MvPolynomial σ R) (n : ℕ) :
+-- TODO we can prove equality here with `NoZeroDivisors R`
+theorem degreeOf_pow_le [NoZeroDivisors R](i : σ) (p : MvPolynomial σ R) (n : ℕ) :
     degreeOf i (p ^ n) ≤ n * degreeOf i p := by
   classical
   repeat' rw [degreeOf]
@@ -273,6 +274,7 @@ theorem degreeOf_sum_le {ι : Type*} (i : σ) (s : Finset ι) (f : ι → MvPoly
   simp_rw [degreeOf_eq_sup]
   exact supDegree_sum_le
 
+-- TODO we can prove equality here if R is a domain
 theorem degreeOf_prod_le {ι : Type*} (i : σ) (s : Finset ι) (f : ι → MvPolynomial σ R) :
     degreeOf i (∏ j ∈ s, f j) ≤ ∑ j ∈ s, (f j).degreeOf i := by
   simp_rw [degreeOf_eq_sup]

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -261,6 +261,24 @@ theorem degreeOf_mul_le (i : σ) (f g : MvPolynomial σ R) :
   convert Multiset.count_le_of_le i (degrees_mul f g)
   rw [Multiset.count_add]
 
+theorem degreeOf_pow_le (i : σ) (p : MvPolynomial σ R) (n : ℕ) :
+    degreeOf i (p ^ n) ≤ n * degreeOf i p := by
+  classical
+  repeat' rw [degreeOf]
+  convert Multiset.count_le_of_le i (degrees_pow p n)
+  rw [Multiset.count_nsmul]
+
+theorem degreeOf_sum_le (i : σ) (s : Finset ι) (f : ι → MvPolynomial σ R) :
+    degreeOf i (∑ j in s, f j) ≤ s.sup fun j => degreeOf i (f j) := by
+  simp_rw [degreeOf_eq_sup]
+  exact supDegree_sum_le
+
+theorem degreeOf_prod_le (n : σ) (s : Finset ι) (f : ι → MvPolynomial σ R) :
+    degreeOf n (∏ i in s, f i) ≤ ∑ i in s, (f i).degreeOf n := by
+  simp_rw [degreeOf_eq_sup]
+  exact supDegree_prod_le (by simp only [coe_zero, Pi.zero_apply])
+    (fun _ _ => by simp only [coe_add, Pi.add_apply])
+
 theorem degreeOf_mul_X_ne {i j : σ} (f : MvPolynomial σ R) (h : i ≠ j) :
     degreeOf i (f * X j) = degreeOf i f := by
   classical

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -219,7 +219,7 @@ theorem degreeOf_eq_sup (n : σ) (f : MvPolynomial σ R) :
   rw [degreeOf_def, degrees, Multiset.count_finset_sup]
   congr
   ext
-  simp
+  simp only [count_toMultiset]
 
 theorem degreeOf_lt_iff {n : σ} {f : MvPolynomial σ R} {d : ℕ} (h : 0 < d) :
     degreeOf n f < d ↔ ∀ m : σ →₀ ℕ, m ∈ f.support → m n < d := by
@@ -257,7 +257,7 @@ theorem monomial_le_degreeOf (i : σ) {f : MvPolynomial σ R} {m : σ →₀ ℕ
 theorem degreeOf_mul_le (i : σ) (f g : MvPolynomial σ R) :
     degreeOf i (f * g) ≤ degreeOf i f + degreeOf i g := by
   classical
-  repeat rw [degreeOf]
+  simp only [degreeOf]
   convert Multiset.count_le_of_le i (degrees_mul f g)
   rw [Multiset.count_add]
 
@@ -281,19 +281,17 @@ theorem degreeOf_pow_le (i : σ) (p : MvPolynomial σ R) (n : ℕ) :
 theorem degreeOf_mul_X_ne {i j : σ} (f : MvPolynomial σ R) (h : i ≠ j) :
     degreeOf i (f * X j) = degreeOf i f := by
   classical
-  repeat rw [degreeOf_eq_sup i]
-  rw [support_mul_X]
-  simp only [Finset.sup_map]
+  simp only [degreeOf_eq_sup i, support_mul_X, Finset.sup_map]
   congr
   ext
   simp only [Finsupp.single, Nat.one_ne_zero, add_right_eq_self, addRightEmbedding_apply, coe_mk,
     Pi.add_apply, comp_apply, ite_eq_right_iff, Finsupp.coe_add, Pi.single_eq_of_ne h]
 
--- TODO in the following we have equality iff `f ≠ 0` and `Nontrivial R`
+-- TODO in the following we have equality iff `f ≠ 0`
 theorem degreeOf_mul_X_eq (j : σ) (f : MvPolynomial σ R) :
     degreeOf j (f * X j) ≤ degreeOf j f + 1 := by
   classical
-  repeat rw [degreeOf]
+  simp only [degreeOf]
   apply (Multiset.count_le_of_le j (degrees_mul f (X j))).trans
   simp only [Multiset.count_add, add_le_add_iff_left]
   convert Multiset.count_le_of_le j (degrees_X' (R := R) j)
@@ -303,13 +301,13 @@ theorem degreeOf_C_mul_le (p : MvPolynomial σ R) (i : σ) (c : R) :
     (C c * p).degreeOf i ≤ p.degreeOf i := by
   unfold degreeOf
   convert Multiset.count_le_of_le i <| degrees_mul (C c) p
-  simp [degrees_C]
+  simp only [degrees_C, zero_add]
 
 theorem degreeOf_mul_C_le (p : MvPolynomial σ R) (i : σ) (c : R) :
     (p * C c).degreeOf i ≤ p.degreeOf i := by
   unfold degreeOf
   convert Multiset.count_le_of_le i <| degrees_mul p (C c)
-  simp [degrees_C]
+  simp only [degrees_C, add_zero]
 
 theorem degreeOf_rename_of_injective {p : MvPolynomial σ R} {f : σ → τ} (h : Function.Injective f)
     (i : σ) : degreeOf (f i) (rename f p) = degreeOf i p := by

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -268,13 +268,13 @@ theorem degreeOf_pow_le (i : σ) (p : MvPolynomial σ R) (n : ℕ) :
   convert Multiset.count_le_of_le i (degrees_pow p n)
   rw [Multiset.count_nsmul]
 
-theorem degreeOf_sum_le (i : σ) (s : Finset ι) (f : ι → MvPolynomial σ R) :
+theorem degreeOf_sum_le {ι : Type*} (i : σ) (s : Finset ι) (f : ι → MvPolynomial σ R) :
     degreeOf i (∑ j in s, f j) ≤ s.sup fun j => degreeOf i (f j) := by
   simp_rw [degreeOf_eq_sup]
   exact supDegree_sum_le
 
-theorem degreeOf_prod_le (n : σ) (s : Finset ι) (f : ι → MvPolynomial σ R) :
-    degreeOf n (∏ i in s, f i) ≤ ∑ i in s, (f i).degreeOf n := by
+theorem degreeOf_prod_le {ι : Type*} (i : σ) (s : Finset ι) (f : ι → MvPolynomial σ R) :
+    degreeOf i (∏ j in s, f j) ≤ ∑ j in s, (f j).degreeOf i := by
   simp_rw [degreeOf_eq_sup]
   exact supDegree_prod_le (by simp only [coe_zero, Pi.zero_apply])
     (fun _ _ => by simp only [coe_add, Pi.add_apply])


### PR DESCRIPTION
Add `degreeOf_XXX_le` where `XXX` is `sub`, `pow`, `sum`, and `prod`, following the analogous theorems for `degrees` & complementing the similar theorems for `degreeOf` but with `add` and `mul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
