### PR TITLE
[Merged by Bors] - chore(Algebra/InfiniteSum/Order): weaken typeclass assumptions

### DIFF
--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -20,14 +20,22 @@ variable {ι κ α : Type*}
 
 section Preorder
 
-variable [Preorder α] [CommMonoid α] [TopologicalSpace α] [OrderClosedTopology α] [T2Space α]
-  {f : ℕ → α} {c : α}
+variable [Preorder α] [CommMonoid α] [TopologicalSpace α] {a c : α} {f : ι → α}
 
 @[to_additive]
-theorem tprod_le_of_prod_range_le (hf : Multipliable f) (h : ∀ n, ∏ i ∈ range n, f i ≤ c) :
-    ∏' n, f n ≤ c :=
-  let ⟨_l, hl⟩ := hf
-  hl.tprod_eq.symm ▸ le_of_tendsto' hl.tendsto_prod_nat h
+lemma hasProd_le_of_prod_le [ClosedIicTopology α]
+    (hf : HasProd f a) (h : ∀ s, ∏ i ∈ s, f i ≤ c) : a ≤ c :=
+  le_of_tendsto' hf h
+
+@[to_additive]
+theorem le_hasProd_of_le_prod [ClosedIciTopology α]
+    (hf : HasProd f a) (h : ∀ s, c ≤ ∏ i ∈ s, f i) : c ≤ a :=
+  ge_of_tendsto' hf h
+
+@[to_additive]
+theorem tprod_le_of_prod_range_le [ClosedIicTopology α] {f : ℕ → α} (hf : Multipliable f)
+    (h : ∀ n, ∏ i ∈ range n, f i ≤ c) : ∏' n, f n ≤ c :=
+  le_of_tendsto' hf.hasProd.tendsto_prod_nat h
 
 end Preorder
 
@@ -43,14 +51,6 @@ theorem hasProd_le (h : ∀ i, f i ≤ g i) (hf : HasProd f a₁) (hg : HasProd 
 @[to_additive]
 theorem hasProd_mono (hf : HasProd f a₁) (hg : HasProd g a₂) (h : f ≤ g) : a₁ ≤ a₂ :=
   hasProd_le h hf hg
-
-@[to_additive]
-theorem hasProd_le_of_prod_le (hf : HasProd f a) (h : ∀ s, ∏ i ∈ s, f i ≤ a₂) : a ≤ a₂ :=
-  le_of_tendsto' hf h
-
-@[to_additive]
-theorem le_hasProd_of_le_prod (hf : HasProd f a) (h : ∀ s, a₂ ≤ ∏ i ∈ s, f i) : a₂ ≤ a :=
-  ge_of_tendsto' hf h
 
 @[to_additive]
 theorem hasProd_le_inj {g : κ → α} (e : ι → κ) (he : Injective e)


### PR DESCRIPTION
Generalise the typeclass assumptions on three lemmas, with no other changes.

- Remove any assumptions relating the order and the algebra on `hasProd_le_of_prod_le`, also weaken OrderClosedTopology to ClosedIicTopology
- Remove any assumptions relating the order and the algebra on `le_hasProd_of_le_prod`, also weaken OrderClosedTopology to ClosedIciTopology
- Remove the T2 assumption on `tprod_le_of_prod_range_le`, also weaken OrderClosedTopology to ClosedIicTopology

The first two changes mean these lemmas can now be used for infinite products of reals. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
