### PR TITLE
[Merged by Bors] - chore(Algebra/Group/Opposite): split off material on `Units`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -326,6 +326,7 @@ import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Algebra.Group.Units.Defs
 import Mathlib.Algebra.Group.Units.Equiv
 import Mathlib.Algebra.Group.Units.Hom
+import Mathlib.Algebra.Group.Units.Opposite
 import Mathlib.Algebra.Group.WithOne.Basic
 import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.Group.ZeroOne

--- a/Mathlib/Algebra/Group/Action/Opposite.lean
+++ b/Mathlib/Algebra/Group/Action/Opposite.lean
@@ -27,6 +27,7 @@ With `open scoped RightActions`, this provides:
 -/
 
 assert_not_exists MonoidWithZero
+assert_not_exists Units
 
 variable {M N α β : Type*}
 

--- a/Mathlib/Algebra/Group/Nat.lean
+++ b/Mathlib/Algebra/Group/Nat.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Algebra.Group.Even
+import Mathlib.Algebra.Group.Units.Defs
 import Mathlib.Data.Nat.Sqrt
 
 /-!

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -6,7 +6,6 @@ Authors: Kenny Lau
 import Mathlib.Algebra.Group.Commute.Defs
 import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Group.InjSurj
-import Mathlib.Algebra.Group.Units.Defs
 import Mathlib.Algebra.Opposites
 import Mathlib.Data.Int.Cast.Defs
 import Mathlib.Tactic.Spread
@@ -15,8 +14,9 @@ import Mathlib.Tactic.Spread
 # Group structures on the multiplicative and additive opposites
 -/
 
-assert_not_exists MonoidWithZero
 assert_not_exists DenselyOrdered
+assert_not_exists MonoidWithZero
+assert_not_exists Units
 
 variable {α : Type*}
 
