### PR TITLE
feat(Computability.Timed): Formalization of runtime complexity of insertion sort

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2167,6 +2167,7 @@ import Mathlib.Computability.Reduce
 import Mathlib.Computability.RegularExpressions
 import Mathlib.Computability.TMComputable
 import Mathlib.Computability.TMToPartrec
+import Mathlib.Computability.Timed.InsertionSort
 import Mathlib.Computability.TuringMachine
 import Mathlib.Condensed.Basic
 import Mathlib.Condensed.CartesianClosed

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2165,6 +2165,7 @@ import Mathlib.Computability.PartrecCode
 import Mathlib.Computability.Primrec
 import Mathlib.Computability.Reduce
 import Mathlib.Computability.RegularExpressions
+import Mathlib.Computability.Timed.InsertionSort
 import Mathlib.Computability.TMComputable
 import Mathlib.Computability.TMToPartrec
 import Mathlib.Computability.TuringMachine

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2165,7 +2165,6 @@ import Mathlib.Computability.PartrecCode
 import Mathlib.Computability.Primrec
 import Mathlib.Computability.Reduce
 import Mathlib.Computability.RegularExpressions
-import Mathlib.Computability.Timed.InsertionSort
 import Mathlib.Computability.TMComputable
 import Mathlib.Computability.TMToPartrec
 import Mathlib.Computability.TuringMachine

--- a/Mathlib/Computability/Timed/InsertionSort.lean
+++ b/Mathlib/Computability/Timed/InsertionSort.lean
@@ -7,16 +7,19 @@ import Mathlib.Data.List.Sort
 import Mathlib.Tactic.Linarith
 /-!
 # Timed Insertion Sort
-  This file defines a new version of Insertion Sort that, besides sorting the input list, counts
-  the number of comparisons made through the execution of the algorithm. Also, it presents proofs
-  of its time complexity and its equivalence to the one defined in Data/List/Sort.lean
- ## Main Definition
-  - Timed.insertion_sort : list α → (list α × ℕ)
+
+This file defines a new version of Insertion Sort that, besides sorting the input list, counts
+the number of comparisons made through the execution of the algorithm. Also, it presents proofs
+of its time complexity and its equivalence to the one defined in Data/List/Sort.lean
+
+## Main Definition
+
+- Timed.insertion_sort : list α → list α × ℕ
+
 ## Main Results
-  - Timed.insertion_sort_complexity :
-      ∀ l : list α, (Timed.insertionSort r l).snd ≤ l.length * l.length
-  - Timed.insertion_sort_equivalence :
-      ∀ l : list α, (Timed.insertionSort r l).fst = List.insertionSort r l
+
+- Timed.insertion_sort_complexity : ∀ l, (Timed.insertionSort r l).snd ≤ l.length * l.length
+- Timed.insertion_sort_equivalence : ∀ l, (Timed.insertionSort r l).fst = List.insertionSort r l
 -/
 
 namespace Timed
@@ -27,16 +30,17 @@ variable {α : Type u} (r : α → α → Prop) [DecidableRel r]
 local infixl:50 " ≼ " => r
 
 /-- The redesigned version of `orderedInsert`, which also returns the number of comparisons
-    performed. -/
-@[simp] def orderedInsert (a : α) : List α → (List α × Nat)
+performed. -/
+@[simp] def orderedInsert (a : α) : List α → List α × ℕ
   | []      => ([a], 0)
