### PR TITLE
[Merged by Bors] - perf(Ideal/Quotient): directly use AddCommGroup instance in CommRing

### DIFF
--- a/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
@@ -63,6 +63,7 @@ protected def ringCon (I : Ideal R) : RingCon R :=
         rw [mul_sub, sub_mul, sub_add_sub_cancel, mul_comm, mul_comm b₁]
       rwa [← this] at F }
 
+-- This instance makes use of the existing AddCommGroup instance to boost performance.
 instance commRing (I : Ideal R) : CommRing (R ⧸ I) where
   __ : AddCommGroup (R ⧸ I) := inferInstance
   __ : CommRing (Quotient.ringCon I).Quotient := inferInstance

--- a/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
@@ -63,8 +63,9 @@ protected def ringCon (I : Ideal R) : RingCon R :=
         rw [mul_sub, sub_mul, sub_add_sub_cancel, mul_comm, mul_comm b₁]
       rwa [← this] at F }
 
-instance commRing (I : Ideal R) : CommRing (R ⧸ I) :=
-    inferInstanceAs (CommRing (Quotient.ringCon I).Quotient)
+instance commRing (I : Ideal R) : CommRing (R ⧸ I) where
+  __ : AddCommGroup (R ⧸ I) := inferInstance
+  __ : CommRing (Quotient.ringCon I).Quotient := inferInstance
 
 -- Sanity test to make sure no diamonds have emerged in `commRing`
 example : (commRing I).toAddCommGroup = Submodule.Quotient.addCommGroup I := rfl


### PR DESCRIPTION
with a bigger effect when applied on top of #17930

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
