### PR TITLE
[Merged by Bors] - refactor(Algebra/Bilinear): generalize to non-commutative base rings

### DIFF
--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -23,11 +23,59 @@ namespace LinearMap
 section NonUnitalNonAssoc
 
 variable (R A : Type*) [CommSemiring R] [NonUnitalNonAssocSemiring A] [Module R A]
-  [SMulCommClass R A A] [IsScalarTower R A A]
+
+section left
+variable {A} [SMulCommClass R A A]
+
+/-- The multiplication on the left in a algebra is a linear map.
+
+Note that this only assumes `SMulCommClass R A A`, so that it also works for `R := Aᵐᵒᵖ`. -/
+def mulLeft (a : A) : A →ₗ[R] A where
+  toFun := (a * ·)
+  map_add' := mul_add _
+  map_smul' _ := mul_smul_comm _ _
+
+@[simp]
+theorem mulLeft_apply (a b : A) : mulLeft R a b = a * b := rfl
+
+@[simp]
+theorem mulLeft_toAddMonoidHom (a : A) : (mulLeft R a : A →+ A) = AddMonoidHom.mulLeft a := rfl
+
+variable (A) in
+@[simp]
+theorem mulLeft_zero_eq_zero : mulLeft R (0 : A) = 0 := ext fun _ => zero_mul _
+
+end left
+
+section right
+variable {A} [IsScalarTower R A A]
+
+/-- The multiplication on the right in an algebra is a linear map.
+
+Note that this only assumes `IsScalarTower R A A`, so that it also works for `R := A`. -/
+def mulRight (b : A) : A →ₗ[R] A where
+  toFun := (· * b)
+  map_add' _ _ := add_mul _ _ _
+  map_smul' _ _ := smul_mul_assoc _ _ _
+
+@[simp]
+theorem mulRight_apply (a b : A) : mulRight R a b = b * a := rfl
+
+@[simp]
+theorem mulRight_toAddMonoidHom (a : A) : (mulRight R a : A →+ A) = AddMonoidHom.mulRight a := rfl
+
+variable (A) in
+@[simp]
+theorem mulRight_zero_eq_zero : mulRight R (0 : A) = 0 := ext fun _ => mul_zero _
+
+end right
+
+variable [SMulCommClass R A A] [IsScalarTower R A A]
 
 /-- The multiplication in a non-unital non-associative algebra is a bilinear map.
 
 A weaker version of this for semirings exists as `AddMonoidHom.mul`. -/
+@[simps!]
 def mul : A →ₗ[R] A →ₗ[R] A :=
   LinearMap.mk₂ R (· * ·) add_mul smul_mul_assoc mul_add mul_smul_comm
 
@@ -38,38 +86,14 @@ noncomputable def mul' : A ⊗[R] A →ₗ[R] A :=
 
 variable {A}
 
-/-- The multiplication on the left in a non-unital algebra is a linear map. -/
-def mulLeft (a : A) : A →ₗ[R] A :=
-  mul R A a
-
-/-- The multiplication on the right in an algebra is a linear map. -/
-def mulRight (a : A) : A →ₗ[R] A :=
-  (mul R A).flip a
-
 /-- Simultaneous multiplication on the left and right is a linear map. -/
 def mulLeftRight (ab : A × A) : A →ₗ[R] A :=
   (mulRight R ab.snd).comp (mulLeft R ab.fst)
-
-@[simp]
-theorem mulLeft_toAddMonoidHom (a : A) : (mulLeft R a : A →+ A) = AddMonoidHom.mulLeft a :=
-  rfl
-
-@[simp]
-theorem mulRight_toAddMonoidHom (a : A) : (mulRight R a : A →+ A) = AddMonoidHom.mulRight a :=
-  rfl
 
 variable {R}
 
 @[simp]
 theorem mul_apply' (a b : A) : mul R A a b = a * b :=
-  rfl
-
-@[simp]
-theorem mulLeft_apply (a b : A) : mulLeft R a b = a * b :=
-  rfl
-
-@[simp]
-theorem mulRight_apply (a b : A) : mulRight R a b = b * a :=
   rfl
 
 @[simp]
