### PR TITLE
[Merged by Bors] - feat(CategoryTheory): retracts of objects and morphisms

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1954,6 +1954,7 @@ import Mathlib.CategoryTheory.MorphismProperty.Factorization
 import Mathlib.CategoryTheory.MorphismProperty.IsInvertedBy
 import Mathlib.CategoryTheory.MorphismProperty.Limits
 import Mathlib.CategoryTheory.MorphismProperty.Representable
+import Mathlib.CategoryTheory.MorphismProperty.Retract
 import Mathlib.CategoryTheory.NatIso
 import Mathlib.CategoryTheory.NatTrans
 import Mathlib.CategoryTheory.Noetherian

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1992,6 +1992,7 @@ import Mathlib.CategoryTheory.Products.Unitor
 import Mathlib.CategoryTheory.Quotient
 import Mathlib.CategoryTheory.Quotient.Linear
 import Mathlib.CategoryTheory.Quotient.Preadditive
+import Mathlib.CategoryTheory.Retract
 import Mathlib.CategoryTheory.Shift.Basic
 import Mathlib.CategoryTheory.Shift.CommShift
 import Mathlib.CategoryTheory.Shift.Induced

--- a/Mathlib/CategoryTheory/MorphismProperty/Retract.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Retract.lean
@@ -9,7 +9,8 @@ import Mathlib.CategoryTheory.MorphismProperty.Basic
 /-!
 # Stability under retracts
 
-Defines the morphism property of being stable under retracts.
+Given `P : MorphismProperty C`, we introduce a typeclass `P.IsStableUnderRetracts` which
+is the property that `P` is stable under retracts.
 
 -/
 

--- a/Mathlib/CategoryTheory/MorphismProperty/Retract.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Retract.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jack McKoen
 -/
 import Mathlib.CategoryTheory.Retract
+import Mathlib.CategoryTheory.MorphismProperty.Basic
 
 /-!
 # Stability under retracts

--- a/Mathlib/CategoryTheory/MorphismProperty/Retract.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Retract.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2024 Jack McKoen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jack McKoen
+-/
+import Mathlib.CategoryTheory.Retract
+
+/-!
+# Stability under retracts
+
+Defines the morphism property of being stable under retracts.
+
+-/
+
+universe v u
+
+namespace CategoryTheory
+
+variable {C : Type u} [Category.{v} C]
+
+namespace MorphismProperty
+
+/-- A class of morphisms is stable under retracts if a retract of such a morphism still
+lies in the class. -/
+class IsStableUnderRetracts (P : MorphismProperty C) : Prop where
+  of_retract {X Y Z W : C} {f : X ⟶ Y} {g : Z ⟶ W} (h : RetractArrow f g) (hg : P g) : P f
+
+lemma of_retract {P : MorphismProperty C} [P.IsStableUnderRetracts]
+    {X Y Z W : C} {f : X ⟶ Y} {g : Z ⟶ W} (h : RetractArrow f g) (hg : P g) : P f :=
+  IsStableUnderRetracts.of_retract h hg
+
+instance IsStableUnderRetracts.monomorphisms : (monomorphisms C).IsStableUnderRetracts where
+  of_retract {_ _ _ _ f g} h (hg : Mono g) := ⟨fun α β w ↦ by
+    rw [← cancel_mono h.i.left, ← cancel_mono g, Category.assoc, Category.assoc,
+      h.i_w, reassoc_of% w]⟩
+
+instance IsStableUnderRetracts.epimorphisms : (epimorphisms C).IsStableUnderRetracts where
+  of_retract {_ _ _ _ f g} h (hg : Epi g) := ⟨fun α β w ↦ by
+    rw [← cancel_epi h.r.right, ← cancel_epi g, ← Category.assoc, ← Category.assoc, ← h.r_w,
+      Category.assoc, Category.assoc, w]⟩
+
+instance IsStableUnderRetracts.isomorphisms : (isomorphisms C).IsStableUnderRetracts where
+  of_retract {X Y Z W f g} h (_ : IsIso _) := by
+    refine ⟨h.i.right ≫ inv g ≫ h.r.left, ?_, ?_⟩
+    · rw [← h.i_w_assoc, IsIso.hom_inv_id_assoc, h.retract_left]
+    · rw [Category.assoc, Category.assoc, h.r_w, IsIso.inv_hom_id_assoc, h.retract_right]
+
+end MorphismProperty
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Retract.lean
+++ b/Mathlib/CategoryTheory/Retract.lean
@@ -104,4 +104,3 @@ instance : IsSplitMono h.i.right := ⟨⟨h.right.splitMono⟩⟩
 end RetractArrow
 
 end CategoryTheory
-#lint

--- a/Mathlib/CategoryTheory/Retract.lean
+++ b/Mathlib/CategoryTheory/Retract.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Jack McKoen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jack McKoen
 -/
