### PR TITLE
[Merged by Bors] - refactor(AlgebraicGeometry): replace `OpenCover` by `Cover @IsOpenImmersion`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -888,6 +888,7 @@ import Mathlib.Algebra.Tropical.BigOperators
 import Mathlib.Algebra.Tropical.Lattice
 import Mathlib.Algebra.Vertex.HVertexOperator
 import Mathlib.AlgebraicGeometry.AffineScheme
+import Mathlib.AlgebraicGeometry.Cover.MorphismProperty
 import Mathlib.AlgebraicGeometry.Cover.Open
 import Mathlib.AlgebraicGeometry.EllipticCurve.Affine
 import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -229,7 +229,8 @@ instance Scheme.isAffine_affineOpenCover (X : Scheme) (𝒰 : X.AffineOpenCover)
     IsAffine (𝒰.openCover.obj i) :=
   inferInstanceAs (IsAffine (Spec (𝒰.obj i)))
 
-instance {X} [IsAffine X] (i) : IsAffine ((Scheme.openCoverOfIsIso (𝟙 X)).obj i) := by
+instance {X} [IsAffine X] (i) :
+    IsAffine ((Scheme.coverOfIsIso (P := @IsOpenImmersion) (𝟙 X)).obj i) := by
   dsimp; infer_instance
 
 theorem isBasis_affine_open (X : Scheme) : Opens.IsBasis X.affineOpens := by

