### PR TITLE
[Merged by Bors] - feat: Goursat's lemma for subgroups

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3120,6 +3120,7 @@ import Mathlib.GroupTheory.FreeGroup.Basic
 import Mathlib.GroupTheory.FreeGroup.IsFreeGroup
 import Mathlib.GroupTheory.FreeGroup.NielsenSchreier
 import Mathlib.GroupTheory.FreeGroup.Reduce
+import Mathlib.GroupTheory.Goursat
 import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.GroupTheory.GroupAction.Blocks
 import Mathlib.GroupTheory.GroupAction.CardCommute

--- a/Mathlib/GroupTheory/Goursat.lean
+++ b/Mathlib/GroupTheory/Goursat.lean
@@ -13,8 +13,8 @@ import Mathlib.GroupTheory.QuotientGroup.Defs
 This file proves Goursat's lemma for subgroups.
 
 If `I` is a subgroup of `G × H` which projects fully on both factors, then there exist normal
-subgroups `G' ≤ G` and `H' ≤ H` such that the image of `I` in `G ⧸ G' × H ⧸ H'` is the graph of an
-isomorphism `G ⧸ G' ≃ H ⧸ H'`.
+subgroups `G' ≤ G` and `H' ≤ H` such that `G' × H' ≤ I` and the image of `I` in `G ⧸ G' × H ⧸ H'` is
+the graph of an isomorphism `G ⧸ G' ≃ H ⧸ H'`.
 
 `G'` and `H'` can be explicitly constructed as `Subgroup.goursatFst I` and `Subgroup.goursatSnd I`
 respectively.
@@ -83,16 +83,16 @@ lemma goursatFst_prod_goursatSnd_le : I.goursatFst.prod I.goursatSnd ≤ I := by
 /-- **Goursat's lemma** for a subgroup of with surjective projections.
 
 If `I` is a subgroup of `G × H` which projects fully on both factors, then there exist normal
