### PR TITLE
fix(CI): build the Archive and Counterexamples with --wfail also

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -207,7 +207,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail Archive"
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -217,7 +217,7 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail Counterexamples"
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -186,6 +186,7 @@ jobs:
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: check the cache
+        id: "check-cache"
         run: |
           # Because the `lean-pr-testing-NNNN` branches use toolchains that are "updated in place"
           # the cache mechanism is unreliable, so we don't test it if we are on such a branch.
@@ -215,6 +216,8 @@ jobs:
 
       - name: build counterexamples
         id: counterexamples
+        # Even if building the archive failed, we build the Counterexamples directory.
+        if: ${{ !cancelled() }} && steps.check-cache.outcome == 'success'
         run: |
           lake exe cache get Counterexamples.lean
           bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail Counterexamples"

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -196,6 +196,7 @@ jobs:
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: check the cache
+        id: "check-cache"
         run: |
           # Because the `lean-pr-testing-NNNN` branches use toolchains that are "updated in place"
           # the cache mechanism is unreliable, so we don't test it if we are on such a branch.
@@ -225,6 +226,8 @@ jobs:
 
       - name: build counterexamples
         id: counterexamples
+        # Even if building the archive failed, we build the Counterexamples directory.
+        if: ${{ !cancelled() }} && steps.check-cache.outcome == 'success'
         run: |
           lake exe cache get Counterexamples.lean
           bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail Counterexamples"

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -217,7 +217,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail Archive"
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -227,7 +227,7 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail Counterexamples"
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail Archive"
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -234,7 +234,7 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail Counterexamples"
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,6 +203,7 @@ jobs:
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: check the cache
+        id: "check-cache"
         run: |
           # Because the `lean-pr-testing-NNNN` branches use toolchains that are "updated in place"
           # the cache mechanism is unreliable, so we don't test it if we are on such a branch.
@@ -232,6 +233,8 @@ jobs:
 
       - name: build counterexamples
         id: counterexamples
+        # Even if building the archive failed, we build the Counterexamples directory.
+        if: ${{ !cancelled() }} && steps.check-cache.outcome == 'success'
         run: |
           lake exe cache get Counterexamples.lean
           bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail Counterexamples"

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -221,7 +221,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail Archive"
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -231,7 +231,7 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail Counterexamples"
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -200,6 +200,7 @@ jobs:
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: check the cache
+        id: "check-cache"
         run: |
           # Because the `lean-pr-testing-NNNN` branches use toolchains that are "updated in place"
           # the cache mechanism is unreliable, so we don't test it if we are on such a branch.
@@ -229,6 +230,8 @@ jobs:
 
       - name: build counterexamples
         id: counterexamples
+        # Even if building the archive failed, we build the Counterexamples directory.
+        if: ${{ !cancelled() }} && steps.check-cache.outcome == 'success'
         run: |
           lake exe cache get Counterexamples.lean
           bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail Counterexamples"


### PR DESCRIPTION
This appears to be an oversight --- which has no consequences right now (the check for noisy output later would catch any warnings), but fixing it doesn't hurt either.
[Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/No.20.60--wfail.60.20when.20building.20archive).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
