### PR TITLE
refactor(GroupTheory/SpecificGroups/Cyclic): Switch from `Fintype` to `Finite`

### DIFF
--- a/Mathlib/Data/Fintype/Units.lean
+++ b/Mathlib/Data/Fintype/Units.lean
@@ -29,18 +29,24 @@ instance [Monoid α] [Fintype α] [DecidableEq α] : Fintype αˣ :=
 
 instance [Monoid α] [Finite α] : Finite αˣ := Finite.of_injective _ Units.ext
 
-theorem Fintype.card_eq_card_units_add_one [GroupWithZero α] [Fintype α] [DecidableEq α] :
-    Fintype.card α = Fintype.card αˣ + 1 := by
-  rw [eq_comm, Fintype.card_congr unitsEquivNeZero]
-  have := Fintype.card_congr (Equiv.sumCompl (· = (0 : α)))
-  rwa [Fintype.card_sum, add_comm, Fintype.card_subtype_eq] at this
+variable (α)
+
+theorem Nat.card_units [GroupWithZero α] :
+    Nat.card αˣ = Nat.card α - 1 := by
+  classical
+  rw [Nat.card_congr unitsEquivNeZero, eq_comm, ← Nat.card_congr (Equiv.sumCompl (· = (0 : α)))]
+  rcases finite_or_infinite {a : α // a ≠ 0}
+  · rw [Nat.card_sum, Nat.card_unique, add_tsub_cancel_left]
+  · rw [Nat.card_eq_zero_of_infinite, Nat.card_eq_zero_of_infinite, zero_tsub]
 
 theorem Nat.card_eq_card_units_add_one [GroupWithZero α] [Finite α] :
     Nat.card α = Nat.card αˣ + 1 := by
-  have : Fintype α := Fintype.ofFinite α
-  classical
-    rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, Fintype.card_eq_card_units_add_one]
+  rw [Nat.card_units, tsub_add_cancel_of_le Nat.card_pos]
 
 theorem Fintype.card_units [GroupWithZero α] [Fintype α] [DecidableEq α] :
     Fintype.card αˣ = Fintype.card α - 1 := by
-  rw [@Fintype.card_eq_card_units_add_one α, Nat.add_sub_cancel]
+  rw [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card, Nat.card_units]
+
+theorem Fintype.card_eq_card_units_add_one [GroupWithZero α] [Fintype α] [DecidableEq α] :
+    Fintype.card α = Fintype.card αˣ + 1 := by
+  rw [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card, Nat.card_eq_card_units_add_one]

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -172,6 +172,7 @@ theorem sum_subgroup_units [Ring K] [NoZeroDivisors K]
 theorem sum_subgroup_pow_eq_zero [CommRing K] [NoZeroDivisors K]
     {G : Subgroup Kˣ} [Fintype G] {k : ℕ} (k_pos : k ≠ 0) (k_lt_card_G : k < Fintype.card G) :
     ∑ x : G, ((x : Kˣ) : K) ^ k = 0 := by
+  rw [← Nat.card_eq_fintype_card] at k_lt_card_G
   nontriviality K
   have := NoZeroDivisors.to_isDomain K
   rcases (exists_pow_ne_one_of_isCyclic k_pos k_lt_card_G) with ⟨a, ha⟩
@@ -255,8 +256,7 @@ theorem cast_card_eq_zero : (q : K) = 0 := by
 theorem forall_pow_eq_one_iff (i : ℕ) : (∀ x : Kˣ, x ^ i = 1) ↔ q - 1 ∣ i := by
   classical
     obtain ⟨x, hx⟩ := IsCyclic.exists_generator (α := Kˣ)
-    rw [← Fintype.card_units, ← orderOf_eq_card_of_forall_mem_zpowers hx,
-      orderOf_dvd_iff_pow_eq_one]
+    rw [← Nat.card_units, ← orderOf_eq_card_of_forall_mem_zpowers hx, orderOf_dvd_iff_pow_eq_one]
     constructor
     · intro h; apply h
     · intro h y
@@ -588,7 +588,7 @@ theorem unit_isSquare_iff (hF : ringChar F ≠ 2) (a : Fˣ) :
     · subst a; intro h
       have key : 2 * (Fintype.card F / 2) ∣ n * (Fintype.card F / 2) := by
         rw [← pow_mul] at h
-        rw [hodd, ← Fintype.card_units, ← orderOf_eq_card_of_forall_mem_zpowers hg]
+        rw [hodd, ← Nat.card_units, ← orderOf_eq_card_of_forall_mem_zpowers hg]
         apply orderOf_dvd_of_pow_eq_one h
       have : 0 < Fintype.card F / 2 := Nat.div_pos Fintype.one_lt_card (by norm_num)
       obtain ⟨m, rfl⟩ := Nat.dvd_of_mul_dvd_mul_right this key

