### PR TITLE
[Merged by Bors] - feat(RingTheory/Valuation/Integers): `dvdNotUnit_iff_lt`

### DIFF
--- a/Mathlib/RingTheory/Valuation/Integers.lean
+++ b/Mathlib/RingTheory/Valuation/Integers.lean
@@ -139,11 +139,11 @@ theorem isUnit_of_one' (hv : Integers v O) {x : O} (hvx : v (algebraMap O F x) =
   refine isUnit_of_one hv (IsUnit.mk0 _ ?_) hvx
   simp only [← v.ne_zero_iff, hvx, ne_eq, one_ne_zero, not_false_eq_true]
 
-lemma isUnit_iff_v_eq_one (hv : Integers v O) {x : O} :
+lemma isUnit_iff_valuation_eq_one (hv : Integers v O) {x : O} :
     IsUnit x ↔ v (algebraMap O F x) = 1 :=
   ⟨hv.one_of_isUnit, hv.isUnit_of_one'⟩
 
-lemma pos_v_iff_ne_zero (hv : Integers v O) {x : O} :
+lemma valuation_pos_iff_ne_zero (hv : Integers v O) {x : O} :
     0 < v (algebraMap O F x) ↔ x ≠ 0 := by
   rw [← not_le]
   refine not_congr ?_
@@ -155,12 +155,12 @@ theorem dvdNotUnit_iff_lt (hv : Integers v O) {x y : O} :
   refine ⟨?_, And.elim dvdNotUnit_of_dvd_of_not_dvd⟩
   rintro ⟨hx0, d, hdu, rfl⟩
   refine ⟨⟨d, rfl⟩, ?_⟩
-  rw [hv.isUnit_iff_v_eq_one, ← ne_eq, ne_iff_lt_iff_le.mpr (hv.map_le_one d)] at hdu
+  rw [hv.isUnit_iff_valuation_eq_one, ← ne_eq, ne_iff_lt_iff_le.mpr (hv.map_le_one d)] at hdu
   rw [dvd_iff_le hv]
   simp only [_root_.map_mul, not_le]
   contrapose! hdu
   refine one_le_of_le_mul_left₀ ?_ hdu
-  simp [hv.pos_v_iff_ne_zero, hx0]
+  simp [hv.valuation_pos_iff_ne_zero, hx0]
 
 theorem eq_algebraMap_or_inv_eq_algebraMap (hv : Integers v O) (x : F) :
     ∃ a : O, x = algebraMap O F a ∨ x⁻¹ = algebraMap O F a := by
@@ -190,13 +190,11 @@ lemma isPrincipal_iff_exists_eq_setOf_valuation_le (hv : Integers v O) {I : Idea
   rw [isPrincipal_iff_exists_isGreatest hv]
   constructor <;> rintro ⟨x, hx⟩
   · obtain ⟨a, ha, rfl⟩ : ∃ a ∈ I, (v ∘ algebraMap O F) a = x := by simpa using hx.left
-    have := hx.right
-    simp at this
     refine ⟨a, ?_⟩
     ext b
     simp only [SetLike.mem_coe, mem_setOf_eq]
     constructor <;> intro h
-    · exact this (Set.mem_image_of_mem _ h)
+    · exact hx.right (Set.mem_image_of_mem _ h)
     · rw [le_iff_dvd hv] at h
       exact Ideal.mem_of_dvd I h ha
   · refine ⟨v (algebraMap O F x), Set.mem_image_of_mem _ ?_, ?_⟩

--- a/Mathlib/RingTheory/Valuation/Integers.lean
+++ b/Mathlib/RingTheory/Valuation/Integers.lean
@@ -139,6 +139,29 @@ theorem isUnit_of_one' (hv : Integers v O) {x : O} (hvx : v (algebraMap O F x) =
   refine isUnit_of_one hv (IsUnit.mk0 _ ?_) hvx
   simp only [← v.ne_zero_iff, hvx, ne_eq, one_ne_zero, not_false_eq_true]
 
+lemma isUnit_iff_v_eq_one (hv : Integers v O) {x : O} :
+    IsUnit x ↔ v (algebraMap O F x) = 1 :=
+  ⟨hv.one_of_isUnit, hv.isUnit_of_one'⟩
+
+lemma pos_v_iff_ne_zero (hv : Integers v O) {x : O} :
+    0 < v (algebraMap O F x) ↔ x ≠ 0 := by
+  rw [← not_le]
+  refine not_congr ?_
+  simp [map_eq_zero_iff _ hv.hom_inj]
+
+theorem dvdNotUnit_iff_lt (hv : Integers v O) {x y : O} :
+    DvdNotUnit x y ↔ v (algebraMap O F y) < v (algebraMap O F x) := by
+  rw [lt_iff_le_not_le, hv.le_iff_dvd, hv.le_iff_dvd]
+  refine ⟨?_, And.elim dvdNotUnit_of_dvd_of_not_dvd⟩
+  rintro ⟨hx0, d, hdu, rfl⟩
+  refine ⟨⟨d, rfl⟩, ?_⟩
+  rw [hv.isUnit_iff_v_eq_one, ← ne_eq, ne_iff_lt_iff_le.mpr (hv.map_le_one d)] at hdu
+  rw [dvd_iff_le hv]
+  simp only [_root_.map_mul, not_le]
+  contrapose! hdu
+  refine one_le_of_le_mul_left₀ ?_ hdu
+  simp [hv.pos_v_iff_ne_zero, hx0]
+
 theorem eq_algebraMap_or_inv_eq_algebraMap (hv : Integers v O) (x : F) :
     ∃ a : O, x = algebraMap O F a ∨ x⁻¹ = algebraMap O F a := by
   rcases val_le_one_or_val_inv_le_one v x with h | h <;>
@@ -161,6 +184,24 @@ lemma isPrincipal_iff_exists_isGreatest (hv : Integers v O) {I : Ideal O} :
     ext b
     simp only [Ideal.submodule_span_eq, Ideal.mem_span_singleton]
     exact ⟨fun hb ↦ dvd_of_le hv (hx.2 <| mem_image_of_mem _ hb), fun hb ↦ I.mem_of_dvd hb ha⟩
+
+lemma isPrincipal_iff_exists_eq_setOf_valuation_le (hv : Integers v O) {I : Ideal O} :
+    I.IsPrincipal ↔ ∃ x, (I : Set O) = {y | v (algebraMap O F y) ≤ v (algebraMap O F x)} := by
+  rw [isPrincipal_iff_exists_isGreatest hv]
+  constructor <;> rintro ⟨x, hx⟩
+  · obtain ⟨a, ha, rfl⟩ : ∃ a ∈ I, (v ∘ algebraMap O F) a = x := by simpa using hx.left
+    have := hx.right
+    simp at this
+    refine ⟨a, ?_⟩
+    ext b
+    simp only [SetLike.mem_coe, mem_setOf_eq]
+    constructor <;> intro h
+    · exact this (Set.mem_image_of_mem _ h)
+    · rw [le_iff_dvd hv] at h
+      exact Ideal.mem_of_dvd I h ha
+  · refine ⟨v (algebraMap O F x), Set.mem_image_of_mem _ ?_, ?_⟩
+    · simp [hx]
+    · simp [hx, mem_upperBounds]
 
 lemma not_denselyOrdered_of_isPrincipalIdealRing [IsPrincipalIdealRing O] (hv : Integers v O) :
     ¬ DenselyOrdered (range v) := by


### PR DESCRIPTION
And `isPrincipal_iff_exists_eq_setOf_valuation_le`

in preparation for showing `WfDvdMonoid`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
