### PR TITLE
RFC chore: do not import `Tactic.Common` in Mathlib

### DIFF
--- a/Mathlib/Algebra/AddConstMap/Basic.lean
+++ b/Mathlib/Algebra/AddConstMap/Basic.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Order.Archimedean.Basic
 import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Logic.Function.Iterate
+import Mathlib.Tactic.WLOG
 
 /-!
 # Maps (semi)conjugating a shift to a shift

--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.NoZeroSMulDivisors.Basic
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Data.Set.Subsingleton
+import Mathlib.Tactic.IrreducibleDef
 
 /-!
 # Finite products and sums over types and sets

--- a/Mathlib/Algebra/CharP/Basic.lean
+++ b/Mathlib/Algebra/CharP/Basic.lean
@@ -12,8 +12,9 @@ import Mathlib.Data.Nat.Cast.Prod
 import Mathlib.Data.Nat.Find
 import Mathlib.Data.Nat.Prime.Defs
 import Mathlib.Data.ULift
-import Mathlib.Tactic.NormNum.Basic
 import Mathlib.Order.Interval.Set.Basic
+import Mathlib.Tactic.TermCongr
+import Mathlib.Tactic.NormNum.Basic
 
 /-!
 # Characteristic of semirings

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.Nat.Cast.Defs
 import Mathlib.Data.Nat.Find
 import Mathlib.Data.Nat.Prime.Defs
 import Mathlib.Tactic.NormNum.Basic
+import Mathlib.Tactic.WLOG
 
 /-!
 # Characteristic of semirings

--- a/Mathlib/Algebra/ContinuedFractions/Basic.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Basic.lean
@@ -3,8 +3,9 @@ Copyright (c) 2019 Kevin Kappelmann. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Kappelmann
 -/
-import Mathlib.Data.Seq.Seq
 import Mathlib.Algebra.Field.Defs
+import Mathlib.Data.Seq.Seq
+import Mathlib.Tactic.Coe
 
 /-!
 # Basic Definitions/Theorems for Continued Fractions

--- a/Mathlib/Algebra/ContinuedFractions/ConvergentsEquiv.lean
+++ b/Mathlib/Algebra/ContinuedFractions/ConvergentsEquiv.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Order.Field.Defs
 import Mathlib.Algebra.ContinuedFractions.ContinuantsRecurrence
 import Mathlib.Algebra.ContinuedFractions.TerminatedStable
 import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Set
 import Mathlib.Tactic.Ring
 
 /-!

--- a/Mathlib/Algebra/ContinuedFractions/Determinant.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Determinant.lean
@@ -6,6 +6,7 @@ Authors: Kevin Kappelmann
 import Mathlib.Algebra.ContinuedFractions.ContinuantsRecurrence
 import Mathlib.Algebra.ContinuedFractions.TerminatedStable
 import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Set
 
 /-!
 # Determinant Formula for Simple Continued Fraction

--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -6,7 +6,7 @@ Neil Strickland, Aaron Anderson
 -/
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Hom.Defs
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.Use
 
 /-!
 # Divisibility

--- a/Mathlib/Algebra/Divisibility/Prod.lean
+++ b/Mathlib/Algebra/Divisibility/Prod.lean
@@ -5,7 +5,7 @@ Authors: Johan Commelin
 -/
 import Mathlib.Algebra.Divisibility.Basic
 import Mathlib.Algebra.Group.Prod
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.Choose
 
 /-!
 # Lemmas about the divisibility relation in product (semi)groups

--- a/Mathlib/Algebra/Field/IsField.lean
+++ b/Mathlib/Algebra/Field/IsField.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Leonardo de Moura, Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Algebra.Field.Defs
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.Convert
 
 /-!
 # `IsField` predicate

--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -5,6 +5,8 @@ Authors: Johannes Hölzl, Jens Wagemaker
 -/
 import Mathlib.Algebra.Associated.Basic
 import Mathlib.Algebra.Ring.Regular
+import Mathlib.Tactic.DefEqTransformations
+import Mathlib.Tactic.Set
 
 /-!
 # Monoids with normalization functions, `gcd`, and `lcm`

--- a/Mathlib/Algebra/Group/Int.lean
+++ b/Mathlib/Algebra/Group/Int.lean
@@ -6,6 +6,8 @@ Authors: Jeremy Avigad
 import Mathlib.Algebra.Group.Nat
 import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Data.Int.Sqrt
+import Mathlib.Tactic.Cases
+import Mathlib.Tactic.Tauto
 
 /-!
 # The integers form a group

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kexing Ying
 -/
 import Mathlib.Algebra.Group.Submonoid.Defs
-import Mathlib.Tactic.Common
 
 /-!
 # Subgroups

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -6,7 +6,10 @@ Authors: Mario Carneiro, Johan Commelin
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Data.Option.Defs
 import Mathlib.Logic.Nontrivial.Basic
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.Coe
+import Mathlib.Tactic.Lift
+import Mathlib.Tactic.SimpRw
+import Mathlib.Tactic.Spread
 
 /-!
 # Adjoining a zero/one to semigroups and related algebraic structures

--- a/Mathlib/Algebra/GroupPower/IterateHom.lean
+++ b/Mathlib/Algebra/GroupPower/IterateHom.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Group.Action.Opposite
 import Mathlib.Algebra.Group.Int
 import Mathlib.Algebra.Group.Nat
 import Mathlib.Logic.Function.Iterate
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.DefEqTransformations
 
 /-!
 # Iterates of monoid homomorphisms

--- a/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
@@ -6,7 +6,6 @@ Authors: Simon Hudon, Patrick Massot
 import Mathlib.Algebra.Group.Action.Pi
 import Mathlib.Algebra.GroupWithZero.Action.Defs
 import Mathlib.Algebra.GroupWithZero.Defs
-import Mathlib.Tactic.Common
 
 /-!
 # Pi instances for multiplicative actions with zero

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -3,13 +3,14 @@ Copyright (c) 2023 Emily Witt. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Emily Witt, Kim Morrison, Jake Levinson, Sam van Gool
 -/
-import Mathlib.RingTheory.Ideal.Basic
 import Mathlib.Algebra.Category.ModuleCat.Colimits
 import Mathlib.Algebra.Category.ModuleCat.Projective
 import Mathlib.CategoryTheory.Abelian.Ext
-import Mathlib.RingTheory.Finiteness
 import Mathlib.CategoryTheory.Limits.Final
