### PR TITLE
[Merged by Bors] - feat: relation of covering by cosets

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2146,6 +2146,7 @@ import Mathlib.Combinatorics.Additive.AP.Three.Defs
 import Mathlib.Combinatorics.Additive.CauchyDavenport
 import Mathlib.Combinatorics.Additive.Corner.Defs
 import Mathlib.Combinatorics.Additive.Corner.Roth
+import Mathlib.Combinatorics.Additive.CovBySMul
 import Mathlib.Combinatorics.Additive.Dissociation
 import Mathlib.Combinatorics.Additive.DoublingConst
 import Mathlib.Combinatorics.Additive.ETransform

--- a/Mathlib/Combinatorics/Additive/CovBySMul.lean
+++ b/Mathlib/Combinatorics/Additive/CovBySMul.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Pointwise.Finset.Basic
+import Mathlib.Data.Real.Basic
+
+/-!
+# Relation of covering by cosets
+
+This file defines a predicate for a set to be covered by at most `K` cosets of another set.
+
+This is a fundamental relation to study in additive combinatorics.
+-/
+
+open scoped Finset Pointwise
+
+variable {M N X : Type*} [Monoid M] [Monoid N] [MulAction M X] [MulAction N X] {K L : ℝ}
+  {A A₁ A₂ B B₁ B₂ C : Set X}
+
+variable (M) in
+/-- Predicate for a set `A` to be covered by at most `K` cosets of another set `B` under the action
+by the monoid `M`. -/
+@[to_additive "Predicate for a set `A` to be covered by at most `K` cosets of another set `B` under
+the action by the monoid `M`."]
+def CovBySMul (K : ℝ) (A B : Set X) : Prop := ∃ F : Finset M, #F ≤ K ∧ A ⊆ (F : Set M) • B
+
+@[to_additive (attr := simp, refl)]
+lemma CovBySMul.rfl : CovBySMul M 1 A A := ⟨1, by simp⟩
+
+@[to_additive (attr := simp)]
+lemma CovBySMul.of_subset (hAB : A ⊆ B) : CovBySMul M 1 A B := ⟨1, by simpa⟩
+
+@[to_additive] lemma CovBySMul.nonneg : CovBySMul M K A B → 0 ≤ K := by
+  rintro ⟨F, hF, -⟩; exact (#F).cast_nonneg.trans hF
+
+@[to_additive (attr := simp)]
+lemma covBySMul_zero : CovBySMul M 0 A B ↔ A = ∅ := by simp [CovBySMul]
+
+@[to_additive]
+lemma CovBySMul.mono (hKL : K ≤ L) : CovBySMul M K A B → CovBySMul M L A B := by
+  rintro ⟨F, hF, hFAB⟩; exact ⟨F, hF.trans hKL, hFAB⟩
+
+@[to_additive] lemma CovBySMul.trans [MulAction M N] [IsScalarTower M N X]
+    (hAB : CovBySMul M K A B) (hBC : CovBySMul N L B C) : CovBySMul N (K * L) A C := by
+  classical
+  have := hAB.nonneg
+  obtain ⟨F₁, hF₁, hFAB⟩ := hAB
+  obtain ⟨F₂, hF₂, hFBC⟩ := hBC
+  refine ⟨F₁ • F₂, ?_, ?_⟩
+  · calc
+      (#(F₁ • F₂) : ℝ) ≤ #F₁ * #F₂ := mod_cast Finset.card_smul_le
+      _ ≤ K * L := by gcongr
+  · calc
+      A ⊆ (F₁ : Set M) • B := hFAB
+      _ ⊆ (F₁ : Set M) • (F₂ : Set N) • C := by gcongr
+      _ = (↑(F₁ • F₂) : Set N) • C := by simp
+
+@[to_additive]
+lemma CovBySMul.subset_left (hA : A₁ ⊆ A₂) (hAB : CovBySMul M K A₂ B) :
+    CovBySMul M K A₁ B := by simpa using (CovBySMul.of_subset (M := M) hA).trans hAB
+
+@[to_additive]
+lemma CovBySMul.subset_right (hB : B₁ ⊆ B₂) (hAB : CovBySMul M K A B₁) :
+    CovBySMul M K A B₂ := by simpa using hAB.trans (.of_subset (M := M) hB)
+
+@[to_additive]
+lemma CovBySMul.subset (hA : A₁ ⊆ A₂) (hB : B₁ ⊆ B₂) (hAB : CovBySMul M K A₂ B₁) :
+    CovBySMul M K A₁ B₂ := (hAB.subset_left hA).subset_right hB


### PR DESCRIPTION
Define a predicate for a set to be covered by at most `K` cosets of another set.

This is a fundamental relation to study in additive combinatorics.

From GrowthInGroups (LeanCamCombi)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