@@ -80,35 +104,37 @@ theorem mulLeftRight_apply (a b x : A) : mulLeftRight R (a, b) x = a * x * b :=
 theorem mul'_apply {a b : A} : mul' R A (a ⊗ₜ b) = a * b :=
   rfl
 
-@[simp]
-theorem mulLeft_zero_eq_zero : mulLeft R (0 : A) = 0 :=
-  (mul R A).map_zero
-
-@[simp]
-theorem mulRight_zero_eq_zero : mulRight R (0 : A) = 0 :=
-  (mul R A).flip.map_zero
-
 end NonUnitalNonAssoc
 
 section NonUnital
 
-variable (R A : Type*) [CommSemiring R] [NonUnitalSemiring A] [Module R A] [SMulCommClass R A A]
-  [IsScalarTower R A A]
+variable (R A B : Type*)
+variable [CommSemiring R] [NonUnitalSemiring A] [NonUnitalSemiring B] [Module R B] [Module R A]
+
+@[simp]
+theorem mulLeft_mul [SMulCommClass R A A] (a b : A) :
+    mulLeft R (a * b) = (mulLeft R a).comp (mulLeft R b) := by
+  ext
+  simp only [mulLeft_apply, comp_apply, mul_assoc]
+
+@[simp]
+theorem mulRight_mul [IsScalarTower R A A] (a b : A) :
+    mulRight R (a * b) = (mulRight R b).comp (mulRight R a) := by
+  ext
+  simp only [mulRight_apply, comp_apply, mul_assoc]
+
+variable [SMulCommClass R A A] [IsScalarTower R A A]
+variable [SMulCommClass R B B] [IsScalarTower R B B]
 
 /-- The multiplication in a non-unital algebra is a bilinear map.
 
 A weaker version of this for non-unital non-associative algebras exists as `LinearMap.mul`. -/
-def _root_.NonUnitalAlgHom.lmul : A →ₙₐ[R] End R A :=
-  { mul R A with
-    map_mul' := by
-      intro a b
-      ext c
-      exact mul_assoc a b c
-    map_zero' := by
-      ext a
-      exact zero_mul a }
+def _root_.NonUnitalAlgHom.lmul : A →ₙₐ[R] End R A where
+  __ := mul R A
+  map_mul' := mulLeft_mul _ _
+  map_zero' := mulLeft_zero_eq_zero _ _
 
-variable {R A}
+variable {R A B}
 
 @[simp]
 theorem _root_.NonUnitalAlgHom.coe_lmul_eq_mul : ⇑(NonUnitalAlgHom.lmul R A) = mul R A :=
@@ -118,23 +144,6 @@ theorem commute_mulLeft_right (a b : A) : Commute (mulLeft R a) (mulRight R b) :
   ext c
   exact (mul_assoc a c b).symm
 
-@[simp]
-theorem mulLeft_mul (a b : A) : mulLeft R (a * b) = (mulLeft R a).comp (mulLeft R b) := by
-  ext
-  simp only [mulLeft_apply, comp_apply, mul_assoc]
-
-@[simp]
-theorem mulRight_mul (a b : A) : mulRight R (a * b) = (mulRight R b).comp (mulRight R a) := by
-  ext
-  simp only [mulRight_apply, comp_apply, mul_assoc]
-
-end NonUnital
-
-section Semiring
-
-variable (R A B : Type*) [CommSemiring R] [Semiring A] [Semiring B] [Algebra R A] [Algebra R B]
-
-variable {R A B} in
 /-- A `LinearMap` preserves multiplication if pre- and post- composition with `LinearMap.mul` are
 equivalent. By converting the statement into an equality of `LinearMap`s, this lemma allows various
 specialized `ext` lemmas about `→ₗ[R]` to then be applied.
@@ -145,26 +154,66 @@ theorem map_mul_iff (f : A →ₗ[R] B) :
       (LinearMap.mul R A).compr₂ f = (LinearMap.mul R B ∘ₗ f).compl₂ f :=
   Iff.symm LinearMap.ext_iff₂
 
