### PR TITLE
[Merged by Bors] - fix: move `Y` notation into a deeper scope

### DIFF
--- a/Mathlib/Algebra/Polynomial/Bivariate.lean
+++ b/Mathlib/Algebra/Polynomial/Bivariate.lean
@@ -17,10 +17,12 @@ the abbreviation `CC` to view a constant in the base ring `R` as a bivariate pol
 -/
 
 /-- The notation `Y` for `X` in the `Polynomial` scope. -/
-scoped[Polynomial] notation3:max "Y" => Polynomial.X (R := Polynomial _)
+scoped[Polynomial.Bivariate] notation3:max "Y" => Polynomial.X (R := Polynomial _)
 
 /-- The notation `R[X][Y]` for `R[X][X]` in the `Polynomial` scope. -/
-scoped[Polynomial] notation3:max R "[X][Y]" => Polynomial (Polynomial R)
+scoped[Polynomial.Bivariate] notation3:max R "[X][Y]" => Polynomial (Polynomial R)
+
+open scoped Polynomial.Bivariate
 
 namespace Polynomial
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
@@ -81,6 +81,7 @@ elliptic curve, rational point, affine coordinates
 -/
 
 open Polynomial
+open scoped Polynomial.Bivariate
 
 local macro "C_simp" : tactic =>
   `(tactic| simp only [map_ofNat, C_0, C_1, C_neg, C_add, C_sub, C_mul, C_pow])

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
@@ -95,6 +95,7 @@ elliptic curve, division polynomial, torsion point
 -/
 
 open Polynomial
+open scoped Polynomial.Bivariate
 
 local macro "C_simp" : tactic =>
   `(tactic| simp only [map_ofNat, C_0, C_1, C_neg, C_add, C_sub, C_mul, C_pow])

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Group.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Group.lean
@@ -62,6 +62,7 @@ elliptic curve, group law, class group
 -/
 
 open Ideal nonZeroDivisors Polynomial
+open scoped Polynomial.Bivariate
 
 local macro "C_simp" : tactic =>
   `(tactic| simp only [map_ofNat, C_0, C_1, C_neg, C_add, C_sub, C_mul, C_pow])


### PR DESCRIPTION
Otherwise this aggressively claims the `Y` notation in places where the intent may only be to access `Polynomial.X`.

An alternative would be to make `Y` an `abbrev`, which would cause it to participate in regular name resolution, allowing local variables to be called `Y`.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Aggressive.20notation.2C.20Y/near/483466695)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
