### PR TITLE
[Merged by Bors] - feat: `stab s ⊓ stab t ≤ stab (s ∩ t)`

### DIFF
--- a/Mathlib/Algebra/Pointwise/Stabilizer.lean
+++ b/Mathlib/Algebra/Pointwise/Stabilizer.lean
@@ -60,19 +60,24 @@ lemma stabilizer_mul_self (s : Set G) : (stabilizer G s : Set G) * s = s := by
   exact smul_mem_smul_set hb
 
 @[to_additive]
+lemma stabilizer_inf_stabilizer_le_stabilizer_apply₂ {f : Set α → Set α → Set α}
+    (hf : ∀ a : G, a • f s t = f (a • s) (a • t)) :
+    stabilizer G s ⊓ stabilizer G t ≤ stabilizer G (f s t) := by aesop (add simp [SetLike.le_def])
+
+@[to_additive]
 lemma stabilizer_inf_stabilizer_le_stabilizer_union :
-    stabilizer G s ⊓ stabilizer G t ≤ stabilizer G (s ∪ t) := by
-  aesop (add simp [SetLike.le_def, smul_set_union])
+    stabilizer G s ⊓ stabilizer G t ≤ stabilizer G (s ∪ t) :=
+  stabilizer_inf_stabilizer_le_stabilizer_apply₂ fun _ ↦ smul_set_union
 
 @[to_additive]
 lemma stabilizer_inf_stabilizer_le_stabilizer_inter :
-    stabilizer G s ⊓ stabilizer G t ≤ stabilizer G (s ∩ t) := by
-  aesop (add simp [SetLike.le_def, smul_set_inter])
+    stabilizer G s ⊓ stabilizer G t ≤ stabilizer G (s ∩ t) :=
+  stabilizer_inf_stabilizer_le_stabilizer_apply₂ fun _ ↦ smul_set_inter
 
 @[to_additive]
 lemma stabilizer_inf_stabilizer_le_stabilizer_sdiff :
-    stabilizer G s ⊓ stabilizer G t ≤ stabilizer G (s \ t) := by
-  aesop (add simp [SetLike.le_def, smul_set_sdiff])
+    stabilizer G s ⊓ stabilizer G t ≤ stabilizer G (s \ t) :=
+  stabilizer_inf_stabilizer_le_stabilizer_apply₂ fun _ ↦ smul_set_sdiff
 
 @[to_additive]
 lemma stabilizer_union_eq_left (hdisj : Disjoint s t) (hstab : stabilizer G s ≤ stabilizer G t)

--- a/Mathlib/Algebra/Pointwise/Stabilizer.lean
+++ b/Mathlib/Algebra/Pointwise/Stabilizer.lean
@@ -16,11 +16,13 @@ open Function MulOpposite Set
 open scoped Pointwise
 
 namespace MulAction
-variable {G H α : Type*} [Group G] [Group H] [MulAction G α] {a : G}
+variable {G H α : Type*}
 
 /-! ### Stabilizer of a set -/
 
 section Set
+section Group
+variable [Group G] [Group H] [MulAction G α] {a : G} {s t : Set α}
 
 @[to_additive (attr := simp)]
 lemma stabilizer_empty : stabilizer G (∅ : Set α) = ⊤ :=
@@ -57,7 +59,71 @@ lemma stabilizer_mul_self (s : Set G) : (stabilizer G s : Set G) * s = s := by
   rw [← mem_stabilizer_iff.1 ha]
   exact smul_mem_smul_set hb
 
