### PR TITLE
[Merged by Bors] - refactor: make `LinearOrderedCommMonoidWithZero` extend `OrderBot`

### DIFF
--- a/Counterexamples/LinearOrderWithPosMulPosEqZero.lean
+++ b/Counterexamples/LinearOrderWithPosMulPosEqZero.lean
@@ -68,13 +68,16 @@ instance commMonoid : CommMonoid Foo where
   mul_comm := by boom
   mul_assoc := by boom
 
-instance : LinearOrderedCommMonoidWithZero Foo :=
-  { Foo.linearOrder, Foo.commMonoid with
-    zero := 0
-    zero_mul := by boom
-    mul_zero := by boom
-    mul_le_mul_left := by rintro ⟨⟩ ⟨⟩ h ⟨⟩ <;> revert h <;> decide
-    zero_le_one := by decide }
+instance : LinearOrderedCommMonoidWithZero Foo where
+  __ := linearOrder
+  __ := commMonoid
+  zero := 0
+  zero_mul := by boom
+  mul_zero := by boom
+  mul_le_mul_left := by rintro ⟨⟩ ⟨⟩ h ⟨⟩ <;> revert h <;> decide
+  zero_le_one := by decide
+  bot := 0
+  bot_le := by boom
 
 theorem not_mul_pos : ¬∀ {M : Type} [LinearOrderedCommMonoidWithZero M],
     ∀ a b : M, 0 < a → 0 < b → 0 < a * b := by

--- a/Mathlib/Algebra/Order/Field/Canonical.lean
+++ b/Mathlib/Algebra/Order/Field/Canonical.lean
@@ -27,9 +27,11 @@ variable {α : Type*} [LinearOrderedSemifield α] [CanonicallyOrderedAdd α]
 /-- Construct a `LinearOrderedCommGroupWithZero` from a canonically ordered
 `LinearOrderedSemifield`. -/
 abbrev LinearOrderedSemifield.toLinearOrderedCommGroupWithZero :
-    LinearOrderedCommGroupWithZero α :=
-  { ‹LinearOrderedSemifield α› with
-    mul_le_mul_left := fun _ _ h _ ↦ mul_le_mul_of_nonneg_left h <| zero_le _ }
+    LinearOrderedCommGroupWithZero α where
+  __ := ‹LinearOrderedSemifield α›
+  bot := 0
+  bot_le := zero_le
+  mul_le_mul_left _ _ h _:= mul_le_mul_of_nonneg_left h <| zero_le _
 
 variable [Sub α] [OrderedSub α]
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -31,7 +31,7 @@ variable {α : Type*}
 
 /-- A linearly ordered commutative monoid with a zero element. -/
 class LinearOrderedCommMonoidWithZero (α : Type*) extends LinearOrderedCommMonoid α,
-  CommMonoidWithZero α where
+  CommMonoidWithZero α, OrderBot α where
   /-- `0 ≤ 1` in any linearly ordered commutative monoid. -/
   zero_le_one : (0 : α) ≤ 1
 
@@ -55,15 +55,17 @@ The following facts are true more generally in a (linearly) ordered commutative 
 -/
 /-- Pullback a `LinearOrderedCommMonoidWithZero` under an injective map.
 See note [reducible non-instances]. -/
-abbrev Function.Injective.linearOrderedCommMonoidWithZero {β : Type*} [Zero β] [One β] [Mul β]
-    [Pow β ℕ] [Max β] [Min β] (f : β → α) (hf : Function.Injective f) (zero : f 0 = 0)
+abbrev Function.Injective.linearOrderedCommMonoidWithZero {β : Type*} [Zero β] [Bot β] [One β]
+    [Mul β] [Pow β ℕ] [Max β] [Min β] (f : β → α) (hf : Function.Injective f) (zero : f 0 = 0)
     (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n)
