### PR TITLE
feat: Notation `≤∧≥` for `AntisymmRel (· ≤ ·)`

### DIFF
--- a/Mathlib/Order/Antisymmetrization.lean
+++ b/Mathlib/Order/Antisymmetrization.lean
@@ -37,11 +37,11 @@ variable (r : α → α → Prop)
 def AntisymmRel (a b : α) : Prop :=
   r a b ∧ r b a
 
-/-- The antisymmetrization relation `a ⋚ b` means that both `a ≤ b` and `b ≤ a`. -/
-infix:50 " ⋚ "  => AntisymmRel (· ≤ ·)
+/-- The antisymmetrization relation `a ≤∧≥ b` means that both `a ≤ b` and `b ≤ a`. -/
+infix:50 " ≤∧≥ "  => AntisymmRel (· ≤ ·)
 
-theorem AntisymmRel.le [LE α] {a b : α} (h : a ⋚ b) : a ≤ b := h.1
-theorem AntisymmRel.ge [LE α] {a b : α} (h : a ⋚ b) : b ≤ a := h.2
+theorem AntisymmRel.le [LE α] {a b : α} (h : a ≤∧≥ b) : a ≤ b := h.1
+theorem AntisymmRel.ge [LE α] {a b : α} (h : a ≤∧≥ b) : b ≤ a := h.2
 
 theorem antisymmRel_swap : AntisymmRel (swap r) = AntisymmRel r :=
   funext fun _ => funext fun _ => propext and_comm
@@ -120,7 +120,7 @@ section Preorder
 
 variable [Preorder α] [Preorder β] {a b : α}
 
-theorem AntisymmRel.image {a b : α} (h : a ⋚ b) {f : α → β} (hf : Monotone f) : f a ⋚ f b :=
+theorem AntisymmRel.image {a b : α} (h : a ≤∧≥ b) {f : α → β} (hf : Monotone f) : f a ≤∧≥ f b :=
   ⟨hf h.1, hf h.2⟩
 
 instance instPartialOrderAntisymmetrization : PartialOrder (Antisymmetrization α (· ≤ ·)) where

--- a/Mathlib/Order/Antisymmetrization.lean
+++ b/Mathlib/Order/Antisymmetrization.lean
@@ -40,11 +40,8 @@ def AntisymmRel (a b : α) : Prop :=
 /-- The antisymmetrization relation `a ⋚ b` means that both `a ≤ b` and `b ≤ a`. -/
 infix:50 " ⋚ "  => AntisymmRel (· ≤ ·)
 
-theorem AntisymmRel.le [LE α] {a b : α} (h : a ⋚ b) : a ≤ b :=
-  h.1
-
-theorem AntisymmRel.ge [LE α] {a b : α} (h : a ⋚ b) : b ≤ a :=
-  h.2
+theorem AntisymmRel.le [LE α] {a b : α} (h : a ⋚ b) : a ≤ b := h.1
+theorem AntisymmRel.ge [LE α] {a b : α} (h : a ⋚ b) : b ≤ a := h.2
 
 theorem antisymmRel_swap : AntisymmRel (swap r) = AntisymmRel r :=
   funext fun _ => funext fun _ => propext and_comm

--- a/Mathlib/Order/Antisymmetrization.lean
+++ b/Mathlib/Order/Antisymmetrization.lean
@@ -33,7 +33,7 @@ section Relation
 
 variable (r : α → α → Prop)
 
-/-- The antisymmetrization relation `a ⋚ b` means that both `a ≤ b` and `b ≤ a`. -/
+/-- The antisymmetrization relation `AntisymmRel r a b` means that both `r a b` and `r b a`. -/
 def AntisymmRel (a b : α) : Prop :=
   r a b ∧ r b a
 

--- a/Mathlib/Order/Antisymmetrization.lean
+++ b/Mathlib/Order/Antisymmetrization.lean
@@ -33,9 +33,12 @@ section Relation
 
 variable (r : α → α → Prop)
 
