### PR TITLE
perf: TRY disabling ALL syntax style linters, see what the effect is

### DIFF
--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -86,7 +86,7 @@ def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
                If you intend to submit this contribution to the Mathlib project, \
                please remove 'set_option {name}'."
 
-initialize addLinter setOptionLinter
+--initialize addLinter setOptionLinter
 
 end Style.setOption
 
@@ -129,7 +129,7 @@ def missingEndLinter : Linter where run := withSetOptionIn fun stx ↦ do
         Linter.logLint linter.style.missingEnd stx
          m!"unclosed sections or namespaces; expected: '{ending}'"
 
-initialize addLinter missingEndLinter
+--initialize addLinter missingEndLinter
 
 end Style.missingEnd
 
@@ -197,7 +197,7 @@ def cdotLinter : Linter where run := withSetOptionIn fun stx ↦ do
             m!"This central dot `·` is isolated; please merge it with the next line."
       | _ => return
 
-initialize addLinter cdotLinter
+--initialize addLinter cdotLinter
 
 end Style
 
@@ -237,7 +237,7 @@ def dollarSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
       Linter.logLint linter.style.dollarSyntax s
         m!"Please use '<|' instead of '$' for the pipe operator."
 
-initialize addLinter dollarSyntaxLinter
+--initialize addLinter dollarSyntaxLinter
 
 end Style.dollarSyntax
 
@@ -283,7 +283,7 @@ def lambdaSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
         Please use 'fun' and not 'λ' to define anonymous functions.\n\
         The 'λ' syntax is deprecated in mathlib4."
 
-initialize addLinter lambdaSyntaxLinter
+--initialize addLinter lambdaSyntaxLinter
 
 end Style.lambdaSyntax
 
@@ -369,7 +369,7 @@ def longFileLinter : Linter where run := withSetOptionIn fun stx ↦ do
           The current limit is {linterBound}, but it is expected to be {candidate}:\n\
           `set_option linter.style.longFile {candidate}`."
 
-initialize addLinter longFileLinter
+--initialize addLinter longFileLinter
 
 end Style.longFile
 
@@ -416,7 +416,7 @@ def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
         else ""
         Linter.logLint linter.style.longLine (.ofRange ⟨line.startPos, line.stopPos⟩)
           m!"This line exceeds the 100 character limit, please shorten it!{stringMsg}"
-initialize addLinter longLineLinter
+--initialize addLinter longLineLinter
 
 end Style.longLine
 


### PR DESCRIPTION
Opening for comparison with #19547: this PR disables *all* syntax style linters (the five linters rewritten in that PR, and two more). Let's see if these linters have any significant effect whatsoever.

---

Once CI is complete, help benchmarking this is welcome.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
