### PR TITLE
[Merged by Bors] - feat: add stream' lemmas

### DIFF
--- a/Mathlib/Combinatorics/Hindman.lean
+++ b/Mathlib/Combinatorics/Hindman.lean
@@ -128,7 +128,7 @@ theorem exists_idempotent_ultrafilter_le_FP {M} [Semigroup M] (a : Stream' M) :
   · apply IsCompact.nonempty_iInter_of_sequence_nonempty_isCompact_isClosed
     · intro n U hU
       filter_upwards [hU]
-      rw [add_comm, ← Stream'.drop_drop, ← Stream'.tail_eq_drop]
+      rw [← Stream'.drop_drop, ← Stream'.tail_eq_drop]
       exact FP.tail _
     · intro n
       exact ⟨pure _, mem_pure.mpr <| FP.head _⟩
@@ -144,7 +144,7 @@ theorem exists_idempotent_ultrafilter_le_FP {M} [Semigroup M] (a : Stream' M) :
     obtain ⟨n', hn⟩ := FP.mul hm
     filter_upwards [hV (n' + n)] with m' hm'
     apply hn
-    simpa only [Stream'.drop_drop] using hm'
+    simpa only [Stream'.drop_drop, add_comm] using hm'
 
 @[to_additive exists_FS_of_large]
 theorem exists_FP_of_large {M} [Semigroup M] (U : Ultrafilter M) (U_idem : U * U = U) (s₀ : Set M)
@@ -208,7 +208,7 @@ theorem FP_drop_subset_FP {M} [Semigroup M] (a : Stream' M) (n : ℕ) : FP (a.dr
   induction n with
   | zero => rfl
   | succ n ih =>
-    rw [Nat.add_comm, ← Stream'.drop_drop]
+    rw [← Stream'.drop_drop]
     exact _root_.trans (FP.tail _) ih
 
 @[to_additive]
@@ -229,7 +229,7 @@ theorem FP.mul_two {M} [Semigroup M] (a : Stream' M) (i j : ℕ) (ij : i < j) :
   have := FP.singleton (a.drop i).tail d
   rw [Stream'.tail_eq_drop, Stream'.get_drop, Stream'.get_drop] at this
   convert this
-  rw [hd, add_comm, Nat.succ_add, Nat.add_succ]
+  omega
 
 @[to_additive]
 theorem FP.finset_prod {M} [CommMonoid M] (a : Stream' M) (s : Finset ℕ) (hs : s.Nonempty) :
@@ -246,7 +246,7 @@ theorem FP.finset_prod {M} [CommMonoid M] (a : Stream' M) (s : Finset ℕ) (hs :
     have : s.min' hs + 1 ≤ (s.erase (s.min' hs)).min' h :=
       Nat.succ_le_of_lt (Finset.min'_lt_of_mem_erase_min' _ _ <| Finset.min'_mem _ _)
     cases' Nat.exists_eq_add_of_le this with d hd
-    rw [hd, add_comm, ← Stream'.drop_drop]
+    rw [hd, ← Stream'.drop_drop, add_comm]
     apply FP_drop_subset_FP
 
 end Hindman

--- a/Mathlib/Data/Stream/Init.lean
+++ b/Mathlib/Data/Stream/Init.lean
@@ -6,7 +6,6 @@ Authors: Leonardo de Moura
 import Mathlib.Data.Stream.Defs
 import Mathlib.Logic.Function.Basic
 import Mathlib.Data.List.Basic
-import Mathlib.Algebra.Order.Group.Nat
 
 /-!
 # Streams a.k.a. infinite lists a.k.a. infinite sequences

--- a/Mathlib/Data/Stream/Init.lean
+++ b/Mathlib/Data/Stream/Init.lean
@@ -585,12 +585,12 @@ lemma take_drop : (a.drop m).take n = (a.take (m + n)).drop m := by
 
 lemma drop_append_of_le_length (h : n ≤ x.length) :
     (x ++ₛ a).drop n = x.drop n ++ₛ a := by
-  obtain ⟨m, hm⟩ := le_iff_exists_add.mp h
+  obtain ⟨m, hm⟩ := Nat.exists_eq_add_of_le h
   ext k; rcases lt_or_ge k m with _ | hk
   · rw [get_drop, get_append_left, get_append_left, List.getElem_drop]; simpa [hm]
-  · obtain ⟨p, rfl⟩ := le_iff_exists_add.mp hk
+  · obtain ⟨p, rfl⟩ := Nat.exists_eq_add_of_le hk
     have hm' : m = (x.drop n).length := by simp [hm]
-    simp_rw [get_drop, ← add_assoc, ← hm, get_append_right, hm', get_append_right]
+    simp_rw [get_drop, ← Nat.add_assoc, ← hm, get_append_right, hm', get_append_right]
 
 -- Take theorem reduces a proof of equality of infinite streams to an
 -- induction over all their finite approximations.

--- a/Mathlib/Data/Stream/Init.lean
+++ b/Mathlib/Data/Stream/Init.lean
@@ -6,6 +6,7 @@ Authors: Leonardo de Moura
 import Mathlib.Data.Stream.Defs
 import Mathlib.Logic.Function.Basic
 import Mathlib.Data.List.Basic
+import Mathlib.Algebra.Order.Group.Nat
 
 /-!
 # Streams a.k.a. infinite lists a.k.a. infinite sequences
@@ -20,6 +21,7 @@ namespace Stream'
 
 universe u v w
 variable {α : Type u} {β : Type v} {δ : Type w}
+variable (m n : ℕ) (x y : List α) (a b : Stream' α)
 
 instance [Inhabited α] : Inhabited (Stream' α) :=
   ⟨Stream'.const default⟩
@@ -44,14 +46,15 @@ theorem tail_cons (a : α) (s : Stream' α) : tail (a::s) = s :=
   rfl
 
 @[simp]
-theorem get_drop (n m : ℕ) (s : Stream' α) : get (drop m s) n = get s (n + m) :=
+theorem get_drop (n m : ℕ) (s : Stream' α) : get (drop m s) n = get s (m + n) := by
+  rw [Nat.add_comm]
   rfl
 
 theorem tail_eq_drop (s : Stream' α) : tail s = drop 1 s :=
   rfl
 
 @[simp]
-theorem drop_drop (n m : ℕ) (s : Stream' α) : drop n (drop m s) = drop (n + m) s := by
+theorem drop_drop (n m : ℕ) (s : Stream' α) : drop n (drop m s) = drop (m + n) s := by
   ext; simp [Nat.add_assoc]
 
 @[simp] theorem get_tail {n : ℕ} {s : Stream' α} : s.tail.get n = s.get (n + 1) := rfl
@@ -69,6 +72,13 @@ theorem get_succ (n : ℕ) (s : Stream' α) : get s (succ n) = get (tail s) n :=
 @[simp]
 theorem get_succ_cons (n : ℕ) (s : Stream' α) (x : α) : get (x::s) n.succ = get s n :=
   rfl
+
+@[simp] lemma get_cons_append_zero {a : α} {x : List α} {s : Stream' α} :
+  (a :: x ++ₛ s).get 0 = a := rfl
+
+@[simp] lemma cons_head_tail (a : Stream' α) : a.head :: a.tail = a := by ext n; cases n <;> rfl
+
+@[simp] lemma append_eq_cons {a : α} {as : Stream' α} : [a] ++ₛ as = a :: as := by rfl
 
 @[simp] theorem drop_zero {s : Stream' α} : s.drop 0 = s := rfl
 
@@ -429,18 +439,41 @@ theorem mem_of_mem_even (a : α) (s : Stream' α) : a ∈ even s → a ∈ s := 
 theorem mem_of_mem_odd (a : α) (s : Stream' α) : a ∈ odd s → a ∈ s := fun ⟨n, h⟩ =>
   Exists.intro (2 * n + 1) (by rw [h, get_odd])
 
-theorem nil_append_stream (s : Stream' α) : appendStream' [] s = s :=
+@[simp] theorem nil_append_stream (s : Stream' α) : appendStream' [] s = s :=
   rfl
 
 theorem cons_append_stream (a : α) (l : List α) (s : Stream' α) :
     appendStream' (a::l) s = a::appendStream' l s :=
   rfl
 
-theorem append_append_stream : ∀ (l₁ l₂ : List α) (s : Stream' α),
+@[simp] theorem append_append_stream : ∀ (l₁ l₂ : List α) (s : Stream' α),
     l₁ ++ l₂ ++ₛ s = l₁ ++ₛ (l₂ ++ₛ s)
   | [], _, _ => rfl
   | List.cons a l₁, l₂, s => by
     rw [List.cons_append, cons_append_stream, cons_append_stream, append_append_stream l₁]
+
+lemma get_append_left (h : n < x.length) : (x ++ₛ a).get n = x[n] := by
+  induction' x with b x ih generalizing n
+  · simp at h
+  · rcases n with (_ | n)
+    · simp
+    · simp [ih n (by simpa using h), cons_append_stream]
+
+@[simp] lemma get_append_right : (x ++ₛ a).get (x.length + n) = a.get n := by
+  induction' x <;> simp [Nat.succ_add, *, cons_append_stream]
+
+@[simp] lemma get_append_length : (x ++ₛ a).get x.length = a.get 0 := get_append_right 0 x a
+
+lemma append_left_injective (h : x ++ₛ a = x ++ₛ b) : a = b := by
+  ext n; replace h := congr_arg (fun a ↦ a.get (x.length + n)) h; simpa using h
+
+@[simp] lemma append_left_inj : x ++ₛ a = x ++ₛ b ↔ a = b :=
+  ⟨append_left_injective x a b, by simp (config := {contextual := true})⟩
+
+lemma append_right_injective (h : x ++ₛ a = y ++ₛ b) (hl : x.length = y.length) : x = y := by
+  apply List.ext_getElem hl
+  intros
+  rw [← get_append_left, ← get_append_left, h]
 
 theorem map_append_stream (f : α → β) :
     ∀ (l : List α) (s : Stream' α), map f (l ++ₛ s) = List.map f l ++ₛ map f s
@@ -453,7 +486,7 @@ theorem drop_append_stream : ∀ (l : List α) (s : Stream' α), drop l.length (
   | List.cons a l, s => by
     rw [List.length_cons, drop_succ, cons_append_stream, tail_cons, drop_append_stream l s]
 
-theorem append_stream_head_tail (s : Stream' α) : [head s] ++ₛ tail s = s := by
+@[simp] theorem append_stream_head_tail (s : Stream' α) : [head s] ++ₛ tail s = s := by
   rw [cons_append_stream, nil_append_stream, Stream'.eta]
 
 theorem mem_append_stream_right : ∀ {a : α} (l : List α) {s : Stream' α}, a ∈ s → a ∈ l ++ₛ s
@@ -495,7 +528,7 @@ theorem take_take {s : Stream' α} : ∀ {m n}, (s.take n).take m = s.take (min 
   | m, 0 => by rw [Nat.zero_min, take_zero, List.take_nil]
   | m+1, n+1 => by rw [take_succ, List.take_succ_cons, Nat.succ_min_succ, take_succ, take_take]
 
-@[simp] theorem concat_take_get {n : ℕ} {s : Stream' α} : s.take n ++ [s.get n] = s.take (n+1) :=
+@[simp] theorem concat_take_get {n : ℕ} {s : Stream' α} : s.take n ++ [s.get n] = s.take (n + 1) :=
   (take_succ' n).symm
 
 theorem get?_take {s : Stream' α} : ∀ {k n}, k < n → (s.take n).get? k = s.get k
@@ -521,6 +554,43 @@ theorem append_take_drop : ∀ (n : ℕ) (s : Stream' α),
     rfl
   · intro s
     rw [take_succ, drop_succ, cons_append_stream, ih (tail s), Stream'.eta]
+
+lemma append_take : x ++ (a.take n) = (x ++ₛ a).take (x.length + n) := by
+  induction' x <;> simp [take, Nat.add_comm, cons_append_stream, *]
+
+@[simp] lemma take_get (h : m < (a.take n).length) : (a.take n)[m] = a.get m := by
+  nth_rw 2 [← append_take_drop n a]; rw [get_append_left]
+
+theorem take_append_of_le_length (h : n ≤ x.length) :
+    (x ++ₛ a).take n = x.take n := by
+  apply List.ext_getElem (by simp [h])
+  intro _ _ _; rw [List.getElem_take, take_get, get_append_left]
+
+lemma take_add : a.take (m + n) = a.take m ++ (a.drop m).take n := by
+  apply append_right_injective _ _ (a.drop (m + n)) ((a.drop m).drop n) <;>
+    simp [- drop_drop]
+
+@[gcongr] lemma take_prefix_take_left (h : m ≤ n) : a.take m <+: a.take n := by
+  rw [(by simp [h] : a.take m = (a.take n).take m)]
+  apply List.take_prefix
+
+@[simp] lemma take_prefix : a.take m <+: a.take n ↔ m ≤ n :=
+  ⟨fun h ↦ by simpa using h.length_le, take_prefix_take_left m n a⟩
+
+lemma map_take (f : α → β) : (a.take n).map f = (a.map f).take n := by
+  apply List.ext_getElem <;> simp
+
+lemma take_drop : (a.drop m).take n = (a.take (m + n)).drop m := by
+  apply List.ext_getElem <;> simp
+
+lemma drop_append_of_le_length (h : n ≤ x.length) :
+    (x ++ₛ a).drop n = x.drop n ++ₛ a := by
+  obtain ⟨m, hm⟩ := le_iff_exists_add.mp h
+  ext k; rcases lt_or_ge k m with _ | hk
+  · rw [get_drop, get_append_left, get_append_left, List.getElem_drop]; simpa [hm]
+  · obtain ⟨p, rfl⟩ := le_iff_exists_add.mp hk
+    have hm' : m = (x.drop n).length := by simp [hm]
+    simp_rw [get_drop, ← add_assoc, ← hm, get_append_right, hm', get_append_right]
 
 -- Take theorem reduces a proof of equality of infinite streams to an
 -- induction over all their finite approximations.

--- a/Mathlib/Data/Stream/Init.lean
+++ b/Mathlib/Data/Stream/Init.lean
@@ -486,8 +486,8 @@ theorem drop_append_stream : ∀ (l : List α) (s : Stream' α), drop l.length (
   | List.cons a l, s => by
     rw [List.length_cons, drop_succ, cons_append_stream, tail_cons, drop_append_stream l s]
 
-@[simp] theorem append_stream_head_tail (s : Stream' α) : [head s] ++ₛ tail s = s := by
-  rw [cons_append_stream, nil_append_stream, Stream'.eta]
+theorem append_stream_head_tail (s : Stream' α) : [head s] ++ₛ tail s = s := by
+  simp
 
 theorem mem_append_stream_right : ∀ {a : α} (l : List α) {s : Stream' α}, a ∈ s → a ∈ l ++ₛ s
   | _, [], _, h => h


### PR DESCRIPTION
The orders of summands in some lemmas are changed and simp annotations are added to make the API closer to the one for lists.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
