### PR TITLE
[Merged by Bors] - feat(Data/Real/Cardinality): `Uncountable ℝ`

### DIFF
--- a/Mathlib/Data/Real/Cardinality.lean
+++ b/Mathlib/Data/Real/Cardinality.lean
@@ -204,9 +204,8 @@ instance : Uncountable ℝ := by
   rw [← aleph0_lt_mk_iff, mk_real]
   exact aleph0_lt_continuum
 
-theorem not_countable_real : ¬(Set.univ : Set ℝ).Countable := by
-  rw [← le_aleph0_iff_set_countable, not_le, mk_univ_real]
-  apply cantor
+theorem not_countable_real : ¬(Set.univ : Set ℝ).Countable :=
+  not_countable_univ
 
 /-- The cardinality of the interval (a, ∞). -/
 theorem mk_Ioi_real (a : ℝ) : #(Ioi a) = 𝔠 := by

--- a/Mathlib/Data/Real/Cardinality.lean
+++ b/Mathlib/Data/Real/Cardinality.lean
@@ -200,6 +200,10 @@ theorem mk_real : #ℝ = 𝔠 := by
 theorem mk_univ_real : #(Set.univ : Set ℝ) = 𝔠 := by rw [mk_univ, mk_real]
 
 /-- **Non-Denumerability of the Continuum**: The reals are not countable. -/
+instance : Uncountable ℝ := by
+  rw [← aleph0_lt_mk_iff, mk_real]
+  exact aleph0_lt_continuum
+
 theorem not_countable_real : ¬(Set.univ : Set ℝ).Countable := by
   rw [← le_aleph0_iff_set_countable, not_le, mk_univ_real]
   apply cantor

--- a/Mathlib/Data/Set/Countable.lean
+++ b/Mathlib/Data/Set/Countable.lean
@@ -128,11 +128,17 @@ protected theorem countable_iff_exists_surjective {s : Set α} (hs : s.Nonempty)
 
 alias ⟨Countable.exists_surjective, _⟩ := Set.countable_iff_exists_surjective
 
+theorem countable_univ_iff : (univ : Set α).Countable ↔ Countable α :=
+  countable_coe_iff.symm.trans (Equiv.Set.univ _).countable_iff
+
 theorem countable_univ [Countable α] : (univ : Set α).Countable :=
   to_countable univ
 
-theorem countable_univ_iff : (univ : Set α).Countable ↔ Countable α :=
-  countable_coe_iff.symm.trans (Equiv.Set.univ _).countable_iff
+theorem not_countable_univ_iff : ¬ (univ : Set α).Countable ↔ Uncountable α := by
+  rw [countable_univ_iff, not_countable_iff]
+
+theorem not_countable_univ [Uncountable α] : ¬ (univ : Set α).Countable :=
+  not_countable_univ_iff.2 ‹_›
 
 /-- If `s : Set α` is a nonempty countable set, then there exists a map
 `f : ℕ → α` such that `s = range f`. -/

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -1590,6 +1590,13 @@ theorem le_aleph0_iff_subtype_countable {p : α → Prop} :
     #{ x // p x } ≤ ℵ₀ ↔ { x | p x }.Countable :=
   le_aleph0_iff_set_countable
 
+theorem aleph0_lt_mk_iff : ℵ₀ < #α ↔ Uncountable α := by
+  rw [← not_le, ← not_countable_iff, not_iff_not, mk_le_aleph0_iff]
+
+@[simp]
+theorem aleph0_lt_mk [Uncountable α] : ℵ₀ < #a :=
+  aleph0_lt_mk_iff.mpr <_>
+
 instance canLiftCardinalNat : CanLift Cardinal ℕ (↑) fun x => x < ℵ₀ :=
   ⟨fun _ hx =>
     let ⟨n, hn⟩ := lt_aleph0.mp hx

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -1594,8 +1594,8 @@ theorem aleph0_lt_mk_iff : ℵ₀ < #α ↔ Uncountable α := by
   rw [← not_le, ← not_countable_iff, not_iff_not, mk_le_aleph0_iff]
 
 @[simp]
-theorem aleph0_lt_mk [Uncountable α] : ℵ₀ < #a :=
-  aleph0_lt_mk_iff.mpr <_>
+theorem aleph0_lt_mk [Uncountable α] : ℵ₀ < #α :=
+  aleph0_lt_mk_iff.mpr ‹_›
 
 instance canLiftCardinalNat : CanLift Cardinal ℕ (↑) fun x => x < ℵ₀ :=
   ⟨fun _ hx =>


### PR DESCRIPTION
We were somehow missing this spelling of that theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
