### PR TITLE
[Merged by Bors] - feat: `MulLeftMono` implies `PosMulMono`

### DIFF
--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
@@ -193,6 +193,30 @@ instance MulPosReflectLT.to_contravariantClass_pos_mul_lt [MulPosReflectLT α] :
     ContravariantClass α>0 α (fun x y => y * x) (· < ·) :=
   ⟨fun a _ _ bc => @ContravariantClass.elim α≥0 α (fun x y => y * x) (· < ·) _ ⟨_, a.2.le⟩ _ _ bc⟩
 
+instance (priority := 100) MulLeftMono.toPosMulMono [MulLeftMono α] :
+    PosMulMono α where elim _ _ := ‹MulLeftMono α›.elim _
+
+instance (priority := 100) MulRightMono.toMulPosMono [MulRightMono α] :
+    MulPosMono α where elim _ _ := ‹MulRightMono α›.elim _
+
+instance (priority := 100) MulLeftStrictMono.toPosMulStrictMono [MulLeftStrictMono α] :
+    PosMulStrictMono α where elim _ _ := ‹MulLeftStrictMono α›.elim _
+
+instance (priority := 100) MulRightStrictMono.toMulPosStrictMono [MulRightStrictMono α] :
+    MulPosStrictMono α where elim _ _ := ‹MulRightStrictMono α›.elim _
+
+instance (priority := 100) MulLeftMono.toPosMulReflectLT [MulLeftReflectLT α] :
+   PosMulReflectLT α where elim _ _ := ‹MulLeftReflectLT α›.elim _
+
+instance (priority := 100) MulRightMono.toMulPosReflectLT [MulRightReflectLT α] :
+   MulPosReflectLT α where elim _ _ := ‹MulRightReflectLT α›.elim _
+
+instance (priority := 100) MulLeftStrictMono.toPosMulReflectLE [MulLeftReflectLE α] :
+   PosMulReflectLE α where elim _ _ := ‹MulLeftReflectLE α›.elim _
+
+instance (priority := 100) MulRightStrictMono.toMulPosReflectLE [MulRightReflectLE α] :
+   MulPosReflectLE α where elim _ _ := ‹MulRightReflectLE α›.elim _
+
 @[gcongr]
 theorem mul_le_mul_of_nonneg_left [PosMulMono α] (h : b ≤ c) (a0 : 0 ≤ a) : a * b ≤ a * c :=
   @CovariantClass.elim α≥0 α (fun x y => x * y) (· ≤ ·) _ ⟨a, a0⟩ _ _ h


### PR DESCRIPTION
... and similarly for the other typeclasses

From GrowthInGroups (LeanCamCombi)

Co-authored-by: Andrew Yang


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
