### PR TITLE
[Merged by Bors] - feat(Data/Fintype/Units): Generalize `card_units` to infinite types

### DIFF
--- a/Mathlib/Data/Fintype/Units.lean
+++ b/Mathlib/Data/Fintype/Units.lean
@@ -29,18 +29,24 @@ instance [Monoid α] [Fintype α] [DecidableEq α] : Fintype αˣ :=
 
 instance [Monoid α] [Finite α] : Finite αˣ := Finite.of_injective _ Units.ext
 
-theorem Fintype.card_eq_card_units_add_one [GroupWithZero α] [Fintype α] [DecidableEq α] :
-    Fintype.card α = Fintype.card αˣ + 1 := by
-  rw [eq_comm, Fintype.card_congr unitsEquivNeZero]
-  have := Fintype.card_congr (Equiv.sumCompl (· = (0 : α)))
-  rwa [Fintype.card_sum, add_comm, Fintype.card_subtype_eq] at this
+variable (α)
+
+theorem Nat.card_units [GroupWithZero α] :
+    Nat.card αˣ = Nat.card α - 1 := by
+  classical
+  rw [Nat.card_congr unitsEquivNeZero, eq_comm, ← Nat.card_congr (Equiv.sumCompl (· = (0 : α)))]
+  rcases finite_or_infinite {a : α // a ≠ 0}
+  · rw [Nat.card_sum, Nat.card_unique, add_tsub_cancel_left]
+  · rw [Nat.card_eq_zero_of_infinite, Nat.card_eq_zero_of_infinite, zero_tsub]
 
 theorem Nat.card_eq_card_units_add_one [GroupWithZero α] [Finite α] :
     Nat.card α = Nat.card αˣ + 1 := by
-  have : Fintype α := Fintype.ofFinite α
-  classical
-    rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, Fintype.card_eq_card_units_add_one]
+  rw [Nat.card_units, tsub_add_cancel_of_le Nat.card_pos]
 
 theorem Fintype.card_units [GroupWithZero α] [Fintype α] [DecidableEq α] :
     Fintype.card αˣ = Fintype.card α - 1 := by
-  rw [@Fintype.card_eq_card_units_add_one α, Nat.add_sub_cancel]
+  rw [← Nat.card_eq_fintype_card, Nat.card_units, Nat.card_eq_fintype_card]
+
+theorem Fintype.card_eq_card_units_add_one [GroupWithZero α] [Fintype α] [DecidableEq α] :
+    Fintype.card α = Fintype.card αˣ + 1 := by
+  rw [Fintype.card_units, tsub_add_cancel_of_le Fintype.card_pos]


### PR DESCRIPTION
This PR proves `Nat.card αˣ = Nat.card α - 1` for all groups with zero `α`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
