### PR TITLE
[Merged by Bors] - chore(Algebra/Ring/Int): split `Algebra/Ring/Int.lean` into `Defs`, `Parity` and `Units`

### DIFF
--- a/Archive/Imo/Imo2011Q5.lean
+++ b/Archive/Imo/Imo2011Q5.lean
@@ -5,7 +5,7 @@ Authors: Alain Verberkmoes
 -/
 import Mathlib.Algebra.Order.Group.Int
 import Mathlib.Algebra.Ring.Divisibility.Basic
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 
 /-!
 # IMO 2011 Q5

--- a/Archive/Imo/Imo2011Q5.lean
+++ b/Archive/Imo/Imo2011Q5.lean
@@ -5,7 +5,7 @@ Authors: Alain Verberkmoes
 -/
 import Mathlib.Algebra.Order.Group.Int
 import Mathlib.Algebra.Ring.Divisibility.Basic
-import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Defs
 
 /-!
 # IMO 2011 Q5

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -818,8 +818,9 @@ import Mathlib.Algebra.Ring.Hom.Defs
 import Mathlib.Algebra.Ring.Idempotents
 import Mathlib.Algebra.Ring.Identities
 import Mathlib.Algebra.Ring.InjSurj
-import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.Algebra.Ring.Int.Defs
+import Mathlib.Algebra.Ring.Int.Parity
+import Mathlib.Algebra.Ring.Int.Units
 import Mathlib.Algebra.Ring.Invertible
 import Mathlib.Algebra.Ring.MinimalAxioms
 import Mathlib.Algebra.Ring.Nat

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -818,7 +818,8 @@ import Mathlib.Algebra.Ring.Hom.Defs
 import Mathlib.Algebra.Ring.Idempotents
 import Mathlib.Algebra.Ring.Identities
 import Mathlib.Algebra.Ring.InjSurj
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Algebra.Ring.Invertible
 import Mathlib.Algebra.Ring.MinimalAxioms
 import Mathlib.Algebra.Ring.Nat

--- a/Mathlib/Algebra/EuclideanDomain/Int.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Int.lean
@@ -5,7 +5,8 @@ Authors: Louis Carlin, Mario Carneiro
 -/
 import Mathlib.Algebra.EuclideanDomain.Defs
 import Mathlib.Algebra.Order.Group.Unbundled.Int
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Defs
+import Mathlib.Algebra.Ring.Nat
 
 /-!
 # Instances for Euclidean domains

--- a/Mathlib/Algebra/Field/Power.lean
+++ b/Mathlib/Algebra/Field/Power.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Leonardo de Moura, Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Algebra.Field.Defs
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 
 /-!
 # Results about powers in fields or division rings.

--- a/Mathlib/Algebra/Field/Power.lean
+++ b/Mathlib/Algebra/Field/Power.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Leonardo de Moura, Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Algebra.Field.Defs
-import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Parity
 
 /-!
 # Results about powers in fields or division rings.

--- a/Mathlib/Algebra/GCDMonoid/Nat.lean
+++ b/Mathlib/Algebra/GCDMonoid/Nat.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Jens Wagemaker, Aaron Anderson
 -/
 import Mathlib.Algebra.GCDMonoid.Basic
 import Mathlib.Algebra.Order.Group.Unbundled.Int
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.Data.Int.GCD
 
 /-!

--- a/Mathlib/Algebra/GCDMonoid/Nat.lean
+++ b/Mathlib/Algebra/GCDMonoid/Nat.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Jens Wagemaker, Aaron Anderson
 -/
 import Mathlib.Algebra.GCDMonoid.Basic
 import Mathlib.Algebra.Order.Group.Unbundled.Int
-import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Units
 import Mathlib.Data.Int.GCD
 
 /-!

--- a/Mathlib/Algebra/Group/NatPowAssoc.lean
+++ b/Mathlib/Algebra/Group/NatPowAssoc.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Carnahan
 -/
 import Mathlib.Algebra.Group.Action.Prod
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Data.Nat.Cast.Basic
 
 /-!

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -8,7 +8,7 @@ import Mathlib.Algebra.FreeMonoid.Basic
 import Mathlib.Algebra.Group.Submonoid.MulOpposite
 import Mathlib.Algebra.Group.Submonoid.Operations
 import Mathlib.Algebra.GroupWithZero.Divisibility
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Data.Finset.NoncommProd
 import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Util.AssertExists

