### PR TITLE
[Merged by Bors] - docs: `Matrix.IsTotallyUnimodular` docstring

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
@@ -28,7 +28,8 @@ namespace Matrix
 
 variable {m n R : Type*} [CommRing R]
 
-/-- Is the matrix `A` totally unimodular? -/
+/-- `A.IsTotallyUnimodular` means that every square submatrix of `A` (not necessarily contiguous)
+has determinant `0` or `1` or `-1`. -/
 def IsTotallyUnimodular (A : Matrix m n R) : Prop :=
   ∀ k : ℕ, ∀ f : Fin k → m, ∀ g : Fin k → n, f.Injective → g.Injective →
     (A.submatrix f g).det = 0 ∨


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
