### PR TITLE
[Merged by Bors] - chore: move unitsEquivNeZero later

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -5,12 +5,10 @@ Authors: Johan Commelin
 -/
 import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Algebra.GroupWithZero.Basic
-import Mathlib.Logic.Equiv.Defs
 import Mathlib.Tactic.Contrapose
 import Mathlib.Tactic.Nontriviality
 import Mathlib.Tactic.Spread
 import Mathlib.Util.AssertExists
-import Mathlib.Data.Subtype
 
 /-!
 # Lemmas about units in a `MonoidWithZero` or a `GroupWithZero`.
@@ -20,8 +18,11 @@ We also define `Ring.inverse`, a globally defined function on any ring
 -/
 
 -- Guard against import creep
-assert_not_exists Multiplicative
 assert_not_exists DenselyOrdered
+assert_not_exists Equiv
+assert_not_exists Multiplicative
+assert_not_exists Subtype.restrict
+
 
 variable {α M₀ G₀ : Type*}
 variable [MonoidWithZero M₀]

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -392,14 +392,6 @@ theorem Ring.inverse_eq_inv (a : G₀) : Ring.inverse a = a⁻¹ := by
 theorem Ring.inverse_eq_inv' : (Ring.inverse : G₀ → G₀) = Inv.inv :=
   funext Ring.inverse_eq_inv
 
-/-- In a `GroupWithZero` `α`, the unit group `αˣ` is equivalent to the subtype of nonzero
-elements. -/
-@[simps] def unitsEquivNeZero [GroupWithZero α] : αˣ ≃ {a : α // a ≠ 0} where
-  toFun a := ⟨a, a.ne_zero⟩
-  invFun a := Units.mk0 _ a.prop
-  left_inv _ := Units.ext rfl
-  right_inv _ := rfl
-
 end GroupWithZero
 
 section CommGroupWithZero

--- a/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
@@ -12,13 +12,17 @@ import Mathlib.Algebra.GroupWithZero.Units.Basic
 
 assert_not_exists DenselyOrdered
 
-variable {G₀ : Type*}
+variable {G₀ : Type*} [GroupWithZero G₀]
+
+/-- In a `GroupWithZero` `G₀`, the unit group `G₀ˣ` is equivalent to the subtype of nonzero
+elements. -/
+@[simps] def unitsEquivNeZero : G₀ˣ ≃ {a : G₀ // a ≠ 0} where
+  toFun a := ⟨a, a.ne_zero⟩
+  invFun a := Units.mk0 _ a.prop
+  left_inv _ := Units.ext rfl
+  right_inv _ := rfl
 
 namespace Equiv
-
-section GroupWithZero
-
-variable [GroupWithZero G₀]
 
 /-- Left multiplication by a nonzero element in a `GroupWithZero` is a permutation of the
 underlying type. -/
@@ -46,7 +50,5 @@ def divRight₀ (a : G₀) (ha : a ≠ 0) : G₀ ≃ G₀ where
   invFun := (· * a)
   left_inv _ := by simp [ha]
   right_inv _ := by simp [ha]
-
-end GroupWithZero
 
 end Equiv


### PR DESCRIPTION
This is only used in a single place, where the later file is already imported. This reduces the imports of a number of low level algebra files.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
