### PR TITLE
[Merged by Bors] - chore(RingTheory/NonUnitalSubsemiring): split `Basic.lean`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4182,6 +4182,7 @@ import Mathlib.RingTheory.Nilpotent.Lemmas
 import Mathlib.RingTheory.Noetherian
 import Mathlib.RingTheory.NonUnitalSubring.Basic
 import Mathlib.RingTheory.NonUnitalSubsemiring.Basic
+import Mathlib.RingTheory.NonUnitalSubsemiring.Defs
 import Mathlib.RingTheory.Norm.Basic
 import Mathlib.RingTheory.Norm.Defs
 import Mathlib.RingTheory.NormTrace

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
@@ -14,12 +14,12 @@ import Mathlib.Algebra.Ring.Prod
 import Mathlib.Algebra.Group.Hom.End
 import Mathlib.Data.Set.Finite
 import Mathlib.GroupTheory.Subsemigroup.Centralizer
+import Mathlib.RingTheory.NonUnitalSubsemiring.Defs
 
 /-!
 # Bundled non-unital subsemirings
 
-We define bundled non-unital subsemirings and some standard constructions:
-`CompleteLattice` structure, `subtype` and `inclusion` ring homomorphisms, non-unital subsemiring
+We define the `CompleteLattice` structure, and non-unital subsemiring
 `map`, `comap` and range (`srange`) of a `NonUnitalRingHom` etc.
 -/
 
@@ -28,105 +28,7 @@ universe u v w
 
 variable {R : Type u} {S : Type v} {T : Type w} [NonUnitalNonAssocSemiring R] (M : Subsemigroup R)
 
-/-- `NonUnitalSubsemiringClass S R` states that `S` is a type of subsets `s ⊆ R` that
-are both an additive submonoid and also a multiplicative subsemigroup. -/
-class NonUnitalSubsemiringClass (S : Type*) (R : outParam (Type u)) [NonUnitalNonAssocSemiring R]
-  [SetLike S R] extends AddSubmonoidClass S R : Prop where
-  mul_mem : ∀ {s : S} {a b : R}, a ∈ s → b ∈ s → a * b ∈ s
-
--- See note [lower instance priority]
-instance (priority := 100) NonUnitalSubsemiringClass.mulMemClass (S : Type*) (R : Type u)
-    [NonUnitalNonAssocSemiring R] [SetLike S R] [h : NonUnitalSubsemiringClass S R] :
-    MulMemClass S R :=
-  { h with }
-
-namespace NonUnitalSubsemiringClass
-
-variable [SetLike S R] [NonUnitalSubsemiringClass S R] (s : S)
-
-open AddSubmonoidClass
-
-/- Prefer subclasses of `NonUnitalNonAssocSemiring` over subclasses of
-`NonUnitalSubsemiringClass`. -/
-/-- A non-unital subsemiring of a `NonUnitalNonAssocSemiring` inherits a
-`NonUnitalNonAssocSemiring` structure -/
-instance (priority := 75) toNonUnitalNonAssocSemiring : NonUnitalNonAssocSemiring s :=
-  Subtype.coe_injective.nonUnitalNonAssocSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
-
-instance noZeroDivisors [NoZeroDivisors R] : NoZeroDivisors s :=
-  Subtype.coe_injective.noZeroDivisors (↑) rfl fun _ _ => rfl
-
-/-- The natural non-unital ring hom from a non-unital subsemiring of a non-unital semiring `R` to
-`R`. -/
-def subtype : s →ₙ+* R :=
-  { AddSubmonoidClass.subtype s, MulMemClass.subtype s with toFun := (↑) }
-
-@[simp]
-theorem coeSubtype : (subtype s : s → R) = ((↑) : s → R) :=
-  rfl
-
-/-- A non-unital subsemiring of a `NonUnitalSemiring` is a `NonUnitalSemiring`. -/
-instance toNonUnitalSemiring {R} [NonUnitalSemiring R] [SetLike S R]
-    [NonUnitalSubsemiringClass S R] : NonUnitalSemiring s :=
-  Subtype.coe_injective.nonUnitalSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
-
-/-- A non-unital subsemiring of a `NonUnitalCommSemiring` is a `NonUnitalCommSemiring`. -/
-instance toNonUnitalCommSemiring {R} [NonUnitalCommSemiring R] [SetLike S R]
-    [NonUnitalSubsemiringClass S R] : NonUnitalCommSemiring s :=
-  Subtype.coe_injective.nonUnitalCommSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
-
-/-! Note: currently, there are no ordered versions of non-unital rings. -/
-
-
-end NonUnitalSubsemiringClass
-
-/-- A non-unital subsemiring of a non-unital semiring `R` is a subset `s` that is both an additive
-submonoid and a semigroup. -/
-structure NonUnitalSubsemiring (R : Type u) [NonUnitalNonAssocSemiring R] extends AddSubmonoid R,
-  Subsemigroup R
-
-/-- Reinterpret a `NonUnitalSubsemiring` as a `Subsemigroup`. -/
-add_decl_doc NonUnitalSubsemiring.toSubsemigroup
-
-/-- Reinterpret a `NonUnitalSubsemiring` as an `AddSubmonoid`. -/
-add_decl_doc NonUnitalSubsemiring.toAddSubmonoid
-
 namespace NonUnitalSubsemiring
