### PR TITLE
[Merged by Bors] - chore(Algebra/Polynomial): don't import `Ideal` when defining `Polynomial.roots`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4215,6 +4215,7 @@ import Mathlib.RingTheory.Adjoin.Basic
 import Mathlib.RingTheory.Adjoin.Dimension
 import Mathlib.RingTheory.Adjoin.FG
 import Mathlib.RingTheory.Adjoin.Field
+import Mathlib.RingTheory.Adjoin.Polynomial
 import Mathlib.RingTheory.Adjoin.PowerBasis
 import Mathlib.RingTheory.Adjoin.Tower
 import Mathlib.RingTheory.AdjoinRoot
@@ -4474,6 +4475,7 @@ import Mathlib.RingTheory.Polynomial.Eisenstein.IsIntegral
 import Mathlib.RingTheory.Polynomial.GaussLemma
 import Mathlib.RingTheory.Polynomial.Hermite.Basic
 import Mathlib.RingTheory.Polynomial.Hermite.Gaussian
+import Mathlib.RingTheory.Polynomial.Ideal
 import Mathlib.RingTheory.Polynomial.IntegralNormalization
 import Mathlib.RingTheory.Polynomial.IrreducibleRing
 import Mathlib.RingTheory.Polynomial.Nilpotent

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -3,11 +3,10 @@ Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser, Jujian Zhang
 -/
-import Mathlib.Algebra.Module.BigOperators
 import Mathlib.Algebra.Group.Subgroup.Pointwise
 import Mathlib.Algebra.Order.Group.Action
-import Mathlib.RingTheory.Ideal.Span
-import Mathlib.LinearAlgebra.Finsupp.LinearCombination
+import Mathlib.LinearAlgebra.Finsupp.Supported
+import Mathlib.LinearAlgebra.Span.Basic
 
 /-! # Pointwise instances on `Submodule`s
 
@@ -39,6 +38,7 @@ Other than section `set_acting_on_submodules`, most of the lemmas in this file a
 lemmas from the file `Mathlib.Algebra.Group.Submonoid.Pointwise`.
 -/
 
+assert_not_exists Ideal
 
 variable {α : Type*} {R : Type*} {M : Type*}
 
@@ -526,33 +526,6 @@ lemma sup_set_smul (s t : Set S) :
         · exact Submodule.mem_sup_right (mem_set_smul_of_mem_mem hr hn))
     (sup_le (set_smul_mono_left _ le_sup_left) (set_smul_mono_left _ le_sup_right))
 
