### PR TITLE
[Merged by Bors] - chore(RingTheory/Noetherian): split `Noetherian.lean`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4236,7 +4236,11 @@ import Mathlib.RingTheory.Nakayama
 import Mathlib.RingTheory.Nilpotent.Basic
 import Mathlib.RingTheory.Nilpotent.Defs
 import Mathlib.RingTheory.Nilpotent.Lemmas
-import Mathlib.RingTheory.Noetherian
+import Mathlib.RingTheory.Noetherian.Defs
+import Mathlib.RingTheory.Noetherian.Filter
+import Mathlib.RingTheory.Noetherian.Nilpotent
+import Mathlib.RingTheory.Noetherian.Orzech
+import Mathlib.RingTheory.Noetherian.UniqueFactorizationDomain
 import Mathlib.RingTheory.NonUnitalSubring.Basic
 import Mathlib.RingTheory.NonUnitalSubring.Defs
 import Mathlib.RingTheory.NonUnitalSubsemiring.Basic

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -3,13 +3,13 @@ Copyright (c) 2023 Emily Witt. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Emily Witt, Kim Morrison, Jake Levinson, Sam van Gool
 -/
-import Mathlib.RingTheory.Ideal.Basic
 import Mathlib.Algebra.Category.ModuleCat.Colimits
 import Mathlib.Algebra.Category.ModuleCat.Projective
 import Mathlib.CategoryTheory.Abelian.Ext
-import Mathlib.RingTheory.Finiteness
 import Mathlib.CategoryTheory.Limits.Final
-import Mathlib.RingTheory.Noetherian
+import Mathlib.RingTheory.Finiteness
+import Mathlib.RingTheory.Ideal.Basic
+import Mathlib.RingTheory.Noetherian.Defs
 
 /-!
 # Local cohomology.

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
 import Mathlib.Algebra.Lie.Subalgebra
-import Mathlib.RingTheory.Noetherian
 import Mathlib.RingTheory.Artinian
+import Mathlib.RingTheory.Noetherian.Orzech
 
 /-!
 # Lie submodules of a Lie algebra

--- a/Mathlib/Algebra/Module/FinitePresentation.lean
+++ b/Mathlib/Algebra/Module/FinitePresentation.lean
@@ -3,10 +3,10 @@ Copyright (c) 2024 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.RingTheory.Noetherian
-import Mathlib.RingTheory.Localization.Module
-import Mathlib.LinearAlgebra.Isomorphisms
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
+import Mathlib.LinearAlgebra.Isomorphisms
+import Mathlib.RingTheory.Localization.Module
+import Mathlib.RingTheory.Noetherian.Defs
 /-!
 
 # Finitely Presented Modules

--- a/Mathlib/Algebra/Polynomial/Degree/CardPowDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/CardPowDegree.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 import Mathlib.Algebra.Order.EuclideanAbsoluteValue
-import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Algebra.Polynomial.FieldDivision
 

--- a/Mathlib/FieldTheory/Tower.lean
+++ b/Mathlib/FieldTheory/Tower.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import Mathlib.RingTheory.Noetherian
+import Mathlib.RingTheory.Noetherian.Defs
 
 /-!
 # Finiteness of `IsScalarTower`

--- a/Mathlib/FieldTheory/Tower.lean
+++ b/Mathlib/FieldTheory/Tower.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import Mathlib.RingTheory.AlgebraTower
 import Mathlib.RingTheory.Noetherian
 
 /-!

--- a/Mathlib/Geometry/RingedSpace/LocallyRingedSpace.lean
+++ b/Mathlib/Geometry/RingedSpace/LocallyRingedSpace.lean
@@ -6,6 +6,7 @@ Authors: Johan Commelin
 import Mathlib.Algebra.Category.Ring.Constructions
 import Mathlib.Geometry.RingedSpace.Basic
 import Mathlib.Geometry.RingedSpace.Stalks
+import Mathlib.RingTheory.Nilpotent.Defs
 
 /-!
 # The category of locally ringed spaces

--- a/Mathlib/LinearAlgebra/Dimension/Free.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Free.lean
@@ -6,6 +6,7 @@ Authors: Riccardo Brasca
 import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 import Mathlib.LinearAlgebra.FreeModule.Basic
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
+import Mathlib.RingTheory.AlgebraTower
 import Mathlib.SetTheory.Cardinal.Finsupp
 
 /-!

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
+import Mathlib.LinearAlgebra.Basis.Basic
 import Mathlib.LinearAlgebra.Dimension.Finrank
 import Mathlib.LinearAlgebra.InvariantBasisNumber
 

--- a/Mathlib/LinearAlgebra/FreeModule/PID.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/PID.lean
@@ -5,6 +5,7 @@ Authors: Anne Baanen
 -/
 import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 import Mathlib.LinearAlgebra.FreeModule.Basic
+import Mathlib.LinearAlgebra.Matrix.ToLin
 
 /-! # Free modules over PID
 

--- a/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
+++ b/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel, Kim Morrison
 -/
 import Mathlib.RingTheory.Ideal.Quotient.Basic
+import Mathlib.RingTheory.Noetherian.Orzech
 import Mathlib.RingTheory.OrzechProperty
 import Mathlib.RingTheory.PrincipalIdealDomain
 

--- a/Mathlib/NumberTheory/PellMatiyasevic.lean
+++ b/Mathlib/NumberTheory/PellMatiyasevic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Data.Nat.ModEq
 import Mathlib.NumberTheory.Zsqrtd.Basic

