### PR TITLE
[Merged by Bors] - feat(Pointwise): monotonicity of `pow`

### DIFF
--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -230,7 +230,7 @@ theorem pow_subset_pow {n : ℕ} : (↑M : Set A) ^ n ⊆ ↑(M ^ n : Submodule 
   trans AddSubmonoid.pow_subset_pow (le_pow_toAddSubmonoid M)
 
 theorem pow_mem_pow {x : A} (hx : x ∈ M) (n : ℕ) : x ^ n ∈ M ^ n :=
-  pow_subset_pow _ <| Set.pow_mem_pow hx _
+  pow_subset_pow _ <| Set.pow_mem_pow hx
 
 end Module
 

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -950,11 +950,11 @@ protected def monoid : Monoid (Finset α) :=
 
 scoped[Pointwise] attribute [instance] Finset.monoid Finset.addMonoid
 
--- `Finset.pow_left_mono` doesn't exist since it would syntactically be a special case of
+-- `Finset.pow_left_monotone` doesn't exist since it would syntactically be a special case of
 -- `pow_left_mono`
 
 @[to_additive]
-protected lemma pow_right_mono (hs : 1 ∈ s) : Monotone (s ^ ·) :=
+protected lemma pow_right_monotone (hs : 1 ∈ s) : Monotone (s ^ ·) :=
   pow_right_monotone <| one_subset.2 hs
 
 @[to_additive (attr := gcongr)]
@@ -962,7 +962,7 @@ lemma pow_subset_pow_left (hst : s ⊆ t) : s ^ n ⊆ t ^ n := pow_left_mono _ h
 
 @[to_additive (attr := gcongr)]
 lemma pow_subset_pow_right (hs : 1 ∈ s) (hmn : m ≤ n) : s ^ m ⊆ s ^ n :=
-  Finset.pow_right_mono hs hmn
+  Finset.pow_right_monotone hs hmn
 
 @[to_additive (attr := gcongr)]
 lemma pow_subset_pow (hst : s ⊆ t) (ht : 1 ∈ t) (hmn : m ≤ n) : s ^ m ⊆ t ^ n :=
@@ -974,12 +974,11 @@ lemma pow_subset_pow (hst : s ⊆ t) (ht : 1 ∈ t) (hmn : m ≤ n) : s ^ m ⊆ 
 alias nsmul_subset_nsmul_of_zero_mem := nsmul_subset_nsmul_right
 
 @[to_additive]
-lemma pow_subset_pow_mul_of_sq_subset_mul (hst : s ^ 2 ⊆ t * s) (hn : 1 < n) :
+lemma pow_subset_pow_mul_of_sq_subset_mul (hst : s ^ 2 ⊆ t * s) (hn : n ≠ 0) :
     s ^ n ⊆ t ^ (n - 1) * s := pow_le_pow_mul_of_sq_le_mul hst hn
 
 @[to_additive (attr := simp) nsmul_empty]
-theorem empty_pow (hn : n ≠ 0) : (∅ : Finset α) ^ n = ∅ := by
-  rw [← tsub_add_cancel_of_le (Nat.succ_le_of_lt <| Nat.pos_of_ne_zero hn), pow_succ', empty_mul]
+lemma empty_pow (hn : n ≠ 0) : (∅ : Finset α) ^ n = ∅ := match n with | n + 1 => by simp [pow_succ]
 
 @[deprecated (since := "2024-10-21")] alias empty_nsmul := nsmul_empty
 
@@ -1486,6 +1485,22 @@ theorem mul_subset_iff_right : s * t ⊆ u ↔ ∀ b ∈ t, op b • s ⊆ u :=
   image₂_subset_iff_right
 
 end Mul
+
+section Monoid
+variable [DecidableEq α] [DecidableEq β] [Monoid α] [Monoid β] [FunLike F α β]
+
+@[to_additive]
+lemma image_pow_of_ne_zero [MulHomClass F α β] :
+    ∀ {n}, n ≠ 0 → ∀ (f : F) (s : Finset α), (s ^ n).image f = s.image f ^ n
+  | 1, _ => by simp
+  | n + 2, _ => by simp [image_mul, pow_succ _ n.succ, image_pow_of_ne_zero]
+
+@[to_additive]
+lemma image_pow [MonoidHomClass F α β] (f : F) (s : Finset α) : ∀ n, (s ^ n).image f = s.image f ^ n
+  | 0 => by simp [singleton_one]
+  | n + 1 => image_pow_of_ne_zero n.succ_ne_zero ..
+
+end Monoid
 
 section Semigroup
 

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
@@ -119,6 +119,20 @@ theorem Right.pow_lt_one_of_lt {n : ℕ} {x : M} (hn : 0 < n) (h : x < 1) : x ^ 
 
 @[deprecated (since := "2024-09-21")] alias Right.pow_neg := Right.nsmul_neg
 
+/-- This lemma is useful in non-cancellative monoids, like sets under pointwise operations. -/
+@[to_additive
+"This lemma is useful in non-cancellative monoids, like sets under pointwise operations."]
+lemma pow_le_pow_mul_of_sq_le_mul [MulLeftMono M] {a b : M} (hab : a ^ 2 ≤ b * a) :
+    ∀ {n}, 1 < n → a ^ n ≤ b ^ (n - 1) * a
+  | 2, _ => by simpa
+  | n + 3, _ => by
+    calc
+      a ^ (n + 3) = a ^ (n + 2) * a := by rw [pow_succ]
+      _ ≤ b ^ (n + 1) * a * a := mul_le_mul_right' (pow_le_pow_mul_of_sq_le_mul hab (by omega)) _
+      _ = b ^ (n + 1) * a ^ 2 := by rw [mul_assoc, sq]
+      _ ≤ b ^ (n + 1) * (b * a) := mul_le_mul_left' hab _
+      _ = b ^ (n + 2) * a := by rw [← mul_assoc, ← pow_succ]
+
 end Right
 
 section CovariantLTSwap

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
@@ -123,15 +123,15 @@ theorem Right.pow_lt_one_of_lt {n : ℕ} {x : M} (hn : 0 < n) (h : x < 1) : x ^ 
 @[to_additive
 "This lemma is useful in non-cancellative monoids, like sets under pointwise operations."]
 lemma pow_le_pow_mul_of_sq_le_mul [MulLeftMono M] {a b : M} (hab : a ^ 2 ≤ b * a) :
-    ∀ {n}, 1 < n → a ^ n ≤ b ^ (n - 1) * a
-  | 2, _ => by simpa
-  | n + 3, _ => by
+    ∀ {n}, n ≠ 0 → a ^ n ≤ b ^ (n - 1) * a
+  | 1, _ => by simp
+  | n + 2, _ => by
     calc
-      a ^ (n + 3) = a ^ (n + 2) * a := by rw [pow_succ]
-      _ ≤ b ^ (n + 1) * a * a := mul_le_mul_right' (pow_le_pow_mul_of_sq_le_mul hab (by omega)) _
-      _ = b ^ (n + 1) * a ^ 2 := by rw [mul_assoc, sq]
-      _ ≤ b ^ (n + 1) * (b * a) := mul_le_mul_left' hab _
-      _ = b ^ (n + 2) * a := by rw [← mul_assoc, ← pow_succ]
+      a ^ (n + 2) = a ^ (n + 1) * a := by rw [pow_succ]
+      _ ≤ b ^ n * a * a := mul_le_mul_right' (pow_le_pow_mul_of_sq_le_mul hab (by omega)) _
+      _ = b ^ n * a ^ 2 := by rw [mul_assoc, sq]
+      _ ≤ b ^ n * (b * a) := mul_le_mul_left' hab _
+      _ = b ^ (n + 1) * a := by rw [← mul_assoc, ← pow_succ]
 
 end Right
 

--- a/Mathlib/Analysis/Convex/EGauge.lean
+++ b/Mathlib/Analysis/Convex/EGauge.lean
@@ -111,8 +111,7 @@ lemma egauge_zero_right (hs : s.Nonempty) : egauge 𝕜 s 0 = 0 := by
   have : 0 ∈ (0 : 𝕜) • s := by simp [zero_smul_set hs]
   simpa using egauge_le_of_mem_smul this
 
-@[simp]
-lemma egauge_zero_zero : egauge 𝕜 (0 : Set E) 0 = 0 := egauge_zero_right _ ⟨0, rfl⟩
+lemma egauge_zero_zero : egauge 𝕜 (0 : Set E) 0 = 0 := by simp
 
 lemma egauge_le_one (h : x ∈ s) : egauge 𝕜 s x ≤ 1 := by
   rw [← one_smul 𝕜 s] at h

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1044,7 +1044,7 @@ def powCardSubgroup {G : Type*} [Group G] [Fintype G] (S : Set G) (hS : S.Nonemp
   have one_mem : (1 : G) ∈ S ^ Fintype.card G := by
     obtain ⟨a, ha⟩ := hS
     rw [← pow_card_eq_one]
-    exact Set.pow_mem_pow ha (Fintype.card G)
+    exact Set.pow_mem_pow ha
   subgroupOfIdempotent (S ^ Fintype.card G) ⟨1, one_mem⟩ <| by
     classical
     apply (Set.eq_of_subset_of_card_le (Set.subset_mul_left _ one_mem) (ge_of_eq _)).symm


### PR DESCRIPTION
... and `s ^ n = ∅ ↔ s = ∅ ∧ n ≠ 0`

From GrowthInGroups


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #19249

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
