### PR TITLE
[Merged by Bors] - feat(Polynomial): bounding the coefficients of `modByMonic`/`divByMonic`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -791,6 +791,7 @@ import Mathlib.Algebra.Polynomial.Bivariate
 import Mathlib.Algebra.Polynomial.CancelLeads
 import Mathlib.Algebra.Polynomial.Cardinal
 import Mathlib.Algebra.Polynomial.Coeff
+import Mathlib.Algebra.Polynomial.CoeffMem
 import Mathlib.Algebra.Polynomial.Degree.CardPowDegree
 import Mathlib.Algebra.Polynomial.Degree.Definitions
 import Mathlib.Algebra.Polynomial.Degree.Domain

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -89,6 +89,7 @@ theorem toSubMulAction_one : (1 : Submodule R A).toSubMulAction = 1 :=
 theorem one_eq_span_one_set : (1 : Submodule R A) = span R 1 :=
   one_eq_span
 
+@[simp]
 theorem one_le {P : Submodule R A} : (1 : Submodule R A) ≤ P ↔ (1 : A) ∈ P := by
   -- Porting note: simpa no longer closes refl goals, so added `SetLike.mem_coe`
   simp only [one_eq_span, span_le, Set.singleton_subset_iff, SetLike.mem_coe]

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -708,11 +708,14 @@ theorem le_div_iff {I J K : Submodule R A} : I ≤ J / K ↔ ∀ x ∈ I, ∀ z 
 theorem le_div_iff_mul_le {I J K : Submodule R A} : I ≤ J / K ↔ I * K ≤ J := by
   rw [le_div_iff, mul_le]
 
-@[simp]
 theorem one_le_one_div {I : Submodule R A} : 1 ≤ 1 / I ↔ I ≤ 1 := by
   constructor; all_goals intro hI
   · rwa [le_div_iff_mul_le, one_mul] at hI
   · rwa [le_div_iff_mul_le, one_mul]
+
+@[simp]
+theorem one_mem_div {I J : Submodule R A} : 1 ∈ I / J ↔ J ≤ I := by
+  rw [← one_le, le_div_iff_mul_le, one_mul]
 
 theorem le_self_mul_one_div {I : Submodule R A} (hI : I ≤ 1) : I ≤ I * (1 / I) := by
   refine (mul_one I).symm.trans_le ?_  -- Porting note: drop `rw {occs := _}` in favor of `refine`

