### PR TITLE
[Merged by Bors] - feat: interaction of `Finset.sup` and `Nat.cast`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -740,6 +740,7 @@ import Mathlib.Algebra.Order.Ring.Canonical
 import Mathlib.Algebra.Order.Ring.Cast
 import Mathlib.Algebra.Order.Ring.Cone
 import Mathlib.Algebra.Order.Ring.Defs
+import Mathlib.Algebra.Order.Ring.Finset
 import Mathlib.Algebra.Order.Ring.InjSurj
 import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Algebra.Order.Ring.Nat

--- a/Mathlib/Algebra/Order/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/Ring/Finset.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2022 Eric Wieser, Yaël Dillies, Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser, Yaël Dillies, Andrew Yang
+-/
+import Mathlib.Algebra.Order.Field.Canonical.Defs
+import Mathlib.Algebra.Order.Floor
+import Mathlib.Data.Finset.Lattice.Fold
+
+/-!
+# `Finset.sup` in a ring
+-/
+
+open Finset
+
+namespace Nat
+variable {ι R : Type*}
+
+section LinearOrderedSemiring
+variable [LinearOrderedSemiring R] [FloorSemiring R] {s : Finset ι}
+
+set_option linter.docPrime false in
+@[simp, norm_cast]
+lemma cast_finsetSup' (f : ι → ℕ) (hs) : ((s.sup' hs f : ℕ) : R) = s.sup' hs fun i ↦ (f i : R) := by
+  apply le_antisymm
+  · rw [← le_floor_iff, sup'_le_iff]
+    · intros i hi
+      apply le_floor
+      exact le_sup' (fun i ↦ (f i : R)) hi
+    · exact le_sup'_of_le (fun i ↦ (f i : R)) hs.choose_spec (Nat.cast_nonneg _)
+  apply sup'_le
+  exact fun i hi ↦ Nat.mono_cast (le_sup' _ hi)
+
+set_option linter.docPrime false in
+@[simp, norm_cast]
+lemma cast_finsetInf' (f : ι → ℕ) (hs) : (↑(s.inf' hs f) : R) = s.inf' hs fun i ↦ (f i : R) :=
+  eq_of_forall_le_iff fun c ↦ by simp only [le_inf'_iff, ← Nat.ceil_le]
+
+end LinearOrderedSemiring
+
+@[simp, norm_cast]
+lemma cast_finsetSup [CanonicallyLinearOrderedSemifield R] [FloorSemiring R]
+    (s : Finset ι) (f : ι → ℕ) : (↑(s.sup f) : R) = s.sup fun i ↦ (f i : R) := by
+  obtain rfl | hs := s.eq_empty_or_nonempty
+  · simp
+  · rw [← sup'_eq_sup hs, ← sup'_eq_sup hs, Nat.cast_finsetSup']
+
+end Nat

--- a/Mathlib/Algebra/Order/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/Ring/Finset.lean
@@ -17,32 +17,23 @@ namespace Nat
 variable {ι R : Type*}
 
 section LinearOrderedSemiring
-variable [LinearOrderedSemiring R] [FloorSemiring R] {s : Finset ι}
+variable [LinearOrderedSemiring R] {s : Finset ι}
 
 set_option linter.docPrime false in
 @[simp, norm_cast]
 lemma cast_finsetSup' (f : ι → ℕ) (hs) : ((s.sup' hs f : ℕ) : R) = s.sup' hs fun i ↦ (f i : R) := by
-  apply le_antisymm
-  · rw [← le_floor_iff, sup'_le_iff]
-    · intros i hi
-      apply le_floor
-      exact le_sup' (fun i ↦ (f i : R)) hi
-    · exact le_sup'_of_le (fun i ↦ (f i : R)) hs.choose_spec (Nat.cast_nonneg _)
-  apply sup'_le
-  exact fun i hi ↦ Nat.mono_cast (le_sup' _ hi)
+  induction hs using Finset.Nonempty.cons_induction <;> simp [*]
 
 set_option linter.docPrime false in
 @[simp, norm_cast]
-lemma cast_finsetInf' (f : ι → ℕ) (hs) : (↑(s.inf' hs f) : R) = s.inf' hs fun i ↦ (f i : R) :=
-  eq_of_forall_le_iff fun c ↦ by simp only [le_inf'_iff, ← Nat.ceil_le]
+lemma cast_finsetInf' (f : ι → ℕ) (hs) : (↑(s.inf' hs f) : R) = s.inf' hs fun i ↦ (f i : R) := by
+  induction hs using Finset.Nonempty.cons_induction <;> simp [*]
 
 end LinearOrderedSemiring
 
 @[simp, norm_cast]
 lemma cast_finsetSup [CanonicallyLinearOrderedSemifield R] [FloorSemiring R]
     (s : Finset ι) (f : ι → ℕ) : (↑(s.sup f) : R) = s.sup fun i ↦ (f i : R) := by
