### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Matrix/ToLin): for R-module M, End(Mⁿ) ≅ Matₙₓₙ(End(M))

### DIFF
--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1497,6 +1497,19 @@ theorem mapMatrix_trans (f : α ≃+* β) (g : β ≃+* γ) :
     f.mapMatrix.trans g.mapMatrix = ((f.trans g).mapMatrix : Matrix m m α ≃+* _) :=
   rfl
 
+open MulOpposite in
+/--
+For any ring `R`, we have ring isomorphism `Matₙₓₙ(Rᵒᵖ) ≅ (Matₙₓₙ(R))ᵒᵖ` given by transpose.
+-/
+@[simps apply symm_apply]
+def mopMatrix : Matrix m m αᵐᵒᵖ ≃+* (Matrix m m α)ᵐᵒᵖ where
+  toFun := fun M => op (M.transpose.map unop)
+  invFun := fun M => M.unop.transpose.map op
+  left_inv _ := by aesop
+  right_inv _ := by aesop
+  map_mul' _ _ := unop_injective <| by ext; simp [transpose, mul_apply]
+  map_add' _ _ := by aesop
+
 end RingEquiv
 
 namespace AlgHom

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1503,8 +1503,8 @@ For any ring `R`, we have ring isomorphism `Matₙₓₙ(Rᵒᵖ) ≅ (Matₙₓ
 -/
 @[simps apply symm_apply]
 def mopMatrix : Matrix m m αᵐᵒᵖ ≃+* (Matrix m m α)ᵐᵒᵖ where
-  toFun := fun M => op (M.transpose.map unop)
-  invFun := fun M => M.unop.transpose.map op
+  toFun M := op (M.transpose.map unop)
+  invFun M := M.unop.transpose.map op
   left_inv _ := by aesop
   right_inv _ := by aesop
   map_mul' _ _ := unop_injective <| by ext; simp [transpose, mul_apply]

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -984,3 +984,61 @@ lemma end_apply_apply (ij : ι × ι) (k : ι) : (b.end ij) (b k) = if ij.2 = k 
   linearMap_apply_apply b b ij k
 
 end Basis
+
+section
+
+variable (ι : Type*) [Fintype ι] [DecidableEq ι]
+variable (R : Type*) [Semiring R]
+variable (M : Type*) [AddCommMonoid M] [Module R M]
+
+@[simps]
+def endVecEquivMatrixEnd :
+    Module.End R (ι → M) ≃ Matrix ι ι (Module.End R M) where
+  toFun f i j :=
+  { toFun := fun x ↦ f (Pi.single j x) i
+    map_add' := fun x y ↦ by simp [Pi.single_add]
+    map_smul' := fun x y ↦ by simp [Pi.single_smul] }
+  invFun m :=
+  { toFun := fun x i ↦ ∑ j, m i j (x j)
+    map_add' := by intros; ext; simp [Finset.sum_add_distrib]
+    map_smul' := by intros; ext; simp [Finset.smul_sum] }
+  left_inv f := by
+    ext i x j
+    simp only [LinearMap.coe_mk, AddHom.coe_mk, coe_comp, coe_single, Function.comp_apply]
+    rw [← Fintype.sum_apply, ← map_sum]
+    exact congr_arg₂ _ (by aesop) rfl
+  right_inv m := by ext; simp [Pi.single_apply, apply_ite]
+
+@[simp]
+def endVecRingEquivMatrixEnd :
+    Module.End R (ι → M) ≃+* Matrix ι ι (Module.End R M) where
+  __ := endVecEquivMatrixEnd ι R M
+  map_mul' f g := by
+    ext
+    simp only [Equiv.toFun_as_coe, endVecEquivMatrixEnd_apply_apply, LinearMap.mul_apply,
+      Matrix.mul_apply, coeFn_sum, Finset.sum_apply]
+    rw [← Fintype.sum_apply, ← map_sum]
+    exact congr_arg₂ _ (by aesop) rfl
+  map_add' f g := by ext; simp
+
+end
+
+section
+
+variable (ι : Type*) [Fintype ι] [DecidableEq ι]
+variable (R : Type*) [CommSemiring R]
+variable (M : Type*) [AddCommMonoid M] [Module R M]
+
+@[simps! apply_apply symm_apply_apply]
+def endVecAlgEquivMatrixEnd :
+    Module.End R (ι → M) ≃ₐ[R] Matrix ι ι (Module.End R M) where
+  __ := endVecRingEquivMatrixEnd ι R M
+  commutes' r := by
+    ext
+    simp only [endVecRingEquivMatrixEnd, RingEquiv.toEquiv_eq_coe, Module.algebraMap_end_eq_smul_id,
+      Equiv.toFun_as_coe, EquivLike.coe_coe, RingEquiv.coe_mk, endVecEquivMatrixEnd_apply_apply,
+      LinearMap.smul_apply, id_coe, id_eq, Pi.smul_apply, Pi.single_apply, smul_ite, smul_zero,
+      algebraMap_matrix_apply]
+    split_ifs <;> rfl
+
+end

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -999,9 +999,9 @@ are `R`-linear maps `M → M`. In another word, we have`End(Mⁿ) ≅ Matₙₓ�
 
 See also `LinearMap.toMatrix'`
 -/
