### PR TITLE
[Merged by Bors] - chore: remove instance of lift from `Option` to `MetaM`

### DIFF
--- a/Mathlib/Algebra/Order/BigOperators/Expect.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Expect.lean
@@ -171,6 +171,7 @@ namespace Mathlib.Meta.Positivity
 open Qq Lean Meta Finset
 open scoped BigOperators
 
+attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib in
 /-- Positivity extension for `Finset.expect`. -/
 @[positivity Finset.expect _ _]
 def evalFinsetExpect : PositivityExt where eval {u α} zα pα e := do

--- a/Mathlib/Algebra/Order/BigOperators/Expect.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Expect.lean
@@ -171,7 +171,7 @@ namespace Mathlib.Meta.Positivity
 open Qq Lean Meta Finset
 open scoped BigOperators
 
-attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- Positivity extension for `Finset.expect`. -/
 @[positivity Finset.expect _ _]
 def evalFinsetExpect : PositivityExt where eval {u α} zα pα e := do

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -205,6 +205,7 @@ open Qq Lean Meta Finset
 
 private alias ⟨_, prod_ne_zero⟩ := prod_ne_zero_iff
 
+attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib in
 /-- The `positivity` extension which proves that `∏ i ∈ s, f i` is nonnegative if `f` is, and
 positive if each `f i` is.
 

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -205,7 +205,7 @@ open Qq Lean Meta Finset
 
 private alias ⟨_, prod_ne_zero⟩ := prod_ne_zero_iff
 
-attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `positivity` extension which proves that `∏ i ∈ s, f i` is nonnegative if `f` is, and
 positive if each `f i` is.
 

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -1946,6 +1946,7 @@ namespace Mathlib.Meta.Positivity
 
 open Qq Lean Meta MeasureTheory
 
+attribute [local instance] monadLiftOptionMetaM in
 /-- Positivity extension for integrals.
 
 This extension only proves non-negativity, strict positivity is more delicate for integration and

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -212,12 +212,12 @@ theorem isRat_add {α} [Ring α] {f : α → α → α} {a b : α} {na nb nc : �
     (Nat.cast_commute (α := α) da dc).invOf_left.invOf_right.right_comm,
     (Nat.cast_commute (α := α) db dc).invOf_left.invOf_right.right_comm]
 