+import Mathlib.RingTheory.Finiteness
+import Mathlib.RingTheory.Ideal.Basic
 import Mathlib.RingTheory.Noetherian
+import Mathlib.Tactic.ApplyWith
 
 /-!
 # Local cohomology.

--- a/Mathlib/Algebra/Module/Defs.lean
+++ b/Mathlib/Algebra/Module/Defs.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.GroupWithZero.Action.End
 import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.SMulWithZero
 import Mathlib.Data.Int.Cast.Lemmas
+import Mathlib.Tactic.NthRewrite
 
 /-!
 # Modules over a ring

--- a/Mathlib/Algebra/Order/Archimedean/Hom.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Hom.lean
@@ -5,6 +5,7 @@ Authors: Alex J. Best, Yaël Dillies
 -/
 import Mathlib.Algebra.Order.Archimedean.Basic
 import Mathlib.Algebra.Order.Hom.Ring
+import Mathlib.Tactic.WLOG
 
 /-!
 ### Uniqueness of ring homomorphisms to archimedean fields.

--- a/Mathlib/Algebra/Order/CauSeq/Basic.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Basic.lean
@@ -11,6 +11,7 @@ import Mathlib.Algebra.Ring.Pi
 import Mathlib.Data.Setoid.Basic
 import Mathlib.GroupTheory.GroupAction.Ring
 import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.Set
 
 /-!
 # Cauchy sequences

--- a/Mathlib/Algebra/Order/GroupWithZero/Action/Synonym.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Action/Synonym.lean
@@ -5,7 +5,6 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Order.GroupWithZero.Synonym
 import Mathlib.Algebra.SMulWithZero
-import Mathlib.Tactic.Common
 
 /-!
 # Actions by and on order synonyms

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -13,6 +13,8 @@ import Mathlib.Algebra.Order.GroupWithZero.Unbundled
 import Mathlib.Algebra.Order.Monoid.Basic
 import Mathlib.Algebra.Order.Monoid.OrderDual
 import Mathlib.Algebra.Order.Monoid.TypeTags
+import Mathlib.Tactic.ByContra
+import Mathlib.Tactic.Cases
 
 /-!
 # Linearly ordered commutative groups and monoids with a zero element adjoined

--- a/Mathlib/Algebra/Prime/Defs.lean
+++ b/Mathlib/Algebra/Prime/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jens Wagemaker
 -/
 import Mathlib.Algebra.GroupWithZero.Divisibility
+import Mathlib.Tactic.Says
 
 /-!
 # Prime and irreducible elements.

--- a/Mathlib/Algebra/Quotient.lean
+++ b/Mathlib/Algebra/Quotient.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
-import Mathlib.Tactic.Common
 
 /-!
 # Algebraic quotients

--- a/Mathlib/Algebra/Quotient.lean
+++ b/Mathlib/Algebra/Quotient.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
+import Mathlib.Init
 
 /-!
 # Algebraic quotients

--- a/Mathlib/Algebra/Ring/Parity.lean
+++ b/Mathlib/Algebra/Ring/Parity.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Data.Nat.Cast.Commute
 import Mathlib.Data.Set.Operations
 import Mathlib.Logic.Function.Iterate
+import Mathlib.Tactic.Cases
 
 /-!
 # Even and odd elements in rings

--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Group.Subgroup.Basic
 import Mathlib.Algebra.Ring.Subsemiring.Basic
 import Mathlib.RingTheory.NonUnitalSubring.Basic
+import Mathlib.Tactic.RSuffices
 
 /-!
 # Subrings

--- a/Mathlib/Algebra/Ring/WithZero.lean
+++ b/Mathlib/Algebra/Ring/WithZero.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Johan Commelin
 -/
 import Mathlib.Algebra.GroupWithZero.WithZero
 import Mathlib.Algebra.Ring.Defs
+import Mathlib.Tactic.Cases
 
 /-!
 # Adjoining a zero to a semiring

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Algebra.Hom
 import Mathlib.RingTheory.Congruence.Basic
 import Mathlib.RingTheory.Ideal.Quotient.Defs
 import Mathlib.RingTheory.Ideal.Span
+import Mathlib.Tactic.IrreducibleDef
 
 /-!
 # Quotients of non-commutative rings

--- a/Mathlib/Algebra/Star/SelfAdjoint.lean
+++ b/Mathlib/Algebra/Star/SelfAdjoint.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Star.Pi
 import Mathlib.Algebra.Star.Rat
+import Mathlib.Tactic.TermCongr
 
 /-!
 # Self-adjoint, skew-adjoint and normal elements of a star additive group

--- a/Mathlib/Analysis/Analytic/RadiusLiminf.lean
+++ b/Mathlib/Analysis/Analytic/RadiusLiminf.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Analysis.Analytic.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
+import Mathlib.Tactic.InferParam
 
 /-!
 # Representation of `FormalMultilinearSeries.radius` as a `liminf`

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -6,6 +6,7 @@ Authors: Yury Kudryashov
 import Mathlib.Algebra.Order.BigOperators.Ring.Finset
 import Mathlib.Analysis.Convex.Hull
 import Mathlib.LinearAlgebra.AffineSpace.Basis
+import Mathlib.Tactic.SimpIntro
 
 /-!
 # Convex combinations

--- a/Mathlib/CategoryTheory/Abelian/InjectiveResolution.lean
+++ b/Mathlib/CategoryTheory/Abelian/InjectiveResolution.lean
@@ -3,10 +3,11 @@ Copyright (c) 2022 Jujian Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang, Kim Morrison
 -/
-import Mathlib.CategoryTheory.Preadditive.InjectiveResolution
 import Mathlib.Algebra.Homology.HomotopyCategory
+import Mathlib.CategoryTheory.Preadditive.InjectiveResolution
 import Mathlib.Data.Set.Subsingleton
 import Mathlib.Tactic.AdaptationNote
+import Mathlib.Tactic.IrreducibleDef
 
 /-!
 # Abelian categories with enough injectives have injective resolutions

--- a/Mathlib/CategoryTheory/Abelian/ProjectiveResolution.lean
+++ b/Mathlib/CategoryTheory/Abelian/ProjectiveResolution.lean
@@ -5,6 +5,7 @@ Authors: Markus Himmel, Kim Morrison, Jakob von Raumer, Joël Riou
 -/
 import Mathlib.CategoryTheory.Preadditive.ProjectiveResolution
 import Mathlib.Algebra.Homology.HomotopyCategory
