### PR TITLE
[Merged by Bors] - refactor(ENat.Lattice): ENat.sSup_mem_of_nonempty_of_lt_top naming convention

### DIFF
--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -105,12 +105,12 @@ lemma finite_of_sSup_lt_top (h : sSup s < ⊤) : s.Finite := by
   simp only [top_le_iff]
   exact sSup_eq_top_of_infinite h
 
-lemma sSup_mem_of_Nonempty_of_lt_top [Nonempty s] (hs' : sSup s < ⊤) : sSup s ∈ s :=
+lemma sSup_mem_of_nonempty_of_lt_top [Nonempty s] (hs' : sSup s < ⊤) : sSup s ∈ s :=
   Nonempty.csSup_mem nonempty_of_nonempty_subtype (finite_of_sSup_lt_top hs')
 
 lemma exists_eq_iSup_of_lt_top [Nonempty ι] (h : ⨆ i, f i < ⊤) :
     ∃ i, f i = ⨆ i, f i :=
-  sSup_mem_of_Nonempty_of_lt_top h
+  sSup_mem_of_nonempty_of_lt_top h
 
 lemma exists_eq_iSup₂_of_lt_top {ι₁ ι₂ : Type*} {f : ι₁ → ι₂ → ℕ∞} [Nonempty ι₁] [Nonempty ι₂]
     (h : ⨆ i, ⨆ j, f i j < ⊤) : ∃ i j, f i j = ⨆ i, ⨆ j, f i j := by

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -194,7 +194,7 @@ lemma height_orderIso (f : α ≃o β) (x : α) : height (f x) = height x := by
 
 private lemma exists_eq_iSup_of_iSup_eq_coe {α : Type*} [Nonempty α] {f : α → ℕ∞} {n : ℕ}
     (h : (⨆ x, f x) = n) : ∃ x, f x = n := by
-  obtain ⟨x, hx⟩ := ENat.sSup_mem_of_Nonempty_of_lt_top (h ▸ ENat.coe_lt_top _)
+  obtain ⟨x, hx⟩ := ENat.sSup_mem_of_nonempty_of_lt_top (h ▸ ENat.coe_lt_top _)
   use x
   simpa [hx] using h
 


### PR DESCRIPTION
The `of_nonempty` should not be capitalized.
