### PR TITLE
[Merged by Bors] - feat: zulip emoji reactions on public and `mathlib reviewers` channels

### DIFF
--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -31,7 +31,7 @@ public_response = client.get_messages({
     "num_after": 0,
     "narrow": [
         {"operator": "channels", "operand": "public"},
-        {"operator": "search", "operand": f'{PR_NUMBER}'},
+        {"operator": "search", "operand": f'#{PR_NUMBER}'},
     ],
 })
 
@@ -43,7 +43,7 @@ reviewers_response = client.get_messages({
     "num_after": 0,
     "narrow": [
         {"operator": "channel", "operand": "mathlib reviewers"},
-        {"operator": "search", "operand": f'{PR_NUMBER}'},
+        {"operator": "search", "operand": f'#{PR_NUMBER}'},
     ],
 })
 

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -23,15 +23,34 @@ client = zulip.Client(
     site=ZULIP_SITE
 )
 
-# Fetch the last 200 messages
-response = client.get_messages({
+# Fetch the messages containing the PR number from the public channels.
+# There does not seem to be a way to search simultaneously public and private channels.
+public_response = client.get_messages({
     "anchor": "newest",
-    "num_before": 200,
+    "num_before": 5000,
     "num_after": 0,
-    "narrow": [{"operator": "channel", "operand": "PR reviews"}],
+    "narrow": [
+        {"operator": "channels", "operand": "public"},
+        {"operator": "search", "operand": f'{PR_NUMBER}'},
+    ],
 })
 
-messages = response['messages']
+# Fetch the messages containing the PR number from the `mathlib reviewers` channel
+# There does not seem to be a way to search simultaneously public and private channels.
+reviewers_response = client.get_messages({
+    "anchor": "newest",
+    "num_before": 5000,
+    "num_after": 0,
+    "narrow": [
+        {"operator": "channel", "operand": "mathlib reviewers"},
+        {"operator": "search", "operand": f'{PR_NUMBER}'},
+    ],
+})
+
+print(f"public_response:{public_response}")
+print(f"reviewers_response:{reviewers_response}")
+
+messages = (public_response['messages']) + (reviewers_response['messages'])
 
 pr_pattern = re.compile(f'https://github.com/leanprover-community/mathlib4/pull/{PR_NUMBER}')
 


### PR DESCRIPTION
Updates the action that places emoji reactions triggered by `bors x`: now the reactions should be added to all public channels and to the `mathlib reviewers` channel.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
