### PR TITLE
[Merged by Bors] - feat: adapt tactics to use `optConfig` instead of `(config)?`

### DIFF
--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -512,7 +512,7 @@ which rewrites all group expressions into a normal form.
 * `abel_nf` works as both a tactic and a conv tactic.
   In tactic mode, `abel_nf at h` can be used to rewrite in a hypothesis.
 -/
-elab (name := abelNF) "abel_nf" tk:"!"? cfg:(config ?) loc:(location)? : tactic => do
+elab (name := abelNF) "abel_nf" tk:"!"? cfg:optConfig loc:(location)? : tactic => do
   let mut cfg ← elabAbelNFConfig cfg
   if tk.isSome then cfg := { cfg with red := .default }
   let loc := (loc.map expandLocation).getD (.targets #[] true)
@@ -520,20 +520,20 @@ elab (name := abelNF) "abel_nf" tk:"!"? cfg:(config ?) loc:(location)? : tactic 
   withLocation loc (abelNFLocalDecl s cfg) (abelNFTarget s cfg)
     fun _ ↦ throwError "abel_nf made no progress"
 
-@[inherit_doc abelNF] macro "abel_nf!" cfg:(config)? loc:(location)? : tactic =>
-  `(tactic| abel_nf ! $(cfg)? $(loc)?)
+@[inherit_doc abelNF] macro "abel_nf!" cfg:optConfig loc:(location)? : tactic =>
+  `(tactic| abel_nf ! $cfg:optConfig $(loc)?)
 
-@[inherit_doc abelNF] syntax (name := abelNFConv) "abel_nf" "!"? (config)? : conv
+@[inherit_doc abelNF] syntax (name := abelNFConv) "abel_nf" "!"? optConfig : conv
 
 /-- Elaborator for the `abel_nf` tactic. -/
 @[tactic abelNFConv] def elabAbelNFConv : Tactic := fun stx ↦ match stx with
-  | `(conv| abel_nf $[!%$tk]? $(_cfg)?) => withMainContext do
-    let mut cfg ← elabAbelNFConfig stx[2]
+  | `(conv| abel_nf $[!%$tk]? $cfg:optConfig) => withMainContext do
+    let mut cfg ← elabAbelNFConfig cfg
     if tk.isSome then cfg := { cfg with red := .default }
     Conv.applySimpResult (← abelNFCore (← IO.mkRef {}) cfg (← instantiateMVars (← Conv.getLhs)))
   | _ => Elab.throwUnsupportedSyntax
 
-@[inherit_doc abelNF] macro "abel_nf!" cfg:(config)? : conv => `(conv| abel_nf ! $(cfg)?)
+@[inherit_doc abelNF] macro "abel_nf!" cfg:optConfig : conv => `(conv| abel_nf ! $cfg:optConfig)
 
 /--
 Tactic for evaluating expressions in abelian groups.

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -241,11 +241,11 @@ tactic searches through the local context for `RingHom` properties that can be c
 `Algebra` properties. The macro `algebraize_only` calls
 `algebraize (config := {properties := false})`,
 so in other words it only adds `Algebra` and `IsScalarTower` instances. -/
-syntax "algebraize" (ppSpace config)? (ppSpace algebraizeTermSeq)? : tactic
+syntax "algebraize " optConfig (algebraizeTermSeq)? : tactic
 
 elab_rules : tactic
-  | `(tactic| algebraize $[$config]? $args) => withMainContext do
-    let cfg ← elabAlgebraizeConfig (mkOptionalNode config)
+  | `(tactic| algebraize $cfg:optConfig $args) => withMainContext do
+    let cfg ← elabAlgebraizeConfig cfg
     let t ← match args with
     | `(algebraizeTermSeq| [$rs,*]) => rs.getElems.mapM fun i => Term.elabTerm i none
     | _ =>
@@ -278,9 +278,7 @@ but does not try to add any instances about any properties tagged with
 syntax "algebraize_only" (ppSpace algebraizeTermSeq)? : tactic
 
 macro_rules
-  | `(tactic| algebraize_only $args) =>
-    `(tactic| algebraize (config := {properties := false}) $args)
-  | `(tactic| algebraize_only) =>
-    `(tactic| algebraize (config := {properties := false}))
+  | `(tactic| algebraize_only $[$args]?) =>
+    `(tactic| algebraize -properties $[$args]?)
 
 end Mathlib.Tactic

--- a/Mathlib/Tactic/CC.lean
+++ b/Mathlib/Tactic/CC.lean
@@ -251,8 +251,8 @@ example (f : ℕ → ℕ) (x : ℕ)
     f x = x := by
   cc
 ``` -/
-elab (name := _root_.Mathlib.Tactic.cc) "cc" cfg:(config)? : tactic => do
-  let cfg ← elabCCConfig (mkOptionalNode cfg)
+elab (name := _root_.Mathlib.Tactic.cc) "cc" cfg:optConfig : tactic => do
+  let cfg ← elabCCConfig cfg
   withMainContext <| liftMetaFinishingTactic (·.cc cfg)
 
 end Mathlib.Tactic.CC

--- a/Mathlib/Tactic/CongrExclamation.lean
+++ b/Mathlib/Tactic/CongrExclamation.lean
@@ -733,12 +733,12 @@ This is somewhat like `congr`.
 
 See `Congr!.Config` for all options.
 -/
-syntax (name := congr!) "congr!" (Parser.Tactic.config)? (ppSpace num)?
+syntax (name := congr!) "congr!" Parser.Tactic.optConfig (ppSpace num)?
   (" with" (ppSpace colGt rintroPat)*)? : tactic
 
 elab_rules : tactic
-| `(tactic| congr! $[$cfg:config]? $[$n]? $[with $ps?*]?) => do
-  let config ← elabConfig (mkOptionalNode cfg)
+| `(tactic| congr! $cfg:optConfig $[$n]? $[with $ps?*]?) => do
+  let config ← elabConfig cfg
   let patterns := (Lean.Elab.Tactic.RCases.expandRIntroPats (ps?.getD #[])).toList
   liftMetaTactic fun g ↦
     let depth := n.map (·.getNat)

--- a/Mathlib/Tactic/Continuity.lean
+++ b/Mathlib/Tactic/Continuity.lean
@@ -34,4 +34,4 @@ macro "continuity?" : tactic =>
 
 -- Todo: implement `continuity!` and `continuity!?` and add configuration, original
 -- syntax was (same for the missing `continuity` variants):
--- syntax (name := continuity) "continuity" (config)? : tactic
+-- syntax (name := continuity) "continuity" optConfig : tactic

--- a/Mathlib/Tactic/Convert.lean
+++ b/Mathlib/Tactic/Convert.lean
@@ -117,7 +117,7 @@ convert (config := {transparency := .default}) h
 ```
 These are passed to `congr!`. See `Congr!.Config` for options.
 -/
-syntax (name := convert) "convert" (Parser.Tactic.config)? " ←"? ppSpace term (" using " num)?
+syntax (name := convert) "convert" Parser.Tactic.optConfig " ←"? ppSpace term (" using " num)?
   (" with" (ppSpace colGt rintroPat)*)? : tactic
 
 /--
@@ -137,9 +137,9 @@ def elabTermForConvert (term : Syntax) (expectedType? : Option Expr) :
       return t
 
 elab_rules : tactic
-| `(tactic| convert $[$cfg:config]? $[←%$sym]? $term $[using $n]? $[with $ps?*]?) =>
+| `(tactic| convert $cfg:optConfig $[←%$sym]? $term $[using $n]? $[with $ps?*]?) =>
   withMainContext do
-    let config ← Congr!.elabConfig (mkOptionalNode cfg)
+    let config ← Congr!.elabConfig cfg
     let patterns := (Lean.Elab.Tactic.RCases.expandRIntroPats (ps?.getD #[])).toList
     let expectedType ← mkFreshExprMVar (mkSort (← getLevel (← getMainTarget)))
     let (e, gs) ← elabTermForConvert term expectedType
@@ -174,14 +174,14 @@ the syntax for `convert_to` is the same as for `convert`, and it has variations 
 Note that `convert_to ty at h` may leave a copy of `h` if a later local hypotheses or the target
 depends on it, just like in `rw` or `simp`.
 -/
-syntax (name := convertTo) "convert_to" (Parser.Tactic.config)? " ←"? ppSpace term (" using " num)?
+syntax (name := convertTo) "convert_to" Parser.Tactic.optConfig " ←"? ppSpace term (" using " num)?
   (" with" (ppSpace colGt rintroPat)*)? (Parser.Tactic.location)? : tactic
 
 elab_rules : tactic
-| `(tactic| convert_to $[$cfg:config]? $[←%$sym]? $newType $[using $n]?
+| `(tactic| convert_to $cfg:optConfig $[←%$sym]? $newType $[using $n]?
     $[with $ps?*]? $[$loc?:location]?) => do
   let n : ℕ := n |>.map (·.getNat) |>.getD 1
-  let config ← Congr!.elabConfig (mkOptionalNode cfg)
+  let config ← Congr!.elabConfig cfg
   let patterns := (Lean.Elab.Tactic.RCases.expandRIntroPats (ps?.getD #[])).toList
   withLocation (expandOptLocation (mkOptionalNode loc?))
     (atLocal := fun fvarId ↦ do

--- a/Mathlib/Tactic/Convert.lean
+++ b/Mathlib/Tactic/Convert.lean
@@ -117,7 +117,7 @@ convert (config := {transparency := .default}) h
 ```
 These are passed to `congr!`. See `Congr!.Config` for options.
 -/
-syntax (name := convert) "convert" Parser.Tactic.optConfig " ←"? ppSpace term (" using " num)?
+syntax (name := convert) "convert" (Parser.Tactic.config)? " ←"? ppSpace term (" using " num)?
   (" with" (ppSpace colGt rintroPat)*)? : tactic
 
 /--
@@ -137,9 +137,9 @@ def elabTermForConvert (term : Syntax) (expectedType? : Option Expr) :
       return t
 
 elab_rules : tactic
-| `(tactic| convert $cfg:optConfig $[←%$sym]? $term $[using $n]? $[with $ps?*]?) =>
+| `(tactic| convert $[$cfg:config]? $[←%$sym]? $term $[using $n]? $[with $ps?*]?) =>
   withMainContext do
-    let config ← Congr!.elabConfig cfg
+    let config ← Congr!.elabConfig (mkOptionalNode cfg)
     let patterns := (Lean.Elab.Tactic.RCases.expandRIntroPats (ps?.getD #[])).toList
     let expectedType ← mkFreshExprMVar (mkSort (← getLevel (← getMainTarget)))
     let (e, gs) ← elabTermForConvert term expectedType
@@ -174,14 +174,14 @@ the syntax for `convert_to` is the same as for `convert`, and it has variations 
 Note that `convert_to ty at h` may leave a copy of `h` if a later local hypotheses or the target
 depends on it, just like in `rw` or `simp`.
 -/
-syntax (name := convertTo) "convert_to" Parser.Tactic.optConfig " ←"? ppSpace term (" using " num)?
+syntax (name := convertTo) "convert_to" (Parser.Tactic.config)? " ←"? ppSpace term (" using " num)?
   (" with" (ppSpace colGt rintroPat)*)? (Parser.Tactic.location)? : tactic
 
 elab_rules : tactic
-| `(tactic| convert_to $cfg:optConfig $[←%$sym]? $newType $[using $n]?
+| `(tactic| convert_to $[$cfg:config]? $[←%$sym]? $newType $[using $n]?
     $[with $ps?*]? $[$loc?:location]?) => do
   let n : ℕ := n |>.map (·.getNat) |>.getD 1
-  let config ← Congr!.elabConfig cfg
+  let config ← Congr!.elabConfig (mkOptionalNode cfg)
   let patterns := (Lean.Elab.Tactic.RCases.expandRIntroPats (ps?.getD #[])).toList
   withLocation (expandOptLocation (mkOptionalNode loc?))
     (atLocal := fun fvarId ↦ do

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -145,13 +145,13 @@ that have numerals in denominators.
 The tactics are not related: `cancel_denoms` will only handle numeric denominators, and will try to
 entirely remove (numeric) division from the expression by multiplying by a factor.
 -/
-syntax (name := fieldSimp) "field_simp" (config)? (discharger)? (&" only")?
+syntax (name := fieldSimp) "field_simp" optConfig (discharger)? (&" only")?
   (simpArgs)? (location)? : tactic
 
 elab_rules : tactic
-| `(tactic| field_simp $[$cfg:config]? $[(discharger := $dis)]? $[only%$only?]?
+| `(tactic| field_simp $cfg:optConfig $[(discharger := $dis)]? $[only%$only?]?
     $[$sa:simpArgs]? $[$loc:location]?) => withMainContext do
-  let cfg ← elabSimpConfig (mkOptionalNode cfg) .simp
+  let cfg ← elabSimpConfig cfg .simp
   -- The `field_simp` discharger relies on recursively calling the discharger.
   -- Prior to https://github.com/leanprover/lean4/pull/3523,
   -- the maxDischargeDepth wasn't actually being checked: now we have to set it higher.

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -21,7 +21,7 @@ declare_config_elab elabFunPropConfig FunProp.Config
 
 /-- Tactic to prove function properties -/
 syntax (name := funPropTacStx)
-  "fun_prop" (config)? (discharger)? (" [" withoutPosition(ident,*,?) "]")? : tactic
+  "fun_prop" optConfig (discharger)? (" [" withoutPosition(ident,*,?) "]")? : tactic
 
 private def emptyDischarge : Expr → MetaM (Option Expr) :=
   fun e =>
@@ -32,7 +32,7 @@ private def emptyDischarge : Expr → MetaM (Option Expr) :=
 /-- Tactic to prove function properties -/
 @[tactic funPropTacStx]
 def funPropTac : Tactic
-  | `(tactic| fun_prop $[$cfg]? $[$d]? $[[$names,*]]?) => do
+  | `(tactic| fun_prop $cfg:optConfig $[$d]? $[[$names,*]]?) => do
 
     let goal ← getMainGoal
     goal.withContext do
@@ -49,7 +49,6 @@ def funPropTac : Tactic
             else ""
           throwError "`{← ppExpr type}` is not a `fun_prop` goal!{hint}"
 
-      let cfg := cfg.map (fun c => mkNullNode #[c.raw]) |>.getD (mkNullNode #[])
       let cfg ← elabFunPropConfig cfg
 
       let disch ← show MetaM (Expr → MetaM (Option Expr)) from do

--- a/Mathlib/Tactic/GeneralizeProofs.lean
+++ b/Mathlib/Tactic/GeneralizeProofs.lean
@@ -501,9 +501,9 @@ example : List.nthLe [1, 2] 1 (by simp) = 2 := by
   -- ⊢ [1, 2].nthLe 1 h = 2
 ```
 -/
-elab (name := generalizeProofsElab) "generalize_proofs" config?:(Parser.Tactic.config)?
+elab (name := generalizeProofsElab) "generalize_proofs" config:Parser.Tactic.optConfig
     hs:(ppSpace colGt binderIdent)* loc?:(location)? : tactic => withMainContext do
-  let config ← GeneralizeProofs.elabConfig (mkOptionalNode config?)
+  let config ← GeneralizeProofs.elabConfig config
   let (fvars, target) ←
     match expandOptLocation (Lean.mkOptionalNode loc?) with
     | .wildcard => pure ((← getLCtx).getFVarIds, true)

--- a/Mathlib/Tactic/LiftLets.lean
+++ b/Mathlib/Tactic/LiftLets.lean
@@ -117,10 +117,10 @@ example : (let x := 1; x) = 1 := by
 
 During the lifting process, let bindings are merged if they have the same type and value.
 -/
-syntax (name := lift_lets) "lift_lets" (Parser.Tactic.config)? (ppSpace location)? : tactic
+syntax (name := lift_lets) "lift_lets" optConfig (ppSpace location)? : tactic
 
 elab_rules : tactic
-  | `(tactic| lift_lets $[$cfg:config]? $[$loc:location]?) => do
+  | `(tactic| lift_lets $cfg:optConfig $[$loc:location]?) => do
     let config ← elabConfig (mkOptionalNode cfg)
     withLocation (expandOptLocation (Lean.mkOptionalNode loc))
       (atLocal := fun h ↦ liftMetaTactic1 fun mvarId ↦ do

--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -367,7 +367,7 @@ end Linarith
 open Parser Tactic Syntax
 
 /-- Syntax for the arguments of `linarith`, after the optional `!`. -/
-syntax linarithArgsRest := (config)? (&" only")? (" [" term,* "]")?
+syntax linarithArgsRest := optConfig (&" only")? (" [" term,* "]")?
 
 /--
 `linarith` attempts to find a contradiction between hypotheses that are linear (in)equalities.
@@ -461,9 +461,9 @@ Allow elaboration of `LinarithConfig` arguments to tactics.
 declare_config_elab elabLinarithConfig Linarith.LinarithConfig
 
 elab_rules : tactic
-  | `(tactic| linarith $[!%$bang]? $[$cfg]? $[only%$o]? $[[$args,*]]?) => withMainContext do
+  | `(tactic| linarith $[!%$bang]? $cfg:optConfig $[only%$o]? $[[$args,*]]?) => withMainContext do
     let args ← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg `linarith)
-    let cfg := (← elabLinarithConfig (mkOptionalNode cfg)).updateReducibility bang.isSome
+    let cfg := (← elabLinarithConfig cfg).updateReducibility bang.isSome
     commitIfNoEx do liftMetaFinishingTactic <| Linarith.linarith o.isSome args.toList cfg
 
 -- TODO restore this when `add_tactic_doc` is ported
@@ -476,9 +476,9 @@ elab_rules : tactic
 open Linarith
 
 elab_rules : tactic
-  | `(tactic| nlinarith $[!%$bang]? $[$cfg]? $[only%$o]? $[[$args,*]]?) => withMainContext do
+  | `(tactic| nlinarith $[!%$bang]? $cfg:optConfig $[only%$o]? $[[$args,*]]?) => withMainContext do
     let args ← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg `nlinarith)
-    let cfg := (← elabLinarithConfig (mkOptionalNode cfg)).updateReducibility bang.isSome
+    let cfg := (← elabLinarithConfig cfg).updateReducibility bang.isSome
     let cfg := { cfg with
       preprocessors := cfg.preprocessors.concat nlinarithExtras }
     commitIfNoEx do liftMetaFinishingTactic <| Linarith.linarith o.isSome args.toList cfg

--- a/Mathlib/Tactic/Measurability.lean
+++ b/Mathlib/Tactic/Measurability.lean
@@ -29,7 +29,7 @@ macro "measurability" : attr =>
 The tactic `measurability` solves goals of the form `Measurable f`, `AEMeasurable f`,
 `StronglyMeasurable f`, `AEStronglyMeasurable f μ`, or `MeasurableSet s` by applying lemmas tagged
 with the `measurability` user attribute. -/
-macro "measurability" _cfg:optConfig : tactic =>
+macro "measurability" : tactic =>
   `(tactic| aesop (config := { terminal := true })
     (rule_sets := [$(Lean.mkIdent `Measurable):ident]))
 
@@ -38,11 +38,11 @@ The tactic `measurability?` solves goals of the form `Measurable f`, `AEMeasurab
 `StronglyMeasurable f`, `AEStronglyMeasurable f μ`, or `MeasurableSet s` by applying lemmas tagged
 with the `measurability` user attribute, and suggests a faster proof script that can be substituted
 for the tactic call in case of success. -/
-macro "measurability?" _cfg:optConfig : tactic =>
+macro "measurability?" : tactic =>
   `(tactic| aesop? (config := { terminal := true })
     (rule_sets := [$(Lean.mkIdent `Measurable):ident]))
 
 -- Todo: implement `measurability!` and `measurability!?` and add configuration,
 -- original syntax was (same for the missing `measurability` variants):
-syntax (name := measurability!) "measurability!" optConfig : tactic
-syntax (name := measurability!?) "measurability!?" optConfig : tactic
+syntax (name := measurability!) "measurability!" : tactic
+syntax (name := measurability!?) "measurability!?" : tactic

--- a/Mathlib/Tactic/Measurability.lean
+++ b/Mathlib/Tactic/Measurability.lean
@@ -12,7 +12,7 @@ import Mathlib.Algebra.Group.Defs
 
 We define the `measurability` tactic using `aesop`. -/
 
-open Lean.Parser.Tactic (config)
+open Lean.Parser.Tactic (optConfig)
 
 attribute [aesop (rule_sets := [Measurable]) unfold norm] Function.comp
 -- FIXME: `npowRec` is an internal implementation detail,
@@ -29,7 +29,7 @@ macro "measurability" : attr =>
 The tactic `measurability` solves goals of the form `Measurable f`, `AEMeasurable f`,
 `StronglyMeasurable f`, `AEStronglyMeasurable f μ`, or `MeasurableSet s` by applying lemmas tagged
 with the `measurability` user attribute. -/
-macro "measurability" (config)? : tactic =>
+macro "measurability" _cfg:optConfig : tactic =>
   `(tactic| aesop (config := { terminal := true })
     (rule_sets := [$(Lean.mkIdent `Measurable):ident]))
 
@@ -38,11 +38,11 @@ The tactic `measurability?` solves goals of the form `Measurable f`, `AEMeasurab
 `StronglyMeasurable f`, `AEStronglyMeasurable f μ`, or `MeasurableSet s` by applying lemmas tagged
 with the `measurability` user attribute, and suggests a faster proof script that can be substituted
 for the tactic call in case of success. -/
-macro "measurability?" (config)? : tactic =>
+macro "measurability?" _cfg:optConfig : tactic =>
   `(tactic| aesop? (config := { terminal := true })
     (rule_sets := [$(Lean.mkIdent `Measurable):ident]))
 
 -- Todo: implement `measurability!` and `measurability!?` and add configuration,
 -- original syntax was (same for the missing `measurability` variants):
-syntax (name := measurability!) "measurability!" (config)? : tactic
-syntax (name := measurability!?) "measurability!?" (config)? : tactic
+syntax (name := measurability!) "measurability!" optConfig : tactic
+syntax (name := measurability!?) "measurability!?" optConfig : tactic

--- a/Mathlib/Tactic/Monotonicity/Basic.lean
+++ b/Mathlib/Tactic/Monotonicity/Basic.lean
@@ -47,11 +47,10 @@ elab_rules : tactic
   if let some h := h then throwErrorAt h (msg "'left'/'right'/'both'")
   if let some w := w then throwErrorAt w (msg "'with'")
   if let some u := u then throwErrorAt u (msg "'using'")
-  let cfg := {
+  let cfg := { { : Meta.SolveByElim.ApplyRulesConfig } with
     backtracking := false
     transparency := .reducible
-    exfalso := false
-  }
+    exfalso := false }
   liftMetaTactic fun g => do processSyntax cfg false false [] [] #[mkIdent `mono] [g]
 
 end Monotonicity

--- a/Mathlib/Tactic/Monotonicity/Basic.lean
+++ b/Mathlib/Tactic/Monotonicity/Basic.lean
@@ -47,11 +47,11 @@ elab_rules : tactic
   if let some h := h then throwErrorAt h (msg "'left'/'right'/'both'")
   if let some w := w then throwErrorAt w (msg "'with'")
   if let some u := u then throwErrorAt u (msg "'using'")
-  let cfg ← elabApplyRulesConfig <| mkNullNode #[]
-  let cfg := { cfg with
+  let cfg := {
     backtracking := false
     transparency := .reducible
-    exfalso := false }
+    exfalso := false
+  }
   liftMetaTactic fun g => do processSyntax cfg false false [] [] #[mkIdent `mono] [g]
 
 end Monotonicity

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -315,7 +315,7 @@ and can prove goals of the form `A = B`, `A ≠ B`, `A < B` and `A ≤ B`, where
 numerical expressions. It also has a relatively simple primality prover.
 -/
 elab (name := normNum)
-    "norm_num" cfg:(config ?) only:&" only"? args:(simpArgs ?) loc:(location ?) : tactic =>
+    "norm_num" cfg:optConfig only:&" only"? args:(simpArgs ?) loc:(location ?) : tactic =>
   elabNormNum cfg args loc (simpOnly := only.isSome) (useSimp := true)
 
 /-- Basic version of `norm_num` that does not call `simp`. -/
@@ -332,7 +332,7 @@ open Lean Elab Tactic
   Conv.applySimpResult (← deriveSimp ctx (← instantiateMVars (← Conv.getLhs)) (useSimp := false))
 
 @[inherit_doc normNum] syntax (name := normNumConv)
-    "norm_num" (config)? &" only"? (simpArgs)? : conv
+    "norm_num" optConfig &" only"? (simpArgs)? : conv
 
 /-- Elaborator for `norm_num` conv tactic. -/
 @[tactic normNumConv] def elabNormNumConv : Tactic := fun stx ↦ withMainContext do
@@ -355,8 +355,8 @@ Unlike `norm_num`, this command does not fail when no simplifications are made.
 
 `#norm_num` understands local variables, so you can use them to introduce parameters.
 -/
-macro (name := normNumCmd) "#norm_num" cfg:(config)? o:(&" only")?
+macro (name := normNumCmd) "#norm_num" cfg:optConfig o:(&" only")?
     args:(Parser.Tactic.simpArgs)? " :"? ppSpace e:term : command =>
-  `(command| #conv norm_num $(cfg)? $[only%$o]? $(args)? => $e)
+  `(command| #conv norm_num $cfg:optConfig $[only%$o]? $(args)? => $e)
 
 end Mathlib.Tactic

--- a/Mathlib/Tactic/Tauto.lean
+++ b/Mathlib/Tactic/Tauto.lean
@@ -214,10 +214,10 @@ The Lean 3 version of this tactic by default attempted to avoid classical reason
 where possible. This Lean 4 version makes no such attempt. The `itauto` tactic
 is designed for that purpose.
 -/
-syntax (name := tauto) "tauto" (config)? : tactic
+syntax (name := tauto) "tauto" optConfig : tactic
 
-elab_rules : tactic | `(tactic| tauto $[$cfg:config]?) => do
-  let _cfg ← elabConfig (mkOptionalNode cfg)
+elab_rules : tactic | `(tactic| tauto $cfg:optConfig) => do
+  let _cfg ← elabConfig cfg
   tautology
 
 end Mathlib.Tactic.Tauto


### PR DESCRIPTION
Except for `convert` and `convert_to`, tactics now use the new `optConfig` configuration option syntax.

The problem with `convert` and `convert_to` is that `optConfig` isn't compatible with a term following it. This should eventually be possible, but it will depend on core changes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
