### PR TITLE
[Merged by Bors] - docs(RingTheory/Finiteness/Defs): specify namespace of `Finite`

### DIFF
--- a/Mathlib/RingTheory/Finiteness/Defs.lean
+++ b/Mathlib/RingTheory/Finiteness/Defs.lean
@@ -100,7 +100,7 @@ section ModuleAndAlgebra
 
 variable (R A B M N : Type*)
 
-/-- A module over a semiring is `Finite` if it is finitely generated as a module. -/
+/-- A module over a semiring is `Module.Finite` if it is finitely generated as a module. -/
 protected class Module.Finite [Semiring R] [AddCommMonoid M] [Module R M] : Prop where
   out : (⊤ : Submodule R M).FG
 
@@ -142,7 +142,7 @@ namespace RingHom
 
 variable {A B C : Type*} [CommRing A] [CommRing B] [CommRing C]
 
-/-- A ring morphism `A →+* B` is `Finite` if `B` is finitely generated as `A`-module. -/
+/-- A ring morphism `A →+* B` is `RingHom.Finite` if `B` is finitely generated as `A`-module. -/
 @[algebraize Module.Finite]
 def Finite (f : A →+* B) : Prop :=
   letI : Algebra A B := f.toAlgebra


### PR DESCRIPTION
Currently, `Module.Finite` and `RingHom.Finite` have docstrings that link to `Finite`, which is confusing.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
