### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Generator): introduce classes HasDetector and HasSeparator

### DIFF
--- a/Mathlib/CategoryTheory/Generator.lean
+++ b/Mathlib/CategoryTheory/Generator.lean
@@ -574,89 +574,173 @@ theorem wellPowered_of_isSeparator [HasPullbacks C] [Balanced C] (G : C) (hG : I
 
 section HasGenerator
 
-variable (E : Type u₃) [Category.{v₃} E]
+section Definitions
+
+variable (C)
 
 /--
-A category instantiates `HasSeparator` if and only if it has a separator.
-See also `IsSeparator`.
+For a category `C` and an object `G : C`, `G` is a separator of `C` if
+the functor `C(G, -)` is faithful.
+
+While `IsSeparator G : Prop` is the proposition that `G` is a separator of `C`,
+an `HasSeparator C : Prop` is the proposition that such a separator exists.
+Note that `HasSeparator C` is a proposition. It does not designate a favored separator
+and merely asserts the existence of one.
 -/
-class HasSeparator : Prop :=
-  hasSeparator : ∃ G : E, IsSeparator G
+class HasSeparator : Prop where
+  hasSeparator : ∃ G : C, IsSeparator G
 
 /--
-A category instantiates `HasCoseparator` if and only if it has a coseparator.
-See also `IsCoseparator`.
+For a category `C` and an object `G : C`, `G` is a coseparator of `C` if
+the functor `C(-, G)` is faithful.
+
+While `IsCoseparator G : Prop` is the proposition that `G` is a coseparator of `C`,
+an `HasCoseparator C : Prop` is the proposition that such a coseparator exists.
+Note that `HasCoseparator C` is a proposition. It does not designate a favored coseparator
+and merely asserts the existence of one.
 -/
-class HasCoseparator : Prop :=
-  hasCoseparator : ∃ G : E, IsCoseparator G
+class HasCoseparator : Prop where
+  hasCoseparator : ∃ G : C, IsCoseparator G
 
 /--
-A category instantiates `HasDetector` if and only if it has a detector.
-See also `IsDetector`.
+For a category `C` and an object `G : C`, `G` is a detector of `C` if
+the functor `C(G, -)` reflects isomorphisms.
+
+While `IsDetector G : Prop` is the proposition that `G` is a detector of `C`,
+an `HasDetector C : Prop` is the proposition that such a detector exists.
+Note that `HasDetector C` is a proposition. It does not designate a favored detector
+and merely asserts the existence of one.
 -/
-class HasDetector : Prop :=
-  hasDetector : ∃ G : E, IsDetector G
+class HasDetector : Prop where
+  hasDetector : ∃ G : C, IsDetector G
 
 /--
-A category instantiates `HasCodetector` if and only if it has a codetector.
-See also `IsCodetector`.
+For a category `C` and an object `G : C`, `G` is a codetector of `C` if
+the functor `C(-, G)` reflects isomorphisms.
+
+While `IsCodetector G : Prop` is the proposition that `G` is a codetector of `C`,
+an `HasCodetector C : Prop` is the proposition that such a codetector exists.
+Note that `HasCodetector C` is a proposition. It does not designate a favored codetector
+and merely asserts the existence of one.
 -/
-class HasCodetector : Prop :=
-  hasCodetector : ∃ G : E, IsCodetector G
+class HasCodetector : Prop where
+  hasCodetector : ∃ G : C, IsCodetector G
 
-theorem HasSeparator.hasDetector [Balanced C] [HasSeparator C] : HasDetector C := by
-  obtain ⟨G, hG⟩ : HasSeparator C := inferInstance
-  exact ⟨G, hG.isDetector⟩
+end Definitions
 
-theorem HasDetector.hasSeparator [HasEqualizers C] [HasDetector C] : HasSeparator C := by
-  obtain ⟨G, hG⟩ : HasDetector C := inferInstance
-  exact ⟨G, hG.isSeparator⟩
+section Choice
 
-theorem HasCoseparator.hasCodetector [Balanced C] [HasCoseparator C] : HasCodetector C := by
-  obtain ⟨G, hG⟩ : HasCoseparator C := inferInstance
-  exact ⟨G, hG.isCodetector⟩
+variable (C)
 
-theorem HasCodetector.hasCoseparator [HasCoequalizers C] [HasCodetector C] : HasCoseparator C := by
-  obtain ⟨G, hG⟩ : HasCodetector C := inferInstance
-  exact ⟨G, hG.isCoseparator⟩
+/--
+Given a category `C` that has a separator (`HasSeparator C`), `separator` is an arbitrarily
+chosen separator of `C`.
+-/
+noncomputable def separator [HasSeparator C] : C :=
+  Classical.indefiniteDescription _ HasSeparator.hasSeparator |>.1
 
-theorem HasDetector.wellPowered [HasPullbacks C] [HasDetector C] : WellPowered C := by
-  obtain ⟨G, hG⟩ : HasDetector C := inferInstance
-  exact wellPowered_of_isDetector G hG
 
-theorem HasSeparator.wellPowered [HasPullbacks C] [Balanced C] [HasSeparator C] :
+/--
+Given a category `C` that has a coseparator (`HasCoseparator C`), `coseparator` is an arbitrarily
+chosen coseparator of `C`.
+-/
+noncomputable def coseparator [HasCoseparator C] : C :=
+  Classical.indefiniteDescription _ HasCoseparator.hasCoseparator |>.1
+
+/--
+Given a category `C` that has a detector (`HasDetector C`), `detector` is an arbitrarily
+chosen detector of `C`.
+-/
+noncomputable def detector [HasDetector C] : C :=
+  Classical.indefiniteDescription _ HasDetector.hasDetector |>.1
+
+/--
+Given a category `C` that has a codetector (`HasCodetector C`), `codetector` is an arbitrarily
+chosen codetector of `C`.
+-/
+noncomputable def codetector [HasCodetector C] : C :=
+  Classical.indefiniteDescription _ HasCodetector.hasCodetector |>.1
+
+theorem isSeparator_separator [HasSeparator C] : IsSeparator (separator C) :=
+  Classical.indefiniteDescription _ HasSeparator.hasSeparator |>.2
+
+theorem isDetector_separator [Balanced C] [HasSeparator C] : IsDetector (separator C) :=
+  isSeparator_separator C |>.isDetector
+
+theorem isCoseparator_coseparator [HasCoseparator C] : IsCoseparator (coseparator C) :=
+  Classical.indefiniteDescription _ HasCoseparator.hasCoseparator |>.2
+
+theorem isCodetector_coseparator [Balanced C] [HasCoseparator C] : IsCodetector (coseparator C) :=
+  isCoseparator_coseparator C |>.isCodetector
+
+theorem isDetector_detector [HasDetector C] : IsDetector (detector C) :=
+  Classical.indefiniteDescription _ HasDetector.hasDetector |>.2
+
+theorem isSeparator_detector [HasEqualizers C] [HasDetector C] : IsSeparator (detector C) :=
+  isDetector_detector C |>.isSeparator
+
+theorem isCodetector_codetector [HasCodetector C] : IsCodetector (codetector C) :=
+  Classical.indefiniteDescription _ HasCodetector.hasCodetector |>.2
+
+theorem isCoseparator_codetector [HasCoequalizers C] [HasCodetector C] :
+    IsCoseparator (codetector C) := isCodetector_codetector C |>.isCoseparator
+
+end Choice
+
+section Instances
+
+theorem HasSeparator.hasDetector [Balanced C] [HasSeparator C] : HasDetector C :=
+  ⟨_, isDetector_separator C⟩
+
+theorem HasDetector.hasSeparator [HasEqualizers C] [HasDetector C] : HasSeparator C :=
+  ⟨_, isSeparator_detector C⟩
+
+theorem HasCoseparator.hasCodetector [Balanced C] [HasCoseparator C] : HasCodetector C :=
+  ⟨_, isCodetector_coseparator C⟩
+
+theorem HasCodetector.hasCoseparator [HasCoequalizers C] [HasCodetector C] : HasCoseparator C :=
+  ⟨_, isCoseparator_codetector C⟩
+
+instance HasDetector.wellPowered [HasPullbacks C] [HasDetector C] : WellPowered C :=
+  isDetector_detector C |> wellPowered_of_isDetector _
+
+instance HasSeparator.wellPowered [HasPullbacks C] [Balanced C] [HasSeparator C] :
     WellPowered C := HasSeparator.hasDetector.wellPowered
+
+end Instances
 
 section Dual
 
 @[simp]
-theorem hasSeparator_op_iff : HasSeparator Eᵒᵖ ↔ HasCoseparator E :=
+theorem hasSeparator_op_iff : HasSeparator Cᵒᵖ ↔ HasCoseparator C :=
   ⟨fun ⟨G, hG⟩ => ⟨unop G, (isCoseparator_unop_iff G).mpr hG⟩,
    fun ⟨G, hG⟩ => ⟨op G, (isSeparator_op_iff G).mpr hG⟩⟩
 
 @[simp]
-theorem hasCoseparator_op_iff : HasCoseparator Eᵒᵖ ↔ HasSeparator E :=
+theorem hasCoseparator_op_iff : HasCoseparator Cᵒᵖ ↔ HasSeparator C :=
   ⟨fun ⟨G, hG⟩ => ⟨unop G, (isSeparator_unop_iff G).mpr hG⟩,
    fun ⟨G, hG⟩ => ⟨op G, (isCoseparator_op_iff G).mpr hG⟩⟩
 
-theorem HasSeparator.hasCoseparator_op [HasSeparator C] : HasCoseparator Cᵒᵖ := by simp [*]
-theorem HasSeparator.hasCoseparator_unop [h : HasSeparator Cᵒᵖ] : HasCoseparator C := by simp_all
-theorem HasCoseparator.hasSeparator_op [HasCoseparator C] : HasSeparator Cᵒᵖ := by simp [*]
-theorem HasCoseparator.hasSeparator_unop [HasCoseparator Cᵒᵖ] : HasSeparator C := by simp_all
-
 @[simp]
-theorem hasDetector_op_iff : HasDetector Eᵒᵖ ↔ HasCodetector E :=
+theorem hasDetector_op_iff : HasDetector Cᵒᵖ ↔ HasCodetector C :=
   ⟨fun ⟨G, hG⟩ => ⟨unop G, (isCodetector_unop_iff G).mpr hG⟩,
    fun ⟨G, hG⟩ => ⟨op G, (isDetector_op_iff G).mpr hG⟩⟩
 
 @[simp]
-theorem hasCodetector_op_iff : HasCodetector Eᵒᵖ ↔ HasDetector E :=
+theorem hasCodetector_op_iff : HasCodetector Cᵒᵖ ↔ HasDetector C :=
   ⟨fun ⟨G, hG⟩ => ⟨unop G, (isDetector_unop_iff G).mpr hG⟩,
    fun ⟨G, hG⟩ => ⟨op G, (isCodetector_op_iff G).mpr hG⟩⟩
 
-theorem HasDetector.hasCodetector_op [HasDetector C] : HasCodetector Cᵒᵖ := by simp [*]
+instance HasSeparator.hasCoseparator_op [HasSeparator C] : HasCoseparator Cᵒᵖ := by simp [*]
+theorem HasSeparator.hasCoseparator_unop [h : HasSeparator Cᵒᵖ] : HasCoseparator C := by simp_all
+
+instance HasCoseparator.hasSeparator_op [HasCoseparator C] : HasSeparator Cᵒᵖ := by simp [*]
+theorem HasCoseparator.hasSeparator_unop [HasCoseparator Cᵒᵖ] : HasSeparator C := by simp_all
+
+instance HasDetector.hasCodetector_op [HasDetector C] : HasCodetector Cᵒᵖ := by simp [*]
 theorem HasDetector.hasCodetector_unop [HasDetector Cᵒᵖ] : HasCodetector C := by simp_all
-theorem HasCodetector.hasDetector_op [HasCodetector C] : HasDetector Cᵒᵖ := by simp [*]
+
+instance HasCodetector.hasDetector_op [HasCodetector C] : HasDetector Cᵒᵖ := by simp [*]
 theorem HasCodetector.hasDetector_unop [HasCodetector Cᵒᵖ] : HasDetector C := by simp_all
 
 end Dual

--- a/Mathlib/CategoryTheory/Generator.lean
+++ b/Mathlib/CategoryTheory/Generator.lean
@@ -51,7 +51,7 @@ and `HasCodetector` on categories and prove analogous results for these.
 -/
 
 
-universe w v₁ v₂ v₃ u₁ u₂ u₃
+universe w v₁ v₂ u₁ u₂
 
 open CategoryTheory.Limits Opposite
 
@@ -633,54 +633,49 @@ section Choice
 variable (C)
 
 /--
-Given a category `C` that has a separator (`HasSeparator C`), `separator` is an arbitrarily
+Given a category `C` that has a separator (`HasSeparator C`), `separator C` is an arbitrarily
 chosen separator of `C`.
 -/
-noncomputable def separator [HasSeparator C] : C :=
-  Classical.indefiniteDescription _ HasSeparator.hasSeparator |>.1
-
+noncomputable def separator [HasSeparator C] : C := HasSeparator.hasSeparator.choose
 
 /--
-Given a category `C` that has a coseparator (`HasCoseparator C`), `coseparator` is an arbitrarily
+Given a category `C` that has a coseparator (`HasCoseparator C`), `coseparator C` is an arbitrarily
 chosen coseparator of `C`.
 -/
-noncomputable def coseparator [HasCoseparator C] : C :=
-  Classical.indefiniteDescription _ HasCoseparator.hasCoseparator |>.1
+noncomputable def coseparator [HasCoseparator C] : C := HasCoseparator.hasCoseparator.choose
 
 /--
-Given a category `C` that has a detector (`HasDetector C`), `detector` is an arbitrarily
+Given a category `C` that has a detector (`HasDetector C`), `detector C` is an arbitrarily
 chosen detector of `C`.
 -/
-noncomputable def detector [HasDetector C] : C :=
-  Classical.indefiniteDescription _ HasDetector.hasDetector |>.1
+noncomputable def detector [HasDetector C] : C := HasDetector.hasDetector.choose
 
 /--
-Given a category `C` that has a codetector (`HasCodetector C`), `codetector` is an arbitrarily
+Given a category `C` that has a codetector (`HasCodetector C`), `codetector C` is an arbitrarily
 chosen codetector of `C`.
 -/
-noncomputable def codetector [HasCodetector C] : C :=
-  Classical.indefiniteDescription _ HasCodetector.hasCodetector |>.1
+noncomputable def codetector [HasCodetector C] : C := HasCodetector.hasCodetector.choose
 
 theorem isSeparator_separator [HasSeparator C] : IsSeparator (separator C) :=
-  Classical.indefiniteDescription _ HasSeparator.hasSeparator |>.2
+  HasSeparator.hasSeparator.choose_spec
 
 theorem isDetector_separator [Balanced C] [HasSeparator C] : IsDetector (separator C) :=
   isSeparator_separator C |>.isDetector
 
 theorem isCoseparator_coseparator [HasCoseparator C] : IsCoseparator (coseparator C) :=
-  Classical.indefiniteDescription _ HasCoseparator.hasCoseparator |>.2
+  HasCoseparator.hasCoseparator.choose_spec
 
 theorem isCodetector_coseparator [Balanced C] [HasCoseparator C] : IsCodetector (coseparator C) :=
   isCoseparator_coseparator C |>.isCodetector
 
 theorem isDetector_detector [HasDetector C] : IsDetector (detector C) :=
-  Classical.indefiniteDescription _ HasDetector.hasDetector |>.2
+  HasDetector.hasDetector.choose_spec
 
 theorem isSeparator_detector [HasEqualizers C] [HasDetector C] : IsSeparator (detector C) :=
   isDetector_detector C |>.isSeparator
 
 theorem isCodetector_codetector [HasCodetector C] : IsCodetector (codetector C) :=
-  Classical.indefiniteDescription _ HasCodetector.hasCodetector |>.2
+  HasCodetector.hasCodetector.choose_spec
 
 theorem isCoseparator_codetector [HasCoequalizers C] [HasCodetector C] :
     IsCoseparator (codetector C) := isCodetector_codetector C |>.isCoseparator

--- a/Mathlib/CategoryTheory/Generator.lean
+++ b/Mathlib/CategoryTheory/Generator.lean
@@ -732,16 +732,20 @@ theorem hasCodetector_op_iff : HasCodetector Cᵒᵖ ↔ HasDetector C :=
    fun ⟨G, hG⟩ => ⟨op G, (isCodetector_op_iff G).mpr hG⟩⟩
 
 instance HasSeparator.hasCoseparator_op [HasSeparator C] : HasCoseparator Cᵒᵖ := by simp [*]
-theorem HasSeparator.hasCoseparator_unop [h : HasSeparator Cᵒᵖ] : HasCoseparator C := by simp_all
+theorem HasSeparator.hasCoseparator_of_hasSeparator_op [h : HasSeparator Cᵒᵖ] :
+    HasCoseparator C := by simp_all
 
 instance HasCoseparator.hasSeparator_op [HasCoseparator C] : HasSeparator Cᵒᵖ := by simp [*]
-theorem HasCoseparator.hasSeparator_unop [HasCoseparator Cᵒᵖ] : HasSeparator C := by simp_all
+theorem HasCoseparator.hasSeparator_of_hasCoseparator_op [HasCoseparator Cᵒᵖ] :
+    HasSeparator C := by simp_all
 
 instance HasDetector.hasCodetector_op [HasDetector C] : HasCodetector Cᵒᵖ := by simp [*]
-theorem HasDetector.hasCodetector_unop [HasDetector Cᵒᵖ] : HasCodetector C := by simp_all
+theorem HasDetector.hasCodetector_of_hasDetector_op [HasDetector Cᵒᵖ] :
+    HasCodetector C := by simp_all
 
 instance HasCodetector.hasDetector_op [HasCodetector C] : HasDetector Cᵒᵖ := by simp [*]
-theorem HasCodetector.hasDetector_unop [HasCodetector Cᵒᵖ] : HasDetector C := by simp_all
+theorem HasCodetector.hasDetector_of_hasCodetector_op [HasCodetector Cᵒᵖ] :
+    HasDetector C := by simp_all
 
 end Dual
 

--- a/Mathlib/CategoryTheory/Generator.lean
+++ b/Mathlib/CategoryTheory/Generator.lean
@@ -583,7 +583,6 @@ See also `IsSeparator`.
 class HasSeparator : Prop :=
   hasSeparator : ∃ G : E, IsSeparator G
 
-
 /--
 A category instantiates `HasCoseparator` if and only if it has a coseparator.
 See also `IsCoseparator`.
@@ -591,14 +590,12 @@ See also `IsCoseparator`.
 class HasCoseparator : Prop :=
   hasCoseparator : ∃ G : E, IsCoseparator G
 
-
 /--
 A category instantiates `HasDetector` if and only if it has a detector.
 See also `IsDetector`.
 -/
 class HasDetector : Prop :=
   hasDetector : ∃ G : E, IsDetector G
-
 
 /--
 A category instantiates `HasCodetector` if and only if it has a codetector.

--- a/Mathlib/CategoryTheory/Generator.lean
+++ b/Mathlib/CategoryTheory/Generator.lean
@@ -41,7 +41,7 @@ We
 * show that `G` is a detector if and only if `coyoneda.obj (op G)` reflects isomorphisms (and the
   dual);
 * show that `C` is `WellPowered` if it admits small pullbacks and a detector;
-* define corresponding type classes `HasSeparator`, `HasCoseparator`, `HasDetector`
+* define corresponding typeclasses `HasSeparator`, `HasCoseparator`, `HasDetector`
 and `HasCodetector` on categories and prove analogous results for these.
 
 ## Future work
@@ -58,7 +58,6 @@ open CategoryTheory.Limits Opposite
 namespace CategoryTheory
 
 variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
-  (E : Type u₃) [Category.{v₃} E]
 
 /-- We say that `𝒢` is a separating set if the functors `C(G, -)` for `G ∈ 𝒢` are collectively
     faithful, i.e., if `h ≫ f = h ≫ g` for all `h` with domain in `𝒢` implies `f = g`. -/
@@ -566,12 +565,16 @@ theorem isCodetector_iff_reflectsIsomorphisms_yoneda_obj (G : C) :
     rwa [isIso_iff_bijective, Function.bijective_iff_existsUnique]
 
 theorem wellPowered_of_isDetector [HasPullbacks C] (G : C) (hG : IsDetector G) : WellPowered C :=
+  -- Porting note: added the following `haveI` to prevent universe issues
+  haveI := small_subsingleton ({G} : Set C)
   wellPowered_of_isDetecting hG
 
 theorem wellPowered_of_isSeparator [HasPullbacks C] [Balanced C] (G : C) (hG : IsSeparator G) :
     WellPowered C := wellPowered_of_isDetecting hG.isDetector
 
 section HasGenerator
+
+variable (E : Type u₃) [Category.{v₃} E]
 
 /--
 A category instantiates `HasSeparator` if and only if it has a separator.
@@ -627,8 +630,6 @@ theorem HasDetector.wellPowered [HasPullbacks C] [HasDetector C] : WellPowered C
 theorem HasSeparator.wellPowered [HasPullbacks C] [Balanced C] [HasSeparator C] :
     WellPowered C := HasSeparator.hasDetector.wellPowered
 
-end HasGenerator
-
 section Dual
 
 @[simp]
@@ -642,7 +643,7 @@ theorem hasCoseparator_op_iff : HasCoseparator Eᵒᵖ ↔ HasSeparator E :=
    fun ⟨G, hG⟩ => ⟨op G, (isCoseparator_op_iff G).mpr hG⟩⟩
 
 theorem HasSeparator.hasCoseparator_op [HasSeparator C] : HasCoseparator Cᵒᵖ := by simp [*]
-theorem HasSeparator.hasCoseparator_unop [HasSeparator Cᵒᵖ] : HasCoseparator C := by simp_all
+theorem HasSeparator.hasCoseparator_unop [h : HasSeparator Cᵒᵖ] : HasCoseparator C := by simp_all
 theorem HasCoseparator.hasSeparator_op [HasCoseparator C] : HasSeparator Cᵒᵖ := by simp [*]
 theorem HasCoseparator.hasSeparator_unop [HasCoseparator Cᵒᵖ] : HasSeparator C := by simp_all
 
@@ -662,5 +663,7 @@ theorem HasCodetector.hasDetector_op [HasCodetector C] : HasDetector Cᵒᵖ := 
 theorem HasCodetector.hasDetector_unop [HasCodetector Cᵒᵖ] : HasDetector C := by simp_all
 
 end Dual
+
+end HasGenerator
 
 end CategoryTheory


### PR DESCRIPTION
This change defines the typeclasses `HasDetector` and `HasSeparator` for categories with detectors/separators. Several results for `IsDetector` and `IsSeparator` are also proved for the new typeclasses.

Convenience theorems for proving the well-poweredness of categories with separators are added, too.

Two typos are fixed: "separating" is corrected to "coseparating" in the module docstring and `IsCospearator.isCodetector` is renamed to `IsCoseparator.isCodetector`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
