### PR TITLE
[Merged by Bors] - feat(Analysis/Normed/Ultra): Normed algebra preserves ultrametricity

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1296,6 +1296,7 @@ import Mathlib.Analysis.Normed.Algebra.Norm
 import Mathlib.Analysis.Normed.Algebra.QuaternionExponential
 import Mathlib.Analysis.Normed.Algebra.Spectrum
 import Mathlib.Analysis.Normed.Algebra.TrivSqZeroExt
+import Mathlib.Analysis.Normed.Algebra.Ultra
 import Mathlib.Analysis.Normed.Algebra.Unitization
 import Mathlib.Analysis.Normed.Algebra.UnitizationL1
 import Mathlib.Analysis.Normed.Field.Basic

--- a/Mathlib/Analysis/Normed/Algebra/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Ultra.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2024 Jiedong Jiang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jiedong Jiang
+-/
+
+import Mathlib.Analysis.Normed.Field.Ultra
+import Mathlib.Analysis.Normed.Module.Basic
+
+/-!
+# Normed algebra preserves ultrametricity
+
+This file contains the proof that a normed division ring over an ultrametric field is ultrametric.
+-/
+
+theorem IsUltrametricDist.of_normedAlgebra (K : Type*) {L : Type*} [NormedField K]
+    [NormedDivisionRing L] [NormedAlgebra K L] [h : IsUltrametricDist K] : IsUltrametricDist L := by
+  rw [isUltrametricDist_iff_forall_norm_natCast_le_one] at h ⊢
+  exact fun n => (algebraMap.coe_natCast (R := K) (A := L) n) ▸ norm_algebraMap' L (n : K) ▸ h n

--- a/Mathlib/Analysis/Normed/Algebra/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Ultra.lean
@@ -13,7 +13,35 @@ import Mathlib.Analysis.Normed.Module.Basic
 This file contains the proof that a normed division ring over an ultrametric field is ultrametric.
 -/
 
-theorem IsUltrametricDist.of_normedAlgebra (K : Type*) {L : Type*} [NormedField K]
-    [NormedDivisionRing L] [NormedAlgebra K L] [h : IsUltrametricDist K] : IsUltrametricDist L := by
+variable {K L : Type*} [NormedField K]
+
+variable (L) in
+/--
+The other direction of `IsUltrametricDist.of_normedAlgebra`.
+Let `K` be a normed field. If a seminormed ring `L` is a normed `K`-algebra, and `‖1‖ = 1` in `L`,
+then `K` is ultrametric (i.e. the norm on `L` is nonarchimedean) if `F` is.
+This can be further generalized to the case where `‖1‖ ≠ 0` in `L`.
+-/
+theorem IsUltrametricDist.of_normedAlgebra' [SeminormedRing L] [NormOneClass L] [NormedAlgebra K L]
+    [h : IsUltrametricDist L] : IsUltrametricDist K :=
+  ⟨fun x y z => by
+    simpa using h.dist_triangle_max (algebraMap K L x) (algebraMap K L y) (algebraMap K L z)⟩
+
+variable (K) in
+/--
+Let `K` be a normed field. If a normed division ring `L` is a normed `K`-algebra,
+then `L` is ultrametric (i.e. the norm on `L` is nonarchimedean) if `K` is.
+-/
+theorem IsUltrametricDist.of_normedAlgebra [NormedDivisionRing L] [NormedAlgebra K L]
+    [h : IsUltrametricDist K] : IsUltrametricDist L := by
   rw [isUltrametricDist_iff_forall_norm_natCast_le_one] at h ⊢
   exact fun n => (algebraMap.coe_natCast (R := K) (A := L) n) ▸ norm_algebraMap' L (n : K) ▸ h n
+
+variable (K L) in
+/--
+Let `K` be a normed field. If a normed division ring `L` is a normed `K`-algebra,
+then `L` is ultrametric (i.e. the norm on `L` is nonarchimedean) if and only if `K` is.
+-/
+theorem IsUltrametricDist.normedAlgebra_iff [NormedDivisionRing L] [NormedAlgebra K L] :
+    IsUltrametricDist L ↔ IsUltrametricDist K :=
+  ⟨fun _ => IsUltrametricDist.of_normedAlgebra' L, fun _ => IsUltrametricDist.of_normedAlgebra K⟩

--- a/Mathlib/Analysis/Normed/Field/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Field/Ultra.lean
@@ -4,11 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yakov Pechersky
 -/
 import Mathlib.Analysis.Normed.Field.Basic
-import Mathlib.Analysis.Normed.Group.Ultra
+import Mathlib.Analysis.Normed.Ring.Ultra
 import Mathlib.Data.Nat.Choose.Sum
 
 /-!
-## Sufficient conditions to have an ultrametric norm on a division ring
+## Conditions to have an ultrametric norm on a division ring
 
 This file provides ways of constructing an instance of `IsUltrametricDist` based on
 facts about the existing norm.
@@ -17,6 +17,9 @@ facts about the existing norm.
 
 * `isUltrametricDist_of_forall_norm_natCast_le_one`: a norm in a division ring is ultrametric
   if the norm of the image of a natural is less than or equal to one
+
+* `isUltrametricDist_iff_forall_norm_natCast_le_one`: a norm in a division ring is ultrametric
+  if and only if the norm of the image of a natural is less than or equal to one
 
 ## Implementation details
 
@@ -130,3 +133,8 @@ lemma isUltrametricDist_of_forall_norm_natCast_le_one
 end sufficient
 
 end IsUltrametricDist
