### PR TITLE
[Merged by Bors] - feat(CategoryTheory): split up a product into a binary product

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1830,6 +1830,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.Kernels
 import Mathlib.CategoryTheory.Limits.Shapes.Multiequalizer
 import Mathlib.CategoryTheory.Limits.Shapes.NormalMono.Basic
 import Mathlib.CategoryTheory.Limits.Shapes.NormalMono.Equalizers
+import Mathlib.CategoryTheory.Limits.Shapes.PiProd
 import Mathlib.CategoryTheory.Limits.Shapes.Products
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Assoc
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq

--- a/Mathlib/CategoryTheory/Limits/Shapes/PiProd.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/PiProd.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dagur Asgeirsson
+-/
+import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
+import Mathlib.CategoryTheory.Limits.Shapes.Products
+/-!
+
+# A product as a binary product
+
+We write a product indexed by `I` as a binary product of the products indexed by a subset of `I`
+and its complement.
+
+-/
+
+namespace CategoryTheory.Limits
+
+variable {C I : Type*} [Category C] {X Y : I → C}
+  (f : (i : I) → X i ⟶ Y i) (P : I → Prop) [∀ i, Decidable (P i)]
+  [HasProduct X] [HasProduct Y]
+  [HasProduct (fun (i : {x : I // P x}) ↦ X i.val)]
+  [HasProduct (fun (i : {x : I // ¬ (P x)}) ↦ X i.val)]
+  [HasProduct (fun (i : {x : I // P x}) ↦ Y i.val)]
+  [HasProduct (fun (i : {x : I // ¬ (P x)}) ↦ Y i.val)]
+
+variable (X) in
+/--
+The projection maps of a product to the products indexed by a subset and its complement, as a
+binary fan.
+-/
+noncomputable def Pi.binaryFanOfProp : BinaryFan (∏ᶜ (fun (i : {x : I // P x}) ↦ X i.val))
+    (∏ᶜ (fun (i : {x : I // ¬ (P x)}) ↦ X i.val)) :=
+  BinaryFan.mk (P := ∏ᶜ X) (Pi.map' Subtype.val fun _ ↦ 𝟙 _)
+    (Pi.map' Subtype.val fun _ ↦ 𝟙 _)
+
+variable (X) in
+/--
+A product indexed by `I` is a binary product of the products indexed by a subset of `I` and its
+complement.
+-/
+noncomputable def Pi.binaryFanOfPropIsLimit : IsLimit (Pi.binaryFanOfProp X P) :=
+  BinaryFan.isLimitMk
+    (fun s ↦ Pi.lift fun b ↦ if h : (P b) then
+      s.π.app ⟨WalkingPair.left⟩ ≫ Pi.π (fun (i : {x : I // P x}) ↦ X i.val) ⟨b, h⟩ else
+      s.π.app ⟨WalkingPair.right⟩ ≫ Pi.π (fun (i : {x : I // ¬ (P x)}) ↦ X i.val) ⟨b, h⟩)
+    (by aesop) (by aesop)
+    (fun _ _ h₁ h₂ ↦ Pi.hom_ext _ _ fun b ↦ by
+      by_cases h : (P b)
+      · simp [← h₁, dif_pos h]
+      · simp [← h₂, dif_neg h])
+
+lemma hasBinaryProduct_of_products : HasBinaryProduct (∏ᶜ (fun (i : {x : I // P x}) ↦ X i.val))
+    (∏ᶜ (fun (i : {x : I // ¬ (P x)}) ↦ X i.val)) :=
+  ⟨Pi.binaryFanOfProp X P, Pi.binaryFanOfPropIsLimit X P⟩
+
+attribute [local instance] hasBinaryProduct_of_products
+
+lemma Pi.map_eq_prod_map : Pi.map f =
+    ((Pi.binaryFanOfPropIsLimit X P).conePointUniqueUpToIso (prodIsProd _ _)).hom ≫
+      prod.map (Pi.map (fun (i : {x : I // P x}) ↦ f i.val))
+      (Pi.map (fun (i : {x : I // ¬ (P x)}) ↦ f i.val)) ≫
+        ((Pi.binaryFanOfPropIsLimit Y P).conePointUniqueUpToIso (prodIsProd _ _)).inv := by
+  rw [← Category.assoc, Iso.eq_comp_inv]
+  dsimp only [IsLimit.conePointUniqueUpToIso, binaryFanOfProp, prodIsProd]
+  apply prod.hom_ext
+  all_goals aesop_cat
+
+end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Shapes/PiProd.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/PiProd.lean
@@ -20,9 +20,9 @@ variable {C I : Type*} [Category C] {X Y : I → C}
   (f : (i : I) → X i ⟶ Y i) (P : I → Prop) [∀ i, Decidable (P i)]
   [HasProduct X] [HasProduct Y]
   [HasProduct (fun (i : {x : I // P x}) ↦ X i.val)]
-  [HasProduct (fun (i : {x : I // ¬ (P x)}) ↦ X i.val)]
+  [HasProduct (fun (i : {x : I // ¬ P x}) ↦ X i.val)]
   [HasProduct (fun (i : {x : I // P x}) ↦ Y i.val)]
-  [HasProduct (fun (i : {x : I // ¬ (P x)}) ↦ Y i.val)]
+  [HasProduct (fun (i : {x : I // ¬ P x}) ↦ Y i.val)]
 
 variable (X) in
 /--
@@ -30,7 +30,7 @@ The projection maps of a product to the products indexed by a subset and its com
 binary fan.
 -/
 noncomputable def Pi.binaryFanOfProp : BinaryFan (∏ᶜ (fun (i : {x : I // P x}) ↦ X i.val))
-    (∏ᶜ (fun (i : {x : I // ¬ (P x)}) ↦ X i.val)) :=
+    (∏ᶜ (fun (i : {x : I // ¬ P x}) ↦ X i.val)) :=
   BinaryFan.mk (P := ∏ᶜ X) (Pi.map' Subtype.val fun _ ↦ 𝟙 _)
     (Pi.map' Subtype.val fun _ ↦ 𝟙 _)
 
@@ -41,17 +41,17 @@ complement.
 -/
 noncomputable def Pi.binaryFanOfPropIsLimit : IsLimit (Pi.binaryFanOfProp X P) :=
   BinaryFan.isLimitMk
-    (fun s ↦ Pi.lift fun b ↦ if h : (P b) then
+    (fun s ↦ Pi.lift fun b ↦ if h : P b then
       s.π.app ⟨WalkingPair.left⟩ ≫ Pi.π (fun (i : {x : I // P x}) ↦ X i.val) ⟨b, h⟩ else
-      s.π.app ⟨WalkingPair.right⟩ ≫ Pi.π (fun (i : {x : I // ¬ (P x)}) ↦ X i.val) ⟨b, h⟩)
+      s.π.app ⟨WalkingPair.right⟩ ≫ Pi.π (fun (i : {x : I // ¬ P x}) ↦ X i.val) ⟨b, h⟩)
     (by aesop) (by aesop)
     (fun _ _ h₁ h₂ ↦ Pi.hom_ext _ _ fun b ↦ by
-      by_cases h : (P b)
+      by_cases h : P b
       · simp [← h₁, dif_pos h]
       · simp [← h₂, dif_neg h])
 
 lemma hasBinaryProduct_of_products : HasBinaryProduct (∏ᶜ (fun (i : {x : I // P x}) ↦ X i.val))
-    (∏ᶜ (fun (i : {x : I // ¬ (P x)}) ↦ X i.val)) :=
+    (∏ᶜ (fun (i : {x : I // ¬ P x}) ↦ X i.val)) :=
   ⟨Pi.binaryFanOfProp X P, Pi.binaryFanOfPropIsLimit X P⟩
 
 attribute [local instance] hasBinaryProduct_of_products
@@ -59,7 +59,7 @@ attribute [local instance] hasBinaryProduct_of_products
 lemma Pi.map_eq_prod_map : Pi.map f =
     ((Pi.binaryFanOfPropIsLimit X P).conePointUniqueUpToIso (prodIsProd _ _)).hom ≫
       prod.map (Pi.map (fun (i : {x : I // P x}) ↦ f i.val))
-      (Pi.map (fun (i : {x : I // ¬ (P x)}) ↦ f i.val)) ≫
+      (Pi.map (fun (i : {x : I // ¬ P x}) ↦ f i.val)) ≫
         ((Pi.binaryFanOfPropIsLimit Y P).conePointUniqueUpToIso (prodIsProd _ _)).inv := by
   rw [← Category.assoc, Iso.eq_comp_inv]
   dsimp only [IsLimit.conePointUniqueUpToIso, binaryFanOfProp, prodIsProd]


### PR DESCRIPTION
---

This is used in #18497 to prove that light condensed modules satisfy countable AB4*

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
