### PR TITLE
[Merged by Bors] - feat(Data/Int/Interval): add `Icc_eq_pair`

### DIFF
--- a/Mathlib/Data/Int/Interval.lean
+++ b/Mathlib/Data/Int/Interval.lean
@@ -129,6 +129,18 @@ theorem card_Ioc_of_le (h : a ≤ b) : (#(Ioc a b) : ℤ) = b - a := by
 theorem card_Ioo_of_lt (h : a < b) : (#(Ioo a b) : ℤ) = b - a - 1 := by
   rw [card_Ioo, sub_sub, toNat_sub_of_le h]
 
+theorem Icc_of_eq_sub_1 (h : a = b - 1) : Icc a b = {a, b} := by
+  refine le_antisymm (fun t ht ↦ ?_) (fun t ht ↦ ?_)
+  · rw [h, mem_Icc] at ht
+    by_cases hta : t = b - 1
+    · rw [hta, ← h]; exact mem_insert_self ..
+    · suffices b = t from this ▸ mem_insert.2 (Or.inr (mem_singleton.2 rfl))
+      exact le_antisymm (sub_add_cancel b 1 ▸ (ne_eq t (b - 1) ▸ hta).symm.lt_of_le ht.1) ht.2
+  · have hab : a ≤ b := h ▸ sub_le_self b one_pos.le
+    rcases mem_insert.1 ht with rfl | hb
+    · exact mem_Icc.2 ⟨le_refl t, hab⟩
+    · rw [mem_singleton.1 hb]; exact mem_Icc.2 ⟨hab, le_refl b⟩
+
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): removed `simp` attribute because `simpNF` says it can prove it
 theorem card_fintype_Icc : Fintype.card (Set.Icc a b) = (b + 1 - a).toNat := by
   rw [← card_Icc, Fintype.card_ofFinset]

--- a/Mathlib/Data/Int/Interval.lean
+++ b/Mathlib/Data/Int/Interval.lean
@@ -129,18 +129,10 @@ theorem card_Ioc_of_le (h : a ≤ b) : (#(Ioc a b) : ℤ) = b - a := by
 theorem card_Ioo_of_lt (h : a < b) : (#(Ioo a b) : ℤ) = b - a - 1 := by
   rw [card_Ioo, sub_sub, toNat_sub_of_le h]
 
-theorem Icc_eq_pair (h : a + 1 = b) : Icc a b = {a, b} := by
-  rw [← eq_sub_iff_add_eq] at h
-  refine le_antisymm (fun t ht ↦ ?_) (fun t ht ↦ ?_)
-  · rw [h, mem_Icc] at ht
-    by_cases hta : t = b - 1
-    · rw [hta, ← h]; exact mem_insert_self ..
-    · suffices b = t from this ▸ mem_insert.2 (Or.inr (mem_singleton.2 rfl))
-      exact le_antisymm (sub_add_cancel b 1 ▸ (ne_eq t (b - 1) ▸ hta).symm.lt_of_le ht.1) ht.2
-  · have hab : a ≤ b := h ▸ sub_le_self b one_pos.le
-    rcases mem_insert.1 ht with rfl | hb
-    · exact mem_Icc.2 ⟨le_refl t, hab⟩
-    · rw [mem_singleton.1 hb]; exact mem_Icc.2 ⟨hab, le_refl b⟩
+theorem Icc_eq_pair : Finset.Icc a (a + 1) = {a, a + 1} := by
+  ext
+  simp
+  omega
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): removed `simp` attribute because `simpNF` says it can prove it
 theorem card_fintype_Icc : Fintype.card (Set.Icc a b) = (b + 1 - a).toNat := by

--- a/Mathlib/Data/Int/Interval.lean
+++ b/Mathlib/Data/Int/Interval.lean
@@ -129,7 +129,8 @@ theorem card_Ioc_of_le (h : a ≤ b) : (#(Ioc a b) : ℤ) = b - a := by
 theorem card_Ioo_of_lt (h : a < b) : (#(Ioo a b) : ℤ) = b - a - 1 := by
   rw [card_Ioo, sub_sub, toNat_sub_of_le h]
 
-theorem Icc_of_eq_sub_one (h : a = b - 1) : Icc a b = {a, b} := by
+theorem Icc_eq_pair (h : a + 1 = b) : Icc a b = {a, b} := by
+  rw [← eq_sub_iff_add_eq] at h
   refine le_antisymm (fun t ht ↦ ?_) (fun t ht ↦ ?_)
   · rw [h, mem_Icc] at ht
     by_cases hta : t = b - 1

--- a/Mathlib/Data/Int/Interval.lean
+++ b/Mathlib/Data/Int/Interval.lean
@@ -129,7 +129,7 @@ theorem card_Ioc_of_le (h : a ≤ b) : (#(Ioc a b) : ℤ) = b - a := by
 theorem card_Ioo_of_lt (h : a < b) : (#(Ioo a b) : ℤ) = b - a - 1 := by
   rw [card_Ioo, sub_sub, toNat_sub_of_le h]
 
-theorem Icc_of_eq_sub_1 (h : a = b - 1) : Icc a b = {a, b} := by
+theorem Icc_of_eq_sub_one (h : a = b - 1) : Icc a b = {a, b} := by
   refine le_antisymm (fun t ht ↦ ?_) (fun t ht ↦ ?_)
   · rw [h, mem_Icc] at ht
     by_cases hta : t = b - 1


### PR DESCRIPTION
Upstreamed from the [Carleson](https://github.com/fpvandoorn/carleson) project. 

Co-authored-by: James Sundstrom

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
