### PR TITLE
[Merged by Bors] - feat(Analysis/Convex/Topology): closure of interior and interior of closure for a convex set

### DIFF
--- a/Mathlib/Analysis/Convex/Topology.lean
+++ b/Mathlib/Analysis/Convex/Topology.lean
@@ -268,6 +268,30 @@ protected theorem Convex.strictConvex {s : Set E} (hs : Convex 𝕜 s)
 
 end ContinuousConstSMul
 
+section ContinuousSMul
+
+variable [LinearOrderedField 𝕜] [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E]
+  [TopologicalAddGroup E] [TopologicalSpace 𝕜] [OrderTopology 𝕜] [ContinuousSMul 𝕜 E]
+
+theorem Convex.closure_interior_eq_closure_of_nonempty_interior {s : Set E} (hs : Convex 𝕜 s)
+    (hs' : (interior s).Nonempty) : closure (interior s) = closure s :=
+  subset_antisymm (closure_mono interior_subset)
+    fun _ h ↦ closure_mono (hs.openSegment_interior_closure_subset_interior hs'.choose_spec h)
+      (segment_subset_closure_openSegment (right_mem_segment ..))
+
+theorem Convex.interior_closure_eq_interior_of_nonempty_interior {s : Set E} (hs : Convex 𝕜 s)
+    (hs' : (interior s).Nonempty) : interior (closure s) = interior s := by
+  refine subset_antisymm ?_ (interior_mono subset_closure)
+  intro y hy
+  have h := AffineMap.lineMap_apply_one (k := 𝕜) hs'.choose y
+  obtain ⟨t, ht1, ht⟩ := AffineMap.lineMap_continuous.tendsto' _ _ h |>.eventually_mem
+    (mem_interior_iff_mem_nhds.1 hy) |>.exists_gt
+  apply hs.openSegment_interior_closure_subset_interior hs'.choose_spec ht
+  nth_rw 1 [← AffineMap.lineMap_apply_zero (k := 𝕜) hs'.choose y, ← image_openSegment]
+  exact ⟨1, Ioo_subset_openSegment ⟨zero_lt_one, ht1⟩, h⟩
+
+end ContinuousSMul
+
 section TopologicalSpace
 
 variable [OrderedSemiring 𝕜] [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E]

--- a/Mathlib/Analysis/Convex/Topology.lean
+++ b/Mathlib/Analysis/Convex/Topology.lean
@@ -283,11 +283,12 @@ theorem Convex.interior_closure_eq_interior_of_nonempty_interior {s : Set E} (hs
     (hs' : (interior s).Nonempty) : interior (closure s) = interior s := by
   refine subset_antisymm ?_ (interior_mono subset_closure)
   intro y hy
-  have h := AffineMap.lineMap_apply_one (k := 𝕜) hs'.choose y
+  rcases hs' with ⟨x, hx⟩
+  have h := AffineMap.lineMap_apply_one (k := 𝕜) x y
   obtain ⟨t, ht1, ht⟩ := AffineMap.lineMap_continuous.tendsto' _ _ h |>.eventually_mem
     (mem_interior_iff_mem_nhds.1 hy) |>.exists_gt
-  apply hs.openSegment_interior_closure_subset_interior hs'.choose_spec ht
-  nth_rw 1 [← AffineMap.lineMap_apply_zero (k := 𝕜) hs'.choose y, ← image_openSegment]
+  apply hs.openSegment_interior_closure_subset_interior hx ht
+  nth_rw 1 [← AffineMap.lineMap_apply_zero (k := 𝕜) x y, ← image_openSegment]
   exact ⟨1, Ioo_subset_openSegment ⟨zero_lt_one, ht1⟩, h⟩
 
 end ContinuousSMul


### PR DESCRIPTION
For a convex set `s` with non-empty interior, `closure (interior s) = closure s` and `interior (closure s) = interior s`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
