### PR TITLE
[Merged by Bors] - fix: add `realm_emoji` (and `emoji_code`) to auto-zulip reactions

### DIFF
--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -82,7 +82,9 @@ for message in messages:
             print('Removing bors')
             result = client.remove_reaction({
                 "message_id": message['id'],
-                "emoji_name": "bors"
+                "emoji_name": "bors",
+                "emoji_code": "22134",
+                "reaction_type": "realm_emoji",
             })
             print(f"result: '{result}'")
         if has_merge:


### PR DESCRIPTION
[Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2319522.3A.20emoji.20reactions.20to.20all.20public.20channels/near/485003969)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
