### PR TITLE
[Merged by Bors] - feat(NumberTheory/EulerProduct/DirichletLSeries): add exp-log variants of Euler products

### DIFF
--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -139,8 +139,8 @@ theorem DirichletCharacter.LSeries_eulerProduct {N : ℕ} (χ : DirichletCharact
 open LSeries
 
 /-- A variant of the Euler product for Dirichlet L-series. -/
-theorem DirichletCharacter.LSeries_eulerProduct' {N : ℕ} (χ : DirichletCharacter ℂ N) {s : ℂ}
-    (hs : 1 < s.re) :
+theorem DirichletCharacter.LSeries_eulerProduct_exp_log {N : ℕ} (χ : DirichletCharacter ℂ N)
+    {s : ℂ} (hs : 1 < s.re) :
     exp (∑' p : Nat.Primes, -log (1 - χ p * p ^ (-s))) = L ↗χ s := by
   let f := dirichletSummandHom χ <| ne_zero_of_one_lt_re hs
   have h n : term ↗χ s n = f n := by
@@ -154,15 +154,16 @@ theorem DirichletCharacter.LSeries_eulerProduct' {N : ℕ} (χ : DirichletCharac
 open DirichletCharacter
 
 /-- A variant of the Euler product for the L-series of `ζ`. -/
-theorem ArithmeticFunction.LSeries_zeta_eulerProduct' {s : ℂ} (hs : 1 < s.re) :
+theorem ArithmeticFunction.LSeries_zeta_eulerProduct_exp_log {s : ℂ} (hs : 1 < s.re) :
     exp (∑' p : Nat.Primes, -Complex.log (1 - p ^ (-s))) = L 1 s := by
-  convert modOne_eq_one (R := ℂ) ▸ LSeries_eulerProduct' (1 : DirichletCharacter ℂ 1) hs using 7
+  convert modOne_eq_one (R := ℂ) ▸
+    DirichletCharacter.LSeries_eulerProduct_exp_log (1 : DirichletCharacter ℂ 1) hs using 7
   rw [MulChar.one_apply <| isUnit_of_subsingleton _, one_mul]
 
 /-- A variant of the Euler product for the Riemann zeta function. -/
-theorem riemannZeta_eulerProduct' {s : ℂ} (hs : 1 < s.re) :
+theorem riemannZeta_eulerProduct_exp_log {s : ℂ} (hs : 1 < s.re) :
     exp (∑' p : Nat.Primes, -Complex.log (1 - p ^ (-s))) = riemannZeta s :=
-  LSeries_one_eq_riemannZeta hs ▸ ArithmeticFunction.LSeries_zeta_eulerProduct' hs
+  LSeries_one_eq_riemannZeta hs ▸ ArithmeticFunction.LSeries_zeta_eulerProduct_exp_log hs
 
 /-!
 ### Changing the level of a Dirichlet `L`-series

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -3,10 +3,8 @@ Copyright (c) 2023 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
-import Mathlib.NumberTheory.DirichletCharacter.Bounds
-import Mathlib.NumberTheory.EulerProduct.Basic
-import Mathlib.NumberTheory.LSeries.Basic
-import Mathlib.NumberTheory.LSeries.RiemannZeta
+import Mathlib.NumberTheory.EulerProduct.ExpLog
+import Mathlib.NumberTheory.LSeries.Dirichlet
 
 /-!
 # The Euler Product for the Riemann Zeta Function and Dirichlet L-Series
@@ -107,27 +105,64 @@ open scoped LSeries.notation
 
 /-- The Euler product for Dirichlet L-series, valid for `s.re > 1`.
 This version is stated in terms of `HasProd`. -/
-theorem dirichletLSeries_eulerProduct_hasProd {N : ℕ} (χ : DirichletCharacter ℂ N)
+theorem DirichletCharacter.LSeries_eulerProduct_hasProd {N : ℕ} (χ : DirichletCharacter ℂ N)
     (hs : 1 < s.re) :
     HasProd (fun p : Primes ↦ (1 - χ p * (p : ℂ) ^ (-s))⁻¹) (L ↗χ s) := by
   rw [← tsum_dirichletSummand χ hs]
   convert eulerProduct_completely_multiplicative_hasProd <| summable_dirichletSummand χ hs
 
+@[deprecated (since := "2024-11-14")] alias
+  dirichletLSeries_eulerProduct_hasProd := DirichletCharacter.LSeries_eulerProduct_hasProd
+
 /-- The Euler product for Dirichlet L-series, valid for `s.re > 1`.
 This version is stated in terms of `tprod`. -/
-theorem dirichletLSeries_eulerProduct_tprod {N : ℕ} (χ : DirichletCharacter ℂ N)
+theorem DirichletCharacter.LSeries_eulerProduct_tprod {N : ℕ} (χ : DirichletCharacter ℂ N)
     (hs : 1 < s.re) :
     ∏' p : Primes, (1 - χ p * (p : ℂ) ^ (-s))⁻¹ = L ↗χ s :=
-  (dirichletLSeries_eulerProduct_hasProd χ hs).tprod_eq
+  (DirichletCharacter.LSeries_eulerProduct_hasProd χ hs).tprod_eq
+
+@[deprecated (since := "2024-11-14")] alias
+  dirichlet_LSeries_eulerProduct_tprod := DirichletCharacter.LSeries_eulerProduct_tprod
 
 /-- The Euler product for Dirichlet L-series, valid for `s.re > 1`.
 This version is stated in the form of convergence of finite partial products. -/
-theorem dirichletLSeries_eulerProduct {N : ℕ} (χ : DirichletCharacter ℂ N) (hs : 1 < s.re) :
+theorem DirichletCharacter.LSeries_eulerProduct {N : ℕ} (χ : DirichletCharacter ℂ N)
+    (hs : 1 < s.re) :
     Tendsto (fun n : ℕ ↦ ∏ p ∈ primesBelow n, (1 - χ p * (p : ℂ) ^ (-s))⁻¹) atTop
       (𝓝 (L ↗χ s)) := by
   rw [← tsum_dirichletSummand χ hs]
   apply eulerProduct_completely_multiplicative <| summable_dirichletSummand χ hs
 
+@[deprecated (since := "2024-11-14")] alias
+  dirichletLSeries_eulerProduct := DirichletCharacter.LSeries_eulerProduct
+
+open LSeries
+
+/-- A variant of the Euler product for Dirichlet L-series. -/
+theorem DirichletCharacter.LSeries_eulerProduct' {N : ℕ} (χ : DirichletCharacter ℂ N) {s : ℂ}
+    (hs : 1 < s.re) :
+    exp (∑' p : Nat.Primes, -log (1 - χ p * p ^ (-s))) = L ↗χ s := by
+  let f := dirichletSummandHom χ <| ne_zero_of_one_lt_re hs
+  have h n : term ↗χ s n = f n := by
+    rcases eq_or_ne n 0 with rfl | hn
+    · simp only [term_zero, map_zero]
+    · simp only [ne_eq, hn, not_false_eq_true, term_of_ne_zero, div_eq_mul_inv,
+        dirichletSummandHom, cpow_neg, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, f]
+  simpa only [LSeries, h]
+    using exp_tsum_primes_log_eq_tsum (f := f) <| summable_dirichletSummand χ hs
+
+open DirichletCharacter
+
+/-- A variant of the Euler product for the L-series of `ζ`. -/
+theorem ArithmeticFunction.LSeries_zeta_eulerProduct' {s : ℂ} (hs : 1 < s.re) :
+    exp (∑' p : Nat.Primes, -Complex.log (1 - p ^ (-s))) = L 1 s := by
+  convert modOne_eq_one (R := ℂ) ▸ LSeries_eulerProduct' (1 : DirichletCharacter ℂ 1) hs using 7
+  rw [MulChar.one_apply <| isUnit_of_subsingleton _, one_mul]
+
+/-- A variant of the Euler product for the Riemann zeta function. -/
+theorem riemannZeta_eulerProduct'  {s : ℂ} (hs : 1 < s.re) :
+    exp (∑' p : Nat.Primes, -Complex.log (1 - p ^ (-s))) = riemannZeta s :=
+  LSeries_one_eq_riemannZeta hs ▸ ArithmeticFunction.LSeries_zeta_eulerProduct' hs
 
 /-!
 ### Changing the level of a Dirichlet `L`-series
@@ -140,15 +175,15 @@ lemma DirichletCharacter.LSeries_changeLevel {M N : ℕ} [NeZero N]
     (hMN : M ∣ N) (χ : DirichletCharacter ℂ M) {s : ℂ} (hs : 1 < s.re) :
     LSeries ↗(changeLevel hMN χ) s =
       LSeries ↗χ s * ∏ p ∈ N.primeFactors, (1 - χ p * p ^ (-s)) := by
-  rw [prod_eq_tprod_mulIndicator, ← dirichletLSeries_eulerProduct_tprod _ hs,
-    ← dirichletLSeries_eulerProduct_tprod _ hs]
+  rw [prod_eq_tprod_mulIndicator, ← DirichletCharacter.LSeries_eulerProduct_tprod _ hs,
+    ← DirichletCharacter.LSeries_eulerProduct_tprod _ hs]
   -- convert to a form suitable for `tprod_subtype`
   have (f : Primes → ℂ) : ∏' (p : Primes), f p = ∏' (p : ↑{p : ℕ | p.Prime}), f p := rfl
   rw [this, tprod_subtype _ fun p : ℕ ↦ (1 - (changeLevel hMN χ) p * p ^ (-s))⁻¹,
     this, tprod_subtype _ fun p : ℕ ↦ (1 - χ p * p ^ (-s))⁻¹, ← tprod_mul]
   rotate_left -- deal with convergence goals first
   · exact multipliable_subtype_iff_mulIndicator.mp
-      (dirichletLSeries_eulerProduct_hasProd χ hs).multipliable
+      (DirichletCharacter.LSeries_eulerProduct_hasProd χ hs).multipliable
   · exact multipliable_subtype_iff_mulIndicator.mp Multipliable.of_finite
   · congr 1 with p
     simp only [Set.mulIndicator_apply, Set.mem_setOf_eq, Finset.mem_coe, Nat.mem_primeFactors,

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -160,7 +160,7 @@ theorem ArithmeticFunction.LSeries_zeta_eulerProduct' {s : ℂ} (hs : 1 < s.re) 
   rw [MulChar.one_apply <| isUnit_of_subsingleton _, one_mul]
 
 /-- A variant of the Euler product for the Riemann zeta function. -/
-theorem riemannZeta_eulerProduct'  {s : ℂ} (hs : 1 < s.re) :
+theorem riemannZeta_eulerProduct' {s : ℂ} (hs : 1 < s.re) :
     exp (∑' p : Nat.Primes, -Complex.log (1 - p ^ (-s))) = riemannZeta s :=
   LSeries_one_eq_riemannZeta hs ▸ ArithmeticFunction.LSeries_zeta_eulerProduct' hs
 


### PR DESCRIPTION
This adds "exp-log" versions of the Euler product formula for Dirichlet L-series; it is another step on the way to PNT and Dirichlet's Theorem.

It also renames `dirichletLSeries_<...>` to `DirichletCharacter.LSeries_<...>` for consistency (and to allow dot notation).

See [here](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/Prerequisites.20for.20PNT.20and.20Dirichlet's.20Thm/near/482194943) on Zulip.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
