### PR TITLE
[Merged by Bors] - feat(SetTheory/Game/PGame): down and up games

### DIFF
--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1946,9 +1946,15 @@ theorem up_moveLeft (x) : up.moveLeft x = 0 :=
 theorem up_moveRight (x) : up.moveRight x = star :=
   rfl
 
+@[simp]
 theorem up_positive : 0 < up := by
   rw [lt_iff_le_and_lf, zero_lf]
   simp [zero_le_lf, zero_lf_star]
+
+theorem up_star_fuzzy : star ‖ up := by
+  unfold Fuzzy
+  simp [← PGame.not_le]
+  simp [le_iff_forall_lf]
 
 /-- The pre-game `down` -/
 def down : PGame.{u} :=
@@ -1971,11 +1977,12 @@ theorem down_moveRight (x) : down.moveRight x = 0 :=
   rfl
 
 @[simp]
-theorem neg_down_up : up = -down := by simp [up, down]
-
 theorem down_negative : down < 0 := by
   rw [lt_iff_le_and_lf, lf_zero]
   simp [le_zero_lf, star_lf_zero]
+
+@[simp]
+theorem neg_down_up : up = -down := by simp [up, down]
 
 instance : ZeroLEOneClass PGame :=
   ⟨PGame.zero_lt_one.le⟩

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1979,7 +1979,7 @@ theorem down_negative : down < 0 := by
 @[simp]
 theorem neg_down_up : up = -down := by simp [up, down]
 
-theorem down_star_fuzzy : star ‖ down := by
+theorem star_fuzzy_down : star ‖ down := by
   rw [← neg_fuzzy_neg_iff, ← neg_down_up, neg_star]
   exact up_star_fuzzy
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1973,9 +1973,6 @@ theorem down_moveRight (x) : down.moveRight x = 0 :=
 @[simp]
 theorem neg_down_up : up = -down := by simp [up, down]
 
-@[simp]
-theorem neg_up_down : -up = down := by simp only [neg_down_up, neg_neg]
-
 theorem down_negative : down < 0 := by
   rw [lt_iff_le_and_lf, lf_zero]
   simp [le_zero_lf, star_lf_zero]

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1953,7 +1953,7 @@ theorem up_positive : 0 < up := by
 
 theorem up_star_fuzzy : star ‖ up := by
   unfold Fuzzy
-  simp [← PGame.not_le]
+  simp only [← PGame.not_le]
   simp [le_iff_forall_lf]
 
 /-- The pre-game `down` -/
@@ -1983,6 +1983,10 @@ theorem down_negative : down < 0 := by
 
 @[simp]
 theorem neg_down_up : up = -down := by simp [up, down]
+
+theorem down_star_fuzzy : star ‖ down := by
+  rw [← neg_fuzzy_neg_iff, ← neg_down_up, neg_star]
+  exact up_star_fuzzy
 
 instance : ZeroLEOneClass PGame :=
   ⟨PGame.zero_lt_one.le⟩

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1974,7 +1974,7 @@ theorem down_moveRight (x) : down.moveRight x = 0 :=
 theorem neg_down_up : up = -down := by simp [up, down]
 
 @[simp]
-theorem neg_up_down : -up = down := by simp [up, down]
+theorem neg_up_down : -up = down := by simp only [neg_down_up, neg_neg]
 
 theorem down_negative : down < 0 := by
   rw [lt_iff_le_and_lf, lf_zero]

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1926,6 +1926,60 @@ theorem neg_star : -star = star := by simp [star]
 protected theorem zero_lt_one : (0 : PGame) < 1 :=
   lt_of_le_of_lf (zero_le_of_isEmpty_rightMoves 1) (zero_lf_le.2 ⟨default, le_rfl⟩)
 