--- a/Mathlib/GroupTheory/Exponent.lean
+++ b/Mathlib/GroupTheory/Exponent.lean
@@ -501,9 +501,11 @@ variable [Group G]
 lemma Group.one_lt_exponent [Finite G] [Nontrivial G] : 1 < Monoid.exponent G :=
   Monoid.one_lt_exponent
 
+@[to_additive]
 theorem Group.exponent_dvd_card [Fintype G] : Monoid.exponent G ∣ Fintype.card G :=
   Monoid.exponent_dvd.mpr <| fun _ => orderOf_dvd_card
 
+@[to_additive]
 theorem Group.exponent_dvd_nat_card : Monoid.exponent G ∣ Nat.card G :=
   Monoid.exponent_dvd.mpr orderOf_dvd_natCard
 

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -91,9 +91,9 @@ theorem Nontrivial.of_not_isCyclic (nc : ¬IsCyclic α) : Nontrivial α := by
   exact @isCyclic_of_subsingleton _ _ (not_nontrivial_iff_subsingleton.mp nc)
 
 @[to_additive]
-theorem MonoidHom.map_cyclic {G : Type*} [Group G] [h : IsCyclic G] (σ : G →* G) :
-    ∃ m : ℤ, ∀ g : G, σ g = g ^ m := by
-  obtain ⟨h, hG⟩ := IsCyclic.exists_generator (α := G)
+theorem MonoidHom.map_cyclic [h : IsCyclic α] (σ : α →* α) :
+    ∃ m : ℤ, ∀ g, σ g = g ^ m := by
+  obtain ⟨h, hG⟩ := IsCyclic.exists_generator (α := α)
   obtain ⟨m, hm⟩ := hG (σ h)
   refine ⟨m, fun g => ?_⟩
   obtain ⟨n, rfl⟩ := hG g
@@ -199,7 +199,7 @@ theorem Infinite.orderOf_eq_zero_of_forall_mem_zpowers [Infinite α] {g : α}
   rw [orderOf_eq_card_of_forall_mem_zpowers h, Nat.card_eq_zero_of_infinite]
 
 @[to_additive]
-instance Bot.isCyclic {α : Type u} [Group α] : IsCyclic (⊥ : Subgroup α) :=
+instance Bot.isCyclic : IsCyclic (⊥ : Subgroup α) :=
   ⟨⟨1, fun x => ⟨0, Subtype.eq <| (zpow_zero (1 : α)).trans <| Eq.symm (Subgroup.mem_bot.1 x.2)⟩⟩⟩
 
 @[to_additive]

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -45,8 +45,6 @@ variable {α : Type u} {a : α}
 
 section Cyclic
 
-attribute [local instance] setFintype
-
 open Subgroup
 
 @[to_additive]
