### PR TITLE
[Merged by Bors] - feat(NumberTheory/LSeries/DirichletContinuation): results on logarithmic derivatives

### DIFF
--- a/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
+++ b/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
@@ -351,8 +351,7 @@ lemma LFunctionTrivChar₁_differentiable : Differentiable ℂ (LFunctionTrivCha
     (fun _ hs ↦ DifferentiableAt.differentiableWithinAt <| by fun_prop (disch := simp_all [hs]))
     fun _ hs ↦ by rw [LFunctionTrivChar₁_apply_of_ne_one n (Set.mem_diff_singleton.mp hs).2],
     continuousWithinAt_compl_self.mp ?_⟩
-  simpa only [mul_comm (LFunctionTrivChar ..), continuousWithinAt_compl_self,
-    continuousAt_update_same]
+  simpa only [continuousWithinAt_compl_self, continuousAt_update_same]
     using LFunctionTrivChar_residue_one
 
 lemma deriv_LFunctionTrivChar₁_apply_of_ne_one  {s : ℂ} (hs : s ≠ 1) :

--- a/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
+++ b/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
@@ -354,7 +354,7 @@ lemma LFunctionTrivChar₁_differentiable : Differentiable ℂ (LFunctionTrivCha
   simpa only [continuousWithinAt_compl_self, continuousAt_update_same]
     using LFunctionTrivChar_residue_one
 
-lemma deriv_LFunctionTrivChar₁_apply_of_ne_one  {s : ℂ} (hs : s ≠ 1) :
+lemma deriv_LFunctionTrivChar₁_apply_of_ne_one {s : ℂ} (hs : s ≠ 1) :
     deriv (LFunctionTrivChar₁ n) s =
       (s - 1) * deriv (LFunctionTrivChar n) s + LFunctionTrivChar n s := by
   have H : deriv (LFunctionTrivChar₁ n) s =

--- a/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
+++ b/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
@@ -327,9 +327,8 @@ section trivial
 variable (n : ℕ) [NeZero n]
 
 /-- The function obtained by "multiplying away" the pole of `L χ` for a trivial Dirichlet
-character `χ`. Its (negative) logarithmic derivative is used in the Wiener-Ikehara Theorem
-to prove the Prime Number Theorem version of Dirichlet's Theorem on primes in arithmetic
-progressions. -/
+character `χ`. Its (negative) logarithmic derivative is used to prove Dirichlet's Theorem
+on primes in arithmetic progression. -/
 noncomputable abbrev LFunctionTrivChar₁ : ℂ → ℂ :=
   Function.update (fun s ↦ LFunctionTrivChar n s * (s - 1)) 1
     (∏ p ∈ n.primeFactors, (1 - (p : ℂ)⁻¹))
@@ -350,13 +349,11 @@ lemma LFunctionTrivChar₁_differentiable : Differentiable ℂ (LFunctionTrivCha
     ← differentiableOn_compl_singleton_and_continuousAt_iff (c := 1) Filter.univ_mem]
   refine ⟨DifferentiableOn.congr (f := fun s ↦ LFunctionTrivChar n s * (s - 1))
     (fun _ hs ↦ DifferentiableAt.differentiableWithinAt <| by fun_prop (disch := simp_all [hs]))
-    fun _ hs ↦ ?_,
+    fun _ hs ↦ by rw [LFunctionTrivChar₁_apply_of_ne_one n (Set.mem_diff_singleton.mp hs).2],
     continuousWithinAt_compl_self.mp ?_⟩
-  · simp only [Set.mem_diff, Set.mem_univ, Set.mem_singleton_iff, true_and] at hs
-    simp only [ne_eq, hs, not_false_eq_true, Function.update_noteq]
-  · simpa only [mul_comm (LFunctionTrivChar ..), continuousWithinAt_compl_self,
-      continuousAt_update_same]
-      using LFunctionTrivChar_residue_one
+  simpa only [mul_comm (LFunctionTrivChar ..), continuousWithinAt_compl_self,
+    continuousAt_update_same]
+    using LFunctionTrivChar_residue_one
 
 lemma deriv_LFunctionTrivChar₁_apply_of_ne_one  {s : ℂ} (hs : s ≠ 1) :
     deriv (LFunctionTrivChar₁ n) s =

--- a/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
+++ b/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
@@ -330,11 +330,11 @@ variable (n : ℕ) [NeZero n]
 character `χ`. Its (negative) logarithmic derivative is used to prove Dirichlet's Theorem
 on primes in arithmetic progression. -/
 noncomputable abbrev LFunctionTrivChar₁ : ℂ → ℂ :=
-  Function.update (fun s ↦ LFunctionTrivChar n s * (s - 1)) 1
+  Function.update (fun s ↦ (s - 1) * LFunctionTrivChar n s) 1
     (∏ p ∈ n.primeFactors, (1 - (p : ℂ)⁻¹))
 
 lemma LFunctionTrivChar₁_apply_of_ne_one {s : ℂ} (hs : s ≠ 1) :
-    LFunctionTrivChar₁ n s = LFunctionTrivChar n s * (s - 1) := by
+    LFunctionTrivChar₁ n s = (s - 1) * LFunctionTrivChar n s := by
   simp only [ne_eq, hs, not_false_eq_true, Function.update_noteq]
 
 lemma LFunctionTrivChar₁_apply_one_ne_zero : LFunctionTrivChar₁ n 1 ≠ 0 := by
@@ -347,7 +347,7 @@ lemma LFunctionTrivChar₁_apply_one_ne_zero : LFunctionTrivChar₁ n 1 ≠ 0 :=
 lemma LFunctionTrivChar₁_differentiable : Differentiable ℂ (LFunctionTrivChar₁ n) := by
   rw [← differentiableOn_univ,
     ← differentiableOn_compl_singleton_and_continuousAt_iff (c := 1) Filter.univ_mem]
-  refine ⟨DifferentiableOn.congr (f := fun s ↦ LFunctionTrivChar n s * (s - 1))
+  refine ⟨DifferentiableOn.congr (f := fun s ↦ (s - 1) * LFunctionTrivChar n s)
     (fun _ hs ↦ DifferentiableAt.differentiableWithinAt <| by fun_prop (disch := simp_all [hs]))
     fun _ hs ↦ by rw [LFunctionTrivChar₁_apply_of_ne_one n (Set.mem_diff_singleton.mp hs).2],
     continuousWithinAt_compl_self.mp ?_⟩
@@ -357,16 +357,16 @@ lemma LFunctionTrivChar₁_differentiable : Differentiable ℂ (LFunctionTrivCha
 
 lemma deriv_LFunctionTrivChar₁_apply_of_ne_one  {s : ℂ} (hs : s ≠ 1) :
     deriv (LFunctionTrivChar₁ n) s =
-      deriv (LFunctionTrivChar n) s * (s - 1) + LFunctionTrivChar n s := by
+      (s - 1) * deriv (LFunctionTrivChar n) s + LFunctionTrivChar n s := by
   have H : deriv (LFunctionTrivChar₁ n) s =
-      deriv (fun w ↦ LFunctionTrivChar n w * (w - 1)) s := by
+      deriv (fun w ↦ (w - 1) * LFunctionTrivChar n w) s := by
     refine Filter.eventuallyEq_iff_exists_mem.mpr ?_ |>.deriv_eq
-    refine ⟨{w | w ≠ 1}, IsOpen.mem_nhds isOpen_ne hs, fun w hw ↦ ?_⟩
-    simp only [ne_eq, Set.mem_setOf.mp hw, not_false_eq_true, Function.update_noteq]
-  rw [H, deriv_mul (differentiableAt_LFunction _ s (.inl hs)) <| by fun_prop, deriv_sub_const,
-    deriv_id'', mul_one]
+    exact ⟨{w | w ≠ 1}, IsOpen.mem_nhds isOpen_ne hs,
+      fun w hw ↦ LFunctionTrivChar₁_apply_of_ne_one n (Set.mem_setOf.mp hw)⟩
+  rw [H, deriv_mul (by fun_prop) (differentiableAt_LFunction _ s (.inl hs)), deriv_sub_const,
+    deriv_id'', one_mul, add_comm]
 
-/-- The negative logarithmtic derivative of `s ↦ (L χ s) * (s - 1)` for a trivial
+/-- The negative logarithmtic derivative of `s ↦ (s - 1) * L χ s` for a trivial
 Dirichlet character `χ` is continuous away from the zeros of `L χ` (including at `s = 1`). -/
 lemma continuousOn_neg_logDeriv_LFunctionTrivChar₁ :
     ContinuousOn (fun s ↦ -deriv (LFunctionTrivChar₁ n) s / LFunctionTrivChar₁ n s)
@@ -378,7 +378,7 @@ lemma continuousOn_neg_logDeriv_LFunctionTrivChar₁ :
   rcases eq_or_ne w 1 with rfl | hw'
   · exact LFunctionTrivChar₁_apply_one_ne_zero _
   · rw [LFunctionTrivChar₁_apply_of_ne_one n hw', mul_ne_zero_iff]
-    exact ⟨(Set.mem_setOf.mp hw).resolve_left hw', sub_ne_zero_of_ne hw'⟩
+    exact ⟨sub_ne_zero_of_ne hw', (Set.mem_setOf.mp hw).resolve_left hw'⟩
 
 end trivial
 

--- a/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
+++ b/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
@@ -333,15 +333,11 @@ noncomputable abbrev LFunctionTrivChar₁ : ℂ → ℂ :=
   Function.update (fun s ↦ (s - 1) * LFunctionTrivChar n s) 1
     (∏ p ∈ n.primeFactors, (1 - (p : ℂ)⁻¹))
 
-lemma LFunctionTrivChar₁_apply_of_ne_one {s : ℂ} (hs : s ≠ 1) :
-    LFunctionTrivChar₁ n s = (s - 1) * LFunctionTrivChar n s := by
-  simp only [ne_eq, hs, not_false_eq_true, Function.update_noteq]
-
 lemma LFunctionTrivChar₁_apply_one_ne_zero : LFunctionTrivChar₁ n 1 ≠ 0 := by
   simp only [Function.update_same]
   refine Finset.prod_ne_zero_iff.mpr fun p hp ↦ ?_
-  rw [sub_ne_zero, ne_eq, one_eq_inv]
-  exact_mod_cast (Nat.prime_of_mem_primeFactors hp).ne_one
+  simpa only [ne_eq, sub_ne_zero, one_eq_inv, Nat.cast_eq_one]
+    using (Nat.prime_of_mem_primeFactors hp).ne_one
 
 /-- `s ↦ (s - 1) * L χ s` is an entire function when `χ` is a trivial Dirichlet character. -/
 lemma differentiable_LFunctionTrivChar₁ : Differentiable ℂ (LFunctionTrivChar₁ n) := by
@@ -349,7 +345,7 @@ lemma differentiable_LFunctionTrivChar₁ : Differentiable ℂ (LFunctionTrivCha
     ← differentiableOn_compl_singleton_and_continuousAt_iff (c := 1) Filter.univ_mem]
   refine ⟨DifferentiableOn.congr (f := fun s ↦ (s - 1) * LFunctionTrivChar n s)
     (fun _ hs ↦ DifferentiableAt.differentiableWithinAt <| by fun_prop (disch := simp_all [hs]))
-    fun _ hs ↦ by rw [LFunctionTrivChar₁_apply_of_ne_one n (Set.mem_diff_singleton.mp hs).2],
+   fun _ hs ↦ Function.update_noteq (Set.mem_diff_singleton.mp hs).2 ..,
     continuousWithinAt_compl_self.mp ?_⟩
   simpa only [continuousWithinAt_compl_self, continuousAt_update_same]
     using LFunctionTrivChar_residue_one
@@ -359,9 +355,8 @@ lemma deriv_LFunctionTrivChar₁_apply_of_ne_one {s : ℂ} (hs : s ≠ 1) :
       (s - 1) * deriv (LFunctionTrivChar n) s + LFunctionTrivChar n s := by
   have H : deriv (LFunctionTrivChar₁ n) s =
       deriv (fun w ↦ (w - 1) * LFunctionTrivChar n w) s := by
-    refine Filter.eventuallyEq_iff_exists_mem.mpr ?_ |>.deriv_eq
-    exact ⟨{w | w ≠ 1}, IsOpen.mem_nhds isOpen_ne hs,
-      fun w hw ↦ LFunctionTrivChar₁_apply_of_ne_one n (Set.mem_setOf.mp hw)⟩
+    refine eventuallyEq_iff_exists_mem.mpr ?_ |>.deriv_eq
+    exact ⟨_, isOpen_ne.mem_nhds hs, fun _ hw ↦ Function.update_noteq (Set.mem_setOf.mp hw) ..⟩
   rw [H, deriv_mul (by fun_prop) (differentiableAt_LFunction _ s (.inl hs)), deriv_sub_const,
     deriv_id'', one_mul, add_comm]
 
@@ -376,7 +371,7 @@ lemma continuousOn_neg_logDeriv_LFunctionTrivChar₁ :
     h.continuous.continuousOn fun w hw ↦ ?_).neg
   rcases eq_or_ne w 1 with rfl | hw'
   · exact LFunctionTrivChar₁_apply_one_ne_zero _
-  · rw [LFunctionTrivChar₁_apply_of_ne_one n hw', mul_ne_zero_iff]
+  · rw [LFunctionTrivChar₁, Function.update_noteq hw', mul_ne_zero_iff]
     exact ⟨sub_ne_zero_of_ne hw', (Set.mem_setOf.mp hw).resolve_left hw'⟩
 
 end trivial
@@ -389,7 +384,7 @@ variable {n : ℕ} [NeZero n] {χ : DirichletCharacter ℂ n}
 is continuous away from the zeros of the L-function. -/
 lemma continuousOn_neg_logDeriv_LFunction_of_nontriv (hχ : χ ≠ 1) :
     ContinuousOn (fun s ↦ -deriv (LFunction χ) s / LFunction χ s) {s | LFunction χ s ≠ 0} := by
-  simp_rw [neg_div]
+  simp only [neg_div]
   have h := differentiable_LFunction hχ
   exact ((h.contDiff.continuous_deriv le_rfl).continuousOn.div
     h.continuous.continuousOn fun _ hw ↦ hw).neg

--- a/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
+++ b/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
@@ -344,7 +344,7 @@ lemma LFunctionTrivChar₁_apply_one_ne_zero : LFunctionTrivChar₁ n 1 ≠ 0 :=
   exact_mod_cast (Nat.prime_of_mem_primeFactors hp).ne_one
 
 /-- `s ↦ (s - 1) * L χ s` is an entire function when `χ` is a trivial Dirichlet character. -/
-lemma LFunctionTrivChar₁_differentiable : Differentiable ℂ (LFunctionTrivChar₁ n) := by
+lemma differentiable_LFunctionTrivChar₁ : Differentiable ℂ (LFunctionTrivChar₁ n) := by
   rw [← differentiableOn_univ,
     ← differentiableOn_compl_singleton_and_continuousAt_iff (c := 1) Filter.univ_mem]
   refine ⟨DifferentiableOn.congr (f := fun s ↦ (s - 1) * LFunctionTrivChar n s)
@@ -371,7 +371,7 @@ lemma continuousOn_neg_logDeriv_LFunctionTrivChar₁ :
     ContinuousOn (fun s ↦ -deriv (LFunctionTrivChar₁ n) s / LFunctionTrivChar₁ n s)
       {s | s = 1 ∨ LFunctionTrivChar n s ≠ 0} := by
   simp_rw [neg_div]
-  have h := LFunctionTrivChar₁_differentiable n
+  have h := differentiable_LFunctionTrivChar₁ n
   refine ((h.contDiff.continuous_deriv le_rfl).continuousOn.div
     h.continuous.continuousOn fun w hw ↦ ?_).neg
   rcases eq_or_ne w 1 with rfl | hw'

--- a/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
+++ b/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
@@ -115,7 +115,7 @@ lemma Even.LFunction_neg_two_mul_nat {χ : DirichletCharacter ℂ N} (hχ : Even
   ZMod.LFunction_neg_two_mul_nat_sub_one hχ.to_fun n
 
 /-!
-## Results on changing levels
+### Results on changing levels
 -/
 
 private lemma LFunction_changeLevel_aux {M N : ℕ} [NeZero M] [NeZero N] (hMN : M ∣ N)
@@ -158,7 +158,7 @@ lemma LFunction_changeLevel {M N : ℕ} [NeZero M] [NeZero N] (hMN : M ∣ N)
   · exact LFunction_changeLevel_aux hMN χ h
 
 /-!
-## The `L`-function of the trivial character mod `N`
+### The `L`-function of the trivial character mod `N`
 -/
 
 /-- The `L`-function of the trivial character mod `N`. -/
@@ -191,7 +191,7 @@ lemma LFunctionTrivChar_residue_one :
     fun_prop
 
 /-!
-## Completed L-functions and the functional equation
+### Completed L-functions and the functional equation
 -/
 
 section gammaFactor

--- a/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
+++ b/Mathlib/NumberTheory/LSeries/DirichletContinuation.lean
@@ -343,7 +343,7 @@ lemma LFunctionTrivChar₁_apply_one_ne_zero : LFunctionTrivChar₁ n 1 ≠ 0 :=
   rw [sub_ne_zero, ne_eq, one_eq_inv]
   exact_mod_cast (Nat.prime_of_mem_primeFactors hp).ne_one
 
-/-- `s ↦ (L χ s) * (s - 1)` is an entire function when `χ` is a trivial Dirichlet character. -/
+/-- `s ↦ (s - 1) * L χ s` is an entire function when `χ` is a trivial Dirichlet character. -/
 lemma LFunctionTrivChar₁_differentiable : Differentiable ℂ (LFunctionTrivChar₁ n) := by
   rw [← differentiableOn_univ,
     ← differentiableOn_compl_singleton_and_continuousAt_iff (c := 1) Filter.univ_mem]


### PR DESCRIPTION
As a further step in the direction of Dirichlet's Theorem on primes in AP, this PR adds results on (negative) logarithmic derivatives of `L χ` for a non-trivial Dirichlet character `χ` and of `s ↦ (L χ s) * (s - 1)` when `χ` is trivial.

See [here on Zulip](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/Prerequisites.20for.20PNT.20and.20Dirichlet's.20Thm/near/482543603).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