--- a/Mathlib/Algebra/Homology/Embedding/Basic.lean
+++ b/Mathlib/Algebra/Homology/Embedding/Basic.lean
@@ -5,7 +5,7 @@ Authors: Joël Riou
 -/
 import Mathlib.Algebra.Homology.ComplexShape
 import Mathlib.Algebra.Order.Ring.Nat
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Defs
 
 /-! # Embeddings of complex shapes
 

--- a/Mathlib/Algebra/Order/Field/Power.lean
+++ b/Mathlib/Algebra/Order/Field/Power.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.CharZero.Lemmas
 import Mathlib.Algebra.GroupWithZero.Commute
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Order.Ring.Pow
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 
 /-!
 # Lemmas about powers in ordered fields.

--- a/Mathlib/Algebra/Order/Field/Power.lean
+++ b/Mathlib/Algebra/Order/Field/Power.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.CharZero.Lemmas
 import Mathlib.Algebra.GroupWithZero.Commute
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Order.Ring.Pow
-import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Parity
 
 /-!
 # Lemmas about powers in ordered fields.

--- a/Mathlib/Algebra/Order/Ring/Int.lean
+++ b/Mathlib/Algebra/Order/Ring/Int.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad
 -/
 import Mathlib.Algebra.Order.Group.Unbundled.Int
 import Mathlib.Algebra.Order.Ring.Defs
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.Data.Set.Basic
 
 /-!

--- a/Mathlib/Algebra/Order/Ring/Int.lean
+++ b/Mathlib/Algebra/Order/Ring/Int.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad
 -/
 import Mathlib.Algebra.Order.Group.Unbundled.Int
 import Mathlib.Algebra.Order.Ring.Defs
-import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Parity
 import Mathlib.Data.Set.Basic
 
 /-!

--- a/Mathlib/Algebra/Ring/Int/Basic.lean
+++ b/Mathlib/Algebra/Ring/Int/Basic.lean
@@ -3,81 +3,21 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
-import Mathlib.Algebra.CharZero.Defs
-import Mathlib.Algebra.Group.Int
 import Mathlib.Algebra.Ring.Parity
+import Mathlib.Algebra.Ring.Int.Defs
 
 /-!
-# The integers are a ring
+# Miscellaneous lemmas on the ring structure for `ℤ`.
 
 This file contains the commutative ring instance on `ℤ`.
 
 See note [foundational algebra order theory].
-
-## Note
-
-If this file needs to be split, please create an `Algebra.Ring.Int` folder and make the first file
-be `Algebra.Ring.Int.Basic`.
 -/
 
 assert_not_exists DenselyOrdered
 assert_not_exists Set.Subsingleton
 
 namespace Int
-
-instance instCommRing : CommRing ℤ where
-  __ := instAddCommGroup
-  __ := instCommSemigroup
-  zero_mul := Int.zero_mul
-  mul_zero := Int.mul_zero
-  left_distrib := Int.mul_add
-  right_distrib := Int.add_mul
-  mul_one := Int.mul_one
-  one_mul := Int.one_mul
-  npow n x := x ^ n
-  npow_zero _ := rfl
-  npow_succ _ _ := rfl
-  natCast := (·)
-  natCast_zero := rfl
-  natCast_succ _ := rfl
-  intCast := (·)
-  intCast_ofNat _ := rfl
-  intCast_negSucc _ := rfl
-
-instance instCancelCommMonoidWithZero : CancelCommMonoidWithZero ℤ where
-  mul_left_cancel_of_ne_zero {_a _b _c} ha := (mul_eq_mul_left_iff ha).1
-
-instance instCharZero : CharZero ℤ where cast_injective _ _ := ofNat.inj
-
-instance instMulDivCancelClass : MulDivCancelClass ℤ where mul_div_cancel _ _ := mul_ediv_cancel _
-
-@[simp, norm_cast]
-lemma cast_mul {α : Type*} [NonAssocRing α] : ∀ m n, ((m * n : ℤ) : α) = m * n := fun m => by
-  obtain ⟨m, rfl | rfl⟩ := Int.eq_nat_or_neg m
-  · induction m with
-    | zero => simp
-    | succ m ih => simp_all [add_mul]
-  · induction m with
-    | zero => simp
-    | succ m ih => simp_all [add_mul]
-
-@[simp, norm_cast] lemma cast_pow {R : Type*} [Ring R] (n : ℤ) (m : ℕ) :
-    ↑(n ^ m) = (n ^ m : R) := by
-  induction' m with m ih <;> simp [_root_.pow_succ, *]
-
-/-!
-### Extra instances to short-circuit type class resolution
-
-These also prevent non-computable instances like `Int.normedCommRing` being used to construct
-these instances non-computably.
--/
-
-instance instCommSemiring : CommSemiring ℤ := inferInstance
-instance instSemiring     : Semiring ℤ     := inferInstance
-instance instRing         : Ring ℤ         := inferInstance
-instance instDistrib      : Distrib ℤ      := inferInstance
-
-/-! ### Miscellaneous lemmas -/
 
 /-! #### Units -/
 