-@[simps]
-def endVecEquivMatrixEnd :
-    Module.End R (ι → M) ≃ Matrix ι ι (Module.End R M) where
+@[simp]
+def endVecRingEquivMatrixEnd :
+    Module.End R (ι → M) ≃+* Matrix ι ι (Module.End R M) where
   toFun f i j :=
   { toFun := fun x ↦ f (Pi.single j x) i
     map_add' := fun x y ↦ by simp [Pi.single_add]
@@ -1016,23 +1016,10 @@ def endVecEquivMatrixEnd :
     rw [← Fintype.sum_apply, ← map_sum]
     exact congr_arg₂ _ (by aesop) rfl
   right_inv m := by ext; simp [Pi.single_apply, apply_ite]
-
-/--
-Let `M` be an `R`-module. Every `R`-linear map `Mⁿ → Mⁿ` corresponds to a `n×n`-matrix whose entries
-are `R`-linear maps `M → M`. In another word, we have`End(Mⁿ) ≅ Matₙₓₙ(End(M))` defined by:
-`(f : Mⁿ → Mⁿ) ↦ (x ↦ f (0, ...,x at j-th position, ..., 0) i)ᵢⱼ` and
-`m : Matₙₓₙ(End(M)) ↦ (v ↦ ∑ⱼ mᵢⱼ(vⱼ))`.
-
-See also `LinearMap.toMatrix'`
--/
-@[simp]
-def endVecRingEquivMatrixEnd :
-    Module.End R (ι → M) ≃+* Matrix ι ι (Module.End R M) where
-  __ := endVecEquivMatrixEnd ι R M
   map_mul' f g := by
     ext
-    simp only [Equiv.toFun_as_coe, endVecEquivMatrixEnd_apply_apply, LinearMap.mul_apply,
-      Matrix.mul_apply, coeFn_sum, Finset.sum_apply]
+    simp only [LinearMap.mul_apply, LinearMap.coe_mk, AddHom.coe_mk, Matrix.mul_apply, coeFn_sum,
+      Finset.sum_apply]
     rw [← Fintype.sum_apply, ← map_sum]
     exact congr_arg₂ _ (by aesop) rfl
   map_add' f g := by ext; simp
@@ -1043,7 +1030,8 @@ section
 
 variable (ι : Type*) [Fintype ι] [DecidableEq ι]
 variable (R : Type*) [CommSemiring R]
-variable (M : Type*) [AddCommMonoid M] [Module R M]
+variable (A : Type*) [Semiring A] [Algebra R A]
+variable (M : Type*) [AddCommMonoid M] [Module R M] [Module A M] [IsScalarTower R A M]
 
 /--
 Let `M` be an `R`-module. Every `R`-linear map `Mⁿ → Mⁿ` corresponds to a `n×n`-matrix whose entries
@@ -1055,14 +1043,14 @@ See also `LinearMap.toMatrix'`
 -/
 @[simps! apply_apply symm_apply_apply]
 def endVecAlgEquivMatrixEnd :
-    Module.End R (ι → M) ≃ₐ[R] Matrix ι ι (Module.End R M) where
-  __ := endVecRingEquivMatrixEnd ι R M
+    Module.End A (ι → M) ≃ₐ[R] Matrix ι ι (Module.End A M) where
+  __ := endVecRingEquivMatrixEnd ι A M
   commutes' r := by
     ext
     simp only [endVecRingEquivMatrixEnd, RingEquiv.toEquiv_eq_coe, Module.algebraMap_end_eq_smul_id,
-      Equiv.toFun_as_coe, EquivLike.coe_coe, RingEquiv.coe_mk, endVecEquivMatrixEnd_apply_apply,
+      Equiv.toFun_as_coe, EquivLike.coe_coe, RingEquiv.coe_mk, Equiv.coe_fn_mk,
       LinearMap.smul_apply, id_coe, id_eq, Pi.smul_apply, Pi.single_apply, smul_ite, smul_zero,
-      algebraMap_matrix_apply]
+      LinearMap.coe_mk, AddHom.coe_mk, algebraMap_matrix_apply]
     split_ifs <;> rfl
 
 end

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -988,12 +988,13 @@ end Basis
 section
 
 variable (ι : Type*) [Fintype ι] [DecidableEq ι]
