### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Matrix/Determinant/TotallyUnimodular): iff_fintype

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
@@ -54,7 +54,7 @@ lemma isTotallyUnimodular_iff (A : Matrix m n R) : A.IsTotallyUnimodular ↔
   · intro _ _ _ _ _
     apply hA
 
-lemma Matrix.isTotallyUnimodular_iff_fintype.{w} (A : Matrix m n R) : A.IsTotallyUnimodular ↔
+lemma isTotallyUnimodular_iff_fintype.{w} (A : Matrix m n R) : A.IsTotallyUnimodular ↔
     ∀ (ι : Type w) [Fintype ι] [DecidableEq ι], ∀ f : ι → m, ∀ g : ι → n,
       (A.submatrix f g).det ∈ Set.range SignType.cast := by
   rw [isTotallyUnimodular_iff]

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
@@ -61,8 +61,7 @@ lemma isTotallyUnimodular_iff_fintype.{w} (A : Matrix m n R) : A.IsTotallyUnimod
   constructor
   · intro hA ι _ _ f g
     specialize hA (Fintype.card ι) (f ∘ (Fintype.equivFin ι).symm) (g ∘ (Fintype.equivFin ι).symm)
-    rw [←submatrix_submatrix, det_submatrix_equiv_self] at hA
-    exact hA
+    rwa [←submatrix_submatrix, det_submatrix_equiv_self] at hA
   · intro hA k f g
     specialize hA (ULift (Fin k)) (f ∘ Equiv.ulift) (g ∘ Equiv.ulift)
     rwa [←submatrix_submatrix, det_submatrix_equiv_self] at hA

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
@@ -54,6 +54,19 @@ lemma isTotallyUnimodular_iff (A : Matrix m n R) : A.IsTotallyUnimodular ↔
   · intro _ _ _ _ _
     apply hA
 
+lemma Matrix.isTotallyUnimodular_iff_fintype.{w} (A : Matrix m n R) : A.IsTotallyUnimodular ↔
+    ∀ (ι : Type w) [Fintype ι] [DecidableEq ι], ∀ f : ι → m, ∀ g : ι → n,
+      (A.submatrix f g).det ∈ Set.range SignType.cast := by
+  rw [isTotallyUnimodular_iff]
+  constructor
+  · intro hA ι _ _ f g
+    specialize hA (Fintype.card ι) (f ∘ (Fintype.equivFin ι).symm) (g ∘ (Fintype.equivFin ι).symm)
+    rw [←submatrix_submatrix, det_submatrix_equiv_self] at hA
+    exact hA
+  · intro hA k f g
+    specialize hA (ULift (Fin k)) (f ∘ Equiv.ulift) (g ∘ Equiv.ulift)
+    rwa [←submatrix_submatrix, det_submatrix_equiv_self] at hA
+
 lemma IsTotallyUnimodular.apply {A : Matrix m n R} (hA : A.IsTotallyUnimodular)
     (i : m) (j : n) :
     A i j ∈ Set.range SignType.cast := by


### PR DESCRIPTION
add a lemma relating the definition of `Matrix.IsTotallyUnimodular` to `Fintype` rather than `Fin`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
