### PR TITLE
[Merged by Bors] - chore(Data/Set): split the `CoeSort` instance to its own file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2920,6 +2920,7 @@ import Mathlib.Data.Set.Accumulate
 import Mathlib.Data.Set.Basic
 import Mathlib.Data.Set.BoolIndicator
 import Mathlib.Data.Set.Card
+import Mathlib.Data.Set.CoeSort
 import Mathlib.Data.Set.Constructions
 import Mathlib.Data.Set.Countable
 import Mathlib.Data.Set.Defs

--- a/Mathlib/Algebra/Group/Int.lean
+++ b/Mathlib/Algebra/Group/Int.lean
@@ -16,8 +16,9 @@ This file contains the additive group and multiplicative monoid instances on the
 See note [foundational algebra order theory].
 -/
 
-assert_not_exists Ring
 assert_not_exists DenselyOrdered
+assert_not_exists Ring
+assert_not_exists Set.range
 
 open Nat
 

--- a/Mathlib/CategoryTheory/Types.lean
+++ b/Mathlib/CategoryTheory/Types.lean
@@ -5,7 +5,7 @@ Authors: Stephen Morgan, Kim Morrison, Johannes Hölzl
 -/
 import Mathlib.CategoryTheory.EpiMono
 import Mathlib.CategoryTheory.Functor.FullyFaithful
-import Mathlib.Data.Set.Operations
+import Mathlib.Data.Set.CoeSort
 import Mathlib.Tactic.PPWithUniv
 import Mathlib.Tactic.ToAdditive
 

--- a/Mathlib/Data/Finite/Defs.lean
+++ b/Mathlib/Data/Finite/Defs.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import Mathlib.Data.Set.Operations
+import Mathlib.Data.Set.CoeSort
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Tactic.Set
 import Mathlib.Util.AssertExists

--- a/Mathlib/Data/Set/CoeSort.lean
+++ b/Mathlib/Data/Set/CoeSort.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Johannes Hölzl, Reid Barton, Kim Morrison, Patrick Massot, Kyle Miller,
+Minchao Wu, Yury Kudryashov, Floris van Doorn
+-/
+import Mathlib.Data.Set.Defs
+
+/-!
+# Coercing sets to types.
+
+This file defines `Set.Elem s` as the type of all elements of the set `s`.
+More advanced theorems about these definitions are located in other files in `Mathlib/Data/Set`.
+
+## Main definitions
+
+- `Set.Elem`: coercion of a set to a type; it is reducibly equal to `{x // x ∈ s}`;
+-/
+
+namespace Set
+
+universe u v w
+
+variable {α : Type u} {β : Type v} {γ : Type w}
+
+-- Porting note: I've introduced this abbreviation, with the `@[coe]` attribute,
+-- so that `norm_cast` has something to index on.
+-- It is currently an abbreviation so that instance coming from `Subtype` are available.
+-- If you're interested in making it a `def`, as it probably should be,
+-- you'll then need to create additional instances (and possibly prove lemmas about them).
+-- The first error should appear below at `monotoneOn_iff_monotone`.
+/-- Given the set `s`, `Elem s` is the `Type` of element of `s`. -/
+@[coe, reducible] def Elem (s : Set α) : Type u := {x // x ∈ s}
+
+/-- Coercion from a set to the corresponding subtype. -/
+instance : CoeSort (Set α) (Type u) := ⟨Elem⟩
+
+end Set

--- a/Mathlib/Data/Set/Operations.lean
+++ b/Mathlib/Data/Set/Operations.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Johannes Hölzl, Reid Barton, Kim Morrison, Patrick Massot, Kyle Miller,
 Minchao Wu, Yury Kudryashov, Floris van Doorn
 -/
+import Mathlib.Data.Set.CoeSort
 import Mathlib.Data.SProd
 import Mathlib.Data.Subtype
 import Mathlib.Order.Notation
@@ -19,7 +20,6 @@ More advanced theorems about these definitions are located in other files in `Ma
 ## Main definitions
 
 - complement of a set and set difference;
-- `Set.Elem`: coercion of a set to a type; it is reducibly equal to `{x // x ∈ s}`;
 - `Set.preimage f s`, a.k.a. `f ⁻¹' s`: preimage of a set;
 - `Set.range f`: the range of a function;
   it is more general than `f '' univ` because it allows functions from `Sort*`;
@@ -88,18 +88,6 @@ theorem diff_eq (s t : Set α) : s \ t = s ∩ tᶜ := rfl
 @[simp] theorem mem_diff {s t : Set α} (x : α) : x ∈ s \ t ↔ x ∈ s ∧ x ∉ t := Iff.rfl
 
 theorem mem_diff_of_mem {s t : Set α} {x : α} (h1 : x ∈ s) (h2 : x ∉ t) : x ∈ s \ t := ⟨h1, h2⟩
-
--- Porting note: I've introduced this abbreviation, with the `@[coe]` attribute,
--- so that `norm_cast` has something to index on.
--- It is currently an abbreviation so that instance coming from `Subtype` are available.
--- If you're interested in making it a `def`, as it probably should be,
--- you'll then need to create additional instances (and possibly prove lemmas about them).
--- The first error should appear below at `monotoneOn_iff_monotone`.
-/-- Given the set `s`, `Elem s` is the `Type` of element of `s`. -/
-@[coe, reducible] def Elem (s : Set α) : Type u := {x // x ∈ s}
-
-/-- Coercion from a set to the corresponding subtype. -/
-instance : CoeSort (Set α) (Type u) := ⟨Elem⟩
 
 /-- The preimage of `s : Set β` by `f : α → β`, written `f ⁻¹' s`,
   is the set of `x : α` such that `f x ∈ s`. -/


### PR DESCRIPTION
Although `Data.Set.Operations` is somewhat light-weight, it still pulls in a few imports. In particular, if we want to move the definition of `Set.Finite` to `Data.Finite.Defs`, then `Algebra.Group.Int` will complain that it's not allowed to import `Set.range` from `Data.Set.Operations`; this split will allow us to do the move without removing an `assert_not_exists`.

See also this discussion on GitHub: https://github.com/leanprover-community/mathlib4/pull/18619#discussion_r1841131715
Zulip thread: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Splitting.20docs.23Set.2EinstCoeSortType.20to.20its.20own.20file.3F


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
