### PR TITLE
feat(SetTheory/Game/PGame): dicotic pregames

### DIFF
--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1890,6 +1890,8 @@ def dicotic (x : PGame) : Prop :=
     ((LeftMoves (x.moveRight r) ≠ PEmpty) ∧
     (RightMoves (x.moveRight r)) ≠ PEmpty))
 
+/-! ### Special pre-games -/
+
 /-- The pre-game `star`, which is fuzzy with zero. -/
 def star : PGame.{u} :=
   ⟨PUnit, PUnit, fun _ => 0, fun _ => 0⟩

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1877,8 +1877,18 @@ theorem insertRight_insertLeft {x x' x'' : PGame} :
   cases x; cases x'; cases x''
   dsimp [insertLeft, insertRight]
 
-/-! ### Special pre-games -/
+/-! ### Dicotic pre-games -/
 
+/-- A game is dicotic if both players can move from every nonempty subposition of G. -/
+def dicotic (x : PGame) : Prop :=
+  (∀ (l : LeftMoves x),
+    (x.moveLeft l = 0) ∨
+    ((LeftMoves (x.moveLeft l) ≠ PEmpty) ∧
+    (RightMoves (x.moveLeft l)) ≠ PEmpty)) ∧
+  (∀ (r : RightMoves x),
+    (x.moveRight r = 0) ∨
+    ((LeftMoves (x.moveRight r) ≠ PEmpty) ∧
+    (RightMoves (x.moveRight r)) ≠ PEmpty))
 
 /-- The pre-game `star`, which is fuzzy with zero. -/
 def star : PGame.{u} :=
@@ -1921,6 +1931,10 @@ theorem star_fuzzy_zero : star ‖ 0 :=
 
 @[simp]
 theorem neg_star : -star = star := by simp [star]
+
+theorem star_dicotic : dicotic star := by
+  unfold dicotic
+  simp
 
 @[simp]
 protected theorem zero_lt_one : (0 : PGame) < 1 :=


### PR DESCRIPTION
Adds the definition of dicotic pregames and that `star` is a dicotic pregame. A second pull request may introduce the lawnmower theorem for long and short games.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
