### PR TITLE
[Merged by Bors] - chore(Submonoid): make `coe` projection be a prefix

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -599,7 +599,7 @@ variable (R : Type u) {A : Type v} {B : Type w}
 variable [CommSemiring R] [Semiring A] [Algebra R A] [Semiring B] [Algebra R B]
 
 /-- The minimal subalgebra that includes `s`. -/
-@[simps! coe toSubsemiring]
+@[simps toSubsemiring]
 def adjoin (s : Set A) : Subalgebra R A :=
   { Subsemiring.closure (Set.range (algebraMap R A) ∪ s) with
     algebraMap_mem' := fun r => Subsemiring.subset_closure <| Or.inl ⟨r, rfl⟩ }

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -42,6 +42,8 @@ instance SubsemiringClass : SubsemiringClass (Subalgebra R A) A where
   one_mem {s} := one_mem s.toSubsemiring
   zero_mem {s} := zero_mem s.toSubsemiring
 
+initialize_simps_projections Subalgebra (carrier → coe, as_prefix coe)
+
 @[simp]
 theorem mem_toSubsemiring {S : Subalgebra R A} {x} : x ∈ S.toSubsemiring ↔ x ∈ S :=
   Iff.rfl
@@ -66,14 +68,11 @@ theorem toSubsemiring_inj {S U : Subalgebra R A} : S.toSubsemiring = U.toSubsemi
 
 /-- Copy of a subalgebra with a new `carrier` equal to the old one. Useful to fix definitional
 equalities. -/
+@[simps coe toSubsemiring]
 protected def copy (S : Subalgebra R A) (s : Set A) (hs : s = ↑S) : Subalgebra R A :=
   { S.toSubsemiring.copy s hs with
     carrier := s
     algebraMap_mem' := hs.symm ▸ S.algebraMap_mem' }
-
-@[simp]
-theorem coe_copy (S : Subalgebra R A) (s : Set A) (hs : s = ↑S) : (S.copy s hs : Set A) = s :=
-  rfl
 
 theorem copy_eq (S : Subalgebra R A) (s : Set A) (hs : s = ↑S) : S.copy s hs = S :=
   SetLike.coe_injective hs
@@ -170,6 +169,7 @@ protected theorem intCast_mem {R : Type u} {A : Type v} [CommRing R] [Ring A] [A
 @[deprecated intCast_mem (since := "2024-04-05")] alias coe_int_mem := Subalgebra.intCast_mem
 
 /-- The projection from a subalgebra of `A` to an additive submonoid of `A`. -/
+@[simps coe]
 def toAddSubmonoid {R : Type u} {A : Type v} [CommSemiring R] [Semiring A] [Algebra R A]
     (S : Subalgebra R A) : AddSubmonoid A :=
   S.toSubsemiring.toAddSubmonoid
@@ -181,6 +181,7 @@ def toAddSubmonoid {R : Type u} {A : Type v} [CommSemiring R] [Semiring A] [Alge
 --   S.toSubsemiring.toSubmonoid
 
 /-- A subalgebra over a ring is also a `Subring`. -/
+@[simps toSubsemiring]
 def toSubring {R : Type u} {A : Type v} [CommRing R] [Ring A] [Algebra R A] (S : Subalgebra R A) :
     Subring A :=
   { S.toSubsemiring with neg_mem' := S.neg_mem }
@@ -351,6 +352,7 @@ def toSubmoduleEquiv (S : Subalgebra R A) : toSubmodule S ≃ₗ[R] S :=
   LinearEquiv.ofEq _ _ rfl
 
 /-- Transport a subalgebra via an algebra homomorphism. -/
+@[simps! coe toSubsemiring]
 def map (f : A →ₐ[R] B) (S : Subalgebra R A) : Subalgebra R B :=
   { S.toSubsemiring.map (f : A →+* B) with
     algebraMap_mem' := fun r => f.commutes r ▸ Set.mem_image_of_mem _ (S.algebraMap_mem r) }
@@ -378,18 +380,14 @@ theorem map_toSubmodule {S : Subalgebra R A} {f : A →ₐ[R] B} :
     (toSubmodule <| S.map f) = S.toSubmodule.map f.toLinearMap :=
   SetLike.coe_injective rfl
 
-theorem map_toSubsemiring {S : Subalgebra R A} {f : A →ₐ[R] B} :
-    (S.map f).toSubsemiring = S.toSubsemiring.map f.toRingHom :=
-  SetLike.coe_injective rfl
-
-@[simp]
-theorem coe_map (S : Subalgebra R A) (f : A →ₐ[R] B) : (S.map f : Set B) = f '' S := rfl
-
 /-- Preimage of a subalgebra under an algebra homomorphism. -/
+@[simps! coe toSubsemiring]
 def comap (f : A →ₐ[R] B) (S : Subalgebra R B) : Subalgebra R A :=
   { S.toSubsemiring.comap (f : A →+* B) with
     algebraMap_mem' := fun r =>
       show f (algebraMap R A r) ∈ S from (f.commutes r).symm ▸ S.algebraMap_mem r }
+
+attribute [norm_cast] coe_comap
 
 theorem map_le {S : Subalgebra R A} {f : A →ₐ[R] B} {U : Subalgebra R B} :
     map f S ≤ U ↔ S ≤ comap f U :=
@@ -400,10 +398,6 @@ theorem gc_map_comap (f : A →ₐ[R] B) : GaloisConnection (map f) (comap f) :=
 @[simp]
 theorem mem_comap (S : Subalgebra R B) (f : A →ₐ[R] B) (x : A) : x ∈ S.comap f ↔ f x ∈ S :=
   Iff.rfl
-
-@[simp, norm_cast]
-theorem coe_comap (S : Subalgebra R B) (f : A →ₐ[R] B) : (S.comap f : Set A) = f ⁻¹' (S : Set B) :=
-  rfl
 
 instance noZeroDivisors {R A : Type*} [CommSemiring R] [Semiring A] [NoZeroDivisors A]
     [Algebra R A] (S : Subalgebra R A) : NoZeroDivisors S :=
@@ -450,6 +444,7 @@ variable {R A : Type*} [CommSemiring R] [Semiring A] [Algebra R A]
 variable (p : Submodule R A)
 
 /-- A submodule containing `1` and closed under multiplication is a subalgebra. -/
+@[simps coe toSubsemiring]
 def toSubalgebra (p : Submodule R A) (h_one : (1 : A) ∈ p)
     (h_mul : ∀ x y, x ∈ p → y ∈ p → x * y ∈ p) : Subalgebra R A :=
   { p with
@@ -462,10 +457,6 @@ def toSubalgebra (p : Submodule R A) (h_one : (1 : A) ∈ p)
 @[simp]
 theorem mem_toSubalgebra {p : Submodule R A} {h_one h_mul} {x} :
     x ∈ p.toSubalgebra h_one h_mul ↔ x ∈ p := Iff.rfl
-
-@[simp]
-theorem coe_toSubalgebra (p : Submodule R A) (h_one h_mul) :
-    (p.toSubalgebra h_one h_mul : Set A) = p := rfl
 
 -- Porting note: changed statement to reflect new structures
 -- @[simp] -- Porting note: as a result, it is no longer a great simp lemma
@@ -495,6 +486,7 @@ variable [Semiring A] [Algebra R A] [Semiring B] [Algebra R B] [Semiring C] [Alg
 variable (φ : A →ₐ[R] B)
 
 /-- Range of an `AlgHom` as a subalgebra. -/
+@[simps! coe toSubsemiring]
 protected def range (φ : A →ₐ[R] B) : Subalgebra R B :=
   { φ.toRingHom.rangeS with algebraMap_mem' := fun r => ⟨algebraMap R A r, φ.commutes r⟩ }
 
@@ -504,12 +496,6 @@ theorem mem_range (φ : A →ₐ[R] B) {y : B} : y ∈ φ.range ↔ ∃ x, φ x 
 
 theorem mem_range_self (φ : A →ₐ[R] B) (x : A) : φ x ∈ φ.range :=
   φ.mem_range.2 ⟨x, rfl⟩
-
-@[simp]
-theorem coe_range (φ : A →ₐ[R] B) : (φ.range : Set B) = Set.range φ := by
-  ext
-  rw [SetLike.mem_coe, mem_range]
-  rfl
 
 theorem range_comp (f : A →ₐ[R] B) (g : B →ₐ[R] C) : (g.comp f).range = f.range.map g :=
   SetLike.coe_injective (Set.range_comp g f)
@@ -613,7 +599,7 @@ variable (R : Type u) {A : Type v} {B : Type w}
 variable [CommSemiring R] [Semiring A] [Algebra R A] [Semiring B] [Algebra R B]
 
 /-- The minimal subalgebra that includes `s`. -/
-@[simps toSubsemiring]
+@[simps! coe toSubsemiring]
 def adjoin (s : Set A) : Subalgebra R A :=
   { Subsemiring.closure (Set.range (algebraMap R A) ∪ s) with
     algebraMap_mem' := fun r => Subsemiring.subset_closure <| Or.inl ⟨r, rfl⟩ }
@@ -1056,15 +1042,9 @@ variable (R A)
 
 /-- The center of an algebra is the set of elements which commute with every element. They form a
 subalgebra. -/
+@[simps! coe toSubsemiring]
 def center : Subalgebra R A :=
   { Subsemiring.center A with algebraMap_mem' := Set.algebraMap_mem_center }
-
-theorem coe_center : (center R A : Set A) = Set.center A :=
-  rfl
-
-@[simp]
-theorem center_toSubsemiring : (center R A).toSubsemiring = Subsemiring.center A :=
-  rfl
 
 @[simp]
 theorem center_toSubring (R A : Type*) [CommRing R] [Ring A] [Algebra R A] :
@@ -1141,6 +1121,7 @@ section Nat
 variable {R : Type*} [Semiring R]
 
 /-- A subsemiring is an `ℕ`-subalgebra. -/
+@[simps toSubsemiring]
 def subalgebraOfSubsemiring (S : Subsemiring R) : Subalgebra ℕ R :=
   { S with algebraMap_mem' := fun i => natCast_mem S i }
 
@@ -1156,6 +1137,7 @@ section Int
 variable {R : Type*} [Ring R]
 
 /-- A subring is a `ℤ`-subalgebra. -/
+@[simps toSubsemiring]
 def subalgebraOfSubring (S : Subring R) : Subalgebra ℤ R :=
   { S with
     algebraMap_mem' := fun i =>
@@ -1181,6 +1163,7 @@ variable {R A B : Type*} [CommSemiring R] [Semiring A] [Algebra R A] [Semiring B
 variable {F : Type*}
 
 /-- The equalizer of two R-algebra homomorphisms -/
+@[simps coe toSubsemiring]
 def equalizer (ϕ ψ : F) [FunLike F A B] [AlgHomClass F R A B] : Subalgebra R A where
   carrier := { a | ϕ a = ψ a }
   zero_mem' := by simp only [Set.mem_setOf_eq, map_zero]

--- a/Mathlib/Algebra/Algebra/Subalgebra/MulOpposite.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/MulOpposite.lean
@@ -22,25 +22,23 @@ section Semiring
 variable {ι : Sort*} {R A : Type*} [CommSemiring R] [Semiring A] [Algebra R A]
 
 /-- Pull a subalgebra back to an opposite subalgebra along `MulOpposite.unop` -/
-@[simps toSubsemiring]
+@[simps coe toSubsemiring]
 protected def op (S : Subalgebra R A) : Subalgebra R Aᵐᵒᵖ where
   toSubsemiring := S.toSubsemiring.op
   algebraMap_mem' := S.algebraMap_mem
 
-@[simp, norm_cast]
-theorem op_coe (S : Subalgebra R A) : S.op = MulOpposite.unop ⁻¹' (S : Set A) := rfl
+attribute [norm_cast] coe_op
 
 @[simp]
 theorem mem_op {x : Aᵐᵒᵖ} {S : Subalgebra R A} : x ∈ S.op ↔ x.unop ∈ S := Iff.rfl
 
 /-- Pull an subalgebra subring back to a subalgebra along `MulOpposite.op` -/
-@[simps toSubsemiring]
+@[simps coe toSubsemiring]
 protected def unop (S : Subalgebra R Aᵐᵒᵖ) : Subalgebra R A where
   toSubsemiring := S.toSubsemiring.unop
   algebraMap_mem' := S.algebraMap_mem
 
-@[simp, norm_cast]
-theorem unop_coe (S : Subalgebra R Aᵐᵒᵖ) : S.unop = MulOpposite.op ⁻¹' (S : Set Aᵐᵒᵖ) := rfl
+attribute [norm_cast] coe_unop
 
 @[simp]
 theorem mem_unop {x : A} {S : Subalgebra R Aᵐᵒᵖ} : x ∈ S.unop ↔ MulOpposite.op x ∈ S := Iff.rfl

--- a/Mathlib/Algebra/Algebra/Subalgebra/MulOpposite.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/MulOpposite.lean
@@ -22,7 +22,7 @@ section Semiring
 variable {ι : Sort*} {R A : Type*} [CommSemiring R] [Semiring A] [Algebra R A]
 
 /-- Pull a subalgebra back to an opposite subalgebra along `MulOpposite.unop` -/
-@[simps coe toSubsemiring]
+@[simps! coe toSubsemiring]
 protected def op (S : Subalgebra R A) : Subalgebra R Aᵐᵒᵖ where
   toSubsemiring := S.toSubsemiring.op
   algebraMap_mem' := S.algebraMap_mem
@@ -33,7 +33,7 @@ attribute [norm_cast] coe_op
 theorem mem_op {x : Aᵐᵒᵖ} {S : Subalgebra R A} : x ∈ S.op ↔ x.unop ∈ S := Iff.rfl
 
 /-- Pull an subalgebra subring back to a subalgebra along `MulOpposite.op` -/
-@[simps coe toSubsemiring]
+@[simps! coe toSubsemiring]
 protected def unop (S : Subalgebra R Aᵐᵒᵖ) : Subalgebra R A where
   toSubsemiring := S.toSubsemiring.unop
   algebraMap_mem' := S.algebraMap_mem

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -311,8 +311,8 @@ theorem mk_le_mk {s t : Set G} (h_one) (h_mul) (h_inv) (h_one') (h_mul') (h_inv'
     mk ⟨⟨s, h_one⟩, h_mul⟩ h_inv ≤ mk ⟨⟨t, h_one'⟩, h_mul'⟩ h_inv' ↔ s ⊆ t :=
   Iff.rfl
 
-initialize_simps_projections Subgroup (carrier → coe)
-initialize_simps_projections AddSubgroup (carrier → coe)
+initialize_simps_projections Subgroup (carrier → coe, as_prefix coe)
+initialize_simps_projections AddSubgroup (carrier → coe, as_prefix coe)
 
 @[to_additive (attr := simp)]
 theorem coe_toSubmonoid (K : Subgroup G) : (K.toSubmonoid : Set G) = K :=

--- a/Mathlib/Algebra/Group/Subgroup/MulOppositeLemmas.lean
+++ b/Mathlib/Algebra/Group/Subgroup/MulOppositeLemmas.lean
@@ -103,7 +103,7 @@ theorem unop_iInf (S : ι → Subgroup Gᵐᵒᵖ) : (iInf S).unop = ⨅ i, (S i
 
 @[to_additive]
 theorem op_closure (s : Set G) : (closure s).op = closure (MulOpposite.unop ⁻¹' s) := by
-  simp_rw [closure, op_sInf, Set.preimage_setOf_eq, Subgroup.unop_coe]
+  simp_rw [closure, op_sInf, Set.preimage_setOf_eq, Subgroup.coe_unop]
   congr with a
   exact MulOpposite.unop_surjective.forall
 

--- a/Mathlib/Algebra/Group/Submonoid/Defs.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Defs.lean
@@ -131,9 +131,8 @@ instance : SubmonoidClass (Submonoid M) M where
   one_mem := Submonoid.one_mem'
   mul_mem {s} := s.mul_mem'
 
-initialize_simps_projections Submonoid (carrier → coe)
-
-initialize_simps_projections AddSubmonoid (carrier → coe)
+initialize_simps_projections Submonoid (carrier → coe, as_prefix coe)
+initialize_simps_projections AddSubmonoid (carrier → coe, as_prefix coe)
 
 @[to_additive (attr := simp)]
 theorem mem_toSubsemigroup {s : Submonoid M} {x : M} : x ∈ s.toSubsemigroup ↔ x ∈ s :=

--- a/Mathlib/Algebra/Group/Submonoid/MulOpposite.lean
+++ b/Mathlib/Algebra/Group/Submonoid/MulOpposite.lean
@@ -157,7 +157,7 @@ theorem unop_iInf (S : ι → Submonoid Mᵐᵒᵖ) : (iInf S).unop = ⨅ i, (S 
 
 @[to_additive]
 theorem op_closure (s : Set M) : (closure s).op = closure (MulOpposite.unop ⁻¹' s) := by
-  simp_rw [closure, op_sInf, Set.preimage_setOf_eq, Submonoid.unop_coe]
+  simp_rw [closure, op_sInf, Set.preimage_setOf_eq, Submonoid.coe_unop]
   congr with a
   exact MulOpposite.unop_surjective.forall
 

--- a/Mathlib/Algebra/Ring/Subring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subring/Defs.lean
@@ -163,6 +163,8 @@ instance : SubringClass (Subring R) R where
   mul_mem {s} := s.mul_mem'
   neg_mem {s} := s.neg_mem'
 
+initialize_simps_projections Subring (carrier → coe, as_prefix coe)
+
 @[simp]
 theorem mem_toSubsemiring {s : Subring R} {x : R} : x ∈ s.toSubsemiring ↔ x ∈ s := Iff.rfl
 
@@ -186,14 +188,11 @@ theorem ext {S T : Subring R} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T :=
 
 /-- Copy of a subring with a new `carrier` equal to the old one. Useful to fix definitional
 equalities. -/
+@[simps coe toSubsemiring]
 protected def copy (S : Subring R) (s : Set R) (hs : s = ↑S) : Subring R :=
   { S.toSubsemiring.copy s hs with
     carrier := s
     neg_mem' := hs.symm ▸ S.neg_mem' }
-
-@[simp]
-theorem coe_copy (S : Subring R) (s : Set R) (hs : s = ↑S) : (S.copy s hs : Set R) = s :=
-  rfl
 
 theorem copy_eq (S : Subring R) (s : Set R) (hs : s = ↑S) : S.copy s hs = S :=
   SetLike.coe_injective hs
@@ -209,14 +208,10 @@ theorem toSubmonoid_injective : Function.Injective (fun s : Subring R => s.toSub
 
 /-- Construct a `Subring R` from a set `s`, a submonoid `sm`, and an additive
 subgroup `sa` such that `x ∈ s ↔ x ∈ sm ↔ x ∈ sa`. -/
+@[simps! coe toSubsemiring]
 protected def mk' (s : Set R) (sm : Submonoid R) (sa : AddSubgroup R) (hm : ↑sm = s)
     (ha : ↑sa = s) : Subring R :=
   { sm.copy s hm.symm, sa.copy s ha.symm with }
-
-@[simp]
-theorem coe_mk' {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : AddSubgroup R} (ha : ↑sa = s) :
-    (Subring.mk' s sm sa hm ha : Set R) = s :=
-  rfl
 
 @[simp]
 theorem mem_mk' {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : AddSubgroup R} (ha : ↑sa = s)
@@ -236,6 +231,7 @@ theorem mk'_toAddSubgroup {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : 
 end Subring
 
 /-- A `Subsemiring` containing -1 is a `Subring`. -/
+@[simps toSubsemiring]
 def Subsemiring.toSubring (s : Subsemiring R) (hneg : (-1 : R) ∈ s) : Subring R where
   toSubsemiring := s
   neg_mem' h := by

--- a/Mathlib/Algebra/Ring/Subring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subring/Defs.lean
@@ -208,7 +208,7 @@ theorem toSubmonoid_injective : Function.Injective (fun s : Subring R => s.toSub
 
 /-- Construct a `Subring R` from a set `s`, a submonoid `sm`, and an additive
 subgroup `sa` such that `x ∈ s ↔ x ∈ sm ↔ x ∈ sa`. -/
-@[simps! coe toSubsemiring]
+@[simps! coe]
 protected def mk' (s : Set R) (sm : Submonoid R) (sa : AddSubgroup R) (hm : ↑sm = s)
     (ha : ↑sa = s) : Subring R :=
   { sm.copy s hm.symm, sa.copy s ha.symm with }

--- a/Mathlib/Algebra/Ring/Subring/MulOpposite.lean
+++ b/Mathlib/Algebra/Ring/Subring/MulOpposite.lean
@@ -19,7 +19,7 @@ namespace Subring
 variable {ι : Sort*} {R : Type*} [Ring R]
 
 /-- Pull a subring back to an opposite subring along `MulOpposite.unop` -/
-@[simps coe toSubsemiring]
+@[simps! coe toSubsemiring]
 protected def op (S : Subring R) : Subring Rᵐᵒᵖ where
   toSubsemiring := S.toSubsemiring.op
   neg_mem' {x} hx := neg_mem (show x.unop ∈ S from hx)
@@ -30,7 +30,7 @@ attribute [norm_cast] coe_op
 theorem mem_op {x : Rᵐᵒᵖ} {S : Subring R} : x ∈ S.op ↔ x.unop ∈ S := Iff.rfl
 
 /-- Pull an opposite subring back to a subring along `MulOpposite.op` -/
-@[simps coe toSubsemiring]
+@[simps! coe toSubsemiring]
 protected def unop (S : Subring Rᵐᵒᵖ) : Subring R where
   toSubsemiring := S.toSubsemiring.unop
   neg_mem' {x} hx := neg_mem (show MulOpposite.op x ∈ S from hx)

--- a/Mathlib/Algebra/Ring/Subring/MulOpposite.lean
+++ b/Mathlib/Algebra/Ring/Subring/MulOpposite.lean
@@ -19,25 +19,23 @@ namespace Subring
 variable {ι : Sort*} {R : Type*} [Ring R]
 
 /-- Pull a subring back to an opposite subring along `MulOpposite.unop` -/
-@[simps toSubsemiring]
+@[simps coe toSubsemiring]
 protected def op (S : Subring R) : Subring Rᵐᵒᵖ where
   toSubsemiring := S.toSubsemiring.op
   neg_mem' {x} hx := neg_mem (show x.unop ∈ S from hx)
 
-@[simp, norm_cast]
-theorem op_coe (S : Subring R) : S.op = MulOpposite.unop ⁻¹' (S : Set R) := rfl
+attribute [norm_cast] coe_op
 
 @[simp]
 theorem mem_op {x : Rᵐᵒᵖ} {S : Subring R} : x ∈ S.op ↔ x.unop ∈ S := Iff.rfl
 
 /-- Pull an opposite subring back to a subring along `MulOpposite.op` -/
-@[simps toSubsemiring]
+@[simps coe toSubsemiring]
 protected def unop (S : Subring Rᵐᵒᵖ) : Subring R where
   toSubsemiring := S.toSubsemiring.unop
   neg_mem' {x} hx := neg_mem (show MulOpposite.op x ∈ S from hx)
 
-@[simp, norm_cast]
-theorem unop_coe (S : Subring Rᵐᵒᵖ) : S.unop = MulOpposite.op ⁻¹' (S : Set Rᵐᵒᵖ) := rfl
+attribute [norm_cast] coe_unop
 
 @[simp]
 theorem mem_unop {x : R} {S : Subring Rᵐᵒᵖ} : x ∈ S.unop ↔ MulOpposite.op x ∈ S := Iff.rfl
@@ -135,7 +133,7 @@ theorem unop_iInf (S : ι → Subring Rᵐᵒᵖ) : (iInf S).unop = ⨅ i, (S i)
   opEquiv.symm.map_iInf _
 
 theorem op_closure (s : Set R) : (closure s).op = closure (MulOpposite.unop ⁻¹' s) := by
-  simp_rw [closure, op_sInf, Set.preimage_setOf_eq, unop_coe]
+  simp_rw [closure, op_sInf, Set.preimage_setOf_eq, coe_unop]
   congr with a
   exact MulOpposite.unop_surjective.forall
 

--- a/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
@@ -103,12 +103,9 @@ def topEquiv : (⊤ : Subsemiring R) ≃+* R where
   map_add' := (⊤ : Subsemiring R).coe_add
 
 /-- The preimage of a subsemiring along a ring homomorphism is a subsemiring. -/
+@[simps coe toSubmonoid]
 def comap (f : R →+* S) (s : Subsemiring S) : Subsemiring R :=
   { s.toSubmonoid.comap (f : R →* S), s.toAddSubmonoid.comap (f : R →+ S) with carrier := f ⁻¹' s }
-
-@[simp]
-theorem coe_comap (s : Subsemiring S) (f : R →+* S) : (s.comap f : Set R) = f ⁻¹' s :=
-  rfl
 
 @[simp]
 theorem mem_comap {s : Subsemiring S} {f : R →+* S} {x : R} : x ∈ s.comap f ↔ f x ∈ s :=
@@ -119,12 +116,9 @@ theorem comap_comap (s : Subsemiring T) (g : S →+* T) (f : R →+* S) :
   rfl
 
 /-- The image of a subsemiring along a ring homomorphism is a subsemiring. -/
+@[simps coe toSubmonoid]
 def map (f : R →+* S) (s : Subsemiring R) : Subsemiring S :=
   { s.toSubmonoid.map (f : R →* S), s.toAddSubmonoid.map (f : R →+ S) with carrier := f '' s }
-
-@[simp]
-theorem coe_map (f : R →+* S) (s : Subsemiring R) : (s.map f : Set S) = f '' s :=
-  rfl
 
 @[simp]
 lemma mem_map {f : R →+* S} {s : Subsemiring R} {y : S} : y ∈ s.map f ↔ ∃ x ∈ s, f x = y := Iff.rfl
@@ -161,12 +155,9 @@ namespace RingHom
 variable (g : S →+* T) (f : R →+* S)
 
 /-- The range of a ring homomorphism is a subsemiring. See Note [range copy pattern]. -/
+@[simps! coe toSubmonoid]
 def rangeS : Subsemiring S :=
   ((⊤ : Subsemiring R).map f).copy (Set.range f) Set.image_univ.symm
-
-@[simp]
-theorem coe_rangeS : (f.rangeS : Set S) = Set.range f :=
-  rfl
 
 @[simp]
 theorem mem_rangeS {f : R →+* S} {y : S} : y ∈ f.rangeS ↔ ∃ x, f x = y :=
@@ -260,16 +251,10 @@ variable (R)
 
 /-- The center of a non-associative semiring `R` is the set of elements that commute and associate
 with everything in `R` -/
+@[simps coe toSubmonoid]
 def center : Subsemiring R :=
   { NonUnitalSubsemiring.center R with
     one_mem' := Set.one_mem_center }
-
-theorem coe_center : ↑(center R) = Set.center R :=
-  rfl
-
-@[simp]
-theorem center_toSubmonoid : (center R).toSubmonoid = Submonoid.center R :=
-  rfl
 
 /-- The center is commutative and associative.
 

--- a/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
@@ -137,6 +137,8 @@ instance : SubsemiringClass (Subsemiring R) R where
   one_mem {s} := Submonoid.one_mem' s.toSubmonoid
   mul_mem {s} := Subsemigroup.mul_mem' s.toSubmonoid.toSubsemigroup
 
+initialize_simps_projections Subsemiring (carrier → coe, as_prefix coe)
+
 @[simp]
 theorem mem_toSubmonoid {s : Subsemiring R} {x : R} : x ∈ s.toSubmonoid ↔ x ∈ s :=
   Iff.rfl
@@ -151,12 +153,9 @@ theorem ext {S T : Subsemiring R} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T :=
 
 /-- Copy of a subsemiring with a new `carrier` equal to the old one. Useful to fix definitional
 equalities. -/
+@[simps coe toSubmonoid]
 protected def copy (S : Subsemiring R) (s : Set R) (hs : s = ↑S) : Subsemiring R :=
   { S.toAddSubmonoid.copy s hs, S.toSubmonoid.copy s hs with carrier := s }
-
-@[simp]
-theorem coe_copy (S : Subsemiring R) (s : Set R) (hs : s = ↑S) : (S.copy s hs : Set R) = s :=
-  rfl
 
 theorem copy_eq (S : Subsemiring R) (s : Set R) (hs : s = ↑S) : S.copy s hs = S :=
   SetLike.coe_injective hs
@@ -170,6 +169,7 @@ theorem toAddSubmonoid_injective :
 
 /-- Construct a `Subsemiring R` from a set `s`, a submonoid `sm`, and an additive
 submonoid `sa` such that `x ∈ s ↔ x ∈ sm ↔ x ∈ sa`. -/
+@[simps coe]
 protected def mk' (s : Set R) (sm : Submonoid R) (hm : ↑sm = s) (sa : AddSubmonoid R)
     (ha : ↑sa = s) : Subsemiring R where
   carrier := s
@@ -177,11 +177,6 @@ protected def mk' (s : Set R) (sm : Submonoid R) (hm : ↑sm = s) (sa : AddSubmo
   one_mem' := by exact hm ▸ sm.one_mem
   add_mem' {x y} := by simpa only [← ha] using sa.add_mem
   mul_mem' {x y} := by simpa only [← hm] using sm.mul_mem
-
-@[simp]
-theorem coe_mk' {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : AddSubmonoid R} (ha : ↑sa = s) :
-    (Subsemiring.mk' s sm hm sa ha : Set R) = s :=
-  rfl
 
 @[simp]
 theorem mem_mk' {s : Set R} {sm : Submonoid R} (hm : ↑sm = s) {sa : AddSubmonoid R} (ha : ↑sa = s)

--- a/Mathlib/Algebra/Ring/Subsemiring/MulOpposite.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/MulOpposite.lean
@@ -20,28 +20,26 @@ namespace Subsemiring
 variable {ι : Sort*} {R : Type*} [NonAssocSemiring R]
 
 /-- Pull a subsemiring back to an opposite subsemiring along `MulOpposite.unop` -/
-@[simps toSubmonoid]
+@[simps coe toSubmonoid]
 protected def op (S : Subsemiring R) : Subsemiring Rᵐᵒᵖ where
   toSubmonoid := S.toSubmonoid.op
   add_mem' {x} {y} hx hy := add_mem (show x.unop ∈ S from hx) (show y.unop ∈ S from hy)
   zero_mem' := zero_mem S
 
-@[simp, norm_cast]
-theorem op_coe (S : Subsemiring R) : S.op = MulOpposite.unop ⁻¹' (S : Set R) := rfl
+attribute [norm_cast] coe_op
 
 @[simp]
 theorem mem_op {x : Rᵐᵒᵖ} {S : Subsemiring R} : x ∈ S.op ↔ x.unop ∈ S := Iff.rfl
 
 /-- Pull an opposite subsemiring back to a subsemiring along `MulOpposite.op` -/
-@[simps toSubmonoid]
+@[simps coe toSubmonoid]
 protected def unop (S : Subsemiring Rᵐᵒᵖ) : Subsemiring R where
   toSubmonoid := S.toSubmonoid.unop
   add_mem' {x} {y} hx hy := add_mem
     (show MulOpposite.op x ∈ S from hx) (show MulOpposite.op y ∈ S from hy)
   zero_mem' := zero_mem S
 
-@[simp, norm_cast]
-theorem unop_coe (S : Subsemiring Rᵐᵒᵖ) : S.unop = MulOpposite.op ⁻¹' (S : Set Rᵐᵒᵖ) := rfl
+attribute [norm_cast] coe_unop
 
 @[simp]
 theorem mem_unop {x : R} {S : Subsemiring Rᵐᵒᵖ} : x ∈ S.unop ↔ MulOpposite.op x ∈ S := Iff.rfl
@@ -142,7 +140,7 @@ theorem unop_iInf (S : ι → Subsemiring Rᵐᵒᵖ) : (iInf S).unop = ⨅ i, (
   opEquiv.symm.map_iInf _
 
 theorem op_closure (s : Set R) : (closure s).op = closure (MulOpposite.unop ⁻¹' s) := by
-  simp_rw [closure, op_sInf, Set.preimage_setOf_eq, unop_coe]
+  simp_rw [closure, op_sInf, Set.preimage_setOf_eq, coe_unop]
   congr with a
   exact MulOpposite.unop_surjective.forall
 

--- a/Mathlib/Algebra/Ring/Subsemiring/MulOpposite.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/MulOpposite.lean
@@ -20,7 +20,7 @@ namespace Subsemiring
 variable {ι : Sort*} {R : Type*} [NonAssocSemiring R]
 
 /-- Pull a subsemiring back to an opposite subsemiring along `MulOpposite.unop` -/
-@[simps coe toSubmonoid]
+@[simps! coe toSubmonoid]
 protected def op (S : Subsemiring R) : Subsemiring Rᵐᵒᵖ where
   toSubmonoid := S.toSubmonoid.op
   add_mem' {x} {y} hx hy := add_mem (show x.unop ∈ S from hx) (show y.unop ∈ S from hy)
@@ -32,7 +32,7 @@ attribute [norm_cast] coe_op
 theorem mem_op {x : Rᵐᵒᵖ} {S : Subsemiring R} : x ∈ S.op ↔ x.unop ∈ S := Iff.rfl
 
 /-- Pull an opposite subsemiring back to a subsemiring along `MulOpposite.op` -/
-@[simps coe toSubmonoid]
+@[simps! coe toSubmonoid]
 protected def unop (S : Subsemiring Rᵐᵒᵖ) : Subsemiring R where
   toSubmonoid := S.toSubmonoid.unop
   add_mem' {x} {y} hx hy := add_mem


### PR DESCRIPTION
Change `initialize_simps_projection` to use `coe` as prefix on `Submonoid` and `Subgroup`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
