### PR TITLE
[Merged by Bors] - chore(AdicCompletion): generalise algebra instance to separate rings

### DIFF
--- a/Mathlib/RingTheory/AdicCompletion/Algebra.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Algebra.lean
@@ -25,7 +25,7 @@ suppress_compilation
 
 open Submodule
 
-variable {R : Type*} [CommRing R] (I : Ideal R)
+variable {R S : Type*} [CommRing R] [CommRing S] (I : Ideal R)
 variable {M : Type*} [AddCommGroup M] [Module R M]
 
 namespace AdicCompletion
@@ -87,8 +87,10 @@ instance : CommRing (AdicCompletion I R) :=
     (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
     (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl)
 
-instance : Algebra R (AdicCompletion I R) where
-  toFun r := ⟨algebraMap R (∀ n, R ⧸ (I ^ n • ⊤ : Ideal R)) r, by simp⟩
+instance [Algebra S R] : Algebra S (AdicCompletion I R) where
+  toFun r := ⟨algebraMap S (∀ n, R ⧸ (I ^ n • ⊤ : Ideal R)) r, by
+    simp [-Ideal.Quotient.mk_algebraMap,
+      IsScalarTower.algebraMap_apply S R (R ⧸ (I ^ _ • ⊤ : Ideal R))]⟩
   map_one' := Subtype.ext <| map_one _
   map_mul' x y := Subtype.ext <| map_mul _ x y
   map_zero' := Subtype.ext <| map_zero _
@@ -252,23 +254,15 @@ instance module : Module (AdicCompletion I R) (AdicCompletion I M) where
   mul_smul r s x := by
     ext n
     simp only [smul_eval, val_mul, mul_smul]
-  smul_zero r := by
-    ext n
-    rw [smul_eval, val_zero, smul_zero]
-  smul_add r x y := by
-    ext n
-    simp only [smul_eval, val_add, smul_add]
-  add_smul r s x := by
-    ext n
-    simp only [coe_eval, smul_eval, map_add, add_smul, val_add]
-  zero_smul x := by
-    ext n
-    simp only [smul_eval, _root_.map_zero, zero_smul, val_zero]
+  smul_zero r := by ext n; simp
+  smul_add r x y := by ext n; simp
+  add_smul r s x := by ext n; simp [val_smul, add_smul]
+  zero_smul x := by ext n; simp
 
 instance : IsScalarTower R (AdicCompletion I R) (AdicCompletion I M) where
   smul_assoc r s x := by
     ext n
-    rw [smul_eval, val_smul, val_smul, smul_eval, smul_assoc]
+    rw [smul_eval, val_smul_apply, val_smul_apply, smul_eval, smul_assoc]
 
 /-- A priori `AdicCompletion I R` has two `AdicCompletion I R`-module instances.
 Both agree definitionally. -/

--- a/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
+++ b/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
@@ -101,7 +101,7 @@ private lemma piEquivOfFintype_comp_ofTensorProduct_eq :
   ext i j k
   suffices h : (if j = i then 1 else 0) = (if j = i then 1 else 0 : AdicCompletion I R).val k by
     simpa [Pi.single_apply, -smul_eq_mul, -Algebra.id.smul_eq_mul]
-  split <;> simp only [smul_eq_mul, val_zero, val_one]
+  split <;> simp
 
 private lemma ofTensorProduct_eq :
     ofTensorProduct I (ι → R) = (piEquivOfFintype I (ι := ι) (fun _ : ι ↦ R)).symm.toLinearMap ∘ₗ

--- a/Mathlib/RingTheory/AdicCompletion/Basic.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Basic.lean
@@ -29,7 +29,7 @@ suppress_compilation
 
 open Submodule
 
-variable {R : Type*} [CommRing R] (I : Ideal R)
+variable {R S T : Type*} [CommRing R] (I : Ideal R)
 variable (M : Type*) [AddCommGroup M] [Module R M]
 variable {N : Type*} [AddCommGroup N] [Module R N]
 
@@ -202,24 +202,57 @@ instance : Neg (AdicCompletion I M) where
 instance : Sub (AdicCompletion I M) where
   sub x y := ⟨x.val - y.val, by simp [x.property, y.property]⟩
 
-instance : SMul ℕ (AdicCompletion I M) where
-  smul n x := ⟨n • x.val, by simp [x.property]⟩
+instance instSMul [SMul S R] [SMul S M] [IsScalarTower S R M] : SMul S (AdicCompletion I M) where
+  smul r x := ⟨r • x.val, by simp [x.property]⟩
 
-instance : SMul ℤ (AdicCompletion I M) where
-  smul n x := ⟨n • x.val, by simp [x.property]⟩
+@[simp, norm_cast] lemma val_zero : (0 : AdicCompletion I M).val = 0 := rfl
+
+lemma val_zero_apply (n : ℕ) : (0 : AdicCompletion I M).val n = 0 := rfl
+
+variable {I M}
+
+@[simp, norm_cast] lemma val_add (f g : AdicCompletion I M) : (f + g).val = f.val + g.val := rfl
+@[simp, norm_cast] lemma val_sub (f g : AdicCompletion I M) : (f - g).val = f.val - g.val := rfl
+@[simp, norm_cast] lemma val_neg (f : AdicCompletion I M) : (-f).val = -f.val := rfl
+
+lemma val_add_apply (f g : AdicCompletion I M) (n : ℕ) : (f + g).val n = f.val n + g.val n := rfl
+lemma val_sub_apply (f g : AdicCompletion I M) (n : ℕ) : (f - g).val n = f.val n - g.val n := rfl
+lemma val_neg_apply (f : AdicCompletion I M) (n : ℕ) : (-f).val n = -f.val n := rfl
+
+/- No `simp` attribute, since it causes `simp` unification timeouts when considering
+the `Module (AdicCompletion I R) (AdicCompletion I M)` instance (see `AdicCompletion/Algebra`). -/
+@[norm_cast]
+lemma val_smul [SMul S R] [SMul S M] [IsScalarTower S R M] (s : S) (f : AdicCompletion I M) :
+    (s • f).val = s • f.val := rfl
+
+lemma val_smul_apply [SMul S R] [SMul S M] [IsScalarTower S R M] (s : S) (f : AdicCompletion I M)
+    (n : ℕ) : (s • f).val n = s • f.val n := rfl
+
+@[ext]
+lemma ext {x y : AdicCompletion I M} (h : ∀ n, x.val n = y.val n) : x = y := Subtype.eq <| funext h
+
+variable (I M)
 
 instance : AddCommGroup (AdicCompletion I M) :=
   let f : AdicCompletion I M → ∀ n, M ⧸ (I ^ n • ⊤ : Submodule R M) := Subtype.val
-  Subtype.val_injective.addCommGroup f rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
-    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+  Subtype.val_injective.addCommGroup f rfl val_add val_neg val_sub (fun _ _ ↦ val_smul ..)
+    (fun _ _ ↦ val_smul ..)
 
-instance : SMul R (AdicCompletion I M) where
-  smul r x := ⟨r • x.val, by simp [x.property]⟩
-
-instance : Module R (AdicCompletion I M) :=
+instance [Semiring S] [SMul S R] [Module S M] [IsScalarTower S R M] :
+    Module S (AdicCompletion I M) :=
   let f : AdicCompletion I M →+ ∀ n, M ⧸ (I ^ n • ⊤ : Submodule R M) :=
     { toFun := Subtype.val, map_zero' := rfl, map_add' := fun _ _ ↦ rfl }
-  Subtype.val_injective.module R f (fun _ _ ↦ rfl)
+  Subtype.val_injective.module S f val_smul
+
+instance instIsScalarTower [SMul S T] [SMul S R] [SMul T R] [SMul S M] [SMul T M]
+    [IsScalarTower S R M] [IsScalarTower T R M] [IsScalarTower S T M] :
+    IsScalarTower S T (AdicCompletion I M) where
+  smul_assoc s t f := by ext; simp [val_smul]
+
+instance instSMulCommClass [SMul S R] [SMul T R] [SMul S M] [SMul T M]
+    [IsScalarTower S R M] [IsScalarTower T R M] [SMulCommClass S T M] :
+    SMulCommClass S T (AdicCompletion I M) where
+  smul_comm r s f := by ext; simp [val_smul, smul_comm]
 
 /-- The canonical inclusion from the completion to the product. -/
 @[simps]
@@ -227,6 +260,18 @@ def incl : AdicCompletion I M →ₗ[R] (∀ n, M ⧸ (I ^ n • ⊤ : Submodule
   toFun x := x.val
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
+
+variable {I M}
+
+@[simp, norm_cast]
+lemma val_sum {ι : Type*} (s : Finset ι) (f : ι → AdicCompletion I M) :
+    (∑ i ∈ s, f i).val = ∑ i ∈ s, (f i).val := by
+  simp_rw [← funext (incl_apply _ _ _), map_sum]
+
+lemma val_sum_apply {ι : Type*} (s : Finset ι) (f : ι → AdicCompletion I M) (n : ℕ) :
+    (∑ i ∈ s, f i).val n = ∑ i ∈ s, (f i).val n := by simp
+
+variable (I M)
 
 /-- The canonical linear map to the completion. -/
 def of : M →ₗ[R] AdicCompletion I M where
@@ -266,43 +311,17 @@ theorem eval_surjective (n : ℕ) : Function.Surjective (eval I M n) := fun x �
 theorem range_eval (n : ℕ) : LinearMap.range (eval I M n) = ⊤ :=
   LinearMap.range_eq_top.2 (eval_surjective I M n)
 
-@[simp]
-theorem val_zero (n : ℕ) : (0 : AdicCompletion I M).val n = 0 :=
-  rfl
-
 variable {I M}
-
-@[simp]
-theorem val_add (n : ℕ) (f g : AdicCompletion I M) : (f + g).val n = f.val n + g.val n :=
-  rfl
-
-@[simp]
-theorem val_sub (n : ℕ) (f g : AdicCompletion I M) : (f - g).val n = f.val n - g.val n :=
-  rfl
-
-@[simp]
-theorem val_sum {α : Type*} (s : Finset α) (f : α → AdicCompletion I M) (n : ℕ) :
-    (Finset.sum s f).val n = Finset.sum s (fun a ↦ (f a).val n) := by
-  simp_rw [← incl_apply, map_sum, Finset.sum_apply]
-
-/- No `simp` attribute, since it causes `simp` unification timeouts when considering
-the `AdicCompletion I R` module instance on `AdicCompletion I M` (see `AdicCompletion/Algebra`). -/
-theorem val_smul (n : ℕ) (r : R) (f : AdicCompletion I M) : (r • f).val n = r • f.val n :=
-  rfl
-
-@[ext]
-theorem ext {x y : AdicCompletion I M} (h : ∀ n, x.val n = y.val n) : x = y :=
-  Subtype.eq <| funext h
 
 variable (I M)
 
 instance : IsHausdorff I (AdicCompletion I M) where
   haus' x h := ext fun n ↦ by
     refine smul_induction_on (SModEq.zero.1 <| h n) (fun r hr x _ ↦ ?_) (fun x y hx hy ↦ ?_)
-    · simp only [val_smul, val_zero]
+    · simp only [val_smul_apply, val_zero]
       exact Quotient.inductionOn' (x.val n)
         (fun a ↦ SModEq.zero.2 <| smul_mem_smul hr mem_top)
-    · simp only [val_add, hx, val_zero, hy, add_zero]
+    · simp only [val_add_apply, hx, val_zero_apply, hy, add_zero]
 
 @[simp]
 theorem transitionMap_mk {m n : ℕ} (hmn : m ≤ n) (x : M) :

--- a/Mathlib/RingTheory/AdicCompletion/Basic.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Basic.lean
@@ -252,7 +252,12 @@ instance instIsScalarTower [SMul S T] [SMul S R] [SMul T R] [SMul S M] [SMul T M
 instance instSMulCommClass [SMul S R] [SMul T R] [SMul S M] [SMul T M]
     [IsScalarTower S R M] [IsScalarTower T R M] [SMulCommClass S T M] :
     SMulCommClass S T (AdicCompletion I M) where
-  smul_comm r s f := by ext; simp [val_smul, smul_comm]
+  smul_comm s t f := by ext; simp [val_smul, smul_comm]
+
+instance instIsCentralScalar [SMul S R] [SMul Sᵐᵒᵖ R] [SMul S M] [SMul Sᵐᵒᵖ M]
+    [IsScalarTower S R M] [IsScalarTower Sᵐᵒᵖ R M] [IsCentralScalar S M] :
+    IsCentralScalar S (AdicCompletion I M) where
+  op_smul_eq_smul s f := by ext; simp [val_smul, op_smul_eq_smul]
 
 /-- The canonical inclusion from the completion to the product. -/
 @[simps]

--- a/Mathlib/RingTheory/AdicCompletion/Functoriality.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Functoriality.lean
@@ -302,7 +302,7 @@ theorem sum_comp_sumInv : sum I M ∘ₗ sumInv I M = LinearMap.id := by
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.id_coe, id_eq, mk_apply_coe,
     Submodule.mkQ_apply]
   rw [← DirectSum.sum_univ_of (((sumInv I M) ((AdicCompletion.mk I (⨁ (j : ι), M j)) f)))]
-  simp only [sumInv_apply, map_mk, map_sum, sum_of, val_sum, mk_apply_coe,
+  simp only [sumInv_apply, map_mk, map_sum, sum_of, val_sum_apply, mk_apply_coe,
     AdicCauchySequence.map_apply_coe, Submodule.mkQ_apply]
   simp only [← Submodule.mkQ_apply, ← map_sum]
   erw [DirectSum.sum_univ_of]


### PR DESCRIPTION
In the existing instance `Algebra R (AdicCompletion I R)`, `R` appears three times: On the left, on the right, and in `I : Ideal R`. The left occurrence can be generalised to a ring `S` such that `R` is a `S`-algebra.

Closes ImperialCollegeLondon/FLT/issues/230.

From FLT


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