-import Mathlib.CategoryTheory.MorphismProperty.Basic
+import Mathlib.CategoryTheory.Comma.Arrow
 import Mathlib.CategoryTheory.EpiMono
 
 /-!

--- a/Mathlib/CategoryTheory/Retract.lean
+++ b/Mathlib/CategoryTheory/Retract.lean
@@ -22,12 +22,11 @@ variable {C : Type u} [Category.{v} C] {D : Type u'} [Category.{v'} D]
 /-- An object `X` is a retract of `Y` if there are morphisms `i : X ⟶ Y` and `r : Y ⟶ X` such
 that `i ≫ r = 𝟙 X`. -/
 structure Retract (X Y : C) where
-  /-- `i : X ⟶ Y` -/
+  /-- the split monomorphism -/
   i : X ⟶ Y
-  /-- `r : Y ⟶ X` -/
+  /-- the split epimorphism -/
   r : Y ⟶ X
-  /-- `i ≫ r = 𝟙 X` -/
-  retract : i ≫ r = 𝟙 X
+  retract : i ≫ r = 𝟙 X := by aesop_cat
 
 namespace Retract
 
@@ -90,11 +89,11 @@ lemma retract_right : h.i.right ≫ h.r.right = 𝟙 Y := Arrow.hom.congr_right 
 lemma fac : h.i.left ≫ g ≫ h.r.right = f := by simp
 
 /-- The top of a retract diagram of morphisms determines a retract of objects. -/
-@[simps]
-def left : Retract X Z where
-  i := h.i.left
-  r := h.r.left
-  retract := h.retract_left
+@[simps!]
+def left : Retract X Z := h.map Arrow.leftFunc
+
+@[reassoc (attr := simp)]
+lemma retract_left : h.i.left ≫ h.r.left = 𝟙 X := h.left.retract
 
 /-- The bottom of a retract diagram of morphisms determines a retract of objects. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Retract.lean
+++ b/Mathlib/CategoryTheory/Retract.lean
@@ -83,19 +83,19 @@ lemma retract_right : h.i.right ≫ h.r.right = 𝟙 Y := Arrow.hom.congr_right 
 lemma fac : h.i.left ≫ g ≫ h.r.right = f := by simp
 
 /-- the bottom of a retract diagram determines a split epimorphism. -/
-@[simps] def splitEpi_left : SplitEpi h.r.left where
+@[simps] def splitEpiLeft : SplitEpi h.r.left where
   section_ := h.i.left
 
 /-- the top of a retract diagram determines a split epimorphism. -/
-@[simps] def splitEpi_right : SplitEpi h.r.right where
+@[simps] def splitEpiRight : SplitEpi h.r.right where
   section_ := h.i.right
 
 /-- the bottom of a retract diagram determines a split monomorphism. -/
-@[simps] def splitMono_left : SplitMono h.i.left where
+@[simps] def splitMonoLeft : SplitMono h.i.left where
   retraction := h.r.left
 
 /-- the top of a retract diagram determines a split monomorphism. -/
-@[simps] def splitMono_right : SplitMono h.i.right where
+@[simps] def splitMonoRight : SplitMono h.i.right where
   retraction := h.r.right
 
 instance : IsSplitEpi h.r.left := ⟨⟨h.splitEpi_left⟩⟩
@@ -130,12 +130,10 @@ instance IsStableUnderRetracts.epimorphisms : (epimorphisms C).IsStableUnderRetr
       Category.assoc, Category.assoc, w]⟩
 
 instance IsStableUnderRetracts.isomorphisms : (isomorphisms C).IsStableUnderRetracts where
-  of_retract {X Y Z W f g} h:= fun ⟨inv, ⟨h₁, h₂⟩⟩ ↦ ⟨by
-    refine ⟨h.i.right ≫ inv ≫ h.r.left, ?_, ?_⟩
-    · rw [← Category.assoc, ← h.i_w, Category.assoc, ← Category.assoc g, h₁,
-        Category.id_comp, h.retract_left]
-    · rw [Category.assoc, Category.assoc, h.r_w, ← Category.assoc inv, h₂, Category.id_comp,
-        h.retract_right]⟩
+  of_retract {X Y Z W f g} h (_ : IsIso _) := by
+    refine ⟨h.i.right ≫ inv g ≫ h.r.left, ?_, ?_⟩
+    · rw [← h.i_w_assoc, IsIso.hom_inv_id_assoc, h.retract_left]
+    · rw [Category.assoc, Category.assoc, h.r_w, IsIso.inv_hom_id_assoc, h.retract_right]
 
 end MorphismProperty
 

