### PR TITLE
[Merged by Bors] - feat: semiring with discrete PrimeSpectrum

### DIFF
--- a/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
+++ b/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
@@ -136,7 +136,7 @@ theorem toΓSpecCApp_iff
   -- Porting Note: Type class problem got stuck in `IsLocalization.Away.AwayMap.lift_comp`
   -- created instance manually. This replaces the `pick_goal` tactics
   have loc_inst := IsLocalization.to_basicOpen (Γ.obj (op X)) r
-  rw [← @IsLocalization.Away.AwayMap.lift_comp _ _ _ _ _ _ _ r loc_inst _
+  rw [← @IsLocalization.Away.lift_comp _ _ _ _ _ _ _ r loc_inst _
       (X.isUnit_res_toΓSpecMapBasicOpen r)]
   --pick_goal 5; exact is_localization.to_basic_open _ r
   constructor

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -9,7 +9,7 @@ import Mathlib.RingTheory.Ideal.Over
 import Mathlib.RingTheory.KrullDimension.Basic
 import Mathlib.RingTheory.LocalRing.ResidueField.Defs
 import Mathlib.RingTheory.LocalRing.RingHom.Basic
-import Mathlib.RingTheory.Localization.Away.Lemmas
+import Mathlib.RingTheory.Localization.Away.Basic
 import Mathlib.Tactic.StacksAttribute
 import Mathlib.Topology.KrullDimension
 import Mathlib.Topology.Sober

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -576,7 +576,7 @@ lemma _root_.RingHom.toLocalizationIsMaximal_surjective_of_discreteTopology :
   have := eq (e ⟨I, I.2.isPrime⟩)
   rwa [← AlgEquiv.symm_apply_eq, AlgEquiv.commutes, e.symm_apply_apply] at this
 
-/-- If the prime spectrum of a commutative ring R has discrete Zariski topology, then R is
+/-- If the prime spectrum of a commutative semiring R has discrete Zariski topology, then R is
 canonically isomorphic to the product of its localizations at the (finitely many) maximal ideals. -/
 @[stacks 00JA
 "See also `PrimeSpectrum.discreteTopology_iff_finite_isMaximal_and_sInf_le_nilradical`."]

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -530,17 +530,60 @@ theorem isLocalization_away_iff_atPrime_of_basicOpen_eq_singleton [Algebra R S]
     {f : R} {p : PrimeSpectrum R} (h : (basicOpen f).1 = {p}) :
     IsLocalization.Away f S ↔ IsLocalization.AtPrime S p.1 :=
   have : IsLocalization.AtPrime (Localization.Away f) p.1 := by
-    refine .of_le_of_exists_dvd (Submonoid.powers f) _
+    refine .of_le_of_exists_dvd (.powers f) _
       (Submonoid.powers_le.mpr <| by apply h ▸ Set.mem_singleton p) fun r hr ↦ ?_
     contrapose! hr
     simp_rw [← Ideal.mem_span_singleton] at hr
     have ⟨q, prime, le, disj⟩ := Ideal.exists_le_prime_disjoint (Ideal.span {r})
-      (Submonoid.powers f) (Set.disjoint_right.mpr hr)
+      (.powers f) (Set.disjoint_right.mpr hr)
     have : ⟨q, prime⟩ ∈ (basicOpen f).1 := Set.disjoint_right.mp disj (Submonoid.mem_powers f)
     rw [h, Set.mem_singleton_iff] at this
     rw [← this]
     exact not_not.mpr (q.span_singleton_le_iff_mem.mp le)
   IsLocalization.isLocalization_iff_of_isLocalization _ _ (Localization.Away f)
+
+variable [DiscreteTopology (PrimeSpectrum R)]
+
+variable (R) in
+lemma _root_.RingHom.toLocalizationIsMaximal_surjective_of_discreteTopology :
+    Function.Surjective (RingHom.toLocalizationIsMaximal R) := fun x ↦ by
+  have (p : PrimeSpectrum R) : ∃ f, (basicOpen f : Set _) = {p} :=
+    have ⟨_, ⟨f, rfl⟩, hpf, hfp⟩ := isTopologicalBasis_basic_opens.isOpen_iff.mp
+      (isOpen_discrete {p}) p rfl
+    ⟨f, hfp.antisymm <| Set.singleton_subset_iff.mpr hpf⟩
+  choose f hf using this
+  let e := Equiv.ofInjective f fun p q eq ↦ Set.singleton_injective (hf p ▸ eq ▸ hf q)
+  have loc a : IsLocalization.AtPrime (Localization.Away a.1) (e.symm a).1 :=
+    (isLocalization_away_iff_atPrime_of_basicOpen_eq_singleton <| hf _).mp <| by
+      simp_rw [Equiv.apply_ofInjective_symm]; infer_instance
+  let algE a := IsLocalization.algEquiv (e.symm a).1.primeCompl
+    (Localization.AtPrime (e.symm a).1) (Localization.Away a.1)
+  have span_eq : Ideal.span (Set.range f) = ⊤ := iSup_basicOpen_eq_top_iff.mp <| top_unique
+    fun p _ ↦ TopologicalSpace.Opens.mem_iSup.mpr ⟨p, (hf p).ge rfl⟩
+  replace hf a : (basicOpen a.1 : Set _) = {e.symm a} := by
+    simp_rw [← hf, Equiv.apply_ofInjective_symm]
+  have := (discreteTopology_iff_finite_and_isPrime_imp_isMaximal.mp ‹_›).2
+  obtain ⟨r, eq, -⟩ := Localization.existsUnique_algebraMap_eq_of_span_eq_top _ span_eq
+    (fun a ↦ algE a (x ⟨_, this _ inferInstance⟩)) fun a b ↦ by
+      obtain rfl | ne := eq_or_ne a b; · rfl
+      have ⟨n, hn⟩ : IsNilpotent (a * b : R) := (basicOpen_eq_bot_iff _).mp <| by
+        simp_rw [basicOpen_mul, SetLike.ext'_iff, TopologicalSpace.Opens.coe_inf, hf]
+        exact bot_unique (fun _ ⟨ha, hb⟩ ↦ ne <| e.symm.injective (ha.symm.trans hb))
+      have := IsLocalization.subsingleton (M := .powers (a * b : R))
+        (S := Localization.Away (a * b : R)) <| hn ▸ ⟨n, rfl⟩
+      apply Subsingleton.elim
+  refine ⟨r, funext fun I ↦ ?_⟩
+  have := eq (e ⟨I, I.2.isPrime⟩)
+  rwa [← AlgEquiv.symm_apply_eq, AlgEquiv.commutes, e.symm_apply_apply] at this
+
+/-- If the prime spectrum of a commutative ring R has discrete Zariski topology, then R is
+canonically isomorphic to the product of its localizations at the (finitely many) maximal ideals. -/
+@[stacks 00JA
+"See also `PrimeSpectrum.discreteTopology_iff_finite_isMaximal_and_sInf_le_nilradical`."]
+def _root_.RingHom.toLocalizationIsMaximalEquiv : R ≃+*
+    Π I : {I : Ideal R // I.IsMaximal}, haveI : I.1.IsMaximal := I.2; Localization.AtPrime I.1 :=
+  .ofBijective _ ⟨RingHom.toLocalizationIsMaximal_injective R,
+    RingHom.toLocalizationIsMaximal_surjective_of_discreteTopology R⟩
 
 end BasicOpen
 
@@ -1101,40 +1144,5 @@ lemma isIdempotentElemEquivClopens_symm_sup (s₁ s₂ : Clopens (PrimeSpectrum 
   ring
 
 end PrimeSpectrum
-
-variable [DiscreteTopology (PrimeSpectrum R)]
-open PrimeSpectrum
-
-variable (R) in
-lemma RingHom.toLocalizationIsMaximal_surjective_of_discreteTopology :
-    Function.Surjective (RingHom.toLocalizationIsMaximal R) := fun x ↦ by
-  let idem I := isIdempotentElemEquivClopens (R := R).symm ⟨{I}, isClopen_discrete _⟩
-  let ideal I := Ideal.span {1 - (idem I).1}
-  let toSpec (I : {I : Ideal R | I.IsMaximal}) : PrimeSpectrum R := ⟨I.1, I.2.isPrime⟩
-  have loc I : IsLocalization.AtPrime (R ⧸ ideal I) I.1 := by
-    rw [← isLocalization_away_iff_atPrime_of_basicOpen_eq_singleton]
-    exacts [IsLocalization.Away.quotient_of_isIdempotentElem (idem I).2,
-      congr_arg (·.1) (basicOpen_isIdempotentElemEquivClopens_symm ⟨{I}, isClopen_discrete _⟩)]
-  let equiv I := IsLocalization.algEquiv I.1.primeCompl (Localization.AtPrime I.1) (R ⧸ ideal I)
-  have := (discreteTopology_iff_finite_isMaximal_and_sInf_le_nilradical.mp ‹_›).1
-  have ⟨r, hr⟩ := Ideal.pi_quotient_surjective ?_ fun I ↦ equiv (toSpec I) (x I)
-  · refine ⟨r, funext fun I ↦ (equiv <| toSpec I).injective ?_⟩
-    rw [← hr]; exact (equiv _).commutes r
-  refine fun I J ne ↦ Ideal.isCoprime_iff_exists.mpr ?_
-  have := ((idem <| toSpec I).2.mul (idem <| toSpec J).2).eq_zero_of_isNilpotent <| by
-    simp_rw [← basicOpen_eq_bot_iff, basicOpen_mul, SetLike.ext'_iff, idem,
-      TopologicalSpace.Opens.coe_inf, basicOpen_isIdempotentElemEquivClopens_symm]
-    exact Set.singleton_inter_eq_empty.mpr fun h ↦ ne (Subtype.ext <| congr_arg (·.1) h)
-  simp_rw [ideal, Ideal.mem_span_singleton', exists_exists_eq_and]
-  exact ⟨1, idem (toSpec I), by simpa [mul_sub]⟩
-
-/-- If the prime spectrum of a commutative ring R has discrete Zariski topology, then R is
-canonically isomorphic to the product of its localizations at the (finitely many) maximal ideals. -/
-@[stacks 00JA
-"See also `PrimeSpectrum.discreteTopology_iff_finite_isMaximal_and_sInf_le_nilradical`."]
-def RingHom.toLocalizationIsMaximalEquiv : R ≃+*
-    Π I : {I : Ideal R // I.IsMaximal}, haveI : I.1.IsMaximal := I.2; Localization.AtPrime I.1 :=
-  .ofBijective _ ⟨RingHom.toLocalizationIsMaximal_injective R,
-    RingHom.toLocalizationIsMaximal_surjective_of_discreteTopology R⟩
 
 end Idempotent

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -150,6 +150,16 @@ theorem span_pow_eq_top (s : Set α) (hs : span s = ⊤) (n : ℕ) :
   rw [mul_pow, mem_span_singleton]
   exact ⟨f x ^ (n + 1), mul_comm _ _⟩
 
+theorem span_range_pow_eq_top (s : Set α) (hs : span s = ⊤) (n : s → ℕ) :
+    span (Set.range fun x ↦ x.1 ^ n x) = ⊤ := by
+  have ⟨t, hts, mem⟩ := Submodule.mem_span_finite_of_mem_span ((eq_top_iff_one _).mp hs)
+  refine top_unique ((span_pow_eq_top _ ((eq_top_iff_one _).mpr mem) <|
+    t.attach.sup fun x ↦ n ⟨x, hts x.2⟩).ge.trans <| span_le.mpr ?_)
+  rintro _ ⟨x, hxt, rfl⟩
+  rw [← Nat.sub_add_cancel (Finset.le_sup <| t.mem_attach ⟨x, hxt⟩)]
+  simp_rw [pow_add]
+  exact mul_mem_left _ _ (subset_span ⟨_, rfl⟩)
+
 end Ideal
 
 end CommSemiring

--- a/Mathlib/RingTheory/Localization/Away/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/Localization/Away/AdjoinRoot.lean
@@ -28,7 +28,7 @@ noncomputable def Localization.awayEquivAdjoin (r : R) : Away r ≃ₐ[R] Adjoin
       (isUnit_of_mul_eq_one ((algebraMap R (AdjoinRoot (C r * X - 1))) r) (root (C r * X - 1))
         (root_isInv r)) with
       commutes' :=
-        IsLocalization.Away.AwayMap.lift_eq r (isUnit_of_mul_eq_one _ _ <| root_isInv r) }
+        IsLocalization.Away.lift_eq r (isUnit_of_mul_eq_one _ _ <| root_isInv r) }
     (liftHom _ (IsLocalization.Away.invSelf r) <| by
       simp only [map_sub, map_mul, aeval_C, aeval_X, IsLocalization.Away.mul_invSelf, aeval_one,
         sub_self])

--- a/Mathlib/RingTheory/Localization/Away/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Away/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Mario Carneiro, Johan Commelin, Amelia Livingston, Anne Baanen
 -/
 import Mathlib.GroupTheory.MonoidLocalization.Away
+import Mathlib.Algebra.Algebra.Pi
 import Mathlib.RingTheory.Ideal.Maps
 import Mathlib.RingTheory.Localization.Basic
 import Mathlib.RingTheory.UniqueFactorizationDomain.Multiplicity
@@ -123,6 +124,9 @@ lemma iff_of_associated {r r' : R} (h : Associated r r') :
     IsLocalization.Away r S ↔ IsLocalization.Away r' S :=
   ⟨fun _ ↦ IsLocalization.Away.of_associated h, fun _ ↦ IsLocalization.Away.of_associated h.symm⟩
 
+lemma isUnit_of_dvd {r : R} (h : r ∣ x) : IsUnit (algebraMap R S r) :=
+  isUnit_of_dvd_unit (map_dvd _ h) (algebraMap_isUnit x)
+
 variable {g : R →+* P}
 
 /-- Given `x : R`, a localization map `F : R →+* S` away from `x`, and a map of `CommSemiring`s
@@ -136,20 +140,33 @@ noncomputable def lift (hg : IsUnit (g x)) : S →+* P :=
       exact IsUnit.map (powMonoidHom n : P →* P) hg
 
 @[simp]
-theorem AwayMap.lift_eq (hg : IsUnit (g x)) (a : R) : lift x hg ((algebraMap R S) a) = g a :=
+theorem lift_eq (hg : IsUnit (g x)) (a : R) : lift x hg (algebraMap R S a) = g a :=
   IsLocalization.lift_eq _ _
 
 @[simp]
-theorem AwayMap.lift_comp (hg : IsUnit (g x)) : (lift x hg).comp (algebraMap R S) = g :=
+theorem lift_comp (hg : IsUnit (g x)) : (lift x hg).comp (algebraMap R S) = g :=
   IsLocalization.lift_comp _
+
+@[deprecated (since := "2024-11-25")] alias AwayMap.lift_eq := lift_eq
+@[deprecated (since := "2024-11-25")] alias AwayMap.lift_comp := lift_comp
+
+/-- Given `x y : R` and localizations `S`, `P` away from `x` and `y * x`
+respectively, the homomorphism induced from `S` to `P`. -/
+noncomputable def awayToAwayLeft (y : R) [Algebra R P] [IsLocalization.Away (y * x) P] : S →+* P :=
+  lift x <| isUnit_of_dvd (y * x) (dvd_mul_left _ _)
 
 /-- Given `x y : R` and localizations `S`, `P` away from `x` and `x * y`
 respectively, the homomorphism induced from `S` to `P`. -/
 noncomputable def awayToAwayRight (y : R) [Algebra R P] [IsLocalization.Away (x * y) P] : S →+* P :=
-  lift x <|
-    show IsUnit ((algebraMap R P) x) from
-      isUnit_of_mul_eq_one ((algebraMap R P) x) (mk' P y ⟨x * y, Submonoid.mem_powers _⟩) <| by
-        rw [mul_mk'_eq_mk'_of_mul, mk'_self]
+  lift x <| isUnit_of_dvd (x * y) (dvd_mul_right _ _)
+
+theorem awayToAwayLeft_eq (y : R) [Algebra R P] [IsLocalization.Away (y * x) P] (a : R) :
+    awayToAwayLeft x y (algebraMap R S a) = algebraMap R P a :=
+  lift_eq _ _ _
+
+theorem awayToAwayRight_eq (y : R) [Algebra R P] [IsLocalization.Away (x * y) P] (a : R) :
+    awayToAwayRight x y (algebraMap R S a) = algebraMap R P a :=
+  lift_eq _ _ _
 
 variable (S) (Q : Type*) [CommSemiring Q] [Algebra P Q]
 
@@ -164,10 +181,10 @@ noncomputable def map (f : R →+* P) (r : R) [IsLocalization.Away r S]
 
 section Algebra
 
-variable {A : Type*} [CommRing A] [Algebra R A]
-variable {B : Type*} [CommRing B] [Algebra R B]
-variable (Aₚ : Type*) [CommRing Aₚ] [Algebra A Aₚ] [Algebra R Aₚ] [IsScalarTower R A Aₚ]
-variable (Bₚ : Type*) [CommRing Bₚ] [Algebra B Bₚ] [Algebra R Bₚ] [IsScalarTower R B Bₚ]
+variable {A : Type*} [CommSemiring A] [Algebra R A]
+variable {B : Type*} [CommSemiring B] [Algebra R B]
+variable (Aₚ : Type*) [CommSemiring Aₚ] [Algebra A Aₚ] [Algebra R Aₚ] [IsScalarTower R A Aₚ]
+variable (Bₚ : Type*) [CommSemiring Bₚ] [Algebra B Bₚ] [Algebra R Bₚ] [IsScalarTower R B Bₚ]
 
 instance {f : A →+* B} (a : A) [Away (f a) Bₚ] : IsLocalization (.map f (.powers a)) Bₚ := by
   simpa
@@ -279,7 +296,7 @@ noncomputable def atUnit (x : R) (e : IsUnit x) [IsLocalization.Away x S] : R �
 noncomputable def atOne [IsLocalization.Away (1 : R) S] : R ≃ₐ[R] S :=
   @atUnit R _ S _ _ (1 : R) isUnit_one _
 
-theorem away_of_isUnit_of_bijective {R : Type*} (S : Type*) [CommRing R] [CommRing S]
+theorem away_of_isUnit_of_bijective {R : Type*} (S : Type*) [CommSemiring R] [CommSemiring S]
     [Algebra R S] {r : R} (hr : IsUnit r) (H : Function.Bijective (algebraMap R S)) :
     IsLocalization.Away r S :=
   { map_units' := by
@@ -364,13 +381,73 @@ noncomputable abbrev awayMap (f : R →+* P) (r : R) :
     Localization.Away r →+* Localization.Away (f r) :=
   IsLocalization.Away.map _ _ f r
 
-variable {A : Type*} [CommRing A] [Algebra R A]
-variable {B : Type*} [CommRing B] [Algebra R B]
+variable {A : Type*} [CommSemiring A] [Algebra R A]
+variable {B : Type*} [CommSemiring B] [Algebra R B]
 
 /-- Given a map `f : A →ₐ[R] B` and an element `a : A`, we may construct a map `Aₐ →ₐ[R] Bₐ`. -/
 noncomputable abbrev awayMapₐ (f : A →ₐ[R] B) (a : A) :
     Localization.Away a →ₐ[R] Localization.Away (f a) :=
   IsLocalization.Away.mapₐ _ _ f a
+
+theorem algebraMap_injective_of_span_eq_top (s : Set R) (span_eq : Ideal.span s = ⊤) :
+    Function.Injective (algebraMap R <| Π a : s, Away a.1) := fun x y eq ↦ by
+  suffices Module.eqIdeal R x y = ⊤ by simpa [Module.eqIdeal] using (Ideal.eq_top_iff_one _).mp this
+  by_contra ne
+  have ⟨r, hrs, disj⟩ := Ideal.exists_disjoint_powers_of_span_eq_top s span_eq _ ne
+  let r : s := ⟨r, hrs⟩
+  have ⟨⟨_, n, rfl⟩, eq⟩ := (IsLocalization.eq_iff_exists (.powers r.1) _).mp (congr_fun eq r)
+  exact Set.disjoint_left.mp disj eq ⟨n, rfl⟩
+
+/-- The sheaf condition for the structure sheaf on `Spec R`
+for a covering of the whole prime spectrum by basic opens. -/
+theorem existsUnique_algebraMap_eq_of_span_eq_top (s : Set R) (span_eq : Ideal.span s = ⊤)
+    (f : Π a : s, Away a.1) (h : ∀ a b : s,
+      Away.awayToAwayRight (P := Away (a * b : R)) a.1 b (f a) = Away.awayToAwayLeft b.1 a (f b)) :
+    ∃! r : R, ∀ a : s, algebraMap R _ r = f a := by
+  have mem := (Ideal.eq_top_iff_one _).mp span_eq; clear span_eq
+  wlog finset_eq : ∃ t : Finset R, t = s generalizing s
+  · have ⟨t, hts, mem⟩ := Submodule.mem_span_finite_of_mem_span mem
+    have ⟨r, eq, uniq⟩ := this t (fun a ↦ f ⟨a, hts a.2⟩)
+      (fun a b ↦ h ⟨a, hts a.2⟩ ⟨b, hts b.2⟩) mem ⟨_, rfl⟩
+    refine ⟨r, fun a ↦ ?_, fun _ eq ↦ uniq _ fun a ↦ eq ⟨a, hts a.2⟩⟩
+    replace hts := Set.insert_subset a.2 hts
+    classical
+    have ⟨r', eq, _⟩ := this ({a.1} ∪ t) (fun a ↦ f ⟨a, hts a.2⟩) (fun a b ↦
+      h ⟨a, hts a.2⟩ ⟨b, hts b.2⟩) (Ideal.span_mono (fun _ ↦ .inr) mem) ⟨{a.1} ∪ t, by simp⟩
+    exact (congr_arg _ (uniq _ fun b ↦ eq ⟨b, .inr b.2⟩).symm).trans (eq ⟨a, .inl rfl⟩)
+  have span_eq := (Ideal.eq_top_iff_one _).mpr mem
+  refine exists_unique_of_exists_of_unique ?_ fun x y hx hy ↦
+    algebraMap_injective_of_span_eq_top s span_eq (funext fun a ↦ (hx a).trans (hy a).symm)
+  obtain ⟨s, rfl⟩ := finset_eq
+  choose n r eq using fun a ↦ Away.surj a.1 (f a)
+  let N := s.attach.sup n
+  let r a := a ^ (N - n a) * r a
+  have eq a : f a * algebraMap R _ (a ^ N) = algebraMap R _ (r a) := by
+    rw [map_mul, ← eq, mul_left_comm, ← map_pow, ← map_mul, ← pow_add,
+      Nat.sub_add_cancel (Finset.le_sup <| s.mem_attach a)]
+  have eq2 a b : ∃ N', (a * b) ^ N' * (r a * b ^ N) = (a * b) ^ N' * (r b * a ^ N) :=
+    Away.exists_of_eq (S := Away (a * b : R)) _ <| by
+      simp_rw [map_mul, ← Away.awayToAwayRight_eq (S := Away a.1) a.1 b (r a),
+        ← Away.awayToAwayLeft_eq (S := Away b.1) b.1 a (r b), ← eq, map_mul,
+        Away.awayToAwayRight_eq, Away.awayToAwayLeft_eq, h, mul_assoc, ← map_mul, mul_comm]
+  choose N' hN' using eq2
+  let N' := (s ×ˢ s).attach.sup fun a ↦ N'
+    ⟨_, (Finset.mem_product.mp a.2).1⟩ ⟨_, (Finset.mem_product.mp a.2).2⟩
+  have eq2 a b : (a * b) ^ N' * (r a * b ^ N) = (a * b) ^ N' * (r b * a ^ N) := by
+    dsimp only [N']; rw [← Nat.sub_add_cancel (Finset.le_sup <| (Finset.mem_attach _ ⟨⟨a, b⟩,
+      Finset.mk_mem_product a.2 b.2⟩)), pow_add, mul_assoc, hN', ← mul_assoc]
+  let N := N' + N
+  let r a := a ^ N' * r a
+  have eq a : f a * algebraMap R _ (a ^ N) = algebraMap R _ (r a) := by
+    rw [map_mul, ← eq, mul_left_comm, ← map_mul, ← pow_add]
+  have eq2 a b : r a * b ^ N = r b * a ^ N := by
+    rw [pow_add, mul_mul_mul_comm, ← mul_pow, eq2,
+      mul_comm a.1, mul_pow, mul_mul_mul_comm, ← pow_add]
+  have ⟨c, eq1⟩ := (mem_span_range_iff_exists_fun _).mp <|
+    (Ideal.eq_top_iff_one _).mp <| (Set.image_eq_range _ _ ▸ Ideal.span_pow_eq_top _ span_eq N)
+  refine ⟨∑ b, c b * r b, fun a ↦ ((Away.algebraMap_isUnit a.1).pow N).mul_left_inj.mp ?_⟩
+  simp_rw [← map_pow, eq, ← map_mul, Finset.sum_mul, mul_assoc, eq2 _ a, mul_left_comm (c _),
+    ← Finset.mul_sum, ← smul_eq_mul (a := c _), eq1, mul_one]
 
 end Localization
 
@@ -378,14 +455,14 @@ end CommSemiring
 
 open Localization
 
-variable {R : Type*} [CommRing R]
+variable {R : Type*} [CommSemiring R]
 
 section NumDen
 
 open IsLocalization
 
 variable (x : R)
-variable (B : Type*) [CommRing B] [Algebra R B] [IsLocalization.Away x B]
+variable (B : Type*) [CommSemiring B] [Algebra R B] [IsLocalization.Away x B]
 
 /-- `selfZPow x (m : ℤ)` is `x ^ m` as an element of the localization away from `x`. -/
 noncomputable def selfZPow (m : ℤ) : B :=
@@ -478,7 +555,8 @@ theorem selfZPow_pow_sub (a : R) (b : B) (m d : ℤ) :
     simp only at this
     rwa [mul_comm _ b, mul_assoc b _ _, selfZPow_mul_neg, mul_one] at this
 
-variable [IsDomain R] [WfDvdMonoid R]
+variable {R : Type*} [CommRing R] (x : R) (B : Type*) [CommRing B]
+variable [Algebra R B] [IsLocalization.Away x B] [IsDomain R] [WfDvdMonoid R]
 
 theorem exists_reduced_fraction' {b : B} (hb : b ≠ 0) (hx : Irreducible x) :
     ∃ (a : R) (n : ℤ), ¬x ∣ a ∧ selfZPow x B n * algebraMap R B a = b := by


### PR DESCRIPTION
If the prime spectrum of a commutative semiring R has discrete Zariski topology, then R is canonically isomorphic to the product of its localizations at the (finitely many) maximal ideals. This was previously only proven for commutative rings R; a different proof using the sheaf property is required to generalize it.

---

follow-up to #18891

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
