### PR TITLE
[Merged by Bors] - feat: `IntermediateField.rank_sup_le`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4181,6 +4181,7 @@ import Mathlib.RingTheory.Adjoin.Tower
 import Mathlib.RingTheory.AdjoinRoot
 import Mathlib.RingTheory.AlgebraTower
 import Mathlib.RingTheory.Algebraic
+import Mathlib.RingTheory.Algebraic.Cardinality
 import Mathlib.RingTheory.AlgebraicIndependent
 import Mathlib.RingTheory.Artinian
 import Mathlib.RingTheory.Bezout

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2972,6 +2972,7 @@ import Mathlib.FieldTheory.Minpoly.Field
 import Mathlib.FieldTheory.Minpoly.IsConjRoot
 import Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed
 import Mathlib.FieldTheory.Minpoly.MinpolyDiv
+import Mathlib.FieldTheory.MvRatFunc.Rank
 import Mathlib.FieldTheory.Normal
 import Mathlib.FieldTheory.NormalClosure
 import Mathlib.FieldTheory.Perfect

--- a/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Algebra.ZMod
 import Mathlib.Algebra.MvPolynomial.Cardinal
 import Mathlib.Algebra.Polynomial.Cardinal
 import Mathlib.FieldTheory.IsAlgClosed.Basic
+import Mathlib.RingTheory.Algebraic.Cardinality
 import Mathlib.RingTheory.AlgebraicIndependent
 
 /-!
@@ -28,59 +29,6 @@ universe u
 open scoped Cardinal Polynomial
 
 open Cardinal
