### PR TITLE
[Merged by Bors] - feat(Polynomial): composing with the constant polynomial

### DIFF
--- a/Mathlib/Algebra/Polynomial/Eval/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Coeff.lean
@@ -80,6 +80,9 @@ theorem coeff_map (n : ℕ) : coeff (p.map f) n = f (coeff p n) := by
   simp only [RingHom.coe_comp, Function.comp, coeff_C_mul_X_pow]
   split_ifs <;> simp [f.map_zero]
 
+lemma coeff_map_eq_comp (p : R[X]) (f : R →+* S) : (p.map f).coeff = f ∘ p.coeff := by
+  ext n; exact coeff_map ..
+
 theorem map_map [Semiring T] (g : S →+* T) (p : R[X]) : (p.map f).map g = p.map (g.comp f) :=
   ext (by simp [coeff_map])
 

--- a/Mathlib/Algebra/Polynomial/Eval/Defs.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Defs.lean
@@ -560,6 +560,9 @@ protected theorem map_ofNat (n : ℕ) [n.AtLeastTwo] :
 theorem map_dvd (f : R →+* S) {x y : R[X]} : x ∣ y → x.map f ∣ y.map f :=
   (mapRingHom f).map_dvd
 
+lemma mapRingHom_comp_C {R S} [CommRing R] [CommRing S] (f : R →+* S) :
+    (mapRingHom f).comp C = C.comp f := by ext; simp
+
 theorem eval₂_eq_eval_map {x : S} : p.eval₂ f x = (p.map f).eval x := by
   induction p using Polynomial.induction_on' with
   | h_add p q hp hq =>


### PR DESCRIPTION
... and a point-free version of `coeff_map`

From GrowthInGroups


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
