### PR TITLE
feat: stop `ring`/`abel` from seeing algebraic operations inside `let`s

### DIFF
--- a/Archive/Imo/Imo2006Q3.lean
+++ b/Archive/Imo/Imo2006Q3.lean
@@ -107,9 +107,11 @@ theorem proof₂ (M : ℝ)
   calc 18 ^ 2 * 2 * α
       = 18 ^ 2 * α ^ 2 * α := by linear_combination -324 * α * hα
     _ = abs (-(18 ^ 2 * α ^ 2 * α)) := by rw [abs_neg, abs_of_nonneg]; positivity
-    _ = |a * 2 * (a ^ 2 - 2 ^ 2) + 2 * c * (2 ^ 2 - c ^ 2) + c * a * (c ^ 2 - a ^ 2)| := by ring_nf
+    _ = |a * 2 * (a ^ 2 - 2 ^ 2) + 2 * c * (2 ^ 2 - c ^ 2) + c * a * (c ^ 2 - a ^ 2)| := by
+        unfold a c
+        ring_nf
     _ ≤ M * (a ^ 2 + 2 ^ 2 + c ^ 2) ^ 2 := by apply h
-    _ = M * 48 ^ 2 := by linear_combination (324 * α ^ 2 + 1080) * M * hα
+    _ = M * 48 ^ 2 := by unfold a c; linear_combination (324 * α ^ 2 + 1080) * M * hα
 
 end Imo2006Q3
 

--- a/Archive/Imo/Imo2008Q2.lean
+++ b/Archive/Imo/Imo2008Q2.lean
@@ -105,7 +105,7 @@ theorem imo2008_q2b : Set.Infinite rationalSolutions := by
             · simp only [t, gt_iff_lt, lt_max_iff]; right; trivial
             exact ⟨rfl, rfl, rfl⟩
         · have hg : -z = g (x, y, z) := rfl
-          rw [hg, hz_def]; ring
+          rw [hg, hz_def]; unfold g; ring
       have h₂ : q < t * (t + 1) := by
         calc
           q < q + 1 := by linarith

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5249,5 +5249,6 @@ import Mathlib.Util.Superscript
 import Mathlib.Util.SynthesizeUsing
 import Mathlib.Util.Tactic
 import Mathlib.Util.TermBeta
+import Mathlib.Util.WHNF
 import Mathlib.Util.WhatsNew
 import Mathlib.Util.WithWeakNamespace

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
@@ -429,6 +429,7 @@ theorem abs_sub_convs_le (not_terminatedAt_n : ¬(of v).TerminatedAt n) :
       have tmp := sub_convs_eq stream_nth_eq
       simp only [stream_nth_fr_ne_zero, conts_eq.symm, pred_conts_eq.symm, if_false] at tmp
       rw [tmp]
+      unfold den'
       ring
     rwa [this]
   -- derive some tedious inequalities that we need to rewrite our goal

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -477,6 +477,7 @@ theorem comp_summable_nnreal (q : FormalMultilinearSeries 𝕜 F G) (p : FormalM
           (‖q c.length‖₊ * ∏ i, ‖p (c.blocksFun i)‖₊) * r ^ n :=
         mul_le_mul' (q.compAlongComposition_nnnorm p c) le_rfl
       _ = ‖q c.length‖₊ * rq ^ n * ((∏ i, ‖p (c.blocksFun i)‖₊) * rp ^ n) * r0 ^ n := by
+        unfold r
         ring
       _ ≤ Cq * Cp ^ n * r0 ^ n := mul_le_mul' (mul_le_mul' A B) le_rfl
       _ = Cq / 4 ^ n := by

