### PR TITLE
[Merged by Bors] - chore(Pointwise): rename `image_inv` to `image_inv_eq_inv`

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -198,9 +198,7 @@ scoped[Pointwise] attribute [instance] Finset.inv Finset.neg
 theorem inv_def : s⁻¹ = s.image fun x => x⁻¹ :=
   rfl
 
-@[to_additive]
-theorem image_inv_eq_inv (s : Finset α) : (s.image fun x => x⁻¹) = s⁻¹ :=
-  rfl
+@[to_additive] lemma image_inv_eq_inv (s : Finset α) : s.image (·⁻¹) = s⁻¹ := rfl
 
 @[to_additive]
 theorem mem_inv {x : α} : x ∈ s⁻¹ ↔ ∃ y ∈ s, y⁻¹ = x :=

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -199,7 +199,7 @@ theorem inv_def : s⁻¹ = s.image fun x => x⁻¹ :=
   rfl
 
 @[to_additive]
-theorem image_inv : (s.image fun x => x⁻¹) = s⁻¹ :=
+theorem image_inv_eq_inv (s : Finset α) : (s.image fun x => x⁻¹) = s⁻¹ :=
   rfl
 
 @[to_additive]
@@ -279,7 +279,7 @@ variable [DecidableEq α] [InvolutiveInv α] {s : Finset α} {a : α}
 lemma mem_inv' : a ∈ s⁻¹ ↔ a⁻¹ ∈ s := by simp [mem_inv, inv_eq_iff_eq_inv]
 
 @[to_additive (attr := simp, norm_cast)]
-theorem coe_inv (s : Finset α) : ↑s⁻¹ = (s : Set α)⁻¹ := coe_image.trans Set.image_inv
+theorem coe_inv (s : Finset α) : ↑s⁻¹ = (s : Set α)⁻¹ := coe_image.trans Set.image_inv_eq_inv
 
 @[to_additive (attr := simp)]
 theorem card_inv (s : Finset α) : s⁻¹.card = s.card := card_image_of_injective _ inv_injective
@@ -322,7 +322,10 @@ lemma coe_smul (s : Finset α) (t : Finset β) : ↑(s • t) = (s : Set α) •
 
 @[to_additive] lemma smul_mem_smul : a ∈ s → b ∈ t → a • b ∈ s • t := mem_image₂_of_mem
 
-@[to_additive] lemma smul_card_le : (s • t).card ≤ s.card • t.card := card_image₂_le ..
+@[to_additive] lemma card_smul_le : #(s • t) ≤ #s * #t := card_image₂_le ..
+
+@[deprecated (since := "2024-11-19")] alias smul_card_le := card_smul_le
+@[deprecated (since := "2024-11-19")] alias vadd_card_le := card_vadd_le
 
 @[to_additive (attr := simp)]
 lemma empty_smul (t : Finset β) : (∅ : Finset α) • t = ∅ := image₂_empty_left
@@ -1173,6 +1176,9 @@ theorem image_mul_left' :
 theorem image_mul_right' :
     image (· * b⁻¹) t = preimage t (· * b) (mul_left_injective _).injOn := by simp
 
+@[to_additive]
+lemma image_inv (f : F) (s : Finset α) : s⁻¹.image f = (s.image f)⁻¹ := image_comm (map_inv _)
+
 theorem image_div : (s / t).image (f : α → β) = s.image f / t.image f :=
   image_image₂_distrib <| map_div f
 
@@ -1793,4 +1799,4 @@ instance Nat.decidablePred_mem_vadd_set {s : Set ℕ} [DecidablePred (· ∈ s)]
   fun n ↦ decidable_of_iff' (a ≤ n ∧ n - a ∈ s) <| by
     simp only [Set.mem_vadd_set, vadd_eq_add]; aesop
 
-set_option linter.style.longFile 1800
+set_option linter.style.longFile 2000

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -218,7 +218,7 @@ theorem Nonempty.inv (h : s.Nonempty) : s⁻¹.Nonempty :=
   nonempty_inv.2 h
 
 @[to_additive (attr := simp)]
-theorem image_inv_eq_inv : Inv.inv '' s = s⁻¹ :=
+theorem image_inv_eq_inv : (·⁻¹) '' s = s⁻¹ :=
   congr_fun (image_eq_preimage_of_inverse inv_involutive.leftInverse inv_involutive.rightInverse) _
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -141,10 +141,10 @@ end One
 section Inv
 
 /-- The pointwise inversion of set `s⁻¹` is defined as `{x | x⁻¹ ∈ s}` in locale `Pointwise`. It is
