### PR TITLE
feat(Algebra/BigOperators/Fin): Add `finSigmaFinEquiv`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -422,21 +422,8 @@ def finPiFinEquiv {m : ℕ} {n : Fin m → ℕ} : (∀ i : Fin m, Fin (n i)) ≃
         change (_ + ∑ y : _, _ / (x * _) % _ * (x * _)) = _
         simp_rw [← Nat.div_div_eq_div_mul, mul_left_comm (_ % _ : ℕ), ← mul_sum]
         convert Nat.mod_add_div _ _
-        -- Porting note: new
         refine (ih (a / x) (Nat.div_lt_of_lt_mul <| a.is_lt.trans_eq ?_))
-        exact Fin.prod_univ_succ _
-        -- Porting note: was:
-        /-
-        refine' Eq.trans _ (ih (a / x) (Nat.div_lt_of_lt_mul <| a.is_lt.trans_eq _))
-        swap
-        · convert Fin.prod_univ_succ (Fin.cons x xs : _ → ℕ)
-          simp_rw [Fin.cons_succ]
-        congr with i
-        congr with j
-        · cases j
-          rfl
-        · cases j
-          rfl-/)
+        exact Fin.prod_univ_succ _)
 
 theorem finPiFinEquiv_apply {m : ℕ} {n : Fin m → ℕ} (f : ∀ i : Fin m, Fin (n i)) :
     (finPiFinEquiv f : ℕ) = ∑ i, f i * ∏ j, n (Fin.castLE i.is_lt.le j) := rfl

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -371,20 +371,17 @@ theorem finFunctionFinEquiv_single {m n : ℕ} [NeZero m] (i : Fin n) (j : Fin m
 /-- Equivalence between `(i : Fin m) × Fin (n i)` and `Fin (∑ i, n i)`. -/
 def finSigmaFinEquiv {m : ℕ} {n : Fin m → ℕ} : (i : Fin m) × Fin (n i) ≃ Fin (∑ i, n i) :=
   .ofRightInverseOfCardLE (le_of_eq <| by simp_rw [Fintype.card_sigma, Fintype.card_fin])
-    (fun ⟨i, j⟩ =>
-      let h : m ≠ 0 := Nat.not_eq_zero_of_lt i.prop
-      ⟨∑ k, n (Fin.castLE i.isLt.le k) + j, by
-        have hi : i.val + 1 + (m - i.val - 1) = m := by omega
-        conv_rhs => rw [← Fin.sum_congr' n hi, Fin.sum_univ_add, Fin.sum_univ_add, add_assoc]
-        have hk {k : Fin i} : Fin.castLE i.isLt.le k =
-              Fin.cast hi (Fin.castAdd (m - i - 1) (Fin.castAdd 1 k)) := by
-          simp only [Fin.castLE, Fin.cast, Fin.coe_castAdd]
-        simp_rw [hk, Nat.add_lt_add_iff_left, univ_unique, sum_singleton]
-        exact Nat.lt_add_right _ (by simp only [Fin.cast, Fin.coe_castAdd, Fin.coe_natAdd,
-            Fin.val_eq_zero, add_zero, Fin.is_lt])⟩)
+    (fun ⟨i, j⟩ => ⟨∑ k, n (Fin.castLE i.isLt.le k) + j, by
+      have hi : i.val + 1 + (m - i.val - 1) = m := by omega
+      conv_rhs => rw [← Fin.sum_congr' n hi, Fin.sum_univ_add, Fin.sum_univ_add, add_assoc]
+      have hk {k : Fin i} : Fin.castLE i.isLt.le k =
+            Fin.cast hi (Fin.castAdd (m - i - 1) (Fin.castAdd 1 k)) := by
+        simp only [Fin.castLE, Fin.cast, Fin.coe_castAdd]
+      simp_rw [hk, Nat.add_lt_add_iff_left, univ_unique, sum_singleton]
+      exact Nat.lt_add_right _ (by simp only [Fin.cast, Fin.coe_castAdd, Fin.coe_natAdd,
+          Fin.val_eq_zero, add_zero, Fin.is_lt])⟩)
     (fun k => ⟨k.divSum, k.modSum⟩)
-    (by
-      intro a
+    (fun a => by
       induction n using Fin.consInduction with
       | h0 =>
         simp only [univ_eq_empty, sum_empty] at a

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -270,7 +270,7 @@ index `i` such that `k` is smaller than `∑ j < i, n j`, and `none` otherwise.
 This is defined en-route to `Fin.divSum`, which is the dependent version of `Fin.divNat`.
 -/
 def divSum? {m : ℕ} (n : Fin m → ℕ) (k : ℕ) : Option (Fin m) :=
-  find (fun i => k < ∑ j, n (castLE i.isLt j))
+  find (fun i => k < ∑ j : Fin i.val.succ, n (castLE i.isLt j))
 
 theorem divSum?_is_some_iff_lt_sum {m : ℕ} {n : Fin m → ℕ} {k : ℕ} :
     (divSum? n k).isSome ↔ k < ∑ i, n i := by

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -267,7 +267,7 @@ end Fin
 /-- Equivalence between `Fin n → Fin m` and `Fin (m ^ n)`. -/
 @[simps!]
 def finFunctionFinEquiv {m n : ℕ} : (Fin n → Fin m) ≃ Fin (m ^ n) :=
-  Equiv.ofRightInverseOfCardLE (le_of_eq <| by simp_rw [Fintype.card_fun, Fintype.card_fin])
+  .ofRightInverseOfCardLE (le_of_eq <| by simp_rw [Fintype.card_fun, Fintype.card_fin])
     (fun f => ⟨∑ i, f i * m ^ (i : ℕ), by
       induction n with
       | zero => simp
@@ -311,7 +311,7 @@ theorem finFunctionFinEquiv_single {m n : ℕ} [NeZero m] (i : Fin n) (j : Fin m
 
 /-- Equivalence between `(i : Fin m) × Fin (n i)` and `Fin (∑ i, n i)`. -/
 def finSigmaFinEquiv {m : ℕ} {n : Fin m → ℕ} : (i : Fin m) × Fin (n i) ≃ Fin (∑ i, n i) :=
-  Equiv.ofRightInverseOfCardLE (le_of_eq <| by simp_rw [Fintype.card_sigma, Fintype.card_fin])
+  .ofRightInverseOfCardLE (le_of_eq <| by simp_rw [Fintype.card_sigma, Fintype.card_fin])
     (fun ⟨i, j⟩ => if h : m = 0 then Fin.elim0 (i.cast h) else
       ⟨∑ k, n (Fin.castLE i.isLt.le k) + j, by
         have hi : i.val + 1 + (m - i.val - 1) = m := by omega
@@ -339,11 +339,12 @@ def finSigmaFinEquiv {m : ℕ} {n : Fin m → ℕ} : (i : Fin m) × Fin (n i) �
         exact hk⟩
       ⟨i, j⟩)
     (by
-      intro a; revert a
-      refine Fin.consInduction (fun a => ?_) ?_ n
-      · simp only [Finset.univ_eq_empty, Finset.sum_empty] at a
+      intro a
+      induction n using Fin.consInduction with
+      | h0 =>
+        simp only [Finset.univ_eq_empty, Finset.sum_empty] at a
         exact Fin.elim0 a
-      · intro _ _ _ _ _
+      | h =>
         ext
         exact Nat.add_sub_cancel' (sum_le_of_find_eq_some (Option.some_get _).symm))
   where
@@ -355,8 +356,8 @@ def finSigmaFinEquiv {m : ℕ} {n : Fin m → ℕ} : (i : Fin m) × Fin (n i) �
         simp only [univ_eq_empty, sum_empty, Nat.zero_le]
       · have : (i.val - 1) + 1 = i.val := by omega
         rw [← Fin.sum_congr' _ this]
-        have := Fin.find_min (Option.mem_def.mp hi) (j := ⟨i.val - 1, by omega⟩) <| Fin.lt_def.mpr
-          (by simp only [and_true]; omega)
+        have := Fin.find_min (Option.mem_def.mp hi) (j := ⟨i.val - 1, by omega⟩)
+          <| Fin.lt_def.mpr (by simp only [and_true]; omega)
         exact not_lt.mp this
 
 @[simp]
@@ -374,7 +375,7 @@ theorem finSigmaFinEquiv_pair {m : ℕ} {n : Fin m → ℕ} (hm : m ≠ 0) (i : 
 
 /-- Equivalence between `∀ i : Fin m, Fin (n i)` and `Fin (∏ i : Fin m, n i)`. -/
 def finPiFinEquiv {m : ℕ} {n : Fin m → ℕ} : (∀ i : Fin m, Fin (n i)) ≃ Fin (∏ i : Fin m, n i) :=
-  Equiv.ofRightInverseOfCardLE (le_of_eq <| by simp_rw [Fintype.card_pi, Fintype.card_fin])
+  .ofRightInverseOfCardLE (le_of_eq <| by simp_rw [Fintype.card_pi, Fintype.card_fin])
     (fun f => ⟨∑ i, f i * ∏ j, n (Fin.castLE i.is_lt.le j), by
       induction m with
       | zero => simp

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -363,9 +363,8 @@ def finSigmaFinEquiv {m : ℕ} {n : Fin m → ℕ} : (i : Fin m) × Fin (n i) �
         exact not_lt.mp this
 
 @[simp]
-theorem finSigmaFinEquiv_apply {m : ℕ} {n : Fin m → ℕ}
-    (k : (i : Fin m) × Fin (n i)) :
-      (finSigmaFinEquiv k : ℕ) = ∑ i, n (Fin.castLE k.1.isLt.le i) + k.2 := rfl
+theorem finSigmaFinEquiv_apply {m : ℕ} {n : Fin m → ℕ} (k : (i : Fin m) × Fin (n i)) :
+    (finSigmaFinEquiv k : ℕ) = ∑ i : Fin k.1, n (Fin.castLE k.1.isLt.le i) + k.2 := rfl
 
 theorem finSigmaFinEquiv_pair {m : ℕ} {n : Fin m → ℕ} (i : Fin m) (k : Fin (n i)) :
     (finSigmaFinEquiv ⟨i, k⟩ : ℕ) = ∑ j, n (Fin.castLE i.isLt.le j) + k := by

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -312,7 +312,8 @@ theorem finFunctionFinEquiv_single {m n : ℕ} [NeZero m] (i : Fin n) (j : Fin m
 /-- Equivalence between `(i : Fin m) × Fin (n i)` and `Fin (∑ i, n i)`. -/
 def finSigmaFinEquiv {m : ℕ} {n : Fin m → ℕ} : (i : Fin m) × Fin (n i) ≃ Fin (∑ i, n i) :=
   .ofRightInverseOfCardLE (le_of_eq <| by simp_rw [Fintype.card_sigma, Fintype.card_fin])
-    (fun ⟨i, j⟩ => if h : m = 0 then Fin.elim0 (i.cast h) else
+    (fun ⟨i, j⟩ =>
+      let h : m ≠ 0 := Nat.not_eq_zero_of_lt i.prop
       ⟨∑ k, n (Fin.castLE i.isLt.le k) + j, by
         have hi : i.val + 1 + (m - i.val - 1) = m := by omega
         conv_rhs => rw [← Fin.sum_congr' n hi, Fin.sum_univ_add, Fin.sum_univ_add, add_assoc]
@@ -323,7 +324,8 @@ def finSigmaFinEquiv {m : ℕ} {n : Fin m → ℕ} : (i : Fin m) × Fin (n i) �
         simp only [Finset.univ_unique, Finset.sum_singleton]
         exact Nat.lt_add_right _ (by simp only [Fin.cast, Fin.coe_castAdd, Fin.coe_natAdd,
             Fin.val_eq_zero, add_zero, Fin.is_lt])⟩)
-    (fun k => if h : m = 0 then Fin.elim0 <| k.cast (by subst h; simp) else
+    (fun k =>
+      have h : m ≠ 0 := fun h => Fin.elim0 <| k.cast (by subst h; simp)
       let i : Fin m := Fin.find (fun i => k < ∑ j, n (Fin.castLE i.isLt j)) |>.get (by
         refine Fin.isSome_find_iff.mpr ?_
         have hm : (m - 1) + 1 = m := by omega
@@ -361,17 +363,13 @@ def finSigmaFinEquiv {m : ℕ} {n : Fin m → ℕ} : (i : Fin m) × Fin (n i) �
         exact not_lt.mp this
 
 @[simp]
-theorem finSigmaFinEquiv_apply_zero {n : Fin 0 → ℕ} (k : (i : Fin 0) × Fin (n i)) :
-    finSigmaFinEquiv k = Fin.elim0 k.1 := rfl
-
-@[simp]
-theorem finSigmaFinEquiv_apply_succ {m : ℕ} {n : Fin (m + 1) → ℕ}
-    (k : (i : Fin (m + 1)) × Fin (n i)) :
+theorem finSigmaFinEquiv_apply {m : ℕ} {n : Fin m → ℕ}
+    (k : (i : Fin m) × Fin (n i)) :
       (finSigmaFinEquiv k : ℕ) = ∑ i, n (Fin.castLE k.1.isLt.le i) + k.2 := rfl
 
-theorem finSigmaFinEquiv_pair {m : ℕ} {n : Fin m → ℕ} (hm : m ≠ 0) (i : Fin m) (k : Fin (n i)) :
+theorem finSigmaFinEquiv_pair {m : ℕ} {n : Fin m → ℕ} (i : Fin m) (k : Fin (n i)) :
     (finSigmaFinEquiv ⟨i, k⟩ : ℕ) = ∑ j, n (Fin.castLE i.isLt.le j) + k := by
-  simp only [finSigmaFinEquiv, hm, ↓reduceDIte, Equiv.ofRightInverseOfCardLE_apply]
+  simp only [finSigmaFinEquiv, ↓reduceDIte, Equiv.ofRightInverseOfCardLE_apply]
 
 /-- Equivalence between `∀ i : Fin m, Fin (n i)` and `Fin (∏ i : Fin m, n i)`. -/
 def finPiFinEquiv {m : ℕ} {n : Fin m → ℕ} : (∀ i : Fin m, Fin (n i)) ≃ Fin (∏ i : Fin m, n i) :=


### PR DESCRIPTION
This PR adds `finSigmaFinEquiv` which is the equivalence `(i : Fin m) × Fin (n i) ≃ Fin (∑ i, n i)`. This is the dependent version of `finProdFinEquiv`.

CI should be passing, but there are two things I'd like feedback on:
1. When defining the mappings, I have to consider `m = 0` separately. Is there a more uniform definition?
2. I'm proving this as a step toward defining `Fin.join`, which is the analogue of `List.join`. I can now technically define `Fin.join` as:
```
variable {a : Fin n → ℕ} {α : (i : Fin n) → (j : Fin (a i)) → Sort*}

def join (v : (i : Fin n) → (j : Fin (a i)) → α i j) (k : Fin (∑ i, a i)) :
    α (finSigmaFinEquiv.invFun k).1 (finSigmaFinEquiv.invFun k).2 :=
  v (finSigmaFinEquiv.invFun k).1 (finSigmaFinEquiv.invFun k).2
```
but this looks horrible. This highly motivates refactoring `invFun` as two new definitions:
```
def func1 {n : ℕ} (a : Fin n → ℕ) (k : Fin (∑ i, a i)) : Fin n := sorry

def func2 {n : ℕ} (a : Fin n → ℕ) (k : Fin (∑ i, a i)) : Fin (a (func1 a k)) := sorry
```
I'm not sure what to call these functions. The analogues in the non-dependent case are `divNat` and `modNat`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
