### PR TITLE
[Merged by Bors] - feat: `isCoprime_mul_units_left`, `isCoprime_mul_units_right`

### DIFF
--- a/Mathlib/RingTheory/Coprime/Basic.lean
+++ b/Mathlib/RingTheory/Coprime/Basic.lean
@@ -244,7 +244,7 @@ end ScalarTower
 
 section CommSemiringUnit
 
-variable {R : Type*} [CommSemiring R] {x u v: R}
+variable {R : Type*} [CommSemiring R] {x u v : R}
 
 theorem isCoprime_mul_unit_left_left (hu : IsUnit x) (y z : R) :
     IsCoprime (x * y) z ↔ IsCoprime y z :=
@@ -272,13 +272,13 @@ theorem isCoprime_mul_unit_right (hu : IsUnit x) (y z : R) :
     IsCoprime (y * x) (z * x) ↔ IsCoprime y z :=
   (isCoprime_mul_unit_right_left hu y (z * x)).trans (isCoprime_mul_unit_right_right hu y z)
 
-theorem isCoprime_mul_units_left (hu : IsUnit u) (hv: IsUnit v) (y z: R) :
+theorem isCoprime_mul_units_left (hu : IsUnit u) (hv : IsUnit v) (y z : R) :
     IsCoprime (u * y) (v * z) ↔ IsCoprime y z :=
   Iff.trans
     (isCoprime_mul_unit_left_left hu _ _)
     (isCoprime_mul_unit_left_right hv _ _)
 
-theorem isCoprime_mul_units_right (hu : IsUnit u) (hv: IsUnit v) (y z : R) :
+theorem isCoprime_mul_units_right (hu : IsUnit u) (hv : IsUnit v) (y z : R) :
     IsCoprime (y * u) (z * v) ↔ IsCoprime y z :=
   Iff.trans
     (isCoprime_mul_unit_right_left hu _ _)

--- a/Mathlib/RingTheory/Coprime/Basic.lean
+++ b/Mathlib/RingTheory/Coprime/Basic.lean
@@ -244,7 +244,7 @@ end ScalarTower
 
 section CommSemiringUnit
 
-variable {R : Type*} [CommSemiring R] {x : R}
+variable {R : Type*} [CommSemiring R] {x u v: R}
 
 theorem isCoprime_mul_unit_left_left (hu : IsUnit x) (y z : R) :
     IsCoprime (x * y) z ↔ IsCoprime y z :=
@@ -271,6 +271,18 @@ theorem isCoprime_mul_unit_right_right (hu : IsUnit x) (y z : R) :
 theorem isCoprime_mul_unit_right (hu : IsUnit x) (y z : R) :
     IsCoprime (y * x) (z * x) ↔ IsCoprime y z :=
   (isCoprime_mul_unit_right_left hu y (z * x)).trans (isCoprime_mul_unit_right_right hu y z)
+
+theorem isCoprime_mul_units_left (hu : IsUnit u) (hv: IsUnit v) (y z: R) :
+    IsCoprime (u * y) (v * z) ↔ IsCoprime y z :=
+  Iff.trans
+    (isCoprime_mul_unit_left_left hu _ _)
+    (isCoprime_mul_unit_left_right hv _ _)
+
+theorem isCoprime_mul_units_right (hu : IsUnit u) (hv: IsUnit v) (y z : R) :
+    IsCoprime (y * u) (z * v) ↔ IsCoprime y z :=
+  Iff.trans
+    (isCoprime_mul_unit_right_left hu _ _)
+    (isCoprime_mul_unit_right_right hv _ _)
 
 end CommSemiringUnit
 

--- a/Mathlib/RingTheory/Coprime/Basic.lean
+++ b/Mathlib/RingTheory/Coprime/Basic.lean
@@ -256,10 +256,6 @@ theorem isCoprime_mul_unit_left_right (hu : IsUnit x) (y z : R) :
   let ⟨u, hu⟩ := hu
   hu ▸ isCoprime_group_smul_right u y z
 
-theorem isCoprime_mul_unit_left (hu : IsUnit x) (y z : R) :
-    IsCoprime (x * y) (x * z) ↔ IsCoprime y z :=
-  (isCoprime_mul_unit_left_left hu y (x * z)).trans (isCoprime_mul_unit_left_right hu y z)
-
 theorem isCoprime_mul_unit_right_left (hu : IsUnit x) (y z : R) :
     IsCoprime (y * x) z ↔ IsCoprime y z :=
   mul_comm x y ▸ isCoprime_mul_unit_left_left hu y z
@@ -267,10 +263,6 @@ theorem isCoprime_mul_unit_right_left (hu : IsUnit x) (y z : R) :
 theorem isCoprime_mul_unit_right_right (hu : IsUnit x) (y z : R) :
     IsCoprime y (z * x) ↔ IsCoprime y z :=
   mul_comm x z ▸ isCoprime_mul_unit_left_right hu y z
-
-theorem isCoprime_mul_unit_right (hu : IsUnit x) (y z : R) :
-    IsCoprime (y * x) (z * x) ↔ IsCoprime y z :=
-  (isCoprime_mul_unit_right_left hu y (z * x)).trans (isCoprime_mul_unit_right_right hu y z)
 
 theorem isCoprime_mul_units_left (hu : IsUnit u) (hv : IsUnit v) (y z : R) :
     IsCoprime (u * y) (v * z) ↔ IsCoprime y z :=
@@ -283,6 +275,14 @@ theorem isCoprime_mul_units_right (hu : IsUnit u) (hv : IsUnit v) (y z : R) :
   Iff.trans
     (isCoprime_mul_unit_right_left hu _ _)
     (isCoprime_mul_unit_right_right hv _ _)
+
+theorem isCoprime_mul_unit_left (hu : IsUnit x) (y z : R) :
+    IsCoprime (x * y) (x * z) ↔ IsCoprime y z :=
+  isCoprime_mul_units_left hu hu _ _
+
+theorem isCoprime_mul_unit_right (hu : IsUnit x) (y z : R) :
+    IsCoprime (y * x) (z * x) ↔ IsCoprime y z :=
+  isCoprime_mul_units_right hu hu _ _
 
 end CommSemiringUnit
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Add `isCoprime_mul_units_left` and `isCoprime_mul_units_right`. These are slight generalizations of same unit version `isCoprime_mul_unit_left` and `isCoprime_mul_unit_right`. Currently exists as a lemma in #18882.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
