### PR TITLE
[Merged by Bors] - feat(Combinatorics/Additive): characterise sets with no doubling

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2152,11 +2152,11 @@ import Mathlib.Combinatorics.Additive.ETransform
 import Mathlib.Combinatorics.Additive.Energy
 import Mathlib.Combinatorics.Additive.ErdosGinzburgZiv
 import Mathlib.Combinatorics.Additive.FreimanHom
-import Mathlib.Combinatorics.Additive.NoDoubling
 import Mathlib.Combinatorics.Additive.PluenneckeRuzsa
 import Mathlib.Combinatorics.Additive.Randomisation
 import Mathlib.Combinatorics.Additive.RuzsaCovering
 import Mathlib.Combinatorics.Additive.SmallTripling
+import Mathlib.Combinatorics.Additive.VerySmallDoubling
 import Mathlib.Combinatorics.Colex
 import Mathlib.Combinatorics.Configuration
 import Mathlib.Combinatorics.Derangements.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2152,6 +2152,7 @@ import Mathlib.Combinatorics.Additive.ETransform
 import Mathlib.Combinatorics.Additive.Energy
 import Mathlib.Combinatorics.Additive.ErdosGinzburgZiv
 import Mathlib.Combinatorics.Additive.FreimanHom
+import Mathlib.Combinatorics.Additive.NoDoubling
 import Mathlib.Combinatorics.Additive.PluenneckeRuzsa
 import Mathlib.Combinatorics.Additive.Randomisation
 import Mathlib.Combinatorics.Additive.RuzsaCovering

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -740,11 +740,11 @@ theorem singleton_div_singleton (a b : α) : ({a} : Finset α) / {b} = {a / b} :
 theorem div_subset_div : s₁ ⊆ s₂ → t₁ ⊆ t₂ → s₁ / t₁ ⊆ s₂ / t₂ :=
   image₂_subset
 
-@[to_additive]
+@[to_additive (attr := gcongr)]
 theorem div_subset_div_left : t₁ ⊆ t₂ → s / t₁ ⊆ s / t₂ :=
   image₂_subset_left
 
-@[to_additive]
+@[to_additive (attr := gcongr)]
 theorem div_subset_div_right : s₁ ⊆ s₂ → s₁ / t ⊆ s₂ / t :=
   image₂_subset_right
 
@@ -1467,6 +1467,8 @@ end SMul
 section Mul
 
 variable [Mul α] [DecidableEq α] {s t u : Finset α} {a : α}
+
+@[to_additive] lemma smul_finset_subset_mul : a ∈ s → a • t ⊆ s * t := image_subset_image₂_right
 
 @[to_additive]
 theorem op_smul_finset_subset_mul : a ∈ t → op a • s ⊆ s * t :=

