### PR TITLE
[Merged by Bors] - feat: add `Subgroup.index_antitone` and `Subgroup.index_strictAnti`

### DIFF
--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -392,6 +392,24 @@ noncomputable def fintypeOfIndexNeZero (hH : H.index ≠ 0) : Fintype (G ⧸ H) 
 lemma index_eq_zero_iff_infinite : H.index = 0 ↔ Infinite (G ⧸ H) := by
   simp [index_eq_card, Nat.card_eq_zero]
 
+@[to_additive]
+lemma index_mono (h : H ≤ K) [h₁ : Finite (G ⧸ H)] : K.index ≤ H.index := by
+  rcases eq_or_ne H.index 0 with h0 | h0
+  · rw [index_eq_zero_iff_infinite] at h0
+    exfalso
+    exact not_finite (G ⧸ H)
+  refine Nat.le_of_dvd (Nat.zero_lt_of_ne_zero h0) (index_dvd_of_le h)
+
+@[to_additive]
+lemma index_strict_mono (h : H < K) [h₁ : Finite (G ⧸ H)] : K.index < H.index := by
+  rcases eq_or_ne K.index 0 with h0 | h0
+  · rw [h0, index_eq_card]
+    exact Finite.card_pos
+  apply lt_of_le_of_ne
+  · exact Nat.le_of_dvd (by rw [index_eq_card]; apply Finite.card_pos) <| index_dvd_of_le h.le
+  rw [←mul_one K.index, ←relindex_mul_index h.le, mul_comm, Ne, eq_comm]
+  simp [h0, h.not_le]
+
 @[to_additive one_lt_index_of_ne_top]
 theorem one_lt_index_of_ne_top [Finite (G ⧸ H)] (hH : H ≠ ⊤) : 1 < H.index :=
   Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨index_ne_zero_of_finite, mt index_eq_one.mp hH⟩

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -398,7 +398,7 @@ lemma index_mono (h : H ≤ K) [h₁ : Finite (G ⧸ H)] : K.index ≤ H.index :
   · rw [index_eq_zero_iff_infinite] at h0
     exfalso
     exact not_finite (G ⧸ H)
-  refine Nat.le_of_dvd (Nat.zero_lt_of_ne_zero h0) (index_dvd_of_le h)
+  exact Nat.le_of_dvd (Nat.zero_lt_of_ne_zero h0) (index_dvd_of_le h)
 
 @[to_additive]
 lemma index_strict_mono (h : H < K) [h₁ : Finite (G ⧸ H)] : K.index < H.index := by

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -407,7 +407,7 @@ lemma index_strict_mono (h : H < K) [h₁ : Finite (G ⧸ H)] : K.index < H.inde
     exact Finite.card_pos
   apply lt_of_le_of_ne
   · exact Nat.le_of_dvd (by rw [index_eq_card]; apply Finite.card_pos) <| index_dvd_of_le h.le
-  rw [←mul_one K.index, ←relindex_mul_index h.le, mul_comm, Ne, eq_comm]
+  rw [← mul_one K.index, ← relindex_mul_index h.le, mul_comm, Ne, eq_comm]
   simp [h0, h.not_le]
 
 @[to_additive one_lt_index_of_ne_top]

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -405,8 +405,7 @@ lemma index_strictAnti (h : H < K) [h₁ : Finite (G ⧸ H)] : K.index < H.index
   rcases eq_or_ne K.index 0 with h0 | h0
   · rw [h0, index_eq_card]
     exact Finite.card_pos
-  apply lt_of_le_of_ne
-  · exact Nat.le_of_dvd (by rw [index_eq_card]; apply Finite.card_pos) <| index_dvd_of_le h.le
+  apply lt_of_le_of_ne (index_antitone h.le)
   rw [← mul_one K.index, ← relindex_mul_index h.le, mul_comm, Ne, eq_comm]
   simp [h0, h.not_le]
 

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -392,23 +392,6 @@ noncomputable def fintypeOfIndexNeZero (hH : H.index ≠ 0) : Fintype (G ⧸ H) 
 lemma index_eq_zero_iff_infinite : H.index = 0 ↔ Infinite (G ⧸ H) := by
   simp [index_eq_card, Nat.card_eq_zero]
 
