### PR TITLE
[Merged by Bors] - feat: `Measure.count s = 0 ↔ s = ∅` unconditionally

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Count.lean
+++ b/Mathlib/MeasureTheory/Measure/Count.lean
@@ -98,33 +98,21 @@ theorem count_apply_lt_top [MeasurableSingletonClass α] : count s < ∞ ↔ s.F
     _ ↔ ¬s.Infinite := not_congr count_apply_eq_top
     _ ↔ s.Finite := Classical.not_not
 
-theorem empty_of_count_eq_zero' (s_mble : MeasurableSet s) (hsc : count s = 0) : s = ∅ := by
-  have hs : s.Finite := by
-    rw [← count_apply_lt_top' s_mble, hsc]
-    exact WithTop.top_pos
-  simpa [count_apply_finite' hs s_mble] using hsc
-
-theorem empty_of_count_eq_zero [MeasurableSingletonClass α] (hsc : count s = 0) : s = ∅ := by
-  have hs : s.Finite := by
-    rw [← count_apply_lt_top, hsc]
-    exact WithTop.top_pos
-  simpa [count_apply_finite _ hs] using hsc
-
 @[simp]
-theorem count_eq_zero_iff' (s_mble : MeasurableSet s) : count s = 0 ↔ s = ∅ :=
-  ⟨empty_of_count_eq_zero' s_mble, fun h => h.symm ▸ count_empty⟩
+theorem count_eq_zero_iff : count s = 0 ↔ s = ∅ where
+  mp h := eq_empty_of_forall_not_mem fun x hx ↦ by
+    simpa [hx] using ((ENNReal.le_tsum x).trans <| le_sum_apply _ _).trans_eq h
+  mpr := by rintro rfl; exact count_empty
 
-@[simp]
-theorem count_eq_zero_iff [MeasurableSingletonClass α] : count s = 0 ↔ s = ∅ :=
-  ⟨empty_of_count_eq_zero, fun h => h.symm ▸ count_empty⟩
+lemma count_ne_zero_iff : count s ≠ 0 ↔ s.Nonempty :=
+  count_eq_zero_iff.not.trans nonempty_iff_ne_empty.symm
 
-theorem count_ne_zero' (hs' : s.Nonempty) (s_mble : MeasurableSet s) : count s ≠ 0 := by
-  rw [Ne, count_eq_zero_iff' s_mble]
-  exact hs'.ne_empty
+alias ⟨_, count_ne_zero⟩ := count_ne_zero_iff
 
-theorem count_ne_zero [MeasurableSingletonClass α] (hs' : s.Nonempty) : count s ≠ 0 := by
-  rw [Ne, count_eq_zero_iff]
-  exact hs'.ne_empty
+@[deprecated (since := "2024-11-20")] alias ⟨empty_of_count_eq_zero, _⟩ := count_eq_zero_iff
+@[deprecated (since := "2024-11-20")] alias empty_of_count_eq_zero' := empty_of_count_eq_zero
+@[deprecated (since := "2024-11-20")] alias count_eq_zero_iff' := count_eq_zero_iff
+@[deprecated (since := "2024-11-20")] alias count_ne_zero' := count_ne_zero
 
 @[simp]
 theorem count_singleton' {a : α} (ha : MeasurableSet ({a} : Set α)) : count ({a} : Set α) = 1 := by

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -748,6 +748,11 @@ theorem coe_zero {_m : MeasurableSpace α} : ⇑(0 : Measure α) = 0 :=
   ext s hs
   simp [hs]
 
+@[simp] lemma _root_.MeasureTheory.OuterMeasure.toMeasure_eq_zero {ms : MeasurableSpace α}
+    {μ : OuterMeasure α} (h : ms ≤ μ.caratheodory) : μ.toMeasure h = 0 ↔ μ = 0 where
+  mp hμ := by ext s; exact le_bot_iff.1 <| (le_toMeasure_apply _ _ _).trans_eq congr($hμ s)
+  mpr := by rintro rfl; simp
+
 @[nontriviality]
 lemma apply_eq_zero_of_isEmpty [IsEmpty α] {_ : MeasurableSpace α} (μ : Measure α) (s : Set α) :
     μ s = 0 := by
@@ -1274,10 +1279,11 @@ theorem sum_apply₀ (f : ι → Measure α) {s : Set α} (hs : NullMeasurableSe
 /-! For the next theorem, the countability assumption is necessary. For a counterexample, consider
 an uncountable space, with a distinguished point `x₀`, and the sigma-algebra made of countable sets
 not containing `x₀`, and their complements. All points but `x₀` are measurable.
-Consider the sum of the Dirac masses at points different from `x₀`, and `s = x₀`. For any Dirac mass
-`δ_x`, we have `δ_x (x₀) = 0`, so `∑' x, δ_x (x₀) = 0`. On the other hand, the measure `sum δ_x`
-gives mass one to each point different from `x₀`, so it gives infinite mass to any measurable set
-containing `x₀` (as such a set is uncountable), and by outer regularity one get `sum δ_x {x₀} = ∞`.
+Consider the sum of the Dirac masses at points different from `x₀`, and `s = {x₀}`. For any Dirac
+mass `δ_x`, we have `δ_x (x₀) = 0`, so `∑' x, δ_x (x₀) = 0`. On the other hand, the measure
+`sum δ_x` gives mass one to each point different from `x₀`, so it gives infinite mass to any
+measurable set containing `x₀` (as such a set is uncountable), and by outer regularity one gets
+`sum δ_x {x₀} = ∞`.
 -/
 theorem sum_apply_of_countable [Countable ι] (f : ι → Measure α) (s : Set α) :
     sum f s = ∑' i, f i s := by

--- a/Mathlib/Probability/UniformOn.lean
+++ b/Mathlib/Probability/UniformOn.lean
@@ -42,7 +42,7 @@ open MeasureTheory MeasurableSpace
 
 namespace ProbabilityTheory
 
-variable {Ω : Type*} [MeasurableSpace Ω]
+variable {Ω : Type*} [MeasurableSpace Ω] {s : Set Ω}
 
 /-- Given a set `s`, `uniformOn s` is the uniform measure on `s`, defined as the counting measure
 conditioned by `s`. One should think of `uniformOn s t` as the proportion of `s` that is contained
@@ -70,6 +70,16 @@ theorem uniformOn_empty {s : Set Ω} : uniformOn s ∅ = 0 := by simp
 @[deprecated (since := "2024-10-09")]
 alias condCount_empty := uniformOn_empty
 
+/-- See `uniformOn_eq_zero` for a version assuming `MeasurableSingletonClass Ω` instead of
+`MeasurableSet s`. -/
+@[simp] lemma uniformOn_eq_zero' (hs : MeasurableSet s) : uniformOn s = 0 ↔ s.Infinite ∨ s = ∅ := by
+  simp [uniformOn, hs]
+
+/-- See `uniformOn_eq_zero'` for a version assuming `MeasurableSet s` instead of
+`MeasurableSingletonClass Ω`. -/
+@[simp] lemma uniformOn_eq_zero [MeasurableSingletonClass Ω] :
+    uniformOn s = 0 ↔ s.Infinite ∨ s = ∅ := by simp [uniformOn]
+
 theorem finite_of_uniformOn_ne_zero {s t : Set Ω} (h : uniformOn s t ≠ 0) : s.Finite := by
   by_contra hs'
   simp [uniformOn, cond, Measure.count_apply_infinite hs'] at h
@@ -93,7 +103,7 @@ variable [MeasurableSingletonClass Ω]
 theorem uniformOn_isProbabilityMeasure {s : Set Ω} (hs : s.Finite) (hs' : s.Nonempty) :
     IsProbabilityMeasure (uniformOn s) := by
   apply cond_isProbabilityMeasure_of_finite
-  · exact fun h => hs'.ne_empty <| Measure.empty_of_count_eq_zero h
+  · rwa [Measure.count_ne_zero_iff]
   · exact (Measure.count_apply_lt_top.2 hs).ne
 
 @[deprecated (since := "2024-10-09")]
@@ -120,7 +130,7 @@ alias condCount_inter_self := uniformOn_inter_self
 
 theorem uniformOn_self (hs : s.Finite) (hs' : s.Nonempty) : uniformOn s s = 1 := by
   rw [uniformOn, cond_apply hs.measurableSet, Set.inter_self, ENNReal.inv_mul_cancel]
-  · exact fun h => hs'.ne_empty <| Measure.empty_of_count_eq_zero h
+  · rwa [Measure.count_ne_zero_iff]
   · exact (Measure.count_apply_lt_top.2 hs).ne
 
 @[deprecated (since := "2024-10-09")]


### PR DESCRIPTION
By moving cases around, we can remove all side conditions from the lemma stating `count s = 0 ↔ s = ∅`. As a result, a few pairs of lemmas are unified.

From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
