### PR TITLE
[Merged by Bors] - chore: all variants of `limitOpIsoOpColimit`

### DIFF
--- a/Mathlib/CategoryTheory/Limits/IndYoneda.lean
+++ b/Mathlib/CategoryTheory/Limits/IndYoneda.lean
@@ -38,45 +38,6 @@ open Opposite
 
 variable {C : Type u₁} [Category.{u₂} C] {I : Type v₁} [Category.{v₂} I]
 
-section LimitOpColimit
-
-/-- The limit of `F.op` is the opposite of `colimit F`. -/
-noncomputable def limitOpIsoOpColimit (F : I ⥤ C) [HasColimit F] :
-    limit F.op ≅ op <| colimit F :=
-  limit.isoLimitCone ⟨(colimit.cocone F).op, (colimit.isColimit F).op⟩
-
-@[reassoc (attr := simp)]
-lemma limitOpIsoOpColimit_inv_comp_π (F : I ⥤ C) [HasColimit F] (i : I) :
-    (limitOpIsoOpColimit F).inv ≫ limit.π F.op ⟨i⟩ = (colimit.ι F i).op := by
-  simp [limitOpIsoOpColimit]
-
-@[reassoc (attr := simp)]
-lemma limitOpIsoOpColimit_hom_comp_ι (F : I ⥤ C) [HasColimit F] (i : I) :
-    (limitOpIsoOpColimit F).hom ≫ (colimit.ι F i).op = limit.π F.op ⟨i⟩ := by
-  rw [← limitOpIsoOpColimit_inv_comp_π, ← Category.assoc, Iso.hom_inv_id, Category.id_comp]
-
-instance (F : Iᵒᵖ ⥤ C) [HasColimit F] : HasLimit F.rightOp where
-  exists_limit := ⟨⟨coneRightOpOfCocone (colimit.cocone F),
-    isLimitConeRightOpOfCocone F (colimit.isColimit F)⟩⟩
-
-/-- `limitOpIsoOpColimit` for contravariant functor. -/
-noncomputable def limitRightOpIsoOpColimit (F : Iᵒᵖ ⥤ C) [HasColimit F] :
-    limit F.rightOp ≅ op <| colimit F :=
-  limit.isoLimitCone ⟨coneRightOpOfCocone (colimit.cocone F),
-    isLimitConeRightOpOfCocone F (colimit.isColimit F)⟩
-
-@[reassoc (attr := simp)]
-lemma limitRightOpIsoOpColimit_inv_comp_π (F : Iᵒᵖ ⥤ C) [HasColimit F] (i : I) :
-    (limitRightOpIsoOpColimit F).inv ≫ limit.π F.rightOp i = (colimit.ι F ⟨i⟩).op := by
-  simp [limitRightOpIsoOpColimit]
-
-@[reassoc (attr := simp)]
-lemma limitRightOpIsoOpColimit_hom_comp_ι (F : Iᵒᵖ ⥤ C) [HasColimit F] (i : I) :
-    (limitRightOpIsoOpColimit F).hom ≫ (colimit.ι F ⟨i⟩).op = limit.π F.rightOp i := by
-  rw [← limitRightOpIsoOpColimit_inv_comp_π, ← Category.assoc, Iso.hom_inv_id, Category.id_comp]
-
-end LimitOpColimit
-
 section HomCocontinuousCovariant
 
 variable (F : I ⥤ C) [HasColimit F]

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -213,6 +213,66 @@ instance hasLimit_unop_of_hasColimit (F : Jᵒᵖ ⥤ Cᵒᵖ) [HasColimit F] : 
     { cone := coneUnopOfCocone (colimit.cocone F)
       isLimit := isLimitConeUnopOfCocone _ (colimit.isColimit _) }
 
