### PR TITLE
[Merged by Bors] - fix: percentages in bench report

### DIFF
--- a/scripts/bench_summary.lean
+++ b/scripts/bench_summary.lean
@@ -217,7 +217,8 @@ def addBenchSummaryComment (PR : Nat) (repo : String)
     { cmd := "jq"
       args := #["-c", "[{file: .dimension.benchmark, diff: .diff, reldiff: .reldiff}]", tempFile] }
   dbg_trace "\n#running\n\
-    jq -c '[\{file: .dimension.benchmark, diff: .diff, reldiff: .reldiff}]' {tempFile} > {tempFile}.2"
+    jq -c '[\{file: .dimension.benchmark, diff: .diff, reldiff: .reldiff}]' {tempFile} > \
+      {tempFile}.2"
   let secondFilter ← IO.Process.run jq2
   IO.FS.writeFile tempFile secondFilter
   let jq3 : IO.Process.SpawnArgs :=

--- a/scripts/bench_summary.lean
+++ b/scripts/bench_summary.lean
@@ -23,7 +23,7 @@ It contains
 * an integer `diff` representing the change in number of instructions for `file`;
 * a float `reldiff` representing the percentage change in number of instructions for `file`.
 -/
-structure Bench :=
+structure Bench where
   file    : String
   diff    : Int
   reldiff : Float
@@ -124,8 +124,8 @@ def benchOutput (jsonInput : String) : IO String := do
   -- The `boundᵢ` entry becomes `none` for the collapsed entries, so that we know that these
   -- should be printed individually instead of inside a `<details><summary>`-block.
   -- A single bin with just a single file is also marked with `none`, for the same reason.
-  let ts1 := togetherSorted.groupBy (·.2.size == 1 && ·.2.size == 1)
-  let ts2 := List.join <| ts1.map fun l ↦
+  let ts1 := togetherSorted.splitBy (·.2.size == 1 && ·.2.size == 1)
+  let ts2 := List.flatten <| ts1.map fun l ↦
     if (l.getD 0 default).2.size == 1 then
       [(none, l.foldl (· ++ ·.2) #[])]
     else

--- a/scripts/bench_summary.lean
+++ b/scripts/bench_summary.lean
@@ -59,13 +59,13 @@ def formatPercent (reldiff : Float) : String :=
   s!"({sgn}{intDigs}.{if decDigs < 10 then "0" else ""}{decDigs}%)"
 
 /--
-info: [(+0.00%), (+14.28%), (+0.20%), (-0.60%), (-0.08%)]
+info: [(+0.00%), (+14.28%), (+0.20%), (-0.60%), (-0.08%), (+1.02%)]
 ---
 info: [+0.0⬝10⁹, +1.0⬝10⁹, +30.200⬝10⁹, -0.460⬝10⁹]
 -/
 #guard_msgs in
 run_cmd
-  let floats : Array Float := #[0, 1/7, 0.002, -0.006, -8.253600406145226E-4]
+  let floats : Array Float := #[0, 1/7, 0.002, -0.006, -8.253600406145226E-4, 0.0102]
   logInfo m!"{floats.map formatPercent}"
   let ints : Array Int := #[0, 10^9, 302*10^8, -460000000]
   logInfo m!"{ints.map formatDiff}"


### PR DESCRIPTION
Fixes a bug [reported on Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/typeclass.20inference.20in.20linarith/near/481042226).

The script would print percentages in the form `x.y%`, where `y` should have consisted of two digits. However, when `y` was in the range `0..9`, it would not add a leading `0`.

The rest of the PR takes care of
* updating deprecated declarations and `structure` format;
* adding command-line analogues of the lean script for easier step-by-step debugging;
* add some comments.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
