### PR TITLE
[Merged by Bors] - feat(Algebra/Module/Submodule/Pointwise): `span_singleton_toAddSubgroup_eq_zmultiples`

### DIFF
--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -546,7 +546,7 @@ lemma coe_span_smul {R' M' : Type*} [CommSemiring R'] [AddCommMonoid M'] [Module
 
 end set_acting_on_submodules
 
-@[simp] lemma span_singleton_toAddSubgroup_eq_zmultiples (a : ℤ) :
+lemma span_singleton_toAddSubgroup_eq_zmultiples (a : ℤ) :
    (span ℤ {a}).toAddSubgroup = AddSubgroup.zmultiples a := by
   ext i
   simp [Ideal.mem_span_singleton', AddSubgroup.mem_zmultiples_iff]

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -546,4 +546,13 @@ lemma coe_span_smul {R' M' : Type*} [CommSemiring R'] [AddCommMonoid M'] [Module
 
 end set_acting_on_submodules
 
+@[simp] lemma span_singleton_toAddSubgroup_eq_zmultiples (a : ℤ) :
+   (span ℤ {a}).toAddSubgroup = AddSubgroup.zmultiples a := by
+  ext i
+  simp [Ideal.mem_span_singleton', AddSubgroup.mem_zmultiples_iff]
+
 end Submodule
+
+@[simp] lemma Ideal.span_singleton_toAddSubgroup_eq_zmultiples (a : ℤ) :
+   (Ideal.span {a}).toAddSubgroup = AddSubgroup.zmultiples a :=
+  Submodule.span_singleton_toAddSubgroup_eq_zmultiples _

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -547,7 +547,7 @@ lemma coe_span_smul {R' M' : Type*} [CommSemiring R'] [AddCommMonoid M'] [Module
 end set_acting_on_submodules
 
 lemma span_singleton_toAddSubgroup_eq_zmultiples (a : ℤ) :
-   (span ℤ {a}).toAddSubgroup = AddSubgroup.zmultiples a := by
+    (span ℤ {a}).toAddSubgroup = AddSubgroup.zmultiples a := by
   ext i
   simp [Ideal.mem_span_singleton', AddSubgroup.mem_zmultiples_iff]
 


### PR DESCRIPTION
Add lemmas equating the span of a single element of `ℤ` (`Submodule.span` or `Ideal.span`) to `AddSubgroup.zmultiples`. Extracted from #18002, where this location was suggested based on `find_home` rather than any stronger link to the other lemmas here (`Mathlib.RingTheory.Ideal.Span` doesn't know about `zmultiples`).

Indirectly from AperiodicMonotilesLean after refactoring via #18002.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