-
-instance : SetLike (NonUnitalSubsemiring R) R where
-  coe s := s.carrier
-  coe_injective' p q h := by cases p; cases q; congr; exact SetLike.coe_injective' h
-
-instance : NonUnitalSubsemiringClass (NonUnitalSubsemiring R) R where
-  zero_mem {s} := AddSubmonoid.zero_mem' s.toAddSubmonoid
-  add_mem {s} := AddSubsemigroup.add_mem' s.toAddSubmonoid.toAddSubsemigroup
-  mul_mem {s} := mul_mem' s
-
-theorem mem_carrier {s : NonUnitalSubsemiring R} {x : R} : x ∈ s.carrier ↔ x ∈ s :=
-  Iff.rfl
-
-/-- Two non-unital subsemirings are equal if they have the same elements. -/
-@[ext]
-theorem ext {S T : NonUnitalSubsemiring R} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T :=
-  SetLike.ext h
-
-/-- Copy of a non-unital subsemiring with a new `carrier` equal to the old one. Useful to fix
-definitional equalities. -/
-protected def copy (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) :
-    NonUnitalSubsemiring R :=
-  { S.toAddSubmonoid.copy s hs, S.toSubsemigroup.copy s hs with carrier := s }
-
-@[simp]
-theorem coe_copy (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) :
-    (S.copy s hs : Set R) = s :=
-  rfl
-
-theorem copy_eq (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) : S.copy s hs = S :=
-  SetLike.coe_injective hs
-
-theorem toSubsemigroup_injective :
-    Function.Injective (toSubsemigroup : NonUnitalSubsemiring R → Subsemigroup R)
-  | _, _, h => ext (SetLike.ext_iff.mp h : _)
 
 @[mono]
 theorem toSubsemigroup_strictMono :
@@ -136,10 +38,6 @@ theorem toSubsemigroup_strictMono :
 theorem toSubsemigroup_mono : Monotone (toSubsemigroup : NonUnitalSubsemiring R → Subsemigroup R) :=
   toSubsemigroup_strictMono.monotone
 
-theorem toAddSubmonoid_injective :
-    Function.Injective (toAddSubmonoid : NonUnitalSubsemiring R → AddSubmonoid R)
-  | _, _, h => ext (SetLike.ext_iff.mp h : _)
-
 @[mono]
 theorem toAddSubmonoid_strictMono :
     StrictMono (toAddSubmonoid : NonUnitalSubsemiring R → AddSubmonoid R) := fun _ _ => id
@@ -147,35 +45,6 @@ theorem toAddSubmonoid_strictMono :
 @[mono]
 theorem toAddSubmonoid_mono : Monotone (toAddSubmonoid : NonUnitalSubsemiring R → AddSubmonoid R) :=
   toAddSubmonoid_strictMono.monotone
