### PR TITLE
[Merged by Bors] - feat(CI): add a log of the size of the oleans

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -183,6 +183,10 @@ jobs:
             lake build --no-build
           fi
 
+      - name: print the sizes of the oleans
+        run: |
+          du .lake/build/lib/Mathlib
+
       - name: build archive
         id: archive
         run: |

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -156,6 +156,10 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
+      - name: print the sizes of the oleans
+        run: |
+          du .lake/build/lib/Mathlib || echo "This code should be unreachable"
+
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
         # but not if any earlier step failed or was cancelled.
@@ -182,10 +186,6 @@ jobs:
             lake exe cache get || (sleep 1; lake exe cache get)
             lake build --no-build
           fi
-
-      - name: print the sizes of the oleans
-        run: |
-          du .lake/build/lib/Mathlib || echo "This code should be unreachable"
 
       - name: build archive
         id: archive

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/Mathlib
+          du .lake/build/lib/Mathlib || echo "This code should be unreachable"
 
       - name: build archive
         id: archive

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -166,6 +166,10 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
+      - name: print the sizes of the oleans
+        run: |
+          du .lake/build/lib/Mathlib || echo "This code should be unreachable"
+
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
         # but not if any earlier step failed or was cancelled.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,10 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
+      - name: print the sizes of the oleans
+        run: |
+          du .lake/build/lib/Mathlib || echo "This code should be unreachable"
+
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
         # but not if any earlier step failed or was cancelled.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -170,6 +170,10 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
+      - name: print the sizes of the oleans
+        run: |
+          du .lake/build/lib/Mathlib || echo "This code should be unreachable"
+
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
         # but not if any earlier step failed or was cancelled.


### PR DESCRIPTION
Split off from #16020: it only adds a step that computes the sizes of the oleans.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
