### PR TITLE
[Merged by Bors] - perf: hard-code typeclass inference in linarith

### DIFF
--- a/Mathlib/Tactic/Linarith/Lemmas.lean
+++ b/Mathlib/Tactic/Linarith/Lemmas.lean
@@ -24,6 +24,8 @@ namespace Linarith
 universe u
 theorem lt_irrefl {α : Type u} [Preorder α] {a : α} : ¬a < a := _root_.lt_irrefl a
 
+theorem zero_lt_one {α : Type u} [StrictOrderedSemiring α] : (0:α) < 1 := _root_.zero_lt_one
+
 theorem eq_of_eq_of_eq {α} [OrderedSemiring α] {a b : α} (ha : a = 0) (hb : b = 0) : a + b = 0 := by
   simp [*]
 
@@ -38,6 +40,22 @@ theorem le_of_le_of_eq {α} [OrderedSemiring α] {a b : α} (ha : a ≤ 0) (hb :
 
 theorem lt_of_lt_of_eq {α} [OrderedSemiring α] {a b : α} (ha : a < 0) (hb : b = 0) : a + b < 0 := by
   simp [*]
+
+theorem add_nonpos {α : Type*} [OrderedSemiring α] {a b : α} (ha : a ≤ 0) (hb : b ≤ 0) :
+    a + b ≤ 0 :=
+  _root_.add_nonpos ha hb
+
+theorem add_lt_of_le_of_neg {α : Type*} [StrictOrderedSemiring α] {a b c : α} (hbc : b ≤ c)
+    (ha : a < 0) : b + a < c :=
+  _root_.add_lt_of_le_of_neg hbc ha
+
+theorem add_lt_of_neg_of_le {α : Type*} [StrictOrderedSemiring α] {a b c : α} (ha : a < 0)
+    (hbc : b ≤ c) : a + b < c :=
+  _root_.add_lt_of_neg_of_le ha hbc
+
+theorem add_neg {α : Type*} [StrictOrderedSemiring α] {a b : α} (ha : a < 0)
+    (hb : b < 0) : a + b < 0 :=
+  _root_.add_neg ha hb
 
 theorem mul_neg {α} [StrictOrderedRing α] {a b : α} (ha : a < 0) (hb : 0 < b) : b * a < 0 :=
   have : (-b)*a > 0 := mul_pos_of_neg_of_neg (neg_neg_of_pos hb) ha
@@ -58,6 +76,12 @@ def _root_.Mathlib.Ineq.toConstMulName : Ineq → Lean.Name
   | .lt => ``mul_neg
   | .le => ``mul_nonpos
   | .eq => ``mul_eq
+
+theorem sub_nonpos_of_le {α : Type*} [OrderedRing α] {a b : α} : a ≤ b → a - b ≤ 0 :=
+  _root_.sub_nonpos_of_le
+
+theorem sub_neg_of_lt {α : Type*} [OrderedRing α] {a b : α} : a < b → a - b < 0 :=
+  _root_.sub_neg_of_lt
 
 lemma eq_of_not_lt_of_not_gt {α} [LinearOrder α] (a b : α) (h1 : ¬ a < b) (h2 : ¬ b < a) : a = b :=
   le_antisymm (le_of_not_gt h2) (le_of_not_gt h1)

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -205,8 +205,8 @@ and turns it into a proof of a comparison `_ R 0`, where `R ∈ {=, ≤, <}`.
  -/
 partial def rearrangeComparison (e : Expr) : MetaM (Option Expr) := do
   match ← (← inferType e).ineq? with
-  | (Ineq.le, _) => try? <| mkAppM ``sub_nonpos_of_le #[e]
-  | (Ineq.lt, _) => try? <| mkAppM ``sub_neg_of_lt #[e]
+  | (Ineq.le, _) => try? <| mkAppM ``Linarith.sub_nonpos_of_le #[e]
+  | (Ineq.lt, _) => try? <| mkAppM ``Linarith.sub_neg_of_lt #[e]
   | (Ineq.eq, _) => try? <| mkAppM ``sub_eq_zero_of_eq #[e]
 
 /--

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -90,11 +90,11 @@ def addIneq : Ineq → Ineq → (Name × Ineq)
   | eq, le => (``Linarith.le_of_eq_of_le, le)
   | eq, lt => (``Linarith.lt_of_eq_of_lt, lt)
   | le, eq => (``Linarith.le_of_le_of_eq, le)
-  | le, le => (``add_nonpos, le)
-  | le, lt => (``add_lt_of_le_of_neg, lt)
+  | le, le => (``Linarith.add_nonpos, le)
+  | le, lt => (``Linarith.add_lt_of_le_of_neg, lt)
   | lt, eq => (``Linarith.lt_of_lt_of_eq, lt)
-  | lt, le => (``add_lt_of_neg_of_le, lt)
-  | lt, lt => (``Left.add_neg, lt)
+  | lt, le => (``Linarith.add_lt_of_neg_of_le, lt)
+  | lt, lt => (``Linarith.add_neg, lt)
 
 /--
 `mkLTZeroProof coeffs pfs` takes a list of proofs of the form `tᵢ Rᵢ 0`,
@@ -136,7 +136,7 @@ def typeOfIneqProof (prf : Expr) : MetaM Expr := do
 where the numerals are natively of type `tp`.
 -/
 def mkNegOneLtZeroProof (tp : Expr) : MetaM Expr := do
-  let zero_lt_one ← mkAppOptM ``zero_lt_one #[tp, none, none, none, none, none]
+  let zero_lt_one ← mkAppOptM ``Linarith.zero_lt_one #[tp, none]
   mkAppM `neg_neg_of_pos #[zero_lt_one]
 
 /--

--- a/MathlibTest/linarith.lean
+++ b/MathlibTest/linarith.lean
@@ -8,6 +8,12 @@ private axiom test_sorry : ∀ {α}, α
 set_option linter.unusedVariables false
 set_option autoImplicit false
 
+open Lean.Elab.Tactic in
+def testSorryTac : TacticM Unit := do
+  let e ← getMainTarget
+  let t ← `(test_sorry)
+  closeMainGoalUsing `sorry fun _ _ => elabTerm t e
+
 example {α} [LinearOrderedCommRing α] {a b : α} (h : a < b) (w : b < a) : False := by
   linarith
 
@@ -264,6 +270,20 @@ example (x y z : ℚ) (hx : x < 5) (hx2 : x > 5) (hy : y < 5000000000) (hz : z >
 
 example (x y z : ℚ) (hx : x < 5) (hy : y < 5000000000) (hz : z > 34*y) : x ≤ 5 := by
   linarith only [hx]
+
+/- The speed of `linarith` is very sensitive to how much typeclass inference is demanded by the
+lemmas it orchestrates.
+
+This example took 3318 heartbeats (and 110 ms on a good laptop) on an earlier implementation, which
+in several places used off-the-shelf library lemmas requiring low-level typeclasses, e.g.
+`Add{Left,Right}{Strict}Mono`.
+
+After a tweak to rely only on custom `linarith` clones of these lemmas taking high-level typeclasses,
+this now (November 2024) takes 1647 heartbeats (63 ms on a good laptop). -/
+set_option maxHeartbeats 2000 in
+example {K : Type*} [LinearOrderedField K] {x y : K}
+    (h : x + y = 10) (h' : x + 2 * y ≤ 18) (h : x < 2) : False := by
+  linarith (config := {discharger := testSorryTac})
 
 example (u v x y A B : ℚ)
     (a : 0 < A)


### PR DESCRIPTION
This PR modifies the `linarith` tactic to rely on custom copies of many lemmas, rather than the library versions of these lemmas.  The difference is that the copies use high-level typeclasses (such as `OrderedSemiring`) rather than lower-level typeclasses (such as `AddRightMono`).

This seems to improve `linarith` performance.  The PR also introduces a performance test to the `linarith` test file, with a heartbeat limit which failed before this PR and passes (with leeway) after this PR.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/typeclass.20inference.20in.20linarith)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
