### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Enriched/Opposite): the opposite category of an enriched category

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1670,6 +1670,7 @@ import Mathlib.CategoryTheory.Endofunctor.Algebra
 import Mathlib.CategoryTheory.Endomorphism
 import Mathlib.CategoryTheory.Enriched.Basic
 import Mathlib.CategoryTheory.Enriched.FunctorCategory
+import Mathlib.CategoryTheory.Enriched.Opposite
 import Mathlib.CategoryTheory.Enriched.Ordinary
 import Mathlib.CategoryTheory.EpiMono
 import Mathlib.CategoryTheory.EqToHom

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2024 Daniel Carranza. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Daniel Carranza
+-/
+import Mathlib.CategoryTheory.Closed.Enrichment
+
+/-!
+
+# The opposite category of an enriched category
+
+When a monoidal category `V` is braided, we may define the opposite `V`-category of a
+`V`-cagtegory. The symmetry map is required to define the composition morphism.
+
+-/
+
+universe v₁ u₁ v u
+
+namespace CategoryTheory
+
+open BraidedCategory
+
+/-- The underlying type of the enriched opposite category.
+
+This takes `V` as an argument so that, if `C` is enriched over multiple categories,
+the instances of the underlying categories on `ForgetEnrichment C` do not coincide -/
+@[nolint unusedArguments]
+structure eOpposite (V : Type u₁) (C : Type u) where
+  as : C
+
+namespace eOpposite
+
+def op {V : Type u₁} {C : Type u} (x : C) : eOpposite V C := ⟨x⟩
+
+def unop {V : Type u₁} {C : Type u} (x : eOpposite V C) : C := x.as
+
+@[simp]
+theorem op_of_unop (V : Type u₁) {C : Type u} (x : eOpposite V C) : op (unop x) = x := rfl
+
+@[simp]
+theorem unop_of_op (V : Type u₁) {C : Type u} (x : C) :  unop (V := V) (op x) = x := rfl
+
+/-- The type-level equivalence between a type and its enriched opposite. -/
+def equivToEnrichedOpposite (V : Type u₁) (C : Type u) : C ≃ eOpposite V C where
+  toFun := op
+  invFun := unop
+  left_inv := by aesop_cat
+  right_inv := by aesop_cat
+
+variable (V : Type u₁) [Category.{v₁} V] [MonoidalCategory V] [BraidedCategory V]
+variable (C : Type u) [EnrichedCategory V C]
+
+/-- The enriched category structure on `eOpposite V C` -/
+instance EnrichedCategory.opposite : EnrichedCategory V (eOpposite V C) where
+  Hom y x := EnrichedCategory.Hom x.unop y.unop
+  id x := EnrichedCategory.id x.unop
+  comp z y x := (β_ _ _).hom ≫ EnrichedCategory.comp (x.unop) (y.unop) (z.unop)
+  id_comp _ _ := by
+    simp only [braiding_naturality_left_assoc, braiding_tensorUnit_left,
+      Category.assoc, Iso.inv_hom_id_assoc]
+    exact EnrichedCategory.comp_id _ _
+  comp_id _ _ := by
+    simp only [braiding_naturality_right_assoc, braiding_tensorUnit_right,
+      Category.assoc, Iso.inv_hom_id_assoc]
+    exact EnrichedCategory.id_comp _ _
+  assoc _ _ _ _ := by
+    simp only [braiding_naturality_left_assoc,
+      MonoidalCategory.whiskerLeft_comp, Category.assoc]
+    rw [← EnrichedCategory.assoc]
+    simp only [braiding_tensor_left, Category.assoc, Iso.inv_hom_id_assoc,
+      braiding_naturality_right_assoc, braiding_tensor_right]
+
+end eOpposite
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -80,8 +80,8 @@ open ForgetEnrichment
 
 variable (C : Type u) [EnrichedCategory V C]
 
-/-- The functor going from the underlying category of `Cᵒᵖ` to the opposite of the underlying
-category of `C`. -/
+/-- The functor going from the underlying category of the enriched category `Cᵒᵖ`
+to the opposite of the underlying category of the enriched category `C`. -/
 def forgetEnrichmentOppositeEquivalence.functor :
     ForgetEnrichment V Cᵒᵖ ⥤ (ForgetEnrichment V C)ᵒᵖ where
   obj x := x
@@ -92,8 +92,8 @@ def forgetEnrichmentOppositeEquivalence.functor :
       leftUnitor_inv_braiding_assoc, ← unitors_inv_equal, ← Category.assoc]
     congr 1
 