--- a/Mathlib/CategoryTheory/Retract.lean
+++ b/Mathlib/CategoryTheory/Retract.lean
@@ -79,53 +79,29 @@ lemma i_w : h.i.left ≫ g = f ≫ h.i.right := h.i.w
 @[reassoc]
 lemma r_w : h.r.left ≫ f = g ≫ h.r.right := h.r.w
 
-@[simp, reassoc]
-lemma retract_left : h.i.left ≫ h.r.left = 𝟙 X := Arrow.hom.congr_left h.retract
-
-@[simp, reassoc]
-lemma retract_right : h.i.right ≫ h.r.right = 𝟙 Y := Arrow.hom.congr_right h.retract
-
-@[reassoc]
-lemma fac : h.i.left ≫ g ≫ h.r.right = f := by simp
-
 /-- The top of a retract diagram of morphisms determines a retract of objects. -/
 @[simps!]
 def left : Retract X Z := h.map Arrow.leftFunc
 
+/-- The bottom of a retract diagram of morphisms determines a retract of objects. -/
+@[simps!]
+def right : Retract Y W := h.map Arrow.rightFunc
+
 @[reassoc (attr := simp)]
 lemma retract_left : h.i.left ≫ h.r.left = 𝟙 X := h.left.retract
 
-/-- The bottom of a retract diagram of morphisms determines a retract of objects. -/
-@[simps]
-def right : Retract Y W where
-  i := h.i.right
-  r := h.r.right
-  retract := h.retract_right
+@[reassoc (attr := simp)]
+lemma retract_right : h.i.right ≫ h.r.right = 𝟙 Y := h.right.retract
 
-/-- The bottom of a retract diagram determines a split epimorphism. -/
-@[simps] def splitEpiLeft : SplitEpi h.r.left where
-  section_ := h.i.left
+instance : IsSplitEpi h.r.left := ⟨⟨h.left.splitEpi⟩⟩
 
-/-- The top of a retract diagram determines a split epimorphism. -/
-@[simps] def splitEpiRight : SplitEpi h.r.right where
-  section_ := h.i.right
+instance : IsSplitEpi h.r.right := ⟨⟨h.right.splitEpi⟩⟩
 
-/-- The bottom of a retract diagram determines a split monomorphism. -/
-@[simps] def splitMonoLeft : SplitMono h.i.left where
-  retraction := h.r.left
+instance : IsSplitMono h.i.left := ⟨⟨h.left.splitMono⟩⟩
 
-/-- The top of a retract diagram determines a split monomorphism. -/
-@[simps] def splitMonoRight : SplitMono h.i.right where
-  retraction := h.r.right
-
-instance : IsSplitEpi h.r.left := ⟨⟨h.splitEpiLeft⟩⟩
-
-instance : IsSplitEpi h.r.right := ⟨⟨h.splitEpiRight⟩⟩
-
-instance : IsSplitMono h.i.left := ⟨⟨h.splitMonoLeft⟩⟩
-
-instance : IsSplitMono h.i.right := ⟨⟨h.splitMonoRight⟩⟩
+instance : IsSplitMono h.i.right := ⟨⟨h.right.splitMono⟩⟩
 
 end RetractArrow
 
 end CategoryTheory
+#lint