-  obtain rfl | hs := s.eq_empty_or_nonempty
-  · simp
-  · rw [← sup'_eq_sup hs, ← sup'_eq_sup hs, Nat.cast_finsetSup']
+  comp_sup_eq_sup_comp _ (by simp) (by simp)
 
 end Nat

--- a/Mathlib/Algebra/Order/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/Ring/Finset.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser, Yaël Dillies, Andrew Yang
 -/
 import Mathlib.Algebra.Order.Field.Canonical.Defs
-import Mathlib.Algebra.Order.Floor
 import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Data.Nat.Cast.Order.Ring
 
 /-!
 # `Finset.sup` of `Nat.cast`
@@ -21,19 +21,19 @@ variable [LinearOrderedSemiring R] {s : Finset ι}
 
 set_option linter.docPrime false in
 @[simp, norm_cast]
-lemma cast_finsetSup' (f : ι → ℕ) (hs) : ((s.sup' hs f : ℕ) : R) = s.sup' hs fun i ↦ (f i : R) := by
-  induction hs using Finset.Nonempty.cons_induction <;> simp [*]
+lemma cast_finsetSup' (f : ι → ℕ) (hs) : ((s.sup' hs f : ℕ) : R) = s.sup' hs fun i ↦ (f i : R) :=
+  comp_sup'_eq_sup'_comp _ _ cast_max
 
 set_option linter.docPrime false in
 @[simp, norm_cast]
-lemma cast_finsetInf' (f : ι → ℕ) (hs) : (↑(s.inf' hs f) : R) = s.inf' hs fun i ↦ (f i : R) := by
-  induction hs using Finset.Nonempty.cons_induction <;> simp [*]
+lemma cast_finsetInf' (f : ι → ℕ) (hs) : (↑(s.inf' hs f) : R) = s.inf' hs fun i ↦ (f i : R) :=
+  comp_inf'_eq_inf'_comp _ _ cast_min
 
 end LinearOrderedSemiring
 
 @[simp, norm_cast]
-lemma cast_finsetSup [CanonicallyLinearOrderedSemifield R] [FloorSemiring R]
-    (s : Finset ι) (f : ι → ℕ) : (↑(s.sup f) : R) = s.sup fun i ↦ (f i : R) := by
-  comp_sup_eq_sup_comp _ (by simp) (by simp)
+lemma cast_finsetSup [CanonicallyLinearOrderedSemifield R] (s : Finset ι) (f : ι → ℕ) :
+    (↑(s.sup f) : R) = s.sup fun i ↦ (f i : R) :=
+  comp_sup_eq_sup_comp _ cast_max (by simp)
 
 end Nat

--- a/Mathlib/Algebra/Order/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/Ring/Finset.lean
@@ -8,7 +8,7 @@ import Mathlib.Algebra.Order.Floor
 import Mathlib.Data.Finset.Lattice.Fold
 
 /-!
-# `Finset.sup` in a ring
+# `Finset.sup` of `Nat.cast`
 -/
 
 open Finset

--- a/Mathlib/Data/Nat/Cast/Order/Ring.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Ring.lean
@@ -37,11 +37,11 @@ theorem ofNat_nonneg {α} [OrderedSemiring α] (n : ℕ) [n.AtLeastTwo] :
   ofNat_nonneg' n
 
 @[simp, norm_cast]
-theorem cast_min {α} [LinearOrderedSemiring α] {a b : ℕ} : ((min a b : ℕ) : α) = min (a : α) b :=
+theorem cast_min {α} [LinearOrderedSemiring α] (m n : ℕ) : (↑(min m n : ℕ) : α) = min (m : α) n :=
   (@mono_cast α _).map_min
 
 @[simp, norm_cast]
-theorem cast_max {α} [LinearOrderedSemiring α] {a b : ℕ} : ((max a b : ℕ) : α) = max (a : α) b :=
+theorem cast_max {α} [LinearOrderedSemiring α] (m n : ℕ) : (↑(max m n : ℕ) : α) = max (m : α) n :=
   (@mono_cast α _).map_max
 
 section Nontrivial


### PR DESCRIPTION
Co-authored-by: Andrew Yang


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #19461

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
