### PR TITLE
chore: Reduce dependents of Data.Rat.Denumerable

### DIFF
--- a/Mathlib/Data/Real/Cardinality.lean
+++ b/Mathlib/Data/Real/Cardinality.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import Mathlib.Analysis.SpecificLimits.Basic
-import Mathlib.Data.Rat.Denumerable
 import Mathlib.Data.Set.Pointwise.Interval
 import Mathlib.SetTheory.Cardinal.Continuum
 
@@ -189,7 +188,7 @@ theorem mk_real : #ℝ = 𝔠 := by
   · rw [Real.equivCauchy.cardinal_eq]
     apply mk_quotient_le.trans
     apply (mk_subtype_le _).trans_eq
-    rw [← power_def, mk_nat, mkRat, aleph0_power_aleph0]
+    rw [← power_def, mk_nat, mk_eq_aleph0, aleph0_power_aleph0]
   · convert mk_le_of_injective (cantorFunction_injective _ _)
     · rw [← power_def, mk_bool, mk_nat, two_power_aleph0]
     · exact 1 / 3

--- a/Mathlib/FieldTheory/Cardinality.lean
+++ b/Mathlib/FieldTheory/Cardinality.lean
@@ -6,7 +6,7 @@ Authors: Eric Rodriguez
 import Mathlib.Algebra.Field.ULift
 import Mathlib.Algebra.MvPolynomial.Cardinal
 import Mathlib.Data.Nat.Factorization.PrimePow
-import Mathlib.Data.Rat.Denumerable
+import Mathlib.Data.Rat.Encodable
 import Mathlib.FieldTheory.Finite.GaloisField
 import Mathlib.Logic.Equiv.TransferInstance
 import Mathlib.RingTheory.Localization.Cardinality

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -3,7 +3,8 @@ Copyright (c) 2022 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
-import Mathlib.Data.Rat.Denumerable
+import Mathlib.Algebra.CharZero.Infinite
+import Mathlib.Data.Rat.Encodable
 import Mathlib.ModelTheory.Complexity
 import Mathlib.ModelTheory.Fraisse
 import Mathlib.Order.CountableDenseLinearOrder


### PR DESCRIPTION
---
This is in preparation for a PR where I intend to use continued fractions to prove denumerability of Q (providing a much more efficiently computable bijection with Nat). I don't want continued fractions  to be imported everywhere, so I'm reducing the imports of the denumerability file in advance.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
