### PR TITLE
feat: prepare for removing @[simp] from Sum.forall and Sum.exists

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/CombinedProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/CombinedProducts.lean
@@ -19,6 +19,8 @@ We provide constructors for combining (co)fans and show their (co)limit properti
 
 universe u₁ u₂
 
+attribute [local simp] Sum.forall
+
 namespace CategoryTheory
 
 namespace Limits

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -706,11 +706,11 @@ theorem fix_aux {α σ} (f : α →. σ ⊕ α) (a : α) (b : σ) :
   · rcases h with ⟨n, ⟨_x, h₁⟩, h₂⟩
     have : ∀ m a', Sum.inr a' ∈ F a m → b ∈ PFun.fix f a' → b ∈ PFun.fix f a := by
       intro m a' am ba
-      induction' m with m IH generalizing a' <;> simp [F] at am
+      induction' m with m IH generalizing a' <;> simp [F, Sum.exists] at am
       · rwa [← am]
       rcases am with ⟨a₂, am₂, fa₂⟩
       exact IH _ am₂ (PFun.mem_fix_iff.2 (Or.inr ⟨_, fa₂, ba⟩))
-    cases n <;> simp [F] at h₂
+    cases n <;> simp [F, Sum.exists] at h₂
     rcases h₂ with (h₂ | ⟨a', am', fa'⟩)
     · cases' h₁ (Nat.lt_succ_self _) with a' h
       injection mem_unique h h₂
@@ -724,9 +724,9 @@ theorem fix_aux {α σ} (f : α →. σ ⊕ α) (a : α) (b : σ) :
     intro a₂ h₂ IH k hk
     rcases PFun.mem_fix_iff.1 h₂ with (h₂ | ⟨a₃, am₃, _⟩)
     · refine ⟨k.succ, ?_, fun m mk km => ⟨a₂, ?_⟩⟩
-      · simpa [F] using Or.inr ⟨_, hk, h₂⟩
+      · simpa [F, Sum.exists] using Or.inr ⟨_, hk, h₂⟩
       · rwa [le_antisymm (Nat.le_of_lt_succ mk) km]
-    · rcases IH _ am₃ k.succ (by simpa [F] using ⟨_, hk, am₃⟩) with ⟨n, hn₁, hn₂⟩
+    · rcases IH _ am₃ k.succ (by simpa [F, Sum.exists] using ⟨_, hk, am₃⟩) with ⟨n, hn₁, hn₂⟩
       refine ⟨n, hn₁, fun m mn km => ?_⟩
       cases' km.lt_or_eq_dec with km km
       · exact hn₂ _ mn km
@@ -742,6 +742,6 @@ theorem fix {f : α →. σ ⊕ α} (hf : Partrec f) : Partrec (PFun.fix f) := b
   have hp : Partrec₂ p :=
     hF.map ((sum_casesOn Computable.id (const true).to₂ (const false).to₂).comp snd).to₂
   exact (hp.rfind.bind (hF.bind (sum_casesOn_right snd snd.to₂ none.to₂).to₂).to₂).of_eq fun a =>
-    ext fun b => by simpa [p] using fix_aux f _ _
+    ext fun b => by simpa [p, Sum.exists] using fix_aux f _ _
 
 end Partrec

--- a/Mathlib/Data/Finset/Sum.lean
+++ b/Mathlib/Data/Finset/Sum.lean
@@ -22,6 +22,8 @@ the `Finset.sum` operation which computes the additive sum.
 
 open Function Multiset Sum
 
+attribute [local simp] Sum.forall Sum.exists
+
 namespace Finset
 
 variable {α β : Type*} (s : Finset α) (t : Finset β)

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -108,12 +108,12 @@ lemma fromRows_toRows (A : Matrix (m₁ ⊕ m₂) n R) : fromRows A.toRows₁ A.
 
 lemma fromRows_inj : Function.Injective2 (@fromRows R m₁ m₂ n) := by
   intros x1 x2 y1 y2
-  simp only [funext_iff, ← Matrix.ext_iff]
+  simp only [funext_iff, ← Matrix.ext_iff, Sum.forall]
   aesop
 
 lemma fromColumns_inj : Function.Injective2 (@fromColumns R m n₁ n₂) := by
   intros x1 x2 y1 y2
-  simp only [funext_iff, ← Matrix.ext_iff]
+  simp only [funext_iff, ← Matrix.ext_iff, Sum.forall]
   aesop
 
 lemma fromColumns_ext_iff (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (B₁ : Matrix m n₁ R)

--- a/Mathlib/Data/Matroid/Sum.lean
+++ b/Mathlib/Data/Matroid/Sum.lean
@@ -226,21 +226,22 @@ protected def sum (M : Matroid α) (N : Matroid β) : Matroid (α ⊕ β) :=
 
 @[simp] lemma sum_ground (M : Matroid α) (N : Matroid β) :
     (M.sum N).E = (.inl '' M.E) ∪ (.inr '' N.E) := by
-  simp [Matroid.sum, Set.ext_iff, mapEquiv, mapEmbedding, Equiv.ulift, Equiv.sumEquivSigmaBool]
+  simp [Matroid.sum, Set.ext_iff, mapEquiv, mapEmbedding, Equiv.ulift, Equiv.sumEquivSigmaBool,
+    Sum.exists]
 
 @[simp] lemma sum_indep_iff (M : Matroid α) (N : Matroid β) {I : Set (α ⊕ β)} :
     (M.sum N).Indep I ↔ M.Indep (.inl ⁻¹' I) ∧ N.Indep (.inr ⁻¹' I) := by
   simp only [Matroid.sum, mapEquiv_indep_iff, Equiv.sumCongr_symm, Equiv.sumCongr_apply,
     Equiv.symm_symm, sigma_indep_iff, Bool.forall_bool, Equiv.ulift_apply]
   convert Iff.rfl <;>
-    simp [Set.ext_iff, Equiv.ulift, Equiv.sumEquivSigmaBool]
+    simp [Set.ext_iff, Equiv.ulift, Equiv.sumEquivSigmaBool, Sum.exists]
 
 @[simp] lemma sum_base_iff {M : Matroid α} {N : Matroid β} {B : Set (α ⊕ β)} :
     (M.sum N).Base B ↔ M.Base (.inl ⁻¹' B) ∧ N.Base (.inr ⁻¹' B) := by
   simp only [Matroid.sum, mapEquiv_base_iff, Equiv.sumCongr_symm, Equiv.sumCongr_apply,
     Equiv.symm_symm, sigma_base_iff, Bool.forall_bool, Equiv.ulift_apply]
   convert Iff.rfl <;>
-    simp [Set.ext_iff, Equiv.ulift, Equiv.sumEquivSigmaBool]
+    simp [Set.ext_iff, Equiv.ulift, Equiv.sumEquivSigmaBool, Sum.exists]
 
 @[simp] lemma sum_basis_iff {M : Matroid α} {N : Matroid β} {I X : Set (α ⊕ β)} :
     (M.sum N).Basis I X ↔
@@ -248,7 +249,7 @@ protected def sum (M : Matroid α) (N : Matroid β) : Matroid (α ⊕ β) :=
   simp only [Matroid.sum, mapEquiv_basis_iff, Equiv.sumCongr_symm,
     Equiv.sumCongr_apply, Equiv.symm_symm, sigma_basis_iff, Bool.forall_bool, Equiv.ulift_apply,
     Equiv.sumEquivSigmaBool, Equiv.coe_fn_mk, Equiv.ulift]
-  convert Iff.rfl <;> exact ext <| by simp
+  convert Iff.rfl <;> exact ext <| by simp [Sum.exists]
 
 end Sum
 

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -59,6 +59,8 @@ end get
 
 open Function (update update_eq_iff update_comp_eq_of_injective update_comp_eq_of_forall_ne)
 
+attribute [local simp] Sum.forall
+
 @[simp]
 theorem update_elim_inl [DecidableEq α] [DecidableEq (α ⊕ β)] {f : α → γ} {g : β → γ} {i : α}
     {x : γ} : update (Sum.elim f g) (inl i) x = Sum.elim (update f i x) g :=

--- a/Mathlib/Logic/Embedding/Set.lean
+++ b/Mathlib/Logic/Embedding/Set.lean
@@ -158,7 +158,7 @@ variable {α ι : Type*} {s t r : Set α}
 
 @[simp] theorem Function.Embedding.sumSet_range {s t : Set α} (h : Disjoint s t) :
     range (Function.Embedding.sumSet h) = s ∪ t := by
-  simp [Set.ext_iff]
+  simp [Set.ext_iff, Sum.exists]
 
 /-- For an indexed family `s : ι → Set α` of disjoint sets,
 the natural injection from the sigma-type `(i : ι) × ↑(s i)` to `α`. -/

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -498,7 +498,7 @@ theorem fundamentalDomain_stdBasis :
         (Set.univ.pi fun _ => Set.Ico 0 1) ×ˢ
         (Set.univ.pi fun _ => Complex.measurableEquivPi⁻¹' (Set.univ.pi fun _ => Set.Ico 0 1)) := by
   ext
-  simp [stdBasis, mem_fundamentalDomain, Complex.measurableEquivPi]
+  simp [stdBasis, mem_fundamentalDomain, Complex.measurableEquivPi, Sum.forall]
 
 theorem volume_fundamentalDomain_stdBasis :
     volume (fundamentalDomain (stdBasis K)) = 1 := by

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -486,7 +486,7 @@ theorem cof_eq_one_iff_is_succ {o} : cof.{u} o = 1 ↔ ∃ a, o = succ a :=
         exact x.2
       · suffices r x a ∨ ∃ _ : PUnit.{u}, ↑a = x by
           convert this
-          dsimp [RelEmbedding.ofMonotone]; simp
+          dsimp [RelEmbedding.ofMonotone]; simp [Sum.exists]
         rcases trichotomous_of r x a with (h | h | h)
         · exact Or.inl h
         · exact Or.inr ⟨PUnit.unit, h.symm⟩

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -793,13 +793,13 @@ instance instAddLeftMono : AddLeftMono Ordinal.{u} where
   elim c a b := by
     refine inductionOn₃ a b c fun α r _ β s _ γ t _ ⟨f⟩ ↦
       (RelEmbedding.ofMonotone (Sum.recOn · Sum.inl (Sum.inr ∘ f)) ?_).ordinal_type_le
-    simp [f.map_rel_iff]
+    simp [f.map_rel_iff, Sum.forall]
 
 instance instAddRightMono : AddRightMono Ordinal.{u} where
   elim c a b := by
     refine inductionOn₃ a b c fun α r _ β s _ γ t _  ⟨f⟩ ↦
       (RelEmbedding.ofMonotone (Sum.recOn · (Sum.inl ∘ f) Sum.inr) ?_).ordinal_type_le
-    simp [f.map_rel_iff]
+    simp [f.map_rel_iff, Sum.forall]
 
 theorem le_add_right (a b : Ordinal) : a ≤ a + b := by
   simpa only [add_zero] using add_le_add_left (Ordinal.zero_le b) a
@@ -828,7 +828,7 @@ private theorem succ_le_iff' {a b : Ordinal} : a + 1 ≤ b ↔ a < b := by
   · refine ⟨((InitialSeg.leAdd _ _).trans f).toPrincipalSeg fun h ↦ ?_⟩
     simpa using h (f (Sum.inr PUnit.unit))
   · apply (RelEmbedding.ofMonotone (Sum.recOn · f fun _ ↦ f.top) ?_).ordinal_type_le
-    simpa [f.map_rel_iff] using f.lt_top
+    simpa [f.map_rel_iff, Sum.forall] using f.lt_top
 
 instance noMaxOrder : NoMaxOrder Ordinal :=
   ⟨fun _ => ⟨_, succ_le_iff'.1 le_rfl⟩⟩


### PR DESCRIPTION
I would like to remove `@[simp]` from `Sum.forall` and `Sum.exists`, per https://github.com/leanprover/lean4/pull/5900.

The right hand sides of these lemmas are more complicated, and moreover they cause many problems with simp lemma confluence. (Confluence tool coming soon!)

This PR pre-emptively prepares Mathlib for this change. If we can't get it review in time I can just make these lemmas into simp lemmas globally in Mathlib.