@@ -415,45 +415,6 @@ def MonoidHom.fromOpposite {M N : Type*} [MulOneClass M] [MulOneClass N] (f : M 
   toFun := f ∘ MulOpposite.unop
   map_one' := f.map_one
   map_mul' _ _ := (f.map_mul _ _).trans (hf _ _).eq
-
-/-- The units of the opposites are equivalent to the opposites of the units. -/
-@[to_additive
-      "The additive units of the additive opposites are equivalent to the additive opposites
-      of the additive units."]
-def Units.opEquiv {M} [Monoid M] : Mᵐᵒᵖˣ ≃* Mˣᵐᵒᵖ where
-  toFun u := op ⟨unop u, unop ↑u⁻¹, op_injective u.4, op_injective u.3⟩
-  invFun := MulOpposite.rec' fun u => ⟨op ↑u, op ↑u⁻¹, unop_injective <| u.4, unop_injective u.3⟩
-  map_mul' _ _ := unop_injective <| Units.ext <| rfl
-  left_inv x := Units.ext <| by simp
-  right_inv x := unop_injective <| Units.ext <| by rfl
-
-@[to_additive (attr := simp)]
-theorem Units.coe_unop_opEquiv {M} [Monoid M] (u : Mᵐᵒᵖˣ) :
-    ((Units.opEquiv u).unop : M) = unop (u : Mᵐᵒᵖ) :=
-  rfl
-
-@[to_additive (attr := simp)]
-theorem Units.coe_opEquiv_symm {M} [Monoid M] (u : Mˣᵐᵒᵖ) :
-    (Units.opEquiv.symm u : Mᵐᵒᵖ) = op (u.unop : M) :=
-  rfl
-
-@[to_additive]
-nonrec theorem IsUnit.op {M} [Monoid M] {m : M} (h : IsUnit m) : IsUnit (op m) :=
-  let ⟨u, hu⟩ := h
-  hu ▸ ⟨Units.opEquiv.symm (op u), rfl⟩
-
-@[to_additive]
-nonrec theorem IsUnit.unop {M} [Monoid M] {m : Mᵐᵒᵖ} (h : IsUnit m) : IsUnit (unop m) :=
-  let ⟨u, hu⟩ := h
-  hu ▸ ⟨unop (Units.opEquiv u), rfl⟩
-
-@[to_additive (attr := simp)]
-theorem isUnit_op {M} [Monoid M] {m : M} : IsUnit (op m) ↔ IsUnit m :=
-  ⟨IsUnit.unop, IsUnit.op⟩
-
-@[to_additive (attr := simp)]
-theorem isUnit_unop {M} [Monoid M] {m : Mᵐᵒᵖ} : IsUnit (unop m) ↔ IsUnit m :=
-  ⟨IsUnit.op, IsUnit.unop⟩
 
 /-- A semigroup homomorphism `M →ₙ* N` can equivalently be viewed as a semigroup homomorphism
 `Mᵐᵒᵖ →ₙ* Nᵐᵒᵖ`. This is the action of the (fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/

--- a/Mathlib/Algebra/Group/Units/Opposite.lean
+++ b/Mathlib/Algebra/Group/Units/Opposite.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2018 Kenny Lau. All rights reserved.
+Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kenny Lau
+Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Group.Opposite
 import Mathlib.Algebra.Group.Units.Defs

--- a/Mathlib/Algebra/Group/Units/Opposite.lean
+++ b/Mathlib/Algebra/Group/Units/Opposite.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2018 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+-/
+import Mathlib.Algebra.Group.Opposite
+import Mathlib.Algebra.Group.Units.Defs
+
+/-!
+# Units in multiplicative and additive opposites
+-/
+
+assert_not_exists MonoidWithZero
+assert_not_exists DenselyOrdered
+
+variable {α : Type*}
+
+open MulOpposite
+
+/-- The units of the opposites are equivalent to the opposites of the units. -/
+@[to_additive
+      "The additive units of the additive opposites are equivalent to the additive opposites
+      of the additive units."]
+def Units.opEquiv {M} [Monoid M] : Mᵐᵒᵖˣ ≃* Mˣᵐᵒᵖ where
+  toFun u := op ⟨unop u, unop ↑u⁻¹, op_injective u.4, op_injective u.3⟩
+  invFun := MulOpposite.rec' fun u => ⟨op ↑u, op ↑u⁻¹, unop_injective <| u.4, unop_injective u.3⟩
+  map_mul' _ _ := unop_injective <| Units.ext <| rfl
+  left_inv x := Units.ext <| by simp
+  right_inv x := unop_injective <| Units.ext <| by rfl
+
+@[to_additive (attr := simp)]
+theorem Units.coe_unop_opEquiv {M} [Monoid M] (u : Mᵐᵒᵖˣ) :
+    ((Units.opEquiv u).unop : M) = unop (u : Mᵐᵒᵖ) :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem Units.coe_opEquiv_symm {M} [Monoid M] (u : Mˣᵐᵒᵖ) :
+    (Units.opEquiv.symm u : Mᵐᵒᵖ) = op (u.unop : M) :=
+  rfl
+
+@[to_additive]
+nonrec theorem IsUnit.op {M} [Monoid M] {m : M} (h : IsUnit m) : IsUnit (op m) :=
+  let ⟨u, hu⟩ := h
+  hu ▸ ⟨Units.opEquiv.symm (op u), rfl⟩
+
+@[to_additive]
+nonrec theorem IsUnit.unop {M} [Monoid M] {m : Mᵐᵒᵖ} (h : IsUnit m) : IsUnit (unop m) :=
+  let ⟨u, hu⟩ := h
+  hu ▸ ⟨unop (Units.opEquiv u), rfl⟩
+
+@[to_additive (attr := simp)]
+theorem isUnit_op {M} [Monoid M] {m : M} : IsUnit (op m) ↔ IsUnit m :=
+  ⟨IsUnit.unop, IsUnit.op⟩
+
+@[to_additive (attr := simp)]
+theorem isUnit_unop {M} [Monoid M] {m : Mᵐᵒᵖ} : IsUnit (unop m) ↔ IsUnit m :=
+  ⟨IsUnit.op, IsUnit.unop⟩

--- a/Mathlib/Algebra/Ring/AddAut.lean
+++ b/Mathlib/Algebra/Ring/AddAut.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.GroupWithZero.Action.Basic
 import Mathlib.Algebra.GroupWithZero.Action.Units
+import Mathlib.Algebra.Group.Units.Opposite
 import Mathlib.Algebra.Module.Opposite
 
 /-!

--- a/Mathlib/Algebra/SMulWithZero.lean
+++ b/Mathlib/Algebra/SMulWithZero.lean
@@ -34,6 +34,7 @@ We also add an `instance`:
 * `smulMonoidWithZeroHom`: Scalar multiplication bundled as a morphism of monoids with zero.
 -/
 
+assert_not_exists Units
 
 variable {R R' M M' : Type*}
 


### PR DESCRIPTION
This removes a few dependencies on `Units` that appear in the basics of group actions.

The hope is that we can eventually avoid importing `Units` in the file defining `Module`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