+import Mathlib.Tactic.IrreducibleDef
 import Mathlib.Tactic.SuppressCompilation
 
 /-!

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -6,7 +6,7 @@ Authors: Stephen Morgan, Kim Morrison, Johannes Hölzl, Reid Barton
 import Mathlib.CategoryTheory.Category.Init
 import Mathlib.Combinatorics.Quiver.Basic
 import Mathlib.Tactic.PPWithUniv
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.Convert
 import Mathlib.Tactic.StacksAttribute
 
 /-!

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison, Johannes Hölzl, Reid Barton, Sean Leather, Yury Kudryashov
 -/
 import Mathlib.CategoryTheory.Types
+import Mathlib.Util.AssertExists
 
 /-!
 # Concrete categories

--- a/Mathlib/CategoryTheory/DiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/DiscreteCategory.lean
@@ -6,6 +6,8 @@ Authors: Stephen Morgan, Kim Morrison, Floris van Doorn
 import Mathlib.CategoryTheory.EqToHom
 import Mathlib.CategoryTheory.Pi.Basic
 import Mathlib.Data.ULift
+import Mathlib.Tactic.CasesM
+import Mathlib.Tactic.FailIfNoProgress
 
 /-!
 # Discrete categories

--- a/Mathlib/CategoryTheory/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/EssentiallySmall.lean
@@ -7,6 +7,7 @@ import Mathlib.CategoryTheory.Category.ULift
 import Mathlib.CategoryTheory.Skeletal
 import Mathlib.Logic.UnivLE
 import Mathlib.Logic.Small.Basic
+import Mathlib.Tactic.Constructor
 
 /-!
 # Essentially small categories.

--- a/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
@@ -5,6 +5,7 @@ Authors: Kim Morrison
 -/
 import Mathlib.CategoryTheory.NatIso
 import Mathlib.Logic.Equiv.Defs
+import Mathlib.Tactic.Cases
 
 /-!
 # Full and faithful functors

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -6,6 +6,7 @@ Authors: Joël Riou
 import Mathlib.CategoryTheory.Comma.StructuredArrow.Basic
 import Mathlib.CategoryTheory.Limits.Shapes.Equivalence
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Terminal
+import Mathlib.Tactic.NthRewrite
 
 /-!
 # Kan extensions

--- a/Mathlib/CategoryTheory/GlueData.lean
+++ b/Mathlib/CategoryTheory/GlueData.lean
@@ -8,6 +8,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.Multiequalizer
 import Mathlib.CategoryTheory.Limits.Constructions.EpiMono
 import Mathlib.CategoryTheory.Limits.Preserves.Limits
 import Mathlib.CategoryTheory.Limits.Shapes.Types
+import Mathlib.Tactic.ApplyWith
 
 /-!
 # Gluing data

--- a/Mathlib/CategoryTheory/Groupoid/FreeGroupoid.lean
+++ b/Mathlib/CategoryTheory/Groupoid/FreeGroupoid.lean
@@ -5,6 +5,7 @@ Authors: Rémi Bottinelli
 -/
 import Mathlib.CategoryTheory.Groupoid
 import Mathlib.CategoryTheory.PathCategory.Basic
+import Mathlib.Tactic.NthRewrite
 
 /-!
 # Free groupoid on a quiver

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -11,6 +11,7 @@ import Mathlib.CategoryTheory.Filtered.Basic
 import Mathlib.CategoryTheory.Limits.Yoneda
 import Mathlib.CategoryTheory.PUnit
 import Mathlib.CategoryTheory.Grothendieck
+import Mathlib.Tactic.RSuffices
 
 /-!
 # Final and initial functors

--- a/Mathlib/CategoryTheory/Limits/IsLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/IsLimit.lean
@@ -6,6 +6,7 @@ Authors: Reid Barton, Mario Carneiro, Kim Morrison, Floris van Doorn
 import Mathlib.CategoryTheory.Adjunction.Basic
 import Mathlib.CategoryTheory.Limits.Cones
 import Batteries.Tactic.Congr
+import Mathlib.Tactic.Choose
 
 /-!
 # Limits and colimits

--- a/Mathlib/CategoryTheory/Limits/Preserves/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Opposites.lean
@@ -5,6 +5,7 @@ Authors: Markus Himmel
 -/
 import Mathlib.CategoryTheory.Limits.Opposites
 import Mathlib.CategoryTheory.Limits.Preserves.Finite
+import Mathlib.Tactic.ApplyWith
 
 /-!
 # Limit preservation properties of `Functor.op` and related constructions

--- a/Mathlib/CategoryTheory/Limits/Shapes/Countable.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Countable.lean
@@ -7,6 +7,7 @@ import Mathlib.CategoryTheory.Limits.Final
 import Mathlib.CategoryTheory.Limits.Shapes.FiniteLimits
 import Mathlib.CategoryTheory.Countable
 import Mathlib.Data.Countable.Defs
+import Mathlib.Tactic.ClearExclamation
 /-!
 # Countable limits and colimits
 

--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions/Fractions.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions/Fractions.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 import Mathlib.CategoryTheory.Localization.CalculusOfFractions
+import Mathlib.Tactic.NthRewrite
 
 /-!
 # Lemmas on fractions

--- a/Mathlib/CategoryTheory/Monad/Comonadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Comonadicity.lean
@@ -7,6 +7,7 @@ import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Equalizers
 import Mathlib.CategoryTheory.Limits.Shapes.Reflexive
 import Mathlib.CategoryTheory.Monad.Equalizer
 import Mathlib.CategoryTheory.Monad.Limits
+import Mathlib.Tactic.ApplyWith
 
 /-!
 # Comonadicity theorems

--- a/Mathlib/CategoryTheory/Monad/Monadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Monadicity.lean
@@ -7,6 +7,7 @@ import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Equalizers
 import Mathlib.CategoryTheory.Limits.Shapes.Reflexive
 import Mathlib.CategoryTheory.Monad.Coequalizer
 import Mathlib.CategoryTheory.Monad.Limits
+import Mathlib.Tactic.ApplyWith
 
 /-!
 # Monadicity theorems

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -6,6 +6,7 @@ Authors: Stephen Morgan, Kim Morrison
 import Mathlib.CategoryTheory.Functor.Const
 import Mathlib.CategoryTheory.Opposites
 import Mathlib.Data.Prod.Basic
+import Mathlib.Tactic.Says
 
 /-!
 # Cartesian products of categories

