### PR TITLE
[Merged by Bors] - feat(Algebra/Homology/Embedding): dualise extend

### DIFF
--- a/Mathlib/Algebra/Homology/Embedding/Extend.lean
+++ b/Mathlib/Algebra/Homology/Embedding/Extend.lean
@@ -5,6 +5,7 @@ Authors: Joël Riou
 -/
 import Mathlib.Algebra.Homology.Embedding.Basic
 import Mathlib.Algebra.Homology.Additive
+import Mathlib.Algebra.Homology.Opposite
 
 /-!
 # The extension of a homological complex by an embedding of complex shapes
@@ -46,6 +47,12 @@ lemma isZero_X {i : Option ι} (hi : i = none) :
   subst hi
   exact Limits.isZero_zero _
 
+/-- The canonical isomorphism `X K.op i ≅ Opposite.op (X K i)`. -/
+noncomputable def XOpIso (i : Option ι) : X K.op i ≅ Opposite.op (X K i) :=
+  match i with
+  | some _ => Iso.refl _
+  | none => IsZero.iso (isZero_X _ rfl) (isZero_X K rfl).op
+
 /-- Auxiliary definition for the `d` field of `HomologicalComplex.extend`. -/
 noncomputable def d : ∀ (i j : Option ι), extend.X K i ⟶ extend.X K j
   | none, _ => 0
@@ -63,6 +70,21 @@ lemma d_eq {i j : Option ι} {a b : ι} (hi : i = some a) (hj : j = some b) :
   subst hi hj
   dsimp [XIso, d]
   erw [id_comp, comp_id]
+
+@[reassoc]
+lemma XOpIso_hom_d_op (i j : Option ι) :
+    (XOpIso K i).hom ≫ (d K j i).op =
+      d K.op i j ≫ (XOpIso K j).hom :=
+  match i, j with
+  | none, _ => by
+      simp only [d_none_eq_zero, d_none_eq_zero', comp_zero, zero_comp, op_zero]
+  | some i, some j => by
+      dsimp [XOpIso]
+      simp only [d_eq _ rfl rfl, Option.some.injEq, d_eq, op_comp, assoc,
+        id_comp, comp_id]
+      rfl
+  | some _, none => by
+      simp only [d_none_eq_zero, d_none_eq_zero', comp_zero, zero_comp, op_zero]
 
 variable {K L}
 
@@ -221,6 +243,20 @@ lemma extendMap_zero : extendMap (0 : K ⟶ L) e = 0 := by
   · obtain ⟨i, hi⟩ := hi'
     simp [extendMap_f _ e hi]
   · apply (K.isZero_extend_X e i' (fun i hi => hi' ⟨i, hi⟩)).eq_of_src
+
+/-- The canonical isomorphism `K.op.extend e.op ≅ (K.extend e).op`. -/
+noncomputable def extendOpIso : K.op.extend e.op ≅ (K.extend e).op :=
+  Hom.isoOfComponents (fun _ ↦ extend.XOpIso _ _) (fun _ _ _ ↦
+    extend.XOpIso_hom_d_op _ _ _)
+
+@[reassoc]
+lemma extend_op_d (i' j' : ι') :
+    (K.op.extend e.op).d i' j' =
+      (K.extendOpIso e).hom.f i' ≫ ((K.extend e).d j' i').op ≫
+        (K.extendOpIso e).inv.f j' := by
+  have := (K.extendOpIso e).inv.comm i' j'
+  dsimp at this
+  rw [← this, ← comp_f_assoc, Iso.hom_inv_id, id_f, id_comp]
 
 end
 


### PR DESCRIPTION
When `e` is an embedding of complex shapes, we obtain an isomorphism `extendOpIso : K.op.extend e.op ≅ (K.extend e).op`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