-lemma coe_span_smul {R' M' : Type*} [CommSemiring R'] [AddCommMonoid M'] [Module R' M']
-    (s : Set R') (N : Submodule R' M') :
-    (Ideal.span s : Set R') • N = s • N :=
-  set_smul_eq_of_le _ _ _
-    (by rintro r n hr hn
-        induction hr using Submodule.span_induction with
-        | mem _ h => exact mem_set_smul_of_mem_mem h hn
-        | zero => rw [zero_smul]; exact Submodule.zero_mem _
-        | add _ _ _ _ ihr ihs => rw [add_smul]; exact Submodule.add_mem _ ihr ihs
-        | smul _ _ hr =>
-          rw [mem_span_set] at hr
-          obtain ⟨c, hc, rfl⟩ := hr
-          rw [Finsupp.sum, Finset.smul_sum, Finset.sum_smul]
-          refine Submodule.sum_mem _ fun i hi => ?_
-          rw [← mul_smul, smul_eq_mul, mul_comm, mul_smul]
-          exact mem_set_smul_of_mem_mem (hc hi) <| Submodule.smul_mem _ _ hn) <|
-    set_smul_mono_left _ Submodule.subset_span
-
 end set_acting_on_submodules
 
-lemma span_singleton_toAddSubgroup_eq_zmultiples (a : ℤ) :
-    (span ℤ {a}).toAddSubgroup = AddSubgroup.zmultiples a := by
-  ext i
-  simp [Ideal.mem_span_singleton', AddSubgroup.mem_zmultiples_iff]
-
 end Submodule
-
-@[simp] lemma Ideal.span_singleton_toAddSubgroup_eq_zmultiples (a : ℤ) :
-   (Ideal.span {a}).toAddSubgroup = AddSubgroup.zmultiples a :=
-  Submodule.span_singleton_toAddSubgroup_eq_zmultiples _

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -4,11 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker
 -/
 import Mathlib.Algebra.Algebra.Pi
+import Mathlib.Algebra.Algebra.Subalgebra.Basic
+import Mathlib.Algebra.Algebra.Tower
 import Mathlib.Algebra.MonoidAlgebra.Basic
 import Mathlib.Algebra.Polynomial.Eval.Algebra
 import Mathlib.Algebra.Polynomial.Eval.Degree
 import Mathlib.Algebra.Polynomial.Monomial
-import Mathlib.RingTheory.Adjoin.Basic
 
 /-!
 # Theory of univariate polynomials
@@ -17,6 +18,7 @@ We show that `A[X]` is an R-algebra when `A` is an R-algebra.
 We promote `eval₂` to an algebra hom in `aeval`.
 -/
 
+assert_not_exists Ideal
 
 noncomputable section
 
@@ -230,13 +232,6 @@ This is a stronger variant of the linear map `Polynomial.leval`. -/
 def aeval : R[X] →ₐ[R] A :=
   eval₂AlgHom' (Algebra.ofId _ _) x (Algebra.commutes · _)
 
-@[simp]
-theorem adjoin_X : Algebra.adjoin R ({X} : Set R[X]) = ⊤ := by
-  refine top_unique fun p _hp => ?_
-  set S := Algebra.adjoin R ({X} : Set R[X])
-  rw [← sum_monomial_eq p]; simp only [← smul_X_eq_monomial, Sum]
-  exact S.sum_mem fun n _hn => S.smul_mem (S.pow_mem (Algebra.subset_adjoin rfl) _) _
-
 @[ext 1200]
 theorem algHom_ext {f g : R[X] →ₐ[R] B} (hX : f X = g X) :
     f = g :=
@@ -414,31 +409,6 @@ theorem aeval_eq_zero_of_dvd_aeval_eq_zero [CommSemiring S] [CommSemiring T] [Al
     {p q : S[X]} (h₁ : p ∣ q) {a : T} (h₂ : aeval a p = 0) : aeval a q = 0 := by
   rw [aeval_def, ← eval_map] at h₂ ⊢
   exact eval_eq_zero_of_dvd_of_eval_eq_zero (Polynomial.map_dvd (algebraMap S T) h₁) h₂
-
-variable (R)
-
-theorem _root_.Algebra.adjoin_singleton_eq_range_aeval (x : A) :
-    Algebra.adjoin R {x} = (Polynomial.aeval x).range := by
-  rw [← Algebra.map_top, ← adjoin_X, AlgHom.map_adjoin, Set.image_singleton, aeval_X]
-
-@[simp]
-theorem aeval_mem_adjoin_singleton :
-    aeval x p ∈ Algebra.adjoin R {x} := by
-  simpa only [Algebra.adjoin_singleton_eq_range_aeval] using Set.mem_range_self p
-
-instance instCommSemiringAdjoinSingleton :
-    CommSemiring <| Algebra.adjoin R {x} :=
-  { mul_comm := fun ⟨p, hp⟩ ⟨q, hq⟩ ↦ by
-      obtain ⟨p', rfl⟩ := Algebra.adjoin_singleton_eq_range_aeval R x ▸ hp
-      obtain ⟨q', rfl⟩ := Algebra.adjoin_singleton_eq_range_aeval R x ▸ hq
-      simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_coe, MulMemClass.mk_mul_mk, ← map_mul,
-        mul_comm p' q'] }
-
-instance instCommRingAdjoinSingleton {R A : Type*} [CommRing R] [Ring A] [Algebra R A] (x : A) :
-    CommRing <| Algebra.adjoin R {x} :=
-  { mul_comm := mul_comm }
-
-variable {R}
 
 section Semiring
 

--- a/Mathlib/Algebra/Polynomial/Derivation.lean
+++ b/Mathlib/Algebra/Polynomial/Derivation.lean
@@ -6,6 +6,7 @@ Authors: Kevin Buzzard, Richard M. Hill
 import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.Algebra.Polynomial.Derivative
 import Mathlib.Algebra.Polynomial.Module.AEval
+import Mathlib.RingTheory.Adjoin.Polynomial
 import Mathlib.RingTheory.Derivation.Basic
 /-!
 # Derivations of univariate polynomials

--- a/Mathlib/Algebra/Polynomial/Div.lean
+++ b/Mathlib/Algebra/Polynomial/Div.lean
@@ -3,10 +3,11 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker
 -/
+import Mathlib.Algebra.Field.IsField
 import Mathlib.Algebra.Polynomial.Inductions
 import Mathlib.Algebra.Polynomial.Monic
+import Mathlib.Algebra.Ring.Regular
 import Mathlib.RingTheory.Multiplicity
-import Mathlib.RingTheory.Ideal.Maps
 
 /-!
 # Division of univariate polynomials
@@ -15,7 +16,6 @@ The main defs are `divByMonic` and `modByMonic`.
 The compatibility between these is given by `modByMonic_add_div`.
 We also define `rootMultiplicity`.
 -/
-
 
 noncomputable section
 
@@ -592,16 +592,6 @@ theorem dvd_iff_isRoot : X - C a ∣ p ↔ IsRoot p a :=
 theorem X_sub_C_dvd_sub_C_eval : X - C a ∣ p - C (p.eval a) := by
   rw [dvd_iff_isRoot, IsRoot, eval_sub, eval_C, sub_self]
 
-theorem mem_span_C_X_sub_C_X_sub_C_iff_eval_eval_eq_zero {b : R[X]} {P : R[X][X]} :
-    P ∈ Ideal.span {C (X - C a), X - C b} ↔ (P.eval b).eval a = 0 := by
-  rw [Ideal.mem_span_pair]
-  constructor <;> intro h
-  · rcases h with ⟨_, _, rfl⟩
-    simp only [eval_C, eval_X, eval_add, eval_sub, eval_mul, add_zero, mul_zero, sub_self]
-  · rcases dvd_iff_isRoot.mpr h with ⟨p, hp⟩
-    rcases @X_sub_C_dvd_sub_C_eval _ b _ P with ⟨q, hq⟩
-    exact ⟨C p, q, by rw [mul_comm, mul_comm q, eq_add_of_sub_eq' hq, hp, C_mul]⟩
-
 -- TODO: generalize this to Ring. In general, 0 can be replaced by any element in the center of R.
 theorem modByMonic_X (p : R[X]) : p %ₘ X = C (p.eval 0) := by
   rw [← modByMonic_X_sub_C_eq_C_eval, C_0, sub_zero]
@@ -614,10 +604,6 @@ theorem sub_dvd_eval_sub (a b : R) (p : R[X]) : a - b ∣ p.eval a - p.eval b :=
   suffices X - C b ∣ p - C (p.eval b) by
     simpa only [coe_evalRingHom, eval_sub, eval_X, eval_C] using (evalRingHom a).map_dvd this
   simp [dvd_iff_isRoot]
-
-theorem ker_evalRingHom (x : R) : RingHom.ker (evalRingHom x) = Ideal.span {X - C x} := by
-  ext y
-  simp [Ideal.mem_span_singleton, dvd_iff_isRoot, RingHom.mem_ker]
 
 @[simp]
 theorem rootMultiplicity_eq_zero_iff {p : R[X]} {x : R} :

--- a/Mathlib/Algebra/Polynomial/PartialFractions.lean
+++ b/Mathlib/Algebra/Polynomial/PartialFractions.lean
@@ -5,6 +5,7 @@ Authors: Kevin Buzzard, Sidharth Hariharan
 -/
 import Mathlib.Algebra.Polynomial.Div
 import Mathlib.Logic.Function.Basic
+import Mathlib.RingTheory.Coprime.Lemmas
 import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.LinearCombination

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -6,7 +6,6 @@ Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker, Johan Comm
 import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.Algebra.Polynomial.Div
 import Mathlib.RingTheory.Coprime.Basic
-import Mathlib.RingTheory.Ideal.Span
 
 /-!
 # Theory of univariate polynomials

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -6,6 +6,7 @@ Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker, Johan Comm
 import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.Algebra.Polynomial.Div
 import Mathlib.RingTheory.Coprime.Basic
+import Mathlib.RingTheory.Ideal.Span
 
 /-!
 # Theory of univariate polynomials

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -67,11 +67,6 @@ theorem mem_ker_modByMonic (hq : q.Monic) {p : R[X]} :
     p ∈ LinearMap.ker (modByMonicHom q) ↔ q ∣ p :=
   LinearMap.mem_ker.trans (modByMonic_eq_zero_iff_dvd hq)
 
-@[simp]
-theorem ker_modByMonicHom (hq : q.Monic) :
-    LinearMap.ker (Polynomial.modByMonicHom q) = (Ideal.span {q}).restrictScalars R :=
-  Submodule.ext fun _ => (mem_ker_modByMonic hq).trans Ideal.mem_span_singleton.symm
-
 section
 
 variable [Ring S]

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker, Johan Commelin
 -/
 import Mathlib.Algebra.Polynomial.AlgebraMap
-import Mathlib.Algebra.Polynomial.Degree.Lemmas
 import Mathlib.Algebra.Polynomial.Div
+import Mathlib.RingTheory.Coprime.Basic
 
 /-!
 # Theory of univariate polynomials
@@ -13,6 +13,8 @@ import Mathlib.Algebra.Polynomial.Div
 We prove basic results about univariate polynomials.
 
 -/
+
+assert_not_exists Ideal.map
 
 noncomputable section
 

--- a/Mathlib/Algebra/Polynomial/Roots.lean
+++ b/Mathlib/Algebra/Polynomial/Roots.lean
@@ -29,6 +29,8 @@ We define the multiset of roots of a polynomial, and prove basic results about i
 
 -/
 
+assert_not_exists Ideal
+
 open Multiset Finset
 
 noncomputable section

--- a/Mathlib/Algebra/Polynomial/Roots.lean
+++ b/Mathlib/Algebra/Polynomial/Roots.lean
@@ -5,8 +5,8 @@ Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker, Johan Comm
 -/
 import Mathlib.Algebra.Polynomial.BigOperators
 import Mathlib.Algebra.Polynomial.RingDivision
-import Mathlib.Data.Fintype.Pi
 import Mathlib.Data.Set.Finite.Lemmas
+import Mathlib.RingTheory.Coprime.Lemmas
 import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.SetTheory.Cardinal.Basic
 

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -6,6 +6,7 @@ Authors: Chris Hughes
 import Mathlib.Algebra.Polynomial.FieldDivision
 import Mathlib.Algebra.Polynomial.Lifts
 import Mathlib.Data.List.Prime
+import Mathlib.RingTheory.Adjoin.Basic
 import Mathlib.RingTheory.Polynomial.Tower
 
 /-!

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Field.Subfield.Defs
 import Mathlib.Algebra.Order.Group.Pointwise.Interval
 import Mathlib.Analysis.Normed.Group.Constructions
 import Mathlib.Analysis.Normed.Group.Submodule
+import Mathlib.Algebra.Ring.Regular
 
 /-!
 # Normed fields

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
+import Mathlib.Algebra.Algebra.Subalgebra.Tower
 import Mathlib.Algebra.Field.IsField
 import Mathlib.Algebra.Field.Subfield.Basic
 import Mathlib.Algebra.Polynomial.AlgebraMap

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -9,6 +9,7 @@ import Mathlib.Data.Matrix.Block
 import Mathlib.Data.Matrix.Notation
 import Mathlib.LinearAlgebra.Matrix.StdBasis
 import Mathlib.RingTheory.AlgebraTower
+import Mathlib.RingTheory.Ideal.Span
 
 /-!
 # Linear maps and matrices

--- a/Mathlib/RingTheory/Adjoin/Basic.lean
+++ b/Mathlib/RingTheory/Adjoin/Basic.lean
@@ -22,6 +22,7 @@ adjoin, algebra
 
 -/
 
+assert_not_exists Polynomial
 
 universe uR uS uA uB
 

--- a/Mathlib/RingTheory/Adjoin/Polynomial.lean
+++ b/Mathlib/RingTheory/Adjoin/Polynomial.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2018 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker
+-/
+import Mathlib.Algebra.Polynomial.AlgebraMap
+import Mathlib.RingTheory.Adjoin.Basic
+
+/-!
+# Polynomials and adjoining roots
+
+## Main results
+
+* `Polynomial.instCommSemiringAdjoinSingleton, instCommRingAdjoinSingleton`:
+  adjoining an element to a commutative (semi)ring gives a commutative (semi)ring
+-/
+
+noncomputable section
+
+open Finset
+
+open Polynomial
+
+namespace Polynomial
+
+universe u v w z
+
+variable {R : Type u} {S : Type v} {T : Type w} {A : Type z} {A' B : Type*} {a b : R} {n : ℕ}
+
+section aeval
+
+variable [CommSemiring R] [Semiring A] [CommSemiring A'] [Semiring B]
+variable [Algebra R A] [Algebra R B]
+variable {p q : R[X]} (x : A)
+
+@[simp]
+theorem adjoin_X : Algebra.adjoin R ({X} : Set R[X]) = ⊤ := by
+  refine top_unique fun p _hp => ?_
+  set S := Algebra.adjoin R ({X} : Set R[X])
+  rw [← sum_monomial_eq p]; simp only [← smul_X_eq_monomial, Sum]
+  exact S.sum_mem fun n _hn => S.smul_mem (S.pow_mem (Algebra.subset_adjoin rfl) _) _
+
+variable (R)
+theorem _root_.Algebra.adjoin_singleton_eq_range_aeval (x : A) :
+    Algebra.adjoin R {x} = (Polynomial.aeval x).range := by
+  rw [← Algebra.map_top, ← adjoin_X, AlgHom.map_adjoin, Set.image_singleton, aeval_X]
+
+@[simp]
+theorem aeval_mem_adjoin_singleton :
+    aeval x p ∈ Algebra.adjoin R {x} := by
+  simpa only [Algebra.adjoin_singleton_eq_range_aeval] using Set.mem_range_self p
+
+instance instCommSemiringAdjoinSingleton :
+    CommSemiring <| Algebra.adjoin R {x} :=
+  { mul_comm := fun ⟨p, hp⟩ ⟨q, hq⟩ ↦ by
+      obtain ⟨p', rfl⟩ := Algebra.adjoin_singleton_eq_range_aeval R x ▸ hp
+      obtain ⟨q', rfl⟩ := Algebra.adjoin_singleton_eq_range_aeval R x ▸ hq
+      simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_coe, MulMemClass.mk_mul_mk, ← map_mul,
+        mul_comm p' q'] }
+
+instance instCommRingAdjoinSingleton {R A : Type*} [CommRing R] [Ring A] [Algebra R A] (x : A) :
+    CommRing <| Algebra.adjoin R {x} :=
+  { mul_comm := mul_comm }
+
+end aeval
+
+end Polynomial

--- a/Mathlib/RingTheory/Algebraic/MvPolynomial.lean
+++ b/Mathlib/RingTheory/Algebraic/MvPolynomial.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 import Mathlib.Algebra.MvPolynomial.Supported
+import Mathlib.RingTheory.Adjoin.Polynomial
 import Mathlib.RingTheory.Algebraic.Basic
 
 /-!

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 import Mathlib.Algebra.FreeAlgebra
+import Mathlib.RingTheory.Adjoin.Polynomial
 import Mathlib.RingTheory.Adjoin.Tower
 import Mathlib.RingTheory.Ideal.Quotient.Operations
 import Mathlib.RingTheory.Noetherian.Orzech

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson, Scott Carnahan
 -/
 import Mathlib.Algebra.Algebra.Subalgebra.Basic
+import Mathlib.Algebra.Module.BigOperators
 import Mathlib.Data.Finset.MulAntidiagonal
 import Mathlib.Data.Finset.SMulAntidiagonal
 import Mathlib.GroupTheory.GroupAction.Ring

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
 import Mathlib.Algebra.Algebra.Operations
+import Mathlib.Algebra.Module.BigOperators
 import Mathlib.Data.Fintype.Lattice
 import Mathlib.RingTheory.Coprime.Lemmas
 import Mathlib.RingTheory.Ideal.Basic
@@ -21,6 +22,33 @@ universe u v w x
 open Pointwise
 
 namespace Submodule
+
+lemma coe_span_smul {R' M' : Type*} [CommSemiring R'] [AddCommMonoid M'] [Module R' M']
+    (s : Set R') (N : Submodule R' M') :
+    (Ideal.span s : Set R') • N = s • N :=
+  set_smul_eq_of_le _ _ _
+    (by rintro r n hr hn
+        induction hr using Submodule.span_induction with
+        | mem _ h => exact mem_set_smul_of_mem_mem h hn
+        | zero => rw [zero_smul]; exact Submodule.zero_mem _
+        | add _ _ _ _ ihr ihs => rw [add_smul]; exact Submodule.add_mem _ ihr ihs
+        | smul _ _ hr =>
+          rw [mem_span_set] at hr
+          obtain ⟨c, hc, rfl⟩ := hr
+          rw [Finsupp.sum, Finset.smul_sum, Finset.sum_smul]
+          refine Submodule.sum_mem _ fun i hi => ?_
+          rw [← mul_smul, smul_eq_mul, mul_comm, mul_smul]
+          exact mem_set_smul_of_mem_mem (hc hi) <| Submodule.smul_mem _ _ hn) <|
+    set_smul_mono_left _ Submodule.subset_span
+
+lemma span_singleton_toAddSubgroup_eq_zmultiples (a : ℤ) :
+    (span ℤ {a}).toAddSubgroup = AddSubgroup.zmultiples a := by
+  ext i
+  simp [Ideal.mem_span_singleton', AddSubgroup.mem_zmultiples_iff]
+
+@[simp] lemma _root_.Ideal.span_singleton_toAddSubgroup_eq_zmultiples (a : ℤ) :
+   (Ideal.span {a}).toAddSubgroup = AddSubgroup.zmultiples a :=
+  Submodule.span_singleton_toAddSubgroup_eq_zmultiples _
 
 variable {R : Type u} {M : Type v} {M' F G : Type*}
 

--- a/Mathlib/RingTheory/IntegralClosure/IsIntegral/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegral/Basic.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau
 -/
 import Mathlib.RingTheory.IntegralClosure.IsIntegral.Defs
 import Mathlib.Algebra.Polynomial.Expand
+import Mathlib.RingTheory.Adjoin.Polynomial
 import Mathlib.RingTheory.Finiteness.Subalgebra
 import Mathlib.RingTheory.Polynomial.Tower
 

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -5,6 +5,7 @@ Authors: Andrew Yang
 -/
 import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.Algebra.Module.ULift
+import Mathlib.Tactic.Ring
 
 /-!
 # The characteristic predicate of tensor product

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.Algebra.Module.ULift
+import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.Tactic.Ring
 
 /-!

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Algebra.Tower
 import Mathlib.Algebra.Field.IsField
 import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 import Mathlib.GroupTheory.MonoidLocalization.MonoidWithZero
-import Mathlib.RingTheory.Ideal.Defs
 import Mathlib.RingTheory.Localization.Defs
 import Mathlib.RingTheory.OreLocalization.Ring
 
@@ -68,6 +67,7 @@ localization, ring localization, commutative ring localization, characteristic p
 commutative ring, field of fractions
 -/
 
+assert_not_exists Ideal
 
 open Function
 
@@ -81,15 +81,6 @@ namespace IsLocalization
 section IsLocalization
 
 variable [IsLocalization M S]
-
-theorem mk'_mem_iff {x} {y : M} {I : Ideal S} : mk' S x y ∈ I ↔ algebraMap R S x ∈ I := by
-  constructor <;> intro h
-  · rw [← mk'_spec S x y, mul_comm]
-    exact I.mul_mem_left ((algebraMap R S) y) h
-  · rw [← mk'_spec S x y] at h
-    obtain ⟨b, hb⟩ := isUnit_iff_exists_inv.1 (map_units S y)
-    have := I.mul_mem_left b h
-    rwa [mul_comm, mul_assoc, hb, mul_one] at this
 
 variable (M S) in
 include M in

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -33,6 +33,7 @@ localization, ring localization, commutative ring localization, characteristic p
 commutative ring, field of fractions
 -/
 
+assert_not_exists Ideal
 
 variable (R : Type*) [CommRing R] {M : Submonoid R} (S : Type*) [CommRing S]
 variable [Algebra R S] {P : Type*} [CommRing P]

--- a/Mathlib/RingTheory/Localization/Ideal.lean
+++ b/Mathlib/RingTheory/Localization/Ideal.lean
@@ -5,7 +5,7 @@ Authors: Kenny Lau, Mario Carneiro, Johan Commelin, Amelia Livingston, Anne Baan
 -/
 import Mathlib.GroupTheory.MonoidLocalization.Away
 import Mathlib.RingTheory.Ideal.Quotient.Operations
-import Mathlib.RingTheory.Localization.Basic
+import Mathlib.RingTheory.Localization.Defs
 
 /-!
 # Ideals in localizations of commutative rings
@@ -23,6 +23,16 @@ section CommSemiring
 
 variable {R : Type*} [CommSemiring R] (M : Submonoid R) (S : Type*) [CommSemiring S]
 variable [Algebra R S] [IsLocalization M S]
+
+variable {M S} in
+theorem mk'_mem_iff {x} {y : M} {I : Ideal S} : mk' S x y ∈ I ↔ algebraMap R S x ∈ I := by
+  constructor <;> intro h
+  · rw [← mk'_spec S x y, mul_comm]
+    exact I.mul_mem_left ((algebraMap R S) y) h
+  · rw [← mk'_spec S x y] at h
+    obtain ⟨b, hb⟩ := isUnit_iff_exists_inv.1 (map_units S y)
+    have := I.mul_mem_left b h
+    rwa [mul_comm, mul_assoc, hb, mul_one] at this
 
 /-- Explicit characterization of the ideal given by `Ideal.map (algebraMap R S) I`.
 In practice, this ideal differs only in that the carrier set is defined explicitly.

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -8,7 +8,6 @@ import Mathlib.Algebra.GeomSum
 import Mathlib.Algebra.MvPolynomial.CommRing
 import Mathlib.Algebra.MvPolynomial.Equiv
 import Mathlib.Algebra.Polynomial.BigOperators
-import Mathlib.Algebra.Polynomial.Div
 import Mathlib.RingTheory.Noetherian.Basic
 
 /-!
@@ -751,37 +750,6 @@ theorem is_fg_degreeLE [IsNoetherianRing R] (I : Ideal R[X]) (n : ℕ) :
   isNoetherian_submodule_left.1
     (isNoetherian_of_fg_of_noetherian _ ⟨_, degreeLE_eq_span_X_pow.symm⟩) _
 
-open Algebra in
-lemma _root_.Algebra.mem_ideal_map_adjoin {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
-    (x : S) (I : Ideal R) {y : adjoin R ({x} : Set S)} :
-    y ∈ I.map (algebraMap R (adjoin R ({x} : Set S))) ↔
-      ∃ p : R[X], (∀ i, p.coeff i ∈ I) ∧ Polynomial.aeval x p = y := by
-  constructor
-  · intro H
-    induction' H using Submodule.span_induction with a ha a b ha hb ha' hb' a b hb hb'
-    · obtain ⟨a, ha, rfl⟩ := ha
-      exact ⟨C a, fun i ↦ by rw [coeff_C]; aesop, aeval_C _ _⟩
-    · exact ⟨0, by simp, aeval_zero _⟩
-    · obtain ⟨a, ha, ha'⟩ := ha'
-      obtain ⟨b, hb, hb'⟩ := hb'
-      exact ⟨a + b, fun i ↦ by simpa using add_mem (ha i) (hb i), by simp [ha', hb']⟩
-    · obtain ⟨b', hb, hb'⟩ := hb'
-      obtain ⟨a, ha⟩ := a
-      rw [Algebra.adjoin_singleton_eq_range_aeval] at ha
-      obtain ⟨p, hp : aeval x p = a⟩ := ha
-      refine ⟨p * b', fun i ↦ ?_, by simp [hp, hb']⟩
-      rw [coeff_mul]
-      exact sum_mem fun i hi ↦ Ideal.mul_mem_left _ _ (hb _)
-  · rintro ⟨p, hp, hp'⟩
-    have : y = ∑ i in p.support, p.coeff i • ⟨_, (X ^ i).aeval_mem_adjoin_singleton _ x⟩ := by
-      trans ∑ i in p.support, ⟨_, (C (p.coeff i) * X ^ i).aeval_mem_adjoin_singleton _ x⟩
-      · ext1
-        simp only [AddSubmonoidClass.coe_finset_sum, ← map_sum, ← hp', ← as_sum_support_C_mul_X_pow]
-      · congr with i
-        simp [Algebra.smul_def]
-    simp_rw [this, Algebra.smul_def]
-    exact sum_mem fun i _ ↦ Ideal.mul_mem_right _ _ (Ideal.mem_map_of_mem _ (hp i))
-
 end CommRing
 
 end Ideal
@@ -815,26 +783,6 @@ theorem mem_span_C_coeff : f ∈ Ideal.span { g : R[X] | ∃ i : ℕ, g = C (coe
 
 theorem exists_C_coeff_not_mem : f ∉ I → ∃ i : ℕ, C (coeff f i) ∉ I :=
   Not.imp_symm fun cf => span_le_of_C_coeff_mem (not_exists_not.mp cf) mem_span_C_coeff
-
-namespace Polynomial
-
-variable {R : Type*} [CommRing R] {a : R}
-
-theorem mem_span_C_X_sub_C_X_sub_C_iff_eval_eval_eq_zero {b : R[X]} {P : R[X][X]} :
-    P ∈ Ideal.span {C (X - C a), X - C b} ↔ (P.eval b).eval a = 0 := by
-  rw [Ideal.mem_span_pair]
-  constructor <;> intro h
-  · rcases h with ⟨_, _, rfl⟩
-    simp only [eval_C, eval_X, eval_add, eval_sub, eval_mul, add_zero, mul_zero, sub_self]
-  · rcases dvd_iff_isRoot.mpr h with ⟨p, hp⟩
-    rcases @X_sub_C_dvd_sub_C_eval _ b _ P with ⟨q, hq⟩
-    exact ⟨C p, q, by rw [mul_comm, mul_comm q, eq_add_of_sub_eq' hq, hp, C_mul]⟩
-
-theorem ker_evalRingHom (x : R) : RingHom.ker (evalRingHom x) = Ideal.span {X - C x} := by
-  ext y
-  simp [Ideal.mem_span_singleton, dvd_iff_isRoot, RingHom.mem_ker]
-
-end Polynomial
 
 end Ideal
 

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.GeomSum
 import Mathlib.Algebra.MvPolynomial.CommRing
 import Mathlib.Algebra.MvPolynomial.Equiv
 import Mathlib.Algebra.Polynomial.BigOperators
+import Mathlib.Algebra.Polynomial.Div
 import Mathlib.RingTheory.Noetherian.Basic
 
 /-!
@@ -814,6 +815,26 @@ theorem mem_span_C_coeff : f ∈ Ideal.span { g : R[X] | ∃ i : ℕ, g = C (coe
 
 theorem exists_C_coeff_not_mem : f ∉ I → ∃ i : ℕ, C (coeff f i) ∉ I :=
   Not.imp_symm fun cf => span_le_of_C_coeff_mem (not_exists_not.mp cf) mem_span_C_coeff
+
+namespace Polynomial
+
+variable {R : Type*} [CommRing R] {a : R}
+
+theorem mem_span_C_X_sub_C_X_sub_C_iff_eval_eval_eq_zero {b : R[X]} {P : R[X][X]} :
+    P ∈ Ideal.span {C (X - C a), X - C b} ↔ (P.eval b).eval a = 0 := by
+  rw [Ideal.mem_span_pair]
+  constructor <;> intro h
+  · rcases h with ⟨_, _, rfl⟩
+    simp only [eval_C, eval_X, eval_add, eval_sub, eval_mul, add_zero, mul_zero, sub_self]
+  · rcases dvd_iff_isRoot.mpr h with ⟨p, hp⟩
+    rcases @X_sub_C_dvd_sub_C_eval _ b _ P with ⟨q, hq⟩
+    exact ⟨C p, q, by rw [mul_comm, mul_comm q, eq_add_of_sub_eq' hq, hp, C_mul]⟩
+
+theorem ker_evalRingHom (x : R) : RingHom.ker (evalRingHom x) = Ideal.span {X - C x} := by
+  ext y
+  simp [Ideal.mem_span_singleton, dvd_iff_isRoot, RingHom.mem_ker]
+
+end Polynomial
 
 end Ideal
 

--- a/Mathlib/RingTheory/Polynomial/Eisenstein/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Riccardo Brasca. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
+import Mathlib.RingTheory.Adjoin.Basic
 import Mathlib.RingTheory.EisensteinCriterion
 import Mathlib.RingTheory.Polynomial.ScaleRoots
 

--- a/Mathlib/RingTheory/Polynomial/Ideal.lean
+++ b/Mathlib/RingTheory/Polynomial/Ideal.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2019 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+-/
+import Mathlib.Algebra.Polynomial.RingDivision
+import Mathlib.RingTheory.Adjoin.Polynomial
+import Mathlib.RingTheory.Ideal.Maps
+
+/-!
+# Ideals in polynomial rings
+-/
+
+noncomputable section
+
+open Polynomial
+
+open Finset
+
+universe u v w
+
+namespace Polynomial
+
+variable {R : Type*} [CommRing R] {a : R}
+
+theorem mem_span_C_X_sub_C_X_sub_C_iff_eval_eval_eq_zero {b : R[X]} {P : R[X][X]} :
+    P ∈ Ideal.span {C (X - C a), X - C b} ↔ (P.eval b).eval a = 0 := by
+  rw [Ideal.mem_span_pair]
+  constructor <;> intro h
+  · rcases h with ⟨_, _, rfl⟩
+    simp only [eval_C, eval_X, eval_add, eval_sub, eval_mul, add_zero, mul_zero, sub_self]
+  · rcases dvd_iff_isRoot.mpr h with ⟨p, hp⟩
+    rcases @X_sub_C_dvd_sub_C_eval _ b _ P with ⟨q, hq⟩
+    exact ⟨C p, q, by rw [mul_comm, mul_comm q, eq_add_of_sub_eq' hq, hp, C_mul]⟩
+
+theorem ker_evalRingHom (x : R) : RingHom.ker (evalRingHom x) = Ideal.span {X - C x} := by
+  ext y
+  simp [Ideal.mem_span_singleton, dvd_iff_isRoot, RingHom.mem_ker]
+
+@[simp]
+theorem ker_modByMonicHom {q : R[X]} (hq : q.Monic) :
+    LinearMap.ker (Polynomial.modByMonicHom q) = (Ideal.span {q}).restrictScalars R :=
+  Submodule.ext fun _ => (mem_ker_modByMonic hq).trans Ideal.mem_span_singleton.symm
+
+open Algebra in
+lemma _root_.Algebra.mem_ideal_map_adjoin {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
+    (x : S) (I : Ideal R) {y : adjoin R ({x} : Set S)} :
+    y ∈ I.map (algebraMap R (adjoin R ({x} : Set S))) ↔
+      ∃ p : R[X], (∀ i, p.coeff i ∈ I) ∧ Polynomial.aeval x p = y := by
+  constructor
+  · intro H
+    induction' H using Submodule.span_induction with a ha a b ha hb ha' hb' a b hb hb'
+    · obtain ⟨a, ha, rfl⟩ := ha
+      exact ⟨C a, fun i ↦ by rw [coeff_C]; aesop, aeval_C _ _⟩
+    · exact ⟨0, by simp, aeval_zero _⟩
+    · obtain ⟨a, ha, ha'⟩ := ha'
+      obtain ⟨b, hb, hb'⟩ := hb'
+      exact ⟨a + b, fun i ↦ by simpa using add_mem (ha i) (hb i), by simp [ha', hb']⟩
+    · obtain ⟨b', hb, hb'⟩ := hb'
+      obtain ⟨a, ha⟩ := a
+      rw [Algebra.adjoin_singleton_eq_range_aeval] at ha
+      obtain ⟨p, hp : aeval x p = a⟩ := ha
+      refine ⟨p * b', fun i ↦ ?_, by simp [hp, hb']⟩
+      rw [coeff_mul]
+      exact sum_mem fun i hi ↦ Ideal.mul_mem_left _ _ (hb _)
+  · rintro ⟨p, hp, hp'⟩
+    have : y = ∑ i in p.support, p.coeff i • ⟨_, (X ^ i).aeval_mem_adjoin_singleton _ x⟩ := by
+      trans ∑ i in p.support, ⟨_, (C (p.coeff i) * X ^ i).aeval_mem_adjoin_singleton _ x⟩
+      · ext1
+        simp only [AddSubmonoidClass.coe_finset_sum, ← map_sum, ← hp', ← as_sum_support_C_mul_X_pow]
+      · congr with i
+        simp [Algebra.smul_def]
+    simp_rw [this, Algebra.smul_def]
+    exact sum_mem fun i _ ↦ Ideal.mul_mem_right _ _ (Ideal.mem_map_of_mem _ (hp i))
+
+end Polynomial

--- a/Mathlib/RingTheory/Polynomial/IntegralNormalization.lean
+++ b/Mathlib/RingTheory/Polynomial/IntegralNormalization.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker, Andrew Yang, Yuyang Zhao
 -/
+import Mathlib.Algebra.Polynomial.Div
 import Mathlib.Algebra.Polynomial.Monic
 import Mathlib.RingTheory.Polynomial.ScaleRoots
 

--- a/Mathlib/RingTheory/Polynomial/IntegralNormalization.lean
+++ b/Mathlib/RingTheory/Polynomial/IntegralNormalization.lean
@@ -3,8 +3,8 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker, Andrew Yang, Yuyang Zhao
 -/
-import Mathlib.Algebra.Polynomial.Div
 import Mathlib.Algebra.Polynomial.Monic
+import Mathlib.Algebra.Ring.Regular
 import Mathlib.RingTheory.Polynomial.ScaleRoots
 
 /-!

--- a/Mathlib/RingTheory/Polynomial/Quotient.lean
+++ b/Mathlib/RingTheory/Polynomial/Quotient.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Polynomial.Eval.SMul
 import Mathlib.GroupTheory.GroupAction.Ring
 import Mathlib.RingTheory.Ideal.Quotient.Operations
 import Mathlib.RingTheory.Polynomial.Basic
+import Mathlib.RingTheory.Polynomial.Ideal
 
 /-!
 # Quotients of polynomial rings


### PR DESCRIPTION
This PR moves around a few definitions in order to free the definition of `Polynomial.roots` of the knowledge of `Ideal`. This was mostly motivated by writing `assert_not_exists Ideal` in a few files and being amazed that it did exist.

In particular, the following changes are made:
* results involving ideals in `Algebra/Module/Submodule/Pointwise.lean` go to `RingTheory/Ideal/Operations.lean` (the first place that they are used) 
* results on ideal membership in `RingTheory/Localization/Defs.lean` go to `RingTheory/Localization/Ideal.lean` (idem)
* results on adjoining polynomials to a ring in `Algebra/Polynomial/AlgebraMap.lean` go to the new file `RingTheory/Adjoin/Polynomial.lean` (I couldn't find an obvious place to put this: `RingTheory/Adjoin/Basic.lean` does not know polynomials)
* results on ideal membership in `Algebra/Polynomial/Div.lean`, `Algebra/Polynomial/RingDivision.lean` and a few from `RingTheory/Polynomial/Basic.lean` go to the new file `RingTheory/Polynomial/Ideal.lean` (merging this with `RingTheory/Polynomial/Basic.lean` is an okay option but would increase the downstream imports a lot)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
