### PR TITLE
feat: Explanation widgets

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4833,6 +4833,7 @@ import Mathlib.Tactic.Widget.Calc
 import Mathlib.Tactic.Widget.CommDiag
 import Mathlib.Tactic.Widget.CongrM
 import Mathlib.Tactic.Widget.Conv
+import Mathlib.Tactic.Widget.Explain
 import Mathlib.Tactic.Widget.GCongr
 import Mathlib.Tactic.Widget.InteractiveUnfold
 import Mathlib.Tactic.Widget.SelectInsertParamsClass

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -254,6 +254,7 @@ import Mathlib.Tactic.Widget.Calc
 import Mathlib.Tactic.Widget.CommDiag
 import Mathlib.Tactic.Widget.CongrM
 import Mathlib.Tactic.Widget.Conv
+import Mathlib.Tactic.Widget.Explain
 import Mathlib.Tactic.Widget.GCongr
 import Mathlib.Tactic.Widget.InteractiveUnfold
 import Mathlib.Tactic.Widget.SelectInsertParamsClass

--- a/Mathlib/Tactic/Widget/Explain.lean
+++ b/Mathlib/Tactic/Widget/Explain.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2024 Adam Topaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Topaz
+-/
+import ProofWidgets
+
+/-!
+
+# Explanation Widgets
+
+This file defines some simple widgets wrapped in a tactic, term and command elaborator
+that display nicely rendered markdown in the infoview.
+
+Example tactic usage:
+```
+example : True := by
+  explain "This is the first step."
+  explain "This is the last step." exact trivial
+```
+Placing the cursor on each line results will render the explanation in the infoview.
+
+Example term usage:
+```
+example : Nat := explain% "This is zero" 0
+```
+Placing the cursor on the term will render the explanation in the infoview.
+
+
+Example command usage:
+```
+#explain "This is an explanation."
+```
+This will render the provided text in the infoview.
+
+
+# Implementation
+
+This code uses `MarkdownDisplay` from `ProofWidgets2`, and thus supports
+markdown and latex via mathjax.
+
+-/
+
+namespace Mathlib.Tactic
+
+open Lean Elab ProofWidgets ProofWidgets.Jsx
+
+def displayMarkdown (md : String) (stx : Syntax) : CoreM Unit := do
+  let html : Html := <MarkdownDisplay contents={md}/>
+  Widget.savePanelWidgetInfo
+    (hash HtmlDisplayPanel.javascript)
+    (return json% { html: $(← Server.RpcEncodable.rpcEncode html) })
+    stx
+
+syntax (name := explainTacStx) "explain" str (tactic)? : tactic
+
+open Tactic in
+@[tactic explainTacStx]
+def elabExplainTac : Tactic := fun stx =>
+  match stx with
+  | `(tactic|explain%$tk $s:str) => do
+    displayMarkdown s.getString tk
+  | `(tactic|explain%$tk $s:str $t:tactic) => do
+    displayMarkdown s.getString tk
+    evalTactic t
+  | _ => throwUnsupportedSyntax
+
+syntax (name := explainTermStx) "explain%" str term : term
+
+open Term in
+@[term_elab explainTermStx]
+def elabExplainTerm : TermElab := fun stx type? =>
+  match stx with
+  | `(explain%%$tk $s:str $t:term) => do
+    displayMarkdown s.getString tk
+    elabTerm t type?
+  | _ => throwUnsupportedSyntax
+
+syntax (name := explainCmdStx) "#explain" str : command
+
+open Command in
+@[command_elab explainCmdStx]
+def elabExlpainCommand : CommandElab := fun stx =>
+  match stx with
+  | `(command|#explain%$tk $s:str) => do
+    Command.liftCoreM <| displayMarkdown s.getString tk
+  | _ => throwUnsupportedSyntax

--- a/Mathlib/Tactic/Widget/Explain.lean
+++ b/Mathlib/Tactic/Widget/Explain.lean
@@ -46,6 +46,7 @@ namespace Mathlib.Tactic
 
 open Lean Elab ProofWidgets ProofWidgets.Jsx
 
+/-- Displays the markdown source in `md` in a widget when the cursor is placed at `stx`. -/
 def displayMarkdown (md : String) (stx : Syntax) : CoreM Unit := do
   let html : Html := <MarkdownDisplay contents={md}/>
   Widget.savePanelWidgetInfo
@@ -56,6 +57,7 @@ def displayMarkdown (md : String) (stx : Syntax) : CoreM Unit := do
 syntax (name := explainTacStx) "explain" str (tactic)? : tactic
 
 open Tactic in
+/-- A tactic that adds an explanation widget in markdown form. -/
 @[tactic explainTacStx]
 def elabExplainTac : Tactic := fun stx =>
   match stx with
@@ -69,6 +71,7 @@ def elabExplainTac : Tactic := fun stx =>
 syntax (name := explainTermStx) "explain%" str term : term
 
 open Term in
+/-- A term elaborator that adds an explanation widget in markdown form. -/
 @[term_elab explainTermStx]
 def elabExplainTerm : TermElab := fun stx type? =>
   match stx with
@@ -80,9 +83,12 @@ def elabExplainTerm : TermElab := fun stx type? =>
 syntax (name := explainCmdStx) "#explain" str : command
 
 open Command in
+/-- A command that displays an explanation widget in markdown form. -/
 @[command_elab explainCmdStx]
 def elabExplainCommand : CommandElab := fun stx =>
   match stx with
   | `(command|#explain%$tk $s:str) => do
     Command.liftCoreM <| displayMarkdown s.getString tk
   | _ => throwUnsupportedSyntax
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Widget/Explain.lean
+++ b/Mathlib/Tactic/Widget/Explain.lean
@@ -81,7 +81,7 @@ syntax (name := explainCmdStx) "#explain" str : command
 
 open Command in
 @[command_elab explainCmdStx]
-def elabExlpainCommand : CommandElab := fun stx =>
+def elabExplainCommand : CommandElab := fun stx =>
   match stx with
   | `(command|#explain%$tk $s:str) => do
     Command.liftCoreM <| displayMarkdown s.getString tk

--- a/Mathlib/Tactic/Widget/Explain.lean
+++ b/Mathlib/Tactic/Widget/Explain.lean
@@ -54,7 +54,7 @@ def displayMarkdown (md : String) (stx : Syntax) : CoreM Unit := do
     (return json% { html: $(← Server.RpcEncodable.rpcEncode html) })
     stx
 
-syntax (name := explainTacStx) "explain" str (tactic)? : tactic
+syntax (name := explainTacStx) "explain" str (ppIndent("in" tactic))? : tactic
 
 open Tactic in
 /-- A tactic that adds an explanation widget in markdown form. -/
@@ -63,19 +63,19 @@ def elabExplainTac : Tactic := fun stx =>
   match stx with
   | `(tactic|explain%$tk $s:str) => do
     displayMarkdown s.getString tk
-  | `(tactic|explain%$tk $s:str $t:tactic) => do
+  | `(tactic|explain%$tk $s:str in $t:tactic) => do
     displayMarkdown s.getString tk
     evalTactic t
   | _ => throwUnsupportedSyntax
 
-syntax (name := explainTermStx) "explain%" str term : term
+syntax (name := explainTermStx) "explain%" str ppIndent("in" term) : term
 
 open Term in
 /-- A term elaborator that adds an explanation widget in markdown form. -/
 @[term_elab explainTermStx]
 def elabExplainTerm : TermElab := fun stx type? =>
   match stx with
-  | `(explain%%$tk $s:str $t:term) => do
+  | `(explain%%$tk $s:str in $t:term) => do
     displayMarkdown s.getString tk
     elabTerm t type?
   | _ => throwUnsupportedSyntax

--- a/Mathlib/Tactic/Widget/Explain.lean
+++ b/Mathlib/Tactic/Widget/Explain.lean
@@ -17,13 +17,15 @@ Example tactic usage:
 ```
 example : True := by
   explain "This is the first step."
-  explain "This is the last step." exact trivial
+  explain "This is the last step." in
+    exact trivial
 ```
 Placing the cursor on each line results will render the explanation in the infoview.
 
 Example term usage:
 ```
-example : Nat := explain% "This is zero" 0
+example : Nat := explain "This is zero" in
+  0
 ```
 Placing the cursor on the term will render the explanation in the infoview.
 
@@ -54,7 +56,9 @@ def displayMarkdown (md : String) (stx : Syntax) : CoreM Unit := do
     (return json% { html: $(← Server.RpcEncodable.rpcEncode html) })
     stx
 
-syntax (name := explainTacStx) "explain" str (ppIndent("in" tactic))? : tactic
+syntax (name := explainTacStx) "explain" str ("in" ppIndent(tactic))? : tactic
+syntax (name := explainTermStx) "explain" str "in" ppIndent(term) : term
+syntax (name := explainCmdStx) "#explain" str : command
 
 open Tactic in
 /-- A tactic that adds an explanation widget in markdown form. -/
@@ -68,19 +72,15 @@ def elabExplainTac : Tactic := fun stx =>
     evalTactic t
   | _ => throwUnsupportedSyntax
 
-syntax (name := explainTermStx) "explain%" str ppIndent("in" term) : term
-
 open Term in
 /-- A term elaborator that adds an explanation widget in markdown form. -/
 @[term_elab explainTermStx]
 def elabExplainTerm : TermElab := fun stx type? =>
   match stx with
-  | `(explain%%$tk $s:str in $t:term) => do
+  | `(explain%$tk $s:str in $t:term) => do
     displayMarkdown s.getString tk
     elabTerm t type?
   | _ => throwUnsupportedSyntax
-
-syntax (name := explainCmdStx) "#explain" str : command
 
 open Command in
 /-- A command that displays an explanation widget in markdown form. -/

--- a/Mathlib/Tactic/Widget/Explain.lean
+++ b/Mathlib/Tactic/Widget/Explain.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
+import Mathlib.Init
 import ProofWidgets
 
 /-!

--- a/Mathlib/Tactic/Widget/Explain.lean
+++ b/Mathlib/Tactic/Widget/Explain.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
 import Mathlib.Init
-import ProofWidgets
+import ProofWidgets.Component.HtmlDisplay
 
 /-!
 
@@ -56,8 +56,13 @@ def displayMarkdown (md : String) (stx : Syntax) : CoreM Unit := do
     (return json% { html: $(← Server.RpcEncodable.rpcEncode html) })
     stx
 
+/-- Syntax for the `explain` tactic elaborator. -/
 syntax (name := explainTacStx) "explain" str ("in" ppIndent(tactic))? : tactic
+
+/-- Syntax for the `explain` term elaborator. -/
 syntax (name := explainTermStx) "explain" str "in" ppIndent(term) : term
+
+/-- Syntax for the `#explain` command. -/
 syntax (name := explainCmdStx) "#explain" str : command
 
 open Tactic in

--- a/Mathlib/Tactic/Widget/Explain.lean
+++ b/Mathlib/Tactic/Widget/Explain.lean
@@ -37,7 +37,7 @@ This will render the provided text in the infoview.
 
 # Implementation
 
-This code uses `MarkdownDisplay` from `ProofWidgets2`, and thus supports
+This code uses `MarkdownDisplay` from `ProofWidgets`, and thus supports
 markdown and latex via mathjax.
 
 -/


### PR DESCRIPTION
This adds some simple widgets, wrapped in a tactic, term and command elaborator, for displaying markdown explanations in the infoview.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
