### PR TITLE
[Merged by Bors] - feat: `IsScalarTower` and `SMulCommClass` instances for pointwise actions of submodules

### DIFF
--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -290,6 +290,8 @@ variable (R)
 theorem span_mul_span : span R S * span R T = span R (S * T) := by
   rw [mul_eq_map₂]; apply map₂_span_span
 
+lemma mul_def (S T : Submodule R A) : S * T = span R (S * T : Set A) := by simp [← span_mul_span]
+
 variable {R} (M N P Q)
 
 protected theorem mul_one : M * 1 = M := by
@@ -352,6 +354,22 @@ theorem comap_op_mul (M N : Submodule R Aᵐᵒᵖ) :
       comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) N *
         comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M := by
   simp_rw [comap_equiv_eq_map_symm, map_unop_mul]
+
+section
+variable {B : Type*} [Semiring B] [Algebra R B] [Module A B] [SMulCommClass A R B]
+
+instance [IsScalarTower A B B] : IsScalarTower A (Submodule R B) (Submodule R B) where
+  smul_assoc a S T := by
+    rw [← S.span_eq, ← T.span_eq]
+    rw [smul_span, smul_eq_mul, smul_eq_mul, span_mul_span,  span_mul_span, smul_span,
+      smul_mul_assoc]
+
+instance [SMulCommClass A B B] : SMulCommClass A (Submodule R B) (Submodule R B) where
+  smul_comm a S T := by
+    rw [← S.span_eq, ← T.span_eq, smul_span, smul_eq_mul, smul_eq_mul, span_mul_span, span_mul_span,
+      smul_span, mul_smul_comm]
+
+end
 
 section
 
@@ -635,7 +653,7 @@ instance moduleSet : Module (SetSemiring A) (Submodule R A) where
 
 variable {R A}
 
-theorem smul_def (s : SetSemiring A) (P : Submodule R A) :
+theorem setSemiring_smul_def (s : SetSemiring A) (P : Submodule R A) :
     s • P = span R (SetSemiring.down (α := A) s) * P :=
   rfl
 
@@ -647,7 +665,7 @@ theorem smul_le_smul {s t : SetSemiring A} {M N : Submodule R A}
 theorem singleton_smul (a : A) (M : Submodule R A) :
     Set.up ({a} : Set A) • M = M.map (LinearMap.mulLeft R a) := by
   conv_lhs => rw [← span_eq M]
-  rw [smul_def, SetSemiring.down_up, span_mul_span, singleton_mul]
+  rw [setSemiring_smul_def, SetSemiring.down_up, span_mul_span, singleton_mul]
   exact (map (LinearMap.mulLeft R a) M).span_eq
 
 section Quotient

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -369,6 +369,9 @@ instance [SMulCommClass A B B] : SMulCommClass A (Submodule R B) (Submodule R B)
     rw [← S.span_eq, ← T.span_eq, smul_span, smul_eq_mul, smul_eq_mul, span_mul_span, span_mul_span,
       smul_span, mul_smul_comm]
 
+instance [SMulCommClass B A B] : SMulCommClass (Submodule R B) A (Submodule R B) :=
+  have := SMulCommClass.symm B A B; .symm ..
+
 end
 
 section

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -285,14 +285,14 @@ theorem mul_eq_map₂ : M * N = map₂ (LinearMap.mul R A) M N :=
   le_antisymm (mul_le.mpr fun _m hm _n ↦ apply_mem_map₂ _ hm)
     (map₂_le.mpr fun _m hm _n ↦ mul_mem_mul hm)
 
-variable (R)
+variable (R M N)
 
 theorem span_mul_span : span R S * span R T = span R (S * T) := by
   rw [mul_eq_map₂]; apply map₂_span_span
 
-lemma mul_def (S T : Submodule R A) : S * T = span R (S * T : Set A) := by simp [← span_mul_span]
+lemma mul_def : M * N = span R (M * N : Set A) := by simp [← span_mul_span]
 
