### PR TITLE
[Merged by Bors] - fix(Algebra/Order/Field): fix instance diamond for `NNRat`

### DIFF
--- a/Mathlib/Algebra/Field/Rat.lean
+++ b/Mathlib/Algebra/Field/Rat.lean
@@ -46,6 +46,10 @@ protected lemma inv_nonneg {a : ℚ} (ha : 0 ≤ a) : 0 ≤ a⁻¹ := by
 protected lemma div_nonneg {a b : ℚ} (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a / b :=
   mul_nonneg ha (Rat.inv_nonneg hb)
 
+protected lemma zpow_nonneg {a : ℚ} (ha : 0 ≤ a) : ∀ n : ℤ, 0 ≤ a ^ n
+  | Int.ofNat n => by simp [ha]
+  | Int.negSucc n => by simpa using Rat.inv_nonneg (pow_nonneg ha (n + 1))
+
 end Rat
 
 namespace NNRat
@@ -56,8 +60,12 @@ instance instInv : Inv ℚ≥0 where
 instance instDiv : Div ℚ≥0 where
   div x y := ⟨x / y, Rat.div_nonneg x.2 y.2⟩
 
+instance instZPow : Pow ℚ≥0 ℤ where
+  pow x n := ⟨x ^ n, Rat.zpow_nonneg x.2 n⟩
+
 @[simp, norm_cast] lemma coe_inv (q : ℚ≥0) : ((q⁻¹ : ℚ≥0) : ℚ) = (q : ℚ)⁻¹ := rfl
 @[simp, norm_cast] lemma coe_div (p q : ℚ≥0) : ((p / q : ℚ≥0) : ℚ) = p / q := rfl
+@[simp, norm_cast] lemma coe_zpow (p : ℚ≥0) (n : ℤ) : ((p ^ n : ℚ≥0) : ℚ) = p ^ n := rfl
 
 lemma inv_def (q : ℚ≥0) : q⁻¹ = divNat q.den q.num := by ext; simp [Rat.inv_def', num_coe, den_coe]
 lemma div_def (p q : ℚ≥0) : p / q = divNat (p.num * q.den) (p.den * q.num) := by
@@ -85,5 +93,9 @@ instance instSemifield : Semifield ℚ≥0 where
   nnratCast_def q := q.num_div_den.symm
   nnqsmul q a := q * a
   nnqsmul_def q a := rfl
+  zpow n a := a ^ n
+  zpow_zero' a := by ext; norm_cast
+  zpow_succ' n a := by ext; norm_cast
+  zpow_neg' n a := by ext; norm_cast
 
 end NNRat

--- a/Mathlib/Algebra/Order/Field/Rat.lean
+++ b/Mathlib/Algebra/Order/Field/Rat.lean
@@ -32,7 +32,3 @@ end Rat
 -- instances for performance
 deriving instance CanonicallyLinearOrderedSemifield, LinearOrderedSemifield,
   LinearOrderedCommGroupWithZero for NNRat
-
-/-- These test cases ensure there is no diamond with the `Semifield` structure defined earlier. -/
-example : (inferInstanceAs (Semifield ℚ≥0)).toCommGroupWithZero =
-    (inferInstanceAs (LinearOrderedCommGroupWithZero ℚ≥0)).toCommGroupWithZero := rfl

--- a/Mathlib/Algebra/Order/Field/Rat.lean
+++ b/Mathlib/Algebra/Order/Field/Rat.lean
@@ -32,3 +32,7 @@ end Rat
 -- instances for performance
 deriving instance CanonicallyLinearOrderedSemifield, LinearOrderedSemifield,
   LinearOrderedCommGroupWithZero for NNRat
+
+/-- These test cases ensure there is no diamond with the `Semifield` structure defined earlier. -/
+example : (inferInstanceAs (Semifield ℚ≥0)).toCommGroupWithZero =
+    (inferInstanceAs (LinearOrderedCommGroupWithZero ℚ≥0)).toCommGroupWithZero := rfl

--- a/MathlibTest/instance_diamonds.lean
+++ b/MathlibTest/instance_diamonds.lean
@@ -278,3 +278,12 @@ example {A : Type*} [Ring A] [Algebra ℝ A]:
   rfl
 
 end complexToReal
+
+/-! ## Instances on `ℚ≥0`
+-/
+
+/-- This diamond arose because the semifield structure on `NNRat` needs to be defined as early as
+possible, before `Nonneg.zpow` becomes available; `Nonneg.zpow` is used to then define the
+`LinearOrderedCommGroupWithZero` instance. -/
+example : (inferInstanceAs (Semifield ℚ≥0)).toCommGroupWithZero =
+    (inferInstanceAs (LinearOrderedCommGroupWithZero ℚ≥0)).toCommGroupWithZero := rfl


### PR DESCRIPTION
The `Semifield ℚ≥0` instance used a default definition of `zpow` using `zpowRec`, while the `LinearOrderedSemifield` instance has a custom definition of `zpow` called `Nonneg.zpow` (using the fact that `zpow` preserves nonnegativity). These two are not defeq and therefore we found an instance diamond in #18830.

The fix is to use `Nonneg.zpow` (or something defeq to it) in the definition of `NNRat.instSemifield`. However, this is tricky because `Nonneg.zpow` is only defined after that instance.

I saw two ways to implement the fix:
 * postpone the `Semifield NNRat` instance to after the definition of `Nonneg.zpow`. It should definitely be possible to move all the `NNRat`-related definitions from `Algebra.Field.Rat` to `Algebra.Order.Field.Rat`, but it looks like the import graph gets a bit more tangled this way.
 * redo the proof of `Nonneg.zpow` inline in `NNRat.instSemifield`. It turns out `inv` and `div` are already redefined in the same way in the same section, so this seems like the neatest solution with the least surprises.

I also added an `example` that checks the diamond is indeed now fixed.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
