### PR TITLE
[Merged by Bors] - chore(Order/Interval/Set/Infinite): instance `NoMaxOrder.infinite` and `NoMinOrder.infinite`

### DIFF
--- a/Mathlib/Order/Interval/Set/Infinite.lean
+++ b/Mathlib/Order/Interval/Set/Infinite.lean
@@ -16,15 +16,13 @@ preorder is an infinite type.
 
 variable {α : Type*} [Preorder α]
 
-/-- A nonempty preorder with no maximal element is infinite. This is not an instance to avoid
-a cycle with `Infinite α → Nontrivial α → Nonempty α`. -/
-theorem NoMaxOrder.infinite [Nonempty α] [NoMaxOrder α] : Infinite α :=
+/-- A nonempty preorder with no maximal element is infinite. -/
+instance NoMaxOrder.infinite [Nonempty α] [NoMaxOrder α] : Infinite α :=
   let ⟨f, hf⟩ := Nat.exists_strictMono α
   Infinite.of_injective f hf.injective
 
-/-- A nonempty preorder with no minimal element is infinite. This is not an instance to avoid
-a cycle with `Infinite α → Nontrivial α → Nonempty α`. -/
-theorem NoMinOrder.infinite [Nonempty α] [NoMinOrder α] : Infinite α :=
+/-- A nonempty preorder with no minimal element is infinite. -/
+instance NoMinOrder.infinite [Nonempty α] [NoMinOrder α] : Infinite α :=
   @NoMaxOrder.infinite αᵒᵈ _ _ _
 
 namespace Set

--- a/Mathlib/Order/Interval/Set/Infinite.lean
+++ b/Mathlib/Order/Interval/Set/Infinite.lean
@@ -21,10 +21,8 @@ instance NoMaxOrder.infinite [Nonempty α] [NoMaxOrder α] : Infinite α :=
   let ⟨f, hf⟩ := Nat.exists_strictMono α
   Infinite.of_injective f hf.injective
 
-/-- A nonempty preorder with no minimal element is infinite.
-This instance has lower priority to avoid the cycle `Infinite α → Nontrivial α → Nonempty α` if possible.
--/
-instance (priority := 100) NoMinOrder.infinite [Nonempty α] [NoMinOrder α] : Infinite α :=
+/-- A nonempty preorder with no minimal element is infinite. -/
+instance NoMinOrder.infinite [Nonempty α] [NoMinOrder α] : Infinite α :=
   @NoMaxOrder.infinite αᵒᵈ _ _ _
 
 namespace Set

--- a/Mathlib/Order/Interval/Set/Infinite.lean
+++ b/Mathlib/Order/Interval/Set/Infinite.lean
@@ -16,10 +16,8 @@ preorder is an infinite type.
 
 variable {α : Type*} [Preorder α]
 
-/-- A nonempty preorder with no maximal element is infinite.
-This instance has lower priority to avoid the cycle `Infinite α → Nontrivial α → Nonempty α` if possible.
--/
-instance (priority := 100) NoMaxOrder.infinite [Nonempty α] [NoMaxOrder α] : Infinite α :=
+/-- A nonempty preorder with no maximal element is infinite. -/
+instance NoMaxOrder.infinite [Nonempty α] [NoMaxOrder α] : Infinite α :=
   let ⟨f, hf⟩ := Nat.exists_strictMono α
   Infinite.of_injective f hf.injective
 

--- a/Mathlib/Order/Interval/Set/Infinite.lean
+++ b/Mathlib/Order/Interval/Set/Infinite.lean
@@ -23,8 +23,10 @@ instance (priority := 100) NoMaxOrder.infinite [Nonempty α] [NoMaxOrder α] : I
   let ⟨f, hf⟩ := Nat.exists_strictMono α
   Infinite.of_injective f hf.injective
 
-/-- A nonempty preorder with no minimal element is infinite. -/
-instance NoMinOrder.infinite [Nonempty α] [NoMinOrder α] : Infinite α :=
+/-- A nonempty preorder with no minimal element is infinite.
+This instance has lower priority to avoid the cycle `Infinite α → Nontrivial α → Nonempty α` if possible.
+-/
+instance (priority := 100) NoMinOrder.infinite [Nonempty α] [NoMinOrder α] : Infinite α :=
   @NoMaxOrder.infinite αᵒᵈ _ _ _
 
 namespace Set

--- a/Mathlib/Order/Interval/Set/Infinite.lean
+++ b/Mathlib/Order/Interval/Set/Infinite.lean
@@ -16,8 +16,10 @@ preorder is an infinite type.
 
 variable {α : Type*} [Preorder α]
 
-/-- A nonempty preorder with no maximal element is infinite. -/
-instance NoMaxOrder.infinite [Nonempty α] [NoMaxOrder α] : Infinite α :=
+/-- A nonempty preorder with no maximal element is infinite.
+This instance has lower priority to avoid the cycle `Infinite α → Nontrivial α → Nonempty α` if possible.
+-/
+instance (priority := 100) NoMaxOrder.infinite [Nonempty α] [NoMaxOrder α] : Infinite α :=
   let ⟨f, hf⟩ := Nat.exists_strictMono α
   Infinite.of_injective f hf.injective
 


### PR DESCRIPTION
These instances are no longer problematic in Lean 4.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
