### PR TITLE
[Merged by Bors] - fix: more stable choice of representative for atoms in `ring` and `abel`

### DIFF
--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -247,11 +247,11 @@ theorem term_atom_pfg {α} [AddCommGroup α] (x x' : α) (h : x = x') : x = term
 /-- Interpret an expression as an atom for `abel`'s normal form. -/
 def evalAtom (e : Expr) : M (NormalExpr × Expr) := do
   let { expr := e', proof?, .. } ← (← readThe AtomM.Context).evalAtom e
-  let i ← AtomM.addAtom e'
+  let (i, a) ← AtomM.addAtom e'
   let p ← match proof? with
   | none => iapp ``term_atom #[e]
-  | some p => iapp ``term_atom_pf #[e, e', p]
-  return (← term' (← intToExpr 1, 1) (i, e') (← zero'), p)
+  | some p => iapp ``term_atom_pf #[e, a, p]
+  return (← term' (← intToExpr 1, 1) (i, a) (← zero'), p)
 
 theorem unfold_sub {α} [SubtractionMonoid α] (a b c : α) (h : a + -b = c) : a - b = c := by
   rw [sub_eq_add_neg, h]

--- a/Mathlib/Tactic/ITauto.lean
+++ b/Mathlib/Tactic/ITauto.lean
@@ -486,7 +486,7 @@ partial def reify (e : Q(Prop)) : AtomM IProp :=
   | ~q(@Ne Prop $a $b) => return .not (.eq (← reify a) (← reify b))
   | e =>
     if e.isArrow then return .imp (← reify e.bindingDomain!) (← reify e.bindingBody!)
-    else return .var (← AtomM.addAtom e)
+    else return .var (← AtomM.addAtom e).1
 
 /-- Once we have a proof object, we have to apply it to the goal. -/
 partial def applyProof (g : MVarId) (Γ : NameMap Expr) (p : Proof) : MetaM Unit :=

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -273,12 +273,12 @@ partial def findSquares (s : RBSet (Nat × Bool) lexOrd.compare) (e : Expr) :
   | (``HPow.hPow, #[_, _, _, _, a, b]) => match b.numeral? with
     | some 2 => do
       let s ← findSquares s a
-      let ai ← AtomM.addAtom a
+      let (ai, _) ← AtomM.addAtom a
       return (s.insert (ai, true))
     | _ => e.foldlM findSquares s
   | (``HMul.hMul, #[_, _, _, _, a, b]) => do
-    let ai ← AtomM.addAtom a
-    let bi ← AtomM.addAtom b
+    let (ai, _) ← AtomM.addAtom a
+    let (bi, _) ← AtomM.addAtom b
     if ai = bi then do
       let s ← findSquares s a
       return (s.insert (ai, false))

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -464,9 +464,10 @@ partial def parse (iM : Q(AddCommMonoid $M)) (x : Q($M)) :
     pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [], q(NF.zero_eq_eval $M)⟩
   /- anything else should be treated as an atom -/
   | _ =>
-    let k : ℕ ← AtomM.addAtom x
-    pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [((q(1), x), k)],
-      q(NF.atom_eq_eval $x)⟩
+    let (k, x') ← AtomM.addAtom x
+    have x' : Q($M) := x'
+    pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [((q(1), x'), k)],
+      (q(NF.atom_eq_eval $x'):)⟩
 
 /-- Given expressions `R` and `M` representing types such that `M`'s is a module over `R`'s, and
 given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -464,8 +464,7 @@ partial def parse (iM : Q(AddCommMonoid $M)) (x : Q($M)) :
     pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [], q(NF.zero_eq_eval $M)⟩
   /- anything else should be treated as an atom -/
   | _ =>
-    let (k, x') ← AtomM.addAtom x
-    have x' : Q($M) := x'
+    let (k, x') ← AtomM.addAtomQ x
     pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [((q(1), x'), k)],
       (q(NF.atom_eq_eval $x'):)⟩
 

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -464,7 +464,7 @@ partial def parse (iM : Q(AddCommMonoid $M)) (x : Q($M)) :
     pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [], q(NF.zero_eq_eval $M)⟩
   /- anything else should be treated as an atom -/
   | _ =>
-    let (k, x') ← AtomM.addAtomQ x
+    let (k, ⟨x', _⟩) ← AtomM.addAtomQ x
     pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [((q(1), x'), k)],
       (q(NF.atom_eq_eval $x'):)⟩
 

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -466,7 +466,7 @@ partial def parse (iM : Q(AddCommMonoid $M)) (x : Q($M)) :
   | _ =>
     let (k, ⟨x', _⟩) ← AtomM.addAtomQ x
     pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [((q(1), x'), k)],
-      (q(NF.atom_eq_eval $x'):)⟩
+      q(NF.atom_eq_eval $x')⟩
 
 /-- Given expressions `R` and `M` representing types such that `M`'s is a module over `R`'s, and
 given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s

--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -133,7 +133,7 @@ partial def parse {u : Level} {α : Q(Type u)} (sα : Q(CommSemiring $α))
     (c : Ring.Cache sα) (e : Q($α)) : AtomM Poly := do
   let els := do
     try pure <| Poly.const (← (← NormNum.derive e).toRat)
-    catch _ => pure <| Poly.var (← addAtom e)
+    catch _ => pure <| Poly.var (← addAtom e).1
   let .const n _ := (← withReducible <| whnf e).getAppFn | els
   match n, c.rα with
   | ``HAdd.hAdd, _ | ``Add.add, _ => match e with

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -513,8 +513,9 @@ partial def ExBase.evalNatCast {a : Q(ℕ)} (va : ExBase sℕ a) : AtomM (Result
   match va with
   | .atom _ => do
     let a' : Q($α) := q($a)
-    let i ← addAtom a'
-    pure ⟨a', ExBase.atom i, (q(Eq.refl $a') : Expr)⟩
+    let (i, b) ← addAtom a'
+    let b' : Q($α) := b
+    pure ⟨b', ExBase.atom i, (q(Eq.refl $b') : Expr)⟩
   | .sum va => do
     let ⟨_, vc, p⟩ ← va.evalNatCast
     pure ⟨_, .sum vc, p⟩
@@ -952,11 +953,12 @@ Evaluates an atom, an expression where `ring` can find no additional structure.
 def evalAtom (e : Q($α)) : AtomM (Result (ExSum sα) e) := do
   let r ← (← read).evalAtom e
   have e' : Q($α) := r.expr
-  let i ← addAtom e'
-  let ve' := (ExBase.atom i (e := e')).toProd (ExProd.mkNat sℕ 1).2 |>.toSum
+  let (i, a) ← addAtom e'
+  have a' : Q($α) := a
+  let ve' := (ExBase.atom i (e := a')).toProd (ExProd.mkNat sℕ 1).2 |>.toSum
   pure ⟨_, ve', match r.proof? with
   | none => (q(atom_pf $e) : Expr)
-  | some (p : Q($e = $e')) => (q(atom_pf' $p) : Expr)⟩
+  | some (p : Q($e = $a')) => (q(atom_pf' $p) : Expr)⟩
 
 theorem inv_mul {R} [DivisionRing R] {a₁ a₂ a₃ b₁ b₃ c}
     (_ : (a₁⁻¹ : R) = b₁) (_ : (a₃⁻¹ : R) = b₃)
@@ -978,8 +980,9 @@ variable (dα : Q(DivisionRing $α))
 /-- Applies `⁻¹` to a polynomial to get an atom. -/
 def evalInvAtom (a : Q($α)) : AtomM (Result (ExBase sα) q($a⁻¹)) := do
   let a' : Q($α) := q($a⁻¹)
-  let i ← addAtom a'
-  pure ⟨a', ExBase.atom i, (q(Eq.refl $a') : Expr)⟩
+  let (i, b) ← addAtom a'
+  let b' : Q($α) := b
+  pure ⟨b', ExBase.atom i, (q(Eq.refl $b') : Expr)⟩
 
 /-- Inverts a polynomial `va` to get a normalized result polynomial.
 

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -513,7 +513,7 @@ partial def ExBase.evalNatCast {a : Q(ℕ)} (va : ExBase sℕ a) : AtomM (Result
   match va with
   | .atom _ => do
     let a' : Q($α) := q($a)
-    let (i, b') ← addAtomQ a'
+    let (i, ⟨b', _⟩) ← addAtomQ a'
     pure ⟨b', ExBase.atom i, (q(Eq.refl $b') : Expr)⟩
   | .sum va => do
     let ⟨_, vc, p⟩ ← va.evalNatCast
@@ -952,7 +952,7 @@ Evaluates an atom, an expression where `ring` can find no additional structure.
 def evalAtom (e : Q($α)) : AtomM (Result (ExSum sα) e) := do
   let r ← (← read).evalAtom e
   have e' : Q($α) := r.expr
-  let (i, a') ← addAtomQ e'
+  let (i, ⟨a', _⟩) ← addAtomQ e'
   let ve' := (ExBase.atom i (e := a')).toProd (ExProd.mkNat sℕ 1).2 |>.toSum
   pure ⟨_, ve', match r.proof? with
   | none => (q(atom_pf $e) : Expr)
@@ -978,7 +978,7 @@ variable (dα : Q(DivisionRing $α))
 /-- Applies `⁻¹` to a polynomial to get an atom. -/
 def evalInvAtom (a : Q($α)) : AtomM (Result (ExBase sα) q($a⁻¹)) := do
   let a' : Q($α) := q($a⁻¹)
-  let (i, b') ← addAtomQ a'
+  let (i, ⟨b', _⟩) ← addAtomQ a'
   pure ⟨b', ExBase.atom i, (q(Eq.refl $b') : Expr)⟩
 
 /-- Inverts a polynomial `va` to get a normalized result polynomial.

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -512,9 +512,8 @@ mutual
 partial def ExBase.evalNatCast {a : Q(ℕ)} (va : ExBase sℕ a) : AtomM (Result (ExBase sα) q($a)) :=
   match va with
   | .atom _ => do
-    let a' : Q($α) := q($a)
-    let (i, ⟨b', _⟩) ← addAtomQ a'
-    pure ⟨b', ExBase.atom i, (q(Eq.refl $b') : Expr)⟩
+    let (i, ⟨b', _⟩) ← addAtomQ q($a)
+    pure ⟨b', ExBase.atom i, q(Eq.refl $b')⟩
   | .sum va => do
     let ⟨_, vc, p⟩ ← va.evalNatCast
     pure ⟨_, .sum vc, p⟩
@@ -977,9 +976,8 @@ variable (dα : Q(DivisionRing $α))
 
 /-- Applies `⁻¹` to a polynomial to get an atom. -/
 def evalInvAtom (a : Q($α)) : AtomM (Result (ExBase sα) q($a⁻¹)) := do
-  let a' : Q($α) := q($a⁻¹)
-  let (i, ⟨b', _⟩) ← addAtomQ a'
-  pure ⟨b', ExBase.atom i, (q(Eq.refl $b') : Expr)⟩
+  let (i, ⟨b', _⟩) ← addAtomQ q($a⁻¹)
+  pure ⟨b', ExBase.atom i, q(Eq.refl $b')⟩
 
 /-- Inverts a polynomial `va` to get a normalized result polynomial.
 

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -513,8 +513,7 @@ partial def ExBase.evalNatCast {a : Q(ℕ)} (va : ExBase sℕ a) : AtomM (Result
   match va with
   | .atom _ => do
     let a' : Q($α) := q($a)
-    let (i, b) ← addAtom a'
-    let b' : Q($α) := b
+    let (i, b') ← addAtomQ a'
     pure ⟨b', ExBase.atom i, (q(Eq.refl $b') : Expr)⟩
   | .sum va => do
     let ⟨_, vc, p⟩ ← va.evalNatCast
@@ -953,8 +952,7 @@ Evaluates an atom, an expression where `ring` can find no additional structure.
 def evalAtom (e : Q($α)) : AtomM (Result (ExSum sα) e) := do
   let r ← (← read).evalAtom e
   have e' : Q($α) := r.expr
-  let (i, a) ← addAtom e'
-  have a' : Q($α) := a
+  let (i, a') ← addAtomQ e'
   let ve' := (ExBase.atom i (e := a')).toProd (ExProd.mkNat sℕ 1).2 |>.toSum
   pure ⟨_, ve', match r.proof? with
   | none => (q(atom_pf $e) : Expr)
@@ -980,8 +978,7 @@ variable (dα : Q(DivisionRing $α))
 /-- Applies `⁻¹` to a polynomial to get an atom. -/
 def evalInvAtom (a : Q($α)) : AtomM (Result (ExBase sα) q($a⁻¹)) := do
   let a' : Q($α) := q($a⁻¹)
-  let (i, b) ← addAtom a'
-  let b' : Q($α) := b
+  let (i, b') ← addAtomQ a'
   pure ⟨b', ExBase.atom i, (q(Eq.refl $b') : Expr)⟩
 
 /-- Inverts a polynomial `va` to get a normalized result polynomial.

--- a/Mathlib/Tactic/TFAE.lean
+++ b/Mathlib/Tactic/TFAE.lean
@@ -298,18 +298,18 @@ elab_rules : tactic
   goal.withContext do
     let (tfaeListQ, tfaeList) ← getTFAEList (← goal.getType)
     closeMainGoal `tfae_finish <|← AtomM.run .reducible do
-      let is ← tfaeList.mapM AtomM.addAtom
+      let is ← tfaeList.mapM (fun e ↦ Prod.fst <$> AtomM.addAtom e)
       let mut hyps := #[]
       for hyp in ← getLocalHyps do
         let ty ← whnfR <|← instantiateMVars <|← inferType hyp
         if let (``Iff, #[p1, p2]) := ty.getAppFnArgs then
-          let q1 ← AtomM.addAtom p1
-          let q2 ← AtomM.addAtom p2
+          let (q1, _) ← AtomM.addAtom p1
+          let (q2, _) ← AtomM.addAtom p2
           hyps := hyps.push (q1, q2, ← mkAppM ``Iff.mp #[hyp])
           hyps := hyps.push (q2, q1, ← mkAppM ``Iff.mpr #[hyp])
         else if ty.isArrow then
-          let q1 ← AtomM.addAtom ty.bindingDomain!
-          let q2 ← AtomM.addAtom ty.bindingBody!
+          let (q1, _) ← AtomM.addAtom ty.bindingDomain!
+          let (q2, _) ← AtomM.addAtom ty.bindingBody!
           hyps := hyps.push (q1, q2, hyp)
       proveTFAE hyps (← get).atoms is tfaeListQ
 

--- a/Mathlib/Util/AtomM.lean
+++ b/Mathlib/Util/AtomM.lean
@@ -46,11 +46,11 @@ def AtomM.run {α : Type} (red : TransparencyMode) (m : AtomM α)
 
 /-- Get the index corresponding to an atomic expression, if it has already been encountered, or
 put it in the list of atoms and return the new index, otherwise. -/
-def AtomM.addAtom (e : Expr) : AtomM Nat := do
+def AtomM.addAtom (e : Expr) : AtomM (Nat × Expr) := do
   let c ← get
   for h : i in [:c.atoms.size] do
     if ← withTransparency (← read).red <| isDefEq e c.atoms[i] then
-      return i
-  modifyGet fun c ↦ (c.atoms.size, { c with atoms := c.atoms.push e })
+      return (i, c.atoms[i])
+  modifyGet fun c ↦ ((c.atoms.size, e), { c with atoms := c.atoms.push e })
 
 end Mathlib.Tactic

--- a/Mathlib/Util/AtomM.lean
+++ b/Mathlib/Util/AtomM.lean
@@ -65,7 +65,9 @@ atom (which will be defeq at the specified transparency, but not necessarily syn
 If the atomic expression has *not* already been encountered, store it in the list of atoms, and
 return the new index (and the stored form of the atom, which will be itself).
 
-In a normalizing tactic, the expression returned by `addAtom` should be considered the normal form.
+In a normalizing tactic, the expression returned by `addAtomQ` should be considered the normal form.
+
+This is a strongly-typed version of `AtomM.addAtom` for code using `Qq`.
 -/
 def AtomM.addAtomQ {u : Level} {α : Q(Type u)} (e : Q($α)) :
     AtomM (Nat × {e' : Q($α) // $e =Q $e'}) := do

--- a/Mathlib/Util/AtomM.lean
+++ b/Mathlib/Util/AtomM.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Init
 import Lean.Meta.Tactic.Simp.Types
+import Qq
 
 /-!
 # A monad for tracking and deduplicating atoms
@@ -54,5 +55,12 @@ def AtomM.addAtom (e : Expr) : AtomM (Nat × Expr) := do
     if ← withTransparency (← read).red <| isDefEq e c.atoms[i] then
       return (i, c.atoms[i])
   modifyGet fun c ↦ ((c.atoms.size, e), { c with atoms := c.atoms.push e })
+
+open Qq in
+/-- If an atomic expression has already been encountered, get the index and the stored form of the
+atom (which will be defeq at the specified transparency, but not necessarily syntactically equal).
+If the atomic expression has *not* already been encountered, store it in the list of atoms, and
+return the new index (and the stored form of the atom, which will be itself). -/
+def AtomM.addAtomQ {u : Level} {α : Q(Type u)} (e : Q($α)) : AtomM (Nat × Q($α)) := AtomM.addAtom e
 
 end Mathlib.Tactic

--- a/Mathlib/Util/AtomM.lean
+++ b/Mathlib/Util/AtomM.lean
@@ -44,8 +44,10 @@ def AtomM.run {α : Type} (red : TransparencyMode) (m : AtomM α)
     MetaM α :=
   (m { red, evalAtom }).run' {}
 
-/-- Get the index corresponding to an atomic expression, if it has already been encountered, or
-put it in the list of atoms and return the new index, otherwise. -/
+/-- If an atomic expression has already been encountered, get the index and the stored form of the
+atom (which will be defeq at the specified transparency, but not necessarily syntactically equal).
+If the atomic expression has *not* already been encountered, store it in the list of atoms, and
+return the new index (and the stored form of the atom, which will be itself). -/
 def AtomM.addAtom (e : Expr) : AtomM (Nat × Expr) := do
   let c ← get
   for h : i in [:c.atoms.size] do

--- a/Mathlib/Util/AtomM.lean
+++ b/Mathlib/Util/AtomM.lean
@@ -48,7 +48,10 @@ def AtomM.run {α : Type} (red : TransparencyMode) (m : AtomM α)
 /-- If an atomic expression has already been encountered, get the index and the stored form of the
 atom (which will be defeq at the specified transparency, but not necessarily syntactically equal).
 If the atomic expression has *not* already been encountered, store it in the list of atoms, and
-return the new index (and the stored form of the atom, which will be itself). -/
+return the new index (and the stored form of the atom, which will be itself).
+
+In a normalizing tactic, the expression returned by `addAtom` should be considered the normal form.
+-/
 def AtomM.addAtom (e : Expr) : AtomM (Nat × Expr) := do
   let c ← get
   for h : i in [:c.atoms.size] do
@@ -60,7 +63,9 @@ open Qq in
 /-- If an atomic expression has already been encountered, get the index and the stored form of the
 atom (which will be defeq at the specified transparency, but not necessarily syntactically equal).
 If the atomic expression has *not* already been encountered, store it in the list of atoms, and
-return the new index (and the stored form of the atom, which will be itself). -/
+return the new index (and the stored form of the atom, which will be itself).
+
+In a normalizing tactic, the expression returned by `addAtom` should be considered the normal form. -/
 def AtomM.addAtomQ {u : Level} {α : Q(Type u)} (e : Q($α)) : AtomM (Nat × Q($α)) := AtomM.addAtom e
 
 end Mathlib.Tactic

--- a/Mathlib/Util/AtomM.lean
+++ b/Mathlib/Util/AtomM.lean
@@ -66,6 +66,9 @@ If the atomic expression has *not* already been encountered, store it in the lis
 return the new index (and the stored form of the atom, which will be itself).
 
 In a normalizing tactic, the expression returned by `addAtom` should be considered the normal form. -/
-def AtomM.addAtomQ {u : Level} {α : Q(Type u)} (e : Q($α)) : AtomM (Nat × Q($α)) := AtomM.addAtom e
+def AtomM.addAtomQ {u : Level} {α : Q(Type u)} (e : Q($α)) :
+    AtomM (Nat × {e' : Q($α) // $e =Q $e'}) := do
+  let (n, e') ← AtomM.addAtom e
+  return (n, ⟨e, ⟨⟩⟩)
 
 end Mathlib.Tactic

--- a/Mathlib/Util/AtomM.lean
+++ b/Mathlib/Util/AtomM.lean
@@ -65,10 +65,11 @@ atom (which will be defeq at the specified transparency, but not necessarily syn
 If the atomic expression has *not* already been encountered, store it in the list of atoms, and
 return the new index (and the stored form of the atom, which will be itself).
 
-In a normalizing tactic, the expression returned by `addAtom` should be considered the normal form. -/
+In a normalizing tactic, the expression returned by `addAtom` should be considered the normal form.
+-/
 def AtomM.addAtomQ {u : Level} {α : Q(Type u)} (e : Q($α)) :
     AtomM (Nat × {e' : Q($α) // $e =Q $e'}) := do
   let (n, e') ← AtomM.addAtom e
-  return (n, ⟨e, ⟨⟩⟩)
+  return (n, ⟨e', ⟨⟩⟩)
 
 end Mathlib.Tactic

--- a/MathlibTest/abel.lean
+++ b/MathlibTest/abel.lean
@@ -142,12 +142,21 @@ example [AddCommGroup α] (x y z : α) (h : False) (w : x - x = y + z) : False :
   guard_hyp w : 0 = y + z
   assumption
 
--- test that when `abel_nf` normalizes multiple expressions which contain a particular atom, it uses
--- a form for that atom which is consistent between expressions
+/-
+Test that when `abel_nf` normalizes multiple expressions which contain a particular atom, it uses a
+form for that atom which is consistent between expression.
+
+Note: This test is useless unless done at `=ₛ` (the level of syntactic equality); doing this test at
+`=` (the level of reducible equality) would not catch the erroneous old behaviour (normalizing one
+expression to `2 • a` and the other to `2 • x`).  But to get syntactic equality, we need to make the
+typeclass arguments agree, which requires some handholding in typeclass inference ... which is the
+reason for all the locally deleted instances here.
+-/
+attribute [-instance] Int.instAddGroup AddGroupWithOne.toAddGroup in
 example (x : ℤ) (R : ℤ → ℤ → Prop) (hR : Reflexive R) : True := by
   let a := x
   have : R (a + x) (x + a) := by
     abel_nf
-    guard_target = R ((2:ℤ) • a) ((2:ℤ) • a)
+    guard_target =ₛ R ((2:ℤ) • a) ((2:ℤ) • a)
     apply hR
   trivial

--- a/MathlibTest/abel.lean
+++ b/MathlibTest/abel.lean
@@ -141,3 +141,13 @@ example [AddCommGroup α] (x y z : α) (h : False) (w : x - x = y + z) : False :
   abel_nf at *
   guard_hyp w : 0 = y + z
   assumption
+
+-- test that when `abel_nf` normalizes multiple expressions which contain a particular atom, it uses
+-- a form for that atom which is consistent between expressions
+example (x : ℤ) (R : ℤ → ℤ → Prop) (hR : Reflexive R) : True := by
+  let a := x
+  have : R (a + x) (x + a) := by
+    abel_nf
+    guard_target = R ((2:ℤ) • a) ((2:ℤ) • a)
+    apply hR
+  trivial

--- a/MathlibTest/abel.lean
+++ b/MathlibTest/abel.lean
@@ -142,21 +142,22 @@ example [AddCommGroup α] (x y z : α) (h : False) (w : x - x = y + z) : False :
   guard_hyp w : 0 = y + z
   assumption
 
+abbrev myId (a : ℤ) : ℤ := a
+
 /-
 Test that when `abel_nf` normalizes multiple expressions which contain a particular atom, it uses a
 form for that atom which is consistent between expression.
 
 Note: This test is useless unless done at `=ₛ` (the level of syntactic equality); doing this test at
 `=` (the level of reducible equality) would not catch the erroneous old behaviour (normalizing one
-expression to `2 • a` and the other to `2 • x`).  But to get syntactic equality, we need to make the
-typeclass arguments agree, which requires some handholding in typeclass inference ... which is the
-reason for all the locally deleted instances here.
+expression to `2 • myId x` and the other to `2 • x`).  But to get syntactic equality, we need to
+make the typeclass arguments agree, which requires some handholding in typeclass inference ... which
+is the reason for all the locally deleted instances here.
 -/
 attribute [-instance] Int.instAddGroup AddGroupWithOne.toAddGroup in
 example (x : ℤ) (R : ℤ → ℤ → Prop) (hR : Reflexive R) : True := by
-  let a := x
-  have : R (a + x) (x + a) := by
+  have : R (myId x + x) (x + myId x) := by
     abel_nf
-    guard_target =ₛ R ((2:ℤ) • a) ((2:ℤ) • a)
+    guard_target =ₛ R ((2:ℤ) • myId x) ((2:ℤ) • myId x)
     apply hR
   trivial

--- a/MathlibTest/abel.lean
+++ b/MathlibTest/abel.lean
@@ -143,21 +143,18 @@ example [AddCommGroup α] (x y z : α) (h : False) (w : x - x = y + z) : False :
   assumption
 
 abbrev myId (a : ℤ) : ℤ := a
+irreducible_def myIdOpaque : ℤ → ℤ := myId
 
 /-
 Test that when `abel_nf` normalizes multiple expressions which contain a particular atom, it uses a
 form for that atom which is consistent between expression.
-
-Note: This test is useless unless done at `=ₛ` (the level of syntactic equality); doing this test at
-`=` (the level of reducible equality) would not catch the erroneous old behaviour (normalizing one
-expression to `2 • myId x` and the other to `2 • x`).  But to get syntactic equality, we need to
-make the typeclass arguments agree, which requires some handholding in typeclass inference ... which
-is the reason for all the locally deleted instances here.
 -/
-attribute [-instance] Int.instAddGroup AddGroupWithOne.toAddGroup in
 example (x : ℤ) (R : ℤ → ℤ → Prop) (hR : Reflexive R) : True := by
   have : R (myId x + x) (x + myId x) := by
     abel_nf
-    guard_target =ₛ R ((2:ℤ) • myId x) ((2:ℤ) • myId x)
+    -- `guard_target` is using reducible defeq, so we need to make sure it cannot unfold any `myId`s
+    -- in the goal state.
+    rw [← myIdOpaque_def]
+    guard_target = R ((2:ℤ) • myIdOpaque x) ((2:ℤ) • myIdOpaque x)
     apply hR
   trivial

--- a/MathlibTest/abel.lean
+++ b/MathlibTest/abel.lean
@@ -153,7 +153,7 @@ We can't use `guard_hyp h :ₛ` here, as while it does tell apart `x` and `myId 
 about differing instance paths.
 -/
 /--
-info: α : Type ?u.68666
+info: α : Type _
 a b : α
 x : ℤ
 R : ℤ → ℤ → Prop
@@ -162,6 +162,7 @@ h : R (2 • myId x) (2 • myId x)
 ⊢ True
 -/
 #guard_msgs (info) in
+set_option pp.mvars false in
 example (x : ℤ) (R : ℤ → ℤ → Prop) (hR : Reflexive R) : True := by
   have h : R (myId x + x) (x + myId x) := hR ..
   abel_nf at h

--- a/MathlibTest/abel.lean
+++ b/MathlibTest/abel.lean
@@ -142,19 +142,30 @@ example [AddCommGroup α] (x y z : α) (h : False) (w : x - x = y + z) : False :
   guard_hyp w : 0 = y + z
   assumption
 
+section
 abbrev myId (a : ℤ) : ℤ := a
-irreducible_def myIdOpaque : ℤ → ℤ := myId
 
 /-
 Test that when `abel_nf` normalizes multiple expressions which contain a particular atom, it uses a
-form for that atom which is consistent between expression.
+form for that atom which is consistent between expressions.
+
+We can't use `guard_hyp h :ₛ` here, as while it does tell apart `x` and `myId x`, it also complains
+about differing instance paths.
 -/
+/--
+info: α : Type ?u.68666
+a b : α
+x : ℤ
+R : ℤ → ℤ → Prop
+hR : Reflexive R
+h : R (2 • myId x) (2 • myId x)
+⊢ True
+-/
+#guard_msgs (info) in
 example (x : ℤ) (R : ℤ → ℤ → Prop) (hR : Reflexive R) : True := by
-  have : R (myId x + x) (x + myId x) := by
-    abel_nf
-    -- `guard_target` is using reducible defeq, so we need to make sure it cannot unfold any `myId`s
-    -- in the goal state.
-    rw [← myIdOpaque_def]
-    guard_target = R ((2:ℤ) • myIdOpaque x) ((2:ℤ) • myIdOpaque x)
-    apply hR
+  have h : R (myId x + x) (x + myId x) := hR ..
+  abel_nf at h
+  trace_state
   trivial
+
+end

--- a/MathlibTest/ring.lean
+++ b/MathlibTest/ring.lean
@@ -84,13 +84,25 @@ example (x : ℝ) (hx : x ≠ 0) :
   field_simp
   ring
 
--- test that when `ring_nf` normalizes multiple expressions which contain a particular atom, it uses
--- a form for that atom which is consistent between expressions
+/-
+Test that when `ring_nf` normalizes multiple expressions which contain a particular atom, it uses a
+form for that atom which is consistent between expressions.
+
+Note: This test is useless unless done at `=ₛ` (the level of syntactic equality); doing this test at
+`=` (the level of reducible equality) would not catch the erroneous old behaviour (normalizing one
+expression to `a * 2` and the other to `x * 2`).  But to get syntactic equality, we need to make the
+typeclass arguments agree, which requires some handholding in typeclass inference ... which is the
+reason for all the locally deleted instances here.
+-/
+attribute [-instance] instOfNat instNatCastInt Int.instSemiring Int.instOrderedCommRing
+  Int.instOrderedRing Int.instLinearOrderedCommRing Int.instMul NonUnitalNonAssocRing.toMul
+  NonUnitalNonAssocCommSemiring.toNonUnitalNonAssocSemiring
+  NonUnitalNonAssocRing.toNonUnitalNonAssocSemiring in
 example (x : ℤ) (R : ℤ → ℤ → Prop) : True := by
   let a := x
   have : R (a + x) (x + a) := by
     ring_nf
-    guard_target = R (a * 2) (a * 2)
+    guard_target =ₛ R (a * 2) (a * 2)
     exact test_sorry
   trivial
 

--- a/MathlibTest/ring.lean
+++ b/MathlibTest/ring.lean
@@ -84,6 +84,16 @@ example (x : ℝ) (hx : x ≠ 0) :
   field_simp
   ring
 
+-- test that when `ring_nf` normalizes multiple expressions which contain a particular atom, it uses
+-- a form for that atom which is consistent between expressions
+example (x : ℤ) (R : ℤ → ℤ → Prop) : True := by
+  let a := x
+  have : R (a + x) (x + a) := by
+    ring_nf
+    guard_target = R (a * 2) (a * 2)
+    exact test_sorry
+  trivial
+
 -- As reported at
 -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/ring_nf.20failing.20to.20fully.20normalize
 example (x : ℤ) (h : x - x + x = 0) : x = 0 := by

--- a/MathlibTest/ring.lean
+++ b/MathlibTest/ring.lean
@@ -84,25 +84,26 @@ example (x : ℝ) (hx : x ≠ 0) :
   field_simp
   ring
 
+abbrev myId (a : ℤ) : ℤ := a
+
 /-
 Test that when `ring_nf` normalizes multiple expressions which contain a particular atom, it uses a
 form for that atom which is consistent between expressions.
 
 Note: This test is useless unless done at `=ₛ` (the level of syntactic equality); doing this test at
 `=` (the level of reducible equality) would not catch the erroneous old behaviour (normalizing one
-expression to `a * 2` and the other to `x * 2`).  But to get syntactic equality, we need to make the
-typeclass arguments agree, which requires some handholding in typeclass inference ... which is the
-reason for all the locally deleted instances here.
+expression to `myId x * 2` and the other to `x * 2`).  But to get syntactic equality, we need to
+make the typeclass arguments agree, which requires some handholding in typeclass inference ... which
+is the reason for all the locally deleted instances here.
 -/
 attribute [-instance] instOfNat instNatCastInt Int.instSemiring Int.instOrderedCommRing
   Int.instOrderedRing Int.instLinearOrderedCommRing Int.instMul NonUnitalNonAssocRing.toMul
   NonUnitalNonAssocCommSemiring.toNonUnitalNonAssocSemiring
   NonUnitalNonAssocRing.toNonUnitalNonAssocSemiring in
 example (x : ℤ) (R : ℤ → ℤ → Prop) : True := by
-  let a := x
-  have : R (a + x) (x + a) := by
+  have : R (myId x + x) (x + myId x) := by
     ring_nf
-    guard_target =ₛ R (a * 2) (a * 2)
+    guard_target =ₛ R (myId x * 2) (myId x * 2)
     exact test_sorry
   trivial
 

--- a/MathlibTest/ring.lean
+++ b/MathlibTest/ring.lean
@@ -84,23 +84,6 @@ example (x : ℝ) (hx : x ≠ 0) :
   field_simp
   ring
 
-abbrev myId (a : ℤ) : ℤ := a
-irreducible_def myIdOpaque : ℤ → ℤ := myId
-
-/-
-Test that when `ring_nf` normalizes multiple expressions which contain a particular atom, it uses a
-form for that atom which is consistent between expressions.
--/
-example (x : ℤ) (R : ℤ → ℤ → Prop) : True := by
-  have : R (myId x + x) (x + myId x) := by
-    ring_nf
-    -- `guard_target` is using reducible defeq, so we need to make sure it cannot unfold any `myId`s
-    -- in the goal state.
-    rw [← myIdOpaque_def]
-    guard_target = R (myIdOpaque x * 2) (myIdOpaque x * 2)
-    exact test_sorry
-  trivial
-
 -- As reported at
 -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/ring_nf.20failing.20to.20fully.20normalize
 example (x : ℤ) (h : x - x + x = 0) : x = 0 := by
@@ -195,3 +178,28 @@ example {n : ℝ} (_hn : 0 ≤ n) : (n + 1 / 2) ^ 2 * (n + 1 + 1 / 3) ≤ (n + 1
   ring_nf
   trace_state
   exact test_sorry
+
+section
+abbrev myId (a : ℤ) : ℤ := a
+
+/-
+Test that when `ring_nf` normalizes multiple expressions which contain a particular atom, it uses a
+form for that atom which is consistent between expressions.
+
+We can't use `guard_hyp h :ₛ` here, as while it does tell apart `x` and `myId x`, it also complains
+about differing instance paths.
+-/
+/--
+info: x : ℤ
+R : ℤ → ℤ → Prop
+h : R (myId x * 2) (myId x * 2)
+⊢ True
+-/
+#guard_msgs (info) in
+example (x : ℤ) (R : ℤ → ℤ → Prop) : True := by
+  have h : R (myId x + x) (x + myId x) := test_sorry
+  ring_nf at h
+  trace_state
+  trivial
+
+end

--- a/MathlibTest/ring.lean
+++ b/MathlibTest/ring.lean
@@ -85,25 +85,19 @@ example (x : ℝ) (hx : x ≠ 0) :
   ring
 
 abbrev myId (a : ℤ) : ℤ := a
+irreducible_def myIdOpaque : ℤ → ℤ := myId
 
 /-
 Test that when `ring_nf` normalizes multiple expressions which contain a particular atom, it uses a
 form for that atom which is consistent between expressions.
-
-Note: This test is useless unless done at `=ₛ` (the level of syntactic equality); doing this test at
-`=` (the level of reducible equality) would not catch the erroneous old behaviour (normalizing one
-expression to `myId x * 2` and the other to `x * 2`).  But to get syntactic equality, we need to
-make the typeclass arguments agree, which requires some handholding in typeclass inference ... which
-is the reason for all the locally deleted instances here.
 -/
-attribute [-instance] instOfNat instNatCastInt Int.instSemiring Int.instOrderedCommRing
-  Int.instOrderedRing Int.instLinearOrderedCommRing Int.instMul NonUnitalNonAssocRing.toMul
-  NonUnitalNonAssocCommSemiring.toNonUnitalNonAssocSemiring
-  NonUnitalNonAssocRing.toNonUnitalNonAssocSemiring in
 example (x : ℤ) (R : ℤ → ℤ → Prop) : True := by
   have : R (myId x + x) (x + myId x) := by
     ring_nf
-    guard_target =ₛ R (myId x * 2) (myId x * 2)
+    -- `guard_target` is using reducible defeq, so we need to make sure it cannot unfold any `myId`s
+    -- in the goal state.
+    rw [← myIdOpaque_def]
+    guard_target = R (myIdOpaque x * 2) (myIdOpaque x * 2)
     exact test_sorry
   trivial
 


### PR DESCRIPTION
Algebraic normalization tactics (`ring`, `abel`, etc.) typically require a concept of "atom", with expressions which are t-defeq (for some transparency t) being identified.  However, the particular representative of this equivalence class which turns up in the final normalized expression is basically random.  (It often ends up being the "first", in some tree sense, occurrence of the equivalence class in the expression being normalized.)

This ends up being particularly unpredictable when multiple expressions are being normalized simultaneously, e.g. with `ring_nf` or `abel_nf`: it can occur that in different expressions, a different representative of the equivalence class is chosen.  For example, on current Mathlib,
```lean
example (x : ℤ) (R : ℤ → ℤ → Prop) : True := by
  let a := x
  have h : R (a + x) (x + a) := sorry
  ring_nf at h
```
the statement of `h` after the ring-normalization step is `h : R (a * 2) (x * 2)`.  Here `a` and `x` are reducibly defeq.  When normalizing `a + x`, the representative `a` was chosen for the equivalence class; when normalizing `x + a`, the representative `x` was chosen.

This PR implements a fix.  The `AtomM` monad (which is used for atom-tracking in `ring`, `abel`, etc.) has its `addAtom` function modified to report, not just the index of an atom, but also the stored form of the atom.  Then the code surrounding `addAtom` calls in the `ring`, `abel` and `module` tactics is modified to use the stored form of the atom, rather than the form actually encountered at that point in the expression.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
