### PR TITLE
[Merged by Bors] - feat(NumberTheory/DirichletCharacter/Orthogonality): new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3619,6 +3619,7 @@ import Mathlib.NumberTheory.DiophantineApproximation
 import Mathlib.NumberTheory.DirichletCharacter.Basic
 import Mathlib.NumberTheory.DirichletCharacter.Bounds
 import Mathlib.NumberTheory.DirichletCharacter.GaussSum
+import Mathlib.NumberTheory.DirichletCharacter.Orthogonality
 import Mathlib.NumberTheory.Divisors
 import Mathlib.NumberTheory.EllipticDivisibilitySequence
 import Mathlib.NumberTheory.EulerProduct.Basic

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -906,6 +906,14 @@ theorem inv_mul_of_unit {n : ℕ} (a : ZMod n) (h : IsUnit a) : a⁻¹ * a = 1 :
 protected theorem inv_eq_of_mul_eq_one (n : ℕ) (a b : ZMod n) (h : a * b = 1) : a⁻¹ = b :=
   left_inv_eq_right_inv (inv_mul_of_unit a ⟨⟨a, b, h, mul_comm a b ▸ h⟩, rfl⟩) h
 
+lemma inv_mul_eq_one_of_isUnit {n : ℕ} {a : ZMod n} (ha : IsUnit a) (b : ZMod n) :
+    a⁻¹ * b = 1 ↔ a = b := by
+  -- ideally, this would be `ha.inv_mul_eq_one`, but `ZMod n` is not a `DivisionMonoid`...
+  -- (see the "TODO" above)
+  refine ⟨fun H ↦ ?_, fun H ↦ H ▸ a.inv_mul_of_unit ha⟩
+  apply_fun (a * ·) at H
+  rwa [← mul_assoc, a.mul_inv_of_unit ha, one_mul, mul_one, eq_comm] at H
+
 -- TODO: this equivalence is true for `ZMod 0 = ℤ`, but needs to use different functions.
 /-- Equivalence between the units of `ZMod n` and
 the subtype of terms `x : ZMod n` for which `x.val` is coprime to `n` -/

--- a/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
@@ -63,7 +63,7 @@ theorem exists_apply_ne_one_of_hasEnoughRootsOfUnity {a : G} (ha : a ≠ 1) :
 /-- A finite commutative group `G` is (noncanonically) isomorphic to the group `G →* Mˣ`
 when `M` is a commutative monoid with enough `n`th roots of unity, where `n` is the exponent
 of `G`. -/
-theorem mulEquiv_monoidHom_of_hasEnoughRootsOfUnity : Nonempty (G ≃* (G →* Mˣ)) := by
+theorem mmonoidHom_mulEquiv_of_hasEnoughRootsOfUnity : Nonempty ((G →* Mˣ) ≃* G) := by
   classical -- to get `DecidableEq ι`
   obtain ⟨ι, _, n, ⟨h₁, h₂⟩⟩ := equiv_prod_multiplicative_zmod_of_finite G
   let e := h₂.some
