### PR TITLE
[Merged by Bors] - chore: more unused variables

### DIFF
--- a/Mathlib/Algebra/Module/ZLattice/Covolume.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Covolume.lean
@@ -33,7 +33,7 @@ open Submodule MeasureTheory Module MeasureTheory Module ZSpan
 
 section General
 
-variable {E : Type*} [NormedAddCommGroup E] [ProperSpace E] [MeasurableSpace E] (L : Submodule ℤ E)
+variable {E : Type*} [NormedAddCommGroup E] [MeasurableSpace E] (L : Submodule ℤ E)
 
 /-- The covolume of a `ℤ`-lattice is the volume of some fundamental domain; see
 `ZLattice.covolume_eq_volume` for the proof that the volume does not depend on the choice of

--- a/Mathlib/Algebra/MvPolynomial/Supported.lean
+++ b/Mathlib/Algebra/MvPolynomial/Supported.lean
@@ -25,11 +25,11 @@ universe u v w
 
 namespace MvPolynomial
 
-variable {σ τ : Type*} {R : Type u} {S : Type v} {r : R} {e : ℕ} {n m : σ}
+variable {σ : Type*} {R : Type u}
 
 section CommSemiring
 
-variable [CommSemiring R] {p q : MvPolynomial σ R}
+variable [CommSemiring R] {p : MvPolynomial σ R}
 variable (R)
 
 /-- The set of polynomials whose variables are contained in `s` as a `Subalgebra` over `R`. -/

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -347,7 +347,7 @@ end FormalMultilinearSeries
 
 section
 
