### PR TITLE
perf: change the priority of `*.toSemiring` instances

### DIFF
--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -99,6 +99,8 @@ class DivisionSemiring (K : Type*) extends Semiring K, GroupWithZero K, NNRatCas
   Do not use this lemma directly. Use `NNRat.smul_def` instead. -/
   protected nnqsmul_def (q : ℚ≥0) (a : K) : nnqsmul q a = NNRat.cast q * a := by intros; rfl
 
+attribute [instance 50] DivisionSemiring.toSemiring
+
 /-- A `DivisionRing` is a `Ring` with multiplicative inverses for nonzero elements.
 
 An instance of `DivisionRing K` includes maps `ratCast : ℚ → K` and `qsmul : ℚ → K → K`.

--- a/Mathlib/Algebra/Order/Kleene.lean
+++ b/Mathlib/Algebra/Order/Kleene.lean
@@ -66,6 +66,8 @@ class IdemSemiring (α : Type u) extends Semiring α, SemilatticeSup α where
   protected bot : α := 0
   protected bot_le : ∀ a, bot ≤ a
 
+attribute [instance 50] IdemSemiring.toSemiring
+
 /-- An idempotent commutative semiring is a commutative semiring with the additional property that
 addition is idempotent. -/
 class IdemCommSemiring (α : Type u) extends CommSemiring α, IdemSemiring α

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -142,6 +142,12 @@ class Semiring (α : Type u) extends NonUnitalSemiring α, NonAssocSemiring α, 
 /-- A `Ring` is a `Semiring` with negation making it an additive group. -/
 class Ring (R : Type u) extends Semiring R, AddCommGroup R, AddGroupWithOne R
 
+/- The instance from `Ring` to `Semiring` happens often in linear algebra, for which all the basic
+definitions are given in terms of semirings, but many applications use rings or fields. We increase
+a little bit its priority above 100 to try it quickly, but remaining below the default 1000 so that
+more specific instances are tried first. -/
+attribute [instance 200] Ring.toSemiring
+
 /-!
 ### Semirings
 -/
@@ -209,6 +215,8 @@ class NonUnitalCommSemiring (α : Type u) extends NonUnitalSemiring α, CommSemi
 
 /-- A commutative semiring is a semiring with commutative multiplication. -/
 class CommSemiring (R : Type u) extends Semiring R, CommMonoid R
+
+attribute [instance 90] CommSemiring.toSemiring
 
 -- see Note [lower instance priority]
 instance (priority := 100) CommSemiring.toNonUnitalCommSemiring [CommSemiring α] :
@@ -353,13 +361,6 @@ instance (priority := 100) Ring.toNonUnitalRing : NonUnitalRing α :=
 -- A (unital, associative) ring is a not-necessarily-associative ring
 -- see Note [lower instance priority]
 instance (priority := 100) Ring.toNonAssocRing : NonAssocRing α :=
-  { ‹Ring α› with }
-
-/-- The instance from `Ring` to `Semiring` happens often in linear algebra, for which all the basic
-definitions are given in terms of semirings, but many applications use rings or fields. We increase
-a little bit its priority above 100 to try it quickly, but remaining below the default 1000 so that
-more specific instances are tried first. -/
-instance (priority := 200) : Semiring α :=
   { ‹Ring α› with }
 
 end Ring

--- a/Mathlib/FieldTheory/Extension.lean
+++ b/Mathlib/FieldTheory/Extension.lean
@@ -81,7 +81,7 @@ theorem Lifts.exists_lift_of_splits' (x : Lifts F E K) {s : E} (h1 : IsIntegral 
       rw [mem_aroots, and_iff_right (minpoly.ne_zero h1)]
       exact map_rootOfSplits x.emb.toRingHom h2 I2⟩)
   ⟨⟨carrier, (@algHomEquivSigma F x.carrier carrier K _ _ _ _ _ _ _ _
-      (IsScalarTower.of_algebraMap_eq fun _ ↦ rfl)).symm ⟨x.emb, φ⟩⟩,
+      (IsScalarTower.of_algebraMap_eq fun _ ↦ by rfl)).symm ⟨x.emb, φ⟩⟩,
     ⟨fun z hz ↦ algebraMap_mem x.carrier⟮s⟯ ⟨z, hz⟩, φ.commutes⟩,
     mem_adjoin_simple_self x.carrier s⟩
 

