### PR TITLE
[Merged by Bors] - fix: remove `ref: master` in zulip emoji reaction script

### DIFF
--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -103,7 +103,6 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: master
           sparse-checkout: |
             scripts/zulip_emoji_merge_delegate.py
 


### PR DESCRIPTION
This way, the script will extract the python file from the current PR, allowing testing and debugging of changes in its behaviour.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
