### PR TITLE
[Merged by Bors] - feat: `uIoo`

### DIFF
--- a/Mathlib/Order/Interval/Set/UnorderedInterval.lean
+++ b/Mathlib/Order/Interval/Set/UnorderedInterval.lean
@@ -337,7 +337,7 @@ variable {x : α}
 
 lemma mem_uIoo_of_lt (ha : a < x) (hb : x < b) : x ∈ uIoo a b := Ioo_subset_uIoo ⟨ha, hb⟩
 
-lemma mem_uIoo_of_ge (hb : b < x) (ha : x < a) : x ∈ uIoo a b := Ioo_subset_uIoo' ⟨hb, ha⟩
+lemma mem_uIoo_of_gt (hb : b < x) (ha : x < a) : x ∈ uIoo a b := Ioo_subset_uIoo' ⟨hb, ha⟩
 
 variable [LinearOrder β] {f : α → β} {s : Set α} {a a₁ a₂ b b₁ b₂ c d x : α}
 

--- a/Mathlib/Order/Interval/Set/UnorderedInterval.lean
+++ b/Mathlib/Order/Interval/Set/UnorderedInterval.lean
@@ -314,11 +314,11 @@ def uIoo (a b : α) : Set α := Ioo (a ⊓ b) (a ⊔ b)
 @[simp] lemma dual_uIoo (a b : α) : uIoo (toDual a) (toDual b) = ofDual ⁻¹' uIoo a b :=
   dual_Ioo (α := α)
 
-@[simp]
-lemma uIoo_of_le (h : a ≤ b) : uIoo a b = Ioo a b := by rw [uIoo, inf_eq_left.2 h, sup_eq_right.2 h]
+@[simp] lemma uIoo_of_le (h : a ≤ b) : uIoo a b = Ioo a b := by
+  rw [uIoo, inf_eq_left.2 h, sup_eq_right.2 h]
 
-@[simp]
-lemma uIoo_of_ge (h : b ≤ a) : uIoo a b = Ioo b a := by rw [uIoo, inf_eq_right.2 h, sup_eq_left.2 h]
+@[simp] lemma uIoo_of_ge (h : b ≤ a) : uIoo a b = Ioo b a := by
+  rw [uIoo, inf_eq_right.2 h, sup_eq_left.2 h]
 
 lemma uIoo_comm (a b : α) : uIoo a b = uIoo b a := by simp_rw [uIoo, inf_comm, sup_comm]
 
@@ -330,7 +330,10 @@ lemma uIoo_self : uIoo a a = ∅ := by simp [uIoo]
 
 lemma Ioo_subset_uIoo : Ioo a b ⊆ uIoo a b := Ioo_subset_Ioo inf_le_left le_sup_right
 
+/-- Same as `Ioo_subset_uIoo` but with `Ioo a b` replaced by `Ioo b a`. -/
 lemma Ioo_subset_uIoo' : Ioo b a ⊆ uIoo a b := Ioo_subset_Ioo inf_le_right le_sup_left
+
+variable {x : α}
 
 lemma mem_uIoo_of_le (ha : a < x) (hb : x < b) : x ∈ uIoo a b := Ioo_subset_uIoo ⟨ha, hb⟩
 
@@ -344,8 +347,8 @@ lemma uIoo_of_not_le (h : ¬a ≤ b) : uIoo a b = Ioo b a := uIoo_of_gt <| lt_of
 
 lemma uIoo_of_not_ge (h : ¬b ≤ a) : uIoo a b = Ioo a b := uIoo_of_lt <| lt_of_not_ge h
 
-theorem uIoo_subset_uIcc {α : Type*} [LinearOrder α] (a : α) (b : α) :
-    uIoo a b ⊆ uIcc a b := by simp [uIoo, uIcc, Ioo_subset_Icc_self]
+theorem uIoo_subset_uIcc {α : Type*} [LinearOrder α] (a : α) (b : α) : uIoo a b ⊆ uIcc a b := by
+  simp [uIoo, uIcc, Ioo_subset_Icc_self]
 
 end uIoo
 

--- a/Mathlib/Order/Interval/Set/UnorderedInterval.lean
+++ b/Mathlib/Order/Interval/Set/UnorderedInterval.lean
@@ -304,6 +304,51 @@ lemma uIoc_injective_right (a : α) : Injective fun b => Ι b a := by
 lemma uIoc_injective_left (a : α) : Injective (Ι a) := by
   simpa only [uIoc_comm] using uIoc_injective_right a
 