+/-- The pre-game `up` -/
+def up : PGame.{u} :=
+  ⟨PUnit, PUnit, fun _ => 0, fun _ => star⟩
+
+@[simp]
+theorem up_leftMoves : up.LeftMoves = PUnit :=
+  rfl
+
+@[simp]
+theorem up_rightMoves : up.RightMoves = PUnit :=
+  rfl
+
+@[simp]
+theorem up_moveLeft (x) : up.moveLeft x = 0 :=
+  rfl
+
+@[simp]
+theorem up_moveRight (x) : up.moveRight x = star :=
+  rfl
+
+theorem up_positive : 0 < up := by
+  rw [lt_iff_le_and_lf, zero_lf]
+  simp [zero_le_lf, zero_lf_star]
+
+/-- The pre-game `down` -/
+def down : PGame.{u} :=
+  ⟨PUnit, PUnit, fun _ => star, fun _ => 0⟩
+
+@[simp]
+theorem down_leftMoves : down.LeftMoves = PUnit :=
+  rfl
+
+@[simp]
+theorem down_rightMoves : down.RightMoves = PUnit :=
+  rfl
+
+@[simp]
+theorem down_moveLeft (x) : down.moveLeft x = star :=
+  rfl
+
+@[simp]
+theorem down_moveRight (x) : down.moveRight x = 0 :=
+  rfl
+
+@[simp]
+theorem neg_down_up : up = -down := by simp [up, down]
+
+@[simp]
+theorem neg_up_down : -up = down := by simp [up, down]
+
+theorem down_negative : down < 0 := by
+  rw [lt_iff_le_and_lf, lf_zero]
+  simp [le_zero_lf, star_lf_zero]
+
 instance : ZeroLEOneClass PGame :=
   ⟨PGame.zero_lt_one.le⟩
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1976,7 +1976,6 @@ theorem down_moveLeft (x) : down.moveLeft x = star :=
 theorem down_moveRight (x) : down.moveRight x = 0 :=
   rfl
 
-@[simp]
 theorem down_negative : down < 0 := by
   rw [lt_iff_le_and_lf, lf_zero]
   simp [le_zero_lf, star_lf_zero]

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1946,11 +1946,6 @@ theorem up_moveLeft (x) : up.moveLeft x = 0 :=
 theorem up_moveRight (x) : up.moveRight x = star :=
   rfl
 
-@[simp]
-theorem up_positive : 0 < up := by
-  rw [lt_iff_le_and_lf, zero_lf]
-  simp [zero_le_lf, zero_lf_star]
-
 theorem up_star_fuzzy : star ‖ up := by
   unfold Fuzzy
   simp only [← PGame.not_le]
@@ -1976,6 +1971,7 @@ theorem down_moveLeft (x) : down.moveLeft x = star :=
 theorem down_moveRight (x) : down.moveRight x = 0 :=
   rfl
 
+@[simp]
 theorem down_negative : down < 0 := by
   rw [lt_iff_le_and_lf, lf_zero]
   simp [le_zero_lf, star_lf_zero]

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1972,7 +1972,7 @@ theorem down_moveRight (x) : down.moveRight x = 0 :=
   rfl
 
 @[simp]
-theorem down_negative : down < 0 := by
+theorem down_neg : down < 0 := by
   rw [lt_iff_le_and_lf, lf_zero]
   simp [le_zero_lf, star_lf_zero]
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1977,7 +1977,7 @@ theorem down_negative : down < 0 := by
   simp [le_zero_lf, star_lf_zero]
 
 @[simp]
-theorem neg_down_up : up = -down := by simp [up, down]
+theorem neg_down : -down = up := by simp [up, down]
 
 theorem star_fuzzy_down : star ‖ down := by
   rw [← neg_fuzzy_neg_iff, ← neg_down_up, neg_star]

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1946,6 +1946,11 @@ theorem up_moveLeft (x) : up.moveLeft x = 0 :=
 theorem up_moveRight (x) : up.moveRight x = star :=
   rfl
 
+@[simp]
+theorem up_neg : 0 < up := by
+  rw [lt_iff_le_and_lf, zero_lf]
+  simp [zero_le_lf, zero_lf_star]
+
 theorem star_fuzzy_up : star ‖ up := by
   unfold Fuzzy
   simp only [← PGame.not_le]
@@ -1979,9 +1984,12 @@ theorem down_neg : down < 0 := by
 @[simp]
 theorem neg_down : -down = up := by simp [up, down]
 
+@[simp]
+theorem neg_up : -up = down := by simp [up, down]
+
 theorem star_fuzzy_down : star ‖ down := by
-  rw [← neg_fuzzy_neg_iff, ← neg_down_up, neg_star]
-  exact up_star_fuzzy
+  rw [← neg_fuzzy_neg_iff, neg_down, neg_star]
+  exact star_fuzzy_up
 
 instance : ZeroLEOneClass PGame :=
   ⟨PGame.zero_lt_one.le⟩

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1946,7 +1946,7 @@ theorem up_moveLeft (x) : up.moveLeft x = 0 :=
 theorem up_moveRight (x) : up.moveRight x = star :=
   rfl
 
-theorem up_star_fuzzy : star ‖ up := by
+theorem star_fuzzy_up : star ‖ up := by
   unfold Fuzzy
   simp only [← PGame.not_le]
   simp [le_iff_forall_lf]


### PR DESCRIPTION
Implements definitions for up and down games, their negations, and their inequivalence to 0. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