--- a/Mathlib/Combinatorics/Additive/NoDoubling.lean
+++ b/Mathlib/Combinatorics/Additive/NoDoubling.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2024 Yaël Dillies, Patrick Luo. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Patrick Luo
+-/
+import Mathlib.Algebra.Group.Pointwise.Finset.Basic
+import Mathlib.GroupTheory.GroupAction.Defs
+
+/-!
+# Sets with no doubling
+
+This file characterises sets with no doubling (finsets `A` such that `#(A ^ 2) = #A`) as the sets
+which are either empty or translates of a subgroup.
+-/
+
+open MulOpposite MulAction
+open scoped Pointwise RightActions
+
+namespace Finset
+variable {G : Type*} [Group G] [DecidableEq G] {A : Finset G}
+
+/-- A set with no doubling is either empty or the translate of a subgroup. -/
+@[to_additive "A set with no doubling is either empty or the translate of a subgroup."]
+lemma exists_subgroup_of_no_doubling (hA : #(A * A) ≤ #A) :
+    ∃ H : Subgroup G, ∀ a ∈ A, a •> (H : Set G) = A ∧ (H : Set G) <• a = A := by
+  have smul_A {a} (ha : a ∈ A) : a •> A = A * A :=
+    eq_of_subset_of_card_le (smul_finset_subset_mul ha) (by simpa)
+  have op_smul_A {a} (ha : a ∈ A) : A <• a = A * A :=
+    eq_of_subset_of_card_le (op_smul_finset_subset_mul ha) (by simpa)
+  have smul_A_eq_op_smul_A {a} (ha : a ∈ A) : a •> A = A <• a := by rw [smul_A ha, op_smul_A ha]
+  have smul_A_eq_op_smul_A' {a} (ha : a ∈ A) : a⁻¹ •> A = A <• a⁻¹ := by
+    rw [inv_smul_eq_iff, smul_comm, smul_A_eq_op_smul_A ha, op_inv, inv_smul_smul]
+  let H := stabilizer G A
+  have inv_smul_A {a} (ha : a ∈ A) : a⁻¹ • (A : Set G) = H := by
+    ext x
+    refine ⟨?_, fun hx ↦ ?_⟩
+    · rintro ⟨b, hb, rfl⟩
+      simp [H, mul_smul, inv_smul_eq_iff, smul_A ha, smul_A hb]
+    · norm_cast
+      rwa [smul_A_eq_op_smul_A' ha, op_inv, mem_inv_smul_finset_iff, op_smul_eq_mul, ← smul_eq_mul,
+        ← mem_inv_smul_finset_iff, inv_mem hx]
+  refine ⟨H, fun a ha ↦ ⟨?_, ?_⟩⟩
+  · rw [← inv_smul_A ha, smul_inv_smul]
+  · rw [← inv_smul_A ha, smul_comm]
+    norm_cast
+    rw [← smul_A_eq_op_smul_A ha, inv_smul_smul]
+
+end Finset

--- a/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
+++ b/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
@@ -14,7 +14,8 @@ which are either empty or translates of a subgroup.
 
 ## TODO
 
-Do we need a version stated using the doubling constant (`Finset.mulConst`)?
+* Do we need a version stated using the doubling constant (`Finset.mulConst`)?
+* Add characterisation for sets with doubling < 3/2
 -/
 
 open MulOpposite MulAction

--- a/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
+++ b/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
@@ -12,6 +12,9 @@ import Mathlib.GroupTheory.GroupAction.Defs
 This file characterises sets with no doubling (finsets `A` such that `#(A ^ 2) = #A`) as the sets
 which are either empty or translates of a subgroup.
 
+For the converse, use the existing facts from the pointwise API: `∅ ^ 2 = ∅` (`Finset.empty_pow`),
+`(a • H) ^ 2 = a ^ 2 • H ^ 2 = a ^ 2 • H` (`smul_pow`, `coe_set_pow`)
+
 ## TODO
 
 * Do we need a version stated using the doubling constant (`Finset.mulConst`)?

--- a/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
+++ b/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
@@ -11,6 +11,10 @@ import Mathlib.GroupTheory.GroupAction.Defs
 
 This file characterises sets with no doubling (finsets `A` such that `#(A ^ 2) = #A`) as the sets
 which are either empty or translates of a subgroup.
+
+## TODO
+
+Do we need a version stated using the doubling constant (`Finset.mulConst`)?
 -/
 
 open MulOpposite MulAction
@@ -19,15 +23,21 @@ open scoped Pointwise RightActions
 namespace Finset
 variable {G : Type*} [Group G] [DecidableEq G] {A : Finset G}
 
-/-- A set with no doubling is either empty or the translate of a subgroup. -/
-@[to_additive "A set with no doubling is either empty or the translate of a subgroup."]
+/-- A set with no doubling is either empty or the translate of a subgroup.
+
+Precisely, if `A` has no doubling then there exists a subgroup `H` such `aH = Ha = A` for all
+`a ∈ A`. -/
+@[to_additive "A set with no doubling is either empty or the translate of a subgroup.
+
+Precisely, if `A` has no doubling then there exists a subgroup `H` such `a + H = H + a = A` for all
+`a ∈ A`."]
 lemma exists_subgroup_of_no_doubling (hA : #(A * A) ≤ #A) :
     ∃ H : Subgroup G, ∀ a ∈ A, a •> (H : Set G) = A ∧ (H : Set G) <• a = A := by
   have smul_A {a} (ha : a ∈ A) : a •> A = A * A :=
     eq_of_subset_of_card_le (smul_finset_subset_mul ha) (by simpa)
-  have op_smul_A {a} (ha : a ∈ A) : A <• a = A * A :=
+  have A_smul {a} (ha : a ∈ A) : A <• a = A * A :=
     eq_of_subset_of_card_le (op_smul_finset_subset_mul ha) (by simpa)
-  have smul_A_eq_op_smul_A {a} (ha : a ∈ A) : a •> A = A <• a := by rw [smul_A ha, op_smul_A ha]
+  have smul_A_eq_op_smul_A {a} (ha : a ∈ A) : a •> A = A <• a := by rw [smul_A ha, A_smul ha]
   have smul_A_eq_op_smul_A' {a} (ha : a ∈ A) : a⁻¹ •> A = A <• a⁻¹ := by
     rw [inv_smul_eq_iff, smul_comm, smul_A_eq_op_smul_A ha, op_inv, inv_smul_smul]
   let H := stabilizer G A

--- a/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
+++ b/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 import Mathlib.GroupTheory.GroupAction.Defs
 
 /-!
-# Sets with no doubling
+# Sets with very small doubling
 
 This file characterises sets with no doubling (finsets `A` such that `#(A ^ 2) = #A`) as the sets
 which are either empty or translates of a subgroup.


### PR DESCRIPTION
They are exactly the empty set and cosets of a subgroup.

From LeanCamCombi

Co-authored-by: Patrick Luo


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
