### PR TITLE
chore(Algebra/MonoidAlgebra): split Defs.lean further

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -613,7 +613,11 @@ import Mathlib.Algebra.MonoidAlgebra.Degree
 import Mathlib.Algebra.MonoidAlgebra.Division
 import Mathlib.Algebra.MonoidAlgebra.Grading
 import Mathlib.Algebra.MonoidAlgebra.Ideal
+import Mathlib.Algebra.MonoidAlgebra.Lift
+import Mathlib.Algebra.MonoidAlgebra.MapDomain
+import Mathlib.Algebra.MonoidAlgebra.Module
 import Mathlib.Algebra.MonoidAlgebra.NoZeroDivisors
+import Mathlib.Algebra.MonoidAlgebra.Opposite
 import Mathlib.Algebra.MonoidAlgebra.Support
 import Mathlib.Algebra.MonoidAlgebra.ToDirectSum
 import Mathlib.Algebra.MvPolynomial.Basic

--- a/Mathlib/Algebra/MonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Basic.lean
@@ -5,11 +5,8 @@ Authors: Johannes Hölzl, Yury Kudryashov, Kim Morrison
 -/
 import Mathlib.Algebra.Algebra.Equiv
 import Mathlib.Algebra.Algebra.NonUnitalHom
-import Mathlib.Algebra.BigOperators.Finsupp
-import Mathlib.Algebra.Module.BigOperators
-import Mathlib.Algebra.MonoidAlgebra.Defs
-import Mathlib.Data.Finsupp.Basic
-import Mathlib.LinearAlgebra.Finsupp.SumProd
+import Mathlib.Algebra.MonoidAlgebra.MapDomain
+import Mathlib.Algebra.MonoidAlgebra.Module
 
 /-!
 # Monoid algebras

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Yury Kudryashov, Kim Morrison
 -/
 import Mathlib.Algebra.BigOperators.Finsupp
 import Mathlib.Algebra.Ring.Defs
+import Mathlib.Data.Finsupp.SMulWithZero
 
 /-!
 # Monoid algebras
@@ -222,6 +223,30 @@ theorem natCast_def (n : ℕ) : (n : MonoidAlgebra k G) = single (1 : G) (n : k)
 alias nat_cast_def := natCast_def
 
 end MulOneClass
+
+section SMul
+
+variable {S : Type*}
+
+instance smulZeroClass [Semiring k] [SMulZeroClass R k] : SMulZeroClass R (MonoidAlgebra k G) :=
+  Finsupp.smulZeroClass
+
+instance distribSMul [Semiring k] [DistribSMul R k] : DistribSMul R (MonoidAlgebra k G) :=
+  Finsupp.distribSMul _ _
+
+instance isScalarTower [Semiring k] [SMulZeroClass R k] [SMulZeroClass S k] [SMul R S]
+    [IsScalarTower R S k] : IsScalarTower R S (MonoidAlgebra k G) :=
+  Finsupp.isScalarTower G k
+
+instance smulCommClass [Semiring k] [SMulZeroClass R k] [SMulZeroClass S k] [SMulCommClass R S k] :
+    SMulCommClass R S (MonoidAlgebra k G) :=
+  Finsupp.smulCommClass G k
+
+instance isCentralScalar [Semiring k] [SMulZeroClass R k] [SMulZeroClass Rᵐᵒᵖ k]
+    [IsCentralScalar R k] : IsCentralScalar R (MonoidAlgebra k G) :=
+  Finsupp.isCentralScalar G k
+
+end SMul
 
 /-! #### Semiring structure -/
 
@@ -742,6 +767,30 @@ theorem natCast_def (n : ℕ) : (n : k[G]) = single (0 : G) (n : k) :=
 alias nat_cast_def := natCast_def
 
 end MulOneClass
+
+section SMul
+
+variable {S : Type*}
+
+instance smulZeroClass [Semiring k] [SMulZeroClass R k] : SMulZeroClass R (AddMonoidAlgebra k G) :=
+  Finsupp.smulZeroClass
+
+instance distribSMul [Semiring k] [DistribSMul R k] : DistribSMul R k[G] :=
+  Finsupp.distribSMul G k
+
+instance isScalarTower [Semiring k] [SMulZeroClass R k] [SMulZeroClass S k] [SMul R S]
+    [IsScalarTower R S k] : IsScalarTower R S k[G] :=
+  Finsupp.isScalarTower G k
+
+instance smulCommClass [Semiring k] [SMulZeroClass R k] [SMulZeroClass S k] [SMulCommClass R S k] :
+    SMulCommClass R S k[G] :=
+  Finsupp.smulCommClass G k
+
+instance isCentralScalar [Semiring k] [SMulZeroClass R k] [SMulZeroClass Rᵐᵒᵖ k]
+    [IsCentralScalar R k] : IsCentralScalar R k[G] :=
+  Finsupp.isCentralScalar G k
+
+end SMul
 
 /-! #### Semiring structure -/
 

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -257,11 +257,6 @@ section DerivedInstances
 instance commSemiring [CommSemiring k] [CommMonoid G] : CommSemiring (MonoidAlgebra k G) :=
   { MonoidAlgebra.nonUnitalCommSemiring, MonoidAlgebra.semiring with }
 
-/-
-instance unique [Semiring k] [Subsingleton k] : Unique (MonoidAlgebra k G) :=
-  Finsupp.uniqueOfRight
--/
-
 instance addCommGroup [Ring k] : AddCommGroup (MonoidAlgebra k G) :=
   Finsupp.instAddCommGroup
 
@@ -928,13 +923,6 @@ def singleHom [AddZeroClass G] : k × Multiplicative G →* k[G] where
   toFun a := single a.2.toAdd a.1
   map_one' := rfl
   map_mul' _a _b := single_mul_single.symm
-
-/-
-/-- Copy of `Finsupp.smul_single'` that avoids the `AddMonoidAlgebra = Finsupp` defeq abuse. -/
-@[simp]
-theorem smul_single' (c : k) (a : G) (b : k) : c • single a b = single a (c * b) :=
-  Finsupp.smul_single' c a b
--/
 
 theorem mul_single_apply_aux [Add G] (f : k[G]) (r : k) (x y z : G)
     (H : ∀ a, a + x = z ↔ a = y) : (f * single x r) z = f y * r :=

--- a/Mathlib/Algebra/MonoidAlgebra/Division.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Division.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.MonoidAlgebra.Defs
+import Mathlib.Data.Finsupp.Basic
 
 /-!
 # Division of `AddMonoidAlgebra` by monomials

