### PR TITLE
[Merged by Bors] - feat(Multiset/Fintype): `Multiset.ToType` equivalence between `v ::ₘ m` and `Option m`

### DIFF
--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -271,7 +271,7 @@ def consEquiv {v : α} : v ::ₘ m ≃ Option m where
     rintro (_ | x)
     · simp
     · simp only [Option.elim_some, Nat.zero_eq, Fin.coe_castLE, Fin.eta, Sigma.eta, dite_eq_ite,
-      ite_eq_right_iff, reduceCtorEq, imp_false, not_and]
+        ite_eq_right_iff, reduceCtorEq, imp_false, not_and]
       rintro rfl
       exact x.2.2.ne
 

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -304,8 +304,8 @@ There is some equivalence between `m` and `m.map f` which respects `f`.
 def mapEquiv_aux (m : Multiset α) (f : α → β) :
     Squash { v : m ≃ m.map f // ∀ a : m, v a = f a} :=
   Quotient.recOnSubsingleton m fun l ↦ .mk <|
-    List.recOn l ⟨@Equiv.equivOfIsEmpty _ _ (by dsimp; infer_instance) (by dsimp; infer_instance),
-      by simp⟩
+    List.recOn l
+      ⟨@Equiv.equivOfIsEmpty _ _ (by dsimp; infer_instance) (by dsimp; infer_instance), by simp⟩
       fun a s ⟨v, hv⟩ ↦ ⟨Multiset.consEquiv.trans v.optionCongr |>.trans
         Multiset.consEquiv.symm |>.trans (Multiset.cast (map_cons f a s)).symm, fun x ↦ by
         simp only [consEquiv, Equiv.trans_apply, Equiv.coe_fn_mk, Equiv.optionCongr_apply,

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -272,7 +272,8 @@ def consEquiv {v : α} : v ::ₘ m ≃ Option m where
     · simp
     · simp only [Option.elim_some, Nat.zero_eq, Fin.coe_castLE, Fin.eta, Sigma.eta, dite_eq_ite,
       ite_eq_right_iff, reduceCtorEq, imp_false, not_and]
-      apply ne_of_lt ∘ (· ▸ x.2.2)
+      rintro rfl
+      exact x.2.2.ne
 
 @[simp]
 lemma consEquiv_symm_none {v : α} :

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -277,25 +277,20 @@ lemma consEquiv_symm_none {v : α} :
 lemma coe_consEquiv_of_ne {v : α} (x : v ::ₘ m) (hx : ↑x ≠ v) :
     ↑(consEquiv x) = some x.1 := by simp [consEquiv, hx]
 
-private theorem mapEquiv_aux (m : Multiset α) (f : α → β) :
-    ∃ v : m ≃ m.map f, ∀ a : m, v a = f a := by
-  induction m using Multiset.induction with
-  | empty =>
-    simp only [map_zero, count_zero, Multiset.forall_coe, IsEmpty.forall_iff, implies_true]
-    use Equiv.equivOfIsEmpty _ _
-  | cons a s ih =>
-    obtain ⟨v, hv⟩ := ih
-    use Multiset.consEquiv.trans v.optionCongr |>.trans Multiset.consEquiv.symm |>.trans
-      (Multiset.cast (map_cons f a s)).symm
-    intro x
+def mapEquiv_aux (m : Multiset α) (f : α → β) :
+    Squash { v : m ≃ m.map f // ∀ a : m, v a = f a} :=
+  Quotient.recOnSubsingleton m (fun l ↦ .mk (List.recOn l
+    ⟨@Equiv.equivOfIsEmpty _ _ (by dsimp; infer_instance) (by dsimp; infer_instance), by simp⟩
+    fun a s ⟨v, hv⟩ ↦ ⟨Multiset.consEquiv.trans v.optionCongr |>.trans Multiset.consEquiv.symm
+      |>.trans (Multiset.cast (map_cons f a s)).symm, fun x ↦ by
     simp only [consEquiv, Equiv.trans_apply, Equiv.coe_fn_mk, Equiv.optionCongr_apply,
-      Equiv.coe_fn_symm_mk, cast_apply_fst]
-    split <;> simp_all
+        Equiv.coe_fn_symm_mk, cast_symm_apply_fst]
+    split <;> simp_all⟩))
 
 noncomputable def mapEquiv (s : Multiset α) (f : α → β) : s ≃ s.map f :=
-  (Multiset.mapEquiv_aux s f).choose
+  (Multiset.mapEquiv_aux s f).out.1
 
 theorem mapEquiv_apply (s : Multiset α) (f : α → β) (v : s) : s.mapEquiv f v = f v :=
-  (Multiset.mapEquiv_aux s f).choose_spec v
+  (Multiset.mapEquiv_aux s f).out.2 v
 
 end Multiset

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -280,8 +280,22 @@ lemma consEquiv_symm_none {v : α} :
       ⟨v, ⟨m.count v, (count_cons_self v m) ▸ (Nat.lt_add_one _)⟩⟩ :=
   rfl
 
+@[simp]
+lemma consEquiv_symm_some {v : α} {x : m} :
+    (consEquiv (v := v)).symm (some x) =
+      ⟨x, x.2.castLE (count_le_count_cons ..)⟩ :=
+  rfl
+
 lemma coe_consEquiv_of_ne {v : α} (x : v ::ₘ m) (hx : ↑x ≠ v) :
-    ↑(consEquiv x) = some x.1 := by simp [consEquiv, hx]
+    consEquiv x = some ⟨x.1, x.2.cast (by simp [hx])⟩ := by
+  simp [consEquiv, hx]
+  rfl
+
+lemma coe_consEquiv_of_eq_of_eq {v : α} (x : v ::ₘ m) (hx : ↑x = v) (hx2 : x.2 = m.count v) :
+    consEquiv x = none := by simp [consEquiv, hx, hx2]
+
+lemma coe_consEquiv_of_eq_of_lt {v : α} (x : v ::ₘ m) (hx : ↑x = v) (hx2 : x.2 < m.count v) :
+    consEquiv x = some ⟨x.1, ⟨x.2, by simpa [hx]⟩⟩ := by simp [consEquiv, hx, hx2.ne]
 
 /--
 There is some equivalence between `m` and `m.map f` which respects `f`.

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -303,6 +303,7 @@ One of the possible equivalences from `Multiset.mapEquiv_aux`, selected using ch
 noncomputable def mapEquiv (s : Multiset α) (f : α → β) : s ≃ s.map f :=
   (Multiset.mapEquiv_aux s f).out.1
 
+@[simp]
 theorem mapEquiv_apply (s : Multiset α) (f : α → β) (v : s) : s.mapEquiv f v = f v :=
   (Multiset.mapEquiv_aux s f).out.2 v
 

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -33,11 +33,13 @@ multiset enumeration
 -/
 
 
-variable {α : Type*} [DecidableEq α] {m : Multiset α}
+variable {α β : Type*} [DecidableEq α] [DecidableEq β] {m : Multiset α}
+
+namespace Multiset
 
 /-- Auxiliary definition for the `CoeSort` instance. This prevents the `CoeOut m α`
 instance from inadvertently applying to other sigma types. -/
-def Multiset.ToType (m : Multiset α) : Type _ := (x : α) × Fin (m.count x)
+def ToType (m : Multiset α) : Type _ := (x : α) × Fin (m.count x)
 
 /-- Create a type that has the same number of elements as the multiset.
 Terms of this type are triples `⟨x, ⟨i, h⟩⟩` where `x : α`, `i : ℕ`, and `h : i < m.count x`.
@@ -51,7 +53,7 @@ example : DecidableEq m := inferInstanceAs <| DecidableEq ((x : α) × Fin (m.co
 /-- Constructor for terms of the coercion of `m` to a type.
 This helps Lean pick up the correct instances. -/
 @[reducible, match_pattern]
-def Multiset.mkToType (m : Multiset α) (x : α) (i : Fin (m.count x)) : m :=
+def mkToType (m : Multiset α) (x : α) (i : Fin (m.count x)) : m :=
   ⟨x, i⟩
 
 /-- As a convenience, there is a coercion from `m : Type*` to `α` by projecting onto the first
@@ -64,18 +66,18 @@ instance instCoeSortMultisetType.instCoeOutToType : CoeOut m α :=
 -- Syntactic equality
 
 -- @[simp] -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10685): dsimp can prove this
-theorem Multiset.coe_mk {x : α} {i : Fin (m.count x)} : ↑(m.mkToType x i) = x :=
+theorem coe_mk {x : α} {i : Fin (m.count x)} : ↑(m.mkToType x i) = x :=
   rfl
 
-@[simp] lemma Multiset.coe_mem {x : m} : ↑x ∈ m := Multiset.count_pos.mp (by have := x.2.2; omega)
+@[simp] lemma coe_mem {x : m} : ↑x ∈ m := Multiset.count_pos.mp (by have := x.2.2; omega)
 
 @[simp]
-protected theorem Multiset.forall_coe (p : m → Prop) :
+protected theorem forall_coe (p : m → Prop) :
     (∀ x : m, p x) ↔ ∀ (x : α) (i : Fin (m.count x)), p ⟨x, i⟩ :=
   Sigma.forall
 
 @[simp]
-protected theorem Multiset.exists_coe (p : m → Prop) :
+protected theorem exists_coe (p : m → Prop) :
     (∃ x : m, p x) ↔ ∃ (x : α) (i : Fin (m.count x)), p ⟨x, i⟩ :=
   Sigma.exists
 
@@ -92,18 +94,16 @@ instance : Fintype { p : α × ℕ | p.2 < m.count p.1 } :=
 /-- Construct a finset whose elements enumerate the elements of the multiset `m`.
 The `ℕ` component is used to differentiate between equal elements: if `x` appears `n` times
 then `(x, 0)`, ..., and `(x, n-1)` appear in the `Finset`. -/
-def Multiset.toEnumFinset (m : Multiset α) : Finset (α × ℕ) :=
+def toEnumFinset (m : Multiset α) : Finset (α × ℕ) :=
   { p : α × ℕ | p.2 < m.count p.1 }.toFinset
 
 @[simp]
-theorem Multiset.mem_toEnumFinset (m : Multiset α) (p : α × ℕ) :
+theorem mem_toEnumFinset (m : Multiset α) (p : α × ℕ) :
     p ∈ m.toEnumFinset ↔ p.2 < m.count p.1 :=
   Set.mem_toFinset
 
-theorem Multiset.mem_of_mem_toEnumFinset {p : α × ℕ} (h : p ∈ m.toEnumFinset) : p.1 ∈ m :=
+theorem mem_of_mem_toEnumFinset {p : α × ℕ} (h : p ∈ m.toEnumFinset) : p.1 ∈ m :=
   have := (m.mem_toEnumFinset p).mp h; Multiset.count_pos.mp (by omega)
-
-namespace Multiset
 
 @[simp] lemma toEnumFinset_filter_eq (m : Multiset α) (a : α) :
     m.toEnumFinset.filter (·.1 = a) = {a} ×ˢ Finset.range (m.count a) := by aesop
@@ -132,24 +132,22 @@ namespace Multiset
     omega
   exact Nat.le_of_pred_lt (han.trans_lt <| by simpa using hsm hn)
 
-end Multiset
-
 @[mono]
-theorem Multiset.toEnumFinset_mono {m₁ m₂ : Multiset α} (h : m₁ ≤ m₂) :
+theorem toEnumFinset_mono {m₁ m₂ : Multiset α} (h : m₁ ≤ m₂) :
     m₁.toEnumFinset ⊆ m₂.toEnumFinset := by
   intro p
   simp only [Multiset.mem_toEnumFinset]
   exact gt_of_ge_of_gt (Multiset.le_iff_count.mp h p.1)
 
 @[simp]
-theorem Multiset.toEnumFinset_subset_iff {m₁ m₂ : Multiset α} :
+theorem toEnumFinset_subset_iff {m₁ m₂ : Multiset α} :
     m₁.toEnumFinset ⊆ m₂.toEnumFinset ↔ m₁ ≤ m₂ :=
   ⟨fun h ↦ by simpa using map_fst_le_of_subset_toEnumFinset h, Multiset.toEnumFinset_mono⟩
 
 /-- The embedding from a multiset into `α × ℕ` where the second coordinate enumerates repeats.
 If you are looking for the function `m → α`, that would be plain `(↑)`. -/
 @[simps]
-def Multiset.coeEmbedding (m : Multiset α) : m ↪ α × ℕ where
+def coeEmbedding (m : Multiset α) : m ↪ α × ℕ where
   toFun x := (x, x.2)
   inj' := by
     intro ⟨x, i, hi⟩ ⟨y, j, hj⟩
@@ -159,7 +157,7 @@ def Multiset.coeEmbedding (m : Multiset α) : m ↪ α × ℕ where
 /-- Another way to coerce a `Multiset` to a type is to go through `m.toEnumFinset` and coerce
 that `Finset` to a type. -/
 @[simps]
-def Multiset.coeEquiv (m : Multiset α) : m ≃ m.toEnumFinset where
+def coeEquiv (m : Multiset α) : m ≃ m.toEnumFinset where
   toFun x :=
     ⟨m.coeEmbedding x, by
       rw [Multiset.mem_toEnumFinset]
@@ -176,14 +174,14 @@ def Multiset.coeEquiv (m : Multiset α) : m ≃ m.toEnumFinset where
     rfl
 
 @[simp]
-theorem Multiset.toEmbedding_coeEquiv_trans (m : Multiset α) :
+theorem toEmbedding_coeEquiv_trans (m : Multiset α) :
     m.coeEquiv.toEmbedding.trans (Function.Embedding.subtype _) = m.coeEmbedding := by ext <;> rfl
 
 @[irreducible]
-instance Multiset.fintypeCoe : Fintype m :=
+instance fintypeCoe : Fintype m :=
   Fintype.ofEquiv m.toEnumFinset m.coeEquiv.symm
 
-theorem Multiset.map_univ_coeEmbedding (m : Multiset α) :
+theorem map_univ_coeEmbedding (m : Multiset α) :
     (Finset.univ : Finset m).map m.coeEmbedding = m.toEnumFinset := by
   ext ⟨x, i⟩
   simp only [Fin.exists_iff, Finset.mem_map, Finset.mem_univ, Multiset.coeEmbedding_apply,
@@ -191,7 +189,7 @@ theorem Multiset.map_univ_coeEmbedding (m : Multiset α) :
     exists_prop, exists_eq_right_right, exists_eq_right, Multiset.mem_toEnumFinset, true_and]
 
 @[simp]
-theorem Multiset.map_univ_coe (m : Multiset α) :
+theorem map_univ_coe (m : Multiset α) :
     (Finset.univ : Finset m).val.map (fun x : m ↦ (x : α)) = m := by
   have := m.map_toEnumFinset_fst
   rw [← m.map_univ_coeEmbedding] at this
@@ -199,36 +197,105 @@ theorem Multiset.map_univ_coe (m : Multiset α) :
     Function.comp_apply] using this
 
 @[simp]
-theorem Multiset.map_univ {β : Type*} (m : Multiset α) (f : α → β) :
+theorem map_univ {β : Type*} (m : Multiset α) (f : α → β) :
     ((Finset.univ : Finset m).val.map fun (x : m) ↦ f (x : α)) = m.map f := by
   erw [← Multiset.map_map, Multiset.map_univ_coe]
 
 @[simp]
-theorem Multiset.card_toEnumFinset (m : Multiset α) : m.toEnumFinset.card = Multiset.card m := by
+theorem card_toEnumFinset (m : Multiset α) : m.toEnumFinset.card = Multiset.card m := by
   rw [Finset.card, ← Multiset.card_map Prod.fst m.toEnumFinset.val]
   congr
   exact m.map_toEnumFinset_fst
 
 @[simp]
-theorem Multiset.card_coe (m : Multiset α) : Fintype.card m = Multiset.card m := by
+theorem card_coe (m : Multiset α) : Fintype.card m = Multiset.card m := by
   rw [Fintype.card_congr m.coeEquiv]
   simp only [Fintype.card_coe, card_toEnumFinset]
 
 @[to_additive]
-theorem Multiset.prod_eq_prod_coe [CommMonoid α] (m : Multiset α) : m.prod = ∏ x : m, (x : α) := by
+theorem prod_eq_prod_coe [CommMonoid α] (m : Multiset α) : m.prod = ∏ x : m, (x : α) := by
   congr
   simp
 
 @[to_additive]
-theorem Multiset.prod_eq_prod_toEnumFinset [CommMonoid α] (m : Multiset α) :
+theorem prod_eq_prod_toEnumFinset [CommMonoid α] (m : Multiset α) :
     m.prod = ∏ x ∈ m.toEnumFinset, x.1 := by
   congr
   simp
 
 @[to_additive]
-theorem Multiset.prod_toEnumFinset {β : Type*} [CommMonoid β] (m : Multiset α) (f : α → ℕ → β) :
+theorem prod_toEnumFinset {β : Type*} [CommMonoid β] (m : Multiset α) (f : α → ℕ → β) :
     ∏ x ∈ m.toEnumFinset, f x.1 x.2 = ∏ x : m, f x x.2 := by
   rw [Fintype.prod_equiv m.coeEquiv (fun x ↦ f x x.2) fun x ↦ f x.1.1 x.1.2]
   · rw [← m.toEnumFinset.prod_coe_sort fun x ↦ f x.1 x.2]
   · intro x
     rfl
+
+@[simps]
+def cast {s t : Multiset α} (h : s = t) : s ≃ t where
+  toFun x := ⟨x.1, x.2.cast (by simp [h])⟩
+  invFun x := ⟨x.1, x.2.cast (by simp [h])⟩
+  left_inv x := rfl
+  right_inv x := rfl
+
+instance : IsEmpty (0 : Multiset α) := Fintype.card_eq_zero_iff.mp (by simp)
+
+instance : IsEmpty (∅ : Multiset α) := Fintype.card_eq_zero_iff.mp (by simp)
+
+def consEquiv {v : α} : (v ::ₘ m) ≃ Option m where
+  toFun x := if h : x.1 = v ∧ x.2.val = m.count v then none else some ⟨x.1, ⟨x.2, by
+    by_cases hv : x.1 = v
+    · simp only [hv, true_and] at h ⊢
+      apply lt_of_le_of_ne (Nat.le_of_lt_add_one _) h
+      convert x.2.2 using 1
+      simp [hv]
+    · convert x.2.2 using 1
+      exact (count_cons_of_ne hv _).symm
+    ⟩⟩
+  invFun x := x.elim ⟨v, ⟨m.count v, by simp⟩⟩ (fun x ↦ ⟨x.1, x.2.castLE (count_le_count_cons ..)⟩)
+  left_inv := by
+    rintro ⟨x, hx⟩
+    dsimp only
+    split
+    · rename_i h
+      obtain ⟨rfl, h2⟩ := h
+      simp [← h2]
+    · simp
+  right_inv := by
+    rintro (_ | x)
+    · simp
+    · simp only [Option.elim_some, Nat.zero_eq, Fin.coe_castLE, Fin.eta, Sigma.eta, dite_eq_ite,
+      ite_eq_right_iff, reduceCtorEq, imp_false, not_and]
+      apply ne_of_lt ∘ (· ▸ x.2.2)
+
+@[simp]
+lemma consEquiv_symm_none {v : α} :
+    (consEquiv (m := m) (v := v)).symm none =
+      ⟨v, ⟨m.count v, (count_cons_self v m) ▸ (Nat.lt_add_one _)⟩⟩ :=
+  rfl
+
+lemma coe_consEquiv_of_ne {v : α} (x : v ::ₘ m) (hx : ↑x ≠ v) :
+    ↑(consEquiv x) = some x.1 := by simp [consEquiv, hx]
+
+private theorem mapEquiv_aux (m : Multiset α) (f : α → β) :
+    ∃ v : m ≃ m.map f, ∀ a : m, v a = f a := by
+  induction m using Multiset.induction with
+  | empty =>
+    simp only [map_zero, count_zero, Multiset.forall_coe, IsEmpty.forall_iff, implies_true]
+    use Equiv.equivOfIsEmpty _ _
+  | cons a s ih =>
+    obtain ⟨v, hv⟩ := ih
+    use Multiset.consEquiv.trans v.optionCongr |>.trans Multiset.consEquiv.symm |>.trans
+      (Multiset.cast (map_cons f a s)).symm
+    intro x
+    simp only [consEquiv, Equiv.trans_apply, Equiv.coe_fn_mk, Equiv.optionCongr_apply,
+      Equiv.coe_fn_symm_mk, cast_apply_fst]
+    split <;> simp_all
+
+noncomputable def mapEquiv (s : Multiset α) (f : α → β) : s ≃ s.map f :=
+  (Multiset.mapEquiv_aux s f).choose
+
+theorem mapEquiv_apply (s : Multiset α) (f : α → β) (v : s) : s.mapEquiv f v = f v :=
+  (Multiset.mapEquiv_aux s f).choose_spec v
+
+end Multiset

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -279,13 +279,14 @@ lemma coe_consEquiv_of_ne {v : α} (x : v ::ₘ m) (hx : ↑x ≠ v) :
 
 def mapEquiv_aux (m : Multiset α) (f : α → β) :
     Squash { v : m ≃ m.map f // ∀ a : m, v a = f a} :=
-  Quotient.recOnSubsingleton m (fun l ↦ .mk (List.recOn l
-    ⟨@Equiv.equivOfIsEmpty _ _ (by dsimp; infer_instance) (by dsimp; infer_instance), by simp⟩
-    fun a s ⟨v, hv⟩ ↦ ⟨Multiset.consEquiv.trans v.optionCongr |>.trans Multiset.consEquiv.symm
-      |>.trans (Multiset.cast (map_cons f a s)).symm, fun x ↦ by
-    simp only [consEquiv, Equiv.trans_apply, Equiv.coe_fn_mk, Equiv.optionCongr_apply,
-        Equiv.coe_fn_symm_mk, cast_symm_apply_fst]
-    split <;> simp_all⟩))
+  Quotient.recOnSubsingleton m fun l ↦ .mk <|
+    List.recOn l ⟨@Equiv.equivOfIsEmpty _ _ (by dsimp; infer_instance) (by dsimp; infer_instance),
+      by simp⟩
+      fun a s ⟨v, hv⟩ ↦ ⟨Multiset.consEquiv.trans v.optionCongr |>.trans
+        Multiset.consEquiv.symm |>.trans (Multiset.cast (map_cons f a s)).symm, fun x ↦ by
+        simp only [consEquiv, Equiv.trans_apply, Equiv.coe_fn_mk, Equiv.optionCongr_apply,
+            Equiv.coe_fn_symm_mk, cast_symm_apply_fst]
+        split <;> simp_all⟩
 
 noncomputable def mapEquiv (s : Multiset α) (f : α → β) : s ≃ s.map f :=
   (Multiset.mapEquiv_aux s f).out.1

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -231,6 +231,9 @@ theorem prod_toEnumFinset {β : Type*} [CommMonoid β] (m : Multiset α) (f : α
   · intro x
     rfl
 
+/--
+If `s = t` then there's an equivalence between the appropriate types.
+-/
 @[simps]
 def cast {s t : Multiset α} (h : s = t) : s ≃ t where
   toFun x := ⟨x.1, x.2.cast (by simp [h])⟩
@@ -242,7 +245,10 @@ instance : IsEmpty (0 : Multiset α) := Fintype.card_eq_zero_iff.mp (by simp)
 
 instance : IsEmpty (∅ : Multiset α) := Fintype.card_eq_zero_iff.mp (by simp)
 
-def consEquiv {v : α} : (v ::ₘ m) ≃ Option m where
+/--
+`v ::ₘ m` is equivalent to `Option m` by mapping one `v` to `none` and everything else to `m`.
+-/
+def consEquiv {v : α} : v ::ₘ m ≃ Option m where
   toFun x := if h : x.1 = v ∧ x.2.val = m.count v then none else some ⟨x.1, ⟨x.2, by
     by_cases hv : x.1 = v
     · simp only [hv, true_and] at h ⊢
@@ -277,6 +283,9 @@ lemma consEquiv_symm_none {v : α} :
 lemma coe_consEquiv_of_ne {v : α} (x : v ::ₘ m) (hx : ↑x ≠ v) :
     ↑(consEquiv x) = some x.1 := by simp [consEquiv, hx]
 
+/--
+There is some equivalence between `m` and `m.map f` which respects `f`.
+-/
 def mapEquiv_aux (m : Multiset α) (f : α → β) :
     Squash { v : m ≃ m.map f // ∀ a : m, v a = f a} :=
   Quotient.recOnSubsingleton m fun l ↦ .mk <|
@@ -288,6 +297,9 @@ def mapEquiv_aux (m : Multiset α) (f : α → β) :
             Equiv.coe_fn_symm_mk, cast_symm_apply_fst]
         split <;> simp_all⟩
 
+/--
+One of the possible equivalences from `Multiset.mapEquiv_aux`, selected using choice.
+-/
 noncomputable def mapEquiv (s : Multiset α) (f : α → β) : s ≃ s.map f :=
   (Multiset.mapEquiv_aux s f).out.1
 


### PR DESCRIPTION
Also add an arbitrary equivalence `s ≃ s.map f`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
