### PR TITLE
[Merged by Bors] - fix(to_additive): automatically translate all instances generated by `extends`

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -355,7 +355,6 @@ class CommSemigroup (G : Type u) extends Semigroup G, CommMagma G where
 class AddCommSemigroup (G : Type u) extends AddSemigroup G, AddCommMagma G where
 
 attribute [to_additive] CommSemigroup
-attribute [to_additive existing] CommSemigroup.toCommMagma
 
 section CommMagma
 
@@ -731,9 +730,6 @@ class Monoid (M : Type u) extends Semigroup M, MulOneClass M where
   /-- Raising to the power `(n + 1 : ℕ)` behaves as expected. -/
   protected npow_succ : ∀ (n : ℕ) (x), npow (n + 1) x = npow n x * x := by intros; rfl
 
--- Bug https://github.com/leanprover-community/mathlib4/issues/660
-attribute [to_additive existing] Monoid.toMulOneClass
-
 @[default_instance high] instance Monoid.toNatPow {M : Type*} [Monoid M] : Pow M ℕ :=
   ⟨fun x n ↦ Monoid.npow n x⟩
 
@@ -816,8 +812,6 @@ class AddCommMonoid (M : Type u) extends AddMonoid M, AddCommSemigroup M
 @[to_additive]
 class CommMonoid (M : Type u) extends Monoid M, CommSemigroup M
 
-attribute [to_additive existing] CommMonoid.toCommSemigroup
-
 section LeftCancelMonoid
 
 /-- An additive monoid in which addition is left-cancellative.