--- a/Mathlib/Algebra/Ring/Int/Defs.lean
+++ b/Mathlib/Algebra/Ring/Int/Defs.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad
+-/
+import Mathlib.Algebra.CharZero.Defs
+import Mathlib.Algebra.Group.Int
+import Mathlib.Algebra.Ring.Defs
+
+/-!
+# The integers are a ring
+
+This file contains the commutative ring instance on `ℤ`.
+
+See note [foundational algebra order theory].
+-/
+
+assert_not_exists DenselyOrdered
+assert_not_exists Set.Subsingleton
+
+namespace Int
+
+instance instCommRing : CommRing ℤ where
+  __ := instAddCommGroup
+  __ := instCommSemigroup
+  zero_mul := Int.zero_mul
+  mul_zero := Int.mul_zero
+  left_distrib := Int.mul_add
+  right_distrib := Int.add_mul
+  mul_one := Int.mul_one
+  one_mul := Int.one_mul
+  npow n x := x ^ n
+  npow_zero _ := rfl
+  npow_succ _ _ := rfl
+  natCast := (·)
+  natCast_zero := rfl
+  natCast_succ _ := rfl
+  intCast := (·)
+  intCast_ofNat _ := rfl
+  intCast_negSucc _ := rfl
+
+instance instCancelCommMonoidWithZero : CancelCommMonoidWithZero ℤ where
+  mul_left_cancel_of_ne_zero {_a _b _c} ha := (mul_eq_mul_left_iff ha).1
+
+instance instCharZero : CharZero ℤ where cast_injective _ _ := ofNat.inj
+
+instance instMulDivCancelClass : MulDivCancelClass ℤ where mul_div_cancel _ _ := mul_ediv_cancel _
+
+@[simp, norm_cast]
+lemma cast_mul {α : Type*} [NonAssocRing α] : ∀ m n, ((m * n : ℤ) : α) = m * n := fun m => by
+  obtain ⟨m, rfl | rfl⟩ := Int.eq_nat_or_neg m
+  · induction m with
+    | zero => simp
+    | succ m ih => simp_all [add_mul]
+  · induction m with
+    | zero => simp
+    | succ m ih => simp_all [add_mul]
+
+@[simp, norm_cast] lemma cast_pow {R : Type*} [Ring R] (n : ℤ) (m : ℕ) :
+    ↑(n ^ m) = (n ^ m : R) := by
+  induction' m with m ih <;> simp [_root_.pow_succ, *]
+
+/-!
+### Extra instances to short-circuit type class resolution
+
+These also prevent non-computable instances like `Int.normedCommRing` being used to construct
+these instances non-computably.
+-/
+
+instance instCommSemiring : CommSemiring ℤ := inferInstance
+instance instSemiring     : Semiring ℤ     := inferInstance
+instance instRing         : Ring ℤ         := inferInstance
+instance instDistrib      : Distrib ℤ      := inferInstance
+
+end Int

--- a/Mathlib/Algebra/Ring/Int/Parity.lean
+++ b/Mathlib/Algebra/Ring/Int/Parity.lean
@@ -7,9 +7,7 @@ import Mathlib.Algebra.Ring.Parity
 import Mathlib.Algebra.Ring.Int.Defs
 
 /-!