--- a/Mathlib/CategoryTheory/Retract.lean
+++ b/Mathlib/CategoryTheory/Retract.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2024 Jack McKoen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jack McKoen
+-/
+import Mathlib.CategoryTheory.MorphismProperty.Basic
+import Mathlib.CategoryTheory.EpiMono
+
+/-!
+# Retracts
+
+Defines retracts of objects and morphisms.
+
+-/
+
+universe v u
+
+namespace CategoryTheory
+
+variable {C : Type u} [Category.{v} C]
+
+/-- An object `X` is a retract of `Y` if there are morphisms `i : X ⟶ Y` and `r : Y ⟶ X` such
+that `i ≫ r = 𝟙 X`. -/
+structure Retract (X Y : C) where
+  /-- `i : X ⟶ Y` -/
+  i : X ⟶ Y
+  /-- `r : Y ⟶ X` -/
+  r : Y ⟶ X
+  /-- `i ≫ r = 𝟙 X` -/
+  retract : i ≫ r = 𝟙 X
+
+namespace Retract
+
+attribute [reassoc (attr := simp)] retract
+
+variable {X Y : C} (h : Retract X Y)
+
+/-- a retract determines a split epimorphism. -/
+@[simps] def splitEpi : SplitEpi h.r where
+  section_ := h.i
+
+/-- a retract determines a split monomorphism. -/
+@[simps] def splitMono : SplitMono h.i where
+  retraction := h.r
+
+instance : IsSplitEpi h.r := ⟨⟨h.splitEpi⟩⟩
+
+instance : IsSplitMono h.i := ⟨⟨h.splitMono⟩⟩
+
+end Retract
+
+/--
+```
+  X -------> Z -------> X
+  |          |          |
+  f          g          f
+  |          |          |
+  v          v          v
+  Y -------> W -------> Y
+
+```
+A morphism `f : X ⟶ Y` is a retract of `g : Z ⟶ W` if there are morphisms `i : f ⟶ g`
+and `r : g ⟶ f` in the arrow category such that `i ≫ r = 𝟙 f`. -/
+abbrev RetractArrow {X Y Z W : C} (f : X ⟶ Y) (g : Z ⟶ W) := Retract (Arrow.mk f) (Arrow.mk g)
+
+namespace RetractArrow
+
+variable {X Y Z W : C} {f : X ⟶ Y} {g : Z ⟶ W} (h : RetractArrow f g)
+
+@[reassoc]
+lemma i_w : h.i.left ≫ g = f ≫ h.i.right := h.i.w
+
+@[reassoc]
+lemma r_w : h.r.left ≫ f = g ≫ h.r.right := h.r.w
+
+@[simp, reassoc]
+lemma retract_left : h.i.left ≫ h.r.left = 𝟙 X := Arrow.hom.congr_left h.retract
+
+@[simp, reassoc]
+lemma retract_right : h.i.right ≫ h.r.right = 𝟙 Y := Arrow.hom.congr_right h.retract
+
+@[reassoc]
+lemma fac : h.i.left ≫ g ≫ h.r.right = f := by simp
+
+/-- the bottom of a retract diagram determines a split epimorphism. -/
+@[simps] def splitEpi_left : SplitEpi h.r.left where
+  section_ := h.i.left
+
+/-- the top of a retract diagram determines a split epimorphism. -/
+@[simps] def splitEpi_right : SplitEpi h.r.right where
+  section_ := h.i.right
+
+/-- the bottom of a retract diagram determines a split monomorphism. -/
+@[simps] def splitMono_left : SplitMono h.i.left where
+  retraction := h.r.left
+
+/-- the top of a retract diagram determines a split monomorphism. -/
+@[simps] def splitMono_right : SplitMono h.i.right where
+  retraction := h.r.right
+
+instance : IsSplitEpi h.r.left := ⟨⟨h.splitEpi_left⟩⟩
+
+instance : IsSplitEpi h.r.right := ⟨⟨h.splitEpi_right⟩⟩
+
+instance : IsSplitMono h.i.left := ⟨⟨h.splitMono_left⟩⟩
+
+instance : IsSplitMono h.i.right := ⟨⟨h.splitMono_right⟩⟩
+
+end RetractArrow
+
+namespace MorphismProperty
+
+/-- A class of morphisms is stable under retracts if a retract of such a morphism still
+lies in the class. -/
+class IsStableUnderRetracts (P : MorphismProperty C) : Prop where
+  of_retract {X Y Z W : C} {f : X ⟶ Y} {g : Z ⟶ W} (h : RetractArrow f g) (hg : P g) : P f
+
+lemma of_retract {P : MorphismProperty C} [P.IsStableUnderRetracts]
+    {X Y Z W : C} {f : X ⟶ Y} {g : Z ⟶ W} (h : RetractArrow f g) (hg : P g) : P f :=
+  IsStableUnderRetracts.of_retract h hg
+
+instance IsStableUnderRetracts.monomorphisms : (monomorphisms C).IsStableUnderRetracts where
+  of_retract {_ _ _ _ f g} h (hg : Mono g) := ⟨fun α β w ↦ by
+    rw [← cancel_mono h.i.left, ← cancel_mono g, Category.assoc, Category.assoc,
+      h.i_w, reassoc_of% w]⟩
+
+instance IsStableUnderRetracts.epimorphisms : (epimorphisms C).IsStableUnderRetracts where
+  of_retract {_ _ _ _ f g} h (hg : Epi g) := ⟨fun α β w ↦ by
+    rw [← cancel_epi h.r.right, ← cancel_epi g, ← Category.assoc, ← Category.assoc, ← h.r_w,
+      Category.assoc, Category.assoc, w]⟩
+
+instance IsStableUnderRetracts.isomorphisms : (isomorphisms C).IsStableUnderRetracts where
+  of_retract {X Y Z W f g} h:= fun ⟨inv, ⟨h₁, h₂⟩⟩ ↦ ⟨by
+    refine ⟨h.i.right ≫ inv ≫ h.r.left, ?_, ?_⟩
+    · rw [← Category.assoc, ← h.i_w, Category.assoc, ← Category.assoc g, h₁,
+        Category.id_comp, h.retract_left]
+    · rw [Category.assoc, Category.assoc, h.r_w, ← Category.assoc inv, h₂, Category.id_comp,
+        h.retract_right]⟩
+
+end MorphismProperty
+
+end CategoryTheory


### PR DESCRIPTION
Defines retracts of objects and morphisms, and basic API. Used in #19135.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