@@ -832,8 +826,6 @@ attribute [instance 75] AddLeftCancelMonoid.toAddMonoid -- See note [lower cance
 class LeftCancelMonoid (M : Type u) extends Monoid M, LeftCancelSemigroup M
 
 attribute [instance 75] LeftCancelMonoid.toMonoid -- See note [lower cancel priority]
-
-attribute [to_additive existing] LeftCancelMonoid.toLeftCancelSemigroup
 
 end LeftCancelMonoid
 
@@ -852,8 +844,6 @@ class RightCancelMonoid (M : Type u) extends Monoid M, RightCancelSemigroup M
 
 attribute [instance 75] RightCancelMonoid.toMonoid -- See note [lower cancel priority]
 
-attribute [to_additive existing] RightCancelMonoid.toRightCancelSemigroup
-
 end RightCancelMonoid
 
 section CancelMonoid
@@ -867,8 +857,6 @@ class AddCancelMonoid (M : Type u) extends AddLeftCancelMonoid M, AddRightCancel
 @[to_additive]
 class CancelMonoid (M : Type u) extends LeftCancelMonoid M, RightCancelMonoid M
 
-attribute [to_additive existing] CancelMonoid.toRightCancelMonoid
-
 /-- Commutative version of `AddCancelMonoid`. -/
 class AddCancelCommMonoid (M : Type u) extends AddCommMonoid M, AddLeftCancelMonoid M
 
@@ -879,8 +867,6 @@ attribute [instance 75] AddCancelCommMonoid.toAddCommMonoid -- See note [lower c
 class CancelCommMonoid (M : Type u) extends CommMonoid M, LeftCancelMonoid M
 
 attribute [instance 75] CancelCommMonoid.toCommMonoid -- See note [lower cancel priority]
-
-attribute [to_additive existing] CancelCommMonoid.toLeftCancelMonoid
 
 -- see Note [lower instance priority]
 @[to_additive]
@@ -1150,9 +1136,6 @@ class InvOneClass (G : Type*) extends One G, Inv G where
 @[to_additive]
 class DivInvOneMonoid (G : Type*) extends DivInvMonoid G, InvOneClass G
 
--- FIXME: `to_additive` is not operating on the second parent. (https://github.com/leanprover-community/mathlib4/issues/660)
-attribute [to_additive existing] DivInvOneMonoid.toInvOneClass
-
 variable [InvOneClass G]
 
 @[to_additive (attr := simp)]
@@ -1179,8 +1162,6 @@ class DivisionMonoid (G : Type u) extends DivInvMonoid G, InvolutiveInv G where
   /-- Despite the asymmetry of `inv_eq_of_mul`, the symmetric version is true thanks to the
   involutivity of inversion. -/
   protected inv_eq_of_mul (a b : G) : a * b = 1 → a⁻¹ = b
-
-attribute [to_additive existing] DivisionMonoid.toInvolutiveInv
 
 section DivisionMonoid
 
@@ -1212,8 +1193,6 @@ class SubtractionCommMonoid (G : Type u) extends SubtractionMonoid G, AddCommMon
 This is the immediate common ancestor of `CommGroup` and `CommGroupWithZero`. -/
 @[to_additive SubtractionCommMonoid]
 class DivisionCommMonoid (G : Type u) extends DivisionMonoid G, CommMonoid G
-
-attribute [to_additive existing] DivisionCommMonoid.toCommMonoid
 
 /-- A `Group` is a `Monoid` with an operation `⁻¹` satisfying `a⁻¹ * a = 1`.
 
@@ -1302,8 +1281,6 @@ class AddCommGroup (G : Type u) extends AddGroup G, AddCommMonoid G
 /-- A commutative group is a group with commutative `(*)`. -/
 @[to_additive]
 class CommGroup (G : Type u) extends Group G, CommMonoid G
-
-attribute [to_additive existing] CommGroup.toCommMonoid
 
 section CommGroup
 

--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -95,9 +95,6 @@ add_decl_doc AddEquiv.toAddHom
 /-- `MulEquiv α β` is the type of an equiv `α ≃ β` which preserves multiplication. -/
 @[to_additive]
 structure MulEquiv (M N : Type*) [Mul M] [Mul N] extends M ≃ N, M →ₙ* N
--- Porting note: remove when `to_additive` can do this
--- https://github.com/leanprover-community/mathlib4/issues/660
-attribute [to_additive existing] MulEquiv.toMulHom
 
 /-- The `Equiv` underlying a `MulEquiv`. -/
 add_decl_doc MulEquiv.toEquiv

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -342,9 +342,6 @@ When you extend this structure, make sure to extend `MonoidHomClass`.
 @[to_additive]
 structure MonoidHom (M : Type*) (N : Type*) [MulOneClass M] [MulOneClass N] extends
   OneHom M N, M →ₙ* N
--- Porting note: remove once `to_additive` is updated
--- This is waiting on https://github.com/leanprover-community/mathlib4/issues/660
-attribute [to_additive existing] MonoidHom.toMulHom
 
 attribute [nolint docBlame] MonoidHom.toMulHom
 attribute [nolint docBlame] MonoidHom.toOneHom

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -203,8 +203,6 @@ class CanonicallyLinearOrderedAddCommMonoid (α : Type*)
 class CanonicallyLinearOrderedCommMonoid (α : Type*)
   extends CanonicallyOrderedCommMonoid α, LinearOrderedCommMonoid α
 
-attribute [to_additive existing] CanonicallyLinearOrderedCommMonoid.toLinearOrderedCommMonoid
-
 section CanonicallyLinearOrderedCommMonoid
 
 variable [CanonicallyLinearOrderedCommMonoid α]

--- a/Mathlib/Algebra/Order/Monoid/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Defs.lean
@@ -99,8 +99,6 @@ in which multiplication is cancellative and monotone. -/
 class LinearOrderedCancelCommMonoid (α : Type*) extends OrderedCancelCommMonoid α,
     LinearOrderedCommMonoid α
 
-attribute [to_additive existing] LinearOrderedCancelCommMonoid.toLinearOrderedCommMonoid
-
 variable [LinearOrderedCommMonoid α] {a : α}
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1097,7 +1097,7 @@ def targetName (cfg : Config) (src : Name) : CoreM Name := do
 will insert translations from `src.a_i` to `tgt.b_i`
 (or from `a_i` to `b_i` if `prependName` is false). -/
 def proceedFieldsAux (src tgt : Name) (f : Name → CoreM (Array Name))
-  (prependName := true) : CoreM Unit := do
+    (prependName := true) : CoreM Unit := do
   let srcFields ← f src
   let tgtFields ← f tgt
   if srcFields.size != tgtFields.size then

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1094,27 +1094,41 @@ def targetName (cfg : Config) (src : Name) : CoreM Name := do
   return res
 
 /-- if `f src = #[a_1, ..., a_n]` and `f tgt = #[b_1, ... b_n]` then `proceedFieldsAux src tgt f`
-  will insert translations from `src.a_i` to `tgt.b_i`. -/
-def proceedFieldsAux (src tgt : Name) (f : Name → CoreM (Array Name)) : CoreM Unit := do
+will insert translations from `src.a_i` to `tgt.b_i`
+(or from `a_i` to `b_i` if `prependName` is false). -/
+def proceedFieldsAux (src tgt : Name) (f : Name → CoreM (Array Name))
+  (prependName := true) : CoreM Unit := do
   let srcFields ← f src
   let tgtFields ← f tgt
   if srcFields.size != tgtFields.size then
-    throwError "Failed to map fields of {src}, {tgt} with {srcFields} ↦ {tgtFields}"
+    throwError "Failed to map fields of {src}, {tgt} with {srcFields} ↦ {tgtFields}.\n \
+      Lengths do not match."
   for (srcField, tgtField) in srcFields.zip tgtFields do
+    let srcName := if prependName then src ++ srcField else srcField
+    let tgtName := if prependName then tgt ++ tgtField else tgtField
     if srcField != tgtField then
-      insertTranslation (src ++ srcField) (tgt ++ tgtField)
+      insertTranslation srcName tgtName
     else
-      trace[to_additive] "Translation {src ++ srcField} ↦ {tgt ++ tgtField} is automatic."
+      trace[to_additive] "Translation {srcName} ↦ {tgtName} is automatic."
 
 /-- Add the structure fields of `src` to the translations dictionary
 so that future uses of `to_additive` will map them to the corresponding `tgt` fields. -/
 def proceedFields (src tgt : Name) : CoreM Unit := do
-  let aux := proceedFieldsAux src tgt
+  let aux := @proceedFieldsAux src tgt
+  -- add translations for the structure fields
   aux fun declName ↦ do
     if isStructure (← getEnv) declName then
       return getStructureFields (← getEnv) declName
     else
       return #[]
+  -- add translations for the automatically generated instances with `extend`.
+  aux (prependName := false) fun declName ↦ do
+    if isStructure (← getEnv) declName then
+      return getStructureInfo (← getEnv) declName |>.parentInfo
+        |>.filterMap fun c ↦ if !c.subobject then c.projFn else none
+    else
+      return #[]
+  -- add translations for the constructors of an inductive type
   aux fun declName ↦ do match (← getEnv).find? declName with
     | some (ConstantInfo.inductInfo {ctors := ctors, ..}) =>
         return ctors.toArray.map (.mkSimple ·.lastComponentAsString)


### PR DESCRIPTION
Fixes  #660

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
