### PR TITLE
[Merged by Bors] - feat: duality results for cyclic groups

### DIFF
--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -242,3 +242,41 @@ theorem mem_rootsOfUnity_prime_pow_mul_iff' (p k : ℕ) (m : ℕ) [ExpChar R p] 
 end Reduced
 
 end rootsOfUnity
+
+section cyclic
+
+namespace IsCyclic
+
+/-- The isomorphism from the group of group homomorphisms from a finite cyclic group `G` of order
+`n` into another group `G'` to the group of `n`th roots of unity in `G'` determined by a generator
+`g` of `G`. It sends `φ : G →* G'` to `φ g`. -/
+noncomputable
+def monoidHomMulEquivRootsOfUnityOfGenerator {G : Type*} [CommGroup G] [Fintype G] {g : G}
+    (hg : ∀ (x : G), x ∈ Subgroup.zpowers g) (G' : Type*) [CommGroup G'] :
+    (G →* G') ≃* rootsOfUnity (Fintype.card G) G' where
+  toFun φ := ⟨(IsUnit.map φ <| Group.isUnit g).unit, by
+    simp only [mem_rootsOfUnity, Units.ext_iff, Units.val_pow_eq_pow_val, IsUnit.unit_spec,
+      ← map_pow, pow_card_eq_one, map_one, Units.val_one]⟩
+  invFun ζ := monoidHomOfForallMemZpowers hg (g' := (ζ.val : G')) <| by
+    simpa only [orderOf_eq_card_of_forall_mem_zpowers hg, orderOf_dvd_iff_pow_eq_one,
+      ← Units.val_pow_eq_pow_val, Units.val_eq_one] using ζ.prop
+  left_inv φ := (MonoidHom.eq_iff_eq_on_generator hg _ φ).mpr <| by
+    simp only [IsUnit.unit_spec, monoidHomOfForallMemZpowers_apply_gen]
+  right_inv φ := Subtype.ext <| by
+    simp only [monoidHomOfForallMemZpowers_apply_gen, IsUnit.unit_of_val_units]
+  map_mul' x y := by
+    simp only [MonoidHom.mul_apply, MulMemClass.mk_mul_mk, Subtype.mk.injEq, Units.ext_iff,
+      IsUnit.unit_spec, Units.val_mul]
+
+/-- The group of group homomorphisms from a finite cyclic group `G` of order `n` into another
+group `G'` is (noncanonically) isomorphic to the group of `n`th roots of unity in `G'`. -/
+lemma monoidHom_mulEquiv_rootsOfUnity (G : Type*) [CommGroup G] [Finite G] [IsCyclic G]
+    (G' : Type*) [CommGroup G'] :
+    Nonempty <| (G →* G') ≃* rootsOfUnity (Nat.card G) G' := by
+  obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := G)
+  have : Fintype G := Fintype.ofFinite _
+  exact ⟨Nat.card_eq_fintype_card (α  := G) ▸ monoidHomMulEquivRootsOfUnityOfGenerator hg G'⟩
+
+end IsCyclic
+
+end cyclic

--- a/Mathlib/RingTheory/RootsOfUnity/EnoughRootsOfUnity.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/EnoughRootsOfUnity.lean
@@ -77,3 +77,18 @@ lemma natCard_rootsOfUnity (M : Type*) [CommMonoid M] (n : ℕ) [NeZero n]
     rw [← Units.eq_iff, Units.val_pow_eq_pow_val, IsUnit.unit_spec, h.pow_eq_one, Units.val_one]
 
 end HasEnoughRootsOfUnity
+
+section cyclic
+
+/-- The group of group homomorphims from a finite cyclic group `G` of order `n` into the
+group of units of a ring `M` with all roots of unity is isomorphic to `G` -/
+lemma monoidHom_equiv_self (G M : Type*) [CommGroup G] [Finite G]
+    [IsCyclic G] [CommMonoid M] [HasEnoughRootsOfUnity M (Nat.card G)] :
+    Nonempty ((G →* Mˣ) ≃* G) := by
+  have : Fintype G := Fintype.ofFinite G
+  have : NeZero (Nat.card G) := ⟨Nat.card_pos.ne'⟩
+  have hord := HasEnoughRootsOfUnity.natCard_rootsOfUnity M (Nat.card G)
+  let e := (IsCyclic.monoidHom_mulEquiv_rootsOfUnity G Mˣ).some
+  exact ⟨e.trans (rootsOfUnityUnitsMulEquiv M (Nat.card G)) |>.trans (mulEquivOfCyclicCardEq hord)⟩
+
+end cyclic

--- a/Mathlib/RingTheory/RootsOfUnity/EnoughRootsOfUnity.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/EnoughRootsOfUnity.lean
@@ -85,7 +85,6 @@ group of units of a ring `M` with all roots of unity is isomorphic to `G` -/
 lemma monoidHom_equiv_self (G M : Type*) [CommGroup G] [Finite G]
     [IsCyclic G] [CommMonoid M] [HasEnoughRootsOfUnity M (Nat.card G)] :
     Nonempty ((G →* Mˣ) ≃* G) := by
