### PR TITLE
[Merged by Bors] - feat: right-division as an `OrderIso`

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
@@ -38,6 +38,13 @@ protected def mulRight₀ (a : G) (ha : a ≠ 0) : Perm G :=
 theorem _root_.mulRight_bijective₀ (a : G) (ha : a ≠ 0) : Function.Bijective ((· * a) : G → G) :=
   (Equiv.mulRight₀ a ha).bijective
 
+@[simps! (config := { simpRhs := true })]
+def divRight₀ {G₀} [GroupWithZero G₀] (a : G₀) (ha : a ≠ 0) : G₀ ≃ G₀ where
+  toFun := (· / a)
+  invFun := (· * a)
+  left_inv _ := by simp [ha]
+  right_inv _ := by simp [ha]
+
 end GroupWithZero
 
 end Equiv

--- a/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
@@ -12,34 +12,36 @@ import Mathlib.Algebra.GroupWithZero.Units.Basic
 
 assert_not_exists DenselyOrdered
 
-variable {G : Type*}
+variable {G₀ : Type*}
 
 namespace Equiv
 
 section GroupWithZero
 
-variable [GroupWithZero G]
+variable [GroupWithZero G₀]
 
 /-- Left multiplication by a nonzero element in a `GroupWithZero` is a permutation of the
 underlying type. -/
 @[simps! (config := .asFn)]
-protected def mulLeft₀ (a : G) (ha : a ≠ 0) : Perm G :=
+protected def mulLeft₀ (a : G₀) (ha : a ≠ 0) : Perm G₀ :=
   (Units.mk0 a ha).mulLeft
 
-theorem _root_.mulLeft_bijective₀ (a : G) (ha : a ≠ 0) : Function.Bijective (a * · : G → G) :=
+theorem _root_.mulLeft_bijective₀ (a : G₀) (ha : a ≠ 0) : Function.Bijective (a * · : G₀ → G₀) :=
   (Equiv.mulLeft₀ a ha).bijective
 
 /-- Right multiplication by a nonzero element in a `GroupWithZero` is a permutation of the
 underlying type. -/
 @[simps! (config := .asFn)]
-protected def mulRight₀ (a : G) (ha : a ≠ 0) : Perm G :=
+protected def mulRight₀ (a : G₀) (ha : a ≠ 0) : Perm G₀ :=
   (Units.mk0 a ha).mulRight
 
-theorem _root_.mulRight_bijective₀ (a : G) (ha : a ≠ 0) : Function.Bijective ((· * a) : G → G) :=
+theorem _root_.mulRight_bijective₀ (a : G₀) (ha : a ≠ 0) : Function.Bijective ((· * a) : G₀ → G₀) :=
   (Equiv.mulRight₀ a ha).bijective
 
+/-- Right division by a nonzero element in a `GroupWithZero` is a permutation of the
+underlying type. -/
 @[simps! (config := { simpRhs := true })]
-def divRight₀ {G₀} [GroupWithZero G₀] (a : G₀) (ha : a ≠ 0) : G₀ ≃ G₀ where
+def divRight₀ (a : G₀) (ha : a ≠ 0) : G₀ ≃ G₀ where
   toFun := (· / a)
   invFun := (· * a)
   left_inv _ := by simp [ha]

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Lemmas.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Lemmas.lean
@@ -25,3 +25,13 @@ def OrderIso.mulLeft₀ [PosMulMono G₀] [PosMulReflectLE G₀] (a : G₀) (ha 
 def OrderIso.mulRight₀ [MulPosMono G₀] [MulPosReflectLE G₀] (a : G₀) (ha : 0 < a) : G₀ ≃o G₀ where
   toEquiv := .mulRight₀ a ha.ne'
   map_rel_iff' := mul_le_mul_right ha
+
+/-- `Equiv.divRight₀` as an order isomorphism. -/
+@[simps! (config := { simpRhs := true })]
+def OrderIso.divRight₀ {G₀} [GroupWithZero G₀] [PartialOrder G₀] [ZeroLEOneClass G₀]
+    [MulPosStrictMono G₀] [MulPosReflectLE G₀] [PosMulReflectLT G₀]
+    (a : G₀) (ha : 0 < a) : G₀ ≃o G₀ where
+  toEquiv := .divRight₀ a ha.ne'
+  map_rel_iff' {b c} := by
+    simp only [Equiv.divRight₀_apply, div_eq_mul_inv]
+    exact mul_le_mul_right (a := a⁻¹) (inv_pos.mpr ha)


### PR DESCRIPTION
Co-authored-by: Andrew Yang


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
