### PR TITLE
[Merged by Bors] - feat(GroupTheory/SpecificGroups/ZGroup): Add `IsZGroup.of_surjective`

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -48,4 +48,15 @@ theorem of_injective [hG' : IsZGroup G'] (hf : Function.Injective f) : IsZGroup 
 
 instance [IsZGroup G] (H : Subgroup G) : IsZGroup H := of_injective H.subtype_injective
 
+theorem of_surjective [Finite G] [hG : IsZGroup G] (hf : Function.Surjective f) : IsZGroup G' := by
+  rw [isZGroup_iff] at hG ⊢
+  intro p hp P
+  have := Fact.mk hp
+  obtain ⟨Q, rfl⟩ := Sylow.mapSurjective_surjective hf p P
+  specialize hG p hp Q
+  exact isCyclic_of_surjective _ (f.subgroupMap_surjective Q)
+
+instance [Finite G] [IsZGroup G] (H : Subgroup G) [H.Normal] : IsZGroup (G ⧸ H) :=
+  of_surjective (QuotientGroup.mk'_surjective H)
+
 end IsZGroup


### PR DESCRIPTION
This PR shows that if all Sylow subgroups of `G` are cyclic, then the same is true for any quotient of `G`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
