### PR TITLE
[Merged by Bors] - feat(NumberTheory/ModularForms/LevelOne)

### DIFF
--- a/Mathlib/NumberTheory/ModularForms/Basic.lean
+++ b/Mathlib/NumberTheory/ModularForms/Basic.lean
@@ -235,13 +235,15 @@ theorem mul_coe {k_1 k_2 : ℤ} {Γ : Subgroup SL(2, ℤ)} (f : ModularForm Γ k
   rfl
 
 /-- The constant function with value `x : ℂ` as a modular form of weight 0 and any level. -/
-@[simps! (config := .asFn) toFun toSlashInvariantForm]
 def const (x : ℂ) : ModularForm Γ 0 where
   toSlashInvariantForm := .const x
   holo' _ := mdifferentiableAt_const
   bdd_at_infty' A := by
     simpa only [SlashInvariantForm.const_toFun,
       ModularForm.is_invariant_const] using atImInfty.const_boundedAtFilter x
+
+@[simp]
+lemma const_apply (x : ℂ) (τ : ℍ) : (const x : ModularForm Γ 0) τ = x := rfl
 
 instance : One (ModularForm Γ 0) where
   one := { const 1 with toSlashInvariantForm := 1 }

--- a/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -64,6 +64,9 @@ theorem Gamma_one_top : Gamma 1 = ⊤ := by
   ext
   simp [eq_iff_true_of_subsingleton]
 
+lemma mem_Gamma_one (γ : SL(2, ℤ)) : γ ∈ Γ(1) := by
+  simp only [Gamma_one_top, Subgroup.mem_top]
+
 theorem Gamma_zero_bot : Gamma 0 = ⊥ := by
   ext
   simp only [Gamma_mem, coe_matrix_coe, Int.coe_castRingHom, map_apply, Int.cast_id,

--- a/Mathlib/NumberTheory/ModularForms/LevelOne.lean
+++ b/Mathlib/NumberTheory/ModularForms/LevelOne.lean
@@ -3,8 +3,9 @@ Copyright (c) 2024 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/
+import Mathlib.Analysis.Complex.AbsMax
 import Mathlib.NumberTheory.Modular
-import Mathlib.NumberTheory.ModularForms.SlashInvariantForms
+import Mathlib.NumberTheory.ModularForms.QExpansion
 /-!
 # Level one modular forms
 
@@ -15,24 +16,126 @@ TODO: Add finite-dimensionality of these spaces of modular forms.
 -/
 
 open UpperHalfPlane ModularGroup SlashInvariantForm ModularForm Complex MatrixGroups
+  CongruenceSubgroup Real Function SlashInvariantFormClass ModularFormClass
+
+local notation "𝕢" => Periodic.qParam
 
 lemma SlashInvariantForm.exists_one_half_le_im_and_norm_le {k : ℤ} (hk : k ≤ 0) {F : Type*}
-    [FunLike F ℍ ℂ] [SlashInvariantFormClass F ⊤ k] (f : F) (τ : ℍ) :
+    [FunLike F ℍ ℂ] [SlashInvariantFormClass F Γ(1) k] (f : F) (τ : ℍ) :
     ∃ ξ : ℍ, 1/2 ≤ ξ.im ∧ ‖f τ‖ ≤ ‖f ξ‖ :=
   let ⟨γ, hγ, hdenom⟩ := exists_one_half_le_im_smul_and_norm_denom_le τ
-  ⟨γ • τ, hγ, by simpa only [slash_action_eqn'' _ (show γ ∈ ⊤ by tauto), norm_mul, norm_zpow]
-    using le_mul_of_one_le_left (norm_nonneg _) <|
+  ⟨γ • τ, hγ, by simpa only [slash_action_eqn'' _ (show γ ∈ Γ(1) by rw [Gamma_one_top]; tauto),
+    norm_mul, norm_zpow] using le_mul_of_one_le_left (norm_nonneg _) <|
       one_le_zpow_of_nonpos₀ (norm_pos_iff.2 (denom_ne_zero _ _)) hdenom hk⟩
 
 /-- If a constant function is modular of weight `k`, then either `k = 0`, or the constant is `0`. -/
 lemma SlashInvariantForm.wt_eq_zero_of_eq_const
-    {F : Type*} [FunLike F ℍ ℂ] (k : ℤ) [SlashInvariantFormClass F ⊤ k]
+    {F : Type*} [FunLike F ℍ ℂ] (k : ℤ) [SlashInvariantFormClass F Γ(1) k]
     {f : F} {c : ℂ} (hf : ∀ τ, f τ = c) : k = 0 ∨ c = 0 := by
-  have hI := slash_action_eqn'' f (by tauto : ModularGroup.S ∈ ⊤) I
-  have h2I2 := slash_action_eqn'' f (by tauto : ModularGroup.S ∈ ⊤) ⟨2 * Complex.I, by simp⟩
+  have hI := slash_action_eqn'' f (show ModularGroup.S ∈ Γ(1) by rw [Gamma_one_top]; tauto) I
+  have h2I2 := slash_action_eqn'' f (show ModularGroup.S ∈ Γ(1) by rw [Gamma_one_top]; tauto)
+    ⟨2 * Complex.I, by simp⟩
   simp only [sl_moeb, hf, denom_S, coe_mk_subtype] at hI h2I2
   nth_rw 1 [h2I2] at hI
   simp only [mul_zpow, coe_I, mul_eq_mul_right_iff, mul_left_eq_self₀] at hI
   refine hI.imp_left (Or.casesOn · (fun H ↦ ?_) (False.elim ∘ zpow_ne_zero k I_ne_zero))
   rwa [← Complex.ofReal_ofNat, ← ofReal_zpow, ← ofReal_one, ofReal_inj,
     zpow_eq_one_iff_right₀ (by norm_num) (by norm_num)] at H
+
+lemma qParam_image_bound (ξ : ℍ) (hξ : 1 / 2 ≤ ξ.im) : ‖𝕢 1 ξ‖ ≤ rexp (-(π * √3 * (1 / 2))) := by
+  simp only [Periodic.qParam, ofReal_one, div_one, Complex.norm_eq_abs, Complex.abs_exp]
+  apply Real.exp_le_exp_of_le
+  simp only [mul_re, re_ofNat, ofReal_re, im_ofNat, ofReal_im, mul_zero, sub_zero,
+    Complex.I_re, mul_im, zero_mul, add_zero, Complex.I_im, mul_one, sub_self, coe_re,
+    coe_im, zero_sub, neg_le]
+  ring_nf
+  simp_rw [mul_assoc]
+  apply mul_le_mul_of_nonneg_left _ pi_nonneg
+  have : 1 ≤ ξ.im * 2 := by
+    rwa [div_le_iff₀ zero_lt_two] at hξ
+  apply le_trans _ this
+  have : √3 ≤ 2 := sqrt_le_iff.mpr (by norm_cast)
+  linarith
+
+lemma neg_wt_modform_zero (k : ℤ) (hk : k ≤ 0) {F : Type*} [FunLike F ℍ ℂ]
+    [ModularFormClass F Γ(1) k] (f : F) : ⇑f = 0 ∨ (k = 0 ∧ ∃ c : ℂ, ⇑f = fun _ => c) := by
+  have hdiff : DifferentiableOn ℂ (cuspFunction 1 f) (Metric.ball 0 1) := by
+    apply fun z hz ↦ DifferentiableAt.differentiableWithinAt (differentiableAt_cuspFunction 1 f ?_)
+    rw [@mem_ball_zero_iff] at hz
+    exact hz
+  have heq : Set.EqOn (cuspFunction 1 f) (Function.const ℂ ((cuspFunction 1 f) 0))
+    (Metric.ball 0 1) := by
+    apply eq_const_of_exists_le (r := exp (-(π * √3 * (1 / 2)))) hdiff
+    · exact exp_nonneg _
+    · simp only [one_div, exp_lt_one_iff, Left.neg_neg_iff, pi_pos, mul_pos_iff_of_pos_left,
+      sqrt_pos, Nat.ofNat_pos, inv_pos]
+    · intro z hz
+      rcases eq_or_ne z 0 with rfl | hz'
+      · refine ⟨0, by simpa using exp_nonneg _, by rfl⟩
+      · let t : ℍ := ⟨(Function.Periodic.invQParam 1 z), by
+          apply  Function.Periodic.im_invQParam_pos_of_abs_lt_one Real.zero_lt_one
+            (mem_ball_zero_iff.mp hz) hz'⟩
+        obtain ⟨ξ, hξ, hξ₂⟩ := exists_one_half_le_im_and_norm_le hk f t
+        use 𝕢 1 ξ
+        simp only [Metric.mem_closedBall, dist_zero_right]
+        refine ⟨qParam_image_bound ξ hξ, ?_⟩
+        rw [← eq_cuspFunction 1 f ξ, ← eq_cuspFunction 1 f t] at hξ₂
+        simp at hξ₂
+        convert hξ₂
+        rw [← (Function.Periodic.qParam_right_inv one_ne_zero hz')]
+        congr
+  have H : ∀ z, ⇑f z = Function.const ℍ ((cuspFunction 1 f) 0) z:= by
+    intro z
+    have hQ : 𝕢 1 z ∈ (Metric.ball 0 1) := by
+      simpa only [Metric.mem_ball, dist_zero_right, Complex.norm_eq_abs, neg_mul, mul_zero, div_one,
+        Real.exp_zero] using (Function.Periodic.abs_qParam_lt_iff zero_lt_one 0 z.1).mpr z.2
+    simpa only [← eq_cuspFunction 1 f z, Nat.cast_one, const_apply] using heq hQ
+  have HF := SlashInvariantForm.wt_eq_zero_of_eq_const k (c := cuspFunction 1 f 0) H
+  rcases HF with HF | HF
+  · right
+    refine ⟨HF, (cuspFunction 1 (f) 0), by ext z; exact H z⟩
+  · left
+    rw [HF] at H
+    ext z
+    simpa using H z
+
+lemma ModularForm_neg_weight_eq_zero (k : ℤ) (hk : k < 0) {F : Type*} [FunLike F ℍ ℂ]
+    [ModularFormClass F Γ(1) k] (f : F) : ⇑f = 0 := by
+  rcases neg_wt_modform_zero k hk.le f with h | ⟨rfl, _, _⟩
+  · exact h
+  · aesop
+
+lemma ModularForm_weight_zero_constant {F : Type*} [FunLike F ℍ ℂ]
+    [ModularFormClass F Γ(1) 0] (f : F) : ∃ c : ℂ, ⇑f = fun _ => c := by
+  rcases neg_wt_modform_zero 0 (by rfl) f with h1 | h2
+  · refine ⟨0, ?_⟩
+    simp only [h1]
+    rfl
+  · aesop
+
+lemma weight_zero_rank_eq_one : Module.rank ℂ (ModularForm Γ(1) 0) = 1 := by
+  let f := ModularForm.const 1 (Γ := Γ(1))
+  have hf : f ≠ 0 := by
+    rw [@DFunLike.ne_iff]
+    use I
+    simp only [ModularForm.const_toFun, const_apply, zero_apply, ne_eq, one_ne_zero,
+      not_false_eq_true, f]
+  apply rank_eq_one f hf
+  intro g
+  rw [@DFunLike.ne_iff] at hf
+  obtain ⟨c', hc'⟩ := ModularForm_weight_zero_constant g
+  use c'
+  ext z
+  simp only [zero_apply, ne_eq, SlashInvariantForm.toFun_eq_coe, toSlashInvariantForm_coe,
+   smul_eq_mul] at *
+  have : f z = 1 := rfl
+  simp only [ModularForm.smul_apply, this, smul_eq_mul, mul_one]
+  exact (congrFun hc' z).symm
+
+lemma neg_weight_rank_zero (k : ℤ) (hk : k < 0) : Module.rank ℂ (ModularForm Γ(1) k) = 0 := by
+  rw [rank_eq_zero_iff]
+  intro f
+  refine ⟨1, by simp, ?_⟩
+  exact
+    Eq.mpr (id (congrArg (fun x ↦ x = 0) (one_smul ℂ f)))
+      (ModularForm.ext_iff.mpr (congrFun (ModularForm_neg_weight_eq_zero k hk f)))

--- a/Mathlib/NumberTheory/ModularForms/LevelOne.lean
+++ b/Mathlib/NumberTheory/ModularForms/LevelOne.lean
@@ -44,7 +44,7 @@ lemma SlashInvariantForm.wt_eq_zero_of_eq_const
 
 namespace ModularFormClass
 
-theorem neg_wt_eq_const {k : ℤ} (hk : k ≤ 0) {F : Type*}  [FunLike F ℍ ℂ]
+theorem neg_wt_cuspFunction_EqOn_const {k : ℤ} (hk : k ≤ 0) {F : Type*}  [FunLike F ℍ ℂ]
     [ModularFormClass F Γ(1) k] (f : F) :
     Set.EqOn (cuspFunction 1 f) (const ℂ (cuspFunction 1 f 0)) (Metric.ball 0 1) := by
   have hdiff : DifferentiableOn ℂ (cuspFunction 1 f) (Metric.ball 0 1) := by
@@ -68,30 +68,26 @@ theorem neg_wt_eq_const {k : ℤ} (hk : k ≤ 0) {F : Type*}  [FunLike F ℍ ℂ
       rw [← (qParam_right_inv one_ne_zero hz')]
       congr
 
-lemma levelOne_neg_wt_eq_zero_or_const {k : ℤ} (hk : k ≤ 0) {F : Type*} [FunLike F ℍ ℂ]
-    [ModularFormClass F Γ(1) k] (f : F) : ⇑f = 0 ∨ (k = 0 ∧ ∃ c : ℂ, ⇑f = fun _ => c) := by
-  have H : ∀ z, ⇑f z = const ℍ (cuspFunction 1 f 0) z := by
-    intro z
-    have hQ : 𝕢 1 z ∈ (Metric.ball 0 1) := by
-      simpa only [Metric.mem_ball, dist_zero_right, Complex.norm_eq_abs, neg_mul, mul_zero, div_one,
-        Real.exp_zero] using (abs_qParam_lt_iff zero_lt_one 0 z.1).mpr z.2
-    simpa only [← eq_cuspFunction 1 f z, Nat.cast_one, const_apply] using (neg_wt_eq_const hk f) hQ
-  rcases (wt_eq_zero_of_eq_const k (c := cuspFunction 1 f 0) H) with HF | HF
-  · right
-    refine ⟨HF, (cuspFunction 1 (f) 0), funext fun z ↦ H z⟩
-  · left
-    rw [HF] at H
-    exact funext fun z ↦ id (H z)
+theorem levelOne_neg_wt_const {k : ℤ} (hk : k ≤ 0) {F : Type*} [FunLike F ℍ ℂ]
+    [ModularFormClass F Γ(1) k] (f : F) (z : ℍ) :
+    f z = Function.const ℍ (SlashInvariantFormClass.cuspFunction 1 f 0) z := by
+  have hQ : 𝕢 1 z ∈ (Metric.ball 0 1) := by
+    simpa only [Metric.mem_ball, dist_zero_right, Complex.norm_eq_abs, neg_mul, mul_zero, div_one,
+      Real.exp_zero] using (abs_qParam_lt_iff zero_lt_one 0 z.1).mpr z.2
+  simpa only [← eq_cuspFunction 1 f z, Nat.cast_one, const_apply] using
+    (neg_wt_cuspFunction_EqOn_const hk f) hQ
 
 lemma levelOne_non_pos_weight_eq_zero {k : ℤ} (hk : k < 0) {F : Type*} [FunLike F ℍ ℂ]
     [ModularFormClass F Γ(1) k] (f : F) : ⇑f = 0 := by
-  have := levelOne_neg_wt_eq_zero_or_const hk.le f
-  aesop
+  have H := (levelOne_neg_wt_const hk.le f)
+  rcases (wt_eq_zero_of_eq_const k (c := cuspFunction 1 f 0) H) with rfl | HF
+  · omega
+  · rw [HF] at H
+    exact funext fun z ↦ id (H z)
 
-lemma levelOne_weight_zero_constant {F : Type*} [FunLike F ℍ ℂ]
+lemma levelOne_weight_zero_const {F : Type*} [FunLike F ℍ ℂ]
     [ModularFormClass F Γ(1) 0] (f : F) : ∃ c : ℂ, ⇑f = fun _ => c := by
-  have := levelOne_neg_wt_eq_zero_or_const (by rfl) f
-  aesop
+  refine ⟨(cuspFunction 1 (f) 0), funext fun z ↦ ((levelOne_neg_wt_const (show 0 ≤ 0 by rfl) f)) z⟩
 
 end ModularFormClass
 
@@ -103,7 +99,7 @@ lemma ModularForm.levelOne_weight_zero_rank_one : Module.rank ℂ (ModularForm �
       not_false_eq_true, f]⟩
   apply rank_eq_one f hf
   intro g
-  obtain ⟨c', hc'⟩ := levelOne_weight_zero_constant g
+  obtain ⟨c', hc'⟩ := levelOne_weight_zero_const g
   use c'
   ext z
   simp only [zero_apply, ne_eq, (congrFun hc' z).symm, smul_apply, show f z = 1 by rfl, smul_eq_mul,

--- a/Mathlib/NumberTheory/ModularForms/LevelOne.lean
+++ b/Mathlib/NumberTheory/ModularForms/LevelOne.lean
@@ -16,7 +16,7 @@ TODO: Add finite-dimensionality of these spaces of modular forms.
 -/
 
 open UpperHalfPlane ModularGroup SlashInvariantForm ModularForm Complex MatrixGroups
-  CongruenceSubgroup Real Function SlashInvariantFormClass ModularFormClass
+  CongruenceSubgroup Real Function SlashInvariantFormClass ModularFormClass Periodic
 
 local notation "𝕢" => Periodic.qParam
 
@@ -42,81 +42,74 @@ lemma SlashInvariantForm.wt_eq_zero_of_eq_const
   rwa [← Complex.ofReal_ofNat, ← ofReal_zpow, ← ofReal_one, ofReal_inj,
     zpow_eq_one_iff_right₀ (by norm_num) (by norm_num)] at H
 
-lemma neg_wt_modform_zero (k : ℤ) (hk : k ≤ 0) {F : Type*} [FunLike F ℍ ℂ]
+namespace ModularFormClass
+
+lemma levelOne_neg_wt_eq_zero_or_const {k : ℤ} (hk : k ≤ 0) {F : Type*} [FunLike F ℍ ℂ]
     [ModularFormClass F Γ(1) k] (f : F) : ⇑f = 0 ∨ (k = 0 ∧ ∃ c : ℂ, ⇑f = fun _ => c) := by
   have hdiff : DifferentiableOn ℂ (cuspFunction 1 f) (Metric.ball 0 1) := by
-    apply fun z hz ↦ DifferentiableAt.differentiableWithinAt (differentiableAt_cuspFunction 1 f ?_)
-    rw [@mem_ball_zero_iff] at hz
-    exact hz
-  have heq : Set.EqOn (cuspFunction 1 f) (Function.const ℂ ((cuspFunction 1 f) 0))
+    exact fun z hz ↦ DifferentiableAt.differentiableWithinAt (differentiableAt_cuspFunction 1 f
+      (mem_ball_zero_iff.mp hz))
+  have heq : Set.EqOn (cuspFunction 1 f) (const ℂ (cuspFunction 1 f 0))
     (Metric.ball 0 1) := by
-    apply eq_const_of_exists_le (r := exp (-(π * √3 * (1 / 2)))) hdiff
-    · exact exp_nonneg _
+    apply eq_const_of_exists_le (r := exp (-(π * √3 * (1 / 2)))) hdiff (exp_nonneg _)
     · simp only [one_div, exp_lt_one_iff, Left.neg_neg_iff, pi_pos, mul_pos_iff_of_pos_left,
-      sqrt_pos, Nat.ofNat_pos, inv_pos]
+        sqrt_pos, Nat.ofNat_pos, inv_pos]
     · intro z hz
       rcases eq_or_ne z 0 with rfl | hz'
       · refine ⟨0, by simpa using exp_nonneg _, by rfl⟩
-      · let t : ℍ := ⟨(Function.Periodic.invQParam 1 z), by
-          apply  Function.Periodic.im_invQParam_pos_of_abs_lt_one Real.zero_lt_one
-            (mem_ball_zero_iff.mp hz) hz'⟩
+      · let t : ℍ := ⟨(invQParam 1 z), im_invQParam_pos_of_abs_lt_one Real.zero_lt_one
+          (mem_ball_zero_iff.mp hz) hz'⟩
         obtain ⟨ξ, hξ, hξ₂⟩ := exists_one_half_le_im_and_norm_le hk f t
         use 𝕢 1 ξ
         simp only [Metric.mem_closedBall, dist_zero_right]
         refine ⟨qParam_im_ge_half ξ hξ, ?_⟩
-        simp only [← eq_cuspFunction 1 f t, Nat.cast_one, Complex.norm_eq_abs, ←
-          eq_cuspFunction 1 f ξ] at hξ₂
+        simp only [← eq_cuspFunction 1 f t, Nat.cast_one, Complex.norm_eq_abs,
+          ← eq_cuspFunction 1 f ξ] at hξ₂
         convert hξ₂
-        rw [← (Function.Periodic.qParam_right_inv one_ne_zero hz')]
+        rw [← (qParam_right_inv one_ne_zero hz')]
         congr
-  have H : ∀ z, ⇑f z = Function.const ℍ ((cuspFunction 1 f) 0) z:= by
+  have H : ∀ z, ⇑f z = const ℍ (cuspFunction 1 f 0) z := by
     intro z
     have hQ : 𝕢 1 z ∈ (Metric.ball 0 1) := by
       simpa only [Metric.mem_ball, dist_zero_right, Complex.norm_eq_abs, neg_mul, mul_zero, div_one,
-        Real.exp_zero] using (Function.Periodic.abs_qParam_lt_iff zero_lt_one 0 z.1).mpr z.2
+        Real.exp_zero] using (abs_qParam_lt_iff zero_lt_one 0 z.1).mpr z.2
     simpa only [← eq_cuspFunction 1 f z, Nat.cast_one, const_apply] using heq hQ
-  rcases (SlashInvariantForm.wt_eq_zero_of_eq_const k (c := cuspFunction 1 f 0) H) with HF | HF
+  rcases (wt_eq_zero_of_eq_const k (c := cuspFunction 1 f 0) H) with HF | HF
   · right
-    refine ⟨HF, (cuspFunction 1 (f) 0), by ext z; exact H z⟩
+    refine ⟨HF, (cuspFunction 1 (f) 0), funext fun z ↦ H z⟩
   · left
     rw [HF] at H
-    ext z
-    simpa using H z
+    exact funext fun z ↦ id (H z)
 
-lemma ModularForm_neg_weight_eq_zero (k : ℤ) (hk : k < 0) {F : Type*} [FunLike F ℍ ℂ]
+lemma levelOne_non_pos_weight_eq_zero {k : ℤ} (hk : k < 0) {F : Type*} [FunLike F ℍ ℂ]
     [ModularFormClass F Γ(1) k] (f : F) : ⇑f = 0 := by
-  rcases neg_wt_modform_zero k hk.le f with h | ⟨rfl, _, _⟩
-  · exact h
-  · omega
+  have := levelOne_neg_wt_eq_zero_or_const hk.le f
+  aesop
 
-lemma ModularForm_weight_zero_constant {F : Type*} [FunLike F ℍ ℂ]
+lemma levelOne_weight_zero_constant {F : Type*} [FunLike F ℍ ℂ]
     [ModularFormClass F Γ(1) 0] (f : F) : ∃ c : ℂ, ⇑f = fun _ => c := by
-  rcases neg_wt_modform_zero 0 (by rfl) f with h1 | h2
-  · refine ⟨0, h1⟩
-  · exact h2.2
+  have := levelOne_neg_wt_eq_zero_or_const (by rfl) f
+  aesop
 
-lemma weight_zero_rank_eq_one : Module.rank ℂ (ModularForm Γ(1) 0) = 1 := by
+end ModularFormClass
+
+lemma ModularForm.levelOne_weight_zero_rank_one : Module.rank ℂ (ModularForm Γ(1) 0) = 1 := by
   let f := ModularForm.const 1 (Γ := Γ(1))
   have hf : f ≠ 0 := by
-    rw [@DFunLike.ne_iff]
-    use I
-    simp only [ModularForm.const_toFun, const_apply, zero_apply, ne_eq, one_ne_zero,
-      not_false_eq_true, f]
+    rw [DFunLike.ne_iff]
+    refine ⟨I, by simp only [const_toFun, const_apply, zero_apply, ne_eq, one_ne_zero,
+      not_false_eq_true, f]⟩
   apply rank_eq_one f hf
   intro g
-  rw [@DFunLike.ne_iff] at hf
-  obtain ⟨c', hc'⟩ := ModularForm_weight_zero_constant g
+  obtain ⟨c', hc'⟩ := levelOne_weight_zero_constant g
   use c'
   ext z
-  simp only [zero_apply, ne_eq, SlashInvariantForm.toFun_eq_coe, toSlashInvariantForm_coe,
-   smul_eq_mul] at *
-  simp only [ModularForm.smul_apply, show  f z = 1 by rfl, smul_eq_mul, mul_one]
-  exact (congrFun hc' z).symm
+  simp only [zero_apply, ne_eq, (congrFun hc' z).symm, smul_apply, show f z = 1 by rfl, smul_eq_mul,
+    mul_one] at *
 
-lemma neg_weight_rank_zero (k : ℤ) (hk : k < 0) : Module.rank ℂ (ModularForm Γ(1) k) = 0 := by
+lemma ModularForm.levelOne_nono_pos_weight_rank_zero {k : ℤ} (hk : k < 0) :
+    Module.rank ℂ (ModularForm Γ(1) k) = 0 := by
   rw [rank_eq_zero_iff]
   intro f
-  refine ⟨1, by simp, ?_⟩
-  exact
-    Eq.mpr (id (congrArg (fun x ↦ x = 0) (one_smul ℂ f)))
-      (ModularForm.ext_iff.mpr (congrFun (ModularForm_neg_weight_eq_zero k hk f)))
+  refine ⟨1, (zero_ne_one' ℂ).symm, Eq.mpr (id (congrArg (fun x ↦ x = 0) (one_smul ℂ f)))
+      (ModularForm.ext_iff.mpr (congrFun (levelOne_non_pos_weight_eq_zero hk f)))⟩

--- a/Mathlib/NumberTheory/ModularForms/LevelOne.lean
+++ b/Mathlib/NumberTheory/ModularForms/LevelOne.lean
@@ -44,36 +44,38 @@ lemma SlashInvariantForm.wt_eq_zero_of_eq_const
 
 namespace ModularFormClass
 
-lemma levelOne_neg_wt_eq_zero_or_const {k : ℤ} (hk : k ≤ 0) {F : Type*} [FunLike F ℍ ℂ]
-    [ModularFormClass F Γ(1) k] (f : F) : ⇑f = 0 ∨ (k = 0 ∧ ∃ c : ℂ, ⇑f = fun _ => c) := by
+theorem neg_wt_eq_const {k : ℤ} (hk : k ≤ 0) {F : Type*}  [FunLike F ℍ ℂ]
+    [ModularFormClass F Γ(1) k] (f : F) :
+    Set.EqOn (cuspFunction 1 f) (const ℂ (cuspFunction 1 f 0)) (Metric.ball 0 1) := by
   have hdiff : DifferentiableOn ℂ (cuspFunction 1 f) (Metric.ball 0 1) := by
     exact fun z hz ↦ DifferentiableAt.differentiableWithinAt (differentiableAt_cuspFunction 1 f
       (mem_ball_zero_iff.mp hz))
-  have heq : Set.EqOn (cuspFunction 1 f) (const ℂ (cuspFunction 1 f 0))
-    (Metric.ball 0 1) := by
-    apply eq_const_of_exists_le (r := exp (-(π * √3 * (1 / 2)))) hdiff (exp_nonneg _)
-    · simp only [one_div, exp_lt_one_iff, Left.neg_neg_iff, pi_pos, mul_pos_iff_of_pos_left,
-        sqrt_pos, Nat.ofNat_pos, inv_pos]
-    · intro z hz
-      rcases eq_or_ne z 0 with rfl | hz'
-      · refine ⟨0, by simpa using exp_nonneg _, by rfl⟩
-      · let t : ℍ := ⟨(invQParam 1 z), im_invQParam_pos_of_abs_lt_one Real.zero_lt_one
-          (mem_ball_zero_iff.mp hz) hz'⟩
-        obtain ⟨ξ, hξ, hξ₂⟩ := exists_one_half_le_im_and_norm_le hk f t
-        use 𝕢 1 ξ
-        simp only [Metric.mem_closedBall, dist_zero_right]
-        refine ⟨qParam_im_ge_half ξ hξ, ?_⟩
-        simp only [← eq_cuspFunction 1 f t, Nat.cast_one, Complex.norm_eq_abs,
-          ← eq_cuspFunction 1 f ξ] at hξ₂
-        convert hξ₂
-        rw [← (qParam_right_inv one_ne_zero hz')]
-        congr
+  apply eq_const_of_exists_le (r := exp (-(π * √3 * (1 / 2)))) hdiff (exp_nonneg _)
+  · simp only [one_div, exp_lt_one_iff, Left.neg_neg_iff, pi_pos, mul_pos_iff_of_pos_left,
+      sqrt_pos, Nat.ofNat_pos, inv_pos]
+  · intro z hz
+    rcases eq_or_ne z 0 with rfl | hz'
+    · refine ⟨0, by simpa using exp_nonneg _, by rfl⟩
+    · let t : ℍ := ⟨(invQParam 1 z), im_invQParam_pos_of_abs_lt_one Real.zero_lt_one
+        (mem_ball_zero_iff.mp hz) hz'⟩
+      obtain ⟨ξ, hξ, hξ₂⟩ := exists_one_half_le_im_and_norm_le hk f t
+      use 𝕢 1 ξ
+      simp only [Metric.mem_closedBall, dist_zero_right]
+      refine ⟨qParam_im_ge_half ξ hξ, ?_⟩
+      simp only [← eq_cuspFunction 1 f t, Nat.cast_one, Complex.norm_eq_abs,
+        ← eq_cuspFunction 1 f ξ] at hξ₂
+      convert hξ₂
+      rw [← (qParam_right_inv one_ne_zero hz')]
+      congr
+
+lemma levelOne_neg_wt_eq_zero_or_const {k : ℤ} (hk : k ≤ 0) {F : Type*} [FunLike F ℍ ℂ]
+    [ModularFormClass F Γ(1) k] (f : F) : ⇑f = 0 ∨ (k = 0 ∧ ∃ c : ℂ, ⇑f = fun _ => c) := by
   have H : ∀ z, ⇑f z = const ℍ (cuspFunction 1 f 0) z := by
     intro z
     have hQ : 𝕢 1 z ∈ (Metric.ball 0 1) := by
       simpa only [Metric.mem_ball, dist_zero_right, Complex.norm_eq_abs, neg_mul, mul_zero, div_one,
         Real.exp_zero] using (abs_qParam_lt_iff zero_lt_one 0 z.1).mpr z.2
-    simpa only [← eq_cuspFunction 1 f z, Nat.cast_one, const_apply] using heq hQ
+    simpa only [← eq_cuspFunction 1 f z, Nat.cast_one, const_apply] using (neg_wt_eq_const hk f) hQ
   rcases (wt_eq_zero_of_eq_const k (c := cuspFunction 1 f 0) H) with HF | HF
   · right
     refine ⟨HF, (cuspFunction 1 (f) 0), funext fun z ↦ H z⟩
@@ -107,7 +109,7 @@ lemma ModularForm.levelOne_weight_zero_rank_one : Module.rank ℂ (ModularForm �
   simp only [zero_apply, ne_eq, (congrFun hc' z).symm, smul_apply, show f z = 1 by rfl, smul_eq_mul,
     mul_one] at *
 
-lemma ModularForm.levelOne_nono_pos_weight_rank_zero {k : ℤ} (hk : k < 0) :
+lemma ModularForm.levelOne_non_pos_weight_rank_zero {k : ℤ} (hk : k < 0) :
     Module.rank ℂ (ModularForm Γ(1) k) = 0 := by
   rw [rank_eq_zero_iff]
   intro f

--- a/Mathlib/NumberTheory/ModularForms/LevelOne.lean
+++ b/Mathlib/NumberTheory/ModularForms/LevelOne.lean
@@ -50,7 +50,7 @@ theorem neg_wt_cuspFunction_EqOn_const {k : ℤ} (hk : k ≤ 0) {F : Type*} [Fun
   have hdiff : DifferentiableOn ℂ (cuspFunction 1 f) (Metric.ball 0 1) := by
     exact fun z hz ↦ DifferentiableAt.differentiableWithinAt (differentiableAt_cuspFunction 1 f
       (mem_ball_zero_iff.mp hz))
-  apply eq_const_of_exists_le (r := exp (-(π * √3 * (1 / 2)))) hdiff (exp_nonneg _)
+  apply eq_const_of_exists_le (r := exp (-π)) hdiff (exp_nonneg _)
   · simp only [one_div, exp_lt_one_iff, Left.neg_neg_iff, pi_pos, mul_pos_iff_of_pos_left,
       sqrt_pos, Nat.ofNat_pos, inv_pos]
   · intro z hz
@@ -61,7 +61,7 @@ theorem neg_wt_cuspFunction_EqOn_const {k : ℤ} (hk : k ≤ 0) {F : Type*} [Fun
       obtain ⟨ξ, hξ, hξ₂⟩ := exists_one_half_le_im_and_norm_le hk f t
       use 𝕢 1 ξ
       rw [Metric.mem_closedBall, dist_zero_right]
-      refine ⟨qParam_im_ge_half ξ hξ, ?_⟩
+      refine ⟨qParam_abs_le_of_one_half_le_abs hξ, ?_⟩
       simp only [one_div, ← eq_cuspFunction 1 f t, Nat.cast_one, Complex.norm_eq_abs, ←
         eq_cuspFunction 1 f ξ] at *
       rw [← qParam_right_inv one_ne_zero hz']

--- a/Mathlib/NumberTheory/ModularForms/LevelOne.lean
+++ b/Mathlib/NumberTheory/ModularForms/LevelOne.lean
@@ -63,9 +63,9 @@ lemma neg_wt_modform_zero (k : ℤ) (hk : k ≤ 0) {F : Type*} [FunLike F ℍ �
         obtain ⟨ξ, hξ, hξ₂⟩ := exists_one_half_le_im_and_norm_le hk f t
         use 𝕢 1 ξ
         simp only [Metric.mem_closedBall, dist_zero_right]
-        refine ⟨qParam_image_bound ξ hξ, ?_⟩
-        rw [← eq_cuspFunction 1 f ξ, ← eq_cuspFunction 1 f t] at hξ₂
-        simp at hξ₂
+        refine ⟨qParam_im_ge_half ξ hξ, ?_⟩
+        simp only [← eq_cuspFunction 1 f t, Nat.cast_one, Complex.norm_eq_abs, ←
+          eq_cuspFunction 1 f ξ] at hξ₂
         convert hξ₂
         rw [← (Function.Periodic.qParam_right_inv one_ne_zero hz')]
         congr
@@ -75,8 +75,7 @@ lemma neg_wt_modform_zero (k : ℤ) (hk : k ≤ 0) {F : Type*} [FunLike F ℍ �
       simpa only [Metric.mem_ball, dist_zero_right, Complex.norm_eq_abs, neg_mul, mul_zero, div_one,
         Real.exp_zero] using (Function.Periodic.abs_qParam_lt_iff zero_lt_one 0 z.1).mpr z.2
     simpa only [← eq_cuspFunction 1 f z, Nat.cast_one, const_apply] using heq hQ
-  have HF := SlashInvariantForm.wt_eq_zero_of_eq_const k (c := cuspFunction 1 f 0) H
-  rcases HF with HF | HF
+  rcases (SlashInvariantForm.wt_eq_zero_of_eq_const k (c := cuspFunction 1 f 0) H) with HF | HF
   · right
     refine ⟨HF, (cuspFunction 1 (f) 0), by ext z; exact H z⟩
   · left
@@ -88,15 +87,13 @@ lemma ModularForm_neg_weight_eq_zero (k : ℤ) (hk : k < 0) {F : Type*} [FunLike
     [ModularFormClass F Γ(1) k] (f : F) : ⇑f = 0 := by
   rcases neg_wt_modform_zero k hk.le f with h | ⟨rfl, _, _⟩
   · exact h
-  · aesop
+  · omega
 
 lemma ModularForm_weight_zero_constant {F : Type*} [FunLike F ℍ ℂ]
     [ModularFormClass F Γ(1) 0] (f : F) : ∃ c : ℂ, ⇑f = fun _ => c := by
   rcases neg_wt_modform_zero 0 (by rfl) f with h1 | h2
-  · refine ⟨0, ?_⟩
-    simp only [h1]
-    rfl
-  · aesop
+  · refine ⟨0, h1⟩
+  · exact h2.2
 
 lemma weight_zero_rank_eq_one : Module.rank ℂ (ModularForm Γ(1) 0) = 1 := by
   let f := ModularForm.const 1 (Γ := Γ(1))
@@ -113,8 +110,7 @@ lemma weight_zero_rank_eq_one : Module.rank ℂ (ModularForm Γ(1) 0) = 1 := by
   ext z
   simp only [zero_apply, ne_eq, SlashInvariantForm.toFun_eq_coe, toSlashInvariantForm_coe,
    smul_eq_mul] at *
-  have : f z = 1 := rfl
-  simp only [ModularForm.smul_apply, this, smul_eq_mul, mul_one]
+  simp only [ModularForm.smul_apply, show  f z = 1 by rfl, smul_eq_mul, mul_one]
   exact (congrFun hc' z).symm
 
 lemma neg_weight_rank_zero (k : ℤ) (hk : k < 0) : Module.rank ℂ (ModularForm Γ(1) k) = 0 := by

--- a/Mathlib/NumberTheory/ModularForms/LevelOne.lean
+++ b/Mathlib/NumberTheory/ModularForms/LevelOne.lean
@@ -42,21 +42,6 @@ lemma SlashInvariantForm.wt_eq_zero_of_eq_const
   rwa [← Complex.ofReal_ofNat, ← ofReal_zpow, ← ofReal_one, ofReal_inj,
     zpow_eq_one_iff_right₀ (by norm_num) (by norm_num)] at H
 
-lemma qParam_image_bound (ξ : ℍ) (hξ : 1 / 2 ≤ ξ.im) : ‖𝕢 1 ξ‖ ≤ rexp (-(π * √3 * (1 / 2))) := by
-  simp only [Periodic.qParam, ofReal_one, div_one, Complex.norm_eq_abs, Complex.abs_exp]
-  apply Real.exp_le_exp_of_le
-  simp only [mul_re, re_ofNat, ofReal_re, im_ofNat, ofReal_im, mul_zero, sub_zero,
-    Complex.I_re, mul_im, zero_mul, add_zero, Complex.I_im, mul_one, sub_self, coe_re,
-    coe_im, zero_sub, neg_le]
-  ring_nf
-  simp_rw [mul_assoc]
-  apply mul_le_mul_of_nonneg_left _ pi_nonneg
-  have : 1 ≤ ξ.im * 2 := by
-    rwa [div_le_iff₀ zero_lt_two] at hξ
-  apply le_trans _ this
-  have : √3 ≤ 2 := sqrt_le_iff.mpr (by norm_cast)
-  linarith
-
 lemma neg_wt_modform_zero (k : ℤ) (hk : k ≤ 0) {F : Type*} [FunLike F ℍ ℂ]
     [ModularFormClass F Γ(1) k] (f : F) : ⇑f = 0 ∨ (k = 0 ∧ ∃ c : ℂ, ⇑f = fun _ => c) := by
   have hdiff : DifferentiableOn ℂ (cuspFunction 1 f) (Metric.ball 0 1) := by

--- a/Mathlib/NumberTheory/ModularForms/LevelOne.lean
+++ b/Mathlib/NumberTheory/ModularForms/LevelOne.lean
@@ -39,12 +39,12 @@ lemma SlashInvariantForm.wt_eq_zero_of_eq_const
   nth_rw 1 [h2I2] at hI
   simp only [mul_zpow, coe_I, mul_eq_mul_right_iff, mul_left_eq_self₀] at hI
   refine hI.imp_left (Or.casesOn · (fun H ↦ ?_) (False.elim ∘ zpow_ne_zero k I_ne_zero))
-  rwa [← Complex.ofReal_ofNat, ← ofReal_zpow, ← ofReal_one, ofReal_inj,
+  rwa [← ofReal_ofNat, ← ofReal_zpow, ← ofReal_one, ofReal_inj,
     zpow_eq_one_iff_right₀ (by norm_num) (by norm_num)] at H
 
 namespace ModularFormClass
 
-theorem neg_wt_cuspFunction_EqOn_const {k : ℤ} (hk : k ≤ 0) {F : Type*}  [FunLike F ℍ ℂ]
+theorem neg_wt_cuspFunction_EqOn_const {k : ℤ} (hk : k ≤ 0) {F : Type*} [FunLike F ℍ ℂ]
     [ModularFormClass F Γ(1) k] (f : F) :
     Set.EqOn (cuspFunction 1 f) (const ℂ (cuspFunction 1 f 0)) (Metric.ball 0 1) := by
   have hdiff : DifferentiableOn ℂ (cuspFunction 1 f) (Metric.ball 0 1) := by
@@ -60,13 +60,12 @@ theorem neg_wt_cuspFunction_EqOn_const {k : ℤ} (hk : k ≤ 0) {F : Type*}  [Fu
         (mem_ball_zero_iff.mp hz) hz'⟩
       obtain ⟨ξ, hξ, hξ₂⟩ := exists_one_half_le_im_and_norm_le hk f t
       use 𝕢 1 ξ
-      simp only [Metric.mem_closedBall, dist_zero_right]
+      rw [Metric.mem_closedBall, dist_zero_right]
       refine ⟨qParam_im_ge_half ξ hξ, ?_⟩
-      simp only [← eq_cuspFunction 1 f t, Nat.cast_one, Complex.norm_eq_abs,
-        ← eq_cuspFunction 1 f ξ] at hξ₂
-      convert hξ₂
-      rw [← (qParam_right_inv one_ne_zero hz')]
-      congr
+      simp only [one_div, ← eq_cuspFunction 1 f t, Nat.cast_one, Complex.norm_eq_abs, ←
+        eq_cuspFunction 1 f ξ] at *
+      rw [← qParam_right_inv one_ne_zero hz']
+      exact hξ₂
 
 theorem levelOne_neg_wt_const {k : ℤ} (hk : k ≤ 0) {F : Type*} [FunLike F ℍ ℂ]
     [ModularFormClass F Γ(1) k] (f : F) (z : ℍ) :

--- a/Mathlib/NumberTheory/ModularForms/LevelOne.lean
+++ b/Mathlib/NumberTheory/ModularForms/LevelOne.lean
@@ -35,11 +35,11 @@ lemma exists_one_half_le_im_and_norm_le (hk : k ≤ 0) (f : F) (τ : ℍ) :
 
 variable (k) in
 /-- If a constant function is modular of weight `k`, then either `k = 0`, or the constant is `0`. -/
-lemma wt_eq_zero_of_eq_const {f : F} {c : ℂ} (hf : ∀ τ, f τ = c) :
+lemma wt_eq_zero_of_eq_const {f : F} {c : ℂ} (hf : ⇑f = Function.const _ c) :
     k = 0 ∨ c = 0 := by
   have hI := slash_action_eqn'' f (mem_Gamma_one S) I
   have h2I2 := slash_action_eqn'' f (mem_Gamma_one S) ⟨2 * Complex.I, by norm_num⟩
-  simp only [sl_moeb, hf, denom_S, coe_mk_subtype] at hI h2I2
+  simp only [sl_moeb, hf, Function.const, denom_S, coe_mk_subtype] at hI h2I2
   nth_rw 1 [h2I2] at hI
   simp only [mul_zpow, coe_I, mul_eq_mul_right_iff, mul_left_eq_self₀] at hI
   refine hI.imp_left (Or.casesOn · (fun H ↦ ?_) (False.elim ∘ zpow_ne_zero k I_ne_zero))
@@ -66,8 +66,9 @@ private theorem cuspFunction_eqOn_const_of_nonpos_wt (hk : k ≤ 0) (f : F) :
         by simpa only [← eq_cuspFunction 1 f, Nat.cast_one, coe_mk_subtype,
           qParam_right_inv one_ne_zero hq'] using hξ₂⟩
 
-private theorem levelOne_nonpos_wt_const (hk : k ≤ 0) (f : F) (z : ℍ) :
-    f z = cuspFunction 1 f 0 := by
+private theorem levelOne_nonpos_wt_const (hk : k ≤ 0) (f : F) :
+    ⇑f = Function.const _ (cuspFunction 1 f 0) := by
+  ext z
   have hQ : 𝕢 1 z ∈ (Metric.ball 0 1) := by
     simpa only [Metric.mem_ball, dist_zero_right, Complex.norm_eq_abs, neg_mul, mul_zero, div_one,
       Real.exp_zero] using (abs_qParam_lt_iff zero_lt_one 0 z.1).mpr z.2
@@ -78,19 +79,18 @@ lemma levelOne_neg_weight_eq_zero (hk : k < 0) (f : F) : ⇑f = 0 := by
   have hf := levelOne_nonpos_wt_const hk.le f
   rcases wt_eq_zero_of_eq_const k hf with rfl | hf₀
   · exact (lt_irrefl _ hk).elim
-  · exact funext fun z ↦ (hf₀ ▸ hf) z
+  · rw [hf, hf₀, const_zero]
 
 lemma levelOne_weight_zero_const [ModularFormClass F Γ(1) 0] (f : F) :
-    ∃ c, ⇑f = fun _ ↦ c :=
-  ⟨_, funext <| levelOne_nonpos_wt_const le_rfl f⟩
+    ∃ c, ⇑f = Function.const _ c :=
+  ⟨_, levelOne_nonpos_wt_const le_rfl f⟩
 
 end ModularFormClass
 
 lemma ModularForm.levelOne_weight_zero_rank_one : Module.rank ℂ (ModularForm Γ(1) 0) = 1 := by
   refine rank_eq_one (const 1) (by simp [DFunLike.ne_iff]) fun g ↦ ?_
   obtain ⟨c', hc'⟩ := levelOne_weight_zero_const g
-  refine ⟨c', DFunLike.ext _ _ fun z ↦ ?_⟩
-  simp only [← congrFun hc' z, smul_apply, const_apply, smul_eq_mul, mul_one]
+  aesop
 
 lemma ModularForm.levelOne_neg_weight_rank_zero (hk : k < 0) :
     Module.rank ℂ (ModularForm Γ(1) k) = 0 := by

--- a/Mathlib/NumberTheory/ModularForms/LevelOne.lean
+++ b/Mathlib/NumberTheory/ModularForms/LevelOne.lean
@@ -15,26 +15,30 @@ TODO: Add finite-dimensionality of these spaces of modular forms.
 
 -/
 
-open UpperHalfPlane ModularGroup SlashInvariantForm ModularForm Complex MatrixGroups
+open UpperHalfPlane ModularGroup SlashInvariantForm ModularForm Complex
   CongruenceSubgroup Real Function SlashInvariantFormClass ModularFormClass Periodic
 
-local notation "𝕢" => Periodic.qParam
+local notation "𝕢" => qParam
 
-lemma SlashInvariantForm.exists_one_half_le_im_and_norm_le {k : ℤ} (hk : k ≤ 0) {F : Type*}
-    [FunLike F ℍ ℂ] [SlashInvariantFormClass F Γ(1) k] (f : F) (τ : ℍ) :
-    ∃ ξ : ℍ, 1/2 ≤ ξ.im ∧ ‖f τ‖ ≤ ‖f ξ‖ :=
+variable {F : Type*} [FunLike F ℍ ℂ] {k : ℤ}
+
+namespace SlashInvariantForm
+
+variable [SlashInvariantFormClass F Γ(1) k]
+
+lemma exists_one_half_le_im_and_norm_le (hk : k ≤ 0) (f : F) (τ : ℍ) :
+    ∃ ξ : ℍ, 1 / 2 ≤ ξ.im ∧ ‖f τ‖ ≤ ‖f ξ‖ :=
   let ⟨γ, hγ, hdenom⟩ := exists_one_half_le_im_smul_and_norm_denom_le τ
-  ⟨γ • τ, hγ, by simpa only [slash_action_eqn'' _ (show γ ∈ Γ(1) by rw [Gamma_one_top]; tauto),
+  ⟨γ • τ, hγ, by simpa only [slash_action_eqn'' _ (mem_Gamma_one γ),
     norm_mul, norm_zpow] using le_mul_of_one_le_left (norm_nonneg _) <|
       one_le_zpow_of_nonpos₀ (norm_pos_iff.2 (denom_ne_zero _ _)) hdenom hk⟩
 
+variable (k) in
 /-- If a constant function is modular of weight `k`, then either `k = 0`, or the constant is `0`. -/
-lemma SlashInvariantForm.wt_eq_zero_of_eq_const
-    {F : Type*} [FunLike F ℍ ℂ] (k : ℤ) [SlashInvariantFormClass F Γ(1) k]
-    {f : F} {c : ℂ} (hf : ∀ τ, f τ = c) : k = 0 ∨ c = 0 := by
-  have hI := slash_action_eqn'' f (show ModularGroup.S ∈ Γ(1) by rw [Gamma_one_top]; tauto) I
-  have h2I2 := slash_action_eqn'' f (show ModularGroup.S ∈ Γ(1) by rw [Gamma_one_top]; tauto)
-    ⟨2 * Complex.I, by simp⟩
+lemma wt_eq_zero_of_eq_const {f : F} {c : ℂ} (hf : ∀ τ, f τ = c) :
+    k = 0 ∨ c = 0 := by
+  have hI := slash_action_eqn'' f (mem_Gamma_one S) I
+  have h2I2 := slash_action_eqn'' f (mem_Gamma_one S) ⟨2 * Complex.I, by norm_num⟩
   simp only [sl_moeb, hf, denom_S, coe_mk_subtype] at hI h2I2
   nth_rw 1 [h2I2] at hI
   simp only [mul_zpow, coe_I, mul_eq_mul_right_iff, mul_left_eq_self₀] at hI
@@ -42,71 +46,53 @@ lemma SlashInvariantForm.wt_eq_zero_of_eq_const
   rwa [← ofReal_ofNat, ← ofReal_zpow, ← ofReal_one, ofReal_inj,
     zpow_eq_one_iff_right₀ (by norm_num) (by norm_num)] at H
 
+end SlashInvariantForm
+
 namespace ModularFormClass
 
-theorem neg_wt_cuspFunction_EqOn_const {k : ℤ} (hk : k ≤ 0) {F : Type*} [FunLike F ℍ ℂ]
-    [ModularFormClass F Γ(1) k] (f : F) :
-    Set.EqOn (cuspFunction 1 f) (const ℂ (cuspFunction 1 f 0)) (Metric.ball 0 1) := by
-  have hdiff : DifferentiableOn ℂ (cuspFunction 1 f) (Metric.ball 0 1) := by
-    exact fun z hz ↦ DifferentiableAt.differentiableWithinAt (differentiableAt_cuspFunction 1 f
-      (mem_ball_zero_iff.mp hz))
-  apply eq_const_of_exists_le (r := exp (-π)) hdiff (exp_nonneg _)
-  · simp only [one_div, exp_lt_one_iff, Left.neg_neg_iff, pi_pos, mul_pos_iff_of_pos_left,
-      sqrt_pos, Nat.ofNat_pos, inv_pos]
-  · intro z hz
-    rcases eq_or_ne z 0 with rfl | hz'
-    · refine ⟨0, by simpa using exp_nonneg _, by rfl⟩
-    · let t : ℍ := ⟨(invQParam 1 z), im_invQParam_pos_of_abs_lt_one Real.zero_lt_one
-        (mem_ball_zero_iff.mp hz) hz'⟩
-      obtain ⟨ξ, hξ, hξ₂⟩ := exists_one_half_le_im_and_norm_le hk f t
-      use 𝕢 1 ξ
-      rw [Metric.mem_closedBall, dist_zero_right]
-      refine ⟨qParam_abs_le_of_one_half_le_abs hξ, ?_⟩
-      simp only [one_div, ← eq_cuspFunction 1 f t, Nat.cast_one, Complex.norm_eq_abs, ←
-        eq_cuspFunction 1 f ξ] at *
-      rw [← qParam_right_inv one_ne_zero hz']
-      exact hξ₂
+variable [ModularFormClass F Γ(1) k]
 
-theorem levelOne_neg_wt_const {k : ℤ} (hk : k ≤ 0) {F : Type*} [FunLike F ℍ ℂ]
-    [ModularFormClass F Γ(1) k] (f : F) (z : ℍ) :
-    f z = Function.const ℍ (SlashInvariantFormClass.cuspFunction 1 f 0) z := by
+private theorem cuspFunction_eqOn_const_of_nonpos_wt (hk : k ≤ 0) (f : F) :
+    Set.EqOn (cuspFunction 1 f) (const ℂ (cuspFunction 1 f 0)) (Metric.ball 0 1) := by
+  refine eq_const_of_exists_le (fun q hq ↦ ?_) (exp_nonneg (-π)) ?_ (fun q hq ↦ ?_)
+  · exact (differentiableAt_cuspFunction 1 f (mem_ball_zero_iff.mp hq)).differentiableWithinAt
+  · simp only [exp_lt_one_iff, Left.neg_neg_iff, pi_pos]
+  · simp only [Metric.mem_closedBall, dist_zero_right]
+    rcases eq_or_ne q 0 with rfl | hq'
+    · refine ⟨0, by simpa only [norm_zero] using exp_nonneg _, le_rfl⟩
+    · obtain ⟨ξ, hξ, hξ₂⟩ := exists_one_half_le_im_and_norm_le hk f
+        ⟨_, im_invQParam_pos_of_abs_lt_one Real.zero_lt_one (mem_ball_zero_iff.mp hq) hq'⟩
+      exact ⟨_, abs_qParam_le_of_one_half_le_im hξ,
+        by simpa only [← eq_cuspFunction 1 f, Nat.cast_one, coe_mk_subtype,
+          qParam_right_inv one_ne_zero hq'] using hξ₂⟩
+
+private theorem levelOne_nonpos_wt_const (hk : k ≤ 0) (f : F) (z : ℍ) :
+    f z = cuspFunction 1 f 0 := by
   have hQ : 𝕢 1 z ∈ (Metric.ball 0 1) := by
     simpa only [Metric.mem_ball, dist_zero_right, Complex.norm_eq_abs, neg_mul, mul_zero, div_one,
       Real.exp_zero] using (abs_qParam_lt_iff zero_lt_one 0 z.1).mpr z.2
-  simpa only [← eq_cuspFunction 1 f z, Nat.cast_one, const_apply] using
-    (neg_wt_cuspFunction_EqOn_const hk f) hQ
+  simpa only [← eq_cuspFunction 1 f z, Nat.cast_one, Function.const_apply] using
+    (cuspFunction_eqOn_const_of_nonpos_wt hk f) hQ
 
-lemma levelOne_non_pos_weight_eq_zero {k : ℤ} (hk : k < 0) {F : Type*} [FunLike F ℍ ℂ]
-    [ModularFormClass F Γ(1) k] (f : F) : ⇑f = 0 := by
-  have H := (levelOne_neg_wt_const hk.le f)
-  rcases (wt_eq_zero_of_eq_const k (c := cuspFunction 1 f 0) H) with rfl | HF
-  · omega
-  · rw [HF] at H
-    exact funext fun z ↦ id (H z)
+lemma levelOne_neg_weight_eq_zero (hk : k < 0) (f : F) : ⇑f = 0 := by
+  have hf := levelOne_nonpos_wt_const hk.le f
+  rcases wt_eq_zero_of_eq_const k hf with rfl | hf₀
+  · exact (lt_irrefl _ hk).elim
+  · exact funext fun z ↦ (hf₀ ▸ hf) z
 
-lemma levelOne_weight_zero_const {F : Type*} [FunLike F ℍ ℂ]
-    [ModularFormClass F Γ(1) 0] (f : F) : ∃ c : ℂ, ⇑f = fun _ => c := by
-  refine ⟨(cuspFunction 1 (f) 0), funext fun z ↦ ((levelOne_neg_wt_const (show 0 ≤ 0 by rfl) f)) z⟩
+lemma levelOne_weight_zero_const [ModularFormClass F Γ(1) 0] (f : F) :
+    ∃ c, ⇑f = fun _ ↦ c :=
+  ⟨_, funext <| levelOne_nonpos_wt_const le_rfl f⟩
 
 end ModularFormClass
 
 lemma ModularForm.levelOne_weight_zero_rank_one : Module.rank ℂ (ModularForm Γ(1) 0) = 1 := by
-  let f := ModularForm.const 1 (Γ := Γ(1))
-  have hf : f ≠ 0 := by
-    rw [DFunLike.ne_iff]
-    refine ⟨I, by simp only [const_toFun, const_apply, zero_apply, ne_eq, one_ne_zero,
-      not_false_eq_true, f]⟩
-  apply rank_eq_one f hf
-  intro g
+  refine rank_eq_one (const 1) (by simp [DFunLike.ne_iff]) fun g ↦ ?_
   obtain ⟨c', hc'⟩ := levelOne_weight_zero_const g
-  use c'
-  ext z
-  simp only [zero_apply, ne_eq, (congrFun hc' z).symm, smul_apply, show f z = 1 by rfl, smul_eq_mul,
-    mul_one] at *
+  refine ⟨c', DFunLike.ext _ _ fun z ↦ ?_⟩
+  simp only [← congrFun hc' z, smul_apply, const_apply, smul_eq_mul, mul_one]
 
-lemma ModularForm.levelOne_non_pos_weight_rank_zero {k : ℤ} (hk : k < 0) :
+lemma ModularForm.levelOne_neg_weight_rank_zero (hk : k < 0) :
     Module.rank ℂ (ModularForm Γ(1) k) = 0 := by
-  rw [rank_eq_zero_iff]
-  intro f
-  refine ⟨1, (zero_ne_one' ℂ).symm, Eq.mpr (id (congrArg (fun x ↦ x = 0) (one_smul ℂ f)))
-      (ModularForm.ext_iff.mpr (congrFun (levelOne_non_pos_weight_eq_zero hk f)))⟩
+  refine rank_eq_zero_iff.mpr fun f ↦ ⟨_, one_ne_zero, ?_⟩
+  simpa only [one_smul, ← DFunLike.coe_injective.eq_iff] using levelOne_neg_weight_eq_zero hk f

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -44,7 +44,7 @@ lemma qParam_im_ge_half (ξ : ℍ) (hξ : 1 / 2 ≤ ξ.im) : ‖𝕢 1 ξ‖ ≤
   apply Real.exp_le_exp_of_le
   simp only [mul_re, re_ofNat, ofReal_re, im_ofNat, ofReal_im, mul_zero, sub_zero, Complex.I_re,
     mul_im, zero_mul, add_zero, Complex.I_im, mul_one, sub_self, coe_re, coe_im,
-    show 2 * π * ξ.im = π * 2 * ξ.im by ring, zero_sub, one_div, neg_le, neg_neg]
+    show 2 * π * ξ.im = π * 2 * ξ.im by ring, zero_sub, neg_le, neg_neg]
   have : √3 ≤ 2 := sqrt_le_iff.mpr (by norm_cast)
   have : 1 ≤ ξ.im * 2 := by
     rwa [div_le_iff₀ zero_lt_two] at hξ

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -20,9 +20,9 @@ application, we show that cusp forms decay exponentially to 0 as `im τ → ∞`
 * define the `q`-expansion as a formal power series
 -/
 
-open ModularForm Complex Filter Asymptotics UpperHalfPlane Function
+open ModularForm Complex Filter UpperHalfPlane Function
 
-open scoped Real Topology Manifold MatrixGroups CongruenceSubgroup
+open scoped Real MatrixGroups CongruenceSubgroup
 
 noncomputable section
 
@@ -36,13 +36,13 @@ theorem Function.Periodic.im_invQParam_pos_of_abs_lt_one
     0 < im (Periodic.invQParam h q) :=
   im_invQParam .. ▸ mul_pos_of_neg_of_neg
     (div_neg_of_neg_of_pos (neg_lt_zero.mpr hh) Real.two_pi_pos)
-    ((Real.log_neg_iff (Complex.abs.pos hq_ne)).mpr hq)
+    ((Real.log_neg_iff (abs.pos hq_ne)).mpr hq)
 
-lemma Function.Periodic.qParam_abs_le_of_one_half_le_abs {ξ : ℂ} (hξ : 1 / 2 ≤ ξ.im) :
+lemma Function.Periodic.abs_qParam_le_of_one_half_le_im {ξ : ℂ} (hξ : 1 / 2 ≤ ξ.im) :
     ‖𝕢 1 ξ‖ ≤ rexp (-π) := by
-  rwa [Periodic.qParam, ofReal_one, div_one, Complex.norm_eq_abs, Complex.abs_exp, Real.exp_le_exp,
+  rwa [Periodic.qParam, ofReal_one, div_one, norm_eq_abs, abs_exp, Real.exp_le_exp,
     mul_right_comm, mul_I_re, neg_le_neg_iff, ← ofReal_ofNat, ← ofReal_mul, im_ofReal_mul,
-    mul_comm _ π, mul_assoc, le_mul_iff_one_le_right Real.pi_pos, ← div_le_iff₀' (by norm_num)]
+    mul_comm _ π, mul_assoc, le_mul_iff_one_le_right Real.pi_pos, ← div_le_iff₀' two_pos]
 
 namespace SlashInvariantFormClass
 

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -38,15 +38,11 @@ theorem Function.Periodic.im_invQParam_pos_of_abs_lt_one
     (div_neg_of_neg_of_pos (neg_lt_zero.mpr hh) Real.two_pi_pos)
     ((Real.log_neg_iff (Complex.abs.pos hq_ne)).mpr hq)
 
-open Real in
-lemma qParam_im_ge_half (ξ : ℍ) (hξ : 1 / 2 ≤ ξ.im) : ‖𝕢 1 ξ‖ ≤ rexp (-(π * √3 * (1 / 2))) := by
-  rw [Periodic.qParam, ofReal_one, div_one, Complex.norm_eq_abs, Complex.abs_exp]
-  apply Real.exp_le_exp_of_le
-  simp only [mul_re, re_ofNat, ofReal_re, im_ofNat, ofReal_im, mul_zero, sub_zero, Complex.I_re,
-    mul_im, zero_mul, add_zero, Complex.I_im, mul_one, sub_self, coe_re, coe_im,
-    show 2 * π * ξ.im = π * 2 * ξ.im by ring, zero_sub, neg_le, neg_neg]
-  have : √3 ≤ 2 := sqrt_le_iff.mpr (by norm_cast)
-  gcongr
+lemma Function.Periodic.qParam_abs_le_of_one_half_le_abs {ξ : ℂ} (hξ : 1 / 2 ≤ ξ.im) :
+    ‖𝕢 1 ξ‖ ≤ rexp (-π) := by
+  rwa [Periodic.qParam, ofReal_one, div_one, Complex.norm_eq_abs, Complex.abs_exp, Real.exp_le_exp,
+    mul_right_comm, mul_I_re, neg_le_neg_iff, ← ofReal_ofNat, ← ofReal_mul, im_ofReal_mul,
+    mul_comm _ π, mul_assoc, le_mul_iff_one_le_right Real.pi_pos, ← div_le_iff₀' (by norm_num)]
 
 namespace SlashInvariantFormClass
 

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -47,6 +47,7 @@ lemma qParam_im_ge_half (ξ : ℍ) (hξ : 1 / 2 ≤ ξ.im) : ‖𝕢 1 ξ‖ ≤
     show 2 * π * ξ.im = π * 2 * ξ.im by ring, zero_sub, neg_le, neg_neg]
   have : √3 ≤ 2 := sqrt_le_iff.mpr (by norm_cast)
   gcongr
+
 namespace SlashInvariantFormClass
 
 theorem periodic_comp_ofComplex [SlashInvariantFormClass F Γ(n) k] :

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -40,7 +40,7 @@ theorem Function.Periodic.im_invQParam_pos_of_abs_lt_one
 
 open Real in
 lemma qParam_im_ge_half (ξ : ℍ) (hξ : 1 / 2 ≤ ξ.im) : ‖𝕢 1 ξ‖ ≤ rexp (-(π * √3 * (1 / 2))) := by
-  simp only [Periodic.qParam, ofReal_one, div_one, Complex.norm_eq_abs, Complex.abs_exp]
+  rw [Periodic.qParam, ofReal_one, div_one, Complex.norm_eq_abs, Complex.abs_exp]
   apply Real.exp_le_exp_of_le
   simp only [mul_re, re_ofNat, ofReal_re, im_ofNat, ofReal_im, mul_zero, sub_zero, Complex.I_re,
     mul_im, zero_mul, add_zero, Complex.I_im, mul_one, sub_self, coe_re, coe_im,

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -46,10 +46,7 @@ lemma qParam_im_ge_half (ξ : ℍ) (hξ : 1 / 2 ≤ ξ.im) : ‖𝕢 1 ξ‖ ≤
     mul_im, zero_mul, add_zero, Complex.I_im, mul_one, sub_self, coe_re, coe_im,
     show 2 * π * ξ.im = π * 2 * ξ.im by ring, zero_sub, neg_le, neg_neg]
   have : √3 ≤ 2 := sqrt_le_iff.mpr (by norm_cast)
-  have : 1 ≤ ξ.im * 2 := by
-    rwa [div_le_iff₀ zero_lt_two] at hξ
   gcongr
-
 namespace SlashInvariantFormClass
 
 theorem periodic_comp_ofComplex [SlashInvariantFormClass F Γ(n) k] :

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -38,6 +38,21 @@ theorem Function.Periodic.im_invQParam_pos_of_abs_lt_one
     (div_neg_of_neg_of_pos (neg_lt_zero.mpr hh) Real.two_pi_pos)
     ((Real.log_neg_iff (Complex.abs.pos hq_ne)).mpr hq)
 
+open Real in
+lemma qParam_image_bound (ξ : ℍ) (hξ : 1 / 2 ≤ ξ.im) : ‖𝕢 1 ξ‖ ≤ rexp (-(π * √3 * (1 / 2))) := by
+  simp only [Periodic.qParam, ofReal_one, div_one, Complex.norm_eq_abs, Complex.abs_exp]
+  apply Real.exp_le_exp_of_le
+  simp  [mul_re, re_ofNat, ofReal_re, im_ofNat, ofReal_im, mul_zero, sub_zero,
+    Complex.I_re, mul_im, zero_mul, add_zero, Complex.I_im, mul_one, sub_self, coe_re,
+    coe_im, zero_sub, neg_le]
+  ring_nf
+  simp_rw [mul_assoc]
+  apply mul_le_mul_of_nonneg_left _ pi_nonneg
+  have : 1 ≤ ξ.im * 2 := by
+    rwa [div_le_iff₀ zero_lt_two] at hξ
+  apply le_trans _ this
+  have : √3 ≤ 2 := sqrt_le_iff.mpr (by norm_cast)
+  linarith
 namespace SlashInvariantFormClass
 
 theorem periodic_comp_ofComplex [SlashInvariantFormClass F Γ(n) k] :

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -39,20 +39,17 @@ theorem Function.Periodic.im_invQParam_pos_of_abs_lt_one
     ((Real.log_neg_iff (Complex.abs.pos hq_ne)).mpr hq)
 
 open Real in
-lemma qParam_image_bound (ξ : ℍ) (hξ : 1 / 2 ≤ ξ.im) : ‖𝕢 1 ξ‖ ≤ rexp (-(π * √3 * (1 / 2))) := by
+lemma qParam_im_ge_half (ξ : ℍ) (hξ : 1 / 2 ≤ ξ.im) : ‖𝕢 1 ξ‖ ≤ rexp (-(π * √3 * (1 / 2))) := by
   simp only [Periodic.qParam, ofReal_one, div_one, Complex.norm_eq_abs, Complex.abs_exp]
   apply Real.exp_le_exp_of_le
-  simp  [mul_re, re_ofNat, ofReal_re, im_ofNat, ofReal_im, mul_zero, sub_zero,
-    Complex.I_re, mul_im, zero_mul, add_zero, Complex.I_im, mul_one, sub_self, coe_re,
-    coe_im, zero_sub, neg_le]
-  ring_nf
-  simp_rw [mul_assoc]
-  apply mul_le_mul_of_nonneg_left _ pi_nonneg
+  simp only [mul_re, re_ofNat, ofReal_re, im_ofNat, ofReal_im, mul_zero, sub_zero, Complex.I_re,
+    mul_im, zero_mul, add_zero, Complex.I_im, mul_one, sub_self, coe_re, coe_im,
+    show 2 * π * ξ.im = π * 2 * ξ.im by ring, zero_sub, one_div, neg_le, neg_neg]
+  have : √3 ≤ 2 := sqrt_le_iff.mpr (by norm_cast)
   have : 1 ≤ ξ.im * 2 := by
     rwa [div_le_iff₀ zero_lt_two] at hξ
-  apply le_trans _ this
-  have : √3 ≤ 2 := sqrt_le_iff.mpr (by norm_cast)
-  linarith
+  gcongr
+
 namespace SlashInvariantFormClass
 
 theorem periodic_comp_ofComplex [SlashInvariantFormClass F Γ(n) k] :


### PR DESCRIPTION
add dimensions in non-positive weights.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