-    (hsup : ∀ x y, f (x ⊔ y) = max (f x) (f y)) (hinf : ∀ x y, f (x ⊓ y) = min (f x) (f y)) :
-    LinearOrderedCommMonoidWithZero β :=
-  { LinearOrder.lift f hf hsup hinf, hf.orderedCommMonoid f one mul npow,
-    hf.commMonoidWithZero f zero one mul npow with
-    zero_le_one :=
-      show f 0 ≤ f 1 by simp only [zero, one, LinearOrderedCommMonoidWithZero.zero_le_one] }
+    (hsup : ∀ x y, f (x ⊔ y) = max (f x) (f y)) (hinf : ∀ x y, f (x ⊓ y) = min (f x) (f y))
+    (bot : f ⊥ = ⊥) : LinearOrderedCommMonoidWithZero β where
+  __ := LinearOrder.lift f hf hsup hinf
+  __ := hf.orderedCommMonoid f one mul npow
+  __ := hf.commMonoidWithZero f zero one mul npow
+  zero_le_one :=
+      show f 0 ≤ f 1 by simp only [zero, one, LinearOrderedCommMonoidWithZero.zero_le_one]
+  bot_le a := show f ⊥ ≤ f a from bot ▸ bot_le
 
 @[simp] lemma zero_le' : 0 ≤ a := by
   simpa only [mul_zero, mul_one] using mul_le_mul_left' (zero_le_one' α) a
@@ -81,15 +83,18 @@ theorem zero_lt_iff : 0 < a ↔ a ≠ 0 :=
 
 theorem ne_zero_of_lt (h : b < a) : a ≠ 0 := fun h1 ↦ not_lt_zero' <| show b < 0 from h1 ▸ h
 
+/-- See also `bot_eq_zero` and `bot_eq_zero'` for canonically ordered monoids. -/
+lemma bot_eq_zero'' : (0 : α) = ⊥ := eq_of_forall_ge_iff fun _ ↦ by simp
+
 instance instLinearOrderedAddCommMonoidWithTopAdditiveOrderDual :
     LinearOrderedAddCommMonoidWithTop (Additive αᵒᵈ) where
-  top := (0 : α)
-  top_add' := fun a ↦ zero_mul a.toMul
-  le_top := fun _ ↦ zero_le'
+  top := .ofMul <| .toDual 0
+  top_add' a := zero_mul a.toMul.ofDual
+  le_top _ := zero_le'
 
 instance instLinearOrderedAddCommMonoidWithTopOrderDualAdditive :
     LinearOrderedAddCommMonoidWithTop (Additive α)ᵒᵈ where
-  top := OrderDual.toDual (Additive.ofMul 0)
+  top := .toDual <| .ofMul _
   top_add' := fun a ↦ zero_mul (Additive.toMul (OrderDual.ofDual a))
   le_top := fun a ↦ @zero_le' _ _ (Additive.toMul (OrderDual.ofDual a))
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -83,7 +83,7 @@ theorem zero_lt_iff : 0 < a ↔ a ≠ 0 :=
 theorem ne_zero_of_lt (h : b < a) : a ≠ 0 := fun h1 ↦ not_lt_zero' <| show b < 0 from h1 ▸ h
 
 /-- See also `bot_eq_zero` and `bot_eq_zero'` for canonically ordered monoids. -/
-lemma bot_eq_zero'' : (0 : α) = ⊥ := eq_of_forall_ge_iff fun _ ↦ by simp
+lemma bot_eq_zero'' : (⊥ : α) = 0 := eq_of_forall_ge_iff fun _ ↦ by simp
 
 instance instLinearOrderedAddCommMonoidWithTopAdditiveOrderDual :
     LinearOrderedAddCommMonoidWithTop (Additive αᵒᵈ) where

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.GroupWithZero.InjSurj
 import Mathlib.Algebra.GroupWithZero.Units.Equiv
 import Mathlib.Algebra.GroupWithZero.WithZero
 import Mathlib.Algebra.Order.AddGroupWithTop
-import Mathlib.Algebra.Order.GroupWithZero.Synonym
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Lemmas
 import Mathlib.Algebra.Order.Monoid.Basic
 import Mathlib.Algebra.Order.Monoid.OrderDual

--- a/Mathlib/RingTheory/Valuation/Archimedean.lean
+++ b/Mathlib/RingTheory/Valuation/Archimedean.lean
@@ -24,6 +24,8 @@ variable {F Γ₀ O : Type*} [Field F] [LinearOrderedCommGroupWithZero Γ₀]
 instance : LinearOrderedCommGroupWithZero (MonoidHom.mrange v) where
   __ : CommGroupWithZero (MonoidHom.mrange v) := inferInstance
   __ : LinearOrder (MonoidHom.mrange v) := inferInstance