--- a/Mathlib/Algebra/Polynomial/CoeffMem.lean
+++ b/Mathlib/Algebra/Polynomial/CoeffMem.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2024 Yaël Dillies, Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Andrew Yang
+-/
+import Mathlib.Algebra.Algebra.Operations
+import Mathlib.Algebra.Polynomial.Div
+
+/-!
+# Bounding the coefficients of the quotient and remainder of polynomials
+
+This file proves that, for polynomials `p q : R[X]`, the coefficients of `p /ₘ q` and `p %ₘ q` can
+be written as sums of products of coefficients of `p` and `q`.
+
+Precisely, we show that each summand needs at most one coefficient of `p` and `deg p` coefficients
+of `q`.
+-/
+
+namespace Polynomial
+variable {R : Type*} [Ring R]
+
+local notation "deg("p")" => natDegree p
+local notation3 "coeffs("p")" => Set.range (coeff p)
+local notation3 "spanCoeffs("p")" => 1 ⊔ Submodule.span ℤ coeffs(p)
+
+open Submodule Set in
+lemma coeff_divModByMonicAux_mem_span_pow_mul_span : ∀ (p q : R[X]) (hq : q.Monic) (i),
+    (p.divModByMonicAux hq).1.coeff i ∈ spanCoeffs(q) ^ deg(p) * spanCoeffs(p) ∧
+    (p.divModByMonicAux hq).2.coeff i ∈ spanCoeffs(q) ^ deg(p) * spanCoeffs(p)
+  | p, q, hq, i => by
+    rw [divModByMonicAux]
+    have H₀ (i) : p.coeff i ∈ spanCoeffs(q) ^ deg(p) * spanCoeffs(p) := by
+      refine Submodule.mul_le_mul_left (pow_le_pow_left' le_sup_left _) ?_
+      simp only [one_pow, one_mul]
+      exact SetLike.le_def.mp le_sup_right (subset_span (mem_range_self i))
+    split_ifs with hpq; swap
+    · simpa using H₀ _
+    simp only [coeff_add, coeff_C_mul, coeff_X_pow]
+    generalize hr : (p - q * (C p.leadingCoeff * X ^ (deg(p) - deg(q)))) = r
+    by_cases hr' : r = 0
+    · simp only [mul_ite, mul_one, mul_zero, hr', divModByMonicAux, degree_zero, le_bot_iff,
+        degree_eq_bot, ne_eq, not_true_eq_false, and_false, ↓reduceDIte, Prod.mk_zero_zero,
+        Prod.fst_zero, coeff_zero, add_zero, Prod.snd_zero, Submodule.zero_mem, and_true]
+      split_ifs
+      exacts [H₀ _, zero_mem _]
+    have H : span ℤ coeffs(r) ≤ span ℤ coeffs(p) ⊔ span ℤ coeffs(q) * span ℤ coeffs(p) := by
+      rw [span_le, ← hr]
+      rintro _ ⟨i, rfl⟩
+      rw [coeff_sub, ← mul_assoc, coeff_mul_X_pow', coeff_mul_C]
+      apply sub_mem
+      · exact SetLike.le_def.mp le_sup_left (subset_span (mem_range_self _))
+      · split_ifs
+        · refine SetLike.le_def.mp le_sup_right (mul_mem_mul ?_ ?_) <;> exact subset_span ⟨_, rfl⟩
+        · exact zero_mem _
+    have deg_r_lt_deg_p : deg(r) < deg(p) := natDegree_lt_natDegree hr' (hr ▸ div_wf_lemma hpq hq)
+    have H'' := calc
+      spanCoeffs(q) ^ deg(r) * spanCoeffs(r)
+      _ ≤ spanCoeffs(q) ^ deg(r) *
+          (1 ⊔ (span ℤ coeffs(p) ⊔ span ℤ coeffs(q) * span ℤ coeffs(p))) := by gcongr
+      _ ≤ spanCoeffs(q) ^ deg(r) * (spanCoeffs(q) * spanCoeffs(p)) := by
+        gcongr
+        simp only [sup_le_iff]
+        refine ⟨one_le_mul le_sup_left le_sup_left, ?_, mul_le_mul' le_sup_right le_sup_right⟩
+        rw [Submodule.sup_mul, one_mul]
+        exact le_sup_of_le_left le_sup_right
+      _ = spanCoeffs(q) ^ (deg(r) + 1) * spanCoeffs(p) := by rw [pow_succ, mul_assoc]
+      _ ≤ spanCoeffs(q) ^ deg(p) * spanCoeffs(p) := by gcongr; exacts [le_sup_left, deg_r_lt_deg_p]
+    refine ⟨add_mem ?_ ?_, ?_⟩
+    · split_ifs <;> simp only [mul_one, mul_zero]
+      exacts [H₀ _, zero_mem _]
+    · exact H'' (coeff_divModByMonicAux_mem_span_pow_mul_span r _ hq i).1
+    · exact H'' (coeff_divModByMonicAux_mem_span_pow_mul_span _ _ hq i).2
+  termination_by p => deg(p)
+
+/-- For polynomials `p q : R[X]`, the coefficients of `p %ₘ q` can be written as sums of products of
+coefficients of `p` and `q`.
+
+Precisely, each summand needs at most one coefficient of `p` and `deg p` coefficients of `q`. -/
+lemma coeff_modByMonic_mem_span_pow_mul_span (p q : R[X]) (i : ℕ) :
+    (p %ₘ q).coeff i ∈ spanCoeffs(q) ^ deg(p) * spanCoeffs(p) := by
+  delta modByMonic
+  split_ifs with H
+  · exact (coeff_divModByMonicAux_mem_span_pow_mul_span p q H i).2
+  · refine Submodule.mul_le_mul_left (pow_le_pow_left' le_sup_left _) ?_
+    simp only [one_pow, one_mul]
+    exact SetLike.le_def.mp le_sup_right (Submodule.subset_span (Set.mem_range_self i))
+
+/-- For polynomials `p q : R[X]`, the coefficients of `p /ₘ q` can be written as sums of products of
+coefficients of `p` and `q`.
+
+Precisely, each summand needs at most one coefficient of `p` and `deg p` coefficients of `q`. -/
+lemma coeff_divByMonic_mem_span_pow_mul_span (p q : R[X]) (i : ℕ) :
+    (p /ₘ q).coeff i ∈ spanCoeffs(q) ^ deg(p) * spanCoeffs(p) := by
+  delta divByMonic
+  split_ifs with H
+  · exact (coeff_divModByMonicAux_mem_span_pow_mul_span p q H i).1
+  · simp
+
+end Polynomial

--- a/Mathlib/Algebra/Polynomial/Div.lean
+++ b/Mathlib/Algebra/Polynomial/Div.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker
 -/
+import Mathlib.Algebra.Algebra.Operations
 import Mathlib.Algebra.Field.IsField
 import Mathlib.Algebra.Polynomial.Inductions
 import Mathlib.Algebra.Polynomial.Monic
@@ -306,7 +307,8 @@ lemma coeff_divModByMonicAux_mem_span_pow_mul_span : ∀ (p q : R[X]) (hq : q.Mo
         gcongr
         simp only [sup_le_iff]
         refine ⟨one_le_mul le_sup_left le_sup_left, ?_, mul_le_mul' le_sup_right le_sup_right⟩
-        simpa [Submodule.sup_mul] using le_sup_of_le_left le_sup_right
+        rw [Submodule.sup_mul, one_mul]
+        exact le_sup_of_le_left le_sup_right
       _ = spanCoeffs(q) ^ (deg(r) + 1) * spanCoeffs(p) := by rw [pow_succ, mul_assoc]
       _ ≤ spanCoeffs(q) ^ deg(p) * spanCoeffs(p) := by gcongr; exacts [le_sup_left, deg_r_lt_deg_p]
     refine ⟨add_mem ?_ ?_, ?_⟩

--- a/Mathlib/Algebra/Polynomial/Div.lean
+++ b/Mathlib/Algebra/Polynomial/Div.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker
 -/
-import Mathlib.Algebra.Algebra.Operations
 import Mathlib.Algebra.Field.IsField
 import Mathlib.Algebra.Polynomial.Inductions
 import Mathlib.Algebra.Polynomial.Monic
@@ -262,79 +261,6 @@ theorem divByMonic_eq_zero_iff [Nontrivial R] (hq : Monic q) : p /ₘ q = 0 ↔ 
     classical
     have : ¬degree q ≤ degree p := not_le_of_gt h
     unfold divByMonic divModByMonicAux; dsimp; rw [dif_pos hq, if_neg (mt And.left this)]⟩
-
-section coeff_mem
-
-local notation "deg("p")" => Polynomial.natDegree p
-local notation3 "coeffs("p")" => Set.range (coeff p)
-local notation3 "spanCoeffs("p")" => 1 ⊔ Submodule.span ℤ coeffs(p)
-
-open Submodule Set in
-lemma coeff_divModByMonicAux_mem_span_pow_mul_span : ∀ (p q : R[X]) (hq : q.Monic) (i),
-    (p.divModByMonicAux hq).1.coeff i ∈ spanCoeffs(q) ^ deg(p) * spanCoeffs(p) ∧
-    (p.divModByMonicAux hq).2.coeff i ∈ spanCoeffs(q) ^ deg(p) * spanCoeffs(p)
-  | p, q, hq, i => by
-    rw [divModByMonicAux]
-    have H₀ (i) : p.coeff i ∈ spanCoeffs(q) ^ deg(p) * spanCoeffs(p) := by
-      refine Submodule.mul_le_mul_left (pow_le_pow_left' le_sup_left _) ?_
-      simp only [one_pow, one_mul]
-      exact SetLike.le_def.mp le_sup_right (subset_span (mem_range_self i))
-    split_ifs with hpq; swap
-    · simpa using H₀ _
-    simp only [coeff_add, coeff_C_mul, coeff_X_pow]
-    generalize hr : (p - q * (C p.leadingCoeff * X ^ (deg(p) - deg(q)))) = r
-    by_cases hr' : r = 0
-    · simp only [mul_ite, mul_one, mul_zero, hr', divModByMonicAux, degree_zero, le_bot_iff,
-        degree_eq_bot, ne_eq, not_true_eq_false, and_false, ↓reduceDIte, Prod.mk_zero_zero,
-        Prod.fst_zero, coeff_zero, add_zero, Prod.snd_zero, Submodule.zero_mem, and_true]
-      split_ifs
-      exacts [H₀ _, zero_mem _]
-    have H : span ℤ coeffs(r) ≤ span ℤ coeffs(p) ⊔ span ℤ coeffs(q) * span ℤ coeffs(p) := by
-      rw [span_le, ← hr]
-      rintro _ ⟨i, rfl⟩
-      rw [coeff_sub, ← mul_assoc, coeff_mul_X_pow', coeff_mul_C]
-      apply sub_mem
-      · exact SetLike.le_def.mp le_sup_left (subset_span (mem_range_self _))
-      · split_ifs
-        · refine SetLike.le_def.mp le_sup_right (mul_mem_mul ?_ ?_) <;> exact subset_span ⟨_, rfl⟩
-        · exact zero_mem _
-    have deg_r_lt_deg_p : deg(r) < deg(p) := natDegree_lt_natDegree hr' (hr ▸ div_wf_lemma hpq hq)
-    have H'' := calc
-      spanCoeffs(q) ^ deg(r) * spanCoeffs(r)
-      _ ≤ spanCoeffs(q) ^ deg(r) *
-          (1 ⊔ (span ℤ coeffs(p) ⊔ span ℤ coeffs(q) * span ℤ coeffs(p))) := by gcongr
-      _ ≤ spanCoeffs(q) ^ deg(r) * (spanCoeffs(q) * spanCoeffs(p)) := by
-        gcongr
-        simp only [sup_le_iff]
-        refine ⟨one_le_mul le_sup_left le_sup_left, ?_, mul_le_mul' le_sup_right le_sup_right⟩
-        rw [Submodule.sup_mul, one_mul]
-        exact le_sup_of_le_left le_sup_right
-      _ = spanCoeffs(q) ^ (deg(r) + 1) * spanCoeffs(p) := by rw [pow_succ, mul_assoc]
-      _ ≤ spanCoeffs(q) ^ deg(p) * spanCoeffs(p) := by gcongr; exacts [le_sup_left, deg_r_lt_deg_p]
-    refine ⟨add_mem ?_ ?_, ?_⟩
-    · split_ifs <;> simp only [mul_one, mul_zero]
-      exacts [H₀ _, zero_mem _]
-    · exact H'' (coeff_divModByMonicAux_mem_span_pow_mul_span r _ hq i).1
-    · exact H'' (coeff_divModByMonicAux_mem_span_pow_mul_span _ _ hq i).2
-  termination_by p => deg(p)
-
-lemma coeff_modByMonic_mem_span_pow_mul_span (p q : R[X]) (i) :
-    (p %ₘ q).coeff i ∈ spanCoeffs(q) ^ deg(p) * spanCoeffs(p) := by
-  delta modByMonic
-  split_ifs with H
-  · exact (coeff_divModByMonicAux_mem_span_pow_mul_span p q H i).2
-  · refine Submodule.mul_le_mul_left (pow_le_pow_left' le_sup_left _) ?_
-    simp only [one_pow, one_mul]
-    exact SetLike.le_def.mp le_sup_right (Submodule.subset_span (Set.mem_range_self i))
-
-lemma coeff_divByMonic_mem_span_pow_mul_span (p q : R[X]) (i) :
-    (p /ₘ q).coeff i ∈ spanCoeffs(q) ^ deg(p) * spanCoeffs(p) := by
-  delta divByMonic
-  split_ifs with H
-  · exact (coeff_divModByMonicAux_mem_span_pow_mul_span p q H i).1
-  · simp
-
-end coeff_mem
 
 theorem degree_add_divByMonic (hq : Monic q) (h : degree q ≤ degree p) :
     degree q + degree (p /ₘ q) = degree p := by


### PR DESCRIPTION
Using the usual euclidean algorithm, one can write the coefficients of `p %ₘ q` and `p /ₘ q` as sums of products of a few number of coefficients of `p` and `q`.

From GrowthInGroups

Co-authored-by: Yaël Dillies <yael.dillies@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