-# Miscellaneous lemmas on the ring structure for `ℤ`.
-
-This file contains the commutative ring instance on `ℤ`.
+# Basic parity lemmas for the ring `ℤ`
 
 See note [foundational algebra order theory].
 -/
@@ -18,14 +16,6 @@ assert_not_exists DenselyOrdered
 assert_not_exists Set.Subsingleton
 
 namespace Int
-
-/-! #### Units -/
-
-lemma units_eq_one_or (u : ℤˣ) : u = 1 ∨ u = -1 := by
-  simpa only [Units.ext_iff] using isUnit_eq_one_or u.isUnit
-
-lemma units_ne_iff_eq_neg {u v : ℤˣ} : u ≠ v ↔ u = -v := by
-  simpa only [Ne, Units.ext_iff] using isUnit_ne_iff_eq_neg u.isUnit v.isUnit
 
 /-! #### Parity -/
 

--- a/Mathlib/Algebra/Ring/Int/Units.lean
+++ b/Mathlib/Algebra/Ring/Int/Units.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad
+-/
+import Mathlib.Algebra.Ring.Int.Defs
+import Mathlib.Algebra.Ring.Units
+
+/-!
+# Basic lemmas for `ℤˣ`.
+
+This file contains lemmas on the units of `ℤ`.
+
+## Main results
+
+ * `Int.units_eq_one_or`: the invertible integers are 1 and -1.
+
+See note [foundational algebra order theory].
+-/
+
+assert_not_exists DenselyOrdered
+assert_not_exists Set.Subsingleton
+
+namespace Int
+
+/-! #### Units -/
+
+lemma units_eq_one_or (u : ℤˣ) : u = 1 ∨ u = -1 := by
+  simpa only [Units.ext_iff] using isUnit_eq_one_or u.isUnit
+
+lemma units_ne_iff_eq_neg {u v : ℤˣ} : u ≠ v ↔ u = -v := by
+  simpa only [Ne, Units.ext_iff] using isUnit_ne_iff_eq_neg u.isUnit v.isUnit
+
+end Int

--- a/Mathlib/Algebra/Ring/NegOnePow.lean
+++ b/Mathlib/Algebra/Ring/NegOnePow.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou, Johan Commelin
 -/
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.Data.ZMod.IntUnitsPower
 
 /-!

--- a/Mathlib/Algebra/Ring/NegOnePow.lean
+++ b/Mathlib/Algebra/Ring/NegOnePow.lean
@@ -3,7 +3,8 @@ Copyright (c) 2023 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou, Johan Commelin
 -/
-import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Parity
+import Mathlib.Algebra.Ring.Int.Units
 import Mathlib.Data.ZMod.IntUnitsPower
 
 /-!

--- a/Mathlib/Algebra/Ring/Rat.lean
+++ b/Mathlib/Algebra/Ring/Rat.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Algebra.GroupWithZero.Units.Basic
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Basic
+import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Data.Rat.Defs
 
 /-!

--- a/Mathlib/Data/Fintype/Units.lean
+++ b/Mathlib/Data/Fintype/Units.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Mathlib.Algebra.Ring.Int.Units
 import Mathlib.Data.Fintype.Prod
 import Mathlib.Data.Fintype.Sum
 import Mathlib.SetTheory.Cardinal.Finite

--- a/Mathlib/Data/Int/AbsoluteValue.lean
+++ b/Mathlib/Data/Int/AbsoluteValue.lean
@@ -6,6 +6,7 @@ Authors: Anne Baanen
 import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Order.AbsoluteValue
+import Mathlib.Algebra.Ring.Int.Units
 import Mathlib.Data.Int.Cast.Lemmas
 
 /-!

--- a/Mathlib/Data/Int/Associated.lean
+++ b/Mathlib/Data/Int/Associated.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 import Mathlib.Algebra.Associated.Basic
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 /-!
 # Associated elements and the integers
 

--- a/Mathlib/Data/Int/Associated.lean
+++ b/Mathlib/Data/Int/Associated.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 import Mathlib.Algebra.Associated.Basic
-import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Units
 /-!
 # Associated elements and the integers
 

