### PR TITLE
[Merged by Bors] - feat: `Matrix.abs_det_submatrix_equiv_equiv`

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Abs.lean
+++ b/Mathlib/Algebra/Order/Ring/Abs.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Algebra.Ring.Divisibility.Basic
+import Mathlib.Algebra.Ring.Int.Units
 import Mathlib.Data.Nat.Cast.Order.Ring
 
 /-!
@@ -150,6 +151,9 @@ theorem abs_sub_sq (a b : α) : |a - b| * |a - b| = a * a + b * b - (1 + 1) * a 
   rw [abs_mul_abs_self]
   simp only [mul_add, add_comm, add_left_comm, mul_comm, sub_eq_add_neg, mul_one, mul_neg,
     neg_add_rev, neg_neg, add_assoc]
+
+lemma abs_unit_coe (a : ℤˣ) : |((a : ℤ) : α)| = 1 := by
+  cases Int.units_eq_one_or a <;> simp_all
 
 end LinearOrderedCommRing
 

--- a/Mathlib/Algebra/Order/Ring/Abs.lean
+++ b/Mathlib/Algebra/Order/Ring/Abs.lean
@@ -152,7 +152,7 @@ theorem abs_sub_sq (a b : α) : |a - b| * |a - b| = a * a + b * b - (1 + 1) * a 
   simp only [mul_add, add_comm, add_left_comm, mul_comm, sub_eq_add_neg, mul_one, mul_neg,
     neg_add_rev, neg_neg, add_assoc]
 
-lemma abs_unit_coe (a : ℤˣ) : |((a : ℤ) : α)| = 1 := by
+lemma abs_unit_intCast (a : ℤˣ) : |((a : ℤ) : α)| = 1 := by
   cases Int.units_eq_one_or a <;> simp_all
 
 end LinearOrderedCommRing

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -231,7 +231,7 @@ theorem abs_det_submatrix_equiv_equiv {R : Type*} [LinearOrderedCommRing R]
   have hee : e₂ = e₁.trans (e₁.symm.trans e₂) := by ext; simp
   rw [hee]
   show |((A.submatrix id (e₁.symm.trans e₂)).submatrix e₁ e₁).det| = |A.det|
-  rw [Matrix.det_submatrix_equiv_self, Matrix.det_permute', abs_mul, abs_unit_coe, one_mul]
+  rw [Matrix.det_submatrix_equiv_self, Matrix.det_permute', abs_mul, abs_unit_intCast, one_mul]
 
 /-- Reindexing both indices along the same equivalence preserves the determinant.
 

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -222,6 +222,18 @@ theorem det_submatrix_equiv_self (e : n ≃ m) (A : Matrix m m R) :
   intro i
   rw [Equiv.permCongr_apply, Equiv.symm_apply_apply, submatrix_apply]
 
+/-- Permuting rows and columns with two equivalences does not change the absolute value of the
+determinant. -/
+@[simp]
+theorem abs_det_submatrix_equiv_equiv {R : Type*} [LinearOrderedCommRing R]
+    (e₁ e₂ : n ≃ m) (A : Matrix m m R) :
+    |(A.submatrix e₁ e₂).det| = |A.det| := by
+  have hee : e₂ = e₁.trans (e₁.symm.trans e₂) := by ext; simp
+  rw [hee]
+  show |((A.submatrix id (e₁.symm.trans e₂)).submatrix e₁ e₁).det| = |A.det|
+  rw [Matrix.det_submatrix_equiv_self, Matrix.det_permute']
+  cases' Int.units_eq_one_or (sign (e₁.symm.trans e₂)) with he he <;> rw [he] <;> simp
+
 /-- Reindexing both indices along the same equivalence preserves the determinant.
 
 For the `simp` version of this lemma, see `det_submatrix_equiv_self`; this one is unsuitable because

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -222,6 +222,9 @@ theorem det_submatrix_equiv_self (e : n ≃ m) (A : Matrix m m R) :
   intro i
   rw [Equiv.permCongr_apply, Equiv.symm_apply_apply, submatrix_apply]
 
+lemma abs_unit_coe {R : Type*} [LinearOrderedRing R] (a : ℤˣ) : |((a : ℤ) : R)| = 1 := by
+  cases Int.units_eq_one_or a <;> simp_all
+
 /-- Permuting rows and columns with two equivalences does not change the absolute value of the
 determinant. -/
 @[simp]
@@ -231,8 +234,7 @@ theorem abs_det_submatrix_equiv_equiv {R : Type*} [LinearOrderedCommRing R]
   have hee : e₂ = e₁.trans (e₁.symm.trans e₂) := by ext; simp
   rw [hee]
   show |((A.submatrix id (e₁.symm.trans e₂)).submatrix e₁ e₁).det| = |A.det|
-  rw [Matrix.det_submatrix_equiv_self, Matrix.det_permute']
-  cases' Int.units_eq_one_or (sign (e₁.symm.trans e₂)) with he he <;> rw [he] <;> simp
+  rw [Matrix.det_submatrix_equiv_self, Matrix.det_permute', abs_mul, abs_unit_coe, one_mul]
 
 /-- Reindexing both indices along the same equivalence preserves the determinant.
 

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -222,9 +222,6 @@ theorem det_submatrix_equiv_self (e : n ≃ m) (A : Matrix m m R) :
   intro i
   rw [Equiv.permCongr_apply, Equiv.symm_apply_apply, submatrix_apply]
 
-lemma abs_unit_coe {R : Type*} [LinearOrderedRing R] (a : ℤˣ) : |((a : ℤ) : R)| = 1 := by
-  cases Int.units_eq_one_or a <;> simp_all
-
 /-- Permuting rows and columns with two equivalences does not change the absolute value of the
 determinant. -/
 @[simp]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
