### PR TITLE
[Merged by Bors] - feat: `s⁻¹.encard = s.encard`

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import Mathlib.Data.Set.Card
 import Mathlib.Data.Set.Pointwise.Finite
 import Mathlib.SetTheory.Cardinal.Finite
 
@@ -47,6 +48,12 @@ lemma _root_.Cardinal.mk_inv (s : Set G) : #↥(s⁻¹) = #s := by
 lemma natCard_inv (s : Set G) : Nat.card ↥(s⁻¹) = Nat.card s := by
   rw [← image_inv, Nat.card_image_of_injective inv_injective]
 
+@[to_additive (attr := simp)]
+lemma encard_inv (s : Set G) : s⁻¹.encard = s.encard := by simp [encard, PartENat.card]
+
+@[to_additive (attr := simp)]
+lemma ncard_inv (s : Set G) : s⁻¹.ncard = s.ncard := by simp [ncard]
+
 @[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_inv := natCard_inv
 
 end InvolutiveInv
@@ -78,6 +85,13 @@ lemma _root_.Cardinal.mk_smul_set (a : G) (s : Set α) : #↥(a • s) = #s :=
 @[to_additive (attr := simp)]
 lemma natCard_smul_set (a : G) (s : Set α) : Nat.card ↥(a • s) = Nat.card s :=
   Nat.card_image_of_injective (MulAction.injective a) _
+
+@[to_additive (attr := simp)]
+lemma encard_smul_set (a : G) (s : Set α) : (a • s).encard = s.encard := by
+  simp [encard, PartENat.card]
+
+@[to_additive (attr := simp)]
+lemma ncard_smul_set (a : G) (s : Set α) : (a • s).ncard = s.ncard := by simp [ncard]
 
 @[to_additive (attr := deprecated (since := "2024-09-30"))]
 alias card_smul_set := Cardinal.mk_smul_set

--- a/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
@@ -48,13 +48,13 @@ lemma _root_.Cardinal.mk_inv (s : Set G) : #↥(s⁻¹) = #s := by
 lemma natCard_inv (s : Set G) : Nat.card ↥(s⁻¹) = Nat.card s := by
   rw [← image_inv, Nat.card_image_of_injective inv_injective]
 
+@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_inv := natCard_inv
+
 @[to_additive (attr := simp)]
 lemma encard_inv (s : Set G) : s⁻¹.encard = s.encard := by simp [encard, PartENat.card]
 
 @[to_additive (attr := simp)]
 lemma ncard_inv (s : Set G) : s⁻¹.ncard = s.ncard := by simp [ncard]
-
-@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_inv := natCard_inv
 
 end InvolutiveInv
 
@@ -86,15 +86,15 @@ lemma _root_.Cardinal.mk_smul_set (a : G) (s : Set α) : #↥(a • s) = #s :=
 lemma natCard_smul_set (a : G) (s : Set α) : Nat.card ↥(a • s) = Nat.card s :=
   Nat.card_image_of_injective (MulAction.injective a) _
 
+@[to_additive (attr := deprecated (since := "2024-09-30"))]
+alias card_smul_set := Cardinal.mk_smul_set
+
 @[to_additive (attr := simp)]
 lemma encard_smul_set (a : G) (s : Set α) : (a • s).encard = s.encard := by
   simp [encard, PartENat.card]
 
 @[to_additive (attr := simp)]
 lemma ncard_smul_set (a : G) (s : Set α) : (a • s).ncard = s.ncard := by simp [ncard]
-
-@[to_additive (attr := deprecated (since := "2024-09-30"))]
-alias card_smul_set := Cardinal.mk_smul_set
 
 end Group
 end Set


### PR DESCRIPTION
From Kneser (LeanCamCombi)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
