### PR TITLE
[Merged by Bors] - feat(Topology/ShrinkingLemma): add a predicate on refined open sets

### DIFF
--- a/Mathlib/Topology/ShrinkingLemma.lean
+++ b/Mathlib/Topology/ShrinkingLemma.lean
@@ -59,7 +59,7 @@ a maximal element, then show that the maximal element must have `carrier = univ`
   /-- For each `i ∈ carrier`, the original set includes the closure of the refined set. -/
   closure_subset : ∀ {i}, i ∈ carrier → closure (toFun i) ⊆ u i
   /-- For each `i ∈ carrier`, the refined set satisfies `p`. -/
-  p_refined {i} (hi : i ∈ carrier) : p (toFun i)
+  pred_of_mem {i} (hi : i ∈ carrier) : p (toFun i)
   /-- Sets that correspond to `i ∉ carrier` are not modified. -/
   apply_eq : ∀ {i}, i ∉ carrier → toFun i = u i
 

--- a/Mathlib/Topology/ShrinkingLemma.lean
+++ b/Mathlib/Topology/ShrinkingLemma.lean
@@ -147,12 +147,7 @@ def chainSup (c : Set (PartialRefinement u s p)) (hc : IsChain (· ≤ ·) c) (n
       have : v j ≤ v i := (hc.total (hvc _ hxi) (hvc _ hj')).elim (fun h => (hmax j hj' h).ge) id
       simpa only [find_apply_of_mem hc ne (hvc _ hxi) (this.1 <| hiv _ hj')]
   closure_subset hi := (find c ne _).closure_subset ((mem_find_carrier_iff _).2 hi)
-  p_refined {i} hi := by
-    simp only
-    obtain ⟨v, hv⟩ := Set.mem_iUnion.mp hi
-    simp only [mem_iUnion, exists_prop] at hv
-    rw [find_apply_of_mem hc ne hv.1 hv.2]
-    exact v.p_refined hv.2
+  p_refined {i} hi := v.p_refined <| by aesop
   apply_eq hi := (find c ne _).apply_eq (mt (mem_find_carrier_iff _).1 hi)
 
 /-- `chainSup hu c hc ne hfin hU` is an upper bound of the chain `c`. -/

--- a/Mathlib/Topology/ShrinkingLemma.lean
+++ b/Mathlib/Topology/ShrinkingLemma.lean
@@ -165,7 +165,7 @@ theorem le_chainSup {c : Set (PartialRefinement u s p)} (hc : IsChain (· ≤ ·
 `i ∉ v.carrier`, then there exists a partial refinement that is strictly greater than `v`. -/
 theorem exists_gt [NormalSpace X] (v : PartialRefinement u s ⊤) (hs : IsClosed s)
     (i : ι) (hi : i ∉ v.carrier) :
-    ∃ v' : PartialRefinement u s (fun _ => True), v < v' := by
+    ∃ v' : PartialRefinement u s ⊤, v < v' := by
   have I : (s ∩ ⋂ (j) (_ : j ≠ i), (v j)ᶜ) ⊆ v i := by
     simp only [subset_def, mem_inter_iff, mem_iInter, and_imp]
     intro x hxs H
@@ -214,9 +214,9 @@ corresponding original open set. -/
 theorem exists_subset_iUnion_closure_subset (hs : IsClosed s) (uo : ∀ i, IsOpen (u i))
     (uf : ∀ x ∈ s, { i | x ∈ u i }.Finite) (us : s ⊆ ⋃ i, u i) :
     ∃ v : ι → Set X, s ⊆ iUnion v ∧ (∀ i, IsOpen (v i)) ∧ ∀ i, closure (v i) ⊆ u i := by
-  haveI : Nonempty (PartialRefinement u s (fun _ => True)) :=
+  haveI : Nonempty (PartialRefinement u s ⊤) :=
     ⟨⟨u, ∅, uo, us, False.elim, False.elim, fun _ => rfl⟩⟩
-  have : ∀ c : Set (PartialRefinement u s (fun _ => True)),
+  have : ∀ c : Set (PartialRefinement u s ⊤),
       IsChain (· ≤ ·) c → c.Nonempty → ∃ ub, ∀ v ∈ c, v ≤ ub :=
     fun c hc ne => ⟨.chainSup c hc ne uf us, fun v hv => PartialRefinement.le_chainSup _ _ _ _ hv⟩
   rcases zorn_le_nonempty this with ⟨v, hv⟩

--- a/Mathlib/Topology/ShrinkingLemma.lean
+++ b/Mathlib/Topology/ShrinkingLemma.lean
@@ -147,7 +147,12 @@ def chainSup (c : Set (PartialRefinement u s p)) (hc : IsChain (· ≤ ·) c) (n
       have : v j ≤ v i := (hc.total (hvc _ hxi) (hvc _ hj')).elim (fun h => (hmax j hj' h).ge) id
       simpa only [find_apply_of_mem hc ne (hvc _ hxi) (this.1 <| hiv _ hj')]
   closure_subset hi := (find c ne _).closure_subset ((mem_find_carrier_iff _).2 hi)
-  p_refined {i} hi := v.p_refined <| by aesop
+  pred_of_mem {i} hi := by
+    obtain ⟨v, hv⟩ := Set.mem_iUnion.mp hi
+    simp only [mem_iUnion, exists_prop] at hv
+    simp only
+    rw [find_apply_of_mem hc ne hv.1 hv.2]
+    exact v.pred_of_mem hv.2
   apply_eq hi := (find c ne _).apply_eq (mt (mem_find_carrier_iff _).1 hi)
 
 /-- `chainSup hu c hc ne hfin hU` is an upper bound of the chain `c`. -/

--- a/Mathlib/Topology/ShrinkingLemma.lean
+++ b/Mathlib/Topology/ShrinkingLemma.lean
@@ -47,7 +47,7 @@ This type is equipped with the following partial order: `v ≤ v'` if `v.carrier
 and `v i = v' i` for `i ∈ v.carrier`. We will use Zorn's lemma to prove that this type has
 a maximal element, then show that the maximal element must have `carrier = univ`. -/
 -- Porting note(#5171): this linter isn't ported yet. @[nolint has_nonempty_instance]
-@[ext] structure PartialRefinement (u : ι → Set X) (s : Set X) where
+@[ext] structure PartialRefinement (u : ι → Set X) (s : Set X) (p : Set X → Prop) where
   /-- A family of sets that form a partial refinement of `u`. -/
   toFun : ι → Set X
   /-- The set of indexes `i` such that `i`-th set is already shrunk. -/
@@ -58,21 +58,23 @@ a maximal element, then show that the maximal element must have `carrier = univ`
   subset_iUnion : s ⊆ ⋃ i, toFun i
   /-- For each `i ∈ carrier`, the original set includes the closure of the refined set. -/
   closure_subset : ∀ {i}, i ∈ carrier → closure (toFun i) ⊆ u i
+  /-- For each `i ∈ carrier`, the refined set satisfies `p`. -/
+  p_refined {i} (hi : i ∈ carrier) : p (toFun i)
   /-- Sets that correspond to `i ∉ carrier` are not modified. -/
   apply_eq : ∀ {i}, i ∉ carrier → toFun i = u i
 
 namespace PartialRefinement
 
-variable {u : ι → Set X} {s : Set X}
+variable {u : ι → Set X} {s : Set X} {p : Set X → Prop}
 
-instance : CoeFun (PartialRefinement u s) fun _ => ι → Set X := ⟨toFun⟩
+instance : CoeFun (PartialRefinement u s p) fun _ => ι → Set X := ⟨toFun⟩
 
-protected theorem subset (v : PartialRefinement u s) (i : ι) : v i ⊆ u i := by
+protected theorem subset (v : PartialRefinement u s p) (i : ι) : v i ⊆ u i := by
   classical
   exact if h : i ∈ v.carrier then subset_closure.trans (v.closure_subset h) else (v.apply_eq h).le
 
 open Classical in
-instance : PartialOrder (PartialRefinement u s) where
+instance : PartialOrder (PartialRefinement u s p) where
   le v₁ v₂ := v₁.carrier ⊆ v₂.carrier ∧ ∀ i ∈ v₁.carrier, v₁ i = v₂ i
   le_refl _ := ⟨Subset.refl _, fun _ _ => rfl⟩
   le_trans _ _ _ h₁₂ h₂₃ :=
@@ -87,28 +89,29 @@ instance : PartialOrder (PartialRefinement u s) where
 
 /-- If two partial refinements `v₁`, `v₂` belong to a chain (hence, they are comparable)
 and `i` belongs to the carriers of both partial refinements, then `v₁ i = v₂ i`. -/
-theorem apply_eq_of_chain {c : Set (PartialRefinement u s)} (hc : IsChain (· ≤ ·) c) {v₁ v₂}
+theorem apply_eq_of_chain {c : Set (PartialRefinement u s p)} (hc : IsChain (· ≤ ·) c) {v₁ v₂}
     (h₁ : v₁ ∈ c) (h₂ : v₂ ∈ c) {i} (hi₁ : i ∈ v₁.carrier) (hi₂ : i ∈ v₂.carrier) :
     v₁ i = v₂ i :=
   (hc.total h₁ h₂).elim (fun hle => hle.2 _ hi₁) (fun hle => (hle.2 _ hi₂).symm)
 
 /-- The carrier of the least upper bound of a non-empty chain of partial refinements is the union of
 their carriers. -/
-def chainSupCarrier (c : Set (PartialRefinement u s)) : Set ι :=
+def chainSupCarrier (c : Set (PartialRefinement u s p)) : Set ι :=
   ⋃ v ∈ c, carrier v
 
 open Classical in
 /-- Choice of an element of a nonempty chain of partial refinements. If `i` belongs to one of
 `carrier v`, `v ∈ c`, then `find c ne i` is one of these partial refinements. -/
-def find (c : Set (PartialRefinement u s)) (ne : c.Nonempty) (i : ι) : PartialRefinement u s :=
+def find (c : Set (PartialRefinement u s p)) (ne : c.Nonempty) (i : ι) : PartialRefinement u s p :=
   if hi : ∃ v ∈ c, i ∈ carrier v then hi.choose else ne.some
 
-theorem find_mem {c : Set (PartialRefinement u s)} (i : ι) (ne : c.Nonempty) : find c ne i ∈ c := by
+theorem find_mem {c : Set (PartialRefinement u s p)} (i : ι) (ne : c.Nonempty) :
+    find c ne i ∈ c := by
   rw [find]
   split_ifs with h
   exacts [h.choose_spec.1, ne.some_mem]
 
-theorem mem_find_carrier_iff {c : Set (PartialRefinement u s)} {i : ι} (ne : c.Nonempty) :
+theorem mem_find_carrier_iff {c : Set (PartialRefinement u s p)} {i : ι} (ne : c.Nonempty) :
     i ∈ (find c ne i).carrier ↔ i ∈ chainSupCarrier c := by
   rw [find]
   split_ifs with h
@@ -118,14 +121,14 @@ theorem mem_find_carrier_iff {c : Set (PartialRefinement u s)} {i : ι} (ne : c.
     refine iff_of_false (h _ ne.some_mem) ?_
     simpa only [chainSupCarrier, mem_iUnion₂, not_exists]
 
-theorem find_apply_of_mem {c : Set (PartialRefinement u s)} (hc : IsChain (· ≤ ·) c)
+theorem find_apply_of_mem {c : Set (PartialRefinement u s p)} (hc : IsChain (· ≤ ·) c)
     (ne : c.Nonempty) {i v} (hv : v ∈ c) (hi : i ∈ carrier v) : find c ne i i = v i :=
   apply_eq_of_chain hc (find_mem _ _) hv ((mem_find_carrier_iff _).2 <| mem_iUnion₂.2 ⟨v, hv, hi⟩)
     hi
 
 /-- Least upper bound of a nonempty chain of partial refinements. -/
-def chainSup (c : Set (PartialRefinement u s)) (hc : IsChain (· ≤ ·) c) (ne : c.Nonempty)
-    (hfin : ∀ x ∈ s, { i | x ∈ u i }.Finite) (hU : s ⊆ ⋃ i, u i) : PartialRefinement u s where
+def chainSup (c : Set (PartialRefinement u s p)) (hc : IsChain (· ≤ ·) c) (ne : c.Nonempty)
+    (hfin : ∀ x ∈ s, { i | x ∈ u i }.Finite) (hU : s ⊆ ⋃ i, u i) : PartialRefinement u s p where
   toFun i := find c ne i i
   carrier := chainSupCarrier c
   isOpen i := (find _ _ _).isOpen i
@@ -134,7 +137,7 @@ def chainSup (c : Set (PartialRefinement u s)) (hc : IsChain (· ≤ ·) c) (ne 
     · use i
       simpa only [(find c ne i).apply_eq (mt (mem_find_carrier_iff _).1 hi)]
     · simp_rw [not_exists, not_and, not_imp_not, chainSupCarrier, mem_iUnion₂] at hx
-      haveI : Nonempty (PartialRefinement u s) := ⟨ne.some⟩
+      haveI : Nonempty (PartialRefinement u s p) := ⟨ne.some⟩
       choose! v hvc hiv using hx
       rcases (hfin x hxs).exists_maximal_wrt v _ (mem_iUnion.1 (hU hxs)) with
         ⟨i, hxi : x ∈ u i, hmax : ∀ j, x ∈ u j → v i ≤ v j → v i = v j⟩
@@ -144,19 +147,25 @@ def chainSup (c : Set (PartialRefinement u s)) (hc : IsChain (· ≤ ·) c) (ne 
       have : v j ≤ v i := (hc.total (hvc _ hxi) (hvc _ hj')).elim (fun h => (hmax j hj' h).ge) id
       simpa only [find_apply_of_mem hc ne (hvc _ hxi) (this.1 <| hiv _ hj')]
   closure_subset hi := (find c ne _).closure_subset ((mem_find_carrier_iff _).2 hi)
+  p_refined {i} hi := by
+    simp only
+    obtain ⟨v, hv⟩ := Set.mem_iUnion.mp hi
+    simp only [mem_iUnion, exists_prop] at hv
+    rw [find_apply_of_mem hc ne hv.1 hv.2]
+    exact v.p_refined hv.2
   apply_eq hi := (find c ne _).apply_eq (mt (mem_find_carrier_iff _).1 hi)
 
 /-- `chainSup hu c hc ne hfin hU` is an upper bound of the chain `c`. -/
-theorem le_chainSup {c : Set (PartialRefinement u s)} (hc : IsChain (· ≤ ·) c) (ne : c.Nonempty)
+theorem le_chainSup {c : Set (PartialRefinement u s p)} (hc : IsChain (· ≤ ·) c) (ne : c.Nonempty)
     (hfin : ∀ x ∈ s, { i | x ∈ u i }.Finite) (hU : s ⊆ ⋃ i, u i) {v} (hv : v ∈ c) :
     v ≤ chainSup c hc ne hfin hU :=
   ⟨fun _ hi => mem_biUnion hv hi, fun _ hi => (find_apply_of_mem hc _ hv hi).symm⟩
 
 /-- If `s` is a closed set, `v` is a partial refinement, and `i` is an index such that
 `i ∉ v.carrier`, then there exists a partial refinement that is strictly greater than `v`. -/
-theorem exists_gt [NormalSpace X] (v : PartialRefinement u s) (hs : IsClosed s) (i : ι)
-    (hi : i ∉ v.carrier) :
-    ∃ v' : PartialRefinement u s, v < v' := by
+theorem exists_gt [NormalSpace X] (v : PartialRefinement u s (fun _ => True)) (hs : IsClosed s)
+    (i : ι) (hi : i ∉ v.carrier) :
+    ∃ v' : PartialRefinement u s (fun _ => True), v < v' := by
   have I : (s ∩ ⋂ (j) (_ : j ≠ i), (v j)ᶜ) ⊆ v i := by
     simp only [subset_def, mem_inter_iff, mem_iInter, and_imp]
     intro x hxs H
@@ -166,7 +175,7 @@ theorem exists_gt [NormalSpace X] (v : PartialRefinement u s) (hs : IsClosed s) 
     IsClosed.inter hs (isClosed_biInter fun _ _ => isClosed_compl_iff.2 <| v.isOpen _)
   rcases normal_exists_closure_subset C (v.isOpen i) I with ⟨vi, ovi, hvi, cvi⟩
   classical
-  refine ⟨⟨update v i vi, insert i v.carrier, ?_, ?_, ?_, ?_⟩, ?_, ?_⟩
+  refine ⟨⟨update v i vi, insert i v.carrier, ?_, ?_, ?_, ?_, ?_⟩, ?_, ?_⟩
   · intro j
     rcases eq_or_ne j i with (rfl| hne) <;> simp [*, v.isOpen]
   · refine fun x hx => mem_iUnion.2 ?_
@@ -181,6 +190,7 @@ theorem exists_gt [NormalSpace X] (v : PartialRefinement u s) (hs : IsClosed s) 
     · rwa [update_same, ← v.apply_eq hi]
     · rw [update_noteq (ne_of_mem_of_not_mem hj hi)]
       exact v.closure_subset hj
+  · exact fun _ => trivial
   · intro j hj
     rw [mem_insert_iff, not_or] at hj
     rw [update_noteq hj.1, v.apply_eq hj.2]
@@ -192,9 +202,11 @@ end PartialRefinement
 
 end ShrinkingLemma
 
+section NormalSpace
+
 open ShrinkingLemma
 
-variable {u : ι → Set X} {s : Set X} [NormalSpace X]
+variable {u : ι → Set X} {s : Set X} {p : Set X → Prop} [NormalSpace X]
 
 /-- **Shrinking lemma**. A point-finite open cover of a closed subset of a normal space can be
 "shrunk" to a new open cover so that the closure of each new open set is contained in the
@@ -202,8 +214,9 @@ corresponding original open set. -/
 theorem exists_subset_iUnion_closure_subset (hs : IsClosed s) (uo : ∀ i, IsOpen (u i))
     (uf : ∀ x ∈ s, { i | x ∈ u i }.Finite) (us : s ⊆ ⋃ i, u i) :
     ∃ v : ι → Set X, s ⊆ iUnion v ∧ (∀ i, IsOpen (v i)) ∧ ∀ i, closure (v i) ⊆ u i := by
-  haveI : Nonempty (PartialRefinement u s) := ⟨⟨u, ∅, uo, us, False.elim, fun _ => rfl⟩⟩
-  have : ∀ c : Set (PartialRefinement u s),
+  haveI : Nonempty (PartialRefinement u s (fun _ => True)) :=
+    ⟨⟨u, ∅, uo, us, False.elim, False.elim, fun _ => rfl⟩⟩
+  have : ∀ c : Set (PartialRefinement u s (fun _ => True)),
       IsChain (· ≤ ·) c → c.Nonempty → ∃ ub, ∀ v ∈ c, v ≤ ub :=
     fun c hc ne => ⟨.chainSup c hc ne uf us, fun v hv => PartialRefinement.le_chainSup _ _ _ _ hv⟩
   rcases zorn_le_nonempty this with ⟨v, hv⟩
@@ -240,3 +253,5 @@ theorem exists_iUnion_eq_closed_subset (uo : ∀ i, IsOpen (u i)) (uf : ∀ x, {
     ∃ v : ι → Set X, iUnion v = univ ∧ (∀ i, IsClosed (v i)) ∧ ∀ i, v i ⊆ u i :=
   let ⟨v, vU, hv⟩ := exists_subset_iUnion_closed_subset isClosed_univ uo (fun x _ => uf x) uU.ge
   ⟨v, univ_subset_iff.1 vU, hv⟩
+
+end NormalSpace

--- a/Mathlib/Topology/ShrinkingLemma.lean
+++ b/Mathlib/Topology/ShrinkingLemma.lean
@@ -158,7 +158,7 @@ theorem le_chainSup {c : Set (PartialRefinement u s p)} (hc : IsChain (· ≤ ·
 
 /-- If `s` is a closed set, `v` is a partial refinement, and `i` is an index such that
 `i ∉ v.carrier`, then there exists a partial refinement that is strictly greater than `v`. -/
-theorem exists_gt [NormalSpace X] (v : PartialRefinement u s (fun _ => True)) (hs : IsClosed s)
+theorem exists_gt [NormalSpace X] (v : PartialRefinement u s ⊤) (hs : IsClosed s)
     (i : ι) (hi : i ∉ v.carrier) :
     ∃ v' : PartialRefinement u s (fun _ => True), v < v' := by
   have I : (s ∩ ⋂ (j) (_ : j ≠ i), (v j)ᶜ) ⊆ v i := by


### PR DESCRIPTION
add a predicate `p : Set X  → Prop` for `PartialRefinent`. All the existing theorems remain valid by taking `fun _ => True` as `p`.

motivation: with this we can require that the refined open set has a compact closure, by taking `fun w => IsCompact (closure w)` as `p`. This can be applied when X is locally compact and T2, and we can obtain a `PartitionOfUnity` for an open cover of a compact set. (This will be done in #12266)

This splits from #12266 