### PR TITLE
[Merged by Bors] - feat: additivize equivariance of morphisms of actions

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -26,7 +26,7 @@ import Mathlib.Algebra.Group.Hom.CompTypeclasses
 
 The above types have corresponding classes:
 * `MulActionHomClass F φ X Y` states that `F` is a type of bundled `X → Y` homs
-  which are `φ`-equivariant; 
+  which are `φ`-equivariant;
   `AddActionHomClass F φ X Y` is its additive version.
 * `DistribMulActionHomClass F φ A B` states that `F` is a type of bundled `A → B` homs
   preserving the additive monoid structure and `φ`-equivariant
@@ -70,7 +70,7 @@ structure MulActionHom where
   protected map_smul' : ∀ (m : M) (x : X), toFun (m • x) = (φ m) • toFun x
 
 /-- Equivariant functions :
-When `φ : M → N` is a function, and types `X` and `Y` are endowed with additive actions 
+When `φ : M → N` is a function, and types `X` and `Y` are endowed with additive actions
 of `M` and `N`, a function `f : X → Y` is `φ`-equivariant if `f (m +ᵥ x) = (φ m) +ᵥ (f x)`. -/
 structure AddActionHom {M N : Type*} (φ: M → N) (X : Type*) [VAdd M X] (Y : Type*) [VAdd N Y] where
   /-- The underlying function. -/
