### PR TITLE
[Merged by Bors] - chore(AlgebraicTopology): move Nerve.* to CategoryTheory.Nerve.*

### DIFF
--- a/Mathlib/AlgebraicTopology/Quasicategory/Nerve.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/Nerve.lean
@@ -19,13 +19,13 @@ a quasicategory.
 
 universe v u
 
-open CategoryTheory SSet
+open SSet
 
-namespace Nerve
+namespace CategoryTheory.Nerve
 
 /-- By virtue of satisfying the `StrictSegal` condition, the nerve of a
 category is a `Quasicategory`. -/
 instance quasicategory {C : Type u} [Category.{v} C] :
   Quasicategory (nerve C) := inferInstance
 
-end Nerve
+end CategoryTheory.Nerve

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StrictSegal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StrictSegal.lean
@@ -160,8 +160,6 @@ namespace CategoryTheory.Nerve
 
 open SSet
 
-variable {C : Type*} [Category C] {n : ℕ}
-
 /-- Simplices in the nerve of categories are uniquely determined by their spine. Indeed, this
 property describes the essential image of the nerve functor.-/
 noncomputable instance strictSegal (C : Type u) [Category.{v} C] : StrictSegal (nerve C) where

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StrictSegal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StrictSegal.lean
@@ -156,7 +156,7 @@ end StrictSegal
 
 end SSet
 
-namespace Nerve
+namespace CategoryTheory.Nerve
 
 open SSet
 
@@ -184,4 +184,4 @@ noncomputable instance strictSegal (C : Type u) [Category.{v} C] : StrictSegal (
     · intro i hi
       apply ComposableArrows.mkOfObjOfMapSucc_map_succ
 
-end Nerve
+end CategoryTheory.Nerve


### PR DESCRIPTION
Moves definitions to more appropriate namespaces:
- Nerve.strictSegal -> CategoryTheory.Nerve.strictSegal
- Nerve.quasicategory -> CategoryTheory.Nerve.quasicategory

Co-Authored-By: [Emily Riehl](https://github.com/emilyriehl)

---
I believe this is more consistent than `Nerve` being a top-level namespace given that we have `CategoryTheory.nerve` and `CategoryTheory.nerveFunctor`. Please let me know if there is a better way to organize these instances, though.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