--- a/Mathlib/Algebra/MonoidAlgebra/Lift.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Lift.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Yury Kudryashov, Kim Morrison
+-/
+import Mathlib.Algebra.MonoidAlgebra.Defs
+
+/-!
+# Lifting monoid algebras
+
+## Main results
+
+* `MonoidAlgebra.liftNC`, `AddMonoidAlgebra.liftNC`: lift a homomorphism `f : k →+ R` and a
+  function `g : G → R` to a homomorphism `MonoidAlgebra k G →+ R`.
+-/
+
+assert_not_exists AlgEquiv
+assert_not_exists NonUnitalAlgHom
+
+noncomputable section
+
+open Finset
+
+open Finsupp hiding single
+
+universe u₁ u₂ u₃ u₄
+
+variable (k : Type u₁) (G : Type u₂) (H : Type*) {R : Type*}
+
+/-! ### Multiplicative monoids -/
+
+
+namespace MonoidAlgebra
+
+variable {k G}
+
+section
+
+variable [Semiring k] [NonUnitalNonAssocSemiring R]
+
+/-- A non-commutative version of `MonoidAlgebra.lift`: given an additive homomorphism `f : k →+ R`
+and a homomorphism `g : G → R`, returns the additive homomorphism from
+`MonoidAlgebra k G` such that `liftNC f g (single a b) = f b * g a`. If `f` is a ring homomorphism
+and the range of either `f` or `g` is in center of `R`, then the result is a ring homomorphism.  If
+`R` is a `k`-algebra and `f = algebraMap k R`, then the result is an algebra homomorphism called
+`MonoidAlgebra.lift`. -/
+def liftNC (f : k →+ R) (g : G → R) : MonoidAlgebra k G →+ R :=
+  liftAddHom fun x : G => (AddMonoidHom.mulRight (g x)).comp f
+
+@[simp]
+theorem liftNC_single (f : k →+ R) (g : G → R) (a : G) (b : k) :
+    liftNC f g (single a b) = f b * g a :=
+  liftAddHom_apply_single _ _ _
+
+end
+
+section Mul
+
+variable [Semiring k] [Mul G] [Semiring R]
+
+theorem liftNC_mul {g_hom : Type*} [FunLike g_hom G R] [MulHomClass g_hom G R]
+    (f : k →+* R) (g : g_hom) (a b : MonoidAlgebra k G)
+    (h_comm : ∀ {x y}, y ∈ a.support → Commute (f (b x)) (g y)) :
+    liftNC (f : k →+ R) g (a * b) = liftNC (f : k →+ R) g a * liftNC (f : k →+ R) g b := by
+  conv_rhs => rw [← sum_single a, ← sum_single b]
+  -- Porting note: `(liftNC _ g).map_finsupp_sum` → `map_finsupp_sum`
+  simp_rw [mul_def, map_finsupp_sum, liftNC_single, Finsupp.sum_mul, Finsupp.mul_sum]
+  refine Finset.sum_congr rfl fun y hy => Finset.sum_congr rfl fun x _hx => ?_
+  simp [mul_assoc, (h_comm hy).left_comm]
+
+end Mul
+
+section One
+
+variable [NonAssocSemiring R] [Semiring k] [One G]
+
+@[simp]
+theorem liftNC_one {g_hom : Type*} [FunLike g_hom G R] [OneHomClass g_hom G R]
+    (f : k →+* R) (g : g_hom) :
+    liftNC (f : k →+ R) g 1 = 1 := by simp [one_def]
+
+end One
+
+/-! #### Semiring structure -/
+
+
+section Semiring
+
+variable [Semiring k] [Monoid G] [Semiring R]
+
+/-- `liftNC` as a `RingHom`, for when `f x` and `g y` commute -/
+def liftNCRingHom (f : k →+* R) (g : G →* R) (h_comm : ∀ x y, Commute (f x) (g y)) :
+    MonoidAlgebra k G →+* R :=
+  { liftNC (f : k →+ R) g with
+    map_one' := liftNC_one _ _
+    map_mul' := fun _a _b => liftNC_mul _ _ _ _ fun {_ _} _ => h_comm _ _ }
+
+end Semiring
+
+end MonoidAlgebra
+
+/-! ### Additive monoids -/
+
+namespace AddMonoidAlgebra
+
+variable {k G}
+
+section
+
+variable [Semiring k] [NonUnitalNonAssocSemiring R]
+
+/-- A non-commutative version of `AddMonoidAlgebra.lift`: given an additive homomorphism
+`f : k →+ R` and a map `g : Multiplicative G → R`, returns the additive
+homomorphism from `k[G]` such that `liftNC f g (single a b) = f b * g a`. If `f`
+is a ring homomorphism and the range of either `f` or `g` is in center of `R`, then the result is a
+ring homomorphism.  If `R` is a `k`-algebra and `f = algebraMap k R`, then the result is an algebra
+homomorphism called `AddMonoidAlgebra.lift`. -/
+def liftNC (f : k →+ R) (g : Multiplicative G → R) : k[G] →+ R :=
+  liftAddHom fun x : G => (AddMonoidHom.mulRight (g <| Multiplicative.ofAdd x)).comp f
+
+@[simp]
+theorem liftNC_single (f : k →+ R) (g : Multiplicative G → R) (a : G) (b : k) :
+    liftNC f g (single a b) = f b * g (Multiplicative.ofAdd a) :=
+  liftAddHom_apply_single _ _ _
+
+end
+
+section Mul
+
+variable [Semiring k] [Add G] [Semiring R]
+
+theorem liftNC_mul {g_hom : Type*}
+    [FunLike g_hom (Multiplicative G) R] [MulHomClass g_hom (Multiplicative G) R]
+    (f : k →+* R) (g : g_hom) (a b : k[G])
+    (h_comm : ∀ {x y}, y ∈ a.support → Commute (f (b x)) (g <| Multiplicative.ofAdd y)) :
+    liftNC (f : k →+ R) g (a * b) = liftNC (f : k →+ R) g a * liftNC (f : k →+ R) g b :=
+  (MonoidAlgebra.liftNC_mul f g _ _ @h_comm : _)
+
+end Mul
+
+section One
+
+variable [Semiring k] [Zero G] [NonAssocSemiring R]
+
+@[simp]
+theorem liftNC_one {g_hom : Type*}
+    [FunLike g_hom (Multiplicative G) R] [OneHomClass g_hom (Multiplicative G) R]
+    (f : k →+* R) (g : g_hom) : liftNC (f : k →+ R) g 1 = 1 :=
+  MonoidAlgebra.liftNC_one f g
+
+end One
+
+/-! #### Semiring structure -/
+
+section Semiring
+
+variable [Semiring k] [AddMonoid G] [Semiring R]
+
+/-- `liftNC` as a `RingHom`, for when `f` and `g` commute -/
+def liftNCRingHom (f : k →+* R) (g : Multiplicative G →* R) (h_comm : ∀ x y, Commute (f x) (g y)) :
+    k[G] →+* R :=
+  { liftNC (f : k →+ R) g with
+    map_one' := liftNC_one _ _
+    map_mul' := fun _a _b => liftNC_mul _ _ _ _ fun {_ _} _ => h_comm _ _ }
+
+end Semiring
+
+end AddMonoidAlgebra

--- a/Mathlib/Algebra/MonoidAlgebra/MapDomain.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/MapDomain.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Yury Kudryashov, Kim Morrison
+-/
+import Mathlib.Algebra.MonoidAlgebra.Defs
+import Mathlib.Data.Finsupp.Basic
+
+/-!
+# Changing the index of monoid algebras
+
+## Main results
+
+* `MonoidAlgebra.mapDomain`, `AddMonoidAlgebra.mapDomain`: change the index of a monoid algebra
+* `AddMonoidAlgebra.toMultiplicative`, `MonoidAlgebra.toAdditive`: `MonoidAlgebra` and
+  `AddMonoidAlgebra` are the multiplicative/additive version of the other
+-/
+
+assert_not_exists AlgEquiv
+assert_not_exists NonUnitalAlgHom
+
+noncomputable section
+
+open Finset
+
+open Finsupp hiding single mapDomain
+
+universe u₁ u₂ u₃ u₄
+
+variable (k : Type u₁) (G : Type u₂) (H : Type*) {R : Type*}
+
+/-! ### Multiplicative monoids -/
+
+namespace MonoidAlgebra
+
+variable {k G}
+
+section
+
+variable [Semiring k] [NonUnitalNonAssocSemiring R]
+
+abbrev mapDomain {G' : Type*} (f : G → G') (v : MonoidAlgebra k G) : MonoidAlgebra k G' :=
+  Finsupp.mapDomain f v
+
+theorem mapDomain_sum {k' G' : Type*} [Semiring k'] {f : G → G'} {s : MonoidAlgebra k' G}
+    {v : G → k' → MonoidAlgebra k G} :
+    mapDomain f (s.sum v) = s.sum fun a b => mapDomain f (v a b) :=
+  Finsupp.mapDomain_sum
+
+end
+
+section MiscTheorems
+
+variable [Semiring k]
+
+section
+
+/-- Like `Finsupp.mapDomain_zero`, but for the `1` of the `Semiring` structure -/
+@[simp]
+theorem mapDomain_one {α : Type*} {β : Type*} {α₂ : Type*} [Semiring β] [One α] [One α₂]
+    {F : Type*} [FunLike F α α₂] [OneHomClass F α α₂] (f : F) :
+    (mapDomain f (1 : MonoidAlgebra β α) : MonoidAlgebra β α₂) = (1 : MonoidAlgebra β α₂) := by
+  simp_rw [one_def, mapDomain_single, map_one]
+
+/-- Like `Finsupp.mapDomain_add`, but for the convolutive multiplication on `MonoidAlgebra` -/
+theorem mapDomain_mul {α : Type*} {β : Type*} {α₂ : Type*} [Semiring β] [Mul α] [Mul α₂]
+    {F : Type*} [FunLike F α α₂] [MulHomClass F α α₂] (f : F) (x y : MonoidAlgebra β α) :
+    mapDomain f (x * y) = mapDomain f x * mapDomain f y := by
+  simp_rw [mul_def, mapDomain_sum, mapDomain_single, map_mul]
+  rw [Finsupp.sum_mapDomain_index]
+  · congr
+    ext a b
+    rw [Finsupp.sum_mapDomain_index]
+    · simp
+    · simp [mul_add]
+  · simp
+  · simp [add_mul]
+
+/-- If `f : G → H` is a multiplicative homomorphism between two monoids, then
+`Finsupp.mapDomain f` is a ring homomorphism between their monoid algebras. -/
+@[simps]
+def mapDomainRingHom (k : Type*) {H F : Type*} [Semiring k] [Monoid G] [Monoid H]
+    [FunLike F G H] [MonoidHomClass F G H] (f : F) : MonoidAlgebra k G →+* MonoidAlgebra k H :=
+  { (Finsupp.mapDomain.addMonoidHom f : MonoidAlgebra k G →+ MonoidAlgebra k H) with
+    map_one' := mapDomain_one f
+    map_mul' := fun x y => mapDomain_mul f x y }
+
+end
+
+end MiscTheorems
+
+end MonoidAlgebra
+
+/-! ### Additive monoids -/
+
+namespace AddMonoidAlgebra
+
+variable {k G}
+
+section
+
+variable [Semiring k] [NonUnitalNonAssocSemiring R]
+
+abbrev mapDomain {G' : Type*} (f : G → G') (v : k[G]) : k[G'] :=
+  Finsupp.mapDomain f v
+
+theorem mapDomain_sum {k' G' : Type*} [Semiring k'] {f : G → G'} {s : AddMonoidAlgebra k' G}
+    {v : G → k' → k[G]} :
+    mapDomain f (s.sum v) = s.sum fun a b => mapDomain f (v a b) :=
+  Finsupp.mapDomain_sum
+
+theorem mapDomain_single {G' : Type*} {f : G → G'} {a : G} {b : k} :
+    mapDomain f (single a b) = single (f a) b :=
+  Finsupp.mapDomain_single
+
+end
+
+section MiscTheorems
+
+variable [Semiring k]
+
+/-- Like `Finsupp.mapDomain_zero`, but for the `1` of the `Semiring` structure -/
+@[simp]
+theorem mapDomain_one {α : Type*} {β : Type*} {α₂ : Type*} [Semiring β] [Zero α] [Zero α₂]
+    {F : Type*} [FunLike F α α₂] [ZeroHomClass F α α₂] (f : F) :
+    (mapDomain f (1 : AddMonoidAlgebra β α) : AddMonoidAlgebra β α₂) =
+      (1 : AddMonoidAlgebra β α₂) := by
+  simp_rw [one_def, mapDomain_single, map_zero]
+
+/-- Like `Finsupp.mapDomain_add`, but for the convolutive multiplication on `MonoidAlgebra` -/
+theorem mapDomain_mul {α : Type*} {β : Type*} {α₂ : Type*} [Semiring β] [Add α] [Add α₂]
+    {F : Type*} [FunLike F α α₂] [AddHomClass F α α₂] (f : F) (x y : AddMonoidAlgebra β α) :
+    mapDomain f (x * y) = mapDomain f x * mapDomain f y := by
+  simp_rw [mul_def, mapDomain_sum, mapDomain_single, map_add]
+  rw [Finsupp.sum_mapDomain_index]
+  · congr
+    ext a b
+    rw [Finsupp.sum_mapDomain_index]
+    · simp
+    · simp [mul_add]
+  · simp
+  · simp [add_mul]
+
+/-- If `f : G → H` is an additive homomorphism between two additive monoids, then
+`Finsupp.mapDomain f` is a ring homomorphism between their add monoid algebras. -/
+@[simps]
+def mapDomainRingHom (k : Type*) [Semiring k] {H F : Type*} [AddMonoid G] [AddMonoid H]
+    [FunLike F G H] [AddMonoidHomClass F G H] (f : F) : k[G] →+* k[H] :=
+  { (Finsupp.mapDomain.addMonoidHom f : MonoidAlgebra k G →+ MonoidAlgebra k H) with
+    map_one' := mapDomain_one f
+    map_mul' := fun x y => mapDomain_mul f x y }
+
+end MiscTheorems
+
+end AddMonoidAlgebra
+
+/-!
+#### Conversions between `AddMonoidAlgebra` and `MonoidAlgebra`
+
+We have not defined `k[G] = MonoidAlgebra k (Multiplicative G)`
+because historically this caused problems;
+since the changes that have made `nsmul` definitional, this would be possible,
+but for now we just construct the ring isomorphisms using `RingEquiv.refl _`.
+-/
+
+/-- The equivalence between `AddMonoidAlgebra` and `MonoidAlgebra` in terms of
+`Multiplicative` -/
+protected def AddMonoidAlgebra.toMultiplicative [Semiring k] [Add G] :
+    AddMonoidAlgebra k G ≃+* MonoidAlgebra k (Multiplicative G) :=
+  { Finsupp.domCongr
+      Multiplicative.ofAdd with
+    toFun := equivMapDomain Multiplicative.ofAdd
+    map_mul' := fun x y => by
+      -- Porting note: added `dsimp only`; `beta_reduce` alone is not sufficient
+      dsimp only
+      repeat' rw [equivMapDomain_eq_mapDomain (M := k)]
+      dsimp [Multiplicative.ofAdd]
+      exact MonoidAlgebra.mapDomain_mul (α := Multiplicative G) (β := k)
+        (MulHom.id (Multiplicative G)) x y }
+
+/-- The equivalence between `MonoidAlgebra` and `AddMonoidAlgebra` in terms of `Additive` -/
+protected def MonoidAlgebra.toAdditive [Semiring k] [Mul G] :
+    MonoidAlgebra k G ≃+* AddMonoidAlgebra k (Additive G) :=
+  { Finsupp.domCongr Additive.ofMul with
+    toFun := equivMapDomain Additive.ofMul
+    map_mul' := fun x y => by
+      -- Porting note: added `dsimp only`; `beta_reduce` alone is not sufficient
+      dsimp only
+      repeat' rw [equivMapDomain_eq_mapDomain (M := k)]
+      dsimp [Additive.ofMul]
+      convert MonoidAlgebra.mapDomain_mul (β := k) (MulHom.id G) x y }

--- a/Mathlib/Algebra/MonoidAlgebra/Module.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Module.lean
@@ -36,7 +36,6 @@ variable {k G}
 
 /-! #### Derived instances -/
 
-
 section DerivedInstances
 
 instance unique [Semiring k] [Subsingleton k] : Unique (MonoidAlgebra k G) :=
@@ -44,15 +43,9 @@ instance unique [Semiring k] [Subsingleton k] : Unique (MonoidAlgebra k G) :=
 
 variable {S : Type*}
 
-instance smulZeroClass [Semiring k] [SMulZeroClass R k] : SMulZeroClass R (MonoidAlgebra k G) :=
-  Finsupp.smulZeroClass
-
 instance noZeroSMulDivisors [Zero R] [Semiring k] [SMulZeroClass R k] [NoZeroSMulDivisors R k] :
     NoZeroSMulDivisors R (MonoidAlgebra k G) :=
   Finsupp.noZeroSMulDivisors
-
-instance distribSMul [Semiring k] [DistribSMul R k] : DistribSMul R (MonoidAlgebra k G) :=
-  Finsupp.distribSMul _ _
 
 instance distribMulAction [Monoid R] [Semiring k] [DistribMulAction R k] :
     DistribMulAction R (MonoidAlgebra k G) :=
@@ -64,18 +57,6 @@ instance module [Semiring R] [Semiring k] [Module R k] : Module R (MonoidAlgebra
 instance faithfulSMul [Semiring k] [SMulZeroClass R k] [FaithfulSMul R k] [Nonempty G] :
     FaithfulSMul R (MonoidAlgebra k G) :=
   Finsupp.faithfulSMul
-
-instance isScalarTower [Semiring k] [SMulZeroClass R k] [SMulZeroClass S k] [SMul R S]
-    [IsScalarTower R S k] : IsScalarTower R S (MonoidAlgebra k G) :=
-  Finsupp.isScalarTower G k
-
-instance smulCommClass [Semiring k] [SMulZeroClass R k] [SMulZeroClass S k] [SMulCommClass R S k] :
-    SMulCommClass R S (MonoidAlgebra k G) :=
-  Finsupp.smulCommClass G k
-
-instance isCentralScalar [Semiring k] [SMulZeroClass R k] [SMulZeroClass Rᵐᵒᵖ k]
-    [IsCentralScalar R k] : IsCentralScalar R (MonoidAlgebra k G) :=
-  Finsupp.isCentralScalar G k
 
 /-- This is not an instance as it conflicts with `MonoidAlgebra.distribMulAction` when `G = kˣ`.
 -/
@@ -242,15 +223,9 @@ instance unique [Semiring k] [Subsingleton k] : Unique k[G] :=
 
 variable {S : Type*}
 
-instance smulZeroClass [Semiring k] [SMulZeroClass R k] : SMulZeroClass R k[G] :=
-  Finsupp.smulZeroClass
-
 instance noZeroSMulDivisors [Zero R] [Semiring k] [SMulZeroClass R k] [NoZeroSMulDivisors R k] :
     NoZeroSMulDivisors R k[G] :=
   Finsupp.noZeroSMulDivisors
-
-instance distribSMul [Semiring k] [DistribSMul R k] : DistribSMul R k[G] :=
-  Finsupp.distribSMul G k
 
 instance distribMulAction [Monoid R] [Semiring k] [DistribMulAction R k] :
     DistribMulAction R k[G] :=
@@ -262,18 +237,6 @@ instance faithfulSMul [Semiring k] [SMulZeroClass R k] [FaithfulSMul R k] [Nonem
 
 instance module [Semiring R] [Semiring k] [Module R k] : Module R k[G] :=
   Finsupp.module G k
-
-instance isScalarTower [Semiring k] [SMulZeroClass R k] [SMulZeroClass S k] [SMul R S]
-    [IsScalarTower R S k] : IsScalarTower R S k[G] :=
-  Finsupp.isScalarTower G k
-
-instance smulCommClass [Semiring k] [SMulZeroClass R k] [SMulZeroClass S k] [SMulCommClass R S k] :
-    SMulCommClass R S k[G] :=
-  Finsupp.smulCommClass G k
-
-instance isCentralScalar [Semiring k] [SMulZeroClass R k] [SMulZeroClass Rᵐᵒᵖ k]
-    [IsCentralScalar R k] : IsCentralScalar R k[G] :=
-  Finsupp.isCentralScalar G k
 
 /-! It is hard to state the equivalent of `DistribMulAction G k[G]`
 because we've never discussed actions of additive groups. -/

--- a/Mathlib/Algebra/MonoidAlgebra/Module.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Module.lean
@@ -1,0 +1,374 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Yury Kudryashov, Kim Morrison
+-/
+import Mathlib.Algebra.Module.BigOperators
+import Mathlib.Algebra.Module.Submodule.Basic
+import Mathlib.Algebra.MonoidAlgebra.Lift
+import Mathlib.LinearAlgebra.Finsupp.LSum
+
+/-!
+# Module structure on monoid algebras
+
+## Main results
+* `MonoidAlgebra.module`, `AddMonoidAlgebra.module`: lift a module structure to monoid algebras
+-/
+
+assert_not_exists AlgEquiv
+assert_not_exists NonUnitalAlgHom
+
+noncomputable section
+
+open Finset
+
+open Finsupp hiding single
+
+universe u₁ u₂ u₃ u₄
+
+variable (k : Type u₁) (G : Type u₂) (H : Type*) {R : Type*}
+
+/-! ### Multiplicative monoids -/
+
+namespace MonoidAlgebra
+
+variable {k G}
+
+/-! #### Derived instances -/
+
+
+section DerivedInstances
+
+instance unique [Semiring k] [Subsingleton k] : Unique (MonoidAlgebra k G) :=
+  Finsupp.uniqueOfRight
+
+variable {S : Type*}
+
+instance smulZeroClass [Semiring k] [SMulZeroClass R k] : SMulZeroClass R (MonoidAlgebra k G) :=
+  Finsupp.smulZeroClass
+
+instance noZeroSMulDivisors [Zero R] [Semiring k] [SMulZeroClass R k] [NoZeroSMulDivisors R k] :
+    NoZeroSMulDivisors R (MonoidAlgebra k G) :=
+  Finsupp.noZeroSMulDivisors
+
+instance distribSMul [Semiring k] [DistribSMul R k] : DistribSMul R (MonoidAlgebra k G) :=
+  Finsupp.distribSMul _ _
+
+instance distribMulAction [Monoid R] [Semiring k] [DistribMulAction R k] :
+    DistribMulAction R (MonoidAlgebra k G) :=
+  Finsupp.distribMulAction G k
+
+instance module [Semiring R] [Semiring k] [Module R k] : Module R (MonoidAlgebra k G) :=
+  Finsupp.module G k
+
+instance faithfulSMul [Semiring k] [SMulZeroClass R k] [FaithfulSMul R k] [Nonempty G] :
+    FaithfulSMul R (MonoidAlgebra k G) :=
+  Finsupp.faithfulSMul
+
+instance isScalarTower [Semiring k] [SMulZeroClass R k] [SMulZeroClass S k] [SMul R S]
+    [IsScalarTower R S k] : IsScalarTower R S (MonoidAlgebra k G) :=
+  Finsupp.isScalarTower G k
+
+instance smulCommClass [Semiring k] [SMulZeroClass R k] [SMulZeroClass S k] [SMulCommClass R S k] :
+    SMulCommClass R S (MonoidAlgebra k G) :=
+  Finsupp.smulCommClass G k
+
+instance isCentralScalar [Semiring k] [SMulZeroClass R k] [SMulZeroClass Rᵐᵒᵖ k]
+    [IsCentralScalar R k] : IsCentralScalar R (MonoidAlgebra k G) :=
+  Finsupp.isCentralScalar G k
+
+/-- This is not an instance as it conflicts with `MonoidAlgebra.distribMulAction` when `G = kˣ`.
+-/
+def comapDistribMulActionSelf [Group G] [Semiring k] : DistribMulAction G (MonoidAlgebra k G) :=
+  Finsupp.comapDistribMulAction
+
+end DerivedInstances
+
+/-!
+#### Copies of `ext` lemmas and bundled `single`s from `Finsupp`
+
+As `MonoidAlgebra` is a type synonym, `ext` will not unfold it to find `ext` lemmas.
+We need bundled version of `Finsupp.single` with the right types to state these lemmas.
+It is good practice to have those, regardless of the `ext` issue.
+-/
+
+section ExtLemmas
+
+/-- A copy of `Finsupp.distribMulActionHom_ext'` for `MonoidAlgebra`. -/
+@[ext]
+theorem distribMulActionHom_ext' {N : Type*} [Monoid R] [Semiring k] [AddMonoid N]
+    [DistribMulAction R N] [DistribMulAction R k]
+    {f g : MonoidAlgebra k G →+[R] N}
+    (h : ∀ a : G,
+      f.comp (DistribMulActionHom.single (M := k) a) = g.comp (DistribMulActionHom.single a)) :
+    f = g :=
+  Finsupp.distribMulActionHom_ext' h
+
+/-- A copy of `Finsupp.lsingle` for `MonoidAlgebra`. -/
+abbrev lsingle [Semiring R] [Semiring k] [Module R k] (a : G) :
+    k →ₗ[R] MonoidAlgebra k G := Finsupp.lsingle a
+
+@[simp] lemma lsingle_apply [Semiring R] [Semiring k] [Module R k] (a : G) (b : k) :
+  lsingle (R := R) a b = single a b := rfl
+
+/-- A copy of `Finsupp.lhom_ext'` for `MonoidAlgebra`. -/
+@[ext high]
+lemma lhom_ext' {N : Type*} [Semiring R] [Semiring k] [AddCommMonoid N] [Module R N] [Module R k]
+    ⦃f g : MonoidAlgebra k G →ₗ[R] N⦄
+    (H : ∀ (x : G), LinearMap.comp f (lsingle x) = LinearMap.comp g (lsingle x)) :
+    f = g :=
+  Finsupp.lhom_ext' H
+
+end ExtLemmas
+
+section MiscTheorems
+
+variable [Semiring k]
+
+/-- Copy of `Finsupp.smul_single'` that avoids the `MonoidAlgebra = Finsupp` defeq abuse. -/
+@[simp]
+theorem smul_single' (c : k) (a : G) (b : k) : c • single a b = single a (c * b) :=
+  Finsupp.smul_single' c a b
+
+theorem smul_of [MulOneClass G] (g : G) (r : k) : r • of k G g = single g r := by
+  simp
+
+theorem liftNC_smul [MulOneClass G] {R : Type*} [Semiring R] (f : k →+* R) (g : G →* R) (c : k)
+    (φ : MonoidAlgebra k G) : liftNC (f : k →+ R) g (c • φ) = f c * liftNC (f : k →+ R) g φ := by
+  suffices (liftNC (↑f) g).comp (smulAddHom k (MonoidAlgebra k G) c) =
+      (AddMonoidHom.mulLeft (f c)).comp (liftNC (↑f) g) from
+    DFunLike.congr_fun this φ
+  ext
+  -- Porting note: `reducible` cannot be `local` so the proof gets more complex.
+  unfold MonoidAlgebra
+  simp only [AddMonoidHom.coe_comp, Function.comp_apply, singleAddHom_apply, smulAddHom_apply,
+    smul_single, smul_eq_mul, AddMonoidHom.coe_mulLeft, Finsupp.singleAddHom_apply]
+  -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
+  erw [liftNC_single, liftNC_single]; rw [AddMonoidHom.coe_coe, map_mul, mul_assoc]
+
+end MiscTheorems
+
+/-! #### Non-unital, non-associative algebra structure -/
+
+section NonUnitalNonAssocAlgebra
+
+variable (k) [Semiring k] [DistribSMul R k] [Mul G]
+
+instance isScalarTower_self [IsScalarTower R k k] :
+    IsScalarTower R (MonoidAlgebra k G) (MonoidAlgebra k G) where
+  smul_assoc t a b := by
+    ext
+    -- Porting note: `refine` & `rw` are required because `simp` behaves differently.
+    classical
+    simp only [smul_eq_mul, mul_apply]
+    rw [coe_smul]
+    refine Eq.trans (sum_smul_index' (g := a) (b := t) ?_) ?_ <;>
+      simp only [mul_apply, Finsupp.smul_sum, smul_ite, smul_mul_assoc,
+        zero_mul, ite_self, imp_true_iff, sum_zero, Pi.smul_apply, smul_zero]
+
+/-- Note that if `k` is a `CommSemiring` then we have `SMulCommClass k k k` and so we can take
+`R = k` in the below. In other words, if the coefficients are commutative amongst themselves, they
+also commute with the algebra multiplication. -/
+instance smulCommClass_self [SMulCommClass R k k] :
+    SMulCommClass R (MonoidAlgebra k G) (MonoidAlgebra k G) where
+  smul_comm t a b := by
+    ext
+    -- Porting note: `refine` & `rw` are required because `simp` behaves differently.
+    classical
+    simp only [smul_eq_mul, mul_apply]
+    rw [coe_smul]
+    refine Eq.symm (Eq.trans (congr_arg (sum a)
+      (funext₂ fun a₁ b₁ => sum_smul_index' (g := b) (b := t) ?_)) ?_) <;>
+    simp only [mul_apply, Finsupp.sum, Finset.smul_sum, smul_ite, mul_smul_comm,
+      imp_true_iff, ite_eq_right_iff, Pi.smul_apply, mul_zero, smul_zero]
+
+instance smulCommClass_symm_self [SMulCommClass k R k] :
+    SMulCommClass (MonoidAlgebra k G) R (MonoidAlgebra k G) :=
+  ⟨fun t a b => by
+    haveI := SMulCommClass.symm k R k
+    rw [← smul_comm]⟩
+
+end NonUnitalNonAssocAlgebra
+
+theorem induction_on [Semiring k] [Monoid G] {p : MonoidAlgebra k G → Prop} (f : MonoidAlgebra k G)
+    (hM : ∀ g, p (of k G g)) (hadd : ∀ f g : MonoidAlgebra k G, p f → p g → p (f + g))
+    (hsmul : ∀ (r : k) (f), p f → p (r • f)) : p f := by
+  refine Finsupp.induction_linear f ?_ (fun f g hf hg => hadd f g hf hg) fun g r => ?_
+  · simpa using hsmul 0 (of k G 1) (hM 1)
+  · convert hsmul r (of k G g) (hM g)
+    simp
+
+section Submodule
+
+variable [CommSemiring k] [Monoid G]
+variable {V : Type*} [AddCommMonoid V]
+variable [Module k V] [Module (MonoidAlgebra k G) V] [IsScalarTower k (MonoidAlgebra k G) V]
+
+/-- A submodule over `k` which is stable under scalar multiplication by elements of `G` is a
+submodule over `MonoidAlgebra k G`  -/
+def submoduleOfSMulMem (W : Submodule k V) (h : ∀ (g : G) (v : V), v ∈ W → of k G g • v ∈ W) :
+    Submodule (MonoidAlgebra k G) V where
+  carrier := W
+  zero_mem' := W.zero_mem'
+  add_mem' := W.add_mem'
+  smul_mem' := by
+    intro f v hv
+    rw [← Finsupp.sum_single f, Finsupp.sum, Finset.sum_smul]
+    simp_rw [← smul_of, smul_assoc]
+    exact Submodule.sum_smul_mem W _ fun g _ => h g v hv
+
+end Submodule
+
+end MonoidAlgebra
+
+/-! ### Additive monoids -/
+
+namespace AddMonoidAlgebra
+
+variable {k G}
+
+section Mul
+
+variable [Semiring k] [Add G] [Semiring R]
+
+end Mul
+
+/-! #### Derived instances -/
+
+section DerivedInstances
+
+instance unique [Semiring k] [Subsingleton k] : Unique k[G] :=
+  Finsupp.uniqueOfRight
+
+variable {S : Type*}
+
+instance smulZeroClass [Semiring k] [SMulZeroClass R k] : SMulZeroClass R k[G] :=
+  Finsupp.smulZeroClass
+
+instance noZeroSMulDivisors [Zero R] [Semiring k] [SMulZeroClass R k] [NoZeroSMulDivisors R k] :
+    NoZeroSMulDivisors R k[G] :=
+  Finsupp.noZeroSMulDivisors
+
+instance distribSMul [Semiring k] [DistribSMul R k] : DistribSMul R k[G] :=
+  Finsupp.distribSMul G k
+
+instance distribMulAction [Monoid R] [Semiring k] [DistribMulAction R k] :
+    DistribMulAction R k[G] :=
+  Finsupp.distribMulAction G k
+
+instance faithfulSMul [Semiring k] [SMulZeroClass R k] [FaithfulSMul R k] [Nonempty G] :
+    FaithfulSMul R k[G] :=
+  Finsupp.faithfulSMul
+
+instance module [Semiring R] [Semiring k] [Module R k] : Module R k[G] :=
+  Finsupp.module G k
+
+instance isScalarTower [Semiring k] [SMulZeroClass R k] [SMulZeroClass S k] [SMul R S]
+    [IsScalarTower R S k] : IsScalarTower R S k[G] :=
+  Finsupp.isScalarTower G k
+
+instance smulCommClass [Semiring k] [SMulZeroClass R k] [SMulZeroClass S k] [SMulCommClass R S k] :
+    SMulCommClass R S k[G] :=
+  Finsupp.smulCommClass G k
+
+instance isCentralScalar [Semiring k] [SMulZeroClass R k] [SMulZeroClass Rᵐᵒᵖ k]
+    [IsCentralScalar R k] : IsCentralScalar R k[G] :=
+  Finsupp.isCentralScalar G k
+
+/-! It is hard to state the equivalent of `DistribMulAction G k[G]`
+because we've never discussed actions of additive groups. -/
+
+end DerivedInstances
+
+/-!
+#### Copies of `ext` lemmas and bundled `single`s from `Finsupp`
+
+As `AddMonoidAlgebra` is a type synonym, `ext` will not unfold it to find `ext` lemmas.
+We need bundled version of `Finsupp.single` with the right types to state these lemmas.
+It is good practice to have those, regardless of the `ext` issue.
+-/
+
+section ExtLemmas
+
+/-- A copy of `Finsupp.distribMulActionHom_ext'` for `AddMonoidAlgebra`. -/
+@[ext]
+theorem distribMulActionHom_ext' {N : Type*} [Monoid R] [Semiring k] [AddMonoid N]
+    [DistribMulAction R N] [DistribMulAction R k]
+    {f g : AddMonoidAlgebra k G →+[R] N}
+    (h : ∀ a : G,
+      f.comp (DistribMulActionHom.single (M := k) a) = g.comp (DistribMulActionHom.single a)) :
+    f = g :=
+  Finsupp.distribMulActionHom_ext' h
+
+/-- A copy of `Finsupp.lsingle` for `AddMonoidAlgebra`. -/
+abbrev lsingle [Semiring R] [Semiring k] [Module R k] (a : G) :
+    k →ₗ[R] AddMonoidAlgebra k G := Finsupp.lsingle a
+
+@[simp] lemma lsingle_apply [Semiring R] [Semiring k] [Module R k] (a : G) (b : k) :
+  lsingle (R := R) a b = single a b := rfl
+
+/-- A copy of `Finsupp.lhom_ext'` for `AddMonoidAlgebra`. -/
+@[ext high]
+lemma lhom_ext' {N : Type*} [Semiring R] [Semiring k] [AddCommMonoid N] [Module R N] [Module R k]
+    ⦃f g : AddMonoidAlgebra k G →ₗ[R] N⦄
+    (H : ∀ (x : G), LinearMap.comp f (lsingle x) = LinearMap.comp g (lsingle x)) :
+    f = g :=
+  Finsupp.lhom_ext' H
+
+end ExtLemmas
+
+section MiscTheorems
+
+variable [Semiring k]
+
+/-- Copy of `Finsupp.smul_single'` that avoids the `AddMonoidAlgebra = Finsupp` defeq abuse. -/
+@[simp]
+theorem smul_single' (c : k) (a : G) (b : k) : c • single a b = single a (c * b) :=
+  Finsupp.smul_single' c a b
+
+theorem liftNC_smul {R : Type*} [AddZeroClass G] [Semiring R] (f : k →+* R)
+    (g : Multiplicative G →* R) (c : k) (φ : MonoidAlgebra k G) :
+    liftNC (f : k →+ R) g (c • φ) = f c * liftNC (f : k →+ R) g φ :=
+  @MonoidAlgebra.liftNC_smul k (Multiplicative G) _ _ _ _ f g c φ
+
+theorem induction_on [AddMonoid G] {p : k[G] → Prop} (f : k[G])
+    (hM : ∀ g, p (of k G (Multiplicative.ofAdd g)))
+    (hadd : ∀ f g : k[G], p f → p g → p (f + g))
+    (hsmul : ∀ (r : k) (f), p f → p (r • f)) : p f := by
+  refine Finsupp.induction_linear f ?_ (fun f g hf hg => hadd f g hf hg) fun g r => ?_
+  · simpa using hsmul 0 (of k G (Multiplicative.ofAdd 0)) (hM 0)
+  · convert hsmul r (of k G (Multiplicative.ofAdd g)) (hM g)
+    simp
+
+end MiscTheorems
+
+end AddMonoidAlgebra
+
+namespace AddMonoidAlgebra
+
+variable {k G H}
+
+/-! #### Non-unital, non-associative algebra structure -/
+
+section NonUnitalNonAssocAlgebra
+
+variable (k) [Semiring k] [DistribSMul R k] [Add G]
+
+instance isScalarTower_self [IsScalarTower R k k] :
+    IsScalarTower R k[G] k[G] :=
+  @MonoidAlgebra.isScalarTower_self k (Multiplicative G) R _ _ _ _
+
+/-- Note that if `k` is a `CommSemiring` then we have `SMulCommClass k k k` and so we can take
+`R = k` in the below. In other words, if the coefficients are commutative amongst themselves, they
+also commute with the algebra multiplication. -/
+instance smulCommClass_self [SMulCommClass R k k] :
+    SMulCommClass R k[G] k[G] :=
+  @MonoidAlgebra.smulCommClass_self k (Multiplicative G) R _ _ _ _
+
+instance smulCommClass_symm_self [SMulCommClass k R k] :
+    SMulCommClass k[G] R k[G] :=
+  @MonoidAlgebra.smulCommClass_symm_self k (Multiplicative G) R _ _ _ _
+
+end NonUnitalNonAssocAlgebra
+
+end AddMonoidAlgebra

--- a/Mathlib/Algebra/MonoidAlgebra/Opposite.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Opposite.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Yury Kudryashov, Kim Morrison
+-/
+import Mathlib.Algebra.Group.Hom.End
+import Mathlib.Algebra.MonoidAlgebra.Defs
+import Mathlib.Algebra.Ring.Opposite
+import Mathlib.Data.Finsupp.Basic
+
+/-!
+# Monoid algebras and the opposite ring
+-/
+
+assert_not_exists AlgEquiv
+assert_not_exists NonUnitalAlgHom
+
+noncomputable section
+
+variable {k G : Type*}
+
+/-! ### Multiplicative monoids -/
+
+namespace MonoidAlgebra
+
+section Opposite
+
+open Finsupp MulOpposite
+
+variable [Semiring k]
+
+/-- The opposite of a `MonoidAlgebra R I` equivalent as a ring to
+the `MonoidAlgebra Rᵐᵒᵖ Iᵐᵒᵖ` over the opposite ring, taking elements to their opposite. -/
+@[simps! (config := { simpRhs := true }) apply symm_apply]
+protected noncomputable def opRingEquiv [Monoid G] :
+    (MonoidAlgebra k G)ᵐᵒᵖ ≃+* MonoidAlgebra kᵐᵒᵖ Gᵐᵒᵖ :=
+  { opAddEquiv.symm.trans <|
+      (Finsupp.mapRange.addEquiv (opAddEquiv : k ≃+ kᵐᵒᵖ)).trans <| Finsupp.domCongr opEquiv with
+    map_mul' := by
+      -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
+      rw [Equiv.toFun_as_coe, AddEquiv.toEquiv_eq_coe]; erw [AddEquiv.coe_toEquiv]
+      rw [← AddEquiv.coe_toAddMonoidHom]
+      refine Iff.mpr (AddMonoidHom.map_mul_iff (R := (MonoidAlgebra k G)ᵐᵒᵖ)
+        (S := MonoidAlgebra kᵐᵒᵖ Gᵐᵒᵖ) _) ?_
+      ext
+      -- Porting note: `reducible` cannot be `local` so proof gets long.
+      simp only [AddMonoidHom.coe_comp, AddEquiv.coe_toAddMonoidHom, opAddEquiv_apply,
+        Function.comp_apply, singleAddHom_apply, AddMonoidHom.compr₂_apply, AddMonoidHom.coe_mul,
+        AddMonoidHom.coe_mulLeft, AddMonoidHom.compl₂_apply]
+      -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
+      erw [AddEquiv.trans_apply, AddEquiv.trans_apply, AddEquiv.trans_apply, AddEquiv.trans_apply,
+        AddEquiv.trans_apply, AddEquiv.trans_apply, MulOpposite.opAddEquiv_symm_apply]
+      rw [MulOpposite.unop_mul (α := MonoidAlgebra k G), unop_op, unop_op, single_mul_single]
+      simp }
+
+-- @[simp] -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10618): simp can prove this.
+-- More specifically, the LHS simplifies to `Finsupp.single`, which implies there's some
+-- defeq abuse going on.
+theorem opRingEquiv_single [Monoid G] (r : k) (x : G) :
+    MonoidAlgebra.opRingEquiv (op (single x r)) = single (op x) (op r) := by simp
+
+theorem opRingEquiv_symm_single [Monoid G] (r : kᵐᵒᵖ) (x : Gᵐᵒᵖ) :
+    MonoidAlgebra.opRingEquiv.symm (single x r) = op (single x.unop r.unop) := by simp
+
+end Opposite
+
+end MonoidAlgebra
+
+/-! ### Additive monoids -/
+
+namespace AddMonoidAlgebra
+
+section Opposite
+
+open Finsupp MulOpposite
+
+variable [Semiring k]
+
+/-- The opposite of an `R[I]` is ring equivalent to
+the `AddMonoidAlgebra Rᵐᵒᵖ I` over the opposite ring, taking elements to their opposite. -/
+@[simps! (config := { simpRhs := true }) apply symm_apply]
+protected noncomputable def opRingEquiv [AddCommMonoid G] :
+    k[G]ᵐᵒᵖ ≃+* kᵐᵒᵖ[G] :=
+  { MulOpposite.opAddEquiv.symm.trans
+      (Finsupp.mapRange.addEquiv (MulOpposite.opAddEquiv : k ≃+ kᵐᵒᵖ)) with
+    map_mul' := by
+      -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
+      rw [Equiv.toFun_as_coe, AddEquiv.toEquiv_eq_coe]; erw [AddEquiv.coe_toEquiv]
+      rw [← AddEquiv.coe_toAddMonoidHom]
+      refine Iff.mpr (AddMonoidHom.map_mul_iff (R := k[G]ᵐᵒᵖ) (S := kᵐᵒᵖ[G]) _) ?_
+      -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): Was `ext`.
+      refine AddMonoidHom.mul_op_ext _ _ <| addHom_ext' fun i₁ => AddMonoidHom.ext fun r₁ =>
+        AddMonoidHom.mul_op_ext _ _ <| addHom_ext' fun i₂ => AddMonoidHom.ext fun r₂ => ?_
+      -- Porting note: `reducible` cannot be `local` so proof gets long.
+      dsimp
+      -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
+      erw [AddEquiv.trans_apply, AddEquiv.trans_apply, AddEquiv.trans_apply,
+        MulOpposite.opAddEquiv_symm_apply]; rw [MulOpposite.unop_mul (α := k[G])]
+      dsimp
+      rw [mapRange_single, single_mul_single, mapRange_single, mapRange_single]
+      simp only [mapRange_single, single_mul_single, ← op_mul, add_comm] }
+
+-- @[simp] -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10618): simp can prove this.
+-- More specifically, the LHS simplifies to `Finsupp.single`, which implies there's some
+-- defeq abuse going on.
+theorem opRingEquiv_single [AddCommMonoid G] (r : k) (x : G) :
+    AddMonoidAlgebra.opRingEquiv (op (single x r)) = single x (op r) := by simp
+
+theorem opRingEquiv_symm_single [AddCommMonoid G] (r : kᵐᵒᵖ) (x : Gᵐᵒᵖ) :
+    AddMonoidAlgebra.opRingEquiv.symm (single x r) = op (single x r.unop) := by simp
+
+end Opposite
+
+end AddMonoidAlgebra

--- a/Mathlib/Algebra/MonoidAlgebra/Support.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Support.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
-import Mathlib.Algebra.MonoidAlgebra.Defs
+import Mathlib.Algebra.MonoidAlgebra.Module
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 import Mathlib.LinearAlgebra.Finsupp.Supported
 

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker
 -/
 import Mathlib.Algebra.GroupWithZero.Divisibility
-import Mathlib.Algebra.MonoidAlgebra.Defs
+import Mathlib.Algebra.MonoidAlgebra.Module
 import Mathlib.Algebra.Order.Monoid.Unbundled.WithTop
 import Mathlib.Data.Finset.Sort
 

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -565,6 +565,10 @@ unless `β i`'s addition is commutative. -/
 instance instNatSMul : SMul ℕ (α →₀ M) :=
   ⟨fun n v => v.mapRange (n • ·) (nsmul_zero _)⟩
 
+@[simp, norm_cast] lemma coe_nsmul (n : ℕ) (f : α →₀ M) : ⇑(n • f) = n • ⇑f := rfl
+
+lemma nsmul_apply (n : ℕ) (f : α →₀ M) (x : α) : (n • f) x = n • f x := rfl
+
 instance instAddMonoid : AddMonoid (α →₀ M) :=
   DFunLike.coe_injective.addMonoid _ coe_zero coe_add fun _ _ => rfl
 

--- a/Mathlib/RingTheory/Polynomial/Opposites.lean
+++ b/Mathlib/RingTheory/Polynomial/Opposites.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
+import Mathlib.Algebra.MonoidAlgebra.Opposite
 import Mathlib.Algebra.Polynomial.Degree.Support
 
 /-!  #  Interactions between `R[X]` and `Rᵐᵒᵖ[X]`


### PR DESCRIPTION
This PR further splits the big file `MonoidAlgebra/Defs.lean` to focus on the ring structure on (`Add`)`MonoidAlgebra`. The following files have been split off:
 * `MonoidAlgebra/Lift.lean`: definition of `liftNC`
 * `MonoidAlgebra/MapDomain.lean`: definition of `mapDomain`
 * `MonoidAlgebra/Module.lean`: module structure (and some submodule results)
 * `MonoidAlgebra/Opposite.lean`: results on the `MulOpposite` ring structure

I also changed one proof about scalar multiplication by natural numbers, so that it wouldn't need a full on module structure on `Finsupp`. This required adding a pair of lemmas on the definition of multiplying `Finsupp`s by natural numbers.

---

- [x] depends on: #19087
- [x] depends on: #19205

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