-subgroups `M ≤ G` and `N ≤ H` such that the image of `I` in `G ⧸ M × H ⧸ N` is the graph of an
-isomorphism `G ⧸ M ≃ H ⧸ N'`.
+subgroups `M ≤ G` and `N ≤ H` such that `G' × H' ≤ I` and the image of `I` in `G ⧸ M × H ⧸ N` is the
+graph of an isomorphism `G ⧸ M ≃ H ⧸ N'`.
 
 `G'` and `H'` can be explicitly constructed as `I.goursatFst` and `I.goursatSnd` respectively. -/
 @[to_additive
 "**Goursat's lemma** for a subgroup of with surjective projections.
 
 If `I` is a subgroup of `G × H` which projects fully on both factors, then there exist normal
-subgroups `M ≤ G` and `N ≤ H` such that the image of `I` in `G ⧸ M × H ⧸ N` is the graph of an
-isomorphism `G ⧸ M ≃ H ⧸ N'`.
+subgroups `M ≤ G` and `N ≤ H` such that `G' × H' ≤ I` and the image of `I` in `G ⧸ M × H ⧸ N` is the
+graph of an isomorphism `G ⧸ M ≃ H ⧸ N'`.
 
 `G'` and `H'` can be explicitly constructed as `I.goursatFst` and `I.goursatSnd` respectively."]
 lemma goursat_surjective :
@@ -111,16 +111,14 @@ lemma goursat_surjective :
 /-- **Goursat's lemma** for an arbitrary subgroup.
 
 If `I` is a subgroup of `G × H`, then there exist subgroups `G' ≤ G`, `H' ≤ H` and normal subgroups
-`M ≤ G'` and `N ≤ H'` such that the image of `I` in `G' ⧸ M × H' ⧸ N` is the graph of an
-isomorphism `G ⧸ G' ≃ H ⧸ H'`. -/
+`M ≤ G'` and `N ≤ H'` such that `M × N ≤ I` and the image of `I` in `G' ⧸ M × H' ⧸ N` is the graph
+of an isomorphism `G ⧸ G' ≃ H ⧸ H'`. -/
 @[to_additive
 "**Goursat's lemma** for an arbitrary subgroup.
 
-If `I` is a subgroup of `G × H` which projects fully on both factors, then there exist normal
-subgroups `G' ≤ G` and `H' ≤ H` such that the image of `I` in `G ⧸ G' × H ⧸ H'` is the graph of an
-isomorphism `G ⧸ G' ≃ H ⧸ H'`.
-
-`G'` and `H'` can be explicitly constructed as `I.goursatFst` and `I.goursatSnd` respectively."]
+If `I` is a subgroup of `G × H`, then there exist subgroups `G' ≤ G`, `H' ≤ H` and normal subgroups
+`M ≤ G'` and `N ≤ H'` such that `M × N ≤ I` and the image of `I` in `G' ⧸ M × H' ⧸ N` is the graph
+of an isomorphism `G ⧸ G' ≃ H ⧸ H'`."]
 lemma goursat :
     ∃ (G' : Subgroup G) (H' : Subgroup H) (M : Subgroup G') (N : Subgroup H') (_ : M.Normal)
       (_ : N.Normal) (e : G' ⧸ M ≃* H' ⧸ N),

--- a/Mathlib/GroupTheory/Goursat.lean
+++ b/Mathlib/GroupTheory/Goursat.lean
@@ -122,8 +122,8 @@ isomorphism `G ⧸ G' ≃ H ⧸ H'`.
 
 `G'` and `H'` can be explicitly constructed as `I.goursatFst` and `I.goursatSnd` respectively."]
 lemma goursat :
-    ∃ (G' : Subgroup G) (H' : Subgroup H) (M : Subgroup G') (N : Subgroup H') (hM : M.Normal)
-      (hN : N.Normal) (e : G' ⧸ M ≃* H' ⧸ N),
+    ∃ (G' : Subgroup G) (H' : Subgroup H) (M : Subgroup G') (N : Subgroup H') (_ : M.Normal)
+      (_ : N.Normal) (e : G' ⧸ M ≃* H' ⧸ N),
       I = (e.toMonoidHom.graph.comap <| (QuotientGroup.mk' M).prodMap (QuotientGroup.mk' N)).map
         (G'.subtype.prodMap H'.subtype) := by
   let G' := I.map (MonoidHom.fst ..)
@@ -147,7 +147,34 @@ lemma goursat :
   refine ⟨I.map (MonoidHom.fst ..), I.map (MonoidHom.snd ..),
     I'.goursatFst, I'.goursatSnd, inferInstance, inferInstance, e, ?_⟩
   rw [← he]
-  simp only [MonoidHom.range_comp, Subgroup.range_subtype, I', Subgroup.comap_map_eq]
-  sorry
+  simp only [MonoidHom.range_comp, Subgroup.range_subtype, I']
+  rw [comap_map_eq_self]
+  · ext ⟨g, h⟩
+    constructor
+    · intro hgh
+      simpa only [mem_map, MonoidHom.mem_range, MonoidHom.prod_apply, Subtype.exists, Prod.exists,
+        MonoidHom.coe_prodMap, coeSubtype, Prod.mk.injEq, Prod.map_apply, MonoidHom.coe_snd,
+        exists_eq_right, exists_and_right, exists_eq_right_right, MonoidHom.coe_fst]
+        using ⟨⟨h, hgh⟩, ⟨g, hgh⟩, g, h, hgh, ⟨rfl, rfl⟩⟩
+    · simp only [mem_map, MonoidHom.mem_range, MonoidHom.prod_apply, Subtype.exists, Prod.exists,
+        MonoidHom.coe_prodMap, coeSubtype, Prod.mk.injEq, Prod.map_apply, MonoidHom.coe_snd,
+        exists_eq_right, exists_and_right, exists_eq_right_right, MonoidHom.coe_fst,
+        forall_exists_index, and_imp]
+      rintro h₁ hgh₁ g₁ hg₁h g₂ h₂ hg₂h₂ hP hQ
+      simp only [Subtype.ext_iff] at hP hQ
+      rwa [← hP, ← hQ]
+  · rintro ⟨⟨g, _⟩, ⟨h, _⟩⟩ hgh
+    simp only [MonoidHom.prodMap, MonoidHom.mem_ker, MonoidHom.prod_apply, MonoidHom.coe_comp,
+      QuotientGroup.coe_mk', MonoidHom.coe_fst, comp_apply, MonoidHom.coe_snd, Prod.mk_eq_one,
+      QuotientGroup.eq_one_iff, mem_goursatFst, MonoidHom.mem_range, Prod.mk.injEq, Subtype.exists,
+      Prod.exists, mem_goursatSnd] at hgh
+    rcases hgh with ⟨⟨g₁, h₁, hg₁h₁, hPQ₁⟩, ⟨g₂, h₂, hg₂h₂, hPQ₂⟩⟩
+    simp only [Subtype.ext_iff] at hPQ₁ hPQ₂
+    rcases hPQ₁ with ⟨rfl, rfl⟩
+    rcases hPQ₂ with ⟨rfl, rfl⟩
+    simp only [MonoidHom.mem_range, MonoidHom.prod_apply, Prod.mk.injEq, Subtype.exists,
+      Prod.exists]
+    refine ⟨g₁, h₂, ?_, rfl, rfl⟩
+    simpa only [OneMemClass.coe_one, Prod.mk_mul_mk, mul_one, one_mul] using mul_mem hg₁h₁ hg₂h₂
 
 end Subgroup


### PR DESCRIPTION
Proves Goursat's lemma for subgroups.

If `I` is a subgroup of `G × H` which projects fully on both factors, then there exist normal
subgroups `G' ≤ G` and `H' ≤ H` such that `G' × H' ≤ I` and the image of `I` in `G ⧸ G' × H ⧸ H'` is the graph of an
isomorphism `G ⧸ G' ≃ H ⧸ H'`.

We construct `G'` and `H'` as explicit subgroups.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #18822
- [x] depends on: #19518

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
