### PR TITLE
[Merged by Bors] - feat: the derivatives of the L-function and the L-series of a Dirichlet character agree

### DIFF
--- a/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
+++ b/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
@@ -72,8 +72,7 @@ lemma LFunction_eq_LSeries (χ : DirichletCharacter ℂ N) {s : ℂ} (hs : 1 < r
     LFunction χ s = LSeries (χ ·) s :=
   ZMod.LFunction_eq_LSeries χ hs
 
-lemma deriv_LFunction_eq_deriv_LSeries {n : ℕ} [NeZero n] (χ : DirichletCharacter ℂ n) {s : ℂ}
-    (hs : 1 < s.re) :
+lemma deriv_LFunction_eq_deriv_LSeries (χ : DirichletCharacter ℂ N) {s : ℂ} (hs : 1 < s.re) :
     deriv (LFunction χ) s = deriv (LSeries (χ ·)) s := by
   refine Filter.EventuallyEq.deriv_eq ?_
   have h : {z | 1 < z.re} ∈ nhds s :=

--- a/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
+++ b/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
@@ -72,6 +72,15 @@ lemma LFunction_eq_LSeries (χ : DirichletCharacter ℂ N) {s : ℂ} (hs : 1 < r
     LFunction χ s = LSeries (χ ·) s :=
   ZMod.LFunction_eq_LSeries χ hs
 
+lemma deriv_LFunction_eq_deriv_LSeries {n : ℕ} [NeZero n] (χ : DirichletCharacter ℂ n) {s : ℂ}
+    (hs : 1 < s.re) :
+    deriv (LFunction χ) s = deriv (LSeries (χ ·)) s := by
+  refine Filter.EventuallyEq.deriv_eq ?_
+  have h : {z | 1 < z.re} ∈ nhds s :=
+    (isOpen_lt continuous_const continuous_re).mem_nhds hs
+  filter_upwards [h] with z hz
+  exact LFunction_eq_LSeries χ hz
+
 /--
 The L-function of a Dirichlet character is differentiable, except at `s = 1` if the character is
 trivial.


### PR DESCRIPTION
Another preparatory PR for PNT and Dirichlet's Theorem. See [here](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/Prerequisites.20for.20PNT.20and.20Dirichlet's.20Thm/near/482005581) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
