### PR TITLE
[Merged by Bors] - chore: dualize Limits.Preserves.Opposites

### DIFF
--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -1131,7 +1131,7 @@ def IsLimit.unop {t : Cone F.op} (P : IsLimit t) : IsColimit t.unop where
       rw [← w]
       rfl
 
-/-- If `t : Cocone F.op` is a colimit cocone, then `t.unop : Cone F.` is a limit cone.
+/-- If `t : Cocone F.op` is a colimit cocone, then `t.unop : Cone F` is a limit cone.
 -/
 def IsColimit.unop {t : Cocone F.op} (P : IsColimit t) : IsLimit t.unop where
   lift s := (P.desc s.op).unop
@@ -1146,17 +1146,31 @@ def IsColimit.unop {t : Cocone F.op} (P : IsColimit t) : IsLimit t.unop where
       rw [← w]
       rfl
 
+/-- If `t.op : Cocone F.op` is a colimit cocone, then `t : Cone F` is a limit cone. -/
+def isLimitOfOp {t : Cone F} (P : IsColimit t.op) : IsLimit t :=
+  P.unop
+
+/-- If `t.op : Cone F.op` is a limit cone, then `t : Cocone F` is a colimit cocone. -/
+def isColimitOfOp {t : Cocone F} (P : IsLimit t.op) : IsColimit t :=
+  P.unop
+
+/-- If `t.unop : Cocone F` is a colimit cocone, then `t : Cone F.op` is a limit cone.-/
+def isLimitOfUnop {t : Cone F.op} (P : IsColimit t.unop) : IsLimit t :=
+  P.op
+
+/-- If `t.unop : Cone F` is a limit cone, then `t : Cocone F.op` is a colimit cocone. -/
+def isColimitOfUnop {t : Cocone F.op} (P : IsLimit t.unop) : IsColimit t :=
+  P.op
+
 /-- `t : Cone F` is a limit cone if and only if `t.op : Cocone F.op` is a colimit cocone.
 -/
 def isLimitEquivIsColimitOp {t : Cone F} : IsLimit t ≃ IsColimit t.op :=
-  equivOfSubsingletonOfSubsingleton IsLimit.op fun P =>
-    P.unop.ofIsoLimit (Cones.ext (Iso.refl _))
+  equivOfSubsingletonOfSubsingleton IsLimit.op isLimitOfOp
 
 /-- `t : Cocone F` is a colimit cocone if and only if `t.op : Cone F.op` is a limit cone.
 -/
 def isColimitEquivIsLimitOp {t : Cocone F} : IsColimit t ≃ IsLimit t.op :=
-  equivOfSubsingletonOfSubsingleton IsColimit.op fun P =>
-    P.unop.ofIsoColimit (Cocones.ext (Iso.refl _))
+  equivOfSubsingletonOfSubsingleton IsColimit.op isColimitOfOp
 
 end Opposite
 

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -139,7 +139,7 @@ def isLimitConeOfCoconeRightOp (F : Jᵒᵖ ⥤ C) {c : Cocone F.rightOp} (hc : 
     refine Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj ?_)
     simpa only [Quiver.Hom.op_unop, IsColimit.fac] using w (op j)
 
-/-- Turn a limit for `F.rightOp : J ⥤ Cᵒᵖ` into a limit for `F : Jᵒᵖ ⥤ C`. -/
+/-- Turn a limit for `F.rightOp : J ⥤ Cᵒᵖ` into a colimit for `F : Jᵒᵖ ⥤ C`. -/
 @[simps]
 def isColimitCoconeOfConeRightOp (F : Jᵒᵖ ⥤ C) {c : Cone F.rightOp} (hc : IsLimit c) :
     IsColimit (coconeOfConeRightOp c) where
