### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology/SimplicialSet): applications of the simplicial identities

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplexCategory.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory.lean
@@ -271,7 +271,7 @@ def σ {n} (i : Fin (n + 1)) : ([n + 1] : SimplexCategory) ⟶ [n] :=
 
 /-- The generic case of the first simplicial identity -/
 theorem δ_comp_δ {n} {i j : Fin (n + 2)} (H : i ≤ j) :
-    δ i ≫ δ j.succ = δ j ≫ δ (Fin.castSucc i) := by
+    δ i ≫ δ j.succ = δ j ≫ δ i.castSucc := by
   ext k
   dsimp [δ, Fin.succAbove]
   rcases i with ⟨i, _⟩
@@ -279,7 +279,7 @@ theorem δ_comp_δ {n} {i j : Fin (n + 2)} (H : i ≤ j) :
   rcases k with ⟨k, _⟩
   split_ifs <;> · simp at * <;> omega
 
-theorem δ_comp_δ' {n} {i : Fin (n + 2)} {j : Fin (n + 3)} (H : Fin.castSucc i < j) :
+theorem δ_comp_δ' {n} {i : Fin (n + 2)} {j : Fin (n + 3)} (H : i.castSucc < j) :
     δ i ≫ δ j =
       δ (j.pred fun (hj : j = 0) => by simp [hj, Fin.not_lt_zero] at H) ≫
         δ (Fin.castSucc i) := by
