### PR TITLE
[Merged by Bors] - chore(Pointwise): move auxiliary lemma out

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -1431,33 +1431,3 @@ variable {ι : Type*} {α : ι → Type*} [∀ i, Inv (α i)]
 lemma inv_pi (s : Set ι) (t : ∀ i, Set (α i)) : (s.pi t)⁻¹ = s.pi fun i ↦ (t i)⁻¹ := by ext x; simp
 
 end Set
-
-/-! ### Miscellaneous -/
-
-
-open Set
-
-open Pointwise
-
-namespace Group
-
-@[to_additive]
-theorem card_pow_eq_card_pow_card_univ_aux {f : ℕ → ℕ} (h1 : Monotone f) {B : ℕ} (h2 : ∀ n, f n ≤ B)
-    (h3 : ∀ n, f n = f (n + 1) → f (n + 1) = f (n + 2)) : ∀ k, B ≤ k → f k = f B := by
-  have key : ∃ n : ℕ, n ≤ B ∧ f n = f (n + 1) := by
-    contrapose! h2
-    suffices ∀ n : ℕ, n ≤ B + 1 → n ≤ f n by exact ⟨B + 1, this (B + 1) (le_refl (B + 1))⟩
-    exact fun n =>
-      Nat.rec (fun _ => Nat.zero_le (f 0))
-        (fun n ih h =>
-          lt_of_le_of_lt (ih (n.le_succ.trans h))
-            (lt_of_le_of_ne (h1 n.le_succ) (h2 n (Nat.succ_le_succ_iff.mp h))))
-        n
-  obtain ⟨n, hn1, hn2⟩ := key
-  replace key : ∀ k : ℕ, f (n + k) = f (n + k + 1) ∧ f (n + k) = f n := fun k =>
-    Nat.rec ⟨hn2, rfl⟩ (fun k ih => ⟨h3 _ ih.1, ih.1.symm.trans ih.2⟩) k
-  replace key : ∀ k : ℕ, n ≤ k → f k = f n := fun k hk =>
-    (congr_arg f (Nat.add_sub_of_le hk)).symm.trans (key (k - n)).2
-  exact fun k hk => (key k (hn1.trans hk)).trans (key B hn1).symm
-
-end Group

