### PR TITLE
[Merged by Bors] - chore(Data/Matrix): reverse import order of `Data.Matrix.Basis` and `LinearAlgebra.Matrix.Trace`

### DIFF
--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.Algebra.Equiv
+import Mathlib.Algebra.Star.SelfAdjoint
 import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 import Mathlib.LinearAlgebra.FreeModule.Basic
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jalex Stark, Kim Morrison, Eric Wieser, Oliver Nash, Wen Yang
 -/
 import Mathlib.Data.Matrix.Basic
-import Mathlib.LinearAlgebra.Matrix.Trace
 
 /-!
 # Matrices with a single non-zero element.
@@ -158,21 +157,6 @@ theorem diag_same : diag (stdBasisMatrix i i c) = Pi.single i c := by
   by_cases hij : i = j <;> (try rw [hij]) <;> simp [hij]
 
 end
-
-section trace
-variable [Fintype n] [AddCommMonoid α] (i j : n) (c : α)
-
-@[simp]
-theorem trace_zero (h : j ≠ i) : trace (stdBasisMatrix i j c) = 0 := by
-  -- Porting note: added `-diag_apply`
-  simp [trace, -diag_apply, h]
-
-@[simp]
-theorem trace_eq : trace (stdBasisMatrix i i c) = c := by
-  -- Porting note: added `-diag_apply`
-  simp [trace, -diag_apply]
-
-end trace
 
 section mul
 variable [Fintype n] [NonUnitalNonAssocSemiring α] (i j : n) (c : α)

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -12,6 +12,7 @@ This file provides `Matrix.stdBasisMatrix`. The matrix `Matrix.stdBasisMatrix i 
 at position `(i, j)`, and zeroes elsewhere.
 -/
 
+assert_not_exists Matrix.trace
 
 variable {l m n : Type*}
 variable {R α : Type*}

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen, Lu-Ming Zhang
 -/
 import Mathlib.Data.Matrix.Invertible
-import Mathlib.LinearAlgebra.Matrix.Adjugate
 import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+import Mathlib.LinearAlgebra.Matrix.Adjugate
+import Mathlib.LinearAlgebra.Matrix.Trace
 
 /-!
 # Nonsingular inverses

--- a/Mathlib/LinearAlgebra/Matrix/Trace.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Trace.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 -/
+import Mathlib.Data.Matrix.Basis
 import Mathlib.Data.Matrix.Block
 import Mathlib.Data.Matrix.RowCol
 import Mathlib.Data.Matrix.Notation
@@ -228,5 +229,22 @@ theorem trace_fin_three_of (a b c d e f g h i : R) :
   trace_fin_three _
 
 end Fin
+
+namespace StdBasisMatrix
+
+variable {l m n : Type*} {R α : Type*} [DecidableEq l] [DecidableEq m] [DecidableEq n]
+variable [Fintype n] [AddCommMonoid α] (i j : n) (c : α)
+
+@[simp]
+theorem trace_zero (h : j ≠ i) : trace (stdBasisMatrix i j c) = 0 := by
+  -- Porting note: added `-diag_apply`
+  simp [trace, -diag_apply, h]
+
+@[simp]
+theorem trace_eq : trace (stdBasisMatrix i i c) = c := by
+  -- Porting note: added `-diag_apply`
+  simp [trace, -diag_apply]
+
+end StdBasisMatrix
 
 end Matrix


### PR DESCRIPTION
Previously, the definition of `Matrix.stdBasisMatrix` depended on the definition (and many properties of) the trace of a matrix. I think that dependency should be reversed, since `stdBasisMatrix` is otherwise a much less heavy definition, import-wise.

This was spotted while adding `assert_not_exists` statements to #18964.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