-/-- The antisymmetrization relation. -/
+/-- The antisymmetrization relation `a ⋚ b` means that both `a ≤ b` and `b ≤ a`. -/
 def AntisymmRel (a b : α) : Prop :=
   r a b ∧ r b a
+
+/-- The antisymmetrization relation `a ⋚ b` means that both `a ≤ b` and `b ≤ a`. -/
+infix:50 " ⋚ "  => AntisymmRel (· ≤ ·)
 
 theorem antisymmRel_swap : AntisymmRel (swap r) = AntisymmRel r :=
   funext fun _ => funext fun _ => propext and_comm
@@ -114,8 +117,7 @@ section Preorder
 
 variable [Preorder α] [Preorder β] {a b : α}
 
-theorem AntisymmRel.image {a b : α} (h : AntisymmRel (· ≤ ·) a b) {f : α → β} (hf : Monotone f) :
-    AntisymmRel (· ≤ ·) (f a) (f b) :=
+theorem AntisymmRel.image {a b : α} (h : a ⋚ b) {f : α → β} (hf : Monotone f) : f a ⋚ f b :=
   ⟨hf h.1, hf h.2⟩
 
 instance instPartialOrderAntisymmetrization : PartialOrder (Antisymmetrization α (· ≤ ·)) where

--- a/Mathlib/Order/Antisymmetrization.lean
+++ b/Mathlib/Order/Antisymmetrization.lean
@@ -40,6 +40,12 @@ def AntisymmRel (a b : α) : Prop :=
 /-- The antisymmetrization relation `a ⋚ b` means that both `a ≤ b` and `b ≤ a`. -/
 infix:50 " ⋚ "  => AntisymmRel (· ≤ ·)
 
+theorem AntisymmRel.le [LE α] {a b : α} (h : a ⋚ b) : a ≤ b :=
+  h.1
+
+theorem AntisymmRel.ge [LE α] {a b : α} (h : a ⋚ b) : b ≤ a :=
+  h.2
+
 theorem antisymmRel_swap : AntisymmRel (swap r) = AntisymmRel r :=
   funext fun _ => funext fun _ => propext and_comm
 

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -57,7 +57,7 @@ theorem wcovBy_of_le_of_le (h1 : a ≤ b) (h2 : b ≤ a) : a ⩿ b :=
 
 alias LE.le.wcovBy_of_le := wcovBy_of_le_of_le
 
-theorem AntisymmRel.wcovBy (h : a ⋚ b) : a ⩿ b :=
+theorem AntisymmRel.wcovBy (h : a ≤∧≥ b) : a ⩿ b :=
   wcovBy_of_le_of_le h.1 h.2
 
 theorem WCovBy.wcovBy_iff_le (hab : a ⩿ b) : b ⩿ a ↔ b ≤ a :=
@@ -66,16 +66,16 @@ theorem WCovBy.wcovBy_iff_le (hab : a ⩿ b) : b ⩿ a ↔ b ≤ a :=
 theorem wcovBy_of_eq_or_eq (hab : a ≤ b) (h : ∀ c, a ≤ c → c ≤ b → c = a ∨ c = b) : a ⩿ b :=
   ⟨hab, fun c ha hb => (h c ha.le hb.le).elim ha.ne' hb.ne⟩
 
-theorem AntisymmRel.trans_wcovBy (hab : a ⋚ b) (hbc : b ⩿ c) : a ⩿ c :=
+theorem AntisymmRel.trans_wcovBy (hab : a ≤∧≥ b) (hbc : b ⩿ c) : a ⩿ c :=
   ⟨hab.1.trans hbc.le, fun _ had hdc => hbc.2 (hab.2.trans_lt had) hdc⟩
 
-theorem wcovBy_congr_left (hab : a ⋚ b) : a ⩿ c ↔ b ⩿ c :=
+theorem wcovBy_congr_left (hab : a ≤∧≥ b) : a ⩿ c ↔ b ⩿ c :=
   ⟨hab.symm.trans_wcovBy, hab.trans_wcovBy⟩
 
