### PR TITLE
[Merged by Bors] - feat(Probability): proper kernels

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4180,6 +4180,7 @@ import Mathlib.Probability.Kernel.Disintegration.Unique
 import Mathlib.Probability.Kernel.Integral
 import Mathlib.Probability.Kernel.Invariance
 import Mathlib.Probability.Kernel.MeasurableIntegral
+import Mathlib.Probability.Kernel.Proper
 import Mathlib.Probability.Kernel.RadonNikodym
 import Mathlib.Probability.Kernel.WithDensity
 import Mathlib.Probability.Martingale.Basic

--- a/Mathlib/Probability/Kernel/Proper.lean
+++ b/Mathlib/Probability/Kernel/Proper.lean
@@ -11,7 +11,7 @@ import Mathlib.Probability.Kernel.Basic
 This file defines properness of measure kernels.
 
 For two σ-algebras `𝓑 ≤ 𝓧`, a `𝓑, 𝓧`-kernel `π : X → Measure X` is proper if
-`∫ x, f x * g x ∂(π x₀) = g x₀ * ∫ x, f x ∂(π x₀)` for all `x₀ : X`, `𝓧`-measurable function `f`
+`∫ x, g x * f x ∂(π x₀) = g x₀ * ∫ x, f x ∂(π x₀)` for all `x₀ : X`, `𝓧`-measurable function `f`
 and `𝓑`-measurable function `g`.
 
 By the standard machine, this is equivalent to having that, for all `B ∈ 𝓑`, `π` restricted to `B`
