### PR TITLE
[Merged by Bors] - chore(Algebra/Category): remove a few erws

### DIFF
--- a/Mathlib/Algebra/Category/AlgebraCat/Limits.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Limits.lean
@@ -112,7 +112,7 @@ def limitConeIsLimit : IsLimit (limitCone.{v, w} F) := by
     rfl
   · intro x y
     simp only [Functor.comp_obj, Functor.mapCone_pt, Functor.mapCone_π_app]
-    erw [← map_mul (MulEquiv.symm Shrink.mulEquiv)]
+    rw [← equivShrink_mul]
     apply congrArg
     ext j
     simp only [Functor.comp_obj, Functor.mapCone_pt, Functor.mapCone_π_app,
@@ -124,7 +124,7 @@ def limitConeIsLimit : IsLimit (limitCone.{v, w} F) := by
     simp only [map_zero, Pi.zero_apply]
   · intro x y
     simp only [Functor.mapCone_π_app]
-    erw [← map_add (AddEquiv.symm Shrink.addEquiv)]
+    rw [← equivShrink_add]
     apply congrArg
     ext j
     simp only [forget_map_eq_coe, map_add]

--- a/Mathlib/Algebra/Category/ModuleCat/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Limits.lean
@@ -115,11 +115,11 @@ def limitConeIsLimit : IsLimit (limitCone.{t, v, w} F) := by
     (fun s => rfl)
   · intro x y
     simp only [Types.Small.limitConeIsLimit_lift, Functor.mapCone_π_app, forget_map, map_add]
-    erw [← map_add (AddEquiv.symm Shrink.addEquiv)]
+    rw [← equivShrink_add]
     rfl
   · intro r x
     simp only [Types.Small.limitConeIsLimit_lift, Functor.mapCone_π_app, forget_map, map_smul]
-    erw [← map_smul (LinearEquiv.symm <| Shrink.linearEquiv _ _)]
+    rw [← equivShrink_smul]
     rfl
 
 end HasLimits

--- a/Mathlib/Algebra/Category/MonCat/Limits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Limits.lean
@@ -8,7 +8,7 @@ import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.Submonoid.Operations
 import Mathlib.CategoryTheory.Limits.Creates
 import Mathlib.CategoryTheory.Limits.Types
-import Mathlib.Logic.Equiv.TransferInstance
+import Mathlib.Logic.Small.Group
 
 /-!
 # The category of (commutative) (additive) monoids has all limits
@@ -71,10 +71,10 @@ noncomputable def limitπMonoidHom (j : J) :
       ((F ⋙ forget MonCat.{u}).obj j) where
   toFun := (Types.Small.limitCone.{v, u} (F ⋙ forget MonCat.{u})).π.app j
   map_one' := by
-    simp only [Types.Small.limitCone_π_app, ← Equiv.mulEquiv_apply, map_one]
+    simp only [Types.Small.limitCone_pt, Types.Small.limitCone_π_app, equivShrink_symm_one]
     rfl
   map_mul' _ _ := by
-    simp only [Types.Small.limitCone_π_app, ← Equiv.mulEquiv_apply, map_mul]
+    simp only [Types.Small.limitCone_pt, Types.Small.limitCone_π_app, equivShrink_symm_mul]
     rfl
 
 namespace HasLimits
@@ -103,8 +103,8 @@ noncomputable def limitConeIsLimit : IsLimit (limitCone F) := by
   · simp only [Functor.mapCone_π_app, forget_map, map_one]
     rfl
   · intro x y
-    simp only [Functor.mapCone_π_app, forget_map, map_mul]
-    erw [← map_mul (MulEquiv.symm Shrink.mulEquiv)]
+    simp only [Functor.mapCone_π_app, forget_map, map_mul, Functor.comp_obj, Equiv.toFun_as_coe]
+    rw [← equivShrink_mul]
     rfl
 
 /-- If `(F ⋙ forget MonCat).sections` is `u`-small, `F` has a limit. -/

--- a/Mathlib/Algebra/Category/Ring/Limits.lean
+++ b/Mathlib/Algebra/Category/Ring/Limits.lean
@@ -40,8 +40,7 @@ variable {J : Type v} [Category.{w} J] (F : J ⥤ SemiRingCat.{u})
 instance semiringObj (j) : Semiring ((F ⋙ forget SemiRingCat).obj j) :=
   inferInstanceAs <| Semiring (F.obj j)
 
-/-- The flat sections of a functor into `SemiRingCat` form a subsemiring of all sections.
--/
+/-- The flat sections of a functor into `SemiRingCat` form a subsemiring of all sections. -/
 def sectionsSubsemiring : Subsemiring (∀ j, F.obj j) :=
   -- Porting note: if `f` and `g` were inlined, it does not compile
   letI f : J ⥤ AddMonCat.{u} := F ⋙ forget₂ SemiRingCat.{u} AddCommMonCat.{u} ⋙
@@ -100,14 +99,16 @@ def limitConeIsLimit : IsLimit (limitCone F) := by
   · simp only [Functor.mapCone_π_app, forget_map, map_one]
     rfl
   · intro x y
-    simp only [Functor.mapCone_π_app, forget_map, map_mul]
-    erw [← map_mul (MulEquiv.symm Shrink.mulEquiv)]
+    simp only [Functor.comp_obj, Equiv.toFun_as_coe, Functor.mapCone_pt, Functor.mapCone_π_app,
+          forget_map, map_mul]
+    rw [← equivShrink_mul]
     rfl
   · simp only [Functor.mapCone_π_app, forget_map, map_zero]
     rfl
   · intro x y
-    simp only [Functor.mapCone_π_app, forget_map, map_add]
-    erw [← map_add (AddEquiv.symm Shrink.addEquiv)]
+    simp only [Functor.comp_obj, Equiv.toFun_as_coe, Functor.mapCone_pt, Functor.mapCone_π_app,
+      forget_map, map_add]
+    rw [← equivShrink_add]
     rfl
 
 end HasLimits

--- a/Mathlib/Logic/Small/Group.lean
+++ b/Mathlib/Logic/Small/Group.lean
@@ -38,6 +38,18 @@ lemma equivShrink_mul [Mul α] [Small α] (x y : α) :
   rw [Equiv.mul_def]
   simp
 
+@[simp]
+lemma equivShrink_symm_smul {R : Type*} [SMul R α] [Small α] (r : R) (x : Shrink α) :
+    (equivShrink α).symm (r • x) = r • (equivShrink α).symm x := by
+  rw [Equiv.smul_def]
+  simp
+
+@[simp]
+lemma equivShrink_smul {R : Type*} [SMul R α] [Small α] (r : R) (x : α) :
+    equivShrink α (r • x) = r • equivShrink α x := by
+  rw [Equiv.smul_def]
+  simp
+
 -- TODO: noncomputable has to be specified explicitly. https://github.com/leanprover-community/mathlib4/issues/1074 (item 8)
 @[to_additive]
 noncomputable instance [Div α] [Small α] : Div (Shrink α) := (equivShrink _).symm.div


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
