### PR TITLE
[Merged by Bors] - feat: `s ⊆ s ^ n` when `1 ∈ s`

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -968,6 +968,10 @@ lemma pow_subset_pow_right (hs : 1 ∈ s) (hmn : m ≤ n) : s ^ m ⊆ s ^ n :=
 lemma pow_subset_pow (hst : s ⊆ t) (ht : 1 ∈ t) (hmn : m ≤ n) : s ^ m ⊆ t ^ n :=
   (pow_subset_pow_left hst).trans (pow_subset_pow_right ht hmn)
 
+@[to_additive]
+lemma subset_pow (hs : 1 ∈ s) (hn : n ≠ 0) : s ⊆ s ^ n := by
+  simpa using pow_subset_pow_right hs <| Nat.one_le_iff_ne_zero.2 hn
+
 @[deprecated (since := "2024-11-19")] alias pow_subset_pow_of_one_mem := pow_subset_pow_right
 
 @[deprecated (since := "2024-11-19")]
@@ -1515,7 +1519,16 @@ end Semigroup
 
 section IsLeftCancelMul
 
-variable [Mul α] [IsLeftCancelMul α] [DecidableEq α] (s t : Finset α) (a : α)
+variable [Mul α] [IsLeftCancelMul α] [DecidableEq α] {s t : Finset α} {a : α}
+
+@[to_additive]
+lemma Nontrivial.mul_left : t.Nontrivial → s.Nonempty → (s * t).Nontrivial := by
+  rintro ⟨a, ha, b, hb, hab⟩ ⟨c, hc⟩
+  exact ⟨c * a, mul_mem_mul hc ha, c * b, mul_mem_mul hc hb, by simpa⟩
+
+@[to_additive]
+lemma Nontrivial.mul (hs : s.Nontrivial) (ht : t.Nontrivial) : (s * t).Nontrivial :=
+  ht.mul_left hs.nonempty
 
 @[to_additive]
 theorem pairwiseDisjoint_smul_iff {s : Set α} {t : Finset α} :
@@ -1523,11 +1536,11 @@ theorem pairwiseDisjoint_smul_iff {s : Set α} {t : Finset α} :
   simp_rw [← pairwiseDisjoint_coe, coe_smul_finset, Set.pairwiseDisjoint_smul_iff]
 
 @[to_additive (attr := simp)]
-theorem card_singleton_mul : ({a} * t).card = t.card :=
+theorem card_singleton_mul (a : α) (t : Finset α) : ({a} * t).card = t.card :=
   card_image₂_singleton_left _ <| mul_right_injective _
 
 @[to_additive]
-theorem singleton_mul_inter : {a} * (s ∩ t) = {a} * s ∩ ({a} * t) :=
+theorem singleton_mul_inter (a : α) (s t : Finset α) : {a} * (s ∩ t) = {a} * s ∩ ({a} * t) :=
   image₂_singleton_inter _ _ <| mul_right_injective _
 
 @[to_additive]
@@ -1547,20 +1560,25 @@ theorem card_le_card_mul_self {s : Finset α} : s.card ≤ (s * s).card := by
 
 end IsLeftCancelMul
 
-section
+section IsRightCancelMul
 
-variable [Mul α] [IsRightCancelMul α] [DecidableEq α] (s t : Finset α) (a : α)
+variable [Mul α] [IsRightCancelMul α] [DecidableEq α] {s t : Finset α} {a : α}
+
+@[to_additive]
+lemma Nontrivial.mul_right : s.Nontrivial → t.Nonempty → (s * t).Nontrivial := by
+  rintro ⟨a, ha, b, hb, hab⟩ ⟨c, hc⟩
+  exact ⟨a * c, mul_mem_mul ha hc, b * c, mul_mem_mul hb hc, by simpa⟩
 
 @[to_additive (attr := simp)]
-theorem card_mul_singleton : (s * {a}).card = s.card :=
+theorem card_mul_singleton (s : Finset α) (a : α) : (s * {a}).card = s.card :=
   card_image₂_singleton_right _ <| mul_left_injective _
 
 @[to_additive]
-theorem inter_mul_singleton : s ∩ t * {a} = s * {a} ∩ (t * {a}) :=
+theorem inter_mul_singleton (s t : Finset α) (a : α) : s ∩ t * {a} = s * {a} ∩ (t * {a}) :=
   image₂_inter_singleton _ _ <| mul_left_injective _
 
 @[to_additive]
-theorem card_le_card_mul_right {t : Finset α} (ht : t.Nonempty) : s.card ≤ (s * t).card :=
+theorem card_le_card_mul_right (ht : t.Nonempty) : s.card ≤ (s * t).card :=
   card_le_card_image₂_right _ ht mul_left_injective
 
 /--
