### PR TITLE
[Merged by Bors] - feat: tensoring a localization with itself does nothing

### DIFF
--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -32,6 +32,7 @@ def mul : A →ₗ[R] A →ₗ[R] A :=
   LinearMap.mk₂ R (· * ·) add_mul smul_mul_assoc mul_add mul_smul_comm
 
 /-- The multiplication map on a non-unital algebra, as an `R`-linear map from `A ⊗[R] A` to `A`. -/
+-- TODO: upgrade to A-linear map if A is a semiring.
 noncomputable def mul' : A ⊗[R] A →ₗ[R] A :=
   TensorProduct.lift (mul R A)
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -1091,10 +1091,6 @@ lemma comm_comp_rTensor_comp_comm_eq (g : N →ₗ[R] P) :
       lTensor Q g :=
   TensorProduct.ext rfl
 
-theorem rTensor_tensor : rTensor (M ⊗[R] N) g = TensorProduct.assoc R Q M N ∘ₗ
-    rTensor N (rTensor M g) ∘ₗ (TensorProduct.assoc R P M N).symm :=
-  TensorProduct.ext <| LinearMap.ext fun _ ↦ TensorProduct.ext rfl
-
 lemma comm_comp_lTensor_comp_comm_eq (g : N →ₗ[R] P) :
     TensorProduct.comm R Q P ∘ₗ lTensor Q g ∘ₗ TensorProduct.comm R N Q =
       rTensor Q g :=

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -569,9 +569,7 @@ theorem mapOfCompatibleSMul_surjective : Function.Surjective (mapOfCompatibleSMu
   fun x ↦ x.induction_on (⟨0, map_zero _⟩) (fun m n ↦ ⟨_, mapOfCompatibleSMul_tmul ..⟩)
     fun _ _ ⟨x, hx⟩ ⟨y, hy⟩ ↦ ⟨x + y, by simpa using congr($hx + $hy)⟩
 
-variable [CompatibleSMul A R M N]
-
-def equivOfCompatibleSMul : M ⊗[A] N ≃ₗ[A] M ⊗[R] N where
+def equivOfCompatibleSMul [CompatibleSMul A R M N] : M ⊗[A] N ≃ₗ[A] M ⊗[R] N where
   __ := mapOfCompatibleSMul R M N A
   invFun := mapOfCompatibleSMul A M N R
   left_inv x := x.induction_on (map_zero _) (fun _ _ ↦ rfl)

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -569,6 +569,8 @@ theorem mapOfCompatibleSMul_surjective : Function.Surjective (mapOfCompatibleSMu
   fun x ↦ x.induction_on (⟨0, map_zero _⟩) (fun m n ↦ ⟨_, mapOfCompatibleSMul_tmul ..⟩)
     fun _ _ ⟨x, hx⟩ ⟨y, hy⟩ ↦ ⟨x + y, by simpa using congr($hx + $hy)⟩
 
+/-- If the R- and A-actions on M and N satisfy `CompatibleSMul` both ways,
+then `M ⊗[A] N` is canonically isomorphic to `M ⊗[R] N`. -/
 def equivOfCompatibleSMul [CompatibleSMul A R M N] : M ⊗[A] N ≃ₗ[A] M ⊗[R] N where
   __ := mapOfCompatibleSMul R M N A
   invFun := mapOfCompatibleSMul A M N R

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -538,6 +538,49 @@ theorem lift_compr₂ (g : P →ₗ[R] Q) : lift (f.compr₂ g) = g.comp (lift f
 theorem lift_mk_compr₂ (f : M ⊗ N →ₗ[R] P) : lift ((mk R M N).compr₂ f) = f := by
   rw [lift_compr₂ f, lift_mk, LinearMap.comp_id]
 
+section ScalarTower
+
+variable (R M N A) [CommSemiring A] [Module A M] [Module A N] [SMulCommClass R A M]
+  [CompatibleSMul R A M N]
+
+/-- If M and N are both R- and A-modules and their actions on them commute,
+and if the A-action on `M ⊗[R] N` can switch between the two factors, then there is a
+canonical A-linear map from `M ⊗[A] N` to `M ⊗[R] N`. -/
+def mapOfCompatibleSMul : M ⊗[A] N →ₗ[A] M ⊗[R] N :=
+  lift
+  { toFun := fun m ↦
+    { __ := mk R M N m
+      map_smul' := fun _ _ ↦ (smul_tmul _ _ _).symm }
+    map_add' := fun _ _ ↦ LinearMap.ext <| by simp
+    map_smul' := fun _ _ ↦ rfl }
+
+@[simp] theorem mapOfCompatibleSMul_tmul (m n) : mapOfCompatibleSMul R M N A (m ⊗ₜ n) = m ⊗ₜ n :=
+  rfl
+
+attribute [local instance] SMulCommClass.symm
+
+/-- `mapOfCompatibleSMul R M N A` is also A-linear. -/
+def mapOfCompatibleSMul' : M ⊗[A] N →ₗ[R] M ⊗[R] N where
+  __ := mapOfCompatibleSMul R M N A
+  map_smul' _ x := x.induction_on (map_zero _) (fun _ _ ↦ by simp [smul_tmul'])
+    fun _ _ h h' ↦ by simpa using congr($h + $h')
+
+theorem mapOfCompatibleSMul_surjective : Function.Surjective (mapOfCompatibleSMul R M N A) :=
+  fun x ↦ x.induction_on (⟨0, map_zero _⟩) (fun m n ↦ ⟨_, mapOfCompatibleSMul_tmul ..⟩)
+    fun _ _ ⟨x, hx⟩ ⟨y, hy⟩ ↦ ⟨x + y, by simpa using congr($hx + $hy)⟩
+
+variable [CompatibleSMul A R M N]
+
+def equivOfCompatibleSMul : M ⊗[A] N ≃ₗ[A] M ⊗[R] N where
+  __ := mapOfCompatibleSMul R M N A
+  invFun := mapOfCompatibleSMul A M N R
+  left_inv x := x.induction_on (map_zero _) (fun _ _ ↦ rfl)
+    fun _ _ h h' ↦ by simpa using congr($h + $h')
+  right_inv x := x.induction_on (map_zero _) (fun _ _ ↦ rfl)
+    fun _ _ h h' ↦ by simpa using congr($h + $h')
+
+end ScalarTower
+
 /-- This used to be an `@[ext]` lemma, but it fails very slowly when the `ext` tactic tries to apply
 it in some cases, notably when one wants to show equality of two linear maps. The `@[ext]`
 attribute is now added locally where it is needed. Using this as the `@[ext]` lemma instead of
