### PR TITLE
perf: merge several style syntax linters

### DIFF
--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -63,6 +63,7 @@ def parse_set_option : Syntax → Option Name
 def is_set_option : Syntax → Bool :=
   fun stx ↦ parse_set_option stx matches some _name
 
+/-- TODO: add a doc-string! -/
 def findErrors (stx : Syntax) : Option (Lean.Option Bool × Syntax × MessageData):= Id.run do
   if let some head := stx.find? is_set_option then
     if let some name := parse_set_option head then
@@ -121,6 +122,7 @@ register_option linter.style.missingEnd : Bool := {
 
 namespace Style.missingEnd
 
+/-- TODO: add a doc-string! -/
 def findErrors (stx : Syntax) : CommandElabM (Option (Lean.Option Bool × Syntax × MessageData)) := do
   -- Only run this linter at the end of a module.
   unless stx.isOfKind ``Lean.Parser.Command.eoi do return none
@@ -208,6 +210,7 @@ def unwanted_cdot (stx : Syntax) : Array Syntax :=
 
 namespace Style
 
+/-- TODO: add a doc-string! -/
 def cdotLinter.findErrors (stx : Syntax) : List (Lean.Option Bool × Syntax × MessageData) := Id.run do
   let res := unwanted_cdot stx |>.map (fun s ↦
     (linter.style.cdot, s, m!"Please, use '·' (typed as `\\.`) instead of '{s}' as 'cdot'."))
@@ -266,6 +269,7 @@ def findDollarSyntax : Syntax → Array Syntax
       | _ => dargs
   |_ => #[]
 
+/-- TODO: add a doc-string! -/
 def findErrors (stx : Syntax) : Array (Lean.Option Bool × Syntax × MessageData) := Id.run do
   findDollarSyntax stx |>.map (fun s ↦ (linter.style.dollarSyntax, s, m!"Please use '<|' instead of '$' for the pipe operator."))
 
@@ -313,6 +317,7 @@ def findLambdaSyntax : Syntax → Array Syntax
       | _ =>  dargs
   |_ => #[]
 
+/-- TODO: add a doc-string! -/
 def findErrors (stx : Syntax) : Array (Lean.Option Bool × Syntax × MessageData) := Id.run do
   findLambdaSyntax stx |>.filterMap (fun s ↦ if let .atom _ "λ" := s[0] then
     some (linter.style.lambdaSyntax, s[0], m!"Please use 'fun' and not 'λ' to define anonymous \
@@ -420,6 +425,7 @@ initialize addLinter longFileLinter
 
 end Style.longFile
 
+/-- TODO: add a doc-string! -/
 def jointSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
   if (← MonadState.get).messages.hasErrors then
     return

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -211,7 +211,7 @@ def unwanted_cdot (stx : Syntax) : Array Syntax :=
 namespace Style
 
 /-- TODO: add a doc-string! -/
-def cdotLinter.findErrors (stx : Syntax) : List (Syntax × MessageData) := Id.run do
+def cdotLinter.findErrors (stx : Syntax) : Array (Syntax × MessageData) := Id.run do
   let res := unwanted_cdot stx |>.map (fun s ↦
     (s, m!"Please, use '·' (typed as `\\.`) instead of '{s}' as 'cdot'."))
   let mut res2 := #[]
@@ -219,7 +219,7 @@ def cdotLinter.findErrors (stx : Syntax) : List (Syntax × MessageData) := Id.ru
     if let some (.node _ _ #[.atom (.original _ _ afterCDot _) _]) := cdot.find? (·.isOfKind `token.«· ») then
       if (afterCDot.takeWhile (·.isWhitespace)).contains '\n' then
         res2 := res2.push (cdot, m!"This central dot `·` is isolated; please merge it with the next line.")
-  return res.toList ++ res2.toList
+  return res.append res2
 
 @[inherit_doc linter.style.cdot]
 def cdotLinter : Linter where run := withSetOptionIn fun stx ↦ do

--- a/MathlibTest/LintStyle.lean
+++ b/MathlibTest/LintStyle.lean
@@ -162,8 +162,10 @@ warning: Please, use '·' (typed as `\.`) instead of '.' as 'cdot'.
 note: this linter can be disabled with `set_option linter.style.cdot false`
 ---
 warning: This central dot `·` is isolated; please merge it with the next line.
+note: this linter can be disabled with `set_option linter.style.cdot false`
 ---
 warning: This central dot `·` is isolated; please merge it with the next line.
+note: this linter can be disabled with `set_option linter.style.cdot false`
 -/
 #guard_msgs in
 example : Nat := by


### PR DESCRIPTION
Does this improve performance? To be determined!

---

Opening just for benchmarking purposes. Would need clean-up before it can be merged.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
