### PR TITLE
[Merged by Bors] - doc(Algebra/Central/Defs): correct doc

### DIFF
--- a/Mathlib/Algebra/Central/Defs.lean
+++ b/Mathlib/Algebra/Central/Defs.lean
@@ -19,7 +19,7 @@ is a (not necessarily commutative) `K`-algebra.
 ## Implementation notes
 
 We require the `K`-center of `D` to be smaller than or equal to the smallest subalgebra so that when
-we prove something is central, there we don't need to prove `⊥ ≤ center K D` even though this
+we prove something is central, we don't need to prove `⊥ ≤ center K D` even though this
 direction is trivial.
 
 ### Central Simple Algebras
@@ -34,11 +34,11 @@ but an instance of `[Algebra.IsCentralSimple K D]` would not imply `[IsSimpleRin
 synthesization orders (`K` cannot be inferred). Thus, to obtain a central simple `K`-algebra `D`,
 one should use `Algebra.IsCentral K D` and `IsSimpleRing D` separately.
 
-Note that the predicate `Albgera.IsCentral K D` and `IsSimpleRing D` makes sense just for `K` a
+Note that the predicate `Algebra.IsCentral K D` and `IsSimpleRing D` makes sense just for `K` a
 `CommRing` but it doesn't give the right definition for central simple algebra; for a commutative
 ring base, one should use the theory of Azumaya algebras. In fact ideals of `K` immediately give
 rise to nontrivial quotients of `D` so there are no central simple algebras in this case according
-to our definition, if K is not a field.
+to our definition, if `K` is not a field.
 The theory of central simple algebras really is a theory over fields.
 
 Thus to declare a central simple algebra, one should use the following:


### PR DESCRIPTION
Correct two typos and a bad syntax in the doc.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
