### PR TITLE
[Merged by Bors] - feat: some API for Pi.mulSingle and monoids

### DIFF
--- a/Mathlib/Algebra/BigOperators/Pi.lean
+++ b/Mathlib/Algebra/BigOperators/Pi.lean
@@ -145,3 +145,37 @@ theorem snd_prod : (∏ c ∈ s, f c).2 = ∏ c ∈ s, (f c).2 :=
   map_prod (MonoidHom.snd α β) f s
 
 end Prod
+
+section MulEquiv
+
+/-- The canonical isomorphism between the monoid of homomorphisms from a finite product of
+commutative monoids to another commutative monoid and the product of the homomorphism monoids. -/
+@[to_additive]
+def Pi.monoidHomMulEquiv {ι : Type*} [Fintype ι] [DecidableEq ι] (M : ι → Type*)
+    [(i : ι) → CommMonoid (M i)] (M' : Type*) [CommMonoid M'] :
+    (((i : ι) → M i) →* M') ≃* ((i : ι) → (M i →* M')) where
+      toFun φ i := φ.comp <| MonoidHom.mulSingle M i
+      invFun φ := ∏ (i : ι), (φ i).comp (Pi.evalMonoidHom M i)
+      left_inv φ := by
+        ext
+        simp only [MonoidHom.finset_prod_apply, MonoidHom.coe_comp, Function.comp_apply,
+          evalMonoidHom_apply, MonoidHom.mulSingle_apply, ← map_prod]
+        refine congrArg _ <| funext fun _ ↦ ?_
+        rw [Fintype.prod_apply]
+        exact Fintype.prod_pi_mulSingle ..
+      right_inv φ := by
+        ext i m
+        simp only [MonoidHom.coe_comp, Function.comp_apply, MonoidHom.mulSingle_apply,
+          MonoidHom.finset_prod_apply, evalMonoidHom_apply, ]
+        let φ' i : M i → M' := ⇑(φ i)
+        conv =>
+          enter [1, 2, j]
+          rw [show φ j = φ' j from rfl, Pi.apply_mulSingle φ' (fun i ↦ map_one (φ i))]
+        rw [show φ' i = φ i from rfl]
+        exact Fintype.prod_pi_mulSingle' ..
+      map_mul' φ ψ := by
+        ext
+        simp only [MonoidHom.coe_comp, Function.comp_apply, MonoidHom.mulSingle_apply,
+          MonoidHom.mul_apply, mul_apply]
+
+end MulEquiv

--- a/Mathlib/Algebra/BigOperators/Pi.lean
+++ b/Mathlib/Algebra/BigOperators/Pi.lean
@@ -150,7 +150,9 @@ section MulEquiv
 
 /-- The canonical isomorphism between the monoid of homomorphisms from a finite product of
 commutative monoids to another commutative monoid and the product of the homomorphism monoids. -/
-@[to_additive]
+@[to_additive "The canonical isomorphism between the additive monoid of homomorphisms from
+a finite product of additive commutative monoids to another additive commutative monoid and
+the product of the homomorphism monoids."]
 def Pi.monoidHomMulEquiv {ι : Type*} [Fintype ι] [DecidableEq ι] (M : ι → Type*)
     [(i : ι) → CommMonoid (M i)] (M' : Type*) [CommMonoid M'] :
     (((i : ι) → M i) →* M') ≃* ((i : ι) → (M i →* M')) where

--- a/Mathlib/Algebra/Group/TypeTags.lean
+++ b/Mathlib/Algebra/Group/TypeTags.lean
@@ -554,3 +554,21 @@ is often used for composition, without affecting the behavior of the function it
 instance Multiplicative.coeToFun {α : Type*} {β : α → Sort*} [CoeFun α β] :
     CoeFun (Multiplicative α) fun a => β (toAdd a) :=
   ⟨fun a => CoeFun.coe (toAdd a)⟩
+
+lemma Pi.mulSingle_multiplicativeOfAdd_eq {ι : Type*} [DecidableEq ι] {M : ι → Type*}
+    [(i : ι) → AddMonoid (M i)] (i : ι) (a : M i) (j : ι) :
+    Pi.mulSingle (f := fun i ↦ Multiplicative (M i)) i (Multiplicative.ofAdd a) j =
+      Multiplicative.ofAdd ((Pi.single i a) j) := by
+  rcases eq_or_ne j i with rfl | h
+  · simp only [mulSingle_eq_same, single_eq_same]
+  · simp only [mulSingle, ne_eq, h, not_false_eq_true, Function.update_noteq, one_apply, single,
+      zero_apply, ofAdd_zero]
+
+lemma Pi.single_additiveOfMul_eq {ι : Type*} [DecidableEq ι] {M : ι → Type*}
+    [(i : ι) → Monoid (M i)] (i : ι) (a : M i) (j : ι) :
+    Pi.single (f := fun i ↦ Additive (M i)) i (Additive.ofMul a) j =
+      Additive.ofMul ((Pi.mulSingle i a) j) := by
+  rcases eq_or_ne j i with rfl | h
+  · simp only [mulSingle_eq_same, single_eq_same]
+  · simp only [single, ne_eq, h, not_false_eq_true, Function.update_noteq, zero_apply, mulSingle,
+      one_apply, ofMul_one]

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1162,3 +1162,12 @@ lemma orderOf_eq [Group G] (a : G) {x y : G} (h : SemiconjBy a x y) : orderOf x 
   exact (h.pow_right n).eq_one_iff
 
 end SemiconjBy
+
+section single
+
+lemma orderOf_piMulSingle {ι : Type*} [DecidableEq ι] {M : ι → Type*} [(i : ι) → Monoid (M i)]
+    (i : ι) (g : M i) :
+    orderOf (Pi.mulSingle i g) = orderOf g :=
+  orderOf_injective (MonoidHom.mulSingle M i) (Pi.mulSingle_injective M i) g
+
+end single


### PR DESCRIPTION
This adds some useful API definitions and lemmas dealing with products of monoids.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
