### PR TITLE
[Merged by Bors] - chore(100.yml): various clean-ups

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -310,7 +310,7 @@
   decls  :
     - sum_range_pow
     - sum_Ico_pow
-  author : mathlib (Moritz Firsching, Fabian Kruse, Ashvni Narayanan)
+  author : Moritz Firsching, Fabian Kruse, Ashvni Narayanan
 78:
   title  : The Cauchy-Schwarz Inequality
   decls  :
@@ -320,7 +320,7 @@
 79:
   title  : The Intermediate Value Theorem
   decl   : intermediate_value_Icc
-  author : mathlib (Rob Lewis and Chris Hughes)
+  author : Rob Lewis and Chris Hughes
 80:
   title  : The Fundamental Theorem of Arithmetic
   decls  :
@@ -329,7 +329,7 @@
     - EuclideanDomain.to_principal_ideal_domain
     - UniqueFactorizationMonoid
     - UniqueFactorizationMonoid.factors_unique
-  author : mathlib (Chris Hughes)
+  author : Chris Hughes
   note   : "it also has a generalized version, by showing that every Euclidean domain is a unique factorization domain, and showing that the integers form a Euclidean domain."
 81:
   title  : Divergence of the Prime Reciprocal Series
@@ -374,7 +374,7 @@
   title  : Stirling’s Formula
   decls  :
     - Stirling.tendsto_stirlingSeq_sqrt_pi
-  author : mathlib (Moritz Firsching, Fabian Kruse, Nikolas Kuhn, Heather Macbeth)
+  author : Moritz Firsching, Fabian Kruse, Nikolas Kuhn, Heather Macbeth
 91:
   title  : The Triangle Inequality
   decl   : norm_add_le

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -35,7 +35,7 @@
 9:
   title  : The Area of a Circle
   decl   : Theorems100.area_disc
-  author : James Arthur, Benjamin Davidson, and Andrew Souther
+  author : James Arthur and Benjamin Davidson and Andrew Souther
 10:
   title  : Euler’s Generalization of Fermat’s Little Theorem
   decl   : Nat.ModEq.pow_totient
@@ -51,7 +51,7 @@
 14:
   title  : Euler’s Summation of 1 + (1/2)^2 + (1/3)^2 + ….
   decl   : hasSum_zeta_two
-  author : Marc Masdeu, David Loeffler
+  author : Marc Masdeu and David Loeffler
 15:
   title  : Fundamental Theorem of Integral Calculus
   decls  :
@@ -113,7 +113,7 @@
   title  : Feuerbach’s Theorem
 30:
   title  : The Ballot Problem
-  author : Bhavik Mehta, Kexing Ying
+  author : Bhavik Mehta and Kexing Ying
   decl   : Ballot.ballot_problem
 31:
   title  : Ramsey’s Theorem
@@ -127,7 +127,7 @@
 34:
   title  : Divergence of the Harmonic Series
   decl   : Real.tendsto_sum_range_one_div_nat_succ_atTop
-  author : Anatole Dedecker, Yury Kudryashov
+  author : Anatole Dedecker and Yury Kudryashov
 35:
   title  : Taylor’s Theorem
   decls  :
@@ -157,12 +157,12 @@
 40:
   title  : Minkowski’s Fundamental Theorem
   decl   : MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure
-  author : Alex J. Best, Yaël Dillies
+  author : Alex J. Best and Yaël Dillies
 41:
   title  : Puiseux’s Theorem
 42:
   title  : Sum of the Reciprocals of the Triangular Numbers
-  author : Jalex Stark, Yury Kudryashov
+  author : Jalex Stark and Yury Kudryashov
   decl   : Theorems100.inverse_triangle_sum
 43:
   title  : The Isoperimetric Theorem
@@ -172,7 +172,7 @@
   author : Chris Hughes
 45:
   title  : The Partition Theorem
-  author : Bhavik Mehta, Aaron Anderson
+  author : Bhavik Mehta and Aaron Anderson
   decl   : Theorems100.partition_theorem
 46:
   title  : The Solution of the General Quartic Equation
@@ -310,7 +310,7 @@
   decls  :
     - sum_range_pow
     - sum_Ico_pow
-  author : Moritz Firsching, Fabian Kruse, Ashvni Narayanan
+  author : Moritz Firsching and Fabian Kruse and Ashvni Narayanan
 78:
   title  : The Cauchy-Schwarz Inequality
   decls  :
@@ -336,7 +336,7 @@
   decls  :
     - Theorems100.Real.tendsto_sum_one_div_prime_atTop
     - not_summable_one_div_on_primes
-  author : Manuel Candales (archive), Michael Stoll (Mathlib)
+  author : Manuel Candales (archive), Michael Stoll (mathlib)
 82:
   title  : Dissection of Cubes (J.E. Littlewood’s ‘elegant’ proof)
   decl   : Theorems100.«82».cannot_cube_a_cube
@@ -344,7 +344,7 @@
 83:
   title  : The Friendship Theorem
   decl   : Theorems100.friendship_theorem
-  author : Aaron Anderson, Jalex Stark, Kyle Miller
+  author : Aaron Anderson and Jalex Stark and Kyle Miller
 84:
   title  : Morley’s Theorem
 85:
@@ -374,7 +374,7 @@
   title  : Stirling’s Formula
   decls  :
     - Stirling.tendsto_stirlingSeq_sqrt_pi
-  author : Moritz Firsching, Fabian Kruse, Nikolas Kuhn, Heather Macbeth
+  author : Moritz Firsching and Fabian Kruse and Nikolas Kuhn and Heather Macbeth
 91:
   title  : The Triangle Inequality
   decl   : norm_add_le
@@ -412,7 +412,7 @@
 98:
   title  : Bertrand’s Postulate
   decl   : Nat.bertrand
-  author : Bolton Bailey, Patrick Stevens
+  author : Bolton Bailey and Patrick Stevens
 99:
   title  : Buffon Needle Problem
   links  :


### PR DESCRIPTION
Standardise how multiple authors are listed, by
- removing a 'mathlib (author names)' identifier: it is apparent when results are in mathlib
- always using `and` to separate multiple authors of the same formalisation (the previous state used a mix of `and` and `,`, yielding inconsistent results on the webpage). Keep using `,` to separate authors of different formalisations.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