-def monadLiftOptionMetaM_mathlib : MonadLift Option MetaM where
+def _root_.Mathlib.Meta.monadLiftOptionMetaM : MonadLift Option MetaM where
   monadLift
   | none => failure
   | some e => pure e
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a + b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ + _] def evalAdd : NormNumExt where eval {u α} e := do
@@ -279,7 +279,7 @@ theorem isRat_neg {α} [Ring α] : ∀ {f : α → α} {a : α} {n n' : ℤ} {d 
     f = Neg.neg → IsRat a n d → Int.neg n = n' → IsRat (-a) n' d
   | _, _, _, _, _, rfl, ⟨h, rfl⟩, rfl => ⟨h, by rw [← neg_mul, ← Int.cast_neg]; rfl⟩
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `-a`,
 such that `norm_num` successfully recognises `a`. -/
 @[norm_num -_] def evalNeg : NormNumExt where eval {u α} e := do
@@ -327,7 +327,7 @@ theorem isRat_sub {α} [Ring α] {f : α → α → α} {a b : α} {na nb nc : �
   refine isRat_add rfl ra (isRat_neg (n' := -nb) rfl rb rfl) (k := k) (nc := nc) ?_ h₂
   rw [show Int.mul (-nb) _ = _ from neg_mul ..]; exact h₁
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a - b` in a ring,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ - _] def evalSub : NormNumExt where eval {u α} e := do
@@ -398,7 +398,7 @@ theorem isRat_mul {α} [Ring α] {f : α → α → α} {a b : α} {na nb nc : �
     (Nat.cast_commute (α := α) da dc).invOf_left.invOf_right.right_comm,
     (Nat.cast_commute (α := α) db dc).invOf_left.invOf_right.right_comm]
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a * b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ * _] def evalMul : NormNumExt where eval {u α} e := do
@@ -452,7 +452,7 @@ theorem isRat_div {α : Type u} [DivisionRing α] : {a b : α} → {cn : ℤ} �
 def inferDivisionRing {u : Level} (α : Q(Type u)) : MetaM Q(DivisionRing $α) :=
   return ← synthInstanceQ (q(DivisionRing $α) : Q(Type u)) <|> throwError "not a division ring"
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a / b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ / _] def evalDiv : NormNumExt where eval {u α} e := do

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -212,6 +212,7 @@ theorem isRat_add {α} [Ring α] {f : α → α → α} {a b : α} {na nb nc : �
     (Nat.cast_commute (α := α) da dc).invOf_left.invOf_right.right_comm,
     (Nat.cast_commute (α := α) db dc).invOf_left.invOf_right.right_comm]
 
+/-- Consider an `Option` as an object in the `MetaM` monad, by throwing an error on `none`. -/
 def _root_.Mathlib.Meta.monadLiftOptionMetaM : MonadLift Option MetaM where
   monadLift
   | none => failure

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -212,10 +212,12 @@ theorem isRat_add {α} [Ring α] {f : α → α → α} {a b : α} {na nb nc : �
     (Nat.cast_commute (α := α) da dc).invOf_left.invOf_right.right_comm,
     (Nat.cast_commute (α := α) db dc).invOf_left.invOf_right.right_comm]
 
-instance : MonadLift Option MetaM where
+def monadLiftOptionMetaM_mathlib : MonadLift Option MetaM where
   monadLift
   | none => failure
   | some e => pure e
+
+attribute [local instance] monadLiftOptionMetaM_mathlib
 
 /-- The `norm_num` extension which identifies expressions of the form `a + b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -217,8 +217,7 @@ def monadLiftOptionMetaM_mathlib : MonadLift Option MetaM where
   | none => failure
   | some e => pure e
 
-attribute [local instance] monadLiftOptionMetaM_mathlib
-
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `a + b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ + _] def evalAdd : NormNumExt where eval {u α} e := do
@@ -280,6 +279,7 @@ theorem isRat_neg {α} [Ring α] : ∀ {f : α → α} {a : α} {n n' : ℤ} {d 
     f = Neg.neg → IsRat a n d → Int.neg n = n' → IsRat (-a) n' d
   | _, _, _, _, _, rfl, ⟨h, rfl⟩, rfl => ⟨h, by rw [← neg_mul, ← Int.cast_neg]; rfl⟩
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `-a`,
 such that `norm_num` successfully recognises `a`. -/
 @[norm_num -_] def evalNeg : NormNumExt where eval {u α} e := do
@@ -327,6 +327,7 @@ theorem isRat_sub {α} [Ring α] {f : α → α → α} {a b : α} {na nb nc : �
   refine isRat_add rfl ra (isRat_neg (n' := -nb) rfl rb rfl) (k := k) (nc := nc) ?_ h₂
   rw [show Int.mul (-nb) _ = _ from neg_mul ..]; exact h₁
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `a - b` in a ring,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ - _] def evalSub : NormNumExt where eval {u α} e := do
@@ -397,6 +398,7 @@ theorem isRat_mul {α} [Ring α] {f : α → α → α} {a b : α} {na nb nc : �
     (Nat.cast_commute (α := α) da dc).invOf_left.invOf_right.right_comm,
     (Nat.cast_commute (α := α) db dc).invOf_left.invOf_right.right_comm]
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `a * b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ * _] def evalMul : NormNumExt where eval {u α} e := do
@@ -450,6 +452,7 @@ theorem isRat_div {α : Type u} [DivisionRing α] : {a b : α} → {cn : ℤ} �
 def inferDivisionRing {u : Level} (α : Q(Type u)) : MetaM Q(DivisionRing $α) :=
   return ← synthInstanceQ (q(DivisionRing $α) : Q(Type u)) <|> throwError "not a division ring"
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `a / b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ / _] def evalDiv : NormNumExt where eval {u α} e := do

--- a/Mathlib/Tactic/NormNum/BigOperators.lean
+++ b/Mathlib/Tactic/NormNum/BigOperators.lean
@@ -42,6 +42,8 @@ open Lean hiding Rat mkRat
 open Meta
 open Qq
 
+attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib
+
 variable {u v : Level}
 
 /-- This represents the result of trying to determine whether the given expression `n : Q(ℕ)`

--- a/Mathlib/Tactic/NormNum/BigOperators.lean
+++ b/Mathlib/Tactic/NormNum/BigOperators.lean
@@ -346,7 +346,7 @@ partial def evalFinsetBigop {α : Q(Type u)} {β : Q(Type v)}
       let eq : Q($op $s $f = $op (Finset.cons $a $s' $h) $f) := q(congr_fun (congr_arg _ $pf) _)
       pure (res.eq_trans eq)
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- `norm_num` plugin for evaluating products of finsets.
 
 If your finset is not supported, you can add it to the match in `Finset.proveEmptyOrCons`.
@@ -376,7 +376,7 @@ partial def evalFinsetProd : NormNumExt where eval {u β} e := do
       pure <| res.eq_trans eq)
     s
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- `norm_num` plugin for evaluating sums of finsets.
 
 If your finset is not supported, you can add it to the match in `Finset.proveEmptyOrCons`.

--- a/Mathlib/Tactic/NormNum/BigOperators.lean
+++ b/Mathlib/Tactic/NormNum/BigOperators.lean
@@ -42,8 +42,6 @@ open Lean hiding Rat mkRat
 open Meta
 open Qq
 
-attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib
-
 variable {u v : Level}
 
 /-- This represents the result of trying to determine whether the given expression `n : Q(ℕ)`
@@ -348,6 +346,7 @@ partial def evalFinsetBigop {α : Q(Type u)} {β : Q(Type v)}
       let eq : Q($op $s $f = $op (Finset.cons $a $s' $h) $f) := q(congr_fun (congr_arg _ $pf) _)
       pure (res.eq_trans eq)
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- `norm_num` plugin for evaluating products of finsets.
 
 If your finset is not supported, you can add it to the match in `Finset.proveEmptyOrCons`.
@@ -377,6 +376,7 @@ partial def evalFinsetProd : NormNumExt where eval {u β} e := do
       pure <| res.eq_trans eq)
     s
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- `norm_num` plugin for evaluating sums of finsets.
 
 If your finset is not supported, you can add it to the match in `Finset.proveEmptyOrCons`.

--- a/Mathlib/Tactic/NormNum/DivMod.lean
+++ b/Mathlib/Tactic/NormNum/DivMod.lean
@@ -46,7 +46,7 @@ lemma isInt_ediv_neg {a b q q' : ℤ} (h : IsInt (a / -b) q) (hq : -q = q') : Is
 lemma isNat_neg_of_isNegNat {a : ℤ} {b : ℕ} (h : IsInt a (.negOfNat b)) : IsNat (-a) b :=
   ⟨by simp [h.out]⟩
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `Int.ediv a b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num (_ : ℤ) / _, Int.ediv _ _]
@@ -105,7 +105,7 @@ lemma isInt_emod {a b q m a' : ℤ} {b' r : ℕ}
 lemma isInt_emod_neg {a b : ℤ} {r : ℕ} (h : IsNat (a % -b) r) : IsNat (a % b) r :=
   ⟨by rw [← Int.emod_neg, h.out]⟩
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `Int.emod a b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num (_ : ℤ) % _, Int.emod _ _]
@@ -160,7 +160,7 @@ theorem isInt_dvd_false : {a b : ℤ} → {a' b' : ℤ} →
     IsInt a a' → IsInt b b' → Int.emod b' a' != 0 → ¬a ∣ b
   | _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, e => mt Int.emod_eq_zero_of_dvd (by simpa using e)
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `(a : ℤ) ∣ b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num (_ : ℤ) ∣ _] def evalIntDvd : NormNumExt where eval {u α} e := do

--- a/Mathlib/Tactic/NormNum/DivMod.lean
+++ b/Mathlib/Tactic/NormNum/DivMod.lean
@@ -46,6 +46,7 @@ lemma isInt_ediv_neg {a b q q' : ℤ} (h : IsInt (a / -b) q) (hq : -q = q') : Is
 lemma isNat_neg_of_isNegNat {a : ℤ} {b : ℕ} (h : IsInt a (.negOfNat b)) : IsNat (-a) b :=
   ⟨by simp [h.out]⟩
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `Int.ediv a b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num (_ : ℤ) / _, Int.ediv _ _]
@@ -104,6 +105,7 @@ lemma isInt_emod {a b q m a' : ℤ} {b' r : ℕ}
 lemma isInt_emod_neg {a b : ℤ} {r : ℕ} (h : IsNat (a % -b) r) : IsNat (a % b) r :=
   ⟨by rw [← Int.emod_neg, h.out]⟩
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `Int.emod a b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num (_ : ℤ) % _, Int.emod _ _]
@@ -158,6 +160,7 @@ theorem isInt_dvd_false : {a b : ℤ} → {a' b' : ℤ} →
     IsInt a a' → IsInt b b' → Int.emod b' a' != 0 → ¬a ∣ b
   | _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, e => mt Int.emod_eq_zero_of_dvd (by simpa using e)
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `(a : ℤ) ∣ b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num (_ : ℤ) ∣ _] def evalIntDvd : NormNumExt where eval {u α} e := do

--- a/Mathlib/Tactic/NormNum/Eq.lean
+++ b/Mathlib/Tactic/NormNum/Eq.lean
@@ -42,7 +42,7 @@ theorem isRat_eq_false [Ring α] [CharZero α] : {a b : α} → {na nb : ℤ} �
   | _, _, _, _, _, _, ⟨_, rfl⟩, ⟨_, rfl⟩, h => by
     rw [Rat.invOf_denom_swap]; exact mod_cast of_decide_eq_false h
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a = b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ = _] def evalEq : NormNumExt where eval {v β} e := do

--- a/Mathlib/Tactic/NormNum/Eq.lean
+++ b/Mathlib/Tactic/NormNum/Eq.lean
@@ -23,6 +23,8 @@ open Lean Meta Qq
 
 namespace Mathlib.Meta.NormNum
 
+attribute [local instance] monadLiftOptionMetaM_mathlib
+
 theorem isNat_eq_false [AddMonoidWithOne α] [CharZero α] : {a b : α} → {a' b' : ℕ} →
     IsNat a a' → IsNat b b' → Nat.beq a' b' = false → ¬a = b
   | _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, h => by simpa using Nat.ne_of_beq_eq_false h

--- a/Mathlib/Tactic/NormNum/Eq.lean
+++ b/Mathlib/Tactic/NormNum/Eq.lean
@@ -23,8 +23,6 @@ open Lean Meta Qq
 
 namespace Mathlib.Meta.NormNum
 
-attribute [local instance] monadLiftOptionMetaM_mathlib
-
 theorem isNat_eq_false [AddMonoidWithOne α] [CharZero α] : {a b : α} → {a' b' : ℕ} →
     IsNat a a' → IsNat b b' → Nat.beq a' b' = false → ¬a = b
   | _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, h => by simpa using Nat.ne_of_beq_eq_false h
@@ -44,6 +42,7 @@ theorem isRat_eq_false [Ring α] [CharZero α] : {a b : α} → {na nb : ℤ} �
   | _, _, _, _, _, _, ⟨_, rfl⟩, ⟨_, rfl⟩, h => by
     rw [Rat.invOf_denom_swap]; exact mod_cast of_decide_eq_false h
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `a = b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ = _] def evalEq : NormNumExt where eval {v β} e := do

