### PR TITLE
[Merged by Bors] - chore(Algebra/Ring): find a better home for `RingHom.map_isUnit`

### DIFF
--- a/Mathlib/Algebra/Ring/Hom/Basic.lean
+++ b/Mathlib/Algebra/Ring/Hom/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amelia Livingston, Jireh Loreaux
 -/
 import Mathlib.Algebra.Divisibility.Basic
-import Mathlib.Algebra.Group.Units.Hom
 import Mathlib.Algebra.GroupWithZero.InjSurj
 import Mathlib.Algebra.Ring.Hom.Defs
 import Mathlib.Data.Set.Basic
@@ -41,9 +40,6 @@ end
 section Semiring
 
 variable [Semiring α] [Semiring β]
-
-theorem isUnit_map (f : α →+* β) {a : α} : IsUnit a → IsUnit (f a) :=
-  IsUnit.map f
 
 protected theorem map_dvd (f : α →+* β) {a b : α} : a ∣ b → f a ∣ f b :=
   map_dvd f

--- a/Mathlib/Algebra/Ring/Units.lean
+++ b/Mathlib/Algebra/Ring/Units.lean
@@ -123,3 +123,18 @@ theorem add_eq_mul_one_add_div [Semiring R] {a : Rˣ} {b : R} : ↑a + b = a * (
   rw [mul_add, mul_one, ← mul_assoc, Units.mul_inv, one_mul]
 
 end Units
+
+namespace RingHom
+
+section Semiring
+
+variable [Semiring α] [Semiring β]
+
+theorem isUnit_map (f : α →+* β) {a : α} : IsUnit a → IsUnit (f a) :=
+  IsUnit.map f
+
+end Semiring
+
+end RingHom
+
+variable [Semiring α] [Semiring β]


### PR DESCRIPTION
This result is in the grab-bag file `Ring.Hom.Basic` and fits neatly into `Algebra.Ring.Units`.

The hope is that we can eventually avoid importing `Units` in the file defining `Module`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