-/-- The functor going from the opposite of the underlying category of `C` to the underlying
-category of `Cᵒᵖ`. -/
+/-- The functor going from the opposite of the underlying category of the enriched category `C`
+to the underlying category of the enriched category `Cᵒᵖ`. -/
 def forgetEnrichmentOppositeEquivalence.inverse :
     (ForgetEnrichment V C)ᵒᵖ ⥤ ForgetEnrichment V Cᵒᵖ where
   obj x := x

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -141,8 +141,7 @@ def ForgetEnrichment.Opposite.fromToNatIso :
 /-- The equivalence between the underlying category of `Cᵒᵖ` and the opposite of the underlying
 category of `C`. -/
 @[simps]
-def forgetEnrichmentOppositeEquivalence :
-    ForgetEnrichment V Cᵒᵖ ≌ (ForgetEnrichment V C)ᵒᵖ where
+def forgetEnrichmentOppositeEquivalence : ForgetEnrichment V Cᵒᵖ ≌ (ForgetEnrichment V C)ᵒᵖ where
   functor := ForgetEnrichment.Opposite.toOp V C
   inverse := ForgetEnrichment.Opposite.fromOp V C
   unitIso := NatIso.ofComponents (fun _ ↦ Iso.refl _)

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -148,7 +148,6 @@ def ForgetEnrichment.Opposite.equiv : ForgetEnrichment V Cᵒᵖ ≌ (ForgetEnri
 /-- If `D` is an enriched ordinary category then `Dᵒᵖ` is an enriched ordinary category. -/
 instance EnrichedOrdinaryCategory.Opposite {D : Type u} [Category.{v} D]
     [EnrichedOrdinaryCategory V D] : EnrichedOrdinaryCategory V Dᵒᵖ where
-  toEnrichedCategory := inferInstanceAs (EnrichedCategory V Dᵒᵖ)
   homEquiv := Quiver.Hom.opEquiv.symm.trans homEquiv
   homEquiv_id x := homEquiv_id (x.unop)
   homEquiv_comp f g := by

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -79,11 +79,14 @@ lemma tensorHom_eComp_op_eq {C : Type u} [EnrichedCategory V C] {x y z : Cᵒᵖ
 -- This section establishes the equivalence on underlying categories
 section
 
+open ForgetEnrichment
+
 variable (C : Type u) [EnrichedCategory V C]
 
 /-- The functor going from the underlying category of `Cᵒᵖ` to the opposite of the underlying
 category of `C`. -/
-def ForgetEnrichment.Opposite.toOp : ForgetEnrichment V Cᵒᵖ ⥤ (ForgetEnrichment V C)ᵒᵖ where
+def forgetEnrichmentOppositeEquivalence.functor :
+    ForgetEnrichment V Cᵒᵖ ⥤ (ForgetEnrichment V C)ᵒᵖ where
   obj x := x
   map {x y} f := f.op
   map_comp {x y z} f g := by
@@ -94,7 +97,8 @@ def ForgetEnrichment.Opposite.toOp : ForgetEnrichment V Cᵒᵖ ⥤ (ForgetEnric
 
 /-- The functor going from the opposite of the underlying category of `C` to the underlying
 category of `Cᵒᵖ`. -/
-def ForgetEnrichment.Opposite.fromOp : (ForgetEnrichment V C)ᵒᵖ ⥤ ForgetEnrichment V Cᵒᵖ where
+def forgetEnrichmentOppositeEquivalence.inverse :
+    (ForgetEnrichment V C)ᵒᵖ ⥤ ForgetEnrichment V Cᵒᵖ where
   obj x := x
   map {x y} f := f.unop
   map_comp {x y z} f g := by
@@ -113,8 +117,8 @@ def ForgetEnrichment.Opposite.fromOp : (ForgetEnrichment V C)ᵒᵖ ⥤ ForgetEn
 category of `C`. -/
 @[simps]
 def forgetEnrichmentOppositeEquivalence : ForgetEnrichment V Cᵒᵖ ≌ (ForgetEnrichment V C)ᵒᵖ where
-  functor := ForgetEnrichment.Opposite.toOp V C
-  inverse := ForgetEnrichment.Opposite.fromOp V C
+  functor := forgetEnrichmentOppositeEquivalence.functor V C
+  inverse := forgetEnrichmentOppositeEquivalence.inverse V C
   unitIso := NatIso.ofComponents (fun _ ↦ Iso.refl _)
   counitIso := NatIso.ofComponents (fun _ ↦ Iso.refl _)
 

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -144,7 +144,7 @@ def ForgetEnrichment.Opposite.equiv : ForgetEnrichment V Cᵒᵖ ≌ (ForgetEnri
   Equivalence.mk (toOp V C) (fromOp V C) (toFromNatIso V C) (fromToNatIso V C)
 
 /-- If `D` is an enriched ordinary category then `Dᵒᵖ` is an enriched ordinary category. -/
-instance EnrichedOrdinaryCategory.Opposite {D : Type u} [Category.{v} D]
+instance EnrichedOrdinaryCategory.opposite {D : Type u} [Category.{v} D]
     [EnrichedOrdinaryCategory V D] : EnrichedOrdinaryCategory V Dᵒᵖ where
   homEquiv := Quiver.Hom.opEquiv.symm.trans homEquiv
   homEquiv_id x := homEquiv_id (x.unop)

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -107,9 +107,8 @@ def forgetEnrichmentOppositeEquivalence.inverse :
     rw [this, forgetEnrichment_comp, Category.assoc, unitors_inv_equal,
       ← leftUnitor_inv_braiding_assoc]
     have : (β_ _ _).hom ≫ (homTo V g.unop ⊗ homTo V f.unop) ≫
-        eComp V («to» V z.unop) («to» V y.unop) («to» V x.unop) =
-        ((homTo V f.unop) ⊗ (homTo V g.unop)) ≫ eComp V x y z :=
-      by exact (tensorHom_eComp_op_eq V _ _).symm
+      eComp V («to» V z.unop) («to» V y.unop) («to» V x.unop) =
+      ((homTo V f.unop) ⊗ (homTo V g.unop)) ≫ eComp V x y z := (tensorHom_eComp_op_eq V _ _).symm
     rw [this, ← Category.assoc]
     congr 1
 

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -21,9 +21,6 @@ We also show that if `C` is an enriched ordinary category (i.e. a category enric
 equipped with an identification `(X ⟶ Y) ≃ (𝟙_ V ⟶ (X ⟶[V] Y))`) then `Cᵒᵖ` is again
 an enriched ordinary category.
 
-We use `Cᵒᵖ` for the underlying type as this allows us to construct the instance of
-`EnrichedOrdinaryCategory V (Cᵒᵖ)` which extends the opposite `V`-category structure.
-
 -/
 
 universe v₁ u₁ v u

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -3,7 +3,8 @@ Copyright (c) 2024 Daniel Carranza. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Daniel Carranza
 -/
-import Mathlib.CategoryTheory.Closed.Enrichment
+import Mathlib.CategoryTheory.Enriched.Ordinary
+import Mathlib.CategoryTheory.Monoidal.Braided.Basic
 
 /-!
 
@@ -12,46 +13,30 @@ import Mathlib.CategoryTheory.Closed.Enrichment
 When a monoidal category `V` is braided, we may define the opposite `V`-category of a
 `V`-cagtegory. The symmetry map is required to define the composition morphism.
 
+This file constructs the opposite `V`-category as an instance on the type `Cᵒᵖ` and constructs an
+equivalence between the underlying category `ForgetEnrichment V (Cᵒᵖ)` and the opposite category
+`(ForgetEnrichment V C)ᵒᵖ`.
+
+We use `Cᵒᵖ` for the underlying type as this allows us to construct an instance of
+`EnrichedOrdinaryCategory V Cᵒᵖ` in the case that `C` comes with an instance of
+`EnrichedOrdinaryCategory V C`.
+
 -/
 
 universe v₁ u₁ v u
 
 namespace CategoryTheory
 
-open BraidedCategory
-
-/-- The underlying type of the enriched opposite category.
-
-This takes `V` as an argument so that, if `C` is enriched over multiple categories,
-the instances of the underlying categories on `ForgetEnrichment C` do not coincide -/
-@[nolint unusedArguments]
-structure eOpposite (V : Type u₁) (C : Type u) where
-  as : C
-
-namespace eOpposite
-
-def op {V : Type u₁} {C : Type u} (x : C) : eOpposite V C := ⟨x⟩
-
-def unop {V : Type u₁} {C : Type u} (x : eOpposite V C) : C := x.as
-
-@[simp]
-theorem op_of_unop (V : Type u₁) {C : Type u} (x : eOpposite V C) : op (unop x) = x := rfl
-
-@[simp]
-theorem unop_of_op (V : Type u₁) {C : Type u} (x : C) :  unop (V := V) (op x) = x := rfl
-
-/-- The type-level equivalence between a type and its enriched opposite. -/
-def equivToEnrichedOpposite (V : Type u₁) (C : Type u) : C ≃ eOpposite V C where
-  toFun := op
-  invFun := unop
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+open MonoidalCategory BraidedCategory
 
 variable (V : Type u₁) [Category.{v₁} V] [MonoidalCategory V] [BraidedCategory V]
+
+section
+
 variable (C : Type u) [EnrichedCategory V C]
 
-/-- The enriched category structure on `eOpposite V C` -/
-instance EnrichedCategory.opposite : EnrichedCategory V (eOpposite V C) where
+/-- The enriched category structure on `eOpposite V C`. -/
+instance EnrichedCategory.opposite : EnrichedCategory V Cᵒᵖ where
   Hom y x := EnrichedCategory.Hom x.unop y.unop
   id x := EnrichedCategory.id x.unop
   comp z y x := (β_ _ _).hom ≫ EnrichedCategory.comp (x.unop) (y.unop) (z.unop)
@@ -70,6 +55,108 @@ instance EnrichedCategory.opposite : EnrichedCategory V (eOpposite V C) where
     simp only [braiding_tensor_left, Category.assoc, Iso.inv_hom_id_assoc,
       braiding_naturality_right_assoc, braiding_tensor_right]
 
-end eOpposite
+end
+
+/-- Unfold the definition of composition in the enriched opposite category. -/
+@[reassoc]
+lemma eComp_op_eq {C : Type u} [EnrichedCategory V C] (x y z : Cᵒᵖ) :
+    eComp V z y x = (β_ _ _).hom ≫ eComp V x.unop y.unop z.unop :=
+  rfl
+
+/-- When composing a tensor product of morphisms with the `V`-composition morphism in `Cᵒᵖ`,
+this re-writes the `V`-composition to be in `C` and moves the braiding to the left. -/
+@[reassoc]
+lemma tensorHom_eComp_op_eq {C : Type u} [EnrichedCategory V C] {x y z : Cᵒᵖ} {v w : V}
+    (f : v ⟶ EnrichedCategory.Hom z y) (g : w ⟶ EnrichedCategory.Hom y x) :
+    (f ⊗ g) ≫ eComp V z y x = (β_ v w).hom ≫ (g ⊗ f) ≫ eComp V x.unop y.unop z.unop := by
+  rw [eComp_op_eq]
+  exact braiding_naturality_assoc (C := V) f g _
+
+
+-- In this section, we establish an equivalence between
+--  • the underlying category of the `V`-category `Cᵒᵖ`; and
+--  • the opposite category of the underlying category of `C`.
+-- We also show that if `C` is an enriched ordinary category (i.e. a category enriched in `V`
+-- equipped with an identification `(X ⟶ Y) ≃ (𝟙_ V ⟶ (X ⟶[V] Y))`) then `Cᵒᵖ` is again
+-- an enriched ordinary category.
+section
+
+variable (C : Type u) [EnrichedCategory V C]
+
+/-- The functor going from the underlying category of `Cᵒᵖ` to the opposite of the underlying
+category of `C`. -/
+def ForgetEnrichment.opposite.toOp :
+    ForgetEnrichment V Cᵒᵖ ⥤ (ForgetEnrichment V C)ᵒᵖ where
+  obj x := x
+  map {x y} f := f.op
+  map_comp {x y z} f g := by
+    have : (f ≫ g) = homTo V (f ≫ g) := rfl
+    rw [this, forgetEnrichment_comp, Category.assoc, tensorHom_eComp_op_eq,
+      leftUnitor_inv_braiding_assoc, ← unitors_inv_equal, ← Category.assoc]
+    congr 1
+
+/-- The functor going from the opposite of the underlying category of `C` to the underlying
+category of `Cᵒᵖ`. -/
+def ForgetEnrichment.opposite.fromOp :
+    (ForgetEnrichment V C)ᵒᵖ ⥤ ForgetEnrichment V Cᵒᵖ where
+  obj x := x
+  map {x y} f := f.unop
+  map_comp {x y z} f g := by
+    have : g.unop ≫ f.unop = homTo V (g.unop ≫ f.unop) := rfl
+    dsimp
+    rw [this, forgetEnrichment_comp, Category.assoc, unitors_inv_equal,
+      ← leftUnitor_inv_braiding_assoc]
+    have : (β_ _ _).hom ≫ (homTo V g.unop ⊗ homTo V f.unop) ≫
+        eComp V («to» V (Opposite.unop z)) («to» V (Opposite.unop y)) («to» V (Opposite.unop x)) =
+        ((homTo V f.unop) ⊗ (homTo V g.unop)) ≫ eComp V x y z :=
+      by exact (tensorHom_eComp_op_eq V _ _).symm
+    rw [this, ← Category.assoc]
+    congr 1
+
+/-- The identity functor on `ForgetEnrichment V (Cᵒᵖ)` is naturally isomorphic to the composite
+functor from `ForgetEnrichment V (Cᵒᵖ)` to `(ForgetEnrichment V C)ᵒᵖ` and
+back to `ForgetEnrichment V (Cᵒᵖ)`. -/
+def ForgetEnrichment.opposite.toFromNatIso :
+    𝟭 (ForgetEnrichment V Cᵒᵖ) ≅ toOp V C ⋙ fromOp V C where
+  hom := {app := 𝟙}
+  inv := {
+    app := 𝟙
+    naturality := fun ⦃X Y⦄ f => by
+      dsimp
+      have :  𝟙 ((fromOp V C).obj ((toOp V C).obj Y)) = 𝟙 Y := rfl
+      rw [← this, Category.comp_id, Category.id_comp f]
+      congr 1
+  }
+
+/-- The composite functor from `(ForgetEnrichment V C)ᵒᵖ` to `ForgetEnrichment V (Cᵒᵖ)` and
+back to `(ForgetEnrichment V C)ᵒᵖ` is naturally isomorphic to the identity functor. -/
+def ForgetEnrichment.opposite.fromToNatIso :
+    fromOp V C ⋙ toOp V C ≅ 𝟭 (ForgetEnrichment V C)ᵒᵖ where
+  hom := {
+    app := 𝟙
+    naturality := fun ⦃X Y⦄ f => by
+      dsimp
+      have :  𝟙 ((toOp V C).obj ((fromOp V C).obj Y)) = 𝟙 Y := rfl
+      rw [← this, Category.comp_id, Category.id_comp f]
+      congr 1
+  }
+  inv := {app := 𝟙}
+
+/-- The equivalence between the underlying category of `Cᵒᵖ` and the opposite of the underlying
+category of `C`. -/
+def ForgetEnrichment.opposite.equiv : ForgetEnrichment V Cᵒᵖ ≌ (ForgetEnrichment V C)ᵒᵖ :=
+  Equivalence.mk (toOp V C) (fromOp V C) (toFromNatIso V C) (fromToNatIso V C)
+
+/-- If `D` is an enriched ordinary category then `Dᵒᵖ` is an enriched ordinary category. -/
+instance EnrichedOrdinaryCategory.opposite {D : Type u} [Category.{v} D]
+    [EnrichedOrdinaryCategory V D] : EnrichedOrdinaryCategory V Dᵒᵖ where
+  toEnrichedCategory := inferInstanceAs (EnrichedCategory V Dᵒᵖ)
+  homEquiv := Quiver.Hom.opEquiv.symm.trans homEquiv
+  homEquiv_id x := homEquiv_id (x.unop)
+  homEquiv_comp f g := by
+    simp only [unop_comp, tensorHom_eComp_op_eq, leftUnitor_inv_braiding_assoc, ← unitors_inv_equal]
+    exact homEquiv_comp g.unop f.unop
+
+end
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -109,35 +109,6 @@ def ForgetEnrichment.Opposite.fromOp : (ForgetEnrichment V C)ᵒᵖ ⥤ ForgetEn
     rw [this, ← Category.assoc]
     congr 1
 
-/-- The identity functor on `ForgetEnrichment V (Cᵒᵖ)` is naturally isomorphic to the composite
-functor from `ForgetEnrichment V (Cᵒᵖ)` to `(ForgetEnrichment V C)ᵒᵖ` and
-back to `ForgetEnrichment V (Cᵒᵖ)`. -/
-def ForgetEnrichment.Opposite.toFromNatIso :
-    𝟭 (ForgetEnrichment V Cᵒᵖ) ≅ toOp V C ⋙ fromOp V C where
-  hom := {app := 𝟙}
-  inv := {
-    app := 𝟙
-    naturality := fun ⦃X Y⦄ f => by
-      dsimp
-      have :  𝟙 ((fromOp V C).obj ((toOp V C).obj Y)) = 𝟙 Y := rfl
-      rw [← this, Category.comp_id, Category.id_comp f]
-      congr 1
-  }
-
-/-- The composite functor from `(ForgetEnrichment V C)ᵒᵖ` to `ForgetEnrichment V (Cᵒᵖ)` and
-back to `(ForgetEnrichment V C)ᵒᵖ` is naturally isomorphic to the identity functor. -/
-def ForgetEnrichment.Opposite.fromToNatIso :
-    fromOp V C ⋙ toOp V C ≅ 𝟭 (ForgetEnrichment V C)ᵒᵖ where
-  hom := {
-    app := 𝟙
-    naturality := fun ⦃X Y⦄ f => by
-      dsimp
-      have :  𝟙 ((toOp V C).obj ((fromOp V C).obj Y)) = 𝟙 Y := rfl
-      rw [← this, Category.comp_id, Category.id_comp f]
-      congr 1
-  }
-  inv := {app := 𝟙}
-
 /-- The equivalence between the underlying category of `Cᵒᵖ` and the opposite of the underlying
 category of `C`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -74,7 +74,7 @@ lemma tensorHom_eComp_op_eq {C : Type u} [EnrichedCategory V C] {x y z : Cᵒᵖ
     (f : v ⟶ EnrichedCategory.Hom z y) (g : w ⟶ EnrichedCategory.Hom y x) :
     (f ⊗ g) ≫ eComp V z y x = (β_ v w).hom ≫ (g ⊗ f) ≫ eComp V x.unop y.unop z.unop := by
   rw [eComp_op_eq]
-  exact braiding_naturality_assoc (C := V) f g _
+  exact braiding_naturality_assoc f g _
 
 -- This section establishes the equivalence on underlying categories
 section

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -11,14 +11,14 @@ import Mathlib.CategoryTheory.Monoidal.Braided.Basic
 # The opposite category of an enriched category
 
 When a monoidal category `V` is braided, we may define the opposite `V`-category of a
-`V`-cagtegory. The symmetry map is required to define the composition morphism.
+`V`-category. The symmetry map is required to define the composition morphism.
 
 This file constructs the opposite `V`-category as an instance on the type `Cᵒᵖ` and constructs an
 equivalence between the underlying category `ForgetEnrichment V (Cᵒᵖ)` and the opposite category
 `(ForgetEnrichment V C)ᵒᵖ`.
 
 We use `Cᵒᵖ` for the underlying type as this allows us to construct an instance of
-`EnrichedOrdinaryCategory V Cᵒᵖ` in the case that `C` comes with an instance of
+`EnrichedOrdinaryCategory V (Cᵒᵖ)` in the case that `C` comes with an instance of
 `EnrichedOrdinaryCategory V C`.
 
 -/
@@ -35,8 +35,9 @@ section
 
 variable (C : Type u) [EnrichedCategory V C]
 
-/-- The enriched category structure on `eOpposite V C`. -/
-instance EnrichedCategory.opposite : EnrichedCategory V Cᵒᵖ where
+/-- For a `V`-category `C`, construct the opposite `V`-category structure on the type `Cᵒᵖ`
+using the braiding in `V`. -/
+instance EnrichedCategory.Opposite : EnrichedCategory V Cᵒᵖ where
   Hom y x := EnrichedCategory.Hom x.unop y.unop
   id x := EnrichedCategory.id x.unop
   comp z y x := (β_ _ _).hom ≫ EnrichedCategory.comp (x.unop) (y.unop) (z.unop)
@@ -72,7 +73,6 @@ lemma tensorHom_eComp_op_eq {C : Type u} [EnrichedCategory V C] {x y z : Cᵒᵖ
   rw [eComp_op_eq]
   exact braiding_naturality_assoc (C := V) f g _
 
-
 -- In this section, we establish an equivalence between
 --  • the underlying category of the `V`-category `Cᵒᵖ`; and
 --  • the opposite category of the underlying category of `C`.
@@ -85,8 +85,7 @@ variable (C : Type u) [EnrichedCategory V C]
 
 /-- The functor going from the underlying category of `Cᵒᵖ` to the opposite of the underlying
 category of `C`. -/
-def ForgetEnrichment.opposite.toOp :
-    ForgetEnrichment V Cᵒᵖ ⥤ (ForgetEnrichment V C)ᵒᵖ where
+def ForgetEnrichment.Opposite.toOp : ForgetEnrichment V Cᵒᵖ ⥤ (ForgetEnrichment V C)ᵒᵖ where
   obj x := x
   map {x y} f := f.op
   map_comp {x y z} f g := by
@@ -97,8 +96,7 @@ def ForgetEnrichment.opposite.toOp :
 
 /-- The functor going from the opposite of the underlying category of `C` to the underlying
 category of `Cᵒᵖ`. -/
-def ForgetEnrichment.opposite.fromOp :
-    (ForgetEnrichment V C)ᵒᵖ ⥤ ForgetEnrichment V Cᵒᵖ where
+def ForgetEnrichment.Opposite.fromOp : (ForgetEnrichment V C)ᵒᵖ ⥤ ForgetEnrichment V Cᵒᵖ where
   obj x := x
   map {x y} f := f.unop
   map_comp {x y z} f g := by
@@ -107,7 +105,7 @@ def ForgetEnrichment.opposite.fromOp :
     rw [this, forgetEnrichment_comp, Category.assoc, unitors_inv_equal,
       ← leftUnitor_inv_braiding_assoc]
     have : (β_ _ _).hom ≫ (homTo V g.unop ⊗ homTo V f.unop) ≫
-        eComp V («to» V (Opposite.unop z)) («to» V (Opposite.unop y)) («to» V (Opposite.unop x)) =
+        eComp V («to» V z.unop) («to» V y.unop) («to» V x.unop) =
         ((homTo V f.unop) ⊗ (homTo V g.unop)) ≫ eComp V x y z :=
       by exact (tensorHom_eComp_op_eq V _ _).symm
     rw [this, ← Category.assoc]
@@ -116,7 +114,7 @@ def ForgetEnrichment.opposite.fromOp :
 /-- The identity functor on `ForgetEnrichment V (Cᵒᵖ)` is naturally isomorphic to the composite
 functor from `ForgetEnrichment V (Cᵒᵖ)` to `(ForgetEnrichment V C)ᵒᵖ` and
 back to `ForgetEnrichment V (Cᵒᵖ)`. -/
-def ForgetEnrichment.opposite.toFromNatIso :
+def ForgetEnrichment.Opposite.toFromNatIso :
     𝟭 (ForgetEnrichment V Cᵒᵖ) ≅ toOp V C ⋙ fromOp V C where
   hom := {app := 𝟙}
   inv := {
@@ -130,7 +128,7 @@ def ForgetEnrichment.opposite.toFromNatIso :
 
 /-- The composite functor from `(ForgetEnrichment V C)ᵒᵖ` to `ForgetEnrichment V (Cᵒᵖ)` and
 back to `(ForgetEnrichment V C)ᵒᵖ` is naturally isomorphic to the identity functor. -/
-def ForgetEnrichment.opposite.fromToNatIso :
+def ForgetEnrichment.Opposite.fromToNatIso :
     fromOp V C ⋙ toOp V C ≅ 𝟭 (ForgetEnrichment V C)ᵒᵖ where
   hom := {
     app := 𝟙
@@ -144,11 +142,11 @@ def ForgetEnrichment.opposite.fromToNatIso :
 
 /-- The equivalence between the underlying category of `Cᵒᵖ` and the opposite of the underlying
 category of `C`. -/
-def ForgetEnrichment.opposite.equiv : ForgetEnrichment V Cᵒᵖ ≌ (ForgetEnrichment V C)ᵒᵖ :=
+def ForgetEnrichment.Opposite.equiv : ForgetEnrichment V Cᵒᵖ ≌ (ForgetEnrichment V C)ᵒᵖ :=
   Equivalence.mk (toOp V C) (fromOp V C) (toFromNatIso V C) (fromToNatIso V C)
 
 /-- If `D` is an enriched ordinary category then `Dᵒᵖ` is an enriched ordinary category. -/
-instance EnrichedOrdinaryCategory.opposite {D : Type u} [Category.{v} D]
+instance EnrichedOrdinaryCategory.Opposite {D : Type u} [Category.{v} D]
     [EnrichedOrdinaryCategory V D] : EnrichedOrdinaryCategory V Dᵒᵖ where
   toEnrichedCategory := inferInstanceAs (EnrichedCategory V Dᵒᵖ)
   homEquiv := Quiver.Hom.opEquiv.symm.trans homEquiv

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -14,12 +14,15 @@ When a monoidal category `V` is braided, we may define the opposite `V`-category
 `V`-category. The symmetry map is required to define the composition morphism.
 
 This file constructs the opposite `V`-category as an instance on the type `Cᵒᵖ` and constructs an
-equivalence between the underlying category `ForgetEnrichment V (Cᵒᵖ)` and the opposite category
-`(ForgetEnrichment V C)ᵒᵖ`.
+equivalence between
+ • `ForgetEnrichment V (Cᵒᵖ)`, the underlying category of the `V`-category `Cᵒᵖ`; and
+ • `(ForgetEnrichment V C)ᵒᵖ`, the opposite category of the underlying category of `C`.
+We also show that if `C` is an enriched ordinary category (i.e. a category enriched in `V`
+equipped with an identification `(X ⟶ Y) ≃ (𝟙_ V ⟶ (X ⟶[V] Y))`) then `Cᵒᵖ` is again
+an enriched ordinary category.
 
-We use `Cᵒᵖ` for the underlying type as this allows us to construct an instance of
-`EnrichedOrdinaryCategory V (Cᵒᵖ)` in the case that `C` comes with an instance of
-`EnrichedOrdinaryCategory V C`.
+We use `Cᵒᵖ` for the underlying type as this allows us to construct the instance of
+`EnrichedOrdinaryCategory V (Cᵒᵖ)` which extends the opposite `V`-category structure.
 
 -/
 
@@ -73,12 +76,7 @@ lemma tensorHom_eComp_op_eq {C : Type u} [EnrichedCategory V C] {x y z : Cᵒᵖ
   rw [eComp_op_eq]
   exact braiding_naturality_assoc (C := V) f g _
 
--- In this section, we establish an equivalence between
---  • the underlying category of the `V`-category `Cᵒᵖ`; and
---  • the opposite category of the underlying category of `C`.
--- We also show that if `C` is an enriched ordinary category (i.e. a category enriched in `V`
--- equipped with an identification `(X ⟶ Y) ≃ (𝟙_ V ⟶ (X ⟶[V] Y))`) then `Cᵒᵖ` is again
--- an enriched ordinary category.
+-- This section establishes the equivalence on underlying categories
 section
 
 variable (C : Type u) [EnrichedCategory V C]

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -140,8 +140,13 @@ def ForgetEnrichment.Opposite.fromToNatIso :
 
 /-- The equivalence between the underlying category of `Cᵒᵖ` and the opposite of the underlying
 category of `C`. -/
-def ForgetEnrichment.Opposite.equiv : ForgetEnrichment V Cᵒᵖ ≌ (ForgetEnrichment V C)ᵒᵖ :=
-  Equivalence.mk (toOp V C) (fromOp V C) (toFromNatIso V C) (fromToNatIso V C)
+@[simps]
+def forgetEnrichmentOppositeEquivalence :
+    ForgetEnrichment V Cᵒᵖ ≌ (ForgetEnrichment V C)ᵒᵖ where
+  functor := ForgetEnrichment.Opposite.toOp V C
+  inverse := ForgetEnrichment.Opposite.fromOp V C
+  unitIso := NatIso.ofComponents (fun _ ↦ Iso.refl _)
+  counitIso := NatIso.ofComponents (fun _ ↦ Iso.refl _)
 
 /-- If `D` is an enriched ordinary category then `Dᵒᵖ` is an enriched ordinary category. -/
 instance EnrichedOrdinaryCategory.opposite {D : Type u} [Category.{v} D]

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -37,7 +37,7 @@ variable (C : Type u) [EnrichedCategory V C]
 
 /-- For a `V`-category `C`, construct the opposite `V`-category structure on the type `Cᵒᵖ`
 using the braiding in `V`. -/
-instance EnrichedCategory.Opposite : EnrichedCategory V Cᵒᵖ where
+instance EnrichedCategory.opposite : EnrichedCategory V Cᵒᵖ where
   Hom y x := EnrichedCategory.Hom x.unop y.unop
   id x := EnrichedCategory.id x.unop
   comp z y x := (β_ _ _).hom ≫ EnrichedCategory.comp (x.unop) (y.unop) (z.unop)

--- a/Mathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/Mathlib/CategoryTheory/Enriched/Opposite.lean
@@ -109,8 +109,8 @@ def forgetEnrichmentOppositeEquivalence.inverse :
     rw [this, ← Category.assoc]
     congr 1
 
-/-- The equivalence between the underlying category of `Cᵒᵖ` and the opposite of the underlying
-category of `C`. -/
+/-- The equivalence between the underlying category of the enriched category `Cᵒᵖ` and
+the opposite of the underlying category of the enriched category `C`. -/
 @[simps]
 def forgetEnrichmentOppositeEquivalence : ForgetEnrichment V Cᵒᵖ ≌ (ForgetEnrichment V C)ᵒᵖ where
   functor := forgetEnrichmentOppositeEquivalence.functor V C


### PR DESCRIPTION
For a `V`-category `C`, define the opposite `V`-category as an instance on the type `Cᵒᵖ`, construct an equivalence between the underlying category `ForgetEnrichment V (Cᵒᵖ)` and the opposite category `(ForgetEnrichment V C)ᵒᵖ`, and construct an instance of `EnrichedOrdinaryCategory V (Cᵒᵖ)` in the case that `C` comes with an instance of `EnrichedOrdinaryCategory V C`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Any comments and/or suggestions are greatly appreciated! In particular, I don't know whether it's best to construct the `V`-category structure on `Cᵒᵖ` as done here, or to introduce a new underlying type instead. The current implementation is chosen so that we may immediately define the `EnrichedOrdinaryCategory` instance, but I am happy to re-write and/or re-organize if this is not preferred.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