--- a/Mathlib/Tactic/NormNum/Ineq.lean
+++ b/Mathlib/Tactic/NormNum/Ineq.lean
@@ -108,7 +108,7 @@ theorem isInt_lt_false [OrderedRing α] {a b : α} {a' b' : ℤ}
     (ha : IsInt a a') (hb : IsInt b b') (h : decide (b' ≤ a')) : ¬a < b :=
   not_lt_of_le (isInt_le_true hb ha h)
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a ≤ b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ ≤ _] def evalLE : NormNumExt where eval {v β} e := do
@@ -173,7 +173,7 @@ where
     else -- Nats can appear in an `OrderedRing` without `CharZero`.
       intArm
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a < b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ < _] def evalLT : NormNumExt where eval {v β} e := do

--- a/Mathlib/Tactic/NormNum/Ineq.lean
+++ b/Mathlib/Tactic/NormNum/Ineq.lean
@@ -108,6 +108,7 @@ theorem isInt_lt_false [OrderedRing α] {a b : α} {a' b' : ℤ}
     (ha : IsInt a a') (hb : IsInt b b') (h : decide (b' ≤ a')) : ¬a < b :=
   not_lt_of_le (isInt_le_true hb ha h)
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `a ≤ b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ ≤ _] def evalLE : NormNumExt where eval {v β} e := do
@@ -172,6 +173,7 @@ where
     else -- Nats can appear in an `OrderedRing` without `CharZero`.
       intArm
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `a < b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ < _] def evalLT : NormNumExt where eval {v β} e := do

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -25,6 +25,8 @@ namespace Mathlib.Meta.NormNum
 
 open Lean.Meta Qq
 