-theorem WCovBy.trans_antisymm_rel (hab : a ⩿ b) (hbc : b ⋚ c) : a ⩿ c :=
+theorem WCovBy.trans_antisymm_rel (hab : a ⩿ b) (hbc : b ≤∧≥ c) : a ⩿ c :=
   ⟨hab.le.trans hbc.1, fun _ had hdc => hab.2 had <| hdc.trans_le hbc.2⟩
 
-theorem wcovBy_congr_right (hab : a ⋚ b) : c ⩿ a ↔ c ⩿ b :=
+theorem wcovBy_congr_right (hab : a ≤∧≥ b) : c ⩿ a ↔ c ⩿ b :=
   ⟨fun h => h.trans_antisymm_rel hab, fun h => h.trans_antisymm_rel hab.symm⟩
 
 /-- If `a ≤ b`, then `b` does not cover `a` iff there's an element in between. -/
@@ -283,16 +283,16 @@ theorem wcovBy_iff_covBy_or_le_and_le : a ⩿ b ↔ a ⋖ b ∨ a ≤ b ∧ b �
 
 alias ⟨WCovBy.covBy_or_le_and_le, _⟩ := wcovBy_iff_covBy_or_le_and_le
 
-theorem AntisymmRel.trans_covBy (hab : a ⋚ b) (hbc : b ⋖ c) : a ⋖ c :=
+theorem AntisymmRel.trans_covBy (hab : a ≤∧≥ b) (hbc : b ⋖ c) : a ⋖ c :=
   ⟨hab.1.trans_lt hbc.lt, fun _ had hdc => hbc.2 (hab.2.trans_lt had) hdc⟩
 
-theorem covBy_congr_left (hab : a ⋚ b) : a ⋖ c ↔ b ⋖ c :=
+theorem covBy_congr_left (hab : a ≤∧≥ b) : a ⋖ c ↔ b ⋖ c :=
   ⟨hab.symm.trans_covBy, hab.trans_covBy⟩
 
-theorem CovBy.trans_antisymmRel (hab : a ⋖ b) (hbc : b ⋚ c) : a ⋖ c :=
+theorem CovBy.trans_antisymmRel (hab : a ⋖ b) (hbc : b ≤∧≥ c) : a ⋖ c :=
   ⟨hab.lt.trans_le hbc.1, fun _ had hdb => hab.2 had <| hdb.trans_le hbc.2⟩
 
-theorem covBy_congr_right (hab : a ⋚ b) : c ⋖ a ↔ c ⋖ b :=
+theorem covBy_congr_right (hab : a ≤∧≥ b) : c ⋖ a ↔ c ⋖ b :=
   ⟨fun h => h.trans_antisymmRel hab, fun h => h.trans_antisymmRel hab.symm⟩
 
 instance : IsNonstrictStrictOrder α (· ⩿ ·) (· ⋖ ·) :=

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -57,7 +57,7 @@ theorem wcovBy_of_le_of_le (h1 : a ≤ b) (h2 : b ≤ a) : a ⩿ b :=
 
 alias LE.le.wcovBy_of_le := wcovBy_of_le_of_le
 
-theorem AntisymmRel.wcovBy (h : AntisymmRel (· ≤ ·) a b) : a ⩿ b :=
+theorem AntisymmRel.wcovBy (h : a ⋚ b) : a ⩿ b :=
   wcovBy_of_le_of_le h.1 h.2
 
 theorem WCovBy.wcovBy_iff_le (hab : a ⩿ b) : b ⩿ a ↔ b ≤ a :=
@@ -66,16 +66,16 @@ theorem WCovBy.wcovBy_iff_le (hab : a ⩿ b) : b ⩿ a ↔ b ≤ a :=
 theorem wcovBy_of_eq_or_eq (hab : a ≤ b) (h : ∀ c, a ≤ c → c ≤ b → c = a ∨ c = b) : a ⩿ b :=
   ⟨hab, fun c ha hb => (h c ha.le hb.le).elim ha.ne' hb.ne⟩
 