-variable (R : Type*) [Semiring R]
-variable (M : Type*) [AddCommMonoid M] [Module R M]
+variable (R : Type*) [CommSemiring R]
+variable (A : Type*) [Semiring A] [Algebra R A]
+variable (M : Type*) [AddCommMonoid M] [Module R M] [Module A M] [IsScalarTower R A M]
 
 /--
-Let `M` be an `R`-module. Every `R`-linear map `Mⁿ → Mⁿ` corresponds to a `n×n`-matrix whose entries
-are `R`-linear maps `M → M`. In another word, we have`End(Mⁿ) ≅ Matₙₓₙ(End(M))` defined by:
+Let `M` be an `A`-module. Every `A`-linear map `Mⁿ → Mⁿ` corresponds to a `n×n`-matrix whose entries
+are `A`-linear maps `M → M`. In another word, we have`End(Mⁿ) ≅ Matₙₓₙ(End(M))` defined by:
 `(f : Mⁿ → Mⁿ) ↦ (x ↦ f (0, ..., x at j-th position, ..., 0) i)ᵢⱼ` and
 `m : Matₙₓₙ(End(M)) ↦ (v ↦ ∑ⱼ mᵢⱼ(vⱼ))`.
 
@@ -1001,7 +1002,7 @@ See also `LinearMap.toMatrix'`
 -/
 @[simp]
 def endVecRingEquivMatrixEnd :
