### PR TITLE
[Merged by Bors] - chore: move definition of ENat and PNat out of Order.TypeTags

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2346,6 +2346,7 @@ import Mathlib.Data.ENNReal.Operations
 import Mathlib.Data.ENNReal.Real
 import Mathlib.Data.ENat.Basic
 import Mathlib.Data.ENat.BigOperators
+import Mathlib.Data.ENat.Defs
 import Mathlib.Data.ENat.Lattice
 import Mathlib.Data.Erased
 import Mathlib.Data.FP.Basic
@@ -2724,6 +2725,7 @@ import Mathlib.Data.PNat.Equiv
 import Mathlib.Data.PNat.Factors
 import Mathlib.Data.PNat.Find
 import Mathlib.Data.PNat.Interval
+import Mathlib.Data.PNat.Notation
 import Mathlib.Data.PNat.Prime
 import Mathlib.Data.PNat.Xgcd
 import Mathlib.Data.PSigma.Order

--- a/Mathlib/Data/Countable/Basic.lean
+++ b/Mathlib/Data/Countable/Basic.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Data.Countable.Defs
 import Mathlib.Data.Fin.Tuple.Basic
+import Mathlib.Data.ENat.Defs
 import Mathlib.Logic.Equiv.Nat
 
 /-!

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -3,12 +3,13 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Algebra.CharZero.Lemmas
-import Mathlib.Algebra.Order.Ring.WithTop
-import Mathlib.Algebra.Order.Sub.WithTop
+import Mathlib.Data.ENat.Defs
 import Mathlib.Data.Nat.Cast.Order.Basic
 import Mathlib.Data.Nat.SuccPred
 import Mathlib.Order.Nat
+import Mathlib.Algebra.CharZero.Lemmas
+import Mathlib.Algebra.Order.Ring.WithTop
+import Mathlib.Algebra.Order.Sub.WithTop
 
 /-!
 # Definition and basic properties of extended natural numbers

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -3,13 +3,13 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
+import Mathlib.Algebra.CharZero.Lemmas
+import Mathlib.Algebra.Order.Ring.WithTop
+import Mathlib.Algebra.Order.Sub.WithTop
 import Mathlib.Data.ENat.Defs
 import Mathlib.Data.Nat.Cast.Order.Basic
 import Mathlib.Data.Nat.SuccPred
 import Mathlib.Order.Nat
-import Mathlib.Algebra.CharZero.Lemmas
-import Mathlib.Algebra.Order.Ring.WithTop
-import Mathlib.Algebra.Order.Sub.WithTop
 
 /-!
 # Definition and basic properties of extended natural numbers

--- a/Mathlib/Data/ENat/Defs.lean
+++ b/Mathlib/Data/ENat/Defs.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Simon Hudon, Yury Kudryashov
+-/
+
+import Mathlib.Order.TypeTags
+import Mathlib.Data.Nat.Notation
+
+/-! # Definition and notation for extended natural numbers -/
+
+/-- Extended natural numbers `ℕ∞ = WithTop ℕ`. -/
+def ENat : Type := WithTop ℕ deriving Top, Inhabited
+
+@[inherit_doc] notation "ℕ∞" => ENat
+
+namespace ENat
+
+instance instNatCast : NatCast ℕ∞ := ⟨WithTop.some⟩
+
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11445): new definition copied from `WithTop`
+/-- Recursor for `ENat` using the preferred forms `⊤` and `↑a`. -/
+@[elab_as_elim, induction_eliminator, cases_eliminator]
+def recTopCoe {C : ℕ∞ → Sort*} (top : C ⊤) (coe : ∀ a : ℕ, C a) : ∀ n : ℕ∞, C n
+  | none => top
+  | Option.some a => coe a
+
+@[simp]
+theorem recTopCoe_top {C : ℕ∞ → Sort*} (d : C ⊤) (f : ∀ a : ℕ, C a) :
+    @recTopCoe C d f ⊤ = d :=
+  rfl
+
+@[simp]
+theorem recTopCoe_coe {C : ℕ∞ → Sort*} (d : C ⊤) (f : ∀ a : ℕ, C a) (x : ℕ) :
+    @recTopCoe C d f ↑x = f x :=
+  rfl
+
+end ENat

--- a/Mathlib/Data/ENat/Defs.lean
+++ b/Mathlib/Data/ENat/Defs.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Simon Hudon, Yury Kudryashov
 -/
 
-import Mathlib.Order.TypeTags
 import Mathlib.Data.Nat.Notation
