### PR TITLE
[Merged by Bors] - chore(zulip_emoji_merge_delegate): exclude rss channel in python logic instead of zulip search

### DIFF
--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -23,14 +23,14 @@ client = zulip.Client(
     site=ZULIP_SITE
 )
 
-# Fetch the messages containing the PR number from the public channels (exluding #rss).
+# Fetch the messages containing the PR number from the public channels.
 # There does not seem to be a way to search simultaneously public and private channels.
 public_response = client.get_messages({
     "anchor": "newest",
     "num_before": 5000,
     "num_after": 0,
     "narrow": [
-        {"operator": "channel", "operand": "rss", "negated": True},
+        {"operator": "channels", "operand": "public"},
         {"operator": "search", "operand": f'#{PR_NUMBER}'},
     ],
 })
@@ -57,6 +57,8 @@ pr_pattern = re.compile(f'https://github.com/leanprover-community/mathlib4/pull/
 print(f"Searching for: '{pr_pattern}'")
 
 for message in messages:
+    if message['display_recipient'] == 'rss':
+        continue
     content = message['content']
     # Check for emoji reactions
     reactions = message['reactions']


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
