### PR TITLE
[Merged by Bors] - feat(Algebra/Category/ModuleCat/Products): show that arbitrary coproducts agree with direct sum

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Products.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Products.lean
@@ -5,6 +5,7 @@ Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Category.ModuleCat.Basic
 import Mathlib.LinearAlgebra.Pi
+import Mathlib.Algebra.DirectSum.Module
 import Mathlib.Tactic.CategoryTheory.Elementwise
 
 /-!
@@ -23,6 +24,7 @@ namespace ModuleCat
 variable {R : Type u} [Ring R]
 variable {ι : Type v} (Z : ι → ModuleCatMax.{v, w} R)
 
+section product
 
 /-- The product cone induced by the concrete product. -/
 def productCone : Fan Z :=
@@ -59,5 +61,53 @@ theorem piIsoPi_inv_kernel_ι (i : ι) :
 theorem piIsoPi_hom_ker_subtype (i : ι) :
     (piIsoPi Z).hom ≫ (LinearMap.proj i : (∀ i : ι, Z i) →ₗ[R] Z i) = Pi.π Z i :=
   IsLimit.conePointUniqueUpToIso_inv_comp _ (limit.isLimit _) (Discrete.mk i)
+
+end product
+
+section coproduct
+
+open DirectSum
+
+variable [DecidableEq ι]
+
+/-- The coproduct cone induced by the concrete product. -/
+def coproductCocone : Cofan Z :=
+  Cofan.mk (ModuleCat.of R (⨁ i : ι, Z i)) fun i => (DirectSum.lof R ι (fun i ↦ Z i) i)
+
+/-- The concrete coproduct cone is limiting. -/
+def coproductCoconeIsColimit : IsColimit (coproductCocone Z) where
+  desc s := DirectSum.toModule R ι _ fun i ↦ s.ι.app ⟨i⟩
+  fac := by
+    rintro s ⟨i⟩
+    ext (x : Z i)
+    simpa only [Discrete.functor_obj_eq_as, coproductCocone, Cofan.mk_pt, Functor.const_obj_obj,
+      Cofan.mk_ι_app, coe_comp, Function.comp_apply] using
+      DirectSum.toModule_lof (ι := ι) R (M := fun i ↦ Z i) i x
+  uniq := by
+    rintro s f h
+    refine DirectSum.linearMap_ext _ fun i ↦ ?_
+    ext x
+    simpa only [LinearMap.coe_comp, Function.comp_apply, toModule_lof] using
+      congr($(h ⟨i⟩) x)
+
+variable [HasCoproduct Z]
+
+/-- The categorical coproduct of a family of objects in `ModuleCat`
+agrees with direct sum.
+-/
+noncomputable def coprodIsoDirectSum : ∐ Z ≅ ModuleCat.of R (⨁ i, Z i) :=
+  colimit.isoColimitCocone ⟨_, coproductCoconeIsColimit Z⟩
+
+@[simp, elementwise]
+theorem ι_coprodIsoDirectSum_hom (i : ι) :
+    Sigma.ι Z i ≫ (coprodIsoDirectSum Z).hom = DirectSum.lof R ι (fun i ↦ Z i) i :=
+  colimit.isoColimitCocone_ι_hom _ _
+
+@[simp, elementwise]
+theorem lof_coprodIsoDirectSum_inv (i : ι) :
+    DirectSum.lof R ι (fun i ↦ Z i) i ≫ (coprodIsoDirectSum Z).inv = Sigma.ι Z i :=
+  (coproductCoconeIsColimit Z).comp_coconePointUniqueUpToIso_hom (colimit.isColimit _) _
+
+end coproduct
 
 end ModuleCat


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
