### PR TITLE
feat(Computability.Timed): Formalization of runtime complexity of List.mergeSort

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2167,6 +2167,7 @@ import Mathlib.Computability.Reduce
 import Mathlib.Computability.RegularExpressions
 import Mathlib.Computability.Timed.InsertionSort
 import Mathlib.Computability.Timed.Merge
+import Mathlib.Computability.Timed.MergeSort
 import Mathlib.Computability.Timed.Split
 import Mathlib.Computability.TMComputable
 import Mathlib.Computability.TMToPartrec

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2166,6 +2166,7 @@ import Mathlib.Computability.Primrec
 import Mathlib.Computability.Reduce
 import Mathlib.Computability.RegularExpressions
 import Mathlib.Computability.Timed.InsertionSort
+import Mathlib.Computability.Timed.Merge
 import Mathlib.Computability.Timed.Split
 import Mathlib.Computability.TMComputable
 import Mathlib.Computability.TMToPartrec

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2165,6 +2165,7 @@ import Mathlib.Computability.PartrecCode
 import Mathlib.Computability.Primrec
 import Mathlib.Computability.Reduce
 import Mathlib.Computability.RegularExpressions
+import Mathlib.Computability.Timed.InsertionSort
 import Mathlib.Computability.TMComputable
 import Mathlib.Computability.TMToPartrec
 import Mathlib.Computability.TuringMachine

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2166,6 +2166,7 @@ import Mathlib.Computability.Primrec
 import Mathlib.Computability.Reduce
 import Mathlib.Computability.RegularExpressions
 import Mathlib.Computability.Timed.InsertionSort
+import Mathlib.Computability.Timed.Split
 import Mathlib.Computability.TMComputable
 import Mathlib.Computability.TMToPartrec
 import Mathlib.Computability.TuringMachine

