### PR TITLE
perf(CI): automatically benchmark PRs when they are opened

### DIFF
--- a/.github/workflows/first_bench_is_free.yml
+++ b/.github/workflows/first_bench_is_free.yml
@@ -2,19 +2,24 @@ name: Auto-bench
 
 on:
   pull_request:
-    types: [opened]  # This triggers the action when the PR is opened.
+    #types: [opened]  # This triggers the action when the PR is opened.
 
 jobs:
   automatic_first_bench:
     runs-on: ubuntu-latest
 
     steps:
+
+      - name: Produce bench message
+        id: bench_message
+        run: |
+          message=$'!bench\n\nThis is an automated bench-marking that runs when a PR is opened. No need to repeat.\n'
+          printf '%s' "${message}" | hexdump -cC
+          printf 'message<<EOF\n%s\nEOF' "${message}" >> "${GITHUB_OUTPUT}"
+
       - name: Add comment to PR
         uses: GrantBirki/comment@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            !bench
-
-            This is an automated bench-marking that runs when a PR is opened. No need to repeat.
+          body: ${{ steps.bench_message.outputs.message }}

--- a/.github/workflows/first_bench_is_free.yml
+++ b/.github/workflows/first_bench_is_free.yml
@@ -1,0 +1,20 @@
+name: Auto-bench
+
+on:
+  pull_request:
+    types: [opened]  # This triggers the action when the PR is opened.
+
+jobs:
+  automatic_first_bench:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add comment to PR
+        uses: GrantBirki/comment@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            !bench
+
+            This is an automated bench-marking that runs when a PR is opened. No need to repeat.


### PR DESCRIPTION
This action posts the comment

```
!bench

This is an automated bench-marking that runs when a PR is opened. No need to repeat.
```

whenever a PR is *opened*. It then ignores any subsequent changes to the PR.

The automatic benching should help in catching PRs that unknowingly introduce a high performance cost, as was the case for my PR #18033.

### Note.

Running `!bench` strains the benchmarking system and it is not feasible to run it on every push.  However, Sebastian, in private communication with Johan, approved of automatically benching every PR once, when it is opened.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
