### PR TITLE
[Merged by Bors] - feat: select correct lean4checker version

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -4,15 +4,6 @@
 ### NB: and regenerate those files by manually running
 ### NB: .github/workflows/mk_build_yml.sh
 
-# .github/workflows/bors.yml:308:155: unexpected token "[" while parsing variable access, function call, null, bool, int, float or string. expecting "IDENT", "(", "INTEGER", "FLOAT", "STRING" [expression]
-# .github/workflows/bors.yml:309:9: shellcheck reported issue in this script: SC2086:info:7:16: Double quote to prevent globbing and word splitting [shellcheck]
-# .github/workflows/build.yml:315:155: unexpected token "[" while parsing variable access, function call, null, bool, int, float or string. expecting "IDENT", "(", "INTEGER", "FLOAT", "STRING" [expression]
-# .github/workflows/build.yml:316:9: shellcheck reported issue in this script: SC2086:info:7:16: Double quote to prevent globbing and word splitting [shellcheck]
-# .github/workflows/build_fork.yml:312:155: unexpected token "[" while parsing variable access, function call, null, bool, int, float or string. expecting "IDENT", "(", "INTEGER", "FLOAT", "STRING" [expression]
-# .github/workflows/build_fork.yml:313:9: shellcheck reported issue in this script: SC2086:info:7:16: Double quote to prevent globbing and word splitting [shellcheck]
-# .github/workflows/lean4checker.yml:70:9: shellcheck reported issue in this script: SC2086:info:7:16: Double quote to prevent globbing and word splitting [shellcheck]
-# reviewdog: found at least one issue with severity greater than or equal to the given level: error
-
 jobs:
   # Cancels previous runs of jobs in this file
   cancel:

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -294,6 +294,23 @@ jobs:
           scripts/lean-pr-testing-comments.sh lean
           scripts/lean-pr-testing-comments.sh batteries
 
+      - name: build lean4checker, but don't run it
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        run: |
+          git clone https://github.com/leanprover/lean4checker
+          cd lean4checker
+          # Read lean-toolchain file and checkout appropriate branch
+          TOOLCHAIN=$(cat ../lean-toolchain)
+          if [[ $TOOLCHAIN =~ ^leanprover/lean4:v ]]; then
+            VERSION=${TOOLCHAIN#leanprover/lean4:}
+            git checkout $VERSION
+          else
+            git checkout master
+          fi
+          # Build lean4checker using the same toolchain
+          cp ../lean-toolchain .
+          lake build
+
   final:
     name: Post-CI jobJOB_NAME
     if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -295,7 +295,7 @@ jobs:
           scripts/lean-pr-testing-comments.sh batteries
 
       - name: build lean4checker, but don't run it
-        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files || [], 'lean-toolchain') }}
+        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -295,7 +295,7 @@ jobs:
           scripts/lean-pr-testing-comments.sh batteries
 
       - name: build lean4checker, but don't run it
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files || [], 'lean-toolchain') }}
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -303,7 +303,7 @@ jobs:
           TOOLCHAIN=$(cat ../lean-toolchain)
           if [[ "$TOOLCHAIN" =~ ^leanprover/lean4:v ]]; then
             VERSION=${TOOLCHAIN#leanprover/lean4:}
-            git checkout $VERSION
+            git checkout "$VERSION"
           else
             git checkout master
           fi

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -4,6 +4,15 @@
 ### NB: and regenerate those files by manually running
 ### NB: .github/workflows/mk_build_yml.sh
 
+# .github/workflows/bors.yml:308:155: unexpected token "[" while parsing variable access, function call, null, bool, int, float or string. expecting "IDENT", "(", "INTEGER", "FLOAT", "STRING" [expression]
+# .github/workflows/bors.yml:309:9: shellcheck reported issue in this script: SC2086:info:7:16: Double quote to prevent globbing and word splitting [shellcheck]
+# .github/workflows/build.yml:315:155: unexpected token "[" while parsing variable access, function call, null, bool, int, float or string. expecting "IDENT", "(", "INTEGER", "FLOAT", "STRING" [expression]
+# .github/workflows/build.yml:316:9: shellcheck reported issue in this script: SC2086:info:7:16: Double quote to prevent globbing and word splitting [shellcheck]
+# .github/workflows/build_fork.yml:312:155: unexpected token "[" while parsing variable access, function call, null, bool, int, float or string. expecting "IDENT", "(", "INTEGER", "FLOAT", "STRING" [expression]
+# .github/workflows/build_fork.yml:313:9: shellcheck reported issue in this script: SC2086:info:7:16: Double quote to prevent globbing and word splitting [shellcheck]
+# .github/workflows/lean4checker.yml:70:9: shellcheck reported issue in this script: SC2086:info:7:16: Double quote to prevent globbing and word splitting [shellcheck]
+# reviewdog: found at least one issue with severity greater than or equal to the given level: error
+
 jobs:
   # Cancels previous runs of jobs in this file
   cancel:
@@ -301,7 +310,7 @@ jobs:
           cd lean4checker
           # Read lean-toolchain file and checkout appropriate branch
           TOOLCHAIN=$(cat ../lean-toolchain)
-          if [[ $TOOLCHAIN =~ ^leanprover/lean4:v ]]; then
+          if [[ "$TOOLCHAIN" =~ ^leanprover/lean4:v ]]; then
             VERSION=${TOOLCHAIN#leanprover/lean4:}
             git checkout $VERSION
           else

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -305,13 +305,13 @@ jobs:
           scripts/lean-pr-testing-comments.sh batteries
 
       - name: build lean4checker, but don't run it
-        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files || [], 'lean-toolchain') }}
+        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker
           # Read lean-toolchain file and checkout appropriate branch
           TOOLCHAIN=$(cat ../lean-toolchain)
