### PR TITLE
[Merged by Bors] - feat: weighted technical debt in PR summary

### DIFF
--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -149,7 +149,14 @@ then
   then
     printf '<details><summary>No changes to technical debt.</summary>\n'
   else
-    printf '<details><summary>Changes to technical debt</summary>\n\n%s\n' "${rep}"
+    printf '%s\n' "${rep}" |
+      awk -F '|' -v rep="${rep}" '
+        BEGIN{total=0; weight=0}
+        (($3+0 == $3) && (!($2+0 == 0))) {total+=1 / $2; weight+=$3 / $2}
+        END{
+          average=weight/total
+          if(average < 0) {change= "Decrease"; average=-average} else {change= "Increase"}
+          printf("<details><summary>%s in tech debt: %4.2f</summary>\n\n%s\n", change, average, rep) }'
   fi
   printf '\nYou can run this locally as\n```\n./scripts/technical-debt-metrics.sh pr_summary\n```\n</details>\n'
 else


### PR DESCRIPTION
Add a "weighted technical debt average" to the PR summary.

The weighted average is obtained by weighting each change by the inverse of the current value of the measure.  Thus, to balance an increase in a category that has a small number of exceptions, you would have to decrease substantially more a category that has a large number of exceptions.

The heuristic behind this choice is that category with few exceptions tend to be harder/more desirable to remove.  This is not perfect, but it is a start!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
