### PR TITLE
[Merged by Bors] - chore(Tactic/DefEqTransformations): restore `unfold_let` tactic with deprecated warning

### DIFF
--- a/Mathlib/Tactic/DefEqTransformations.lean
+++ b/Mathlib/Tactic/DefEqTransformations.lean
@@ -140,7 +140,7 @@ This also exists as a `conv`-mode tactic.
 If no local definitions are given, then all local definitions are unfolded.
 This variant also exists as the `conv`-mode tactic `zeta`.
 -/
-@[deprecated unfold]
+@[deprecated unfold (since := "2024-11-11")]
 syntax (name := unfoldLetStx) "unfold_let" (ppSpace colGt term:max)*
   (ppSpace Parser.Tactic.location)? : tactic
 
@@ -153,7 +153,7 @@ elab_rules : tactic
     logWarning "The `unfold_let` tactic is deprecated. Please use `unfold` instead."
     runDefEqTactic (fun _ => unfoldFVars fvars) loc? "unfold_let"
 
-@[inherit_doc unfoldLetStx, deprecated unfold]
+@[inherit_doc unfoldLetStx, deprecated unfold (since := "2024-11-11")]
 syntax "unfold_let" (ppSpace colGt term:max)* : conv
 
 elab_rules : conv

--- a/Mathlib/Tactic/DefEqTransformations.lean
+++ b/Mathlib/Tactic/DefEqTransformations.lean
@@ -145,18 +145,23 @@ syntax (name := unfoldLetStx) "unfold_let" (ppSpace colGt term:max)*
   (ppSpace Parser.Tactic.location)? : tactic
 
 elab_rules : tactic
-  | `(tactic| unfold_let $[$loc?]?) =>
+  | `(tactic| unfold_let $[$loc?]?) => do
+    logWarning "The `unfold_let` tactic is deprecated. Please use `unfold` instead."
     runDefEqTactic (fun _ => zetaReduce) loc? "unfold_let"
   | `(tactic| unfold_let $hs:term* $[$loc?]?) => do
     let fvars ← getFVarIds hs
+    logWarning "The `unfold_let` tactic is deprecated. Please use `unfold` instead."
     runDefEqTactic (fun _ => unfoldFVars fvars) loc? "unfold_let"
 
 @[inherit_doc unfoldLetStx, deprecated unfold]
 syntax "unfold_let" (ppSpace colGt term:max)* : conv
 
 elab_rules : conv
-  | `(conv| unfold_let) => runDefEqConvTactic zetaReduce
+  | `(conv| unfold_let) => do
+    logWarning "The `unfold_let` tactic is deprecated. Please use `unfold` instead."
+    runDefEqConvTactic zetaReduce
   | `(conv| unfold_let $hs:term*) => do
+    logWarning "The `unfold_let` tactic is deprecated. Please use `unfold` instead."
     runDefEqConvTactic (unfoldFVars (← getFVarIds hs))
 
 

--- a/Mathlib/Tactic/DefEqTransformations.lean
+++ b/Mathlib/Tactic/DefEqTransformations.lean
@@ -114,6 +114,52 @@ elab "reduce" loc?:(ppSpace Parser.Tactic.location)? : tactic =>
   runDefEqTactic (fun _ e => reduce e (skipTypes := false) (skipProofs := false)) loc? "reduce"
 
 
+/-! ### `unfold_let` -/
+
+/-- Unfold all the fvars from `fvars` in `e` that have local definitions (are "let-bound"). -/
+def unfoldFVars (fvars : Array FVarId) (e : Expr) : MetaM Expr := do
+  transform (usedLetOnly := true) e fun node => do
+    match node with
+    | .fvar fvarId =>
+      if fvars.contains fvarId then
+        if let some val ← fvarId.getValue? then
+          return .visit (← instantiateMVars val)
+        else
+          return .continue
+      else
+        return .continue
+    | _ => return .continue
+
+/--
+This tactic is subsumed by the `unfold` tactic.
+
+`unfold_let x y z at loc` unfolds the local definitions `x`, `y`, and `z` at the given
+location, which is known as "zeta reduction."
+This also exists as a `conv`-mode tactic.
+
+If no local definitions are given, then all local definitions are unfolded.
+This variant also exists as the `conv`-mode tactic `zeta`.
+-/
+@[deprecated unfold]
+syntax (name := unfoldLetStx) "unfold_let" (ppSpace colGt term:max)*
+  (ppSpace Parser.Tactic.location)? : tactic
+
+elab_rules : tactic
+  | `(tactic| unfold_let $[$loc?]?) =>
+    runDefEqTactic (fun _ => zetaReduce) loc? "unfold_let"
+  | `(tactic| unfold_let $hs:term* $[$loc?]?) => do
+    let fvars ← getFVarIds hs
+    runDefEqTactic (fun _ => unfoldFVars fvars) loc? "unfold_let"
+
+@[inherit_doc unfoldLetStx, deprecated unfold]
+syntax "unfold_let" (ppSpace colGt term:max)* : conv
+
+elab_rules : conv
+  | `(conv| unfold_let) => runDefEqConvTactic zetaReduce
+  | `(conv| unfold_let $hs:term*) => do
+    runDefEqConvTactic (unfoldFVars (← getFVarIds hs))
+
+
 /-! ### `refold_let` -/
 
 /-- For each fvar, looks for its body in `e` and replaces it with the fvar. -/


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