--- a/Mathlib/Algebra/Group/Pointwise/Set/Finite.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Finite.lean
@@ -181,7 +181,7 @@ theorem card_pow_eq_card_pow_card_univ [∀ k : ℕ, DecidablePred (· ∈ S ^ k
     exact Subtype.ext (mul_right_cancel (Subtype.ext_iff.mp hbc))
   have mono : Monotone (fun n ↦ Fintype.card (↥(S ^ n)) : ℕ → ℕ) :=
     monotone_nat_of_le_succ fun n ↦ key a _ _ fun b hb ↦ Set.mul_mem_mul hb ha
-  refine Nat.stabilises_of_monotone mono (fun n ↦ set_fintype_card_le_univ (S ^ n))
+  refine fun _ ↦ Nat.stabilises_of_monotone mono (fun n ↦ set_fintype_card_le_univ (S ^ n))
     fun n h ↦ le_antisymm (mono (n + 1).le_succ) (key a⁻¹ (S ^ (n + 2)) (S ^ (n + 1)) ?_)
   replace h₂ : S ^ n * {a} = S ^ (n + 1) := by
     have : Fintype (S ^ n * Set.singleton a) := by

--- a/Mathlib/Algebra/Group/Pointwise/Set/Finite.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Finite.lean
@@ -181,7 +181,7 @@ theorem card_pow_eq_card_pow_card_univ [∀ k : ℕ, DecidablePred (· ∈ S ^ k
     exact Subtype.ext (mul_right_cancel (Subtype.ext_iff.mp hbc))
   have mono : Monotone (fun n ↦ Fintype.card (↥(S ^ n)) : ℕ → ℕ) :=
     monotone_nat_of_le_succ fun n ↦ key a _ _ fun b hb ↦ Set.mul_mem_mul hb ha
-  refine card_pow_eq_card_pow_card_univ_aux mono (fun n ↦ set_fintype_card_le_univ (S ^ n))
+  refine Nat.stabilises_of_monotone mono (fun n ↦ set_fintype_card_le_univ (S ^ n))
     fun n h ↦ le_antisymm (mono (n + 1).le_succ) (key a⁻¹ (S ^ (n + 2)) (S ^ (n + 1)) ?_)
   replace h₂ : S ^ n * {a} = S ^ (n + 1) := by
     have : Fintype (S ^ n * Set.singleton a) := by

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -10,6 +10,7 @@ import Mathlib.Order.Compare
 import Mathlib.Order.Max
 import Mathlib.Order.RelClasses
 import Mathlib.Tactic.Coe
+import Mathlib.Tactic.Contrapose
 import Mathlib.Tactic.Choose
 
 /-!
@@ -1104,3 +1105,26 @@ alias ⟨Monotone.apply₂, Monotone.of_apply₂⟩ := monotone_iff_apply₂
 alias ⟨Antitone.apply₂, Antitone.of_apply₂⟩ := antitone_iff_apply₂
 
 end apply
+
+/-- A monotone function `f : ℕ → ℕ` bounded by `B`, which is constant after stabilising for the
+first time, stabilises in at most `B` steps. -/
+lemma Nat.stabilises_of_monotone {f : ℕ → ℕ} {b n : ℕ} (hfmono : Monotone f) (hfb : ∀ m, f m ≤ b)
+    (hfstab : ∀ m, f m = f (m + 1) → f (m + 1) = f (m + 2)) (hbn : b ≤ n) : f n = f b := by
+  obtain ⟨m, hmb, hm⟩ : ∃ m ≤ b, f m = f (m + 1) := by
+    contrapose! hfb
+    let rec strictMono : ∀ m ≤ b + 1, m ≤ f m
+    | 0, _ => Nat.zero_le _
+    | m + 1, hmb => (strictMono _ <| m.le_succ.trans hmb).trans_lt <| (hfmono m.le_succ).lt_of_ne <|
+        hfb _ <| Nat.le_of_succ_le_succ hmb
+    exact ⟨b + 1, strictMono _ le_rfl⟩
+  replace key : ∀ k : ℕ, f (m + k) = f (m + k + 1) ∧ f (m + k) = f m := fun k =>
+    Nat.rec ⟨hm, rfl⟩ (fun k ih => ⟨hfstab _ ih.1, ih.1.symm.trans ih.2⟩) k
+  replace key : ∀ k ≥ m, f k = f m := fun k hk =>
+    (congr_arg f (Nat.add_sub_of_le hk)).symm.trans (key (k - m)).2
+  exact (key n (hmb.trans hbn)).trans (key b hmb).symm
+
+@[deprecated (since := "2024-11-27")]
+alias Group.card_pow_eq_card_pow_card_univ_aux := Nat.stabilises_of_monotone
+
+@[deprecated (since := "2024-11-27")]
+alias Group.card_nsmul_eq_card_nsmulpow_card_univ_aux := Nat.stabilises_of_monotone

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -1106,8 +1106,8 @@ alias ⟨Antitone.apply₂, Antitone.of_apply₂⟩ := antitone_iff_apply₂
 
 end apply
 
-/-- A monotone function `f : ℕ → ℕ` bounded by `B`, which is constant after stabilising for the
-first time, stabilises in at most `B` steps. -/
+/-- A monotone function `f : ℕ → ℕ` bounded by `b`, which is constant after stabilising for the
+first time, stabilises in at most `b` steps. -/
 lemma Nat.stabilises_of_monotone {f : ℕ → ℕ} {b n : ℕ} (hfmono : Monotone f) (hfb : ∀ m, f m ≤ b)
     (hfstab : ∀ m, f m = f (m + 1) → f (m + 1) = f (m + 2)) (hbn : b ≤ n) : f n = f b := by
   obtain ⟨m, hmb, hm⟩ : ∃ m ≤ b, f m = f (m + 1) := by


### PR DESCRIPTION
This has nothing to do with pointwise actions and doesn't need to be additivised


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
