### PR TITLE
[Merged by Bors] - feat(KrullDimension): height characterizations

### DIFF
--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -191,7 +191,7 @@ lemma height_orderIso (f : α ≃o β) (x : α) : height (f x) = height x := by
   · simpa using height_le_height_apply_of_strictMono _ f.symm.strictMono (f x)
   · exact height_le_height_apply_of_strictMono _ f.strictMono x
 
-private lemma exist_eq_iSup_of_iSup_eq_coe {α : Type*} [Nonempty α] {f : α → ℕ∞} {n : ℕ}
+private lemma exists_eq_iSup_of_iSup_eq_coe {α : Type*} [Nonempty α] {f : α → ℕ∞} {n : ℕ}
     (h : (⨆ x, f x) = n) : ∃ x, f x = n := by
   obtain ⟨x, hx⟩ := ENat.sSup_mem_of_Nonempty_of_lt_top (h ▸ ENat.coe_lt_top _)
   use x
@@ -205,7 +205,6 @@ lemma exists_series_of_le_height (a : α) {n : ℕ} (h : n ≤ height a) :
   | top =>
     clear h
     rw [height_eq_iSup_last_eq, iSup_subtype', ENat.iSup_coe_eq_top, bddAbove_def] at ha
-    push_neg at ha
     contrapose! ha
     use n
     rintro m ⟨⟨p, rfl⟩, hp⟩
@@ -215,7 +214,7 @@ lemma exists_series_of_le_height (a : α) {n : ℕ} (h : n ≤ height a) :
   | coe m =>
     rw [ha, Nat.cast_le] at h
     rw [height_eq_iSup_last_eq, iSup_subtype'] at ha
-    obtain ⟨⟨p,hlast⟩, hlen⟩ := exist_eq_iSup_of_iSup_eq_coe ha
+    obtain ⟨⟨p, hlast⟩, hlen⟩ := exists_eq_iSup_of_iSup_eq_coe ha
     simp only [Nat.cast_inj] at hlen
     use p.drop ⟨m-n, by omega⟩
     constructor
@@ -228,7 +227,7 @@ lemma exists_series_of_height_eq_coe (a : α) {n : ℕ} (h : height a = n) :
   exists_series_of_le_height a (le_of_eq h.symm)
 
 /-- Another characterization of height, based on the supremum of the heights of elements below. -/
-lemma height_eq_isup_lt_height (x : α) : height x = ⨆ (y : α) (_  : y < x), height y + 1 := by
+lemma height_eq_iSup_lt_height (x : α) : height x = ⨆ (y : α) (_  : y < x), height y + 1 := by
   apply le_antisymm
   · apply height_le
     intro p hp
@@ -246,7 +245,7 @@ lemma height_eq_isup_lt_height (x : α) : height x = ⨆ (y : α) (_  : y < x), 
 
 lemma height_le_coe_iff (x : α) (n : ℕ) :
     height x ≤ n ↔ (∀ y, y < x → height y < n) := by
-  conv_lhs => rw [height_eq_isup_lt_height, iSup₂_le_iff]
+  conv_lhs => rw [height_eq_iSup_lt_height, iSup₂_le_iff]
   congr! 2 with y _
   cases height y
   · simp

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -97,6 +97,9 @@ lemma height_le {a : α} {n : ℕ∞} (h : ∀ (p : LTSeries α), p.last = a →
   apply h
   simp [p']
 
+/--
+Variant of `height_le_iff` ranging only over those series that end exactly on `a`.
+-/
 lemma height_le_iff' {a : α} {n : ℕ∞} :
     height a ≤ n ↔ ∀ ⦃p : LTSeries α⦄, p.last = a → p.length ≤ n := by
  constructor
@@ -187,6 +190,67 @@ lemma height_orderIso (f : α ≃o β) (x : α) : height (f x) = height x := by
   apply le_antisymm
   · simpa using height_le_height_apply_of_strictMono _ f.symm.strictMono (f x)
   · exact height_le_height_apply_of_strictMono _ f.strictMono x
+
+private lemma exist_eq_iSup_of_iSup_eq_coe {α : Type*} [Nonempty α] {f : α → ℕ∞} {n : ℕ}
+    (h : (⨆ x, f x) = n) : ∃ x, f x = n := by
+  obtain ⟨x, hx⟩ := ENat.sSup_mem_of_Nonempty_of_lt_top (h ▸ ENat.coe_lt_top _)
+  use x
+  simpa [hx] using h
+
+/-- There exist a series ending in a element for any length up to the element’s height.  -/
+lemma exists_series_of_le_height (a : α) {n : ℕ} (h : n ≤ height a) :
+    ∃ p : LTSeries α, p.last = a ∧ p.length = n := by
+  have hne : Nonempty { p : LTSeries α // p.last = a } := ⟨RelSeries.singleton _ a, rfl⟩
+  cases ha : height a with
+  | top =>
+    clear h
+    rw [height_eq_iSup_last_eq, iSup_subtype', ENat.iSup_coe_eq_top, bddAbove_def] at ha
+    push_neg at ha
+    contrapose! ha
+    use n
+    rintro m ⟨⟨p, rfl⟩, hp⟩
+    simp only at hp
+    by_contra! hnm
+    apply ha (p.drop ⟨m-n, by omega⟩) (by simp) (by simp; omega)
+  | coe m =>
+    rw [ha, Nat.cast_le] at h
+    rw [height_eq_iSup_last_eq, iSup_subtype'] at ha
+    obtain ⟨⟨p,hlast⟩, hlen⟩ := exist_eq_iSup_of_iSup_eq_coe ha
+    simp only [Nat.cast_inj] at hlen
+    use p.drop ⟨m-n, by omega⟩
+    constructor
+    · simp [hlast]
+    · simp [hlen]; omega
+
+/-- For an element of finite height there exists a series ending in that element of that height. -/
+lemma exists_series_of_height_eq_coe (a : α) {n : ℕ} (h : height a = n) :
+    ∃ p : LTSeries α, p.last = a ∧ p.length = n :=
+  exists_series_of_le_height a (le_of_eq h.symm)
+
+/-- Another characterization of height, based on the supremum of the heights of elements below. -/
+lemma height_eq_isup_lt_height (x : α) : height x = ⨆ (y : α) (_  : y < x), height y + 1 := by
+  apply le_antisymm
+  · apply height_le
+    intro p hp
+    cases hlen : p.length with
+    | zero => simp
+    | succ n =>
+      apply le_iSup_of_le p.eraseLast.last
+      apply le_iSup_of_le (by rw [← hp]; apply RelSeries.eraseLast_last_rel_last _ (by omega))
+      rw [height_add_const]
+      apply le_iSup₂_of_le p.eraseLast (by rfl) (by simp [hlen])
+  · apply iSup₂_le; intro y hyx
+    rw [height_add_const]
+    apply iSup₂_le; intro p hp
+    apply le_iSup₂_of_le (p.snoc x (hp ▸ hyx)) (by simp) (by simp)
+
+lemma height_le_coe_iff (x : α) (n : ℕ) :
+    height x ≤ n ↔ (∀ y, y < x → height y < n) := by
+  conv_lhs => rw [height_eq_isup_lt_height, iSup₂_le_iff]
+  congr! 2 with y _
+  cases height y
+  · simp
+  · norm_cast
 
 end height
 


### PR DESCRIPTION
Next parts from PR #15524: obtaining certain series given the element's heights, and characterizations of height in terms of the height of the elements below it.


From the Carleson project
