### PR TITLE
[Merged by Bors] - chore: fix some left/right injectivity names

### DIFF
--- a/Mathlib/Algebra/Group/Invertible/Defs.lean
+++ b/Mathlib/Algebra/Group/Invertible/Defs.lean
@@ -230,23 +230,23 @@ section
 variable [Monoid α] {a b c : α} [Invertible c]
 
 variable (c) in
-theorem mul_right_inj_of_invertible : a * c = b * c ↔ a = b :=
+theorem mul_left_inj_of_invertible : a * c = b * c ↔ a = b :=
   ⟨fun h => by simpa using congr_arg (· * ⅟c) h, congr_arg (· * _)⟩
 
 variable (c) in
-theorem mul_left_inj_of_invertible : c * a = c * b ↔ a = b :=
+theorem mul_right_inj_of_invertible : c * a = c * b ↔ a = b :=
   ⟨fun h => by simpa using congr_arg (⅟c * ·) h, congr_arg (_ * ·)⟩
 
 theorem invOf_mul_eq_iff_eq_mul_left : ⅟c * a = b ↔ a = c * b := by
-  rw [← mul_left_inj_of_invertible (c := c), mul_invOf_cancel_left]
+  rw [← mul_right_inj_of_invertible (c := c), mul_invOf_cancel_left]
 
 theorem mul_left_eq_iff_eq_invOf_mul : c * a = b ↔ a = ⅟c * b := by
-  rw [← mul_left_inj_of_invertible (c := ⅟c), invOf_mul_cancel_left]
+  rw [← mul_right_inj_of_invertible (c := ⅟c), invOf_mul_cancel_left]
 
 theorem mul_invOf_eq_iff_eq_mul_right : a * ⅟c = b ↔ a = b * c := by
-  rw [← mul_right_inj_of_invertible (c := c), invOf_mul_cancel_right]
+  rw [← mul_left_inj_of_invertible (c := c), invOf_mul_cancel_right]
 
 theorem mul_right_eq_iff_eq_mul_invOf : a * c = b ↔ a = b * ⅟c := by
-  rw [← mul_right_inj_of_invertible (c := ⅟c), mul_invOf_cancel_right]
+  rw [← mul_left_inj_of_invertible (c := ⅟c), mul_invOf_cancel_right]
 
 end

--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -244,11 +244,11 @@ section GroupWithZero
 
 variable [GroupWithZero G₀] {a b x : G₀}
 
-theorem GroupWithZero.mul_left_injective (h : x ≠ 0) :
+theorem GroupWithZero.mul_right_injective (h : x ≠ 0) :
     Function.Injective fun y => x * y := fun y y' w => by
   simpa only [← mul_assoc, inv_mul_cancel₀ h, one_mul] using congr_arg (fun y => x⁻¹ * y) w
 
-theorem GroupWithZero.mul_right_injective (h : x ≠ 0) :
+theorem GroupWithZero.mul_left_injective (h : x ≠ 0) :
     Function.Injective fun y => y * x := fun y y' w => by
   simpa only [mul_assoc, mul_inv_cancel₀ h, mul_one] using congr_arg (fun y => y * x⁻¹) w
 

--- a/Mathlib/Analysis/SpecialFunctions/Bernstein.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Bernstein.lean
@@ -109,8 +109,8 @@ theorem probability (n : ℕ) (x : I) : (∑ k : Fin (n + 1), bernstein n k x) =
 theorem variance {n : ℕ} (h : 0 < (n : ℝ)) (x : I) :
     (∑ k : Fin (n + 1), (x - k/ₙ : ℝ) ^ 2 * bernstein n k x) = (x : ℝ) * (1 - x) / n := by
   have h' : (n : ℝ) ≠ 0 := ne_of_gt h
-  apply_fun fun x : ℝ => x * n using GroupWithZero.mul_right_injective h'
-  apply_fun fun x : ℝ => x * n using GroupWithZero.mul_right_injective h'
+  apply_fun fun x : ℝ => x * n using GroupWithZero.mul_left_injective h'
+  apply_fun fun x : ℝ => x * n using GroupWithZero.mul_left_injective h'
   dsimp
   conv_lhs => simp only [Finset.sum_mul, z]
   conv_rhs => rw [div_mul_cancel₀ _ h']


### PR DESCRIPTION
Follow-up Mathlib fixes from [zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/.60add_right_inj.60/near/482835891).