### PR TITLE
[Merged by Bors] - chore: refactor roots of unity to avoid PNat

### DIFF
--- a/Mathlib/FieldTheory/KummerExtension.lean
+++ b/Mathlib/FieldTheory/KummerExtension.lean
@@ -246,7 +246,7 @@ We first develop the theory for a specific `K[n√a] := AdjoinRoot (X ^ n - C a)
 The main result is the description of the galois group: `autAdjoinRootXPowSubCEquiv`.
 -/
 
-variable {n : ℕ} (hζ : (primitiveRoots n K).Nonempty) (hn : 0 < n)
+variable {n : ℕ} (hζ : (primitiveRoots n K).Nonempty)
 variable (a : K) (H : Irreducible (X ^ n - C a))
 
 set_option quotPrecheck false in
@@ -280,14 +280,15 @@ theorem Polynomial.separable_X_pow_sub_C_of_irreducible : (X ^ n - C a).Separabl
   exact (hζ.map_of_injective (algebraMap K K[n√a]).injective).injOn_pow_mul
     (root_X_pow_sub_C_ne_zero (lt_of_le_of_ne (show 1 ≤ n from hn) (Ne.symm hn')) _)
 
+variable (n)
+
 /-- The natural embedding of the roots of unity of `K` into `Gal(K[ⁿ√a]/K)`, by sending
 `η ↦ (ⁿ√a ↦ η • ⁿ√a)`. Also see `autAdjoinRootXPowSubC` for the `AlgEquiv` version. -/
 noncomputable
 def autAdjoinRootXPowSubCHom :
-    rootsOfUnity ⟨n, hn⟩ K →* (K[n√a] →ₐ[K] K[n√a]) where
+    rootsOfUnity n K →* (K[n√a] →ₐ[K] K[n√a]) where
   toFun := fun η ↦ liftHom (X ^ n - C a) (((η : Kˣ) : K) • (root _) : K[n√a]) <| by
     have := (mem_rootsOfUnity' _ _).mp η.prop
-    dsimp at this
     rw [map_sub, map_pow, aeval_C, aeval_X, Algebra.smul_def, mul_pow, root_X_pow_sub_C_pow,
       AdjoinRoot.algebraMap_eq, ← map_pow, this, map_one, one_mul, sub_self]
   map_one' := algHom_ext <| by simp
@@ -298,11 +299,13 @@ def autAdjoinRootXPowSubCHom :
 See `autAdjoinRootXPowSubCEquiv`. -/
 noncomputable
 def autAdjoinRootXPowSubC :
-    rootsOfUnity ⟨n, hn⟩ K →* (K[n√a] ≃ₐ[K] K[n√a]) :=
-  (AlgEquiv.algHomUnitsEquiv _ _).toMonoidHom.comp (autAdjoinRootXPowSubCHom hn a).toHomUnits
+    rootsOfUnity n K →* (K[n√a] ≃ₐ[K] K[n√a]) :=
+  (AlgEquiv.algHomUnitsEquiv _ _).toMonoidHom.comp (autAdjoinRootXPowSubCHom n a).toHomUnits
+
+variable {n}
 
 lemma autAdjoinRootXPowSubC_root (η) :
-    autAdjoinRootXPowSubC hn a η (root _) = ((η : Kˣ) : K) • root _ := by
+    autAdjoinRootXPowSubC n a η (root _) = ((η : Kˣ) : K) • root _ := by
   dsimp [autAdjoinRootXPowSubC, autAdjoinRootXPowSubCHom, AlgEquiv.algHomUnitsEquiv]
   apply liftHom_root
 
@@ -311,34 +314,33 @@ variable {a}
 /-- The inverse function of `autAdjoinRootXPowSubC` if `K` has all roots of unity.
 See `autAdjoinRootXPowSubCEquiv`. -/
 noncomputable
-def AdjoinRootXPowSubCEquivToRootsOfUnity (σ : K[n√a] ≃ₐ[K] K[n√a]) :
-    rootsOfUnity ⟨n, hn⟩ K :=
+def AdjoinRootXPowSubCEquivToRootsOfUnity [NeZero n] (σ : K[n√a] ≃ₐ[K] K[n√a]) :
+    rootsOfUnity n K :=
   letI := Fact.mk H
   letI : IsDomain K[n√a] := inferInstance
   letI := Classical.decEq K
-  (rootsOfUnityEquivOfPrimitiveRoots (n := ⟨n, hn⟩) (algebraMap K K[n√a]).injective hζ).symm
+  (rootsOfUnityEquivOfPrimitiveRoots (n := n) (algebraMap K K[n√a]).injective hζ).symm
     (rootsOfUnity.mkOfPowEq (if a = 0 then 1 else σ (root _) / root _) (by
     -- The if is needed in case `n = 1` and `a = 0` and `K[n√a] = K`.
     split
     · exact one_pow _
     rw [div_pow, ← map_pow]
-    simp only [PNat.mk_coe, root_X_pow_sub_C_pow, ← AdjoinRoot.algebraMap_eq, AlgEquiv.commutes]
+    simp only [root_X_pow_sub_C_pow, ← AdjoinRoot.algebraMap_eq, AlgEquiv.commutes]
     rw [div_self]
     rwa [Ne, map_eq_zero_iff _ (algebraMap K _).injective]))
 
 /-- The equivalence between the roots of unity of `K` and `Gal(K[ⁿ√a]/K)`. -/
 noncomputable
-def autAdjoinRootXPowSubCEquiv :
-    rootsOfUnity ⟨n, hn⟩ K ≃* (K[n√a] ≃ₐ[K] K[n√a]) where
-  __ := autAdjoinRootXPowSubC hn a
-  invFun := AdjoinRootXPowSubCEquivToRootsOfUnity hζ hn H
+def autAdjoinRootXPowSubCEquiv [NeZero n] :
+    rootsOfUnity n K ≃* (K[n√a] ≃ₐ[K] K[n√a]) where
+  __ := autAdjoinRootXPowSubC n a
+  invFun := AdjoinRootXPowSubCEquivToRootsOfUnity hζ H
   left_inv := by
     intro η
     have := Fact.mk H
     have : IsDomain K[n√a] := inferInstance
     letI : Algebra K K[n√a] := inferInstance
-    apply (rootsOfUnityEquivOfPrimitiveRoots
-      (n := ⟨n, hn⟩) (algebraMap K K[n√a]).injective hζ).injective
+    apply (rootsOfUnityEquivOfPrimitiveRoots (algebraMap K K[n√a]).injective hζ).injective
     ext
     simp only [AdjoinRoot.algebraMap_eq, OneHom.toFun_eq_coe, MonoidHom.toOneHom_coe,
       autAdjoinRootXPowSubC_root, Algebra.smul_def, ne_eq, MulEquiv.apply_symm_apply,
@@ -347,36 +349,34 @@ def autAdjoinRootXPowSubCEquiv :
     split_ifs with h
     · obtain rfl := not_imp_not.mp (fun hn ↦ ne_zero_of_irreducible_X_pow_sub_C' hn H) h
       have : (η : Kˣ) = 1 := (pow_one _).symm.trans η.prop
-      simp only [PNat.mk_one, this, Units.val_one, map_one]
-    · exact mul_div_cancel_right₀ _ (root_X_pow_sub_C_ne_zero' hn h)
+      simp only [this, Units.val_one, map_one]
+    · exact mul_div_cancel_right₀ _ (root_X_pow_sub_C_ne_zero' (NeZero.pos n) h)
   right_inv := by
     intro e
     have := Fact.mk H
     letI : Algebra K K[n√a] := inferInstance
     apply AlgEquiv.coe_algHom_injective
     apply AdjoinRoot.algHom_ext
-    simp only [AdjoinRoot.algebraMap_eq, OneHom.toFun_eq_coe, MonoidHom.toOneHom_coe,
-      AlgHom.coe_coe, autAdjoinRootXPowSubC_root, Algebra.smul_def, PNat.mk_coe,
-      AdjoinRootXPowSubCEquivToRootsOfUnity]
+    simp only [AdjoinRootXPowSubCEquivToRootsOfUnity, AdjoinRoot.algebraMap_eq, OneHom.toFun_eq_coe,
+      MonoidHom.toOneHom_coe, AlgHom.coe_coe, autAdjoinRootXPowSubC_root, Algebra.smul_def]
     rw [rootsOfUnityEquivOfPrimitiveRoots_symm_apply, rootsOfUnity.val_mkOfPowEq_coe]
     split_ifs with h
     · obtain rfl := not_imp_not.mp (fun hn ↦ ne_zero_of_irreducible_X_pow_sub_C' hn H) h
       rw [(pow_one _).symm.trans (root_X_pow_sub_C_pow 1 a), one_mul,
         ← AdjoinRoot.algebraMap_eq, AlgEquiv.commutes]
-    · refine div_mul_cancel₀ _ (root_X_pow_sub_C_ne_zero' hn h)
+    · refine div_mul_cancel₀ _ (root_X_pow_sub_C_ne_zero' (NeZero.pos n) h)
 
-lemma autAdjoinRootXPowSubCEquiv_root (η) :
-    autAdjoinRootXPowSubCEquiv hζ hn H η (root _) = ((η : Kˣ) : K) • root _ :=
-  autAdjoinRootXPowSubC_root hn a η
+lemma autAdjoinRootXPowSubCEquiv_root [NeZero n] (η) :
+    autAdjoinRootXPowSubCEquiv hζ H η (root _) = ((η : Kˣ) : K) • root _ :=
+  autAdjoinRootXPowSubC_root a η
 
-lemma autAdjoinRootXPowSubCEquiv_symm_smul (σ) :
-    ((autAdjoinRootXPowSubCEquiv hζ hn H).symm σ : Kˣ) • (root _ : K[n√a]) = σ (root _) := by
+lemma autAdjoinRootXPowSubCEquiv_symm_smul [NeZero n] (σ) :
+    ((autAdjoinRootXPowSubCEquiv hζ H).symm σ : Kˣ) • (root _ : K[n√a]) = σ (root _) := by
   have := Fact.mk H
   simp only [autAdjoinRootXPowSubCEquiv, OneHom.toFun_eq_coe, MonoidHom.toOneHom_coe,
     MulEquiv.symm_mk, MulEquiv.coe_mk, Equiv.coe_fn_symm_mk, AdjoinRootXPowSubCEquivToRootsOfUnity,
-    AdjoinRoot.algebraMap_eq, Units.smul_def, Algebra.smul_def,
-    rootsOfUnityEquivOfPrimitiveRoots_symm_apply, rootsOfUnity.mkOfPowEq, PNat.mk_coe,
-    Units.val_ofPowEqOne, ite_mul, one_mul, ne_eq]
+    AdjoinRoot.algebraMap_eq, rootsOfUnity.mkOfPowEq, Units.smul_def, Algebra.smul_def,
+    rootsOfUnityEquivOfPrimitiveRoots_symm_apply, Units.val_ofPowEqOne, ite_mul, one_mul]
   simp_rw [← root_X_pow_sub_C_eq_zero_iff H]
   split_ifs with h
   · rw [h, map_zero]
@@ -459,8 +459,8 @@ abbrev rootOfSplitsXPowSubC (hn : 0 < n) (a : K)
   (rootOfSplits _ (IsSplittingField.splits L (X ^ n - C a))
       (by simpa [degree_X_pow_sub_C hn] using Nat.pos_iff_ne_zero.mp hn))
 
-lemma rootOfSplitsXPowSubC_pow :
-    (rootOfSplitsXPowSubC hn a L) ^ n = algebraMap K L a := by
+lemma rootOfSplitsXPowSubC_pow [NeZero n] :
+    (rootOfSplitsXPowSubC (NeZero.pos n) a L) ^ n = algebraMap K L a := by
   have := map_rootOfSplits _ (IsSplittingField.splits L (X ^ n - C a))
   simp only [eval₂_sub, eval₂_X_pow, eval₂_C, sub_eq_zero] at this
   exact this _
@@ -471,15 +471,15 @@ variable {a}
 roots of unity in `K` if `K` contains all of them.
 Note that this does not depend on a choice of `ⁿ√a`. -/
 noncomputable
-def autEquivRootsOfUnity :
-    (L ≃ₐ[K] L) ≃* (rootsOfUnity ⟨n, hn⟩ K) :=
-  (AlgEquiv.autCongr (adjoinRootXPowSubCEquiv hζ H (rootOfSplitsXPowSubC_pow hn a L)).symm).trans
-    (autAdjoinRootXPowSubCEquiv hζ hn H).symm
+def autEquivRootsOfUnity [NeZero n] :
+    (L ≃ₐ[K] L) ≃* (rootsOfUnity n K) :=
+  (AlgEquiv.autCongr (adjoinRootXPowSubCEquiv hζ H (rootOfSplitsXPowSubC_pow a L)).symm).trans
+    (autAdjoinRootXPowSubCEquiv hζ H).symm
 
-lemma autEquivRootsOfUnity_apply_rootOfSplit (σ : L ≃ₐ[K] L) :
-    σ (rootOfSplitsXPowSubC hn a L) =
-      autEquivRootsOfUnity hζ hn H L σ • (rootOfSplitsXPowSubC hn a L) := by
-  obtain ⟨η, rfl⟩ := (autEquivRootsOfUnity hζ hn H L).symm.surjective σ
+lemma autEquivRootsOfUnity_apply_rootOfSplit [NeZero n] (σ : L ≃ₐ[K] L) :
+    σ (rootOfSplitsXPowSubC (NeZero.pos n) a L) =
+      autEquivRootsOfUnity hζ H L σ • (rootOfSplitsXPowSubC (NeZero.pos n) a L) := by
+  obtain ⟨η, rfl⟩ := (autEquivRootsOfUnity hζ H L).symm.surjective σ
   rw [MulEquiv.apply_symm_apply, autEquivRootsOfUnity]
   simp only [MulEquiv.symm_trans_apply, AlgEquiv.autCongr_symm, AlgEquiv.symm_symm,
     MulEquiv.symm_symm, AlgEquiv.autCongr_apply, AlgEquiv.trans_apply,
@@ -488,43 +488,44 @@ lemma autEquivRootsOfUnity_apply_rootOfSplit (σ : L ≃ₐ[K] L) :
   rfl
 
 include hα in
-lemma autEquivRootsOfUnity_smul (σ : L ≃ₐ[K] L) :
-    autEquivRootsOfUnity hζ hn H L σ • α = σ α := by
+lemma autEquivRootsOfUnity_smul [NeZero n] (σ : L ≃ₐ[K] L) :
+    autEquivRootsOfUnity hζ H L σ • α = σ α := by
   have ⟨ζ, hζ'⟩ := hζ
+  have hn := NeZero.pos n
   rw [mem_primitiveRoots hn] at hζ'
   rw [← mem_nthRoots hn, (hζ'.map_of_injective (algebraMap K L).injective).nthRoots_eq
-    (rootOfSplitsXPowSubC_pow hn a L)] at hα
+    (rootOfSplitsXPowSubC_pow a L)] at hα
   simp only [Finset.range_val, Multiset.mem_map, Multiset.mem_range] at hα
   obtain ⟨i, _, rfl⟩ := hα
   simp only [map_mul, ← map_pow, ← Algebra.smul_def, map_smul,
-    autEquivRootsOfUnity_apply_rootOfSplit hζ hn H L]
+    autEquivRootsOfUnity_apply_rootOfSplit hζ H L]
   exact smul_comm _ _ _
 
 /-- Suppose `L/K` is the splitting field of `Xⁿ - a`, and `ζ` is a `n`-th primitive root of unity
 in `K`, then `Gal(L/K)` is isomorphic to `ZMod n`. -/
 noncomputable
-def autEquivZmod {ζ : K} (hζ : IsPrimitiveRoot ζ n) :
+def autEquivZmod [NeZero n] {ζ : K} (hζ : IsPrimitiveRoot ζ n) :
     (L ≃ₐ[K] L) ≃* Multiplicative (ZMod n) :=
   haveI hn := Nat.pos_iff_ne_zero.mpr (ne_zero_of_irreducible_X_pow_sub_C H)
-  (autEquivRootsOfUnity ⟨ζ, (mem_primitiveRoots hn).mpr hζ⟩ hn H L).trans
-    ((MulEquiv.subgroupCongr (IsPrimitiveRoot.zpowers_eq (k := ⟨n, hn⟩)
+  (autEquivRootsOfUnity ⟨ζ, (mem_primitiveRoots hn).mpr hζ⟩ H L).trans
+    ((MulEquiv.subgroupCongr (IsPrimitiveRoot.zpowers_eq
       (hζ.isUnit_unit' hn)).symm).trans (AddEquiv.toMultiplicative'
         (hζ.isUnit_unit' hn).zmodEquivZPowers.symm))
 
 include hα in
-lemma autEquivZmod_symm_apply_intCast {ζ : K} (hζ : IsPrimitiveRoot ζ n) (m : ℤ) :
+lemma autEquivZmod_symm_apply_intCast [NeZero n] {ζ : K} (hζ : IsPrimitiveRoot ζ n) (m : ℤ) :
     (autEquivZmod H L hζ).symm (Multiplicative.ofAdd (m : ZMod n)) α = ζ ^ m • α := by
   have hn := Nat.pos_iff_ne_zero.mpr (ne_zero_of_irreducible_X_pow_sub_C H)
-  rw [← autEquivRootsOfUnity_smul ⟨ζ, (mem_primitiveRoots hn).mpr hζ⟩ hn H L hα]
+  rw [← autEquivRootsOfUnity_smul ⟨ζ, (mem_primitiveRoots hn).mpr hζ⟩ H L hα]
   simp [MulEquiv.subgroupCongr_symm_apply, Subgroup.smul_def, Units.smul_def, autEquivZmod]
 
 include hα in
-lemma autEquivZmod_symm_apply_natCast {ζ : K} (hζ : IsPrimitiveRoot ζ n) (m : ℕ) :
+lemma autEquivZmod_symm_apply_natCast [NeZero n] {ζ : K} (hζ : IsPrimitiveRoot ζ n) (m : ℕ) :
     (autEquivZmod H L hζ).symm (Multiplicative.ofAdd (m : ZMod n)) α = ζ ^ m • α := by
   simpa only [Int.cast_natCast, zpow_natCast] using autEquivZmod_symm_apply_intCast H L hα hζ m
 
 include hζ H in
-lemma isCyclic_of_isSplittingField_X_pow_sub_C : IsCyclic (L ≃ₐ[K] L) :=
+lemma isCyclic_of_isSplittingField_X_pow_sub_C [NeZero n] : IsCyclic (L ≃ₐ[K] L) :=
   have hn := Nat.pos_iff_ne_zero.mpr (ne_zero_of_irreducible_X_pow_sub_C H)
   isCyclic_of_surjective _
     (autEquivZmod H _ <| (mem_primitiveRoots hn).mp hζ.choose_spec).symm.surjective
@@ -641,6 +642,7 @@ lemma isCyclic_tfae (K L) [Field K] [Field L] [Algebra K L] [FiniteDimensional K
       ∃ a : K, Irreducible (X ^ (finrank K L) - C a) ∧
         IsSplittingField K L (X ^ (finrank K L) - C a),
       ∃ (α : L), α ^ (finrank K L) ∈ Set.range (algebraMap K L) ∧ K⟮α⟯ = ⊤] := by
+  have : NeZero (Module.finrank K L) := NeZero.of_pos finrank_pos
   tfae_have 1 → 3
   | ⟨inst₁, inst₂⟩ => exists_root_adjoin_eq_top_of_isCyclic K L hK
   tfae_have 3 → 2

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -271,7 +271,7 @@ theorem mem_center_iff {A : SpecialLinearGroup n R} :
 def center_equiv_rootsOfUnity' (i : n) :
     center (SpecialLinearGroup n R) ≃* rootsOfUnity (Fintype.card n) R where
   toFun A :=
-    have : Nonempty n := ⟨i⟩
+    haveI : Nonempty n := ⟨i⟩
     rootsOfUnity.mkOfPowEq (↑ₘA i i) <| by
       obtain ⟨r, hr, hr'⟩ := mem_center_iff.mp A.property
       replace hr' : A.val i i = r := by simp only [← hr', scalar_apply, diagonal_apply_eq]

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -266,6 +266,8 @@ theorem mem_center_iff {A : SpecialLinearGroup n R} :
     simpa only [coe_mul, ← hr] using (scalar_commute (n := n) r (Commute.all r) B).symm
 
 /-- An equivalence of groups, from the center of the special linear group to the roots of unity. -/
+-- TODO: this looks like an ugly hack to map 0 --> 1
+--       replace by `max (Fintype.card n) 1`?
 @[simps]
 def center_equiv_rootsOfUnity' (i : n) :
     center (SpecialLinearGroup n R) ≃* rootsOfUnity (Fintype.card n).toPNat' R where
@@ -294,11 +296,13 @@ open scoped Classical in
 /-- An equivalence of groups, from the center of the special linear group to the roots of unity.
 
 See also `center_equiv_rootsOfUnity'`. -/
