### PR TITLE
[Merged by Bors] - feat: make `tsub_self` a `simp` lemma

### DIFF
--- a/Mathlib/Algebra/Order/Sub/Basic.lean
+++ b/Mathlib/Algebra/Order/Sub/Basic.lean
@@ -32,6 +32,7 @@ theorem tsub_eq_zero_iff_le : a - b = 0 ↔ a ≤ b := by
 
 alias ⟨_, tsub_eq_zero_of_le⟩ := tsub_eq_zero_iff_le
 
+@[simp]
 theorem tsub_self (a : α) : a - a = 0 :=
   tsub_eq_zero_of_le le_rfl
 


### PR DESCRIPTION
The lemma `tsub_eq_zero_iff_le` used to be `@[simp]`, but this was (intentionally) changed a few months ago. As a result, goals like `(1 : ℝ≥0) - 1 = 0` are no longer provable by any easy tactic, which is silly. The solution is to mark `tsub_self` with `@[simp]`, which is safe.

---

in case you want to try it for yourself:

```lean
import Mathlib

open scoped NNReal

example : (1 : ℝ≥0) - 1 = 0 := by hint -- works, but only because it finds `exact tsub_self 1`
```

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