+@[to_additive]
+lemma stabilizer_inf_stabilizer_le_stabilizer_union :
+    stabilizer G s ⊓ stabilizer G t ≤ stabilizer G (s ∪ t) := by
+  aesop (add simp [SetLike.le_def, smul_set_union])
+
+@[to_additive]
+lemma stabilizer_inf_stabilizer_le_stabilizer_inter :
+    stabilizer G s ⊓ stabilizer G t ≤ stabilizer G (s ∩ t) := by
+  aesop (add simp [SetLike.le_def, smul_set_inter])
+
+@[to_additive]
+lemma stabilizer_inf_stabilizer_le_stabilizer_sdiff :
+    stabilizer G s ⊓ stabilizer G t ≤ stabilizer G (s \ t) := by
+  aesop (add simp [SetLike.le_def, smul_set_sdiff])
+
+@[to_additive]
+lemma stabilizer_union_eq_left (hdisj : Disjoint s t) (hstab : stabilizer G s ≤ stabilizer G t)
+    (hstab_union : stabilizer G (s ∪ t) ≤ stabilizer G t) :
+    stabilizer G (s ∪ t) = stabilizer G s := by
+  refine le_antisymm ?_ ?_
+  · calc
+      stabilizer G (s ∪ t)
+        ≤ stabilizer G (s ∪ t) ⊓ stabilizer G t := by simpa
+      _ ≤ stabilizer G ((s ∪ t) \ t) := stabilizer_inf_stabilizer_le_stabilizer_sdiff
+      _ = stabilizer G s := by rw [union_diff_cancel_right]; simpa [← disjoint_iff_inter_eq_empty]
+  · calc
+      stabilizer G s
+        ≤ stabilizer G s ⊓ stabilizer G t := by simpa
+      _ ≤ stabilizer G (s ∪ t) := stabilizer_inf_stabilizer_le_stabilizer_union
+
+@[to_additive]
+lemma stabilizer_union_eq_right (hdisj : Disjoint s t) (hstab : stabilizer G t ≤ stabilizer G s)
+    (hstab_union : stabilizer G (s ∪ t) ≤ stabilizer G s)  :
+    stabilizer G (s ∪ t) = stabilizer G t := by
+  rw [union_comm, stabilizer_union_eq_left hdisj.symm hstab (union_comm .. ▸ hstab_union)]
+
+variable {s : Set G}
+
+open scoped RightActions in
+@[to_additive]
+lemma op_smul_set_stabilizer_subset (ha : a ∈ s) : (stabilizer G s : Set G) <• a ⊆ s :=
+  smul_set_subset_iff.2 fun b hb ↦ by rw [← hb]; exact smul_mem_smul_set ha
+
+@[to_additive]
+lemma stabilizer_subset_div_right (ha : a ∈ s) : ↑(stabilizer G s) ⊆ s / {a} := fun b hb ↦
+  ⟨_, by rwa [← smul_eq_mul, mem_stabilizer_set.1 hb], _, mem_singleton _, mul_div_cancel_right _ _⟩
+
+@[to_additive]
+lemma stabilizer_finite (hs₀ : s.Nonempty) (hs : s.Finite) : (stabilizer G s : Set G).Finite := by
+  obtain ⟨a, ha⟩ := hs₀
+  exact (hs.div <| finite_singleton _).subset <| stabilizer_subset_div_right ha
+
+end Group
+
+section CommGroup
+variable [CommGroup G] {s t : Set G} {a : G}
+
+@[to_additive]
+lemma smul_set_stabilizer_subset (ha : a ∈ s) : a • (stabilizer G s : Set G) ⊆ s := by
+  simpa using op_smul_set_stabilizer_subset ha
+
+end CommGroup
 end Set
+
+variable [Group G] [Group H] [MulAction G α] {a : G}
 
 /-! ### Stabilizer of a subgroup -/
 
@@ -92,7 +158,7 @@ end Subgroup
 section Finset
 variable [DecidableEq α]
 
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp, norm_cast)]
 lemma stabilizer_coe_finset (s : Finset α) : stabilizer G (s : Set α) = stabilizer G s := by
   ext; simp [← Finset.coe_inj]
 
@@ -131,6 +197,28 @@ lemma mem_stabilizer_finset' {s : Finset α} : a ∈ stabilizer G s ↔ ∀ ⦃b
 end Finset
 
 /-! ### Stabilizer of a finite set -/
