### PR TITLE
[Merged by Bors] - chore(RingTheory): split up `Algebraic.lean`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4210,8 +4210,13 @@ import Mathlib.RingTheory.Adjoin.PowerBasis
 import Mathlib.RingTheory.Adjoin.Tower
 import Mathlib.RingTheory.AdjoinRoot
 import Mathlib.RingTheory.AlgebraTower
-import Mathlib.RingTheory.Algebraic
+import Mathlib.RingTheory.Algebraic.Basic
 import Mathlib.RingTheory.Algebraic.Cardinality
+import Mathlib.RingTheory.Algebraic.Defs
+import Mathlib.RingTheory.Algebraic.Integral
+import Mathlib.RingTheory.Algebraic.LinearIndependent
+import Mathlib.RingTheory.Algebraic.MvPolynomial
+import Mathlib.RingTheory.Algebraic.Pi
 import Mathlib.RingTheory.AlgebraicIndependent
 import Mathlib.RingTheory.Artinian
 import Mathlib.RingTheory.Bezout

--- a/Mathlib/Algebra/AlgebraicCard.lean
+++ b/Mathlib/Algebra/AlgebraicCard.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
 import Mathlib.Algebra.Polynomial.Cardinal
-import Mathlib.RingTheory.Algebraic
+import Mathlib.RingTheory.Algebraic.Basic
 
 /-!
 ### Cardinality of algebraic numbers