--- a/Mathlib/NumberTheory/PrimeCounting.lean
+++ b/Mathlib/NumberTheory/PrimeCounting.lean
@@ -6,6 +6,7 @@ Authors: Bolton Bailey, Ralf Stephan
 import Mathlib.Data.Nat.Prime.Nth
 import Mathlib.Data.Nat.Totient
 import Mathlib.NumberTheory.SmoothNumbers
+import Mathlib.Order.Filter.AtTopBot
 
 /-!
 # The Prime Counting Function

--- a/Mathlib/NumberTheory/PythagoreanTriples.lean
+++ b/Mathlib/NumberTheory/PythagoreanTriples.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul van Wamelen
 -/
 import Mathlib.Algebra.Field.Basic
-import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.RingTheory.Int.Basic
 import Mathlib.Tactic.Ring

--- a/Mathlib/RingTheory/Artinian.lean
+++ b/Mathlib/RingTheory/Artinian.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes
 -/
 import Mathlib.Data.SetLike.Fintype
 import Mathlib.Algebra.Divisibility.Prod
+import Mathlib.Order.Filter.EventuallyConst
 import Mathlib.RingTheory.Nakayama
 import Mathlib.RingTheory.SimpleModule
 import Mathlib.Tactic.RSuffices

--- a/Mathlib/RingTheory/ChainOfDivisors.lean
+++ b/Mathlib/RingTheory/ChainOfDivisors.lean
@@ -5,8 +5,9 @@ Authors: Anne Baanen, Paul Lezeau
 -/
 import Mathlib.Algebra.IsPrimePow
 import Mathlib.Algebra.Squarefree.Basic
-import Mathlib.Order.Hom.Bounded
 import Mathlib.Algebra.GCDMonoid.Basic
+import Mathlib.Data.ZMod.Defs
+import Mathlib.Order.Hom.Bounded
 /-!
 
 # Chains of divisors

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 María Inés de Frutos-Fernández. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: María Inés de Frutos-Fernández
 -/
+import Mathlib.Order.Filter.Cofinite
 import Mathlib.RingTheory.DedekindDomain.Ideal
 
 /-!

--- a/Mathlib/RingTheory/Filtration.lean
+++ b/Mathlib/RingTheory/Filtration.lean
@@ -5,12 +5,12 @@ Authors: Andrew Yang
 -/
 import Mathlib.Algebra.Polynomial.Module.Basic
 import Mathlib.Algebra.Ring.Idempotents
-import Mathlib.RingTheory.Noetherian
-import Mathlib.RingTheory.ReesAlgebra
-import Mathlib.RingTheory.Finiteness
 import Mathlib.Order.Basic
 import Mathlib.Order.Hom.Lattice
+import Mathlib.RingTheory.Finiteness
 import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
+import Mathlib.RingTheory.Noetherian.Orzech
+import Mathlib.RingTheory.ReesAlgebra
 
 /-!
 

--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
+import Mathlib.Data.Finite.Sum
 import Mathlib.RingTheory.FiniteType
 import Mathlib.RingTheory.Ideal.Quotient.Operations
 import Mathlib.RingTheory.MvPolynomial.Tower

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -6,6 +6,7 @@ Authors: Johan Commelin
 import Mathlib.Algebra.FreeAlgebra
 import Mathlib.RingTheory.Adjoin.Tower
 import Mathlib.RingTheory.Ideal.Quotient.Operations
+import Mathlib.RingTheory.Noetherian.Orzech
 
 /-!
 # Finiteness conditions in commutative algebra

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -12,7 +12,6 @@ import Mathlib.Algebra.Module.Projective
 import Mathlib.LinearAlgebra.DirectSum.TensorProduct
 import Mathlib.LinearAlgebra.FreeModule.Basic
 import Mathlib.LinearAlgebra.TensorProduct.RightExactness
-import Mathlib.RingTheory.Noetherian.Orzech
 
 /-!
 # Flat modules

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -12,7 +12,7 @@ import Mathlib.Algebra.Module.Projective
 import Mathlib.LinearAlgebra.DirectSum.TensorProduct
 import Mathlib.LinearAlgebra.FreeModule.Basic
 import Mathlib.LinearAlgebra.TensorProduct.RightExactness
-import Mathlib.RingTheory.Noetherian
+import Mathlib.RingTheory.Noetherian.Orzech
 
 /-!
 # Flat modules

--- a/Mathlib/RingTheory/FractionalIdeal/Operations.lean
+++ b/Mathlib/RingTheory/FractionalIdeal/Operations.lean
@@ -6,6 +6,7 @@ Authors: Anne Baanen, Filippo A. E. Nuccio
 import Mathlib.RingTheory.FractionalIdeal.Basic
 import Mathlib.RingTheory.IntegralClosure.IsIntegral.Basic
 import Mathlib.RingTheory.LocalRing.Basic
+import Mathlib.Tactic.FieldSimp
 
 /-!
 # More operations on fractional ideals

--- a/Mathlib/RingTheory/GradedAlgebra/HomogeneousLocalization.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/HomogeneousLocalization.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Jujian Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang, Eric Wieser
 -/
+import Mathlib.Order.Filter.AtTopBot
 import Mathlib.RingTheory.Localization.AtPrime
 import Mathlib.RingTheory.GradedAlgebra.Basic
 

