### PR TITLE
feat(LinearAlgebra): add a variable_alias for VectorSpace

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3415,6 +3415,7 @@ import Mathlib.LinearAlgebra.TensorProduct.Vanishing
 import Mathlib.LinearAlgebra.Trace
 import Mathlib.LinearAlgebra.UnitaryGroup
 import Mathlib.LinearAlgebra.Vandermonde
+import Mathlib.LinearAlgebra.VectorSpace
 import Mathlib.Logic.Basic
 import Mathlib.Logic.Denumerable
 import Mathlib.Logic.Embedding.Basic

--- a/Mathlib/LinearAlgebra/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/VectorSpace.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2024 Julian Berman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julian Berman
+-/
+import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.Module.Pi
+import Mathlib.Tactic.Variable
+
+/-!
+# Vector spaces
+
+This file provides `VectorSpace` as a simple alias for a module over a field using the
+`variable_alias` attribute.
+-/
+
+/-- A vector space is a module over a field. -/
+@[variable_alias]
+structure VectorSpace (k V : Type*)
+  [Field k] [AddCommGroup V] [Module k V]
+
+/-- If 𝔽 is a field, 𝔽^n is a vector space over 𝔽. -/
+example {𝔽 : Type*} [Field 𝔽] {n : ℕ} : VectorSpace 𝔽 (Fin n → 𝔽) := {}

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -348,6 +348,7 @@
   "Mathlib.Logic.Function.Defs": ["Mathlib.Tactic.AdaptationNote"],
   "Mathlib.Logic.Function.Basic": ["Batteries.Tactic.Init"],
   "Mathlib.Logic.Equiv.Defs": ["Mathlib.Data.Bool.Basic"],
+  "Mathlib.LinearAlgebra.VectorSpace": ["Mathlib.Algebra.Module.Pi"],
   "Mathlib.LinearAlgebra.Matrix.Transvection": ["Mathlib.Data.Matrix.DMatrix"],
   "Mathlib.LinearAlgebra.DFinsupp": ["Mathlib.LinearAlgebra.Finsupp.SumProd"],
   "Mathlib.LinearAlgebra.Basic": ["Mathlib.Algebra.BigOperators.Group.Finset"],


### PR DESCRIPTION
Taken directly from the variable_alias docs.

Zulip: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/why.20.5Bvariable_alias.5D.20attribute.20is.20not.20used.20in.20Mathlib.3F

---

This is the first actual variable alias added to mathlib. I haven't reviewed variable_alias fully, but it seems like there's at least 3 ways they could be distributed in Mathlib:

* alongside whatever subfolder they "belong to" (which is what I've tentatively done here)
* In a file called `Aliases` somewhere near the thing they alias (which seems less discoverable to me)
* In a single file, a la `Mathlib.TrainingWheels` (with some less playful name) which is meant to define a bunch of more "friendly" aliases all in one place.

I kind of like the idea of the third thing as a future module but perhaps it can be synthesized if/when there are more aliases? For now as I say I've done the first one, but please let me know if someone prefers something else.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
