### PR TITLE
[Merged by Bors] - chore(Combinatorics/Additive/SmallTripling): additivise

### DIFF
--- a/Mathlib/Combinatorics/Additive/SmallTripling.lean
+++ b/Mathlib/Combinatorics/Additive/SmallTripling.lean
@@ -30,7 +30,8 @@ open scoped Pointwise
 namespace Finset
 variable {G : Type*} [DecidableEq G] [Group G] {A : Finset G} {k K : ℝ} {m : ℕ}
 
-private lemma inductive_claim (hm : 3 ≤ m)
+@[to_additive]
+private lemma inductive_claim_mul (hm : 3 ≤ m)
     (h : ∀ ε : Fin 3 → ℤ, (∀ i, |ε i| = 1) → #((finRange 3).map fun i ↦ A ^ ε i).prod ≤ k * #A)
     (ε : Fin m → ℤ) (hε : ∀ i, |ε i| = 1) :
     #((finRange m).map fun i ↦ A ^ ε i).prod ≤ k ^ (m - 2) * #A := by
@@ -61,7 +62,8 @@ private lemma inductive_claim (hm : 3 ≤ m)
       · exact ih (Fin.cons 1 <| tail <| tail ε) <| Fin.cons (by simp) (by simp [hε, Fin.tail])
     _ = #A * (k ^ m * #A) := by rw [← pow_sub_one_mul hm₀]; ring
 
-private lemma small_neg_pos_pos (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A * A) ≤ K ^ 2 * #A := by
+@[to_additive]
+private lemma small_neg_pos_pos_mul (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A * A) ≤ K ^ 2 * #A := by
   obtain rfl | hA₀ := A.eq_empty_or_nonempty
   · simp
   have : 0 ≤ K := nonneg_of_mul_nonneg_left (hA.trans' <| by positivity) (by positivity)
@@ -78,18 +80,22 @@ private lemma small_neg_pos_pos (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A * A) �
         _ ≤ K * #A := hA
     _ = #A * (K ^ 2 * #A) := by ring
 
-private lemma small_neg_neg_pos (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A⁻¹ * A) ≤ K ^ 2 * #A := by
+@[to_additive]
+private lemma small_neg_neg_pos_mul (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A⁻¹ * A) ≤ K ^ 2 * #A := by
   rw [← card_inv]
-  simpa [mul_assoc] using small_neg_pos_pos (A := A) (K := K) (by simpa)
+  simpa [mul_assoc] using small_neg_pos_pos_mul (A := A) (K := K) (by simpa)
 
-private lemma small_pos_neg_neg (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ * A⁻¹) ≤ K ^ 2 * #A := by
-  simpa using small_neg_pos_pos (A := A⁻¹) (by simpa)
+@[to_additive]
+private lemma small_pos_neg_neg_mul (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ * A⁻¹) ≤ K ^ 2 * #A := by
+  simpa using small_neg_pos_pos_mul (A := A⁻¹) (by simpa)
 
-private lemma small_pos_pos_neg (hA : #(A ^ 3) ≤ K * #A) : #(A * A * A⁻¹) ≤ K ^ 2 * #A := by
+@[to_additive]
+private lemma small_pos_pos_neg_mul (hA : #(A ^ 3) ≤ K * #A) : #(A * A * A⁻¹) ≤ K ^ 2 * #A := by
   rw [← card_inv]
-  simpa [mul_assoc] using small_pos_neg_neg (A := A) (K := K) (by simpa)
+  simpa [mul_assoc] using small_pos_neg_neg_mul (A := A) (K := K) (by simpa)
 
-private lemma small_pos_neg_pos (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ * A) ≤ K ^ 3 * #A := by
+@[to_additive]
+private lemma small_pos_neg_pos_mul (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ * A) ≤ K ^ 3 * #A := by
   obtain rfl | hA₀ := A.eq_empty_or_nonempty
   · simp
   have : 0 ≤ K := nonneg_of_mul_nonneg_left (hA.trans' <| by positivity) (by positivity)
@@ -100,15 +106,16 @@ private lemma small_pos_neg_pos (hA : #(A ^ 3) ≤ K * #A) : #(A * A⁻¹ * A) �
     _ = #(A  * A * A⁻¹) * #(A ^ 2) := by simp [pow_succ, mul_assoc]
     _ ≤ (K ^ 2 * #A) * (K * #A) := by
       gcongr
-      · exact small_pos_pos_neg hA
+      · exact small_pos_pos_neg_mul hA
       calc
         (#(A ^ 2) : ℝ) ≤ #(A ^ 3) := mod_cast hA₀.card_pow_mono (by norm_num)
         _ ≤ K * #A := hA
     _ = #A * (K ^ 3 * #A) := by ring
 
-private lemma small_neg_pos_neg (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A * A⁻¹) ≤ K ^ 3 * #A := by
+@[to_additive]
+private lemma small_neg_pos_neg_mul (hA : #(A ^ 3) ≤ K * #A) : #(A⁻¹ * A * A⁻¹) ≤ K ^ 3 * #A := by
   rw [← card_inv]
-  simpa [mul_assoc] using small_pos_neg_pos (A := A) (K := K) (by simpa)
+  simpa [mul_assoc] using small_pos_neg_pos_mul (A := A) (K := K) (by simpa)
 
 /-- If `A` has small tripling, say with constant `K`, then `A` has small alternating powers, in the
 sense that `|A^±1 * ... * A^±1|` is at most `|A|` times a constant exponential in the number of
@@ -116,7 +123,14 @@ terms in the product.
 
 When `A` is symmetric (`A⁻¹ = A`), the base of the exponential can be lowered from `K ^ 3` to `K`,
 where `K` is the tripling constant. See `Finset.small_pow_of_small_tripling`. -/
-lemma small_alternating_pow_of_small_tripling (hm : 3 ≤ m) (hA : #(A ^ 3) ≤ K * #A) (ε : Fin m → ℤ)
+@[to_additive
+"If `A` has small tripling, say with constant `K`, then `A` has small alternating powers, in the
+sense that `|±A ± ... ± A|` is at most `|A|` times a constant exponential in the number of
+terms in the product.
+
+When `A` is symmetric (`-A = A`), the base of the exponential can be lowered from `K ^ 3` to `K`,
+where `K` is the tripling constant. See `Finset.small_nsmul_of_small_tripling`."]
+lemma small_alternating_pow_of_small_tripling' (hm : 3 ≤ m) (hA : #(A ^ 3) ≤ K * #A) (ε : Fin m → ℤ)
     (hε : ∀ i, |ε i| = 1) :
     #((finRange m).map fun i ↦ A ^ ε i).prod ≤ K ^ (3 * (m - 2)) * #A := by
   have hm₀ : m ≠ 0 := by positivity
@@ -127,7 +141,7 @@ lemma small_alternating_pow_of_small_tripling (hm : 3 ≤ m) (hA : #(A ^ 3) ≤ 
     one_le_of_le_mul_right₀ (by positivity)
       (hA.trans' <| by norm_cast; exact card_le_card_pow (by norm_num))
   rw [pow_mul]
-  refine inductive_claim hm (fun δ hδ ↦ ?_) ε hε
+  refine inductive_claim_mul hm (fun δ hδ ↦ ?_) ε hε
   simp only [finRange_succ_eq_map, Nat.reduceAdd, isValue, finRange_zero, map_nil, List.map_cons,
     succ_zero_eq_one, succ_one_eq_two, List.prod_cons, prod_nil, mul_one, ← mul_assoc]
   simp only [zero_le_one, abs_eq, Int.reduceNeg, forall_iff_succ, isValue, succ_zero_eq_one,
@@ -140,12 +154,12 @@ lemma small_alternating_pow_of_small_tripling (hm : 3 ≤ m) (hA : #(A ^ 3) ≤ 
   obtain ⟨hδ₀ | hδ₀, hδ₁ | hδ₁, hδ₂ | hδ₂⟩ := hδ <;> simp [hδ₀, hδ₁, hδ₂]
   · simp [pow_succ] at hA
     nlinarith
-  · nlinarith [small_pos_pos_neg hA]
-  · nlinarith [small_pos_neg_pos hA]
-  · nlinarith [small_pos_neg_neg hA]
-  · nlinarith [small_neg_pos_pos hA]
-  · nlinarith [small_neg_pos_neg hA]
-  · nlinarith [small_neg_neg_pos hA]
+  · nlinarith [small_pos_pos_neg_mul hA]
+  · nlinarith [small_pos_neg_pos_mul hA]
+  · nlinarith [small_pos_neg_neg_mul hA]
+  · nlinarith [small_neg_pos_pos_mul hA]
+  · nlinarith [small_neg_pos_neg_mul hA]
+  · nlinarith [small_neg_neg_pos_mul hA]
   · simp [*, pow_succ', ← mul_inv_rev] at hA ⊢
     nlinarith
 
@@ -154,14 +168,19 @@ in the sense that `|A ^ m|` is at most `|A|` times a constant exponential in `m`
 
 See also `Finset.small_alternating_pow_of_small_tripling` for a version with a weaker constant but
 which encompasses non-symmetric sets. -/
-lemma small_pow_of_small_tripling (hm : 3 ≤ m) (hA : #(A ^ 3) ≤ K * #A) (hAsymm : A⁻¹ = A) :
+@[to_additive
+"If `A` is symmetric (`-A = A`) and has small tripling, then `A` has small powers,
+in the sense that `|m • A|` is at most `|A|` times a constant exponential in `m`.
+
+See also `Finset.small_alternating_nsmul_of_small_tripling` for a version with a weaker constant but
+which encompasses non-symmetric sets."]
+lemma small_pow_of_small_tripling' (hm : 3 ≤ m) (hA : #(A ^ 3) ≤ K * #A) (hAsymm : A⁻¹ = A) :
     #(A ^ m) ≤ K ^ (m - 2) * #A := by
   have (ε : ℤ) (hε : |ε| = 1) : A ^ ε = A := by
     obtain rfl | rfl := eq_or_eq_neg_of_abs_eq hε <;> simp [hAsymm]
   calc
     (#(A ^ m) : ℝ) = #((finRange m).map fun i ↦ A ^ 1).prod := by simp
     _ ≤ K ^ (m - 2) * #A :=
-      inductive_claim hm (fun δ hδ ↦ by simpa [this _ (hδ _), pow_succ'] using hA) _
-        (by simp)
+      inductive_claim_mul hm (fun δ hδ ↦ by simpa [this _ (hδ _), pow_succ'] using hA) _ (by simp)
 
 end Finset


### PR DESCRIPTION
I completely missed this the first time around

From GrowthInGroups


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