+section uIoo
+
+/-- `uIoo a b` is the set of elements lying between `a` and `b`, with `a` and `b` not included.
+Note that we define it more generally in a lattice as `Set.Ioo (a ⊓ b) (a ⊔ b)`. In a product type,
+`uIoo` corresponds to the bounding box of the two elements. -/
+def uIoo (a b : α) : Set α := Ioo (a ⊓ b) (a ⊔ b)
+
+@[simp] lemma dual_uIoo (a b : α) : uIoo (toDual a) (toDual b) = ofDual ⁻¹' uIoo a b :=
+  dual_Ioo (α := α)
+
+@[simp]
+lemma uIoo_of_le (h : a ≤ b) : uIoo a b = Ioo a b := by rw [uIoo, inf_eq_left.2 h, sup_eq_right.2 h]
+
+@[simp]
+lemma uIoo_of_ge (h : b ≤ a) : uIoo a b = Ioo b a := by rw [uIoo, inf_eq_right.2 h, sup_eq_left.2 h]
+
+lemma uIoo_comm (a b : α) : uIoo a b = uIoo b a := by simp_rw [uIoo, inf_comm, sup_comm]
+
+lemma uIoo_of_lt (h : a < b) : uIoo a b = Ioo a b := uIoo_of_le h.le
+
+lemma uIoo_of_gt (h : b < a) : uIoo a b = Ioo b a := uIoo_of_ge h.le
+
+lemma uIoo_self : uIoo a a = ∅ := by simp [uIoo]
+
+lemma Ioo_subset_uIoo : Ioo a b ⊆ uIoo a b := Ioo_subset_Ioo inf_le_left le_sup_right
+
+lemma Ioo_subset_uIoo' : Ioo b a ⊆ uIoo a b := Ioo_subset_Ioo inf_le_right le_sup_left
+
+lemma mem_uIoo_of_le (ha : a < x) (hb : x < b) : x ∈ uIoo a b := Ioo_subset_uIoo ⟨ha, hb⟩
+
+lemma mem_uIoo_of_ge (hb : b < x) (ha : x < a) : x ∈ uIoo a b := Ioo_subset_uIoo' ⟨hb, ha⟩
+
+variable [LinearOrder β] {f : α → β} {s : Set α} {a a₁ a₂ b b₁ b₂ c d x : α}
+
+theorem Ioo_min_max : Ioo (min a b) (max a b) = uIoo a b := rfl
+
+lemma uIoo_of_not_le (h : ¬a ≤ b) : uIoo a b = Ioo b a := uIoo_of_gt <| lt_of_not_ge h
+
+lemma uIoo_of_not_ge (h : ¬b ≤ a) : uIoo a b = Ioo a b := uIoo_of_lt <| lt_of_not_ge h
+
+theorem uIoo_subset_uIcc {α : Type*} [LinearOrder α] (a : α) (b : α) :
+    uIoo a b ⊆ uIcc a b := by simp [uIoo, uIcc, Ioo_subset_Icc_self]
+
+end uIoo
+
 end LinearOrder
 
 end Set

--- a/Mathlib/Order/Interval/Set/UnorderedInterval.lean
+++ b/Mathlib/Order/Interval/Set/UnorderedInterval.lean
@@ -335,7 +335,7 @@ lemma Ioo_subset_uIoo' : Ioo b a ⊆ uIoo a b := Ioo_subset_Ioo inf_le_right le_
 
 variable {x : α}
 
-lemma mem_uIoo_of_le (ha : a < x) (hb : x < b) : x ∈ uIoo a b := Ioo_subset_uIoo ⟨ha, hb⟩
+lemma mem_uIoo_of_lt (ha : a < x) (hb : x < b) : x ∈ uIoo a b := Ioo_subset_uIoo ⟨ha, hb⟩
 
 lemma mem_uIoo_of_ge (hb : b < x) (ha : x < a) : x ∈ uIoo a b := Ioo_subset_uIoo' ⟨hb, ha⟩
 


### PR DESCRIPTION
This PR is the first in a series which breaks #9598 (proving that holomorphic functions on disks have primitives) into smaller pieces. This piece introduces the notation `uIoo` (unordered Interval, open-open) which is the `oo` analog of `uIcc`. Then we prove the analogous API theorems to those available for `uIcc`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
