### PR TITLE
[Merged by Bors] - feat(Probability): identity, copy, discard and swap kernels

### DIFF
--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -149,7 +149,7 @@ def swap (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] : Kernel (α 
 
 instance : IsMarkovKernel (swap α β) := by rw [swap]; infer_instance
 
-/-- See `swap_apply` for a fully applied version of this lemma. -/
+/-- See `swap_apply'` for a fully applied version of this lemma. -/
 lemma swap_apply (ab : α × β) : swap α β ab = Measure.dirac ab.swap := by
   rw [swap, deterministic_apply]
 

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -15,6 +15,13 @@ kernels.
 
 * `ProbabilityTheory.Kernel.deterministic (f : α → β) (hf : Measurable f)`:
   kernel `a ↦ Measure.dirac (f a)`.
+* `ProbabilityTheory.Kernel.id`: the identity kernel, deterministic kernel for
+  the identity function.
+* `ProbabilityTheory.Kernel.copy α`: the deterministic kernel that maps `x : α` to
+  the Dirac measure at `(x, x) : α × α`.
+* `ProbabilityTheory.Kernel.discard α`: the Markov kernel to the type `Unit`.
+* `ProbabilityTheory.Kernel.swap α β`: the deterministic kernel that maps `(x, y)` to
+  the Dirac measure at `(y, x)`.
 * `ProbabilityTheory.Kernel.const α (μβ : measure β)`: constant kernel `a ↦ μβ`.
 * `ProbabilityTheory.Kernel.restrict κ (hs : MeasurableSet s)`: kernel for which the image of
   `a : α` is `(κ a).restrict s`.
@@ -92,6 +99,66 @@ theorem setLIntegral_deterministic {f : β → ℝ≥0∞} {g : α → β} {a : 
 alias set_lintegral_deterministic := setLIntegral_deterministic
 
 end Deterministic
+
+section Id
+
+/-- The identity kernel, that maps `x : α` to the Dirac measure at `x`. -/
+protected noncomputable
+def id : Kernel α α := Kernel.deterministic id measurable_id
+
+instance : IsMarkovKernel (Kernel.id : Kernel α α) := by rw [Kernel.id]; infer_instance
+
+lemma id_apply (a : α) : Kernel.id a = Measure.dirac a := by
+  rw [Kernel.id, deterministic_apply, id_def]
+
+end Id
+
+section Copy
+
+/-- The deterministic kernel that maps `x : α` to the Dirac measure at `(x, x) : α × α`. -/
+noncomputable
+def copy (α : Type*) [MeasurableSpace α] : Kernel α (α × α) :=
+  Kernel.deterministic (fun x ↦ (x, x)) (measurable_id.prod measurable_id)
+
+instance : IsMarkovKernel (copy α) := by rw [copy]; infer_instance
+
+lemma copy_apply (a : α) : copy α a = Measure.dirac (a, a) := by simp [copy, deterministic_apply]
+
+end Copy
+
+section Discard
+
+/-- The Markov kernel to the `Unit` type. -/
+noncomputable
+def discard (α : Type*) [MeasurableSpace α] : Kernel α Unit :=
+  Kernel.deterministic (fun _ ↦ ()) measurable_const
+
+instance : IsMarkovKernel (discard α) := by rw [discard]; infer_instance
+
+@[simp]
+lemma discard_apply (a : α) : discard α a = Measure.dirac () := deterministic_apply _ _
+
+end Discard
+
+section Swap
+
+/-- The deterministic kernel that maps `(x, y)` to the Dirac measure at `(y, x)`. -/
+noncomputable
+def swap (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] : Kernel (α × β) (β × α) :=
+  Kernel.deterministic Prod.swap measurable_swap
+
+instance : IsMarkovKernel (swap α β) := by rw [swap]; infer_instance
+
+/-- See `swap_apply` for a fully applied version of this lemma. -/
+lemma swap_apply (ab : α × β) : swap α β ab = Measure.dirac ab.swap := by
+  rw [swap, deterministic_apply]
+
+/-- See `swap_apply` for a partially applied version of this lemma. -/
+lemma swap_apply' (ab : α × β) {s : Set (β × α)} (hs : MeasurableSet s) :
+    swap α β ab s = s.indicator 1 ab.swap := by
+  rw [swap_apply, Measure.dirac_apply' _ hs]
+
+end Swap
 
 section Const
 

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -1124,6 +1124,32 @@ lemma deterministic_comp_deterministic (hf : Measurable f) (hg : Measurable g) :
     (deterministic g hg) ∘ₖ (deterministic f hf) = deterministic (g ∘ f) (hg.comp hf) := by
   ext; simp [comp_deterministic_eq_comap, comap_apply, deterministic_apply]
 
+@[simp]
+lemma comp_id (κ : Kernel α β) : κ ∘ₖ Kernel.id = κ := by
+  rw [Kernel.id, comp_deterministic_eq_comap, comap_id]
+
+@[simp]
+lemma id_comp (κ : Kernel α β) : Kernel.id ∘ₖ κ = κ := by
+  rw [Kernel.id, deterministic_comp_eq_map, map_id]
+
+@[simp]
+lemma comp_discard (κ : Kernel α β) [IsMarkovKernel κ] : discard β ∘ₖ κ = discard α := by
+  ext a s hs; simp [comp_apply' _ _ _ hs]
+
+@[simp]
+lemma swap_copy : (swap α α) ∘ₖ (copy α) = copy α := by
+  ext a s hs
+  rw [comp_apply, copy_apply, Measure.dirac_bind (Kernel.measurable _), swap_apply' _ hs,
+    Measure.dirac_apply' _ hs]
+  congr
+
+@[simp]
+lemma swap_swap : (swap α β) ∘ₖ (swap β α) = Kernel.id := by
+  simp_rw [swap, Kernel.deterministic_comp_deterministic, Prod.swap_swap_eq, Kernel.id]
+
+lemma swap_comp_eq_map {κ : Kernel α (β × γ)} : (swap β γ) ∘ₖ κ = κ.map Prod.swap := by
+  rw [swap, deterministic_comp_eq_map]
+
 lemma const_comp (μ : Measure γ) (κ : Kernel α β) :
     const β μ ∘ₖ κ = fun a ↦ (κ a) Set.univ • μ := by
   ext _ _ hs
@@ -1241,11 +1267,28 @@ lemma map_prod_swap (κ : Kernel α β) (η : Kernel α γ) [IsSFiniteKernel κ]
   refine (lintegral_lintegral_swap ?_).symm
   exact hf.aemeasurable
 
+@[simp]
+lemma swap_prod {κ : Kernel α β} [IsSFiniteKernel κ] {η : Kernel α γ} [IsSFiniteKernel η] :
+    (swap β γ) ∘ₖ (κ ×ₖ η) = (η ×ₖ κ) := by
+  rw [swap_comp_eq_map, map_prod_swap]
+
 lemma deterministic_prod_deterministic {f : α → β} {g : α → γ}
     (hf : Measurable f) (hg : Measurable g) :
     deterministic f hf ×ₖ deterministic g hg
       = deterministic (fun a ↦ (f a, g a)) (hf.prod_mk hg) := by
   ext; simp_rw [prod_apply, deterministic_apply, Measure.dirac_prod_dirac]
+
+lemma compProd_prodMkLeft_eq_comp
+    (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel β γ) [IsSFiniteKernel η] :
+    κ ⊗ₖ (prodMkLeft α η) = (Kernel.id ×ₖ η) ∘ₖ κ := by
+  ext a s hs
+  rw [comp_eq_snd_compProd, compProd_apply hs, snd_apply' _ _ hs, compProd_apply]
+  swap; · exact measurable_snd hs
+  simp only [prodMkLeft_apply, Set.mem_setOf_eq, Set.setOf_mem_eq, prod_apply' _ _ _ hs,
+    id_apply, id_eq]
+  congr with b
+  rw [lintegral_dirac']
+  exact measurable_measure_prod_mk_left hs
 
 end Prod
 end Kernel


### PR DESCRIPTION
Add some notable deterministic kernels. These kernels play a particular role in the Markov category point of view on probability transition kernels.

From the TestingLowerBounds project.
Co-authored-by: Lorenzo Luccioli

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
