### PR TITLE
[Merged by Bors] - chore: split out Algebra.GroupWithZero.Nat

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -365,6 +365,7 @@ import Mathlib.Algebra.GroupWithZero.Hom
 import Mathlib.Algebra.GroupWithZero.Indicator
 import Mathlib.Algebra.GroupWithZero.InjSurj
 import Mathlib.Algebra.GroupWithZero.Invertible
+import Mathlib.Algebra.GroupWithZero.Nat
 import Mathlib.Algebra.GroupWithZero.NeZero
 import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 import Mathlib.Algebra.GroupWithZero.Opposite

--- a/Mathlib/Algebra/EuclideanDomain/Int.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Int.lean
@@ -6,7 +6,6 @@ Authors: Louis Carlin, Mario Carneiro
 import Mathlib.Algebra.EuclideanDomain.Defs
 import Mathlib.Algebra.Order.Group.Unbundled.Int
 import Mathlib.Algebra.Ring.Int.Defs
-import Mathlib.Algebra.Ring.Nat
 
 /-!
 # Instances for Euclidean domains

--- a/Mathlib/Algebra/Group/Nat/Basic.lean
+++ b/Mathlib/Algebra/Group/Nat/Basic.lean
@@ -20,6 +20,10 @@ namespace Nat
 
 /-! ### Instances -/
 
+instance instMulOneClass : MulOneClass ℕ where
+  one_mul := Nat.one_mul
+  mul_one := Nat.mul_one
+
 instance instAddCancelCommMonoid : AddCancelCommMonoid ℕ where
   add := Nat.add
   add_assoc := Nat.add_assoc

