### PR TITLE
[Merged by Bors] - feat: add Nat.digits_base_pow_mul and Nat.digits_append_zeroes_append_digits

### DIFF
--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -406,6 +406,19 @@ theorem lt_base_pow_length_digits {b m : ℕ} (hb : 1 < b) : m < b ^ (digits b m
   rcases b with (_ | _ | b) <;> try simp_all
   exact lt_base_pow_length_digits'
 
+theorem digits_base_pow_mul {b k m : ℕ} (hb : 1 < b) (hm : 0 < m) :
+    digits b (b ^ k * m) = List.replicate k 0 ++ digits b m := by
+  induction k generalizing m with
+  | zero => simp
+  | succ k ih =>
+    have hmb : 0 < m * b := lt_mul_of_lt_of_one_lt' hm hb
+    let h1 := digits_def' hb hmb
+    have h2 : m = m * b / b :=
+      Nat.eq_div_of_mul_eq_left (not_eq_zero_of_lt hb) rfl
+    simp only [mul_mod_left, ←h2] at h1
+    rw [List.replicate_succ', List.append_assoc, List.singleton_append, ←h1, ←ih hmb]
+    ring_nf
+
 theorem ofDigits_digits_append_digits {b m n : ℕ} :
     ofDigits b (digits b n ++ digits b m) = n + b ^ (digits b n).length * m := by
   rw [ofDigits_append, ofDigits_digits, ofDigits_digits]
@@ -422,6 +435,13 @@ theorem digits_append_digits {b m n : ℕ} (hb : 0 < b) :
       exact getLast_digit_ne_zero b <| digits_ne_nil_iff_ne_zero.mp h_append
     · exact (List.getLast_append' _ _ h) ▸
           (getLast_digit_ne_zero _ <| digits_ne_nil_iff_ne_zero.mp h)
+
+theorem digits_append_zeroes_append_digits {b k m n : ℕ} (hb : 1 < b) (hm : 0 < m) :
+    digits b n ++ List.replicate k 0 ++ digits b m =
+    digits b (n + b ^ ((digits b n).length + k) * m) := by
+  rw [List.append_assoc, ←digits_base_pow_mul hb hm]
+  simp only [digits_append_digits (zero_lt_of_lt hb), digits_inj_iff, add_right_inj]
+  ring
 
 theorem digits_len_le_digits_len_succ (b n : ℕ) :
     (digits b n).length ≤ (digits b (n + 1)).length := by

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -415,8 +415,8 @@ theorem digits_base_pow_mul {b k m : ℕ} (hb : 1 < b) (hm : 0 < m) :
     let h1 := digits_def' hb hmb
     have h2 : m = m * b / b :=
       Nat.eq_div_of_mul_eq_left (not_eq_zero_of_lt hb) rfl
-    simp only [mul_mod_left, ←h2] at h1
-    rw [List.replicate_succ', List.append_assoc, List.singleton_append, ←h1, ←ih hmb]
+    simp only [mul_mod_left, ← h2] at h1
+    rw [List.replicate_succ', List.append_assoc, List.singleton_append, ← h1, ← ih hmb]
     ring_nf
 
 theorem ofDigits_digits_append_digits {b m n : ℕ} :
@@ -439,7 +439,7 @@ theorem digits_append_digits {b m n : ℕ} (hb : 0 < b) :
 theorem digits_append_zeroes_append_digits {b k m n : ℕ} (hb : 1 < b) (hm : 0 < m) :
     digits b n ++ List.replicate k 0 ++ digits b m =
     digits b (n + b ^ ((digits b n).length + k) * m) := by
-  rw [List.append_assoc, ←digits_base_pow_mul hb hm]
+  rw [List.append_assoc, ← digits_base_pow_mul hb hm]
   simp only [digits_append_digits (zero_lt_of_lt hb), digits_inj_iff, add_right_inj]
   ring
 


### PR DESCRIPTION
Adds two `Nat.digits` lemmas that I needed in Compfiles for USAMO 1992 Problem 1:
https://github.com/dwrensha/compfiles/blob/472f49e2b567e05c2cc1d963d5efbd6118f2b66c/Compfiles/Usa1992P1.lean#L32-L52

`Nat.digits_base_pow_mul` is like [`Nat.digits_append_digits`](https://github.com/leanprover-community/mathlib4/blob/7aeae34dfe1ca991bdb678b042ab1c7e3bea0df7/Mathlib/Data/Nat/Digits.lean#L413-L414), but with `Nat.digits b n` replaced by `List.replicate k 0`. This new lemma is useful because `Nat.digits b n` can never equal a nonempty list of all zeroes.

`Nat.digits_append_zeroes_append_digits` is like `Nat.digits_append_digits` with an extra `List.replicate k 0` inserted in the middle. 