### PR TITLE
[Merged by Bors] - feat: tensor product of two flat modules is flat

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -1091,8 +1091,8 @@ lemma comm_comp_rTensor_comp_comm_eq (g : N →ₗ[R] P) :
       lTensor Q g :=
   TensorProduct.ext rfl
 
-theorem rTensor_tensor : rTensor (M ⊗[R] N) g = TensorProduct.assoc R Q M N ∘ₗ
-    rTensor N (rTensor M g) ∘ₗ (TensorProduct.assoc R P M N).symm :=
+theorem rTensor_tensor : rTensor (M ⊗[R] N) g =
+    TensorProduct.assoc R Q M N ∘ₗ rTensor N (rTensor M g) ∘ₗ (TensorProduct.assoc R P M N).symm :=
   TensorProduct.ext <| LinearMap.ext fun _ ↦ TensorProduct.ext rfl
 
 lemma comm_comp_lTensor_comp_comm_eq (g : N →ₗ[R] P) :

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -1091,6 +1091,10 @@ lemma comm_comp_rTensor_comp_comm_eq (g : N →ₗ[R] P) :
       lTensor Q g :=
   TensorProduct.ext rfl
 
+theorem rTensor_tensor : rTensor (M ⊗[R] N) g = TensorProduct.assoc R Q M N ∘ₗ
+    rTensor N (rTensor M g) ∘ₗ (TensorProduct.assoc R P M N).symm :=
+  TensorProduct.ext <| LinearMap.ext fun _ ↦ TensorProduct.ext rfl
+
 lemma comm_comp_lTensor_comp_comm_eq (g : N →ₗ[R] P) :
     TensorProduct.comm R Q P ∘ₗ lTensor Q g ∘ₗ TensorProduct.comm R N Q =
       rTensor Q g :=

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -306,8 +306,9 @@ variable [AddCommMonoid M] [Module R M] [Module A M] [Module B M]
 variable [IsScalarTower R A M] [IsScalarTower R B M] [SMulCommClass A B M]
 variable [AddCommMonoid N] [Module R N]
 variable [AddCommMonoid P] [Module A P]
+variable [AddCommMonoid P'] [Module A P']
 variable [AddCommMonoid Q] [Module R Q]
