### PR TITLE
[Merged by Bors] - fix: make sure that a MeasurableSpace instance uses Discreteness

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/AddChar.lean
+++ b/Mathlib/MeasureTheory/Constructions/AddChar.lean
@@ -20,6 +20,7 @@ Give the definition in the correct generality.
 namespace AddChar
 variable {A M : Type*} [AddMonoid A] [Monoid M] [MeasurableSpace A] [MeasurableSpace M]
 
+@[nolint unusedArguments]
 instance instMeasurableSpace [DiscreteMeasurableSpace A] [DiscreteMeasurableSpace M] :
     MeasurableSpace (AddChar A M) :=
   ⊤

--- a/Mathlib/MeasureTheory/Constructions/AddChar.lean
+++ b/Mathlib/MeasureTheory/Constructions/AddChar.lean
@@ -18,10 +18,14 @@ Give the definition in the correct generality.
 -/
 
 namespace AddChar
-variable {A M : Type*} [AddMonoid A] [Monoid M]
-  [MeasurableSpace A] [DiscreteMeasurableSpace A] [MeasurableSpace M] [DiscreteMeasurableSpace M]
+variable {A M : Type*} [AddMonoid A] [Monoid M] [MeasurableSpace A] [MeasurableSpace M]
 
-instance instMeasurableSpace : MeasurableSpace (AddChar A M) := ⊤
-instance instDiscreteMeasurableSpace : DiscreteMeasurableSpace (AddChar A M) := ⟨fun _ ↦ trivial⟩
+instance instMeasurableSpace [DiscreteMeasurableSpace A] [DiscreteMeasurableSpace M] :
+    MeasurableSpace (AddChar A M) :=
+  ⊤
+
+instance instDiscreteMeasurableSpace [DiscreteMeasurableSpace A] [DiscreteMeasurableSpace M] :
+    DiscreteMeasurableSpace (AddChar A M) :=
+  ⟨fun _ ↦ trivial⟩
 
 end AddChar


### PR DESCRIPTION
The discreteness assumptions were intended, but not used: they are now.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Mathlib.2FMeasureTheory.2FConstructions.2FAddChar.2Elean)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