@@ -1486,3 +1529,5 @@ theorem rTensor_neg (f : N →ₗ[R] P) : (-f).rTensor M = -f.rTensor M := by
 end LinearMap
 
 end Ring
+
+set_option linter.style.longFile 1700

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -1091,6 +1091,10 @@ lemma comm_comp_rTensor_comp_comm_eq (g : N →ₗ[R] P) :
       lTensor Q g :=
   TensorProduct.ext rfl
 
+theorem rTensor_tensor : rTensor (M ⊗[R] N) g = TensorProduct.assoc R Q M N ∘ₗ
+    rTensor N (rTensor M g) ∘ₗ (TensorProduct.assoc R P M N).symm :=
+  TensorProduct.ext <| LinearMap.ext fun _ ↦ TensorProduct.ext rfl
+
 lemma comm_comp_lTensor_comp_comm_eq (g : N →ₗ[R] P) :
     TensorProduct.comm R Q P ∘ₗ lTensor Q g ∘ₗ TensorProduct.comm R N Q =
       rTensor Q g :=

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -348,9 +348,12 @@ variable [Algebra A B] [IsScalarTower A B M]
 /-- `B`-linear equivalence between `M ⊗[A] (A ⊗[R] N)` and `M ⊗[R] N`.
 In particular useful with `B = A`. -/
 def cancelBaseChange : M ⊗[A] (A ⊗[R] N) ≃ₗ[B] M ⊗[R] N := by
-  letI g : (M ⊗[A] A) ⊗[R] N ≃ₗ[B] M ⊗[R] N :=
-    AlgebraTensorModule.congr (AlgebraTensorModule.rid A B M) (LinearEquiv.refl R N)
-  exact (AlgebraTensorModule.assoc R A B M A N).symm ≪≫ₗ g
+  letI g : (M ⊗[A] A) ⊗[R] N ≃ₗ[B] M ⊗[R] N := congr (AlgebraTensorModule.rid A B M) (.refl R N)
+  exact (assoc R A B M A N).symm ≪≫ₗ g
+
+/-- Base change distributes over tensor product. -/
+def distribBaseChange : A ⊗[R] (M ⊗[R] N) ≃ₗ[A] (A ⊗[R] M) ⊗[A] (A ⊗[R] N) :=
+  (cancelBaseChange _ _ _ _ _ ≪≫ₗ assoc _ _ _ _ _ _).symm
 
 variable {M P N Q}
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -347,9 +347,9 @@ variable [Algebra A B] [IsScalarTower A B M]
 
 /-- `B`-linear equivalence between `M ⊗[A] (A ⊗[R] N)` and `M ⊗[R] N`.
 In particular useful with `B = A`. -/