-  have : Fintype G := Fintype.ofFinite G
   have : NeZero (Nat.card G) := ⟨Nat.card_pos.ne'⟩
   have hord := HasEnoughRootsOfUnity.natCard_rootsOfUnity M (Nat.card G)
   let e := (IsCyclic.monoidHom_mulEquiv_rootsOfUnity G Mˣ).some

--- a/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -757,7 +757,7 @@ section cyclic
 then for each `a : G` with `a ≠ 1` there is a homomorphism `φ : G →* G'` such that `φ a ≠ 1`. -/
 lemma IsCyclic.exists_apply_ne_one {G G' : Type*} [CommGroup G] [IsCyclic G] [Finite G]
     [CommGroup G'] (hG' : ∃ ζ : G', IsPrimitiveRoot ζ (Nat.card G)) ⦃a : G⦄ (ha : a ≠ 1) :
-    ∃ φ  : G →* G', φ a ≠ 1 := by
+    ∃ φ : G →* G', φ a ≠ 1 := by
   let inst : Fintype G := Fintype.ofFinite _
   obtain ⟨ζ, hζ⟩ := hG'
   -- pick a generator `g` of `G`

--- a/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -750,3 +750,44 @@ theorem autToPow_spec [NeZero n] (f : S ≃ₐ[R] S) : μ ^ (hμ.autToPow R f : 
 end Automorphisms
 
 end IsPrimitiveRoot
+
+section cyclic
+
+/-- If `G` is cyclic of order `n` and `G'` contains a primitive `n`th root of unity,
+then for each `a : G` with `a ≠ 1` there is a homomorphism `φ : G →* G'` such that `φ a ≠ 1`. -/
+lemma IsCyclic.exists_apply_ne_one {G G' : Type*} [CommGroup G] [IsCyclic G] [Finite G]
+    [CommGroup G'] (hG' : ∃ ζ : G', IsPrimitiveRoot ζ (Nat.card G)) ⦃a : G⦄ (ha : a ≠ 1) :
+    ∃ φ  : G →* G', φ a ≠ 1 := by
+  let inst : Fintype G := Fintype.ofFinite _
+  obtain ⟨ζ, hζ⟩ := hG'
+  -- pick a generator `g` of `G`
+  obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := G)
+  have hζg : orderOf ζ ∣ orderOf g := by
+    rw [← hζ.eq_orderOf, orderOf_eq_card_of_forall_mem_zpowers hg, Nat.card_eq_fintype_card]
+  -- use the homomorphism `φ` given by `g ↦ ζ`
+  let φ := monoidHomOfForallMemZpowers hg hζg
+  have hφg : IsPrimitiveRoot (φ g) (Nat.card G) := by
+    rwa [monoidHomOfForallMemZpowers_apply_gen hg hζg]
+  use φ
+  contrapose! ha
+  specialize hg a
+  rw [← mem_powers_iff_mem_zpowers, Submonoid.mem_powers_iff] at hg
+  obtain ⟨k, hk⟩ := hg
+  rw [← hk, map_pow] at ha
+  obtain ⟨l, rfl⟩ := (hφg.pow_eq_one_iff_dvd k).mp ha
+  rw [← hk, pow_mul, Nat.card_eq_fintype_card, pow_card_eq_one, one_pow]
+
+/-- If `M` is a commutative group that contains a primitive `n`th root of unity
+and `a : ZMod n` is nonzero, then there exists a group homomorphism `φ` from the
+additive group `ZMod n` to the multiplicative group `Mˣ` such that `φ a ≠ 1`. -/
+lemma ZMod.exists_monoidHom_apply_ne_one {M : Type*} [CommMonoid M] {n : ℕ} [NeZero n]
+    (hG : ∃ ζ : M, IsPrimitiveRoot ζ n) {a : ZMod n} (ha : a ≠ 0) :
+    ∃ φ : Multiplicative (ZMod n) →* Mˣ, φ (Multiplicative.ofAdd a) ≠ 1 := by
+  obtain ⟨ζ, hζ⟩ := hG
+  have hc : n = Nat.card (Multiplicative (ZMod n)) := by
+    simp only [Nat.card_eq_fintype_card, Fintype.card_multiplicative, card]
+  exact IsCyclic.exists_apply_ne_one
+    (hc ▸ ⟨hζ.toRootsOfUnity.val, IsPrimitiveRoot.coe_units_iff.mp hζ⟩) <|
+    by simp only [ne_eq, ofAdd_eq_one, ha, not_false_eq_true]
+
+end cyclic


### PR DESCRIPTION
This PR adds orthogonality results for cyclic groups (point 1 in [this message on Zulip](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/Orthogonality.20of.20Dirichlet.20characters/near/480747063)).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
