### PR TITLE
fix: fix the definition of the absolute Galois group of a field

### DIFF
--- a/Mathlib/FieldTheory/AbsoluteGaloisGroup.lean
+++ b/Mathlib/FieldTheory/AbsoluteGaloisGroup.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: María Inés de Frutos-Fernández
 -/
 import Mathlib.FieldTheory.KrullTopology
-import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
+import Mathlib.FieldTheory.SeparableClosure
 import Mathlib.Topology.Algebra.Group.TopologicalAbelianization
 
 /-!
@@ -13,8 +13,8 @@ import Mathlib.Topology.Algebra.Group.TopologicalAbelianization
 We define the absolute Galois group of a field `K` and its topological abelianization.
 
 ## Main definitions
-- `Field.absoluteGaloisGroup` : The Galois group of the field extension `K^al/K`, where `K^al` is an
-  algebraic closure of `K`.
+- `Field.absoluteGaloisGroup` : The Galois group of the field extension `K^al/K`, where `K^sep` is
+  "the" separable closure of `K`.
 - `Field.absoluteGaloisGroupAbelianization` : The topological abelianization of
   `Field.absoluteGaloisGroup K`, that is, the quotient of `Field.absoluteGaloisGroup K` by the
   topological closure of its commutator subgroup.
@@ -24,7 +24,7 @@ We define the absolute Galois group of a field `K` and its topological abelianiz
   commutator of `absoluteGaloisGroup` is a normal subgroup.
 
 ## Tags
-field, algebraic closure, galois group, abelianization
+field, separable closure, Galois group, absolute Galois group, abelianization
 
 -/
 
@@ -36,14 +36,23 @@ variable (K : Type*) [Field K]
 
 /-- The absolute Galois group of `K`, defined as the Galois group of the field extension `K^al/K`,
   where `K^al` is an algebraic closure of `K`. -/
-def absoluteGaloisGroup := AlgebraicClosure K ≃ₐ[K] AlgebraicClosure K
+def absoluteGaloisGroup := SeparableClosure K ≃ₐ[K] SeparableClosure K
 
 local notation "G_K" => absoluteGaloisGroup
 
 noncomputable instance : Group (G_K K) := AlgEquiv.aut
 
 /-- `absoluteGaloisGroup` is a topological space with the Krull topology. -/
-noncomputable instance : TopologicalSpace (G_K K) := krullTopology K (AlgebraicClosure K)
+noncomputable instance : TopologicalSpace (G_K K) := krullTopology K (SeparableClosure K)
+
+/-- `absoluteGaloisGroup` is T2 with the Krull topology. -/
+instance : T2Space (G_K K) := krullTopology_t2
+
+/-- `absoluteGaloisGroup` is totally disconnected with the Krull topology. -/
+instance : TotallyDisconnectedSpace (G_K K) := krullTopology_totallyDisconnectedSpace
+
+/-- `absoluteGaloisGroup` is a compact space. -/
+proof_wanted instCompactSpaceAbsoluteGaloisGroup : CompactSpace (G_K K)
 
 /-! ### The topological abelianization of the absolute Galois group -/
 

--- a/Mathlib/FieldTheory/AbsoluteGaloisGroup.lean
+++ b/Mathlib/FieldTheory/AbsoluteGaloisGroup.lean
@@ -13,7 +13,7 @@ import Mathlib.Topology.Algebra.Group.TopologicalAbelianization
 We define the absolute Galois group of a field `K` and its topological abelianization.
 
 ## Main definitions
-- `Field.absoluteGaloisGroup` : The Galois group of the field extension `K^al/K`, where `K^sep` is
+- `Field.absoluteGaloisGroup` : The Galois group of the field extension `K^sep/K`, where `K^sep` is
   "the" separable closure of `K`.
 - `Field.absoluteGaloisGroupAbelianization` : The topological abelianization of
   `Field.absoluteGaloisGroup K`, that is, the quotient of `Field.absoluteGaloisGroup K` by the
@@ -34,8 +34,8 @@ variable (K : Type*) [Field K]
 
 /-! ### The absolute Galois group -/
 
-/-- The absolute Galois group of `K`, defined as the Galois group of the field extension `K^al/K`,
-  where `K^al` is an algebraic closure of `K`. -/
+/-- The absolute Galois group of `K`, defined as the Galois group of the field extension `K^sep/K`,
+  where `K^sep` is the separable closure of `K`. -/
 def absoluteGaloisGroup := SeparableClosure K ≃ₐ[K] SeparableClosure K
 
 local notation "G_K" => absoluteGaloisGroup

--- a/Mathlib/FieldTheory/KrullTopology.lean
+++ b/Mathlib/FieldTheory/KrullTopology.lean
@@ -267,6 +267,12 @@ theorem krullTopology_totallyDisconnected {K L : Type*} [Field K] [Field L] [Alg
     not_forall]
   exact ⟨x, IntermediateField.mem_adjoin_simple_self K x, hx⟩
 
+/-- If `L/K` is an algebraic field extension, then the Krull topology on `L ≃ₐ[K] L` is
+  totally disconnected. -/
+theorem krullTopology_totallyDisconnectedSpace {K L : Type*} [Field K] [Field L] [Algebra K L]
+    [Algebra.IsIntegral K L] : TotallyDisconnectedSpace (L ≃ₐ[K] L) :=
+  ⟨krullTopology_totallyDisconnected⟩
+
 end TotallyDisconnected
 
 @[simp] lemma IntermediateField.fixingSubgroup_top (K L : Type*) [Field K] [Field L] [Algebra K L] :


### PR DESCRIPTION
Previously it was defined as the Galois group of the algebraic closure, as opposed to the separable closure.
Also, this adds some missing instances for this group.

Still missing is compactness, but that seems like a bigger project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
