### PR TITLE
[Merged by Bors] - chore(Data/Nat/Defs): rename two lemmas that were not about `Ne`

### DIFF
--- a/Mathlib/Algebra/Group/Nat/Even.lean
+++ b/Mathlib/Algebra/Group/Nat/Even.lean
@@ -31,7 +31,7 @@ instance : DecidablePred (IsSquare : ℕ → Prop) :=
   fun m ↦ decidable_of_iff' (Nat.sqrt m * Nat.sqrt m = m) <| by
     simp_rw [← Nat.exists_mul_self m, IsSquare, eq_comm]
 
-lemma not_even_iff : ¬ Even n ↔ n % 2 = 1 := by rw [even_iff, mod_two_ne_zero]
+lemma not_even_iff : ¬ Even n ↔ n % 2 = 1 := by rw [even_iff, mod_two_not_eq_zero]
 
 @[simp] lemma two_dvd_ne_zero : ¬2 ∣ n ↔ n % 2 = 1 :=
   (even_iff_exists_two_nsmul _).symm.not.trans not_even_iff

--- a/Mathlib/Algebra/Ring/Parity.lean
+++ b/Mathlib/Algebra/Ring/Parity.lean
@@ -201,7 +201,7 @@ lemma odd_iff : Odd n ↔ n % 2 = 1 :=
 
 instance : DecidablePred (Odd : ℕ → Prop) := fun _ ↦ decidable_of_iff _ odd_iff.symm
 
-lemma not_odd_iff : ¬Odd n ↔ n % 2 = 0 := by rw [odd_iff, mod_two_ne_one]
+lemma not_odd_iff : ¬Odd n ↔ n % 2 = 0 := by rw [odd_iff, mod_two_not_eq_one]
 
 @[simp] lemma not_odd_iff_even : ¬Odd n ↔ Even n := by rw [not_odd_iff, even_iff]
 @[simp] lemma not_even_iff_odd : ¬Even n ↔ Odd n := by rw [not_even_iff, odd_iff]

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -1002,11 +1002,6 @@ lemma div_eq_iff_eq_of_dvd_dvd (hn : n ≠ 0) (ha : a ∣ n) (hb : b ∣ n) : n 
     exact Nat.eq_mul_of_div_eq_right ha h
   · rw [h]
 
-lemma le_mul_div_add (hb : b ≠ 0) : a ≤ b * (a / b) + b - 1 := by
-  refine Nat.le_sub_of_add_le ?_
-  rw [succ_le_iff, ← Nat.mul_add_one, Nat.mul_comm, ← div_lt_iff_lt_mul (Nat.pos_iff_ne_zero.2 hb),
-    Nat.lt_add_one_iff]
-
 protected lemma div_eq_zero_iff (hb : 0 < b) : a / b = 0 ↔ a < b where
   mp h := by rw [← mod_add_div a b, h, Nat.mul_zero, Nat.add_zero]; exact mod_lt _ hb
   mpr h := by rw [← Nat.mul_right_inj (Nat.ne_of_gt hb), ← Nat.add_left_cancel_iff, mod_add_div,

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -968,11 +968,14 @@ lemma set_induction {S : Set ℕ} (hb : 0 ∈ S) (h_ind : ∀ k : ℕ, k ∈ S �
 
 attribute [simp] Nat.dvd_zero
 
-@[simp] lemma mod_two_ne_one : ¬n % 2 = 1 ↔ n % 2 = 0 := by
+@[simp] lemma mod_two_not_eq_one : ¬n % 2 = 1 ↔ n % 2 = 0 := by
   cases mod_two_eq_zero_or_one n <;> simp [*]
 
-@[simp] lemma mod_two_ne_zero : ¬n % 2 = 0 ↔ n % 2 = 1 := by
+@[simp] lemma mod_two_not_eq_zero : ¬n % 2 = 0 ↔ n % 2 = 1 := by
   cases mod_two_eq_zero_or_one n <;> simp [*]
+
+lemma mod_two_ne_one : n % 2 ≠ 1 ↔ n % 2 = 0 := mod_two_not_eq_one
+lemma mod_two_ne_zero : n % 2 ≠ 0 ↔ n % 2 = 1 := mod_two_not_eq_zero
 
 @[deprecated mod_mul_right_div_self (since := "2024-05-29")]
 lemma div_mod_eq_mod_mul_div (a b c : ℕ) : a / b % c = a % (b * c) / b :=
@@ -998,6 +1001,11 @@ lemma div_eq_iff_eq_of_dvd_dvd (hn : n ≠ 0) (ha : a ∣ n) (hb : b ∣ n) : n 
     rw [eq_comm, Nat.mul_comm, Nat.mul_div_assoc _ hb]
     exact Nat.eq_mul_of_div_eq_right ha h
   · rw [h]
+
+lemma le_mul_div_add (hb : b ≠ 0) : a ≤ b * (a / b) + b - 1 := by
+  refine Nat.le_sub_of_add_le ?_
+  rw [succ_le_iff, ← Nat.mul_add_one, Nat.mul_comm, ← div_lt_iff_lt_mul (Nat.pos_iff_ne_zero.2 hb),
+    Nat.lt_add_one_iff]
 
 protected lemma div_eq_zero_iff (hb : 0 < b) : a / b = 0 ↔ a < b where
   mp h := by rw [← mod_add_div a b, h, Nat.mul_zero, Nat.add_zero]; exact mod_lt _ hb


### PR DESCRIPTION
From LeanCamCombi

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
