### PR TITLE
[Merged by Bors] - feat(Data/Finset/Max): max'/min' union

### DIFF
--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -249,6 +249,12 @@ theorem min'_lt_max'_of_card (h₂ : 1 < card s) :
   rcases one_lt_card.1 h₂ with ⟨a, ha, b, hb, hab⟩
   exact s.min'_lt_max' ha hb hab
 
+theorem max'_union {s₁ s₂ : Finset α} (h₁ : s₁.Nonempty) (h₂ : s₂.Nonempty) :
+    (s₁ ∪ s₂).max' (h₁.mono subset_union_left) = (s₁.max' h₁) ⊔ (s₂.max' h₂) := sup'_union h₁ h₂ id
+
+theorem min'_union {s₁ s₂ : Finset α} (h₁ : s₁.Nonempty) (h₂ : s₂.Nonempty) :
+    (s₁ ∪ s₂).min' (h₁.mono subset_union_left) = (s₁.min' h₁) ⊓ (s₂.min' h₂) := inf'_union h₁ h₂ id
+
 theorem map_ofDual_min (s : Finset αᵒᵈ) : s.min.map ofDual = (s.image ofDual).max := by
   rw [max_eq_sup_withBot, sup_image]
   exact congr_fun Option.map_id _

--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -250,10 +250,10 @@ theorem min'_lt_max'_of_card (h₂ : 1 < card s) :
   exact s.min'_lt_max' ha hb hab
 
 theorem max'_union {s₁ s₂ : Finset α} (h₁ : s₁.Nonempty) (h₂ : s₂.Nonempty) :
-    (s₁ ∪ s₂).max' (h₁.mono subset_union_left) = (s₁.max' h₁) ⊔ (s₂.max' h₂) := sup'_union h₁ h₂ id
+    (s₁ ∪ s₂).max' (h₁.mono subset_union_left) = s₁.max' h₁ ⊔ s₂.max' h₂ := sup'_union h₁ h₂ id
 
 theorem min'_union {s₁ s₂ : Finset α} (h₁ : s₁.Nonempty) (h₂ : s₂.Nonempty) :
-    (s₁ ∪ s₂).min' (h₁.mono subset_union_left) = (s₁.min' h₁) ⊓ (s₂.min' h₂) := inf'_union h₁ h₂ id
+    (s₁ ∪ s₂).min' (h₁.mono subset_union_left) = s₁.min' h₁ ⊓ s₂.min' h₂ := inf'_union h₁ h₂ id
 
 theorem map_ofDual_min (s : Finset αᵒᵈ) : s.min.map ofDual = (s.image ofDual).max := by
   rw [max_eq_sup_withBot, sup_image]


### PR DESCRIPTION
Continues https://github.com/leanprover-community/mathlib4/pull/18545. Though, I'm unsure if I should simply ignore the earlier variable declaration `variable (s : Finset α) (H : s.Nonempty) {x : α}` and continue as is.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
