### PR TITLE
[Merged by Bors] - feat: expand API of `ContMDiff` and `MFDeriv`

### DIFF
--- a/Mathlib/Geometry/Manifold/ContMDiff/Atlas.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Atlas.lean
@@ -99,6 +99,17 @@ theorem contMDiffOn_extChartAt_symm (x : M) :
   convert contMDiffOn_extend_symm (chart_mem_maximalAtlas (I := I) x)
   rw [extChartAt_target, I.image_eq]
 
+theorem contMDiffWithinAt_extChartAt_symm_target
+    (x : M) {y : E} (hy : y ∈ (extChartAt I x).target) :
+    ContMDiffWithinAt 𝓘(𝕜, E) I n (extChartAt I x).symm (extChartAt I x).target y :=
+  contMDiffOn_extChartAt_symm x y hy
+
+theorem contMDiffWithinAt_extChartAt_symm_range
+    (x : M) {y : E} (hy : y ∈ (extChartAt I x).target) :
+    ContMDiffWithinAt 𝓘(𝕜, E) I n (extChartAt I x).symm (range I) y :=
+  (contMDiffWithinAt_extChartAt_symm_target x hy).mono_of_mem_nhdsWithin
+    (extChartAt_target_mem_nhdsWithin_of_mem hy)
+
 /-- An element of `contDiffGroupoid ⊤ I` is `C^n` for any `n`. -/
 theorem contMDiffOn_of_mem_contDiffGroupoid {e' : PartialHomeomorph H H}
     (h : e' ∈ contDiffGroupoid ⊤ I) : ContMDiffOn I I n e' e'.source :=

--- a/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
@@ -771,7 +771,6 @@ theorem contMDiffWithinAt_iff_contMDiffOn_nhds
     rwa [contMDiffOn_iff_of_subset_source' hv₁ hv₂, PartialEquiv.image_symm_image_of_subset_target]
     exact hsub.trans inter_subset_left
 
-
 /-- If a function is `C^m` within a set at a point, for some finite `m`, then it is `C^m` within
 this set on an open set around the basepoint.
 -/

--- a/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
@@ -654,10 +654,16 @@ theorem ContMDiffWithinAt.mono (hf : ContMDiffWithinAt I I' n f s x) (hts : t �
     ContMDiffWithinAt I I' n f t x :=
   hf.mono_of_mem_nhdsWithin <| mem_of_superset self_mem_nhdsWithin hts
 
-theorem contMDiffWithinAt_congr_nhds (hst : 𝓝[s] x = 𝓝[t] x) :
+theorem contMDiffWithinAt_congr_set (h : s =ᶠ[𝓝 x] t) :
     ContMDiffWithinAt I I' n f s x ↔ ContMDiffWithinAt I I' n f t x :=
-  ⟨fun h => h.mono_of_mem_nhdsWithin <| hst ▸ self_mem_nhdsWithin, fun h =>
-    h.mono_of_mem_nhdsWithin <| hst.symm ▸ self_mem_nhdsWithin⟩
+  (contDiffWithinAt_localInvariantProp n).liftPropWithinAt_congr_set h
+
+theorem ContMDiffWithinAt.congr_set (h : ContMDiffWithinAt I I' n f s x) (hst : s =ᶠ[𝓝 x] t) :
+    ContMDiffWithinAt I I' n f t x :=
+  (contMDiffWithinAt_congr_set hst).1 h
+
+@[deprecated (since := "2024-10-23")]
+alias contMDiffWithinAt_congr_nhds := contMDiffWithinAt_congr_set
 
 theorem contMDiffWithinAt_insert_self :
     ContMDiffWithinAt I I' n f (insert x s) x ↔ ContMDiffWithinAt I I' n f s x := by
@@ -669,24 +675,32 @@ theorem contMDiffWithinAt_insert_self :
 alias ⟨ContMDiffWithinAt.of_insert, _⟩ := contMDiffWithinAt_insert_self
 
 -- TODO: use `alias` again once it can make protected theorems
-theorem ContMDiffWithinAt.insert (h : ContMDiffWithinAt I I' n f s x) :
+protected theorem ContMDiffWithinAt.insert (h : ContMDiffWithinAt I I' n f s x) :
     ContMDiffWithinAt I I' n f (insert x s) x :=
   contMDiffWithinAt_insert_self.2 h
 
-theorem ContMDiffAt.contMDiffWithinAt (hf : ContMDiffAt I I' n f x) :
+/-- Being `C^n` in a set only depends on the germ of the set. Version where one only requires
+the two sets to coincide locally in the complement of a point `y`. -/
+theorem contMDiffWithinAt_congr_set' (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
+    ContMDiffWithinAt I I' n f s x ↔ ContMDiffWithinAt I I' n f t x := by
+  have : T1Space M := I.t1Space M
+  rw [← contMDiffWithinAt_insert_self (s := s), ← contMDiffWithinAt_insert_self (s := t)]
+  exact contMDiffWithinAt_congr_set (eventuallyEq_insert h)
+
+protected theorem ContMDiffAt.contMDiffWithinAt (hf : ContMDiffAt I I' n f x) :
     ContMDiffWithinAt I I' n f s x :=
   ContMDiffWithinAt.mono hf (subset_univ _)
 
-theorem SmoothAt.smoothWithinAt (hf : SmoothAt I I' f x) : SmoothWithinAt I I' f s x :=
+protected theorem SmoothAt.smoothWithinAt (hf : SmoothAt I I' f x) : SmoothWithinAt I I' f s x :=
   ContMDiffAt.contMDiffWithinAt hf
 
 theorem ContMDiffOn.mono (hf : ContMDiffOn I I' n f s) (hts : t ⊆ s) : ContMDiffOn I I' n f t :=
   fun x hx => (hf x (hts hx)).mono hts
 
-theorem ContMDiff.contMDiffOn (hf : ContMDiff I I' n f) : ContMDiffOn I I' n f s := fun x _ =>
-  (hf x).contMDiffWithinAt
+protected theorem ContMDiff.contMDiffOn (hf : ContMDiff I I' n f) : ContMDiffOn I I' n f s :=
+  fun x _ => (hf x).contMDiffWithinAt
 
-theorem Smooth.smoothOn (hf : Smooth I I' f) : SmoothOn I I' f s :=
+protected theorem Smooth.smoothOn (hf : Smooth I I' f) : SmoothOn I I' f s :=
   ContMDiff.contMDiffOn hf
 
 theorem contMDiffWithinAt_inter' (ht : t ∈ 𝓝[s] x) :
@@ -697,19 +711,20 @@ theorem contMDiffWithinAt_inter (ht : t ∈ 𝓝 x) :
     ContMDiffWithinAt I I' n f (s ∩ t) x ↔ ContMDiffWithinAt I I' n f s x :=
   (contDiffWithinAt_localInvariantProp n).liftPropWithinAt_inter ht
 
-theorem ContMDiffWithinAt.contMDiffAt (h : ContMDiffWithinAt I I' n f s x) (ht : s ∈ 𝓝 x) :
+protected theorem ContMDiffWithinAt.contMDiffAt
+    (h : ContMDiffWithinAt I I' n f s x) (ht : s ∈ 𝓝 x) :
     ContMDiffAt I I' n f x :=
   (contDiffWithinAt_localInvariantProp n).liftPropAt_of_liftPropWithinAt h ht
 
-theorem SmoothWithinAt.smoothAt (h : SmoothWithinAt I I' f s x) (ht : s ∈ 𝓝 x) :
+protected theorem SmoothWithinAt.smoothAt (h : SmoothWithinAt I I' f s x) (ht : s ∈ 𝓝 x) :
     SmoothAt I I' f x :=
   ContMDiffWithinAt.contMDiffAt h ht
 
-theorem ContMDiffOn.contMDiffAt (h : ContMDiffOn I I' n f s) (hx : s ∈ 𝓝 x) :
+protected theorem ContMDiffOn.contMDiffAt (h : ContMDiffOn I I' n f s) (hx : s ∈ 𝓝 x) :
     ContMDiffAt I I' n f x :=
   (h x (mem_of_mem_nhds hx)).contMDiffAt hx
 
-theorem SmoothOn.smoothAt (h : SmoothOn I I' f s) (hx : s ∈ 𝓝 x) : SmoothAt I I' f x :=
+protected theorem SmoothOn.smoothAt (h : SmoothOn I I' f s) (hx : s ∈ 𝓝 x) : SmoothAt I I' f x :=
   h.contMDiffAt hx
 
 theorem contMDiffOn_iff_source_of_mem_maximalAtlas [SmoothManifoldWithCorners I M]
@@ -719,9 +734,8 @@ theorem contMDiffOn_iff_source_of_mem_maximalAtlas [SmoothManifoldWithCorners I 
   simp_rw [ContMDiffOn, Set.forall_mem_image]
   refine forall₂_congr fun x hx => ?_
   rw [contMDiffWithinAt_iff_source_of_mem_maximalAtlas he (hs hx)]
-  apply contMDiffWithinAt_congr_nhds
-  simp_rw [nhdsWithin_eq_iff_eventuallyEq,
-    e.extend_symm_preimage_inter_range_eventuallyEq hs (hs hx)]
+  apply contMDiffWithinAt_congr_set
+  simp_rw [e.extend_symm_preimage_inter_range_eventuallyEq hs (hs hx)]
 
 -- Porting note: didn't compile; fixed by golfing the proof and moving parts to lemmas
 /-- A function is `C^n` within a set at a point, for `n : ℕ`, if and only if it is `C^n` on
@@ -757,6 +771,30 @@ theorem contMDiffWithinAt_iff_contMDiffOn_nhds
     rwa [contMDiffOn_iff_of_subset_source' hv₁ hv₂, PartialEquiv.image_symm_image_of_subset_target]
     exact hsub.trans inter_subset_left
 
+
+/-- If a function is `C^m` within a set at a point, for some finite `m`, then it is `C^m` within
+this set on an open set around the basepoint.
+-/
+theorem ContMDiffWithinAt.contMDiffOn'
+    [SmoothManifoldWithCorners I M] [SmoothManifoldWithCorners I' M']
+    {m : ℕ} (hm : (m : ℕ∞) ≤ n)
+    (h : ContMDiffWithinAt I I' n f s x) :
+    ∃ u, IsOpen u ∧ x ∈ u ∧ ContMDiffOn I I' m f (insert x s ∩ u) := by
+  rcases contMDiffWithinAt_iff_contMDiffOn_nhds.1 (h.of_le hm) with ⟨t, ht, h't⟩
+  rcases mem_nhdsWithin.1 ht with ⟨u, u_open, xu, hu⟩
+  rw [inter_comm] at hu
+  exact ⟨u, u_open, xu, h't.mono hu⟩
+
+/-- If a function is `C^m` within a set at a point, for some finite `m`, then it is `C^m` within
+this set on a neighborhood of the basepoint. -/
+theorem ContMDiffWithinAt.contMDiffOn
+    [SmoothManifoldWithCorners I M] [SmoothManifoldWithCorners I' M']
+    {m : ℕ} (hm : (m : ℕ∞) ≤ n)
+    (h : ContMDiffWithinAt I I' n f s x) :
+    ∃ u ∈ 𝓝[insert x s] x, u ⊆ insert x s ∧ ContMDiffOn I I' m f u := by
+  let ⟨_u, uo, xu, h⟩ := h.contMDiffOn' hm
+  exact ⟨_, inter_mem_nhdsWithin _ (uo.mem_nhds xu), inter_subset_left, h⟩
+
 /-- A function is `C^n` at a point, for `n : ℕ`, if and only if it is `C^n` on
 a neighborhood of this point. -/
 theorem contMDiffAt_iff_contMDiffOn_nhds
@@ -775,6 +813,19 @@ theorem contMDiffAt_iff_contMDiffAt_nhds
   refine (eventually_mem_nhds_iff.mpr hu).mono fun x' hx' => ?_
   exact (h x' <| mem_of_mem_nhds hx').contMDiffAt hx'
 
+/-- Note: This does not hold for `n = ∞`. `f` being `C^∞` at `x` means that for every `n`, `f` is
+`C^n` on some neighborhood of `x`, but this neighborhood can depend on `n`. -/
+theorem contMDiffWithinAt_iff_contMDiffWithinAt_nhdsWithin
+    [SmoothManifoldWithCorners I M] [SmoothManifoldWithCorners I' M'] {n : ℕ} :
+    ContMDiffWithinAt I I' n f s x ↔
+      ∀ᶠ x' in 𝓝[insert x s] x, ContMDiffWithinAt I I' n f s x' := by
+  refine ⟨?_, fun h ↦ mem_of_mem_nhdsWithin (mem_insert x s) h⟩
+  rw [contMDiffWithinAt_iff_contMDiffOn_nhds]
+  rintro ⟨u, hu, h⟩
+  filter_upwards [hu, eventually_mem_nhdsWithin_iff.mpr hu] with x' h'x' hx'
+  apply (h x' h'x').mono_of_mem_nhdsWithin
+  exact nhdsWithin_mono _ (subset_insert x s) hx'
+
 /-! ### Congruence lemmas -/
 
 theorem ContMDiffWithinAt.congr (h : ContMDiffWithinAt I I' n f s x) (h₁ : ∀ y ∈ s, f₁ y = f y)
@@ -785,9 +836,22 @@ theorem contMDiffWithinAt_congr (h₁ : ∀ y ∈ s, f₁ y = f y) (hx : f₁ x 
     ContMDiffWithinAt I I' n f₁ s x ↔ ContMDiffWithinAt I I' n f s x :=
   (contDiffWithinAt_localInvariantProp n).liftPropWithinAt_congr_iff h₁ hx
 
+theorem ContMDiffWithinAt.congr_of_mem
+    (h : ContMDiffWithinAt I I' n f s x) (h₁ : ∀ y ∈ s, f₁ y = f y) (hx : x ∈ s) :
+    ContMDiffWithinAt I I' n f₁ s x :=
+  (contDiffWithinAt_localInvariantProp n).liftPropWithinAt_congr_of_mem h h₁ hx
+
+theorem contMDiffWithinAt_congr_of_mem (h₁ : ∀ y ∈ s, f₁ y = f y) (hx : x ∈ s) :
+    ContMDiffWithinAt I I' n f₁ s x ↔ ContMDiffWithinAt I I' n f s x :=
+  (contDiffWithinAt_localInvariantProp n).liftPropWithinAt_congr_iff_of_mem h₁ hx
+
 theorem ContMDiffWithinAt.congr_of_eventuallyEq (h : ContMDiffWithinAt I I' n f s x)
     (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : ContMDiffWithinAt I I' n f₁ s x :=
   (contDiffWithinAt_localInvariantProp n).liftPropWithinAt_congr_of_eventuallyEq h h₁ hx
+
+theorem ContMDiffWithinAt.congr_of_eventuallyEq_of_mem (h : ContMDiffWithinAt I I' n f s x)
+    (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : x ∈ s) : ContMDiffWithinAt I I' n f₁ s x :=
+  (contDiffWithinAt_localInvariantProp n).liftPropWithinAt_congr_of_eventuallyEq_of_mem h h₁ hx
 
 theorem Filter.EventuallyEq.contMDiffWithinAt_iff (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) :
     ContMDiffWithinAt I I' n f₁ s x ↔ ContMDiffWithinAt I I' n f s x :=

--- a/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
@@ -15,7 +15,7 @@ import Mathlib.Analysis.NormedSpace.OperatorNorm.Prod
 
 -/
 
-open Set ChartedSpace SmoothManifoldWithCorners
+open Set ChartedSpace
 open scoped Topology Manifold
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
@@ -23,27 +23,15 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*}
   [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
   {I : ModelWithCorners 𝕜 E H} {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
-  -- declare a smooth manifold `M'` over the pair `(E', H')`.
-  {E' : Type*}
-  [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H' : Type*} [TopologicalSpace H']
-  {I' : ModelWithCorners 𝕜 E' H'} {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
-  [SmoothManifoldWithCorners I' M']
-  -- declare a smooth manifold `N` over the pair `(F, G)`.
-  {F : Type*}
-  [NormedAddCommGroup F] [NormedSpace 𝕜 F] {G : Type*} [TopologicalSpace G]
-  {J : ModelWithCorners 𝕜 F G} {N : Type*} [TopologicalSpace N] [ChartedSpace G N]
-  [SmoothManifoldWithCorners J N]
-  -- declare a smooth manifold `N'` over the pair `(F', G')`.
-  {F' : Type*}
-  [NormedAddCommGroup F'] [NormedSpace 𝕜 F'] {G' : Type*} [TopologicalSpace G']
-  {J' : ModelWithCorners 𝕜 F' G'} {N' : Type*} [TopologicalSpace N'] [ChartedSpace G' N']
-  [SmoothManifoldWithCorners J' N']
-  -- F₁, F₂, F₃, F₄ are normed spaces
+  -- declare normed spaces `E'`, `F`, `F'`, `F₁`, `F₂`, `F₃`, `F₄`.
+  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  {F' : Type*} [NormedAddCommGroup F'] [NormedSpace 𝕜 F']
   {F₁ : Type*} [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁] {F₂ : Type*} [NormedAddCommGroup F₂]
   [NormedSpace 𝕜 F₂] {F₃ : Type*} [NormedAddCommGroup F₃] [NormedSpace 𝕜 F₃] {F₄ : Type*}
   [NormedAddCommGroup F₄] [NormedSpace 𝕜 F₄]
   -- declare functions, sets, points and smoothness indices
-  {f f₁ : M → M'} {s t : Set M} {x : M} {m n : ℕ∞}
+  {s : Set M} {x : M} {n : ℕ∞}
 
 section Module
 

--- a/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
@@ -176,6 +176,8 @@ theorem ContMDiff.clm_comp {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ →L
     (hg : ContMDiff I 𝓘(𝕜, F₁ →L[𝕜] F₃) n g) (hf : ContMDiff I 𝓘(𝕜, F₂ →L[𝕜] F₁) n f) :
     ContMDiff I 𝓘(𝕜, F₂ →L[𝕜] F₃) n fun x => (g x).comp (f x) := fun x => (hg x).clm_comp (hf x)
 
+/-- Applying a linear map to a vector is smooth within a set. Version in vector spaces. For a
+version in nontrivial vector bundles, see `ContMDiffWithinAt.clm_apply_of_inCoordinates`. -/
 theorem ContMDiffWithinAt.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : M → F₁} {s : Set M} {x : M}
     (hg : ContMDiffWithinAt I 𝓘(𝕜, F₁ →L[𝕜] F₂) n g s x)
     (hf : ContMDiffWithinAt I 𝓘(𝕜, F₁) n f s x) :
@@ -185,6 +187,8 @@ theorem ContMDiffWithinAt.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : M → 
     (by apply ContDiff.contDiffAt; exact contDiff_fst.clm_apply contDiff_snd) (hg.prod_mk_space hf)
     (by simp_rw [preimage_univ, subset_univ])
 
+/-- Applying a linear map to a vector is smooth. Version in vector spaces. For a
+version in nontrivial vector bundles, see `ContMDiffAt.clm_apply_of_inCoordinates`. -/
 nonrec theorem ContMDiffAt.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : M → F₁} {x : M}
     (hg : ContMDiffAt I 𝓘(𝕜, F₁ →L[𝕜] F₂) n g x) (hf : ContMDiffAt I 𝓘(𝕜, F₁) n f x) :
     ContMDiffAt I 𝓘(𝕜, F₂) n (fun x => g x (f x)) x :=

--- a/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
@@ -15,7 +15,7 @@ import Mathlib.Analysis.NormedSpace.OperatorNorm.Prod
 
 -/
 
-open Set ChartedSpace
+open Set ChartedSpace SmoothManifoldWithCorners
 open scoped Topology Manifold
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
@@ -23,15 +23,27 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*}
   [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
   {I : ModelWithCorners 𝕜 E H} {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
-  -- declare normed spaces `E'`, `F`, `F'`, `F₁`, `F₂`, `F₃`, `F₄`.
-  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
-  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
-  {F' : Type*} [NormedAddCommGroup F'] [NormedSpace 𝕜 F']
+  -- declare a smooth manifold `M'` over the pair `(E', H')`.
+  {E' : Type*}
+  [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H' : Type*} [TopologicalSpace H']
+  {I' : ModelWithCorners 𝕜 E' H'} {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
+  [SmoothManifoldWithCorners I' M']
+  -- declare a smooth manifold `N` over the pair `(F, G)`.
+  {F : Type*}
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F] {G : Type*} [TopologicalSpace G]
+  {J : ModelWithCorners 𝕜 F G} {N : Type*} [TopologicalSpace N] [ChartedSpace G N]
+  [SmoothManifoldWithCorners J N]
+  -- declare a smooth manifold `N'` over the pair `(F', G')`.
+  {F' : Type*}
+  [NormedAddCommGroup F'] [NormedSpace 𝕜 F'] {G' : Type*} [TopologicalSpace G']
+  {J' : ModelWithCorners 𝕜 F' G'} {N' : Type*} [TopologicalSpace N'] [ChartedSpace G' N']
+  [SmoothManifoldWithCorners J' N']
+  -- F₁, F₂, F₃, F₄ are normed spaces
   {F₁ : Type*} [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁] {F₂ : Type*} [NormedAddCommGroup F₂]
   [NormedSpace 𝕜 F₂] {F₃ : Type*} [NormedAddCommGroup F₃] [NormedSpace 𝕜 F₃] {F₄ : Type*}
   [NormedAddCommGroup F₄] [NormedSpace 𝕜 F₄]
   -- declare functions, sets, points and smoothness indices
-  {s : Set M} {x : M} {n : ℕ∞}
+  {f f₁ : M → M'} {s t : Set M} {x : M} {m n : ℕ∞}
 
 section Module
 
@@ -176,8 +188,6 @@ theorem ContMDiff.clm_comp {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ →L
     (hg : ContMDiff I 𝓘(𝕜, F₁ →L[𝕜] F₃) n g) (hf : ContMDiff I 𝓘(𝕜, F₂ →L[𝕜] F₁) n f) :
     ContMDiff I 𝓘(𝕜, F₂ →L[𝕜] F₃) n fun x => (g x).comp (f x) := fun x => (hg x).clm_comp (hf x)
 
-/-- Applying a linear map to a vector is smooth within a set. Version in vector spaces. For a
-version in nontrivial vector bundles, see `ContMDiffWithinAt.clm_apply_of_inCoordinates`. -/
 theorem ContMDiffWithinAt.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : M → F₁} {s : Set M} {x : M}
     (hg : ContMDiffWithinAt I 𝓘(𝕜, F₁ →L[𝕜] F₂) n g s x)
     (hf : ContMDiffWithinAt I 𝓘(𝕜, F₁) n f s x) :
@@ -187,8 +197,6 @@ theorem ContMDiffWithinAt.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : M → 
     (by apply ContDiff.contDiffAt; exact contDiff_fst.clm_apply contDiff_snd) (hg.prod_mk_space hf)
     (by simp_rw [preimage_univ, subset_univ])
 
-/-- Applying a linear map to a vector is smooth. Version in vector spaces. For a
-version in nontrivial vector bundles, see `ContMDiffAt.clm_apply_of_inCoordinates`. -/
 nonrec theorem ContMDiffAt.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : M → F₁} {x : M}
     (hg : ContMDiffAt I 𝓘(𝕜, F₁ →L[𝕜] F₂) n g x) (hf : ContMDiffAt I 𝓘(𝕜, F₁) n f x) :
     ContMDiffAt I 𝓘(𝕜, F₂) n (fun x => g x (f x)) x :=

--- a/Mathlib/Geometry/Manifold/ContMDiff/Product.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Product.lean
@@ -36,6 +36,9 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {F' : Type*}
   [NormedAddCommGroup F'] [NormedSpace 𝕜 F'] {G' : Type*} [TopologicalSpace G']
   {J' : ModelWithCorners 𝕜 F' G'} {N' : Type*} [TopologicalSpace N'] [ChartedSpace G' N']
+  -- declare a few vector spaces
+  {F₁ : Type*} [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁]
+  {F₂ : Type*} [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
   -- declare functions, sets, points and smoothness indices
   {f : M → M'} {s : Set M} {x : M} {n : ℕ∞}
 
@@ -229,20 +232,52 @@ theorem Smooth.snd {f : N → M × M'} (hf : Smooth J (I.prod I') f) : Smooth J 
 
 end Projections
 
-theorem contMDiffWithinAt_prod_iff (f : M → M' × N') {s : Set M} {x : M} :
+theorem contMDiffWithinAt_prod_iff (f : M → M' × N') :
     ContMDiffWithinAt I (I'.prod J') n f s x ↔
       ContMDiffWithinAt I I' n (Prod.fst ∘ f) s x ∧ ContMDiffWithinAt I J' n (Prod.snd ∘ f) s x :=
   ⟨fun h => ⟨h.fst, h.snd⟩, fun h => h.1.prod_mk h.2⟩
 
-theorem contMDiffAt_prod_iff (f : M → M' × N') {x : M} :
+theorem contMDiffWithinAt_prod_module_iff (f : M → F₁ × F₂) :
+    ContMDiffWithinAt I 𝓘(𝕜, F₁ × F₂) n f s x ↔
+      ContMDiffWithinAt I 𝓘(𝕜, F₁) n (Prod.fst ∘ f) s x ∧
+      ContMDiffWithinAt I 𝓘(𝕜, F₂) n (Prod.snd ∘ f) s x := by
+  rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
+  exact contMDiffWithinAt_prod_iff f
+
+theorem contMDiffAt_prod_iff (f : M → M' × N') :
     ContMDiffAt I (I'.prod J') n f x ↔
       ContMDiffAt I I' n (Prod.fst ∘ f) x ∧ ContMDiffAt I J' n (Prod.snd ∘ f) x := by
   simp_rw [← contMDiffWithinAt_univ]; exact contMDiffWithinAt_prod_iff f
+
+theorem contMDiffAt_prod_module_iff (f : M → F₁ × F₂) :
+    ContMDiffAt I 𝓘(𝕜, F₁ × F₂) n f x ↔
+      ContMDiffAt I 𝓘(𝕜, F₁) n (Prod.fst ∘ f) x ∧ ContMDiffAt I 𝓘(𝕜, F₂) n (Prod.snd ∘ f) x := by
+  rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
+  exact contMDiffAt_prod_iff f
+
+theorem contMDiffOn_prod_iff (f : M → M' × N') :
+    ContMDiffOn I (I'.prod J') n f s ↔
+      ContMDiffOn I I' n (Prod.fst ∘ f) s ∧ ContMDiffOn I J' n (Prod.snd ∘ f) s :=
+  ⟨fun h ↦ ⟨fun x hx ↦ ((contMDiffWithinAt_prod_iff f).1 (h x hx)).1,
+      fun x hx ↦ ((contMDiffWithinAt_prod_iff f).1 (h x hx)).2⟩ ,
+    fun h x hx ↦ (contMDiffWithinAt_prod_iff f).2 ⟨h.1 x hx, h.2 x hx⟩⟩
+
+theorem contMDiffOn_prod_module_iff (f : M → F₁ × F₂) :
+    ContMDiffOn I 𝓘(𝕜, F₁ × F₂) n f s ↔
+      ContMDiffOn I 𝓘(𝕜, F₁) n (Prod.fst ∘ f) s ∧ ContMDiffOn I 𝓘(𝕜, F₂) n (Prod.snd ∘ f) s := by
+  rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
+  exact contMDiffOn_prod_iff f
 
 theorem contMDiff_prod_iff (f : M → M' × N') :
     ContMDiff I (I'.prod J') n f ↔
       ContMDiff I I' n (Prod.fst ∘ f) ∧ ContMDiff I J' n (Prod.snd ∘ f) :=
   ⟨fun h => ⟨h.fst, h.snd⟩, fun h => by convert h.1.prod_mk h.2⟩
+
+theorem contMDiff_prod_module_iff (f : M → F₁ × F₂) :
+    ContMDiff I 𝓘(𝕜, F₁ × F₂) n f ↔
+      ContMDiff I 𝓘(𝕜, F₁) n (Prod.fst ∘ f) ∧ ContMDiff I 𝓘(𝕜, F₂) n (Prod.snd ∘ f) := by
+  rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
+  exact contMDiff_prod_iff f
 
 theorem smoothAt_prod_iff (f : M → M' × N') {x : M} :
     SmoothAt I (I'.prod J') f x ↔ SmoothAt I I' (Prod.fst ∘ f) x ∧ SmoothAt I J' (Prod.snd ∘ f) x :=

--- a/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
+++ b/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
@@ -338,6 +338,13 @@ theorem liftPropWithinAt_inter (ht : t ∈ 𝓝 x) :
     LiftPropWithinAt P g (s ∩ t) x ↔ LiftPropWithinAt P g s x :=
   hG.liftPropWithinAt_inter' (mem_nhdsWithin_of_mem_nhds ht)
 
+theorem liftPropWithinAt_congr_set (hu : s =ᶠ[𝓝 x] t) :
+    LiftPropWithinAt P g s x ↔ LiftPropWithinAt P g t x := by
+  rw [← hG.liftPropWithinAt_inter (s := s) hu, ← hG.liftPropWithinAt_inter (s := t) hu,
+    ← eq_iff_iff]
+  congr 1
+  aesop
+
 theorem liftPropAt_of_liftPropWithinAt (h : LiftPropWithinAt P g s x) (hs : s ∈ 𝓝 x) :
     LiftPropAt P g x := by
   rwa [← univ_inter s, hG.liftPropWithinAt_inter hs] at h
@@ -370,6 +377,10 @@ theorem liftPropWithinAt_congr_of_eventuallyEq (h : LiftPropWithinAt P g s x) (h
     (fun y ↦ chartAt H' (g' x) (g' y) = chartAt H' (g x) (g y)) (mem_chart_source H x)]
   exact h₁.mono fun y hy ↦ by rw [hx, hy]
 
+theorem liftPropWithinAt_congr_of_eventuallyEq_of_mem (h : LiftPropWithinAt P g s x)
+    (h₁ : g' =ᶠ[𝓝[s] x] g) (h₂ : x ∈ s) : LiftPropWithinAt P g' s x :=
+  liftPropWithinAt_congr_of_eventuallyEq hG h h₁ (mem_of_mem_nhdsWithin h₂ h₁ : _)
+
 theorem liftPropWithinAt_congr_iff_of_eventuallyEq (h₁ : g' =ᶠ[𝓝[s] x] g) (hx : g' x = g x) :
     LiftPropWithinAt P g' s x ↔ LiftPropWithinAt P g s x :=
   ⟨fun h ↦ hG.liftPropWithinAt_congr_of_eventuallyEq h h₁.symm hx.symm,
@@ -379,9 +390,17 @@ theorem liftPropWithinAt_congr_iff (h₁ : ∀ y ∈ s, g' y = g y) (hx : g' x =
     LiftPropWithinAt P g' s x ↔ LiftPropWithinAt P g s x :=
   hG.liftPropWithinAt_congr_iff_of_eventuallyEq (eventually_nhdsWithin_of_forall h₁) hx
 
+theorem liftPropWithinAt_congr_iff_of_mem (h₁ : ∀ y ∈ s, g' y = g y) (hx : x ∈ s) :
+    LiftPropWithinAt P g' s x ↔ LiftPropWithinAt P g s x :=
+  hG.liftPropWithinAt_congr_iff_of_eventuallyEq (eventually_nhdsWithin_of_forall h₁) (h₁ _ hx)
+
 theorem liftPropWithinAt_congr (h : LiftPropWithinAt P g s x) (h₁ : ∀ y ∈ s, g' y = g y)
     (hx : g' x = g x) : LiftPropWithinAt P g' s x :=
   (hG.liftPropWithinAt_congr_iff h₁ hx).mpr h
+
+theorem liftPropWithinAt_congr_of_mem (h : LiftPropWithinAt P g s x) (h₁ : ∀ y ∈ s, g' y = g y)
+    (hx : x ∈ s) : LiftPropWithinAt P g' s x :=
+  (hG.liftPropWithinAt_congr_iff h₁ (h₁ _ hx)).mpr h
 
 theorem liftPropAt_congr_iff_of_eventuallyEq (h₁ : g' =ᶠ[𝓝 x] g) :
     LiftPropAt P g' x ↔ LiftPropAt P g x :=

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -1073,18 +1073,18 @@ theorem MDifferentiableWithinAt.comp_of_eq {y : M'} (hg : MDifferentiableWithinA
     MDifferentiableWithinAt I I'' (g ∘ f) s x := by
   subst hy; exact hg.comp _ hf h
 
-theorem MDifferentiableWithinAt.comp_of_mem_nhdsWithin
+theorem MDifferentiableWithinAt.comp_of_preimage_mem_nhdsWithin
     (hg : MDifferentiableWithinAt I' I'' g u (f x))
     (hf : MDifferentiableWithinAt I I' f s x) (h : f ⁻¹' u ∈ 𝓝[s] x) :
     MDifferentiableWithinAt I I'' (g ∘ f) s x :=
   (hg.comp _ (hf.mono inter_subset_right) inter_subset_left).mono_of_mem_nhdsWithin
     (Filter.inter_mem h self_mem_nhdsWithin)
 
-theorem MDifferentiableWithinAt.comp_of_mem_nhdsWithin_of_eq {y : M'}
+theorem MDifferentiableWithinAt.comp_of_preimage_mem_nhdsWithin_of_eq {y : M'}
     (hg : MDifferentiableWithinAt I' I'' g u y)
     (hf : MDifferentiableWithinAt I I' f s x) (h : f ⁻¹' u ∈ 𝓝[s] x) (hy : f x = y) :
     MDifferentiableWithinAt I I'' (g ∘ f) s x := by
-  subst hy; exact MDifferentiableWithinAt.comp_of_mem_nhdsWithin _ hg hf h
+  subst hy; exact MDifferentiableWithinAt.comp_of_preimage_mem_nhdsWithin _ hg hf h
 
 theorem MDifferentiableAt.comp (hg : MDifferentiableAt I' I'' g (f x))
     (hf : MDifferentiableAt I I' f x) : MDifferentiableAt I I'' (g ∘ f) x :=
@@ -1119,7 +1119,8 @@ theorem mfderivWithin_comp_of_eq {x : M} {y : M'} (hg : MDifferentiableWithinAt 
       (mfderivWithin I' I'' g u y).comp (mfderivWithin I I' f s x) := by
   subst hy; exact mfderivWithin_comp x hg hf h hxs
 
-theorem mfderivWithin_comp_of_mem_nhdsWithin (hg : MDifferentiableWithinAt I' I'' g u (f x))
+theorem mfderivWithin_comp_of_preimage_mem_nhdsWithin
+    (hg : MDifferentiableWithinAt I' I'' g u (f x))
     (hf : MDifferentiableWithinAt I I' f s x) (h : f ⁻¹' u ∈ 𝓝[s] x)
     (hxs : UniqueMDiffWithinAt I s x) :
     mfderivWithin I I'' (g ∘ f) s x =
@@ -1133,13 +1134,13 @@ theorem mfderivWithin_comp_of_mem_nhdsWithin (hg : MDifferentiableWithinAt I' I'
   rw [B, C]
   exact mfderivWithin_comp _ hg (hf.mono inter_subset_left) inter_subset_right (hxs.inter' h)
 
-theorem mfderivWithin_comp_of_mem_nhdsWithin_of_eq {y : M'}
+theorem mfderivWithin_comp_of_preimage_mem_nhdsWithin_of_eq {y : M'}
     (hg : MDifferentiableWithinAt I' I'' g u y)
     (hf : MDifferentiableWithinAt I I' f s x) (h : f ⁻¹' u ∈ 𝓝[s] x)
     (hxs : UniqueMDiffWithinAt I s x) (hy : f x = y) :
     mfderivWithin I I'' (g ∘ f) s x =
       (mfderivWithin I' I'' g u y).comp (mfderivWithin I I' f s x) := by
-  subst hy; exact mfderivWithin_comp_of_mem_nhdsWithin _ hg hf h hxs
+  subst hy; exact mfderivWithin_comp_of_preimage_mem_nhdsWithin _ hg hf h hxs
 
 theorem mfderiv_comp_mfderivWithin (hg : MDifferentiableAt I' I'' g (f x))
     (hf : MDifferentiableWithinAt I I' f s x) (hxs : UniqueMDiffWithinAt I s x) :

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -812,7 +812,6 @@ theorem tangentMapWithin_proj {p : TangentBundle I M} :
 theorem tangentMap_proj {p : TangentBundle I M} : (tangentMap I I' f p).proj = f p.proj :=
   rfl
 
-
 /-- If two sets coincide locally around `x`, except maybe at a point `y`, then their
 preimage under `extChartAt x` coincide locally, except maybe at `extChartAt I x x`. -/
 theorem preimage_extChartAt_eventuallyEq_compl_singleton (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
@@ -867,7 +866,6 @@ theorem mdifferentiableWithinAt_congr_set (h : s =ᶠ[𝓝 x] t) :
     MDifferentiableWithinAt I I' f s x ↔ MDifferentiableWithinAt I I' f t x := by
   simp only [mdifferentiableWithinAt_iff_exists_hasMFDerivWithinAt]
   exact exists_congr fun _ => hasMFDerivWithinAt_congr_set h
-
 
 /-- If two sets coincide locally, except maybe at a point, then derivatives within these sets
 are the same. -/

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -25,7 +25,7 @@ noncomputable section
 assert_not_exists tangentBundleCore
 
 open scoped Topology Manifold
-open Set Bundle
+open Set Bundle ChartedSpace
 
 section DerivativesProperties
 
@@ -50,6 +50,11 @@ theorem uniqueMDiffWithinAt_univ : UniqueMDiffWithinAt I univ x := by
   exact I.uniqueDiffOn _ (mem_range_self _)
 
 variable {I}
+
+theorem uniqueMDiffWithinAt_iff_inter_range {s : Set M} {x : M} :
+    UniqueMDiffWithinAt I s x ↔
+      UniqueDiffWithinAt 𝕜 ((extChartAt I x).symm ⁻¹' s ∩ range I)
+        ((extChartAt I x) x) := Iff.rfl
 
 theorem uniqueMDiffWithinAt_iff {s : Set M} {x : M} :
     UniqueMDiffWithinAt I s x ↔
@@ -103,16 +108,6 @@ theorem UniqueMDiffOn.prod {s : Set M} {t : Set M'} (hs : UniqueMDiffOn I s)
     (ht : UniqueMDiffOn I' t) : UniqueMDiffOn (I.prod I') (s ×ˢ t) := fun x h ↦
   (hs x.1 h.1).prod (ht x.2 h.2)
 
-theorem mdifferentiableWithinAt_iff {f : M → M'} {s : Set M} {x : M} :
-    MDifferentiableWithinAt I I' f s x ↔
-      ContinuousWithinAt f s x ∧
-        DifferentiableWithinAt 𝕜 (writtenInExtChartAt I I' x f)
-          ((extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' s) ((extChartAt I x) x) := by
-  rw [mdifferentiableWithinAt_iff']
-  refine and_congr Iff.rfl (exists_congr fun f' => ?_)
-  rw [inter_comm]
-  simp only [HasFDerivWithinAt, nhdsWithin_inter, nhdsWithin_extChartAt_target_eq]
-
 theorem MDifferentiableWithinAt.mono (hst : s ⊆ t) (h : MDifferentiableWithinAt I I' f t x) :
     MDifferentiableWithinAt I I' f s x :=
   ⟨ContinuousWithinAt.mono h.1 hst, DifferentiableWithinAt.mono
@@ -163,6 +158,304 @@ theorem mdifferentiableOn_of_locally_mdifferentiableOn
   rcases h x xs with ⟨t, t_open, xt, ht⟩
   exact (mdifferentiableWithinAt_inter (t_open.mem_nhds xt)).1 (ht x ⟨xs, xt⟩)
 
+theorem MDifferentiable.mdifferentiableAt (hf : MDifferentiable I I' f) :
+    MDifferentiableAt I I' f x :=
+  hf x
+
+/-!
+### Relating differentiability in a manifold and differentiability in the model space
+through extended charts
+-/
+
+
+theorem mdifferentiableWithinAt_iff_target_inter {f : M → M'} {s : Set M} {x : M} :
+    MDifferentiableWithinAt I I' f s x ↔
+      ContinuousWithinAt f s x ∧
+        DifferentiableWithinAt 𝕜 (writtenInExtChartAt I I' x f)
+          ((extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' s) ((extChartAt I x) x) := by
+  rw [mdifferentiableWithinAt_iff']
+  refine and_congr Iff.rfl (exists_congr fun f' => ?_)
+  rw [inter_comm]
+  simp only [HasFDerivWithinAt, nhdsWithin_inter, nhdsWithin_extChartAt_target_eq]
+
+/-- One can reformulate smoothness within a set at a point as continuity within this set at this
+point, and smoothness in the corresponding extended chart. -/
+theorem mdifferentiableWithinAt_iff :
+    MDifferentiableWithinAt I I' f s x ↔
+      ContinuousWithinAt f s x ∧
+        DifferentiableWithinAt 𝕜 (extChartAt I' (f x) ∘ f ∘ (extChartAt I x).symm)
+          ((extChartAt I x).symm ⁻¹' s ∩ range I) (extChartAt I x x) := by
+  simp_rw [MDifferentiableWithinAt, ChartedSpace.liftPropWithinAt_iff']; rfl
+
+/-- One can reformulate smoothness within a set at a point as continuity within this set at this
+point, and smoothness in the corresponding extended chart. This form states smoothness of `f`
+written in such a way that the set is restricted to lie within the domain/codomain of the
+corresponding charts.
+Even though this expression is more complicated than the one in `mdifferentiableWithinAt_iff`, it is
+a smaller set, but their germs at `extChartAt I x x` are equal. It is sometimes useful to rewrite
+using this in the goal.
+-/
+theorem mdifferentiableWithinAt_iff_target_inter' :
+    MDifferentiableWithinAt I I' f s x ↔
+      ContinuousWithinAt f s x ∧
+        DifferentiableWithinAt 𝕜 (extChartAt I' (f x) ∘ f ∘ (extChartAt I x).symm)
+          ((extChartAt I x).target ∩
+            (extChartAt I x).symm ⁻¹' (s ∩ f ⁻¹' (extChartAt I' (f x)).source))
+          (extChartAt I x x) := by
+  simp only [MDifferentiableWithinAt, liftPropWithinAt_iff']
+  exact and_congr_right fun hc => differentiableWithinAt_congr_nhds <|
+    hc.nhdsWithin_extChartAt_symm_preimage_inter_range
+
+/-- One can reformulate smoothness within a set at a point as continuity within this set at this
+point, and smoothness in the corresponding extended chart in the target. -/
+theorem mdifferentiableWithinAt_iff_target :
+    MDifferentiableWithinAt I I' f s x ↔
+      ContinuousWithinAt f s x ∧
+      MDifferentiableWithinAt I 𝓘(𝕜, E') (extChartAt I' (f x) ∘ f) s x := by
+  simp_rw [MDifferentiableWithinAt, liftPropWithinAt_iff', ← and_assoc]
+  have cont :
+    ContinuousWithinAt f s x ∧ ContinuousWithinAt (extChartAt I' (f x) ∘ f) s x ↔
+        ContinuousWithinAt f s x :=
+      and_iff_left_of_imp <| (continuousAt_extChartAt _).comp_continuousWithinAt
+  simp_rw [cont, DifferentiableWithinAtProp, extChartAt, PartialHomeomorph.extend,
+    PartialEquiv.coe_trans,
+    ModelWithCorners.toPartialEquiv_coe, PartialHomeomorph.coe_coe, modelWithCornersSelf_coe,
+    chartAt_self_eq, PartialHomeomorph.refl_apply]
+  rfl
+
+theorem mdifferentiableAt_iff_target {x : M} :
+    MDifferentiableAt I I' f x ↔
+      ContinuousAt f x ∧ MDifferentiableAt I 𝓘(𝕜, E') (extChartAt I' (f x) ∘ f) x := by
+  rw [← mdifferentiableWithinAt_univ, ← mdifferentiableWithinAt_univ,
+    mdifferentiableWithinAt_iff_target, continuousWithinAt_univ]
+
+section SmoothManifoldWithCorners
+
+variable {e : PartialHomeomorph M H} {e' : PartialHomeomorph M' H'}
+
+open SmoothManifoldWithCorners
+
+theorem mdifferentiableWithinAt_iff_source_of_mem_maximalAtlas
+    [SmoothManifoldWithCorners I M] (he : e ∈ maximalAtlas I M) (hx : x ∈ e.source) :
+    MDifferentiableWithinAt I I' f s x ↔
+      MDifferentiableWithinAt 𝓘(𝕜, E) I' (f ∘ (e.extend I).symm) ((e.extend I).symm ⁻¹' s ∩ range I)
+        (e.extend I x) := by
+  have h2x := hx; rw [← e.extend_source (I := I)] at h2x
+  simp_rw [MDifferentiableWithinAt,
+    differentiableWithinAt_localInvariantProp.liftPropWithinAt_indep_chart_source he hx,
+    StructureGroupoid.liftPropWithinAt_self_source,
+    e.extend_symm_continuousWithinAt_comp_right_iff, differentiableWithinAtProp_self_source,
+    DifferentiableWithinAtProp, Function.comp, e.left_inv hx, (e.extend I).left_inv h2x]
+  rfl
+
+theorem mdifferentiableWithinAt_iff_source_of_mem_source
+    [SmoothManifoldWithCorners I M] {x' : M} (hx' : x' ∈ (chartAt H x).source) :
+    MDifferentiableWithinAt I I' f s x' ↔
+      MDifferentiableWithinAt 𝓘(𝕜, E) I' (f ∘ (extChartAt I x).symm)
+        ((extChartAt I x).symm ⁻¹' s ∩ range I) (extChartAt I x x') :=
+  mdifferentiableWithinAt_iff_source_of_mem_maximalAtlas (chart_mem_maximalAtlas x) hx'
+
+theorem mdifferentiableAt_iff_source_of_mem_source
+    [SmoothManifoldWithCorners I M] {x' : M} (hx' : x' ∈ (chartAt H x).source) :
+    MDifferentiableAt I I' f x' ↔
+      MDifferentiableWithinAt 𝓘(𝕜, E) I' (f ∘ (extChartAt I x).symm) (range I)
+        (extChartAt I x x') := by
+  simp_rw [← mdifferentiableWithinAt_univ, mdifferentiableWithinAt_iff_source_of_mem_source hx',
+    preimage_univ, univ_inter]
+
+theorem mdifferentiableWithinAt_iff_target_of_mem_source
+    [SmoothManifoldWithCorners I' M'] {x : M} {y : M'} (hy : f x ∈ (chartAt H' y).source) :
+    MDifferentiableWithinAt I I' f s x ↔
+      ContinuousWithinAt f s x ∧ MDifferentiableWithinAt I 𝓘(𝕜, E') (extChartAt I' y ∘ f) s x := by
+  simp_rw [MDifferentiableWithinAt]
+  rw [differentiableWithinAt_localInvariantProp.liftPropWithinAt_indep_chart_target
+      (chart_mem_maximalAtlas y) hy,
+    and_congr_right]
+  intro hf
+  simp_rw [StructureGroupoid.liftPropWithinAt_self_target]
+  simp_rw [((chartAt H' y).continuousAt hy).comp_continuousWithinAt hf]
+  rw [← extChartAt_source I'] at hy
+  simp_rw [(continuousAt_extChartAt' hy).comp_continuousWithinAt hf]
+  rfl
+
+theorem mdifferentiableAt_iff_target_of_mem_source
+    [SmoothManifoldWithCorners I' M'] {x : M} {y : M'} (hy : f x ∈ (chartAt H' y).source) :
+    MDifferentiableAt I I' f x ↔
+      ContinuousAt f x ∧ MDifferentiableAt I 𝓘(𝕜, E') (extChartAt I' y ∘ f) x := by
+  rw [← mdifferentiableWithinAt_univ, mdifferentiableWithinAt_iff_target_of_mem_source hy,
+    continuousWithinAt_univ, ← mdifferentiableWithinAt_univ]
+
+variable [SmoothManifoldWithCorners I M] [SmoothManifoldWithCorners I' M']
+
+theorem mdifferentiableWithinAt_iff_of_mem_maximalAtlas {x : M} (he : e ∈ maximalAtlas I M)
+    (he' : e' ∈ maximalAtlas I' M') (hx : x ∈ e.source) (hy : f x ∈ e'.source) :
+    MDifferentiableWithinAt I I' f s x ↔
+      ContinuousWithinAt f s x ∧
+        DifferentiableWithinAt 𝕜 (e'.extend I' ∘ f ∘ (e.extend I).symm)
+          ((e.extend I).symm ⁻¹' s ∩ range I) (e.extend I x) :=
+  differentiableWithinAt_localInvariantProp.liftPropWithinAt_indep_chart he hx he' hy
+
+/-- An alternative formulation of `mdifferentiableWithinAt_iff_of_mem_maximalAtlas`
+  if the set if `s` lies in `e.source`. -/
+theorem mdifferentiableWithinAt_iff_image {x : M} (he : e ∈ maximalAtlas I M)
+    (he' : e' ∈ maximalAtlas I' M') (hs : s ⊆ e.source) (hx : x ∈ e.source) (hy : f x ∈ e'.source) :
+    MDifferentiableWithinAt I I' f s x ↔
+      ContinuousWithinAt f s x ∧
+        DifferentiableWithinAt 𝕜 (e'.extend I' ∘ f ∘ (e.extend I).symm) (e.extend I '' s)
+          (e.extend I x) := by
+  rw [mdifferentiableWithinAt_iff_of_mem_maximalAtlas he he' hx hy, and_congr_right_iff]
+  refine fun _ => differentiableWithinAt_congr_nhds ?_
+  simp_rw [nhdsWithin_eq_iff_eventuallyEq, e.extend_symm_preimage_inter_range_eventuallyEq hs hx]
+
+/-- One can reformulate smoothness within a set at a point as continuity within this set at this
+point, and smoothness in any chart containing that point. -/
+theorem mdifferentiableWithinAt_iff_of_mem_source {x' : M} {y : M'} (hx : x' ∈ (chartAt H x).source)
+    (hy : f x' ∈ (chartAt H' y).source) :
+    MDifferentiableWithinAt I I' f s x' ↔
+      ContinuousWithinAt f s x' ∧
+        DifferentiableWithinAt 𝕜 (extChartAt I' y ∘ f ∘ (extChartAt I x).symm)
+          ((extChartAt I x).symm ⁻¹' s ∩ range I) (extChartAt I x x') :=
+  mdifferentiableWithinAt_iff_of_mem_maximalAtlas (chart_mem_maximalAtlas x)
+    (chart_mem_maximalAtlas y) hx hy
+
+/-- One can reformulate smoothness within a set at a point as continuity within this set at this
+point, and smoothness in any chart containing that point. Version requiring differentiability
+in the target instead of `range I`. -/
+theorem mdifferentiableWithinAt_iff_of_mem_source' {x' : M} {y : M'}
+    (hx : x' ∈ (chartAt H x).source) (hy : f x' ∈ (chartAt H' y).source) :
+    MDifferentiableWithinAt I I' f s x' ↔
+      ContinuousWithinAt f s x' ∧
+        DifferentiableWithinAt 𝕜 (extChartAt I' y ∘ f ∘ (extChartAt I x).symm)
+          ((extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' (s ∩ f ⁻¹' (extChartAt I' y).source))
+          (extChartAt I x x') := by
+  refine (mdifferentiableWithinAt_iff_of_mem_source hx hy).trans ?_
+  rw [← extChartAt_source I] at hx
+  rw [← extChartAt_source I'] at hy
+  rw [and_congr_right_iff]
+  set e := extChartAt I x; set e' := extChartAt I' (f x)
+  refine fun hc => differentiableWithinAt_congr_nhds ?_
+  rw [← e.image_source_inter_eq', ← map_extChartAt_nhdsWithin_eq_image' hx,
+    ← map_extChartAt_nhdsWithin' hx, inter_comm, nhdsWithin_inter_of_mem]
+  exact hc (extChartAt_source_mem_nhds' hy)
+
+theorem mdifferentiableAt_iff_of_mem_source {x' : M} {y : M'} (hx : x' ∈ (chartAt H x).source)
+    (hy : f x' ∈ (chartAt H' y).source) :
+    MDifferentiableAt I I' f x' ↔
+      ContinuousAt f x' ∧
+        DifferentiableWithinAt 𝕜 (extChartAt I' y ∘ f ∘ (extChartAt I x).symm) (range I)
+          (extChartAt I x x') :=
+  (mdifferentiableWithinAt_iff_of_mem_source hx hy).trans <| by
+    rw [continuousWithinAt_univ, preimage_univ, univ_inter]
+
+theorem mdifferentiableOn_iff_of_mem_maximalAtlas (he : e ∈ maximalAtlas I M)
+    (he' : e' ∈ maximalAtlas I' M') (hs : s ⊆ e.source) (h2s : MapsTo f s e'.source) :
+    MDifferentiableOn I I' f s ↔
+      ContinuousOn f s ∧
+        DifferentiableOn 𝕜 (e'.extend I' ∘ f ∘ (e.extend I).symm) (e.extend I '' s) := by
+  simp_rw [ContinuousOn, DifferentiableOn, Set.forall_mem_image, ← forall_and, MDifferentiableOn]
+  exact forall₂_congr fun x hx => mdifferentiableWithinAt_iff_image he he' hs (hs hx) (h2s hx)
+
+/-- Differentiability on a set is equivalent to differentiability in the extended charts. -/
+theorem mdifferentiableOn_iff_of_mem_maximalAtlas' (he : e ∈ maximalAtlas I M)
+    (he' : e' ∈ maximalAtlas I' M') (hs : s ⊆ e.source) (h2s : MapsTo f s e'.source) :
+    MDifferentiableOn I I' f s ↔
+      DifferentiableOn 𝕜 (e'.extend I' ∘ f ∘ (e.extend I).symm) (e.extend I '' s) :=
+  (mdifferentiableOn_iff_of_mem_maximalAtlas he he' hs h2s).trans <| and_iff_right_of_imp fun h ↦
+    (e.continuousOn_writtenInExtend_iff hs h2s).1 h.continuousOn
+
+/-- If the set where you want `f` to be smooth lies entirely in a single chart, and `f` maps it
+  into a single chart, the smoothness of `f` on that set can be expressed by purely looking in
+  these charts.
+  Note: this lemma uses `extChartAt I x '' s` instead of `(extChartAt I x).symm ⁻¹' s` to ensure
+  that this set lies in `(extChartAt I x).target`. -/
+theorem mdifferentiableOn_iff_of_subset_source {x : M} {y : M'} (hs : s ⊆ (chartAt H x).source)
+    (h2s : MapsTo f s (chartAt H' y).source) :
+    MDifferentiableOn I I' f s ↔
+      ContinuousOn f s ∧
+        DifferentiableOn 𝕜 (extChartAt I' y ∘ f ∘ (extChartAt I x).symm) (extChartAt I x '' s) :=
+  mdifferentiableOn_iff_of_mem_maximalAtlas (chart_mem_maximalAtlas x)
+    (chart_mem_maximalAtlas y) hs h2s
+
+/-- If the set where you want `f` to be smooth lies entirely in a single chart, and `f` maps it
+  into a single chart, the smoothness of `f` on that set can be expressed by purely looking in
+  these charts.
+  Note: this lemma uses `extChartAt I x '' s` instead of `(extChartAt I x).symm ⁻¹' s` to ensure
+  that this set lies in `(extChartAt I x).target`. -/
+theorem mdifferentiableOn_iff_of_subset_source' {x : M} {y : M'} (hs : s ⊆ (extChartAt I x).source)
+    (h2s : MapsTo f s (extChartAt I' y).source) :
+    MDifferentiableOn I I' f s ↔
+        DifferentiableOn 𝕜 (extChartAt I' y ∘ f ∘ (extChartAt I x).symm) (extChartAt I x '' s) := by
+  rw [extChartAt_source] at hs h2s
+  exact mdifferentiableOn_iff_of_mem_maximalAtlas' (chart_mem_maximalAtlas x)
+    (chart_mem_maximalAtlas y) hs h2s
+
+/-- One can reformulate smoothness on a set as continuity on this set, and smoothness in any
+extended chart. -/
+theorem mdifferentiableOn_iff :
+    MDifferentiableOn I I' f s ↔
+      ContinuousOn f s ∧
+        ∀ (x : M) (y : M'),
+          DifferentiableOn 𝕜 (extChartAt I' y ∘ f ∘ (extChartAt I x).symm)
+            ((extChartAt I x).target ∩
+              (extChartAt I x).symm ⁻¹' (s ∩ f ⁻¹' (extChartAt I' y).source)) := by
+  constructor
+  · intro h
+    refine ⟨fun x hx => (h x hx).1, fun x y z hz => ?_⟩
+    simp only [mfld_simps] at hz
+    let w := (extChartAt I x).symm z
+    have : w ∈ s := by simp only [w, hz, mfld_simps]
+    specialize h w this
+    have w1 : w ∈ (chartAt H x).source := by simp only [w, hz, mfld_simps]
+    have w2 : f w ∈ (chartAt H' y).source := by simp only [w, hz, mfld_simps]
+    convert ((mdifferentiableWithinAt_iff_of_mem_source w1 w2).mp h).2.mono _
+    · simp only [w, hz, mfld_simps]
+    · mfld_set_tac
+  · rintro ⟨hcont, hdiff⟩ x hx
+    refine differentiableWithinAt_localInvariantProp.liftPropWithinAt_iff.mpr ?_
+    refine ⟨hcont x hx, ?_⟩
+    dsimp [DifferentiableWithinAtProp]
+    convert hdiff x (f x) (extChartAt I x x) (by simp only [hx, mfld_simps]) using 1
+    mfld_set_tac
+
+/-- One can reformulate smoothness on a set as continuity on this set, and smoothness in any
+extended chart in the target. -/
+theorem mdifferentiableOn_iff_target :
+    MDifferentiableOn I I' f s ↔
+      ContinuousOn f s ∧
+        ∀ y : M', MDifferentiableOn I 𝓘(𝕜, E') (extChartAt I' y ∘ f)
+          (s ∩ f ⁻¹' (extChartAt I' y).source) := by
+  simp only [mdifferentiableOn_iff, ModelWithCorners.source_eq, chartAt_self_eq,
+    PartialHomeomorph.refl_partialEquiv, PartialEquiv.refl_trans, extChartAt,
+    PartialHomeomorph.extend, Set.preimage_univ, Set.inter_univ, and_congr_right_iff]
+  intro h
+  constructor
+  · refine fun h' y => ⟨?_, fun x _ => h' x y⟩
+    have h'' : ContinuousOn _ univ := (ModelWithCorners.continuous I').continuousOn
+    convert (h''.comp_inter (chartAt H' y).continuousOn_toFun).comp_inter h
+    simp
+  · exact fun h' x y => (h' y).2 x 0
+
+/-- One can reformulate smoothness as continuity and smoothness in any extended chart. -/
+theorem mdifferentiable_iff :
+    MDifferentiable I I' f ↔
+      Continuous f ∧
+        ∀ (x : M) (y : M'),
+          DifferentiableOn 𝕜 (extChartAt I' y ∘ f ∘ (extChartAt I x).symm)
+            ((extChartAt I x).target ∩
+              (extChartAt I x).symm ⁻¹' (f ⁻¹' (extChartAt I' y).source)) := by
+  simp [← mdifferentiableOn_univ, mdifferentiableOn_iff, continuous_iff_continuousOn_univ]
+
+/-- One can reformulate smoothness as continuity and smoothness in any extended chart in the
+target. -/
+theorem mdifferentiable_iff_target :
+    MDifferentiable I I' f ↔
+      Continuous f ∧ ∀ y : M',
+        MDifferentiableOn I 𝓘(𝕜, E') (extChartAt I' y ∘ f) (f ⁻¹' (extChartAt I' y).source) := by
+  rw [← mdifferentiableOn_univ, mdifferentiableOn_iff_target]
+  simp [continuous_iff_continuousOn_univ]
+
+end SmoothManifoldWithCorners
+
 /-! ### Deducing differentiability from smoothness -/
 
 variable {n : ℕ∞}
@@ -179,6 +472,10 @@ theorem ContMDiffWithinAt.mdifferentiableWithinAt (hf : ContMDiffWithinAt I I' n
 theorem ContMDiffAt.mdifferentiableAt (hf : ContMDiffAt I I' n f x) (hn : 1 ≤ n) :
     MDifferentiableAt I I' f x :=
   mdifferentiableWithinAt_univ.1 <| ContMDiffWithinAt.mdifferentiableWithinAt hf hn
+
+theorem ContMDiff.mdifferentiableAt (hf : ContMDiff I I' n f) (hn : 1 ≤ n) :
+    MDifferentiableAt I I' f x :=
+  hf.contMDiffAt.mdifferentiableAt hn
 
 theorem ContMDiffOn.mdifferentiableOn (hf : ContMDiffOn I I' n f s) (hn : 1 ≤ n) :
     MDifferentiableOn I I' f s := fun x hx => (hf x hx).mdifferentiableWithinAt hn
@@ -281,19 +578,6 @@ protected theorem UniqueMDiffOn.eq (U : UniqueMDiffOn I s) (hx : x ∈ s)
 We mimic the API for functions between vector spaces
 -/
 
-variable [SmoothManifoldWithCorners I M] [SmoothManifoldWithCorners I' M'] in
-/-- One can reformulate differentiability within a set at a point as continuity within this set at
-this point, and differentiability in any chart containing that point. -/
-theorem mdifferentiableWithinAt_iff_of_mem_source {x' : M} {y : M'}
-    (hx : x' ∈ (chartAt H x).source) (hy : f x' ∈ (chartAt H' y).source) :
-    MDifferentiableWithinAt I I' f s x' ↔
-      ContinuousWithinAt f s x' ∧
-        DifferentiableWithinAt 𝕜 (extChartAt I' y ∘ f ∘ (extChartAt I x).symm)
-          ((extChartAt I x).symm ⁻¹' s ∩ Set.range I) ((extChartAt I x) x') :=
-  differentiableWithinAt_localInvariantProp.liftPropWithinAt_indep_chart
-    (StructureGroupoid.chart_mem_maximalAtlas _ x) hx (StructureGroupoid.chart_mem_maximalAtlas _ y)
-    hy
-
 theorem mfderivWithin_zero_of_not_mdifferentiableWithinAt
     (h : ¬MDifferentiableWithinAt I I' f s x) : mfderivWithin I I' f s x = 0 := by
   simp only [mfderivWithin, h, if_neg, not_false_iff]
@@ -366,6 +650,25 @@ theorem MDifferentiableWithinAt.hasMFDerivWithinAt (h : MDifferentiableWithinAt 
   simp only [mfderivWithin, h, if_pos, mfld_simps]
   exact DifferentiableWithinAt.hasFDerivWithinAt h.2
 
+theorem mdifferentiableWithinAt_iff_exists_hasMFDerivWithinAt :
+    MDifferentiableWithinAt I I' f s x ↔ ∃ f', HasMFDerivWithinAt I I' f s x f' := by
+  refine ⟨fun h ↦ ⟨mfderivWithin I I' f s x, h.hasMFDerivWithinAt⟩, ?_⟩
+  rintro ⟨f', hf'⟩
+  exact hf'.mdifferentiableWithinAt
+
+theorem MDifferentiableWithinAt.mono_of_mem_nhdsWithin
+    (h : MDifferentiableWithinAt I I' f s x) {t : Set M}
+    (hst : s ∈ 𝓝[t] x) : MDifferentiableWithinAt I I' f t x :=
+  (h.hasMFDerivWithinAt.mono_of_mem_nhdsWithin hst).mdifferentiableWithinAt
+
+theorem MDifferentiableWithinAt.congr_nhds (h : MDifferentiableWithinAt I I' f s x) {t : Set M}
+    (hst : 𝓝[s] x = 𝓝[t] x) : MDifferentiableWithinAt I I' f t x :=
+  h.mono_of_mem_nhdsWithin <| hst ▸ self_mem_nhdsWithin
+
+theorem mdifferentiableWithinAt_congr_nhds {t : Set M} (hst : 𝓝[s] x = 𝓝[t] x) :
+    MDifferentiableWithinAt I I' f s x ↔ MDifferentiableWithinAt I I' f t x :=
+  ⟨fun h => h.congr_nhds hst, fun h => h.congr_nhds hst.symm⟩
+
 protected theorem MDifferentiableWithinAt.mfderivWithin (h : MDifferentiableWithinAt I I' f s x) :
     mfderivWithin I I' f s x =
       fderivWithin 𝕜 (writtenInExtChartAt I I' x f : _) ((extChartAt I x).symm ⁻¹' s ∩ range I)
@@ -419,21 +722,61 @@ lemma mfderivWithin_of_isOpen (hs : IsOpen s) (hx : x ∈ s) :
     mfderivWithin I I' f s x = mfderiv I I' f x :=
   mfderivWithin_of_mem_nhds (hs.mem_nhds hx)
 
+theorem hasMFDerivWithinAt_insert {y : M} :
+    HasMFDerivWithinAt I I' f (insert y s) x f' ↔ HasMFDerivWithinAt I I' f s x f' := by
+  have : T1Space M := I.t1Space M
+  refine ⟨fun h => h.mono <| subset_insert y s, fun hf ↦ ?_⟩
+  rcases eq_or_ne x y with rfl | h
+  · rw [HasMFDerivWithinAt] at hf ⊢
+    refine ⟨hf.1.insert, ?_⟩
+    have : (extChartAt I x).target ∈
+        𝓝[(extChartAt I x).symm ⁻¹' insert x s ∩ range I] (extChartAt I x) x :=
+      nhdsWithin_mono _ inter_subset_right (extChartAt_target_mem_nhdsWithin x)
+    rw [← hasFDerivWithinAt_inter' this]
+    apply hf.2.insert.mono
+    rintro z ⟨⟨hz, h2z⟩, h'z⟩
+    simp only [mem_inter_iff, mem_preimage, mem_insert_iff, mem_range] at hz h2z ⊢
+    rcases hz with xz | h'z
+    · left
+      have : x ∈ (extChartAt I x).source := mem_extChartAt_source x
+      exact (((extChartAt I x).eq_symm_apply this h'z).1 xz.symm).symm
+    · exact Or.inr ⟨h'z, h2z⟩
+  · apply hf.mono_of_mem_nhdsWithin ?_
+    simp_rw [nhdsWithin_insert_of_ne h, self_mem_nhdsWithin]
+
+alias ⟨HasMFDerivWithinAt.of_insert, HasMFDerivWithinAt.insert'⟩ := hasMFDerivWithinAt_insert
+
+protected theorem HasMFDerivWithinAt.insert (h : HasMFDerivWithinAt I I' f s x f') :
+    HasMFDerivWithinAt I I' f (insert x s) x f' :=
+  h.insert'
+
+theorem hasMFDerivWithinAt_diff_singleton (y : M) :
+    HasMFDerivWithinAt I I' f (s \ {y}) x f' ↔ HasMFDerivWithinAt I I' f s x f' := by
+  rw [← hasMFDerivWithinAt_insert, insert_diff_singleton, hasMFDerivWithinAt_insert]
+
 theorem mfderivWithin_eq_mfderiv (hs : UniqueMDiffWithinAt I s x) (h : MDifferentiableAt I I' f x) :
     mfderivWithin I I' f s x = mfderiv I I' f x := by
   rw [← mfderivWithin_univ]
   exact mfderivWithin_subset (subset_univ _) hs h.mdifferentiableWithinAt
 
-variable [SmoothManifoldWithCorners I M] [SmoothManifoldWithCorners I' M'] in
-theorem mdifferentiableAt_iff_of_mem_source {x' : M} {y : M'}
-    (hx : x' ∈ (chartAt H x).source) (hy : f x' ∈ (chartAt H' y).source) :
-    MDifferentiableAt I I' f x' ↔
-      ContinuousAt f x' ∧
-        DifferentiableWithinAt 𝕜 (extChartAt I' y ∘ f ∘ (extChartAt I x).symm) (Set.range I)
-          ((extChartAt I x) x') :=
-  mdifferentiableWithinAt_univ.symm.trans <|
-    (mdifferentiableWithinAt_iff_of_mem_source hx hy).trans <| by
-      rw [continuousWithinAt_univ, Set.preimage_univ, Set.univ_inter]
+theorem mdifferentiableWithinAt_insert_self :
+    MDifferentiableWithinAt I I' f (insert x s) x ↔ MDifferentiableWithinAt I I' f s x :=
+  ⟨fun h ↦ h.mono (subset_insert x s), fun h ↦ h.hasMFDerivWithinAt.insert.mdifferentiableWithinAt⟩
+
+theorem mdifferentiableWithinAt_insert {y : M} :
+    MDifferentiableWithinAt I I' f (insert y s) x ↔ MDifferentiableWithinAt I I' f s x := by
+  rcases eq_or_ne x y with (rfl | h)
+  · exact mdifferentiableWithinAt_insert_self
+  have : T1Space M := I.t1Space M
+  apply mdifferentiableWithinAt_congr_nhds
+  exact nhdsWithin_insert_of_ne h
+
+alias ⟨MDifferentiableWithinAt.of_insert, MDifferentiableWithinAt.insert'⟩ :=
+mdifferentiableWithinAt_insert
+
+protected theorem MDifferentiableWithinAt.insert (h : MDifferentiableWithinAt I I' f s x) :
+    MDifferentiableWithinAt I I' f (insert x s) x :=
+  h.insert'
 
 /-! ### Deriving continuity from differentiability on manifolds -/
 
@@ -469,7 +812,89 @@ theorem tangentMapWithin_proj {p : TangentBundle I M} :
 theorem tangentMap_proj {p : TangentBundle I M} : (tangentMap I I' f p).proj = f p.proj :=
   rfl
 
+
+/-- If two sets coincide locally around `x`, except maybe at a point `y`, then their
+preimage under `extChartAt x` coincide locally, except maybe at `extChartAt I x x`. -/
+theorem preimage_extChartAt_eventuallyEq_compl_singleton (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
+    ((extChartAt I x).symm ⁻¹' s ∩ range I : Set E) =ᶠ[𝓝[{extChartAt I x x}ᶜ] (extChartAt I x x)]
+    ((extChartAt I x).symm ⁻¹' t ∩ range I : Set E) := by
+  have : T1Space M := I.t1Space M
+  obtain ⟨u, u_mem, hu⟩ : ∃ u ∈ 𝓝 x, u ∩ {x}ᶜ ⊆ {y | (y ∈ s) = (y ∈ t)} :=
+    mem_nhdsWithin_iff_exists_mem_nhds_inter.1 (nhdsWithin_compl_singleton_le x y h)
+  rw [← extChartAt_to_inv (I:= I) x] at u_mem
+  have B : (extChartAt I x).target ∪ (range I)ᶜ ∈ 𝓝 (extChartAt I x x) := by
+    rw [← nhdsWithin_univ, ← union_compl_self (range I), nhdsWithin_union]
+    apply Filter.union_mem_sup (extChartAt_target_mem_nhdsWithin x) self_mem_nhdsWithin
+  apply mem_nhdsWithin_iff_exists_mem_nhds_inter.2
+    ⟨_, Filter.inter_mem ((continuousAt_extChartAt_symm x).preimage_mem_nhds u_mem) B, ?_⟩
+  rintro z ⟨hz, h'z⟩
+  simp only [eq_iff_iff, mem_setOf_eq]
+  change z ∈ (extChartAt I x).symm ⁻¹' s ∩ range I ↔ z ∈ (extChartAt I x).symm ⁻¹' t ∩ range I
+  by_cases hIz : z ∈ range I
+  · simp [-extChartAt, hIz] at hz ⊢
+    rw [← eq_iff_iff]
+    apply hu ⟨hz.1, ?_⟩
+    simp only [mem_compl_iff, mem_singleton_iff, ne_comm, ne_eq] at h'z ⊢
+    rw [(extChartAt I x).eq_symm_apply (by simp) hz.2]
+    exact Ne.symm h'z
+  · simp [hIz]
+
 /-! ### Congruence lemmas for derivatives on manifolds -/
+
+/-- If two sets coincide locally, except maybe at a point, then it is equivalent to have a manifold
+derivative within one or the other. -/
+theorem hasMFDerivWithinAt_congr_set' (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
+    HasMFDerivWithinAt I I' f s x f' ↔ HasMFDerivWithinAt I I' f t x f' := by
+  have : T1Space M := I.t1Space M
+  simp only [HasMFDerivWithinAt]
+  refine and_congr ?_ ?_
+  · exact continuousWithinAt_congr_set' _ h
+  · apply hasFDerivWithinAt_congr_set' (extChartAt I x x)
+    exact preimage_extChartAt_eventuallyEq_compl_singleton y h
+
+theorem hasMFDerivWithinAt_congr_set (h : s =ᶠ[𝓝 x] t) :
+    HasMFDerivWithinAt I I' f s x f' ↔ HasMFDerivWithinAt I I' f t x f' :=
+  hasMFDerivWithinAt_congr_set' x <| h.filter_mono inf_le_left
+
+/-- If two sets coincide around a point (except possibly at a single point `y`), then it is
+equivalent to be differentiable within one or the other set. -/
+theorem mdifferentiableWithinAt_congr_set' (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
+    MDifferentiableWithinAt I I' f s x ↔ MDifferentiableWithinAt I I' f t x := by
+  simp only [mdifferentiableWithinAt_iff_exists_hasMFDerivWithinAt]
+  exact exists_congr fun _ => hasMFDerivWithinAt_congr_set' _ h
+
+theorem mdifferentiableWithinAt_congr_set (h : s =ᶠ[𝓝 x] t) :
+    MDifferentiableWithinAt I I' f s x ↔ MDifferentiableWithinAt I I' f t x := by
+  simp only [mdifferentiableWithinAt_iff_exists_hasMFDerivWithinAt]
+  exact exists_congr fun _ => hasMFDerivWithinAt_congr_set h
+
+
+/-- If two sets coincide locally, except maybe at a point, then derivatives within these sets
+are the same. -/
+theorem mfderivWithin_congr_set' (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
+    mfderivWithin I I' f s x = mfderivWithin I I' f t x := by
+  by_cases hx : MDifferentiableWithinAt I I' f s x
+  · simp only [mfderivWithin, hx, (mdifferentiableWithinAt_congr_set' y h).1 hx, ↓reduceIte]
+    apply fderivWithin_congr_set' (extChartAt I x x)
+    exact preimage_extChartAt_eventuallyEq_compl_singleton y h
+  · simp [mfderivWithin, hx, ← mdifferentiableWithinAt_congr_set' y h]
+
+/-- If two sets coincide locally, then derivatives within these sets
+are the same. -/
+theorem mfderivWithin_congr_set (h : s =ᶠ[𝓝 x] t) :
+    mfderivWithin I I' f s x = mfderivWithin I I' f t x :=
+  mfderivWithin_congr_set' x <| h.filter_mono inf_le_left
+
+/-- If two sets coincide locally, except maybe at a point, then derivatives within these sets
+coincide locally. -/
+theorem mfderivWithin_eventually_congr_set' (y : M) (h : s =ᶠ[𝓝[{y}ᶜ] x] t) :
+    ∀ᶠ y in 𝓝 x, mfderivWithin I I' f s y = mfderivWithin I I' f t y :=
+  (eventually_nhds_nhdsWithin.2 h).mono fun _ => mfderivWithin_congr_set' y
+
+/-- If two sets coincide locally, then derivatives within these sets coincide locally. -/
+theorem mfderivWithin_eventually_congr_set (h : s =ᶠ[𝓝 x] t) :
+    ∀ᶠ y in 𝓝 x, mfderivWithin I I' f s y = mfderivWithin I I' f t y :=
+  mfderivWithin_eventually_congr_set' x <| h.filter_mono inf_le_left
 
 theorem HasMFDerivAt.congr_mfderiv (h : HasMFDerivAt I I' f x f') (h' : f' = f₁') :
     HasMFDerivAt I I' f x f₁' :=
@@ -505,7 +930,15 @@ theorem MDifferentiableWithinAt.congr_of_eventuallyEq (h : MDifferentiableWithin
     (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : MDifferentiableWithinAt I I' f₁ s x :=
   (h.hasMFDerivWithinAt.congr_of_eventuallyEq h₁ hx).mdifferentiableWithinAt
 
-variable (I I')
+theorem MDifferentiableWithinAt.congr_of_eventuallyEq_of_mem
+    (h : MDifferentiableWithinAt I I' f s x) (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : x ∈ s) :
+    MDifferentiableWithinAt I I' f₁ s x :=
+  h.congr_of_eventuallyEq h₁ (mem_of_mem_nhdsWithin hx h₁ :)
+
+theorem MDifferentiableWithinAt.congr_of_eventuallyEq_insert
+    (h : MDifferentiableWithinAt I I' f s x) (h₁ : f₁ =ᶠ[𝓝[insert x s] x] f) :
+    MDifferentiableWithinAt I I' f₁ s x :=
+  (h.insert.congr_of_eventuallyEq_of_mem h₁ (mem_insert x s)).of_insert
 
 theorem Filter.EventuallyEq.mdifferentiableWithinAt_iff (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) :
     MDifferentiableWithinAt I I' f s x ↔ MDifferentiableWithinAt I I' f₁ s x := by
@@ -517,8 +950,6 @@ theorem Filter.EventuallyEq.mdifferentiableWithinAt_iff (h₁ : f₁ =ᶠ[𝓝[s
     apply h₁.mono
     intro y
     apply Eq.symm
-
-variable {I I'}
 
 theorem MDifferentiableWithinAt.congr_mono (h : MDifferentiableWithinAt I I' f s x)
     (ht : ∀ x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (h₁ : t ⊆ s) :
@@ -539,19 +970,29 @@ theorem MDifferentiableAt.congr_of_eventuallyEq (h : MDifferentiableAt I I' f x)
 
 theorem MDifferentiableWithinAt.mfderivWithin_congr_mono (h : MDifferentiableWithinAt I I' f s x)
     (hs : ∀ x ∈ t, f₁ x = f x) (hx : f₁ x = f x) (hxt : UniqueMDiffWithinAt I t x) (h₁ : t ⊆ s) :
-    mfderivWithin I I' f₁ t x = (mfderivWithin I I' f s x : _) :=
+    mfderivWithin I I' f₁ t x = mfderivWithin I I' f s x :=
   (HasMFDerivWithinAt.congr_mono h.hasMFDerivWithinAt hs hx h₁).mfderivWithin hxt
 
+theorem MDifferentiableWithinAt.mfderivWithin_mono (h : MDifferentiableWithinAt I I' f s x)
+    (hxt : UniqueMDiffWithinAt I t x) (h₁ : t ⊆ s) :
+    mfderivWithin I I' f t x = mfderivWithin I I' f s x :=
+  h.mfderivWithin_congr_mono (fun _ _ ↦ rfl) rfl hxt h₁
+
+theorem MDifferentiableWithinAt.mfderivWithin_mono_of_mem_nhdsWithin
+    (h : MDifferentiableWithinAt I I' f s x) (hxt : UniqueMDiffWithinAt I t x) (h₁ : s ∈ 𝓝[t] x) :
+    mfderivWithin I I' f t x = mfderivWithin I I' f s x :=
+  (HasMFDerivWithinAt.mono_of_mem_nhdsWithin h.hasMFDerivWithinAt h₁).mfderivWithin hxt
+
 theorem Filter.EventuallyEq.mfderivWithin_eq (hs : UniqueMDiffWithinAt I s x) (hL : f₁ =ᶠ[𝓝[s] x] f)
-    (hx : f₁ x = f x) : mfderivWithin I I' f₁ s x = (mfderivWithin I I' f s x : _) := by
+    (hx : f₁ x = f x) : mfderivWithin I I' f₁ s x = mfderivWithin I I' f s x := by
   by_cases h : MDifferentiableWithinAt I I' f s x
   · exact (h.hasMFDerivWithinAt.congr_of_eventuallyEq hL hx).mfderivWithin hs
   · unfold mfderivWithin
     rw [if_neg h, if_neg]
-    rwa [← hL.mdifferentiableWithinAt_iff I I' hx]
+    rwa [← hL.mdifferentiableWithinAt_iff hx]
 
 theorem mfderivWithin_congr (hs : UniqueMDiffWithinAt I s x) (hL : ∀ x ∈ s, f₁ x = f x)
-    (hx : f₁ x = f x) : mfderivWithin I I' f₁ s x = (mfderivWithin I I' f s x : _) :=
+    (hx : f₁ x = f x) : mfderivWithin I I' f₁ s x = mfderivWithin I I' f s x :=
   Filter.EventuallyEq.mfderivWithin_eq hs (Filter.eventuallyEq_of_mem self_mem_nhdsWithin hL) hx
 
 theorem tangentMapWithin_congr (h : ∀ x ∈ s, f x = f₁ x) (p : TangentBundle I M) (hp : p.1 ∈ s)
@@ -562,7 +1003,7 @@ theorem tangentMapWithin_congr (h : ∀ x ∈ s, f x = f₁ x) (p : TangentBundl
   rw [tangentMapWithin, h p.1 hp, tangentMapWithin, mfderivWithin_congr hs h (h _ hp)]
 
 theorem Filter.EventuallyEq.mfderiv_eq (hL : f₁ =ᶠ[𝓝 x] f) :
-    mfderiv I I' f₁ x = (mfderiv I I' f x : _) := by
+    mfderiv I I' f₁ x = mfderiv I I' f x := by
   have A : f₁ x = f x := (mem_of_mem_nhds hL : _)
   rw [← mfderivWithin_univ, ← mfderivWithin_univ]
   rw [← nhdsWithin_univ] at hL
@@ -629,9 +1070,42 @@ theorem MDifferentiableWithinAt.comp (hg : MDifferentiableWithinAt I' I'' g u (f
   have G : HasMFDerivWithinAt I' I'' g u (f x) g' := ⟨hg.1, hg'⟩
   exact (HasMFDerivWithinAt.comp x G F h).mdifferentiableWithinAt
 
+theorem MDifferentiableWithinAt.comp_of_eq {y : M'} (hg : MDifferentiableWithinAt I' I'' g u y)
+    (hf : MDifferentiableWithinAt I I' f s x) (h : s ⊆ f ⁻¹' u) (hy : f x = y) :
+    MDifferentiableWithinAt I I'' (g ∘ f) s x := by
+  subst hy; exact hg.comp _ hf h
+
+theorem MDifferentiableWithinAt.comp_of_mem_nhdsWithin
+    (hg : MDifferentiableWithinAt I' I'' g u (f x))
+    (hf : MDifferentiableWithinAt I I' f s x) (h : f ⁻¹' u ∈ 𝓝[s] x) :
+    MDifferentiableWithinAt I I'' (g ∘ f) s x :=
+  (hg.comp _ (hf.mono inter_subset_right) inter_subset_left).mono_of_mem_nhdsWithin
+    (Filter.inter_mem h self_mem_nhdsWithin)
+
+theorem MDifferentiableWithinAt.comp_of_mem_nhdsWithin_of_eq {y : M'}
+    (hg : MDifferentiableWithinAt I' I'' g u y)
+    (hf : MDifferentiableWithinAt I I' f s x) (h : f ⁻¹' u ∈ 𝓝[s] x) (hy : f x = y) :
+    MDifferentiableWithinAt I I'' (g ∘ f) s x := by
+  subst hy; exact MDifferentiableWithinAt.comp_of_mem_nhdsWithin _ hg hf h
+
 theorem MDifferentiableAt.comp (hg : MDifferentiableAt I' I'' g (f x))
     (hf : MDifferentiableAt I I' f x) : MDifferentiableAt I I'' (g ∘ f) x :=
   (hg.hasMFDerivAt.comp x hf.hasMFDerivAt).mdifferentiableAt
+
+theorem MDifferentiableAt.comp_of_eq {y : M'} (hg : MDifferentiableAt I' I'' g y)
+    (hf : MDifferentiableAt I I' f x) (hy : f x = y) : MDifferentiableAt I I'' (g ∘ f) x := by
+  subst hy; exact hg.comp _ hf
+
+theorem MDifferentiableAt.comp_mdifferentiableWithinAt
+    (hg : MDifferentiableAt I' I'' g (f x)) (hf : MDifferentiableWithinAt I I' f s x) :
+    MDifferentiableWithinAt I I'' (g ∘ f) s x := by
+  rw [← mdifferentiableWithinAt_univ] at hg
+  exact hg.comp _ hf (by simp)
+
+theorem MDifferentiableAt.comp_mdifferentiableWithinAt_of_eq {y : M'}
+    (hg : MDifferentiableAt I' I'' g y) (hf : MDifferentiableWithinAt I I' f s x) (hy : f x = y) :
+    MDifferentiableWithinAt I I'' (g ∘ f) s x := by
+  subst hy; exact hg.comp_mdifferentiableWithinAt _ hf
 
 theorem mfderivWithin_comp (hg : MDifferentiableWithinAt I' I'' g u (f x))
     (hf : MDifferentiableWithinAt I I' f s x) (h : s ⊆ f ⁻¹' u) (hxs : UniqueMDiffWithinAt I s x) :
@@ -639,6 +1113,48 @@ theorem mfderivWithin_comp (hg : MDifferentiableWithinAt I' I'' g u (f x))
       (mfderivWithin I' I'' g u (f x)).comp (mfderivWithin I I' f s x) := by
   apply HasMFDerivWithinAt.mfderivWithin _ hxs
   exact HasMFDerivWithinAt.comp x hg.hasMFDerivWithinAt hf.hasMFDerivWithinAt h
+
+theorem mfderivWithin_comp_of_eq {x : M} {y : M'} (hg : MDifferentiableWithinAt I' I'' g u y)
+    (hf : MDifferentiableWithinAt I I' f s x) (h : s ⊆ f ⁻¹' u) (hxs : UniqueMDiffWithinAt I s x)
+    (hy : f x = y) :
+    mfderivWithin I I'' (g ∘ f) s x =
+      (mfderivWithin I' I'' g u y).comp (mfderivWithin I I' f s x) := by
+  subst hy; exact mfderivWithin_comp x hg hf h hxs
+
+theorem mfderivWithin_comp_of_mem_nhdsWithin (hg : MDifferentiableWithinAt I' I'' g u (f x))
+    (hf : MDifferentiableWithinAt I I' f s x) (h : f ⁻¹' u ∈ 𝓝[s] x)
+    (hxs : UniqueMDiffWithinAt I s x) :
+    mfderivWithin I I'' (g ∘ f) s x =
+      (mfderivWithin I' I'' g u (f x)).comp (mfderivWithin I I' f s x) := by
+  have A : s ∩ f ⁻¹' u ∈ 𝓝[s] x := Filter.inter_mem self_mem_nhdsWithin h
+  have B : mfderivWithin I I'' (g ∘ f) s x = mfderivWithin I I'' (g ∘ f) (s ∩ f ⁻¹' u) x := by
+    apply MDifferentiableWithinAt.mfderivWithin_mono_of_mem_nhdsWithin _ hxs A
+    exact hg.comp _ (hf.mono inter_subset_left) inter_subset_right
+  have C : mfderivWithin I I' f s x = mfderivWithin I I' f (s ∩ f ⁻¹' u) x :=
+    MDifferentiableWithinAt.mfderivWithin_mono_of_mem_nhdsWithin (hf.mono inter_subset_left) hxs A
+  rw [B, C]
+  exact mfderivWithin_comp _ hg (hf.mono inter_subset_left) inter_subset_right (hxs.inter' h)
+
+theorem mfderivWithin_comp_of_mem_nhdsWithin_of_eq {y : M'}
+    (hg : MDifferentiableWithinAt I' I'' g u y)
+    (hf : MDifferentiableWithinAt I I' f s x) (h : f ⁻¹' u ∈ 𝓝[s] x)
+    (hxs : UniqueMDiffWithinAt I s x) (hy : f x = y) :
+    mfderivWithin I I'' (g ∘ f) s x =
+      (mfderivWithin I' I'' g u y).comp (mfderivWithin I I' f s x) := by
+  subst hy; exact mfderivWithin_comp_of_mem_nhdsWithin _ hg hf h hxs
+
+theorem mfderiv_comp_mfderivWithin (hg : MDifferentiableAt I' I'' g (f x))
+    (hf : MDifferentiableWithinAt I I' f s x) (hxs : UniqueMDiffWithinAt I s x) :
+    mfderivWithin I I'' (g ∘ f) s x =
+      (mfderiv I' I'' g (f x)).comp (mfderivWithin I I' f s x) := by
+  rw [← mfderivWithin_univ]
+  exact mfderivWithin_comp _ hg.mdifferentiableWithinAt hf (by simp) hxs
+
+theorem mfderiv_comp_mfderivWithin_of_eq {x : M} {y : M'} (hg : MDifferentiableAt I' I'' g y)
+    (hf : MDifferentiableWithinAt I I' f s x) (hxs : UniqueMDiffWithinAt I s x) (hy : f x = y) :
+    mfderivWithin I I'' (g ∘ f) s x =
+      (mfderiv I' I'' g y).comp (mfderivWithin I I' f s x) := by
+  subst hy; exact mfderiv_comp_mfderivWithin x hg hf hxs
 
 theorem mfderiv_comp (hg : MDifferentiableAt I' I'' g (f x)) (hf : MDifferentiableAt I I' f x) :
     mfderiv I I'' (g ∘ f) x = (mfderiv I' I'' g (f x)).comp (mfderiv I I' f x) := by
@@ -650,9 +1166,25 @@ theorem mfderiv_comp_of_eq {x : M} {y : M'} (hg : MDifferentiableAt I' I'' g y)
     mfderiv I I'' (g ∘ f) x = (mfderiv I' I'' g (f x)).comp (mfderiv I I' f x) := by
   subst hy; exact mfderiv_comp x hg hf
 
+theorem mfderiv_comp_apply (hg : MDifferentiableAt I' I'' g (f x))
+    (hf : MDifferentiableAt I I' f x) (v : TangentSpace I x) :
+    mfderiv I I'' (g ∘ f) x v = (mfderiv I' I'' g (f x)) ((mfderiv I I' f x) v) := by
+  rw [mfderiv_comp _ hg hf]
+  rfl
+
+theorem mfderiv_comp_apply_of_eq {y : M'} (hg : MDifferentiableAt I' I'' g y)
+    (hf : MDifferentiableAt I I' f x)  (hy : f x = y) (v : TangentSpace I x) :
+    mfderiv I I'' (g ∘ f) x v = (mfderiv I' I'' g y) ((mfderiv I I' f x) v) := by
+  subst hy; exact mfderiv_comp_apply _ hg hf v
+
 theorem MDifferentiableOn.comp (hg : MDifferentiableOn I' I'' g u) (hf : MDifferentiableOn I I' f s)
     (st : s ⊆ f ⁻¹' u) : MDifferentiableOn I I'' (g ∘ f) s := fun x hx =>
   MDifferentiableWithinAt.comp x (hg (f x) (st hx)) (hf x hx) st
+
+theorem MDifferentiable.comp_mdifferentiableOn (hg : MDifferentiable I' I'' g)
+    (hf : MDifferentiableOn I I' f s) : MDifferentiableOn I I'' (g ∘ f) s := by
+  rw [← mdifferentiableOn_univ] at hg
+  exact hg.comp hf (by simp)
 
 theorem MDifferentiable.comp (hg : MDifferentiable I' I'' g) (hf : MDifferentiable I I' f) :
     MDifferentiable I I'' (g ∘ f) := fun x => MDifferentiableAt.comp x (hg (f x)) (hf x)

--- a/Mathlib/Geometry/Manifold/MFDeriv/Defs.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Defs.lean
@@ -128,6 +128,22 @@ differentiable functions between manifolds. -/
 def DifferentiableWithinAtProp (f : H → H') (s : Set H) (x : H) : Prop :=
   DifferentiableWithinAt 𝕜 (I' ∘ f ∘ I.symm) (I.symm ⁻¹' s ∩ Set.range I) (I x)
 
+open scoped Manifold
+
+theorem differentiableWithinAtProp_self_source {f : E → H'} {s : Set E} {x : E} :
+    DifferentiableWithinAtProp 𝓘(𝕜, E) I' f s x ↔ DifferentiableWithinAt 𝕜 (I' ∘ f) s x := by
+  simp_rw [DifferentiableWithinAtProp, modelWithCornersSelf_coe, range_id, inter_univ,
+    modelWithCornersSelf_coe_symm, CompTriple.comp_eq, preimage_id_eq, id_eq]
+
+theorem DifferentiableWithinAtProp_self {f : E → E'} {s : Set E} {x : E} :
+    DifferentiableWithinAtProp 𝓘(𝕜, E) 𝓘(𝕜, E') f s x ↔ DifferentiableWithinAt 𝕜 f s x :=
+  differentiableWithinAtProp_self_source
+
+theorem differentiableWithinAtProp_self_target {f : H → E'} {s : Set H} {x : H} :
+    DifferentiableWithinAtProp I 𝓘(𝕜, E') f s x ↔
+      DifferentiableWithinAt 𝕜 (f ∘ I.symm) (I.symm ⁻¹' s ∩ range I) (I x) :=
+  Iff.rfl
+
 /-- Being differentiable in the model space is a local property, invariant under smooth maps.
 Therefore, it will lift nicely to manifolds. -/
 theorem differentiableWithinAt_localInvariantProp :


### PR DESCRIPTION
Sequel to #17927 and #18447.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