--- a/Mathlib/FieldTheory/PurelyInseparable.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable.lean
@@ -793,7 +793,7 @@ theorem LinearIndependent.map_pow_expChar_pow_of_isSeparable [Algebra.IsSeparabl
   haveI : Algebra.IsSeparable F E' := Algebra.isSeparable_tower_bot_of_isSeparable F E' E
   let v' (i : s) : E' := ⟨v i.1, subset_adjoin F _ (Finset.mem_image.2 ⟨i.1, i.2, rfl⟩)⟩
   have h' : LinearIndependent F v' := (h s).of_comp E'.val.toLinearMap
-  exact (h'.map_pow_expChar_pow_of_fd_isSeparable q n).map'
+  exact (LinearIndependent.map_pow_expChar_pow_of_fd_isSeparable (F := F) (E := E') q n h' : _).map'
     E'.val.toLinearMap (LinearMap.ker_eq_bot_of_injective E'.val.injective)
 
 /-- If `E / F` is a field extension of exponential characteristic `q`, if `{ u_i }` is a
@@ -807,7 +807,7 @@ theorem LinearIndependent.map_pow_expChar_pow_of_isIntegral'
     rintro _ ⟨y, rfl⟩; exact hsep y
   let v' (i : ι) : E' := ⟨v i, subset_adjoin F _ ⟨i, rfl⟩⟩
   have h' : LinearIndependent F v' := h.of_comp E'.val.toLinearMap
-  exact (h'.map_pow_expChar_pow_of_isSeparable q n).map'
+  exact (LinearIndependent.map_pow_expChar_pow_of_isSeparable (F := F) (E := E') q n h' : _).map'
     E'.val.toLinearMap (LinearMap.ker_eq_bot_of_injective E'.val.injective)
 
 /-- If `E / F` is a separable extension of exponential characteristic `q`, if `{ u_i }` is an
@@ -1090,7 +1090,8 @@ theorem minpoly.map_eq_of_isSeparable_of_isPurelyInseparable (x : K)
   have := Algebra.IsSeparable.isAlgebraic F F⟮x⟯
   have := Algebra.IsSeparable.isAlgebraic E E⟮x⟯
   rw [Polynomial.natDegree_map, ← adjoin.finrank hi, ← adjoin.finrank hi',
-    ← finSepDegree_eq_finrank_of_isSeparable F _, ← finSepDegree_eq_finrank_of_isSeparable E _,
+    ← finSepDegree_eq_finrank_of_isSeparable F F⟮x⟯,
+    ← finSepDegree_eq_finrank_of_isSeparable E E⟮x⟯,
     finSepDegree_eq, finSepDegree_eq,
     sepDegree_adjoin_eq_of_isAlgebraic_of_isPurelyInseparable (F := F) E]
 

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
@@ -155,7 +155,8 @@ theorem matPolyEquiv_symm_map_eval (M : (Matrix n n R)[X]) (r : R) :
 
 theorem matPolyEquiv_eval_eq_map (M : Matrix n n R[X]) (r : R) :
     (matPolyEquiv M).eval (scalar n r) = M.map (eval r) := by
-  simpa only [AlgEquiv.symm_apply_apply] using (matPolyEquiv_symm_map_eval (matPolyEquiv M) r).symm
+  simpa only [AlgEquiv.symm_apply_apply] using
+    (matPolyEquiv_symm_map_eval (R := R) (matPolyEquiv M) r).symm
 
 -- I feel like this should use `Polynomial.algHom_eval₂_algebraMap`
 theorem matPolyEquiv_eval (M : Matrix n n R[X]) (r : R) (i j : n) :

--- a/Mathlib/RingTheory/Etale/Field.lean
+++ b/Mathlib/RingTheory/Etale/Field.lean
@@ -98,7 +98,7 @@ lemma of_isSeparable [Algebra.IsSeparable K L] : FormallyEtale K L := by
     have := IntermediateField.adjoin.finiteDimensional
       (Algebra.IsSeparable.isSeparable K k).isIntegral
     have := FormallyEtale.of_isSeparable_aux K (K⟮k⟯)
-    have := FormallyEtale.comp_bijective (R := K) (A := K⟮k⟯) I h
+    have := this.comp_bijective (R := K) (A := K⟮k⟯) I h
     exact this.existsUnique _
   choose g hg₁ hg₂ using this
   have hg₃ : ∀ x y (h : x ∈ K⟮y⟯), g y ⟨x, h⟩ = g x (IntermediateField.AdjoinSimple.gen K x) := by
@@ -136,6 +136,8 @@ lemma of_isSeparable [Algebra.IsSeparable K L] : FormallyEtale K L := by
   · show g 0 0 = 0; rw [map_zero]
   · intros x y
     obtain ⟨α, hx, hy⟩ := H x y
+    have : LinearMapClass (K⟮α⟯ →ₐ[K] B) _ _ _ := inferInstance
+    have : AddHomClass (K⟮α⟯ →ₐ[K] B) _ _ := inferInstance
     simp only [← hg₃ _ _ hx, ← hg₃ _ _ hy, ← map_add, ← hg₃ _ _ (add_mem hx hy)]
     rfl
   · intro r

--- a/Mathlib/RingTheory/Filtration.lean
+++ b/Mathlib/RingTheory/Filtration.lean
@@ -208,7 +208,7 @@ theorem Stable.exists_pow_smul_eq_of_ge (h : F.Stable) :
 theorem stable_iff_exists_pow_smul_eq_of_ge :
     F.Stable ↔ ∃ n₀, ∀ n ≥ n₀, F.N n = I ^ (n - n₀) • F.N n₀ := by
   refine ⟨Stable.exists_pow_smul_eq_of_ge, fun h => ⟨h.choose, fun n hn => ?_⟩⟩
-  rw [h.choose_spec n hn, h.choose_spec (n + 1) (by omega), smul_smul, ← pow_succ',
+  rw [h.choose_spec n hn, h.choose_spec (n + 1) (by omega), smul_smul I, ← pow_succ',
     tsub_add_eq_add_tsub hn]
 
 theorem Stable.exists_forall_le (h : F.Stable) (e : F.N 0 ≤ F'.N 0) :

--- a/Mathlib/RingTheory/Localization/Integral.lean
+++ b/Mathlib/RingTheory/Localization/Integral.lean
@@ -101,7 +101,7 @@ theorem integerNormalization_eval₂_eq_zero (g : S →+* R') (p : S[X]) {x : R'
 theorem integerNormalization_aeval_eq_zero [Algebra R R'] [Algebra S R'] [IsScalarTower R S R']
     (p : S[X]) {x : R'} (hx : aeval x p = 0) : aeval x (integerNormalization M p) = 0 := by
   rw [aeval_def, IsScalarTower.algebraMap_eq R S R',
-    integerNormalization_eval₂_eq_zero _ (algebraMap _ _) _ hx]
+    integerNormalization_eval₂_eq_zero _ (algebraMap S _) _ hx]
 
 end IntegerNormalization
 


### PR DESCRIPTION
Need to fix some regressions in subsequent PRs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [ ] depends on: #18468
- [ ] depends on: #18470

From #7873.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
