### PR TITLE
[Merged by Bors] - chore: use AlgHom.restrictDomain

### DIFF
--- a/Mathlib/FieldTheory/Extension.lean
+++ b/Mathlib/FieldTheory/Extension.lean
@@ -96,7 +96,7 @@ section
 
 private theorem exists_algHom_adjoin_of_splits'' {L : IntermediateField F E}
     (f : L →ₐ[F] K) (hK : ∀ s ∈ S, IsIntegral L s ∧ (minpoly L s).Splits f.toRingHom) :
-    ∃ φ : adjoin L S →ₐ[F] K, φ.comp (IsScalarTower.toAlgHom F L _) = f := by
+    ∃ φ : adjoin L S →ₐ[F] K, φ.restrictDomain L = f := by
   obtain ⟨φ, hfφ, hφ⟩ := zorn_le_nonempty_Ici₀ _
     (fun c _ hc _ _ ↦ Lifts.exists_upper_bound c hc) ⟨L, f⟩ le_rfl
   refine ⟨φ.emb.comp (inclusion <| (le_extendScalars_iff hfφ.1 <| adjoin L S).mp <|
@@ -114,7 +114,7 @@ variable {L : Type*} [Field L] [Algebra F L] [Algebra L E] [IsScalarTower F L E]
 
 include hK in
 theorem exists_algHom_adjoin_of_splits' :
-    ∃ φ : adjoin L S →ₐ[F] K, φ.comp (IsScalarTower.toAlgHom F L _) = f := by
+    ∃ φ : adjoin L S →ₐ[F] K, φ.restrictDomain L = f := by
   let L' := (IsScalarTower.toAlgHom F L E).fieldRange
   let f' : L' →ₐ[F] K := f.comp (AlgEquiv.ofInjectiveField _).symm.toAlgHom
   have := exists_algHom_adjoin_of_splits'' f' (S := S) fun s hs ↦ ?_
@@ -123,21 +123,20 @@ theorem exists_algHom_adjoin_of_splits' :
     · simp_rw [← SetLike.coe_subset_coe, coe_restrictScalars, adjoin_subset_adjoin_iff]
       exact ⟨subset_adjoin_of_subset_left S (F := L'.toSubfield) le_rfl, subset_adjoin _ _⟩
     · ext x
-      rw [AlgHom.comp_assoc]
       exact congr($hφ _).trans (congr_arg f <| AlgEquiv.symm_apply_apply _ _)
-  letI : Algebra L L' := (AlgEquiv.ofInjectiveField _).toRingEquiv.toRingHom.toAlgebra
+  letI : Algebra L L' := (AlgEquiv.ofInjectiveField _).toRingHom.toAlgebra
   have : IsScalarTower L L' E := IsScalarTower.of_algebraMap_eq' rfl
   refine ⟨(hK s hs).1.tower_top, (hK s hs).1.minpoly_splits_tower_top' ?_⟩
   convert (hK s hs).2; ext; exact congr_arg f (AlgEquiv.symm_apply_apply _ _)
 
 include hK in
 theorem exists_algHom_of_adjoin_splits' (hS : adjoin L S = ⊤) :
-    ∃ φ : E →ₐ[F] K, φ.comp (IsScalarTower.toAlgHom F L E) = f :=
+    ∃ φ : E →ₐ[F] K, φ.restrictDomain L = f :=
   have ⟨φ, hφ⟩ := exists_algHom_adjoin_of_splits' f hK
   ⟨φ.comp (((equivOfEq hS).trans topEquiv).symm.toAlgHom.restrictScalars F), hφ⟩
 
 theorem exists_algHom_of_splits' (hK : ∀ s : E, IsIntegral L s ∧ (minpoly L s).Splits f.toRingHom) :
-    ∃ φ : E →ₐ[F] K, φ.comp (IsScalarTower.toAlgHom F L E) = f :=
+    ∃ φ : E →ₐ[F] K, φ.restrictDomain L = f :=
   exists_algHom_of_adjoin_splits' f (fun x _ ↦ hK x) (adjoin_univ L E)
 
 end

--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -262,11 +262,14 @@ variable {K : Type u} [Field K] {L : Type v} {M : Type w} [Field L] [Algebra K L
 /-- If E/L/K is a tower of field extensions with E/L algebraic, and if M is an algebraically
   closed extension of K, then any embedding of L/K into M/K extends to an embedding of E/K.
   Known as the extension lemma in https://math.stackexchange.com/a/687914. -/
-theorem surjective_comp_algebraMap_of_isAlgebraic {E : Type*}
+theorem surjective_restrictDomain_of_isAlgebraic {E : Type*}
     [Field E] [Algebra K E] [Algebra L E] [IsScalarTower K L E] [Algebra.IsAlgebraic L E] :
-    Function.Surjective fun φ : E →ₐ[K] M ↦ φ.comp (IsScalarTower.toAlgHom K L E) :=
+    Function.Surjective fun φ : E →ₐ[K] M ↦ φ.restrictDomain L :=
   fun f ↦ IntermediateField.exists_algHom_of_splits'
     (E := E) f fun s ↦ ⟨Algebra.IsIntegral.isIntegral s, IsAlgClosed.splits_codomain _⟩
+
+@[deprecated (since := "2024-11-15")]
+alias surjective_comp_algebraMap_of_isAlgebraic := surjective_restrictDomain_of_isAlgebraic
 
 variable [Algebra.IsAlgebraic K L] (K L M)
 

--- a/Mathlib/FieldTheory/IsSepClosed.lean
+++ b/Mathlib/FieldTheory/IsSepClosed.lean
@@ -269,12 +269,15 @@ namespace IsSepClosed
 variable {K : Type u} (L : Type v) {M : Type w} [Field K] [Field L] [Algebra K L] [Field M]
   [Algebra K M] [IsSepClosed M]
 
-theorem surjective_comp_algebraMap_of_isSeparable {E : Type*}
+theorem surjective_restrictDomain_of_isSeparable {E : Type*}
     [Field E] [Algebra K E] [Algebra L E] [IsScalarTower K L E] [Algebra.IsSeparable L E] :
-    Function.Surjective fun φ : E →ₐ[K] M ↦ φ.comp (IsScalarTower.toAlgHom K L E) :=
+    Function.Surjective fun φ : E →ₐ[K] M ↦ φ.restrictDomain L :=
   fun f ↦ IntermediateField.exists_algHom_of_splits' (E := E) f
     fun s ↦ ⟨Algebra.IsSeparable.isIntegral L s,
       IsSepClosed.splits_codomain _ <| Algebra.IsSeparable.isSeparable L s⟩
+
+@[deprecated (since := "2024-11-15")]
+alias surjective_comp_algebraMap_of_isSeparable := surjective_restrictDomain_of_isSeparable
 
 variable [Algebra.IsSeparable K L] {L}
 

--- a/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
@@ -66,8 +66,8 @@ def galRestrictHom : (L →ₐ[K] L) ≃* (B →ₐ[A] B) where
     apply (IsIntegralClosure.equiv A (integralClosure A L) L B).symm.injective
     ext
     dsimp
-    simp only [AlgEquiv.symm_apply_apply, AlgHom.coe_codRestrict, AlgHom.coe_comp,
-      AlgHom.coe_restrictScalars', IsScalarTower.coe_toAlgHom', Function.comp_apply,
+    simp only [AlgEquiv.symm_apply_apply, AlgHom.coe_codRestrict, AlgHom.coe_restrictScalars',
+      AlgHom.coe_comp, AlgHom.restrictDomain, IsScalarTower.coe_toAlgHom', Function.comp_apply,
       AlgHom.mul_apply, IsIntegralClosure.algebraMap_equiv, Subalgebra.algebraMap_eq]
     rfl
   invFun := galLift A K L B
@@ -75,17 +75,17 @@ def galRestrictHom : (L →ₐ[K] L) ≃* (B →ₐ[A] B) where
     have := (IsFractionRing.injective A K).isDomain
     have := IsIntegralClosure.isLocalization A K L B
     AlgHom.coe_ringHom_injective <| IsLocalization.ringHom_ext (Algebra.algebraMapSubmonoid B A⁰)
-      <| RingHom.ext fun x ↦ by simp [Subalgebra.algebraMap_eq, galLift]
+      <| RingHom.ext fun x ↦ by simp [Subalgebra.algebraMap_eq, AlgHom.restrictDomain, galLift]
   right_inv σ :=
     have := (IsFractionRing.injective A K).isDomain
     have := IsIntegralClosure.isLocalization A K L B
-    AlgHom.ext fun x ↦
-      IsIntegralClosure.algebraMap_injective B A L (by simp [Subalgebra.algebraMap_eq, galLift])
+    AlgHom.ext fun x ↦ IsIntegralClosure.algebraMap_injective B A L
+      (by simp [AlgHom.restrictDomain, Subalgebra.algebraMap_eq, galLift])
 
 @[simp]
 lemma algebraMap_galRestrictHom_apply (σ : L →ₐ[K] L) (x : B) :
     algebraMap B L (galRestrictHom A K L B σ x) = σ (algebraMap B L x) := by
-  simp [galRestrictHom, Subalgebra.algebraMap_eq]
+  simp [galRestrictHom, Subalgebra.algebraMap_eq, AlgHom.restrictDomain]
 
 @[simp, nolint unusedHavesSuffices] -- false positive from unfolding galRestrictHom
 lemma galRestrictHom_symm_algebraMap_apply (σ : B →ₐ[A] B) (x : B) :

--- a/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
@@ -58,7 +58,7 @@ Also see `galRestrict` for the `AlgEquiv` version. -/
 noncomputable
 def galRestrictHom : (L →ₐ[K] L) ≃* (B →ₐ[A] B) where
   toFun := fun f ↦ (IsIntegralClosure.equiv A (integralClosure A L) L B).toAlgHom.comp
-      (((f.restrictScalars A).comp (IsScalarTower.toAlgHom A B L)).codRestrict
+      (((f.restrictScalars A).restrictDomain B).codRestrict
         (integralClosure A L) (fun x ↦ IsIntegral.map _ (IsIntegralClosure.isIntegral A L x)))
   map_mul' := by
     intros σ₁ σ₂

--- a/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
@@ -58,7 +58,7 @@ Also see `galRestrict` for the `AlgEquiv` version. -/
 noncomputable
 def galRestrictHom : (L →ₐ[K] L) ≃* (B →ₐ[A] B) where
   toFun := fun f ↦ (IsIntegralClosure.equiv A (integralClosure A L) L B).toAlgHom.comp
-      (((f.restrictScalars A).restrictDomain B).codRestrict
+      (((f.restrictScalars A).comp (IsScalarTower.toAlgHom A B L)).codRestrict
         (integralClosure A L) (fun x ↦ IsIntegral.map _ (IsIntegralClosure.isIntegral A L x)))
   map_mul' := by
     intros σ₁ σ₂

--- a/Mathlib/RingTheory/Unramified/Basic.lean
+++ b/Mathlib/RingTheory/Unramified/Basic.lean
@@ -174,7 +174,7 @@ theorem comp [FormallyUnramified R A] [FormallyUnramified A B] :
   have e' :=
     FormallyUnramified.lift_unique I ⟨2, hI⟩ (f₁.comp <| IsScalarTower.toAlgHom R A B)
       (f₂.comp <| IsScalarTower.toAlgHom R A B) (by rw [← AlgHom.comp_assoc, e, AlgHom.comp_assoc])
-  letI := (f₁.comp (IsScalarTower.toAlgHom R A B)).toRingHom.toAlgebra
+  letI := (f₁.restrictDomain A).toAlgebra
   let F₁ : B →ₐ[A] C := { f₁ with commutes' := fun r => rfl }
   let F₂ : B →ₐ[A] C := { f₂ with commutes' := AlgHom.congr_fun e'.symm }
   ext1 x


### PR DESCRIPTION
I previously didn't know the existence of `AlgHom.restrictDomain` and wrote many lemmas using a longer expression that is exactly the definition of `AlgHom.restrictDomain`; I'm now changing all these lemmas to use `AlgHom.restrictDomain`. There are more appearances of `.comp (IsScalarTower.toAlgHom` but either the file doesn't import `AlgHom.restrictDomain`, or using it breaks the proof, so I only replaced one appearance.

---

[Another replacement can be made](https://github.com/leanprover-community/mathlib4/compare/restrictDomain_galRestrictHom?expand=1#diff-6c5be70eec39d6174e862455c4b40edf3675e04ab9b24e681dfbc42460fa8062), and if reviewers think it's appropriate, I can certainly merge.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