-  | b :: l => if a ≼ b then (a :: b :: l, 1)
-              else let (l', n) := orderedInsert a l
-                   (b :: l', n + 1)
+  | b :: l =>
+    if a ≼ b then (a :: b :: l, 1)
+    else let (l', n) := orderedInsert a l
+    (b :: l', n + 1)
 
 /-- The redesigned version of `insertionSort`, which also returns the number of comparisons
-    performed. -/
-@[simp] def insertionSort : List α → (List α × Nat)
+performed. -/
+@[simp] def insertionSort : List α → List α × ℕ
   | [] => ([], 0)
   | (h :: t) => let (l', n)  := insertionSort t
                 let (l'', m) := orderedInsert r h l'

--- a/Mathlib/Computability/Timed/InsertionSort.lean
+++ b/Mathlib/Computability/Timed/InsertionSort.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2024 Tomaz Mascarenhas. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomaz Mascarenhas
+-/
+import Mathlib.Data.List.Sort
+import Mathlib.Tactic.Linarith
+/-!
+# Timed Insertion Sort
+  This file defines a new version of Insertion Sort that, besides sorting the input list, counts the
+  number of comparisons made through the execution of the algorithm. Also, it presents proofs of
+  its time complexity and its equivalence to the one defined in Data/List/Sort.lean
+ ## Main Definition
+  - Timed.insertion_sort : list α → (list α × ℕ)
+## Main Results
+  - Timed.insertion_sort_complexity :
+      ∀ l : list α, (Timed.insertionSort r l).snd ≤ l.length * l.length
+  - Timed.insertion_sort_equivalence :
+      ∀ l : list α, (Timed.insertionSort r l).fst = List.insertionSort r l
+-/
+
+namespace Timed
+
+universe u
+
+variable {α : Type u} (r : α → α → Prop) [DecidableRel r]
+local infixl:50 " ≼ " => r
+
+@[simp] def orderedInsert (a : α) : List α → (List α × Nat)
+  | []      => ([a], 0)
+  | b :: l => if a ≼ b then (a :: b :: l, 1)
+              else let (l', n) := orderedInsert a l
+                   (b :: l', n + 1)
+
+@[simp] def insertionSort : List α → (List α × Nat)
+  | [] => ([], 0)
+  | (h :: t) => let (l', n)  := insertionSort t
+                let (l'', m) := orderedInsert r h l'
+                (l'', n + m)
+
+theorem orderedInsert_complexity (a : α) :
+    ∀ l : List α, (orderedInsert r a l).snd ≤ l.length
+  | []     => by simp
+  | b :: l' => by
+    simp only [orderedInsert, List.length_cons]
+    split_ifs with h
+    · simp
+    · simp [orderedInsert_complexity a l']
+
+theorem orderedInsert_equivalence (a : α) : ∀ l : List α,
+    (orderedInsert r a l).fst = List.orderedInsert r a l
+  | [] => by simp
+  | b :: l' => by
+    simp only [orderedInsert, List.orderedInsert]
+    split_ifs with h
+    · rfl
+    · simp [orderedInsert_equivalence a l']
+
+theorem orderedInsert_increases_length (a : α) : ∀ l : List α,
+    (orderedInsert r a l).fst.length = l.length + 1
+  | [] => by simp
+  | b :: l' => by
+    simp only [orderedInsert, List.length_cons]
+    split_ifs with h
+    · rfl
+    · simp [orderedInsert_increases_length a l']
+
+theorem insertionSort_preserves_length : ∀ l : List α,
+    (insertionSort r l).fst.length = l.length := fun l =>
+  match l with
+  | [] => by simp
+  | a :: l' => by
+    simp only [insertionSort, List.length_cons]
+    rw [orderedInsert_increases_length r a (insertionSort r l').fst]
+    simp [insertionSort_preserves_length l']
+
+theorem insertionSort_complexity :
+    ∀ l : List α, (insertionSort r l).snd ≤ l.length * l.length
+  | [] => by simp
+  | a :: l' => by
+    have same_lengths := insertionSort_preserves_length r l'
+    have :
+      (insertionSort r l').snd + (orderedInsert r a (insertionSort r l').fst).snd ≤
+      l'.length * l'.length + (orderedInsert r a (insertionSort r l').fst).snd :=
+        add_le_add (insertionSort_complexity l') le_rfl
+    have :
+      l'.length * l'.length + (orderedInsert r a (insertionSort r l').fst).snd ≤
+      l'.length * l'.length + l'.length := by
+        apply add_le_add le_rfl
+        have orderedInsert_compl :=
+          orderedInsert_complexity r a (insertionSort r l').fst
+        rw [same_lengths] at orderedInsert_compl
+        exact orderedInsert_compl
+    simp only [insertionSort, List.length_cons, ge_iff_le]
+    linarith
+
+theorem insertionSort_equivalence : ∀ l : List α,
+    (insertionSort r l).fst = List.insertionSort r l
+  | [] => by simp
+  | _ :: l' => by
+    simp [orderedInsert_equivalence, insertionSort_equivalence l']
+
+end Timed

--- a/Mathlib/Computability/Timed/InsertionSort.lean
+++ b/Mathlib/Computability/Timed/InsertionSort.lean
@@ -26,12 +26,14 @@ universe u
 variable {α : Type u} (r : α → α → Prop) [DecidableRel r]
 local infixl:50 " ≼ " => r
 
+/-- The redesigned version of `orderedInsert`, which also returns the number of comparisons performed. -/
 @[simp] def orderedInsert (a : α) : List α → (List α × Nat)
   | []      => ([a], 0)
   | b :: l => if a ≼ b then (a :: b :: l, 1)
               else let (l', n) := orderedInsert a l
                    (b :: l', n + 1)
 
+/-- The redesigned version of `insertionSort`, which also returns the number of comparisons performed. -/
 @[simp] def insertionSort : List α → (List α × Nat)
   | [] => ([], 0)
   | (h :: t) => let (l', n)  := insertionSort t

--- a/Mathlib/Computability/Timed/InsertionSort.lean
+++ b/Mathlib/Computability/Timed/InsertionSort.lean
@@ -7,9 +7,9 @@ import Mathlib.Data.List.Sort
 import Mathlib.Tactic.Linarith
 /-!
 # Timed Insertion Sort
-  This file defines a new version of Insertion Sort that, besides sorting the input list, counts the
-  number of comparisons made through the execution of the algorithm. Also, it presents proofs of
-  its time complexity and its equivalence to the one defined in Data/List/Sort.lean
+  This file defines a new version of Insertion Sort that, besides sorting the input list, counts
+  the number of comparisons made through the execution of the algorithm. Also, it presents proofs
+  of its time complexity and its equivalence to the one defined in Data/List/Sort.lean
  ## Main Definition
   - Timed.insertion_sort : list α → (list α × ℕ)
 ## Main Results
@@ -26,14 +26,16 @@ universe u
 variable {α : Type u} (r : α → α → Prop) [DecidableRel r]
 local infixl:50 " ≼ " => r
 
-/-- The redesigned version of `orderedInsert`, which also returns the number of comparisons performed. -/
+/-- The redesigned version of `orderedInsert`, which also returns the number of comparisons
+    performed. -/
 @[simp] def orderedInsert (a : α) : List α → (List α × Nat)
   | []      => ([a], 0)
   | b :: l => if a ≼ b then (a :: b :: l, 1)
               else let (l', n) := orderedInsert a l
                    (b :: l', n + 1)
 
-/-- The redesigned version of `insertionSort`, which also returns the number of comparisons performed. -/
+/-- The redesigned version of `insertionSort`, which also returns the number of comparisons
+    performed. -/
 @[simp] def insertionSort : List α → (List α × Nat)
   | [] => ([], 0)
   | (h :: t) => let (l', n)  := insertionSort t


### PR DESCRIPTION
This PR adds the formalization of the runtime complexity of the insertion sort algorithm, defined in `Data/List/Sort`.
References:
- Previous PR on mathlib3: https://github.com/leanprover-community/mathlib3/pull/14494/
- First discussion on Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/BSc.20Final.20Project/near/220647062
- Second disussion on Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Formalization.20of.20Runtime.20Complexity.20of.20Sorting.20Algorithms/near/284184450
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