--- a/Mathlib/RingTheory/GradedAlgebra/Noetherian.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/Noetherian.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Fangming Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fangming Li
 -/
-import Mathlib.RingTheory.Noetherian
 import Mathlib.RingTheory.GradedAlgebra.Basic
+import Mathlib.RingTheory.Noetherian.Defs
 
 /-!
 # The properties of a graded Noetherian ring.

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime.lean
@@ -6,7 +6,7 @@ Authors: Andrew Yang
 import Mathlib.LinearAlgebra.Span
 import Mathlib.RingTheory.Ideal.IsPrimary
 import Mathlib.RingTheory.Ideal.Quotient.Operations
-import Mathlib.RingTheory.Noetherian
+import Mathlib.RingTheory.Noetherian.Defs
 
 /-!
 

--- a/Mathlib/RingTheory/Ideal/Quotient/Noetherian.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Noetherian.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 import Mathlib.RingTheory.Ideal.Quotient.Operations
-import Mathlib.RingTheory.Noetherian
+import Mathlib.RingTheory.Noetherian.Defs
 
 /-!
 # Noetherian quotient rings and quotient modules

--- a/Mathlib/RingTheory/Lasker.lean
+++ b/Mathlib/RingTheory/Lasker.lean
@@ -6,7 +6,7 @@ Authors: Yakov Pechersky
 import Mathlib.Order.Irreducible
 import Mathlib.RingTheory.Ideal.Colon
 import Mathlib.RingTheory.Ideal.IsPrimary
-import Mathlib.RingTheory.Noetherian
+import Mathlib.RingTheory.Noetherian.Defs
 
 /-!
 # Lasker ring

--- a/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
+++ b/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau, Chris Hughes, Mario Carneiro
 -/
 import Mathlib.RingTheory.LocalRing.MaximalIdeal.Defs
 import Mathlib.RingTheory.JacobsonIdeal
+import Mathlib.RingTheory.Nilpotent.Lemmas
 
 /-!
 

--- a/Mathlib/RingTheory/Localization/Away/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Away/Basic.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Mario Carneiro, Johan Commelin, Amelia Livingston, Anne Baanen
 -/
 import Mathlib.GroupTheory.MonoidLocalization.Away
-import Mathlib.RingTheory.UniqueFactorizationDomain
+import Mathlib.RingTheory.Ideal.Maps
 import Mathlib.RingTheory.Localization.Basic
+import Mathlib.RingTheory.UniqueFactorizationDomain
 
 /-!
 # Localizations away from an element

--- a/Mathlib/RingTheory/Localization/Submodule.lean
+++ b/Mathlib/RingTheory/Localization/Submodule.lean
@@ -5,7 +5,7 @@ Authors: Kenny Lau, Mario Carneiro, Johan Commelin, Amelia Livingston, Anne Baan
 -/
 import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.RingTheory.Localization.Ideal
-import Mathlib.RingTheory.Noetherian
+import Mathlib.RingTheory.Noetherian.Defs
 
 /-!
 # Submodules in localizations of commutative rings

--- a/Mathlib/RingTheory/Nilpotent/Lemmas.lean
+++ b/Mathlib/RingTheory/Nilpotent/Lemmas.lean
@@ -7,6 +7,7 @@ import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.Quotient.Basic
 import Mathlib.RingTheory.Ideal.Maps
 import Mathlib.RingTheory.Nilpotent.Defs
+import Mathlib.RingTheory.Noetherian
 
 /-!
 # Nilpotent elements
@@ -123,3 +124,8 @@ theorem IsNilpotent.mapQ (hnp : IsNilpotent f) : IsNilpotent (p.mapQ p f hp) := 
   simp [← p.mapQ_pow, hk]
 
 end Module.End
+
+theorem IsNoetherianRing.isNilpotent_nilradical (R : Type*) [CommRing R] [IsNoetherianRing R] :
+    IsNilpotent (nilradical R) := by
+  obtain ⟨n, hn⟩ := Ideal.exists_radical_pow_le_of_fg (⊥ : Ideal R) (IsNoetherian.noetherian _)
+  exact ⟨n, eq_bot_iff.mpr hn⟩

--- a/Mathlib/RingTheory/Nilpotent/Lemmas.lean
+++ b/Mathlib/RingTheory/Nilpotent/Lemmas.lean
@@ -7,7 +7,6 @@ import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.Quotient.Basic
 import Mathlib.RingTheory.Ideal.Maps
 import Mathlib.RingTheory.Nilpotent.Defs
-import Mathlib.RingTheory.Noetherian
 
 /-!
 # Nilpotent elements
@@ -124,8 +123,3 @@ theorem IsNilpotent.mapQ (hnp : IsNilpotent f) : IsNilpotent (p.mapQ p f hp) := 
   simp [← p.mapQ_pow, hk]
 
 end Module.End
-
-theorem IsNoetherianRing.isNilpotent_nilradical (R : Type*) [CommRing R] [IsNoetherianRing R] :
-    IsNilpotent (nilradical R) := by
-  obtain ⟨n, hn⟩ := Ideal.exists_radical_pow_le_of_fg (⊥ : Ideal R) (IsNoetherian.noetherian _)
-  exact ⟨n, eq_bot_iff.mpr hn⟩

