### PR TITLE
[Merged by Bors] - feat: topological closure of non-unital subobjects

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4693,6 +4693,8 @@ import Mathlib.Topology.Algebra.Module.WeakDual
 import Mathlib.Topology.Algebra.Monoid
 import Mathlib.Topology.Algebra.MulAction
 import Mathlib.Topology.Algebra.MvPolynomial
+import Mathlib.Topology.Algebra.NonUnitalAlgebra
+import Mathlib.Topology.Algebra.NonUnitalStarAlgebra
 import Mathlib.Topology.Algebra.Nonarchimedean.AdicTopology
 import Mathlib.Topology.Algebra.Nonarchimedean.Bases
 import Mathlib.Topology.Algebra.Nonarchimedean.Basic

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -527,13 +527,7 @@ theorem Submonoid.topologicalClosure_minimal (s : Submonoid M) {t : Submonoid M}
 topological closure."]
 def Submonoid.commMonoidTopologicalClosure [T2Space M] (s : Submonoid M)
     (hs : ∀ x y : s, x * y = y * x) : CommMonoid s.topologicalClosure :=
-  { s.topologicalClosure.toMonoid with
-    mul_comm :=
-      have : ∀ x ∈ s, ∀ y ∈ s, x * y = y * x := fun x hx y hy =>
-        congr_arg Subtype.val (hs ⟨x, hx⟩ ⟨y, hy⟩)
-      fun ⟨x, hx⟩ ⟨y, hy⟩ =>
-      Subtype.ext <|
-        eqOn_closure₂ this continuous_mul (continuous_snd.mul continuous_fst) x hx y hy }
+  { s.topologicalClosure.toMonoid, s.toSubsemigroup.commSemigroupTopologicalClosure hs with }
 
 @[to_additive exists_nhds_zero_quarter]
 theorem exists_nhds_one_split4 {u : Set M} (hu : u ∈ 𝓝 (1 : M)) :

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -463,10 +463,14 @@ theorem Subsemigroup.topologicalClosure_minimal (s : Subsemigroup M) {t : Subsem
     (h : s ≤ t) (ht : IsClosed (t : Set M)) : s.topologicalClosure ≤ t := closure_minimal h ht
 
 /-- If a subsemigroup of a topological semigroup is commutative, then so is its topological
-closure. -/
+closure.
+
+See note [reducible non-instances] -/
 @[to_additive "If a submonoid of an additive topological monoid is commutative, then so is its
-topological closure."]
-def Subsemigroup.commSemigroupTopologicalClosure [T2Space M] (s : Subsemigroup M)
+topological closure.
+
+See note [reducible non-instances]"]
+abbrev Subsemigroup.commSemigroupTopologicalClosure [T2Space M] (s : Subsemigroup M)
     (hs : ∀ x y : s, x * y = y * x) : CommSemigroup s.topologicalClosure :=
   { MulMemClass.toSemigroup s.topologicalClosure with
     mul_comm :=

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -304,10 +304,43 @@ theorem isClosed_setOf_map_mul [Mul M₁] [Mul M₂] [ContinuousMul M₂] :
         isClosed_eq (continuous_apply _)
           (by continuity)
 
--- Porting note: split variables command over two lines, can't change explicitness at the same time
--- as declaring new variables.
-variable {M₁ M₂}
-variable [MulOneClass M₁] [MulOneClass M₂] [ContinuousMul M₂]
+section Semigroup
+
+variable {M₁ M₂} [Mul M₁] [Mul M₂] [ContinuousMul M₂]
+  {F : Type*} [FunLike F M₁ M₂] [MulHomClass F M₁ M₂] {l : Filter α}
+
+/-- Construct a bundled semigroup homomorphism `M₁ →ₙ* M₂` from a function `f` and a proof that it
+belongs to the closure of the range of the coercion from `M₁ →ₙ* M₂` (or another type of bundled
+homomorphisms that has a `MulHomClass` instance) to `M₁ → M₂`. -/
+@[to_additive (attr := simps (config := .asFn))
+  "Construct a bundled additive semigroup homomorphism `M₁ →ₙ+ M₂` from a function `f`
+and a proof that it belongs to the closure of the range of the coercion from `M₁ →ₙ+ M₂` (or another
+type of bundled homomorphisms that has an `AddHomClass` instance) to `M₁ → M₂`."]
+def mulHomOfMemClosureRangeCoe (f : M₁ → M₂)
+    (hf : f ∈ closure (range fun (f : F) (x : M₁) => f x)) : M₁ →ₙ* M₂ where
+  toFun := f
+  map_mul' := (isClosed_setOf_map_mul M₁ M₂).closure_subset_iff.2 (range_subset_iff.2 map_mul) hf
+
+/-- Construct a bundled semigroup homomorphism from a pointwise limit of semigroup homomorphisms. -/
+@[to_additive (attr := simps! (config := .asFn))
+  "Construct a bundled additive semigroup homomorphism from a pointwise limit of additive
+semigroup homomorphisms"]
+def mulHomOfTendsto (f : M₁ → M₂) (g : α → F) [l.NeBot]
+    (h : Tendsto (fun a x => g a x) l (𝓝 f)) : M₁ →ₙ* M₂ :=
+  mulHomOfMemClosureRangeCoe f <|
+    mem_closure_of_tendsto h <| Eventually.of_forall fun _ => mem_range_self _
+
+variable (M₁ M₂)
+
+@[to_additive]
+theorem MulHom.isClosed_range_coe : IsClosed (Set.range ((↑) : (M₁ →ₙ* M₂) → M₁ → M₂)) :=
+  isClosed_of_closure_subset fun f hf => ⟨mulHomOfMemClosureRangeCoe f hf, rfl⟩
+
+end Semigroup
+
+section Monoid
+
+variable {M₁ M₂} [MulOneClass M₁] [MulOneClass M₂] [ContinuousMul M₂]
   {F : Type*} [FunLike F M₁ M₂] [MonoidHomClass F M₁ M₂] {l : Filter α}
 
 /-- Construct a bundled monoid homomorphism `M₁ →* M₂` from a function `f` and a proof that it
@@ -337,6 +370,8 @@ variable (M₁ M₂)
 @[to_additive]
 theorem MonoidHom.isClosed_range_coe : IsClosed (Set.range ((↑) : (M₁ →* M₂) → M₁ → M₂)) :=
   isClosed_of_closure_subset fun f hf => ⟨monoidHomOfMemClosureRangeCoe f hf, rfl⟩
+
+end Monoid
 
 end PointwiseLimits
 
@@ -392,6 +427,61 @@ theorem exists_open_nhds_one_mul_subset {U : Set M} (hU : U ∈ 𝓝 (1 : M)) :
 end MulOneClass
 
 section ContinuousMul
+
+section Semigroup
+
+variable [TopologicalSpace M] [Semigroup M] [ContinuousMul M]
+
+@[to_additive]
+theorem Subsemigroup.top_closure_mul_self_subset (s : Subsemigroup M) :
+    _root_.closure (s : Set M) * _root_.closure s ⊆ _root_.closure s :=
+  image2_subset_iff.2 fun _ hx _ hy =>
+    map_mem_closure₂ continuous_mul hx hy fun _ ha _ hb => s.mul_mem ha hb
+
+/-- The (topological-space) closure of a subsemigroup of a space `M` with `ContinuousMul` is
+itself a subsemigroup. -/
+@[to_additive "The (topological-space) closure of an additive submonoid of a space `M` with
+`ContinuousAdd` is itself an additive submonoid."]
+def Subsemigroup.topologicalClosure (s : Subsemigroup M) : Subsemigroup M where
+  carrier := _root_.closure (s : Set M)
+  mul_mem' ha hb := s.top_closure_mul_self_subset ⟨_, ha, _, hb, rfl⟩
+
+@[to_additive]
+theorem Subsemigroup.coe_topologicalClosure (s : Subsemigroup M) :
+    (s.topologicalClosure : Set M) = _root_.closure (s : Set M) := rfl
+
+@[to_additive]
+theorem Subsemigroup.le_topologicalClosure (s : Subsemigroup M) : s ≤ s.topologicalClosure :=
+  _root_.subset_closure
+
+@[to_additive]
+theorem Subsemigroup.isClosed_topologicalClosure (s : Subsemigroup M) :
+    IsClosed (s.topologicalClosure : Set M) := isClosed_closure
+
+@[to_additive]
+theorem Subsemigroup.topologicalClosure_minimal (s : Subsemigroup M) {t : Subsemigroup M}
+    (h : s ≤ t) (ht : IsClosed (t : Set M)) : s.topologicalClosure ≤ t := closure_minimal h ht
+
+/-- If a subsemigroup of a topological semigroup is commutative, then so is its topological
+closure. -/
+@[to_additive "If a submonoid of an additive topological monoid is commutative, then so is its
+topological closure."]
+def Subsemigroup.commSemigroupTopologicalClosure [T2Space M] (s : Subsemigroup M)
+    (hs : ∀ x y : s, x * y = y * x) : CommSemigroup s.topologicalClosure :=
+  { MulMemClass.toSemigroup s.topologicalClosure with
+    mul_comm :=
+      have : ∀ x ∈ s, ∀ y ∈ s, x * y = y * x := fun x hx y hy =>
+        congr_arg Subtype.val (hs ⟨x, hx⟩ ⟨y, hy⟩)
+      fun ⟨x, hx⟩ ⟨y, hy⟩ =>
+      Subtype.ext <|
+        eqOn_closure₂ this continuous_mul (continuous_snd.mul continuous_fst) x hx y hy }
+
+@[to_additive]
+theorem IsCompact.mul {s t : Set M} (hs : IsCompact s) (ht : IsCompact t) : IsCompact (s * t) := by
+  rw [← image_mul_prod]
+  exact (hs.prod ht).image continuous_mul
+
+end Semigroup
 
 variable [TopologicalSpace M] [Monoid M] [ContinuousMul M]
 
@@ -453,11 +543,6 @@ theorem exists_nhds_one_split4 {u : Set M} (hu : u ∈ 𝓝 (1 : M)) :
   use V, V1
   intro v w s t v_in w_in s_in t_in
   simpa only [mul_assoc] using h _ (h' v v_in w w_in) _ (h' s s_in t t_in)
-
-@[to_additive]
-theorem IsCompact.mul {s t : Set M} (hs : IsCompact s) (ht : IsCompact t) : IsCompact (s * t) := by
-  rw [← image_mul_prod]
-  exact (hs.prod ht).image continuous_mul
 
 @[to_additive]
 theorem tendsto_list_prod {f : ι → α → M} {x : Filter α} {a : ι → M} :

--- a/Mathlib/Topology/Algebra/NonUnitalAlgebra.lean
+++ b/Mathlib/Topology/Algebra/NonUnitalAlgebra.lean
@@ -60,8 +60,11 @@ end Semiring
 section Ring
 
 variable {R A : Type*} [CommRing R] [TopologicalSpace A]
-variable [NonUnitalRing A] [Module R A] [TopologicalSemiring A]
+variable [NonUnitalRing A] [Module R A] [TopologicalRing A]
 variable [ContinuousConstSMul R A]
+
+instance instTopologicalRing (s : NonUnitalSubalgebra R A) : TopologicalRing s :=
+  s.toNonUnitalSubring.instTopologicalRing
 
 /-- If a non-unital subalgebra of a non-unital topological algebra is commutative, then so is its
 topological closure.

--- a/Mathlib/Topology/Algebra/NonUnitalAlgebra.lean
+++ b/Mathlib/Topology/Algebra/NonUnitalAlgebra.lean
@@ -49,7 +49,7 @@ theorem topologicalClosure_minimal (s : NonUnitalSubalgebra R A) {t : NonUnitalS
 
 /-- If a non-unital subalgebra of a non-unital topological algebra is commutative, then so is its
 topological closure. -/
-def nonUnitalCommSemiringTopologicalClosure [T2Space A] (s : NonUnitalSubalgebra R A)
+abbrev nonUnitalCommSemiringTopologicalClosure [T2Space A] (s : NonUnitalSubalgebra R A)
     (hs : ∀ x y : s, x * y = y * x) : NonUnitalCommSemiring s.topologicalClosure :=
   s.toNonUnitalSubsemiring.nonUnitalCommSemiringTopologicalClosure hs
 

--- a/Mathlib/Topology/Algebra/NonUnitalAlgebra.lean
+++ b/Mathlib/Topology/Algebra/NonUnitalAlgebra.lean
@@ -9,13 +9,13 @@ import Mathlib.Topology.Algebra.Module.Basic
 /-!
 # Non-unital topological (sub)algebras
 
-A non-unital topological algebra over a topological semiring `R` is a topological (non-unital) 
-semiring with a compatible continuous scalar multiplication by elements of `R`. We reuse 
+A non-unital topological algebra over a topological semiring `R` is a topological (non-unital)
+semiring with a compatible continuous scalar multiplication by elements of `R`. We reuse
 typeclass `ContinuousSMul` to express the latter condition.
 
 ## Results
 
-Any non-unital subalgebra of a non-unital topological algebra is itself a non-unital 
+Any non-unital subalgebra of a non-unital topological algebra is itself a non-unital
 topological algebra, and its closure is again a non-unital subalgebra.
 
 -/

--- a/Mathlib/Topology/Algebra/NonUnitalAlgebra.lean
+++ b/Mathlib/Topology/Algebra/NonUnitalAlgebra.lean
@@ -6,7 +6,19 @@ Authors: Jireh Loreaux
 import Mathlib.Algebra.Algebra.NonUnitalSubalgebra
 import Mathlib.Topology.Algebra.Module.Basic
 
-/-! # Non-unital topological (sub)algebras -/
+/-!
+# Non-unital topological (sub)algebras
+
+A non-unital topological algebra over a topological semiring `R` is a topological (non-unital) 
+semiring with a compatible continuous scalar multiplication by elements of `R`. We reuse 
+typeclass `ContinuousSMul` to express the latter condition.
+
+## Results
+
+Any non-unital subalgebra of a non-unital topological algebra is itself a non-unital 
+topological algebra, and its closure is again a non-unital subalgebra.
+
+-/
 
 namespace NonUnitalSubalgebra
 
@@ -29,7 +41,7 @@ theorem le_topologicalClosure (s : NonUnitalSubalgebra R A) : s ≤ s.topologica
   subset_closure
 
 theorem isClosed_topologicalClosure (s : NonUnitalSubalgebra R A) :
-    IsClosed (s.topologicalClosure : Set A) := by convert @isClosed_closure A s _
+    IsClosed (s.topologicalClosure : Set A) := isClosed_closure
 
 theorem topologicalClosure_minimal (s : NonUnitalSubalgebra R A) {t : NonUnitalSubalgebra R A}
     (h : s ≤ t) (ht : IsClosed (t : Set A)) : s.topologicalClosure ≤ t :=

--- a/Mathlib/Topology/Algebra/NonUnitalAlgebra.lean
+++ b/Mathlib/Topology/Algebra/NonUnitalAlgebra.lean
@@ -48,7 +48,9 @@ theorem topologicalClosure_minimal (s : NonUnitalSubalgebra R A) {t : NonUnitalS
   closure_minimal h ht
 
 /-- If a non-unital subalgebra of a non-unital topological algebra is commutative, then so is its
-topological closure. -/
+topological closure.
+
+See note [reducible non-instances]. -/
 abbrev nonUnitalCommSemiringTopologicalClosure [T2Space A] (s : NonUnitalSubalgebra R A)
     (hs : ∀ x y : s, x * y = y * x) : NonUnitalCommSemiring s.topologicalClosure :=
   s.toNonUnitalSubsemiring.nonUnitalCommSemiringTopologicalClosure hs

--- a/Mathlib/Topology/Algebra/NonUnitalAlgebra.lean
+++ b/Mathlib/Topology/Algebra/NonUnitalAlgebra.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2024 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+import Mathlib.Algebra.Algebra.NonUnitalSubalgebra
+import Mathlib.Topology.Algebra.Module.Basic
+
+/-! # Non-unital topological (sub)algebras -/
+
+namespace NonUnitalSubalgebra
+
+section Semiring
+
+variable {R A : Type*} [CommSemiring R] [TopologicalSpace A]
+variable [NonUnitalSemiring A] [Module R A] [TopologicalSemiring A]
+variable [ContinuousConstSMul R A]
+
+instance instTopologicalSemiring (s : NonUnitalSubalgebra R A) : TopologicalSemiring s :=
+  s.toNonUnitalSubsemiring.instTopologicalSemiring
+
+/-- The (topological) closure of a non-unital subalgebra of a non-unital topological algebra is
+itself a non-unital subalgebra. -/
+def topologicalClosure (s : NonUnitalSubalgebra R A) : NonUnitalSubalgebra R A :=
+  { s.toNonUnitalSubsemiring.topologicalClosure, s.toSubmodule.topologicalClosure with
+    carrier := _root_.closure (s : Set A) }
+
+theorem le_topologicalClosure (s : NonUnitalSubalgebra R A) : s ≤ s.topologicalClosure :=
+  subset_closure
+
+theorem isClosed_topologicalClosure (s : NonUnitalSubalgebra R A) :
+    IsClosed (s.topologicalClosure : Set A) := by convert @isClosed_closure A s _
+
+theorem topologicalClosure_minimal (s : NonUnitalSubalgebra R A) {t : NonUnitalSubalgebra R A}
+    (h : s ≤ t) (ht : IsClosed (t : Set A)) : s.topologicalClosure ≤ t :=
+  closure_minimal h ht
+
+/-- If a non-unital subalgebra of a non-unital topological algebra is commutative, then so is its
+topological closure. -/
+def nonUnitalCommSemiringTopologicalClosure [T2Space A] (s : NonUnitalSubalgebra R A)
+    (hs : ∀ x y : s, x * y = y * x) : NonUnitalCommSemiring s.topologicalClosure :=
+  s.toNonUnitalSubsemiring.nonUnitalCommSemiringTopologicalClosure hs
+
+end Semiring
+
+section Ring
+
+variable {R A : Type*} [CommRing R] [TopologicalSpace A]
+variable [NonUnitalRing A] [Module R A] [TopologicalSemiring A]
+variable [ContinuousConstSMul R A]
+
+/-- If a non-unital subalgebra of a non-unital topological algebra is commutative, then so is its
+topological closure.
+
+See note [reducible non-instances]. -/
+abbrev nonUnitalCommRingTopologicalClosure [T2Space A] (s : NonUnitalSubalgebra R A)
+    (hs : ∀ x y : s, x * y = y * x) : NonUnitalCommRing s.topologicalClosure :=
+  { s.topologicalClosure.toNonUnitalRing, s.toSubsemigroup.commSemigroupTopologicalClosure hs with }
+
+end Ring
+
+end NonUnitalSubalgebra

--- a/Mathlib/Topology/Algebra/NonUnitalStarAlgebra.lean
+++ b/Mathlib/Topology/Algebra/NonUnitalStarAlgebra.lean
@@ -10,14 +10,14 @@ import Mathlib.Topology.Algebra.Star
 /-!
 # Non-unital topological star (sub)algebras
 
-A non-unital topological star algebra over a topological semiring `R` is a topological 
-(non-unital) semiring with a compatible continuous scalar multiplication by elements 
-of `R` and a continuous `star` operation. We reuse typeclasses `ContinuousSMul` and 
+A non-unital topological star algebra over a topological semiring `R` is a topological
+(non-unital) semiring with a compatible continuous scalar multiplication by elements
+of `R` and a continuous `star` operation. We reuse typeclasses `ContinuousSMul` and
 `ContinuousStar` to express the latter two conditions.
 
 ## Results
 
-Any non-unital star subalgebra of a non-unital topological star algebra is itself a 
+Any non-unital star subalgebra of a non-unital topological star algebra is itself a
 non-unital topological star algebra, and its closure is again a non-unital star subalgebra.
 
 -/

--- a/Mathlib/Topology/Algebra/NonUnitalStarAlgebra.lean
+++ b/Mathlib/Topology/Algebra/NonUnitalStarAlgebra.lean
@@ -7,7 +7,20 @@ import Mathlib.Algebra.Star.NonUnitalSubalgebra
 import Mathlib.Topology.Algebra.NonUnitalAlgebra
 import Mathlib.Topology.Algebra.Star
 
-/-! # Non-unital topological star (sub)algebras -/
+/-!
+# Non-unital topological star (sub)algebras
+
+A non-unital topological star algebra over a topological semiring `R` is a topological 
+(non-unital) semiring with a compatible continuous scalar multiplication by elements 
+of `R` and a continuous `star` operation. We reuse typeclasses `ContinuousSMul` and 
+`ContinuousStar` to express the latter two conditions.
+
+## Results
+
+Any non-unital star subalgebra of a non-unital topological star algebra is itself a 
+non-unital topological star algebra, and its closure is again a non-unital star subalgebra.
+
+-/
 
 namespace NonUnitalStarSubalgebra
 
@@ -31,7 +44,7 @@ theorem le_topologicalClosure (s : NonUnitalStarSubalgebra R A) : s ≤ s.topolo
   subset_closure
 
 theorem isClosed_topologicalClosure (s : NonUnitalStarSubalgebra R A) :
-    IsClosed (s.topologicalClosure : Set A) := by convert @isClosed_closure A s _
+    IsClosed (s.topologicalClosure : Set A) := isClosed_closure
 
 theorem topologicalClosure_minimal (s : NonUnitalStarSubalgebra R A)
     {t : NonUnitalStarSubalgebra R A} (h : s ≤ t) (ht : IsClosed (t : Set A)) :

--- a/Mathlib/Topology/Algebra/NonUnitalStarAlgebra.lean
+++ b/Mathlib/Topology/Algebra/NonUnitalStarAlgebra.lean
@@ -52,7 +52,9 @@ theorem topologicalClosure_minimal (s : NonUnitalStarSubalgebra R A)
   closure_minimal h ht
 
 /-- If a non-unital star subalgebra of a non-unital topological star algebra is commutative, then
-so is its topological closure. -/
+so is its topological closure.
+
+See note [reducible non-instances] -/
 abbrev nonUnitalCommSemiringTopologicalClosure [T2Space A] (s : NonUnitalStarSubalgebra R A)
     (hs : ∀ x y : s, x * y = y * x) : NonUnitalCommSemiring s.topologicalClosure :=
   s.toNonUnitalSubalgebra.nonUnitalCommSemiringTopologicalClosure hs

--- a/Mathlib/Topology/Algebra/NonUnitalStarAlgebra.lean
+++ b/Mathlib/Topology/Algebra/NonUnitalStarAlgebra.lean
@@ -64,8 +64,11 @@ end Semiring
 section Ring
 
 variable {R A : Type*} [CommRing R] [TopologicalSpace A]
-variable [NonUnitalRing A] [Module R A] [Star A] [TopologicalSemiring A] [ContinuousStar A]
+variable [NonUnitalRing A] [Module R A] [Star A] [TopologicalRing A] [ContinuousStar A]
 variable [ContinuousConstSMul R A]
+
+instance instTopologicalRing (s : NonUnitalStarSubalgebra R A) : TopologicalRing s :=
+  s.toNonUnitalSubring.instTopologicalRing
 
 /-- If a non-unital star subalgebra of a non-unital topological star algebra is commutative, then
 so is its topological closure.

--- a/Mathlib/Topology/Algebra/NonUnitalStarAlgebra.lean
+++ b/Mathlib/Topology/Algebra/NonUnitalStarAlgebra.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
 import Mathlib.Algebra.Star.NonUnitalSubalgebra
-import Mathlib.Algebra.Star.SelfAdjoint
 import Mathlib.Topology.Algebra.NonUnitalAlgebra
 import Mathlib.Topology.Algebra.Star
 

--- a/Mathlib/Topology/Algebra/NonUnitalStarAlgebra.lean
+++ b/Mathlib/Topology/Algebra/NonUnitalStarAlgebra.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2024 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+import Mathlib.Algebra.Star.NonUnitalSubalgebra
+import Mathlib.Algebra.Star.SelfAdjoint
+import Mathlib.Topology.Algebra.NonUnitalAlgebra
+import Mathlib.Topology.Algebra.Star
+
+/-! # Non-unital topological star (sub)algebras -/
+
+namespace NonUnitalStarSubalgebra
+
+section Semiring
+
+variable {R A : Type*} [CommSemiring R] [TopologicalSpace A] [Star A]
+variable [NonUnitalSemiring A] [Module R A] [TopologicalSemiring A] [ContinuousStar A]
+variable [ContinuousConstSMul R A]
+
+instance instTopologicalSemiring (s : NonUnitalStarSubalgebra R A) : TopologicalSemiring s :=
+  s.toNonUnitalSubalgebra.instTopologicalSemiring
+
+/-- The (topological) closure of a non-unital star subalgebra of a non-unital topological star
+algebra is itself a non-unital star subalgebra. -/
+def topologicalClosure (s : NonUnitalStarSubalgebra R A) : NonUnitalStarSubalgebra R A :=
+  { s.toNonUnitalSubalgebra.topologicalClosure with
+    star_mem' := fun h ↦ map_mem_closure continuous_star h fun _ ↦ star_mem
+    carrier := _root_.closure (s : Set A) }
+
+theorem le_topologicalClosure (s : NonUnitalStarSubalgebra R A) : s ≤ s.topologicalClosure :=
+  subset_closure
+
+theorem isClosed_topologicalClosure (s : NonUnitalStarSubalgebra R A) :
+    IsClosed (s.topologicalClosure : Set A) := by convert @isClosed_closure A s _
+
+theorem topologicalClosure_minimal (s : NonUnitalStarSubalgebra R A)
+    {t : NonUnitalStarSubalgebra R A} (h : s ≤ t) (ht : IsClosed (t : Set A)) :
+    s.topologicalClosure ≤ t :=
+  closure_minimal h ht
+
+/-- If a non-unital star subalgebra of a non-unital topological star algebra is commutative, then
+so is its topological closure. -/
+abbrev nonUnitalCommSemiringTopologicalClosure [T2Space A] (s : NonUnitalStarSubalgebra R A)
+    (hs : ∀ x y : s, x * y = y * x) : NonUnitalCommSemiring s.topologicalClosure :=
+  s.toNonUnitalSubalgebra.nonUnitalCommSemiringTopologicalClosure hs
+
+end Semiring
+
+section Ring
+
+variable {R A : Type*} [CommRing R] [TopologicalSpace A]
+variable [NonUnitalRing A] [Module R A] [Star A] [TopologicalSemiring A] [ContinuousStar A]
+variable [ContinuousConstSMul R A]
+
+/-- If a non-unital star subalgebra of a non-unital topological star algebra is commutative, then
+so is its topological closure.
+
+See note [reducible non-instances]. -/
+abbrev nonUnitalCommRingTopologicalClosure [T2Space A] (s : NonUnitalStarSubalgebra R A)
+    (hs : ∀ x y : s, x * y = y * x) : NonUnitalCommRing s.topologicalClosure :=
+  { s.topologicalClosure.toNonUnitalRing, s.toSubsemigroup.commSemigroupTopologicalClosure hs with }
+
+end Ring
+
+end NonUnitalStarSubalgebra

--- a/Mathlib/Topology/Algebra/Ring/Basic.lean
+++ b/Mathlib/Topology/Algebra/Ring/Basic.lean
@@ -111,7 +111,7 @@ theorem topologicalClosure_minimal (s : NonUnitalSubsemiring α) {t : NonUnitalS
 
 /-- If a non-unital subsemiring of a non-unital topological semiring is commutative, then so is its
 topological closure. -/
-def nonUnitalCommSemiringTopologicalClosure [T2Space α] (s : NonUnitalSubsemiring α)
+abbrev nonUnitalCommSemiringTopologicalClosure [T2Space α] (s : NonUnitalSubsemiring α)
     (hs : ∀ x y : s, x * y = y * x) : NonUnitalCommSemiring s.topologicalClosure :=
   { NonUnitalSubsemiringClass.toNonUnitalSemiring s.topologicalClosure,
     s.toSubsemigroup.commSemigroupTopologicalClosure hs with }

--- a/Mathlib/Topology/Algebra/Ring/Basic.lean
+++ b/Mathlib/Topology/Algebra/Ring/Basic.lean
@@ -110,7 +110,9 @@ theorem topologicalClosure_minimal (s : NonUnitalSubsemiring α) {t : NonUnitalS
   closure_minimal h ht
 
 /-- If a non-unital subsemiring of a non-unital topological semiring is commutative, then so is its
-topological closure. -/
+topological closure.
+
+See note [reducible non-instances] -/
 abbrev nonUnitalCommSemiringTopologicalClosure [T2Space α] (s : NonUnitalSubsemiring α)
     (hs : ∀ x y : s, x * y = y * x) : NonUnitalCommSemiring s.topologicalClosure :=
   { NonUnitalSubsemiringClass.toNonUnitalSemiring s.topologicalClosure,
@@ -290,8 +292,10 @@ theorem topologicalClosure_minimal (s : NonUnitalSubring α) {t : NonUnitalSubri
   closure_minimal h ht
 
 /-- If a non-unital subring of a non-unital topological ring is commutative, then so is its
-topological closure. -/
-def nonUnitalCommRingTopologicalClosure [T2Space α] (s : NonUnitalSubring α)
+topological closure.
+
+See note [reducible non-instances] -/
+abbrev nonUnitalCommRingTopologicalClosure [T2Space α] (s : NonUnitalSubring α)
     (hs : ∀ x y : s, x * y = y * x) : NonUnitalCommRing s.topologicalClosure :=
   { s.topologicalClosure.toNonUnitalRing, s.toSubsemigroup.commSemigroupTopologicalClosure hs with }
 

--- a/Mathlib/Topology/Algebra/Ring/Basic.lean
+++ b/Mathlib/Topology/Algebra/Ring/Basic.lean
@@ -81,6 +81,43 @@ instance (priority := 50) DiscreteTopology.topologicalRing [TopologicalSpace α]
 
 section
 
+namespace NonUnitalSubsemiring
+
+variable [TopologicalSpace α] [NonUnitalSemiring α] [TopologicalSemiring α]
+
+instance instTopologicalSemiring (S : NonUnitalSubsemiring α) : TopologicalSemiring S :=
+  { S.toSubsemigroup.continuousMul, S.toAddSubmonoid.continuousAdd with }
+
+/-- The (topological) closure of a non-unital subsemiring of a non-unital topological semiring is
+itself a non-unital subsemiring. -/
+def topologicalClosure (s : NonUnitalSubsemiring α) : NonUnitalSubsemiring α :=
+  { s.toSubsemigroup.topologicalClosure, s.toAddSubmonoid.topologicalClosure with
+    carrier := _root_.closure (s : Set α) }
+
+@[simp]
+theorem topologicalClosure_coe (s : NonUnitalSubsemiring α) :
+    (s.topologicalClosure : Set α) = _root_.closure (s : Set α) :=
+  rfl
+
+theorem le_topologicalClosure (s : NonUnitalSubsemiring α) : s ≤ s.topologicalClosure :=
+  _root_.subset_closure
+
+theorem isClosed_topologicalClosure (s : NonUnitalSubsemiring α) :
+    IsClosed (s.topologicalClosure : Set α) := isClosed_closure
+
+theorem topologicalClosure_minimal (s : NonUnitalSubsemiring α) {t : NonUnitalSubsemiring α}
+    (h : s ≤ t) (ht : IsClosed (t : Set α)) : s.topologicalClosure ≤ t :=
+  closure_minimal h ht
+
+/-- If a non-unital subsemiring of a non-unital topological semiring is commutative, then so is its
+topological closure. -/
+def nonUnitalCommSemiringTopologicalClosure [T2Space α] (s : NonUnitalSubsemiring α)
+    (hs : ∀ x y : s, x * y = y * x) : NonUnitalCommSemiring s.topologicalClosure :=
+  { NonUnitalSubsemiringClass.toNonUnitalSemiring s.topologicalClosure,
+    s.toSubsemigroup.commSemigroupTopologicalClosure hs with }
+
+end NonUnitalSubsemiring
+
 variable [TopologicalSpace α] [Semiring α] [TopologicalSemiring α]
 
 instance : TopologicalSemiring (ULift α) where
@@ -228,6 +265,37 @@ theorem mulRight_continuous (x : α) : Continuous (AddMonoidHom.mulRight x) :=
   continuous_id.mul continuous_const
 
 end
+
+namespace NonUnitalSubring
+
+variable [NonUnitalRing α] [TopologicalRing α]
+
+instance instTopologicalRing (S : NonUnitalSubring α) : TopologicalRing S :=
+  { S.toSubsemigroup.continuousMul, inferInstanceAs (TopologicalAddGroup S.toAddSubgroup) with }
+
+/-- The (topological) closure of a non-unital subring of a non-unital topological ring is
+itself a non-unital subring. -/
+def topologicalClosure (S : NonUnitalSubring α) : NonUnitalSubring α :=
+  { S.toSubsemigroup.topologicalClosure, S.toAddSubgroup.topologicalClosure with
+    carrier := _root_.closure (S : Set α) }
+
+theorem le_topologicalClosure (s : NonUnitalSubring α) : s ≤ s.topologicalClosure :=
+  _root_.subset_closure
+
+theorem isClosed_topologicalClosure (s : NonUnitalSubring α) :
+    IsClosed (s.topologicalClosure : Set α) := isClosed_closure
+
+theorem topologicalClosure_minimal (s : NonUnitalSubring α) {t : NonUnitalSubring α} (h : s ≤ t)
+    (ht : IsClosed (t : Set α)) : s.topologicalClosure ≤ t :=
+  closure_minimal h ht
+
+/-- If a non-unital subring of a non-unital topological ring is commutative, then so is its
+topological closure. -/
+def nonUnitalCommRingTopologicalClosure [T2Space α] (s : NonUnitalSubring α)
+    (hs : ∀ x y : s, x * y = y * x) : NonUnitalCommRing s.topologicalClosure :=
+  { s.topologicalClosure.toNonUnitalRing, s.toSubsemigroup.commSemigroupTopologicalClosure hs with }
+
+end NonUnitalSubring
 
 variable [Ring α] [TopologicalRing α]
 


### PR DESCRIPTION
This adds `*.topologicalClosure` and the related fundamental lemmas for each of `Semigroup`, `AddSemigroup`, `NonUnitalSemiring`, `NonUnitalSubring`, `NonUnitalAlgebra` and `NonUnitalStarAlgebra`, thereby filling a gap in our API for these objects.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