-    Module.End R (ι → M) ≃+* Matrix ι ι (Module.End R M) where
+    Module.End A (ι → M) ≃+* Matrix ι ι (Module.End A M) where
   toFun f i j :=
   { toFun := fun x ↦ f (Pi.single j x) i
     map_add' := fun x y ↦ by simp [Pi.single_add]
@@ -1023,15 +1024,6 @@ def endVecRingEquivMatrixEnd :
     rw [← Fintype.sum_apply, ← map_sum]
     exact congr_arg₂ _ (by aesop) rfl
   map_add' f g := by ext; simp
-
-end
-
-section
-
-variable (ι : Type*) [Fintype ι] [DecidableEq ι]
-variable (R : Type*) [CommSemiring R]
-variable (A : Type*) [Semiring A] [Algebra R A]
-variable (M : Type*) [AddCommMonoid M] [Module R M] [Module A M] [IsScalarTower R A M]
 
 /--
 Let `M` be an `A`-module. Every `A`-linear map `Mⁿ → Mⁿ` corresponds to a `n×n`-matrix whose entries

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -1028,7 +1028,7 @@ def endVecRingEquivMatrixEnd :
 /--
 Let `M` be an `A`-module. Every `A`-linear map `Mⁿ → Mⁿ` corresponds to a `n×n`-matrix whose entries
 are `R`-linear maps `M → M`. In another word, we have`End(Mⁿ) ≅ Matₙₓₙ(End(M))` defined by:
-`(f : Mⁿ → Mⁿ) ↦ (x ↦ f (0, ...,x at j-th position, ..., 0) i)ᵢⱼ` and
+`(f : Mⁿ → Mⁿ) ↦ (x ↦ f (0, ..., x at j-th position, ..., 0) i)ᵢⱼ` and
 `m : Matₙₓₙ(End(M)) ↦ (v ↦ ∑ⱼ mᵢⱼ(vⱼ))`.
 
 See also `LinearMap.toMatrix'`

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -991,6 +991,14 @@ variable (ι : Type*) [Fintype ι] [DecidableEq ι]
 variable (R : Type*) [Semiring R]
 variable (M : Type*) [AddCommMonoid M] [Module R M]
 
+/--
+Let `M` be an `R`-module. Every `R`-linear map `Mⁿ → Mⁿ` corresponds to a `n×n`-matrix whose entries
+are `R`-linear maps `M → M`. In another word, we have`End(Mⁿ) ≅ Matₙₓₙ(End(M))` defined by:
+`(f : Mⁿ → Mⁿ) ↦ (x ↦ f (0, ...,x at j-th position, ..., 0) i)ᵢⱼ` and
+`m : Matₙₓₙ(End(M)) ↦ (v ↦ ∑ⱼ mᵢⱼ(vⱼ))`.
+
+See also `LinearMap.toMatrix'`
+-/
 @[simps]
 def endVecEquivMatrixEnd :
     Module.End R (ι → M) ≃ Matrix ι ι (Module.End R M) where
@@ -1009,6 +1017,14 @@ def endVecEquivMatrixEnd :
     exact congr_arg₂ _ (by aesop) rfl
   right_inv m := by ext; simp [Pi.single_apply, apply_ite]
 
+/--
+Let `M` be an `R`-module. Every `R`-linear map `Mⁿ → Mⁿ` corresponds to a `n×n`-matrix whose entries
+are `R`-linear maps `M → M`. In another word, we have`End(Mⁿ) ≅ Matₙₓₙ(End(M))` defined by:
+`(f : Mⁿ → Mⁿ) ↦ (x ↦ f (0, ...,x at j-th position, ..., 0) i)ᵢⱼ` and
+`m : Matₙₓₙ(End(M)) ↦ (v ↦ ∑ⱼ mᵢⱼ(vⱼ))`.
+
+See also `LinearMap.toMatrix'`
+-/
 @[simp]
 def endVecRingEquivMatrixEnd :
     Module.End R (ι → M) ≃+* Matrix ι ι (Module.End R M) where
@@ -1029,6 +1045,14 @@ variable (ι : Type*) [Fintype ι] [DecidableEq ι]
 variable (R : Type*) [CommSemiring R]
 variable (M : Type*) [AddCommMonoid M] [Module R M]
 
+/--
+Let `M` be an `R`-module. Every `R`-linear map `Mⁿ → Mⁿ` corresponds to a `n×n`-matrix whose entries
+are `R`-linear maps `M → M`. In another word, we have`End(Mⁿ) ≅ Matₙₓₙ(End(M))` defined by:
+`(f : Mⁿ → Mⁿ) ↦ (x ↦ f (0, ...,x at j-th position, ..., 0) i)ᵢⱼ` and
+`m : Matₙₓₙ(End(M)) ↦ (v ↦ ∑ⱼ mᵢⱼ(vⱼ))`.
+
+See also `LinearMap.toMatrix'`
+-/
 @[simps! apply_apply symm_apply_apply]
 def endVecAlgEquivMatrixEnd :
     Module.End R (ι → M) ≃ₐ[R] Matrix ι ι (Module.End R M) where

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -994,7 +994,7 @@ variable (M : Type*) [AddCommMonoid M] [Module R M]
 /--
 Let `M` be an `R`-module. Every `R`-linear map `Mⁿ → Mⁿ` corresponds to a `n×n`-matrix whose entries
 are `R`-linear maps `M → M`. In another word, we have`End(Mⁿ) ≅ Matₙₓₙ(End(M))` defined by:
-`(f : Mⁿ → Mⁿ) ↦ (x ↦ f (0, ...,x at j-th position, ..., 0) i)ᵢⱼ` and
+`(f : Mⁿ → Mⁿ) ↦ (x ↦ f (0, ..., x at j-th position, ..., 0) i)ᵢⱼ` and
 `m : Matₙₓₙ(End(M)) ↦ (v ↦ ∑ⱼ mᵢⱼ(vⱼ))`.
 
 See also `LinearMap.toMatrix'`
@@ -1020,7 +1020,7 @@ def endVecEquivMatrixEnd :
 /--
 Let `M` be an `R`-module. Every `R`-linear map `Mⁿ → Mⁿ` corresponds to a `n×n`-matrix whose entries
 are `R`-linear maps `M → M`. In another word, we have`End(Mⁿ) ≅ Matₙₓₙ(End(M))` defined by:
-`(f : Mⁿ → Mⁿ) ↦ (x ↦ f (0, ...,x at j-th position, ..., 0) i)ᵢⱼ` and
+`(f : Mⁿ → Mⁿ) ↦ (x ↦ f (0, ..., x at j-th position, ..., 0) i)ᵢⱼ` and
 `m : Matₙₓₙ(End(M)) ↦ (v ↦ ∑ⱼ mᵢⱼ(vⱼ))`.
 
 See also `LinearMap.toMatrix'`


### PR DESCRIPTION
This isomorphism is defined in a similar fashion to [LinearMap.toMatrix'](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Matrix/ToLin.html#LinearMap.toMatrix'), but we consider End(Mⁿ) instead of End(Rⁿ)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
