### PR TITLE
[Merged by Bors] - feat(NumberTheory/LSeries/PrimesInAP): proof of Dirichlet's Theorem

### DIFF
--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -468,6 +468,7 @@ namespace Nat
 open ArithmeticFunction vonMangoldt
 
 variable {q : ℕ} [NeZero q] {a : ZMod q}
+
 /-- **Dirichlet's Theorem** on primes in arithmetic progression: if `q` is a positive
 integer and `a : ZMod q` is a unit, then there are infintely many prime numbers `p`
 such that `(p : ZMod q) = a`. -/

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -32,6 +32,12 @@ The main steps of the proof are as follows.
    `(q.totient)⁻¹/(s-1)`, which cancels the pole at `s = 1`.
 5. Show that the auxiliary function is continuous on `re s ≥ 1`,
    See `ArithmeticFunction.vonMangoldt.continuousOn_auxFun`.
+   This relies heavily on the non-vanihsing of Dirichlet L-functions on the *closed*
+   half-plane `re s ≥ 1` (`DirichletCharacter.LFunction_ne_zero_of_one_le_re`), which
+   in turn can only be stated since we know that the L-series of a Dirichlet character
+   extends to an entire function (unless the character is trivial; then there is a
+   simple pole at `s = 1`); see `DirichletCharacter.LFunction_eq_LSeries`
+   (contributed by David Loeffler).
 6. Show that the sum of `Λ n / n` over any residue class, but *excluding* the primes, converges.
    See `ArithmeticFunction.vonMangoldt.summable_residueClass_non_primes_div`.
 7. Combining these ingredients, we can deduce that the sum of `Λ n / n` over

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
 import Mathlib.NumberTheory.DirichletCharacter.Orthogonality
-import Mathlib.NumberTheory.LSeries.DirichletContinuation
 import Mathlib.NumberTheory.LSeries.Linearity
+import Mathlib.NumberTheory.LSeries.Nonvanishing
 import Mathlib.RingTheory.RootsOfUnity.AlgebraicallyClosed
 
 /-!
@@ -15,12 +15,46 @@ The goal of this file is to prove **Dirichlet's Theorem**: If `q` is a positive 
 and `a : ZMod q` is invertible, then there are infinitely many prime numbers `p` such that
 `(p : ZMod q) = a`.
 
-This will be done in the following steps:
+The main steps of the proof are as follows.
+1. Define `ArithmeticFunction.vonMangoldt.residueClass a` for `a : ZMod q`, which is
+   a function `ℕ → ℝ` taking the value zero when `(n : ℤMod q) ≠ a` and `Λ n` else
+   (where `Λ` is the vn Mangoldt function `ArithmeticFunction.vonMangoldt`; we have
+   `Λ (p^k) = log p` for prime powers and `Λ n = 0` otherwise.)
+2. Show that this function can be written as a linear combination of functions
+   of the form `χ * Λ` with Dirichlet characters `χ` mod `q`.
+   See `ArithmeticFunction.vonMangoldt.residueClass_eq`.
+3. This implies that the L-series of `ArithmeticFunction.vonMangoldt.residueClass a`
+   agrees (on `re s > 1`) with the corresponding linear combinations of negative logarithmic
+   derivatives of Dirichlet L-functions.
+   See `ArithmeticFunction.vonMangoldt.LSeries_residueClass_eq`.
+4. Define an auxiliary function `ArithmeticFunction.vonMangoldt.auxFun a` that is
+   this linear combination of negative logarithmic derivatives of L-functions minus
+   `(q.totient)⁻¹/(s-1)`, which cancels the pole at `s = 1`.
+5. Show that the auxiliary function is continuous on `re s ≥ 1`:
+   `ArithmeticFunction.vonMangoldt.continuousOn_auxFun`.
+6. Show that the sum of `Λ n / n` over any residue class, but *excluding* the primes, converges.
+   See `ArithmeticFunction.vonMangoldt.summable_residueClass_non_primes_div`.
+7. Combining these ingredients, we can deduce that the sum of `Λ n / n` over
+   the *primes* in a residue class must diverge.
+   See `ArithmeticFunction.vonMangoldt.not_summable_residueClass_prime_div`.
+8. This finally easily implies that there must be infinitely many primes in the residue class.
 
-1. Some auxiliary lemmas on infinite products and sums
-2. Results on the von Mangoldt function restricted to a residue class
-3. (TODO) Results on its L-series and an auxiliary function related to it
-4. (TODO) Derivation of Dirichlet's Theorem
+## Definitions
+
+* `ArithmeticFunction.vonMangoldt.residueClass a` (see above).
+* `ArithmeticFunction.vonMangoldt.continuousOn_auxFun` (see above).
+
+## Main Result
+
+We give two versions of **Dirichlet's Theorem**:
+* `Nat.setOf_prime_and_eq_mod_infinite` states that the set of primes `p`
+   such that `(p : ZMod q) = a` is infinite (when `a` is invertible in `ZMod q`).
+* `Nat.forall_exists_prime_gt_and_eq_mod` states that for any natural number `n`
+  there is a prime `p > n` such that `(p : ZMod q) = a`.
+
+## Tags
+
+prime number, arithmetic progression, residue class, Dirichlet's Theorem
 -/
 
 /-!