-
-/-- Construct a `NonUnitalSubsemiring R` from a set `s`, a subsemigroup `sg`, and an additive
-submonoid `sa` such that `x ∈ s ↔ x ∈ sg ↔ x ∈ sa`. -/
-protected def mk' (s : Set R) (sg : Subsemigroup R) (hg : ↑sg = s) (sa : AddSubmonoid R)
-    (ha : ↑sa = s) : NonUnitalSubsemiring R where
-  carrier := s
-  zero_mem' := by subst ha; exact sa.zero_mem
-  add_mem' := by subst ha; exact sa.add_mem
-  mul_mem' := by subst hg; exact sg.mul_mem
-
-@[simp]
-theorem coe_mk' {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
-    (ha : ↑sa = s) : (NonUnitalSubsemiring.mk' s sg hg sa ha : Set R) = s :=
-  rfl
-
-@[simp]
-theorem mem_mk' {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
-    (ha : ↑sa = s) {x : R} : x ∈ NonUnitalSubsemiring.mk' s sg hg sa ha ↔ x ∈ s :=
-  Iff.rfl
-
-@[simp]
-theorem mk'_toSubsemigroup {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
-    (ha : ↑sa = s) : (NonUnitalSubsemiring.mk' s sg hg sa ha).toSubsemigroup = sg :=
-  SetLike.coe_injective hg.symm
-
-@[simp]
-theorem mk'_toAddSubmonoid {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
-    (ha : ↑sa = s) : (NonUnitalSubsemiring.mk' s sg hg sa ha).toAddSubmonoid = sa :=
-  SetLike.coe_injective ha.symm
 
 end NonUnitalSubsemiring
 
@@ -185,49 +54,6 @@ variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
 variable {F G : Type*} [FunLike F R S] [NonUnitalRingHomClass F R S]
   [FunLike G S T] [NonUnitalRingHomClass G S T]
   (s : NonUnitalSubsemiring R)
-
-@[simp, norm_cast]
-theorem coe_zero : ((0 : s) : R) = (0 : R) :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_add (x y : s) : ((x + y : s) : R) = (x + y : R) :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_mul (x y : s) : ((x * y : s) : R) = (x * y : R) :=
-  rfl
-
-/-! Note: currently, there are no ordered versions of non-unital rings. -/
-
-
-@[simp high]
-theorem mem_toSubsemigroup {s : NonUnitalSubsemiring R} {x : R} : x ∈ s.toSubsemigroup ↔ x ∈ s :=
-  Iff.rfl
-
-@[simp high]
-theorem coe_toSubsemigroup (s : NonUnitalSubsemiring R) : (s.toSubsemigroup : Set R) = s :=
-  rfl
-
-@[simp]
-theorem mem_toAddSubmonoid {s : NonUnitalSubsemiring R} {x : R} : x ∈ s.toAddSubmonoid ↔ x ∈ s :=
-  Iff.rfl
-
-@[simp]
-theorem coe_toAddSubmonoid (s : NonUnitalSubsemiring R) : (s.toAddSubmonoid : Set R) = s :=
-  rfl
-
-/-- The non-unital subsemiring `R` of the non-unital semiring `R`. -/
-instance : Top (NonUnitalSubsemiring R) :=
-  ⟨{ (⊤ : Subsemigroup R), (⊤ : AddSubmonoid R) with }⟩
-
-@[simp]
-theorem mem_top (x : R) : x ∈ (⊤ : NonUnitalSubsemiring R) :=
-  Set.mem_univ x
-
-@[simp]
-theorem coe_top : ((⊤ : NonUnitalSubsemiring R) : Set R) = Set.univ :=
-  rfl
 
 /-- The ring equiv between the top element of `NonUnitalSubsemiring R` and `R`. -/
 @[simps!]
@@ -335,37 +161,6 @@ instance finite_srange [Finite R] (f : F) : Finite (srange f : NonUnitalSubsemir
 end NonUnitalRingHom
 
 namespace NonUnitalSubsemiring
-
--- should we define this as the range of the zero homomorphism?
-instance : Bot (NonUnitalSubsemiring R) :=
-  ⟨{  carrier := {0}
-      add_mem' := fun _ _ => by simp_all
-      zero_mem' := Set.mem_singleton 0
-      mul_mem' := fun _ _ => by simp_all }⟩
-
-instance : Inhabited (NonUnitalSubsemiring R) :=
-  ⟨⊥⟩
-
-theorem coe_bot : ((⊥ : NonUnitalSubsemiring R) : Set R) = {0} :=
-  rfl
-
-theorem mem_bot {x : R} : x ∈ (⊥ : NonUnitalSubsemiring R) ↔ x = 0 :=
-  Set.mem_singleton_iff
-
-/-- The inf of two non-unital subsemirings is their intersection. -/
-instance : Inf (NonUnitalSubsemiring R) :=
-  ⟨fun s t =>
-    { s.toSubsemigroup ⊓ t.toSubsemigroup, s.toAddSubmonoid ⊓ t.toAddSubmonoid with
-      carrier := s ∩ t }⟩
-
-@[simp]
-theorem coe_inf (p p' : NonUnitalSubsemiring R) :
-    ((p ⊓ p' : NonUnitalSubsemiring R) : Set R) = (p : Set R) ∩ p' :=
-  rfl
-
-@[simp]
-theorem mem_inf {p p' : NonUnitalSubsemiring R} {x : R} : x ∈ p ⊓ p' ↔ x ∈ p ∧ x ∈ p' :=
-  Iff.rfl
 
 instance : InfSet (NonUnitalSubsemiring R) :=
   ⟨fun s =>
@@ -809,13 +604,6 @@ variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
 
 open NonUnitalSubsemiringClass NonUnitalSubsemiring
 
-/-- Restriction of a non-unital ring homomorphism to a non-unital subsemiring of the codomain. -/
-def codRestrict (f : F) (s : S') (h : ∀ x, f x ∈ s) : R →ₙ+* s where
-  toFun n := ⟨f n, h n⟩
-  map_mul' x y := Subtype.eq (map_mul f x y)
-  map_add' x y := Subtype.eq (map_add f x y)
-  map_zero' := Subtype.eq (map_zero f)
-
 /-- Restriction of a non-unital ring homomorphism to its range interpreted as a
 non-unital subsemiring.
 
@@ -842,11 +630,6 @@ theorem srange_top_iff_surjective {f : F} :
 theorem srange_top_of_surjective (f : F) (hf : Function.Surjective (f : R → S)) :
     srange f = (⊤ : NonUnitalSubsemiring S) :=
   srange_top_iff_surjective.2 hf
-
-/-- The non-unital subsemiring of elements `x : R` such that `f x = g x` -/
-def eqSlocus (f g : F) : NonUnitalSubsemiring R :=
-  { (f : R →ₙ* S).eqLocus (g : R →ₙ* S), (f : R →+ S).eqLocusM g with
-    carrier := { x | f x = g x } }
 
 /-- If two non-unital ring homomorphisms are equal on a set, then they are equal on its
 non-unital subsemiring closure. -/
@@ -875,11 +658,6 @@ end NonUnitalRingHom
 namespace NonUnitalSubsemiring
 
 open NonUnitalRingHom NonUnitalSubsemiringClass
-
-/-- The non-unital ring homomorphism associated to an inclusion of
-non-unital subsemirings. -/
-def inclusion {S T : NonUnitalSubsemiring R} (h : S ≤ T) : S →ₙ+* T :=
-  codRestrict (subtype S) _ fun x => h x.2
 
 @[simp]
 theorem srange_subtype (s : NonUnitalSubsemiring R) : NonUnitalRingHom.srange (subtype s) = s :=

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -1,0 +1,288 @@
+/-
+Copyright (c) 2022 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+import Mathlib.Algebra.Ring.Hom.Defs
+import Mathlib.Algebra.Ring.InjSurj
+import Mathlib.Algebra.Group.Submonoid.Defs
+
+/-!
+# Bundled non-unital subsemirings
+
+We define bundled non-unital subsemirings and some standard constructions:
+`subtype` and `inclusion` ring homomorphisms.
+-/
+
+
+universe u v w
+
+variable {R : Type u} {S : Type v} {T : Type w} [NonUnitalNonAssocSemiring R] (M : Subsemigroup R)
+
+/-- `NonUnitalSubsemiringClass S R` states that `S` is a type of subsets `s ⊆ R` that
+are both an additive submonoid and also a multiplicative subsemigroup. -/
+class NonUnitalSubsemiringClass (S : Type*) (R : outParam (Type u)) [NonUnitalNonAssocSemiring R]
+  [SetLike S R] extends AddSubmonoidClass S R : Prop where
+  mul_mem : ∀ {s : S} {a b : R}, a ∈ s → b ∈ s → a * b ∈ s
+
+-- See note [lower instance priority]
+instance (priority := 100) NonUnitalSubsemiringClass.mulMemClass (S : Type*) (R : Type u)
+    [NonUnitalNonAssocSemiring R] [SetLike S R] [h : NonUnitalSubsemiringClass S R] :
+    MulMemClass S R :=
+  { h with }
+
+namespace NonUnitalSubsemiringClass
+
+variable [SetLike S R] [NonUnitalSubsemiringClass S R] (s : S)
+
+open AddSubmonoidClass
+
+/- Prefer subclasses of `NonUnitalNonAssocSemiring` over subclasses of
+`NonUnitalSubsemiringClass`. -/
+/-- A non-unital subsemiring of a `NonUnitalNonAssocSemiring` inherits a
+`NonUnitalNonAssocSemiring` structure -/
+instance (priority := 75) toNonUnitalNonAssocSemiring : NonUnitalNonAssocSemiring s :=
+  Subtype.coe_injective.nonUnitalNonAssocSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
+
+instance noZeroDivisors [NoZeroDivisors R] : NoZeroDivisors s :=
+  Subtype.coe_injective.noZeroDivisors (↑) rfl fun _ _ => rfl
+
+/-- The natural non-unital ring hom from a non-unital subsemiring of a non-unital semiring `R` to
+`R`. -/
+def subtype : s →ₙ+* R :=
+  { AddSubmonoidClass.subtype s, MulMemClass.subtype s with toFun := (↑) }
+
+@[simp]
+theorem coeSubtype : (subtype s : s → R) = ((↑) : s → R) :=
+  rfl
+
+/-- A non-unital subsemiring of a `NonUnitalSemiring` is a `NonUnitalSemiring`. -/
+instance toNonUnitalSemiring {R} [NonUnitalSemiring R] [SetLike S R]
+    [NonUnitalSubsemiringClass S R] : NonUnitalSemiring s :=
+  Subtype.coe_injective.nonUnitalSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
+
+/-- A non-unital subsemiring of a `NonUnitalCommSemiring` is a `NonUnitalCommSemiring`. -/
+instance toNonUnitalCommSemiring {R} [NonUnitalCommSemiring R] [SetLike S R]
+    [NonUnitalSubsemiringClass S R] : NonUnitalCommSemiring s :=
+  Subtype.coe_injective.nonUnitalCommSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
+
+/-! Note: currently, there are no ordered versions of non-unital rings. -/
+
+
+end NonUnitalSubsemiringClass
+
+/-- A non-unital subsemiring of a non-unital semiring `R` is a subset `s` that is both an additive
+submonoid and a semigroup. -/
+structure NonUnitalSubsemiring (R : Type u) [NonUnitalNonAssocSemiring R] extends AddSubmonoid R,
+  Subsemigroup R
+
+/-- Reinterpret a `NonUnitalSubsemiring` as a `Subsemigroup`. -/
+add_decl_doc NonUnitalSubsemiring.toSubsemigroup
+
+/-- Reinterpret a `NonUnitalSubsemiring` as an `AddSubmonoid`. -/
+add_decl_doc NonUnitalSubsemiring.toAddSubmonoid
+
+namespace NonUnitalSubsemiring
+
+instance : SetLike (NonUnitalSubsemiring R) R where
+  coe s := s.carrier
+  coe_injective' p q h := by cases p; cases q; congr; exact SetLike.coe_injective' h
+
+instance : NonUnitalSubsemiringClass (NonUnitalSubsemiring R) R where
+  zero_mem {s} := AddSubmonoid.zero_mem' s.toAddSubmonoid
+  add_mem {s} := AddSubsemigroup.add_mem' s.toAddSubmonoid.toAddSubsemigroup
+  mul_mem {s} := mul_mem' s
+
+theorem mem_carrier {s : NonUnitalSubsemiring R} {x : R} : x ∈ s.carrier ↔ x ∈ s :=
+  Iff.rfl
+
+/-- Two non-unital subsemirings are equal if they have the same elements. -/
+@[ext]
+theorem ext {S T : NonUnitalSubsemiring R} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T :=
+  SetLike.ext h
+
+/-- Copy of a non-unital subsemiring with a new `carrier` equal to the old one. Useful to fix
+definitional equalities. -/
+protected def copy (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) :
+    NonUnitalSubsemiring R :=
+  { S.toAddSubmonoid.copy s hs, S.toSubsemigroup.copy s hs with carrier := s }
+
+@[simp]
+theorem coe_copy (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) :
+    (S.copy s hs : Set R) = s :=
+  rfl
+
+theorem copy_eq (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) : S.copy s hs = S :=
+  SetLike.coe_injective hs
+
+theorem toSubsemigroup_injective :
+    Function.Injective (toSubsemigroup : NonUnitalSubsemiring R → Subsemigroup R)
+  | _, _, h => ext (SetLike.ext_iff.mp h : _)
+
+theorem toAddSubmonoid_injective :
+    Function.Injective (toAddSubmonoid : NonUnitalSubsemiring R → AddSubmonoid R)
+  | _, _, h => ext (SetLike.ext_iff.mp h : _)
+
+/-- Construct a `NonUnitalSubsemiring R` from a set `s`, a subsemigroup `sg`, and an additive
+submonoid `sa` such that `x ∈ s ↔ x ∈ sg ↔ x ∈ sa`. -/
+protected def mk' (s : Set R) (sg : Subsemigroup R) (hg : ↑sg = s) (sa : AddSubmonoid R)
+    (ha : ↑sa = s) : NonUnitalSubsemiring R where
+  carrier := s
+  zero_mem' := by subst ha; exact sa.zero_mem
+  add_mem' := by subst ha; exact sa.add_mem
+  mul_mem' := by subst hg; exact sg.mul_mem
+
+@[simp]
+theorem coe_mk' {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
+    (ha : ↑sa = s) : (NonUnitalSubsemiring.mk' s sg hg sa ha : Set R) = s :=
+  rfl
+
+@[simp]
+theorem mem_mk' {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
+    (ha : ↑sa = s) {x : R} : x ∈ NonUnitalSubsemiring.mk' s sg hg sa ha ↔ x ∈ s :=
+  Iff.rfl
+
+@[simp]
+theorem mk'_toSubsemigroup {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
+    (ha : ↑sa = s) : (NonUnitalSubsemiring.mk' s sg hg sa ha).toSubsemigroup = sg :=
+  SetLike.coe_injective hg.symm
+
+@[simp]
+theorem mk'_toAddSubmonoid {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
+    (ha : ↑sa = s) : (NonUnitalSubsemiring.mk' s sg hg sa ha).toAddSubmonoid = sa :=
+  SetLike.coe_injective ha.symm
+
+end NonUnitalSubsemiring
+
+namespace NonUnitalSubsemiring
+
+variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
+variable {F G : Type*} [FunLike F R S] [NonUnitalRingHomClass F R S]
+  [FunLike G S T] [NonUnitalRingHomClass G S T]
+  (s : NonUnitalSubsemiring R)
+
+@[simp, norm_cast]
+theorem coe_zero : ((0 : s) : R) = (0 : R) :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_add (x y : s) : ((x + y : s) : R) = (x + y : R) :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_mul (x y : s) : ((x * y : s) : R) = (x * y : R) :=
+  rfl
+
+/-! Note: currently, there are no ordered versions of non-unital rings. -/
+
+
+@[simp high]
+theorem mem_toSubsemigroup {s : NonUnitalSubsemiring R} {x : R} : x ∈ s.toSubsemigroup ↔ x ∈ s :=
+  Iff.rfl
+
+@[simp high]
+theorem coe_toSubsemigroup (s : NonUnitalSubsemiring R) : (s.toSubsemigroup : Set R) = s :=
+  rfl
+
+@[simp]
+theorem mem_toAddSubmonoid {s : NonUnitalSubsemiring R} {x : R} : x ∈ s.toAddSubmonoid ↔ x ∈ s :=
+  Iff.rfl
+
+@[simp]
+theorem coe_toAddSubmonoid (s : NonUnitalSubsemiring R) : (s.toAddSubmonoid : Set R) = s :=
+  rfl
+
+/-- The non-unital subsemiring `R` of the non-unital semiring `R`. -/
+instance : Top (NonUnitalSubsemiring R) :=
+  ⟨{ (⊤ : Subsemigroup R), (⊤ : AddSubmonoid R) with }⟩
+
+@[simp]
+theorem mem_top (x : R) : x ∈ (⊤ : NonUnitalSubsemiring R) :=
+  Set.mem_univ x
+
+@[simp]
+theorem coe_top : ((⊤ : NonUnitalSubsemiring R) : Set R) = Set.univ :=
+  rfl
+
+end NonUnitalSubsemiring
+
+namespace NonUnitalRingHom
+
+open NonUnitalSubsemiring
+
+variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
+variable {F G : Type*} [FunLike F R S] [NonUnitalRingHomClass F R S]
+variable [FunLike G S T] [NonUnitalRingHomClass G S T] (f : F) (g : G)
+
+end NonUnitalRingHom
+
+namespace NonUnitalSubsemiring
+
+-- should we define this as the range of the zero homomorphism?
+instance : Bot (NonUnitalSubsemiring R) :=
+  ⟨{  carrier := {0}
+      add_mem' := fun _ _ => by simp_all
+      zero_mem' := Set.mem_singleton 0
+      mul_mem' := fun _ _ => by simp_all }⟩
+
+instance : Inhabited (NonUnitalSubsemiring R) :=
+  ⟨⊥⟩
+
+theorem coe_bot : ((⊥ : NonUnitalSubsemiring R) : Set R) = {0} :=
+  rfl
+
+theorem mem_bot {x : R} : x ∈ (⊥ : NonUnitalSubsemiring R) ↔ x = 0 :=
+  Set.mem_singleton_iff
+
+/-- The inf of two non-unital subsemirings is their intersection. -/
+instance : Inf (NonUnitalSubsemiring R) :=
+  ⟨fun s t =>
+    { s.toSubsemigroup ⊓ t.toSubsemigroup, s.toAddSubmonoid ⊓ t.toAddSubmonoid with
+      carrier := s ∩ t }⟩
+
+@[simp]
+theorem coe_inf (p p' : NonUnitalSubsemiring R) :
+    ((p ⊓ p' : NonUnitalSubsemiring R) : Set R) = (p : Set R) ∩ p' :=
+  rfl
+
+@[simp]
+theorem mem_inf {p p' : NonUnitalSubsemiring R} {x : R} : x ∈ p ⊓ p' ↔ x ∈ p ∧ x ∈ p' :=
+  Iff.rfl
+
+end NonUnitalSubsemiring
+
+namespace NonUnitalRingHom
+
+variable {F : Type*} [FunLike F R S]
+
+variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
+  [NonUnitalRingHomClass F R S]
+  {S' : Type*} [SetLike S' S] [NonUnitalSubsemiringClass S' S]
+  {s : NonUnitalSubsemiring R}
+
+open NonUnitalSubsemiringClass NonUnitalSubsemiring
+
+/-- Restriction of a non-unital ring homomorphism to a non-unital subsemiring of the codomain. -/
+def codRestrict (f : F) (s : S') (h : ∀ x, f x ∈ s) : R →ₙ+* s where
+  toFun n := ⟨f n, h n⟩
+  map_mul' x y := Subtype.eq (map_mul f x y)
+  map_add' x y := Subtype.eq (map_add f x y)
+  map_zero' := Subtype.eq (map_zero f)
+
+/-- The non-unital subsemiring of elements `x : R` such that `f x = g x` -/
+def eqSlocus (f g : F) : NonUnitalSubsemiring R :=
+  { (f : R →ₙ* S).eqLocus (g : R →ₙ* S), (f : R →+ S).eqLocusM g with
+    carrier := { x | f x = g x } }
+
+end NonUnitalRingHom
+
+namespace NonUnitalSubsemiring
+
+open NonUnitalRingHom NonUnitalSubsemiringClass
+
+/-- The non-unital ring homomorphism associated to an inclusion of
+non-unital subsemirings. -/
+def inclusion {S T : NonUnitalSubsemiring R} (h : S ≤ T) : S →ₙ+* T :=
+  codRestrict (subtype S) _ fun x => h x.2
+
+end NonUnitalSubsemiring


### PR DESCRIPTION
This PR splits off a `Defs.lean` file from `NonUnitalSubsemiring/Basic.lean` containing on the definition and non unital subsemiring structure of `NonUnitalSubSemiring`(`Class`).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
