### PR TITLE
[Merged by Bors] - doc(GroupTheory/Commensurable): clarify some docstrings

### DIFF
--- a/Mathlib/GroupTheory/Commensurable.lean
+++ b/Mathlib/GroupTheory/Commensurable.lean
@@ -8,19 +8,23 @@ import Mathlib.GroupTheory.Index
 /-!
 # Commensurability for subgroups
 
-This file defines commensurability for subgroups of a group `G`. It then goes on to prove that
-commensurability defines an equivalence relation and finally defines the commensurator of a subgroup
-of `G`.
+Two subgroups `H` and `K` of a group `G` are commensurable if `H ∩ K` has finite index in both `H`
+and `K`.
+
+This file defines commensurability for subgroups of a group `G`. It goes on to prove that
+commensurability defines an equivalence relation on subgroups of `G` and finally defines the
+commensurator of a subgroup `H` of `G`, which is the elements `g` of `G` such that `gHg⁻¹` is
+commensurable with `H`.
 
 ## Main definitions
 
-* `Commensurable`: defines commensurability for two subgroups `H`, `K` of `G`
-* `commensurator`: defines the commensurator of a subgroup `H` of `G`.
+* `Commensurable H K`: the statement that the subgroups `H` and `K` of `G` are commensurable.
+* `commensurator H`: the commensurator of a subgroup `H` of `G`.
 
 ## Implementation details
 
 We define the commensurator of a subgroup `H` of `G` by first defining it as a subgroup of
-`(conjAct G)`, which we call commensurator' and then taking the pre-image under
+`(conjAct G)`, which we call `commensurator'` and then taking the pre-image under
 the map `G → (conjAct G)` to obtain our commensurator as a subgroup of `G`.
 -/
 

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -42,16 +42,16 @@ open Cardinal
 
 variable {G G' : Type*} [Group G] [Group G'] (H K L : Subgroup G)
 
-/-- The index of a subgroup as a natural number, and returns 0 if the index is infinite. -/
+/-- The index of a subgroup as a natural number. Returns `0` if the index is infinite. -/
 @[to_additive "The index of a subgroup as a natural number,
 and returns 0 if the index is infinite."]
 noncomputable def index : ℕ :=
   Nat.card (G ⧸ H)
 
-/-- The relative index of a subgroup as a natural number,
-  and returns 0 if the relative index is infinite. -/
-@[to_additive "The relative index of a subgroup as a natural number,
-and returns 0 if the relative index is infinite."]
+/-- If `H` and `K` are subgroups of a group `G`, then `relindex H K : ℕ` is the index
+of `H ∩ K` in `K`. The function returns `0` if the index is infinite. -/
+@[to_additive "If `H` and `K` are subgroups of an additive group `G`, then `relindex H K : ℕ`
+is the index of `H ∩ K` in `K`. The function returns `0` if the index is infinite."]
 noncomputable def relindex : ℕ :=
   (H.subgroupOf K).index
 

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -43,8 +43,8 @@ open Cardinal
 variable {G G' : Type*} [Group G] [Group G'] (H K L : Subgroup G)
 
 /-- The index of a subgroup as a natural number. Returns `0` if the index is infinite. -/
-@[to_additive "The index of a subgroup as a natural number,
-and returns 0 if the index is infinite."]
+@[to_additive "The index of an additive subgroup as a natural number.
+Returns 0 if the index is infinite."]
 noncomputable def index : ℕ :=
   Nat.card (G ⧸ H)
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I was trying to learn about commensurators from mathlib, but all the docstrings seemed to have been written for people who already knew what the definitions were. This wasn't hard to fix.