### PR TITLE
[Merged by Bors] - chore: `Pi.single` and `MultilinearMap.piFamily`

### DIFF
--- a/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
@@ -137,7 +137,7 @@ theorem dfinsuppFamily_single [∀ i, DecidableEq (κ i)]
 the component from that member. -/
 @[simp]
 theorem dfinsuppFamily_single_left_apply [∀ i, DecidableEq (κ i)]
-    (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) (x) :
+    (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) (x : Π i, Π₀ j, M i j) :
     dfinsuppFamily (Pi.single p f) x = DFinsupp.single p (f fun i => x _ (p i)) := by
   ext p'
   obtain rfl | hp := eq_or_ne p p'

--- a/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
@@ -137,7 +137,7 @@ theorem dfinsuppFamily_single [∀ i, DecidableEq (κ i)]
 the component from that member. -/
 @[simp]
 theorem dfinsuppFamily_single_left_apply [∀ i, DecidableEq (κ i)]
-    (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) (x):
+    (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) (x) :
     dfinsuppFamily (Pi.single p f) x = DFinsupp.single p (f fun i => x _ (p i)) := by
   ext p'
   obtain rfl | hp := eq_or_ne p p'

--- a/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
@@ -133,6 +133,23 @@ theorem dfinsuppFamily_single [∀ i, DecidableEq (κ i)]
     apply (f q).map_coord_zero i
     simp_rw [DFinsupp.single_eq_of_ne hpqi]
 
+/-- When only one member of the family of linear maps is nonzero, the result consists only of the
+component from that member. -/
+@[simp]
+theorem dfinsuppFamily_single_left_apply [∀ i, DecidableEq (κ i)]
+    (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) (x):
+    dfinsuppFamily (Pi.single p f) x = DFinsupp.single p (f fun i => x _ (p i)) := by
+  ext p'
+  obtain rfl | hp := eq_or_ne p p'
+  · simp
+  · simp [hp]
+
+theorem dfinsuppFamily_single_left [∀ i, DecidableEq (κ i)]
+    (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) :
+    dfinsuppFamily (Pi.single p f) =
+      (DFinsupp.lsingle p).compMultilinearMap (f.compLinearMap fun i => DFinsupp.lapply (p i)) :=
+  ext <| dfinsuppFamily_single_left_apply _ _
+
 @[simp]
 theorem dfinsuppFamily_compLinearMap_lsingle [∀ i, DecidableEq (κ i)]
     (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p)) (p : ∀ i, κ i) :

--- a/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/DFinsupp.lean
@@ -133,8 +133,8 @@ theorem dfinsuppFamily_single [∀ i, DecidableEq (κ i)]
     apply (f q).map_coord_zero i
     simp_rw [DFinsupp.single_eq_of_ne hpqi]
 
-/-- When only one member of the family of linear maps is nonzero, the result consists only of the
-component from that member. -/
+/-- When only one member of the family of multilinear maps is nonzero, the result consists only of
+the component from that member. -/
 @[simp]
 theorem dfinsuppFamily_single_left_apply [∀ i, DecidableEq (κ i)]
     (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) (x):

--- a/Mathlib/LinearAlgebra/Multilinear/Pi.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Pi.lean
@@ -99,6 +99,23 @@ theorem piFamily_single [Fintype ι] [∀ i, DecidableEq (κ i)]
     apply (f q).map_coord_zero i
     simp_rw [Pi.single_eq_of_ne' hpqi]
 
+/-- When only one member of the family of linear maps is nonzero, the result consists only of the
+component from that member. -/
+@[simp]
+theorem piFamily_single_left_apply [Fintype ι] [∀ i, DecidableEq (κ i)]
+    (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) (x : Π i j, M i j) :
+    piFamily (Pi.single p f) x = Pi.single p (f fun i => x i (p i)) := by
+  ext p'
+  obtain rfl | hp := eq_or_ne p p'
+  · simp
+  · simp [hp]
+
+theorem piFamily_single_left [Fintype ι] [∀ i, DecidableEq (κ i)]
+    (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) :
+    piFamily (Pi.single p f) =
+      (LinearMap.single R _ p).compMultilinearMap (f.compLinearMap fun i => .proj (p i)) :=
+  ext <| piFamily_single_left_apply _ _
+
 @[simp]
 theorem piFamily_compLinearMap_lsingle [Fintype ι] [∀ i, DecidableEq (κ i)]
     (f : Π (p : Π i, κ i), MultilinearMap R (fun i ↦ M i (p i)) (N p)) (p : ∀ i, κ i) :

--- a/Mathlib/LinearAlgebra/Multilinear/Pi.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Pi.lean
@@ -99,8 +99,8 @@ theorem piFamily_single [Fintype ι] [∀ i, DecidableEq (κ i)]
     apply (f q).map_coord_zero i
     simp_rw [Pi.single_eq_of_ne' hpqi]
 
-/-- When only one member of the family of linear maps is nonzero, the result consists only of the
-component from that member. -/
+/-- When only one member of the family of multilinear maps is nonzero, the result consists only of
+the component from that member. -/
 @[simp]
 theorem piFamily_single_left_apply [Fintype ι] [∀ i, DecidableEq (κ i)]
     (p : Π i, κ i) (f : MultilinearMap R (fun i ↦ M i (p i)) (N p)) (x : Π i j, M i j) :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
