### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Sites): chosen finite products on sheaves

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1951,6 +1951,7 @@ import Mathlib.CategoryTheory.Sites.Abelian
 import Mathlib.CategoryTheory.Sites.Adjunction
 import Mathlib.CategoryTheory.Sites.Canonical
 import Mathlib.CategoryTheory.Sites.CartesianClosed
+import Mathlib.CategoryTheory.Sites.ChosenFiniteProducts
 import Mathlib.CategoryTheory.Sites.Closed
 import Mathlib.CategoryTheory.Sites.Coherent.Basic
 import Mathlib.CategoryTheory.Sites.Coherent.CoherentSheaves

--- a/Mathlib/CategoryTheory/Sites/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Sites/ChosenFiniteProducts.lean
@@ -49,23 +49,29 @@ noncomputable instance : ChosenFiniteProducts (Sheaf J A) where
           (P := { val := X.val ⊗ Y.val
                   cond := tensorProd_isSheaf J X Y})
           ⟨(ChosenFiniteProducts.fst _ _)⟩ ⟨(ChosenFiniteProducts.snd _ _)⟩
-      isLimit := by
-        apply (by infer_instance : ReflectsLimit (pair X Y) (sheafToPresheaf J A)).reflects
-        apply IsLimit.equivOfNatIsoOfIso (pairComp X Y _) _ _ _ |>.invFun
-            (ChosenFiniteProducts.product X.val Y.val).isLimit
-        fapply Cones.ext
-        · exact Iso.refl _
-        · rintro ⟨⟨⟩⟩ <;> simp [pairComp, ChosenFiniteProducts.fst, ChosenFiniteProducts.snd] }
+      isLimit :=
+        { lift := fun f ↦ ⟨ChosenFiniteProducts.lift (BinaryFan.fst f).val (BinaryFan.snd f).val⟩
+          fac := by rintro s ⟨⟨j⟩⟩ <;> apply Sheaf.hom_ext <;> simp
+          uniq := by
+            intro x f h
+            apply Sheaf.hom_ext
+            apply ChosenFiniteProducts.hom_ext
+            · specialize h ⟨WalkingPair.left⟩
+              rw [Sheaf.hom_ext_iff] at h
+              simpa using h
+            · specialize h ⟨WalkingPair.right⟩
+              rw [Sheaf.hom_ext_iff] at h
+              simpa using h } }
   terminal :=
     { cone := asEmptyCone { val := 𝟙_ (Cᵒᵖ ⥤ A)
                             cond := tensorUnit_isSheaf _}
-      isLimit := by
-        apply (by infer_instance : ReflectsLimit (Functor.empty _) (sheafToPresheaf J A)).reflects
-        apply IsLimit.equivOfNatIsoOfIso (Functor.emptyExt _ _) _ _ _ |>.invFun
-            ChosenFiniteProducts.terminal.isLimit
-        fapply Cones.ext
-        · exact Iso.refl _
-        · simp }
+      isLimit :=
+        { lift := fun f ↦ ⟨ChosenFiniteProducts.toUnit f.pt.val⟩
+          fac := by intro s ⟨e⟩; cases e
+          uniq := by
+            intro x f h
+            apply Sheaf.hom_ext
+            exact ChosenFiniteProducts.toUnit_unique f.val _} }
 
 @[simp]
 lemma fst_val : (ChosenFiniteProducts.fst X Y).val = ChosenFiniteProducts.fst X.val Y.val := rfl
@@ -77,28 +83,12 @@ variable {X Y}
 variable {W : Sheaf J A} (f : W ⟶ X) (g : W ⟶ Y)
 
 @[simp]
-lemma lift_val : (ChosenFiniteProducts.lift f g).val = ChosenFiniteProducts.lift f.val g.val := by
-  apply ChosenFiniteProducts.hom_ext
-  · change (ChosenFiniteProducts.lift f g ≫ ChosenFiniteProducts.fst _ _).val = _
-    simp
-  · change (ChosenFiniteProducts.lift f g ≫ ChosenFiniteProducts.snd _ _).val = _
-    simp
+lemma lift_val : (ChosenFiniteProducts.lift f g).val = ChosenFiniteProducts.lift f.val g.val := rfl
 
 @[simp]