--- a/Mathlib/CategoryTheory/Sites/DenseSubsite.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite.lean
@@ -3,11 +3,12 @@ Copyright (c) 2021 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.CategoryTheory.Sites.Sheaf
+import Mathlib.CategoryTheory.Adjunction.FullyFaithful
 import Mathlib.CategoryTheory.Sites.CoverLifting
 import Mathlib.CategoryTheory.Sites.CoverPreserving
-import Mathlib.CategoryTheory.Adjunction.FullyFaithful
 import Mathlib.CategoryTheory.Sites.LocallyFullyFaithful
+import Mathlib.CategoryTheory.Sites.Sheaf
+import Mathlib.Tactic.ApplyWith
 
 /-!
 # Dense subsites

--- a/Mathlib/CategoryTheory/Sites/EffectiveEpimorphic.lean
+++ b/Mathlib/CategoryTheory/Sites/EffectiveEpimorphic.lean
@@ -5,6 +5,8 @@ Authors: Adam Topaz
 -/
 import Mathlib.CategoryTheory.Sites.Sieves
 import Mathlib.CategoryTheory.EffectiveEpi.Basic
+import Mathlib.Tactic.NthRewrite
+
 /-!
 
 # Effective epimorphic sieves

--- a/Mathlib/CategoryTheory/Sites/Sieves.lean
+++ b/Mathlib/CategoryTheory/Sites/Sieves.lean
@@ -3,8 +3,9 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Edward Ayers
 -/
-import Mathlib.Data.Set.Lattice
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
+import Mathlib.Data.Set.Lattice
+import Mathlib.Tactic.TermCongr
 
 /-!
 # Theory of sieves

--- a/Mathlib/CategoryTheory/Thin.lean
+++ b/Mathlib/CategoryTheory/Thin.lean
@@ -5,6 +5,7 @@ Authors: Kim Morrison, Bhavik Mehta
 -/
 import Mathlib.CategoryTheory.Functor.Category
 import Mathlib.CategoryTheory.Iso
+import Mathlib.Tactic.Subsingleton
 
 /-!
 # Thin categories

--- a/Mathlib/Combinatorics/Quiver/Covering.lean
+++ b/Mathlib/Combinatorics/Quiver/Covering.lean
@@ -7,7 +7,7 @@ import Mathlib.Combinatorics.Quiver.Cast
 import Mathlib.Combinatorics.Quiver.Symmetric
 import Mathlib.Data.Sigma.Basic
 import Mathlib.Logic.Equiv.Basic
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.Cases
 
 /-!
 # Covering

--- a/Mathlib/Combinatorics/SetFamily/Compression/Down.lean
+++ b/Mathlib/Combinatorics/SetFamily/Compression/Down.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Data.Finset.Lattice
+import Mathlib.Tactic.Set
 
 /-!
 # Down-compressions

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Computability.Partrec
 import Mathlib.Data.Option.Basic
+import Mathlib.Tactic.RSuffices
 
 /-!
 # Gödel Numbering for Partial Recursive Functions.

--- a/Mathlib/Computability/TuringMachine.lean
+++ b/Mathlib/Computability/TuringMachine.lean
@@ -6,12 +6,14 @@ Authors: Mario Carneiro
 import Mathlib.Data.Fintype.Option
 import Mathlib.Data.Fintype.Prod
 import Mathlib.Data.Fintype.Pi
-import Mathlib.Data.Vector.Basic
+import Mathlib.Data.List.GetD
 import Mathlib.Data.PFun
+import Mathlib.Data.Vector.Basic
 import Mathlib.Logic.Function.Iterate
 import Mathlib.Order.Basic
 import Mathlib.Tactic.ApplyFun
-import Mathlib.Data.List.GetD
+import Mathlib.Tactic.DefEqTransformations
+import Mathlib.Tactic.RSuffices
 
 /-!
 # Turing machines

--- a/Mathlib/Control/Bifunctor.lean
+++ b/Mathlib/Control/Bifunctor.lean
@@ -3,9 +3,11 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
 -/
-import Mathlib.Control.Functor
-import Mathlib.Tactic.Common
+import Aesop
 import Batteries.Data.Sum.Basic
+import Mathlib.Control.Functor
+import Mathlib.Logic.Function.Basic
+import Mathlib.Tactic.HigherOrder
 
 /-!
 # Functors with two arguments

--- a/Mathlib/Control/Fix.lean
+++ b/Mathlib/Control/Fix.lean
@@ -7,7 +7,6 @@ import Mathlib.Data.Part
 import Mathlib.Data.Nat.Find
 import Mathlib.Data.Nat.Upto
 import Mathlib.Data.Stream.Defs
-import Mathlib.Tactic.Common
 
 /-!
 # Fixed point

--- a/Mathlib/Control/LawfulFix.lean
+++ b/Mathlib/Control/LawfulFix.lean
@@ -3,10 +3,11 @@ Copyright (c) 2020 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
 -/
-import Mathlib.Data.Stream.Init
-import Mathlib.Tactic.ApplyFun
 import Mathlib.Control.Fix
+import Mathlib.Data.Stream.Init
 import Mathlib.Order.OmegaCompletePartialOrder
+import Mathlib.Tactic.ApplyFun
+import Mathlib.Tactic.WLOG
 
 /-!
 # Lawful fixed point operators

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -8,8 +8,8 @@ import Mathlib.Data.Nat.Defs
 import Mathlib.Data.Int.DivMod
 import Mathlib.Logic.Embedding.Basic
 import Mathlib.Logic.Equiv.Set
-import Mathlib.Tactic.Common
 import Mathlib.Tactic.Attr.Register
+import Mathlib.Tactic.Cases
 
 /-!
 # The finite type with `n` elements

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -5,6 +5,7 @@ Authors: Floris van Doorn, Yury Kudryashov, Sébastien Gouëzel, Chris Hughes
 -/
 import Mathlib.Data.Fin.Basic
 import Mathlib.Data.Nat.Find
+import Mathlib.Tactic.Set
 
 /-!
 # Operation on tuples

--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Data.Finset.Lattice
+import Mathlib.Tactic.Set
 
 /-!
 # Maximum and minimum of finite sets

--- a/Mathlib/Data/Finset/Update.lean
+++ b/Mathlib/Data/Finset/Update.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import Mathlib.Data.Finset.Basic
+import Mathlib.Tactic.Set
 
 /-!
 # Update a function on a set of values

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Data.List.NodupEquivFin
 import Mathlib.Data.Set.Image
 import Mathlib.Order.WellFounded
