### PR TITLE
[Merged by Bors] - feat(GroupTheory/FiniteAbelian/Duality): new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2979,6 +2979,7 @@ import Mathlib.GroupTheory.DoubleCoset
 import Mathlib.GroupTheory.EckmannHilton
 import Mathlib.GroupTheory.Exponent
 import Mathlib.GroupTheory.FiniteAbelian.Basic
+import Mathlib.GroupTheory.FiniteAbelian.Duality
 import Mathlib.GroupTheory.Finiteness
 import Mathlib.GroupTheory.FixedPointFree
 import Mathlib.GroupTheory.Frattini

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -14,7 +14,7 @@ import Mathlib.Data.ZMod.Quotient
   `p i ^ e i`.
 * `AddCommGroup.equiv_directSum_zmod_of_finite` : Any finite abelian group is a direct sum of
   some `ZMod (p i ^ e i)` for some prime powers `p i ^ e i`.
-
+* `CommGroup-equiv_prod_multiplicative_zmod` is a version for multiplicative groups.
 -/
 
 open scoped DirectSum
@@ -139,7 +139,7 @@ theorem equiv_directSum_zmod_of_finite [Finite G] :
             ⟨Finsupp.single 0 a, Finsupp.single_eq_same⟩).false.elim
 
 /-- **Structure theorem of finite abelian groups** : Any finite abelian group is a direct sum of
-some `ZMod (q i)` for some prime powers `q i > 1`. -/
+some `ZMod (n i)` for some natural numbers `n i > 1`. -/
 lemma equiv_directSum_zmod_of_finite' (G : Type*) [AddCommGroup G] [Finite G] :
     ∃ (ι : Type) (_ : Fintype ι) (n : ι → ℕ),
       (∀ i, 1 < n i) ∧ Nonempty (G ≃+ ⨁ i, ZMod (n i)) := by
@@ -161,7 +161,7 @@ namespace CommGroup
 theorem finite_of_fg_torsion [CommGroup G] [Group.FG G] (hG : Monoid.IsTorsion G) : Finite G :=
   @Finite.of_equiv _ _ (AddCommGroup.finite_of_fg_torsion (Additive G) hG) Multiplicative.ofAdd
 
-/-- The **Classification Theorem For Finite Abelian Groups** in a multiplicative version:
+/-- The **Structure Theorem For Finite Abelian Groups** in a multiplicative version:
 A finite commutative group `G` is isomorphic to a finite product of finite cyclic groups. -/
 theorem equiv_prod_multiplicative_zmod (G : Type*) [CommGroup G] [Finite G] :
     ∃ (ι : Type) (_ : Fintype ι) (n : ι → ℕ),

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -14,7 +14,7 @@ import Mathlib.Data.ZMod.Quotient
   `p i ^ e i`.
 * `AddCommGroup.equiv_directSum_zmod_of_finite` : Any finite abelian group is a direct sum of
   some `ZMod (p i ^ e i)` for some prime powers `p i ^ e i`.
-* `CommGroup-equiv_prod_multiplicative_zmod` is a version for multiplicative groups.
+* `CommGroup.equiv_prod_multiplicative_zmod` is a version for multiplicative groups.
 -/
 
 open scoped DirectSum

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -14,7 +14,7 @@ import Mathlib.Data.ZMod.Quotient
   `p i ^ e i`.
 * `AddCommGroup.equiv_directSum_zmod_of_finite` : Any finite abelian group is a direct sum of
   some `ZMod (p i ^ e i)` for some prime powers `p i ^ e i`.
-* `CommGroup.equiv_prod_multiplicative_zmod` is a version for multiplicative groups.
+* `CommGroup.equiv_prod_multiplicative_zmod_of_finite` is a version for multiplicative groups.
 -/
 
 open scoped DirectSum
