### PR TITLE
[Merged by Bors] - chore(Data/Int): move `Pi.instIntCast`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2519,6 +2519,7 @@ import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Data.Int.Cast.Defs
 import Mathlib.Data.Int.Cast.Field
 import Mathlib.Data.Int.Cast.Lemmas
+import Mathlib.Data.Int.Cast.Pi
 import Mathlib.Data.Int.Cast.Prod
 import Mathlib.Data.Int.CharZero
 import Mathlib.Data.Int.ConditionallyCompleteOrder

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -366,25 +366,3 @@ end NonAssocRing
 @[simp]
 theorem Int.castRingHom_int : Int.castRingHom ℤ = RingHom.id ℤ :=
   (RingHom.id ℤ).eq_intCast'.symm
-
-namespace Pi
-
-variable {π : ι → Type*} [∀ i, IntCast (π i)]
-
-instance instIntCast : IntCast (∀ i, π i) where intCast n _ := n
-
-theorem intCast_apply (n : ℤ) (i : ι) : (n : ∀ i, π i) i = n :=
-  rfl
-
-@[simp]
-theorem intCast_def (n : ℤ) : (n : ∀ i, π i) = fun _ => ↑n :=
-  rfl
-
-@[deprecated (since := "2024-04-05")] alias int_apply := intCast_apply
-@[deprecated (since := "2024-04-05")] alias coe_int := intCast_def
-
-end Pi
-
-theorem Sum.elim_intCast_intCast {α β γ : Type*} [IntCast γ] (n : ℤ) :
-    Sum.elim (n : α → γ) (n : β → γ) = n :=
-  Sum.elim_lam_const_lam_const (γ := γ) n

--- a/Mathlib/Data/Int/Cast/Pi.lean
+++ b/Mathlib/Data/Int/Cast/Pi.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2017 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Batteries.Tactic.Alias
+import Mathlib.Data.Int.Notation
+import Mathlib.Tactic.TypeStar
+import Mathlib.Util.AssertExists
+
+/-!
+# Cast of integers to function types
+
+This file provides a (pointwise) cast from `ℤ` to function types.
+
+## Main declarations
+
+* `Pi.instIntCast`: map `n : ℤ` to the constant function `n : ∀ i, π i` 
+-/
+
+assert_not_exists OrderedCommMonoid
+assert_not_exists RingHom
+
+namespace Pi
+
+variable {ι : Type*} {π : ι → Type*} [∀ i, IntCast (π i)]
+
+instance instIntCast : IntCast (∀ i, π i) where intCast n _ := n
+
+theorem intCast_apply (n : ℤ) (i : ι) : (n : ∀ i, π i) i = n :=
+  rfl
+
+@[simp]
+theorem intCast_def (n : ℤ) : (n : ∀ i, π i) = fun _ => ↑n :=
+  rfl
+
+@[deprecated (since := "2024-04-05")] alias int_apply := intCast_apply
+@[deprecated (since := "2024-04-05")] alias coe_int := intCast_def
+
+end Pi
+
+theorem Sum.elim_intCast_intCast {α β γ : Type*} [IntCast γ] (n : ℤ) :
+    Sum.elim (n : α → γ) (n : β → γ) = n :=
+  Sum.elim_lam_const_lam_const (γ := γ) n

--- a/Mathlib/Data/Int/Cast/Pi.lean
+++ b/Mathlib/Data/Int/Cast/Pi.lean
@@ -15,7 +15,7 @@ This file provides a (pointwise) cast from `ℤ` to function types.
 
 ## Main declarations
 
-* `Pi.instIntCast`: map `n : ℤ` to the constant function `n : ∀ i, π i` 
+* `Pi.instIntCast`: map `n : ℤ` to the constant function `n : ∀ i, π i`
 -/
 
 assert_not_exists OrderedCommMonoid

--- a/Mathlib/Data/Int/CharZero.lean
+++ b/Mathlib/Data/Int/CharZero.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro
 import Mathlib.Algebra.Group.Support
 import Mathlib.Data.Int.Cast.Field
 import Mathlib.Data.Int.Cast.Lemmas
+import Mathlib.Data.Int.Cast.Pi
 
 /-!
 # Injectivity of `Int.Cast` into characteristic zero rings and fields.

--- a/Mathlib/Data/Matrix/Diagonal.lean
+++ b/Mathlib/Data/Matrix/Diagonal.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Ellen Arlt. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin, Lu-Ming Zhang
 -/
-import Mathlib.Data.Int.Cast.Lemmas
+import Mathlib.Data.Int.Cast.Pi
 import Mathlib.Data.Matrix.Defs
 import Mathlib.Data.Nat.Cast.Basic
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -4,14 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Data.Finset.Update
-import Mathlib.Data.Int.Cast.Lemmas
+import Mathlib.Data.Int.Cast.Pi
+import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Data.Prod.TProd
 import Mathlib.Data.Set.UnionLift
 import Mathlib.GroupTheory.Coset.Defs
 import Mathlib.MeasureTheory.MeasurableSpace.Instances
 import Mathlib.Order.Filter.SmallSets
-import Mathlib.Tactic.FinCases
 import Mathlib.Order.LiminfLimsup
+import Mathlib.Tactic.FinCases
 
 /-!
 # Measurable spaces and measurable functions

--- a/Mathlib/Order/Filter/Germ/Basic.lean
+++ b/Mathlib/Order/Filter/Germ/Basic.lean
@@ -5,7 +5,8 @@ Authors: Yury Kudryashov, Abhimanyu Pallavi Sudhir
 -/
 import Mathlib.Algebra.Module.Pi
 import Mathlib.Algebra.Order.Monoid.Unbundled.ExistsOfLE
-import Mathlib.Data.Int.Cast.Lemmas
+import Mathlib.Data.Int.Cast.Pi
+import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Order.Filter.Tendsto
 
 /-!


### PR DESCRIPTION
This instance was found in `Data.Int.Cast.Lemmas` and is used quite a few times without all the theory in those files.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
