### PR TITLE
[Merged by Bors] - fix(RingTheory/Multiplicity): rename `Finite.emultiplicity_ne_top` to `multiplicity.Finite.emultiplicity_ne_top`

### DIFF
--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -62,6 +62,9 @@ theorem finite_iff_emultiplicity_ne_top :
 
 alias ⟨multiplicity.Finite.emultiplicity_ne_top, _⟩ := finite_iff_emultiplicity_ne_top
 
+@[deprecated (since := "2024-11-08")]
+alias Finite.emultiplicity_ne_top := multiplicity.Finite.emultiplicity_ne_top
+
 theorem finite_of_emultiplicity_eq_natCast {n : ℕ} (h : emultiplicity a b = n) :
     Finite a b := by
   by_contra! nh

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -60,7 +60,7 @@ theorem emultiplicity_lt_top {a b : α} : emultiplicity a b < ⊤ ↔ Finite a b
 theorem finite_iff_emultiplicity_ne_top :
     Finite a b ↔ emultiplicity a b ≠ ⊤ := by simp
 
-alias ⟨Finite.emultiplicity_ne_top, _⟩ := finite_iff_emultiplicity_ne_top
+alias ⟨multiplicity.Finite.emultiplicity_ne_top, _⟩ := finite_iff_emultiplicity_ne_top
 
 theorem finite_of_emultiplicity_eq_natCast {n : ℕ} (h : emultiplicity a b = n) :
     Finite a b := by


### PR DESCRIPTION
Moves:
- `Finite.emultiplicity_ne_top` -> `multiplicity.Finite.emultiplicity_ne_top`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
