### PR TITLE
[Merged by Bors] - feat: LSeries commutes with finite sums

### DIFF
--- a/Mathlib/NumberTheory/LSeries/Linearity.lean
+++ b/Mathlib/NumberTheory/LSeries/Linearity.lean
@@ -163,22 +163,4 @@ lemma LSeries_sum (hf : ∀ i ∈ S, LSeriesSummable (f i) s) :
     LSeries (∑ i ∈ S, f i) s = ∑ i ∈ S, LSeries (f i) s := by
   simpa only [LSeries, term_sum, Finset.sum_apply] using tsum_sum hf
 
-variable [Fintype ι]
-
-/-- The version of `LSeriesHasSum.sum` for sums over a `Fintype`. -/
-lemma LSeriesHasSum.sum' {a : ι → ℂ} (hf : ∀ i, LSeriesHasSum (f i) s (a i)) :
-    LSeriesHasSum (∑ i : ι, f i) s (∑ i : ι, a i) :=
-  sum fun i _ ↦ hf i
-
-/-- The version of `LSeriesSummable.sum` for sums over a `Fintype`. -/
-lemma LSeriesSummable.sum' (hf : ∀ i, LSeriesSummable (f i) s) :
-    LSeriesSummable (∑ i : ι, f i) s :=
-  sum fun i _ ↦ hf i
-
-/-- The version of `LSeries_sum` for sums over a `Fintype`. -/
-@[simp]
-lemma LSeries_sum' (hf : ∀ i, LSeriesSummable (f i) s) :
-    LSeries (∑ i : ι, f i) s = ∑ i : ι, LSeries (f i) s :=
-  LSeries_sum fun i _ ↦ hf i
-
 end sum

--- a/Mathlib/NumberTheory/LSeries/Linearity.lean
+++ b/Mathlib/NumberTheory/LSeries/Linearity.lean
@@ -139,6 +139,7 @@ section sum
 
 variable {ι : Type*} (f : ι → ℕ → ℂ) (S : Finset ι) (s : ℂ)
 
+@[simp]
 lemma LSeries.term_sum_apply (n : ℕ) :
     term (∑ i ∈ S, f i) s n  = ∑ i ∈ S, term (f i) s n := by
   rcases eq_or_ne n 0 with rfl | hn

--- a/Mathlib/NumberTheory/LSeries/Linearity.lean
+++ b/Mathlib/NumberTheory/LSeries/Linearity.lean
@@ -75,8 +75,6 @@ lemma LSeries_neg (f : ℕ → ℂ) (s : ℂ) : LSeries (-f) s = -LSeries f s :=
 ### Subtraction
 -/
 
-open LSeries
-
 lemma LSeries.term_sub (f g : ℕ → ℂ) (s : ℂ) : term (f - g) s = term f s - term g s := by
   simp_rw [sub_eq_add_neg, term_add, term_neg]
 
@@ -132,3 +130,57 @@ lemma LSeriesSummable.smul_iff {f : ℕ → ℂ} {c s : ℂ} (hc : c ≠ 0) :
 @[simp]
 lemma LSeries_smul (f : ℕ → ℂ) (c s : ℂ) : LSeries (c • f) s = c * LSeries f s := by
   simp only [LSeries, term_smul_apply, tsum_mul_left]
