### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Matching): add `IsPerfectMatching.toSubgraph_spanningCoe_iff`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -204,7 +204,7 @@ lemma IsPerfectMatching.induce_connectedComponent_isMatching (h : M.IsPerfectMat
   simpa [h.2.verts_eq_univ] using h.1.induce_connectedComponent c
 
 @[simp]
-lemma IsPerfectMatching.toSubgraph_spanningCoe_iff {M : Subgraph G} (h : M.spanningCoe ≤ G') :
+lemma IsPerfectMatching.toSubgraph_spanningCoe_iff (h : M.spanningCoe ≤ G') :
     (G'.toSubgraph M.spanningCoe h).IsPerfectMatching ↔ M.IsPerfectMatching := by
   constructor
   · intro ⟨hmatch, hspan⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -206,16 +206,7 @@ lemma IsPerfectMatching.induce_connectedComponent_isMatching (h : M.IsPerfectMat
 @[simp]
 lemma IsPerfectMatching.toSubgraph_spanningCoe_iff (h : M.spanningCoe ≤ G') :
     (G'.toSubgraph M.spanningCoe h).IsPerfectMatching ↔ M.IsPerfectMatching := by
-  constructor
-  · intro ⟨hmatch, hspan⟩
-    rw [isPerfectMatching_iff]
-    intro v
-    simpa [toSubgraph_adj, spanningCoe_adj] using
-      (hmatch (by simp only [toSubgraph_verts, Set.mem_univ]))
-  · intro hM
-    refine ⟨?_, fun v ↦ by simp⟩
-    intro v _
-    simpa [Subgraph.IsSpanning.verts_eq_univ hM.2, Set.mem_univ] using hM.1 (hM.2 v)
+  simp only [isPerfectMatching_iff, toSubgraph_adj, spanningCoe_adj]
 
 end Subgraph
 

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -203,6 +203,20 @@ lemma IsPerfectMatching.induce_connectedComponent_isMatching (h : M.IsPerfectMat
     (c : ConnectedComponent G) : (M.induce c.supp).IsMatching := by
   simpa [h.2.verts_eq_univ] using h.1.induce_connectedComponent c
 
+@[simp]
+lemma IsPerfectMatching.toSubgraph_spanningCoe_iff {M : Subgraph G} (h : M.spanningCoe ≤ G') :
+    (G'.toSubgraph M.spanningCoe h).IsPerfectMatching ↔ M.IsPerfectMatching := by
+  constructor
+  · intro ⟨hmatch, hspan⟩
+    rw [isPerfectMatching_iff]
+    intro v
+    simpa [toSubgraph_adj, spanningCoe_adj] using
+      (hmatch (by simp only [toSubgraph_verts, Set.mem_univ]))
+  · intro hM
+    refine ⟨?_, fun v ↦ by simp⟩
+    intro v _
+    simpa [Subgraph.IsSpanning.verts_eq_univ hM.2, Set.mem_univ] using hM.1 (hM.2 v)
+
 end Subgraph
 
 namespace ConnectedComponent


### PR DESCRIPTION
Just a small lemma about perfect matchings and `spanningCoe`.
In preparation for Tutte's theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Zulip thread on Tutte's theorem](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Tutte's.20theorem)