### PR TITLE
[Merged by Bors] - doc(Logic/Small/Defs): document `Small.{u, max u v}` instance

### DIFF
--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -71,7 +71,9 @@ theorem small_lift (α : Type u) [hα : Small.{v} α] : Small.{max v w} α :=
   let ⟨⟨_, ⟨f⟩⟩⟩ := hα
   Small.mk' <| f.trans (Equiv.ulift.{w}).symm
 
-/- This was an instance but useless due to https://github.com/leanprover/lean4/issues/2297. -/
+/-- Due to https://github.com/leanprover/lean4/issues/2297, this is useless as an instance.
+
+See however `Logic.UnivLE`, whose API is able to indirectly provide this instance. -/
 lemma small_max (α : Type v) : Small.{max w v} α :=
   small_lift.{v, w} α
 

--- a/Mathlib/Logic/UnivLE.lean
+++ b/Mathlib/Logic/UnivLE.lean
@@ -11,6 +11,9 @@ import Mathlib.Logic.Small.Defs
 A proposition expressing a universe inequality. `UnivLE.{u, v}` expresses that `u ≤ v`,
 in the form `∀ α : Type u, Small.{v} α`.
 
+This API indirectly provides an instance for `Small.{u, max u v}`, which could not be declared
+directly due to https://github.com/leanprover/lean4/issues/2297.
+
 See the doc-string for the comparison with an alternative stronger definition.
 -/
 


### PR DESCRIPTION
Counterintuitively, we're able to state this theorem before we're able to make it into an instance in an entirely different file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
