### PR TITLE
[Merged by Bors] - feat: `norm_num` extension for `Rat.num` and `Rat.den`

### DIFF
--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -210,6 +210,53 @@ def evalIntLCM : NormNumExt where eval {u α} e := do
   let ⟨ed, pf⟩ := proveIntLCM ex ey
   return .isNat _ ed q(isInt_lcm $p $q $pf)
 
+
+theorem isInt_ratNum : ∀ {q : ℚ} {n : ℤ} {d : ℕ} {g : ℕ} {n' : ℤ},
+   IsRat q n d → Int.gcd n (Int.ofNat d) = g → IsInt (n / g) n' → IsInt q.num n'
+  | _, num, denom, g, _, ⟨hi, rfl⟩, hg, ⟨h'⟩ => by
+    subst g
+    have : 0 < denom := Nat.pos_iff_ne_zero.mpr <| by simpa using hi.ne_zero
+    constructor
+    simp_rw [Rat.mul_num, Rat.intCast_den, invOf_eq_inv,
+      Rat.inv_natCast_den_of_pos this, Rat.inv_natCast_num_of_pos this,
+      Rat.intCast_num, one_mul, mul_one]
+    rwa [Int.gcd, Int.ofNat_eq_natCast, Int.natAbs_ofNat] at h'
+
+theorem isNat_ratDen : ∀ {q : ℚ} {n : ℤ} {d : ℕ} {g : ℕ} {d' : ℕ},
+   IsRat q n d → Int.gcd n (Int.ofNat d) = g → IsNat (d / g) d' → IsNat q.den d'
+  | _, num, denom, g, _, ⟨hi, rfl⟩, hg, ⟨h'⟩ => by
+    subst g
+    have : 0 < denom := Nat.pos_iff_ne_zero.mpr <| by simpa using hi.ne_zero
+    constructor
+    simp_rw [Rat.mul_den, Rat.intCast_den, invOf_eq_inv,
+      Rat.inv_natCast_den_of_pos this, Rat.inv_natCast_num_of_pos this,
+      Rat.intCast_num, one_mul, mul_one, Nat.cast_id]
+    rwa [Int.gcd, Int.ofNat_eq_natCast, Int.natAbs_ofNat] at h'
+
+@[norm_num Rat.num _]
+def evalRatNum : NormNumExt where eval {u α} e := do
+  let .proj _ _ (q : Q(ℚ)) ← Meta.whnfR e | failure
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℤ := ⟨⟩
+  have : $e =Q Rat.num $q := ⟨⟩
+  let _ : Q(DivisionRing ℚ) := q(inferInstance)
+  let ⟨q', n, d, eq⟩ ← deriveRat q
+  let eq : Q(IsRat $q $n $d) := eq
+  let ⟨gcd, pf⟩ := proveIntGCD q($n) q(Int.ofNat $d)
+  let ⟨lit, plit⟩ ← deriveInt q($n / $gcd) _
+  return .isInt _ lit q'.num q(isInt_ratNum $eq $pf $plit)
+
+@[norm_num Rat.den _]
+def evalRatDen : NormNumExt where eval {u α} e := do
+  let .proj _ _ (q : Q(ℚ)) ← Meta.whnfR e | failure
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩
+  have : $e =Q Rat.den $q := ⟨⟩
+  let _ : Q(DivisionRing ℚ) := q(inferInstance)
+  let ⟨q', n, d, eq⟩ ← deriveRat q
+  let eq : Q(IsRat $q $n $d) := eq
+  let ⟨gcd, pf⟩ := proveIntGCD q($n) q(Int.ofNat $d)
+  let ⟨lit, plit⟩ ← deriveNat q($d / $gcd) _
+  return .isNat _ lit q(isNat_ratDen $eq $pf $plit)
+
 end NormNum
 
 end Tactic

--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -212,27 +212,26 @@ def evalIntLCM : NormNumExt where eval {u α} e := do
 
 
 theorem isInt_ratNum : ∀ {q : ℚ} {n : ℤ} {d : ℕ} {g : ℕ} {n' : ℤ},
-   IsRat q n d → Int.gcd n (Int.ofNat d) = g → IsInt (n / g) n' → IsInt q.num n'
-  | _, num, denom, g, _, ⟨hi, rfl⟩, hg, ⟨h'⟩ => by
-    subst g
-    have : 0 < denom := Nat.pos_iff_ne_zero.mpr <| by simpa using hi.ne_zero
+    IsRat q n d → Int.gcd n (Int.ofNat d) = g → IsInt (n / g) n' → IsInt q.num n'
+  | _, num, denom, _, _, ⟨hi, rfl⟩, rfl, ⟨h'⟩ => by
     constructor
+    have : 0 < denom := Nat.pos_iff_ne_zero.mpr <| by simpa using hi.ne_zero
     simp_rw [Rat.mul_num, Rat.intCast_den, invOf_eq_inv,
       Rat.inv_natCast_den_of_pos this, Rat.inv_natCast_num_of_pos this,
       Rat.intCast_num, one_mul, mul_one]
     rwa [Int.gcd, Int.ofNat_eq_natCast, Int.natAbs_ofNat] at h'
 
 theorem isNat_ratDen : ∀ {q : ℚ} {n : ℤ} {d : ℕ} {g : ℕ} {d' : ℕ},
-   IsRat q n d → Int.gcd n (Int.ofNat d) = g → IsNat (d / g) d' → IsNat q.den d'
-  | _, num, denom, g, _, ⟨hi, rfl⟩, hg, ⟨h'⟩ => by
-    subst g
-    have : 0 < denom := Nat.pos_iff_ne_zero.mpr <| by simpa using hi.ne_zero
+    IsRat q n d → Int.gcd n (Int.ofNat d) = g → IsNat (d / g) d' → IsNat q.den d'
+  | _, num, denom, _, _, ⟨hi, rfl⟩, rfl, ⟨h'⟩ => by
     constructor
+    have : 0 < denom := Nat.pos_iff_ne_zero.mpr <| by simpa using hi.ne_zero
     simp_rw [Rat.mul_den, Rat.intCast_den, invOf_eq_inv,
       Rat.inv_natCast_den_of_pos this, Rat.inv_natCast_num_of_pos this,
       Rat.intCast_num, one_mul, mul_one, Nat.cast_id]
     rwa [Int.gcd, Int.ofNat_eq_natCast, Int.natAbs_ofNat] at h'
 
+/-- Evaluates the `Rat.num` function. -/
 @[norm_num Rat.num _]
 def evalRatNum : NormNumExt where eval {u α} e := do
   let .proj _ _ (q : Q(ℚ)) ← Meta.whnfR e | failure
@@ -247,6 +246,7 @@ def evalRatNum : NormNumExt where eval {u α} e := do
   let plit : Q(IsInt ($n / $gcd) $lit) := q(.raw_refl $lit)
   return .isInt _ lit q'.num q(isInt_ratNum $eq $pf $plit)
 
+/-- Evaluates the `Rat.den` function. -/
 @[norm_num Rat.den _]
 def evalRatDen : NormNumExt where eval {u α} e := do
   let .proj _ _ (q : Q(ℚ)) ← Meta.whnfR e | failure

--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -242,7 +242,9 @@ def evalRatNum : NormNumExt where eval {u α} e := do
   let ⟨q', n, d, eq⟩ ← deriveRat q
   let eq : Q(IsRat $q $n $d) := eq
   let ⟨gcd, pf⟩ := proveIntGCD q($n) q(Int.ofNat $d)
-  let ⟨lit, plit⟩ ← deriveInt q($n / $gcd) _
+  have lit : Q(ℤ) := mkRawIntLit q'.num
+  have : ($n / $gcd) =Q $lit := ⟨⟩
+  let plit : Q(IsInt ($n / $gcd) $lit) := q(.raw_refl $lit)
   return .isInt _ lit q'.num q(isInt_ratNum $eq $pf $plit)
 
 @[norm_num Rat.den _]
@@ -253,8 +255,10 @@ def evalRatDen : NormNumExt where eval {u α} e := do
   let _ : Q(DivisionRing ℚ) := q(inferInstance)
   let ⟨q', n, d, eq⟩ ← deriveRat q
   let eq : Q(IsRat $q $n $d) := eq
-  let ⟨gcd, pf⟩ := proveIntGCD q($n) q(Int.ofNat $d)
-  let ⟨lit, plit⟩ ← deriveNat q($d / $gcd) _
+  have ⟨gcd, pf⟩ := proveIntGCD q($n) q(Int.ofNat $d)
+  have lit : Q(ℕ) := mkRawNatLit q'.den
+  have : ($d / $gcd) =Q $lit := ⟨⟩
+  let plit : Q(IsNat ($d / $gcd) $lit) := q(.raw_refl $lit)
   return .isNat _ lit q(isNat_ratDen $eq $pf $plit)
 
 end NormNum

--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -232,7 +232,7 @@ theorem isNat_ratDen : ∀ {q : ℚ} {n : ℤ} {d : ℕ} {g : ℕ} {d' : ℕ},
     rwa [Int.gcd, Int.ofNat_eq_natCast, Int.natAbs_ofNat] at h'
 
 /-- Evaluates the `Rat.num` function. -/
-@[norm_num Rat.num _]
+@[nolint unusedHavesSuffices, norm_num Rat.num _]
 def evalRatNum : NormNumExt where eval {u α} e := do
   let .proj _ _ (q : Q(ℚ)) ← Meta.whnfR e | failure
   have : u =QL 0 := ⟨⟩; have : $α =Q ℤ := ⟨⟩
@@ -247,7 +247,7 @@ def evalRatNum : NormNumExt where eval {u α} e := do
   return .isInt _ lit q'.num q(isInt_ratNum $eq $pf $plit)
 
 /-- Evaluates the `Rat.den` function. -/
-@[norm_num Rat.den _]
+@[nolint unusedHavesSuffices, norm_num Rat.den _]
 def evalRatDen : NormNumExt where eval {u α} e := do
   let .proj _ _ (q : Q(ℚ)) ← Meta.whnfR e | failure
   have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩

--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro, Kyle Miller
+Authors: Mario Carneiro, Kyle Miller, Eric Wieser
 -/
 import Mathlib.Data.Int.GCD
 import Mathlib.Tactic.NormNum

--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -211,7 +211,7 @@ def evalIntLCM : NormNumExt where eval {u α} e := do
   return .isNat _ ed q(isInt_lcm $p $q $pf)
 
 theorem isInt_ratNum : ∀ {q : ℚ} {n : ℤ} {n' : ℕ} {d : ℕ},
-    IsRat q n d → n.natAbs = n' → n'.Coprime d → IsInt q.num n
+    IsRat q n d → n.natAbs = n' → n'.gcd d = 1 → IsInt q.num n
   | _, n, _, d, ⟨hi, rfl⟩, rfl, h => by
     constructor
     have : 0 < d := Nat.pos_iff_ne_zero.mpr <| by simpa using hi.ne_zero
@@ -220,7 +220,7 @@ theorem isInt_ratNum : ∀ {q : ℚ} {n : ℤ} {n' : ℕ} {d : ℕ},
       Rat.intCast_num, one_mul, mul_one, h, Nat.cast_one, Int.ediv_one, Int.cast_id]
 
 theorem isNat_ratDen : ∀ {q : ℚ} {n : ℤ} {n' : ℕ} {d : ℕ},
-    IsRat q n d → n.natAbs = n' → n'.Coprime d → IsNat q.den d
+    IsRat q n d → n.natAbs = n' → n'.gcd d = 1 → IsNat q.den d
   | _, n, _, d, ⟨hi, rfl⟩, rfl, h => by
     constructor
     have : 0 < d := Nat.pos_iff_ne_zero.mpr <| by simpa using hi.ne_zero

--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -210,7 +210,6 @@ def evalIntLCM : NormNumExt where eval {u α} e := do
   let ⟨ed, pf⟩ := proveIntLCM ex ey
   return .isNat _ ed q(isInt_lcm $p $q $pf)
 
-
 theorem isInt_ratNum : ∀ {q : ℚ} {n : ℤ} {n' : ℕ} {d : ℕ},
     IsRat q n d → n.natAbs = n' → n'.Coprime d → IsInt q.num n
   | _, n, _, d, ⟨hi, rfl⟩, rfl, h => by

--- a/MathlibTest/norm_num_ext.lean
+++ b/MathlibTest/norm_num_ext.lean
@@ -459,5 +459,3 @@ example : (-6 / 15 : ℚ).num = -2 := by norm_num1
 example : (-6 / 15 : ℚ).den = 5 := by norm_num1
 
 end num_den
-
-end

--- a/MathlibTest/norm_num_ext.lean
+++ b/MathlibTest/norm_num_ext.lean
@@ -458,4 +458,6 @@ example : (6 / 15 : ℚ).den = 5 := by norm_num1
 example : (-6 / 15 : ℚ).num = -2 := by norm_num1
 example : (-6 / 15 : ℚ).den = 5 := by norm_num1
 
+end num_den
+
 end

--- a/MathlibTest/norm_num_ext.lean
+++ b/MathlibTest/norm_num_ext.lean
@@ -449,3 +449,13 @@ example : (553105253 : ℤ) ∣ 553105253 * 776531401 := by norm_num1
 example : ¬ (553105253 : ℤ) ∣ 553105253 * 776531401 + 1 := by norm_num1
 
 end mod
+
+section num_den
+
+example : (6 / 15 : ℚ).num = 2 := by norm_num1
+example : (6 / 15 : ℚ).den = 5 := by norm_num1
+
+example : (-6 / 15 : ℚ).num = -2 := by norm_num1
+example : (-6 / 15 : ℚ).den = 5 := by norm_num1
+
+end


### PR DESCRIPTION
Closes #18826

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

