### PR TITLE
[Merged by Bors] - chore: fix typo `Continous`-> `Continuous`

### DIFF
--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -250,8 +250,10 @@ def reCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_re : Continuous re :=
   reCLM.continuous
 
-lemma uniformlyContinous_re : UniformContinuous re :=
+lemma uniformlyContinuous_re : UniformContinuous re :=
   reCLM.uniformContinuous
+
+@[deprecated (since := "2024-11-04")] alias uniformlyContinous_re := uniformlyContinuous_re
 
 @[simp]
 theorem reCLM_coe : (reCLM : ℂ →ₗ[ℝ] ℝ) = reLm :=
@@ -269,8 +271,10 @@ def imCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_im : Continuous im :=
   imCLM.continuous
 
-lemma uniformlyContinous_im : UniformContinuous im :=
+lemma uniformlyContinuous_im : UniformContinuous im :=
   imCLM.uniformContinuous
+
+@[deprecated (since := "2024-11-04")] alias uniformlyContinous_im := uniformlyContinuous_im
 
 @[simp]
 theorem imCLM_coe : (imCLM : ℂ →ₗ[ℝ] ℝ) = imLm :=

--- a/Mathlib/Analysis/Complex/ReImTopology.lean
+++ b/Mathlib/Analysis/Complex/ReImTopology.lean
@@ -189,21 +189,21 @@ variable {α ι : Type*}
 protected lemma TendstoUniformlyOn.re {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ} {K : Set α}
     (hf : TendstoUniformlyOn f g p K) :
     TendstoUniformlyOn (fun n x => (f n x).re) (fun y => (g y).re) p K := by
-  apply UniformContinuous.comp_tendstoUniformlyOn uniformlyContinous_re hf
+  apply UniformContinuous.comp_tendstoUniformlyOn uniformlyContinuous_re hf
 
 protected lemma TendstoUniformly.re {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ}
     (hf : TendstoUniformly f g p) :
     TendstoUniformly (fun n x => (f n x).re) (fun y => (g y).re) p := by
-  apply UniformContinuous.comp_tendstoUniformly uniformlyContinous_re hf
+  apply UniformContinuous.comp_tendstoUniformly uniformlyContinuous_re hf
 
 protected lemma TendstoUniformlyOn.im {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ} {K : Set α}
     (hf : TendstoUniformlyOn f g p K) :
     TendstoUniformlyOn (fun n x => (f n x).im) (fun y => (g y).im) p K := by
-  apply UniformContinuous.comp_tendstoUniformlyOn uniformlyContinous_im hf
+  apply UniformContinuous.comp_tendstoUniformlyOn uniformlyContinuous_im hf
 
 protected lemma TendstoUniformly.im {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ}
     (hf : TendstoUniformly f g p) :
     TendstoUniformly (fun n x => (f n x).im) (fun y => (g y).im) p := by
-  apply UniformContinuous.comp_tendstoUniformly uniformlyContinous_im hf
+  apply UniformContinuous.comp_tendstoUniformly uniformlyContinuous_im hf
 
 end continuity

--- a/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
@@ -41,8 +41,8 @@ We introduce two convenience definitions:
 * `VectorFourier.fourierSMulRight L f`: given `f : V → E` and `L` a bilinear pairing
   between `V` and `W`, then this is the function `fun v ↦ -(2 * π * I) (L v ⬝) • f v`,
   from `V` to `Hom (W, E)`.
-  This is essentially `ContinousLinearMap.smulRight`, up to the factor `- 2πI` designed to make sure
-  that the Fourier integral of `fourierSMulRight L f` is the derivative of the Fourier
+  This is essentially `ContinuousLinearMap.smulRight`, up to the factor `- 2πI` designed to make
+  sure that the Fourier integral of `fourierSMulRight L f` is the derivative of the Fourier
   integral of `f`.
 * `VectorFourier.fourierPowSMulRight` is the higher order analogue for higher derivatives:
   `fourierPowSMulRight L f v n` is informally `(-(2 * π * I))^n (L v ⬝)^n • f v`, in

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -645,7 +645,7 @@ theorem tendsto_iff_forall_integral_tendsto {γ : Type*} {F : Filter γ} {μs : 
   simp_rw [aux, BoundedContinuousFunction.toReal_lintegral_coe_eq_integral] at tends_pos tends_neg
   exact Tendsto.sub tends_pos tends_neg
 
-lemma continuous_integral_boundedContinousFunction
+lemma continuous_integral_boundedContinuousFunction
     {α : Type*} [TopologicalSpace α] [MeasurableSpace α] [OpensMeasurableSpace α] (f : α →ᵇ ℝ) :
     Continuous fun μ : FiniteMeasure α ↦ ∫ x, f x ∂μ := by
   rw [continuous_iff_continuousAt]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
