### PR TITLE
[Merged by Bors] - chore: move Polynomial.induction_on earlier

### DIFF
--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -892,6 +892,35 @@ theorem sum_monomial_eq : ∀ p : R[X], (p.sum fun n a => monomial n a) = p
 theorem sum_C_mul_X_pow_eq (p : R[X]) : (p.sum fun n a => C a * X ^ n) = p := by
   simp_rw [C_mul_X_pow_eq_monomial, sum_monomial_eq]
 
+@[elab_as_elim]
+protected theorem induction_on {M : R[X] → Prop} (p : R[X]) (h_C : ∀ a, M (C a))
+    (h_add : ∀ p q, M p → M q → M (p + q))
+    (h_monomial : ∀ (n : ℕ) (a : R), M (C a * X ^ n) → M (C a * X ^ (n + 1))) : M p := by
+  have A : ∀ {n : ℕ} {a}, M (C a * X ^ n) := by
+    intro n a
+    induction n with
+    | zero => rw [pow_zero, mul_one]; exact h_C a
+    | succ n ih => exact h_monomial _ _ ih
+  have B : ∀ s : Finset ℕ, M (s.sum fun n : ℕ => C (p.coeff n) * X ^ n) := by
+    apply Finset.induction
+    · convert h_C 0
+      exact C_0.symm
+    · intro n s ns ih
+      rw [sum_insert ns]
+      exact h_add _ _ A ih
+  rw [← sum_C_mul_X_pow_eq p, Polynomial.sum]
+  exact B (support p)
+
+/-- To prove something about polynomials,
+it suffices to show the condition is closed under taking sums,
+and it holds for monomials.
+-/
+@[elab_as_elim]
+protected theorem induction_on' {M : R[X] → Prop} (p : R[X]) (h_add : ∀ p q, M p → M q → M (p + q))
+    (h_monomial : ∀ (n : ℕ) (a : R), M (monomial n a)) : M p :=
+  Polynomial.induction_on p (h_monomial 0) h_add fun n a _h =>
+    by rw [C_mul_X_pow_eq_monomial]; exact h_monomial _ _
+
 /-- `erase p n` is the polynomial `p` in which the `X^n` term has been erased. -/
 irreducible_def erase (n : ℕ) : R[X] → R[X]
   | ⟨p⟩ => ⟨p.erase n⟩

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker
 -/
 import Mathlib.Algebra.Polynomial.Eval
+import Mathlib.Algebra.Prime.Lemmas
 
 /-!
 # Theory of degrees of polynomials

--- a/Mathlib/Algebra/Polynomial/Eval.lean
+++ b/Mathlib/Algebra/Polynomial/Eval.lean
@@ -3,10 +3,10 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker
 -/
-import Mathlib.Algebra.Polynomial.Degree.Definitions
-import Mathlib.Algebra.Polynomial.Induction
-import Mathlib.Algebra.Ring.Subsemiring.Basic
 import Mathlib.Algebra.Algebra.Defs
+import Mathlib.Algebra.Polynomial.Degree.Definitions
+import Mathlib.Algebra.Prime.Defs
+import Mathlib.Algebra.Ring.Subsemiring.Basic
 import Mathlib.Algebra.Ring.Subring.Basic
 
 /-!

--- a/Mathlib/Algebra/Polynomial/Induction.lean
+++ b/Mathlib/Algebra/Polynomial/Induction.lean
@@ -32,35 +32,6 @@ section Semiring
 
 variable [Semiring R]
 
-@[elab_as_elim]
-protected theorem induction_on {M : R[X] → Prop} (p : R[X]) (h_C : ∀ a, M (C a))
-    (h_add : ∀ p q, M p → M q → M (p + q))
-    (h_monomial : ∀ (n : ℕ) (a : R), M (C a * X ^ n) → M (C a * X ^ (n + 1))) : M p := by
-  have A : ∀ {n : ℕ} {a}, M (C a * X ^ n) := by
-    intro n a
-    induction n with
-    | zero => rw [pow_zero, mul_one]; exact h_C a
-    | succ n ih => exact h_monomial _ _ ih
-  have B : ∀ s : Finset ℕ, M (s.sum fun n : ℕ => C (p.coeff n) * X ^ n) := by
-    apply Finset.induction
-    · convert h_C 0
-      exact C_0.symm
-    · intro n s ns ih
-      rw [sum_insert ns]
-      exact h_add _ _ A ih
-  rw [← sum_C_mul_X_pow_eq p, Polynomial.sum]
-  exact B (support p)
-
-/-- To prove something about polynomials,
-it suffices to show the condition is closed under taking sums,
-and it holds for monomials.
--/
-@[elab_as_elim]
-protected theorem induction_on' {M : R[X] → Prop} (p : R[X]) (h_add : ∀ p q, M p → M q → M (p + q))
-    (h_monomial : ∀ (n : ℕ) (a : R), M (monomial n a)) : M p :=
-  Polynomial.induction_on p (h_monomial 0) h_add fun n a _h =>
-    by rw [C_mul_X_pow_eq_monomial]; exact h_monomial _ _
-
 open Submodule Polynomial Set
 
 variable {f : R[X]} {I : Ideal R[X]}

--- a/Mathlib/Algebra/Polynomial/Inductions.lean
+++ b/Mathlib/Algebra/Polynomial/Inductions.lean
@@ -5,7 +5,6 @@ Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Damiano Testa, Jens Wagema
 -/
 import Mathlib.Algebra.MonoidAlgebra.Division
 import Mathlib.Algebra.Polynomial.Degree.Definitions
-import Mathlib.Algebra.Polynomial.Induction
 import Mathlib.Algebra.Polynomial.EraseLead
 import Mathlib.Order.Interval.Finset.Nat
 

--- a/Mathlib/Algebra/Polynomial/Monic.lean
+++ b/Mathlib/Algebra/Polynomial/Monic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker
 -/
+import Mathlib.Algebra.Associated.Basic
 import Mathlib.Algebra.Polynomial.Reverse
 import Mathlib.Algebra.Regular.SMul
 

--- a/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
+++ b/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
 import Mathlib.Algebra.Polynomial.Mirror
+import Mathlib.Algebra.Ring.Regular
 import Mathlib.Data.Int.Order.Units
 import Mathlib.RingTheory.Coprime.Basic
 

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/IsOpenComapC.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/IsOpenComapC.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
+import Mathlib.Algebra.Polynomial.Induction
 import Mathlib.AlgebraicGeometry.PrimeSpectrum.Basic
 import Mathlib.RingTheory.Polynomial.Basic
 


### PR DESCRIPTION
This creates the odd situation that Induction.lean no longer contains anything about induction, which I'll fix after this.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