@@ -1571,18 +1589,23 @@ See `card_le_card_mul_self` for the version with left-cancellative multiplicatio
 "The size of `s + s` is at least the size of `s`, version with right-cancellative addition.
 See `card_le_card_add_self` for the version with left-cancellative addition."
 ]
-theorem card_le_card_mul_self' {s : Finset α} : s.card ≤ (s * s).card := by
+theorem card_le_card_mul_self' : s.card ≤ (s * s).card := by
   cases s.eq_empty_or_nonempty <;> simp [card_le_card_mul_right, *]
 
-end
+end IsRightCancelMul
 
 section CancelMonoid
 variable [DecidableEq α] [CancelMonoid α] {s : Finset α} {m n : ℕ}
 
+@[to_additive]
+lemma Nontrivial.pow (hs : s.Nontrivial) : ∀ {n}, n ≠ 0 → (s ^ n).Nontrivial
+  | 1, _ => by simpa
+  | n + 2, _ => by simpa [pow_succ] using (hs.pow n.succ_ne_zero).mul hs
+
 /-- See `Finset.card_pow_mono` for a version that works for the empty set. -/
 @[to_additive "See `Finset.card_nsmul_mono` for a version that works for the empty set."]
 protected lemma Nonempty.card_pow_mono (hs : s.Nonempty) : Monotone fun n : ℕ ↦ (s ^ n).card :=
-  monotone_nat_of_le_succ fun n ↦ by rw [pow_succ]; exact card_le_card_mul_right _ hs
+  monotone_nat_of_le_succ fun n ↦ by rw [pow_succ]; exact card_le_card_mul_right hs
 
 /-- See `Finset.Nonempty.card_pow_mono` for a version that works for zero powers. -/
 @[to_additive "See `Finset.Nonempty.card_nsmul_mono` for a version that works for zero scalars."]

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -1097,6 +1097,10 @@ lemma pow_subset_pow_right (hs : 1 ∈ s) (hmn : m ≤ n) : s ^ m ⊆ s ^ n :=
 lemma pow_subset_pow (hst : s ⊆ t) (ht : 1 ∈ t) (hmn : m ≤ n) : s ^ m ⊆ t ^ n :=
   (pow_subset_pow_left hst).trans (pow_subset_pow_right ht hmn)
 
+@[to_additive]
+lemma subset_pow (hs : 1 ∈ s) (hn : n ≠ 0) : s ⊆ s ^ n := by
+  simpa using pow_subset_pow_right hs <| Nat.one_le_iff_ne_zero.2 hn
+
 @[deprecated (since := "2024-11-19")] alias pow_subset_pow_of_one_mem := pow_subset_pow_right
 
 @[deprecated (since := "2024-11-19")]
@@ -1162,6 +1166,40 @@ protected theorem _root_.IsUnit.set : IsUnit a → IsUnit ({a} : Set α) :=
   IsUnit.map (singletonMonoidHom : α →* Set α)
 
 end Monoid
+
+section IsLeftCancelMul
+variable [Mul α] [IsLeftCancelMul α] {s t : Set α}
+
+@[to_additive]
+lemma Nontrivial.mul_left : t.Nontrivial → s.Nonempty → (s * t).Nontrivial := by
+  rintro ⟨a, ha, b, hb, hab⟩ ⟨c, hc⟩
+  exact ⟨c * a, mul_mem_mul hc ha, c * b, mul_mem_mul hc hb, by simpa⟩
+
+@[to_additive]
+lemma Nontrivial.mul (hs : s.Nontrivial) (ht : t.Nontrivial) : (s * t).Nontrivial :=
+  ht.mul_left hs.nonempty
+
+end IsLeftCancelMul
+
+section IsRightCancelMul
+variable [Mul α] [IsRightCancelMul α] {s t : Set α}
+
+@[to_additive]
+lemma Nontrivial.mul_right : s.Nontrivial → t.Nonempty → (s * t).Nontrivial := by
+  rintro ⟨a, ha, b, hb, hab⟩ ⟨c, hc⟩
+  exact ⟨a * c, mul_mem_mul ha hc, b * c, mul_mem_mul hb hc, by simpa⟩
+
+end IsRightCancelMul
+
+section CancelMonoid
+variable [CancelMonoid α] {s t : Set α} {a : α} {n : ℕ}
+
+@[to_additive]
+lemma Nontrivial.pow (hs : s.Nontrivial) : ∀ {n}, n ≠ 0 → (s ^ n).Nontrivial
+  | 1, _ => by simpa
+  | n + 2, _ => by simpa [pow_succ] using (hs.pow n.succ_ne_zero).mul hs
+
+end CancelMonoid
 
 /-- `Set α` is a `CommMonoid` under pointwise operations if `α` is. -/
 @[to_additive "`Set α` is an `AddCommMonoid` under pointwise operations if `α` is."]