-lemma whiskerLeft_val : (X ◁ f).val = (X.val ◁ f.val) := by
-  apply ChosenFiniteProducts.hom_ext
-  · change ((X ◁ f) ≫ ChosenFiniteProducts.fst _ _).val = _
-    simp
-  · change ((X ◁ f) ≫ ChosenFiniteProducts.snd _ _).val = _
-    simp
-
+lemma whiskerLeft_val : (X ◁ f).val = (X.val ◁ f.val) := rfl
 @[simp]
-lemma whiskerRight_val : (f ▷ X).val = (f.val ▷ X.val) := by
-  apply ChosenFiniteProducts.hom_ext
-  · change ((f ▷ X) ≫ ChosenFiniteProducts.fst _ _).val = _
-    simp
-  · change ((f ▷ X) ≫ ChosenFiniteProducts.snd _ _).val = _
-    simp
+lemma whiskerRight_val : (f ▷ X).val = (f.val ▷ X.val) := rfl
 
 /-- The inclusion from sheaves to presheaves is monoidal with respect to the cartesian monoidal
 structures. -/

--- a/Mathlib/CategoryTheory/Sites/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Sites/ChosenFiniteProducts.lean
@@ -43,7 +43,7 @@ lemma tensorUnit_isSheaf : Presheaf.IsSheaf J (𝟙_ (Cᵒᵖ ⥤ A)) := by
 /-- Any `ChosenFiniteProducts` on `A` induce a `ChosenFiniteProducts` structures on `A`-valued
 sheaves. -/
 @[simps! product_cone_pt_val terminal_cone_pt_val_obj terminal_cone_pt_val_map]