+import Mathlib.Tactic.WLOG
 
 /-!
 # Cardinalities of finite types

--- a/Mathlib/Data/Fintype/CardEmbedding.lean
+++ b/Mathlib/Data/Fintype/CardEmbedding.lean
@@ -5,6 +5,7 @@ Authors: Eric Rodriguez
 -/
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Logic.Equiv.Embedding
+import Mathlib.Tactic.ClearExclamation
 
 /-!
 # Number of embeddings

--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -6,6 +6,7 @@ Authors: Jeremy Avigad
 import Mathlib.Algebra.Ring.Int
 import Mathlib.Data.Nat.Bitwise
 import Mathlib.Data.Nat.Size
+import Mathlib.Tactic.DefEqTransformations
 
 /-!
 # Bitwise operations on integers

--- a/Mathlib/Data/Int/Sqrt.lean
+++ b/Mathlib/Data/Int/Sqrt.lean
@@ -5,7 +5,6 @@ Authors: Kenny Lau
 -/
 import Mathlib.Data.Int.Defs
 import Mathlib.Data.Nat.Sqrt
-import Mathlib.Tactic.Common
 
 /-!
 # Square root of integers

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -11,7 +11,12 @@ import Mathlib.Data.List.Monad
 import Mathlib.Logic.OpClass
 import Mathlib.Logic.Unique
 import Mathlib.Order.Basic
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.Cases
+import Mathlib.Tactic.Contrapose
+import Mathlib.Tactic.Says
+import Mathlib.Tactic.Subsingleton
+import Mathlib.Tactic.TermCongr
+import Mathlib.Tactic.Use
 
 /-!
 # Basic properties of lists

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro, Kenny Lau, Yury Kudryashov
 import Mathlib.Logic.Relation
 import Mathlib.Data.List.Forall2
 import Mathlib.Data.List.Lex
+import Mathlib.Tactic.ByContra
 
 /-!
 # Relation chain

--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Mario Carneiro
 -/
 import Mathlib.Logic.Function.Basic
-import Mathlib.Tactic.Common
+import Mathlib.Util.AssertExists
 
 /-!
 # Counting in lists

--- a/Mathlib/Data/List/Forall2.lean
+++ b/Mathlib/Data/List/Forall2.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Data.List.Basic
+import Mathlib.Tactic.MkIffOfInductiveProp
 
 /-!
 # Double universal quantification on a list

--- a/Mathlib/Data/List/Infix.lean
+++ b/Mathlib/Data/List/Infix.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Data.List.Basic
+import Mathlib.Tactic.NthRewrite
 
 /-!
 # Prefixes, suffixes, infixes

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -10,6 +10,7 @@ import Mathlib.Data.Set.List
 import Mathlib.Order.Hom.Basic
 import Mathlib.Data.List.Perm.Lattice
 import Mathlib.Data.List.Perm.Basic
+import Mathlib.Tactic.Constructor
 
 /-!
 # Multisets

--- a/Mathlib/Data/NNRat/Lemmas.lean
+++ b/Mathlib/Data/NNRat/Lemmas.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Field.Rat
 import Mathlib.Algebra.Group.Indicator
 import Mathlib.Algebra.GroupWithZero.Action.End
 import Mathlib.Algebra.Order.Field.Rat
+import Mathlib.Tactic.NthRewrite
 
 /-!
 # Field and action structures on the nonnegative rationals

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -10,7 +10,8 @@ import Mathlib.Data.List.GetD
 import Mathlib.Data.Nat.Bits
 import Mathlib.Order.Basic
 import Mathlib.Tactic.AdaptationNote
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.Cases
+import Mathlib.Tactic.Set
 
 /-!
 # Bitwise operations on natural numbers

--- a/Mathlib/Data/Nat/Cast/Field.lean
+++ b/Mathlib/Data/Nat/Cast/Field.lean
@@ -5,7 +5,6 @@ Authors: Mario Carneiro, Yaël Dillies, Patrick Stevens
 -/
 import Mathlib.Algebra.CharZero.Defs
 import Mathlib.Data.Nat.Cast.Basic
-import Mathlib.Tactic.Common
 import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.GroupWithZero.Units.Basic
 

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -4,9 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Chris Hughes, Floris van Doorn, Yaël Dillies
 -/
 import Mathlib.Data.Nat.Defs
+import Mathlib.Tactic.Cases
 import Mathlib.Tactic.GCongr.CoreAttrs
-import Mathlib.Tactic.Common
 import Mathlib.Tactic.Monotonicity.Attr
+import Mathlib.Tactic.NthRewrite
 
 /-!
 # Factorial and variants

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -6,6 +6,7 @@ Authors: Jeremy Avigad, Leonardo de Moura
 import Batteries.Data.Nat.Gcd
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.Ring.Nat
+import Mathlib.Tactic.NthRewrite
 
 /-!
 # Properties of `Nat.gcd`, `Nat.lcm`, and `Nat.Coprime`

--- a/Mathlib/Data/Nat/MaxPowDiv.lean
+++ b/Mathlib/Data/Nat/MaxPowDiv.lean
@@ -5,7 +5,7 @@ Authors: Matthew Robert Ballard
 -/
 import Mathlib.Algebra.Divisibility.Units
 import Mathlib.Algebra.Order.Ring.Nat
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.NthRewrite
 
 /-!
 # The maximal power of one natural number dividing another

--- a/Mathlib/Data/Nat/Prime/Basic.lean
+++ b/Mathlib/Data/Nat/Prime/Basic.lean
@@ -6,6 +6,7 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 import Mathlib.Algebra.Associated.Basic
 import Mathlib.Algebra.Ring.Parity
 import Mathlib.Data.Nat.Prime.Defs
+import Mathlib.Tactic.ByContra
 
 /-!
 # Prime numbers

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -7,7 +7,9 @@ import Mathlib.Algebra.Group.Defs
 import Mathlib.Data.Int.Defs
 import Mathlib.Data.Rat.Init
 import Mathlib.Order.Basic
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.Cases
+import Mathlib.Tactic.Coe
+import Mathlib.Tactic.Tauto
 import Batteries.Data.Rat.Lemmas
 
 /-!

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.Ring.Rat
 import Mathlib.Data.PNat.Defs
+import Mathlib.Tactic.NthRewrite
 
 /-!
 # Further lemmas for the Rational Numbers

