### PR TITLE
refactor: make `Set.mem_graphOn` defeq

### DIFF
--- a/Mathlib/Data/Set/Operations.lean
+++ b/Mathlib/Data/Set/Operations.lean
@@ -242,7 +242,7 @@ def InjOn (f : α → β) (s : Set α) : Prop :=
   ∀ ⦃x₁ : α⦄, x₁ ∈ s → ∀ ⦃x₂ : α⦄, x₂ ∈ s → f x₁ = f x₂ → x₁ = x₂
 
 /-- The graph of a function `f : α → β` on a set `s`. -/
-def graphOn (f : α → β) (s : Set α) : Set (α × β) := (fun x ↦ (x, f x)) '' s
+def graphOn (f : α → β) (s : Set α) : Set (α × β) := {x | x.1 ∈ s ∧ f x.1 = x.2}
 
 /-- `f` is surjective from `s` to `t` if `t` is contained in the image of `s`. -/
 def SurjOn (f : α → β) (s : Set α) (t : Set β) : Prop := t ⊆ f '' s

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -940,38 +940,35 @@ variable {x : α × β}
 
 @[simp] lemma mem_graphOn : x ∈ s.graphOn f ↔ x.1 ∈ s ∧ f x.1 = x.2 := by aesop (add simp graphOn)
 
-@[simp] lemma graphOn_empty (f : α → β) : graphOn f ∅ = ∅ := image_empty _
-@[simp] lemma graphOn_eq_empty : graphOn f s = ∅ ↔ s = ∅ := image_eq_empty
-@[simp] lemma graphOn_nonempty : (s.graphOn f).Nonempty ↔ s.Nonempty := image_nonempty
+@[simp] lemma graphOn_empty (f : α → β) : graphOn f ∅ = ∅ := by simp [graphOn]
+@[simp] lemma graphOn_eq_empty : graphOn f s = ∅ ↔ s = ∅ := by simp [graphOn, Set.ext_iff]
+@[simp] lemma graphOn_nonempty : (s.graphOn f).Nonempty ↔ s.Nonempty := by
+  simp [graphOn, Set.Nonempty]
 
 protected alias ⟨_, Nonempty.graphOn⟩ := graphOn_nonempty
 
 @[simp]
-lemma graphOn_union (f : α → β) (s t : Set α) : graphOn f (s ∪ t) = graphOn f s ∪ graphOn f t :=
-  image_union ..
+lemma graphOn_union (f : α → β) (s t : Set α) : graphOn f (s ∪ t) = graphOn f s ∪ graphOn f t := by
+  simp [graphOn, or_and_right, setOf_or]
 
 @[simp]
-lemma graphOn_singleton (f : α → β) (x : α) : graphOn f {x} = {(x, f x)} :=
-  image_singleton ..
+lemma graphOn_singleton (f : α → β) (x : α) : graphOn f {x} = {(x, f x)} := by aesop
 
 @[simp]
 lemma graphOn_insert (f : α → β) (x : α) (s : Set α) :
-    graphOn f (insert x s) = insert (x, f x) (graphOn f s) :=
-  image_insert_eq ..
+    graphOn f (insert x s) = insert (x, f x) (graphOn f s) := by aesop
 
 @[simp]
-lemma image_fst_graphOn (f : α → β) (s : Set α) : Prod.fst '' graphOn f s = s := by
-  simp [graphOn, image_image]
+lemma image_fst_graphOn (f : α → β) (s : Set α) : Prod.fst '' graphOn f s = s := by aesop
 
 @[simp] lemma image_snd_graphOn (f : α → β) : Prod.snd '' s.graphOn f = f '' s := by ext x; simp
 
 lemma fst_injOn_graph : (s.graphOn f).InjOn Prod.fst := by aesop (add simp InjOn)
 
 lemma graphOn_comp (s : Set α) (f : α → β) (g : β → γ) :
-    s.graphOn (g ∘ f) = (fun x ↦ (x.1, g x.2)) '' s.graphOn f := by
-  simpa using image_comp (fun x ↦ (x.1, g x.2)) (fun x ↦ (x, f x)) _
+    s.graphOn (g ∘ f) = (fun x ↦ (x.1, g x.2)) '' s.graphOn f := by aesop
 
-lemma graphOn_univ_eq_range : univ.graphOn f = range fun x ↦ (x, f x) := image_univ
+lemma graphOn_univ_eq_range : univ.graphOn f = range fun x ↦ (x, f x) := by aesop
 
 @[simp] lemma graphOn_inj {g : α → β} : s.graphOn f = s.graphOn g ↔ s.EqOn f g := by
   simp [Set.ext_iff, funext_iff, forall_swap, EqOn]

--- a/Mathlib/MeasureTheory/Covering/Besicovitch.lean
+++ b/Mathlib/MeasureTheory/Covering/Besicovitch.lean
@@ -846,7 +846,7 @@ theorem exists_disjoint_closedBall_covering_ae (μ : Measure α) [SFinite μ] (f
     refine fun x hx y hy heq ↦ v_disj.eq hx hy <| not_disjoint_iff.2 ⟨x.1, ?_⟩
     simp [*]
   have hinj : InjOn (fun x ↦ (x, r x)) t := LeftInvOn.injOn (f₁' := Prod.fst) fun _ _ ↦ rfl
-  simp only [graphOn, forall_mem_image, biUnion_image, hinj.pairwiseDisjoint_image] at *
+  simp only [graphOn_eq_image, forall_mem_image, biUnion_image, hinj.pairwiseDisjoint_image] at *
   exact ⟨t, r, countable_of_injective_of_countable_image hinj v_count, vs, vg, μv, v_disj⟩
 
 /-- In a space with the Besicovitch property, any set `s` can be covered with balls whose measures


### PR DESCRIPTION
The definition as an image is cute but not very useful. Also unsimp `graphOn_univ` since the RHS contains `f` more times than the LHS does.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
Later, I would like to introduce `Set.graph` to have a `Set` version with good defeqs of `LinearMap.graph` and alike

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
