### PR TITLE
[Merged by Bors] - chore: missing deprecations from #18967

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Basic.lean
@@ -67,7 +67,7 @@ attribute [bound] pow_le_one₀ one_le_pow₀
 @[deprecated (since := "2024-10-04")] alias pow_le_pow_right := pow_le_pow_right₀
 @[deprecated (since := "2024-10-04")] alias le_self_pow := le_self_pow₀
 
-@[mono, gcongr, bound]
+@[deprecated pow_le_pow_left₀ (since := "2024-11-13")]
 theorem pow_le_pow_left {a b : R} (ha : 0 ≤ a) (hab : a ≤ b) : ∀ n, a ^ n ≤ b ^ n :=
   pow_le_pow_left₀ ha hab
 
@@ -143,49 +143,49 @@ end StrictOrderedRing
 section LinearOrderedSemiring
 variable [LinearOrderedSemiring R] {a b : R} {m n : ℕ}
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated pow_le_pow_iff_left₀ (since := "2024-11-12")]
 lemma pow_le_pow_iff_left (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) : a ^ n ≤ b ^ n ↔ a ≤ b :=
   pow_le_pow_iff_left₀ ha hb hn
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated pow_lt_pow_iff_left₀ (since := "2024-11-12")]
 lemma pow_lt_pow_iff_left (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) : a ^ n < b ^ n ↔ a < b :=
   pow_lt_pow_iff_left₀ ha hb hn
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated pow_left_inj₀ (since := "2024-11-12")]
 lemma pow_left_inj (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b :=
   pow_left_inj₀ ha hb hn
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated pow_right_injective₀ (since := "2024-11-12")]
 lemma pow_right_injective (ha₀ : 0 < a) (ha₁ : a ≠ 1) : Injective (a ^ ·) :=
   pow_right_injective₀ ha₀ ha₁
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated pow_right_inj₀ (since := "2024-11-12")]
 lemma pow_right_inj (ha₀ : 0 < a) (ha₁ : a ≠ 1) : a ^ m = a ^ n ↔ m = n := pow_right_inj₀ ha₀ ha₁
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated sq_le_one_iff₀ (since := "2024-11-12")]
 theorem sq_le_one_iff {a : R} (ha : 0 ≤ a) : a ^ 2 ≤ 1 ↔ a ≤ 1 := sq_le_one_iff₀ ha
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated sq_lt_one_iff₀ (since := "2024-11-12")]
 theorem sq_lt_one_iff {a : R} (ha : 0 ≤ a) : a ^ 2 < 1 ↔ a < 1 := sq_lt_one_iff₀ ha
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated one_le_sq_iff₀ (since := "2024-11-12")]
 theorem one_le_sq_iff {a : R} (ha : 0 ≤ a) : 1 ≤ a ^ 2 ↔ 1 ≤ a := one_le_sq_iff₀ ha
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated one_lt_sq_iff₀ (since := "2024-11-12")]
 theorem one_lt_sq_iff {a : R} (ha : 0 ≤ a) : 1 < a ^ 2 ↔ 1 < a := one_lt_sq_iff₀ ha
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated lt_of_pow_lt_pow_left₀ (since := "2024-11-12")]
 theorem lt_of_pow_lt_pow_left (n : ℕ) (hb : 0 ≤ b) (h : a ^ n < b ^ n) : a < b :=
   lt_of_pow_lt_pow_left₀ n hb h
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated le_of_pow_le_pow_left₀ (since := "2024-11-12")]
 theorem le_of_pow_le_pow_left (hn : n ≠ 0) (hb : 0 ≤ b) (h : a ^ n ≤ b ^ n) : a ≤ b :=
   le_of_pow_le_pow_left₀ hn hb h
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated sq_eq_sq₀ (since := "2024-11-12")]
 theorem sq_eq_sq {a b : R} (ha : 0 ≤ a) (hb : 0 ≤ b) : a ^ 2 = b ^ 2 ↔ a = b := sq_eq_sq₀ ha hb
 
-@[deprecated (since := "2024-11-12")]
+@[deprecated lt_of_mul_self_lt_mul_self₀ (since := "2024-11-12")]
 theorem lt_of_mul_self_lt_mul_self (hb : 0 ≤ b) : a * a < b * b → a < b :=
   lt_of_mul_self_lt_mul_self₀ hb
 

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -869,7 +869,7 @@ def compCLM {g : D → E} (hg : g.HasTemperateGrowth)
           simp only [le_add_iff_nonneg_right, norm_nonneg]
       have := norm_iteratedFDeriv_comp_le f.smooth' hg.1 le_top x hbound hgrowth'
       have hxk : ‖x‖ ^ k ≤ (1 + ‖x‖) ^ k :=
-        pow_le_pow_left (norm_nonneg _) (by simp only [zero_le_one, le_add_iff_nonneg_left]) _
+        pow_le_pow_left₀ (norm_nonneg _) (by simp only [zero_le_one, le_add_iff_nonneg_left]) _
       refine le_trans (mul_le_mul hxk this (by positivity) (by positivity)) ?_
       have rearrange :
         (1 + ‖x‖) ^ k *

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -135,7 +135,7 @@ lemma cos_le_one_sub_mul_cos_sq (hx : |x| ≤ π) : cos x ≤ 1 - 2 / π ^ 2 * x
   case inr => simpa using this (by rwa [abs_neg]) <| neg_nonneg.2 <| le_of_not_le hx₀
   rw [abs_of_nonneg hx₀] at hx
   have : x / π ≤ sin (x / 2) := by simpa using mul_le_sin (x := x / 2) (by positivity) (by linarith)
-  have := (pow_le_pow_left (by positivity) this 2).trans_eq (sin_sq_eq_half_sub _)
+  have := (pow_le_pow_left₀ (by positivity) this 2).trans_eq (sin_sq_eq_half_sub _)
   ring_nf at this ⊢
   linarith
 

--- a/Mathlib/MeasureTheory/Integral/PeakFunction.lean
+++ b/Mathlib/MeasureTheory/Integral/PeakFunction.lean
@@ -317,12 +317,12 @@ theorem tendsto_setIntegral_pow_smul_of_unique_maximum_of_isCompact_of_measure_n
               exact lt_of_le_of_lt (measure_mono inter_subset_right) hs.measure_lt_top
             · exact (I n).mono inter_subset_right le_rfl
             · intro x hx
-              exact pow_le_pow_left t'_pos.le (le_of_lt (hv hx)) _
+              exact pow_le_pow_left₀ t'_pos.le (hv hx).le _
           _ ≤ ∫ y in s, c y ^ n ∂μ :=
             setIntegral_mono_set (I n) (J n) (Eventually.of_forall inter_subset_right)
       simp_rw [φ, ← div_eq_inv_mul, div_pow, div_div]
       apply div_le_div (pow_nonneg t_pos n) _ _ B
-      · exact pow_le_pow_left (hnc _ hx.1) (ht x hx) _
+      · exact pow_le_pow_left₀ (hnc _ hx.1) (ht x hx) _
       · apply mul_pos (pow_pos (t_pos.trans_lt tt') _) (ENNReal.toReal_pos (hμ v v_open x₀_v).ne' _)
         have : μ (v ∩ s) ≤ μ s := measure_mono inter_subset_right
         exact ne_of_lt (lt_of_le_of_lt this hs.measure_lt_top)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #19173

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