--- a/Mathlib/Data/Real/Basic.lean
+++ b/Mathlib/Data/Real/Basic.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Floris van Doorn
 -/
 import Mathlib.Algebra.Order.CauSeq.Completion
 import Mathlib.Algebra.Order.Field.Rat
+import Mathlib.Tactic.IrreducibleDef
 
 /-!
 # Real numbers from Cauchy sequences

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Data.Nat.Find
 import Mathlib.Data.Stream.Init
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.DefEqTransformations
 
 /-!
 # Coinductive formalization of unbounded computations.

--- a/Mathlib/Data/Seq/Seq.lean
+++ b/Mathlib/Data/Seq/Seq.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Data.Option.NAry
 import Mathlib.Data.Seq.Computation
+import Batteries.Data.MLList.Basic
 
 /-!
 # Possibly infinite lists

--- a/Mathlib/Data/Seq/WSeq.lean
+++ b/Mathlib/Data/Seq/WSeq.lean
@@ -3,10 +3,11 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Logic.Relation
+import Batteries.Data.DList.Basic
 import Mathlib.Data.Option.Basic
 import Mathlib.Data.Seq.Seq
-import Batteries.Data.DList.Basic
+import Mathlib.Logic.Relation
+import Mathlib.Tactic.Substs
 
 /-!
 # Partially defined possibly infinite lists

--- a/Mathlib/Data/Set/Enumerate.lean
+++ b/Mathlib/Data/Set/Enumerate.lean
@@ -5,8 +5,9 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Nat
-import Mathlib.Tactic.Common
 import Mathlib.Data.Set.Basic
+import Mathlib.Tactic.Says
+import Mathlib.Tactic.SwapVar
 
 /-!
 # Set enumeration

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -7,6 +7,7 @@ import Mathlib.Logic.Pairwise
 import Mathlib.Order.CompleteBooleanAlgebra
 import Mathlib.Order.Directed
 import Mathlib.Order.GaloisConnection
+import Mathlib.Tactic.Cases
 
 /-!
 # The set lattice

--- a/Mathlib/Data/Set/Pairwise/Basic.lean
+++ b/Mathlib/Data/Set/Pairwise/Basic.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl
 import Mathlib.Data.Set.Function
 import Mathlib.Logic.Pairwise
 import Mathlib.Logic.Relation
+import Mathlib.Tactic.Cases
 
 /-!
 # Relations holding pairwise

--- a/Mathlib/Data/TypeVec.lean
+++ b/Mathlib/Data/TypeVec.lean
@@ -5,7 +5,6 @@ Authors: Jeremy Avigad, Mario Carneiro, Simon Hudon
 -/
 import Mathlib.Data.Fin.Fin2
 import Mathlib.Logic.Function.Basic
-import Mathlib.Tactic.Common
 
 /-!
 

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -10,6 +10,7 @@ import Mathlib.Data.List.OfFn
 import Mathlib.Data.List.InsertIdx
 import Mathlib.Control.Applicative
 import Mathlib.Control.Traversable.Basic
+import Mathlib.Tactic.ClearExcept
 
 /-!
 # Additional theorems and definitions about the `Vector` type

--- a/Mathlib/Data/Vector/Defs.lean
+++ b/Mathlib/Data/Vector/Defs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 import Mathlib.Data.List.Defs
-import Mathlib.Tactic.Common
+import Mathlib.Util.AssertExists
 
 /-!
 The type `Vector` represents lists with fixed length.

--- a/Mathlib/GroupTheory/FreeGroup/IsFreeGroup.lean
+++ b/Mathlib/GroupTheory/FreeGroup/IsFreeGroup.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Wärn, Eric Wieser, Joachim Breitner
 -/
 import Mathlib.GroupTheory.FreeGroup.Basic
+import Mathlib.Tactic.IrreducibleDef
 
 /-!
 # Free groups structures on arbitrary types

--- a/Mathlib/GroupTheory/GroupAction/Defs.lean
+++ b/Mathlib/GroupTheory/GroupAction/Defs.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Algebra.Group.Submonoid.Operations
 import Mathlib.Algebra.GroupWithZero.Action.Defs
+import Mathlib.Tactic.Set
 
 /-!
 # Definition of `orbit`, `fixedPoints` and `stabilizer`

--- a/Mathlib/GroupTheory/OreLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/OreLocalization/Basic.lean
@@ -5,6 +5,8 @@ Authors: Jakob von Raumer, Kevin Klinge, Andrew Yang
 -/
 import Mathlib.Algebra.Group.Submonoid.Operations
 import Mathlib.GroupTheory.OreLocalization.OreSet
+import Mathlib.Tactic.DefEqTransformations
+import Mathlib.Tactic.Set
 
 /-!
 

--- a/Mathlib/GroupTheory/Perm/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Basic.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Group.Units.Equiv
 import Mathlib.Algebra.GroupPower.IterateHom
 import Mathlib.Logic.Equiv.Set
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.NthRewrite
 
 /-!
 # The group of permutations (self-equivalences) of a type `α`

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
@@ -5,6 +5,7 @@ Authors: Zhangir Azerbayev, Adam Topaz, Eric Wieser
 -/
 import Mathlib.LinearAlgebra.CliffordAlgebra.Basic
 import Mathlib.LinearAlgebra.Alternating.Basic
+import Mathlib.Tactic.ExistsI
 
 /-!
 # Exterior Algebras

--- a/Mathlib/LinearAlgebra/PiTensorProduct.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct.lean
@@ -5,6 +5,7 @@ Authors: Frédéric Dupuis, Eric Wieser
 -/
 import Mathlib.LinearAlgebra.Multilinear.TensorProduct
 import Mathlib.Tactic.AdaptationNote
+import Mathlib.Tactic.ExistsI
 
 /-!
 # Tensor product of an indexed family of modules over commutative semirings

--- a/Mathlib/Logic/Pairwise.lean
+++ b/Mathlib/Logic/Pairwise.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Logic.Function.Basic
 import Mathlib.Data.Set.Defs
-import Mathlib.Tactic.Common
 
 /-!
 # Relations holding pairwise

--- a/Mathlib/MeasureTheory/Measure/Portmanteau.lean
+++ b/Mathlib/MeasureTheory/Measure/Portmanteau.lean
@@ -7,6 +7,7 @@ import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
 import Mathlib.MeasureTheory.Integral.Layercake
 import Mathlib.MeasureTheory.Integral.BoundedContinuousFunction