-equal to `{x⁻¹ | x ∈ s}`, see `Set.image_inv`. -/
+equal to `{x⁻¹ | x ∈ s}`, see `Set.image_inv_eq_inv`. -/
 @[to_additive
       "The pointwise negation of set `-s` is defined as `{x | -x ∈ s}` in locale `Pointwise`.
-      It is equal to `{-x | x ∈ s}`, see `Set.image_neg`."]
+      It is equal to `{-x | x ∈ s}`, see `Set.image_neg_eq_neg`."]
 protected def inv [Inv α] : Inv (Set α) :=
   ⟨preimage Inv.inv⟩
 
@@ -218,12 +218,12 @@ theorem Nonempty.inv (h : s.Nonempty) : s⁻¹.Nonempty :=
   nonempty_inv.2 h
 
 @[to_additive (attr := simp)]
-theorem image_inv : Inv.inv '' s = s⁻¹ :=
+theorem image_inv_eq_inv : Inv.inv '' s = s⁻¹ :=
   congr_fun (image_eq_preimage_of_inverse inv_involutive.leftInverse inv_involutive.rightInverse) _
 
 @[to_additive (attr := simp)]
 theorem inv_eq_empty : s⁻¹ = ∅ ↔ s = ∅ := by
-  rw [← image_inv, image_eq_empty]
+  rw [← image_inv_eq_inv, image_eq_empty]
 
 @[to_additive (attr := simp)]
 noncomputable instance involutiveInv : InvolutiveInv (Set α) where
@@ -238,7 +238,8 @@ theorem inv_subset_inv : s⁻¹ ⊆ t⁻¹ ↔ s ⊆ t :=
 theorem inv_subset : s⁻¹ ⊆ t ↔ s ⊆ t⁻¹ := by rw [← inv_subset_inv, inv_inv]
 
 @[to_additive (attr := simp)]
-theorem inv_singleton (a : α) : ({a} : Set α)⁻¹ = {a⁻¹} := by rw [← image_inv, image_singleton]
+theorem inv_singleton (a : α) : ({a} : Set α)⁻¹ = {a⁻¹} := by
+  rw [← image_inv_eq_inv, image_singleton]
 
 @[to_additive (attr := simp)]
 theorem inv_insert (a : α) (s : Set α) : (insert a s)⁻¹ = insert a⁻¹ s⁻¹ := by
@@ -246,14 +247,14 @@ theorem inv_insert (a : α) (s : Set α) : (insert a s)⁻¹ = insert a⁻¹ s�
 
 @[to_additive]
 theorem inv_range {ι : Sort*} {f : ι → α} : (range f)⁻¹ = range fun i => (f i)⁻¹ := by
-  rw [← image_inv]
+  rw [← image_inv_eq_inv]
   exact (range_comp ..).symm
 
 open MulOpposite
 
 @[to_additive]
 theorem image_op_inv : op '' s⁻¹ = (op '' s)⁻¹ := by
-  simp_rw [← image_inv, Function.Semiconj.set_image op_inv s]
+  simp_rw [← image_inv_eq_inv, Function.Semiconj.set_image op_inv s]
 
 end InvolutiveInv
 
@@ -1171,13 +1172,13 @@ protected theorem mul_eq_one_iff : s * t = 1 ↔ ∃ a b, s = {a} ∧ t = {b} �
 protected noncomputable def divisionMonoid : DivisionMonoid (Set α) :=
   { Set.monoid, Set.involutiveInv, Set.div, @Set.ZPow α _ _ _ with
     mul_inv_rev := fun s t => by
-      simp_rw [← image_inv]
+      simp_rw [← image_inv_eq_inv]
       exact image_image2_antidistrib mul_inv_rev
     inv_eq_of_mul := fun s t h => by
       obtain ⟨a, b, rfl, rfl, hab⟩ := Set.mul_eq_one_iff.1 h
       rw [inv_singleton, inv_eq_of_mul_eq_one_right hab]
     div_eq_mul_inv := fun s t => by
-      rw [← image_id (s / t), ← image_inv]
+      rw [← image_id (s / t), ← image_inv_eq_inv]
       exact image_image2_distrib_right div_eq_mul_inv }
 
 scoped[Pointwise] attribute [instance] Set.divisionMonoid Set.subtractionMonoid
@@ -1296,6 +1297,11 @@ theorem mul_univ (hs : s.Nonempty) : s * (univ : Set α) = univ :=
 theorem univ_mul (ht : t.Nonempty) : (univ : Set α) * t = univ :=
   let ⟨a, ha⟩ := ht
   eq_univ_of_forall fun b => ⟨b * a⁻¹, trivial, a, ha, inv_mul_cancel_right ..⟩
+
+@[to_additive]
+lemma image_inv [DivisionMonoid β] [FunLike F α β] [MonoidHomClass F α β] (f : F) (s : Set α) :
+    f '' s⁻¹ = (f '' s)⁻¹ := by
+  rw [← image_inv_eq_inv, ← image_inv_eq_inv]; exact image_comm (map_inv _)
 
 end Group
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
@@ -48,11 +48,11 @@ variable [InvolutiveInv G]
 
 @[to_additive (attr := simp)]
 lemma _root_.Cardinal.mk_inv (s : Set G) : #↥(s⁻¹) = #s := by
-  rw [← image_inv, Cardinal.mk_image_eq_of_injOn _ _ inv_injective.injOn]
+  rw [← image_inv_eq_inv, Cardinal.mk_image_eq_of_injOn _ _ inv_injective.injOn]
 
 @[to_additive (attr := simp)]
 lemma natCard_inv (s : Set G) : Nat.card ↥(s⁻¹) = Nat.card s := by
-  rw [← image_inv, Nat.card_image_of_injective inv_injective]
+  rw [← image_inv_eq_inv, Nat.card_image_of_injective inv_injective]
 
 @[to_additive] alias card_inv := natCard_inv
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Finite.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Finite.lean
@@ -112,7 +112,7 @@ section InvolutiveInv
 variable [InvolutiveInv α] {s : Set α}
 
 @[to_additive (attr := simp)] lemma finite_inv : s⁻¹.Finite ↔ s.Finite := by
-  rw [← image_inv, finite_image_iff inv_injective.injOn]
+  rw [← image_inv_eq_inv, finite_image_iff inv_injective.injOn]
 
 @[to_additive (attr := simp)] lemma infinite_inv : s⁻¹.Infinite ↔ s.Infinite := finite_inv.not
 

--- a/Mathlib/Algebra/GroupWithZero/Pointwise/Finset.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pointwise/Finset.lean
@@ -199,11 +199,11 @@ variable [Monoid α] [AddGroup β] [DistribMulAction α β]
 
 @[simp]
 lemma smul_finset_neg (a : α) (t : Finset β) : a • -t = -(a • t) := by
-  simp only [← image_smul, ← image_neg, Function.comp_def, image_image, smul_neg]
+  simp only [← image_smul, ← image_neg_eq_neg, Function.comp_def, image_image, smul_neg]
 
 @[simp]
 protected lemma smul_neg (s : Finset α) (t : Finset β) : s • -t = -(s • t) := by
-  simp_rw [← image_neg]; exact image_image₂_right_comm smul_neg
+  simp_rw [← image_neg_eq_neg]; exact image_image₂_right_comm smul_neg
 
 end Monoid
 end Finset

--- a/Mathlib/Algebra/Order/Group/Pointwise/CompleteLattice.lean
+++ b/Mathlib/Algebra/Order/Group/Pointwise/CompleteLattice.lean
@@ -39,12 +39,12 @@ variable [Group M] [MulLeftMono M] [MulRightMono M]
 
 @[to_additive]
 lemma csSup_inv (hs₀ : s.Nonempty) (hs₁ : BddBelow s) : sSup s⁻¹ = (sInf s)⁻¹ := by
-  rw [← image_inv]
+  rw [← image_inv_eq_inv]
   exact ((OrderIso.inv _).map_csInf' hs₀ hs₁).symm
 
 @[to_additive]
 lemma csInf_inv (hs₀ : s.Nonempty) (hs₁ : BddAbove s) : sInf s⁻¹ = (sSup s)⁻¹ := by
-  rw [← image_inv]
+  rw [← image_inv_eq_inv]
   exact ((OrderIso.inv _).map_csSup' hs₀ hs₁).symm
 
 @[to_additive]
@@ -89,12 +89,12 @@ variable [Group M] [MulLeftMono M] [MulRightMono M]
 
 @[to_additive]
 lemma sSup_inv (s : Set M) : sSup s⁻¹ = (sInf s)⁻¹ := by
-  rw [← image_inv, sSup_image]
+  rw [← image_inv_eq_inv, sSup_image]
   exact ((OrderIso.inv M).map_sInf _).symm
 
 @[to_additive]
 lemma sInf_inv (s : Set M) : sInf s⁻¹ = (sSup s)⁻¹ := by
-  rw [← image_inv, sInf_image]
+  rw [← image_inv_eq_inv, sInf_image]
   exact ((OrderIso.inv M).map_sSup _).symm
 
 @[to_additive]

--- a/Mathlib/Algebra/Ring/Pointwise/Finset.lean
+++ b/Mathlib/Algebra/Ring/Pointwise/Finset.lean
@@ -58,11 +58,11 @@ variable [Ring α] [AddCommGroup β] [Module α β] [DecidableEq β] {s : Finset
 
 @[simp]
 lemma neg_smul_finset : -a • t = -(a • t) := by
-  simp only [← image_smul, ← image_neg, image_image, neg_smul, Function.comp_def]
+  simp only [← image_smul, ← image_neg_eq_neg, image_image, neg_smul, Function.comp_def]
 
 @[simp]
 protected lemma neg_smul [DecidableEq α] : -s • t = -(s • t) := by
-  simp_rw [← image_neg]
+  simp_rw [← image_neg_eq_neg]
   exact image₂_image_left_comm neg_smul
 
 end Ring

--- a/Mathlib/Algebra/Ring/Pointwise/Set.lean
+++ b/Mathlib/Algebra/Ring/Pointwise/Set.lean
@@ -29,8 +29,8 @@ namespace Set
 /-- `Set α` has distributive negation if `α` has. -/
 protected noncomputable def hasDistribNeg [Mul α] [HasDistribNeg α] : HasDistribNeg (Set α) where
   __ := Set.involutiveNeg
-  neg_mul _ _ := by simp_rw [← image_neg]; exact image2_image_left_comm neg_mul
-  mul_neg _ _ := by simp_rw [← image_neg]; exact image_image2_right_comm mul_neg
+  neg_mul _ _ := by simp_rw [← image_neg_eq_neg]; exact image2_image_left_comm neg_mul
+  mul_neg _ _ := by simp_rw [← image_neg_eq_neg]; exact image_image2_right_comm mul_neg
 
 scoped[Pointwise] attribute [instance] Set.hasDistribNeg
 

--- a/Mathlib/Analysis/Convex/Hull.lean
+++ b/Mathlib/Analysis/Convex/Hull.lean
@@ -194,7 +194,7 @@ theorem affineSpan_convexHull (s : Set E) : affineSpan 𝕜 (convexHull 𝕜 s) 
   exact convexHull_subset_affineSpan s
 
 theorem convexHull_neg (s : Set E) : convexHull 𝕜 (-s) = -convexHull 𝕜 s := by
-  simp_rw [← image_neg]
+  simp_rw [← image_neg_eq_neg]
   exact AffineMap.image_convexHull (-1) _ |>.symm
 
 lemma convexHull_vadd (x : E) (s : Set E) : convexHull 𝕜 (x +ᵥ s) = x +ᵥ convexHull 𝕜 s :=

--- a/Mathlib/Analysis/Convex/Star.lean
+++ b/Mathlib/Analysis/Convex/Star.lean
@@ -327,7 +327,7 @@ theorem StarConvex.affine_image (f : E →ᵃ[𝕜] F) {s : Set E} (hs : StarCon
   rw [Convex.combo_affine_apply hab, hy'f]
 
 theorem StarConvex.neg (hs : StarConvex 𝕜 x s) : StarConvex 𝕜 (-x) (-s) := by
-  rw [← image_neg]
+  rw [← image_neg_eq_neg]
   exact hs.is_linear_image IsLinearMap.isLinearMap_neg
 
 theorem StarConvex.sub (hs : StarConvex 𝕜 x s) (ht : StarConvex 𝕜 y t) :

--- a/Mathlib/Analysis/Convex/Topology.lean
+++ b/Mathlib/Analysis/Convex/Topology.lean
@@ -360,7 +360,7 @@ theorem Convex.closure_subset_image_homothety_interior_of_one_lt {s : Set E} (hs
   refine
     ⟨homothety x t⁻¹ y, hs.openSegment_interior_closure_subset_interior hx hy ?_,
       (AffineEquiv.homothetyUnitsMulHom x (Units.mk0 t hne)).apply_symm_apply y⟩
-  rw [openSegment_eq_image_lineMap, ← inv_one, ← inv_Ioi₀ (zero_lt_one' ℝ), ← image_inv,
+  rw [openSegment_eq_image_lineMap, ← inv_one, ← inv_Ioi₀ (zero_lt_one' ℝ), ← image_inv_eq_inv,
     image_image, homothety_eq_lineMap]
   exact mem_image_of_mem _ ht
 

--- a/Mathlib/Analysis/Normed/Group/Pointwise.lean
+++ b/Mathlib/Analysis/Normed/Group/Pointwise.lean
@@ -39,7 +39,7 @@ theorem Bornology.IsBounded.of_mul (hst : IsBounded (s * t)) : IsBounded s ∨ I
 
 @[to_additive]
 theorem Bornology.IsBounded.inv : IsBounded s → IsBounded s⁻¹ := by
-  simp_rw [isBounded_iff_forall_norm_le', ← image_inv, forall_mem_image, norm_inv']
+  simp_rw [isBounded_iff_forall_norm_le', ← image_inv_eq_inv, forall_mem_image, norm_inv']
   exact id
 
 @[to_additive]
@@ -58,7 +58,7 @@ open EMetric
 
 @[to_additive (attr := simp)]
 theorem infEdist_inv_inv (x : E) (s : Set E) : infEdist x⁻¹ s⁻¹ = infEdist x s := by
-  rw [← image_inv, infEdist_image isometry_inv]
+  rw [← image_inv_eq_inv, infEdist_image isometry_inv]
 
 @[to_additive]
 theorem infEdist_inv (x : E) (s : Set E) : infEdist x⁻¹ s = infEdist x s⁻¹ := by

--- a/Mathlib/Analysis/Normed/Group/Quotient.lean
+++ b/Mathlib/Analysis/Normed/Group/Quotient.lean
@@ -150,7 +150,7 @@ theorem quotient_norm_mk_le' (S : AddSubgroup M) (m : M) : ‖(m : M ⧸ S)‖ �
 /-- The norm of the image under the natural morphism to the quotient. -/
 theorem quotient_norm_mk_eq (S : AddSubgroup M) (m : M) :
     ‖mk' S m‖ = sInf ((‖m + ·‖) '' S) := by
-  rw [mk'_apply, norm_mk, sInf_image', ← infDist_image isometry_neg, image_neg,
+  rw [mk'_apply, norm_mk, sInf_image', ← infDist_image isometry_neg, image_neg_eq_neg,
     neg_coe_set (H := S), infDist_eq_iInf]
   simp only [dist_eq_norm', sub_neg_eq_add, add_comm]
 

--- a/Mathlib/Data/Real/Cardinality.lean
+++ b/Mathlib/Data/Real/Cardinality.lean
@@ -252,7 +252,7 @@ theorem mk_Ioo_real {a b : ℝ} (h : a < b) : #(Ioo a b) = 𝔠 := by
   replace h := sub_pos_of_lt h
   have h2 : #(Inv.inv '' Ioo 0 (b - a)) ≤ #(Ioo 0 (b - a)) := mk_image_le
   refine le_trans ?_ h2
-  rw [image_inv, inv_Ioo_0_left h, mk_Ioi_real]
+  rw [image_inv_eq_inv, inv_Ioo_0_left h, mk_Ioi_real]
 
 /-- The cardinality of the interval [a, b). -/
 theorem mk_Ico_real {a b : ℝ} (h : a < b) : #(Ico a b) = 𝔠 :=

--- a/Mathlib/Data/Set/Pointwise/SMul.lean
+++ b/Mathlib/Data/Set/Pointwise/SMul.lean
@@ -521,11 +521,11 @@ variable [Monoid α] [AddGroup β] [DistribMulAction α β] (a : α) (s : Set α
 
 @[simp]
 theorem smul_set_neg : a • -t = -(a • t) := by
-  simp_rw [← image_smul, ← image_neg, image_image, smul_neg]
+  simp_rw [← image_smul, ← image_neg_eq_neg, image_image, smul_neg]
 
 @[simp]
 protected theorem smul_neg : s • -t = -(s • t) := by
-  simp_rw [← image_neg]
+  simp_rw [← image_neg_eq_neg]
   exact image_image2_right_comm smul_neg
 
 end Monoid
@@ -546,11 +546,11 @@ variable [Ring α] [AddCommGroup β] [Module α β] (a : α) (s : Set α) (t : S
 
 @[simp]
 theorem neg_smul_set : -a • t = -(a • t) := by
-  simp_rw [← image_smul, ← image_neg, image_image, neg_smul]
+  simp_rw [← image_smul, ← image_neg_eq_neg, image_image, neg_smul]
 
 @[simp]
 protected theorem neg_smul : -s • t = -(s • t) := by
-  simp_rw [← image_neg]
+  simp_rw [← image_neg_eq_neg]
   exact image2_image_left_comm neg_smul
 
 end Ring

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -419,7 +419,7 @@ theorem MeasurableSet.inv {s : Set G} (hs : MeasurableSet s) : MeasurableSet s�
 @[to_additive]
 theorem measurableEmbedding_inv [InvolutiveInv α] [MeasurableInv α] :
     MeasurableEmbedding (Inv.inv (α := α)) :=
-  ⟨inv_injective, measurable_inv, fun s hs ↦ s.image_inv ▸ hs.inv⟩
+  ⟨inv_injective, measurable_inv, fun s hs ↦ s.image_inv_eq_inv ▸ hs.inv⟩
 
 end Inv
 

--- a/Mathlib/MeasureTheory/Group/Prod.lean
+++ b/Mathlib/MeasureTheory/Group/Prod.lean
@@ -263,9 +263,9 @@ theorem ae_measure_preimage_mul_right_lt_top (hμs : μ' s ≠ ∞) :
   apply ae_lt_top (measurable_measure_mul_right ν' sm)
   have h1 := measure_mul_lintegral_eq μ' ν' sm (A⁻¹.indicator 1) (measurable_one.indicator hA.inv)
   rw [lintegral_indicator hA.inv] at h1
-  simp_rw [Pi.one_apply, setLIntegral_one, ← image_inv, indicator_image inv_injective, image_inv,
-    ← indicator_mul_right _ fun x => ν' ((fun y => y * x) ⁻¹' s), Function.comp, Pi.one_apply,
-    mul_one] at h1
+  simp_rw [Pi.one_apply, setLIntegral_one, ← image_inv_eq_inv, indicator_image inv_injective,
+    image_inv_eq_inv, ← indicator_mul_right _ fun x => ν' ((· * x) ⁻¹' s), Function.comp,
+    Pi.one_apply, mul_one] at h1
   rw [← lintegral_indicator hA, ← h1]
   exact ENNReal.mul_ne_top hμs h3A.ne
 

--- a/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
@@ -116,7 +116,7 @@ theorem parallelepiped_orthonormalBasis_one_dim (b : OrthonormalBasis ι ℝ ℝ
   · right
     simp_rw [H, parallelepiped, Algebra.id.smul_eq_mul, A]
     simp only [F, Finset.univ_unique, Fin.default_eq_zero, mul_neg, mul_one, Finset.sum_neg_distrib,
-      Finset.sum_singleton, ← image_comp, Function.comp, image_neg, neg_Icc, neg_zero]
+      Finset.sum_singleton, ← image_comp, Function.comp, image_neg_eq_neg, neg_Icc, neg_zero]
 
 theorem parallelepiped_eq_sum_segment (v : ι → E) : parallelepiped v = ∑ i, segment ℝ 0 (v i) := by
   ext

--- a/Mathlib/Topology/Algebra/Field.lean
+++ b/Mathlib/Topology/Algebra/Field.lean
@@ -52,7 +52,7 @@ def Subfield.topologicalClosure (K : Subfield α) : Subfield α :=
       rcases eq_or_ne x 0 with (rfl | h)
       · rwa [inv_zero]
       · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: Lean fails to find InvMemClass instance
-        rw [← @inv_coe_set α (Subfield α) _ _ SubfieldClass.toInvMemClass K, ← Set.image_inv]
+        rw [← @inv_coe_set α (Subfield α) _ _ SubfieldClass.toInvMemClass K, ← Set.image_inv_eq_inv]
         exact mem_closure_image (continuousAt_inv₀ h) hx }
 
 theorem Subfield.le_topologicalClosure (s : Subfield α) : s ≤ s.topologicalClosure :=

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -284,7 +284,7 @@ variable [TopologicalSpace G] [InvolutiveInv G] [ContinuousInv G] {s : Set G}
 
 @[to_additive]
 theorem IsCompact.inv (hs : IsCompact s) : IsCompact s⁻¹ := by
-  rw [← image_inv]
+  rw [← image_inv_eq_inv]
   exact hs.image continuous_inv
 
 variable (G)


### PR DESCRIPTION
This is to make space for `f '' s⁻¹ = (f '' s)⁻¹`. Also rename `smul_card_le` to `card_smul_le`.

From LeanCamCombi

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
