### PR TITLE
[Merged by Bors] - feat(Algebra/GradedMonoid): add `prod_mem_graded`

### DIFF
--- a/Mathlib/Algebra/GradedMonoid.lean
+++ b/Mathlib/Algebra/GradedMonoid.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Group.Submonoid.Defs
 import Mathlib.Data.List.FinRange
 import Mathlib.Data.SetLike.Basic
 import Mathlib.Data.Sigma.Basic
+import Mathlib.Algebra.BigOperators.Group.Finset
 import Lean.Elab.Tactic
 
 /-!
@@ -671,3 +672,32 @@ def SetLike.homogeneousSubmonoid [AddMonoid ι] [Monoid R] (A : ι → S) [SetLi
   mul_mem' a b := SetLike.homogeneous_mul a b
 
 end HomogeneousElements
+
+section CommMonoid
+
+namespace SetLike
+
+variable {ι R S : Type*} [SetLike S R] [CommMonoid R] [AddCommMonoid ι]
+variable (A : ι → S) [SetLike.GradedMonoid A]
+
+variable {κ : Type*} (i : κ → ι) (g : κ → R) {F : Finset κ}
+
+theorem prod_mem_graded (hF : ∀ k ∈ F, g k ∈ A (i k)) : ∏ k ∈ F, g k ∈ A (∑ k ∈ F, i k) := by
+  classical
+  induction F using Finset.induction_on
+  · simp [GradedOne.one_mem]
+  · case insert j F' hF2 h3 =>
+    rw [Finset.prod_insert hF2, Finset.sum_insert hF2]
+    apply SetLike.mul_mem_graded (hF j <| Finset.mem_insert_self j F')
+    apply h3
+    intro k hk
+    apply hF k
+    exact Finset.mem_insert_of_mem hk
+
+theorem prod_pow_mem_graded (n : κ → ℕ) (hF : ∀ k ∈ F, g k ∈ A (i k)) :
+    ∏ k ∈ F, g k ^ n k ∈ A (∑ k ∈ F, n k • i k) :=
+  prod_mem_graded A _ _ fun k hk ↦ pow_mem_graded _ (hF k hk)
+
+end SetLike
+
+end CommMonoid


### PR DESCRIPTION
Co-authored-by: Kevin Buzzard

This contribution was created as part of the Durham Computational Algebraic Geometry Workshop.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
