### PR TITLE
[Merged by Bors] - feat(Probability): more notation for conditional probability

### DIFF
--- a/Mathlib/Probability/ConditionalProbability.lean
+++ b/Mathlib/Probability/ConditionalProbability.lean
@@ -70,14 +70,32 @@ and scaled by the inverse of `μ s` (to make it a probability measure):
 def cond (s : Set Ω) : Measure Ω :=
   (μ s)⁻¹ • μ.restrict s
 
-@[inherit_doc] scoped notation μ "[" s "|" t "]" => ProbabilityTheory.cond μ t s
-@[inherit_doc] scoped notation:max μ "[|" t "]" => ProbabilityTheory.cond μ t
+@[inherit_doc] scoped notation:max μ "[" t " | " s "]" => ProbabilityTheory.cond μ s t
+@[inherit_doc] scoped notation:max μ "[|" s "]" => ProbabilityTheory.cond μ s
+
+/-- The conditional probability measure of measure `μ` on `{ω | X ω ∈ s}`.
+
+It is `μ` restricted to `{ω | X ω ∈ s}` and scaled by the inverse of `μ {ω | X ω ∈ s}`
+(to make it a probability measure): `(μ {ω | X ω ∈ s})⁻¹ • μ.restrict {ω | X ω ∈ s}`. -/
+scoped notation:max μ "[|" X " in " s "]" => μ[|X ⁻¹' s]
+
+/-- The conditional probability measure of measure `μ` on set `{ω | X ω = x}`.
+
+It is `μ` restricted to `{ω | X ω = x}` and scaled by the inverse of `μ {ω | X ω = x}`
+(to make it a probability measure): `(μ {ω | X ω = x})⁻¹ • μ.restrict {ω | X ω = x}`. -/
+scoped notation:max μ "[" s " | "  X " in " t "]" => μ[s | X ⁻¹' t]
 
 /-- The conditional probability measure of measure `μ` on `{ω | X ω = x}`.
 
 It is `μ` restricted to `{ω | X ω = x}` and scaled by the inverse of `μ {ω | X ω = x}`
 (to make it a probability measure): `(μ {ω | X ω = x})⁻¹ • μ.restrict {ω | X ω = x}`. -/
-scoped notation:max μ "[|" X " ← " x "]" => μ[|X ⁻¹' {x}]
+scoped notation:max μ "[|" X " ← " x "]" => μ[|X in {x}]
+
+/-- The conditional probability measure of measure `μ` on set `{ω | X ω = x}`.
+
+It is `μ` restricted to `{ω | X ω = x}` and scaled by the inverse of `μ {ω | X ω = x}`
+(to make it a probability measure): `(μ {ω | X ω = x})⁻¹ • μ.restrict {ω | X ω = x}`. -/
+scoped notation:max μ "[" s " | "  X " ← " x "]" => μ[s | X in {x}]
 
 /-- The conditional probability measure of any measure on any set of finite positive measure
 is a probability measure. -/
@@ -201,7 +219,7 @@ theorem cond_eq_inv_mul_cond_mul (hms : MeasurableSet s) (hmt : MeasurableSet t)
 end Bayes
 
 lemma comap_cond {i : Ω' → Ω} (hi : MeasurableEmbedding i) (hi' : ∀ᵐ ω ∂μ, ω ∈ range i)
-    (hs : MeasurableSet s) : comap i μ[|s] = (comap i μ)[|i ⁻¹' s] := by
+    (hs : MeasurableSet s) : comap i μ[|s] = (comap i μ)[|i in s] := by
   ext t ht
   change μ (range i)ᶜ = 0 at hi'
   rw [cond_apply, comap_apply, cond_apply, comap_apply, comap_apply, image_inter,


### PR DESCRIPTION
Make `μ[|X in s]` notation for `μ[|X ⁻¹' s]`, `μ[t | X in s]` notation for `μ[t | X ⁻¹' s]`, `μ[t | X ← x]` notation for `μ[t | X in {x}]`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
