### PR TITLE
[Merged by Bors] - fix: `bors x` comments and zulip reactions

### DIFF
--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -25,74 +25,70 @@ client = zulip.Client(
 
 # Fetch the last 200 messages
 response = client.get_messages({
-    "operator": "search",
-    "operand": f"https://github\.com/leanprover-community/mathlib4/pull/{PR_NUMBER}",
+    "anchor": "newest",
+    "num_before": 200,
+    "num_after": 0,
+    "narrow": [{"operator": "channel", "operand": "PR reviews"}],
 })
 
 messages = response['messages']
 
+pr_pattern = re.compile(f'https://github.com/leanprover-community/mathlib4/pull/{PR_NUMBER}')
+
+print(f"Searching for: '{pr_pattern}'")
+
 for message in messages:
     content = message['content']
-    print(f"matched: '{message}'")
     # Check for emoji reactions
     reactions = message['reactions']
     has_peace_sign = any(reaction['emoji_name'] == 'peace_sign' for reaction in reactions)
     has_bors = any(reaction['emoji_name'] == 'bors' for reaction in reactions)
     has_merge = any(reaction['emoji_name'] == 'merge' for reaction in reactions)
+    match = pr_pattern.search(content)
+    if match:
+        print(f"matched: '{message}'")
 
-    pr_url = f"https://api.github.com/repos/leanprover-community/mathlib4/pulls/{PR_NUMBER}"
-
-    print('Removing peace_sign')
-    result = client.remove_reaction({
-        "message_id": message['id'],
-        "emoji_name": "peace_sign"
-    })
-    print(f"result: '{result}'")
-    print('Removing bors')
-    result = client.remove_reaction({
-        "message_id": message['id'],
-        "emoji_name": "bors"
-    })
-    print(f"result: '{result}'")
-
-    print('Removing merge')
-    result = client.remove_reaction({
-        "message_id": message['id'],
-        "emoji_name": "merge"
-    })
-    print(f"result: '{result}'")
-
-    if 'delegated' == LABEL:
-        print('adding delegated')
-
-        client.add_reaction({
-            "message_id": message['id'],
-            "emoji_name": "peace_sign"
-        })
-    elif 'ready-to-merge' == LABEL:
-        print('adding ready-to-merge')
+        # removing previous emoji reactions
+        print("Removing previous reactions, if present.")
         if has_peace_sign:
-            client.remove_reaction({
+            print('Removing peace_sign')
+            result = client.remove_reaction({
                 "message_id": message['id'],
                 "emoji_name": "peace_sign"
             })
-        client.add_reaction({
-            "message_id": message['id'],
-            "emoji_name": "bors"
-        })
-    elif LABEL.startswith("[Merged by Bors]"):
-        print('adding [Merged by Bors]')
-        if has_peace_sign:
-            client.remove_reaction({
-                "message_id": message['id'],
-                "emoji_name": "peace_sign"
-            })
+            print(f"result: '{result}'")
         if has_bors:
-            client.remove_reaction({
+            print('Removing bors')
+            result = client.remove_reaction({
                 "message_id": message['id'],
                 "emoji_name": "bors"
             })
-        client.add_reaction({
-            "message_id": message['id'],
-            "emoji_name": "merge"
-        })
+            print(f"result: '{result}'")
+        if has_merge:
+            print('Removing merge')
+            result = client.remove_reaction({
+                "message_id": message['id'],
+                "emoji_name": "merge"
+            })
+            print(f"result: '{result}'")
+
+        # applying appropriate emoji reaction
+        print("Applying reactions, as appropriate.")
+        if 'delegated' == LABEL:
+            print('adding delegated')
+            client.add_reaction({
+                "message_id": message['id'],
+                "emoji_name": "peace_sign"
+            })
+        elif 'ready-to-merge' == LABEL:
+            print('adding ready-to-merge')
+            client.add_reaction({
+                "message_id": message['id'],
+                "emoji_name": "bors"
+            })
+        elif LABEL.startswith("[Merged by Bors]"):
+            print('adding [Merged by Bors]')
+            client.add_reaction({
+                "message_id": message['id'],
+                "emoji_name": "merge"
+            })

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -74,17 +74,17 @@ for message in messages:
 
         # applying appropriate emoji reaction
         print("Applying reactions, as appropriate.")
-        if 'delegated' == LABEL:
-            print('adding delegated')
-            client.add_reaction({
-                "message_id": message['id'],
-                "emoji_name": "peace_sign"
-            })
-        elif 'ready-to-merge' == LABEL:
+        if 'ready-to-merge' == LABEL:
             print('adding ready-to-merge')
             client.add_reaction({
                 "message_id": message['id'],
                 "emoji_name": "bors"
+            })
+        elif 'delegated' == LABEL:
+            print('adding delegated')
+            client.add_reaction({
+                "message_id": message['id'],
+                "emoji_name": "peace_sign"
             })
         elif LABEL.startswith("[Merged by Bors]"):
             print('adding [Merged by Bors]')


### PR DESCRIPTION
Restores the bot reacting to `bors d`, `bors merge` and `bors r+`.  It only searches in `PR reviews`, but at least it should no longer fail CI.

I plan to investigate making the bot search all of Zulip in a later PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
