### PR TITLE
[Merged by Bors] - feat(RingTheory/Localization/FractionRing): `fieldEquivOfAlgEquivHom` is injective

### DIFF
--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -300,6 +300,12 @@ lemma fieldEquivOfAlgEquivHom_apply (f : B ≃ₐ[A] B) :
     fieldEquivOfAlgEquivHom K L f = fieldEquivOfAlgEquiv K L L f :=
   rfl
 
+lemma fieldEquivOfAlgEquivHom_injective :
+    Function.Injective (fieldEquivOfAlgEquivHom K L : (B ≃ₐ[A] B) →* (L ≃ₐ[K] L)) := by
+  intro f g h
+  ext b
+  simpa using AlgEquiv.ext_iff.mp h (algebraMap B L b)
+
 end fieldEquivOfAlgEquivHom
 
 theorem isFractionRing_iff_of_base_ringEquiv (h : R ≃+* P) :

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -300,6 +300,8 @@ lemma fieldEquivOfAlgEquivHom_apply (f : B ≃ₐ[A] B) :
     fieldEquivOfAlgEquivHom K L f = fieldEquivOfAlgEquiv K L L f :=
   rfl
 
+variable (A B)
+
 lemma fieldEquivOfAlgEquivHom_injective :
     Function.Injective (fieldEquivOfAlgEquivHom K L : (B ≃ₐ[A] B) →* (L ≃ₐ[K] L)) := by
   intro f g h


### PR DESCRIPTION
This PR adds a short lemma stating that `fieldEquivOfAlgEquivHom` is injective.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
