### PR TITLE
[Merged by Bors] - feat(Tactic/StacksAttribute): improve comment shown in docstring for stack tags

### DIFF
--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -153,8 +153,8 @@ initialize Lean.registerBuiltinAttribute {
       | _ => throwUnsupportedSyntax
     let tagStr ← tag.getStacksTag
     let comment := (comment.map (·.getString)).getD ""
-    let comment := if comment = "" then "" else s!" ({comment})"
-    let newDoc := [oldDoc, s!"[{SorK} Tag {tagStr}]({url}/{tagStr}){comment}"]
+    let commentInDoc := if comment = "" then "" else s!" ({comment})"
+    let newDoc := [oldDoc, s!"[{SorK} Tag {tagStr}]({url}/{tagStr}){commentInDoc}"]
     addDocString decl <| "\n\n".intercalate (newDoc.filter (· != ""))
     addTagEntry decl database tagStr <| comment
 }

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -153,7 +153,8 @@ initialize Lean.registerBuiltinAttribute {
       | _ => throwUnsupportedSyntax
     let tagStr ← tag.getStacksTag
     let comment := (comment.map (·.getString)).getD ""
-    let newDoc := [oldDoc, s!"[{SorK} Tag {tagStr}]({url}/{tagStr})", comment]
+    let comment := if comment = "" then "" else s!" ({comment})"
+    let newDoc := [oldDoc, s!"[{SorK} Tag {tagStr}]({url}/{tagStr}){comment}"]
     addDocString decl <| "\n\n".intercalate (newDoc.filter (· != ""))
     addTagEntry decl database tagStr <| comment
 }

--- a/MathlibTest/StacksAttribute.lean
+++ b/MathlibTest/StacksAttribute.lean
@@ -11,6 +11,15 @@ theorem tagged : True := .intro
 
 end X
 
+/--
+info: some ([Stacks Tag A04Q](https://stacks.math.columbia.edu/tag/A04Q) (A comment)
+
+[Kerodon Tag B15R](https://kerodon.net/tag/B15R) (Also a comment))
+-/
+#guard_msgs in
+run_cmd
+  Lean.logInfo m!"{← Lean.findDocString? (← Lean.getEnv) `X.tagged}"
+
 #guard_msgs in
 @[stacks 0BR2, kerodon 0X12]
 example : True := .intro


### PR DESCRIPTION
Previously it was

```text
Stacks Tag 09HK

Part 1, finSepDegree variant
```

Now it should be

```text
Stacks Tag 09HK (Part 1, finSepDegree variant)
```

which is more compact.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
