### PR TITLE
[Merged by Bors] - feat(RingTheory/Ideal/Over): Action of stabilizer on quotient

### DIFF
--- a/Mathlib/RingTheory/Ideal/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Over.lean
@@ -493,6 +493,7 @@ namespace Quotient
 
 variable (R : Type*) [CommSemiring R] {A B : Type*} [CommRing A] [CommRing B] [Algebra A B]
   [Algebra R A] [Algebra R B] [IsScalarTower R A B] (P : Ideal B) (p : Ideal A) [P.LiesOver p]
+  (G : Type*) [Group G] [MulSemiringAction G B] [SMulCommClass G A B]
 
 /-- If `P` lies over `p`, then canonically `B ⧸ P` is a `A ⧸ p`-algebra. -/
 instance algebraOfLiesOver : Algebra (A ⧸ p) (B ⧸ P) :=
@@ -526,6 +527,24 @@ theorem algebraMap_injective_of_liesOver :
 
 instance [P.IsPrime] : NoZeroSMulDivisors (A ⧸ p) (B ⧸ P) :=
   NoZeroSMulDivisors.of_algebraMap_injective (Quotient.algebraMap_injective_of_liesOver P p)
+
+/-- If `P` lies over `p`, then the stabilizer of `P` acts on the extension `(B ⧸ P) / (A ⧸ p). -/
+def stabilizerHom : MulAction.stabilizer G P →* ((B ⧸ P) ≃ₐ[A ⧸ p] (B ⧸ P)) where
+  toFun g :=
+  { __ := Ideal.quotientEquiv P P (MulSemiringAction.toRingEquiv G B g) g.2.symm
+    commutes' := fun q ↦ by
+      obtain ⟨a, rfl⟩ := Ideal.Quotient.mk_surjective q
+      simp [← Ideal.Quotient.algebraMap_eq, ← IsScalarTower.algebraMap_apply] }
+  map_one' := AlgEquiv.ext (fun q ↦ by
+    obtain ⟨b, rfl⟩ := Ideal.Quotient.mk_surjective q
+    simp)
+  map_mul' g h := AlgEquiv.ext (fun q ↦ by
+    obtain ⟨b, rfl⟩ := Ideal.Quotient.mk_surjective q
+    simp [mul_smul])
+
+@[simp] theorem stabilizerHom_apply (g : MulAction.stabilizer G P) (b : B) :
+    stabilizerHom P p G g b = ↑(g • b) :=
+  rfl
 
 end Quotient
 


### PR DESCRIPTION
For `P` lying over `p`, this PR adds a homomorphism `MulAction.stabilizer G P →* ((B ⧸ P) ≃ₐ[A ⧸ p] (B ⧸ P))`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