--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -3,7 +3,7 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Data.Nat.Bitwise
 import Mathlib.Data.Nat.Size
 

--- a/Mathlib/Data/Int/Cast/Field.lean
+++ b/Mathlib/Data/Int/Cast/Field.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import Mathlib.Algebra.Field.Defs
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Defs
 
 /-!
 # Cast of integers into fields

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Algebra.Ring.Hom.Basic
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Defs
+import Mathlib.Algebra.Ring.Parity
 
 /-!
 # Cast of integers (additional theorems)

--- a/Mathlib/Data/Nat/Prime/Int.lean
+++ b/Mathlib/Data/Nat/Prime/Int.lean
@@ -3,7 +3,7 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Data.Nat.Prime.Basic
 
 /-!

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.Ring.Rat
+import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.Data.PNat.Defs
 
 /-!

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.Ring.Rat
-import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Parity
 import Mathlib.Data.PNat.Defs
 
 /-!

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Mathlib.Algebra.Ring.InjSurj
 import Mathlib.Data.ZMod.Defs
 import Mathlib.Data.BitVec
 

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -5,7 +5,7 @@ Authors: Eric Rodriguez
 -/
 import Mathlib.Algebra.Group.Fin.Basic
 import Mathlib.Algebra.NeZero
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Data.Nat.ModEq
 import Mathlib.Data.Fintype.Card
 

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -5,7 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.GroupPower.IterateHom
 import Mathlib.Algebra.Ring.Divisibility.Basic
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Data.List.Cycle
 import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Data.Nat.Prime.Basic

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Newell Jensen, Mitchell Lee
 -/
 import Mathlib.Algebra.Group.Subgroup.Pointwise
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.GroupTheory.Coxeter.Matrix
 import Mathlib.GroupTheory.PresentedGroup
 import Mathlib.Tactic.NormNum.DivMod

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Newell Jensen, Mitchell Lee
 -/
 import Mathlib.Algebra.Group.Subgroup.Pointwise
-import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Parity
 import Mathlib.GroupTheory.Coxeter.Matrix
 import Mathlib.GroupTheory.PresentedGroup
 import Mathlib.Tactic.NormNum.DivMod

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes
 -/
 import Mathlib.Algebra.Group.Subgroup.Basic
 import Mathlib.Algebra.Group.Submonoid.Membership
+import Mathlib.Algebra.Ring.Int.Units
 import Mathlib.Data.Finset.Fin
 import Mathlib.Data.Finset.Sort
 import Mathlib.Data.Fintype.Sum

--- a/Mathlib/NumberTheory/Multiplicity.lean
+++ b/Mathlib/NumberTheory/Multiplicity.lean
@@ -5,7 +5,7 @@ Authors: Tian Chen, Mantas Bakšys
 -/
 import Mathlib.Algebra.GeomSum
 import Mathlib.Algebra.Order.Ring.Basic
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.Data.Nat.Prime.Int
 import Mathlib.NumberTheory.Padics.PadicVal.Defs

--- a/Mathlib/NumberTheory/Multiplicity.lean
+++ b/Mathlib/NumberTheory/Multiplicity.lean
@@ -5,7 +5,7 @@ Authors: Tian Chen, Mantas Bakšys
 -/
 import Mathlib.Algebra.GeomSum
 import Mathlib.Algebra.Order.Ring.Basic
-import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Parity
 import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.Data.Nat.Prime.Int
 import Mathlib.NumberTheory.Padics.PadicVal.Defs

--- a/Mathlib/NumberTheory/NumberField/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Ashvni Narayanan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ashvni Narayanan, Anne Baanen
 -/
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.RingTheory.DedekindDomain.IntegralClosure
 import Mathlib.Algebra.Algebra.Rat
 

--- a/Mathlib/NumberTheory/NumberField/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Basic.lean
@@ -3,9 +3,10 @@ Copyright (c) 2021 Ashvni Narayanan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ashvni Narayanan, Anne Baanen
 -/
-import Mathlib.Algebra.Ring.Int.Basic
-import Mathlib.RingTheory.DedekindDomain.IntegralClosure
 import Mathlib.Algebra.Algebra.Rat
