### PR TITLE
[Merged by Bors] - chore: generalise `MeasurableSpace (AddChar A M)`

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/AddChar.lean
+++ b/Mathlib/MeasureTheory/Constructions/AddChar.lean
@@ -9,8 +9,7 @@ import Mathlib.MeasureTheory.MeasurableSpace.Defs
 /-!
 # Measurable space instance for additive characters
 
-This file endows `AddChar A M` with the discrete measurable space structure whenever `A` and `M`
-are themselves discrete measurable spaces.
+This file endows `AddChar A M` with the discrete measurable space structure whenever `A` is a finite discrete measurable space.
 
 ## TODO
 
@@ -21,11 +20,11 @@ namespace AddChar
 variable {A M : Type*} [AddMonoid A] [Monoid M] [MeasurableSpace A] [MeasurableSpace M]
 
 @[nolint unusedArguments]
-instance instMeasurableSpace [DiscreteMeasurableSpace A] [DiscreteMeasurableSpace M] :
+instance instMeasurableSpace [DiscreteMeasurableSpace A] [Finite A] :
     MeasurableSpace (AddChar A M) :=
   ⊤
 
-instance instDiscreteMeasurableSpace [DiscreteMeasurableSpace A] [DiscreteMeasurableSpace M] :
+instance instDiscreteMeasurableSpace [DiscreteMeasurableSpace A] [Finite A] :
     DiscreteMeasurableSpace (AddChar A M) :=
   ⟨fun _ ↦ trivial⟩
 

--- a/Mathlib/MeasureTheory/Constructions/AddChar.lean
+++ b/Mathlib/MeasureTheory/Constructions/AddChar.lean
@@ -9,7 +9,8 @@ import Mathlib.MeasureTheory.MeasurableSpace.Defs
 /-!
 # Measurable space instance for additive characters
 
-This file endows `AddChar A M` with the discrete measurable space structure whenever `A` is a finite discrete measurable space.
+This file endows `AddChar A M` with the discrete measurable space structure whenever `A` is a finite
+discrete measurable space.
 
 ## TODO
 


### PR DESCRIPTION
This was ungeneralised in #18494, but I need this for `A` a finite group and `M = ℂ`, which is certainly not discrete.

From LeanAPAP

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
