### PR TITLE
[Merged by Bors] - feat(CategoryTheory): inclusion of terminal object is final

### DIFF
--- a/Mathlib/CategoryTheory/Filtered/Final.lean
+++ b/Mathlib/CategoryTheory/Filtered/Final.lean
@@ -97,6 +97,17 @@ theorem Functor.final_of_exists_of_isFiltered [IsFilteredOrEmpty C]
   suffices ∀ d, IsFiltered (StructuredArrow d F) from final_of_isFiltered_structuredArrow F
   exact isFiltered_structuredArrow_of_isFiltered_of_exists F h₁ h₂
 
+/-- The inclusion of a terminal object is final. -/
+theorem Functor.final_const_of_isTerminal {X : C} (hX : IsTerminal X) :
+    ((Functor.const (Discrete PUnit.{v₂ + 1})).obj X).Final :=
+  Functor.final_of_exists_of_isFiltered _ (fun d => ⟨⟨PUnit.unit⟩, ⟨hX.from d⟩⟩)
+    (fun _ _ => ⟨⟨PUnit.unit⟩, 𝟙 _, hX.hom_ext _ _⟩)
+
+/-- The inclusion of the terminal object is final. -/
+theorem Functor.final_const_terminal [HasTerminal C] :
+    ((Functor.const (Discrete PUnit.{v₂ + 1})).obj (⊤_ C)).Final :=
+  Functor.final_const_of_isTerminal terminalIsTerminal
+
 /-- If `C` is cofiltered, then we can give an explicit condition for a functor `F : C ⥤ D` to
     be final. The converse is also true, see `initial_iff_of_isCofiltered`. -/
 theorem Functor.initial_of_exists_of_isCofiltered [IsCofilteredOrEmpty C]
@@ -105,6 +116,17 @@ theorem Functor.initial_of_exists_of_isCofiltered [IsCofilteredOrEmpty C]
   suffices ∀ d, IsCofiltered (CostructuredArrow F d) from
     initial_of_isCofiltered_costructuredArrow F
   exact isCofiltered_costructuredArrow_of_isCofiltered_of_exists F h₁ h₂
+
+/-- The inclusion of an initial object is initial. -/
+theorem Functor.initial_const_of_isInitial {X : C} (hX : IsInitial X) :
+    ((Functor.const (Discrete PUnit.{v₂ + 1})).obj X).Initial :=
+  Functor.initial_of_exists_of_isCofiltered _ (fun d => ⟨⟨PUnit.unit⟩, ⟨hX.to d⟩⟩)
+    (fun _ _ => ⟨⟨PUnit.unit⟩, 𝟙 _, hX.hom_ext _ _⟩)
+
+/-- The inclusion of the initial object is initial. -/
+theorem Functor.inial_const_initial [HasInitial C] :
+    ((Functor.const (Discrete PUnit.{v₂ + 1})).obj (⊥_ C)).Initial :=
+  Functor.initial_const_of_isInitial initialIsInitial
 
 /-- In this situation, `F` is also final, see
     `Functor.final_of_exists_of_isFiltered_of_fullyFaithful`. -/

--- a/Mathlib/CategoryTheory/Filtered/Final.lean
+++ b/Mathlib/CategoryTheory/Filtered/Final.lean
@@ -124,7 +124,7 @@ theorem Functor.initial_const_of_isInitial [IsCofiltered C] {X : D} (hX : IsInit
     (fun {_ c} _ _ => ⟨c, 𝟙 _, hX.hom_ext _ _⟩)
 
 /-- The inclusion of the initial object is initial. -/
-theorem Functor.inial_const_initial [IsCofiltered C] [HasInitial D] :
+theorem Functor.initial_const_initial [IsCofiltered C] [HasInitial D] :
     ((Functor.const C).obj (⊥_ D)).Initial :=
   Functor.initial_const_of_isInitial initialIsInitial
 

--- a/Mathlib/CategoryTheory/Filtered/Final.lean
+++ b/Mathlib/CategoryTheory/Filtered/Final.lean
@@ -98,14 +98,14 @@ theorem Functor.final_of_exists_of_isFiltered [IsFilteredOrEmpty C]
   exact isFiltered_structuredArrow_of_isFiltered_of_exists F h₁ h₂
 
 /-- The inclusion of a terminal object is final. -/
-theorem Functor.final_const_of_isTerminal {X : C} (hX : IsTerminal X) :
-    ((Functor.const (Discrete PUnit.{v₂ + 1})).obj X).Final :=
-  Functor.final_of_exists_of_isFiltered _ (fun d => ⟨⟨PUnit.unit⟩, ⟨hX.from d⟩⟩)
-    (fun _ _ => ⟨⟨PUnit.unit⟩, 𝟙 _, hX.hom_ext _ _⟩)
+theorem Functor.final_const_of_isTerminal [IsFiltered C] {X : D} (hX : IsTerminal X) :
+    ((Functor.const C).obj X).Final :=
+  Functor.final_of_exists_of_isFiltered _ (fun _ => ⟨IsFiltered.nonempty.some, ⟨hX.from _⟩⟩)
+    (fun {_ c} _ _ => ⟨c, 𝟙 _, hX.hom_ext _ _⟩)
 
 /-- The inclusion of the terminal object is final. -/
-theorem Functor.final_const_terminal [HasTerminal C] :
-    ((Functor.const (Discrete PUnit.{v₂ + 1})).obj (⊤_ C)).Final :=
+theorem Functor.final_const_terminal [IsFiltered C] [HasTerminal D] :
+    ((Functor.const C).obj (⊤_ D)).Final :=
   Functor.final_const_of_isTerminal terminalIsTerminal
 
 /-- If `C` is cofiltered, then we can give an explicit condition for a functor `F : C ⥤ D` to
@@ -118,14 +118,14 @@ theorem Functor.initial_of_exists_of_isCofiltered [IsCofilteredOrEmpty C]
   exact isCofiltered_costructuredArrow_of_isCofiltered_of_exists F h₁ h₂
 
 /-- The inclusion of an initial object is initial. -/
-theorem Functor.initial_const_of_isInitial {X : C} (hX : IsInitial X) :
-    ((Functor.const (Discrete PUnit.{v₂ + 1})).obj X).Initial :=
-  Functor.initial_of_exists_of_isCofiltered _ (fun d => ⟨⟨PUnit.unit⟩, ⟨hX.to d⟩⟩)
-    (fun _ _ => ⟨⟨PUnit.unit⟩, 𝟙 _, hX.hom_ext _ _⟩)
+theorem Functor.initial_const_of_isInitial [IsCofiltered C] {X : D} (hX : IsInitial X) :
+    ((Functor.const C).obj X).Initial :=
+  Functor.initial_of_exists_of_isCofiltered _ (fun _ => ⟨IsCofiltered.nonempty.some, ⟨hX.to _⟩⟩)
+    (fun {_ c} _ _ => ⟨c, 𝟙 _, hX.hom_ext _ _⟩)
 
 /-- The inclusion of the initial object is initial. -/
-theorem Functor.inial_const_initial [HasInitial C] :
-    ((Functor.const (Discrete PUnit.{v₂ + 1})).obj (⊥_ C)).Initial :=
+theorem Functor.inial_const_initial [IsCofiltered C] [HasInitial D] :
+    ((Functor.const C).obj (⊥_ D)).Initial :=
   Functor.initial_const_of_isInitial initialIsInitial
 
 /-- In this situation, `F` is also final, see


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