+
+/-!
+### Sums
+-/
+
+section sum
+
+variable {ι : Type*} [DecidableEq ι] (f : ι → ℕ → ℂ) (S : Finset ι) (s : ℂ)
+
+lemma LSeries.term_sum_apply (n : ℕ) :
+    term (∑ i ∈ S, f i) s n  = ∑ i ∈ S, term (f i) s n := by
+  induction S using Finset.induction_on with
+  | empty =>
+    simp only [Finset.sum_empty, term, Pi.zero_apply, zero_div, ite_self]
+  | insert hi IH  =>
+    simp only [Finset.sum_insert hi, term_add_apply, IH]
+
+lemma LSeries.term_sum : term (∑ i ∈ S, f i) s  = ∑ i ∈ S, term (f i) s :=
+  funext fun _ ↦ by rw [Finset.sum_apply]; exact term_sum_apply f S s _
+
+variable {f S s}
+
+lemma LSeriesHasSum.sum {a : ι → ℂ} (hf : ∀ i ∈ S, LSeriesHasSum (f i) s (a i)) :
+    LSeriesHasSum (∑ i ∈ S, f i) s (∑ i ∈ S, a i) := by
+  simpa only [LSeriesHasSum, term_sum, Finset.sum_fn S fun i ↦ term (f i) s] using hasSum_sum hf
+
+lemma LSeriesSummable.sum (hf : ∀ i ∈ S, LSeriesSummable (f i) s) :
+    LSeriesSummable (∑ i ∈ S, f i) s := by
+  simpa only [LSeriesSummable, ← term_sum_apply] using summable_sum hf
+
+@[simp]
+lemma LSeries_sum (hf : ∀ i ∈ S, LSeriesSummable (f i) s) :
+    LSeries (∑ i ∈ S, f i) s = ∑ i ∈ S, LSeries (f i) s := by
+  simpa only [LSeries, term_sum, Finset.sum_apply] using tsum_sum hf
+
+variable [Fintype ι]
+
+/-- The version of `LSeriesHasSum.sum` for `Fintype.sum`. -/
+lemma LSeriesHasSum.sum' {a : ι → ℂ} (hf : ∀ i, LSeriesHasSum (f i) s (a i)) :
+    LSeriesHasSum (∑ i : ι, f i) s (∑ i : ι, a i) :=
+  sum fun i _ ↦ hf i
+
+/-- The version of `LSeriesSummable.sum` for `Fintype.sum`. -/
+lemma LSeriesSummable.sum' (hf : ∀ i, LSeriesSummable (f i) s) :
+    LSeriesSummable (∑ i : ι, f i) s :=
+  sum fun i _ ↦ hf i
+
+/-- The version of `LSeries_sum` for `Fintype.sum`. -/
+@[simp]
+lemma LSeries_sum' (hf : ∀ i, LSeriesSummable (f i) s) :
+    LSeries (∑ i : ι, f i) s = ∑ i : ι, LSeries (f i) s :=
+  LSeries_sum fun i _ ↦ hf i
+
+end sum

--- a/Mathlib/NumberTheory/LSeries/Linearity.lean
+++ b/Mathlib/NumberTheory/LSeries/Linearity.lean
@@ -137,15 +137,13 @@ lemma LSeries_smul (f : ℕ → ℂ) (c s : ℂ) : LSeries (c • f) s = c * LSe
 
 section sum
 
-variable {ι : Type*} [DecidableEq ι] (f : ι → ℕ → ℂ) (S : Finset ι) (s : ℂ)
+variable {ι : Type*} (f : ι → ℕ → ℂ) (S : Finset ι) (s : ℂ)
 
 lemma LSeries.term_sum_apply (n : ℕ) :
     term (∑ i ∈ S, f i) s n  = ∑ i ∈ S, term (f i) s n := by
-  induction S using Finset.induction_on with
-  | empty =>
-    simp only [Finset.sum_empty, term, Pi.zero_apply, zero_div, ite_self]
-  | insert hi IH  =>
-    simp only [Finset.sum_insert hi, term_add_apply, IH]
+  rcases eq_or_ne n 0 with rfl | hn
+  · simp only [term_zero, Finset.sum_const_zero]
+  · simp only [ne_eq, hn, not_false_eq_true, term_of_ne_zero, Finset.sum_apply, Finset.sum_div]
 
 lemma LSeries.term_sum : term (∑ i ∈ S, f i) s  = ∑ i ∈ S, term (f i) s :=
   funext fun _ ↦ by rw [Finset.sum_apply]; exact term_sum_apply f S s _
@@ -167,17 +165,17 @@ lemma LSeries_sum (hf : ∀ i ∈ S, LSeriesSummable (f i) s) :
 
 variable [Fintype ι]
 
-/-- The version of `LSeriesHasSum.sum` for `Fintype.sum`. -/
+/-- The version of `LSeriesHasSum.sum` for sums over a `Fintype`. -/
 lemma LSeriesHasSum.sum' {a : ι → ℂ} (hf : ∀ i, LSeriesHasSum (f i) s (a i)) :
     LSeriesHasSum (∑ i : ι, f i) s (∑ i : ι, a i) :=
   sum fun i _ ↦ hf i
 
-/-- The version of `LSeriesSummable.sum` for `Fintype.sum`. -/
+/-- The version of `LSeriesSummable.sum` for sums over a `Fintype`. -/
 lemma LSeriesSummable.sum' (hf : ∀ i, LSeriesSummable (f i) s) :
     LSeriesSummable (∑ i : ι, f i) s :=
   sum fun i _ ↦ hf i
 
-/-- The version of `LSeries_sum` for `Fintype.sum`. -/
+/-- The version of `LSeries_sum` for sums over a `Fintype`. -/
 @[simp]
 lemma LSeries_sum' (hf : ∀ i, LSeriesSummable (f i) s) :
     LSeries (∑ i : ι, f i) s = ∑ i : ι, LSeries (f i) s :=


### PR DESCRIPTION
The fourth PR in [this series](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/Prerequisites.20for.20PNT.20and.20Dirichlet's.20Thm/near/482005581) extends the LSeries API by showing that forming the LSeries commutes with finite sums.

From [EulerProducts](https://github.com/MichaelStollBayreuth/EulerProducts).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
