### PR TITLE
[Merged by Bors] - doc: update README.md instructions for building documentation locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,17 +88,20 @@ Call `lake exe cache` to see its help menu.
 
 ### Building HTML documentation
 
-Building HTML documentation locally is straightforward, but it may take a while (>20 minutes):
+The [mathlib4_docs repository](https://github.com/leanprover-community/mathlib4_docs)
+is responsible for generating and publishing the
+[mathlib4 docs](https://leanprover-community.github.io/mathlib4_docs/index.html).
 
+That repo can be used to build the docs locally:
 ```shell
-lake -R -Kdoc=on update doc-gen4
+git clone https://github.com/leanprover-community/mathlib4_docs.git
+cd mathlib4_docs
+cp ../mathlib4/lean-toolchain .
+lake exe cache get
 lake build Mathlib:docs
 ```
-
-The HTML files can then be found in `build/doc`.
-
-Warning: these commands will make a change to `lake-manifest.json`
-which should *not* be committed to Mathlib.
+The last step may take a while (>20 minutes).
+The HTML files can then be found in `.lake/build/doc`.
 
 ## Transitioning from Lean 3
 


### PR DESCRIPTION
Since #14229, the current instructions in README.md for building docs no longer work.

This PR updates the instructions to refer to the `mathlib4_docs` repo, which is discussed in
[this zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/How.20does.20build.20.26.20deploy.20document.20for.20Mathlib4.20currently.3F/near/476591680).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