+
+variable {s : Set α}
+
+@[to_additive]
+lemma mem_stabilizer_iff_subset_smul_set (hs : s.Finite) : a ∈ stabilizer G s ↔ s ⊆ a • s := by
+  classical
+  lift s to Finset α using hs
+  norm_cast
+  exact mem_stabilizer_finset_iff_subset_smul_finset
+
+@[to_additive]
+lemma mem_stabilizer_iff_smul_set_subset (hs : s.Finite) : a ∈ stabilizer G s ↔ a • s ⊆ s := by
+  classical
+  lift s to Finset α using hs
+  norm_cast
+  exact mem_stabilizer_finset_iff_smul_finset_subset
+
+@[deprecated (since := "2024-11-25")]
+alias mem_stabilizer_of_finite_iff_smul_le := mem_stabilizer_iff_subset_smul_set
+
+@[deprecated (since := "2024-11-25")]
+alias mem_stabilizer_of_finite_iff_le_smul := mem_stabilizer_iff_smul_set_subset
 
 @[to_additive]
 lemma mem_stabilizer_set_iff_subset_smul_set {s : Set α} (hs : s.Finite) :

--- a/Mathlib/Algebra/Pointwise/Stabilizer.lean
+++ b/Mathlib/Algebra/Pointwise/Stabilizer.lean
@@ -201,26 +201,6 @@ end Finset
 variable {s : Set α}
 
 @[to_additive]
-lemma mem_stabilizer_iff_subset_smul_set (hs : s.Finite) : a ∈ stabilizer G s ↔ s ⊆ a • s := by
-  classical
-  lift s to Finset α using hs
-  norm_cast
-  exact mem_stabilizer_finset_iff_subset_smul_finset
-
-@[to_additive]
-lemma mem_stabilizer_iff_smul_set_subset (hs : s.Finite) : a ∈ stabilizer G s ↔ a • s ⊆ s := by
-  classical
-  lift s to Finset α using hs
-  norm_cast
-  exact mem_stabilizer_finset_iff_smul_finset_subset
-
-@[deprecated (since := "2024-11-25")]
-alias mem_stabilizer_of_finite_iff_smul_le := mem_stabilizer_iff_subset_smul_set
-
-@[deprecated (since := "2024-11-25")]
-alias mem_stabilizer_of_finite_iff_le_smul := mem_stabilizer_iff_smul_set_subset
-
-@[to_additive]
 lemma mem_stabilizer_set_iff_subset_smul_set {s : Set α} (hs : s.Finite) :
     a ∈ stabilizer G s ↔ s ⊆ a • s := by
   lift s to Finset α using hs
@@ -235,6 +215,12 @@ lemma mem_stabilizer_set_iff_smul_set_subset {s : Set α} (hs : s.Finite) :
   classical
   rw [stabilizer_coe_finset, mem_stabilizer_finset_iff_smul_finset_subset, ← Finset.coe_smul_finset,
     Finset.coe_subset]
+
+@[deprecated (since := "2024-11-25")]
+alias mem_stabilizer_of_finite_iff_smul_le := mem_stabilizer_set_iff_subset_smul_set
+
+@[deprecated (since := "2024-11-25")]
+alias mem_stabilizer_of_finite_iff_le_smul := mem_stabilizer_set_iff_smul_set_subset
 
 @[to_additive]
 lemma mem_stabilizer_set' {s : Set α} (hs : s.Finite) :

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -5,7 +5,6 @@ Authors: Chris Hughes
 -/
 import Mathlib.Algebra.Group.Subgroup.Map
 import Mathlib.Data.Finite.Sigma
-import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Data.Set.Finite.Range
 import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Data.Setoid.Basic

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -291,29 +291,4 @@ theorem le_stabilizer_iff_smul_le (s : Set α) (H : Subgroup G) :
       simp only [Set.smul_mem_smul_set_iff, hx]
     · simp only [smul_inv_smul]
 
