### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Matrix): split off `Matrix.stdBasis` to its own file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3281,6 +3281,7 @@ import Mathlib.LinearAlgebra.Matrix.SchurComplement
 import Mathlib.LinearAlgebra.Matrix.SesquilinearForm
 import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
 import Mathlib.LinearAlgebra.Matrix.Spectrum
+import Mathlib.LinearAlgebra.Matrix.StdBasis
 import Mathlib.LinearAlgebra.Matrix.Symmetric
 import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.Matrix.ToLinearEquiv

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
 import Mathlib.Data.Finsupp.Fintype
+import Mathlib.Data.Matrix.Basic
 import Mathlib.LinearAlgebra.Basis.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Basic.lean
@@ -3,8 +3,9 @@ Copyright (c) 2021 Riccardo Brasca. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
-import Mathlib.RingTheory.Finiteness
 import Mathlib.LinearAlgebra.FreeModule.Basic
+import Mathlib.LinearAlgebra.Matrix.StdBasis
+import Mathlib.RingTheory.Finiteness
 
 /-!
 # Finite and free modules

--- a/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
+++ b/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 -/
 import Mathlib.Algebra.Order.Star.Basic
+import Mathlib.Data.Matrix.RowCol
 import Mathlib.LinearAlgebra.StdBasis
 
 /-!

--- a/Mathlib/LinearAlgebra/Matrix/StdBasis.lean
+++ b/Mathlib/LinearAlgebra/Matrix/StdBasis.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2019 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
+-/
+import Mathlib.Data.Matrix.Basis
+import Mathlib.LinearAlgebra.StdBasis
+
+/-!
+# Standard basis on matrices
+
+## Main results
+
+* `Basis.matrix`: extend a basis on `M` to the standard basis on `Matrix n m M`
+-/
+
+namespace Basis
+variable {ι R M : Type*} (m n : Type*)
+variable [Fintype m] [Fintype n] [Semiring R] [AddCommMonoid M] [Module R M]
+
+/-- The standard basis of `Matrix m n M` given a basis on `M`. -/
+protected noncomputable def matrix (b : Basis ι R M) :
+    Basis (m × n × ι) R (Matrix m n M) :=
+  Basis.reindex (Pi.basis fun _ : m => Pi.basis fun _ : n => b)
+    ((Equiv.sigmaEquivProd _ _).trans <| .prodCongr (.refl _) (Equiv.sigmaEquivProd _ _))
+    |>.map (Matrix.ofLinearEquiv R)
+
+variable {n m}
+
+@[simp]
+theorem matrix_apply (b : Basis ι R M) (i : m) (j : n) (k : ι) [DecidableEq m] [DecidableEq n] :
+    b.matrix m n (i, j, k) = Matrix.stdBasisMatrix i j (b k) := by
+  simp [Basis.matrix, Matrix.stdBasisMatrix_eq_of_single_single]
+
+end Basis
+
+namespace Matrix
+
+variable (R : Type*) (m n : Type*) [Fintype m] [Finite n] [Semiring R]
+
+/-- The standard basis of `Matrix m n R`. -/
+noncomputable def stdBasis : Basis (m × n) R (Matrix m n R) :=
+  Basis.reindex (Pi.basis fun _ : m => Pi.basisFun R n) (Equiv.sigmaEquivProd _ _)
+    |>.map (ofLinearEquiv R)
+
+variable {n m}
+
+theorem stdBasis_eq_stdBasisMatrix (i : m) (j : n) [DecidableEq m] [DecidableEq n] :
+    stdBasis R m n (i, j) = stdBasisMatrix i j (1 : R) := by
+  simp [stdBasis, stdBasisMatrix_eq_of_single_single]
+
+end Matrix

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -3,12 +3,12 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 -/
-import Mathlib.Data.Matrix.Block
-import Mathlib.Data.Matrix.Notation
-import Mathlib.LinearAlgebra.StdBasis
-import Mathlib.RingTheory.AlgebraTower
 import Mathlib.Algebra.Algebra.Subalgebra.Tower
 import Mathlib.Data.Finite.Sum