-
-section AlgebraicClosure
-
-namespace Algebra.IsAlgebraic
-
-variable (R L : Type u) [CommRing R] [CommRing L] [IsDomain L] [Algebra R L]
-variable [NoZeroSMulDivisors R L] [Algebra.IsAlgebraic R L]
-
-theorem cardinalMk_le_sigma_polynomial :
-    #L ≤ #(Σ p : R[X], { x : L // x ∈ p.aroots L }) :=
-  @mk_le_of_injective L (Σ p : R[X], {x : L | x ∈ p.aroots L})
-    (fun x : L =>
-      let p := Classical.indefiniteDescription _ (Algebra.IsAlgebraic.isAlgebraic x)
-      ⟨p.1, x, by
-        dsimp
-        have h : p.1.map (algebraMap R L) ≠ 0 := by
-          rw [Ne, ← Polynomial.degree_eq_bot,
-            Polynomial.degree_map_eq_of_injective (NoZeroSMulDivisors.algebraMap_injective R L),
-            Polynomial.degree_eq_bot]
-          exact p.2.1
-        rw [Polynomial.mem_roots h, Polynomial.IsRoot, Polynomial.eval_map, ← Polynomial.aeval_def,
-          p.2.2]⟩)
-    fun x y => by
-      intro h
-      simp? at h says simp only [Set.coe_setOf, ne_eq, Set.mem_setOf_eq, Sigma.mk.inj_iff] at h
-      refine (Subtype.heq_iff_coe_eq ?_).1 h.2
-      simp only [h.1, forall_true_iff]
-
-@[deprecated (since := "2024-11-10")]
-alias cardinal_mk_le_sigma_polynomial := cardinalMk_le_sigma_polynomial
-
-/-- The cardinality of an algebraic extension is at most the maximum of the cardinality
-of the base ring or `ℵ₀`. -/
-@[stacks 09GK]
-theorem cardinalMk_le_max : #L ≤ max #R ℵ₀ :=
-  calc
-    #L ≤ #(Σ p : R[X], { x : L // x ∈ p.aroots L }) :=
-      cardinalMk_le_sigma_polynomial R L
-    _ = Cardinal.sum fun p : R[X] => #{x : L | x ∈ p.aroots L} := by
-      rw [← mk_sigma]; rfl
-    _ ≤ Cardinal.sum.{u, u} fun _ : R[X] => ℵ₀ :=
-      (sum_le_sum _ _ fun _ => (Multiset.finite_toSet _).lt_aleph0.le)
-    _ = #(R[X]) * ℵ₀ := sum_const' _ _
-    _ ≤ max (max #(R[X]) ℵ₀) ℵ₀ := mul_le_max _ _
-    _ ≤ max (max (max #R ℵ₀) ℵ₀) ℵ₀ :=
-      (max_le_max (max_le_max Polynomial.cardinalMk_le_max le_rfl) le_rfl)
-    _ = max #R ℵ₀ := by simp only [max_assoc, max_comm ℵ₀, max_left_comm ℵ₀, max_self]
-
-@[deprecated (since := "2024-11-10")] alias cardinal_mk_le_max := cardinalMk_le_max
-
-end Algebra.IsAlgebraic
-
-end AlgebraicClosure
 
 namespace IsAlgClosed
 

--- a/Mathlib/FieldTheory/MvRatFunc/Rank.lean
+++ b/Mathlib/FieldTheory/MvRatFunc/Rank.lean
@@ -22,15 +22,14 @@ theorem MvRatFunc.rank_eq_max_lift
     Module.rank F (FractionRing (MvPolynomial σ F)) = lift.{u} #F ⊔ lift.{v} #σ ⊔ ℵ₀ := by
   let R := MvPolynomial σ F
   let K := FractionRing R
-  refine le_antisymm ?_ ?_
-  · refine (rank_le_card _ _).trans ?_
-    rw [FractionRing.cardinalMk, MvPolynomial.cardinalMk_eq_max_lift]
-  · have hinj := IsFractionRing.injective R K
-    have h1 := (IsScalarTower.toAlgHom F R K).toLinearMap.rank_le_of_injective hinj
-    rw [MvPolynomial.rank_eq_lift, mk_finsupp_nat, lift_max, lift_aleph0, max_le_iff] at h1
-    obtain ⟨i⟩ := ‹Nonempty σ›
-    have hx : Transcendental F (algebraMap R K (MvPolynomial.X i)) :=
-      (transcendental_algebraMap_iff hinj).2 (MvPolynomial.transcendental_X F i)
-    have h2 := hx.linearIndependent_sub_inv.cardinal_lift_le_rank
-    rw [lift_id'.{v, u}, lift_umax.{v, u}] at h2
-    exact max_le_iff.2 ⟨max_le_iff.2 ⟨h2, h1.1⟩, h1.2⟩
+  refine ((rank_le_card _ _).trans ?_).antisymm ?_
+  · rw [FractionRing.cardinalMk, MvPolynomial.cardinalMk_eq_max_lift]
+  have hinj := IsFractionRing.injective R K
+  have h1 := (IsScalarTower.toAlgHom F R K).toLinearMap.rank_le_of_injective hinj
+  rw [MvPolynomial.rank_eq_lift, mk_finsupp_nat, lift_max, lift_aleph0, max_le_iff] at h1
+  obtain ⟨i⟩ := ‹Nonempty σ›
+  have hx : Transcendental F (algebraMap R K (MvPolynomial.X i)) :=
+    (transcendental_algebraMap_iff hinj).2 (MvPolynomial.transcendental_X F i)
+  have h2 := hx.linearIndependent_sub_inv.cardinal_lift_le_rank
+  rw [lift_id'.{v, u}, lift_umax.{v, u}] at h2
+  exact max_le (max_le h2 h1.1) h1.2

--- a/Mathlib/FieldTheory/MvRatFunc/Rank.lean
+++ b/Mathlib/FieldTheory/MvRatFunc/Rank.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2024 Jz Pan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jz Pan
+-/
+import Mathlib.Algebra.MvPolynomial.Cardinal
+import Mathlib.RingTheory.Algebraic
+import Mathlib.RingTheory.Localization.Cardinality
+import Mathlib.RingTheory.MvPolynomial
+
+/-!
+# Rank of multivariate rational function field
+-/
+
+noncomputable section
+
+universe u v
+
+open Cardinal in
+theorem MvRatFunc.rank_eq_max_lift
+    {σ : Type u} {F : Type v} [Field F] [Nonempty σ] :
+    Module.rank F (FractionRing (MvPolynomial σ F)) = lift.{u} #F ⊔ lift.{v} #σ ⊔ ℵ₀ := by
+  let R := MvPolynomial σ F
+  let K := FractionRing R
+  refine le_antisymm ?_ ?_
+  · refine (rank_le_card _ _).trans ?_
+    rw [FractionRing.cardinalMk, MvPolynomial.cardinalMk_eq_max_lift]
+  · have hinj := IsFractionRing.injective R K
+    have h1 := (IsScalarTower.toAlgHom F R K).toLinearMap.rank_le_of_injective hinj
+    rw [MvPolynomial.rank_eq_lift, mk_finsupp_nat, lift_max, lift_aleph0, max_le_iff] at h1
+    obtain ⟨i⟩ := ‹Nonempty σ›
+    have hx : Transcendental F (algebraMap R K (MvPolynomial.X i)) :=
+      (transcendental_algebraMap_iff hinj).2 (MvPolynomial.transcendental_X F i)
+    have h2 := hx.linearIndependent_sub_inv.cardinal_lift_le_rank
+    rw [lift_id'.{v, u}, lift_umax.{v, u}] at h2
+    exact max_le_iff.2 ⟨max_le_iff.2 ⟨h2, h1.1⟩, h1.2⟩

--- a/Mathlib/RingTheory/Algebraic.lean
+++ b/Mathlib/RingTheory/Algebraic.lean
@@ -955,13 +955,12 @@ end MvPolynomial
 section Infinite
 
 theorem Transcendental.infinite {R A : Type*} [CommRing R] [Ring A] [Algebra R A]
-    [Nontrivial R] {x : A} (hx : Transcendental R x) : Infinite A := by
-  rw [transcendental_iff_injective] at hx
-  exact Infinite.of_injective _ hx
+    [Nontrivial R] {x : A} (hx : Transcendental R x) : Infinite A :=
+  .of_injective _ (transcendental_iff_injective.mp hx)
 
 theorem Algebra.Transcendental.infinite (R A : Type*) [CommRing R] [Ring A] [Algebra R A]
-    [Nontrivial R] [Algebra.Transcendental R A] : Infinite A := by
-  obtain ⟨x, hx⟩ := ‹Algebra.Transcendental R A›
-  exact hx.infinite
+    [Nontrivial R] [Algebra.Transcendental R A] : Infinite A :=
+  have ⟨x, hx⟩ := ‹Algebra.Transcendental R A›
+  hx.infinite
 
 end Infinite

--- a/Mathlib/RingTheory/Algebraic.lean
+++ b/Mathlib/RingTheory/Algebraic.lean
@@ -951,3 +951,17 @@ theorem transcendental_supported_X_iff [Nontrivial R] {i : σ} {s : Set σ} :
     transcendental_supported_polynomial_aeval_X_iff R (i := i) (s := s) (f := Polynomial.X)
 
 end MvPolynomial
+
+section Infinite
+
+theorem Transcendental.infinite {R A : Type*} [CommRing R] [Ring A] [Algebra R A]
+    [Nontrivial R] {x : A} (hx : Transcendental R x) : Infinite A := by
+  rw [transcendental_iff_injective] at hx
+  exact Infinite.of_injective _ hx
+
+theorem Algebra.Transcendental.infinite (R A : Type*) [CommRing R] [Ring A] [Algebra R A]
+    [Nontrivial R] [Algebra.Transcendental R A] : Infinite A := by
+  obtain ⟨x, hx⟩ := ‹Algebra.Transcendental R A›
+  exact hx.infinite
+
+end Infinite

--- a/Mathlib/RingTheory/Algebraic/Cardinality.lean
+++ b/Mathlib/RingTheory/Algebraic/Cardinality.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2022 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes
+-/
+import Mathlib.Algebra.Polynomial.Cardinal
+import Mathlib.RingTheory.Algebraic
+
+/-!
+# Cardinality of algebraic extensions
+
+This file contains results on cardinality of algebraic extensions.
+-/
+
+
+universe u v
+
+open scoped Cardinal Polynomial
+
+open Cardinal
+
+namespace Algebra.IsAlgebraic
+
+variable (R : Type u) [CommRing R] (L : Type v) [CommRing L] [IsDomain L] [Algebra R L]
+variable [NoZeroSMulDivisors R L] [Algebra.IsAlgebraic R L]
+
+theorem lift_cardinalMk_le_sigma_polynomial :
+    lift.{u} #L ≤ #(Σ p : R[X], { x : L // x ∈ p.aroots L }) := by
+  have := @lift_mk_le_lift_mk_of_injective L (Σ p : R[X], {x : L | x ∈ p.aroots L})
+    (fun x : L =>
+      let p := Classical.indefiniteDescription _ (Algebra.IsAlgebraic.isAlgebraic x)
+      ⟨p.1, x, by
+        dsimp
+        have := (Polynomial.map_ne_zero_iff (NoZeroSMulDivisors.algebraMap_injective R L)).2 p.2.1
+        rw [Polynomial.mem_roots this, Polynomial.IsRoot, Polynomial.eval_map,
+          ← Polynomial.aeval_def, p.2.2]⟩)
+    fun x y => by
+      intro h
+      simp only [Set.coe_setOf, ne_eq, Set.mem_setOf_eq, Sigma.mk.inj_iff] at h
+      refine (Subtype.heq_iff_coe_eq ?_).1 h.2
+      simp only [h.1, forall_true_iff]
+  rwa [lift_umax, lift_id'.{v}] at this
+
+theorem lift_cardinalMk_le_max : lift.{u} #L ≤ lift.{v} #R ⊔ ℵ₀ :=
+  calc
+    lift.{u} #L ≤ #(Σ p : R[X], { x : L // x ∈ p.aroots L }) :=
+      lift_cardinalMk_le_sigma_polynomial R L
+    _ = Cardinal.sum fun p : R[X] => #{x : L | x ∈ p.aroots L} := by
+      rw [← mk_sigma]; rfl
+    _ ≤ Cardinal.sum.{u, v} fun _ : R[X] => ℵ₀ :=
+      (sum_le_sum _ _ fun _ => (Multiset.finite_toSet _).lt_aleph0.le)
+    _ = lift.{v} #(R[X]) * ℵ₀ := by rw [sum_const, lift_aleph0]
+    _ ≤ lift.{v} (#R ⊔ ℵ₀) ⊔ ℵ₀ ⊔ ℵ₀ := (mul_le_max _ _).trans <| by
+      gcongr; simp only [lift_le, Polynomial.cardinalMk_le_max]
+    _ = _ := by simp
+
+variable (L : Type u) [CommRing L] [IsDomain L] [Algebra R L]
+variable [NoZeroSMulDivisors R L] [Algebra.IsAlgebraic R L]
+
+theorem cardinalMk_le_sigma_polynomial :
+    #L ≤ #(Σ p : R[X], { x : L // x ∈ p.aroots L }) := by
+  simpa only [lift_id] using lift_cardinalMk_le_sigma_polynomial R L
+
+@[deprecated (since := "2024-11-10")]
+alias cardinal_mk_le_sigma_polynomial := cardinalMk_le_sigma_polynomial
+
+/-- The cardinality of an algebraic extension is at most the maximum of the cardinality
+of the base ring or `ℵ₀`. -/
+@[stacks 09GK]
+theorem cardinalMk_le_max : #L ≤ max #R ℵ₀ := by
+  simpa only [lift_id] using lift_cardinalMk_le_max R L
+
+@[deprecated (since := "2024-11-10")] alias cardinal_mk_le_max := cardinalMk_le_max
+
+end Algebra.IsAlgebraic

--- a/Mathlib/RingTheory/AlgebraicIndependent.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent.lean
@@ -753,13 +753,10 @@ theorem IsTranscendenceBasis.lift_cardinalMk_eq_max_lift
     {ι : Type w} {x : ι → E} [Nonempty ι] (hx : IsTranscendenceBasis F x) :
     lift.{max u w} #E = lift.{max v w} #F ⊔ lift.{max u v} #ι ⊔ ℵ₀ := by
   let K := Algebra.adjoin F (Set.range x)
-  suffices #E = #K by
-    rw [this, ← lift_mk_eq'.2 ⟨hx.1.aevalEquiv.toEquiv⟩]
-    simp
+  suffices #E = #K by simp [this, ← lift_mk_eq'.2 ⟨hx.1.aevalEquiv.toEquiv⟩]
   haveI : Algebra.IsAlgebraic K E := hx.isAlgebraic
   refine le_antisymm ?_ (mk_le_of_injective Subtype.val_injective)
-  obtain ⟨i⟩ := ‹Nonempty ι›
-  haveI : Infinite K := hx.1.aevalEquiv.toEquiv.infinite_iff.1 inferInstance
+  haveI : Infinite K := hx.1.aevalEquiv.infinite_iff.1 inferInstance
   simpa only [sup_eq_left.2 (aleph0_le_mk K)] using Algebra.IsAlgebraic.cardinalMk_le_max K E
 
 theorem IsTranscendenceBasis.lift_rank_eq_max_lift
@@ -769,12 +766,10 @@ theorem IsTranscendenceBasis.lift_rank_eq_max_lift
   let K := IntermediateField.adjoin F (Set.range x)
   haveI : Algebra.IsAlgebraic K E := hx.isAlgebraic_field
   rw [← rank_mul_rank F K E, lift_mul, ← hx.1.aevalEquivField.toLinearEquiv.lift_rank_eq,
-    MvRatFunc.rank_eq_max_lift, lift_max, lift_max, lift_lift, lift_lift,
-    lift_aleph0]
+    MvRatFunc.rank_eq_max_lift, lift_max, lift_max, lift_lift, lift_lift, lift_aleph0]
   refine mul_eq_left le_sup_right ((lift_le.2 ((rank_le_card K E).trans
     (Algebra.IsAlgebraic.cardinalMk_le_max K E))).trans_eq ?_) (by simp [rank_pos.ne'])
-  rw [lift_max, ← lift_mk_eq'.2 ⟨hx.1.aevalEquivField.toEquiv⟩]
-  simp
+  simp [← lift_mk_eq'.2 ⟨hx.1.aevalEquivField.toEquiv⟩]
 
 theorem Algebra.Transcendental.rank_eq_cardinalMk
     (F : Type u) (E : Type v) [Field F] [Field E] [Algebra F E] [Algebra.Transcendental F E] :
@@ -792,8 +787,7 @@ theorem IntermediateField.rank_sup_le
   · exact rank_sup_le_of_isAlgebraic A B (Or.inr hB)
   rw [← Algebra.transcendental_iff_not_isAlgebraic] at hA hB
   haveI : Algebra.Transcendental F ↥(A ⊔ B) := .ringHom_of_comp_eq (RingHom.id F)
-    (inclusion (le_sup_left : A ≤ A ⊔ B)) Function.surjective_id (inclusion_injective _)
-    (by ext; rfl)
+    (inclusion le_sup_left) Function.surjective_id (inclusion_injective _) rfl
   haveI := Algebra.Transcendental.infinite F A
   haveI := Algebra.Transcendental.infinite F B
   simp_rw [Algebra.Transcendental.rank_eq_cardinalMk]

--- a/Mathlib/RingTheory/AlgebraicIndependent.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent.lean
@@ -6,6 +6,8 @@ Authors: Chris Hughes
 import Mathlib.Algebra.MvPolynomial.Monad
 import Mathlib.Data.Fin.Tuple.Reflection
 import Mathlib.FieldTheory.Adjoin
+import Mathlib.FieldTheory.MvRatFunc.Rank
+import Mathlib.RingTheory.Algebraic.Cardinality
 import Mathlib.RingTheory.MvPolynomial.Basic
 
 /-!
@@ -56,7 +58,7 @@ open Function Set Subalgebra MvPolynomial Algebra
 
 open scoped Classical
 
-universe x u v w
+universe u v w
 
 variable {ι : Type*} {ι' : Type*} (R : Type*) {K : Type*}
 variable {A : Type*} {A' : Type*}
@@ -741,3 +743,68 @@ theorem algebraicIndependent_empty [Nontrivial A] :
   algebraicIndependent_empty_type
 
 end Field
+
+section RankAndCardinality
+
+open Cardinal
+
+theorem IsTranscendenceBasis.lift_cardinalMk_eq_max_lift
+    {F : Type u} {E : Type v} [CommRing F] [Nontrivial F] [CommRing E] [IsDomain E] [Algebra F E]
+    {ι : Type w} {x : ι → E} [Nonempty ι] (hx : IsTranscendenceBasis F x) :
+    lift.{max u w} #E = lift.{max v w} #F ⊔ lift.{max u v} #ι ⊔ ℵ₀ := by
+  let K := Algebra.adjoin F (Set.range x)
+  suffices #E = #K by
+    rw [this, ← lift_mk_eq'.2 ⟨hx.1.aevalEquiv.toEquiv⟩]
+    simp
+  haveI : Algebra.IsAlgebraic K E := hx.isAlgebraic
+  refine le_antisymm ?_ (mk_le_of_injective Subtype.val_injective)
+  obtain ⟨i⟩ := ‹Nonempty ι›
+  haveI : Infinite K := hx.1.aevalEquiv.toEquiv.infinite_iff.1 inferInstance
+  simpa only [sup_eq_left.2 (aleph0_le_mk K)] using Algebra.IsAlgebraic.cardinalMk_le_max K E
+
+theorem IsTranscendenceBasis.lift_rank_eq_max_lift
+    {F : Type u} {E : Type v} [Field F] [Field E] [Algebra F E]
+    {ι : Type w} {x : ι → E} [Nonempty ι] (hx : IsTranscendenceBasis F x) :
+    lift.{max u w} (Module.rank F E) = lift.{max v w} #F ⊔ lift.{max u v} #ι ⊔ ℵ₀ := by
+  let K := IntermediateField.adjoin F (Set.range x)
+  haveI : Algebra.IsAlgebraic K E := hx.isAlgebraic_field
+  rw [← rank_mul_rank F K E, lift_mul, ← hx.1.aevalEquivField.toLinearEquiv.lift_rank_eq,
+    MvRatFunc.rank_eq_max_lift, lift_max, lift_max, lift_lift, lift_lift,
+    lift_aleph0]
+  refine mul_eq_left le_sup_right ((lift_le.2 ((rank_le_card K E).trans
+    (Algebra.IsAlgebraic.cardinalMk_le_max K E))).trans_eq ?_) (by simp [rank_pos.ne'])
+  rw [lift_max, ← lift_mk_eq'.2 ⟨hx.1.aevalEquivField.toEquiv⟩]
+  simp
+
+theorem Algebra.Transcendental.rank_eq_cardinalMk
+    (F : Type u) (E : Type v) [Field F] [Field E] [Algebra F E] [Algebra.Transcendental F E] :
+    Module.rank F E = #E := by
+  obtain ⟨ι, x, hx⟩ := exists_isTranscendenceBasis' _ (algebraMap F E).injective
+  haveI := hx.nonempty_iff_transcendental.2 ‹_›
+  simpa [← hx.lift_cardinalMk_eq_max_lift] using hx.lift_rank_eq_max_lift
+
+theorem IntermediateField.rank_sup_le
+    {F : Type u} {E : Type v} [Field F] [Field E] [Algebra F E] (A B : IntermediateField F E) :
+    Module.rank F ↥(A ⊔ B) ≤ Module.rank F A * Module.rank F B := by
+  by_cases hA : Algebra.IsAlgebraic F A
+  · exact rank_sup_le_of_isAlgebraic A B (Or.inl hA)
+  by_cases hB : Algebra.IsAlgebraic F B
+  · exact rank_sup_le_of_isAlgebraic A B (Or.inr hB)
+  rw [← Algebra.transcendental_iff_not_isAlgebraic] at hA hB
+  haveI : Algebra.Transcendental F ↥(A ⊔ B) := .ringHom_of_comp_eq (RingHom.id F)
+    (inclusion (le_sup_left : A ≤ A ⊔ B)) Function.surjective_id (inclusion_injective _)
+    (by ext; rfl)
+  haveI := Algebra.Transcendental.infinite F A
+  haveI := Algebra.Transcendental.infinite F B
+  simp_rw [Algebra.Transcendental.rank_eq_cardinalMk]
+  rw [sup_def, mul_mk_eq_max, ← Cardinal.lift_le.{u}]
+  refine (lift_cardinalMk_adjoin_le _ _).trans ?_
+  calc
+    _ ≤ Cardinal.lift.{v} #F ⊔ Cardinal.lift.{u} (#A ⊔ #B) ⊔ ℵ₀ := by
+      gcongr
+      rw [Cardinal.lift_le]
+      exact (mk_union_le _ _).trans_eq (by simp)
+    _ = _ := by
+      simp [lift_mk_le_lift_mk_of_injective (algebraMap F A).injective]
+
+end RankAndCardinality


### PR DESCRIPTION
New results:

In `Mathlib/RingTheory/AlgebraicIndependent.lean`:

- `IsTranscendenceBasis.lift_(cardinalMk|rank)_eq_max_lift`: if `x` is a transcendence basis of `E/F` and is not empty, then `[E:F] = #E = max(#F, #x, ℵ₀)`
- `Algebra.Transcendental.rank_eq_cardinalMk`: if `E/F` is transcendental, then `[E:F] = #E`. (a corollary of above result)
- `IntermediateField.rank_sup_le`: if `A` and `B` are intermediate fields of `E/F`, then `[AB:F] ≤ [A:F] * [B:F]` (an application of above result)

In `Mathlib/RingTheory/Algebraic.lean`:

- `[Algebra.]Transcendental.infinite`: a ring has infinitely many elements if it has a transcendental element.

In `Mathlib/FieldTheory/MvRatFunc/Rank.lean` (new file):

- `MvRatFunc.rank_eq_max_lift`: rank of multivariate rational function field. Note that we don't have `MvRatFunc` yet, so the statement uses `FractionRing (MvPolynomial ...)`. Eventually the theory of `MvRatFunc` should go this directory.

Also move the results `Algebra.IsAlgebraic.[lift_]cardinalMk_le_XXX` from `Mathlib/FieldTheory/IsAlgClosed/Classification.lean` to a new file `Mathlib/RingTheory/Algebraic/Cardinality.lean` which has fewer imports.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Discussion: https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/.60IntermediateField.2Erank_sup_le.60

`[Algebra.]Transcendental.infinite` should go to `Mathlib/RingTheory/Algebraic/Defs.lean` I think, once #19370 is merged.