--- a/Mathlib/RingTheory/Noetherian.lean
+++ b/Mathlib/RingTheory/Noetherian.lean
@@ -3,12 +3,11 @@ Copyright (c) 2018 Mario Carneiro, Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kevin Buzzard
 -/
+import Mathlib.Algebra.Module.Submodule.IterateMapComap
+import Mathlib.Algebra.Order.Archimedean.Basic
 import Mathlib.Order.Filter.EventuallyConst
 import Mathlib.Order.PartialSups
-import Mathlib.Algebra.Module.Submodule.IterateMapComap
 import Mathlib.RingTheory.OrzechProperty
-import Mathlib.RingTheory.Nilpotent.Lemmas
-import Mathlib.Algebra.Order.Archimedean.Basic
 
 /-!
 # Noetherian rings and modules
@@ -539,11 +538,6 @@ instance isNoetherianRing_range {R} [Ring R] {S} [Ring S] (f : R →+* S) [IsNoe
 theorem isNoetherianRing_of_ringEquiv (R) [Ring R] {S} [Ring S] (f : R ≃+* S) [IsNoetherianRing R] :
     IsNoetherianRing S :=
   isNoetherianRing_of_surjective R S f.toRingHom f.toEquiv.surjective
-
-theorem IsNoetherianRing.isNilpotent_nilradical (R : Type*) [CommRing R] [IsNoetherianRing R] :
-    IsNilpotent (nilradical R) := by
-  obtain ⟨n, hn⟩ := Ideal.exists_radical_pow_le_of_fg (⊥ : Ideal R) (IsNoetherian.noetherian _)
-  exact ⟨n, eq_bot_iff.mpr hn⟩
 
 /-- Any Noetherian ring satisfies Orzech property.
 See also `IsNoetherian.injective_of_surjective_of_submodule` and

--- a/Mathlib/RingTheory/Noetherian/Defs.lean
+++ b/Mathlib/RingTheory/Noetherian/Defs.lean
@@ -3,11 +3,7 @@ Copyright (c) 2018 Mario Carneiro, Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kevin Buzzard
 -/
-import Mathlib.Algebra.Module.Submodule.IterateMapComap
-import Mathlib.Algebra.Order.Archimedean.Basic
-import Mathlib.Order.Filter.EventuallyConst
-import Mathlib.Order.PartialSups
-import Mathlib.RingTheory.OrzechProperty
+import Mathlib.RingTheory.Finiteness
 
 /-!
 # Noetherian rings and modules
@@ -51,7 +47,7 @@ Noetherian, noetherian, Noetherian ring, Noetherian module, noetherian ring, noe
 -/
 
 
-open Set Filter Pointwise
+open Set Pointwise
 
 /-- `IsNoetherian R M` is the proposition that `M` is a Noetherian `R`-module,
 implemented as the predicate that all `R`-submodules of `M` are finitely generated.
@@ -300,11 +296,6 @@ theorem monotone_stabilizes_iff_noetherian :
     (∀ f : ℕ →o Submodule R M, ∃ n, ∀ m, n ≤ m → f n = f m) ↔ IsNoetherian R M := by
   rw [isNoetherian_iff, WellFounded.monotone_chain_condition]
 
-theorem eventuallyConst_of_isNoetherian [IsNoetherian R M] (f : ℕ →o Submodule R M) :
-    atTop.EventuallyConst f := by
-  simp_rw [eventuallyConst_atTop, eq_comm]
-  exact (monotone_stabilizes_iff_noetherian.mpr inferInstance) f
-
 /-- If `∀ I > J, P I` implies `P J`, then `P` holds for all submodules. -/
 theorem IsNoetherian.induction [IsNoetherian R M] {P : Submodule R M → Prop}
     (hgt : ∀ I, (∀ J > I, P J) → P I) (I : Submodule R M) : P I :=
@@ -361,61 +352,6 @@ theorem isNoetherian_iff_submodule_quotient (S : Submodule R P) :
   apply isNoetherian_of_range_eq_ker S.subtype S.mkQ
   rw [Submodule.ker_mkQ, Submodule.range_subtype]
 
-/-- For an endomorphism of a Noetherian module, any sufficiently large iterate has disjoint kernel
-and range. -/
-theorem LinearMap.eventually_disjoint_ker_pow_range_pow (f : M →ₗ[R] M) :
-    ∀ᶠ n in atTop, Disjoint (LinearMap.ker (f ^ n)) (LinearMap.range (f ^ n)) := by
-  obtain ⟨n, hn : ∀ m, n ≤ m → LinearMap.ker (f ^ n) = LinearMap.ker (f ^ m)⟩ :=
-    monotone_stabilizes_iff_noetherian.mpr inferInstance f.iterateKer
-  refine eventually_atTop.mpr ⟨n, fun m hm ↦ disjoint_iff.mpr ?_⟩
-  rw [← hn _ hm, Submodule.eq_bot_iff]
-  rintro - ⟨hx, ⟨x, rfl⟩⟩
-  apply LinearMap.pow_map_zero_of_le hm
-  replace hx : x ∈ LinearMap.ker (f ^ (n + m)) := by
-    simpa [f.pow_apply n, f.pow_apply m, ← f.pow_apply (n + m), ← iterate_add_apply] using hx
-  rwa [← hn _ (n.le_add_right m)] at hx
-
-lemma LinearMap.eventually_iSup_ker_pow_eq (f : M →ₗ[R] M) :
-    ∀ᶠ n in atTop, ⨆ m, LinearMap.ker (f ^ m) = LinearMap.ker (f ^ n) := by
-  obtain ⟨n, hn : ∀ m, n ≤ m → ker (f ^ n) = ker (f ^ m)⟩ :=
-    monotone_stabilizes_iff_noetherian.mpr inferInstance f.iterateKer
-  refine eventually_atTop.mpr ⟨n, fun m hm ↦ ?_⟩
-  refine le_antisymm (iSup_le fun l ↦ ?_) (le_iSup (fun i ↦ LinearMap.ker (f ^ i)) m)
-  rcases le_or_lt m l with h | h
-  · rw [← hn _ (hm.trans h), hn _ hm]
-  · exact f.iterateKer.monotone h.le
-
-/-- **Orzech's theorem** for Noetherian modules: if `R` is a ring (not necessarily commutative),
-`M` and `N` are `R`-modules, `M` is Noetherian, `i : N →ₗ[R] M` is injective,
-`f : N →ₗ[R] M` is surjective, then `f` is also injective. The proof here is adapted from
-Djoković's paper *Epimorphisms of modules which must be isomorphisms* [djokovic1973],
-utilizing `LinearMap.iterateMapComap`.
-See also Orzech's original paper: *Onto endomorphisms are isomorphisms* [orzech1971]. -/
-theorem IsNoetherian.injective_of_surjective_of_injective (i f : N →ₗ[R] M)
-    (hi : Injective i) (hf : Surjective f) : Injective f := by
-  haveI := isNoetherian_of_injective i hi
-  obtain ⟨n, H⟩ := monotone_stabilizes_iff_noetherian.2 ‹_›
-    ⟨_, monotone_nat_of_le_succ <| f.iterateMapComap_le_succ i ⊥ (by simp)⟩
-  exact LinearMap.ker_eq_bot.1 <| bot_unique <|
-    f.ker_le_of_iterateMapComap_eq_succ i ⊥ n (H _ (Nat.le_succ _)) hf hi
-
-/-- **Orzech's theorem** for Noetherian modules: if `R` is a ring (not necessarily commutative),
-`M` is a Noetherian `R`-module, `N` is a submodule, `f : N →ₗ[R] M` is surjective, then `f` is also
-injective. -/
-theorem IsNoetherian.injective_of_surjective_of_submodule
-    {N : Submodule R M} (f : N →ₗ[R] M) (hf : Surjective f) : Injective f :=
-  IsNoetherian.injective_of_surjective_of_injective N.subtype f N.injective_subtype hf
-
-/-- Any surjective endomorphism of a Noetherian module is injective. -/
-theorem IsNoetherian.injective_of_surjective_endomorphism (f : M →ₗ[R] M)
-    (s : Surjective f) : Injective f :=
-  IsNoetherian.injective_of_surjective_of_injective _ f (LinearEquiv.refl _ _).injective s
-
-/-- Any surjective endomorphism of a Noetherian module is bijective. -/
-theorem IsNoetherian.bijective_of_surjective_endomorphism (f : M →ₗ[R] M)
-    (s : Surjective f) : Bijective f :=
-  ⟨IsNoetherian.injective_of_surjective_endomorphism f s, s⟩
-
 /-- A sequence `f` of submodules of a noetherian module,
 with `f (n+1)` disjoint from the supremum of `f 0`, ..., `f n`,
 is eventually zero. -/
@@ -434,19 +370,6 @@ theorem IsNoetherian.disjoint_partialSups_eventually_bot
   exact
     ⟨n, fun m p =>
       (h m).eq_bot_of_ge <| sup_eq_left.1 <| (w (m + 1) <| le_add_right p).symm.trans <| w m p⟩
-
-/-- If `M ⊕ N` embeds into `M`, for `M` noetherian over `R`, then `N` is trivial. -/
-theorem IsNoetherian.subsingleton_of_prod_injective (f : M × N →ₗ[R] M)
-    (i : Injective f) : Subsingleton N := .intro fun x y ↦ by
-  have h := IsNoetherian.injective_of_surjective_of_injective f _ i LinearMap.fst_surjective
-  simpa using h (show LinearMap.fst R M N (0, x) = LinearMap.fst R M N (0, y) from rfl)
-
-/-- If `M ⊕ N` embeds into `M`, for `M` noetherian over `R`, then `N` is trivial. -/
-@[simps!]
-def IsNoetherian.equivPUnitOfProdInjective (f : M × N →ₗ[R] M)
-    (i : Injective f) : N ≃ₗ[R] PUnit.{w + 1} :=
-  haveI := IsNoetherian.subsingleton_of_prod_injective f i
-  .ofSubsingleton _ _
 
 end
 
@@ -538,12 +461,3 @@ instance isNoetherianRing_range {R} [Ring R] {S} [Ring S] (f : R →+* S) [IsNoe
 theorem isNoetherianRing_of_ringEquiv (R) [Ring R] {S} [Ring S] (f : R ≃+* S) [IsNoetherianRing R] :
     IsNoetherianRing S :=
   isNoetherianRing_of_surjective R S f.toRingHom f.toEquiv.surjective
-
-/-- Any Noetherian ring satisfies Orzech property.
-See also `IsNoetherian.injective_of_surjective_of_submodule` and
-`IsNoetherian.injective_of_surjective_of_injective`. -/
-instance (priority := 100) IsNoetherianRing.orzechProperty
-    (R) [Ring R] [IsNoetherianRing R] : OrzechProperty R where
-  injective_of_surjective_of_submodule' {M} :=
-    letI := Module.addCommMonoidToAddCommGroup R (M := M)
-    IsNoetherian.injective_of_surjective_of_submodule

--- a/Mathlib/RingTheory/Noetherian/Filter.lean
+++ b/Mathlib/RingTheory/Noetherian/Filter.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2018 Mario Carneiro, Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Kevin Buzzard
+-/
+import Mathlib.Order.Filter.EventuallyConst
+import Mathlib.RingTheory.Noetherian.Defs
+
+/-!
+# Noetherian modules and finiteness of chains
+
+## Main results
+
+Let `R` be a ring and let `M` be an `R`-module.
+
+* `eventuallyConst_of_isNoetherian`: an ascending chain of submodules in a
+  Noetherian module is eventually constant
+
+## References
+
+* [M. F. Atiyah and I. G. Macdonald, *Introduction to commutative algebra*][atiyah-macdonald]
+* [samuel1967]
+
+## Tags
+
+Noetherian, noetherian, Noetherian ring, Noetherian module, noetherian ring, noetherian module
+
+-/
+
+
+open Set Filter Pointwise
+
+open IsNoetherian Submodule Function
+
+section Semiring
+
+variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
+
+theorem eventuallyConst_of_isNoetherian [IsNoetherian R M] (f : ℕ →o Submodule R M) :
+    atTop.EventuallyConst f := by
+  simp_rw [eventuallyConst_atTop, eq_comm]
+  exact (monotone_stabilizes_iff_noetherian.mpr inferInstance) f
+
+end Semiring

--- a/Mathlib/RingTheory/Noetherian/Nilpotent.lean
+++ b/Mathlib/RingTheory/Noetherian/Nilpotent.lean
@@ -12,7 +12,7 @@ import Mathlib.RingTheory.Noetherian.Defs
 
 ## Main results
 
-* `IsNoetherianRing.isNilpotent_nilradical`:
+* `IsNoetherianRing.isNilpotent_nilradical`
 -/
 
 open IsNoetherian

--- a/Mathlib/RingTheory/Noetherian/Nilpotent.lean
+++ b/Mathlib/RingTheory/Noetherian/Nilpotent.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2018 Mario Carneiro, Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang
+-/
+import Mathlib.RingTheory.Nilpotent.Lemmas
+import Mathlib.RingTheory.Noetherian.Defs
+
+/-!
+# Nilpotent ideals in Noetherian rings
+
+
+## Main results
+
+* `IsNoetherianRing.isNilpotent_nilradical`: 
+-/
+
+open IsNoetherian
+
+theorem IsNoetherianRing.isNilpotent_nilradical (R : Type*) [CommRing R] [IsNoetherianRing R] :
+    IsNilpotent (nilradical R) := by
+  obtain ⟨n, hn⟩ := Ideal.exists_radical_pow_le_of_fg (⊥ : Ideal R) (IsNoetherian.noetherian _)
+  exact ⟨n, eq_bot_iff.mpr hn⟩

--- a/Mathlib/RingTheory/Noetherian/Nilpotent.lean
+++ b/Mathlib/RingTheory/Noetherian/Nilpotent.lean
@@ -12,7 +12,7 @@ import Mathlib.RingTheory.Noetherian.Defs
 
 ## Main results
 
-* `IsNoetherianRing.isNilpotent_nilradical`: 
+* `IsNoetherianRing.isNilpotent_nilradical`:
 -/
 
 open IsNoetherian

--- a/Mathlib/RingTheory/Noetherian/Orzech.lean
+++ b/Mathlib/RingTheory/Noetherian/Orzech.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2018 Mario Carneiro, Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Kevin Buzzard
+-/
+import Mathlib.Algebra.Module.Submodule.IterateMapComap
+import Mathlib.Algebra.Order.Archimedean.Basic
+import Mathlib.Order.PartialSups
+import Mathlib.RingTheory.Noetherian.Defs
+import Mathlib.RingTheory.OrzechProperty
+import Mathlib.Order.Filter.AtTopBot
+
+/-!
+# Noetherian rings have the Orzech property
+
+## Main results
+
+* `IsNoetherian.injective_of_surjective_of_injective`: if `M` and `N` are `R`-modules for a ring `R`
+  (not necessarily commutative), `M` is Noetherian, `i : N →ₗ[R] M` is injective,
+  `f : N →ₗ[R] M` is surjective, then `f` is also injective.
+* `IsNoetherianRing.orzechProperty`: Any Noetherian ring satisfies the Orzech property.
+-/
+
+
+open Set Filter Pointwise
+
+open IsNoetherian Submodule Function
+
+section
+
+universe w
+
+variable {R M P : Type*} {N : Type w} [Ring R] [AddCommGroup M] [Module R M] [AddCommGroup N]
+  [Module R N] [AddCommGroup P] [Module R P] [IsNoetherian R M]
+
+/-- For an endomorphism of a Noetherian module, any sufficiently large iterate has disjoint kernel
+and range. -/
+theorem LinearMap.eventually_disjoint_ker_pow_range_pow (f : M →ₗ[R] M) :
+    ∀ᶠ n in atTop, Disjoint (LinearMap.ker (f ^ n)) (LinearMap.range (f ^ n)) := by
+  obtain ⟨n, hn : ∀ m, n ≤ m → LinearMap.ker (f ^ n) = LinearMap.ker (f ^ m)⟩ :=
+    monotone_stabilizes_iff_noetherian.mpr inferInstance f.iterateKer
+  refine eventually_atTop.mpr ⟨n, fun m hm ↦ disjoint_iff.mpr ?_⟩
+  rw [← hn _ hm, Submodule.eq_bot_iff]
+  rintro - ⟨hx, ⟨x, rfl⟩⟩
+  apply LinearMap.pow_map_zero_of_le hm
+  replace hx : x ∈ LinearMap.ker (f ^ (n + m)) := by
+    simpa [f.pow_apply n, f.pow_apply m, ← f.pow_apply (n + m), ← iterate_add_apply] using hx
+  rwa [← hn _ (n.le_add_right m)] at hx
+
+lemma LinearMap.eventually_iSup_ker_pow_eq (f : M →ₗ[R] M) :
+    ∀ᶠ n in atTop, ⨆ m, LinearMap.ker (f ^ m) = LinearMap.ker (f ^ n) := by
+  obtain ⟨n, hn : ∀ m, n ≤ m → ker (f ^ n) = ker (f ^ m)⟩ :=
+    monotone_stabilizes_iff_noetherian.mpr inferInstance f.iterateKer
+  refine eventually_atTop.mpr ⟨n, fun m hm ↦ ?_⟩
+  refine le_antisymm (iSup_le fun l ↦ ?_) (le_iSup (fun i ↦ LinearMap.ker (f ^ i)) m)
+  rcases le_or_lt m l with h | h
+  · rw [← hn _ (hm.trans h), hn _ hm]
+  · exact f.iterateKer.monotone h.le
+
+/-- **Orzech's theorem** for Noetherian modules: if `R` is a ring (not necessarily commutative),
+`M` and `N` are `R`-modules, `M` is Noetherian, `i : N →ₗ[R] M` is injective,
+`f : N →ₗ[R] M` is surjective, then `f` is also injective. The proof here is adapted from
+Djoković's paper *Epimorphisms of modules which must be isomorphisms* [djokovic1973],
+utilizing `LinearMap.iterateMapComap`.
+See also Orzech's original paper: *Onto endomorphisms are isomorphisms* [orzech1971]. -/
+theorem IsNoetherian.injective_of_surjective_of_injective (i f : N →ₗ[R] M)
+    (hi : Injective i) (hf : Surjective f) : Injective f := by
+  haveI := isNoetherian_of_injective i hi
+  obtain ⟨n, H⟩ := monotone_stabilizes_iff_noetherian.2 ‹_›
+    ⟨_, monotone_nat_of_le_succ <| f.iterateMapComap_le_succ i ⊥ (by simp)⟩
+  exact LinearMap.ker_eq_bot.1 <| bot_unique <|
+    f.ker_le_of_iterateMapComap_eq_succ i ⊥ n (H _ (Nat.le_succ _)) hf hi
+
+/-- **Orzech's theorem** for Noetherian modules: if `R` is a ring (not necessarily commutative),
+`M` is a Noetherian `R`-module, `N` is a submodule, `f : N →ₗ[R] M` is surjective, then `f` is also
+injective. -/
+theorem IsNoetherian.injective_of_surjective_of_submodule
+    {N : Submodule R M} (f : N →ₗ[R] M) (hf : Surjective f) : Injective f :=
+  IsNoetherian.injective_of_surjective_of_injective N.subtype f N.injective_subtype hf
+
+/-- Any surjective endomorphism of a Noetherian module is injective. -/
+theorem IsNoetherian.injective_of_surjective_endomorphism (f : M →ₗ[R] M)
+    (s : Surjective f) : Injective f :=
+  IsNoetherian.injective_of_surjective_of_injective _ f (LinearEquiv.refl _ _).injective s
+
+/-- Any surjective endomorphism of a Noetherian module is bijective. -/
+theorem IsNoetherian.bijective_of_surjective_endomorphism (f : M →ₗ[R] M)
+    (s : Surjective f) : Bijective f :=
+  ⟨IsNoetherian.injective_of_surjective_endomorphism f s, s⟩
+
+/-- If `M ⊕ N` embeds into `M`, for `M` noetherian over `R`, then `N` is trivial. -/
+theorem IsNoetherian.subsingleton_of_prod_injective (f : M × N →ₗ[R] M)
+    (i : Injective f) : Subsingleton N := .intro fun x y ↦ by
+  have h := IsNoetherian.injective_of_surjective_of_injective f _ i LinearMap.fst_surjective
+  simpa using h (show LinearMap.fst R M N (0, x) = LinearMap.fst R M N (0, y) from rfl)
+
+/-- If `M ⊕ N` embeds into `M`, for `M` noetherian over `R`, then `N` is trivial. -/
+@[simps!]
+def IsNoetherian.equivPUnitOfProdInjective (f : M × N →ₗ[R] M)
+    (i : Injective f) : N ≃ₗ[R] PUnit.{w + 1} :=
+  haveI := IsNoetherian.subsingleton_of_prod_injective f i
+  .ofSubsingleton _ _
+
+end
+
+/-- Any Noetherian ring satisfies Orzech property.
+See also `IsNoetherian.injective_of_surjective_of_submodule` and
+`IsNoetherian.injective_of_surjective_of_injective`. -/
+instance (priority := 100) IsNoetherianRing.orzechProperty
+    (R) [Ring R] [IsNoetherianRing R] : OrzechProperty R where
+  injective_of_surjective_of_submodule' {M} :=
+    letI := Module.addCommMonoidToAddCommGroup R (M := M)
+    IsNoetherian.injective_of_surjective_of_submodule

--- a/Mathlib/RingTheory/Noetherian/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/Noetherian/UniqueFactorizationDomain.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2018 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Anderson
+-/
+import Mathlib.RingTheory.Noetherian.Defs
+import Mathlib.RingTheory.UniqueFactorizationDomain
+/-!
+# Noetherian domains have unique factorization
+
+## Main results
+
+# IsNoetherianRing.wfDvdMonoid
+-/
+
+variable {R : Type*} [CommSemiring R] [IsDomain R]
+
+-- see Note [lower instance priority]
+instance (priority := 100) IsNoetherianRing.wfDvdMonoid [h : IsNoetherianRing R] :
+    WfDvdMonoid R :=
+  WfDvdMonoid.of_setOf_isPrincipal_wellFoundedOn_gt h.wf.wellFoundedOn

--- a/Mathlib/RingTheory/PrimeSpectrum.lean
+++ b/Mathlib/RingTheory/PrimeSpectrum.lean
@@ -7,7 +7,7 @@ import Mathlib.LinearAlgebra.Finsupp
 import Mathlib.RingTheory.Ideal.Prod
 import Mathlib.RingTheory.Localization.Ideal
 import Mathlib.RingTheory.Nilpotent.Lemmas
-import Mathlib.RingTheory.Noetherian
+import Mathlib.RingTheory.Noetherian.Defs
 
 /-!
 # Prime spectrum of a commutative (semi)ring as a type

--- a/Mathlib/RingTheory/PrincipalIdealDomain.lean
+++ b/Mathlib/RingTheory/PrincipalIdealDomain.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Morenikeji Neri
 -/
 import Mathlib.Algebra.EuclideanDomain.Field
-import Mathlib.RingTheory.UniqueFactorizationDomain
+import Mathlib.RingTheory.Noetherian.UniqueFactorizationDomain
 
 /-!
 # Principal ideal rings, principal ideal domains, and Bézout rings

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -5,10 +5,11 @@ Authors: Johannes Hölzl, Jens Wagemaker, Aaron Anderson
 -/
 import Mathlib.Algebra.BigOperators.Associated
 import Mathlib.Algebra.GCDMonoid.Basic
+import Mathlib.Data.ENat.Lattice
 import Mathlib.Data.Finsupp.Multiset
 import Mathlib.Data.Nat.Factors
-import Mathlib.RingTheory.Noetherian
 import Mathlib.RingTheory.Multiplicity
+import Mathlib.RingTheory.Ideal.Operations
 
 /-!
 
@@ -2010,11 +2011,6 @@ lemma WfDvdMonoid.of_setOf_isPrincipal_wellFoundedOn_gt [CommSemiring α] [IsDom
   convert InvImage.wf (fun a => ⟨Ideal.span ({a} : Set α), _, rfl⟩) this
   ext
   exact Ideal.span_singleton_lt_span_singleton.symm
-
--- see Note [lower instance priority]
-instance (priority := 100) IsNoetherianRing.wfDvdMonoid [CommSemiring α] [IsDomain α]
-    [h : IsNoetherianRing α] : WfDvdMonoid α :=
-  WfDvdMonoid.of_setOf_isPrincipal_wellFoundedOn_gt h.wf.wellFoundedOn
 
 end Ideal
 

--- a/Mathlib/RingTheory/Valuation/ValuationRing.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationRing.lean
@@ -8,6 +8,7 @@ import Mathlib.RingTheory.LocalRing.Basic
 import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.RingTheory.Localization.Integer
 import Mathlib.RingTheory.Valuation.Integers
+import Mathlib.Tactic.FieldSimp
 
 /-!
 # Valuation Rings

--- a/Mathlib/RingTheory/ZMod.lean
+++ b/Mathlib/RingTheory/ZMod.lean
@@ -6,6 +6,7 @@ Authors: Alex J. Best
 import Mathlib.Algebra.Squarefree.Basic
 import Mathlib.Algebra.EuclideanDomain.Int
 import Mathlib.Data.ZMod.Basic
+import Mathlib.RingTheory.Nilpotent.Lemmas
 import Mathlib.RingTheory.PrincipalIdealDomain
 
 /-!


### PR DESCRIPTION
This PR splits `RingTheory/Noetherian.lean` into the following files:
* `Noetherian/Defs.lean`: definition of `IsNoetherian` and `IsNoetherianRing`; proof of `isNoetherian_iff`
* `Noetherian/Filter.lean`: ascending chain condition, expressed in terms of filters
* `Noetherian/Orzech.lean`: Orzech's theorem and property
* `Noetherian/Nilpotent.lean`: nilpotent ideals in Noetherian rings
* `Noetherian/UniqueFactorization.lean`: Noetherian implies unique factorization

This change should also clean up the import graph for `LinearAlgebra` somewhat, especially in combination with PR #18731.

Note that there was a timeout in `Topology/Sheaves/Stalks.lean` caused by the instance search order changing. We can either do a local priority change, or simply avoid importing the slow instances. [See also Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Instance.20order.20sensitivity.20in.20.60Topology.2FSheaves.2FStalks.2Elean.60).

---

- [x] depends on: #18762

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
