### PR TITLE
[Merged by Bors] - feat: `Complex.Rectangle`

### DIFF
--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -839,4 +839,63 @@ unsafe instance instRepr : Repr ℂ where
     (if p > 65 then (Std.Format.bracket "(" · ")") else (·)) <|
       reprPrec f.re 65 ++ " + " ++ reprPrec f.im 70 ++ "*I"
 
+section reProdIm
+
+/-- The preimage under `equivRealProd` of `s ×ˢ t` is `s ×ℂ t`. -/
+lemma preimage_equivRealProd_prod (s t : Set ℝ) : equivRealProd ⁻¹' (s ×ˢ t) = s ×ℂ t := rfl
+
+/-- The inequality `s × t ⊆ s₁ × t₁` holds in `ℂ` iff it holds in `ℝ × ℝ`. -/
+lemma reProdIm_subset_iff {s s₁ t t₁ : Set ℝ} : s ×ℂ t ⊆ s₁ ×ℂ t₁ ↔ s ×ˢ t ⊆ s₁ ×ˢ t₁ := by
+  rw [← @preimage_equivRealProd_prod s t, ← @preimage_equivRealProd_prod s₁ t₁]
+  exact Equiv.preimage_subset equivRealProd _ _
+
+/-- If `s ⊆ s₁ ⊆ ℝ` and `t ⊆ t₁ ⊆ ℝ`, then `s × t ⊆ s₁ × t₁` in `ℂ`. -/
+lemma reProdIm_subset_iff' {s s₁ t t₁ : Set ℝ} :
+    s ×ℂ t ⊆ s₁ ×ℂ t₁ ↔ s ⊆ s₁ ∧ t ⊆ t₁ ∨ s = ∅ ∨ t = ∅ := by
+  convert prod_subset_prod_iff
+  exact reProdIm_subset_iff
+
+end reProdIm
+
+open scoped Interval
+
+section Rectangle
+
+/-- A `Rectangle` is an axis-parallel rectangle with corners `z` and `w`. -/
+def Rectangle (z w : ℂ) : Set ℂ := [[z.re, w.re]] ×ℂ [[z.im, w.im]]
+
+end Rectangle
+
+section Segments
+
+/-- A real segment `[a₁, a₂]` translated by `b * I` is the complex line segment. -/
+lemma horizontalSegment_eq (a₁ a₂ b : ℝ) :
+    (fun (x : ℝ) ↦ x + b * I) '' [[a₁, a₂]] = [[a₁, a₂]] ×ℂ {b} := by
+  rw [← preimage_equivRealProd_prod]
+  ext x
+  constructor
+  · intro hx
+    obtain ⟨x₁, hx₁, hx₁'⟩ := hx
+    simp [← hx₁', mem_preimage, mem_prod, hx₁]
+  · intro hx
+    obtain ⟨x₁, hx₁, hx₁', hx₁''⟩ := hx
+    refine ⟨x.re, x₁, by simp⟩
+
+/-- A vertical segment `[b₁, b₂]` translated by `a` is the complex line segment. -/
+lemma verticalSegment_eq (a b₁ b₂ : ℝ) :
+    (fun (y : ℝ) ↦ a + y * I) '' [[b₁, b₂]] = {a} ×ℂ [[b₁, b₂]] := by
+  rw [← preimage_equivRealProd_prod]
+  ext x
+  constructor
+  · intro hx
+    obtain ⟨x₁, hx₁, hx₁'⟩ := hx
+    simp [← hx₁', mem_preimage, mem_prod, hx₁]
+  · intro hx
+    simp only [equivRealProd_apply, singleton_prod, mem_image, Prod.mk.injEq,
+      exists_eq_right_right, mem_preimage] at hx
+    obtain ⟨x₁, hx₁, hx₁', hx₁''⟩ := hx
+    refine ⟨x.im, x₁, by simp⟩
+
+end Segments
+
 end Complex


### PR DESCRIPTION
This is another PR breaking #9598 into smaller pieces. We prove a variety of theorems about `reProdIm`, in particular defining a complex `Rectangle` and horizontal and vertical segments.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
