### PR TITLE
[Merged by Bors] - feat(Data/Finsupp/MonomialOrder): monomial orders

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2448,6 +2448,7 @@ import Mathlib.Data.Finsupp.Fintype
 import Mathlib.Data.Finsupp.Indicator
 import Mathlib.Data.Finsupp.Interval
 import Mathlib.Data.Finsupp.Lex
+import Mathlib.Data.Finsupp.MonomialOrder
 import Mathlib.Data.Finsupp.Multiset
 import Mathlib.Data.Finsupp.NeLocus
 import Mathlib.Data.Finsupp.Notation

--- a/Mathlib/Data/Finsupp/MonomialOrder.lean
+++ b/Mathlib/Data/Finsupp/MonomialOrder.lean
@@ -4,10 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir
 -/
 import Mathlib.Data.Finsupp.Lex
-import Mathlib.Data.Finsupp.Weight
 import Mathlib.Data.Finsupp.WellFounded
 import Mathlib.Data.List.TFAE
-import Mathlib.Logic.Equiv.TransferInstance
 
 /-! # Monomial orders
 

--- a/Mathlib/Data/Finsupp/MonomialOrder.lean
+++ b/Mathlib/Data/Finsupp/MonomialOrder.lean
@@ -1,0 +1,167 @@
+/-
+Copyright (c) 2024 Antoine Chambert-Loir. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir
+-/
+import Mathlib.Data.Finsupp.Lex
+import Mathlib.Data.Finsupp.Weight
+import Mathlib.Data.Finsupp.WellFounded
+import Mathlib.Data.List.TFAE
+import Mathlib.Logic.Equiv.TransferInstance
+
+/-! # Monomial orders
+
+## Monomial orders
+
+A *monomial order* is well ordering relation on a type of the form `σ →₀ ℕ` which
+is compatible with addition and for which `0` is the smallest element.
+Since several monomial orders may have to be used simultaneously, one cannot
+get them as instances.
+In this formalization, they are presented as a structure `MonomialOrder` which encapsulates
+`MonomialOrder.toSyn`, an additive and monotone isomorphism to a linearly ordered cancellative
+additive commutative monoid.
+The entry `MonomialOrder.wf` asserts that `MonomialOrder.syn` is well founded.
+
+The terminology comes from commutative algebra and algebraic geometry, especially Gröbner bases,
+where `c : σ →₀ ℕ` are exponents of monomial.
+
+Given a monomial order `m : MonomialOrder σ`, we provide the notation
+`c ≼[m] d` and `c ≺[m] d` to compare `c d : σ →₀ ℕ` with respect to `m`.
+It is activated using `open scoped MonomialOrder`.
+
+## Examples
+
+Commutative algebra defines many monomial orders, with different usefulness ranges.
+In this file, we provide the basic example of lexicographic ordering.
+For the graded lexicographic ordering, see `Mathlib/Data/Finsupp/DegLex.lean`
+
+* `MonomialOrder.lex` : the lexicographic ordering on `σ →₀ ℕ`.
+For this, `σ` needs to be embedded with an ordering relation which satisfies `WellFoundedGT σ`.
+(This last property is automatic when `σ` is finite).
+
+The type synonym is `Lex (σ →₀ ℕ)` and the two lemmas `MonomialOrder.lex_le_iff`
+and `MonomialOrder.lex_lt_iff` rewrite the ordering as comparisons in the type `Lex (σ →₀ ℕ)`.
+
+## References
+
+* [Cox, Little and O'Shea, *Ideals, varieties, and algorithms*][coxlittleoshea1997]
+* [Becker and Weispfenning, *Gröbner bases*][Becker-Weispfenning1993]
+
+## Note
+
+In algebraic geometry, when the finitely many variables are indexed by integers,
+it is customary to order them using the opposite order : `MvPolynomial.X 0 > MvPolynomial.X 1 > … `
+
+-/
+
+/-- Monomial orders : equivalence of `σ →₀ ℕ` with a well ordered type -/
+structure MonomialOrder (σ : Type*) where
+  /-- The synonym type -/
+  syn : Type*
+  /-- `syn` is a linearly ordered cancellative additive commutative monoid -/
+  locacm : LinearOrderedCancelAddCommMonoid syn := by infer_instance
+  /-- the additive equivalence from `σ →₀ ℕ` to `syn` -/
+  toSyn : (σ →₀ ℕ) ≃+ syn
+  /-- `toSyn` is monotone -/
+  toSyn_monotone : Monotone toSyn
+  /-- `syn` is a well ordering -/
+  wf : WellFoundedLT syn := by infer_instance
+
+attribute [instance] MonomialOrder.locacm MonomialOrder.wf
+
+namespace MonomialOrder
+
+variable {σ : Type*} (m : MonomialOrder σ)
+
+lemma le_add_right (a b : σ →₀ ℕ) :
+    m.toSyn a ≤ m.toSyn a + m.toSyn b := by
+  rw [← map_add]
+  exact m.toSyn_monotone le_self_add
+
+instance orderBot : OrderBot (m.syn) where
+  bot := 0
+  bot_le a := by
+    have := m.le_add_right 0 (m.toSyn.symm a)
+    simp [map_add, zero_add] at this
+    exact this
+
+@[simp]
+theorem bot_eq_zero : (⊥ : m.syn) = 0 := rfl
+
+theorem eq_zero_iff {a : m.syn} : a = 0 ↔ a ≤ 0 := eq_bot_iff
+
+lemma toSyn_strictMono : StrictMono (m.toSyn) := by
+  apply m.toSyn_monotone.strictMono_of_injective m.toSyn.injective
+
+/-- Given a monomial order, notation for the corresponding strict order relation on `σ →₀ ℕ` -/
+scoped
+notation:25 c "≺[" m:25 "]" d:25 => (MonomialOrder.toSyn m c < MonomialOrder.toSyn m d)
+
+/-- Given a monomial order, notation for the corresponding order relation on `σ →₀ ℕ` -/
+scoped
+notation:25 c "≼[" m:25 "]" d:25 => (MonomialOrder.toSyn m c ≤ MonomialOrder.toSyn m d)
+
+end MonomialOrder
+
+section Lex
+
+open Finsupp
+
+open scoped MonomialOrder
+
+-- The linear order on `Finsupp`s obtained by the lexicographic ordering. -/
+noncomputable instance {α N : Type*} [LinearOrder α] [OrderedCancelAddCommMonoid N] :
+    OrderedCancelAddCommMonoid (Lex (α →₀ N)) where
+  le_of_add_le_add_left a b c h := by simpa only [add_le_add_iff_left] using h
+  add_le_add_left a b h c := by simpa only [add_le_add_iff_left] using h
+
+theorem Finsupp.lex_lt_iff {α N : Type*} [LinearOrder α] [LinearOrder N] [Zero N]
+    {a b : Lex (α →₀ N)} :
+    a < b ↔ ∃ i, (∀ j, j< i → ofLex a j = ofLex b j) ∧ ofLex a i < ofLex b i :=
+    Finsupp.lex_def
+
+theorem Finsupp.lex_le_iff {α N : Type*} [LinearOrder α] [LinearOrder N] [Zero N]
+    {a b : Lex (α →₀ N)} :
+    a ≤ b ↔ a = b ∨ ∃ i, (∀ j, j< i → ofLex a j = ofLex b j) ∧ ofLex a i < ofLex b i := by
+    rw [le_iff_eq_or_lt, Finsupp.lex_lt_iff]
+
+/-- for the lexicographic ordering, X 0 * X 1 < X 0  ^ 2 -/
+example : toLex (Finsupp.single 0 2) > toLex (Finsupp.single 0 1 + Finsupp.single 1 1) := by
+  use 0; simp
+
+/-- for the lexicographic ordering, X 1 < X 0 -/
+example : toLex (Finsupp.single 1 1) < toLex (Finsupp.single 0 1) := by
+  use 0; simp
+
+/-- for the lexicographic ordering, X 1 < X 0 ^ 2 -/
+example : toLex (Finsupp.single 1 1) < toLex (Finsupp.single 0 2) := by
+  use 0; simp
+
+/- -- #check Finsupp.toLex_monotone
+theorem _root_.Finsupp.toLex_monotone' {σ : Type*} [LinearOrder σ] :
+    Monotone (toLex (α := σ →₀ ℕ)) := by
+  apply Finsupp.toLex_monotone
+  intro a b h
+  rw [← (add_tsub_cancel_of_le h), toLex_add]
+  simp only [AddEquiv.refl_symm, le_add_iff_nonneg_right, ge_iff_le]
+  apply bot_le
+-/
+
+variable {σ : Type*} [LinearOrder σ]
+
+/-- The lexicographic order on `σ →₀ ℕ`, as a `MonomialOrder` -/
+noncomputable def MonomialOrder.lex [WellFoundedGT σ] :
+    MonomialOrder σ where
+  syn := Lex (σ →₀ ℕ)
+  toSyn := {
+    toEquiv := toLex
+    map_add' := toLex_add } -- AddEquiv.refl _ -- (AddEquiv.refl (Lex (σ →₀ ℕ))).symm
+  toSyn_monotone := Finsupp.toLex_monotone
+
+theorem MonomialOrder.lex_le_iff [WellFoundedGT σ] {c d : σ →₀ ℕ} :
+    c ≼[lex] d ↔ toLex c ≤ toLex d := Iff.rfl
+
+theorem MonomialOrder.lex_lt_iff [WellFoundedGT σ] {c d : σ →₀ ℕ} :
+    c ≺[lex] d ↔ toLex c < toLex d := Iff.rfl
+
+end Lex

--- a/Mathlib/Data/Finsupp/MonomialOrder.lean
+++ b/Mathlib/Data/Finsupp/MonomialOrder.lean
@@ -21,7 +21,7 @@ additive commutative monoid.
 The entry `MonomialOrder.wf` asserts that `MonomialOrder.syn` is well founded.
 
 The terminology comes from commutative algebra and algebraic geometry, especially Gröbner bases,
-where `c : σ →₀ ℕ` are exponents of monomial.
+where `c : σ →₀ ℕ` are exponents of monomials.
 
 Given a monomial order `m : MonomialOrder σ`, we provide the notation
 `c ≼[m] d` and `c ≺[m] d` to compare `c d : σ →₀ ℕ` with respect to `m`.
@@ -135,15 +135,6 @@ example : toLex (Finsupp.single 1 1) < toLex (Finsupp.single 0 1) := by
 example : toLex (Finsupp.single 1 1) < toLex (Finsupp.single 0 2) := by
   use 0; simp
 
-/- -- #check Finsupp.toLex_monotone
-theorem _root_.Finsupp.toLex_monotone' {σ : Type*} [LinearOrder σ] :
-    Monotone (toLex (α := σ →₀ ℕ)) := by
-  apply Finsupp.toLex_monotone
-  intro a b h
-  rw [← (add_tsub_cancel_of_le h), toLex_add]
-  simp only [AddEquiv.refl_symm, le_add_iff_nonneg_right, ge_iff_le]
-  apply bot_le
--/
 
 variable {σ : Type*} [LinearOrder σ]
 
@@ -151,9 +142,9 @@ variable {σ : Type*} [LinearOrder σ]
 noncomputable def MonomialOrder.lex [WellFoundedGT σ] :
     MonomialOrder σ where
   syn := Lex (σ →₀ ℕ)
-  toSyn := {
-    toEquiv := toLex
-    map_add' := toLex_add } -- AddEquiv.refl _ -- (AddEquiv.refl (Lex (σ →₀ ℕ))).symm
+  toSyn :=
+  { toEquiv := toLex
+    map_add' := toLex_add }
   toSyn_monotone := Finsupp.toLex_monotone
 
 theorem MonomialOrder.lex_le_iff [WellFoundedGT σ] {c d : σ →₀ ℕ} :

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -247,6 +247,21 @@
   year          = {2004}
 }
 
+@Book{            Becker-Weispfenning1993,
+  address       = {New York, NY},
+  series        = {Graduate Texts in Mathematics},
+  title         = {Gröbner Bases},
+  volume        = {141},
+  isbn          = {978-1-4612-6944-1},
+  url           = {http://link.springer.com/10.1007/978-1-4612-0913-3},
+  doi           = {10.1007/978-1-4612-0913-3},
+  publisher     = {Springer New York},
+  author        = {Becker, Thomas and Weispfenning, Volker},
+  year          = {1993},
+  collection    = {Graduate Texts in Mathematics},
+  language      = {en}
+}
+
 @Book{            behrends1979,
   author        = {Ehrhard {Behrends}},
   title         = {{M-structure and the Banach-Stone theorem}},


### PR DESCRIPTION
Definition of monomial orders, with the example of the lexicographic ordering

This is the starting point of implementation of the beginnings of Gröbner theory.
3 subsequent PRs will address:
- division algorithm
- example of the homogeneous lexicographic ordering
- example of the homogeneous reverse lexicographic ordering

These various orderings (and other ones…) may look exotic but are actually used in algebraic geometry.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