-noncomputable instance : ChosenFiniteProducts (Sheaf J A) where
+noncomputable instance chosenFiniteProducts: ChosenFiniteProducts (Sheaf J A) where
   product X Y :=
     { cone := BinaryFan.mk
           (P := { val := X.val ⊗ Y.val
@@ -74,21 +74,24 @@ noncomputable instance : ChosenFiniteProducts (Sheaf J A) where
             exact ChosenFiniteProducts.toUnit_unique f.val _} }
 
 @[simp]
-lemma fst_val : (ChosenFiniteProducts.fst X Y).val = ChosenFiniteProducts.fst X.val Y.val := rfl
+lemma chosenFiniteProducts_fst_val : (ChosenFiniteProducts.fst X Y).val =
+    ChosenFiniteProducts.fst X.val Y.val := rfl
 
 @[simp]
-lemma snd_val : (ChosenFiniteProducts.snd X Y).val = ChosenFiniteProducts.snd X.val Y.val := rfl
+lemma chosenFiniteProducts_snd_val : (ChosenFiniteProducts.snd X Y).val =
+    ChosenFiniteProducts.snd X.val Y.val := rfl
 
 variable {X Y}
 variable {W : Sheaf J A} (f : W ⟶ X) (g : W ⟶ Y)
 
 @[simp]
-lemma lift_val : (ChosenFiniteProducts.lift f g).val = ChosenFiniteProducts.lift f.val g.val := rfl
+lemma chosenFiniteProducts_lift_val : (ChosenFiniteProducts.lift f g).val =
+    ChosenFiniteProducts.lift f.val g.val := rfl
 
 @[simp]
-lemma whiskerLeft_val : (X ◁ f).val = (X.val ◁ f.val) := rfl
+lemma chosenFiniteProducts_whiskerLeft_val : (X ◁ f).val = (X.val ◁ f.val) := rfl
 @[simp]
-lemma whiskerRight_val : (f ▷ X).val = (f.val ▷ X.val) := rfl
+lemma chosenFiniteProducts_whiskerRight_val : (f ▷ X).val = (f.val ▷ X.val) := rfl
 
 /-- The inclusion from sheaves to presheaves is monoidal with respect to the cartesian monoidal
 structures. -/

--- a/Mathlib/CategoryTheory/Sites/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Sites/ChosenFiniteProducts.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.ChosenFiniteProducts.FunctorCategory
 # Chosen finite products on sheaves
 
 In this file, we put a `ChosenFiniteProducts` instance on `A`-valued sheaves for a
-`GrothendieckTopology` whenever `A` has a ChosenFiniteProducts instance.
+`GrothendieckTopology` whenever `A` has a `ChosenFiniteProducts` instance.
 -/
 
 

--- a/Mathlib/CategoryTheory/Sites/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Sites/ChosenFiniteProducts.lean
@@ -42,8 +42,7 @@ lemma tensorUnit_isSheaf : Presheaf.IsSheaf J (𝟙_ (Cᵒᵖ ⥤ A)) := by
 
 /-- Any `ChosenFiniteProducts` on `A` induce a `ChosenFiniteProducts` structures on `A`-valued
 sheaves. -/
-@[simps! product_cone_pt_val product_cone_pt_val_obj product_cone_pt_val_map
-  terminal_cone_pt_val_obj terminal_cone_pt_val_map]
+@[simps! product_cone_pt_val terminal_cone_pt_val_obj terminal_cone_pt_val_map]
 noncomputable instance : ChosenFiniteProducts (Sheaf J A) where
   product X Y :=
     { cone := BinaryFan.mk

--- a/Mathlib/CategoryTheory/Sites/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Sites/ChosenFiniteProducts.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2024 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+import Mathlib.CategoryTheory.Sites.Limits
+import Mathlib.CategoryTheory.ChosenFiniteProducts.FunctorCategory
+
+/-!
+# Chosen finite products on sheaves
+
+In this file, we put a `ChosenFiniteProducts` instance on `A`-valued sheaves for a
+`GrothendieckTopology` whenever `A` has a ChosenFiniteProducts instance.
+-/
+
+
+universe v₁ v₂ u₁ u₂
+
+namespace CategoryTheory
+
+open Opposite CategoryTheory Category Limits Sieve MonoidalCategory
+
+variable {C : Type u₁} [Category.{v₁} C]
+variable {A : Type u₂} [Category.{v₂} A]
+variable (J : GrothendieckTopology C)
+variable [ChosenFiniteProducts A]
+
+namespace Sheaf
+
+variable (X Y : Sheaf J A)
+
+lemma tensorProd_isSheaf : Presheaf.IsSheaf J (X.val ⊗ Y.val) := by
+  apply isSheaf_of_isLimit (E := (Cones.postcompose (pairComp X Y (sheafToPresheaf J A)).inv).obj
+    (ChosenFiniteProducts.product X.val Y.val).cone)
+  exact (IsLimit.postcomposeInvEquiv _ _).invFun (ChosenFiniteProducts.product X.val Y.val).isLimit
+
+lemma tensorUnit_isSheaf : Presheaf.IsSheaf J (𝟙_ (Cᵒᵖ ⥤ A)) := by
+  apply isSheaf_of_isLimit (E := (Cones.postcompose (Functor.uniqueFromEmpty _).inv).obj
+    ChosenFiniteProducts.terminal.cone)
+  · exact (IsLimit.postcomposeInvEquiv _ _).invFun ChosenFiniteProducts.terminal.isLimit
+  · exact Functor.empty _
+
+/-- Any `ChosenFiniteProducts` on `A` induce a `ChosenFiniteProducts` structures on `A`-valued
+sheaves. -/
+@[simps! product_cone_pt_val product_cone_pt_val_obj product_cone_pt_val_map
+  terminal_cone_pt_val_obj terminal_cone_pt_val_map]
+noncomputable instance : ChosenFiniteProducts (Sheaf J A) where
+  product X Y :=
+    { cone := BinaryFan.mk
+          (P := { val := X.val ⊗ Y.val
+                  cond := tensorProd_isSheaf J X Y})
+          ⟨(ChosenFiniteProducts.fst _ _)⟩ ⟨(ChosenFiniteProducts.snd _ _)⟩
+      isLimit := by
+        apply (by infer_instance : ReflectsLimit (pair X Y) (sheafToPresheaf J A)).reflects
+        apply IsLimit.equivOfNatIsoOfIso (pairComp X Y _) _ _ _ |>.invFun
+            (ChosenFiniteProducts.product X.val Y.val).isLimit
+        fapply Cones.ext
+        · exact Iso.refl _
+        · rintro ⟨⟨⟩⟩ <;> simp [pairComp, ChosenFiniteProducts.fst, ChosenFiniteProducts.snd] }
+  terminal :=
+    { cone := asEmptyCone { val := 𝟙_ (Cᵒᵖ ⥤ A)
+                            cond := tensorUnit_isSheaf _}
+      isLimit := by
+        apply (by infer_instance : ReflectsLimit (Functor.empty _) (sheafToPresheaf J A)).reflects
+        apply IsLimit.equivOfNatIsoOfIso (Functor.emptyExt _ _) _ _ _ |>.invFun
+            ChosenFiniteProducts.terminal.isLimit
+        fapply Cones.ext
+        · exact Iso.refl _
+        · simp }
+
+@[simp]
+lemma fst_val : (ChosenFiniteProducts.fst X Y).val = ChosenFiniteProducts.fst X.val Y.val := rfl
+
+@[simp]
+lemma snd_val : (ChosenFiniteProducts.snd X Y).val = ChosenFiniteProducts.snd X.val Y.val := rfl
+
+variable {X Y}
+variable {W : Sheaf J A} (f : W ⟶ X) (g : W ⟶ Y)
+
+@[simp]
+lemma lift_val : (ChosenFiniteProducts.lift f g).val = ChosenFiniteProducts.lift f.val g.val := by
+  apply ChosenFiniteProducts.hom_ext
+  · change (ChosenFiniteProducts.lift f g ≫ ChosenFiniteProducts.fst _ _).val = _
+    simp
+  · change (ChosenFiniteProducts.lift f g ≫ ChosenFiniteProducts.snd _ _).val = _
+    simp
+
+@[simp]
+lemma whiskerLeft_val : (X ◁ f).val = (X.val ◁ f.val) := by
+  apply ChosenFiniteProducts.hom_ext
+  · change ((X ◁ f) ≫ ChosenFiniteProducts.fst _ _).val = _
+    simp
+  · change ((X ◁ f) ≫ ChosenFiniteProducts.snd _ _).val = _
+    simp
+
+@[simp]
+lemma whiskerRight_val : (f ▷ X).val = (f.val ▷ X.val) := by
+  apply ChosenFiniteProducts.hom_ext
+  · change ((f ▷ X) ≫ ChosenFiniteProducts.fst _ _).val = _
+    simp
+  · change ((f ▷ X) ≫ ChosenFiniteProducts.snd _ _).val = _
+    simp
+
+/-- The inclusion from sheaves to presheaves is monoidal with respect to the cartesian monoidal
+structures. -/
+@[simps!]
+noncomputable def monoidalSheafToPresheaf : MonoidalFunctor (Sheaf J A) (Cᵒᵖ ⥤ A) :=
+  Functor.toMonoidalFunctorOfChosenFiniteProducts (sheafToPresheaf J A)
+
+end CategoryTheory.Sheaf


### PR DESCRIPTION
Introduce a `ChosenFiniteProduct` instance on sheaves on a category `C` with a Grothendieck topology `J` whenever the coefficient category `A` has a `ChosenFiniteProduct` instance. We also provide some basic `simp` lemmas to relate this structure to the one on `Cᵒᵖ ⥤ A`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
