### PR TITLE
[Merged by Bors] - feat(Order/InitialSeg): initial segments preserve successor limits

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3998,6 +3998,7 @@ import Mathlib.Order.Sublattice
 import Mathlib.Order.SuccPred.Archimedean
 import Mathlib.Order.SuccPred.Basic
 import Mathlib.Order.SuccPred.CompleteLinearOrder
+import Mathlib.Order.SuccPred.InitialSeg
 import Mathlib.Order.SuccPred.IntervalSucc
 import Mathlib.Order.SuccPred.Limit
 import Mathlib.Order.SuccPred.LinearLocallyFinite

--- a/Mathlib/Order/InitialSeg.lean
+++ b/Mathlib/Order/InitialSeg.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Floris van Doorn, Violeta Hernández Palacios
 -/
 import Mathlib.Data.Sum.Order
 import Mathlib.Logic.Equiv.Set
+import Mathlib.Order.Cover
 import Mathlib.Order.RelIso.Set
 import Mathlib.Order.WellFounded
 /-!
@@ -656,15 +657,29 @@ theorem monotone [PartialOrder α] (f : α ≤i β) : Monotone f :=
 theorem strictMono [PartialOrder α] (f : α ≤i β) : StrictMono f :=
   f.toOrderEmbedding.strictMono
 
-theorem map_isMin [PartialOrder α] (f : α ≤i β) (h : IsMin a) : IsMin (f a) := by
-  intro b hb
+@[simp]
+theorem isMin_apply_iff [PartialOrder α] (f : α ≤i β) : IsMin (f a) ↔ IsMin a := by
+  refine ⟨StrictMono.isMin_of_apply f.strictMono, fun h b hb ↦ ?_⟩
   obtain ⟨x, rfl⟩ := f.mem_range_of_le hb
   rw [f.le_iff_le] at hb ⊢
   exact h hb
 
+alias ⟨_, map_isMin⟩ := isMin_apply_iff
+
 @[simp]
 theorem map_bot [PartialOrder α] [OrderBot α] [OrderBot β] (f : α ≤i β) : f ⊥ = ⊥ :=
   (map_isMin f isMin_bot).eq_bot
+
+@[simp]
+theorem apply_covBy_apply_iff [PartialOrder α] (f : α ≤i β) : f a ⋖ f a' ↔ a ⋖ a' := by
+  refine ⟨CovBy.of_image f.toOrderEmbedding, fun h ↦ ⟨(lt_iff_lt f).2 h.lt, fun b ha hb ↦ ?_⟩⟩
+  obtain ⟨c, rfl⟩ := f.mem_range_of_rel hb
+  rw [lt_iff_lt] at ha hb
+  exact h.2 ha hb
+
+@[simp]
+theorem apply_wCovBy_apply_iff [PartialOrder α] (f : α ≤i β) : f a ⩿ f a' ↔ a ⩿ a' := by
+  simp [wcovBy_iff_eq_or_covBy]
 
 theorem le_apply_iff [LinearOrder α] (f : α ≤i β) : b ≤ f a ↔ ∃ c ≤ a, f c = b := by
   constructor
@@ -712,12 +727,23 @@ theorem monotone [PartialOrder α] (f : α <i β) : Monotone f :=
 theorem strictMono [PartialOrder α] (f : α <i β) : StrictMono f :=
   (f : α ≤i β).strictMono
 
-theorem map_isMin [PartialOrder α] (f : α <i β) (h : IsMin a) : IsMin (f a) :=
-  (f : α ≤i β).map_isMin h
+@[simp]
+theorem isMin_apply_iff [PartialOrder α] (f : α <i β) : IsMin (f a) ↔ IsMin a :=
+  (f : α ≤i β).isMin_apply_iff
+
+alias ⟨_, map_isMin⟩ := isMin_apply_iff
 
 @[simp]
 theorem map_bot [PartialOrder α] [OrderBot α] [OrderBot β] (f : α <i β) : f ⊥ = ⊥ :=
   (f : α ≤i β).map_bot