+import Mathlib.Order.TypeTags
 
 /-! # Definition and notation for extended natural numbers -/
 

--- a/Mathlib/Data/PNat/Defs.lean
+++ b/Mathlib/Data/PNat/Defs.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Neil Strickland
 -/
 import Mathlib.Data.Nat.Defs
+import Mathlib.Data.PNat.Notation
 import Mathlib.Order.Basic
-import Mathlib.Order.TypeTags
 import Mathlib.Tactic.Coe
 import Mathlib.Tactic.Lift
 import Mathlib.Data.Int.Order.Basic

--- a/Mathlib/Data/PNat/Notation.lean
+++ b/Mathlib/Data/PNat/Notation.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Simon Hudon, Yury Kudryashov
 -/
 
-import Mathlib.Order.TypeTags
 import Mathlib.Data.Nat.Notation
 
 /-! # Definition and notation for positive natural numbers -/

--- a/Mathlib/Data/PNat/Notation.lean
+++ b/Mathlib/Data/PNat/Notation.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Simon Hudon, Yury Kudryashov
+-/
+
+import Mathlib.Order.TypeTags
+import Mathlib.Data.Nat.Notation
+
+/-! # Definition and notation for positive natural numbers -/
+
+/-- `ℕ+` is the type of positive natural numbers. It is defined as a subtype,
+  and the VM representation of `ℕ+` is the same as `ℕ` because the proof
+  is not stored. -/
+def PNat := { n : ℕ // 0 < n } deriving DecidableEq
+
+@[inherit_doc]
+notation "ℕ+" => PNat
+
+/-- The underlying natural number -/
+@[coe]
+def PNat.val : ℕ+ → ℕ := Subtype.val
+
+instance coePNatNat : Coe ℕ+ ℕ :=
+  ⟨PNat.val⟩
+
+instance : Repr ℕ+ :=
+  ⟨fun n n' => reprPrec n.1 n'⟩

--- a/Mathlib/Order/TypeTags.lean
+++ b/Mathlib/Order/TypeTags.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Simon Hudon, Yury Kudryashov
 -/
 import Mathlib.Order.Notation
-import Mathlib.Data.Nat.Notation
 
 /-!
 # Order-related type synonyms
@@ -103,49 +102,3 @@ theorem recTopCoe_coe {C : WithTop α → Sort*} (d : C ⊤) (f : ∀ a : α, C 
   rfl
 
 end WithTop
-
-/-- Extended natural numbers `ℕ∞ = WithTop ℕ`. -/
-def ENat : Type := WithTop ℕ deriving Top, Inhabited
-
-@[inherit_doc] notation "ℕ∞" => ENat
-
-namespace ENat
-
-instance instNatCast : NatCast ℕ∞ := ⟨WithTop.some⟩
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11445): new definition copied from `WithTop`
-/-- Recursor for `ENat` using the preferred forms `⊤` and `↑a`. -/
-@[elab_as_elim, induction_eliminator, cases_eliminator]
-def recTopCoe {C : ℕ∞ → Sort*} (top : C ⊤) (coe : ∀ a : ℕ, C a) : ∀ n : ℕ∞, C n
-  | none => top
-  | Option.some a => coe a
-
-@[simp]
-theorem recTopCoe_top {C : ℕ∞ → Sort*} (d : C ⊤) (f : ∀ a : ℕ, C a) :
-    @recTopCoe C d f ⊤ = d :=
-  rfl
-
-@[simp]
-theorem recTopCoe_coe {C : ℕ∞ → Sort*} (d : C ⊤) (f : ∀ a : ℕ, C a) (x : ℕ) :
-    @recTopCoe C d f ↑x = f x :=
-  rfl
-
-end ENat
-
-/-- `ℕ+` is the type of positive natural numbers. It is defined as a subtype,
-  and the VM representation of `ℕ+` is the same as `ℕ` because the proof
-  is not stored. -/
-def PNat := { n : ℕ // 0 < n } deriving DecidableEq
-
-@[inherit_doc]
-notation "ℕ+" => PNat
-
-/-- The underlying natural number -/
-@[coe]
-def PNat.val : ℕ+ → ℕ := Subtype.val
-
-instance coePNatNat : Coe ℕ+ ℕ :=
-  ⟨PNat.val⟩
-
-instance : Repr ℕ+ :=
-  ⟨fun n n' => reprPrec n.1 n'⟩


### PR DESCRIPTION
These had been moved to `Order.TypeTags` to reduce imports elsewhere, but they are sort of off-topic here, so I've just moved them to their own files.