@@ -78,7 +78,7 @@ structure AddActionHom {M N : Type*} (φ: M → N) (X : Type*) [VAdd M X] (Y : T
   /-- The proposition that the function commutes with the additive actions. -/
   protected map_vadd' : ∀ (m : M) (x : X), toFun (m +ᵥ x) = (φ m) +ᵥ toFun x
 
-attribute [to_additive] MulActionHom 
+attribute [to_additive] MulActionHom
 
 /- Porting note: local notation given a name, conflict with Algebra.Hom.GroupAction
  see https://github.com/leanprover/lean4/issues/2000 -/

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -15,6 +15,7 @@ import Mathlib.Algebra.Group.Hom.CompTypeclasses
 
 * `MulActionHom φ X Y`, the type of equivariant functions from `X` to `Y`,
   where `φ : M → N` is a map, `M` acting on the type `X` and `N` acting on the type of `Y`.
+  `AddActionHom φ X Y` is its additive version.
 * `DistribMulActionHom φ A B`,
   the type of equivariant additive monoid homomorphisms from `A` to `B`,
   where `φ : M → N` is a morphism of monoids,
@@ -25,7 +26,8 @@ import Mathlib.Algebra.Group.Hom.CompTypeclasses
 
 The above types have corresponding classes:
 * `MulActionHomClass F φ X Y` states that `F` is a type of bundled `X → Y` homs
-  which are `φ`-equivariant
+  which are `φ`-equivariant; 
+  `AddActionHomClass F φ X Y` is its additive version.
 * `DistribMulActionHomClass F φ A B` states that `F` is a type of bundled `A → B` homs
   preserving the additive monoid structure and `φ`-equivariant
 * `SMulSemiringHomClass F φ R S` states that `F` is a type of bundled `R → S` homs
@@ -35,12 +37,12 @@ The above types have corresponding classes:
 
 We introduce the following notation to code equivariant maps
 (the subscript index `ₑ` is for *equivariant*) :
-* `X →ₑ[φ] Y` is `MulActionHom φ X Y`.
+* `X →ₑ[φ] Y` is `MulActionHom φ X Y` and `X →ₑᵥ[φ] Y` is `AddActionHom φ X Y`
 * `A →ₑ+[φ] B` is `DistribMulActionHom φ A B`.
 * `R →ₑ+*[φ] S` is `MulSemiringActionHom φ R S`.
 
 When `M = N` and `φ = MonoidHom.id M`, we provide the backward compatible notation :
-* `X →[M] Y` is `MulActionHom (@id M) X Y`
+* `X →[M] Y` is `MulActionHom (@id M) X Y` and `X →ᵥ[M] Y` is `AddActionHom (@id M) X Y`
 * `A →+[M] B` is `DistribMulActionHom (MonoidHom.id M) A B`
 * `R →+*[M] S` is `MulSemiringActionHom (MonoidHom.id M) R S`
 -/

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -87,21 +87,23 @@ structure MulActionHom where
 /- Porting note: local notation given a name, conflict with Algebra.Hom.GroupAction
  see https://github.com/leanprover/lean4/issues/2000 -/
 /-- `φ`-equivariant functions `X → Y`,
-where `φ : M → N`, where `M` and `N` act on `X` and `Y` respectively -/
+where `φ : M → N`, where `M` and `N` act on `X` and `Y` respectively.-/
 notation:25 (name := «MulActionHomLocal≺») X " →ₑ[" φ:25 "] " Y:0 => MulActionHom φ X Y
 
-/-- `M`-equivariant functions `X → Y` with respect to the action of `M`
-
-This is the same as `X →ₑ[@id M] Y` -/
+/-- `M`-equivariant functions `X → Y` with respect to the action of `M`.
+This is the same as `X →ₑ[@id M] Y`. -/
 notation:25 (name := «MulActionHomIdLocal≺») X " →[" M:25 "] " Y:0 => MulActionHom (@id M) X Y
 
 /-- `φ`-equivariant functions `X → Y`,
-where `φ : M → N`, where `M` and `N` act additively on `X` and `Y` respectively -/
+where `φ : M → N`, where `M` and `N` act additively on `X` and `Y` respectively 
+
+We use the same notation as for multiplicative actions, as conflicts are unlikely. -/
 notation:25 (name := «AddActionHomLocal≺») X " →ₑ[" φ:25 "] " Y:0 => AddActionHom φ X Y
 
-/-- `M`-equivariant functions `X → Y` with respect to the additive action of `M`
+/-- `M`-equivariant functions `X → Y` with respect to the additive action of `M`.
+This is the same as `X →ₑ[@id M] Y`.
 
-This is the same as `X →ₑ[@id M] Y` -/
+We use the same notation as for multiplicative actions, as conflicts are unlikely. -/
 notation:25 (name := «AddActionHomIdLocal≺») X " →[" M:25 "] " Y:0 => AddActionHom (@id M) X Y
 
 /-- `AddActionSemiHomClass F φ X Y` states that

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -37,12 +37,12 @@ The above types have corresponding classes:
 
 We introduce the following notation to code equivariant maps
 (the subscript index `ₑ` is for *equivariant*) :
-* `X →ₑ[φ] Y` is `MulActionHom φ X Y` and `X →ₑᵥ[φ] Y` is `AddActionHom φ X Y`
+* `X →ₑ[φ] Y` is `MulActionHom φ X Y` and `AddActionHom φ X Y`
 * `A →ₑ+[φ] B` is `DistribMulActionHom φ A B`.
 * `R →ₑ+*[φ] S` is `MulSemiringActionHom φ R S`.
 
 When `M = N` and `φ = MonoidHom.id M`, we provide the backward compatible notation :
-* `X →[M] Y` is `MulActionHom (@id M) X Y` and `X →ᵥ[M] Y` is `AddActionHom (@id M) X Y`
+* `X →[M] Y` is `MulActionHom (@id M) X Y` and `AddActionHom (@id M) X Y`
 * `A →+[M] B` is `DistribMulActionHom (MonoidHom.id M) A B`
 * `R →+*[M] S` is `MulSemiringActionHom (MonoidHom.id M) R S`
 -/
@@ -93,13 +93,12 @@ notation:25 (name := «MulActionHomIdLocal≺») X " →[" M:25 "] " Y:0 => MulA
 
 /-- `φ`-equivariant functions `X → Y`,
 where `φ : M → N`, where `M` and `N` act additively on `X` and `Y` respectively -/
-notation:25 (name := «AddActionHomLocal≺») X " →ₑᵥ[" φ:25 "] " Y:0 => AddActionHom φ X Y
+notation:25 (name := «AddActionHomLocal≺») X " →ₑ[" φ:25 "] " Y:0 => AddActionHom φ X Y
 
 /-- `M`-equivariant functions `X → Y` with respect to the additive action of `M`
 
 This is the same as `X →ₑ[@id M] Y` -/
-notation:25 (name := «AddActionHomIdLocal≺») X " →ᵥ[" M:25 "] " Y:0 => AddActionHom (@id M) X Y
-
+notation:25 (name := «AddActionHomIdLocal≺») X " →[" M:25 "] " Y:0 => AddActionHom (@id M) X Y
 
 /-- `MulActionSemiHomClass F φ X Y` states that
   `F` is a type of morphisms which are `φ`-equivariant.

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -59,17 +59,6 @@ variable (Y : Type*) [SMul N Y] [SMul M' Y]
 variable (Z : Type*) [SMul P Z]
 
 /-- Equivariant functions :
-When `φ : M → N` is a function, and types `X` and `Y` are endowed with actions of `M` and `N`,
-a function `f : X → Y` is `φ`-equivariant if `f (m • x) = (φ m) • (f x)`. -/
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/5171): this linter isn't ported yet.
--- @[nolint has_nonempty_instance]
-structure MulActionHom where
-  /-- The underlying function. -/
-  protected toFun : X → Y
-  /-- The proposition that the function commutes with the actions. -/
-  protected map_smul' : ∀ (m : M) (x : X), toFun (m • x) = (φ m) • toFun x
-
-/-- Equivariant functions :
 When `φ : M → N` is a function, and types `X` and `Y` are endowed with additive actions
 of `M` and `N`, a function `f : X → Y` is `φ`-equivariant if `f (m +ᵥ x) = (φ m) +ᵥ (f x)`. -/
 structure AddActionHom {M N : Type*} (φ: M → N) (X : Type*) [VAdd M X] (Y : Type*) [VAdd N Y] where
@@ -78,7 +67,17 @@ structure AddActionHom {M N : Type*} (φ: M → N) (X : Type*) [VAdd M X] (Y : T
   /-- The proposition that the function commutes with the additive actions. -/
   protected map_vadd' : ∀ (m : M) (x : X), toFun (m +ᵥ x) = (φ m) +ᵥ toFun x
 
-attribute [to_additive] MulActionHom
+/-- Equivariant functions :
+When `φ : M → N` is a function, and types `X` and `Y` are endowed with actions of `M` and `N`,
+a function `f : X → Y` is `φ`-equivariant if `f (m • x) = (φ m) • (f x)`. -/
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/5171): this linter isn't ported yet.
+-- @[nolint has_nonempty_instance]
+@[to_additive]
+structure MulActionHom where
+  /-- The underlying function. -/
+  protected toFun : X → Y
+  /-- The proposition that the function commutes with the actions. -/
+  protected map_smul' : ∀ (m : M) (x : X), toFun (m • x) = (φ m) • toFun x
 
 /- Porting note: local notation given a name, conflict with Algebra.Hom.GroupAction
  see https://github.com/leanprover/lean4/issues/2000 -/
@@ -100,18 +99,6 @@ notation:25 (name := «AddActionHomLocal≺») X " →ₑ[" φ:25 "] " Y:0 => Ad
 This is the same as `X →ₑ[@id M] Y` -/
 notation:25 (name := «AddActionHomIdLocal≺») X " →[" M:25 "] " Y:0 => AddActionHom (@id M) X Y
 
-/-- `MulActionSemiHomClass F φ X Y` states that
-  `F` is a type of morphisms which are `φ`-equivariant.
-
-You should extend this class when you extend `MulActionHom`. -/
-class MulActionSemiHomClass (F : Type*)
-    {M N : outParam Type*} (φ : outParam (M → N))
-    (X Y : outParam Type*) [SMul M X] [SMul N Y] [FunLike F X Y] : Prop where
-  /-- The proposition that the function preserves the action. -/
-  map_smulₛₗ : ∀ (f : F) (c : M) (x : X), f (c • x) = (φ c) • (f x)
-
-export MulActionSemiHomClass (map_smulₛₗ)
-
 /-- `AddActionSemiHomClass F φ X Y` states that
   `F` is a type of morphisms which are `φ`-equivariant.
 
@@ -122,8 +109,18 @@ class AddActionSemiHomClass (F : Type*)
   /-- The proposition that the function preserves the action. -/
   map_vaddₛₗ : ∀ (f : F) (c : M) (x : X), f (c +ᵥ x) = (φ c) +ᵥ (f x)
 
-attribute [to_additive] MulActionSemiHomClass
+/-- `MulActionSemiHomClass F φ X Y` states that
+  `F` is a type of morphisms which are `φ`-equivariant.
 
+You should extend this class when you extend `MulActionHom`. -/
+@[to_additive]
+class MulActionSemiHomClass (F : Type*)
+    {M N : outParam Type*} (φ : outParam (M → N))
+    (X Y : outParam Type*) [SMul M X] [SMul N Y] [FunLike F X Y] : Prop where
+  /-- The proposition that the function preserves the action. -/
+  map_smulₛₗ : ∀ (f : F) (c : M) (x : X), f (c • x) = (φ c) • (f x)
+
+export MulActionSemiHomClass (map_smulₛₗ)
 export AddActionSemiHomClass (map_vaddₛₗ)
 
 /-- `MulActionHomClass F M X Y` states that `F` is a type of

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -169,7 +169,7 @@ see also Algebra.Hom.Group -/
 /-- Turn an element of a type `F` satisfying `MulActionSemiHomClass F φ X Y`
   into an actual `MulActionHom`.
   This is declared as the default coercion from `F` to `MulActionSemiHom φ X Y`. -/
-@[to_additive (attr := coe) 
+@[to_additive (attr := coe)
   "Turn an element of a type `F` satisfying `AddActionSemiHomClass F φ X Y`
   into an actual `AddActionHom`.
   This is declared as the default coercion from `F` to `AddActionSemiHom φ X Y`."]

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -164,7 +164,9 @@ see also Algebra.Hom.Group -/
 /-- Turn an element of a type `F` satisfying `MulActionSemiHomClass F φ X Y`
   into an actual `MulActionHom`.
   This is declared as the default coercion from `F` to `MulActionSemiHom φ X Y`. -/
-@[to_additive (attr := coe)]
+@[to_additive (attr := coe) "Turn an element of a type `F` satisfying `AddActionSemiHomClass F φ X Y`
+  into an actual `AddActionHom`.
+  This is declared as the default coercion from `F` to `AddActionSemiHom φ X Y`."] 
 def _root_.MulActionSemiHomClass.toMulActionHom [MulActionSemiHomClass F φ X Y] (f : F) :
     X →ₑ[φ] Y where
   toFun := DFunLike.coe f
@@ -200,7 +202,7 @@ protected theorem congr_fun {f g : X →ₑ[φ] Y} (h : f = g) (x : X) :
   DFunLike.congr_fun h _
 
 /-- Two equal maps on scalars give rise to an equivariant map for identity -/
-@[to_additive]
+@[to_additive "Two equal maps on scalars give rise to an equivariant map for identity"]
 def ofEq {φ' : M → N} (h : φ = φ') (f : X →ₑ[φ] Y) : X →ₑ[φ'] Y where
   toFun := f.toFun
   map_smul' m a := h ▸ f.map_smul' m a
@@ -218,7 +220,7 @@ theorem ofEq_apply {φ' : M → N} (h : φ = φ') (f : X →ₑ[φ] Y) (a : X) :
 variable {ψ χ} (M N)
 
 /-- The identity map as an equivariant map. -/
-@[to_additive]
+@[to_additive "The identity map as an equivariant map."]
 protected def id : X →[M] X :=
   ⟨id, fun _ _ => rfl⟩
 
@@ -239,7 +241,7 @@ variable {φ ψ χ X Y Z}
 -- attribute [instance] CompTriple.id_comp CompTriple.comp_id
 
 /-- Composition of two equivariant maps. -/
-@[to_additive]
+@[to_additive "Composition of two equivariant maps."]
 def comp (g : Y →ₑ[ψ] Z) (f : X →ₑ[φ] Y) [κ : CompTriple φ ψ χ] :
     X →ₑ[χ] Z :=
   ⟨g ∘ f, fun m x =>
@@ -275,8 +277,9 @@ theorem comp_assoc {Q T : Type*} [SMul Q T]
 
 variable {φ' : N → M}
 variable {Y₁ : Type*} [SMul M Y₁]
+
 /-- The inverse of a bijective equivariant map is equivariant. -/
-@[to_additive (attr := simps)]
+@[to_additive (attr := simps) "The inverse of a bijective equivariant map is equivariant."]
 def inverse (f : X →[M] Y₁) (g : Y₁ → X)
     (h₁ : Function.LeftInverse g f) (h₂ : Function.RightInverse g f) : Y₁ →[M] X where
   toFun := g
@@ -288,7 +291,7 @@ def inverse (f : X →[M] Y₁) (g : Y₁ → X)
 
 
 /-- The inverse of a bijective equivariant map is equivariant. -/
-@[to_additive (attr := simps)]
+@[to_additive (attr := simps) "The inverse of a bijective equivariant map is equivariant."]
 def inverse' (f : X →ₑ[φ] Y) (g : Y → X) (k : Function.RightInverse φ' φ)
     (h₁ : Function.LeftInverse g f) (h₂ : Function.RightInverse g f) :
     Y →ₑ[φ'] X where
@@ -337,7 +340,8 @@ theorem inverse'_comp {f : X →ₑ[φ] Y} {g : Y → X}
 
 /-- If actions of `M` and `N` on `α` commute,
   then for `c : M`, `(c • · : α → α)` is an `N`-action homomorphism. -/
-@[to_additive (attr := simps)]
+@[to_additive (attr := simps) "If additive actions of `M` and `N` on `α` commute,
+  then for `c : M`, `(c • · : α → α)` is an `N`-additive action homomorphism."]
 def _root_.SMulCommClass.toMulActionHom {M} (N α : Type*)
     [SMul M α] [SMul N α] [SMulCommClass M N α] (c : M) :
     α →[N] α where

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -95,7 +95,7 @@ This is the same as `X →ₑ[@id M] Y`. -/
 notation:25 (name := «MulActionHomIdLocal≺») X " →[" M:25 "] " Y:0 => MulActionHom (@id M) X Y
 
 /-- `φ`-equivariant functions `X → Y`,
-where `φ : M → N`, where `M` and `N` act additively on `X` and `Y` respectively 
+where `φ : M → N`, where `M` and `N` act additively on `X` and `Y` respectively
 
 We use the same notation as for multiplicative actions, as conflicts are unlikely. -/
 notation:25 (name := «AddActionHomLocal≺») X " →ₑ[" φ:25 "] " Y:0 => AddActionHom φ X Y

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -166,7 +166,7 @@ see also Algebra.Hom.Group -/
   This is declared as the default coercion from `F` to `MulActionSemiHom φ X Y`. -/
 @[to_additive (attr := coe) "Turn an element of a type `F` satisfying `AddActionSemiHomClass F φ X Y`
   into an actual `AddActionHom`.
-  This is declared as the default coercion from `F` to `AddActionSemiHom φ X Y`."] 
+  This is declared as the default coercion from `F` to `AddActionSemiHom φ X Y`."]
 def _root_.MulActionSemiHomClass.toMulActionHom [MulActionSemiHomClass F φ X Y] (f : F) :
     X →ₑ[φ] Y where
   toFun := DFunLike.coe f

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -45,6 +45,11 @@ When `M = N` and `φ = MonoidHom.id M`, we provide the backward compatible notat
 * `X →[M] Y` is `MulActionHom (@id M) X Y` and `AddActionHom (@id M) X Y`
 * `A →+[M] B` is `DistribMulActionHom (MonoidHom.id M) A B`
 * `R →+*[M] S` is `MulSemiringActionHom (MonoidHom.id M) R S`
+
+The notation for `MulActionHom` and `AddActionHom` is the same, because it is unlikely
+that it could lead to confusion — unless one needs types `M` and `X` with simultaneous
+instances of `Mul M`, `Add M`, `SMul M X` and `VAdd M X`…
+
 -/
 
 assert_not_exists Submonoid
@@ -137,7 +142,7 @@ abbrev MulActionHomClass (F : Type*) (M : outParam Type*)
   coe := MulActionHom.toFun
   coe_injective' f g h := by cases f; cases g; congr
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem map_smul {F M X Y : Type*} [SMul M X] [SMul M Y]
     [FunLike F X Y] [MulActionHomClass F M X Y]
     (f : F) (c : M) (x : X) : f (c • x) = c • f x :=
@@ -164,7 +169,8 @@ see also Algebra.Hom.Group -/
 /-- Turn an element of a type `F` satisfying `MulActionSemiHomClass F φ X Y`
   into an actual `MulActionHom`.
   This is declared as the default coercion from `F` to `MulActionSemiHom φ X Y`. -/
-@[to_additive (attr := coe) "Turn an element of a type `F` satisfying `AddActionSemiHomClass F φ X Y`
+@[to_additive (attr := coe) 
+  "Turn an element of a type `F` satisfying `AddActionSemiHomClass F φ X Y`
   into an actual `AddActionHom`.
   This is declared as the default coercion from `F` to `AddActionSemiHom φ X Y`."]
 def _root_.MulActionSemiHomClass.toMulActionHom [MulActionSemiHomClass F φ X Y] (f : F) :
@@ -207,11 +213,11 @@ def ofEq {φ' : M → N} (h : φ = φ') (f : X →ₑ[φ] Y) : X →ₑ[φ'] Y w
   toFun := f.toFun
   map_smul' m a := h ▸ f.map_smul' m a
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem ofEq_coe {φ' : M → N} (h : φ = φ') (f : X →ₑ[φ] Y) :
     (f.ofEq h).toFun = f.toFun := rfl
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem ofEq_apply {φ' : M → N} (h : φ = φ') (f : X →ₑ[φ] Y) (a : X) :
     (f.ofEq h) a = f a :=
   rfl
@@ -226,7 +232,7 @@ protected def id : X →[M] X :=
 
 variable {M N Z}
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem id_apply (x : X) :
     MulActionHom.id M x = x :=
   rfl
@@ -251,22 +257,22 @@ def comp (g : Y →ₑ[ψ] Z) (f : X →ₑ[φ] Y) [κ : CompTriple φ ψ χ] :
       _ = (ψ ∘ φ) m • g (f x) := rfl
       _ = χ m • g (f x) := by rw [κ.comp_eq] ⟩
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem comp_apply
     (g : Y →ₑ[ψ] Z) (f : X →ₑ[φ] Y) [CompTriple φ ψ χ] (x : X) :
     g.comp f x = g (f x) := rfl
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem id_comp (f : X →ₑ[φ] Y) :
     (MulActionHom.id N).comp f = f :=
   ext fun x => by rw [comp_apply, id_apply]
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem comp_id (f : X →ₑ[φ] Y) :
     f.comp (MulActionHom.id M) = f :=
   ext fun x => by rw [comp_apply, id_apply]
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem comp_assoc {Q T : Type*} [SMul Q T]
     {η : P → Q} {θ : M → Q} {ζ : N → Q}
     (h : Z →ₑ[η] T) (g : Y →ₑ[ψ] Z) (f : X →ₑ[φ] Y)


### PR DESCRIPTION
Additivize the definition of equivariant morphisms with respect to multiplicative actions.
The notation introduced is `X →ₑᵥ[φ] Y` for equivariant morphisms, and `X →ᵥ[M] Y` when the
underlying map is identity.

The goal is to be able to fully additivize the properties of blocks for actions and the definition
of primitive actions in #12052 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
