### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Matching): add `IsCycles` and `IsAlternating` with basic results

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -362,11 +362,11 @@ possible. This property is used to create new matchings using `symmDiff`. The de
 for `SimpleGraph` as well.
 -/
 def IsAlternating (G  G' : SimpleGraph V) :=
-  ∀ {v w w': V}, w ≠ w' → G.Adj v w → G.Adj v w' → (G'.Adj v w ↔ ¬ G'.Adj v w')
+  ∀ ⦃v w w': V⦄, w ≠ w' → G.Adj v w → G.Adj v w' → (G'.Adj v w ↔ ¬ G'.Adj v w')
 
 lemma IsPerfectMatching.symmDiff_spanningCoe_of_isAlternating {M : Subgraph G}
     (hM : M.IsPerfectMatching) (hG' : G'.IsAlternating M.spanningCoe) (hG'cyc : G'.IsCycles)  :
-    ((symmDiff M.spanningCoe G').toSubgraph (symmDiff M.spanningCoe G')
+    ((M.spanningCoe ∆ G').toSubgraph (M.spanningCoe ∆ G')
     (by rfl)).IsPerfectMatching := by
   rw [Subgraph.isPerfectMatching_iff]
   intro v

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -33,7 +33,7 @@ one edge, and the edges of the subgraph represent the paired vertices.
   also known as isolated vertices)
 
 * `SimpleGraph.IsAlternating` means that edges in a graph `G` are alternatingly
-  also included and not included in some other graph `G'`
+  included and not included in some other graph `G'`
 
 ## TODO
 
@@ -320,7 +320,7 @@ lemma exists_maximal_isMatchingFree [Finite V] (h : G.IsMatchingFree) :
 /-- A graph `G` consists of a set of cycles, if each vertex is either isolated or connected to
 exactly two vertices. This is used to create new matchings by taking the `symmDiff` with cycles.
 The definition of `symmDiff` that makes sense is the one for `SimpleGraph`. This is why this
-definition is for graphs, rather than subgraphs.
+definition is for `SimpleGraph`, rather than `SimpleGraph.Subgraph`.
 -/
 def IsCycles (G : SimpleGraph V) := ∀ ⦃v⦄, (G.neighborSet v).Nonempty → (G.neighborSet v).ncard = 2
 -- def IsCycles (G : SimpleGraph V) := (∀ v : V, (G.neighborSet v) = ∅ ∨ (G.neighborSet v).ncard = 2)

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -323,7 +323,7 @@ The definition of `symmDiff` that makes sense is the one for `SimpleGraph`. This
 definition is for `SimpleGraph`, rather than `SimpleGraph.Subgraph`.
 -/
 def IsCycles (G : SimpleGraph V) := ∀ ⦃v⦄, (G.neighborSet v).Nonempty → (G.neighborSet v).ncard = 2
--- def IsCycles (G : SimpleGraph V) := (∀ v : V, (G.neighborSet v) = ∅ ∨ (G.neighborSet v).ncard = 2)
+
 /--
 Given a vertex with one edge in a graph of cycles this gives the other edge incident
 to the same vertex.

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -27,6 +27,14 @@ one edge, and the edges of the subgraph represent the paired vertices.
 * `SimpleGraph.Subgraph.IsPerfectMatching` defines when a subgraph `M` of a simple graph is a
   perfect matching, denoted `M.IsPerfectMatching`.
 
