### PR TITLE
[Merged by Bors] - feat(GroupTheory/SpecificGroups/Cyclic): Cardinality of automorphism group

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2859,6 +2859,7 @@ import Mathlib.Data.Vector3
 import Mathlib.Data.W.Basic
 import Mathlib.Data.W.Cardinal
 import Mathlib.Data.W.Constructions
+import Mathlib.Data.ZMod.Aut
 import Mathlib.Data.ZMod.Basic
 import Mathlib.Data.ZMod.Coprime
 import Mathlib.Data.ZMod.Defs

--- a/Mathlib/Data/ZMod/Aut.lean
+++ b/Mathlib/Data/ZMod/Aut.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2024 Thomas Browning. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Browning
+-/
+import Mathlib.Algebra.Ring.AddAut
+import Mathlib.Data.ZMod.Basic
+
+/-!
+# Automorphism Group of `ZMod`.
+-/
+
+namespace ZMod
+
+variable (n : ℕ)
+
+/-- The automorphism group of `ZMod n` is isomorphic to the group of units of `ZMod n`. -/
+@[simps]
+def AddAutEquivUnits : AddAut (ZMod n) ≃* (ZMod n)ˣ :=
+  have h (f : AddAut (ZMod n)) (x : ZMod n) : f 1 * x = f x := by
+    rw [mul_comm, ← x.intCast_zmod_cast, ← zsmul_eq_mul, ← map_zsmul, zsmul_one]
+  { toFun := fun f ↦ Units.mkOfMulEqOne (f 1) (f⁻¹ 1) ((h f _).trans (f.inv_apply_self _ _))
+    invFun := AddAut.mulLeft
+    left_inv := fun f ↦ by simp [DFunLike.ext_iff, Units.smul_def, h]
+    right_inv := fun x ↦ by simp [Units.ext_iff, Units.smul_def]
+    map_mul' := fun f g ↦ by simp [Units.ext_iff, h] }
+
+end ZMod

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.Order.BigOperators.Ring.Finset
 import Mathlib.Data.Nat.Totient
+import Mathlib.Data.ZMod.Aut
 import Mathlib.Data.ZMod.Quotient
 import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.GroupTheory.Subgroup.Simple
@@ -736,6 +737,13 @@ noncomputable def mulEquivOfPrimeCardEq {p : ℕ} [Fintype G] [Fintype G'] [Grou
   apply mulEquivOfCyclicCardEq
   rw [← Nat.card_eq_fintype_card] at hG hH
   exact hG.trans hH.symm
+
+theorem IsCyclic.card_mulAut [Group G] [Finite G] [h : IsCyclic G] :
+    Nat.card (MulAut G) = Nat.totient (Nat.card G) := by
+  have : NeZero (Nat.card G) := ⟨Nat.card_pos.ne'⟩
+  rw [← ZMod.card_units_eq_totient, ← Nat.card_eq_fintype_card]
+  exact Nat.card_congr ((MulAut.congr (zmodCyclicMulEquiv h)).toEquiv.symm.trans
+    (MulEquiv.toAdditive.trans (ZMod.AddAutEquivUnits (Nat.card G)).toEquiv))
 
 end ZMod
 


### PR DESCRIPTION
This PR computes the cardinality of the automorphism group of a cyclic group. This is useful when paired with the N/C theorem in PR #19006.

I added a new file to avoid adding extra imports to `Data/ZMod/Basic.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
