### PR TITLE
[Merged by Bors] - chore(Algebra/Field): split `Subfield.lean` into `Defs` and `Basic`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -216,7 +216,8 @@ import Mathlib.Algebra.Field.MinimalAxioms
 import Mathlib.Algebra.Field.Opposite
 import Mathlib.Algebra.Field.Power
 import Mathlib.Algebra.Field.Rat
-import Mathlib.Algebra.Field.Subfield
+import Mathlib.Algebra.Field.Subfield.Basic
+import Mathlib.Algebra.Field.Subfield.Defs
 import Mathlib.Algebra.Field.ULift
 import Mathlib.Algebra.Free
 import Mathlib.Algebra.FreeAlgebra

--- a/Mathlib/Algebra/Field/Subfield/Basic.lean
+++ b/Mathlib/Algebra/Field/Subfield/Basic.lean
@@ -3,15 +3,16 @@ Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
-import Mathlib.Algebra.Ring.Subring.Basic
 import Mathlib.Algebra.Algebra.Defs
+import Mathlib.Algebra.Field.Subfield.Defs
+import Mathlib.Algebra.Ring.Subring.Basic
 import Mathlib.Data.Rat.Cast.Defs
 
 /-!
 # Subfields
 
 Let `K` be a division ring, for example a field.
-This file defines the "bundled" subfield type `Subfield K`, a type
+This file concerns the "bundled" subfield type `Subfield K`, a type
 whose terms correspond to subfields of `K`. Note we do not require the "subfields" to be
 commutative, so they are really sub-division rings / skew fields. This is the preferred way to talk
 about subfields in mathlib. Unbundled subfields (`s : Set K` and `IsSubfield s`)
@@ -29,8 +30,6 @@ Notation used here:
 
 `(K : Type u) [DivisionRing K] (L : Type u) [DivisionRing L] (f g : K →+* L)`
 `(A : Subfield K) (B : Subfield L) (s : Set K)`
-
-* `Subfield K` : the type of subfields of a division ring `K`.
 
 * `instance : CompleteLattice (Subfield K)` : the complete lattice structure on the subfields.
 
@@ -65,204 +64,11 @@ universe u v w
 variable {K : Type u} {L : Type v} {M : Type w}
 variable [DivisionRing K] [DivisionRing L] [DivisionRing M]
 
