### PR TITLE
[Merged by Bors] - chore(SpecialFunctions/Log): transfer results from log to logb

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -106,7 +106,7 @@ theorem div_logb {a b c : ℝ} (h₁ : c ≠ 0) (h₂ : c ≠ 1) (h₃ : c ≠ -
 theorem logb_rpow_eq_mul_logb_of_pos (hx : 0 < x) : logb b (x ^ y) = y * logb b x := by
   rw [logb, log_rpow hx, logb, mul_div_assoc]
 
-theorem logb_pow {k : ℕ} : logb b (x ^ k) = k * logb b x := by
+theorem logb_pow (b x : ℝ) (k : ℕ) : logb b (x ^ k) = k * logb b x := by
   rw [logb, logb, log_pow, mul_div_assoc]
 
 section BPosAndNeOne

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -106,8 +106,8 @@ theorem div_logb {a b c : ℝ} (h₁ : c ≠ 0) (h₂ : c ≠ 1) (h₃ : c ≠ -
 theorem logb_rpow_eq_mul_logb_of_pos (hx : 0 < x) : logb b (x ^ y) = y * logb b x := by
   rw [logb, log_rpow hx, logb, mul_div_assoc]
 
-theorem logb_pow {k : ℕ} (hx : 0 < x) : logb b (x ^ k) = k * logb b x := by
-  rw [← rpow_natCast, logb_rpow_eq_mul_logb_of_pos hx]
+theorem logb_pow {k : ℕ} : logb b (x ^ k) = k * logb b x := by
+  rw [logb, logb, log_pow, mul_div_assoc]
 
 section BPosAndNeOne
 
@@ -399,7 +399,47 @@ theorem logb_eq_zero : logb b x = 0 ↔ b = 0 ∨ b = 1 ∨ b = -1 ∨ x = 0 ∨
   simp_rw [logb, div_eq_zero_iff, log_eq_zero]
   tauto
 
--- TODO add other limits and continuous API lemmas analogous to those in Log.lean
+theorem tendsto_logb_nhdsWithin_zero (hb : 1 < b) :
+    Tendsto (logb b) (𝓝[≠] 0) atBot :=
+  tendsto_log_nhdsWithin_zero.atBot_div_const (log_pos hb)
+
+theorem tendsto_logb_nhdsWithin_zero_of_base_lt_one (hb₀ : 0 < b) (hb : b < 1) :
+    Tendsto (logb b) (𝓝[≠] 0) atTop :=
+  tendsto_log_nhdsWithin_zero.atBot_mul_const_of_neg (inv_lt_zero.2 (log_neg hb₀ hb))
+
+lemma tendsto_logb_nhdsWithin_zero_right (hb : 1 < b) : Tendsto (logb b) (𝓝[>] 0) atBot :=
+  tendsto_log_nhdsWithin_zero_right.atBot_div_const (log_pos hb)
+
+lemma tendsto_logb_nhdsWithin_zero_right_of_base_lt_one (hb₀ : 0 < b) (hb : b < 1) :
+    Tendsto (logb b) (𝓝[>] 0) atTop :=
+  tendsto_log_nhdsWithin_zero_right.atBot_mul_const_of_neg (inv_lt_zero.2 (log_neg hb₀ hb))
+
+theorem continuousOn_logb : ContinuousOn (logb b) {0}ᶜ := continuousOn_log.div_const _
+
+/-- The real logarithm base b is continuous as a function from nonzero reals. -/
+@[continuity]
+theorem continuous_logb : Continuous fun x : { x : ℝ // x ≠ 0 } => logb b x :=
+  continuous_log.div_const _
+
+/-- The real logarithm base b is continuous as a function from positive reals. -/
+@[continuity]
+theorem continuous_logb' : Continuous fun x : { x : ℝ // 0 < x } => logb b x :=
+  continuous_log'.div_const _
+
+theorem continuousAt_logb (hx : x ≠ 0) : ContinuousAt (logb b) x :=
+  (continuousAt_log hx).div_const _
+
+@[simp]
+theorem continuousAt_logb_iff (hb₀ : 0 < b) (hb : b ≠ 1) : ContinuousAt (logb b) x ↔ x ≠ 0 := by
+  refine ⟨?_, continuousAt_logb⟩
+  rintro h rfl
+  cases lt_or_gt_of_ne hb with
+  | inl hb₁ =>
+      exact not_tendsto_nhds_of_tendsto_atTop (tendsto_logb_nhdsWithin_zero_of_base_lt_one hb₀ hb₁)
+        _ (h.tendsto.mono_left inf_le_left)
+  | inr hb₁ =>
+      exact not_tendsto_nhds_of_tendsto_atBot (tendsto_logb_nhdsWithin_zero hb₁)
+        _ (h.tendsto.mono_left inf_le_left)
 
 theorem logb_prod {α : Type*} (s : Finset α) (f : α → ℝ) (hf : ∀ x ∈ s, f x ≠ 0) :
     logb b (∏ i ∈ s, f i) = ∑ i ∈ s, logb b (f i) := by
@@ -408,6 +448,16 @@ theorem logb_prod {α : Type*} (s : Finset α) (f : α → ℝ) (hf : ∀ x ∈ 
     · simp
     simp only [Finset.mem_insert, forall_eq_or_imp] at hf
     simp [ha, ih hf.2, logb_mul hf.1 (Finset.prod_ne_zero_iff.2 hf.2)]
+
+protected theorem _root_.Finsupp.logb_prod {α β : Type*} [Zero β] (f : α →₀ β) (g : α → β → ℝ)
+    (hg : ∀ a, g a (f a) = 0 → f a = 0) : logb b (f.prod g) = f.sum fun a c ↦ logb b (g a c) :=
+  logb_prod _ _ fun _x hx h₀ ↦ Finsupp.mem_support_iff.1 hx <| hg _ h₀
+
+theorem logb_nat_eq_sum_factorization (n : ℕ) :
+    logb b n = n.factorization.sum fun p t => t * logb b p := by
+  simp only [logb, mul_div_assoc', log_nat_eq_sum_factorization n, Finsupp.sum, Finset.sum_div]
+
+-- TODO add other limits and continuous API lemmas analogous to those in Log.lean
 
 end Real
 

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -417,12 +417,12 @@ lemma tendsto_logb_nhdsWithin_zero_right_of_base_lt_one (hb₀ : 0 < b) (hb : b 
 theorem continuousOn_logb : ContinuousOn (logb b) {0}ᶜ := continuousOn_log.div_const _
 
 /-- The real logarithm base b is continuous as a function from nonzero reals. -/
-@[continuity]
+@[fun_prop]
 theorem continuous_logb : Continuous fun x : { x : ℝ // x ≠ 0 } => logb b x :=
   continuous_log.div_const _
 
 /-- The real logarithm base b is continuous as a function from positive reals. -/
-@[continuity]
+@[fun_prop]
 theorem continuous_logb' : Continuous fun x : { x : ℝ // 0 < x } => logb b x :=
   continuous_log'.div_const _
 

--- a/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -324,10 +324,12 @@ theorem continuousOn_log : ContinuousOn log {0}ᶜ := by
   conv in log _ => rw [log_of_ne_zero (show (x : ℝ) ≠ 0 from x.2)]
   exact expOrderIso.symm.continuous.comp (continuous_subtype_val.norm.subtype_mk _)
 
+/-- The real logarithm is continuous as a function from nonzero reals. -/
 @[continuity]
 theorem continuous_log : Continuous fun x : { x : ℝ // x ≠ 0 } => log x :=
   continuousOn_iff_continuous_restrict.1 <| continuousOn_log.mono fun _ => id
 
+/-- The real logarithm is continuous as a function from positive reals. -/
 @[continuity]
 theorem continuous_log' : Continuous fun x : { x : ℝ // 0 < x } => log x :=
   continuousOn_iff_continuous_restrict.1 <| continuousOn_log.mono fun _ hx => ne_of_gt hx

--- a/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -325,12 +325,12 @@ theorem continuousOn_log : ContinuousOn log {0}ᶜ := by
   exact expOrderIso.symm.continuous.comp (continuous_subtype_val.norm.subtype_mk _)
 
 /-- The real logarithm is continuous as a function from nonzero reals. -/
-@[continuity]
+@[fun_prop]
 theorem continuous_log : Continuous fun x : { x : ℝ // x ≠ 0 } => log x :=
   continuousOn_iff_continuous_restrict.1 <| continuousOn_log.mono fun _ => id
 
 /-- The real logarithm is continuous as a function from positive reals. -/
-@[continuity]
+@[fun_prop]
 theorem continuous_log' : Continuous fun x : { x : ℝ // 0 < x } => log x :=
   continuousOn_iff_continuous_restrict.1 <| continuousOn_log.mono fun _ hx => ne_of_gt hx
 

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -377,7 +377,7 @@ lemma one_lt_of_not_bounded (notbdd : ¬ ∀ n : ℕ, f n ≤ 1) {n₀ : ℕ} (h
       gcongr
       exact h_ineq1 <| one_le_pow₀ (one_le_iff_ne_zero.mpr h₀)
     _   = (n₀ * (k * logb n₀ n + 1)) ^ (k : ℝ)⁻¹ := by
-      rw [Nat.cast_pow, logb_pow (mod_cast h₀.bot_lt)]
+      rw [Nat.cast_pow, logb_pow]
     _   ≤ (n₀ * ( k * logb n₀ n + k)) ^ (k : ℝ)⁻¹ := by
       gcongr
       exact one_le_cast.mpr hk

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -438,7 +438,6 @@ private lemma param_upperbound {k : ℕ} (hk : k ≠ 0) :
     _ ≤ (m * f m / (f m - 1)) * (f m) ^ (logb m ↑(n ^ k)) := h_ineq1 hm (Nat.one_lt_pow hk hn)
     _ = (m * f m / (f m - 1)) * (f m) ^ (k * logb m n) := by
       rw [Nat.cast_pow, Real.logb_pow]
-      exact_mod_cast zero_lt_of_lt hn
 
 include hm hn notbdd in
 /-- Given two natural numbers `n, m` greater than 1 we have `f n ≤ f m ^ logb m n`. -/


### PR DESCRIPTION
These are mostly transferred directly, except for `continuousAt_logb_iff` which needs different handling since it's not always true.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