+import Mathlib.Tactic.InferParam
 
 /-!
 # Characterizations of weak convergence of finite measures and probability measures

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Martin Zinkevich, Rémy Degenne
 -/
 import Mathlib.Logic.Encodable.Lattice
 import Mathlib.MeasureTheory.MeasurableSpace.Defs
+import Mathlib.Tactic.DefEqTransformations
 
 /-!
 # Induction principles for measurable sets, related to π-systems and λ-systems.

--- a/Mathlib/NumberTheory/BernoulliPolynomials.lean
+++ b/Mathlib/NumberTheory/BernoulliPolynomials.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.Algebra.Polynomial.Derivative
 import Mathlib.Data.Nat.Choose.Cast
 import Mathlib.NumberTheory.Bernoulli
+import Mathlib.Tactic.ApplyCongr
 
 /-!
 # Bernoulli polynomials

--- a/Mathlib/NumberTheory/Liouville/LiouvilleWith.lean
+++ b/Mathlib/NumberTheory/Liouville/LiouvilleWith.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics
 import Mathlib.NumberTheory.Liouville.Basic
+import Mathlib.Tactic.Rename
 import Mathlib.Topology.Instances.Irrational
 
 /-!

--- a/Mathlib/NumberTheory/RamificationInertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia.lean
@@ -5,6 +5,7 @@ Authors: Anne Baanen
 -/
 import Mathlib.LinearAlgebra.Dimension.DivisionRing
 import Mathlib.RingTheory.DedekindDomain.Ideal
+import Mathlib.Tactic.ApplyWith
 
 /-!
 # Ramification index and inertia degree

--- a/Mathlib/Order/Filter/AtTopBot.lean
+++ b/Mathlib/Order/Filter/AtTopBot.lean
@@ -9,6 +9,7 @@ import Mathlib.Order.Filter.Bases
 import Mathlib.Order.Filter.Prod
 import Mathlib.Order.Interval.Set.Disjoint
 import Mathlib.Order.Interval.Set.OrderIso
+import Mathlib.Tactic.RSuffices
 
 /-!
 # `Filter.atTop` and `Filter.atBot` filters on preorders, monoids and groups.

--- a/Mathlib/Order/FixedPoints.lean
+++ b/Mathlib/Order/FixedPoints.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Kenny Lau, Yury Kudryashov
 import Mathlib.Dynamics.FixedPoints.Basic
 import Mathlib.Order.Hom.Order
 import Mathlib.Order.OmegaCompletePartialOrder
+import Mathlib.Tactic.Set
 
 /-!
 # Fixed point construction on complete lattices

--- a/Mathlib/Order/Heyting/Boundary.lean
+++ b/Mathlib/Order/Heyting/Boundary.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Order.BooleanAlgebra
-import Mathlib.Tactic.Common
 
 /-!
 # Co-Heyting boundary

--- a/Mathlib/Order/Interval/Set/OrdConnectedComponent.lean
+++ b/Mathlib/Order/Interval/Set/OrdConnectedComponent.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Order.Interval.Set.OrdConnected
 import Mathlib.Data.Set.Lattice
+import Mathlib.Tactic.WLOG
 
 /-!
 # Order connected components of a set

--- a/Mathlib/Order/Interval/Set/UnorderedInterval.lean
+++ b/Mathlib/Order/Interval/Set/UnorderedInterval.lean
@@ -5,7 +5,6 @@ Authors: Zhouhang Zhou
 -/
 import Mathlib.Order.Interval.Set.Image
 import Mathlib.Order.Bounds.Basic
-import Mathlib.Tactic.Common
 
 /-!
 # Intervals without endpoints ordering

--- a/Mathlib/Order/OrderIsoNat.lean
+++ b/Mathlib/Order/OrderIsoNat.lean
@@ -9,6 +9,7 @@ import Mathlib.Logic.Denumerable
 import Mathlib.Logic.Function.Iterate
 import Mathlib.Order.Hom.Basic
 import Mathlib.Data.Set.Subsingleton
+import Mathlib.Tactic.CongrM
 
 /-!
 # Relation embeddings from the naturals

--- a/Mathlib/Order/Part.lean
+++ b/Mathlib/Order/Part.lean
@@ -5,7 +5,6 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Data.Part
 import Mathlib.Order.Hom.Basic
-import Mathlib.Tactic.Common
 
 /-!
 # Monotonicity of monadic operations on `Part`

--- a/Mathlib/Order/PiLex.lean
+++ b/Mathlib/Order/PiLex.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import Mathlib.Order.WellFounded
-import Mathlib.Tactic.Common
+import Mathlib.Tactic.Cases
 
 /-!
 # Lexicographic order on Pi types

--- a/Mathlib/Order/PrimeSeparator.lean
+++ b/Mathlib/Order/PrimeSeparator.lean
@@ -6,6 +6,7 @@ Authors: Sam van Gool
 
 import Mathlib.Order.PrimeIdeal
 import Mathlib.Order.Zorn
+import Mathlib.Tactic.Set
 
 /-!
 # Separating prime filters and ideals

--- a/Mathlib/Order/SuccPred/Archimedean.lean
+++ b/Mathlib/Order/SuccPred/Archimedean.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Order.SuccPred.Basic
+import Mathlib.Tactic.ApplyAt
+import Mathlib.Tactic.WLOG
 
 /-!
 # Archimedean successor and predecessor

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -6,6 +6,7 @@ Authors: Yaël Dillies
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
 import Mathlib.Order.Cover
 import Mathlib.Order.Iterate
+import Mathlib.Tactic.TermCongr
 
 /-!
 # Successor and predecessor

--- a/Mathlib/RingTheory/Localization/Defs.lean
+++ b/Mathlib/RingTheory/Localization/Defs.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau, Mario Carneiro, Johan Commelin, Amelia Livingston, Anne Baan
 -/
 import Mathlib.GroupTheory.MonoidLocalization.MonoidWithZero
 import Mathlib.RingTheory.OreLocalization.Ring
+import Mathlib.Tactic.ApplyAt
 import Mathlib.Tactic.Ring
 
 /-!

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Field.Equiv
 import Mathlib.Algebra.Order.Field.Rat
 import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.RingTheory.Localization.Basic
+import Mathlib.Tactic.IrreducibleDef
 
 /-!
 # Fraction ring / fraction field Frac(R) as localization

--- a/Mathlib/RingTheory/Valuation/ValExtension.lean
+++ b/Mathlib/RingTheory/Valuation/ValExtension.lean
@@ -3,8 +3,9 @@ Copyright (c) 2024 Jiedong Jiang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jiedong Jiang, Bichang Lei
 -/