-variable {f g : E → F} {p pf pg : FormalMultilinearSeries 𝕜 E F} {s t : Set E} {x : E} {r r' : ℝ≥0∞}
+variable {f g : E → F} {p pf : FormalMultilinearSeries 𝕜 E F} {s t : Set E} {x : E} {r r' : ℝ≥0∞}
 
 /-- Given a function `f : E → F` and a formal multilinear series `p`, we say that `f` has `p` as
 a power series on the ball of radius `r > 0` around `x` if `f (x + y) = ∑' pₙ yⁿ` for all `‖y‖ < r`.

--- a/Mathlib/Analysis/Analytic/CPolynomial.lean
+++ b/Mathlib/Analysis/Analytic/CPolynomial.lean
@@ -390,8 +390,6 @@ section
 /-! We study what happens when we change the origin of a finite formal multilinear series `p`. The
 main point is that the new series `p.changeOrigin x` is still finite, with the same bound. -/
 
-variable (p : FormalMultilinearSeries 𝕜 E F) {x y : E} {r R : ℝ≥0}
-
 /-- If `p` is a formal multilinear series such that `p m = 0` for `n ≤ m`, then
 `p.changeOriginSeriesTerm k l = 0` for `n ≤ k + l`. -/
 lemma changeOriginSeriesTerm_bound (p : FormalMultilinearSeries 𝕜 E F) {n : ℕ}

--- a/Mathlib/Analysis/Analytic/ChangeOrigin.lean
+++ b/Mathlib/Analysis/Analytic/ChangeOrigin.lean
@@ -45,7 +45,7 @@ namespace FormalMultilinearSeries
 
 section
 
-variable (p : FormalMultilinearSeries 𝕜 E F) {x y : E} {r R : ℝ≥0}
+variable (p : FormalMultilinearSeries 𝕜 E F) {x y : E} {r : ℝ≥0}
 
 /-- A term of `FormalMultilinearSeries.changeOriginSeries`.
 
@@ -236,7 +236,7 @@ end
 
 -- From this point on, assume that the space is complete, to make sure that series that converge
 -- in norm also converge in `F`.
-variable [CompleteSpace F] (p : FormalMultilinearSeries 𝕜 E F) {x y : E} {r R : ℝ≥0}
+variable [CompleteSpace F] (p : FormalMultilinearSeries 𝕜 E F) {x y : E}
 
 theorem hasFPowerSeriesOnBall_changeOrigin (k : ℕ) (hr : 0 < p.radius) :
     HasFPowerSeriesOnBall (fun x => p.changeOrigin x k) (p.changeOriginSeries k) 0 p.radius :=

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -125,8 +125,6 @@ section
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 variable {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
-variable {G : Type*} [NormedAddCommGroup G] [NormedSpace 𝕜 G]
-variable {G' : Type*} [NormedAddCommGroup G'] [NormedSpace 𝕜 G']
 
 /-- A function `f` has the continuous linear map `f'` as derivative along the filter `L` if
 `f x' = f x + f' (x' - x) + o (x' - x)` when `x'` converges along the filter `L`. This definition
@@ -196,7 +194,6 @@ def Differentiable (f : E → F) :=
 variable {𝕜}
 variable {f f₀ f₁ g : E → F}
 variable {f' f₀' f₁' g' : E →L[𝕜] F}
-variable (e : E →L[𝕜] F)
 variable {x : E}
 variable {s t : Set E}
 variable {L L₁ L₂ : Filter E}

--- a/Mathlib/Analysis/Convex/Exposed.lean
+++ b/Mathlib/Analysis/Convex/Exposed.lean
@@ -60,7 +60,7 @@ end PreorderSemiring
 section OrderedRing
 
 variable {𝕜 : Type*} {E : Type*} [TopologicalSpace 𝕜] [OrderedRing 𝕜] [AddCommMonoid E]
-  [TopologicalSpace E] [Module 𝕜 E] {l : E →L[𝕜] 𝕜} {A B C : Set E} {X : Finset E} {x : E}
+  [TopologicalSpace E] [Module 𝕜 E] {l : E →L[𝕜] 𝕜} {A B C : Set E} {x : E}
 
 /-- A useful way to build exposed sets from intersecting `A` with halfspaces (modelled by an
 inequality with a functional). -/
@@ -209,7 +209,7 @@ end OrderedRing
 section LinearOrderedRing
 
 variable {𝕜 : Type*} {E : Type*} [TopologicalSpace 𝕜] [LinearOrderedRing 𝕜] [AddCommMonoid E]
-  [TopologicalSpace E] [Module 𝕜 E] {A B C : Set E}
+  [TopologicalSpace E] [Module 𝕜 E] {A B : Set E}
 
 namespace IsExposed
 

--- a/Mathlib/Analysis/Convex/Extreme.lean
+++ b/Mathlib/Analysis/Convex/Extreme.lean
@@ -156,7 +156,7 @@ end SMul
 section OrderedSemiring
 
 variable [OrderedSemiring 𝕜] [AddCommGroup E] [AddCommGroup F] [∀ i, AddCommGroup (π i)]
-  [Module 𝕜 E] [Module 𝕜 F] [∀ i, Module 𝕜 (π i)] {A B : Set E} {x : E}
+  [Module 𝕜 E] [Module 𝕜 F] [∀ i, Module 𝕜 (π i)] {A B : Set E}
 
 theorem IsExtreme.convex_diff (hA : Convex 𝕜 A) (hAB : IsExtreme 𝕜 A B) : Convex 𝕜 (A \ B) :=
   convex_iff_openSegment_subset.2 fun _ ⟨hx₁A, hx₁B⟩ _ ⟨hx₂A, _⟩ _ hx ↦
@@ -225,7 +225,7 @@ end OrderedRing
 section LinearOrderedRing
 
 variable [LinearOrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E]
-variable [DenselyOrdered 𝕜] [NoZeroSMulDivisors 𝕜 E] {A B : Set E} {x : E}
+variable [DenselyOrdered 𝕜] [NoZeroSMulDivisors 𝕜 E] {A : Set E} {x : E}
 
 /-- A useful restatement using `segment`: `x` is an extreme point iff the only (closed) segments
 that contain it are those with `x` as one of their endpoints. -/

--- a/Mathlib/Analysis/Convex/Independent.lean
+++ b/Mathlib/Analysis/Convex/Independent.lean
@@ -49,7 +49,7 @@ variable {𝕜 E ι : Type*}
 
 section OrderedSemiring
 
-variable (𝕜) [OrderedSemiring 𝕜] [AddCommGroup E] [Module 𝕜 E] {s t : Set E}
+variable (𝕜) [OrderedSemiring 𝕜] [AddCommGroup E] [Module 𝕜 E]
 
 /-- An indexed family is said to be convex independent if every point only belongs to convex hulls
 of sets containing it. -/

--- a/Mathlib/Analysis/Convex/Join.lean
+++ b/Mathlib/Analysis/Convex/Join.lean
@@ -104,7 +104,7 @@ end OrderedSemiring
 
 section LinearOrderedField
 
-variable [LinearOrderedField 𝕜] [AddCommGroup E] [Module 𝕜 E] {s t u : Set E} {x y : E}
+variable [LinearOrderedField 𝕜] [AddCommGroup E] [Module 𝕜 E] {s t : Set E} {x : E}
 
 theorem convexJoin_assoc_aux (s t u : Set E) :
     convexJoin 𝕜 (convexJoin 𝕜 s t) u ⊆ convexJoin 𝕜 s (convexJoin 𝕜 t u) := by

--- a/Mathlib/Analysis/Convex/Quasiconvex.lean
+++ b/Mathlib/Analysis/Convex/Quasiconvex.lean
@@ -29,7 +29,7 @@ quasiconcavity, and monotonicity implies quasilinearity.
 
 open Function OrderDual Set
 
-variable {𝕜 E F β : Type*}
+variable {𝕜 E β : Type*}
 
 section OrderedSemiring
 
@@ -37,7 +37,7 @@ variable [OrderedSemiring 𝕜]
 
 section AddCommMonoid_E
 
-variable [AddCommMonoid E] [AddCommMonoid F]
+variable [AddCommMonoid E]
 
 section LE_β
 
@@ -105,7 +105,7 @@ end Semilattice_β
 
 section LinearOrder_β
 
-variable [LinearOrder β] [SMul 𝕜 E] {s : Set E} {f g : E → β}
+variable [LinearOrder β] [SMul 𝕜 E] {s : Set E} {f : E → β}
 
 theorem quasiconvexOn_iff_le_max : QuasiconvexOn 𝕜 s f ↔ Convex 𝕜 s ∧ ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄,
     y ∈ s → ∀ ⦃a b : 𝕜⦄, 0 ≤ a → 0 ≤ b → a + b = 1 → f (a • x + b • y) ≤ max (f x) (f y) :=

--- a/Mathlib/Analysis/Convex/SimplicialComplex/Basic.lean
+++ b/Mathlib/Analysis/Convex/SimplicialComplex/Basic.lean
@@ -43,7 +43,7 @@ Simplicial complexes can be generalized to affine spaces once `ConvexHull` has b
 
 open Finset Set
 
-variable (𝕜 E : Type*) {ι : Type*} [OrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E]
+variable (𝕜 E : Type*) [OrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E]
 
 namespace Geometry
 

--- a/Mathlib/Analysis/Convex/StoneSeparation.lean
+++ b/Mathlib/Analysis/Convex/StoneSeparation.lean
@@ -20,7 +20,7 @@ complement is convex.
 
 open Set
 
-variable {𝕜 E ι : Type*} [LinearOrderedField 𝕜] [AddCommGroup E] [Module 𝕜 E] {s t : Set E}
+variable {𝕜 E : Type*} [LinearOrderedField 𝕜] [AddCommGroup E] [Module 𝕜 E] {s t : Set E}
 
 /-- In a tetrahedron with vertices `x`, `y`, `p`, `q`, any segment `[u, v]` joining the opposite
 edges `[x, p]` and `[y, q]` passes through any triangle of vertices `p`, `q`, `z` where

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -59,7 +59,6 @@ noncomputable section
 
 variable {ι ι' 𝕜 : Type*} [RCLike 𝕜]
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
-variable {E' : Type*} [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E']
 variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F]
 variable {F' : Type*} [NormedAddCommGroup F'] [InnerProductSpace ℝ F']
 

--- a/Mathlib/CategoryTheory/SmallObject/Construction.lean
+++ b/Mathlib/CategoryTheory/SmallObject/Construction.lean
@@ -62,7 +62,7 @@ variable {C : Type u} [Category.{v} C] {I : Type w} {A B : I → C} (f : ∀ i, 
 
 section
 
-variable {S : C} {X Y Z : C} (πX : X ⟶ S) (πY : Y ⟶ S) (φ : X ⟶ Y)
+variable {S : C} {X Y : C} (πX : X ⟶ S) (πY : Y ⟶ S) (φ : X ⟶ Y)
 
 /-- Given a family of morphisms `f i : A i ⟶ B i` and a morphism `πX : X ⟶ S`,
 this type parametrizes the commutative squares with a morphism `f i` on the left

--- a/Mathlib/CategoryTheory/Widesubcategory.lean
+++ b/Mathlib/CategoryTheory/Widesubcategory.lean
@@ -33,7 +33,7 @@ open MorphismProperty
 section Induced
 
 variable {C : Type u₁} (D : Type u₂) [Category.{v₁} D]
-variable (F : C → D) (P : MorphismProperty D) [IsMultiplicative P]
+variable (F : C → D) (P : MorphismProperty D) [P.IsMultiplicative]
 
 /-- `InducedWideCategory D F P`, where `F : C → D`, is a typeclass synonym for `C`,
 which provides a category structure so that the morphisms `X ⟶ Y` are the morphisms

--- a/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
@@ -72,7 +72,7 @@ lemma threeAPFree_sphere {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 namespace Behrend
 
-variable {α β : Type*} {n d k N : ℕ} {x : Fin n → ℕ}
+variable {n d k N : ℕ} {x : Fin n → ℕ}
 
 /-!
 ### Turning the sphere into 3AP-free set

--- a/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
@@ -46,7 +46,7 @@ the size of the biggest 3AP-free subset of `{0, ..., n - 1}`.
 open Finset Function
 open scoped Pointwise
 
-variable {F α β 𝕜 E : Type*}
+variable {F α β : Type*}
 
 section ThreeAPFree
 
@@ -101,7 +101,7 @@ theorem threeGPFree_pi {ι : Type*} {α : ι → Type*} [∀ i, Monoid (α i)] {
 end Monoid
 
 section CommMonoid
-variable [CommMonoid α] [CommMonoid β] {s A : Set α} {t B : Set β} {f : α → β} {a : α}
+variable [CommMonoid α] [CommMonoid β] {s A : Set α} {t : Set β} {f : α → β}
 
 /-- Geometric progressions of length three are reflected under `2`-Freiman homomorphisms. -/
 @[to_additive
@@ -388,7 +388,7 @@ end RothNumber
 
 section rothNumberNat
 
-variable {s : Finset ℕ} {k n : ℕ}
+variable {k n : ℕ}
 
 /-- The Roth number of a natural `N` is the largest integer `m` for which there is a subset of
 `range N` of size `m` with no arithmetic progression of length 3.

--- a/Mathlib/Combinatorics/Additive/Corner/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Defs.lean
@@ -23,7 +23,7 @@ variable {G H : Type*}
 
 section AddCommMonoid
 variable [AddCommMonoid G] [AddCommMonoid H] {A B : Set (G × G)} {s : Set G} {t : Set H} {f : G → H}
-  {a b c x₁ y₁ x₂ y₂ : G}
+  {x₁ y₁ x₂ y₂ : G}
 
 /-- A **corner** of a set `A` in an abelian group is a triple of points of the form
 `(x, y), (x + d, y), (x, y + d)`. It is **nontrivial** if `d ≠ 0`.

--- a/Mathlib/Combinatorics/Additive/FreimanHom.lean
+++ b/Mathlib/Combinatorics/Additive/FreimanHom.lean
@@ -67,7 +67,7 @@ variable {F α β γ : Type*}
 
 section CommMonoid
 variable [CommMonoid α] [CommMonoid β] [CommMonoid γ] {A A₁ A₂ : Set α}
-  {B B₁ B₂ : Set β} {C : Set γ} {f f₁ f₂ : α → β} {g : β → γ} {m n : ℕ}
+  {B B₁ B₂ : Set β} {C : Set γ} {f f₁ f₂ : α → β} {g : β → γ} {n : ℕ}
 
 /-- An additive `n`-Freiman homomorphism from a set `A` to a set `B` is a map which preserves sums
 of `n` elements. -/
@@ -323,7 +323,7 @@ lemma IsMulFreimanIso.mono {hmn : m ≤ n} (hf : IsMulFreimanIso n A B f) :
 end CancelCommMonoid
 
 section DivisionCommMonoid
-variable [CommMonoid α] [DivisionCommMonoid β] {A : Set α} {B : Set β} {f : α → β} {m n : ℕ}
+variable [CommMonoid α] [DivisionCommMonoid β] {A : Set α} {B : Set β} {f : α → β} {n : ℕ}
 
 @[to_additive]
 lemma IsMulFreimanHom.inv (hf : IsMulFreimanHom n A B f) : IsMulFreimanHom n A B⁻¹ f⁻¹ where

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -413,7 +413,7 @@ protected theorem CliqueFree.sup_edge (h : G.CliqueFree n) (v w : α) :
 end CliqueFree
 
 section CliqueFreeOn
-variable {s s₁ s₂ : Set α} {t : Finset α} {a b : α} {m n : ℕ}
+variable {s s₁ s₂ : Set α} {a : α} {m n : ℕ}
 
 /-- `G.CliqueFreeOn s n` means that `G` has no `n`-cliques contained in `s`. -/
 def CliqueFreeOn (G : SimpleGraph α) (s : Set α) (n : ℕ) : Prop :=
@@ -475,7 +475,7 @@ end CliqueFreeOn
 
 section CliqueSet
 
-variable {n : ℕ} {a b c : α} {s : Finset α}
+variable {n : ℕ} {s : Finset α}
 
 /-- The `n`-cliques in a graph as a set. -/
 def cliqueSet (n : ℕ) : Set (Finset α) :=
@@ -545,7 +545,7 @@ end CliqueSet
 
 section CliqueFinset
 
-variable [Fintype α] [DecidableEq α] [DecidableRel G.Adj] {n : ℕ} {a b c : α} {s : Finset α}
+variable [Fintype α] [DecidableEq α] [DecidableRel G.Adj] {n : ℕ} {s : Finset α}
 
 /-- The `n`-cliques in a graph as a finset. -/
 def cliqueFinset (n : ℕ) : Finset (Finset α) := {s | G.IsNClique n s}

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -488,7 +488,7 @@ end Walk
 namespace Walk
 
 variable {G G' G''}
-variable (f : G →g G') (f' : G' →g G'') {u v u' v' : V} (p : G.Walk u v)
+variable (f : G →g G') {u v : V} (p : G.Walk u v)
 variable {p f}
 
 theorem map_isPath_of_injective (hinj : Function.Injective f) (hp : p.IsPath) :
@@ -589,7 +589,7 @@ end Path
 
 namespace Walk
 
-variable {G} {p} {u v : V} {H : SimpleGraph V}
+variable {G} {u v : V} {H : SimpleGraph V}
 variable {p : G.Walk u v}
 
 protected theorem IsPath.transfer (hp) (pp : p.IsPath) :

--- a/Mathlib/Data/Matrix/DoublyStochastic.lean
+++ b/Mathlib/Data/Matrix/DoublyStochastic.lean
@@ -105,7 +105,7 @@ end OrderedSemiring
 
 section LinearOrderedSemifield
 
-variable [LinearOrderedSemifield R] {M : Matrix n n R}
+variable [LinearOrderedSemifield R]
 
 /--
 A matrix is `s` times a doubly stochastic matrix iff all entries are nonnegative, and all row and

--- a/Mathlib/Data/Nat/Factorization/PrimePow.lean
+++ b/Mathlib/Data/Nat/Factorization/PrimePow.lean
@@ -14,8 +14,6 @@ This file deals with factorizations of prime powers.
 -/
 
 
-variable {R : Type*} [CommMonoidWithZero R] (n p : R) (k : ℕ)
-
 theorem IsPrimePow.minFac_pow_factorization_eq {n : ℕ} (hn : IsPrimePow n) :
     n.minFac ^ n.factorization n.minFac = n := by
   obtain ⟨p, k, hp, hk, rfl⟩ := hn

--- a/Mathlib/Data/Sym/Card.lean
+++ b/Mathlib/Data/Sym/Card.lean
@@ -54,7 +54,7 @@ stars and bars, multichoose
 
 open Finset Fintype Function Sum Nat
 
-variable {α β : Type*}
+variable {α : Type*}
 
 namespace Sym
 

--- a/Mathlib/Geometry/Manifold/VectorBundle/Pullback.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Pullback.lean
@@ -25,9 +25,9 @@ variable [NontriviallyNormedField 𝕜] [∀ x, AddCommMonoid (E x)] [∀ x, Mod
   [NormedAddCommGroup F] [NormedSpace 𝕜 F] [TopologicalSpace (TotalSpace F E)]
   [∀ x, TopologicalSpace (E x)] {EB : Type*} [NormedAddCommGroup EB] [NormedSpace 𝕜 EB]
   {HB : Type*} [TopologicalSpace HB] {IB : ModelWithCorners 𝕜 EB HB} [TopologicalSpace B]
-  [ChartedSpace HB B] [SmoothManifoldWithCorners IB B] {EB' : Type*} [NormedAddCommGroup EB']
+  [ChartedSpace HB B] {EB' : Type*} [NormedAddCommGroup EB']
   [NormedSpace 𝕜 EB'] {HB' : Type*} [TopologicalSpace HB'] (IB' : ModelWithCorners 𝕜 EB' HB')
-  [TopologicalSpace B'] [ChartedSpace HB' B'] [SmoothManifoldWithCorners IB' B'] [FiberBundle F E]
+  [TopologicalSpace B'] [ChartedSpace HB' B'] [FiberBundle F E]
   [VectorBundle 𝕜 F E] [SmoothVectorBundle F E IB] (f : SmoothMap IB' IB B' B)
 
 /-- For a smooth vector bundle `E` over a manifold `B` and a smooth map `f : B' → B`, the pullback

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -52,7 +52,7 @@ namespace MeasureTheory
 
 namespace Measure
 
-variable {α β : Type*} {m : MeasurableSpace α} {μ ν : Measure α}
+variable {α : Type*} {m : MeasurableSpace α} {μ ν : Measure α}
 
 /-- A pair of measures `μ` and `ν` is said to `HaveLebesgueDecomposition` if there exists a
 measure `ξ` and a measurable function `f`, such that `ξ` is mutually singular with respect to

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -43,7 +43,7 @@ namespace MeasureTheory
 variable {α E G : Type*}
   [NormedAddCommGroup E] [NormedSpace ℝ E]
   [NormedAddCommGroup G] [NormedSpace ℝ G]
-  {f g : α → E} {m : MeasurableSpace α} {μ : Measure α}
+  {m : MeasurableSpace α} {μ : Measure α}
 
 /-- **Lebesgue dominated convergence theorem** provides sufficient conditions under which almost
   everywhere convergence of a sequence of functions implies the convergence of their integrals.
@@ -194,7 +194,7 @@ namespace intervalIntegral
 
 section DCT
 
-variable {ι 𝕜 E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {a b : ℝ} {f : ℝ → E} {μ : Measure ℝ}
 
 /-- Lebesgue dominated convergence theorem for filters with a countable basis -/

--- a/Mathlib/MeasureTheory/Integral/FundThmCalculus.lean
+++ b/Mathlib/MeasureTheory/Integral/FundThmCalculus.lean
@@ -146,7 +146,7 @@ open MeasureTheory Set Filter Function
 
 open scoped Classical Topology Filter ENNReal Interval NNReal
 
-variable {ι 𝕜 E F A : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable {ι 𝕜 E A : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 namespace intervalIntegral
 
@@ -467,7 +467,7 @@ at `(a, b)` provided that `f` is integrable on `a..b` and is continuous at `a` a
 
 
 variable [CompleteSpace E]
-  {f : ℝ → E} {c ca cb : E} {l l' la la' lb lb' : Filter ℝ} {lt : Filter ι} {a b z : ℝ}
+  {f : ℝ → E} {c ca cb : E} {l l' la la' lb lb' : Filter ℝ} {lt : Filter ι} {a b : ℝ}
   {u v ua ub va vb : ι → ℝ} [FTCFilter a la la'] [FTCFilter b lb lb']
 
 /-!
@@ -953,7 +953,7 @@ semicontinuity. As  `g' t < G' t`, this gives the conclusion. One can therefore 
 this inequality to the right until the point `b`, where it gives the desired conclusion.
 -/
 
-variable {f : ℝ → E} {g' g φ : ℝ → ℝ} {a b : ℝ}
+variable {g' g φ : ℝ → ℝ} {a b : ℝ}
 
 /-- Hard part of FTC-2 for integrable derivatives, real-valued functions: one has
 `g b - g a ≤ ∫ y in a..b, g' y` when `g'` is integrable.

--- a/Mathlib/MeasureTheory/Integral/Prod.lean
+++ b/Mathlib/MeasureTheory/Integral/Prod.lean
@@ -45,10 +45,7 @@ open TopologicalSpace
 
 open Filter hiding prod_eq map
 
-variable {α α' β β' γ E : Type*}
-variable [MeasurableSpace α] [MeasurableSpace α'] [MeasurableSpace β] [MeasurableSpace β']
-variable [MeasurableSpace γ]
-variable {μ μ' : Measure α} {ν ν' : Measure β} {τ : Measure γ}
+variable {α β E : Type*} [MeasurableSpace α] [MeasurableSpace β] {μ : Measure α} {ν : Measure β}
 variable [NormedAddCommGroup E]
 
 /-! ### Measurability

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
@@ -223,8 +223,7 @@ theorem map_linearMap_addHaar_pi_eq_smul_addHaar {ι : Type*} [Finite ι] {f : (
     Real.map_linearMap_volume_pi_eq_smul_volume_pi hf, smul_comm]
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
-  [FiniteDimensional ℝ E] (μ : Measure E) [IsAddHaarMeasure μ] {F : Type*} [NormedAddCommGroup F]
-  [NormedSpace ℝ F] [CompleteSpace F]
+  [FiniteDimensional ℝ E] (μ : Measure E) [IsAddHaarMeasure μ]
 
 theorem map_linearMap_addHaar_eq_smul_addHaar {f : E →ₗ[ℝ] E} (hf : LinearMap.det f ≠ 0) :
     Measure.map f μ = ENNReal.ofReal |(LinearMap.det f)⁻¹| • μ := by

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -136,7 +136,7 @@ theorem toMonoidWithZeroHom_coe_eq_coe (v : Valuation R Γ₀) :
 theorem ext {v₁ v₂ : Valuation R Γ₀} (h : ∀ r, v₁ r = v₂ r) : v₁ = v₂ :=
   DFunLike.ext _ _ h
 
-variable (v : Valuation R Γ₀) {x y z : R}
+variable (v : Valuation R Γ₀)
 
 @[simp, norm_cast]
 theorem coe_coe : ⇑(v : R →*₀ Γ₀) = v := rfl
@@ -252,7 +252,7 @@ end Monoid
 
 section Group
 
-variable [LinearOrderedCommGroupWithZero Γ₀] (v : Valuation R Γ₀) {x y z : R}
+variable [LinearOrderedCommGroupWithZero Γ₀] (v : Valuation R Γ₀) {x y : R}
 
 @[simp]
 theorem map_neg (x : R) : v (-x) = v x :=
@@ -526,9 +526,7 @@ end
 
 section Supp
 
-variable [CommRing R]
-variable [LinearOrderedCommMonoidWithZero Γ₀] [LinearOrderedCommMonoidWithZero Γ'₀]
-variable (v : Valuation R Γ₀)
+variable [CommRing R] [LinearOrderedCommMonoidWithZero Γ₀] (v : Valuation R Γ₀)
 
 /-- The support of a valuation `v : R → Γ₀` is the ideal of `R` where `v` vanishes. -/
 def supp : Ideal R where
@@ -605,7 +603,7 @@ instance (R) (Γ₀) [Ring R] [LinearOrderedAddCommMonoidWithTop Γ₀] :
   coe_injective' f g := by cases f; cases g; simp (config := {contextual := true})
 
 variable [Ring R] [LinearOrderedAddCommMonoidWithTop Γ₀] [LinearOrderedAddCommMonoidWithTop Γ'₀]
-  (v : AddValuation R Γ₀) {x y z : R}
+  (v : AddValuation R Γ₀)
 
 section
 
@@ -735,7 +733,7 @@ end Monoid
 
 section Group
 
-variable [LinearOrderedAddCommGroupWithTop Γ₀] [Ring R] (v : AddValuation R Γ₀) {x y z : R}
+variable [LinearOrderedAddCommGroupWithTop Γ₀] [Ring R] (v : AddValuation R Γ₀) {x y : R}
 
 @[simp]
 theorem map_inv (v : AddValuation K Γ₀) {x : K} : v x⁻¹ = - (v x) :=
@@ -830,9 +828,7 @@ end IsEquiv
 
 section Supp
 
-variable [LinearOrderedAddCommMonoidWithTop Γ₀] [LinearOrderedAddCommMonoidWithTop Γ'₀]
-variable [CommRing R]
-variable (v : AddValuation R Γ₀)
+variable [LinearOrderedAddCommMonoidWithTop Γ₀] [CommRing R] (v : AddValuation R Γ₀)
 
 /-- The support of an additive valuation `v : R → Γ₀` is the ideal of `R` where `v x = ⊤` -/
 def supp : Ideal R :=

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -149,8 +149,6 @@ def uniquify : List α → List (α × ℕ)
     let lms := uniquify ms
     (m, 0) :: (lms.map fun (x, n) => if x == m then (x, n + 1) else (x, n))
 
-variable [Inhabited α]
-
 /-- Return a sorting key so that all `(a, true)`s are in the list's order
 and sorted before all `(a, false)`s, which are also in the list's order.
 Although `weight` does not require this, we use `weight` in the case where the list obtained


### PR DESCRIPTION
#17715

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
