### PR TITLE
[Merged by Bors] - feat: prove `zmodRepr` is unique

### DIFF
--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -193,9 +193,9 @@ def zmodRepr : ℕ :=
 theorem zmodRepr_spec : zmodRepr x < p ∧ x - zmodRepr x ∈ maximalIdeal ℤ_[p] :=
   Classical.choose_spec (exists_unique_mem_range x).exists
 
-theorem zmodRepr_unique (y : ℕ) (hy : y < p ∧ x - y ∈ maximalIdeal ℤ_[p]) : y = zmodRepr x :=
-  have := (Classical.choose_spec (exists_unique_mem_range x)).right
-  (this y hy).trans (this (zmodRepr x) (zmodRepr_spec x)).symm
+theorem zmodRepr_unique (y : ℕ) (hy₁ : y < p) (hy₂ : x - y ∈ maximalIdeal ℤ_[p]) : y = zmodRepr x :=
+  have h := (Classical.choose_spec (exists_unique_mem_range x)).right
+  (h y ⟨hy₁, hy₂⟩).trans (h (zmodRepr x) (zmodRepr_spec x)).symm
 
 theorem zmodRepr_lt_p : zmodRepr x < p :=
   (zmodRepr_spec _).1

--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -178,14 +178,24 @@ theorem exists_mem_range : ∃ n : ℕ, n < p ∧ x - n ∈ maximalIdeal ℤ_[p]
   apply max_lt hr
   simpa using hn
 
+theorem exists_unique_mem_range : ∃! n : ℕ, n < p ∧ x - n ∈ maximalIdeal ℤ_[p] := by
+  obtain ⟨n, hn₁, hn₂⟩ := exists_mem_range x
+  use n, ⟨hn₁, hn₂⟩, fun m ⟨hm₁, hm₂⟩ ↦ ?_
+  have := (zmod_congr_of_sub_mem_max_ideal x n m hn₂ hm₂).symm
+  rwa [ZMod.natCast_eq_natCast_iff, ModEq, mod_eq_of_lt hn₁, mod_eq_of_lt hm₁] at this
+
 /-- `zmod_repr x` is the unique natural number smaller than `p`
 satisfying `‖(x - zmod_repr x : ℤ_[p])‖ < 1`.
 -/
 def zmodRepr : ℕ :=
-  Classical.choose (exists_mem_range x)
+  Classical.choose (exists_unique_mem_range x).exists
 
 theorem zmodRepr_spec : zmodRepr x < p ∧ x - zmodRepr x ∈ maximalIdeal ℤ_[p] :=
-  Classical.choose_spec (exists_mem_range x)
+  Classical.choose_spec (exists_unique_mem_range x).exists
+
+theorem zmodRepr_unique (y : ℕ) (hy : y < p ∧ x - y ∈ maximalIdeal ℤ_[p]) : y = zmodRepr x :=
+  have := (Classical.choose_spec (exists_unique_mem_range x)).right
+  (this y hy).trans (this (zmodRepr x) (zmodRepr_spec x)).symm
 
 theorem zmodRepr_lt_p : zmodRepr x < p :=
   (zmodRepr_spec _).1


### PR DESCRIPTION
We prove `PadicInt.exists_unique_mem_range` which is a strengthening of `exists_mem_range`, proving uniqueness of the natural number. I need this to simplify `toZMod(1+ap)` to `1`.