+attribute [local instance] monadLiftOptionMetaM_mathlib
+
 /-- Helper function to synthesize a typed `CharZero α` expression given `Ring α`. -/
 def inferCharZeroOfRing {α : Q(Type u)} (_i : Q(Ring $α) := by with_reducible assumption) :
     MetaM Q(CharZero $α) :=

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -25,8 +25,6 @@ namespace Mathlib.Meta.NormNum
 
 open Lean.Meta Qq
 
-attribute [local instance] monadLiftOptionMetaM_mathlib
-
 /-- Helper function to synthesize a typed `CharZero α` expression given `Ring α`. -/
 def inferCharZeroOfRing {α : Q(Type u)} (_i : Q(Ring $α) := by with_reducible assumption) :
     MetaM Q(CharZero $α) :=
@@ -67,6 +65,7 @@ theorem isRat_mkRat : {a na n : ℤ} → {b nb d : ℕ} → IsInt a na → IsNat
     IsRat (na / nb : ℚ) n d → IsRat (mkRat a b) n d
   | _, _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, ⟨_, h⟩ => by rw [Rat.mkRat_eq_div]; exact ⟨_, h⟩
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `mkRat a b`,
 such that `norm_num` successfully recognises both `a` and `b`, and returns `a / b`. -/
 @[norm_num mkRat _ _]