@@ -163,7 +163,7 @@ theorem finite_of_fg_torsion [CommGroup G] [Group.FG G] (hG : Monoid.IsTorsion G
 
 /-- The **Structure Theorem For Finite Abelian Groups** in a multiplicative version:
 A finite commutative group `G` is isomorphic to a finite product of finite cyclic groups. -/
-theorem equiv_prod_multiplicative_zmod (G : Type*) [CommGroup G] [Finite G] :
+theorem equiv_prod_multiplicative_zmod_of_finite (G : Type*) [CommGroup G] [Finite G] :
     ∃ (ι : Type) (_ : Fintype ι) (n : ι → ℕ),
        (∀ (i : ι), 1 < n i) ∧ Nonempty (G ≃* ((i : ι) → Multiplicative (ZMod (n i)))) := by
   obtain ⟨ι, inst, n, h₁, h₂⟩ := AddCommGroup.equiv_directSum_zmod_of_finite' (Additive G)

--- a/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
@@ -34,7 +34,7 @@ variable (G M : Type*) [CommGroup G] [Finite G] [CommMonoid M]
 
 private
 lemma exists_apply_ne_one_aux (H : ∀ n : ℕ, n ∣ Monoid.exponent G → ∀ a : ZMod n, a ≠ 0 →
-       ∃ φ : Multiplicative (ZMod n) →* M, φ (.ofAdd a) ≠ 1)
+    ∃ φ : Multiplicative (ZMod n) →* M, φ (.ofAdd a) ≠ 1)
     {a : G} (ha : a ≠ 1) :
     ∃ φ : G →* M, φ a ≠ 1 := by
   obtain ⟨ι, _, n, _, h⟩ := CommGroup.equiv_prod_multiplicative_zmod G

