### PR TITLE
[Merged by Bors] - chore(Algebra/Ring/Subsemiring): split `Basic.lean`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4182,6 +4182,7 @@ import Mathlib.RingTheory.Nilpotent.Lemmas
 import Mathlib.RingTheory.Noetherian
 import Mathlib.RingTheory.NonUnitalSubring.Basic
 import Mathlib.RingTheory.NonUnitalSubsemiring.Basic
+import Mathlib.RingTheory.NonUnitalSubsemiring.Defs
 import Mathlib.RingTheory.Norm.Basic
 import Mathlib.RingTheory.Norm.Defs
 import Mathlib.RingTheory.NormTrace

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -834,6 +834,7 @@ import Mathlib.Algebra.Ring.Subring.Order
 import Mathlib.Algebra.Ring.Subring.Pointwise
 import Mathlib.Algebra.Ring.Subring.Units
 import Mathlib.Algebra.Ring.Subsemiring.Basic
+import Mathlib.Algebra.Ring.Subsemiring.Defs
 import Mathlib.Algebra.Ring.Subsemiring.MulOpposite
 import Mathlib.Algebra.Ring.Subsemiring.Order
 import Mathlib.Algebra.Ring.Subsemiring.Pointwise

--- a/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Ring.Action.Subobjects
 import Mathlib.Algebra.Ring.Equiv
 import Mathlib.Algebra.Ring.Prod
+import Mathlib.Algebra.Ring.Subsemiring.Defs
 import Mathlib.Data.Set.Finite
 import Mathlib.GroupTheory.Submonoid.Centralizer
 import Mathlib.RingTheory.NonUnitalSubsemiring.Basic
@@ -15,107 +16,20 @@ import Mathlib.RingTheory.NonUnitalSubsemiring.Basic
 /-!
 # Bundled subsemirings
 
-We define bundled subsemirings and some standard constructions: `CompleteLattice` structure,
-`Subtype` and `inclusion` ring homomorphisms, subsemiring `map`, `comap` and range (`rangeS`) of
-a `RingHom` etc.
+We define some standard constructions on bundled subsemirings: `CompleteLattice` structure,
+subsemiring `map`, `comap` and range (`rangeS`) of a `RingHom` etc.
 -/
 
 
 universe u v w
 
-section AddSubmonoidWithOneClass
-
-/-- `AddSubmonoidWithOneClass S R` says `S` is a type of subsets `s ≤ R` that contain `0`, `1`,
-and are closed under `(+)` -/
-class AddSubmonoidWithOneClass (S : Type*) (R : outParam Type*) [AddMonoidWithOne R]
-  [SetLike S R] extends AddSubmonoidClass S R, OneMemClass S R : Prop
-
-variable {S R : Type*} [AddMonoidWithOne R] [SetLike S R] (s : S)
-
-@[aesop safe apply (rule_sets := [SetLike])]
-theorem natCast_mem [AddSubmonoidWithOneClass S R] (n : ℕ) : (n : R) ∈ s := by
-  induction n <;> simp [zero_mem, add_mem, one_mem, *]
-
-@[deprecated (since := "2024-04-05")] alias coe_nat_mem := natCast_mem
-
-@[aesop safe apply (rule_sets := [SetLike])]
-lemma ofNat_mem [AddSubmonoidWithOneClass S R] (s : S) (n : ℕ) [n.AtLeastTwo] :
-    no_index (OfNat.ofNat n) ∈ s := by
-  rw [← Nat.cast_eq_ofNat]; exact natCast_mem s n
-
-instance (priority := 74) AddSubmonoidWithOneClass.toAddMonoidWithOne
-    [AddSubmonoidWithOneClass S R] : AddMonoidWithOne s :=
-  { AddSubmonoidClass.toAddMonoid s with
-    one := ⟨_, one_mem s⟩
-    natCast := fun n => ⟨n, natCast_mem s n⟩
-    natCast_zero := Subtype.ext Nat.cast_zero
-    natCast_succ := fun _ => Subtype.ext (Nat.cast_succ _) }
-
-end AddSubmonoidWithOneClass
-
 variable {R : Type u} {S : Type v} {T : Type w} [NonAssocSemiring R] (M : Submonoid R)
 
 section SubsemiringClass
 
-/-- `SubsemiringClass S R` states that `S` is a type of subsets `s ⊆ R` that
-are both a multiplicative and an additive submonoid. -/
-class SubsemiringClass (S : Type*) (R : outParam (Type u)) [NonAssocSemiring R]
-  [SetLike S R] extends SubmonoidClass S R, AddSubmonoidClass S R : Prop
-
--- See note [lower instance priority]
-instance (priority := 100) SubsemiringClass.addSubmonoidWithOneClass (S : Type*)
-    (R : Type u) {_ : NonAssocSemiring R} [SetLike S R] [h : SubsemiringClass S R] :
-    AddSubmonoidWithOneClass S R :=
-  { h with }
-
-instance (priority := 100) SubsemiringClass.nonUnitalSubsemiringClass (S : Type*)
-    (R : Type u) [NonAssocSemiring R] [SetLike S R] [SubsemiringClass S R] :
-    NonUnitalSubsemiringClass S R where
-  mul_mem := mul_mem
-
 variable [SetLike S R] [hSR : SubsemiringClass S R] (s : S)
 
 namespace SubsemiringClass
-
--- Prefer subclasses of `NonAssocSemiring` over subclasses of `SubsemiringClass`.
-/-- A subsemiring of a `NonAssocSemiring` inherits a `NonAssocSemiring` structure -/
-instance (priority := 75) toNonAssocSemiring : NonAssocSemiring s :=
-  Subtype.coe_injective.nonAssocSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) fun _ => rfl
-
-instance nontrivial [Nontrivial R] : Nontrivial s :=
-  nontrivial_of_ne 0 1 fun H => zero_ne_one (congr_arg Subtype.val H)
-
-instance noZeroDivisors [NoZeroDivisors R] : NoZeroDivisors s :=
-  Subtype.coe_injective.noZeroDivisors _ rfl fun _ _ => rfl
-
-/-- The natural ring hom from a subsemiring of semiring `R` to `R`. -/
-def subtype : s →+* R :=
-  { SubmonoidClass.subtype s, AddSubmonoidClass.subtype s with toFun := (↑) }
-
-@[simp]
-theorem coe_subtype : (subtype s : s → R) = ((↑) : s → R) :=
-  rfl
-
--- Prefer subclasses of `Semiring` over subclasses of `SubsemiringClass`.
-/-- A subsemiring of a `Semiring` is a `Semiring`. -/
-instance (priority := 75) toSemiring {R} [Semiring R] [SetLike S R] [SubsemiringClass S R] :
-    Semiring s :=
-  Subtype.coe_injective.semiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) fun _ => rfl
-
-@[simp, norm_cast]
-theorem coe_pow {R} [Semiring R] [SetLike S R] [SubsemiringClass S R] (x : s) (n : ℕ) :
-    ((x ^ n : s) : R) = (x : R) ^ n := by
-  induction n with
-  | zero => simp
-  | succ n ih => simp [pow_succ, ih]
-
-/-- A subsemiring of a `CommSemiring` is a `CommSemiring`. -/
-instance toCommSemiring {R} [CommSemiring R] [SetLike S R] [SubsemiringClass S R] :
-    CommSemiring s :=
-  Subtype.coe_injective.commSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) fun _ => rfl
 
 instance instCharZero [CharZero R] : CharZero s :=
   ⟨Function.Injective.of_comp (f := Subtype.val) (g := Nat.cast (R := s)) Nat.cast_injective⟩
@@ -126,126 +40,9 @@ end SubsemiringClass
 
 variable [NonAssocSemiring S] [NonAssocSemiring T]
 
