### PR TITLE
[Merged by Bors] - feat(GroupTheory/SpecificGroups/ZGroup): Predicate for groups whose Sylow subgroups are all cyclic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3027,6 +3027,7 @@ import Mathlib.GroupTheory.SpecificGroups.Cyclic
 import Mathlib.GroupTheory.SpecificGroups.Dihedral
 import Mathlib.GroupTheory.SpecificGroups.KleinFour
 import Mathlib.GroupTheory.SpecificGroups.Quaternion
+import Mathlib.GroupTheory.SpecificGroups.ZGroup
 import Mathlib.GroupTheory.Subgroup.Center
 import Mathlib.GroupTheory.Subgroup.Centralizer
 import Mathlib.GroupTheory.Subgroup.Saturated

--- a/Mathlib/Algebra/Squarefree/Basic.lean
+++ b/Mathlib/Algebra/Squarefree/Basic.lean
@@ -84,7 +84,7 @@ theorem Squarefree.eq_zero_or_one_of_pow_of_not_isUnit [Monoid R] {x : R} {n : �
   have : x * x ∣ x ^ n := by rw [← sq]; exact pow_dvd_pow x h'
   exact h.squarefree_of_dvd this x (refl _)
 
-theorem _root_.Squarefree.pow_dvd_of_pow_dvd [Monoid R] {x y : R} {n : ℕ}
+theorem Squarefree.pow_dvd_of_pow_dvd [Monoid R] {x y : R} {n : ℕ}
     (hx : Squarefree y) (h : x ^ n ∣ y) : x ^ n ∣ x := by
   by_cases hu : IsUnit x
   · exact (hu.pow n).dvd

--- a/Mathlib/Algebra/Squarefree/Basic.lean
+++ b/Mathlib/Algebra/Squarefree/Basic.lean
@@ -67,22 +67,28 @@ theorem Irreducible.squarefree [CommMonoid R] {x : R} (h : Irreducible x) : Squa
 theorem Prime.squarefree [CancelCommMonoidWithZero R] {x : R} (h : Prime x) : Squarefree x :=
   h.irreducible.squarefree
 
-theorem Squarefree.of_mul_left [CommMonoid R] {m n : R} (hmn : Squarefree (m * n)) : Squarefree m :=
+theorem Squarefree.of_mul_left [Monoid R] {m n : R} (hmn : Squarefree (m * n)) : Squarefree m :=
   fun p hp => hmn p (dvd_mul_of_dvd_left hp n)
 
 theorem Squarefree.of_mul_right [CommMonoid R] {m n : R} (hmn : Squarefree (m * n)) :
     Squarefree n := fun p hp => hmn p (dvd_mul_of_dvd_right hp m)
 
-theorem Squarefree.squarefree_of_dvd [CommMonoid R] {x y : R} (hdvd : x ∣ y) (hsq : Squarefree y) :
+theorem Squarefree.squarefree_of_dvd [Monoid R] {x y : R} (hdvd : x ∣ y) (hsq : Squarefree y) :
     Squarefree x := fun _ h => hsq _ (h.trans hdvd)
 
-theorem Squarefree.eq_zero_or_one_of_pow_of_not_isUnit [CommMonoid R] {x : R} {n : ℕ}
+theorem Squarefree.eq_zero_or_one_of_pow_of_not_isUnit [Monoid R] {x : R} {n : ℕ}
     (h : Squarefree (x ^ n)) (h' : ¬ IsUnit x) :
     n = 0 ∨ n = 1 := by
   contrapose! h'
   replace h' : 2 ≤ n := by omega
   have : x * x ∣ x ^ n := by rw [← sq]; exact pow_dvd_pow x h'
   exact h.squarefree_of_dvd this x (refl _)
+
+theorem _root_.Squarefree.pow_dvd_of_pow_dvd [Monoid R] {x y : R} {n : ℕ}
+    (hx : Squarefree y) (h : x ^ n ∣ y) : x ^ n ∣ x := by
+  by_cases hu : IsUnit x
+  · exact (hu.pow n).dvd
+  · rcases (hx.squarefree_of_dvd h).eq_zero_or_one_of_pow_of_not_isUnit hu with rfl | rfl <;> simp
 
 section SquarefreeGcdOfSquarefree
 

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2024 Thomas Browning. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Browning
+-/
+import Mathlib.GroupTheory.Sylow
+
+/-!
+# Z-Groups
+
+A Z-group is a group whose Sylow subgroups are all cyclic.
+
+## Main definitions
+
+* `IsZGroup G`: A predicate stating that Sylow subgroups of `G` are cyclic.
+
+TODO: Show that if `G` is a Z-group with commutator subgroup `G'`, then `G = G' ⋊ G/G'` where `G'`
+and `G/G'` are cyclic of coprime orders.
+
+-/
+
+variable (G G' : Type*) [Group G] [Group G'] (f : G →* G')
+
+class IsZGroup : Prop where
+  isZGroup : ∀ p : ℕ, p.Prime → ∀ P : Sylow p G, IsCyclic P
+
+variable {G G' f}
+
+theorem IsZGroup_iff : IsZGroup G ↔ ∀ p : ℕ, p.Prime → ∀ P : Sylow p G, IsCyclic P :=
+  ⟨fun h ↦ h.1, fun h ↦ ⟨h⟩⟩
+
+namespace IsZGroup
+
+theorem of_injective [hG' : IsZGroup G'] (hf : Function.Injective f) : IsZGroup G := by
+  rw [IsZGroup_iff] at hG' ⊢
+  intro p hp P
+  obtain ⟨Q, hQ⟩ := P.exists_comap_eq_of_injective hf
+  specialize hG' p hp Q
+  have h : Subgroup.map f P ≤ Q := hQ ▸ Subgroup.map_comap_le f ↑Q
+  have := isCyclic_of_surjective _ (Subgroup.subgroupOfEquivOfLe h).surjective
+  exact isCyclic_of_surjective _ (Subgroup.equivMapOfInjective P f hf).symm.surjective
+
+instance [IsZGroup G] (H : Subgroup G) : IsZGroup H := of_injective H.subtype_injective
+
+end IsZGroup

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -23,13 +23,10 @@ and `G/G'` are cyclic of coprime orders.
 variable (G G' : Type*) [Group G] [Group G'] (f : G →* G')
 
 /-- A Z-group is a group whose Sylow subgroups are all cyclic. -/
-class IsZGroup : Prop where
+@[mk_iff] class IsZGroup : Prop where
   isZGroup : ∀ p : ℕ, p.Prime → ∀ P : Sylow p G, IsCyclic P
 
 variable {G G' f}
-
-theorem IsZGroup_iff : IsZGroup G ↔ ∀ p : ℕ, p.Prime → ∀ P : Sylow p G, IsCyclic P :=
-  ⟨fun h ↦ h.1, fun h ↦ ⟨h⟩⟩
 
 namespace IsZGroup
 
@@ -41,7 +38,7 @@ theorem of_squarefree (hG : Squarefree (Nat.card G)) : IsZGroup G := by
   exact isCyclic_of_card_dvd_prime ((hk ▸ hG.pow_dvd_of_pow_dvd) P.card_subgroup_dvd_card)
 
 theorem of_injective [hG' : IsZGroup G'] (hf : Function.Injective f) : IsZGroup G := by
-  rw [IsZGroup_iff] at hG' ⊢
+  rw [isZGroup_iff] at hG' ⊢
   intro p hp P
   obtain ⟨Q, hQ⟩ := P.exists_comap_eq_of_injective hf
   specialize hG' p hp Q

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
+import Mathlib.Data.Nat.Squarefree
 import Mathlib.GroupTheory.Sylow
 
 /-!
@@ -12,7 +13,7 @@ A Z-group is a group whose Sylow subgroups are all cyclic.
 
 ## Main definitions
 
-* `IsZGroup G`: A predicate stating that Sylow subgroups of `G` are cyclic.
+* `IsZGroup G`: A predicate stating that all Sylow subgroups of `G` are cyclic.
 
 TODO: Show that if `G` is a Z-group with commutator subgroup `G'`, then `G = G' ⋊ G/G'` where `G'`
 and `G/G'` are cyclic of coprime orders.
@@ -30,6 +31,13 @@ theorem IsZGroup_iff : IsZGroup G ↔ ∀ p : ℕ, p.Prime → ∀ P : Sylow p G
   ⟨fun h ↦ h.1, fun h ↦ ⟨h⟩⟩
 
 namespace IsZGroup
+
+theorem of_squarefree (hG : Squarefree (Nat.card G)) : IsZGroup G := by
+  have : Finite G := Nat.finite_of_card_ne_zero hG.ne_zero
+  refine ⟨fun p hp P ↦ ?_⟩
+  have := Fact.mk hp
+  obtain ⟨k, hk⟩ := P.2.exists_card_eq
+  exact isCyclic_of_card_dvd_prime ((hk ▸ hG.pow_dvd_of_pow_dvd) P.card_subgroup_dvd_card)
 
 theorem of_injective [hG' : IsZGroup G'] (hf : Function.Injective f) : IsZGroup G := by
   rw [IsZGroup_iff] at hG' ⊢

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -22,6 +22,7 @@ and `G/G'` are cyclic of coprime orders.
 
 variable (G G' : Type*) [Group G] [Group G'] (f : G →* G')
 
+/-- A Z-group is a group whose Sylow subgroups are all cyclic. -/
 class IsZGroup : Prop where
   isZGroup : ∀ p : ℕ, p.Prime → ∀ P : Sylow p G, IsCyclic P
 

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
-import Mathlib.Data.Nat.Squarefree
+import Mathlib.Algebra.Squarefree.Basic
 import Mathlib.GroupTheory.Sylow
 
 /-!


### PR DESCRIPTION
This PR adds a predicate stating that all Sylow subgroups of `G` are cyclic (for instance, when `G` has squarefree order). Ultimately, the goal is to show that any such group is a semidirect product of two cyclic groups.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