@@ -168,6 +168,78 @@ def isColimitCoconeOfConeUnop (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cone F.unop} (hc : 
   uniq s m w := by
     refine Quiver.Hom.unop_inj (hc.hom_ext fun j => Quiver.Hom.op_inj ?_)
     simpa only [Quiver.Hom.unop_op, IsLimit.fac] using w (op j)
+
+/-- Turn a limit for `F.leftOp : Jᵒᵖ ⥤ C` into a colimit for `F : J ⥤ Cᵒᵖ`. -/
+@[simps!]
+def isColimitOfConeLeftOpOfCocone (F : J ⥤ Cᵒᵖ) {c : Cocone F}
+    (hc : IsLimit (coneLeftOpOfCocone c)) : IsColimit c :=
+  isColimitCoconeOfConeLeftOp F hc
+
+/-- Turn a colimit for `F.leftOp : Jᵒᵖ ⥤ C` into a limit for `F : J ⥤ Cᵒᵖ`. -/
+@[simps!]
+def isLimitOfCoconeLeftOpOfCone (F : J ⥤ Cᵒᵖ) {c : Cone F}
+    (hc : IsColimit (coconeLeftOpOfCone c)) : IsLimit c :=
+  isLimitConeOfCoconeLeftOp F hc
+
+/-- Turn a limit for `F.rightOp : J ⥤ Cᵒᵖ` into a colimit for `F : Jᵒᵖ ⥤ C`. -/
+@[simps!]
+def isColimitOfConeRightOpOfCocone (F : Jᵒᵖ ⥤ C) {c : Cocone F}
+    (hc : IsLimit (coneRightOpOfCocone c)) : IsColimit c :=
+  isColimitCoconeOfConeRightOp F hc
+
+/-- Turn a colimit for `F.rightOp : J ⥤ Cᵒᵖ` into a limit for `F : Jᵒᵖ ⥤ C`. -/
+@[simps!]
+def isLimitOfCoconeRightOpOfCone (F : Jᵒᵖ ⥤ C) {c : Cone F}
+    (hc : IsColimit (coconeRightOpOfCone c)) : IsLimit c :=
+  isLimitConeOfCoconeRightOp F hc
+
+/-- Turn a limit for `F.unop : J ⥤ C` into a colimit for `F : Jᵒᵖ ⥤ Cᵒᵖ`. -/
+@[simps!]
+def isColimitOfConeUnopOfCocone (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cocone F}
+    (hc : IsLimit (coneUnopOfCocone c)) : IsColimit c :=
+  isColimitCoconeOfConeUnop F hc
+
+/-- Turn a colimit for `F.unop : J ⥤ C` into a limit for `F : Jᵒᵖ ⥤ Cᵒᵖ`. -/
+@[simps!]
+def isLimitOfCoconeUnopOfCone (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cone F}
+    (hc : IsColimit (coconeUnopOfCone c)) : IsLimit c :=
+  isLimitConeOfCoconeUnop F hc
+
+/-- Turn a limit for `F : J ⥤ Cᵒᵖ` into a colimit for `F.leftOp : Jᵒᵖ ⥤ C`. -/
+@[simps!]
+def isColimitOfConeOfCoconeLeftOp (F : J ⥤ Cᵒᵖ) {c : Cocone F.leftOp}
+    (hc : IsLimit (coneOfCoconeLeftOp c)) : IsColimit c :=
+  isColimitCoconeLeftOpOfCone F hc
+
+/-- Turn a colimit for `F : J ⥤ Cᵒᵖ` into a limit for `F.leftOp : Jᵒᵖ ⥤ C`. -/
+@[simps!]
+def isLimitOfCoconeOfConeLeftOp (F : J ⥤ Cᵒᵖ) {c : Cone F.leftOp}
+    (hc : IsColimit (coconeOfConeLeftOp c)) : IsLimit c :=
+  isLimitConeLeftOpOfCocone F hc
+
+/-- Turn a limit for `F : Jᵒᵖ ⥤ C` into a colimit for `F.rightOp : J ⥤ Cᵒᵖ.` -/
+@[simps!]
+def isColimitOfConeOfCoconeRightOp (F : Jᵒᵖ ⥤ C) {c : Cocone F.rightOp}
+    (hc : IsLimit (coneOfCoconeRightOp c)) : IsColimit c :=
+  isColimitCoconeRightOpOfCone F hc
+
+/-- Turn a colimit for `F : Jᵒᵖ ⥤ C` into a limit for `F.rightOp : J ⥤ Cᵒᵖ`. -/
+@[simps!]
+def isLimitOfCoconeOfConeRightOp (F : Jᵒᵖ ⥤ C) {c : Cone F.rightOp}
+    (hc : IsColimit (coconeOfConeRightOp c)) : IsLimit c :=
+  isLimitConeRightOpOfCocone F hc
+
+/-- Turn a limit for `F : Jᵒᵖ ⥤ Cᵒᵖ` into a colimit for `F.unop : J ⥤ C`. -/
+@[simps!]
+def isColimitOfConeOfCoconeUnop (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cocone F.unop}
+    (hc : IsLimit (coneOfCoconeUnop c)) : IsColimit c :=
+  isColimitCoconeUnopOfCone F hc
+
+/-- Turn a colimit for `F : Jᵒᵖ ⥤ Cᵒᵖ` into a limit for `F.unop : J ⥤ C`. -/
+@[simps!]
+def isLimitOfCoconeOfConeUnop (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cone F.unop}
+    (hc : IsColimit (coconeOfConeUnop c)) : IsLimit c :=
+  isLimitConeUnopOfCocone F hc
 
 @[deprecated (since := "2024-11-01")] alias isColimitConeOfCoconeUnop := isColimitCoconeOfConeUnop
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Opposites.lean
@@ -10,12 +10,7 @@ import Mathlib.CategoryTheory.Limits.Preserves.Finite
 # Limit preservation properties of `Functor.op` and related constructions
 
 We formulate conditions about `F` which imply that `F.op`, `F.unop`, `F.leftOp` and `F.rightOp`
-preserve certain (co)limits.
-
-## Future work
-
-* Dually, it is possible to formulate conditions about `F.op` ec. for `F` to preserve certain
-(co)limits.
+preserve certain (co)limits and vice versa.
 
 -/
 
@@ -38,12 +33,24 @@ def preservesLimitOp (K : J ⥤ Cᵒᵖ) (F : C ⥤ D) [PreservesColimit K.leftO
   preserves {_} hc :=
     isLimitConeRightOpOfCocone _ (isColimitOfPreserves F (isColimitCoconeLeftOpOfCone _ hc))
 
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves colimits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F : C ⥤ D` preserves
+    limits of `K : J ⥤ C`. -/
+def preservesLimitOfOp (K : J ⥤ C) (F : C ⥤ D) [PreservesColimit K.op F.op] :
+    PreservesLimit K F where
+  preserves {_} hc := isLimitOfOp (isColimitOfPreserves F.op (IsLimit.op hc))
+
 /-- If `F : C ⥤ Dᵒᵖ` preserves colimits of `K.leftOp : Jᵒᵖ ⥤ C`, then `F.leftOp : Cᵒᵖ ⥤ D`
     preserves limits of `K : J ⥤ Cᵒᵖ`. -/
 def preservesLimitLeftOp (K : J ⥤ Cᵒᵖ) (F : C ⥤ Dᵒᵖ) [PreservesColimit K.leftOp F] :
     PreservesLimit K F.leftOp where
   preserves {_} hc :=
     isLimitConeUnopOfCocone _ (isColimitOfPreserves F (isColimitCoconeLeftOpOfCone _ hc))
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` preserves colimits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F : C ⥤ Dᵒᵖ` preserves
+    limits of `K : J ⥤ C`. -/
+def preservesLimitOfLeftOp (K : J ⥤ C) (F : C ⥤ Dᵒᵖ) [PreservesColimit K.op F.leftOp] :
+    PreservesLimit K F where
+  preserves {_} hc := isLimitOfCoconeLeftOpOfCone _ (isColimitOfPreserves F.leftOp (IsLimit.op hc))
 
 /-- If `F : Cᵒᵖ ⥤ D` preserves colimits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F.rightOp : C ⥤ Dᵒᵖ` preserves
     limits of `K : J ⥤ C`. -/
@@ -52,12 +59,26 @@ def preservesLimitRightOp (K : J ⥤ C) (F : Cᵒᵖ ⥤ D) [PreservesColimit K.
   preserves {_} hc :=
     isLimitConeRightOpOfCocone _ (isColimitOfPreserves F hc.op)
 
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` preserves colimits of `K.leftOp : Jᵒᵖ ⥤ Cᵒᵖ`, then `F : Cᵒᵖ ⥤ D`
+    preserves limits of `K : J ⥤ Cᵒᵖ`. -/
+def preservesLimitOfRightOp (K : J ⥤ Cᵒᵖ) (F : Cᵒᵖ ⥤ D) [PreservesColimit K.leftOp F.rightOp] :
+    PreservesLimit K F where
+  preserves {_} hc :=
+    isLimitOfOp (isColimitOfPreserves F.rightOp (isColimitCoconeLeftOpOfCone _ hc))
+
 /-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves colimits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F.unop : C ⥤ D` preserves
     limits of `K : J ⥤ C`. -/
 def preservesLimitUnop (K : J ⥤ C) (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesColimit K.op F] :
     PreservesLimit K F.unop where
   preserves {_} hc :=
     isLimitConeUnopOfCocone _ (isColimitOfPreserves F hc.op)
+
+/-- If `F.unop : C ⥤ D` preserves colimits of `K.leftOp : Jᵒᵖ ⥤ C`, then `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves
+    limits of `K : J ⥤ Cᵒᵖ`. -/
+def preservesLimitOfUnop (K : J ⥤ Cᵒᵖ) (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesColimit K.leftOp F.unop] :
+    PreservesLimit K F where
+  preserves {_} hc :=
+    isLimitOfCoconeLeftOpOfCone _ (isColimitOfPreserves F.unop (isColimitCoconeLeftOpOfCone _ hc))
 
 /-- If `F : C ⥤ D` preserves limits of `K.leftOp : Jᵒᵖ ⥤ C`, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves
     colimits of `K : J ⥤ Cᵒᵖ`. -/
@@ -66,12 +87,25 @@ def preservesColimitOp (K : J ⥤ Cᵒᵖ) (F : C ⥤ D) [PreservesLimit K.leftO
   preserves {_} hc :=
     isColimitCoconeRightOpOfCone _ (isLimitOfPreserves F (isLimitConeLeftOpOfCocone _ hc))
 
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves limits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F : C ⥤ D` preserves
+    colimits of `K : J ⥤ C`. -/
+def preservesColimitOfOp (K : J ⥤ C) (F : C ⥤ D) [PreservesLimit K.op F.op] :
+    PreservesColimit K F where
+  preserves {_} hc := isColimitOfOp (isLimitOfPreserves F.op (IsColimit.op hc))
+
 /-- If `F : C ⥤ Dᵒᵖ` preserves limits of `K.leftOp : Jᵒᵖ ⥤ C`, then `F.leftOp : Cᵒᵖ ⥤ D` preserves
     colimits of `K : J ⥤ Cᵒᵖ`. -/
 def preservesColimitLeftOp (K : J ⥤ Cᵒᵖ) (F : C ⥤ Dᵒᵖ) [PreservesLimit K.leftOp F] :
     PreservesColimit K F.leftOp where
   preserves {_} hc :=
     isColimitCoconeUnopOfCone _ (isLimitOfPreserves F (isLimitConeLeftOpOfCocone _ hc))
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` preserves limits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F : C ⥤ Dᵒᵖ` preserves
+    colimits of `K : J ⥤ C`. -/
+def preservesColimitOfLeftOp (K : J ⥤ C) (F : C ⥤ Dᵒᵖ) [PreservesLimit K.op F.leftOp] :
+    PreservesColimit K F where
+  preserves {_} hc :=
+    isColimitOfConeLeftOpOfCocone _ (isLimitOfPreserves F.leftOp (IsColimit.op hc))
 
 /-- If `F : Cᵒᵖ ⥤ D` preserves limits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F.rightOp : C ⥤ Dᵒᵖ` preserves
     colimits of `K : J ⥤ C`. -/
@@ -80,12 +114,26 @@ def preservesColimitRightOp (K : J ⥤ C) (F : Cᵒᵖ ⥤ D) [PreservesLimit K.
   preserves {_} hc :=
     isColimitCoconeRightOpOfCone _ (isLimitOfPreserves F hc.op)
 
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` preserves limits of `K.leftOp : Jᵒᵖ ⥤ C`, then `F : Cᵒᵖ ⥤ D`
+    preserves colimits of `K : J ⥤ Cᵒᵖ`. -/
+def preservesColimitOfRightOp (K : J ⥤ Cᵒᵖ) (F : Cᵒᵖ ⥤ D) [PreservesLimit K.leftOp F.rightOp] :
+    PreservesColimit K F where
+  preserves {_} hc :=
+    isColimitOfOp (isLimitOfPreserves F.rightOp (isLimitConeLeftOpOfCocone _ hc))
+
 /-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves limits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F.unop : C ⥤ D` preserves
     colimits of `K : J ⥤ C`. -/
 def preservesColimitUnop (K : J ⥤ C) (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesLimit K.op F] :
     PreservesColimit K F.unop where
   preserves {_} hc :=
     isColimitCoconeUnopOfCone _ (isLimitOfPreserves F hc.op)
+
+/-- If `F.unop : C ⥤ D` preserves limits of `K.op : Jᵒᵖ ⥤ C`, then `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves
+    colimits of `K : J ⥤ Cᵒᵖ`. -/
+def preservesColimitOfUnop (K : J ⥤ Cᵒᵖ) (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesLimit K.leftOp F.unop] :
+    PreservesColimit K F where
+  preserves {_} hc :=
+    isColimitOfConeLeftOpOfCocone _ (isLimitOfPreserves F.unop (isLimitConeLeftOpOfCocone _ hc))
 
 section
 
@@ -131,7 +179,127 @@ def preservesColimitsOfShapeRightOp (F : Cᵒᵖ ⥤ D) [PreservesLimitsOfShape 
 def preservesColimitsOfShapeUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesLimitsOfShape Jᵒᵖ F] :
     PreservesColimitsOfShape J F.unop where preservesColimit {K} := preservesColimitUnop K F
 
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves colimits of shape `Jᵒᵖ`, then `F : C ⥤ D` preserves limits
+    of shape `J`. -/
+def preservesLimitsOfShapeOfOp (F : C ⥤ D) [PreservesColimitsOfShape Jᵒᵖ F.op] :
+    PreservesLimitsOfShape J F where preservesLimit {K} := preservesLimitOfOp K F
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` preserves colimits of shape `Jᵒᵖ`, then `F : C ⥤ Dᵒᵖ` preserves limits
+    of shape `J`. -/
+def preservesLimitsOfShapeOfLeftOp (F : C ⥤ Dᵒᵖ) [PreservesColimitsOfShape Jᵒᵖ F.leftOp] :
+    PreservesLimitsOfShape J F where preservesLimit {K} := preservesLimitOfLeftOp K F
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` preserves colimits of shape `Jᵒᵖ`, then `F : Cᵒᵖ ⥤ D` preserves limits
+    of shape `J`. -/
+def preservesLimitsOfShapeOfRightOp (F : Cᵒᵖ ⥤ D) [PreservesColimitsOfShape Jᵒᵖ F.rightOp] :
+    PreservesLimitsOfShape J F where preservesLimit {K} := preservesLimitOfRightOp K F
+
+/-- If `F.unop : C ⥤ D` preserves colimits of shape `Jᵒᵖ`, then `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves limits
+    of shape `J`. -/
+def preservesLimitsOfShapeOfUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesColimitsOfShape Jᵒᵖ F.unop] :
+    PreservesLimitsOfShape J F where preservesLimit {K} := preservesLimitOfUnop K F
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves limits of shape `Jᵒᵖ`, then `F : C ⥤ D` preserves colimits
+    of shape `J`. -/
+def preservesColimitsOfShapeOfOp (F : C ⥤ D) [PreservesLimitsOfShape Jᵒᵖ F.op] :
+    PreservesColimitsOfShape J F where preservesColimit {K} := preservesColimitOfOp K F
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` preserves limits of shape `Jᵒᵖ`, then `F : C ⥤ Dᵒᵖ` preserves colimits
+    of shape `J`. -/
+def preservesColimitsOfShapeOfLeftOp (F : C ⥤ Dᵒᵖ) [PreservesLimitsOfShape Jᵒᵖ F.leftOp] :
+    PreservesColimitsOfShape J F where preservesColimit {K} := preservesColimitOfLeftOp K F
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` preserves limits of shape `Jᵒᵖ`, then `F : Cᵒᵖ ⥤ D` preserves colimits
+    of shape `J`. -/
+def preservesColimitsOfShapeOfRightOp (F : Cᵒᵖ ⥤ D) [PreservesLimitsOfShape Jᵒᵖ F.rightOp] :
+    PreservesColimitsOfShape J F where preservesColimit {K} := preservesColimitOfRightOp K F
+
+/-- If `F.unop : C ⥤ D` preserves limits of shape `Jᵒᵖ`, then `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves colimits
+    of shape `J`. -/
+def preservesColimitsOfShapeOfUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesLimitsOfShape Jᵒᵖ F.unop] :
+    PreservesColimitsOfShape J F where preservesColimit {K} := preservesColimitOfUnop K F
+
 end
+
+/-- If `F : C ⥤ D` preserves colimits, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves limits. -/
+def preservesLimitsOfSizeOp (F : C ⥤ D) [PreservesColimitsOfSize.{w, w'} F] :
+    PreservesLimitsOfSize.{w, w'} F.op where
+  preservesLimitsOfShape {_} _ := preservesLimitsOfShapeOp _ _
+
+/-- If `F : C ⥤ Dᵒᵖ` preserves colimits, then `F.leftOp : Cᵒᵖ ⥤ D` preserves limits. -/
+def preservesLimitsOfSizeLeftOp (F : C ⥤ Dᵒᵖ) [PreservesColimitsOfSize.{w, w'} F] :
+    PreservesLimitsOfSize.{w, w'} F.leftOp where
+  preservesLimitsOfShape {_} _ := preservesLimitsOfShapeLeftOp _ _
+
+/-- If `F : Cᵒᵖ ⥤ D` preserves colimits, then `F.rightOp : C ⥤ Dᵒᵖ` preserves limits. -/
+def preservesLimitsOfSizeRightOp (F : Cᵒᵖ ⥤ D) [PreservesColimitsOfSize.{w, w'} F] :
+    PreservesLimitsOfSize.{w, w'} F.rightOp where
+  preservesLimitsOfShape {_} _ := preservesLimitsOfShapeRightOp _ _
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves colimits, then `F.unop : C ⥤ D` preserves limits. -/
+def preservesLimitsOfSizeUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesColimitsOfSize.{w, w'} F] :
+    PreservesLimitsOfSize.{w, w'} F.unop where
+  preservesLimitsOfShape {_} _ := preservesLimitsOfShapeUnop _ _
+
+/-- If `F : C ⥤ D` preserves limits, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves colimits. -/
+def preservesColimitsOfSizeOp (F : C ⥤ D) [PreservesLimitsOfSize.{w, w'} F] :
+    PreservesColimitsOfSize.{w, w'} F.op where
+  preservesColimitsOfShape {_} _ := preservesColimitsOfShapeOp _ _
+
+/-- If `F : C ⥤ Dᵒᵖ` preserves limits, then `F.leftOp : Cᵒᵖ ⥤ D` preserves colimits. -/
+def preservesColimitsOfSizeLeftOp (F : C ⥤ Dᵒᵖ) [PreservesLimitsOfSize.{w, w'} F] :
+    PreservesColimitsOfSize.{w, w'} F.leftOp where
+  preservesColimitsOfShape {_} _ := preservesColimitsOfShapeLeftOp _ _
+
+/-- If `F : Cᵒᵖ ⥤ D` preserves limits, then `F.rightOp : C ⥤ Dᵒᵖ` preserves colimits. -/
+def preservesColimitsOfSizeRightOp (F : Cᵒᵖ ⥤ D) [PreservesLimitsOfSize.{w, w'} F] :
+    PreservesColimitsOfSize.{w, w'} F.rightOp where
+  preservesColimitsOfShape {_} _ := preservesColimitsOfShapeRightOp _ _
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves limits, then `F.unop : C ⥤ D` preserves colimits. -/
+def preservesColimitsOfSizeUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesLimitsOfSize.{w, w'} F] :
+    PreservesColimitsOfSize.{w, w'} F.unop where
+  preservesColimitsOfShape {_} _ := preservesColimitsOfShapeUnop _ _
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves colimits, then `F : C ⥤ D` preserves limits. -/
+def preservesLimitsOfSizeOfOp (F : C ⥤ D) [PreservesColimitsOfSize.{w, w'} F.op] :
+    PreservesLimitsOfSize.{w, w'} F where
+  preservesLimitsOfShape {_} _ := preservesLimitsOfShapeOfOp _ _
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` preserves colimits, then `F : C ⥤ Dᵒᵖ` preserves limits. -/
+def preservesLimitsOfSizeOfLeftOp (F : C ⥤ Dᵒᵖ) [PreservesColimitsOfSize.{w, w'} F.leftOp] :
+    PreservesLimitsOfSize.{w, w'} F where
+  preservesLimitsOfShape {_} _ := preservesLimitsOfShapeOfLeftOp _ _
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` preserves colimits, then `F : Cᵒᵖ ⥤ D` preserves limits. -/
+def preservesLimitsOfSizeOfRightOp (F : Cᵒᵖ ⥤ D) [PreservesColimitsOfSize.{w, w'} F.rightOp] :
+    PreservesLimitsOfSize.{w, w'} F where
+  preservesLimitsOfShape {_} _ := preservesLimitsOfShapeOfRightOp _ _
+
+/-- If `F.unop : C ⥤ D` preserves colimits, then `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves limits. -/
+def preservesLimitsOfSizeOfUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesColimitsOfSize.{w, w'} F.unop] :
+    PreservesLimitsOfSize.{w, w'} F where
+  preservesLimitsOfShape {_} _ := preservesLimitsOfShapeOfUnop _ _
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves limits, then `F : C ⥤ D` preserves colimits. -/
+def preservesColimitsOfSizeOfOp (F : C ⥤ D) [PreservesLimitsOfSize.{w, w'} F.op] :
+    PreservesColimitsOfSize.{w, w'} F where
+  preservesColimitsOfShape {_} _ := preservesColimitsOfShapeOfOp _ _
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` preserves limits, then `F : C ⥤ Dᵒᵖ` preserves colimits. -/
+def preservesColimitsOfSizeOfLeftOp (F : C ⥤ Dᵒᵖ) [PreservesLimitsOfSize.{w, w'} F.leftOp] :
+    PreservesColimitsOfSize.{w, w'} F where
+  preservesColimitsOfShape {_} _ := preservesColimitsOfShapeOfLeftOp _ _
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` preserves limits, then `F : Cᵒᵖ ⥤ D` preserves colimits. -/
+def preservesColimitsOfSizeOfRightOp (F : Cᵒᵖ ⥤ D) [PreservesLimitsOfSize.{w, w'} F.rightOp] :
+    PreservesColimitsOfSize.{w, w'} F where
+  preservesColimitsOfShape {_} _ := preservesColimitsOfShapeOfRightOp _ _
+
+/-- If `F.unop : C ⥤ D` preserves limits, then `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves colimits. -/
+def preservesColimitsOfSizeOfUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesLimitsOfSize.{w, w'} F.unop] :
+    PreservesColimitsOfSize.{w, w'} F where
+  preservesColimitsOfShape {_} _ := preservesColimitsOfShapeOfUnop _ _
 
 /-- If `F : C ⥤ D` preserves colimits, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves limits. -/
 def preservesLimitsOp (F : C ⥤ D) [PreservesColimits F] : PreservesLimits F.op where
@@ -165,53 +333,130 @@ def preservesColimitsRightOp (F : Cᵒᵖ ⥤ D) [PreservesLimits F] : Preserves
 def preservesColimitsUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesLimits F] : PreservesColimits F.unop where
   preservesColimitsOfShape {_} _ := preservesColimitsOfShapeUnop _ _
 
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves colimits, then `F : C ⥤ D` preserves limits. -/
+def preservesLimitsOfOp (F : C ⥤ D) [PreservesColimits F.op] : PreservesLimits F where
+  preservesLimitsOfShape {_} _ := preservesLimitsOfShapeOfOp _ _
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` preserves colimits, then `F : C ⥤ Dᵒᵖ` preserves limits. -/
+def preservesLimitsOfLeftOp (F : C ⥤ Dᵒᵖ) [PreservesColimits F.leftOp] : PreservesLimits F where
+  preservesLimitsOfShape {_} _ := preservesLimitsOfShapeOfLeftOp _ _
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` preserves colimits, then `F : Cᵒᵖ ⥤ D` preserves limits. -/
+def preservesLimitsOfRightOp (F : Cᵒᵖ ⥤ D) [PreservesColimits F.rightOp] : PreservesLimits F where
+  preservesLimitsOfShape {_} _ := preservesLimitsOfShapeOfRightOp _ _
+
+/-- If `F.unop : C ⥤ D` preserves colimits, then `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves limits. -/
+def preservesLimitsOfUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesColimits F.unop] : PreservesLimits F where
+  preservesLimitsOfShape {_} _ := preservesLimitsOfShapeOfUnop _ _
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves limits, then `F : C ⥤ D` preserves colimits. -/
+def preservesColimitsOfOp (F : C ⥤ D) [PreservesLimits F.op] : PreservesColimits F where
+  preservesColimitsOfShape {_} _ := preservesColimitsOfShapeOfOp _ _
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` preserves limits, then `F : C ⥤ Dᵒᵖ` preserves colimits. -/
+def preservesColimitsOfLeftOp (F : C ⥤ Dᵒᵖ) [PreservesLimits F.leftOp] : PreservesColimits F where
+  preservesColimitsOfShape {_} _ := preservesColimitsOfShapeOfLeftOp _ _
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` preserves limits, then `F : Cᵒᵖ ⥤ D` preserves colimits. -/
+def preservesColimitsOfRightOp (F : Cᵒᵖ ⥤ D) [PreservesLimits F.rightOp] : PreservesColimits F where
+  preservesColimitsOfShape {_} _ := preservesColimitsOfShapeOfRightOp _ _
+
+/-- If `F.unop : C ⥤ D` preserves limits, then `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves colimits. -/
+def preservesColimitsOfUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesLimits F.unop] : PreservesColimits F where
+  preservesColimitsOfShape {_} _ := preservesColimitsOfShapeOfUnop _ _
+
 /-- If `F : C ⥤ D` preserves finite colimits, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite
     limits. -/
 def preservesFiniteLimitsOp (F : C ⥤ D) [PreservesFiniteColimits F] :
     PreservesFiniteLimits F.op where
-  preservesFiniteLimits J (_ : SmallCategory J) _ := preservesLimitsOfShapeOp J F
+  preservesFiniteLimits J _ _ := preservesLimitsOfShapeOp J F
 
 /-- If `F : C ⥤ Dᵒᵖ` preserves finite colimits, then `F.leftOp : Cᵒᵖ ⥤ D` preserves finite
     limits. -/
 def preservesFiniteLimitsLeftOp (F : C ⥤ Dᵒᵖ) [PreservesFiniteColimits F] :
     PreservesFiniteLimits F.leftOp where
-  preservesFiniteLimits J (_ : SmallCategory J) _ := preservesLimitsOfShapeLeftOp J F
+  preservesFiniteLimits J _ _ := preservesLimitsOfShapeLeftOp J F
 
 /-- If `F : Cᵒᵖ ⥤ D` preserves finite colimits, then `F.rightOp : C ⥤ Dᵒᵖ` preserves finite
     limits. -/
 def preservesFiniteLimitsRightOp (F : Cᵒᵖ ⥤ D) [PreservesFiniteColimits F] :
     PreservesFiniteLimits F.rightOp where
-  preservesFiniteLimits J (_ : SmallCategory J) _ := preservesLimitsOfShapeRightOp J F
+  preservesFiniteLimits J _ _ := preservesLimitsOfShapeRightOp J F
 
 /-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite colimits, then `F.unop : C ⥤ D` preserves finite
     limits. -/
 def preservesFiniteLimitsUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesFiniteColimits F] :
     PreservesFiniteLimits F.unop where
-  preservesFiniteLimits J (_ : SmallCategory J) _ := preservesLimitsOfShapeUnop J F
+  preservesFiniteLimits J _ _ := preservesLimitsOfShapeUnop J F
 
 /-- If `F : C ⥤ D` preserves finite limits, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite
     colimits. -/
 def preservesFiniteColimitsOp (F : C ⥤ D) [PreservesFiniteLimits F] :
     PreservesFiniteColimits F.op where
-  preservesFiniteColimits J (_ : SmallCategory J) _ := preservesColimitsOfShapeOp J F
+  preservesFiniteColimits J _ _ := preservesColimitsOfShapeOp J F
 
 /-- If `F : C ⥤ Dᵒᵖ` preserves finite limits, then `F.leftOp : Cᵒᵖ ⥤ D` preserves finite
     colimits. -/
 def preservesFiniteColimitsLeftOp (F : C ⥤ Dᵒᵖ) [PreservesFiniteLimits F] :
     PreservesFiniteColimits F.leftOp where
-  preservesFiniteColimits J (_ : SmallCategory J) _ := preservesColimitsOfShapeLeftOp J F
+  preservesFiniteColimits J _ _ := preservesColimitsOfShapeLeftOp J F
 
 /-- If `F : Cᵒᵖ ⥤ D` preserves finite limits, then `F.rightOp : C ⥤ Dᵒᵖ` preserves finite
     colimits. -/
 def preservesFiniteColimitsRightOp (F : Cᵒᵖ ⥤ D) [PreservesFiniteLimits F] :
     PreservesFiniteColimits F.rightOp where
-  preservesFiniteColimits J (_ : SmallCategory J) _ := preservesColimitsOfShapeRightOp J F
+  preservesFiniteColimits J _ _ := preservesColimitsOfShapeRightOp J F
 
 /-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite limits, then `F.unop : C ⥤ D` preserves finite
     colimits. -/
 def preservesFiniteColimitsUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesFiniteLimits F] :
     PreservesFiniteColimits F.unop where
-  preservesFiniteColimits J (_ : SmallCategory J) _ := preservesColimitsOfShapeUnop J F
+  preservesFiniteColimits J _ _ := preservesColimitsOfShapeUnop J F
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite colimits, then `F : C ⥤ D` preserves finite limits. -/
+def preservesFiniteLimitsOfOp (F : C ⥤ D) [PreservesFiniteColimits F.op] :
+    PreservesFiniteLimits F where
+  preservesFiniteLimits J _ _ := preservesLimitsOfShapeOfOp J F
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` preserves finite colimits, then `F : C ⥤ Dᵒᵖ` preserves finite
+    limits. -/
+def preservesFiniteLimitsOfLeftOp (F : C ⥤ Dᵒᵖ) [PreservesFiniteColimits F.leftOp] :
+    PreservesFiniteLimits F where
+  preservesFiniteLimits J _ _ := preservesLimitsOfShapeOfLeftOp J F
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` preserves finite colimits, then `F : Cᵒᵖ ⥤ D` preserves finite
+    limits. -/
+def preservesFiniteLimitsOfRightOp (F : Cᵒᵖ ⥤ D) [PreservesFiniteColimits F.rightOp] :
+    PreservesFiniteLimits F where
+  preservesFiniteLimits J _ _ := preservesLimitsOfShapeOfRightOp J F
+
+/-- If `F.unop : C ⥤ D` preserves finite colimits, then `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite limits. -/
+def preservesFiniteLimitsOfUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesFiniteColimits F.unop] :
+    PreservesFiniteLimits F where
+  preservesFiniteLimits J _ _ := preservesLimitsOfShapeOfUnop J F
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite limits, then `F : C ⥤ D` preserves finite colimits. -/
+def preservesFiniteColimitsOfOp (F : C ⥤ D) [PreservesFiniteLimits F.op] :
+    PreservesFiniteColimits F where
+  preservesFiniteColimits J _ _ := preservesColimitsOfShapeOfOp J F
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` preserves finite limits, then `F : C ⥤ Dᵒᵖ` preserves finite
+    colimits. -/
+def preservesFiniteColimitsOfLeftOp (F : C ⥤ Dᵒᵖ) [PreservesFiniteLimits F.leftOp] :
+    PreservesFiniteColimits F where
+  preservesFiniteColimits J _ _ := preservesColimitsOfShapeOfLeftOp J F
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` preserves finite limits, then `F : Cᵒᵖ ⥤ D` preserves finite
+    colimits. -/
+def preservesFiniteColimitsOfRightOp (F : Cᵒᵖ ⥤ D) [PreservesFiniteLimits F.rightOp] :
+    PreservesFiniteColimits F where
+  preservesFiniteColimits J _ _ := preservesColimitsOfShapeOfRightOp J F
+
+/-- If `F.unop : C ⥤ D` preserves finite limits, then `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite colimits. -/
+def preservesFiniteColimitsOfUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesFiniteLimits F.unop] :
+    PreservesFiniteColimits F where
+  preservesFiniteColimits J _ _ := preservesColimitsOfShapeOfUnop J F
+
 
 /-- If `F : C ⥤ D` preserves finite coproducts, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite
     products. -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
