### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): the big etale site

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -913,6 +913,7 @@ import Mathlib.AlgebraicGeometry.Morphisms.AffineAnd
 import Mathlib.AlgebraicGeometry.Morphisms.Basic
 import Mathlib.AlgebraicGeometry.Morphisms.ClosedImmersion
 import Mathlib.AlgebraicGeometry.Morphisms.Constructors
+import Mathlib.AlgebraicGeometry.Morphisms.Etale
 import Mathlib.AlgebraicGeometry.Morphisms.FinitePresentation
 import Mathlib.AlgebraicGeometry.Morphisms.FiniteType
 import Mathlib.AlgebraicGeometry.Morphisms.Immersion
@@ -948,6 +949,8 @@ import Mathlib.AlgebraicGeometry.ResidueField
 import Mathlib.AlgebraicGeometry.Restrict
 import Mathlib.AlgebraicGeometry.Scheme
 import Mathlib.AlgebraicGeometry.Sites.BigZariski
+import Mathlib.AlgebraicGeometry.Sites.Etale
+import Mathlib.AlgebraicGeometry.Sites.MorphismProperty
 import Mathlib.AlgebraicGeometry.Spec
 import Mathlib.AlgebraicGeometry.SpreadingOut
 import Mathlib.AlgebraicGeometry.Stalk

--- a/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
@@ -73,6 +73,29 @@ theorem Cover.iUnion_range {X : Scheme.{u}} (𝒰 : X.Cover P) :
   rw [Set.mem_iUnion]
   exact ⟨𝒰.f x, 𝒰.covers x⟩
 
+/-- Given a family of schemes with morphisms to `X` satisfying `P` that jointly
+cover `X`, this an associated `P`-cover of `X`. -/
+@[simps]
+def Cover.mkOfCovers (J : Type*) (obj : J → Scheme.{u}) (map : (j : J) → obj j ⟶ X)
+    (covers : ∀ x, ∃ j y, (map j).base y = x)
+    (map_prop : ∀ j, P (map j) := by infer_instance) : X.Cover P where
+  J := J
+  obj := obj
+  map := map
+  f x := (covers x).choose
+  covers x := (covers x).choose_spec
+  map_prop := map_prop
+
+/-- Turn a `P`-cover into a `Q`-cover by showing that the components satisfiy `Q`. -/
+def Cover.changeProp (Q : MorphismProperty Scheme.{u}) (𝒰 : X.Cover P) (h : ∀ j, Q (𝒰.map j)) :
+    X.Cover Q where
+  J := 𝒰.J
+  obj := 𝒰.obj
+  map := 𝒰.map
+  f := 𝒰.f
+  covers := 𝒰.covers
+  map_prop := h
+
 /-- Given a `P`-cover `{ Uᵢ }` of `X`, and for each `Uᵢ` a `P`-cover, we may combine these
 covers to form a `P`-cover of `X`. -/
 @[simps! J obj map]

--- a/Mathlib/AlgebraicGeometry/GluingOneHypercover.lean
+++ b/Mathlib/AlgebraicGeometry/GluingOneHypercover.lean
@@ -45,7 +45,7 @@ noncomputable def oneHypercover : Scheme.zariskiTopology.OneHypercover D.glued w
   p₂ i₁ i₂ _ := D.t i₁ i₂ ≫ D.f i₂ i₁
   w i₁ i₂ _ := by simp only [Category.assoc, Scheme.GlueData.glue_condition]
   mem₀ := by
-    refine zariskiTopology.superset_covering ?_ (zariskiTopology_openCover D.openCover)
+    refine zariskiTopology.superset_covering ?_ (grothendieckTopology_cover D.openCover)
     rw [Sieve.generate_le_iff]
     rintro W _ ⟨i⟩
     exact ⟨_, 𝟙 _, _, ⟨i⟩, by simp; rfl⟩

--- a/Mathlib/AlgebraicGeometry/Morphisms/Etale.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Etale.lean
@@ -1,4 +1,5 @@
-/- Copyright (c) 2024 Christian Merten. All rights reserved.
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/