-@[to_additive (attr := gcongr)]
-lemma index_antitone (h : H ≤ K) [h₁ : Finite (G ⧸ H)] : K.index ≤ H.index := by
-  rcases eq_or_ne H.index 0 with h0 | h0
-  · rw [index_eq_zero_iff_infinite] at h0
-    exfalso
-    exact not_finite (G ⧸ H)
-  exact Nat.le_of_dvd (Nat.zero_lt_of_ne_zero h0) (index_dvd_of_le h)
-
-@[to_additive (attr := gcongr)]
-lemma index_strictAnti (h : H < K) [h₁ : Finite (G ⧸ H)] : K.index < H.index := by
-  rcases eq_or_ne K.index 0 with h0 | h0
-  · rw [h0, index_eq_card]
-    exact Finite.card_pos
-  apply lt_of_le_of_ne (index_antitone h.le)
-  rw [← mul_one K.index, ← relindex_mul_index h.le, mul_comm, Ne, eq_comm]
-  simp [h0, h.not_le]
-
 @[to_additive one_lt_index_of_ne_top]
 theorem one_lt_index_of_ne_top [Finite (G ⧸ H)] (hH : H ≠ ⊤) : 1 < H.index :=
   Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨index_ne_zero_of_finite, mt index_eq_one.mp hH⟩
@@ -573,6 +556,23 @@ variable {H K}
 @[to_additive]
 theorem finiteIndex_of_le [FiniteIndex H] (h : H ≤ K) : FiniteIndex K :=
   ⟨ne_zero_of_dvd_ne_zero FiniteIndex.finiteIndex (index_dvd_of_le h)⟩
+
+@[to_additive (attr := gcongr)]
+lemma index_antitone (h : H ≤ K) [H.FiniteIndex] : K.index ≤ H.index := by
+  rcases eq_or_ne H.index 0 with h0 | h0
+  · rw [index_eq_zero_iff_infinite] at h0
+    exfalso
+    exact not_finite (G ⧸ H)
+  exact Nat.le_of_dvd (Nat.zero_lt_of_ne_zero h0) (index_dvd_of_le h)
+
+@[to_additive (attr := gcongr)]
+lemma index_strictAnti (h : H < K) [H.FiniteIndex] : K.index < H.index := by
+  rcases eq_or_ne K.index 0 with h0 | h0
+  · rw [h0, index_eq_card]
+    exact Finite.card_pos
+  apply lt_of_le_of_ne (index_antitone h.le)
+  rw [← mul_one K.index, ← relindex_mul_index h.le, mul_comm, Ne, eq_comm]
+  simp [h0, h.not_le]
 
 variable (H K)
 

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -401,7 +401,7 @@ lemma index_antitone (h : H ≤ K) [h₁ : Finite (G ⧸ H)] : K.index ≤ H.ind
   exact Nat.le_of_dvd (Nat.zero_lt_of_ne_zero h0) (index_dvd_of_le h)
 
 @[to_additive (attr := gcongr)]
-lemma index_Anti (h : H < K) [h₁ : Finite (G ⧸ H)] : K.index < H.index := by
+lemma index_strictAnti (h : H < K) [h₁ : Finite (G ⧸ H)] : K.index < H.index := by
   rcases eq_or_ne K.index 0 with h0 | h0
   · rw [h0, index_eq_card]
     exact Finite.card_pos

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -558,18 +558,12 @@ theorem finiteIndex_of_le [FiniteIndex H] (h : H ≤ K) : FiniteIndex K :=
   ⟨ne_zero_of_dvd_ne_zero FiniteIndex.finiteIndex (index_dvd_of_le h)⟩
 
 @[to_additive (attr := gcongr)]
-lemma index_antitone (h : H ≤ K) [H.FiniteIndex] : K.index ≤ H.index := by
-  rcases eq_or_ne H.index 0 with h0 | h0
-  · rw [index_eq_zero_iff_infinite] at h0
-    exfalso
-    exact not_finite (G ⧸ H)
-  exact Nat.le_of_dvd (Nat.zero_lt_of_ne_zero h0) (index_dvd_of_le h)
+lemma index_antitone (h : H ≤ K) [H.FiniteIndex] : K.index ≤ H.index :=
+  Nat.le_of_dvd (Nat.zero_lt_of_ne_zero FiniteIndex.finiteIndex) (index_dvd_of_le h)
 
 @[to_additive (attr := gcongr)]
