### PR TITLE
[Merged by Bors] - chore: don't use `TopologicalGroup.toUniformSpace` in `tendstoUniformly_iff`

### DIFF
--- a/Mathlib/Topology/Algebra/UniformGroup/Basic.lean
+++ b/Mathlib/Topology/Algebra/UniformGroup/Basic.lean
@@ -207,41 +207,47 @@ lemma MonoidHom.tendsto_coe_cofinite_of_discrete [T2Space G] {H : Type*} [Group 
   replace hf : Function.Injective f.rangeRestrict := by simpa
   exact f.range.tendsto_coe_cofinite_of_discrete.comp hf.tendsto_cofinite
 
-@[to_additive]
-theorem TopologicalGroup.tendstoUniformly_iff {ι α : Type*} (F : ι → α → G) (f : α → G)
-    (p : Filter ι) :
-    @TendstoUniformly α G ι (TopologicalGroup.toUniformSpace G) F f p ↔
-      ∀ u ∈ 𝓝 (1 : G), ∀ᶠ i in p, ∀ a, F i a / f a ∈ u :=
-  ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩, fun h _ ⟨u, hu, hv⟩ =>
-    mem_of_superset (h u hu) fun _ hi a => hv (hi a)⟩
+end TopologicalGroup
+
+namespace UniformGroup
+
+variable {ι α G : Type*} [Group G] [UniformSpace G] [UniformGroup G]
 
 @[to_additive]
-theorem TopologicalGroup.tendstoUniformlyOn_iff {ι α : Type*} (F : ι → α → G) (f : α → G)
-    (p : Filter ι) (s : Set α) :
-    @TendstoUniformlyOn α G ι (TopologicalGroup.toUniformSpace G) F f p s ↔
-      ∀ u ∈ 𝓝 (1 : G), ∀ᶠ i in p, ∀ a ∈ s, F i a / f a ∈ u :=
-  ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩, fun h _ ⟨u, hu, hv⟩ =>
-    mem_of_superset (h u hu) fun _ hi a ha => hv (hi a ha)⟩
+theorem tendstoUniformly_iff (F : ι → α → G) (f : α → G) (p : Filter ι) :
+    TendstoUniformly F f p ↔ ∀ u ∈ 𝓝 (1 : G), ∀ᶠ i in p, ∀ a, F i a / f a ∈ u :=
+  toUniformSpace_eq (G := G) ▸
+    ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩,
+      fun h _ ⟨u, hu, hv⟩ => mem_of_superset (h u hu) fun _ hi a => hv (hi a)⟩
 
 @[to_additive]
-theorem TopologicalGroup.tendstoLocallyUniformly_iff {ι α : Type*} [TopologicalSpace α]
+theorem tendstoUniformlyOn_iff (F : ι → α → G) (f : α → G) (p : Filter ι) (s : Set α) :
+    TendstoUniformlyOn F f p s ↔ ∀ u ∈ 𝓝 (1 : G), ∀ᶠ i in p, ∀ a ∈ s, F i a / f a ∈ u :=
+  toUniformSpace_eq (G := G) ▸
+    ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩,
+      fun h _ ⟨u, hu, hv⟩ => mem_of_superset (h u hu) fun _ hi a ha => hv (hi a ha)⟩
+
+@[to_additive]
+theorem tendstoLocallyUniformly_iff [TopologicalSpace α]
     (F : ι → α → G) (f : α → G) (p : Filter ι) :
-    @TendstoLocallyUniformly α G ι (TopologicalGroup.toUniformSpace G) _ F f p ↔
+    TendstoLocallyUniformly F f p ↔
       ∀ u ∈ 𝓝 (1 : G), ∀ (x : α), ∃ t ∈ 𝓝 x, ∀ᶠ i in p, ∀ a ∈ t, F i a / f a ∈ u :=
+  toUniformSpace_eq (G := G) ▸
     ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩, fun h _ ⟨u, hu, hv⟩ x =>
       Exists.imp (fun _ ⟨h, hp⟩ => ⟨h, mem_of_superset hp fun _ hi a ha => hv (hi a ha)⟩)
         (h u hu x)⟩
 
 @[to_additive]
-theorem TopologicalGroup.tendstoLocallyUniformlyOn_iff {ι α : Type*} [TopologicalSpace α]
+theorem tendstoLocallyUniformlyOn_iff [TopologicalSpace α]
     (F : ι → α → G) (f : α → G) (p : Filter ι) (s : Set α) :
-    @TendstoLocallyUniformlyOn α G ι (TopologicalGroup.toUniformSpace G) _ F f p s ↔
+    TendstoLocallyUniformlyOn F f p s ↔
       ∀ u ∈ 𝓝 (1 : G), ∀ x ∈ s, ∃ t ∈ 𝓝[s] x, ∀ᶠ i in p, ∀ a ∈ t, F i a / f a ∈ u :=
-  ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩, fun h _ ⟨u, hu, hv⟩ x =>
-    (Exists.imp fun _ ⟨h, hp⟩ => ⟨h, mem_of_superset hp fun _ hi a ha => hv (hi a ha)⟩) ∘
-      h u hu x⟩
+  toUniformSpace_eq (G := G) ▸
+    ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩, fun h _ ⟨u, hu, hv⟩ x =>
+      (Exists.imp fun _ ⟨h, hp⟩ => ⟨h, mem_of_superset hp fun _ hi a ha => hv (hi a ha)⟩) ∘
+        h u hu x⟩
 
-end TopologicalGroup
+end UniformGroup
 
 open Filter Set Function
 

--- a/Mathlib/Topology/Algebra/UniformGroup/Basic.lean
+++ b/Mathlib/Topology/Algebra/UniformGroup/Basic.lean
@@ -209,45 +209,43 @@ lemma MonoidHom.tendsto_coe_cofinite_of_discrete [T2Space G] {H : Type*} [Group 
 
 end TopologicalGroup
 
-namespace UniformGroup
+namespace TopologicalGroup
 
-variable {ι α G : Type*} [Group G] [UniformSpace G] [UniformGroup G]
+variable {ι α G : Type*} [Group G] [u : UniformSpace G] [TopologicalGroup G]
 
 @[to_additive]
-theorem tendstoUniformly_iff (F : ι → α → G) (f : α → G) (p : Filter ι) :
+theorem tendstoUniformly_iff (F : ι → α → G) (f : α → G) (p : Filter ι)
+    (hu : TopologicalGroup.toUniformSpace G = u) :
     TendstoUniformly F f p ↔ ∀ u ∈ 𝓝 (1 : G), ∀ᶠ i in p, ∀ a, F i a / f a ∈ u :=
-  toUniformSpace_eq (G := G) ▸
-    ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩,
-      fun h _ ⟨u, hu, hv⟩ => mem_of_superset (h u hu) fun _ hi a => hv (hi a)⟩
+  hu ▸ ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩,
+    fun h _ ⟨u, hu, hv⟩ => mem_of_superset (h u hu) fun _ hi a => hv (hi a)⟩
 
 @[to_additive]
-theorem tendstoUniformlyOn_iff (F : ι → α → G) (f : α → G) (p : Filter ι) (s : Set α) :
+theorem tendstoUniformlyOn_iff (F : ι → α → G) (f : α → G) (p : Filter ι) (s : Set α)
+    (hu : TopologicalGroup.toUniformSpace G = u) :
     TendstoUniformlyOn F f p s ↔ ∀ u ∈ 𝓝 (1 : G), ∀ᶠ i in p, ∀ a ∈ s, F i a / f a ∈ u :=
-  toUniformSpace_eq (G := G) ▸
-    ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩,
-      fun h _ ⟨u, hu, hv⟩ => mem_of_superset (h u hu) fun _ hi a ha => hv (hi a ha)⟩
+  hu ▸ ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩,
+    fun h _ ⟨u, hu, hv⟩ => mem_of_superset (h u hu) fun _ hi a ha => hv (hi a ha)⟩
 
 @[to_additive]
-theorem tendstoLocallyUniformly_iff [TopologicalSpace α]
-    (F : ι → α → G) (f : α → G) (p : Filter ι) :
+theorem tendstoLocallyUniformly_iff [TopologicalSpace α] (F : ι → α → G) (f : α → G)
+    (p : Filter ι) (hu : TopologicalGroup.toUniformSpace G = u) :
     TendstoLocallyUniformly F f p ↔
       ∀ u ∈ 𝓝 (1 : G), ∀ (x : α), ∃ t ∈ 𝓝 x, ∀ᶠ i in p, ∀ a ∈ t, F i a / f a ∈ u :=
-  toUniformSpace_eq (G := G) ▸
-    ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩, fun h _ ⟨u, hu, hv⟩ x =>
-      Exists.imp (fun _ ⟨h, hp⟩ => ⟨h, mem_of_superset hp fun _ hi a ha => hv (hi a ha)⟩)
-        (h u hu x)⟩
+  hu ▸ ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩, fun h _ ⟨u, hu, hv⟩ x =>
+    Exists.imp (fun _ ⟨h, hp⟩ => ⟨h, mem_of_superset hp fun _ hi a ha => hv (hi a ha)⟩)
+      (h u hu x)⟩
 
 @[to_additive]
-theorem tendstoLocallyUniformlyOn_iff [TopologicalSpace α]
-    (F : ι → α → G) (f : α → G) (p : Filter ι) (s : Set α) :
+theorem tendstoLocallyUniformlyOn_iff [TopologicalSpace α] (F : ι → α → G) (f : α → G)
+    (p : Filter ι) (s : Set α) (hu : TopologicalGroup.toUniformSpace G = u) :
     TendstoLocallyUniformlyOn F f p s ↔
       ∀ u ∈ 𝓝 (1 : G), ∀ x ∈ s, ∃ t ∈ 𝓝[s] x, ∀ᶠ i in p, ∀ a ∈ t, F i a / f a ∈ u :=
-  toUniformSpace_eq (G := G) ▸
-    ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩, fun h _ ⟨u, hu, hv⟩ x =>
-      (Exists.imp fun _ ⟨h, hp⟩ => ⟨h, mem_of_superset hp fun _ hi a ha => hv (hi a ha)⟩) ∘
-        h u hu x⟩
+  hu ▸ ⟨fun h u hu => h _ ⟨u, hu, fun _ => id⟩, fun h _ ⟨u, hu, hv⟩ x =>
+    (Exists.imp fun _ ⟨h, hp⟩ => ⟨h, mem_of_superset hp fun _ hi a ha => hv (hi a ha)⟩) ∘
+      h u hu x⟩
 
-end UniformGroup
+end TopologicalGroup
 
 open Filter Set Function
 


### PR DESCRIPTION
This changes `TopologicalGroup.tendstoUniformly_iff` so that it takes a `UniformSpace` instance instead of only a `TopologicalGroup` instance, along with a proof that the uniform space is the one induced by the topological group structure. The previous version would have been hard to use in case you had, for example, a normed commutative group, as the uniform space structure inferred would not match (defeq) the one given in this theorem, which was previously `TopologicalSpace.toUniformSpace`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