--- a/Mathlib/AlgebraicGeometry/Morphisms/Etale.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Etale.lean
@@ -1,0 +1,58 @@
+/- Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.AlgebraicGeometry.Morphisms.Smooth
+import Mathlib.CategoryTheory.MorphismProperty.Comma
+
+/-!
+
+# Etale morphisms
+
+A morphism of schemes `f : X ⟶ Y` is étale if it is smooth of relative dimension zero. We
+also define the category of schemes étale over `X`.
+
+-/
+
+universe t u
+
+universe u₂ u₁ v₂ v₁
+
+open CategoryTheory MorphismProperty
+
+namespace AlgebraicGeometry
+
+/-- A morphism of schemes is étale if it is smooth of relative dimension zero. -/
+abbrev IsEtale {X Y : Scheme.{u}} (f : X ⟶ Y) := IsSmoothOfRelativeDimension 0 f
+
+namespace IsEtale
+
+variable {X Y : Scheme.{u}} (f : X ⟶ Y)
+
+instance : IsStableUnderBaseChange @IsEtale :=
+  isSmoothOfRelativeDimension_isStableUnderBaseChange 0
+
+end IsEtale
+
+/-- The category `Etale X` is the category of schemes étale over `X`. -/
+def Etale (X : Scheme.{u}) : Type _ := MorphismProperty.Over @IsEtale ⊤ X
+
+variable (X : Scheme.{u})
+
+instance : Category (Etale X) :=
+  inferInstanceAs <| Category (MorphismProperty.Over @IsEtale ⊤ X)
+
+/-- The forgetful functor from schemes étale over `X` to schemes over `X`. -/
+def Etale.forget : Etale X ⥤ Over X :=
+  MorphismProperty.Over.forget @IsEtale ⊤ X
+
+/-- The forgetful functor from schemes étale over `X` to schemes over `X` is fully faithful. -/
+def Etale.forgetFullyFaithful : (Etale.forget X).FullyFaithful :=
+  MorphismProperty.Comma.forgetFullyFaithful _ _ _
+
+instance : (Etale.forget X).Full :=
+  inferInstanceAs <| (MorphismProperty.Comma.forget _ _ _ _ _).Full
+instance : (Etale.forget X).Faithful :=
+  inferInstanceAs <| (MorphismProperty.Comma.forget _ _ _ _ _).Faithful
+
+end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Morphisms/Smooth.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Smooth.lean
@@ -160,8 +160,9 @@ instance {Z : Scheme.{u}} (g : Y ⟶ Z) [IsSmoothOfRelativeDimension 0 f]
     IsSmoothOfRelativeDimension 0 (f ≫ g) :=
   inferInstanceAs <| IsSmoothOfRelativeDimension (0 + 0) (f ≫ g)
 
-/-- Smooth of relative dimension `0` is stable under composition. -/
-instance : MorphismProperty.IsStableUnderComposition (@IsSmoothOfRelativeDimension 0) where
+/-- Smooth of relative dimension `0` is multiplicative. -/
+instance : MorphismProperty.IsMultiplicative (@IsSmoothOfRelativeDimension 0) where
+  id_mem _ := inferInstance
   comp_mem _ _ _ _ := inferInstance
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Sites/BigZariski.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/BigZariski.lean
@@ -3,8 +3,7 @@ Copyright (c) 2023 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou, Adam Topaz
 -/
-import Mathlib.AlgebraicGeometry.Pullbacks
-import Mathlib.CategoryTheory.Sites.Pretopology
+import Mathlib.AlgebraicGeometry.Sites.MorphismProperty
 import Mathlib.CategoryTheory.Sites.Canonical
 /-!
 # The big Zariski site of schemes
@@ -36,39 +35,12 @@ namespace AlgebraicGeometry
 namespace Scheme
 
 /-- The Zariski pretopology on the category of schemes. -/
-def zariskiPretopology : Pretopology (Scheme.{u}) where
-  coverings Y S := ∃ (U : OpenCover.{u} Y), S = Presieve.ofArrows U.obj U.map
-  has_isos _ _ f _ := ⟨coverOfIsIso f, (Presieve.ofArrows_pUnit _).symm⟩
-  pullbacks := by
-    rintro Y X f _ ⟨U, rfl⟩
-    exact ⟨U.pullbackCover' f, (Presieve.ofArrows_pullback _ _ _).symm⟩
-  transitive := by
-    rintro X _ T ⟨U, rfl⟩ H
-    choose V hV using H
-    use U.bind (fun j => V (U.map j) ⟨j⟩)
-    simpa only [Cover.bind, ← hV] using Presieve.ofArrows_bind U.obj U.map _
-      (fun _ f H => (V f H).obj) (fun _ f H => (V f H).map)
+def zariskiPretopology : Pretopology (Scheme.{u}) :=
+  pretopology @IsOpenImmersion
 
 /-- The Zariski topology on the category of schemes. -/
 abbrev zariskiTopology : GrothendieckTopology (Scheme.{u}) :=
   zariskiPretopology.toGrothendieck
