### PR TITLE
[Merged by Bors] - chore(Algebra/Group/Subgroup): split MulOpposite

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -292,6 +292,7 @@ import Mathlib.Algebra.Group.Subgroup.Basic
 import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Algebra.Group.Subgroup.Finite
 import Mathlib.Algebra.Group.Subgroup.MulOpposite
+import Mathlib.Algebra.Group.Subgroup.MulOppositeLemmas
 import Mathlib.Algebra.Group.Subgroup.Order
 import Mathlib.Algebra.Group.Subgroup.Pointwise
 import Mathlib.Algebra.Group.Subgroup.ZPowers

--- a/Mathlib/Algebra/Group/Subgroup/MulOpposite.lean
+++ b/Mathlib/Algebra/Group/Subgroup/MulOpposite.lean
@@ -3,9 +3,8 @@ Copyright (c) 2022 Alex Kontorovich. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex Kontorovich, Eric Wieser
 -/
-import Mathlib.Algebra.Group.Subgroup.Basic
+import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Algebra.Group.Submonoid.MulOpposite
-import Mathlib.Logic.Encodable.Basic
 
 /-!
 # Mul-opposite subgroups
@@ -28,12 +27,14 @@ protected def op (H : Subgroup G) : Subgroup Gᵐᵒᵖ where
   mul_mem' ha hb := H.mul_mem hb ha
   inv_mem' := H.inv_mem
 
+/-
 /- We redeclare this instance to get keys
 `SMul (@Subtype (MulOpposite _) (@Membership.mem (MulOpposite _)
   (Subgroup (MulOpposite _) _) _ (@Subgroup.op _ _ _))) _`
 compared to the keys for `Submonoid.smul`
 `SMul (@Subtype _ (@Membership.mem _ (Submonoid _ _) _ _)) _` -/
 @[to_additive] instance instSMul (H : Subgroup G) : SMul H.op G := Submonoid.smul ..
+-/
 
 @[to_additive (attr := simp)]
 theorem mem_op {x : Gᵐᵒᵖ} {S : Subgroup G} : x ∈ S.op ↔ x.unop ∈ S := Iff.rfl
@@ -104,102 +105,10 @@ theorem op_inj {S T : Subgroup G} : S.op = T.op ↔ S = T := opEquiv.eq_iff_eq
 @[to_additive (attr := simp)]
 theorem unop_inj {S T : Subgroup Gᵐᵒᵖ} : S.unop = T.unop ↔ S = T := opEquiv.symm.eq_iff_eq
 
