### PR TITLE
[Merged by Bors] - feat: left division by a nonzero element as a `Perm`

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
@@ -12,17 +12,19 @@ import Mathlib.Algebra.GroupWithZero.Units.Basic
 
 assert_not_exists DenselyOrdered
 
-variable {G₀ : Type*} [GroupWithZero G₀]
+variable {G₀ : Type*}
+
+namespace Equiv
+section GroupWithZero
+variable [GroupWithZero G₀]
 
 /-- In a `GroupWithZero` `G₀`, the unit group `G₀ˣ` is equivalent to the subtype of nonzero
 elements. -/
-@[simps] def unitsEquivNeZero : G₀ˣ ≃ {a : G₀ // a ≠ 0} where
+@[simps] def _root_.unitsEquivNeZero : G₀ˣ ≃ {a : G₀ // a ≠ 0} where
   toFun a := ⟨a, a.ne_zero⟩
   invFun a := Units.mk0 _ a.prop
   left_inv _ := Units.ext rfl
   right_inv _ := rfl
-
-namespace Equiv
 
 /-- Left multiplication by a nonzero element in a `GroupWithZero` is a permutation of the
 underlying type. -/
@@ -45,10 +47,25 @@ theorem _root_.mulRight_bijective₀ (a : G₀) (ha : a ≠ 0) : Function.Biject
 /-- Right division by a nonzero element in a `GroupWithZero` is a permutation of the
 underlying type. -/
 @[simps! (config := { simpRhs := true })]
-def divRight₀ (a : G₀) (ha : a ≠ 0) : G₀ ≃ G₀ where
+def divRight₀ (a : G₀) (ha : a ≠ 0) : Perm G₀ where
   toFun := (· / a)
   invFun := (· * a)
   left_inv _ := by simp [ha]
   right_inv _ := by simp [ha]
 
+end GroupWithZero
+
+section CommGroupWithZero
+variable [CommGroupWithZero G₀]
+
+/-- Left division by a nonzero element in a `CommGroupWithZero` is a permutation of the underlying
+type. -/
+@[simps! (config := { simpRhs := true })]
+def divLeft₀ (a : G₀) (ha : a ≠ 0) : G₀ ≃ G₀ where
+  toFun := (a / ·)
+  invFun := (a / ·)
+  left_inv _ := by simp [ha]
+  right_inv _ := by simp [ha]
+
+end CommGroupWithZero
 end Equiv

--- a/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
@@ -61,7 +61,7 @@ variable [CommGroupWithZero G₀]
 /-- Left division by a nonzero element in a `CommGroupWithZero` is a permutation of the underlying
 type. -/
 @[simps! (config := { simpRhs := true })]
-def divLeft₀ (a : G₀) (ha : a ≠ 0) : G₀ ≃ G₀ where
+def divLeft₀ (a : G₀) (ha : a ≠ 0) : Perm G₀ where
   toFun := (a / ·)
   invFun := (a / ·)
   left_inv _ := by simp [ha]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #19459

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
