### PR TITLE
feat: two BigO lemmas for shifted functions

### DIFF
--- a/Mathlib/Analysis/Calculus/Deriv/Shift.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Shift.lean
@@ -61,3 +61,33 @@ lemma deriv_comp_const_sub : deriv (fun x ↦ f (a - x)) x = -deriv f (a - x) :=
 
 lemma deriv_comp_sub_const : deriv (fun x ↦ f (x - a)) x = deriv f (x - a) := by
   simp_rw [sub_eq_add_neg, deriv_comp_add_const]
+
+section BigO
+
+open Topology Asymptotics Filter
+
+lemma ContinuousAt.isBigO {𝕜 𝕜' : Type*} [NormedRing 𝕜] [NormedRing 𝕜'] [NormOneClass 𝕜']
+    {f : 𝕜 → 𝕜'} {z : 𝕜} (hf : ContinuousAt f z) :
+    (fun w ↦ f (w + z)) =O[𝓝 0] (fun _ ↦ (1 : 𝕜')) := by
+  rw [isBigO_iff']
+  replace hf : ContinuousAt (fun w ↦ f (w + z)) 0 := by
+    convert (Homeomorph.comp_continuousAt_iff' (Homeomorph.addLeft (-z)) _ z).mp ?_
+    · simp only [Homeomorph.coe_addLeft, neg_add_cancel]
+    · simp only [Homeomorph.coe_addLeft, Function.comp_def, neg_add_cancel_comm, hf]
+  simp_rw [Metric.continuousAt_iff', dist_eq_norm_sub, zero_add] at hf
+  specialize hf 1 zero_lt_one
+  refine ⟨‖f z‖ + 1, by positivity, ?_⟩
+  refine Eventually.mp hf <| Eventually.of_forall fun w hw ↦ le_of_lt ?_
+  calc ‖f (w + z)‖
+    _ ≤ ‖f z‖ + ‖f (w + z) - f z‖ := norm_le_insert' ..
+    _ < ‖f z‖ + 1 := add_lt_add_left hw _
+    _ = _ := by simp only [norm_one, mul_one]
+
+lemma DifferentiableAt.isBigO_of_eq_zero {f : 𝕜 → F} {z : 𝕜} (hf : DifferentiableAt 𝕜 f z)
+    (hz : f z = 0) :
+    (fun w ↦ f (w + z)) =O[𝓝 0] id := by
+  rw [← zero_add z] at hf
+  simpa only [zero_add, hz, sub_zero]
+    using (hf.hasDerivAt.comp_add_const 0 z).differentiableAt.isBigO_sub
+
+end BigO

--- a/Mathlib/Analysis/Calculus/Deriv/Shift.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Shift.lean
@@ -68,20 +68,8 @@ open Topology Asymptotics Filter
 
 lemma ContinuousAt.isBigO {𝕜 𝕜' : Type*} [NormedRing 𝕜] [NormedRing 𝕜'] [NormOneClass 𝕜']
     {f : 𝕜 → 𝕜'} {z : 𝕜} (hf : ContinuousAt f z) :
-    (fun w ↦ f (w + z)) =O[𝓝 0] (fun _ ↦ (1 : 𝕜')) := by
-  rw [isBigO_iff']
-  replace hf : ContinuousAt (fun w ↦ f (w + z)) 0 := by
-    convert (Homeomorph.comp_continuousAt_iff' (Homeomorph.addLeft (-z)) _ z).mp ?_
-    · simp only [Homeomorph.coe_addLeft, neg_add_cancel]
-    · simp only [Homeomorph.coe_addLeft, Function.comp_def, neg_add_cancel_comm, hf]
-  simp_rw [Metric.continuousAt_iff', dist_eq_norm_sub, zero_add] at hf
-  specialize hf 1 zero_lt_one
-  refine ⟨‖f z‖ + 1, by positivity, ?_⟩
-  refine Eventually.mp hf <| Eventually.of_forall fun w hw ↦ le_of_lt ?_
-  calc ‖f (w + z)‖
-    _ ≤ ‖f z‖ + ‖f (w + z) - f z‖ := norm_le_insert' ..
-    _ < ‖f z‖ + 1 := add_lt_add_left hw _
-    _ = _ := by simp only [norm_one, mul_one]
+    (fun w ↦ f (w + z)) =O[𝓝 0] (fun _ ↦ (1 : 𝕜')) :=
+  (ContinuousAt.comp ((zero_add z).symm ▸ hf) (by fun_prop)).tendsto.isBigO_one 𝕜'
 
 lemma DifferentiableAt.isBigO_of_eq_zero {f : 𝕜 → F} {z : 𝕜} (hf : DifferentiableAt 𝕜 f z)
     (hz : f z = 0) :


### PR DESCRIPTION
This third PR in [this series](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/Prerequisites.20for.20PNT.20and.20Dirichlet's.20Thm/near/482005581) adds two further `IsBigO` lemmas for functions of the form `f (· + z)`.

From [EulerProducts](https://github.com/MichaelStollBayreuth/EulerProducts).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
