### PR TITLE
[Merged by Bors] - chore: remove unused variables

### DIFF
--- a/Mathlib/Algebra/Associated/Basic.lean
+++ b/Mathlib/Algebra/Associated/Basic.lean
@@ -24,7 +24,7 @@ and prove basic properties of this quotient.
 assert_not_exists OrderedCommMonoid
 assert_not_exists Multiset
 
-variable {M N : Type*}
+variable {M : Type*}
 
 /-- Two elements of a `Monoid` are `Associated` if one of them is another one
 multiplied by a unit on the right. -/

--- a/Mathlib/Algebra/Group/Action/End.lean
+++ b/Mathlib/Algebra/Group/Action/End.lean
@@ -31,7 +31,7 @@ assert_not_exists MonoidWithZero
 
 open Function (Injective Surjective)
 
-variable {M N G H α β γ δ : Type*}
+variable {M N α : Type*}
 
 section
 variable [Monoid M] [MulAction M α]

--- a/Mathlib/Algebra/Group/Action/Faithful.lean
+++ b/Mathlib/Algebra/Group/Action/Faithful.lean
@@ -29,7 +29,7 @@ assert_not_exists MonoidWithZero
 
 open Function (Injective Surjective)
 
-variable {M N G H α β γ δ : Type*}
+variable {M G α : Type*}
 
 /-! ### Faithful actions -/
 

--- a/Mathlib/Algebra/Group/Action/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Action/TypeTags.lean
@@ -18,7 +18,7 @@ assert_not_exists MonoidWithZero
 
 open Function (Injective Surjective)
 
-variable {M N G H α β γ δ : Type*}
+variable {M α β γ : Type*}
 
 section
 

--- a/Mathlib/Algebra/Group/Fin/Tuple.lean
+++ b/Mathlib/Algebra/Group/Fin/Tuple.lean
@@ -12,7 +12,7 @@ import Mathlib.Data.Fin.VecNotation
 -/
 
 namespace Fin
-variable {m n : ℕ} {α : Fin (n + 1) → Type*}
+variable {n : ℕ} {α : Fin (n + 1) → Type*}
 
 @[to_additive (attr := simp)]
 lemma insertNth_one_right [∀ j, One (α j)] (i : Fin (n + 1)) (x : α i) :

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -54,8 +54,7 @@ assert_not_exists Ring
 open Function
 open scoped Int
 
-variable {G G' G'' : Type*} [Group G] [Group G'] [Group G'']
-variable {A : Type*} [AddGroup A]
+variable {G : Type*} [Group G] {A : Type*} [AddGroup A]
 
 section SubgroupClass
 
@@ -558,11 +557,7 @@ theorem subtype_comp_inclusion {H K : Subgroup G} (hH : H ≤ K) :
     K.subtype.comp (inclusion hH) = H.subtype :=
   rfl
 
-variable {k : Set G}
-
 open Set
-
-variable {N : Type*} [Group N] {P : Type*} [Group P]
 
 /-- A subgroup is normal if whenever `n ∈ H`, then `g * n * g⁻¹ ∈ H` for every `g : G` -/
 structure Normal : Prop where
@@ -588,7 +583,7 @@ end AddSubgroup
 
 namespace Subgroup
 
-variable {H K : Subgroup G}
+variable {H : Subgroup G}
 
 @[to_additive]
 instance (priority := 100) normal_of_comm {G : Type*} [CommGroup G] (H : Subgroup G) : H.Normal :=
@@ -619,7 +614,7 @@ end Subgroup
 
 namespace Subgroup
 
-variable (H : Subgroup G) {K : Subgroup G}
+variable (H : Subgroup G)
 
 section Normalizer
 

--- a/Mathlib/Algebra/Group/Subsemigroup/Membership.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Membership.lean
@@ -29,7 +29,7 @@ subsemigroup
 
 assert_not_exists MonoidWithZero
 
-variable {ι : Sort*} {M A B : Type*}
+variable {ι : Sort*} {M : Type*}
 
 section NonAssoc
 

