### PR TITLE
[Merged by Bors] - CI(maintainer merge): emphasize merge/delegate

### DIFF
--- a/scripts/maintainer_merge_message.sh
+++ b/scripts/maintainer_merge_message.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 AUTHOR="${1:-AUTHOR not set}"         # the author of the PR
-M_or_D="**${2:-M_or_D not set}**"         # `merge` or `delegate`
+M_or_D="**${2:-M_or_D not set}**"     # `merge` or `delegate`
 EVENT_NAME="${3:-EVENT_NAME not set}" # one of `issue_comment`, `pull_request_review` or `pull_request_review_comment`
                                       # to be converted to `comment`, `review` or `review comment`
 PR="${4:-PR not set}"                 # the number of the PR

--- a/scripts/maintainer_merge_message.sh
+++ b/scripts/maintainer_merge_message.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 AUTHOR="${1:-AUTHOR not set}"         # the author of the PR
-M_or_D="**${2:-M_or_D not set}**"     # `merge` or `delegate`
+M_or_D="${2:-M_or_D not set}"         # `merge` or `delegate`
 EVENT_NAME="${3:-EVENT_NAME not set}" # one of `issue_comment`, `pull_request_review` or `pull_request_review_comment`
                                       # to be converted to `comment`, `review` or `review comment`
 PR="${4:-PR not set}"                 # the number of the PR
@@ -34,5 +34,5 @@ esac
 >&2 echo "title:      '${PR_TITLE}'"
 >&2 echo "EVENT_NAME: '${EVENT_NAME}'"
 
-printf '%s requested a maintainer %s from %s on PR [#%s](%s):\n' "${AUTHOR}" "${M_or_D}" "${SOURCE}" "${PR}" "${URL}"
+printf '%s requested a maintainer **%s** from %s on PR [#%s](%s):\n' "${AUTHOR}" "${M_or_D}" "${SOURCE}" "${PR}" "${URL}"
 printf '> %s\n' "${PR_TITLE}"

--- a/scripts/maintainer_merge_message.sh
+++ b/scripts/maintainer_merge_message.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 AUTHOR="${1:-AUTHOR not set}"         # the author of the PR
-M_or_D="${2:-M_or_D not set}"         # `merge` or `delegate`
+M_or_D="**${2:-M_or_D not set}**"         # `merge` or `delegate`
 EVENT_NAME="${3:-EVENT_NAME not set}" # one of `issue_comment`, `pull_request_review` or `pull_request_review_comment`
                                       # to be converted to `comment`, `review` or `review comment`
 PR="${4:-PR not set}"                 # the number of the PR


### PR DESCRIPTION
Makes the words `delegate` and `merge` bold in the Zulip post triggered by `maintainer delegate`/`maintainer merge`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
