### PR TITLE
feat: AM-HM inequality

### DIFF
--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -209,7 +209,7 @@ theorem sq_sum_div_le_sum_sq_div [LinearOrderedSemifield R] [ExistsAddOfLE R] (s
   exact (hg i hi).ne'
 
 /-- Weighted **AM-HM** inequality": The weighted harmonic mean is less than or equal to the
-arithmetic mean -/
+arithmetic mean. -/
 theorem inv_sum_div_le_sum_mul [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
     {w f : ι → R} (hw : ∑ i ∈ s, w i = 1) (hw' : ∀ i ∈ s, 0 < w i) (hf : ∀ i ∈ s, 0 < f i) :
     (∑ i ∈ s, w i / f i)⁻¹ ≤ ∑ i ∈ s, w i * f i := by
@@ -219,7 +219,7 @@ theorem inv_sum_div_le_sum_mul [LinearOrderedSemifield R] [ExistsAddOfLE R] (s :
     refine sum_congr rfl fun i hi ↦ ?_
     rw [div_div_cancel' (hw' i hi).ne']
 
-/-- **AM-HM** inequality: The harmonic mean is less than or equal to the arithmetic mean -/
+/-- **AM-HM** inequality: The harmonic mean is less than or equal to the arithmetic mean. -/
 theorem div_sum_inv_le_sum_div [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
     {f : ι → R} (hf : ∀ i ∈ s, 0 < f i) : #s / ∑ i ∈ s, (f i)⁻¹ ≤ (∑ i ∈ s, f i) / #s := by
   obtain hs | hs := eq_zero_or_pos #s
@@ -230,7 +230,7 @@ theorem div_sum_inv_le_sum_div [LinearOrderedSemifield R] [ExistsAddOfLE R] (s :
     · simp_rw [div_eq_mul_inv, ← mul_sum, inv_mul_eq_div, inv_div, div_eq_mul_inv]
     · rw [← mul_sum, inv_mul_eq_div]
 
-/-- **AM-HM** inequality: The harmonic mean is less than or equal to the arithmetic mean -/
+/-- **AM-HM** inequality: The harmonic mean is less than or equal to the arithmetic mean. -/
 theorem sq_le_sum_mul_sum_inv [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
     {f : ι → R} (hf : ∀ i ∈ s, 0 < f i) : #s ^ 2 ≤ (∑ i ∈ s, f i) * (∑ i ∈ s, (f i)⁻¹) := by
   have hf' : ∀ i ∈ s, 0 < (f i)⁻¹ := fun i hi ↦ inv_pos.2 (hf i hi)

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -208,7 +208,7 @@ theorem sq_sum_div_le_sum_sq_div [LinearOrderedSemifield R] [ExistsAddOfLE R] (s
   rw [div_mul_cancel₀]
   exact (hg i hi).ne'
 
-/-- Weighted **AM-HM** inequality": The weighted harmonic mean is less than or equal to the
+/-- Weighted **AM-HM inequality**: The weighted harmonic mean is less than or equal to the
 arithmetic mean. -/
 theorem inv_sum_div_le_sum_mul [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
     {w f : ι → R} (hw : ∑ i ∈ s, w i = 1) (hw' : ∀ i ∈ s, 0 < w i) (hf : ∀ i ∈ s, 0 < f i) :
@@ -219,7 +219,7 @@ theorem inv_sum_div_le_sum_mul [LinearOrderedSemifield R] [ExistsAddOfLE R] (s :
     refine sum_congr rfl fun i hi ↦ ?_
     rw [div_div_cancel' (hw' i hi).ne']
 
-/-- **AM-HM** inequality: The harmonic mean is less than or equal to the arithmetic mean. -/
+/-- **AM-HM inequality**: The harmonic mean is less than or equal to the arithmetic mean. -/
 theorem div_sum_inv_le_sum_div [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
     {f : ι → R} (hf : ∀ i ∈ s, 0 < f i) : #s / ∑ i ∈ s, (f i)⁻¹ ≤ (∑ i ∈ s, f i) / #s := by
   obtain hs | hs := eq_zero_or_pos #s
@@ -230,7 +230,7 @@ theorem div_sum_inv_le_sum_div [LinearOrderedSemifield R] [ExistsAddOfLE R] (s :
     · simp_rw [div_eq_mul_inv, ← mul_sum, inv_mul_eq_div, inv_div, div_eq_mul_inv]
     · rw [← mul_sum, inv_mul_eq_div]
 
-/-- **AM-HM** inequality: The harmonic mean is less than or equal to the arithmetic mean. -/
+/-- **AM-HM inequality**: The harmonic mean is less than or equal to the arithmetic mean. -/
 theorem sq_le_sum_mul_sum_inv [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
     {f : ι → R} (hf : ∀ i ∈ s, 0 < f i) : #s ^ 2 ≤ (∑ i ∈ s, f i) * (∑ i ∈ s, (f i)⁻¹) := by
   have hf' : ∀ i ∈ s, 0 < (f i)⁻¹ := fun i hi ↦ inv_pos.2 (hf i hi)

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -231,7 +231,7 @@ theorem div_sum_inv_le_sum_div [LinearOrderedSemifield R] [ExistsAddOfLE R] (s :
 
 /-- **AM-HM** inequality. -/
 theorem sq_le_sum_mul_sum_inv [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
-    {f : ι → R} (hf : ∀ i ∈ s, 0 < f i) : (#s)^2 ≤ (∑ i ∈ s, f i) * (∑ i ∈ s, (f i)⁻¹) := by
+    {f : ι → R} (hf : ∀ i ∈ s, 0 < f i) : #s ^ 2 ≤ (∑ i ∈ s, f i) * (∑ i ∈ s, (f i)⁻¹) := by
   have hf' : ∀ i ∈ s, 0 < (f i)⁻¹ := fun i hi ↦ inv_pos.2 (hf i hi)
   obtain hs | hs := eq_zero_or_pos (#s)
   · rw [hs, Nat.cast_zero, zero_pow two_ne_zero]

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -208,7 +208,8 @@ theorem sq_sum_div_le_sum_sq_div [LinearOrderedSemifield R] [ExistsAddOfLE R] (s
   rw [div_mul_cancel₀]
   exact (hg i hi).ne'
 
-/-- Weighted **AM-HM** inequality. -/
+/-- Weighted **AM-HM** inequality": The weighted harmonic mean is less than or equal to the
+arithmetic mean -/
 theorem inv_sum_div_le_sum_mul [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
     {w f : ι → R} (hw : ∑ i ∈ s, w i = 1) (hw' : ∀ i ∈ s, 0 < w i) (hf : ∀ i ∈ s, 0 < f i) :
     (∑ i ∈ s, w i / f i)⁻¹ ≤ ∑ i ∈ s, w i * f i := by
@@ -218,7 +219,7 @@ theorem inv_sum_div_le_sum_mul [LinearOrderedSemifield R] [ExistsAddOfLE R] (s :
     refine sum_congr rfl fun i hi ↦ ?_
     rw [div_div_cancel' (hw' i hi).ne']
 
-/-- **AM-HM** inequality. -/
+/-- **AM-HM** inequality: The harmonic mean is less than or equal to the arithmetic mean -/
 theorem div_sum_inv_le_sum_div [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
     {f : ι → R} (hf : ∀ i ∈ s, 0 < f i) : #s / ∑ i ∈ s, (f i)⁻¹ ≤ (∑ i ∈ s, f i) / #s := by
   obtain hs | hs := eq_zero_or_pos #s
@@ -229,7 +230,7 @@ theorem div_sum_inv_le_sum_div [LinearOrderedSemifield R] [ExistsAddOfLE R] (s :
     · simp_rw [div_eq_mul_inv, ← mul_sum, inv_mul_eq_div, inv_div, div_eq_mul_inv]
     · rw [← mul_sum, inv_mul_eq_div]
 
-/-- **AM-HM** inequality. -/
+/-- **AM-HM** inequality: The harmonic mean is less than or equal to the arithmetic mean -/
 theorem sq_le_sum_mul_sum_inv [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
     {f : ι → R} (hf : ∀ i ∈ s, 0 < f i) : #s ^ 2 ≤ (∑ i ∈ s, f i) * (∑ i ∈ s, (f i)⁻¹) := by
   have hf' : ∀ i ∈ s, 0 < (f i)⁻¹ := fun i hi ↦ inv_pos.2 (hf i hi)

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -208,6 +208,39 @@ theorem sq_sum_div_le_sum_sq_div [LinearOrderedSemifield R] [ExistsAddOfLE R] (s
   rw [div_mul_cancel₀]
   exact (hg i hi).ne'
 
+/-- Weighted **AM-HM** inequality. -/
+theorem inv_sum_div_le_sum_mul [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
+    {w f : ι → R} (hw : ∑ i ∈ s, w i = 1) (hw' : ∀ i ∈ s, 0 < w i) (hf : ∀ i ∈ s, 0 < f i) :
+    (∑ i ∈ s, w i / f i)⁻¹ ≤ ∑ i ∈ s, w i * f i := by
+  convert sq_sum_div_le_sum_sq_div s w fun i hi ↦ div_pos (hw' i hi) (hf i hi) using 1
+  · rw [hw, one_pow, one_div]
+  · simp_rw [pow_two, mul_div_assoc]
+    refine sum_congr rfl fun i hi ↦ ?_
+    rw [div_div_cancel' (hw' i hi).ne']
+
+/-- **AM-HM** inequality. -/
+theorem div_sum_inv_le_sum_div [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
+    {f : ι → R} (hf : ∀ i ∈ s, 0 < f i) : #s / ∑ i ∈ s, (f i)⁻¹ ≤ (∑ i ∈ s, f i) / #s := by
+  obtain hs | hs := eq_zero_or_pos #s
+  · simp [hs]
+  · have hs : 0 < (#s : R) := mod_cast hs
+    have hw : ∑ _ ∈ s, (#s : R)⁻¹ = 1 := by rw [sum_const, nsmul_eq_mul, mul_inv_cancel₀ hs.ne']
+    convert inv_sum_div_le_sum_mul s hw (fun _ _ ↦ inv_pos.2 hs) hf using 1
+    · simp_rw [div_eq_mul_inv, ← mul_sum, inv_mul_eq_div, inv_div, div_eq_mul_inv]
+    · rw [← mul_sum, inv_mul_eq_div]
+
+/-- **AM-HM** inequality. -/
+theorem sq_le_sum_mul_sum_inv [LinearOrderedSemifield R] [ExistsAddOfLE R] (s : Finset ι)
+    {f : ι → R} (hf : ∀ i ∈ s, 0 < f i) : (#s)^2 ≤ (∑ i ∈ s, f i) * (∑ i ∈ s, (f i)⁻¹) := by
+  have hf' : ∀ i ∈ s, 0 < (f i)⁻¹ := fun i hi ↦ inv_pos.2 (hf i hi)
+  obtain hs | hs := eq_zero_or_pos (#s)
+  · rw [hs, Nat.cast_zero, zero_pow two_ne_zero]
+    apply mul_nonneg <;> apply sum_nonneg fun i hi ↦ ?_
+    · exact (hf i hi).le
+    · exact (hf' i hi).le
+  · rw [pow_two, ← div_le_div_iff₀ (sum_pos hf' (card_pos.1 hs)) (mod_cast hs)]
+    exact div_sum_inv_le_sum_div s hf
+
 end Finset
 
 /-! ### Absolute values -/

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -144,7 +144,7 @@ theorem geom_mean_le_arith_mean_weighted (w z : ι → ℝ) (hw : ∀ i ∈ s, 0
       · simp [A i hi hz.symm]
       · rw [exp_log hz]
 
-/-- **AM-GM inequality**: The **geometric mean is less than or equal to the arithmetic mean. --/
+/-- **AM-GM inequality**: The geometric mean is less than or equal to the arithmetic mean. --/
 theorem geom_mean_le_arith_mean {ι : Type*} (s : Finset ι) (w : ι → ℝ) (z : ι → ℝ)
     (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : 0 < ∑ i ∈ s, w i) (hz : ∀ i ∈ s, 0 ≤ z i) :
     (∏ i ∈ s, z i ^ w i) ^ (∑ i ∈ s, w i)⁻¹  ≤  (∑ i ∈ s, w i * z i) / (∑ i ∈ s, w i) := by
@@ -282,7 +282,7 @@ theorem harm_mean_le_geom_mean_weighted (w z : ι → ℝ) (hs : s.Nonempty) (hw
     · rw [Real.inv_rpow]; apply fun i hi ↦ le_of_lt (hz i hi); assumption
 
 
-/-- **HM-GM inequality**: The **harmonic mean is less than or equal to the geometric mean. --/
+/-- **HM-GM inequality**: The harmonic mean is less than or equal to the geometric mean. --/
 theorem harm_mean_le_geom_mean {ι : Type*} (s : Finset ι) (hs : s.Nonempty) (w : ι → ℝ)
     (z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i) (hw' : 0 < ∑ i in s, w i) (hz : ∀ i ∈ s, 0 < z i) :
     (∑ i in s, w i) / (∑ i in s, w i / z i) ≤ (∏ i in s, z i ^ w i) ^ (∑ i in s, w i)⁻¹ := by


### PR DESCRIPTION
We prove the weighted and unweighted AM-HM inequalities in linearly ordered semifields.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