-def cancelBaseChange : M ⊗[A] (A ⊗[R] N) ≃ₗ[B] M ⊗[R] N := by
+def cancelBaseChange : M ⊗[A] (A ⊗[R] N) ≃ₗ[B] M ⊗[R] N :=
   letI g : (M ⊗[A] A) ⊗[R] N ≃ₗ[B] M ⊗[R] N := congr (AlgebraTensorModule.rid A B M) (.refl R N)
-  exact (assoc R A B M A N).symm ≪≫ₗ g
+  (assoc R A B M A N).symm ≪≫ₗ g
 
 /-- Base change distributes over tensor product. -/
 def distribBaseChange : A ⊗[R] (M ⊗[R] N) ≃ₗ[A] (A ⊗[R] M) ⊗[A] (A ⊗[R] N) :=

--- a/Mathlib/RingTheory/Localization/BaseChange.lean
+++ b/Mathlib/RingTheory/Localization/BaseChange.lean
@@ -64,6 +64,10 @@ theorem tensorProduct_compatibleSMul : CompatibleSMul R A M₁ M₂ where
     simp_rw [algebraMap_smul, smul_tmul', ← smul_assoc, smul_tmul, ← smul_assoc, smul_mk'_self,
       algebraMap_smul, smul_tmul]
 
+noncomputable example : M₁ ⊗[A] M₂ ≃ₗ[A] M₁ ⊗[R] M₂ :=
+  have := tensorProduct_compatibleSMul S A M₁ M₂
+  equivOfCompatibleSMul R M₁ M₂ A
+
 /-- If A is a localization of a commutative ring R, the tensor product of A with A over R is
 canonically isomorphic as A-algebras to A itself. -/
 noncomputable def tensorSelfAlgEquiv : A ⊗[R] A ≃ₐ[A] A :=

--- a/Mathlib/RingTheory/Localization/BaseChange.lean
+++ b/Mathlib/RingTheory/Localization/BaseChange.lean
@@ -19,7 +19,7 @@ localize `M` by `S`. This gives us a `Localization S`-module.
 -/
 
 variable {R : Type*} [CommSemiring R] (S : Submonoid R)
