### PR TITLE
[Merged by Bors] - fix: `linear_combination` with an additive constant

### DIFF
--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -105,14 +105,14 @@ partial def expandLinearCombo (ty : Expr) (stx : Syntax.Term) : TermElabM Expand
       logWarningAt c "this constant has no effect on the linear combination; it can be dropped \
         from the term"
       pure (.proof rel p)
-    | .const c, .proof rel p =>
+    | .const c, .proof eq p =>
       logWarningAt c "this constant has no effect on the linear combination; it can be dropped \
         from the term"
-      .proof rel <$> ``(Eq.symm $p)
+      .proof eq <$> ``(Eq.symm $p)
     | .proof rel₁ p₁, .proof eq p₂ =>
       let i := mkIdent <| Ineq.addRelRelData rel₁ eq
       .proof rel₁ <$> ``($i $p₁ (Eq.symm $p₂))
-    | .proof _ _, .proof _ _ =>
+    | _, .proof _ _ =>
       throwError "coefficients of inequalities in 'linear_combination' must be nonnegative"
   | `(-$e) => do
       match ← expandLinearCombo ty e with

--- a/MathlibTest/linear_combination.lean
+++ b/MathlibTest/linear_combination.lean
@@ -384,6 +384,10 @@ h2 : b ≥ 0
 #guard_msgs in
 example (a b : ℚ) (h1 : a ≤ 1) (h2 : b ≥ 0) : a ≤ b := by linear_combination h1
 
+/-- error: coefficients of inequalities in 'linear_combination' must be nonnegative -/
+#guard_msgs in
+example (x y : ℤ) (h : x ≤ y) : -x ≤ -y := by linear_combination 4 - h
+
 /-! ### Nonlinear inequalities -/
 
 example {a b : ℝ} (ha : 0 ≤ a) (hb : b < 1) : a * b ≤ a := by linear_combination a * hb


### PR DESCRIPTION
Fix a bug in one of the "off-label" use cases of `linear_combination`, which would not turn up in mathlib (because it throws a warning) but might confuse users in the wild.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