+end NonUnital
+
+section Semiring
+
+variable (R A B : Type*) [CommSemiring R] [Semiring A] [Semiring B]
+
+section left
+variable [Module R A] [SMulCommClass R A A]
+
+@[simp]
+theorem mulLeft_one : mulLeft R (1 : A) = LinearMap.id := ext fun _ => one_mul _
+
+@[simp]
+theorem mulLeft_eq_zero_iff (a : A) : mulLeft R a = 0 ↔ a = 0 := by
+  constructor <;> intro h
+  -- Porting note: had to supply `R` explicitly in `@mulLeft_apply` below
+  · rw [← mul_one a, ← mulLeft_apply R a 1, h, LinearMap.zero_apply]
+  · rw [h]
+    exact mulLeft_zero_eq_zero _ _
+
+@[simp]
+theorem pow_mulLeft (a : A) (n : ℕ) : mulLeft R a ^ n = mulLeft R (a ^ n) :=
+  match n with
+  | 0 => by rw [pow_zero, pow_zero, mulLeft_one, LinearMap.one_eq_id]
+  | (n + 1) => by rw [pow_succ, pow_succ, mulLeft_mul, LinearMap.mul_eq_comp, pow_mulLeft]
+
+end left
+
+section right
+variable [Module R A] [IsScalarTower R A A]
+
+@[simp]
+theorem mulRight_one : mulRight R (1 : A) = LinearMap.id := ext fun _ => mul_one _
+
+@[simp]
+theorem mulRight_eq_zero_iff (a : A) : mulRight R a = 0 ↔ a = 0 := by
+  constructor <;> intro h
+  -- Porting note: had to supply `R` explicitly in `@mulRight_apply` below
+  · rw [← one_mul a, ← mulRight_apply R a 1, h, LinearMap.zero_apply]
+  · rw [h]
+    exact mulRight_zero_eq_zero _ _
+
+@[simp]
+theorem pow_mulRight (a : A) (n : ℕ) : mulRight R a ^ n = mulRight R (a ^ n) :=
+  match n with
+  | 0 => by rw [pow_zero, pow_zero, mulRight_one, LinearMap.one_eq_id]
+  | (n + 1) => by rw [pow_succ, pow_succ', mulRight_mul, LinearMap.mul_eq_comp, pow_mulRight]
+
+end right
+
+variable [Algebra R A] [Algebra R B]
+
 /-- The multiplication in an algebra is an algebra homomorphism into the endomorphisms on
 the algebra.
 
-A weaker version of this for non-unital algebras exists as `NonUnitalAlgHom.mul`. -/
-def _root_.Algebra.lmul : A →ₐ[R] End R A :=
-  { LinearMap.mul R A with
-    map_one' := by
-      ext a
-      exact one_mul a
-    map_mul' := by
-      intro a b
-      ext c
-      exact mul_assoc a b c
-    map_zero' := by
-      ext a
-      exact zero_mul a
-    commutes' := by
-      intro r
-      ext a
-      exact (Algebra.smul_def r a).symm }
+A weaker version of this for non-unital algebras exists as `NonUnitalAlgHom.lmul`. -/
+def _root_.Algebra.lmul : A →ₐ[R] End R A where
+  __ := NonUnitalAlgHom.lmul R A
+  map_one' := mulLeft_one _ _
+  commutes' r := ext fun a => (Algebra.smul_def r a).symm
 
 variable {R A}
 
@@ -179,42 +228,6 @@ theorem _root_.Algebra.lmul_isUnit_iff {x : A} :
     IsUnit (Algebra.lmul R A x) ↔ IsUnit x := by
   rw [Module.End_isUnit_iff, Iff.comm]
   exact IsUnit.isUnit_iff_mulLeft_bijective
-
-@[simp]
-theorem mulLeft_eq_zero_iff (a : A) : mulLeft R a = 0 ↔ a = 0 := by
-  constructor <;> intro h
-  -- Porting note: had to supply `R` explicitly in `@mulLeft_apply` below
-  · rw [← mul_one a, ← @mulLeft_apply R _ _ _ _ _ _ a 1, h, LinearMap.zero_apply]
-  · rw [h]
-    exact mulLeft_zero_eq_zero
-
-@[simp]
-theorem mulRight_eq_zero_iff (a : A) : mulRight R a = 0 ↔ a = 0 := by
-  constructor <;> intro h
-  -- Porting note: had to supply `R` explicitly in `@mulRight_apply` below
-  · rw [← one_mul a, ← @mulRight_apply R _ _ _ _ _ _ a 1, h, LinearMap.zero_apply]
-  · rw [h]
-    exact mulRight_zero_eq_zero
-
-@[simp]
-theorem mulLeft_one : mulLeft R (1 : A) = LinearMap.id := by
-  ext
-  simp
-
-@[simp]
-theorem mulRight_one : mulRight R (1 : A) = LinearMap.id := by
-  ext
-  simp
-
-@[simp]
-theorem pow_mulLeft (a : A) (n : ℕ) : mulLeft R a ^ n = mulLeft R (a ^ n) := by
-  simpa only [mulLeft, ← Algebra.coe_lmul_eq_mul] using (map_pow (Algebra.lmul R A) a n).symm
-
-@[simp]
-theorem pow_mulRight (a : A) (n : ℕ) : mulRight R a ^ n = mulRight R (a ^ n) := by
-  simp only [mulRight, ← Algebra.coe_lmul_eq_mul]
-  exact
-    LinearMap.coe_injective (((mulRight R a).coe_pow n).symm ▸ mul_right_iterate a n)
 
 theorem toSpanSingleton_eq_algebra_linearMap : toSpanSingleton R A 1 = Algebra.linearMap R A := by
   ext; simp

--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -31,7 +31,9 @@ variable {A} [SMulCommClass R A A]
 
 /-- The multiplication on the left in a algebra is a linear map.
 
-Note that this only assumes `SMulCommClass R A A`, so that it also works for `R := Aᵐᵒᵖ`. -/
+Note that this only assumes `SMulCommClass R A A`, so that it also works for `R := Aᵐᵒᵖ`.
+
+When `A` is unital and associative, this is the same as `DistribMulAction.toLinearMap R A a` -/
 def mulLeft (a : A) : A →ₗ[R] A where
   toFun := (a * ·)
   map_add' := mul_add _
@@ -54,7 +56,10 @@ variable {A} [IsScalarTower R A A]
 
 /-- The multiplication on the right in an algebra is a linear map.
 
-Note that this only assumes `IsScalarTower R A A`, so that it also works for `R := A`. -/
+Note that this only assumes `IsScalarTower R A A`, so that it also works for `R := A`.
+
+When `A` is unital and associative, this is the same as
+`DistribMulAction.toLinearMap R A (MulOpposite.op b)`. -/
 def mulRight (b : A) : A →ₗ[R] A where
   toFun := (· * b)
   map_add' _ _ := add_mul _ _ _

--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -21,8 +21,10 @@ open TensorProduct Module
 namespace LinearMap
 
 section NonUnitalNonAssoc
+variable (R A : Type*)
 
-variable (R A : Type*) [CommSemiring R] [NonUnitalNonAssocSemiring A] [Module R A]
+section one_side
+variable [Semiring R] [NonUnitalNonAssocSemiring A] [Module R A]
 
 section left
 variable {A} [SMulCommClass R A A]
@@ -70,6 +72,9 @@ theorem mulRight_zero_eq_zero : mulRight R (0 : A) = 0 := ext fun _ => mul_zero 
 
 end right
 
+end one_side
+
+variable [CommSemiring R] [NonUnitalNonAssocSemiring A] [Module R A]
 variable [SMulCommClass R A A] [IsScalarTower R A A]
 
 /-- The multiplication in a non-unital non-associative algebra is a bilinear map.
@@ -109,7 +114,8 @@ end NonUnitalNonAssoc
 section NonUnital
 
 variable (R A B : Type*)
-variable [CommSemiring R] [NonUnitalSemiring A] [NonUnitalSemiring B] [Module R B] [Module R A]
+section one_side
+variable [Semiring R] [NonUnitalSemiring A] [NonUnitalSemiring B] [Module R B] [Module R A]
 
 @[simp]
 theorem mulLeft_mul [SMulCommClass R A A] (a b : A) :
@@ -123,6 +129,9 @@ theorem mulRight_mul [IsScalarTower R A A] (a b : A) :
   ext
   simp only [mulRight_apply, comp_apply, mul_assoc]
 
+end one_side
+
+variable [CommSemiring R] [NonUnitalSemiring A] [NonUnitalSemiring B] [Module R B] [Module R A]
 variable [SMulCommClass R A A] [IsScalarTower R A A]
 variable [SMulCommClass R B B] [IsScalarTower R B B]
 
@@ -158,7 +167,9 @@ end NonUnital
 
 section Semiring
 
-variable (R A : Type*) [CommSemiring R] [Semiring A]
+variable (R A : Type*)
+section one_side
+variable [Semiring R] [Semiring A]
 
 section left
 variable [Module R A] [SMulCommClass R A A]
@@ -204,7 +215,9 @@ theorem pow_mulRight (a : A) (n : ℕ) : mulRight R a ^ n = mulRight R (a ^ n) :
 
 end right
 
-variable [Algebra R A]
+end one_side
+
+variable [CommSemiring R] [Semiring A] [Algebra R A]
 
 /-- The multiplication in an algebra is an algebra homomorphism into the endomorphisms on
 the algebra.

--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -112,8 +112,8 @@ theorem mul'_apply {a b : A} : mul' R A (a ⊗ₜ b) = a * b :=
 end NonUnitalNonAssoc
 
 section NonUnital
-
 variable (R A B : Type*)
+
 section one_side
 variable [Semiring R] [NonUnitalSemiring A] [NonUnitalSemiring B] [Module R B] [Module R A]
 

--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -158,7 +158,7 @@ end NonUnital
 
 section Semiring
 
-variable (R A B : Type*) [CommSemiring R] [Semiring A] [Semiring B]
+variable (R A : Type*) [CommSemiring R] [Semiring A]
 
 section left
 variable [Module R A] [SMulCommClass R A A]
@@ -204,7 +204,7 @@ theorem pow_mulRight (a : A) (n : ℕ) : mulRight R a ^ n = mulRight R (a ^ n) :
 
 end right
 
-variable [Algebra R A] [Algebra R B]
+variable [Algebra R A]
 
 /-- The multiplication in an algebra is an algebra homomorphism into the endomorphisms on
 the algebra.

--- a/Mathlib/RingTheory/PiTensorProduct.lean
+++ b/Mathlib/RingTheory/PiTensorProduct.lean
@@ -272,6 +272,7 @@ noncomputable def constantBaseRingEquiv : (⨂[R] _ : ι, R) ≃ₐ[R] R :=
       toFun
       ((lift.tprod _).trans Finset.prod_const_one)
       (by
+        letI := IsScalarTower.right (R := R) (A := ⨂[R] (x : ι), R)
         rw [LinearMap.map_mul_iff]
         ext x y
         show toFun (tprod R x * tprod R y) = toFun (tprod R x) * toFun (tprod R y)

--- a/Mathlib/RingTheory/PiTensorProduct.lean
+++ b/Mathlib/RingTheory/PiTensorProduct.lean
@@ -272,7 +272,11 @@ noncomputable def constantBaseRingEquiv : (⨂[R] _ : ι, R) ≃ₐ[R] R :=
       toFun
       ((lift.tprod _).trans Finset.prod_const_one)
       (by
-        letI := IsScalarTower.right (R := R) (A := ⨂[R] (x : ι), R)
+        -- one of these is required, the other is a performance optimization
+        letI : IsScalarTower R (⨂[R] x : ι, R) (⨂[R] x : ι, R) :=
+          IsScalarTower.right (R := R) (A := ⨂[R] (x : ι), R)
+        letI : SMulCommClass R (⨂[R] x : ι, R) (⨂[R] x : ι, R) :=
+          Algebra.to_smulCommClass (R := R) (A := ⨂[R] x : ι, R)
         rw [LinearMap.map_mul_iff]
         ext x y
         show toFun (tprod R x * tprod R y) = toFun (tprod R x) * toFun (tprod R y)


### PR DESCRIPTION
This removes unnecessary `IsScalarTower R A A` and `SMulCommClass R A A` arguments from `LinearMap.mulLeft` and `LinearMap.mulRight`, respectively.

As described in the new docstring, this allows respective specializations to `R := Aᵐᵒᵖ` and `R := A`.

Unfortunately all of the lemmas have to be reordered to take advantage of these relaxed assumptions.

In the chaos, a few lemmas also became generalized to non-unital rings.

There is some overlap here with `DistribMulAction.toLinearMap`, but that doesn't work in the case of non-unital rings.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
