### PR TITLE
[Merged by Bors] - refactor(Multiset): drop `Multiset.Disjoint`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -2079,7 +2079,7 @@ end List
 namespace Multiset
 
 theorem disjoint_list_sum_left {a : Multiset α} {l : List (Multiset α)} :
-    Multiset.Disjoint l.sum a ↔ ∀ b ∈ l, Multiset.Disjoint b a := by
+    Disjoint l.sum a ↔ ∀ b ∈ l, Disjoint b a := by
   induction l with
   | nil =>
     simp only [zero_disjoint, List.not_mem_nil, IsEmpty.forall_iff, forall_const, List.sum_nil]
@@ -2088,26 +2088,26 @@ theorem disjoint_list_sum_left {a : Multiset α} {l : List (Multiset α)} :
     simp [and_congr_left_iff, ih]
 
 theorem disjoint_list_sum_right {a : Multiset α} {l : List (Multiset α)} :
-    Multiset.Disjoint a l.sum ↔ ∀ b ∈ l, Multiset.Disjoint a b := by
-  simpa only [@disjoint_comm _ a] using disjoint_list_sum_left
+    Disjoint a l.sum ↔ ∀ b ∈ l, Disjoint a b := by
+  simpa only [disjoint_comm (a := a)] using disjoint_list_sum_left
 
 theorem disjoint_sum_left {a : Multiset α} {i : Multiset (Multiset α)} :
-    Multiset.Disjoint i.sum a ↔ ∀ b ∈ i, Multiset.Disjoint b a :=
+    Disjoint i.sum a ↔ ∀ b ∈ i, Disjoint b a :=
   Quotient.inductionOn i fun l => by
     rw [quot_mk_to_coe, Multiset.sum_coe]
     exact disjoint_list_sum_left
 
 theorem disjoint_sum_right {a : Multiset α} {i : Multiset (Multiset α)} :
-    Multiset.Disjoint a i.sum ↔ ∀ b ∈ i, Multiset.Disjoint a b := by
-  simpa only [@disjoint_comm _ a] using disjoint_sum_left
+    Disjoint a i.sum ↔ ∀ b ∈ i, Disjoint a b := by
+  simpa only [disjoint_comm (a := a)] using disjoint_sum_left
 
 theorem disjoint_finset_sum_left {β : Type*} {i : Finset β} {f : β → Multiset α} {a : Multiset α} :
-    Multiset.Disjoint (i.sum f) a ↔ ∀ b ∈ i, Multiset.Disjoint (f b) a := by
+    Disjoint (i.sum f) a ↔ ∀ b ∈ i, Disjoint (f b) a := by
   convert @disjoint_sum_left _ a (map f i.val)
   simp [and_congr_left_iff]
 
 theorem disjoint_finset_sum_right {β : Type*} {i : Finset β} {f : β → Multiset α}
-    {a : Multiset α} : Multiset.Disjoint a (i.sum f) ↔ ∀ b ∈ i, Multiset.Disjoint a (f b) := by
+    {a : Multiset α} : Disjoint a (i.sum f) ↔ ∀ b ∈ i, Disjoint a (f b) := by
   simpa only [disjoint_comm] using disjoint_finset_sum_left
 
 @[simp]

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -135,7 +135,7 @@ theorem mem_degrees {p : MvPolynomial σ R} {i : σ} :
   classical
   simp only [degrees_def, Multiset.mem_sup, ← mem_support_iff, Finsupp.mem_toMultiset, exists_prop]
 
-theorem le_degrees_add {p q : MvPolynomial σ R} (h : p.degrees.Disjoint q.degrees) :
+theorem le_degrees_add {p q : MvPolynomial σ R} (h : Disjoint p.degrees q.degrees) :
     p.degrees ≤ (p + q).degrees := by
   classical
   apply Finset.sup_le
