### PR TITLE
[Merged by Bors] - feat: vertical line test for functions, group homs, linear maps

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -271,6 +271,7 @@ import Mathlib.Algebra.Group.Fin.Basic
 import Mathlib.Algebra.Group.Fin.Tuple
 import Mathlib.Algebra.Group.FiniteSupport
 import Mathlib.Algebra.Group.ForwardDiff
+import Mathlib.Algebra.Group.Graph
 import Mathlib.Algebra.Group.Hom.Basic
 import Mathlib.Algebra.Group.Hom.CompTypeclasses
 import Mathlib.Algebra.Group.Hom.Defs

--- a/Mathlib/Algebra/Group/Graph.lean
+++ b/Mathlib/Algebra/Group/Graph.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Prod
+import Mathlib.Data.Set.Function
+
+/-!
+# Vertical line test for group homs
+
+This file proves the vertical line test for monoid homomorphisms/isomorphisms.
+
+Let `f : G → H × I` be a homomorphism to a product of monoids. Assume that `f` is surjective on the
+first factor and that the image of `f` intersects every "vertical line" `{(h, i) | i : I}` at most
+once. Then the image of `f` is the graph of some monoid homomorphism `f' : H → I`.
+
+Furthermore, if `f` is also surjective on the second factor and its image intersects every
+"horizontal line" `{(h, i) | h : H}` at most once, then `f'` is actually an isomorphism
+`f' : H ≃ I`.
+-/
+
+open Function Set
+
+variable {G H I : Type*} [Monoid G] [Monoid H] [Monoid I]
+
+/-- **Vertical line test** for monoid homomorphisms.
+
+Let `f : G → H × I` be a homomorphism to a product of monoids. Assume that `f` is surjective on the
+first factor and that the image of `f` intersects every "vertical line" `{(h, i) | i : I}` at most
+once. Then the image of `f` is the graph of some monoid homomorphism `f' : H → I`. -/
+@[to_additive "**Vertical line test** for monoid homomorphisms.
+
+Let `f : G → H × I` be a homomorphism to a product of monoids. Assume that `f` is surjective on the
+first factor and that the image of `f` intersects every \"vertical line\" `{(h, i) | i : I}` at most
+once. Then the image of `f` is the graph of some monoid homomorphism `f' : H → I`."]
+lemma MonoidHom.exists_range_eq_graph (f : G →* H × I) (hf₁ : Surjective (Prod.fst ∘ f))
+    (hf : ∀ g₁ g₂, (f g₁).1 = (f g₂).1 → (f g₁).2 = (f g₂).2) :
+    ∃ f' : H →* I, .range f = univ.graphOn f' := by
+  use
+  { toFun := fun h ↦ (f (hf₁ h).choose).snd
+    map_one' := by simpa using hf (hf₁ 1).choose 1 (by simpa using (hf₁ 1).choose_spec)
+    map_mul' := fun h₁ h₂ ↦ by
+      have := calc (f (hf₁ (h₁ * h₂)).choose).fst
+        _ = h₁ * h₂ := (hf₁ (h₁ * h₂)).choose_spec
+        _ = (f (hf₁ h₁).choose).fst * (f (hf₁ h₂).choose).fst := by
+          congr 1; exacts [(hf₁ h₁).choose_spec.symm, (hf₁ h₂).choose_spec.symm]
+        _ = (f ((hf₁ h₁).choose * (hf₁ h₂).choose)).fst := by simp
+      simpa using hf _ _ this }
+  ext x
+  simp only [Set.mem_range, Function.comp_apply, coe_mk, OneHom.coe_mk, mem_graphOn, mem_univ,
+    true_and]
+  refine ⟨?_, fun hi ↦ ⟨(hf₁ x.1).choose, Prod.ext (hf₁ x.1).choose_spec hi⟩⟩
+  rintro ⟨g, rfl⟩
+  exact hf _ _ (hf₁ (f g).1).choose_spec
+
+/-- **Vertical line test** for monoid isomorphisms.
+
+Let `f : G → H × I` be a homomorphism to a product of monoids. Assume that `f` is surjective on both
+factors and that the image of `f` intersects every "vertical line" `{(h, i) | i : I}` and every
+"horizontal line" `{(h, i) | h : H}` at most once. Then the image of `f` is the graph of some monoid
+isomorphism `f' : H ≃ I`. -/
+@[to_additive "**Vertical line test** for monoid isomorphisms.
+
+Let `f : G → H × I` be a homomorphism to a product of monoids. Assume that `f` is surjective on both
+factors and that the image of `f` intersects every \"vertical line\" `{(h, i) | i : I}` and every
+\"horizontal line\" `{(h, i) | h : H}` at most once. Then the image of `f` is the graph of some
+monoid isomorphism `f' : H ≃ I`."]
+lemma MonoidHom.exists_mulEquiv_range_eq_graph (f : G →* H × I) (hf₁ : Surjective (Prod.fst ∘ f))
+    (hf₂ : Surjective (Prod.snd ∘ f)) (hf : ∀ g₁ g₂, (f g₁).1 = (f g₂).1 ↔ (f g₁).2 = (f g₂).2) :
+    ∃ e : H ≃* I, .range f = univ.graphOn e := by
+  obtain ⟨e₁, he₁⟩ := f.exists_range_eq_graph hf₁ fun _ _ ↦ (hf _ _).1
+  obtain ⟨e₂, he₂⟩ := (MulEquiv.prodComm.toMonoidHom.comp f).exists_range_eq_graph (by simpa) <|
+    by simp [hf]
+  have he₁₂ h i : e₁ h = i ↔ e₂ i = h := by
+    rw [Set.ext_iff] at he₁ he₂
+    aesop (add simp [Prod.swap_eq_iff_eq_swap])
+  exact ⟨
+  { toFun := e₁
+    map_mul' := e₁.map_mul'
+    invFun := e₂
+    left_inv := fun h ↦ by rw [← he₁₂]
+    right_inv := fun i ↦ by rw [he₁₂] }, he₁⟩

--- a/Mathlib/Algebra/Group/Graph.lean
+++ b/Mathlib/Algebra/Group/Graph.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, David Loeffler
 -/
-import Mathlib.Algebra.Group.Subgroup.Basic
+import Mathlib.Algebra.Group.Subgroup.Ker
 
 /-!
 # Vertical line test for group homs

--- a/Mathlib/Algebra/Group/Graph.lean
+++ b/Mathlib/Algebra/Group/Graph.lean
@@ -34,11 +34,11 @@ namespace MonoidHom
 
 /-- The graph of a monoid homomorphism as a submonoid.
 
-See also `MonoidHom.range` for the graph as a subgroup. -/
+See also `MonoidHom.graph` for the graph as a subgroup. -/
 @[to_additive
 "The graph of a monoid homomorphism as a submonoid.
 
-See also `AddMonoidHom.range` for the graph as a subgroup."]
+See also `AddMonoidHom.graph` for the graph as a subgroup."]
 def mgraph (f : G →* H) : Submonoid (G × H) where
   carrier := {x | f x.1 = x.2}
   one_mem' := map_one f
@@ -153,11 +153,11 @@ namespace MonoidHom
 
 /-- The graph of a group homomorphism as a subgroup.
 
-See also `MonoidHom.mrange` for the graph as a submonoid. -/
+See also `MonoidHom.mgraph` for the graph as a submonoid. -/
 @[to_additive
 "The graph of a group homomorphism as a subgroup.
 
-See also `AddMonoidHom.mrange` for the graph as a submonoid."]
+See also `AddMonoidHom.mgraph` for the graph as a submonoid."]
 def graph (f : G →* H) : Subgroup (G × H) where
   toSubmonoid := f.mgraph
   inv_mem' {x} := by simp +contextual
@@ -168,7 +168,7 @@ attribute [simps! coe toAddSubmonoid] AddMonoidHom.graph
 set_option linter.existingAttributeWarning false in
 attribute [to_additive existing] coe_graph graph_toSubmonoid
 
-@[to_additive (attr := simp)]
+@[to_additive]
 lemma mem_graph {f : G →* H} {x : G × H} : x ∈ f.mgraph ↔ f x.1 = x.2 := .rfl
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/Graph.lean
+++ b/Mathlib/Algebra/Group/Graph.lean
@@ -1,10 +1,9 @@
 /-
 Copyright (c) 2024 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yaël Dillies
+Authors: Yaël Dillies, David Loeffler
 -/
-import Mathlib.Algebra.Group.Prod
-import Mathlib.Data.Set.Function
+import Mathlib.Algebra.Group.Subgroup.Basic
 
 /-!
 # Vertical line test for group homs
@@ -18,6 +17,10 @@ once. Then the image of `f` is the graph of some monoid homomorphism `f' : H →
 Furthermore, if `f` is also surjective on the second factor and its image intersects every
 "horizontal line" `{(h, i) | h : H}` at most once, then `f'` is actually an isomorphism
 `f' : H ≃ I`.
+
+We also prove specialised versions when `f` is the inclusion of a subgroup of the direct product.
+(The version for general homomorphisms can easily be reduced to this special case, but the
+homomorphism version is more flexible in applications.)
 -/
 
 open Function Set
@@ -34,7 +37,7 @@ once. Then the image of `f` is the graph of some monoid homomorphism `f' : H →
 Let `f : G → H × I` be a homomorphism to a product of monoids. Assume that `f` is surjective on the
 first factor and that the image of `f` intersects every \"vertical line\" `{(h, i) | i : I}` at most
 once. Then the image of `f` is the graph of some monoid homomorphism `f' : H → I`."]
-lemma MonoidHom.exists_range_eq_graph (f : G →* H × I) (hf₁ : Surjective (Prod.fst ∘ f))
+lemma MonoidHom.exists_range_eq_graph {f : G →* H × I} (hf₁ : Surjective (Prod.fst ∘ f))
     (hf : ∀ g₁ g₂, (f g₁).1 = (f g₂).1 → (f g₁).2 = (f g₂).2) :
     ∃ f' : H →* I, .range f = univ.graphOn f' := by
   use
@@ -54,19 +57,34 @@ lemma MonoidHom.exists_range_eq_graph (f : G →* H × I) (hf₁ : Surjective (P
   rintro ⟨g, rfl⟩
   exact hf _ _ (hf₁ (f g).1).choose_spec
 
-/-- **Vertical line test** for monoid isomorphisms.
+/-- **Vertical line test** for monoid homomorphisms.
+
+Let `G ≤ H × I` be a submonoid of a product of monoids. Assume that `G` maps bijectively to the
+first factor. Then `G` is the graph of some monoid homomorphism `f : H → I`. -/
+@[to_additive "**Vertical line test** for additive monoid homomorphisms.
+
+Let `G ≤ H × I` be a submonoid of a product of monoids. Assume that `G` surjects onto the first
+factor and `G` intersects every \"vertical line\" `{(h, i) | i : I}` at most once. Then `G` is the
+graph of some monoid homomorphism `f : H → I`."]
+lemma Submonoid.exists_eq_graph {G : Submonoid (H × I)} (hf₁ : Bijective (Prod.fst ∘ G.subtype)) :
+    ∃ f : H →* I, G = univ.graphOn f := by
+  simpa only [coe_subtype, Subtype.range_coe_subtype, SetLike.setOf_mem_eq]
+    using MonoidHom.exists_range_eq_graph hf₁.surjective
+      (fun a b h ↦ congr_arg (Prod.snd ∘ G.subtype) (hf₁.injective h))
+
+/-- **Line test** for monoid isomorphisms.
 
 Let `f : G → H × I` be a homomorphism to a product of monoids. Assume that `f` is surjective on both
 factors and that the image of `f` intersects every "vertical line" `{(h, i) | i : I}` and every
 "horizontal line" `{(h, i) | h : H}` at most once. Then the image of `f` is the graph of some monoid
 isomorphism `f' : H ≃ I`. -/
-@[to_additive "**Vertical line test** for monoid isomorphisms.
+@[to_additive "**Line test** for monoid isomorphisms.
 
 Let `f : G → H × I` be a homomorphism to a product of monoids. Assume that `f` is surjective on both
 factors and that the image of `f` intersects every \"vertical line\" `{(h, i) | i : I}` and every
 \"horizontal line\" `{(h, i) | h : H}` at most once. Then the image of `f` is the graph of some
 monoid isomorphism `f' : H ≃ I`."]
-lemma MonoidHom.exists_mulEquiv_range_eq_graph (f : G →* H × I) (hf₁ : Surjective (Prod.fst ∘ f))
+lemma MonoidHom.exists_mulEquiv_range_eq_graph {f : G →* H × I} (hf₁ : Surjective (Prod.fst ∘ f))
     (hf₂ : Surjective (Prod.snd ∘ f)) (hf : ∀ g₁ g₂, (f g₁).1 = (f g₂).1 ↔ (f g₁).2 = (f g₂).2) :
     ∃ e : H ≃* I, .range f = univ.graphOn e := by
   obtain ⟨e₁, he₁⟩ := f.exists_range_eq_graph hf₁ fun _ _ ↦ (hf _ _).1
@@ -81,3 +99,18 @@ lemma MonoidHom.exists_mulEquiv_range_eq_graph (f : G →* H × I) (hf₁ : Surj
     invFun := e₂
     left_inv := fun h ↦ by rw [← he₁₂]
     right_inv := fun i ↦ by rw [he₁₂] }, he₁⟩
+
+/-- **Goursat's lemma** for monoid isomorphisms.
+
+Let `G ≤ H × I` be a submonoid of a product of monoids. Assume that the natural maps from `G` to
+both factors are bijective. Then `G` is the graph of some isomorphism `f : H ≃* I`. -/
+@[to_additive "**Goursat's lemma** for additive monoid isomorphisms.
+
+Let `G ≤ H × I` be a submonoid of a product of additive monoids. Assume that the natural maps from
+`G` to both factors are bijective. Then `G` is the graph of some isomorphism `f : H ≃+ I`."]
+lemma Submonoid.exists_mulEquiv_eq_graph {G : Submonoid (H × I)}
+    (hf₁ : Bijective (Prod.fst ∘ G.subtype)) (hf₂ : Bijective (Prod.snd ∘ G.subtype)) :
+    ∃ e : H ≃* I, G = univ.graphOn e := by
+  simpa only [coe_subtype, Subtype.range_coe_subtype, SetLike.setOf_mem_eq]
+    using MonoidHom.exists_mulEquiv_range_eq_graph hf₁.surjective hf₂.surjective
+      (fun _ _ ↦ (hf₁.injective.eq_iff).trans hf₂.injective.eq_iff.symm)

--- a/Mathlib/Algebra/Group/Graph.lean
+++ b/Mathlib/Algebra/Group/Graph.lean
@@ -3,7 +3,9 @@ Copyright (c) 2024 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, David Loeffler
 -/
-import Mathlib.Algebra.Group.Subgroup.Basic
+import Mathlib.Algebra.Group.Prod
+import Mathlib.Data.Set.Function
+import Mathlib.Algebra.Group.Submonoid.Defs
 
 /-!
 # Vertical line test for group homs

--- a/Mathlib/Algebra/Group/Graph.lean
+++ b/Mathlib/Algebra/Group/Graph.lean
@@ -69,22 +69,16 @@ once. Then the image of `f` is the graph of some monoid homomorphism `f' : H →
 lemma exists_mrange_eq_mgraph {f : G →* H × I} (hf₁ : Surjective (Prod.fst ∘ f))
     (hf : ∀ g₁ g₂, (f g₁).1 = (f g₂).1 → (f g₁).2 = (f g₂).2) :
     ∃ f' : H →* I, mrange f = f'.mgraph := by
+  obtain ⟨f', hf'⟩ := exists_range_eq_graphOn_univ hf₁ hf
+  simp only [Set.ext_iff, Set.mem_range, mem_graphOn, mem_univ, true_and, Prod.forall] at hf'
   use
-  { toFun := fun h ↦ (f (hf₁ h).choose).snd
-    map_one' := by simpa using hf (hf₁ 1).choose 1 (by simpa using (hf₁ 1).choose_spec)
-    map_mul' := fun h₁ h₂ ↦ by
-      have := calc (f (hf₁ (h₁ * h₂)).choose).fst
-        _ = h₁ * h₂ := (hf₁ (h₁ * h₂)).choose_spec
-        _ = (f (hf₁ h₁).choose).fst * (f (hf₁ h₂).choose).fst := by
-          congr 1; exacts [(hf₁ h₁).choose_spec.symm, (hf₁ h₂).choose_spec.symm]
-        _ = (f ((hf₁ h₁).choose * (hf₁ h₂).choose)).fst := by simp
-      simpa using hf _ _ this }
-  ext x
-  simp only [Set.mem_range, Function.comp_apply, coe_mk, OneHom.coe_mk, mem_graphOn, mem_univ,
-    true_and]
-  refine ⟨?_, fun hi ↦ ⟨(hf₁ x.1).choose, Prod.ext (hf₁ x.1).choose_spec hi⟩⟩
-  rintro ⟨g, rfl⟩
-  exact hf _ _ (hf₁ (f g).1).choose_spec
+  { toFun := f'
+    map_one' := (hf' _ _).1 ⟨1, map_one _⟩
+    map_mul' := by
+      simp_rw [hf₁.forall]
+      rintro g₁ g₂
+      exact (hf' _ _).1 ⟨g₁ * g₂, by simp [Prod.ext_iff, (hf' (f _).1 _).1 ⟨_, rfl⟩]⟩ }
+  simpa [SetLike.ext_iff] using hf'
 
 /-- **Line test** for monoid isomorphisms.
 

--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -149,6 +149,8 @@ theorem mk_div_mk [Div G] [Div H] (x₁ x₂ : G) (y₁ y₂ : H) :
 theorem swap_div [Div G] [Div H] (a b : G × H) : (a / b).swap = a.swap / b.swap :=
   rfl
 
+@[to_additive] lemma div_def [Div M] [Div N] (a b : M × N) : a / b = (a.1 / b.1, a.2 / b.2) := rfl
+
 @[to_additive]
 instance instSemigroup [Semigroup M] [Semigroup N] : Semigroup (M × N) :=
   { mul_assoc := fun _ _ _ => mk.inj_iff.mpr ⟨mul_assoc _ _ _, mul_assoc _ _ _⟩ }

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -5,12 +5,13 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Logic.Function.Defs
 import Mathlib.Logic.Function.Iterate
+import Aesop
 import Mathlib.Tactic.Inhabit
 
 /-!
 # Extra facts about `Prod`
 
-This file defines `Prod.swap : α × β → β × α` and proves various simple lemmas about `Prod`.
+This file proves various simple lemmas about `Prod`.
 It also defines better delaborators for product projections.
 -/
 
@@ -19,6 +20,8 @@ variable {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 @[deprecated (since := "2024-05-08")] alias Prod_map := Prod.map_apply
 
 namespace Prod
+
+lemma swap_eq_iff_eq_swap {x : α × β} {y : β × α} : x.swap = y ↔ x = y.swap := by aesop
 
 def mk.injArrow {x₁ : α} {y₁ : β} {x₂ : α} {y₂ : β} :
     (x₁, y₁) = (x₂, y₂) → ∀ ⦃P : Sort*⦄, (x₁ = x₂ → y₁ = y₂ → P) → P :=

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -1665,4 +1665,55 @@ lemma bijOn_swap (ha : a ∈ s) (hb : b ∈ s) : BijOn (swap a b) s s :=
 
 end Equiv
 
+/-! ### Vertical line test -/
+
+namespace Set
+
+/-- **Vertical line test** for functions.
+
+Let `f : α → β × γ` be a function to a product. Assume that `f` is surjective on the first factor
+and that the image of `f` intersects every "vertical line" `{(b, c) | c : γ}` at most once.
+Then the image of `f` is the graph of some monoid homomorphism `f' : β → γ`. -/
+lemma exists_range_eq_graphOn_univ {f : α → β × γ} (hf₁ : Surjective (Prod.fst ∘ f))
+    (hf : ∀ g₁ g₂, (f g₁).1 = (f g₂).1 → (f g₁).2 = (f g₂).2) :
+    ∃ f' : β → γ, range f = univ.graphOn f' := by
+  refine ⟨fun h ↦ (f (hf₁ h).choose).snd, ?_⟩
+  ext x
+  simp only [mem_range, comp_apply, mem_graphOn, mem_univ, true_and]
+  refine ⟨?_, fun hi ↦ ⟨(hf₁ x.1).choose, Prod.ext (hf₁ x.1).choose_spec hi⟩⟩
+  rintro ⟨g, rfl⟩
+  exact hf _ _ (hf₁ (f g).1).choose_spec
+
+/-- **Line test** for equivalences.
+
+Let `f : α → β × γ` be a homomorphism to a product of monoids. Assume that `f` is surjective on both
+factors and that the image of `f` intersects every "vertical line" `{(b, c) | c : γ}` and every
+"horizontal line" `{(b, c) | b : β}` at most once. Then the image of `f` is the graph of some
+equivalence `f' : β ≃ γ`. -/
+lemma exists_equiv_range_eq_graphOn_univ {f : α → β × γ} (hf₁ : Surjective (Prod.fst ∘ f))
+    (hf₂ : Surjective (Prod.snd ∘ f)) (hf : ∀ g₁ g₂, (f g₁).1 = (f g₂).1 ↔ (f g₁).2 = (f g₂).2) :
+    ∃ e : β ≃ γ, range f = univ.graphOn e := by
+  obtain ⟨e₁, he₁⟩ := exists_range_eq_graphOn_univ hf₁ fun _ _ ↦ (hf _ _).1
+  obtain ⟨e₂, he₂⟩ := exists_range_eq_graphOn_univ (f := Equiv.prodComm _ _ ∘ f) (by simpa) <|
+    by simp [hf]
+  have he₁₂ h i : e₁ h = i ↔ e₂ i = h := by
+    rw [Set.ext_iff] at he₁ he₂
+    aesop (add simp [Prod.swap_eq_iff_eq_swap])
+  exact ⟨
+  { toFun := e₁
+    invFun := e₂
+    left_inv := fun h ↦ by rw [← he₁₂]
+    right_inv := fun i ↦ by rw [he₁₂] }, he₁⟩
+
+/-- **Vertical line test** for functions.
+
+Let `s : Set (β × γ)` be a set in a product. Assume that `s` maps bijectively to the first factor.
+Then `s` is the graph of some function `f : β → γ`. -/
+lemma exists_eq_mgraphOn_univ {s : Set (β × γ)}
+    (hs₁ : Bijective (Prod.fst ∘ (Subtype.val : s → β × γ))) : ∃ f : β → γ, s = univ.graphOn f := by
+  simpa using exists_range_eq_graphOn_univ hs₁.surjective
+    fun a b h ↦ congr_arg (Prod.snd ∘ (Subtype.val : s → β × γ)) (hs₁.injective h)
+
+end Set
+
 set_option linter.style.longFile 1800

--- a/Mathlib/LinearAlgebra/Prod.lean
+++ b/Mathlib/LinearAlgebra/Prod.lean
@@ -985,8 +985,9 @@ most once. Then the image of `f` is the graph of some linear map `f' : H → I`.
 lemma LinearMap.exists_range_eq_graph {f : G →ₛₗ[σ] H × I} (hf₁ : Surjective (Prod.fst ∘ f))
     (hf : ∀ g₁ g₂, (f g₁).1 = (f g₂).1 → (f g₁).2 = (f g₂).2) :
     ∃ f' : H →ₗ[S] I, LinearMap.range f = LinearMap.graph f' := by
-  obtain ⟨f', hf'⟩ := AddMonoidHom.exists_range_eq_graph (I := I) (f := f) hf₁ hf
-  simp only [Set.ext_iff, mem_graphOn, mem_univ, true_and, AddMonoidHom.coe_coe] at hf'
+  obtain ⟨f', hf'⟩ := AddMonoidHom.exists_mrange_eq_mgraph (I := I) (f := f) hf₁ hf
+  simp only [SetLike.ext_iff, AddMonoidHom.mem_mrange, AddMonoidHom.coe_coe,
+    AddMonoidHom.mem_mgraph] at hf'
   use
   { toFun := f'.toFun
     map_add' := f'.map_add'
@@ -994,9 +995,9 @@ lemma LinearMap.exists_range_eq_graph {f : G →ₛₗ[σ] H × I} (hf₁ : Surj
       intro s h
       simp only [ZeroHom.toFun_eq_coe, AddMonoidHom.toZeroHom_coe, RingHom.id_apply]
       refine (hf' (s • h, _)).mp ?_
-      rw [← Prod.smul_mk, ← LinearMap.range_coe, SetLike.mem_coe]
+      rw [← Prod.smul_mk, ← LinearMap.mem_range]
       apply Submodule.smul_mem
-      rw [← SetLike.mem_coe, LinearMap.range_coe, hf'] }
+      rw [LinearMap.mem_range, hf'] }
   ext x
   simpa only [mem_range, Eq.comm, ZeroHom.toFun_eq_coe, AddMonoidHom.toZeroHom_coe, mem_graph_iff,
     coe_mk, AddHom.coe_mk, AddMonoidHom.coe_coe, Set.mem_range] using hf' x

--- a/Mathlib/LinearAlgebra/Prod.lean
+++ b/Mathlib/LinearAlgebra/Prod.lean
@@ -1011,4 +1011,39 @@ lemma Submodule.exists_eq_graph {G : Submodule S (H × I)} (hf₁ : Bijective (P
   simpa only [range_subtype] using LinearMap.exists_range_eq_graph hf₁.surjective
       (fun a b h ↦ congr_arg (Prod.snd ∘ G.subtype) (hf₁.injective h))
 
+/-- **Line test** for module isomorphisms.
+
+Let `f : G → H × I` be a homomorphism to a product of modules. Assume that `f` is surjective onto
+both factors and that the image of `f` intersects every "vertical line" `{(h, i) | i : I}` and every
+"horizontal line" `{(h, i) | h : H}` at most once. Then the image of `f` is the graph of some
+module isomorphism `f' : H ≃ I`. -/
+lemma LinearMap.exists_linearEquiv_eq_graph {f : G →ₛₗ[σ] H × I} (hf₁ : Surjective (Prod.fst ∘ f))
+    (hf₂ : Surjective (Prod.snd ∘ f)) (hf : ∀ g₁ g₂, (f g₁).1 = (f g₂).1 ↔ (f g₁).2 = (f g₂).2) :
+    ∃ e : H ≃ₗ[S] I, range f = e.toLinearMap.graph := by
+  obtain ⟨e₁, he₁⟩ := f.exists_range_eq_graph hf₁ fun _ _ ↦ (hf _ _).1
+  obtain ⟨e₂, he₂⟩ := ((LinearEquiv.prodComm _ _ _).toLinearMap.comp f).exists_range_eq_graph
+    (by simpa) <| by simp [hf]
+  have he₁₂ h i : e₁ h = i ↔ e₂ i = h := by
+    simp only [SetLike.ext_iff, LinearMap.mem_graph_iff] at he₁ he₂
+    rw [Eq.comm, ← he₁ (h, i), Eq.comm, ← he₂ (i, h)]
+    simp only [mem_range, coe_comp, LinearEquiv.coe_coe, Function.comp_apply,
+      LinearEquiv.prodComm_apply, Prod.swap_eq_iff_eq_swap, Prod.swap_prod_mk]
+  exact ⟨
+  { toFun := e₁
+    map_smul' := e₁.map_smul'
+    map_add' := e₁.map_add'
+    invFun := e₂
+    left_inv := fun h ↦ by rw [← he₁₂]
+    right_inv := fun i ↦ by rw [he₁₂] }, he₁⟩
+
+/-- **Goursat's lemma** for module isomorphisms.
+
+Let `G ≤ H × I` be a submodule of a product of modules. Assume that the natural maps from `G` to
+both factors are bijective. Then `G` is the graph of some module isomorphism `f : H ≃ I`. -/
+lemma Submodule.exists_equiv_eq_graph {G : Submodule S (H × I)}
+    (hG₁ : Bijective (Prod.fst ∘ G.subtype)) (hG₂ : Bijective (Prod.snd ∘ G.subtype)) :
+    ∃ e : H ≃ₗ[S] I, G = e.toLinearMap.graph := by
+  simpa only [range_subtype] using LinearMap.exists_linearEquiv_eq_graph
+    hG₁.surjective hG₂.surjective fun _ _ ↦ hG₁.injective.eq_iff.trans hG₂.injective.eq_iff.symm
+
 end LineTest

--- a/Mathlib/LinearAlgebra/Prod.lean
+++ b/Mathlib/LinearAlgebra/Prod.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov, Eric Wieser
 -/
 import Mathlib.Algebra.Algebra.Prod
+import Mathlib.Algebra.Group.Graph
 import Mathlib.LinearAlgebra.Span.Basic
 import Mathlib.Order.PartialSups
-import Mathlib.Algebra.Group.Graph
 
 /-! ### Products of modules
 


### PR DESCRIPTION
Prove the vertical line test for monoid homomorphisms/isomorphisms.

Let `f : G → H × I` be a homomorphism to a product of monoids. Assume that `f` is surjective on the
first factor and that the image of `f` intersects every "vertical line" `{(h, i) | i : I}` at most
once. Then the image of `f` is the graph of some monoid homomorphism `f' : H → I`.

Furthermore, if `f` is also surjective on the second factor and its image intersects every
"horizontal line" `{(h, i) | h : H}` at most once, then `f'` is actually an isomorphism
`f' : H ≃ I`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #18870

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
