### PR TITLE
[Merged by Bors] - feat: improve defeq in skeletonEquivalence

### DIFF
--- a/Mathlib/CategoryTheory/FullSubcategory.lean
+++ b/Mathlib/CategoryTheory/FullSubcategory.lean
@@ -63,6 +63,15 @@ instance InducedCategory.category : Category.{v} (InducedCategory D F) where
   id X := 𝟙 (F X)
   comp f g := f ≫ g
 
+variable {F} in
+/-- Construct an isomorphism in the induced category
+from an isomorphism in the original category. -/
+@[simps] def InducedCategory.isoMk {X Y : InducedCategory D F} (f : F X ≅ F Y) : X ≅ Y where
+  hom := f.hom
+  inv := f.inv
+  hom_inv_id := f.hom_inv_id
+  inv_hom_id := f.inv_hom_id
+
 /-- The forgetful functor from an induced category to the original category,
 forgetting the extra data.
 -/

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -386,7 +386,7 @@ def tensorIso {X Y X' Y' : C} (f : X ≅ Y)
   inv_hom_id := by rw [← tensor_comp, Iso.inv_hom_id, Iso.inv_hom_id, ← tensor_id]
 
 /-- Notation for `tensorIso`, the tensor product of isomorphisms -/
-infixr:70 " ⊗ " => tensorIso
+scoped infixr:70 " ⊗ " => tensorIso
 
 theorem tensorIso_def {X Y X' Y' : C} (f : X ≅ Y) (g : X' ≅ Y') :
     f ⊗ g = whiskerRightIso f X' ≪≫ whiskerLeftIso Y g :=

--- a/Mathlib/CategoryTheory/Monoidal/Skeleton.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Skeleton.lean
@@ -55,6 +55,12 @@ the tensor product, and satisfies the monoid axioms since it is a skeleton.
 noncomputable instance instMonoid : Monoid (Skeleton C) :=
   monoidOfSkeletalMonoidal (skeleton_isSkeleton _).skel
 
+theorem mul_eq (X Y : Skeleton C) : X * Y = toSkeleton (X.out ⊗ Y.out) := rfl
+theorem one_eq : (1 : Skeleton C) = toSkeleton (𝟙_ C) := rfl
+
+theorem toSkeleton_tensorObj (X Y : C) : toSkeleton (X ⊗ Y) = toSkeleton X * toSkeleton Y :=
+  let φ := (skeletonEquivalence C).symm.unitIso.app; Quotient.sound ⟨φ X ⊗ φ Y⟩
+
 /-- The skeleton of a braided monoidal category has a braided monoidal structure itself, induced by
 the equivalence. -/
 noncomputable instance instBraidedCategory [BraidedCategory C] : BraidedCategory (Skeleton C) :=

--- a/Mathlib/CategoryTheory/Skeletal.lean
+++ b/Mathlib/CategoryTheory/Skeletal.lean
@@ -76,6 +76,9 @@ instance [Inhabited C] : Inhabited (Skeleton C) :=
 noncomputable instance : Category (Skeleton C) := by
   apply InducedCategory.category
 
+noncomputable instance {α} [CoeSort C α] : CoeSort (Skeleton C) α :=
+  inferInstanceAs (CoeSort (InducedCategory _ _) _)
+
 /-- The functor from the skeleton of `C` to `C`. -/
 @[simps!]
 noncomputable def fromSkeleton : Skeleton C ⥤ C :=
@@ -92,9 +95,25 @@ instance : (fromSkeleton C).EssSurj where mem_essImage X := ⟨Quotient.mk' X, Q
 -- Porting note: named this instance
 noncomputable instance fromSkeleton.isEquivalence : (fromSkeleton C).IsEquivalence where
 
+theorem fromSkeleton_asEquivalence_inverse_obj (X : C) :
+    (fromSkeleton C).asEquivalence.inverse.obj X = ⟦X⟧ :=
+  Quotient.eq_mk_iff_out.mpr ⟨(fromSkeleton C).asEquivalence.counitIso.app X⟩
+
 /-- The equivalence between the skeleton and the category itself. -/
 noncomputable def skeletonEquivalence : Skeleton C ≌ C :=
-  (fromSkeleton C).asEquivalence
+  (fromSkeleton C).asEquivalence.changeInverse <|
+    Functor.isoCopyObj _ _ (eqToIso <| fromSkeleton_asEquivalence_inverse_obj C ·)
+
+variable {C}
+
+/-- The class of an object in the skeleton. -/
+abbrev toSkeleton (X : C) : Skeleton C := ⟦X⟧
+
+theorem skeletonEquivalence_inverse_obj (X : C) :
+    (skeletonEquivalence C).inverse.obj X = toSkeleton X :=
+  rfl
+
+variable (C)
 
 theorem skeleton_skeletal : Skeletal (Skeleton C) := by
   rintro X Y ⟨h⟩

--- a/Mathlib/CategoryTheory/Skeletal.lean
+++ b/Mathlib/CategoryTheory/Skeletal.lean
@@ -106,6 +106,7 @@ noncomputable def preCounitIso (X : C) : (fromSkeleton C).obj (toSkeleton X) ≅
 
 variable (C)
 
+/-- An inverse to `fromSkeleton C` that forms an equivalence with it. -/
 @[simps] noncomputable def toSkeletonFunctor : C ⥤ Skeleton C where
   obj := toSkeleton
   map {X Y} f := by apply (preCounitIso X).hom ≫ f ≫ (preCounitIso Y).inv


### PR DESCRIPTION
+ Change the `inverse` in `skeletonEquivalence` to be defeq to `Quotient.mk`; it's previously obtained from `IsEquivalence.asEquivalence` by arbitrary choice.

+ Make `tensorIso` notation scoped (`tensorObj` and `tensorHom` are already scoped).

+ Add a `CoeSort` instance for `Sksleton`.

+ Add a few API lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