@@ -248,6 +282,194 @@ lemma LSeries_residueClass_eq (ha : IsUnit a) {s : ℂ} (hs : 1 < s.re) :
   simp only [Pi.smul_apply, residueClass_apply ha, smul_eq_mul, ← mul_assoc,
     mul_inv_cancel_of_invertible, one_mul, Finset.sum_apply, Pi.mul_apply]
 
+variable (a)
+
+open Classical in
+/-- The auxiliary function used, e.g., with the Wiener-Ikehara Theorem to prove
+Dirichlet's Theorem. On `re s > 1`, it agrees with the L-series of the von Mangoldt
+function restricted to the residue class `a : ZMod q` minus the principal part
+`(q.totient)⁻¹/(s-1)` of the pole at `s = 1`; see `DirichletsThm.auxFun_prop`. -/
+noncomputable
+abbrev auxFun (s : ℂ) : ℂ :=
+  (q.totient : ℂ)⁻¹ * (-deriv (LFunctionTrivChar₁ q) s / LFunctionTrivChar₁ q s -
+    ∑ χ ∈ ({1}ᶜ : Finset (DirichletCharacter ℂ q)), χ a⁻¹ * deriv (LFunction χ) s / LFunction χ s)
+
+/-- The auxiliary function is continuous away from the zeros of the L-functions of the Dirichlet
+characters mod `q` (including at `s = 1`). -/
+lemma continuousOn_auxFun' :
+    ContinuousOn (auxFun a) {s | s = 1 ∨ ∀ χ : DirichletCharacter ℂ q, LFunction χ s ≠ 0} := by
+  rw [show auxFun a = fun s ↦ _ from rfl]
+  simp only [auxFun, sub_eq_add_neg]
+  refine continuousOn_const.mul <| ContinuousOn.add ?_ ?_
+  · refine (continuousOn_neg_logDeriv_LFunctionTrivChar₁ q).mono fun s hs ↦ ?_
+    have := LFunction_ne_zero_of_one_le_re (1 : DirichletCharacter ℂ q) (s := s)
+    simp only [ne_eq, Set.mem_setOf_eq] at hs
+    tauto
+  · simp only [← Finset.sum_neg_distrib, mul_div_assoc, ← mul_neg, ← neg_div]
+    refine continuousOn_finset_sum _ fun χ hχ ↦ continuousOn_const.mul ?_
+    replace hχ : χ ≠ 1 := by simpa only [ne_eq, Finset.mem_compl, Finset.mem_singleton] using hχ
+    refine (continuousOn_neg_logDeriv_LFunction_of_nontriv hχ).mono fun s hs ↦ ?_
+    simp only [ne_eq, Set.mem_setOf_eq] at hs
+    rcases hs with rfl | hs
+    · simp only [ne_eq, Set.mem_setOf_eq, one_re, le_refl,
+        LFunction_ne_zero_of_one_le_re χ (.inl hχ), not_false_eq_true]
+    · exact hs χ
+
+/-- The L-series of the von Mangoldt function restricted to the prime residue class `a` mod `q`
+is continuous on `re s ≥ 1` except for a single pole at `s = 1` with residue `(q.totient)⁻¹`.
+The statement as given here in terms auf `DirichletsThm.auxFun` is equivalent. -/
+lemma continuousOn_auxFun : ContinuousOn (auxFun a) {s | 1 ≤ s.re} := by
+  refine (continuousOn_auxFun' a).mono fun s hs ↦ ?_
+  rcases eq_or_ne s 1 with rfl | hs₁
+  · simp only [ne_eq, Set.mem_setOf_eq, true_or]
+  · simp only [ne_eq, Set.mem_setOf_eq, hs₁, false_or]
+    exact fun χ ↦ LFunction_ne_zero_of_one_le_re χ (.inr hs₁) <| Set.mem_setOf.mp hs
+
+variable {a}
+
+open scoped LSeries.notation
+
+/-- The auxiliary function agrees on `re s > 1` with the L-series of the von Mangoldt function
+restricted to the residue class `a : ZMod q` minus the principal part `(q.totient)⁻¹/(s-1)`
+of its pole at `s = 1`. -/
+lemma eqOn_auxFun (ha : IsUnit a) :
+    Set.EqOn (auxFun a)
+      (fun s ↦ L ↗(residueClass a) s - (q.totient : ℂ)⁻¹ / (s - 1))
+      {s | 1 < s.re} := by
+  intro s hs
+  replace hs := Set.mem_setOf.mp hs
+  simp only [LSeries_residueClass_eq ha hs, auxFun]
+  rw [neg_div, ← neg_add', mul_neg, ← neg_mul, div_eq_mul_one_div (q.totient : ℂ)⁻¹,
+    sub_eq_add_neg, ← neg_mul, ← mul_add]
+  congrm (_ * ?_)
+  -- this should be easier, but `IsUnit.inv ha` does not work here
+  have ha' : IsUnit a⁻¹ := isUnit_of_dvd_one ⟨a, (ZMod.inv_mul_of_unit a ha).symm⟩
+  classical -- for `Fintype.sum_eq_add_sum_compl`
+  rw [Fintype.sum_eq_add_sum_compl 1, MulChar.one_apply ha', one_mul, add_right_comm]
+  simp only [mul_div_assoc]
+  congrm (?_ + _)
+  have hs₁ : s ≠ 1 := fun h ↦ ((h ▸ hs).trans_eq one_re).false
+  rw [deriv_LFunctionTrivChar₁_apply_of_ne_one _ hs₁, LFunctionTrivChar₁,
+    Function.update_noteq hs₁, LFunctionTrivChar, add_div,
+    mul_div_mul_left _ _ (sub_ne_zero_of_ne hs₁)]
+  conv_lhs => enter [2, 1]; rw [← mul_one (LFunction ..)]
+  rw [mul_comm _ 1, mul_div_mul_right _ _ <| LFunction_ne_zero_of_one_le_re 1 (.inr hs₁) hs.le]
+
+/-- The auxiliary function takes real values for real arguments `x > 1`. -/
+lemma auxFun_real (ha : IsUnit a) {x : ℝ} (hx : 1 < x) : auxFun a x = (auxFun a x).re := by
+  rw [eqOn_auxFun ha hx]
+  simp only [sub_re, ofReal_sub]
+  congr 1
+  · rw [LSeries, re_tsum <| LSeriesSummable_of_abscissaOfAbsConv_lt_re <|
+      (abscissaOfAbsConv_residueClass_le_one a).trans_lt <| by norm_cast]
+    push_cast
+    refine tsum_congr fun n ↦ ?_
+    rcases eq_or_ne n 0 with rfl | hn
+    · simp only [term_zero, zero_re, ofReal_zero]
+    · simp only [term_of_ne_zero hn, ← ofReal_natCast n, ← ofReal_cpow n.cast_nonneg, ← ofReal_div,
+        ofReal_re]
+  · rw [show (q.totient : ℂ) = (q.totient : ℝ) from rfl, ← ofReal_one, ← ofReal_sub, ← ofReal_inv,
+      ← ofReal_div, ofReal_re]
+
+variable {q : ℕ} [NeZero q] {a : ZMod q}
+
+/-- As `x` approaches `1` from the right along the real axis, the L-series of
+`ArithmeticFunction.vonMangoldt.residueClass` is bounded below by `(q.totient)⁻¹/(x-1) - C`. -/
+lemma LSeries_residueClass_lower_bound (ha : IsUnit a) :
+    ∃ C : ℝ, ∀ {x : ℝ} (_ : x ∈ Set.Ioc 1 2),
+      (q.totient : ℝ)⁻¹ / (x - 1) - C ≤ ∑' n, residueClass a n / (n : ℝ) ^ x := by
+  have H {x : ℝ} (hx : 1 < x) :
+      ∑' n, residueClass a n / (n : ℝ) ^ x = (auxFun a x).re + (q.totient : ℝ)⁻¹ / (x - 1) := by
+    refine ofReal_injective ?_
+    simp only [ofReal_tsum, ofReal_div, ofReal_cpow (Nat.cast_nonneg _), ofReal_natCast,
+      ofReal_add, ofReal_inv, ofReal_sub, ofReal_one]
+    simp_rw [← auxFun_real ha hx, eqOn_auxFun ha <| Set.mem_setOf.mpr (ofReal_re x ▸ hx),
+      sub_add_cancel, LSeries, term]
+    refine tsum_congr fun n ↦ ?_
+    split_ifs with hn
+    · simp only [hn, residueClass_apply_zero, ofReal_zero, zero_div]
+    · rfl
+  have : ContinuousOn (fun x : ℝ ↦ (auxFun a x).re) (Set.Icc 1 2) :=
+    continuous_re.continuousOn.comp (t := Set.univ) (continuousOn_auxFun a)
+      (fun ⦃x⦄ a ↦ trivial) |>.comp continuous_ofReal.continuousOn fun x hx ↦ by
+        simpa only [Set.mem_setOf_eq, ofReal_re] using hx.1
+  obtain ⟨C, hC⟩ := bddBelow_def.mp <| IsCompact.bddBelow_image isCompact_Icc this
+  replace hC {x : ℝ} (hx : x ∈ Set.Icc 1 2) : C ≤ (auxFun a x).re :=
+    hC (auxFun a x).re <| Set.mem_image_of_mem (fun x : ℝ ↦ (auxFun a x).re) hx
+  refine ⟨-C, fun {x} hx ↦ ?_⟩
+  rw [H hx.1, add_comm, sub_neg_eq_add, add_le_add_iff_left]
+  exact hC <| Set.mem_Icc_of_Ioc hx
+
+open vonMangoldt Filter Topology in
+/-- The function `n ↦ Λ n / n` restricted to primes in an invertible residue class
+is not summable. This then implies that there must be infinitely many such primes. -/
+lemma not_summable_residueClass_prime_div (ha : IsUnit a) :
+    ¬ Summable fun n : ℕ ↦ (if n.Prime then residueClass a n else 0) / n := by
+  intro H
+  have key : Summable fun n : ℕ ↦ residueClass a n / n := by
+    convert (summable_residueClass_non_primes_div a).add H using 2 with n
+    simp only [← add_div, ite_add_ite, zero_add, add_zero, ite_self]
+  let C := ∑' n, residueClass a n / n
+  have H₁ {x : ℝ} (hx : 1 < x) : ∑' n, residueClass a n / (n : ℝ) ^ x ≤ C := by
+    refine tsum_le_tsum (fun n ↦ ?_) ?_ key
+    · rcases n.eq_zero_or_pos with rfl | hn
+      · simp only [Nat.cast_zero, Real.zero_rpow (zero_lt_one.trans hx).ne', div_zero, le_refl]
+      · refine div_le_div_of_nonneg_left (residueClass_nonneg a _) (mod_cast hn) ?_
+        conv_lhs => rw [← Real.rpow_one n]
+        exact Real.rpow_le_rpow_of_exponent_le (by norm_cast) hx.le
+    · exact summable_real_of_abscissaOfAbsConv_lt <|
+        (abscissaOfAbsConv_residueClass_le_one a).trans_lt <| mod_cast hx
+  obtain ⟨C', hC'⟩ := LSeries_residueClass_lower_bound ha
+  have H₁ {x} (hx : x ∈ Set.Ioc 1 2) : (q.totient : ℝ)⁻¹ ≤ (C + C') * (x - 1) :=
+    (div_le_iff₀ <| sub_pos.mpr hx.1).mp <|
+      sub_le_iff_le_add.mp <| (hC' hx).trans (H₁ hx.1)
+  have hq : 0 < (q.totient : ℝ)⁻¹ := inv_pos.mpr (mod_cast q.totient.pos_of_neZero)
+  rcases le_or_lt (C + C') 0 with h₀ | h₀
+  · have := hq.trans_le (H₁ (Set.right_mem_Ioc.mpr one_lt_two))
+    rw [show (2 : ℝ) - 1 = 1 by norm_num, mul_one] at this
+    exact (this.trans_le h₀).false
+  · obtain ⟨ξ, hξ₁, hξ₂⟩ : ∃ ξ ∈ Set.Ioc 1 2, (C + C') * (ξ - 1) < (q.totient : ℝ)⁻¹ := by
+      refine ⟨min (1 + (q.totient : ℝ)⁻¹ / (C + C') / 2) 2, ⟨?_, min_le_right ..⟩, ?_⟩
+      · simpa only [lt_inf_iff, lt_add_iff_pos_right, Nat.ofNat_pos, div_pos_iff_of_pos_right,
+          Nat.one_lt_ofNat, and_true] using div_pos hq h₀
+      · rw [← min_sub_sub_right, add_sub_cancel_left, ← lt_div_iff₀' h₀]
+        exact (min_le_left ..).trans_lt <| div_lt_self (div_pos hq h₀) one_lt_two
+    exact ((H₁ hξ₁).trans_lt hξ₂).false
+
 end ArithmeticFunction.vonMangoldt
 
 end arith_prog
+
+/-!
+### Dirichlet's Theorem
+-/
+
+section DirichletsTheorem
+
+namespace Nat
+
+open ArithmeticFunction vonMangoldt
+
+variable {q : ℕ} [NeZero q] {a : ZMod q}
+/-- **Dirichlet's Theorem** on primes in arithmetic progression: if `q` is a positive
+integer and `a : ZMod q` is a unit, then there are infintely many prime numbers `p`
+such that `(p : ZMod q) = a`. -/
+theorem setOf_prime_and_eq_mod_infinite (ha : IsUnit a) :
+    {p : ℕ | p.Prime ∧ (p : ZMod q) = a}.Infinite := by
+  by_contra H
+  rw [Set.not_infinite] at H
+  have := support_residueClass_prime_div a ▸ H
+  exact not_summable_residueClass_prime_div ha <|
+    summable_of_finite_support <| support_residueClass_prime_div a ▸ H
+
+/-- **Dirichlet's Theorem** on primes in arithmetic progression: if `q` is a positive
+integer and `a : ZMod q` is a unit, then there are infintely many prime numbers `p`
+such that `(p : ZMod q) = a`. -/
+theorem forall_exists_prime_gt_and_eq_mod (ha : IsUnit a) (n : ℕ) :
+    ∃ p > n, p.Prime ∧ (p : ZMod q) = a := by
+  obtain ⟨p, hp₁, hp₂⟩ := Set.infinite_iff_exists_gt.mp (setOf_prime_and_eq_mod_infinite ha) n
+  exact ⟨p, hp₂.gt, Set.mem_setOf.mp hp₁⟩
+
+end Nat
+
+end DirichletsTheorem

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -30,7 +30,7 @@ The main steps of the proof are as follows.
 4. Define an auxiliary function `ArithmeticFunction.vonMangoldt.auxFun a` that is
    this linear combination of negative logarithmic derivatives of L-functions minus
    `(q.totient)⁻¹/(s-1)`, which cancels the pole at `s = 1`.
-   See `ArithmeticFuncion.vonMangolgt.eqOn_auxFun` for the statement that the auxiliary function
+   See `ArithmeticFunction.vonMangoldt.eqOn_auxFun` for the statement that the auxiliary function
    agrees with the L-series of `ArithmeticFunction.vonMangoldt.residueClass` up to the
    term `(q.totient)⁻¹/(s-1)`.
 5. Show that the auxiliary function is continuous on `re s ≥ 1`,

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -18,20 +18,20 @@ and `a : ZMod q` is invertible, then there are infinitely many prime numbers `p`
 The main steps of the proof are as follows.
 1. Define `ArithmeticFunction.vonMangoldt.residueClass a` for `a : ZMod q`, which is
    a function `ℕ → ℝ` taking the value zero when `(n : ℤMod q) ≠ a` and `Λ n` else
-   (where `Λ` is the vn Mangoldt function `ArithmeticFunction.vonMangoldt`; we have
+   (where `Λ` is the von Mangoldt function `ArithmeticFunction.vonMangoldt`; we have
    `Λ (p^k) = log p` for prime powers and `Λ n = 0` otherwise.)
 2. Show that this function can be written as a linear combination of functions
-   of the form `χ * Λ` with Dirichlet characters `χ` mod `q`.
+   of the form `χ * Λ` (pointwise product) with Dirichlet characters `χ` mod `q`.
    See `ArithmeticFunction.vonMangoldt.residueClass_eq`.
 3. This implies that the L-series of `ArithmeticFunction.vonMangoldt.residueClass a`
-   agrees (on `re s > 1`) with the corresponding linear combinations of negative logarithmic
+   agrees (on `re s > 1`) with the corresponding linear combination of negative logarithmic
    derivatives of Dirichlet L-functions.
    See `ArithmeticFunction.vonMangoldt.LSeries_residueClass_eq`.
 4. Define an auxiliary function `ArithmeticFunction.vonMangoldt.auxFun a` that is
    this linear combination of negative logarithmic derivatives of L-functions minus
    `(q.totient)⁻¹/(s-1)`, which cancels the pole at `s = 1`.
-5. Show that the auxiliary function is continuous on `re s ≥ 1`:
-   `ArithmeticFunction.vonMangoldt.continuousOn_auxFun`.
+5. Show that the auxiliary function is continuous on `re s ≥ 1`,
+   See `ArithmeticFunction.vonMangoldt.continuousOn_auxFun`.
 6. Show that the sum of `Λ n / n` over any residue class, but *excluding* the primes, converges.
    See `ArithmeticFunction.vonMangoldt.summable_residueClass_non_primes_div`.
 7. Combining these ingredients, we can deduce that the sum of `Λ n / n` over

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -27,14 +27,14 @@ The main steps of the proof are as follows.
    agrees (on `re s > 1`) with the corresponding linear combination of negative logarithmic
    derivatives of Dirichlet L-functions.
    See `ArithmeticFunction.vonMangoldt.LSeries_residueClass_eq`.
-4. Define an auxiliary function `ArithmeticFunction.vonMangoldt.auxFun a` that is
+4. Define an auxiliary function `ArithmeticFunction.vonMangoldt.LfunctionResidueClassAux a` that is
    this linear combination of negative logarithmic derivatives of L-functions minus
    `(q.totient)⁻¹/(s-1)`, which cancels the pole at `s = 1`.
-   See `ArithmeticFunction.vonMangoldt.eqOn_auxFun` for the statement that the auxiliary function
-   agrees with the L-series of `ArithmeticFunction.vonMangoldt.residueClass` up to the
-   term `(q.totient)⁻¹/(s-1)`.
+   See `ArithmeticFunction.vonMangoldt.eqOn_LfunctionResidueClassAux` for the statement
+   that the auxiliary function agrees with the L-series of
+   `ArithmeticFunction.vonMangoldt.residueClass` up to the term `(q.totient)⁻¹/(s-1)`.
 5. Show that the auxiliary function is continuous on `re s ≥ 1`,
-   See `ArithmeticFunction.vonMangoldt.continuousOn_auxFun`.
+   See `ArithmeticFunction.vonMangoldt.continuousOn_LfunctionResidueClassAux`.
    This relies heavily on the non-vanihsing of Dirichlet L-functions on the *closed*
    half-plane `re s ≥ 1` (`DirichletCharacter.LFunction_ne_zero_of_one_le_re`), which
    in turn can only be stated since we know that the L-series of a Dirichlet character
@@ -51,7 +51,7 @@ The main steps of the proof are as follows.
 ## Definitions
 
 * `ArithmeticFunction.vonMangoldt.residueClass a` (see above).
-* `ArithmeticFunction.vonMangoldt.continuousOn_auxFun` (see above).
+* `ArithmeticFunction.vonMangoldt.continuousOn_LfunctionResidueClassAux` (see above).
 
 ## Main Result
 
@@ -297,18 +297,20 @@ open Classical in
 /-- The auxiliary function used, e.g., with the Wiener-Ikehara Theorem to prove
 Dirichlet's Theorem. On `re s > 1`, it agrees with the L-series of the von Mangoldt
 function restricted to the residue class `a : ZMod q` minus the principal part
-`(q.totient)⁻¹/(s-1)` of the pole at `s = 1`; see `ArithmeticFunction.vonMangoldt.eqOn_auxFun`. -/
+`(q.totient)⁻¹/(s-1)` of the pole at `s = 1`;
+see `ArithmeticFunction.vonMangoldt.eqOn_LfunctionResidueClassAux`. -/
 noncomputable
-abbrev auxFun (s : ℂ) : ℂ :=
+abbrev LfunctionResidueClassAux (s : ℂ) : ℂ :=
   (q.totient : ℂ)⁻¹ * (-deriv (LFunctionTrivChar₁ q) s / LFunctionTrivChar₁ q s -
     ∑ χ ∈ ({1}ᶜ : Finset (DirichletCharacter ℂ q)), χ a⁻¹ * deriv (LFunction χ) s / LFunction χ s)
 
 /-- The auxiliary function is continuous away from the zeros of the L-functions of the Dirichlet
 characters mod `q` (including at `s = 1`). -/
-lemma continuousOn_auxFun' :
-    ContinuousOn (auxFun a) {s | s = 1 ∨ ∀ χ : DirichletCharacter ℂ q, LFunction χ s ≠ 0} := by
-  rw [show auxFun a = fun s ↦ _ from rfl]
-  simp only [auxFun, sub_eq_add_neg]
+lemma continuousOn_LfunctionResidueClassAux' :
+    ContinuousOn (LfunctionResidueClassAux a)
+      {s | s = 1 ∨ ∀ χ : DirichletCharacter ℂ q, LFunction χ s ≠ 0} := by
+  rw [show LfunctionResidueClassAux a = fun s ↦ _ from rfl]
+  simp only [LfunctionResidueClassAux, sub_eq_add_neg]
   refine continuousOn_const.mul <| ContinuousOn.add ?_ ?_
   · refine (continuousOn_neg_logDeriv_LFunctionTrivChar₁ q).mono fun s hs ↦ ?_
     have := LFunction_ne_zero_of_one_le_re (1 : DirichletCharacter ℂ q) (s := s)
@@ -326,9 +328,11 @@ lemma continuousOn_auxFun' :
 
 /-- The L-series of the von Mangoldt function restricted to the prime residue class `a` mod `q`
 is continuous on `re s ≥ 1` except for a single pole at `s = 1` with residue `(q.totient)⁻¹`.
-The statement as given here in terms of `ArithmeticFunction.vonMangoldt.auxFun` is equivalent. -/
-lemma continuousOn_auxFun : ContinuousOn (auxFun a) {s | 1 ≤ s.re} := by
-  refine (continuousOn_auxFun' a).mono fun s hs ↦ ?_
+The statement as given here in terms of `ArithmeticFunction.vonMangoldt.LfunctionResidueClassAux`
+is equivalent. -/
+lemma continuousOn_LfunctionResidueClassAux :
+    ContinuousOn (LfunctionResidueClassAux a) {s | 1 ≤ s.re} := by
+  refine (continuousOn_LfunctionResidueClassAux' a).mono fun s hs ↦ ?_
   rcases eq_or_ne s 1 with rfl | hs₁
   · simp only [ne_eq, Set.mem_setOf_eq, true_or]
   · simp only [ne_eq, Set.mem_setOf_eq, hs₁, false_or]
@@ -341,13 +345,13 @@ open scoped LSeries.notation
 /-- The auxiliary function agrees on `re s > 1` with the L-series of the von Mangoldt function
 restricted to the residue class `a : ZMod q` minus the principal part `(q.totient)⁻¹/(s-1)`
 of its pole at `s = 1`. -/
-lemma eqOn_auxFun (ha : IsUnit a) :
-    Set.EqOn (auxFun a)
+lemma eqOn_LfunctionResidueClassAux (ha : IsUnit a) :
+    Set.EqOn (LfunctionResidueClassAux a)
       (fun s ↦ L ↗(residueClass a) s - (q.totient : ℂ)⁻¹ / (s - 1))
       {s | 1 < s.re} := by
   intro s hs
   replace hs := Set.mem_setOf.mp hs
-  simp only [LSeries_residueClass_eq ha hs, auxFun]
+  simp only [LSeries_residueClass_eq ha hs, LfunctionResidueClassAux]
   rw [neg_div, ← neg_add', mul_neg, ← neg_mul, div_eq_mul_one_div (q.totient : ℂ)⁻¹,
     sub_eq_add_neg, ← neg_mul, ← mul_add]
   congrm (_ * ?_)
@@ -365,8 +369,9 @@ lemma eqOn_auxFun (ha : IsUnit a) :
   rw [mul_comm _ 1, mul_div_mul_right _ _ <| LFunction_ne_zero_of_one_le_re 1 (.inr hs₁) hs.le]
 
 /-- The auxiliary function takes real values for real arguments `x > 1`. -/
-lemma auxFun_real (ha : IsUnit a) {x : ℝ} (hx : 1 < x) : auxFun a x = (auxFun a x).re := by
-  rw [eqOn_auxFun ha hx]
+lemma LfunctionResidueClassAux_real (ha : IsUnit a) {x : ℝ} (hx : 1 < x) :
+    LfunctionResidueClassAux a x = (LfunctionResidueClassAux a x).re := by
+  rw [eqOn_LfunctionResidueClassAux ha hx]
   simp only [sub_re, ofReal_sub]
   congr 1
   · rw [LSeries, re_tsum <| LSeriesSummable_of_abscissaOfAbsConv_lt_re <|
@@ -388,23 +393,26 @@ lemma LSeries_residueClass_lower_bound (ha : IsUnit a) :
     ∃ C : ℝ, ∀ {x : ℝ} (_ : x ∈ Set.Ioc 1 2),
       (q.totient : ℝ)⁻¹ / (x - 1) - C ≤ ∑' n, residueClass a n / (n : ℝ) ^ x := by
   have H {x : ℝ} (hx : 1 < x) :
-      ∑' n, residueClass a n / (n : ℝ) ^ x = (auxFun a x).re + (q.totient : ℝ)⁻¹ / (x - 1) := by
+      ∑' n, residueClass a n / (n : ℝ) ^ x =
+        (LfunctionResidueClassAux a x).re + (q.totient : ℝ)⁻¹ / (x - 1) := by
     refine ofReal_injective ?_
     simp only [ofReal_tsum, ofReal_div, ofReal_cpow (Nat.cast_nonneg _), ofReal_natCast,
       ofReal_add, ofReal_inv, ofReal_sub, ofReal_one]
-    simp_rw [← auxFun_real ha hx, eqOn_auxFun ha <| Set.mem_setOf.mpr (ofReal_re x ▸ hx),
-      sub_add_cancel, LSeries, term]
+    simp_rw [← LfunctionResidueClassAux_real ha hx,
+      eqOn_LfunctionResidueClassAux ha <| Set.mem_setOf.mpr (ofReal_re x ▸ hx), sub_add_cancel,
+      LSeries, term]
     refine tsum_congr fun n ↦ ?_
     split_ifs with hn
     · simp only [hn, residueClass_apply_zero, ofReal_zero, zero_div]
     · rfl
-  have : ContinuousOn (fun x : ℝ ↦ (auxFun a x).re) (Set.Icc 1 2) :=
-    continuous_re.continuousOn.comp (t := Set.univ) (continuousOn_auxFun a)
+  have : ContinuousOn (fun x : ℝ ↦ (LfunctionResidueClassAux a x).re) (Set.Icc 1 2) :=
+    continuous_re.continuousOn.comp (t := Set.univ) (continuousOn_LfunctionResidueClassAux a)
       (fun ⦃x⦄ a ↦ trivial) |>.comp continuous_ofReal.continuousOn fun x hx ↦ by
         simpa only [Set.mem_setOf_eq, ofReal_re] using hx.1
   obtain ⟨C, hC⟩ := bddBelow_def.mp <| IsCompact.bddBelow_image isCompact_Icc this
-  replace hC {x : ℝ} (hx : x ∈ Set.Icc 1 2) : C ≤ (auxFun a x).re :=
-    hC (auxFun a x).re <| Set.mem_image_of_mem (fun x : ℝ ↦ (auxFun a x).re) hx
+  replace hC {x : ℝ} (hx : x ∈ Set.Icc 1 2) : C ≤ (LfunctionResidueClassAux a x).re :=
+    hC (LfunctionResidueClassAux a x).re <|
+      Set.mem_image_of_mem (fun x : ℝ ↦ (LfunctionResidueClassAux a x).re) hx
   refine ⟨-C, fun {x} hx ↦ ?_⟩
   rw [H hx.1, add_comm, sub_neg_eq_add, add_le_add_iff_left]
   exact hC <| Set.mem_Icc_of_Ioc hx

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -30,6 +30,9 @@ The main steps of the proof are as follows.
 4. Define an auxiliary function `ArithmeticFunction.vonMangoldt.auxFun a` that is
    this linear combination of negative logarithmic derivatives of L-functions minus
    `(q.totient)⁻¹/(s-1)`, which cancels the pole at `s = 1`.
+   See `ArithmeticFuncion.vonMangolgt.eqOn_auxFun` for the statement that the auxiliary function
+   agrees with the L-series of `ArithmeticFunction.vonMangoldt.residueClass` up to the
+   term `(q.totient)⁻¹/(s-1)`.
 5. Show that the auxiliary function is continuous on `re s ≥ 1`,
    See `ArithmeticFunction.vonMangoldt.continuousOn_auxFun`.
    This relies heavily on the non-vanihsing of Dirichlet L-functions on the *closed*
@@ -294,7 +297,7 @@ open Classical in
 /-- The auxiliary function used, e.g., with the Wiener-Ikehara Theorem to prove
 Dirichlet's Theorem. On `re s > 1`, it agrees with the L-series of the von Mangoldt
 function restricted to the residue class `a : ZMod q` minus the principal part
-`(q.totient)⁻¹/(s-1)` of the pole at `s = 1`; see `DirichletsThm.auxFun_prop`. -/
+`(q.totient)⁻¹/(s-1)` of the pole at `s = 1`; see `ArithmeticFunction.vonMangoldt.eqOn_auxFun`. -/
 noncomputable
 abbrev auxFun (s : ℂ) : ℂ :=
   (q.totient : ℂ)⁻¹ * (-deriv (LFunctionTrivChar₁ q) s / LFunctionTrivChar₁ q s -
@@ -323,7 +326,7 @@ lemma continuousOn_auxFun' :
 
 /-- The L-series of the von Mangoldt function restricted to the prime residue class `a` mod `q`
 is continuous on `re s ≥ 1` except for a single pole at `s = 1` with residue `(q.totient)⁻¹`.
-The statement as given here in terms auf `DirichletsThm.auxFun` is equivalent. -/
+The statement as given here in terms of `ArithmeticFunction.vonMangoldt.auxFun` is equivalent. -/
 lemma continuousOn_auxFun : ContinuousOn (auxFun a) {s | 1 ≤ s.re} := by
   refine (continuousOn_auxFun' a).mono fun s hs ↦ ?_
   rcases eq_or_ne s 1 with rfl | hs₁

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -33,9 +33,9 @@ The main steps of the proof are as follows.
    See `ArithmeticFunction.vonMangoldt.eqOn_LfunctionResidueClassAux` for the statement
    that the auxiliary function agrees with the L-series of
    `ArithmeticFunction.vonMangoldt.residueClass` up to the term `(q.totient)⁻¹/(s-1)`.
-5. Show that the auxiliary function is continuous on `re s ≥ 1`,
-   See `ArithmeticFunction.vonMangoldt.continuousOn_LfunctionResidueClassAux`.
-   This relies heavily on the non-vanihsing of Dirichlet L-functions on the *closed*
+5. Show that the auxiliary function is continuous on `re s ≥ 1`;
+   see `ArithmeticFunction.vonMangoldt.continuousOn_LfunctionResidueClassAux`.
+   This relies heavily on the non-vanishing of Dirichlet L-functions on the *closed*
    half-plane `re s ≥ 1` (`DirichletCharacter.LFunction_ne_zero_of_one_le_re`), which
    in turn can only be stated since we know that the L-series of a Dirichlet character
    extends to an entire function (unless the character is trivial; then there is a
@@ -257,7 +257,7 @@ lemma summable_residueClass_non_primes_div :
 variable [NeZero q] {a}
 
 /-- We can express `ArithmeticFunction.vonMangoldt.residueClass` as a linear combination
-of twists of the von Mangoldt function with Dirichlet charaters. -/
+of twists of the von Mangoldt function by Dirichlet charaters. -/
 lemma residueClass_apply (ha : IsUnit a) (n : ℕ) :
     residueClass a n =
       (q.totient : ℂ)⁻¹ * ∑ χ : DirichletCharacter ℂ q, χ a⁻¹ * χ n * vonMangoldt n := by
@@ -267,7 +267,7 @@ lemma residueClass_apply (ha : IsUnit a) (n : ℕ) :
     ite_mul, zero_mul, ↓reduceIte, ite_self]
 
 /-- We can express `ArithmeticFunction.vonMangoldt.residueClass` as a linear combination
-of twists of the von Mangoldt function with Dirichlet charaters. -/
+of twists of the von Mangoldt function by Dirichlet charaters. -/
 lemma residueClass_eq (ha : IsUnit a) :
     ↗(residueClass a) = (q.totient : ℂ)⁻¹ •
       ∑ χ : DirichletCharacter ℂ q, χ a⁻¹ • (fun n : ℕ ↦ χ n * vonMangoldt n) := by
@@ -327,7 +327,7 @@ lemma continuousOn_LfunctionResidueClassAux' :
     · exact hs χ
 
 /-- The L-series of the von Mangoldt function restricted to the prime residue class `a` mod `q`
-is continuous on `re s ≥ 1` except for a single pole at `s = 1` with residue `(q.totient)⁻¹`.
+is continuous on `re s ≥ 1` except for a simple pole at `s = 1` with residue `(q.totient)⁻¹`.
 The statement as given here in terms of `ArithmeticFunction.vonMangoldt.LfunctionResidueClassAux`
 is equivalent. -/
 lemma continuousOn_LfunctionResidueClassAux :

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -458,7 +458,6 @@ theorem setOf_prime_and_eq_mod_infinite (ha : IsUnit a) :
     {p : ℕ | p.Prime ∧ (p : ZMod q) = a}.Infinite := by
   by_contra H
   rw [Set.not_infinite] at H
-  have := support_residueClass_prime_div a ▸ H
   exact not_summable_residueClass_prime_div ha <|
     summable_of_finite_support <| support_residueClass_prime_div a ▸ H
 

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -182,6 +182,8 @@
   title  : The Central Limit Theorem
 48:
   title  : Dirichlet’s Theorem
+  decl   : Nat.setOf_prime_and_eq_mod_infinite
+  author : Michael Stoll
 49:
   title  : The Cayley-Hamilton Theorem
   decl   : Matrix.aeval_self_charpoly

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -183,7 +183,7 @@
 48:
   title  : Dirichlet’s Theorem
   decl   : Nat.setOf_prime_and_eq_mod_infinite
-  author : Michael Stoll
+  author : David Loeffler, Michael Stoll
 49:
   title  : The Cayley-Hamilton Theorem
   decl   : Matrix.aeval_self_charpoly


### PR DESCRIPTION
---
This completes the proof of **Dirichlet's Theorem** on primes in residue classes.

See [here](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/Prerequisites.20for.20PNT.20and.20Dirichlet's.20Thm/near/484092915) on Zulip.

Note: I've added @loefflerd as an author in the `100.yaml` entry: without his great work on the analytic continuation of Dirichlet L-series, the proof would not had been possible.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