-theorem AntisymmRel.trans_wcovBy (hab : AntisymmRel (· ≤ ·) a b) (hbc : b ⩿ c) : a ⩿ c :=
+theorem AntisymmRel.trans_wcovBy (hab : a ⋚ b) (hbc : b ⩿ c) : a ⩿ c :=
   ⟨hab.1.trans hbc.le, fun _ had hdc => hbc.2 (hab.2.trans_lt had) hdc⟩
 
-theorem wcovBy_congr_left (hab : AntisymmRel (· ≤ ·) a b) : a ⩿ c ↔ b ⩿ c :=
+theorem wcovBy_congr_left (hab : a ⋚ b) : a ⩿ c ↔ b ⩿ c :=
   ⟨hab.symm.trans_wcovBy, hab.trans_wcovBy⟩
 
-theorem WCovBy.trans_antisymm_rel (hab : a ⩿ b) (hbc : AntisymmRel (· ≤ ·) b c) : a ⩿ c :=
+theorem WCovBy.trans_antisymm_rel (hab : a ⩿ b) (hbc : b ⋚ c) : a ⩿ c :=
   ⟨hab.le.trans hbc.1, fun _ had hdc => hab.2 had <| hdc.trans_le hbc.2⟩
 
-theorem wcovBy_congr_right (hab : AntisymmRel (· ≤ ·) a b) : c ⩿ a ↔ c ⩿ b :=
+theorem wcovBy_congr_right (hab : a ⋚ b) : c ⩿ a ↔ c ⩿ b :=
   ⟨fun h => h.trans_antisymm_rel hab, fun h => h.trans_antisymm_rel hab.symm⟩
 
 /-- If `a ≤ b`, then `b` does not cover `a` iff there's an element in between. -/
@@ -283,16 +283,16 @@ theorem wcovBy_iff_covBy_or_le_and_le : a ⩿ b ↔ a ⋖ b ∨ a ≤ b ∧ b �
 
 alias ⟨WCovBy.covBy_or_le_and_le, _⟩ := wcovBy_iff_covBy_or_le_and_le
 
-theorem AntisymmRel.trans_covBy (hab : AntisymmRel (· ≤ ·) a b) (hbc : b ⋖ c) : a ⋖ c :=
+theorem AntisymmRel.trans_covBy (hab : a ⋚ b) (hbc : b ⋖ c) : a ⋖ c :=
   ⟨hab.1.trans_lt hbc.lt, fun _ had hdc => hbc.2 (hab.2.trans_lt had) hdc⟩
 
-theorem covBy_congr_left (hab : AntisymmRel (· ≤ ·) a b) : a ⋖ c ↔ b ⋖ c :=
+theorem covBy_congr_left (hab : a ⋚ b) : a ⋖ c ↔ b ⋖ c :=
   ⟨hab.symm.trans_covBy, hab.trans_covBy⟩
 
-theorem CovBy.trans_antisymmRel (hab : a ⋖ b) (hbc : AntisymmRel (· ≤ ·) b c) : a ⋖ c :=
+theorem CovBy.trans_antisymmRel (hab : a ⋖ b) (hbc : b ⋚ c) : a ⋖ c :=
   ⟨hab.lt.trans_le hbc.1, fun _ had hdb => hab.2 had <| hdb.trans_le hbc.2⟩
 
-theorem covBy_congr_right (hab : AntisymmRel (· ≤ ·) a b) : c ⋖ a ↔ c ⋖ b :=
+theorem covBy_congr_right (hab : a ⋚ b) : c ⋖ a ↔ c ⋖ b :=
   ⟨fun h => h.trans_antisymmRel hab, fun h => h.trans_antisymmRel hab.symm⟩
 
 instance : IsNonstrictStrictOrder α (· ⩿ ·) (· ⋖ ·) :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Notation.20for.20AntisymmRel/near/485545682).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
