### PR TITLE
[Merged by Bors] - feat: stacks and kerodon tags are hoverable

### DIFF
--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -191,7 +191,7 @@ def traceStacksTags (db : Database) (verbose : Bool := false) :
     let cmt := parL ++ d.comment ++ parR
     msgs := msgs.push
       m!"[Stacks Tag {d.tag}]({databaseURL db ++ d.tag}) \
-        corresponds to declaration '{dname}'.{cmt}"
+        corresponds to declaration '{.ofConstName dname}'.{cmt}"
     if verbose then
       let dType := ((env.find? dname).getD default).type
       msgs := (msgs.push m!"{dType}").push ""

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -186,14 +186,13 @@ def traceStacksTags (db : Database) (verbose : Bool := false) :
   if entries.isEmpty then logInfo "No tags found." else
   let mut msgs := #[m!""]
   for d in entries do
-    let dname ← Command.liftCoreM do realizeGlobalConstNoOverloadWithInfo (mkIdent d.declName)
     let (parL, parR) := if d.comment.isEmpty then ("", "") else (" (", ")")
     let cmt := parL ++ d.comment ++ parR
     msgs := msgs.push
       m!"[Stacks Tag {d.tag}]({databaseURL db ++ d.tag}) \
-        corresponds to declaration '{.ofConstName dname}'.{cmt}"
+        corresponds to declaration '{.ofConstName d.declName}'.{cmt}"
     if verbose then
-      let dType := ((env.find? dname).getD default).type
+      let dType := ((env.find? d.declName).getD default).type
       msgs := (msgs.push m!"{dType}").push ""
   let msg := MessageData.joinSep msgs.toList "\n"
   logInfo msg


### PR DESCRIPTION
With this change, you can get hover information and go-to-definition in the output of `#stacks_tags` and `#kerodon_tags`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
