### PR TITLE
[Merged by Bors] - feat(Algebra/Homology): more duality results

### DIFF
--- a/Mathlib/Algebra/Homology/Opposite.lean
+++ b/Mathlib/Algebra/Homology/Opposite.lean
@@ -213,6 +213,16 @@ instance (K : HomologicalComplex Vᵒᵖ c) (i : ι) [K.HasHomology i] :
     K.unop.HasHomology i :=
   (inferInstance : (K.sc i).unop.HasHomology)
 
+instance (K : HomologicalComplex V c) (i : ι) [K.HasHomology i] :
+    ((opFunctor _ _).obj (op K)).HasHomology i := by
+  dsimp
+  infer_instance
+
+instance (K : HomologicalComplex Vᵒᵖ c) (i : ι) [K.HasHomology i] :
+    ((unopFunctor _ _).obj (op K)).HasHomology i := by
+  dsimp
+  infer_instance
+
 variable {V c}
 
 /-- If `K` is a homological complex, then the homology of `K.op` identifies to
@@ -226,6 +236,57 @@ then the homology of `K.unop` identifies to the opposite of the homology of `K`.
 def homologyUnop (K : HomologicalComplex Vᵒᵖ c) (i : ι) [K.HasHomology i] :
     K.unop.homology i ≅ unop (K.homology i) :=
   (K.unop.homologyOp i).unop
+
+section
+
+variable (K : HomologicalComplex V c) (i : ι) [K.HasHomology i]
+
+/-- The canonical isomorphism `K.op.cycles i ≅ op (K.opcycles i)`. -/
+def cyclesOpIso : K.op.cycles i ≅ op (K.opcycles i) :=
+  (K.sc i).cyclesOpIso
+
+/-- The canonical isomorphism `K.op.opcycles i ≅ op (K.cycles i)`. -/
+def opcyclesOpIso : K.op.opcycles i ≅ op (K.cycles i) :=
+  (K.sc i).opcyclesOpIso
+
+variable (j : ι)
+
+@[reassoc (attr := simp)]
+lemma opcyclesOpIso_hom_toCycles_op :
+    (K.opcyclesOpIso i).hom ≫ (K.toCycles j i).op = K.op.fromOpcycles i j := by
+  by_cases hij : c.Rel j i
+  · obtain rfl := c.prev_eq' hij
+    exact (K.sc i).opcyclesOpIso_hom_toCycles_op
+  · rw [K.toCycles_eq_zero hij, K.op.fromOpcycles_eq_zero hij, op_zero, comp_zero]
+
+@[reassoc (attr := simp)]
+lemma fromOpcycles_op_cyclesOpIso_inv :
+    (K.fromOpcycles i j).op ≫ (K.cyclesOpIso i).inv = K.op.toCycles j i := by
+  by_cases hij : c.Rel i j
+  · obtain rfl := c.next_eq' hij
+    exact (K.sc i).fromOpcycles_op_cyclesOpIso_inv
+  · rw [K.op.toCycles_eq_zero hij, K.fromOpcycles_eq_zero hij, op_zero, zero_comp]
+
+end
+
+section
+
+variable {K L : HomologicalComplex V c} (φ : K ⟶ L) (i : ι)
+  [K.HasHomology i] [L.HasHomology i]
+
+@[reassoc]
+lemma opcyclesOpIso_hom_naturality :
+    (L.opcyclesOpIso i).hom ≫ (cyclesMap φ i).op =
+      opcyclesMap ((opFunctor _ _).map φ.op) _ ≫ (K.opcyclesOpIso i).hom :=
+  ShortComplex.opcyclesOpIso_hom_naturality ((shortComplexFunctor V c i).map φ)
+
+@[reassoc]
+lemma cyclesOpIso_inv_naturality :
+    (opcyclesMap φ i).op ≫ (K.cyclesOpIso i).inv =
+      (L.cyclesOpIso i).inv ≫ cyclesMap ((opFunctor _ _).map φ.op) _ :=
+  ShortComplex.cyclesOpIso_inv_naturality ((shortComplexFunctor V c i).map φ)
+
+end
 
 end
 

--- a/Mathlib/Algebra/Homology/Opposite.lean
+++ b/Mathlib/Algebra/Homology/Opposite.lean
@@ -275,16 +275,59 @@ variable {K L : HomologicalComplex V c} (φ : K ⟶ L) (i : ι)
   [K.HasHomology i] [L.HasHomology i]
 
 @[reassoc]
+lemma homologyOp_hom_naturality :
+    homologyMap ((opFunctor _ _).map φ.op) _ ≫ (K.homologyOp i).hom =
+      (L.homologyOp i).hom ≫ (homologyMap φ i).op :=
+  ShortComplex.homologyOpIso_hom_naturality ((shortComplexFunctor V c i).map φ)
+
+@[reassoc]
 lemma opcyclesOpIso_hom_naturality :