-  (A : Type*) [CommRing A] [Algebra R A] [IsLocalization S A]
+  (A : Type*) [CommSemiring A] [Algebra R A] [IsLocalization S A]
   {M : Type*} [AddCommMonoid M] [Module R M]
   {M' : Type*} [AddCommMonoid M'] [Module R M'] [Module A M'] [IsScalarTower R A M']
   (f : M →ₗ[R] M')
@@ -48,6 +48,35 @@ theorem isLocalizedModule_iff_isBaseChange : IsLocalizedModule S f ↔ IsBaseCha
   rw [LinearMap.coe_comp, LinearEquiv.coe_coe, Function.comp_apply,
     LinearEquiv.restrictScalars_apply, LinearEquiv.trans_apply, IsBaseChange.equiv_symm_apply,
     IsBaseChange.equiv_tmul, one_smul]
+
+namespace IsLocalization
+
+include S
+open TensorProduct Algebra.TensorProduct
+
+variable (M₁ M₂) [AddCommMonoid M₁] [AddCommMonoid M₂] [Module R M₁] [Module R M₂]
+  [Module A M₁] [Module A M₂] [IsScalarTower R A M₁] [IsScalarTower R A M₂]
+
+theorem tensorProduct_compatibleSMul : CompatibleSMul R A M₁ M₂ where
+  smul_tmul a _ _ := by
+    obtain ⟨r, s, rfl⟩ := IsLocalization.mk'_surjective S a
+    rw [← (map_units A s).smul_left_cancel]
+    simp_rw [algebraMap_smul, smul_tmul', ← smul_assoc, smul_tmul, ← smul_assoc, smul_mk'_self,
+      algebraMap_smul, smul_tmul]
+
+/-- If A is a localization of a commutative ring R, the tensor product of A with A over R is
+canonically isomorphic as A-algebras to A itself. -/
+noncomputable def tensorSelfAlgEquiv : A ⊗[R] A ≃ₐ[A] A :=
+  .ofAlgHom (lmul'' R) includeLeft lmul'_comp_includeLeft <| AlgHom.ext fun x ↦ x.induction_on
+    (by simp) (fun x y ↦ show (x * y) ⊗ₜ[R] 1 = x ⊗ₜ[R] y by
+      rw [mul_comm, ← smul_eq_mul, (tensorProduct_compatibleSMul S A _ _).1, smul_eq_mul, mul_one])
+    fun _ _ hx hy ↦ by simp_all [hx, hy, add_tmul]
+
+set_option linter.docPrime false in
+theorem bijective_linearMap_mul' : Function.Bijective (LinearMap.mul' R A) :=
+  (tensorSelfAlgEquiv S A).bijective
+
+end IsLocalization
 
 variable (T B : Type*) [CommSemiring T] [CommSemiring B]
   [Algebra R T] [Algebra T B] [Algebra R B] [Algebra A B] [IsScalarTower R T B]

--- a/Mathlib/RingTheory/Localization/BaseChange.lean
+++ b/Mathlib/RingTheory/Localization/BaseChange.lean
@@ -68,13 +68,15 @@ noncomputable example : M₁ ⊗[A] M₂ ≃ₗ[A] M₁ ⊗[R] M₂ :=
   have := tensorProduct_compatibleSMul S A M₁ M₂
   equivOfCompatibleSMul R M₁ M₂ A
 
+noncomputable example : A ⊗[R] M₁ ≃ₗ[A] M₁ :=
+  have := tensorProduct_compatibleSMul S A A M₁
+  (equivOfCompatibleSMul R A M₁ A).symm ≪≫ₗ TensorProduct.lid _ _
+
 /-- If A is a localization of a commutative ring R, the tensor product of A with A over R is
 canonically isomorphic as A-algebras to A itself. -/
 noncomputable def tensorSelfAlgEquiv : A ⊗[R] A ≃ₐ[A] A :=
-  .ofAlgHom (lmul'' R) includeLeft lmul'_comp_includeLeft <| AlgHom.ext fun x ↦ x.induction_on
-    (by simp) (fun x y ↦ show (x * y) ⊗ₜ[R] 1 = x ⊗ₜ[R] y by
-      rw [mul_comm, ← smul_eq_mul, (tensorProduct_compatibleSMul S A _ _).1, smul_eq_mul, mul_one])
-    fun _ _ hx hy ↦ by simp_all [hx, hy, add_tmul]
+  have := tensorProduct_compatibleSMul S A A A
+  lmulEquiv R A
 
 set_option linter.docPrime false in
 theorem bijective_linearMap_mul' : Function.Bijective (LinearMap.mul' R A) :=

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -91,6 +91,16 @@ theorem mk'_mem_iff {x} {y : M} {I : Ideal S} : mk' S x y ∈ I ↔ algebraMap R
     have := I.mul_mem_left b h
     rwa [mul_comm, mul_assoc, hb, mul_one] at this
 