@@ -142,6 +141,7 @@ theorem isRat_inv_neg {α} [DivisionRing α] [CharZero α] {a : α} {n d : ℕ} 
 
 open Lean
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `a⁻¹`,
 such that `norm_num` successfully recognises `a`. -/
 @[norm_num _⁻¹] def evalInv : NormNumExt where eval {u α} e := do

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -65,7 +65,7 @@ theorem isRat_mkRat : {a na n : ℤ} → {b nb d : ℕ} → IsInt a na → IsNat
     IsRat (na / nb : ℚ) n d → IsRat (mkRat a b) n d
   | _, _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, ⟨_, h⟩ => by rw [Rat.mkRat_eq_div]; exact ⟨_, h⟩
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `mkRat a b`,
 such that `norm_num` successfully recognises both `a` and `b`, and returns `a / b`. -/
 @[norm_num mkRat _ _]
@@ -141,7 +141,7 @@ theorem isRat_inv_neg {α} [DivisionRing α] [CharZero α] {a : α} {n d : ℕ} 
 
 open Lean
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a⁻¹`,
 such that `norm_num` successfully recognises `a`. -/
 @[norm_num _⁻¹] def evalInv : NormNumExt where eval {u α} e := do

--- a/Mathlib/Tactic/NormNum/Pow.lean
+++ b/Mathlib/Tactic/NormNum/Pow.lean
@@ -169,7 +169,7 @@ theorem isRat_pow {α} [Ring α] {f : α → ℕ → α} {a : α} {an cn : ℤ} 
   rw [← Nat.cast_pow] at this
   use this; simp [invOf_pow, Commute.mul_pow]
 
-attribute [local instance] monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a ^ b`,
 such that `norm_num` successfully recognises both `a` and `b`, with `b : ℕ`. -/
 @[norm_num _ ^ (_ : ℕ)]

--- a/Mathlib/Tactic/NormNum/Pow.lean
+++ b/Mathlib/Tactic/NormNum/Pow.lean
@@ -24,7 +24,6 @@ open Meta
 
 namespace Meta.NormNum
 open Qq
-attribute [local instance] monadLiftOptionMetaM_mathlib
 
 variable {a b c : ℕ}
 