+
+@[simp]
+theorem apply_covBy_apply_iff [PartialOrder α] (f : α <i β) : f a ⋖ f a' ↔ a ⋖ a' :=
+  (f : α ≤i β).apply_covBy_apply_iff
+
+@[simp]
+theorem apply_wCovBy_apply_iff [PartialOrder α] (f : α <i β) : f a ⩿ f a' ↔ a ⩿ a' :=
+  (f : α ≤i β).apply_wCovBy_apply_iff
 
 theorem le_apply_iff [LinearOrder α] (f : α <i β) : b ≤ f a ↔ ∃ c ≤ a, f c = b :=
   (f : α ≤i β).le_apply_iff

--- a/Mathlib/Order/InitialSeg.lean
+++ b/Mathlib/Order/InitialSeg.lean
@@ -7,7 +7,9 @@ import Mathlib.Data.Sum.Order
 import Mathlib.Logic.Equiv.Set
 import Mathlib.Order.Cover
 import Mathlib.Order.RelIso.Set
+import Mathlib.Order.UpperLower.Basic
 import Mathlib.Order.WellFounded
+
 /-!
 # Initial and principal segments
 
@@ -671,11 +673,8 @@ theorem map_bot [PartialOrder α] [OrderBot α] [OrderBot β] (f : α ≤i β) :
   (map_isMin f isMin_bot).eq_bot
 
 @[simp]
-theorem apply_covBy_apply_iff [PartialOrder α] (f : α ≤i β) : f a ⋖ f a' ↔ a ⋖ a' := by
-  refine ⟨CovBy.of_image f.toOrderEmbedding, fun h ↦ ⟨(lt_iff_lt f).2 h.lt, fun b ha hb ↦ ?_⟩⟩
-  obtain ⟨c, rfl⟩ := f.mem_range_of_rel hb
-  rw [lt_iff_lt] at ha hb
-  exact h.2 ha hb
+theorem apply_covBy_apply_iff [PartialOrder α] (f : α ≤i β) : f a ⋖ f a' ↔ a ⋖ a' :=
+  Set.OrdConnected.apply_covBy_apply_iff f.toOrderEmbedding (isLowerSet_range f).ordConnected
 
 @[simp]
 theorem apply_wCovBy_apply_iff [PartialOrder α] (f : α ≤i β) : f a ⩿ f a' ↔ a ⩿ a' := by

--- a/Mathlib/Order/InitialSeg.lean
+++ b/Mathlib/Order/InitialSeg.lean
@@ -5,9 +5,7 @@ Authors: Mario Carneiro, Floris van Doorn, Violeta Hernández Palacios
 -/
 import Mathlib.Data.Sum.Order
 import Mathlib.Logic.Equiv.Set
-import Mathlib.Order.Cover
 import Mathlib.Order.RelIso.Set
-import Mathlib.Order.UpperLower.Basic
 import Mathlib.Order.WellFounded
 
 /-!
@@ -672,14 +670,6 @@ alias ⟨_, map_isMin⟩ := isMin_apply_iff
 theorem map_bot [PartialOrder α] [OrderBot α] [OrderBot β] (f : α ≤i β) : f ⊥ = ⊥ :=
   (map_isMin f isMin_bot).eq_bot
 
-@[simp]
-theorem apply_covBy_apply_iff [PartialOrder α] (f : α ≤i β) : f a ⋖ f a' ↔ a ⋖ a' :=
-  Set.OrdConnected.apply_covBy_apply_iff f.toOrderEmbedding (isLowerSet_range f).ordConnected
-
-@[simp]
-theorem apply_wCovBy_apply_iff [PartialOrder α] (f : α ≤i β) : f a ⩿ f a' ↔ a ⩿ a' := by
-  simp [wcovBy_iff_eq_or_covBy]
-
 theorem le_apply_iff [LinearOrder α] (f : α ≤i β) : b ≤ f a ↔ ∃ c ≤ a, f c = b := by
   constructor
   · intro h
@@ -735,14 +725,6 @@ alias ⟨_, map_isMin⟩ := isMin_apply_iff
 @[simp]
 theorem map_bot [PartialOrder α] [OrderBot α] [OrderBot β] (f : α <i β) : f ⊥ = ⊥ :=
   (f : α ≤i β).map_bot