--- a/Mathlib/Algebra/MvPolynomial/Equiv.lean
+++ b/Mathlib/Algebra/MvPolynomial/Equiv.lean
@@ -546,6 +546,11 @@ lemma finSuccEquiv_rename_finSuccEquiv (e : σ ≃ Fin n) (φ : MvPolynomial (Op
 
 end
 
+@[simp]
+theorem rename_polynomial_aeval_X {σ τ : Type*} (f : σ → τ) (i : σ) (p : R[X]) :
+    rename f (Polynomial.aeval (X i) p) = Polynomial.aeval (X (f i) : MvPolynomial τ R) p := by
+  rw [← aeval_algHom_apply, rename_X]
+
 end Equiv
 
 end MvPolynomial

--- a/Mathlib/Data/Real/GoldenRatio.lean
+++ b/Mathlib/Data/Real/GoldenRatio.lean
@@ -3,10 +3,11 @@ Copyright (c) 2020 Anatole Dedecker. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker, Alexey Soloyev, Junyan Xu, Kamila Szewczyk
 -/
-import Mathlib.Data.Real.Irrational
-import Mathlib.Data.Nat.Fib.Basic
-import Mathlib.Data.Fin.VecNotation
+import Mathlib.Algebra.EuclideanDomain.Basic
 import Mathlib.Algebra.LinearRecurrence
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Data.Nat.Fib.Basic
+import Mathlib.Data.Real.Irrational
 import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.Prime
 

--- a/Mathlib/Data/Real/Irrational.lean
+++ b/Mathlib/Data/Real/Irrational.lean
@@ -6,7 +6,7 @@ Authors: Mario Carneiro, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne, Yury K
 import Mathlib.Algebra.Algebra.Rat
 import Mathlib.Data.Rat.Sqrt
 import Mathlib.Data.Real.Sqrt
-import Mathlib.RingTheory.Algebraic
+import Mathlib.RingTheory.Algebraic.Basic
 import Mathlib.RingTheory.Int.Basic
 import Mathlib.Tactic.IntervalCases
 

--- a/Mathlib/Data/Real/Irrational.lean
+++ b/Mathlib/Data/Real/Irrational.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne, Yury Kudryashov
 -/
 import Mathlib.Algebra.Algebra.Rat
+import Mathlib.Data.Nat.Prime.Int
 import Mathlib.Data.Rat.Sqrt
 import Mathlib.Data.Real.Sqrt
 import Mathlib.RingTheory.Algebraic.Basic
-import Mathlib.RingTheory.Int.Basic
 import Mathlib.Tactic.IntervalCases
 
 /-!

--- a/Mathlib/FieldTheory/AxGrothendieck.lean
+++ b/Mathlib/FieldTheory/AxGrothendieck.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 
-import Mathlib.RingTheory.Algebraic
+import Mathlib.RingTheory.Algebraic.Basic
 import Mathlib.Data.Fintype.Card
 import Mathlib.ModelTheory.Algebra.Field.IsAlgClosed
 import Mathlib.ModelTheory.Algebra.Ring.Definability

--- a/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 import Mathlib.FieldTheory.IntermediateField.Basic
-import Mathlib.RingTheory.Algebraic
-import Mathlib.FieldTheory.Tower
 import Mathlib.FieldTheory.Minpoly.Basic
+import Mathlib.FieldTheory.Tower
 import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+import Mathlib.RingTheory.Algebraic.Basic
 
 /-!
 # Results on finite dimensionality and algebraicity of intermediate fields.

--- a/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
@@ -7,7 +7,7 @@ import Mathlib.FieldTheory.IntermediateField.Basic
 import Mathlib.FieldTheory.Minpoly.Basic
 import Mathlib.FieldTheory.Tower
 import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
-import Mathlib.RingTheory.Algebraic.Basic
+import Mathlib.RingTheory.Algebraic.Integral
 
 /-!
 # Results on finite dimensionality and algebraicity of intermediate fields.

--- a/Mathlib/FieldTheory/Minpoly/Field.lean
+++ b/Mathlib/FieldTheory/Minpoly/Field.lean
@@ -5,7 +5,8 @@ Authors: Riccardo Brasca, Johan Commelin
 -/
 import Mathlib.Algebra.Polynomial.FieldDivision
 import Mathlib.FieldTheory.Minpoly.Basic
-import Mathlib.RingTheory.Algebraic
+import Mathlib.RingTheory.Algebraic.Integral
+import Mathlib.RingTheory.LocalRing.Basic
 
 /-!
 # Minimal polynomials on an algebra over a field

--- a/Mathlib/FieldTheory/MvRatFunc/Rank.lean
+++ b/Mathlib/FieldTheory/MvRatFunc/Rank.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jz Pan
 -/
 import Mathlib.Algebra.MvPolynomial.Cardinal
-import Mathlib.RingTheory.Algebraic
+import Mathlib.RingTheory.Algebraic.LinearIndependent
+import Mathlib.RingTheory.Algebraic.MvPolynomial
 import Mathlib.RingTheory.Localization.Cardinality
 import Mathlib.RingTheory.MvPolynomial
 

--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes
 -/
 import Mathlib.Algebra.CharP.Algebra
 import Mathlib.FieldTheory.SplittingField.IsSplittingField
+import Mathlib.RingTheory.Algebraic.Basic
 
 /-!
 # Splitting fields

--- a/Mathlib/NumberTheory/DiophantineApproximation.lean
+++ b/Mathlib/NumberTheory/DiophantineApproximation.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.ContinuedFractions.Computation.ApproximationCorollaries
 import Mathlib.Algebra.ContinuedFractions.Computation.Translations
 import Mathlib.Data.Real.Irrational
 import Mathlib.RingTheory.Coprime.Lemmas
+import Mathlib.RingTheory.Int.Basic
 import Mathlib.Tactic.Basic
 
 /-!

--- a/Mathlib/RingTheory/Algebraic/Basic.lean
+++ b/Mathlib/RingTheory/Algebraic/Basic.lean
@@ -17,7 +17,6 @@ a tower of algebraic field extensions is algebraic.
 
 universe u v w
 
-open scoped Classical
 open Polynomial
 
 section

--- a/Mathlib/RingTheory/Algebraic/Basic.lean
+++ b/Mathlib/RingTheory/Algebraic/Basic.lean
@@ -3,10 +3,8 @@ Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
-import Mathlib.RingTheory.Polynomial.IntegralNormalization
-import Mathlib.RingTheory.LocalRing.Basic
-import Mathlib.Algebra.MvPolynomial.Supported
+import Mathlib.RingTheory.Algebraic.Defs
+import Mathlib.RingTheory.Algebraic.Integral
 
 /-!
 # Algebraic elements and algebraic extensions
@@ -17,7 +15,6 @@ The main result in this file proves transitivity of algebraicity:
 a tower of algebraic field extensions is algebraic.
 -/
 
-
 universe u v w
 
 open scoped Classical
@@ -27,28 +24,11 @@ section
 
 variable (R : Type u) {A : Type v} [CommRing R] [Ring A] [Algebra R A]
 
-/-- An element of an R-algebra is algebraic over R if it is a root of a nonzero polynomial
-with coefficients in R. -/
-@[stacks 09GC "Algebraic elements"]
-def IsAlgebraic (x : A) : Prop :=
-  ∃ p : R[X], p ≠ 0 ∧ aeval x p = 0
-
-/-- An element of an R-algebra is transcendental over R if it is not algebraic over R. -/
-def Transcendental (x : A) : Prop :=
-  ¬IsAlgebraic R x
-
 @[nontriviality]
 theorem is_transcendental_of_subsingleton [Subsingleton R] (x : A) : Transcendental R x :=
   fun ⟨p, h, _⟩ => h <| Subsingleton.elim p 0
 
 variable {R}
-
-/-- An element `x` is transcendental over `R` if and only if for any polynomial `p`,
-`Polynomial.aeval x p = 0` implies `p = 0`. This is similar to `algebraicIndependent_iff`. -/
-theorem transcendental_iff {x : A} :
-    Transcendental R x ↔ ∀ p : R[X], aeval x p = 0 → p = 0 := by
-  rw [Transcendental, IsAlgebraic, not_exists]
-  congr! 1; tauto
 
 variable (R) in
 theorem Polynomial.transcendental_X : Transcendental R (X (R := R)) := by
@@ -96,76 +76,6 @@ theorem Polynomial.transcendental (f : R[X]) (hf : f.natDegree ≠ 0)
     Transcendental R f := by
   simpa using (transcendental_X R).aeval f hf hf'
 
-/-- If `E / F` is a field extension, `x` is an element of `E` transcendental over `F`,
-then `{(x - a)⁻¹ | a : F}` is linearly independent over `F`. -/
-theorem Transcendental.linearIndependent_sub_inv
-    {F E : Type*} [Field F] [Field E] [Algebra F E] {x : E} (H : Transcendental F x) :
-    LinearIndependent F fun a ↦ (x - algebraMap F E a)⁻¹ := by
-  rw [transcendental_iff] at H
-  refine linearIndependent_iff'.2 fun s m hm i hi ↦ ?_
-  have hnz (a : F) : x - algebraMap F E a ≠ 0 := fun h ↦
-    X_sub_C_ne_zero a <| H (.X - .C a) (by simp [h])
-  let b := s.prod fun j ↦ x - algebraMap F E j
-  have h1 : ∀ i ∈ s, m i • (b * (x - algebraMap F E i)⁻¹) =
-      m i • (s.erase i).prod fun j ↦ x - algebraMap F E j := fun i hi ↦ by
-    simp_rw [b, ← s.prod_erase_mul _ hi, mul_inv_cancel_right₀ (hnz i)]
-  replace hm := congr(b * $(hm))
-  simp_rw [mul_zero, Finset.mul_sum, mul_smul_comm, Finset.sum_congr rfl h1] at hm
-  let p : Polynomial F := s.sum fun i ↦ .C (m i) * (s.erase i).prod fun j ↦ .X - .C j
-  replace hm := congr(Polynomial.aeval i $(H p (by simp_rw [← hm, p, map_sum, map_mul, map_prod,
-    map_sub, aeval_X, aeval_C, Algebra.smul_def])))
-  have h2 : ∀ j ∈ s.erase i, m j * ((s.erase j).prod fun x ↦ i - x) = 0 := fun j hj ↦ by
-    have := Finset.mem_erase_of_ne_of_mem (Finset.ne_of_mem_erase hj).symm hi
-    simp_rw [← (s.erase j).prod_erase_mul _ this, sub_self, mul_zero]
-  simp_rw [map_zero, p, map_sum, map_mul, map_prod, map_sub, aeval_X,
-    aeval_C, Algebra.id.map_eq_self, ← s.sum_erase_add _ hi,
-    Finset.sum_eq_zero h2, zero_add] at hm
-  exact eq_zero_of_ne_zero_of_mul_right_eq_zero (Finset.prod_ne_zero_iff.2 fun j hj ↦
-    sub_ne_zero.2 (Finset.ne_of_mem_erase hj).symm) hm
-
-/-- A subalgebra is algebraic if all its elements are algebraic. -/
-nonrec
-def Subalgebra.IsAlgebraic (S : Subalgebra R A) : Prop :=
-  ∀ x ∈ S, IsAlgebraic R x
-
-variable (R A)
-
-/-- An algebra is algebraic if all its elements are algebraic. -/
-@[stacks 09GC "Algebraic extensions"]
-protected class Algebra.IsAlgebraic : Prop where
-  isAlgebraic : ∀ x : A, IsAlgebraic R x
-
-/-- An algebra is transcendental if some element is transcendental. -/
-protected class Algebra.Transcendental : Prop where
-  transcendental : ∃ x : A, Transcendental R x
-
-variable {R A}
-
-lemma Algebra.isAlgebraic_def : Algebra.IsAlgebraic R A ↔ ∀ x : A, IsAlgebraic R x :=
-  ⟨fun ⟨h⟩ ↦ h, fun h ↦ ⟨h⟩⟩
-
-lemma Algebra.transcendental_def : Algebra.Transcendental R A ↔ ∃ x : A, Transcendental R x :=
-  ⟨fun ⟨h⟩ ↦ h, fun h ↦ ⟨h⟩⟩
-
-theorem Algebra.transcendental_iff_not_isAlgebraic :
-    Algebra.Transcendental R A ↔ ¬ Algebra.IsAlgebraic R A := by
-  simp [isAlgebraic_def, transcendental_def, Transcendental]
-
-/-- A subalgebra is algebraic if and only if it is algebraic as an algebra. -/
-theorem Subalgebra.isAlgebraic_iff (S : Subalgebra R A) :
-    S.IsAlgebraic ↔ Algebra.IsAlgebraic R S := by
-  delta Subalgebra.IsAlgebraic
-  rw [Subtype.forall', Algebra.isAlgebraic_def]
-  refine forall_congr' fun x => exists_congr fun p => and_congr Iff.rfl ?_
-  have h : Function.Injective S.val := Subtype.val_injective
-  conv_rhs => rw [← h.eq_iff, map_zero]
-  rw [← aeval_algHom_apply, S.val_apply]
-
-/-- An algebra is algebraic if and only if it is algebraic as a subalgebra. -/
-theorem Algebra.isAlgebraic_iff : Algebra.IsAlgebraic R A ↔ (⊤ : Subalgebra R A).IsAlgebraic := by
-  delta Subalgebra.IsAlgebraic
-  simp only [Algebra.isAlgebraic_def, Algebra.mem_top, forall_prop_of_true]
-
 theorem isAlgebraic_iff_not_injective {x : A} :
     IsAlgebraic R x ↔ ¬Function.Injective (Polynomial.aeval x : R[X] →ₐ[R] A) := by
   simp only [IsAlgebraic, injective_iff_map_eq_zero, not_forall, and_comm, exists_prop]
@@ -189,13 +99,6 @@ section zero_ne_one
 variable {R : Type u} {S : Type*} {A : Type v} [CommRing R]
 variable [CommRing S] [Ring A] [Algebra R A] [Algebra R S] [Algebra S A]
 variable [IsScalarTower R S A]
-
-/-- An integral element of an algebra is algebraic. -/
-theorem IsIntegral.isAlgebraic [Nontrivial R] {x : A} : IsIntegral R x → IsAlgebraic R x :=
-  fun ⟨p, hp, hpx⟩ => ⟨p, hp.ne_zero, hpx⟩
-
-instance Algebra.IsIntegral.isAlgebraic [Nontrivial R] [Algebra.IsIntegral R A] :
-    Algebra.IsAlgebraic R A := ⟨fun a ↦ (Algebra.IsIntegral.isIntegral a).isAlgebraic⟩
 
 theorem isAlgebraic_zero [Nontrivial R] : IsAlgebraic R (0 : A) :=
   ⟨_, X_ne_zero, aeval_X 0⟩
@@ -447,31 +350,6 @@ section Field
 
 variable {K : Type u} {A : Type v} [Field K] [Ring A] [Algebra K A]
 
-/-- An element of an algebra over a field is algebraic if and only if it is integral. -/
-theorem isAlgebraic_iff_isIntegral {x : A} : IsAlgebraic K x ↔ IsIntegral K x := by
-  refine ⟨?_, IsIntegral.isAlgebraic⟩
-  rintro ⟨p, hp, hpx⟩
-  refine ⟨_, monic_mul_leadingCoeff_inv hp, ?_⟩
-  rw [← aeval_def, map_mul, hpx, zero_mul]
-
-protected theorem Algebra.isAlgebraic_iff_isIntegral :
-    Algebra.IsAlgebraic K A ↔ Algebra.IsIntegral K A := by
-  rw [Algebra.isAlgebraic_def, Algebra.isIntegral_def,
-      forall_congr' fun _ ↦ isAlgebraic_iff_isIntegral]
-
-alias ⟨IsAlgebraic.isIntegral, _⟩ := isAlgebraic_iff_isIntegral
-
-/-- This used to be an `alias` of `Algebra.isAlgebraic_iff_isIntegral` but that would make
-`Algebra.IsAlgebraic K A` an explicit parameter instead of instance implicit. -/
-protected instance Algebra.IsAlgebraic.isIntegral [Algebra.IsAlgebraic K A] :
-    Algebra.IsIntegral K A := Algebra.isAlgebraic_iff_isIntegral.mp ‹_›
-
-variable (K) in
-theorem Algebra.IsAlgebraic.of_isIntegralClosure (B C : Type*)
-    [CommRing B] [CommRing C] [Algebra K B] [Algebra K C] [Algebra B C]
-    [IsScalarTower K B C] [IsIntegralClosure B K C] : Algebra.IsAlgebraic K B :=
-  Algebra.isAlgebraic_iff_isIntegral.mpr (IsIntegralClosure.isIntegral_algebra K C)
-
 /-- If `K` is a field, `r : A` and `f : K[X]`, then `Polynomial.aeval r f` is
 transcendental over `K` if and only if `r` and `f` are both transcendental over `K`.
 See also `Transcendental.aeval_of_transcendental` and `Transcendental.of_aeval`. -/
@@ -572,17 +450,7 @@ theorem Transcendental.of_tower_top {x : A} (h : Transcendental L x) :
 theorem Algebra.IsAlgebraic.tower_top [Algebra.IsAlgebraic K A] : Algebra.IsAlgebraic L A :=
   Algebra.IsAlgebraic.extendScalars (algebraMap K L).injective
 
-variable (K)
-
-theorem IsAlgebraic.of_finite (e : A) [FiniteDimensional K A] : IsAlgebraic K e :=
-  (IsIntegral.of_finite K e).isAlgebraic
-
-variable (A)
-
-/-- A field extension is algebraic if it is finite. -/
-@[stacks 09GG "first part"]
-instance Algebra.IsAlgebraic.of_finite [FiniteDimensional K A] : Algebra.IsAlgebraic K A :=
-  (IsIntegral.of_finite K A).isAlgebraic
+variable (K) (A)
 
 theorem Algebra.IsAlgebraic.tower_bot (K L A : Type*) [CommRing K] [Field L] [Ring A]
     [Algebra K L] [Algebra L A] [Algebra K A] [IsScalarTower K L A]
@@ -720,17 +588,6 @@ end
 
 variable {R S : Type*} [CommRing R] [IsDomain R] [CommRing S]
 
-theorem exists_integral_multiple [Algebra R S] {z : S} (hz : IsAlgebraic R z)
-    (inj : ∀ x, algebraMap R S x = 0 → x = 0) :
-    ∃ᵉ (x : integralClosure R S) (y ≠ (0 : R)), z * algebraMap R S y = x := by
-  rcases hz with ⟨p, p_ne_zero, px⟩
-  set a := p.leadingCoeff
-  have a_ne_zero : a ≠ 0 := mt Polynomial.leadingCoeff_eq_zero.mp p_ne_zero
-  have x_integral : IsIntegral R (z * algebraMap R S a) :=
-    ⟨p.integralNormalization, monic_integralNormalization p_ne_zero,
-      integralNormalization_aeval_eq_zero px inj⟩
-  exact ⟨⟨_, x_integral⟩, a, a_ne_zero, rfl⟩
-
 section Field
 
 variable {K L : Type*} [Field K] [Field L] [Algebra K L] (A : Subalgebra K L)
@@ -791,166 +648,6 @@ theorem Subalgebra.isField_of_algebraic [Algebra.IsAlgebraic K L] : IsField A :=
         Subtype.ext (mul_inv_cancel₀ (mt (Subalgebra.coe_eq_zero _).mp ha))⟩ }
 
 end Field
-
-section Pi
-
-variable (R' : Type u) (S' : Type v) (T' : Type w)
-
-/-- This is not an instance as it forms a diamond with `Pi.instSMul`.
-
-See the `instance_diamonds` test for details. -/
-def Polynomial.hasSMulPi [Semiring R'] [SMul R' S'] : SMul R'[X] (R' → S') :=
-  ⟨fun p f x => eval x p • f x⟩
-
-/-- This is not an instance as it forms a diamond with `Pi.instSMul`.
-
-See the `instance_diamonds` test for details. -/
-noncomputable def Polynomial.hasSMulPi' [CommSemiring R'] [Semiring S'] [Algebra R' S']
-    [SMul S' T'] : SMul R'[X] (S' → T') :=
-  ⟨fun p f x => aeval x p • f x⟩
-
-attribute [local instance] Polynomial.hasSMulPi Polynomial.hasSMulPi'
-
-@[simp]
-theorem polynomial_smul_apply [Semiring R'] [SMul R' S'] (p : R'[X]) (f : R' → S') (x : R') :
-    (p • f) x = eval x p • f x :=
-  rfl
-
-@[simp]
-theorem polynomial_smul_apply' [CommSemiring R'] [Semiring S'] [Algebra R' S'] [SMul S' T']
-    (p : R'[X]) (f : S' → T') (x : S') : (p • f) x = aeval x p • f x :=
-  rfl
-
-variable [CommSemiring R'] [CommSemiring S'] [CommSemiring T'] [Algebra R' S'] [Algebra S' T']
-
--- Porting note: the proofs in this definition used `funext` in term-mode, but I was not able
--- to get them to work anymore.
-/-- This is not an instance for the same reasons as `Polynomial.hasSMulPi'`. -/
-noncomputable def Polynomial.algebraPi : Algebra R'[X] (S' → T') :=
-  { Polynomial.hasSMulPi' R' S' T' with
-    toFun := fun p z => algebraMap S' T' (aeval z p)
-    map_one' := by
-      funext z
-      simp only [Polynomial.aeval_one, Pi.one_apply, map_one]
-    map_mul' := fun f g => by
-      funext z
-      simp only [Pi.mul_apply, map_mul]
-    map_zero' := by
-      funext z
-      simp only [Polynomial.aeval_zero, Pi.zero_apply, map_zero]
-    map_add' := fun f g => by
-      funext z
-      simp only [Polynomial.aeval_add, Pi.add_apply, map_add]
-    commutes' := fun p f => by
-      funext z
-      exact mul_comm _ _
-    smul_def' := fun p f => by
-      funext z
-      simp only [polynomial_smul_apply', Algebra.algebraMap_eq_smul_one, RingHom.coe_mk,
-        MonoidHom.coe_mk, OneHom.coe_mk, Pi.mul_apply, Algebra.smul_mul_assoc, one_mul] }
-
-attribute [local instance] Polynomial.algebraPi
-
-@[simp]
-theorem Polynomial.algebraMap_pi_eq_aeval :
-    (algebraMap R'[X] (S' → T') : R'[X] → S' → T') = fun p z => algebraMap _ _ (aeval z p) :=
-  rfl
-
-@[simp]
-theorem Polynomial.algebraMap_pi_self_eq_eval :
-    (algebraMap R'[X] (R' → R') : R'[X] → R' → R') = fun p z => eval z p :=
-  rfl
-
-end Pi
-
-namespace MvPolynomial
-
-variable {σ : Type*} (R : Type*) [CommRing R]
-
--- TODO: move to suitable place
-private theorem rename_polynomial_aeval_X
-    {σ τ R : Type*} [CommSemiring R] (f : σ → τ) (i : σ) (p : R[X]) :
-    rename f (Polynomial.aeval (X i) p) = Polynomial.aeval (X (f i) : MvPolynomial τ R) p := by
-  rw [← AlgHom.comp_apply]
-  congr 1; ext1; simp
-
-theorem transcendental_supported_polynomial_aeval_X {i : σ} {s : Set σ} (h : i ∉ s)
-    {f : R[X]} (hf : Transcendental R f) :
-    Transcendental (supported R s) (Polynomial.aeval (X i : MvPolynomial σ R) f) := by
-  rw [transcendental_iff_injective] at hf ⊢
-  let g := MvPolynomial.mapAlgHom (R := R) (σ := s) (Polynomial.aeval (R := R) f)
-  replace hf : Function.Injective g := MvPolynomial.map_injective _ hf
-  let u := (Subalgebra.val _).comp
-    ((optionEquivRight R s).symm |>.trans
-      (renameEquiv R (Set.subtypeInsertEquivOption h).symm) |>.trans
-      (supportedEquivMvPolynomial _).symm).toAlgHom |>.comp
-    g |>.comp
-    ((optionEquivLeft R s).symm.trans (optionEquivRight R s)).toAlgHom
-  let v := ((Polynomial.aeval (R := supported R s)
-    (Polynomial.aeval (X i : MvPolynomial σ R) f)).restrictScalars R).comp
-      (Polynomial.mapAlgEquiv (supportedEquivMvPolynomial s).symm).toAlgHom
-  replace hf : Function.Injective u := by
-    simp only [AlgEquiv.toAlgHom_eq_coe, AlgHom.coe_comp, Subalgebra.coe_val,
-      AlgHom.coe_coe, AlgEquiv.coe_trans, Function.comp_assoc, u]
-    apply Subtype.val_injective.comp
-    simp only [EquivLike.comp_injective]
-    apply hf.comp
-    simp only [EquivLike.comp_injective, EquivLike.injective]
-  have h1 : Polynomial.aeval (X i : MvPolynomial σ R) = ((Subalgebra.val _).comp
-      (supportedEquivMvPolynomial _).symm.toAlgHom |>.comp
-      (Polynomial.aeval (X ⟨i, s.mem_insert i⟩ : MvPolynomial ↑(insert i s) R))) := by
-    ext1; simp
-  have h2 : u = v := by
-    simp only [u, v, g]
-    ext1
-    · ext1
-      simp [Set.subtypeInsertEquivOption, Subalgebra.algebraMap_eq]
-    · simp [Set.subtypeInsertEquivOption, rename_polynomial_aeval_X, h1]
-  simpa only [h2, v, AlgEquiv.toAlgHom_eq_coe, AlgHom.coe_comp, AlgHom.coe_coe,
-    EquivLike.injective_comp, AlgHom.coe_restrictScalars'] using hf
-
-theorem transcendental_polynomial_aeval_X (i : σ) {f : R[X]} (hf : Transcendental R f) :
-    Transcendental R (Polynomial.aeval (X i : MvPolynomial σ R) f) := by
-  have := transcendental_supported_polynomial_aeval_X R (Set.not_mem_empty i) hf
-  let g := (Algebra.botEquivOfInjective (MvPolynomial.C_injective σ R)).symm.trans
-    (Subalgebra.equivOfEq _ _ supported_empty).symm
-  rwa [Transcendental, ← isAlgebraic_ringHom_iff_of_comp_eq g (RingHom.id (MvPolynomial σ R))
-    Function.injective_id (by ext1; rfl), RingHom.id_apply, ← Transcendental]
-
-theorem transcendental_polynomial_aeval_X_iff (i : σ) {f : R[X]} :
-    Transcendental R (Polynomial.aeval (X i : MvPolynomial σ R) f) ↔ Transcendental R f := by
-  refine ⟨?_, transcendental_polynomial_aeval_X R i⟩
-  simp_rw [Transcendental, not_imp_not]
-  exact fun h ↦ h.algHom _
-
-theorem transcendental_supported_polynomial_aeval_X_iff
-    [Nontrivial R] {i : σ} {s : Set σ} {f : R[X]} :
-    Transcendental (supported R s) (Polynomial.aeval (X i : MvPolynomial σ R) f) ↔
-    i ∉ s ∧ Transcendental R f := by
-  refine ⟨fun h ↦ ⟨?_, ?_⟩, fun ⟨h, hf⟩ ↦ transcendental_supported_polynomial_aeval_X R h hf⟩
-  · rw [Transcendental] at h
-    contrapose! h
-    refine isAlgebraic_algebraMap (⟨Polynomial.aeval (X i) f, ?_⟩ : supported R s)
-    exact Algebra.adjoin_mono (Set.singleton_subset_iff.2 (Set.mem_image_of_mem _ h))
-      (Polynomial.aeval_mem_adjoin_singleton _ _)
-  · rw [← transcendental_polynomial_aeval_X_iff R i]
-    refine h.restrictScalars fun _ _ heq ↦ MvPolynomial.C_injective σ R ?_
-    simp_rw [← MvPolynomial.algebraMap_eq]
-    exact congr($(heq).1)
-
-theorem transcendental_supported_X {i : σ} {s : Set σ} (h : i ∉ s) :
-    Transcendental (supported R s) (X i : MvPolynomial σ R) := by
-  simpa using transcendental_supported_polynomial_aeval_X R h (Polynomial.transcendental_X R)
-
-theorem transcendental_X (i : σ) : Transcendental R (X i : MvPolynomial σ R) := by
-  simpa using transcendental_polynomial_aeval_X R i (Polynomial.transcendental_X R)
-
-theorem transcendental_supported_X_iff [Nontrivial R] {i : σ} {s : Set σ} :
-    Transcendental (supported R s) (X i : MvPolynomial σ R) ↔ i ∉ s := by
-  simpa [Polynomial.transcendental_X] using
-    transcendental_supported_polynomial_aeval_X_iff R (i := i) (s := s) (f := Polynomial.X)
-
-end MvPolynomial
 
 section Infinite
 

--- a/Mathlib/RingTheory/Algebraic/Basic.lean
+++ b/Mathlib/RingTheory/Algebraic/Basic.lean
@@ -3,8 +3,11 @@ Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
+import Mathlib.Algebra.EuclideanDomain.Field
+import Mathlib.Algebra.Polynomial.Expand
+import Mathlib.Algebra.Polynomial.Roots
 import Mathlib.RingTheory.Algebraic.Defs
-import Mathlib.RingTheory.Algebraic.Integral
+import Mathlib.RingTheory.Polynomial.Tower
 
 /-!
 # Algebraic elements and algebraic extensions
@@ -345,24 +348,6 @@ alias ⟨_, IsAlgebraic.inv⟩ := IsAlgebraic.inv_iff
 
 end zero_ne_one
 
-section Field
-
-variable {K : Type u} {A : Type v} [Field K] [Ring A] [Algebra K A]
-
-/-- If `K` is a field, `r : A` and `f : K[X]`, then `Polynomial.aeval r f` is
-transcendental over `K` if and only if `r` and `f` are both transcendental over `K`.
-See also `Transcendental.aeval_of_transcendental` and `Transcendental.of_aeval`. -/
-@[simp]
-theorem transcendental_aeval_iff {r : A} {f : K[X]} :
-    Transcendental K (Polynomial.aeval r f) ↔ Transcendental K r ∧ Transcendental K f := by
-  refine ⟨fun h ↦ ⟨?_, h.of_aeval⟩, fun ⟨h1, h2⟩ ↦ h1.aeval_of_transcendental h2⟩
-  rw [Transcendental] at h ⊢
-  contrapose! h
-  rw [isAlgebraic_iff_isIntegral] at h ⊢
-  exact .of_mem_of_fg _ h.fg_adjoin_singleton _ (aeval_mem_adjoin_singleton _ _)
-
-end Field
-
 section
 
 variable {K L R S A : Type*}
@@ -461,22 +446,6 @@ end Field
 
 end Ring
 
-section CommRing
-
-variable [Field K] [Field L] [Ring A]
-variable [Algebra K L] [Algebra L A] [Algebra K A] [IsScalarTower K L A]
-
-/-- If L is an algebraic field extension of K and A is an algebraic algebra over L,
-then A is algebraic over K. -/
-@[stacks 09GJ]
-protected theorem Algebra.IsAlgebraic.trans
-    [L_alg : Algebra.IsAlgebraic K L] [A_alg : Algebra.IsAlgebraic L A] :
-    Algebra.IsAlgebraic K A := by
-  rw [Algebra.isAlgebraic_iff_isIntegral] at L_alg A_alg ⊢
-  exact Algebra.IsIntegral.trans L
-
-end CommRing
-
 section NoZeroSMulDivisors
 
 namespace Algebra.IsAlgebraic
@@ -525,23 +494,6 @@ noncomputable def algEquivEquivAlgHom [NoZeroSMulDivisors K L] [Algebra.IsAlgebr
 end Algebra.IsAlgebraic
 
 end NoZeroSMulDivisors
-
-section Field
-
-variable [Field K] [Field L]
-variable [Algebra K L]
-
-theorem AlgHom.bijective [FiniteDimensional K L] (ϕ : L →ₐ[K] L) : Function.Bijective ϕ :=
-  (Algebra.IsAlgebraic.of_finite K L).algHom_bijective ϕ
-
-variable (K L)
-
-/-- Bijection between algebra equivalences and algebra homomorphisms -/
-noncomputable abbrev algEquivEquivAlgHom [FiniteDimensional K L] :
-    (L ≃ₐ[K] L) ≃* (L →ₐ[K] L) :=
-  Algebra.IsAlgebraic.algEquivEquivAlgHom K L
-
-end Field
 
 end
 

--- a/Mathlib/RingTheory/Algebraic/Basic.lean
+++ b/Mathlib/RingTheory/Algebraic/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import Mathlib.Algebra.EuclideanDomain.Field
 import Mathlib.Algebra.Polynomial.Expand
 import Mathlib.Algebra.Polynomial.Roots
 import Mathlib.RingTheory.Algebraic.Defs

--- a/Mathlib/RingTheory/Algebraic/Cardinality.lean
+++ b/Mathlib/RingTheory/Algebraic/Cardinality.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import Mathlib.Algebra.Polynomial.Cardinal
-import Mathlib.RingTheory.Algebraic.Basic
+import Mathlib.Algebra.Polynomial.Roots
+import Mathlib.RingTheory.Algebraic.Defs
 
 /-!
 # Cardinality of algebraic extensions

--- a/Mathlib/RingTheory/Algebraic/Cardinality.lean
+++ b/Mathlib/RingTheory/Algebraic/Cardinality.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import Mathlib.Algebra.Polynomial.Cardinal
-import Mathlib.RingTheory.Algebraic
+import Mathlib.RingTheory.Algebraic.Basic
 
 /-!
 # Cardinality of algebraic extensions

--- a/Mathlib/RingTheory/Algebraic/Defs.lean
+++ b/Mathlib/RingTheory/Algebraic/Defs.lean
@@ -13,7 +13,7 @@ An R-algebra is algebraic over R if and only if all its elements are algebraic o
 
 ## Main definitions
 
-* `IsAlgebraic`: algebraic elements of an algebra. 
+* `IsAlgebraic`: algebraic elements of an algebra.
 * `Transcendental`: transcendental elements of an algebra are those that are not algebraic.
 * `Subalgebra.IsAlgebraic`: a subalgebra is algebraic if all its elements are algebraic.
 * `Algebra.IsAlgebraic`: an algebra is algebraic if all its elements are algebraic.

--- a/Mathlib/RingTheory/Algebraic/Defs.lean
+++ b/Mathlib/RingTheory/Algebraic/Defs.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2019 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin
+-/
+import Mathlib.Algebra.Polynomial.AlgebraMap
+
+/-!
+# Algebraic elements and algebraic extensions
+
+An element of an R-algebra is algebraic over R if it is the root of a nonzero polynomial.
+An R-algebra is algebraic over R if and only if all its elements are algebraic over R.
+
+## Main definitions
+
+* `IsAlgebraic`: algebraic elements of an algebra. 
+* `Transcendental`: transcendental elements of an algebra are those that are not algebraic.
+* `Subalgebra.IsAlgebraic`: a subalgebra is algebraic if all its elements are algebraic.
+* `Algebra.IsAlgebraic`: an algebra is algebraic if all its elements are algebraic.
+* `Algebra.Transcendental`: an algebra is transcendental if some element is transcendental.
+
+## Main results
+
+* `transcendental_iff`: an element `x : A` is transcendental over `R` iff out of `R[X]`
+  only the zero polynomial evaluates to 0 at `x`.
+* `Subalgebra.isAlgebraic_iff`: a subalgebra is algebraic iff it is algebraic as an algebra.
+-/
+
+assert_not_exists IsIntegralClosure
+assert_not_exists LinearIndependent
+assert_not_exists LocalRing
+assert_not_exists MvPolynomial
+
+universe u v w
+
+open scoped Classical
+open Polynomial
+
+section
+
+variable (R : Type u) {A : Type v} [CommRing R] [Ring A] [Algebra R A]
+
+/-- An element of an R-algebra is algebraic over R if it is a root of a nonzero polynomial
+with coefficients in R. -/
+@[stacks 09GC "Algebraic elements"]
+def IsAlgebraic (x : A) : Prop :=
+  ∃ p : R[X], p ≠ 0 ∧ aeval x p = 0
+
+/-- An element of an R-algebra is transcendental over R if it is not algebraic over R. -/
+def Transcendental (x : A) : Prop :=
+  ¬IsAlgebraic R x
+
+variable {R}
+
+/-- An element `x` is transcendental over `R` if and only if for any polynomial `p`,
+`Polynomial.aeval x p = 0` implies `p = 0`. This is similar to `algebraicIndependent_iff`. -/
+theorem transcendental_iff {x : A} :
+    Transcendental R x ↔ ∀ p : R[X], aeval x p = 0 → p = 0 := by
+  rw [Transcendental, IsAlgebraic, not_exists]
+  congr! 1; tauto
+
+/-- A subalgebra is algebraic if all its elements are algebraic. -/
+nonrec
+def Subalgebra.IsAlgebraic (S : Subalgebra R A) : Prop :=
+  ∀ x ∈ S, IsAlgebraic R x
+
+variable (R A)
+
+/-- An algebra is algebraic if all its elements are algebraic. -/
+@[stacks 09GC "Algebraic extensions"]
+protected class Algebra.IsAlgebraic : Prop where
+  isAlgebraic : ∀ x : A, IsAlgebraic R x
+
+/-- An algebra is transcendental if some element is transcendental. -/
+protected class Algebra.Transcendental : Prop where
+  transcendental : ∃ x : A, Transcendental R x
+
+variable {R A}
+
+lemma Algebra.isAlgebraic_def : Algebra.IsAlgebraic R A ↔ ∀ x : A, IsAlgebraic R x :=
+  ⟨fun ⟨h⟩ ↦ h, fun h ↦ ⟨h⟩⟩
+
+lemma Algebra.transcendental_def : Algebra.Transcendental R A ↔ ∃ x : A, Transcendental R x :=
+  ⟨fun ⟨h⟩ ↦ h, fun h ↦ ⟨h⟩⟩
+
+theorem Algebra.transcendental_iff_not_isAlgebraic :
+    Algebra.Transcendental R A ↔ ¬ Algebra.IsAlgebraic R A := by
+  simp [isAlgebraic_def, transcendental_def, Transcendental]
+
+/-- A subalgebra is algebraic if and only if it is algebraic as an algebra. -/
+theorem Subalgebra.isAlgebraic_iff (S : Subalgebra R A) :
+    S.IsAlgebraic ↔ Algebra.IsAlgebraic R S := by
+  delta Subalgebra.IsAlgebraic
+  rw [Subtype.forall', Algebra.isAlgebraic_def]
+  refine forall_congr' fun x => exists_congr fun p => and_congr Iff.rfl ?_
+  have h : Function.Injective S.val := Subtype.val_injective
+  conv_rhs => rw [← h.eq_iff, map_zero]
+  rw [← aeval_algHom_apply, S.val_apply]
+
+/-- An algebra is algebraic if and only if it is algebraic as a subalgebra. -/
+theorem Algebra.isAlgebraic_iff : Algebra.IsAlgebraic R A ↔ (⊤ : Subalgebra R A).IsAlgebraic := by
+  delta Subalgebra.IsAlgebraic
+  simp only [Algebra.isAlgebraic_def, Algebra.mem_top, forall_prop_of_true]
+
+end

--- a/Mathlib/RingTheory/Algebraic/Defs.lean
+++ b/Mathlib/RingTheory/Algebraic/Defs.lean
@@ -32,8 +32,6 @@ assert_not_exists LocalRing
 assert_not_exists MvPolynomial
 
 universe u v w
-
-open scoped Classical
 open Polynomial
 
 section

--- a/Mathlib/RingTheory/Algebraic/Integral.lean
+++ b/Mathlib/RingTheory/Algebraic/Integral.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import Mathlib.RingTheory.Algebraic.Defs
+import Mathlib.RingTheory.Algebraic.Basic
 import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
 import Mathlib.RingTheory.Polynomial.IntegralNormalization
 
@@ -99,6 +99,51 @@ instance Algebra.IsAlgebraic.of_finite [FiniteDimensional K A] : Algebra.IsAlgeb
 end Field
 
 end Ring
+
+section CommRing
+
+variable {K L} [Field K] [Field L] [Ring A]
+variable [Algebra K L] [Algebra L A] [Algebra K A] [IsScalarTower K L A]
+
+/-- If L is an algebraic field extension of K and A is an algebraic algebra over L,
+then A is algebraic over K. -/
+@[stacks 09GJ]
+protected theorem Algebra.IsAlgebraic.trans
+    [L_alg : Algebra.IsAlgebraic K L] [A_alg : Algebra.IsAlgebraic L A] :
+    Algebra.IsAlgebraic K A := by
+  rw [Algebra.isAlgebraic_iff_isIntegral] at L_alg A_alg ⊢
+  exact Algebra.IsIntegral.trans L
+
+end CommRing
+
+section Field
+
+variable {K L} [Field K] [Ring A] [Algebra K A]
+
+/-- If `K` is a field, `r : A` and `f : K[X]`, then `Polynomial.aeval r f` is
+transcendental over `K` if and only if `r` and `f` are both transcendental over `K`.
+See also `Transcendental.aeval_of_transcendental` and `Transcendental.of_aeval`. -/
+@[simp]
+theorem transcendental_aeval_iff {r : A} {f : K[X]} :
+    Transcendental K (Polynomial.aeval r f) ↔ Transcendental K r ∧ Transcendental K f := by
+  refine ⟨fun h ↦ ⟨?_, h.of_aeval⟩, fun ⟨h1, h2⟩ ↦ h1.aeval_of_transcendental h2⟩
+  rw [Transcendental] at h ⊢
+  contrapose! h
+  rw [isAlgebraic_iff_isIntegral] at h ⊢
+  exact .of_mem_of_fg _ h.fg_adjoin_singleton _ (aeval_mem_adjoin_singleton _ _)
+
+variable [Field L] [Algebra K L]
+
+theorem AlgHom.bijective [FiniteDimensional K L] (ϕ : L →ₐ[K] L) : Function.Bijective ϕ :=
+  (Algebra.IsAlgebraic.of_finite K L).algHom_bijective ϕ
+
+variable (K L) in
+/-- Bijection between algebra equivalences and algebra homomorphisms -/
+noncomputable abbrev algEquivEquivAlgHom [FiniteDimensional K L] :
+    (L ≃ₐ[K] L) ≃* (L →ₐ[K] L) :=
+  Algebra.IsAlgebraic.algEquivEquivAlgHom K L
+
+end Field
 
 end
 

--- a/Mathlib/RingTheory/Algebraic/Integral.lean
+++ b/Mathlib/RingTheory/Algebraic/Integral.lean
@@ -27,7 +27,6 @@ assert_not_exists LocalRing
 
 universe u v w
 
-open scoped Classical
 open Polynomial
 
 section zero_ne_one

--- a/Mathlib/RingTheory/Algebraic/Integral.lean
+++ b/Mathlib/RingTheory/Algebraic/Integral.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2019 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin
+-/
+import Mathlib.RingTheory.Algebraic.Defs
+import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
+import Mathlib.RingTheory.Polynomial.IntegralNormalization
+
+/-!
+# Algebraic elements and integral elements
+
+This file relates algebraic and integral elements of an algebra, by proving every integral element
+is algebraic and that every algebraic element over a field is integral.
+
+## Main results
+
+* `IsIntegral.isAlgebraic`, `Algebra.IsIntegral.isAlgebraic`: integral implies algebraic.
+* `isAlgebraic_iff_isIntegral`, `Algebra.isAlgebraic_iff_isIntegral`: integral iff algebraic
+  over a field.
+* `IsAlgebraic.of_finite`, `Algebra.IsAlgebraic.of_finite`: finite-dimensional (as module) implies
+  algebraic.
+* `exists_integral_multiple`: an algebraic element has a multiple which is integral
+-/
+
+assert_not_exists LocalRing
+
+universe u v w
+
+open scoped Classical
+open Polynomial
+
+section zero_ne_one
+
+variable {R : Type u} {S : Type*} {A : Type v} [CommRing R]
+variable [CommRing S] [Ring A] [Algebra R A] [Algebra R S] [Algebra S A]
+variable [IsScalarTower R S A]
+
+/-- An integral element of an algebra is algebraic. -/
+theorem IsIntegral.isAlgebraic [Nontrivial R] {x : A} : IsIntegral R x → IsAlgebraic R x :=
+  fun ⟨p, hp, hpx⟩ => ⟨p, hp.ne_zero, hpx⟩
+
+instance Algebra.IsIntegral.isAlgebraic [Nontrivial R] [Algebra.IsIntegral R A] :
+    Algebra.IsAlgebraic R A := ⟨fun a ↦ (Algebra.IsIntegral.isIntegral a).isAlgebraic⟩
+
+end zero_ne_one
+
+section Field
+
+variable {K : Type u} {A : Type v} [Field K] [Ring A] [Algebra K A]
+
+/-- An element of an algebra over a field is algebraic if and only if it is integral. -/
+theorem isAlgebraic_iff_isIntegral {x : A} : IsAlgebraic K x ↔ IsIntegral K x := by
+  refine ⟨?_, IsIntegral.isAlgebraic⟩
+  rintro ⟨p, hp, hpx⟩
+  refine ⟨_, monic_mul_leadingCoeff_inv hp, ?_⟩
+  rw [← aeval_def, map_mul, hpx, zero_mul]
+
+protected theorem Algebra.isAlgebraic_iff_isIntegral :
+    Algebra.IsAlgebraic K A ↔ Algebra.IsIntegral K A := by
+  rw [Algebra.isAlgebraic_def, Algebra.isIntegral_def,
+      forall_congr' fun _ ↦ isAlgebraic_iff_isIntegral]
+
+alias ⟨IsAlgebraic.isIntegral, _⟩ := isAlgebraic_iff_isIntegral
+
+/-- This used to be an `alias` of `Algebra.isAlgebraic_iff_isIntegral` but that would make
+`Algebra.IsAlgebraic K A` an explicit parameter instead of instance implicit. -/
+protected instance Algebra.IsAlgebraic.isIntegral [Algebra.IsAlgebraic K A] :
+    Algebra.IsIntegral K A := Algebra.isAlgebraic_iff_isIntegral.mp ‹_›
+
+variable (K) in
+theorem Algebra.IsAlgebraic.of_isIntegralClosure (B C : Type*)
+    [CommRing B] [CommRing C] [Algebra K B] [Algebra K C] [Algebra B C]
+    [IsScalarTower K B C] [IsIntegralClosure B K C] : Algebra.IsAlgebraic K B :=
+  Algebra.isAlgebraic_iff_isIntegral.mpr (IsIntegralClosure.isIntegral_algebra K C)
+
+end Field
+
+section
+
+variable (K L : Type*) {R S A : Type*}
+
+section Ring
+
+section Field
+
+variable [Field K] [Field L] [Ring A]
+variable [Algebra K L] [Algebra L A] [Algebra K A] [IsScalarTower K L A]
+
+theorem IsAlgebraic.of_finite (e : A) [FiniteDimensional K A] : IsAlgebraic K e :=
+  (IsIntegral.of_finite K e).isAlgebraic
+
+variable (A)
+
+/-- A field extension is algebraic if it is finite. -/
+@[stacks 09GG "first part"]
+instance Algebra.IsAlgebraic.of_finite [FiniteDimensional K A] : Algebra.IsAlgebraic K A :=
+  (IsIntegral.of_finite K A).isAlgebraic
+
+end Field
+
+end Ring
+
+end
+
+variable {R S : Type*} [CommRing R] [IsDomain R] [CommRing S]
+
+theorem exists_integral_multiple [Algebra R S] {z : S} (hz : IsAlgebraic R z)
+    (inj : ∀ x, algebraMap R S x = 0 → x = 0) :
+    ∃ᵉ (x : integralClosure R S) (y ≠ (0 : R)), z * algebraMap R S y = x := by
+  rcases hz with ⟨p, p_ne_zero, px⟩
+  set a := p.leadingCoeff
+  have a_ne_zero : a ≠ 0 := mt Polynomial.leadingCoeff_eq_zero.mp p_ne_zero
+  have x_integral : IsIntegral R (z * algebraMap R S a) :=
+    ⟨p.integralNormalization, monic_integralNormalization p_ne_zero,
+      integralNormalization_aeval_eq_zero px inj⟩
+  exact ⟨⟨_, x_integral⟩, a, a_ne_zero, rfl⟩

--- a/Mathlib/RingTheory/Algebraic/LinearIndependent.lean
+++ b/Mathlib/RingTheory/Algebraic/LinearIndependent.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2019 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin
+-/
+import Mathlib.LinearAlgebra.LinearIndependent
+import Mathlib.RingTheory.Algebraic.Defs
+
+/-!
+# Linear independence of transcendental elements
+
+## Main result
+
+* `Transcendental.linearIndependent_sub_inv`: let `x : E` transcendental over `F`,
+  then `{(x - a)⁻¹ | a : F}` is linearly independent over `F`.
+-/
+
+open scoped Classical
+open Polynomial
+
+section
+
+/-- If `E / F` is a field extension, `x` is an element of `E` transcendental over `F`,
+then `{(x - a)⁻¹ | a : F}` is linearly independent over `F`. -/
+theorem Transcendental.linearIndependent_sub_inv
+    {F E : Type*} [Field F] [Field E] [Algebra F E] {x : E} (H : Transcendental F x) :
+    LinearIndependent F fun a ↦ (x - algebraMap F E a)⁻¹ := by
+  rw [transcendental_iff] at H
+  refine linearIndependent_iff'.2 fun s m hm i hi ↦ ?_
+  have hnz (a : F) : x - algebraMap F E a ≠ 0 := fun h ↦
+    X_sub_C_ne_zero a <| H (.X - .C a) (by simp [h])
+  let b := s.prod fun j ↦ x - algebraMap F E j
+  have h1 : ∀ i ∈ s, m i • (b * (x - algebraMap F E i)⁻¹) =
+      m i • (s.erase i).prod fun j ↦ x - algebraMap F E j := fun i hi ↦ by
+    simp_rw [b, ← s.prod_erase_mul _ hi, mul_inv_cancel_right₀ (hnz i)]
+  replace hm := congr(b * $(hm))
+  simp_rw [mul_zero, Finset.mul_sum, mul_smul_comm, Finset.sum_congr rfl h1] at hm
+  let p : Polynomial F := s.sum fun i ↦ .C (m i) * (s.erase i).prod fun j ↦ .X - .C j
+  replace hm := congr(Polynomial.aeval i $(H p (by simp_rw [← hm, p, map_sum, map_mul, map_prod,
+    map_sub, aeval_X, aeval_C, Algebra.smul_def])))
+  have h2 : ∀ j ∈ s.erase i, m j * ((s.erase j).prod fun x ↦ i - x) = 0 := fun j hj ↦ by
+    have := Finset.mem_erase_of_ne_of_mem (Finset.ne_of_mem_erase hj).symm hi
+    simp_rw [← (s.erase j).prod_erase_mul _ this, sub_self, mul_zero]
+  simp_rw [map_zero, p, map_sum, map_mul, map_prod, map_sub, aeval_X,
+    aeval_C, Algebra.id.map_eq_self, ← s.sum_erase_add _ hi,
+    Finset.sum_eq_zero h2, zero_add] at hm
+  exact eq_zero_of_ne_zero_of_mul_right_eq_zero (Finset.prod_ne_zero_iff.2 fun j hj ↦
+    sub_ne_zero.2 (Finset.ne_of_mem_erase hj).symm) hm
+
+end

--- a/Mathlib/RingTheory/Algebraic/LinearIndependent.lean
+++ b/Mathlib/RingTheory/Algebraic/LinearIndependent.lean
@@ -15,7 +15,6 @@ import Mathlib.RingTheory.Algebraic.Defs
   then `{(x - a)⁻¹ | a : F}` is linearly independent over `F`.
 -/
 
-open scoped Classical
 open Polynomial
 
 section
@@ -25,6 +24,7 @@ then `{(x - a)⁻¹ | a : F}` is linearly independent over `F`. -/
 theorem Transcendental.linearIndependent_sub_inv
     {F E : Type*} [Field F] [Field E] [Algebra F E] {x : E} (H : Transcendental F x) :
     LinearIndependent F fun a ↦ (x - algebraMap F E a)⁻¹ := by
+  classical
   rw [transcendental_iff] at H
   refine linearIndependent_iff'.2 fun s m hm i hi ↦ ?_
   have hnz (a : F) : x - algebraMap F E a ≠ 0 := fun h ↦

--- a/Mathlib/RingTheory/Algebraic/MvPolynomial.lean
+++ b/Mathlib/RingTheory/Algebraic/MvPolynomial.lean
@@ -7,12 +7,10 @@ import Mathlib.Algebra.MvPolynomial.Supported
 import Mathlib.RingTheory.Algebraic.Basic
 
 /-!
-# Algebraic elements and algebraic extensions
+# Transcendental elements in `MvPolynomial`
 
-An element of an R-algebra is algebraic over R if it is the root of a nonzero polynomial.
-An R-algebra is algebraic over R if and only if all its elements are algebraic over R.
-The main result in this file proves transitivity of algebraicity:
-a tower of algebraic field extensions is algebraic.
+This file lists some results on some elements in `MvPolynomial σ R` being transcendental
+over the base ring `R` and subrings `MvPolynomial.supported` of `MvPolynomial σ R`.
 -/
 
 universe u v w

--- a/Mathlib/RingTheory/Algebraic/MvPolynomial.lean
+++ b/Mathlib/RingTheory/Algebraic/MvPolynomial.lean
@@ -17,7 +17,6 @@ a tower of algebraic field extensions is algebraic.
 
 universe u v w
 
-open scoped Classical
 open Polynomial
 
 namespace MvPolynomial
@@ -34,6 +33,7 @@ private theorem rename_polynomial_aeval_X
 theorem transcendental_supported_polynomial_aeval_X {i : σ} {s : Set σ} (h : i ∉ s)
     {f : R[X]} (hf : Transcendental R f) :
     Transcendental (supported R s) (Polynomial.aeval (X i : MvPolynomial σ R) f) := by
+  classical
   rw [transcendental_iff_injective] at hf ⊢
   let g := MvPolynomial.mapAlgHom (R := R) (σ := s) (Polynomial.aeval (R := R) f)
   replace hf : Function.Injective g := MvPolynomial.map_injective _ hf

--- a/Mathlib/RingTheory/Algebraic/MvPolynomial.lean
+++ b/Mathlib/RingTheory/Algebraic/MvPolynomial.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2019 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin
+-/
+import Mathlib.Algebra.MvPolynomial.Supported
+import Mathlib.RingTheory.Algebraic.Basic
+
+/-!
+# Algebraic elements and algebraic extensions
+
+An element of an R-algebra is algebraic over R if it is the root of a nonzero polynomial.
+An R-algebra is algebraic over R if and only if all its elements are algebraic over R.
+The main result in this file proves transitivity of algebraicity:
+a tower of algebraic field extensions is algebraic.
+-/
+
+universe u v w
+
+open scoped Classical
+open Polynomial
+
+namespace MvPolynomial
+
+variable {σ : Type*} (R : Type*) [CommRing R]
+
+-- TODO: move to suitable place
+private theorem rename_polynomial_aeval_X
+    {σ τ R : Type*} [CommSemiring R] (f : σ → τ) (i : σ) (p : R[X]) :
+    rename f (Polynomial.aeval (X i) p) = Polynomial.aeval (X (f i) : MvPolynomial τ R) p := by
+  rw [← AlgHom.comp_apply]
+  congr 1; ext1; simp
+
+theorem transcendental_supported_polynomial_aeval_X {i : σ} {s : Set σ} (h : i ∉ s)
+    {f : R[X]} (hf : Transcendental R f) :
+    Transcendental (supported R s) (Polynomial.aeval (X i : MvPolynomial σ R) f) := by
+  rw [transcendental_iff_injective] at hf ⊢
+  let g := MvPolynomial.mapAlgHom (R := R) (σ := s) (Polynomial.aeval (R := R) f)
+  replace hf : Function.Injective g := MvPolynomial.map_injective _ hf
+  let u := (Subalgebra.val _).comp
+    ((optionEquivRight R s).symm |>.trans
+      (renameEquiv R (Set.subtypeInsertEquivOption h).symm) |>.trans
+      (supportedEquivMvPolynomial _).symm).toAlgHom |>.comp
+    g |>.comp
+    ((optionEquivLeft R s).symm.trans (optionEquivRight R s)).toAlgHom
+  let v := ((Polynomial.aeval (R := supported R s)
+    (Polynomial.aeval (X i : MvPolynomial σ R) f)).restrictScalars R).comp
+      (Polynomial.mapAlgEquiv (supportedEquivMvPolynomial s).symm).toAlgHom
+  replace hf : Function.Injective u := by
+    simp only [AlgEquiv.toAlgHom_eq_coe, AlgHom.coe_comp, Subalgebra.coe_val,
+      AlgHom.coe_coe, AlgEquiv.coe_trans, Function.comp_assoc, u]
+    apply Subtype.val_injective.comp
+    simp only [EquivLike.comp_injective]
+    apply hf.comp
+    simp only [EquivLike.comp_injective, EquivLike.injective]
+  have h1 : Polynomial.aeval (X i : MvPolynomial σ R) = ((Subalgebra.val _).comp
+      (supportedEquivMvPolynomial _).symm.toAlgHom |>.comp
+      (Polynomial.aeval (X ⟨i, s.mem_insert i⟩ : MvPolynomial ↑(insert i s) R))) := by
+    ext1; simp
+  have h2 : u = v := by
+    simp only [u, v, g]
+    ext1
+    · ext1
+      simp [Set.subtypeInsertEquivOption, Subalgebra.algebraMap_eq]
+    · simp [Set.subtypeInsertEquivOption, rename_polynomial_aeval_X, h1]
+  simpa only [h2, v, AlgEquiv.toAlgHom_eq_coe, AlgHom.coe_comp, AlgHom.coe_coe,
+    EquivLike.injective_comp, AlgHom.coe_restrictScalars'] using hf
+
+theorem transcendental_polynomial_aeval_X (i : σ) {f : R[X]} (hf : Transcendental R f) :
+    Transcendental R (Polynomial.aeval (X i : MvPolynomial σ R) f) := by
+  have := transcendental_supported_polynomial_aeval_X R (Set.not_mem_empty i) hf
+  let g := (Algebra.botEquivOfInjective (MvPolynomial.C_injective σ R)).symm.trans
+    (Subalgebra.equivOfEq _ _ supported_empty).symm
+  rwa [Transcendental, ← isAlgebraic_ringHom_iff_of_comp_eq g (RingHom.id (MvPolynomial σ R))
+    Function.injective_id (by ext1; rfl), RingHom.id_apply, ← Transcendental]
+
+theorem transcendental_polynomial_aeval_X_iff (i : σ) {f : R[X]} :
+    Transcendental R (Polynomial.aeval (X i : MvPolynomial σ R) f) ↔ Transcendental R f := by
+  refine ⟨?_, transcendental_polynomial_aeval_X R i⟩
+  simp_rw [Transcendental, not_imp_not]
+  exact fun h ↦ h.algHom _
+
+theorem transcendental_supported_polynomial_aeval_X_iff
+    [Nontrivial R] {i : σ} {s : Set σ} {f : R[X]} :
+    Transcendental (supported R s) (Polynomial.aeval (X i : MvPolynomial σ R) f) ↔
+    i ∉ s ∧ Transcendental R f := by
+  refine ⟨fun h ↦ ⟨?_, ?_⟩, fun ⟨h, hf⟩ ↦ transcendental_supported_polynomial_aeval_X R h hf⟩
+  · rw [Transcendental] at h
+    contrapose! h
+    refine isAlgebraic_algebraMap (⟨Polynomial.aeval (X i) f, ?_⟩ : supported R s)
+    exact Algebra.adjoin_mono (Set.singleton_subset_iff.2 (Set.mem_image_of_mem _ h))
+      (Polynomial.aeval_mem_adjoin_singleton _ _)
+  · rw [← transcendental_polynomial_aeval_X_iff R i]
+    refine h.restrictScalars fun _ _ heq ↦ MvPolynomial.C_injective σ R ?_
+    simp_rw [← MvPolynomial.algebraMap_eq]
+    exact congr($(heq).1)
+
+theorem transcendental_supported_X {i : σ} {s : Set σ} (h : i ∉ s) :
+    Transcendental (supported R s) (X i : MvPolynomial σ R) := by
+  simpa using transcendental_supported_polynomial_aeval_X R h (Polynomial.transcendental_X R)
+
+theorem transcendental_X (i : σ) : Transcendental R (X i : MvPolynomial σ R) := by
+  simpa using transcendental_polynomial_aeval_X R i (Polynomial.transcendental_X R)
+
+theorem transcendental_supported_X_iff [Nontrivial R] {i : σ} {s : Set σ} :
+    Transcendental (supported R s) (X i : MvPolynomial σ R) ↔ i ∉ s := by
+  simpa [Polynomial.transcendental_X] using
+    transcendental_supported_polynomial_aeval_X_iff R (i := i) (s := s) (f := Polynomial.X)
+
+end MvPolynomial

--- a/Mathlib/RingTheory/Algebraic/MvPolynomial.lean
+++ b/Mathlib/RingTheory/Algebraic/MvPolynomial.lean
@@ -21,13 +21,6 @@ namespace MvPolynomial
 
 variable {σ : Type*} (R : Type*) [CommRing R]
 
--- TODO: move to suitable place
-private theorem rename_polynomial_aeval_X
-    {σ τ R : Type*} [CommSemiring R] (f : σ → τ) (i : σ) (p : R[X]) :
-    rename f (Polynomial.aeval (X i) p) = Polynomial.aeval (X (f i) : MvPolynomial τ R) p := by
-  rw [← AlgHom.comp_apply]
-  congr 1; ext1; simp
-
 theorem transcendental_supported_polynomial_aeval_X {i : σ} {s : Set σ} (h : i ∉ s)
     {f : R[X]} (hf : Transcendental R f) :
     Transcendental (supported R s) (Polynomial.aeval (X i : MvPolynomial σ R) f) := by
@@ -60,7 +53,7 @@ theorem transcendental_supported_polynomial_aeval_X {i : σ} {s : Set σ} (h : i
     ext1
     · ext1
       simp [Set.subtypeInsertEquivOption, Subalgebra.algebraMap_eq]
-    · simp [Set.subtypeInsertEquivOption, rename_polynomial_aeval_X, h1]
+    · simp [Set.subtypeInsertEquivOption, h1]
   simpa only [h2, v, AlgEquiv.toAlgHom_eq_coe, AlgHom.coe_comp, AlgHom.coe_coe,
     EquivLike.injective_comp, AlgHom.coe_restrictScalars'] using hf
 

--- a/Mathlib/RingTheory/Algebraic/Pi.lean
+++ b/Mathlib/RingTheory/Algebraic/Pi.lean
@@ -16,47 +16,45 @@ assert_not_exists LinearIndependent
 assert_not_exists LocalRing
 assert_not_exists MvPolynomial
 
-universe u v w
-
 open Polynomial
 
 section Pi
 
-variable (R' : Type u) (S' : Type v) (T' : Type w)
+variable (R S T : Type*)
 
 /-- This is not an instance as it forms a diamond with `Pi.instSMul`.
 
 See the `instance_diamonds` test for details. -/
-def Polynomial.hasSMulPi [Semiring R'] [SMul R' S'] : SMul R'[X] (R' → S') :=
+def Polynomial.hasSMulPi [Semiring R] [SMul R S] : SMul R[X] (R → S) :=
   ⟨fun p f x => eval x p • f x⟩
 
 /-- This is not an instance as it forms a diamond with `Pi.instSMul`.
 
 See the `instance_diamonds` test for details. -/
-noncomputable def Polynomial.hasSMulPi' [CommSemiring R'] [Semiring S'] [Algebra R' S']
-    [SMul S' T'] : SMul R'[X] (S' → T') :=
+noncomputable def Polynomial.hasSMulPi' [CommSemiring R] [Semiring S] [Algebra R S]
+    [SMul S T] : SMul R[X] (S → T) :=
   ⟨fun p f x => aeval x p • f x⟩
 
 attribute [local instance] Polynomial.hasSMulPi Polynomial.hasSMulPi'
 
 @[simp]
-theorem polynomial_smul_apply [Semiring R'] [SMul R' S'] (p : R'[X]) (f : R' → S') (x : R') :
+theorem polynomial_smul_apply [Semiring R] [SMul R S] (p : R[X]) (f : R → S) (x : R) :
     (p • f) x = eval x p • f x :=
   rfl
 
 @[simp]
-theorem polynomial_smul_apply' [CommSemiring R'] [Semiring S'] [Algebra R' S'] [SMul S' T']
-    (p : R'[X]) (f : S' → T') (x : S') : (p • f) x = aeval x p • f x :=
+theorem polynomial_smul_apply' [CommSemiring R] [Semiring S] [Algebra R S] [SMul S T]
+    (p : R[X]) (f : S → T) (x : S) : (p • f) x = aeval x p • f x :=
   rfl
 
-variable [CommSemiring R'] [CommSemiring S'] [CommSemiring T'] [Algebra R' S'] [Algebra S' T']
+variable [CommSemiring R] [CommSemiring S] [CommSemiring T] [Algebra R S] [Algebra S T]
 
 -- Porting note: the proofs in this definition used `funext` in term-mode, but I was not able
 -- to get them to work anymore.
 /-- This is not an instance for the same reasons as `Polynomial.hasSMulPi'`. -/
-noncomputable def Polynomial.algebraPi : Algebra R'[X] (S' → T') :=
-  { Polynomial.hasSMulPi' R' S' T' with
-    toFun := fun p z => algebraMap S' T' (aeval z p)
+noncomputable def Polynomial.algebraPi : Algebra R[X] (S → T) :=
+  { Polynomial.hasSMulPi' R S T with
+    toFun := fun p z => algebraMap S T (aeval z p)
     map_one' := by
       funext z
       simp only [Polynomial.aeval_one, Pi.one_apply, map_one]
@@ -81,12 +79,12 @@ attribute [local instance] Polynomial.algebraPi
 
 @[simp]
 theorem Polynomial.algebraMap_pi_eq_aeval :
-    (algebraMap R'[X] (S' → T') : R'[X] → S' → T') = fun p z => algebraMap _ _ (aeval z p) :=
+    (algebraMap R[X] (S → T) : R[X] → S → T) = fun p z => algebraMap _ _ (aeval z p) :=
   rfl
 
 @[simp]
 theorem Polynomial.algebraMap_pi_self_eq_eval :
-    (algebraMap R'[X] (R' → R') : R'[X] → R' → R') = fun p z => eval z p :=
+    (algebraMap R[X] (R → R) : R[X] → R → R) = fun p z => eval z p :=
   rfl
 
 end Pi

--- a/Mathlib/RingTheory/Algebraic/Pi.lean
+++ b/Mathlib/RingTheory/Algebraic/Pi.lean
@@ -18,7 +18,6 @@ assert_not_exists MvPolynomial
 
 universe u v w
 
-open scoped Classical
 open Polynomial
 
 section Pi

--- a/Mathlib/RingTheory/Algebraic/Pi.lean
+++ b/Mathlib/RingTheory/Algebraic/Pi.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2019 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin
+-/
+import Mathlib.Algebra.Polynomial.AlgebraMap
+
+/-!
+# Algebraic functions
+
+This file defines algebraic functions as the image of the `algebraMap R[X] (R → S)`.
+-/
+
+assert_not_exists IsIntegralClosure
+assert_not_exists LinearIndependent
+assert_not_exists LocalRing
+assert_not_exists MvPolynomial
+
+universe u v w
+
+open scoped Classical
+open Polynomial
+
+section Pi
+
+variable (R' : Type u) (S' : Type v) (T' : Type w)
+
+/-- This is not an instance as it forms a diamond with `Pi.instSMul`.
+
+See the `instance_diamonds` test for details. -/
+def Polynomial.hasSMulPi [Semiring R'] [SMul R' S'] : SMul R'[X] (R' → S') :=
+  ⟨fun p f x => eval x p • f x⟩
+
+/-- This is not an instance as it forms a diamond with `Pi.instSMul`.
+
+See the `instance_diamonds` test for details. -/
+noncomputable def Polynomial.hasSMulPi' [CommSemiring R'] [Semiring S'] [Algebra R' S']
+    [SMul S' T'] : SMul R'[X] (S' → T') :=
+  ⟨fun p f x => aeval x p • f x⟩
+
+attribute [local instance] Polynomial.hasSMulPi Polynomial.hasSMulPi'
+
+@[simp]
+theorem polynomial_smul_apply [Semiring R'] [SMul R' S'] (p : R'[X]) (f : R' → S') (x : R') :
+    (p • f) x = eval x p • f x :=
+  rfl
+
+@[simp]
+theorem polynomial_smul_apply' [CommSemiring R'] [Semiring S'] [Algebra R' S'] [SMul S' T']
+    (p : R'[X]) (f : S' → T') (x : S') : (p • f) x = aeval x p • f x :=
+  rfl
+
+variable [CommSemiring R'] [CommSemiring S'] [CommSemiring T'] [Algebra R' S'] [Algebra S' T']
+
+-- Porting note: the proofs in this definition used `funext` in term-mode, but I was not able
+-- to get them to work anymore.
+/-- This is not an instance for the same reasons as `Polynomial.hasSMulPi'`. -/
+noncomputable def Polynomial.algebraPi : Algebra R'[X] (S' → T') :=
+  { Polynomial.hasSMulPi' R' S' T' with
+    toFun := fun p z => algebraMap S' T' (aeval z p)
+    map_one' := by
+      funext z
+      simp only [Polynomial.aeval_one, Pi.one_apply, map_one]
+    map_mul' := fun f g => by
+      funext z
+      simp only [Pi.mul_apply, map_mul]
+    map_zero' := by
+      funext z
+      simp only [Polynomial.aeval_zero, Pi.zero_apply, map_zero]
+    map_add' := fun f g => by
+      funext z
+      simp only [Polynomial.aeval_add, Pi.add_apply, map_add]
+    commutes' := fun p f => by
+      funext z
+      exact mul_comm _ _
+    smul_def' := fun p f => by
+      funext z
+      simp only [polynomial_smul_apply', Algebra.algebraMap_eq_smul_one, RingHom.coe_mk,
+        MonoidHom.coe_mk, OneHom.coe_mk, Pi.mul_apply, Algebra.smul_mul_assoc, one_mul] }
+
+attribute [local instance] Polynomial.algebraPi
+
+@[simp]
+theorem Polynomial.algebraMap_pi_eq_aeval :
+    (algebraMap R'[X] (S' → T') : R'[X] → S' → T') = fun p z => algebraMap _ _ (aeval z p) :=
+  rfl
+
+@[simp]
+theorem Polynomial.algebraMap_pi_self_eq_eval :
+    (algebraMap R'[X] (R' → R') : R'[X] → R' → R') = fun p z => eval z p :=
+  rfl
+
+end Pi

--- a/Mathlib/RingTheory/AlgebraicIndependent.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent.lean
@@ -9,6 +9,7 @@ import Mathlib.FieldTheory.Adjoin
 import Mathlib.FieldTheory.MvRatFunc.Rank
 import Mathlib.RingTheory.Algebraic.Cardinality
 import Mathlib.RingTheory.MvPolynomial.Basic
+import Mathlib.RingTheory.Algebraic.MvPolynomial
 
 /-!
 # Algebraic Independence

--- a/Mathlib/RingTheory/Localization/Integral.lean
+++ b/Mathlib/RingTheory/Localization/Integral.lean
@@ -6,7 +6,7 @@ Authors: Kenny Lau, Mario Carneiro, Johan Commelin, Amelia Livingston, Anne Baan
 import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 import Mathlib.Algebra.Polynomial.Lifts
 import Mathlib.GroupTheory.MonoidLocalization.Basic
-import Mathlib.RingTheory.Algebraic.Basic
+import Mathlib.RingTheory.Algebraic.Integral
 import Mathlib.RingTheory.IntegralClosure.Algebra.Basic
 import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.RingTheory.Localization.Integer

--- a/Mathlib/RingTheory/Localization/Integral.lean
+++ b/Mathlib/RingTheory/Localization/Integral.lean
@@ -6,7 +6,7 @@ Authors: Kenny Lau, Mario Carneiro, Johan Commelin, Amelia Livingston, Anne Baan
 import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 import Mathlib.Algebra.Polynomial.Lifts
 import Mathlib.GroupTheory.MonoidLocalization.Basic
-import Mathlib.RingTheory.Algebraic
+import Mathlib.RingTheory.Algebraic.Basic
 import Mathlib.RingTheory.IntegralClosure.Algebra.Basic
 import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.RingTheory.Localization.Integer

--- a/MathlibTest/instance_diamonds.lean
+++ b/MathlibTest/instance_diamonds.lean
@@ -9,7 +9,7 @@ import Mathlib.Algebra.Module.Pi
 import Mathlib.Algebra.Polynomial.Basic
 import Mathlib.Data.Complex.Module
 import Mathlib.Data.ZMod.Basic
-import Mathlib.RingTheory.Algebraic.Basic
+import Mathlib.RingTheory.Algebraic.Pi
 import Mathlib.RingTheory.TensorProduct.Basic
 
 /-! # Tests that instances do not form diamonds -/

--- a/MathlibTest/instance_diamonds.lean
+++ b/MathlibTest/instance_diamonds.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
+import Mathlib.Algebra.EuclideanDomain.Field
 import Mathlib.Algebra.GroupWithZero.Action.Prod
 import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.Module.Pi

--- a/MathlibTest/instance_diamonds.lean
+++ b/MathlibTest/instance_diamonds.lean
@@ -9,7 +9,7 @@ import Mathlib.Algebra.Module.Pi
 import Mathlib.Algebra.Polynomial.Basic
 import Mathlib.Data.Complex.Module
 import Mathlib.Data.ZMod.Basic
-import Mathlib.RingTheory.Algebraic
+import Mathlib.RingTheory.Algebraic.Basic
 import Mathlib.RingTheory.TensorProduct.Basic
 
 /-! # Tests that instances do not form diamonds -/


### PR DESCRIPTION
Split up the file `RingTheory/Algebraic.lean` into a few subfiles:
* `Algebraic/Defs.lean`: definition of algebraic and transcendental elements and (sub)algebras
* `Algebraic/Integral.lean`: relate `IsAlgebraic` and `IsIntegral`
* `Algebraic/Basic.lean`: most results on showing certain elements are algebraic (this is probably the file you want to import afterwards)
* `Algebraic/LinearIndependent.lean`: showing certain families are linear independent using transcendentality
* `Algebraic/MvPolynomial.lean`: results on multivariate polynomials
* `Algebraic/Pi.lean`: a definition of algebraic function (which seems to be unused otherwise). See also [mathlib3#11156](https://github.com/leanprover-community/mathlib3/pull/11156).

I don't expect a particularly exciting import reduction, but it does clean up the file structure somewhat, in particular by moving the relation between algebraic and integral elements to one dedicated place (which had been irritating me for years!).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
