### PR TITLE
[Merged by Bors] - chore(Algebra/Order/SuccPred/TypeTags): fix defeq abuse with Additive and Multiplicative

### DIFF
--- a/Mathlib/Algebra/Order/SuccPred/TypeTags.lean
+++ b/Mathlib/Algebra/Order/SuccPred/TypeTags.lean
@@ -36,15 +36,19 @@ namespace Order
 open Additive Multiplicative
 
 @[simp] lemma succ_ofMul [Preorder X] [SuccOrder X] (x : X) : succ (ofMul x) = ofMul (succ x) := rfl
-@[simp] lemma succ_toMul [Preorder X] [SuccOrder X] (x : X) : succ (toMul x) = toMul (succ x) := rfl
+@[simp] lemma succ_toMul [Preorder X] [SuccOrder X] (x : Additive X) :
+  succ (toMul x) = toMul (succ x) := rfl
 
 @[simp] lemma succ_ofAdd [Preorder X] [SuccOrder X] (x : X) : succ (ofAdd x) = ofAdd (succ x) := rfl
-@[simp] lemma succ_toAdd [Preorder X] [SuccOrder X] (x : X) : succ (toAdd x) = toAdd (succ x) := rfl
+@[simp] lemma succ_toAdd [Preorder X] [SuccOrder X] (x : Multiplicative X) :
+  succ (toAdd x) = toAdd (succ x) := rfl
 
 @[simp] lemma pred_ofMul [Preorder X] [PredOrder X] (x : X) : pred (ofMul x) = ofMul (pred x) := rfl
-@[simp] lemma pred_toMul [Preorder X] [PredOrder X] (x : X) : pred (toMul x) = toMul (pred x) := rfl
+@[simp] lemma pred_toMul [Preorder X] [PredOrder X] (x : Additive X) :
+  pred (toMul x) = toMul (pred x) := rfl
 
 @[simp] lemma pred_ofAdd [Preorder X] [PredOrder X] (x : X) : pred (ofAdd x) = ofAdd (pred x) := rfl
-@[simp] lemma pred_toAdd [Preorder X] [PredOrder X] (x : X) : pred (toAdd x) = toAdd (pred x) := rfl
+@[simp] lemma pred_toAdd [Preorder X] [PredOrder X] (x : Multiplicative X) :
+  pred (toAdd x) = toAdd (pred x) := rfl
 
 end Order


### PR DESCRIPTION
these simp lemmas now don't use defeq abuse between `A` and `Multiplicative A`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
