### PR TITLE
[Merged by Bors] - fix: `>>` and print author

### DIFF
--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -42,16 +42,17 @@ jobs:
             sed -n 's=^bors  *\(merge\|r+\) *$=ready-to-merge=p; s=^bors  *d.*=delegated=p' | head -1)"
 
           printf $'"bors delegate" or "bors merge" found? \'%s\'\n' "${m_or_d}"
+          printf $'AUTHOR: \'%s\'\n' "${AUTHOR}"
 
-          printf $'mOrD=%s\n' "${m_or_d}" > "${GITHUB_OUTPUT}"
+          printf $'mOrD=%s\n' "${m_or_d}" >> "${GITHUB_OUTPUT}"
           if [ "${AUTHOR}" == 'leanprover-community-mathlib4-bot' ] ||
              [ "${AUTHOR}" == 'leanprover-community-bot-assistant' ]
           then
             printf $'bot=true\n'
-            printf $'bot=true\n' > "${GITHUB_OUTPUT}"
+            printf $'bot=true\n' >> "${GITHUB_OUTPUT}"
           else
             printf $'bot=false\n'
-            printf $'bot=false\n' > "${GITHUB_OUTPUT}"
+            printf $'bot=false\n' >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Check whether user is a mathlib admin


### PR DESCRIPTION
Use `>>` to set `GITHUB_OUTPUT`, instead of `>`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