-
-lemma zariskiPretopology_openCover {Y : Scheme.{u}} (U : OpenCover.{u} Y) :
-    zariskiPretopology Y (Presieve.ofArrows U.obj U.map) :=
-  ⟨U, rfl⟩
-
-lemma zariskiTopology_openCover {Y : Scheme.{u}} (U : OpenCover.{v} Y) :
-    zariskiTopology Y (Sieve.generate (Presieve.ofArrows U.obj U.map)) := by
-  let V : OpenCover.{u} Y :=
-    { J := Y
-      obj := fun y => U.obj (U.f y)
-      map := fun y => U.map (U.f y)
-      f := id
-      covers := U.covers
-      map_prop := fun _ => U.map_prop _ }
-  refine ⟨_, zariskiPretopology_openCover V, ?_⟩
-  rintro _ _ ⟨y⟩
-  exact ⟨_, 𝟙 _, U.map (U.f y), ⟨_⟩, by simp⟩
 
 instance subcanonical_zariskiTopology : zariskiTopology.Subcanonical := by
   apply GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj

--- a/Mathlib/AlgebraicGeometry/Sites/Etale.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/Etale.lean
@@ -3,8 +3,9 @@ Copyright (c) 2024 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
-import Mathlib.AlgebraicGeometry.Sites.BigZariski
 import Mathlib.AlgebraicGeometry.Morphisms.Etale
+import Mathlib.AlgebraicGeometry.PullbackCarrier
+import Mathlib.AlgebraicGeometry.Sites.BigZariski
 
 /-!
 

--- a/Mathlib/AlgebraicGeometry/Sites/Etale.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/Etale.lean
@@ -11,8 +11,12 @@ import Mathlib.AlgebraicGeometry.Sites.BigZariski
 
 # The étale site
 
-In this file we define the étale topology as a Grothendieck topology on the category
-of schemes.
+In this file we define the big étale site, i.e. the étale topology as a Grothendieck topology
+on the category of schemes.
+
+## TODO:
+
+- define the small étale site
 
 -/
 
@@ -22,11 +26,11 @@ open CategoryTheory MorphismProperty Limits
 
 namespace AlgebraicGeometry.Scheme
 
-/-- The étale pretopology on the category of schemes. -/
+/-- Big étale site: the étale pretopology on the category of schemes. -/
 def etalePretopology : Pretopology Scheme.{u} :=
   pretopology @IsEtale
 
-/-- The étale topology on the category of schemes. -/
+/-- Big étale site: the étale topology on the category of schemes. -/
 abbrev etaleTopology : GrothendieckTopology Scheme.{u} :=
   etalePretopology.toGrothendieck
 

--- a/Mathlib/AlgebraicGeometry/Sites/Etale.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/Etale.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.AlgebraicGeometry.Sites.BigZariski
+import Mathlib.AlgebraicGeometry.Morphisms.Etale
+
+/-!
+
+# The étale site
+
+In this file we define the étale topology as a Grothendieck topology on the category
+of schemes.
+
+-/
+
+universe v u
+
+open CategoryTheory MorphismProperty Limits
+
+namespace AlgebraicGeometry.Scheme
+
+/-- The étale pretopology on the category of schemes. -/
+def etalePretopology : Pretopology Scheme.{u} :=
+  pretopology @IsEtale
+
+/-- The étale topology on the category of schemes. -/
+abbrev etaleTopology : GrothendieckTopology Scheme.{u} :=
+  etalePretopology.toGrothendieck
+
+lemma zariskiTopology_le_etaleTopology : zariskiTopology ≤ etaleTopology := by
+  apply grothendieckTopology_le_grothendieckTopology
+  intro X Y f hf
+  infer_instance
+
+end AlgebraicGeometry.Scheme