@@ -297,19 +297,19 @@ theorem δ_comp_δ'' {n} {i : Fin (n + 3)} {j : Fin (n + 2)} (H : i ≤ Fin.cast
 
 /-- The special case of the first simplicial identity -/
 @[reassoc]
-theorem δ_comp_δ_self {n} {i : Fin (n + 2)} : δ i ≫ δ (Fin.castSucc i) = δ i ≫ δ i.succ :=
+theorem δ_comp_δ_self {n} {i : Fin (n + 2)} : δ i ≫ δ i.castSucc = δ i ≫ δ i.succ :=
   (δ_comp_δ (le_refl i)).symm
 
 @[reassoc]
-theorem δ_comp_δ_self' {n} {i : Fin (n + 2)} {j : Fin (n + 3)} (H : j = Fin.castSucc i) :
+theorem δ_comp_δ_self' {n} {i : Fin (n + 2)} {j : Fin (n + 3)} (H : j = i.castSucc) :
     δ i ≫ δ j = δ i ≫ δ i.succ := by
   subst H
   rw [δ_comp_δ_self]
 
 /-- The second simplicial identity -/
 @[reassoc]
-theorem δ_comp_σ_of_le {n} {i : Fin (n + 2)} {j : Fin (n + 1)} (H : i ≤ Fin.castSucc j) :
-    δ (Fin.castSucc i) ≫ σ j.succ = σ j ≫ δ i := by
+theorem δ_comp_σ_of_le {n} {i : Fin (n + 2)} {j : Fin (n + 1)} (H : i ≤ j.castSucc) :
+    δ i.castSucc ≫ σ j.succ = σ j ≫ δ i := by
   ext k : 3
   dsimp [σ, δ]
   rcases le_or_lt i k with (hik | hik)
@@ -341,7 +341,7 @@ theorem δ_comp_σ_self {n} {i : Fin (n + 1)} :
   all_goals omega
 
 @[reassoc]
-theorem δ_comp_σ_self' {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = Fin.castSucc i) :
+theorem δ_comp_σ_self' {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = i.castSucc) :
     δ j ≫ σ i = 𝟙 ([n] : SimplexCategory) := by
   subst H
   rw [δ_comp_σ_self]
@@ -356,15 +356,15 @@ theorem δ_comp_σ_succ {n} {i : Fin (n + 1)} : δ i.succ ≫ σ i = 𝟙 ([n] :
   split_ifs <;> simp <;> simp at * <;> omega
 
 @[reassoc]
-theorem δ_comp_σ_succ' {n} (j : Fin (n + 2)) (i : Fin (n + 1)) (H : j = i.succ) :
+theorem δ_comp_σ_succ' {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = i.succ) :
     δ j ≫ σ i = 𝟙 ([n] : SimplexCategory) := by
   subst H
   rw [δ_comp_σ_succ]
 
 /-- The fourth simplicial identity -/
 @[reassoc]
-theorem δ_comp_σ_of_gt {n} {i : Fin (n + 2)} {j : Fin (n + 1)} (H : Fin.castSucc j < i) :
-    δ i.succ ≫ σ (Fin.castSucc j) = σ j ≫ δ i := by
+theorem δ_comp_σ_of_gt {n} {i : Fin (n + 2)} {j : Fin (n + 1)} (H : j.castSucc < i) :
+    δ i.succ ≫ σ j.castSucc = σ j ≫ δ i := by
   ext k : 3
   dsimp [δ, σ]
   rcases le_or_lt k i with (hik | hik)

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
@@ -482,8 +482,8 @@ lemma δ_comp_σ_of_le_apply {n} {i : Fin (n + 2)} {j : Fin (n + 1)} (H : i ≤ 
     S.δ (Fin.castSucc i) (S.σ j.succ x) = S.σ j (S.δ i x) := congr_fun (S.δ_comp_σ_of_le H) x
 
 @[simp]
-lemma δ_comp_σ_self_apply {n} (i : Fin (n + 1)) (x : S _[n]) : S.δ i.castSucc (S.σ i x) = x
-  := congr_fun S.δ_comp_σ_self x
+lemma δ_comp_σ_self_apply {n} (i : Fin (n + 1)) (x : S _[n]) : S.δ i.castSucc (S.σ i x) = x :=
+  congr_fun S.δ_comp_σ_self x
 
 @[simp]
 lemma δ_comp_σ_self'_apply {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = Fin.castSucc i)
@@ -511,7 +511,5 @@ lemma σ_comp_σ_apply {n} {i j : Fin (n + 1)} (H : i ≤ j) (x : S _[n]) :
     S.σ i.castSucc (S.σ j x) = S.σ j.succ (S.σ i x) := congr_fun (S.σ_comp_σ H) x
 
 end applications
-
-
 
 end SSet

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
@@ -455,4 +455,19 @@ noncomputable def standardSimplex : SimplexCategory ⥤ SSet.Augmented.{u} where
 
 end Augmented
 
+section applications
+
+@[simp]
+lemma SSet.δ_comp_σ_self_apply (S : SSet) {n} (i : Fin (n + 1)) (x : S _[n]) :
+    S.δ i.castSucc (S.σ i x) = x := congr_fun S.δ_comp_σ_self x
+
+@[simp]
+lemma SSet.δ_comp_σ_succ_apply (S : SSet) {n} (i : Fin (n + 1)) (x : S _[n]) :
+    S.δ i.succ (S.σ i x) = x := congr_fun S.δ_comp_σ_succ x
+
+
+end applications
+
+
+
 end SSet

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
@@ -485,7 +485,6 @@ lemma δ_comp_σ_of_le_apply {n} {i : Fin (n + 2)} {j : Fin (n + 1)} (H : i ≤ 
 lemma δ_comp_σ_self_apply {n} (i : Fin (n + 1)) (x : S _[n]) : S.δ i.castSucc (S.σ i x) = x :=
   congr_fun S.δ_comp_σ_self x
 
-@[simp]
 lemma δ_comp_σ_self'_apply {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = Fin.castSucc i)
     (x : S _[n]) : S.δ j (S.σ i x) = x := congr_fun (S.δ_comp_σ_self' H) x
 
@@ -493,7 +492,6 @@ lemma δ_comp_σ_self'_apply {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = Fi
 lemma δ_comp_σ_succ_apply {n} (i : Fin (n + 1)) (x : S _[n]) : S.δ i.succ (S.σ i x) = x :=
   congr_fun S.δ_comp_σ_succ x
 
-@[simp]
 lemma δ_comp_σ_succ'_apply {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = i.succ) (x : S _[n]) :
     S.δ j (S.σ i x) = x := congr_fun (S.δ_comp_σ_succ' H) x
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
@@ -456,15 +456,59 @@ noncomputable def standardSimplex : SimplexCategory ⥤ SSet.Augmented.{u} where
 end Augmented
 
 section applications
+variable {S : SSet}
+
+lemma δ_comp_δ_apply {n} {i j : Fin (n + 2)} (H : i ≤ j) (x : S _[n + 2]) :
+    S.δ i (S.δ j.succ x) = S.δ j (S.δ i.castSucc x) := congr_fun (S.δ_comp_δ H) x
+
+lemma δ_comp_δ'_apply {n} {i : Fin (n + 2)} {j : Fin (n + 3)} (H : Fin.castSucc i < j)
+    (x : S _[n + 2]) : S.δ i (S.δ j x) =
+      S.δ (j.pred fun (hj : j = 0) => by simp [hj, Fin.not_lt_zero] at H) (S.δ i.castSucc x) :=
+  congr_fun (S.δ_comp_δ' H) x
+
+lemma δ_comp_δ''_apply {n} {i : Fin (n + 3)} {j : Fin (n + 2)} (H : i ≤ Fin.castSucc j)
+    (x : S _[n + 2]) :
+    S.δ (i.castLT (Nat.lt_of_le_of_lt (Fin.le_iff_val_le_val.mp H) j.is_lt)) (S.δ j.succ x) =
+      S.δ j (S.δ i x) := congr_fun (S.δ_comp_δ'' H) x
+
+lemma δ_comp_δ_self_apply {n} {i : Fin (n + 2)} (x : S _[n + 2]) :
+    S.δ i (S.δ i.castSucc x) = S.δ i (S.δ i.succ x) := congr_fun S.δ_comp_δ_self x
+
+lemma δ_comp_δ_self'_apply {n} {i : Fin (n + 2)} {j : Fin (n + 3)} (H : j = Fin.castSucc i)
+    (x : S _[n + 2]) : S.δ i (S.δ j x) = S.δ i (S.δ i.succ x) := congr_fun (S.δ_comp_δ_self' H) x
+
+lemma δ_comp_σ_of_le_apply {n} {i : Fin (n + 2)} {j : Fin (n + 1)} (H : i ≤ Fin.castSucc j)
+    (x : S _[n + 1]) :
+    S.δ (Fin.castSucc i) (S.σ j.succ x) = S.σ j (S.δ i x) := congr_fun (S.δ_comp_σ_of_le H) x
 
 @[simp]
-lemma SSet.δ_comp_σ_self_apply (S : SSet) {n} (i : Fin (n + 1)) (x : S _[n]) :
-    S.δ i.castSucc (S.σ i x) = x := congr_fun S.δ_comp_σ_self x
+lemma δ_comp_σ_self_apply {n} (i : Fin (n + 1)) (x : S _[n]) : S.δ i.castSucc (S.σ i x) = x
+  := congr_fun S.δ_comp_σ_self x
 
 @[simp]
-lemma SSet.δ_comp_σ_succ_apply (S : SSet) {n} (i : Fin (n + 1)) (x : S _[n]) :
-    S.δ i.succ (S.σ i x) = x := congr_fun S.δ_comp_σ_succ x
+lemma δ_comp_σ_self'_apply {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = Fin.castSucc i)
+    (x : S _[n]) : S.δ j (S.σ i x) = x := congr_fun (S.δ_comp_σ_self' H) x
 
+@[simp]
+lemma δ_comp_σ_succ_apply {n} (i : Fin (n + 1)) (x : S _[n]) : S.δ i.succ (S.σ i x) = x :=
+  congr_fun S.δ_comp_σ_succ x
+
+@[simp]
+lemma δ_comp_σ_succ'_apply {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = i.succ) (x : S _[n]) :
+    S.δ j (S.σ i x) = x := congr_fun (S.δ_comp_σ_succ' H) x
+
+lemma δ_comp_σ_of_gt_apply {n} {i : Fin (n + 2)} {j : Fin (n + 1)} (H : Fin.castSucc j < i)
+    (x : S _[n + 1]) : S.δ i.succ (S.σ (Fin.castSucc j) x) = S.σ j (S.δ i x) :=
+  congr_fun (S.δ_comp_σ_of_gt H) x
+
+lemma δ_comp_σ_of_gt'_apply {n} {i : Fin (n + 3)} {j : Fin (n + 2)} (H : j.succ < i)
+    (x : S _[n + 1]) : S.δ i (S.σ j x) =
+      S.σ (j.castLT ((add_lt_add_iff_right 1).mp (lt_of_lt_of_le H i.is_le)))
+        (S.δ (i.pred fun (hi : i = 0) => by simp only [Fin.not_lt_zero, hi] at H) x) :=
+  congr_fun (S.δ_comp_σ_of_gt' H) x
+
+lemma σ_comp_σ_apply {n} {i j : Fin (n + 1)} (H : i ≤ j) (x : S _[n]) :
+    S.σ i.castSucc (S.σ j x) = S.σ j.succ (S.σ i x) := congr_fun (S.σ_comp_σ H) x
 
 end applications
 


### PR DESCRIPTION
For each of the generating simplicial identities, we provide a corresponding application lemma in simplicial sets.

---

This PR implements a suggestion of @joelriou; let me know if you'd like to be credited as a co-author.

I've added a "simp" tag only in the cases that reduce to the identity function and only for two of these: `δ_comp_σ_self_apply` and `δ_comp_σ_succ_apply`. The linter pointed out that simp could then prove the primed versions. Or should I simp those too but with a different priority? (I don't know how to do this.)

This also implements a very minor bit of cleanup in the SimplexCategory file:
(*) replacing `Fin.castSucc i` by `i.castSucc`
(**) making the `j` and `i` arguments of `δ_comp_σ_succ'` implicit; I assume this was a mistake?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