+* `SimpleGraph.IsMatchingFree` means that a SimpleGraph `G` has no perfect matchings.
+
+* `SimpleGraph.IsCycles` means that a graph consists of cycles (including cycles of length 0,
+  also known as isolated vertices)
+
+* `SimpleGraph.IsAlternating` means that edges in a SimpleGraph `G` are alternatingly
+  also included and not included in some other SimpleGraph `G'`
+
 ## TODO
 
 * Define an `other` function and prove useful results about it (https://leanprover.zulipchat.com/#narrow/stream/252551-graph-theory/topic/matchings/near/266205863)
@@ -308,5 +316,76 @@ lemma exists_maximal_isMatchingFree [Finite V] (h : G.IsMatchingFree) :
   simp_rw [← @not_forall_not _ Subgraph.IsPerfectMatching]
   obtain ⟨Gmax, hGmax⟩ := Finite.exists_le_maximal h
   exact ⟨Gmax, ⟨hGmax.1, ⟨hGmax.2.prop, fun _ h' ↦ hGmax.2.not_prop_of_gt h'⟩⟩⟩
+
+/-- A graph `G` consists of a set of cycles, if each vertex is either isolated or connected to
+exactly two vertices. This is used to create new matchings by taking the `symmDiff` with cycles.
+The definition of `symmDiff` that makes sense is the one for `SimpleGraph`. This is why this
+definition is for graphs, rather than subgraphs.
+-/
+def IsCycles (G : SimpleGraph V) := (∀ v : V, (G.neighborSet v) = ∅ ∨ (G.neighborSet v).ncard = 2)
+
+/--
+Given a vertex with one edge in a graph of cycles this gives the other edge incident
+to the same vertex.
+-/
+lemma IsCycles.other_adj_of_adj (h : G.IsCycles) (hadj : G.Adj v w) :
+  ∃ w', w ≠ w' ∧ G.Adj v w' := by
+  simp_rw [← SimpleGraph.mem_neighborSet] at hadj ⊢
+  cases' h v with hl hr
+  · exact ((Set.eq_empty_iff_forall_not_mem.mp hl) _ hadj).elim
+  · obtain ⟨w', hww'⟩ := (G.neighborSet v).exists_ne_of_one_lt_ncard (by omega) w
+    exact ⟨w', ⟨hww'.2.symm, hww'.1⟩⟩
+
+lemma Subgraph.IsPerfectMatching.symmDiff_spanningCoe_IsCycles
+    {M : Subgraph G} {M' : Subgraph G'} (hM : M.IsPerfectMatching)
+    (hM' : M'.IsPerfectMatching) : (symmDiff M.spanningCoe M'.spanningCoe).IsCycles := by
+  intro v
+  obtain ⟨w, hw⟩ := hM.1 (hM.2 v)
+  obtain ⟨w', hw'⟩ := hM'.1 (hM'.2 v)
+  simp only [symmDiff_def, Set.eq_empty_iff_forall_not_mem, SimpleGraph.mem_neighborSet,
+    SimpleGraph.sup_adj, sdiff_adj, spanningCoe_adj, not_or, not_and, not_not, Set.ncard_eq_two,
+    ne_eq]
+  by_cases hww' : w = w'
+  · simp_all [hww']
+  · right
+    use w, w'
+    aesop
+
+/--
+A graph `G` is alternating with respect to some other graph `G'`, if exactly every other edge in
+`G` is in `G'`. Note that the degree of each vertex needs to be bounded by 2 for this to be
+possible. This property is used to create new matchings using `symmDiff`. The definition of
+`symmDiff` for `SimpleGraph` is the on
+-/
+def IsAlternating (G : SimpleGraph V) (G' : SimpleGraph V) :=
+  ∀ {v w w': V}, w ≠ w' → G.Adj v w → G.Adj v w' → (G'.Adj v w ↔ ¬ G'.Adj v w')
+
+lemma IsPerfectMatching.symmDiff_spanningCoe_of_IsAlternating {M : Subgraph G}
+    (hM : M.IsPerfectMatching) (hG' : G'.IsAlternating M.spanningCoe) (hG'cyc : G'.IsCycles)  :
+    ((symmDiff M.spanningCoe G').toSubgraph (symmDiff M.spanningCoe G')
+    (by rfl)).IsPerfectMatching := by
+  rw [Subgraph.isPerfectMatching_iff]
+  intro v
+  simp only [toSubgraph_adj, symmDiff_def, sup_adj, sdiff_adj, Subgraph.spanningCoe_adj]
+  obtain ⟨w, hw⟩ := hM.1 (hM.2 v)
+  by_cases h : G'.Adj v w
+  · obtain ⟨w', hw'⟩ := hG'cyc.other_adj_of_adj h
+    have hmadj :  M.Adj v w ↔ ¬M.Adj v w' := by simpa using hG' hw'.1 h hw'.2
+    use w'
+    simp only [hmadj.mp hw.1, hw'.2, not_true_eq_false, and_self, not_false_eq_true, or_true,
+      true_and]
+    rintro y (hl | hr)
+    · aesop
+    · obtain ⟨w'', hw''⟩ := hG'cyc.other_adj_of_adj hr.1
+      by_contra! hc
+      simp_all only [show M.Adj v y ↔ ¬M.Adj v w' from by simpa using hG' hc hr.1 hw'.2,
+        not_false_eq_true, ne_eq, iff_true, not_true_eq_false, and_false]
+  · use w
+    simp only [hw.1, h, not_false_eq_true, and_self, not_true_eq_false, or_false, true_and]
+    rintro y (hl | hr)
+    · exact hw.2 _ hl.1
+    · have ⟨w', hw'⟩ := hG'cyc.other_adj_of_adj hr.1
+      simp_all only [show M.Adj v y ↔ ¬M.Adj v w' from by simpa using hG' hw'.1 hr.1 hw'.2, not_not,
+        ne_eq, and_false]
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -361,13 +361,13 @@ possible. This property is used to create new matchings using `symmDiff`. The de
 `symmDiff` for `SimpleGraph` is the one that makes sense, so this property is defined
 for `SimpleGraph` as well.
 -/
-def IsAlternating (G  G' : SimpleGraph V) :=
+def IsAlternating (G G' : SimpleGraph V) :=
   ∀ ⦃v w w': V⦄, w ≠ w' → G.Adj v w → G.Adj v w' → (G'.Adj v w ↔ ¬ G'.Adj v w')
 
 lemma IsPerfectMatching.symmDiff_spanningCoe_of_isAlternating {M : Subgraph G}
     (hM : M.IsPerfectMatching) (hG' : G'.IsAlternating M.spanningCoe) (hG'cyc : G'.IsCycles)  :
-    ((M.spanningCoe ∆ G').toSubgraph (M.spanningCoe ∆ G')
-    (by rfl)).IsPerfectMatching := by
+    (SimpleGraph.toSubgraph (M.spanningCoe ∆ G')
+      (by rfl)).IsPerfectMatching := by
   rw [Subgraph.isPerfectMatching_iff]
   intro v
   simp only [toSubgraph_adj, symmDiff_def, sup_adj, sdiff_adj, Subgraph.spanningCoe_adj]

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -356,7 +356,7 @@ lemma Subgraph.IsPerfectMatching.symmDiff_spanningCoe_IsCycles
 
 /--
 A graph `G` is alternating with respect to some other graph `G'`, if exactly every other edge in
-`G` is in `G'`. Note that the degree of each vertex needs to be bounded by 2 for this to be
+`G` is in `G'`. Note that the degree of each vertex needs to be at most 2 for this to be
 possible. This property is used to create new matchings using `symmDiff`. The definition of
 `symmDiff` for `SimpleGraph` is the one that makes sense, so this property is defined
 for `SimpleGraph` as well.

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -329,7 +329,7 @@ Given a vertex with one edge in a graph of cycles this gives the other edge inci
 to the same vertex.
 -/
 lemma IsCycles.other_adj_of_adj (h : G.IsCycles) (hadj : G.Adj v w) :
-  ∃ w', w ≠ w' ∧ G.Adj v w' := by
+    ∃ w', w ≠ w' ∧ G.Adj v w' := by
   simp_rw [← SimpleGraph.mem_neighborSet] at hadj ⊢
   cases' h v with hl hr
   · exact ((Set.eq_empty_iff_forall_not_mem.mp hl) _ hadj).elim

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -319,8 +319,10 @@ lemma exists_maximal_isMatchingFree [Finite V] (h : G.IsMatchingFree) :
 
 /-- A graph `G` consists of a set of cycles, if each vertex is either isolated or connected to
 exactly two vertices. This is used to create new matchings by taking the `symmDiff` with cycles.
-The definition of `symmDiff` that makes sense is the one for `SimpleGraph`. This is why this
-definition is for `SimpleGraph`, rather than `SimpleGraph.Subgraph`.
+The definition of `symmDiff` that makes sense is the one for `SimpleGraph`. The `symmDiff`
+for `SimpleGraph.Subgraph` deriving from the lattice structure also affects the vertices included,
+which we do not want in this case. This is why this property is defined for `SimpleGraph`, rather
+than `SimpleGraph.Subgraph`.
 -/
 def IsCycles (G : SimpleGraph V) := ∀ ⦃v⦄, (G.neighborSet v).Nonempty → (G.neighborSet v).ncard = 2
 
@@ -357,9 +359,11 @@ lemma Subgraph.IsPerfectMatching.symmDiff_spanningCoe_IsCycles
 /--
 A graph `G` is alternating with respect to some other graph `G'`, if exactly every other edge in
 `G` is in `G'`. Note that the degree of each vertex needs to be at most 2 for this to be
-possible. This property is used to create new matchings using `symmDiff`. The definition of
-`symmDiff` for `SimpleGraph` is the one that makes sense, so this property is defined
-for `SimpleGraph` as well.
+possible. This property is used to create new matchings using `symmDiff`.
+The definition of `symmDiff` that makes sense is the one for `SimpleGraph`. The `symmDiff`
+for `SimpleGraph.Subgraph` deriving from the lattice structure also affects the vertices included,
+which we do not want in this case. This is why this property, just like `IsCycles`, is defined
+for `SimpleGraph` rather than `SimpleGraph.Subgraph`.
 -/
 def IsAlternating (G G' : SimpleGraph V) :=
   ∀ ⦃v w w': V⦄, w ≠ w' → G.Adj v w → G.Adj v w' → (G'.Adj v w ↔ ¬ G'.Adj v w')

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -27,7 +27,7 @@ one edge, and the edges of the subgraph represent the paired vertices.
 * `SimpleGraph.Subgraph.IsPerfectMatching` defines when a subgraph `M` of a simple graph is a
   perfect matching, denoted `M.IsPerfectMatching`.
 
-* `SimpleGraph.IsMatchingFree` means that a SimpleGraph `G` has no perfect matchings.
+* `SimpleGraph.IsMatchingFree` means that a simple graph `G` has no perfect matchings.
 
 * `SimpleGraph.IsCycles` means that a graph consists of cycles (including cycles of length 0,
   also known as isolated vertices)
@@ -322,7 +322,7 @@ exactly two vertices. This is used to create new matchings by taking the `symmDi
 The definition of `symmDiff` that makes sense is the one for `SimpleGraph`. This is why this
 definition is for graphs, rather than subgraphs.
 -/
-def IsCycles (G : SimpleGraph V) := (∀ v : V, (G.neighborSet v) = ∅ ∨ (G.neighborSet v).ncard = 2)
+def IsCycles (G : SimpleGraph V) := ∀ ⦃v⦄, (G.neighborSet v).Nonempty → (G.neighborSet v).ncard = 2
 
 /--
 Given a vertex with one edge in a graph of cycles this gives the other edge incident
@@ -338,7 +338,7 @@ lemma IsCycles.other_adj_of_adj (h : G.IsCycles) (hadj : G.Adj v w) :
 
 lemma Subgraph.IsPerfectMatching.symmDiff_spanningCoe_IsCycles
     {M : Subgraph G} {M' : Subgraph G'} (hM : M.IsPerfectMatching)
-    (hM' : M'.IsPerfectMatching) : (symmDiff M.spanningCoe M'.spanningCoe).IsCycles := by
+    (hM' : M'.IsPerfectMatching) : (M.spanningCoe ∆ M'.spanningCoe).IsCycles := by
   intro v
   obtain ⟨w, hw⟩ := hM.1 (hM.2 v)
   obtain ⟨w', hw'⟩ := hM'.1 (hM'.2 v)
@@ -357,10 +357,10 @@ A graph `G` is alternating with respect to some other graph `G'`, if exactly eve
 possible. This property is used to create new matchings using `symmDiff`. The definition of
 `symmDiff` for `SimpleGraph` is the on
 -/
-def IsAlternating (G : SimpleGraph V) (G' : SimpleGraph V) :=
+def IsAlternating (G  G' : SimpleGraph V) :=
   ∀ {v w w': V}, w ≠ w' → G.Adj v w → G.Adj v w' → (G'.Adj v w ↔ ¬ G'.Adj v w')
 
-lemma IsPerfectMatching.symmDiff_spanningCoe_of_IsAlternating {M : Subgraph G}
+lemma IsPerfectMatching.symmDiff_spanningCoe_of_isAlternating {M : Subgraph G}
     (hM : M.IsPerfectMatching) (hG' : G'.IsAlternating M.spanningCoe) (hG'cyc : G'.IsCycles)  :
     ((symmDiff M.spanningCoe G').toSubgraph (symmDiff M.spanningCoe G')
     (by rfl)).IsPerfectMatching := by


### PR DESCRIPTION
add `SimpleGraph.IsCycles` and `SimpleGraph.IsAlternating` with some basic results involving matchings. These are defined on `SimpleGraph`, because we want to use the `symmDiff` defined on there.
This is in preparation for Tutte's theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Zulip thread on Tutte's](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Tutte's.20theorem)