### PR TITLE
[Merged by Bors] - style(Computability/ContextFreeGrammar/reverse): injective and surjec…

### DIFF
--- a/Mathlib/Computability/ContextFreeGrammar.lean
+++ b/Mathlib/Computability/ContextFreeGrammar.lean
@@ -223,10 +223,10 @@ lemma reverse_bijective : Bijective (reverse : ContextFreeRule T N → ContextFr
   reverse_involutive.bijective
 
 lemma reverse_injective : Injective (reverse : ContextFreeRule T N → ContextFreeRule T N) :=
-  reverse_involutive.injective
+  reverse_bijective.injective
 
 lemma reverse_surjective : Surjective (reverse : ContextFreeRule T N → ContextFreeRule T N) :=
-  reverse_involutive.surjective
+  reverse_bijective.surjective
 
 protected lemma Rewrites.reverse : ∀ {u v}, r.Rewrites u v → r.reverse.Rewrites u.reverse v.reverse
   | _, _, head s => by simpa using .append_left .input_output _
@@ -257,10 +257,10 @@ lemma reverse_bijective : Bijective (reverse : ContextFreeGrammar T → ContextF
   reverse_involutive.bijective
 
 lemma reverse_injective : Injective (reverse : ContextFreeGrammar T → ContextFreeGrammar T) :=
-  reverse_involutive.injective
+  reverse_bijective.injective
 
 lemma reverse_surjective : Surjective (reverse : ContextFreeGrammar T → ContextFreeGrammar T) :=
-  reverse_involutive.surjective
+  reverse_bijective.surjective
 
 lemma produces_reverse : g.reverse.Produces u.reverse v.reverse ↔ g.Produces u v :=
   (Equiv.ofBijective _ ContextFreeRule.reverse_bijective).exists_congr


### PR DESCRIPTION
…tive from bijective


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
