### PR TITLE
[Merged by Bors] - chore(OnePoint): use `induction_eliminator`

### DIFF
--- a/Mathlib/Topology/Compactification/OnePoint.lean
+++ b/Mathlib/Topology/Compactification/OnePoint.lean
@@ -106,11 +106,11 @@ theorem infty_ne_coe (x : X) : ∞ ≠ (x : OnePoint X) :=
   nofun
 
 /-- Recursor for `OnePoint` using the preferred forms `∞` and `↑x`. -/
-@[elab_as_elim]
-protected def rec {C : OnePoint X → Sort*} (h₁ : C ∞) (h₂ : ∀ x : X, C x) :
+@[elab_as_elim, induction_eliminator, cases_eliminator]
+protected def rec {C : OnePoint X → Sort*} (infty : C ∞) (coe : ∀ x : X, C x) :
     ∀ z : OnePoint X, C z
-  | ∞ => h₁
-  | (x : X) => h₂ x
+  | ∞ => infty
+  | (x : X) => coe x
 
 /-- An elimination principle for `OnePoint`. -/
 @[inline] protected def elim : OnePoint X → Y → (X → Y) → Y := Option.elim
@@ -541,12 +541,12 @@ instance (X : Type*) [TopologicalSpace X] [DiscreteTopology X] :
     TotallySeparatedSpace (OnePoint X) where
   isTotallySeparated_univ x _ y _ hxy := by
     cases x with
-    | none =>
+    | infty =>
       refine ⟨{y}ᶜ, {y}, isOpen_compl_singleton, ?_, hxy, rfl, (compl_union_self _).symm.subset,
         disjoint_compl_left⟩
       rw [OnePoint.isOpen_iff_of_not_mem]
       exacts [isOpen_discrete _, hxy]
-    | some val =>
+    | coe val =>
       refine ⟨{some val}, {some val}ᶜ, ?_, isOpen_compl_singleton, rfl, hxy.symm, by simp,
         disjoint_compl_right⟩
       rw [OnePoint.isOpen_iff_of_not_mem]

--- a/Mathlib/Topology/Compactification/OnePointEquiv.lean
+++ b/Mathlib/Topology/Compactification/OnePointEquiv.lean
@@ -35,24 +35,23 @@ variable (K : Type*) [DivisionRing K] [DecidableEq K]
  the projectivivization `ℙ K (K × K)`. -/
 def equivProjectivization :
     OnePoint K ≃ ℙ K (K × K) where
-  toFun p := Option.elim p (mk K (1, 0) (by simp)) (fun t ↦ mk K (t, 1) (by simp))
+  toFun p := p.elim (mk K (1, 0) (by simp)) (fun t ↦ mk K (t, 1) (by simp))
   invFun p := by
     refine Projectivization.lift
-      (fun u : {v : K × K // v ≠ 0} ↦ if u.1.2 ≠ 0 then ((u.1.2)⁻¹ * u.1.1) else ∞) ?_ p
+      (fun u : {v : K × K // v ≠ 0} ↦ if u.1.2 = 0 then ∞ else ((u.1.2)⁻¹ * u.1.1)) ?_ p
     rintro ⟨-, hv⟩ ⟨⟨x, y⟩, hw⟩ t rfl
     have ht : t ≠ 0 := by rintro rfl; simp at hv
     by_cases h₀ : y = 0 <;> simp [h₀, ht, mul_assoc]
-  left_inv p := by cases p <;> simp [OnePoint.infty, OnePoint.some]
+  left_inv p := by cases p <;> simp
   right_inv p := by
     induction' p using ind with p hp
     obtain ⟨x, y⟩ := p
-    by_cases h₀ : y = 0 <;>
-    simp only [Option.elim, ne_eq, ite_not, h₀, Projectivization.lift_mk, reduceIte]
-    · have h₀' : x ≠ 0 := by aesop
-      simp only [mk_eq_mk_iff, Prod.smul_mk, smul_zero, Prod.mk.injEq, and_true]
-      exact ⟨Units.mk0 _ (inv_ne_zero h₀'), by simp [h₀']⟩
-    · simp only [mk_eq_mk_iff, Prod.smul_mk, Prod.mk.injEq]
-      exact ⟨Units.mk0 _ (inv_ne_zero h₀), by simp [h₀]⟩
+    by_cases h₀ : y = 0 <;> simp only [mk_eq_mk_iff', h₀, Projectivization.lift_mk, if_true,
+      if_false, OnePoint.elim_infty, OnePoint.elim_some, Prod.smul_mk, Prod.mk.injEq, smul_eq_mul,
+      mul_zero, and_true]
+    · use x⁻¹
+      simp_all
+    · exact ⟨y⁻¹, rfl, inv_mul_cancel₀ h₀⟩
 
 @[simp]
 lemma equivProjectivization_apply_infinity :


### PR DESCRIPTION
- Add `@[induction_eliminator, cases_eliminator]` to `OnePoint.rec`.
- Rename arguments of `OnePoint.rec`.
- Use `OnePoint.elim` instead of `Option.elim` in
  `equivProjectivization`.
- Golf a bit.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)