+import Mathlib.Data.Matrix.Block
+import Mathlib.Data.Matrix.Notation
+import Mathlib.LinearAlgebra.Matrix.StdBasis
+import Mathlib.RingTheory.AlgebraTower
 
 /-!
 # Linear maps and matrices

--- a/Mathlib/LinearAlgebra/StdBasis.lean
+++ b/Mathlib/LinearAlgebra/StdBasis.lean
@@ -3,10 +3,9 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import Mathlib.Data.Matrix.Basis
-import Mathlib.LinearAlgebra.Pi
-import Mathlib.LinearAlgebra.LinearIndependent
 import Mathlib.LinearAlgebra.Basis.Defs
+import Mathlib.LinearAlgebra.LinearIndependent
+import Mathlib.LinearAlgebra.Pi
 
 /-!
 # The standard basis
@@ -286,40 +285,3 @@ lemma piEquiv_apply_apply (ι R M : Type*) [Fintype ι] [CommSemiring R]
   rw [← LinearMap.range_eq_top, range_piEquiv]
 
 end Module
-
-namespace Basis
-variable {ι R M : Type*} (m n : Type*)
-variable [Fintype m] [Fintype n] [Semiring R] [AddCommMonoid M] [Module R M]
-
-/-- The standard basis of `Matrix m n M` given a basis on `M`. -/
-protected noncomputable def matrix (b : Basis ι R M) :
-    Basis (m × n × ι) R (Matrix m n M) :=
-  Basis.reindex (Pi.basis fun _ : m => Pi.basis fun _ : n => b)
-    ((Equiv.sigmaEquivProd _ _).trans <| .prodCongr (.refl _) (Equiv.sigmaEquivProd _ _))
-    |>.map (Matrix.ofLinearEquiv R)
-
-variable {n m}
-
-@[simp]
-theorem matrix_apply (b : Basis ι R M) (i : m) (j : n) (k : ι) [DecidableEq m] [DecidableEq n] :
-    b.matrix m n (i, j, k) = Matrix.stdBasisMatrix i j (b k) := by
-  simp [Basis.matrix, Matrix.stdBasisMatrix_eq_of_single_single]
-
-end Basis
-
-namespace Matrix
-
-variable (R : Type*) (m n : Type*) [Fintype m] [Finite n] [Semiring R]
-
-/-- The standard basis of `Matrix m n R`. -/
-noncomputable def stdBasis : Basis (m × n) R (Matrix m n R) :=
-  Basis.reindex (Pi.basis fun _ : m => Pi.basisFun R n) (Equiv.sigmaEquivProd _ _)
-    |>.map (ofLinearEquiv R)
-
-variable {n m}
-
-theorem stdBasis_eq_stdBasisMatrix (i : m) (j : n) [DecidableEq m] [DecidableEq n] :
-    stdBasis R m n (i, j) = stdBasisMatrix i j (1 : R) := by
-  simp [stdBasis, stdBasisMatrix_eq_of_single_single]
-
-end Matrix

--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -35,6 +35,7 @@ In this file we define a notion of finiteness that is common in commutative alge
 
 -/
 
+assert_not_exists Matrix
 
 open Function (Surjective)
 open Finsupp

--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -35,8 +35,6 @@ In this file we define a notion of finiteness that is common in commutative alge
 
 -/
 
-assert_not_exists Matrix
-
 open Function (Surjective)
 open Finsupp
 


### PR DESCRIPTION
Previously, `LinearAlgebra.StdBasis` also defined the standard basis for matrices. We don't need matrices to define finite-dimensional spaces.

It would be nice to instead swap the import order: `LinearAlgebra.StdBasis` imported by `LinearAlgebra.Matrix.Basis`, but unfortunately that would cause a cycle with `LinearAlgebra.Matrix.ToLin`. Not entirely sure if that dependency is worth the hassle of further untangling.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