+import Mathlib.Algebra.Ring.Int.Parity
+import Mathlib.Algebra.Ring.Int.Units
+import Mathlib.RingTheory.DedekindDomain.IntegralClosure
 
 /-!
 # Number fields

--- a/Mathlib/NumberTheory/SumFourSquares.lean
+++ b/Mathlib/NumberTheory/SumFourSquares.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.Data.ZMod.Basic
 import Mathlib.FieldTheory.Finite.Basic
 import Mathlib.Data.Fintype.BigOperators

--- a/Mathlib/NumberTheory/SumFourSquares.lean
+++ b/Mathlib/NumberTheory/SumFourSquares.lean
@@ -3,10 +3,11 @@ Copyright (c) 2019 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Parity
+import Mathlib.Algebra.Ring.Int.Units
+import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Data.ZMod.Basic
 import Mathlib.FieldTheory.Finite.Basic
-import Mathlib.Data.Fintype.BigOperators
 
 /-!
 # Lagrange's four square theorem

--- a/Mathlib/Order/Filter/AtTopBot/ModEq.lean
+++ b/Mathlib/Order/Filter/AtTopBot/ModEq.lean
@@ -6,7 +6,7 @@ Authors: Yury Kudryashov
 import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Algebra.Order.Ring.Nat
 import Mathlib.Algebra.Ring.Divisibility.Basic
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Data.Nat.ModEq
 import Mathlib.Order.Filter.AtTopBot.Monoid
 

--- a/Mathlib/SetTheory/Game/Basic.lean
+++ b/Mathlib/SetTheory/Game/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Mario Carneiro, Isabel Longbottom, Kim Morrison, Apurva Nakade
 -/
 import Mathlib.Algebra.Order.Group.Defs
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.SetTheory.Game.PGame
 import Mathlib.Tactic.Abel
 

--- a/Mathlib/SetTheory/Game/Basic.lean
+++ b/Mathlib/SetTheory/Game/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Mario Carneiro, Isabel Longbottom, Kim Morrison, Apurva Nakade
 -/
 import Mathlib.Algebra.Order.Group.Defs
-import Mathlib.Algebra.Ring.Int.Basic
 import Mathlib.SetTheory.Game.PGame
 import Mathlib.Tactic.Abel
 

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -3,13 +3,13 @@ Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Thomas Murrills
 -/
+import Mathlib.Algebra.GroupWithZero.Invertible
+import Mathlib.Algebra.Ring.Int.Defs
+import Mathlib.Data.Nat.Cast.Basic
+import Mathlib.Data.Nat.Cast.Commute
 import Mathlib.Tactic.NormNum.Core
 import Mathlib.Tactic.HaveI
-import Mathlib.Data.Nat.Cast.Commute
-import Mathlib.Algebra.Ring.Int
-import Mathlib.Algebra.GroupWithZero.Invertible
 import Mathlib.Tactic.ClearExclamation
-import Mathlib.Data.Nat.Cast.Basic
 
 /-!
 ## `norm_num` basic plugins

--- a/MathlibTest/Zify.lean
+++ b/MathlibTest/Zify.lean
@@ -5,7 +5,7 @@ Authors: Moritz Doll, Robert Y. Lewis
 -/
 
 import Mathlib.Tactic.Zify
-import Mathlib.Algebra.Ring.Int
+import Mathlib.Algebra.Ring.Int.Basic
 
 set_option linter.unusedVariables false
 

--- a/MathlibTest/Zify.lean
+++ b/MathlibTest/Zify.lean
@@ -5,7 +5,8 @@ Authors: Moritz Doll, Robert Y. Lewis
 -/
 
 import Mathlib.Tactic.Zify
-import Mathlib.Algebra.Ring.Int.Basic
+import Mathlib.Algebra.Ring.Int.Parity
+import Mathlib.Algebra.Ring.Int.Units
 
 set_option linter.unusedVariables false
 


### PR DESCRIPTION
The definition of the ring structure on the integers in this file was accompanied by a set of miscellaneous lemmas. If we split off the lemmas to their own files, they are not needed nearly as often.

(Hopefully this also allows some cleaning up around `Data.Int.Cast` in the future, although that seems still to be in a bit too much of a mess right now.)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