--- a/Mathlib/Algebra/GroupWithZero/Action/End.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/End.lean
@@ -18,7 +18,7 @@ assert_not_exists Ring
 
 open Function
 
-variable {M N A B α β : Type*}
+variable {M N A α β : Type*}
 
 /-- Push forward the action of `R` on `M` along a compatible surjective map `f : R →* S`.
 

--- a/Mathlib/Algebra/Module/Prod.lean
+++ b/Mathlib/Algebra/Module/Prod.lean
@@ -13,7 +13,7 @@ This file defines instances for binary product of modules
 -/
 
 
-variable {R : Type*} {S : Type*} {M : Type*} {N : Type*}
+variable {R : Type*} {M : Type*} {N : Type*}
 
 namespace Prod
 

--- a/Mathlib/Algebra/Order/BigOperators/Group/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/List.lean
@@ -14,7 +14,7 @@ This file contains the results concerning the interaction of list big operators 
 groups/monoids.
 -/
 
-variable {ι α M N P M₀ G R : Type*}
+variable {ι α M N : Type*}
 
 namespace List
 section Monoid

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Lemmas.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Lemmas.lean
@@ -12,7 +12,7 @@ import Mathlib.Order.Hom.Basic
 # Multiplication by a positive element as an order isomorphism
 -/
 
-variable {G₀} [GroupWithZero G₀] [Preorder G₀] [ZeroLEOneClass G₀] {a : G₀}
+variable {G₀} [GroupWithZero G₀] [Preorder G₀] {a : G₀}
 
 /-- `Equiv.mulLeft₀` as an order isomorphism. -/
 @[simps! (config := { simpRhs := true })]

--- a/Mathlib/Algebra/Order/Hom/Ring.lean
+++ b/Mathlib/Algebra/Order/Hom/Ring.lean
@@ -295,7 +295,7 @@ namespace OrderRingIso
 
 section LE
 
-variable [Mul α] [Add α] [LE α] [Mul β] [Add β] [LE β] [Mul γ] [Add γ] [LE γ] [Mul δ] [Add δ] [LE δ]
+variable [Mul α] [Add α] [LE α] [Mul β] [Add β] [LE β] [Mul γ] [Add γ] [LE γ]
 
 /-- Reinterpret an ordered ring isomorphism as an order isomorphism. -/
 -- Porting note: Added @[coe] attribute
@@ -426,8 +426,7 @@ end LE
 
 section NonAssocSemiring
 
-variable [NonAssocSemiring α] [Preorder α] [NonAssocSemiring β] [Preorder β] [NonAssocSemiring γ]
-  [Preorder γ]
+variable [NonAssocSemiring α] [Preorder α] [NonAssocSemiring β] [Preorder β]
 
 /-- Reinterpret an ordered ring isomorphism as an ordered ring homomorphism. -/
 def toOrderRingHom (f : α ≃+*o β) : α →+*o β :=