-@[to_additive (attr := simp)]
-theorem op_bot : (⊥ : Subgroup G).op = ⊥ := opEquiv.map_bot
-
-@[to_additive (attr := simp)]
-theorem op_eq_bot {S : Subgroup G} : S.op = ⊥ ↔ S = ⊥ := op_injective.eq_iff' op_bot
-
-@[to_additive (attr := simp)]
-theorem unop_bot : (⊥ : Subgroup Gᵐᵒᵖ).unop = ⊥ := opEquiv.symm.map_bot
-
-@[to_additive (attr := simp)]
-theorem unop_eq_bot {S : Subgroup Gᵐᵒᵖ} : S.unop = ⊥ ↔ S = ⊥ := unop_injective.eq_iff' unop_bot
-
-@[to_additive (attr := simp)]
-theorem op_top : (⊤ : Subgroup G).op = ⊤ := rfl
-
-@[to_additive (attr := simp)]
-theorem op_eq_top {S : Subgroup G} : S.op = ⊤ ↔ S = ⊤ := op_injective.eq_iff' op_top
-
-@[to_additive (attr := simp)]
-theorem unop_top : (⊤ : Subgroup Gᵐᵒᵖ).unop = ⊤ := rfl
-
-@[to_additive (attr := simp)]
-theorem unop_eq_top {S : Subgroup Gᵐᵒᵖ} : S.unop = ⊤ ↔ S = ⊤ := unop_injective.eq_iff' unop_top
-
-@[to_additive]
-theorem op_sup (S₁ S₂ : Subgroup G) : (S₁ ⊔ S₂).op = S₁.op ⊔ S₂.op :=
-  opEquiv.map_sup _ _
-
-@[to_additive]
-theorem unop_sup (S₁ S₂ : Subgroup Gᵐᵒᵖ) : (S₁ ⊔ S₂).unop = S₁.unop ⊔ S₂.unop :=
-  opEquiv.symm.map_sup _ _
-
-@[to_additive]
-theorem op_inf (S₁ S₂ : Subgroup G) : (S₁ ⊓ S₂).op = S₁.op ⊓ S₂.op := rfl
-
-@[to_additive]
-theorem unop_inf (S₁ S₂ : Subgroup Gᵐᵒᵖ) : (S₁ ⊓ S₂).unop = S₁.unop ⊓ S₂.unop := rfl
-
-@[to_additive]
-theorem op_sSup (S : Set (Subgroup G)) : (sSup S).op = sSup (.unop ⁻¹' S) :=
-  opEquiv.map_sSup_eq_sSup_symm_preimage _
-
-@[to_additive]
-theorem unop_sSup (S : Set (Subgroup Gᵐᵒᵖ)) : (sSup S).unop = sSup (.op ⁻¹' S) :=
-  opEquiv.symm.map_sSup_eq_sSup_symm_preimage _
-
-@[to_additive]
-theorem op_sInf (S : Set (Subgroup G)) : (sInf S).op = sInf (.unop ⁻¹' S) :=
-  opEquiv.map_sInf_eq_sInf_symm_preimage _
-
-@[to_additive]
-theorem unop_sInf (S : Set (Subgroup Gᵐᵒᵖ)) : (sInf S).unop = sInf (.op ⁻¹' S) :=
-  opEquiv.symm.map_sInf_eq_sInf_symm_preimage _
-
-@[to_additive]
-theorem op_iSup (S : ι → Subgroup G) : (iSup S).op = ⨆ i, (S i).op := opEquiv.map_iSup _
-
-@[to_additive]
-theorem unop_iSup (S : ι → Subgroup Gᵐᵒᵖ) : (iSup S).unop = ⨆ i, (S i).unop :=
-  opEquiv.symm.map_iSup _
-
-@[to_additive]
-theorem op_iInf (S : ι → Subgroup G) : (iInf S).op = ⨅ i, (S i).op := opEquiv.map_iInf _
-
-@[to_additive]
-theorem unop_iInf (S : ι → Subgroup Gᵐᵒᵖ) : (iInf S).unop = ⨅ i, (S i).unop :=
-  opEquiv.symm.map_iInf _
-
-@[to_additive]
-theorem op_closure (s : Set G) : (closure s).op = closure (MulOpposite.unop ⁻¹' s) := by
-  simp_rw [closure, op_sInf, Set.preimage_setOf_eq, Subgroup.unop_coe]
-  congr with a
-  exact MulOpposite.unop_surjective.forall
-
-@[to_additive]
-theorem unop_closure (s : Set Gᵐᵒᵖ) : (closure s).unop = closure (MulOpposite.op ⁻¹' s) := by
-  rw [← op_inj, op_unop, op_closure]
-  simp_rw [Set.preimage_preimage, MulOpposite.op_unop, Set.preimage_id']
-
 /-- Bijection between a subgroup `H` and its opposite. -/
 @[to_additive (attr := simps!) "Bijection between an additive subgroup `H` and its opposite."]
 def equivOp (H : Subgroup G) : H ≃ H.op :=
   MulOpposite.opEquiv.subtypeEquiv fun _ => Iff.rfl
-
-@[to_additive]
-instance (H : Subgroup G) [Encodable H] : Encodable H.op :=
-  Encodable.ofEquiv H H.equivOp.symm
-
-@[to_additive]
-instance (H : Subgroup G) [Countable H] : Countable H.op :=
-  Countable.of_equiv H H.equivOp
-
-@[to_additive]
-theorem smul_opposite_mul {H : Subgroup G} (x g : G) (h : H.op) :
-    h • (g * x) = g * h • x :=
-  mul_assoc _ _ _
 
 @[to_additive]
 theorem op_normalizer (H : Subgroup G) : H.normalizer.op = H.op.normalizer := by
@@ -209,23 +118,5 @@ theorem op_normalizer (H : Subgroup G) : H.normalizer.op = H.op.normalizer := by
 @[to_additive]
 theorem unop_normalizer (H : Subgroup Gᵐᵒᵖ) : H.normalizer.unop = H.unop.normalizer := by
   rw [← op_inj, op_unop, op_normalizer, op_unop]
-
-@[to_additive (attr := simp)]
-theorem normal_op {H : Subgroup G} : H.op.Normal ↔ H.Normal := by
-  simp only [← normalizer_eq_top, ← op_normalizer, op_eq_top]
-
-@[to_additive] alias ⟨Normal.of_op, Normal.op⟩ := normal_op
-
-@[to_additive]
-instance op.instNormal {H : Subgroup G} [H.Normal] : H.op.Normal := .op ‹_›
-
-@[to_additive (attr := simp)]
-theorem normal_unop {H : Subgroup Gᵐᵒᵖ} : H.unop.Normal ↔ H.Normal := by
-  rw [← normal_op, op_unop]
-
-@[to_additive] alias ⟨Normal.of_unop, Normal.unop⟩ := normal_unop
-
-@[to_additive]
-instance unop.instNormal {H : Subgroup Gᵐᵒᵖ} [H.Normal] : H.unop.Normal := .unop ‹_›
 
 end Subgroup

--- a/Mathlib/Algebra/Group/Subgroup/MulOpposite.lean
+++ b/Mathlib/Algebra/Group/Subgroup/MulOpposite.lean
@@ -27,15 +27,6 @@ protected def op (H : Subgroup G) : Subgroup Gᵐᵒᵖ where
   mul_mem' ha hb := H.mul_mem hb ha
   inv_mem' := H.inv_mem
 
-/-
-/- We redeclare this instance to get keys
-`SMul (@Subtype (MulOpposite _) (@Membership.mem (MulOpposite _)
-  (Subgroup (MulOpposite _) _) _ (@Subgroup.op _ _ _))) _`
-compared to the keys for `Submonoid.smul`
-`SMul (@Subtype _ (@Membership.mem _ (Submonoid _ _) _ _)) _` -/
-@[to_additive] instance instSMul (H : Subgroup G) : SMul H.op G := Submonoid.smul ..
--/
-
 @[to_additive (attr := simp)]
 theorem mem_op {x : Gᵐᵒᵖ} {S : Subgroup G} : x ∈ S.op ↔ x.unop ∈ S := Iff.rfl
 

--- a/Mathlib/Algebra/Group/Subgroup/MulOppositeLemmas.lean
+++ b/Mathlib/Algebra/Group/Subgroup/MulOppositeLemmas.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2022 Alex Kontorovich. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Kontorovich, Eric Wieser
+-/
+import Mathlib.Algebra.Group.Subgroup.Basic
+import Mathlib.Algebra.Group.Subgroup.MulOpposite
+import Mathlib.Algebra.Group.Submonoid.MulOpposite
+import Mathlib.Logic.Encodable.Basic
+
+/-!
+# Mul-opposite subgroups
+
+This file contains a somewhat arbitrary assortment of results on the opposite subgroup `H.op`
+that rely on further theory to define. As such it is a somewhat arbitrary assortment of results,
+which might be organized and split up further.
+
+## Tags
+subgroup, subgroups
+
+-/
+
+variable {ι : Sort*} {G : Type*} [Group G]
+
+namespace Subgroup
+
+/- We redeclare this instance to get keys
+`SMul (@Subtype (MulOpposite _) (@Membership.mem (MulOpposite _)
+  (Subgroup (MulOpposite _) _) _ (@Subgroup.op _ _ _))) _`
+compared to the keys for `Submonoid.smul`
+`SMul (@Subtype _ (@Membership.mem _ (Submonoid _ _) _ _)) _` -/
+@[to_additive] instance instSMul (H : Subgroup G) : SMul H.op G := Submonoid.smul ..
+
+/-! ### Lattice results -/
+
+@[to_additive (attr := simp)]
+theorem op_bot : (⊥ : Subgroup G).op = ⊥ := opEquiv.map_bot
+
+@[to_additive (attr := simp)]
+theorem op_eq_bot {S : Subgroup G} : S.op = ⊥ ↔ S = ⊥ := op_injective.eq_iff' op_bot
+
+@[to_additive (attr := simp)]
+theorem unop_bot : (⊥ : Subgroup Gᵐᵒᵖ).unop = ⊥ := opEquiv.symm.map_bot
+
+@[to_additive (attr := simp)]
+theorem unop_eq_bot {S : Subgroup Gᵐᵒᵖ} : S.unop = ⊥ ↔ S = ⊥ := unop_injective.eq_iff' unop_bot
+
+@[to_additive (attr := simp)]
+theorem op_top : (⊤ : Subgroup G).op = ⊤ := rfl
+
+@[to_additive (attr := simp)]
+theorem op_eq_top {S : Subgroup G} : S.op = ⊤ ↔ S = ⊤ := op_injective.eq_iff' op_top
+
+@[to_additive (attr := simp)]
+theorem unop_top : (⊤ : Subgroup Gᵐᵒᵖ).unop = ⊤ := rfl
+
+@[to_additive (attr := simp)]
+theorem unop_eq_top {S : Subgroup Gᵐᵒᵖ} : S.unop = ⊤ ↔ S = ⊤ := unop_injective.eq_iff' unop_top
+
+@[to_additive]
+theorem op_sup (S₁ S₂ : Subgroup G) : (S₁ ⊔ S₂).op = S₁.op ⊔ S₂.op :=
+  opEquiv.map_sup _ _
+
+@[to_additive]
+theorem unop_sup (S₁ S₂ : Subgroup Gᵐᵒᵖ) : (S₁ ⊔ S₂).unop = S₁.unop ⊔ S₂.unop :=
+  opEquiv.symm.map_sup _ _
+
+@[to_additive]
+theorem op_inf (S₁ S₂ : Subgroup G) : (S₁ ⊓ S₂).op = S₁.op ⊓ S₂.op := rfl
+
+@[to_additive]
+theorem unop_inf (S₁ S₂ : Subgroup Gᵐᵒᵖ) : (S₁ ⊓ S₂).unop = S₁.unop ⊓ S₂.unop := rfl
+
+@[to_additive]
+theorem op_sSup (S : Set (Subgroup G)) : (sSup S).op = sSup (.unop ⁻¹' S) :=
+  opEquiv.map_sSup_eq_sSup_symm_preimage _
+
+@[to_additive]
+theorem unop_sSup (S : Set (Subgroup Gᵐᵒᵖ)) : (sSup S).unop = sSup (.op ⁻¹' S) :=
+  opEquiv.symm.map_sSup_eq_sSup_symm_preimage _
+
+@[to_additive]
+theorem op_sInf (S : Set (Subgroup G)) : (sInf S).op = sInf (.unop ⁻¹' S) :=
+  opEquiv.map_sInf_eq_sInf_symm_preimage _
+
+@[to_additive]
+theorem unop_sInf (S : Set (Subgroup Gᵐᵒᵖ)) : (sInf S).unop = sInf (.op ⁻¹' S) :=
+  opEquiv.symm.map_sInf_eq_sInf_symm_preimage _
+
+@[to_additive]
+theorem op_iSup (S : ι → Subgroup G) : (iSup S).op = ⨆ i, (S i).op := opEquiv.map_iSup _
+
+@[to_additive]
+theorem unop_iSup (S : ι → Subgroup Gᵐᵒᵖ) : (iSup S).unop = ⨆ i, (S i).unop :=
+  opEquiv.symm.map_iSup _
+
+@[to_additive]
+theorem op_iInf (S : ι → Subgroup G) : (iInf S).op = ⨅ i, (S i).op := opEquiv.map_iInf _
+
+@[to_additive]
+theorem unop_iInf (S : ι → Subgroup Gᵐᵒᵖ) : (iInf S).unop = ⨅ i, (S i).unop :=
+  opEquiv.symm.map_iInf _
+
+@[to_additive]
+theorem op_closure (s : Set G) : (closure s).op = closure (MulOpposite.unop ⁻¹' s) := by
+  simp_rw [closure, op_sInf, Set.preimage_setOf_eq, Subgroup.unop_coe]
+  congr with a
+  exact MulOpposite.unop_surjective.forall
+
+@[to_additive]
+theorem unop_closure (s : Set Gᵐᵒᵖ) : (closure s).unop = closure (MulOpposite.op ⁻¹' s) := by
+  rw [← op_inj, op_unop, op_closure]
+  simp_rw [Set.preimage_preimage, MulOpposite.op_unop, Set.preimage_id']
+
+@[to_additive]
+instance (H : Subgroup G) [Encodable H] : Encodable H.op :=
+  Encodable.ofEquiv H H.equivOp.symm
+
+@[to_additive]
+instance (H : Subgroup G) [Countable H] : Countable H.op :=
+  Countable.of_equiv H H.equivOp
+
+@[to_additive]
+theorem smul_opposite_mul {H : Subgroup G} (x g : G) (h : H.op) :
+    h • (g * x) = g * h • x :=
+  mul_assoc _ _ _
+
+@[to_additive (attr := simp)]
+theorem normal_op {H : Subgroup G} : H.op.Normal ↔ H.Normal := by
+  simp only [← normalizer_eq_top, ← op_normalizer, op_eq_top]
+
+@[to_additive] alias ⟨Normal.of_op, Normal.op⟩ := normal_op
+
+@[to_additive]
+instance op.instNormal {H : Subgroup G} [H.Normal] : H.op.Normal := .op ‹_›
+
+@[to_additive (attr := simp)]
+theorem normal_unop {H : Subgroup Gᵐᵒᵖ} : H.unop.Normal ↔ H.Normal := by
+  rw [← normal_op, op_unop]
+
+@[to_additive] alias ⟨Normal.of_unop, Normal.unop⟩ := normal_unop
+
+@[to_additive]
+instance unop.instNormal {H : Subgroup Gᵐᵒᵖ} [H.Normal] : H.unop.Normal := .unop ‹_›
+
+end Subgroup

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Algebra.Group.Subgroup.MulOpposite
+import Mathlib.Algebra.Group.Subgroup.MulOppositeLemmas
 import Mathlib.Algebra.Group.Submonoid.Pointwise
 import Mathlib.GroupTheory.GroupAction.ConjAct
 

--- a/Mathlib/GroupTheory/Coset/Basic.lean
+++ b/Mathlib/GroupTheory/Coset/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Mitchell Rowett. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mitchell Rowett, Kim Morrison
 -/
-import Mathlib.Algebra.Group.Subgroup.MulOpposite
+import Mathlib.Algebra.Group.Subgroup.Basic
 import Mathlib.Algebra.Quotient
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Set.Pointwise.SMul

--- a/Mathlib/GroupTheory/Coset/Defs.lean
+++ b/Mathlib/GroupTheory/Coset/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mitchell Rowett, Kim Morrison
 -/
 import Mathlib.Algebra.Quotient
+import Mathlib.Algebra.Group.Action.Opposite
 import Mathlib.Algebra.Group.Subgroup.MulOpposite
 import Mathlib.GroupTheory.GroupAction.Defs
 

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -5,6 +5,7 @@ Authors: Kevin Buzzard, Patrick Massot
 -/
 -- This file is to a certain extent based on `quotient_module.lean` by Johannes Hölzl.
 
+import Mathlib.Algebra.Group.Subgroup.Basic
 import Mathlib.GroupTheory.Congruence.Hom
 import Mathlib.GroupTheory.Coset.Defs
 


### PR DESCRIPTION
This PR splits off results from `MulOpposite.lean` into a new file `MulOppositeLemmas.lean` if they rely on more complicated theory. The goal is that the definition of a quotient group should rely on the least amount of theory possible.

Hoard factor change:
 * `master`: 0.896884 per-decl; 0.605522 per-module
 * `split-Subgroup.MulOpposite`: 0.896895 per-decl; 0.605601 per-module

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
