### PR TITLE
[Merged by Bors] - feat: (co)products in functor categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1742,6 +1742,7 @@ import Mathlib.CategoryTheory.Limits.FullSubcategory
 import Mathlib.CategoryTheory.Limits.FunctorCategory.Basic
 import Mathlib.CategoryTheory.Limits.FunctorCategory.EpiMono
 import Mathlib.CategoryTheory.Limits.FunctorCategory.Finite
+import Mathlib.CategoryTheory.Limits.FunctorCategory.Shapes.Products
 import Mathlib.CategoryTheory.Limits.FunctorToTypes
 import Mathlib.CategoryTheory.Limits.HasLimits
 import Mathlib.CategoryTheory.Limits.IndYoneda

--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/Shapes/Products.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2024 Markus Himmel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Himmel
+-/
+import Mathlib.CategoryTheory.Limits.FunctorCategory.Basic
+import Mathlib.CategoryTheory.Limits.Shapes.Products
+
+/-!
+# (Co)products in functor categories
+
+Given `f : α → D ⥤ C`, we prove the isomorphisms
+`(∏ᶜ f).obj d ≅ ∏ᶜ (fun s => (f s).obj d)` and `(∐ f).obj d ≅ ∐ (fun s => (f s).obj d)`.
+
+-/
+
+universe w v v₁ v₂ u u₁ u₂
+
+namespace CategoryTheory.Limits
+
+variable {C : Type u} [Category.{v} C] {D : Type u₁} [Category.{v₁} D]
+  {α : Type w}
+
+section Product
+
+variable [HasLimitsOfShape (Discrete α) C]
+
+/-- Evaluating a product of functors amounts to taking the product of the evaluations. -/
+noncomputable def piObjIso (f : α → D ⥤ C) (d : D) : (∏ᶜ f).obj d ≅ ∏ᶜ (fun s => (f s).obj d) :=
+  limitObjIsoLimitCompEvaluation (Discrete.functor f) d ≪≫
+    HasLimit.isoOfNatIso (Discrete.compNatIsoDiscrete _ _)
+
+@[reassoc (attr := simp)]
+theorem piObjIso_hom_comp_π (f : α → D ⥤ C) (d : D) (s : α) :
+    (piObjIso f d).hom ≫ Pi.π (fun s => (f s).obj d) s = (Pi.π f s).app d := by
+  simp [piObjIso]
+
+@[reassoc (attr := simp)]
+theorem piObjIso_inv_comp_pi (f : α → D ⥤ C) (d : D) (s : α) :
+    (piObjIso f d).inv ≫ (Pi.π f s).app d = Pi.π (fun s => (f s).obj d) s := by
+  simp [piObjIso]
+
+end Product
+
+section Coproduct
+
+variable [HasColimitsOfShape (Discrete α) C]
+
+/-- Evaluating a coproduct of functors amounts to taking the coproduct of the evaluations. -/
+noncomputable def sigmaObjIso (f : α → D ⥤ C) (d : D) : (∐ f).obj d ≅ ∐ (fun s => (f s).obj d) :=
+  colimitObjIsoColimitCompEvaluation (Discrete.functor f) d ≪≫
+    HasColimit.isoOfNatIso (Discrete.compNatIsoDiscrete _ _)
+
+@[reassoc (attr := simp)]
+theorem ι_comp_sigmaObjIso_hom (f : α → D ⥤ C) (d : D) (s : α) :
+    (Sigma.ι f s).app d ≫ (sigmaObjIso f d).hom = Sigma.ι (fun s => (f s).obj d) s := by
+  simp [sigmaObjIso]
+
+@[reassoc (attr := simp)]
+theorem ι_comp_sigmaObjIso_inv (f : α → D ⥤ C) (d : D) (s : α) :
+    Sigma.ι (fun s => (f s).obj d) s ≫ (sigmaObjIso f d).inv = (Sigma.ι f s).app d := by
+  simp [sigmaObjIso]
+
+end Coproduct
+
+end CategoryTheory.Limits


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
