### PR TITLE
[Merged by Bors] - chore: remove isStrictTotalOrder_of_linearOrder

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2903,6 +2903,7 @@ import Mathlib.Deprecated.LazyList
 import Mathlib.Deprecated.Logic
 import Mathlib.Deprecated.MinMax
 import Mathlib.Deprecated.NatLemmas
+import Mathlib.Deprecated.Order
 import Mathlib.Deprecated.RelClasses
 import Mathlib.Deprecated.Ring
 import Mathlib.Deprecated.Subfield

--- a/Mathlib/Deprecated/Order.lean
+++ b/Mathlib/Deprecated/Order.lean
@@ -5,6 +5,12 @@ Authors: Leonardo de Moura, Jeremy Avigad, Floris van Doorn
 -/
 import Mathlib.Order.Defs
 
+/-!
+# Deprecated instances about order structures.
+-/
+
+variable {α : Type*}
+
 @[deprecated (since := "2024-11-26")] -- unused in Mathlib
 instance isStrictTotalOrder_of_linearOrder [LinearOrder α] : IsStrictTotalOrder α (· < ·) where
   irrefl := lt_irrefl

--- a/Mathlib/Deprecated/Order.lean
+++ b/Mathlib/Deprecated/Order.lean
@@ -1,0 +1,11 @@
+/-
+Copyright (c) 2014 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura, Jeremy Avigad, Floris van Doorn
+-/
+import Mathlib.Order.Defs
+
+@[deprecated (since := "2024-11-26")] -- unused in Mathlib
+instance isStrictTotalOrder_of_linearOrder [LinearOrder α] : IsStrictTotalOrder α (· < ·) where
+  irrefl := lt_irrefl
+  trichotomous := lt_trichotomy

--- a/Mathlib/Order/Defs.lean
+++ b/Mathlib/Order/Defs.lean
@@ -488,11 +488,6 @@ instance (priority := 900) (a b : α) : Decidable (a = b) := LinearOrder.decidab
 lemma eq_or_lt_of_not_lt (h : ¬a < b) : a = b ∨ b < a :=
   if h₁ : a = b then Or.inl h₁ else Or.inr (lt_of_not_ge fun hge => h (lt_of_le_of_ne hge h₁))
 
--- TODO(Leo): decide whether we should keep this instance or not
-instance isStrictTotalOrder_of_linearOrder : IsStrictTotalOrder α (· < ·) where
-  irrefl := lt_irrefl
-  trichotomous := lt_trichotomy
-
 /-- Perform a case-split on the ordering of `x` and `y` in a decidable linear order. -/
 def ltByCases (x y : α) {P : Sort*} (h₁ : x < y → P) (h₂ : x = y → P) (h₃ : y < x → P) : P :=
   if h : x < y then h₁ h


### PR DESCRIPTION
This has been around since Lean3 core, but it is unused in Mathlib. Propose deletion.