### PR TITLE
chore: change some `linarith`s to `linear_combination`s

### DIFF
--- a/Archive/Imo/Imo1959Q2.lean
+++ b/Archive/Imo/Imo1959Q2.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Data.Real.Sqrt
+import Mathlib.Tactic.LinearCombination
 
 /-!
 # IMO 1959 Q2
@@ -39,7 +40,7 @@ theorem isGood_iff : IsGood x A ↔
     sqrt (2 * x - 1) + 1 + |sqrt (2 * x - 1) - 1| = A * sqrt 2 ∧ 1 / 2 ≤ x := by
   cases le_or_lt (1 / 2) x with
   | inl hx =>
-    have hx' : 0 ≤ 2 * x - 1 := by linarith
+    have hx' : 0 ≤ 2 * x - 1 := by linear_combination 2 * hx
     have h₁ : x + sqrt (2 * x - 1) = (sqrt (2 * x - 1) + 1) ^ 2 / 2 := by
       rw [add_sq, sq_sqrt hx']; field_simp; ring
     have h₂ : x - sqrt (2 * x - 1) = (sqrt (2 * x - 1) - 1) ^ 2 / 2 := by
@@ -49,7 +50,7 @@ theorem isGood_iff : IsGood x A ↔
     rw [sqrt_sq, sqrt_sq_eq_abs] <;> [skip; positivity]
     field_simp
   | inr hx =>
-    have : 2 * x - 1 < 0 := by linarith
+    have : 2 * x - 1 < 0 := by linear_combination 2 * hx
     simp only [IsGood, this.not_le, hx.not_le]; simp
 
 theorem IsGood.one_half_le (h : IsGood x A) : 1 / 2 ≤ x := (isGood_iff.1 h).2
@@ -66,7 +67,7 @@ theorem isGood_iff_eq_sqrt_two (hx : x ∈ Icc (1 / 2) 1) : IsGood x A ↔ A = s
 
 theorem isGood_iff_eq_sqrt (hx : 1 < x) : IsGood x A ↔ A = sqrt (4 * x - 2) := by
   have h₁ : 1 < sqrt (2 * x - 1) := by simpa only [← not_le, sqrt_two_mul_sub_one_le_one] using hx
-  have h₂ : 1 / 2 ≤ x := by linarith
+  have h₂ : 1 / 2 ≤ x := by linear_combination hx
   simp only [isGood_iff, h₂, abs_of_pos (sub_pos.2 h₁), add_add_sub_cancel, and_true]
   rw [← mul_two, ← div_eq_iff (by positivity), mul_div_assoc, div_sqrt, ← sqrt_mul' _ zero_le_two,
     eq_comm]
@@ -75,7 +76,7 @@ theorem isGood_iff_eq_sqrt (hx : 1 < x) : IsGood x A ↔ A = sqrt (4 * x - 2) :=
 theorem IsGood.sqrt_two_lt_of_one_lt (h : IsGood x A) (hx : 1 < x) : sqrt 2 < A := by
   rw [(isGood_iff_eq_sqrt hx).1 h]
   refine sqrt_lt_sqrt zero_le_two ?_
-  linarith
+  linear_combination 4 * hx
 
 theorem IsGood.eq_sqrt_two_iff_le_one (h : IsGood x A) : A = sqrt 2 ↔ x ≤ 1 :=
   ⟨fun hA ↦ not_lt.1 fun hx ↦ (h.sqrt_two_lt_of_one_lt hx).ne' hA, fun hx ↦

--- a/Archive/Imo/Imo1988Q6.lean
+++ b/Archive/Imo/Imo1988Q6.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Nat.Prime.Defs
 import Mathlib.Data.Rat.Defs
 import Mathlib.Order.WellFounded
 import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.Ring
 import Mathlib.Tactic.WLOG
 
@@ -225,7 +226,7 @@ theorem imo1988_q6 {a b : ℕ} (h : a * b + 1 ∣ a ^ 2 + b ^ 2) :
     calc
       x * x + x * x = x * x * 2 := by rw [mul_two]
       _ ≤ x * x * k := Nat.mul_le_mul_left (x * x) k_lt_one
-      _ < (x * x + 1) * k := by linarith
+      _ < (x * x + 1) * k := by linear_combination k_lt_one
   · -- Show the descent step.
     intro x y hx x_lt_y _ _ z h_root _ hV₀
     constructor

--- a/Archive/Imo/Imo2005Q3.lean
+++ b/Archive/Imo/Imo2005Q3.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Real.Basic
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.Ring
 
 /-!
@@ -38,7 +39,7 @@ theorem key_insight (x y z : ℝ) (hx : x > 0) (hy : y > 0) (hz : z > 0) (h : x 
         ((x ^ 5 + y ^ 2 + z ^ 2) * (x ^ 3 * (x ^ 2 + y ^ 2 + z ^ 2))) ≥ 0 := by positivity
   calc
     (x ^ 5 - x ^ 2) / (x ^ 5 + y ^ 2 + z ^ 2)
-      ≥ (x ^ 5 - x ^ 2 * 1) / (x ^ 3 * (x ^ 2 + y ^ 2 + z ^ 2)) := by linarith only [key, h₅]
+      ≥ (x ^ 5 - x ^ 2 * 1) / (x ^ 3 * (x ^ 2 + y ^ 2 + z ^ 2)) := by linear_combination h₅ - key
     _ ≥ (x ^ 5 - x ^ 2 * (x * y * z)) / (x ^ 3 * (x ^ 2 + y ^ 2 + z ^ 2)) := by gcongr
     _ = (x ^ 2 - y * z) / (x ^ 2 + y ^ 2 + z ^ 2) := by field_simp; ring
 

--- a/Archive/Imo/Imo2008Q2.lean
+++ b/Archive/Imo/Imo2008Q2.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.Set.Finite.Lattice
 import Mathlib.Tactic.Abel
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.Ring
 
 /-!
@@ -106,7 +107,7 @@ theorem imo2008_q2b : Set.Infinite rationalSolutions := by
             exact ⟨rfl, rfl, rfl⟩
         · have hg : -z = g (x, y, z) := rfl
           rw [hg, hz_def]; ring
-      have h₂ : q < t * (t + 1) := by linarith [sq_nonneg t, le_max_left (q + 1) 1]
+      have h₂ : q < t * (t + 1) := by linear_combination sq_nonneg t + le_max_left (q + 1) 1
       exact ⟨h₁, h₂⟩
     have hK_inf : Set.Infinite K := by intro h; apply hK_not_bdd; exact Set.Finite.bddAbove h
     exact hK_inf.of_image g

--- a/Archive/Imo/Imo2008Q3.lean
+++ b/Archive/Imo/Imo2008Q3.lean
@@ -61,12 +61,12 @@ theorem p_lemma (p : ℕ) (hpp : Nat.Prime p) (hp_mod_4_eq_1 : p ≡ 1 [MOD 4]) 
   have hreal₃ : (k : ℝ) ^ 2 + 4 ≥ p := by assumption_mod_cast
   have hreal₅ : (k : ℝ) > 4 := by
     refine lt_of_pow_lt_pow_left₀ 2 k.cast_nonneg ?_
-    linarith only [hreal₂, hreal₃]
+    linear_combination hreal₂ + hreal₃
   have hreal₆ : (k : ℝ) > sqrt (2 * n) := by
     refine lt_of_pow_lt_pow_left₀ 2 k.cast_nonneg ?_
     rw [sq_sqrt (mul_nonneg zero_le_two n.cast_nonneg)]
-    linarith only [hreal₁, hreal₃, hreal₅]
-  exact ⟨n, hnat₁, by linarith only [hreal₆, hreal₁]⟩
+    linear_combination hreal₁ + hreal₃ + hreal₅
+  exact ⟨n, hnat₁, by linear_combination hreal₆ + hreal₁⟩
 
 end Imo2008Q3
 
@@ -76,8 +76,8 @@ theorem imo2008_q3 : ∀ N : ℕ, ∃ n : ℕ, n ≥ N ∧
     ∃ p : ℕ, Nat.Prime p ∧ p ∣ n ^ 2 + 1 ∧ (p : ℝ) > 2 * n + sqrt (2 * n) := by
   intro N
   obtain ⟨p, hpp, hineq₁, hpmod4⟩ := Nat.exists_prime_gt_modEq_one (N ^ 2 + 20) four_ne_zero
-  obtain ⟨n, hnat, hreal⟩ := p_lemma p hpp hpmod4 (by linarith [hineq₁, Nat.zero_le (N ^ 2)])
+  obtain ⟨n, hnat, hreal⟩ := p_lemma p hpp hpmod4 (by linear_combination hineq₁ + sq_nonneg N)
   have hineq₂ : n ^ 2 + 1 ≥ p := Nat.le_of_dvd (n ^ 2).succ_pos hnat
-  have hineq₃ : n * n ≥ N * N := by linarith [hineq₁, hineq₂]
+  have hineq₃ : n * n ≥ N * N := by linear_combination hineq₁ + hineq₂
   have hn_ge_N : n ≥ N := Nat.mul_self_le_mul_self_iff.1 hineq₃
   exact ⟨n, hn_ge_N, p, hpp, hnat, hreal⟩

--- a/Archive/Imo/Imo2013Q5.lean
+++ b/Archive/Imo/Imo2013Q5.lean
@@ -65,10 +65,10 @@ theorem le_of_all_pow_lt_succ' {x y : ℝ} (hx : 1 < x) (hy : 0 < y)
   refine le_of_all_pow_lt_succ hx ?_ h
   by_contra! hy'' : y ≤ 1
   -- Then there exists y' such that 0 < y ≤ 1 < y' < x.
-  have h_y'_lt_x : (x + 1) / 2 < x := by linarith
-  have h1_lt_y' : 1 < (x + 1) / 2 := by linarith
+  have h_y'_lt_x : (x + 1) / 2 < x := by linear_combination hx / 2
+  have h1_lt_y' : 1 < (x + 1) / 2 := by linear_combination hx / 2
   set y' := (x + 1) / 2
-  have h_y_lt_y' : y < y' := by linarith
+  have h_y_lt_y' : y < y' := by linear_combination hy'' + h1_lt_y'
   have hh : ∀ n, 0 < n → x ^ n - 1 < y' ^ n := by
     intro n hn
     calc

--- a/Archive/Imo/Imo2021Q1.lean
+++ b/Archive/Imo/Imo2021Q1.lean
@@ -6,6 +6,7 @@ Authors: Mantas Bakšys
 import Mathlib.Order.Interval.Finset.Nat
 import Mathlib.Tactic.IntervalCases
 import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
 
 /-!
 # IMO 2021 Q1
@@ -58,7 +59,7 @@ lemma exists_numbers_in_interval {n : ℕ} (hn : 100 ≤ n) :
   refine ⟨l, ?_, ?_⟩
   · calc n + 4 * l ≤ (l ^ 2 + 4 * l + 2) + 4 * l := by linarith only [h₂]
       _ ≤ 2 * l ^ 2 := by nlinarith only [h₃]
-  · linarith only [h₁]
+  · linear_combination 2 * h₁
 
 lemma exists_triplet_summing_to_squares {n : ℕ} (hn : 100 ≤ n) :
     ∃ a b c : ℕ, n ≤ a ∧ a < b ∧ b < c ∧ c ≤ 2 * n ∧

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -901,7 +901,7 @@ theorem HasFPowerSeriesWithinOnBall.tendsto_partialSum_prod {y : E}
     gcongr
     · exact I _ h'z
     · simp only [norm_neg]; exact I _ yr'
-  _ < ε := by linarith
+  _ < ε := by linear_combination εpos / 4
 
 /-- If a function admits a power series on a ball, then the partial sums
 `p.partialSum n z` converges to `f (x + y)` as `n → ∞` and `z → y`. -/

--- a/Mathlib/Analysis/Analytic/Inverse.lean
+++ b/Mathlib/Analysis/Analytic/Inverse.lean
@@ -527,7 +527,7 @@ theorem radius_rightInv_pos_of_radius_pos
           gcongr
           · simp only [sub_le_self_iff]
             positivity
-          · linarith only [rSn]
+          · linear_combination rSn
         _ = I * a + 2 * I * C * (r * S n) ^ 2 := by ring
         _ ≤ I * a + 2 * I * C * (r * ((I + 1) * a)) ^ 2 := by gcongr
         _ = (I + 2 * I * C * r ^ 2 * (I + 1) ^ 2 * a) * a := by ring

--- a/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
@@ -344,7 +344,7 @@ theorem y_eq_one_of_mem_closedBall {D : ℝ} {x : E} (Dpos : 0 < D)
     have C : ball x D ⊆ ball 0 1 := by
       apply ball_subset_ball'
       simp only [mem_closedBall] at hx
-      linarith only [hx]
+      linear_combination hx
     intro y hy
     simp only [φ, indicator, mem_closedBall, ite_eq_left_iff, not_le, zero_ne_one]
     intro h'y
@@ -429,7 +429,7 @@ theorem y_pos_of_mem_ball {D : ℝ} {x : E} (Dpos : 0 < D) (D_lt_one : D < 1)
         nlinarith only [hx, D_lt_one]
     apply lt_of_lt_of_le _ (measure_mono C)
     apply measure_ball_pos
-    exact div_pos (mul_pos Dpos (by linarith only [hx])) B
+    exact div_pos (mul_pos Dpos (by linear_combination hx)) B
 
 variable (E)
 

--- a/Mathlib/Analysis/Complex/AbelLimit.lean
+++ b/Mathlib/Analysis/Complex/AbelLimit.lean
@@ -225,7 +225,7 @@ theorem tendsto_tsum_powerSeries_nhdsWithin_stolzSet
           (summable_geometric_of_lt_one (by positivity) zn)
       _ = ‖1 - z‖ * (ε / 4 / M) / (1 - ‖z‖) := by
         rw [tsum_geometric_of_lt_one (by positivity) zn, ← div_eq_mul_inv]
-      _ < M * (1 - ‖z‖) * (ε / 4 / M) / (1 - ‖z‖) := by gcongr; linarith only [zn]
+      _ < M * (1 - ‖z‖) * (ε / 4 / M) / (1 - ‖z‖) := by gcongr; linear_combination zn
       _ = _ := by
         rw [← mul_rotate, mul_div_cancel_right₀ _ (by linarith only [zn]),
           div_mul_cancel₀ _ (by linarith only [hM])]

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -484,11 +484,11 @@ theorem Convex_subadditive_le [SMul 𝕜 E] {f : E → 𝕜} (hf1 : ∀ x y, f (
     Convex 𝕜 { x | f x ≤ B } := by
   rw [convex_iff_segment_subset]
   rintro x hx y hy z ⟨a, b, ha, hb, hs, rfl⟩
-  calc
-    _ ≤ a • (f x) + b • (f y) := le_trans (hf1 _ _) (add_le_add (hf2 x ha) (hf2 y hb))
-    _ ≤ a • B + b • B :=
-        add_le_add (smul_le_smul_of_nonneg_left hx ha) (smul_le_smul_of_nonneg_left hy hb)
-    _ ≤ B := by rw [← add_smul, hs, one_smul]
+  dsimp at hx hy ⊢
+  linear_combination (norm := skip)
+    hf1 (a • x) (b • y) + hf2 x ha + hf2 y hb + a * hx + b * hy + hs * B
+  apply le_of_eq
+  noncomm_ring [smul_eq_mul]
 
 end LinearOrderedRing
 

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -484,11 +484,11 @@ theorem Convex_subadditive_le [SMul 𝕜 E] {f : E → 𝕜} (hf1 : ∀ x y, f (
     Convex 𝕜 { x | f x ≤ B } := by
   rw [convex_iff_segment_subset]
   rintro x hx y hy z ⟨a, b, ha, hb, hs, rfl⟩
-  dsimp at hx hy ⊢
-  linear_combination (norm := skip)
-    hf1 (a • x) (b • y) + hf2 x ha + hf2 y hb + a * hx + b * hy + hs * B
-  apply le_of_eq
-  noncomm_ring [smul_eq_mul]
+  calc
+    _ ≤ a • (f x) + b • (f y) := le_trans (hf1 _ _) (add_le_add (hf2 x ha) (hf2 y hb))
+    _ ≤ a • B + b • B :=
+        add_le_add (smul_le_smul_of_nonneg_left hx ha) (smul_le_smul_of_nonneg_left hy hb)
+    _ ≤ B := by rw [← add_smul, hs, one_smul]
 
 end LinearOrderedRing
 

--- a/Mathlib/Analysis/Convex/Gauge.lean
+++ b/Mathlib/Analysis/Convex/Gauge.lean
@@ -187,7 +187,7 @@ theorem gauge_add_le (hs : Convex ℝ s) (absorbs : Absorbent ℝ s) (x y : E) :
     gauge s (a • x + b • y) ≤ a + b := gauge_le_of_mem (by positivity) <| by
       rw [hs.add_smul ha.le hb.le]
       exact add_mem_add (smul_mem_smul_set hx) (smul_mem_smul_set hy)
-    _ < gauge s (a • x) + gauge s (b • y) + ε := by linarith
+    _ < gauge s (a • x) + gauge s (b • y) + ε := by linear_combination ha' + hb'
 
 theorem self_subset_gauge_le_one : s ⊆ { x | gauge s x ≤ 1 } := fun _ => gauge_le_one_of_mem
 

--- a/Mathlib/Analysis/Convex/Slope.lean
+++ b/Mathlib/Analysis/Convex/Slope.lean
@@ -25,9 +25,7 @@ theorem ConvexOn.slope_mono_adjacent (hf : ConvexOn 𝕜 s f) {x y z : 𝕜} (hx
     (hxy : x < y) (hyz : y < z) : (f y - f x) / (y - x) ≤ (f z - f y) / (z - y) := by
   have hxz := hxy.trans hyz
   rw [← sub_pos] at hxy hxz hyz
-  suffices f y / (y - x) + f y / (z - y) ≤ f x / (y - x) + f z / (z - y) by
-    ring_nf at this ⊢
-    linarith
+  suffices f y / (y - x) + f y / (z - y) ≤ f x / (y - x) + f z / (z - y) by linear_combination this
   set a := (z - y) / (z - x)
   set b := (y - x) / (z - x)
   have hy : a • x + b • z = y := by field_simp [a, b]; ring
@@ -39,7 +37,7 @@ theorem ConvexOn.slope_mono_adjacent (hf : ConvexOn 𝕜 s f) {x y z : 𝕜} (hx
   replace key := mul_le_mul_of_nonneg_left key hxz.le
   field_simp [a, b, mul_comm (z - x) _] at key ⊢
   rw [div_le_div_iff_of_pos_right]
-  · linarith
+  · linear_combination key
   · positivity
 
 /-- If `f : 𝕜 → 𝕜` is concave, then for any three points `x < y < z` the slope of the secant line of
@@ -59,9 +57,7 @@ theorem StrictConvexOn.slope_strict_mono_adjacent (hf : StrictConvexOn 𝕜 s f)
   have hxz := hxy.trans hyz
   have hxz' := hxz.ne
   rw [← sub_pos] at hxy hxz hyz
-  suffices f y / (y - x) + f y / (z - y) < f x / (y - x) + f z / (z - y) by
-    ring_nf at this ⊢
-    linarith
+  suffices f y / (y - x) + f y / (z - y) < f x / (y - x) + f z / (z - y) by linear_combination this
   set a := (z - y) / (z - x)
   set b := (y - x) / (z - x)
   have hy : a • x + b • z = y := by field_simp [a, b]; ring
@@ -72,7 +68,7 @@ theorem StrictConvexOn.slope_strict_mono_adjacent (hf : StrictConvexOn 𝕜 s f)
   replace key := mul_lt_mul_of_pos_left key hxz
   field_simp [mul_comm (z - x) _] at key ⊢
   rw [div_lt_div_iff_of_pos_right]
-  · linarith
+  · linear_combination key
   · positivity
 
 /-- If `f : 𝕜 → 𝕜` is strictly concave, then for any three points `x < y < z` the slope of the
@@ -218,9 +214,9 @@ theorem strictConcaveOn_iff_slope_strict_anti_adjacent :
 
 theorem ConvexOn.secant_mono_aux1 (hf : ConvexOn 𝕜 s f) {x y z : 𝕜} (hx : x ∈ s) (hz : z ∈ s)
     (hxy : x < y) (hyz : y < z) : (z - x) * f y ≤ (z - y) * f x + (y - x) * f z := by
-  have hxy' : 0 < y - x := by linarith
-  have hyz' : 0 < z - y := by linarith
-  have hxz' : 0 < z - x := by linarith
+  have hxy' : 0 < y - x := by linear_combination hxy
+  have hyz' : 0 < z - y := by linear_combination hyz
+  have hxz' : 0 < z - x := by linear_combination hxy + hyz
   rw [← le_div_iff₀' hxz']
   have ha : 0 ≤ (z - y) / (z - x) := by positivity
   have hb : 0 ≤ (y - x) / (z - x) := by positivity
@@ -236,17 +232,17 @@ theorem ConvexOn.secant_mono_aux1 (hf : ConvexOn 𝕜 s f) {x y z : 𝕜} (hx : 
 
 theorem ConvexOn.secant_mono_aux2 (hf : ConvexOn 𝕜 s f) {x y z : 𝕜} (hx : x ∈ s) (hz : z ∈ s)
     (hxy : x < y) (hyz : y < z) : (f y - f x) / (y - x) ≤ (f z - f x) / (z - x) := by
-  have hxy' : 0 < y - x := by linarith
-  have hxz' : 0 < z - x := by linarith
+  have hxy' : 0 < y - x := by linear_combination hxy
+  have hxz' : 0 < z - x := by linear_combination hxy + hyz
   rw [div_le_div_iff₀ hxy' hxz']
-  linarith only [hf.secant_mono_aux1 hx hz hxy hyz]
+  linear_combination hf.secant_mono_aux1 hx hz hxy hyz
 
 theorem ConvexOn.secant_mono_aux3 (hf : ConvexOn 𝕜 s f) {x y z : 𝕜} (hx : x ∈ s) (hz : z ∈ s)
     (hxy : x < y) (hyz : y < z) : (f z - f x) / (z - x) ≤ (f z - f y) / (z - y) := by
-  have hyz' : 0 < z - y := by linarith
-  have hxz' : 0 < z - x := by linarith
+  have hyz' : 0 < z - y := by linear_combination hyz
+  have hxz' : 0 < z - x := by linear_combination hxy + hyz
   rw [div_le_div_iff₀ hxz' hyz']
-  linarith only [hf.secant_mono_aux1 hx hz hxy hyz]
+  linear_combination hf.secant_mono_aux1 hx hz hxy hyz
 
 /-- If `f : 𝕜 → 𝕜` is convex, then for any point `a` the slope of the secant line of `f` through `a`
 and `b ≠ a` is monotone with respect to `b`. -/
@@ -264,9 +260,9 @@ theorem ConvexOn.secant_mono (hf : ConvexOn 𝕜 s f) {a x y : 𝕜} (ha : a ∈
 
 theorem StrictConvexOn.secant_strict_mono_aux1 (hf : StrictConvexOn 𝕜 s f) {x y z : 𝕜} (hx : x ∈ s)
     (hz : z ∈ s) (hxy : x < y) (hyz : y < z) : (z - x) * f y < (z - y) * f x + (y - x) * f z := by
-  have hxy' : 0 < y - x := by linarith
-  have hyz' : 0 < z - y := by linarith
-  have hxz' : 0 < z - x := by linarith
+  have hxy' : 0 < y - x := by linear_combination hxy
+  have hyz' : 0 < z - y := by linear_combination hyz
+  have hxz' : 0 < z - x := by linear_combination hxy + hyz
   rw [← lt_div_iff₀' hxz']
   have ha : 0 < (z - y) / (z - x) := by positivity
   have hb : 0 < (y - x) / (z - x) := by positivity
@@ -282,17 +278,17 @@ theorem StrictConvexOn.secant_strict_mono_aux1 (hf : StrictConvexOn 𝕜 s f) {x
 
 theorem StrictConvexOn.secant_strict_mono_aux2 (hf : StrictConvexOn 𝕜 s f) {x y z : 𝕜} (hx : x ∈ s)
     (hz : z ∈ s) (hxy : x < y) (hyz : y < z) : (f y - f x) / (y - x) < (f z - f x) / (z - x) := by
-  have hxy' : 0 < y - x := by linarith
-  have hxz' : 0 < z - x := by linarith
+  have hxy' : 0 < y - x := by linear_combination hxy
+  have hxz' : 0 < z - x := by linear_combination hxy + hyz
   rw [div_lt_div_iff₀ hxy' hxz']
-  linarith only [hf.secant_strict_mono_aux1 hx hz hxy hyz]
+  linear_combination hf.secant_strict_mono_aux1 hx hz hxy hyz
 
 theorem StrictConvexOn.secant_strict_mono_aux3 (hf : StrictConvexOn 𝕜 s f) {x y z : 𝕜} (hx : x ∈ s)
     (hz : z ∈ s) (hxy : x < y) (hyz : y < z) : (f z - f x) / (z - x) < (f z - f y) / (z - y) := by
-  have hyz' : 0 < z - y := by linarith
-  have hxz' : 0 < z - x := by linarith
+  have hyz' : 0 < z - y := by linear_combination hyz
+  have hxz' : 0 < z - x := by linear_combination hxy + hyz
   rw [div_lt_div_iff₀ hxz' hyz']
-  linarith only [hf.secant_strict_mono_aux1 hx hz hxy hyz]
+  linear_combination hf.secant_strict_mono_aux1 hx hz hxy hyz
 
 /-- If `f : 𝕜 → 𝕜` is strictly convex, then for any point `a` the slope of the secant line of `f`
 through `a` and `b` is strictly monotone with respect to `b`. -/

--- a/Mathlib/Analysis/Convex/SpecificFunctions/Basic.lean
+++ b/Mathlib/Analysis/Convex/SpecificFunctions/Basic.lean
@@ -38,15 +38,15 @@ theorem strictConvexOn_exp : StrictConvexOn ℝ univ exp := by
   apply strictConvexOn_of_slope_strict_mono_adjacent convex_univ
   rintro x y z - - hxy hyz
   trans exp y
-  · have h1 : 0 < y - x := by linarith
-    have h2 : x - y < 0 := by linarith
+  · have h1 : 0 < y - x := by linear_combination hxy
+    have h2 : x - y < 0 := by linear_combination hxy
     rw [div_lt_iff₀ h1]
     calc
       exp y - exp x = exp y - exp y * exp (x - y) := by rw [← exp_add]; ring_nf
       _ = exp y * (1 - exp (x - y)) := by ring
       _ < exp y * -(x - y) := by gcongr; linarith [add_one_lt_exp h2.ne]
       _ = exp y * (y - x) := by ring
-  · have h1 : 0 < z - y := by linarith
+  · have h1 : 0 < z - y := by linear_combination hyz
     rw [lt_div_iff₀ h1]
     calc
       exp y * (z - y) < exp y * (exp (z - y) - 1) := by
@@ -65,7 +65,7 @@ theorem strictConcaveOn_log_Ioi : StrictConcaveOn ℝ (Ioi 0) log := by
   intro x y z (hx : 0 < x) (hz : 0 < z) hxy hyz
   have hy : 0 < y := hx.trans hxy
   trans y⁻¹
-  · have h : 0 < z - y := by linarith
+  · have h : 0 < z - y := by linear_combination hyz
     rw [div_lt_iff₀ h]
     have hyz' : 0 < z / y := by positivity
     have hyz'' : z / y ≠ 1 := by
@@ -76,7 +76,7 @@ theorem strictConcaveOn_log_Ioi : StrictConcaveOn ℝ (Ioi 0) log := by
       log z - log y = log (z / y) := by rw [← log_div hz.ne' hy.ne']
       _ < z / y - 1 := log_lt_sub_one_of_pos hyz' hyz''
       _ = y⁻¹ * (z - y) := by field_simp
-  · have h : 0 < y - x := by linarith
+  · have h : 0 < y - x := by linear_combination hxy
     rw [lt_div_iff₀ h]
     have hxy' : 0 < x / y := by positivity
     have hxy'' : x / y ≠ 1 := by
@@ -204,9 +204,9 @@ theorem convexOn_rpow {p : ℝ} (hp : 1 ≤ p) : ConvexOn ℝ (Ici 0) fun x : �
 theorem strictConcaveOn_log_Iio : StrictConcaveOn ℝ (Iio 0) log := by
   refine ⟨convex_Iio _, ?_⟩
   intro x (hx : x < 0) y (hy : y < 0) hxy a b ha hb hab
-  have hx' : 0 < -x := by linarith
-  have hy' : 0 < -y := by linarith
-  have hxy' : -x ≠ -y := by contrapose! hxy; linarith
+  have hx' : 0 < -x := by linear_combination hx
+  have hy' : 0 < -y := by linear_combination hy
+  have hxy' : -x ≠ -y := by contrapose! hxy; linear_combination -hxy
   calc
     a • log x + b • log y = a • log (-x) + b • log (-y) := by simp_rw [log_neg_eq_log]
     _ < log (a • -x + b • -y) := strictConcaveOn_log_Ioi.2 hx' hy' hxy' ha hb hab

--- a/Mathlib/Analysis/Convex/Uniform.lean
+++ b/Mathlib/Analysis/Convex/Uniform.lean
@@ -96,7 +96,7 @@ theorem exists_forall_closed_ball_dist_add_le_two_sub (hε : 0 < ε) :
     _ ≤ 2 - δ + δ' + δ' :=
       (add_le_add_three (h (h₁ _ hx') (h₁ _ hy') hxy') (h₂ _ hx hx'.le) (h₂ _ hy hy'.le))
     _ ≤ 2 - δ' := by
-      suffices δ' ≤ δ / 3 by linarith
+      suffices δ' ≤ δ / 3 by linear_combination 3 * this
       exact min_le_of_right_le <| min_le_right _ _
 
 theorem exists_forall_closed_ball_dist_add_le_two_mul_sub (hε : 0 < ε) (r : ℝ) :

--- a/Mathlib/Analysis/Convex/Visible.lean
+++ b/Mathlib/Analysis/Convex/Visible.lean
@@ -76,8 +76,8 @@ lemma IsVisible.of_convexHull_of_pos {ι : Type*} {t : Finset ι} {a : ι → V}
   rintro _ hε ⟨⟨ε, ⟨hε₀, hε₁⟩, rfl⟩, h⟩
   replace hε₀ : 0 < ε := hε₀.lt_of_ne <| by rintro rfl; simp at h
   replace hε₁ : ε < 1 := hε₁.lt_of_ne <| by rintro rfl; simp at h
-  have : 0 < 1 - ε := by linarith
-  have hwi : 0 < 1 - w i := by linarith
+  have : 0 < 1 - ε := by linear_combination hε₁
+  have hwi : 0 < 1 - w i := by linear_combination hwi
   refine hw (z := lineMap x (∑ j ∈ t, w j • a j) ((w i)⁻¹ / ((1 - ε) / ε + (w i)⁻¹)))
     ?_ <| sbtw_lineMap_iff.2 ⟨(ne_of_mem_of_not_mem ((convex_convexHull ..).sum_mem hw₀ hw₁
     fun i hi ↦ subset_convexHull _ _ <| ha _ hi) hx).symm, by positivity,

--- a/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
+++ b/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
@@ -146,7 +146,7 @@ theorem T_insert_le_T_lmarginal_singleton [∀ i, SigmaFinite (μ i)] (hp₀ : 0
     fun {_} ↦ hf.lmarginal μ |>.comp <| measurable_update _
   have hF₀ : Measurable fun t ↦ f (X t) := hf.comp <| measurable_update _
   let k : ℝ := s.card
-  have hk' : 0 ≤ 1 - k * p := by linarith only [hp]
+  have hk' : 0 ≤ 1 - k * p := by linear_combination hp
   calc ∫⁻ t, f (X t) ^ (1 - k * p)
           * ∏ j in (insert i s), (∫⋯∫⁻_{j}, f ∂μ) (X t) ^ p ∂ (μ i)
       = ∫⁻ t, (∫⋯∫⁻_{i}, f ∂μ) (X t) ^ p * (f (X t) ^ (1 - k * p)
@@ -275,7 +275,7 @@ theorem lintegral_prod_lintegral_pow_le [Fintype ι] [∀ i, SigmaFinite (μ i)]
   have : Nontrivial ι :=
     Fintype.one_lt_card_iff_nontrivial.mp (by exact_mod_cast hp.one_lt)
   have h0 : (1 : ℝ) < #ι := by norm_cast; exact Fintype.one_lt_card
-  have h1 : (0 : ℝ) < #ι - 1 := by linarith
+  have h1 : (0 : ℝ) < #ι - 1 := by linear_combination h0
   have h2 : 0 ≤ ((1 : ℝ) / (#ι - 1 : ℝ)) := by positivity
   have h3 : (#ι - 1 : ℝ) * ((1 : ℝ) / (#ι - 1 : ℝ)) ≤ 1 := by field_simp
   have h4 : p = 1 + 1 / (↑#ι - 1) := by field_simp; rw [mul_comm, hp.sub_one_mul_conj]

--- a/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
@@ -416,7 +416,7 @@ theorem exists_seq_norm_le_one_le_norm_sub' {c : 𝕜} (hc : 1 < ‖c‖) {R : �
 theorem exists_seq_norm_le_one_le_norm_sub (h : ¬FiniteDimensional 𝕜 E) :
     ∃ (R : ℝ) (f : ℕ → E), 1 < R ∧ (∀ n, ‖f n‖ ≤ R) ∧ Pairwise fun m n => 1 ≤ ‖f m - f n‖ := by
   obtain ⟨c, hc⟩ : ∃ c : 𝕜, 1 < ‖c‖ := NormedField.exists_one_lt_norm 𝕜
-  have A : ‖c‖ < ‖c‖ + 1 := by linarith
+  have A : ‖c‖ < ‖c‖ + 1 := by linear_combination
   rcases exists_seq_norm_le_one_le_norm_sub' hc A h with ⟨f, hf⟩
   exact ⟨‖c‖ + 1, f, hc.trans A, hf.1, hf.2⟩
 

--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -388,7 +388,7 @@ theorem sum_Ioc_inv_sq_le_sub {k n : ℕ} (hk : k ≠ 0) (h : k ≤ n) :
   have A : 0 < (n : α) := by simpa using hk.bot_lt.trans_le hn
   field_simp
   rw [div_le_div_iff₀ _ A]
-  · linarith
+  · linear_combination A
   · positivity
 
 theorem sum_Ioo_inv_sq_le (k n : ℕ) : (∑ i ∈ Ioo k n, (i ^ 2 : α)⁻¹) ≤ 2 / (k + 1) :=

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
@@ -56,7 +56,7 @@ theorem Gamma_mul_add_mul_le_rpow_Gamma_mul_rpow_Gamma {s t a b : ℝ} (hs : 0 <
   -- and `q = 1 / b`, to the functions `f a s` and `f b t`, where `f` is as follows:
   let f : ℝ → ℝ → ℝ → ℝ := fun c u x => exp (-c * x) * x ^ (c * (u - 1))
   have e : IsConjExponent (1 / a) (1 / b) := Real.isConjExponent_one_div ha hb hab
-  have hab' : b = 1 - a := by linarith
+  have hab' : b = 1 - a := by linear_combination hab
   have hst : 0 < a * s + b * t := by positivity
   -- some properties of f:
   have posf : ∀ c u x : ℝ, x ∈ Ioi (0 : ℝ) → 0 ≤ f c u x := fun c u x hx =>
@@ -108,7 +108,7 @@ theorem Gamma_mul_add_mul_le_rpow_Gamma_mul_rpow_Gamma {s t a b : ℝ} (hs : 0 <
 
 theorem convexOn_log_Gamma : ConvexOn ℝ (Ioi 0) (log ∘ Gamma) := by
   refine convexOn_iff_forall_pos.mpr ⟨convex_Ioi _, fun x hx y hy a b ha hb hab => ?_⟩
-  have : b = 1 - a := by linarith
+  have : b = 1 - a := by linear_combination hab
   subst this
   simp_rw [Function.comp_apply, smul_eq_mul]
   simp only [mem_Ioi] at hx hy

--- a/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -149,7 +149,7 @@ theorem log_pos (hx : 1 < x) : 0 < log x :=
 
 theorem log_pos_of_lt_neg_one (hx : x < -1) : 0 < log x := by
   rw [← neg_neg x, log_neg_eq_log]
-  have : 1 < -x := by linarith
+  have : 1 < -x := by linear_combination hx
   exact log_pos this
 
 theorem log_neg_iff (h : 0 < x) : log x < 0 ↔ x < 1 := by
@@ -162,8 +162,8 @@ theorem log_neg (h0 : 0 < x) (h1 : x < 1) : log x < 0 :=
 
 theorem log_neg_of_lt_zero (h0 : x < 0) (h1 : -1 < x) : log x < 0 := by
   rw [← neg_neg x, log_neg_eq_log]
-  have h0' : 0 < -x := by linarith
-  have h1' : -x < 1 := by linarith
+  have h0' : 0 < -x := by linear_combination h0
+  have h1' : -x < 1 := by linear_combination h1
   exact log_neg h0' h1'
 
 theorem log_nonneg_iff (hx : 0 < x) : 0 ≤ log x ↔ 1 ≤ x := by rw [← not_lt, log_neg_iff hx, not_lt]
@@ -285,7 +285,7 @@ lemma one_sub_inv_le_log_of_pos (hx : 0 < x) : 1 - x⁻¹ ≤ log x := by
 lemma log_le_self (hx : 0 ≤ x) : log x ≤ x := by
   obtain rfl | hx := hx.eq_or_lt
   · simp
-  · exact (log_le_sub_one_of_pos hx).trans (by linarith)
+  · exact (log_le_sub_one_of_pos hx).trans (by linear_combination)
 
 /-- See `Real.one_sub_inv_le_log_of_pos` for the stronger version when `x ≠ 0`. -/
 lemma neg_inv_le_log (hx : 0 ≤ x) : -x⁻¹ ≤ log x := by
@@ -295,7 +295,7 @@ lemma neg_inv_le_log (hx : 0 ≤ x) : -x⁻¹ ≤ log x := by
 theorem abs_log_mul_self_lt (x : ℝ) (h1 : 0 < x) (h2 : x ≤ 1) : |log x * x| < 1 := by
   have : 0 < 1 / x := by simpa only [one_div, inv_pos] using h1
   replace := log_le_sub_one_of_pos this
-  replace : log (1 / x) < 1 / x := by linarith
+  replace : log (1 / x) < 1 / x := by linear_combination this
   rw [log_div one_ne_zero h1.ne', log_one, zero_sub, lt_div_iff₀ h1] at this
   have aux : 0 ≤ -log x * x := by
     refine mul_nonneg ?_ h1.le

--- a/Mathlib/Analysis/SpecialFunctions/Log/Monotone.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Monotone.lean
@@ -52,7 +52,7 @@ theorem log_div_self_rpow_antitoneOn {a : ℝ} (ha : 0 < a) :
   simp only [AntitoneOn, mem_setOf_eq]
   intro x hex y _ hxy
   have x_pos : 0 < x := lt_of_lt_of_le (exp_pos (1 / a)) hex
-  have y_pos : 0 < y := by linarith
+  have y_pos : 0 < y := by linear_combination x_pos + hxy
   nth_rw 1 [← rpow_one y]
   nth_rw 1 [← rpow_one x]
   rw [← div_self (ne_of_lt ha).symm, div_eq_mul_one_div a a, rpow_mul y_pos.le, rpow_mul x_pos.le,

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -593,7 +593,7 @@ theorem tendsto_one_plus_div_rpow_exp (t : ℝ) :
   have h₂ : Tendsto (fun x : ℝ => 1 + t / x) atTop (𝓝 1) := by
     simpa using (tendsto_inv_atTop_zero.const_mul t).const_add 1
   refine (h₂.eventually_const_le h₁).mono fun x hx => ?_
-  have hx' : 0 < 1 + t / x := by linarith
+  have hx' : 0 < 1 + t / x := by linear_combination hx
   simp [mul_comm x, exp_mul, exp_log hx']
 
 /-- The function `(1 + t/x) ^ x` tends to `exp t` at `+∞` for naturals `x`. -/

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -879,7 +879,7 @@ lemma norm_prime_cpow_le_one_half (p : Nat.Primes) {s : ℂ} (hs : 1 < s.re) :
     ‖(p : ℂ) ^ (-s)‖ ≤ 1 / 2 := by
   rw [norm_natCast_cpow_of_re_ne_zero p <| by rw [neg_re]; linarith only [hs]]
   refine (Real.rpow_le_rpow_of_nonpos zero_lt_two (Nat.cast_le.mpr p.prop.two_le) <|
-    by rw [neg_re]; linarith only [hs]).trans ?_
+    by rw [neg_re]; linear_combination hs).trans ?_
   rw [one_div, ← Real.rpow_neg_one]
   exact Real.rpow_le_rpow_of_exponent_le one_le_two <| (neg_lt_neg hs).le
 

--- a/Mathlib/Analysis/SpecificLimits/FloorPow.lean
+++ b/Mathlib/Analysis/SpecificLimits/FloorPow.lean
@@ -92,7 +92,7 @@ theorem tendsto_div_of_monotone_of_exists_subseq_tendsto_div (u : ℕ → ℝ) (
       _ ≤ ε * c N + ε * c (N - 1) * l := by
         gcongr
         · exact (ha N (a.le_succ.trans aN)).2
-        · linarith only [IcN]
+        · linear_combination IcN
       _ ≤ ε * ((1 + ε) * c (N - 1)) + ε * c (N - 1) * l := by gcongr
       _ = ε * (1 + ε + l) * c (N - 1) := by ring
       _ ≤ ε * (1 + ε + l) * n := by gcongr
@@ -161,10 +161,10 @@ theorem tendsto_div_of_monotone_of_exists_subseq_tendsto_div (u : ℕ → ℝ) (
     calc
       d < (n : ℝ)⁻¹ * n * (l - ε * (1 + l)) := by
         rw [inv_mul_cancel₀, one_mul]
-        · linarith only [hε]
+        · linear_combination hε
         · exact Nat.cast_ne_zero.2 (ne_of_gt npos)
       _ = (n : ℝ)⁻¹ * (n * l - ε * (1 + l) * n) := by ring
-      _ ≤ (n : ℝ)⁻¹ * u n := by gcongr; linarith only [hn]
+      _ ≤ (n : ℝ)⁻¹ * u n := by gcongr; linear_combination hn
   · obtain ⟨ε, hε, εpos⟩ : ∃ ε : ℝ, l + ε * (1 + ε + l) < d ∧ 0 < ε := by
       have L : Tendsto (fun ε => l + ε * (1 + ε + l)) (𝓝[>] 0) (𝓝 (l + 0 * (1 + 0 + l))) := by
         apply Tendsto.mono_left _ nhdsWithin_le_nhds
@@ -175,7 +175,7 @@ theorem tendsto_div_of_monotone_of_exists_subseq_tendsto_div (u : ℕ → ℝ) (
       exact (((tendsto_order.1 L).2 d hd).and self_mem_nhdsWithin).exists
     filter_upwards [A ε εpos, Ioi_mem_atTop 0] with n hn (npos : 0 < n)
     calc
-      u n / n ≤ (n * l + ε * (1 + ε + l) * n) / n := by gcongr; linarith only [hn]
+      u n / n ≤ (n * l + ε * (1 + ε + l) * n) / n := by gcongr; linear_combination hn
       _ = (l + ε * (1 + ε + l)) := by field_simp; ring
       _ < d := hε
 

--- a/Mathlib/MeasureTheory/Covering/BesicovitchVectorSpace.lean
+++ b/Mathlib/MeasureTheory/Covering/BesicovitchVectorSpace.lean
@@ -310,17 +310,17 @@ theorem exists_normalized_aux1 {N : ℕ} {τ : ℝ} (a : SatelliteConfig E N τ)
       Pairwise fun i j => a.r i ≤ ‖a.c i - a.c j‖ ∧ a.r j ≤ τ * a.r i ∨
         a.r j ≤ ‖a.c j - a.c i‖ ∧ a.r i ≤ τ * a.r j := by
     simpa only [dist_eq_norm] using a.h
-  have δnonneg : 0 ≤ δ := by linarith only [hτ, hδ1]
-  have D : 0 ≤ 1 - δ / 4 := by linarith only [hδ2]
+  have δnonneg : 0 ≤ δ := by linear_combination 4 * (hτ + hδ1)
+  have D : 0 ≤ 1 - δ / 4 := by linear_combination hδ2 / 4
   have τpos : 0 < τ := _root_.zero_lt_one.trans_le hτ
   have I : (1 - δ / 4) * τ ≤ 1 :=
     calc
       (1 - δ / 4) * τ ≤ (1 - δ / 4) * (1 + δ / 4) := by gcongr
       _ = (1 : ℝ) - δ ^ 2 / 16 := by ring
-      _ ≤ 1 := by linarith only [sq_nonneg δ]
-  have J : 1 - δ ≤ 1 - δ / 4 := by linarith only [δnonneg]
+      _ ≤ 1 := by linear_combination sq_nonneg δ / 16
+  have J : 1 - δ ≤ 1 - δ / 4 := by linear_combination 3 / 4 * δnonneg
   have K : 1 - δ / 4 ≤ τ⁻¹ := by rw [inv_eq_one_div, le_div_iff₀ τpos]; exact I
-  suffices L : τ⁻¹ ≤ ‖a.c i - a.c j‖ by linarith only [J, K, L]
+  suffices L : τ⁻¹ ≤ ‖a.c i - a.c j‖ by linear_combination J + K + L
   have hτ' : ∀ k, τ⁻¹ ≤ a.r k := by
     intro k
     rw [inv_eq_one_div, div_le_iff₀ τpos, ← lastr, mul_comm]
@@ -342,8 +342,8 @@ theorem exists_normalized_aux2 {N : ℕ} {τ : ℝ} (a : SatelliteConfig E N τ)
       Pairwise fun i j => a.r i ≤ ‖a.c i - a.c j‖ ∧ a.r j ≤ τ * a.r i ∨
         a.r j ≤ ‖a.c j - a.c i‖ ∧ a.r i ≤ τ * a.r j := by
     simpa only [dist_eq_norm] using a.h
-  have δnonneg : 0 ≤ δ := by linarith only [hτ, hδ1]
-  have D : 0 ≤ 1 - δ / 4 := by linarith only [hδ2]
+  have δnonneg : 0 ≤ δ := by linear_combination 4 * (hτ + hδ1)
+  have D : 0 ≤ 1 - δ / 4 := by linear_combination hδ2 / 4
   have hcrj : ‖a.c j‖ ≤ a.r j + 1 := by simpa only [lastc, lastr, dist_zero_right] using a.inter' j
   have I : a.r i ≤ 2 := by
     rcases lt_or_le i (last N) with (H | H)
@@ -356,19 +356,19 @@ theorem exists_normalized_aux2 {N : ℕ} {τ : ℝ} (a : SatelliteConfig E N τ)
     calc
       (1 - δ / 4) * τ ≤ (1 - δ / 4) * (1 + δ / 4) := by gcongr
       _ = (1 : ℝ) - δ ^ 2 / 16 := by ring
-      _ ≤ 1 := by linarith only [sq_nonneg δ]
+      _ ≤ 1 := by linear_combination (sq_nonneg δ) / 16
   have A : a.r j - δ ≤ ‖a.c i - a.c j‖ := by
     rcases ah inej.symm with (H | H); · rw [norm_sub_rev]; linarith [H.1]
     have C : a.r j ≤ 4 :=
       calc
         a.r j ≤ τ * a.r i := H.2
         _ ≤ τ * 2 := by gcongr
-        _ ≤ 5 / 4 * 2 := by gcongr; linarith only [hδ1, hδ2]
+        _ ≤ 5 / 4 * 2 := by gcongr; linear_combination hδ1 + hδ2 / 4
         _ ≤ 4 := by norm_num
     calc
       a.r j - δ ≤ a.r j - a.r j / 4 * δ := by
         gcongr _ - ?_
-        exact mul_le_of_le_one_left δnonneg (by linarith only [C])
+        exact mul_le_of_le_one_left δnonneg (by linear_combination C / 4)
       _ = (1 - δ / 4) * a.r j := by ring
       _ ≤ (1 - δ / 4) * (τ * a.r i) := mul_le_mul_of_nonneg_left H.2 D
       _ ≤ 1 * a.r i := by rw [← mul_assoc]; gcongr
@@ -384,8 +384,8 @@ theorem exists_normalized_aux2 {N : ℕ} {τ : ℝ} (a : SatelliteConfig E N τ)
         rw [← one_smul ℝ (a.c j), hd, ← sub_smul, norm_smul, norm_sub_rev, Real.norm_eq_abs,
           abs_of_nonneg A, sub_mul]
         field_simp [(zero_le_two.trans_lt hj).ne']
-        linarith only [hcrj]
-  linarith only [this]
+        linear_combination hcrj
+  linear_combination this
 
 theorem exists_normalized_aux3 {N : ℕ} {τ : ℝ} (a : SatelliteConfig E N τ)
     (lastc : a.c (last N) = 0) (lastr : a.r (last N) = 1) (hτ : 1 ≤ τ) (δ : ℝ) (hδ1 : τ ≤ 1 + δ / 4)
@@ -395,7 +395,7 @@ theorem exists_normalized_aux3 {N : ℕ} {τ : ℝ} (a : SatelliteConfig E N τ)
       Pairwise fun i j => a.r i ≤ ‖a.c i - a.c j‖ ∧ a.r j ≤ τ * a.r i ∨
         a.r j ≤ ‖a.c j - a.c i‖ ∧ a.r i ≤ τ * a.r j := by
     simpa only [dist_eq_norm] using a.h
-  have δnonneg : 0 ≤ δ := by linarith only [hτ, hδ1]
+  have δnonneg : 0 ≤ δ := by linear_combination 4 * (hτ + hδ1)
   have hcrj : ‖a.c j‖ ≤ a.r j + 1 := by simpa only [lastc, lastr, dist_zero_right] using a.inter' j
   have A : a.r i ≤ ‖a.c i‖ := by
     have : i < last N := by
@@ -430,13 +430,12 @@ theorem exists_normalized_aux3 {N : ℕ} {τ : ℝ} (a : SatelliteConfig E N τ)
             a.r j - ‖a.c j - a.c i‖ ≤ τ * a.r i - a.r i := sub_le_sub H.2 H.1
             _ = a.r i * (τ - 1) := by ring
             _ ≤ s * (τ - 1) := mul_le_mul_of_nonneg_right A (sub_nonneg.2 hτ)
-      _ ≤ s * (δ / 2) := (mul_le_mul_of_nonneg_left (by linarith only [δnonneg, hδ1]) spos.le)
+      _ ≤ s * (δ / 2) := by linear_combination s * (hδ1 + δnonneg / 4)
       _ = s / 2 * δ := by ring
   have invs_nonneg : 0 ≤ 2 / s := div_nonneg zero_le_two (zero_le_two.trans hi.le)
   calc
     1 - δ = 2 / s * (s / 2 - s / 2 * δ) := by field_simp [spos.ne']; ring
-    _ ≤ 2 / s * ‖d - a.c i‖ :=
-      (mul_le_mul_of_nonneg_left (by linarith only [hcrj, I, J, hi]) invs_nonneg)
+    _ ≤ 2 / s * ‖d - a.c i‖ := by linear_combination 2 / s * (hcrj + I + J + hi / 2)
     _ = ‖(2 / s) • a.c i - (2 / ‖a.c j‖) • a.c j‖ := by
       conv_lhs => rw [norm_sub_rev, ← abs_of_nonneg invs_nonneg]
       rw [← Real.norm_eq_abs, ← norm_smul, smul_sub, hd, smul_smul]

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -167,7 +167,7 @@ variable (ι : Type*) [Fintype ι] {p : ℝ}
 theorem MeasureTheory.volume_sum_rpow_lt_one (hp : 1 ≤ p) :
     volume {x : ι → ℝ | ∑ i, |x i| ^ p < 1} =
       .ofReal ((2 * Gamma (1 / p + 1)) ^ card ι / Gamma (card ι / p + 1)) := by
-  have h₁ : 0 < p := by linarith
+  have h₁ : 0 < p := by linear_combination hp
   have h₂ : ∀ x : ι → ℝ, 0 ≤ ∑ i, |x i| ^ p := by
     refine fun _ => Finset.sum_nonneg' ?_
     exact fun i => (fun _ => rpow_nonneg (abs_nonneg _) _) _
@@ -219,7 +219,7 @@ theorem MeasureTheory.volume_sum_rpow_lt [Nonempty ι] {p : ℝ} (hp : 1 ≤ p) 
 theorem MeasureTheory.volume_sum_rpow_le [Nonempty ι] {p : ℝ} (hp : 1 ≤ p) (r : ℝ) :
     volume {x : ι → ℝ | (∑ i, |x i| ^ p) ^ (1 / p) ≤ r} = (.ofReal r) ^ card ι *
       .ofReal ((2 * Gamma (1 / p + 1)) ^ card ι / Gamma (card ι / p + 1)) := by
-  have h₁ : 0 < p := by linarith
+  have h₁ : 0 < p := by linear_combination hp
   -- We collect facts about `Lp` norms that will be used in `measure_le_one_eq_lt_one`
   have eq_norm := fun x : ι → ℝ => (PiLp.norm_eq_sum (p := .ofReal p) (f := x)
     ((toReal_ofReal (le_of_lt h₁)).symm ▸ h₁))
@@ -239,7 +239,7 @@ theorem MeasureTheory.volume_sum_rpow_le [Nonempty ι] {p : ℝ} (hp : 1 ≤ p) 
 theorem Complex.volume_sum_rpow_lt_one {p : ℝ} (hp : 1 ≤ p) :
     volume {x : ι → ℂ | ∑ i, ‖x i‖ ^ p < 1} =
       .ofReal ((π * Real.Gamma (2 / p + 1)) ^ card ι / Real.Gamma (2 * card ι / p + 1)) := by
-  have h₁ : 0 < p := by linarith
+  have h₁ : 0 < p := by linear_combination hp
   have h₂ : ∀ x : ι → ℂ, 0 ≤ ∑ i, ‖x i‖ ^ p := by
     refine fun _ => Finset.sum_nonneg' ?_
     exact fun i => (fun _ => rpow_nonneg (norm_nonneg _) _) _
@@ -294,7 +294,7 @@ theorem Complex.volume_sum_rpow_lt [Nonempty ι] {p : ℝ} (hp : 1 ≤ p) (r : �
 theorem Complex.volume_sum_rpow_le [Nonempty ι] {p : ℝ} (hp : 1 ≤ p) (r : ℝ) :
     volume {x : ι → ℂ | (∑ i, ‖x i‖ ^ p) ^ (1 / p) ≤ r} = (.ofReal r) ^ (2 * card ι) *
       .ofReal ((π * Real.Gamma (2 / p + 1)) ^ card ι / Real.Gamma (2 * card ι / p + 1)) := by
-  have h₁ : 0 < p := by linarith
+  have h₁ : 0 < p := by linear_combination hp
   -- We collect facts about `Lp` norms that will be used in `measure_lt_one_eq_integral_div_gamma`
   have eq_norm := fun x : ι → ℂ => (PiLp.norm_eq_sum (p := .ofReal p) (f := x)
     ((toReal_ofReal (le_of_lt h₁)).symm ▸ h₁))

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -325,7 +325,7 @@ variable {z}
 theorem exists_eq_T_zpow_of_c_eq_zero (hc : g 1 0 = 0) :
     ∃ n : ℤ, ∀ z : ℍ, g • z = T ^ n • z := by
   have had := g.det_coe
-  replace had : g 0 0 * g 1 1 = 1 := by rw [det_fin_two, hc] at had; linarith
+  replace had : g 0 0 * g 1 1 = 1 := by rw [det_fin_two, hc] at had; linear_combination had
   rcases Int.eq_one_or_neg_one_of_mul_eq_one' had with (⟨ha, hd⟩ | ⟨ha, hd⟩)
   · use g 0 1
     suffices g = T ^ g 0 1 by intro z; conv_lhs => rw [this]
@@ -339,7 +339,7 @@ theorem exists_eq_T_zpow_of_c_eq_zero (hc : g 1 0 = 0) :
 -- If `c = 1`, then `g` factorises into a product terms involving only `T` and `S`.
 theorem g_eq_of_c_eq_one (hc : g 1 0 = 1) : g = T ^ g 0 0 * S * T ^ g 1 1 := by
   have hg := g.det_coe.symm
-  replace hg : g 0 1 = g 0 0 * g 1 1 - 1 := by rw [det_fin_two, hc] at hg; linarith
+  replace hg : g 0 1 = g 0 0 * g 1 1 - 1 := by rw [det_fin_two, hc] at hg; linear_combination hg
   refine Subtype.ext ?_
   conv_lhs => rw [(g : Matrix _ _ ℤ).eta_fin_two]
   simp only [hg, sub_eq_add_neg, hc, coe_mul, coe_T_zpow, coe_S, mul_fin_two, mul_zero, mul_one,
@@ -393,7 +393,7 @@ theorem three_le_four_mul_im_sq_of_mem_fd {τ : ℍ} (h : τ ∈ 𝒟) : 3 ≤ 4
 theorem one_lt_normSq_T_zpow_smul (hz : z ∈ 𝒟ᵒ) (n : ℤ) : 1 < normSq (T ^ n • z : ℍ) := by
   have hz₁ : 1 < z.re * z.re + z.im * z.im := hz.1
   have hzn := Int.nneg_mul_add_sq_of_abs_le_one n (abs_two_mul_re_lt_one_of_mem_fdo hz).le
-  have : 1 < (z.re + ↑n) * (z.re + ↑n) + z.im * z.im := by linarith
+  have : 1 < (z.re + ↑n) * (z.re + ↑n) + z.im * z.im := by linear_combination hz₁ + hzn
   simpa [coe_T_zpow, normSq, num, denom, -map_zpow]
 
 theorem eq_zero_of_mem_fdo_of_T_zpow_mem_fdo {n : ℤ} (hz : z ∈ 𝒟ᵒ) (hg : T ^ n • z ∈ 𝒟ᵒ) :
@@ -455,8 +455,7 @@ theorem abs_c_le_one (hz : z ∈ 𝒟ᵒ) (hg : g • z ∈ 𝒟ᵒ) : |g 1 0| �
     rcases eq_or_ne c 0 with (hc | hc)
     · rw [hc]; norm_num
     · refine (abs_lt_of_sq_lt_sq' ?_ (by norm_num)).2
-      specialize this hc
-      linarith
+      linear_combination this hc
   intro hc
   have h₁ : 3 * 3 * c ^ 4 < 4 * (g • z).im ^ 2 * (4 * z.im ^ 2) * c ^ 4 := by
     gcongr <;> apply three_lt_four_mul_im_sq_of_mem_fdo <;> assumption
@@ -466,11 +465,11 @@ theorem abs_c_le_one (hz : z ∈ 𝒟ᵒ) (hg : g • z ∈ 𝒟ᵒ) : |g 1 0| �
       (sq_nonneg _)
   let nsq := normSq (denom g z)
   calc
-    9 * c ^ 4 < c ^ 4 * z.im ^ 2 * (g • z).im ^ 2 * 16 := by linarith
+    9 * c ^ 4 < c ^ 4 * z.im ^ 2 * (g • z).im ^ 2 * 16 := by linear_combination h₁
     _ = c ^ 4 * z.im ^ 4 / nsq ^ 2 * 16 := by
-      rw [im_smul_eq_div_normSq, div_pow]
+      rw [im_smul_eq_div_normSq]
       ring
-    _ ≤ 16 := by rw [← mul_pow]; linarith
+    _ ≤ 16 := by rw [← mul_pow]; linear_combination 16 * h₂
 
 /-- An auxiliary result en route to `ModularGroup.eq_smul_self_of_mem_fdo_mem_fdo`. -/
 theorem c_eq_zero (hz : z ∈ 𝒟ᵒ) (hg : g • z ∈ 𝒟ᵒ) : g 1 0 = 0 := by

--- a/Mathlib/NumberTheory/Transcendental/Liouville/LiouvilleWith.lean
+++ b/Mathlib/NumberTheory/Transcendental/Liouville/LiouvilleWith.lean
@@ -60,7 +60,7 @@ theorem liouvilleWith_one (x : ℝ) : LiouvilleWith 1 x := by
     add_div_eq_mul_add_div _ _ hn'.ne']
   gcongr
   calc _ ≤ x * n + 1 := by push_cast; gcongr; apply Int.floor_le
-    _ < x * n + 2 := by linarith
+    _ < x * n + 2 := by linear_combination
 
 namespace LiouvilleWith
 

--- a/Mathlib/Probability/Distributions/Pareto.lean
+++ b/Mathlib/Probability/Distributions/Pareto.lean
@@ -73,7 +73,7 @@ lemma stronglyMeasurable_paretoPDFReal (t r : ℝ) :
 lemma paretoPDFReal_pos (ht : 0 < t) (hr : 0 < r) (hx : t ≤ x) :
     0 < paretoPDFReal t r x := by
   rw [paretoPDFReal, if_pos hx]
-  have _ : 0 < x := by linarith
+  have _ : 0 < x := by linear_combination ht + hx
   positivity
 
 /-- The Pareto pdf is nonnegative. -/


### PR DESCRIPTION
Change 100 `linarith`s to `linear_combination`s; this is generally a slight speedup.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

- [x] depends on: #18714 (not strictly blocked by this, but the speed comparison will be more informative after it)