@@ -33,7 +33,7 @@ variable {X : Type*} {𝓑 𝓧 : MeasurableSpace X} {π : Kernel[𝓑, 𝓧] X 
   {f g : X → ℝ≥0∞} {x₀ : X}
 
 /-- For two σ-algebras `𝓑 ≤ 𝓧` on a space `X`, a `𝓑, 𝓧`-kernel `π : X → Measure X` is proper if
-`∫ x, f x * g x ∂(π x₀) = g x₀ * ∫ x, f x ∂(π x₀)` for all `x₀ : X`, `𝓧`-measurable function `f`
+`∫ x, g x * f x ∂(π x₀) = g x₀ * ∫ x, f x ∂(π x₀)` for all `x₀ : X`, `𝓧`-measurable function `f`
 and `𝓑`-measurable function `g`.
 
 By the standard machine, this is equivalent to having that, for all `B ∈ 𝓑`, `π` restricted to `B`
@@ -89,27 +89,27 @@ private lemma IsProper.lintegral_indicator_mul_indicator (hπ : IsProper π) (h�
 set_option linter.style.multiGoal false in -- false positive
 /-- Auxiliary lemma for `IsProper.lintegral_mul` and
 `IsProper.setLIntegral_eq_indicator_mul_lintegral`. -/
-private lemma IsProper.lintegral_mul_indicator (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧)
+private lemma IsProper.lintegral_indicator_mul (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧)
     (hf : Measurable[𝓧] f) (hB : MeasurableSet[𝓑] B) :
-    ∫⁻ x, f x * B.indicator 1 x ∂(π x₀) = B.indicator 1 x₀ * ∫⁻ x, f x ∂(π x₀) := by
+    ∫⁻ x, B.indicator 1 x * f x ∂(π x₀) = B.indicator 1 x₀ * ∫⁻ x, f x ∂(π x₀) := by
   refine hf.ennreal_induction ?_ ?_ ?_
   · rintro c A hA
-    simp_rw [← smul_indicator_one_apply, smul_mul_assoc, mul_comm, smul_eq_mul]
+    simp_rw [← smul_indicator_one_apply, mul_smul_comm, smul_eq_mul]
     rw [lintegral_const_mul, lintegral_const_mul, hπ.lintegral_indicator_mul_indicator h𝓑𝓧 hA hB,
       mul_left_comm] <;> measurability
   · rintro f₁ f₂ - _ _ hf₁ hf₂
-    simp only [Pi.add_apply, add_mul]
+    simp only [Pi.add_apply, mul_add]
     rw [lintegral_add_right, lintegral_add_right, hf₁, hf₂, mul_add] <;> measurability
   · rintro f' hf'_meas hf'_mono hf'
-    simp_rw [ENNReal.iSup_mul]
+    simp_rw [ENNReal.mul_iSup]
     rw [lintegral_iSup (by measurability), lintegral_iSup hf'_meas hf'_mono, ENNReal.mul_iSup]
     simp_rw [hf']
-    · exact hf'_mono.mul_const (zero_le _)
+    · exact hf'_mono.const_mul (zero_le _)
 
 lemma IsProper.setLIntegral_eq_indicator_mul_lintegral (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧)
     (hf : Measurable[𝓧] f) (hB : MeasurableSet[𝓑] B) (x₀ : X) :
     ∫⁻ x in B, f x ∂(π x₀) = B.indicator 1 x₀ * ∫⁻ x, f x ∂(π x₀) := by
-  simp [← hπ.lintegral_mul_indicator h𝓑𝓧 hf hB, ← indicator_mul_right,
+  simp [← hπ.lintegral_indicator_mul h𝓑𝓧 hf hB, ← indicator_mul_left,
     lintegral_indicator (h𝓑𝓧 _ hB)]
 
 lemma IsProper.setLIntegral_inter_eq_indicator_mul_setLIntegral (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧)
@@ -120,20 +120,20 @@ lemma IsProper.setLIntegral_inter_eq_indicator_mul_setLIntegral (hπ : IsProper 
 
 lemma IsProper.lintegral_mul (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧) (hf : Measurable[𝓧] f)
     (hg : Measurable[𝓑] g) (x₀ : X) :
-    ∫⁻ x, f x * g x ∂(π x₀) = g x₀ * ∫⁻ x, f x ∂(π x₀) := by
+    ∫⁻ x, g x * f x ∂(π x₀) = g x₀ * ∫⁻ x, f x ∂(π x₀) := by
   refine hg.ennreal_induction ?_ ?_ ?_
   · rintro c A hA
-    simp_rw [← smul_indicator_one_apply, mul_smul_comm, smul_eq_mul]
-    rw [lintegral_const_mul, hπ.lintegral_mul_indicator h𝓑𝓧 hf hA, mul_assoc]
+    simp_rw [← smul_indicator_one_apply, smul_mul_assoc, smul_eq_mul]
+    rw [lintegral_const_mul, hπ.lintegral_indicator_mul h𝓑𝓧 hf hA]
     · measurability
   · rintro g₁ g₂ - _ hg₂_meas hg₁ hg₂
     simp only [Pi.add_apply, mul_add, add_mul]
     rw [lintegral_add_right, hg₁, hg₂]
-    · exact hf.mul (hg₂_meas.mono h𝓑𝓧 le_rfl)
+    · exact (hg₂_meas.mono h𝓑𝓧 le_rfl).mul hf
   · rintro g' hg'_meas hg'_mono hg'
-    simp_rw [ENNReal.iSup_mul, ENNReal.mul_iSup]
-    rw [lintegral_iSup (fun n ↦ hf.mul ((hg'_meas _).mono h𝓑𝓧 le_rfl))
-      (hg'_mono.const_mul (zero_le _))]
+    simp_rw [ENNReal.iSup_mul]
+    rw [lintegral_iSup (fun n ↦ ((hg'_meas _).mono h𝓑𝓧 le_rfl).mul hf)
+      (hg'_mono.mul_const (zero_le _))]
     simp_rw [hg']
 
 end ProbabilityTheory.Kernel

--- a/Mathlib/Probability/Kernel/Proper.lean
+++ b/Mathlib/Probability/Kernel/Proper.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2024 Yaël Dillies, Kalle Kytölä, Kin Yau James Wong. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Kalle Kytölä, Kin Yau James Wong
+-/
+import Mathlib.Probability.Kernel.Basic
+
+/-!
+# Proper kernels
+
+This file defines properness of measure kernels.
+
+For two σ-algebras `𝓑 ≤ 𝓧`, a `𝓑, 𝓧`-kernel `π : X → Measure X` is proper if
+`∫ x, f x * g x ∂(π x₀) = g x₀ * ∫ x, f x ∂(π x₀)` for all `x₀ : X`, `𝓧`-measurable function `f`
+and `𝓑`-measurable function `g`.
+
+By the standard machine, this is equivalent to having that, for all `B ∈ 𝓑`, `π` restricted to `B`
+is the same as `π` times the indicator of `B`.
+
+This should be thought of as the condition under which one can meaningfully restrict a kernel to an
+event.
+
+## TODO
+
+Prove the `integral` versions of the `lintegral` lemmas below
+-/
+
+open MeasureTheory ENNReal NNReal Set
+open scoped ProbabilityTheory
+
+namespace ProbabilityTheory.Kernel
+variable {X : Type*} {𝓑 𝓧 : MeasurableSpace X} {π : Kernel[𝓑, 𝓧] X X} {A B : Set X}
+  {f g : X → ℝ≥0∞} {x₀ : X}
+
+/-- For two σ-algebras `𝓑 ≤ 𝓧` on a space `X`, a `𝓑, 𝓧`-kernel `π : X → Measure X` is proper if
+`∫ x, f x * g x ∂(π x₀) = g x₀ * ∫ x, f x ∂(π x₀)` for all `x₀ : X`, `𝓧`-measurable function `f`
+and `𝓑`-measurable function `g`.
+
+By the standard machine, this is equivalent to having that, for all `B ∈ 𝓑`, `π` restricted to `B`
+is the same as `π` times the indicator of `B`.
+
+To avoid assuming `𝓑 ≤ 𝓧` in the definition, we replace `𝓑` by `𝓑 ⊓ 𝓧` in the restriction. -/
+structure IsProper (π : Kernel[𝓑, 𝓧] X X) : Prop where
+  restrict_eq_indicator_smul' :
+    ∀ ⦃B : Set X⦄ (hB : MeasurableSet[𝓑 ⊓ 𝓧] B) (x : X),
+      π.restrict (inf_le_right (b := 𝓧) _ hB) x = B.indicator (fun _ ↦ (1 : ℝ≥0∞)) x • π x
+
+lemma isProper_iff_restrict_eq_indicator_smul (h𝓑𝓧 : 𝓑 ≤ 𝓧) :
+    IsProper π ↔ ∀ ⦃B : Set X⦄ (hB : MeasurableSet[𝓑] B) (x : X),
+      π.restrict (h𝓑𝓧 _ hB) x = B.indicator (fun _ ↦ (1 : ℝ≥0∞)) x • π x := by
+  refine ⟨fun ⟨h⟩ ↦ ?_, fun h ↦ ⟨?_⟩⟩ <;> simpa only [inf_eq_left.2 h𝓑𝓧] using h
+
+lemma isProper_iff_inter_eq_indicator_mul (h𝓑𝓧 : 𝓑 ≤ 𝓧) :
+    IsProper π ↔
+      ∀ ⦃A : Set X⦄ (_hA : MeasurableSet[𝓧] A) ⦃B : Set X⦄ (_hB : MeasurableSet[𝓑] B) (x : X),
+        π x (A ∩ B) = B.indicator 1 x * π x A := by
+  calc
+    _ ↔ ∀ ⦃A : Set X⦄ (_hA : MeasurableSet[𝓧] A) ⦃B : Set X⦄ (hB : MeasurableSet[𝓑] B) (x : X),
+          π.restrict (h𝓑𝓧 _ hB) x A = B.indicator 1 x * π x A := by
+      simp [isProper_iff_restrict_eq_indicator_smul h𝓑𝓧, Measure.ext_iff]; aesop
+    _ ↔ _ := by congr! 5 with A hA B hB x; rw [restrict_apply, Measure.restrict_apply hA]
+
+alias ⟨IsProper.restrict_eq_indicator_smul, IsProper.of_restrict_eq_indicator_smul⟩ :=
+  isProper_iff_restrict_eq_indicator_smul
+
+alias ⟨IsProper.inter_eq_indicator_mul, IsProper.of_inter_eq_indicator_mul⟩ :=
+  isProper_iff_inter_eq_indicator_mul
+
+lemma IsProper.setLIntegral_eq_bind (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧) {μ : Measure[𝓧] X}
+    (hA : MeasurableSet[𝓧] A) (hB : MeasurableSet[𝓑] B) :
+    ∫⁻ a in B, π a A ∂μ = μ.bind π (A ∩ B) := by
+  rw [Measure.bind_apply (by measurability) (π.measurable.mono h𝓑𝓧 le_rfl)]
+  simp only [hπ.inter_eq_indicator_mul h𝓑𝓧 hA hB, ← indicator_mul_const, Pi.one_apply, one_mul]
+  rw [← lintegral_indicator (h𝓑𝓧 _ hB)]
+  rfl
+
+/-- Auxiliary lemma for `IsProper.lintegral_mul` and
+`IsProper.setLIntegral_eq_indicator_mul_lintegral`. -/
+private lemma IsProper.lintegral_indicator_mul_indicator (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧)
+    (hA : MeasurableSet[𝓧] A) (hB : MeasurableSet[𝓑] B) :
+    ∫⁻ x, B.indicator 1 x * A.indicator 1 x ∂(π x₀) =
+      B.indicator 1 x₀ * ∫⁻ x, A.indicator 1 x ∂(π x₀) := by
+  simp_rw [← inter_indicator_mul]
+  rw [lintegral_indicator ((h𝓑𝓧 _ hB).inter hA), lintegral_indicator hA]
+  simp only [MeasureTheory.lintegral_const, MeasurableSet.univ, Measure.restrict_apply, univ_inter,
+    Pi.one_apply, one_mul]
+  rw [← hπ.inter_eq_indicator_mul h𝓑𝓧 hA hB, inter_comm]
+
+set_option linter.style.multiGoal false in -- false positive
+/-- Auxiliary lemma for `IsProper.lintegral_mul` and
+`IsProper.setLIntegral_eq_indicator_mul_lintegral`. -/
+private lemma IsProper.lintegral_mul_indicator (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧)
+    (hf : Measurable[𝓧] f) (hB : MeasurableSet[𝓑] B) :
+    ∫⁻ x, f x * B.indicator 1 x ∂(π x₀) = B.indicator 1 x₀ * ∫⁻ x, f x ∂(π x₀) := by
+  refine hf.ennreal_induction ?_ ?_ ?_
+  · rintro c A hA
+    simp_rw [← smul_indicator_one_apply, smul_mul_assoc, mul_comm, smul_eq_mul]
+    rw [lintegral_const_mul, lintegral_const_mul, hπ.lintegral_indicator_mul_indicator h𝓑𝓧 hA hB,
+      mul_left_comm] <;> measurability
+  · rintro f₁ f₂ - _ _ hf₁ hf₂
+    simp only [Pi.add_apply, add_mul]
+    rw [lintegral_add_right, lintegral_add_right, hf₁, hf₂, mul_add] <;> measurability
+  · rintro f' hf'_meas hf'_mono hf'
+    simp_rw [ENNReal.iSup_mul]
+    rw [lintegral_iSup (by measurability), lintegral_iSup hf'_meas hf'_mono, ENNReal.mul_iSup]
+    simp_rw [hf']
+    · exact hf'_mono.mul_const (zero_le _)
+
+lemma IsProper.setLIntegral_eq_indicator_mul_lintegral (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧)
+    (hf : Measurable[𝓧] f) (hB : MeasurableSet[𝓑] B) (x₀ : X) :
+    ∫⁻ x in B, f x ∂(π x₀) = B.indicator 1 x₀ * ∫⁻ x, f x ∂(π x₀) := by
+  simp [← hπ.lintegral_mul_indicator h𝓑𝓧 hf hB, ← indicator_mul_right,
+    lintegral_indicator (h𝓑𝓧 _ hB)]
+
+lemma IsProper.setLIntegral_inter_eq_indicator_mul_setLIntegral (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧)
+    (hf : Measurable[𝓧] f) (hA : MeasurableSet[𝓧] A) (hB : MeasurableSet[𝓑] B) (x₀ : X) :
+    ∫⁻ x in A ∩ B, f x ∂(π x₀) = B.indicator 1 x₀ * ∫⁻ x in A, f x ∂(π x₀) := by
+  rw [← lintegral_indicator hA, ← hπ.setLIntegral_eq_indicator_mul_lintegral h𝓑𝓧 _ hB,
+    setLIntegral_indicator] <;> measurability
+
+lemma IsProper.lintegral_mul (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧) (hf : Measurable[𝓧] f)
+    (hg : Measurable[𝓑] g) (x₀ : X) :
+    ∫⁻ x, f x * g x ∂(π x₀) = g x₀ * ∫⁻ x, f x ∂(π x₀) := by
+  refine hg.ennreal_induction ?_ ?_ ?_
+  · rintro c A hA
+    simp_rw [← smul_indicator_one_apply, mul_smul_comm, smul_eq_mul]
+    rw [lintegral_const_mul, hπ.lintegral_mul_indicator h𝓑𝓧 hf hA, mul_assoc]
+    · measurability
+  · rintro g₁ g₂ - _ hg₂_meas hg₁ hg₂
+    simp only [Pi.add_apply, mul_add, add_mul]
+    rw [lintegral_add_right, hg₁, hg₂]
+    · exact hf.mul (hg₂_meas.mono h𝓑𝓧 le_rfl)
+  · rintro g' hg'_meas hg'_mono hg'
+    simp_rw [ENNReal.iSup_mul, ENNReal.mul_iSup]
+    rw [lintegral_iSup (fun n ↦ hf.mul ((hg'_meas _).mono h𝓑𝓧 le_rfl))
+      (hg'_mono.const_mul (zero_le _))]
+    simp_rw [hg']
+
+end ProbabilityTheory.Kernel


### PR DESCRIPTION
Define proper kernels, which are self-kernels which can meaningfully be restricted to an event.

From GibbsMeasure

Co-authored-by: Kalle Kytölä
Co-authored-by: Kin Yau James Wong


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
