### PR TITLE
[Merged by Bors] - feat(Algebra/Lie/Weights/Basic): define `weightSpace`

### DIFF
--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -52,6 +52,17 @@ namespace LieModule
 
 open Set Function TensorProduct LieModule
 
+variable (M) in
+/-- If `M` is a representation of a Lie algebra `L` and `χ : L → R` is a family of scalars,
+then `weightSpace M χ` is the intersection of the `χ x`-eigenspaces
+of the action of `x` on `M` as `x` ranges over `L`. -/
+def weightSpace (χ : L → R) : LieSubmodule R L M where
+  __ := ⨅ x : L, (toEnd R L M x).eigenspace (χ x)
+  lie_mem {x m} hm := by simp_all [smul_comm (χ x)]
+
+lemma mem_weightSpace (χ : L → R) (m : M) : m ∈ weightSpace M χ ↔ ∀ x, ⁅x, m⁆ = χ x • m := by
+  simp [weightSpace]
+
 section notation_genWeightSpaceOf
 
 /-- Until we define `LieModule.genWeightSpaceOf`, it is useful to have some notation as follows: -/
@@ -183,6 +194,14 @@ theorem mem_genWeightSpace (χ : L → R) (m : M) :
 lemma genWeightSpace_le_genWeightSpaceOf (x : L) (χ : L → R) :
     genWeightSpace M χ ≤ genWeightSpaceOf M (χ x) x :=
   iInf_le _ x
+
+lemma weightSpace_le_genWeightSpace (χ : L → R) :
+    weightSpace M χ ≤ genWeightSpace M χ := by
+  apply le_iInf
+  intro x
+  rw [← (LieSubmodule.toSubmodule_orderEmbedding R L M).le_iff_le]
+  apply (iInf_le _ x).trans
+  exact ((toEnd R L M x).genEigenspace (χ x)).monotone le_top
 
 variable (R L) in
 /-- A weight of a Lie module is a map `L → R` such that the corresponding weight space is


### PR DESCRIPTION
Before this, mathlib only had `genWeightSpace` which takes maximal
generalized eigenspaces instead of "ordinary" eigenspaces.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
