### PR TITLE
[Merged by Bors] - feat(fun_prop): failure cache for `fun_prop` and command to print out `fun_prop` theorems

### DIFF
--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -83,6 +83,59 @@ def funPropTac : Tactic
 
   | _ => throwUnsupportedSyntax
 
+
+
+/- Command that printins all function properties attached to a function.
+
+For example
+```
+#print_fun_prop_theorems HAdd.hAdd
+```
+might print out
+```
+Continuous
+  continuous_add, args: [4,5], priority: 1000
+  continuous_add_left, args: [5], priority: 1000
+  continuous_add_right, args [4], priority: 1000
+  ...
+Diferentiable
+  Differentiable.add, args: [4,5], priority: 1000
+  Differentiable.add_const, args: [4], priority: 1000
+  Differentiable.const_add, args: [5], priority: 1000
+  ...
+```
+
+You can also see only theorems about a concrete function property
+```
+#print_fun_prop_theorems HAdd.hAdd Continuous
+```
+-/
+elab "#print_fun_prop_theorems " funIdent:ident funProp:(ident)? : command => do
+
+  let funName ← ensureNonAmbiguous funIdent (← resolveGlobalConst funIdent)
+  let funProp? ← funProp.mapM (fun stx => do
+    ensureNonAmbiguous stx (← resolveGlobalConst stx))
+
+  let theorems := (functionTheoremsExt.getState (← getEnv)).theorems.findD funName {}
+
+  let logTheorems (funProp : Name) (thms : Array FunctionTheorem) : Command.CommandElabM Unit := do
+    let mut msg : MessageData := ""
+    msg := msg ++ m!"{← Meta.ppOrigin (.decl funProp)}"
+    for thm in thms do
+      msg := msg ++ m!"\n  {← Meta.ppOrigin (.decl thm.thmOrigin.name)}, \
+                 args: {thm.mainArgs}, form: {thm.form}"
+      pure ()
+    logInfo msg
+
+
+  match funProp? with
+  | none =>
+    for (funProp,thms) in theorems do
+      logTheorems funProp thms
+  | some funProp =>
+    logTheorems funProp (theorems.findD funProp #[])
+
+
 end Meta.FunProp
 
 end Mathlib

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -85,7 +85,7 @@ def funPropTac : Tactic
 
 
 
-/- Command that printins all function properties attached to a function.
+/-- Command that printins all function properties attached to a function.
 
 For example
 ```

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -145,7 +145,7 @@ inductive TheoremForm where
 
 /-- TheoremForm to string -/
 instance : ToString TheoremForm :=
-  ⟨fun x => match x with | .uncurried => "uncurried" | .comp => "compositional"⟩
+  ⟨fun x => match x with | .uncurried => "simple" | .comp => "compositional"⟩
 
 /-- theorem about specific function (either declared constant or free variable) -/
 structure FunctionTheorem where

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -97,8 +97,10 @@ structure Context where
 /-- `fun_prop` state -/
 structure State where
   /-- Simp's cache is used as the `fun_prop` tactic is designed to be used inside of simp and
-  utilize its cache -/
+  utilize its cache. It holds succesfull goals. -/
   cache : Simp.Cache := {}
+  /-- Cache storing failed goals such that they are not tried again. -/
+  failureCache : ExprSet := {}
   /-- Count the number of steps and stop when maxSteps is reached. -/
   numSteps := 0
   /-- Log progress and failures messages that should be displayed to the user at the end. -/

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -97,7 +97,7 @@ structure Context where
 /-- `fun_prop` state -/
 structure State where
   /-- Simp's cache is used as the `fun_prop` tactic is designed to be used inside of simp and
-  utilize its cache. It holds succesfull goals. -/
+  utilize its cache. It holds successful goals. -/
   cache : Simp.Cache := {}
   /-- Cache storing failed goals such that they are not tried again. -/
   failureCache : ExprSet := {}

--- a/MathlibTest/fun_prop_dev.lean
+++ b/MathlibTest/fun_prop_dev.lean
@@ -591,3 +591,12 @@ example (f : R → R) (hf : Con f) :
 --     Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1) + x + 1) := by fun_prop -- fails in 89ms
 
 end PerformanceTests
+
+
+/--
+info: Con
+  add_Con, args: [4, 5], form: simple
+  add_Con', args: [4, 5], form: compositional
+-/
+#guard_msgs in
+#print_fun_prop_theorems HAdd.hAdd Con

--- a/MathlibTest/fun_prop_dev.lean
+++ b/MathlibTest/fun_prop_dev.lean
@@ -562,8 +562,8 @@ example [Add α] (y : α):
 
 
 section PerformanceTests
-set_option trace.Meta.Tactic.fun_prop true
-set_option profiler true
+-- set_option trace.Meta.Tactic.fun_prop true
+-- set_option profiler true
 
 variable {R : Type*} [Add R] [∀ n, OfNat R n]
 example (f : R → R) (hf : Con f) :

--- a/MathlibTest/fun_prop_dev.lean
+++ b/MathlibTest/fun_prop_dev.lean
@@ -536,14 +536,15 @@ example [Add α] (a : α) :
 -- Test that local theorem is being used
 /--
 info: [Meta.Tactic.fun_prop] [✅️] Con fun x => f x y
-  [Meta.Tactic.fun_prop] candidate local theorems for f #[this : Con f]
-  [Meta.Tactic.fun_prop] removing argument to later use this : Con f
-  [Meta.Tactic.fun_prop] [✅️] applying: Con_comp
-    [Meta.Tactic.fun_prop] [✅️] Con fun f => f y
-      [Meta.Tactic.fun_prop] [✅️] applying: Con_apply
-    [Meta.Tactic.fun_prop] [✅️] Con fun x => f x
-      [Meta.Tactic.fun_prop] candidate local theorems for f #[this : Con f]
-      [Meta.Tactic.fun_prop] [✅️] applying: this : Con f
+  [Meta.Tactic.fun_prop] [✅️] Con fun x => f x y
+    [Meta.Tactic.fun_prop] candidate local theorems for f #[this : Con f]
+    [Meta.Tactic.fun_prop] removing argument to later use this : Con f
+    [Meta.Tactic.fun_prop] [✅️] applying: Con_comp
+      [Meta.Tactic.fun_prop] [✅️] Con fun f => f y
+        [Meta.Tactic.fun_prop] [✅️] applying: Con_apply
+      [Meta.Tactic.fun_prop] [✅️] Con fun x => f x
+        [Meta.Tactic.fun_prop] candidate local theorems for f #[this : Con f]
+        [Meta.Tactic.fun_prop] [✅️] applying: this : Con f
 -/
 #guard_msgs in
 example [Add α] (y : α):
@@ -553,3 +554,40 @@ example [Add α] (y : α):
   have : Con f := by fun_prop
   set_option trace.Meta.Tactic.fun_prop true in
   fun_prop
+
+
+
+--- pefromance tests - mainly testing fast failure ---
+------------------------------------------------------
+
+
+section PerformanceTests
+set_option trace.Meta.Tactic.fun_prop true
+set_option profiler true
+
+variable {R : Type*} [Add R] [∀ n, OfNat R n]
+example (f : R → R) (hf : Con f) :
+    Con (fun x ↦ f (x + 3)) := by fun_prop -- succeeds in 5ms
+example (f : R → R) (hf : Con f) :
+    Con (fun x ↦ (f (x + 3)) + 2) := by fun_prop -- succeeds in 6ms
+example (f : R → R) (hf : Con f) :
+    Con (fun x ↦ (f (x + 3)) + (2 + f (x + 1))) := by fun_prop -- succeeds in 8ms
+example (f : R → R) (hf : Con f) :
+    Con (fun x ↦ (f (x + 3)) + (2 + f (x + 1)) + x) := by fun_prop -- succeeds in 10ms
+example (f : R → R) (hf : Con f) :
+    Con (fun x ↦ (f (x + 3)) + 2 + f (x + 1) + x + 1) := by fun_prop -- succeeds in 11ms
+
+-- this used to fail in exponentially increasing time, up to 6s for the last example
+-- example (f : R → R) :
+--     Con (fun x ↦ f (x + 3)) := by fun_prop -- fails in 6ms
+-- example (f : R → R) :
+--     Con (fun x ↦ (f (x + 3)) + 2) := by fun_prop -- fails in 18ms
+-- example (f : R → R) :
+--     Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1)) := by fun_prop -- fails in 54ms
+-- example (f : R → R) :
+
+--     Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1) + x) := by fun_prop -- fails in 84ms
+-- example (f : R → R) :
+--     Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1) + x + 1) := by fun_prop -- fails in 89ms
+
+end PerformanceTests

--- a/MathlibTest/fun_prop_dev.lean
+++ b/MathlibTest/fun_prop_dev.lean
@@ -6,6 +6,7 @@ Authors: Tomáš Skřivan
 import Mathlib.Tactic.FunProp
 import Mathlib.Logic.Function.Basic
 import Mathlib.Data.FunLike.Basic
+import Mathlib.Tactic.SuccessIfFailWithMsg
 import Aesop
 
 /-! # Tests for the `fun_prop` tactic
@@ -577,18 +578,37 @@ example (f : R → R) (hf : Con f) :
 example (f : R → R) (hf : Con f) :
     Con (fun x ↦ (f (x + 3)) + 2 + f (x + 1) + x + 1) := by fun_prop -- succeeds in 11ms
 
--- this used to fail in exponentially increasing time, up to 6s for the last example
--- example (f : R → R) :
---     Con (fun x ↦ f (x + 3)) := by fun_prop -- fails in 6ms
--- example (f : R → R) :
---     Con (fun x ↦ (f (x + 3)) + 2) := by fun_prop -- fails in 18ms
--- example (f : R → R) :
---     Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1)) := by fun_prop -- fails in 54ms
--- example (f : R → R) :
+-- This used to fail in exponentially increasing time, up to 6s for the last example
+-- We set maxHearthbeats to 1000 such that the last three examples should fail if the exponential
+-- blow happen again.
+set_option maxHeartbeats 1000 in
+example (f : R → R) :
+    Con (fun x ↦ f (x + 3)) := by
+  fail_if_success fun_prop
+  apply silentSorry
 
---     Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1) + x) := by fun_prop -- fails in 84ms
--- example (f : R → R) :
---     Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1) + x + 1) := by fun_prop -- fails in 89ms
+example (f : R → R) :
+    Con (fun x ↦ (f (x + 3)) + 2) := by
+  fail_if_success fun_prop
+  apply silentSorry
+
+set_option maxHeartbeats 1000 in
+example (f : R → R) :
+    Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1)) := by
+  fail_if_success fun_prop
+  apply silentSorry
+
+set_option maxHeartbeats 1000 in
+example (f : R → R) :
+    Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1) + x) := by
+  fail_if_success fun_prop
+  apply silentSorry
+
+set_option maxHeartbeats 1000 in
+example (f : R → R) :
+    Con (fun x ↦ ((f (x + 3)) + 2) + f (x + 1) + x + 1) := by
+  fail_if_success fun_prop
+  apply silentSorry
 
 end PerformanceTests
 


### PR DESCRIPTION
Add new cache to `fun_prop`  for failed goals. `fun_prop` used to take exponentially long to fail without this cache.
Also add command `#print_fun_prop_theorems HAdd.hAdd`  prints out all `fun_prop` theorems associated with addition.

---

Command useful for maintenance of `fun_prop` attribute. Allows you to to see all the theorems for a given function thus spotting duplicated and bad theorems more easily.

This will also be useful on deciding priority for new `fun_prop` theorems once priority is supported.