@@ -154,7 +154,7 @@ theorem le_degrees_add {p q : MvPolynomial σ R} (h : p.degrees.Disjoint q.degre
     all_goals rw [mem_degrees]; refine ⟨d, ?_, hj⟩; assumption
 
 theorem degrees_add_of_disjoint [DecidableEq σ] {p q : MvPolynomial σ R}
-    (h : Multiset.Disjoint p.degrees q.degrees) : (p + q).degrees = p.degrees ∪ q.degrees := by
+    (h : Disjoint p.degrees q.degrees) : (p + q).degrees = p.degrees ∪ q.degrees := by
   apply le_antisymm
   · apply degrees_add
   · apply Multiset.union_le

--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -550,10 +550,8 @@ end Fintype
 
 namespace Multiset
 
-theorem finset_sum_eq_sup_iff_disjoint [DecidableEq α] {β : Type*} {i : Finset β}
-    {f : β → Multiset α} :
-    i.sum f = i.sup f ↔
-      ∀ᵉ (x ∈ i) (y ∈ i), x ≠ y → Multiset.Disjoint (f x) (f y) := by
+theorem finset_sum_eq_sup_iff_disjoint [DecidableEq α] {i : Finset β} {f : β → Multiset α} :
+    i.sum f = i.sup f ↔ ∀ x ∈ i, ∀ y ∈ i, x ≠ y → Disjoint (f x) (f y) := by
   induction' i using Finset.cons_induction_on with z i hz hr
   · simp only [Finset.not_mem_empty, IsEmpty.forall_iff, imp_true_iff, Finset.sum_empty,
       Finset.sup_empty, bot_eq_zero, eq_self_iff_true]
@@ -566,7 +564,7 @@ theorem finset_sum_eq_sup_iff_disjoint [DecidableEq α] {β : Type*} {i : Finset
       and_self_iff]
     exact add_eq_union_left_of_le (Finset.sup_le fun x hx => le_sum_of_mem (mem_map_of_mem f hx))
 
-theorem sup_powerset_len {α : Type*} [DecidableEq α] (x : Multiset α) :
+theorem sup_powerset_len [DecidableEq α] (x : Multiset α) :
     (Finset.sup (Finset.range (card x + 1)) fun k => x.powersetCard k) = x.powerset := by
   convert bind_powerset_len x using 1
   rw [Multiset.bind, Multiset.join, ← Finset.range_val, ← Finset.sum_eq_multiset_sum]

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -867,8 +867,8 @@ theorem disjoint_iff_ne : Disjoint s t ↔ ∀ a ∈ s, ∀ b ∈ t, a ≠ b := 
   simp only [disjoint_left, imp_not_comm, forall_eq']
 
 @[simp]
-theorem disjoint_val : s.1.Disjoint t.1 ↔ Disjoint s t :=
-  disjoint_left.symm
+theorem disjoint_val : Disjoint s.1 t.1 ↔ Disjoint s t :=
+  Multiset.disjoint_left.trans disjoint_left.symm
 
 theorem _root_.Disjoint.forall_ne_finset (h : Disjoint s t) (ha : a ∈ s) (hb : b ∈ t) : a ≠ b :=
   disjoint_iff_ne.1 h _ ha _ hb
@@ -3111,15 +3111,10 @@ namespace Multiset
 
 variable [DecidableEq α]
 
+@[simp]
 theorem disjoint_toFinset {m1 m2 : Multiset α} :
-    _root_.Disjoint m1.toFinset m2.toFinset ↔ m1.Disjoint m2 := by
-  rw [Finset.disjoint_iff_ne]
-  refine ⟨fun h a ha1 ha2 => ?_, ?_⟩
-  · rw [← Multiset.mem_toFinset] at ha1 ha2
-    exact h _ ha1 _ ha2 rfl
-  · rintro h a ha b hb rfl
-    rw [Multiset.mem_toFinset] at ha hb
-    exact h ha hb
+    _root_.Disjoint m1.toFinset m2.toFinset ↔ Disjoint m1 m2 := by
+  simp [disjoint_left, Finset.disjoint_left]
 
 end Multiset
 
@@ -3127,8 +3122,9 @@ namespace List
 
 variable [DecidableEq α] {l l' : List α}
 
+@[simp]
 theorem disjoint_toFinset_iff_disjoint : _root_.Disjoint l.toFinset l'.toFinset ↔ l.Disjoint l' :=
-  Multiset.disjoint_toFinset
+  Multiset.disjoint_toFinset.trans (Multiset.coe_disjoint _ _)
 
 end List
 

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -2609,61 +2609,59 @@ end Quot
 
 
 /-- `Disjoint s t` means that `s` and `t` have no elements in common. -/
-def Disjoint (s t : Multiset α) : Prop :=
+@[deprecated _root_.Disjoint (since := "2024-11-01")]
+protected def Disjoint (s t : Multiset α) : Prop :=
   ∀ ⦃a⦄, a ∈ s → a ∈ t → False
 
-@[simp]
-theorem coe_disjoint (l₁ l₂ : List α) : @Disjoint α l₁ l₂ ↔ l₁.Disjoint l₂ :=
-  Iff.rfl
+theorem disjoint_left {s t : Multiset α} : Disjoint s t ↔ ∀ {a}, a ∈ s → a ∉ t := by
+  refine ⟨fun h a hs ht ↦ ?_, fun h u hs ht ↦ ?_⟩
+  · simpa using h (singleton_le.mpr hs) (singleton_le.mpr ht)
+  · rw [le_bot_iff, bot_eq_zero, eq_zero_iff_forall_not_mem]
+    exact fun a ha ↦ h (subset_of_le hs ha) (subset_of_le ht ha)
 
-@[symm]
-theorem Disjoint.symm {s t : Multiset α} (d : Disjoint s t) : Disjoint t s
-  | _a, i₂, i₁ => d i₁ i₂
+@[simp, norm_cast]
+theorem coe_disjoint (l₁ l₂ : List α) : Disjoint (l₁ : Multiset α) l₂ ↔ l₁.Disjoint l₂ :=
+  disjoint_left
 
-theorem disjoint_comm {s t : Multiset α} : Disjoint s t ↔ Disjoint t s :=
-  ⟨Disjoint.symm, Disjoint.symm⟩
-
-theorem disjoint_left {s t : Multiset α} : Disjoint s t ↔ ∀ {a}, a ∈ s → a ∉ t :=
-  Iff.rfl
+@[deprecated (since := "2024-11-01")] protected alias Disjoint.symm := _root_.Disjoint.symm
+@[deprecated (since := "2024-11-01")] protected alias disjoint_comm := _root_.disjoint_comm
 
 theorem disjoint_right {s t : Multiset α} : Disjoint s t ↔ ∀ {a}, a ∈ t → a ∉ s :=
-  disjoint_comm
+  disjoint_comm.trans disjoint_left
 
 theorem disjoint_iff_ne {s t : Multiset α} : Disjoint s t ↔ ∀ a ∈ s, ∀ b ∈ t, a ≠ b := by
   simp [disjoint_left, imp_not_comm]
 
-theorem disjoint_of_subset_left {s t u : Multiset α} (h : s ⊆ u) (d : Disjoint u t) : Disjoint s t
-  | _x, m₁ => d (h m₁)
+theorem disjoint_of_subset_left {s t u : Multiset α} (h : s ⊆ u) (d : Disjoint u t) :
+    Disjoint s t :=
+  disjoint_left.mpr fun ha ↦ disjoint_left.mp d <| h ha
 
-theorem disjoint_of_subset_right {s t u : Multiset α} (h : t ⊆ u) (d : Disjoint s u) : Disjoint s t
-  | _x, m, m₁ => d m (h m₁)
+theorem disjoint_of_subset_right {s t u : Multiset α} (h : t ⊆ u) (d : Disjoint s u) :
+    Disjoint s t :=
+  (disjoint_of_subset_left h d.symm).symm
 
-theorem disjoint_of_le_left {s t u : Multiset α} (h : s ≤ u) : Disjoint u t → Disjoint s t :=
-  disjoint_of_subset_left (subset_of_le h)
-
-theorem disjoint_of_le_right {s t u : Multiset α} (h : t ≤ u) : Disjoint s u → Disjoint s t :=
-  disjoint_of_subset_right (subset_of_le h)
+@[deprecated (since := "2024-11-01")] protected alias disjoint_of_le_left := Disjoint.mono_left
+@[deprecated (since := "2024-11-01")] protected alias disjoint_of_le_right := Disjoint.mono_right
 
 @[simp]
-theorem zero_disjoint (l : Multiset α) : Disjoint 0 l
-  | a => (not_mem_nil a).elim
+theorem zero_disjoint (l : Multiset α) : Disjoint 0 l := disjoint_bot_left
 
 @[simp]
 theorem singleton_disjoint {l : Multiset α} {a : α} : Disjoint {a} l ↔ a ∉ l := by
-  simp [Disjoint]
+  simp [disjoint_left]
 
 @[simp]
 theorem disjoint_singleton {l : Multiset α} {a : α} : Disjoint l {a} ↔ a ∉ l := by
-  rw [disjoint_comm, singleton_disjoint]
+  rw [_root_.disjoint_comm, singleton_disjoint]
 
 @[simp]
 theorem disjoint_add_left {s t u : Multiset α} :
-    Disjoint (s + t) u ↔ Disjoint s u ∧ Disjoint t u := by simp [Disjoint, or_imp, forall_and]
+    Disjoint (s + t) u ↔ Disjoint s u ∧ Disjoint t u := by simp [disjoint_left, or_imp, forall_and]
 
 @[simp]
 theorem disjoint_add_right {s t u : Multiset α} :
     Disjoint s (t + u) ↔ Disjoint s t ∧ Disjoint s u := by
-  rw [disjoint_comm, disjoint_add_left]; tauto
+  rw [_root_.disjoint_comm, disjoint_add_left]; tauto
 
 @[simp]
 theorem disjoint_cons_left {a : α} {s t : Multiset α} :
@@ -2673,18 +2671,18 @@ theorem disjoint_cons_left {a : α} {s t : Multiset α} :
 @[simp]
 theorem disjoint_cons_right {a : α} {s t : Multiset α} :
     Disjoint s (a ::ₘ t) ↔ a ∉ s ∧ Disjoint s t := by
-  rw [disjoint_comm, disjoint_cons_left]; tauto
+  rw [_root_.disjoint_comm, disjoint_cons_left]; tauto
 
 theorem inter_eq_zero_iff_disjoint [DecidableEq α] {s t : Multiset α} :
-    s ∩ t = 0 ↔ Disjoint s t := by rw [← subset_zero]; simp [subset_iff, Disjoint]
+    s ∩ t = 0 ↔ Disjoint s t := by rw [← subset_zero]; simp [subset_iff, disjoint_left]
 
 @[simp]
 theorem disjoint_union_left [DecidableEq α] {s t u : Multiset α} :
-    Disjoint (s ∪ t) u ↔ Disjoint s u ∧ Disjoint t u := by simp [Disjoint, or_imp, forall_and]
+    Disjoint (s ∪ t) u ↔ Disjoint s u ∧ Disjoint t u :=  disjoint_sup_left
 
 @[simp]
 theorem disjoint_union_right [DecidableEq α] {s t u : Multiset α} :
-    Disjoint s (t ∪ u) ↔ Disjoint s t ∧ Disjoint s u := by simp [Disjoint, or_imp, forall_and]
+    Disjoint s (t ∪ u) ↔ Disjoint s t ∧ Disjoint s u := disjoint_sup_right
 
 theorem add_eq_union_iff_disjoint [DecidableEq α] {s t : Multiset α} :
     s + t = s ∪ t ↔ Disjoint s t := by
@@ -2692,7 +2690,7 @@ theorem add_eq_union_iff_disjoint [DecidableEq α] {s t : Multiset α} :
     Nat.min_eq_zero_iff, Nat.add_eq_max_iff]
 
 lemma add_eq_union_left_of_le [DecidableEq α] {s t u : Multiset α} (h : t ≤ s) :
-    u + s = u ∪ t ↔ u.Disjoint s ∧ s = t := by
+    u + s = u ∪ t ↔ Disjoint u s ∧ s = t := by
   rw [← add_eq_union_iff_disjoint]
   refine ⟨fun h0 ↦ ?_, ?_⟩
   · rw [and_iff_right_of_imp]
@@ -2703,12 +2701,12 @@ lemma add_eq_union_left_of_le [DecidableEq α] {s t u : Multiset α} (h : t ≤ 
     exact h0
 
 lemma add_eq_union_right_of_le [DecidableEq α] {x y z : Multiset α} (h : z ≤ y) :
-    x + y = x ∪ z ↔ y = z ∧ x.Disjoint y := by
+    x + y = x ∪ z ↔ y = z ∧ Disjoint x y := by
   simpa only [and_comm] using add_eq_union_left_of_le h
 
 theorem disjoint_map_map {f : α → γ} {g : β → γ} {s : Multiset α} {t : Multiset β} :
     Disjoint (s.map f) (t.map g) ↔ ∀ a ∈ s, ∀ b ∈ t, f a ≠ g b := by
-  simp [Disjoint, @eq_comm _ (f _) (g _)]
+  simp [disjoint_iff_ne]
 
 /-- `Pairwise r m` states that there exists a list of the elements s.t. `r` holds pairwise on this
 list. -/

--- a/Mathlib/Data/Multiset/Dedup.lean
+++ b/Mathlib/Data/Multiset/Dedup.lean
@@ -124,7 +124,7 @@ theorem Subset.dedup_add_left {s t : Multiset α} (h : t ⊆ s) :
 theorem Disjoint.dedup_add {s t : Multiset α} (h : Disjoint s t) :
     dedup (s + t) = dedup s + dedup t := by
   induction s, t using Quot.induction_on₂
-  exact congr_arg ((↑) : List α → Multiset α) <| List.Disjoint.dedup_append h
+  exact congr_arg ((↑) : List α → Multiset α) <| List.Disjoint.dedup_append (by simpa using h)
 
 /-- Note that the stronger `List.Subset.dedup_append_right` is proved earlier. -/
 theorem _root_.List.Subset.dedup_append_left {s t : List α} (h : t ⊆ s) :

--- a/Mathlib/Data/Multiset/FinsetOps.lean
+++ b/Mathlib/Data/Multiset/FinsetOps.lean
@@ -108,12 +108,12 @@ theorem attach_ndinsert (a : α) (s : Multiset α) :
 @[simp]
 theorem disjoint_ndinsert_left {a : α} {s t : Multiset α} :
     Disjoint (ndinsert a s) t ↔ a ∉ t ∧ Disjoint s t :=
-  Iff.trans (by simp [Disjoint]) disjoint_cons_left
+  Iff.trans (by simp [disjoint_left]) disjoint_cons_left
 
 @[simp]
 theorem disjoint_ndinsert_right {a : α} {s t : Multiset α} :
     Disjoint s (ndinsert a t) ↔ a ∉ s ∧ Disjoint s t := by
-  rw [disjoint_comm, disjoint_ndinsert_left]; tauto
+  rw [_root_.disjoint_comm, disjoint_ndinsert_left]; tauto
 
 /-! ### finset union -/
 
@@ -179,7 +179,7 @@ theorem dedup_add (s t : Multiset α) : dedup (s + t) = ndunion s (dedup t) :=
 theorem Disjoint.ndunion_eq {s t : Multiset α} (h : Disjoint s t) :
     s.ndunion t = s.dedup + t := by
   induction s, t using Quot.induction_on₂
-  exact congr_arg ((↑) : List α → Multiset α) <| List.Disjoint.union_eq h
+  exact congr_arg ((↑) : List α → Multiset α) <| List.Disjoint.union_eq <| by simpa using h
 
 theorem Subset.ndunion_eq_right {s t : Multiset α} (h : s ⊆ t) : s.ndunion t = t := by
   induction s, t using Quot.induction_on₂
@@ -243,7 +243,7 @@ theorem ndinter_eq_inter {s t : Multiset α} (d : Nodup s) : ndinter s t = s ∩
   le_antisymm (le_inter (ndinter_le_left _ _) (ndinter_le_right _ d)) (inter_le_ndinter _ _)
 
 theorem ndinter_eq_zero_iff_disjoint {s t : Multiset α} : ndinter s t = 0 ↔ Disjoint s t := by
-  rw [← subset_zero]; simp [subset_iff, Disjoint]
+  rw [← subset_zero]; simp [subset_iff, disjoint_left]
 
 alias ⟨_, Disjoint.ndinter_eq_zero⟩ := ndinter_eq_zero_iff_disjoint
 

--- a/Mathlib/Data/Multiset/Nodup.lean
+++ b/Mathlib/Data/Multiset/Nodup.lean
@@ -95,7 +95,7 @@ theorem Pairwise.forall (H : Symmetric r) (hs : Pairwise r s) :
   hl₁.symm ▸ hl₂.forall H
 
 theorem nodup_add {s t : Multiset α} : Nodup (s + t) ↔ Nodup s ∧ Nodup t ∧ Disjoint s t :=
-  Quotient.inductionOn₂ s t fun _ _ => nodup_append
+  Quotient.inductionOn₂ s t fun _ _ => by simp [nodup_append]
 
 theorem disjoint_of_nodup_add {s t : Multiset α} (d : Nodup (s + t)) : Disjoint s t :=
   (nodup_add.1 d).2.2

--- a/Mathlib/Data/Multiset/Powerset.lean
+++ b/Mathlib/Data/Multiset/Powerset.lean
@@ -262,9 +262,9 @@ theorem powersetCard_map {β : Type*} (f : α → β) (n : ℕ) (s : Multiset α
   · cases n <;> simp [ih, map_comp_cons]
 
 theorem pairwise_disjoint_powersetCard (s : Multiset α) :
-    _root_.Pairwise fun i j => Multiset.Disjoint (s.powersetCard i) (s.powersetCard j) :=
-  fun _ _ h _ hi hj =>
-  h (Eq.trans (Multiset.mem_powersetCard.mp hi).right.symm (Multiset.mem_powersetCard.mp hj).right)
+    _root_.Pairwise fun i j => Disjoint (s.powersetCard i) (s.powersetCard j) :=
+  fun _ _ h ↦ disjoint_left.mpr fun hi hj ↦
+    h ((Multiset.mem_powersetCard.mp hi).2.symm.trans (Multiset.mem_powersetCard.mp hj).2)
 
 theorem bind_powerset_len {α : Type*} (S : Multiset α) :
     (bind (Multiset.range (card S + 1)) fun k => S.powersetCard k) = S.powerset := by

--- a/Mathlib/Data/Multiset/Range.lean
+++ b/Mathlib/Data/Multiset/Range.lean
@@ -50,7 +50,8 @@ theorem range_add (a b : ℕ) : range (a + b) = range a + (range b).map (a + ·)
   congr_arg ((↑) : List ℕ → Multiset ℕ) (List.range_add _ _)
 
 theorem range_disjoint_map_add (a : ℕ) (m : Multiset ℕ) :
-    (range a).Disjoint (m.map (a + ·)) := by
+    Disjoint (range a) (m.map (a + ·)) := by
+  rw [disjoint_left]
   intro x hxa hxb
   rw [range, mem_coe, List.mem_range] at hxa
   obtain ⟨c, _, rfl⟩ := mem_map.1 hxb

--- a/Mathlib/Data/Multiset/Sum.lean
+++ b/Mathlib/Data/Multiset/Sum.lean
@@ -86,10 +86,8 @@ theorem disjSum_strictMono_right (s : Multiset α) :
   disjSum_lt_disjSum_of_le_of_lt le_rfl
 
 protected theorem Nodup.disjSum (hs : s.Nodup) (ht : t.Nodup) : (s.disjSum t).Nodup := by
-  refine ((hs.map inl_injective).add_iff <| ht.map inr_injective).2 fun x hs ht => ?_
-  rw [Multiset.mem_map] at hs ht
-  obtain ⟨a, _, rfl⟩ := hs
-  obtain ⟨b, _, h⟩ := ht
-  exact inr_ne_inl h
+  refine ((hs.map inl_injective).add_iff <| ht.map inr_injective).2 ?_
+  rw [disjoint_map_map]
+  exact fun _ _ _ _ ↦ inr_ne_inl.symm
 
 end Multiset

--- a/Mathlib/Order/Interval/Multiset.lean
+++ b/Mathlib/Order/Interval/Multiset.lean
@@ -235,10 +235,10 @@ theorem Ioo_cons_left (h : a < b) : a ::ₘ Ioo a b = Ico a b := by
     rw [Ioo, ← Finset.insert_val_of_not_mem left_not_mem_Ioo, Finset.Ioo_insert_left h]
     rfl
 
-theorem Ico_disjoint_Ico {a b c d : α} (h : b ≤ c) : (Ico a b).Disjoint (Ico c d) :=
-  fun x hab hbc => by
-  rw [mem_Ico] at hab hbc
-  exact hab.2.not_le (h.trans hbc.1)
+theorem Ico_disjoint_Ico {a b c d : α} (h : b ≤ c) : Disjoint (Ico a b) (Ico c d) :=
+  disjoint_left.mpr fun hab hbc => by
+    rw [mem_Ico] at hab hbc
+    exact hab.2.not_le (h.trans hbc.1)
 
 @[simp]
 theorem Ico_inter_Ico_of_le [DecidableEq α] {a b c d : α} (h : b ≤ c) : Ico a b ∩ Ico c d = 0 :=

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -138,7 +138,8 @@ variable {R : Type*} [CommRing R] [IsDomain R] [NormalizationMonoid R]
 
 /-- Coprime elements have disjoint prime factors (as multisets). -/
 theorem disjoint_normalizedFactors {a b : R} (hc : IsCoprime a b) :
-    (normalizedFactors a).Disjoint (normalizedFactors b) := by
+    Disjoint (normalizedFactors a) (normalizedFactors b) := by
+  rw [Multiset.disjoint_left]
   intro x hxa hxb
   have x_dvd_a := dvd_of_mem_normalizedFactors hxa
   have x_dvd_b := dvd_of_mem_normalizedFactors hxb
@@ -164,7 +165,7 @@ theorem radical_neg_one : radical (-1 : R) = 1 :=
 
 /-- Radical is multiplicative for coprime elements. -/
 theorem radical_mul {a b : R} (hc : IsCoprime a b) :
-    radical (a * b) = (radical a) * (radical b) := by
+    radical (a * b) = radical a * radical b := by
   by_cases ha : a = 0
   · subst ha; rw [isCoprime_zero_left] at hc
     simp only [zero_mul, radical_zero_eq, one_mul, radical_unit_eq_one hc]


### PR DESCRIPTION
Use `_root_.Disjoint` instead.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
