### PR TITLE
feat(SetTheory/Game/Birthday): up/down birthdays

### DIFF
--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -104,6 +104,12 @@ theorem birthday_one : birthday 1 = 1 := by rw [birthday_def]; simp
 theorem birthday_star : birthday star = 1 := by rw [birthday_def]; simp
 
 @[simp]
+theorem birthday_up : birthday up = 2 := by rw [birthday_def]; simp
+
+@[simp]
+theorem birthday_down : birthday down = 2 := by rw [birthday_def]; simp
+
+@[simp]
 theorem birthday_neg : ∀ x : PGame, (-x).birthday = x.birthday
   | ⟨xl, xr, xL, xR⟩ => by
     rw [birthday_def, birthday_def, max_comm]

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1974,7 +1974,7 @@ theorem down_moveRight (x) : down.moveRight x = 0 :=
 theorem neg_down_up : up = -down := by simp [up, down]
 
 @[simp]
-theorem neg_up_down : -up = down := by simp [up, down]
+theorem neg_up_down : -up = down := by simp only [neg_down_up, neg_neg]
 
 theorem down_negative : down < 0 := by
   rw [lt_iff_le_and_lf, lf_zero]

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1926,6 +1926,60 @@ theorem neg_star : -star = star := by simp [star]
 protected theorem zero_lt_one : (0 : PGame) < 1 :=
   lt_of_le_of_lf (zero_le_of_isEmpty_rightMoves 1) (zero_lf_le.2 ⟨default, le_rfl⟩)
 
+/-- The pre-game `up` -/
+def up : PGame.{u} :=
+  ⟨PUnit, PUnit, fun _ => 0, fun _ => star⟩
+
+@[simp]
+theorem up_leftMoves : up.LeftMoves = PUnit :=
+  rfl
+
+@[simp]
+theorem up_rightMoves : up.RightMoves = PUnit :=
+  rfl
+
+@[simp]
+theorem up_moveLeft (x) : up.moveLeft x = 0 :=
+  rfl
+
+@[simp]
+theorem up_moveRight (x) : up.moveRight x = star :=
+  rfl
+
+theorem up_positive : 0 < up := by
+  rw [lt_iff_le_and_lf, zero_lf]
+  simp [zero_le_lf, zero_lf_star]
+
+/-- The pre-game `down` -/
+def down : PGame.{u} :=
+  ⟨PUnit, PUnit, fun _ => star, fun _ => 0⟩
+
+@[simp]
+theorem down_leftMoves : down.LeftMoves = PUnit :=
+  rfl
+
+@[simp]
+theorem down_rightMoves : down.RightMoves = PUnit :=
+  rfl
+
+@[simp]
+theorem down_moveLeft (x) : down.moveLeft x = star :=
+  rfl
+
+@[simp]
+theorem down_moveRight (x) : down.moveRight x = 0 :=
+  rfl
+
+@[simp]
+theorem neg_down_up : up = -down := by simp [up, down]
+
+@[simp]
+theorem neg_up_down : -up = down := by simp [up, down]
+
+theorem down_negative : down < 0 := by
+  rw [lt_iff_le_and_lf, lf_zero]
+  simp [le_zero_lf, star_lf_zero]
+
 instance : ZeroLEOneClass PGame :=
   ⟨PGame.zero_lt_one.le⟩
 


### PR DESCRIPTION
Sets up definitions for birthdays for up and down normal games.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

- [ ] depends on: #145049