-
-@[simp]
-theorem apply_covBy_apply_iff [PartialOrder α] (f : α <i β) : f a ⋖ f a' ↔ a ⋖ a' :=
-  (f : α ≤i β).apply_covBy_apply_iff
-
-@[simp]
-theorem apply_wCovBy_apply_iff [PartialOrder α] (f : α <i β) : f a ⩿ f a' ↔ a ⩿ a' :=
-  (f : α ≤i β).apply_wCovBy_apply_iff
 
 theorem le_apply_iff [LinearOrder α] (f : α <i β) : b ≤ f a ↔ ∃ c ≤ a, f c = b :=
   (f : α ≤i β).le_apply_iff

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
-import Mathlib.Order.Cover
+import Mathlib.Order.InitialSeg
 import Mathlib.Order.Iterate
 
 /-!
@@ -339,7 +339,7 @@ lemma succ_eq_of_covBy (h : a ⋖ b) : succ a = b := (succ_le_of_lt h.lt).antisy
 
 alias _root_.CovBy.succ_eq := succ_eq_of_covBy
 
-theorem _root_.OrderIso.map_succ {β : Type*} [PartialOrder β] [SuccOrder β] (f : α ≃o β) (a : α) :
+theorem _root_.OrderIso.map_succ [PartialOrder β] [SuccOrder β] (f : α ≃o β) (a : α) :
     f (succ a) = succ (f a) := by
   by_cases h : IsMax a
   · rw [h.succ_eq, (f.isMax_apply.2 h).succ_eq]
@@ -351,6 +351,14 @@ variable [NoMaxOrder α]
 
 theorem succ_eq_iff_covBy : succ a = b ↔ a ⋖ b :=
   ⟨by rintro rfl; exact covBy_succ _, CovBy.succ_eq⟩
+
+theorem _root_.InitialSeg.map_succ [PartialOrder β] [SuccOrder β] (f : α ≤i β) (a : α) :
+    f (succ a) = succ (f a) :=
+  (f.apply_covBy_apply_iff.2 (covBy_succ a)).succ_eq.symm
+
+theorem _root_.PrincipalSeg.map_succ [PartialOrder β] [SuccOrder β] (f : α <i β) (a : α) :
+    f (succ a) = succ (f a) :=
+  (f : α ≤i β).map_succ a
 
 end NoMaxOrder
 

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
-import Mathlib.Order.InitialSeg
+import Mathlib.Order.Cover
 import Mathlib.Order.Iterate
 
 /-!
@@ -351,14 +351,6 @@ variable [NoMaxOrder α]
 
 theorem succ_eq_iff_covBy : succ a = b ↔ a ⋖ b :=
   ⟨by rintro rfl; exact covBy_succ _, CovBy.succ_eq⟩
-
-theorem _root_.InitialSeg.map_succ [PartialOrder β] [SuccOrder β] (f : α ≤i β) (a : α) :
-    f (succ a) = succ (f a) :=
-  (f.apply_covBy_apply_iff.2 (covBy_succ a)).succ_eq.symm
-
-theorem _root_.PrincipalSeg.map_succ [PartialOrder β] [SuccOrder β] (f : α <i β) (a : α) :
-    f (succ a) = succ (f a) :=
-  (f : α ≤i β).map_succ a
 
 end NoMaxOrder
 

--- a/Mathlib/Order/SuccPred/InitialSeg.lean
+++ b/Mathlib/Order/SuccPred/InitialSeg.lean
@@ -21,7 +21,7 @@ namespace InitialSeg
 
 @[simp]
 theorem apply_covBy_apply_iff (f : α ≤i β) : f a ⋖ f b ↔ a ⋖ b :=
-  Set.OrdConnected.apply_covBy_apply_iff f.toOrderEmbedding (isLowerSet_range f).ordConnected
+  (isLowerSet_range f).ordConnected.apply_covBy_apply_iff f.toOrderEmbedding
 
 @[simp]
 theorem apply_wCovBy_apply_iff (f : α ≤i β) : f a ⩿ f b ↔ a ⩿ b := by