@@ -104,65 +102,65 @@ theorem MonoidHom.map_cyclic {G : Type*} [Group G] [h : IsCyclic G] (σ : G →*
 MonoidAddHom.map_add_cyclic := AddMonoidHom.map_addCyclic
 
 @[to_additive]
-theorem isCyclic_of_orderOf_eq_card [Fintype α] (x : α) (hx : orderOf x = Fintype.card α) :
+theorem isCyclic_of_orderOf_eq_card [Finite α] (x : α) (hx : orderOf x = Nat.card α) :
     IsCyclic α := by
+  cases nonempty_fintype α
   use x
   rw [← Set.range_eq_univ, ← coe_zpowers]
-  rw [← Fintype.card_congr (Equiv.Set.univ α), ← Fintype.card_zpowers] at hx
+  rw [← Nat.card_congr (Equiv.Set.univ α), Nat.card_eq_fintype_card, ← Fintype.card_zpowers] at hx
   convert Set.eq_of_subset_of_card_le (Set.subset_univ _) (ge_of_eq hx)
 @[deprecated (since := "2024-02-21")]
 alias isAddCyclic_of_orderOf_eq_card := isAddCyclic_of_addOrderOf_eq_card
 
 @[to_additive]
-theorem Subgroup.eq_bot_or_eq_top_of_prime_card {G : Type*} [Group G] {_ : Fintype G}
-    (H : Subgroup G) [hp : Fact (Fintype.card G).Prime] : H = ⊥ ∨ H = ⊤ := by
-  classical
+theorem Subgroup.eq_bot_or_eq_top_of_prime_card
+    (H : Subgroup α) [hp : Fact (Nat.card α).Prime] : H = ⊥ ∨ H = ⊤ := by
+  have : Finite α := Nat.finite_of_card_ne_zero hp.1.ne_zero
   have := card_subgroup_dvd_card H
-  rwa [Nat.card_eq_fintype_card (α := G), Nat.dvd_prime hp.1, ← Nat.card_eq_fintype_card,
-    ← eq_bot_iff_card, card_eq_iff_eq_top] at this
+  rwa [Nat.dvd_prime hp.1, ← eq_bot_iff_card, card_eq_iff_eq_top] at this
 
 /-- Any non-identity element of a finite group of prime order generates the group. -/
 @[to_additive "Any non-identity element of a finite group of prime order generates the group."]
-theorem zpowers_eq_top_of_prime_card {G : Type*} [Group G] {_ : Fintype G} {p : ℕ}
-    [hp : Fact p.Prime] (h : Fintype.card G = p) {g : G} (hg : g ≠ 1) : zpowers g = ⊤ := by
+theorem zpowers_eq_top_of_prime_card {p : ℕ}
+    [hp : Fact p.Prime] (h : Nat.card α = p) {g : α} (hg : g ≠ 1) : zpowers g = ⊤ := by
   subst h
   have := (zpowers g).eq_bot_or_eq_top_of_prime_card
   rwa [zpowers_eq_bot, or_iff_right hg] at this
 
 @[to_additive]
-theorem mem_zpowers_of_prime_card {G : Type*} [Group G] {_ : Fintype G} {p : ℕ} [hp : Fact p.Prime]
-    (h : Fintype.card G = p) {g g' : G} (hg : g ≠ 1) : g' ∈ zpowers g := by
+theorem mem_zpowers_of_prime_card {p : ℕ} [hp : Fact p.Prime]
+    (h : Nat.card α = p) {g g' : α} (hg : g ≠ 1) : g' ∈ zpowers g := by
   simp_rw [zpowers_eq_top_of_prime_card h hg, Subgroup.mem_top]
 
 @[to_additive]
-theorem mem_powers_of_prime_card {G : Type*} [Group G] {_ : Fintype G} {p : ℕ} [hp : Fact p.Prime]
-    (h : Fintype.card G = p) {g g' : G} (hg : g ≠ 1) : g' ∈ Submonoid.powers g := by
+theorem mem_powers_of_prime_card {p : ℕ} [hp : Fact p.Prime]
+    (h : Nat.card α = p) {g g' : α} (hg : g ≠ 1) : g' ∈ Submonoid.powers g := by
+  have : Finite α := Nat.finite_of_card_ne_zero (h ▸ hp.1.ne_zero)
   rw [mem_powers_iff_mem_zpowers]
   exact mem_zpowers_of_prime_card h hg
 
 @[to_additive]
-theorem powers_eq_top_of_prime_card {G : Type*} [Group G] {_ : Fintype G} {p : ℕ}
-    [hp : Fact p.Prime] (h : Fintype.card G = p) {g : G} (hg : g ≠ 1) : Submonoid.powers g = ⊤ := by
+theorem powers_eq_top_of_prime_card {p : ℕ}
+    [hp : Fact p.Prime] (h : Nat.card α = p) {g : α} (hg : g ≠ 1) : Submonoid.powers g = ⊤ := by
   ext x
   simp [mem_powers_of_prime_card h hg]
 
 /-- A finite group of prime order is cyclic. -/
 @[to_additive "A finite group of prime order is cyclic."]
-theorem isCyclic_of_prime_card {α : Type u} [Group α] [Fintype α] {p : ℕ} [hp : Fact p.Prime]
-    (h : Fintype.card α = p) : IsCyclic α := by
-  obtain ⟨g, hg⟩ : ∃ g, g ≠ 1 := Fintype.exists_ne_of_one_lt_card (h.symm ▸ hp.1.one_lt) 1
+theorem isCyclic_of_prime_card {p : ℕ} [hp : Fact p.Prime]
+    (h : Nat.card α = p) : IsCyclic α := by
+  have : Finite α := Nat.finite_of_card_ne_zero (h ▸ hp.1.ne_zero)
+  have : Nontrivial α := Finite.one_lt_card_iff_nontrivial.mp (h ▸ hp.1.one_lt)
+  obtain ⟨g, hg⟩ : ∃ g : α, g ≠ 1 := exists_ne 1
   exact ⟨g, fun g' ↦ mem_zpowers_of_prime_card h hg⟩
 
 /-- A finite group of order dividing a prime is cyclic. -/
 @[to_additive "A finite group of order dividing a prime is cyclic."]
-theorem isCyclic_of_card_dvd_prime {α : Type u} [Group α] {p : ℕ} [hp : Fact p.Prime]
+theorem isCyclic_of_card_dvd_prime {p : ℕ} [hp : Fact p.Prime]
     (h : Nat.card α ∣ p) : IsCyclic α := by
-  have : Finite α := Nat.finite_of_card_ne_zero (ne_zero_of_dvd_ne_zero hp.1.ne_zero h)
   rcases (Nat.dvd_prime hp.out).mp h with h | h
   · exact @isCyclic_of_subsingleton α _ (Nat.card_eq_one_iff_unique.mp h).1
-  · have : Fintype α := Fintype.ofFinite α
-    rw [Nat.card_eq_fintype_card] at h
-    exact isCyclic_of_prime_card h
+  · exact isCyclic_of_prime_card h
 
 @[to_additive]
 theorem isCyclic_of_surjective {H G F : Type*} [Group H] [Group G] [hH : IsCyclic H]
@@ -175,54 +173,37 @@ theorem isCyclic_of_surjective {H G F : Type*} [Group H] [Group G] [hH : IsCycli
   exact ⟨n, (map_zpow _ _ _).symm⟩
 
 @[to_additive]
-theorem orderOf_eq_card_of_forall_mem_zpowers [Fintype α] {g : α} (hx : ∀ x, x ∈ zpowers g) :
-    orderOf g = Fintype.card α := by
-  classical
-    rw [← Fintype.card_zpowers]
-    apply Fintype.card_of_finset'
-    simpa using hx
+theorem orderOf_eq_card_of_forall_mem_zpowers {g : α} (hx : ∀ x, x ∈ zpowers g) :
+    orderOf g = Nat.card α := by
+  have : zpowers g = ⊤ := by simpa only [Subgroup.ext_iff, mem_top, iff_true]
+  rw [← Nat.card_zpowers, this, card_top]
 
 @[to_additive]
 lemma orderOf_generator_eq_natCard (h : ∀ x, x ∈ Subgroup.zpowers a) : orderOf a = Nat.card α :=
   Nat.card_zpowers a ▸ (Nat.card_congr <| Equiv.subtypeUnivEquiv h)
 
 @[to_additive]
-theorem exists_pow_ne_one_of_isCyclic {G : Type*} [Group G] [Fintype G] [G_cyclic : IsCyclic G]
-    {k : ℕ} (k_pos : k ≠ 0) (k_lt_card_G : k < Fintype.card G) : ∃ a : G, a ^ k ≠ 1 := by
+theorem exists_pow_ne_one_of_isCyclic [G_cyclic : IsCyclic α]
+    {k : ℕ} (k_pos : k ≠ 0) (k_lt_card_G : k < Nat.card α) : ∃ a : α, a ^ k ≠ 1 := by
+  have : Finite α := Nat.finite_of_card_ne_zero (Nat.not_eq_zero_of_lt k_lt_card_G)
   rcases G_cyclic with ⟨a, ha⟩
   use a
   contrapose! k_lt_card_G
   convert orderOf_le_of_pow_eq_one k_pos.bot_lt k_lt_card_G
-  rw [← Nat.card_eq_fintype_card, ← Nat.card_zpowers, eq_comm, card_eq_iff_eq_top, eq_top_iff]
+  rw [← Nat.card_zpowers, eq_comm, card_eq_iff_eq_top, eq_top_iff]
   exact fun x _ ↦ ha x
 
 @[to_additive]
 theorem Infinite.orderOf_eq_zero_of_forall_mem_zpowers [Infinite α] {g : α}
     (h : ∀ x, x ∈ zpowers g) : orderOf g = 0 := by
-  classical
-    rw [orderOf_eq_zero_iff']
-    refine fun n hn hgn => ?_
-    have ho := isOfFinOrder_iff_pow_eq_one.mpr ⟨n, hn, hgn⟩
-    obtain ⟨x, hx⟩ :=
-      Infinite.exists_not_mem_finset
-        (Finset.image (fun x => g ^ x) <| Finset.range <| orderOf g)
-    apply hx
-    rw [← ho.mem_powers_iff_mem_range_orderOf, Submonoid.mem_powers_iff]
-    obtain ⟨k, hk⟩ := h x
-    dsimp at hk
-    obtain ⟨k, rfl | rfl⟩ := k.eq_nat_or_neg
-    · exact ⟨k, mod_cast hk⟩
-    rw [← zpow_mod_orderOf] at hk
-    have : 0 ≤ (-k % orderOf g : ℤ) := Int.emod_nonneg (-k) (mod_cast ho.orderOf_pos.ne')
-    refine ⟨(-k % orderOf g : ℤ).toNat, ?_⟩
-    rwa [← zpow_natCast, Int.toNat_of_nonneg this]
+  rw [orderOf_eq_card_of_forall_mem_zpowers h, Nat.card_eq_zero_of_infinite]
 
 @[to_additive]
 instance Bot.isCyclic {α : Type u} [Group α] : IsCyclic (⊥ : Subgroup α) :=
   ⟨⟨1, fun x => ⟨0, Subtype.eq <| (zpow_zero (1 : α)).trans <| Eq.symm (Subgroup.mem_bot.1 x.2)⟩⟩⟩
 
 @[to_additive]
-instance Subgroup.isCyclic {α : Type u} [Group α] [IsCyclic α] (H : Subgroup α) : IsCyclic H :=
+instance Subgroup.isCyclic [IsCyclic α] (H : Subgroup α) : IsCyclic H :=
   haveI := Classical.propDecidable
   let ⟨g, hg⟩ := IsCyclic.exists_generator (α := α)
   if hx : ∃ x : α, x ∈ H ∧ x ≠ (1 : α) then
@@ -271,7 +252,7 @@ instance Subgroup.isCyclic {α : Type u} [Group α] [IsCyclic α] (H : Subgroup 
     subst this; infer_instance
 
 @[to_additive]
-lemma Subgroup.isCyclic_of_le {G : Type*} [Group G] {H H' : Subgroup G} (h : H ≤ H')
+lemma Subgroup.isCyclic_of_le {H H' : Subgroup α} (h : H ≤ H')
     [IsCyclic H'] :
     IsCyclic H := by
   let e := Subgroup.subgroupOfEquivOfLe h
@@ -304,8 +285,8 @@ theorem IsCyclic.card_pow_eq_one_le [DecidableEq α] [Fintype α] [IsCyclic α] 
             rw [zpow_natCast, ← pow_mul, Nat.mul_div_cancel_left', hm]
             refine Nat.dvd_of_mul_dvd_mul_right (gcd_pos_of_pos_left (Fintype.card α) hn0) ?_
             conv_lhs =>
-              rw [Nat.div_mul_cancel (Nat.gcd_dvd_right _ _), ←
-                orderOf_eq_card_of_forall_mem_zpowers hg]
+              rw [Nat.div_mul_cancel (Nat.gcd_dvd_right _ _), ← Nat.card_eq_fintype_card,
+                ← orderOf_eq_card_of_forall_mem_zpowers hg]
             exact orderOf_dvd_of_pow_eq_one hgmn⟩
     _ ≤ n := by
       let ⟨m, hm⟩ := Nat.gcd_dvd_right n (Fintype.card α)
@@ -315,6 +296,7 @@ theorem IsCyclic.card_pow_eq_one_le [DecidableEq α] [Fintype α] [IsCyclic α] 
           exact hm.elim' 1
       simp only [Set.toFinset_card, SetLike.coe_sort_coe]
       rw [Fintype.card_zpowers, orderOf_pow g, orderOf_eq_card_of_forall_mem_zpowers hg]
+      rw [Nat.card_eq_fintype_card]
       nth_rw 2 [hm]; nth_rw 3 [hm]
       rw [Nat.mul_div_cancel_left _ (gcd_pos_of_pos_left _ hn0), gcd_mul_left_left, hm,
         Nat.mul_div_cancel _ hm0]
@@ -360,9 +342,9 @@ theorem IsCyclic.unique_zpow_zmod (ha : ∀ x : α, x ∈ zpowers a) (x : α) :
   obtain ⟨n, rfl⟩ := ha x
   refine ⟨n, (?_ : a ^ n = _), fun y (hy : a ^ n = _) ↦ ?_⟩
   · rw [← zpow_natCast, zpow_eq_zpow_iff_modEq, orderOf_eq_card_of_forall_mem_zpowers ha,
-      Int.modEq_comm, Int.modEq_iff_add_fac, ← ZMod.intCast_eq_iff]
+      Int.modEq_comm, Int.modEq_iff_add_fac, Nat.card_eq_fintype_card, ← ZMod.intCast_eq_iff]
   · rw [← zpow_natCast, zpow_eq_zpow_iff_modEq, orderOf_eq_card_of_forall_mem_zpowers ha,
-      ← ZMod.intCast_eq_intCast_iff] at hy
+      Nat.card_eq_fintype_card, ← ZMod.intCast_eq_intCast_iff] at hy
     simp [hy]
 
 variable [DecidableEq α]
@@ -376,7 +358,8 @@ theorem IsCyclic.image_range_orderOf (ha : ∀ x : α, x ∈ zpowers a) :
 @[to_additive]
 theorem IsCyclic.image_range_card (ha : ∀ x : α, x ∈ zpowers a) :
     Finset.image (fun i => a ^ i) (range (Fintype.card α)) = univ := by
-  rw [← orderOf_eq_card_of_forall_mem_zpowers ha, IsCyclic.image_range_orderOf ha]
+  rw [← Nat.card_eq_fintype_card, ← orderOf_eq_card_of_forall_mem_zpowers ha,
+    IsCyclic.image_range_orderOf ha]
 
 @[to_additive]
 lemma IsCyclic.ext {G : Type*} [Group G] [Fintype G] [IsCyclic G] {d : ℕ} {a b : ZMod d}
@@ -384,7 +367,7 @@ lemma IsCyclic.ext {G : Type*} [Group G] [Fintype G] [IsCyclic G] {d : ℕ} {a b
   obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := G)
   specialize h g
   subst hGcard
-  rw [pow_eq_pow_iff_modEq, orderOf_eq_card_of_forall_mem_zpowers hg,
+  rw [pow_eq_pow_iff_modEq, orderOf_eq_card_of_forall_mem_zpowers hg, Nat.card_eq_fintype_card,
     ← ZMod.natCast_eq_natCast_iff] at h
   simpa [ZMod.natCast_val, ZMod.cast_id'] using h
 
@@ -477,13 +460,14 @@ theorem card_orderOf_eq_totient_aux₂ {d : ℕ} (hd : d ∣ Fintype.card α) :
 
 @[to_additive isAddCyclic_of_card_nsmul_eq_zero_le, stacks 09HX "This theorem is stronger than \
 09HX. It removes the abelian condition, and requires only `≤` instead of `=`."]
-theorem isCyclic_of_card_pow_eq_one_le : IsCyclic α :=
+theorem isCyclic_of_card_pow_eq_one_le : IsCyclic α := by
   have : Finset.Nonempty {a : α | orderOf a = Fintype.card α} :=
     card_pos.1 <| by
       rw [card_orderOf_eq_totient_aux₂ hn dvd_rfl, totient_pos]
       apply Fintype.card_pos
   let ⟨x, hx⟩ := this
-  isCyclic_of_orderOf_eq_card x (Finset.mem_filter.1 hx).2
+  rw [← Nat.card_eq_fintype_card] at hx
+  exact isCyclic_of_orderOf_eq_card x (Finset.mem_filter.1 hx).2
 
 @[deprecated (since := "2024-02-21")]
 alias isAddCyclic_of_card_pow_eq_one_le := isAddCyclic_of_card_nsmul_eq_zero_le
@@ -500,12 +484,11 @@ alias IsAddCyclic.card_orderOf_eq_totient := IsAddCyclic.card_addOrderOf_eq_toti
 
 /-- A finite group of prime order is simple. -/
 @[to_additive "A finite group of prime order is simple."]
-theorem isSimpleGroup_of_prime_card {α : Type u} [Group α] [Fintype α] {p : ℕ} [hp : Fact p.Prime]
-    (h : Fintype.card α = p) : IsSimpleGroup α := by
+theorem isSimpleGroup_of_prime_card {p : ℕ} [hp : Fact p.Prime]
+    (h : Nat.card α = p) : IsSimpleGroup α := by
   subst h
-  have : Nontrivial α := by
-    have h' := Nat.Prime.one_lt hp.out
-    exact Fintype.one_lt_card_iff_nontrivial.1 h'
+  have : Finite α := Nat.finite_of_card_ne_zero hp.1.ne_zero
+  have : Nontrivial α := Finite.one_lt_card_iff_nontrivial.mp hp.1.one_lt
   exact ⟨fun H _ => H.eq_bot_or_eq_top_of_prime_card⟩
 
 end Cyclic
@@ -567,18 +550,18 @@ instance (priority := 100) isCyclic : IsCyclic α := by
   exact ⟨⟨g, (Subgroup.eq_top_iff' _).1 this⟩⟩
 
 @[to_additive]
-theorem prime_card [Fintype α] : (Fintype.card α).Prime := by
-  have h0 : 0 < Fintype.card α := Fintype.card_pos_iff.2 (by infer_instance)
+theorem prime_card [Finite α] : (Nat.card α).Prime := by
+  have h0 : 0 < Nat.card α := Nat.card_pos
   obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := α)
   rw [Nat.prime_def_lt'']
-  refine ⟨Fintype.one_lt_card_iff_nontrivial.2 inferInstance, fun n hn => ?_⟩
+  refine ⟨Finite.one_lt_card_iff_nontrivial.2 inferInstance, fun n hn => ?_⟩
   refine (IsSimpleOrder.eq_bot_or_eq_top (Subgroup.zpowers (g ^ n))).symm.imp ?_ ?_
   · intro h
     have hgo := orderOf_pow (n := n) g
     rw [orderOf_eq_card_of_forall_mem_zpowers hg, Nat.gcd_eq_right_iff_dvd.1 hn,
       orderOf_eq_card_of_forall_mem_zpowers, eq_comm,
       Nat.div_eq_iff_eq_mul_left (Nat.pos_of_dvd_of_pos hn h0) hn] at hgo
-    · exact (mul_left_cancel₀ (ne_of_gt h0) ((mul_one (Fintype.card α)).trans hgo)).symm
+    · exact (mul_left_cancel₀ (ne_of_gt h0) ((mul_one (Nat.card α)).trans hgo)).symm
     · intro x
       rw [h]
       exact Subgroup.mem_top _
@@ -594,13 +577,13 @@ end CommGroup
 end IsSimpleGroup
 
 @[to_additive]
-theorem CommGroup.is_simple_iff_isCyclic_and_prime_card [Fintype α] [CommGroup α] :
-    IsSimpleGroup α ↔ IsCyclic α ∧ (Fintype.card α).Prime := by
+theorem CommGroup.is_simple_iff_isCyclic_and_prime_card [Finite α] [CommGroup α] :
+    IsSimpleGroup α ↔ IsCyclic α ∧ (Nat.card α).Prime := by
   constructor
   · intro h
     exact ⟨IsSimpleGroup.isCyclic, IsSimpleGroup.prime_card⟩
   · rintro ⟨_, hp⟩
-    haveI : Fact (Fintype.card α).Prime := ⟨hp⟩
+    haveI : Fact (Nat.card α).Prime := ⟨hp⟩
     exact isSimpleGroup_of_prime_card rfl
 
 section SpecificInstances
@@ -621,24 +604,23 @@ section Exponent
 open Monoid
 
 @[to_additive]
-theorem IsCyclic.exponent_eq_card [Group α] [IsCyclic α] [Fintype α] :
-    exponent α = Fintype.card α := by
+theorem IsCyclic.exponent_eq_card [Group α] [IsCyclic α] :
+    exponent α = Nat.card α := by
   obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := α)
-  apply Nat.dvd_antisymm
-  · rw [← lcm_orderOf_eq_exponent, Finset.lcm_dvd_iff]
-    exact fun b _ => orderOf_dvd_card
-  rw [← orderOf_eq_card_of_forall_mem_zpowers hg]
+  apply Nat.dvd_antisymm Group.exponent_dvd_nat_card
+  rw [← orderOf_generator_eq_natCard hg]
   exact order_dvd_exponent _
 
 @[to_additive]
-theorem IsCyclic.of_exponent_eq_card [CommGroup α] [Fintype α] (h : exponent α = Fintype.card α) :
+theorem IsCyclic.of_exponent_eq_card [CommGroup α] [Finite α] (h : exponent α = Nat.card α) :
     IsCyclic α :=
+  let ⟨_⟩ := nonempty_fintype α
   let ⟨g, _, hg⟩ := Finset.mem_image.mp (Finset.max'_mem _ _)
   isCyclic_of_orderOf_eq_card g <| hg.trans <| exponent_eq_max'_orderOf.symm.trans h
 
 @[to_additive]
-theorem IsCyclic.iff_exponent_eq_card [CommGroup α] [Fintype α] :
-    IsCyclic α ↔ exponent α = Fintype.card α :=
+theorem IsCyclic.iff_exponent_eq_card [CommGroup α] [Finite α] :
+    IsCyclic α ↔ exponent α = Nat.card α :=
   ⟨fun _ => IsCyclic.exponent_eq_card, IsCyclic.of_exponent_eq_card⟩
 
 @[to_additive]
@@ -651,27 +633,26 @@ theorem IsCyclic.exponent_eq_zero_of_infinite [Group α] [IsCyclic α] [Infinite
 protected theorem ZMod.exponent (n : ℕ) : AddMonoid.exponent (ZMod n) = n := by
   cases n
   · rw [IsAddCyclic.exponent_eq_zero_of_infinite]
-  · rw [IsAddCyclic.exponent_eq_card, card]
+  · rw [IsAddCyclic.exponent_eq_card, Nat.card_zmod]
 
 /-- A group of order `p ^ 2` is not cyclic if and only if its exponent is `p`. -/
 @[to_additive]
 lemma not_isCyclic_iff_exponent_eq_prime [Group α] {p : ℕ} (hp : p.Prime)
     (hα : Nat.card α = p ^ 2) : ¬ IsCyclic α ↔ Monoid.exponent α = p := by
   -- G is a nontrivial fintype of cardinality `p ^ 2`
-  let _inst : Fintype α := @Fintype.ofFinite α <| Nat.finite_of_card_ne_zero <| by aesop
-  have hα' : Fintype.card α = p ^ 2 := by simpa using hα
-  have := (Fintype.one_lt_card_iff_nontrivial (α := α)).mp <|
-    hα' ▸ one_lt_pow₀ hp.one_lt two_ne_zero
+  have : Finite α := Nat.finite_of_card_ne_zero (hα ▸ pow_ne_zero 2 hp.ne_zero)
+  have : Nontrivial α := Finite.one_lt_card_iff_nontrivial.mp
+    (hα ▸ one_lt_pow₀ hp.one_lt two_ne_zero)
   /- in the forward direction, we apply `exponent_eq_prime_iff`, and the reverse direction follows
   immediately because if `α` has exponent `p`, it has no element of order `p ^ 2`. -/
   refine ⟨fun h_cyc ↦ (Monoid.exponent_eq_prime_iff hp).mpr fun g hg ↦ ?_, fun h_exp h_cyc ↦ by
-    obtain (rfl|rfl) := eq_zero_or_one_of_sq_eq_self <| hα' ▸ h_exp ▸ (h_cyc.exponent_eq_card).symm
+    obtain (rfl|rfl) := eq_zero_or_one_of_sq_eq_self <| hα ▸ h_exp ▸ (h_cyc.exponent_eq_card).symm
     · exact Nat.not_prime_zero hp
     · exact Nat.not_prime_one hp⟩
   /- we must show every non-identity element has order `p`. By Lagrange's theorem, the only possible
   orders of `g` are `1`, `p`, or `p ^ 2`. It can't be the former because `g ≠ 1`, and it can't
   the latter because the group isn't cyclic. -/
-  have := (Nat.mem_divisors (m := p ^ 2)).mpr ⟨hα' ▸ orderOf_dvd_card (x := g), by aesop⟩
+  have := (Nat.mem_divisors (m := p ^ 2)).mpr ⟨hα ▸ orderOf_dvd_natCard (x := g), by aesop⟩
   simp? [Nat.divisors_prime_pow hp 2] at this says
     simp only [Nat.divisors_prime_pow hp 2, Nat.reduceAdd, Finset.mem_map, Finset.mem_range,
       Function.Embedding.coeFn_mk] at this
@@ -735,12 +716,11 @@ noncomputable def mulEquivOfCyclicCardEq [Group G] [Group H] [hG : IsCyclic G]
 
 /-- Two groups of the same prime cardinality are isomorphic. -/
 @[to_additive "Two additive groups of the same prime cardinality are isomorphic."]
-noncomputable def mulEquivOfPrimeCardEq {p : ℕ} [Fintype G] [Fintype H] [Group G] [Group H]
-    [Fact p.Prime] (hG : Fintype.card G = p) (hH : Fintype.card H = p) : G ≃* H := by
+noncomputable def mulEquivOfPrimeCardEq {p : ℕ} [Group G] [Group H]
+    [Fact p.Prime] (hG : Nat.card G = p) (hH : Nat.card H = p) : G ≃* H := by
   have hGcyc := isCyclic_of_prime_card hG
   have hHcyc := isCyclic_of_prime_card hH
   apply mulEquivOfCyclicCardEq
-  rw [← Nat.card_eq_fintype_card] at hG hH
   exact hG.trans hH.symm
 
 end ZMod

--- a/Mathlib/GroupTheory/SpecificGroups/Quaternion.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Quaternion.lean
@@ -210,7 +210,7 @@ theorem orderOf_xa [NeZero n] (i : ZMod (2 * n)) : orderOf (xa i) = 4 := by
 /-- In the special case `n = 1`, `Quaternion 1` is a cyclic group (of order `4`). -/
 theorem quaternionGroup_one_isCyclic : IsCyclic (QuaternionGroup 1) := by
   apply isCyclic_of_orderOf_eq_card
-  · rw [card, mul_one]
+  · rw [Nat.card_eq_fintype_card, card, mul_one]
     exact orderOf_xa 0
 
 /-- If `0 < n`, then `a 1` has order `2 * n`.

--- a/Mathlib/NumberTheory/LucasPrimality.lean
+++ b/Mathlib/NumberTheory/LucasPrimality.lean
@@ -54,7 +54,8 @@ theorem reverse_lucas_primality (p : ℕ) (hP : p.Prime) :
   have : Fact p.Prime := ⟨hP⟩
   obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := (ZMod p)ˣ)
   have h1 : orderOf g = p - 1 := by
-    rwa [orderOf_eq_card_of_forall_mem_zpowers hg, ← Nat.prime_iff_card_units]
+    rwa [orderOf_eq_card_of_forall_mem_zpowers hg, Nat.card_eq_fintype_card,
+      ← Nat.prime_iff_card_units]
   have h2 := tsub_pos_iff_lt.2 hP.one_lt
   rw [← orderOf_injective (Units.coeHom _) Units.ext _, orderOf_eq_iff h2] at h1
   refine ⟨g, h1.1, fun q hq hqd ↦ ?_⟩


### PR DESCRIPTION
This PR switches most of `Cyclic.lean` from `Fintype` to `Finite`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #19074
- [ ] depends on: #19075

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