-variable {R} (M N P Q)
+variable {R} (P Q)
 
 protected theorem mul_one : M * 1 = M := by
   conv_lhs => rw [one_eq_span, ← span_eq M]

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -356,21 +356,21 @@ theorem comap_op_mul (M N : Submodule R Aᵐᵒᵖ) :
   simp_rw [comap_equiv_eq_map_symm, map_unop_mul]
 
 section
-variable {B : Type*} [Semiring B] [Algebra R B] [Module A B] [SMulCommClass A R B]
+variable {α : Type*} [Monoid α] [DistribMulAction α A] [SMulCommClass α R A]
 
-instance [IsScalarTower A B B] : IsScalarTower A (Submodule R B) (Submodule R B) where
+instance [IsScalarTower α A A] : IsScalarTower α (Submodule R A) (Submodule R A) where
   smul_assoc a S T := by
     rw [← S.span_eq, ← T.span_eq]
     rw [smul_span, smul_eq_mul, smul_eq_mul, span_mul_span,  span_mul_span, smul_span,
       smul_mul_assoc]
 
-instance [SMulCommClass A B B] : SMulCommClass A (Submodule R B) (Submodule R B) where
+instance [SMulCommClass α A A] : SMulCommClass α (Submodule R A) (Submodule R A) where
   smul_comm a S T := by
     rw [← S.span_eq, ← T.span_eq, smul_span, smul_eq_mul, smul_eq_mul, span_mul_span, span_mul_span,
       smul_span, mul_smul_comm]
 
-instance [SMulCommClass B A B] : SMulCommClass (Submodule R B) A (Submodule R B) :=
-  have := SMulCommClass.symm B A B; .symm ..
+instance [SMulCommClass A α A] : SMulCommClass (Submodule R A) α (Submodule R A) :=
+  have := SMulCommClass.symm A α A; .symm ..
 
 end
 

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -360,9 +360,8 @@ variable {α : Type*} [Monoid α] [DistribMulAction α A] [SMulCommClass α R A]
 
 instance [IsScalarTower α A A] : IsScalarTower α (Submodule R A) (Submodule R A) where
   smul_assoc a S T := by
-    rw [← S.span_eq, ← T.span_eq]
-    rw [smul_span, smul_eq_mul, smul_eq_mul, span_mul_span,  span_mul_span, smul_span,
-      smul_mul_assoc]
+    rw [← S.span_eq, ← T.span_eq, smul_span, smul_eq_mul, smul_eq_mul, span_mul_span, span_mul_span,
+      smul_span, smul_mul_assoc]
 
 instance [SMulCommClass α A A] : SMulCommClass α (Submodule R A) (Submodule R A) where
   smul_comm a S T := by

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -228,6 +228,8 @@ theorem smul_sup' (a : α) (S T : Submodule R M) : a • (S ⊔ T) = a • S ⊔
 theorem smul_span (a : α) (s : Set M) : a • span R s = span R (a • s) :=
   map_span _ _
 
+lemma smul_def (a : α) (s : Submodule R M) : a • s = span R (a • s : Set M) := by simp [← smul_span]
+
 theorem span_smul (a : α) (s : Set M) : span R (a • s) = a • span R s :=
   Eq.symm (span_image _).symm
 

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -228,7 +228,7 @@ theorem smul_sup' (a : α) (S T : Submodule R M) : a • (S ⊔ T) = a • S ⊔
 theorem smul_span (a : α) (s : Set M) : a • span R s = span R (a • s) :=
   map_span _ _
 
-lemma smul_def (a : α) (s : Submodule R M) : a • s = span R (a • s : Set M) := by simp [← smul_span]
+lemma smul_def (a : α) (S : Submodule R M) : a • S = span R (a • S : Set M) := by simp [← smul_span]
 
 theorem span_smul (a : α) (s : Set M) : span R (a • s) = a • span R s :=
   Eq.symm (span_image _).symm


### PR DESCRIPTION
Moves:
- `Submodule.smul_def` → `Submodule.setSemiring_smul_def`

From GrowthInGroups

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
