### PR TITLE
[Merged by Bors] - feat(NumberTheory/LSeries/PrimesInAP): von Mangoldt restricted to a residue class

### DIFF
--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -85,6 +85,9 @@ variable {q : ℕ} (a : ZMod q)
 noncomputable abbrev residue_class : ℕ → ℝ :=
   {n : ℕ | (n : ZMod q) = a}.indicator (vonMangoldt ·)
 
+lemma residue_class_nonneg : 0 ≤ residue_class a :=
+  fun _ ↦ Set.indicator_apply_nonneg fun _ ↦ vonMangoldt_nonneg
+
 lemma residue_class_apply_zero : residue_class a 0 = 0 := by
   simp only [Set.indicator_apply_eq_zero, Set.mem_setOf_eq, Nat.cast_zero, map_zero, ofReal_zero,
     implies_true]

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -85,8 +85,8 @@ variable {q : ℕ} (a : ZMod q)
 noncomputable abbrev residueClass : ℕ → ℝ :=
   {n : ℕ | (n : ZMod q) = a}.indicator (vonMangoldt ·)
 
-lemma residueClass_nonneg : 0 ≤ residueClass a :=
-  fun _ ↦ Set.indicator_apply_nonneg fun _ ↦ vonMangoldt_nonneg
+lemma residueClass_nonneg (n : ℕ) : 0 ≤ residueClass a n :=
+  Set.indicator_apply_nonneg fun _ ↦ vonMangoldt_nonneg
 
 lemma residueClass_apply_zero : residueClass a 0 = 0 := by
   simp only [Set.indicator_apply_eq_zero, Set.mem_setOf_eq, Nat.cast_zero, map_zero, ofReal_zero,

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -91,6 +91,7 @@ lemma residueClass_nonneg (n : ℕ) : 0 ≤ residueClass a n :=
 lemma residueClass_le (n : ℕ) : residueClass a n ≤ vonMangoldt n :=
   Set.indicator_apply_le' (fun _ ↦ le_rfl) (fun _ ↦ vonMangoldt_nonneg)
 
+@[simp]
 lemma residueClass_apply_zero : residueClass a 0 = 0 := by
   simp only [Set.indicator_apply_eq_zero, Set.mem_setOf_eq, Nat.cast_zero, map_zero, ofReal_zero,
     implies_true]
@@ -129,9 +130,9 @@ lemma residueClass_eq (ha : IsUnit a) :
   simpa only [Pi.smul_apply, Finset.sum_apply, smul_eq_mul, ← mul_assoc]
     using residueClass_apply ha n
 
-/-- The L-series of the von Mangoldt function restricted to the prime residue class `a` mod `q`
-is a linear combination of logarithmic derivatives of L-functions of the Dirichlet characters
-mod `q` (on `re s > 1`). -/
+/-- The L-series of the von Mangoldt function restricted to the residue class `a` mod `q`
+with `a` invertible in `ZMod q` is a linear combination of logarithmic derivatives of
+L-functions of the Dirichlet characters mod `q` (on `re s > 1`). -/
 lemma LSeries_residueClass_eq (ha : IsUnit a) {s : ℂ} (hs : 1 < s.re) :
     LSeries ↗(residueClass a) s =
       -(q.totient : ℂ)⁻¹ * ∑ χ : DirichletCharacter ℂ q, χ a⁻¹ *

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -3,9 +3,10 @@ Copyright (c) 2024 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
-import Mathlib.Data.Nat.Factorization.PrimePow
-import Mathlib.Topology.Algebra.InfiniteSum.Constructions
-import Mathlib.Topology.Algebra.InfiniteSum.NatInt
+import Mathlib.NumberTheory.DirichletCharacter.Orthogonality
+import Mathlib.NumberTheory.LSeries.DirichletContinuation
+import Mathlib.NumberTheory.LSeries.Linearity
+import Mathlib.RingTheory.RootsOfUnity.AlgebraicallyClosed
 
 /-!
 # Dirichlet's Theorem on primes in arithmetic progression
@@ -17,8 +18,8 @@ and `a : ZMod q` is invertible, then there are infinitely many prime numbers `p`
 This will be done in the following steps:
 
 1. Some auxiliary lemmas on infinite products and sums
-2. (TODO) Results on the von Mangoldt function restricted to a residue class
-3. (TODO) Results on its L-series
+2. Results on the von Mangoldt function restricted to a residue class
+3. (TODO) Results on its L-series and an auxiliary function related to it
 4. (TODO) Derivation of Dirichlet's Theorem
 -/
 
@@ -65,3 +66,79 @@ lemma tprod_eq_tprod_primes_mul_tprod_primes_of_mulSupport_subset_prime_powers {
     Function.Injective.prodMap (fun ⦃_ _⦄ a ↦ a) <| add_left_injective 1
 
 end auxiliary
+
+/-!
+### The L-series of the von Mangoldt function restricted to a residue class
+-/
+
+section arith_prog
+
+namespace ArithmeticFunction.vonMangoldt
+
+open Complex LSeries DirichletCharacter
+
+open scoped LSeries.notation
+
+variable {q : ℕ} (a : ZMod q)
+
+/-- The von Mangoldt function restricted to the residue class `a` mod `q`. -/
+noncomputable abbrev residue_class : ℕ → ℝ :=
+  {n : ℕ | (n : ZMod q) = a}.indicator (vonMangoldt ·)
+
+lemma residue_class_apply_zero : residue_class a 0 = 0 := by
+  simp only [Set.indicator_apply_eq_zero, Set.mem_setOf_eq, Nat.cast_zero, map_zero, ofReal_zero,
+    implies_true]
+
+lemma abscissaOfAbsConv_residue_class_le_one :
+    abscissaOfAbsConv ↗(vonMangoldt.residue_class a) ≤ 1 := by
+  refine abscissaOfAbsConv_le_of_forall_lt_LSeriesSummable fun y hy ↦ ?_
+  unfold LSeriesSummable
+  have := LSeriesSummable_vonMangoldt <| show 1 < (y : ℂ).re by simp only [ofReal_re, hy]
+  convert this.indicator {n : ℕ | (n : ZMod q) = a}
+  ext1 n
+  by_cases hn : (n : ZMod q) = a
+  · simp +contextual only [term, Set.indicator, Set.mem_setOf_eq, hn, ↓reduceIte, apply_ite,
+      ite_self]
+  · simp +contextual only [term, Set.mem_setOf_eq, hn, not_false_eq_true, Set.indicator_of_not_mem,
+      ofReal_zero, zero_div, ite_self]
+
+variable [NeZero q] {a}
+
+/-- We can express `ArithmeticFunction.vonMangoldt.residue_class` as a linear combination
+of twists of the von Mangoldt function with Dirichlet charaters. -/
+lemma residue_class_apply (ha : IsUnit a) (n : ℕ) :
+    residue_class a n =
+      (q.totient : ℂ)⁻¹ * ∑ χ : DirichletCharacter ℂ q, χ a⁻¹ * χ n * vonMangoldt n := by
+  rw [eq_inv_mul_iff_mul_eq₀ <| mod_cast (Nat.totient_pos.mpr q.pos_of_neZero).ne']
+  simp +contextual only [residue_class, Set.indicator_apply, Set.mem_setOf_eq, apply_ite,
+    ofReal_zero, mul_zero, ← Finset.sum_mul, sum_char_inv_mul_char_eq ℂ ha n, eq_comm (a := a),
+    ite_mul, zero_mul, ↓reduceIte, ite_self]
+
+/-- We can express `ArithmeticFunction.vonMangoldt.residue_class` as a linear combination
+of twists of the von Mangoldt function with Dirichlet charaters. -/
+lemma residue_class_eq (ha : IsUnit a) :
+    ↗(residue_class a) = (q.totient : ℂ)⁻¹ •
+      ∑ χ : DirichletCharacter ℂ q, χ a⁻¹ • (fun n : ℕ ↦ χ n * vonMangoldt n) := by
+  ext1 n
+  simpa only [Pi.smul_apply, Finset.sum_apply, smul_eq_mul, ← mul_assoc]
+    using residue_class_apply ha n
+
+/-- The L-series of the von Mangoldt function restricted to the prime residue class `a` mod `q`
+is a linear combination of logarithmic derivatives of L-functions of the Dirichlet characters
+mod `q` (on `re s > 1`). -/
+lemma LSeries_residue_class_eq (ha : IsUnit a) {s : ℂ} (hs : 1 < s.re) :
+    LSeries ↗(residue_class a) s =
+      -(q.totient : ℂ)⁻¹ * ∑ χ : DirichletCharacter ℂ q, χ a⁻¹ *
+        (deriv (LFunction χ) s / LFunction χ s) := by
+  simp only [deriv_LFunction_eq_deriv_LSeries _ hs, LFunction_eq_LSeries _ hs, neg_mul, ← mul_neg,
+    ← Finset.sum_neg_distrib, ← neg_div, ← LSeries_twist_vonMangoldt_eq _ hs]
+  rw [eq_inv_mul_iff_mul_eq₀ <| mod_cast (Nat.totient_pos.mpr q.pos_of_neZero).ne']
+  simp_rw [← LSeries_smul,
+    ← LSeries_sum <| fun χ _ ↦ (LSeriesSummable_twist_vonMangoldt χ hs).smul _]
+  refine LSeries_congr s fun {n} _ ↦ ?_
+  simp only [Pi.smul_apply, residue_class_apply ha, smul_eq_mul, ← mul_assoc,
+    mul_inv_cancel_of_invertible, one_mul, Finset.sum_apply, Pi.mul_apply]
+
+end ArithmeticFunction.vonMangoldt
+
+end arith_prog

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -88,6 +88,9 @@ noncomputable abbrev residueClass : ℕ → ℝ :=
 lemma residueClass_nonneg (n : ℕ) : 0 ≤ residueClass a n :=
   Set.indicator_apply_nonneg fun _ ↦ vonMangoldt_nonneg
 
+lemma residueClass_le (n : ℕ) : residueClass a n ≤ vonMangoldt n :=
+  Set.indicator_apply_le' (fun _ ↦ le_rfl) (fun _ ↦ vonMangoldt_nonneg)
+
 lemma residueClass_apply_zero : residueClass a 0 = 0 := by
   simp only [Set.indicator_apply_eq_zero, Set.mem_setOf_eq, Nat.cast_zero, map_zero, ofReal_zero,
     implies_true]

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -82,18 +82,18 @@ open scoped LSeries.notation
 variable {q : ℕ} (a : ZMod q)
 
 /-- The von Mangoldt function restricted to the residue class `a` mod `q`. -/
-noncomputable abbrev residue_class : ℕ → ℝ :=
+noncomputable abbrev residueClass : ℕ → ℝ :=
   {n : ℕ | (n : ZMod q) = a}.indicator (vonMangoldt ·)
 
-lemma residue_class_nonneg : 0 ≤ residue_class a :=
+lemma residueClass_nonneg : 0 ≤ residueClass a :=
   fun _ ↦ Set.indicator_apply_nonneg fun _ ↦ vonMangoldt_nonneg
 
-lemma residue_class_apply_zero : residue_class a 0 = 0 := by
+lemma residueClass_apply_zero : residueClass a 0 = 0 := by
   simp only [Set.indicator_apply_eq_zero, Set.mem_setOf_eq, Nat.cast_zero, map_zero, ofReal_zero,
     implies_true]
 
-lemma abscissaOfAbsConv_residue_class_le_one :
-    abscissaOfAbsConv ↗(vonMangoldt.residue_class a) ≤ 1 := by
+lemma abscissaOfAbsConv_residueClass_le_one :
+    abscissaOfAbsConv ↗(residueClass a) ≤ 1 := by
   refine abscissaOfAbsConv_le_of_forall_lt_LSeriesSummable fun y hy ↦ ?_
   unfold LSeriesSummable
   have := LSeriesSummable_vonMangoldt <| show 1 < (y : ℂ).re by simp only [ofReal_re, hy]
@@ -107,30 +107,30 @@ lemma abscissaOfAbsConv_residue_class_le_one :
 
 variable [NeZero q] {a}
 
-/-- We can express `ArithmeticFunction.vonMangoldt.residue_class` as a linear combination
+/-- We can express `ArithmeticFunction.vonMangoldt.residueClass` as a linear combination
 of twists of the von Mangoldt function with Dirichlet charaters. -/
-lemma residue_class_apply (ha : IsUnit a) (n : ℕ) :
-    residue_class a n =
+lemma residueClass_apply (ha : IsUnit a) (n : ℕ) :
+    residueClass a n =
       (q.totient : ℂ)⁻¹ * ∑ χ : DirichletCharacter ℂ q, χ a⁻¹ * χ n * vonMangoldt n := by
   rw [eq_inv_mul_iff_mul_eq₀ <| mod_cast (Nat.totient_pos.mpr q.pos_of_neZero).ne']
-  simp +contextual only [residue_class, Set.indicator_apply, Set.mem_setOf_eq, apply_ite,
+  simp +contextual only [residueClass, Set.indicator_apply, Set.mem_setOf_eq, apply_ite,
     ofReal_zero, mul_zero, ← Finset.sum_mul, sum_char_inv_mul_char_eq ℂ ha n, eq_comm (a := a),
     ite_mul, zero_mul, ↓reduceIte, ite_self]
 
-/-- We can express `ArithmeticFunction.vonMangoldt.residue_class` as a linear combination
+/-- We can express `ArithmeticFunction.vonMangoldt.residueClass` as a linear combination
 of twists of the von Mangoldt function with Dirichlet charaters. -/
-lemma residue_class_eq (ha : IsUnit a) :
-    ↗(residue_class a) = (q.totient : ℂ)⁻¹ •
+lemma residueClass_eq (ha : IsUnit a) :
+    ↗(residueClass a) = (q.totient : ℂ)⁻¹ •
       ∑ χ : DirichletCharacter ℂ q, χ a⁻¹ • (fun n : ℕ ↦ χ n * vonMangoldt n) := by
   ext1 n
   simpa only [Pi.smul_apply, Finset.sum_apply, smul_eq_mul, ← mul_assoc]
-    using residue_class_apply ha n
+    using residueClass_apply ha n
 
 /-- The L-series of the von Mangoldt function restricted to the prime residue class `a` mod `q`
 is a linear combination of logarithmic derivatives of L-functions of the Dirichlet characters
 mod `q` (on `re s > 1`). -/
-lemma LSeries_residue_class_eq (ha : IsUnit a) {s : ℂ} (hs : 1 < s.re) :
-    LSeries ↗(residue_class a) s =
+lemma LSeries_residueClass_eq (ha : IsUnit a) {s : ℂ} (hs : 1 < s.re) :
+    LSeries ↗(residueClass a) s =
       -(q.totient : ℂ)⁻¹ * ∑ χ : DirichletCharacter ℂ q, χ a⁻¹ *
         (deriv (LFunction χ) s / LFunction χ s) := by
   simp only [deriv_LFunction_eq_deriv_LSeries _ hs, LFunction_eq_LSeries _ hs, neg_mul, ← mul_neg,
@@ -139,7 +139,7 @@ lemma LSeries_residue_class_eq (ha : IsUnit a) {s : ℂ} (hs : 1 < s.re) :
   simp_rw [← LSeries_smul,
     ← LSeries_sum <| fun χ _ ↦ (LSeriesSummable_twist_vonMangoldt χ hs).smul _]
   refine LSeries_congr s fun {n} _ ↦ ?_
-  simp only [Pi.smul_apply, residue_class_apply ha, smul_eq_mul, ← mul_assoc,
+  simp only [Pi.smul_apply, residueClass_apply ha, smul_eq_mul, ← mul_assoc,
     mul_inv_cancel_of_invertible, one_mul, Finset.sum_apply, Pi.mul_apply]
 
 end ArithmeticFunction.vonMangoldt


### PR DESCRIPTION
This is the next step on the way to **Dirichlet's Theorem**. It defines `ArithmeticFunction.vonMangoldt.residueClass` as the function that is the von Mangoldt function on a given residue class and zero outside and proves some facts about it (in particular that it is a linear combination of twists of the von Mangoldt function by Dirichlet characters).

See [here](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/Prerequisites.20for.20PNT.20and.20Dirichlet's.20Thm/near/483785853) on Zulip.

The large import increase is caused by the need for more material to be able to state and prove the new things.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