--- a/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
@@ -167,7 +167,7 @@ theorem mem_A_of_differentiable {ε : ℝ} (hε : 0 < ε) {x : E} (hx : Differen
     _ ≤ δ * ‖z - x‖ + δ * ‖y - x‖ :=
       add_le_add (hR _ (ball_subset_ball hr.2.le hz)) (hR _ (ball_subset_ball hr.2.le hy))
     _ ≤ δ * r + δ * r := by rw [mem_ball_iff_norm] at hz hy; gcongr
-    _ = (ε / 2) * r := by ring
+    _ = (ε / 2) * r := by unfold δ; ring
     _ < ε * r := by gcongr; exacts [hr.1, half_lt_self hε]
 
 theorem norm_sub_le_of_mem_A {c : 𝕜} (hc : 1 < ‖c‖) {r ε : ℝ} (hε : 0 < ε) (hr : 0 < r) {x : E}

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
@@ -102,6 +102,7 @@ theorem Gamma_mul_add_mul_le_rpow_Gamma_mul_rpow_Gamma {s t a b : ℝ} (hs : 0 <
     have B : x ^ (a * s + b * t - 1) = x ^ (a * (s - 1)) * x ^ (b * (t - 1)) := by
       rw [← rpow_add hx, hab']; congr 1; ring
     rw [A, B]
+    unfold f
     ring
   · rw [one_div_one_div, one_div_one_div]
     congr 2 <;> exact setIntegral_congr_fun measurableSet_Ioi fun x hx => fpow (by assumption) _ hx

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -597,7 +597,7 @@ theorem integral_sin_pow_aux :
   · calc
       (∫ x in a..b, sin x ^ (n + 2)) = ∫ x in a..b, sin x ^ (n + 1) * sin x := by
         simp only [_root_.pow_succ]
-      _ = C + (↑n + 1) * ∫ x in a..b, cos x ^ 2 * sin x ^ n := by simp [H, h, sq]; ring
+      _ = C + (↑n + 1) * ∫ x in a..b, cos x ^ 2 * sin x ^ n := by simp [H, h, sq, C]; ring
       _ = C + (↑n + 1) * ∫ x in a..b, sin x ^ n - sin x ^ (n + 2) := by
         simp [cos_sq', sub_mul, ← pow_add, add_comm]
       _ = (C + (↑n + 1) * ∫ x in a..b, sin x ^ n) - (↑n + 1) * ∫ x in a..b, sin x ^ (n + 2) := by

--- a/Mathlib/Analysis/SpecialFunctions/Stirling.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Stirling.lean
@@ -82,7 +82,7 @@ theorem log_stirlingSeq_diff_hasSum (m : ℕ) :
     ring
   · have h : ∀ x ≠ (0 : ℝ), 1 + x⁻¹ = (x + 1) / x := fun x hx ↦ by field_simp [hx]
     simp (disch := positivity) only [log_stirlingSeq_formula, log_div, log_mul, log_exp,
-      factorial_succ, cast_mul, cast_succ, cast_zero, range_one, sum_singleton, h]
+      factorial_succ, cast_mul, cast_succ, cast_zero, range_one, sum_singleton, h, f]
     ring
 
 /-- The sequence `log ∘ stirlingSeq ∘ succ` is monotone decreasing -/

--- a/Mathlib/Data/Real/Pi/Irrational.lean
+++ b/Mathlib/Data/Real/Pi/Irrational.lean
@@ -106,7 +106,7 @@ private lemma recursion' (n : ℕ) :
   have (x) : u₂' x = (2 * n + 1) * f x ^ n - 2 * n * f x ^ (n - 1) := by
     cases n with
     | zero => simp [u₂']
-    | succ n => ring!
+    | succ n => simp only [u₂', f, Nat.add_one_sub_one]; ring
   simp_rw [this, sub_mul, mul_assoc _ _ (v₂ _)]
   have : Continuous v₂ := by fun_prop
   rw [mul_mul_mul_comm, integral_sub, mul_sub, add_sub_assoc]

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -414,7 +414,8 @@ lemma hasSum_int_completedSinZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
       rwa [summable_one_div_nat_rpow]
   refine (mellin_div_const .. ▸ hasSum_mellin_pi_mul_sq' (zero_lt_one.trans hs) hF h_sum).congr_fun
     fun n ↦ ?_
-  simp only [Int.sign_eq_sign, SignType.intCast_cast, sign_intCast, ← Int.cast_abs, ofReal_intCast]
+  simp only [Int.sign_eq_sign, SignType.intCast_cast, sign_intCast, ← Int.cast_abs, ofReal_intCast,
+    c]
   ring
 
 /-- Formula for `completedSinZeta` as a Dirichlet series in the convergence range

--- a/Mathlib/NumberTheory/SumPrimeReciprocals.lean
+++ b/Mathlib/NumberTheory/SumPrimeReciprocals.lean
@@ -46,6 +46,7 @@ lemma one_half_le_sum_primes_ge_one_div (k : ℕ) :
   suffices 1 / 2 ≤ S by
     convert this using 5
     rw [show 4 = 2 ^ 2 by norm_num, pow_right_comm]
+    unfold N₀ m
     ring
   suffices 2 * N₀ ≤ m * (2 * N₀).sqrt + 2 * N₀ * S by
     rwa [hN₀, ← mul_assoc, ← pow_two 2, ← mul_pow, sqrt_eq', ← sub_le_iff_le_add',

--- a/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
+++ b/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
@@ -66,7 +66,7 @@ def mkUnit {a : Units k} {A : 𝕎 k} (hA : A.coeff 0 = a) : Units (𝕎 k) :=
     have ha : (a : k) ^ p ^ (n + 1) = ↑(a ^ p ^ (n + 1)) := by norm_cast
     have ha_inv : (↑a⁻¹ : k) ^ p ^ (n + 1) = ↑(a ^ p ^ (n + 1))⁻¹ := by norm_cast
     simp only [nthRemainder_spec, inverseCoeff, succNthValUnits, hA,
-      one_coeff_eq_of_pos, Nat.succ_pos', ha_inv, ha, inv_pow]
+      one_coeff_eq_of_pos, Nat.succ_pos', ha_inv, ha, inv_pow, H_coeff]
     ring!)
 
 @[simp]

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro, Kim Morrison
 import Mathlib.Tactic.NormNum.Basic
 import Mathlib.Tactic.TryThis
 import Mathlib.Util.AtomM
+import Mathlib.Util.WHNF
 
 /-!
 # The `abel` tactic
@@ -458,7 +459,7 @@ partial def abelNFCore
       let pre : Simp.Simproc := fun e =>
         try
           guard <| root || parent != e -- recursion guard
-          let e ← withReducible <| whnfCore e (config := { zetaDelta := false })
+          let e ← withReducible <| whnfWithConfig e (config := { zetaDelta := false })
           guard e.isApp -- all interesting group expressions are applications
           let (a, pa) ← eval e (← mkContext e) { red := cfg.red, evalAtom } s
           guard !a.isAtom

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -458,7 +458,7 @@ partial def abelNFCore
       let pre : Simp.Simproc := fun e =>
         try
           guard <| root || parent != e -- recursion guard
-          let e ← withReducible <| whnf e
+          let e ← withReducible <| whnfCore e (config := { zetaDelta := false })
           guard e.isApp -- all interesting group expressions are applications
           let (a, pa) ← eval e (← mkContext e) { red := cfg.red, evalAtom } s
           guard !a.isAtom

--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -134,7 +134,8 @@ partial def parse {u : Level} {α : Q(Type u)} (sα : Q(CommSemiring $α))
   let els := do
     try pure <| Poly.const (← (← NormNum.derive e).toRat)
     catch _ => pure <| Poly.var (← addAtom e)
-  let .const n _ := (← withReducible <| whnf e).getAppFn | els
+  let e' ← withReducible <| whnfWithConfig e (config := { zetaDelta := false })
+  let .const n _ := e'.getAppFn | els
   match n, c.rα with
   | ``HAdd.hAdd, _ | ``Add.add, _ => match e with
     | ~q($a + $b) => pure <| (← parse sα c a).add (← parse sα c b)

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro, Aurélien Saue, Anne Baanen
 import Mathlib.Tactic.NormNum.Inv
 import Mathlib.Tactic.NormNum.Pow
 import Mathlib.Util.AtomM
+import Mathlib.Util.WHNF
 
 /-!
 # `ring` tactic
@@ -1083,7 +1084,7 @@ def isAtomOrDerivable {u} {α : Q(Type u)} (sα : Q(CommSemiring $α))
   let els := try
       pure <| some (evalCast sα (← derive e))
     catch _ => pure (some none)
-  let e' ← withReducible <| whnfCore e (config := { zetaDelta := false })
+  let e' ← withReducible <| whnfWithConfig e (config := { zetaDelta := false })
   let .const n _ := e'.getAppFn | els
   match n, c.rα, c.dα with
   | ``HAdd.hAdd, _, _ | ``Add.add, _, _
@@ -1105,7 +1106,7 @@ partial def eval {u : Lean.Level} {α : Q(Type u)} (sα : Q(CommSemiring $α))
   let els := do
     try evalCast sα (← derive e)
     catch _ => evalAtom sα e
-  let e' ← withReducible <| whnfCore e (config := { zetaDelta := false })
+  let e' ← withReducible <| whnfWithConfig e (config := { zetaDelta := false })
   let .const n _ := e'.getAppFn | els
   match n, c.rα, c.dα with
   | ``HAdd.hAdd, _, _ | ``Add.add, _, _ => match e with

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -1083,7 +1083,8 @@ def isAtomOrDerivable {u} {α : Q(Type u)} (sα : Q(CommSemiring $α))
   let els := try
       pure <| some (evalCast sα (← derive e))
     catch _ => pure (some none)
-  let .const n _ := (← withReducible <| whnf e).getAppFn | els
+  let e' ← withReducible <| whnfCore e (config := { zetaDelta := false })
+  let .const n _ := e'.getAppFn | els
   match n, c.rα, c.dα with
   | ``HAdd.hAdd, _, _ | ``Add.add, _, _
   | ``HMul.hMul, _, _ | ``Mul.mul, _, _
@@ -1104,7 +1105,8 @@ partial def eval {u : Lean.Level} {α : Q(Type u)} (sα : Q(CommSemiring $α))
   let els := do
     try evalCast sα (← derive e)
     catch _ => evalAtom sα e
-  let .const n _ := (← withReducible <| whnf e).getAppFn | els
+  let e' ← withReducible <| whnfCore e (config := { zetaDelta := false })
+  let .const n _ := e'.getAppFn | els
   match n, c.rα, c.dα with
   | ``HAdd.hAdd, _, _ | ``Add.add, _, _ => match e with
     | ~q($a + $b) =>

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -92,7 +92,7 @@ def rewrite (parent : Expr) (root := true) : M Simp.Result :=
     let pre : Simp.Simproc := fun e =>
       try
         guard <| root || parent != e -- recursion guard
-        let e ← withReducible <| whnf e
+        let e ← withReducible <| whnfCore e (config := { zetaDelta := false })
         guard e.isApp -- all interesting ring expressions are applications
         let ⟨u, α, e⟩ ← inferTypeQ' e
         let sα ← synthInstanceQ (q(CommSemiring $α) : Q(Type u))

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -92,7 +92,7 @@ def rewrite (parent : Expr) (root := true) : M Simp.Result :=
     let pre : Simp.Simproc := fun e =>
       try
         guard <| root || parent != e -- recursion guard
-        let e ← withReducible <| whnfCore e (config := { zetaDelta := false })
+        let e ← withReducible <| whnfWithConfig e (config := { zetaDelta := false })
         guard e.isApp -- all interesting ring expressions are applications
         let ⟨u, α, e⟩ ← inferTypeQ' e
         let sα ← synthInstanceQ (q(CommSemiring $α) : Q(Type u))

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -751,7 +751,7 @@ instance : SecondCountableTopology GHSpace := by
   calc
     dist p q = ghDist p.Rep q.Rep := dist_ghDist p q
     _ ≤ ε + ε / 2 + ε := main
-    _ = δ := by ring
+    _ = δ := by unfold ε; ring
 
 /-- Compactness criterion: a closed set of compact metric spaces is compact if the spaces have
 a uniformly bounded diameter, and for all `ε` the number of balls of radius `ε` required

--- a/Mathlib/Util/WHNF.lean
+++ b/Mathlib/Util/WHNF.lean
@@ -52,7 +52,7 @@ private def cache (useCache : Bool) (e r : Expr) : MetaM Expr := do
 `beta`, projection, `zeta` and `zetaDelta` reduction to be turned on or off explicitly. -/
 partial def whnfWithConfig (e : Expr) (config : WhnfCoreConfig := {}) : MetaM Expr :=
   let k := fun e => do
-    let useCache ← useWHNFCache e
+    let useCache ← useWHNFCache e config
     match (← cached? useCache e) with
     | some e' => pure e'
     | none    =>

--- a/Mathlib/Util/WHNF.lean
+++ b/Mathlib/Util/WHNF.lean
@@ -62,7 +62,7 @@ partial def whnfWithConfig (e : Expr) (config : WhnfCoreConfig := {}) : MetaM Ex
           | some v => cache useCache e v
           | none   =>
             match (← unfoldDefinition? e') with
-            | some e'' => cache useCache e (← whnfImp e'')
+            | some e'' => cache useCache e (← whnfWithConfig e'' config)
             | none => cache useCache e e'
   withIncRecDepth <| whnfEasyCases e k config
 

--- a/Mathlib/Util/WHNF.lean
+++ b/Mathlib/Util/WHNF.lean
@@ -35,6 +35,9 @@ private def cache (useCache : Bool) (e r : Expr) : MetaM Expr := do
     | _        => unreachable!
   return r
 
+/-- Compute the "weak head-normal form" of an expression.  This is a variant of the core function
+`Lean.Meta.whnf` which takes a config option of type `Lean.Meta.WhnfCoreConfig`, allowing `iota`,
+`beta`, projection, `zeta` and `zetaDelta` reduction to be turned on or off explicitly. -/
 partial def whnfWithConfig (e : Expr) (config : WhnfCoreConfig := {}) : MetaM Expr :=
   let k := fun e => do
     let useCache ← useWHNFCache e

--- a/Mathlib/Util/WHNF.lean
+++ b/Mathlib/Util/WHNF.lean
@@ -36,7 +36,7 @@ private def cache (useCache : Bool) (e r : Expr) : MetaM Expr := do
   return r
 
 partial def whnfWithConfig (e : Expr) (config : WhnfCoreConfig := {}) : MetaM Expr :=
-  withIncRecDepth <| whnfEasyCases e fun e => do
+  let k := fun e => do
     let useCache ← useWHNFCache e
     match (← cached? useCache e) with
     | some e' => pure e'
@@ -53,5 +53,6 @@ partial def whnfWithConfig (e : Expr) (config : WhnfCoreConfig := {}) : MetaM Ex
             match (← unfoldDefinition? e') with
             | some e'' => cache useCache e (← whnfImp e'')
             | none => cache useCache e e'
+  withIncRecDepth <| whnfEasyCases e k config
 
 end Lean.Meta

--- a/Mathlib/Util/WHNF.lean
+++ b/Mathlib/Util/WHNF.lean
@@ -3,7 +3,15 @@ Copyright (c) 2019 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Lean
+import Mathlib.Init
+
+/-!
+# WHNF with configuration options
+
+This file provides `Lean.Meta.whnfWithConfig`, a variant of the core function `Lean.Meta.whnf` which
+takes a config option of type `Lean.Meta.WhnfCoreConfig`, allowing `iota`, `beta`, projection,
+`zeta` and `zetaDelta` reduction to be turned on or off explicitly.
+-/
 
 namespace Lean.Meta
 

--- a/MathlibTest/abel.lean
+++ b/MathlibTest/abel.lean
@@ -150,3 +150,10 @@ example (a : ℤ) : True := by
   abel_nf at h2
   guard_hyp h2 : (3:ℤ) • a + (3:ℤ) • b = (3:ℤ) • 1
   trivial
+
+-- check that abel_nf does not unfold lets whose head is an algebraic operation
+/-- error: abel_nf made no progress -/
+#guard_msgs in
+example (a : ℤ) (f : ℤ → ℤ) (h : f (1 - a) = a) : True := by
+  set b := 1 - a
+  abel_nf at h

--- a/MathlibTest/abel.lean
+++ b/MathlibTest/abel.lean
@@ -141,3 +141,12 @@ example [AddCommGroup α] (x y z : α) (h : False) (w : x - x = y + z) : False :
   abel_nf at *
   guard_hyp w : 0 = y + z
   assumption
+
+-- check that abel_nf does not unfold lets whose head is an algebraic operation
+example (a : ℤ) : True := by
+  have h1 : a + (1 - a) = 1 := by abel
+  set b := 1 - a
+  have h2 := congr(3 • $h1)
+  abel_nf at h2
+  guard_hyp h2 : (3:ℤ) • a + (3:ℤ) • b = (3:ℤ) • 1
+  trivial

--- a/MathlibTest/ring.lean
+++ b/MathlibTest/ring.lean
@@ -151,6 +151,17 @@ example (a : ℤ) : True := by
   guard_hyp h2 : a ^ 2 - b ^ 2 = a - b
   trivial
 
+-- check that ring_nf does not unfold lets whose head is an algebraic operation
+/--
+warning: 'ring_nf at _h' tactic does nothing
+note: this linter can be disabled with `set_option linter.unusedTactic false`
+-/
+#guard_msgs in
+example (a : ℤ) (f : ℤ → ℤ) (_h : f (1 - a) = a) : True := by
+  set b := 1 - a
+  ring_nf at _h
+  trivial
+
 -- Powers in the exponent get evaluated correctly
 example (X : ℤ) : (X^5 + 1) * (X^2^3 + X) = X^13 + X^8 + X^6 + X := by ring
 

--- a/MathlibTest/ring.lean
+++ b/MathlibTest/ring.lean
@@ -142,6 +142,15 @@ example (a b : ℤ) : a+b=0 ↔ b+a=0 := by
   have : 3 = 3 := rfl
   ring_nf -- reduced to `True` with mdata
 
+-- check that ring_nf does not unfold lets whose head is an algebraic operation
+example (a : ℤ) : True := by
+  have h1 : a + (1 - a) = 1 := by ring
+  set b := 1 - a
+  have h2 := congr((a - b) * $h1)
+  ring_nf at h2
+  guard_hyp h2 : a ^ 2 - b ^ 2 = a - b
+  trivial
+
 -- Powers in the exponent get evaluated correctly
 example (X : ℤ) : (X^5 + 1) * (X^2^3 + X) = X^13 + X^8 + X^6 + X := by ring
 


### PR DESCRIPTION
This draft PR illustrates a feature I would like to see in core: a variant of `whnf` which allows particular kinds of reduction, such as zeta-delta reduction, to be turned off.  Here it is used to make ring-normalization and abelian-group-normalization a bit more responsive to what (I think) users expect: these normalizations would no longer look inside user-defined lets to see algebraic operations in those expressions.

Note: In Lean/Mathlib 3, `ring` matched for algebraic operations on an algebraic expression `e` itself, not on `← whnfR e`.  So mathlib3 `ring` didn't see algebraic operations inside `let`s -- but it also didn't see algebraic operations requiring beta-reduction (like `(fun t ↦ t + 1) x`) or see inside abbreviations.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/239415-metaprogramming-.2F-tactics/topic/whnf.20variant.20which.20preserves.20let-bindings)

Update: fortuitously, it looks like the new core PR https://github.com/leanprover/lean4/pull/6053 will provide this feature!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
