### PR TITLE
[Merged by Bors] - chore(Data/{Nat,Int}/Cast): move `nsmul_one`/`zsmul_one` lemmas

### DIFF
--- a/Mathlib/Algebra/Order/Interval/Set/Group.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Group.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Ring.Defs
-import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.Order.Interval.Set.Basic
 import Mathlib.Logic.Pairwise
 

--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -115,3 +115,11 @@ theorem cast_three : ((3 : ℤ) : R) = 3 := cast_ofNat _
 theorem cast_four : ((4 : ℤ) : R) = 4 := cast_ofNat _
 
 end Int
+
+section zsmul
+
+variable {R : Type*}
+
+@[simp] lemma zsmul_one [AddGroupWithOne R] (n : ℤ) : n • (1 : R) = n := by cases n <;> simp
+
+end zsmul

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -219,8 +219,6 @@ theorem eq_intCast' [AddGroupWithOne α] [FunLike F ℤ α] [AddMonoidHomClass F
     ∀ n : ℤ, f n = n :=
   DFunLike.ext_iff.1 <| (f : ℤ →+ α).eq_intCastAddHom h₁
 
-@[simp] lemma zsmul_one [AddGroupWithOne α] (n : ℤ) : n • (1 : α) = n := by cases n <;> simp
-
 @[simp]
 theorem Int.castAddHom_int : Int.castAddHom ℤ = AddMonoidHom.id ℤ :=
   ((AddMonoidHom.id ℤ).eq_intCastAddHom rfl).symm

--- a/Mathlib/Data/Nat/Cast/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Basic.lean
@@ -125,13 +125,6 @@ theorem map_ofNat' {A} [AddMonoidWithOne A] [FunLike F A B] [AddMonoidHomClass F
     (f : F) (h : f 1 = 1) (n : ℕ) [n.AtLeastTwo] : f (OfNat.ofNat n) = OfNat.ofNat n :=
   map_natCast' f h n
 
-@[simp] lemma nsmul_one {A} [AddMonoidWithOne A] : ∀ n : ℕ, n • (1 : A) = n := by
-  let f : ℕ →+ A :=
-  { toFun := fun n ↦ n • (1 : A)
-    map_zero' := zero_nsmul _
-    map_add' := add_nsmul _ }
-  exact eq_natCast' f <| by simp [f]
-
 end AddMonoidHomClass
 
 section MonoidWithZeroHomClass

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -203,3 +203,11 @@ theorem three_add_one_eq_four [AddMonoidWithOne R] : 3 + 1 = (4 : R) := by
 theorem two_add_two_eq_four [AddMonoidWithOne R] : 2 + 2 = (4 : R) := by
   simp [← one_add_one_eq_two, ← Nat.cast_one, ← three_add_one_eq_four,
     ← two_add_one_eq_three, add_assoc]
+
+section nsmul
+
+@[simp] lemma nsmul_one {A} [AddMonoidWithOne A] : ∀ n : ℕ, n • (1 : A) = n
+  | 0 => by simp [zero_nsmul]
+  | n + 1 => by simp [succ_nsmul, nsmul_one n]
+
+end nsmul


### PR DESCRIPTION
These two lemmas can be proven without the machinery of ring homomorphisms from the natural numbers / integers, although the proof is slightly less conceptual. The goal is to drop an import of `Data.Int.Cast.Lemmas` in #18520.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