--- a/Mathlib/Algebra/Prime/Defs.lean
+++ b/Mathlib/Algebra/Prime/Defs.lean
@@ -27,7 +27,7 @@ In decomposition monoids (e.g., `ℕ`, `ℤ`), this predicate is equivalent to `
 assert_not_exists OrderedCommMonoid
 assert_not_exists Multiset
 
-variable {M N : Type*}
+variable {M : Type*}
 
 section Prime
 
@@ -174,7 +174,7 @@ end CommMonoidWithZero
 
 section CancelCommMonoidWithZero
 
-variable [CancelCommMonoidWithZero M] {a p : M}
+variable [CancelCommMonoidWithZero M] {p : M}
 
 protected theorem Prime.irreducible (hp : Prime p) : Irreducible p :=
   ⟨hp.not_unit, fun a b ↦ by

--- a/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
@@ -45,7 +45,7 @@ instance (priority := 74) AddSubmonoidWithOneClass.toAddMonoidWithOne
 
 end AddSubmonoidWithOneClass
 
-variable {R : Type u} {S : Type v} {T : Type w} [NonAssocSemiring R] (M : Submonoid R)
+variable {R : Type u} {S : Type v} [NonAssocSemiring R]
 
 section SubsemiringClass
 
@@ -113,7 +113,7 @@ end SubsemiringClass
 
 end SubsemiringClass
 
-variable [NonAssocSemiring S] [NonAssocSemiring T]
+variable [NonAssocSemiring S]
 
 /-- A subsemiring of a semiring `R` is a subset `s` that is both a multiplicative and an additive
 submonoid. -/
@@ -329,9 +329,7 @@ end Subsemiring
 
 namespace RingHom
 
-variable [NonAssocSemiring T] {s : Subsemiring R}
-variable {σR σS : Type*}
-variable [SetLike σR R] [SetLike σS S] [SubsemiringClass σR R] [SubsemiringClass σS S]
+variable {s : Subsemiring R} {σR : Type*} [SetLike σR R] [SubsemiringClass σR R]
 
 open Subsemiring
 
@@ -352,15 +350,3 @@ theorem eqLocusS_same (f : R →+* S) : f.eqLocusS f = ⊤ :=
   SetLike.ext fun _ => eq_self_iff_true _
 
 end RingHom
-
-namespace Subsemiring
-
-open RingHom
-
-end Subsemiring
-
-namespace RingEquiv
-
-variable {s t : Subsemiring R}
-
-end RingEquiv

--- a/Mathlib/Data/List/Perm/Basic.lean
+++ b/Mathlib/Data/List/Perm/Basic.lean
@@ -24,7 +24,7 @@ assert_not_exists Monoid
 open Nat
 
 namespace List
-variable {α β : Type*} {l l₁ l₂ : List α} {a : α}
+variable {α β : Type*} {l : List α}
 
 instance : Trans (@List.Perm α) (@List.Perm α) List.Perm where
   trans := @List.Perm.trans α

--- a/Mathlib/Data/List/Perm/Lattice.lean
+++ b/Mathlib/Data/List/Perm/Lattice.lean
@@ -21,7 +21,7 @@ assert_not_exists Monoid
 open Nat
 
 namespace List
-variable {α β : Type*} {l l₁ l₂ : List α} {a : α}
+variable {α : Type*}
 
 open Perm (swap)
 

--- a/Mathlib/Data/List/Perm/Subperm.lean
+++ b/Mathlib/Data/List/Perm/Subperm.lean
@@ -20,7 +20,7 @@ The notation `<+~` is used for sub-permutations.
 open Nat
 
 namespace List
-variable {α β : Type*} {l l₁ l₂ : List α} {a : α}
+variable {α : Type*} {l l₁ l₂ : List α} {a : α}
 
 open Perm
 

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1773,7 +1773,7 @@ end Function
 
 section Disjoint
 
-variable {s t u : Set α} {f : α → β}
+variable {s t : Set α}
 
 namespace Set
 

--- a/Mathlib/Data/Set/SymmDiff.lean
+++ b/Mathlib/Data/Set/SymmDiff.lean
@@ -18,8 +18,8 @@ import Mathlib.Data.Set.Basic
 
 namespace Set
 
-universe u v
-variable {α : Type u} {β : Type v} {a b : α} {s s₁ s₂ t t₁ t₂ u : Set α}
+universe u
+variable {α : Type u} {a : α} {s t u : Set α}
 
 open scoped symmDiff
 

--- a/Mathlib/Deprecated/Logic.lean
+++ b/Mathlib/Deprecated/Logic.lean
@@ -20,7 +20,7 @@ variable {α : Sort u}
 
 section Binary
 
-variable {α : Type u} {β : Type v} (f : α → α → α) (inv : α → α) (one : α)
+variable {α : Type u} (f : α → α → α) (inv : α → α) (one : α)
 
 /-- Local notation for `f`, high priority to avoid ambiguity with `HMul.hMul`. -/
 local infix:70 (priority := high) " * " => f

--- a/Mathlib/Logic/Function/Defs.lean
+++ b/Mathlib/Logic/Function/Defs.lean
@@ -173,7 +173,7 @@ end Function
 
 namespace Function
 
-variable {α : Type u₁} {β : Type u₂} {φ : Type u₃}
+variable {α : Type u₁} {β : Type u₂}
 
 protected theorem LeftInverse.id {g : β → α} {f : α → β} (h : LeftInverse g f) : g ∘ f = id :=
   funext h

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -19,9 +19,9 @@ open Function Set
 
 open OrderDual (toDual ofDual)
 
-universe u v w x
+universe u v
 
-variable {α : Type u} {β : Type v} {γ : Type w} {ι : Sort x}
+variable {α : Type u} {γ : Type v}
 
 section
 

--- a/Mathlib/RingTheory/Congruence/Defs.lean
+++ b/Mathlib/RingTheory/Congruence/Defs.lean
@@ -38,7 +38,7 @@ add_decl_doc RingCon.toCon
 /-- The induced additive congruence from a `RingCon`. -/
 add_decl_doc RingCon.toAddCon
 
-variable {α R : Type*}
+variable {R : Type*}
 
 /-- The inductively defined smallest ring congruence relation containing a given binary
     relation. -/

--- a/Mathlib/RingTheory/NonUnitalSubring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Defs.lean
@@ -318,8 +318,7 @@ section Hom
 
 namespace NonUnitalSubring
 
-variable {R : Type u} {S : Type v}
-  [NonUnitalNonAssocRing R] [NonUnitalNonAssocRing S]
+variable {R : Type u} [NonUnitalNonAssocRing R]
 
 open NonUnitalRingHom
 

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -17,7 +17,7 @@ We define bundled non-unital subsemirings and some standard constructions:
 
 universe u v w
 
-variable {R : Type u} {S : Type v} {T : Type w} [NonUnitalNonAssocSemiring R] (M : Subsemigroup R)
+variable {R : Type u} {S : Type v} {T : Type w} [NonUnitalNonAssocSemiring R]
 
 /-- `NonUnitalSubsemiringClass S R` states that `S` is a type of subsets `s ⊆ R` that
 are both an additive submonoid and also a multiplicative subsemigroup. -/
@@ -156,10 +156,8 @@ end NonUnitalSubsemiring
 
 namespace NonUnitalSubsemiring
 
-variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
-variable {F G : Type*} [FunLike F R S] [NonUnitalRingHomClass F R S]
-  [FunLike G S T] [NonUnitalRingHomClass G S T]
-  (s : NonUnitalSubsemiring R)
+variable [NonUnitalNonAssocSemiring S]
+variable {F : Type*} [FunLike F R S] [NonUnitalRingHomClass F R S] (s : NonUnitalSubsemiring R)
 
 @[simp, norm_cast]
 theorem coe_zero : ((0 : s) : R) = (0 : R) :=
@@ -210,9 +208,9 @@ namespace NonUnitalRingHom
 
 open NonUnitalSubsemiring
 
-variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
-variable {F G : Type*} [FunLike F R S] [NonUnitalRingHomClass F R S]
-variable [FunLike G S T] [NonUnitalRingHomClass G S T] (f : F) (g : G)
+variable [NonUnitalNonAssocSemiring S]
+variable {F : Type*} [FunLike F R S] [NonUnitalRingHomClass F R S]
+variable (f : F)
 
 end NonUnitalRingHom
 
@@ -255,7 +253,7 @@ namespace NonUnitalRingHom
 
 variable {F : Type*} [FunLike F R S]
 
-variable [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring T]
+variable [NonUnitalNonAssocSemiring S]
   [NonUnitalRingHomClass F R S]
   {S' : Type*} [SetLike S' S] [NonUnitalSubsemiringClass S' S]
   {s : NonUnitalSubsemiring R}


### PR DESCRIPTION
#17715

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
