### PR TITLE
[Merged by Bors] - feat(SetTheory/Cardinal/Arithmetic): fix namespace of `mk_iUnion_Ordinal_le_of_le`

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Cardinal/Arithmetic.lean
@@ -837,7 +837,7 @@ lemma mk_iUnion_Ordinal_le_of_le {β : Type*} {o : Ordinal} {c : Cardinal}
 
 end Cardinal
 
-@[deprecated mk_iUnion_Ordinal_le_of_le (since := "2024-08-30")]
+@[deprecated mk_iUnion_Ordinal_le_of_le (since := "2024-11-02")]
 alias Ordinal.Cardinal.mk_iUnion_Ordinal_le_of_le := mk_iUnion_Ordinal_le_of_le
 
 /-! ### Cardinality of ordinals -/

--- a/Mathlib/SetTheory/Cardinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Cardinal/Arithmetic.lean
@@ -815,7 +815,30 @@ theorem extend_function_of_lt {α β : Type*} {s : Set α} (f : s ↪ β) (hs : 
 
 end extend
 
+/-! ### Cardinal operations with ordinal indices -/
+
+/-- Bounds the cardinal of an ordinal-indexed union of sets. -/
+lemma mk_iUnion_Ordinal_lift_le_of_le {β : Type v} {o : Ordinal.{u}} {c : Cardinal.{v}}
+    (ho : lift.{v} o.card ≤ lift.{u} c) (hc : ℵ₀ ≤ c) (A : Ordinal → Set β)
+    (hA : ∀ j < o, #(A j) ≤ c) : #(⋃ j < o, A j) ≤ c := by
+  simp_rw [← mem_Iio, biUnion_eq_iUnion, iUnion, iSup, ← o.enumIsoToType.symm.surjective.range_comp]
+  rw [← lift_le.{u}]
+  apply ((mk_iUnion_le_lift _).trans _).trans_eq (mul_eq_self (aleph0_le_lift.2 hc))
+  rw [mk_toType]
+  refine mul_le_mul' ho (ciSup_le' ?_)
+  intro i
+  simpa using hA _ (o.enumIsoToType.symm i).2
+
+lemma mk_iUnion_Ordinal_le_of_le {β : Type*} {o : Ordinal} {c : Cardinal}
+    (ho : o.card ≤ c) (hc : ℵ₀ ≤ c) (A : Ordinal → Set β)
+    (hA : ∀ j < o, #(A j) ≤ c) : #(⋃ j < o, A j) ≤ c := by
+  apply mk_iUnion_Ordinal_lift_le_of_le _ hc A hA
+  rwa [Cardinal.lift_le]
+
 end Cardinal
+
+@[deprecated mk_iUnion_Ordinal_le_of_le (since := "2024-08-30")]
+alias Ordinal.Cardinal.mk_iUnion_Ordinal_le_of_le := mk_iUnion_Ordinal_le_of_le
 
 /-! ### Cardinality of ordinals -/
 
@@ -849,30 +872,4 @@ theorem card_iSup_Iio_le_card_mul_iSup {o : Ordinal.{u}} (f : Ordinal.{u} → Or
   · exact mk_toType o
   · exact (enumIsoToType o).symm.iSup_comp (g := fun x ↦ (f x.1).card)
 
-end Ordinal
-
-/-!
-### Cardinal operations with ordinal indices
-
-Results on cardinality of ordinal-indexed families of sets.
--/
-
-namespace Ordinal
-namespace Cardinal
-
-open scoped Cardinal
-
-/--
-Bounding the cardinal of an ordinal-indexed union of sets.
--/
-lemma mk_iUnion_Ordinal_le_of_le {β : Type*} {o : Ordinal} {c : Cardinal}
-    (ho : o.card ≤ c) (hc : ℵ₀ ≤ c) (A : Ordinal → Set β)
-    (hA : ∀ j < o, #(A j) ≤ c) :
-    #(⋃ j < o, A j) ≤ c := by
-  simp_rw [← mem_Iio, biUnion_eq_iUnion, iUnion, iSup, ← o.enumIsoToType.symm.surjective.range_comp]
-  apply ((mk_iUnion_le _).trans _).trans_eq (mul_eq_self hc)
-  rw [mk_toType]
-  exact mul_le_mul' ho <| ciSup_le' <| (hA _ <| typein_lt_self ·)
-
-end Cardinal
 end Ordinal


### PR DESCRIPTION
This was previously in the `Ordinal.Cardinal` namespace, it's now been moved to simply the `Cardinal` namespace.

Also add the universe-polymorphic version of this lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