-variable (R A B M N P Q)
+variable (R A B M N P P' Q)
 
 attribute [local ext high] TensorProduct.ext
 
@@ -339,6 +340,11 @@ theorem assoc_tmul (m : M) (p : P) (q : Q) :
 theorem assoc_symm_tmul (m : M) (p : P) (q : Q) :
     (assoc R A B M P Q).symm (m ⊗ₜ (p ⊗ₜ q)) = (m ⊗ₜ p) ⊗ₜ q :=
   rfl
+
+theorem rTensor_tensor [Module R P'] [IsScalarTower R A P'] (g : P →ₗ[A] P') :
+    rTensor (M ⊗[R] N) g =
+      assoc R A A P' M N ∘ₗ map (rTensor M g) id ∘ₗ (assoc R A A P M N).symm.toLinearMap :=
+  TensorProduct.ext <| LinearMap.ext fun _ ↦ ext fun _ _ ↦ rfl
 
 end assoc
 

--- a/Mathlib/RingTheory/Flat/Algebra.lean
+++ b/Mathlib/RingTheory/Flat/Algebra.lean
@@ -41,9 +41,11 @@ variable (R : Type u) (S : Type v) [CommRing R] [CommRing S]
 
 /-- If `T` is a flat `S`-algebra and `S` is a flat `R`-algebra,
 then `T` is a flat `R`-algebra. -/
-theorem comp (T : Type w) [CommRing T] [Algebra R S] [Algebra R T] [Algebra S T]
+theorem trans (T : Type w) [CommRing T] [Algebra R S] [Algebra R T] [Algebra S T]
     [IsScalarTower R S T] [Algebra.Flat R S] [Algebra.Flat S T] : Algebra.Flat R T where
-  out := Module.Flat.comp R S T
+  out := Module.Flat.trans R S T
+
+@[deprecated (since := "2024-11-08")] alias comp := trans
 
 /-- If `S` is a flat `R`-algebra and `T` is any `R`-algebra,
 then `T ⊗[R] S` is a flat `T`-algebra. -/
@@ -78,6 +80,6 @@ variable {R : Type u} {S : Type v} {T : Type w} [CommRing R] [CommRing S] [CommR
 instance comp [RingHom.Flat f] [RingHom.Flat g] : RingHom.Flat (g.comp f) where
   out := by
     algebraize_only [f, g, g.comp f]
-    exact Algebra.Flat.comp R S T
+    exact Algebra.Flat.trans R S T
 
 end RingHom.Flat

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -260,10 +260,14 @@ theorem rTensor_preserves_injective_linearMap {N' : Type*} [AddCommGroup N'] [Mo
 @[deprecated (since := "2024-03-29")]
 alias preserves_injective_linearMap := rTensor_preserves_injective_linearMap
 
-instance [Flat R M] [Flat R N] : Flat R (M ⊗[R] N) :=
+instance {S} [CommRing S] [Algebra R S] [Module S M] [IsScalarTower R S M] [Flat S M] [Flat R N] :
+    Flat S (M ⊗[R] N) :=
   (iff_rTensor_injective' _ _).mpr fun I ↦ by
-    simpa [rTensor_tensor] using rTensor_preserves_injective_linearMap _
+    simpa [AlgebraTensorModule.rTensor_tensor] using
+      rTensor_preserves_injective_linearMap (.restrictScalars R <| rTensor M I.subtype)
       (rTensor_preserves_injective_linearMap _ I.injective_subtype)
+
+example [Flat R M] [Flat R N] : Flat R (M ⊗[R] N) := inferInstance
 
 /--
 If `M` is a flat module, then `𝟙 M ⊗ f` is injective for all injective linear maps `f`.

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -398,9 +398,11 @@ theorem iff_rTensor_exact : Flat R M ↔
         Function.Exact f g → Function.Exact (f.rTensor M) (g.rTensor M) :=
   iff_rTensor_exact'.{max u v}
 
+variable (p : Submodule R M) (q : Submodule R N)
+
 /-- If p and q are submodules of M and N respectively, and M and q are flat,
 then `p ⊗ q → M ⊗ N` is injective. -/
-theorem tensorProduct_mapIncl_injective (p : Submodule R M) (q : Submodule R N)
+theorem tensorProduct_mapIncl_injective_of_right_flat
     [Flat R M] [Flat R q] : Function.Injective (mapIncl p q) := by
   rw [mapIncl, ← lTensor_comp_rTensor]
   exact (lTensor_preserves_injective_linearMap _ q.injective_subtype).comp
@@ -408,7 +410,7 @@ theorem tensorProduct_mapIncl_injective (p : Submodule R M) (q : Submodule R N)
 
 /-- If p and q are submodules of M and N respectively, and N and p are flat,
 then `p ⊗ q → M ⊗ N` is injective. -/
-theorem tensorProduct_mapIncl_injective' (p : Submodule R M) (q : Submodule R N)
+theorem tensorProduct_mapIncl_injective_of_left_flat
     [Flat R p] [Flat R N] : Function.Injective (mapIncl p q) := by
   rw [mapIncl, ← rTensor_comp_lTensor]
   exact (rTensor_preserves_injective_linearMap _ p.injective_subtype).comp

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -260,6 +260,11 @@ theorem rTensor_preserves_injective_linearMap {N' : Type*} [AddCommGroup N'] [Mo
 @[deprecated (since := "2024-03-29")]
 alias preserves_injective_linearMap := rTensor_preserves_injective_linearMap
 
+instance [Flat R M] [Flat R N] : Flat R (M ⊗[R] N) :=
+  (iff_rTensor_injective' _ _).mpr fun I ↦ by
+    simpa [rTensor_tensor] using rTensor_preserves_injective_linearMap _
+      (rTensor_preserves_injective_linearMap _ I.injective_subtype)
+
 /--
 If `M` is a flat module, then `𝟙 M ⊗ f` is injective for all injective linear maps `f`.
 -/
@@ -392,6 +397,22 @@ theorem iff_rTensor_exact : Flat R M ↔
       [Module R N] [Module R N'] [Module R N''] ⦃f : N →ₗ[R] N'⦄ ⦃g : N' →ₗ[R] N''⦄,
         Function.Exact f g → Function.Exact (f.rTensor M) (g.rTensor M) :=
   iff_rTensor_exact'.{max u v}
+
+/-- If p and q are submodules of M and N respectively, and M and q are flat,
+then `p ⊗ q → M ⊗ N` is injective. -/
+theorem tensorProduct_mapIncl_injective (p : Submodule R M) (q : Submodule R N)
+    [Flat R M] [Flat R q] : Function.Injective (mapIncl p q) := by
+  rw [mapIncl, ← lTensor_comp_rTensor]
+  exact (lTensor_preserves_injective_linearMap _ q.injective_subtype).comp
+    (rTensor_preserves_injective_linearMap _ p.injective_subtype)
+
+/-- If p and q are submodules of M and N respectively, and N and p are flat,
+then `p ⊗ q → M ⊗ N` is injective. -/
+theorem tensorProduct_mapIncl_injective' (p : Submodule R M) (q : Submodule R N)
+    [Flat R p] [Flat R N] : Function.Injective (mapIncl p q) := by
+  rw [mapIncl, ← rTensor_comp_lTensor]
+  exact (rTensor_preserves_injective_linearMap _ p.injective_subtype).comp
+    (lTensor_preserves_injective_linearMap _ q.injective_subtype)
 
 end Flat
 

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -402,7 +402,7 @@ variable (p : Submodule R M) (q : Submodule R N)
 
 /-- If p and q are submodules of M and N respectively, and M and q are flat,
 then `p ⊗ q → M ⊗ N` is injective. -/
-theorem tensorProduct_mapIncl_injective_of_right_flat
+theorem tensorProduct_mapIncl_injective_of_right
     [Flat R M] [Flat R q] : Function.Injective (mapIncl p q) := by
   rw [mapIncl, ← lTensor_comp_rTensor]
   exact (lTensor_preserves_injective_linearMap _ q.injective_subtype).comp
@@ -410,7 +410,7 @@ theorem tensorProduct_mapIncl_injective_of_right_flat
 
 /-- If p and q are submodules of M and N respectively, and N and p are flat,
 then `p ⊗ q → M ⊗ N` is injective. -/
-theorem tensorProduct_mapIncl_injective_of_left_flat
+theorem tensorProduct_mapIncl_injective_of_left
     [Flat R p] [Flat R N] : Function.Injective (mapIncl p q) := by
   rw [mapIncl, ← rTensor_comp_lTensor]
   exact (rTensor_preserves_injective_linearMap _ p.injective_subtype).comp

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat.lean
@@ -38,7 +38,7 @@ A module `M` over a commutative ring `R` is *faithfully flat* if it is flat and 
   all linear maps `f : N → N'`, `f = 0` iff `f ⊗ M = 0`.
 
 - `Module.FaithfullyFlat.of_linearEquiv`: modules linearly equivalent to a flat modules are flat
-- `Module.FaithfullyFlat.comp`: if `S` is `R`-faithfully flat and `M` is `S`-faithfully flat, then
+- `Module.FaithfullyFlat.trans`: if `S` is `R`-faithfully flat and `M` is `S`-faithfully flat, then
   `M` is `R`-faithfully flat.
 
 - `Module.FaithfullyFlat.self`: the `R`-module `R` is faithfully flat.
@@ -465,7 +465,7 @@ end fixed_universe
 
 end linearMap
 
-section comp
+section trans
 
 open TensorProduct LinearMap
 
@@ -477,10 +477,9 @@ variable [FaithfullyFlat R S] [FaithfullyFlat S M]
 include S in
 /-- If `S` is a faithfully flat `R`-algebra, then any faithfully flat `S`-Module is faithfully flat
 as an `R`-module. -/
-theorem comp  :
-    FaithfullyFlat R M := by
+theorem trans : FaithfullyFlat R M := by
   rw [iff_zero_iff_lTensor_zero]
-  refine ⟨Module.Flat.comp R S M, @fun N _ _ N' _ _ f => ⟨fun aux => ?_, fun eq => eq ▸ by simp⟩⟩
+  refine ⟨Module.Flat.trans R S M, @fun N _ _ N' _ _ f => ⟨fun aux => ?_, fun eq => eq ▸ by simp⟩⟩
   rw [zero_iff_lTensor_zero (R:= R) (M := S) f,
     show f.lTensor S = (AlgebraTensorModule.map (A:= S) LinearMap.id f).restrictScalars R by aesop,
     show (0 :  S ⊗[R] N →ₗ[R] S ⊗[R] N') = (0 : S ⊗[R] N →ₗ[S] S ⊗[R] N').restrictScalars R by rfl,
@@ -489,7 +488,9 @@ theorem comp  :
   apply_fun AlgebraTensorModule.cancelBaseChange R S S M N' using LinearEquiv.injective _
   simpa using congr($aux (m ⊗ₜ[R] n))
 
-end comp
+@[deprecated (since := "2024-11-08")] alias comp := trans
+
+end trans
 
 end FaithfullyFlat
 

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -62,13 +62,13 @@ private noncomputable abbrev auxRightMul (I : Ideal R) : M ⊗[R] I →ₗ[S] M 
 
 private noncomputable abbrev J (I : Ideal R) : Ideal S := LinearMap.range (auxRightMul R S S I)
 
-private noncomputable abbrev auxIso [Module.Flat R S] {I : Ideal R} :
+private noncomputable abbrev auxIso [Flat R S] {I : Ideal R} :
     S ⊗[R] I ≃ₗ[S] J R S I := by
   apply LinearEquiv.ofInjective (auxRightMul R S S I)
   simp only [LinearMap.coe_comp, LinearEquiv.coe_coe, EquivLike.comp_injective]
-  exact (Module.Flat.iff_lTensor_injective' R S).mp inferInstance I
+  exact (Flat.iff_lTensor_injective' R S).mp inferInstance I
 
-private noncomputable abbrev auxLTensor [Module.Flat R S] (I : Ideal R) :
+private noncomputable abbrev auxLTensor [Flat R S] (I : Ideal R) :
     M ⊗[R] I →ₗ[S] M := by
   letI e1 : M ⊗[R] I ≃ₗ[S] M ⊗[S] (S ⊗[R] I) :=
     (AlgebraTensorModule.cancelBaseChange R S S M I).symm
@@ -78,24 +78,26 @@ private noncomputable abbrev auxLTensor [Module.Flat R S] (I : Ideal R) :
   letI e4 : M ⊗[S] S →ₗ[S] M := TensorProduct.rid S M
   exact e4 ∘ₗ e3 ∘ₗ (e1 ≪≫ₗ e2)
 
-private lemma auxLTensor_eq [Module.Flat R S] {I : Ideal R} :
+private lemma auxLTensor_eq [Flat R S] {I : Ideal R} :
     (auxLTensor R S M I : M ⊗[R] I →ₗ[R] M) =
-    TensorProduct.rid R M ∘ₗ lTensor M (I.subtype) := by
+    TensorProduct.rid R M ∘ₗ lTensor M I.subtype := by
   apply TensorProduct.ext'
   intro m x
   erw [TensorProduct.rid_tmul]
   simp
 
 /-- If `S` is a flat `R`-algebra, then any flat `S`-Module is also `R`-flat. -/
-theorem comp [Module.Flat R S] [Module.Flat S M] : Module.Flat R M := by
-  rw [Module.Flat.iff_lTensor_injective']
+theorem trans [Flat R S] [Flat S M] : Flat R M := by
+  rw [Flat.iff_lTensor_injective']
   intro I
   rw [← EquivLike.comp_injective _ (TensorProduct.rid R M)]
-  haveI h : TensorProduct.rid R M ∘ lTensor M (Submodule.subtype I) =
+  haveI h : TensorProduct.rid R M ∘ lTensor M I.subtype =
     TensorProduct.rid R M ∘ₗ lTensor M I.subtype := rfl
   simp only [h, ← auxLTensor_eq R S M, LinearMap.coe_restrictScalars, LinearMap.coe_comp,
     LinearEquiv.coe_coe, EquivLike.comp_injective, EquivLike.injective_comp]
-  exact (Module.Flat.iff_lTensor_injective' S M).mp inferInstance _
+  exact (Flat.iff_lTensor_injective' S M).mp inferInstance _
+
+@[deprecated (since := "2024-11-03")] alias comp := trans
 
 end Composition
 
@@ -124,27 +126,26 @@ private noncomputable abbrev auxRTensorBaseChange (I : Ideal S) :
     AlgebraTensorModule.cancelBaseChange R S S I M
   letI e2 : S ⊗[S] (S ⊗[R] M) ≃ₗ[S] S ⊗[R] M :=
     AlgebraTensorModule.cancelBaseChange R S S S M
-  letI f : I ⊗[R] M →ₗ[S] S ⊗[R] M := AlgebraTensorModule.map
-    (Submodule.subtype I) LinearMap.id
+  letI f : I ⊗[R] M →ₗ[S] S ⊗[R] M := AlgebraTensorModule.map I.subtype LinearMap.id
   e2.symm.toLinearMap ∘ₗ f ∘ₗ e1.toLinearMap
 
 private lemma auxRTensorBaseChange_eq (I : Ideal S) :
-    auxRTensorBaseChange R S M I = rTensor (S ⊗[R] M) (Submodule.subtype I) := by
+    auxRTensorBaseChange R S M I = rTensor (S ⊗[R] M) I.subtype := by
   ext
   simp
 
 /-- If `M` is a flat `R`-module and `S` is any `R`-algebra, `S ⊗[R] M` is `S`-flat. -/
-instance baseChange [Module.Flat R M] : Module.Flat S (S ⊗[R] M) := by
-  rw [Module.Flat.iff_rTensor_injective']
+instance baseChange [Flat R M] : Flat S (S ⊗[R] M) := by
+  rw [Flat.iff_rTensor_injective']
   intro I
   simp only [← auxRTensorBaseChange_eq, auxRTensorBaseChange, LinearMap.coe_comp,
     LinearEquiv.coe_coe, EmbeddingLike.comp_injective, EquivLike.injective_comp]
   exact rTensor_preserves_injective_linearMap (I.subtype : I →ₗ[R] S) Subtype.val_injective
 
 /-- A base change of a flat module is flat. -/
-theorem isBaseChange [Module.Flat R M] (N : Type t) [AddCommGroup N] [Module R N] [Module S N]
+theorem isBaseChange [Flat R M] (N : Type t) [AddCommGroup N] [Module R N] [Module S N]
     [IsScalarTower R S N] {f : M →ₗ[R] N} (h : IsBaseChange S f) :
-    Module.Flat S N :=
+    Flat S N :=
   of_linearEquiv S (S ⊗[R] M) N (IsBaseChange.equiv h).symm
 
 end BaseChange
@@ -155,16 +156,16 @@ variable {R : Type u} {M Mp : Type*} (Rp : Type v)
   [CommRing R] [AddCommGroup M] [Module R M] [CommRing Rp] [Algebra R Rp]
   [AddCommGroup Mp] [Module R Mp] [Module Rp Mp] [IsScalarTower R Rp Mp]
 
-instance localizedModule [Module.Flat R M] (S : Submonoid R) : Module.Flat (Localization S)
-    (LocalizedModule S M) := by
-  apply Module.Flat.isBaseChange (R := R) (S := Localization S)
+instance localizedModule [Flat R M] (S : Submonoid R) :
+    Flat (Localization S) (LocalizedModule S M) := by
+  apply Flat.isBaseChange (R := R) (S := Localization S)
     (f := LocalizedModule.mkLinearMap S M)
   rw [← isLocalizedModule_iff_isBaseChange S]
   exact localizedModuleIsLocalizedModule S
 
-theorem of_isLocalizedModule [Module.Flat R M] (S : Submonoid R) [IsLocalization S Rp]
-    (f : M →ₗ[R] Mp) [h : IsLocalizedModule S f] : Module.Flat Rp Mp := by
-  fapply Module.Flat.isBaseChange (R := R) (M := M) (S := Rp) (N := Mp)
+theorem of_isLocalizedModule [Flat R M] (S : Submonoid R) [IsLocalization S Rp]
+    (f : M →ₗ[R] Mp) [h : IsLocalizedModule S f] : Flat Rp Mp := by
+  fapply Flat.isBaseChange (R := R) (M := M) (S := Rp) (N := Mp)
   exact (isLocalizedModule_iff_isBaseChange S Rp f).mp h
 
 end Localization


### PR DESCRIPTION
Add the missing `Flat R (M ⊗[R] N)` instance.

Add two lemmas relating flatness to injectivity of `mapIncl`.

Clean up the file Flat/Stability, renaming `Flat.comp` to `Flat.trans`.

Also rename `Algebra.Flat.comp` and `FaithfullyFlat.comp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