--- a/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2024 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Stoll
+-/
+import Mathlib.GroupTheory.FiniteAbelian.Basic
+import Mathlib.RingTheory.RootsOfUnity.EnoughRootsOfUnity
+
+/-!
+# Duality for finite abelian groups
+
+Let `G` be a finite abelian group and let `M` be a commutative monoid that has enough `n`th roots
+of unity, where `n` is the exponent of `G`. The main results in this file are
+* `CommGroup.exists_apply_ne_one_of_hasEnoughRootsOfUnity`: Homomorphisms `G →* Mˣ` separate
+  elements of `G`.
+* `CommGroup.monoidHom_mulEquiv_self_of_hasEnoughRootsOfUnity`: `G` is isomorphic to `G →* Mˣ`.
+-/
+
+namespace CommGroup
+
+open MonoidHom
+
+private
+lemma dvd_exponent {ι G : Type*} [Finite ι] [CommGroup G] {n : ι → ℕ}
+    (e : G ≃* ((i : ι) → Multiplicative (ZMod (n i)))) (i : ι) :
+  n i ∣ Monoid.exponent G := by
+  classical -- to get `DecidableEq ι`
+  have : n i = orderOf (e.symm <| Pi.mulSingle i <| .ofAdd 1) := by
+    simpa only [MulEquiv.orderOf_eq, orderOf_piMulSingle, orderOf_ofAdd_eq_addOrderOf]
+      using (ZMod.addOrderOf_one (n i)).symm
+  exact this ▸ Monoid.order_dvd_exponent _
+
+variable (G M : Type*) [CommGroup G] [Finite G] [CommMonoid M]
+
+private
+lemma exists_apply_ne_one_aux (H : ∀ n : ℕ, n ∣ Monoid.exponent G → ∀ a : ZMod n, a ≠ 0 →
+       ∃ φ : Multiplicative (ZMod n) →* M, φ (.ofAdd a) ≠ 1)
+    {a : G} (ha : a ≠ 1) :
+    ∃ φ : G →* M, φ a ≠ 1 := by
+  obtain ⟨ι, _, n, _, h⟩ := CommGroup.equiv_prod_multiplicative_zmod G
+  let e := h.some
+  obtain ⟨i, hi⟩ : ∃ i : ι, e a i ≠ 1 := by
+    contrapose! ha
+    exact (MulEquiv.map_eq_one_iff e).mp <| funext ha
+  have hi : Multiplicative.toAdd (e a i) ≠ 0 := by
+    simp only [ne_eq, toAdd_eq_zero, hi, not_false_eq_true]
+  obtain ⟨φi, hφi⟩ := H (n i) (dvd_exponent e i) (Multiplicative.toAdd <| e a i) hi
+  use (φi.comp (Pi.evalMonoidHom (fun (i : ι) ↦ Multiplicative (ZMod (n i))) i)).comp e
+  simpa only [coe_comp, coe_coe, Function.comp_apply, Pi.evalMonoidHom_apply, ne_eq] using hφi
+
+variable  [HasEnoughRootsOfUnity M (Monoid.exponent G)]
+
+/-- If `G` is a finite commutative group of exponent `n` and `M` is a commutative monoid
+with enough `n`th roots of unity, then for each `a ≠ 1` in `G`, there exists a
+group homomorphism `φ : G → Mˣ` such that `φ a ≠ 1`. -/
+theorem exists_apply_ne_one_of_hasEnoughRootsOfUnity {a : G} (ha : a ≠ 1) :
+    ∃ φ : G →* Mˣ, φ a ≠ 1 := by
+  refine exists_apply_ne_one_aux G Mˣ (fun n hn a ha₀ ↦ ?_) ha
+  have : NeZero n := ⟨fun H ↦ NeZero.ne _ <| Nat.eq_zero_of_zero_dvd (H ▸ hn)⟩
+  have := HasEnoughRootsOfUnity.of_dvd M hn
+  exact ZMod.exists_monoidHom_apply_ne_one (HasEnoughRootsOfUnity.exists_primitiveRoot M n) ha₀
+
+/-- A finite commutative group `G` is (noncanonically) isomorphic to the group `G →* Mˣ`
+of `M`-valued characters when `M` is a commutative monoid with enough `n`th roots of unity,
+where `n` is the exponent of `G`. -/
+theorem monoidHom_mulEquiv_self_of_hasEnoughRootsOfUnity : Nonempty (G ≃* (G →* Mˣ)) := by
+  classical -- to get `DecidableEq ι`
+  obtain ⟨ι, _, n, ⟨h₁, h₂⟩⟩ := equiv_prod_multiplicative_zmod G
+  let e := h₂.some
+  let e' := Pi.monoidHomMulEquiv (fun i ↦ Multiplicative (ZMod (n i))) Mˣ
+  let e'' := MulEquiv.monoidHomCongr e (.refl Mˣ)
+  have : ∀ i, NeZero (n i) := fun i ↦ NeZero.of_gt (h₁ i)
+  have inst i : HasEnoughRootsOfUnity M <| Nat.card <| Multiplicative <| ZMod (n i) := by
+    have hdvd : Nat.card (Multiplicative (ZMod (n i))) ∣ Monoid.exponent G := by
+      simpa only [Nat.card_eq_fintype_card, Fintype.card_multiplicative, ZMod.card]
+        using dvd_exponent e i
+    exact HasEnoughRootsOfUnity.of_dvd M hdvd
+  let E i := (IsCyclic.monoidHom_equiv_self (Multiplicative (ZMod (n i))) M).some
+  exact ⟨e.trans (MulEquiv.piCongrRight E).symm|>.trans e'.symm|>.trans e''.symm⟩
+
+end CommGroup

--- a/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
@@ -37,7 +37,7 @@ lemma exists_apply_ne_one_aux (H : ∀ n : ℕ, n ∣ Monoid.exponent G → ∀ 
     ∃ φ : Multiplicative (ZMod n) →* M, φ (.ofAdd a) ≠ 1)
     {a : G} (ha : a ≠ 1) :
     ∃ φ : G →* M, φ a ≠ 1 := by
-  obtain ⟨ι, _, n, _, h⟩ := CommGroup.equiv_prod_multiplicative_zmod G
+  obtain ⟨ι, _, n, _, h⟩ := CommGroup.equiv_prod_multiplicative_zmod_of_finite G
   let e := h.some
   obtain ⟨i, hi⟩ : ∃ i : ι, e a i ≠ 1 := by
     contrapose! ha

--- a/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
@@ -63,7 +63,7 @@ theorem exists_apply_ne_one_of_hasEnoughRootsOfUnity {a : G} (ha : a ≠ 1) :
 /-- A finite commutative group `G` is (noncanonically) isomorphic to the group `G →* Mˣ`
 when `M` is a commutative monoid with enough `n`th roots of unity, where `n` is the exponent
 of `G`. -/