+/-- The limit of `F.op` is the opposite of `colimit F`. -/
+def limitOpIsoOpColimit (F : J ⥤ C) [HasColimit F] :
+    limit F.op ≅ op (colimit F) :=
+  limit.isoLimitCone ⟨_, (colimit.isColimit _).op⟩
+
+@[reassoc (attr := simp)]
+lemma limitOpIsoOpColimit_inv_comp_π (F : J ⥤ C) [HasColimit F] (j : Jᵒᵖ) :
+    (limitOpIsoOpColimit F).inv ≫ limit.π F.op j = (colimit.ι F j.unop).op := by
+  simp [limitOpIsoOpColimit]
+
+@[reassoc (attr := simp)]
+lemma limitOpIsoOpColimit_hom_comp_ι (F : J ⥤ C) [HasColimit F] (j : J) :
+    (limitOpIsoOpColimit F).hom ≫ (colimit.ι F j).op = limit.π F.op (op j) := by
+  simp [← Iso.eq_inv_comp]
+
+/-- The limit of `F.leftOp` is the unopposite of `colimit F`. -/
+def limitLeftOpIsoUnopColimit (F : J ⥤ Cᵒᵖ) [HasColimit F] :
+    limit F.leftOp ≅ unop (colimit F) :=
+  limit.isoLimitCone ⟨_, isLimitConeLeftOpOfCocone _ (colimit.isColimit _)⟩
+
+@[reassoc (attr := simp)]
+lemma limitLeftOpIsoUnopColimit_inv_comp_π (F : J ⥤ Cᵒᵖ) [HasColimit F] (j : Jᵒᵖ) :
+    (limitLeftOpIsoUnopColimit F).inv ≫ limit.π F.leftOp j = (colimit.ι F j.unop).unop := by
+  simp [limitLeftOpIsoUnopColimit]
+
+@[reassoc (attr := simp)]
+lemma limitLeftOpIsoUnopColimit_hom_comp_ι (F : J ⥤ Cᵒᵖ) [HasColimit F] (j : J) :
+    (limitLeftOpIsoUnopColimit F).hom ≫ (colimit.ι F j).unop = limit.π F.leftOp (op j) := by
+  simp [← Iso.eq_inv_comp]
+
+/-- The limit of `F.rightOp` is the opposite of `colimit F`. -/
+def limitRightOpIsoOpColimit (F : Jᵒᵖ ⥤ C) [HasColimit F] :
+    limit F.rightOp ≅ op (colimit F) :=
+  limit.isoLimitCone ⟨_, isLimitConeRightOpOfCocone _ (colimit.isColimit _)⟩
+
+@[reassoc (attr := simp)]
+lemma limitRightOpIsoOpColimit_inv_comp_π (F : Jᵒᵖ ⥤ C) [HasColimit F] (j : J) :
+    (limitRightOpIsoOpColimit F).inv ≫ limit.π F.rightOp j = (colimit.ι F (op j)).op := by
+  simp [limitRightOpIsoOpColimit]
+
+@[reassoc (attr := simp)]
+lemma limitRightOpIsoOpColimit_hom_comp_ι (F : Jᵒᵖ ⥤ C) [HasColimit F] (j : Jᵒᵖ) :
+    (limitRightOpIsoOpColimit F).hom ≫ (colimit.ι F j).op = limit.π F.rightOp j.unop := by
+  simp [← Iso.eq_inv_comp]
+
+/-- The limit of `F.unop` is the unopposite of `colimit F`. -/
+def limitUnopIsoUnopColimit (F : Jᵒᵖ ⥤ Cᵒᵖ) [HasColimit F] :
+    limit F.unop ≅ unop (colimit F) :=
+  limit.isoLimitCone ⟨_, isLimitConeUnopOfCocone _ (colimit.isColimit _)⟩
+
+@[reassoc (attr := simp)]
+lemma limitUnopIsoUnopColimit_inv_comp_π (F : Jᵒᵖ ⥤ Cᵒᵖ) [HasColimit F] (j : J) :
+    (limitUnopIsoUnopColimit F).inv ≫ limit.π F.unop j = (colimit.ι F (op j)).unop := by
+  simp [limitUnopIsoUnopColimit]
+
+@[reassoc (attr := simp)]
+lemma limitUnopIsoUnopColimit_hom_comp_ι (F : Jᵒᵖ ⥤ Cᵒᵖ) [HasColimit F] (j : Jᵒᵖ) :
+    (limitUnopIsoUnopColimit F).hom ≫ (colimit.ι F j).unop = limit.π F.unop j.unop := by
+  simp [← Iso.eq_inv_comp]
+
 /-- If `C` has colimits of shape `Jᵒᵖ`, we can construct limits in `Cᵒᵖ` of shape `J`.
 -/
 theorem hasLimitsOfShape_op_of_hasColimitsOfShape [HasColimitsOfShape Jᵒᵖ C] :
@@ -281,6 +341,66 @@ instance hasColimit_unop_of_hasLimit (F : Jᵒᵖ ⥤ Cᵒᵖ) [HasLimit F] : Ha
   HasColimit.mk
     { cocone := coconeUnopOfCone (limit.cone F)
       isColimit := isColimitCoconeUnopOfCone _ (limit.isLimit _) }