@@ -170,6 +169,7 @@ theorem isRat_pow {α} [Ring α] {f : α → ℕ → α} {a : α} {an cn : ℤ} 
   rw [← Nat.cast_pow] at this
   use this; simp [invOf_pow, Commute.mul_pow]
 
+attribute [local instance] monadLiftOptionMetaM_mathlib in
 /-- The `norm_num` extension which identifies expressions of the form `a ^ b`,
 such that `norm_num` successfully recognises both `a` and `b`, with `b : ℕ`. -/
 @[norm_num _ ^ (_ : ℕ)]

--- a/Mathlib/Tactic/NormNum/Pow.lean
+++ b/Mathlib/Tactic/NormNum/Pow.lean
@@ -24,6 +24,7 @@ open Meta
 
 namespace Meta.NormNum
 open Qq
+attribute [local instance] monadLiftOptionMetaM_mathlib
 
 variable {a b c : ℕ}
 

--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -127,7 +127,7 @@ def Poly.toSyntax : Poly → Unhygienic Syntax.Term
   | .pow p q => do `($(← p.toSyntax) ^ $(← q.toSyntax))
   | .neg p => do `(-$(← p.toSyntax))
 
-attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- Reifies a ring expression of type `α` as a `Poly`. -/
 partial def parse {u : Level} {α : Q(Type u)} (sα : Q(CommSemiring $α))
     (c : Ring.Cache sα) (e : Q($α)) : AtomM Poly := do

--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -127,6 +127,7 @@ def Poly.toSyntax : Poly → Unhygienic Syntax.Term
   | .pow p q => do `($(← p.toSyntax) ^ $(← q.toSyntax))
   | .neg p => do `(-$(← p.toSyntax))
 
+attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib in
 /-- Reifies a ring expression of type `α` as a `Poly`. -/
 partial def parse {u : Level} {α : Q(Type u)} (sα : Q(CommSemiring $α))
     (c : Ring.Cache sα) (e : Q($α)) : AtomM Poly := do

--- a/Mathlib/Tactic/Positivity/Finset.lean
+++ b/Mathlib/Tactic/Positivity/Finset.lean
@@ -20,6 +20,8 @@ namespace Mathlib.Meta.Positivity
 
 open Qq Lean Meta Finset
 
+attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib
+
 /-- Extension for `Finset.card`. `#s` is positive if `s` is nonempty.
 
 It calls `Mathlib.Meta.proveFinsetNonempty` to attempt proving that the finset is nonempty. -/

--- a/Mathlib/Tactic/Positivity/Finset.lean
+++ b/Mathlib/Tactic/Positivity/Finset.lean
@@ -54,7 +54,7 @@ def evalFinsetDens : PositivityExt where eval {u 𝕜} _ _ e := do
     return .positive q(@Nonempty.dens_pos $α $instα $s $ps)
   | _, _, _ => throwError "not Finset.dens"
 
-attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- The `positivity` extension which proves that `∑ i ∈ s, f i` is nonnegative if `f` is, and
 positive if each `f i` is and `s` is nonempty.
 

--- a/Mathlib/Tactic/Positivity/Finset.lean
+++ b/Mathlib/Tactic/Positivity/Finset.lean
@@ -20,8 +20,6 @@ namespace Mathlib.Meta.Positivity
 
 open Qq Lean Meta Finset
 
-attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib
-
 /-- Extension for `Finset.card`. `#s` is positive if `s` is nonempty.
 
 It calls `Mathlib.Meta.proveFinsetNonempty` to attempt proving that the finset is nonempty. -/
@@ -56,6 +54,7 @@ def evalFinsetDens : PositivityExt where eval {u 𝕜} _ _ e := do
     return .positive q(@Nonempty.dens_pos $α $instα $s $ps)
   | _, _, _ => throwError "not Finset.dens"
 
+attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib in
 /-- The `positivity` extension which proves that `∑ i ∈ s, f i` is nonnegative if `f` is, and
 positive if each `f i` is and `s` is nonempty.
 

--- a/Mathlib/Tactic/ReduceModChar.lean
+++ b/Mathlib/Tactic/ReduceModChar.lean
@@ -56,6 +56,7 @@ lemma CharP.isNat_pow {α} [Semiring α] : ∀ {f : α → ℕ → α} {a : α} 
     rw [h, Nat.cast_id, Nat.pow_eq, ← Nat.cast_pow, CharP.natCast_eq_natCast_mod α n]
     rfl⟩
 