-          if [[ $TOOLCHAIN =~ ^leanprover/lean4:v ]]; then
+          if [[ "$TOOLCHAIN" =~ ^leanprover/lean4:v ]]; then
             VERSION=${TOOLCHAIN#leanprover/lean4:}
             git checkout $VERSION
           else

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -313,7 +313,7 @@ jobs:
           TOOLCHAIN=$(cat ../lean-toolchain)
           if [[ "$TOOLCHAIN" =~ ^leanprover/lean4:v ]]; then
             VERSION=${TOOLCHAIN#leanprover/lean4:}
-            git checkout $VERSION
+            git checkout "$VERSION"
           else
             git checkout master
           fi

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -304,6 +304,23 @@ jobs:
           scripts/lean-pr-testing-comments.sh lean
           scripts/lean-pr-testing-comments.sh batteries
 
+      - name: build lean4checker, but don't run it
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        run: |
+          git clone https://github.com/leanprover/lean4checker
+          cd lean4checker
+          # Read lean-toolchain file and checkout appropriate branch
+          TOOLCHAIN=$(cat ../lean-toolchain)
+          if [[ $TOOLCHAIN =~ ^leanprover/lean4:v ]]; then
+            VERSION=${TOOLCHAIN#leanprover/lean4:}
+            git checkout $VERSION
+          else
+            git checkout master
+          fi
+          # Build lean4checker using the same toolchain
+          cp ../lean-toolchain .
+          lake build
+
   final:
     name: Post-CI job
     if: github.repository == 'leanprover-community/mathlib4'

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -305,7 +305,7 @@ jobs:
           scripts/lean-pr-testing-comments.sh batteries
 
       - name: build lean4checker, but don't run it
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files || [], 'lean-toolchain') }}
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,7 +320,7 @@ jobs:
           TOOLCHAIN=$(cat ../lean-toolchain)
           if [[ "$TOOLCHAIN" =~ ^leanprover/lean4:v ]]; then
             VERSION=${TOOLCHAIN#leanprover/lean4:}
-            git checkout $VERSION
+            git checkout "$VERSION"
           else
             git checkout master
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,6 +311,23 @@ jobs:
           scripts/lean-pr-testing-comments.sh lean
           scripts/lean-pr-testing-comments.sh batteries
 
+      - name: build lean4checker, but don't run it
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        run: |
+          git clone https://github.com/leanprover/lean4checker
+          cd lean4checker
+          # Read lean-toolchain file and checkout appropriate branch
+          TOOLCHAIN=$(cat ../lean-toolchain)
+          if [[ $TOOLCHAIN =~ ^leanprover/lean4:v ]]; then
+            VERSION=${TOOLCHAIN#leanprover/lean4:}
+            git checkout $VERSION
+          else
+            git checkout master
+          fi
+          # Build lean4checker using the same toolchain
+          cp ../lean-toolchain .
+          lake build
+
   final:
     name: Post-CI job
     if: github.repository == 'leanprover-community/mathlib4'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,13 +312,13 @@ jobs:
           scripts/lean-pr-testing-comments.sh batteries
 
       - name: build lean4checker, but don't run it
-        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files || [], 'lean-toolchain') }}
+        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker
           # Read lean-toolchain file and checkout appropriate branch
           TOOLCHAIN=$(cat ../lean-toolchain)
