### PR TITLE
chore: remove `TensorProduct` from the import list of `Ideal.Operations`

### DIFF
--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -3,10 +3,9 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Yury Kudryashov
 -/
-import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.Algebra.NonUnitalHom
-import Mathlib.Algebra.GroupPower.IterateHom
-import Mathlib.LinearAlgebra.TensorProduct.Basic
+import Mathlib.LinearAlgebra.BilinearMap
+import Mathlib.LinearAlgebra.Span
 
 /-!
 # Facts about algebras involving bilinear maps and tensor products
@@ -16,7 +15,7 @@ in order to avoid importing `LinearAlgebra.BilinearMap` and
 `LinearAlgebra.TensorProduct` unnecessarily.
 -/
 
-open TensorProduct Module
+open Module
 
 namespace LinearMap
 
@@ -24,16 +23,6 @@ section NonUnitalNonAssoc
 
 variable (R A : Type*) [CommSemiring R] [NonUnitalNonAssocSemiring A] [Module R A]
   [SMulCommClass R A A] [IsScalarTower R A A]
-
-/-- The multiplication in a non-unital non-associative algebra is a bilinear map.
-
-A weaker version of this for semirings exists as `AddMonoidHom.mul`. -/
-def mul : A →ₗ[R] A →ₗ[R] A :=
-  LinearMap.mk₂ R (· * ·) add_mul smul_mul_assoc mul_add mul_smul_comm
-
-/-- The multiplication map on a non-unital algebra, as an `R`-linear map from `A ⊗[R] A` to `A`. -/
-noncomputable def mul' : A ⊗[R] A →ₗ[R] A :=
-  TensorProduct.lift (mul R A)
 
 variable {A}
 
@@ -73,10 +62,6 @@ theorem mulRight_apply (a b : A) : mulRight R a b = b * a :=
 
 @[simp]
 theorem mulLeftRight_apply (a b x : A) : mulLeftRight R (a, b) x = a * x * b :=
-  rfl
-
-@[simp]
-theorem mul'_apply {a b : A} : mul' R A (a ⊗ₜ b) = a * b :=
   rfl
 
 @[simp]

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.Algebra.Algebra.Opposite
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
+import Mathlib.Algebra.Module.Submodule.Bilinear
 import Mathlib.Algebra.Module.Submodule.Pointwise
 import Mathlib.Data.Set.Pointwise.BigOperators
 import Mathlib.Data.Set.Semiring

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -376,6 +376,20 @@ protected abbrev BilinForm : Type _ := LinearMap.BilinMap R M R
 
 end CommSemiring
 
+section NonUnitalNonAssocSemiring
+
+variable (R A : Type*) [CommSemiring R] [NonUnitalNonAssocSemiring A] [Module R A]
+  [SMulCommClass R A A] [IsScalarTower R A A]
+
+/-- The multiplication in a non-unital non-associative algebra is a bilinear map.
+
+A weaker version of this for semirings exists as `AddMonoidHom.mul`.
+Also see other variants defined in `Algebra/Algebra/Operations`. -/
+def mul : A →ₗ[R] A →ₗ[R] A :=
+  LinearMap.mk₂ R (· * ·) add_mul smul_mul_assoc mul_add mul_smul_comm
+
+end NonUnitalNonAssocSemiring
+
 section CommRing
 
 variable {R M : Type*} [CommRing R]

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -1486,3 +1486,19 @@ theorem rTensor_neg (f : N →ₗ[R] P) : (-f).rTensor M = -f.rTensor M := by
 end LinearMap
 
 end Ring
+
+open TensorProduct
+
+namespace LinearMap
+
+variable (R A : Type*) [CommSemiring R] [NonUnitalNonAssocSemiring A] [Module R A]
+  [SMulCommClass R A A] [IsScalarTower R A A]
+
+/-- The multiplication map on a non-unital algebra, as an `R`-linear map from `A ⊗[R] A` to `A`. -/
+noncomputable def mul' : A ⊗[R] A →ₗ[R] A := TensorProduct.lift (mul R A)
+
+@[simp] theorem mul'_apply {a b : A} : mul' R A (a ⊗ₜ b) = a * b := rfl
+
+end LinearMap
+
+set_option linter.style.longFile 1700

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -15,6 +15,7 @@ import Mathlib.RingTheory.NonUnitalSubsemiring.Basic
 
 assert_not_exists Basis -- See `RingTheory.Ideal.Basis`
 assert_not_exists Submodule.hasQuotient -- See `RingTheory.Ideal.Quotient.Operations`
+assert_not_exists TensorProduct
 
 universe u v w x
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