@@ -76,6 +76,6 @@ theorem mulEquiv_monoidHom_of_hasEnoughRootsOfUnity : Nonempty (G ≃* (G →* M
         using dvd_exponent e i
     exact HasEnoughRootsOfUnity.of_dvd M hdvd
   let E i := (IsCyclic.monoidHom_equiv_self (Multiplicative (ZMod (n i))) M).some
-  exact ⟨e.trans (MulEquiv.piCongrRight E).symm|>.trans e'.symm|>.trans e''.symm⟩
+  exact ⟨e''.trans <| e'.trans <| (MulEquiv.piCongrRight E).trans e.symm⟩
 
 end CommGroup

--- a/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
@@ -63,7 +63,7 @@ theorem exists_apply_ne_one_of_hasEnoughRootsOfUnity {a : G} (ha : a ≠ 1) :
 /-- A finite commutative group `G` is (noncanonically) isomorphic to the group `G →* Mˣ`
 when `M` is a commutative monoid with enough `n`th roots of unity, where `n` is the exponent
 of `G`. -/
-theorem mmonoidHom_mulEquiv_of_hasEnoughRootsOfUnity : Nonempty ((G →* Mˣ) ≃* G) := by
+theorem monoidHom_mulEquiv_of_hasEnoughRootsOfUnity : Nonempty ((G →* Mˣ) ≃* G) := by
   classical -- to get `DecidableEq ι`
   obtain ⟨ι, _, n, ⟨h₁, h₂⟩⟩ := equiv_prod_multiplicative_zmod_of_finite G
   let e := h₂.some

--- a/Mathlib/NumberTheory/DirichletCharacter/Orthogonality.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/Orthogonality.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2024 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Stoll
+-/
+import Mathlib.FieldTheory.Finite.Basic
+import Mathlib.NumberTheory.DirichletCharacter.Basic
+import Mathlib.NumberTheory.MulChar.Duality
+
+/-!
+# Orthogonality relations for Dirichlet characters
+
+Let `n` be a positive natural number. The main result of this file is
+`DirichletCharacter.sum_char_inv_mul_char_eq`, which says that when `a : ZMod n` is a unit
+and `b : ZMod n`, then the sum `∑ χ : DirichletCharacter R n, χ a⁻¹ * χ b` vanishes
+when `a ≠ b` and has the value `n.totient` otherwise. This requires `R` to have
+enough roots of unity (e.g., `R` could be an algebraically closed field of characteristic zero).
+-/
+
+namespace DirichletCharacter
+
+-- This is needed to be able to write down sums over characters.
+noncomputable instance fintype {R : Type*} [CommRing R] [IsDomain R] {n : ℕ} :
+    Fintype (DirichletCharacter R n) := .ofFinite _
+
+variable (R : Type*) [CommRing R] (n : ℕ) [NeZero n] [HasEnoughRootsOfUnity R n.totient]
+
+private lemma HasEnoughRootsOfUnity.of_totient :
+    HasEnoughRootsOfUnity R (Monoid.exponent (ZMod n)ˣ) :=
+  HasEnoughRootsOfUnity.of_dvd R (ZMod.card_units_eq_totient n ▸ Group.exponent_dvd_card)
+
+/-- The group of Dirichlet characters mod `n` with values in a ring `R` that has enough
+roots of unity is (noncanonically) isomorphic to `(ZMod n)ˣ`. -/
+lemma mulEquiv_units : Nonempty (DirichletCharacter R n ≃* (ZMod n)ˣ) :=
+  have := HasEnoughRootsOfUnity.of_totient R n
+  MulChar.mulEquiv_units ..
+
+/-- There are `n.totient` Dirichlet characters mod `n` with values in a ring that has enough
+roots of unity. -/
+lemma card_eq_totient_of_hasEnoughRootsOfUnity :
+    Nat.card (DirichletCharacter R n) = n.totient := by
+  rw [← ZMod.card_units_eq_totient n, ← Nat.card_eq_fintype_card]
+  exact Nat.card_congr (mulEquiv_units R n).some.toEquiv
+
+variable {n}
+
+/-- If `R` is a ring that has enough roots of unity and `n ≠ 0`, then for each
+`a ≠ 1` in `ZMod n`, there exists a Dirichlet character `χ` mod `n` with values in `R`
+such that `χ a ≠ 1`. -/
+theorem exists_apply_ne_one_of_hasEnoughRootsOfUnity [Nontrivial R] ⦃a : ZMod n⦄ (ha : a ≠ 1) :
+    ∃ χ : DirichletCharacter R n, χ a ≠ 1 :=
+  have := HasEnoughRootsOfUnity.of_totient R n
+  MulChar.exists_apply_ne_one_of_hasEnoughRootsOfUnity (ZMod n) R ha
+
+variable [IsDomain R]
+
+/-- If `R` is an integral domain that has enough roots of unity and `n ≠ 0`, then
+for each `a ≠ 1` in `ZMod n`, the sum of `χ a` over all Dirichlet characters mod `n`
+with values in `R` vanishes. -/
+theorem sum_characters_eq_zero ⦃a : ZMod n⦄ (ha : a ≠ 1) :
+    ∑ χ : DirichletCharacter R n, χ a = 0 := by
+  obtain ⟨χ, hχ⟩ := exists_apply_ne_one_of_hasEnoughRootsOfUnity R ha
+  refine eq_zero_of_mul_eq_self_left hχ ?_
+  simp only [Finset.mul_sum, ← MulChar.mul_apply]
+  exact Fintype.sum_bijective _ (Group.mulLeft_bijective χ) _ _ fun χ' ↦ rfl
+
+/-- If `R` is an integral domain that has enough roots of unity and `n ≠ 0`, then
+for `a` in `ZMod n`, the sum of `χ a` over all Dirichlet characters mod `n`
+with values in `R` vanishes if `a ≠ 1` and has the value `n.totient` if `a = 1`. -/
+theorem sum_characters_eq (a : ZMod n) :
+    ∑ χ : DirichletCharacter R n, χ a = if a = 1 then (n.totient : R) else 0 := by
+  split_ifs with ha
+  · simpa only [ha, map_one, Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_one,
+      ← Nat.card_eq_fintype_card]
+      using congrArg Nat.cast <| card_eq_totient_of_hasEnoughRootsOfUnity R n
+  · exact sum_characters_eq_zero R ha
+
+/-- If `R` is an integral domain that has enough roots of unity and `n ≠ 0`, then for `a` and `b`
+in `ZMod n` with `a` a unit, the sum of `χ a⁻¹ * χ b` over all Dirichlet characters
+mod `n` with values in `R` vanishes if `a ≠ b` and has the value `n.totient` if `a = b`. -/
+theorem sum_char_inv_mul_char_eq {a : ZMod n} (ha : IsUnit a) (b : ZMod n) :
+    ∑ χ : DirichletCharacter R n, χ a⁻¹ * χ b = if a = b then (n.totient : R) else 0 := by
+  simp only [← map_mul, sum_characters_eq, ZMod.inv_mul_eq_one_of_isUnit ha]
+
+end DirichletCharacter

--- a/Mathlib/NumberTheory/DirichletCharacter/Orthogonality.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/Orthogonality.lean
@@ -23,16 +23,12 @@ namespace DirichletCharacter
 noncomputable instance fintype {R : Type*} [CommRing R] [IsDomain R] {n : ℕ} :
     Fintype (DirichletCharacter R n) := .ofFinite _
 
-variable (R : Type*) [CommRing R] (n : ℕ) [NeZero n] [HasEnoughRootsOfUnity R n.totient]
-
-private lemma HasEnoughRootsOfUnity.of_totient :
-    HasEnoughRootsOfUnity R (Monoid.exponent (ZMod n)ˣ) :=
-  HasEnoughRootsOfUnity.of_dvd R (ZMod.card_units_eq_totient n ▸ Group.exponent_dvd_card)
+variable (R : Type*) [CommRing R] (n : ℕ) [NeZero n]
+  [HasEnoughRootsOfUnity R (Monoid.exponent (ZMod n)ˣ)]
 
 /-- The group of Dirichlet characters mod `n` with values in a ring `R` that has enough
 roots of unity is (noncanonically) isomorphic to `(ZMod n)ˣ`. -/
 lemma mulEquiv_units : Nonempty (DirichletCharacter R n ≃* (ZMod n)ˣ) :=
-  have := HasEnoughRootsOfUnity.of_totient R n
   MulChar.mulEquiv_units ..
 
 /-- There are `n.totient` Dirichlet characters mod `n` with values in a ring that has enough
@@ -49,7 +45,6 @@ variable {n}
 such that `χ a ≠ 1`. -/
 theorem exists_apply_ne_one_of_hasEnoughRootsOfUnity [Nontrivial R] ⦃a : ZMod n⦄ (ha : a ≠ 1) :
     ∃ χ : DirichletCharacter R n, χ a ≠ 1 :=
-  have := HasEnoughRootsOfUnity.of_totient R n
   MulChar.exists_apply_ne_one_of_hasEnoughRootsOfUnity (ZMod n) R ha
 
 variable [IsDomain R]

--- a/Mathlib/NumberTheory/MulChar/Duality.lean
+++ b/Mathlib/NumberTheory/MulChar/Duality.lean
@@ -64,7 +64,7 @@ theorem exists_apply_ne_one_of_hasEnoughRootsOfUnity [Nontrivial R] {a : M} (ha 
 of unity. -/
 lemma mulEquiv_units : Nonempty (MulChar M R ≃* Mˣ) :=
   ⟨mulEquivToUnitHom.trans
-    (CommGroup.mulEquiv_monoidHom_of_hasEnoughRootsOfUnity Mˣ R).some.symm⟩
+    (CommGroup.mmonoidHom_mulEquiv_of_hasEnoughRootsOfUnity Mˣ R).some⟩
 
 /-- The cardinality of the group of `R`-valued multiplicative characters on a finite commutative
 monoid `M` is the same as that of its unit group `Mˣ` when `R` is a ring that has enough roots

--- a/Mathlib/NumberTheory/MulChar/Duality.lean
+++ b/Mathlib/NumberTheory/MulChar/Duality.lean
@@ -64,7 +64,7 @@ theorem exists_apply_ne_one_of_hasEnoughRootsOfUnity [Nontrivial R] {a : M} (ha 
 of unity. -/
 lemma mulEquiv_units : Nonempty (MulChar M R ≃* Mˣ) :=
   ⟨mulEquivToUnitHom.trans
-    (CommGroup.mmonoidHom_mulEquiv_of_hasEnoughRootsOfUnity Mˣ R).some⟩
+    (CommGroup.monoidHom_mulEquiv_of_hasEnoughRootsOfUnity Mˣ R).some⟩
 
 /-- The cardinality of the group of `R`-valued multiplicative characters on a finite commutative
 monoid `M` is the same as that of its unit group `Mˣ` when `R` is a ring that has enough roots


### PR DESCRIPTION
This PR is the final step in establishing the orthogonality relations for Dirichlet characters. 

See [here on Zulip](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/Orthogonality.20of.20Dirichlet.20characters/near/480747063).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
