### PR TITLE
[Merged by Bors] - chore: bump toolchain to v4.14.0-rc3

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.14.0-rc2
+leanprover/lean4:v4.14.0-rc3


### PR DESCRIPTION
This bumps the toolchain to v4.14.0-rc3. This differs from rc2 only in changes to the behaviour of Lake, which will hopefully eliminate problems with ProofWidgets.