### PR TITLE
[Merged by Bors] - refactor(Algebra/Polynomial/Basic): define nsmul/zsmul for Polynomial

### DIFF
--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -127,6 +127,9 @@ instance mul' : Mul R[X] :=
 @[simp] theorem add_eq_add : add p q = p + q := rfl
 @[simp] theorem mul_eq_mul : mul p q = p * q := rfl
 
+instance instNSMul : SMul ℕ R[X] where
+  smul r p := ⟨r • p.toFinsupp⟩
+
 instance smulZeroClass {S : Type*} [SMulZeroClass S R] : SMulZeroClass S R[X] where
   smul r p := ⟨r • p.toFinsupp⟩
   smul_zero a := congr_arg ofFinsupp (smul_zero a)
@@ -158,6 +161,11 @@ theorem ofFinsupp_sub {R : Type u} [Ring R] {a b} : (⟨a - b⟩ : R[X]) = ⟨a�
 @[simp]
 theorem ofFinsupp_mul (a b) : (⟨a * b⟩ : R[X]) = ⟨a⟩ * ⟨b⟩ :=
   show _ = mul _ _ by rw [mul_def]
+
+@[simp]
+theorem ofFinsupp_nsmul (a : ℕ) (b) :
+    (⟨a • b⟩ : R[X]) = (a • ⟨b⟩ : R[X]) :=
+  rfl
 
 @[simp]
 theorem ofFinsupp_smul {S : Type*} [SMulZeroClass S R] (a : S) (b) :
@@ -201,6 +209,11 @@ theorem toFinsupp_mul (a b : R[X]) : (a * b).toFinsupp = a.toFinsupp * b.toFinsu
   cases a
   cases b
   rw [← ofFinsupp_mul]
+
+@[simp]
+theorem toFinsupp_nsmul (a : ℕ) (b : R[X]) :
+    (a • b).toFinsupp = a • b.toFinsupp :=
+  rfl
 
 @[simp]
 theorem toFinsupp_smul {S : Type*} [SMulZeroClass S R] (a : S) (b : R[X]) :
@@ -250,7 +263,7 @@ instance instNatCast : NatCast R[X] where natCast n := ofFinsupp n
 instance semiring : Semiring R[X] :=
   --TODO: add reference to library note in PR https://github.com/leanprover-community/mathlib4/pull/7432
   { Function.Injective.semiring toFinsupp toFinsupp_injective toFinsupp_zero toFinsupp_one
-      toFinsupp_add toFinsupp_mul (fun _ _ => toFinsupp_smul _ _) toFinsupp_pow fun _ => rfl with
+      toFinsupp_add toFinsupp_mul (fun _ _ => toFinsupp_nsmul _ _) toFinsupp_pow fun _ => rfl with
     toAdd := Polynomial.add'
     toMul := Polynomial.mul'
     toZero := Polynomial.zero
@@ -1031,14 +1044,27 @@ section Ring
 
 variable [Ring R]
 
+instance instZSMul : SMul ℤ R[X] where
+  smul r p := ⟨r • p.toFinsupp⟩
+
+@[simp]
+theorem ofFinsupp_zsmul (a : ℤ) (b) :
+    (⟨a • b⟩ : R[X]) = (a • ⟨b⟩ : R[X]) :=
+  rfl
+
+@[simp]
+theorem toFinsupp_zsmul (a : ℤ) (b : R[X]) :
+    (a • b).toFinsupp = a • b.toFinsupp :=
+  rfl
+
 instance instIntCast : IntCast R[X] where intCast n := ofFinsupp n
 
 instance ring : Ring R[X] :=
   --TODO: add reference to library note in PR https://github.com/leanprover-community/mathlib4/pull/7432
   { Function.Injective.ring toFinsupp toFinsupp_injective (toFinsupp_zero (R := R))
       toFinsupp_one toFinsupp_add
-      toFinsupp_mul toFinsupp_neg toFinsupp_sub (fun _ _ => toFinsupp_smul _ _)
-      (fun _ _ => toFinsupp_smul _ _) toFinsupp_pow (fun _ => rfl) fun _ => rfl with
+      toFinsupp_mul toFinsupp_neg toFinsupp_sub (fun _ _ => toFinsupp_nsmul _ _)
+      (fun _ _ => toFinsupp_zsmul _ _) toFinsupp_pow (fun _ => rfl) fun _ => rfl with
     toSemiring := Polynomial.semiring,
     toNeg := Polynomial.neg'
     toSub := Polynomial.sub


### PR DESCRIPTION
The goal of this PR is to make the ring instances on `Polynomial` independent of the module structure. This is currently somewhat useless and will only be useful in an upcoming PR that splits this entire file `Polynomial/Basic.lean`. But since adding definitions while splitting files is very annoying to review, let's do it in multiple steps.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
