### PR TITLE
[Merged by Bors] - chore(Tactic/Lift): don't use `True`/`False` where a `Bool` is expected

### DIFF
--- a/Mathlib/Tactic/Lift.lean
+++ b/Mathlib/Tactic/Lift.lean
@@ -162,20 +162,20 @@ def Lift.main (e t : TSyntax `term) (hUsing : Option (TSyntax `term))
   if hUsing.isNone then withMainContext <| setGoals (prf.mvarId! :: (← getGoals))
 
 elab_rules : tactic
-  | `(tactic| lift $e to $t $[using $h]?) => withMainContext <| Lift.main e t h none none False
+  | `(tactic| lift $e to $t $[using $h]?) => withMainContext <| Lift.main e t h none none false
 
 elab_rules : tactic | `(tactic| lift $e to $t $[using $h]?
-    with $newVarName) => withMainContext <| Lift.main e t h newVarName none False
+    with $newVarName) => withMainContext <| Lift.main e t h newVarName none false
 
 elab_rules : tactic | `(tactic| lift $e to $t $[using $h]?
-    with $newVarName $newEqName) => withMainContext <| Lift.main e t h newVarName newEqName False
+    with $newVarName $newEqName) => withMainContext <| Lift.main e t h newVarName newEqName false
 
 elab_rules : tactic | `(tactic| lift $e to $t $[using $h]?
     with $newVarName $newEqName $newPrfName) => withMainContext do
-  if h.isNone then Lift.main e t h newVarName newEqName False
+  if h.isNone then Lift.main e t h newVarName newEqName false
   else
     let some h := h | unreachable!
-    if h.raw == newPrfName then Lift.main e t h newVarName newEqName True
-    else Lift.main e t h newVarName newEqName False
+    if h.raw == newPrfName then Lift.main e t h newVarName newEqName true
+    else Lift.main e t h newVarName newEqName false
 
 end Mathlib.Tactic


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
