### PR TITLE
[Merged by Bors] - feat(GroupTheory/SpecificGroups/ZGroup): A nilpotent group with cyclic Sylow subgroups is cyclic

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
 import Mathlib.Algebra.Squarefree.Basic
-import Mathlib.GroupTheory.Sylow
+import Mathlib.GroupTheory.Nilpotent
 
 /-!
 # Z-Groups
@@ -29,6 +29,9 @@ variable (G G' : Type*) [Group G] [Group G'] (f : G →* G')
 variable {G G' f}
 
 namespace IsZGroup
+
+instance [IsZGroup G] {p : ℕ} [Fact p.Prime] (P : Sylow p G) : IsCyclic P :=
+  isZGroup p Fact.out P
 
 theorem of_squarefree (hG : Squarefree (Nat.card G)) : IsZGroup G := by
   have : Finite G := Nat.finite_of_card_ne_zero hG.ne_zero
@@ -58,5 +61,25 @@ theorem of_surjective [Finite G] [hG : IsZGroup G] (hf : Function.Surjective f) 
 
 instance [Finite G] [IsZGroup G] (H : Subgroup G) [H.Normal] : IsZGroup (G ⧸ H) :=
   of_surjective (QuotientGroup.mk'_surjective H)
+
+theorem exponent_eq_card [Finite G] [IsZGroup G] : Monoid.exponent G = Nat.card G := by
+  refine dvd_antisymm Group.exponent_dvd_nat_card ?_
+  rw [← Nat.factorization_prime_le_iff_dvd Nat.card_pos.ne' Monoid.exponent_ne_zero_of_finite]
+  intro p hp
+  have := Fact.mk hp
+  let P : Sylow p G := default
+  rw [← hp.pow_dvd_iff_le_factorization Monoid.exponent_ne_zero_of_finite,
+      ← P.card_eq_multiplicity, ← (isZGroup p hp P).exponent_eq_card]
+  exact Monoid.exponent_dvd_of_monoidHom P.1.subtype P.1.subtype_injective
+
+instance [Finite G] [IsZGroup G] [hG : Group.IsNilpotent G] : IsCyclic G := by
+  have (p : { x // x ∈ (Nat.card G).primeFactors }) : Fact p.1.Prime :=
+    ⟨Nat.prime_of_mem_primeFactors p.2⟩
+  let h (p : { x // x ∈ (Nat.card G).primeFactors }) (P : Sylow p G) : CommGroup P :=
+    IsCyclic.commGroup
+  obtain ⟨ϕ⟩ := ((isNilpotent_of_finite_tfae (G := G)).out 0 4).mp hG
+  let _ : CommGroup G :=
+    ⟨fun g h ↦ by rw [← ϕ.symm.injective.eq_iff, map_mul, mul_comm, ← map_mul]⟩
+  exact IsCyclic.of_exponent_eq_card exponent_eq_card
 
 end IsZGroup


### PR DESCRIPTION
This PR proves that a nilpotent Z-group (a group with cyclic Sylow subgroups) is cyclic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