-lemma index_strictAnti (h : H < K) [H.FiniteIndex] : K.index < H.index := by
-  rcases eq_or_ne K.index 0 with h0 | h0
-  · rw [h0, index_eq_card]
-    exact Finite.card_pos
+lemma index_strictAnti (h : H < K) [hf : H.FiniteIndex] : K.index < H.index := by
+  have h0 : K.index ≠ 0 := fun H ↦ hf.1 <| by simpa [H] using (index_dvd_of_le h.le)
   apply lt_of_le_of_ne (index_antitone h.le)
   rw [← mul_one K.index, ← relindex_mul_index h.le, mul_comm, Ne, eq_comm]
   simp [h0, h.not_le]

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -563,7 +563,7 @@ lemma index_antitone (h : H ≤ K) [H.FiniteIndex] : K.index ≤ H.index :=
 
 @[to_additive (attr := gcongr)]
 lemma index_strictAnti (h : H < K) [hf : H.FiniteIndex] : K.index < H.index := by
-  have h0 : K.index ≠ 0 := fun H ↦ hf.1 <| by simpa [H] using (index_dvd_of_le h.le)
+  have h0 : K.index ≠ 0 := (finiteIndex_of_le h.le).finiteIndex
   apply lt_of_le_of_ne (index_antitone h.le)
   rw [← relindex_mul_index h.le, Ne, eq_comm, mul_eq_right₀ h0, relindex_eq_one]
   exact h.not_le

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -562,7 +562,7 @@ lemma index_antitone (h : H ≤ K) [H.FiniteIndex] : K.index ≤ H.index :=
   Nat.le_of_dvd (Nat.zero_lt_of_ne_zero FiniteIndex.finiteIndex) (index_dvd_of_le h)
 
 @[to_additive (attr := gcongr)]
-lemma index_strictAnti (h : H < K) [hf : H.FiniteIndex] : K.index < H.index := by
+lemma index_strictAnti (h : H < K) [H.FiniteIndex] : K.index < H.index := by
   have h0 : K.index ≠ 0 := (finiteIndex_of_le h.le).finiteIndex
   apply lt_of_le_of_ne (index_antitone h.le)
   rw [← relindex_mul_index h.le, Ne, eq_comm, mul_eq_right₀ h0, relindex_eq_one]

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -565,8 +565,8 @@ lemma index_antitone (h : H ≤ K) [H.FiniteIndex] : K.index ≤ H.index :=
 lemma index_strictAnti (h : H < K) [hf : H.FiniteIndex] : K.index < H.index := by
   have h0 : K.index ≠ 0 := fun H ↦ hf.1 <| by simpa [H] using (index_dvd_of_le h.le)
   apply lt_of_le_of_ne (index_antitone h.le)
-  rw [← mul_one K.index, ← relindex_mul_index h.le, mul_comm, Ne, eq_comm]
-  simp [h0, h.not_le]
+  rw [← relindex_mul_index h.le, Ne, eq_comm, mul_eq_right₀ h0, relindex_eq_one]
+  exact h.not_le
 
 variable (H K)
 

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -392,16 +392,16 @@ noncomputable def fintypeOfIndexNeZero (hH : H.index ≠ 0) : Fintype (G ⧸ H) 
 lemma index_eq_zero_iff_infinite : H.index = 0 ↔ Infinite (G ⧸ H) := by
   simp [index_eq_card, Nat.card_eq_zero]
 
-@[to_additive]
-lemma index_mono (h : H ≤ K) [h₁ : Finite (G ⧸ H)] : K.index ≤ H.index := by
+@[to_additive (attr := gcongr)]
+lemma index_antitone (h : H ≤ K) [h₁ : Finite (G ⧸ H)] : K.index ≤ H.index := by
   rcases eq_or_ne H.index 0 with h0 | h0
   · rw [index_eq_zero_iff_infinite] at h0
     exfalso
     exact not_finite (G ⧸ H)
   exact Nat.le_of_dvd (Nat.zero_lt_of_ne_zero h0) (index_dvd_of_le h)
 
-@[to_additive]
-lemma index_strict_mono (h : H < K) [h₁ : Finite (G ⧸ H)] : K.index < H.index := by
+@[to_additive (attr := gcongr)]
+lemma index_Anti (h : H < K) [h₁ : Finite (G ⧸ H)] : K.index < H.index := by
   rcases eq_or_ne K.index 0 with h0 | h0
   · rw [h0, index_eq_card]
     exact Finite.card_pos


### PR DESCRIPTION
from flt-regular.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
