### PR TITLE
[Merged by Bors] - chore: remove the `Smooth` alias for infinitely differentiable functions between manifolds

### DIFF
--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Manifold.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Manifold.lean
@@ -26,15 +26,17 @@ instance : SmoothManifoldWithCorners 𝓘(ℂ) ℍ :=
   UpperHalfPlane.isOpenEmbedding_coe.singleton_smoothManifoldWithCorners
 
 /-- The inclusion map `ℍ → ℂ` is a smooth map of manifolds. -/
-theorem smooth_coe : Smooth 𝓘(ℂ) 𝓘(ℂ) ((↑) : ℍ → ℂ) := fun _ => contMDiffAt_extChartAt
+theorem contMDiff_coe : ContMDiff 𝓘(ℂ) 𝓘(ℂ) ⊤ ((↑) : ℍ → ℂ) := fun _ => contMDiffAt_extChartAt
+
+@[deprecated (since := "2024-11-20")] alias smooth_coe := contMDiff_coe
 
 /-- The inclusion map `ℍ → ℂ` is a differentiable map of manifolds. -/
 theorem mdifferentiable_coe : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) ((↑) : ℍ → ℂ) :=
-  smooth_coe.mdifferentiable
+  contMDiff_coe.mdifferentiable (by simp)
 
-lemma smoothAt_ofComplex {z : ℂ} (hz : 0 < z.im) :
-    SmoothAt 𝓘(ℂ) 𝓘(ℂ) ofComplex z := by
-  rw [SmoothAt, contMDiffAt_iff]
+lemma contMDiffAt_ofComplex {z : ℂ} (hz : 0 < z.im) :
+    ContMDiffAt 𝓘(ℂ) 𝓘(ℂ) ⊤ ofComplex z := by
+  rw [contMDiffAt_iff]
   constructor
   · -- continuity at z
     rw [ContinuousAt, nhds_induced, tendsto_comap_iff]
@@ -48,9 +50,11 @@ lemma smoothAt_ofComplex {z : ℂ} (hz : 0 < z.im) :
       Set.range_id, id_eq, contDiffWithinAt_univ]
     exact contDiffAt_id.congr_of_eventuallyEq (eventuallyEq_coe_comp_ofComplex hz)
 
+@[deprecated (since := "2024-11-20")] alias smoothAt_ofComplex := contMDiffAt_ofComplex
+
 lemma mdifferentiableAt_ofComplex {z : ℂ} (hz : 0 < z.im) :
     MDifferentiableAt 𝓘(ℂ) 𝓘(ℂ) ofComplex z :=
-  (smoothAt_ofComplex hz).mdifferentiableAt
+  (contMDiffAt_ofComplex hz).mdifferentiableAt (by simp)
 
 lemma mdifferentiableAt_iff {f : ℍ → ℂ} {τ : ℍ} :
     MDifferentiableAt 𝓘(ℂ) 𝓘(ℂ) f τ ↔ DifferentiableAt ℂ (f ∘ ofComplex) ↑τ := by

--- a/Mathlib/Analysis/Distribution/AEEqOfIntegralContDiff.lean
+++ b/Mathlib/Analysis/Distribution/AEEqOfIntegralContDiff.lean
@@ -40,7 +40,7 @@ variable {H : Type*} [TopologicalSpace H] (I : ModelWithCorners ℝ E H)
 when multiplied by any smooth compactly supported function, then `f` vanishes almost everywhere. -/
 theorem ae_eq_zero_of_integral_smooth_smul_eq_zero [SigmaCompactSpace M]
     (hf : LocallyIntegrable f μ)
-    (h : ∀ g : M → ℝ, Smooth I 𝓘(ℝ) g → HasCompactSupport g → ∫ x, g x • f x ∂μ = 0) :
+    (h : ∀ g : M → ℝ, ContMDiff I 𝓘(ℝ) ⊤ g → HasCompactSupport g → ∫ x, g x • f x ∂μ = 0) :
     ∀ᵐ x ∂μ, f x = 0 := by
   -- record topological properties of `M`
   have := I.locallyCompactSpace
@@ -60,7 +60,7 @@ theorem ae_eq_zero_of_integral_smooth_smul_eq_zero [SigmaCompactSpace M]
   let v : ℕ → Set M := fun n ↦ thickening (u n) s
   obtain ⟨K, K_compact, vK⟩ : ∃ K, IsCompact K ∧ ∀ n, v n ⊆ K :=
     ⟨_, hδ, fun n ↦ thickening_subset_cthickening_of_le (u_pos n).2.le _⟩
-  have : ∀ n, ∃ (g : M → ℝ), support g = v n ∧ Smooth I 𝓘(ℝ) g ∧ Set.range g ⊆ Set.Icc 0 1
+  have : ∀ n, ∃ (g : M → ℝ), support g = v n ∧ ContMDiff I 𝓘(ℝ) ⊤ g ∧ Set.range g ⊆ Set.Icc 0 1
           ∧ ∀ x ∈ s, g x = 1 := by
     intro n
     rcases exists_msmooth_support_eq_eq_one_iff I isOpen_thickening hs.isClosed
@@ -121,7 +121,7 @@ instance (U : Opens M) : BorelSpace U := inferInstanceAs (BorelSpace (U : Set M)
 nonrec theorem IsOpen.ae_eq_zero_of_integral_smooth_smul_eq_zero' {U : Set M} (hU : IsOpen U)
     (hSig : IsSigmaCompact U) (hf : LocallyIntegrableOn f U μ)
     (h : ∀ g : M → ℝ,
-      Smooth I 𝓘(ℝ) g → HasCompactSupport g → tsupport g ⊆ U → ∫ x, g x • f x ∂μ = 0) :
+      ContMDiff I 𝓘(ℝ) ⊤ g → HasCompactSupport g → tsupport g ⊆ U → ∫ x, g x • f x ∂μ = 0) :
     ∀ᵐ x ∂μ, x ∈ U → f x = 0 := by
   have meas_U := hU.measurableSet
   rw [← ae_restrict_iff' meas_U, ae_restrict_iff_subtype meas_U]
@@ -146,7 +146,7 @@ variable [SigmaCompactSpace M]
 theorem IsOpen.ae_eq_zero_of_integral_smooth_smul_eq_zero {U : Set M} (hU : IsOpen U)
     (hf : LocallyIntegrableOn f U μ)
     (h : ∀ g : M → ℝ,
-      Smooth I 𝓘(ℝ) g → HasCompactSupport g → tsupport g ⊆ U → ∫ x, g x • f x ∂μ = 0) :
+      ContMDiff I 𝓘(ℝ) ⊤ g → HasCompactSupport g → tsupport g ⊆ U → ∫ x, g x • f x ∂μ = 0) :
     ∀ᵐ x ∂μ, x ∈ U → f x = 0 :=
   haveI := I.locallyCompactSpace
   haveI := ChartedSpace.locallyCompactSpace H M