+variable (M S) in
+include M in
+theorem linearMap_compatibleSMul (N₁ N₂) [AddCommMonoid N₁] [AddCommMonoid N₂] [Module R N₁]
+    [Module S N₁] [Module R N₂] [Module S N₂] [IsScalarTower R S N₁] [IsScalarTower R S N₂] :
+    LinearMap.CompatibleSMul N₁ N₂ S R where
+  map_smul f s s' := by
+    obtain ⟨r, m, rfl⟩ := mk'_surjective M s
+    rw [← (map_units S m).smul_left_cancel]
+    simp_rw [algebraMap_smul, ← map_smul, ← smul_assoc, smul_mk'_self, algebraMap_smul, map_smul]
+
 variable {g : R →+* P} (hg : ∀ y : M, IsUnit (g y))
 
 variable (M) in

--- a/Mathlib/RingTheory/Localization/Defs.lean
+++ b/Mathlib/RingTheory/Localization/Defs.lean
@@ -593,7 +593,7 @@ theorem map_map {A : Type*} [CommSemiring A] {U : Submonoid A} {W} [CommSemiring
     map W l hl (map Q g hy x) = map W (l.comp g) (fun _ hx => hl (hy hx)) x := by
   rw [← map_comp_map (Q := Q) hy hl]; rfl
 
-theorem map_smul (x : S) (z : R) : map Q g hy (z • x : S) = g z • map Q g hy x := by
+protected theorem map_smul (x : S) (z : R) : map Q g hy (z • x : S) = g z • map Q g hy x := by
   rw [Algebra.smul_def, Algebra.smul_def, RingHom.map_mul, map_eq]
 
 end

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -1036,7 +1036,7 @@ variable [Algebra R A] [Algebra R B] [Algebra R S]
 variable (f : A →ₐ[R] S) (g : B →ₐ[R] S)
 variable (R)
 
-/-- `LinearMap.mul'` as an `AlgHom` over a commutative algebra. -/
+/-- `LinearMap.mul'` as an `AlgHom` over the algebra. -/
 def lmul'' : S ⊗[R] S →ₐ[S] S :=
   algHomOfLinearMapTensorProduct
     { __ := LinearMap.mul' R S
@@ -1064,6 +1064,15 @@ theorem lmul'_comp_includeLeft : (lmul' R : _ →ₐ[R] S).comp includeLeft = Al
 @[simp]
 theorem lmul'_comp_includeRight : (lmul' R : _ →ₐ[R] S).comp includeRight = AlgHom.id R S :=
   AlgHom.ext <| one_mul
+
+variable (R S) in
+/-- If multiplication by elements of S can switch between the two factors of `S ⊗[R] S`,
+then `lmul''` is an isomorphism. -/
+def lmulEquiv [CompatibleSMul R S S S] : S ⊗[R] S ≃ₐ[S] S :=
+  .ofAlgHom (lmul'' R) includeLeft lmul'_comp_includeLeft <| AlgHom.ext fun x ↦ x.induction_on
+    (by simp) (fun x y ↦ show (x * y) ⊗ₜ[R] 1 = x ⊗ₜ[R] y by
+      rw [mul_comm, ← smul_eq_mul, smul_tmul, smul_eq_mul, mul_one])
+    fun _ _ hx hy ↦ by simp_all [hx, hy, add_tmul]
 
 /-- If `S` is commutative, for a pair of morphisms `f : A →ₐ[R] S`, `g : B →ₐ[R] S`,
 We obtain a map `A ⊗[R] B →ₐ[R] S` that commutes with `f`, `g` via `a ⊗ b ↦ f(a) * g(b)`.

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -110,6 +110,10 @@ lemma baseChange_mul (f g : Module.End R M) :
 
 variable (R A M N)
 
+/-- `baseChange A e` for `e : M ≃ₗ[R] N` is the `A`-linear map `A ⊗[R] M ≃ₗ[A] A ⊗[R] N`. -/
+def _root_.LinearEquiv.baseChange (e : M ≃ₗ[R] N) : A ⊗[R] M ≃ₗ[A] A ⊗[R] N :=
+  AlgebraTensorModule.congr (.refl _ _) e
+
 /-- `baseChange` as a linear map.
 
 When `M = N`, this is true more strongly as `Module.End.baseChangeHom`. -/
@@ -1032,11 +1036,17 @@ variable [Algebra R A] [Algebra R B] [Algebra R S]
 variable (f : A →ₐ[R] S) (g : B →ₐ[R] S)
 variable (R)
 
-/-- `LinearMap.mul'` is an `AlgHom` on commutative rings. -/
-def lmul' : S ⊗[R] S →ₐ[R] S :=
-  algHomOfLinearMapTensorProduct (LinearMap.mul' R S)
-    (fun a₁ a₂ b₁ b₂ => by simp only [LinearMap.mul'_apply, mul_mul_mul_comm]) <| by
-    simp only [LinearMap.mul'_apply, mul_one]
+/-- `LinearMap.mul'` as an `AlgHom` over a commutative algebra. -/
+def lmul'' : S ⊗[R] S →ₐ[S] S :=
+  algHomOfLinearMapTensorProduct
+    { __ := LinearMap.mul' R S
+      map_smul' := fun s x ↦ x.induction_on (by simp)
+        (fun _ _ ↦ by simp [TensorProduct.smul_tmul', mul_assoc])
+        fun x y hx hy ↦ by simp_all [hx, hy, mul_add] }
+    (fun a₁ a₂ b₁ b₂ => by simp [mul_mul_mul_comm]) <| by simp
+
+/-- `LinearMap.mul'` as an `AlgHom` over the base ring. -/
+def lmul' : S ⊗[R] S →ₐ[R] S := (lmul'' R).restrictScalars R
 
 variable {R}
 


### PR DESCRIPTION
`IsLocalization.tensorSelfAlgEquiv`: If A is a localization of a commutative ring R, then `A ⊗[R] A` is canonically isomorphic to `A` as `A`-algebras via multiplication. To construct the isomorphism we introduce a stronger version of `Algebra.TensorProduct.lmul'`.

Also add some easy theorem (`linearMap_compatibleSMul`) and defs (`distribBaseChange`, `LinearEquiv.baseChange`) and protect `IsLocalization.map_smul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
