### PR TITLE
[Merged by Bors] - feat(SetTheory/ZFC/Basic): results on pairs

### DIFF
--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -893,21 +893,21 @@ theorem mem_pair {x y z : ZFSet.{u}} : x ∈ ({y, z} : ZFSet) ↔ x = y ∨ x = 
   simp
 
 @[simp]
-theorem pair_self (x : ZFSet) : {x, x} = ({x} : ZFSet) := by
+theorem pair_eq_singleton (x : ZFSet) : {x, x} = ({x} : ZFSet) := by
   ext
   simp
 
 @[simp]
-theorem pair_eq_singleton {x y z : ZFSet} : ({x, y} : ZFSet) = {z} ↔ x = z ∧ y = z := by
+theorem pair_eq_singleton_iff {x y z : ZFSet} : ({x, y} : ZFSet) = {z} ↔ x = z ∧ y = z := by
   refine ⟨fun h ↦ ?_, ?_⟩
   · rw [← mem_singleton, ← mem_singleton]
     simp [← h]
   · rintro ⟨rfl, rfl⟩
-    exact pair_self y
+    exact pair_eq_singleton y
 
 @[simp]
-theorem singleton_eq_pair {x y z : ZFSet} : ({x} : ZFSet) = {y, z} ↔ x = y ∧ x = z := by
-  rw [eq_comm, pair_eq_singleton]
+theorem singleton_eq_pair_iff {x y z : ZFSet} : ({x} : ZFSet) = {y, z} ↔ x = y ∧ x = z := by
+  rw [eq_comm, pair_eq_singleton_iff]
   simp_rw [eq_comm]
 
 /-- `omega` is the first infinite von Neumann ordinal -/
@@ -1233,7 +1233,7 @@ theorem pair_injective : Function.Injective2 pair := by
     rintro rfl
     simpa [eq_comm] using H {y, y'}
   have hx := H {x, y}
-  simp_rw [pair_eq_singleton, true_and, or_true, true_iff] at hx
+  simp_rw [pair_eq_singleton_iff, true_and, or_true, true_iff] at hx
   refine ⟨rfl, hx.elim he fun hy ↦ Or.elim ?_ he id⟩
   simpa using ZFSet.ext_iff.1 hy y
 


### PR DESCRIPTION
We add a few lemmas on unordered pairs and use them to golf down the injectivity of the Kuratowski pair.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
