### PR TITLE
[Merged by Bors] - chore(discover-lean-pr-testing): determine old and new lean-toolchain more accurately

### DIFF
--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -29,14 +29,14 @@ jobs:
       run: |
         # `lean-toolchain` contains a string of the form "leanprover/lean4:nightly-2024-11-20"
         # We grab the part after the ":"
-        NEW=$(cat lean-toolchain | cut -f2 -d:)
+        NEW=$(cut -f2 -d: lean-toolchain)
 
         # Find the commit hash of the previous change to `lean-toolchain`
         PREV_COMMIT=$(git log -2 --format=format:%H -- lean-toolchain | tail -1)
 
         # Get the contents of `lean-toolchain` from the previous commit
         # The "./" in front of the path is important for `git show`
-        OLD=$(git show $PREV_COMMIT:./lean-toolchain | cut -f2 -d:)
+        OLD=$(git show "$PREV_COMMIT":./lean-toolchain | cut -f2 -d:)
 
         echo "new=$NEW" >> "$GITHUB_OUTPUT"
         echo "old=$OLD" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -24,22 +24,22 @@ jobs:
         git config --global user.name "github-actions"
         git config --global user.email "github-actions@github.com"
 
-      - name: Determine old and new lean-toolchain
-        id: determine-toolchains
-        run: |
-          # `lean-toolchain` contains a string of the form "leanprover/lean4:nightly-2024-11-20"
-          # We grab the part after the ":"
-          NEW=$(cat lean-toolchain | cut -f2 -d:)
+    - name: Determine old and new lean-toolchain
+      id: determine-toolchains
+      run: |
+        # `lean-toolchain` contains a string of the form "leanprover/lean4:nightly-2024-11-20"
+        # We grab the part after the ":"
+        NEW=$(cat lean-toolchain | cut -f2 -d:)
 
-          # Find the commit hash of the previous change to `lean-toolchain`
-          PREV_COMMIT=$(git log -2 --format=format:%H -- lean-toolchain | tail -1)
+        # Find the commit hash of the previous change to `lean-toolchain`
+        PREV_COMMIT=$(git log -2 --format=format:%H -- lean-toolchain | tail -1)
 
-          # Get the contents of `lean-toolchain` from the previous commit
-          # The "./" in front of the path is important for `git show`
-          OLD=$(git show $PREV_COMMIT:./lean-toolchain | cut -f2 -d:)
+        # Get the contents of `lean-toolchain` from the previous commit
+        # The "./" in front of the path is important for `git show`
+        OLD=$(git show $PREV_COMMIT:./lean-toolchain | cut -f2 -d:)
 
-          echo "new=$NEW" >> "$GITHUB_OUTPUT"
-          echo "old=$OLD" >> "$GITHUB_OUTPUT"
+        echo "new=$NEW" >> "$GITHUB_OUTPUT"
+        echo "old=$OLD" >> "$GITHUB_OUTPUT"
 
     - name: Clone lean4 repository and get PRs
       id: get-prs

--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -24,6 +24,23 @@ jobs:
         git config --global user.name "github-actions"
         git config --global user.email "github-actions@github.com"
 
+      - name: Determine old and new lean-toolchain
+        id: determine-toolchains
+        run: |
+          # `lean-toolchain` contains a string of the form "leanprover/lean4:nightly-2024-11-20"
+          # We grab the part after the ":"
+          NEW=$(cat lean-toolchain | cut -f2 -d:)
+
+          # Find the commit hash of the previous change to `lean-toolchain`
+          PREV_COMMIT=$(git log -2 --format=format:%H -- lean-toolchain | tail -1)
+
+          # Get the contents of `lean-toolchain` from the previous commit
+          # The "./" in front of the path is important for `git show`
+          OLD=$(git show $PREV_COMMIT:./lean-toolchain | cut -f2 -d:)
+
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+          echo "old=$OLD" >> "$GITHUB_OUTPUT"
+
     - name: Clone lean4 repository and get PRs
       id: get-prs
       run: |
@@ -38,14 +55,15 @@ jobs:
         # Navigate to the cloned repository
         cd lean4-nightly || exit 1
 
-        # Shallow fetch of the last two tags
-        LAST_TWO_TAGS=$(git ls-remote --tags | grep nightly | tail -2 | cut -f2)
-        OLD=$(echo "$LAST_TWO_TAGS" | head -1)
-        NEW=$(echo "$LAST_TWO_TAGS" | tail -1)
+        # Use the OLD and NEW toolchains determined in the previous step
+        OLD="${{ steps.determine-toolchains.outputs.old }}"
+        NEW="${{ steps.determine-toolchains.outputs.new }}"
+
+        # Fetch the $OLD tag
         git fetch --depth=1 origin tag "$OLD" --no-tags
-        # Fetch the latest 100 commits prior to the $NEW tag.
-        # This should cover the terrain between $OLD and $NEW while still being a speedy download.
-        git fetch --depth=100 origin tag "$NEW" --no-tags
+        # Fetch the $NEW tag.
+        # This will only fetch commits newer than previously fetched commits (ie $OLD)
+        git fetch origin tag "$NEW" --no-tags
 
         PRS=$(git log --oneline "$OLD..$NEW" | sed 's/.*(#\([0-9]\+\))$/\1/')
         


### PR DESCRIPTION
Also, improve the way we fetch the history between the old and new nightlies.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
