### PR TITLE
[Merged by Bors] - refactor(GroupTheory/Sylow): use namespacing and dot-notation

### DIFF
--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -264,11 +264,11 @@ theorem smul_eq_of_normal {g : G} {P : Sylow p G} [h : P.Normal] :
 end Sylow
 
 theorem Subgroup.sylow_mem_fixedPoints_iff (H : Subgroup G) {P : Sylow p G} :
-    P ∈ fixedPoints H (Sylow p G) ↔ H ≤ (P : Subgroup G).normalizer := by
+    P ∈ fixedPoints H (Sylow p G) ↔ H ≤ P.normalizer := by
   simp_rw [SetLike.le_def, ← Sylow.smul_eq_iff_mem_normalizer]; exact Subtype.forall
 
 theorem IsPGroup.inf_normalizer_sylow {P : Subgroup G} (hP : IsPGroup p P) (Q : Sylow p G) :
-    P ⊓ (Q : Subgroup G).normalizer = P ⊓ Q :=
+    P ⊓ Q.normalizer = P ⊓ Q :=
   le_antisymm
     (le_inf inf_le_left
       (sup_eq_right.mp
@@ -346,7 +346,7 @@ theorem orbit_eq_top [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) : orbit
   top_le_iff.mp fun Q _ => exists_smul_eq G P Q
 
 theorem stabilizer_eq_normalizer (P : Sylow p G) :
-    stabilizer G P = (P : Subgroup G).normalizer := by
+    stabilizer G P = P.normalizer := by
   ext; simp [smul_eq_iff_mem_normalizer]
 
 theorem conj_eq_normalizer_conj_of_mem_centralizer [Fact p.Prime] [Finite (Sylow p G)]
@@ -393,15 +393,16 @@ theorem card_eq_card_quotient_normalizer [Fact p.Prime] [Finite (Sylow p G)]
 alias _root_.card_sylow_eq_card_quotient_normalizer := card_eq_card_quotient_normalizer
 
 theorem card_eq_index_normalizer [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
-    Nat.card (Sylow p G) = (P : Subgroup G).normalizer.index :=
+    Nat.card (Sylow p G) = P.normalizer.index :=
   P.card_eq_card_quotient_normalizer
 
 @[deprecated (since := "2024-11-07")]
 alias _root_.card_sylow_eq_index_normalizer := card_eq_index_normalizer
 
 theorem card_dvd_index [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
-    Nat.card (Sylow p G) ∣ (P : Subgroup G).index :=
-  ((congr_arg _ P.card_eq_index_normalizer).mp dvd_rfl).trans (index_dvd_of_le le_normalizer)
+    Nat.card (Sylow p G) ∣ P.index :=
+  ((congr_arg _ P.card_eq_index_normalizer).mp dvd_rfl).trans
+    (index_dvd_of_le le_normalizer)
 
 @[deprecated (since := "2024-11-07")]
 alias _root_.card_sylow_dvd_index := card_dvd_index
@@ -410,7 +411,7 @@ alias _root_.card_sylow_dvd_index := card_dvd_index
 private theorem not_dvd_index_aux [hp : Fact p.Prime] (P : Sylow p G) [P.Normal]
     [P.FiniteIndex] : ¬ p ∣ P.index := by
   intro h
-  rw [index_eq_card (P : Subgroup G)] at h
+  rw [P.index_eq_card] at h
   obtain ⟨x, hx⟩ := exists_prime_orderOf_dvd_card' (G := G ⧸ (P : Subgroup G)) p h
   have h := IsPGroup.of_card (((Nat.card_zpowers x).trans hx).trans (pow_one p).symm)
   let Q := (zpowers x).comap (QuotientGroup.mk' (P : Subgroup G))
@@ -448,7 +449,8 @@ alias _root_.not_dvd_index_sylow' := not_dvd_index
 /-- **Frattini's Argument**: If `N` is a normal subgroup of `G`, and if `P` is a Sylow `p`-subgroup
   of `N`, then `N_G(P) ⊔ N = G`. -/
 theorem normalizer_sup_eq_top {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N.Normal]
-    [Finite (Sylow p N)] (P : Sylow p N) : (P.map N.subtype).normalizer ⊔ N = ⊤ := by
+    [Finite (Sylow p N)] (P : Sylow p N) :
+    (P.map N.subtype).normalizer ⊔ N = ⊤ := by
   refine top_le_iff.mp fun g _ => ?_
   obtain ⟨n, hn⟩ := exists_smul_eq N ((MulAut.conjNormal g : MulAut N) • P) P
   rw [← inv_mul_cancel_left (↑n) g, sup_comm]

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -53,11 +53,11 @@ variable {p} {G}
 
 namespace Sylow
 
-attribute [coe] Sylow.toSubgroup
+attribute [coe] toSubgroup
 
 -- Porting note: Changed to `CoeOut`
 instance : CoeOut (Sylow p G) (Subgroup G) :=
-  ⟨Sylow.toSubgroup⟩
+  ⟨toSubgroup⟩
 
 -- Porting note: syntactic tautology
 -- @[simp]
@@ -108,19 +108,15 @@ def ofCard [Finite G] {p : ℕ} [Fact p.Prime] (H : Subgroup G)
 
 @[simp, norm_cast]
 theorem coe_ofCard [Finite G] {p : ℕ} [Fact p.Prime] (H : Subgroup G)
-    (card_eq : Nat.card H = p ^ (Nat.card G).factorization p) : ↑(ofCard H card_eq) = H :=
+    (card_eq : Nat.card H = p ^ (Nat.card G).factorization p) : ofCard H card_eq = H :=
   rfl
 
 variable (P : Sylow p G)
 
-/-- The action by a Sylow subgroup is the action by the underlying group. -/
-instance mulActionLeft {α : Type*} [MulAction G α] : MulAction P α :=
-  inferInstanceAs (MulAction (P : Subgroup G) α)
-
 variable {K : Type*} [Group K] (ϕ : K →* G) {N : Subgroup G}
 
 /-- The preimage of a Sylow subgroup under a p-group-kernel homomorphism is a Sylow subgroup. -/
-def comapOfKerIsPGroup (hϕ : IsPGroup p ϕ.ker) (h : ↑P ≤ ϕ.range) : Sylow p K :=
+def comapOfKerIsPGroup (hϕ : IsPGroup p ϕ.ker) (h : P ≤ ϕ.range) : Sylow p K :=
   { P.1.comap ϕ with
     isPGroup' := P.2.comap_of_ker_isPGroup ϕ hϕ
     is_maximal' := fun {Q} hQ hle => by
@@ -129,28 +125,28 @@ def comapOfKerIsPGroup (hϕ : IsPGroup p ϕ.ker) (h : ↑P ≤ ϕ.range) : Sylow
       exact (comap_map_eq_self ((P.1.ker_le_comap ϕ).trans hle)).symm }
 
 @[simp]
-theorem coe_comapOfKerIsPGroup (hϕ : IsPGroup p ϕ.ker) (h : ↑P ≤ ϕ.range) :
-    (P.comapOfKerIsPGroup ϕ hϕ h : Subgroup K) = Subgroup.comap ϕ ↑P :=
+theorem coe_comapOfKerIsPGroup (hϕ : IsPGroup p ϕ.ker) (h : P ≤ ϕ.range) :
+    P.comapOfKerIsPGroup ϕ hϕ h = P.comap ϕ :=
   rfl
 
 /-- The preimage of a Sylow subgroup under an injective homomorphism is a Sylow subgroup. -/
-def comapOfInjective (hϕ : Function.Injective ϕ) (h : ↑P ≤ ϕ.range) : Sylow p K :=
+def comapOfInjective (hϕ : Function.Injective ϕ) (h : P ≤ ϕ.range) : Sylow p K :=
   P.comapOfKerIsPGroup ϕ (IsPGroup.ker_isPGroup_of_injective hϕ) h
 
 @[simp]
-theorem coe_comapOfInjective (hϕ : Function.Injective ϕ) (h : ↑P ≤ ϕ.range) :
-    ↑(P.comapOfInjective ϕ hϕ h) = Subgroup.comap ϕ ↑P :=
+theorem coe_comapOfInjective (hϕ : Function.Injective ϕ) (h : P ≤ ϕ.range) :
+    P.comapOfInjective ϕ hϕ h = P.comap ϕ :=
   rfl
 
 /-- A sylow subgroup of G is also a sylow subgroup of a subgroup of G. -/
-protected def subtype (h : ↑P ≤ N) : Sylow p N :=
+protected def subtype (h : P ≤ N) : Sylow p N :=
   P.comapOfInjective N.subtype Subtype.coe_injective (by rwa [subtype_range])
 
 @[simp]
-theorem coe_subtype (h : ↑P ≤ N) : ↑(P.subtype h) = subgroupOf (↑P) N :=
+theorem coe_subtype (h : P ≤ N) : P.subtype h = subgroupOf P N :=
   rfl
 
-theorem subtype_injective {P Q : Sylow p G} {hP : ↑P ≤ N} {hQ : ↑Q ≤ N}
+theorem subtype_injective {P Q : Sylow p G} {hP : P ≤ N} {hQ : Q ≤ N}
     (h : P.subtype hP = Q.subtype hQ) : P = Q := by
   rw [SetLike.ext_iff] at h ⊢
   exact fun g => ⟨fun hg => (h ⟨g, hP hg⟩).mp hg, fun hg => (h ⟨g, hQ hg⟩).mpr hg⟩
@@ -181,19 +177,19 @@ instance nonempty : Nonempty (Sylow p G) :=
   nonempty_of_exists IsPGroup.of_bot.exists_le_sylow
 
 noncomputable instance inhabited : Inhabited (Sylow p G) :=
-  Classical.inhabited_of_nonempty Sylow.nonempty
+  Classical.inhabited_of_nonempty nonempty
 
 theorem exists_comap_eq_of_ker_isPGroup {H : Type*} [Group H] (P : Sylow p H) {f : H →* G}
-    (hf : IsPGroup p f.ker) : ∃ Q : Sylow p G, (Q : Subgroup G).comap f = P :=
+    (hf : IsPGroup p f.ker) : ∃ Q : Sylow p G, Q.comap f = P :=
   Exists.imp (fun Q hQ => P.3 (Q.2.comap_of_ker_isPGroup f hf) (map_le_iff_le_comap.mp hQ))
     (P.2.map f).exists_le_sylow
 
 theorem exists_comap_eq_of_injective {H : Type*} [Group H] (P : Sylow p H) {f : H →* G}
-    (hf : Function.Injective f) : ∃ Q : Sylow p G, (Q : Subgroup G).comap f = P :=
+    (hf : Function.Injective f) : ∃ Q : Sylow p G, Q.comap f = P :=
   P.exists_comap_eq_of_ker_isPGroup (IsPGroup.ker_isPGroup_of_injective hf)
 
 theorem exists_comap_subtype_eq {H : Subgroup G} (P : Sylow p H) :
-    ∃ Q : Sylow p G, (Q : Subgroup G).comap H.subtype = P :=
+    ∃ Q : Sylow p G, Q.comap H.subtype = P :=
   P.exists_comap_eq_of_injective Subtype.coe_injective
 
 /-- If the kernel of `f : H →* G` is a `p`-group,
@@ -203,16 +199,16 @@ theorem finite_of_ker_is_pGroup {H : Type*} [Group H] {f : H →* G}
   let h_exists := fun P : Sylow p H => P.exists_comap_eq_of_ker_isPGroup hf
   let g : Sylow p H → Sylow p G := fun P => Classical.choose (h_exists P)
   have hg : ∀ P : Sylow p H, (g P).1.comap f = P := fun P => Classical.choose_spec (h_exists P)
-  Finite.of_injective g fun P Q h => Sylow.ext (by rw [← hg, h]; exact (h_exists Q).choose_spec)
+  Finite.of_injective g fun P Q h => ext (by rw [← hg, h]; exact (h_exists Q).choose_spec)
 
 /-- If `f : H →* G` is injective, then `Finite (Sylow p G)` implies `Finite (Sylow p H)`. -/
 theorem finite_of_injective {H : Type*} [Group H] {f : H →* G}
     (hf : Function.Injective f) [Finite (Sylow p G)] : Finite (Sylow p H) :=
-  Sylow.finite_of_ker_is_pGroup (IsPGroup.ker_isPGroup_of_injective hf)
+  finite_of_ker_is_pGroup (IsPGroup.ker_isPGroup_of_injective hf)
 
 /-- If `H` is a subgroup of `G`, then `Finite (Sylow p G)` implies `Finite (Sylow p H)`. -/
 instance (H : Subgroup G) [Finite (Sylow p G)] : Finite (Sylow p H) :=
-  Sylow.finite_of_injective H.subtype_injective
+  finite_of_injective H.subtype_injective
 
 open Pointwise
 
@@ -220,13 +216,13 @@ open Pointwise
 instance pointwiseMulAction {α : Type*} [Group α] [MulDistribMulAction α G] :
     MulAction α (Sylow p G) where
   smul g P :=
-    ⟨(g • P.toSubgroup : Subgroup G), P.2.map _, fun {Q} hQ hS =>
+    ⟨g • P.toSubgroup, P.2.map _, fun {Q} hQ hS =>
       inv_smul_eq_iff.mp
         (P.3 (hQ.map _) fun s hs =>
           (congr_arg (· ∈ g⁻¹ • Q) (inv_smul_smul g s)).mp
             (smul_mem_pointwise_smul (g • s) g⁻¹ Q (hS (smul_mem_pointwise_smul s g P hs))))⟩
-  one_smul P := Sylow.ext (one_smul α P.toSubgroup)
-  mul_smul g h P := Sylow.ext (mul_smul g h P.toSubgroup)
+  one_smul P := ext (one_smul α P.toSubgroup)
+  mul_smul g h P := ext (mul_smul g h P.toSubgroup)
 
 theorem pointwise_smul_def {α : Type*} [Group α] [MulDistribMulAction α G] {g : α}
     {P : Sylow p G} : ↑(g • P) = g • (P : Subgroup G) :=
@@ -245,15 +241,15 @@ theorem coe_subgroup_smul {g : G} {P : Sylow p G} :
 theorem coe_smul {g : G} {P : Sylow p G} : ↑(g • P) = MulAut.conj g • (P : Set G) :=
   rfl
 
-theorem smul_le {P : Sylow p G} {H : Subgroup G} (hP : ↑P ≤ H) (h : H) : ↑(h • P) ≤ H :=
+theorem smul_le {P : Sylow p G} {H : Subgroup G} (hP : P ≤ H) (h : H) : ↑(h • P) ≤ H :=
   Subgroup.conj_smul_le_of_le hP h
 
-theorem smul_subtype {P : Sylow p G} {H : Subgroup G} (hP : ↑P ≤ H) (h : H) :
-    h • P.subtype hP = (h • P).subtype (Sylow.smul_le hP h) :=
-  Sylow.ext (Subgroup.conj_smul_subgroupOf hP h)
+theorem smul_subtype {P : Sylow p G} {H : Subgroup G} (hP : P ≤ H) (h : H) :
+    h • P.subtype hP = (h • P).subtype (smul_le hP h) :=
+  ext (Subgroup.conj_smul_subgroupOf hP h)
 
 theorem smul_eq_iff_mem_normalizer {g : G} {P : Sylow p G} :
-    g • P = P ↔ g ∈ (P : Subgroup G).normalizer := by
+    g • P = P ↔ g ∈ P.normalizer := by
   rw [eq_comm, SetLike.ext_iff, ← inv_mem_iff (G := G) (H := normalizer P.toSubgroup),
       mem_normalizer_iff, inv_inv]
   exact
@@ -262,8 +258,8 @@ theorem smul_eq_iff_mem_normalizer {g : G} {P : Sylow p G} :
         ⟨fun ⟨a, b, c⟩ => c ▸ by simpa [mul_assoc] using b,
           fun hh => ⟨(MulAut.conj g)⁻¹ h, hh, MulAut.apply_inv_self G (MulAut.conj g) h⟩⟩
 
-theorem smul_eq_of_normal {g : G} {P : Sylow p G} [h : (P : Subgroup G).Normal] :
-    g • P = P := by simp only [Sylow.smul_eq_iff_mem_normalizer, normalizer_eq_top.mpr h, mem_top]
+theorem smul_eq_of_normal {g : G} {P : Sylow p G} [h : P.Normal] :
+    g • P = P := by simp only [smul_eq_iff_mem_normalizer, normalizer_eq_top.mpr h, mem_top]
 
 end Sylow
 
@@ -351,13 +347,13 @@ theorem orbit_eq_top [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) : orbit
 
 theorem stabilizer_eq_normalizer (P : Sylow p G) :
     stabilizer G P = (P : Subgroup G).normalizer := by
-  ext; simp [Sylow.smul_eq_iff_mem_normalizer]
+  ext; simp [smul_eq_iff_mem_normalizer]
 
 theorem conj_eq_normalizer_conj_of_mem_centralizer [Fact p.Prime] [Finite (Sylow p G)]
-    (P : Sylow p G) (x g : G) (hx : x ∈ centralizer (P : Set G))
-    (hy : g⁻¹ * x * g ∈ centralizer (P : Set G)) :
-    ∃ n ∈ (P : Subgroup G).normalizer, g⁻¹ * x * g = n⁻¹ * x * n := by
-  have h1 : ↑P ≤ centralizer (zpowers x : Set G) := by rwa [le_centralizer_iff, zpowers_le]
+    (P : Sylow p G) (x g : G) (hx : x ∈ centralizer P)
+    (hy : g⁻¹ * x * g ∈ centralizer P) :
+    ∃ n ∈ P.normalizer, g⁻¹ * x * g = n⁻¹ * x * n := by
+  have h1 : P ≤ centralizer (zpowers x : Set G) := by rwa [le_centralizer_iff, zpowers_le]
   have h2 : ↑(g • P) ≤ centralizer (zpowers x : Set G) := by
     rw [le_centralizer_iff, zpowers_le]
     rintro - ⟨z, hz, rfl⟩
@@ -366,50 +362,49 @@ theorem conj_eq_normalizer_conj_of_mem_centralizer [Fact p.Prime] [Finite (Sylow
       eq_inv_mul_iff_mul_eq, ← mul_assoc, ← mul_assoc] at hy
   obtain ⟨h, hh⟩ :=
     exists_smul_eq (centralizer (zpowers x : Set G)) ((g • P).subtype h2) (P.subtype h1)
-  simp_rw [Sylow.smul_subtype, Subgroup.smul_def, smul_smul] at hh
-  refine ⟨h * g, Sylow.smul_eq_iff_mem_normalizer.mp (Sylow.subtype_injective hh), ?_⟩
+  simp_rw [smul_subtype, Subgroup.smul_def, smul_smul] at hh
+  refine ⟨h * g, smul_eq_iff_mem_normalizer.mp (subtype_injective hh), ?_⟩
   rw [← mul_assoc, Commute.right_comm (h.prop x (mem_zpowers x)), mul_inv_rev, inv_mul_cancel_right]
 
 theorem conj_eq_normalizer_conj_of_mem [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
-    [_hP : (P : Subgroup G).IsCommutative] (x g : G) (hx : x ∈ P) (hy : g⁻¹ * x * g ∈ P) :
-    ∃ n ∈ (P : Subgroup G).normalizer, g⁻¹ * x * g = n⁻¹ * x * n :=
+    [_hP : P.IsCommutative] (x g : G) (hx : x ∈ P) (hy : g⁻¹ * x * g ∈ P) :
+    ∃ n ∈ P.normalizer, g⁻¹ * x * g = n⁻¹ * x * n :=
   P.conj_eq_normalizer_conj_of_mem_centralizer x g
-    (le_centralizer (P : Subgroup G) hx) (le_centralizer (P : Subgroup G) hy)
+    (P.le_centralizer hx) (P.le_centralizer hy)
 
 /-- Sylow `p`-subgroups are in bijection with cosets of the normalizer of a Sylow `p`-subgroup -/
 noncomputable def equivQuotientNormalizer [Fact p.Prime] [Finite (Sylow p G)]
-    (P : Sylow p G) : Sylow p G ≃ G ⧸ (P : Subgroup G).normalizer :=
+    (P : Sylow p G) : Sylow p G ≃ G ⧸ P.normalizer :=
   calc
     Sylow p G ≃ (⊤ : Set (Sylow p G)) := (Equiv.Set.univ (Sylow p G)).symm
     _ ≃ orbit G P := Equiv.setCongr P.orbit_eq_top.symm
     _ ≃ G ⧸ stabilizer G P := orbitEquivQuotientStabilizer G P
-    _ ≃ G ⧸ (P : Subgroup G).normalizer := by rw [P.stabilizer_eq_normalizer]
+    _ ≃ G ⧸ P.normalizer := by rw [P.stabilizer_eq_normalizer]
 
 instance [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
-    Finite (G ⧸ (P : Subgroup G).normalizer) :=
+    Finite (G ⧸ P.normalizer) :=
   Finite.of_equiv (Sylow p G) P.equivQuotientNormalizer
 
 theorem card_eq_card_quotient_normalizer [Fact p.Prime] [Finite (Sylow p G)]
-    (P : Sylow p G) : Nat.card (Sylow p G) = Nat.card (G ⧸ (P : Subgroup G).normalizer) :=
+    (P : Sylow p G) : Nat.card (Sylow p G) = Nat.card (G ⧸ P.normalizer) :=
   Nat.card_congr P.equivQuotientNormalizer
 
 @[deprecated (since := "2024-11-07")]
-alias card_sylow_eq_card_quotient_normalizer := card_eq_card_quotient_normalizer
+alias _root_.card_sylow_eq_card_quotient_normalizer := card_eq_card_quotient_normalizer
 
 theorem card_eq_index_normalizer [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
     Nat.card (Sylow p G) = (P : Subgroup G).normalizer.index :=
-  card_sylow_eq_card_quotient_normalizer P
+  P.card_eq_card_quotient_normalizer
 
 @[deprecated (since := "2024-11-07")]
-alias card_sylow_eq_index_normalizer := Sylow.card_eq_index_normalizer
+alias _root_.card_sylow_eq_index_normalizer := card_eq_index_normalizer
 
 theorem card_dvd_index [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
     Nat.card (Sylow p G) ∣ (P : Subgroup G).index :=
-  ((congr_arg _ (card_sylow_eq_index_normalizer P)).mp dvd_rfl).trans
-    (index_dvd_of_le le_normalizer)
+  ((congr_arg _ P.card_eq_index_normalizer).mp dvd_rfl).trans (index_dvd_of_le le_normalizer)
 
 @[deprecated (since := "2024-11-07")]
-alias card_sylow_dvd_index := Sylow.card_dvd_index
+alias _root_.card_sylow_dvd_index := card_dvd_index
 
 /-- Auxilliary lemma for `Sylow.not_dvd_index` which is strictly stronger. -/
 private theorem not_dvd_index_aux [hp : Fact p.Prime] (P : Sylow p G) [P.Normal]
@@ -432,15 +427,15 @@ private theorem not_dvd_index_aux [hp : Fact p.Prime] (P : Sylow p G) [P.Normal]
 /-- A Sylow p-subgroup has index indivisible by `p`, assuming [N(P) : P] < ∞. -/
 theorem not_dvd_index' [hp : Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
     (hP : P.relindex P.normalizer ≠ 0) : ¬ p ∣ P.index := by
-  rw [← relindex_mul_index le_normalizer, ← card_sylow_eq_index_normalizer]
-  haveI : (P.subtype le_normalizer : Subgroup (P : Subgroup G).normalizer).Normal :=
+  rw [← relindex_mul_index le_normalizer, ← card_eq_index_normalizer]
+  haveI : (P.subtype le_normalizer).Normal :=
     Subgroup.normal_in_normalizer
-  haveI : FiniteIndex ↑(P.subtype le_normalizer : Subgroup (P : Subgroup G).normalizer) := ⟨hP⟩
+  haveI : (P.subtype le_normalizer).FiniteIndex := ⟨hP⟩
   replace hP := not_dvd_index_aux (P.subtype le_normalizer)
   exact hp.1.not_dvd_mul hP (not_dvd_card_sylow p G)
 
 @[deprecated (since := "2024-11-03")]
-alias not_dvd_index_sylow := Sylow.not_dvd_index'
+alias _root_.not_dvd_index_sylow := not_dvd_index'
 
 /-- A Sylow p-subgroup has index indivisible by `p`. -/
 theorem not_dvd_index [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) [P.FiniteIndex] :
@@ -448,19 +443,18 @@ theorem not_dvd_index [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) [P.Fin
   P.not_dvd_index' Nat.card_pos.ne'
 
 @[deprecated (since := "2024-11-03")]
-alias not_dvd_index_sylow' := Sylow.not_dvd_index
+alias _root_.not_dvd_index_sylow' := not_dvd_index
 
 /-- **Frattini's Argument**: If `N` is a normal subgroup of `G`, and if `P` is a Sylow `p`-subgroup
   of `N`, then `N_G(P) ⊔ N = G`. -/
 theorem normalizer_sup_eq_top {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N.Normal]
-    [Finite (Sylow p N)] (P : Sylow p N) :
-    ((↑P : Subgroup N).map N.subtype).normalizer ⊔ N = ⊤ := by
+    [Finite (Sylow p N)] (P : Sylow p N) : (P.map N.subtype).normalizer ⊔ N = ⊤ := by
   refine top_le_iff.mp fun g _ => ?_
   obtain ⟨n, hn⟩ := exists_smul_eq N ((MulAut.conjNormal g : MulAut N) • P) P
   rw [← inv_mul_cancel_left (↑n) g, sup_comm]
   apply mul_mem_sup (N.inv_mem n.2)
-  rw [Sylow.smul_def, ← mul_smul, ← MulAut.conjNormal_val, ← MulAut.conjNormal.map_mul,
-    Sylow.ext_iff, Sylow.pointwise_smul_def, Subgroup.pointwise_smul_def] at hn
+  rw [smul_def, ← mul_smul, ← MulAut.conjNormal_val, ← MulAut.conjNormal.map_mul,
+    Sylow.ext_iff, pointwise_smul_def, Subgroup.pointwise_smul_def] at hn
   have : Function.Injective (MulAut.conj (n * g)).toMonoidHom := (MulAut.conj (n * g)).injective
   refine fun x ↦ (mem_map_iff_mem this).symm.trans ?_
   rw [map_map, ← congr_arg (map N.subtype) hn, map_map]
@@ -469,8 +463,8 @@ theorem normalizer_sup_eq_top {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N.Norma
 /-- **Frattini's Argument**: If `N` is a normal subgroup of `G`, and if `P` is a Sylow `p`-subgroup
   of `N`, then `N_G(P) ⊔ N = G`. -/
 theorem normalizer_sup_eq_top' {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N.Normal]
-    [Finite (Sylow p N)] (P : Sylow p G) (hP : ↑P ≤ N) : (P : Subgroup G).normalizer ⊔ N = ⊤ := by
-  rw [← Sylow.normalizer_sup_eq_top (P.subtype hP), P.coe_subtype, subgroupOf_map_subtype,
+    [Finite (Sylow p N)] (P : Sylow p G) (hP : P ≤ N) : P.normalizer ⊔ N = ⊤ := by
+  rw [← normalizer_sup_eq_top (P.subtype hP), P.coe_subtype, subgroupOf_map_subtype,
     inf_of_le_left hP]
 
 end Sylow
@@ -676,14 +670,14 @@ theorem dvd_card_of_dvd_card [Finite G] {p : ℕ} [Fact p.Prime] (P : Sylow p G)
 
 /-- Sylow subgroups are Hall subgroups. -/
 theorem card_coprime_index [Finite G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow p G) :
-    (Nat.card P).Coprime (index (P : Subgroup G)) :=
+    (Nat.card P).Coprime P.index :=
   let ⟨_n, hn⟩ := IsPGroup.iff_card.mp P.2
   hn.symm ▸ (hp.1.coprime_pow_of_not_dvd P.not_dvd_index).symm
 
 theorem ne_bot_of_dvd_card [Finite G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow p G)
     (hdvd : p ∣ Nat.card G) : (P : Subgroup G) ≠ ⊥ := by
   refine fun h => hp.out.not_dvd_one ?_
-  have key : p ∣ Nat.card (P : Subgroup G) := P.dvd_card_of_dvd_card hdvd
+  have key : p ∣ Nat.card P := P.dvd_card_of_dvd_card hdvd
   rwa [h, card_bot] at key
 
 /-- The cardinality of a Sylow subgroup is `p ^ n`
@@ -697,11 +691,11 @@ theorem card_eq_multiplicity [Finite G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow
 
 /-- If `G` has a normal Sylow `p`-subgroup, then it is the only Sylow `p`-subgroup. -/
 noncomputable def unique_of_normal {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
-    (h : (P : Subgroup G).Normal) : Unique (Sylow p G) := by
+    (h : P.Normal) : Unique (Sylow p G) := by
   refine { uniq := fun Q ↦ ?_ }
   obtain ⟨x, h1⟩ := exists_smul_eq G P Q
   obtain ⟨x, h2⟩ := exists_smul_eq G P default
-  rw [Sylow.smul_eq_of_normal] at h1 h2
+  rw [smul_eq_of_normal] at h1 h2
   rw [← h1, ← h2]
 
 section Pointwise
@@ -709,8 +703,8 @@ section Pointwise
 open Pointwise
 
 theorem characteristic_of_normal {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
-    (h : (P : Subgroup G).Normal) : (P : Subgroup G).Characteristic := by
-  haveI := Sylow.unique_of_normal P h
+    (h : P.Normal) : P.Characteristic := by
+  haveI := unique_of_normal P h
   rw [characteristic_iff_map_eq]
   intro Φ
   show (Φ • P).toSubgroup = P.toSubgroup
@@ -720,33 +714,33 @@ theorem characteristic_of_normal {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)] (
 end Pointwise
 
 theorem normal_of_normalizer_normal {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
-    (hn : (↑P : Subgroup G).normalizer.Normal) : (↑P : Subgroup G).Normal := by
+    (hn : P.normalizer.Normal) : P.Normal := by
   rw [← normalizer_eq_top, ← normalizer_sup_eq_top' P le_normalizer, sup_idem]
 
 @[simp]
 theorem normalizer_normalizer {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
-    (↑P : Subgroup G).normalizer.normalizer = (↑P : Subgroup G).normalizer := by
+    P.normalizer.normalizer = P.normalizer := by
   have := normal_of_normalizer_normal (P.subtype (le_normalizer.trans le_normalizer))
-  simp_rw [← normalizer_eq_top, Sylow.coe_subtype, ← subgroupOf_normalizer_eq le_normalizer, ←
+  simp_rw [← normalizer_eq_top, coe_subtype, ← subgroupOf_normalizer_eq le_normalizer, ←
     subgroupOf_normalizer_eq le_rfl, subgroupOf_self] at this
-  rw [← subtype_range (P : Subgroup G).normalizer.normalizer, MonoidHom.range_eq_map,
+  rw [← subtype_range P.normalizer.normalizer, MonoidHom.range_eq_map,
     ← this trivial]
   exact map_comap_eq_self (le_normalizer.trans (ge_of_eq (subtype_range _)))
 
 theorem normal_of_all_max_subgroups_normal [Finite G]
     (hnc : ∀ H : Subgroup G, IsCoatom H → H.Normal) {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)]
-    (P : Sylow p G) : (↑P : Subgroup G).Normal :=
+    (P : Sylow p G) : P.Normal :=
   normalizer_eq_top.mp
     (by
-      rcases eq_top_or_exists_le_coatom (↑P : Subgroup G).normalizer with (heq | ⟨K, hK, hNK⟩)
+      rcases eq_top_or_exists_le_coatom P.normalizer with (heq | ⟨K, hK, hNK⟩)
       · exact heq
       · haveI := hnc _ hK
-        have hPK : ↑P ≤ K := le_trans le_normalizer hNK
+        have hPK : P ≤ K := le_trans le_normalizer hNK
         refine (hK.1 ?_).elim
         rw [← sup_of_le_right hNK, P.normalizer_sup_eq_top' hPK])
 
 theorem normal_of_normalizerCondition (hnc : NormalizerCondition G) {p : ℕ} [Fact p.Prime]
-    [Finite (Sylow p G)] (P : Sylow p G) : (↑P : Subgroup G).Normal :=
+    [Finite (Sylow p G)] (P : Sylow p G) : P.Normal :=
   normalizer_eq_top.mp <|
     normalizerCondition_iff_only_full_group_self_normalizing.mp hnc _ <| normalizer_normalizer _
 
@@ -754,8 +748,8 @@ theorem normal_of_normalizerCondition (hnc : NormalizerCondition G) {p : ℕ} [F
 of these Sylow subgroups.
 -/
 noncomputable def directProductOfNormal [Finite G]
-    (hn : ∀ {p : ℕ} [Fact p.Prime] (P : Sylow p G), (↑P : Subgroup G).Normal) :
-    (∀ p : (Nat.card G).primeFactors, ∀ P : Sylow p G, (↑P : Subgroup G)) ≃* G := by
+    (hn : ∀ {p : ℕ} [Fact p.Prime] (P : Sylow p G), P.Normal) :
+    (∀ p : (Nat.card G).primeFactors, ∀ P : Sylow p G, P) ≃* G := by
   have := Fintype.ofFinite G
   set ps := (Nat.card G).primeFactors
   -- “The” Sylow subgroup for p

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -175,28 +175,30 @@ theorem IsPGroup.exists_le_sylow {P : Subgroup G} (hP : IsPGroup p P) : ∃ Q : 
       P hP)
     fun {Q} h => ⟨⟨Q, h.2.prop, h.2.eq_of_ge⟩, h.1⟩
 
-instance Sylow.nonempty : Nonempty (Sylow p G) :=
+namespace Sylow
+
+instance nonempty : Nonempty (Sylow p G) :=
   nonempty_of_exists IsPGroup.of_bot.exists_le_sylow
 
-noncomputable instance Sylow.inhabited : Inhabited (Sylow p G) :=
+noncomputable instance inhabited : Inhabited (Sylow p G) :=
   Classical.inhabited_of_nonempty Sylow.nonempty
 
-theorem Sylow.exists_comap_eq_of_ker_isPGroup {H : Type*} [Group H] (P : Sylow p H) {f : H →* G}
+theorem exists_comap_eq_of_ker_isPGroup {H : Type*} [Group H] (P : Sylow p H) {f : H →* G}
     (hf : IsPGroup p f.ker) : ∃ Q : Sylow p G, (Q : Subgroup G).comap f = P :=
   Exists.imp (fun Q hQ => P.3 (Q.2.comap_of_ker_isPGroup f hf) (map_le_iff_le_comap.mp hQ))
     (P.2.map f).exists_le_sylow
 
-theorem Sylow.exists_comap_eq_of_injective {H : Type*} [Group H] (P : Sylow p H) {f : H →* G}
+theorem exists_comap_eq_of_injective {H : Type*} [Group H] (P : Sylow p H) {f : H →* G}
     (hf : Function.Injective f) : ∃ Q : Sylow p G, (Q : Subgroup G).comap f = P :=
   P.exists_comap_eq_of_ker_isPGroup (IsPGroup.ker_isPGroup_of_injective hf)
 
-theorem Sylow.exists_comap_subtype_eq {H : Subgroup G} (P : Sylow p H) :
+theorem exists_comap_subtype_eq {H : Subgroup G} (P : Sylow p H) :
     ∃ Q : Sylow p G, (Q : Subgroup G).comap H.subtype = P :=
   P.exists_comap_eq_of_injective Subtype.coe_injective
 
 /-- If the kernel of `f : H →* G` is a `p`-group,
   then `Finite (Sylow p G)` implies `Finite (Sylow p H)`. -/
-theorem Sylow.finite_of_ker_is_pGroup {H : Type*} [Group H] {f : H →* G}
+theorem finite_of_ker_is_pGroup {H : Type*} [Group H] {f : H →* G}
     (hf : IsPGroup p f.ker) [Finite (Sylow p G)] : Finite (Sylow p H) :=
   let h_exists := fun P : Sylow p H => P.exists_comap_eq_of_ker_isPGroup hf
   let g : Sylow p H → Sylow p G := fun P => Classical.choose (h_exists P)
@@ -204,7 +206,7 @@ theorem Sylow.finite_of_ker_is_pGroup {H : Type*} [Group H] {f : H →* G}
   Finite.of_injective g fun P Q h => Sylow.ext (by rw [← hg, h]; exact (h_exists Q).choose_spec)
 
 /-- If `f : H →* G` is injective, then `Finite (Sylow p G)` implies `Finite (Sylow p H)`. -/
-theorem Sylow.finite_of_injective {H : Type*} [Group H] {f : H →* G}
+theorem finite_of_injective {H : Type*} [Group H] {f : H →* G}
     (hf : Function.Injective f) [Finite (Sylow p G)] : Finite (Sylow p H) :=
   Sylow.finite_of_ker_is_pGroup (IsPGroup.ker_isPGroup_of_injective hf)
 
@@ -215,7 +217,7 @@ instance (H : Subgroup G) [Finite (Sylow p G)] : Finite (Sylow p H) :=
 open Pointwise
 
 /-- `Subgroup.pointwiseMulAction` preserves Sylow subgroups. -/
-instance Sylow.pointwiseMulAction {α : Type*} [Group α] [MulDistribMulAction α G] :
+instance pointwiseMulAction {α : Type*} [Group α] [MulDistribMulAction α G] :
     MulAction α (Sylow p G) where
   smul g P :=
     ⟨(g • P.toSubgroup : Subgroup G), P.2.map _, fun {Q} hQ hS =>
@@ -226,31 +228,31 @@ instance Sylow.pointwiseMulAction {α : Type*} [Group α] [MulDistribMulAction �
   one_smul P := Sylow.ext (one_smul α P.toSubgroup)
   mul_smul g h P := Sylow.ext (mul_smul g h P.toSubgroup)
 
-theorem Sylow.pointwise_smul_def {α : Type*} [Group α] [MulDistribMulAction α G] {g : α}
+theorem pointwise_smul_def {α : Type*} [Group α] [MulDistribMulAction α G] {g : α}
     {P : Sylow p G} : ↑(g • P) = g • (P : Subgroup G) :=
   rfl
 
-instance Sylow.mulAction : MulAction G (Sylow p G) :=
+instance mulAction : MulAction G (Sylow p G) :=
   compHom _ MulAut.conj
 
-theorem Sylow.smul_def {g : G} {P : Sylow p G} : g • P = MulAut.conj g • P :=
+theorem smul_def {g : G} {P : Sylow p G} : g • P = MulAut.conj g • P :=
   rfl
 
-theorem Sylow.coe_subgroup_smul {g : G} {P : Sylow p G} :
+theorem coe_subgroup_smul {g : G} {P : Sylow p G} :
     ↑(g • P) = MulAut.conj g • (P : Subgroup G) :=
   rfl
 
-theorem Sylow.coe_smul {g : G} {P : Sylow p G} : ↑(g • P) = MulAut.conj g • (P : Set G) :=
+theorem coe_smul {g : G} {P : Sylow p G} : ↑(g • P) = MulAut.conj g • (P : Set G) :=
   rfl
 
-theorem Sylow.smul_le {P : Sylow p G} {H : Subgroup G} (hP : ↑P ≤ H) (h : H) : ↑(h • P) ≤ H :=
+theorem smul_le {P : Sylow p G} {H : Subgroup G} (hP : ↑P ≤ H) (h : H) : ↑(h • P) ≤ H :=
   Subgroup.conj_smul_le_of_le hP h
 
-theorem Sylow.smul_subtype {P : Sylow p G} {H : Subgroup G} (hP : ↑P ≤ H) (h : H) :
+theorem smul_subtype {P : Sylow p G} {H : Subgroup G} (hP : ↑P ≤ H) (h : H) :
     h • P.subtype hP = (h • P).subtype (Sylow.smul_le hP h) :=
   Sylow.ext (Subgroup.conj_smul_subgroupOf hP h)
 
-theorem Sylow.smul_eq_iff_mem_normalizer {g : G} {P : Sylow p G} :
+theorem smul_eq_iff_mem_normalizer {g : G} {P : Sylow p G} :
     g • P = P ↔ g ∈ (P : Subgroup G).normalizer := by
   rw [eq_comm, SetLike.ext_iff, ← inv_mem_iff (G := G) (H := normalizer P.toSubgroup),
       mem_normalizer_iff, inv_inv]
@@ -260,8 +262,10 @@ theorem Sylow.smul_eq_iff_mem_normalizer {g : G} {P : Sylow p G} :
         ⟨fun ⟨a, b, c⟩ => c ▸ by simpa [mul_assoc] using b,
           fun hh => ⟨(MulAut.conj g)⁻¹ h, hh, MulAut.apply_inv_self G (MulAut.conj g) h⟩⟩
 
-theorem Sylow.smul_eq_of_normal {g : G} {P : Sylow p G} [h : (P : Subgroup G).Normal] :
+theorem smul_eq_of_normal {g : G} {P : Sylow p G} [h : (P : Subgroup G).Normal] :
     g • P = P := by simp only [Sylow.smul_eq_iff_mem_normalizer, normalizer_eq_top.mpr h, mem_top]
+
+end Sylow
 
 theorem Subgroup.sylow_mem_fixedPoints_iff (H : Subgroup G) {P : Sylow p G} :
     P ∈ fixedPoints H (Sylow p G) ↔ H ≤ (P : Subgroup G).normalizer := by
@@ -330,24 +334,26 @@ theorem not_dvd_card_sylow [hp : Fact p.Prime] [Finite (Sylow p G)] : ¬p ∣ Na
 
 variable {p} {G}
 
+namespace Sylow
+
 /-- Sylow subgroups are isomorphic -/
-nonrec def Sylow.equivSMul (P : Sylow p G) (g : G) : P ≃* (g • P : Sylow p G) :=
+nonrec def equivSMul (P : Sylow p G) (g : G) : P ≃* (g • P : Sylow p G) :=
   equivSMul (MulAut.conj g) P.toSubgroup
 
 /-- Sylow subgroups are isomorphic -/
-noncomputable def Sylow.equiv [Fact p.Prime] [Finite (Sylow p G)] (P Q : Sylow p G) : P ≃* Q := by
+noncomputable def equiv [Fact p.Prime] [Finite (Sylow p G)] (P Q : Sylow p G) : P ≃* Q := by
   rw [← Classical.choose_spec (exists_smul_eq G P Q)]
   exact P.equivSMul (Classical.choose (exists_smul_eq G P Q))
 
 @[simp]
-theorem Sylow.orbit_eq_top [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) : orbit G P = ⊤ :=
+theorem orbit_eq_top [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) : orbit G P = ⊤ :=
   top_le_iff.mp fun Q _ => exists_smul_eq G P Q
 
-theorem Sylow.stabilizer_eq_normalizer (P : Sylow p G) :
+theorem stabilizer_eq_normalizer (P : Sylow p G) :
     stabilizer G P = (P : Subgroup G).normalizer := by
   ext; simp [Sylow.smul_eq_iff_mem_normalizer]
 
-theorem Sylow.conj_eq_normalizer_conj_of_mem_centralizer [Fact p.Prime] [Finite (Sylow p G)]
+theorem conj_eq_normalizer_conj_of_mem_centralizer [Fact p.Prime] [Finite (Sylow p G)]
     (P : Sylow p G) (x g : G) (hx : x ∈ centralizer (P : Set G))
     (hy : g⁻¹ * x * g ∈ centralizer (P : Set G)) :
     ∃ n ∈ (P : Subgroup G).normalizer, g⁻¹ * x * g = n⁻¹ * x * n := by
@@ -364,14 +370,14 @@ theorem Sylow.conj_eq_normalizer_conj_of_mem_centralizer [Fact p.Prime] [Finite 
   refine ⟨h * g, Sylow.smul_eq_iff_mem_normalizer.mp (Sylow.subtype_injective hh), ?_⟩
   rw [← mul_assoc, Commute.right_comm (h.prop x (mem_zpowers x)), mul_inv_rev, inv_mul_cancel_right]
 
-theorem Sylow.conj_eq_normalizer_conj_of_mem [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
+theorem conj_eq_normalizer_conj_of_mem [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
     [_hP : (P : Subgroup G).IsCommutative] (x g : G) (hx : x ∈ P) (hy : g⁻¹ * x * g ∈ P) :
     ∃ n ∈ (P : Subgroup G).normalizer, g⁻¹ * x * g = n⁻¹ * x * n :=
   P.conj_eq_normalizer_conj_of_mem_centralizer x g
     (le_centralizer (P : Subgroup G) hx) (le_centralizer (P : Subgroup G) hy)
 
 /-- Sylow `p`-subgroups are in bijection with cosets of the normalizer of a Sylow `p`-subgroup -/
-noncomputable def Sylow.equivQuotientNormalizer [Fact p.Prime] [Finite (Sylow p G)]
+noncomputable def equivQuotientNormalizer [Fact p.Prime] [Finite (Sylow p G)]
     (P : Sylow p G) : Sylow p G ≃ G ⧸ (P : Subgroup G).normalizer :=
   calc
     Sylow p G ≃ (⊤ : Set (Sylow p G)) := (Equiv.Set.univ (Sylow p G)).symm
@@ -383,21 +389,30 @@ instance [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
     Finite (G ⧸ (P : Subgroup G).normalizer) :=
   Finite.of_equiv (Sylow p G) P.equivQuotientNormalizer
 
-theorem card_sylow_eq_card_quotient_normalizer [Fact p.Prime] [Finite (Sylow p G)]
+theorem card_eq_card_quotient_normalizer [Fact p.Prime] [Finite (Sylow p G)]
     (P : Sylow p G) : Nat.card (Sylow p G) = Nat.card (G ⧸ (P : Subgroup G).normalizer) :=
   Nat.card_congr P.equivQuotientNormalizer
 
-theorem card_sylow_eq_index_normalizer [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
+@[deprecated (since := "2024-11-07")]
+alias card_sylow_eq_card_quotient_normalizer := card_eq_card_quotient_normalizer
+
+theorem card_eq_index_normalizer [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
     Nat.card (Sylow p G) = (P : Subgroup G).normalizer.index :=
   card_sylow_eq_card_quotient_normalizer P
 
-theorem card_sylow_dvd_index [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
+@[deprecated (since := "2024-11-07")]
+alias card_sylow_eq_index_normalizer := Sylow.card_eq_index_normalizer
+
+theorem card_dvd_index [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
     Nat.card (Sylow p G) ∣ (P : Subgroup G).index :=
   ((congr_arg _ (card_sylow_eq_index_normalizer P)).mp dvd_rfl).trans
     (index_dvd_of_le le_normalizer)
 
+@[deprecated (since := "2024-11-07")]
+alias card_sylow_dvd_index := Sylow.card_dvd_index
+
 /-- Auxilliary lemma for `Sylow.not_dvd_index` which is strictly stronger. -/
-private theorem Sylow.not_dvd_index_aux [hp : Fact p.Prime] (P : Sylow p G) [P.Normal]
+private theorem not_dvd_index_aux [hp : Fact p.Prime] (P : Sylow p G) [P.Normal]
     [P.FiniteIndex] : ¬ p ∣ P.index := by
   intro h
   rw [index_eq_card (P : Subgroup G)] at h
@@ -415,7 +430,7 @@ private theorem Sylow.not_dvd_index_aux [hp : Fact p.Prime] (P : Sylow p G) [P.N
   exact hp.ne' (P.3 hQ hp.le)
 
 /-- A Sylow p-subgroup has index indivisible by `p`, assuming [N(P) : P] < ∞. -/
-theorem Sylow.not_dvd_index' [hp : Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
+theorem not_dvd_index' [hp : Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
     (hP : P.relindex P.normalizer ≠ 0) : ¬ p ∣ P.index := by
   rw [← relindex_mul_index le_normalizer, ← card_sylow_eq_index_normalizer]
   haveI : (P.subtype le_normalizer : Subgroup (P : Subgroup G).normalizer).Normal :=
@@ -428,7 +443,7 @@ theorem Sylow.not_dvd_index' [hp : Fact p.Prime] [Finite (Sylow p G)] (P : Sylow
 alias not_dvd_index_sylow := Sylow.not_dvd_index'
 
 /-- A Sylow p-subgroup has index indivisible by `p`. -/
-theorem Sylow.not_dvd_index [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) [P.FiniteIndex] :
+theorem not_dvd_index [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) [P.FiniteIndex] :
     ¬ p ∣ P.index :=
   P.not_dvd_index' Nat.card_pos.ne'
 
@@ -437,7 +452,7 @@ alias not_dvd_index_sylow' := Sylow.not_dvd_index
 
 /-- **Frattini's Argument**: If `N` is a normal subgroup of `G`, and if `P` is a Sylow `p`-subgroup
   of `N`, then `N_G(P) ⊔ N = G`. -/
-theorem Sylow.normalizer_sup_eq_top {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N.Normal]
+theorem normalizer_sup_eq_top {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N.Normal]
     [Finite (Sylow p N)] (P : Sylow p N) :
     ((↑P : Subgroup N).map N.subtype).normalizer ⊔ N = ⊤ := by
   refine top_le_iff.mp fun g _ => ?_
@@ -453,10 +468,12 @@ theorem Sylow.normalizer_sup_eq_top {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N
 
 /-- **Frattini's Argument**: If `N` is a normal subgroup of `G`, and if `P` is a Sylow `p`-subgroup
   of `N`, then `N_G(P) ⊔ N = G`. -/
-theorem Sylow.normalizer_sup_eq_top' {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N.Normal]
+theorem normalizer_sup_eq_top' {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N.Normal]
     [Finite (Sylow p N)] (P : Sylow p G) (hP : ↑P ≤ N) : (P : Subgroup G).normalizer ⊔ N = ⊤ := by
   rw [← Sylow.normalizer_sup_eq_top (P.subtype hP), P.coe_subtype, subgroupOf_map_subtype,
     inf_of_le_left hP]
+
+end Sylow
 
 end InfiniteSylow
 


### PR DESCRIPTION
This PR cleans up `Sylow.lean` by using namespacing and dot-notation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
