### PR TITLE
[Merged by Bors] - feat: `S ^ n = S` where `S` is a submonoid

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -67,10 +67,23 @@ lemma mul_subgroupClosure (hs : s.Nonempty) : s * closure s = closure s := by
     smul_coe_set <| subset_closure ha
   simp +contextual [h, hs]
 
+open scoped RightActions in
 @[to_additive (attr := simp)]
-lemma mul_subgroupClosure_pow (hs : s.Nonempty) : ∀ n, s ^ n * closure s = closure s
+lemma subgroupClosure_mul (hs : s.Nonempty) : closure s * s = closure s := by
+  rw [← Set.iUnion_op_smul_set]
+  have h a (ha : a ∈ s) :  (closure s : Set G) <• a = closure s :=
+    op_smul_coe_set <| subset_closure ha
+  simp +contextual [h, hs]
+
+@[to_additive (attr := simp)]
+lemma pow_mul_subgroupClosure (hs : s.Nonempty) : ∀ n, s ^ n * closure s = closure s
   | 0 => by simp
-  | n + 1 => by rw [pow_add, pow_one, mul_assoc, mul_subgroupClosure hs, mul_subgroupClosure_pow hs]
+  | n + 1 => by rw [pow_succ, mul_assoc, mul_subgroupClosure hs, pow_mul_subgroupClosure hs]
+
+@[to_additive (attr := simp)]
+lemma subgroupClosure_mul_pow (hs : s.Nonempty) : ∀ n, closure s * s ^ n = closure s
+  | 0 => by simp
+  | n + 1 => by rw [pow_succ', ← mul_assoc, subgroupClosure_mul hs, subgroupClosure_mul_pow hs]
 
 end Set
 

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -51,14 +51,28 @@ lemma op_smul_coe_set [Group G] [SetLike S G] [SubgroupClass S G] {s : S} {a : G
   ext; simp [Set.mem_smul_set_iff_inv_smul_mem, mul_mem_cancel_right, ha]
 
 @[to_additive (attr := simp, norm_cast)]
-lemma coe_mul_coe [SetLike S G] [DivInvMonoid G] [SubgroupClass S G] (H : S) :
-    H * H = (H : Set G) := by aesop (add simp mem_mul)
-
-@[to_additive (attr := simp, norm_cast)]
 lemma coe_div_coe [SetLike S G] [DivisionMonoid G] [SubgroupClass S G] (H : S) :
     H / H = (H : Set G) := by simp [div_eq_mul_inv]
 
 variable [Group G] [AddGroup A] {s : Set G}
+
+namespace Set
+
+open Subgroup
+
+@[to_additive (attr := simp)]
+lemma mul_subgroupClosure (hs : s.Nonempty) : s * closure s = closure s := by
+  rw [← smul_eq_mul, ← Set.iUnion_smul_set]
+  have h a (ha : a ∈ s) : a • (closure s : Set G) = closure s :=
+    smul_coe_set <| subset_closure ha
+  simp (config := {contextual := true}) [h, hs]
+
+@[to_additive (attr := simp)]
+lemma mul_subgroupClosure_pow (hs : s.Nonempty) : ∀ n, s ^ n * closure s = closure s
+  | 0 => by simp
+  | n + 1 => by rw [pow_add, pow_one, mul_assoc, mul_subgroupClosure hs, mul_subgroupClosure_pow hs]
+
+end Set
 
 namespace Subgroup
 

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -65,7 +65,7 @@ lemma mul_subgroupClosure (hs : s.Nonempty) : s * closure s = closure s := by
   rw [← smul_eq_mul, ← Set.iUnion_smul_set]
   have h a (ha : a ∈ s) : a • (closure s : Set G) = closure s :=
     smul_coe_set <| subset_closure ha
-  simp (config := {contextual := true}) [h, hs]
+  simp +contextual [h, hs]
 
 @[to_additive (attr := simp)]
 lemma mul_subgroupClosure_pow (hs : s.Nonempty) : ∀ n, s ^ n * closure s = closure s

--- a/Mathlib/Algebra/Group/Submonoid/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Pointwise.lean
@@ -53,8 +53,19 @@ way to `Module`).
 
 open Set Pointwise
 
-variable {α : Type*} {G : Type*} {M : Type*} {R : Type*} {A : Type*}
+variable {α G M R A S : Type*}
 variable [Monoid M] [AddMonoid A]
+
+@[to_additive (attr := simp, norm_cast)]
+lemma coe_mul_coe [SetLike S M] [SubmonoidClass S M] (H : S) : H * H = (H : Set M) := by
+  aesop (add simp mem_mul)
+
+set_option linter.unusedVariables false in
+@[to_additive (attr := simp)]
+lemma coe_set_pow [SetLike S M] [SubmonoidClass S M] :
+    ∀ {n} (hn : n ≠ 0) (H : S), (H ^ n : Set M) = H
+  | 1, _, H => by simp
+  | n + 2, _, H => by rw [pow_succ, coe_set_pow n.succ_ne_zero, coe_mul_coe]
 
 /-! Some lemmas about pointwise multiplication and submonoids. Ideally we put these in
   `GroupTheory.Submonoid.Basic`, but currently we cannot because that file is imported by this. -/


### PR DESCRIPTION
From GrowthInGroups


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