-    (L.opcyclesOpIso i).hom ≫ (cyclesMap φ i).op =
-      opcyclesMap ((opFunctor _ _).map φ.op) _ ≫ (K.opcyclesOpIso i).hom :=
+    opcyclesMap ((opFunctor _ _).map φ.op) _ ≫ (K.opcyclesOpIso i).hom =
+      (L.opcyclesOpIso i).hom ≫ (cyclesMap φ i).op :=
   ShortComplex.opcyclesOpIso_hom_naturality ((shortComplexFunctor V c i).map φ)
+
+@[reassoc]
+lemma opcyclesOpIso_inv_naturality :
+    (cyclesMap φ i).op ≫ (K.opcyclesOpIso i).inv =
+      (L.opcyclesOpIso i).inv ≫ opcyclesMap ((opFunctor _ _).map φ.op) _ :=
+  ShortComplex.opcyclesOpIso_inv_naturality ((shortComplexFunctor V c i).map φ)
+
+@[reassoc]
+lemma cyclesOpIso_hom_naturality :
+    cyclesMap ((opFunctor _ _).map φ.op) _ ≫ (K.cyclesOpIso i).hom =
+      (L.cyclesOpIso i).hom ≫ (opcyclesMap φ i).op :=
+  ShortComplex.cyclesOpIso_hom_naturality ((shortComplexFunctor V c i).map φ)
 
 @[reassoc]
 lemma cyclesOpIso_inv_naturality :
     (opcyclesMap φ i).op ≫ (K.cyclesOpIso i).inv =
       (L.cyclesOpIso i).inv ≫ cyclesMap ((opFunctor _ _).map φ.op) _ :=
   ShortComplex.cyclesOpIso_inv_naturality ((shortComplexFunctor V c i).map φ)
+
+end
+
+section
+
+variable (V c) [CategoryWithHomology V] (i : ι)
+
+/-- The natural isomorphism `K.op.cycles i ≅ op (K.opcycles i)`. -/
+@[simps!]
+def cyclesOpNatIso :
+    opFunctor V c ⋙ cyclesFunctor Vᵒᵖ c.symm i ≅ (opcyclesFunctor V c i).op :=
+  NatIso.ofComponents (fun K ↦ (unop K).cyclesOpIso i)
+    (fun _ ↦ cyclesOpIso_hom_naturality _ _)
+
+/-- The natural isomorphism `K.op.opcycles i ≅ op (K.cycles i)`. -/
+def opcyclesOpNatIso :
+    opFunctor V c ⋙ opcyclesFunctor Vᵒᵖ c.symm i ≅ (cyclesFunctor V c i).op :=
+  NatIso.ofComponents (fun K ↦ (unop K).opcyclesOpIso i)
+    (fun _ ↦ opcyclesOpIso_hom_naturality _ _)
+
+/-- The natural isomorphism `K.op.homology i ≅ op (K.homology i)`. -/
+def homologyOpNatIso :
+    opFunctor V c ⋙ homologyFunctor Vᵒᵖ c.symm i ≅ (homologyFunctor V c i).op :=
+  NatIso.ofComponents (fun K ↦ (unop K).homologyOp i) (by
+    sorry)
 
 end
 

--- a/Mathlib/Algebra/Homology/Opposite.lean
+++ b/Mathlib/Algebra/Homology/Opposite.lean
@@ -326,8 +326,8 @@ def opcyclesOpNatIso :
 /-- The natural isomorphism `K.op.homology i ≅ op (K.homology i)`. -/
 def homologyOpNatIso :
     opFunctor V c ⋙ homologyFunctor Vᵒᵖ c.symm i ≅ (homologyFunctor V c i).op :=
-  NatIso.ofComponents (fun K ↦ (unop K).homologyOp i) (by
-    sorry)
+  NatIso.ofComponents (fun K ↦ (unop K).homologyOp i)
+    (fun _ ↦ homologyOp_hom_naturality _ _)
 
 end
 

--- a/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
@@ -149,6 +149,11 @@ lemma d_toCycles [K.HasHomology k] :
     K.d i j ≫ K.toCycles j k = 0 := by
   simp only [← cancel_mono (K.iCycles k), assoc, toCycles_i, d_comp_d, zero_comp]
 
+variable {i j} in
+lemma toCycles_eq_zero [K.HasHomology j] (hij : ¬ c.Rel i j) :
+    K.toCycles i j = 0 := by
+  rw [← cancel_mono (K.iCycles j), toCycles_i, zero_comp, K.shape _ _ hij]
+
 variable {i}
 
 section
