### PR TITLE
[Merged by Bors] - feat: an equality condition for AM-GM inequality

### DIFF
--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -192,7 +192,7 @@ theorem geom_mean_eq_arith_mean_weighted_of_constant (w z : ι → ℝ) (x : ℝ
 
 /- **AM-GM inequality - equality condition**: This theorem provides the equality condition for the
 *positive* weighted version of the AM-GM inequality for real-valued nonnegative functions. -/
-theorem geom_mean_arith_mean_weighted_eq_iff_aux (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i)
+theorem geom_mean_eq_arith_mean_weighted_iff_of_pos (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i)
     (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
     ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, z j = ∑ i ∈ s, w i * z i := by
   by_cases A : ∃ i ∈ s, z i = 0 ∧ w i ≠ 0
@@ -227,12 +227,12 @@ theorem geom_mean_arith_mean_weighted_eq_iff_aux (w z : ι → ℝ) (hw : ∀ i 
 
 /- **AM-GM inequality - equality condition**: This theorem provides the equality condition for the
 weighted version of the AM-GM inequality for real-valued nonnegative functions. -/
-theorem geom_mean_arith_mean_weighted_eq_iff (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
+theorem geom_mean_eq_arith_mean_weighted_iff (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
     (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
     ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, w j ≠ 0 → z j = ∑ i ∈ s, w i * z i := by
   have h (i) (_ : i ∈ s) : w i * z i ≠ 0 → w i ≠ 0 := by aesop
   have h' (i) (_ : i ∈ s) : z i ^ w i ≠ 1 → w i ≠ 0 := by aesop
-  rw [← sum_filter_of_ne h, ← prod_filter_of_ne h', geom_mean_arith_mean_weighted_eq_iff_aux]
+  rw [← sum_filter_of_ne h, ← prod_filter_of_ne h', geom_mean_eq_arith_mean_weighted_iff_of_pos]
   · simp
   · simp (config := { contextual := true }) [(hw _ _).gt_iff_ne]
   · rwa [sum_filter_ne_zero]
@@ -241,13 +241,13 @@ theorem geom_mean_arith_mean_weighted_eq_iff (w z : ι → ℝ) (hw : ∀ i ∈ 
 /- **AM-GM inequality - strict inequality condition**: This theorem provides the strict inequality
 condition for the *positive* weighted version of the AM-GM inequality for real-valued nonnegative
 functions. -/
-theorem geom_mean_lt_arith_mean_weighted_iff (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i)
+theorem geom_mean_lt_arith_mean_weighted_iff_of_pos (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i)
     (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
     ∏ i ∈ s, z i ^ w i < ∑ i ∈ s, w i * z i ↔ ∃ j ∈ s, ∃ k ∈ s, z j ≠ z k:= by
   constructor
   · intro h
     by_contra! h_contra
-    rw [(geom_mean_arith_mean_weighted_eq_iff_aux s w z hw hw' hz).mpr ?_] at h
+    rw [(geom_mean_eq_arith_mean_weighted_iff_of_pos s w z hw hw' hz).mpr ?_] at h
     · exact (lt_self_iff_false _).mp h
     · intro j hjs
       rw [← arith_mean_weighted_of_constant s w (fun _ => z j) (z j) hw' fun _ _ => congrFun rfl]
@@ -256,7 +256,7 @@ theorem geom_mean_lt_arith_mean_weighted_iff (w z : ι → ℝ) (hw : ∀ i ∈ 
     have := geom_mean_le_arith_mean_weighted s w z (fun i a => le_of_lt (hw i a)) hw' hz
     by_contra! h
     apply le_antisymm this at h
-    apply (geom_mean_arith_mean_weighted_eq_iff_aux s w z hw hw' hz).mp at h
+    apply (geom_mean_eq_arith_mean_weighted_iff_of_pos s w z hw hw' hz).mp at h
     simp only [h j hjs, h k hks, ne_eq, not_true_eq_false] at hzjk
 
 end Real

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -190,6 +190,48 @@ theorem geom_mean_eq_arith_mean_weighted_of_constant (w z : ι → ℝ) (x : ℝ
     ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i := by
   rw [geom_mean_weighted_of_constant, arith_mean_weighted_of_constant] <;> assumption
 
+
+
+/- **AM-GM inequality - equality condition**: This theorem provides the equality condition for the
+weighted version of the AM-GM inequality for real-valued nonnegative functions. Note that the w i
+here need to be positive.-/
+theorem geom_mean_arith_mean_weighted_eq_iff (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i)
+    (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
+    ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, z j = ∑ i ∈ s, w i * z i := by
+  by_cases A : ∃ i ∈ s, z i = 0 ∧ w i ≠ 0
+  · rcases A with ⟨i, his, hzi, hwi⟩
+    rw [prod_eq_zero his]
+    · constructor
+      · intro h; rw [← h]; intro j hj
+        apply eq_zero_of_ne_zero_of_mul_left_eq_zero (ne_of_lt (hw j hj)).symm
+        apply (sum_eq_zero_iff_of_nonneg ?_).mp h.symm j hj
+        exact fun i hi => (mul_nonneg_iff_of_pos_left (hw i hi)).mpr (hz i hi)
+      · intro h
+        convert h i his
+        exact hzi.symm
+    · rw [hzi]
+      exact zero_rpow hwi
+  · simp only [not_exists, not_and] at A
+    have hz' := fun i h => lt_of_le_of_ne (hz i h) (fun a => (A i h a.symm) (ne_of_gt (hw i h)))
+    have := strictConvexOn_exp.map_sum_eq_iff hw hw' fun i _ => Set.mem_univ <| log (z i)
+    simp only [exp_sum, smul_eq_mul, mul_comm (w _) (log _)] at this
+    convert this using 1
+    · apply Eq.congr <;> [apply prod_congr rfl; apply sum_congr rfl]
+      <;> intro i hi <;> simp [exp_mul, exp_log (hz' i hi)]
+    · constructor <;> intro h j hj
+      · rw [← arith_mean_weighted_of_constant s w _ (log (z j)) hw' fun i _ => congrFun rfl]
+        apply sum_congr rfl
+        intro x hx
+        simp only [mul_comm, h j hj, h x hx]
+      · rw [← arith_mean_weighted_of_constant s w _ (z j) hw' fun i _ => congrFun rfl]
+        apply sum_congr rfl
+        intro x hx
+        simp only [log_injOn_pos (hz' j hj) (hz' x hx), h j hj, h x hx]
+
+
+
+
+
 end Real
 
 namespace NNReal

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -192,7 +192,7 @@ theorem geom_mean_eq_arith_mean_weighted_of_constant (w z : ι → ℝ) (x : ℝ
 
 /- **AM-GM inequality - equality condition**: This theorem provides the equality condition for the
 *positive* weighted version of the AM-GM inequality for real-valued nonnegative functions. -/
-theorem geom_mean_eq_arith_mean_weighted_iff_of_pos (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i)
+theorem geom_mean_eq_arith_mean_weighted_iff_aux_of_pos (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i)
     (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
     ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, z j = ∑ i ∈ s, w i * z i := by
   by_cases A : ∃ i ∈ s, z i = 0 ∧ w i ≠ 0
@@ -232,7 +232,7 @@ theorem geom_mean_eq_arith_mean_weighted_iff (w z : ι → ℝ) (hw : ∀ i ∈ 
     ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, w j ≠ 0 → z j = ∑ i ∈ s, w i * z i := by
   have h (i) (_ : i ∈ s) : w i * z i ≠ 0 → w i ≠ 0 := by aesop
   have h' (i) (_ : i ∈ s) : z i ^ w i ≠ 1 → w i ≠ 0 := by aesop
-  rw [← sum_filter_of_ne h, ← prod_filter_of_ne h', geom_mean_eq_arith_mean_weighted_iff_of_pos]
+  rw [← sum_filter_of_ne h, ← prod_filter_of_ne h', geom_mean_eq_arith_mean_weighted_iff_aux_of_pos]
   · simp
   · simp (config := { contextual := true }) [(hw _ _).gt_iff_ne]
   · rwa [sum_filter_ne_zero]
@@ -247,7 +247,7 @@ theorem geom_mean_lt_arith_mean_weighted_iff_of_pos (w z : ι → ℝ) (hw : ∀
   constructor
   · intro h
     by_contra! h_contra
-    rw [(geom_mean_eq_arith_mean_weighted_iff_of_pos s w z hw hw' hz).mpr ?_] at h
+    rw [(geom_mean_eq_arith_mean_weighted_iff_aux_of_pos s w z hw hw' hz).mpr ?_] at h
     · exact (lt_self_iff_false _).mp h
     · intro j hjs
       rw [← arith_mean_weighted_of_constant s w (fun _ => z j) (z j) hw' fun _ _ => congrFun rfl]
@@ -256,7 +256,7 @@ theorem geom_mean_lt_arith_mean_weighted_iff_of_pos (w z : ι → ℝ) (hw : ∀
     have := geom_mean_le_arith_mean_weighted s w z (fun i a => le_of_lt (hw i a)) hw' hz
     by_contra! h
     apply le_antisymm this at h
-    apply (geom_mean_eq_arith_mean_weighted_iff_of_pos s w z hw hw' hz).mp at h
+    apply (geom_mean_eq_arith_mean_weighted_iff_aux_of_pos s w z hw hw' hz).mp at h
     simp only [h j hjs, h k hks, ne_eq, not_true_eq_false] at hzjk
 
 end Real

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -218,7 +218,7 @@ theorem geom_mean_eq_arith_mean_weighted_iff' (w z : ι → ℝ) (hw : ∀ i ∈
     · apply Eq.congr <;>
       [apply prod_congr rfl; apply sum_congr rfl] <;>
       intro i hi <;>
-      simp [exp_mul, exp_log (hz' i hi)]
+      simp only [exp_mul, exp_log (hz' i hi)]
     · constructor <;> intro h j hj
       · rw [← arith_mean_weighted_of_constant s w _ (log (z j)) hw' fun i _ => congrFun rfl]
         apply sum_congr rfl

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -192,63 +192,48 @@ theorem geom_mean_eq_arith_mean_weighted_of_constant (w z : ι → ℝ) (x : ℝ
 
 /- **AM-GM inequality - equality condition**: This theorem provides the equality condition for the
 weighted version of the AM-GM inequality for real-valued nonnegative functions. -/
-theorem geom_mean_arith_mean_weighted_eq_iff (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i)
+theorem geom_mean_arith_mean_weighted_eq_iff (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
     (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
-    ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, z j = ∑ i ∈ s, w i * z i := by
+    ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, w j ≠ 0 → z j = ∑ i ∈ s, w i * z i := by
   by_cases A : ∃ i ∈ s, z i = 0 ∧ w i ≠ 0
   · rcases A with ⟨i, his, hzi, hwi⟩
     rw [prod_eq_zero his]
     · constructor
-      · intro h; rw [← h]; intro j hj
-        apply eq_zero_of_ne_zero_of_mul_left_eq_zero (ne_of_lt (hw j hj)).symm
+      · intro h; rw [← h]; intro j hj hwj
+        apply eq_zero_of_ne_zero_of_mul_left_eq_zero hwj
         apply (sum_eq_zero_iff_of_nonneg ?_).mp h.symm j hj
-        exact fun i hi => (mul_nonneg_iff_of_pos_left (hw i hi)).mpr (hz i hi)
+        exact fun i a => Left.mul_nonneg (hw i a) (hz i a)
       · intro h
-        convert h i his
-        exact hzi.symm
+        simp only [hzi.symm, h i his hwi]
     · rw [hzi]
       exact zero_rpow hwi
-  · simp only [not_exists, not_and] at A
-    have hz' := fun i h => lt_of_le_of_ne (hz i h) (fun a => (A i h a.symm) (ne_of_gt (hw i h)))
-    have := strictConvexOn_exp.map_sum_eq_iff hw hw' fun i _ => Set.mem_univ <| log (z i)
+  · simp only [ne_eq, not_exists, not_and, not_not] at A
+    have hz' : ∀ i ∈ s, z i = 0 ∧ w i = 0 ∨  0 < z i := by
+      intro i h
+      rcases LE.le.gt_or_eq (hz i h) with h' | h'
+      · right; exact lt_of_le_of_ne (hz i h) (ne_of_lt h')
+      · left; exact ⟨h', A i h h'⟩
+    have := strictConvexOn_exp.map_sum_eq_iff' hw hw' fun i _ => Set.mem_univ <| log (z i)
     simp only [exp_sum, smul_eq_mul, mul_comm (w _) (log _)] at this
     convert this using 1
-    · apply Eq.congr <;> [apply prod_congr rfl; apply sum_congr rfl]
-      <;> intro i hi <;> simp [exp_mul, exp_log (hz' i hi)]
-    · constructor <;> intro h j hj
+    · apply Eq.congr <;> [apply prod_congr rfl; apply sum_congr rfl] <;> intro i hi
+      <;> rcases hz' i hi with h' | h'
+      all_goals simp only [h', rpow_zero, log_zero, mul_zero, exp_zero, mul_one, exp_mul, exp_log]
+    · constructor <;> intro h j hj hwj
       · rw [← arith_mean_weighted_of_constant s w _ (log (z j)) hw' fun i _ => congrFun rfl]
         apply sum_congr rfl
         intro x hx
-        simp only [mul_comm, h j hj, h x hx]
+        rcases eq_or_ne (w x) 0 with hwx | hwx
+        · simp only [hwx, zero_mul, mul_zero]
+        · simp [mul_comm, h j hj hwj, h x hx hwx]
       · rw [← arith_mean_weighted_of_constant s w _ (z j) hw' fun i _ => congrFun rfl]
         apply sum_congr rfl
         intro x hx
-        simp only [log_injOn_pos (hz' j hj) (hz' x hx), h j hj, h x hx]
-
-theorem geom_mean_arith_mean_weighted_eq_iff' (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
-    (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
-    ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, w j ≠ 0 → z j = ∑ i ∈ s, w i * z i := by
-  have h (i) (_ : i ∈ s) : w i * z i ≠ 0 → w i ≠ 0 := by aesop
-  have h' (i) (_ : i ∈ s) : z i ^ w i ≠ 1 → w i ≠ 0 := by aesop
-  rw [← sum_filter_of_ne h, ← prod_filter_of_ne h', geom_mean_arith_mean_weighted_eq_iff]
-  · simp
-  · simp (config := { contextual := true }) [(hw _ _).gt_iff_ne]
-  · rwa [sum_filter_ne_zero]
-  · simp_all only [ne_eq, mul_eq_zero, not_or, not_false_eq_true, and_imp, implies_true, mem_filter]
-
-theorem geom_mean_arith_mean_weighted_eq_iff'' (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
-    (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
-    ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, 0 < w j → z j = ∑ i ∈ s, w i * z i := by
-  have h (i) (a : i ∈ s) : w i * z i ≠ 0 → 0 < w i := fun _ => lt_of_le_of_ne' (hw i a) (by aesop)
-  have h' (i) (a : i ∈ s) : z i ^ w i ≠ 1 → 0 < w i := fun _ => lt_of_le_of_ne' (hw i a) (by aesop)
-  rw [← sum_filter_of_ne h, ← prod_filter_of_ne h', geom_mean_arith_mean_weighted_eq_iff]
-  · simp
-  · simp (config := { contextual := true }) [(hw _ _).gt_iff_ne]
-  · have : filter (fun x => 0 < w x) s = filter (fun x => w x ≠ 0) s := by
-      apply filter_congr
-      exact fun x hx => ⟨fun a => (ne_of_lt a).symm, fun a => lt_of_le_of_ne (hw x hx) a.symm⟩
-    rwa [this, sum_filter_ne_zero]
-  · simp_all only [ne_eq, mul_eq_zero, not_or, not_false_eq_true, and_imp, implies_true, mem_filter]
+        rcases eq_or_ne (w x) 0 with hwx | hwx
+        · simp only [hwx, zero_mul]
+        · have hzjpos := lt_of_le_of_ne (hz j hj) (fun a => hwj (A j hj a.symm))
+          have hzxpos := lt_of_le_of_ne (hz x hx) (fun a => hwx (A x hx a.symm))
+          simp only [log_injOn_pos hzjpos hzxpos, h j hj hwj, h x hx hwx]
 
 end Real
 

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -230,7 +230,7 @@ theorem geom_mean_eq_arith_mean_weighted_iff' (w z : ι → ℝ) (hw : ∀ i ∈
         simp only [log_injOn_pos (hz' j hj) (hz' x hx), h j hj, h x hx]
 
 /-- **AM-GM inequality - equality condition**: This theorem provides the equality condition for the
-weighted version of the AM-GM inequality for real-valued nonnegative functions. --/
+weighted version of the AM-GM inequality for real-valued nonnegative functions. -/
 theorem geom_mean_eq_arith_mean_weighted_iff (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
     (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
     ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, w j ≠ 0 → z j = ∑ i ∈ s, w i * z i := by

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -190,11 +190,8 @@ theorem geom_mean_eq_arith_mean_weighted_of_constant (w z : ι → ℝ) (x : ℝ
     ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i := by
   rw [geom_mean_weighted_of_constant, arith_mean_weighted_of_constant] <;> assumption
 
-
-
 /- **AM-GM inequality - equality condition**: This theorem provides the equality condition for the
-weighted version of the AM-GM inequality for real-valued nonnegative functions. Note that the w i
-here need to be positive.-/
+weighted version of the AM-GM inequality for real-valued nonnegative functions. -/
 theorem geom_mean_arith_mean_weighted_eq_iff (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i)
     (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
     ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, z j = ∑ i ∈ s, w i * z i := by
@@ -228,9 +225,30 @@ theorem geom_mean_arith_mean_weighted_eq_iff (w z : ι → ℝ) (hw : ∀ i ∈ 
         intro x hx
         simp only [log_injOn_pos (hz' j hj) (hz' x hx), h j hj, h x hx]
 
+theorem geom_mean_arith_mean_weighted_eq_iff' (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
+    ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, w j ≠ 0 → z j = ∑ i ∈ s, w i * z i := by
+  have h (i) (_ : i ∈ s) : w i * z i ≠ 0 → w i ≠ 0 := by aesop
+  have h' (i) (_ : i ∈ s) : z i ^ w i ≠ 1 → w i ≠ 0 := by aesop
+  rw [← sum_filter_of_ne h, ← prod_filter_of_ne h', geom_mean_arith_mean_weighted_eq_iff]
+  · simp
+  · simp (config := { contextual := true }) [(hw _ _).gt_iff_ne]
+  · rwa [sum_filter_ne_zero]
+  · simp_all only [ne_eq, mul_eq_zero, not_or, not_false_eq_true, and_imp, implies_true, mem_filter]
 
-
-
+theorem geom_mean_arith_mean_weighted_eq_iff'' (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
+    ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, 0 < w j → z j = ∑ i ∈ s, w i * z i := by
+  have h (i) (a : i ∈ s) : w i * z i ≠ 0 → 0 < w i := fun _ => lt_of_le_of_ne' (hw i a) (by aesop)
+  have h' (i) (a : i ∈ s) : z i ^ w i ≠ 1 → 0 < w i := fun _ => lt_of_le_of_ne' (hw i a) (by aesop)
+  rw [← sum_filter_of_ne h, ← prod_filter_of_ne h', geom_mean_arith_mean_weighted_eq_iff]
+  · simp
+  · simp (config := { contextual := true }) [(hw _ _).gt_iff_ne]
+  · have : filter (fun x => 0 < w x) s = filter (fun x => w x ≠ 0) s := by
+      apply filter_congr
+      exact fun x hx => ⟨fun a => (ne_of_lt a).symm, fun a => lt_of_le_of_ne (hw x hx) a.symm⟩
+    rwa [this, sum_filter_ne_zero]
+  · simp_all only [ne_eq, mul_eq_zero, not_or, not_false_eq_true, and_imp, implies_true, mem_filter]
 
 end Real
 

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -144,7 +144,7 @@ theorem geom_mean_le_arith_mean_weighted (w z : ι → ℝ) (hw : ∀ i ∈ s, 0
       · simp [A i hi hz.symm]
       · rw [exp_log hz]
 
-/-- **AM-GM inequality**: The **geometric mean is less than or equal to the arithmetic mean. --/
+/-- **AM-GM inequality**: The **geometric mean is less than or equal to the arithmetic mean. -/
 theorem geom_mean_le_arith_mean {ι : Type*} (s : Finset ι) (w : ι → ℝ) (z : ι → ℝ)
     (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : 0 < ∑ i ∈ s, w i) (hz : ∀ i ∈ s, 0 ≤ z i) :
     (∏ i ∈ s, z i ^ w i) ^ (∑ i ∈ s, w i)⁻¹  ≤  (∑ i ∈ s, w i * z i) / (∑ i ∈ s, w i) := by
@@ -191,7 +191,7 @@ theorem geom_mean_eq_arith_mean_weighted_of_constant (w z : ι → ℝ) (x : ℝ
   rw [geom_mean_weighted_of_constant, arith_mean_weighted_of_constant] <;> assumption
 
 /-- **AM-GM inequality - equality condition**: This theorem provides the equality condition for the
-*positive* weighted version of the AM-GM inequality for real-valued nonnegative functions. --/
+*positive* weighted version of the AM-GM inequality for real-valued nonnegative functions. -/
 theorem geom_mean_eq_arith_mean_weighted_iff' (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i)
     (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
     ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, z j = ∑ i ∈ s, w i * z i := by
@@ -247,7 +247,7 @@ theorem geom_mean_eq_arith_mean_weighted_iff (w z : ι → ℝ) (hw : ∀ i ∈ 
 
 /-- **AM-GM inequality - strict inequality condition**: This theorem provides the strict inequality
 condition for the *positive* weighted version of the AM-GM inequality for real-valued nonnegative
-functions. --/
+functions. -/
 theorem geom_mean_lt_arith_mean_weighted_iff_of_pos (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i)
     (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
     ∏ i ∈ s, z i ^ w i < ∑ i ∈ s, w i * z i ↔ ∃ j ∈ s, ∃ k ∈ s, z j ≠ z k:= by
@@ -358,7 +358,7 @@ theorem harm_mean_le_geom_mean_weighted (w z : ι → ℝ) (hs : s.Nonempty) (hw
     · rw [Real.inv_rpow]; apply fun i hi ↦ le_of_lt (hz i hi); assumption
 
 
-/-- **HM-GM inequality**: The **harmonic mean is less than or equal to the geometric mean. --/
+/-- **HM-GM inequality**: The **harmonic mean is less than or equal to the geometric mean. -/
 theorem harm_mean_le_geom_mean {ι : Type*} (s : Finset ι) (hs : s.Nonempty) (w : ι → ℝ)
     (z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i) (hw' : 0 < ∑ i in s, w i) (hz : ∀ i ∈ s, 0 < z i) :
     (∑ i in s, w i) / (∑ i in s, w i / z i) ≤ (∏ i in s, z i ^ w i) ^ (∑ i in s, w i)⁻¹ := by


### PR DESCRIPTION
Add some theorems on the equality condition of the weighted AM-GM inequality for real-valued nonnegative functions, referring to `geom_mean_arith_mean_weighted_eq_iff` in `Mathlib/Analysis/MeanInequalities.lean`.


---
<!-- 

The discussion in zulip is here: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Adding.20Equality.20Conditions.20to.20MeanInequalities.20in.20Mathlib4.

It's my first time to make a pr in mathlib4. I plan to incrementally add equality conditions of the cases in `MeanInequalities.lean` to the original file and commit. Once it grows large enough, I'll organize them into a separate file.

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
