### PR TITLE
[Merged by Bors] - feat: improve `fin_cases` names

### DIFF
--- a/Mathlib/Tactic/FinCases.lean
+++ b/Mathlib/Tactic/FinCases.lean
@@ -42,6 +42,8 @@ and we return a list of the first goals which appeared.
 This is useful for hypotheses of the form `h : a ∈ [l₁, l₂, ...]`,
 which will be transformed into a sequence of goals with hypotheses `h : a = l₁`, `h : a = l₂`,
 and so on.
+Cases are named according to the order in which they are generated as tracked by `counter`
+and prefixed with `userNamePre`.
 -/
 partial def unfoldCases (g : MVarId) (h : FVarId)
     (userNamePre : Name := .anonymous) (counter := 0) : MetaM (List MVarId) := do
@@ -121,9 +123,6 @@ produces three goals with hypotheses
 -/
 
 /- TODO: In mathlib3 we ran `norm_num` when there is no `with` clause. Is this still useful? -/
-/- TODO: can we name the cases generated according to their values,
-   rather than `tail.tail.tail.head`?
-   Update: now generates more helpful case names such as `0.2.1` -/
 
 @[tactic finCases] elab_rules : tactic
   | `(tactic| fin_cases $[$hyps:ident],*) => withMainContext <| focus do

--- a/Mathlib/Tactic/FinCases.lean
+++ b/Mathlib/Tactic/FinCases.lean
@@ -58,9 +58,8 @@ partial def unfoldCases (g : MVarId) (h : FVarId)
 /-- Implementation of the `fin_cases` tactic. -/
 partial def finCasesAt (g : MVarId) (hyp : FVarId) : MetaM (List MVarId) := g.withContext do
   let type ← hyp.getType >>= instantiateMVars
-  let userName : Name ← g.getTag
   match ← getMemType type with
-  | some _ => unfoldCases g hyp (userNamePre := userName)
+  | some _ => unfoldCases g hyp (userNamePre := ← g.getTag)
   | none =>
     -- Deal with `x : A`, where `[Fintype A]` is available:
     let inst ← synthInstance (← mkAppM ``Fintype #[type])

--- a/Mathlib/Tactic/FinCases.lean
+++ b/Mathlib/Tactic/FinCases.lean
@@ -50,7 +50,7 @@ partial def unfoldCases (g : MVarId) (h : FVarId)
   let gs ← g.cases h
   try
     let #[g₁, g₂] := gs | throwError "unexpected number of cases"
-    modifyMCtx <| fun m => m.setMVarUserName g₁.mvarId <| .num userNamePre counter
+    g₁.mvarId.setUserName (.num userNamePre counter)
     let gs ← unfoldCases g₂.mvarId g₂.fields[2]!.fvarId! userNamePre (counter+1)
     return g₁.mvarId :: gs
   catch _ => return []

--- a/Mathlib/Tactic/FinCases.lean
+++ b/Mathlib/Tactic/FinCases.lean
@@ -50,7 +50,7 @@ partial def unfoldCases (g : MVarId) (h : FVarId)
   let gs ← g.cases h
   try
     let #[g₁, g₂] := gs | throwError "unexpected number of cases"
-    g₁.mvarId.setUserName (.num userNamePre counter)
+    g₁.mvarId.setUserName (.str userNamePre s!"{counter}")
     let gs ← unfoldCases g₂.mvarId g₂.fields[2]!.fvarId! userNamePre (counter+1)
     return g₁.mvarId :: gs
   catch _ => return []

--- a/Mathlib/Tactic/FinCases.lean
+++ b/Mathlib/Tactic/FinCases.lean
@@ -58,9 +58,7 @@ partial def unfoldCases (g : MVarId) (h : FVarId)
 /-- Implementation of the `fin_cases` tactic. -/
 partial def finCasesAt (g : MVarId) (hyp : FVarId) : MetaM (List MVarId) := g.withContext do
   let type ← hyp.getType >>= instantiateMVars
-  let userName : Name := match (← getMCtx).findDecl? g with
-    | some decl => decl.userName
-    | none => .anonymous
+  let userName : Name ← g.getTag
   match ← getMemType type with
   | some _ => unfoldCases g hyp (userNamePre := userName)
   | none =>

--- a/MathlibTest/fin_cases.lean
+++ b/MathlibTest/fin_cases.lean
@@ -38,6 +38,26 @@ example (p : ℕ) (h2 : 2 < p) (h5 : p < 5) : p = 3 ∨ p = 4 := by
   · norm_num
   · norm_num
 
+-- Check naming of cases
+/--
+info: case «0».«0»
+⊢ True
+
+case «0».«1»
+⊢ True
+
+case «1».«0»
+⊢ True
+
+case «1».«1»
+⊢ True
+-/
+#guard_msgs in
+example (x y:Fin 2): True := by
+  fin_cases x, y
+  trace_state
+  all_goals trivial
+
 -- TODO Restore the remaining tests from mathlib3:
 -- Some of these test the `with` and `using` clauses which haven't been re-implemented.
 


### PR DESCRIPTION
Cases generated by `fin_cases` are now named according to the order in which they are generated.
For example consider:
```lean
import Mathlib.Tactic

example (x y:Fin 3): (x:ℝ)+y < 10 := by
  fin_cases x, y <;> norm_num
``` 
Previously, the case corresponding where `x=1, y=2` would have been displayed as `case tail.head.tail.tail.head`,
where it is now displayed as `case 1.2`

If `fin_cases` is used to replace a goal with an existing name, the existing name will appear in the beginning, for example `goalname.1.2` etc.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Reopened from [here](https://github.com/leanprover-community/mathlib4/pull/18992)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