-          if [[ $TOOLCHAIN =~ ^leanprover/lean4:v ]]; then
+          if [[ "$TOOLCHAIN" =~ ^leanprover/lean4:v ]]; then
             VERSION=${TOOLCHAIN#leanprover/lean4:}
             git checkout $VERSION
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,7 +312,7 @@ jobs:
           scripts/lean-pr-testing-comments.sh batteries
 
       - name: build lean4checker, but don't run it
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files || [], 'lean-toolchain') }}
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -308,6 +308,23 @@ jobs:
           scripts/lean-pr-testing-comments.sh lean
           scripts/lean-pr-testing-comments.sh batteries
 
+      - name: build lean4checker, but don't run it
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        run: |
+          git clone https://github.com/leanprover/lean4checker
+          cd lean4checker
+          # Read lean-toolchain file and checkout appropriate branch
+          TOOLCHAIN=$(cat ../lean-toolchain)
+          if [[ $TOOLCHAIN =~ ^leanprover/lean4:v ]]; then
+            VERSION=${TOOLCHAIN#leanprover/lean4:}
+            git checkout $VERSION
+          else
+            git checkout master
+          fi
+          # Build lean4checker using the same toolchain
+          cp ../lean-toolchain .
+          lake build
+
   final:
     name: Post-CI job (fork)
     if: github.repository != 'leanprover-community/mathlib4'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -309,13 +309,13 @@ jobs:
           scripts/lean-pr-testing-comments.sh batteries
 
       - name: build lean4checker, but don't run it
-        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files || [], 'lean-toolchain') }}
+        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker
           # Read lean-toolchain file and checkout appropriate branch
           TOOLCHAIN=$(cat ../lean-toolchain)
-          if [[ $TOOLCHAIN =~ ^leanprover/lean4:v ]]; then
+          if [[ "$TOOLCHAIN" =~ ^leanprover/lean4:v ]]; then
             VERSION=${TOOLCHAIN#leanprover/lean4:}
             git checkout $VERSION
           else

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -317,7 +317,7 @@ jobs:
           TOOLCHAIN=$(cat ../lean-toolchain)
           if [[ "$TOOLCHAIN" =~ ^leanprover/lean4:v ]]; then
             VERSION=${TOOLCHAIN#leanprover/lean4:}
-            git checkout $VERSION
+            git checkout "$VERSION"
           else
             git checkout master
           fi

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -309,7 +309,7 @@ jobs:
           scripts/lean-pr-testing-comments.sh batteries
 
       - name: build lean4checker, but don't run it
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files || [], 'lean-toolchain') }}
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker

--- a/.github/workflows/lean4checker.yml
+++ b/.github/workflows/lean4checker.yml
@@ -72,7 +72,7 @@ jobs:
           cd lean4checker
           # Read lean-toolchain file and checkout appropriate branch
           TOOLCHAIN=$(cat ../lean-toolchain)
-          if [[ $TOOLCHAIN =~ ^leanprover/lean4:v ]]; then
+          if [[ "$TOOLCHAIN" =~ ^leanprover/lean4:v ]]; then
             VERSION=${TOOLCHAIN#leanprover/lean4:}
             git checkout $VERSION
           else

--- a/.github/workflows/lean4checker.yml
+++ b/.github/workflows/lean4checker.yml
@@ -70,9 +70,14 @@ jobs:
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker
-          # This should be changed back to a version tag when
-          # anything subsequent to `v4.13.0-rc3` is released.
-          git checkout master
+          # Read lean-toolchain file and checkout appropriate branch
+          TOOLCHAIN=$(cat ../lean-toolchain)
+          if [[ $TOOLCHAIN =~ ^leanprover/lean4:v ]]; then
+            VERSION=${TOOLCHAIN#leanprover/lean4:}
+            git checkout $VERSION
+          else
+            git checkout master
+          fi
           # Now that the git hash is embedded in each olean,
           # we need to compile lean4checker on the same toolchain
           cp ../lean-toolchain .

--- a/.github/workflows/lean4checker.yml
+++ b/.github/workflows/lean4checker.yml
@@ -74,7 +74,7 @@ jobs:
           TOOLCHAIN=$(cat ../lean-toolchain)
           if [[ "$TOOLCHAIN" =~ ^leanprover/lean4:v ]]; then
             VERSION=${TOOLCHAIN#leanprover/lean4:}
-            git checkout $VERSION
+            git checkout "$VERSION"
           else
             git checkout master
           fi


### PR DESCRIPTION
Previously we've been bumping versions manually, and they kept getting out of sync with lean-toolchain.

This also adds a regular CI step that only runs when `lean-toolchain` is touched by the PR, and that checks that lean4checker is available for this version, but doesn't actually run it (this still happens in cron).