### PR TITLE
[Merged by Bors] - refactor(LinearAlgebra/Matrix/GeneralLinearGroup): Redefine `Matrix.SpecialLinearGroup.toGL`and remove duplicate `toLinear`

### DIFF
--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -364,12 +364,12 @@ end RealAddAction
 /- these next few lemmas are *not* flagged `@simp` because of the constructors on the RHS;
 instead we use the versions with coercions to `ℂ` as simp lemmas instead. -/
 theorem modular_S_smul (z : ℍ) : ModularGroup.S • z = mk (-z : ℂ)⁻¹ z.im_inv_neg_coe_pos := by
-  rw [specialLinearGroup_apply]; simp [ModularGroup.S, neg_div, inv_neg, coeToGL]
+  rw [specialLinearGroup_apply]; simp [ModularGroup.S, neg_div, inv_neg, toGL]
 
 theorem modular_T_zpow_smul (z : ℍ) (n : ℤ) : ModularGroup.T ^ n • z = (n : ℝ) +ᵥ z := by
   rw [UpperHalfPlane.ext_iff, coe_vadd, add_comm, specialLinearGroup_apply, coe_mk]
   -- Porting note: added `coeToGL` and merged `rw` and `simp`
-  simp [coeToGL, ModularGroup.coe_T_zpow,
+  simp [toGL, ModularGroup.coe_T_zpow,
     of_apply, cons_val_zero, algebraMap.coe_one, Complex.ofReal_one, one_mul, cons_val_one,
     head_cons, algebraMap.coe_zero, zero_mul, zero_add, div_one]
 
@@ -383,7 +383,7 @@ theorem exists_SL2_smul_eq_of_apply_zero_one_eq_zero (g : SL(2, ℝ)) (hc : g 1 
   ext1 ⟨z, hz⟩; ext1
   suffices ↑a * z * a + b * a = b * a + a * a * z by
     -- Porting note: added `coeToGL` and merged `rw` and `simpa`
-    simpa [coeToGL, specialLinearGroup_apply, add_mul]
+    simpa [toGL, specialLinearGroup_apply, add_mul]
   ring
 
 theorem exists_SL2_smul_eq_of_apply_zero_one_ne_zero (g : SL(2, ℝ)) (hc : g 1 0 ≠ 0) :

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -70,7 +70,7 @@ def det : GL n R →* Rˣ where
   map_one' := Units.ext det_one
   map_mul' _ _ := Units.ext <| det_mul _ _
 
-/-- The `GL n R` and `Matrix.GeneralLinearGroup R n` groups are multiplicatively equivalent -/
+/-- The groups `GL n R` and `Matrix.GeneralLinearGroup R n` are multiplicatively equivalent -/
 def toLin : GL n R ≃* LinearMap.GeneralLinearGroup R (n → R) :=
   Units.mapEquiv toLinAlgEquiv'.toMulEquiv
 
@@ -109,22 +109,19 @@ theorem coe_inv : ↑A⁻¹ = (↑A : Matrix n n R)⁻¹ :=
   letI := A.invertible
   invOf_eq_nonsing_inv (↑A : Matrix n n R)
 
-/-- An element of the matrix general linear group on `(n) [Fintype n]` can be considered as an
-element of the endomorphism general linear group on `n → R`. -/
-def toLinear : GeneralLinearGroup n R ≃* LinearMap.GeneralLinearGroup R (n → R) :=
-  Units.mapEquiv Matrix.toLinAlgEquiv'.toRingEquiv.toMulEquiv
+@[deprecated (since := "2024-11-26")] alias toLinear := toLin
 
 -- Note that without the `@` and `‹_›`, Lean infers `fun a b ↦ _inst a b` instead of `_inst` as the
 -- decidability argument, which prevents `simp` from obtaining the instance by unification.
 -- These `fun a b ↦ _inst a b` terms also appear in the type of `A`, but simp doesn't get confused
 -- by them so for now we do not care.
 @[simp]
-theorem coe_toLinear : (@toLinear n ‹_› ‹_› _ _ A : (n → R) →ₗ[R] n → R) = Matrix.mulVecLin A :=
+theorem coe_toLin : (@toLin n ‹_› ‹_› _ _ A : (n → R) →ₗ[R] n → R) = Matrix.mulVecLin A :=
   rfl
 
 -- Porting note: is inserting toLinearEquiv here correct?
 @[simp]
-theorem toLinear_apply (v : n → R) : (toLinear A).toLinearEquiv v = Matrix.mulVecLin (↑A) v :=
+theorem toLin_apply (v : n → R) : (toLin A).toLinearEquiv v = Matrix.mulVecLin (↑A) v :=
   rfl
 
 end CoeLemmas

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -194,7 +194,7 @@ namespace SpecialLinearGroup
 variable {n : Type u} [DecidableEq n] [Fintype n] {R : Type v} [CommRing R]
 
 
-/-- `toGL` is the map from the special linear group to the general linear group -/
+/-- `toGL` is the map from the special linear group to the general linear group. -/
 def toGL : Matrix.SpecialLinearGroup n R →* Matrix.GeneralLinearGroup n R where
   toFun A :=  ⟨↑A, ↑A⁻¹,
     congr_arg Subtype.val (mul_inv_cancel A), congr_arg Subtype.val (inv_mul_cancel A)⟩

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -5,6 +5,7 @@ Authors: Chris Birkbeck
 -/
 import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+import Mathlib.LinearAlgebra.GeneralLinearGroup
 import Mathlib.Algebra.Ring.Subring.Units
 
 /-!

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -70,8 +70,8 @@ def det : GL n R →* Rˣ where
   map_one' := Units.ext det_one
   map_mul' _ _ := Units.ext <| det_mul _ _
 
-/-- The groups `GL n R` (notation for `Matrix.GeneralLinearGroup R n`) and
-`LinearMap.GeneralLinearGroup R n` are multiplicatively equivalent -/
+/-- The groups `GL n R` (notation for `Matrix.GeneralLinearGroup n R`) and
+`LinearMap.GeneralLinearGroup R (n → R)` are multiplicatively equivalent -/
 def toLin : GL n R ≃* LinearMap.GeneralLinearGroup R (n → R) :=
   Units.mapEquiv toLinAlgEquiv'.toMulEquiv
 

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -196,10 +196,9 @@ variable {n : Type u} [DecidableEq n] [Fintype n] {R : Type v} [CommRing R]
 
 /-- `toGL` is the map from the special linear group to the general linear group. -/
 def toGL : Matrix.SpecialLinearGroup n R →* Matrix.GeneralLinearGroup n R where
-  toFun A :=  ⟨↑A, ↑A⁻¹,
-    congr_arg Subtype.val (mul_inv_cancel A), congr_arg Subtype.val (inv_mul_cancel A)⟩
-  map_one' := Units.ext <| rfl
-  map_mul' _ _ := Units.ext <| rfl
+  toFun A := ⟨↑A, ↑A⁻¹, congr_arg (·.1) (mul_inv_cancel A), congr_arg (·.1) (inv_mul_cancel A)⟩
+  map_one' := Units.ext rfl
+  map_mul' _ _ := Units.ext rfl
 
 @[deprecated (since := "2024-11-26")] alias coeToGL := toGL
 

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -70,7 +70,8 @@ def det : GL n R →* Rˣ where
   map_one' := Units.ext det_one
   map_mul' _ _ := Units.ext <| det_mul _ _
 
-/-- The groups `GL n R` (notation for `Matrix.GeneralLinearGroup R n`) and `LinearMap.GeneralLinearGroup R n` are multiplicatively equivalent -/
+/-- The groups `GL n R` (notation for `Matrix.GeneralLinearGroup R n`) and
+`LinearMap.GeneralLinearGroup R n` are multiplicatively equivalent -/
 def toLin : GL n R ≃* LinearMap.GeneralLinearGroup R (n → R) :=
   Units.mapEquiv toLinAlgEquiv'.toMulEquiv
 

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -70,7 +70,7 @@ def det : GL n R →* Rˣ where
   map_one' := Units.ext det_one
   map_mul' _ _ := Units.ext <| det_mul _ _
 
-/-- The groups `GL n R` and `Matrix.GeneralLinearGroup R n` are multiplicatively equivalent -/
+/-- The groups `GL n R` and `LinearMap.GeneralLinearGroup R n` are multiplicatively equivalent -/
 def toLin : GL n R ≃* LinearMap.GeneralLinearGroup R (n → R) :=
   Units.mapEquiv toLinAlgEquiv'.toMulEquiv
 

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -195,17 +195,18 @@ namespace SpecialLinearGroup
 
 variable {n : Type u} [DecidableEq n] [Fintype n] {R : Type v} [CommRing R]
 
--- Porting note: added implementation for the Coe
-/-- The map from SL(n) to GL(n) underlying the coercion, forgetting the value of the determinant.
--/
-@[coe]
-def coeToGL (A : SpecialLinearGroup n R) : GL n R :=
-  ⟨↑A, ↑A⁻¹,
-    congr_arg ((↑) : _ → Matrix n n R) (mul_inv_cancel A),
-    congr_arg ((↑) : _ → Matrix n n R) (inv_mul_cancel A)⟩
+
+/-- `toGL` is the map from the special linear group to the general linear group -/
+def toGL : Matrix.SpecialLinearGroup n R →* Matrix.GeneralLinearGroup n R where
+  toFun A :=  ⟨↑A, ↑A⁻¹,
+    congr_arg Subtype.val (mul_inv_cancel A), congr_arg Subtype.val (inv_mul_cancel A)⟩
+  map_one' := Units.ext <| rfl
+  map_mul' _ _ := Units.ext <| rfl
+
+@[deprecated (since := "2024-11-26")] alias coeToGL := toGL
 
 instance hasCoeToGeneralLinearGroup : Coe (SpecialLinearGroup n R) (GL n R) :=
-  ⟨coeToGL⟩
+  ⟨toGL⟩
 
 @[simp]
 theorem coeToGL_det (g : SpecialLinearGroup n R) :

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -70,7 +70,7 @@ def det : GL n R →* Rˣ where
   map_one' := Units.ext det_one
   map_mul' _ _ := Units.ext <| det_mul _ _
 
-/-- The groups `GL n R` and `LinearMap.GeneralLinearGroup R n` are multiplicatively equivalent -/
+/-- The groups `GL n R` (notation for `Matrix.GeneralLinearGroup R n`) and `LinearMap.GeneralLinearGroup R n` are multiplicatively equivalent -/
 def toLin : GL n R ≃* LinearMap.GeneralLinearGroup R (n → R) :=
   Units.mapEquiv toLinAlgEquiv'.toMulEquiv
 

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -211,14 +211,6 @@ theorem toLin'_injective :
     Function.Injective ↑(toLin' : SpecialLinearGroup n R →* (n → R) ≃ₗ[R] n → R) := fun _ _ h =>
   Subtype.coe_injective <| Matrix.toLin'.injective <| LinearEquiv.toLinearMap_injective.eq_iff.mpr h
 
-/-- `toGL` is the map from the special linear group to the general linear group -/
-def toGL : SpecialLinearGroup n R →* GeneralLinearGroup R (n → R) :=
-  (GeneralLinearGroup.generalLinearEquiv _ _).symm.toMonoidHom.comp toLin'
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): broken dot notation
-theorem coe_toGL (A : SpecialLinearGroup n R) : SpecialLinearGroup.toGL A = A.toLin'.toLinearMap :=
-  rfl
-
 variable {S : Type*} [CommRing S]
 
 /-- A ring homomorphism from `R` to `S` induces a group homomorphism from

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen, Wen Yang
 -/
-import Mathlib.LinearAlgebra.GeneralLinearGroup
 import Mathlib.LinearAlgebra.Matrix.Adjugate
 import Mathlib.LinearAlgebra.Matrix.Transvection
 import Mathlib.RingTheory.RootsOfUnity.Basic

--- a/Mathlib/LinearAlgebra/Matrix/ToLinearEquiv.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLinearEquiv.lean
@@ -50,7 +50,7 @@ See `Matrix.toLinearEquiv` for the same map on arbitrary modules.
 -/
 def toLinearEquiv' (P : Matrix n n R) (_ : Invertible P) : (n → R) ≃ₗ[R] n → R :=
   GeneralLinearGroup.generalLinearEquiv _ _ <|
-    Matrix.GeneralLinearGroup.toLinear <| unitOfInvertible P
+    Matrix.GeneralLinearGroup.toLin <| unitOfInvertible P
 
 @[simp]
 theorem toLinearEquiv'_apply (P : Matrix n n R) (h : Invertible P) :

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -175,7 +175,7 @@ def lcRow0Extend {cd : Fin 2 → ℤ} (hcd : IsCoprime (cd 0) (cd 1)) :
     ![by
       refine
         LinearMap.GeneralLinearGroup.generalLinearEquiv ℝ (Fin 2 → ℝ)
-          (GeneralLinearGroup.toLinear (planeConformalMatrix (cd 0 : ℝ) (-(cd 1 : ℝ)) ?_))
+          (GeneralLinearGroup.toLin (planeConformalMatrix (cd 0 : ℝ) (-(cd 1 : ℝ)) ?_))
       norm_cast
       rw [neg_sq]
       exact hcd.sq_add_sq_ne_zero, LinearEquiv.refl ℝ (Fin 2 → ℝ)]
@@ -210,12 +210,12 @@ theorem tendsto_lcRow0 {cd : Fin 2 → ℤ} (hcd : IsCoprime (cd 0) (cd 1)) :
   · simp only [Fin.isValue, Int.cast_one, map_apply_coe, RingHom.mapMatrix_apply,
       Int.coe_castRingHom, lcRow0_apply, map_apply, Fin.zero_eta, id_eq, Function.comp_apply,
       of_apply, cons_val', cons_val_zero, empty_val', cons_val_fin_one, lcRow0Extend_apply,
-      LinearMap.GeneralLinearGroup.coeFn_generalLinearEquiv, GeneralLinearGroup.coe_toLinear,
+      LinearMap.GeneralLinearGroup.coeFn_generalLinearEquiv, GeneralLinearGroup.coe_toLin,
       val_planeConformalMatrix, neg_neg, mulVecLin_apply, mulVec, dotProduct, Fin.sum_univ_two,
       cons_val_one, head_cons, mB, f₁]
   · convert congr_arg (fun n : ℤ => (-n : ℝ)) g.det_coe.symm using 1
     simp only [Fin.zero_eta, id_eq, Function.comp_apply, lcRow0Extend_apply, cons_val_zero,
-      LinearMap.GeneralLinearGroup.coeFn_generalLinearEquiv, GeneralLinearGroup.coe_toLinear,
+      LinearMap.GeneralLinearGroup.coeFn_generalLinearEquiv, GeneralLinearGroup.coe_toLin,
       mulVecLin_apply, mulVec, dotProduct, det_fin_two, f₁]
     simp only [Fin.isValue, Fin.mk_one, val_planeConformalMatrix, neg_neg, of_apply, cons_val',
       empty_val', cons_val_fin_one, cons_val_one, head_fin_const, map_apply, Fin.sum_univ_two,


### PR DESCRIPTION
This PR redefines `Matrix.SpecialLinearGroup.toGL`, as the multiplicative map from the matrix group $$\mathrm{SL}_n(R)$$ to the matrix group $$\mathrm{GL}_n(R)$$, following a [Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Matrix.2ESpecialLinearGroup.2EtoGL). It also removes a duplicate of `Matrix.GeneralLinearGroup.toLin`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
