### PR TITLE
[Merged by Bors] - feat: glue zero rows/cols to TU matrices

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
@@ -88,7 +88,7 @@ lemma mapEquiv_isTotallyUnimodular {X' Y' : Type*} (A : Matrix m n R) (eX : X' �
   · simpa [submatrix] using hA k (eX.symm ∘ f) (eY.symm ∘ g)
   · simpa [submatrix] using hA k (eX ∘ f) (eY ∘ g)
 
-lemma adjoin_row0s_isTotallyUnimodular_iff (A : Matrix m n R) {m' : Type*} :
+lemma fromRows_row0_isTotallyUnimodular_iff (A : Matrix m n R) {m' : Type*} :
     (fromRows A (row m' 0)).IsTotallyUnimodular ↔ A.IsTotallyUnimodular := by
   rw [isTotallyUnimodular_iff, isTotallyUnimodular_iff]
   constructor <;> intro hA k f g

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
@@ -111,10 +111,9 @@ lemma fromRows_row0_isTotallyUnimodular_iff (A : Matrix m n R) {m' : Type*} :
         apply hf₀
       apply hA
 
-lemma adjoin_col0s_isTotallyUnimodular_iff (A : Matrix m n R) {n' : Type*} :
+lemma fromColumns_col0_isTotallyUnimodular_iff (A : Matrix m n R) {n' : Type*} :
     (fromColumns A (col n' 0)).IsTotallyUnimodular ↔ A.IsTotallyUnimodular := by
-  rw [← transpose_transpose (fromColumns A (col n' 0)), transpose_isTotallyUnimodular_iff,
-    transpose_fromColumns, transpose_col, adjoin_row0s_isTotallyUnimodular_iff,
-    transpose_isTotallyUnimodular_iff]
+  rw [← transpose_isTotallyUnimodular_iff, transpose_fromColumns, transpose_col,
+    fromRows_row0_isTotallyUnimodular_iff, transpose_isTotallyUnimodular_iff]
 
 end Matrix


### PR DESCRIPTION
Co-authored-by: Johan Commelin <johan@commelin.net>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
