### PR TITLE
[Merged by Bors] - chore: golf using `gcongr` and `positivity`

### DIFF
--- a/Mathlib/Analysis/LocallyConvex/AbsConvex.lean
+++ b/Mathlib/Analysis/LocallyConvex/AbsConvex.lean
@@ -281,17 +281,12 @@ lemma balancedHull_subset_convexHull_union_neg {s : Set E} :
   intro a ha
   obtain ⟨r, hr, y, hy, rfl⟩ := mem_balancedHull_iff.1 ha
   apply segment_subset_convexHull (mem_union_left (-s) hy) (mem_union_right _ (neg_mem_neg.mpr hy))
-  refine ⟨(1 + r)/2, (1 - r)/2, ?_, ?_⟩
-  · rw [← zero_div 2]
-    exact (div_le_div_right zero_lt_two).mpr (neg_le_iff_add_nonneg'.mp (neg_le_of_abs_le hr))
-  · constructor
-    · rw [← zero_div 2]
-      exact (div_le_div_right zero_lt_two).mpr (sub_nonneg_of_le (le_of_max_le_left hr))
-    · constructor
-      · ring_nf
-      · rw [smul_neg, ← sub_eq_add_neg, ← sub_smul]
-        apply congrFun (congrArg HSMul.hSMul _) y
-        ring_nf
+  have : 0 ≤ 1 + r := neg_le_iff_add_nonneg'.mp (neg_le_of_abs_le hr)
+  have : 0 ≤ 1 - r := sub_nonneg.2 (le_of_abs_le hr)
+  refine ⟨(1 + r)/2, (1 - r)/2, by positivity, by positivity, by ring, ?_⟩
+  rw [smul_neg, ← sub_eq_add_neg, ← sub_smul]
+  apply congrFun (congrArg HSMul.hSMul _) y
+  ring_nf
 
 @[simp]
 theorem convexHull_union_neg_eq_absConvexHull {s : Set E} :

--- a/Mathlib/Analysis/Normed/Field/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Field/Ultra.lean
@@ -53,8 +53,8 @@ lemma isUltrametricDist_of_forall_norm_add_one_of_norm_le_one
   rcases le_or_lt ‖x‖ 1 with H|H
   · exact (h _ H).trans (le_max_right _ _)
   · suffices ‖x + 1‖ ≤ ‖x‖ from this.trans (le_max_left _ _)
-    rw [← div_le_div_right (c := ‖x‖) (H.trans' zero_lt_one), div_self (H.trans' zero_lt_one).ne',
-        ← norm_div, add_div, div_self (by simpa using (H.trans' zero_lt_one)), add_comm]
+    rw [← div_le_one (by positivity), ← norm_div, add_div,
+      div_self (by simpa using H.trans' zero_lt_one), add_comm]
     apply h
     simp [inv_le_one_iff₀, H.le]
 

--- a/Mathlib/Analysis/Normed/Ring/SeminormFromConst.lean
+++ b/Mathlib/Analysis/Normed/Ring/SeminormFromConst.lean
@@ -132,7 +132,7 @@ def seminormFromConst : RingSeminorm R where
     have h_add : f ((x + y) * c ^ n) ≤ f (x * c ^ n) + f (y * c ^ n) := by
       simp only [add_mul, map_add_le_add f _ _]
     simp only [seminormFromConst_seq, div_add_div_same]
-    exact (div_le_div_right (pow_pos (lt_of_le_of_ne (apply_nonneg f _) hc.symm) _)).mpr h_add
+    gcongr
   neg' x := by
     apply tendsto_nhds_unique_of_eventuallyEq (seminormFromConst_isLimit hf1 hc hpm (-x))
       (seminormFromConst_isLimit hf1 hc hpm x)
@@ -171,8 +171,8 @@ theorem seminormFromConst_isNonarchimedean (hna : IsNonarchimedean f) :
   have hmax : f ((x + y) * c ^ n) ≤ max (f (x * c ^ n)) (f (y * c ^ n)) := by
     simp only [add_mul, hna _ _]
   rw [le_max_iff] at hmax ⊢
-  rcases hmax with hmax | hmax <;> [left; right] <;>
-  exact (div_le_div_right (pow_pos (lt_of_le_of_ne (apply_nonneg f c) hc.symm) _)).mpr hmax
+  unfold seminormFromConst_seq
+  apply hmax.imp <;> intro <;> gcongr
 
 /-- The function `seminormFromConst' hf1 hc hpm` is power-multiplicative. -/
 theorem seminormFromConst_isPowMul : IsPowMul (seminormFromConst' hf1 hc hpm) := fun x m hm ↦ by
@@ -193,9 +193,8 @@ theorem seminormFromConst_le_seminorm (x : R) : seminormFromConst' hf1 hc hpm x 
   simp only [eventually_atTop, ge_iff_le]
   use 1
   intro n hn
-  apply le_trans ((div_le_div_right (pow_pos (lt_of_le_of_ne (apply_nonneg f c) hc.symm) _)).mpr
-    (map_mul_le_mul _ _ _))
-  rw [hpm c hn, mul_div_assoc, div_self (pow_ne_zero n hc), mul_one]
+  rw [seminormFromConst_seq, div_le_iff₀ (by positivity), ← hpm c hn]
+  exact map_mul_le_mul ..
 
 /-- If `x : R` is multiplicative for `f`, then `seminormFromConst' hf1 hc hpm x = f x`. -/
 theorem seminormFromConst_apply_of_isMul {x : R} (hx : ∀ y : R, f (x * y) = f x * f y) :

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -125,8 +125,8 @@ theorem tendsto_exp_div_rpow_atTop (s : ℝ) : Tendsto (fun x : ℝ => exp x / x
   cases' archimedean_iff_nat_lt.1 Real.instArchimedean s with n hn
   refine tendsto_atTop_mono' _ ?_ (tendsto_exp_div_pow_atTop n)
   filter_upwards [eventually_gt_atTop (0 : ℝ), eventually_ge_atTop (1 : ℝ)] with x hx₀ hx₁
-  rw [div_le_div_left (exp_pos _) (pow_pos hx₀ _) (rpow_pos_of_pos hx₀ _), ← Real.rpow_natCast]
-  exact rpow_le_rpow_of_exponent_le hx₁ hn.le
+  gcongr
+  simpa using rpow_le_rpow_of_exponent_le hx₁ hn.le
 
 /-- The function `exp (b * x) / x ^ s` tends to `+∞` at `+∞`, for any real `s` and `b > 0`. -/
 theorem tendsto_exp_mul_div_rpow_atTop (s : ℝ) (b : ℝ) (hb : 0 < b) :

--- a/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
+++ b/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
@@ -578,11 +578,12 @@ theorem transnumAuxSeq_dist_lt (n : ℕ) :
     dist (f.transnumAuxSeq n) (f.transnumAuxSeq (n + 1)) < 1 / 2 / 2 ^ n := by
   have : 0 < (2 ^ (n + 1) : ℝ) := pow_pos zero_lt_two _
   rw [div_div, ← pow_succ', ← abs_of_pos this]
-  replace := abs_pos.2 (ne_of_gt this)
-  convert (div_lt_div_right this).2 ((f ^ 2 ^ n).dist_map_map_zero_lt (f ^ 2 ^ n)) using 1
-  simp_rw [transnumAuxSeq, Real.dist_eq]
-  rw [← abs_div, sub_div, pow_succ, pow_succ', ← two_mul, mul_div_mul_left _ _ (two_ne_zero' ℝ),
-    pow_mul, sq, mul_apply]
+  calc
+    _ = dist ((f ^ 2 ^ n) 0 + (f ^ 2 ^ n) 0) ((f ^ 2 ^ n) ((f ^ 2 ^ n) 0)) / |2 ^ (n + 1)| := by
+      simp_rw [transnumAuxSeq, Real.dist_eq]
+      rw [← abs_div, sub_div, pow_succ, pow_succ', ← two_mul, mul_div_mul_left _ _ (two_ne_zero' ℝ),
+        pow_mul, sq, mul_apply]
+    _ < _ := by gcongr; exact (f ^ 2 ^ n).dist_map_map_zero_lt (f ^ 2 ^ n)
 
 theorem tendsto_translationNumber_aux : Tendsto f.transnumAuxSeq atTop (𝓝 <| τ f) :=
   (cauchySeq_of_le_geometric_two fun n => le_of_lt <| f.transnumAuxSeq_dist_lt n).tendsto_limUnder

--- a/Mathlib/NumberTheory/ClassNumber/AdmissibleAbs.lean
+++ b/Mathlib/NumberTheory/ClassNumber/AdmissibleAbs.lean
@@ -36,7 +36,7 @@ theorem exists_partition_int (n : ℕ) {ε : ℝ} (hε : 0 < ε) {b : ℤ} (hb :
   have hfloor : ∀ i, 0 ≤ floor ((A i % b : ℤ) / abs b • ε : ℝ) :=
     fun _ ↦ floor_nonneg.mpr (div_nonneg (cast_nonneg.mpr (emod_nonneg _ hb)) hbε.le)
   refine ⟨fun i ↦ ⟨natAbs (floor ((A i % b : ℤ) / abs b • ε : ℝ)), ?_⟩, ?_⟩
-  · rw [← ofNat_lt, natAbs_of_nonneg (hfloor i), floor_lt]
+  · rw [← ofNat_lt, natAbs_of_nonneg (hfloor i), floor_lt, Algebra.smul_def, eq_intCast, ← div_div]
     apply lt_of_lt_of_le _ (Nat.le_ceil _)
     rw [Algebra.smul_def, eq_intCast, ← div_div, div_lt_div_right hε, div_lt_iff₀ hb', one_mul,
       cast_lt]

--- a/Mathlib/NumberTheory/ClassNumber/AdmissibleAbs.lean
+++ b/Mathlib/NumberTheory/ClassNumber/AdmissibleAbs.lean
@@ -38,8 +38,8 @@ theorem exists_partition_int (n : ℕ) {ε : ℝ} (hε : 0 < ε) {b : ℤ} (hb :
   refine ⟨fun i ↦ ⟨natAbs (floor ((A i % b : ℤ) / abs b • ε : ℝ)), ?_⟩, ?_⟩
   · rw [← ofNat_lt, natAbs_of_nonneg (hfloor i), floor_lt, Algebra.smul_def, eq_intCast, ← div_div]
     apply lt_of_lt_of_le _ (Nat.le_ceil _)
-    rw [Algebra.smul_def, eq_intCast, ← div_div, div_lt_div_right hε, div_lt_iff₀ hb', one_mul,
-      cast_lt]
+    gcongr
+    rw [div_lt_one hb', cast_lt]
     exact Int.emod_lt _ hb
   intro i₀ i₁ hi
   have hi : (⌊↑(A i₀ % b) / abs b • ε⌋.natAbs : ℤ) = ⌊↑(A i₁ % b) / abs b • ε⌋.natAbs :=

--- a/Mathlib/NumberTheory/Liouville/LiouvilleWith.lean
+++ b/Mathlib/NumberTheory/Liouville/LiouvilleWith.lean
@@ -268,7 +268,8 @@ theorem ne_cast_int (h : LiouvilleWith p x) (hp : 1 < p) (m : ℤ) : x ≠ m := 
     ⟨n : ℕ, hn : 0 < n, m : ℤ, hne : (M : ℝ) ≠ m / n, hlt : |(M - m / n : ℝ)| < n ^ (-1 : ℝ)⟩
   refine hlt.not_le ?_
   have hn' : (0 : ℝ) < n := by simpa
-  rw [rpow_neg_one, ← one_div, sub_div' _ _ _ hn'.ne', abs_div, Nat.abs_cast, div_le_div_right hn']
+  rw [rpow_neg_one, ← one_div, sub_div' _ _ _ hn'.ne', abs_div, Nat.abs_cast]
+  gcongr
   norm_cast
   rw [← zero_add (1 : ℤ), Int.add_one_le_iff, abs_pos, sub_ne_zero]
   rw [Ne, eq_div_iff hn'.ne'] at hne

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/OneVariable.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/OneVariable.lean
@@ -108,15 +108,11 @@ theorem norm_jacobiTheta_sub_one_le {τ : ℂ} (hτ : 0 < im τ) :
 theorem isBigO_at_im_infty_jacobiTheta_sub_one :
     (fun τ => jacobiTheta τ - 1) =O[comap im atTop] fun τ => rexp (-π * τ.im) := by
   simp_rw [IsBigO, IsBigOWith, Filter.eventually_comap, Filter.eventually_atTop]
-  refine ⟨2 / (1 - rexp (-π)), 1, fun y hy τ hτ =>
+  refine ⟨2 / (1 - rexp (-(π * 1))), 1, fun y hy τ hτ =>
     (norm_jacobiTheta_sub_one_le (hτ.symm ▸ zero_lt_one.trans_le hy : 0 < im τ)).trans ?_⟩
-  rw [Real.norm_eq_abs, Real.abs_exp]
-  refine mul_le_mul_of_nonneg_right ?_ (exp_pos _).le
-  rw [div_le_div_left (zero_lt_two' ℝ), sub_le_sub_iff_left, exp_le_exp, neg_mul, neg_le_neg_iff]
-  · exact le_mul_of_one_le_right pi_pos.le (hτ.symm ▸ hy)
-  · rw [sub_pos, exp_lt_one_iff, neg_mul, neg_lt_zero]
-    exact mul_pos pi_pos (hτ.symm ▸ zero_lt_one.trans_le hy)
-  · rw [sub_pos, exp_lt_one_iff, neg_lt_zero]; exact pi_pos
+  rw [Real.norm_eq_abs, Real.abs_exp, hτ, neg_mul]
+  gcongr
+  simp [pi_pos]
 
 theorem differentiableAt_jacobiTheta {τ : ℂ} (hτ : 0 < im τ) :
     DifferentiableAt ℂ jacobiTheta τ := by

--- a/Mathlib/Topology/MetricSpace/Contracting.lean
+++ b/Mathlib/Topology/MetricSpace/Contracting.lean
@@ -295,8 +295,10 @@ theorem aposteriori_dist_iterate_fixedPoint_le (x n) :
 
 theorem apriori_dist_iterate_fixedPoint_le (x n) :
     dist (f^[n] x) (fixedPoint f hf) ≤ dist x (f x) * (K : ℝ) ^ n / (1 - K) :=
-  le_trans (hf.aposteriori_dist_iterate_fixedPoint_le x n) <|
-    (div_le_div_right hf.one_sub_K_pos).2 <| hf.toLipschitzWith.dist_iterate_succ_le_geometric x n
+  calc
+    _ ≤ dist (f^[n] x) (f^[n + 1] x) / (1 - K) := hf.aposteriori_dist_iterate_fixedPoint_le x n
+    _ ≤ _ := by
+      gcongr; exacts [hf.one_sub_K_pos.le, hf.toLipschitzWith.dist_iterate_succ_le_geometric x n]
 
 theorem tendsto_iterate_fixedPoint (x) :
     Tendsto (fun n ↦ f^[n] x) atTop (𝓝 <| fixedPoint f hf) := by


### PR DESCRIPTION
These golfs were prompted by lines getting too long due to renames in #18917


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
