### PR TITLE
[Merged by Bors] - chore(Algebra/BigOperators): don't import `Sym` in the definition of big operators

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -57,6 +57,7 @@ import Mathlib.Algebra.BigOperators.Ring.List
 import Mathlib.Algebra.BigOperators.Ring.Multiset
 import Mathlib.Algebra.BigOperators.Ring.Nat
 import Mathlib.Algebra.BigOperators.RingEquiv
+import Mathlib.Algebra.BigOperators.Sym
 import Mathlib.Algebra.BigOperators.WithTop
 import Mathlib.Algebra.Category.AlgebraCat.Basic
 import Mathlib.Algebra.Category.AlgebraCat.Limits

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -6,8 +6,6 @@ Authors: Johannes Hölzl
 import Mathlib.Algebra.Group.Indicator
 import Mathlib.Data.Finset.Piecewise
 import Mathlib.Data.Finset.Preimage
-import Mathlib.Data.Finset.Sym
-import Mathlib.Data.Sym.Sym2.Order
 
 /-!
 # Big operators
@@ -2256,16 +2254,5 @@ theorem toAdd_prod (s : Finset ι) (f : ι → Multiplicative α) :
   rfl
 
 end AddCommMonoid
-
-theorem Finset.sum_sym2_filter_not_isDiag {ι α} [LinearOrder ι] [AddCommMonoid α]
-    (s : Finset ι) (p : Sym2 ι → α) :
-    ∑ i ∈ s.sym2 with ¬ i.IsDiag, p i = ∑ i ∈ s.offDiag with i.1 < i.2, p s(i.1, i.2) := by
-  rw [Finset.offDiag_filter_lt_eq_filter_le]
-  conv_rhs => rw [← Finset.sum_subtype_eq_sum_filter]
-  refine (Finset.sum_equiv Sym2.sortEquiv.symm ?_ ?_).symm
-  · rintro ⟨⟨i₁, j₁⟩, hij₁⟩
-    simp [and_assoc]
-  · rintro ⟨⟨i₁, j₁⟩, hij₁⟩
-    simp
 
 set_option linter.style.longFile 2400

--- a/Mathlib/Algebra/BigOperators/Sym.lean
+++ b/Mathlib/Algebra/BigOperators/Sym.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl
+-/
+import Mathlib.Algebra.BigOperators.Group.Finset
+import Mathlib.Data.Finset.Sym
+import Mathlib.Data.Sym.Sym2.Order
+
+/-!
+# Lemmas on `Finset.sum` and `Finset.prod` involving `Finset.sym2`
+-/
+
+theorem Finset.sum_sym2_filter_not_isDiag {ι α} [LinearOrder ι] [AddCommMonoid α]
+    (s : Finset ι) (p : Sym2 ι → α) :
+    ∑ i ∈ s.sym2 with ¬ i.IsDiag, p i = ∑ i ∈ s.offDiag with i.1 < i.2, p s(i.1, i.2) := by
+  rw [Finset.offDiag_filter_lt_eq_filter_le]
+  conv_rhs => rw [← Finset.sum_subtype_eq_sum_filter]
+  refine (Finset.sum_equiv Sym2.sortEquiv.symm ?_ ?_).symm
+  · rintro ⟨⟨i₁, j₁⟩, hij₁⟩
+    simp [and_assoc]
+  · rintro ⟨⟨i₁, j₁⟩, hij₁⟩
+    simp

--- a/Mathlib/Algebra/BigOperators/Sym.lean
+++ b/Mathlib/Algebra/BigOperators/Sym.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Copyright (c) 2024 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl
+Authors: Eric Wieser
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset
 import Mathlib.Data.Finset.Sym

--- a/Mathlib/Algebra/Order/Antidiag/Pi.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Pi.lean
@@ -7,6 +7,7 @@ Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández, Eric Wieser, 
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Data.Fin.Tuple.NatAntidiagonal
+import Mathlib.Data.Finset.Sym
 
 /-!
 # Antidiagonal of functions as finsets

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basis.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basis.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
+import Mathlib.Algebra.BigOperators.Sym
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
 
 /-!


### PR DESCRIPTION
In the spirit of [late imports](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/late.20imports), I came across this lemma that wants us to import `Mathlib.Data.Finset.Sym` and `Mathlib.Data.Sym.Sym2.Order` right at the end of the definition of big operators.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
