### PR TITLE
[Merged by Bors] - chore: add location of build.in.yml to directories checked by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ version: 2  # Specifies the version of the Dependabot configuration file format
 updates:
   # Configuration for dependency updates
   - package-ecosystem: "github-actions"  # Specifies the ecosystem to check for updates
-    directory: "/"  # Specifies the directory to check for dependencies; "/" means the root directory
+    directories: 
+      - "/"  # Specifies the directory to check for dependencies; "/" means the root directory
+      - "/.github/" # to hopefully cover build.in.yml as well
     schedule:
       # Check for updates to GitHub Actions every month
       interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: "github-actions"  # Specifies the ecosystem to check for updates
     directories: 
       - "/"  # Specifies the directory to check for dependencies; "/" means the root directory
-      - "/.github/" # to hopefully cover build.in.yml as well
+      - "/.github/" # covers `build.in.yml` as well, which is not in `.github/workflows/` because it shouldn't be run in CI.
     schedule:
       # Check for updates to GitHub Actions every month
       interval: "monthly"


### PR DESCRIPTION
Not sure if this will work, but since dependabot currently doesn't try to update `build.in.yml`, our linter rejects its PRs.

cf. #18026 

---

docs for the config file here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory