### PR TITLE
[Merged by Bors] - refactor(Nat.Prime.Defs): use `csimp` for `Nat.decidablePrime`

### DIFF
--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -129,7 +129,7 @@ theorem prime_of_coprime (n : ℕ) (h1 : 1 < n) (h : ∀ m < n, m ≠ 0 → n.Co
   exact (h m mlt hm).symm.eq_one_of_dvd mdvd
 
 /--
-This instance is set up to work in the kernel (`by decide`)for small values.
+This instance is set up to work in the kernel (`by decide`) for small values.
 
 Below (`decidablePrime'`) we will define a faster variant to be used by the compiler
 (e.g. in `#eval` or `by native_decide`).

--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -128,17 +128,17 @@ theorem prime_of_coprime (n : ℕ) (h1 : 1 < n) (h : ∀ m < n, m ≠ 0 → n.Co
     exact mlt.ne' mdvd
   exact (h m mlt hm).symm.eq_one_of_dvd mdvd
 
-section
+/--
+This instance is set up to work in the kernel (`by decide`)for small values.
 
-/-- This instance is slower than the instance `decidablePrime` defined below,
-  but has the advantage that it works in the kernel for small values.
+Below (`decidablePrime'`) we will define a faster variant to be used by the compiler
+(e.g. in `#eval` or `by native_decide`).
 
-  If you need to prove that a particular number is prime, in any case
-  you should not use `by decide`, but rather `by norm_num`, which is
-  much faster.
-  -/
-@[local instance]
-def decidablePrime1 (p : ℕ) : Decidable (Prime p) :=
+If you need to prove that a particular number is prime, in any case
+you should not use `by decide`, but rather `by norm_num`, which is
+much faster.
+-/
+instance decidablePrime (p : ℕ) : Decidable (Prime p) :=
   decidable_of_iff' _ prime_def_lt'
 
 theorem prime_two : Prime 2 := by decide
@@ -146,8 +146,6 @@ theorem prime_two : Prime 2 := by decide
 theorem prime_three : Prime 3 := by decide
 
 theorem prime_five : Prime 5 := by decide
-
-end
 
 theorem dvd_prime {p m : ℕ} (pp : Prime p) : m ∣ p ↔ m = 1 ∨ m = p :=
   ⟨fun d => pp.eq_one_or_self_of_dvd m d, fun h =>
@@ -297,15 +295,16 @@ theorem prime_def_minFac {p : ℕ} : Prime p ↔ 2 ≤ p ∧ minFac p = p :=
 theorem Prime.minFac_eq {p : ℕ} (hp : Prime p) : minFac p = p :=
   (prime_def_minFac.1 hp).2
 
-/-- This instance is faster in the virtual machine than `decidablePrime1`,
+/--
+This definition is faster in the virtual machine than `decidablePrime`,
 but slower in the kernel.
-
-If you need to prove that a particular number is prime, in any case
-you should not use `by decide`, but rather `by norm_num`, which is
-much faster.
 -/
-instance decidablePrime (p : ℕ) : Decidable (Prime p) :=
+def decidablePrime' (p : ℕ) : Decidable (Prime p) :=
   decidable_of_iff' _ prime_def_minFac
+
+@[csimp] theorem decidablePrime_csimp :
+    @decidablePrime = @decidablePrime' := by
+  funext; apply Subsingleton.elim
 
 theorem not_prime_iff_minFac_lt {n : ℕ} (n2 : 2 ≤ n) : ¬Prime n ↔ minFac n < n :=
   (not_congr <| prime_def_minFac.trans <| and_iff_right n2).trans <|


### PR DESCRIPTION
previously there were two instances for `Decidable (Nat.Prime n)`, a
local one that was kernel-friendly and a non-local one that was compiler
friendly.

It seems we can have this cake and eat it too by defining the instance
to be kernel friendly, and then using `csimp` to use the other instance
when running code natively.

It seems to work, given that
```
set_option trace.compiler.ir.result true in
theorem foo : Prime 31 := by native_decide
```
prints
```
[result]
def Nat.foo._nativeDecide_1._closed_1 : u8 :=
  let x_1 : obj := 31;
  let x_2 : u8 := Nat.decidablePrime' x_1;
  ret x_2
def Nat.foo._nativeDecide_1 : u8 :=
  let x_1 : u8 := Nat.foo._nativeDecide_1._closed_1;
  ret x_1
```
