### PR TITLE
[Merged by Bors] - feat: add `ENat.map` and lemmas

### DIFF
--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -170,14 +170,14 @@ lemma order_eq_top_iff {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) :
     hf.order = ⊤ ↔ ∀ᶠ z in 𝓝[≠] x, f z = 0 := by
   unfold order
   by_cases h : hf.choose_spec.order = ⊤
-  · rw [h, WithTop.map_top, ← WithTop.coe_natCast,
+  · rw [h, ENat.map_top, ← WithTop.coe_natCast,
       top_sub, eq_self, true_iff, eventually_nhdsWithin_iff]
     rw [AnalyticAt.order_eq_top_iff] at h
     filter_upwards [h] with z hf hz
     rwa [smul_eq_zero_iff_right <| pow_ne_zero _ (sub_ne_zero.mpr hz)] at hf
-  · obtain ⟨m, hm⟩ := WithTop.ne_top_iff_exists.mp h
-    rw [← hm, WithTop.map_coe, sub_eq_top_iff, eq_false_intro WithTop.coe_ne_top, false_or]
-    simp only [WithTop.natCast_ne_top, false_iff]
+  · obtain ⟨m, hm⟩ := ENat.ne_top_iff_exists.mp h
+    simp only [← hm, ENat.map_coe, WithTop.coe_natCast, sub_eq_top_iff, WithTop.natCast_ne_top,
+      or_self, false_iff]
     contrapose! h
     rw [AnalyticAt.order_eq_top_iff]
     rw [← hf.choose_spec.frequently_eq_iff_eventually_eq analyticAt_const]
@@ -189,7 +189,7 @@ lemma order_eq_int_iff {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (n :
     ∃ g : 𝕜 → E, AnalyticAt 𝕜 g x ∧ g x ≠ 0 ∧ ∀ᶠ z in 𝓝[≠] x, f z = (z - x) ^ n • g z := by
   unfold order
   by_cases h : hf.choose_spec.order = ⊤
-  · rw [h, WithTop.map_top, ← WithTop.coe_natCast, top_sub,
+  · rw [h, ENat.map_top, ← WithTop.coe_natCast, top_sub,
       eq_false_intro WithTop.top_ne_coe, false_iff]
     rw [AnalyticAt.order_eq_top_iff] at h
     refine fun ⟨g, hg_an, hg_ne, hg_eq⟩ ↦ hg_ne ?_
@@ -200,8 +200,8 @@ lemma order_eq_int_iff {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (n :
     filter_upwards [h, hg_eq] with z hfz hfz_eq hz
     rwa [hfz_eq hz, ← mul_smul, smul_eq_zero_iff_right] at hfz
     exact mul_ne_zero (pow_ne_zero _ (sub_ne_zero.mpr hz)) (zpow_ne_zero _ (sub_ne_zero.mpr hz))
-  · obtain ⟨m, h⟩ := WithTop.ne_top_iff_exists.mp h
-    rw [← h, WithTop.map_coe, ← WithTop.coe_natCast, ← coe_sub, WithTop.coe_inj]
+  · obtain ⟨m, h⟩ := ENat.ne_top_iff_exists.mp h
+    rw [← h, ENat.map_coe, ← WithTop.coe_natCast, ← coe_sub, WithTop.coe_inj]
     obtain ⟨g, hg_an, hg_ne, hg_eq⟩ := (AnalyticAt.order_eq_nat_iff _ _).mp h.symm
     replace hg_eq : ∀ᶠ (z : 𝕜) in 𝓝[≠] x, f z = (z - x) ^ (↑m - ↑hf.choose : ℤ) • g z := by
       rw [eventually_nhdsWithin_iff]
@@ -216,10 +216,10 @@ lemma order_eq_int_iff {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (n :
 lemma _root_.AnalyticAt.meromorphicAt_order {f : 𝕜 → E} {x : 𝕜} (hf : AnalyticAt 𝕜 f x) :
     hf.meromorphicAt.order = hf.order.map (↑) := by
   rcases eq_or_ne hf.order ⊤ with ho | ho
-  · rw [ho, WithTop.map_top, order_eq_top_iff]
+  · rw [ho, ENat.map_top, order_eq_top_iff]
     exact (hf.order_eq_top_iff.mp ho).filter_mono nhdsWithin_le_nhds
-  · obtain ⟨n, hn⟩ := WithTop.ne_top_iff_exists.mp ho
-    simp_rw [← hn, WithTop.map_coe, order_eq_int_iff, zpow_natCast]
+  · obtain ⟨n, hn⟩ := ENat.ne_top_iff_exists.mp ho
+    simp_rw [← hn, ENat.map_coe, order_eq_int_iff, zpow_natCast]
     rcases (hf.order_eq_nat_iff _).mp hn.symm with ⟨g, h1, h2, h3⟩
     exact ⟨g, h1, h2, h3.filter_mono nhdsWithin_le_nhds⟩
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -317,4 +317,39 @@ lemma add_lt_add_iff_right {k : ℕ∞} (h : k ≠ ⊤) : n + k < m + k ↔ n < 
 lemma add_lt_add_iff_left {k : ℕ∞} (h : k ≠ ⊤) : k + n < k + m ↔ n < m :=
   WithTop.add_lt_add_iff_left h
 
+variable {α : Type*}
+
+def map (f : ℕ → α) (k : ℕ∞) : WithTop α := WithTop.map f k
+
+@[simp]
+theorem map_top (f : ℕ → α) : map f ⊤ = ⊤ := rfl
+
+@[simp]
+theorem map_coe (f : ℕ → α) (a : ℕ) : map f a = f a := rfl
+
+@[simp]
+theorem map_zero (f : ℕ → α) : map f 0 = f 0 := rfl
+
+@[simp]
+theorem map_one (f : ℕ → α) : map f 1 = f 1 := rfl
+
+@[simp]
+theorem map_ofNat (f : ℕ → α) (n : ℕ) [n.AtLeastTwo] : map f (no_index (OfNat.ofNat n)) = f n := rfl
+
+@[simp]
+lemma map_eq_top_iff {f : ℕ → α} : map f n = ⊤ ↔ n = ⊤ := WithTop.map_eq_top_iff
+
+@[simp]
+theorem map_natCast_nonneg [AddMonoidWithOne α] [PartialOrder α]
+    [AddLeftMono α] [ZeroLEOneClass α] : 0 ≤ n.map (Nat.cast : ℕ → α) := by
+  cases n <;> simp
+
+@[simp]
+theorem strictMono_map_iff {f : ℕ → α} [Preorder α] : StrictMono (ENat.map f) ↔ StrictMono f :=
+  WithTop.strictMono_map_iff
+
+@[simp]
+theorem monotone_map_iff {f : ℕ → α} [Preorder α] : Monotone (ENat.map f) ↔ Monotone f :=
+  WithTop.monotone_map_iff
+
 end ENat

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -274,6 +274,8 @@ protected lemma exists_nat_gt {n : ℕ∞} (hn : n ≠ ⊤) : ∃ m : ℕ, n < m
   obtain ⟨m, hm⟩ := exists_gt n
   exact ⟨m, Nat.cast_lt.2 hm⟩
 
+lemma ne_top_iff_exists {x : ℕ∞} : x ≠ ⊤ ↔ ∃ a : ℕ, ↑a = x := WithTop.ne_top_iff_exists
+
 @[simp] lemma sub_eq_top_iff : a - b = ⊤ ↔ a = ⊤ ∧ b ≠ ⊤ := WithTop.sub_eq_top_iff
 lemma sub_ne_top_iff : a - b ≠ ⊤ ↔ a ≠ ⊤ ∨ b = ⊤ := WithTop.sub_ne_top_iff
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -321,6 +321,9 @@ lemma add_lt_add_iff_left {k : ℕ∞} (h : k ≠ ⊤) : k + n < k + m ↔ n < m
 
 variable {α : Type*}
 
+/--
+Specialization of `WithTop.map` to `ENat`.
+-/
 def map (f : ℕ → α) (k : ℕ∞) : WithTop α := WithTop.map f k
 
 @[simp]

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -354,4 +354,64 @@ theorem strictMono_map_iff {f : ℕ → α} [Preorder α] : StrictMono (ENat.map
 theorem monotone_map_iff {f : ℕ → α} [Preorder α] : Monotone (ENat.map f) ↔ Monotone f :=
   WithTop.monotone_map_iff
 
+@[simp]
+protected theorem map_add {β F} [Add β] [FunLike F ℕ β] [AddHomClass F ℕ β]
+    (f : F) (a b : ℕ∞) : (a + b).map f = a.map f + b.map f :=
+  WithTop.map_add f a b
+
+/-- A version of `ENat.map` for `OneHom`s. -/
+-- @[to_additive (attr := simps (config := .asFn))
+--   "A version of `ENat.map` for `ZeroHom`s"]
+protected def _root_.OneHom.ENatMap {N : Type*} [One N] (f : OneHom ℕ N) :
+    OneHom ℕ∞ (WithTop N) where
+  toFun := ENat.map f
+  map_one' := by simp
+
+/-- A version of `ENat.map` for `ZeroHom`s. -/
+protected def _root_.ZeroHom.ENatMap {N : Type*} [Zero N] (f : ZeroHom ℕ N) :
+    ZeroHom ℕ∞ (WithTop N) where
+  toFun := ENat.map f
+  map_zero' := by simp
+
+/-- A version of `WithTop.map` for `AddHom`s. -/
+@[simps (config := .asFn)]
+protected def _root_.AddHom.ENatMap {N : Type*} [Add N] (f : AddHom ℕ N) :
+    AddHom ℕ∞ (WithTop N) where
+  toFun := ENat.map f
+  map_add' := ENat.map_add f
+
+/-- A version of `WithTop.map` for `AddMonoidHom`s. -/
+@[simps (config := .asFn)]
+protected def _root_.AddMonoidHom.ENatMap {N : Type*} [AddZeroClass N]
+    (f : ℕ →+ N) : ℕ∞ →+ WithTop N :=
+  { ZeroHom.ENatMap f.toZeroHom, AddHom.ENatMap f.toAddHom with toFun := ENat.map f }
+
+/-- A version of `ENat.map` for `MonoidWithZeroHom`s. -/
+@[simps (config := .asFn)]
+protected def _root_.MonoidWithZeroHom.ENatMap {S : Type*} [MulZeroOneClass S] [DecidableEq S]
+    [Nontrivial S] (f : ℕ →*₀ S)
+    (hf : Function.Injective f) : ℕ∞ →*₀ WithTop S :=
+  { f.toZeroHom.ENatMap, f.toMonoidHom.toOneHom.ENatMap with
+    toFun := ENat.map f
+    map_mul' := fun x y => by
+      have : ∀ z, map f z = 0 ↔ z = 0 := fun z =>
+        (Option.map_injective hf).eq_iff' f.toZeroHom.ENatMap.map_zero
+      rcases Decidable.eq_or_ne x 0 with (rfl | hx)
+      · simp
+      rcases Decidable.eq_or_ne y 0 with (rfl | hy)
+      · simp
+      induction' x with x
+      · simp [hy, this]
+      induction' y with y
+      · have : (f x : WithTop S) ≠ 0 := by simpa [hf.eq_iff' (_root_.map_zero f)] using hx
+        simp [mul_top hx, WithTop.mul_top this]
+      · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: `simp [← coe_mul]` times out
+        simp only [map_coe, ← coe_mul, map_mul, WithTop.coe_mul] }
+
+/-- A version of `ENat.map` for `RingHom`s. -/
+@[simps (config := .asFn)]
+protected def _root_.RingHom.ENatMap {S : Type*} [CanonicallyOrderedCommSemiring S] [DecidableEq S]
+    [Nontrivial S] (f : ℕ →+* S) (hf : Function.Injective f) : ℕ∞ →+* WithTop S :=
+  {MonoidWithZeroHom.ENatMap f.toMonoidWithZeroHom hf, f.toAddMonoidHom.ENatMap with}
+
 end ENat

--- a/Mathlib/Data/Real/ENatENNReal.lean
+++ b/Mathlib/Data/Real/ENatENNReal.lean
@@ -23,12 +23,12 @@ namespace ENat
 variable {m n : ℕ∞}
 
 /-- Coercion from `ℕ∞` to `ℝ≥0∞`. -/
-@[coe] def toENNReal : ℕ∞ → ℝ≥0∞ := WithTop.map Nat.cast
+@[coe] def toENNReal : ℕ∞ → ℝ≥0∞ := ENat.map Nat.cast
 
 instance hasCoeENNReal : CoeTC ℕ∞ ℝ≥0∞ := ⟨toENNReal⟩
 
 @[simp]
-theorem map_coe_nnreal : WithTop.map ((↑) : ℕ → ℝ≥0) = ((↑) : ℕ∞ → ℝ≥0∞) :=
+theorem map_coe_nnreal : ENat.map ((↑) : ℕ → ℝ≥0) = ((↑) : ℕ∞ → ℝ≥0∞) :=
   rfl
 
 /-- Coercion `ℕ∞ → ℝ≥0∞` as an `OrderEmbedding`. -/
@@ -77,7 +77,7 @@ theorem toENNReal_strictMono : StrictMono ((↑) : ℕ∞ → ℝ≥0∞) :=
 
 @[simp, norm_cast]
 theorem toENNReal_zero : ((0 : ℕ∞) : ℝ≥0∞) = 0 :=
-  map_zero toENNRealRingHom
+  _root_.map_zero toENNRealRingHom
 
 @[simp, norm_cast]
 theorem toENNReal_add (m n : ℕ∞) : ↑(m + n) = (m + n : ℝ≥0∞) :=
@@ -85,7 +85,7 @@ theorem toENNReal_add (m n : ℕ∞) : ↑(m + n) = (m + n : ℝ≥0∞) :=
 
 @[simp, norm_cast]
 theorem toENNReal_one : ((1 : ℕ∞) : ℝ≥0∞) = 1 :=
-  map_one toENNRealRingHom
+  _root_.map_one toENNRealRingHom
 
 @[simp, norm_cast]
 theorem toENNReal_mul (m n : ℕ∞) : ↑(m * n) = (m * n : ℝ≥0∞) :=

--- a/Mathlib/Data/Real/ENatENNReal.lean
+++ b/Mathlib/Data/Real/ENatENNReal.lean
@@ -39,7 +39,7 @@ def toENNRealOrderEmbedding : ℕ∞ ↪o ℝ≥0∞ :=
 /-- Coercion `ℕ∞ → ℝ≥0∞` as a ring homomorphism. -/
 @[simps! (config := .asFn)]
 def toENNRealRingHom : ℕ∞ →+* ℝ≥0∞ :=
-  .withTopMap (Nat.castRingHom ℝ≥0) Nat.cast_injective
+  .ENatMap (Nat.castRingHom ℝ≥0) Nat.cast_injective
 
 @[simp, norm_cast]
 theorem toENNReal_top : ((⊤ : ℕ∞) : ℝ≥0∞) = ⊤ :=

--- a/Mathlib/RingTheory/MvPowerSeries/Order.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Order.lean
@@ -244,7 +244,7 @@ theorem min_weightedOrder_le_add :
 private theorem weightedOrder_add_of_weightedOrder_lt.aux
     (H : f.weightedOrder w < g.weightedOrder w) :
     (f + g).weightedOrder w = f.weightedOrder w := by
-  obtain ⟨n, hn : (n : ℕ∞) = _⟩ := ne_top_iff_exists.mp (ne_top_of_lt H)
+  obtain ⟨n, hn : (n : ℕ∞) = _⟩ := ENat.ne_top_iff_exists.mp (ne_top_of_lt H)
   rw [← hn, weightedOrder_eq_nat]
   obtain ⟨d, hd', hd⟩ := ((weightedOrder_eq_nat w).mp hn.symm).1
   constructor


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This follows the results of this poll on Zulip: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Defeq.20abuse.20with.20ENat/near/482110206

Compare to #19164