### PR TITLE
[Merged by Bors] - chore: some `erw`s that can become `rw`s for free

### DIFF
--- a/Mathlib/Algebra/Module/Presentation/DirectSum.lean
+++ b/Mathlib/Algebra/Module/Presentation/DirectSum.lean
@@ -61,7 +61,7 @@ def directSumEquiv :
   invFun t :=
     { var := fun ⟨i, g⟩ ↦ (t i).var g
       linearCombination_var_relation := fun ⟨i, r⟩ ↦ by
-        erw [← (t i).linearCombination_var_relation r]
+        rw [← (t i).linearCombination_var_relation r]
         apply Finsupp.linearCombination_embDomain }
   left_inv _ := rfl
   right_inv _ := rfl

--- a/Mathlib/Algebra/Order/CauSeq/Basic.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Basic.lean
@@ -808,7 +808,7 @@ protected theorem sup_eq_right {a b : CauSeq α abs} (h : a ≤ b) : a ⊔ b ≈
   · intro _ _
     refine ⟨i, fun j hj => ?_⟩
     dsimp
-    erw [← max_sub_sub_right]
+    rw [← max_sub_sub_right]
     rwa [sub_self, max_eq_right, abs_zero]
     rw [sub_nonpos, ← sub_nonneg]
     exact ε0.le.trans (h _ hj)
@@ -820,7 +820,7 @@ protected theorem inf_eq_right {a b : CauSeq α abs} (h : b ≤ a) : a ⊓ b ≈
   · intro _ _
     refine ⟨i, fun j hj => ?_⟩
     dsimp
-    erw [← min_sub_sub_right]
+    rw [← min_sub_sub_right]
     rwa [sub_self, min_eq_right, abs_zero]
     exact ε0.le.trans (h _ hj)
   · refine Setoid.trans (inf_equiv_inf (Setoid.symm h) (Setoid.refl _)) ?_

--- a/Mathlib/CategoryTheory/Sites/Subcanonical.lean
+++ b/Mathlib/CategoryTheory/Sites/Subcanonical.lean
@@ -66,7 +66,7 @@ lemma yonedaEquiv_symm_naturality_left {X X' : C} (f : X' ⟶ X) (F : Sheaf J (T
       ((F.val.map f.op) x) := by
   apply J.yonedaEquiv.injective
   simp only [yonedaEquiv_comp, yoneda_obj_obj, yonedaEquiv_symm_app_apply, Equiv.apply_symm_apply]
-  erw [yonedaEquiv_yoneda_map]
+  rw [yonedaEquiv_yoneda_map]
 
 lemma yonedaEquiv_symm_naturality_right (X : C) {F F' : Sheaf J (Type v)} (f : F ⟶ F')
     (x : F.val.obj ⟨X⟩) : J.yonedaEquiv.symm x ≫ f = J.yonedaEquiv.symm (f.val.app ⟨X⟩ x) := by
@@ -155,7 +155,7 @@ lemma yonedaULiftEquiv_symm_naturality_left {X X' : C} (f : X' ⟶ X) (F : Sheaf
       ((F.val.map f.op) x) := by
   apply J.yonedaULiftEquiv.injective
   simp only [yonedaULiftEquiv_comp, Equiv.apply_symm_apply]
-  erw [yonedaULiftEquiv_yonedaULift_map]
+  rw [yonedaULiftEquiv_yonedaULift_map]
   rfl
 
 lemma yonedaULiftEquiv_symm_naturality_right (X : C) {F F' : Sheaf J (Type (max v v'))}


### PR DESCRIPTION
The linter of #17638 found five more `erw`s that could also be `rw`s. 🐙 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
