### PR TITLE
[Merged by Bors] - feat: add spoiler with comment to maintainer merge

### DIFF
--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -39,9 +39,7 @@ jobs:
 
           # for debugging, we print some information
           printf '%s' "${COMMENT}" | hexdump -cC
-
-          # add the cleaned up comment to the environment for including it in the Zulip post
-          printf 'comment<<EOC\n%s\nEOC' "${COMMENT}" | tee "$GITHUB_OUTPUT"
+          printf 'comment<<EOC\n%s\nEOC' "${COMMENT}"
 
           m_or_d="$(printf '%s' "${COMMENT}" |
             sed -n 's=^maintainer  *\(merge\|delegate\)$=\1=p' | head -1)"
@@ -82,7 +80,7 @@ jobs:
 
           echo ""
           message="$(
-            ./scripts/maintainer_merge_message.sh "${AUTHOR}" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE_ISSUE}${PR_TITLE_PR}" "${{ steps.merge_or_delegate.outputs.comment }}"
+            ./scripts/maintainer_merge_message.sh "${AUTHOR}" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE_ISSUE}${PR_TITLE_PR}" "${COMMENT_EVENT}${COMMENT_REVIEW}"
           )"
           printf 'title<<EOF\n%s\nEOF' "${message}" | tee "$GITHUB_OUTPUT"
 

--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -39,7 +39,7 @@ jobs:
 
           # for debugging, we print some information
           printf '%s' "${COMMENT}" | hexdump -cC
-          printf 'comment<<EOC\n%s\nEOC' "${COMMENT}"
+          printf 'Comment:"%s"\n' "${COMMENT}"
 
           m_or_d="$(printf '%s' "${COMMENT}" |
             sed -n 's=^maintainer  *\(merge\|delegate\)$=\1=p' | head -1)"

--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -33,11 +33,16 @@ jobs:
         id: merge_or_delegate
         run: |
           COMMENT="${COMMENT_EVENT}${COMMENT_REVIEW}"
+
           # we strip `\r` since line endings from GitHub contain this character
           COMMENT="${COMMENT//$'\r'/}"
+
           # for debugging, we print some information
           printf '%s' "${COMMENT}" | hexdump -cC
-          printf 'Comment:"%s"\n' "${COMMENT}"
+
+          # add the cleaned up comment to the environment for including it in the Zulip post
+          printf 'comment<<EOC\n%s\nEOC' "${COMMENT}" | tee "$GITHUB_OUTPUT"
+
           m_or_d="$(printf '%s' "${COMMENT}" |
             sed -n 's=^maintainer  *\(merge\|delegate\)$=\1=p' | head -1)"
 
@@ -77,7 +82,7 @@ jobs:
 
           echo ""
           message="$(
-            ./scripts/maintainer_merge_message.sh "${AUTHOR}" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE_ISSUE}${PR_TITLE_PR}"
+            ./scripts/maintainer_merge_message.sh "${AUTHOR}" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE_ISSUE}${PR_TITLE_PR}" "${{ steps.merge_or_delegate.outputs.comment }}"
           )"
           printf 'title<<EOF\n%s\nEOF' "${message}" | tee "$GITHUB_OUTPUT"
 

--- a/scripts/maintainer_merge_message.sh
+++ b/scripts/maintainer_merge_message.sh
@@ -7,6 +7,7 @@ EVENT_NAME="${3:-EVENT_NAME not set}" # one of `issue_comment`, `pull_request_re
 PR="${4:-PR not set}"                 # the number of the PR
 URL="${5:-URL not set}"               # the url link to the PR
 PR_TITLE="${6:-PR_TITLE not set}"     # the title of the PR
+PR_COMMENT="${7:-PR_COMMENT not set}" # the comment that triggered the `maintainer merge` action
 
 # figure out if the GitHub event starting this action is a comment, a review or a review comment
 # and set the `SOURCE` variable accordingly
@@ -33,6 +34,7 @@ esac
 >&2 echo "PR_URL:     '${PR_URL}'"
 >&2 echo "title:      '${PR_TITLE}'"
 >&2 echo "EVENT_NAME: '${EVENT_NAME}'"
+>&2 printf 'COMMENT\n%s\nEND COMMENT\n' "${PR_COMMENT}"
 
 printf '%s requested a maintainer **%s** from %s on PR [#%s](%s):\n' "${AUTHOR}" "${M_or_D}" "${SOURCE}" "${PR}" "${URL}"
-printf '> %s\n' "${PR_TITLE}"
+printf '```spoiler %s\n%s\n```\n' "${PR_TITLE}" "${PR_COMMENT}"


### PR DESCRIPTION
For this PR, it would produce a message like

adomani requested a maintainer **delegate** from comment on PR [#19069](url):
<details><summary>feat: add spoiler with comment to maintainer merge</summary>
This is a great addition, thanks!

maintainer delegate

Maintainers, please check that it passes CI!

</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
