### PR TITLE
[Merged by Bors] - chore: golf isRoot_of_isRoot_of_dvd_derivative_mul

### DIFF
--- a/Mathlib/Algebra/Polynomial/FieldDivision.lean
+++ b/Mathlib/Algebra/Polynomial/FieldDivision.lean
@@ -175,11 +175,10 @@ See `isRoot_of_isRoot_iff_dvd_derivative_mul` -/
 theorem isRoot_of_isRoot_of_dvd_derivative_mul [CharZero R] {f g : R[X]} (hf0 : f ≠ 0)
     (hfd : f ∣ f.derivative * g) {a : R} (haf : f.IsRoot a) : g.IsRoot a := by
   rcases hfd with ⟨r, hr⟩
-  by_cases hdf0 : derivative f = 0
-  · rw [eq_C_of_derivative_eq_zero hdf0] at haf hf0
-    simp only [eval_C, derivative_C, zero_mul, dvd_zero, iff_true, IsRoot.def] at haf
-    rw [haf, map_zero] at hf0
-    exact (hf0 rfl).elim
+  have hdf0 : derivative f ≠ 0 := by
+    contrapose! haf
+    rw [eq_C_of_derivative_eq_zero haf] at hf0 ⊢
+    exact not_isRoot_C _ _ <| C_ne_zero.mp hf0
   by_contra hg
   have hdfg0 : f.derivative * g ≠ 0 := mul_ne_zero hdf0 (by rintro rfl; simp at hg)
   have hr' := congr_arg (rootMultiplicity a) hr


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