-theorem monoidHom_mulEquiv_self_of_hasEnoughRootsOfUnity : Nonempty (G ≃* (G →* Mˣ)) := by
+theorem mulEquiv_monoidHom_of_hasEnoughRootsOfUnity : Nonempty (G ≃* (G →* Mˣ)) := by
   classical -- to get `DecidableEq ι`
   obtain ⟨ι, _, n, ⟨h₁, h₂⟩⟩ := equiv_prod_multiplicative_zmod_of_finite G
   let e := h₂.some

--- a/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
@@ -65,7 +65,7 @@ when `M` is a commutative monoid with enough `n`th roots of unity, where `n` is 
 of `G`. -/
 theorem monoidHom_mulEquiv_self_of_hasEnoughRootsOfUnity : Nonempty (G ≃* (G →* Mˣ)) := by
   classical -- to get `DecidableEq ι`
-  obtain ⟨ι, _, n, ⟨h₁, h₂⟩⟩ := equiv_prod_multiplicative_zmod G
+  obtain ⟨ι, _, n, ⟨h₁, h₂⟩⟩ := equiv_prod_multiplicative_zmod_of_finite G
   let e := h₂.some
   let e' := Pi.monoidHomMulEquiv (fun i ↦ Multiplicative (ZMod (n i))) Mˣ
   let e'' := MulEquiv.monoidHomCongr e (.refl Mˣ)

--- a/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
@@ -48,7 +48,7 @@ lemma exists_apply_ne_one_aux (H : ∀ n : ℕ, n ∣ Monoid.exponent G → ∀ 
   use (φi.comp (Pi.evalMonoidHom (fun (i : ι) ↦ Multiplicative (ZMod (n i))) i)).comp e
   simpa only [coe_comp, coe_coe, Function.comp_apply, Pi.evalMonoidHom_apply, ne_eq] using hφi
 
-variable  [HasEnoughRootsOfUnity M (Monoid.exponent G)]
+variable [HasEnoughRootsOfUnity M (Monoid.exponent G)]
 
 /-- If `G` is a finite commutative group of exponent `n` and `M` is a commutative monoid
 with enough `n`th roots of unity, then for each `a ≠ 1` in `G`, there exists a
@@ -61,8 +61,8 @@ theorem exists_apply_ne_one_of_hasEnoughRootsOfUnity {a : G} (ha : a ≠ 1) :
   exact ZMod.exists_monoidHom_apply_ne_one (HasEnoughRootsOfUnity.exists_primitiveRoot M n) ha₀
 
 /-- A finite commutative group `G` is (noncanonically) isomorphic to the group `G →* Mˣ`
-of `M`-valued characters when `M` is a commutative monoid with enough `n`th roots of unity,
-where `n` is the exponent of `G`. -/
+when `M` is a commutative monoid with enough `n`th roots of unity, where `n` is the exponent
+of `G`. -/
 theorem monoidHom_mulEquiv_self_of_hasEnoughRootsOfUnity : Nonempty (G ≃* (G →* Mˣ)) := by
   classical -- to get `DecidableEq ι`
   obtain ⟨ι, _, n, ⟨h₁, h₂⟩⟩ := equiv_prod_multiplicative_zmod G

--- a/Mathlib/RingTheory/RootsOfUnity/EnoughRootsOfUnity.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/EnoughRootsOfUnity.lean
@@ -82,7 +82,7 @@ section cyclic
 
 /-- The group of group homomorphims from a finite cyclic group `G` of order `n` into the
 group of units of a ring `M` with all roots of unity is isomorphic to `G` -/
-lemma monoidHom_equiv_self (G M : Type*) [CommGroup G] [Finite G]
+lemma IsCyclic.monoidHom_equiv_self (G M : Type*) [CommGroup G] [Finite G]
     [IsCyclic G] [CommMonoid M] [HasEnoughRootsOfUnity M (Nat.card G)] :
     Nonempty ((G →* Mˣ) ≃* G) := by
   have : NeZero (Nat.card G) := ⟨Nat.card_pos.ne'⟩


### PR DESCRIPTION
This adds duality statements for finite abelian groups.
It also fixes some docstrings and adds a missing namespace that was left out by accident in a previous PR,

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
