### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Abelian/GrothendieckAxioms): remove unnecessary premise, clarify definition of AB4/5

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms.lean
@@ -33,10 +33,9 @@ comments of the linked Stacks page.
 Exactness as the preservation of short exact sequences is introduced in
 `CategoryTheory.Abelian.Exact`.
 
-## Projects
-
-- Add additional axioms, especially define Grothendieck categories.
-- Prove that `AB5` implies `AB4`.
+We do not require `Abelian` in the definition of `AB4` and `AB5` because these classes represent
+individual axioms. A non-abelian category with `AB5` is not an AB5 category in the sense of the
+literature.
 
 ## References
 * [Stacks: Grothendieck's AB conditions](https://stacks.math.columbia.edu/tag/079A)
@@ -117,7 +116,7 @@ instance preservesFiniteLimitsLiftToFinset : PreservesFiniteLimits (liftToFinset
     preservesFiniteLimitsOfNatIso (liftToFinsetEvaluationIso  I).symm
 
 /-- A category with finite biproducts and finite limits is AB4 if it is AB5. -/
-def AB4.ofAB5 [HasFiniteCoproducts C] [HasFilteredColimits C] [AB5 C] : AB4 C where
+def AB4.ofAB5 [HasFilteredColimits C] [AB5 C] : AB4 C where
   preservesFiniteLimits J :=
     letI : PreservesFiniteLimits (liftToFinset C J ⋙ colim) :=
       compPreservesFiniteLimits _ _

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms.lean
@@ -17,8 +17,8 @@ basic facts about them.
 
 ## Definitions
 
-- `AB4` -- an abelian category satisfies `AB4` provided that coproducts are exact.
-- `AB5` -- an abelian category satisfies `AB5` provided that filtered colimits are exact.
+- `AB4` -- a category satisfies `AB4` provided that coproducts are exact.
+- `AB5` -- a category satisfies `AB5` provided that filtered colimits are exact.
 - The duals of the above definitions, called `AB4Star` and `AB5Star`.
 
 ## Theorems
@@ -34,10 +34,11 @@ Exactness as the preservation of short exact sequences is introduced in
 `CategoryTheory.Abelian.Exact`.
 
 We do not require `Abelian` in the definition of `AB4` and `AB5` because these classes represent
-individual axioms. A non-abelian category with `AB5` is not an AB5 category in the sense of the
-literature.
+individual axioms. An `AB4` category is an _abelian_ category satisfying `AB4`, and similarly for
+`AB5`.
 
 ## Projects
+
 - Add additional axioms, especially define Grothendieck categories.
 
 ## References

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms.lean
@@ -37,6 +37,9 @@ We do not require `Abelian` in the definition of `AB4` and `AB5` because these c
 individual axioms. A non-abelian category with `AB5` is not an AB5 category in the sense of the
 literature.
 
+## Projects
+- Add additional axioms, especially define Grothendieck categories.
+
 ## References
 * [Stacks: Grothendieck's AB conditions](https://stacks.math.columbia.edu/tag/079A)
 


### PR DESCRIPTION
Remove the unnecessary `HasFiniteCoproducts` premise from `AB4.ofAB5` and clarify in the module docstring that the typeclasses `AB4` and `AB5` don't require `Abelian`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
