### PR TITLE
[Merged by Bors] - feat: `IsSelfAdjoint.smul_iff`

### DIFF
--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
-import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Group.Invertible.Defs
 import Mathlib.Algebra.GroupWithZero.Units.Lemmas
 import Mathlib.Algebra.Regular.Basic
@@ -38,7 +37,6 @@ assert_not_exists Rat.instField
 universe u v w
 
 open MulOpposite
-open scoped NNRat
 
 /-- Notation typeclass (with no default notation!) for an algebraic structure with a star operation.
 -/

--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -365,18 +365,22 @@ open scoped ComplexConjugate
 end CommSemiring
 
 @[simp]
-theorem star_inv' [DivisionSemiring R] [StarRing R] (x : R) : star x⁻¹ = (star x)⁻¹ :=
-  op_injective <| (map_inv₀ (starRingEquiv : R ≃+* Rᵐᵒᵖ) x).trans (op_inv (star x)).symm
+theorem star_inv₀ [GroupWithZero R] [StarMul R] (x : R) : star x⁻¹ = (star x)⁻¹ :=
+  op_injective <| (map_inv₀ (starMulEquiv : R ≃* Rᵐᵒᵖ) x).trans (op_inv (star x)).symm
+
+@[deprecated (since := "2024-11-18")] alias star_inv' := star_inv₀
 
 @[simp]
-theorem star_zpow₀ [DivisionSemiring R] [StarRing R] (x : R) (z : ℤ) : star (x ^ z) = star x ^ z :=
-  op_injective <| (map_zpow₀ (starRingEquiv : R ≃+* Rᵐᵒᵖ) x z).trans (op_zpow (star x) z).symm
+theorem star_zpow₀ [GroupWithZero R] [StarMul R] (x : R) (z : ℤ) : star (x ^ z) = star x ^ z :=
+  op_injective <| (map_zpow₀ (starMulEquiv : R ≃* Rᵐᵒᵖ) x z).trans (op_zpow (star x) z).symm
 
 /-- When multiplication is commutative, `star` preserves division. -/
 @[simp]
-theorem star_div' [Semifield R] [StarRing R] (x y : R) : star (x / y) = star x / star y := by
+theorem star_div₀ [CommGroupWithZero R] [StarMul R] (x y : R) : star (x / y) = star x / star y := by
   apply op_injective