-/-- `SubfieldClass S K` states `S` is a type of subsets `s ⊆ K` closed under field operations. -/
-class SubfieldClass (S K : Type*) [DivisionRing K] [SetLike S K] extends SubringClass S K,
-  InvMemClass S K : Prop
-
-namespace SubfieldClass
-
-variable (S : Type*) [SetLike S K] [h : SubfieldClass S K]
-
--- See note [lower instance priority]
-/-- A subfield contains `1`, products and inverses.
-
-Be assured that we're not actually proving that subfields are subgroups:
-`SubgroupClass` is really an abbreviation of `SubgroupWithOrWithoutZeroClass`.
- -/
-instance (priority := 100) toSubgroupClass : SubgroupClass S K :=
-  { h with }
-
-variable {S} {x : K}
-
-@[aesop safe apply (rule_sets := [SetLike])]
-lemma nnratCast_mem (s : S) (q : ℚ≥0) : (q : K) ∈ s := by
-  simpa only [NNRat.cast_def] using div_mem (natCast_mem s q.num) (natCast_mem s q.den)
-
-@[aesop safe apply (rule_sets := [SetLike])]
-lemma ratCast_mem (s : S) (q : ℚ) : (q : K) ∈ s := by
-  simpa only [Rat.cast_def] using div_mem (intCast_mem s q.num) (natCast_mem s q.den)
-
-instance instNNRatCast (s : S) : NNRatCast s where nnratCast q := ⟨q, nnratCast_mem s q⟩
-instance instRatCast (s : S) : RatCast s where ratCast q := ⟨q, ratCast_mem s q⟩
-
-@[simp, norm_cast] lemma coe_nnratCast (s : S) (q : ℚ≥0) : ((q : s) : K) = q := rfl
-@[simp, norm_cast] lemma coe_ratCast (s : S) (x : ℚ) : ((x : s) : K) = x := rfl
-
-@[aesop safe apply (rule_sets := [SetLike])]
-lemma nnqsmul_mem (s : S) (q : ℚ≥0) (hx : x ∈ s) : q • x ∈ s := by
-  simpa only [NNRat.smul_def] using mul_mem (nnratCast_mem _ _) hx
-
-@[aesop safe apply (rule_sets := [SetLike])]
-lemma qsmul_mem (s : S) (q : ℚ) (hx : x ∈ s) : q • x ∈ s := by
-  simpa only [Rat.smul_def] using mul_mem (ratCast_mem _ _) hx
-
-@[deprecated (since := "2024-04-05")] alias coe_rat_cast := coe_ratCast
-@[deprecated (since := "2024-04-05")] alias coe_rat_mem := ratCast_mem
-@[deprecated (since := "2024-04-05")] alias rat_smul_mem := qsmul_mem
-
-@[aesop safe apply (rule_sets := [SetLike])]
-lemma ofScientific_mem (s : S) {b : Bool} {n m : ℕ} :
-    (OfScientific.ofScientific n b m : K) ∈ s :=
-  SubfieldClass.nnratCast_mem s (OfScientific.ofScientific n b m)
-
-instance instSMulNNRat (s : S) : SMul ℚ≥0 s where smul q x := ⟨q • x, nnqsmul_mem s q x.2⟩
-instance instSMulRat (s : S) : SMul ℚ s where smul q x := ⟨q • x, qsmul_mem s q x.2⟩
-
-@[simp, norm_cast] lemma coe_nnqsmul (s : S) (q : ℚ≥0) (x : s) : ↑(q • x) = q • (x : K) := rfl
-@[simp, norm_cast] lemma coe_qsmul (s : S) (q : ℚ) (x : s) : ↑(q • x) = q • (x : K) := rfl
-
-variable (S)
-
-/-- A subfield inherits a division ring structure -/
-instance (priority := 75) toDivisionRing (s : S) : DivisionRing s :=
-  Subtype.coe_injective.divisionRing ((↑) : s → K)
-    rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl)
-    (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
-    (fun _ _ ↦ rfl) (coe_nnqsmul _) (coe_qsmul _) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
-    (fun _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl)
-
--- Prefer subclasses of `Field` over subclasses of `SubfieldClass`.
-/-- A subfield of a field inherits a field structure -/
-instance (priority := 75) toField {K} [Field K] [SetLike S K] [SubfieldClass S K] (s : S) :
-    Field s :=
-  Subtype.coe_injective.field ((↑) : s → K)
-    rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl)
-    (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
-    (coe_nnqsmul _) (coe_qsmul _) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl)
-    (fun _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl)
-
-end SubfieldClass
-
-/-- `Subfield R` is the type of subfields of `R`. A subfield of `R` is a subset `s` that is a
-  multiplicative submonoid and an additive subgroup. Note in particular that it shares the
-  same 0 and 1 as R. -/
-structure Subfield (K : Type u) [DivisionRing K] extends Subring K where
-  /-- A subfield is closed under multiplicative inverses. -/
-  inv_mem' : ∀ x ∈ carrier, x⁻¹ ∈ carrier
-
-/-- Reinterpret a `Subfield` as a `Subring`. -/
-add_decl_doc Subfield.toSubring
-
-namespace Subfield
-
-/-- The underlying `AddSubgroup` of a subfield. -/
-def toAddSubgroup (s : Subfield K) : AddSubgroup K :=
-  { s.toSubring.toAddSubgroup with }
-
--- Porting note: toSubmonoid already exists
--- /-- The underlying submonoid of a subfield. -/
--- def toSubmonoid (s : Subfield K) : Submonoid K :=
---   { s.toSubring.toSubmonoid with }
-
-instance : SetLike (Subfield K) K where
-  coe s := s.carrier
-  coe_injective' p q h := by cases p; cases q; congr; exact SetLike.ext' h
-
-instance : SubfieldClass (Subfield K) K where
-  add_mem {s} := s.add_mem'
-  zero_mem s := s.zero_mem'
-  neg_mem {s} := s.neg_mem'
-  mul_mem {s} := s.mul_mem'
-  one_mem s := s.one_mem'
-  inv_mem {s} := s.inv_mem' _
-
-theorem mem_carrier {s : Subfield K} {x : K} : x ∈ s.carrier ↔ x ∈ s :=
-  Iff.rfl
-
--- Porting note: in lean 3, `S` was type `Set K`
-@[simp]
-theorem mem_mk {S : Subring K} {x : K} (h) : x ∈ (⟨S, h⟩ : Subfield K) ↔ x ∈ S :=
-  Iff.rfl
-
-@[simp]
-theorem coe_set_mk (S : Subring K) (h) : ((⟨S, h⟩ : Subfield K) : Set K) = S :=
-  rfl
-
-@[simp]
-theorem mk_le_mk {S S' : Subring K} (h h') : (⟨S, h⟩ : Subfield K) ≤ (⟨S', h'⟩ : Subfield K) ↔
-    S ≤ S' :=
-  Iff.rfl
-
-/-- Two subfields are equal if they have the same elements. -/
-@[ext]
-theorem ext {S T : Subfield K} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T :=
-  SetLike.ext h
-
-/-- Copy of a subfield with a new `carrier` equal to the old one. Useful to fix definitional
-equalities. -/
-protected def copy (S : Subfield K) (s : Set K) (hs : s = ↑S) : Subfield K :=
-  { S.toSubring.copy s hs with
-    carrier := s
-    inv_mem' := hs.symm ▸ S.inv_mem' }
-
-@[simp]
-theorem coe_copy (S : Subfield K) (s : Set K) (hs : s = ↑S) : (S.copy s hs : Set K) = s :=
-  rfl
-
-theorem copy_eq (S : Subfield K) (s : Set K) (hs : s = ↑S) : S.copy s hs = S :=
-  SetLike.coe_injective hs
-
-@[simp]
-theorem coe_toSubring (s : Subfield K) : (s.toSubring : Set K) = s :=
-  rfl
-
-@[simp]
-theorem mem_toSubring (s : Subfield K) (x : K) : x ∈ s.toSubring ↔ x ∈ s :=
-  Iff.rfl
-
-end Subfield
-
-/-- A `Subring` containing inverses is a `Subfield`. -/
-def Subring.toSubfield (s : Subring K) (hinv : ∀ x ∈ s, x⁻¹ ∈ s) : Subfield K :=
-  { s with inv_mem' := hinv }
-
 namespace Subfield
 
 variable (s t : Subfield K)
 
 section DerivedFromSubfieldClass
-
-/-- A subfield contains the field's 1. -/
-protected theorem one_mem : (1 : K) ∈ s :=
-  one_mem s
-
-/-- A subfield contains the field's 0. -/
-protected theorem zero_mem : (0 : K) ∈ s :=
-  zero_mem s
-
-/-- A subfield is closed under multiplication. -/
-protected theorem mul_mem {x y : K} : x ∈ s → y ∈ s → x * y ∈ s :=
-  mul_mem
-
-/-- A subfield is closed under addition. -/
-protected theorem add_mem {x y : K} : x ∈ s → y ∈ s → x + y ∈ s :=
-  add_mem
-
-/-- A subfield is closed under negation. -/
-protected theorem neg_mem {x : K} : x ∈ s → -x ∈ s :=
-  neg_mem
-
-/-- A subfield is closed under subtraction. -/
-protected theorem sub_mem {x y : K} : x ∈ s → y ∈ s → x - y ∈ s :=
-  sub_mem
-
-/-- A subfield is closed under inverses. -/
-protected theorem inv_mem {x : K} : x ∈ s → x⁻¹ ∈ s :=
-  inv_mem
-
-/-- A subfield is closed under division. -/
-protected theorem div_mem {x y : K} : x ∈ s → y ∈ s → x / y ∈ s :=
-  div_mem
 
 /-- Product of a list of elements in a subfield is in the subfield. -/
 protected theorem list_prod_mem {l : List K} : (∀ x ∈ l, x ∈ s) → l.prod ∈ s :=
@@ -281,111 +87,7 @@ protected theorem sum_mem {ι : Type*} {t : Finset ι} {f : ι → K} (h : ∀ c
     (∑ i ∈ t, f i) ∈ s :=
   sum_mem h
 
-protected theorem pow_mem {x : K} (hx : x ∈ s) (n : ℕ) : x ^ n ∈ s :=
-  pow_mem hx n
-
-protected theorem zsmul_mem {x : K} (hx : x ∈ s) (n : ℤ) : n • x ∈ s :=
-  zsmul_mem hx n
-
-protected theorem intCast_mem (n : ℤ) : (n : K) ∈ s := intCast_mem s n
-
-@[deprecated (since := "2024-04-05")] alias coe_int_mem := intCast_mem
-
-theorem zpow_mem {x : K} (hx : x ∈ s) (n : ℤ) : x ^ n ∈ s := by
-  cases n
-  · simpa using s.pow_mem hx _
-  · simpa [pow_succ'] using s.inv_mem (s.mul_mem hx (s.pow_mem hx _))
-
-instance : Ring s :=
-  s.toSubring.toRing
-
-instance : Div s :=
-  ⟨fun x y => ⟨x / y, s.div_mem x.2 y.2⟩⟩
-
-instance : Inv s :=
-  ⟨fun x => ⟨x⁻¹, s.inv_mem x.2⟩⟩
-
-instance : Pow s ℤ :=
-  ⟨fun x z => ⟨x ^ z, s.zpow_mem x.2 z⟩⟩
-
--- TODO: Those are just special cases of `SubfieldClass.toDivisionRing`/`SubfieldClass.toField`
-instance toDivisionRing (s : Subfield K) : DivisionRing s :=
-  Subtype.coe_injective.divisionRing ((↑) : s → K) rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
-    (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
-    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl)
-    (fun _ ↦ rfl) fun _ ↦ rfl
-
-/-- A subfield inherits a field structure -/
-instance toField {K} [Field K] (s : Subfield K) : Field s :=
-  Subtype.coe_injective.field ((↑) : s → K) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
-    (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ ↦ rfl) (fun _ => rfl)
-    (fun _ => rfl) (fun _ ↦ rfl) fun _ => rfl
-
-@[simp, norm_cast]
-theorem coe_add (x y : s) : (↑(x + y) : K) = ↑x + ↑y :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_sub (x y : s) : (↑(x - y) : K) = ↑x - ↑y :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_neg (x : s) : (↑(-x) : K) = -↑x :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_mul (x y : s) : (↑(x * y) : K) = ↑x * ↑y :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_div (x y : s) : (↑(x / y) : K) = ↑x / ↑y :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_inv (x : s) : (↑x⁻¹ : K) = (↑x)⁻¹ :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_zero : ((0 : s) : K) = 0 :=
-  rfl
-
-@[simp, norm_cast]
-theorem coe_one : ((1 : s) : K) = 1 :=
-  rfl
-
 end DerivedFromSubfieldClass
-
-/-- The embedding from a subfield of the field `K` to `K`. -/
-def subtype (s : Subfield K) : s →+* K :=
-  { s.toSubmonoid.subtype, s.toAddSubgroup.subtype with toFun := (↑) }
-
-@[simp]
-theorem coe_subtype : ⇑(s.subtype) = ((↑) : s → K) :=
-  rfl
-
-variable (K) in
-theorem toSubring_subtype_eq_subtype (S : Subfield K) :
-    S.toSubring.subtype = S.subtype :=
-  rfl
-
-/-! # Partial order -/
-
-
-theorem mem_toSubmonoid {s : Subfield K} {x : K} : x ∈ s.toSubmonoid ↔ x ∈ s :=
-  Iff.rfl
-
-@[simp]
-theorem coe_toSubmonoid : (s.toSubmonoid : Set K) = s :=
-  rfl
-
-@[simp]
-theorem mem_toAddSubgroup {s : Subfield K} {x : K} : x ∈ s.toAddSubgroup ↔ x ∈ s :=
-  Iff.rfl
-
-@[simp]
-theorem coe_toAddSubgroup : (s.toAddSubgroup : Set K) = s :=
-  rfl
 
 /-! # top -/
 

--- a/Mathlib/Algebra/Field/Subfield/Defs.lean
+++ b/Mathlib/Algebra/Field/Subfield/Defs.lean
@@ -1,0 +1,356 @@
+/-
+Copyright (c) 2020 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+import Mathlib.Algebra.Ring.Subring.Defs
+import Mathlib.Data.Rat.Cast.Defs
+
+/-!
+# Subfields
+
+Let `K` be a division ring, for example a field.
+This file defines the "bundled" subfield type `Subfield K`, a type
+whose terms correspond to subfields of `K`. Note we do not require the "subfields" to be
+commutative, so they are really sub-division rings / skew fields. This is the preferred way to talk
+about subfields in mathlib. Unbundled subfields (`s : Set K` and `IsSubfield s`)
+are not in this file, and they will ultimately be deprecated.
+
+We prove that subfields are a complete lattice, and that you can `map` (pushforward) and
+`comap` (pull back) them along ring homomorphisms.
+
+We define the `closure` construction from `Set K` to `Subfield K`, sending a subset of `K`
+to the subfield it generates, and prove that it is a Galois insertion.
+
+## Main definitions
+
+Notation used here:
+
+`(K : Type u) [DivisionRing K] (L : Type u) [DivisionRing L] (f g : K →+* L)`
+`(A : Subfield K) (B : Subfield L) (s : Set K)`
+
+* `Subfield K` : the type of subfields of a division ring `K`.
+
+## Implementation notes
+
+A subfield is implemented as a subring which is closed under `⁻¹`.
+
+Lattice inclusion (e.g. `≤` and `⊓`) is used rather than set notation (`⊆` and `∩`), although
+`∈` is defined as membership of a subfield's underlying set.
+
+## Tags
+subfield, subfields
+-/
+
+
+universe u v w
+
+variable {K : Type u} {L : Type v} {M : Type w}
+variable [DivisionRing K] [DivisionRing L] [DivisionRing M]
+
+/-- `SubfieldClass S K` states `S` is a type of subsets `s ⊆ K` closed under field operations. -/
+class SubfieldClass (S K : Type*) [DivisionRing K] [SetLike S K] extends SubringClass S K,
+  InvMemClass S K : Prop
+
+namespace SubfieldClass
+
+variable (S : Type*) [SetLike S K] [h : SubfieldClass S K]
+
+-- See note [lower instance priority]
+/-- A subfield contains `1`, products and inverses.
+
+Be assured that we're not actually proving that subfields are subgroups:
+`SubgroupClass` is really an abbreviation of `SubgroupWithOrWithoutZeroClass`.
+ -/
+instance (priority := 100) toSubgroupClass : SubgroupClass S K :=
+  { h with }
+
+variable {S} {x : K}
+
+@[aesop safe apply (rule_sets := [SetLike])]
+lemma nnratCast_mem (s : S) (q : ℚ≥0) : (q : K) ∈ s := by
+  simpa only [NNRat.cast_def] using div_mem (natCast_mem s q.num) (natCast_mem s q.den)
+
+@[aesop safe apply (rule_sets := [SetLike])]
+lemma ratCast_mem (s : S) (q : ℚ) : (q : K) ∈ s := by
+  simpa only [Rat.cast_def] using div_mem (intCast_mem s q.num) (natCast_mem s q.den)
+
+instance instNNRatCast (s : S) : NNRatCast s where nnratCast q := ⟨q, nnratCast_mem s q⟩
+instance instRatCast (s : S) : RatCast s where ratCast q := ⟨q, ratCast_mem s q⟩
+
+@[simp, norm_cast] lemma coe_nnratCast (s : S) (q : ℚ≥0) : ((q : s) : K) = q := rfl
+@[simp, norm_cast] lemma coe_ratCast (s : S) (x : ℚ) : ((x : s) : K) = x := rfl
+
+@[aesop safe apply (rule_sets := [SetLike])]
+lemma nnqsmul_mem (s : S) (q : ℚ≥0) (hx : x ∈ s) : q • x ∈ s := by
+  simpa only [NNRat.smul_def] using mul_mem (nnratCast_mem _ _) hx
+
+@[aesop safe apply (rule_sets := [SetLike])]
+lemma qsmul_mem (s : S) (q : ℚ) (hx : x ∈ s) : q • x ∈ s := by
+  simpa only [Rat.smul_def] using mul_mem (ratCast_mem _ _) hx
+
+@[deprecated (since := "2024-04-05")] alias coe_rat_cast := coe_ratCast
+@[deprecated (since := "2024-04-05")] alias coe_rat_mem := ratCast_mem
+@[deprecated (since := "2024-04-05")] alias rat_smul_mem := qsmul_mem
+
+@[aesop safe apply (rule_sets := [SetLike])]
+lemma ofScientific_mem (s : S) {b : Bool} {n m : ℕ} :
+    (OfScientific.ofScientific n b m : K) ∈ s :=
+  SubfieldClass.nnratCast_mem s (OfScientific.ofScientific n b m)
+
+instance instSMulNNRat (s : S) : SMul ℚ≥0 s where smul q x := ⟨q • x, nnqsmul_mem s q x.2⟩
+instance instSMulRat (s : S) : SMul ℚ s where smul q x := ⟨q • x, qsmul_mem s q x.2⟩
+
+@[simp, norm_cast] lemma coe_nnqsmul (s : S) (q : ℚ≥0) (x : s) : ↑(q • x) = q • (x : K) := rfl
+@[simp, norm_cast] lemma coe_qsmul (s : S) (q : ℚ) (x : s) : ↑(q • x) = q • (x : K) := rfl
+
+variable (S)
+
+/-- A subfield inherits a division ring structure -/
+instance (priority := 75) toDivisionRing (s : S) : DivisionRing s :=
+  Subtype.coe_injective.divisionRing ((↑) : s → K)
+    rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl)
+    (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+    (fun _ _ ↦ rfl) (coe_nnqsmul _) (coe_qsmul _) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+    (fun _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl)
+
+-- Prefer subclasses of `Field` over subclasses of `SubfieldClass`.
+/-- A subfield of a field inherits a field structure -/
+instance (priority := 75) toField {K} [Field K] [SetLike S K] [SubfieldClass S K] (s : S) :
+    Field s :=
+  Subtype.coe_injective.field ((↑) : s → K)
+    rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl)
+    (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+    (coe_nnqsmul _) (coe_qsmul _) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl)
+    (fun _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl)
+
+end SubfieldClass
+
+/-- `Subfield R` is the type of subfields of `R`. A subfield of `R` is a subset `s` that is a
+  multiplicative submonoid and an additive subgroup. Note in particular that it shares the
+  same 0 and 1 as R. -/
+structure Subfield (K : Type u) [DivisionRing K] extends Subring K where
+  /-- A subfield is closed under multiplicative inverses. -/
+  inv_mem' : ∀ x ∈ carrier, x⁻¹ ∈ carrier
+
+/-- Reinterpret a `Subfield` as a `Subring`. -/
+add_decl_doc Subfield.toSubring
+
+namespace Subfield
+
+/-- The underlying `AddSubgroup` of a subfield. -/
+def toAddSubgroup (s : Subfield K) : AddSubgroup K :=
+  { s.toSubring.toAddSubgroup with }
+
+-- Porting note: toSubmonoid already exists
+-- /-- The underlying submonoid of a subfield. -/
+-- def toSubmonoid (s : Subfield K) : Submonoid K :=
+--   { s.toSubring.toSubmonoid with }
+
+instance : SetLike (Subfield K) K where
+  coe s := s.carrier
+  coe_injective' p q h := by cases p; cases q; congr; exact SetLike.ext' h
+
+instance : SubfieldClass (Subfield K) K where
+  add_mem {s} := s.add_mem'
+  zero_mem s := s.zero_mem'
+  neg_mem {s} := s.neg_mem'
+  mul_mem {s} := s.mul_mem'
+  one_mem s := s.one_mem'
+  inv_mem {s} := s.inv_mem' _
+
+theorem mem_carrier {s : Subfield K} {x : K} : x ∈ s.carrier ↔ x ∈ s :=
+  Iff.rfl
+
+-- Porting note: in lean 3, `S` was type `Set K`
+@[simp]
+theorem mem_mk {S : Subring K} {x : K} (h) : x ∈ (⟨S, h⟩ : Subfield K) ↔ x ∈ S :=
+  Iff.rfl
+
+@[simp]
+theorem coe_set_mk (S : Subring K) (h) : ((⟨S, h⟩ : Subfield K) : Set K) = S :=
+  rfl
+
+@[simp]
+theorem mk_le_mk {S S' : Subring K} (h h') : (⟨S, h⟩ : Subfield K) ≤ (⟨S', h'⟩ : Subfield K) ↔
+    S ≤ S' :=
+  Iff.rfl
+
+/-- Two subfields are equal if they have the same elements. -/
+@[ext]
+theorem ext {S T : Subfield K} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T :=
+  SetLike.ext h
+
+/-- Copy of a subfield with a new `carrier` equal to the old one. Useful to fix definitional
+equalities. -/
+protected def copy (S : Subfield K) (s : Set K) (hs : s = ↑S) : Subfield K :=
+  { S.toSubring.copy s hs with
+    carrier := s
+    inv_mem' := hs.symm ▸ S.inv_mem' }
+
+@[simp]
+theorem coe_copy (S : Subfield K) (s : Set K) (hs : s = ↑S) : (S.copy s hs : Set K) = s :=
+  rfl
+
+theorem copy_eq (S : Subfield K) (s : Set K) (hs : s = ↑S) : S.copy s hs = S :=
+  SetLike.coe_injective hs
+
+@[simp]
+theorem coe_toSubring (s : Subfield K) : (s.toSubring : Set K) = s :=
+  rfl
+
+@[simp]
+theorem mem_toSubring (s : Subfield K) (x : K) : x ∈ s.toSubring ↔ x ∈ s :=
+  Iff.rfl
+
+end Subfield
+
+/-- A `Subring` containing inverses is a `Subfield`. -/
+def Subring.toSubfield (s : Subring K) (hinv : ∀ x ∈ s, x⁻¹ ∈ s) : Subfield K :=
+  { s with inv_mem' := hinv }
+
+namespace Subfield
+
+variable (s t : Subfield K)
+
+section DerivedFromSubfieldClass
+
+/-- A subfield contains the field's 1. -/
+protected theorem one_mem : (1 : K) ∈ s :=
+  one_mem s
+
+/-- A subfield contains the field's 0. -/
+protected theorem zero_mem : (0 : K) ∈ s :=
+  zero_mem s
+
+/-- A subfield is closed under multiplication. -/
+protected theorem mul_mem {x y : K} : x ∈ s → y ∈ s → x * y ∈ s :=
+  mul_mem
+
+/-- A subfield is closed under addition. -/
+protected theorem add_mem {x y : K} : x ∈ s → y ∈ s → x + y ∈ s :=
+  add_mem
+
+/-- A subfield is closed under negation. -/
+protected theorem neg_mem {x : K} : x ∈ s → -x ∈ s :=
+  neg_mem
+
+/-- A subfield is closed under subtraction. -/
+protected theorem sub_mem {x y : K} : x ∈ s → y ∈ s → x - y ∈ s :=
+  sub_mem
+
+/-- A subfield is closed under inverses. -/
+protected theorem inv_mem {x : K} : x ∈ s → x⁻¹ ∈ s :=
+  inv_mem
+
+/-- A subfield is closed under division. -/
+protected theorem div_mem {x y : K} : x ∈ s → y ∈ s → x / y ∈ s :=
+  div_mem
+
+protected theorem pow_mem {x : K} (hx : x ∈ s) (n : ℕ) : x ^ n ∈ s :=
+  pow_mem hx n
+
+protected theorem zsmul_mem {x : K} (hx : x ∈ s) (n : ℤ) : n • x ∈ s :=
+  zsmul_mem hx n
+
+protected theorem intCast_mem (n : ℤ) : (n : K) ∈ s := intCast_mem s n
+
+@[deprecated (since := "2024-04-05")] alias coe_int_mem := intCast_mem
+
+theorem zpow_mem {x : K} (hx : x ∈ s) (n : ℤ) : x ^ n ∈ s := by
+  cases n
+  · simpa using s.pow_mem hx _
+  · simpa [pow_succ'] using s.inv_mem (s.mul_mem hx (s.pow_mem hx _))
+
+instance : Ring s :=
+  s.toSubring.toRing
+
+instance : Div s :=
+  ⟨fun x y => ⟨x / y, s.div_mem x.2 y.2⟩⟩
+
+instance : Inv s :=
+  ⟨fun x => ⟨x⁻¹, s.inv_mem x.2⟩⟩
+
+instance : Pow s ℤ :=
+  ⟨fun x z => ⟨x ^ z, s.zpow_mem x.2 z⟩⟩
+
+-- TODO: Those are just special cases of `SubfieldClass.toDivisionRing`/`SubfieldClass.toField`
+instance toDivisionRing (s : Subfield K) : DivisionRing s :=
+  Subtype.coe_injective.divisionRing ((↑) : s → K) rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+    (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl)
+    (fun _ ↦ rfl) fun _ ↦ rfl
+
+/-- A subfield inherits a field structure -/
+instance toField {K} [Field K] (s : Subfield K) : Field s :=
+  Subtype.coe_injective.field ((↑) : s → K) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
+    (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ ↦ rfl) (fun _ => rfl)
+    (fun _ => rfl) (fun _ ↦ rfl) fun _ => rfl
+
+@[simp, norm_cast]
+theorem coe_add (x y : s) : (↑(x + y) : K) = ↑x + ↑y :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_sub (x y : s) : (↑(x - y) : K) = ↑x - ↑y :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_neg (x : s) : (↑(-x) : K) = -↑x :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_mul (x y : s) : (↑(x * y) : K) = ↑x * ↑y :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_div (x y : s) : (↑(x / y) : K) = ↑x / ↑y :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_inv (x : s) : (↑x⁻¹ : K) = (↑x)⁻¹ :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_zero : ((0 : s) : K) = 0 :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_one : ((1 : s) : K) = 1 :=
+  rfl
+
+end DerivedFromSubfieldClass
+
+/-- The embedding from a subfield of the field `K` to `K`. -/
+def subtype (s : Subfield K) : s →+* K :=
+  { s.toSubmonoid.subtype, s.toAddSubgroup.subtype with toFun := (↑) }
+
+@[simp]
+theorem coe_subtype : ⇑(s.subtype) = ((↑) : s → K) :=
+  rfl
+
+variable (K) in
+theorem toSubring_subtype_eq_subtype (S : Subfield K) :
+    S.toSubring.subtype = S.subtype :=
+  rfl
+
+/-! # Partial order -/
+
+
+theorem mem_toSubmonoid {s : Subfield K} {x : K} : x ∈ s.toSubmonoid ↔ x ∈ s :=
+  Iff.rfl
+
+@[simp]
+theorem coe_toSubmonoid : (s.toSubmonoid : Set K) = s :=
+  rfl
+
+@[simp]
+theorem mem_toAddSubgroup {s : Subfield K} {x : K} : x ∈ s.toAddSubgroup ↔ x ∈ s :=
+  Iff.rfl
+
+@[simp]
+theorem coe_toAddSubgroup : (s.toAddSubgroup : Set K) = s :=
+  rfl
+
+end Subfield

--- a/Mathlib/Algebra/Order/Field/Subfield.lean
+++ b/Mathlib/Algebra/Order/Field/Subfield.lean
@@ -5,7 +5,7 @@ Authors: Damiano Testa
 -/
 
 import Mathlib.Algebra.Order.Field.InjSurj
-import Mathlib.Algebra.Field.Subfield
+import Mathlib.Algebra.Field.Subfield.Defs
 
 /-!
 # Ordered instances on subfields

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -5,10 +5,10 @@ Authors: Patrick Massot, Johannes Hölzl
 -/
 import Mathlib.Algebra.Algebra.NonUnitalSubalgebra
 import Mathlib.Algebra.Algebra.Subalgebra.Basic
-import Mathlib.Algebra.Field.Subfield
 import Mathlib.Analysis.Normed.Group.Constructions
 import Mathlib.Analysis.Normed.Group.Submodule
 import Mathlib.Data.Set.Pointwise.Interval
+import Mathlib.Algebra.Field.Subfield.Defs
 
 /-!
 # Normed fields

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
-import Mathlib.Algebra.Field.Subfield
+import Mathlib.Algebra.Field.Subfield.Basic
 import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.RingTheory.LocalRing.Basic
 

--- a/Mathlib/NumberTheory/NumberField/Completion.lean
+++ b/Mathlib/NumberTheory/NumberField/Completion.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Salvatore Mercuri. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Salvatore Mercuri
 -/
-import Mathlib.Algebra.Field.Subfield
+import Mathlib.Algebra.Field.Subfield.Basic
 import Mathlib.Algebra.Ring.WithAbs
 import Mathlib.Analysis.Normed.Module.Completion
 import Mathlib.NumberTheory.NumberField.Embeddings

--- a/Mathlib/SetTheory/Cardinal/Subfield.lean
+++ b/Mathlib/SetTheory/Cardinal/Subfield.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Junyan Xu. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Junyan Xu
 -/
-import Mathlib.Algebra.Field.Subfield
+import Mathlib.Algebra.Field.Subfield.Basic
 import Mathlib.Data.W.Cardinal
 import Mathlib.Tactic.FinCases
 

--- a/Mathlib/Topology/Algebra/Field.lean
+++ b/Mathlib/Topology/Algebra/Field.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Kim Morrison
 -/
-import Mathlib.Algebra.Field.Subfield
+import Mathlib.Algebra.Field.Subfield.Basic
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Topology.Algebra.GroupWithZero
 import Mathlib.Topology.Algebra.Ring.Basic

--- a/Mathlib/Topology/Algebra/UniformField.lean
+++ b/Mathlib/Topology/Algebra/UniformField.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot
 -/
-import Mathlib.Algebra.Field.Subfield
+import Mathlib.Algebra.Field.Subfield.Basic
 import Mathlib.Topology.Algebra.Field
 import Mathlib.Topology.Algebra.UniformRing
 

--- a/MathlibTest/set_like.lean
+++ b/MathlibTest/set_like.lean
@@ -1,4 +1,4 @@
-import Mathlib.Algebra.Field.Subfield
+import Mathlib.Algebra.Field.Subfield.Basic
 import Mathlib.Algebra.Star.Subalgebra
 import Mathlib.Algebra.Star.SelfAdjoint
 import Mathlib.Algebra.Star.NonUnitalSubalgebra


### PR DESCRIPTION
This PR splits off a `Defs.lean` file from `Subfield.lean` containing on the definition and field structure of `Subfield`(`Class`).

This PR was motivated by the "hoard factor" computation that showed https://github.com/leanprover-community/mathlib4/pull/18520 increased the factor of `Mathlib.Algebra.Order.Field.Subfield` by a lot, meaning there are many transitive imports in that file whose declarations remain unused. The previous PR increased it from 0,814203 to 0,828997, this PR reduces it down to 0,784072

---

- [ ] depends on: #18520 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
