### PR TITLE
[Merged by Bors] - chore(CategoryTheory/EpiMono): composition of `SplitEpi` and `SplitMono`

### DIFF
--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -53,9 +53,10 @@ class IsSplitMono {X Y : C} (f : X ⟶ Y) : Prop where
   exists_splitMono : Nonempty (SplitMono f)
 
 /-- A composition of `SplitMono` is a `SplitMono`. --/
-def SplitMono.comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (sef : SplitMono f) (seg : SplitMono g) :
+@[simps]
+def SplitMono.comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (smf : SplitMono f) (smg : SplitMono g) :
     SplitMono (f ≫ g) where
-  retraction := seg.retraction ≫ sef.retraction
+  retraction := smg.retraction ≫ smf.retraction
 
 /-- A constructor for `IsSplitMono f` taking a `SplitMono f` as an argument -/
 theorem IsSplitMono.mk' {X Y : C} {f : X ⟶ Y} (sm : SplitMono f) : IsSplitMono f :=
@@ -82,6 +83,7 @@ class IsSplitEpi {X Y : C} (f : X ⟶ Y) : Prop where
   /-- There is a splitting -/
   exists_splitEpi : Nonempty (SplitEpi f)
 
+@[simps]
 /-- A composition of `SplitEpi` is a split `SplitEpi`. --/
 def SplitEpi.comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (sef : SplitEpi f) (seg : SplitEpi g) :
     SplitEpi (f ≫ g) where

--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -52,6 +52,11 @@ class IsSplitMono {X Y : C} (f : X ⟶ Y) : Prop where
   /-- There is a splitting -/
   exists_splitMono : Nonempty (SplitMono f)
 
+/-- A composition of `SplitMono` is a `SplitMono`. --/
+def SplitMono.comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (sef : SplitMono f) (seg : SplitMono g) :
+    SplitMono (f ≫ g) where
+  retraction := seg.retraction ≫ sef.retraction
+
 /-- A constructor for `IsSplitMono f` taking a `SplitMono f` as an argument -/
 theorem IsSplitMono.mk' {X Y : C} {f : X ⟶ Y} (sm : SplitMono f) : IsSplitMono f :=
   ⟨Nonempty.intro sm⟩
@@ -76,6 +81,11 @@ attribute [reassoc (attr := simp)] SplitEpi.id
 class IsSplitEpi {X Y : C} (f : X ⟶ Y) : Prop where
   /-- There is a splitting -/
   exists_splitEpi : Nonempty (SplitEpi f)
+
+/-- A composition of `SplitEpi` is a split `SplitEpi`. --/
+def SplitEpi.comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (sef : SplitEpi f) (seg : SplitEpi g) :
+    SplitEpi (f ≫ g) where
+  section_ := seg.section_ ≫ sef.section_
 
 /-- A constructor for `IsSplitEpi f` taking a `SplitEpi f` as an argument -/
 theorem IsSplitEpi.mk' {X Y : C} {f : X ⟶ Y} (se : SplitEpi f) : IsSplitEpi f :=
@@ -145,6 +155,12 @@ theorem SplitEpi.epi {X Y : C} {f : X ⟶ Y} (se : SplitEpi f) : Epi f :=
 /-- Every split epi is an epi. -/
 instance (priority := 100) IsSplitEpi.epi {X Y : C} (f : X ⟶ Y) [hf : IsSplitEpi f] : Epi f :=
   hf.exists_splitEpi.some.epi
+
+instance {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} [hf : IsSplitMono f] [hg : IsSplitMono g] :
+    IsSplitMono (f ≫ g) := IsSplitMono.mk' <| hf.exists_splitMono.some.comp hg.exists_splitMono.some
+
+instance {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} [hf : IsSplitEpi f] [hg : IsSplitEpi g] :
+    IsSplitEpi (f ≫ g) := IsSplitEpi.mk' <| hf.exists_splitEpi.some.comp hg.exists_splitEpi.some
 
 /-- Every split mono whose retraction is mono is an iso. -/
 theorem IsIso.of_mono_retraction' {X Y : C} {f : X ⟶ Y} (hf : SplitMono f) [Mono <| hf.retraction] :

--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -83,8 +83,8 @@ class IsSplitEpi {X Y : C} (f : X ⟶ Y) : Prop where
   /-- There is a splitting -/
   exists_splitEpi : Nonempty (SplitEpi f)
 
-@[simps]
 /-- A composition of `SplitEpi` is a split `SplitEpi`. --/
+@[simps]
 def SplitEpi.comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (sef : SplitEpi f) (seg : SplitEpi g) :
     SplitEpi (f ≫ g) where
   section_ := seg.section_ ≫ sef.section_


### PR DESCRIPTION
Record the fact that the composition of two `SplitMono` is again a `SplitMono`, as well as the corresponding statement for `IsSplitMono`, and the dual statement for epimorphisms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