-  rw [division_def, op_div, mul_comm, star_mul, star_inv', op_mul, op_inv]
+  rw [division_def, op_div, mul_comm, star_mul, star_inv₀, op_mul, op_inv]
+
+@[deprecated (since := "2024-11-18")] alias star_div' := star_div₀
 
 /-- Any commutative semiring admits the trivial `*`-structure.
 

--- a/Mathlib/Algebra/Star/Pointwise.lean
+++ b/Mathlib/Algebra/Star/Pointwise.lean
@@ -6,6 +6,7 @@ Authors: Jireh Loreaux
 import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.Star.Basic
 import Mathlib.Data.Set.Finite.Basic
+import Mathlib.Algebra.Field.Defs
 
 /-!
 # Pointwise star operation on sets

--- a/Mathlib/Algebra/Star/Pointwise.lean
+++ b/Mathlib/Algebra/Star/Pointwise.lean
@@ -118,7 +118,7 @@ protected theorem star_inv [Group α] [StarMul α] (s : Set α) : s⁻¹⋆ = s�
 
 protected theorem star_inv' [DivisionSemiring α] [StarRing α] (s : Set α) : s⁻¹⋆ = s⋆⁻¹ := by
   ext
-  simp only [mem_star, mem_inv, star_inv']
+  simp only [mem_star, mem_inv, star_inv₀]
 
 end Set
 

--- a/Mathlib/Algebra/Star/SelfAdjoint.lean
+++ b/Mathlib/Algebra/Star/SelfAdjoint.lean
@@ -235,22 +235,38 @@ protected theorem intCast (z : ℤ) : IsSelfAdjoint (z : R) :=
 
 end Ring
 
-section DivisionSemiring
+section Group
 
-variable [DivisionSemiring R] [StarRing R]
+variable [Group R] [StarMul R]
 
 @[aesop safe apply]
 theorem inv {x : R} (hx : IsSelfAdjoint x) : IsSelfAdjoint x⁻¹ := by
-  simp only [isSelfAdjoint_iff, star_inv', hx.star_eq]
+  simp only [isSelfAdjoint_iff, star_inv, hx.star_eq]
 
 @[aesop safe apply]
 theorem zpow {x : R} (hx : IsSelfAdjoint x) (n : ℤ) : IsSelfAdjoint (x ^ n) := by
+  simp only [isSelfAdjoint_iff, star_zpow, hx.star_eq]
+
+end Group
+
+section GroupWithZero
+
+variable [GroupWithZero R] [StarMul R]
+
+@[aesop safe apply]
+theorem inv₀ {x : R} (hx : IsSelfAdjoint x) : IsSelfAdjoint x⁻¹ := by
+  simp only [isSelfAdjoint_iff, star_inv₀, hx.star_eq]
+
+@[aesop safe apply]
+theorem zpow₀ {x : R} (hx : IsSelfAdjoint x) (n : ℤ) : IsSelfAdjoint (x ^ n) := by
   simp only [isSelfAdjoint_iff, star_zpow₀, hx.star_eq]
 
-@[simp]
-protected lemma nnratCast (q : ℚ≥0) : IsSelfAdjoint (q : R) := star_nnratCast _
+end GroupWithZero
 
-end DivisionSemiring
+@[simp]
+protected lemma nnratCast [DivisionSemiring R] [StarRing R] (q : ℚ≥0) :
+    IsSelfAdjoint (q : R) :=
+  star_nnratCast _
 
 section DivisionRing
 
@@ -267,17 +283,26 @@ section Semifield
 variable [Semifield R] [StarRing R]
 
 theorem div {x y : R} (hx : IsSelfAdjoint x) (hy : IsSelfAdjoint y) : IsSelfAdjoint (x / y) := by
-  simp only [isSelfAdjoint_iff, star_div', hx.star_eq, hy.star_eq]
+  simp only [isSelfAdjoint_iff, star_div₀, hx.star_eq, hy.star_eq]
 
 end Semifield
 
 section SMul
 
-variable [Star R] [AddMonoid A] [StarAddMonoid A] [SMul R A] [StarModule R A]
-
 @[aesop safe apply]
-theorem smul {r : R} (hr : IsSelfAdjoint r) {x : A} (hx : IsSelfAdjoint x) :
-    IsSelfAdjoint (r • x) := by simp only [isSelfAdjoint_iff, star_smul, hr.star_eq, hx.star_eq]
+theorem smul [Star R] [AddMonoid A] [StarAddMonoid A] [SMul R A] [StarModule R A]
+    {r : R} (hr : IsSelfAdjoint r) {x : A} (hx : IsSelfAdjoint x) :
+    IsSelfAdjoint (r • x) := by
+  simp only [isSelfAdjoint_iff, star_smul, hr.star_eq, hx.star_eq]
+
+theorem smul_iff [Monoid R] [StarMul R] [AddMonoid A] [StarAddMonoid A]
+    [MulAction R A] [StarModule R A] {r : R} (hr : IsSelfAdjoint r) (hu : IsUnit r) {x : A} :
+    IsSelfAdjoint (r • x) ↔ IsSelfAdjoint x := by
+  refine ⟨fun hrx ↦ ?_, .smul hr⟩
+  lift r to Rˣ using hu
+  rw [← inv_smul_smul r x]
+  replace hr : IsSelfAdjoint r := Units.ext hr.star_eq
+  exact hr.inv.smul hrx
 
 end SMul
 
@@ -384,7 +409,7 @@ section Field
 variable [Field R] [StarRing R]
 
 instance : Inv (selfAdjoint R) where
-  inv x := ⟨x.val⁻¹, x.prop.inv⟩
+  inv x := ⟨x.val⁻¹, x.prop.inv₀⟩
 
 @[simp, norm_cast]
 theorem val_inv (x : selfAdjoint R) : ↑x⁻¹ = (x : R)⁻¹ :=
@@ -398,7 +423,7 @@ theorem val_div (x y : selfAdjoint R) : ↑(x / y) = (x / y : R) :=
   rfl
 
 instance : Pow (selfAdjoint R) ℤ where
-  pow x z := ⟨(x : R) ^ z, x.prop.zpow z⟩
+  pow x z := ⟨(x : R) ^ z, x.prop.zpow₀ z⟩
 
 @[simp, norm_cast]
 theorem val_zpow (x : selfAdjoint R) (z : ℤ) : ↑(x ^ z) = (x : R) ^ z :=

--- a/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
@@ -149,7 +149,7 @@ theorem isSymmetric_iff_inner_map_self_real (T : V →ₗ[ℂ] V) :
   · intro h x y
     rw [← inner_conj_symm x (T y)]
     rw [inner_map_polarization T x y]
-    simp only [starRingEnd_apply, star_div', star_sub, star_add, star_mul]
+    simp only [starRingEnd_apply, star_div₀, star_sub, star_add, star_mul]
     simp only [← starRingEnd_apply]
     rw [h (x + y), h (x - y), h (x + Complex.I • y), h (x - Complex.I • y)]
     simp only [Complex.conj_I]

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -469,7 +469,7 @@ theorem div_im (z w : K) : im (z / w) = im z * re w / normSq w - re z * im w / n
 
 @[rclike_simps] -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): was `simp`
 theorem conj_inv (x : K) : conj x⁻¹ = (conj x)⁻¹ :=
-  star_inv' _
+  star_inv₀ _
 
 lemma conj_div (x y : K) : conj (x / y) = conj x / conj y := map_div' conj conj_inv _ _
 

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -741,7 +741,7 @@ lemma ofReal_nnqsmul (q : ℚ≥0) (r : ℝ) : ofReal (q • r) = q • r := by 
 lemma ofReal_qsmul (q : ℚ) (r : ℝ) : ofReal (q • r) = q • r := by simp [Rat.smul_def]
 
 theorem conj_inv (x : ℂ) : conj x⁻¹ = (conj x)⁻¹ :=
-  star_inv' _
+  star_inv₀ _
 
 @[simp, norm_cast]
 theorem ofReal_div (r s : ℝ) : ((r / s : ℝ) : ℂ) = r / s := map_div₀ ofRealHom r s


### PR DESCRIPTION
Also generalizes some typeclass assumptions from `DivisionSemiring` to `GroupWithZero` and renames a few declarations.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