--- a/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
@@ -152,7 +152,8 @@ for any pair of morphisms `f : X ⟶ S` and `g : Y ⟶ S` where `g` satisfies `P
 any pair of points `x : X` and `y : Y` with `f x = g y` can be lifted to a point
 of `X ×[S] Y`.
 
-In later files, this will be automatic, since this holds for any morphism `g`. But at
+In later files, this will be automatic, since this holds for any morphism `g`
+(see `AlgebraicGeometry.Scheme.isJointlySurjectivePreserving`). But at
 this early stage in the import tree, we only know it for open immersions. -/
 class IsJointlySurjectivePreserving (P : MorphismProperty Scheme.{u}) where
   exists_preimage_fst_triplet_of_prop {X Y S : Scheme.{u}} {f : X ⟶ S} {g : Y ⟶ S} [HasPullback f g]

--- a/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2024 Christian Merten. All rights reserved.
+Copyright (c) 2024 Christian Merten, Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Christian Merten
+Authors: Christian Merten, Andrew Yang
 -/
 import Mathlib.AlgebraicGeometry.OpenImmersion
 import Mathlib.CategoryTheory.MorphismProperty.Limits

--- a/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
@@ -1,0 +1,342 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.AlgebraicGeometry.OpenImmersion
+import Mathlib.CategoryTheory.MorphismProperty.Limits
+
+/-!
+# Covers of schemes
+
+This file provides the basic API for covers of schemes. A cover of a scheme `X` with respect to
+a morphism property `P` is a jointly surjective indexed family of scheme morphisms with
+target `X` all satisfying `P`.
+
+## Implementation details
+
+The definition on the pullback of a cover along a morphism depends on results that
+are developed later in the import tree. Hence in this file, they have additional assumptions
+that will be automatically satisfied in later files. The motivation here is that we already
+know that these assumptions are satisfied for open immersions and hence the cover API for open
+immersions can be used to deduce these assumptions in the general case.
+
+-/
+
+
+noncomputable section
+
+open TopologicalSpace CategoryTheory Opposite CategoryTheory.Limits
+
+universe v v₁ v₂ u
+
+namespace AlgebraicGeometry
+
+namespace Scheme
+
+-- TODO: provide API to and from a presieve.
+/-- A cover of `X` consists of jointly surjective indexed family of scheme morphisms
+with target `X` all satisfying `P`.
+
+This is merely a coverage in the pretopology defined by `P`, and it would be optimal
+if we could reuse the existing API about pretopologies, However, the definitions of sieves and
+grothendieck topologies uses `Prop`s, so that the actual open sets and immersions are hard to
+obtain. Also, since such a coverage in the pretopology usually contains a proper class of
+immersions, it is quite hard to glue them, reason about finite covers, etc.
+
+Note: The `map_prop` field is equipped with a default argument `by infer_instance`. In general
+this causes worse error messages, but in practice `P` is mostly defined via `class`.
+-/
+structure Cover (P : MorphismProperty Scheme.{u}) (X : Scheme.{u}) where
+  /-- index set of a cover of a scheme `X` -/
+  J : Type v
+  /-- the components of a cover -/
+  obj (j : J) : Scheme
+  /-- the components map to `X` -/
+  map (j : J) : obj j ⟶ X
+  /-- given a point of `x : X`, `f x` is the index of the component which contains `x`  -/
+  f (x : X) : J
+  /-- the components cover `X` -/
+  covers (x : X) : x ∈ Set.range (map (f x)).base
+  /-- the component maps satisfy `P` -/
+  map_prop (j : J) : P (map j) := by infer_instance
+
+variable {P : MorphismProperty Scheme.{u}}
+
+variable {X Y Z : Scheme.{u}} (𝒰 : X.Cover P) (f : X ⟶ Z) (g : Y ⟶ Z)
+variable [∀ x, HasPullback (𝒰.map x ≫ f) g]
+
+theorem Cover.iUnion_range {X : Scheme.{u}} (𝒰 : X.Cover P) :
+    ⋃ i, Set.range (𝒰.map i).base = Set.univ := by
+  rw [Set.eq_univ_iff_forall]
+  intro x
+  rw [Set.mem_iUnion]
+  exact ⟨𝒰.f x, 𝒰.covers x⟩
+
+/-- Given a `P`-cover `{ Uᵢ }` of `X`, and for each `Uᵢ` a `P`-cover, we may combine these
+covers to form a `P`-cover of `X`. -/
+@[simps! J obj map]
+def Cover.bind [P.IsStableUnderComposition] (f : ∀ x : 𝒰.J, (𝒰.obj x).Cover P) : X.Cover P where
+  J := Σ i : 𝒰.J, (f i).J
+  obj x := (f x.1).obj x.2
+  map x := (f x.1).map x.2 ≫ 𝒰.map x.1
+  f x := ⟨_, (f _).f (𝒰.covers x).choose⟩
+  covers x := by
+    let y := (𝒰.covers x).choose
+    have hy : (𝒰.map (𝒰.f x)).base y = x := (𝒰.covers x).choose_spec
+    rcases (f (𝒰.f x)).covers y with ⟨z, hz⟩
+    change x ∈ Set.range ((f (𝒰.f x)).map ((f (𝒰.f x)).f y) ≫ 𝒰.map (𝒰.f x)).base
+    use z
+    erw [comp_apply]
+    rw [hz, hy]
+  map_prop _ := P.comp_mem _ _ ((f _).map_prop _) (𝒰.map_prop _)
+
+/-- An isomorphism `X ⟶ Y` is a `P`-cover of `Y`. -/
+@[simps J obj map]
+def coverOfIsIso [P.ContainsIdentities] [P.RespectsIso] {X Y : Scheme.{u}} (f : X ⟶ Y)
+    [IsIso f] : Cover.{v} P Y where
+  J := PUnit.{v + 1}
+  obj _ := X
+  map _ := f
+  f _ := PUnit.unit
+  covers x := by
+    rw [Set.range_iff_surjective.mpr]
+    all_goals try trivial
+    rw [← TopCat.epi_iff_surjective]
+    infer_instance
+  map_prop _ := P.of_isIso _
+
+/-- We construct a cover from another, by providing the needed fields and showing that the
+provided fields are isomorphic with the original cover. -/
+@[simps J obj map]
+def Cover.copy [P.RespectsIso] {X : Scheme.{u}} (𝒰 : X.Cover P)
+    (J : Type*) (obj : J → Scheme)
+    (map : ∀ i, obj i ⟶ X) (e₁ : J ≃ 𝒰.J) (e₂ : ∀ i, obj i ≅ 𝒰.obj (e₁ i))
+    (h : ∀ i, map i = (e₂ i).hom ≫ 𝒰.map (e₁ i)) : X.Cover P :=
+  { J, obj, map
+    f := fun x ↦ e₁.symm (𝒰.f x)
+    covers := fun x ↦ by
+      rw [h, Scheme.comp_base, TopCat.coe_comp, Set.range_comp, Set.range_iff_surjective.mpr,
+        Set.image_univ, e₁.rightInverse_symm]
+      · exact 𝒰.covers x
+      · rw [← TopCat.epi_iff_surjective]; infer_instance
+    map_prop := fun j ↦ by
+      rw [h, P.cancel_left_of_respectsIso]
+      exact 𝒰.map_prop (e₁ j) }
+
+/-- The pushforward of a cover along an isomorphism. -/
+@[simps! J obj map]
+def Cover.pushforwardIso [P.RespectsIso] [P.ContainsIdentities] [P.IsStableUnderComposition]
+    {X Y : Scheme.{u}} (𝒰 : Cover.{v} P X) (f : X ⟶ Y) [IsIso f] :
+    Cover.{v} P Y :=
+  ((coverOfIsIso.{v, u} f).bind fun _ => 𝒰).copy 𝒰.J _ _
+    ((Equiv.punitProd _).symm.trans (Equiv.sigmaEquivProd PUnit 𝒰.J).symm) (fun _ => Iso.refl _)
+    fun _ => (Category.id_comp _).symm
+
+/-- Adding map satisfying `P` into a cover gives another cover. -/
+@[simps]
+def Cover.add {X Y : Scheme.{u}} (𝒰 : X.Cover P) (f : Y ⟶ X) (hf : P f := by infer_instance) :
+    X.Cover P where
+  J := Option 𝒰.J
+  obj i := Option.rec Y 𝒰.obj i
+  map i := Option.rec f 𝒰.map i
+  f x := some (𝒰.f x)
+  covers := 𝒰.covers
+  map_prop j := by
+    obtain ⟨_ | _⟩ := j
+    · exact hf
+    · exact 𝒰.map_prop _
+
+/-- A morphism property of schemes is said to preserve joint surjectivity, if
+for any pair of morphisms `f : X ⟶ S` and `g : Y ⟶ S` where `g` satisfies `P`,
+any pair of points `x : X` and `y : Y` with `f x = g y` can be lifted to a point
+of `X ×[S] Y`.
+
+In later files, this will be automatic, since this holds for any morphism `g`. But at
+this early stage in the import tree, we only know it for open immersions. -/
+class IsJointlySurjectivePreserving (P : MorphismProperty Scheme.{u}) where
+  exists_preimage_fst_triplet_of_prop {X Y S : Scheme.{u}} {f : X ⟶ S} {g : Y ⟶ S} [HasPullback f g]
+    (hg : P g) (x : X) (y : Y) (h : f.base x = g.base y) :
+    ∃ a : ↑(pullback f g), (pullback.fst f g).base a = x
+
+lemma IsJointlySurjectivePreserving.exists_preimage_snd_triplet_of_prop
+    [IsJointlySurjectivePreserving P] {X Y S : Scheme.{u}} {f : X ⟶ S} {g : Y ⟶ S} [HasPullback f g]
+    (hf : P f) (x : X) (y : Y) (h : f.base x = g.base y) :
+    ∃ a : ↑(pullback f g), (pullback.snd f g).base a = y := by
+  let iso := pullbackSymmetry f g
+  haveI : HasPullback g f := hasPullback_symmetry f g
+  obtain ⟨a, ha⟩ := exists_preimage_fst_triplet_of_prop hf y x h.symm
+  use (pullbackSymmetry f g).inv.base a
+  rwa [← Scheme.comp_base_apply, pullbackSymmetry_inv_comp_snd]
+
+instance : IsJointlySurjectivePreserving @IsOpenImmersion where
+  exists_preimage_fst_triplet_of_prop {X Y S f g} _ hg x y h := by
+    rw [← show _ = (pullback.fst _ _ : pullback f g ⟶ _).base from
+        PreservesPullback.iso_hom_fst Scheme.forgetToTop f g]
+    have : x ∈ Set.range (pullback.fst f.base g.base) := by
+      rw [TopCat.pullback_fst_range f.base g.base]
+      use y
+    obtain ⟨a, ha⟩ := this
+    use (PreservesPullback.iso forgetToTop f g).inv a
+    rwa [← TopCat.comp_app, Iso.inv_hom_id_assoc]
+
+/-- Given a cover on `X`, we may pull them back along a morphism `W ⟶ X` to obtain
+a cover of `W`.
+
+Note that this requires the (unnecessary) assumptions that the pullback exists and that `P`
+preserves joint surjectivity. This is needed, because we don't know these in general at this
+stage of the import tree, but this API is used in the case of `P = IsOpenImmersion` to
+obtain these results in the general case. -/
+@[simps]
+def Cover.pullbackCover [P.IsStableUnderBaseChange] [IsJointlySurjectivePreserving P]
+    {X W : Scheme.{u}} (𝒰 : X.Cover P) (f : W ⟶ X) [∀ x, HasPullback f (𝒰.map x)] : W.Cover P where
+  J := 𝒰.J
+  obj x := pullback f (𝒰.map x)
+  map _ := pullback.fst _ _
+  f x := 𝒰.f (f.base x)
+  covers x := by
+    obtain ⟨y, hy⟩ := 𝒰.covers (f.base x)
+    exact IsJointlySurjectivePreserving.exists_preimage_fst_triplet_of_prop
+      (𝒰.map_prop _) x y hy.symm
+  map_prop j := P.pullback_fst _ _ (𝒰.map_prop j)
+
+/-- The family of morphisms from the pullback cover to the original cover. -/
+def Cover.pullbackHom [P.IsStableUnderBaseChange] [IsJointlySurjectivePreserving P]
+    {X W : Scheme.{u}} (𝒰 : X.Cover P)
+    (f : W ⟶ X) (i) [∀ x, HasPullback f (𝒰.map x)] :
+    (𝒰.pullbackCover f).obj i ⟶ 𝒰.obj i :=
+  pullback.snd f (𝒰.map i)
+
+@[reassoc (attr := simp)]
+lemma Cover.pullbackHom_map [P.IsStableUnderBaseChange] [IsJointlySurjectivePreserving P]
+    {X W : Scheme.{u}} (𝒰 : X.Cover P) (f : W ⟶ X) [∀ (x : 𝒰.J), HasPullback f (𝒰.map x)] (i) :
+    𝒰.pullbackHom f i ≫ 𝒰.map i = (𝒰.pullbackCover f).map i ≫ f := pullback.condition.symm
+
+/-- Given a cover on `X`, we may pull them back along a morphism `f : W ⟶ X` to obtain
+a cover of `W`. This is similar to `Scheme.Cover.pullbackCover`, but here we
+take `pullback (𝒰.map x) f` instead of `pullback f (𝒰.map x)`. -/
+@[simps]
+def Cover.pullbackCover' [P.IsStableUnderBaseChange] [IsJointlySurjectivePreserving P]
+    {X W : Scheme.{u}} (𝒰 : X.Cover P) (f : W ⟶ X)
+    [∀ x, HasPullback (𝒰.map x) f] :
+    W.Cover P where
+  J := 𝒰.J
+  obj x := pullback (𝒰.map x) f
+  map _ := pullback.snd _ _
+  f x := 𝒰.f (f.base x)
+  covers x := by
+    obtain ⟨y, hy⟩ := 𝒰.covers (f.base x)
+    exact IsJointlySurjectivePreserving.exists_preimage_snd_triplet_of_prop
+      (𝒰.map_prop _) y x hy
+  map_prop j := P.pullback_snd _ _ (𝒰.map_prop j)
+
+/-- Given covers `{ Uᵢ }` and `{ Uⱼ }`, we may form the cover `{ Uᵢ ×[X] Uⱼ }`. -/
+def Cover.inter [P.IsStableUnderBaseChange] [P.IsStableUnderComposition]
+    [IsJointlySurjectivePreserving P]
+    {X : Scheme.{u}} (𝒰₁ : Scheme.Cover.{v₁} P X)
+    (𝒰₂ : Scheme.Cover.{v₂} P X)
+    [∀ (i : 𝒰₁.J) (j : 𝒰₂.J), HasPullback (𝒰₁.map i) (𝒰₂.map j)] : X.Cover P where
+  J := 𝒰₁.J × 𝒰₂.J
+  obj ij := pullback (𝒰₁.map ij.1) (𝒰₂.map ij.2)
+  map ij := pullback.fst _ _ ≫ 𝒰₁.map ij.1
+  f x := ⟨𝒰₁.f x, 𝒰₂.f x⟩
+  covers x := by
+    simp only [comp_coeBase, TopCat.coe_comp, Set.mem_range, Function.comp_apply]
+    obtain ⟨y₁, hy₁⟩ := 𝒰₁.covers x
+    obtain ⟨y₂, hy₂⟩ := 𝒰₂.covers x
+    obtain ⟨z, hz⟩ := IsJointlySurjectivePreserving.exists_preimage_fst_triplet_of_prop
+      (𝒰₂.map_prop _) y₁ y₂ (by rw [hy₁, hy₂])
+    use z
+    rw [hz, hy₁]
+  map_prop ij := P.comp_mem _ _ (P.pullback_fst _ _ (𝒰₂.map_prop ij.2)) (𝒰₁.map_prop ij.1)
+
+/--
+An affine cover of `X` consists of a jointly surjective family of maps into `X` from
+spectra of rings.
+
+Note: The `map_prop` field is equipped with a default argument `by infer_instance`. In general
+this causes worse error messages, but in practice `P` is mostly defined via `class`.
+-/
+structure AffineCover (P : MorphismProperty Scheme.{u}) (X : Scheme.{u}) where
+  /-- index set of an affine cover of a scheme `X` -/
+  J : Type v
+  /-- the ring associated to a component of an affine cover -/
+  obj (j : J) : CommRingCat.{u}
+  /-- the components map to `X` -/
+  map (j : J) : Spec (obj j) ⟶ X
+  /-- given a point of `x : X`, `f x` is the index of the component which contains `x`  -/
+  f (x : X) : J
+  /-- the components cover `X` -/
+  covers (x : X) : x ∈ Set.range (map (f x)).base
+  /-- the component maps satisfy `P` -/
+  map_prop (j : J) : P (map j) := by infer_instance
+
+/-- The cover associated to an affine cover. -/
+@[simps]
+def AffineCover.cover {X : Scheme.{u}} (𝒰 : X.AffineCover P) : X.Cover P where
+  J := 𝒰.J
+  map := 𝒰.map
+  f := 𝒰.f
+  covers := 𝒰.covers
+  map_prop := 𝒰.map_prop
+
+section category
+
+/--
+A morphism between covers `𝒰 ⟶ 𝒱` indicates that `𝒰` is a refinement of `𝒱`.
+Since covers of schemes are indexed, the definition also involves a map on the
+indexing types.
+-/
+structure Cover.Hom {X : Scheme.{u}} (𝒰 𝒱 : Cover.{v} P X) where
+  /-- The map on indexing types associated to a morphism of covers. -/
+  idx : 𝒰.J → 𝒱.J
+  /-- The morphism between open subsets associated to a morphism of covers. -/
+  app (j : 𝒰.J) : 𝒰.obj j ⟶ 𝒱.obj (idx j)
+  app_prop (j : 𝒰.J) : P (app j) := by infer_instance
+  w (j : 𝒰.J) : app j ≫ 𝒱.map _ = 𝒰.map _ := by aesop_cat
+
+attribute [reassoc (attr := simp)] Cover.Hom.w
+
+/-- The identity morphism in the category of covers of a scheme. -/
+def Cover.Hom.id [P.ContainsIdentities] {X : Scheme.{u}} (𝒰 : Cover.{v} P X) : 𝒰.Hom 𝒰 where
+  idx j := j
+  app _ := 𝟙 _
+  app_prop _ := P.id_mem _
+
+/-- The composition of two morphisms in the category of covers of a scheme. -/
+def Cover.Hom.comp [P.IsStableUnderComposition] {X : Scheme.{u}} {𝒰 𝒱 𝒲 : Cover.{v} P X}
+    (f : 𝒰.Hom 𝒱) (g : 𝒱.Hom 𝒲) : 𝒰.Hom 𝒲 where
+  idx j := g.idx <| f.idx j
+  app _ := f.app _ ≫ g.app _
+  app_prop _ := P.comp_mem _ _ (f.app_prop _) (g.app_prop _)
+
+instance Cover.category [P.IsMultiplicative] {X : Scheme.{u}} : Category (Cover.{v} P X) where
+  Hom 𝒰 𝒱 := 𝒰.Hom 𝒱
+  id := Cover.Hom.id
+  comp f g := f.comp g
+
+variable [P.IsMultiplicative]
+
+@[simp]
+lemma Cover.id_idx_apply {X : Scheme.{u}} (𝒰 : X.Cover P) (j : 𝒰.J) :
+    (𝟙 𝒰 : 𝒰 ⟶ 𝒰).idx j = j := rfl
+
+@[simp]
+lemma Cover.id_app {X : Scheme.{u}} (𝒰 : X.Cover P) (j : 𝒰.J) :
+    (𝟙 𝒰 : 𝒰 ⟶ 𝒰).app j = 𝟙 _ := rfl
+
+@[simp]
+lemma Cover.comp_idx_apply {X : Scheme.{u}} {𝒰 𝒱 𝒲 : X.Cover P}
+    (f : 𝒰 ⟶ 𝒱) (g : 𝒱 ⟶ 𝒲) (j : 𝒰.J) :
+    (f ≫ g).idx j = g.idx (f.idx j) := rfl
+
+@[simp]
+lemma Cover.comp_app {X : Scheme.{u}} {𝒰 𝒱 𝒲 : X.Cover P}
+    (f : 𝒰 ⟶ 𝒱) (g : 𝒱 ⟶ 𝒲) (j : 𝒰.J) :
+    (f ≫ g).app j = f.app j ≫ g.app _ := rfl
+
+end category
+
+end Scheme
+
+end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Cover/Open.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Open.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.AlgebraicGeometry.OpenImmersion
+import Mathlib.AlgebraicGeometry.Cover.MorphismProperty
 
 /-!
 # Open covers of schemes
@@ -29,36 +29,15 @@ namespace AlgebraicGeometry
 
 namespace Scheme
 
--- TODO: provide API to and from a presieve.
-/-- An open cover of `X` consists of a family of open immersions into `X`,
-and for each `x : X` an open immersion (indexed by `f x`) that covers `x`.
+abbrev OpenCover (X : Scheme.{u}) : Type _ := Cover.{v} @IsOpenImmersion X
 
-This is merely a coverage in the Zariski pretopology, and it would be optimal
-if we could reuse the existing API about pretopologies, However, the definitions of sieves and
-grothendieck topologies uses `Prop`s, so that the actual open sets and immersions are hard to
-obtain. Also, since such a coverage in the pretopology usually contains a proper class of
-immersions, it is quite hard to glue them, reason about finite covers, etc.
--/
-structure OpenCover (X : Scheme.{u}) where
-  /-- index set of an open cover of a scheme `X` -/
-  J : Type v
-  /-- the subschemes of an open cover -/
-  obj : J → Scheme
-  /-- the embedding of subschemes to `X` -/
-  map : ∀ j : J, obj j ⟶ X
-  /-- given a point of `x : X`, `f x` is the index of the subscheme which contains `x`  -/
-  f : X → J
-  /-- the subschemes covers `X` -/
-  covers : ∀ x, x ∈ Set.range (map (f x)).base
-  /-- the embedding of subschemes are open immersions -/
-  IsOpen : ∀ x, IsOpenImmersion (map x) := by infer_instance
-
-@[deprecated (since := "2024-06-23")] alias OpenCover.Covers := OpenCover.covers
-
-attribute [instance] OpenCover.IsOpen
+@[deprecated (since := "2024-06-23")] alias OpenCover.Covers := Cover.covers
+@[deprecated (since := "2024-11-06")] alias OpenCover.IsOpen := Cover.map_prop
 
 variable {X Y Z : Scheme.{u}} (𝒰 : OpenCover X) (f : X ⟶ Z) (g : Y ⟶ Z)
 variable [∀ x, HasPullback (𝒰.map x ≫ f) g]
+
+instance (i : 𝒰.J) : IsOpenImmersion (𝒰.map i) := 𝒰.map_prop i
 
 /-- The affine cover of a scheme. -/
 def affineCover (X : Scheme.{u}) : OpenCover X where
@@ -80,136 +59,9 @@ def affineCover (X : Scheme.{u}) : OpenCover X where
 instance : Inhabited X.OpenCover :=
   ⟨X.affineCover⟩
 
-theorem OpenCover.iUnion_range {X : Scheme.{u}} (𝒰 : X.OpenCover) :
-    ⋃ i, Set.range (𝒰.map i).base = Set.univ := by
-  rw [Set.eq_univ_iff_forall]
-  intro x
-  rw [Set.mem_iUnion]
-  exact ⟨𝒰.f x, 𝒰.covers x⟩
-
 theorem OpenCover.iSup_opensRange {X : Scheme.{u}} (𝒰 : X.OpenCover) :
     ⨆ i, (𝒰.map i).opensRange = ⊤ :=
   Opens.ext <| by rw [Opens.coe_iSup]; exact 𝒰.iUnion_range
-
-/-- Given an open cover `{ Uᵢ }` of `X`, and for each `Uᵢ` an open cover, we may combine these
-open covers to form an open cover of `X`. -/
-@[simps! J obj map]
-def OpenCover.bind (f : ∀ x : 𝒰.J, OpenCover (𝒰.obj x)) : OpenCover X where
-  J := Σ i : 𝒰.J, (f i).J
-  obj x := (f x.1).obj x.2
-  map x := (f x.1).map x.2 ≫ 𝒰.map x.1
-  f x := ⟨_, (f _).f (𝒰.covers x).choose⟩
-  covers x := by
-    let y := (𝒰.covers x).choose
-    have hy : (𝒰.map (𝒰.f x)).base y = x := (𝒰.covers x).choose_spec
-    rcases (f (𝒰.f x)).covers y with ⟨z, hz⟩
-    change x ∈ Set.range ((f (𝒰.f x)).map ((f (𝒰.f x)).f y) ≫ 𝒰.map (𝒰.f x)).base
-    use z
-    erw [comp_apply]
-    rw [hz, hy]
-  -- Porting note: weirdly, even though no input is needed, `inferInstance` does not work
-  -- `PresheafedSpace.IsOpenImmersion.comp` is marked as `instance`
-  IsOpen _ := PresheafedSpace.IsOpenImmersion.comp _ _
-
-/-- An isomorphism `X ⟶ Y` is an open cover of `Y`. -/
-@[simps J obj map]
-def openCoverOfIsIso {X Y : Scheme.{u}} (f : X ⟶ Y) [IsIso f] : OpenCover.{v} Y where
-  J := PUnit.{v + 1}
-  obj _ := X
-  map _ := f
-  f _ := PUnit.unit
-  covers x := by
-    rw [Set.range_iff_surjective.mpr]
-    all_goals try trivial
-    rw [← TopCat.epi_iff_surjective]
-    infer_instance
-
-/-- We construct an open cover from another, by providing the needed fields and showing that the
-provided fields are isomorphic with the original open cover. -/
-@[simps J obj map]
-def OpenCover.copy {X : Scheme.{u}} (𝒰 : OpenCover X) (J : Type*) (obj : J → Scheme)
-    (map : ∀ i, obj i ⟶ X) (e₁ : J ≃ 𝒰.J) (e₂ : ∀ i, obj i ≅ 𝒰.obj (e₁ i))
-    (e₂ : ∀ i, map i = (e₂ i).hom ≫ 𝒰.map (e₁ i)) : OpenCover X :=
-  { J, obj, map
-    f := fun x => e₁.symm (𝒰.f x)
-    covers := fun x => by
-      rw [e₂, Scheme.comp_base, TopCat.coe_comp, Set.range_comp, Set.range_iff_surjective.mpr,
-        Set.image_univ, e₁.rightInverse_symm]
-      · exact 𝒰.covers x
-      · rw [← TopCat.epi_iff_surjective]; infer_instance
-    -- Porting note: weirdly, even though no input is needed, `inferInstance` does not work
-    -- `PresheafedSpace.IsOpenImmersion.comp` is marked as `instance`
-    IsOpen := fun i => by rw [e₂]; exact PresheafedSpace.IsOpenImmersion.comp _ _ }
-
--- Porting note: need more hint on universe level
-/-- The pushforward of an open cover along an isomorphism. -/
-@[simps! J obj map]
-def OpenCover.pushforwardIso {X Y : Scheme.{u}} (𝒰 : OpenCover.{v} X) (f : X ⟶ Y) [IsIso f] :
-    OpenCover.{v} Y :=
-  ((openCoverOfIsIso.{v, u} f).bind fun _ => 𝒰).copy 𝒰.J _ _
-    ((Equiv.punitProd _).symm.trans (Equiv.sigmaEquivProd PUnit 𝒰.J).symm) (fun _ => Iso.refl _)
-    fun _ => (Category.id_comp _).symm
-
-/-- Adding an open immersion into an open cover gives another open cover. -/
-@[simps]
-def OpenCover.add {X Y : Scheme.{u}} (𝒰 : X.OpenCover) (f : Y ⟶ X) [IsOpenImmersion f] :
-    X.OpenCover where
-  J := Option 𝒰.J
-  obj i := Option.rec Y 𝒰.obj i
-  map i := Option.rec f 𝒰.map i
-  f x := some (𝒰.f x)
-  covers := 𝒰.covers
-  IsOpen := by rintro (_ | _) <;> dsimp <;> infer_instance
-
-/-- Given an open cover on `X`, we may pull them back along a morphism `W ⟶ X` to obtain
-an open cover of `W`. -/
-@[simps]
-def OpenCover.pullbackCover {X W : Scheme.{u}} (𝒰 : X.OpenCover) (f : W ⟶ X) :
-    W.OpenCover where
-  J := 𝒰.J
-  obj x := pullback f (𝒰.map x)
-  map _ := pullback.fst _ _
-  f x := 𝒰.f (f.base x)
-  covers x := by
-    rw [←
-      show _ = (pullback.fst _ _ : pullback f (𝒰.map (𝒰.f (f.base x))) ⟶ _).base from
-        PreservesPullback.iso_hom_fst Scheme.forgetToTop f (𝒰.map (𝒰.f (f.base x)))]
-    -- Porting note: `rw` to `erw` on this single lemma
-    rw [TopCat.coe_comp, Set.range_comp, Set.range_iff_surjective.mpr, Set.image_univ,
-      TopCat.pullback_fst_range]
-    · obtain ⟨y, h⟩ := 𝒰.covers (f.base x)
-      exact ⟨y, h.symm⟩
-    · rw [← TopCat.epi_iff_surjective]; infer_instance
-
-/-- The family of morphisms from the pullback cover to the original cover. -/
-def OpenCover.pullbackHom {X W : Scheme.{u}} (𝒰 : X.OpenCover) (f : W ⟶ X) (i) :
-    (𝒰.pullbackCover f).obj i ⟶ 𝒰.obj i :=
-  pullback.snd f (𝒰.map i)
-
-@[reassoc (attr := simp)]
-lemma OpenCover.pullbackHom_map {X W : Scheme.{u}} (𝒰 : X.OpenCover) (f : W ⟶ X) (i) :
-    𝒰.pullbackHom f i ≫ 𝒰.map i = (𝒰.pullbackCover f).map i ≫ f := pullback.condition.symm
-
-/-- Given an open cover on `X`, we may pull them back along a morphism `f : W ⟶ X` to obtain
-an open cover of `W`. This is similar to `Scheme.OpenCover.pullbackCover`, but here we
-take `pullback (𝒰.map x) f` instead of `pullback f (𝒰.map x)`. -/
-@[simps]
-def OpenCover.pullbackCover' {X W : Scheme.{u}} (𝒰 : X.OpenCover) (f : W ⟶ X) :
-    W.OpenCover where
-  J := 𝒰.J
-  obj x := pullback (𝒰.map x) f
-  map _ := pullback.snd _ _
-  f x := 𝒰.f (f.base x)
-  covers x := by
-    rw [←
-      show _ = (pullback.snd (𝒰.map (𝒰.f (f.base x))) f).base from
-        PreservesPullback.iso_hom_snd Scheme.forgetToTop (𝒰.map (𝒰.f (f.base x))) f]
-    -- Porting note: `rw` to `erw` on this single lemma
-    rw [TopCat.coe_comp, Set.range_comp, Set.range_iff_surjective.mpr, Set.image_univ,
-      TopCat.pullback_snd_range]
-    · obtain ⟨y, h⟩ := 𝒰.covers (f.base x)
-      exact ⟨y, h⟩
-    · rw [← TopCat.epi_iff_surjective]; infer_instance
 
 /-- Every open cover of a quasi-compact scheme can be refined into a finite subcover.
 -/
@@ -248,54 +100,29 @@ theorem OpenCover.compactSpace {X : Scheme.{u}} (𝒰 : X.OpenCover) [Finite �
       (TopCat.homeoOfIso
         (asIso
           (IsOpenImmersion.isoOfRangeEq (𝒰.map i)
-                  (X.ofRestrict (Opens.isOpenEmbedding ⟨_, (𝒰.IsOpen i).base_open.isOpen_range⟩))
-                  Subtype.range_coe.symm).hom.base))
-
-/-- Given open covers `{ Uᵢ }` and `{ Uⱼ }`, we may form the open cover `{ Uᵢ ∩ Uⱼ }`. -/
-def OpenCover.inter {X : Scheme.{u}} (𝒰₁ : Scheme.OpenCover.{v₁} X)
-    (𝒰₂ : Scheme.OpenCover.{v₂} X) : X.OpenCover where
-  J := 𝒰₁.J × 𝒰₂.J
-  obj ij := pullback (𝒰₁.map ij.1) (𝒰₂.map ij.2)
-  map ij := pullback.fst _ _ ≫ 𝒰₁.map ij.1
-  f x := ⟨𝒰₁.f x, 𝒰₂.f x⟩
-  covers x := by
-    rw [IsOpenImmersion.range_pullback_to_base_of_left]
-    exact ⟨𝒰₁.covers x, 𝒰₂.covers x⟩
-  IsOpen _ := inferInstance
-
+            (X.ofRestrict (Opens.isOpenEmbedding ⟨_, (𝒰.map_prop i).base_open.isOpen_range⟩))
+            Subtype.range_coe.symm).hom.base))
 /--
 An affine open cover of `X` consists of a family of open immersions into `X` from
 spectra of rings.
 -/
-structure AffineOpenCover (X : Scheme.{u}) where
-  /-- index set of an affine open cover of a scheme `X` -/
-  J : Type v
-  /-- the ring associated to a component of an affine open cover -/
-  obj : J → CommRingCat.{u}
-  /-- the embedding of subschemes to `X` -/
-  map : ∀ j : J, Spec (obj j) ⟶ X
-  /-- given a point of `x : X`, `f x` is the index of the subscheme which contains `x`  -/
-  f : X → J
-  /-- the subschemes covers `X` -/
-  covers : ∀ x, x ∈ Set.range (map (f x)).base
-  /-- the embedding of subschemes are open immersions -/
-  IsOpen : ∀ x, IsOpenImmersion (map x) := by infer_instance
+abbrev AffineOpenCover (X : Scheme.{u}) : Type _ :=
+  AffineCover.{v} @IsOpenImmersion X
 
 namespace AffineOpenCover
 
-attribute [instance] AffineOpenCover.IsOpen
+instance {X : Scheme.{u}} (𝒰 : X.AffineOpenCover) (j : 𝒰.J) : IsOpenImmersion (𝒰.map j) :=
+  𝒰.map_prop j
 
 /-- The open cover associated to an affine open cover. -/
-@[simps]
-def openCover {X : Scheme.{u}} (𝓤 : X.AffineOpenCover) : X.OpenCover where
-  J := 𝓤.J
-  map := 𝓤.map
-  f := 𝓤.f
-  covers := 𝓤.covers
+@[simps!]
+def openCover {X : Scheme.{u}} (𝒰 : X.AffineOpenCover) : X.OpenCover :=
+  AffineCover.cover 𝒰
 
 end AffineOpenCover
 
 /-- A choice of an affine open cover of a scheme. -/
+@[simps]
 def affineOpenCover (X : Scheme.{u}) : X.AffineOpenCover where
   J := X.affineCover.J
   map := X.affineCover.map
@@ -322,7 +149,7 @@ def OpenCover.pullbackCoverAffineRefinementObjIso (f : X ⟶ Y) (𝒰 : Y.OpenCo
       ((𝒰.obj i.1).affineCover.pullbackCover (𝒰.pullbackHom f i.1)).obj i.2 :=
   pullbackSymmetry _ _ ≪≫ (pullbackRightPullbackFstIso _ _ _).symm ≪≫
     pullbackSymmetry _ _ ≪≫ asIso (pullback.map _ _ _ _ (pullbackSymmetry _ _).hom (𝟙 _) (𝟙 _)
-      (by simp [pullbackHom]) (by simp))
+      (by simp [Cover.pullbackHom]) (by simp))
 
 @[reassoc]
 lemma OpenCover.pullbackCoverAffineRefinementObjIso_inv_map (f : X ⟶ Y) (𝒰 : Y.OpenCover) (i) :
@@ -330,10 +157,10 @@ lemma OpenCover.pullbackCoverAffineRefinementObjIso_inv_map (f : X ⟶ Y) (𝒰 
       (𝒰.affineRefinement.openCover.pullbackCover f).map i =
       ((𝒰.obj i.1).affineCover.pullbackCover (𝒰.pullbackHom f i.1)).map i.2 ≫
         (𝒰.pullbackCover f).map i.1 := by
-  simp only [pullbackCover_obj, AffineOpenCover.openCover_obj, AffineOpenCover.openCover_map,
+  simp only [Cover.pullbackCover_obj, AffineCover.cover_obj, AffineCover.cover_map,
     pullbackCoverAffineRefinementObjIso, Iso.trans_inv, asIso_inv, Iso.symm_inv, Category.assoc,
-    pullbackCover_map, pullbackSymmetry_inv_comp_fst, IsIso.inv_comp_eq, limit.lift_π_assoc, id_eq,
-    PullbackCone.mk_pt, cospan_left, PullbackCone.mk_π_app, pullbackSymmetry_hom_comp_fst]
+    Cover.pullbackCover_map, pullbackSymmetry_inv_comp_fst, IsIso.inv_comp_eq, limit.lift_π_assoc,
+    id_eq, PullbackCone.mk_pt, cospan_left, PullbackCone.mk_π_app, pullbackSymmetry_hom_comp_fst]
   convert pullbackSymmetry_inv_comp_snd_assoc
     ((𝒰.obj i.1).affineCover.map i.2) (pullback.fst _ _) _ using 2
   exact pullbackRightPullbackFstIso_hom_snd _ _ _
@@ -344,66 +171,12 @@ lemma OpenCover.pullbackCoverAffineRefinementObjIso_inv_pullbackHom
     (𝒰.pullbackCoverAffineRefinementObjIso f i).inv ≫
       𝒰.affineRefinement.openCover.pullbackHom f i =
       (𝒰.obj i.1).affineCover.pullbackHom (𝒰.pullbackHom f i.1) i.2 := by
-  simp only [pullbackCover_obj, pullbackHom, AffineOpenCover.openCover_obj,
+  simp only [Cover.pullbackCover_obj, Cover.pullbackHom, AffineCover.cover_obj,
     AffineOpenCover.openCover_map, pullbackCoverAffineRefinementObjIso, Iso.trans_inv, asIso_inv,
     Iso.symm_inv, Category.assoc, pullbackSymmetry_inv_comp_snd, IsIso.inv_comp_eq, limit.lift_π,
     id_eq, PullbackCone.mk_pt, PullbackCone.mk_π_app, Category.comp_id]
   convert pullbackSymmetry_inv_comp_fst ((𝒰.obj i.1).affineCover.map i.2) (pullback.fst _ _)
   exact pullbackRightPullbackFstIso_hom_fst _ _ _
-
-section category
-
-/--
-A morphism between open covers `𝓤 ⟶ 𝓥` indicates that `𝓤` is a refinement of `𝓥`.
-Since open covers of schemes are indexed, the definition also involves a map on the
-indexing types.
--/
-structure OpenCover.Hom {X : Scheme.{u}} (𝓤 𝓥 : OpenCover.{v} X) where
-  /-- The map on indexing types associated to a morphism of open covers. -/
-  idx : 𝓤.J → 𝓥.J
-  /-- The morphism between open subsets associated to a morphism of open covers. -/
-  app (j : 𝓤.J) : 𝓤.obj j ⟶ 𝓥.obj (idx j)
-  isOpen (j : 𝓤.J) : IsOpenImmersion (app j) := by infer_instance
-  w (j : 𝓤.J) : app j ≫ 𝓥.map _ = 𝓤.map _ := by aesop_cat
-
-attribute [reassoc (attr := simp)] OpenCover.Hom.w
-attribute [instance] OpenCover.Hom.isOpen
-
-/-- The identity morphism in the category of open covers of a scheme. -/
-def OpenCover.Hom.id {X : Scheme.{u}} (𝓤 : OpenCover.{v} X) : 𝓤.Hom 𝓤 where
-  idx j := j
-  app _ := 𝟙 _
-
-/-- The composition of two morphisms in the category of open covers of a scheme. -/
-def OpenCover.Hom.comp {X : Scheme.{u}} {𝓤 𝓥 𝓦 : OpenCover.{v} X}
-    (f : 𝓤.Hom 𝓥) (g : 𝓥.Hom 𝓦) : 𝓤.Hom 𝓦 where
-  idx j := g.idx <| f.idx j
-  app _ := f.app _ ≫ g.app _
-
-instance OpenCover.category {X : Scheme.{u}} : Category (OpenCover.{v} X) where
-  Hom 𝓤 𝓥 := 𝓤.Hom 𝓥
-  id := OpenCover.Hom.id
-  comp f g := f.comp g
-
-@[simp]
-lemma OpenCover.id_idx_apply {X : Scheme.{u}} (𝓤 : X.OpenCover) (j : 𝓤.J) :
-    (𝟙 𝓤 : 𝓤 ⟶ 𝓤).idx j = j := rfl
-
-@[simp]
-lemma OpenCover.id_app {X : Scheme.{u}} (𝓤 : X.OpenCover) (j : 𝓤.J) :
-    (𝟙 𝓤 : 𝓤 ⟶ 𝓤).app j = 𝟙 _ := rfl
-
-@[simp]
-lemma OpenCover.comp_idx_apply {X : Scheme.{u}} {𝓤 𝓥 𝓦 : X.OpenCover}
-    (f : 𝓤 ⟶ 𝓥) (g : 𝓥 ⟶ 𝓦) (j : 𝓤.J) :
-    (f ≫ g).idx j = g.idx (f.idx j) := rfl
-
-@[simp]
-lemma OpenCover.comp_app {X : Scheme.{u}} {𝓤 𝓥 𝓦 : X.OpenCover}
-    (f : 𝓤 ⟶ 𝓥) (g : 𝓥 ⟶ 𝓦) (j : 𝓤.J) :
-    (f ≫ g).app j = f.app j ≫ g.app _ := rfl
-
-end category
 
 /-- Given any open cover `𝓤`, this is an affine open cover which refines it. -/
 def OpenCover.fromAffineRefinement {X : Scheme.{u}} (𝓤 : X.OpenCover) :
@@ -464,7 +237,7 @@ def affineBasisCoverOfAffine (R : CommRingCat.{u}) : OpenCover (Spec R) where
       -- `CommRing.ofHom ...` is iso, but without `ofHom` Lean does not know what to do
       change Epi (Spec.map (CommRingCat.ofHom (algebraMap _ _))).base
       infer_instance
-  IsOpen x := AlgebraicGeometry.Scheme.basic_open_isOpenImmersion x
+  map_prop x := AlgebraicGeometry.Scheme.basic_open_isOpenImmersion x
 
 /-- We may bind the basic open sets of an open affine cover to form an affine cover that is also
 a basis. -/

--- a/Mathlib/AlgebraicGeometry/Cover/Open.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Open.lean
@@ -29,6 +29,7 @@ namespace AlgebraicGeometry
 
 namespace Scheme
 
+/-- An open cover of a scheme `X` is a cover where all component maps are open immersions. -/
 abbrev OpenCover (X : Scheme.{u}) : Type _ := Cover.{v} @IsOpenImmersion X
 
 @[deprecated (since := "2024-06-23")] alias OpenCover.Covers := Cover.covers
@@ -115,7 +116,7 @@ instance {X : Scheme.{u}} (𝒰 : X.AffineOpenCover) (j : 𝒰.J) : IsOpenImmers
   𝒰.map_prop j
 
 /-- The open cover associated to an affine open cover. -/
-@[simps!]
+@[simps! J obj map f covers]
 def openCover {X : Scheme.{u}} (𝒰 : X.AffineOpenCover) : X.OpenCover :=
   AffineCover.cover 𝒰
 

--- a/Mathlib/AlgebraicGeometry/Gluing.lean
+++ b/Mathlib/AlgebraicGeometry/Gluing.lean
@@ -251,7 +251,7 @@ def openCover (D : Scheme.GlueData) : OpenCover D.glued where
 
 end GlueData
 
-namespace OpenCover
+namespace Cover
 
 variable {X : Scheme.{u}} (𝒰 : OpenCover.{u} X)
 
@@ -438,7 +438,7 @@ theorem hom_ext {Y : Scheme} (f₁ f₂ : X ⟶ Y) (h : ∀ x, 𝒰.map x ≫ f�
   erw [Multicoequalizer.π_desc_assoc]
   exact h x
 
-end OpenCover
+end Cover
 
 end Scheme
 

--- a/Mathlib/AlgebraicGeometry/Limits.lean
+++ b/Mathlib/AlgebraicGeometry/Limits.lean
@@ -376,7 +376,7 @@ def coprodOpenCover.{w} : (X ⨿ Y).OpenCover where
     obtain (x | x) := x
     · simp only [Sum.elim_inl, coprodMk_inl, exists_apply_eq_apply]
     · simp only [Sum.elim_inr, coprodMk_inr, exists_apply_eq_apply]
-  IsOpen x := x.rec (fun _ ↦ inferInstance) (fun _ ↦ inferInstance)
+  map_prop x := x.rec (fun _ ↦ inferInstance) (fun _ ↦ inferInstance)
 
 variable (R S : Type u) [CommRing R] [CommRing S]
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -270,7 +270,7 @@ lemma isLocalAtTarget [P.IsMultiplicative]
     IsLocalAtTarget P where
   iff_of_openCover' {X Y} f 𝒰 := by
     refine (iff_of_openCover (𝒰.pullbackCover f)).trans (forall_congr' fun i ↦ ?_)
-    rw [← Scheme.OpenCover.pullbackHom_map]
+    rw [← Scheme.Cover.pullbackHom_map]
     constructor
     · exact hP _ _
     · exact fun H ↦ P.comp_mem _ _ H (of_isOpenImmersion _)
@@ -545,9 +545,10 @@ theorem iff_of_openCover (𝒰 : Y.OpenCover) [∀ i, IsAffine (𝒰.obj i)] :
 
 theorem iff_of_isAffine [IsAffine Y] : P f ↔ Q f := by
   letI := isLocal_affineProperty P
-  haveI : ∀ i, IsAffine (Scheme.OpenCover.obj (Scheme.openCoverOfIsIso (𝟙 Y)) i) := fun i => by
+  haveI : ∀ i, IsAffine (Scheme.Cover.obj
+      (Scheme.coverOfIsIso (P := @IsOpenImmersion) (𝟙 Y)) i) := fun i => by
     dsimp; infer_instance
-  rw [iff_of_openCover (P := P) (Scheme.openCoverOfIsIso.{0} (𝟙 Y))]
+  rw [iff_of_openCover (P := P) (Scheme.coverOfIsIso.{0} (𝟙 Y))]
   trans Q (pullback.snd f (𝟙 _))
   · exact ⟨fun H => H PUnit.unit, fun H _ => H⟩
   rw [← Category.comp_id (pullback.snd _ _), ← pullback.condition,
@@ -586,7 +587,7 @@ private theorem pullback_fst_of_right (hP' : Q.IsStableUnderBaseChange)
   intro i
   let e := pullbackSymmetry _ _ ≪≫ pullbackRightPullbackFstIso f g (X.affineCover.map i)
   have : e.hom ≫ pullback.fst _ _ = X.affineCover.pullbackHom (pullback.fst _ _) i := by
-    simp [e, Scheme.OpenCover.pullbackHom]
+    simp [e, Scheme.Cover.pullbackHom]
   rw [← this, Q.cancel_left_of_respectsIso]
   apply hP' (.of_hasPullback _ _)
   exact H
@@ -594,7 +595,7 @@ private theorem pullback_fst_of_right (hP' : Q.IsStableUnderBaseChange)
 theorem isStableUnderBaseChange (hP' : Q.IsStableUnderBaseChange) :
     P.IsStableUnderBaseChange :=
   MorphismProperty.IsStableUnderBaseChange.mk'
-    (fun X Y S f g H => by
+    (fun X Y S f g _ H => by
       rw [IsLocalAtTarget.iff_of_openCover (P := P) (S.affineCover.pullbackCover f)]
       intro i
       let e : pullback (pullback.fst f g) ((S.affineCover.pullbackCover f).map i) ≅
@@ -606,7 +607,7 @@ theorem isStableUnderBaseChange (hP' : Q.IsStableUnderBaseChange) :
           (pullback.map _ _ _ _ (𝟙 _) (𝟙 _) (𝟙 _) (by simpa using pullback.condition) (by simp))
       have : e.hom ≫ pullback.fst _ _ =
           (S.affineCover.pullbackCover f).pullbackHom (pullback.fst _ _) i := by
-        simp [e, Scheme.OpenCover.pullbackHom]
+        simp [e, Scheme.Cover.pullbackHom]
       rw [← this, P.cancel_left_of_respectsIso]
       apply HasAffineProperty.pullback_fst_of_right hP'
       letI := isLocal_affineProperty P

--- a/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
@@ -81,7 +81,7 @@ theorem HasAffineProperty.diagonal_of_openCover (P) {Q} [HasAffineProperty P Q]
   · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
       Functor.const_obj_obj, cospan_one, cospan_left, cospan_right, Category.comp_id]
     convert h𝒰' i j k
-    ext1 <;> simp [Scheme.OpenCover.pullbackHom]
+    ext1 <;> simp [Scheme.Cover.pullbackHom]
 
 theorem HasAffineProperty.diagonal_of_openCover_diagonal
     (P) {Q} [HasAffineProperty P Q]
@@ -116,7 +116,7 @@ theorem HasAffineProperty.diagonal_iff
     (pullback.fst (f := f) (g := 𝟙 Y)), pullback.condition, Category.comp_id] at hf
   let 𝒰 := X.affineCover.pushforwardIso (inv (pullback.fst (f := f) (g := 𝟙 Y)))
   have (i) : IsAffine (𝒰.obj i) := by dsimp [𝒰]; infer_instance
-  exact HasAffineProperty.diagonal_of_openCover P f (Scheme.openCoverOfIsIso (𝟙 _))
+  exact HasAffineProperty.diagonal_of_openCover P f (Scheme.coverOfIsIso (𝟙 _))
     (fun _ ↦ 𝒰) (fun _ _ _ ↦ hf _ _)
 
 instance HasAffineProperty.diagonal_affineProperty_isLocal

--- a/Mathlib/AlgebraicGeometry/Morphisms/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/OpenImmersion.lean
@@ -41,16 +41,6 @@ theorem isOpenImmersion_eq_inf :
   exact isOpenImmersion_iff_stalk.trans
     (and_congr Iff.rfl (forall_congr' fun x ↦ ConcreteCategory.isIso_iff_bijective _))
 
-instance isOpenImmersion_isStableUnderComposition :
-    MorphismProperty.IsStableUnderComposition @IsOpenImmersion where
-  comp_mem f g _ _ := LocallyRingedSpace.IsOpenImmersion.comp f.toLRSHom g.toLRSHom
-
-instance isOpenImmersion_respectsIso : MorphismProperty.RespectsIso @IsOpenImmersion := by
-  apply MorphismProperty.respectsIso_of_isStableUnderComposition
-  intro _ _ f (hf : IsIso f)
-  have : IsIso f := hf
-  infer_instance
-
 instance : IsLocalAtTarget (stalkwise (fun f ↦ Function.Bijective f)) := by
   apply stalkwiseIsLocalAtTarget_of_respectsIso
   rw [RingHom.toMorphismProperty_respectsIso_iff]
@@ -61,10 +51,5 @@ instance : IsLocalAtTarget (stalkwise (fun f ↦ Function.Bijective f)) := by
 
 instance isOpenImmersion_isLocalAtTarget : IsLocalAtTarget @IsOpenImmersion :=
   isOpenImmersion_eq_inf ▸ inferInstance
-
-instance isOpenImmersion_isStableUnderBaseChange :
-    MorphismProperty.IsStableUnderBaseChange @IsOpenImmersion :=
-  MorphismProperty.IsStableUnderBaseChange.mk' <| by
-    intro X Y Z f g H; infer_instance
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -324,7 +324,7 @@ theorem iff_of_source_openCover [IsAffine Y] (𝒰 : X.OpenCover) [∀ i, IsAffi
 
 theorem iff_of_isAffine [IsAffine X] [IsAffine Y] :
     P f ↔ Q (f.app ⊤) := by
-  rw [iff_of_source_openCover (P := P) (Scheme.openCoverOfIsIso.{u} (𝟙 _))]
+  rw [iff_of_source_openCover (P := P) (Scheme.coverOfIsIso.{u} (𝟙 _))]
   simp
 
 theorem Spec_iff {R S : CommRingCat.{u}} {φ : R ⟶ S} :
@@ -373,7 +373,7 @@ lemma stableUnderComposition (hP : RingHom.StableUnderComposition Q) :
     wlog hY : IsAffine Y generalizing X Y
     · rw [IsLocalAtSource.iff_of_openCover (P := P) (Y.affineCover.pullbackCover f)]
       intro i
-      rw [← Scheme.OpenCover.pullbackHom_map_assoc]
+      rw [← Scheme.Cover.pullbackHom_map_assoc]
       exact this _ _ (IsLocalAtTarget.of_isPullback (.of_hasPullback _ _) hf)
         (comp_of_isOpenImmersion _ _ _ hg) inferInstance
     wlog hX : IsAffine X generalizing X

--- a/Mathlib/AlgebraicGeometry/Noetherian.lean
+++ b/Mathlib/AlgebraicGeometry/Noetherian.lean
@@ -172,7 +172,7 @@ theorem isLocallyNoetherian_iff_openCover (𝒰 : Scheme.OpenCover X) :
   · rw [isLocallyNoetherian_iff_of_affine_openCover (𝒰 := 𝒰.affineRefinement.openCover)]
     intro h i
     exact @isNoetherianRing_of_ringEquiv _ _ _ _
-      (IsOpenImmersion.ΓIsoTop (Scheme.OpenCover.map _ i.2)).symm.commRingCatIsoToRingEquiv
+      (IsOpenImmersion.ΓIsoTop (Scheme.Cover.map _ i.2)).symm.commRingCatIsoToRingEquiv
       (IsLocallyNoetherian.component_noetherian ⟨_, isAffineOpen_opensRange _⟩)
 
 /-- If `R` is a noetherian ring, `Spec R` is a noetherian topological space. -/

--- a/Mathlib/AlgebraicGeometry/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
@@ -6,6 +6,7 @@ Authors: Andrew Yang
 import Mathlib.Geometry.RingedSpace.OpenImmersion
 import Mathlib.AlgebraicGeometry.Scheme
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq
+import Mathlib.CategoryTheory.MorphismProperty.Limits
 
 /-!
 # Open immersions of schemes
@@ -635,6 +636,29 @@ instance {Z : Scheme.{u}} (f : X ⟶ Z) (g : Y ⟶ Z) [IsOpenImmersion f]
   IsOpenImmersion.of_comp _ f
 
 end IsOpenImmersion
+
+section MorphismProperty
+
+instance isOpenImmersion_isStableUnderComposition :
+    MorphismProperty.IsStableUnderComposition @IsOpenImmersion where
+  comp_mem f g _ _ := LocallyRingedSpace.IsOpenImmersion.comp f.toLRSHom g.toLRSHom
+
+instance isOpenImmersion_respectsIso : MorphismProperty.RespectsIso @IsOpenImmersion := by
+  apply MorphismProperty.respectsIso_of_isStableUnderComposition
+  intro _ _ f (hf : IsIso f)
+  have : IsIso f := hf
+  infer_instance
+
+instance isOpenImmersion_isMultiplicative :
+    MorphismProperty.IsMultiplicative @IsOpenImmersion where
+  id_mem _ := inferInstance
+
+instance isOpenImmersion_stableUnderBaseChange :
+    MorphismProperty.IsStableUnderBaseChange @IsOpenImmersion :=
+  MorphismProperty.IsStableUnderBaseChange.mk' <| by
+    intro X Y Z f g _ H; infer_instance
+
+end MorphismProperty
 
 namespace Scheme
 

--- a/Mathlib/AlgebraicGeometry/Properties.lean
+++ b/Mathlib/AlgebraicGeometry/Properties.lean
@@ -37,10 +37,11 @@ instance : T0Space X :=
 instance : QuasiSober X := by
   apply (config := { allowSynthFailures := true })
     quasiSober_of_open_cover (Set.range fun x => Set.range <| (X.affineCover.map x).base)
-  · rintro ⟨_, i, rfl⟩; exact (X.affineCover.IsOpen i).base_open.isOpen_range
+  · rintro ⟨_, i, rfl⟩; exact (X.affineCover.map_prop i).base_open.isOpen_range
   · rintro ⟨_, i, rfl⟩
     exact @IsOpenEmbedding.quasiSober _ _ _ _ _ (Homeomorph.ofIsEmbedding _
-      (X.affineCover.IsOpen i).base_open.isEmbedding).symm.isOpenEmbedding PrimeSpectrum.quasiSober
+      (X.affineCover.map_prop i).base_open.isEmbedding).symm.isOpenEmbedding
+        PrimeSpectrum.quasiSober
   · rw [Set.top_eq_univ, Set.sUnion_range, Set.eq_univ_iff_forall]
     intro x; exact ⟨_, ⟨_, rfl⟩, X.affineCover.covers x⟩
 
@@ -117,7 +118,7 @@ theorem reduce_to_affine_global (P : ∀ {X : Scheme} (_ : X.Opens), Prop)
   intro x
   obtain ⟨_, ⟨j, rfl⟩, hx, i⟩ :=
     X.affineBasisCover_is_basis.exists_subset_of_mem_open (SetLike.mem_coe.2 x.prop) U.isOpen
-  let U' : Opens _ := ⟨_, (X.affineBasisCover.IsOpen j).base_open.isOpen_range⟩
+  let U' : Opens _ := ⟨_, (X.affineBasisCover.map_prop j).base_open.isOpen_range⟩
   let i' : U' ⟶ U := homOfLE i
   refine ⟨U', hx, i', ?_⟩
   obtain ⟨_, _, rfl, rfl, h₂'⟩ := h₂ _ _ (X.affineBasisCover.map j)

--- a/Mathlib/AlgebraicGeometry/PullbackCarrier.lean
+++ b/Mathlib/AlgebraicGeometry/PullbackCarrier.lean
@@ -353,7 +353,8 @@ lemma range_map {X' Y' S' : Scheme.{u}} (f' : X' ⟶ S') (g' : Y' ⟶ S') (i₁ 
 
 end Pullback
 
-instance (P : MorphismProperty Scheme.{u}) : IsJointlySurjectivePreserving P where
+instance isJointlySurjectivePreserving (P : MorphismProperty Scheme.{u}) :
+    IsJointlySurjectivePreserving P where
   exists_preimage_fst_triplet_of_prop {X Y S} f g _ hg x y hxy := by
     obtain ⟨a, b, h⟩ := Pullback.exists_preimage_pullback x y hxy
     use a

--- a/Mathlib/AlgebraicGeometry/PullbackCarrier.lean
+++ b/Mathlib/AlgebraicGeometry/PullbackCarrier.lean
@@ -28,9 +28,9 @@ open CategoryTheory Limits TopologicalSpace LocalRing TensorProduct
 
 noncomputable section
 
-namespace AlgebraicGeometry.Scheme.Pullback
-
 universe u
+
+namespace AlgebraicGeometry.Scheme.Pullback
 
 /-- A `Triplet` over `f : X ⟶ S` and `g : Y ⟶ S` is a triple of points `x : X`, `y : Y`,
 `s : S` such that `f x = s = f y`. -/
@@ -351,4 +351,11 @@ lemma range_map {X' Y' S' : Scheme.{u}} (f' : X' ⟶ S') (g' : Y' ⟶ S') (i₁ 
     rw [pullback_map_eq_pullbackFstFstIso_inv, ← Scheme.comp_base_apply, Iso.hom_inv_id_assoc]
     simp [ht₂, T, hw₂.left, T₂]
 
-end AlgebraicGeometry.Scheme.Pullback
+end Pullback
+
+instance (P : MorphismProperty Scheme.{u}) : IsJointlySurjectivePreserving P where
+  exists_preimage_fst_triplet_of_prop {X Y S} f g _ hg x y hxy := by
+    obtain ⟨a, b, h⟩ := Pullback.exists_preimage_pullback x y hxy
+    use a
+
+end AlgebraicGeometry.Scheme

--- a/Mathlib/AlgebraicGeometry/Pullbacks.lean
+++ b/Mathlib/AlgebraicGeometry/Pullbacks.lean
@@ -289,7 +289,7 @@ theorem gluedLift_p1 : gluedLift 𝒰 f g s ≫ p1 𝒰 f g = s.fst := by
   rw [← cancel_epi (𝒰.pullbackCover s.fst).fromGlued]
   apply Multicoequalizer.hom_ext
   intro b
-  simp_rw [OpenCover.fromGlued, Multicoequalizer.π_desc_assoc, gluedLift, ← Category.assoc]
+  simp_rw [Cover.fromGlued, Multicoequalizer.π_desc_assoc, gluedLift, ← Category.assoc]
   simp_rw [(𝒰.pullbackCover s.fst).ι_glueMorphisms]
   simp [p1, pullback.condition]
 
@@ -297,7 +297,7 @@ theorem gluedLift_p2 : gluedLift 𝒰 f g s ≫ p2 𝒰 f g = s.snd := by
   rw [← cancel_epi (𝒰.pullbackCover s.fst).fromGlued]
   apply Multicoequalizer.hom_ext
   intro b
-  simp_rw [OpenCover.fromGlued, Multicoequalizer.π_desc_assoc, gluedLift, ← Category.assoc]
+  simp_rw [Cover.fromGlued, Multicoequalizer.π_desc_assoc, gluedLift, ← Category.assoc]
   simp_rw [(𝒰.pullbackCover s.fst).ι_glueMorphisms]
   simp [p2, pullback.condition]
 
@@ -334,7 +334,7 @@ theorem lift_comp_ι (i : 𝒰.J) :
       (pullback.fst _ _ : pullback (p1 𝒰 f g) (𝒰.map i) ⟶ _) := by
   apply ((gluing 𝒰 f g).openCover.pullbackCover (pullback.fst _ _)).hom_ext
   intro j
-  dsimp only [OpenCover.pullbackCover]
+  dsimp only [Cover.pullbackCover]
   trans pullbackFstιToV 𝒰 f g i j ≫ fV 𝒰 f g j i ≫ (gluing 𝒰 f g).ι _
   · rw [← show _ = fV 𝒰 f g j i ≫ _ from (gluing 𝒰 f g).glue_condition j i]
     simp_rw [← Category.assoc]
@@ -439,7 +439,7 @@ instance base_affine_hasPullback {C : CommRingCat} {X Y : Scheme} (f : X ⟶ Spe
 
 instance left_affine_comp_pullback_hasPullback {X Y Z : Scheme} (f : X ⟶ Z) (g : Y ⟶ Z)
     (i : Z.affineCover.J) : HasPullback ((Z.affineCover.pullbackCover f).map i ≫ f) g := by
-  simp only [OpenCover.pullbackCover_obj, OpenCover.pullbackCover_map, pullback.condition]
+  simp only [Cover.pullbackCover_obj, Cover.pullbackCover_map, pullback.condition]
   exact hasPullback_assoc_symm f (Z.affineCover.map i) (Z.affineCover.map i) g
 
 instance {X Y Z : Scheme} (f : X ⟶ Z) (g : Y ⟶ Z) : HasPullback f g :=
@@ -467,7 +467,7 @@ def openCoverOfLeft (𝒰 : OpenCover X) (f : X ⟶ Z) (g : Y ⟶ Z) : OpenCover
       (fun i => pullback.map _ _ _ _ (𝒰.map i) (𝟙 _) (𝟙 _) (Category.comp_id _) (by simp))
       (Equiv.refl 𝒰.J) fun _ => Iso.refl _
   rintro (i : 𝒰.J)
-  simp_rw [OpenCover.pushforwardIso_J, OpenCover.pushforwardIso_map, GlueData.openCover_map,
+  simp_rw [Cover.pushforwardIso_J, Cover.pushforwardIso_map, GlueData.openCover_map,
     GlueData.openCover_J, gluing_J]
   exact pullback.hom_ext (by simp [p1]) (by simp [p2])
 
@@ -480,7 +480,7 @@ def openCoverOfRight (𝒰 : OpenCover Y) (f : X ⟶ Z) (g : Y ⟶ Z) : OpenCove
       (fun i => pullback.map _ _ _ _ (𝟙 _) (𝒰.map i) (𝟙 _) (by simp) (Category.comp_id _))
       (Equiv.refl _) fun i => pullbackSymmetry _ _
   intro i
-  dsimp [OpenCover.bind]
+  dsimp [Cover.bind]
   apply pullback.hom_ext <;> simp
 
 /-- Given an open cover `{ Xᵢ }` of `X` and an open cover `{ Yⱼ }` of `Y`, then
@@ -506,7 +506,7 @@ def openCoverOfBase' (𝒰 : OpenCover Z) (f : X ⟶ Z) (g : Y ⟶ Z) : OpenCove
   haveI := ((IsPullback.of_hasPullback (pullback.snd g (𝒰.map i))
     (pullback.snd f (𝒰.map i))).paste_horiz (IsPullback.of_hasPullback _ _)).flip
   refine
-    @openCoverOfIsIso _ _
+    @coverOfIsIso _ _ _ _ _
       (f := (pullbackSymmetry (pullback.snd f (𝒰.map i)) (pullback.snd g (𝒰.map i))).hom ≫
         (limit.isoLimitCone ⟨_, this.isLimit⟩).inv ≫
         pullback.map _ _ _ _ (𝟙 _) (𝟙 _) (𝟙 _) ?_ ?_) inferInstance

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -688,15 +688,15 @@ end MorphismRestrict
 noncomputable
 def Scheme.OpenCover.restrict {X : Scheme.{u}} (𝒰 : X.OpenCover) (U : Opens X) :
     U.toScheme.OpenCover := by
-  refine copy (𝒰.pullbackCover U.ι) 𝒰.J _ (𝒰.map · ∣_ U) (Equiv.refl _)
+  refine Cover.copy (𝒰.pullbackCover U.ι) 𝒰.J _ (𝒰.map · ∣_ U) (Equiv.refl _)
     (fun i ↦ IsOpenImmersion.isoOfRangeEq (Opens.ι _) (pullback.snd _ _) ?_) ?_
   · erw [IsOpenImmersion.range_pullback_snd_of_left U.ι (𝒰.map i)]
     rw [Opens.opensRange_ι]
     exact Subtype.range_val
   · intro i
     rw [← cancel_mono U.ι]
-    simp only [morphismRestrict_ι, pullbackCover_J, Equiv.refl_apply, pullbackCover_obj,
-      pullbackCover_map, Category.assoc, pullback.condition]
+    simp only [morphismRestrict_ι, Cover.pullbackCover_J, Equiv.refl_apply, Cover.pullbackCover_obj,
+      Cover.pullbackCover_map, Category.assoc, pullback.condition]
     rw [IsOpenImmersion.isoOfRangeEq_hom_fac_assoc]
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Sites/BigZariski.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/BigZariski.lean
@@ -38,7 +38,7 @@ namespace Scheme
 /-- The Zariski pretopology on the category of schemes. -/
 def zariskiPretopology : Pretopology (Scheme.{u}) where
   coverings Y S := ∃ (U : OpenCover.{u} Y), S = Presieve.ofArrows U.obj U.map
-  has_isos _ _ f _ := ⟨openCoverOfIsIso f, (Presieve.ofArrows_pUnit _).symm⟩
+  has_isos _ _ f _ := ⟨coverOfIsIso f, (Presieve.ofArrows_pUnit _).symm⟩
   pullbacks := by
     rintro Y X f _ ⟨U, rfl⟩
     exact ⟨U.pullbackCover' f, (Presieve.ofArrows_pullback _ _ _).symm⟩
@@ -46,7 +46,7 @@ def zariskiPretopology : Pretopology (Scheme.{u}) where
     rintro X _ T ⟨U, rfl⟩ H
     choose V hV using H
     use U.bind (fun j => V (U.map j) ⟨j⟩)
-    simpa only [OpenCover.bind, ← hV] using Presieve.ofArrows_bind U.obj U.map _
+    simpa only [Cover.bind, ← hV] using Presieve.ofArrows_bind U.obj U.map _
       (fun _ f H => (V f H).obj) (fun _ f H => (V f H).map)
 
 /-- The Zariski topology on the category of schemes. -/
@@ -65,7 +65,7 @@ lemma zariskiTopology_openCover {Y : Scheme.{u}} (U : OpenCover.{v} Y) :
       map := fun y => U.map (U.f y)
       f := id
       covers := U.covers
-      IsOpen := fun _ => U.IsOpen _ }
+      map_prop := fun _ => U.map_prop _ }
   refine ⟨_, zariskiPretopology_openCover V, ?_⟩
   rintro _ _ ⟨y⟩
   exact ⟨_, 𝟙 _, U.map (U.f y), ⟨_⟩, by simp⟩

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
@@ -235,6 +235,9 @@ lemma of_isLimit_cone {D : WalkingCospan ⥤ C} {c : Cone D} (hc : IsLimit c) :
   w := by simp_rw [Cone.w]
   isLimit' := ⟨IsLimit.equivOfNatIsoOfIso _ _ _ (PullbackCone.isoMk c) hc⟩
 
+lemma hasPullback (h : IsPullback fst snd f g) : HasPullback f g where
+  exists_limit := ⟨⟨h.cone, h.isLimit⟩⟩
+
 /-- The pullback provided by `HasPullback f g` fits into an `IsPullback`. -/
 theorem of_hasPullback (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g] :
     IsPullback (pullback.fst f g) (pullback.snd f g) f g :=
@@ -441,6 +444,9 @@ lemma of_isColimit_cocone {D : WalkingSpan ⥤ C} {c : Cocone D} (hc : IsColimit
       (c.ι.app .left) (c.ι.app .right) where
   w := by simp_rw [Cocone.w]
   isColimit' := ⟨IsColimit.equivOfNatIsoOfIso _ _ _ (PushoutCocone.isoMk c) hc⟩
+
+lemma hasPushout (h : IsPushout f g inl inr) : HasPushout f g where
+  exists_colimit := ⟨⟨h.cocone, h.isColimit⟩⟩
 
 /-- The pushout provided by `HasPushout f g` fits into an `IsPushout`. -/
 theorem of_hasPushout (f : Z ⟶ X) (g : Z ⟶ Y) [HasPushout f g] :

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -51,10 +51,12 @@ lemma of_isPullback {P : MorphismProperty C} [P.IsStableUnderBaseChange]
   IsStableUnderBaseChange.of_isPullback sq hg
 
 /-- Alternative constructor for `IsStableUnderBaseChange`. -/
-theorem IsStableUnderBaseChange.mk' {P : MorphismProperty C} [HasPullbacks C] [RespectsIso P]
-    (hP₂ : ∀ (X Y S : C) (f : X ⟶ S) (g : Y ⟶ S) (_ : P g), P (pullback.fst f g)) :
+theorem IsStableUnderBaseChange.mk' {P : MorphismProperty C} [RespectsIso P]
+    (hP₂ : ∀ (X Y S : C) (f : X ⟶ S) (g : Y ⟶ S) [HasPullback f g] (_ : P g),
+      P (pullback.fst f g)) :
     IsStableUnderBaseChange P where
   of_isPullback {X Y Y' S f g f' g'} sq hg := by
+    haveI : HasPullback f g := sq.flip.hasPullback
     let e := sq.flip.isoPullback
     rw [← P.cancel_left_of_respectsIso e.inv, sq.flip.isoPullback_inv_fst]
     exact hP₂ _ _ _ f g hg
@@ -139,10 +141,12 @@ lemma of_isPushout {P : MorphismProperty C} [P.IsStableUnderCobaseChange]
   IsStableUnderCobaseChange.of_isPushout sq hf
 
 /-- An alternative constructor for `IsStableUnderCobaseChange`. -/
-theorem IsStableUnderCobaseChange.mk' {P : MorphismProperty C} [HasPushouts C] [RespectsIso P]
-    (hP₂ : ∀ (A B A' : C) (f : A ⟶ A') (g : A ⟶ B) (_ : P f), P (pushout.inr f g)) :
+theorem IsStableUnderCobaseChange.mk' {P : MorphismProperty C} [RespectsIso P]
+    (hP₂ : ∀ (A B A' : C) (f : A ⟶ A') (g : A ⟶ B) [HasPushout f g] (_ : P f),
+      P (pushout.inr f g)) :
     IsStableUnderCobaseChange P where
   of_isPushout {A A' B B' f g f' g'} sq hf := by
+    haveI : HasPushout f g := sq.flip.hasPushout
     let e := sq.flip.isoPushout
     rw [← P.cancel_right_of_respectsIso _ e.hom, sq.flip.inr_isoPushout_hom]
     exact hP₂ _ _ _ f g hf


### PR DESCRIPTION
This prepares for more general notions of `IsLocalAtTarget` etc. notions and is one option for defining sites defined by morphism properties.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