--- a/Mathlib/AlgebraicGeometry/Sites/MorphismProperty.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/MorphismProperty.lean
@@ -55,7 +55,10 @@ def pretopology : Pretopology Scheme.{u} where
 abbrev grothendieckTopology : GrothendieckTopology Scheme.{u} :=
   (pretopology P).toGrothendieck
 
-/-- The pretopology on the category of schemes defined by jointly surjective families. -/
+/-- The pretopology on the category of schemes defined by jointly surjective families.
+
+Note: The assumption `IsJointlySurjectivePreserving ⊤` is mathematically unneeded, and only here
+to reduce imports. To satisfy it, use `AlgebraicGeometry.Scheme.isJointlySurjectivePreserving`. -/
 def surjectiveFamiliesPretopology [IsJointlySurjectivePreserving ⊤] : Pretopology Scheme.{u} where
   coverings X S :=
     ∀ x : X, ∃ (Y : Scheme.{u}) (y : Y) (f : Y ⟶ X) (hf : S f), f.base y = x

--- a/Mathlib/AlgebraicGeometry/Sites/MorphismProperty.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/MorphismProperty.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten, Joël Riou, Adam Topaz
 -/
-import Mathlib.AlgebraicGeometry.PullbackCarrier
+import Mathlib.AlgebraicGeometry.Pullbacks
 import Mathlib.CategoryTheory.Sites.MorphismProperty
 
 /-!
@@ -27,7 +27,7 @@ open CategoryTheory MorphismProperty Limits
 namespace AlgebraicGeometry.Scheme
 
 variable (P : MorphismProperty Scheme.{u}) [P.IsMultiplicative] [P.RespectsIso]
-  [P.IsStableUnderBaseChange]
+  [P.IsStableUnderBaseChange] [IsJointlySurjectivePreserving P]
 
 /--
 The pretopology on the category of schemes defined by covering families where the components
@@ -56,7 +56,7 @@ abbrev grothendieckTopology : GrothendieckTopology Scheme.{u} :=
   (pretopology P).toGrothendieck
 
 /-- The pretopology on the category of schemes defined by jointly surjective families. -/
-def surjectiveFamiliesPretopology : Pretopology Scheme.{u} where
+def surjectiveFamiliesPretopology [IsJointlySurjectivePreserving ⊤] : Pretopology Scheme.{u} where
   coverings X S :=
     ∀ x : X, ∃ (Y : Scheme.{u}) (y : Y) (f : Y ⟶ X) (hf : S f), f.base y = x
   has_isos X Y f hf x := by
@@ -64,16 +64,17 @@ def surjectiveFamiliesPretopology : Pretopology Scheme.{u} where
     simp [← Scheme.comp_base_apply]
   pullbacks X Y f S hS x := by
     obtain ⟨Z, z, g, hg, hz⟩ := hS (f.base x)
-    obtain ⟨w, hwl, hwr⟩ := Pullback.exists_preimage_pullback z x hz
+    obtain ⟨w, hw⟩ :=
+      IsJointlySurjectivePreserving.exists_preimage_snd_triplet_of_prop (P := ⊤) trivial z x hz
     use pullback g f, w, pullback.snd g f
-    simpa [hwr] using Presieve.pullbackArrows.mk Z g hg
+    simpa [hw] using Presieve.pullbackArrows.mk Z g hg
   transitive X S T hS hT x := by
     obtain ⟨Y, y, f, hf, hy⟩ := hS x
     obtain ⟨Z, z, g, hg, hz⟩ := hT f hf y
     use Z, z, g ≫ f
     simpa [hz, hy] using Presieve.bind_comp f hf hg
 
-lemma pretopology_le_inf :
+lemma pretopology_le_inf [IsJointlySurjectivePreserving ⊤] :
     pretopology P ≤ surjectiveFamiliesPretopology ⊓ P.pretopology := by
   rintro X S ⟨𝒰, rfl⟩
   refine ⟨fun x ↦ ?_, fun ⟨i⟩ ↦ 𝒰.map_prop i⟩
@@ -89,7 +90,7 @@ Note: Because of size issues, this does not hold on the level of pretopologies: 
 in the intersection can have up to `Type (u + 1)` many components, while in the definition
 of `AlgebraicGeometry.Scheme.pretopology` we only allow `Type u` many components.
 -/
