### PR TITLE
[Merged by Bors] - chore(Logic/Small/Basic): add `assert_not_exists`

### DIFF
--- a/Mathlib/Logic/Small/Basic.lean
+++ b/Mathlib/Logic/Small/Basic.lean
@@ -12,10 +12,9 @@ import Mathlib.Logic.Equiv.Set
 In particular we prove `small_of_injective` and `small_of_surjective`.
 -/
 
+assert_not_exists Countable
+
 universe u w v v'
-
-section
-
 
 -- TODO(timotree3): lower the priority on this instance?
 -- This instance applies to every synthesis problem of the form `Small ↥s` for some set `s`,
@@ -66,5 +65,3 @@ instance small_sum {α β} [Small.{w} α] [Small.{w} β] : Small.{w} (α ⊕ β)
 
 instance small_set {α} [Small.{w} α] : Small.{w} (Set α) :=
   ⟨⟨Set (Shrink α), ⟨Equiv.Set.congr (equivShrink α)⟩⟩⟩
-
-end


### PR DESCRIPTION
A docstring in this file reads:

```
We don't define `Countable.toSmall` in this file, to keep imports to `Logic` to a minimum.
```

We enforce this by adding `assert_not_exists Countable`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