--- a/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
+++ b/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
@@ -100,8 +100,8 @@ private lemma wellFoundedOn_devosMulRel :
     Set.WellFoundedOn.prod_lex_of_wellFoundedOn_fiber ?_ fun n ↦
       wellFounded_lt.onFun.wellFoundedOn
   exact wellFounded_lt.onFun.wellFoundedOn.mono' fun x hx y _ ↦ tsub_lt_tsub_left_of_le <|
-    add_le_add ((card_le_card_mul_right _ hx.1.2).trans_eq hx.2) <|
-      (card_le_card_mul_left _ hx.1.1).trans_eq hx.2
+    add_le_add ((card_le_card_mul_right hx.1.2).trans_eq hx.2) <|
+      (card_le_card_mul_left hx.1.1).trans_eq hx.2
 
 /-- A generalisation of the **Cauchy-Davenport theorem** to arbitrary groups. The size of `s * t` is
 lower-bounded by `|s| + |t| - 1` unless this quantity is greater than the size of the smallest
@@ -151,7 +151,7 @@ lemma cauchy_davenport_minOrder_mul (hs : s.Nonempty) (ht : t.Nonempty) :
     refine Or.inl ((minOrder_le_natCard (zpowers_ne_bot.2 hg) <|
       s.finite_toSet.smul_set.subset hS).trans <| WithTop.coe_le_coe.2 <|
         ((Nat.card_mono s.finite_toSet.smul_set hS).trans_eq <| ?_).trans <|
-          card_le_card_mul_right _ ht)
+          card_le_card_mul_right ht)
     rw [← coe_smul_finset]
     simp [-coe_smul_finset]
   -- Else, we can transform `s`, `t` to `s'`, `t'` and `s''`, `t''`, such that one of `(s', t')` and
@@ -165,7 +165,7 @@ lemma cauchy_davenport_minOrder_mul (hs : s.Nonempty) (ht : t.Nonempty) :
   · rw [← card_smul_finset g⁻¹ t]
     refine Or.inr ((add_le_add_right hst _).trans ?_)
     rw [← card_union_of_disjoint hgt]
-    exact (card_le_card_mul_left _ hgs).trans (le_add_of_le_left aux1)
+    exact (card_le_card_mul_left hgs).trans (le_add_of_le_left aux1)
   -- Else, we're done by induction on either `(s', t')` or `(s'', t'')` depending on whether
   -- `|s| + |t| ≤ |s'| + |t'|` or `|s| + |t| < |s''| + |t''|`. One of those two inequalities must
   -- hold since `2 * (|s| + |t|) = |s'| + |t'| + |s''| + |t''|`.
@@ -208,7 +208,7 @@ lemma cauchy_davenport_mul_of_linearOrder_isCancelMul [LinearOrder α] [Semigrou
     [MulLeftMono α] [MulRightMono α]
     {s t : Finset α} (hs : s.Nonempty) (ht : t.Nonempty) : #s + #t - 1 ≤ #(s * t) := by
   suffices s * {t.min' ht} ∩ ({s.max' hs} * t) = {s.max' hs * t.min' ht} by
-    rw [← card_singleton_mul t (s.max' hs), ← card_mul_singleton s (t.min' ht),
+    rw [← card_singleton_mul (s.max' hs) t, ← card_mul_singleton s (t.min' ht),
       ← card_union_add_card_inter, ← card_singleton _, ← this, Nat.add_sub_cancel]
     exact card_mono (union_subset (mul_subset_mul_left <| singleton_subset_iff.2 <| min'_mem _ _) <|
       mul_subset_mul_right <| singleton_subset_iff.2 <| max'_mem _ _)

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -179,7 +179,7 @@ theorem ruzsa_triangle_inequality_mul_mul_mul (A B C : Finset G) :
   push_cast
   refine (le_div_iff₀ <| cast_pos.2 hB.card_pos).1 ?_
   rw [mul_div_right_comm, mul_comm _ B]
-  refine (Nat.cast_le.2 <| card_le_card_mul_left _ hU.1).trans ?_
+  refine (Nat.cast_le.2 <| card_le_card_mul_left hU.1).trans ?_
   refine le_trans ?_
     (mul_le_mul (hUA _ hB') (cast_le.2 <| card_le_card <| mul_subset_mul_right hU.2)
       (zero_le _) (zero_le _))


### PR DESCRIPTION
and the product of nontrivial sets is nontrivial.

From GrowthInGroups

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #19537

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
