### PR TITLE
[Merged by Bors] -  feat: SubtractionMonoid instance for LinearOrderedAddCommGroupWithTop

### DIFF
--- a/Mathlib/Algebra/Order/AddGroupWithTop.lean
+++ b/Mathlib/Algebra/Order/AddGroupWithTop.lean
@@ -116,3 +116,82 @@ instance : LinearOrderedAddCommGroupWithTop (WithTop α) where
 end LinearOrderedAddCommGroup
 
 end WithTop
+
+namespace LinearOrderedAddCommGroupWithTop
+
+variable [LinearOrderedAddCommGroupWithTop α] {a b : α}
+
+attribute [simp] LinearOrderedAddCommGroupWithTop.neg_top
+
+lemma add_neg_cancel_of_ne_top {α : Type*} [LinearOrderedAddCommGroupWithTop α]
+    {a : α} (h : a ≠ ⊤) :
+    a + -a = 0 :=
+  LinearOrderedAddCommGroupWithTop.add_neg_cancel a h
+
+@[simp]
+lemma add_eq_top : a + b = ⊤ ↔ a = ⊤ ∨ b = ⊤ := by
+  constructor
+  · intro h
+    by_contra nh
+    rw [not_or] at nh
+    replace h := congrArg (-a + ·) h
+    dsimp only at h
+    rw [add_top, ← add_assoc, add_comm (-a), add_neg_cancel_of_ne_top,
+      zero_add] at h
+    · exact nh.2 h
+    · exact nh.1
+  · rintro (rfl | rfl)
+    · simp
+    · simp
+
+@[simp]
+lemma top_ne_zero :
+    (⊤ : α) ≠ 0 := by
+  intro nh
+  have ⟨a, b, h⟩ := Nontrivial.exists_pair_ne (α := α)
+  have : a + 0 ≠ b + 0 := by simpa
+  rw [← nh] at this
+  simp at this
+
+@[simp] lemma neg_eq_top {a : α} : -a = ⊤ ↔ a = ⊤ where
+  mp h := by
+    by_contra nh
+    replace nh := add_neg_cancel_of_ne_top nh
+    rw [h, add_top] at nh
+    exact top_ne_zero nh
+  mpr h := by simp [h]
+
+instance (priority := 100) toSubtractionMonoid : SubtractionMonoid α where
+  neg_neg a := by
+    by_cases h : a = ⊤
+    · simp [h]
+    · have h2 : ¬ -a = ⊤ := fun nh ↦ h <| neg_eq_top.mp nh
+      replace h2 : a + (-a + - -a) = a + 0 := congrArg (a + ·) (add_neg_cancel_of_ne_top h2)
+      rw [← add_assoc, add_neg_cancel_of_ne_top h] at h2
+      simp only [zero_add, add_zero] at h2
+      exact h2
+  neg_add_rev a b := by
+    by_cases ha : a = ⊤
+    · simp [ha]
+    by_cases hb : b = ⊤
+    · simp [hb]
+    apply (_ : Function.Injective (a + b + ·))
+    · dsimp
+      rw [add_neg_cancel_of_ne_top, ← add_assoc, add_assoc a,
+        add_neg_cancel_of_ne_top hb, add_zero,
+        add_neg_cancel_of_ne_top ha]
+      simp [ha, hb]
+    · apply Function.LeftInverse.injective (g := (-(a + b) + ·))
+      intro x
+      dsimp only
+      rw [← add_assoc, add_comm (-(a + b)), add_neg_cancel_of_ne_top, zero_add]
+      simp [ha, hb]
+  neg_eq_of_add a b h := by
+    have oh := congrArg (-a + ·) h
+    dsimp only at oh
+    rw [add_zero, ← add_assoc, add_comm (-a), add_neg_cancel_of_ne_top, zero_add] at oh
+    · exact oh.symm
+    intro v
+    simp [v] at h
+
+end LinearOrderedAddCommGroupWithTop


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


See #13724 for an earlier version