@@ -257,6 +262,11 @@ instance : Mono (K.homologyι i) := by
 lemma fromOpcycles_d :
     K.fromOpcycles i j ≫ K.d j k = 0 := by
   simp only [← cancel_epi (K.pOpcycles i), p_fromOpcycles_assoc, d_comp_d, comp_zero]
+
+variable {i j} in
+lemma fromOpcycles_eq_zero (hij : ¬ c.Rel i j) :
+    K.fromOpcycles i j = 0 := by
+  rw [← cancel_epi (K.pOpcycles i), p_fromOpcycles, comp_zero, K.shape _ _ hij]
 
 variable {i}
 

--- a/Mathlib/Algebra/Homology/ShortComplex/Homology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Homology.lean
@@ -1036,6 +1036,18 @@ lemma homologyMap_op [HasHomology S₁] [HasHomology S₂] :
   simp only [assoc, rightHomologyMap'_op, op_comp, ← leftHomologyMap'_comp_assoc, id_comp,
     opMap_id, comp_id, HomologyData.op_left]
 
+@[reassoc]
+lemma homologyOpIso_hom_naturality [S₁.HasHomology] [S₂.HasHomology] :
+    homologyMap (opMap φ) ≫ (S₁.homologyOpIso).hom =
+      S₂.homologyOpIso.hom ≫ (homologyMap φ).op := by
+  simp [homologyMap_op]
+
+@[reassoc]
+lemma homologyOpIso_inv_naturality [S₁.HasHomology] [S₂.HasHomology] :
+    (homologyMap φ).op ≫ (S₁.homologyOpIso).inv =
+      S₂.homologyOpIso.inv ≫ homologyMap (opMap φ) := by
+  simp [homologyMap_op]
+
 variable (C)
 
 /-- The natural isomorphism `(homologyFunctor C).op ≅ opFunctor C ⋙ homologyFunctor Cᵒᵖ`
@@ -1043,7 +1055,7 @@ which relates the homology in `C` and in `Cᵒᵖ`. -/
 noncomputable def homologyFunctorOpNatIso [CategoryWithHomology C] :
     (homologyFunctor C).op ≅ opFunctor C ⋙ homologyFunctor Cᵒᵖ :=
   NatIso.ofComponents (fun S => S.unop.homologyOpIso.symm)
-    (by simp [homologyMap_op])
+    (fun _ ↦ homologyOpIso_inv_naturality _)
 
 variable {C} {A : C}
 

--- a/Mathlib/Algebra/Homology/ShortComplex/RightHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/RightHomology.lean
@@ -998,11 +998,19 @@ lemma cyclesOpIso_inv_op_iCycles [S.HasRightHomology] :
 @[reassoc]
 lemma opcyclesOpIso_hom_naturality (φ : S₁ ⟶ S₂)
     [S₁.HasLeftHomology] [S₂.HasLeftHomology] :
-    S₂.opcyclesOpIso.hom ≫ (cyclesMap φ).op =
-      opcyclesMap (opMap φ) ≫ (S₁.opcyclesOpIso).hom := by
+    opcyclesMap (opMap φ) ≫ (S₁.opcyclesOpIso).hom =
+      S₂.opcyclesOpIso.hom ≫ (cyclesMap φ).op := by
   rw [← cancel_epi S₂.op.pOpcycles, p_opcyclesMap_assoc, opMap_τ₂,
     op_pOpcycles_opcyclesOpIso_hom, op_pOpcycles_opcyclesOpIso_hom_assoc, ← op_comp,
-    cyclesMap_i, op_comp]
+    ← op_comp, cyclesMap_i]
+
+@[reassoc]
+lemma opcyclesOpIso_inv_naturality (φ : S₁ ⟶ S₂)
+    [S₁.HasLeftHomology] [S₂.HasLeftHomology] :
+    (cyclesMap φ).op ≫ (S₁.opcyclesOpIso).inv =
+      S₂.opcyclesOpIso.inv ≫ opcyclesMap (opMap φ) := by
+  rw [← cancel_epi (S₂.opcyclesOpIso.hom), Iso.hom_inv_id_assoc,
+    ← opcyclesOpIso_hom_naturality_assoc, Iso.hom_inv_id, comp_id]
 
 @[reassoc]
 lemma cyclesOpIso_inv_naturality (φ : S₁ ⟶ S₂)
@@ -1011,6 +1019,14 @@ lemma cyclesOpIso_inv_naturality (φ : S₁ ⟶ S₂)
       S₂.cyclesOpIso.inv ≫ cyclesMap (opMap φ) := by
   rw [← cancel_mono S₁.op.iCycles, assoc, assoc, cyclesOpIso_inv_op_iCycles, cyclesMap_i,
     cyclesOpIso_inv_op_iCycles_assoc, ← op_comp, p_opcyclesMap, op_comp, opMap_τ₂]
