### PR TITLE
test: the findDefEqAbuse linter

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4683,6 +4683,7 @@ import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Linter
 import Mathlib.Tactic.Linter.AdmitLinter
 import Mathlib.Tactic.Linter.DocPrime
+import Mathlib.Tactic.Linter.FindDefEqAbuse
 import Mathlib.Tactic.Linter.FlexibleLinter
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -138,6 +138,7 @@ import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Linter
 import Mathlib.Tactic.Linter.AdmitLinter
 import Mathlib.Tactic.Linter.DocPrime
+import Mathlib.Tactic.Linter.FindDefEqAbuse
 import Mathlib.Tactic.Linter.FlexibleLinter
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter

--- a/Mathlib/Tactic/Linter.lean
+++ b/Mathlib/Tactic/Linter.lean
@@ -8,6 +8,7 @@ This file is ignored by `shake`:
 * it is in `ignoreImport`, meaning that where it is imported, it is considered necessary.
 -/
 
+import Mathlib.Tactic.Linter.FindDefEqAbuse
 import Mathlib.Tactic.Linter.FlexibleLinter
 import Mathlib.Tactic.Linter.HaveLetLinter
 import Mathlib.Tactic.Linter.MinImports

--- a/Mathlib/Tactic/Linter/FindDefEqAbuse.lean
+++ b/Mathlib/Tactic/Linter/FindDefEqAbuse.lean
@@ -47,7 +47,7 @@ elab "find_defeq_abuse" tk:("!")? ppSpace id:ident : command => do
     | false, _ => return
 
 namespace FindDefEqAbuse
-#check Expr.containsConst
+
 @[inherit_doc Mathlib.Linter.linter.findDefEqAbuse]
 def findDefEqAbuseLinter : Linter where run := withSetOptionIn fun stx ↦ do
   unless Linter.getLinterValue linter.findDefEqAbuse (← getOptions) do

--- a/Mathlib/Tactic/Linter/FindDefEqAbuse.lean
+++ b/Mathlib/Tactic/Linter/FindDefEqAbuse.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2024 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import Lean.Elab.Command
+import Mathlib.Tactic.DeclarationNames
+
+/-!
+#  The "findDefEqAbuse" linter
+
+The "findDefEqAbuse" linter emits a warning when a variable declared in variable ...
+is globally unused.
+-/
+
+open Lean Parser Elab Command
+
+namespace Mathlib.Linter
+
+/--
+The "findDefEqAbuse" linter emits a warning when a declaration relies on the implementation of
+the definition stored in the `findDefEqAbuseRef` `IO.Ref`.
+-/
+register_option linter.findDefEqAbuse : Bool := {
+  defValue := true
+  descr := "enable the findDefEqAbuse linter"
+}
+
+/--
+`findDefEqAbuseRef` is the `IO.Ref` containing the name of the declaration used by
+`linter.findDefEqAbuse` to flag (ab)uses of definitional equality.
+-/
+initialize findDefEqAbuseRef : IO.Ref Name ← IO.mkRef `ENat
+
+/-- `find_defeq_abuse id` replaces the current value of the `findDefEqAbuseRef` with `id`.
+
+The variant `find_defeq_abuse ! id` also reports if the declaration `id` is already present in
+the environment or not.
+-/
+elab "find_defeq_abuse" tk:("!")? ppSpace id:ident : command => do
+  findDefEqAbuseRef.set id.getId
+  match tk.isSome, ((← getEnv).find? id.getId).isSome with
+    | true, false => logWarningAt id m!"There is no declaration named '{id}' in the environment"
+    | true, true => logInfoAt id m!"The environment contains declaration '{id}'"
+    | false, _ => return
+
+namespace FindDefEqAbuse
+
+@[inherit_doc Mathlib.Linter.linter.findDefEqAbuse]
+def findDefEqAbuseLinter : Linter where run := withSetOptionIn fun stx ↦ do
+  unless Linter.getLinterValue linter.findDefEqAbuse (← getOptions) do
+    return
+  let nm ← findDefEqAbuseRef.get
+  if (← get).messages.hasErrors then
+    return
+  unless stx.isOfKind ``declaration do
+    return
+  let id := mkIdent nm
+  if ((← getEnv).find? nm).isNone then return
+  let irred := mkIdent `irreducible
+  let preMkIrred ← `(command| attribute [$(⟨irred⟩)] $id)
+  let mkIrred : Syntax := preMkIrred.raw.replaceM (m := Id) fun s =>
+    if s.getId == `irreducible then
+      some <| .node default `Lean.Parser.Term.attrInstance #[
+        .node default `Lean.Parser.Term.attrKind (#[mkNullNode #[
+          .node default ``Lean.Parser.Term.local #[mkAtom "local"]]]),
+        .node default `Lean.Parser.Attr.simple #[s, mkNullNode]]
+    else none
+  let s ← get
+  let mut msg := ""
+  withScope (fun s => {s with
+      currNamespace := s.currNamespace ++ `another
+      openDecls := .simple s.currNamespace [] :: s.openDecls
+    }) do
+    elabCommand <| mkNullNode #[mkIrred, stx]
+  msg := s!"Abuse of defeq of '{id}'"
+  let names ← getNamesFrom <| stx.getPos?.getD default
+  if (← get).messages.hasErrors then
+    set s
+    let declId := match stx.find? (·.isOfKind ``declId) with
+      | none => names.back?.getD default
+      |some d => d
+    logWarningAt declId m!"'{declId}' relies on the definition of '{nm}'"
+
+initialize addLinter findDefEqAbuseLinter
+
+end FindDefEqAbuse
+
+end Mathlib.Linter

--- a/MathlibTest/FindDefEqAbuse.lean
+++ b/MathlibTest/FindDefEqAbuse.lean
@@ -1,0 +1,22 @@
+import Mathlib.Tactic.Linter.FindDefEqAbuse
+
+find_defeq_abuse X.Y
+namespace X
+
+def Y := Option Nat
+
+--attribute [irreducible] Y
+
+/-- warning: 'Abuse of defeq of '`X.Y' -/
+#guard_msgs in
+def f : Y := some 0
+
+/-- warning: 'Abuse of defeq of '`X.Y' -/
+#guard_msgs in
+def g : Y := some 0
+
+theorem f_eq_g : f = g := rfl
+
+theorem d : f = g := by
+  unfold f g
+  rfl


### PR DESCRIPTION
This is a prototype, as per [this Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Locating.20defeq.20abuse)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
