### PR TITLE
[Merged by Bors] - feat(RingTheory/RootsOfUnity/EnoughRootsOfUnity): new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4280,6 +4280,7 @@ import Mathlib.RingTheory.RingHomProperties
 import Mathlib.RingTheory.RingInvo
 import Mathlib.RingTheory.RootsOfUnity.Basic
 import Mathlib.RingTheory.RootsOfUnity.Complex
+import Mathlib.RingTheory.RootsOfUnity.EnoughRootsOfUnity
 import Mathlib.RingTheory.RootsOfUnity.Lemmas
 import Mathlib.RingTheory.RootsOfUnity.Minpoly
 import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -270,6 +270,16 @@ instance Subgroup.isCyclic {α : Type u} [Group α] [IsCyclic α] (H : Subgroup 
         ⟨fun h => by simp at *; tauto, fun h => by rw [Subgroup.mem_bot.1 h]; exact H.one_mem⟩
     subst this; infer_instance
 
+@[to_additive]
+lemma Subgroup.isCyclic_of_le {G : Type*} [Group G] {H H' : Subgroup G} (h : H ≤ H')
+    [IsCyclic H'] :
+    IsCyclic H := by
+  let e := Subgroup.subgroupOfEquivOfLe h
+  obtain ⟨g, hg⟩ := Subgroup.isCyclic <| H.subgroupOf H'
+  refine ⟨e g, fun x ↦ ?_⟩
+  obtain ⟨n, hn⟩ := hg (e.symm x)
+  exact ⟨n, by simp only at hn ⊢; rw [← map_zpow, hn, MulEquiv.apply_symm_apply]⟩
+
 open Finset Nat
 
 section Classical

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -5,9 +5,10 @@ Authors: Johan Commelin
 -/
 import Mathlib.Algebra.CharP.Reduced
 import Mathlib.RingTheory.IntegralDomain
+-- TODO: remove Mathlib.Algebra.CharP.Reduced and move the last two lemmas to Lemmas
 
 /-!
-# Roots of unity and primitive roots of unity
+# Roots of unity
 
 We define roots of unity in the context of an arbitrary commutative monoid,
 as a subgroup of the group of units.
@@ -101,6 +102,18 @@ theorem map_rootsOfUnity (f : Mˣ →* Nˣ) (k : ℕ) : (rootsOfUnity k M).map f
 theorem rootsOfUnity.coe_pow [CommMonoid R] (ζ : rootsOfUnity k R) (m : ℕ) :
     (((ζ ^ m :) : Rˣ) : R) = ((ζ : Rˣ) : R) ^ m := by
   rw [Subgroup.coe_pow, Units.val_pow_eq_pow_val]
+
+/-- The canonical isomorphism from the `n`th roots of unity in `Mˣ`
+to the `n`th roots of unity in `M`. -/
+def rootsOfUnityUnitsMulEquiv (M : Type*) [CommMonoid M] (n : ℕ) :
+    rootsOfUnity n Mˣ ≃* rootsOfUnity n M where
+  toFun ζ := ⟨ζ.val, (mem_rootsOfUnity ..).mpr <| (mem_rootsOfUnity' ..).mp ζ.prop⟩
+  invFun ζ := ⟨toUnits ζ.val, by
+    simp only [mem_rootsOfUnity, ← map_pow, MulEquivClass.map_eq_one_iff]
+    exact (mem_rootsOfUnity ..).mp ζ.prop⟩
+  left_inv ζ := by simp only [toUnits_val_apply, Subtype.coe_eta]
+  right_inv ζ := by simp only [val_toUnits_apply, Subtype.coe_eta]
+  map_mul' ζ ζ' := by simp only [Subgroup.coe_mul, Units.val_mul, MulMemClass.mk_mul_mk]
 
 section CommMonoid
 

--- a/Mathlib/RingTheory/RootsOfUnity/EnoughRootsOfUnity.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/EnoughRootsOfUnity.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2024 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Stoll
+-/
+import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
+
+/-!
+# Commutative monoids with enough roots of unity
+
+We define a typeclass `HasEnoughRootsOfUnity M n` for a commutative monoid `M` and
+a natural number `n` that asserts that `M` contains a primitive `n`th root of unity
+and that the group of `n`th roots of unity in `M` is cyclic. Such monoids are suitable
+targets for homomorphisms from groups of exponent (dividing) `n`; for example,
+the homomorphisms can then be used to separate elements of the source group.
+-/
+
+/-- This is a type class recording that a commutative monoid `M` contains primitive `n`th
+roots of unity and such that the group of `n`th roots of unity is cyclic.
+
+Such monoids are suitable targets in the context of duality statements for groups
+of exponent `n`. -/
+class HasEnoughRootsOfUnity (M : Type*) [CommMonoid M] (n : ℕ) where
+  prim : ∃ m : M, IsPrimitiveRoot m n
+  cyc : IsCyclic <| rootsOfUnity n M
+
+namespace HasEnoughRootsOfUnity
+
+lemma exists_primitiveRoot (M : Type*) [CommMonoid M] (n : ℕ) [HasEnoughRootsOfUnity M n] :
+    ∃ ζ : M, IsPrimitiveRoot ζ n :=
+  HasEnoughRootsOfUnity.prim
+
+instance rootsOfUnity_isCyclic (M : Type*) [CommMonoid M] (n : ℕ) [HasEnoughRootsOfUnity M n] :
+    IsCyclic (rootsOfUnity n M) :=
+  HasEnoughRootsOfUnity.cyc
+
+/-- If `HasEnoughRootsOfUnity M n` and `m ∣ n`, then also `HasEnoughRootsOfUnity M m`. -/
+lemma of_dvd (M : Type*) [CommMonoid M] {m n : ℕ} [NeZero n] (hmn : m ∣ n)
+    [HasEnoughRootsOfUnity M n] :
+    HasEnoughRootsOfUnity M m where
+  prim :=
+    have ⟨ζ, hζ⟩ := exists_primitiveRoot M n
+    have ⟨k, hk⟩ := hmn
+    ⟨ζ ^ k, IsPrimitiveRoot.pow (NeZero.pos n) hζ (mul_comm m k ▸ hk)⟩
+  cyc := Subgroup.isCyclic_of_le <| rootsOfUnity_le_of_dvd hmn
+
+/-- If `M` satisfies `HasEnoughRootsOfUnity`, then the group of `n`th roots of unity
+in `M` is finite. -/
+instance finite_rootsOfUnity (M : Type*) [CommMonoid M] (n : ℕ) [NeZero n]
+    [HasEnoughRootsOfUnity M n] :
+    Finite <| rootsOfUnity n M := by
+  have := rootsOfUnity_isCyclic M n
+  obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := rootsOfUnity n M)
+  have hg' : g ^ n = 1 := OneMemClass.coe_eq_one.mp g.prop
+  let f (j : ZMod n) : rootsOfUnity n M := g ^ (j.val : ℤ)
+  refine Finite.of_surjective f fun x ↦ ?_
+  obtain ⟨k, hk⟩ := Subgroup.mem_zpowers_iff.mp <| hg x
+  refine ⟨k, ?_⟩
+  simpa only [ZMod.natCast_val, ← hk, f, ZMod.coe_intCast] using (zpow_eq_zpow_emod' k hg').symm
+
+/-- If `M` satisfies `HasEnoughRootsOfUnity`, then the group of `n`th roots of unity
+in `M` (is cyclic and) has order `n`. -/
+lemma natCard_rootsOfUnity (M : Type*) [CommMonoid M] (n : ℕ) [NeZero n]
+    [HasEnoughRootsOfUnity M n] :
+    Nat.card (rootsOfUnity n M) = n := by
+  obtain ⟨ζ, h⟩ := exists_primitiveRoot M n
+  have : Fintype <| rootsOfUnity n M := Fintype.ofFinite _
+  rw [Nat.card_eq_fintype_card, ← IsCyclic.exponent_eq_card]
+  refine dvd_antisymm ?_ ?_
+  · exact Monoid.exponent_dvd_of_forall_pow_eq_one fun g ↦ OneMemClass.coe_eq_one.mp g.prop
+  · nth_rewrite 1 [h.eq_orderOf]
+    rw [← (h.isUnit <| NeZero.pos n).unit_spec, orderOf_units]
+    let ζ' : rootsOfUnity n M := ⟨(h.isUnit <| NeZero.pos n).unit, ?_⟩
+    · rw [← Subgroup.orderOf_mk]
+      exact Monoid.order_dvd_exponent ζ'
+    simp only [mem_rootsOfUnity, PNat.mk_coe]
+    rw [← Units.eq_iff, Units.val_pow_eq_pow_val, IsUnit.unit_spec, h.pow_eq_one, Units.val_one]
+
+end HasEnoughRootsOfUnity


### PR DESCRIPTION
This PR adds a new file `RingTheory.RootsOfUnity.EnoughRootsOfUnity` that defines the type class `HasEnoughRootsOfUnity`, where `HasEnoughRootsOfUnity M n` for a commutative monoid `M` and a natural number `n` records that `M` has a primitive `n`th root of unity and the group of `n`th roots of unity in `M` is cyclic. Some relevant API is also provided.

This property is the relevant one when considering the dual of an abelian group `G` via `Hom(G, M)` (here `n` is the exponent of `G`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