--- a/Mathlib/Computability/Timed/InsertionSort.lean
+++ b/Mathlib/Computability/Timed/InsertionSort.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2024 Tomaz Mascarenhas. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomaz Mascarenhas
+-/
+import Mathlib.Data.List.Sort
+import Mathlib.Tactic.Linarith
+/-!
+# Timed Insertion Sort
+  This file defines a new version of Insertion Sort that, besides sorting the input list, counts the
+  number of comparisons made through the execution of the algorithm. Also, it presents proofs of
+  its time complexity and its equivalence to the one defined in Data/List/Sort.lean
+ ## Main Definition
+  - Timed.insertion_sort : list α → (list α × ℕ)
+## Main Results
+  - Timed.insertion_sort_complexity :
+      ∀ l : list α, (Timed.insertionSort r l).snd ≤ l.length * l.length
+  - Timed.insertion_sort_equivalence :
+      ∀ l : list α, (Timed.insertionSort r l).fst = List.insertionSort r l
+-/
+
+namespace Timed
+
+universe u
+
+variable {α : Type u} (r : α → α → Prop) [DecidableRel r]
+local infixl:50 " ≼ " => r
+
+@[simp] def orderedInsert (a : α) : List α → (List α × Nat)
+  | []      => ([a], 0)
+  | b :: l => if a ≼ b then (a :: b :: l, 1)
+              else let (l', n) := orderedInsert a l
+                   (b :: l', n + 1)
+
+@[simp] def insertionSort : List α → (List α × Nat)
+  | [] => ([], 0)
+  | (h :: t) => let (l', n)  := insertionSort t
+                let (l'', m) := orderedInsert r h l'
+                (l'', n + m)
+
+theorem orderedInsert_complexity (a : α) :
+    ∀ l : List α, (orderedInsert r a l).snd ≤ l.length
+  | []     => by simp
+  | b :: l' => by
+    simp only [orderedInsert, List.length_cons]
+    split_ifs with h
+    · simp
+    · simp [orderedInsert_complexity a l']
+
+theorem orderedInsert_equivalence (a : α) : ∀ l : List α,
+    (orderedInsert r a l).fst = List.orderedInsert r a l
+  | [] => by simp
+  | b :: l' => by
+    simp only [orderedInsert, List.orderedInsert]
+    split_ifs with h
+    · rfl
+    · simp [orderedInsert_equivalence a l']
+
+theorem orderedInsert_increases_length (a : α) : ∀ l : List α,
+    (orderedInsert r a l).fst.length = l.length + 1
+  | [] => by simp
+  | b :: l' => by
+    simp only [orderedInsert, List.length_cons]
+    split_ifs with h
+    · rfl
+    · simp [orderedInsert_increases_length a l']
+
+theorem insertionSort_preserves_length : ∀ l : List α,
+    (insertionSort r l).fst.length = l.length := fun l =>
+  match l with
+  | [] => by simp
+  | a :: l' => by
+    simp only [insertionSort, List.length_cons]
+    rw [orderedInsert_increases_length r a (insertionSort r l').fst]
+    simp [insertionSort_preserves_length l']
+
+theorem insertionSort_complexity :
+    ∀ l : List α, (insertionSort r l).snd ≤ l.length * l.length
+  | [] => by simp
+  | a :: l' => by
+    have same_lengths := insertionSort_preserves_length r l'
+    have :
+      (insertionSort r l').snd + (orderedInsert r a (insertionSort r l').fst).snd ≤
+      l'.length * l'.length + (orderedInsert r a (insertionSort r l').fst).snd :=
+        add_le_add (insertionSort_complexity l') le_rfl
+    have :
+      l'.length * l'.length + (orderedInsert r a (insertionSort r l').fst).snd ≤
+      l'.length * l'.length + l'.length := by
+        apply add_le_add le_rfl
+        have orderedInsert_compl :=
+          orderedInsert_complexity r a (insertionSort r l').fst
+        rw [same_lengths] at orderedInsert_compl
+        exact orderedInsert_compl
+    simp only [insertionSort, List.length_cons, ge_iff_le]
+    linarith
+
+theorem insertionSort_equivalence : ∀ l : List α,
+    (insertionSort r l).fst = List.insertionSort r l
+  | [] => by simp
+  | _ :: l' => by
+    simp [orderedInsert_equivalence, insertionSort_equivalence l']
+
+end Timed

--- a/Mathlib/Computability/Timed/Merge.lean
+++ b/Mathlib/Computability/Timed/Merge.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2024 Tomaz Mascarenhas. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomaz Mascarenhas
+-/
+import Mathlib.Data.List.Sort
+import Mathlib.Tactic.Linarith
+/-!
+# Timed Merge
+  This file defines a new version of Merge that, besides combining the input lists, counts the
+  number of operations made through the execution of the algorithm. Also, it presents proofs of
+  its time complexity and it's equivalence to the one defined in Data/List/Sort.lean
+## Main Definition
+  - Timed.merge : list α → list α → (list α × ℕ)
+## Main Results
+  - Timed.merge_complexity :
+      ∀ l₁ l₂ : list α, (Timed.merge l₁ l₂).snd ≤ l₁.length + l₂.length
+  - Timed.merge_equivalence :
+      ∀ l₁ l₂ : list α, (Timed.merge l₁ l₂).fst = List.merge l₁ l₂
+-/
+
+namespace Timed
+
+universe u
+
+variable {α : Type u} (s : α → α → Bool)
+local infixl:50 " ≼ " => s
+
+@[simp] def merge (l r : List α) : (List α × Nat) :=
+  loop l r []
+where
+  loop : List α → List α → List α → (List α × Nat)
+  | [], r, t => (List.reverseAux t r, 0)
+  | l, [], t => (List.reverseAux t l, 0)
+  | a::l, b::r, t =>
+    bif s a b then
+      let (l', n) := loop l (b::r) (a::t)
+      (l', n + 1)
+    else
+      let (l', n) := loop (a::l) r (b::t)
+      (l', n + 1)
+
+theorem merge_loop_complexity : ∀ l₁ l₂ l₃ : List α,
+    (merge.loop s l₁ l₂ l₃).snd ≤ l₁.length + l₂.length
+  | [],   r,  t => by simp [merge.loop]
+  | _::_, [], t => by simp [merge.loop]
+  | a::l, b::r, t => by
+    simp only [merge.loop, List.length_cons]
+    cases s a b
+    · have ih := merge_loop_complexity (a :: l) r (b :: t); simp at ih ⊢; linarith
+    · have ih := merge_loop_complexity l (b :: r) (a :: t); simp at ih ⊢; linarith
+
+theorem merge_complexity : ∀ l₁ l₂ : List α,
+    (merge s l₁ l₂).snd ≤ l₁.length + l₂.length
+  | [], l₂ => by simp [merge.loop]
+  | (h₁ :: t₁), [] => by simp [merge.loop]
+  | (h₁ :: t₁), (h₂ :: t₂) => by
+    unfold merge
+    unfold merge.loop
+    cases s h₁ h₂
+    · have ih := merge_loop_complexity s (h₁ :: t₁) t₂ [h₂]
+      simp only [List.length_cons, cond_false, ge_iff_le] at ih ⊢
+      linarith
+    · have ih := merge_loop_complexity s t₁ (h₂ :: t₂) [h₁]
+      simp only [List.length_cons, cond_true, ge_iff_le] at ih ⊢
+      linarith
+
+theorem merge_loop_equivalence : ∀ l₁ l₂ l₃ : List α,
+    (merge.loop s l₁ l₂ l₃).fst = List.merge.loop s l₁ l₂ l₃
+  | [], r, t => by simp [merge.loop, List.merge.loop]
+  | _::_, [], t => by simp [merge.loop, List.merge.loop]
+  | a::l, b::r, t => by
+    simp only [merge.loop, List.merge.loop]
+    cases s a b
+    · simp only [cond_false]; exact merge_loop_equivalence (a :: l) r (b :: t)
+    · simp only [cond_true]; exact merge_loop_equivalence l (b :: r) (a :: t)
+
+theorem merge_equivalence : ∀ l₁ l₂ : List α,
+    (merge s l₁ l₂).fst = List.merge s l₁ l₂
+  | [],       []           => by simp [merge.loop]
+  | [],       (h₂ :: t₂)   => by simp [merge.loop]
+  | (h₁ :: t₁), []         => by simp [merge.loop]
+  | (h₁ :: t₁), (h₂ :: t₂) => by
+    unfold merge
+    unfold List.merge
+    rw [merge_loop_equivalence s (h₁ :: t₁) (h₂ :: t₂) []]
+
+end Timed

--- a/Mathlib/Computability/Timed/MergeSort.lean
+++ b/Mathlib/Computability/Timed/MergeSort.lean
@@ -1,0 +1,238 @@
+/-
+Copyright (c) 2024 Tomaz Mascarenhas. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomaz Mascarenhas
+-/
+import Mathlib.Computability.Timed.Merge
+import Mathlib.Computability.Timed.Split
+import Mathlib.Data.List.Sort
+import Mathlib.Tactic.Linarith
+/-!
+# Timed Merge Sort
+  This file defines a new version of Merge Sort that, besides sorting the input list, counts the
+  number of operations made through the execution of the algorithm. Also, it presents proofs of
+  its time complexity and its equivalence to the one defined in Data/List/Sort.lean
+## Main Definition:
+  - Timed.mergeSort : list α → (list α × ℕ)
+## Main Results:
+  - Timed.mergeSort_complexity :
+      ∀ l : list α, (Timed.mergeSort r l).snd ≤ 8 * l.length * Nat.log 2 l.length
+  - Timed.mergeSort_equivalence :
+      ∀ l : list α, (Timed.mergeSort r l).fst = list.mergeSort r l
+-/
+
+namespace Timed
+
+universe u
+
+variable {α : Type u} (r : α → α → Prop) [DecidableRel r]
+local infixl:50 " ≼ " => r
+
+lemma log_pred (n : Nat) : Nat.log 2 n - 1 = Nat.log 2 (n / 2) :=
+  match n with
+  | 0 => by simp
+  | 1 => by norm_num
+  | (n + 2) => by
+    rw [Nat.log]
+    split_ifs with h
+    · simp
+    · simp at h
+
+lemma log_2_le (n : Nat) : 2 * Nat.log 2 n ≤ n :=
+  match n with
+  | 0     => by simp
+  | n + 1 => by
+    have : (n + 1) / 2 < n + 1 := Nat.div_lt_self' n 0
+    rw [Nat.log]
+    split_ifs
+    · have := log_2_le ((n + 1) / 2); omega
+    · simp
+
+lemma sub_left_eq (n m k : Nat) (h : n = m) : n - k = m - k := by rw [h]
+
+@[simp] def mergeSort : List α → (List α × Nat)
+  | [] => ([], 0)
+  | [a] => ([a], 0)
+  | a :: b :: l => by
+    cases r₁: List.split (a :: b :: l) with
+    | mk l₁ l₂ =>
+      have h := @List.length_split_lt α a b l l₁ l₂ r₁
+      have := h.1
+      have := h.2
+      let ⟨sorted_ls₁, m₁⟩ := mergeSort l₁
+      let ⟨sorted_ls₂, m₂⟩ := mergeSort l₂
+      let ⟨ls', m⟩ := merge (r · ·) sorted_ls₁ sorted_ls₂
+      exact ⟨ls', m₁ + m₂ + m⟩
+  termination_by l => List.length l
+
+theorem mergeSort_cons_cons {a b} {l l₁ l₂ : List α}
+    (h : List.split (a :: b :: l) = (l₁, l₂)) :
+    (mergeSort r (a :: b :: l)).1 = (merge (r · ·) (mergeSort r l₁).1 (mergeSort r l₂).1).1 := by
+  simp only [mergeSort, merge, List.split]
+  simp only [List.split, Prod.mk.injEq] at h
+  have ⟨h₁, h₂⟩ := h
+  rw [← h₁, ← h₂]
+
+theorem mergeSort_equivalence : ∀ (l : List α), (mergeSort r l).fst = List.mergeSort r l
+  | []          => by simp only [mergeSort, List.mergeSort_nil]
+  | [a]         => by simp only [mergeSort, List.mergeSort_singleton]
+  | a :: b :: l => by
+      have : (l.split.1).length < l.length + 1 := Nat.lt_add_one_of_le (List.length_split_fst_le l)
+      have : (l.split.2).length < l.length + 1 := Nat.lt_add_one_of_le (List.length_split_snd_le l)
+      rw [ List.mergeSort_cons_cons r (Prod.ext rfl rfl)
+         , mergeSort_cons_cons r (Prod.ext rfl rfl)
+         , merge_equivalence
+         , mergeSort_equivalence (a :: l.split.1)
+         , mergeSort_equivalence (b :: l.split.2)
+         ]
+  termination_by l => List.length l
+
+theorem mergeSort_cons_cons_snd {a b} {l l₁ l₂ : List α}
+  (hs : List.split (a :: b :: l) = (l₁, l₂)) :
+    (mergeSort r (a :: b :: l)).snd =
+    (mergeSort r l₁).snd + (mergeSort r l₂).snd +
+    (merge (r · ·) (mergeSort r l₁).fst (mergeSort r l₂).fst).snd := by
+  simp only [List.split, Prod.mk.injEq] at hs
+  simp [mergeSort, hs]
+
+theorem mergeSort_complexity : ∀ l : List α,
+    (mergeSort r l).snd ≤ 8 * l.length * Nat.log 2 l.length
+  | [] => by simp
+  | [a] => by simp
+  | a :: b :: l => by
+    cases e : List.split (a :: b :: l) with
+    | mk l₁ l₂ =>
+      rw [mergeSort_cons_cons_snd r e]
+      cases e1 : mergeSort r l₁ with
+      | mk ms1 n1 =>
+        cases e2 : mergeSort r l₂ with
+        | mk ms2 n2 =>
+          have split_lt := @List.length_split_lt α a b l l₁ l₂ e
+          have := split_lt.1
+          have := split_lt.2
+
+          have sortL1Equiv : (mergeSort (r · ·) l₁).1 = List.mergeSort (r · ·) l₁ :=
+            by rw [mergeSort_equivalence]
+          have sortL2Equiv : (mergeSort (r · ·) l₂).1 = List.mergeSort (r · ·) l₂ :=
+            by rw [mergeSort_equivalence]
+
+          have : ms1 = (mergeSort (r · ·) l₁).1 := by rw [e1]
+          have ms1Ident : ms1 = (List.mergeSort (r · ·) l₁) := by rw [this, sortL1Equiv]
+
+          have : ms2 = (mergeSort (r · ·) l₂).1 := by rw [e2]
+          have ms2Ident : ms2 = (List.mergeSort (r · ·) l₂) := by rw [this, sortL2Equiv]
+
+          have ms1Length : ms1.length = l₁.length := by rw [ms1Ident, List.length_mergeSort]
+          have ms2Length : ms2.length = l₂.length := by rw [ms2Ident, List.length_mergeSort]
+
+          have ⟨l₁_small, l₂_small⟩ := split_halves_length e
+          simp only [List.length_cons] at l₁_small
+          simp only [List.length_cons] at l₂_small
+
+          have ih1 := mergeSort_complexity l₁
+          have ih2 := mergeSort_complexity l₂
+          rw [e1] at ih1
+          rw [e2] at ih2
+
+          have : n1 + n2 + (merge.loop (r · ·) ms1 ms2 []).2 ≤
+                   8 * ((l.length + 3) / 2) * Nat.log 2 ((l.length + 3) / 2) +
+                   8 * ((l.length + 2) / 2) * Nat.log 2 ((l.length + 2) / 2) +
+                   (l.length + 2) := by
+            calc
+              n1 + n2 + (merge.loop (r · ·) ms1 ms2 []).2 ≤
+              8 * l₁.length * Nat.log 2 l₁.length +
+              8 * l₂.length * Nat.log 2 l₂.length + (merge.loop (r · ·) ms1 ms2 []).2
+                := by linarith
+              _ ≤
+              8 * l₁.length * Nat.log 2 l₁.length +
+              8 * l₂.length * Nat.log 2 l₂.length + ms1.length + ms2.length
+                := by have := merge_loop_complexity (r · ·) ms1 ms2 []
+                      linarith
+              _ =
+              8 * l₁.length * Nat.log 2 l₁.length +
+              8 * l₂.length * Nat.log 2 l₂.length + l₁.length + l₂.length
+                := by rw [ms1Length, ms2Length]
+              _ =
+              8 * l₁.length * Nat.log 2 l₁.length + 8 * l₂.length * Nat.log 2 l₂.length +
+              (l.length + 1 + 1)
+                := by rw [add_assoc, split_lengths (a :: b :: l) l₁ l₂ e]
+                      simp
+              _ ≤
+              8 * ((l.length + 3) / 2) * Nat.log 2 l₁.length +
+              8 * l₂.length * Nat.log 2 l₂.length + (l.length + 2)
+                := by have : 8 * l₁.length ≤ 8 * ((l.length + 3) / 2) := by omega
+                      have := Nat.mul_le_mul_right (Nat.log 2 l₁.length) this
+                      linarith
+              _ ≤
+              8 * ((l.length + 3) / 2) * Nat.log 2 l₁.length +
+              8 * ((l.length + 2) / 2) * Nat.log 2 l₂.length + (l.length + 2)
+                := by have : 8 * l₂.length ≤ 8 * ((l.length + 2) / 2) := by omega
+                      have := Nat.mul_le_mul_right (Nat.log 2 l₂.length) this
+                      linarith
+              _ ≤
+              8 * ((l.length + 3) / 2) * Nat.log 2 ((l.length + 3) / 2) +
+              8 * ((l.length + 2) / 2) * Nat.log 2 l₂.length + (l.length + 2)
+                := by have : Nat.log 2 l₁.length ≤ Nat.log 2 ((l.length + 3) / 2)
+                        := Nat.log_monotone l₁_small
+                      have := Nat.mul_le_mul_left (8 * ((l.length + 3) / 2)) this
+                      linarith
+              _ ≤
+              8 * ((l.length + 3) / 2) * Nat.log 2 ((l.length + 3) / 2) +
+              8 * ((l.length + 2) / 2) * Nat.log 2 ((l.length + 2) / 2) + (l.length + 2)
+                := by have : Nat.log 2 l₂.length ≤ Nat.log 2 ((l.length + 2) / 2)
+                        := Nat.log_monotone l₂_small
+                      have := Nat.mul_le_mul_left (8 * ((l.length + 2) / 2)) this
+                      linarith
+          apply le_trans this
+
+          let N := l.length + 2
+          show
+            8 * ((N + 1) / 2) * Nat.log 2 ((N + 1) / 2) + 8 * (N / 2) * Nat.log 2 (N / 2) + N
+            ≤
+            8 * N * Nat.log 2 N
+
+          rw [← log_pred N]
+
+          have cancel2 : forall M : Nat, 8 * (M / 2) ≤ 4 * M := by omega
+          have simp_sub : forall (M : Nat) , M ≥ 2 * N → M + 2 * N - 4 * N = M - 2 * N := by omega
+          have N_ge_2 : 2 ≤ N := by linarith
+          calc
+            8 * ((N + 1) / 2) * (Nat.log 2 ((N + 1) / 2)) + 8 * (N / 2) * (Nat.log 2 N - 1) + N ≤
+            8 * ((N + 1) / 2) * (Nat.log 2 N) + 8 * (N / 2) * (Nat.log 2 N - 1) + N
+              := by simp only [Nat.log_div_base, add_le_add_iff_right]
+                    rw [log_pred]
+                    have : (N + 1) / 2 ≤ N := by omega
+                    have : Nat.log 2 ((N + 1) / 2) ≤ Nat.log 2 N := Nat.log_monotone this
+                    exact Nat.mul_le_mul_left _ this
+            _ ≤ 4 * (N + 1) * (Nat.log 2 N) + 8 * (N / 2) * (Nat.log 2 N - 1) + N
+              := by simp; exact Nat.mul_le_mul_right _ (cancel2 (N + 1))
+            _ ≤ 4 * (N + 1) * (Nat.log 2 N) + 4 * N * (Nat.log 2 N - 1) + N
+              := by simp; exact Nat.mul_le_mul_right _ (cancel2 N)
+            _ = 4 * N * (Nat.log 2 N) + 4 * (Nat.log 2 N) + 4 * N * (Nat.log 2 N - 1) + N
+              := by linarith
+            _ ≤ 4 * N * (Nat.log 2 N) + 2 * N + 4 * N * (Nat.log 2 N - 1) + N
+              := by have := log_2_le N; linarith
+            _ = 4 * N * Nat.log 2 N + 2 * N + 4 * N * Nat.log 2 N - (4 * N) + N
+              := by rw [Nat.mul_sub_left_distrib, Nat.mul_one]
+                    simp only [add_left_inj]
+                    have : 4 * N ≤ 4 * N * Nat.log 2 N := by
+                      simp only [Nat.ofNat_pos, mul_pos_iff_of_pos_left, Nat.zero_lt_succ,
+                        le_mul_iff_one_le_right]
+                      exact Nat.log_pos (by simp) N_ge_2
+                    rw [Nat.add_sub_assoc this _]
+            _ = 8 * N * Nat.log 2 N + 2 * N - 4 * N + N := by simp; apply sub_left_eq; linarith
+            _ = 8 * N * Nat.log 2 N - 2 * N + N := by
+              simp only [add_left_inj]
+              apply simp_sub (8 * N * Nat.log 2 N)
+              have : 1 ≤ Nat.log 2 N := Nat.log_pos (by simp) N_ge_2
+              have := Nat.mul_le_mul_left (2 * N) this
+              linarith
+            _ ≤ 8 * N * Nat.log 2 N := by
+              have : N ≤ 8 * N * Nat.log 2 N := by
+                have : 1 ≤ Nat.log 2 N := Nat.log_pos (by simp) N_ge_2
+                have := Nat.mul_le_mul_left N this
+                linarith
+              omega
+  termination_by l => List.length l
+
+end Timed

--- a/Mathlib/Computability/Timed/Split.lean
+++ b/Mathlib/Computability/Timed/Split.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2024 Tomaz Mascarenhas. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomaz Mascarenhas
+-/
+import Mathlib.Data.List.Sort
+import Mathlib.Data.Nat.Log
+import Mathlib.Tactic.Linarith
+/-!
+# Timed Split
+  This file defines some new lemmas related to the `List.split` function that are necessary
+  for proving the complexity of `List.mergeSort`.
+## Main Results
+  - Timed.split_halves_length :
+      ∀ l l₁ l₂ : list α, Timed.split l = (l₁, l₂) →
+        l₁.length ≤ (l.length + 1) / 2 ∧ l₂.length ≤ l.length / 2
+  - Timed.split_lengths :
+      ∀ l l₁ l₂ : list α, Timed.split l = (l₁, l₂) →
+        l₁.length + l₂.length = l.length
+-/
+
+namespace Timed
+
+universe u
+
+variable {α : Type u}
+
+lemma div_two (b a : ℕ) : 2 * a ≤ b → a ≤ b / 2 :=
+  by simp_rw [Nat.le_div_iff_mul_le zero_lt_two, mul_comm, imp_self]
+
+lemma split_halves_length_aux : ∀ {l l₁ l₂ : List α},
+  List.split l = (l₁, l₂) →
+    2 * List.length l₁ ≤ List.length l + 1 ∧ 2 * List.length l₂ ≤ List.length l
+  | []       => by
+    intros h
+    unfold List.split at h
+    simp only [Prod.mk.injEq] at h
+    have ⟨h₁, h₂⟩ := h
+    rw [← h₁, ← h₂]
+    simp
+  | (a :: t) => by
+    intros h'
+    cases e: List.split t with
+    | mk t₁ t₂ =>
+      have split_id : List.split (a :: t) = (a :: t₂, t₁) := by
+        unfold List.split
+        rw [e]
+      rw [split_id] at h'
+      injection h' with h₁ h₂
+      have ⟨ih₁, ih₂⟩ := split_halves_length_aux e
+      apply And.intro
+      · rw [← h₁]
+        simp only [List.length_cons]
+        linarith
+      · rw [← h₂]
+        simp [ih₁]
+
+theorem split_halves_length : ∀ {l l₁ l₂ : List α},
+  List.split l = (l₁, l₂) →
+    List.length l₁ ≤ (List.length l + 1) / 2 ∧
+    List.length l₂ ≤ (List.length l) / 2 := by
+  intros l l₁ l₂ h
+  have ⟨pf₁, pf₂⟩ := split_halves_length_aux h
+  exact ⟨div_two (l.length + 1) l₁.length pf₁, div_two l.length l₂.length pf₂⟩
+
+theorem split_lengths : ∀ (l l₁ l₂ : List α),
+    List.split l = (l₁, l₂) → l₁.length + l₂.length = l.length
+  | []  => by
+    intros l₁ l₂
+    simp only
+      [List.split, Prod.mk.injEq, List.length_nil, add_eq_zero, List.length_eq_zero, and_imp]
+    intros h₁ h₂
+    rw [← h₁, ← h₂]
+    simp
+  | [_] => by
+    intros l₁ l₂
+    simp only [List.split, Prod.mk.injEq, List.length_singleton, and_imp]
+    intros h₁ h₂
+    rw [← h₁, ← h₂]
+    simp
+  | (_ :: _ :: t) => by
+    intros l₁ l₂ h
+    cases e : List.split t with
+    | mk l₁' l₂' =>
+      simp only [List.split, Prod.mk.injEq] at h
+      rw [e] at h
+      have ih := split_lengths t l₁' l₂' e
+      have ⟨h₁, h₂⟩ := h
+      rw [← h₁, ← h₂]
+      simp only [List.length_cons]
+      linarith
+
+end Timed


### PR DESCRIPTION
This PR adds the formalization of the runtime complexity of the merge sort algorithm, defined in `Data/List/Sort`.
Requires: https://github.com/leanprover-community/mathlib4/pull/15451
References:
- Previous PR on mathlib3: https://github.com/leanprover-community/mathlib3/pull/14494/
- First discussion on Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/BSc.20Final.20Project/near/220647062
- Second disussion on Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Formalization.20of.20Runtime.20Complexity.20of.20Sorting.20Algorithms/near/284184450
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
