### PR TITLE
[Merged by Bors] - chore: deal with "`simp` doesn't apply `simp` lemma unless parenthesized" porting notes

### DIFF
--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -68,13 +68,13 @@ theorem mulVec_stdBasisMatrix [NonUnitalNonAssocSemiring α] [Fintype m]
   · simp
   simp [h, h.symm]
 
--- In the following proof, we abuse the definition of `Matrix` by applying matrices.
--- We therefore need to parenthesize `Fintype.sum_apply` to convince `simp` to apply it even though
--- the type is `Matrix m n α`, not `m → _`.
 theorem matrix_eq_sum_stdBasisMatrix [AddCommMonoid α] [Fintype m] [Fintype n] (x : Matrix m n α) :
     x = ∑ i : m, ∑ j : n, stdBasisMatrix i j (x i j) := by
   ext i j
   rw [← Fintype.sum_prod_type']
+  -- In this proof, we abuse the definition of `Matrix` by applying matrices.
+  -- We therefore need to parenthesize `Fintype.sum_apply` to convince `simp` to apply it even
+  -- though the type is `Matrix m n α`, not `m → _`.
   simp [stdBasisMatrix, (Fintype.sum_apply), Matrix.of_apply, ← Prod.mk.inj_iff]
 
 @[deprecated (since := "2024-08-11")] alias matrix_eq_sum_std_basis := matrix_eq_sum_stdBasisMatrix

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -72,10 +72,7 @@ theorem matrix_eq_sum_stdBasisMatrix [AddCommMonoid α] [Fintype m] [Fintype n] 
     x = ∑ i : m, ∑ j : n, stdBasisMatrix i j (x i j) := by
   ext i j
   rw [← Fintype.sum_prod_type']
-  -- In this proof, we abuse the definition of `Matrix` by applying matrices.
-  -- We therefore need to parenthesize `Fintype.sum_apply` to convince `simp` to apply it even
-  -- though the type is `Matrix m n α`, not `m → _`.
-  simp [stdBasisMatrix, (Fintype.sum_apply), Matrix.of_apply, ← Prod.mk.inj_iff]
+  simp [stdBasisMatrix, Matrix.sum_apply, Matrix.of_apply, ← Prod.mk.inj_iff]
 
 @[deprecated (since := "2024-08-11")] alias matrix_eq_sum_std_basis := matrix_eq_sum_stdBasisMatrix
 

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -68,16 +68,14 @@ theorem mulVec_stdBasisMatrix [NonUnitalNonAssocSemiring α] [Fintype m]
   · simp
   simp [h, h.symm]
 
+-- In the following proof, we abuse the definition of `Matrix` by applying matrices.
+-- We therefore need to parenthesize `Fintype.sum_apply` to convince `simp` to apply it even though
+-- the type is `Matrix m n α`, not `m → _`.
 theorem matrix_eq_sum_stdBasisMatrix [AddCommMonoid α] [Fintype m] [Fintype n] (x : Matrix m n α) :
     x = ∑ i : m, ∑ j : n, stdBasisMatrix i j (x i j) := by
-  ext i j; symm
-  iterate 2 rw [Finset.sum_apply]
-  convert (Fintype.sum_eq_single i ?_).trans ?_; swap
-  · -- Porting note(#12717): `simp` seems unwilling to apply `Fintype.sum_apply`
-    simp (config := { unfoldPartialApp := true }) [stdBasisMatrix, (Fintype.sum_apply)]
-  · intro j' hj'
-    -- Porting note(#12717): `simp` seems unwilling to apply `Fintype.sum_apply`
-    simp (config := { unfoldPartialApp := true }) [stdBasisMatrix, (Fintype.sum_apply), hj']
+  ext i j
+  rw [← Fintype.sum_prod_type']
+  simp [stdBasisMatrix, (Fintype.sum_apply), Matrix.of_apply, ← Prod.mk.inj_iff]
 
 @[deprecated (since := "2024-08-11")] alias matrix_eq_sum_std_basis := matrix_eq_sum_stdBasisMatrix
 


### PR DESCRIPTION
In this proof, we abuse the definition of `Matrix` by applying matrices. This is why we needed to parenthesize `Fintype.sum_apply` to convince `simp` to apply it even though the type is `Matrix m n α`, not `m → _`.

Turns out there's a version of `Fintype.sum_apply` specialized to matrices: `Matrix.sum_apply`.

Close #12717


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
