### PR TITLE
[Merged by Bors] - feat: trigger automated Zulip emojis via `bors x` command

### DIFF
--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -84,7 +84,6 @@ jobs:
           curl --request DELETE \
             --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}${{ github.event.pull_request.number }}/labels/awaiting-author" \
             --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'
-            # comment uses ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' &&

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -85,3 +85,30 @@ jobs:
             --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}${{ github.event.pull_request.number }}/labels/awaiting-author" \
             --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'
             # comment uses ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.merge_or_delegate.outputs.bot == 'true' ) }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.merge_or_delegate.outputs.bot == 'true' ) }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install zulip
+
+      - name: Run Zulip Emoji Merge Delegate Script
+        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.merge_or_delegate.outputs.bot == 'true' ) }}
+        env:
+          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+          ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
+          ZULIP_SITE: https://leanprover.zulipchat.com
+        run: |
+          python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${{ github.event.issue.number }}${{ github.event.pull_request.number }}"

--- a/.github/workflows/zulip_emoji_merge_delegate.yaml
+++ b/.github/workflows/zulip_emoji_merge_delegate.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout mathlib repository
       uses: actions/checkout@v4
       with:
-        fetch-depth: 10 # this number matches the number of lines of the `git log` in the final step
+        fetch-depth: 0 # donwload the full repository
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -31,7 +31,11 @@ jobs:
         ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
         ZULIP_SITE: https://leanprover.zulipchat.com
       run: |
-          printf $'Scanning commits:\n%s\n\nContinuing\n' "$(git log --oneline -n 10)"
+          # scan the commits of the past 10 minutes, assuming that the timezone of the current machine
+          # is the same that performed the commit
+          git log --since="10 minutes ago" --pretty=oneline
+
+          printf $'Scanning commits:\n%s\n\nContinuing\n' "$(git log --since="10 minutes ago" --pretty=oneline)"
           while read -r pr_number; do
             printf $'Running the python script with pr "%s"\n' "${pr_number}"
             python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "[Merged by Bors]" "${pr_number}"

--- a/.github/workflows/zulip_emoji_merge_delegate.yaml
+++ b/.github/workflows/zulip_emoji_merge_delegate.yaml
@@ -1,19 +1,19 @@
 name: Zulip Emoji Merge Delegate
 
 on:
-  schedule:
-    - cron: '0 * * * *'  # Runs every hour
+  push:
+    branches:
+      - master
 
 jobs:
-  zulip-emoji-merge-delegate:
+  zulip-emoji-merged:
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout mathlib repository
       uses: actions/checkout@v4
       with:
