### PR TITLE
[Merged by Bors] - fix: missed case in "ring-compare"

### DIFF
--- a/Mathlib/Tactic/Ring/Compare.lean
+++ b/Mathlib/Tactic/Ring/Compare.lean
@@ -148,7 +148,9 @@ def evalLE {v : Level} {α : Q(Type v)} (_ : Q(OrderedCommSemiring $α)) {a b : 
     let rxb := NormNum.Result.ofRawRat cb xb hypb
     let NormNum.Result.isTrue pf ← NormNum.evalLE.core lα rz rxb | return .error tooSmall
     pure <| .ok (q(le_add_of_nonneg_left (a := $a) $pf):)
-  | _, _ => return .error notComparable
+  | _, _ =>
+    unless va.eq vb do return .error notComparable
+    pure <| .ok (q(le_refl $a):)
 
 /-- In a commutative semiring, given `Ring.ExSum` objects `va`, `vb` which differ by a positive
 (additive) constant, construct a proof of `$a < $b`, where `a` (resp. `b`) is the expression in the

--- a/MathlibTest/ring_compare.lean
+++ b/MathlibTest/ring_compare.lean
@@ -13,6 +13,7 @@ variable {x y : ℕ}
 example : 3 ≤ (3:ℕ) := by ring_le
 example : 1 ≤ (3:ℕ) := by ring_le
 example : 0 ≤ (3:ℕ) + 1 := by ring_le
+example : x ≤ x := by ring_le
 example : x ≤ x + 3 := by ring_le
 example : x ≤ 1 + x := by ring_le
 example : x + y + 1 ≤ y + x + 3 := by ring_le


### PR DESCRIPTION
The "ring-based prover for certain inequalities in semirings" added in #16840 missed a case, which I noticed when I started experimenting with the new `linear_combination`-for-inequalities (for which it serves as the discharger).  Namely, it would not prove `e1 ≤ e2` if `e1` and `e2` ring-normalized to the same expression, *and that expression had no numeric constant term*.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