-import Mathlib.RingTheory.Valuation.Integers
 import Mathlib.Algebra.Group.Units.Hom
+import Mathlib.RingTheory.Valuation.Integers
+import Mathlib.Tactic.ApplyAt
 
 /-!
 # Extension of Valuation

--- a/Mathlib/Tactic/CategoryTheory/Bicategory/Datatypes.lean
+++ b/Mathlib/Tactic/CategoryTheory/Bicategory/Datatypes.lean
@@ -5,7 +5,7 @@ Authors: Yuma Mizuno
 -/
 import Mathlib.Tactic.CategoryTheory.Coherence.Datatypes
 import Mathlib.Tactic.CategoryTheory.BicategoricalComp
-import QQ
+import Qq
 
 /-!
 # Expressions for bicategories

--- a/Mathlib/Tactic/CategoryTheory/Bicategory/Datatypes.lean
+++ b/Mathlib/Tactic/CategoryTheory/Bicategory/Datatypes.lean
@@ -5,6 +5,7 @@ Authors: Yuma Mizuno
 -/
 import Mathlib.Tactic.CategoryTheory.Coherence.Datatypes
 import Mathlib.Tactic.CategoryTheory.BicategoricalComp
+import QQ
 
 /-!
 # Expressions for bicategories

--- a/Mathlib/Tactic/Widget/StringDiagram.lean
+++ b/Mathlib/Tactic/Widget/StringDiagram.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Yuma Mizuno. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yuma Mizuno
 -/
+import ProofWidgets.Component.OfRpcMethod
 import ProofWidgets.Component.PenroseDiagram
 import ProofWidgets.Component.Panel.Basic
 import ProofWidgets.Presentation.Expr

--- a/Mathlib/Testing/SlimCheck/Functions.lean
+++ b/Mathlib/Testing/SlimCheck/Functions.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
 -/
+import Batteries.Data.MLList.Basic
 import Mathlib.Data.List.Sigma
 import Mathlib.Data.Int.Range
 import Mathlib.Data.Finsupp.Defs

--- a/Mathlib/Topology/Algebra/ProperAction/Basic.lean
+++ b/Mathlib/Topology/Algebra/ProperAction/Basic.lean
@@ -6,6 +6,7 @@ Authors: Anatole Dedeker, Etienne Marion, Florestan Martin-Baillon, Vincent Guir
 import Mathlib.Topology.Algebra.MulAction
 import Mathlib.Topology.Maps.Proper.Basic
 import Mathlib.Topology.Maps.OpenQuotient
+import Mathlib.Tactic.CongrM
 
 /-!
 # Proper group action

--- a/Mathlib/Topology/Defs/Filter.lean
+++ b/Mathlib/Topology/Defs/Filter.lean
@@ -3,9 +3,10 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Jeremy Avigad
 -/
-import Mathlib.Topology.Defs.Basic
-import Mathlib.Order.Filter.Ultrafilter
 import Mathlib.Data.Set.Lattice
+import Mathlib.Order.Filter.Ultrafilter
+import Mathlib.Tactic.IrreducibleDef
+import Mathlib.Topology.Defs.Basic
 
 /-!
 # Definitions about filters in topological spaces

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -5,6 +5,7 @@ Authors: Oliver Nash, Bhavik Mehta, Daniel Weber
 -/
 import Mathlib.Topology.Constructions
 import Mathlib.Topology.Separation.Basic
+import Mathlib.Tactic.CongrM
 
 /-!
 # Discrete subsets of topological spaces

--- a/Mathlib/Topology/Gluing.lean
+++ b/Mathlib/Topology/Gluing.lean
@@ -3,12 +3,13 @@ Copyright (c) 2021 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
+import Mathlib.CategoryTheory.ConcreteCategory.EpiMono
+import Mathlib.CategoryTheory.Elementwise
 import Mathlib.CategoryTheory.GlueData
+import Mathlib.Tactic.DefEqTransformations
+import Mathlib.Tactic.Generalize
 import Mathlib.Topology.Category.TopCat.Limits.Pullbacks
 import Mathlib.Topology.Category.TopCat.Opens
-import Mathlib.Tactic.Generalize
-import Mathlib.CategoryTheory.Elementwise
-import Mathlib.CategoryTheory.ConcreteCategory.EpiMono
 
 /-!
 # Gluing Topological spaces

--- a/Mathlib/Topology/Sheaves/Stalks.lean
+++ b/Mathlib/Topology/Sheaves/Stalks.lean
@@ -3,15 +3,16 @@ Copyright (c) 2019 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison, Justus Springer
 -/
+import Mathlib.Algebra.Category.Ring.Colimits
+import Mathlib.CategoryTheory.Limits.Final
+import Mathlib.CategoryTheory.Limits.Types
+import Mathlib.CategoryTheory.Limits.Preserves.Filtered
+import Mathlib.CategoryTheory.Sites.Pullback
+import Mathlib.Tactic.CategoryTheory.Elementwise
+import Mathlib.Tactic.Rename
 import Mathlib.Topology.Category.TopCat.OpenNhds
 import Mathlib.Topology.Sheaves.Presheaf
 import Mathlib.Topology.Sheaves.SheafCondition.UniqueGluing
-import Mathlib.CategoryTheory.Limits.Types
-import Mathlib.CategoryTheory.Limits.Preserves.Filtered
-import Mathlib.CategoryTheory.Limits.Final
-import Mathlib.Tactic.CategoryTheory.Elementwise
-import Mathlib.Algebra.Category.Ring.Colimits
-import Mathlib.CategoryTheory.Sites.Pullback
 
 /-!
 # Stalks

--- a/Mathlib/Topology/UniformSpace/Equicontinuity.lean
+++ b/Mathlib/Topology/UniformSpace/Equicontinuity.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Anatole Dedecker. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker
 -/
+import Mathlib.Tactic.CongrM
 import Mathlib.Topology.UniformSpace.UniformConvergenceTopology
 
 /-!


### PR DESCRIPTION
I went through the whole of Mathlib and replaced all imports of `Tactic.Common` with a more specialized file. I'm not sure if this is the right way to go, since it seems rather annoying to have to explicitly import basic tactics. But it should reduce some of the noise when testing how to split imports.

Hoard factor:
 * `master`: 0.896884
 * `unimport-Tactic-Common`: 0.894524

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
