### PR TITLE
[Merged by Bors] - chore(MathlibTest): substitute our own testing attribute instead of batteries'

### DIFF
--- a/MathlibTest/solve_by_elim/basic.lean
+++ b/MathlibTest/solve_by_elim/basic.lean
@@ -6,9 +6,8 @@ Authors: Kim Morrison
 import Lean.Meta.Tactic.SolveByElim
 import Mathlib.Tactic.Constructor
 import Batteries.Tactic.PermuteGoals
-import BatteriesTest.Internal.DummyLabelAttr
+import MathlibTest.solve_by_elim.dummy_label_attr
 
-set_option autoImplicit true
 
 example (h : Nat) : Nat := by solve_by_elim
 example {α β : Type} (f : α → β) (a : α) : β := by solve_by_elim

--- a/MathlibTest/solve_by_elim/dummy_label_attr.lean
+++ b/MathlibTest/solve_by_elim/dummy_label_attr.lean
@@ -1,0 +1,3 @@
+import Lean.LabelAttribute
+
+register_label_attr dummy_label_attr


### PR DESCRIPTION
Remove all dependency on `BatteriesTest.Internal`.
Best not to rely on batteries testing internals, as these do not have a stable guarantee.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
