### PR TITLE
[Merged by Bors] - chore: shortcut instances for `Finite Bool`, `Finite Prop`

### DIFF
--- a/Mathlib/Data/Finite/Defs.lean
+++ b/Mathlib/Data/Finite/Defs.lean
@@ -162,6 +162,9 @@ protected theorem Infinite.false [Finite α] (_ : Infinite α) : False :=
 
 alias ⟨Finite.of_not_infinite, Finite.not_infinite⟩ := not_infinite_iff_finite
 
+instance Bool.instFinite : Finite Bool := .intro finTwoEquiv.symm
+instance Prop.instFinite : Finite Prop := .of_equiv _ Equiv.propEquivBool.symm
+
 section Set
 
 /-!

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -841,10 +841,11 @@ instance (priority := 100) to_wellFoundedGT [Preorder α] : WellFoundedGT α :=
 
 end Finite
 
--- Shortcut instances
+-- Shortcut instances to make sure those are found even in the presence of other instances
+-- See https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/WellFoundedLT.20Prop.20is.20not.20found.20when.20importing.20too.20much
 instance Bool.instWellFoundedLT : WellFoundedLT Bool := inferInstance
-instance Prop.instWellFoundedLT : WellFoundedLT Prop := inferInstance
 instance Bool.instWellFoundedGT : WellFoundedGT Bool := inferInstance
+instance Prop.instWellFoundedLT : WellFoundedLT Prop := inferInstance
 instance Prop.instWellFoundedGT : WellFoundedGT Prop := inferInstance
 
 -- @[nolint fintype_finite] -- Porting note: do we need this?

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -844,6 +844,8 @@ end Finite
 -- Shortcut instances
 instance Bool.instWellFoundedLT : WellFoundedLT Bool := inferInstance
 instance Prop.instWellFoundedLT : WellFoundedLT Prop := inferInstance
+instance Bool.instWellFoundedGT : WellFoundedGT Bool := inferInstance
+instance Prop.instWellFoundedGT : WellFoundedGT Prop := inferInstance
 
 -- @[nolint fintype_finite] -- Porting note: do we need this?
 protected theorem Fintype.false [Infinite α] (_h : Fintype α) : False :=

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -841,6 +841,10 @@ instance (priority := 100) to_wellFoundedGT [Preorder α] : WellFoundedGT α :=
 
 end Finite
 
+-- Shortcut instances
+instance Bool.instWellFoundedLT : WellFoundedLT Bool := inferInstance
+instance Prop.instWellFoundedLT : WellFoundedLT Prop := inferInstance
+
 -- @[nolint fintype_finite] -- Porting note: do we need this?
 protected theorem Fintype.false [Infinite α] (_h : Fintype α) : False :=
   not_finite α


### PR DESCRIPTION
These can be defined much earlier. Also add `WellFoundedLT` shortcut instances.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/WellFoundedLT.20Prop.20is.20not.20found.20when.20importing.20too.20much)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #19186

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