+
+/-- The colimit of `F.op` is the opposite of `limit F`. -/
+def colimitOpIsoOpLimit (F : J ⥤ C) [HasLimit F] :
+    colimit F.op ≅ op (limit F) :=
+  colimit.isoColimitCocone ⟨_, (limit.isLimit _).op⟩
+
+@[reassoc (attr := simp)]
+lemma ι_comp_colimitOpIsoOpLimit_hom (F : J ⥤ C) [HasLimit F] (j : Jᵒᵖ) :
+    colimit.ι F.op j ≫ (colimitOpIsoOpLimit F).hom = (limit.π F j.unop).op := by
+  simp [colimitOpIsoOpLimit]
+
+@[reassoc (attr := simp)]
+lemma π_comp_colimitOpIsoOpLimit_inv (F : J ⥤ C) [HasLimit F] (j : J) :
+    (limit.π F j).op ≫ (colimitOpIsoOpLimit F).inv = colimit.ι F.op (op j) := by
+  simp [Iso.comp_inv_eq]
+
+/-- The colimit of `F.leftOp` is the unopposite of `limit F`. -/
+def colimitLeftOpIsoUnopLimit (F : J ⥤ Cᵒᵖ) [HasLimit F] :
+    colimit F.leftOp ≅ unop (limit F) :=
+  colimit.isoColimitCocone ⟨_, isColimitCoconeLeftOpOfCone _ (limit.isLimit _)⟩
+
+@[reassoc (attr := simp)]
+lemma ι_comp_colimitLeftOpIsoUnopLimit_hom (F : J ⥤ Cᵒᵖ) [HasLimit F] (j : Jᵒᵖ) :
+    colimit.ι F.leftOp j ≫ (colimitLeftOpIsoUnopLimit F).hom = (limit.π F j.unop).unop := by
+  simp [colimitLeftOpIsoUnopLimit]
+
+@[reassoc (attr := simp)]
+lemma π_comp_colimitLeftOpIsoUnopLimit_inv (F : J ⥤ Cᵒᵖ) [HasLimit F] (j : J) :
+    (limit.π F j).unop ≫ (colimitLeftOpIsoUnopLimit F).inv = colimit.ι F.leftOp (op j) := by
+  simp [Iso.comp_inv_eq]
+
+/-- The colimit of `F.rightOp` is the opposite of `limit F`. -/
+def colimitRightOpIsoUnopLimit (F : Jᵒᵖ ⥤ C) [HasLimit F] :
+    colimit F.rightOp ≅ op (limit F) :=
+  colimit.isoColimitCocone ⟨_, isColimitCoconeRightOpOfCone _ (limit.isLimit _)⟩
+
+@[reassoc (attr := simp)]
+lemma ι_comp_colimitRightOpIsoUnopLimit_hom (F : Jᵒᵖ ⥤ C) [HasLimit F] (j : J) :
+    colimit.ι F.rightOp j ≫ (colimitRightOpIsoUnopLimit F).hom = (limit.π F (op j)).op := by
+  simp [colimitRightOpIsoUnopLimit]
+
+@[reassoc (attr := simp)]
+lemma π_comp_colimitRightOpIsoUnopLimit_inv (F : Jᵒᵖ ⥤ C) [HasLimit F] (j : Jᵒᵖ) :
+    (limit.π F j).op ≫ (colimitRightOpIsoUnopLimit F).inv = colimit.ι F.rightOp j.unop := by
+  simp [Iso.comp_inv_eq]
+
+/-- The colimit of `F.unop` is the unopposite of `limit F`. -/
+def colimitUnopIsoOpLimit (F : Jᵒᵖ ⥤ Cᵒᵖ) [HasLimit F] :
+    colimit F.unop ≅ unop (limit F) :=
+  colimit.isoColimitCocone ⟨_, isColimitCoconeUnopOfCone _ (limit.isLimit _)⟩
+
+@[reassoc (attr := simp)]
+lemma ι_comp_colimitUnopIsoOpLimit_hom (F : Jᵒᵖ ⥤ Cᵒᵖ) [HasLimit F] (j : J) :
+    colimit.ι F.unop j ≫ (colimitUnopIsoOpLimit F).hom = (limit.π F (op j)).unop := by
+  simp [colimitUnopIsoOpLimit]
+
+@[reassoc (attr := simp)]
+lemma π_comp_colimitUnopIsoOpLimit_inv (F : Jᵒᵖ ⥤ Cᵒᵖ) [HasLimit F] (j : Jᵒᵖ) :
+    (limit.π F j).unop ≫ (colimitUnopIsoOpLimit F).inv = colimit.ι F.unop j.unop := by
+  simp [Iso.comp_inv_eq]
 
 /-- If `C` has colimits of shape `Jᵒᵖ`, we can construct limits in `Cᵒᵖ` of shape `J`.
 -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
