### PR TITLE
[Merged by Bors] - fix: replace backticks with single quotes in maintainer merge action

### DIFF
--- a/scripts/maintainer_merge_message.sh
+++ b/scripts/maintainer_merge_message.sh
@@ -39,5 +39,7 @@ esac
 # replace backticks in the title with single quotes
 unbacktickedTitle="${PR_TITLE//\`/\'}"
 
+>&2 echo "neat title: '${unbacktickedTitle}'"
+
 printf '%s requested a maintainer **%s** from %s on PR [#%s](%s):\n' "${AUTHOR}" "${M_or_D}" "${SOURCE}" "${PR}" "${URL}"
 printf '```spoiler %s\n%s\n```\n' "${unbacktickedTitle}" "${PR_COMMENT}"

--- a/scripts/maintainer_merge_message.sh
+++ b/scripts/maintainer_merge_message.sh
@@ -36,5 +36,8 @@ esac
 >&2 echo "EVENT_NAME: '${EVENT_NAME}'"
 >&2 printf 'COMMENT\n%s\nEND COMMENT\n' "${PR_COMMENT}"
 
+# replace backticks in the title with single quotes
+unbacktickedTitle="${PR_TITLE//\`/\'}"
+
 printf '%s requested a maintainer **%s** from %s on PR [#%s](%s):\n' "${AUTHOR}" "${M_or_D}" "${SOURCE}" "${PR}" "${URL}"
-printf '```spoiler %s\n%s\n```\n' "${PR_TITLE}" "${PR_COMMENT}"
+printf '```spoiler %s\n%s\n```\n' "${unbacktickedTitle}" "${PR_COMMENT}"


### PR DESCRIPTION
This should prevent mangling the `spoiler` message on Zulip.

---

The spoiler format on Zulip is
````
```spoiler visible title
hidden text
```
````
When `visible title` contains backticks, it messes the `spoiler`.  The bash-ism is simply a replacement of backticks `` ` `` with single quotes `'` in the title, before passing it on to Zulip.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