+
+theorem isUltrametricDist_iff_forall_norm_natCast_le_one {R : Type*}
+    [NormedDivisionRing R] : IsUltrametricDist R ↔ ∀ n : ℕ, ‖(n : R)‖ ≤ 1 :=
+  ⟨fun _ => IsUltrametricDist.norm_natCast_le_one R,
+      IsUltrametricDist.isUltrametricDist_of_forall_norm_natCast_le_one⟩

--- a/Mathlib/Analysis/Normed/Group/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Group/Ultra.lean
@@ -55,6 +55,17 @@ lemma isUltrametricDist_of_isNonarchimedean_norm {S' : Type*} [SeminormedAddGrou
     (h : IsNonarchimedean (norm : S' → ℝ)) : IsUltrametricDist S' :=
   isUltrametricDist_of_forall_norm_add_le_max_norm h
 
+lemma isNonarchimedean_norm {R} [SeminormedAddCommGroup R] [IsUltrametricDist R] :
+    IsNonarchimedean (‖·‖ : R → ℝ) := by
+  intro x y
+  convert dist_triangle_max 0 x (x + y) using 1
+  · simp
+  · congr <;> simp [SeminormedAddGroup.dist_eq]
+
+lemma isUltrametricDist_iff_isNonarchimedean_norm {R} [SeminormedAddCommGroup R] :
+    IsUltrametricDist R ↔ IsNonarchimedean (‖·‖ : R → ℝ) :=
+  ⟨fun h => h.isNonarchimedean_norm, IsUltrametricDist.isUltrametricDist_of_isNonarchimedean_norm⟩
+
 @[to_additive]
 lemma nnnorm_mul_le_max (x y : S) :
     ‖x * y‖₊ ≤ max ‖x‖₊ ‖y‖₊ :=
@@ -68,6 +79,17 @@ lemma isUltrametricDist_of_forall_nnnorm_mul_le_max_nnnorm
 lemma isUltrametricDist_of_isNonarchimedean_nnnorm {S' : Type*} [SeminormedAddGroup S']
     (h : IsNonarchimedean ((↑) ∘ (nnnorm : S' → ℝ≥0))) : IsUltrametricDist S' :=
   isUltrametricDist_of_forall_nnnorm_add_le_max_nnnorm h
+
+lemma isNonarchimedean_nnnorm {R} [SeminormedAddCommGroup R] [IsUltrametricDist R] :
+    IsNonarchimedean (‖·‖₊ : R → ℝ) := by
+  intro x y
+  convert dist_triangle_max 0 x (x + y) using 1
+  · simp
+  · congr <;> simp [SeminormedAddGroup.dist_eq]
+
+lemma isUltrametricDist_iff_isNonarchimedean_nnnorm {R} [SeminormedAddCommGroup R] :
+    IsUltrametricDist R ↔ IsNonarchimedean (‖·‖₊ : R → ℝ) :=
+  ⟨fun h => h.isNonarchimedean_norm, IsUltrametricDist.isUltrametricDist_of_isNonarchimedean_norm⟩
 
 /-- All triangles are isosceles in an ultrametric normed group. -/
 @[to_additive "All triangles are isosceles in an ultrametric normed additive group."]

--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -289,13 +289,25 @@ theorem norm_algebraMap (x : 𝕜) : ‖algebraMap 𝕜 𝕜' x‖ = ‖x‖ * �
 theorem nnnorm_algebraMap (x : 𝕜) : ‖algebraMap 𝕜 𝕜' x‖₊ = ‖x‖₊ * ‖(1 : 𝕜')‖₊ :=
   Subtype.ext <| norm_algebraMap 𝕜' x
 
+theorem dist_algebraMap (x y : 𝕜) :
+    (dist (algebraMap 𝕜 𝕜' x) (algebraMap 𝕜 𝕜' y)) = dist x y * ‖(1 : 𝕜')‖ := by
+  simp only [dist_eq_norm, ← map_sub, norm_algebraMap]
+
+/-- This is a simpler version of `norm_algebraMap` when `‖1‖ = 1` in `𝕜'`.-/
 @[simp]
 theorem norm_algebraMap' [NormOneClass 𝕜'] (x : 𝕜) : ‖algebraMap 𝕜 𝕜' x‖ = ‖x‖ := by
   rw [norm_algebraMap, norm_one, mul_one]
 
+/-- This is a simpler version of `nnnorm_algebraMap` when `‖1‖ = 1` in `𝕜'`.-/
 @[simp]
 theorem nnnorm_algebraMap' [NormOneClass 𝕜'] (x : 𝕜) : ‖algebraMap 𝕜 𝕜' x‖₊ = ‖x‖₊ :=
   Subtype.ext <| norm_algebraMap' _ _
+
+/-- This is a simpler version of `dist_algebraMap` when `‖1‖ = 1` in `𝕜'`.-/
+@[simp]
+theorem dist_algebraMap' [NormOneClass 𝕜'] (x y : 𝕜) :
+    (dist (algebraMap 𝕜 𝕜' x) (algebraMap 𝕜 𝕜' y)) = dist x y := by
+  simp only [dist_eq_norm, ← map_sub, norm_algebraMap']
 
 section NNReal
 


### PR DESCRIPTION
We show the result "Let `K` be a normed field. If a normed division ring `L` is a normed `K`-algebra, then `L` is ultrametric (i.e. the norm on `L` is nonarchimedean) if and only if `K` is." We also add the lemma of `IsNonarchimedean` is equivalent to `IsUltrametricDist`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