-lemma grothendieckTopology_eq_inf :
+lemma grothendieckTopology_eq_inf [IsJointlySurjectivePreserving ⊤] :
     grothendieckTopology P = (surjectiveFamiliesPretopology ⊓ P.pretopology).toGrothendieck := by
   apply le_antisymm ((Pretopology.gi Scheme.{u}).gc.monotone_l (pretopology_le_inf P))
   intro X S ⟨T, ⟨hs, hP⟩, hle⟩
@@ -131,7 +132,7 @@ lemma grothendieckTopology_cover {X : Scheme.{u}} (𝒰 : Cover.{v} P X) :
 section
 
 variable {Q : MorphismProperty Scheme.{u}} [Q.IsMultiplicative] [Q.RespectsIso]
-  [Q.IsStableUnderBaseChange]
+  [Q.IsStableUnderBaseChange] [IsJointlySurjectivePreserving Q]
 
 lemma pretopology_le_pretopology (hPQ : P ≤ Q) :
     pretopology P ≤ pretopology Q := by

--- a/Mathlib/AlgebraicGeometry/Sites/MorphismProperty.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/MorphismProperty.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten, Joël Riou, Adam Topaz
+-/
+import Mathlib.AlgebraicGeometry.PullbackCarrier
+import Mathlib.CategoryTheory.Sites.MorphismProperty
+
+/-!
+
+# Site defined by a morphism property
+
+Given a multiplicative morphism property `P` that is stable under base change, we define the
+associated (pre)topology on the category of schemes, where coverings are given
+by jointly surjective families of morphisms satisfying `P`.
+
+## TODO
+
+- Define the small site on `Over P Q X`.
+
+-/
+
+universe v u
+
+open CategoryTheory MorphismProperty Limits
+
+namespace AlgebraicGeometry.Scheme
+
+variable (P : MorphismProperty Scheme.{u}) [P.IsMultiplicative] [P.RespectsIso]
+  [P.IsStableUnderBaseChange]
+
+/--
+The pretopology on the category of schemes defined by covering families where the components
+satisfy `P`.
+
+The coverings are defined via existence of a `P`-cover. This is convenient in practice, as one
+directly has the cover available. For a pretopology generating the same Grothendieck topology, see
+`AlgebraicGeometry.Scheme.grothendieckTopology_eq_inf`.
+-/
+def pretopology : Pretopology Scheme.{u} where
+  coverings Y S := ∃ (U : Cover.{u} P Y), S = Presieve.ofArrows U.obj U.map
+  has_isos _ _ f _ := ⟨coverOfIsIso f, (Presieve.ofArrows_pUnit _).symm⟩
+  pullbacks := by
+    rintro Y X f _ ⟨U, rfl⟩
+    exact ⟨U.pullbackCover' f, (Presieve.ofArrows_pullback _ _ _).symm⟩
+  transitive := by
+    rintro X _ T ⟨U, rfl⟩ H
+    choose V hV using H
+    use U.bind (fun j => V (U.map j) ⟨j⟩)
+    simpa only [Cover.bind, ← hV] using Presieve.ofArrows_bind U.obj U.map _
+      (fun _ f H => (V f H).obj) (fun _ f H => (V f H).map)
+
+/-- The Grothendieck topology on the category of schemes induced by the pretopology defined by
+`P`-covers. -/
+abbrev grothendieckTopology : GrothendieckTopology Scheme.{u} :=
+  (pretopology P).toGrothendieck
+
+/-- The pretopology on the category of schemes defined by jointly surjective families. -/
+def surjectiveFamiliesPretopology : Pretopology Scheme.{u} where
+  coverings X S :=
+    ∀ x : X, ∃ (Y : Scheme.{u}) (y : Y) (f : Y ⟶ X) (hf : S f), f.base y = x
+  has_isos X Y f hf x := by
+    use Y, (inv f).base x, f
+    simp [← Scheme.comp_base_apply]
+  pullbacks X Y f S hS x := by
+    obtain ⟨Z, z, g, hg, hz⟩ := hS (f.base x)
+    obtain ⟨w, hwl, hwr⟩ := Pullback.exists_preimage_pullback z x hz
+    use pullback g f, w, pullback.snd g f
+    simpa [hwr] using Presieve.pullbackArrows.mk Z g hg
+  transitive X S T hS hT x := by
+    obtain ⟨Y, y, f, hf, hy⟩ := hS x
+    obtain ⟨Z, z, g, hg, hz⟩ := hT f hf y
+    use Z, z, g ≫ f
+    simpa [hz, hy] using Presieve.bind_comp f hf hg
+
+lemma pretopology_le_inf :
+    pretopology P ≤ surjectiveFamiliesPretopology ⊓ P.pretopology := by
+  rintro X S ⟨𝒰, rfl⟩
+  refine ⟨fun x ↦ ?_, fun ⟨i⟩ ↦ 𝒰.map_prop i⟩
+  obtain ⟨a, ha⟩ := 𝒰.covers x
+  refine ⟨𝒰.obj (𝒰.f x), a, 𝒰.map (𝒰.f x), ⟨_⟩, ha⟩
+
+/--
+The Grothendieck topology defined by `P`-covers agrees with the Grothendieck
+topology induced by the intersection of the pretopology of surjective families with
+the pretopology defined by `P`.
+
+Note: Because of size issues, this does not hold on the level of pretopologies: A presieve
+in the intersection can have up to `Type (u + 1)` many components, while in the definition
+of `AlgebraicGeometry.Scheme.pretopology` we only allow `Type u` many components.
+-/
+lemma grothendieckTopology_eq_inf :
+    grothendieckTopology P = (surjectiveFamiliesPretopology ⊓ P.pretopology).toGrothendieck := by
+  apply le_antisymm ((Pretopology.gi Scheme.{u}).gc.monotone_l (pretopology_le_inf P))
+  intro X S ⟨T, ⟨hs, hP⟩, hle⟩
+  let _ : Type (u + 1) := Presieve X
+  let J := (Y : Scheme.{u}) × (Y ⟶ X)
+  choose Y y f hf hy using hs
+  let 𝒰 : Cover.{u} P X :=
+    { J := X
+      obj := Y
+      map := f
+      f := id
+      covers := fun x ↦ ⟨y x, hy x⟩
+      map_prop := fun x ↦ hP (hf x)
+    }
+  refine ⟨Presieve.ofArrows 𝒰.obj 𝒰.map, ⟨𝒰, rfl⟩, ?_⟩
+  rintro Z g ⟨x⟩
+  exact hle _ (hf x)
+
+variable {P}
+
+lemma pretopology_cover {Y : Scheme.{u}} (𝒰 : Cover.{u} P Y) :
+    pretopology P Y (Presieve.ofArrows 𝒰.obj 𝒰.map) :=
+  ⟨𝒰, rfl⟩
+
+lemma grothendieckTopology_cover {X : Scheme.{u}} (𝒰 : Cover.{v} P X) :
+    grothendieckTopology P X (Sieve.generate (Presieve.ofArrows 𝒰.obj 𝒰.map)) := by
+  let 𝒱 : Cover.{u} P X :=
+    { J := X
+      obj := fun x ↦ 𝒰.obj (𝒰.f x)
+      map := fun x ↦ 𝒰.map (𝒰.f x)
+      f := id
+      covers := 𝒰.covers
+      map_prop := fun _ ↦ 𝒰.map_prop _
+    }
+  refine ⟨_, pretopology_cover 𝒱, ?_⟩
+  rintro _ _ ⟨y⟩
+  exact ⟨_, 𝟙 _, 𝒰.map (𝒰.f y), ⟨_⟩, by simp⟩
+
+section
+
+variable {Q : MorphismProperty Scheme.{u}} [Q.IsMultiplicative] [Q.RespectsIso]
+  [Q.IsStableUnderBaseChange]
+
+lemma pretopology_le_pretopology (hPQ : P ≤ Q) :
+    pretopology P ≤ pretopology Q := by
+  rintro X - ⟨𝒰, rfl⟩
+  use 𝒰.changeProp Q (fun j ↦ hPQ _ (𝒰.map_prop j))
+  rfl
+
+lemma grothendieckTopology_le_grothendieckTopology (hPQ : P ≤ Q) :
+    grothendieckTopology P ≤ grothendieckTopology Q :=
+  (Pretopology.gi Scheme.{u}).gc.monotone_l (pretopology_le_pretopology hPQ)
+
+end
+
+end AlgebraicGeometry.Scheme


### PR DESCRIPTION
For any morphism property `P`, we define the pretopology on the category of schemes defined by `P` as jointly surjective families of morphisms satisfying `P`. As an application, this is used to define the étale site.

The small site associated to `P` and with it the small étale site comes in a follow-up PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