--- a/Mathlib/Algebra/GroupWithZero/Nat.lean
+++ b/Mathlib/Algebra/GroupWithZero/Nat.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2014 Floris van Doorn (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
+-/
+import Mathlib.Algebra.Group.Nat.Basic
+import Mathlib.Algebra.GroupWithZero.Defs
+import Mathlib.Tactic.Spread
+
+/-!
+# The natural numbers form a `CancelCommMonoidWithZero`
+
+This file contains the `CancelCommMonoidWithZero` instance on the natural numbers.
+
+See note [foundational algebra order theory].
+-/
+
+assert_not_exists Ring
+
+namespace Nat
+
+instance instMulZeroClass : MulZeroClass ℕ where
+  zero_mul := Nat.zero_mul
+  mul_zero := Nat.mul_zero
+
+instance instSemigroupWithZero : SemigroupWithZero ℕ where
+  __ := instSemigroup
+  __ := instMulZeroClass
+
+instance instMonoidWithZero : MonoidWithZero ℕ where
+  __ := instMonoid
+  __ := instMulZeroClass
+  __ := instSemigroupWithZero
+
+instance instCommMonoidWithZero : CommMonoidWithZero ℕ where
+  __ := instCommMonoid
+  __ := instMonoidWithZero
+
+instance instIsLeftCancelMulZero : IsLeftCancelMulZero ℕ where
+  mul_left_cancel_of_ne_zero h := Nat.eq_of_mul_eq_mul_left (Nat.pos_of_ne_zero h)
+
+instance instCancelCommMonoidWithZero : CancelCommMonoidWithZero ℕ where
+  __ := instCommMonoidWithZero
+  __ := instIsLeftCancelMulZero
+
+instance instMulDivCancelClass : MulDivCancelClass ℕ where
+  mul_div_cancel _ _b hb := Nat.mul_div_cancel _ (Nat.pos_iff_ne_zero.2 hb)
+
+instance instMulZeroOneClass : MulZeroOneClass ℕ where
+  __ := instMulZeroClass
+  __ := instMulOneClass
+
+end Nat

--- a/Mathlib/Algebra/Ring/Nat.lean
+++ b/Mathlib/Algebra/Ring/Nat.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Algebra.CharZero.Defs
-import Mathlib.Algebra.Group.Nat.Basic
+import Mathlib.Algebra.GroupWithZero.Nat
 import Mathlib.Algebra.Ring.Defs
 
 /-!
@@ -17,38 +17,42 @@ See note [foundational algebra order theory].
 
 namespace Nat
 
-/-! ### Instances -/
-
-instance instCommSemiring : CommSemiring ℕ where
-  __ := instCommMonoid
-  left_distrib := Nat.left_distrib
-  right_distrib := Nat.right_distrib
-  zero_mul := Nat.zero_mul
-  mul_zero := Nat.mul_zero
-  npow m n := n ^ m
-  npow_zero := Nat.pow_zero
-  npow_succ _ _ := rfl
+instance instAddMonoidWithOne : AddMonoidWithOne ℕ where
   natCast n := n
   natCast_zero := rfl
   natCast_succ _ := rfl
 
-instance instCancelCommMonoidWithZero : CancelCommMonoidWithZero ℕ where
-  __ : CommMonoidWithZero ℕ := by infer_instance
-  mul_left_cancel_of_ne_zero h := Nat.eq_of_mul_eq_mul_left (Nat.pos_of_ne_zero h)
+instance instAddCommMonoidWithOne : AddCommMonoidWithOne ℕ where
+  __ := instAddMonoidWithOne
+  __ := instAddCommMonoid
 
-instance instMulDivCancelClass : MulDivCancelClass ℕ where
-  mul_div_cancel _ _b hb := Nat.mul_div_cancel _ (Nat.pos_iff_ne_zero.2 hb)
+instance instDistrib : Distrib ℕ where
+  left_distrib := Nat.left_distrib
+  right_distrib := Nat.right_distrib
+
+instance instNonUnitalNonAssocSemiring : NonUnitalNonAssocSemiring ℕ where
+  __ := instAddCommMonoid
+  __ := instDistrib
+  __ := instMulZeroClass
+
+instance instNonUnitalSemiring : NonUnitalSemiring ℕ where
+  __ := instNonUnitalNonAssocSemiring
+  __ := instSemigroupWithZero
+
+instance instNonAssocSemiring : NonAssocSemiring ℕ where
+  __ := instNonUnitalNonAssocSemiring
+  __ := instMulZeroOneClass
+  __ := instAddCommMonoidWithOne
+
+instance instSemiring : Semiring ℕ where
+  __ := instNonUnitalSemiring
+  __ := instNonAssocSemiring
+  __ := instMonoidWithZero
+
+instance instCommSemiring : CommSemiring ℕ where
+  __ := instSemiring
+  __ := instCommMonoid
 
 instance instCharZero : CharZero ℕ where cast_injective := Function.injective_id
-
-/-!
-### Extra instances to short-circuit type class resolution
-
-These also prevent non-computable instances being used to construct these instances non-computably.
--/
-
-instance instAddCommMonoidWithOne : AddCommMonoidWithOne ℕ := by infer_instance
-instance instDistrib              : Distrib ℕ              := by infer_instance
-instance instSemiring             : Semiring ℕ             := by infer_instance
 
 end Nat

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -6,7 +6,7 @@ Authors: Jeremy Avigad, Leonardo de Moura
 import Batteries.Data.Nat.Gcd
 import Mathlib.Algebra.Group.Nat.Units
 import Mathlib.Algebra.GroupWithZero.Divisibility
-import Mathlib.Algebra.Ring.Nat
+import Mathlib.Algebra.GroupWithZero.Nat
 
 /-!
 # Properties of `Nat.gcd`, `Nat.lcm`, and `Nat.Coprime`
@@ -300,7 +300,7 @@ theorem Coprime.mul_add_mul_ne_mul {m n a b : ℕ} (cop : Coprime m n) (ha : a �
         ((congr_arg _ h).mpr (Nat.dvd_mul_right m n)))
   rw [mul_comm, mul_ne_zero_iff, ← one_le_iff_ne_zero] at ha hb
   refine mul_ne_zero hb.2 ha.2 (eq_zero_of_mul_eq_self_left (ne_of_gt (add_le_add ha.1 hb.1)) ?_)
-  rw [← mul_assoc, ← h, add_mul, add_mul, mul_comm _ n, ← mul_assoc, mul_comm y]
+  rw [← mul_assoc, ← h, Nat.add_mul, Nat.add_mul, mul_comm _ n, ← mul_assoc, mul_comm y]
 
 variable {x n m : ℕ}
 

--- a/Mathlib/Data/Nat/ModEq.lean
+++ b/Mathlib/Data/Nat/ModEq.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Algebra.Order.Group.Unbundled.Int
+import Mathlib.Algebra.Ring.Nat
 import Mathlib.Data.Int.GCD
 
 /-!

--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -5,8 +5,8 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Batteries.Data.Nat.Gcd
 import Mathlib.Algebra.Group.Nat.Units
+import Mathlib.Algebra.GroupWithZero.Nat
 import Mathlib.Algebra.Prime.Defs
-import Mathlib.Algebra.Ring.Nat
 import Mathlib.Data.Nat.Sqrt
 import Mathlib.Order.Basic
 
@@ -26,9 +26,9 @@ This file deals with prime numbers: natural numbers `p ≥ 2` whose only divisor
 
 -/
 
-open Bool Subtype
+assert_not_exists Ring
 
-open Nat
+open Bool Subtype Nat
 
 namespace Nat
 variable {n : ℕ}
@@ -234,7 +234,7 @@ theorem minFacAux_has_prop {n : ℕ} (n2 : 2 ≤ n) :
     · exact ⟨k2, dk, a⟩
     · refine
         have := minFac_lemma n k h
-        minFacAux_has_prop n2 (k + 2) (i + 1) (by simp [k, e, left_distrib, add_right_comm])
+        minFacAux_has_prop n2 (k + 2) (i + 1) (by simp [k, e, Nat.left_distrib, add_right_comm])
           fun m m2 d => ?_
       rcases Nat.eq_or_lt_of_le (a m m2 d) with me | ml
       · subst me

--- a/MathlibTest/linear_combination.lean
+++ b/MathlibTest/linear_combination.lean
@@ -521,7 +521,7 @@ typeclass inference is demanded by the lemmas it orchestrates.  This example too
 (and 73 ms on a good laptop) on an implementation with "minimal" typeclasses everywhere, e.g. lots of
 `CovariantClass`/`ContravariantClass`, and takes 206 heartbeats (10 ms on a good laptop) on the
 implementation at the time of joining Mathlib (November 2024). -/
-set_option maxHeartbeats 1100 in
+set_option maxHeartbeats 1200 in
 example {a b : ℝ} (h : a < b) : 0 < b - a := by
   linear_combination (norm := skip) h
   exact test_sorry

--- a/MathlibTest/rewrites.lean
+++ b/MathlibTest/rewrites.lean
@@ -1,3 +1,4 @@
+import Mathlib.Algebra.Ring.Nat
 import Mathlib.Data.Nat.Prime.Defs
 import Mathlib.CategoryTheory.Category.Basic
 import Mathlib.Data.List.InsertIdx


### PR DESCRIPTION
This means `Data.Nat.Prime.Defs` no longer depends on rings.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I'd hoped for somewhat of a bigger win here, but perhaps this is still worth taking.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
