### PR TITLE
[Merged by Bors] - refactor(Algebra/Polynomial/Lifts): Golf some proofs

### DIFF
--- a/Mathlib/Algebra/Polynomial/Lifts.lean
+++ b/Mathlib/Algebra/Polynomial/Lifts.lean
@@ -153,7 +153,7 @@ theorem lifts_and_degree_eq_and_monic [Nontrivial S] {p : S[X]} (hlifts : p ∈ 
     (hp : p.Monic) : ∃ q : R[X], map f q = p ∧ q.degree = p.degree ∧ q.Monic := by
   rw [lifts_iff_coeff_lifts] at hlifts
   let g : ℕ → R := fun k ↦ (hlifts k).choose
-  have hg : ∀ k, f (g k) = p.coeff k := fun k ↦ (hlifts k).choose_spec
+  have hg k : f (g k) = p.coeff k := (hlifts k).choose_spec
   let q : R[X] := X ^ p.natDegree + ∑ k ∈ Finset.range p.natDegree, C (g k) * X ^ k
   have hq : map f q = p := by
     simp_rw [q, Polynomial.map_add, Polynomial.map_sum, Polynomial.map_mul, Polynomial.map_pow,

--- a/Mathlib/Algebra/Polynomial/Lifts.lean
+++ b/Mathlib/Algebra/Polynomial/Lifts.lean
@@ -122,63 +122,26 @@ section LiftDeg
 
 theorem monomial_mem_lifts_and_degree_eq {s : S} {n : ℕ} (hl : monomial n s ∈ lifts f) :
     ∃ q : R[X], map f q = monomial n s ∧ q.degree = (monomial n s).degree := by
-  by_cases hzero : s = 0
-  · use 0
-    simp only [hzero, degree_zero, eq_self_iff_true, and_self_iff, monomial_zero_right,
-      Polynomial.map_zero]
-  rw [lifts_iff_set_range] at hl
-  obtain ⟨q, hq⟩ := hl
-  replace hq := (ext_iff.1 hq) n
-  have hcoeff : f (q.coeff n) = s := by
-    rwa [coeff_map, coeff_monomial_same] at hq
-  use monomial n (q.coeff n)
-  constructor
-  · simp only [hcoeff, map_monomial]
-  have hqzero : q.coeff n ≠ 0 := by
-    intro habs
-    simp only [habs, RingHom.map_zero] at hcoeff
-    exact hzero hcoeff.symm
-  rw [← C_mul_X_pow_eq_monomial, ← C_mul_X_pow_eq_monomial]
-  simp only [hzero, hqzero, Ne, not_false_iff, degree_C_mul_X_pow]
+  rcases eq_or_ne s 0 with rfl | h
+  · exact ⟨0, by simp⟩
+  obtain ⟨a, rfl⟩ := coeff_monomial_same n s ▸ (monomial n s).lifts_iff_coeff_lifts.mp hl n
+  refine ⟨monomial n a, map_monomial f, ?_⟩
+  rw [degree_monomial, degree_monomial n h]
+  exact mt (fun ha ↦ ha ▸ map_zero f) h
 
 /-- A polynomial lifts if and only if it can be lifted to a polynomial of the same degree. -/
 theorem mem_lifts_and_degree_eq {p : S[X]} (hlifts : p ∈ lifts f) :
     ∃ q : R[X], map f q = p ∧ q.degree = p.degree := by
-  generalize hd : p.natDegree = d
-  revert hd p
-  induction' d using Nat.strong_induction_on with n hn
-  intros p hlifts hdeg
-  by_cases erase_zero : p.eraseLead = 0
-  · rw [← eraseLead_add_monomial_natDegree_leadingCoeff p, erase_zero, zero_add, leadingCoeff]
-    exact
-      monomial_mem_lifts_and_degree_eq
-        (monomial_mem_lifts p.natDegree ((lifts_iff_coeff_lifts p).1 hlifts p.natDegree))
-  have deg_erase := Or.resolve_right (eraseLead_natDegree_lt_or_eraseLead_eq_zero p) erase_zero
-  have pzero : p ≠ 0 := by
-    intro habs
-    exfalso
-    rw [habs, eraseLead_zero, eq_self_iff_true, not_true] at erase_zero
-    exact erase_zero
-  have lead_zero : p.coeff p.natDegree ≠ 0 := by
-    rw [← leadingCoeff, Ne, leadingCoeff_eq_zero]; exact pzero
-  obtain ⟨lead, hlead⟩ :=
-    monomial_mem_lifts_and_degree_eq
-      (monomial_mem_lifts p.natDegree ((lifts_iff_coeff_lifts p).1 hlifts p.natDegree))
-  have deg_lead : lead.degree = p.natDegree := by
-    rw [hlead.2, ← C_mul_X_pow_eq_monomial, degree_C_mul_X_pow p.natDegree lead_zero]
-  rw [hdeg] at deg_erase
-  obtain ⟨erase, herase⟩ :=
-    hn p.eraseLead.natDegree deg_erase (erase_mem_lifts p.natDegree hlifts)
-      (refl p.eraseLead.natDegree)
-  use erase + lead
-  constructor
-  · simp only [hlead, herase, Polynomial.map_add]
-    rw [← eraseLead, ← leadingCoeff]
-    rw [eraseLead_add_monomial_natDegree_leadingCoeff p]
-  rw [degree_eq_natDegree pzero, ← deg_lead]
-  apply degree_add_eq_right_of_degree_lt
-  rw [herase.2, deg_lead, ← degree_eq_natDegree pzero]
-  exact degree_erase_lt pzero
+  rw [lifts_iff_coeff_lifts] at hlifts
+  let g : ℕ → R := fun k ↦ (hlifts k).choose
+  have hg : ∀ k, f (g k) = p.coeff k := fun k ↦ (hlifts k).choose_spec
+  let q : R[X] := ∑ k ∈ p.support, monomial k (g k)
+  have hq : map f q = p := by simp_rw [q, Polynomial.map_sum, map_monomial, hg, ← as_sum_support]
+  have hq' : q.support = p.support := by
+    simp_rw [Finset.ext_iff, mem_support_iff, q, finset_sum_coeff, coeff_monomial,
+      Finset.sum_ite_eq', ite_ne_right_iff, mem_support_iff, and_iff_left_iff_imp, not_imp_not]
+    exact fun k h ↦ by rw [← hg, h, map_zero]
+  exact ⟨q, hq, congrArg Finset.max hq'⟩
 
 end LiftDeg
 
@@ -188,24 +151,14 @@ section Monic
 of the same degree. -/
 theorem lifts_and_degree_eq_and_monic [Nontrivial S] {p : S[X]} (hlifts : p ∈ lifts f)
     (hp : p.Monic) : ∃ q : R[X], map f q = p ∧ q.degree = p.degree ∧ q.Monic := by
-  cases' subsingleton_or_nontrivial R with hR hR
-  · obtain ⟨q, hq⟩ := mem_lifts_and_degree_eq hlifts
-    exact ⟨q, hq.1, hq.2, monic_of_subsingleton _⟩
-  have H : erase p.natDegree p + X ^ p.natDegree = p := by
-    simpa only [hp.leadingCoeff, C_1, one_mul, eraseLead] using eraseLead_add_C_mul_X_pow p
-  by_cases h0 : erase p.natDegree p = 0
-  · rw [← H, h0, zero_add]
-    refine ⟨X ^ p.natDegree, ?_, ?_, monic_X_pow p.natDegree⟩
-    · rw [Polynomial.map_pow, map_X]
-    · rw [degree_X_pow, degree_X_pow]
-  obtain ⟨q, hq⟩ := mem_lifts_and_degree_eq (erase_mem_lifts p.natDegree hlifts)
-  have p_neq_0 : p ≠ 0 := by intro hp; apply h0; rw [hp]; simp only [natDegree_zero, erase_zero]
-  have hdeg : q.degree < ((X : R[X]) ^ p.natDegree).degree := by
-    rw [@degree_X_pow R, hq.2, ← degree_eq_natDegree p_neq_0]
-    exact degree_erase_lt p_neq_0
-  refine ⟨q + X ^ p.natDegree, ?_, ?_, (monic_X_pow _).add_of_right hdeg⟩
-  · rw [Polynomial.map_add, hq.1, Polynomial.map_pow, map_X, H]
-  · rw [degree_add_eq_right_of_degree_lt hdeg, degree_X_pow, degree_eq_natDegree hp.ne_zero]
+  rw [lifts_iff_coeff_lifts] at hlifts
+  let g : ℕ → R := fun k ↦ (hlifts k).choose
+  have hg : ∀ k, f (g k) = p.coeff k := fun k ↦ (hlifts k).choose_spec
+  let q : R[X] := X ^ p.natDegree + ∑ k ∈ Finset.range p.natDegree, C (g k) * X ^ k
+  have hq : map f q = p := by simp_rw [q, Polynomial.map_add, Polynomial.map_sum,
+    Polynomial.map_mul, Polynomial.map_pow, map_X, map_C, hg, ← hp.as_sum]
+  have h : q.Monic := monic_X_pow_add (by simp_rw [← Fin.sum_univ_eq_sum_range, degree_sum_fin_lt])
+  exact ⟨q, hq, hq ▸ (h.degree_map f).symm, h⟩
 
 theorem lifts_and_natDegree_eq_and_monic {p : S[X]} (hlifts : p ∈ lifts f) (hp : p.Monic) :
     ∃ q : R[X], map f q = p ∧ q.natDegree = p.natDegree ∧ q.Monic := by

--- a/Mathlib/Algebra/Polynomial/Lifts.lean
+++ b/Mathlib/Algebra/Polynomial/Lifts.lean
@@ -155,8 +155,9 @@ theorem lifts_and_degree_eq_and_monic [Nontrivial S] {p : S[X]} (hlifts : p ∈ 
   let g : ℕ → R := fun k ↦ (hlifts k).choose
   have hg : ∀ k, f (g k) = p.coeff k := fun k ↦ (hlifts k).choose_spec
   let q : R[X] := X ^ p.natDegree + ∑ k ∈ Finset.range p.natDegree, C (g k) * X ^ k
-  have hq : map f q = p := by simp_rw [q, Polynomial.map_add, Polynomial.map_sum,
-    Polynomial.map_mul, Polynomial.map_pow, map_X, map_C, hg, ← hp.as_sum]
+  have hq : map f q = p := by
+    simp_rw [q, Polynomial.map_add, Polynomial.map_sum, Polynomial.map_mul, Polynomial.map_pow,
+      map_X, map_C, hg, ← hp.as_sum]
   have h : q.Monic := monic_X_pow_add (by simp_rw [← Fin.sum_univ_eq_sum_range, degree_sum_fin_lt])
   exact ⟨q, hq, hq ▸ (h.degree_map f).symm, h⟩
 


### PR DESCRIPTION
This PR golfs some proofs in `Algebra/Polynomial/Lifts.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