-        sparse-checkout: |
-          scripts
+        fetch: 10 # this number matches the number of lines of the `git log` in the final step
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -30,6 +30,7 @@ jobs:
         ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
         ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
         ZULIP_SITE: https://leanprover.zulipchat.com
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "$GITHUB_TOKEN"
+          while read -r pr_number; do
+            python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "[Merged by Bors]" "${pr_number}"
+          done < <(git log --oneline -n 10 | awk -F# '{ gsub(/)$/, ""); print $NF}')

--- a/.github/workflows/zulip_emoji_merge_delegate.yaml
+++ b/.github/workflows/zulip_emoji_merge_delegate.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout mathlib repository
       uses: actions/checkout@v4
       with:
-        fetch: 10 # this number matches the number of lines of the `git log` in the final step
+        fetch-depth: 10 # this number matches the number of lines of the `git log` in the final step
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/zulip_emoji_merge_delegate.yaml
+++ b/.github/workflows/zulip_emoji_merge_delegate.yaml
@@ -31,6 +31,8 @@ jobs:
         ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
         ZULIP_SITE: https://leanprover.zulipchat.com
       run: |
+          printf $'Scanning commits:\n%s\n\nContinuing\n' "$(git log --oneline -n 10)"
           while read -r pr_number; do
+            printf $'Running the python script with pr "%s"\n' "${pr_number}"
             python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "[Merged by Bors]" "${pr_number}"
           done < <(git log --oneline -n 10 | awk -F# '{ gsub(/)$/, ""); print $NF}')

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -94,9 +94,12 @@ please do not add new entries to these files. PRs removing (the need for) entrie
   to the appropriate topic on zulip.
 - `count-trans-deps.py`, `import-graph-report.py` and `import_trans_difference.sh` produce various
   summaries of changes in transitive imports that the `PR_summary` message incorporates.
-- `zulip_emoji_merge_delegate.py` is called every hour by a Github action cronjob.
-  It looks through the latest 200 zulip posts: if a message mentions a PR that is delegated, or sent to bors, or merged,
-  then this script will post an emoji reaction `:peace_sign:`, or `:bors:`, or `:merge:` respectively to the message.
+- `zulip_emoji_merge_delegate.py` is called
+  * every time a `bors d`, `bors merge` or `bors r+` comment is added to a PR and
+  * on every push to `master`.
+  It looks through all zulip posts containing a reference to the relevant PR
+  (either delegated, sent to bors or merge) and it will post an emoji reaction
+  `:peace_sign:`, or `:bors:`, or `:merge:` respectively to the message.
 - `late_importers.sh` is the main script used by the `latest_import.yml` action: it formats
   the `linter.minImports` output, summarizing the data in a table.  See the module docs of
   `late_importers.sh` for further details.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -98,7 +98,7 @@ please do not add new entries to these files. PRs removing (the need for) entrie
   * every time a `bors d`, `bors merge` or `bors r+` comment is added to a PR and
   * on every push to `master`.
   It looks through all zulip posts containing a reference to the relevant PR
-  (either delegated, sent to bors or merge) and it will post an emoji reaction
+  (delegated, or sent to bors, or merged) and it will post an emoji reaction
   `:peace_sign:`, or `:bors:`, or `:merge:` respectively to the message.
 - `late_importers.sh` is the main script used by the `latest_import.yml` action: it formats
   the `linter.minImports` output, summarizing the data in a table.  See the module docs of

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -28,7 +28,6 @@ response = client.get_messages({
     "anchor": "newest",
     "num_before": 200,
     "num_after": 0,
-    "narrow": [{"operator": "channel", "operand": "PR reviews"}],
 })
 
 messages = response['messages']

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -25,79 +25,74 @@ client = zulip.Client(
 
 # Fetch the last 200 messages
 response = client.get_messages({
-    "anchor": "newest",
-    "num_before": 200,
-    "num_after": 0,
+    "operator": "search",
+    "operand": f"https://github\.com/leanprover-community/mathlib4/pull/{PR_NUMBER}",
 })
 
 messages = response['messages']
-pr_pattern = re.compile(r'https://github\.com/leanprover-community/mathlib4/pull/' + re.escape(PR_NUMBER))
-print(f"pr_pattern: '{pr_pattern}'")
 
 for message in messages:
     content = message['content']
-    match = pr_pattern.search(content)
-    if match:
-        print(f"matched: '{message}'")
-        # Check for emoji reactions
-        reactions = message['reactions']
-        has_peace_sign = any(reaction['emoji_name'] == 'peace_sign' for reaction in reactions)
-        has_bors = any(reaction['emoji_name'] == 'bors' for reaction in reactions)
-        has_merge = any(reaction['emoji_name'] == 'merge' for reaction in reactions)
+    print(f"matched: '{message}'")
+    # Check for emoji reactions
+    reactions = message['reactions']
+    has_peace_sign = any(reaction['emoji_name'] == 'peace_sign' for reaction in reactions)
+    has_bors = any(reaction['emoji_name'] == 'bors' for reaction in reactions)
+    has_merge = any(reaction['emoji_name'] == 'merge' for reaction in reactions)
 
-        pr_url = f"https://api.github.com/repos/leanprover-community/mathlib4/pulls/{PR_NUMBER}"
+    pr_url = f"https://api.github.com/repos/leanprover-community/mathlib4/pulls/{PR_NUMBER}"
 
-        print('Removing peace_sign')
-        result = client.remove_reaction({
+    print('Removing peace_sign')
+    result = client.remove_reaction({
+        "message_id": message['id'],
+        "emoji_name": "peace_sign"
+    })
+    print(f"result: '{result}'")
+    print('Removing bors')
+    result = client.remove_reaction({
+        "message_id": message['id'],
+        "emoji_name": "bors"
+    })
+    print(f"result: '{result}'")
+
+    print('Removing merge')
+    result = client.remove_reaction({
+        "message_id": message['id'],
+        "emoji_name": "merge"
+    })
+    print(f"result: '{result}'")
+
+    if 'delegated' == LABEL:
+        print('adding delegated')
+
+        client.add_reaction({
             "message_id": message['id'],
             "emoji_name": "peace_sign"
         })
-        print(f"result: '{result}'")
-        print('Removing bors')
-        result = client.remove_reaction({
-            "message_id": message['id'],
-            "emoji_name": "bors"
-        })
-        print(f"result: '{result}'")
-
-        print('Removing merge')
-        result = client.remove_reaction({
-            "message_id": message['id'],
-            "emoji_name": "merge"
-        })
-        print(f"result: '{result}'")
-
-        if 'delegated' == LABEL:
-            print('adding delegated')
-
-            client.add_reaction({
+    elif 'ready-to-merge' == LABEL:
+        print('adding ready-to-merge')
+        if has_peace_sign:
+            client.remove_reaction({
                 "message_id": message['id'],
                 "emoji_name": "peace_sign"
             })
-        elif 'ready-to-merge' == LABEL:
-            print('adding ready-to-merge')
-            if has_peace_sign:
-                client.remove_reaction({
-                    "message_id": message['id'],
-                    "emoji_name": "peace_sign"
-                })
-            client.add_reaction({
+        client.add_reaction({
+            "message_id": message['id'],
+            "emoji_name": "bors"
+        })
+    elif LABEL.startswith("[Merged by Bors]"):
+        print('adding [Merged by Bors]')
+        if has_peace_sign:
+            client.remove_reaction({
+                "message_id": message['id'],
+                "emoji_name": "peace_sign"
+            })
+        if has_bors:
+            client.remove_reaction({
                 "message_id": message['id'],
                 "emoji_name": "bors"
             })
-        elif LABEL.startswith("[Merged by Bors]"):
-            print('adding [Merged by Bors]')
-            if has_peace_sign:
-                client.remove_reaction({
-                    "message_id": message['id'],
-                    "emoji_name": "peace_sign"
-                })
-            if has_bors:
-                client.remove_reaction({
-                    "message_id": message['id'],
-                    "emoji_name": "bors"
-                })
-            client.add_reaction({
-                "message_id": message['id'],
-                "emoji_name": "merge"
-            })
+        client.add_reaction({
+            "message_id": message['id'],
+            "emoji_name": "merge"
+        })

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
 import sys
 import zulip
-import requests
 import re
 
 # Usage:
-# python scripts/zulip_emoji_merge_delegate.py $ZULIP_API_KEY $ZULIP_EMAIL $ZULIP_SITE $GITHUB_TOKEN
+# python scripts/zulip_emoji_merge_delegate.py $ZULIP_API_KEY $ZULIP_EMAIL $ZULIP_SITE $LABEL $PR_NUMBER
 # See .github/workflows/zulip_emoji_merge_delegate.yaml for the meaning of these variables
 
 ZULIP_API_KEY = sys.argv[1]
 ZULIP_EMAIL = sys.argv[2]
 ZULIP_SITE = sys.argv[3]
-GITHUB_TOKEN = sys.argv[4]
+LABEL = sys.argv[4]
+PR_NUMBER = sys.argv[5]
+
+print(f"LABEL: '{LABEL}'")
+print(f"PR_NUMBER: '{PR_NUMBER}'")
 
 # Initialize Zulip client
 client = zulip.Client(
@@ -29,30 +32,51 @@ response = client.get_messages({
 })
 
 messages = response['messages']
-pr_pattern = re.compile(r'https://github\.com/leanprover-community/mathlib4/pull/(\d+)')
+pr_pattern = re.compile(r'https://github\.com/leanprover-community/mathlib4/pull/' + re.escape(PR_NUMBER))
+print(f"pr_pattern: '{pr_pattern}'")
 
 for message in messages:
     content = message['content']
     match = pr_pattern.search(content)
     if match:
-        pr_number = match.group(1)
+        print(f"matched: '{message}'")
         # Check for emoji reactions
         reactions = message['reactions']
         has_peace_sign = any(reaction['emoji_name'] == 'peace_sign' for reaction in reactions)
         has_bors = any(reaction['emoji_name'] == 'bors' for reaction in reactions)
         has_merge = any(reaction['emoji_name'] == 'merge' for reaction in reactions)
 
-        pr_url = f"https://api.github.com/repos/leanprover-community/mathlib4/pulls/{pr_number}"
-        pr_response = requests.get(pr_url, headers={"Authorization": GITHUB_TOKEN})
-        pr_data = pr_response.json()
-        labels = [label['name'] for label in pr_data['labels']]
+        pr_url = f"https://api.github.com/repos/leanprover-community/mathlib4/pulls/{PR_NUMBER}"
 
-        if 'delegated' in labels:
+        print('Removing peace_sign')
+        result = client.remove_reaction({
+            "message_id": message['id'],
+            "emoji_name": "peace_sign"
+        })
+        print(f"result: '{result}'")
+        print('Removing bors')
+        result = client.remove_reaction({
+            "message_id": message['id'],
+            "emoji_name": "bors"
+        })
+        print(f"result: '{result}'")
+
+        print('Removing merge')
+        result = client.remove_reaction({
+            "message_id": message['id'],
+            "emoji_name": "merge"
+        })
+        print(f"result: '{result}'")
+
+        if 'delegated' == LABEL:
+            print('adding delegated')
+
             client.add_reaction({
                 "message_id": message['id'],
                 "emoji_name": "peace_sign"
             })
-        elif 'ready-to-merge' in labels:
+        elif 'ready-to-merge' == LABEL:
+            print('adding ready-to-merge')
             if has_peace_sign:
                 client.remove_reaction({
                     "message_id": message['id'],
@@ -62,7 +86,8 @@ for message in messages:
                 "message_id": message['id'],
                 "emoji_name": "bors"
             })
-        elif pr_data['title'].startswith("[Merged by Bors]"):
+        elif LABEL.startswith("[Merged by Bors]"):
+            print('adding [Merged by Bors]')
             if has_peace_sign:
                 client.remove_reaction({
                     "message_id": message['id'],


### PR DESCRIPTION
Changes the way in which emoji reactions to `delegated`, `ready-to-merge` and `merged` are applied in Zulip: instead of running periodically a script to add the reactions, the reactions are now applied at the same time that the label is applied, or when PRs are merged into master.

---

The test PR is #19367: I was using #19367 as PR to test, but the mechanism to apply/remove the labels was simply using `push`, since triggering the action with a comment could only be done if the script was already on master.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