--- a/Mathlib/Order/SuccPred/InitialSeg.lean
+++ b/Mathlib/Order/SuccPred/InitialSeg.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2024 Violeta Hernández Palacios. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Violeta Hernández Palacios
+-/
+import Mathlib.Order.InitialSeg
+import Mathlib.Order.SuccPred.Limit
+import Mathlib.Order.UpperLower.Basic
+
+/-!
+# Initial segments and successors
+
+We establish some connections between initial segment embeddings and successors and predecessors.
+-/
+
+variable {α β : Type*} {a b : α} [PartialOrder α] [PartialOrder β]
+
+open Order
+
+namespace InitialSeg
+
+@[simp]
+theorem apply_covBy_apply_iff (f : α ≤i β) : f a ⋖ f b ↔ a ⋖ b :=
+  Set.OrdConnected.apply_covBy_apply_iff f.toOrderEmbedding (isLowerSet_range f).ordConnected
+
+@[simp]
+theorem apply_wCovBy_apply_iff (f : α ≤i β) : f a ⩿ f b ↔ a ⩿ b := by
+  simp [wcovBy_iff_eq_or_covBy]
+
+theorem map_succ [SuccOrder α] [NoMaxOrder α] [SuccOrder β] (f : α ≤i β) (a : α) :
+    f (succ a) = succ (f a) :=
+  (f.apply_covBy_apply_iff.2 (covBy_succ a)).succ_eq.symm
+
+theorem map_pred [PredOrder α] [NoMinOrder α] [PredOrder β] (f : α ≤i β) (a : α) :
+    f (pred a) = pred (f a) :=
+  (f.apply_covBy_apply_iff.2 (pred_covBy a)).pred_eq.symm
+
+@[simp]
+theorem isSuccPrelimit_apply_iff (f : α ≤i β) : IsSuccPrelimit (f a) ↔ IsSuccPrelimit a := by
+  constructor <;> intro h b hb
+  · rw [← f.apply_covBy_apply_iff] at hb
+    exact h _ hb
+  · obtain ⟨c, rfl⟩ := f.mem_range_of_rel hb.lt
+    rw [f.apply_covBy_apply_iff] at hb
+    exact h _ hb
+
+@[simp]
+theorem isSuccLimit_apply_iff (f : α ≤i β) : IsSuccLimit (f a) ↔ IsSuccLimit a := by
+  simp [IsSuccLimit]
+
+end InitialSeg
+
+namespace PrincipalSeg
+
+@[simp]
+theorem apply_covBy_apply_iff (f : α <i β) : f a ⋖ f b ↔ a ⋖ b :=
+  (f : α ≤i β).apply_covBy_apply_iff
+
+@[simp]
+theorem apply_wCovBy_apply_iff (f : α <i β) : f a ⩿ f b ↔ a ⩿ b :=
+  (f : α ≤i β).apply_wCovBy_apply_iff
+
+theorem map_succ [SuccOrder α] [NoMaxOrder α] [SuccOrder β] (f : α <i β) (a : α) :
+    f (succ a) = succ (f a) :=
+  (f : α ≤i β).map_succ a
+
+theorem map_pred [PredOrder α] [NoMinOrder α] [PredOrder β] (f : α ≤i β) (a : α) :
+    f (pred a) = pred (f a) :=
+  (f : α ≤i β).map_pred a
+
+@[simp]
+theorem isSuccPrelimit_apply_iff (f : α <i β) : IsSuccPrelimit (f a) ↔ IsSuccPrelimit a :=
+  (f : α ≤i β).isSuccPrelimit_apply_iff
+
+@[simp]
+theorem isSuccLimit_apply_iff (f : α <i β) : IsSuccLimit (f a) ↔ IsSuccLimit a :=
+  (f : α ≤i β).isSuccLimit_apply_iff
+
+end PrincipalSeg

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -3,8 +3,9 @@ Copyright (c) 2022 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
-import Mathlib.Order.SuccPred.Archimedean
 import Mathlib.Order.BoundedOrder
+import Mathlib.Order.InitialSeg
+import Mathlib.Order.SuccPred.Archimedean
 
 /-!
 # Successor and predecessor limits
@@ -24,7 +25,7 @@ predicate `Order.IsSuccLimit`.
 -/
 
 
-variable {α : Type*} {a b : α}
+variable {α β : Type*} {a b : α}
 
 namespace Order
 