+
+@[reassoc]
+lemma cyclesOpIso_hom_naturality (φ : S₁ ⟶ S₂)
+    [S₁.HasRightHomology] [S₂.HasRightHomology] :
+    cyclesMap (opMap φ) ≫ (S₁.cyclesOpIso).hom =
+      S₂.cyclesOpIso.hom ≫ (opcyclesMap φ).op := by
+  rw [← cancel_mono (S₁.cyclesOpIso).inv, assoc, assoc, Iso.hom_inv_id, comp_id,
+    cyclesOpIso_inv_naturality, Iso.hom_inv_id_assoc]
 
 @[simp]
 lemma leftHomologyMap'_op

--- a/Mathlib/Algebra/Homology/ShortComplex/RightHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/RightHomology.lean
@@ -964,6 +964,54 @@ noncomputable def cyclesOpIso [S.HasRightHomology] :
     S.op.cycles ≅ Opposite.op S.opcycles :=
   S.rightHomologyData.op.cyclesIso
 
+@[reassoc (attr := simp)]
+lemma opcyclesOpIso_hom_toCycles_op [S.HasLeftHomology] :
+    S.opcyclesOpIso.hom ≫ S.toCycles.op = S.op.fromOpcycles := by
+  dsimp [opcyclesOpIso, toCycles]
+  rw [← cancel_epi S.op.pOpcycles, p_fromOpcycles,
+    RightHomologyData.pOpcycles_comp_opcyclesIso_hom_assoc,
+    LeftHomologyData.op_p, ← op_comp, LeftHomologyData.f'_i, op_g]
+
+@[reassoc (attr := simp)]
+lemma fromOpcycles_op_cyclesOpIso_inv [S.HasRightHomology]:
+    S.fromOpcycles.op ≫ S.cyclesOpIso.inv = S.op.toCycles := by
+  dsimp [cyclesOpIso, fromOpcycles]
+  rw [← cancel_mono S.op.iCycles, assoc, toCycles_i,
+    LeftHomologyData.cyclesIso_inv_comp_iCycles, RightHomologyData.op_i,
+    ← op_comp, RightHomologyData.p_g', op_f]
+
+@[reassoc (attr := simp)]
+lemma op_pOpcycles_opcyclesOpIso_hom [S.HasLeftHomology] :
+    S.op.pOpcycles ≫ S.opcyclesOpIso.hom = S.iCycles.op := by
+  dsimp [opcyclesOpIso]
+  rw [← S.leftHomologyData.op.p_comp_opcyclesIso_inv, assoc,
+    Iso.inv_hom_id, comp_id]
+  rfl
+
+@[reassoc (attr := simp)]
+lemma cyclesOpIso_inv_op_iCycles [S.HasRightHomology] :
+    S.cyclesOpIso.inv ≫ S.op.iCycles = S.pOpcycles.op := by
+  dsimp [cyclesOpIso]
+  rw [← S.rightHomologyData.op.cyclesIso_hom_comp_i, Iso.inv_hom_id_assoc]
+  rfl
+
+@[reassoc]
+lemma opcyclesOpIso_hom_naturality (φ : S₁ ⟶ S₂)
+    [S₁.HasLeftHomology] [S₂.HasLeftHomology] :
+    S₂.opcyclesOpIso.hom ≫ (cyclesMap φ).op =
+      opcyclesMap (opMap φ) ≫ (S₁.opcyclesOpIso).hom := by
+  rw [← cancel_epi S₂.op.pOpcycles, p_opcyclesMap_assoc, opMap_τ₂,
+    op_pOpcycles_opcyclesOpIso_hom, op_pOpcycles_opcyclesOpIso_hom_assoc, ← op_comp,
+    cyclesMap_i, op_comp]
+
+@[reassoc]
+lemma cyclesOpIso_inv_naturality (φ : S₁ ⟶ S₂)
+    [S₁.HasRightHomology] [S₂.HasRightHomology] :
+    (opcyclesMap φ).op ≫ (S₁.cyclesOpIso).inv =
+      S₂.cyclesOpIso.inv ≫ cyclesMap (opMap φ) := by
+  rw [← cancel_mono S₁.op.iCycles, assoc, assoc, cyclesOpIso_inv_op_iCycles, cyclesMap_i,
+    cyclesOpIso_inv_op_iCycles_assoc, ← op_comp, p_opcyclesMap, op_comp, opMap_τ₂]
+
 @[simp]
 lemma leftHomologyMap'_op
     (φ : S₁ ⟶ S₂) (h₁ : S₁.LeftHomologyData) (h₂ : S₂.LeftHomologyData) :


### PR DESCRIPTION
Given an homological complex `K`, we introduce duality isomorphisms like `cyclesOpIso : K.op.cycles i ≅ op (K.opcycles i)` and study their naturality.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