+  bot := 0
+  bot_le a := show (0 : Γ₀) ≤ _ from zero_le'
   zero_le_one := Subtype.coe_le_coe.mp zero_le_one
   mul_le_mul_left := by
     simp only [Subtype.forall, MonoidHom.mem_mrange, forall_exists_index, Submonoid.mk_mul_mk,

--- a/Mathlib/RingTheory/Valuation/ValuationRing.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationRing.lean
@@ -155,34 +155,36 @@ noncomputable instance linearOrder : LinearOrder (ValueGroup A K) where
   decidableLE := by classical infer_instance
 
 noncomputable instance linearOrderedCommGroupWithZero :
-    LinearOrderedCommGroupWithZero (ValueGroup A K) :=
-  { linearOrder .. with
-    mul_assoc := by rintro ⟨a⟩ ⟨b⟩ ⟨c⟩; apply Quotient.sound'; rw [mul_assoc]
-    one_mul := by rintro ⟨a⟩; apply Quotient.sound'; rw [one_mul]
-    mul_one := by rintro ⟨a⟩; apply Quotient.sound'; rw [mul_one]
-    mul_comm := by rintro ⟨a⟩ ⟨b⟩; apply Quotient.sound'; rw [mul_comm]
-    mul_le_mul_left := by
-      rintro ⟨a⟩ ⟨b⟩ ⟨c, rfl⟩ ⟨d⟩
-      use c; simp only [Algebra.smul_def]; ring
-    zero_mul := by rintro ⟨a⟩; apply Quotient.sound'; rw [zero_mul]
-    mul_zero := by rintro ⟨a⟩; apply Quotient.sound'; rw [mul_zero]
-    zero_le_one := ⟨0, by rw [zero_smul]⟩
-    exists_pair_ne := by
-      use 0, 1
-      intro c; obtain ⟨d, hd⟩ := Quotient.exact' c
-      apply_fun fun t => d⁻¹ • t at hd
-      simp only [inv_smul_smul, smul_zero, one_ne_zero] at hd
-    inv_zero := by apply Quotient.sound'; rw [inv_zero]
-    mul_inv_cancel := by
-      rintro ⟨a⟩ ha
-      apply Quotient.sound'
-      use 1
-      simp only [one_smul, ne_eq]
-      apply (mul_inv_cancel₀ _).symm
-      contrapose ha
-      simp only [Classical.not_not] at ha ⊢
-      rw [ha]
-      rfl }
+    LinearOrderedCommGroupWithZero (ValueGroup A K) where
+  __ := linearOrder ..
+  mul_assoc := by rintro ⟨a⟩ ⟨b⟩ ⟨c⟩; apply Quotient.sound'; rw [mul_assoc]
+  one_mul := by rintro ⟨a⟩; apply Quotient.sound'; rw [one_mul]
+  mul_one := by rintro ⟨a⟩; apply Quotient.sound'; rw [mul_one]
+  mul_comm := by rintro ⟨a⟩ ⟨b⟩; apply Quotient.sound'; rw [mul_comm]
+  mul_le_mul_left := by
+    rintro ⟨a⟩ ⟨b⟩ ⟨c, rfl⟩ ⟨d⟩
+    use c; simp only [Algebra.smul_def]; ring
+  zero_mul := by rintro ⟨a⟩; apply Quotient.sound'; rw [zero_mul]
+  mul_zero := by rintro ⟨a⟩; apply Quotient.sound'; rw [mul_zero]
+  zero_le_one := ⟨0, by rw [zero_smul]⟩
+  exists_pair_ne := by
+    use 0, 1
+    intro c; obtain ⟨d, hd⟩ := Quotient.exact' c
+    apply_fun fun t => d⁻¹ • t at hd
+    simp only [inv_smul_smul, smul_zero, one_ne_zero] at hd
+  inv_zero := by apply Quotient.sound'; rw [inv_zero]
+  mul_inv_cancel := by
+    rintro ⟨a⟩ ha
+    apply Quotient.sound'
+    use 1
+    simp only [one_smul, ne_eq]
+    apply (mul_inv_cancel₀ _).symm
+    contrapose ha
+    simp only [Classical.not_not] at ha ⊢
+    rw [ha]
+    rfl
+  bot := 0
+  bot_le := by rintro ⟨a⟩; exact ⟨0, zero_smul ..⟩
 
 /-- Any valuation ring induces a valuation on its fraction field. -/
 def valuation : Valuation K (ValueGroup A K) where


### PR DESCRIPTION
Currently, the following fails:
```lean
import Mathlib

variable {α : Type*} [LinearOrderedCommGroupWithZero α]

#synth OrderBot α
/-
failed to synthesize
  OrderBot α
Additional diagnostic information may be available using the `set_option diagnostics true` command.
-/
```


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