@@ -192,6 +193,31 @@ variable [PartialOrder α]
 
 theorem isSuccLimit_iff [OrderBot α] : IsSuccLimit a ↔ a ≠ ⊥ ∧ IsSuccPrelimit a := by
   rw [IsSuccLimit, isMin_iff_eq_bot]
+
+@[simp]
+theorem _root_.InitialSeg.isSuccPrelimit_apply_iff [PartialOrder β] (f : α ≤i β) :
+    IsSuccPrelimit (f a) ↔ IsSuccPrelimit a := by
+  constructor <;> intro h b hb
+  · rw [← f.apply_covBy_apply_iff] at hb
+    exact h _ hb
+  · obtain ⟨c, rfl⟩ := f.mem_range_of_rel hb.lt
+    rw [f.apply_covBy_apply_iff] at hb
+    exact h _ hb
+
+@[simp]
+theorem _root_.InitialSeg.isSuccLimit_apply_iff [PartialOrder β] (f : α ≤i β) :
+    IsSuccLimit (f a) ↔ IsSuccLimit a := by
+  simp [IsSuccLimit]
+
+@[simp]
+theorem _root_.PrincipalSeg.isSuccPrelimit_apply_iff [PartialOrder β] (f : α <i β) :
+    IsSuccPrelimit (f a) ↔ IsSuccPrelimit a :=
+  (f : α ≤i β).isSuccPrelimit_apply_iff
+
+@[simp]
+theorem _root_.PrincipalSeg.isSuccLimit_apply_iff [PartialOrder β] (f : α <i β) :
+    IsSuccLimit (f a) ↔ IsSuccLimit a :=
+  (f : α ≤i β).isSuccLimit_apply_iff
 
 variable [SuccOrder α]
 

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
 import Mathlib.Order.BoundedOrder
-import Mathlib.Order.InitialSeg
 import Mathlib.Order.SuccPred.Archimedean
 
 /-!

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
-import Mathlib.Order.BoundedOrder
 import Mathlib.Order.SuccPred.Archimedean
+import Mathlib.Order.BoundedOrder
 
 /-!
 # Successor and predecessor limits

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -24,7 +24,7 @@ predicate `Order.IsSuccLimit`.
 -/
 
 
-variable {α β : Type*} {a b : α}
+variable {α : Type*} {a b : α}
 
 namespace Order
 
@@ -192,31 +192,6 @@ variable [PartialOrder α]
 
 theorem isSuccLimit_iff [OrderBot α] : IsSuccLimit a ↔ a ≠ ⊥ ∧ IsSuccPrelimit a := by
   rw [IsSuccLimit, isMin_iff_eq_bot]
-
-@[simp]
-theorem _root_.InitialSeg.isSuccPrelimit_apply_iff [PartialOrder β] (f : α ≤i β) :
-    IsSuccPrelimit (f a) ↔ IsSuccPrelimit a := by
-  constructor <;> intro h b hb
-  · rw [← f.apply_covBy_apply_iff] at hb
-    exact h _ hb
-  · obtain ⟨c, rfl⟩ := f.mem_range_of_rel hb.lt
-    rw [f.apply_covBy_apply_iff] at hb
-    exact h _ hb
-
-@[simp]
-theorem _root_.InitialSeg.isSuccLimit_apply_iff [PartialOrder β] (f : α ≤i β) :
-    IsSuccLimit (f a) ↔ IsSuccLimit a := by
-  simp [IsSuccLimit]
-
-@[simp]
-theorem _root_.PrincipalSeg.isSuccPrelimit_apply_iff [PartialOrder β] (f : α <i β) :
-    IsSuccPrelimit (f a) ↔ IsSuccPrelimit a :=
-  (f : α ≤i β).isSuccPrelimit_apply_iff
-
-@[simp]
-theorem _root_.PrincipalSeg.isSuccLimit_apply_iff [PartialOrder β] (f : α <i β) :
-    IsSuccLimit (f a) ↔ IsSuccLimit a :=
-  (f : α ≤i β).isSuccLimit_apply_iff
 
 variable [SuccOrder α]
 


### PR DESCRIPTION
Initial segments preserve the covering relation, successors, and successor limits.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