+-- TODO: this looks like an ugly hack to map 0 --> 1; see above
 noncomputable def center_equiv_rootsOfUnity :
     center (SpecialLinearGroup n R) ≃* rootsOfUnity (Fintype.card n).toPNat' R :=
   (isEmpty_or_nonempty n).by_cases
   (fun hn ↦ by
-    rw [center_eq_bot_of_subsingleton, Fintype.card_eq_zero, Nat.toPNat'_zero, rootsOfUnity_one]
+    rw [center_eq_bot_of_subsingleton, Fintype.card_eq_zero, Nat.toPNat'_zero, PNat.one_coe,
+      rootsOfUnity_one]
     exact MulEquiv.mulEquivOfUnique)
   (fun _ ↦ center_equiv_rootsOfUnity' (Classical.arbitrary n))
 

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -266,16 +266,16 @@ theorem mem_center_iff {A : SpecialLinearGroup n R} :
     simpa only [coe_mul, ← hr] using (scalar_commute (n := n) r (Commute.all r) B).symm
 
 /-- An equivalence of groups, from the center of the special linear group to the roots of unity. -/
--- TODO: this looks like an ugly hack to map 0 --> 1
---       replace by `max (Fintype.card n) 1`?
+-- replaced `(Fintype.card n).mkPNat'` by `Fintype.card n` (note `n` is nonempty here)
 @[simps]
 def center_equiv_rootsOfUnity' (i : n) :
-    center (SpecialLinearGroup n R) ≃* rootsOfUnity (Fintype.card n).toPNat' R where
-  toFun A := rootsOfUnity.mkOfPowEq (↑ₘA i i) <| by
+    center (SpecialLinearGroup n R) ≃* rootsOfUnity (Fintype.card n) R where
+  toFun A :=
     have : Nonempty n := ⟨i⟩
-    obtain ⟨r, hr, hr'⟩ := mem_center_iff.mp A.property
-    replace hr' : A.val i i = r := by simp [← hr']
-    simp [hr, hr']
+    rootsOfUnity.mkOfPowEq (↑ₘA i i) <| by
+      obtain ⟨r, hr, hr'⟩ := mem_center_iff.mp A.property
+      replace hr' : A.val i i = r := by simp only [← hr', scalar_apply, diagonal_apply_eq]
+      simp only [hr', hr]
   invFun a := ⟨⟨a • (1 : Matrix n n R), by aesop⟩,
     Subgroup.mem_center_iff.mpr fun B ↦ Subtype.val_injective <| by simp [coe_mul]⟩
   left_inv A := by
@@ -296,15 +296,17 @@ open scoped Classical in
 /-- An equivalence of groups, from the center of the special linear group to the roots of unity.
 
 See also `center_equiv_rootsOfUnity'`. -/
--- TODO: this looks like an ugly hack to map 0 --> 1; see above
+-- replaced `(Fintype.card n).mkPNat'` by what it means, avoiding `PNat`s.
 noncomputable def center_equiv_rootsOfUnity :
-    center (SpecialLinearGroup n R) ≃* rootsOfUnity (Fintype.card n).toPNat' R :=
+    center (SpecialLinearGroup n R) ≃* rootsOfUnity (max (Fintype.card n) 1) R :=
   (isEmpty_or_nonempty n).by_cases
   (fun hn ↦ by
-    rw [center_eq_bot_of_subsingleton, Fintype.card_eq_zero, Nat.toPNat'_zero, PNat.one_coe,
+    rw [center_eq_bot_of_subsingleton, Fintype.card_eq_zero, max_eq_right_of_lt zero_lt_one,
       rootsOfUnity_one]
     exact MulEquiv.mulEquivOfUnique)
-  (fun _ ↦ center_equiv_rootsOfUnity' (Classical.arbitrary n))
+  (fun _ ↦
+    (max_eq_left (NeZero.one_le : 1 ≤ Fintype.card n)).symm ▸
+      center_equiv_rootsOfUnity' (Classical.arbitrary n))
 
 end center
 

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -353,7 +353,7 @@ theorem adjoin_roots_cyclotomic_eq_adjoin_nth_roots [IsDomain B] {ζ : B} {n : �
     rw [IsRoot.def, ← map_cyclotomic n (algebraMap A B), eval_map, ← aeval_def]
     exact hx.2
   · simp only [mem_singleton_iff, exists_eq_left, mem_setOf_eq] at hx
-    obtain ⟨i, _, rfl⟩ := hζ.eq_pow_of_pow_eq_one hx n.pos
+    obtain ⟨i, _, rfl⟩ := hζ.eq_pow_of_pow_eq_one hx
     refine SetLike.mem_coe.2 (Subalgebra.pow_mem _ (subset_adjoin ?_) _)
     rw [mem_rootSet', map_cyclotomic, aeval_def, ← eval_map, map_cyclotomic, ← IsRoot]
     exact ⟨cyclotomic_ne_zero n B, hζ.isRoot_cyclotomic n.pos⟩
@@ -362,7 +362,7 @@ theorem adjoin_roots_cyclotomic_eq_adjoin_root_cyclotomic {n : ℕ+} [IsDomain B
     (hζ : IsPrimitiveRoot ζ n) : adjoin A ((cyclotomic n A).rootSet B) = adjoin A {ζ} := by
   refine le_antisymm (adjoin_le fun x hx => ?_) (adjoin_mono fun x hx => ?_)
   · suffices hx : x ^ n.1 = 1 by
-      obtain ⟨i, _, rfl⟩ := hζ.eq_pow_of_pow_eq_one hx n.pos
+      obtain ⟨i, _, rfl⟩ := hζ.eq_pow_of_pow_eq_one hx
       exact SetLike.mem_coe.2 (Subalgebra.pow_mem _ (subset_adjoin <| mem_singleton ζ) _)
     refine (isRoot_of_unity_iff n.pos B).2 ?_
     refine ⟨n, Nat.mem_divisors_self n n.ne_zero, ?_⟩

--- a/Mathlib/NumberTheory/Cyclotomic/CyclotomicCharacter.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/CyclotomicCharacter.lean
@@ -67,7 +67,7 @@ variable {L : Type u} [CommRing L] [IsDomain L]
 
 -/
 
-variable (n : ℕ+)
+variable (n : ℕ) [NeZero n]
 
 theorem rootsOfUnity.integer_power_of_ringEquiv (g : L ≃+* L) :
     ∃ m : ℤ, ∀ t : rootsOfUnity n L, g (t : Lˣ) = (t ^ m : Lˣ) := by
@@ -81,18 +81,18 @@ theorem rootsOfUnity.integer_power_of_ringEquiv' (g : L ≃+* L) :
 /-- `ModularCyclotomicCharacter_aux g n` is a non-canonical auxiliary integer `j`,
    only well-defined modulo the number of `n`'th roots of unity in `L`, such that `g(ζ)=ζ^j`
    for all `n`'th roots of unity `ζ` in `L`. -/
-noncomputable def ModularCyclotomicCharacter_aux (g : L ≃+* L) (n : ℕ+) : ℤ :=
+noncomputable def ModularCyclotomicCharacter_aux (g : L ≃+* L) (n : ℕ) [NeZero n] : ℤ :=
   (rootsOfUnity.integer_power_of_ringEquiv n g).choose
 
 -- the only thing we know about `ModularCyclotomicCharacter_aux g n`
-theorem ModularCyclotomicCharacter_aux_spec (g : L ≃+* L) (n : ℕ+) :
+theorem ModularCyclotomicCharacter_aux_spec (g : L ≃+* L) (n : ℕ) [NeZero n] :
     ∀ t : rootsOfUnity n L, g (t : Lˣ) = (t ^ (ModularCyclotomicCharacter_aux g n) : Lˣ) :=
   (rootsOfUnity.integer_power_of_ringEquiv n g).choose_spec
 
 /-- If `g` is a ring automorphism of `L`, and `n : ℕ+`, then
   `ModularCyclotomicCharacter.toFun n g` is the `j : ZMod d` such that `g(ζ)=ζ^j` for all
   `n`'th roots of unity. Here `d` is the number of `n`th roots of unity in `L`. -/
-noncomputable def ModularCyclotomicCharacter.toFun (n : ℕ+) (g : L ≃+* L) :
+noncomputable def ModularCyclotomicCharacter.toFun (n : ℕ) [NeZero n] (g : L ≃+* L) :
     ZMod (Fintype.card (rootsOfUnity n L)) :=
   ModularCyclotomicCharacter_aux g n
 
@@ -101,18 +101,18 @@ namespace ModularCyclotomicCharacter
 local notation "χ₀" => ModularCyclotomicCharacter.toFun
 
 /-- The formula which characterises the output of `ModularCyclotomicCharacter g n`. -/
-theorem toFun_spec (g : L ≃+* L) {n : ℕ+} (t : rootsOfUnity n L) :
+theorem toFun_spec (g : L ≃+* L) {n : ℕ} [NeZero n] (t : rootsOfUnity n L) :
     g (t : Lˣ) = (t ^ (χ₀ n g).val : Lˣ) := by
   rw [ModularCyclotomicCharacter_aux_spec g n t, ← zpow_natCast, ModularCyclotomicCharacter.toFun,
     ZMod.val_intCast, ← Subgroup.coe_zpow]
   exact Units.ext_iff.1 <| SetCoe.ext_iff.2 <|
     zpow_eq_zpow_emod _ pow_card_eq_one (G := rootsOfUnity n L)
 
-theorem toFun_spec' (g : L ≃+* L) {n : ℕ+} {t : Lˣ} (ht : t ∈ rootsOfUnity n L) :
+theorem toFun_spec' (g : L ≃+* L) {n : ℕ} [NeZero n] {t : Lˣ} (ht : t ∈ rootsOfUnity n L) :
     g t = t ^ (χ₀ n g).val :=
   toFun_spec g ⟨t, ht⟩
 
-theorem toFun_spec'' (g : L ≃+* L) {n : ℕ+} {t : L} (ht : IsPrimitiveRoot t n) :
+theorem toFun_spec'' (g : L ≃+* L) {n : ℕ} [NeZero n] {t : L} (ht : IsPrimitiveRoot t n) :
     g t = t ^ (χ₀ n g).val :=
   toFun_spec' g (SetLike.coe_mem ht.toRootsOfUnity)
 
@@ -159,7 +159,7 @@ where `d` is the number of `n`'th roots of unity in `L`. It is uniquely
 characterised by the property that `g(ζ)=ζ^(ModularCyclotomicCharacter n g)`
 for `g` an automorphism of `L` and `ζ` an `n`th root of unity. -/
 noncomputable
-def ModularCyclotomicCharacter' (n : ℕ+) :
+def ModularCyclotomicCharacter' (n : ℕ) [NeZero n] :
     (L ≃+* L) →* (ZMod (Fintype.card { x // x ∈ rootsOfUnity n L }))ˣ := MonoidHom.toHomUnits
   { toFun := ModularCyclotomicCharacter.toFun n
     map_one' := ModularCyclotomicCharacter.id n
@@ -180,7 +180,7 @@ of unity, `ModularCyclotomicCharacter n` is a multiplicative homomorphism from t
 automorphisms of `L` to `(ℤ/nℤ)ˣ`. It is uniquely characterised by the property that
 `g(ζ)=ζ^(ModularCyclotomicCharacter n g)` for `g` an automorphism of `L` and `ζ` any `n`th root
 of unity. -/
-noncomputable def ModularCyclotomicCharacter {n : ℕ+}
+noncomputable def ModularCyclotomicCharacter {n : ℕ} [NeZero n]
     (hn : Fintype.card { x // x ∈ rootsOfUnity n L } = n) :
     (L ≃+* L) →* (ZMod n)ˣ :=
   (Units.mapEquiv <| (ZMod.ringEquivCongr hn).toMulEquiv).toMonoidHom.comp
@@ -188,7 +188,7 @@ noncomputable def ModularCyclotomicCharacter {n : ℕ+}
 
 namespace ModularCyclotomicCharacter
 
-variable {n : ℕ+} (hn : Fintype.card { x // x ∈ rootsOfUnity n L } = n)
+variable {n : ℕ} [NeZero n] (hn : Fintype.card { x // x ∈ rootsOfUnity n L } = n)
 
 lemma spec (g : L ≃+* L) {t : Lˣ} (ht : t ∈ rootsOfUnity n L) :
     g t = t ^ ((ModularCyclotomicCharacter L hn g) : ZMod n).val := by
@@ -210,11 +210,14 @@ variable {L}
 /-- The relationship between `IsPrimitiveRoot.autToPow` and
 `ModularCyclotomicCharacter`. Note that `IsPrimitiveRoot.autToPow`
 needs an explicit root of unity, and also an auxiliary "base ring" `R`. -/
-lemma IsPrimitiveRoot.autToPow_eq_ModularCyclotomicCharacter (n : ℕ+)
+lemma IsPrimitiveRoot.autToPow_eq_ModularCyclotomicCharacter (n : ℕ) [NeZero n]
     (R : Type*) [CommRing R] [Algebra R L] {μ : L} (hμ : IsPrimitiveRoot μ n) (g : L ≃ₐ[R] L) :
     hμ.autToPow R g = ModularCyclotomicCharacter L hμ.card_rootsOfUnity g := by
   ext
   apply ZMod.val_injective
   apply hμ.pow_inj (ZMod.val_lt _) (ZMod.val_lt _)
-  simpa [autToPow_spec R hμ g, ModularCyclotomicCharacter', ModularCyclotomicCharacter,
-    ZMod.ringEquivCongr_val] using ModularCyclotomicCharacter.toFun_spec'' g hμ
+  simpa only [autToPow_spec R hμ g, ModularCyclotomicCharacter, RingEquiv.toMulEquiv_eq_coe,
+    MulEquiv.toMonoidHom_eq_coe, ModularCyclotomicCharacter', MonoidHom.coe_comp, MonoidHom.coe_coe,
+    Function.comp_apply, Units.coe_mapEquiv, MonoidHom.coe_toHomUnits, MonoidHom.coe_mk,
+    OneHom.coe_mk, RingEquiv.coe_toMulEquiv, ZMod.ringEquivCongr_val, AlgEquiv.coe_ringEquiv]
+    using ModularCyclotomicCharacter.toFun_spec'' g hμ

--- a/Mathlib/NumberTheory/Cyclotomic/CyclotomicCharacter.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/CyclotomicCharacter.lean
@@ -72,7 +72,9 @@ variable (n : ℕ) [NeZero n]
 theorem rootsOfUnity.integer_power_of_ringEquiv (g : L ≃+* L) :
     ∃ m : ℤ, ∀ t : rootsOfUnity n L, g (t : Lˣ) = (t ^ m : Lˣ) := by
   obtain ⟨m, hm⟩ := MonoidHom.map_cyclic ((g : L ≃* L).restrictRootsOfUnity n).toMonoidHom
-  exact ⟨m, fun t ↦ Units.ext_iff.1 <| SetCoe.ext_iff.2 <| hm t⟩
+  refine ⟨m, fun t ↦ ?_⟩ --Units.ext_iff.1 <| SetCoe.ext_iff.2 <| hm t⟩
+  rw [← SubgroupClass.coe_zpow, ← hm t, MulEquiv.toMonoidHom_eq_coe, MonoidHom.coe_coe,
+    MulEquiv.restrictRootsOfUnity_coe_apply, RingEquiv.coe_toMulEquiv]
 
 theorem rootsOfUnity.integer_power_of_ringEquiv' (g : L ≃+* L) :
     ∃ m : ℤ, ∀ t ∈ rootsOfUnity n L, g (t : Lˣ) = (t ^ m : Lˣ) := by

--- a/Mathlib/NumberTheory/Cyclotomic/CyclotomicCharacter.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/CyclotomicCharacter.lean
@@ -72,9 +72,7 @@ variable (n : ℕ) [NeZero n]
 theorem rootsOfUnity.integer_power_of_ringEquiv (g : L ≃+* L) :
     ∃ m : ℤ, ∀ t : rootsOfUnity n L, g (t : Lˣ) = (t ^ m : Lˣ) := by
   obtain ⟨m, hm⟩ := MonoidHom.map_cyclic ((g : L ≃* L).restrictRootsOfUnity n).toMonoidHom
-  refine ⟨m, fun t ↦ ?_⟩ --Units.ext_iff.1 <| SetCoe.ext_iff.2 <| hm t⟩
-  rw [← SubgroupClass.coe_zpow, ← hm t, MulEquiv.toMonoidHom_eq_coe, MonoidHom.coe_coe,
-    MulEquiv.restrictRootsOfUnity_coe_apply, RingEquiv.coe_toMulEquiv]
+  exact ⟨m, fun t ↦ Units.ext_iff.1 <| SetCoe.ext_iff.2 <| hm t⟩
 
 theorem rootsOfUnity.integer_power_of_ringEquiv' (g : L ≃+* L) :
     ∃ m : ℤ, ∀ t ∈ rootsOfUnity n L, g (t : Lˣ) = (t ^ m : Lˣ) := by

--- a/Mathlib/NumberTheory/Cyclotomic/Gal.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Gal.lean
@@ -54,7 +54,7 @@ theorem autToPow_injective : Function.Injective <| hμ.autToPow K := by
   intro f g hfg
   apply_fun Units.val at hfg
   simp only [IsPrimitiveRoot.coe_autToPow_apply] at hfg
-  generalize_proofs hf' hg' at hfg
+  generalize_proofs hn₀ hf' hg' at hfg
   have hf := hf'.choose_spec
   have hg := hg'.choose_spec
   generalize_proofs hζ at hf hg
@@ -68,9 +68,8 @@ theorem autToPow_injective : Function.Injective <| hμ.autToPow K := by
   congr 2
   rw [pow_eq_pow_iff_modEq]
   convert hfg
-  rw [hμ.eq_orderOf]
-  -- Porting note: was `{occs := occurrences.pos [2]}`
-  conv_rhs => rw [← hμ.val_toRootsOfUnity_coe]
+  -- Porting note: was `{occs := occurrences.pos [2]}` (for the second rewrite)
+  conv => enter [2]; rw [hμ.eq_orderOf, ← hμ.val_toRootsOfUnity_coe]
   rw [orderOf_units, Subgroup.orderOf_coe]
 
 end IsPrimitiveRoot
@@ -113,7 +112,7 @@ noncomputable def autEquivPow (h : Irreducible (cyclotomic n K)) : (L ≃ₐ[K] 
       simp only [IsPrimitiveRoot.powerBasis_gen, IsPrimitiveRoot.autToPow_spec]
     right_inv := fun x => by
       simp only [MonoidHom.toFun_eq_coe]
-      generalize_proofs _ h
+      generalize_proofs _ _ h
       have key := hζ.autToPow_spec K ((hζ.powerBasis K).equivOfMinpoly ((hμ x).powerBasis K) h)
       have := (hζ.powerBasis K).equivOfMinpoly_gen ((hμ x).powerBasis K) h
       rw [hζ.powerBasis_gen K] at this
@@ -135,7 +134,7 @@ variable (h : Irreducible (cyclotomic n K)) {L}
 
 /-- Maps `μ` to the `AlgEquiv` that sends `IsCyclotomicExtension.zeta` to `μ`. -/
 noncomputable def fromZetaAut : L ≃ₐ[K] L :=
-  let hζ := (zeta_spec n K L).eq_pow_of_pow_eq_one hμ.pow_eq_one n.pos
+  let hζ := (zeta_spec n K L).eq_pow_of_pow_eq_one hμ.pow_eq_one
   (autEquivPow L h).symm <|
     ZMod.unitOfCoprime hζ.choose <|
       ((zeta_spec n K L).pow_iff_coprime n.pos hζ.choose).mp <| hζ.choose_spec.2.symm ▸ hμ

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -252,7 +252,7 @@ theorem exists_neg_pow_of_isOfFinOrder [IsCyclotomicExtension {n} ℚ K]
   rw [isRoot_cyclotomic_iff] at hlroot
   obtain ⟨a, ha⟩ := hlroot.dvd_of_isCyclotomicExtension n hlzero.1
   replace hlroot : x ^ (2 * (n : ℕ)) = 1 := by rw [ha, pow_mul, hlroot.pow_eq_one, one_pow]
-  obtain ⟨s, -, hs⟩ := hnegζ.eq_pow_of_pow_eq_one hlroot (by simp)
+  obtain ⟨s, -, hs⟩ := hnegζ.eq_pow_of_pow_eq_one hlroot
   exact ⟨s, hs.symm⟩
 
 /-- If `x` is a root of unity (spelled as `IsOfFinOrder x`) in an `n`-th cyclotomic extension of

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -236,33 +236,33 @@ variable {F R : Type*} [Fintype F] [Field F] [CommRing R] [IsDomain R]
 /-- If `χ` and `φ` are multiplicative characters on a finite field `F` satisfying `χ^n = φ^n = 1`
 and with values in an integral domain `R`, and `μ` is a primitive `n`th root of unity in `R`,
 then the Jacobi sum `J(χ,φ)` is in `ℤ[μ] ⊆ R`. -/
-lemma jacobiSum_mem_algebraAdjoin_of_pow_eq_one {n : ℕ} (hn : n ≠ 0) {χ φ : MulChar F R}
+lemma jacobiSum_mem_algebraAdjoin_of_pow_eq_one {n : ℕ} [NeZero n] {χ φ : MulChar F R}
     (hχ : χ ^ n = 1) (hφ : φ ^ n = 1) {μ : R} (hμ : IsPrimitiveRoot μ n) :
     jacobiSum χ φ ∈ Algebra.adjoin ℤ {μ} :=
   Subalgebra.sum_mem _ fun _ _ ↦ Subalgebra.mul_mem _
-    (MulChar.apply_mem_algebraAdjoin_of_pow_eq_one hn hχ hμ _)
-    (MulChar.apply_mem_algebraAdjoin_of_pow_eq_one hn hφ hμ _)
+    (MulChar.apply_mem_algebraAdjoin_of_pow_eq_one hχ hμ _)
+    (MulChar.apply_mem_algebraAdjoin_of_pow_eq_one hφ hμ _)
 
 open Algebra in
 private
-lemma MulChar.exists_apply_sub_one_eq_mul_sub_one {n : ℕ} (hn : n ≠ 0) {χ : MulChar F R} {μ : R}
+lemma MulChar.exists_apply_sub_one_eq_mul_sub_one {n : ℕ} [NeZero n] {χ : MulChar F R} {μ : R}
     (hχ : χ ^ n = 1) (hμ : IsPrimitiveRoot μ n) {x : F} (hx : x ≠ 0) :
     ∃ z ∈ Algebra.adjoin ℤ {μ}, χ x - 1 = z * (μ - 1) := by
-  obtain ⟨k, _, hk⟩ := exists_apply_eq_pow hn hχ hμ hx
+  obtain ⟨k, _, hk⟩ := exists_apply_eq_pow hχ hμ hx
   refine hk ▸ ⟨(Finset.range k).sum (μ ^ ·), ?_, (geom_sum_mul μ k).symm⟩
   exact Subalgebra.sum_mem _ fun m _ ↦ Subalgebra.pow_mem _ (self_mem_adjoin_singleton _ μ) _
 
 private
-lemma MulChar.exists_apply_sub_one_mul_apply_sub_one {n : ℕ} (hn : n ≠ 0) {χ ψ : MulChar F R}
+lemma MulChar.exists_apply_sub_one_mul_apply_sub_one {n : ℕ} [NeZero n] {χ ψ : MulChar F R}
     {μ : R} (hχ : χ ^ n = 1) (hψ : ψ ^ n = 1) (hμ : IsPrimitiveRoot μ n) (x : F) :
     ∃ z ∈ Algebra.adjoin ℤ {μ}, (χ x - 1) * (ψ (1 - x) - 1) = z * (μ - 1) ^ 2 := by
   rcases eq_or_ne x 0 with rfl | hx₀
   · exact ⟨0, Subalgebra.zero_mem _, by rw [sub_zero, ψ.map_one, sub_self, mul_zero, zero_mul]⟩
   rcases eq_or_ne x 1 with rfl | hx₁
   · exact ⟨0, Subalgebra.zero_mem _, by rw [χ.map_one, sub_self, zero_mul, zero_mul]⟩
-  obtain ⟨z₁, hz₁, Hz₁⟩ := MulChar.exists_apply_sub_one_eq_mul_sub_one hn hχ hμ hx₀
+  obtain ⟨z₁, hz₁, Hz₁⟩ := MulChar.exists_apply_sub_one_eq_mul_sub_one hχ hμ hx₀
   obtain ⟨z₂, hz₂, Hz₂⟩ :=
-    MulChar.exists_apply_sub_one_eq_mul_sub_one hn hψ hμ (sub_ne_zero_of_ne hx₁.symm)
+    MulChar.exists_apply_sub_one_eq_mul_sub_one hψ hμ (sub_ne_zero_of_ne hx₁.symm)
   rewrite [Hz₁, Hz₂, sq]
   exact ⟨z₁ * z₂, Subalgebra.mul_mem _ hz₁ hz₂, mul_mul_mul_comm ..⟩
 
@@ -288,7 +288,8 @@ lemma exists_jacobiSum_eq_neg_one_add {n : ℕ} (hn : 2 < n) {χ ψ : MulChar F 
     rw [jacobiSum_comm, hψ₀, jacobiSum_one_nontrivial hχ₀, zero_mul, add_zero]
   · classical
     rw [jacobiSum_eq_aux, MulChar.sum_eq_zero_of_ne_one hχ₀, MulChar.sum_eq_zero_of_ne_one hψ₀, hq]
-    have H := MulChar.exists_apply_sub_one_mul_apply_sub_one (by omega) hχ hψ hμ
+    have : NeZero n := ⟨by omega⟩
+    have H := MulChar.exists_apply_sub_one_mul_apply_sub_one hχ hψ hμ
     have Hcs x := (H x).choose_spec
     refine ⟨-q * z₁ + ∑ x ∈ (univ \ {0, 1} : Finset F), (H x).choose, ?_, ?_⟩
     · refine Subalgebra.add_mem _ (Subalgebra.mul_mem _ (Subalgebra.neg_mem _ ?_) hz₁) ?_

--- a/Mathlib/NumberTheory/MulChar/Lemmas.lean
+++ b/Mathlib/NumberTheory/MulChar/Lemmas.lean
@@ -186,10 +186,9 @@ variable [IsDomain R]
 
 /-- If `χ` is a multiplicative character with `χ^n = 1` and `μ` is a primitive `n`th root
 of unity, then, for `a ≠ 0`, there is some `k` such that `χ a = μ^k`. -/
-lemma exists_apply_eq_pow {χ : MulChar F R} {n : ℕ} (hn : n ≠ 0) (hχ : χ ^ n = 1) {μ : R}
+lemma exists_apply_eq_pow {χ : MulChar F R} {n : ℕ} [NeZero n] (hχ : χ ^ n = 1) {μ : R}
     (hμ : IsPrimitiveRoot μ n) {a : F} (ha : a ≠ 0) :
     ∃ k < n, χ a = μ ^ k := by
-  have : NeZero n := ⟨hn⟩
   obtain ⟨ζ, hζ₁, hζ₂⟩ := apply_mem_rootsOfUnity_of_pow_eq_one hχ ha
   have hζ' : ζ.val ^ n = 1 := (mem_rootsOfUnity' n ↑ζ).mp hζ₁
   obtain ⟨k, hk₁, hk₂⟩ := hμ.eq_pow_of_pow_eq_one hζ'
@@ -197,13 +196,12 @@ lemma exists_apply_eq_pow {χ : MulChar F R} {n : ℕ} (hn : n ≠ 0) (hχ : χ 
 
 /-- The values of a multiplicative character `χ` such that `χ^n = 1` are contained in `ℤ[μ]` when
 `μ` is a primitive `n`th root of unity. -/
-lemma apply_mem_algebraAdjoin_of_pow_eq_one {χ : MulChar F R} {n : ℕ} (hn : n ≠ 0) (hχ : χ ^ n = 1)
+lemma apply_mem_algebraAdjoin_of_pow_eq_one {χ : MulChar F R} {n : ℕ} [NeZero n] (hχ : χ ^ n = 1)
     {μ : R} (hμ : IsPrimitiveRoot μ n) (a : F) :
     χ a ∈ Algebra.adjoin ℤ {μ} := by
   rcases eq_or_ne a 0 with rfl | h
   · exact χ.map_zero ▸ Subalgebra.zero_mem _
-  · have : NeZero n := ⟨hn⟩
-    obtain ⟨ζ, hζ₁, hζ₂⟩ := apply_mem_rootsOfUnity_of_pow_eq_one hχ h
+  · obtain ⟨ζ, hζ₁, hζ₂⟩ := apply_mem_rootsOfUnity_of_pow_eq_one hχ h
     rw [mem_rootsOfUnity, Units.ext_iff, Units.val_pow_eq_pow_val] at hζ₁
     obtain ⟨k, _, hk⟩ := IsPrimitiveRoot.eq_pow_of_pow_eq_one hμ hζ₁
     exact hζ₂ ▸ hk ▸ Subalgebra.pow_mem _ (Algebra.self_mem_adjoin_singleton ℤ μ) k
@@ -213,7 +211,8 @@ lemma apply_mem_algebraAdjoin_of_pow_eq_one {χ : MulChar F R} {n : ℕ} (hn : n
 lemma apply_mem_algebraAdjoin {χ : MulChar F R} {μ : R} (hμ : IsPrimitiveRoot μ (orderOf χ))
     (a : F) :
     χ a ∈ Algebra.adjoin ℤ {μ} :=
-  apply_mem_algebraAdjoin_of_pow_eq_one χ.orderOf_pos.ne' (pow_orderOf_eq_one χ) hμ a
+  have : NeZero (orderOf χ) := ⟨χ.orderOf_pos.ne'⟩
+  apply_mem_algebraAdjoin_of_pow_eq_one (pow_orderOf_eq_one χ) hμ a
 
 end FiniteField
 

--- a/Mathlib/NumberTheory/MulChar/Lemmas.lean
+++ b/Mathlib/NumberTheory/MulChar/Lemmas.lean
@@ -46,8 +46,8 @@ lemma star_apply [StarRing R'] (χ : MulChar R R') (a : R) : (star χ) a = star 
 
 /-- The values of a multiplicative character on `R` are `n`th roots of unity, where `n = #Rˣ`. -/
 lemma apply_mem_rootsOfUnity [Fintype Rˣ] (a : Rˣ) {χ : MulChar R R'} :
-    equivToUnitHom χ a ∈ rootsOfUnity ⟨Fintype.card Rˣ, Fintype.card_pos⟩ R' := by
-  rw [mem_rootsOfUnity, ← map_pow, ← (equivToUnitHom χ).map_one, PNat.mk_coe, pow_card_eq_one]
+    equivToUnitHom χ a ∈ rootsOfUnity (Fintype.card Rˣ) R' := by
+  rw [mem_rootsOfUnity, ← map_pow, ← (equivToUnitHom χ).map_one, pow_card_eq_one]
 
 variable [Finite Rˣ]
 
@@ -172,23 +172,21 @@ variable {R : Type*} [CommRing R]
 
 /- The non-zero values of a multiplicative character of order `n` are `n`th roots of unity. -/
 lemma apply_mem_rootsOfUnity_orderOf (χ : MulChar F R) {a : F} (ha : a ≠ 0) :
-    ∃ ζ ∈ rootsOfUnity ⟨orderOf χ, χ.orderOf_pos⟩ R, ζ = χ a := by
+    ∃ ζ ∈ rootsOfUnity (orderOf χ) R, ζ = χ a := by
   have hu : IsUnit (χ a) := ha.isUnit.map χ
   refine ⟨hu.unit, ?_, IsUnit.unit_spec hu⟩
-  rw [mem_rootsOfUnity, PNat.mk_coe, Units.ext_iff, Units.val_pow_eq_pow_val, Units.val_one,
+  rw [mem_rootsOfUnity, Units.ext_iff, Units.val_pow_eq_pow_val, Units.val_one,
     IsUnit.unit_spec, ← χ.pow_apply' χ.orderOf_pos.ne', pow_orderOf_eq_one,
     show a = (isUnit_iff_ne_zero.mpr ha).unit by simp only [IsUnit.unit_spec],
     MulChar.one_apply_coe]
 
 /-- The non-zero values of a multiplicative character `χ` such that `χ^n = 1`
 are `n`th roots of unity. -/
-lemma apply_mem_rootsOfUnity_of_pow_eq_one {χ : MulChar F R} {n : ℕ} (hn : n ≠ 0) (hχ : χ ^ n = 1)
+lemma apply_mem_rootsOfUnity_of_pow_eq_one {χ : MulChar F R} {n : ℕ} (hχ : χ ^ n = 1)
     {a : F} (ha : a ≠ 0) :
-    ∃ ζ ∈ rootsOfUnity ⟨n, Nat.pos_of_ne_zero hn⟩ R, ζ = χ a := by
+    ∃ ζ ∈ rootsOfUnity n R, ζ = χ a := by
   obtain ⟨μ, hμ₁, hμ₂⟩ := χ.apply_mem_rootsOfUnity_orderOf ha
-  have hχ' : PNat.val ⟨orderOf χ, χ.orderOf_pos⟩ ∣ PNat.val ⟨n, Nat.pos_of_ne_zero hn⟩ :=
-    orderOf_dvd_of_pow_eq_one hχ
-  exact ⟨μ, rootsOfUnity_le_of_dvd (PNat.dvd_iff.mpr hχ') hμ₁, hμ₂⟩
+  exact ⟨μ, rootsOfUnity_le_of_dvd (orderOf_dvd_of_pow_eq_one hχ) hμ₁, hμ₂⟩
 
 -- Results involving primitive roots of unity require `R` to be an integral domain.
 variable [IsDomain R]
@@ -198,10 +196,10 @@ of unity, then, for `a ≠ 0`, there is some `k` such that `χ a = μ^k`. -/
 lemma exists_apply_eq_pow {χ : MulChar F R} {n : ℕ} (hn : n ≠ 0) (hχ : χ ^ n = 1) {μ : R}
     (hμ : IsPrimitiveRoot μ n) {a : F} (ha : a ≠ 0) :
     ∃ k < n, χ a = μ ^ k := by
-  have hn' := Nat.pos_of_ne_zero hn
-  obtain ⟨ζ, hζ₁, hζ₂⟩ := apply_mem_rootsOfUnity_of_pow_eq_one hn hχ ha
-  have hζ' : ζ.val ^ n = 1 := (mem_rootsOfUnity' ⟨n, hn'⟩ ↑ζ).mp hζ₁
-  obtain ⟨k, hk₁, hk₂⟩ := hμ.eq_pow_of_pow_eq_one hζ' hn'
+  have : NeZero n := ⟨hn⟩
+  obtain ⟨ζ, hζ₁, hζ₂⟩ := apply_mem_rootsOfUnity_of_pow_eq_one hχ ha
+  have hζ' : ζ.val ^ n = 1 := (mem_rootsOfUnity' n ↑ζ).mp hζ₁
+  obtain ⟨k, hk₁, hk₂⟩ := hμ.eq_pow_of_pow_eq_one hζ'
   exact ⟨k, hk₁, (hζ₂ ▸ hk₂).symm⟩
 
 /-- The values of a multiplicative character `χ` such that `χ^n = 1` are contained in `ℤ[μ]` when
@@ -211,9 +209,10 @@ lemma apply_mem_algebraAdjoin_of_pow_eq_one {χ : MulChar F R} {n : ℕ} (hn : n
     χ a ∈ Algebra.adjoin ℤ {μ} := by
   rcases eq_or_ne a 0 with rfl | h
   · exact χ.map_zero ▸ Subalgebra.zero_mem _
-  · obtain ⟨ζ, hζ₁, hζ₂⟩ := apply_mem_rootsOfUnity_of_pow_eq_one hn hχ h
+  · have : NeZero n := ⟨hn⟩
+    obtain ⟨ζ, hζ₁, hζ₂⟩ := apply_mem_rootsOfUnity_of_pow_eq_one hχ h
     rw [mem_rootsOfUnity, Units.ext_iff, Units.val_pow_eq_pow_val] at hζ₁
-    obtain ⟨k, _, hk⟩ := IsPrimitiveRoot.eq_pow_of_pow_eq_one hμ hζ₁ (Nat.pos_of_ne_zero hn)
+    obtain ⟨k, _, hk⟩ := IsPrimitiveRoot.eq_pow_of_pow_eq_one hμ hζ₁
     exact hζ₂ ▸ hk ▸ Subalgebra.pow_mem _ (Algebra.self_mem_adjoin_singleton ℤ μ) k
 
 /-- The values of a multiplicative character of order `n` are contained in `ℤ[μ]` when

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -834,8 +834,8 @@ theorem card_rootsOfUnity {n : ℕ} [NeZero n] (h : IsPrimitiveRoot ζ n) :
 /-- The cardinality of the multiset `nthRoots ↑n (1 : R)` is `n`
 if there is a primitive root of unity in `R`. -/
 theorem card_nthRoots_one {ζ : R} {n : ℕ} (h : IsPrimitiveRoot ζ n) :
-    Multiset.card (nthRoots n (1 : R)) = n :=
-  by rw [card_nthRoots h, if_pos ⟨ζ, h.pow_eq_one⟩]
+    Multiset.card (nthRoots n (1 : R)) = n := by
+  rw [card_nthRoots h, if_pos ⟨ζ, h.pow_eq_one⟩]
 
 theorem nthRoots_nodup {ζ : R} {n : ℕ} (h : IsPrimitiveRoot ζ n) {a : R} (ha : a ≠ 0) :
     (nthRoots n a).Nodup := by

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -144,8 +144,7 @@ def restrictRootsOfUnity [MonoidHomClass F R S] (σ : F) (n : ℕ) :
       ext1; simp only [Subgroup.coe_mul, map_mul, MulMemClass.mk_mul_mk] }
 
 @[simp]
-theorem restrictRootsOfUnity_coe_apply [MonoidHomClass F R S] (σ : F)
-    (ζ : rootsOfUnity k R) :
+theorem restrictRootsOfUnity_coe_apply [MonoidHomClass F R S] (σ : F) (ζ : rootsOfUnity k R) :
     (restrictRootsOfUnity σ k ζ : Sˣ) = σ (ζ : Rˣ) :=
   rfl
 
@@ -154,8 +153,8 @@ nonrec def MulEquiv.restrictRootsOfUnity (σ : R ≃* S) (n : ℕ) :
     rootsOfUnity n R ≃* rootsOfUnity n S where
   toFun := restrictRootsOfUnity σ n
   invFun := restrictRootsOfUnity σ.symm n
-  left_inv ξ := by ext; simp only [restrictRootsOfUnity_coe_apply, symm_apply_apply]
-  right_inv ξ := by ext; simp only [restrictRootsOfUnity_coe_apply, apply_symm_apply]
+  left_inv ξ := by ext; exact σ.symm_apply_apply _
+  right_inv ξ := by ext; exact σ.apply_symm_apply _
   map_mul' := (restrictRootsOfUnity _ n).map_mul
 
 @[simp]
@@ -729,20 +728,9 @@ theorem eq_pow_of_mem_rootsOfUnity {k : ℕ} [NeZero k] {ζ ξ : Rˣ} (h : IsPri
   · rw [← zpow_natCast, hi₀, ← Int.emod_add_ediv n k, zpow_add, zpow_mul, h.zpow_eq_one, one_zpow,
       mul_one]
 
-/- /-- A version of `IsPrimitiveRoot.eq_pow_of_mem_rootsOfUnity` that takes a natural number `k`
-as argument instead of a `PNat` (and `ζ : R` instead of `ζ : Rˣ`). -/
-lemma eq_pow_of_mem_rootsOfUnity' {k : ℕ} (hk : 0 < k) {ζ : R} (hζ : IsPrimitiveRoot ζ k) {ξ : Rˣ}
-    (hξ : ξ ∈ rootsOfUnity k R) :
-    ∃ i < k, ζ ^ i = ξ := by
-  have hζ' : IsPrimitiveRoot (hζ.isUnit hk).unit (⟨k, hk⟩ : ℕ+) := isUnit_unit hk hζ
-  obtain ⟨i, hi₁, hi₂⟩ := hζ'.eq_pow_of_mem_rootsOfUnity hξ
-  simpa only [Units.val_pow_eq_pow_val, IsUnit.unit_spec]
-    using ⟨i, hi₁, congrArg ((↑) : Rˣ → R) hi₂⟩
- -/
-
 theorem eq_pow_of_pow_eq_one {k : ℕ} [NeZero k] {ζ ξ : R} (h : IsPrimitiveRoot ζ k)
     (hξ : ξ ^ k = 1) :
-  ∃ i < k, ζ ^ i = ξ := by
+    ∃ i < k, ζ ^ i = ξ := by
   lift ζ to Rˣ using h.isUnit <| NeZero.pos k
   lift ξ to Rˣ using isUnit_ofPowEqOne hξ <| NeZero.ne k
   simp only [← Units.val_pow_eq_pow_val, ← Units.ext_iff]

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -132,30 +132,25 @@ section CommMonoid
 variable [CommMonoid R] [CommMonoid S] [FunLike F R S]
 
 /-- Restrict a ring homomorphism to the nth roots of unity. -/
-def restrictRootsOfUnity [MonoidHomClass F R S] (σ : F) :
-    (n : ℕ) → rootsOfUnity n R →* rootsOfUnity n S
-  | 0 =>
-    { toFun := fun ξ ↦ ⟨Units.map σ (ξ : Rˣ), by simp only [rootsOfUnity_zero, Subgroup.mem_top]⟩
-      map_one' := by ext1; simp only [OneMemClass.coe_one, map_one]
-      map_mul' := fun ξ₁ ξ₂ ↦ by
-        ext1; simp only [Subgroup.coe_mul, map_mul, MulMemClass.mk_mul_mk]}
-  | n + 1 =>
-    let h : ∀ ξ : rootsOfUnity (n + 1) R, (σ (ξ : Rˣ)) ^ (n + 1) = 1 := fun ξ => by
-      rw [← map_pow, ← Units.val_pow_eq_pow_val, show (ξ : Rˣ) ^ (n + 1) = 1 from ξ.2,
-        Units.val_one, map_one σ]
-    { toFun := fun ξ =>
-        ⟨@unitOfInvertible _ _ _ (invertibleOfPowEqOne _ _ (h ξ) (Nat.zero_ne_add_one n).symm), by
-          ext; rw [Units.val_pow_eq_pow_val]; exact h ξ⟩
-      map_one' := by ext; exact map_one σ
-      map_mul' := fun ξ₁ ξ₂ => by ext; rw [Subgroup.coe_mul, Units.val_mul]; exact map_mul σ _ _ }
+def restrictRootsOfUnity [MonoidHomClass F R S] (σ : F) (n : ℕ) :
+    rootsOfUnity n R →* rootsOfUnity n S :=
+  let h : ∀ ξ : rootsOfUnity n R, (σ (ξ : Rˣ)) ^ n = 1 := fun ξ => by
+    rw [← map_pow, ← Units.val_pow_eq_pow_val, show (ξ : Rˣ) ^ n = 1 from ξ.2,
+      Units.val_one, map_one σ]
+  { toFun := fun ξ ↦ ⟨Units.map σ (ξ : Rˣ), by
+      simp only [mem_rootsOfUnity]
+      rw [Units.ext_iff, ← map_pow, Units.coe_map, Units.val_one,]
+      rw [@Units.val_pow_eq_pow_val, map_pow]
+      exact h ξ⟩
+    map_one' := by ext1; simp only [OneMemClass.coe_one, map_one]
+    map_mul' := fun ξ₁ ξ₂ ↦ by
+      ext1; simp only [Subgroup.coe_mul, map_mul, MulMemClass.mk_mul_mk] }
 
 @[simp]
 theorem restrictRootsOfUnity_coe_apply [MonoidHomClass F R S] (σ : F)
     (ζ : rootsOfUnity k R) :
-    (restrictRootsOfUnity σ k ζ : Sˣ) = σ (ζ : Rˣ) := by
-  match k with
-  | 0 => rfl
-  | _ + 1 => rfl
+    (restrictRootsOfUnity σ k ζ : Sˣ) = σ (ζ : Rˣ) :=
+  rfl
 
 /-- Restrict a monoid isomorphism to the nth roots of unity. -/
 nonrec def MulEquiv.restrictRootsOfUnity (σ : R ≃* S) (n : ℕ) :
@@ -168,10 +163,8 @@ nonrec def MulEquiv.restrictRootsOfUnity (σ : R ≃* S) (n : ℕ) :
 
 @[simp]
 theorem MulEquiv.restrictRootsOfUnity_coe_apply (σ : R ≃* S) (ζ : rootsOfUnity k R) :
-    (σ.restrictRootsOfUnity k ζ : Sˣ) = σ (ζ : Rˣ) := by
-  match k with
-  | 0 => rfl
-  | _ + 1 => rfl
+    (σ.restrictRootsOfUnity k ζ : Sˣ) = σ (ζ : Rˣ) :=
+  rfl
 
 @[simp]
 theorem MulEquiv.restrictRootsOfUnity_symm (σ : R ≃* S) :

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -72,37 +72,38 @@ variable [CommMonoid M] [CommMonoid N] [DivisionCommMonoid G]
 
 section rootsOfUnity
 
-variable {k l : ℕ+}
+variable {k l : ℕ}
 
 /-- `rootsOfUnity k M` is the subgroup of elements `m : Mˣ` that satisfy `m ^ k = 1`. -/
-def rootsOfUnity (k : ℕ+) (M : Type*) [CommMonoid M] : Subgroup Mˣ where
-  carrier := {ζ | ζ ^ (k : ℕ) = 1}
+def rootsOfUnity (k : ℕ) (M : Type*) [CommMonoid M] : Subgroup Mˣ where
+  carrier := {ζ | ζ ^ k = 1}
   one_mem' := one_pow _
   mul_mem' _ _ := by simp_all only [Set.mem_setOf_eq, mul_pow, one_mul]
   inv_mem' _ := by simp_all only [Set.mem_setOf_eq, inv_pow, inv_one]
 
 @[simp]
-theorem mem_rootsOfUnity (k : ℕ+) (ζ : Mˣ) : ζ ∈ rootsOfUnity k M ↔ ζ ^ (k : ℕ) = 1 :=
+theorem mem_rootsOfUnity (k : ℕ) (ζ : Mˣ) : ζ ∈ rootsOfUnity k M ↔ ζ ^ (k : ℕ) = 1 :=
   Iff.rfl
 
-theorem mem_rootsOfUnity' (k : ℕ+) (ζ : Mˣ) : ζ ∈ rootsOfUnity k M ↔ (ζ : M) ^ (k : ℕ) = 1 := by
+theorem mem_rootsOfUnity' (k : ℕ) (ζ : Mˣ) :
+    ζ ∈ rootsOfUnity k M ↔ (ζ : M) ^ (k : ℕ) = 1 := by
   rw [mem_rootsOfUnity]; norm_cast
 
 @[simp]
 theorem rootsOfUnity_one (M : Type*) [CommMonoid M] : rootsOfUnity 1 M = ⊥ := by ext; simp
 
-theorem rootsOfUnity.coe_injective {n : ℕ+} :
+theorem rootsOfUnity.coe_injective {n : ℕ} :
     Function.Injective (fun x : rootsOfUnity n M ↦ x.val.val) :=
   Units.ext.comp fun _ _ => Subtype.eq
 
 /-- Make an element of `rootsOfUnity` from a member of the base ring, and a proof that it has
 a positive power equal to one. -/
 @[simps! coe_val]
-def rootsOfUnity.mkOfPowEq (ζ : M) {n : ℕ+} (h : ζ ^ (n : ℕ) = 1) : rootsOfUnity n M :=
-  ⟨Units.ofPowEqOne ζ n h n.ne_zero, Units.pow_ofPowEqOne _ _⟩
+def rootsOfUnity.mkOfPowEq (ζ : M) {n : ℕ} [NeZero n](h : ζ ^ (n : ℕ) = 1) : rootsOfUnity n M :=
+  ⟨Units.ofPowEqOne ζ n h <| NeZero.ne n, Units.pow_ofPowEqOne _ _⟩
 
 @[simp]
-theorem rootsOfUnity.coe_mkOfPowEq {ζ : M} {n : ℕ+} (h : ζ ^ (n : ℕ) = 1) :
+theorem rootsOfUnity.coe_mkOfPowEq {ζ : M} {n : ℕ} [NeZero n] (h : ζ ^ (n : ℕ) = 1) :
     ((rootsOfUnity.mkOfPowEq _ h : Mˣ) : M) = ζ :=
   rfl
 
@@ -111,7 +112,7 @@ theorem rootsOfUnity_le_of_dvd (h : k ∣ l) : rootsOfUnity k M ≤ rootsOfUnity
   intro ζ h
   simp_all only [mem_rootsOfUnity, PNat.mul_coe, pow_mul, one_pow]
 
-theorem map_rootsOfUnity (f : Mˣ →* Nˣ) (k : ℕ+) : (rootsOfUnity k M).map f ≤ rootsOfUnity k N := by
+theorem map_rootsOfUnity (f : Mˣ →* Nˣ) (k : ℕ) : (rootsOfUnity k M).map f ≤ rootsOfUnity k N := by
   rintro _ ⟨ζ, h, rfl⟩
   simp_all only [← map_pow, mem_rootsOfUnity, SetLike.mem_coe, MonoidHom.map_one]
 
@@ -125,24 +126,25 @@ section CommMonoid
 variable [CommMonoid R] [CommMonoid S] [FunLike F R S]
 
 /-- Restrict a ring homomorphism to the nth roots of unity. -/
-def restrictRootsOfUnity [MonoidHomClass F R S] (σ : F) (n : ℕ+) :
+def restrictRootsOfUnity [MonoidHomClass F R S] (σ : F) (n : ℕ) [NeZero n] :
     rootsOfUnity n R →* rootsOfUnity n S :=
   let h : ∀ ξ : rootsOfUnity n R, (σ (ξ : Rˣ)) ^ (n : ℕ) = 1 := fun ξ => by
     rw [← map_pow, ← Units.val_pow_eq_pow_val, show (ξ : Rˣ) ^ (n : ℕ) = 1 from ξ.2, Units.val_one,
       map_one σ]
   { toFun := fun ξ =>
-      ⟨@unitOfInvertible _ _ _ (invertibleOfPowEqOne _ _ (h ξ) n.ne_zero), by
+      ⟨@unitOfInvertible _ _ _ (invertibleOfPowEqOne _ _ (h ξ) <| NeZero.ne n), by
         ext; rw [Units.val_pow_eq_pow_val]; exact h ξ⟩
     map_one' := by ext; exact map_one σ
     map_mul' := fun ξ₁ ξ₂ => by ext; rw [Subgroup.coe_mul, Units.val_mul]; exact map_mul σ _ _ }
 
 @[simp]
-theorem restrictRootsOfUnity_coe_apply [MonoidHomClass F R S] (σ : F) (ζ : rootsOfUnity k R) :
+theorem restrictRootsOfUnity_coe_apply [NeZero k] [MonoidHomClass F R S] (σ : F)
+    (ζ : rootsOfUnity k R) :
     (restrictRootsOfUnity σ k ζ : Sˣ) = σ (ζ : Rˣ) :=
   rfl
 
 /-- Restrict a monoid isomorphism to the nth roots of unity. -/
-nonrec def MulEquiv.restrictRootsOfUnity (σ : R ≃* S) (n : ℕ+) :
+nonrec def MulEquiv.restrictRootsOfUnity (σ : R ≃* S) (n : ℕ) [NeZero n] :
     rootsOfUnity n R ≃* rootsOfUnity n S where
   toFun := restrictRootsOfUnity σ n
   invFun := restrictRootsOfUnity σ.symm n
@@ -151,12 +153,12 @@ nonrec def MulEquiv.restrictRootsOfUnity (σ : R ≃* S) (n : ℕ+) :
   map_mul' := (restrictRootsOfUnity _ n).map_mul
 
 @[simp]
-theorem MulEquiv.restrictRootsOfUnity_coe_apply (σ : R ≃* S) (ζ : rootsOfUnity k R) :
+theorem MulEquiv.restrictRootsOfUnity_coe_apply [NeZero k] (σ : R ≃* S) (ζ : rootsOfUnity k R) :
     (σ.restrictRootsOfUnity k ζ : Sˣ) = σ (ζ : Rˣ) :=
   rfl
 
 @[simp]
-theorem MulEquiv.restrictRootsOfUnity_symm (σ : R ≃* S) :
+theorem MulEquiv.restrictRootsOfUnity_symm [NeZero k] (σ : R ≃* S) :
     (σ.restrictRootsOfUnity k).symm = σ.symm.restrictRootsOfUnity k :=
   rfl
 
@@ -166,9 +168,9 @@ section IsDomain
 
 variable [CommRing R] [IsDomain R]
 
-theorem mem_rootsOfUnity_iff_mem_nthRoots {ζ : Rˣ} :
+theorem mem_rootsOfUnity_iff_mem_nthRoots [NeZero k] {ζ : Rˣ} :
     ζ ∈ rootsOfUnity k R ↔ (ζ : R) ∈ nthRoots k (1 : R) := by
-  simp only [mem_rootsOfUnity, mem_nthRoots k.pos, Units.ext_iff, Units.val_one,
+  simp only [mem_rootsOfUnity, mem_nthRoots (NeZero.pos k), Units.ext_iff, Units.val_one,
     Units.val_pow_eq_pow_val]
 
 variable (k R)
@@ -178,14 +180,14 @@ variable (k R)
 This is implemented as equivalence of subtypes,
 because `rootsOfUnity` is a subgroup of the group of units,
 whereas `nthRoots` is a multiset. -/
-def rootsOfUnityEquivNthRoots : rootsOfUnity k R ≃ { x // x ∈ nthRoots k (1 : R) } where
+def rootsOfUnityEquivNthRoots [NeZero k] : rootsOfUnity k R ≃ { x // x ∈ nthRoots k (1 : R) } where
   toFun x := ⟨(x : Rˣ), mem_rootsOfUnity_iff_mem_nthRoots.mp x.2⟩
   invFun x := by
     refine ⟨⟨x, ↑x ^ (k - 1 : ℕ), ?_, ?_⟩, ?_⟩
     all_goals
-      rcases x with ⟨x, hx⟩; rw [mem_nthRoots k.pos] at hx
+      rcases x with ⟨x, hx⟩; rw [mem_nthRoots <| NeZero.pos k] at hx
       simp only [Subtype.coe_mk, ← pow_succ, ← pow_succ', hx,
-        tsub_add_cancel_of_le (show 1 ≤ (k : ℕ) from k.one_le)]
+        tsub_add_cancel_of_le (show 1 ≤ (k : ℕ) from NeZero.one_le)]
     simp only [mem_rootsOfUnity, Units.ext_iff, hx, Units.val_mk, Units.val_one, Subtype.coe_mk,
       Units.val_pow_eq_pow_val]
   left_inv := by rintro ⟨x, hx⟩; ext; rfl
@@ -194,25 +196,25 @@ def rootsOfUnityEquivNthRoots : rootsOfUnity k R ≃ { x // x ∈ nthRoots k (1 
 variable {k R}
 
 @[simp]
-theorem rootsOfUnityEquivNthRoots_apply (x : rootsOfUnity k R) :
+theorem rootsOfUnityEquivNthRoots_apply [NeZero k] (x : rootsOfUnity k R) :
     (rootsOfUnityEquivNthRoots R k x : R) = ((x : Rˣ) : R) :=
   rfl
 
 @[simp]
-theorem rootsOfUnityEquivNthRoots_symm_apply (x : { x // x ∈ nthRoots k (1 : R) }) :
+theorem rootsOfUnityEquivNthRoots_symm_apply [NeZero k] (x : { x // x ∈ nthRoots k (1 : R) }) :
     (((rootsOfUnityEquivNthRoots R k).symm x : Rˣ) : R) = (x : R) :=
   rfl
 
 variable (k R)
 
-instance rootsOfUnity.fintype : Fintype (rootsOfUnity k R) :=
+instance rootsOfUnity.fintype [NeZero k] : Fintype (rootsOfUnity k R) :=
   Fintype.ofEquiv { x // x ∈ nthRoots k (1 : R) } <| (rootsOfUnityEquivNthRoots R k).symm
 
-instance rootsOfUnity.isCyclic : IsCyclic (rootsOfUnity k R) :=
+instance rootsOfUnity.isCyclic [NeZero k] : IsCyclic (rootsOfUnity k R) :=
   isCyclic_of_subgroup_isDomain ((Units.coeHom R).comp (rootsOfUnity k R).subtype)
     (Units.ext.comp Subtype.val_injective)
 
-theorem card_rootsOfUnity : Fintype.card (rootsOfUnity k R) ≤ k :=
+theorem card_rootsOfUnity [NeZero k] : Fintype.card (rootsOfUnity k R) ≤ k :=
   calc
     Fintype.card (rootsOfUnity k R) = Fintype.card { x // x ∈ nthRoots k (1 : R) } :=
       Fintype.card_congr (rootsOfUnityEquivNthRoots R k)
@@ -222,7 +224,7 @@ theorem card_rootsOfUnity : Fintype.card (rootsOfUnity k R) ≤ k :=
 
 variable {k R}
 
-theorem map_rootsOfUnity_eq_pow_self [FunLike F R R] [RingHomClass F R R] (σ : F)
+theorem map_rootsOfUnity_eq_pow_self [NeZero k] [FunLike F R R] [RingHomClass F R R] (σ : F)
     (ζ : rootsOfUnity k R) :
     ∃ m : ℕ, σ (ζ : Rˣ) = ((ζ : Rˣ) : R) ^ m := by
   obtain ⟨m, hm⟩ := MonoidHom.map_cyclic (restrictRootsOfUnity σ k)
@@ -238,16 +240,15 @@ section Reduced
 variable (R) [CommRing R] [IsReduced R]
 
 -- @[simp] -- Porting note: simp normal form is `mem_rootsOfUnity_prime_pow_mul_iff'`
-theorem mem_rootsOfUnity_prime_pow_mul_iff (p k : ℕ) (m : ℕ+) [ExpChar R p]
-    {ζ : Rˣ} : ζ ∈ rootsOfUnity (⟨p, expChar_pos R p⟩ ^ k * m) R ↔ ζ ∈ rootsOfUnity m R := by
-  simp only [mem_rootsOfUnity', PNat.mul_coe, PNat.pow_coe, PNat.mk_coe,
-    ExpChar.pow_prime_pow_mul_eq_one_iff]
+theorem mem_rootsOfUnity_prime_pow_mul_iff (p k : ℕ) (m : ℕ) [ExpChar R p] {ζ : Rˣ} :
+    ζ ∈ rootsOfUnity (p ^ k * m) R ↔ ζ ∈ rootsOfUnity m R := by
+  simp only [mem_rootsOfUnity', ExpChar.pow_prime_pow_mul_eq_one_iff]
 
+/-- A variant of `mem_rootsOfUnity_prime_pow_mul_iff` in terms of `ζ ^ _`.-/
 @[simp]
-theorem mem_rootsOfUnity_prime_pow_mul_iff' (p k : ℕ) (m : ℕ+) [ExpChar R p]
-    {ζ : Rˣ} : ζ ^ (p ^ k * ↑m) = 1 ↔ ζ ∈ rootsOfUnity m R := by
-  rw [← PNat.mk_coe p (expChar_pos R p), ← PNat.pow_coe, ← PNat.mul_coe, ← mem_rootsOfUnity,
-    mem_rootsOfUnity_prime_pow_mul_iff]
+theorem mem_rootsOfUnity_prime_pow_mul_iff' (p k : ℕ) (m : ℕ) [ExpChar R p] {ζ : Rˣ} :
+    ζ ^ (p ^ k * m) = 1 ↔ ζ ∈ rootsOfUnity m R := by
+  rw [← mem_rootsOfUnity, mem_rootsOfUnity_prime_pow_mul_iff]
 
 end Reduced
 
@@ -262,7 +263,8 @@ structure IsPrimitiveRoot (ζ : M) (k : ℕ) : Prop where
 
 /-- Turn a primitive root μ into a member of the `rootsOfUnity` subgroup. -/
 @[simps!]
-def IsPrimitiveRoot.toRootsOfUnity {μ : M} {n : ℕ+} (h : IsPrimitiveRoot μ n) : rootsOfUnity n M :=
+def IsPrimitiveRoot.toRootsOfUnity {μ : M} {n : ℕ} [NeZero n] (h : IsPrimitiveRoot μ n) :
+    rootsOfUnity n M :=
   rootsOfUnity.mkOfPowEq μ h.pow_eq_one
 
 section primitiveRoots
@@ -276,6 +278,7 @@ def primitiveRoots (k : ℕ) (R : Type*) [CommRing R] [IsDomain R] : Finset R :=
 
 variable [CommRing R] [IsDomain R]
 
+-- TODO?: replace `(h0 : 0 < k)` by `[NeZero k]`
 @[simp]
 theorem mem_primitiveRoots {ζ : R} (h0 : 0 < k) : ζ ∈ primitiveRoots k R ↔ IsPrimitiveRoot ζ k := by
   rw [primitiveRoots, mem_filter, Multiset.mem_toFinset, mem_nthRoots h0, and_iff_right_iff_imp]
@@ -929,14 +932,15 @@ end IsDomain
 
 section Automorphisms
 
-variable [CommRing S] [IsDomain S] {μ : S} {n : ℕ+} (hμ : IsPrimitiveRoot μ n) (R) [CommRing R]
+variable [CommRing S] [IsDomain S] {μ : S} {n : ℕ} (hμ : IsPrimitiveRoot μ n) (R) [CommRing R]
   [Algebra R S]
 
 /-- The `MonoidHom` that takes an automorphism to the power of μ that μ gets mapped to under it. -/
-noncomputable def autToPow : (S ≃ₐ[R] S) →* (ZMod n)ˣ :=
+noncomputable def autToPow [NeZero n] : (S ≃ₐ[R] S) →* (ZMod n)ˣ :=
   let μ' := hμ.toRootsOfUnity
   have ho : orderOf μ' = n := by
-    rw [hμ.eq_orderOf, ← hμ.val_toRootsOfUnity_coe, orderOf_units, Subgroup.orderOf_coe]
+    refine Eq.trans ?_ hμ.eq_orderOf.symm -- `rw [hμ.eq_orderOf]` gives "motive not type correct"
+    rw [← hμ.val_toRootsOfUnity_coe, orderOf_units, Subgroup.orderOf_coe]
   MonoidHom.toHomUnits
     { toFun := fun σ => (map_rootsOfUnity_eq_pow_self σ.toAlgHom μ').choose
       map_one' := by
@@ -948,7 +952,8 @@ noncomputable def autToPow : (S ≃ₐ[R] S) →* (ZMod n)ˣ :=
         replace h : μ' = μ' ^ h1.choose :=
           rootsOfUnity.coe_injective (by simpa only [rootsOfUnity.coe_pow] using h)
         nth_rw 1 [← pow_one μ'] at h
-        rw [← Nat.cast_one, ZMod.natCast_eq_natCast_iff, ← ho, ← pow_eq_pow_iff_modEq, h]
+        convert ho ▸ (ZMod.natCast_eq_natCast_iff ..).mpr (pow_eq_pow_iff_modEq.mp h).symm
+        exact Nat.cast_one.symm
       map_mul' := by
         intro x y
         dsimp only
@@ -965,24 +970,26 @@ noncomputable def autToPow : (S ≃ₐ[R] S) →* (ZMod n)ˣ :=
         rw [← pow_mul] at hxy
         replace hxy : μ' ^ (hx'.choose * hy'.choose) = μ' ^ hxy'.choose :=
           rootsOfUnity.coe_injective (by simpa only [rootsOfUnity.coe_pow] using hxy)
-        rw [← Nat.cast_mul, ZMod.natCast_eq_natCast_iff, ← ho, ← pow_eq_pow_iff_modEq, hxy] }
+        convert ho ▸ (ZMod.natCast_eq_natCast_iff ..).mpr (pow_eq_pow_iff_modEq.mp hxy).symm
+        exact (Nat.cast_mul ..).symm }
 
 -- We are not using @[simps] in aut_to_pow to avoid a timeout.
-theorem coe_autToPow_apply (f : S ≃ₐ[R] S) :
+theorem coe_autToPow_apply [NeZero n] (f : S ≃ₐ[R] S) :
     (autToPow R hμ f : ZMod n) =
       ((map_rootsOfUnity_eq_pow_self f hμ.toRootsOfUnity).choose : ZMod n) :=
   rfl
 
 @[simp]
-theorem autToPow_spec (f : S ≃ₐ[R] S) : μ ^ (hμ.autToPow R f : ZMod n).val = f μ := by
+theorem autToPow_spec [NeZero n] (f : S ≃ₐ[R] S) : μ ^ (hμ.autToPow R f : ZMod n).val = f μ := by
   rw [IsPrimitiveRoot.coe_autToPow_apply]
   generalize_proofs h
   have := h.choose_spec
   refine (?_ : ((hμ.toRootsOfUnity : Sˣ) : S) ^ _ = _).trans this.symm
   rw [← rootsOfUnity.coe_pow, ← rootsOfUnity.coe_pow]
   congr 2
-  rw [pow_eq_pow_iff_modEq, ZMod.val_natCast, hμ.eq_orderOf, ← Subgroup.orderOf_coe,
-    ← orderOf_units]
+  rw [pow_eq_pow_iff_modEq, ZMod.val_natCast]
+  conv => enter [2, 2]; rw [hμ.eq_orderOf]
+  rw [← Subgroup.orderOf_coe, ← orderOf_units]
   exact Nat.mod_modEq _ _
 
 end Automorphisms

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -134,14 +134,9 @@ variable [CommMonoid R] [CommMonoid S] [FunLike F R S]
 /-- Restrict a ring homomorphism to the nth roots of unity. -/
 def restrictRootsOfUnity [MonoidHomClass F R S] (σ : F) (n : ℕ) :
     rootsOfUnity n R →* rootsOfUnity n S :=
-  let h : ∀ ξ : rootsOfUnity n R, (σ (ξ : Rˣ)) ^ n = 1 := fun ξ => by
-    rw [← map_pow, ← Units.val_pow_eq_pow_val, show (ξ : Rˣ) ^ n = 1 from ξ.2,
-      Units.val_one, map_one σ]
   { toFun := fun ξ ↦ ⟨Units.map σ (ξ : Rˣ), by
-      simp only [mem_rootsOfUnity]
-      rw [Units.ext_iff, ← map_pow, Units.coe_map, Units.val_one,]
-      rw [@Units.val_pow_eq_pow_val, map_pow]
-      exact h ξ⟩
+      rw [mem_rootsOfUnity, ← map_pow, Units.ext_iff, Units.coe_map, ξ.prop]
+      exact map_one σ⟩
     map_one' := by ext1; simp only [OneMemClass.coe_one, map_one]
     map_mul' := fun ξ₁ ξ₂ ↦ by
       ext1; simp only [Subgroup.coe_mul, map_mul, MulMemClass.mk_mul_mk] }

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -938,12 +938,11 @@ noncomputable def autToPow [NeZero n] : (S ≃ₐ[R] S) →* (ZMod n)ˣ :=
         dsimp only
         generalize_proofs hxy' hx' hy'
         have hxy := hxy'.choose_spec
-        have hx := hx'.choose_spec
-        have hy := hy'.choose_spec
-        replace hxy : x (((μ' : Sˣ) : S) ^ hy'.choose) = ((μ' : Sˣ) : S) ^ hxy'.choose := hy ▸ hxy
+        replace hxy : x (((μ' : Sˣ) : S) ^ hy'.choose) = ((μ' : Sˣ) : S) ^ hxy'.choose :=
+          hy'.choose_spec ▸ hxy
         rw [map_pow] at hxy
         replace hxy : (((μ' : Sˣ) : S) ^ hx'.choose) ^ hy'.choose = ((μ' : Sˣ) : S) ^ hxy'.choose :=
-          hx ▸ hxy
+          hx'.choose_spec ▸ hxy
         rw [← pow_mul] at hxy
         replace hxy : μ' ^ (hx'.choose * hy'.choose) = μ' ^ hxy'.choose :=
           rootsOfUnity.coe_injective (by simpa only [rootsOfUnity.coe_pow] using hxy)

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -814,8 +814,8 @@ theorem card_nthRoots {n : ℕ} {ζ : R} (hζ : IsPrimitiveRoot ζ n) (a : R) :
     push_neg at h
     simpa only [Multiset.card_eq_zero, Multiset.eq_zero_iff_forall_not_mem, mem_nthRoots hn]
 
--- was `card_rootsOfUnity'`
-theorem card_rootsOfUnity {n : ℕ} [NeZero n] (h : IsPrimitiveRoot ζ n) :
+/-- A variant of `IsPrimitiveRoot.card_rootsOfUnity` for `ζ : Rˣ`. -/
+theorem card_rootsOfUnity' {n : ℕ} [NeZero n] (h : IsPrimitiveRoot ζ n) :
     Fintype.card (rootsOfUnity n R) = n := by
   let e := h.zmodEquivZPowers
   haveI F : Fintype (Subgroup.zpowers ζ) := Fintype.ofEquiv _ e.toEquiv
@@ -825,11 +825,11 @@ theorem card_rootsOfUnity {n : ℕ} [NeZero n] (h : IsPrimitiveRoot ζ n) :
     _ = Fintype.card (ZMod n) := Fintype.card_congr e.toEquiv.symm
     _ = n := ZMod.card n
 
-/- theorem card_rootsOfUnity {ζ : R} {n : ℕ} [NeZero n] (h : IsPrimitiveRoot ζ n) :
+theorem card_rootsOfUnity {ζ : R} {n : ℕ} [NeZero n] (h : IsPrimitiveRoot ζ n) :
     Fintype.card (rootsOfUnity n R) = n := by
   obtain ⟨ζ, hζ⟩ := h.isUnit <| NeZero.pos n
   rw [← hζ, IsPrimitiveRoot.coe_units_iff] at h
-  exact h.card_rootsOfUnity' -/
+  exact h.card_rootsOfUnity'
 
 /-- The cardinality of the multiset `nthRoots ↑n (1 : R)` is `n`
 if there is a primitive root of unity in `R`. -/

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -21,7 +21,7 @@ monoids, expressing that an element is a primitive root of unity.
 
 ## Main definitions
 
-* `rootsOfUnity n M`, for `n : ℕ+` is the subgroup of the units of a commutative monoid `M`
+* `rootsOfUnity n M`, for `n : ℕ` is the subgroup of the units of a commutative monoid `M`
   consisting of elements `x` that satisfy `x ^ n = 1`.
 * `IsPrimitiveRoot ζ k`: an element `ζ` is a primitive `k`-th root of unity if `ζ ^ k = 1`,
   and if `l` satisfies `ζ ^ l = 1` then `k ∣ l`.
@@ -45,9 +45,10 @@ It is desirable that `rootsOfUnity` is a subgroup,
 and it will mainly be applied to rings (e.g. the ring of integers in a number field) and fields.
 We therefore implement it as a subgroup of the units of a commutative monoid.
 
-We have chosen to define `rootsOfUnity n` for `n : ℕ+`, instead of `n : ℕ`,
-because almost all lemmas need the positivity assumption,
-and in particular the type class instances for `Fintype` and `IsCyclic`.
+We have chosen to define `rootsOfUnity n` for `n : ℕ` and add a `[NeZero n]` typeclass
+assumption when we need `n` to be non-zero (which is the case for most interesting statements).
+Note that `rootsOfUnity 0 M` is the top subgroup of `Mˣ` (as the condition `ζ^0 = 1` is
+satisfied for all units).
 
 On the other hand, for primitive roots of unity, it is desirable to have a predicate
 not just on units, but directly on elements of the ring/field.
@@ -85,6 +86,7 @@ def rootsOfUnity (k : ℕ) (M : Type*) [CommMonoid M] : Subgroup Mˣ where
 theorem mem_rootsOfUnity (k : ℕ) (ζ : Mˣ) : ζ ∈ rootsOfUnity k M ↔ ζ ^ k = 1 :=
   Iff.rfl
 
+/-- A variant of `mem_rootsOfUnity` using `ζ : M`. -/
 theorem mem_rootsOfUnity' (k : ℕ) (ζ : Mˣ) : ζ ∈ rootsOfUnity k M ↔ (ζ : M) ^ k = 1 := by
   rw [mem_rootsOfUnity]; norm_cast
 
@@ -100,7 +102,7 @@ lemma rootsOfUnity_zero (M : Type*) [CommMonoid M] : rootsOfUnity 0 M = ⊤ := b
 
 theorem rootsOfUnity.coe_injective {n : ℕ} :
     Function.Injective (fun x : rootsOfUnity n M ↦ x.val.val) :=
-  Units.ext.comp fun _ _ => Subtype.eq
+  Units.ext.comp fun _ _ ↦ Subtype.eq
 
 /-- Make an element of `rootsOfUnity` from a member of the base ring, and a proof that it has
 a positive power equal to one. -/
@@ -170,9 +172,10 @@ end CommMonoid
 
 section IsDomain
 
-variable [CommRing R] [IsDomain R]
+-- The following results need `k` to be nonzero.
+variable [NeZero k] [CommRing R] [IsDomain R]
 
-theorem mem_rootsOfUnity_iff_mem_nthRoots [NeZero k] {ζ : Rˣ} :
+theorem mem_rootsOfUnity_iff_mem_nthRoots {ζ : Rˣ} :
     ζ ∈ rootsOfUnity k R ↔ (ζ : R) ∈ nthRoots k (1 : R) := by
   simp only [mem_rootsOfUnity, mem_nthRoots (NeZero.pos k), Units.ext_iff, Units.val_one,
     Units.val_pow_eq_pow_val]
@@ -184,41 +187,38 @@ variable (k R)
 This is implemented as equivalence of subtypes,
 because `rootsOfUnity` is a subgroup of the group of units,
 whereas `nthRoots` is a multiset. -/
-def rootsOfUnityEquivNthRoots [NeZero k] : rootsOfUnity k R ≃ { x // x ∈ nthRoots k (1 : R) } where
+def rootsOfUnityEquivNthRoots : rootsOfUnity k R ≃ { x // x ∈ nthRoots k (1 : R) } where
   toFun x := ⟨(x : Rˣ), mem_rootsOfUnity_iff_mem_nthRoots.mp x.2⟩
   invFun x := by
     refine ⟨⟨x, ↑x ^ (k - 1 : ℕ), ?_, ?_⟩, ?_⟩
     all_goals
       rcases x with ⟨x, hx⟩; rw [mem_nthRoots <| NeZero.pos k] at hx
-      simp only [Subtype.coe_mk, ← pow_succ, ← pow_succ', hx,
-        tsub_add_cancel_of_le (show 1 ≤ (k : ℕ) from NeZero.one_le)]
-    simp only [mem_rootsOfUnity, Units.ext_iff, hx, Units.val_mk, Units.val_one, Subtype.coe_mk,
-      Units.val_pow_eq_pow_val]
+      simp only [← pow_succ, ← pow_succ', hx, tsub_add_cancel_of_le NeZero.one_le]
+    simp only [mem_rootsOfUnity, Units.ext_iff, Units.val_pow_eq_pow_val, hx, Units.val_one]
   left_inv := by rintro ⟨x, hx⟩; ext; rfl
   right_inv := by rintro ⟨x, hx⟩; ext; rfl
 
 variable {k R}
 
 @[simp]
-theorem rootsOfUnityEquivNthRoots_apply [NeZero k] (x : rootsOfUnity k R) :
+theorem rootsOfUnityEquivNthRoots_apply (x : rootsOfUnity k R) :
     (rootsOfUnityEquivNthRoots R k x : R) = ((x : Rˣ) : R) :=
   rfl
 
 @[simp]
-theorem rootsOfUnityEquivNthRoots_symm_apply [NeZero k] (x : { x // x ∈ nthRoots k (1 : R) }) :
+theorem rootsOfUnityEquivNthRoots_symm_apply (x : { x // x ∈ nthRoots k (1 : R) }) :
     (((rootsOfUnityEquivNthRoots R k).symm x : Rˣ) : R) = (x : R) :=
   rfl
 
 variable (k R)
 
-instance rootsOfUnity.fintype [NeZero k] : Fintype (rootsOfUnity k R) :=
-  Fintype.ofEquiv { x // x ∈ nthRoots k (1 : R) } <| (rootsOfUnityEquivNthRoots R k).symm
+instance rootsOfUnity.fintype : Fintype (rootsOfUnity k R) :=
+  Fintype.ofEquiv { x // x ∈ nthRoots k (1 : R) } (rootsOfUnityEquivNthRoots R k).symm
 
-instance rootsOfUnity.isCyclic [NeZero k] : IsCyclic (rootsOfUnity k R) :=
-  isCyclic_of_subgroup_isDomain ((Units.coeHom R).comp (rootsOfUnity k R).subtype)
-    (Units.ext.comp Subtype.val_injective)
+instance rootsOfUnity.isCyclic : IsCyclic (rootsOfUnity k R) :=
+  isCyclic_of_subgroup_isDomain ((Units.coeHom R).comp (rootsOfUnity k R).subtype) coe_injective
 
-theorem card_rootsOfUnity [NeZero k] : Fintype.card (rootsOfUnity k R) ≤ k :=
+theorem card_rootsOfUnity : Fintype.card (rootsOfUnity k R) ≤ k :=
   calc
     Fintype.card (rootsOfUnity k R) = Fintype.card { x // x ∈ nthRoots k (1 : R) } :=
       Fintype.card_congr (rootsOfUnityEquivNthRoots R k)
@@ -228,7 +228,7 @@ theorem card_rootsOfUnity [NeZero k] : Fintype.card (rootsOfUnity k R) ≤ k :=
 
 variable {k R}
 
-theorem map_rootsOfUnity_eq_pow_self [NeZero k] [FunLike F R R] [RingHomClass F R R] (σ : F)
+theorem map_rootsOfUnity_eq_pow_self [FunLike F R R] [RingHomClass F R R] (σ : F)
     (ζ : rootsOfUnity k R) :
     ∃ m : ℕ, σ (ζ : Rˣ) = ((ζ : Rˣ) : R) ^ m := by
   obtain ⟨m, hm⟩ := MonoidHom.map_cyclic (restrictRootsOfUnity σ k)
@@ -262,7 +262,7 @@ end rootsOfUnity
 and if `l` satisfies `ζ ^ l = 1` then `k ∣ l`. -/
 @[mk_iff IsPrimitiveRoot.iff_def]
 structure IsPrimitiveRoot (ζ : M) (k : ℕ) : Prop where
-  pow_eq_one : ζ ^ (k : ℕ) = 1
+  pow_eq_one : ζ ^ k = 1
   dvd_of_pow_eq_one : ∀ l : ℕ, ζ ^ l = 1 → k ∣ l
 
 /-- Turn a primitive root μ into a member of the `rootsOfUnity` subgroup. -/
@@ -294,7 +294,7 @@ theorem primitiveRoots_zero : primitiveRoots 0 R = ∅ := by
 
 theorem isPrimitiveRoot_of_mem_primitiveRoots {ζ : R} (h : ζ ∈ primitiveRoots k R) :
     IsPrimitiveRoot ζ k :=
-  k.eq_zero_or_pos.elim (fun hk => by simp [hk] at h) fun hk => (mem_primitiveRoots hk).1 h
+  k.eq_zero_or_pos.elim (fun hk ↦ by simp [hk] at h) fun hk ↦ (mem_primitiveRoots hk).1 h
 
 end primitiveRoots
 
@@ -304,7 +304,7 @@ variable {k l : ℕ}
 
 theorem mk_of_lt (ζ : M) (hk : 0 < k) (h1 : ζ ^ k = 1) (h : ∀ l : ℕ, 0 < l → l < k → ζ ^ l ≠ 1) :
     IsPrimitiveRoot ζ k := by
-  refine ⟨h1, fun l hl => ?_⟩
+  refine ⟨h1, fun l hl ↦ ?_⟩
   suffices k.gcd l = k by exact this ▸ k.gcd_dvd_right l
   rw [eq_iff_le_not_lt]
   refine ⟨Nat.le_of_dvd hk (k.gcd_dvd_left l), ?_⟩
@@ -317,7 +317,7 @@ variable {ζ : M} {f : F}
 
 @[nontriviality]
 theorem of_subsingleton [Subsingleton M] (x : M) : IsPrimitiveRoot x 1 :=
-  ⟨Subsingleton.elim _ _, fun _ _ => one_dvd _⟩
+  ⟨Subsingleton.elim _ _, fun _ _ ↦ one_dvd _⟩
 
 theorem pow_eq_one_iff_dvd (h : IsPrimitiveRoot ζ k) (l : ℕ) : ζ ^ l = 1 ↔ k ∣ l :=
   ⟨h.dvd_of_pow_eq_one l, by
@@ -346,7 +346,7 @@ theorem pow_inj (h : IsPrimitiveRoot ζ k) ⦃i j : ℕ⦄ (hi : i < k) (hj : j 
 
 theorem one : IsPrimitiveRoot (1 : M) 1 :=
   { pow_eq_one := pow_one _
-    dvd_of_pow_eq_one := fun _ _ => one_dvd _ }
+    dvd_of_pow_eq_one := fun _ _ ↦ one_dvd _ }
 
 @[simp]
 theorem one_right_iff : IsPrimitiveRoot ζ 1 ↔ ζ = 1 := by
@@ -379,9 +379,7 @@ theorem pow_of_coprime (h : IsPrimitiveRoot ζ k) (i : ℕ) (hi : i.Coprime k) :
   rw [coe_units_iff] at h ⊢
   refine
     { pow_eq_one := by rw [← pow_mul', pow_mul, h.pow_eq_one, one_pow]
-      dvd_of_pow_eq_one := ?_ }
-  intro l hl
-  apply h.dvd_of_pow_eq_one
+      dvd_of_pow_eq_one := fun l hl ↦ h.dvd_of_pow_eq_one l ?_ }
   rw [← pow_one ζ, ← zpow_natCast ζ, ← hi.gcd_eq_one, Nat.gcd_eq_gcd_ab, zpow_add, mul_pow,
     ← zpow_natCast, ← zpow_mul, mul_right_comm]
   simp only [zpow_mul, hl, h.pow_eq_one, one_zpow, one_pow, one_mul, zpow_natCast]
@@ -392,21 +390,18 @@ theorem pow_of_prime (h : IsPrimitiveRoot ζ k) {p : ℕ} (hprime : Nat.Prime p)
 
 theorem pow_iff_coprime (h : IsPrimitiveRoot ζ k) (h0 : 0 < k) (i : ℕ) :
     IsPrimitiveRoot (ζ ^ i) k ↔ i.Coprime k := by
-  refine ⟨?_, h.pow_of_coprime i⟩
-  intro hi
+  refine ⟨fun hi ↦ ?_, h.pow_of_coprime i⟩
   obtain ⟨a, ha⟩ := i.gcd_dvd_left k
   obtain ⟨b, hb⟩ := i.gcd_dvd_right k
   suffices b = k by
-    -- Porting note: was `rwa [this, ← one_mul k, mul_left_inj' h0.ne', eq_comm] at hb`
-    rw [this, eq_comm, Nat.mul_left_eq_self_iff h0] at hb
-    rwa [Nat.Coprime]
+    rwa [this, eq_comm, Nat.mul_left_eq_self_iff h0, ← Nat.coprime_iff_gcd_eq_one] at hb
   rw [ha] at hi
   rw [mul_comm] at hb
   apply Nat.dvd_antisymm ⟨i.gcd k, hb⟩ (hi.dvd_of_pow_eq_one b _)
   rw [← pow_mul', ← mul_assoc, ← hb, pow_mul, h.pow_eq_one, one_pow]
 
 protected theorem orderOf (ζ : M) : IsPrimitiveRoot ζ (orderOf ζ) :=
-  ⟨pow_orderOf_eq_one ζ, fun _ => orderOf_dvd_of_pow_eq_one⟩
+  ⟨pow_orderOf_eq_one ζ, fun _ ↦ orderOf_dvd_of_pow_eq_one⟩
 
 theorem unique {ζ : M} (hk : IsPrimitiveRoot ζ k) (hl : IsPrimitiveRoot ζ l) : k = l :=
   Nat.dvd_antisymm (hk.2 _ hl.1) (hl.2 _ hk.1)
@@ -416,14 +411,14 @@ theorem eq_orderOf (h : IsPrimitiveRoot ζ k) : k = orderOf ζ :=
 
 protected theorem iff (hk : 0 < k) :
     IsPrimitiveRoot ζ k ↔ ζ ^ k = 1 ∧ ∀ l : ℕ, 0 < l → l < k → ζ ^ l ≠ 1 := by
-  refine ⟨fun h => ⟨h.pow_eq_one, fun l hl' hl => ?_⟩,
-    fun ⟨hζ, hl⟩ => IsPrimitiveRoot.mk_of_lt ζ hk hζ hl⟩
+  refine ⟨fun h ↦ ⟨h.pow_eq_one, fun l hl' hl ↦ ?_⟩,
+    fun ⟨hζ, hl⟩ ↦ IsPrimitiveRoot.mk_of_lt ζ hk hζ hl⟩
   rw [h.eq_orderOf] at hl
   exact pow_ne_one_of_lt_orderOf hl'.ne' hl
 
 protected theorem not_iff : ¬IsPrimitiveRoot ζ k ↔ orderOf ζ ≠ k :=
-  ⟨fun h hk => h <| hk ▸ IsPrimitiveRoot.orderOf ζ,
-    fun h hk => h.symm <| hk.unique <| IsPrimitiveRoot.orderOf ζ⟩
+  ⟨fun h hk ↦ h <| hk ▸ IsPrimitiveRoot.orderOf ζ,
+    fun h hk ↦ h.symm <| hk.unique <| IsPrimitiveRoot.orderOf ζ⟩
 
 theorem pow_mul_pow_lcm {ζ' : M} {k' : ℕ} (hζ : IsPrimitiveRoot ζ k) (hζ' : IsPrimitiveRoot ζ' k')
     (hk : k ≠ 0) (hk' : k' ≠ 0) :
@@ -437,8 +432,9 @@ theorem pow_mul_pow_lcm {ζ' : M} {k' : ℕ} (hζ : IsPrimitiveRoot ζ k) (hζ' 
 
 theorem pow_of_dvd (h : IsPrimitiveRoot ζ k) {p : ℕ} (hp : p ≠ 0) (hdiv : p ∣ k) :
     IsPrimitiveRoot (ζ ^ p) (k / p) := by
-  suffices orderOf (ζ ^ p) = k / p by exact this ▸ IsPrimitiveRoot.orderOf (ζ ^ p)
-  rw [orderOf_pow' _ hp, ← eq_orderOf h, Nat.gcd_eq_right hdiv]
+  rw [h.eq_orderOf] at hdiv ⊢
+  rw [← orderOf_pow_of_dvd hp hdiv]
+  exact IsPrimitiveRoot.orderOf _
 
 protected theorem mem_rootsOfUnity {ζ : Mˣ} {n : ℕ} (h : IsPrimitiveRoot ζ n) :
     ζ ∈ rootsOfUnity n M :=
@@ -449,22 +445,15 @@ then there is a `b`-th primitive root of unity in `R`. -/
 theorem pow {n : ℕ} {a b : ℕ} (hn : 0 < n) (h : IsPrimitiveRoot ζ n) (hprod : n = a * b) :
     IsPrimitiveRoot (ζ ^ a) b := by
   subst n
-  simp only [iff_def, ← pow_mul, h.pow_eq_one, eq_self_iff_true, true_and]
+  simp only [iff_def, ← pow_mul, h.pow_eq_one, true_and]
   intro l hl
-  -- Porting note: was `by rintro rfl; simpa only [Nat.not_lt_zero, zero_mul] using hn`
-  have ha0 : a ≠ 0 := left_ne_zero_of_mul hn.ne'
-  rw [← mul_dvd_mul_iff_left ha0]
-  exact h.dvd_of_pow_eq_one _ hl
+  exact Nat.dvd_of_mul_dvd_mul_left (Nat.pos_of_mul_pos_right hn) <| h.dvd_of_pow_eq_one _ hl
 
 lemma injOn_pow {n : ℕ} {ζ : M} (hζ : IsPrimitiveRoot ζ n) :
     Set.InjOn (ζ ^ ·) (Finset.range n) := by
-  obtain (rfl|hn) := n.eq_zero_or_pos; · simp
   intros i hi j hj e
   rw [Finset.coe_range, Set.mem_Iio] at hi hj
-  have : (hζ.isUnit hn).unit ^ i = (hζ.isUnit hn).unit ^ j := Units.ext (by simpa using e)
-  rw [pow_inj_mod, ← orderOf_injective ⟨⟨Units.val, Units.val_one⟩, Units.val_mul⟩
-    Units.ext (hζ.isUnit hn).unit] at this
-  simpa [← hζ.eq_orderOf, Nat.mod_eq_of_lt, hi, hj] using this
+  exact hζ.pow_inj hi hj e
 
 section Maps
 
@@ -504,11 +493,10 @@ section CommMonoidWithZero
 variable {M₀ : Type*} [CommMonoidWithZero M₀]
 
 theorem zero [Nontrivial M₀] : IsPrimitiveRoot (0 : M₀) 0 :=
-  ⟨pow_zero 0, fun l hl => by
-    simpa [zero_pow_eq, show ∀ p, ¬p → False ↔ p from @Classical.not_not] using hl⟩
+  ⟨pow_zero 0, fun l hl ↦ by simpa [zero_pow_eq] using hl⟩
 
 protected theorem ne_zero [Nontrivial M₀] {ζ : M₀} (h : IsPrimitiveRoot ζ k) : k ≠ 0 → ζ ≠ 0 :=
-  mt fun hn => h.unique (hn.symm ▸ IsPrimitiveRoot.zero)
+  mt fun hn ↦ h.unique (hn.symm ▸ IsPrimitiveRoot.zero)
 
 end CommMonoidWithZero
 
@@ -516,10 +504,10 @@ section CancelCommMonoidWithZero
 
 variable {M₀ : Type*} [CancelCommMonoidWithZero M₀]
 
-lemma injOn_pow_mul {n : ℕ} {ζ : M₀} (hζ : IsPrimitiveRoot ζ n)
-    {α : M₀} (hα : α ≠ 0) :
-    Set.InjOn (ζ ^ · * α) (Finset.range n) := fun i hi j hj e ↦
-  hζ.injOn_pow hi hj (by simpa [mul_eq_mul_right_iff, or_iff_left hα] using e)
+lemma injOn_pow_mul {n : ℕ} {ζ : M₀} (hζ : IsPrimitiveRoot ζ n) {α : M₀} (hα : α ≠ 0) :
+    Set.InjOn (ζ ^ · * α) (Finset.range n) :=
+  fun i hi j hj e ↦
+    hζ.injOn_pow hi hj (by simpa [mul_eq_mul_right_iff, or_iff_left hα] using e)
 
 end CancelCommMonoidWithZero
 
@@ -528,12 +516,12 @@ section DivisionCommMonoid
 variable {ζ : G}
 
 theorem zpow_eq_one (h : IsPrimitiveRoot ζ k) : ζ ^ (k : ℤ) = 1 := by
-  rw [zpow_natCast]; exact h.pow_eq_one
+  exact_mod_cast h.pow_eq_one
 
 theorem zpow_eq_one_iff_dvd (h : IsPrimitiveRoot ζ k) (l : ℤ) : ζ ^ l = 1 ↔ (k : ℤ) ∣ l := by
   by_cases h0 : 0 ≤ l
-  · lift l to ℕ using h0; rw [zpow_natCast]; norm_cast; exact h.pow_eq_one_iff_dvd l
-  · have : 0 ≤ -l := by simp only [not_le, neg_nonneg] at h0 ⊢; exact le_of_lt h0
+  · lift l to ℕ using h0; exact_mod_cast h.pow_eq_one_iff_dvd l
+  · have : 0 ≤ -l := (Int.neg_pos_of_neg <| Int.lt_of_not_ge h0).le
     lift -l to ℕ using this with l' hl'
     rw [← dvd_neg, ← hl']
     norm_cast
@@ -547,21 +535,19 @@ theorem inv (h : IsPrimitiveRoot ζ k) : IsPrimitiveRoot ζ⁻¹ k :=
       rw [← inv_inj, ← inv_pow, hl, inv_one] }
 
 @[simp]
-theorem inv_iff : IsPrimitiveRoot ζ⁻¹ k ↔ IsPrimitiveRoot ζ k := by
-  refine ⟨?_, fun h => inv h⟩; intro h; rw [← inv_inv ζ]; exact inv h
+theorem inv_iff : IsPrimitiveRoot ζ⁻¹ k ↔ IsPrimitiveRoot ζ k :=
+  ⟨fun h ↦ inv_inv ζ ▸ inv h, fun h ↦ inv h⟩
 
 theorem zpow_of_gcd_eq_one (h : IsPrimitiveRoot ζ k) (i : ℤ) (hi : i.gcd k = 1) :
     IsPrimitiveRoot (ζ ^ i) k := by
   by_cases h0 : 0 ≤ i
   · lift i to ℕ using h0
-    rw [zpow_natCast]
-    exact h.pow_of_coprime i hi
-  have : 0 ≤ -i := by simp only [not_le, neg_nonneg] at h0 ⊢; exact le_of_lt h0
+    exact_mod_cast h.pow_of_coprime i hi
+  have : 0 ≤ -i := (Int.neg_pos_of_neg <| Int.lt_of_not_ge h0).le
   lift -i to ℕ using this with i' hi'
   rw [← inv_iff, ← zpow_neg, ← hi', zpow_natCast]
   apply h.pow_of_coprime
-  rw [Int.gcd, ← Int.natAbs_neg, ← hi'] at hi
-  exact hi
+  rwa [Int.gcd, ← Int.natAbs_neg, ← hi'] at hi
 
 end DivisionCommMonoid
 
@@ -576,17 +562,13 @@ end CommRing
 
 section IsDomain
 
-variable {ζ : R}
-variable [CommRing R] [IsDomain R]
+variable {ζ : R} [CommRing R] [IsDomain R]
 
 @[simp]
 theorem primitiveRoots_one : primitiveRoots 1 R = {(1 : R)} := by
-  apply Finset.eq_singleton_iff_unique_mem.2
-  constructor
+  refine Finset.eq_singleton_iff_unique_mem.2 ⟨?_, fun x hx ↦ ?_⟩
   · simp only [IsPrimitiveRoot.one_right_iff, mem_primitiveRoots zero_lt_one]
-  · intro x hx
-    rw [mem_primitiveRoots zero_lt_one, IsPrimitiveRoot.one_right_iff] at hx
-    exact hx
+  · rwa [mem_primitiveRoots zero_lt_one, IsPrimitiveRoot.one_right_iff] at hx
 
 theorem neZero' {n : ℕ} [NeZero n] (hζ : IsPrimitiveRoot ζ n) : NeZero ((n : ℕ) : R) := by
   let p := ringChar R
@@ -594,13 +576,13 @@ theorem neZero' {n : ℕ} [NeZero n] (hζ : IsPrimitiveRoot ζ n) : NeZero ((n :
   obtain ⟨m, hm⟩ := hfin.exists_eq_pow_mul_and_not_dvd
   by_cases hp : p ∣ n
   · obtain ⟨k, hk⟩ := Nat.exists_eq_succ_of_ne_zero (multiplicity_pos_of_dvd hp).ne'
-    haveI : NeZero p := NeZero.of_pos (Nat.pos_of_dvd_of_pos hp (NeZero.pos n))
-    haveI hpri : Fact p.Prime := CharP.char_is_prime_of_pos R p
+    have : NeZero p := NeZero.of_pos (Nat.pos_of_dvd_of_pos hp (NeZero.pos n))
+    have hpri : Fact p.Prime := CharP.char_is_prime_of_pos R p
     have := hζ.pow_eq_one
     rw [hm.1, hk, pow_succ', mul_assoc, pow_mul', ← frobenius_def, ← frobenius_one p] at this
     exfalso
     have hpos : 0 < p ^ k * m :=
-      mul_pos (pow_pos hpri.1.pos _) <| Nat.pos_of_ne_zero (fun H ↦hm.2 <| H ▸ p.dvd_zero)
+      mul_pos (pow_pos hpri.1.pos _) <| Nat.pos_of_ne_zero (fun H ↦ hm.2 <| H ▸ p.dvd_zero)
     refine hζ.pow_ne_one_of_pos_of_lt hpos ?_ (frobenius_inj R p this)
     rw [hm.1, hk, pow_succ', mul_assoc, mul_comm p]
     exact lt_mul_of_one_lt_right hpos hpri.1.one_lt
@@ -614,19 +596,15 @@ end IsDomain
 
 section IsDomain
 
-variable [CommRing R]
-variable {ζ : Rˣ} (h : IsPrimitiveRoot ζ k)
+variable [CommRing R] {ζ : Rˣ} (h : IsPrimitiveRoot ζ k)
 
-theorem eq_neg_one_of_two_right [NoZeroDivisors R] {ζ : R} (h : IsPrimitiveRoot ζ 2) : ζ = -1 := by
-  apply (eq_or_eq_neg_of_sq_eq_sq ζ 1 _).resolve_left
-  · rw [← pow_one ζ]; apply h.pow_ne_one_of_pos_of_lt <;> decide
-  · simp only [h.pow_eq_one, one_pow]
+theorem eq_neg_one_of_two_right [NoZeroDivisors R] {ζ : R} (h : IsPrimitiveRoot ζ 2) : ζ = -1 :=
+  (sq_eq_one_iff.mp h.pow_eq_one).resolve_left <| ne_one h one_lt_two
 
 theorem neg_one (p : ℕ) [Nontrivial R] [h : CharP R p] (hp : p ≠ 2) :
     IsPrimitiveRoot (-1 : R) 2 := by
   convert IsPrimitiveRoot.orderOf (-1 : R)
-  rw [orderOf_neg_one, if_neg]
-  rwa [ringChar.eq_iff.mpr h]
+  rw [orderOf_neg_one, if_neg <| by rwa [ringChar.eq_iff.mpr h]]
 
 /-- If `1 < k` then `(∑ i ∈ range k, ζ ^ i) = 0`. -/
 theorem geom_sum_eq_zero [IsDomain R] {ζ : R} (hζ : IsPrimitiveRoot ζ k) (hk : 1 < k) :
@@ -645,9 +623,9 @@ and the powers of a primitive root of unity `ζ`. -/
 def zmodEquivZPowers (h : IsPrimitiveRoot ζ k) : ZMod k ≃+ Additive (Subgroup.zpowers ζ) :=
   AddEquiv.ofBijective
     (AddMonoidHom.liftOfRightInverse (Int.castAddHom <| ZMod k) _ ZMod.intCast_rightInverse
-      ⟨{  toFun := fun i => Additive.ofMul (⟨_, i, rfl⟩ : Subgroup.zpowers ζ)
+      ⟨{  toFun := fun i ↦ Additive.ofMul (⟨_, i, rfl⟩ : Subgroup.zpowers ζ)
           map_zero' := by simp only [zpow_zero]; rfl
-          map_add' := by intro i j; simp only [zpow_add]; rfl }, fun i hi => by
+          map_add' := by intro i j; simp only [zpow_add]; rfl }, fun i hi ↦ by
         simp only [AddMonoidHom.mem_ker, CharP.intCast_eq_zero_iff (ZMod k) k, AddMonoidHom.coe_mk,
           Int.coe_castAddHom] at hi ⊢
         obtain ⟨i, rfl⟩ := hi
@@ -700,10 +678,9 @@ variable [IsDomain R]
 theorem zpowers_eq {k : ℕ} [NeZero k] {ζ : Rˣ} (h : IsPrimitiveRoot ζ k) :
     Subgroup.zpowers ζ = rootsOfUnity k R := by
   apply SetLike.coe_injective
-  haveI F : Fintype (Subgroup.zpowers ζ) := Fintype.ofEquiv _ h.zmodEquivZPowers.toEquiv
+  have F : Fintype (Subgroup.zpowers ζ) := Fintype.ofEquiv _ h.zmodEquivZPowers.toEquiv
   refine
-    @Set.eq_of_subset_of_card_le Rˣ (Subgroup.zpowers ζ) (rootsOfUnity k R) F
-      (rootsOfUnity.fintype R k)
+    @Set.eq_of_subset_of_card_le Rˣ _ _ F (rootsOfUnity.fintype R k)
       (Subgroup.zpowers_le_of_mem <| show ζ ∈ rootsOfUnity k R from h.pow_eq_one) ?_
   calc
     Fintype.card (rootsOfUnity k R) ≤ k := card_rootsOfUnity R k
@@ -719,7 +696,7 @@ lemma map_rootsOfUnity {S F} [CommRing S] [IsDomain S] [FunLike F R S] [MonoidHo
     ← (hζ.map_of_injective (Units.map_injective (f := (f : R →* S)) hf)).zpowers_eq,
     MonoidHom.map_zpowers]
 
-/-- If `R` contains a `n`-th primitive root, and `S/R` is a ring extension,
+/-- If `R` contains an `n`-th primitive root, and `S/R` is a ring extension,
 then the `n`-th roots of unity in `R` and `S` are isomorphic.
 Also see `IsPrimitiveRoot.map_rootsOfUnity` for the equality as `Subgroup Sˣ`. -/
 @[simps! (config := .lemmasOnly) apply_coe_val apply_coe_inv_val]
@@ -741,7 +718,7 @@ lemma _root_.rootsOfUnityEquivOfPrimitiveRoots_symm_apply
 
 -- Porting note: rephrased the next few lemmas to avoid `∃ (Prop)`
 theorem eq_pow_of_mem_rootsOfUnity {k : ℕ} [NeZero k] {ζ ξ : Rˣ} (h : IsPrimitiveRoot ζ k)
-    (hξ : ξ ∈ rootsOfUnity k R) : ∃ (i : ℕ), i < k ∧ ζ ^ i = ξ := by
+    (hξ : ξ ∈ rootsOfUnity k R) : ∃ i < k, ζ ^ i = ξ := by
   obtain ⟨n, rfl⟩ : ∃ n : ℤ, ζ ^ n = ξ := by rwa [← h.zpowers_eq] at hξ
   have hk0 : (0 : ℤ) < k := mod_cast NeZero.pos k
   let i := n % k
@@ -792,7 +769,7 @@ theorem isPrimitiveRoot_iff {k : ℕ} [NeZero k] {ζ ξ : R} (h : IsPrimitiveRoo
 
 theorem nthRoots_eq {n : ℕ} {ζ : R} (hζ : IsPrimitiveRoot ζ n) {α a : R} (e : α ^ n = a) :
     nthRoots n a = (Multiset.range n).map (ζ ^ · * α) := by
-  obtain (rfl|hn) := n.eq_zero_or_pos; · simp
+  obtain (rfl | hn) := n.eq_zero_or_pos; · simp
   by_cases hα : α = 0
   · rw [hα, zero_pow hn.ne'] at e
     simp only [hα, e.symm, nthRoots_zero_right, mul_zero,
@@ -822,7 +799,7 @@ theorem card_nthRoots {n : ℕ} {ζ : R} (hζ : IsPrimitiveRoot ζ n) (a : R) :
 theorem card_rootsOfUnity' {n : ℕ} [NeZero n] (h : IsPrimitiveRoot ζ n) :
     Fintype.card (rootsOfUnity n R) = n := by
   let e := h.zmodEquivZPowers
-  haveI F : Fintype (Subgroup.zpowers ζ) := Fintype.ofEquiv _ e.toEquiv
+  have : Fintype (Subgroup.zpowers ζ) := Fintype.ofEquiv _ e.toEquiv
   calc
     Fintype.card (rootsOfUnity n R) = Fintype.card (Subgroup.zpowers ζ) :=
       Fintype.card_congr <| by rw [h.zpowers_eq]
@@ -843,7 +820,7 @@ theorem card_nthRoots_one {ζ : R} {n : ℕ} (h : IsPrimitiveRoot ζ n) :
 
 theorem nthRoots_nodup {ζ : R} {n : ℕ} (h : IsPrimitiveRoot ζ n) {a : R} (ha : a ≠ 0) :
     (nthRoots n a).Nodup := by
-  obtain (rfl|hn) := n.eq_zero_or_pos; · simp
+  obtain (rfl | hn) := n.eq_zero_or_pos; · simp
   by_cases h : ∃ α, α ^ n = a
   · obtain ⟨α, hα⟩ := h
     by_cases hα' : α = 0
@@ -890,16 +867,16 @@ theorem card_primitiveRoots {ζ : R} {k : ℕ} (h : IsPrimitiveRoot ζ k) :
 
 /-- The sets `primitiveRoots k R` are pairwise disjoint. -/
 theorem disjoint {k l : ℕ} (h : k ≠ l) : Disjoint (primitiveRoots k R) (primitiveRoots l R) :=
-  Finset.disjoint_left.2 fun _ hk hl =>
+  Finset.disjoint_left.2 fun _ hk hl ↦
     h <|
       (isPrimitiveRoot_of_mem_primitiveRoots hk).unique <| isPrimitiveRoot_of_mem_primitiveRoots hl
 
 /-- `nthRoots n` as a `Finset` is equal to the union of `primitiveRoots i R` for `i ∣ n`
-if there is a primitive root of unity in `R`.
-This holds for any `Nat`, not just `PNat`, see `nthRoots_one_eq_bUnion_primitive_roots`. -/
+if there is a primitive `n`th root of unity in `R`. -/
+private -- marking as `private` since `nthRoots_one_eq_biUnion_primitiveRoots` can be used instead
 theorem nthRoots_one_eq_biUnion_primitiveRoots' {ζ : R} {n : ℕ} [NeZero n]
     (h : IsPrimitiveRoot ζ n) :
-    nthRootsFinset n R = (Nat.divisors n).biUnion fun i => primitiveRoots i R := by
+    nthRootsFinset n R = (Nat.divisors n).biUnion fun i ↦ primitiveRoots i R := by
   symm
   apply Finset.eq_of_subset_of_card_le
   · intro x
@@ -922,12 +899,12 @@ theorem nthRoots_one_eq_biUnion_primitiveRoots' {ζ : R} {n : ℕ} [NeZero n]
       exact disjoint hdiff
 
 /-- `nthRoots n` as a `Finset` is equal to the union of `primitiveRoots i R` for `i ∣ n`
-if there is a primitive root of unity in `R`. -/
+if there is a primitive `n`th root of unity in `R`. -/
 theorem nthRoots_one_eq_biUnion_primitiveRoots {ζ : R} {n : ℕ}
     (h : IsPrimitiveRoot ζ n) :
-    nthRootsFinset n R = (Nat.divisors n).biUnion fun i => primitiveRoots i R := by
+    nthRootsFinset n R = (Nat.divisors n).biUnion fun i ↦ primitiveRoots i R := by
   by_cases hn : n = 0
-  · simp [hn]
+  · simp only [hn, nthRootsFinset_zero, Nat.divisors_zero, biUnion_empty]
   have : NeZero n := ⟨hn⟩
   exact nthRoots_one_eq_biUnion_primitiveRoots' h
 
@@ -938,20 +915,19 @@ section Automorphisms
 variable [CommRing S] [IsDomain S] {μ : S} {n : ℕ} (hμ : IsPrimitiveRoot μ n) (R) [CommRing R]
   [Algebra R S]
 
-/-- The `MonoidHom` that takes an automorphism to the power of μ that μ gets mapped to under it. -/
+/-- The `MonoidHom` that takes an automorphism to the power of `μ` that `μ` gets mapped to
+under it. -/
 noncomputable def autToPow [NeZero n] : (S ≃ₐ[R] S) →* (ZMod n)ˣ :=
   let μ' := hμ.toRootsOfUnity
   have ho : orderOf μ' = n := by
     refine Eq.trans ?_ hμ.eq_orderOf.symm -- `rw [hμ.eq_orderOf]` gives "motive not type correct"
     rw [← hμ.val_toRootsOfUnity_coe, orderOf_units, Subgroup.orderOf_coe]
   MonoidHom.toHomUnits
-    { toFun := fun σ => (map_rootsOfUnity_eq_pow_self σ.toAlgHom μ').choose
+    { toFun := fun σ ↦ (map_rootsOfUnity_eq_pow_self σ.toAlgHom μ').choose
       map_one' := by
         dsimp only
         generalize_proofs h1
         have h := h1.choose_spec
-        dsimp only [μ', AlgEquiv.one_apply, AlgEquiv.toRingEquiv_eq_coe, RingEquiv.toRingHom_eq_coe,
-          RingEquiv.coe_toRingHom, AlgEquiv.coe_ringEquiv] at *
         replace h : μ' = μ' ^ h1.choose :=
           rootsOfUnity.coe_injective (by simpa only [rootsOfUnity.coe_pow] using h)
         nth_rw 1 [← pow_one μ'] at h
@@ -964,8 +940,6 @@ noncomputable def autToPow [NeZero n] : (S ≃ₐ[R] S) →* (ZMod n)ˣ :=
         have hxy := hxy'.choose_spec
         have hx := hx'.choose_spec
         have hy := hy'.choose_spec
-        dsimp only [μ', AlgEquiv.toRingEquiv_eq_coe, RingEquiv.toRingHom_eq_coe,
-          RingEquiv.coe_toRingHom, AlgEquiv.coe_ringEquiv, AlgEquiv.mul_apply] at *
         replace hxy : x (((μ' : Sˣ) : S) ^ hy'.choose) = ((μ' : Sˣ) : S) ^ hxy'.choose := hy ▸ hxy
         rw [map_pow] at hxy
         replace hxy : (((μ' : Sˣ) : S) ^ hx'.choose) ^ hy'.choose = ((μ' : Sˣ) : S) ^ hxy'.choose :=
@@ -976,7 +950,7 @@ noncomputable def autToPow [NeZero n] : (S ≃ₐ[R] S) →* (ZMod n)ˣ :=
         convert ho ▸ (ZMod.natCast_eq_natCast_iff ..).mpr (pow_eq_pow_iff_modEq.mp hxy).symm
         exact (Nat.cast_mul ..).symm }
 
--- We are not using @[simps] in aut_to_pow to avoid a timeout.
+-- We are not using @[simps] in `autToPow` to avoid a timeout.
 theorem coe_autToPow_apply [NeZero n] (f : S ≃ₐ[R] S) :
     (autToPow R hμ f : ZMod n) =
       ((map_rootsOfUnity_eq_pow_self f hμ.toRootsOfUnity).choose : ZMod n) :=
@@ -986,8 +960,7 @@ theorem coe_autToPow_apply [NeZero n] (f : S ≃ₐ[R] S) :
 theorem autToPow_spec [NeZero n] (f : S ≃ₐ[R] S) : μ ^ (hμ.autToPow R f : ZMod n).val = f μ := by
   rw [IsPrimitiveRoot.coe_autToPow_apply]
   generalize_proofs h
-  have := h.choose_spec
-  refine (?_ : ((hμ.toRootsOfUnity : Sˣ) : S) ^ _ = _).trans this.symm
+  refine (?_ : ((hμ.toRootsOfUnity : Sˣ) : S) ^ _ = _).trans h.choose_spec.symm
   rw [← rootsOfUnity.coe_pow, ← rootsOfUnity.coe_pow]
   congr 2
   rw [pow_eq_pow_iff_modEq, ZMod.val_natCast]

--- a/Mathlib/RingTheory/RootsOfUnity/Complex.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Complex.lean
@@ -52,13 +52,14 @@ theorem isPrimitiveRoot_exp (n : ℕ) (h0 : n ≠ 0) : IsPrimitiveRoot (exp (2 *
     isPrimitiveRoot_exp_of_coprime 1 n h0 n.coprime_one_left
 
 theorem isPrimitiveRoot_iff (ζ : ℂ) (n : ℕ) (hn : n ≠ 0) :
-    IsPrimitiveRoot ζ n ↔ ∃ i < (n : ℕ), ∃ _ : i.Coprime n, exp (2 * π * I * (i / n)) = ζ := by
+    IsPrimitiveRoot ζ n ↔ ∃ i < n, ∃ _ : i.Coprime n, exp (2 * π * I * (i / n)) = ζ := by
   have hn0 : (n : ℂ) ≠ 0 := mod_cast hn
   constructor; swap
   · rintro ⟨i, -, hi, rfl⟩; exact isPrimitiveRoot_exp_of_coprime i n hn hi
   intro h
+  have : NeZero n := ⟨hn⟩
   obtain ⟨i, hi, rfl⟩ :=
-    (isPrimitiveRoot_exp n hn).eq_pow_of_pow_eq_one h.pow_eq_one (Nat.pos_of_ne_zero hn)
+    (isPrimitiveRoot_exp n hn).eq_pow_of_pow_eq_one h.pow_eq_one
   refine ⟨i, hi, ((isPrimitiveRoot_exp n hn).pow_iff_coprime (Nat.pos_of_ne_zero hn) i).mp h, ?_⟩
   rw [← exp_nat_mul]
   congr 1
@@ -66,14 +67,14 @@ theorem isPrimitiveRoot_iff (ζ : ℂ) (n : ℕ) (hn : n ≠ 0) :
 
 /-- The complex `n`-th roots of unity are exactly the
 complex numbers of the form `exp (2 * Real.pi * Complex.I * (i / n))` for some `i < n`. -/
-nonrec theorem mem_rootsOfUnity (n : ℕ+) (x : Units ℂ) :
-    x ∈ rootsOfUnity n ℂ ↔ ∃ i < (n : ℕ), exp (2 * π * I * (i / n)) = x := by
+nonrec theorem mem_rootsOfUnity (n : ℕ) [NeZero n] (x : Units ℂ) :
+    x ∈ rootsOfUnity n ℂ ↔ ∃ i < n, exp (2 * π * I * (i / n)) = x := by
   rw [mem_rootsOfUnity, Units.ext_iff, Units.val_pow_eq_pow_val, Units.val_one]
-  have hn0 : (n : ℂ) ≠ 0 := mod_cast n.ne_zero
+  have hn0 : (n : ℂ) ≠ 0 := mod_cast NeZero.out
   constructor
   · intro h
     obtain ⟨i, hi, H⟩ : ∃ i < (n : ℕ), exp (2 * π * I / n) ^ i = x := by
-      simpa only using (isPrimitiveRoot_exp n n.ne_zero).eq_pow_of_pow_eq_one h n.pos
+      simpa only using (isPrimitiveRoot_exp n NeZero.out).eq_pow_of_pow_eq_one h
     refine ⟨i, hi, ?_⟩
     rw [← H, ← exp_nat_mul]
     congr 1
@@ -83,8 +84,8 @@ nonrec theorem mem_rootsOfUnity (n : ℕ+) (x : Units ℂ) :
     use i
     field_simp [hn0, mul_comm ((n : ℕ) : ℂ), mul_comm (i : ℂ)]
 
-theorem card_rootsOfUnity (n : ℕ+) : Fintype.card (rootsOfUnity n ℂ) = n :=
-  (isPrimitiveRoot_exp n n.ne_zero).card_rootsOfUnity
+theorem card_rootsOfUnity (n : ℕ) [NeZero n] : Fintype.card (rootsOfUnity n ℂ) = n :=
+  (isPrimitiveRoot_exp n NeZero.out).card_rootsOfUnity
 
 theorem card_primitiveRoots (k : ℕ) : (primitiveRoots k ℂ).card = φ k := by
   by_cases h : k = 0
@@ -173,9 +174,10 @@ theorem IsPrimitiveRoot.arg {n : ℕ} {ζ : ℂ} (h : IsPrimitiveRoot ζ n) (hn 
     exact mod_cast not_le.mp h₂
   · exact Nat.cast_pos.mpr hn.bot_lt
 
-lemma Complex.norm_eq_one_of_mem_rootsOfUnity {ζ : ℂˣ} {n : ℕ+} (hζ : ζ ∈ rootsOfUnity n ℂ) :
+lemma Complex.norm_eq_one_of_mem_rootsOfUnity {ζ : ℂˣ} {n : ℕ} [NeZero n]
+    (hζ : ζ ∈ rootsOfUnity n ℂ) :
     ‖(ζ : ℂ)‖ = 1 := by
-  refine norm_eq_one_of_pow_eq_one ?_ <| n.ne_zero
+  refine norm_eq_one_of_pow_eq_one ?_ <| NeZero.ne n
   norm_cast
   rw [_root_.mem_rootsOfUnity] at hζ
   rw [hζ, Units.val_one]

--- a/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
@@ -195,9 +195,10 @@ theorem pow_isRoot_minpoly {m : ℕ} (hcop : Nat.Coprime m n) :
 theorem is_roots_of_minpoly [DecidableEq K] :
     primitiveRoots n K ⊆ (map (Int.castRingHom K) (minpoly ℤ μ)).roots.toFinset := by
   by_cases hn : n = 0; · simp_all
+  have : NeZero n := ⟨hn⟩
   have hpos := Nat.pos_of_ne_zero hn
   intro x hx
-  obtain ⟨m, _, hcop, rfl⟩ := (isPrimitiveRoot_iff h hpos).1 ((mem_primitiveRoots hpos).1 hx)
+  obtain ⟨m, _, hcop, rfl⟩ := (isPrimitiveRoot_iff h).1 ((mem_primitiveRoots hpos).1 hx)
   simp only [Multiset.mem_toFinset, mem_roots]
   convert pow_isRoot_minpoly h hcop using 0
   rw [← mem_roots]


### PR DESCRIPTION
This is an attempt to refactor the definition of `rootsOfUnity` using a `Nat` instead of a `PNat`.

* In the definition of `rootsOfUnity`, we replace `(n : ℕ+)` by `(n : ℕ)`. The definition does not require `n` to be nonzero; it gives that `rootsOfUnity 0 M` is the top subgroup of the unit group of `M`.
* For results that need a positive `n`, we replace `(n : ℕ+)` with `(n : ℕ) [NeZero n]` in the parameters. In this way, they transparently apply when a `PNat` is used for `n` since `n` gets coerced to `Nat` and an `NeZero (n : ℕ)` instance is available.

The main benefit is that one no longer needs constructions like `rootsOfUnity ⟨n, <proof that n is positive⟩) R` when `n` is a natural number; one can simply use `rootsOfUnity n R`. (One may need to turn the positivity proof into an `NeZero` instance, however, if that is not available automatically.)

In addition, the code in `Mathlib.RingTheory.RootsOfUnity.Basic` can be simplified a bit in places, e.g., `x ^ (k : ℕ)` can be replaced by `x ^ k` and `∃ (i : ℕ), i < k ∧ P i` can be replaced by `∃ i < k, P i`. One result (`eq_pow_of_mem_rootsOfUnity'`; it was translating between `Nat`s and `PNat`s) can be removed altogether.

Since I was going through this file anyway, I took the opportunity to replace `=>` by `↦` and to do some golfing as well.

What this PR does *not* do is also refactoring cyclotomic extensions to not use (sets of) `PNat`s. This is a more complex matter and requires more thought and discussion.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
