### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology/SimplicialSet): Add auxiliary ext lemma for paths

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
@@ -80,8 +80,9 @@ lemma Path.ext' {n : ℕ} {f g : Path X (n + 1)}
     f = g := by
   ext j
   · rcases Fin.eq_castSucc_or_eq_last j with ⟨k, hk⟩ | hl
-    · erw [hk, ← f.arrow_src k, ← g.arrow_src k, h]
-    · erw [hl, ← f.arrow_tgt (Fin.last n), ← g.arrow_tgt (Fin.last n), h]
+    · rw [hk, ← f.arrow_src k, ← g.arrow_src k, h]
+    · simp only [hl, ← Fin.succ_last]
+      rw [← f.arrow_tgt (Fin.last n), ← g.arrow_tgt (Fin.last n), h]
   · exact h j
 
 end SSet

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
@@ -73,16 +73,16 @@ lemma spine_map_subinterval {n : ℕ} (j l : ℕ) (hjl : j + l ≤ n) (Δ : X _[
   · simp only [spine_arrow, Path.interval, ← FunctorToTypes.map_comp_apply, ← op_comp,
       mkOfSucc_subinterval_eq]
 
-/-- Two paths of the same length can be identified if all of their arrows can
-be identified. -/
+/-- Two paths of the same nonzero length can be identified if all of their
+arrows can be identified. -/
 @[ext]
 lemma Path.ext₁ {n : ℕ} {f g : Path X (n + 1)}
-    (h : ∀ (m : Fin (n + 1)), f.arrow m = g.arrow m) :
+    (h : ∀ i : Fin (n + 1), f.arrow i = g.arrow i) :
     f = g := by
-  ext i
-  · rcases Fin.eq_castSucc_or_eq_last i with ⟨j, hj⟩ | hl
-    · erw [hj, ← f.arrow_src j, ← g.arrow_src j, h]
+  ext j
+  · rcases Fin.eq_castSucc_or_eq_last j with ⟨k, hk⟩ | hl
+    · erw [hk, ← f.arrow_src k, ← g.arrow_src k, h]
     · erw [hl, ← f.arrow_tgt (Fin.last n), ← g.arrow_tgt (Fin.last n), h]
-  · exact h i
+  · exact h j
 
 end SSet

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
@@ -73,4 +73,16 @@ lemma spine_map_subinterval {n : ℕ} (j l : ℕ) (hjl : j + l ≤ n) (Δ : X _[
   · simp only [spine_arrow, Path.interval, ← FunctorToTypes.map_comp_apply, ← op_comp,
       mkOfSucc_subinterval_eq]
 
+/-- Two paths of the same length can be identified if all of their arrows can
+be identified. -/
+@[ext]
+lemma Path.ext₁ {n : ℕ} {f g : Path X (n + 1)}
+    (h : ∀ (m : Fin (n + 1)), f.arrow m = g.arrow m) :
+    f = g := by
+  ext i
+  · rcases Fin.eq_castSucc_or_eq_last i with ⟨j, hj⟩ | hl
+    · erw [hj, ← f.arrow_src j, ← g.arrow_src j, h]
+    · erw [hl, ← f.arrow_tgt (Fin.last n), ← g.arrow_tgt (Fin.last n), h]
+  · exact h i
+
 end SSet

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
@@ -73,10 +73,9 @@ lemma spine_map_subinterval {n : ℕ} (j l : ℕ) (hjl : j + l ≤ n) (Δ : X _[
   · simp only [spine_arrow, Path.interval, ← FunctorToTypes.map_comp_apply, ← op_comp,
       mkOfSucc_subinterval_eq]
 
-/-- Two paths of the same nonzero length can be identified if all of their
-arrows can be identified. -/
+/-- Two paths of the same nonzero length are equal if all of their arrows are equal. -/
 @[ext]
-lemma Path.ext₁ {n : ℕ} {f g : Path X (n + 1)}
+lemma Path.ext' {n : ℕ} {f g : Path X (n + 1)}
     (h : ∀ i : Fin (n + 1), f.arrow i = g.arrow i) :
     f = g := by
   ext j


### PR DESCRIPTION
We implement the generalization of the path extensionality lemmas suggested by @joelriou in #19057. Two paths of the same nonzero length can be identified by constructing an identification between each of their arrows.

Co-Authored-By: [Joël Riou](https://github.com/joelriou)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