@@ -160,7 +160,7 @@ theorem IsOpen.ae_eq_zero_of_integral_smooth_smul_eq_zero {U : Set M} (hU : IsOp
 when multiplied by any smooth compactly supported function, then they coincide almost everywhere. -/
 theorem ae_eq_of_integral_smooth_smul_eq
     (hf : LocallyIntegrable f μ) (hf' : LocallyIntegrable f' μ) (h : ∀ (g : M → ℝ),
-      Smooth I 𝓘(ℝ) g → HasCompactSupport g → ∫ x, g x • f x ∂μ = ∫ x, g x • f' x ∂μ) :
+      ContMDiff I 𝓘(ℝ) ⊤ g → HasCompactSupport g → ∫ x, g x • f x ∂μ = ∫ x, g x • f' x ∂μ) :
     ∀ᵐ x ∂μ, f x = f' x := by
   have : ∀ᵐ x ∂μ, (f - f') x = 0 := by
     apply ae_eq_zero_of_integral_smooth_smul_eq_zero I (hf.sub hf')

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -58,7 +58,7 @@ class LieAddGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [Top
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] (I : ModelWithCorners 𝕜 E H) (G : Type*)
     [AddGroup G] [TopologicalSpace G] [ChartedSpace H G] extends SmoothAdd I G : Prop where
   /-- Negation is smooth in an additive Lie group. -/
-  smooth_neg : Smooth I I fun a : G => -a
+  smooth_neg : ContMDiff I I ⊤ fun a : G => -a
 
 -- See note [Design choices about smooth algebraic structures]
 /-- A (multiplicative) Lie group is a group and a smooth manifold at the same time in which
@@ -68,7 +68,7 @@ class LieGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [Topolo
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] (I : ModelWithCorners 𝕜 E H) (G : Type*)
     [Group G] [TopologicalSpace G] [ChartedSpace H G] extends SmoothMul I G : Prop where
   /-- Inversion is smooth in a Lie group. -/
-  smooth_inv : Smooth I I fun a : G => a⁻¹
+  smooth_inv : ContMDiff I I ⊤ fun a : G => a⁻¹
 
 /-!
   ### Smoothness of inversion, negation, division and subtraction
@@ -91,8 +91,11 @@ variable (I)
 
 /-- In a Lie group, inversion is a smooth map. -/
 @[to_additive "In an additive Lie group, inversion is a smooth map."]
-theorem smooth_inv : Smooth I I fun x : G => x⁻¹ :=
+theorem contMDiff_inv : ContMDiff I I ⊤ fun x : G => x⁻¹ :=
   LieGroup.smooth_inv
+
+@[deprecated (since := "2024-11-21")] alias smooth_inv := contMDiff_inv
+@[deprecated (since := "2024-11-21")] alias smooth_neg := contMDiff_neg
 
 include I in
 /-- A Lie group is a topological group. This is not an instance for technical reasons,
@@ -100,19 +103,19 @@ see note [Design choices about smooth algebraic structures]. -/
 @[to_additive "An additive Lie group is an additive topological group. This is not an instance for
 technical reasons, see note [Design choices about smooth algebraic structures]."]
 theorem topologicalGroup_of_lieGroup : TopologicalGroup G :=
-  { continuousMul_of_smooth I with continuous_inv := (smooth_inv I).continuous }
+  { continuousMul_of_smooth I with continuous_inv := (contMDiff_inv I).continuous }
 
 end
 
 @[to_additive]
 theorem ContMDiffWithinAt.inv {f : M → G} {s : Set M} {x₀ : M}
     (hf : ContMDiffWithinAt I' I n f s x₀) : ContMDiffWithinAt I' I n (fun x => (f x)⁻¹) s x₀ :=
-  ((smooth_inv I).of_le le_top).contMDiffAt.contMDiffWithinAt.comp x₀ hf <| Set.mapsTo_univ _ _
+  ((contMDiff_inv I).of_le le_top).contMDiffAt.contMDiffWithinAt.comp x₀ hf <| Set.mapsTo_univ _ _
 
 @[to_additive]
 theorem ContMDiffAt.inv {f : M → G} {x₀ : M} (hf : ContMDiffAt I' I n f x₀) :
     ContMDiffAt I' I n (fun x => (f x)⁻¹) x₀ :=
-  ((smooth_inv I).of_le le_top).contMDiffAt.comp x₀ hf
+  ((contMDiff_inv I).of_le le_top).contMDiffAt.comp x₀ hf
 
 @[to_additive]
 theorem ContMDiffOn.inv {f : M → G} {s : Set M} (hf : ContMDiffOn I' I n f s) :
@@ -122,24 +125,15 @@ theorem ContMDiffOn.inv {f : M → G} {s : Set M} (hf : ContMDiffOn I' I n f s) 
 theorem ContMDiff.inv {f : M → G} (hf : ContMDiff I' I n f) : ContMDiff I' I n fun x => (f x)⁻¹ :=
   fun x => (hf x).inv
 
-@[to_additive]
-nonrec theorem SmoothWithinAt.inv {f : M → G} {s : Set M} {x₀ : M}
-    (hf : SmoothWithinAt I' I f s x₀) : SmoothWithinAt I' I (fun x => (f x)⁻¹) s x₀ :=
-  hf.inv
+@[deprecated (since := "2024-11-21")] alias SmoothWithinAt.inv := ContMDiffWithinAt.inv
+@[deprecated (since := "2024-11-21")] alias SmoothAt.inv := ContMDiffAt.inv
+@[deprecated (since := "2024-11-21")] alias SmoothOn.inv := ContMDiffOn.inv
+@[deprecated (since := "2024-11-21")] alias Smooth.inv := ContMDiff.inv
 
-@[to_additive]
-nonrec theorem SmoothAt.inv {f : M → G} {x₀ : M} (hf : SmoothAt I' I f x₀) :
-    SmoothAt I' I (fun x => (f x)⁻¹) x₀ :=
-  hf.inv
-
-@[to_additive]
-nonrec theorem SmoothOn.inv {f : M → G} {s : Set M} (hf : SmoothOn I' I f s) :
-    SmoothOn I' I (fun x => (f x)⁻¹) s :=
-  hf.inv
-
-@[to_additive]
-nonrec theorem Smooth.inv {f : M → G} (hf : Smooth I' I f) : Smooth I' I fun x => (f x)⁻¹ :=
-  hf.inv
+@[deprecated (since := "2024-11-21")] alias SmoothWithinAt.neg := ContMDiffWithinAt.neg
+@[deprecated (since := "2024-11-21")] alias SmoothAt.neg := ContMDiffAt.neg
+@[deprecated (since := "2024-11-21")] alias SmoothOn.neg := ContMDiffOn.neg
+@[deprecated (since := "2024-11-21")] alias Smooth.neg := ContMDiff.neg
 
 @[to_additive]
 theorem ContMDiffWithinAt.div {f g : M → G} {s : Set M} {x₀ : M}
@@ -161,26 +155,15 @@ theorem ContMDiffOn.div {f g : M → G} {s : Set M} (hf : ContMDiffOn I' I n f s
 theorem ContMDiff.div {f g : M → G} (hf : ContMDiff I' I n f) (hg : ContMDiff I' I n g) :
     ContMDiff I' I n fun x => f x / g x := by simp_rw [div_eq_mul_inv]; exact hf.mul hg.inv
 
-@[to_additive]
-nonrec theorem SmoothWithinAt.div {f g : M → G} {s : Set M} {x₀ : M}
-    (hf : SmoothWithinAt I' I f s x₀) (hg : SmoothWithinAt I' I g s x₀) :
-    SmoothWithinAt I' I (fun x => f x / g x) s x₀ :=
-  hf.div hg
+@[deprecated (since := "2024-11-21")] alias SmoothWithinAt.div := ContMDiffWithinAt.div
+@[deprecated (since := "2024-11-21")] alias SmoothAt.div := ContMDiffAt.div
+@[deprecated (since := "2024-11-21")] alias SmoothOn.div := ContMDiffOn.div
+@[deprecated (since := "2024-11-21")] alias Smooth.div := ContMDiff.div
 
-@[to_additive]
-nonrec theorem SmoothAt.div {f g : M → G} {x₀ : M} (hf : SmoothAt I' I f x₀)
-    (hg : SmoothAt I' I g x₀) : SmoothAt I' I (fun x => f x / g x) x₀ :=
-  hf.div hg
-
-@[to_additive]
-nonrec theorem SmoothOn.div {f g : M → G} {s : Set M} (hf : SmoothOn I' I f s)
-    (hg : SmoothOn I' I g s) : SmoothOn I' I (f / g) s :=
-  hf.div hg
-
-@[to_additive]
-nonrec theorem Smooth.div {f g : M → G} (hf : Smooth I' I f) (hg : Smooth I' I g) :
-    Smooth I' I (f / g) :=
-  hf.div hg
+@[deprecated (since := "2024-11-21")] alias SmoothWithinAt.sub := ContMDiffWithinAt.sub
+@[deprecated (since := "2024-11-21")] alias SmoothAt.sub := ContMDiffAt.sub
+@[deprecated (since := "2024-11-21")] alias SmoothOn.sub := ContMDiffOn.sub
+@[deprecated (since := "2024-11-21")] alias Smooth.sub := ContMDiff.sub
 
 end PointwiseDivision
 
@@ -195,7 +178,7 @@ instance {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalS
     [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H' : Type*} [TopologicalSpace H']
     {I' : ModelWithCorners 𝕜 E' H'} {G' : Type*} [TopologicalSpace G'] [ChartedSpace H' G']
     [Group G'] [LieGroup I' G'] : LieGroup (I.prod I') (G × G') :=
-  { SmoothMul.prod _ _ _ _ with smooth_inv := smooth_fst.inv.prod_mk smooth_snd.inv }
+  { SmoothMul.prod _ _ _ _ with smooth_inv := contMDiff_fst.inv.prod_mk contMDiff_snd.inv }
 
 end Product
 
@@ -219,7 +202,7 @@ class SmoothInv₀ {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [To
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] (I : ModelWithCorners 𝕜 E H) (G : Type*)
     [Inv G] [Zero G] [TopologicalSpace G] [ChartedSpace H G] : Prop where
   /-- Inversion is smooth away from `0`. -/
-  smoothAt_inv₀ : ∀ ⦃x : G⦄, x ≠ 0 → SmoothAt I I (fun y ↦ y⁻¹) x
+  smoothAt_inv₀ : ∀ ⦃x : G⦄, x ≠ 0 → ContMDiffAt I I ⊤ (fun y ↦ y⁻¹) x
 
 instance {𝕜 : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜] : SmoothInv₀ 𝓘(𝕜) 𝕜 :=
   { smoothAt_inv₀ := by
@@ -235,28 +218,32 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalS
   {I' : ModelWithCorners 𝕜 E' H'} {M : Type*} [TopologicalSpace M] [ChartedSpace H' M]
   {n : ℕ∞} {f : M → G}
 
-theorem smoothAt_inv₀ {x : G} (hx : x ≠ 0) : SmoothAt I I (fun y ↦ y⁻¹) x :=
+theorem contMDiffAt_inv₀ {x : G} (hx : x ≠ 0) : ContMDiffAt I I ⊤ (fun y ↦ y⁻¹) x :=
   SmoothInv₀.smoothAt_inv₀ hx
+
+@[deprecated (since := "2024-11-21")] alias smoothAt_inv₀ := contMDiffAt_inv₀
 
 include I in
 /-- In a manifold with smooth inverse away from `0`, the inverse is continuous away from `0`.
 This is not an instance for technical reasons, see
 note [Design choices about smooth algebraic structures]. -/
 theorem hasContinuousInv₀_of_hasSmoothInv₀ : HasContinuousInv₀ G :=
-  { continuousAt_inv₀ := fun _ hx ↦ (smoothAt_inv₀ I hx).continuousAt }
+  { continuousAt_inv₀ := fun _ hx ↦ (contMDiffAt_inv₀ I hx).continuousAt }
 
-theorem SmoothOn_inv₀ : SmoothOn I I (Inv.inv : G → G) {0}ᶜ := fun _x hx =>
-  (smoothAt_inv₀ I hx).smoothWithinAt
+theorem contMDiffOn_inv₀ : ContMDiffOn I I ⊤ (Inv.inv : G → G) {0}ᶜ := fun _x hx =>
+  (contMDiffAt_inv₀ I hx).contMDiffWithinAt
+
+@[deprecated (since := "2024-11-21")] alias smoothOn_inv₀ := contMDiffOn_inv₀
 
 variable {I} {s : Set M} {a : M}
 
 theorem ContMDiffWithinAt.inv₀ (hf : ContMDiffWithinAt I' I n f s a) (ha : f a ≠ 0) :
     ContMDiffWithinAt I' I n (fun x => (f x)⁻¹) s a :=
-  (smoothAt_inv₀ I ha).contMDiffAt.comp_contMDiffWithinAt a hf
+  ((contMDiffAt_inv₀ I ha).of_le le_top).comp_contMDiffWithinAt a hf
 
 theorem ContMDiffAt.inv₀ (hf : ContMDiffAt I' I n f a) (ha : f a ≠ 0) :
     ContMDiffAt I' I n (fun x ↦ (f x)⁻¹) a :=
-  (smoothAt_inv₀ I ha).contMDiffAt.comp a hf
+  ((contMDiffAt_inv₀ I ha).of_le le_top).comp a hf
 
 theorem ContMDiff.inv₀ (hf : ContMDiff I' I n f) (h0 : ∀ x, f x ≠ 0) :
     ContMDiff I' I n (fun x ↦ (f x)⁻¹) :=
@@ -266,20 +253,10 @@ theorem ContMDiffOn.inv₀ (hf : ContMDiffOn I' I n f s) (h0 : ∀ x ∈ s, f x 
     ContMDiffOn I' I n (fun x => (f x)⁻¹) s :=
   fun x hx ↦ ContMDiffWithinAt.inv₀ (hf x hx) (h0 x hx)
 
-theorem SmoothWithinAt.inv₀ (hf : SmoothWithinAt I' I f s a) (ha : f a ≠ 0) :
-    SmoothWithinAt I' I (fun x => (f x)⁻¹) s a :=
-  ContMDiffWithinAt.inv₀ hf ha
-
-theorem SmoothAt.inv₀ (hf : SmoothAt I' I f a) (ha : f a ≠ 0) :
-    SmoothAt I' I (fun x => (f x)⁻¹) a :=
-  ContMDiffAt.inv₀ hf ha
-
-theorem Smooth.inv₀ (hf : Smooth I' I f) (h0 : ∀ x, f x ≠ 0) : Smooth I' I fun x => (f x)⁻¹ :=
-  ContMDiff.inv₀ hf h0
-
-theorem SmoothOn.inv₀ (hf : SmoothOn I' I f s) (h0 : ∀ x ∈ s, f x ≠ 0) :
-    SmoothOn I' I (fun x => (f x)⁻¹) s :=
-  ContMDiffOn.inv₀ hf h0
+@[deprecated (since := "2024-11-21")] alias SmoothWithinAt.inv₀ := ContMDiffWithinAt.inv₀
+@[deprecated (since := "2024-11-21")] alias SmoothAt.inv₀ := ContMDiffAt.inv₀
+@[deprecated (since := "2024-11-21")] alias SmoothOn.inv₀ := ContMDiffOn.inv₀
+@[deprecated (since := "2024-11-21")] alias Smooth.inv₀ := ContMDiff.inv₀
 
 end SmoothInv₀
 
@@ -313,20 +290,9 @@ theorem ContMDiffAt.div₀ (hf : ContMDiffAt I' I n f a) (hg : ContMDiffAt I' I 
 theorem ContMDiff.div₀ (hf : ContMDiff I' I n f) (hg : ContMDiff I' I n g) (h₀ : ∀ x, g x ≠ 0) :
     ContMDiff I' I n (f / g) := by simpa only [div_eq_mul_inv] using hf.mul (hg.inv₀ h₀)
 
-theorem SmoothWithinAt.div₀ (hf : SmoothWithinAt I' I f s a)
-    (hg : SmoothWithinAt I' I g s a) (h₀ : g a ≠ 0) : SmoothWithinAt I' I (f / g) s a :=
-  ContMDiffWithinAt.div₀ hf hg h₀
-
-theorem SmoothOn.div₀ (hf : SmoothOn I' I f s) (hg : SmoothOn I' I g s) (h₀ : ∀ x ∈ s, g x ≠ 0) :
-    SmoothOn I' I (f / g) s :=
-  ContMDiffOn.div₀ hf hg h₀
-
-theorem SmoothAt.div₀ (hf : SmoothAt I' I f a) (hg : SmoothAt I' I g a) (h₀ : g a ≠ 0) :
-    SmoothAt I' I (f / g) a :=
-  ContMDiffAt.div₀ hf hg h₀
-
-theorem Smooth.div₀ (hf : Smooth I' I f) (hg : Smooth I' I g) (h₀ : ∀ x, g x ≠ 0) :
-    Smooth I' I (f / g) :=
-  ContMDiff.div₀ hf hg h₀
+@[deprecated (since := "2024-11-21")] alias SmoothWithinAt.div₀ := ContMDiffWithinAt.div₀
+@[deprecated (since := "2024-11-21")] alias SmoothAt.div₀ := ContMDiffAt.div₀
+@[deprecated (since := "2024-11-21")] alias SmoothOn.div₀ := ContMDiffOn.div₀
+@[deprecated (since := "2024-11-21")] alias Smooth.div₀ := ContMDiff.div₀
 
 end Div

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -234,6 +234,7 @@ theorem contMDiffOn_inv₀ : ContMDiffOn I I ⊤ (Inv.inv : G → G) {0}ᶜ := f
   (contMDiffAt_inv₀ I hx).contMDiffWithinAt
 
 @[deprecated (since := "2024-11-21")] alias smoothOn_inv₀ := contMDiffOn_inv₀
+@[deprecated (since := "2024-11-21")] alias SmoothOn_inv₀ := contMDiffOn_inv₀
 
 variable {I} {s : Set M} {a : M}
 

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -142,6 +142,9 @@ theorem mdifferentiableAt_mul_left {a b : G} : MDifferentiableAt I I (a * ·) b 
 theorem contMDiff_mul_right {a : G} : ContMDiff I I n (· * a) :=
   contMDiff_id.mul contMDiff_const
 
+@[deprecated (since := "2024-11-21")] alias smooth_mul_right := contMDiff_mul_right
+@[deprecated (since := "2024-11-21")] alias smooth_add_right := contMDiff_add_right
+
 @[to_additive]
 theorem contMDiffAt_mul_right {a b : G} : ContMDiffAt I I n (· * a) b :=
   contMDiff_mul_right.contMDiffAt

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -75,6 +75,7 @@ theorem contMDiff_mul : ContMDiff (I.prod I) I ⊤ fun p : G × G => p.1 * p.2 :
   SmoothMul.smooth_mul
 
 @[deprecated (since := "2024-11-20")] alias smooth_mul := contMDiff_mul
+@[deprecated (since := "2024-11-20")] alias smooth_add := contMDiff_add
 
 include I in
 /-- If the multiplication is smooth, then it is continuous. This is not an instance for technical
@@ -109,12 +110,14 @@ theorem ContMDiff.mul (hf : ContMDiff I' I n f) (hg : ContMDiff I' I n g) :
     ContMDiff I' I n (f * g) := fun x => (hf x).mul (hg x)
 
 @[deprecated (since := "2024-11-21")] alias SmoothWithinAt.mul := ContMDiffWithinAt.mul
-
 @[deprecated (since := "2024-11-21")] alias SmoothAt.mul := ContMDiffAt.mul
-
 @[deprecated (since := "2024-11-21")] alias SmoothOn.mul := ContMDiffOn.mul
-
 @[deprecated (since := "2024-11-21")] alias Smooth.mul := ContMDiff.mul
+
+@[deprecated (since := "2024-11-21")] alias SmoothWithinAt.add := ContMDiffWithinAt.add
+@[deprecated (since := "2024-11-21")] alias SmoothAt.add := ContMDiffAt.add
+@[deprecated (since := "2024-11-21")] alias SmoothOn.add := ContMDiffOn.add
+@[deprecated (since := "2024-11-21")] alias Smooth.add := ContMDiff.add
 
 @[to_additive]
 theorem contMDiff_mul_left {a : G} : ContMDiff I I n (a * ·) :=
@@ -159,13 +162,13 @@ variable (I) (g h : G)
 Lemmas involving `smoothLeftMul` with the notation `𝑳` usually use `L` instead of `𝑳` in the
 names. -/
 def smoothLeftMul : C^∞⟮I, G; I, G⟯ :=
-  ⟨leftMul g, smooth_mul_left⟩
+  ⟨leftMul g, contMDiff_mul_left⟩
 
 /-- Right multiplication by `g`. It is meant to mimic the usual notation in Lie groups.
 Lemmas involving `smoothRightMul` with the notation `𝑹` usually use `R` instead of `𝑹` in the
 names. -/
 def smoothRightMul : C^∞⟮I, G; I, G⟯ :=
-  ⟨rightMul g, smooth_mul_right⟩
+  ⟨rightMul g, contMDiff_mul_right⟩
 
 -- Left multiplication. The abbreviation is `MIL`.
 scoped[LieGroup] notation "𝑳" => smoothLeftMul
@@ -218,8 +221,8 @@ instance SmoothMul.prod {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*
     [ChartedSpace H' G'] [Mul G'] [SmoothMul I' G'] : SmoothMul (I.prod I') (G × G') :=
   { SmoothManifoldWithCorners.prod G G' with
     smooth_mul :=
-      ((smooth_fst.comp smooth_fst).smooth.mul (smooth_fst.comp smooth_snd)).prod_mk
-        ((smooth_snd.comp smooth_fst).smooth.mul (smooth_snd.comp smooth_snd)) }
+      ((contMDiff_fst.comp contMDiff_fst).mul (contMDiff_fst.comp contMDiff_snd)).prod_mk
+        ((contMDiff_snd.comp contMDiff_fst).mul (contMDiff_snd.comp contMDiff_snd)) }
 
 end SmoothMul
 
@@ -232,16 +235,19 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalS
   {G' : Type*} [Monoid G'] [TopologicalSpace G'] [ChartedSpace H' G'] [SmoothMul I' G']
 
 @[to_additive]
-theorem smooth_pow : ∀ n : ℕ, Smooth I I fun a : G => a ^ n
-  | 0 => by simp only [pow_zero]; exact smooth_const
-  | k + 1 => by simpa [pow_succ] using (smooth_pow _).mul smooth_id
+theorem contMDiff_pow : ∀ n : ℕ, ContMDiff I I ⊤ fun a : G => a ^ n
+  | 0 => by simp only [pow_zero]; exact contMDiff_const
+  | k + 1 => by simpa [pow_succ] using (contMDiff_pow _).mul contMDiff_id
+
+@[deprecated (since := "2024-11-21")] alias smooth_pow := contMDiff_pow
+@[deprecated (since := "2024-11-21")] alias smooth_nsmul := contMDiff_nsmul
 
 /-- Morphism of additive smooth monoids. -/
 structure SmoothAddMonoidMorphism (I : ModelWithCorners 𝕜 E H) (I' : ModelWithCorners 𝕜 E' H')
     (G : Type*) [TopologicalSpace G] [ChartedSpace H G] [AddMonoid G] [SmoothAdd I G]
     (G' : Type*) [TopologicalSpace G'] [ChartedSpace H' G'] [AddMonoid G']
     [SmoothAdd I' G'] extends G →+ G' where
-  smooth_toFun : Smooth I I' toFun
+  smooth_toFun : ContMDiff I I' ⊤ toFun
 
 /-- Morphism of smooth monoids. -/
 @[to_additive]
@@ -249,11 +255,11 @@ structure SmoothMonoidMorphism (I : ModelWithCorners 𝕜 E H) (I' : ModelWithCo
     (G : Type*) [TopologicalSpace G] [ChartedSpace H G] [Monoid G] [SmoothMul I G] (G' : Type*)
     [TopologicalSpace G'] [ChartedSpace H' G'] [Monoid G'] [SmoothMul I' G'] extends
     G →* G' where
-  smooth_toFun : Smooth I I' toFun
+  smooth_toFun : ContMDiff I I' ⊤ toFun
 
 @[to_additive]
 instance : One (SmoothMonoidMorphism I I' G G') :=
-  ⟨{  smooth_toFun := smooth_const
+  ⟨{  smooth_toFun := contMDiff_const
       toMonoidHom := 1 }⟩
 
 @[to_additive]
@@ -385,61 +391,43 @@ theorem contMDiff_finprod_cond (hc : ∀ i, p i → ContMDiff I' I n (f i))
   simp only [← finprod_subtype_eq_finprod_cond]
   exact contMDiff_finprod (fun i => hc i i.2) (hf.comp_injective Subtype.coe_injective)
 
-@[to_additive]
-theorem smoothAt_finprod
-    (lf : LocallyFinite fun i ↦ mulSupport <| f i) (h : ∀ i, SmoothAt I' I (f i) x₀) :
-    SmoothAt I' I (fun x ↦ ∏ᶠ i, f i x) x₀ :=
-  contMDiffWithinAt_finprod lf h
+@[deprecated (since := "2024-11-21")] alias smoothAt_finprod := contMDiffAt_finprod
+@[deprecated (since := "2024-11-21")] alias smoothAt_finsum := contMDiffAt_finsum
 
-@[to_additive]
-theorem smoothWithinAt_finset_prod' (h : ∀ i ∈ t, SmoothWithinAt I' I (f i) s x) :
-    SmoothWithinAt I' I (∏ i ∈ t, f i) s x :=
-  contMDiffWithinAt_finset_prod' h
+@[deprecated (since := "2024-11-21")]
+alias smoothWithinAt_finset_prod' := contMDiffWithinAt_finset_prod'
+@[deprecated (since := "2024-11-21")]
+alias smoothWithinAt_finset_sum' := contMDiffWithinAt_finset_sum'
 
-@[to_additive]
-theorem smoothWithinAt_finset_prod (h : ∀ i ∈ t, SmoothWithinAt I' I (f i) s x) :
-    SmoothWithinAt I' I (fun x => ∏ i ∈ t, f i x) s x :=
-  contMDiffWithinAt_finset_prod h
 
-@[to_additive]
-theorem smoothAt_finset_prod' (h : ∀ i ∈ t, SmoothAt I' I (f i) x) :
-    SmoothAt I' I (∏ i ∈ t, f i) x :=
-  contMDiffAt_finset_prod' h
+@[deprecated (since := "2024-11-21")]
+alias smoothWithinAt_finset_prod := contMDiffWithinAt_finset_prod
+@[deprecated (since := "2024-11-21")]
+alias smoothWithinAt_finset_sum := contMDiffWithinAt_finset_sum
 
-@[to_additive]
-theorem smoothAt_finset_prod (h : ∀ i ∈ t, SmoothAt I' I (f i) x) :
-    SmoothAt I' I (fun x => ∏ i ∈ t, f i x) x :=
-  contMDiffAt_finset_prod h
+@[deprecated (since := "2024-11-21")] alias smoothAt_finset_prod' := contMDiffAt_finset_prod'
+@[deprecated (since := "2024-11-21")] alias smoothAt_finset_sum' := contMDiffAt_finset_sum'
 
-@[to_additive]
-theorem smoothOn_finset_prod' (h : ∀ i ∈ t, SmoothOn I' I (f i) s) :
-    SmoothOn I' I (∏ i ∈ t, f i) s :=
-  contMDiffOn_finset_prod' h
+@[deprecated (since := "2024-11-21")] alias smoothAt_finset_prod := contMDiffAt_finset_prod
+@[deprecated (since := "2024-11-21")] alias smoothAt_finset_sum := contMDiffAt_finset_sum
 
-@[to_additive]
-theorem smoothOn_finset_prod (h : ∀ i ∈ t, SmoothOn I' I (f i) s) :
-    SmoothOn I' I (fun x => ∏ i ∈ t, f i x) s :=
-  contMDiffOn_finset_prod h
+@[deprecated (since := "2024-11-21")] alias smoothOn_finset_prod' := contMDiffOn_finset_prod'
+@[deprecated (since := "2024-11-21")] alias smoothOn_finset_sum' := contMDiffOn_finset_sum'
 
-@[to_additive]
-theorem smooth_finset_prod' (h : ∀ i ∈ t, Smooth I' I (f i)) : Smooth I' I (∏ i ∈ t, f i) :=
-  contMDiff_finset_prod' h
+@[deprecated (since := "2024-11-21")] alias smoothOn_finset_prod := contMDiffOn_finset_prod
+@[deprecated (since := "2024-11-21")] alias smoothOn_finset_sum := contMDiffOn_finset_sum
 
-@[to_additive]
-theorem smooth_finset_prod (h : ∀ i ∈ t, Smooth I' I (f i)) :
-    Smooth I' I fun x => ∏ i ∈ t, f i x :=
-  contMDiff_finset_prod h
+@[deprecated (since := "2024-11-21")] alias smooth_finset_prod' := contMDiffOn_finset_prod'
+@[deprecated (since := "2024-11-21")] alias smooth_finset_sum' := contMDiffOn_finset_sum'
 
-@[to_additive]
-theorem smooth_finprod (h : ∀ i, Smooth I' I (f i))
-    (hfin : LocallyFinite fun i => mulSupport (f i)) : Smooth I' I fun x => ∏ᶠ i, f i x :=
-  contMDiff_finprod h hfin
+@[deprecated (since := "2024-11-21")] alias smooth_finset_prod := contMDiff_finset_prod
+@[deprecated (since := "2024-11-21")] alias smooth_finset_sum := contMDiff_finset_sum
 
-@[to_additive]
-theorem smooth_finprod_cond (hc : ∀ i, p i → Smooth I' I (f i))
-    (hf : LocallyFinite fun i => mulSupport (f i)) :
-    Smooth I' I fun x => ∏ᶠ (i) (_ : p i), f i x :=
-  contMDiff_finprod_cond hc hf
+@[deprecated (since := "2024-11-21")] alias smooth_finprod := contMDiff_finprod
+@[deprecated (since := "2024-11-21")] alias smooth_finsum := contMDiff_finsum
+
+@[deprecated (since := "2024-11-21")] alias smooth_finprod_cond := contMDiff_finprod_cond
+@[deprecated (since := "2024-11-21")] alias smooth_finsum_cond := contMDiff_finsum_cond
 
 end CommMonoid
 
@@ -484,23 +472,9 @@ theorem ContMDiffOn.div_const (hf : ContMDiffOn I' I n f s) :
 theorem ContMDiff.div_const (hf : ContMDiff I' I n f) :
     ContMDiff I' I n (fun x ↦ f x / c) := fun x => (hf x).div_const c
 
-@[to_additive]
-nonrec theorem SmoothWithinAt.div_const (hf : SmoothWithinAt I' I f s x) :
-  SmoothWithinAt I' I (fun x ↦ f x / c) s x :=
-  hf.div_const c
-
-@[to_additive]
-nonrec theorem SmoothAt.div_const (hf : SmoothAt I' I f x) :
-    SmoothAt I' I (fun x ↦ f x / c) x :=
-  hf.div_const c
-
-@[to_additive]
-nonrec theorem SmoothOn.div_const (hf : SmoothOn I' I f s) :
-    SmoothOn I' I (fun x ↦ f x / c) s :=
-  hf.div_const c
-
-@[to_additive]
-nonrec theorem Smooth.div_const (hf : Smooth I' I f) : Smooth I' I (fun x ↦ f x / c) :=
-  hf.div_const c
+@[deprecated (since := "2024-11-21")] alias SmoothWithinAt.div_const := ContMDiffWithinAt.div_const
+@[deprecated (since := "2024-11-21")] alias SmoothAt.div_const := ContMDiffAt.div_const
+@[deprecated (since := "2024-11-21")] alias SmoothOn.div_const := ContMDiffOn.div_const
+@[deprecated (since := "2024-11-21")] alias Smooth.div_const := ContMDiff.div_const
 
 end DivConst

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -45,7 +45,7 @@ class SmoothAdd {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [Topol
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] (I : ModelWithCorners 𝕜 E H) (G : Type*)
     [Add G] [TopologicalSpace G] [ChartedSpace H G] extends SmoothManifoldWithCorners I G :
     Prop where
-  smooth_add : Smooth (I.prod I) I fun p : G × G => p.1 + p.2
+  smooth_add : ContMDiff (I.prod I) I ⊤ fun p : G × G => p.1 + p.2
 
 -- See note [Design choices about smooth algebraic structures]
 /-- Basic hypothesis to talk about a smooth (Lie) monoid or a smooth semigroup.
@@ -56,7 +56,7 @@ class SmoothMul {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [Topol
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] (I : ModelWithCorners 𝕜 E H) (G : Type*)
     [Mul G] [TopologicalSpace G] [ChartedSpace H G] extends SmoothManifoldWithCorners I G :
     Prop where
-  smooth_mul : Smooth (I.prod I) I fun p : G × G => p.1 * p.2
+  smooth_mul : ContMDiff (I.prod I) I ⊤ fun p : G × G => p.1 * p.2
 
 section SmoothMul
 
@@ -71,8 +71,10 @@ section
 variable (I)
 
 @[to_additive]
-theorem smooth_mul : Smooth (I.prod I) I fun p : G × G => p.1 * p.2 :=
+theorem contMDiff_mul : ContMDiff (I.prod I) I ⊤ fun p : G × G => p.1 * p.2 :=
   SmoothMul.smooth_mul
+
+@[deprecated (since := "2024-11-20")] alias smooth_mul := contMDiff_mul
 
 include I in
 /-- If the multiplication is smooth, then it is continuous. This is not an instance for technical
@@ -80,7 +82,7 @@ reasons, see note [Design choices about smooth algebraic structures]. -/
 @[to_additive "If the addition is smooth, then it is continuous. This is not an instance for
 technical reasons, see note [Design choices about smooth algebraic structures]."]
 theorem continuousMul_of_smooth : ContinuousMul G :=
-  ⟨(smooth_mul I).continuous⟩
+  ⟨(contMDiff_mul I).continuous⟩
 
 end
 
@@ -91,7 +93,7 @@ variable {f g : M → G} {s : Set M} {x : M} {n : ℕ∞}
 @[to_additive]
 theorem ContMDiffWithinAt.mul (hf : ContMDiffWithinAt I' I n f s x)
     (hg : ContMDiffWithinAt I' I n g s x) : ContMDiffWithinAt I' I n (f * g) s x :=
-  ((smooth_mul I).smoothAt.of_le le_top).comp_contMDiffWithinAt x (hf.prod_mk hg)
+  ((contMDiff_mul I).contMDiffAt.of_le le_top).comp_contMDiffWithinAt x (hf.prod_mk hg)
 
 @[to_additive]
 nonrec theorem ContMDiffAt.mul (hf : ContMDiffAt I' I n f x) (hg : ContMDiffAt I' I n g x) :
@@ -106,52 +108,46 @@ theorem ContMDiffOn.mul (hf : ContMDiffOn I' I n f s) (hg : ContMDiffOn I' I n g
 theorem ContMDiff.mul (hf : ContMDiff I' I n f) (hg : ContMDiff I' I n g) :
     ContMDiff I' I n (f * g) := fun x => (hf x).mul (hg x)
 
-@[to_additive]
-nonrec theorem SmoothWithinAt.mul (hf : SmoothWithinAt I' I f s x)
-    (hg : SmoothWithinAt I' I g s x) : SmoothWithinAt I' I (f * g) s x :=
-  hf.mul hg
+@[deprecated (since := "2024-11-21")] alias SmoothWithinAt.mul := ContMDiffWithinAt.mul
+
+@[deprecated (since := "2024-11-21")] alias SmoothAt.mul := ContMDiffAt.mul
+
+@[deprecated (since := "2024-11-21")] alias SmoothOn.mul := ContMDiffOn.mul
+
+@[deprecated (since := "2024-11-21")] alias Smooth.mul := ContMDiff.mul
 
 @[to_additive]
-nonrec theorem SmoothAt.mul (hf : SmoothAt I' I f x) (hg : SmoothAt I' I g x) :
-    SmoothAt I' I (f * g) x :=
-  hf.mul hg
+theorem contMDiff_mul_left {a : G} : ContMDiff I I n (a * ·) :=
+  contMDiff_const.mul contMDiff_id
+
+@[deprecated (since := "2024-11-21")] alias smooth_mul_left := contMDiff_mul_left
+@[deprecated (since := "2024-11-21")] alias smooth_add_left := contMDiff_add_left
 
 @[to_additive]
-nonrec theorem SmoothOn.mul (hf : SmoothOn I' I f s) (hg : SmoothOn I' I g s) :
-    SmoothOn I' I (f * g) s :=
-  hf.mul hg
-
-@[to_additive]
-nonrec theorem Smooth.mul (hf : Smooth I' I f) (hg : Smooth I' I g) : Smooth I' I (f * g) :=
-  hf.mul hg
-
-@[to_additive]
-theorem smooth_mul_left {a : G} : Smooth I I fun b : G => a * b :=
-  smooth_const.mul smooth_id
-
-@[to_additive]
-theorem smooth_mul_right {a : G} : Smooth I I fun b : G => b * a :=
-  smooth_id.mul smooth_const
-
-theorem contMDiff_mul_left {a : G} : ContMDiff I I n (a * ·) := smooth_mul_left.contMDiff
-
 theorem contMDiffAt_mul_left {a b : G} : ContMDiffAt I I n (a * ·) b :=
   contMDiff_mul_left.contMDiffAt
 
+@[to_additive]
 theorem mdifferentiable_mul_left {a : G} : MDifferentiable I I (a * ·) :=
   contMDiff_mul_left.mdifferentiable le_rfl
 
+@[to_additive]
 theorem mdifferentiableAt_mul_left {a b : G} : MDifferentiableAt I I (a * ·) b :=
   contMDiffAt_mul_left.mdifferentiableAt le_rfl
 
-theorem contMDiff_mul_right {a : G} : ContMDiff I I n (· * a) := smooth_mul_right.contMDiff
+@[to_additive]
+theorem contMDiff_mul_right {a : G} : ContMDiff I I n (· * a) :=
+  contMDiff_id.mul contMDiff_const
 
+@[to_additive]
 theorem contMDiffAt_mul_right {a b : G} : ContMDiffAt I I n (· * a) b :=
   contMDiff_mul_right.contMDiffAt
 
+@[to_additive]
 theorem mdifferentiable_mul_right {a : G} : MDifferentiable I I (· * a) :=
   contMDiff_mul_right.mdifferentiable le_rfl
 
+@[to_additive]
 theorem mdifferentiableAt_mul_right {a b : G} : MDifferentiableAt I I (· * a) b :=
   contMDiffAt_mul_right.mdifferentiableAt le_rfl
 

--- a/Mathlib/Geometry/Manifold/Algebra/SmoothFunctions.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SmoothFunctions.lean
@@ -30,7 +30,7 @@ namespace SmoothMap
 @[to_additive]
 protected instance instMul {G : Type*} [Mul G] [TopologicalSpace G] [ChartedSpace H' G]
     [SmoothMul I' G] : Mul C^∞⟮I, N; I', G⟯ :=
-  ⟨fun f g => ⟨f * g, f.smooth.mul g.smooth⟩⟩
+  ⟨fun f g => ⟨f * g, f.contMDiff.mul g.contMDiff⟩⟩
 
 @[to_additive (attr := simp)]
 theorem coe_mul {G : Type*} [Mul G] [TopologicalSpace G] [ChartedSpace H' G] [SmoothMul I' G]
@@ -54,12 +54,12 @@ theorem coe_one {G : Type*} [One G] [TopologicalSpace G] [ChartedSpace H' G] :
 
 instance instNSMul {G : Type*} [AddMonoid G] [TopologicalSpace G] [ChartedSpace H' G]
     [SmoothAdd I' G] : SMul ℕ C^∞⟮I, N; I', G⟯ where
-  smul n f := ⟨n • (f : N → G), (smooth_nsmul n).comp f.smooth⟩
+  smul n f := ⟨n • (f : N → G), (contMDiff_nsmul n).comp f.contMDiff⟩
 
 @[to_additive existing]
 instance instPow {G : Type*} [Monoid G] [TopologicalSpace G] [ChartedSpace H' G] [SmoothMul I' G] :
     Pow C^∞⟮I, N; I', G⟯ ℕ where
-  pow f n := ⟨(f : N → G) ^ n, (smooth_pow n).comp f.smooth⟩
+  pow f n := ⟨(f : N → G) ^ n, (contMDiff_pow n).comp f.contMDiff⟩
 
 @[to_additive (attr := simp)]
 theorem coe_pow {G : Type*} [Monoid G] [TopologicalSpace G] [ChartedSpace H' G] [SmoothMul I' G]
@@ -104,9 +104,9 @@ variable (I N)
 `C^∞⟮I, N; I'', G''⟯`."]
 def compLeftMonoidHom {G' : Type*} [Monoid G'] [TopologicalSpace G'] [ChartedSpace H' G']
     [SmoothMul I' G'] {G'' : Type*} [Monoid G''] [TopologicalSpace G''] [ChartedSpace H'' G'']
-    [SmoothMul I'' G''] (φ : G' →* G'') (hφ : Smooth I' I'' φ) :
+    [SmoothMul I'' G''] (φ : G' →* G'') (hφ : ContMDiff I' I'' ⊤ φ) :
     C^∞⟮I, N; I', G'⟯ →* C^∞⟮I, N; I'', G''⟯ where
-  toFun f := ⟨φ ∘ f, fun x => (hφ.smooth _).comp x (f.contMDiff x)⟩
+  toFun f := ⟨φ ∘ f, hφ.comp f.contMDiff⟩
   map_one' := by ext; show φ 1 = 1; simp
   map_mul' f g := by ext x; show φ (f x * g x) = φ (f x) * φ (g x); simp
 
@@ -119,7 +119,7 @@ variable (I') {N}
 homomorphism from `C^∞⟮I, V; I', G⟯` to `C^∞⟮I, U; I', G⟯`."]
 def restrictMonoidHom (G : Type*) [Monoid G] [TopologicalSpace G] [ChartedSpace H' G]
     [SmoothMul I' G] {U V : Opens N} (h : U ≤ V) : C^∞⟮I, V; I', G⟯ →* C^∞⟮I, U; I', G⟯ where
-  toFun f := ⟨f ∘ Set.inclusion h, f.smooth.comp (smooth_inclusion h)⟩
+  toFun f := ⟨f ∘ Set.inclusion h, f.contMDiff.comp (contMDiff_inclusion h)⟩
   map_one' := rfl
   map_mul' _ _ := rfl
 
@@ -134,9 +134,9 @@ instance commMonoid {G : Type*} [CommMonoid G] [TopologicalSpace G] [ChartedSpac
 instance group {G : Type*} [Group G] [TopologicalSpace G] [ChartedSpace H' G] [LieGroup I' G] :
     Group C^∞⟮I, N; I', G⟯ :=
   { SmoothMap.monoid with
-    inv := fun f => ⟨fun x => (f x)⁻¹, f.smooth.inv⟩
+    inv := fun f => ⟨fun x => (f x)⁻¹, f.contMDiff.inv⟩
     inv_mul_cancel := fun a => by ext; exact inv_mul_cancel _
-    div := fun f g => ⟨f / g, f.smooth.div g.smooth⟩
+    div := fun f g => ⟨f / g, f.contMDiff.div g.contMDiff⟩
     div_eq_mul_inv := fun f g => by ext; exact div_eq_mul_inv _ _ }
 
 @[to_additive (attr := simp)]
@@ -189,11 +189,11 @@ variable (I N)
 'left-composition-by-`φ`' ring homomorphism from `C^∞⟮I, N; I', R'⟯` to `C^∞⟮I, N; I'', R''⟯`. -/
 def compLeftRingHom {R' : Type*} [Ring R'] [TopologicalSpace R'] [ChartedSpace H' R']
     [SmoothRing I' R'] {R'' : Type*} [Ring R''] [TopologicalSpace R''] [ChartedSpace H'' R'']
-    [SmoothRing I'' R''] (φ : R' →+* R'') (hφ : Smooth I' I'' φ) :
+    [SmoothRing I'' R''] (φ : R' →+* R'') (hφ : ContMDiff I' I'' ⊤ φ) :
     C^∞⟮I, N; I', R'⟯ →+* C^∞⟮I, N; I'', R''⟯ :=
   { SmoothMap.compLeftMonoidHom I N φ.toMonoidHom hφ,
     SmoothMap.compLeftAddMonoidHom I N φ.toAddMonoidHom hφ with
-    toFun := fun f => ⟨φ ∘ f, fun x => (hφ.smooth _).comp x (f.contMDiff x)⟩ }
+    toFun := fun f => ⟨φ ∘ f, hφ.comp f.contMDiff⟩ }
 
 variable (I') {N}
 
@@ -202,7 +202,7 @@ variable (I') {N}
 def restrictRingHom (R : Type*) [Ring R] [TopologicalSpace R] [ChartedSpace H' R] [SmoothRing I' R]
     {U V : Opens N} (h : U ≤ V) : C^∞⟮I, V; I', R⟯ →+* C^∞⟮I, U; I', R⟯ :=
   { SmoothMap.restrictMonoidHom I I' R h, SmoothMap.restrictAddMonoidHom I I' R h with
-    toFun := fun f => ⟨f ∘ Set.inclusion h, f.smooth.comp (smooth_inclusion h)⟩ }
+    toFun := fun f => ⟨f ∘ Set.inclusion h, f.contMDiff.comp (contMDiff_inclusion h)⟩ }
 
 variable {I I'}
 
@@ -232,7 +232,7 @@ field `𝕜` inherit a vector space structure.
 
 instance instSMul {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] :
     SMul 𝕜 C^∞⟮I, N; 𝓘(𝕜, V), V⟯ :=
-  ⟨fun r f => ⟨r • ⇑f, smooth_const.smul f.smooth⟩⟩
+  ⟨fun r f => ⟨r • ⇑f, contMDiff_const.smul f.contMDiff⟩⟩
 
 @[simp]
 theorem coe_smul {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] (r : 𝕜)
@@ -272,7 +272,7 @@ variable {A : Type*} [NormedRing A] [NormedAlgebra 𝕜 A] [SmoothRing 𝓘(𝕜
 
 /-- Smooth constant functions as a `RingHom`. -/
 def C : 𝕜 →+* C^∞⟮I, N; 𝓘(𝕜, A), A⟯ where
-  toFun := fun c : 𝕜 => ⟨fun _ => (algebraMap 𝕜 A) c, smooth_const⟩
+  toFun := fun c : 𝕜 => ⟨fun _ => (algebraMap 𝕜 A) c, contMDiff_const⟩
   map_one' := by ext; exact (algebraMap 𝕜 A).map_one
   map_mul' c₁ c₂ := by ext; exact (algebraMap 𝕜 A).map_mul _ _
   map_zero' := by ext; exact (algebraMap 𝕜 A).map_zero
@@ -280,7 +280,7 @@ def C : 𝕜 →+* C^∞⟮I, N; 𝓘(𝕜, A), A⟯ where
 
 instance algebra : Algebra 𝕜 C^∞⟮I, N; 𝓘(𝕜, A), A⟯ :=
   { --SmoothMap.semiring with -- Porting note: Commented this out.
-    smul := fun r f => ⟨r • f, smooth_const.smul f.smooth⟩
+    smul := fun r f => ⟨r • f, contMDiff_const.smul f.contMDiff⟩
     toRingHom := SmoothMap.C
     commutes' := fun c f => by ext x; exact Algebra.commutes' _ _
     smul_def' := fun c f => by ext x; exact Algebra.smul_def' _ _ }
@@ -309,7 +309,7 @@ is naturally a vector space over the ring of smooth functions from `N` to `𝕜`
 
 instance instSMul' {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] :
     SMul C^∞⟮I, N; 𝕜⟯ C^∞⟮I, N; 𝓘(𝕜, V), V⟯ :=
-  ⟨fun f g => ⟨fun x => f x • g x, Smooth.smul f.2 g.2⟩⟩
+  ⟨fun f g => ⟨fun x => f x • g x, ContMDiff.smul f.2 g.2⟩⟩
 
 @[simp]
 theorem smul_comp' {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] (f : C^∞⟮I'', N'; 𝕜⟯)

--- a/Mathlib/Geometry/Manifold/Algebra/Structures.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Structures.lean
@@ -24,7 +24,7 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalS
 If `R` is a ring, then negation is automatically smooth, as it is multiplication with `-1`. -/
 class SmoothRing (I : ModelWithCorners 𝕜 E H) (R : Type*) [Semiring R] [TopologicalSpace R]
     [ChartedSpace H R] extends SmoothAdd I R : Prop where
-  smooth_mul : Smooth (I.prod I) I fun p : R × R => p.1 * p.2
+  smooth_mul : ContMDiff (I.prod I) I ⊤ fun p : R × R => p.1 * p.2
 
 -- see Note [lower instance priority]
 instance (priority := 100) SmoothRing.toSmoothMul (I : ModelWithCorners 𝕜 E H) (R : Type*)
@@ -36,8 +36,8 @@ instance (priority := 100) SmoothRing.toSmoothMul (I : ModelWithCorners 𝕜 E H
 instance (priority := 100) SmoothRing.toLieAddGroup (I : ModelWithCorners 𝕜 E H) (R : Type*)
     [Ring R] [TopologicalSpace R] [ChartedSpace H R] [SmoothRing I R] : LieAddGroup I R where
   compatible := StructureGroupoid.compatible (contDiffGroupoid ⊤ I)
-  smooth_add := smooth_add I
-  smooth_neg := by simpa only [neg_one_mul] using @smooth_mul_left 𝕜 _ H _ E _ _ I R _ _ _ _ (-1)
+  smooth_add := contMDiff_add I
+  smooth_neg := by simpa only [neg_one_mul] using contMDiff_mul_left (G := R) (a := -1)
 
 end SmoothRing
 
@@ -46,7 +46,7 @@ instance (priority := 100) fieldSmoothRing {𝕜 : Type*} [NontriviallyNormedFie
     SmoothRing 𝓘(𝕜) 𝕜 :=
   { normedSpaceLieAddGroup with
     smooth_mul := by
-      rw [smooth_iff]
+      rw [contMDiff_iff]
       refine ⟨continuous_mul, fun x y => ?_⟩
       simp only [mfld_simps]
       rw [contDiffOn_univ]

--- a/Mathlib/Geometry/Manifold/BumpFunction.lean
+++ b/Mathlib/Geometry/Manifold/BumpFunction.lean
@@ -305,7 +305,7 @@ protected theorem continuous : Continuous f :=
 
 /-- If `f : SmoothBumpFunction I c` is a smooth bump function and `g : M → G` is a function smooth
 on the source of the chart at `c`, then `f • g` is smooth on the whole manifold. -/
-theorem contMDiffAt_smul {G} [NormedAddCommGroup G] [NormedSpace ℝ G] {g : M → G}
+theorem contMDiff_smul {G} [NormedAddCommGroup G] [NormedSpace ℝ G] {g : M → G}
     (hg : ContMDiffOn I 𝓘(ℝ, G) ⊤ g (chartAt H c).source) :
     ContMDiff I 𝓘(ℝ, G) ⊤ fun x => f x • g x := by
   refine contMDiff_of_tsupport fun x hx => ?_
@@ -318,6 +318,6 @@ theorem contMDiffAt_smul {G} [NormedAddCommGroup G] [NormedSpace ℝ G] {g : M �
     f.tsupport_subset_chartAt_source <| tsupport_smul_subset_left _ _ hx
   exact f.contMDiffAt.smul ((hg _ this).contMDiffAt <| (chartAt _ _).open_source.mem_nhds this)
 
-@[deprecated (since := "2024-11-20")] alias smoothAt_smul := contMDiffAt_smul
+@[deprecated (since := "2024-11-20")] alias smooth_smul := contMDiff_smul
 
 end SmoothBumpFunction

--- a/Mathlib/Geometry/Manifold/BumpFunction.lean
+++ b/Mathlib/Geometry/Manifold/BumpFunction.lean
@@ -286,23 +286,28 @@ theorem nhds_basis_support {s : Set M} (hs : s ∈ 𝓝 c) :
 variable [SmoothManifoldWithCorners I M]
 
 /-- A smooth bump function is infinitely smooth. -/
-protected theorem smooth : Smooth I 𝓘(ℝ) f := by
+protected theorem contMDiff : ContMDiff I 𝓘(ℝ) ⊤ f := by
   refine contMDiff_of_tsupport fun x hx => ?_
   have : x ∈ (chartAt H c).source := f.tsupport_subset_chartAt_source hx
   refine ContMDiffAt.congr_of_eventuallyEq ?_ <| f.eqOn_source.eventuallyEq_of_mem <|
     (chartAt H c).open_source.mem_nhds this
   exact f.contDiffAt.contMDiffAt.comp _ (contMDiffAt_extChartAt' this)
 
-protected theorem smoothAt {x} : SmoothAt I 𝓘(ℝ) f x :=
-  f.smooth.smoothAt
+@[deprecated (since := "2024-11-20")] alias smooth := SmoothBumpFunction.contMDiff
+
+protected theorem contMDiffAt {x} : ContMDiffAt I 𝓘(ℝ) ⊤ f x :=
+  f.contMDiff.contMDiffAt
+
+@[deprecated (since := "2024-11-20")] alias smoothAt := SmoothBumpFunction.contMDiffAt
 
 protected theorem continuous : Continuous f :=
-  f.smooth.continuous
+  f.contMDiff.continuous
 
 /-- If `f : SmoothBumpFunction I c` is a smooth bump function and `g : M → G` is a function smooth
 on the source of the chart at `c`, then `f • g` is smooth on the whole manifold. -/
-theorem smooth_smul {G} [NormedAddCommGroup G] [NormedSpace ℝ G] {g : M → G}
-    (hg : SmoothOn I 𝓘(ℝ, G) g (chartAt H c).source) : Smooth I 𝓘(ℝ, G) fun x => f x • g x := by
+theorem contMDiffAt_smul {G} [NormedAddCommGroup G] [NormedSpace ℝ G] {g : M → G}
+    (hg : ContMDiffOn I 𝓘(ℝ, G) ⊤ g (chartAt H c).source) :
+    ContMDiff I 𝓘(ℝ, G) ⊤ fun x => f x • g x := by
   refine contMDiff_of_tsupport fun x hx => ?_
   have : x ∈ (chartAt H c).source :=
   -- Porting note: was a more readable `calc`
@@ -311,6 +316,8 @@ theorem smooth_smul {G} [NormedAddCommGroup G] [NormedSpace ℝ G] {g : M → G}
   --   _ ⊆ tsupport f := tsupport_smul_subset_left _ _
   --   _ ⊆ (chart_at _ c).source := f.tsupport_subset_chartAt_source
     f.tsupport_subset_chartAt_source <| tsupport_smul_subset_left _ _ hx
-  exact f.smoothAt.smul ((hg _ this).contMDiffAt <| (chartAt _ _).open_source.mem_nhds this)
+  exact f.contMDiffAt.smul ((hg _ this).contMDiffAt <| (chartAt _ _).open_source.mem_nhds this)
+
+@[deprecated (since := "2024-11-20")] alias smoothAt_smul := contMDiffAt_smul
 
 end SmoothBumpFunction

--- a/Mathlib/Geometry/Manifold/ContMDiff/Atlas.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Atlas.lean
@@ -125,7 +125,7 @@ variable [ChartedSpace H M'] [IsM' : SmoothManifoldWithCorners I M']
 
 theorem isLocalStructomorphOn_contDiffGroupoid_iff_aux {f : PartialHomeomorph M M'}
     (hf : LiftPropOn (contDiffGroupoid ⊤ I).IsLocalStructomorphWithinAt f f.source) :
-    SmoothOn I I f f.source := by
+    ContMDiffOn I I ⊤ f f.source := by
   -- It suffices to show smoothness near each `x`
   apply contMDiffOn_of_locally_contMDiffOn
   intro x hx
@@ -171,7 +171,7 @@ is a local structomorphism for `I`, if and only if it is manifold-smooth on the 
 in both directions. -/
 theorem isLocalStructomorphOn_contDiffGroupoid_iff (f : PartialHomeomorph M M') :
     LiftPropOn (contDiffGroupoid ⊤ I).IsLocalStructomorphWithinAt f f.source ↔
-      SmoothOn I I f f.source ∧ SmoothOn I I f.symm f.target := by
+      ContMDiffOn I I ⊤ f f.source ∧ ContMDiffOn I I ⊤ f.symm f.target := by
   constructor
   · intro h
     refine ⟨isLocalStructomorphOn_contDiffGroupoid_iff_aux h,

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -82,31 +82,21 @@ theorem ContMDiffWithinAt.comp_of_eq {t : Set M'} {g : M' → M''} {x : M} {y : 
     (st : MapsTo f s t) (hx : f x = y) : ContMDiffWithinAt I I'' n (g ∘ f) s x := by
   subst hx; exact hg.comp x hf st
 
-/-- The composition of `C^∞` functions within domains at points is `C^∞`. -/
-nonrec theorem SmoothWithinAt.comp {t : Set M'} {g : M' → M''} (x : M)
-    (hg : SmoothWithinAt I' I'' g t (f x)) (hf : SmoothWithinAt I I' f s x) (st : MapsTo f s t) :
-    SmoothWithinAt I I'' (g ∘ f) s x :=
-  hg.comp x hf st
+@[deprecated (since := "2024-11-20")] alias SmoothWithinAt.comp := ContMDiffWithinAt.comp
 
 /-- The composition of `C^n` functions on domains is `C^n`. -/
 theorem ContMDiffOn.comp {t : Set M'} {g : M' → M''} (hg : ContMDiffOn I' I'' n g t)
     (hf : ContMDiffOn I I' n f s) (st : s ⊆ f ⁻¹' t) : ContMDiffOn I I'' n (g ∘ f) s := fun x hx =>
   (hg _ (st hx)).comp x (hf x hx) st
 
-/-- The composition of `C^∞` functions on domains is `C^∞`. -/
-nonrec theorem SmoothOn.comp {t : Set M'} {g : M' → M''} (hg : SmoothOn I' I'' g t)
-    (hf : SmoothOn I I' f s) (st : s ⊆ f ⁻¹' t) : SmoothOn I I'' (g ∘ f) s :=
-  hg.comp hf st
+@[deprecated (since := "2024-11-20")] alias SmoothOn.comp := ContMDiffOn.comp
 
 /-- The composition of `C^n` functions on domains is `C^n`. -/
 theorem ContMDiffOn.comp' {t : Set M'} {g : M' → M''} (hg : ContMDiffOn I' I'' n g t)
     (hf : ContMDiffOn I I' n f s) : ContMDiffOn I I'' n (g ∘ f) (s ∩ f ⁻¹' t) :=
   hg.comp (hf.mono inter_subset_left) inter_subset_right
 
-/-- The composition of `C^∞` functions is `C^∞`. -/
-nonrec theorem SmoothOn.comp' {t : Set M'} {g : M' → M''} (hg : SmoothOn I' I'' g t)
-    (hf : SmoothOn I I' f s) : SmoothOn I I'' (g ∘ f) (s ∩ f ⁻¹' t) :=
-  hg.comp' hf
+@[deprecated (since := "2024-11-20")] alias SmoothOn.comp' := ContMDiffOn.comp'
 
 /-- The composition of `C^n` functions is `C^n`. -/
 theorem ContMDiff.comp {g : M' → M''} (hg : ContMDiff I' I'' n g) (hf : ContMDiff I I' n f) :
@@ -114,10 +104,7 @@ theorem ContMDiff.comp {g : M' → M''} (hg : ContMDiff I' I'' n g) (hf : ContMD
   rw [← contMDiffOn_univ] at hf hg ⊢
   exact hg.comp hf subset_preimage_univ
 
-/-- The composition of `C^∞` functions is `C^∞`. -/
-nonrec theorem Smooth.comp {g : M' → M''} (hg : Smooth I' I'' g) (hf : Smooth I I' f) :
-    Smooth I I'' (g ∘ f) :=
-  hg.comp hf
+@[deprecated (since := "2024-11-20")] alias Smooth.comp := ContMDiff.comp
 
 /-- The composition of `C^n` functions within domains at points is `C^n`. -/
 theorem ContMDiffWithinAt.comp' {t : Set M'} {g : M' → M''} (x : M)
@@ -125,11 +112,7 @@ theorem ContMDiffWithinAt.comp' {t : Set M'} {g : M' → M''} (x : M)
     ContMDiffWithinAt I I'' n (g ∘ f) (s ∩ f ⁻¹' t) x :=
   hg.comp x (hf.mono inter_subset_left) inter_subset_right
 
-/-- The composition of `C^∞` functions within domains at points is `C^∞`. -/
-nonrec theorem SmoothWithinAt.comp' {t : Set M'} {g : M' → M''} (x : M)
-    (hg : SmoothWithinAt I' I'' g t (f x)) (hf : SmoothWithinAt I I' f s x) :
-    SmoothWithinAt I I'' (g ∘ f) (s ∩ f ⁻¹' t) x :=
-  hg.comp' x hf
+@[deprecated (since := "2024-11-20")] alias SmoothWithinAt.comp' := ContMDiffWithinAt.comp'
 
 /-- `g ∘ f` is `C^n` within `s` at `x` if `g` is `C^n` at `f x` and
 `f` is `C^n` within `s` at `x`. -/
@@ -138,11 +121,8 @@ theorem ContMDiffAt.comp_contMDiffWithinAt {g : M' → M''} (x : M)
     ContMDiffWithinAt I I'' n (g ∘ f) s x :=
   hg.comp x hf (mapsTo_univ _ _)
 
-/-- `g ∘ f` is `C^∞` within `s` at `x` if `g` is `C^∞` at `f x` and
-`f` is `C^∞` within `s` at `x`. -/
-theorem SmoothAt.comp_smoothWithinAt {g : M' → M''} (x : M) (hg : SmoothAt I' I'' g (f x))
-    (hf : SmoothWithinAt I I' f s x) : SmoothWithinAt I I'' (g ∘ f) s x :=
-  hg.comp_contMDiffWithinAt x hf
+@[deprecated (since := "2024-11-20")]
+alias SmoothAt.comp_smoothWithinAt := ContMDiffAt.comp_contMDiffWithinAt
 
 /-- The composition of `C^n` functions at points is `C^n`. -/
 nonrec theorem ContMDiffAt.comp {g : M' → M''} (x : M) (hg : ContMDiffAt I' I'' n g (f x))
@@ -154,26 +134,19 @@ theorem ContMDiffAt.comp_of_eq {g : M' → M''} {x : M} {y : M'} (hg : ContMDiff
     (hf : ContMDiffAt I I' n f x) (hx : f x = y) : ContMDiffAt I I'' n (g ∘ f) x := by
   subst hx; exact hg.comp x hf
 
-/-- The composition of `C^∞` functions at points is `C^∞`. -/
-nonrec theorem SmoothAt.comp {g : M' → M''} (x : M) (hg : SmoothAt I' I'' g (f x))
-    (hf : SmoothAt I I' f x) : SmoothAt I I'' (g ∘ f) x :=
-  hg.comp x hf
+@[deprecated (since := "2024-11-20")] alias SmoothAt.comp := ContMDiffAt.comp
 
 theorem ContMDiff.comp_contMDiffOn {f : M → M'} {g : M' → M''} {s : Set M}
     (hg : ContMDiff I' I'' n g) (hf : ContMDiffOn I I' n f s) : ContMDiffOn I I'' n (g ∘ f) s :=
   hg.contMDiffOn.comp hf Set.subset_preimage_univ
 
-theorem Smooth.comp_smoothOn {f : M → M'} {g : M' → M''} {s : Set M} (hg : Smooth I' I'' g)
-    (hf : SmoothOn I I' f s) : SmoothOn I I'' (g ∘ f) s :=
-  hg.smoothOn.comp hf Set.subset_preimage_univ
+@[deprecated (since := "2024-11-20")] alias Smooth.comp_smoothOn := ContMDiff.comp_contMDiffOn
 
 theorem ContMDiffOn.comp_contMDiff {t : Set M'} {g : M' → M''} (hg : ContMDiffOn I' I'' n g t)
     (hf : ContMDiff I I' n f) (ht : ∀ x, f x ∈ t) : ContMDiff I I'' n (g ∘ f) :=
   contMDiffOn_univ.mp <| hg.comp hf.contMDiffOn fun x _ => ht x
 
-theorem SmoothOn.comp_smooth {t : Set M'} {g : M' → M''} (hg : SmoothOn I' I'' g t)
-    (hf : Smooth I I' f) (ht : ∀ x, f x ∈ t) : Smooth I I'' (g ∘ f) :=
-  hg.comp_contMDiff hf ht
+@[deprecated (since := "2024-11-20")] alias SmoothOn.comp_smooth := ContMDiffOn.comp_contMDiff
 
 end Composition
 
@@ -185,26 +158,22 @@ theorem contMDiff_id : ContMDiff I I n (id : M → M) :=
   ContMDiff.of_le
     ((contDiffWithinAt_localInvariantProp ∞).liftProp_id contDiffWithinAtProp_id) le_top
 
-theorem smooth_id : Smooth I I (id : M → M) :=
-  contMDiff_id
+@[deprecated (since := "2024-11-20")] alias smooth_id := contMDiff_id
 
 theorem contMDiffOn_id : ContMDiffOn I I n (id : M → M) s :=
   contMDiff_id.contMDiffOn
 
-theorem smoothOn_id : SmoothOn I I (id : M → M) s :=
-  contMDiffOn_id
+@[deprecated (since := "2024-11-20")] alias smoothOn_id := contMDiffOn_id
 
 theorem contMDiffAt_id : ContMDiffAt I I n (id : M → M) x :=
   contMDiff_id.contMDiffAt
 
-theorem smoothAt_id : SmoothAt I I (id : M → M) x :=
-  contMDiffAt_id
+@[deprecated (since := "2024-11-20")] alias smoothAt_id := contMDiffAt_id
 
 theorem contMDiffWithinAt_id : ContMDiffWithinAt I I n (id : M → M) s x :=
   contMDiffAt_id.contMDiffWithinAt
 
-theorem smoothWithinAt_id : SmoothWithinAt I I (id : M → M) s x :=
-  contMDiffWithinAt_id
+@[deprecated (since := "2024-11-20")] alias smoothWithinAt_id := contMDiffWithinAt_id
 
 end id
 
@@ -223,11 +192,10 @@ theorem contMDiff_const : ContMDiff I I' n fun _ : M => c := by
 theorem contMDiff_one [One M'] : ContMDiff I I' n (1 : M → M') := by
   simp only [Pi.one_def, contMDiff_const]
 
-theorem smooth_const : Smooth I I' fun _ : M => c :=
-  contMDiff_const
+@[deprecated (since := "2024-11-20")] alias smooth_const := contMDiff_const
 
-@[to_additive]
-theorem smooth_one [One M'] : Smooth I I' (1 : M → M') := by simp only [Pi.one_def, smooth_const]
+@[deprecated (since := "2024-11-20")] alias smooth_one := contMDiff_one
+@[deprecated (since := "2024-11-20")] alias smooth_zero := contMDiff_zero
 
 theorem contMDiffOn_const : ContMDiffOn I I' n (fun _ : M => c) s :=
   contMDiff_const.contMDiffOn
@@ -236,12 +204,11 @@ theorem contMDiffOn_const : ContMDiffOn I I' n (fun _ : M => c) s :=
 theorem contMDiffOn_one [One M'] : ContMDiffOn I I' n (1 : M → M') s :=
   contMDiff_one.contMDiffOn
 
-theorem smoothOn_const : SmoothOn I I' (fun _ : M => c) s :=
-  contMDiffOn_const
+@[deprecated (since := "2024-11-20")] alias smoothOn_const := contMDiffOn_const
 
-@[to_additive]
-theorem smoothOn_one [One M'] : SmoothOn I I' (1 : M → M') s :=
-  contMDiffOn_one
+@[deprecated (since := "2024-11-20")] alias smoothOn_one := contMDiffOn_one
+@[deprecated (since := "2024-11-20")] alias smoothOn_zero := contMDiffOn_zero
+
 
 theorem contMDiffAt_const : ContMDiffAt I I' n (fun _ : M => c) x :=
   contMDiff_const.contMDiffAt
@@ -250,12 +217,10 @@ theorem contMDiffAt_const : ContMDiffAt I I' n (fun _ : M => c) x :=
 theorem contMDiffAt_one [One M'] : ContMDiffAt I I' n (1 : M → M') x :=
   contMDiff_one.contMDiffAt
 
-theorem smoothAt_const : SmoothAt I I' (fun _ : M => c) x :=
-  contMDiffAt_const
+@[deprecated (since := "2024-11-20")] alias smoothAt_const := contMDiffAt_const
 
-@[to_additive]
-theorem smoothAt_one [One M'] : SmoothAt I I' (1 : M → M') x :=
-  contMDiffAt_one
+@[deprecated (since := "2024-11-20")] alias smoothAt_one := contMDiffAt_one
+@[deprecated (since := "2024-11-20")] alias smoothAt_zero := contMDiffAt_zero
 
 theorem contMDiffWithinAt_const : ContMDiffWithinAt I I' n (fun _ : M => c) s x :=
   contMDiffAt_const.contMDiffWithinAt
@@ -264,12 +229,10 @@ theorem contMDiffWithinAt_const : ContMDiffWithinAt I I' n (fun _ : M => c) s x 
 theorem contMDiffWithinAt_one [One M'] : ContMDiffWithinAt I I' n (1 : M → M') s x :=
   contMDiffAt_const.contMDiffWithinAt
 
-theorem smoothWithinAt_const : SmoothWithinAt I I' (fun _ : M => c) s x :=
-  contMDiffWithinAt_const
+@[deprecated (since := "2024-11-20")] alias smoothWithinAt_const := contMDiffWithinAt_const
 
-@[to_additive]
-theorem smoothWithinAt_one [One M'] : SmoothWithinAt I I' (1 : M → M') s x :=
-  contMDiffWithinAt_one
+@[deprecated (since := "2024-11-20")] alias smoothWithinAt_one := contMDiffWithinAt_one
+@[deprecated (since := "2024-11-20")] alias smoothWithinAt_zero := contMDiffWithinAt_zero
 
 end id
 
@@ -305,12 +268,14 @@ section Inclusion
 
 open TopologicalSpace
 
-theorem contMdiffAt_subtype_iff {n : ℕ∞} {U : Opens M} {f : M → M'} {x : U} :
+theorem contMDiffAt_subtype_iff {n : ℕ∞} {U : Opens M} {f : M → M'} {x : U} :
     ContMDiffAt I I' n (fun x : U ↦ f x) x ↔ ContMDiffAt I I' n f x :=
   ((contDiffWithinAt_localInvariantProp n).liftPropAt_iff_comp_subtype_val _ _).symm
 
+@[deprecated (since := "2024-11-20")] alias contMdiffAt_subtype_iff := contMDiffAt_subtype_iff
+
 theorem contMDiff_subtype_val {n : ℕ∞} {U : Opens M} : ContMDiff I I n (Subtype.val : U → M) :=
-  fun _ ↦ contMdiffAt_subtype_iff.mpr contMDiffAt_id
+  fun _ ↦ contMDiffAt_subtype_iff.mpr contMDiffAt_id
 
 @[to_additive]
 theorem ContMDiff.extend_one [T2Space M] [One M'] {n : ℕ∞} {U : Opens M} {f : U → M'}
@@ -319,7 +284,7 @@ theorem ContMDiff.extend_one [T2Space M] [One M'] {n : ℕ∞} {U : Opens M} {f 
   refine contMDiff_of_mulTSupport (fun x h ↦ ?_) _
   lift x to U using Subtype.coe_image_subset _ _
     (supp.mulTSupport_extend_one_subset continuous_subtype_val h)
-  rw [← contMdiffAt_subtype_iff]
+  rw [← contMDiffAt_subtype_iff]
   simp_rw [← comp_def]
   rw [extend_comp Subtype.val_injective]
   exact diff.contMDiffAt
@@ -333,19 +298,14 @@ theorem contMDiff_inclusion {n : ℕ∞} {U V : Opens M} (h : U ≤ V) :
   rw [Set.univ_inter]
   exact contDiffWithinAt_id.congr I.rightInvOn (congr_arg I (I.left_inv y))
 
-theorem smooth_subtype_iff {U : Opens M} {f : M → M'} {x : U} :
-    SmoothAt I I' (fun x : U ↦ f x) x ↔ SmoothAt I I' f x := contMdiffAt_subtype_iff
+@[deprecated (since := "2024-11-20")] alias smooth_subtype_iff := contMDiffAt_subtype_iff
 
-theorem smooth_subtype_val {U : Opens M} : Smooth I I (Subtype.val : U → M) := contMDiff_subtype_val
+@[deprecated (since := "2024-11-20")] alias smooth_subtype_val := contMDiff_subtype_val
 
-@[to_additive]
-theorem Smooth.extend_one [T2Space M] [One M'] {U : Opens M} {f : U → M'}
-    (supp : HasCompactMulSupport f) (diff : Smooth I I' f) : Smooth I I' (Subtype.val.extend f 1) :=
-  ContMDiff.extend_one supp diff
+@[deprecated (since := "2024-11-20")] alias Smooth.extend_one := ContMDiff.extend_one
+@[deprecated (since := "2024-11-20")] alias Smooth.extend_zero := ContMDiff.extend_zero
 
-theorem smooth_inclusion {U V : Opens M} (h : U ≤ V) :
-    Smooth I I (Opens.inclusion h : U → V) :=
-  contMDiff_inclusion h
+@[deprecated (since := "2024-11-20")] alias smooth_inclusion := contMDiff_inclusion
 
 end Inclusion
 

--- a/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
@@ -155,11 +155,11 @@ read in the preferred chart at this point. -/
 def ContMDiffWithinAt (n : ℕ∞) (f : M → M') (s : Set M) (x : M) :=
   LiftPropWithinAt (ContDiffWithinAtProp I I' n) f s x
 
-variable (I I') in
-/-- Abbreviation for `ContMDiffWithinAt I I' ⊤ f s x`. See also documentation for `Smooth`.
+--variable (I I') in
+/- Abbreviation for `ContMDiffWithinAt I I' ⊤ f s x`. See also documentation for `Smooth`.
 -/
-abbrev SmoothWithinAt (f : M → M') (s : Set M) (x : M) :=
-  ContMDiffWithinAt I I' ⊤ f s x
+--abbrev SmoothWithinAt (f : M → M') (s : Set M) (x : M) :=
+--  ContMDiffWithinAt I I' ⊤ f s x
 
 variable (I I') in
 /-- A function is `n` times continuously differentiable at a point in a manifold if
@@ -175,10 +175,10 @@ theorem contMDiffAt_iff {n : ℕ∞} {f : M → M'} {x : M} :
           (extChartAt I x x) :=
   liftPropAt_iff.trans <| by rw [ContDiffWithinAtProp, preimage_univ, univ_inter]; rfl
 
-variable (I I') in
-/-- Abbreviation for `ContMDiffAt I I' ⊤ f x`. See also documentation for `Smooth`. -/
-abbrev SmoothAt (f : M → M') (x : M) :=
-  ContMDiffAt I I' ⊤ f x
+--variable (I I') in
+/- Abbreviation for `ContMDiffAt I I' ⊤ f x`. See also documentation for `Smooth`. -/
+--abbrev SmoothAt (f : M → M') (x : M) :=
+--  ContMDiffAt I I' ⊤ f x
 
 variable (I I') in
 /-- A function is `n` times continuously differentiable in a set of a manifold if it is continuous
@@ -187,10 +187,10 @@ around these points. -/
 def ContMDiffOn (n : ℕ∞) (f : M → M') (s : Set M) :=
   ∀ x ∈ s, ContMDiffWithinAt I I' n f s x
 
-variable (I I') in
-/-- Abbreviation for `ContMDiffOn I I' ⊤ f s`. See also documentation for `Smooth`. -/
-abbrev SmoothOn (f : M → M') (s : Set M) :=
-  ContMDiffOn I I' ⊤ f s
+--variable (I I') in
+/- Abbreviation for `ContMDiffOn I I' ⊤ f s`. See also documentation for `Smooth`. -/
+--abbrev SmoothOn (f : M → M') (s : Set M) :=
+--  ContMDiffOn I I' ⊤ f s
 
 variable (I I') in
 /-- A function is `n` times continuously differentiable in a manifold if it is continuous
@@ -200,15 +200,15 @@ def ContMDiff (n : ℕ∞) (f : M → M') :=
   ∀ x, ContMDiffAt I I' n f x
 
 variable (I I') in
-/-- Abbreviation for `ContMDiff I I' ⊤ f`.
+/- Abbreviation for `ContMDiff I I' ⊤ f`.
 Short note to work with these abbreviations: a lemma of the form `ContMDiffFoo.bar` will
 apply fine to an assumption `SmoothFoo` using dot notation or normal notation.
 If the consequence `bar` of the lemma involves `ContDiff`, it is still better to restate
 the lemma replacing `ContDiff` with `Smooth` both in the assumption and in the conclusion,
 to make it possible to use `Smooth` consistently.
 This also applies to `SmoothAt`, `SmoothOn` and `SmoothWithinAt`. -/
-abbrev Smooth (f : M → M') :=
-  ContMDiff I I' ⊤ f
+--abbrev Smooth (f : M → M') :=
+--  ContMDiff I I' ⊤ f
 
 /-! ### Deducing smoothness from higher smoothness -/
 
@@ -228,49 +228,38 @@ theorem ContMDiff.of_le (hf : ContMDiff I I' n f) (le : m ≤ n) : ContMDiff I I
 
 /-! ### Basic properties of smooth functions between manifolds -/
 
-theorem ContMDiff.smooth (h : ContMDiff I I' ⊤ f) : Smooth I I' f :=
-  h
+@[deprecated (since := "2024-11-20")] alias ContMDiff.smooth := ContMDiff.of_le
 
-theorem Smooth.contMDiff (h : Smooth I I' f) : ContMDiff I I' n f :=
-  h.of_le le_top
+@[deprecated (since := "2024-11-20")] alias Smooth.contMDiff := ContMDiff.of_le
 
-theorem ContMDiffOn.smoothOn (h : ContMDiffOn I I' ⊤ f s) : SmoothOn I I' f s :=
-  h
+@[deprecated (since := "2024-11-20")] alias ContMDiffOn.smoothOn := ContMDiffOn.of_le
 
-theorem SmoothOn.contMDiffOn (h : SmoothOn I I' f s) : ContMDiffOn I I' n f s :=
-  h.of_le le_top
+@[deprecated (since := "2024-11-20")] alias SmoothOn.contMDiffOn := ContMDiffOn.of_le
 
-theorem ContMDiffAt.smoothAt (h : ContMDiffAt I I' ⊤ f x) : SmoothAt I I' f x :=
-  h
+@[deprecated (since := "2024-11-20")] alias ContMDiffAt.smoothAt := ContMDiffAt.of_le
 
-theorem SmoothAt.contMDiffAt (h : SmoothAt I I' f x) : ContMDiffAt I I' n f x :=
-  h.of_le le_top
+@[deprecated (since := "2024-11-20")] alias SmoothAt.contMDiffAt := ContMDiffOn.of_le
 
-theorem ContMDiffWithinAt.smoothWithinAt (h : ContMDiffWithinAt I I' ⊤ f s x) :
-    SmoothWithinAt I I' f s x :=
-  h
+@[deprecated (since := "2024-11-20")]
+alias ContMDiffWithinAt.smoothWithinAt := ContMDiffWithinAt.of_le
 
-theorem SmoothWithinAt.contMDiffWithinAt (h : SmoothWithinAt I I' f s x) :
-    ContMDiffWithinAt I I' n f s x :=
-  h.of_le le_top
+@[deprecated (since := "2024-11-20")]
+alias SmoothWithinAt.contMDiffWithinAt := ContMDiffWithinAt.of_le
 
 theorem ContMDiff.contMDiffAt (h : ContMDiff I I' n f) : ContMDiffAt I I' n f x :=
   h x
 
-theorem Smooth.smoothAt (h : Smooth I I' f) : SmoothAt I I' f x :=
-  ContMDiff.contMDiffAt h
+@[deprecated (since := "2024-11-20")] alias Smooth.smoothAt := ContMDiff.contMDiffAt
 
 theorem contMDiffWithinAt_univ : ContMDiffWithinAt I I' n f univ x ↔ ContMDiffAt I I' n f x :=
   Iff.rfl
 
-theorem smoothWithinAt_univ : SmoothWithinAt I I' f univ x ↔ SmoothAt I I' f x :=
-  contMDiffWithinAt_univ
+@[deprecated (since := "2024-11-20")] alias smoothWithinAt_univ := contMDiffWithinAt_univ
 
 theorem contMDiffOn_univ : ContMDiffOn I I' n f univ ↔ ContMDiff I I' n f := by
   simp only [ContMDiffOn, ContMDiff, contMDiffWithinAt_univ, forall_prop_of_true, mem_univ]
 
-theorem smoothOn_univ : SmoothOn I I' f univ ↔ Smooth I I' f :=
-  contMDiffOn_univ
+@[deprecated (since := "2024-11-20")] alias smoothOn_univ := contMDiffOn_univ
 
 /-- One can reformulate smoothness within a set at a point as continuity within this set at this
 point, and smoothness in the corresponding extended chart. -/
@@ -315,26 +304,18 @@ theorem contMDiffWithinAt_iff_target :
     chartAt_self_eq, PartialHomeomorph.refl_apply, id_comp]
   rfl
 
-theorem smoothWithinAt_iff :
-    SmoothWithinAt I I' f s x ↔
-      ContinuousWithinAt f s x ∧
-        ContDiffWithinAt 𝕜 ∞ (extChartAt I' (f x) ∘ f ∘ (extChartAt I x).symm)
-          ((extChartAt I x).symm ⁻¹' s ∩ range I) (extChartAt I x x) :=
-  contMDiffWithinAt_iff
+@[deprecated (since := "2024-11-20")] alias smoothWithinAt_iff := contMDiffWithinAt_iff
 
-theorem smoothWithinAt_iff_target :
-    SmoothWithinAt I I' f s x ↔
-      ContinuousWithinAt f s x ∧ SmoothWithinAt I 𝓘(𝕜, E') (extChartAt I' (f x) ∘ f) s x :=
-  contMDiffWithinAt_iff_target
+@[deprecated (since := "2024-11-20")]
+alias smoothWithinAt_iff_target := contMDiffWithinAt_iff_target
 
 theorem contMDiffAt_iff_target {x : M} :
     ContMDiffAt I I' n f x ↔
       ContinuousAt f x ∧ ContMDiffAt I 𝓘(𝕜, E') n (extChartAt I' (f x) ∘ f) x := by
   rw [ContMDiffAt, ContMDiffAt, contMDiffWithinAt_iff_target, continuousWithinAt_univ]
 
-theorem smoothAt_iff_target {x : M} :
-    SmoothAt I I' f x ↔ ContinuousAt f x ∧ SmoothAt I 𝓘(𝕜, E') (extChartAt I' (f x) ∘ f) x :=
-  contMDiffAt_iff_target
+@[deprecated (since := "2024-11-20")] alias smoothAt_iff_target := contMDiffAt_iff_target
+
 
 section SmoothManifoldWithCorners
 
@@ -533,20 +514,10 @@ theorem contMDiffOn_iff_target :
     simp
   · exact fun h' x y => (h' y).2 x 0
 
-theorem smoothOn_iff :
-    SmoothOn I I' f s ↔
-      ContinuousOn f s ∧
-        ∀ (x : M) (y : M'),
-          ContDiffOn 𝕜 ⊤ (extChartAt I' y ∘ f ∘ (extChartAt I x).symm)
-            ((extChartAt I x).target ∩
-              (extChartAt I x).symm ⁻¹' (s ∩ f ⁻¹' (extChartAt I' y).source)) :=
-  contMDiffOn_iff
+@[deprecated (since := "2024-11-20")] alias smoothOn_iff := contMDiffOn_iff
 
-theorem smoothOn_iff_target :
-    SmoothOn I I' f s ↔
-      ContinuousOn f s ∧
-        ∀ y : M', SmoothOn I 𝓘(𝕜, E') (extChartAt I' y ∘ f) (s ∩ f ⁻¹' (extChartAt I' y).source) :=
-  contMDiffOn_iff_target
+@[deprecated (since := "2024-11-20")] alias smoothOn_iff_target := contMDiffOn_iff_target
+
 
 /-- One can reformulate smoothness as continuity and smoothness in any extended chart. -/
 theorem contMDiff_iff :
@@ -567,20 +538,9 @@ theorem contMDiff_iff_target :
   rw [← contMDiffOn_univ, contMDiffOn_iff_target]
   simp [continuous_iff_continuousOn_univ]
 
-theorem smooth_iff :
-    Smooth I I' f ↔
-      Continuous f ∧
-        ∀ (x : M) (y : M'),
-          ContDiffOn 𝕜 ⊤ (extChartAt I' y ∘ f ∘ (extChartAt I x).symm)
-            ((extChartAt I x).target ∩
-              (extChartAt I x).symm ⁻¹' (f ⁻¹' (extChartAt I' y).source)) :=
-  contMDiff_iff
+@[deprecated (since := "2024-11-20")] alias smooth_iff := contMDiff_iff
 
-theorem smooth_iff_target :
-    Smooth I I' f ↔
-      Continuous f ∧
-        ∀ y : M', SmoothOn I 𝓘(𝕜, E') (extChartAt I' y ∘ f) (f ⁻¹' (extChartAt I' y).source) :=
-  contMDiff_iff_target
+@[deprecated (since := "2024-11-20")] alias smooth_iff_target := contMDiff_iff_target
 
 end SmoothManifoldWithCorners
 
@@ -619,17 +579,17 @@ theorem ContMDiff.continuous (hf : ContMDiff I I' n f) : Continuous f :=
 /-! ### `C^∞` smoothness -/
 
 theorem contMDiffWithinAt_top :
-    SmoothWithinAt I I' f s x ↔ ∀ n : ℕ, ContMDiffWithinAt I I' n f s x :=
+    ContMDiffWithinAt I I' ⊤ f s x ↔ ∀ n : ℕ, ContMDiffWithinAt I I' n f s x :=
   ⟨fun h n => ⟨h.1, contDiffWithinAt_top.1 h.2 n⟩, fun H =>
     ⟨(H 0).1, contDiffWithinAt_top.2 fun n => (H n).2⟩⟩
 
-theorem contMDiffAt_top : SmoothAt I I' f x ↔ ∀ n : ℕ, ContMDiffAt I I' n f x :=
+theorem contMDiffAt_top : ContMDiffAt I I' ⊤ f x ↔ ∀ n : ℕ, ContMDiffAt I I' n f x :=
   contMDiffWithinAt_top
 
-theorem contMDiffOn_top : SmoothOn I I' f s ↔ ∀ n : ℕ, ContMDiffOn I I' n f s :=
+theorem contMDiffOn_top : ContMDiffOn I I' ⊤ f s ↔ ∀ n : ℕ, ContMDiffOn I I' n f s :=
   ⟨fun h _ => h.of_le le_top, fun h x hx => contMDiffWithinAt_top.2 fun n => h n x hx⟩
 
-theorem contMDiff_top : Smooth I I' f ↔ ∀ n : ℕ, ContMDiff I I' n f :=
+theorem contMDiff_top : ContMDiff I I' ⊤ f ↔ ∀ n : ℕ, ContMDiff I I' n f :=
   ⟨fun h _ => h.of_le le_top, fun h x => contMDiffWithinAt_top.2 fun n => h n x⟩
 
 theorem contMDiffWithinAt_iff_nat :
@@ -691,8 +651,7 @@ protected theorem ContMDiffAt.contMDiffWithinAt (hf : ContMDiffAt I I' n f x) :
     ContMDiffWithinAt I I' n f s x :=
   ContMDiffWithinAt.mono hf (subset_univ _)
 
-protected theorem SmoothAt.smoothWithinAt (hf : SmoothAt I I' f x) : SmoothWithinAt I I' f s x :=
-  ContMDiffAt.contMDiffWithinAt hf
+@[deprecated (since := "2024-11-20")] alias SmoothAt.smoothWithinAt := ContMDiffAt.contMDiffWithinAt
 
 theorem ContMDiffOn.mono (hf : ContMDiffOn I I' n f s) (hts : t ⊆ s) : ContMDiffOn I I' n f t :=
   fun x hx => (hf x (hts hx)).mono hts
@@ -700,8 +659,7 @@ theorem ContMDiffOn.mono (hf : ContMDiffOn I I' n f s) (hts : t ⊆ s) : ContMDi
 protected theorem ContMDiff.contMDiffOn (hf : ContMDiff I I' n f) : ContMDiffOn I I' n f s :=
   fun x _ => (hf x).contMDiffWithinAt
 
-protected theorem Smooth.smoothOn (hf : Smooth I I' f) : SmoothOn I I' f s :=
-  ContMDiff.contMDiffOn hf
+@[deprecated (since := "2024-11-20")] alias Smooth.smoothOn := ContMDiff.contMDiffOn
 
 theorem contMDiffWithinAt_inter' (ht : t ∈ 𝓝[s] x) :
     ContMDiffWithinAt I I' n f (s ∩ t) x ↔ ContMDiffWithinAt I I' n f s x :=
@@ -716,16 +674,13 @@ protected theorem ContMDiffWithinAt.contMDiffAt
     ContMDiffAt I I' n f x :=
   (contDiffWithinAt_localInvariantProp n).liftPropAt_of_liftPropWithinAt h ht
 
-protected theorem SmoothWithinAt.smoothAt (h : SmoothWithinAt I I' f s x) (ht : s ∈ 𝓝 x) :
-    SmoothAt I I' f x :=
-  ContMDiffWithinAt.contMDiffAt h ht
+@[deprecated (since := "2024-11-20")] alias SmoothWithinAt.smoothAt := ContMDiffWithinAt.contMDiffAt
 
 protected theorem ContMDiffOn.contMDiffAt (h : ContMDiffOn I I' n f s) (hx : s ∈ 𝓝 x) :
     ContMDiffAt I I' n f x :=
   (h x (mem_of_mem_nhds hx)).contMDiffAt hx
 
-protected theorem SmoothOn.smoothAt (h : SmoothOn I I' f s) (hx : s ∈ 𝓝 x) : SmoothAt I I' f x :=
-  h.contMDiffAt hx
+@[deprecated (since := "2024-11-20")] alias SmoothOn.smoothAt := ContMDiffOn.contMDiffAt
 
 theorem contMDiffOn_iff_source_of_mem_maximalAtlas [SmoothManifoldWithCorners I M]
     (he : e ∈ maximalAtlas I M) (hs : s ⊆ e.source) :

--- a/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
@@ -155,11 +155,7 @@ read in the preferred chart at this point. -/
 def ContMDiffWithinAt (n : ℕ∞) (f : M → M') (s : Set M) (x : M) :=
   LiftPropWithinAt (ContDiffWithinAtProp I I' n) f s x
 
---variable (I I') in
-/- Abbreviation for `ContMDiffWithinAt I I' ⊤ f s x`. See also documentation for `Smooth`.
--/
---abbrev SmoothWithinAt (f : M → M') (s : Set M) (x : M) :=
---  ContMDiffWithinAt I I' ⊤ f s x
+@[deprecated (since := "024-11-21")] alias SmoothWithinAt := ContMDiffWithinAt
 
 variable (I I') in
 /-- A function is `n` times continuously differentiable at a point in a manifold if
@@ -175,10 +171,7 @@ theorem contMDiffAt_iff {n : ℕ∞} {f : M → M'} {x : M} :
           (extChartAt I x x) :=
   liftPropAt_iff.trans <| by rw [ContDiffWithinAtProp, preimage_univ, univ_inter]; rfl
 
---variable (I I') in
-/- Abbreviation for `ContMDiffAt I I' ⊤ f x`. See also documentation for `Smooth`. -/
---abbrev SmoothAt (f : M → M') (x : M) :=
---  ContMDiffAt I I' ⊤ f x
+@[deprecated (since := "024-11-21")] alias SmoothAt := ContMDiffAt
 
 variable (I I') in
 /-- A function is `n` times continuously differentiable in a set of a manifold if it is continuous
@@ -187,10 +180,7 @@ around these points. -/
 def ContMDiffOn (n : ℕ∞) (f : M → M') (s : Set M) :=
   ∀ x ∈ s, ContMDiffWithinAt I I' n f s x
 
---variable (I I') in
-/- Abbreviation for `ContMDiffOn I I' ⊤ f s`. See also documentation for `Smooth`. -/
---abbrev SmoothOn (f : M → M') (s : Set M) :=
---  ContMDiffOn I I' ⊤ f s
+@[deprecated (since := "024-11-21")] alias SmoothOn := ContMDiffOn
 
 variable (I I') in
 /-- A function is `n` times continuously differentiable in a manifold if it is continuous
@@ -199,16 +189,8 @@ around these points. -/
 def ContMDiff (n : ℕ∞) (f : M → M') :=
   ∀ x, ContMDiffAt I I' n f x
 
-variable (I I') in
-/- Abbreviation for `ContMDiff I I' ⊤ f`.
-Short note to work with these abbreviations: a lemma of the form `ContMDiffFoo.bar` will
-apply fine to an assumption `SmoothFoo` using dot notation or normal notation.
-If the consequence `bar` of the lemma involves `ContDiff`, it is still better to restate
-the lemma replacing `ContDiff` with `Smooth` both in the assumption and in the conclusion,
-to make it possible to use `Smooth` consistently.
-This also applies to `SmoothAt`, `SmoothOn` and `SmoothWithinAt`. -/
---abbrev Smooth (f : M → M') :=
---  ContMDiff I I' ⊤ f
+@[deprecated (since := "024-11-21")] alias Smooth := ContMDiff
+
 
 /-! ### Deducing smoothness from higher smoothness -/
 

--- a/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
@@ -105,7 +105,8 @@ theorem ContinuousLinearMap.contMDiffWithinAt (L : E →L[𝕜] F) {s x} :
 theorem ContinuousLinearMap.contMDiffOn (L : E →L[𝕜] F) {s} : ContMDiffOn 𝓘(𝕜, E) 𝓘(𝕜, F) n L s :=
   L.contMDiff.contMDiffOn
 
-theorem ContinuousLinearMap.smooth (L : E →L[𝕜] F) : Smooth 𝓘(𝕜, E) 𝓘(𝕜, F) L := L.contMDiff
+@[deprecated (since := "2024-11-20")]
+alias ContinuousLinearMap.smooth := ContinuousLinearMap.contMDiff
 
 theorem ContMDiffWithinAt.clm_precomp {f : M → F₁ →L[𝕜] F₂} {s : Set M} {x : M}
     (hf : ContMDiffWithinAt I 𝓘(𝕜, F₁ →L[𝕜] F₂) n f s x) :
@@ -261,13 +262,15 @@ theorem ContMDiff.clm_prodMap {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ �
 variable {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V]
 
 /-- On any vector space, multiplication by a scalar is a smooth operation. -/
-theorem smooth_smul : Smooth (𝓘(𝕜).prod 𝓘(𝕜, V)) 𝓘(𝕜, V) fun p : 𝕜 × V => p.1 • p.2 :=
-  smooth_iff.2 ⟨continuous_smul, fun _ _ => contDiff_smul.contDiffOn⟩
+theorem contMDiff_smul : ContMDiff (𝓘(𝕜).prod 𝓘(𝕜, V)) 𝓘(𝕜, V) ⊤ fun p : 𝕜 × V => p.1 • p.2 :=
+  contMDiff_iff.2 ⟨continuous_smul, fun _ _ => contDiff_smul.contDiffOn⟩
+
+@[deprecated (since := "2024-11-20")] alias smooth_smul := contMDiff_smul
 
 theorem ContMDiffWithinAt.smul {f : M → 𝕜} {g : M → V} (hf : ContMDiffWithinAt I 𝓘(𝕜) n f s x)
     (hg : ContMDiffWithinAt I 𝓘(𝕜, V) n g s x) :
     ContMDiffWithinAt I 𝓘(𝕜, V) n (fun p => f p • g p) s x :=
-  (smooth_smul.of_le le_top).contMDiffAt.comp_contMDiffWithinAt x (hf.prod_mk hg)
+  (contMDiff_smul.of_le le_top).contMDiffAt.comp_contMDiffWithinAt x (hf.prod_mk hg)
 
 nonrec theorem ContMDiffAt.smul {f : M → 𝕜} {g : M → V} (hf : ContMDiffAt I 𝓘(𝕜) n f x)
     (hg : ContMDiffAt I 𝓘(𝕜, V) n g x) : ContMDiffAt I 𝓘(𝕜, V) n (fun p => f p • g p) x :=
@@ -281,18 +284,10 @@ theorem ContMDiff.smul {f : M → 𝕜} {g : M → V} (hf : ContMDiff I 𝓘(�
     (hg : ContMDiff I 𝓘(𝕜, V) n g) : ContMDiff I 𝓘(𝕜, V) n fun p => f p • g p := fun x =>
   (hf x).smul (hg x)
 
-nonrec theorem SmoothWithinAt.smul {f : M → 𝕜} {g : M → V} (hf : SmoothWithinAt I 𝓘(𝕜) f s x)
-    (hg : SmoothWithinAt I 𝓘(𝕜, V) g s x) : SmoothWithinAt I 𝓘(𝕜, V) (fun p => f p • g p) s x :=
-  hf.smul hg
+@[deprecated (since := "2024-11-20")] alias SmoothWithinAt.smul := ContMDiffWithinAt.smul
 
-nonrec theorem SmoothAt.smul {f : M → 𝕜} {g : M → V} (hf : SmoothAt I 𝓘(𝕜) f x)
-    (hg : SmoothAt I 𝓘(𝕜, V) g x) : SmoothAt I 𝓘(𝕜, V) (fun p => f p • g p) x :=
-  hf.smul hg
+@[deprecated (since := "2024-11-20")] alias SmoothAt.smul := ContMDiffAt.smul
 
-nonrec theorem SmoothOn.smul {f : M → 𝕜} {g : M → V} (hf : SmoothOn I 𝓘(𝕜) f s)
-    (hg : SmoothOn I 𝓘(𝕜, V) g s) : SmoothOn I 𝓘(𝕜, V) (fun p => f p • g p) s :=
-  hf.smul hg
+@[deprecated (since := "2024-11-20")] alias SmoothOn.smul := ContMDiffOn.smul
 
-nonrec theorem Smooth.smul {f : M → 𝕜} {g : M → V} (hf : Smooth I 𝓘(𝕜) f)
-    (hg : Smooth I 𝓘(𝕜, V) g) : Smooth I 𝓘(𝕜, V) fun p => f p • g p :=
-  hf.smul hg
+@[deprecated (since := "2024-11-20")] alias Smooth.smul := ContMDiff.smul

--- a/Mathlib/Geometry/Manifold/ContMDiff/Product.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Product.lean
@@ -81,38 +81,22 @@ theorem ContMDiff.prod_mk_space {f : M → E'} {g : M → F'} (hf : ContMDiff I 
     (hg : ContMDiff I 𝓘(𝕜, F') n g) : ContMDiff I 𝓘(𝕜, E' × F') n fun x => (f x, g x) := fun x =>
   (hf x).prod_mk_space (hg x)
 
-nonrec theorem SmoothWithinAt.prod_mk {f : M → M'} {g : M → N'} (hf : SmoothWithinAt I I' f s x)
-    (hg : SmoothWithinAt I J' g s x) : SmoothWithinAt I (I'.prod J') (fun x => (f x, g x)) s x :=
-  hf.prod_mk hg
+@[deprecated (since := "2024-11-20")] alias SmoothWithinAt.prod_mk := ContMDiffWithinAt.prod_mk
 
-nonrec theorem SmoothWithinAt.prod_mk_space {f : M → E'} {g : M → F'}
-    (hf : SmoothWithinAt I 𝓘(𝕜, E') f s x) (hg : SmoothWithinAt I 𝓘(𝕜, F') g s x) :
-    SmoothWithinAt I 𝓘(𝕜, E' × F') (fun x => (f x, g x)) s x :=
-  hf.prod_mk_space hg
+@[deprecated (since := "2024-11-20")]
+alias SmoothWithinAt.prod_mk_space := ContMDiffWithinAt.prod_mk_space
 
-nonrec theorem SmoothAt.prod_mk {f : M → M'} {g : M → N'} (hf : SmoothAt I I' f x)
-    (hg : SmoothAt I J' g x) : SmoothAt I (I'.prod J') (fun x => (f x, g x)) x :=
-  hf.prod_mk hg
+@[deprecated (since := "2024-11-20")] alias SmoothAt.prod_mk := ContMDiffAt.prod_mk
 
-nonrec theorem SmoothAt.prod_mk_space {f : M → E'} {g : M → F'} (hf : SmoothAt I 𝓘(𝕜, E') f x)
-    (hg : SmoothAt I 𝓘(𝕜, F') g x) : SmoothAt I 𝓘(𝕜, E' × F') (fun x => (f x, g x)) x :=
-  hf.prod_mk_space hg
+@[deprecated (since := "2024-11-20")] alias SmoothAt.prod_mk_space := ContMDiffAt.prod_mk_space
 
-nonrec theorem SmoothOn.prod_mk {f : M → M'} {g : M → N'} (hf : SmoothOn I I' f s)
-    (hg : SmoothOn I J' g s) : SmoothOn I (I'.prod J') (fun x => (f x, g x)) s :=
-  hf.prod_mk hg
+@[deprecated (since := "2024-11-20")] alias SmoothOn.prod_mk := ContMDiffOn.prod_mk
 
-nonrec theorem SmoothOn.prod_mk_space {f : M → E'} {g : M → F'} (hf : SmoothOn I 𝓘(𝕜, E') f s)
-    (hg : SmoothOn I 𝓘(𝕜, F') g s) : SmoothOn I 𝓘(𝕜, E' × F') (fun x => (f x, g x)) s :=
-  hf.prod_mk_space hg
+@[deprecated (since := "2024-11-20")] alias SmoothOn.prod_mk_space := ContMDiffOn.prod_mk_space
 
-nonrec theorem Smooth.prod_mk {f : M → M'} {g : M → N'} (hf : Smooth I I' f) (hg : Smooth I J' g) :
-    Smooth I (I'.prod J') fun x => (f x, g x) :=
-  hf.prod_mk hg
+@[deprecated (since := "2024-11-20")] alias Smooth.prod_mk := ContMDiff.prod_mk
 
-nonrec theorem Smooth.prod_mk_space {f : M → E'} {g : M → F'} (hf : Smooth I 𝓘(𝕜, E') f)
-    (hg : Smooth I 𝓘(𝕜, F') g) : Smooth I 𝓘(𝕜, E' × F') fun x => (f x, g x) :=
-  hf.prod_mk_space hg
+@[deprecated (since := "2024-11-20")] alias Smooth.prod_mk_space := ContMDiff.prod_mk_space
 
 end ProdMk
 
@@ -146,18 +130,13 @@ theorem contMDiffOn_fst {s : Set (M × N)} : ContMDiffOn (I.prod J) I n Prod.fst
 
 theorem contMDiff_fst : ContMDiff (I.prod J) I n (@Prod.fst M N) := fun _ => contMDiffAt_fst
 
-theorem smoothWithinAt_fst {s : Set (M × N)} {p : M × N} :
-    SmoothWithinAt (I.prod J) I Prod.fst s p :=
-  contMDiffWithinAt_fst
+@[deprecated (since := "2024-11-20")] alias smoothWithinAt_fst := contMDiffWithinAt_fst
 
-theorem smoothAt_fst {p : M × N} : SmoothAt (I.prod J) I Prod.fst p :=
-  contMDiffAt_fst
+@[deprecated (since := "2024-11-20")] alias smoothAt_fst := contMDiffAt_fst
 
-theorem smoothOn_fst {s : Set (M × N)} : SmoothOn (I.prod J) I Prod.fst s :=
-  contMDiffOn_fst
+@[deprecated (since := "2024-11-20")] alias smoothOn_fst := contMDiffOn_fst
 
-theorem smooth_fst : Smooth (I.prod J) I (@Prod.fst M N) :=
-  contMDiff_fst
+@[deprecated (since := "2024-11-20")] alias smooth_fst := contMDiff_fst
 
 theorem ContMDiffAt.fst {f : N → M × M'} {x : N} (hf : ContMDiffAt J (I.prod I') n f x) :
     ContMDiffAt J I n (fun x => (f x).1) x :=
@@ -167,12 +146,9 @@ theorem ContMDiff.fst {f : N → M × M'} (hf : ContMDiff J (I.prod I') n f) :
     ContMDiff J I n fun x => (f x).1 :=
   contMDiff_fst.comp hf
 
-theorem SmoothAt.fst {f : N → M × M'} {x : N} (hf : SmoothAt J (I.prod I') f x) :
-    SmoothAt J I (fun x => (f x).1) x :=
-  smoothAt_fst.comp x hf
+@[deprecated (since := "2024-11-20")] alias SmoothAt.fst := ContMDiffAt.fst
 
-theorem Smooth.fst {f : N → M × M'} (hf : Smooth J (I.prod I') f) : Smooth J I fun x => (f x).1 :=
-  smooth_fst.comp hf
+@[deprecated (since := "2024-11-20")] alias Smooth.fst := ContMDiff.fst
 
 theorem contMDiffWithinAt_snd {s : Set (M × N)} {p : M × N} :
     ContMDiffWithinAt (I.prod J) J n Prod.snd s p := by
@@ -202,18 +178,13 @@ theorem contMDiffOn_snd {s : Set (M × N)} : ContMDiffOn (I.prod J) J n Prod.snd
 
 theorem contMDiff_snd : ContMDiff (I.prod J) J n (@Prod.snd M N) := fun _ => contMDiffAt_snd
 
-theorem smoothWithinAt_snd {s : Set (M × N)} {p : M × N} :
-    SmoothWithinAt (I.prod J) J Prod.snd s p :=
-  contMDiffWithinAt_snd
+@[deprecated (since := "2024-11-20")] alias smoothWithinAt_snd := contMDiffWithinAt_snd
 
-theorem smoothAt_snd {p : M × N} : SmoothAt (I.prod J) J Prod.snd p :=
-  contMDiffAt_snd
+@[deprecated (since := "2024-11-20")] alias smoothAt_snd := contMDiffAt_snd
 
-theorem smoothOn_snd {s : Set (M × N)} : SmoothOn (I.prod J) J Prod.snd s :=
-  contMDiffOn_snd
+@[deprecated (since := "2024-11-20")] alias smoothOn_snd := contMDiffOn_snd
 
-theorem smooth_snd : Smooth (I.prod J) J (@Prod.snd M N) :=
-  contMDiff_snd
+@[deprecated (since := "2024-11-20")] alias smooth_snd := contMDiff_snd
 
 theorem ContMDiffAt.snd {f : N → M × M'} {x : N} (hf : ContMDiffAt J (I.prod I') n f x) :
     ContMDiffAt J I' n (fun x => (f x).2) x :=
@@ -223,12 +194,9 @@ theorem ContMDiff.snd {f : N → M × M'} (hf : ContMDiff J (I.prod I') n f) :
     ContMDiff J I' n fun x => (f x).2 :=
   contMDiff_snd.comp hf
 
-theorem SmoothAt.snd {f : N → M × M'} {x : N} (hf : SmoothAt J (I.prod I') f x) :
-    SmoothAt J I' (fun x => (f x).2) x :=
-  smoothAt_snd.comp x hf
+@[deprecated (since := "2024-11-20")] alias SmoothAt.snd := ContMDiffAt.snd
 
-theorem Smooth.snd {f : N → M × M'} (hf : Smooth J (I.prod I') f) : Smooth J I' fun x => (f x).2 :=
-  smooth_snd.comp hf
+@[deprecated (since := "2024-11-20")] alias Smooth.snd := ContMDiff.snd
 
 end Projections
 
@@ -279,17 +247,16 @@ theorem contMDiff_prod_module_iff (f : M → F₁ × F₂) :
   rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
   exact contMDiff_prod_iff f
 
-theorem smoothAt_prod_iff (f : M → M' × N') {x : M} :
-    SmoothAt I (I'.prod J') f x ↔ SmoothAt I I' (Prod.fst ∘ f) x ∧ SmoothAt I J' (Prod.snd ∘ f) x :=
-  contMDiffAt_prod_iff f
+theorem contMDiff_prod_assoc :
+    ContMDiff ((I.prod I').prod J) (I.prod (I'.prod J)) n
+      fun x : (M × M') × N => (x.1.1, x.1.2, x.2) :=
+  contMDiff_fst.fst.prod_mk <| contMDiff_fst.snd.prod_mk contMDiff_snd
 
-theorem smooth_prod_iff (f : M → M' × N') :
-    Smooth I (I'.prod J') f ↔ Smooth I I' (Prod.fst ∘ f) ∧ Smooth I J' (Prod.snd ∘ f) :=
-  contMDiff_prod_iff f
+@[deprecated (since := "2024-11-20")] alias smoothAt_prod_iff := contMDiffAt_prod_iff
 
-theorem smooth_prod_assoc :
-    Smooth ((I.prod I').prod J) (I.prod (I'.prod J)) fun x : (M × M') × N => (x.1.1, x.1.2, x.2) :=
-  smooth_fst.fst.prod_mk <| smooth_fst.snd.prod_mk smooth_snd
+@[deprecated (since := "2024-11-20")] alias smooth_prod_iff := contMDiff_prod_iff
+
+@[deprecated (since := "2024-11-20")] alias smooth_prod_assoc := contMDiff_prod_assoc
 
 section prodMap
 
@@ -329,22 +296,13 @@ theorem ContMDiff.prod_map (hf : ContMDiff I I' n f) (hg : ContMDiff J J' n g) :
   intro p
   exact (hf p.1).prod_map' (hg p.2)
 
-nonrec theorem SmoothWithinAt.prod_map (hf : SmoothWithinAt I I' f s x)
-    (hg : SmoothWithinAt J J' g r y) :
-    SmoothWithinAt (I.prod J) (I'.prod J') (Prod.map f g) (s ×ˢ r) (x, y) :=
-  hf.prod_map hg
+@[deprecated (since := "2024-11-20")] alias SmoothWithinAt.prod_map := ContMDiffWithinAt.prod_map
 
-nonrec theorem SmoothAt.prod_map (hf : SmoothAt I I' f x) (hg : SmoothAt J J' g y) :
-    SmoothAt (I.prod J) (I'.prod J') (Prod.map f g) (x, y) :=
-  hf.prod_map hg
+@[deprecated (since := "2024-11-20")] alias SmoothAt.prod_map := ContMDiffAt.prod_map
 
-nonrec theorem SmoothOn.prod_map (hf : SmoothOn I I' f s) (hg : SmoothOn J J' g r) :
-    SmoothOn (I.prod J) (I'.prod J') (Prod.map f g) (s ×ˢ r) :=
-  hf.prod_map hg
+@[deprecated (since := "2024-11-20")] alias SmoothOn.prod_map := ContMDiffOn.prod_map
 
-nonrec theorem Smooth.prod_map (hf : Smooth I I' f) (hg : Smooth J J' g) :
-    Smooth (I.prod J) (I'.prod J') (Prod.map f g) :=
-  hf.prod_map hg
+@[deprecated (since := "2024-11-20")] alias Smooth.prod_map := ContMDiff.prod_map
 
 end prodMap
 
@@ -380,20 +338,12 @@ theorem contMDiff_pi_space :
     ContMDiff I 𝓘(𝕜, ∀ i, Fi i) n φ ↔ ∀ i, ContMDiff I 𝓘(𝕜, Fi i) n fun x => φ x i :=
   ⟨fun h i x => contMDiffAt_pi_space.1 (h x) i, fun h x => contMDiffAt_pi_space.2 fun i => h i x⟩
 
-theorem smoothWithinAt_pi_space :
-    SmoothWithinAt I 𝓘(𝕜, ∀ i, Fi i) φ s x ↔
-      ∀ i, SmoothWithinAt I 𝓘(𝕜, Fi i) (fun x => φ x i) s x :=
-  contMDiffWithinAt_pi_space
+@[deprecated (since := "2024-11-20")] alias smoothWithinAt_pi_space := contMDiffWithinAt_pi_space
 
-theorem smoothOn_pi_space :
-    SmoothOn I 𝓘(𝕜, ∀ i, Fi i) φ s ↔ ∀ i, SmoothOn I 𝓘(𝕜, Fi i) (fun x => φ x i) s :=
-  contMDiffOn_pi_space
+@[deprecated (since := "2024-11-20")] alias smoothAt_pi_space := contMDiffAt_pi_space
 
-theorem smoothAt_pi_space :
-    SmoothAt I 𝓘(𝕜, ∀ i, Fi i) φ x ↔ ∀ i, SmoothAt I 𝓘(𝕜, Fi i) (fun x => φ x i) x :=
-  contMDiffAt_pi_space
+@[deprecated (since := "2024-11-20")] alias smoothOn_pi_space := contMDiffOn_pi_space
 
-theorem smooth_pi_space : Smooth I 𝓘(𝕜, ∀ i, Fi i) φ ↔ ∀ i, Smooth I 𝓘(𝕜, Fi i) fun x => φ x i :=
-  contMDiff_pi_space
+@[deprecated (since := "2024-11-20")] alias smooth_pi_space := contMDiff_pi_space
 
 end PiSpace

--- a/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
@@ -343,10 +343,7 @@ theorem ContMDiff.continuous_tangentMap (hf : ContMDiff I I' n f) (hmn : 1 ≤ n
   convert hf.continuousOn_tangentMapWithin hmn uniqueMDiffOn_univ
   rw [tangentMapWithin_univ]
 
-/-- If a function is smooth, then its bundled derivative is smooth. -/
-theorem Smooth.tangentMap (hf : Smooth I I' f) :
-    Smooth I.tangent I'.tangent (tangentMap I I' f) :=
-  ContMDiff.contMDiff_tangentMap hf le_rfl
+@[deprecated (since := "2024-11-21")] alias Smooth.tangentMap := ContMDiff.contMDiff_tangentMap
 
 end tangentMap
 
@@ -376,9 +373,9 @@ theorem tangentMap_tangentBundle_pure [Is : SmoothManifoldWithCorners I M] (p : 
     · apply (PartialHomeomorph.open_target _).preimage I.continuous_invFun
     · simp only [mfld_simps]
   have A : MDifferentiableAt I I.tangent (fun x => @TotalSpace.mk M E (TangentSpace I) x 0) x :=
-    haveI : Smooth I (I.prod 𝓘(𝕜, E)) (zeroSection E (TangentSpace I : M → Type _)) :=
-      Bundle.smooth_zeroSection 𝕜 (TangentSpace I : M → Type _)
-    this.mdifferentiableAt
+    haveI : ContMDiff I (I.prod 𝓘(𝕜, E)) ⊤ (zeroSection E (TangentSpace I : M → Type _)) :=
+      Bundle.contMDiff_zeroSection 𝕜 (TangentSpace I : M → Type _)
+    this.mdifferentiableAt le_top
   have B : fderivWithin 𝕜 (fun x' : E ↦ (x', (0 : E))) (Set.range I) (I ((chartAt H x) x)) v
       = (v, 0) := by
     rw [fderivWithin_eq_fderiv, DifferentiableAt.fderiv_prod]

--- a/Mathlib/Geometry/Manifold/ContMDiffMap.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMap.lean
@@ -29,10 +29,10 @@ variable (I I') in
 def ContMDiffMap :=
   { f : M → M' // ContMDiff I I' n f }
 
-variable (I I') in
-/-- Bundled smooth maps. -/
-abbrev SmoothMap :=
-  ContMDiffMap I I' M M' ⊤
+--variable (I I') in
+/- Bundled smooth maps. -/
+--abbrev SmoothMap :=
+--  ContMDiffMap I I' M M' ⊤
 
 @[inherit_doc]
 scoped[Manifold] notation "C^" n "⟮" I ", " M "; " I' ", " M' "⟯" => ContMDiffMap I I' M M' n

--- a/Mathlib/Geometry/Manifold/ContMDiffMap.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMap.lean
@@ -54,8 +54,7 @@ instance instFunLike : FunLike C^n⟮I, M; I', M'⟯ M M' where
 protected theorem contMDiff (f : C^n⟮I, M; I', M'⟯) : ContMDiff I I' n f :=
   f.prop
 
-protected theorem smooth (f : C^∞⟮I, M; I', M'⟯) : Smooth I I' f :=
-  f.prop
+@[deprecated (since := "2024-11-20")] alias smooth := ContMDiffMap.contMDiff
 
 -- Porting note: use generic instance instead
 -- instance : Coe C^n⟮I, M; I', M'⟯ C(M, M') :=

--- a/Mathlib/Geometry/Manifold/ContMDiffMap.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMap.lean
@@ -29,10 +29,7 @@ variable (I I') in
 def ContMDiffMap :=
   { f : M → M' // ContMDiff I I' n f }
 
---variable (I I') in
-/- Bundled smooth maps. -/
---abbrev SmoothMap :=
---  ContMDiffMap I I' M M' ⊤
+@[deprecated (since := "024-11-21")] alias SmoothMap := ContMDiffMap
 
 @[inherit_doc]
 scoped[Manifold] notation "C^" n "⟮" I ", " M "; " I' ", " M' "⟯" => ContMDiffMap I I' M M' n

--- a/Mathlib/Geometry/Manifold/Diffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/Diffeomorph.lean
@@ -125,7 +125,7 @@ protected theorem contMDiffWithinAt (h : M ≃ₘ^n⟮I, I'⟯ M') {s x} : ContM
 protected theorem contDiff (h : E ≃ₘ^n⟮𝓘(𝕜, E), 𝓘(𝕜, E')⟯ E') : ContDiff 𝕜 n h :=
   h.contMDiff.contDiff
 
-protected theorem smooth (h : M ≃ₘ⟮I, I'⟯ M') : Smooth I I' h := h.contMDiff
+@[deprecated (since := "2024-11-21")] alias smooth := Diffeomorph.contDiff
 
 protected theorem mdifferentiable (h : M ≃ₘ^n⟮I, I'⟯ M') (hn : 1 ≤ n) : MDifferentiable I I' h :=
   h.contMDiff.mdifferentiable hn
@@ -539,9 +539,8 @@ theorem contMDiff_transDiffeomorph_right {f : M' → M} :
     ContMDiff I' (I.transDiffeomorph e) n f ↔ ContMDiff I' I n f :=
   (toTransDiffeomorph I M e).contMDiff_diffeomorph_comp_iff le_top
 
-theorem smooth_transDiffeomorph_right {f : M' → M} :
-    Smooth I' (I.transDiffeomorph e) f ↔ Smooth I' I f :=
-  contMDiff_transDiffeomorph_right e
+@[deprecated (since := "2024-11-21")]
+alias smooth_transDiffeomorph_right := contMDiff_transDiffeomorph_right
 
 @[simp]
 theorem contMDiffWithinAt_transDiffeomorph_left {f : M → M'} {x s} :
@@ -563,8 +562,7 @@ theorem contMDiff_transDiffeomorph_left {f : M → M'} :
     ContMDiff (I.transDiffeomorph e) I' n f ↔ ContMDiff I I' n f :=
   ((toTransDiffeomorph I M e).contMDiff_comp_diffeomorph_iff le_top).symm
 
-theorem smooth_transDiffeomorph_left {f : M → M'} :
-    Smooth (I.transDiffeomorph e) I' f ↔ Smooth I I' f :=
-  e.contMDiff_transDiffeomorph_left
+@[deprecated (since := "2024-11-21")]
+alias smooth_transDiffeomorph_left := contMDiff_transDiffeomorph_left
 
 end Diffeomorph

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -477,27 +477,30 @@ theorem ContMDiff.mdifferentiableAt (hf : ContMDiff I I' n f) (hn : 1 ≤ n) :
     MDifferentiableAt I I' f x :=
   hf.contMDiffAt.mdifferentiableAt hn
 
+theorem ContMDiff.mdifferentiableWithinAt (hf : ContMDiff I I' n f) (hn : 1 ≤ n) :
+    MDifferentiableWithinAt I I' f s x :=
+  (hf.contMDiffAt.mdifferentiableAt hn).mdifferentiableWithinAt
+
 theorem ContMDiffOn.mdifferentiableOn (hf : ContMDiffOn I I' n f s) (hn : 1 ≤ n) :
     MDifferentiableOn I I' f s := fun x hx => (hf x hx).mdifferentiableWithinAt hn
 
-nonrec theorem SmoothWithinAt.mdifferentiableWithinAt (hf : SmoothWithinAt I I' f s x) :
-    MDifferentiableWithinAt I I' f s x :=
-  hf.mdifferentiableWithinAt le_top
+@[deprecated (since := "2024-11-20")]
+alias SmoothWithinAt.mdifferentiableWithinAt := ContMDiffWithinAt.mdifferentiableWithinAt
 
 theorem ContMDiff.mdifferentiable (hf : ContMDiff I I' n f) (hn : 1 ≤ n) : MDifferentiable I I' f :=
   fun x => (hf x).mdifferentiableAt hn
 
-nonrec theorem SmoothAt.mdifferentiableAt (hf : SmoothAt I I' f x) : MDifferentiableAt I I' f x :=
-  hf.mdifferentiableAt le_top
+@[deprecated (since := "2024-11-20")]
+alias SmoothAt.mdifferentiableAt := ContMDiffAt.mdifferentiableAt
 
-nonrec theorem SmoothOn.mdifferentiableOn (hf : SmoothOn I I' f s) : MDifferentiableOn I I' f s :=
-  hf.mdifferentiableOn le_top
+@[deprecated (since := "2024-11-20")]
+alias SmoothOn.mdifferentiableOn := ContMDiffOn.mdifferentiableOn
 
-theorem Smooth.mdifferentiable (hf : Smooth I I' f) : MDifferentiable I I' f :=
-  ContMDiff.mdifferentiable hf le_top
+@[deprecated (since := "2024-11-20")]
+alias Smooth.mdifferentiable := ContMDiff.mdifferentiable
 
-theorem Smooth.mdifferentiableAt (hf : Smooth I I' f) : MDifferentiableAt I I' f x :=
-  hf.mdifferentiable x
+@[deprecated (since := "2024-11-20")]
+alias Smooth.mdifferentiableAt := ContMDiff.mdifferentiableAt
 
 theorem MDifferentiableOn.continuousOn (h : MDifferentiableOn I I' f s) : ContinuousOn f s :=
   fun x hx => (h x hx).continuousWithinAt
@@ -505,8 +508,8 @@ theorem MDifferentiableOn.continuousOn (h : MDifferentiableOn I I' f s) : Contin
 theorem MDifferentiable.continuous (h : MDifferentiable I I' f) : Continuous f :=
   continuous_iff_continuousAt.2 fun x => (h x).continuousAt
 
-theorem Smooth.mdifferentiableWithinAt (hf : Smooth I I' f) : MDifferentiableWithinAt I I' f s x :=
-  hf.mdifferentiableAt.mdifferentiableWithinAt
+@[deprecated (since := "2024-11-20")]
+alias Smooth.mdifferentiableWithinAt := ContMDiff.mdifferentiableWithinAt
 
 /-! ### Deriving continuity from differentiability on manifolds -/
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
@@ -120,7 +120,7 @@ variable {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] {Z : M → Type
 
 theorem Trivialization.mdifferentiable (e : Trivialization F (π F Z)) [MemTrivializationAtlas e] :
     e.toPartialHomeomorph.MDifferentiable (I.prod 𝓘(𝕜, F)) (I.prod 𝓘(𝕜, F)) :=
-  ⟨e.smoothOn.mdifferentiableOn, e.smoothOn_symm.mdifferentiableOn⟩
+  ⟨e.contMDiffOn.mdifferentiableOn le_top, e.contMDiffOn_symm.mdifferentiableOn le_top⟩
 
 theorem UniqueMDiffWithinAt.smooth_bundle_preimage {p : TotalSpace F Z}
     (hs : UniqueMDiffWithinAt I s p.proj) :

--- a/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
+++ b/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
@@ -160,8 +160,10 @@ theorem sum_le_one (x : M) : ∑ᶠ i, f i x ≤ 1 :=
 def toPartitionOfUnity : PartitionOfUnity ι M s :=
   { f with toFun := fun i => f i }
 
-theorem smooth_sum : Smooth I 𝓘(ℝ) fun x => ∑ᶠ i, f i x :=
-  smooth_finsum (fun i => (f i).smooth) f.locallyFinite
+theorem contMDiff_sum : ContMDiff I 𝓘(ℝ) ⊤ fun x => ∑ᶠ i, f i x :=
+  contMDiff_finsum (fun i => (f i).contMDiff) f.locallyFinite
+
+@[deprecated (since := "2024-11-21")] alias smooth_sum := contMDiff_sum
 
 theorem le_one (i : ι) (x : M) : f i x ≤ 1 :=
   f.toPartitionOfUnity.le_one i x
@@ -178,9 +180,7 @@ theorem contMDiff_smul {g : M → F} {i} (hg : ∀ x ∈ tsupport (f i), ContMDi
   contMDiff_of_tsupport fun x hx =>
     ((f i).contMDiff.contMDiffAt.of_le le_top).smul <| hg x <| tsupport_smul_subset_left _ _ hx
 
-theorem smooth_smul {g : M → F} {i} (hg : ∀ x ∈ tsupport (f i), SmoothAt I 𝓘(ℝ, F) g x) :
-    Smooth I 𝓘(ℝ, F) fun x => f i x • g x :=
-  f.contMDiff_smul hg
+@[deprecated (since := "2024-11-21")] alias smooth_smul := contMDiff_smul
 
 /-- If `f` is a smooth partition of unity on a set `s : Set M` and `g : ι → M → F` is a family of
 functions such that `g i` is $C^n$ smooth at every point of the topological support of `f i`, then
@@ -191,20 +191,14 @@ theorem contMDiff_finsum_smul {g : ι → M → F}
   (contMDiff_finsum fun i => f.contMDiff_smul (hg i)) <|
     f.locallyFinite.subset fun _ => support_smul_subset_left _ _
 
-/-- If `f` is a smooth partition of unity on a set `s : Set M` and `g : ι → M → F` is a family of
-functions such that `g i` is smooth at every point of the topological support of `f i`, then the sum
-`fun x ↦ ∑ᶠ i, f i x • g i x` is smooth on the whole manifold. -/
-theorem smooth_finsum_smul {g : ι → M → F}
-    (hg : ∀ (i), ∀ x ∈ tsupport (f i), SmoothAt I 𝓘(ℝ, F) (g i) x) :
-    Smooth I 𝓘(ℝ, F) fun x => ∑ᶠ i, f i x • g i x :=
-  f.contMDiff_finsum_smul hg
+@[deprecated (since := "2024-11-21")] alias smooth_finsum_smul := contMDiff_finsum_smul
 
 theorem contMDiffAt_finsum {x₀ : M} {g : ι → M → F}
     (hφ : ∀ i, x₀ ∈ tsupport (f i) → ContMDiffAt I 𝓘(ℝ, F) n (g i) x₀) :
     ContMDiffAt I 𝓘(ℝ, F) n (fun x ↦ ∑ᶠ i, f i x • g i x) x₀ := by
   refine _root_.contMDiffAt_finsum (f.locallyFinite.smul_left _) fun i ↦ ?_
   by_cases hx : x₀ ∈ tsupport (f i)
-  · exact ContMDiffAt.smul ((f i).smooth.of_le le_top).contMDiffAt (hφ i hx)
+  · exact ContMDiffAt.smul ((f i).contMDiff.of_le le_top).contMDiffAt (hφ i hx)
   · exact contMDiffAt_of_not_mem (compl_subset_compl.mpr
       (tsupport_smul_subset_left (f i) (g i)) hx) n
 
@@ -294,13 +288,8 @@ theorem IsSubordinate.contMDiff_finsum_smul {g : ι → M → F} (hf : f.IsSubor
     ContMDiff I 𝓘(ℝ, F) n fun x => ∑ᶠ i, f i x • g i x :=
   f.contMDiff_finsum_smul fun i _ hx => (hg i).contMDiffAt <| (ho i).mem_nhds (hf i hx)
 
-/-- If `f` is a smooth partition of unity on a set `s : Set M` subordinate to a family of open sets
-`U : ι → Set M` and `g : ι → M → F` is a family of functions such that `g i` is smooth on `U i`,
-then the sum `fun x ↦ ∑ᶠ i, f i x • g i x` is smooth on the whole manifold. -/
-theorem IsSubordinate.smooth_finsum_smul {g : ι → M → F} (hf : f.IsSubordinate U)
-    (ho : ∀ i, IsOpen (U i)) (hg : ∀ i, SmoothOn I 𝓘(ℝ, F) (g i) (U i)) :
-    Smooth I 𝓘(ℝ, F) fun x => ∑ᶠ i, f i x • g i x :=
-  hf.contMDiff_finsum_smul ho hg
+@[deprecated (since := "2024-11-21")]
+alias IsSubordinate.smooth_finsum_smul := IsSubordinate.contMDiff_finsum_smul
 
 end IsSubordinate
 
@@ -309,13 +298,16 @@ end SmoothPartitionOfUnity
 namespace BumpCovering
 
 -- Repeat variables to drop `[FiniteDimensional ℝ E]` and `[SmoothManifoldWithCorners I M]`
-theorem smooth_toPartitionOfUnity {E : Type uE} [NormedAddCommGroup E] [NormedSpace ℝ E]
+theorem contMDiff_toPartitionOfUnity {E : Type uE} [NormedAddCommGroup E] [NormedSpace ℝ E]
     {H : Type uH} [TopologicalSpace H] {I : ModelWithCorners ℝ E H} {M : Type uM}
     [TopologicalSpace M] [ChartedSpace H M] {s : Set M} (f : BumpCovering ι M s)
-    (hf : ∀ i, Smooth I 𝓘(ℝ) (f i)) (i : ι) : Smooth I 𝓘(ℝ) (f.toPartitionOfUnity i) :=
-  (hf i).mul <| (smooth_finprod_cond fun j _ => smooth_const.sub (hf j)) <| by
+    (hf : ∀ i, ContMDiff I 𝓘(ℝ) ⊤ (f i)) (i : ι) : ContMDiff I 𝓘(ℝ) ⊤ (f.toPartitionOfUnity i) :=
+  (hf i).mul <| (contMDiff_finprod_cond fun j _ => contMDiff_const.sub (hf j)) <| by
     simp only [Pi.sub_def, mulSupport_one_sub]
     exact f.locallyFinite
+
+@[deprecated (since := "2024-11-21")]
+alias smooth_toPartitionOfUnity := contMDiff_toPartitionOfUnity
 
 variable {s : Set M}
 
@@ -326,24 +318,24 @@ In our formalization, not every `f : BumpCovering ι M s` with smooth functions 
 `SmoothBumpCovering`; instead, a `SmoothBumpCovering` is a covering by supports of
 `SmoothBumpFunction`s. So, we define `BumpCovering.toSmoothPartitionOfUnity`, then reuse it
 in `SmoothBumpCovering.toSmoothPartitionOfUnity`. -/
-def toSmoothPartitionOfUnity (f : BumpCovering ι M s) (hf : ∀ i, Smooth I 𝓘(ℝ) (f i)) :
+def toSmoothPartitionOfUnity (f : BumpCovering ι M s) (hf : ∀ i, ContMDiff I 𝓘(ℝ) ⊤ (f i)) :
     SmoothPartitionOfUnity ι I M s :=
   { f.toPartitionOfUnity with
-    toFun := fun i => ⟨f.toPartitionOfUnity i, f.smooth_toPartitionOfUnity hf i⟩ }
+    toFun := fun i => ⟨f.toPartitionOfUnity i, f.contMDiff_toPartitionOfUnity hf i⟩ }
 
 @[simp]
 theorem toSmoothPartitionOfUnity_toPartitionOfUnity (f : BumpCovering ι M s)
-    (hf : ∀ i, Smooth I 𝓘(ℝ) (f i)) :
+    (hf : ∀ i, ContMDiff I 𝓘(ℝ) ⊤ (f i)) :
     (f.toSmoothPartitionOfUnity hf).toPartitionOfUnity = f.toPartitionOfUnity :=
   rfl
 
 @[simp]
-theorem coe_toSmoothPartitionOfUnity (f : BumpCovering ι M s) (hf : ∀ i, Smooth I 𝓘(ℝ) (f i))
+theorem coe_toSmoothPartitionOfUnity (f : BumpCovering ι M s) (hf : ∀ i, ContMDiff I 𝓘(ℝ) ⊤ (f i))
     (i : ι) : ⇑(f.toSmoothPartitionOfUnity hf i) = f.toPartitionOfUnity i :=
   rfl
 
 theorem IsSubordinate.toSmoothPartitionOfUnity {f : BumpCovering ι M s} {U : ι → Set M}
-    (h : f.IsSubordinate U) (hf : ∀ i, Smooth I 𝓘(ℝ) (f i)) :
+    (h : f.IsSubordinate U) (hf : ∀ i, ContMDiff I 𝓘(ℝ) ⊤ (f i)) :
     (f.toSmoothPartitionOfUnity hf).IsSubordinate U :=
   h.toPartitionOfUnity
 
@@ -457,7 +449,7 @@ alias ⟨_, IsSubordinate.toBumpCovering⟩ := isSubordinate_toBumpCovering
 
 /-- Every `SmoothBumpCovering` defines a smooth partition of unity. -/
 def toSmoothPartitionOfUnity : SmoothPartitionOfUnity ι I M s :=
-  fs.toBumpCovering.toSmoothPartitionOfUnity fun i => (fs i).smooth
+  fs.toBumpCovering.toSmoothPartitionOfUnity fun i => (fs i).contMDiff
 
 theorem toSmoothPartitionOfUnity_apply (i : ι) (x : M) :
     fs.toSmoothPartitionOfUnity i x = fs i x * ∏ᶠ (j) (_ : WellOrderingRel j i), (1 - fs j x) :=
@@ -511,7 +503,7 @@ theorem exists_smooth_zero_one_of_isClosed [T2Space M] [SigmaCompactSpace M] {s 
   rcases SmoothBumpCovering.exists_isSubordinate I ht this with ⟨ι, f, hf⟩
   set g := f.toSmoothPartitionOfUnity
   refine
-    ⟨⟨_, g.smooth_sum⟩, fun x hx => ?_, fun x => g.sum_eq_one, fun x =>
+    ⟨⟨_, g.contMDiff_sum⟩, fun x hx => ?_, fun x => g.sum_eq_one, fun x =>
       ⟨g.sum_nonneg x, g.sum_le_one x⟩⟩
   suffices ∀ i, g i x = 0 by simp only [this, ContMDiffMap.coeFn_mk, finsum_zero, Pi.zero_apply]
   refine fun i => f.toSmoothPartitionOfUnity_zero_of_zero ?_
@@ -554,8 +546,9 @@ def single (i : ι) (s : Set M) : SmoothPartitionOfUnity ι I M s :=
   (BumpCovering.single i s).toSmoothPartitionOfUnity fun j => by
     classical
     rcases eq_or_ne j i with (rfl | h)
-    · simp only [smooth_one, ContinuousMap.coe_one, BumpCovering.coe_single, Pi.single_eq_same]
-    · simp only [smooth_zero, BumpCovering.coe_single, Pi.single_eq_of_ne h, ContinuousMap.coe_zero]
+    · simp only [contMDiff_one, ContinuousMap.coe_one, BumpCovering.coe_single, Pi.single_eq_same]
+    · simp only [contMDiff_zero, BumpCovering.coe_single, Pi.single_eq_of_ne h,
+        ContinuousMap.coe_zero]
 
 instance [Inhabited ι] (s : Set M) : Inhabited (SmoothPartitionOfUnity ι I M s) :=
   ⟨single I default s⟩
@@ -570,12 +563,12 @@ theorem exists_isSubordinate {s : Set M} (hs : IsClosed s) (U : ι → Set M) (h
   haveI : LocallyCompactSpace M := ChartedSpace.locallyCompactSpace H M
   -- porting note(https://github.com/leanprover/std4/issues/116):
   -- split `rcases` into `have` + `rcases`
-  have := BumpCovering.exists_isSubordinate_of_prop (Smooth I 𝓘(ℝ)) ?_ hs U ho hU
+  have := BumpCovering.exists_isSubordinate_of_prop (ContMDiff I 𝓘(ℝ) ⊤) ?_ hs U ho hU
   · rcases this with ⟨f, hf, hfU⟩
     exact ⟨f.toSmoothPartitionOfUnity hf, hfU.toSmoothPartitionOfUnity hf⟩
   · intro s t hs ht hd
     rcases exists_smooth_zero_one_of_isClosed I hs ht hd with ⟨f, hf⟩
-    exact ⟨f, f.smooth, hf⟩
+    exact ⟨f, f.contMDiff, hf⟩
 
 theorem exists_isSubordinate_chartAt_source_of_isClosed {s : Set M} (hs : IsClosed s) :
     ∃ f : SmoothPartitionOfUnity s I M s,
@@ -618,7 +611,7 @@ Then there exists a smooth function `g : C^∞⟮I, M; 𝓘(ℝ, F), F⟯` such 
 See also `exists_contMDiffOn_forall_mem_convex_of_local` and
 `exists_smooth_forall_mem_convex_of_local_const`. -/
 theorem exists_smooth_forall_mem_convex_of_local (ht : ∀ x, Convex ℝ (t x))
-    (Hloc : ∀ x : M, ∃ U ∈ 𝓝 x, ∃ g : M → F, SmoothOn I 𝓘(ℝ, F) g U ∧ ∀ y ∈ U, g y ∈ t y) :
+    (Hloc : ∀ x : M, ∃ U ∈ 𝓝 x, ∃ g : M → F, ContMDiffOn I 𝓘(ℝ, F) ⊤ g U ∧ ∀ y ∈ U, g y ∈ t y) :
     ∃ g : C^∞⟮I, M; 𝓘(ℝ, F), F⟯, ∀ x, g x ∈ t x :=
   exists_contMDiffOn_forall_mem_convex_of_local I ht Hloc
 
@@ -631,7 +624,7 @@ theorem exists_smooth_forall_mem_convex_of_local_const (ht : ∀ x, Convex ℝ (
     (Hloc : ∀ x : M, ∃ c : F, ∀ᶠ y in 𝓝 x, c ∈ t y) : ∃ g : C^∞⟮I, M; 𝓘(ℝ, F), F⟯, ∀ x, g x ∈ t x :=
   exists_smooth_forall_mem_convex_of_local I ht fun x =>
     let ⟨c, hc⟩ := Hloc x
-    ⟨_, hc, fun _ => c, smoothOn_const, fun _ => id⟩
+    ⟨_, hc, fun _ => c, contMDiffOn_const, fun _ => id⟩
 
 /-- Let `M` be a smooth σ-compact manifold with extended distance. Let `K : ι → Set M` be a locally
 finite family of closed sets, let `U : ι → Set M` be a family of open sets such that `K i ⊆ U i` for
@@ -664,7 +657,7 @@ theorem Metric.exists_smooth_forall_closedBall_subset {M} [MetricSpace M] [Chart
   exact hδ i x hx
 
 lemma IsOpen.exists_msmooth_support_eq_aux {s : Set H} (hs : IsOpen s) :
-    ∃ f : H → ℝ, f.support = s ∧ Smooth I 𝓘(ℝ) f ∧ Set.range f ⊆ Set.Icc 0 1 := by
+    ∃ f : H → ℝ, f.support = s ∧ ContMDiff I 𝓘(ℝ) ⊤ f ∧ Set.range f ⊆ Set.Icc 0 1 := by
   have h's : IsOpen (I.symm ⁻¹' s) := I.continuous_symm.isOpen_preimage _ hs
   rcases h's.exists_smooth_support_eq with ⟨f, f_supp, f_diff, f_range⟩
   refine ⟨f ∘ I, ?_, ?_, ?_⟩
@@ -676,11 +669,11 @@ lemma IsOpen.exists_msmooth_support_eq_aux {s : Set H} (hs : IsOpen s) :
 /-- Given an open set in a finite-dimensional real manifold, there exists a nonnegative smooth
 function with support equal to `s`. -/
 theorem IsOpen.exists_msmooth_support_eq {s : Set M} (hs : IsOpen s) :
-    ∃ f : M → ℝ, f.support = s ∧ Smooth I 𝓘(ℝ) f ∧ ∀ x, 0 ≤ f x := by
+    ∃ f : M → ℝ, f.support = s ∧ ContMDiff I 𝓘(ℝ) ⊤ f ∧ ∀ x, 0 ≤ f x := by
   rcases SmoothPartitionOfUnity.exists_isSubordinate_chartAt_source I M with ⟨f, hf⟩
   have A : ∀ (c : M), ∃ g : H → ℝ,
       g.support = (chartAt H c).target ∩ (chartAt H c).symm ⁻¹' s ∧
-      Smooth I 𝓘(ℝ) g ∧ Set.range g ⊆ Set.Icc 0 1 := by
+      ContMDiff I 𝓘(ℝ) ⊤ g ∧ Set.range g ⊆ Set.Icc 0 1 := by
     intro i
     apply IsOpen.exists_msmooth_support_eq_aux
     exact PartialHomeomorph.isOpen_inter_preimage_symm _ hs
@@ -714,7 +707,7 @@ theorem IsOpen.exists_msmooth_support_eq {s : Set M} (hs : IsOpen s) :
       · have : x ∉ support (f c) := by contrapose! Hx; exact subset_tsupport _ Hx
         rw [nmem_support] at this
         simp [this]
-  · apply SmoothPartitionOfUnity.smooth_finsum_smul
+  · apply SmoothPartitionOfUnity.contMDiff_finsum_smul
     intro c x hx
     apply (g_diff c (chartAt H c x)).comp
     exact contMDiffAt_of_mem_maximalAtlas (SmoothManifoldWithCorners.chart_mem_maximalAtlas _)
@@ -727,7 +720,7 @@ exists a smooth function with support equal to `s`, taking values in `[0,1]`, an
 exactly on `t`. -/
 theorem exists_msmooth_support_eq_eq_one_iff
     {s t : Set M} (hs : IsOpen s) (ht : IsClosed t) (h : t ⊆ s) :
-    ∃ f : M → ℝ, Smooth I 𝓘(ℝ) f ∧ range f ⊆ Icc 0 1 ∧ support f = s
+    ∃ f : M → ℝ, ContMDiff I 𝓘(ℝ) ⊤ f ∧ range f ⊆ Icc 0 1 ∧ support f = s
       ∧ (∀ x, x ∈ t ↔ f x = 1) := by
   /- Take `f` with support equal to `s`, and `g` with support equal to `tᶜ`. Then `f / (f + g)`
   satisfies the conclusion of the theorem. -/
@@ -765,7 +758,7 @@ there exists an infinitely smooth function that is equal to `0` exactly on `s` a
 exactly on `t`. See also `exists_smooth_zero_one_of_isClosed` for a slightly weaker version. -/
 theorem exists_msmooth_zero_iff_one_iff_of_isClosed {s t : Set M}
     (hs : IsClosed s) (ht : IsClosed t) (hd : Disjoint s t) :
-    ∃ f : M → ℝ, Smooth I 𝓘(ℝ) f ∧ range f ⊆ Icc 0 1 ∧ (∀ x, x ∈ s ↔ f x = 0)
+    ∃ f : M → ℝ, ContMDiff I 𝓘(ℝ) ⊤ f ∧ range f ⊆ Icc 0 1 ∧ (∀ x, x ∈ s ↔ f x = 0)
       ∧ (∀ x, x ∈ t ↔ f x = 1) := by
   rcases exists_msmooth_support_eq_eq_one_iff I hs.isOpen_compl ht hd.subset_compl_left with
     ⟨f, f_diff, f_range, fs, ft⟩

--- a/Mathlib/Geometry/Manifold/Sheaf/LocallyRingedSpace.lean
+++ b/Mathlib/Geometry/Manifold/Sheaf/LocallyRingedSpace.lean
@@ -97,7 +97,7 @@ theorem smoothSheafCommRing.isUnit_stalk_iff {x : M}
       #adaptation_note /-- https://github.com/leanprover/lean4/pull/6024
         was `exact`; somehow `convert` bypasess unification issues -/
       convert ((contDiffAt_inv _ (hVf y)).contMDiffAt).comp y
-        (f.smooth.comp (smooth_inclusion hUV)).smoothAt
+        (f.contMDiff.comp (contMDiff_inclusion hUV)).contMDiffAt
 
 /-- The non-units of the stalk at `x` of the sheaf of smooth functions from `M` to `𝕜`, considered
 as a sheaf of commutative rings, are the functions whose values at `x` are zero. -/

--- a/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
+++ b/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
@@ -126,7 +126,7 @@ def smoothSheaf.evalAt (x : TopCat.of M) (U : OpenNhds x)
 lemma smoothSheaf.eval_surjective (x : M) : Function.Surjective (smoothSheaf.eval IM I N x) := by
   apply TopCat.stalkToFiber_surjective
   intro n
-  exact ⟨⊤, fun _ ↦ n, smooth_const, rfl⟩
+  exact ⟨⊤, fun _ ↦ n, contMDiff_const, rfl⟩
 
 instance [Nontrivial N] (x : M) : Nontrivial ((smoothSheaf IM I M N).presheaf.stalk x) :=
   (smoothSheaf.eval_surjective IM I N x).nontrivial
@@ -138,10 +138,13 @@ variable {IM I N}
     smoothSheaf.eval IM I N (x : M) ((smoothSheaf IM I M N).presheaf.germ U x hx f) = f ⟨x, hx⟩ :=
   TopCat.stalkToFiber_germ ((contDiffWithinAt_localInvariantProp ⊤).localPredicate M N) _ _ _ _
 
-lemma smoothSheaf.smooth_section {U : (Opens (TopCat.of M))ᵒᵖ}
+lemma smoothSheaf.contMDiff_section {U : (Opens (TopCat.of M))ᵒᵖ}
     (f : (smoothSheaf IM I M N).presheaf.obj U) :
-    Smooth IM I f :=
+    ContMDiff IM I ⊤ f :=
   (contDiffWithinAt_localInvariantProp ⊤).section_spec _ _ _ _
+
+@[deprecated (since := "2024-11-21")]
+alias smoothSheaf.smooth_section := smoothSheaf.contMDiff_section
 
 end TypeCat
 
@@ -213,7 +216,7 @@ noncomputable def smoothSheafCommGroup : TopCat.Sheaf CommGrp.{u} (TopCat.of M) 
 @[to_additive "For a manifold `M` and a smooth homomorphism `φ` between abelian additive Lie groups
 `A`, `A'`, the 'left-composition-by-`φ`' morphism of sheaves from `smoothSheafAddCommGroup IM I M A`
 to `smoothSheafAddCommGroup IM I' M A'`."]
-def smoothSheafCommGroup.compLeft (φ : A →* A') (hφ : Smooth I I' φ) :
+def smoothSheafCommGroup.compLeft (φ : A →* A') (hφ : ContMDiff I I' ⊤ φ) :
     smoothSheafCommGroup IM I M A ⟶ smoothSheafCommGroup IM I' M A' :=
   CategoryTheory.Sheaf.Hom.mk <|
   { app := fun _ ↦ CommGrp.ofHom <| SmoothMap.compLeftMonoidHom _ _ φ hφ

--- a/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
@@ -632,7 +632,7 @@ theorem contMDiffOn_smoothCoordChange (he : e ∈ a.pretrivializationAtlas)
   (Classical.choose_spec (ha.exists_smoothCoordChange e he e' he')).1
 
 @[deprecated (since := "2024-11-21")]
-alias smooth_smoothCoordChange := contMDiffOn_smoothCoordChange
+alias smoothOn_smoothCoordChange := contMDiffOn_smoothCoordChange
 
 theorem smoothCoordChange_apply (he : e ∈ a.pretrivializationAtlas)
     (he' : e' ∈ a.pretrivializationAtlas) {b : B} (hb : b ∈ e.baseSet ∩ e'.baseSet) (v : F) :

--- a/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
@@ -212,40 +212,37 @@ theorem contMDiff_proj : ContMDiff (IB.prod 𝓘(𝕜, F)) IB n (π F E) := fun 
   rw [contMDiffAt_totalSpace] at this
   exact this.1
 
-theorem smooth_proj : Smooth (IB.prod 𝓘(𝕜, F)) IB (π F E) :=
-  contMDiff_proj E
+@[deprecated (since := "2024-11-21")] alias smooth_proj := contMDiff_proj
 
 theorem contMDiffOn_proj {s : Set (TotalSpace F E)} :
     ContMDiffOn (IB.prod 𝓘(𝕜, F)) IB n (π F E) s :=
   (Bundle.contMDiff_proj E).contMDiffOn
 
-theorem smoothOn_proj {s : Set (TotalSpace F E)} : SmoothOn (IB.prod 𝓘(𝕜, F)) IB (π F E) s :=
-  contMDiffOn_proj E
+@[deprecated (since := "2024-11-21")] alias smoothOn_proj := contMDiffOn_proj
 
 theorem contMDiffAt_proj {p : TotalSpace F E} : ContMDiffAt (IB.prod 𝓘(𝕜, F)) IB n (π F E) p :=
   (Bundle.contMDiff_proj E).contMDiffAt
 
-theorem smoothAt_proj {p : TotalSpace F E} : SmoothAt (IB.prod 𝓘(𝕜, F)) IB (π F E) p :=
-  Bundle.contMDiffAt_proj E
+@[deprecated (since := "2024-11-21")] alias smoothAt_proj := contMDiffAt_proj
 
 theorem contMDiffWithinAt_proj {s : Set (TotalSpace F E)} {p : TotalSpace F E} :
     ContMDiffWithinAt (IB.prod 𝓘(𝕜, F)) IB n (π F E) s p :=
   (Bundle.contMDiffAt_proj E).contMDiffWithinAt
 
-theorem smoothWithinAt_proj {s : Set (TotalSpace F E)} {p : TotalSpace F E} :
-    SmoothWithinAt (IB.prod 𝓘(𝕜, F)) IB (π F E) s p :=
-  Bundle.contMDiffWithinAt_proj E
+@[deprecated (since := "2024-11-21")] alias smoothWithinAt_proj := contMDiffWithinAt_proj
 
 variable (𝕜) [∀ x, AddCommMonoid (E x)]
 variable [∀ x, Module 𝕜 (E x)] [VectorBundle 𝕜 F E]
 
-theorem smooth_zeroSection : Smooth IB (IB.prod 𝓘(𝕜, F)) (zeroSection F E) := fun x ↦ by
+theorem contMDiff_zeroSection : ContMDiff IB (IB.prod 𝓘(𝕜, F)) ⊤ (zeroSection F E) := fun x ↦ by
   unfold zeroSection
   rw [Bundle.contMDiffAt_section]
   apply (contMDiffAt_const (c := 0)).congr_of_eventuallyEq
   filter_upwards [(trivializationAt F E x).open_baseSet.mem_nhds
     (mem_baseSet_trivializationAt F E x)] with y hy
     using congr_arg Prod.snd <| (trivializationAt F E x).zeroSection 𝕜 hy
+
+@[deprecated (since := "2024-11-21")] alias smooth_zeroSection := contMDiff_zeroSection
 
 end Bundle
 
@@ -272,9 +269,9 @@ topological vector bundle over `B` with fibers isomorphic to `F`, then `SmoothVe
 registers that the bundle is smooth, in the sense of having smooth transition functions.
 This is a mixin, not carrying any new data. -/
 class SmoothVectorBundle : Prop where
-  protected smoothOn_coordChangeL :
+  protected contMDiffOn_coordChangeL :
     ∀ (e e' : Trivialization F (π F E)) [MemTrivializationAtlas e] [MemTrivializationAtlas e'],
-      SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun b : B => (e.coordChangeL 𝕜 e' b : F →L[𝕜] F))
+      ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun b : B => (e.coordChangeL 𝕜 e' b : F →L[𝕜] F))
         (e.baseSet ∩ e'.baseSet)
 
 variable [SmoothVectorBundle F E IB]
@@ -284,27 +281,23 @@ section SmoothCoordChange
 variable {F E}
 variable (e e' : Trivialization F (π F E)) [MemTrivializationAtlas e] [MemTrivializationAtlas e']
 
-theorem smoothOn_coordChangeL :
-    SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun b : B => (e.coordChangeL 𝕜 e' b : F →L[𝕜] F))
-      (e.baseSet ∩ e'.baseSet) :=
-  SmoothVectorBundle.smoothOn_coordChangeL e e'
-
-theorem smoothOn_symm_coordChangeL :
-    SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun b : B => ((e.coordChangeL 𝕜 e' b).symm : F →L[𝕜] F))
-      (e.baseSet ∩ e'.baseSet) := by
-  rw [inter_comm]
-  refine (SmoothVectorBundle.smoothOn_coordChangeL e' e).congr fun b hb ↦ ?_
-  rw [e.symm_coordChangeL e' hb]
-
 theorem contMDiffOn_coordChangeL :
     ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) n (fun b : B => (e.coordChangeL 𝕜 e' b : F →L[𝕜] F))
       (e.baseSet ∩ e'.baseSet) :=
-  (smoothOn_coordChangeL e e').of_le le_top
+  (SmoothVectorBundle.contMDiffOn_coordChangeL e e').of_le le_top
 
 theorem contMDiffOn_symm_coordChangeL :
     ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) n (fun b : B => ((e.coordChangeL 𝕜 e' b).symm : F →L[𝕜] F))
-      (e.baseSet ∩ e'.baseSet) :=
-  (smoothOn_symm_coordChangeL e e').of_le le_top
+      (e.baseSet ∩ e'.baseSet) := by
+  apply ContMDiffOn.of_le _ le_top
+  rw [inter_comm]
+  refine (SmoothVectorBundle.contMDiffOn_coordChangeL e' e).congr fun b hb ↦ ?_
+  rw [e.symm_coordChangeL e' hb]
+
+@[deprecated (since := "2024-11-21")] alias smoothOn_coordChangeL := contMDiffOn_coordChangeL
+@[deprecated (since := "2024-11-21")]
+alias smoothOn_symm_coordChangeL := contMDiffOn_symm_coordChangeL
+
 
 variable {e e'}
 
@@ -313,9 +306,7 @@ theorem contMDiffAt_coordChangeL {x : B} (h : x ∈ e.baseSet) (h' : x ∈ e'.ba
   (contMDiffOn_coordChangeL e e').contMDiffAt <|
     (e.open_baseSet.inter e'.open_baseSet).mem_nhds ⟨h, h'⟩
 
-theorem smoothAt_coordChangeL {x : B} (h : x ∈ e.baseSet) (h' : x ∈ e'.baseSet) :
-    SmoothAt IB 𝓘(𝕜, F →L[𝕜] F) (fun b : B => (e.coordChangeL 𝕜 e' b : F →L[𝕜] F)) x :=
-  contMDiffAt_coordChangeL h h'
+@[deprecated (since := "2024-11-21")] alias smoothAt_coordChangeL := contMDiffAt_coordChangeL
 
 variable {s : Set M} {f : M → B} {g : M → F} {x : M}
 
@@ -339,25 +330,17 @@ protected theorem ContMDiff.coordChangeL
     ContMDiff IM 𝓘(𝕜, F →L[𝕜] F) n (fun y ↦ (e.coordChangeL 𝕜 e' (f y) : F →L[𝕜] F)) := fun x ↦
   (hf x).coordChangeL (he x) (he' x)
 
-protected nonrec theorem SmoothWithinAt.coordChangeL
-    (hf : SmoothWithinAt IM IB f s x) (he : f x ∈ e.baseSet) (he' : f x ∈ e'.baseSet) :
-    SmoothWithinAt IM 𝓘(𝕜, F →L[𝕜] F) (fun y ↦ (e.coordChangeL 𝕜 e' (f y) : F →L[𝕜] F)) s x :=
-  hf.coordChangeL he he'
+@[deprecated (since := "2024-11-21")]
+alias SmoothWithinAt.coordChangeL := ContMDiffWithinAt.coordChangeL
 
-protected nonrec theorem SmoothAt.coordChangeL
-    (hf : SmoothAt IM IB f x) (he : f x ∈ e.baseSet) (he' : f x ∈ e'.baseSet) :
-    SmoothAt IM 𝓘(𝕜, F →L[𝕜] F) (fun y ↦ (e.coordChangeL 𝕜 e' (f y) : F →L[𝕜] F)) x :=
-  hf.coordChangeL he he'
+@[deprecated (since := "2024-11-21")]
+alias SmoothAt.coordChangeL := ContMDiffAt.coordChangeL
 
-protected nonrec theorem SmoothOn.coordChangeL
-    (hf : SmoothOn IM IB f s) (he : MapsTo f s e.baseSet) (he' : MapsTo f s e'.baseSet) :
-    SmoothOn IM 𝓘(𝕜, F →L[𝕜] F) (fun y ↦ (e.coordChangeL 𝕜 e' (f y) : F →L[𝕜] F)) s :=
-  hf.coordChangeL he he'
+@[deprecated (since := "2024-11-21")]
+alias SmoothOn.coordChangeL := ContMDiffOn.coordChangeL
 
-protected nonrec theorem Smooth.coordChangeL
-    (hf : Smooth IM IB f) (he : ∀ x, f x ∈ e.baseSet) (he' : ∀ x, f x ∈ e'.baseSet) :
-    Smooth IM 𝓘(𝕜, F →L[𝕜] F) (fun y ↦ (e.coordChangeL 𝕜 e' (f y) : F →L[𝕜] F)) :=
-  hf.coordChangeL he he'
+@[deprecated (since := "2024-11-21")]
+alias Smooth.coordChangeL := ContMDiff.coordChangeL
 
 protected theorem ContMDiffWithinAt.coordChange
     (hf : ContMDiffWithinAt IM IB n f s x) (hg : ContMDiffWithinAt IM 𝓘(𝕜, F) n g s x)
@@ -386,26 +369,17 @@ protected theorem ContMDiff.coordChange (hf : ContMDiff IM IB n f)
     ContMDiff IM 𝓘(𝕜, F) n (fun y ↦ e.coordChange e' (f y) (g y)) := fun x ↦
   (hf x).coordChange (hg x) (he x) (he' x)
 
-protected nonrec theorem SmoothWithinAt.coordChange
-    (hf : SmoothWithinAt IM IB f s x) (hg : SmoothWithinAt IM 𝓘(𝕜, F) g s x)
-    (he : f x ∈ e.baseSet) (he' : f x ∈ e'.baseSet) :
-    SmoothWithinAt IM 𝓘(𝕜, F) (fun y ↦ e.coordChange e' (f y) (g y)) s x :=
-  hf.coordChange hg he he'
+@[deprecated (since := "2024-11-21")]
+alias SmoothWithinAt.coordChange := ContMDiffWithinAt.coordChange
 
-protected nonrec theorem SmoothAt.coordChange (hf : SmoothAt IM IB f x)
-    (hg : SmoothAt IM 𝓘(𝕜, F) g x) (he : f x ∈ e.baseSet) (he' : f x ∈ e'.baseSet) :
-    SmoothAt IM 𝓘(𝕜, F) (fun y ↦ e.coordChange e' (f y) (g y)) x :=
-  hf.coordChange hg he he'
+@[deprecated (since := "2024-11-21")]
+alias SmoothAt.coordChange := ContMDiffAt.coordChange
 
-protected nonrec theorem SmoothOn.coordChange (hf : SmoothOn IM IB f s)
-    (hg : SmoothOn IM 𝓘(𝕜, F) g s) (he : MapsTo f s e.baseSet) (he' : MapsTo f s e'.baseSet) :
-    SmoothOn IM 𝓘(𝕜, F) (fun y ↦ e.coordChange e' (f y) (g y)) s :=
-  hf.coordChange hg he he'
+@[deprecated (since := "2024-11-21")]
+alias SmoothOn.coordChange := ContMDiffOn.coordChange
 
-protected theorem Smooth.coordChange (hf : Smooth IM IB f)
-    (hg : Smooth IM 𝓘(𝕜, F) g) (he : ∀ x, f x ∈ e.baseSet) (he' : ∀ x, f x ∈ e'.baseSet) :
-    Smooth IM 𝓘(𝕜, F) (fun y ↦ e.coordChange e' (f y) (g y)) := fun x ↦
-  (hf x).coordChange (hg x) (he x) (he' x)
+@[deprecated (since := "2024-11-21")]
+alias Smooth.coordChange := ContMDiff.coordChange
 
 variable (e e')
 
@@ -458,8 +432,8 @@ instance SmoothFiberwiseLinear.hasGroupoid :
     haveI : MemTrivializationAtlas e := ⟨he⟩
     haveI : MemTrivializationAtlas e' := ⟨he'⟩
     rw [mem_smoothFiberwiseLinear_iff]
-    refine ⟨_, _, e.open_baseSet.inter e'.open_baseSet, smoothOn_coordChangeL e e',
-      smoothOn_symm_coordChangeL e e', ?_⟩
+    refine ⟨_, _, e.open_baseSet.inter e'.open_baseSet, contMDiffOn_coordChangeL e e',
+      contMDiffOn_symm_coordChangeL e e', ?_⟩
     refine PartialHomeomorph.eqOnSourceSetoid.symm ⟨?_, ?_⟩
     · simp only [e.symm_trans_source_eq e', FiberwiseLinear.partialHomeomorph, trans_toPartialEquiv,
         symm_toPartialEquiv]
@@ -478,10 +452,10 @@ instance Bundle.TotalSpace.smoothManifoldWithCorners [SmoothManifoldWithCorners 
   refine ⟨ContMDiffOn.congr ?_ (EqOnSource.eqOn heφ),
       ContMDiffOn.congr ?_ (EqOnSource.eqOn (EqOnSource.symm' heφ))⟩
   · rw [EqOnSource.source_eq heφ]
-    apply smoothOn_fst.prod_mk
+    apply contMDiffOn_fst.prod_mk
     exact (hφ.comp contMDiffOn_fst <| prod_subset_preimage_fst _ _).clm_apply contMDiffOn_snd
   · rw [EqOnSource.target_eq heφ]
-    apply smoothOn_fst.prod_mk
+    apply contMDiffOn_fst.prod_mk
     exact (h2φ.comp contMDiffOn_fst <| prod_subset_preimage_fst _ _).clm_apply contMDiffOn_snd
 
 section
@@ -517,40 +491,35 @@ theorem Trivialization.contMDiff_iff {f : M → TotalSpace F E} (he : ∀ x, f x
       ContMDiff IM 𝓘(𝕜, F) n (fun x ↦ (e (f x)).2) :=
   (forall_congr' fun x ↦ e.contMDiffAt_iff (he x)).trans forall_and
 
-theorem Trivialization.smoothWithinAt_iff {f : M → TotalSpace F E} {s : Set M} {x₀ : M}
-    (he : f x₀ ∈ e.source) :
-    SmoothWithinAt IM (IB.prod 𝓘(𝕜, F)) f s x₀ ↔
-      SmoothWithinAt IM IB (fun x => (f x).proj) s x₀ ∧
-      SmoothWithinAt IM 𝓘(𝕜, F) (fun x ↦ (e (f x)).2) s x₀ :=
-  e.contMDiffWithinAt_iff he
+@[deprecated (since := "2024-11-21")]
+alias Trivialization.smoothWithinAt_iff := Trivialization.contMDiffWithinAt_iff
 
-theorem Trivialization.smoothAt_iff {f : M → TotalSpace F E} {x₀ : M} (he : f x₀ ∈ e.source) :
-    SmoothAt IM (IB.prod 𝓘(𝕜, F)) f x₀ ↔
-      SmoothAt IM IB (fun x => (f x).proj) x₀ ∧ SmoothAt IM 𝓘(𝕜, F) (fun x ↦ (e (f x)).2) x₀ :=
-  e.contMDiffAt_iff he
+@[deprecated (since := "2024-11-21")]
+alias Trivialization.smoothAt_iff := Trivialization.contMDiffAt_iff
 
-theorem Trivialization.smoothOn_iff {f : M → TotalSpace F E} {s : Set M}
-    (he : MapsTo f s e.source) :
-    SmoothOn IM (IB.prod 𝓘(𝕜, F)) f s ↔
-      SmoothOn IM IB (fun x => (f x).proj) s ∧ SmoothOn IM 𝓘(𝕜, F) (fun x ↦ (e (f x)).2) s :=
-  e.contMDiffOn_iff he
+@[deprecated (since := "2024-11-21")]
+alias Trivialization.smoothOn_iff := Trivialization.contMDiffOn_iff
 
-theorem Trivialization.smooth_iff {f : M → TotalSpace F E} (he : ∀ x, f x ∈ e.source) :
-    Smooth IM (IB.prod 𝓘(𝕜, F)) f ↔
-      Smooth IM IB (fun x => (f x).proj) ∧ Smooth IM 𝓘(𝕜, F) (fun x ↦ (e (f x)).2) :=
-  e.contMDiff_iff he
+@[deprecated (since := "2024-11-21")]
+alias Trivialization.smooth_iff := Trivialization.contMDiff_iff
 
-theorem Trivialization.smoothOn (e : Trivialization F (π F E)) [MemTrivializationAtlas e] :
-    SmoothOn (IB.prod 𝓘(𝕜, F)) (IB.prod 𝓘(𝕜, F)) e e.source := by
-  have : SmoothOn (IB.prod 𝓘(𝕜, F)) (IB.prod 𝓘(𝕜, F)) id e.source := smoothOn_id
-  rw [e.smoothOn_iff (mapsTo_id _)] at this
+theorem Trivialization.contMDiffOn (e : Trivialization F (π F E)) [MemTrivializationAtlas e] :
+    ContMDiffOn (IB.prod 𝓘(𝕜, F)) (IB.prod 𝓘(𝕜, F)) ⊤ e e.source := by
+  have : ContMDiffOn (IB.prod 𝓘(𝕜, F)) (IB.prod 𝓘(𝕜, F)) ⊤ id e.source := contMDiffOn_id
+  rw [e.contMDiffOn_iff (mapsTo_id _)] at this
   exact (this.1.prod_mk this.2).congr fun x hx ↦ (e.mk_proj_snd hx).symm
 
-theorem Trivialization.smoothOn_symm (e : Trivialization F (π F E)) [MemTrivializationAtlas e] :
-    SmoothOn (IB.prod 𝓘(𝕜, F)) (IB.prod 𝓘(𝕜, F)) e.toPartialHomeomorph.symm e.target := by
-  rw [e.smoothOn_iff e.toPartialHomeomorph.symm_mapsTo]
-  refine ⟨smoothOn_fst.congr fun x hx ↦ e.proj_symm_apply hx, smoothOn_snd.congr fun x hx ↦ ?_⟩
+theorem Trivialization.contMDiffOn_symm (e : Trivialization F (π F E)) [MemTrivializationAtlas e] :
+    ContMDiffOn (IB.prod 𝓘(𝕜, F)) (IB.prod 𝓘(𝕜, F)) ⊤ e.toPartialHomeomorph.symm e.target := by
+  rw [e.contMDiffOn_iff e.toPartialHomeomorph.symm_mapsTo]
+  refine ⟨contMDiffOn_fst.congr fun x hx ↦ e.proj_symm_apply hx,
+    contMDiffOn_snd.congr fun x hx ↦ ?_⟩
   rw [e.apply_symm_apply hx]
+
+@[deprecated (since := "2024-11-21")] alias Trivialization.smoothOn := Trivialization.contMDiffOn
+
+@[deprecated (since := "2024-11-21")]
+alias Trivialization.smoothOn_symm := Trivialization.contMDiffOn_symm
 
 end
 
@@ -563,21 +532,24 @@ variable {ι : Type*} (Z : VectorBundleCore 𝕜 B F ι)
 
 /-- Mixin for a `VectorBundleCore` stating smoothness (of transition functions). -/
 class IsSmooth (IB : ModelWithCorners 𝕜 EB HB) : Prop where
-  smoothOn_coordChange :
-    ∀ i j, SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (Z.coordChange i j) (Z.baseSet i ∩ Z.baseSet j)
+  contMDiffOn_coordChange :
+    ∀ i j, ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (Z.coordChange i j) (Z.baseSet i ∩ Z.baseSet j)
 
-theorem smoothOn_coordChange (IB : ModelWithCorners 𝕜 EB HB) [h : Z.IsSmooth IB] (i j : ι) :
-    SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (Z.coordChange i j) (Z.baseSet i ∩ Z.baseSet j) :=
+theorem contMDiffOn_coordChange (IB : ModelWithCorners 𝕜 EB HB) [h : Z.IsSmooth IB] (i j : ι) :
+    ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (Z.coordChange i j) (Z.baseSet i ∩ Z.baseSet j) :=
   h.1 i j
+
+@[deprecated (since := "2024-11-21")]
+alias smoothOn_coordChange := contMDiffOn_coordChange
 
 variable [Z.IsSmooth IB]
 
 /-- If a `VectorBundleCore` has the `IsSmooth` mixin, then the vector bundle constructed from it
 is a smooth vector bundle. -/
 instance smoothVectorBundle : SmoothVectorBundle F Z.Fiber IB where
-  smoothOn_coordChangeL := by
+  contMDiffOn_coordChangeL := by
     rintro - - ⟨i, rfl⟩ ⟨i', rfl⟩
-    refine (Z.smoothOn_coordChange IB i i').congr fun b hb ↦ ?_
+    refine (Z.contMDiffOn_coordChange IB i i').congr fun b hb ↦ ?_
     ext v
     exact Z.localTriv_coordChange_eq i i' hb v
 
@@ -587,12 +559,12 @@ end VectorBundleCore
 
 /-- A trivial vector bundle over a smooth manifold is a smooth vector bundle. -/
 instance Bundle.Trivial.smoothVectorBundle : SmoothVectorBundle F (Bundle.Trivial B F) IB where
-  smoothOn_coordChangeL := by
+  contMDiffOn_coordChangeL := by
     intro e e' he he'
     obtain rfl := Bundle.Trivial.eq_trivialization B F e
     obtain rfl := Bundle.Trivial.eq_trivialization B F e'
     simp_rw [Bundle.Trivial.trivialization.coordChangeL]
-    exact smooth_const.smoothOn
+    exact contMDiff_const.contMDiffOn
 
 /-! ### Direct sums of smooth vector bundles -/
 
@@ -613,15 +585,14 @@ variable [SmoothManifoldWithCorners IB B]
 
 /-- The direct sum of two smooth vector bundles over the same base is a smooth vector bundle. -/
 instance Bundle.Prod.smoothVectorBundle : SmoothVectorBundle (F₁ × F₂) (E₁ ×ᵇ E₂) IB where
-  smoothOn_coordChangeL := by
+  contMDiffOn_coordChangeL := by
     rintro _ _ ⟨e₁, e₂, i₁, i₂, rfl⟩ ⟨e₁', e₂', i₁', i₂', rfl⟩
-    rw [SmoothOn]
     refine ContMDiffOn.congr ?_ (e₁.coordChangeL_prod 𝕜 e₁' e₂ e₂')
     refine ContMDiffOn.clm_prodMap ?_ ?_
-    · refine (smoothOn_coordChangeL e₁ e₁').mono ?_
+    · refine (contMDiffOn_coordChangeL e₁ e₁').mono ?_
       simp only [Trivialization.baseSet_prod, mfld_simps]
       mfld_set_tac
-    · refine (smoothOn_coordChangeL e₂ e₂').mono ?_
+    · refine (contMDiffOn_coordChangeL e₂ e₂').mono ?_
       simp only [Trivialization.baseSet_prod, mfld_simps]
       mfld_set_tac
 
@@ -641,7 +612,7 @@ class IsSmooth (a : VectorPrebundle 𝕜 F E) : Prop where
   exists_smoothCoordChange :
     ∀ᵉ (e ∈ a.pretrivializationAtlas) (e' ∈ a.pretrivializationAtlas),
       ∃ f : B → F →L[𝕜] F,
-        SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) f (e.baseSet ∩ e'.baseSet) ∧
+        ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ f (e.baseSet ∩ e'.baseSet) ∧
           ∀ (b : B) (_ : b ∈ e.baseSet ∩ e'.baseSet) (v : F),
             f b v = (e' ⟨b, e.symm b v⟩).2
 
@@ -655,10 +626,13 @@ noncomputable def smoothCoordChange (he : e ∈ a.pretrivializationAtlas)
     (he' : e' ∈ a.pretrivializationAtlas) (b : B) : F →L[𝕜] F :=
   Classical.choose (ha.exists_smoothCoordChange e he e' he') b
 
-theorem smoothOn_smoothCoordChange (he : e ∈ a.pretrivializationAtlas)
+theorem contMDiffOn_smoothCoordChange (he : e ∈ a.pretrivializationAtlas)
     (he' : e' ∈ a.pretrivializationAtlas) :
-    SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (a.smoothCoordChange IB he he') (e.baseSet ∩ e'.baseSet) :=
+    ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (a.smoothCoordChange IB he he') (e.baseSet ∩ e'.baseSet) :=
   (Classical.choose_spec (ha.exists_smoothCoordChange e he e' he')).1
+
+@[deprecated (since := "2024-11-21")]
+alias smooth_smoothCoordChange := contMDiffOn_smoothCoordChange
 
 theorem smoothCoordChange_apply (he : e ∈ a.pretrivializationAtlas)
     (he' : e' ∈ a.pretrivializationAtlas) {b : B} (hb : b ∈ e.baseSet ∩ e'.baseSet) (v : F) :
@@ -678,9 +652,9 @@ variable (IB) in
 theorem smoothVectorBundle : @SmoothVectorBundle
     _ _ F E _ _ _ _ _ _ IB _ _ _ _ _ _ a.totalSpaceTopology _ a.toFiberBundle a.toVectorBundle :=
   letI := a.totalSpaceTopology; letI := a.toFiberBundle; letI := a.toVectorBundle
-  { smoothOn_coordChangeL := by
+  { contMDiffOn_coordChangeL := by
       rintro _ _ ⟨e, he, rfl⟩ ⟨e', he', rfl⟩
-      refine (a.smoothOn_smoothCoordChange he he').congr ?_
+      refine (a.contMDiffOn_smoothCoordChange he he').congr ?_
       intro b hb
       ext v
       rw [a.smoothCoordChange_apply he he' hb v, ContinuousLinearEquiv.coe_coe,

--- a/Mathlib/Geometry/Manifold/VectorBundle/FiberwiseLinear.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/FiberwiseLinear.lean
@@ -103,14 +103,14 @@ fiberwise linear partial homeomorphism. -/
 theorem SmoothFiberwiseLinear.locality_aux₁ (e : PartialHomeomorph (B × F) (B × F))
     (h : ∀ p ∈ e.source, ∃ s : Set (B × F), IsOpen s ∧ p ∈ s ∧
       ∃ (φ : B → F ≃L[𝕜] F) (u : Set B) (hu : IsOpen u)
-        (hφ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (φ x : F →L[𝕜] F)) u)
-        (h2φ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => ((φ x).symm : F →L[𝕜] F)) u),
+        (hφ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => (φ x : F →L[𝕜] F)) u)
+        (h2φ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => ((φ x).symm : F →L[𝕜] F)) u),
           (e.restr s).EqOnSource
             (FiberwiseLinear.partialHomeomorph φ hu hφ.continuousOn h2φ.continuousOn)) :
     ∃ U : Set B, e.source = U ×ˢ univ ∧ ∀ x ∈ U,
         ∃ (φ : B → F ≃L[𝕜] F) (u : Set B) (hu : IsOpen u) (_huU : u ⊆ U) (_hux : x ∈ u),
-          ∃ (hφ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (φ x : F →L[𝕜] F)) u)
-            (h2φ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => ((φ x).symm : F →L[𝕜] F)) u),
+          ∃ (hφ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => (φ x : F →L[𝕜] F)) u)
+            (h2φ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => ((φ x).symm : F →L[𝕜] F)) u),
             (e.restr (u ×ˢ univ)).EqOnSource
               (FiberwiseLinear.partialHomeomorph φ hu hφ.continuousOn h2φ.continuousOn) := by
   rw [SetCoe.forall'] at h
@@ -155,13 +155,13 @@ theorem SmoothFiberwiseLinear.locality_aux₂ (e : PartialHomeomorph (B × F) (B
     (hU : e.source = U ×ˢ univ)
     (h : ∀ x ∈ U,
       ∃ (φ : B → F ≃L[𝕜] F) (u : Set B) (hu : IsOpen u) (_hUu : u ⊆ U) (_hux : x ∈ u)
-        (hφ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (φ x : F →L[𝕜] F)) u)
-        (h2φ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => ((φ x).symm : F →L[𝕜] F)) u),
+        (hφ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => (φ x : F →L[𝕜] F)) u)
+        (h2φ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => ((φ x).symm : F →L[𝕜] F)) u),
           (e.restr (u ×ˢ univ)).EqOnSource
             (FiberwiseLinear.partialHomeomorph φ hu hφ.continuousOn h2φ.continuousOn)) :
     ∃ (Φ : B → F ≃L[𝕜] F) (U : Set B) (hU₀ : IsOpen U) (hΦ :
-      SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (Φ x : F →L[𝕜] F)) U) (h2Φ :
-      SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => ((Φ x).symm : F →L[𝕜] F)) U),
+      ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => (Φ x : F →L[𝕜] F)) U) (h2Φ :
+      ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => ((Φ x).symm : F →L[𝕜] F)) U),
       e.EqOnSource (FiberwiseLinear.partialHomeomorph Φ hU₀ hΦ.continuousOn h2Φ.continuousOn) := by
   classical
   rw [SetCoe.forall'] at h
@@ -192,14 +192,14 @@ theorem SmoothFiberwiseLinear.locality_aux₂ (e : PartialHomeomorph (B × F) (B
     intro x y hyu
     refine (hΦ y (hUu x hyu)).trans ?_
     exact iUnionLift_mk ⟨y, hyu⟩ _
-  have hΦ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun y => (Φ y : F →L[𝕜] F)) U := by
+  have hΦ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun y => (Φ y : F →L[𝕜] F)) U := by
     apply contMDiffOn_of_locally_contMDiffOn
     intro x hx
     refine ⟨u ⟨x, hx⟩, hu ⟨x, hx⟩, hux _, ?_⟩
     refine (ContMDiffOn.congr (hφ ⟨x, hx⟩) ?_).mono inter_subset_right
     intro y hy
     rw [hΦφ ⟨x, hx⟩ y hy]
-  have h2Φ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun y => ((Φ y).symm : F →L[𝕜] F)) U := by
+  have h2Φ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun y => ((Φ y).symm : F →L[𝕜] F)) U := by
     apply contMDiffOn_of_locally_contMDiffOn
     intro x hx
     refine ⟨u ⟨x, hx⟩, hu ⟨x, hx⟩, hux _, ?_⟩
@@ -221,13 +221,13 @@ variable {F B IB} in
 -- in `smoothFiberwiseLinear` are quite slow, even with this change)
 private theorem mem_aux {e : PartialHomeomorph (B × F) (B × F)} :
     (e ∈ ⋃ (φ : B → F ≃L[𝕜] F) (U : Set B) (hU : IsOpen U)
-      (hφ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => φ x : B → F →L[𝕜] F) U)
-      (h2φ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (φ x).symm : B → F →L[𝕜] F) U),
+      (hφ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => φ x : B → F →L[𝕜] F) U)
+      (h2φ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => (φ x).symm : B → F →L[𝕜] F) U),
         {e | e.EqOnSource (FiberwiseLinear.partialHomeomorph φ hU hφ.continuousOn
           h2φ.continuousOn)}) ↔
       ∃ (φ : B → F ≃L[𝕜] F) (U : Set B) (hU : IsOpen U)
-        (hφ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => φ x : B → F →L[𝕜] F) U)
-        (h2φ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (φ x).symm : B → F →L[𝕜] F) U),
+        (hφ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => φ x : B → F →L[𝕜] F) U)
+        (h2φ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => (φ x).symm : B → F →L[𝕜] F) U),
           e.EqOnSource
             (FiberwiseLinear.partialHomeomorph φ hU hφ.continuousOn h2φ.continuousOn) := by
   simp only [mem_iUnion, mem_setOf_eq]
@@ -239,8 +239,8 @@ to the vector bundle belong to this groupoid. -/
 def smoothFiberwiseLinear : StructureGroupoid (B × F) where
   members :=
     ⋃ (φ : B → F ≃L[𝕜] F) (U : Set B) (hU : IsOpen U)
-      (hφ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => φ x : B → F →L[𝕜] F) U)
-      (h2φ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (φ x).symm : B → F →L[𝕜] F) U),
+      (hφ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => φ x : B → F →L[𝕜] F) U)
+      (h2φ : ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => (φ x).symm : B → F →L[𝕜] F) U),
         {e | e.EqOnSource (FiberwiseLinear.partialHomeomorph φ hU hφ.continuousOn h2φ.continuousOn)}
   trans' := by
     simp only [mem_aux]
@@ -248,11 +248,11 @@ def smoothFiberwiseLinear : StructureGroupoid (B × F) where
     refine ⟨fun b => (φ b).trans (φ' b), _, hU.inter hU', ?_, ?_,
       Setoid.trans (PartialHomeomorph.EqOnSource.trans' heφ heφ') ⟨?_, ?_⟩⟩
     · show
-        SmoothOn IB 𝓘(𝕜, F →L[𝕜] F)
+        ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤
           (fun x : B => (φ' x).toContinuousLinearMap ∘L (φ x).toContinuousLinearMap) (U ∩ U')
       exact (hφ'.mono inter_subset_right).clm_comp (hφ.mono inter_subset_left)
     · show
-        SmoothOn IB 𝓘(𝕜, F →L[𝕜] F)
+        ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤
           (fun x : B => (φ x).symm.toContinuousLinearMap ∘L (φ' x).symm.toContinuousLinearMap)
           (U ∩ U')
       exact (h2φ.mono inter_subset_left).clm_comp (h2φ'.mono inter_subset_right)
@@ -267,8 +267,8 @@ def smoothFiberwiseLinear : StructureGroupoid (B × F) where
     exact hφ
   id_mem' := by
     simp_rw [mem_aux]
-    refine ⟨fun _ ↦ ContinuousLinearEquiv.refl 𝕜 F, univ, isOpen_univ, smoothOn_const,
-      smoothOn_const, ⟨?_, fun b _hb ↦ rfl⟩⟩
+    refine ⟨fun _ ↦ ContinuousLinearEquiv.refl 𝕜 F, univ, isOpen_univ, contMDiffOn_const,
+      contMDiffOn_const, ⟨?_, fun b _hb ↦ rfl⟩⟩
     simp only [FiberwiseLinear.partialHomeomorph, PartialHomeomorph.refl_partialEquiv,
       PartialEquiv.refl_source, univ_prod_univ]
   locality' := by
@@ -286,7 +286,7 @@ def smoothFiberwiseLinear : StructureGroupoid (B × F) where
 theorem mem_smoothFiberwiseLinear_iff (e : PartialHomeomorph (B × F) (B × F)) :
     e ∈ smoothFiberwiseLinear B F IB ↔
       ∃ (φ : B → F ≃L[𝕜] F) (U : Set B) (hU : IsOpen U) (hφ :
-        SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => φ x : B → F →L[𝕜] F) U) (h2φ :
-        SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (φ x).symm : B → F →L[𝕜] F) U),
+        ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => φ x : B → F →L[𝕜] F) U) (h2φ :
+        ContMDiffOn IB 𝓘(𝕜, F →L[𝕜] F) ⊤ (fun x => (φ x).symm : B → F →L[𝕜] F) U),
         e.EqOnSource (FiberwiseLinear.partialHomeomorph φ hU hφ.continuousOn h2φ.continuousOn) :=
   mem_aux

--- a/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean
@@ -41,15 +41,18 @@ variable {𝕜 B F₁ F₂ M : Type*} {E₁ : B → Type*} {E₂ : B → Type*} 
 local notation "LE₁E₂" => TotalSpace (F₁ →L[𝕜] F₂) (Bundle.ContinuousLinearMap (RingHom.id 𝕜) E₁ E₂)
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11083): moved slow parts to separate lemmas
-theorem smoothOn_continuousLinearMapCoordChange
+theorem contMDiffOn_continuousLinearMapCoordChange
     [SmoothVectorBundle F₁ E₁ IB] [SmoothVectorBundle F₂ E₂ IB] [MemTrivializationAtlas e₁]
     [MemTrivializationAtlas e₁'] [MemTrivializationAtlas e₂] [MemTrivializationAtlas e₂'] :
-    SmoothOn IB 𝓘(𝕜, (F₁ →L[𝕜] F₂) →L[𝕜] F₁ →L[𝕜] F₂)
+    ContMDiffOn IB 𝓘(𝕜, (F₁ →L[𝕜] F₂) →L[𝕜] F₁ →L[𝕜] F₂) ⊤
       (continuousLinearMapCoordChange (RingHom.id 𝕜) e₁ e₁' e₂ e₂')
       (e₁.baseSet ∩ e₂.baseSet ∩ (e₁'.baseSet ∩ e₂'.baseSet)) := by
-  have h₁ := smoothOn_coordChangeL (IB := IB) e₁' e₁
-  have h₂ := smoothOn_coordChangeL (IB := IB) e₂ e₂'
+  have h₁ := contMDiffOn_coordChangeL (IB := IB) e₁' e₁ (n := ⊤)
+  have h₂ := contMDiffOn_coordChangeL (IB := IB) e₂ e₂' (n := ⊤)
   refine (h₁.mono ?_).cle_arrowCongr (h₂.mono ?_) <;> mfld_set_tac
+
+@[deprecated (since := "2024-11-21")]
+alias smoothOn_continuousLinearMapCoordChange := contMDiffOn_continuousLinearMapCoordChange
 
 variable [∀ x, TopologicalAddGroup (E₂ x)] [∀ x, ContinuousSMul 𝕜 (E₂ x)]
 
@@ -67,12 +70,8 @@ theorem contMDiffAt_hom_bundle (f : M → LE₁E₂) {x₀ : M} {n : ℕ∞} :
           (fun x => inCoordinates F₁ E₁ F₂ E₂ (f x₀).1 (f x).1 (f x₀).1 (f x).1 (f x).2) x₀ :=
   contMDiffAt_totalSpace ..
 
-theorem smoothAt_hom_bundle (f : M → LE₁E₂) {x₀ : M} :
-    SmoothAt IM (IB.prod 𝓘(𝕜, F₁ →L[𝕜] F₂)) f x₀ ↔
-      SmoothAt IM IB (fun x => (f x).1) x₀ ∧
-        SmoothAt IM 𝓘(𝕜, F₁ →L[𝕜] F₂)
-          (fun x => inCoordinates F₁ E₁ F₂ E₂ (f x₀).1 (f x).1 (f x₀).1 (f x).1 (f x).2) x₀ :=
-  contMDiffAt_hom_bundle f
+@[deprecated (since := "2024-11-21")] alias smoothAt_hom_bundle := contMDiffAt_hom_bundle
+
 
 variable [SmoothVectorBundle F₁ E₁ IB] [SmoothVectorBundle F₂ E₂ IB]
 
@@ -81,7 +80,7 @@ instance Bundle.ContinuousLinearMap.vectorPrebundle.isSmooth :
   exists_smoothCoordChange := by
     rintro _ ⟨e₁, e₂, he₁, he₂, rfl⟩ _ ⟨e₁', e₂', he₁', he₂', rfl⟩
     exact ⟨continuousLinearMapCoordChange (RingHom.id 𝕜) e₁ e₁' e₂ e₂',
-      smoothOn_continuousLinearMapCoordChange,
+      contMDiffOn_continuousLinearMapCoordChange,
       continuousLinearMapCoordChange_apply (RingHom.id 𝕜) e₁ e₁' e₂ e₂'⟩
 
 instance SmoothVectorBundle.continuousLinearMap :

--- a/Mathlib/Geometry/Manifold/VectorBundle/Pullback.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Pullback.lean
@@ -28,14 +28,14 @@ variable [NontriviallyNormedField 𝕜] [∀ x, AddCommMonoid (E x)] [∀ x, Mod
   [ChartedSpace HB B] {EB' : Type*} [NormedAddCommGroup EB']
   [NormedSpace 𝕜 EB'] {HB' : Type*} [TopologicalSpace HB'] (IB' : ModelWithCorners 𝕜 EB' HB')
   [TopologicalSpace B'] [ChartedSpace HB' B'] [FiberBundle F E]
-  [VectorBundle 𝕜 F E] [SmoothVectorBundle F E IB] (f : SmoothMap IB' IB B' B)
+  [VectorBundle 𝕜 F E] [SmoothVectorBundle F E IB] (f : ContMDiffMap IB' IB B' B ⊤)
 
 /-- For a smooth vector bundle `E` over a manifold `B` and a smooth map `f : B' → B`, the pullback
 vector bundle `f *ᵖ E` is a smooth vector bundle. -/
 instance SmoothVectorBundle.pullback : SmoothVectorBundle F (f *ᵖ E) IB' where
-  smoothOn_coordChangeL := by
+  contMDiffOn_coordChangeL := by
     rintro _ _ ⟨e, he, rfl⟩ ⟨e', he', rfl⟩
-    refine ((smoothOn_coordChangeL e e').comp f.smooth.smoothOn fun b hb => hb).congr ?_
+    refine ((contMDiffOn_coordChangeL e e').comp f.contMDiff.contMDiffOn fun b hb => hb).congr ?_
     rintro b (hb : f b ∈ e.baseSet ∩ e'.baseSet); ext v
     show ((e.pullback f).coordChangeL 𝕜 (e'.pullback f) b) v = (e.coordChangeL 𝕜 e' (f b)) v
     rw [e.coordChangeL_apply e' hb, (e.pullback f).coordChangeL_apply' _]

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -39,9 +39,7 @@ structure ContMDiffSection where
   protected contMDiff_toFun : ContMDiff I (I.prod 𝓘(𝕜, F)) n fun x ↦
     TotalSpace.mk' F x (toFun x)
 
-/- Bundled smooth sections of a vector bundle. -/
---abbrev SmoothSection :=
---  ContMDiffSection I F ⊤ V
+@[deprecated (since := "024-11-21")] alias SmoothSection := ContMDiffSection
 
 @[inherit_doc] scoped[Manifold] notation "Cₛ^" n "⟮" I "; " F ", " V "⟯" => ContMDiffSection I F n V
 

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -39,9 +39,9 @@ structure ContMDiffSection where
   protected contMDiff_toFun : ContMDiff I (I.prod 𝓘(𝕜, F)) n fun x ↦
     TotalSpace.mk' F x (toFun x)
 
-/-- Bundled smooth sections of a vector bundle. -/
-abbrev SmoothSection :=
-  ContMDiffSection I F ⊤ V
+/- Bundled smooth sections of a vector bundle. -/
+--abbrev SmoothSection :=
+--  ContMDiffSection I F ⊤ V
 
 @[inherit_doc] scoped[Manifold] notation "Cₛ^" n "⟮" I "; " F ", " V "⟯" => ContMDiffSection I F n V
 
@@ -65,9 +65,7 @@ protected theorem contMDiff (s : Cₛ^n⟮I; F, V⟯) :
     ContMDiff I (I.prod 𝓘(𝕜, F)) n fun x => TotalSpace.mk' F x (s x : V x) :=
   s.contMDiff_toFun
 
-protected theorem smooth (s : Cₛ^∞⟮I; F, V⟯) :
-    Smooth I (I.prod 𝓘(𝕜, F)) fun x => TotalSpace.mk' F x (s x : V x) :=
-  s.contMDiff_toFun
+@[deprecated (since := "2024-11-21")] alias smooth := ContMDiffSection.contMDiff
 
 theorem coe_inj ⦃s t : Cₛ^n⟮I; F, V⟯⦄ (h : (s : ∀ x, V x) = t) : s = t :=
   DFunLike.ext' h
@@ -114,7 +112,7 @@ theorem coe_sub (s t : Cₛ^n⟮I; F, V⟯) : ⇑(s - t) = s - t :=
   rfl
 
 instance instZero : Zero Cₛ^n⟮I; F, V⟯ :=
-  ⟨⟨fun _ => 0, (smooth_zeroSection 𝕜 V).of_le le_top⟩⟩
+  ⟨⟨fun _ => 0, (contMDiff_zeroSection 𝕜 V).of_le le_top⟩⟩
 
 instance inhabited : Inhabited Cₛ^n⟮I; F, V⟯ :=
   ⟨0⟩

--- a/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
@@ -286,7 +286,7 @@ end TangentBundle
 
 instance tangentBundleCore.isSmooth : (tangentBundleCore I M).IsSmooth I := by
   refine ⟨fun i j => ?_⟩
-  rw [SmoothOn, contMDiffOn_iff_source_of_mem_maximalAtlas (subset_maximalAtlas i.2),
+  rw [contMDiffOn_iff_source_of_mem_maximalAtlas (subset_maximalAtlas i.2),
     contMDiffOn_iff_contDiffOn]
   · refine ((contDiffOn_fderiv_coord_change (I := I) i j).congr fun x hx => ?_).mono ?_
     · rw [PartialEquiv.trans_source'] at hx

--- a/Mathlib/Geometry/Manifold/WhitneyEmbedding.lean
+++ b/Mathlib/Geometry/Manifold/WhitneyEmbedding.lean
@@ -52,7 +52,7 @@ def embeddingPiTangent : C^∞⟮I, M; 𝓘(ℝ, ι → E × ℝ), ι → E × �
   val x i := (f i x • extChartAt I (f.c i) x, f i x)
   property :=
     contMDiff_pi_space.2 fun i =>
-      ((f i).smooth_smul contMDiffOn_extChartAt).prod_mk_space (f i).smooth
+      ((f i).contMDiff_smul contMDiffOn_extChartAt).prod_mk_space (f i).contMDiff
 
 @[local simp]
 theorem embeddingPiTangent_coe :
@@ -81,7 +81,8 @@ theorem comp_embeddingPiTangent_mfderiv (x : M) (hx : x ∈ s) :
   set L :=
     (ContinuousLinearMap.fst ℝ E ℝ).comp
       (@ContinuousLinearMap.proj ℝ _ ι (fun _ => E × ℝ) _ _ (fun _ => inferInstance) (f.ind x hx))
-  have := L.hasMFDerivAt.comp x f.embeddingPiTangent.smooth.mdifferentiableAt.hasMFDerivAt
+  have := L.hasMFDerivAt.comp x
+    (f.embeddingPiTangent.contMDiff.mdifferentiableAt le_top).hasMFDerivAt
   convert hasMFDerivAt_unique this _
   refine (hasMFDerivAt_extChartAt (f.mem_chartAt_ind_source x hx)).congr_of_eventuallyEq ?_
   refine (f.eventuallyEq_one x hx).mono fun y hy => ?_
@@ -106,7 +107,7 @@ supports of bump functions, then for some `n` it can be immersed into the `n`-di
 Euclidean space. -/
 theorem exists_immersion_euclidean {ι : Type*} [Finite ι] (f : SmoothBumpCovering ι I M) :
     ∃ (n : ℕ) (e : M → EuclideanSpace ℝ (Fin n)),
-      Smooth I (𝓡 n) e ∧ Injective e ∧ ∀ x : M, Injective (mfderiv I (𝓡 n) e x) := by
+      ContMDiff I (𝓡 n) ⊤ e ∧ Injective e ∧ ∀ x : M, Injective (mfderiv I (𝓡 n) e x) := by
   cases nonempty_fintype ι
   set F := EuclideanSpace ℝ (Fin <| finrank ℝ (ι → E × ℝ))
   letI : IsNoetherian ℝ (E × ℝ) := IsNoetherian.iff_fg.2 inferInstance
@@ -114,10 +115,10 @@ theorem exists_immersion_euclidean {ι : Type*} [Finite ι] (f : SmoothBumpCover
   set eEF : (ι → E × ℝ) ≃L[ℝ] F :=
     ContinuousLinearEquiv.ofFinrankEq finrank_euclideanSpace_fin.symm
   refine ⟨_, eEF ∘ f.embeddingPiTangent,
-    eEF.toDiffeomorph.smooth.comp f.embeddingPiTangent.smooth,
+    eEF.toDiffeomorph.contMDiff.comp f.embeddingPiTangent.contMDiff,
     eEF.injective.comp f.embeddingPiTangent_injective, fun x => ?_⟩
   rw [mfderiv_comp _ eEF.differentiableAt.mdifferentiableAt
-      f.embeddingPiTangent.smooth.mdifferentiableAt,
+      (f.embeddingPiTangent.contMDiff.mdifferentiableAt le_top),
     eEF.mfderiv_eq]
   exact eEF.injective.comp (f.embeddingPiTangent_injective_mfderiv _ trivial)
 
@@ -128,7 +129,7 @@ supports of bump functions, then for some `n` it can be embedded into the `n`-di
 Euclidean space. -/
 theorem exists_embedding_euclidean_of_compact [T2Space M] [CompactSpace M] :
     ∃ (n : ℕ) (e : M → EuclideanSpace ℝ (Fin n)),
-      Smooth I (𝓡 n) e ∧ IsClosedEmbedding e ∧ ∀ x : M, Injective (mfderiv I (𝓡 n) e x) := by
+      ContMDiff I (𝓡 n) ⊤ e ∧ IsClosedEmbedding e ∧ ∀ x : M, Injective (mfderiv I (𝓡 n) e x) := by
   rcases SmoothBumpCovering.exists_isSubordinate I isClosed_univ fun (x : M) _ => univ_mem with
     ⟨ι, f, -⟩
   haveI := f.fintype


### PR DESCRIPTION
The abbreviation `Smooth` for `ContMDiff` with infinite smoothness had been introduced in mathlib in ancient times. This has lead to a big API duplication, for no visible gain. We deprecate this abbreviation (with its friends `SmoothAt` and so on) and all the lemmas involving it.

In the longer run, we might consider reintroducing it as a mere notation (without any specific API), but this is not part of this PR, devoted purely to the deprecation. No mathematical content added.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
