### PR TITLE
[Merged by Bors] - feat: `IsCoprime.wronskian_eq_zero_iff`

### DIFF
--- a/Mathlib/RingTheory/Polynomial/Wronskian.lean
+++ b/Mathlib/RingTheory/Polynomial/Wronskian.lean
@@ -120,12 +120,8 @@ variable {k : Type*} [Field k]
 theorem dvd_derivative_iff {a : k[X]} : a ∣ derivative a ↔ derivative a = 0 where
   mp h := by
     by_cases a_nz : a = 0
-    · rw [a_nz]; simp only [derivative_zero]
-    by_contra deriv_nz
-    have deriv_lt := degree_derivative_lt a_nz
-    have le_deriv := Polynomial.degree_le_of_dvd h deriv_nz
-    have lt_self := le_deriv.trans_lt deriv_lt
-    simp only [lt_self_iff_false] at lt_self
+    · simp only [a_nz, derivative_zero]
+    exact eq_zero_of_dvd_of_degree_lt h (degree_derivative_lt a_nz)
   mpr h := by simp [h]
 
 /--

--- a/Mathlib/RingTheory/Polynomial/Wronskian.lean
+++ b/Mathlib/RingTheory/Polynomial/Wronskian.lean
@@ -117,9 +117,8 @@ theorem natDegree_wronskian_lt_add {a b : R[X]} (hw : wronskian a b ≠ 0) :
 variable {k : Type*} [Field k]
 
 @[simp]
-theorem dvd_derivative_iff {a : k[X]} : a ∣ derivative a ↔ derivative a = 0 := by
-  constructor
-  · intro h
+theorem dvd_derivative_iff {a : k[X]} : a ∣ derivative a ↔ derivative a = 0 where
+  mp h := by
     by_cases a_nz : a = 0
     · rw [a_nz]; simp only [derivative_zero]
     by_contra deriv_nz
@@ -127,16 +126,15 @@ theorem dvd_derivative_iff {a : k[X]} : a ∣ derivative a ↔ derivative a = 0 
     have le_deriv := Polynomial.degree_le_of_dvd h deriv_nz
     have lt_self := le_deriv.trans_lt deriv_lt
     simp only [lt_self_iff_false] at lt_self
-  intro h; rw [h]; simp
+  mpr h := by simp [h]
 
 /--
 For coprime polynomials `a` and `b`, their Wronskian is zero
 if and only if their derivatives are constants.
 -/
 theorem IsCoprime.wronskian_eq_zero_iff {a b : k[X]} (hc : IsCoprime a b) :
-    wronskian a b = 0 ↔ derivative a = 0 ∧ derivative b = 0 := by
-  constructor
-  · intro hw
+    wronskian a b = 0 ↔ derivative a = 0 ∧ derivative b = 0 where
+  mp hw := by
     rw [wronskian, sub_eq_iff_eq_add, zero_add] at hw
     constructor
     · rw [← dvd_derivative_iff]
@@ -145,9 +143,9 @@ theorem IsCoprime.wronskian_eq_zero_iff {a b : k[X]} (hc : IsCoprime a b) :
     · rw [← dvd_derivative_iff]
       apply hc.symm.dvd_of_dvd_mul_left
       rw [hw]; exact dvd_mul_left _ _
-  intro hdab
-  cases' hdab with hda hdb
-  rw [wronskian]
-  rw [hda, hdb]; simp only [MulZeroClass.mul_zero, MulZeroClass.zero_mul, sub_self]
+  mpr hdab := by
+    cases' hdab with hda hdb
+    rw [wronskian]
+    rw [hda, hdb]; simp only [MulZeroClass.mul_zero, MulZeroClass.zero_mul, sub_self]
 
 end Polynomial

--- a/Mathlib/RingTheory/Polynomial/Wronskian.lean
+++ b/Mathlib/RingTheory/Polynomial/Wronskian.lean
@@ -130,7 +130,7 @@ theorem dvd_derivative_iff {a : k[X]} : a ∣ derivative a ↔ derivative a = 0 
 
 /--
 For coprime polynomials `a` and `b`, their Wronskian is zero
-if and only if their derivatives are constants.
+if and only if their derivatives are zeros.
 -/
 theorem IsCoprime.wronskian_eq_zero_iff {a b : k[X]} (hc : IsCoprime a b) :
     wronskian a b = 0 ↔ derivative a = 0 ∧ derivative b = 0 where

--- a/Mathlib/RingTheory/Polynomial/Wronskian.lean
+++ b/Mathlib/RingTheory/Polynomial/Wronskian.lean
@@ -1,11 +1,12 @@
 /-
-Copyright (c) 2024 Jineon Back and Seewoo Lee. All rights reserved.
+Copyright (c) 2024 Jineon Baek and Seewoo Lee. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jineon Baek, Seewoo Lee
 -/
 import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.Algebra.Polynomial.Derivative
 import Mathlib.LinearAlgebra.SesquilinearForm
+import Mathlib.RingTheory.Coprime.Basic
 
 /-!
 # Wronskian of a pair of polynomial
@@ -112,5 +113,41 @@ theorem natDegree_wronskian_lt_add {a b : R[X]} (hw : wronskian a b ≠ 0) :
   · exact Polynomial.degree_eq_natDegree hw
   · exact Polynomial.degree_eq_natDegree ha
   · exact Polynomial.degree_eq_natDegree hb
+
+variable {k : Type*} [Field k]
+
+@[simp]
+theorem dvd_derivative_iff {a : k[X]} : a ∣ derivative a ↔ derivative a = 0 := by
+  constructor
+  · intro h
+    by_cases a_nz : a = 0
+    · rw [a_nz]; simp only [derivative_zero]
+    by_contra deriv_nz
+    have deriv_lt := degree_derivative_lt a_nz
+    have le_deriv := Polynomial.degree_le_of_dvd h deriv_nz
+    have lt_self := le_deriv.trans_lt deriv_lt
+    simp only [lt_self_iff_false] at lt_self
+  intro h; rw [h]; simp
+
+/--
+For coprime polynomials `a` and `b`, their Wronskian is zero
+if and only if their derivatives are constants.
+-/
+theorem IsCoprime.wronskian_eq_zero_iff {a b : k[X]} (hc : IsCoprime a b) :
+    wronskian a b = 0 ↔ derivative a = 0 ∧ derivative b = 0 := by
+  constructor
+  · intro hw
+    rw [wronskian, sub_eq_iff_eq_add, zero_add] at hw
+    constructor
+    · rw [← dvd_derivative_iff]
+      apply hc.dvd_of_dvd_mul_right
+      rw [← hw]; exact dvd_mul_right _ _
+    · rw [← dvd_derivative_iff]
+      apply hc.symm.dvd_of_dvd_mul_left
+      rw [hw]; exact dvd_mul_left _ _
+  intro hdab
+  cases' hdab with hda hdb
+  rw [wronskian]
+  rw [hda, hdb]; simp only [MulZeroClass.mul_zero, MulZeroClass.zero_mul, sub_self]
 
 end Polynomial


### PR DESCRIPTION
Add `IsCoprime.wronskian_eq_zero_iff`: For two polynomials $a, b \in k[x]$ over a field, $W(a, b) = 0$ if and only if $a' = b' = 0$. This is a part of PR #15706.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
