### PR TITLE
[Merged by Bors] - feat(Algebra/Group/Aut): Isomorphic groups have isomorphic automorphism groups

### DIFF
--- a/Mathlib/Algebra/Group/Aut.lean
+++ b/Mathlib/Algebra/Group/Aut.lean
@@ -141,6 +141,16 @@ theorem conj_symm_apply [Group G] (g h : G) : (conj g).symm h = g⁻¹ * h * g :
 theorem conj_inv_apply [Group G] (g h : G) : (conj g)⁻¹ h = g⁻¹ * h * g :=
   rfl
 
+/-- Isomorphic groups have isomorphic automorphism groups. -/
+@[simps]
+def congr [Group G] {H : Type*} [Group H] (ϕ : G ≃* H) :
+    MulAut G ≃* MulAut H where
+  toFun f := ϕ.symm.trans (f.trans ϕ)
+  invFun f := ϕ.trans (f.trans ϕ.symm)
+  left_inv _ := by simp [DFunLike.ext_iff]
+  right_inv _ := by simp [DFunLike.ext_iff]
+  map_mul' := by simp [DFunLike.ext_iff]
+
 end MulAut
 
 namespace AddAut
@@ -254,5 +264,15 @@ theorem conj_symm_apply [AddGroup G] (g h : G) : (conj g).symm h = -g + h + g :=
 @[simp]
 theorem conj_inv_apply [AddGroup G] (g h : G) : (Additive.toMul (conj g))⁻¹ h = -g + h + g :=
   rfl
+
+/-- Isomorphic additive groups have isomorphic automorphism groups. -/
+@[simps]
+def congr [AddGroup G] {H : Type*} [AddGroup H] (ϕ : G ≃+ H) :
+    AddAut G ≃* AddAut H where
+  toFun f := ϕ.symm.trans (f.trans ϕ)
+  invFun f := ϕ.trans (f.trans ϕ.symm)
+  left_inv _ := by simp [DFunLike.ext_iff]
+  right_inv _ := by simp [DFunLike.ext_iff]
+  map_mul' := by simp [DFunLike.ext_iff]
 
 end AddAut


### PR DESCRIPTION
This PR shows that isomorphic groups have isomorphic automorphism groups.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
