### PR TITLE
chore: change some `nlinarith`s to `linear_combination`s

### DIFF
--- a/Archive/Imo/Imo2021Q1.lean
+++ b/Archive/Imo/Imo2021Q1.lean
@@ -6,6 +6,7 @@ Authors: Mantas Bakšys
 import Mathlib.Order.Interval.Finset.Nat
 import Mathlib.Tactic.IntervalCases
 import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
 
 /-!
 # IMO 2021 Q1
@@ -56,8 +57,7 @@ lemma exists_numbers_in_interval {n : ℕ} (hn : 100 ≤ n) :
   rw [← Nat.sub_add_cancel hn'] at h₁ h₂ h₃
   set l := (n + 1).sqrt - 1
   refine ⟨l, ?_, ?_⟩
-  · calc n + 4 * l ≤ (l ^ 2 + 4 * l + 2) + 4 * l := by linarith only [h₂]
-      _ ≤ 2 * l ^ 2 := by nlinarith only [h₃]
+  · linear_combination h₂ + (l + 1) * h₃
   · linarith only [h₁]
 
 lemma exists_triplet_summing_to_squares {n : ℕ} (hn : 100 ≤ n) :

--- a/Archive/Wiedijk100Theorems/AreaOfACircle.lean
+++ b/Archive/Wiedijk100Theorems/AreaOfACircle.lean
@@ -114,10 +114,10 @@ theorem area_disc : volume (disc r) = NNReal.pi * r ^ 2 := by
     · suffices -(1 : ℝ) < (r : ℝ)⁻¹ * x by exact this.ne'
       calc
         -(1 : ℝ) = (r : ℝ)⁻¹ * -r := by simp [inv_mul_cancel₀ hlt.ne']
-        _ < (r : ℝ)⁻¹ * x := by nlinarith [inv_pos.mpr hlt]
+        _ < (r : ℝ)⁻¹ * x := by linear_combination (r : ℝ)⁻¹ * hx1
     · suffices (r : ℝ)⁻¹ * x < 1 by exact this.ne
       calc
-        (r : ℝ)⁻¹ * x < (r : ℝ)⁻¹ * r := by nlinarith [inv_pos.mpr hlt]
+        (r : ℝ)⁻¹ * x < (r : ℝ)⁻¹ * r := by linear_combination (r : ℝ)⁻¹ * hx2
         _ = 1 := inv_mul_cancel₀ hlt.ne'
     · nlinarith
   have hcont : ContinuousOn F (Icc (-r) r) := (by continuity : Continuous F).continuousOn

--- a/Mathlib/Analysis/Normed/Group/AddCircle.lean
+++ b/Mathlib/Analysis/Normed/Group/AddCircle.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
 import Mathlib.Analysis.Normed.Group.Quotient
+import Mathlib.Tactic.LinearCombination
 import Mathlib.Topology.Instances.AddCircle
 
 /-!
@@ -208,9 +209,9 @@ theorem coe_real_preimage_closedBall_inter_eq {x ε : ℝ} (s : Set ℝ)
     obtain ⟨hy₃, hy₄⟩ := hs hy₀
     rcases lt_trichotomy 0 p with (hp | (rfl : 0 = p) | hp)
     · cases' Int.cast_le_neg_one_or_one_le_cast_of_ne_zero ℝ hz with hz' hz'
-      · have : ↑z * p ≤ -p := by nlinarith
+      · have : ↑z * p ≤ -p := by linear_combination p * hz'
         linarith [abs_eq_self.mpr hp.le]
-      · have : p ≤ ↑z * p := by nlinarith
+      · have : p ≤ ↑z * p := by linear_combination p * hz'
         linarith [abs_eq_self.mpr hp.le]
     · simp only [mul_zero, add_zero, abs_zero, zero_div] at hy₁ hy₂ hε
       linarith

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -6,6 +6,7 @@ Authors: Patrick Massot, Johannes Hölzl, Yaël Dillies
 import Mathlib.Algebra.CharP.Defs
 import Mathlib.Algebra.Group.Subgroup.Ker
 import Mathlib.Analysis.Normed.Group.Seminorm
+import Mathlib.Tactic.LinearCombination
 import Mathlib.Topology.Metrizable.Uniformity
 import Mathlib.Topology.Sequences
 
@@ -1123,7 +1124,7 @@ theorem pow_mem_ball {n : ℕ} (hn : 0 < n) (h : a ∈ ball b r) : a ^ n ∈ bal
   refine lt_of_le_of_lt (norm_pow_le_mul_norm n (a / b)) ?_
   replace hn : 0 < (n : ℝ) := by norm_cast
   rw [nsmul_eq_mul]
-  nlinarith
+  linear_combination (n:ℝ) * h
 
 @[to_additive]
 theorem mul_mem_closedBall_mul_iff {c : E} : a * c ∈ closedBall (b * c) r ↔ a ∈ closedBall b r := by

--- a/Mathlib/Analysis/Normed/Ring/Units.lean
+++ b/Mathlib/Analysis/Normed/Ring/Units.lean
@@ -48,7 +48,7 @@ def add (x : Rˣ) (t : R) (h : ‖t‖ < ‖(↑x⁻¹ : R)‖⁻¹) : Rˣ :=
       calc
         ‖-(↑x⁻¹ * t)‖ = ‖↑x⁻¹ * t‖ := by rw [norm_neg]
         _ ≤ ‖(↑x⁻¹ : R)‖ * ‖t‖ := norm_mul_le (x⁻¹).1 _
-        _ < ‖(↑x⁻¹ : R)‖ * ‖(↑x⁻¹ : R)‖⁻¹ := by nlinarith only [h, hpos]
+        _ < ‖(↑x⁻¹ : R)‖ * ‖(↑x⁻¹ : R)‖⁻¹ := by linear_combination ‖(↑x⁻¹ : R)‖ * h
         _ = 1 := mul_inv_cancel₀ (ne_of_gt hpos)))
     (x + t) (by simp [mul_add]) _ rfl
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -112,8 +112,7 @@ lemma norm_one_add_mul_inv_le {t : ℝ} (ht : t ∈ Set.Icc 0 1) {z : ℂ} (hz :
   rw [norm_inv, norm_eq_abs]
   refine inv_anti₀ (by linarith) ?_
   calc 1 - ‖z‖
-    _ ≤ 1 - t * ‖z‖ := by
-      nlinarith [norm_nonneg z]
+    _ ≤ 1 - t * ‖z‖ := by linear_combination ‖z‖ * ht.2
     _ = 1 - ‖t * z‖ := by
       rw [norm_mul, norm_eq_abs (t : ℂ), abs_of_nonneg ht.1]
     _ ≤ ‖1 + t * z‖ := by

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
@@ -170,7 +170,7 @@ theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ #P.parts)
           norm_cast
           rw [tsub_mul]
           refine le_tsub_of_add_le_left ?_
-          nlinarith
+          linear_combination #P.parts * hP₇
         · norm_num
     _ = (#P.parts.offDiag * ε * (ε ^ 4 / 3) - #P.parts.offDiag * (ε ^ 5 / 25)) := by ring
     _ ≤ (#(nonUniforms P G ε) * (ε ^ 4 / 3) - #P.parts.offDiag * (ε ^ 5 / 25)) := by gcongr

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -352,9 +352,8 @@ theorem normSq_S_smul_lt_one (h : 1 < normSq z) : normSq ↑(S • z) < 1 := by
 /-- If `|z| < 1`, then applying `S` strictly decreases `im`. -/
 theorem im_lt_im_S_smul (h : normSq z < 1) : z.im < (S • z).im := by
   have : z.im < z.im / normSq (z : ℂ) := by
-    have imz : 0 < z.im := im_pos z
     apply (lt_div_iff₀ z.normSq_pos).mpr
-    nlinarith
+    linear_combination z.im * h
   convert this
   simp only [ModularGroup.im_smul_eq_div_normSq]
   simp [denom, coe_S]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