-/-- To prove membership to stabilizer of a *finite set*, it is enough to prove one inclusion. -/
-theorem mem_stabilizer_of_finite_iff_smul_le (s : Set α) (hs : s.Finite) (g : G) :
-    g ∈ stabilizer G s ↔ g • s ⊆ s := by
-  haveI : Fintype s := Set.Finite.fintype hs
-  haveI : Finite (g • s : Set α) := Finite.Set.finite_image ..
-  haveI : Fintype (g • s : Set α) := Fintype.ofFinite _
-  rw [mem_stabilizer_iff]
-  constructor
-  · exact Eq.subset
-  · rw [← Set.toFinset_inj, ← Set.toFinset_subset_toFinset]
-    intro h
-    apply Finset.eq_of_subset_of_card_le h
-    apply le_of_eq
-    suffices (g • s).toFinset = Finset.map ⟨_, MulAction.injective g⟩ hs.toFinset by
-      rw [this, Finset.card_map, Set.toFinite_toFinset]
-    rw [← Finset.coe_inj]
-    simp only [Set.coe_toFinset, Set.toFinite_toFinset, Finset.coe_map,
-      Function.Embedding.coeFn_mk, Set.image_smul]
-
-/-- To prove membership to stabilizer of a *finite set*, it is enough to prove one inclusion. -/
-theorem mem_stabilizer_of_finite_iff_le_smul (s : Set α) (hs : s.Finite) (g : G) :
-    g ∈ stabilizer G s ↔ s ⊆ g • s := by
-  rw [← @inv_mem_iff, mem_stabilizer_of_finite_iff_smul_le s hs]
-  exact Set.subset_set_smul_iff.symm
-
 end MulAction

--- a/Mathlib/GroupTheory/GroupAction/Blocks.lean
+++ b/Mathlib/GroupTheory/GroupAction/Blocks.lean
@@ -554,7 +554,7 @@ theorem of_subset (a : X) (hfB : B.Finite) :
       smul_smul, ← mul_inv_rev] at hg hx ⊢
     exact fun _ ↦ hx _ ∘ hg _
   have hag' (g : G) (hg : a ∈ g • B') : B' = g • B' := by
-    rw [eq_comm, ← mem_stabilizer_iff, mem_stabilizer_iff_subset_smul_set hfB']
+    rw [eq_comm, ← mem_stabilizer_iff, mem_stabilizer_set_iff_subset_smul_set hfB']
     exact hag g hg
   rw [isBlock_iff_smul_eq_of_nonempty]
   rintro g ⟨b : X, hb' : b ∈ g • B', hb : b ∈ B'⟩

--- a/Mathlib/GroupTheory/GroupAction/Blocks.lean
+++ b/Mathlib/GroupTheory/GroupAction/Blocks.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Antoine Chambert-Loir. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir
 -/
+import Mathlib.Algebra.Pointwise.Stabilizer
 import Mathlib.Data.Setoid.Partition
 import Mathlib.GroupTheory.GroupAction.Pointwise
 import Mathlib.GroupTheory.GroupAction.SubMulAction
@@ -553,7 +554,7 @@ theorem of_subset (a : X) (hfB : B.Finite) :
       smul_smul, ← mul_inv_rev] at hg hx ⊢
     exact fun _ ↦ hx _ ∘ hg _
   have hag' (g : G) (hg : a ∈ g • B') : B' = g • B' := by
-    rw [eq_comm, ← mem_stabilizer_iff, mem_stabilizer_of_finite_iff_le_smul _ hfB']
+    rw [eq_comm, ← mem_stabilizer_iff, mem_stabilizer_iff_subset_smul_set hfB']
     exact hag g hg
   rw [isBlock_iff_smul_eq_of_nonempty]
   rintro g ⟨b : X, hb' : b ∈ g • B', hb : b ∈ B'⟩


### PR DESCRIPTION
and other similar lemmas

Moves:
* `mem_stabilizer_of_finite_iff_smul_le` -> `mem_stabilizer_set_iff_subset_smul_set`
* `mem_stabilizer_of_finite_iff_le_smul` -> `mem_stabilizer_set_iff_smul_set_subset`

From Kneser (LeanCamCombi)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
