### PR TITLE
feat(fun_prop): make fun_prop fail fast by caching failed goals

### DIFF
--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -97,8 +97,10 @@ structure Context where
 /-- `fun_prop` state -/
 structure State where
   /-- Simp's cache is used as the `fun_prop` tactic is designed to be used inside of simp and
-  utilize its cache -/
+  utilize its cache. It holds succesfull goals. -/
   cache : Simp.Cache := {}
+  /-- Cache storing failed goals such that they are not tried again. -/
+  failureCache : ExprSet := {}
   /-- Count the number of steps and stop when maxSteps is reached. -/
   numSteps := 0
   /-- Log progress and failures messages that should be displayed to the user at the end. -/

--- a/MathlibTest/fun_prop_dev.lean
+++ b/MathlibTest/fun_prop_dev.lean
@@ -562,8 +562,8 @@ example [Add α] (y : α):
 
 
 section PerformanceTests
-set_option trace.Meta.Tactic.fun_prop true
-set_option profiler true
+-- set_option trace.Meta.Tactic.fun_prop true
+-- set_option profiler true
 
 variable {R : Type*} [Add R] [∀ n, OfNat R n]
 example (f : R → R) (hf : Con f) :

--- a/MathlibTest/fun_prop_dev.lean
+++ b/MathlibTest/fun_prop_dev.lean
@@ -536,14 +536,15 @@ example [Add α] (a : α) :
 -- Test that local theorem is being used
 /--
 info: [Meta.Tactic.fun_prop] [✅️] Con fun x => f x y
-  [Meta.Tactic.fun_prop] candidate local theorems for f #[this : Con f]
-  [Meta.Tactic.fun_prop] removing argument to later use this : Con f
-  [Meta.Tactic.fun_prop] [✅️] applying: Con_comp
-    [Meta.Tactic.fun_prop] [✅️] Con fun f => f y
-      [Meta.Tactic.fun_prop] [✅️] applying: Con_apply
-    [Meta.Tactic.fun_prop] [✅️] Con fun x => f x
-      [Meta.Tactic.fun_prop] candidate local theorems for f #[this : Con f]
-      [Meta.Tactic.fun_prop] [✅️] applying: this : Con f
+  [Meta.Tactic.fun_prop] [✅️] Con fun x => f x y
+    [Meta.Tactic.fun_prop] candidate local theorems for f #[this : Con f]
+    [Meta.Tactic.fun_prop] removing argument to later use this : Con f
+    [Meta.Tactic.fun_prop] [✅️] applying: Con_comp
+      [Meta.Tactic.fun_prop] [✅️] Con fun f => f y
+        [Meta.Tactic.fun_prop] [✅️] applying: Con_apply
+      [Meta.Tactic.fun_prop] [✅️] Con fun x => f x
+        [Meta.Tactic.fun_prop] candidate local theorems for f #[this : Con f]
+        [Meta.Tactic.fun_prop] [✅️] applying: this : Con f
 -/
 #guard_msgs in
 example [Add α] (y : α):
@@ -553,3 +554,40 @@ example [Add α] (y : α):
   have : Con f := by fun_prop
   set_option trace.Meta.Tactic.fun_prop true in
   fun_prop
+
+
+
+--- pefromance tests - mainly testing fast failure ---
+------------------------------------------------------
+
+
+section PerformanceTests
+set_option trace.Meta.Tactic.fun_prop true
+set_option profiler true
+
+variable {R : Type*} [Add R] [∀ n, OfNat R n]
+example (f : R → R) (hf : Con f) :
+    Con (fun x ↦ f (x + 3)) := by fun_prop -- succeeds in 5ms
+example (f : R → R) (hf : Con f) :
+    Con (fun x ↦ (f (x + 3)) + 2) := by fun_prop -- succeeds in 6ms
+example (f : R → R) (hf : Con f) :
+    Con (fun x ↦ (f (x + 3)) + (2 + f (x + 1))) := by fun_prop -- succeeds in 8ms
+example (f : R → R) (hf : Con f) :
+    Con (fun x ↦ (f (x + 3)) + (2 + f (x + 1)) + x) := by fun_prop -- succeeds in 10ms
+example (f : R → R) (hf : Con f) :
+    Con (fun x ↦ (f (x + 3)) + 2 + f (x + 1) + x + 1) := by fun_prop -- succeeds in 11ms
+
+-- this used to fail in exponentially increasing time, up to 6s for the last example
+-- example (f : R → R) :
+--     Con (fun x ↦ f (x + 3)) := by fun_prop -- fails in 6ms
+-- example (f : R → R) :
+--     Con (fun x ↦ (f (x + 3)) + 2) := by fun_prop -- fails in 18ms
+-- example (f : R → R) :
+--     Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1)) := by fun_prop -- fails in 54ms
+-- example (f : R → R) :
+
+--     Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1) + x) := by fun_prop -- fails in 84ms
+-- example (f : R → R) :
+--     Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1) + x + 1) := by fun_prop -- fails in 89ms
+
+end PerformanceTests


### PR DESCRIPTION
Make `fun_prop` fail fast by adding cache for failed goals. Previously `fun_prop` could have exponential blow up by constantly retrying proving goals that if failed on.

Also a little bit more descriptive tracing messages when applying composition theorem and using cache.

---

Prompted by this [zulip thead](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/fun_prop.20fails.20exponentially.20slowly). Adding cache for failed goals fixes the exponential blow up.

I also took the opportunity to modify tracing messages as `fun_prop` was trying twice composition theorem twice in a row for some mysterious reason. As it turns out there was a reason :) and changing it to a single try of composition theorem would require a lot more refactoring.
