### PR TITLE
[Merged by Bors] - feat(Logic/IsEmpty): Left/Right/BiTotal truthiness on emptiness

### DIFF
--- a/Mathlib/Logic/IsEmpty.lean
+++ b/Mathlib/Logic/IsEmpty.lean
@@ -206,7 +206,6 @@ theorem Function.extend_of_isEmpty [IsEmpty α] (f : α → β) (g : α → γ) 
     Function.extend f g h = h :=
   funext fun _ ↦ (Function.extend_apply' _ _ _) fun ⟨a, _⟩ ↦ isEmptyElim a
 
-section
 open Relator
 
 universe u₁ u₂
@@ -223,5 +222,3 @@ theorem rightTotal_empty [IsEmpty β] : RightTotal R := by
 @[simp]
 theorem biTotal_empty [IsEmpty α] [IsEmpty β] : BiTotal R :=
   ⟨leftTotal_empty R, rightTotal_empty R⟩
-
-end

--- a/Mathlib/Logic/IsEmpty.lean
+++ b/Mathlib/Logic/IsEmpty.lean
@@ -208,8 +208,7 @@ theorem Function.extend_of_isEmpty [IsEmpty α] (f : α → β) (g : α → γ) 
 
 open Relator
 
-universe u₁ u₂
-variable {α : Type u₁} {β : Type u₂} (R : α → β → Prop)
+variable {α β : Type*} (R : α → β → Prop)
 
 @[simp]
 theorem leftTotal_empty [IsEmpty α] : LeftTotal R := by

--- a/Mathlib/Logic/IsEmpty.lean
+++ b/Mathlib/Logic/IsEmpty.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import Mathlib.Logic.Function.Basic
+import Mathlib.Logic.Relator
 
 /-!
 # Types that are empty
@@ -204,3 +205,23 @@ variable {α}
 theorem Function.extend_of_isEmpty [IsEmpty α] (f : α → β) (g : α → γ) (h : β → γ) :
     Function.extend f g h = h :=
   funext fun _ ↦ (Function.extend_apply' _ _ _) fun ⟨a, _⟩ ↦ isEmptyElim a
+
+section
+open Relator
+
+universe u₁ u₂
+variable {α : Type u₁} {β : Type u₂} (R : α → β → Prop)
+
+@[simp]
+theorem leftTotal_empty [IsEmpty α] : LeftTotal R := by
+  simp only [LeftTotal, IsEmpty.forall_iff]
+
+@[simp]
+theorem rightTotal_empty [IsEmpty β] : RightTotal R := by
+  simp only [RightTotal, IsEmpty.forall_iff]
+
+@[simp]
+theorem biTotal_empty [IsEmpty α] [IsEmpty β] : BiTotal R :=
+  ⟨leftTotal_empty R, rightTotal_empty R⟩
+
+end

--- a/Mathlib/Logic/Relator.lean
+++ b/Mathlib/Logic/Relator.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 
 import Mathlib.Logic.Function.Defs
+import Mathlib.Logic.IsEmpty
 
 /-!
 # Relator for functions, pairs, sums, and lists.
@@ -84,6 +85,18 @@ lemma BiTotal.rel_exists (h : BiTotal R) :
 
 lemma left_unique_of_rel_eq {eq' : β → β → Prop} (he : (R ⇒ (R ⇒ Iff)) Eq eq') : LeftUnique R :=
   fun a b c (ac : R a c) (bc : R b c) => (he ac bc).mpr ((he bc bc).mp rfl)
+
+@[simp]
+theorem left_total_empty  {R : α → β → Prop} [IsEmpty α] : LeftTotal R := by
+  simp only [LeftTotal, IsEmpty.forall_iff]
+
+@[simp]
+theorem right_total_empty {R : α → β → Prop} [IsEmpty β] : RightTotal R := by
+  simp only [RightTotal, IsEmpty.forall_iff]
+
+@[simp]
+theorem bi_total_empty {R : α → β → Prop} [IsEmpty α] [IsEmpty β] : BiTotal R := by
+  simp only [BiTotal, left_total_empty, right_total_empty, and_self]
 
 end
 

--- a/Mathlib/Logic/Relator.lean
+++ b/Mathlib/Logic/Relator.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl
 -/
 
 import Mathlib.Logic.Function.Defs
-import Mathlib.Logic.IsEmpty
 
 /-!
 # Relator for functions, pairs, sums, and lists.
@@ -85,18 +84,6 @@ lemma BiTotal.rel_exists (h : BiTotal R) :
 
 lemma left_unique_of_rel_eq {eq' : β → β → Prop} (he : (R ⇒ (R ⇒ Iff)) Eq eq') : LeftUnique R :=
   fun a b c (ac : R a c) (bc : R b c) => (he ac bc).mpr ((he bc bc).mp rfl)
-
-@[simp]
-theorem left_total_empty  {R : α → β → Prop} [IsEmpty α] : LeftTotal R := by
-  simp only [LeftTotal, IsEmpty.forall_iff]
-
-@[simp]
-theorem right_total_empty {R : α → β → Prop} [IsEmpty β] : RightTotal R := by
-  simp only [RightTotal, IsEmpty.forall_iff]
-
-@[simp]
-theorem bi_total_empty {R : α → β → Prop} [IsEmpty α] [IsEmpty β] : BiTotal R := by
-  simp only [BiTotal, left_total_empty, right_total_empty, and_self]
 
 end
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -6,6 +6,7 @@ Authors: Reid Barton, Mario Carneiro, Isabel Longbottom, Kim Morrison, Yuyang Zh
 import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Data.List.InsertIdx
 import Mathlib.Logic.Relation
+import Mathlib.Logic.IsEmpty
 import Mathlib.Logic.Small.Defs
 import Mathlib.Order.GameAdd
 
@@ -393,7 +394,7 @@ theorem moveRight_memᵣ (x : PGame) (b) : x.moveRight b ∈ᵣ x := ⟨_, .rfl�
 theorem identical_of_isEmpty (x y : PGame)
     [IsEmpty x.LeftMoves] [IsEmpty x.RightMoves]
     [IsEmpty y.LeftMoves] [IsEmpty y.RightMoves] : x ≡ y :=
-  identical_iff.2 (by simp [Relator.biTotal_empty])
+  identical_iff.2 (by simp [biTotal_empty])
 
 /-- `Identical` as a `Setoid`. -/
 def identicalSetoid : Setoid PGame :=

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -6,6 +6,7 @@ Authors: Reid Barton, Mario Carneiro, Isabel Longbottom, Kim Morrison, Yuyang Zh
 import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Data.List.InsertIdx
 import Mathlib.Logic.Relation
+import Mathlib.Logic.Relator
 import Mathlib.Logic.Small.Defs
 import Mathlib.Order.GameAdd
 
@@ -393,7 +394,7 @@ theorem moveRight_memᵣ (x : PGame) (b) : x.moveRight b ∈ᵣ x := ⟨_, .rfl�
 theorem identical_of_isEmpty (x y : PGame)
     [IsEmpty x.LeftMoves] [IsEmpty x.RightMoves]
     [IsEmpty y.LeftMoves] [IsEmpty y.RightMoves] : x ≡ y :=
-  identical_iff.2 <| by simp [Relator.BiTotal, Relator.LeftTotal, Relator.RightTotal]
+  identical_iff.2 (by simp [Relator.bi_total_empty])
 
 /-- `Identical` as a `Setoid`. -/
 def identicalSetoid : Setoid PGame :=

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -6,7 +6,6 @@ Authors: Reid Barton, Mario Carneiro, Isabel Longbottom, Kim Morrison, Yuyang Zh
 import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Data.List.InsertIdx
 import Mathlib.Logic.Relation
-import Mathlib.Logic.IsEmpty
 import Mathlib.Logic.Small.Defs
 import Mathlib.Order.GameAdd
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -6,7 +6,6 @@ Authors: Reid Barton, Mario Carneiro, Isabel Longbottom, Kim Morrison, Yuyang Zh
 import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Data.List.InsertIdx
 import Mathlib.Logic.Relation
-import Mathlib.Logic.Relator
 import Mathlib.Logic.Small.Defs
 import Mathlib.Order.GameAdd
 
@@ -394,7 +393,7 @@ theorem moveRight_memᵣ (x : PGame) (b) : x.moveRight b ∈ᵣ x := ⟨_, .rfl�
 theorem identical_of_isEmpty (x y : PGame)
     [IsEmpty x.LeftMoves] [IsEmpty x.RightMoves]
     [IsEmpty y.LeftMoves] [IsEmpty y.RightMoves] : x ≡ y :=
-  identical_iff.2 (by simp [Relator.bi_total_empty])
+  identical_iff.2 (by simp [Relator.biTotal_empty])
 
 /-- `Identical` as a `Setoid`. -/
 def identicalSetoid : Setoid PGame :=


### PR DESCRIPTION
Adds left, right, and bi_total_empty, and golfs `identical_of_isEmpty` in `PGame` as a result.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
