### PR TITLE
[Merged by Bors] - feat(Manifold/IntegralCurve/Transform): pointwise notation and translation lemmas for subtraction

### DIFF
--- a/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
@@ -53,12 +53,7 @@ lemma isIntegralCurveOn_comp_add {dt : ℝ} :
 
 lemma isIntegralCurveOn_comp_sub {dt : ℝ} :
     IsIntegralCurveOn γ v s ↔ IsIntegralCurveOn (γ ∘ (· - dt)) v (dt +ᵥ s) := by
-  nth_rw 2 [← neg_neg dt]
-  refine ⟨fun hγ ↦ hγ.comp_add _, fun hγ ↦ ?_⟩
-  convert hγ.comp_add dt
-  · ext t
-    simp only [comp_apply, add_sub_cancel_right]
-  · simp only [neg_neg, neg_vadd_vadd]
+  simpa using isIntegralCurveOn_comp_add (dt := -dt)
 
 lemma IsIntegralCurveAt.comp_add (hγ : IsIntegralCurveAt γ v t₀) (dt : ℝ) :
     IsIntegralCurveAt (γ ∘ (· + dt)) v (t₀ - dt) := by

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
@@ -20,7 +20,7 @@ curve.
 integral curve, vector field
 -/
 
-open Function Set
+open Function Set Pointwise
 
 variable
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
@@ -33,21 +33,32 @@ variable
 section Translation
 
 lemma IsIntegralCurveOn.comp_add (hγ : IsIntegralCurveOn γ v s) (dt : ℝ) :
-    IsIntegralCurveOn (γ ∘ (· + dt)) v { t | t + dt ∈ s } := by
+    IsIntegralCurveOn (γ ∘ (· + dt)) v (-dt +ᵥ s) := by
   intros t ht
   rw [comp_apply, ← ContinuousLinearMap.comp_id (ContinuousLinearMap.smulRight 1 (v (γ (t + dt))))]
+  rw [mem_vadd_set_iff_neg_vadd_mem, neg_neg, vadd_eq_add, add_comm,
+    ← mem_setOf (p := fun t ↦ t + dt ∈ s)] at ht
   apply HasMFDerivAt.comp t (hγ (t + dt) ht)
   refine ⟨(continuous_add_right _).continuousAt, ?_⟩
   simp only [mfld_simps, hasFDerivWithinAt_univ]
   exact HasFDerivAt.add_const (hasFDerivAt_id _) _
 
 lemma isIntegralCurveOn_comp_add {dt : ℝ} :
-    IsIntegralCurveOn γ v s ↔ IsIntegralCurveOn (γ ∘ (· + dt)) v { t | t + dt ∈ s } := by
+    IsIntegralCurveOn γ v s ↔ IsIntegralCurveOn (γ ∘ (· + dt)) v (-dt +ᵥ s) := by
   refine ⟨fun hγ ↦ hγ.comp_add _, fun hγ ↦ ?_⟩
   convert hγ.comp_add (-dt)
   · ext t
     simp only [Function.comp_apply, neg_add_cancel_right]
-  · simp only [mem_setOf_eq, neg_add_cancel_right, setOf_mem_eq]
+  · simp only [neg_neg, vadd_neg_vadd]
+
+lemma isIntegralCurveOn_comp_sub {dt : ℝ} :
+    IsIntegralCurveOn γ v s ↔ IsIntegralCurveOn (γ ∘ (· - dt)) v (dt +ᵥ s) := by
+  nth_rw 2 [← neg_neg dt]
+  refine ⟨fun hγ ↦ hγ.comp_add _, fun hγ ↦ ?_⟩
+  convert hγ.comp_add dt
+  · ext t
+    simp only [comp_apply, add_sub_cancel_right]
+  · simp only [neg_neg, neg_vadd_vadd]
 
 lemma IsIntegralCurveAt.comp_add (hγ : IsIntegralCurveAt γ v t₀) (dt : ℝ) :
     IsIntegralCurveAt (γ ∘ (· + dt)) v (t₀ - dt) := by
@@ -55,8 +66,7 @@ lemma IsIntegralCurveAt.comp_add (hγ : IsIntegralCurveAt γ v t₀) (dt : ℝ) 
   obtain ⟨ε, hε, h⟩ := hγ
   refine ⟨ε, hε, ?_⟩
   convert h.comp_add dt
-  ext t
-  rw [mem_setOf_eq, Metric.mem_ball, Metric.mem_ball, dist_sub_eq_dist_add_right]
+  rw [Metric.vadd_ball, vadd_eq_add, neg_add_eq_sub]
 
 lemma isIntegralCurveAt_comp_add {dt : ℝ} :
     IsIntegralCurveAt γ v t₀ ↔ IsIntegralCurveAt (γ ∘ (· + dt)) v (t₀ - dt) := by
@@ -66,10 +76,14 @@ lemma isIntegralCurveAt_comp_add {dt : ℝ} :
     simp only [Function.comp_apply, neg_add_cancel_right]
   · simp only [sub_neg_eq_add, sub_add_cancel]
 
+lemma isIntegralCurveAt_comp_sub {dt : ℝ} :
+    IsIntegralCurveAt γ v t₀ ↔ IsIntegralCurveAt (γ ∘ (· - dt)) v (t₀ + dt) := by
+  simpa using isIntegralCurveAt_comp_add (dt := -dt)
+
 lemma IsIntegralCurve.comp_add (hγ : IsIntegralCurve γ v) (dt : ℝ) :
     IsIntegralCurve (γ ∘ (· + dt)) v := by
   rw [isIntegralCurve_iff_isIntegralCurveOn] at *
-  exact hγ.comp_add _
+  simpa using hγ.comp_add dt
 
 lemma isIntegralCurve_comp_add {dt : ℝ} :
     IsIntegralCurve γ v ↔ IsIntegralCurve (γ ∘ (· + dt)) v := by
@@ -77,6 +91,10 @@ lemma isIntegralCurve_comp_add {dt : ℝ} :
   convert hγ.comp_add (-dt)
   ext t
   simp only [Function.comp_apply, neg_add_cancel_right]
+
+lemma isIntegralCurve_comp_sub {dt : ℝ} :
+    IsIntegralCurve γ v ↔ IsIntegralCurve (γ ∘ (· - dt)) v := by
+  simpa using isIntegralCurve_comp_add (dt := -dt)
 
 end Translation
 


### PR DESCRIPTION
We restate the translation lemmas for integral curves using the `Pointwise` API and add translation lemmas for subtraction for convenience.

This is just split out from #9013.

The `Pointwise` API allows us to use lemmas like `Metric.vadd_ball` and more convenient rewriting of the `dt` term (rather than rewriting it inside the set builder notation).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
