### PR TITLE
[Merged by Bors] - feat(Algebra/Exact): iff lemmas

### DIFF
--- a/Mathlib/Algebra/Exact.lean
+++ b/Mathlib/Algebra/Exact.lean
@@ -416,7 +416,9 @@ namespace LinearMap
 
 /-- When we have a commutative diagram from a sequence of two linear maps to another,
 such that the left vertical map is surjective, the middle vertical map is bijective and the right
-vertical map is injective, then the upper row is exact iff the lower row is. -/
+vertical map is injective, then the upper row is exact iff the lower row is.
+See `ShortComplex.exact_iff_of_epi_of_isIso_of_mono` in the file
+`Algebra.Homology.ShortComplex.Exact` for the categorical version of this result. -/
 lemma exact_iff_of_surjective_of_bijective_of_injective
   {M₁ M₂ M₃ N₁ N₂ N₃ : Type*} [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
   [AddCommMonoid N₁] [AddCommMonoid N₂] [AddCommMonoid N₃]

--- a/Mathlib/Algebra/Exact.lean
+++ b/Mathlib/Algebra/Exact.lean
@@ -413,8 +413,8 @@ end Function
 namespace LinearMap
 
 /-- When we have a commutative diagram from a sequence of two linear maps to another,
-such that the left map is surjective, the middle map is bijective and the right
-map is injective, then the upper row is exact iff the lower row is. -/
+such that the left vertical map is surjective, the middle vertical map is bijective and the right
+vertical map is injective, then the upper row is exact iff the lower row is. -/
 lemma exact_iff_of_surjective_of_bijective_of_injective
   {M₁ M₂ M₃ N₁ N₂ N₃ : Type*} [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
   [AddCommMonoid N₁] [AddCommMonoid N₂] [AddCommMonoid N₃]

--- a/Mathlib/Algebra/Exact.lean
+++ b/Mathlib/Algebra/Exact.lean
@@ -90,6 +90,42 @@ lemma exact_of_comp_of_mem_range
     (h1 : g.comp f = 0) (h2 : ∀ x, g x = 0 → x ∈ range f) : Exact f g :=
   exact_of_comp_eq_zero_of_ker_le_range h1 h2
 
+/-- When we have a commutative diagram from a sequence of two maps to another,
+such that the left map is surjective, the middle map is bijective and the right
+map is injective, then the upper row is exact iff the lower row is. -/
+lemma exact_iff_of_surjective_of_bijective_of_injective
+  {M₁ M₂ M₃ N₁ N₂ N₃ : Type*} [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
+  [AddCommMonoid N₁] [AddCommMonoid N₂] [AddCommMonoid N₃]
+  (f : M₁ →+ M₂) (g : M₂ →+ M₃) (f' : N₁ →+ N₂) (g' : N₂ →+ N₃)
+  (τ₁ : M₁ →+ N₁) (τ₂ : M₂ →+ N₂) (τ₃ : M₃ →+ N₃)
+  (comm₁₂ : f'.comp τ₁ = τ₂.comp f)
+  (comm₂₃ : g'.comp τ₂ = τ₃.comp g)
+  (h₁ : Function.Surjective τ₁) (h₂ : Function.Bijective τ₂) (h₃ : Function.Injective τ₃) :
+    Exact f g ↔ Exact f' g' := by
+  replace comm₁₂ := DFunLike.congr_fun comm₁₂
+  replace comm₂₃ := DFunLike.congr_fun comm₂₃
+  dsimp at comm₁₂ comm₂₃
+  constructor
+  · intro h y₂
+    obtain ⟨x₂, rfl⟩ := h₂.2 y₂
+    constructor
+    · intro hx₂
+      obtain ⟨x₁, rfl⟩ := (h x₂).1 (h₃ (by simpa only [map_zero, comm₂₃] using hx₂))
+      exact ⟨τ₁ x₁, by simp only [comm₁₂]⟩
+    · rintro ⟨y₁, hy₁⟩
+      obtain ⟨x₁, rfl⟩ := h₁ y₁
+      rw [comm₂₃, (h x₂).2 _, map_zero]
+      exact ⟨x₁, h₂.1 (by simpa only [comm₁₂] using hy₁)⟩
+  · intro h x₂
+    constructor
+    · intro hx₂
+      obtain ⟨y₁, hy₁⟩ := (h (τ₂ x₂)).1 (by simp only [comm₂₃, hx₂, map_zero])
+      obtain ⟨x₁, rfl⟩ := h₁ y₁
+      exact ⟨x₁, h₂.1 (by simpa only [comm₁₂] using hy₁)⟩
+    · rintro ⟨x₁, rfl⟩
+      apply h₃
+      simp only [← comm₁₂, ← comm₂₃, h.apply_apply_eq_zero (τ₁ x₁), map_zero]
+
 end AddMonoidHom
 
 namespace Function.Exact
@@ -110,38 +146,18 @@ variable {X₁ X₂ X₃ Y₁ Y₂ Y₃ : Type*} [AddCommMonoid X₁] [AddCommMo
   (e₁ : X₁ ≃+ Y₁) (e₂ : X₂ ≃+ Y₂) (e₃ : X₃ ≃+ Y₃)
   {f₁₂ : X₁ →+ X₂} {f₂₃ : X₂ →+ X₃} {g₁₂ : Y₁ →+ Y₂} {g₂₃ : Y₂ →+ Y₃}
 
+lemma iff_of_ladder_addEquiv (comm₁₂ : g₁₂.comp e₁ = AddMonoidHom.comp e₂ f₁₂)
+    (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) : Exact g₁₂ g₂₃ ↔ Exact f₁₂ f₂₃ :=
+  (exact_iff_of_surjective_of_bijective_of_injective _ _ _ _ e₁ e₂ e₃ comm₁₂ comm₂₃
+    e₁.surjective e₂.bijective e₃.injective).symm
+
 lemma of_ladder_addEquiv_of_exact (comm₁₂ : g₁₂.comp e₁ = AddMonoidHom.comp e₂ f₁₂)
-    (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) (H : Exact f₁₂ f₂₃) : Exact g₁₂ g₂₃ := by
-  have h₁₂ := DFunLike.congr_fun comm₁₂
-  have h₂₃ := DFunLike.congr_fun comm₂₃
-  dsimp at h₁₂ h₂₃
-  apply of_comp_eq_zero_of_ker_in_range
-  · ext y₁
-    obtain ⟨x₁, rfl⟩ := e₁.surjective y₁
-    dsimp
-    rw [h₁₂, h₂₃, H.apply_apply_eq_zero, map_zero]
-  · intro y₂ hx₂
-    obtain ⟨x₂, rfl⟩ := e₂.surjective y₂
-    obtain ⟨x₁, rfl⟩ := (H x₂).1 (e₃.injective (by rw [← h₂₃, hx₂, map_zero]))
-    exact ⟨e₁ x₁, by rw [h₁₂]⟩
+    (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) (H : Exact f₁₂ f₂₃) : Exact g₁₂ g₂₃ :=
+  (iff_of_ladder_addEquiv _ _ _ comm₁₂ comm₂₃).2 H
 
 lemma of_ladder_addEquiv_of_exact' (comm₁₂ : g₁₂.comp e₁ = AddMonoidHom.comp e₂ f₁₂)
-    (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) (H : Exact g₁₂ g₂₃) : Exact f₁₂ f₂₃ := by
-  refine of_ladder_addEquiv_of_exact e₁.symm e₂.symm e₃.symm ?_ ?_ H
-  · ext y₁
-    obtain ⟨x₁, rfl⟩ := e₁.surjective y₁
-    apply e₂.injective
-    simpa using DFunLike.congr_fun comm₁₂.symm x₁
-  · ext y₂
-    obtain ⟨x₂, rfl⟩ := e₂.surjective y₂
-    apply e₃.injective
-    simpa using DFunLike.congr_fun comm₂₃.symm x₂
-
-lemma iff_of_ladder_addEquiv (comm₁₂ : g₁₂.comp e₁ = AddMonoidHom.comp e₂ f₁₂)
-    (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) : Exact g₁₂ g₂₃ ↔ Exact f₁₂ f₂₃ := by
-  constructor
-  · exact of_ladder_addEquiv_of_exact' e₁ e₂ e₃ comm₁₂ comm₂₃
-  · exact of_ladder_addEquiv_of_exact e₁ e₂ e₃ comm₁₂ comm₂₃
+    (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) (H : Exact g₁₂ g₂₃) : Exact f₁₂ f₂₃ :=
+  (iff_of_ladder_addEquiv _ _ _ comm₁₂ comm₂₃).1 H
 
 end
 
@@ -395,6 +411,24 @@ lemma Exact.exact_mapQ_iff
 end Function
 
 namespace LinearMap
+
+/-- When we have a commutative diagram from a sequence of two linear maps to another,
+such that the left map is surjective, the middle map is bijective and the right
+map is injective, then the upper row is exact iff the lower row is. -/
+lemma exact_iff_of_surjective_of_bijective_of_injective
+  {M₁ M₂ M₃ N₁ N₂ N₃ : Type*} [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
+  [AddCommMonoid N₁] [AddCommMonoid N₂] [AddCommMonoid N₃]
+  [Module R M₁] [Module R M₂] [Module R M₃]
+  [Module R N₁] [Module R N₂] [Module R N₃]
+  (f : M₁ →ₗ[R] M₂) (g : M₂ →ₗ[R] M₃) (f' : N₁ →ₗ[R] N₂) (g' : N₂ →ₗ[R] N₃)
+  (τ₁ : M₁ →ₗ[R] N₁) (τ₂ : M₂ →ₗ[R] N₂) (τ₃ : M₃ →ₗ[R] N₃)
+  (comm₁₂ : f'.comp τ₁ = τ₂.comp f) (comm₂₃ : g'.comp τ₂ = τ₃.comp g)
+  (h₁ : Function.Surjective τ₁) (h₂ : Function.Bijective τ₂) (h₃ : Function.Injective τ₃) :
+    Function.Exact f g ↔ Function.Exact f' g' :=
+  AddMonoidHom.exact_iff_of_surjective_of_bijective_of_injective
+    f.toAddMonoidHom g.toAddMonoidHom f'.toAddMonoidHom g'.toAddMonoidHom
+    τ₁.toAddMonoidHom τ₂.toAddMonoidHom τ₃.toAddMonoidHom
+    (by ext; apply DFunLike.congr_fun comm₁₂) (by ext; apply DFunLike.congr_fun comm₂₃) h₁ h₂ h₃
 
 lemma surjective_range_liftQ (h : range f ≤ ker g) (hg : Function.Surjective g) :
     Function.Surjective ((range f).liftQ g h) := by

--- a/Mathlib/Algebra/Exact.lean
+++ b/Mathlib/Algebra/Exact.lean
@@ -92,7 +92,9 @@ lemma exact_of_comp_of_mem_range
 
 /-- When we have a commutative diagram from a sequence of two maps to another,
 such that the left vertical map is surjective, the middle vertical map is bijective and the right vertical
-map is injective, then the upper row is exact iff the lower row is. -/
+map is injective, then the upper row is exact iff the lower row is.
+See `ShortComplex.exact_iff_of_epi_of_isIso_of_mono` in the file
+`Algebra.Homology.ShortComplex.Exact` for the categorical version of this result. -/
 lemma exact_iff_of_surjective_of_bijective_of_injective
   {M₁ M₂ M₃ N₁ N₂ N₃ : Type*} [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
   [AddCommMonoid N₁] [AddCommMonoid N₂] [AddCommMonoid N₃]

--- a/Mathlib/Algebra/Exact.lean
+++ b/Mathlib/Algebra/Exact.lean
@@ -91,7 +91,7 @@ lemma exact_of_comp_of_mem_range
   exact_of_comp_eq_zero_of_ker_le_range h1 h2
 
 /-- When we have a commutative diagram from a sequence of two maps to another,
-such that the left map is surjective, the middle map is bijective and the right
+such that the left vertical map is surjective, the middle vertical map is bijective and the right vertical
 map is injective, then the upper row is exact iff the lower row is. -/
 lemma exact_iff_of_surjective_of_bijective_of_injective
   {M₁ M₂ M₃ N₁ N₂ N₃ : Type*} [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]

--- a/Mathlib/Algebra/Exact.lean
+++ b/Mathlib/Algebra/Exact.lean
@@ -91,8 +91,8 @@ lemma exact_of_comp_of_mem_range
   exact_of_comp_eq_zero_of_ker_le_range h1 h2
 
 /-- When we have a commutative diagram from a sequence of two maps to another,
-such that the left vertical map is surjective, the middle vertical map is bijective and the right vertical
-map is injective, then the upper row is exact iff the lower row is.
+such that the left vertical map is surjective, the middle vertical map is bijective and the right
+vertical map is injective, then the upper row is exact iff the lower row is.
 See `ShortComplex.exact_iff_of_epi_of_isIso_of_mono` in the file
 `Algebra.Homology.ShortComplex.Exact` for the categorical version of this result. -/
 lemma exact_iff_of_surjective_of_bijective_of_injective


### PR DESCRIPTION
When we have a commutative diagram from a sequence of two maps to another, such that the left vertical map is surjective, the middle vertical map is bijective and the right vertical map is injective, then the upper row is exact iff the lower row is. This generalizes the case when all the three vertical maps are bijections. This PR introduces two new lemmas `exact_iff_of_surjective_of_bijective_of_injective` in the `AddMonoidHom` and `LinearMap` namespaces, and refactors the proofs of the all-bijections versions.

This parallels the categorical lemma https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Homology/ShortComplex/Exact.html#CategoryTheory.ShortComplex.exact_iff_of_epi_of_isIso_of_mono

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