+attribute [local instance] Mathlib.Meta.monadLiftOptionMetaM in
 /-- Evaluates `e` to an integer using `norm_num` and reduces the result modulo `n`. -/
 def normBareNumeral {α : Q(Type u)} (n n' : Q(ℕ)) (pn : Q(IsNat «$n» «$n'»))
     (e : Q($α)) (_ : Q(Ring $α)) (instCharP : Q(CharP $α $n)) : MetaM (Result e) := do

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -81,7 +81,7 @@ namespace Ring
 
 open Mathlib.Meta Qq NormNum Lean.Meta AtomM
 
-attribute [local instance] monadLiftOptionMetaM_mathlib
+attribute [local instance] monadLiftOptionMetaM
 
 open Lean (MetaM Expr mkRawNatLit)
 

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -81,6 +81,8 @@ namespace Ring
 
 open Mathlib.Meta Qq NormNum Lean.Meta AtomM
 
+attribute [local instance] monadLiftOptionMetaM_mathlib
+
 open Lean (MetaM Expr mkRawNatLit)
 
 /-- A shortcut instance for `CommSemiring ℕ` used by ring. -/

--- a/Mathlib/Tactic/Ring/Compare.lean
+++ b/Mathlib/Tactic/Ring/Compare.lean
@@ -190,6 +190,7 @@ theorem lt_congr {α : Type*} [LT α] {a b c d : α} (h1 : a = b) (h2 : b < c) (
     a < d := by
   rwa [h1, h3]
 
+attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib in
 /-- Prove goals of the form `A ≤ B` in an ordered commutative semiring, if the ring-normal forms of
 `A` and `B` differ by a nonnegative (additive) constant. -/
 def proveLE (g : MVarId) : MetaM Unit := do
@@ -213,6 +214,7 @@ def proveLE (g : MVarId) : MetaM Unit := do
       throwError "ring failed, ring expressions not equal up to an additive constant\n{g'.mvarId!}"
     | tooSmall => throwError "comparison failed, LHS is larger\n{g'.mvarId!}"
 
+attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib in
 /-- Prove goals of the form `A < B` in an ordered commutative semiring, if the ring-normal forms of
 `A` and `B` differ by a positive (additive) constant. -/
 def proveLT (g : MVarId) : MetaM Unit := do

--- a/Mathlib/Tactic/Ring/Compare.lean
+++ b/Mathlib/Tactic/Ring/Compare.lean
@@ -190,7 +190,7 @@ theorem lt_congr {α : Type*} [LT α] {a b c d : α} (h1 : a = b) (h2 : b < c) (
     a < d := by
   rwa [h1, h3]
 
-attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- Prove goals of the form `A ≤ B` in an ordered commutative semiring, if the ring-normal forms of
 `A` and `B` differ by a nonnegative (additive) constant. -/
 def proveLE (g : MVarId) : MetaM Unit := do
@@ -214,7 +214,7 @@ def proveLE (g : MVarId) : MetaM Unit := do
       throwError "ring failed, ring expressions not equal up to an additive constant\n{g'.mvarId!}"
     | tooSmall => throwError "comparison failed, LHS is larger\n{g'.mvarId!}"
 
-attribute [local instance] NormNum.monadLiftOptionMetaM_mathlib in
+attribute [local instance] monadLiftOptionMetaM in
 /-- Prove goals of the form `A < B` in an ordered commutative semiring, if the ring-normal forms of
 `A` and `B` differ by a positive (additive) constant. -/
 def proveLT (g : MVarId) : MetaM Unit := do


### PR DESCRIPTION
Remove the `MonadLift Option MetaM` instance which previously appeared in the middle of the `norm_num` implementation.  This has been there since the port (#519) and my guess is that leaving it there was an oversight -- that @digama0 had intended either to move it earlier or to delete it entirely.

Anyway, this PR takes the easiest path to removing it: de-instance the definition, and invoke it as a local instance in the places where it had been used in Mathlib.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/239415-metaprogramming-.2F-tactics/topic/Lift.20from.20Option.20to.20MetaM)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