-/-- A subsemiring of a semiring `R` is a subset `s` that is both a multiplicative and an additive
-submonoid. -/
-structure Subsemiring (R : Type u) [NonAssocSemiring R] extends Submonoid R, AddSubmonoid R
-
-/-- Reinterpret a `Subsemiring` as a `Submonoid`. -/
-add_decl_doc Subsemiring.toSubmonoid
-
-/-- Reinterpret a `Subsemiring` as an `AddSubmonoid`. -/
-add_decl_doc Subsemiring.toAddSubmonoid
-
-namespace Subsemiring
-
-instance : SetLike (Subsemiring R) R where
-  coe s := s.carrier
-  coe_injective' p q h := by cases p; cases q; congr; exact SetLike.coe_injective' h
-
-instance : SubsemiringClass (Subsemiring R) R where
-  zero_mem := zero_mem'
-  add_mem {s} := AddSubsemigroup.add_mem' s.toAddSubmonoid.toAddSubsemigroup
-  one_mem {s} := Submonoid.one_mem' s.toSubmonoid
-  mul_mem {s} := Subsemigroup.mul_mem' s.toSubmonoid.toSubsemigroup
-
-@[simp]
-theorem mem_toSubmonoid {s : Subsemiring R} {x : R} : x ∈ s.toSubmonoid ↔ x ∈ s :=
-  Iff.rfl
-
-theorem mem_carrier {s : Subsemiring R} {x : R} : x ∈ s.carrier ↔ x ∈ s :=
-  Iff.rfl
-
-/-- Two subsemirings are equal if they have the same elements. -/
-@[ext]
-theorem ext {S T : Subsemiring R} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T :=
-  SetLike.ext h
-
-/-- Copy of a subsemiring with a new `carrier` equal to the old one. Useful to fix definitional
-equalities. -/
-protected def copy (S : Subsemiring R) (s : Set R) (hs : s = ↑S) : Subsemiring R :=
-  { S.toAddSubmonoid.copy s hs, S.toSubmonoid.copy s hs with carrier := s }
-
-@[simp]
-theorem coe_copy (S : Subsemiring R) (s : Set R) (hs : s = ↑S) : (S.copy s hs : Set R) = s :=
-  rfl
-
-theorem copy_eq (S : Subsemiring R) (s : Set R) (hs : s = ↑S) : S.copy s hs = S :=
-  SetLike.coe_injective hs
-
-theorem toSubmonoid_injective : Function.Injective (toSubmonoid : Subsemiring R → Submonoid R)
-  | _, _, h => ext (SetLike.ext_iff.mp h : _)
-
-@[mono]
-theorem toSubmonoid_strictMono : StrictMono (toSubmonoid : Subsemiring R → Submonoid R) :=
-  fun _ _ => id
-
-@[mono]
-theorem toSubmonoid_mono : Monotone (toSubmonoid : Subsemiring R → Submonoid R) :=
-  toSubmonoid_strictMono.monotone
-
-theorem toAddSubmonoid_injective :
-    Function.Injective (toAddSubmonoid : Subsemiring R → AddSubmonoid R)
-  | _, _, h => ext (SetLike.ext_iff.mp h : _)
-
-@[mono]
-theorem toAddSubmonoid_strictMono : StrictMono (toAddSubmonoid : Subsemiring R → AddSubmonoid R) :=
-  fun _ _ => id
-
-@[mono]
-theorem toAddSubmonoid_mono : Monotone (toAddSubmonoid : Subsemiring R → AddSubmonoid R) :=
-  toAddSubmonoid_strictMono.monotone
-
-/-- Construct a `Subsemiring R` from a set `s`, a submonoid `sm`, and an additive
-submonoid `sa` such that `x ∈ s ↔ x ∈ sm ↔ x ∈ sa`. -/
-protected def mk' (s : Set R) (sm : Submonoid R) (hm : ↑sm = s) (sa : AddSubmonoid R)
-    (ha : ↑sa = s) : Subsemiring R where
-  carrier := s
-  zero_mem' := by exact ha ▸ sa.zero_mem
-  one_mem' := by exact hm ▸ sm.one_mem
-  add_mem' {x y} := by simpa only [← ha] using sa.add_mem
-  mul_mem' {x y} := by simpa only [← hm] using sm.mul_mem
-
-@[simp]
-theorem coe_mk' {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : AddSubmonoid R} (ha : ↑sa = s) :
-    (Subsemiring.mk' s sm hm sa ha : Set R) = s :=
-  rfl
-
-@[simp]
-theorem mem_mk' {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : AddSubmonoid R} (ha : ↑sa = s)
-    {x : R} : x ∈ Subsemiring.mk' s sm hm sa ha ↔ x ∈ s :=
-  Iff.rfl
-
-@[simp]
-theorem mk'_toSubmonoid {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : AddSubmonoid R}
-    (ha : ↑sa = s) : (Subsemiring.mk' s sm hm sa ha).toSubmonoid = sm :=
-  SetLike.coe_injective hm.symm
-
-@[simp]
-theorem mk'_toAddSubmonoid {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : AddSubmonoid R}
-    (ha : ↑sa = s) : (Subsemiring.mk' s sm hm sa ha).toAddSubmonoid = sa :=
-  SetLike.coe_injective ha.symm
-
-end Subsemiring
-
 namespace Subsemiring
 
 variable (s : Subsemiring R)
-
-/-- A subsemiring contains the semiring's 1. -/
-protected theorem one_mem : (1 : R) ∈ s :=
-  one_mem s
-
-/-- A subsemiring contains the semiring's 0. -/
-protected theorem zero_mem : (0 : R) ∈ s :=
-  zero_mem s
-
-/-- A subsemiring is closed under multiplication. -/
-protected theorem mul_mem {x y : R} : x ∈ s → y ∈ s → x * y ∈ s :=
-  mul_mem
-
-/-- A subsemiring is closed under addition. -/
-protected theorem add_mem {x y : R} : x ∈ s → y ∈ s → x + y ∈ s :=
-  add_mem
 
 /-- Product of a list of elements in a `Subsemiring` is in the `Subsemiring`. -/
 nonrec theorem list_prod_mem {R : Type*} [Semiring R] (s : Subsemiring R) {l : List R} :
@@ -278,93 +75,6 @@ is in the `add_subsemiring`. -/
 protected theorem sum_mem (s : Subsemiring R) {ι : Type*} {t : Finset ι} {f : ι → R}
     (h : ∀ c ∈ t, f c ∈ s) : (∑ i ∈ t, f i) ∈ s :=
   sum_mem h
-
-/-- A subsemiring of a `NonAssocSemiring` inherits a `NonAssocSemiring` structure -/
-instance toNonAssocSemiring : NonAssocSemiring s :=
-  -- Porting note: this used to be a specialized instance which needed to be expensively unified.
-  SubsemiringClass.toNonAssocSemiring _
-
-@[simp, norm_cast]
-theorem coe_one : ((1 : s) : R) = (1 : R) :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_zero : ((0 : s) : R) = (0 : R) :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_add (x y : s) : ((x + y : s) : R) = (x + y : R) :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_mul (x y : s) : ((x * y : s) : R) = (x * y : R) :=
-  rfl
-
-instance nontrivial [Nontrivial R] : Nontrivial s :=
-  nontrivial_of_ne 0 1 fun H => zero_ne_one (congr_arg Subtype.val H)
-
-protected theorem pow_mem {R : Type*} [Semiring R] (s : Subsemiring R) {x : R} (hx : x ∈ s)
-    (n : ℕ) : x ^ n ∈ s :=
-  pow_mem hx n
-
-instance noZeroDivisors [NoZeroDivisors R] : NoZeroDivisors s where
-  eq_zero_or_eq_zero_of_mul_eq_zero {_ _} h :=
-    (eq_zero_or_eq_zero_of_mul_eq_zero <| Subtype.ext_iff.mp h).imp Subtype.eq Subtype.eq
-
-/-- A subsemiring of a `Semiring` is a `Semiring`. -/
-instance toSemiring {R} [Semiring R] (s : Subsemiring R) : Semiring s :=
-  { s.toNonAssocSemiring, s.toSubmonoid.toMonoid with }
-
-@[simp, norm_cast]
-theorem coe_pow {R} [Semiring R] (s : Subsemiring R) (x : s) (n : ℕ) :
-    ((x ^ n : s) : R) = (x : R) ^ n := by
-  induction n with
-  | zero => simp
-  | succ n ih => simp [pow_succ, ih]
-
-/-- A subsemiring of a `CommSemiring` is a `CommSemiring`. -/
-instance toCommSemiring {R} [CommSemiring R] (s : Subsemiring R) : CommSemiring s :=
-  { s.toSemiring with mul_comm := fun _ _ => Subtype.eq <| mul_comm _ _ }
-
-/-- The natural ring hom from a subsemiring of semiring `R` to `R`. -/
-def subtype : s →+* R :=
-  { s.toSubmonoid.subtype, s.toAddSubmonoid.subtype with toFun := (↑) }
-
-@[simp]
-theorem coe_subtype : ⇑s.subtype = ((↑) : s → R) :=
-  rfl
-
-protected theorem nsmul_mem {x : R} (hx : x ∈ s) (n : ℕ) : n • x ∈ s :=
-  nsmul_mem hx n
-
-@[simp]
-theorem coe_toSubmonoid (s : Subsemiring R) : (s.toSubmonoid : Set R) = s :=
-  rfl
-
--- Porting note: adding this as `simp`-normal form for `coe_toAddSubmonoid`
-@[simp]
-theorem coe_carrier_toSubmonoid (s : Subsemiring R) : (s.toSubmonoid.carrier : Set R) = s :=
-  rfl
-
--- Porting note: can be proven using `SetLike` so removing `@[simp]`
-theorem mem_toAddSubmonoid {s : Subsemiring R} {x : R} : x ∈ s.toAddSubmonoid ↔ x ∈ s :=
-  Iff.rfl
-
--- Porting note: new normal form is `coe_carrier_toSubmonoid` so removing `@[simp]`
-theorem coe_toAddSubmonoid (s : Subsemiring R) : (s.toAddSubmonoid : Set R) = s :=
-  rfl
-
-/-- The subsemiring `R` of the semiring `R`. -/
-instance : Top (Subsemiring R) :=
-  ⟨{ (⊤ : Submonoid R), (⊤ : AddSubmonoid R) with }⟩
-
-@[simp]
-theorem mem_top (x : R) : x ∈ (⊤ : Subsemiring R) :=
-  Set.mem_univ x
-
-@[simp]
-theorem coe_top : ((⊤ : Subsemiring R) : Set R) = Set.univ :=
-  rfl
 
 /-- The ring equiv between the top element of `Subsemiring R` and `R`. -/
 @[simps]
@@ -477,19 +187,6 @@ theorem coe_bot : ((⊥ : Subsemiring R) : Set R) = Set.range ((↑) : ℕ → R
 
 theorem mem_bot {x : R} : x ∈ (⊥ : Subsemiring R) ↔ ∃ n : ℕ, ↑n = x :=
   RingHom.mem_rangeS
-
-/-- The inf of two subsemirings is their intersection. -/
-instance : Inf (Subsemiring R) :=
-  ⟨fun s t =>
-    { s.toSubmonoid ⊓ t.toSubmonoid, s.toAddSubmonoid ⊓ t.toAddSubmonoid with carrier := s ∩ t }⟩
-
-@[simp]
-theorem coe_inf (p p' : Subsemiring R) : ((p ⊓ p' : Subsemiring R) : Set R) = (p : Set R) ∩ p' :=
-  rfl
-
-@[simp]
-theorem mem_inf {p p' : Subsemiring R} {x : R} : x ∈ p ⊓ p' ↔ x ∈ p ∧ x ∈ p' :=
-  Iff.rfl
 
 instance : InfSet (Subsemiring R) :=
   ⟨fun s =>
@@ -953,14 +650,6 @@ variable [SetLike σR R] [SetLike σS S] [SubsemiringClass σR R] [SubsemiringCl
 
 open Subsemiring
 
-/-- Restriction of a ring homomorphism to a subsemiring of the domain. -/
-def domRestrict (f : R →+* S) (s : σR) : s →+* S :=
-  f.comp <| SubsemiringClass.subtype s
-
-@[simp]
-theorem restrict_apply (f : R →+* S) {s : σR} (x : s) : f.domRestrict s x = f x :=
-  rfl
-
 /-- Restriction of a ring homomorphism to a subsemiring of the codomain. -/
 def codRestrict (f : R →+* S) (s : σS) (h : ∀ x, f x ∈ s) : R →+* s :=
   { (f : R →* S).codRestrict s h, (f : R →+ S).codRestrict s h with toFun := fun n => ⟨f n, h n⟩ }
@@ -1003,14 +692,6 @@ theorem rangeS_top_iff_surjective {f : R →+* S} :
 theorem rangeS_top_of_surjective (f : R →+* S) (hf : Function.Surjective f) :
     f.rangeS = (⊤ : Subsemiring S) :=
   rangeS_top_iff_surjective.2 hf
-
-/-- The subsemiring of elements `x : R` such that `f x = g x` -/
-def eqLocusS (f g : R →+* S) : Subsemiring R :=
-  { (f : R →* S).eqLocusM g, (f : R →+ S).eqLocusM g with carrier := { x | f x = g x } }
-
-@[simp]
-theorem eqLocusS_same (f : R →+* S) : f.eqLocusS f = ⊤ :=
-  SetLike.ext fun _ => eq_self_iff_true _
 
 /-- If two ring homomorphisms are equal on a set, then they are equal on its subsemiring closure. -/
 theorem eqOn_sclosure {f g : R →+* S} {s : Set R} (h : Set.EqOn f g s) : Set.EqOn f g (closure s) :=

--- a/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
@@ -44,6 +44,22 @@ namespace Subsemiring
 
 variable (s : Subsemiring R)
 
+@[mono]
+theorem toSubmonoid_strictMono : StrictMono (toSubmonoid : Subsemiring R → Submonoid R) :=
+  fun _ _ => id
+
+@[mono]
+theorem toSubmonoid_mono : Monotone (toSubmonoid : Subsemiring R → Submonoid R) :=
+  toSubmonoid_strictMono.monotone
+
+@[mono]
+theorem toAddSubmonoid_strictMono : StrictMono (toAddSubmonoid : Subsemiring R → AddSubmonoid R) :=
+  fun _ _ => id
+
+@[mono]
+theorem toAddSubmonoid_mono : Monotone (toAddSubmonoid : Subsemiring R → AddSubmonoid R) :=
+  toAddSubmonoid_strictMono.monotone
+
 /-- Product of a list of elements in a `Subsemiring` is in the `Subsemiring`. -/
 nonrec theorem list_prod_mem {R : Type*} [Semiring R] (s : Subsemiring R) {l : List R} :
     (∀ x ∈ l, x ∈ s) → l.prod ∈ s :=

--- a/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
@@ -164,16 +164,6 @@ theorem copy_eq (S : Subsemiring R) (s : Set R) (hs : s = ↑S) : S.copy s hs = 
 theorem toSubmonoid_injective : Function.Injective (toSubmonoid : Subsemiring R → Submonoid R)
   | _, _, h => ext (SetLike.ext_iff.mp h : _)
 
-/-
-@[mono]
-theorem toSubmonoid_strictMono : StrictMono (toSubmonoid : Subsemiring R → Submonoid R) :=
-  fun _ _ => id
-
-@[mono]
-theorem toSubmonoid_mono : Monotone (toSubmonoid : Subsemiring R → Submonoid R) :=
-  toSubmonoid_strictMono.monotone
--/
-
 theorem toAddSubmonoid_injective :
     Function.Injective (toAddSubmonoid : Subsemiring R → AddSubmonoid R)
   | _, _, h => ext (SetLike.ext_iff.mp h : _)

--- a/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
@@ -1,0 +1,376 @@
+/-
+Copyright (c) 2020 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+import Mathlib.RingTheory.NonUnitalSubsemiring.Defs
+
+/-!
+# Bundled subsemirings
+
+We define bundled subsemirings and some standard constructions: `subtype` and `inclusion`
+ring homomorphisms.
+-/
+
+
+universe u v w
+
+section AddSubmonoidWithOneClass
+
+/-- `AddSubmonoidWithOneClass S R` says `S` is a type of subsets `s ≤ R` that contain `0`, `1`,
+and are closed under `(+)` -/
+class AddSubmonoidWithOneClass (S : Type*) (R : outParam Type*) [AddMonoidWithOne R]
+  [SetLike S R] extends AddSubmonoidClass S R, OneMemClass S R : Prop
+
+variable {S R : Type*} [AddMonoidWithOne R] [SetLike S R] (s : S)
+
+@[aesop safe apply (rule_sets := [SetLike])]
+theorem natCast_mem [AddSubmonoidWithOneClass S R] (n : ℕ) : (n : R) ∈ s := by
+  induction n <;> simp [zero_mem, add_mem, one_mem, *]
+
+@[deprecated (since := "2024-04-05")] alias coe_nat_mem := natCast_mem
+
+@[aesop safe apply (rule_sets := [SetLike])]
+lemma ofNat_mem [AddSubmonoidWithOneClass S R] (s : S) (n : ℕ) [n.AtLeastTwo] :
+    no_index (OfNat.ofNat n) ∈ s := by
+  rw [← Nat.cast_eq_ofNat]; exact natCast_mem s n
+
+instance (priority := 74) AddSubmonoidWithOneClass.toAddMonoidWithOne
+    [AddSubmonoidWithOneClass S R] : AddMonoidWithOne s :=
+  { AddSubmonoidClass.toAddMonoid s with
+    one := ⟨_, one_mem s⟩
+    natCast := fun n => ⟨n, natCast_mem s n⟩
+    natCast_zero := Subtype.ext Nat.cast_zero
+    natCast_succ := fun _ => Subtype.ext (Nat.cast_succ _) }
+
+end AddSubmonoidWithOneClass
+
+variable {R : Type u} {S : Type v} {T : Type w} [NonAssocSemiring R] (M : Submonoid R)
+
+section SubsemiringClass
+
+/-- `SubsemiringClass S R` states that `S` is a type of subsets `s ⊆ R` that
+are both a multiplicative and an additive submonoid. -/
+class SubsemiringClass (S : Type*) (R : outParam (Type u)) [NonAssocSemiring R]
+  [SetLike S R] extends SubmonoidClass S R, AddSubmonoidClass S R : Prop
+
+-- See note [lower instance priority]
+instance (priority := 100) SubsemiringClass.addSubmonoidWithOneClass (S : Type*)
+    (R : Type u) {_ : NonAssocSemiring R} [SetLike S R] [h : SubsemiringClass S R] :
+    AddSubmonoidWithOneClass S R :=
+  { h with }
+
+instance (priority := 100) SubsemiringClass.nonUnitalSubsemiringClass (S : Type*)
+    (R : Type u) [NonAssocSemiring R] [SetLike S R] [SubsemiringClass S R] :
+    NonUnitalSubsemiringClass S R where
+  mul_mem := mul_mem
+
+variable [SetLike S R] [hSR : SubsemiringClass S R] (s : S)
+
+namespace SubsemiringClass
+
+-- Prefer subclasses of `NonAssocSemiring` over subclasses of `SubsemiringClass`.
+/-- A subsemiring of a `NonAssocSemiring` inherits a `NonAssocSemiring` structure -/
+instance (priority := 75) toNonAssocSemiring : NonAssocSemiring s :=
+  Subtype.coe_injective.nonAssocSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) fun _ => rfl
+
+instance nontrivial [Nontrivial R] : Nontrivial s :=
+  nontrivial_of_ne 0 1 fun H => zero_ne_one (congr_arg Subtype.val H)
+
+instance noZeroDivisors [NoZeroDivisors R] : NoZeroDivisors s :=
+  Subtype.coe_injective.noZeroDivisors _ rfl fun _ _ => rfl
+
+/-- The natural ring hom from a subsemiring of semiring `R` to `R`. -/
+def subtype : s →+* R :=
+  { SubmonoidClass.subtype s, AddSubmonoidClass.subtype s with toFun := (↑) }
+
+@[simp]
+theorem coe_subtype : (subtype s : s → R) = ((↑) : s → R) :=
+  rfl
+
+-- Prefer subclasses of `Semiring` over subclasses of `SubsemiringClass`.
+/-- A subsemiring of a `Semiring` is a `Semiring`. -/
+instance (priority := 75) toSemiring {R} [Semiring R] [SetLike S R] [SubsemiringClass S R] :
+    Semiring s :=
+  Subtype.coe_injective.semiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) fun _ => rfl
+
+@[simp, norm_cast]
+theorem coe_pow {R} [Semiring R] [SetLike S R] [SubsemiringClass S R] (x : s) (n : ℕ) :
+    ((x ^ n : s) : R) = (x : R) ^ n := by
+  induction n with
+  | zero => simp
+  | succ n ih => simp [pow_succ, ih]
+
+/-- A subsemiring of a `CommSemiring` is a `CommSemiring`. -/
+instance toCommSemiring {R} [CommSemiring R] [SetLike S R] [SubsemiringClass S R] :
+    CommSemiring s :=
+  Subtype.coe_injective.commSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) fun _ => rfl
+
+end SubsemiringClass
+
+end SubsemiringClass
+
+variable [NonAssocSemiring S] [NonAssocSemiring T]
+
+/-- A subsemiring of a semiring `R` is a subset `s` that is both a multiplicative and an additive
+submonoid. -/
+structure Subsemiring (R : Type u) [NonAssocSemiring R] extends Submonoid R, AddSubmonoid R
+
+/-- Reinterpret a `Subsemiring` as a `Submonoid`. -/
+add_decl_doc Subsemiring.toSubmonoid
+
+/-- Reinterpret a `Subsemiring` as an `AddSubmonoid`. -/
+add_decl_doc Subsemiring.toAddSubmonoid
+
+namespace Subsemiring
+
+instance : SetLike (Subsemiring R) R where
+  coe s := s.carrier
+  coe_injective' p q h := by cases p; cases q; congr; exact SetLike.coe_injective' h
+
+instance : SubsemiringClass (Subsemiring R) R where
+  zero_mem := zero_mem'
+  add_mem {s} := AddSubsemigroup.add_mem' s.toAddSubmonoid.toAddSubsemigroup
+  one_mem {s} := Submonoid.one_mem' s.toSubmonoid
+  mul_mem {s} := Subsemigroup.mul_mem' s.toSubmonoid.toSubsemigroup
+
+@[simp]
+theorem mem_toSubmonoid {s : Subsemiring R} {x : R} : x ∈ s.toSubmonoid ↔ x ∈ s :=
+  Iff.rfl
+
+theorem mem_carrier {s : Subsemiring R} {x : R} : x ∈ s.carrier ↔ x ∈ s :=
+  Iff.rfl
+
+/-- Two subsemirings are equal if they have the same elements. -/
+@[ext]
+theorem ext {S T : Subsemiring R} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T :=
+  SetLike.ext h
+
+/-- Copy of a subsemiring with a new `carrier` equal to the old one. Useful to fix definitional
+equalities. -/
+protected def copy (S : Subsemiring R) (s : Set R) (hs : s = ↑S) : Subsemiring R :=
+  { S.toAddSubmonoid.copy s hs, S.toSubmonoid.copy s hs with carrier := s }
+
+@[simp]
+theorem coe_copy (S : Subsemiring R) (s : Set R) (hs : s = ↑S) : (S.copy s hs : Set R) = s :=
+  rfl
+
+theorem copy_eq (S : Subsemiring R) (s : Set R) (hs : s = ↑S) : S.copy s hs = S :=
+  SetLike.coe_injective hs
+
+theorem toSubmonoid_injective : Function.Injective (toSubmonoid : Subsemiring R → Submonoid R)
+  | _, _, h => ext (SetLike.ext_iff.mp h : _)
+
+/-
+@[mono]
+theorem toSubmonoid_strictMono : StrictMono (toSubmonoid : Subsemiring R → Submonoid R) :=
+  fun _ _ => id
+
+@[mono]
+theorem toSubmonoid_mono : Monotone (toSubmonoid : Subsemiring R → Submonoid R) :=
+  toSubmonoid_strictMono.monotone
+-/
+
+theorem toAddSubmonoid_injective :
+    Function.Injective (toAddSubmonoid : Subsemiring R → AddSubmonoid R)
+  | _, _, h => ext (SetLike.ext_iff.mp h : _)
+
+/-- Construct a `Subsemiring R` from a set `s`, a submonoid `sm`, and an additive
+submonoid `sa` such that `x ∈ s ↔ x ∈ sm ↔ x ∈ sa`. -/
+protected def mk' (s : Set R) (sm : Submonoid R) (hm : ↑sm = s) (sa : AddSubmonoid R)
+    (ha : ↑sa = s) : Subsemiring R where
+  carrier := s
+  zero_mem' := by exact ha ▸ sa.zero_mem
+  one_mem' := by exact hm ▸ sm.one_mem
+  add_mem' {x y} := by simpa only [← ha] using sa.add_mem
+  mul_mem' {x y} := by simpa only [← hm] using sm.mul_mem
+
+@[simp]
+theorem coe_mk' {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : AddSubmonoid R} (ha : ↑sa = s) :
+    (Subsemiring.mk' s sm hm sa ha : Set R) = s :=
+  rfl
+
+@[simp]
+theorem mem_mk' {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : AddSubmonoid R} (ha : ↑sa = s)
+    {x : R} : x ∈ Subsemiring.mk' s sm hm sa ha ↔ x ∈ s :=
+  Iff.rfl
+
+@[simp]
+theorem mk'_toSubmonoid {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : AddSubmonoid R}
+    (ha : ↑sa = s) : (Subsemiring.mk' s sm hm sa ha).toSubmonoid = sm :=
+  SetLike.coe_injective hm.symm
+
+@[simp]
+theorem mk'_toAddSubmonoid {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : AddSubmonoid R}
+    (ha : ↑sa = s) : (Subsemiring.mk' s sm hm sa ha).toAddSubmonoid = sa :=
+  SetLike.coe_injective ha.symm
+
+end Subsemiring
+
+namespace Subsemiring
+
+variable (s : Subsemiring R)
+
+/-- A subsemiring contains the semiring's 1. -/
+protected theorem one_mem : (1 : R) ∈ s :=
+  one_mem s
+
+/-- A subsemiring contains the semiring's 0. -/
+protected theorem zero_mem : (0 : R) ∈ s :=
+  zero_mem s
+
+/-- A subsemiring is closed under multiplication. -/
+protected theorem mul_mem {x y : R} : x ∈ s → y ∈ s → x * y ∈ s :=
+  mul_mem
+
+/-- A subsemiring is closed under addition. -/
+protected theorem add_mem {x y : R} : x ∈ s → y ∈ s → x + y ∈ s :=
+  add_mem
+
+/-- A subsemiring of a `NonAssocSemiring` inherits a `NonAssocSemiring` structure -/
+instance toNonAssocSemiring : NonAssocSemiring s :=
+  -- Porting note: this used to be a specialized instance which needed to be expensively unified.
+  SubsemiringClass.toNonAssocSemiring _
+
+@[simp, norm_cast]
+theorem coe_one : ((1 : s) : R) = (1 : R) :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_zero : ((0 : s) : R) = (0 : R) :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_add (x y : s) : ((x + y : s) : R) = (x + y : R) :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_mul (x y : s) : ((x * y : s) : R) = (x * y : R) :=
+  rfl
+
+instance nontrivial [Nontrivial R] : Nontrivial s :=
+  nontrivial_of_ne 0 1 fun H => zero_ne_one (congr_arg Subtype.val H)
+
+protected theorem pow_mem {R : Type*} [Semiring R] (s : Subsemiring R) {x : R} (hx : x ∈ s)
+    (n : ℕ) : x ^ n ∈ s :=
+  pow_mem hx n
+
+instance noZeroDivisors [NoZeroDivisors R] : NoZeroDivisors s where
+  eq_zero_or_eq_zero_of_mul_eq_zero {_ _} h :=
+    (eq_zero_or_eq_zero_of_mul_eq_zero <| Subtype.ext_iff.mp h).imp Subtype.eq Subtype.eq
+
+/-- A subsemiring of a `Semiring` is a `Semiring`. -/
+instance toSemiring {R} [Semiring R] (s : Subsemiring R) : Semiring s :=
+  { s.toNonAssocSemiring, s.toSubmonoid.toMonoid with }
+
+@[simp, norm_cast]
+theorem coe_pow {R} [Semiring R] (s : Subsemiring R) (x : s) (n : ℕ) :
+    ((x ^ n : s) : R) = (x : R) ^ n := by
+  induction n with
+  | zero => simp
+  | succ n ih => simp [pow_succ, ih]
+
+/-- A subsemiring of a `CommSemiring` is a `CommSemiring`. -/
+instance toCommSemiring {R} [CommSemiring R] (s : Subsemiring R) : CommSemiring s :=
+  { s.toSemiring with mul_comm := fun _ _ => Subtype.eq <| mul_comm _ _ }
+
+/-- The natural ring hom from a subsemiring of semiring `R` to `R`. -/
+def subtype : s →+* R :=
+  { s.toSubmonoid.subtype, s.toAddSubmonoid.subtype with toFun := (↑) }
+
+@[simp]
+theorem coe_subtype : ⇑s.subtype = ((↑) : s → R) :=
+  rfl
+
+protected theorem nsmul_mem {x : R} (hx : x ∈ s) (n : ℕ) : n • x ∈ s :=
+  nsmul_mem hx n
+
+@[simp]
+theorem coe_toSubmonoid (s : Subsemiring R) : (s.toSubmonoid : Set R) = s :=
+  rfl
+
+-- Porting note: adding this as `simp`-normal form for `coe_toAddSubmonoid`
+@[simp]
+theorem coe_carrier_toSubmonoid (s : Subsemiring R) : (s.toSubmonoid.carrier : Set R) = s :=
+  rfl
+
+-- Porting note: can be proven using `SetLike` so removing `@[simp]`
+theorem mem_toAddSubmonoid {s : Subsemiring R} {x : R} : x ∈ s.toAddSubmonoid ↔ x ∈ s :=
+  Iff.rfl
+
+-- Porting note: new normal form is `coe_carrier_toSubmonoid` so removing `@[simp]`
+theorem coe_toAddSubmonoid (s : Subsemiring R) : (s.toAddSubmonoid : Set R) = s :=
+  rfl
+
+/-- The subsemiring `R` of the semiring `R`. -/
+instance : Top (Subsemiring R) :=
+  ⟨{ (⊤ : Submonoid R), (⊤ : AddSubmonoid R) with }⟩
+
+@[simp]
+theorem mem_top (x : R) : x ∈ (⊤ : Subsemiring R) :=
+  Set.mem_univ x
+
+@[simp]
+theorem coe_top : ((⊤ : Subsemiring R) : Set R) = Set.univ :=
+  rfl
+
+end Subsemiring
+
+namespace Subsemiring
+
+/-- The inf of two subsemirings is their intersection. -/
+instance : Inf (Subsemiring R) :=
+  ⟨fun s t =>
+    { s.toSubmonoid ⊓ t.toSubmonoid, s.toAddSubmonoid ⊓ t.toAddSubmonoid with carrier := s ∩ t }⟩
+
+@[simp]
+theorem coe_inf (p p' : Subsemiring R) : ((p ⊓ p' : Subsemiring R) : Set R) = (p : Set R) ∩ p' :=
+  rfl
+
+@[simp]
+theorem mem_inf {p p' : Subsemiring R} {x : R} : x ∈ p ⊓ p' ↔ x ∈ p ∧ x ∈ p' :=
+  Iff.rfl
+
+
+end Subsemiring
+
+namespace RingHom
+
+variable [NonAssocSemiring T] {s : Subsemiring R}
+variable {σR σS : Type*}
+variable [SetLike σR R] [SetLike σS S] [SubsemiringClass σR R] [SubsemiringClass σS S]
+
+open Subsemiring
+
+/-- Restriction of a ring homomorphism to a subsemiring of the domain. -/
+def domRestrict (f : R →+* S) (s : σR) : s →+* S :=
+  f.comp <| SubsemiringClass.subtype s
+
+@[simp]
+theorem restrict_apply (f : R →+* S) {s : σR} (x : s) : f.domRestrict s x = f x :=
+  rfl
+
+/-- The subsemiring of elements `x : R` such that `f x = g x` -/
+def eqLocusS (f g : R →+* S) : Subsemiring R :=
+  { (f : R →* S).eqLocusM g, (f : R →+ S).eqLocusM g with carrier := { x | f x = g x } }
+
+@[simp]
+theorem eqLocusS_same (f : R →+* S) : f.eqLocusS f = ⊤ :=
+  SetLike.ext fun _ => eq_self_iff_true _
+
+end RingHom
+
+namespace Subsemiring
+
+open RingHom
+
+end Subsemiring
+
+namespace RingEquiv
+
+variable {s t : Subsemiring R}
+
+end RingEquiv

--- a/Mathlib/Algebra/Ring/Subsemiring/Order.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Order.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 import Mathlib.Algebra.Order.Ring.InjSurj
-import Mathlib.Algebra.Ring.Subsemiring.Basic
+import Mathlib.Algebra.Ring.Subsemiring.Defs
+import Mathlib.Order.Interval.Set.Basic
 
 /-!
 # `Order`ed instances for `SubsemiringClass` and `Subsemiring`.

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
@@ -14,12 +14,12 @@ import Mathlib.Algebra.Ring.Prod
 import Mathlib.Algebra.Group.Hom.End
 import Mathlib.Data.Set.Finite
 import Mathlib.GroupTheory.Subsemigroup.Centralizer
+import Mathlib.RingTheory.NonUnitalSubsemiring.Defs
 
 /-!
 # Bundled non-unital subsemirings
 
-We define bundled non-unital subsemirings and some standard constructions:
-`CompleteLattice` structure, `subtype` and `inclusion` ring homomorphisms, non-unital subsemiring
+We define the `CompleteLattice` structure, and non-unital subsemiring
 `map`, `comap` and range (`srange`) of a `NonUnitalRingHom` etc.
 -/
 
@@ -28,105 +28,7 @@ universe u v w
 
 variable {R : Type u} {S : Type v} {T : Type w} [NonUnitalNonAssocSemiring R] (M : Subsemigroup R)
 
-/-- `NonUnitalSubsemiringClass S R` states that `S` is a type of subsets `s ⊆ R` that
-are both an additive submonoid and also a multiplicative subsemigroup. -/
-class NonUnitalSubsemiringClass (S : Type*) (R : outParam (Type u)) [NonUnitalNonAssocSemiring R]
-  [SetLike S R] extends AddSubmonoidClass S R : Prop where
-  mul_mem : ∀ {s : S} {a b : R}, a ∈ s → b ∈ s → a * b ∈ s
-
--- See note [lower instance priority]
-instance (priority := 100) NonUnitalSubsemiringClass.mulMemClass (S : Type*) (R : Type u)
-    [NonUnitalNonAssocSemiring R] [SetLike S R] [h : NonUnitalSubsemiringClass S R] :
-    MulMemClass S R :=
-  { h with }
-
-namespace NonUnitalSubsemiringClass
-
-variable [SetLike S R] [NonUnitalSubsemiringClass S R] (s : S)
-
-open AddSubmonoidClass
-
-/- Prefer subclasses of `NonUnitalNonAssocSemiring` over subclasses of
-`NonUnitalSubsemiringClass`. -/
-/-- A non-unital subsemiring of a `NonUnitalNonAssocSemiring` inherits a
-`NonUnitalNonAssocSemiring` structure -/
-instance (priority := 75) toNonUnitalNonAssocSemiring : NonUnitalNonAssocSemiring s :=
-  Subtype.coe_injective.nonUnitalNonAssocSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
-
-instance noZeroDivisors [NoZeroDivisors R] : NoZeroDivisors s :=
-  Subtype.coe_injective.noZeroDivisors (↑) rfl fun _ _ => rfl
-
-/-- The natural non-unital ring hom from a non-unital subsemiring of a non-unital semiring `R` to
-`R`. -/
-def subtype : s →ₙ+* R :=
-  { AddSubmonoidClass.subtype s, MulMemClass.subtype s with toFun := (↑) }
-
-@[simp]
-theorem coeSubtype : (subtype s : s → R) = ((↑) : s → R) :=
-  rfl
-
-/-- A non-unital subsemiring of a `NonUnitalSemiring` is a `NonUnitalSemiring`. -/
-instance toNonUnitalSemiring {R} [NonUnitalSemiring R] [SetLike S R]
-    [NonUnitalSubsemiringClass S R] : NonUnitalSemiring s :=
-  Subtype.coe_injective.nonUnitalSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
-
-/-- A non-unital subsemiring of a `NonUnitalCommSemiring` is a `NonUnitalCommSemiring`. -/
-instance toNonUnitalCommSemiring {R} [NonUnitalCommSemiring R] [SetLike S R]
-    [NonUnitalSubsemiringClass S R] : NonUnitalCommSemiring s :=
-  Subtype.coe_injective.nonUnitalCommSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
-
-/-! Note: currently, there are no ordered versions of non-unital rings. -/
-
-
-end NonUnitalSubsemiringClass
-
-/-- A non-unital subsemiring of a non-unital semiring `R` is a subset `s` that is both an additive
-submonoid and a semigroup. -/
-structure NonUnitalSubsemiring (R : Type u) [NonUnitalNonAssocSemiring R] extends AddSubmonoid R,
-  Subsemigroup R
-
-/-- Reinterpret a `NonUnitalSubsemiring` as a `Subsemigroup`. -/
-add_decl_doc NonUnitalSubsemiring.toSubsemigroup
-
-/-- Reinterpret a `NonUnitalSubsemiring` as an `AddSubmonoid`. -/
-add_decl_doc NonUnitalSubsemiring.toAddSubmonoid
-
 namespace NonUnitalSubsemiring
-
-instance : SetLike (NonUnitalSubsemiring R) R where
-  coe s := s.carrier
-  coe_injective' p q h := by cases p; cases q; congr; exact SetLike.coe_injective' h
-
-instance : NonUnitalSubsemiringClass (NonUnitalSubsemiring R) R where
-  zero_mem {s} := AddSubmonoid.zero_mem' s.toAddSubmonoid
-  add_mem {s} := AddSubsemigroup.add_mem' s.toAddSubmonoid.toAddSubsemigroup
-  mul_mem {s} := mul_mem' s
-
-theorem mem_carrier {s : NonUnitalSubsemiring R} {x : R} : x ∈ s.carrier ↔ x ∈ s :=
-  Iff.rfl
-
-/-- Two non-unital subsemirings are equal if they have the same elements. -/
-@[ext]
-theorem ext {S T : NonUnitalSubsemiring R} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T :=
-  SetLike.ext h
-
-/-- Copy of a non-unital subsemiring with a new `carrier` equal to the old one. Useful to fix
-definitional equalities. -/
-protected def copy (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) :
-    NonUnitalSubsemiring R :=
-  { S.toAddSubmonoid.copy s hs, S.toSubsemigroup.copy s hs with carrier := s }
-
-@[simp]
-theorem coe_copy (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) :
-    (S.copy s hs : Set R) = s :=
-  rfl
-
-theorem copy_eq (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) : S.copy s hs = S :=
-  SetLike.coe_injective hs
-
-theorem toSubsemigroup_injective :
-    Function.Injective (toSubsemigroup : NonUnitalSubsemiring R → Subsemigroup R)
-  | _, _, h => ext (SetLike.ext_iff.mp h : _)
 
 @[mono]
 theorem toSubsemigroup_strictMono :
@@ -136,10 +38,6 @@ theorem toSubsemigroup_strictMono :
 theorem toSubsemigroup_mono : Monotone (toSubsemigroup : NonUnitalSubsemiring R → Subsemigroup R) :=
   toSubsemigroup_strictMono.monotone
 
-theorem toAddSubmonoid_injective :
-    Function.Injective (toAddSubmonoid : NonUnitalSubsemiring R → AddSubmonoid R)
-  | _, _, h => ext (SetLike.ext_iff.mp h : _)
-
 @[mono]
 theorem toAddSubmonoid_strictMono :
     StrictMono (toAddSubmonoid : NonUnitalSubsemiring R → AddSubmonoid R) := fun _ _ => id
@@ -147,35 +45,6 @@ theorem toAddSubmonoid_strictMono :
 @[mono]
 theorem toAddSubmonoid_mono : Monotone (toAddSubmonoid : NonUnitalSubsemiring R → AddSubmonoid R) :=
   toAddSubmonoid_strictMono.monotone
-
-/-- Construct a `NonUnitalSubsemiring R` from a set `s`, a subsemigroup `sg`, and an additive
-submonoid `sa` such that `x ∈ s ↔ x ∈ sg ↔ x ∈ sa`. -/
-protected def mk' (s : Set R) (sg : Subsemigroup R) (hg : ↑sg = s) (sa : AddSubmonoid R)
-    (ha : ↑sa = s) : NonUnitalSubsemiring R where
-  carrier := s
-  zero_mem' := by subst ha; exact sa.zero_mem
-  add_mem' := by subst ha; exact sa.add_mem
-  mul_mem' := by subst hg; exact sg.mul_mem
-
-@[simp]
-theorem coe_mk' {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
-    (ha : ↑sa = s) : (NonUnitalSubsemiring.mk' s sg hg sa ha : Set R) = s :=
-  rfl
-
-@[simp]
-theorem mem_mk' {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
-    (ha : ↑sa = s) {x : R} : x ∈ NonUnitalSubsemiring.mk' s sg hg sa ha ↔ x ∈ s :=
-  Iff.rfl
-
-@[simp]
-theorem mk'_toSubsemigroup {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
-    (ha : ↑sa = s) : (NonUnitalSubsemiring.mk' s sg hg sa ha).toSubsemigroup = sg :=
-  SetLike.coe_injective hg.symm
-
-@[simp]
-theorem mk'_toAddSubmonoid {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
-    (ha : ↑sa = s) : (NonUnitalSubsemiring.mk' s sg hg sa ha).toAddSubmonoid = sa :=
-  SetLike.coe_injective ha.symm
 
 end NonUnitalSubsemiring
 
@@ -185,49 +54,6 @@ variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
 variable {F G : Type*} [FunLike F R S] [NonUnitalRingHomClass F R S]
   [FunLike G S T] [NonUnitalRingHomClass G S T]
   (s : NonUnitalSubsemiring R)
-
-@[simp, norm_cast]
-theorem coe_zero : ((0 : s) : R) = (0 : R) :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_add (x y : s) : ((x + y : s) : R) = (x + y : R) :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_mul (x y : s) : ((x * y : s) : R) = (x * y : R) :=
-  rfl
-
-/-! Note: currently, there are no ordered versions of non-unital rings. -/
-
-
-@[simp high]
-theorem mem_toSubsemigroup {s : NonUnitalSubsemiring R} {x : R} : x ∈ s.toSubsemigroup ↔ x ∈ s :=
-  Iff.rfl
-
-@[simp high]
-theorem coe_toSubsemigroup (s : NonUnitalSubsemiring R) : (s.toSubsemigroup : Set R) = s :=
-  rfl
-
-@[simp]
-theorem mem_toAddSubmonoid {s : NonUnitalSubsemiring R} {x : R} : x ∈ s.toAddSubmonoid ↔ x ∈ s :=
-  Iff.rfl
-
-@[simp]
-theorem coe_toAddSubmonoid (s : NonUnitalSubsemiring R) : (s.toAddSubmonoid : Set R) = s :=
-  rfl
-
-/-- The non-unital subsemiring `R` of the non-unital semiring `R`. -/
-instance : Top (NonUnitalSubsemiring R) :=
-  ⟨{ (⊤ : Subsemigroup R), (⊤ : AddSubmonoid R) with }⟩
-
-@[simp]
-theorem mem_top (x : R) : x ∈ (⊤ : NonUnitalSubsemiring R) :=
-  Set.mem_univ x
-
-@[simp]
-theorem coe_top : ((⊤ : NonUnitalSubsemiring R) : Set R) = Set.univ :=
-  rfl
 
 /-- The ring equiv between the top element of `NonUnitalSubsemiring R` and `R`. -/
 @[simps!]
@@ -335,37 +161,6 @@ instance finite_srange [Finite R] (f : F) : Finite (srange f : NonUnitalSubsemir
 end NonUnitalRingHom
 
 namespace NonUnitalSubsemiring
-
--- should we define this as the range of the zero homomorphism?
-instance : Bot (NonUnitalSubsemiring R) :=
-  ⟨{  carrier := {0}
-      add_mem' := fun _ _ => by simp_all
-      zero_mem' := Set.mem_singleton 0
-      mul_mem' := fun _ _ => by simp_all }⟩
-
-instance : Inhabited (NonUnitalSubsemiring R) :=
-  ⟨⊥⟩
-
-theorem coe_bot : ((⊥ : NonUnitalSubsemiring R) : Set R) = {0} :=
-  rfl
-
-theorem mem_bot {x : R} : x ∈ (⊥ : NonUnitalSubsemiring R) ↔ x = 0 :=
-  Set.mem_singleton_iff
-
-/-- The inf of two non-unital subsemirings is their intersection. -/
-instance : Inf (NonUnitalSubsemiring R) :=
-  ⟨fun s t =>
-    { s.toSubsemigroup ⊓ t.toSubsemigroup, s.toAddSubmonoid ⊓ t.toAddSubmonoid with
-      carrier := s ∩ t }⟩
-
-@[simp]
-theorem coe_inf (p p' : NonUnitalSubsemiring R) :
-    ((p ⊓ p' : NonUnitalSubsemiring R) : Set R) = (p : Set R) ∩ p' :=
-  rfl
-
-@[simp]
-theorem mem_inf {p p' : NonUnitalSubsemiring R} {x : R} : x ∈ p ⊓ p' ↔ x ∈ p ∧ x ∈ p' :=
-  Iff.rfl
 
 instance : InfSet (NonUnitalSubsemiring R) :=
   ⟨fun s =>
@@ -809,13 +604,6 @@ variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
 
 open NonUnitalSubsemiringClass NonUnitalSubsemiring
 
-/-- Restriction of a non-unital ring homomorphism to a non-unital subsemiring of the codomain. -/
-def codRestrict (f : F) (s : S') (h : ∀ x, f x ∈ s) : R →ₙ+* s where
-  toFun n := ⟨f n, h n⟩
-  map_mul' x y := Subtype.eq (map_mul f x y)
-  map_add' x y := Subtype.eq (map_add f x y)
-  map_zero' := Subtype.eq (map_zero f)
-
 /-- Restriction of a non-unital ring homomorphism to its range interpreted as a
 non-unital subsemiring.
 
@@ -842,11 +630,6 @@ theorem srange_top_iff_surjective {f : F} :
 theorem srange_top_of_surjective (f : F) (hf : Function.Surjective (f : R → S)) :
     srange f = (⊤ : NonUnitalSubsemiring S) :=
   srange_top_iff_surjective.2 hf
-
-/-- The non-unital subsemiring of elements `x : R` such that `f x = g x` -/
-def eqSlocus (f g : F) : NonUnitalSubsemiring R :=
-  { (f : R →ₙ* S).eqLocus (g : R →ₙ* S), (f : R →+ S).eqLocusM g with
-    carrier := { x | f x = g x } }
 
 /-- If two non-unital ring homomorphisms are equal on a set, then they are equal on its
 non-unital subsemiring closure. -/
@@ -875,11 +658,6 @@ end NonUnitalRingHom
 namespace NonUnitalSubsemiring
 
 open NonUnitalRingHom NonUnitalSubsemiringClass
-
-/-- The non-unital ring homomorphism associated to an inclusion of
-non-unital subsemirings. -/
-def inclusion {S T : NonUnitalSubsemiring R} (h : S ≤ T) : S →ₙ+* T :=
-  codRestrict (subtype S) _ fun x => h x.2
 
 @[simp]
 theorem srange_subtype (s : NonUnitalSubsemiring R) : NonUnitalRingHom.srange (subtype s) = s :=

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -1,0 +1,288 @@
+/-
+Copyright (c) 2022 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+import Mathlib.Algebra.Ring.Hom.Defs
+import Mathlib.Algebra.Ring.InjSurj
+import Mathlib.Algebra.Group.Submonoid.Defs
+
+/-!
+# Bundled non-unital subsemirings
+
+We define bundled non-unital subsemirings and some standard constructions:
+`subtype` and `inclusion` ring homomorphisms.
+-/
+
+
+universe u v w
+
+variable {R : Type u} {S : Type v} {T : Type w} [NonUnitalNonAssocSemiring R] (M : Subsemigroup R)
+
+/-- `NonUnitalSubsemiringClass S R` states that `S` is a type of subsets `s ⊆ R` that
+are both an additive submonoid and also a multiplicative subsemigroup. -/
+class NonUnitalSubsemiringClass (S : Type*) (R : outParam (Type u)) [NonUnitalNonAssocSemiring R]
+  [SetLike S R] extends AddSubmonoidClass S R : Prop where
+  mul_mem : ∀ {s : S} {a b : R}, a ∈ s → b ∈ s → a * b ∈ s
+
+-- See note [lower instance priority]
+instance (priority := 100) NonUnitalSubsemiringClass.mulMemClass (S : Type*) (R : Type u)
+    [NonUnitalNonAssocSemiring R] [SetLike S R] [h : NonUnitalSubsemiringClass S R] :
+    MulMemClass S R :=
+  { h with }
+
+namespace NonUnitalSubsemiringClass
+
+variable [SetLike S R] [NonUnitalSubsemiringClass S R] (s : S)
+
+open AddSubmonoidClass
+
+/- Prefer subclasses of `NonUnitalNonAssocSemiring` over subclasses of
+`NonUnitalSubsemiringClass`. -/
+/-- A non-unital subsemiring of a `NonUnitalNonAssocSemiring` inherits a
+`NonUnitalNonAssocSemiring` structure -/
+instance (priority := 75) toNonUnitalNonAssocSemiring : NonUnitalNonAssocSemiring s :=
+  Subtype.coe_injective.nonUnitalNonAssocSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
+
+instance noZeroDivisors [NoZeroDivisors R] : NoZeroDivisors s :=
+  Subtype.coe_injective.noZeroDivisors (↑) rfl fun _ _ => rfl
+
+/-- The natural non-unital ring hom from a non-unital subsemiring of a non-unital semiring `R` to
+`R`. -/
+def subtype : s →ₙ+* R :=
+  { AddSubmonoidClass.subtype s, MulMemClass.subtype s with toFun := (↑) }
+
+@[simp]
+theorem coeSubtype : (subtype s : s → R) = ((↑) : s → R) :=
+  rfl
+
+/-- A non-unital subsemiring of a `NonUnitalSemiring` is a `NonUnitalSemiring`. -/
+instance toNonUnitalSemiring {R} [NonUnitalSemiring R] [SetLike S R]
+    [NonUnitalSubsemiringClass S R] : NonUnitalSemiring s :=
+  Subtype.coe_injective.nonUnitalSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
+
+/-- A non-unital subsemiring of a `NonUnitalCommSemiring` is a `NonUnitalCommSemiring`. -/
+instance toNonUnitalCommSemiring {R} [NonUnitalCommSemiring R] [SetLike S R]
+    [NonUnitalSubsemiringClass S R] : NonUnitalCommSemiring s :=
+  Subtype.coe_injective.nonUnitalCommSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
+
+/-! Note: currently, there are no ordered versions of non-unital rings. -/
+
+
+end NonUnitalSubsemiringClass
+
+/-- A non-unital subsemiring of a non-unital semiring `R` is a subset `s` that is both an additive
+submonoid and a semigroup. -/
+structure NonUnitalSubsemiring (R : Type u) [NonUnitalNonAssocSemiring R] extends AddSubmonoid R,
+  Subsemigroup R
+
+/-- Reinterpret a `NonUnitalSubsemiring` as a `Subsemigroup`. -/
+add_decl_doc NonUnitalSubsemiring.toSubsemigroup
+
+/-- Reinterpret a `NonUnitalSubsemiring` as an `AddSubmonoid`. -/
+add_decl_doc NonUnitalSubsemiring.toAddSubmonoid
+
+namespace NonUnitalSubsemiring
+
+instance : SetLike (NonUnitalSubsemiring R) R where
+  coe s := s.carrier
+  coe_injective' p q h := by cases p; cases q; congr; exact SetLike.coe_injective' h
+
+instance : NonUnitalSubsemiringClass (NonUnitalSubsemiring R) R where
+  zero_mem {s} := AddSubmonoid.zero_mem' s.toAddSubmonoid
+  add_mem {s} := AddSubsemigroup.add_mem' s.toAddSubmonoid.toAddSubsemigroup
+  mul_mem {s} := mul_mem' s
+
+theorem mem_carrier {s : NonUnitalSubsemiring R} {x : R} : x ∈ s.carrier ↔ x ∈ s :=
+  Iff.rfl
+
+/-- Two non-unital subsemirings are equal if they have the same elements. -/
+@[ext]
+theorem ext {S T : NonUnitalSubsemiring R} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T :=
+  SetLike.ext h
+
+/-- Copy of a non-unital subsemiring with a new `carrier` equal to the old one. Useful to fix
+definitional equalities. -/
+protected def copy (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) :
+    NonUnitalSubsemiring R :=
+  { S.toAddSubmonoid.copy s hs, S.toSubsemigroup.copy s hs with carrier := s }
+
+@[simp]
+theorem coe_copy (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) :
+    (S.copy s hs : Set R) = s :=
+  rfl
+
+theorem copy_eq (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) : S.copy s hs = S :=
+  SetLike.coe_injective hs
+
+theorem toSubsemigroup_injective :
+    Function.Injective (toSubsemigroup : NonUnitalSubsemiring R → Subsemigroup R)
+  | _, _, h => ext (SetLike.ext_iff.mp h : _)
+
+theorem toAddSubmonoid_injective :
+    Function.Injective (toAddSubmonoid : NonUnitalSubsemiring R → AddSubmonoid R)
+  | _, _, h => ext (SetLike.ext_iff.mp h : _)
+
+/-- Construct a `NonUnitalSubsemiring R` from a set `s`, a subsemigroup `sg`, and an additive
+submonoid `sa` such that `x ∈ s ↔ x ∈ sg ↔ x ∈ sa`. -/
+protected def mk' (s : Set R) (sg : Subsemigroup R) (hg : ↑sg = s) (sa : AddSubmonoid R)
+    (ha : ↑sa = s) : NonUnitalSubsemiring R where
+  carrier := s
+  zero_mem' := by subst ha; exact sa.zero_mem
+  add_mem' := by subst ha; exact sa.add_mem
+  mul_mem' := by subst hg; exact sg.mul_mem
+
+@[simp]
+theorem coe_mk' {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
+    (ha : ↑sa = s) : (NonUnitalSubsemiring.mk' s sg hg sa ha : Set R) = s :=
+  rfl
+
+@[simp]
+theorem mem_mk' {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
+    (ha : ↑sa = s) {x : R} : x ∈ NonUnitalSubsemiring.mk' s sg hg sa ha ↔ x ∈ s :=
+  Iff.rfl
+
+@[simp]
+theorem mk'_toSubsemigroup {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
+    (ha : ↑sa = s) : (NonUnitalSubsemiring.mk' s sg hg sa ha).toSubsemigroup = sg :=
+  SetLike.coe_injective hg.symm
+
+@[simp]
+theorem mk'_toAddSubmonoid {s : Set R} {sg : Subsemigroup R} (hg : ↑sg = s) {sa : AddSubmonoid R}
+    (ha : ↑sa = s) : (NonUnitalSubsemiring.mk' s sg hg sa ha).toAddSubmonoid = sa :=
+  SetLike.coe_injective ha.symm
+
+end NonUnitalSubsemiring
+
+namespace NonUnitalSubsemiring
+
+variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
+variable {F G : Type*} [FunLike F R S] [NonUnitalRingHomClass F R S]
+  [FunLike G S T] [NonUnitalRingHomClass G S T]
+  (s : NonUnitalSubsemiring R)
+
+@[simp, norm_cast]
+theorem coe_zero : ((0 : s) : R) = (0 : R) :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_add (x y : s) : ((x + y : s) : R) = (x + y : R) :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_mul (x y : s) : ((x * y : s) : R) = (x * y : R) :=
+  rfl
+
+/-! Note: currently, there are no ordered versions of non-unital rings. -/
+
+
+@[simp high]
+theorem mem_toSubsemigroup {s : NonUnitalSubsemiring R} {x : R} : x ∈ s.toSubsemigroup ↔ x ∈ s :=
+  Iff.rfl
+
+@[simp high]
+theorem coe_toSubsemigroup (s : NonUnitalSubsemiring R) : (s.toSubsemigroup : Set R) = s :=
+  rfl
+
+@[simp]
+theorem mem_toAddSubmonoid {s : NonUnitalSubsemiring R} {x : R} : x ∈ s.toAddSubmonoid ↔ x ∈ s :=
+  Iff.rfl
+
+@[simp]
+theorem coe_toAddSubmonoid (s : NonUnitalSubsemiring R) : (s.toAddSubmonoid : Set R) = s :=
+  rfl
+
+/-- The non-unital subsemiring `R` of the non-unital semiring `R`. -/
+instance : Top (NonUnitalSubsemiring R) :=
+  ⟨{ (⊤ : Subsemigroup R), (⊤ : AddSubmonoid R) with }⟩
+
+@[simp]
+theorem mem_top (x : R) : x ∈ (⊤ : NonUnitalSubsemiring R) :=
+  Set.mem_univ x
+
+@[simp]
+theorem coe_top : ((⊤ : NonUnitalSubsemiring R) : Set R) = Set.univ :=
+  rfl
+
+end NonUnitalSubsemiring
+
+namespace NonUnitalRingHom
+
+open NonUnitalSubsemiring
+
+variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
+variable {F G : Type*} [FunLike F R S] [NonUnitalRingHomClass F R S]
+variable [FunLike G S T] [NonUnitalRingHomClass G S T] (f : F) (g : G)
+
+end NonUnitalRingHom
+
+namespace NonUnitalSubsemiring
+
+-- should we define this as the range of the zero homomorphism?
+instance : Bot (NonUnitalSubsemiring R) :=
+  ⟨{  carrier := {0}
+      add_mem' := fun _ _ => by simp_all
+      zero_mem' := Set.mem_singleton 0
+      mul_mem' := fun _ _ => by simp_all }⟩
+
+instance : Inhabited (NonUnitalSubsemiring R) :=
+  ⟨⊥⟩
+
+theorem coe_bot : ((⊥ : NonUnitalSubsemiring R) : Set R) = {0} :=
+  rfl
+
+theorem mem_bot {x : R} : x ∈ (⊥ : NonUnitalSubsemiring R) ↔ x = 0 :=
+  Set.mem_singleton_iff
+
+/-- The inf of two non-unital subsemirings is their intersection. -/
+instance : Inf (NonUnitalSubsemiring R) :=
+  ⟨fun s t =>
+    { s.toSubsemigroup ⊓ t.toSubsemigroup, s.toAddSubmonoid ⊓ t.toAddSubmonoid with
+      carrier := s ∩ t }⟩
+
+@[simp]
+theorem coe_inf (p p' : NonUnitalSubsemiring R) :
+    ((p ⊓ p' : NonUnitalSubsemiring R) : Set R) = (p : Set R) ∩ p' :=
+  rfl
+
+@[simp]
+theorem mem_inf {p p' : NonUnitalSubsemiring R} {x : R} : x ∈ p ⊓ p' ↔ x ∈ p ∧ x ∈ p' :=
+  Iff.rfl
+
+end NonUnitalSubsemiring
+
+namespace NonUnitalRingHom
+
+variable {F : Type*} [FunLike F R S]
+
+variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
+  [NonUnitalRingHomClass F R S]
+  {S' : Type*} [SetLike S' S] [NonUnitalSubsemiringClass S' S]
+  {s : NonUnitalSubsemiring R}
+
+open NonUnitalSubsemiringClass NonUnitalSubsemiring
+
+/-- Restriction of a non-unital ring homomorphism to a non-unital subsemiring of the codomain. -/
+def codRestrict (f : F) (s : S') (h : ∀ x, f x ∈ s) : R →ₙ+* s where
+  toFun n := ⟨f n, h n⟩
+  map_mul' x y := Subtype.eq (map_mul f x y)
+  map_add' x y := Subtype.eq (map_add f x y)
+  map_zero' := Subtype.eq (map_zero f)
+
+/-- The non-unital subsemiring of elements `x : R` such that `f x = g x` -/
+def eqSlocus (f g : F) : NonUnitalSubsemiring R :=
+  { (f : R →ₙ* S).eqLocus (g : R →ₙ* S), (f : R →+ S).eqLocusM g with
+    carrier := { x | f x = g x } }
+
+end NonUnitalRingHom
+
+namespace NonUnitalSubsemiring
+
+open NonUnitalRingHom NonUnitalSubsemiringClass
+
+/-- The non-unital ring homomorphism associated to an inclusion of
+non-unital subsemirings. -/
+def inclusion {S T : NonUnitalSubsemiring R} (h : S ≤ T) : S →ₙ+* T :=
+  codRestrict (subtype S) _ fun x => h x.2
+
+end NonUnitalSubsemiring


### PR DESCRIPTION
This PR splits off a `Defs.lean` file from `Subsemiring/Basic.lean` containing on the definition and subsemiring structure of `Subsemiring`(`Class`).

---
- [ ] depends on: #18517 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
