### PR TITLE
[Merged by Bors] - feat: add a file tracking results from the 1000+ theorems project

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -250,7 +250,7 @@ jobs:
 
       - name: check declarations in db files
         run: |
-          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          python3 scripts/yaml_check.py docs/100.yaml docs/1000.yaml docs/overview.yaml docs/undergrad.yaml
           lake exe check-yaml
 
       - name: generate our import graph

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -260,7 +260,7 @@ jobs:
 
       - name: check declarations in db files
         run: |
-          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          python3 scripts/yaml_check.py docs/100.yaml docs/1000.yaml docs/overview.yaml docs/undergrad.yaml
           lake exe check-yaml
 
       - name: generate our import graph

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,7 +267,7 @@ jobs:
 
       - name: check declarations in db files
         run: |
-          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          python3 scripts/yaml_check.py docs/100.yaml docs/1000.yaml docs/overview.yaml docs/undergrad.yaml
           lake exe check-yaml
 
       - name: generate our import graph

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -264,7 +264,7 @@ jobs:
 
       - name: check declarations in db files
         run: |
-          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
+          python3 scripts/yaml_check.py docs/100.yaml docs/1000.yaml docs/overview.yaml docs/undergrad.yaml
           lake exe check-yaml
 
       - name: generate our import graph

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1,3 +1,14 @@
+# This file tracks the formalisation status of theorems from the experimental
+# 1000+ theorems project (https://1000-plus.github.io/).
+# This file and associated infrastructure are work in progress.
+#
+# Current TODOs/unresolved questions:
+# - should this file include further metadata, such as repository links, author names or dates?
+# - add infrastructure for updating the information upstream when formalisations are added
+# - perhaps add a wikidata version of the stacks tag, and generate this file automatically
+#   (can this handle formalisation of *statements* also?)
+# - complete the information which theorems are already formalised
+
 Q17001601:
   title: 2-factor theorem
 

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1,0 +1,3597 @@
+Q17001601:
+  title: 2-factor theorem
+
+Q4272645:
+  title: Final value theorem
+
+Q6360586:
+  title: "Kanamori\u2013McAloon theorem"
+
+Q1137206:
+  title: Taylor's theorem
+
+Q5337931:
+  title: Edgeworth's limit theorem
+
+Q339495:
+  title: Symphonic theorem
+
+Q4734844:
+  title: "Alperin\u2013Brauer\u2013Gorenstein theorem"
+
+Q7433295:
+  title: "Osterwalder\u2013Schrader theorem"
+
+Q3527189:
+  title: Lattice theorem
+
+Q995926:
+  title: Perpendicular axis theorem
+
+Q3527071:
+  title: "F\xE1ry\u2013Milnor theorem"
+
+Q26877569:
+  title: Furry's theorem
+
+Q7597317:
+  title: "Stallings\u2013Zeeman theorem"
+
+Q266291:
+  title: Bloch's theorem
+
+Q1621180:
+  title: "Orlicz\u2013Pettis theorem"
+
+Q1148215:
+  title: Mitchell's embedding theorem
+
+Q899002:
+  title: Pascal's theorem
+
+Q5195996:
+  title: "Curtis\u2013Hedlund\u2013Lyndon theorem"
+
+Q5385324:
+  title: "Erd\u0151s\u2013Nagy theorem"
+
+Q1057919:
+  title: Sylow theorems
+
+Q4975963:
+  title: Brown's representability theorem
+
+Q7160302:
+  title: Peeling theorem
+
+Q6528849:
+  title: Lerner symmetry theorem
+
+Q5443005:
+  title: "Fenchel\u2013Moreau theorem"
+
+Q28458131:
+  title: Glivenko's theorem
+
+Q3527100:
+  title: Kruskal's tree theorem
+
+Q656198:
+  title: Maschke's theorem
+
+Q18205730:
+  title: "Byers\u2013Yang theorem"
+
+Q2008549:
+  title: Hilbert's theorem
+
+Q6957141:
+  title: Nachbin's theorem
+
+Q245098:
+  title: Intermediate value theorem
+
+Q9993851:
+  title: "Lax\u2013Milgram theorem"
+
+Q6867867:
+  title: "Minkowski\u2013Hlawka theorem"
+
+Q5299605:
+  title: Glivenko's theorem
+
+Q1050037:
+  title: Coase theorem
+
+Q929547:
+  title: Myers theorem
+
+Q1660147:
+  title: "Mazur\u2013Ulam theorem"
+
+Q943246:
+  title: Wedderburn's little theorem
+
+Q791663:
+  title: Beatty's theorem
+
+Q2345282:
+  title: Shannon's theorem
+
+Q3534036:
+  title: Pompeiu's theorem
+
+Q5005965:
+  title: C-theorem
+
+Q6859648:
+  title: "Milliken\u2013Taylor theorem"
+
+Q25099402:
+  title: "Kolmogorov\u2013Arnold representation theorem"
+
+Q7525845:
+  title: "Sipser\u2013Lautemann theorem"
+
+Q3527102:
+  title: "Kruskal\u2013Katona theorem"
+
+Q5005143:
+  title: "B\xF4cher's theorem"
+
+Q978688:
+  title: Gershgorin circle theorem
+
+Q776578:
+  title: "Artin\u2013Wedderburn theorem"
+
+Q2277040:
+  title: Shannon's expansion theorem
+
+Q576478:
+  title: Liouville's theorem
+
+Q1914905:
+  title: "Ramanujan\u2013Skolem's theorem"
+
+Q909517:
+  title: "Feit\u2013Thompson theorem"
+
+Q4950096:
+  title: "Bourbaki\u2013Witt theorem"
+
+Q3527155:
+  title: "Robertson\u2013Seymour theorem"
+
+Q2226786:
+  title: Sperner's theorem
+
+Q96375449:
+  title: Conway circle theorem
+
+Q7272004:
+  title: "Quillen\u2013Suslin theorem"
+
+Q7849521:
+  title: Tsen's theorem
+
+Q5552370:
+  title: Geroch's splitting theorem
+
+Q737892:
+  title: "Bendixson\u2013Dulac theorem"
+
+Q1530275:
+  title: "Dunford\u2013Pettis theorem"
+
+Q5530454:
+  title: Gell-Mann and Low theorem
+
+Q1179446:
+  title: De Rham's theorem
+
+Q2063099:
+  title: "Poincar\xE9 duality theorem"
+
+Q2734084:
+  title: "Bohr\u2013Mollerup theorem"
+
+Q2226698:
+  title: Kantorovich theorem
+
+Q182505:
+  title: Bayes' theorem
+
+Q765987:
+  title: "Heine\u2013Cantor theorem"
+
+Q11573495:
+  title: Plancherel theorem for spherical functions
+
+Q7269106:
+  title: Quantum threshold theorem
+
+Q2109761:
+  title: Uniformization theorem
+
+Q4979609:
+  title: "Brun\u2013Titchmarsh theorem"
+
+Q2226691:
+  title: Kirchhoff's theorem
+
+Q1068085:
+  title: Closed graph theorem
+
+Q104871594:
+  title: Joubert's theorem
+
+Q6771536:
+  title: "Markus\u2212Yamabe theorem"
+
+Q208416:
+  title: Independence of the continuum hypothesis
+  url: https://github.com/flypitch/flypitch
+  author: Floris van Doorn and Jesse Michael Han
+
+Q1614464:
+  title: "Cauchy\u2013Kowalevski theorem"
+
+Q5221089:
+  title: Danskin's theorem
+
+Q26708:
+  title: Binomial theorem
+
+Q609612:
+  title: "Knaster\u2013Tarski theorem"
+
+Q17018210:
+  title: "Golod\u2013Shafarevich theorem"
+
+Q17104025:
+  title: Riemann singularity theorem
+
+Q1727461:
+  title: Intersecting secants theorem
+
+Q1052678:
+  title: Baire category theorem
+
+Q3154003:
+  title: Le Cam's theorem
+
+Q5443004:
+  title: Fenchel's theorem
+
+Q4455037:
+  title: Hardy's theorem
+
+Q1424481:
+  title: Frucht's theorem
+
+Q6722024:
+  title: MacMahon Master theorem
+
+Q4944906:
+  title: Borel determinacy theorem
+
+Q179208:
+  title: Cayley's theorem
+
+Q1307676:
+  title: "K\xFCnneth theorem"
+
+Q6119825:
+  title: "Jacobson\u2013Bourbaki theorem"
+
+Q5505098:
+  title: Frobenius determinant theorem
+
+Q5385323:
+  title: "Erd\u0151s\u2013Gallai theorem"
+
+Q7496252:
+  title: Shift theorem
+
+Q7100033A:
+  title: "Orbit theorem (Nagano\u2013Sussmann)"
+
+Q4455023:
+  title: Sazonov's theorem
+
+Q637418:
+  title: Napoleon's theorem
+
+Q1315949:
+  title: Mittag-Leffler's theorem
+
+Q3345678:
+  title: "Moore\u2013Aronszajn theorem"
+
+Q2525646:
+  title: "Jordan\u2013H\xF6lder theorem"
+
+Q994401:
+  title: Four-vertex theorem
+
+Q5296972:
+  title: "Doob\u2013Meyer decomposition theorem"
+
+Q1076274:
+  title: "Choquet\u2013Bishop\u2013de Leeuw theorem"
+
+Q4916483:
+  title: "Birkhoff\u2013Grothendieck theorem"
+
+Q977912:
+  title: Stolper&ndash;Samuelson theorem
+
+Q716171:
+  title: "Erd\u0151s\u2013Ginzburg\u2013Ziv theorem"
+
+Q1996305:
+  title: Burnside's theorem
+
+Q5709377:
+  title: Helmholtz theorem (classical mechanics)
+
+Q1149522:
+  title: Lami's theorem
+
+Q338886:
+  title: Divergence theorem
+
+Q7782348:
+  title: Theorem of three moments
+
+Q925854:
+  title: Angle bisector theorem
+
+Q137164:
+  title: Besicovitch covering theorem
+
+Q7031618:
+  title: Nielsen realization problem
+
+Q2226800:
+  title: "Schur\u2013Zassenhaus theorem"
+
+Q2893695:
+  title: Unmixedness theorem
+
+Q207014:
+  title: Independence of the parallel postulate
+
+Q1471282:
+  title: Radon's theorem
+
+Q31838822:
+  title: Kirchberger's theorem
+
+Q1841237:
+  title: Fubini's theorem on differentiation
+
+Q2275191:
+  title: Lebesgue differentiation theorem
+
+Q7127466:
+  title: Paley's theorem
+
+Q1809539:
+  title: Pizza theorem
+
+Q5047046:
+  title: "Brauer\u2013Cartan\u2013Hua theorem"
+
+Q642620:
+  title: "Krein\u2013Milman theorem"
+
+Q2226602:
+  title: "Bauer\u2013Fike theorem"
+
+Q3527226:
+  title: Linear speedup theorem
+
+Q5242704:
+  title: "Dawson\u2013G\xE4rtner theorem"
+
+Q5697927:
+  title: "Gross\u2013Zagier theorem"
+
+Q1139041:
+  title: Cauchy's theorem
+
+Q17008559:
+  title: "Davenport\u2013Schmidt theorem"
+
+Q5612871:
+  title: "Gr\xF6tzsch's theorem"
+
+Q848092:
+  title: "Borsuk\u2013Ulam theorem"
+
+Q273037:
+  title: "Bondy\u2013Chv\xE1tal theorem"
+
+Q2338929:
+  title: Exchange theorem
+
+Q967972:
+  title: Open mapping theorem
+
+Q5580171:
+  title: Goldie's theorem
+
+Q7959587:
+  title: Wagner's theorem
+
+Q377276:
+  title: Cook's theorem
+
+Q4865980:
+  title: Barwise compactness theorem
+
+Q852973:
+  title: Euler's polyhedron theorem
+
+Q4949984:
+  title: Bounded inverse theorem
+
+Q2482753:
+  title: Mann's theorem
+
+Q10942247:
+  title: Hironaka theorem
+
+Q2638931:
+  title: Convolution theorem
+
+Q1505529:
+  title: Runge's theorem
+
+Q1054106:
+  title: Cox's theorem
+
+Q386292:
+  title: Prime number theorem
+
+Q733081:
+  title: Impossibility of angle trisection
+
+Q11883897:
+  title: Nagata's compactification theorem
+
+Q1186134:
+  title: "Poncelet\u2013Steiner theorem"
+
+Q1995468:
+  title: "H\xF6lder's theorem"
+
+Q190556:
+  title: De Moivre's theorem
+
+Q2226774:
+  title: "K\xF6nig's theorem"
+
+Q619985:
+  title: Multinomial theorem
+
+Q1135706:
+  title: Harnack's theorem
+
+Q6783821:
+  title: "Mason\u2013Stothers theorem"
+
+Q2984415:
+  title: "Hajnal\u2013Szemer\xE9di theorem"
+
+Q4857506:
+  title: "Bapat\u2013Beg theorem"
+
+Q7296106:
+  title: Rauch comparison theorem
+
+Q4634017:
+  title: "2\u03C0 theorem"
+
+Q1425529:
+  title: Chebotarev's density theorem
+
+Q660799:
+  title: Darboux's theorem
+
+Q2309760:
+  title: "Looman\u2013Menchoff theorem"
+
+Q599876:
+  title: Cochran's theorem
+
+Q976607:
+  title: "Erd\u0151s\u2013Szekeres theorem"
+
+Q7310041:
+  title: Reider's theorem
+
+Q1134776:
+  title: Dilworth's theorem
+
+Q3424029:
+  title: Chasles's theorems
+
+Q4942215:
+  title: Bonnet theorem
+
+Q240950:
+  title: Faltings's theorem
+
+Q4788680:
+  title: Area theorem (conformal mapping)
+
+Q1751105:
+  title: Blum's speedup theorem
+
+Q656645:
+  title: Hilbert's basis theorem
+
+Q7307252:
+  title: Reflection theorem
+
+Q5576268:
+  title: "Goddard\u2013Thorn theorem"
+
+Q1720410:
+  title: Hjelmslev's theorem
+
+Q1551745:
+  title: Binomial inverse theorem
+
+Q834025:
+  title: Cauchy integral theorem
+
+Q11704319:
+  title: "Chern\u2013Gauss\u2013Bonnet theorem"
+
+Q1191709:
+  title: Egorov's theorem
+
+Q973359:
+  title: Rado's theorem
+
+Q1964537:
+  title: Mergelyan's theorem
+
+Q2226682:
+  title: "Gelfand\u2013Naimark theorem"
+
+Q966837:
+  title: "Cram\xE9r\u2013Wold theorem"
+
+Q730222:
+  title: Ham sandwich theorem
+
+Q931001:
+  title: Inverse function theorem
+
+Q850495:
+  title: Wick's theorem
+
+Q2411312:
+  title: Shannon's source coding theorem
+
+Q1305766:
+  title: "Poincar\xE9\u2013Hopf theorem"
+
+Q6735549:
+  title: Maier's theorem
+
+Q18630480:
+  title: Euler's quadrilateral theorem
+
+Q3527110:
+  title: "Lax\u2013Wendroff theorem"
+
+Q4753992:
+  title: Anderson's theorem
+
+Q830513:
+  title: Residue theorem
+
+Q7430892:
+  title: Schaefer's dichotomy theorem
+
+Q3527205:
+  title: Dimension theorem for vector spaces
+
+Q3527009:
+  title: Baker's theorem
+
+Q1048589:
+  title: "Hohenberg\u2013Kohn theorems"
+
+Q1144897:
+  title: Brouwer fixed-point theorem
+
+Q657469:
+  title: Lefschetz fixed-point theorem
+
+Q5165492:
+  title: Continuous mapping theorem
+
+Q5252320:
+  title: Lickorish twist theorem
+
+Q17081508:
+  title: Bing metrization theorem
+
+Q7632041:
+  title: Subspace theorem
+
+Q4958233:
+  title: "Brauer\u2013Suzuki\u2013Wall theorem"
+
+Q380576:
+  title: Measurable Riemann mapping theorem
+
+Q17005116:
+  title: Birkhoff's representation theorem
+
+Q4455033:
+  title: Fatou's theorem
+
+Q1243340:
+  title: "Birkhoff\u2013Von Neumann theorem"
+
+Q1051404:
+  title: "Ces\xE0ro's theorem"
+
+Q5384150:
+  title: Equal incircles theorem
+
+Q3527125:
+  title: Monsky's theorem
+
+Q1082910:
+  title: Euler's partition theorem
+
+Q428134:
+  title: "Gauss\u2013Markov theorem"
+
+Q1059151:
+  title: FWL theorem
+
+Q3505260:
+  title: "Cayley\u2013Salmon theorem"
+
+Q3527118:
+  title: Mahler's theorem
+
+Q11352023:
+  title: Vitali convergence theorem
+
+Q488541:
+  title: Fisher separation theorem
+
+Q1376515:
+  title: No-hair theorem
+
+Q1308502:
+  title: "Church\u2013Rosser theorem"
+
+Q6795637:
+  title: Maximal ergodic theorem
+
+Q5507285:
+  title: Fuglede's theorem
+
+Q2013213:
+  title: Reuschle's theorem
+
+Q1348736:
+  title: Rybczynski theorem
+
+Q1056283:
+  title: May's theorem
+
+Q643826:
+  title: Slutsky's theorem
+
+Q4666729:
+  title: "Abel\u2013Jacobi theorem"
+
+Q3527004:
+  title: BEST theorem
+
+Q5503689:
+  title: "Bombieri\u2013Friedlander\u2013Iwaniec theorem"
+
+Q253214:
+  title: "Heine\u2013Borel theorem"
+
+Q1153584:
+  title: Monotone convergence theorem
+
+Q4054114:
+  title: ATS theorem
+
+Q859122:
+  title: "Cauchy\u2013Hadamard theorem"
+
+Q6528747:
+  title: Leray's theorem
+
+Q544369:
+  title: "Glivenko\u2013Cantelli theorem"
+
+Q3527215:
+  title: Hilbert projection theorem
+
+Q248931:
+  title: "Poincar\xE9\u2013Bendixson theorem"
+
+Q1065257:
+  title: Squeeze theorem
+
+Q255996:
+  title: Equipartition theorem
+
+Q7309601:
+  title: "Whitney\u2013Graustein Theorem"
+
+Q595466:
+  title: Dini's theorem
+
+Q4455046:
+  title: Monodromy theorem
+
+Q1752988:
+  title: "Kutta\u2013Joukowski theorem"
+
+Q245902:
+  title: "Riesz\u2013Thorin theorem"
+
+Q867141:
+  title: Ehresmann's theorem
+
+Q1370316:
+  title: Casey's theorem
+
+Q15844093:
+  title: Van Schooten's theorem
+
+Q7825061:
+  title: Toponogov's theorem
+
+Q588218:
+  title: Koebe 1/4 theorem
+
+Q245098X:
+  title: Bolzano's theorem
+
+Q5438320:
+  title: "Faustman\u2013Ohlin theorem"
+
+Q1121027:
+  title: "Krylov\u2013Bogolyubov theorem"
+
+Q5597098:
+  title: Graph structure theorem
+
+Q845088:
+  title: Pappus's centroid theorem
+
+Q1077741:
+  title: Hairy ball theorem
+
+Q5187911:
+  title: Crooks fluctuation theorem
+
+Q5094298:
+  title: Chevalley's structure theorem
+
+Q1752621:
+  title: Sylvester's law of inertia
+
+Q468391:
+  title: "Bolzano\u2013Weierstrass theorem"
+
+Q5282247:
+  title: Disintegration theorem
+
+Q764287:
+  title: Van der Waerden's theorem
+
+Q7140218:
+  title: Parthasarathy's theorem
+
+Q2226807:
+  title: Vantieghems theorem
+
+Q915474:
+  title: Robin's theorem
+
+Q1132952:
+  title: Euler's theorem on homogeneous functions
+
+Q3613173:
+  title: Tits alternative
+
+Q7996769:
+  title: Whitney immersion theorem
+
+Q4677985:
+  title: Acyclic models theorem
+
+Q841893:
+  title: Desargues's theorem
+
+Q834211:
+  title: "Wallace\u2013Bolyai\u2013Gerwien theorem"
+
+Q5567394:
+  title: Gleason's theorem
+
+Q1739994:
+  title: "Brauer\u2013Suzuki theorem"
+
+Q1032886:
+  title: "Hales\u2013Jewett theorem"
+
+Q96377355:
+  title: "Erd\u0151s\u2013Dushnik\u2013Miller theorem"
+
+Q1196729:
+  title: Mertens's theorems
+
+Q7190748:
+  title: "Pickands\u2013Balkema\u2013de Haan theorem"
+
+Q5251122:
+  title: Time hierarchy theorem
+
+Q5385325:
+  title: "Erd\u0151s\u2013P\xF3sa theorem"
+
+Q7599389:
+  title: Stanley's reciprocity theorem
+
+Q1422083:
+  title: Ryll-Nardzewski fixed-point theorem
+
+Q4827308:
+  title: Auxiliary polynomial theorem
+
+Q574902:
+  title: Tarski's indefinability theorem
+
+Q1322892:
+  title: Dirac's theorems
+
+Q3711848:
+  title: Sobolev embedding theorem
+
+Q5874979:
+  title: "Hobby\u2013Rice theorem"
+
+Q5504427:
+  title: Friendship theorem
+
+Q928813:
+  title: Menger's theorem
+
+Q3527113:
+  title: "Lie\u2013Kolchin theorem"
+
+Q1139430:
+  title: Hurwitz's theorem
+
+Q1139524:
+  title: Rationality theorem
+
+Q510197:
+  title: Tutte theorem
+
+Q1152521:
+  title: "Mohr\u2013Mascheroni theorem"
+
+Q3984011:
+  title: Duggan&ndash;Schwartz theorem
+
+Q7536097:
+  title: "Skoda\u2013El Mir theorem"
+
+Q8028529:
+  title: Witt's theorem
+
+Q2588432:
+  title: Wold's theorem
+
+Q2226962:
+  title: "Weierstrass\u2013Casorati theorem"
+
+Q1434805:
+  title: Max Noether's theorem
+
+Q17098075:
+  title: "Jurkat\u2013Richert theorem"
+
+Q7782345:
+  title: Bertini's theorem
+
+Q17102744:
+  title: "Riemann\u2013Roch theorem for smooth manifolds"
+
+Q1366581:
+  title: "Erd\u0151s\u2013Rado theorem"
+
+Q6446396:
+  title: Kurosh subgroup theorem
+
+Q17080564:
+  title: Zariski's connectedness theorem
+
+Q4815879:
+  title: "Atiyah\u2013Segal completion theorem"
+
+Q4272300:
+  title: Initial value theorem
+
+Q1751823:
+  title: No-cloning theorem
+
+Q2800071:
+  title: Perfect graph theorem
+
+Q194919:
+  title: Inverse eigenvalues theorem
+
+Q4944923:
+  title: "Borel\u2013Bott\u2013Weil theorem"
+
+Q5659675:
+  title: Harnack's curve theorem
+
+Q2478371:
+  title: Envelope theorem
+
+Q7043732:
+  title: Kuhn's theorem
+
+Q6757284:
+  title: Marcinkiewicz theorem
+
+Q872088:
+  title: Boolean prime ideal theorem
+
+Q1477053:
+  title: "Arzel\xE0\u2013Ascoli theorem"
+
+Q5141331:
+  title: Cohen structure theorem
+
+Q5499906:
+  title: "Shirshov\u2013Witt theorem"
+
+Q739403:
+  title: Stewart's theorem
+
+Q777924:
+  title: Tijdeman's theorem
+
+Q7999797:
+  title: Beer's theorem
+
+Q5610190:
+  title: Gromov's compactness theorem
+
+Q15830473:
+  title: Morley's categoricity theorem
+
+Q766722:
+  title: Liouville's theorem
+
+Q3527214:
+  title: Non-squeezing theorem
+
+Q3527091:
+  title: Gromov's theorem on groups of polynomial growth
+
+Q204884:
+  title: "L\xF6b's theorem"
+
+Q15859323:
+  title: Anne's theorem
+
+Q1632301:
+  title: Sturm's theorem
+
+Q858978:
+  title: Castigliano's first and second theorems
+
+Q467756:
+  title: Stokes's theorem
+
+Q2071632:
+  title: "Rouch\xE9\u2013Capelli theorem"
+
+Q7047379:
+  title: Noether's theorem on rationality for surfaces
+
+Q241868:
+  title: "Th\xE9venin's theorem"
+
+Q3502015:
+  title: Hasse's theorem on elliptic curves
+
+Q172298:
+  title: "Lasker\u2013Noether theorem"
+
+Q2919401:
+  title: Ostrowski's theorem
+
+Q4455003:
+  title: Pomeranchuk's theorem
+
+Q5645731:
+  title: "Hammersley\u2013Clifford theorem"
+
+Q1896455:
+  title: Varignon's theorem
+
+Q1568612:
+  title: Marden's theorem
+
+Q425432:
+  title: Laurent expansion theorem
+
+Q7295875:
+  title: Ratner's theorems
+
+Q8063120:
+  title: ZJ theorem
+
+Q794269:
+  title: Betti's theorem
+
+Q953062:
+  title: Reynolds transport theorem
+
+Q2993319:
+  title: "Mirsky\u2013Newman theorem"
+
+Q213603:
+  title: Ceva's theorem
+
+Q5612159:
+  title: "Grunwald\u2013Wang theorem"
+
+Q2347139:
+  title: Carnot's theorem
+
+Q2027347:
+  title: Optional stopping theorem
+
+Q5473576:
+  title: Foster's theorem
+
+Q20278711:
+  title: Cramer's theorem (algebraic curves)
+
+Q3889376:
+  title: Carmichael's theorem
+
+Q7437564:
+  title: Scott core theorem
+
+Q1602819:
+  title: "Lumer\u2013Phillips theorem"
+
+Q5188510:
+  title: Crossbar theorem
+
+Q7031621:
+  title: Nielsen fixed-point theorem
+
+Q17089994X:
+  title: Tikhonov fixed-point theorem
+
+Q727102:
+  title: Fermat's theorem (stationary points)
+
+Q6379606:
+  title: "Kawamata\u2013Viehweg vanishing theorem"
+
+Q856032:
+  title: CAP theorem
+
+Q2068227:
+  title: "Artin\u2013Schreier theorem"
+
+Q7928688:
+  title: "Vietoris\u2013Begle mapping theorem"
+
+Q1766814:
+  title: Smn theorem
+
+Q918099:
+  title: Ramsey's theorem
+
+Q1704878:
+  title: "Appell\u2013Humbert theorem"
+
+Q16251580:
+  title: Matiyasevich's theorem
+
+Q856158:
+  title: Midy's theorem
+
+Q1893717:
+  title: Rice's theorem
+
+Q6733278:
+  title: Maharam's theorem
+
+Q2993026:
+  title: Ankeny&ndash;Artin&ndash;Chowla theorem
+
+Q7341043:
+  title: Robbins theorem
+
+Q3088644:
+  title: Goldstine theorem
+
+Q2269888:
+  title: Cohn's irreducibility criterion
+
+Q752375:
+  title: Extreme value theorem
+
+Q5421989:
+  title: Exterior angle theorem
+
+Q5047051:
+  title: "Cartan\u2013Kuranishi prolongation theorem"
+
+Q3984017:
+  title: Helly's selection theorem
+
+Q1068385:
+  title: Clairaut's theorem
+
+Q5385326:
+  title: "Erd\u0151s\u2013Stone theorem"
+
+Q3229352:
+  title: Vitali covering theorem
+
+Q784049:
+  title: Blaschke selection theorem
+
+Q2600653:
+  title: "Taylor\u2013Proudman theorem"
+
+Q4991415:
+  title: "Chowla\u2013Mordell theorem"
+
+Q7137494:
+  title: "Paris\u2013Harrington theorem"
+
+Q17017973:
+  title: Godunov's theorem
+
+Q594571:
+  title: Van Aubel's theorem
+
+Q535366:
+  title: Montel's theorem
+
+Q4455030:
+  title: Stone's theorem on one-parameter unitary groups
+
+Q6967039:
+  title: "Nash\u2013Moser theorem"
+
+Q2226855:
+  title: Sarkovskii's theorem
+
+Q1946642X:
+  title: "S\u2013cobordism theorem"
+
+Q5588002:
+  title: "Gottesman\u2013Knill theorem"
+
+Q3527171:
+  title: Synge's theorem
+
+Q897769:
+  title: "K\xF6nig's theorem"
+
+Q6935007:
+  title: Multiplicity-one theorem
+
+Q242045:
+  title: Monotone class theorem
+
+Q4454973:
+  title: "Lindel\xF6f's theorem"
+
+Q7288988:
+  title: Ramanujam vanishing theorem
+
+Q4956438:
+  title: Branching theorem
+
+Q4998912:
+  title: Burke's theorem
+
+Q119450:
+  title: Brianchon's theorem
+
+Q579515:
+  title: "Rao\u2013Blackwell theorem"
+
+Q1209546:
+  title: Kaplansky density theorem
+
+Q985009:
+  title: Helmholtz's theorems
+
+Q6407842:
+  title: "Killing\u2013Hopf theorem"
+
+Q7269076:
+  title: No-deleting theorem
+
+Q4801183:
+  title: "Artin\u2013Verdier duality theorem"
+
+Q2495664:
+  title: Universal coefficient theorem
+
+Q288465:
+  title: Orbit-stabilizer theorem
+
+Q7269437:
+  title: "Denjoy\u2013Carleman theorem"
+
+Q7431925:
+  title: Schnyder's theorem
+
+Q2376918:
+  title: Abelian and Tauberian theorems
+
+Q976033:
+  title: "Gelfond\u2013Schneider theorem"
+
+Q3526998:
+  title: Excision theorem
+
+Q2428364:
+  title: Clausius theorem
+
+Q3527015:
+  title: Bernstein's theorem
+
+Q132427:
+  title: Rademacher's theorem
+
+Q7312009:
+  title: "Remmert\u2013Stein theorem"
+
+Q721695:
+  title: "Szemer\xE9di\u2013Trotter theorem"
+
+Q1576235:
+  title: Lochs's theorem
+
+Q303402:
+  title: "Rank\u2013nullity theorem"
+
+Q505798:
+  title: Lagrange's theorem
+
+Q3527245:
+  title: Six exponentials theorem
+
+Q19323571:
+  title: "Chomsky\u2013Sch\xFCtzenberger enumeration theorem"
+
+Q268132:
+  title: "Gauss\u2013Wantzel theorem"
+
+Q3699212:
+  title: Saint-Venant's theorem
+
+Q1259814:
+  title: "Nielsen\u2013Schreier theorem"
+
+Q282331:
+  title: Addition theorem
+
+Q357192:
+  title: Holland's schema theorem
+
+Q6860180:
+  title: "Milman\u2013Pettis theorem"
+
+Q2226644:
+  title: Easton's theorem
+
+Q567843:
+  title: "Hahn\u2013Mazurkiewicz theorem"
+
+Q756946:
+  title: Lagrange's four-square theorem
+
+Q681406:
+  title: Euler's rotation theorem
+
+Q7597316:
+  title: Stallings theorem about ends of groups
+
+Q4894565:
+  title: Bernstein's theorem
+
+Q193882:
+  title: Menelaus's theorem
+
+Q4695203:
+  title: Four functions theorem
+
+Q6911202:
+  title: Moreau's theorem
+
+Q7660749:
+  title: Sylvester's determinant theorem
+
+Q4927458:
+  title: Blondel's theorem
+
+Q7841060:
+  title: Trichotomy theorem
+
+Q2253746:
+  title: Bertrand's ballot theorem
+
+Q3527079:
+  title: Freiman's theorem
+
+Q1188504:
+  title: Pitman&ndash;Koopman&ndash;Darmois theorem
+
+Q5579030:
+  title: "Goldberg\u2013Sachs theorem"
+
+Q7269559:
+  title: Sylvester pentahedral theorem
+
+Q190391X:
+  title: Lyapunov's central limit theorem
+
+Q1131601:
+  title: Sklar's theorem
+
+Q5455495:
+  title: Fitting's theorem
+
+Q1149458:
+  title: Compactness theorem
+
+Q2378270:
+  title: Thue's theorem
+
+Q6743217:
+  title: Malgrange preparation theorem
+
+Q6373327:
+  title: "Karp\u2013Lipton theorem"
+
+Q3526976:
+  title: "Ax\u2013Kochen theorem"
+
+Q3527279:
+  title: Wiener's tauberian theorem
+
+Q25378690:
+  title: Ionescu-Tulcea theorem
+
+Q1572474:
+  title: "Lindemann\u2013Weierstrass theorem"
+
+Q7894110:
+  title: Universal approximation theorem
+
+Q4838119:
+  title: "Babu\u0161ka\u2013Lax\u2013Milgram theorem"
+
+Q2862403:
+  title: Bombieri's theorem
+
+Q791258:
+  title: Basu's theorem
+
+Q5278348:
+  title: Galvin's theorem
+
+Q420714:
+  title: "Akra\u2013Bazzi theorem"
+
+Q830124:
+  title: Girsanov's theorem
+
+Q283690:
+  title: Arrival theorem
+
+Q7619060:
+  title: The duality theorem
+
+Q179692:
+  title: Independence of the axiom of choice
+
+Q17089994:
+  title: Fixed-point theorems in infinite-dimensional spaces
+
+Q203565:
+  title: Solutions of a general cubic equation
+
+Q112659261:
+  title: Gamas's Theorem
+
+Q2226677:
+  title: "Gelfand\u2013Mazur theorem"
+
+Q376166:
+  title: Cut-elimination theorem
+
+Q1349282:
+  title: "Eilenberg\u2013Zilber theorem"
+
+Q5876058:
+  title: Hodge index theorem
+
+Q852183:
+  title: Viviani's theorem
+
+Q7996766:
+  title: Whitney extension theorem
+
+Q751120:
+  title: "Thue\u2013Siegel\u2013Roth theorem"
+
+Q7911648:
+  title: "Valiant\u2013Vazirani theorem"
+
+Q1452678:
+  title: "Penrose\u2013Hawking singularity theorems"
+
+Q276082:
+  title: Wilson's theorem
+
+Q5042898:
+  title: Carlson's theorem
+
+Q3527054:
+  title: "De Bruijn\u2013Erd\u0151s theorem (graph theory)"
+
+Q1566341:
+  title: Hindman's theorem
+
+Q1420905:
+  title: Hilbert's theorem 90
+
+Q401319:
+  title: Puiseux's theorem
+
+Q1033910:
+  title: "Cantor\u2013Bernstein\u2013Schroeder theorem"
+
+Q6442276:
+  title: Kuiper's theorem
+
+Q180345X:
+  title: Integral root theorem
+
+Q5463860:
+  title: Focal subgroup theorem
+
+Q17029787:
+  title: Higman's embedding theorem
+
+Q4830725:
+  title: "Ax\u2013Grothendieck theorem"
+
+Q32182:
+  title: Balinski's theorem
+
+Q512897:
+  title: Brooks's theorem
+
+Q258374:
+  title: "Carath\xE9odory's theorem"
+
+Q649977:
+  title: "Shirshov\u2013Cohn theorem"
+
+Q4454954:
+  title: Kirszbraun theorem
+
+Q18206032:
+  title: Cartan's theorem
+
+Q4958230:
+  title: "Brauer\u2013Siegel theorem"
+
+Q357858:
+  title: Freyd's adjoint functor theorem
+
+Q657903:
+  title: "Hilbert\u2013Waring theorem"
+
+Q4756099:
+  title: "Andreotti\u2013Frankel theorem"
+
+Q2607007:
+  title: Hinge theorem
+
+Q5508180:
+  title: Full employment theorem
+
+Q6796056:
+  title: Maxwell's theorem
+
+Q848375:
+  title: Implicit function theorem
+
+Q3527067:
+  title: F. and M. Riesz theorem
+
+Q17101806:
+  title: Intersection theorem
+
+Q6813106:
+  title: Mellin inversion theorem
+
+Q1434158:
+  title: Fluctuation dissipation theorem
+
+Q2093886:
+  title: Primitive element theorem
+
+Q7820874:
+  title: Tonelli's theorem
+
+Q268031:
+  title: Abel's binomial theorem
+
+Q6707093:
+  title: Lyapunov&ndash;Malkin theorem
+
+Q1052752:
+  title: "Stolz\u2013Ces\xE0ro theorem"
+
+Q5445112:
+  title: Fernique's theorem
+
+Q6414200:
+  title: "Kinoshita\u2013Lee\u2013Nauenberg theorem"
+
+Q5091194:
+  title: Cheng's eigenvalue comparison theorem
+
+Q4746948:
+  title: "Amitsur\u2013Levitzki theorem"
+
+Q2374733:
+  title: "Skolem\u2013Mahler\u2013Lech theorem"
+
+Q3984056:
+  title: No-communication theorem
+
+Q999783:
+  title: "Buckingham \u03C0 theorem"
+
+Q3527132:
+  title: "Nagell\u2013Lutz theorem"
+
+Q7433034:
+  title: Great orthogonality theorem
+
+Q550402:
+  title: Dirichlet's theorem on arithmetic progressions
+
+Q7020025:
+  title: Newton's theorem about ovals
+
+Q552367:
+  title: Berge's theorem
+
+Q7160983:
+  title: Peixoto's theorem
+
+Q1457052:
+  title: Well-ordering theorem
+
+Q2266397:
+  title: Intersecting chords theorem
+
+Q15872491:
+  title: Newton's theorem (quadrilateral)
+
+Q570779:
+  title: Vieta's formulas
+
+Q844612:
+  title: Brun's theorem
+
+Q906809:
+  title: "Hellmann\u2013Feynman theorem"
+
+Q1426292:
+  title: "Banach\u2013Steinhaus theorem"
+
+Q6015420:
+  title: Increment theorem
+
+Q4918128:
+  title: "Bishop\u2013Cannings theorem"
+
+Q4866385:
+  title: Base change theorems
+
+Q17019684:
+  title: Grushko theorem
+
+Q6701653:
+  title: Lukacs's proportion-sum independence theorem
+
+Q646523:
+  title: Pick's theorem
+
+Q17098298:
+  title: Jacobson density theorem
+
+Q1136262:
+  title: Optical theorem
+
+Q931404:
+  title: "Bertrand\u2013Diquet\u2013Puiseux theorem"
+
+Q208756:
+  title: Castelnuovo theorem
+
+Q1188048:
+  title: Barbier's theorem
+
+Q1125462:
+  title: Dinostratus' theorem
+
+Q7621715:
+  title: Strassmann's theorem
+
+Q8066611:
+  title: "K\xF6vari\u2013S\xF3s\u2013Tur\xE1n theorem"
+
+Q1052021:
+  title: Craig's interpolation theorem
+
+Q28194853:
+  title: Lovelock's theorem
+
+Q1529941:
+  title: "Peter\u2013Weyl theorem"
+
+Q6935403:
+  title: Mumford vanishing theorem
+
+Q371685:
+  title: "Kraft\u2013McMillan theorem"
+
+Q4455025:
+  title: No wandering domain theorem
+
+Q7524563:
+  title: Sinkhorn's theorem
+
+Q7686760:
+  title: Bang's theorem
+
+Q190391:
+  title: Central limit theorem
+
+Q6734194:
+  title: Mahler's compactness theorem
+
+Q6456122:
+  title: L-balance theorem
+
+Q1361393:
+  title: Luzin's theorem
+
+Q1008566:
+  title: "Gauss\u2013Lucas theorem"
+
+Q4455016:
+  title: Reeb sphere theorem
+
+Q6925496:
+  title: Mountain pass theorem
+
+Q18206266:
+  title: "Euclid\u2013Euler theorem"
+
+Q25303622:
+  title: "Browder\u2013Minty theorem"
+
+Q890875:
+  title: "Bohr\u2013van Leeuwen theorem"
+
+Q869647:
+  title: Szpilrajn extension theorem
+
+Q6711207:
+  title: "L\xE9vy's modulus of continuity theorem"
+
+Q2540738:
+  title: "Cartan\u2013Dieudonn\xE9 theorem"
+
+Q5697916B:
+  title: Waldhausen's theorem
+
+Q974405:
+  title: "Hille\u2013Yosida theorem"
+
+Q1786419:
+  title: Kramers' theorem
+
+Q587081:
+  title: "Kolmogorov\u2013Arnold\u2013Moser theorem"
+
+Q4884789:
+  title: Beltrami's theorem
+
+Q643513:
+  title: "Riesz\u2013Fischer theorem"
+
+Q3527064:
+  title: Donsker's theorem
+
+Q60681777:
+  title: Constant chord theorem
+
+Q6859627:
+  title: Milliken's tree theorem
+
+Q1542114:
+  title: "B\xE9zout's theorem"
+
+Q4826848:
+  title: Autonomous convergence theorem
+
+Q111982312:
+  title: "Friedberg\u2013Muchnik theorem"
+
+Q5656673:
+  title: "Hardy\u2013Littlewood tauberian theorem"
+
+Q7098850:
+  title: Optical equivalence theorem
+
+Q842953:
+  title: Lebesgue's density theorem
+
+Q2379132:
+  title: Going-up and going-down theorems
+
+Q3983972:
+  title: Simplicial approximation theorem
+
+Q5498822:
+  title: Birkhoff's theorem
+
+Q3527241:
+  title: Krull's principal ideal theorem
+
+Q5180651:
+  title: Craig's theorem
+
+Q5566491:
+  title: Glaisher's theorem
+
+Q851166:
+  title: Pappus's hexagon theorem
+
+Q1249069:
+  title: Richardson's theorem
+
+Q1317350:
+  title: Chen's theorem
+
+Q1140200:
+  title: PCP theorem
+
+Q657469X:
+  title: "Lefschetz\u2013Hopf theorem"
+
+Q1166774:
+  title: Stone's representation theorem for Boolean algebras
+
+Q3527034:
+  title: Cauchy's theorem
+
+Q1555342:
+  title: "Reeh\u2013Schlieder theorem"
+
+Q5610718:
+  title: Grothendieck's connectedness theorem
+
+Q1946642:
+  title: H-cobordism theorem
+
+Q2022775:
+  title: "Hilbert\u2013Schmidt theorem"
+
+Q3983968:
+  title: "Sturm\u2013Picone comparison theorem"
+
+Q33481:
+  title: Arrow's impossibility theorem
+
+Q5001327:
+  title: Busemann's theorem
+
+Q4454919:
+  title: Aumann's agreement theorem
+
+Q4179283:
+  title: Positive energy theorem
+
+Q1046232:
+  title: "Szemer\xE9di's theorem"
+
+Q1143540:
+  title: "Heckscher\u2013Ohlin theorem"
+
+Q3077634:
+  title: Sahlqvist correspondence theorem
+
+Q719966:
+  title: Toda's theorem
+
+Q925224:
+  title: "Sonnenschein\u2013Mantel\u2013Debreu Theorem"
+
+Q5436274:
+  title: "Farrell\u2013Markushevich theorem"
+
+Q4454910:
+  title: "Ostrowski\u2013Hadamard gap theorem"
+
+Q1357684:
+  title: Riesz representation theorem
+
+Q3526993:
+  title: Takagi existence theorem
+
+Q15813392:
+  title: "Barban\u2013Davenport\u2013Halberstam theorem"
+
+Q3527185:
+  title: Whitehead theorem
+
+Q2473965:
+  title: Ugly duckling theorem
+
+Q2360531:
+  title: "Jordan\u2013Schur theorem"
+
+Q7103669:
+  title: Ornstein theorem
+
+Q17003552:
+  title: Alexandrov's uniqueness theorem
+
+Q4937691:
+  title: "Bogoliubov\u2013Parasyuk theorem"
+
+Q1095330:
+  title: "Ap\xE9ry's theorem"
+
+Q2287393:
+  title: Caristi fixed-point theorem
+
+Q7160489:
+  title: Peetre theorem
+
+Q226014:
+  title: "Poincar\xE9 recurrence theorem"
+
+Q190026:
+  title: Ford's theorem
+
+Q2703389:
+  title: Linnik's theorem
+
+Q164262:
+  title: Lebesgue covering dimension
+
+Q211981:
+  title: "Hartman\u2013Grobman theorem"
+
+Q4663326:
+  title: "Hirzebruch\u2013Riemann\u2013Roch theorem"
+
+Q2993308:
+  title: "Cameron\u2013Erd\u0151s theorem"
+
+Q2267175:
+  title: Tangent-secant theorem
+
+Q1425308:
+  title: Brahmagupta theorem
+
+Q10369454:
+  title: Noether's second theorem
+
+Q6513990:
+  title: Lee Hwa Chung theorem
+
+Q3984063:
+  title: Mostow rigidity theorem
+
+Q2631152:
+  title: "Carath\xE9odory's extension theorem"
+
+Q332465:
+  title: Absolute convergence theorem
+
+Q951327:
+  title: Pasch's theorem
+
+Q8074796:
+  title: Zsigmondy's theorem
+
+Q5139948:
+  title: Codd's theorem
+
+Q1182249:
+  title: Deduction theorem
+
+Q7396621:
+  title: "Saccheri\u2013Legendre theorem"
+
+Q1149022:
+  title: Fubini's theorem
+
+Q401905:
+  title: Skorokhod's representation theorem
+
+Q4853767:
+  title: "Banach\u2013Stone theorem"
+
+Q4914101:
+  title: Bing's recognition theorem
+
+Q3527019:
+  title: Birch's theorem
+
+Q8066795:
+  title: Zariski's main theorem
+
+Q282649:
+  title: Pentagonal number theorem
+
+Q5172143:
+  title: Corona theorem
+
+Q1668861:
+  title: Picard theorem
+
+Q1765521:
+  title: Doob's martingale convergence theorems
+
+Q112740521:
+  title: Netto's theorem
+
+Q1455794:
+  title: Freudenthal suspension theorem
+
+Q1568811:
+  title: Hahn decomposition theorem
+
+Q3661294:
+  title: Kelvin's circulation theorem
+
+Q1933521:
+  title: Kleene's recursion theorem
+
+Q225973:
+  title: Ore's theorem
+
+Q4944923X:
+  title: "Borel\u2013Weil theorem"
+
+Q4958221:
+  title: Brauer's three main theorems
+
+Q7432915:
+  title: "Schroeder\u2013Bernstein theorem for measurable spaces"
+
+Q1202608:
+  title: De Gua's theorem
+
+Q2981012:
+  title: Monge's theorem
+
+Q954210:
+  title: Savitch's theorem
+
+Q5610188:
+  title: Gromov's compactness theorem
+
+Q4891633:
+  title: "Berger\u2013Kazdan comparison theorem"
+
+Q2533936:
+  title: Descartes's theorem on total angular defect
+
+Q19779530:
+  title: Thomsen's theorem
+
+Q3984020:
+  title: "Holmstr\xF6m's theorem"
+
+Q256303:
+  title: Lax&ndash;Richtmyer theorem
+
+Q528987:
+  title: Von Neumann bicommutant theorem
+
+Q4724004B:
+  title: Riemann's existence theorem
+
+Q1637085:
+  title: Poynting's theorem
+
+Q4455015:
+  title: "Routh\u2013Hurwitz theorem"
+
+Q1068283:
+  title: "L\xF6wenheim\u2013Skolem theorem"
+
+Q965294:
+  title: Thabit ibn Qurra's theorem
+
+Q4878586:
+  title: Beck's monadicity theorem
+
+Q7042768:
+  title: No-broadcasting theorem
+
+Q1191319:
+  title: "Radon\u2013Nikodym theorem"
+
+Q5155090:
+  title: Commutation theorem
+
+Q2226695:
+  title: Hurwitz's automorphisms theorem
+
+Q48998319:
+  title: Frobenius reciprocity theorem
+
+Q5586067:
+  title: "Gordon\u2013Newell theorem"
+
+Q7352955:
+  title: Robinson's joint consistency theorem
+
+Q780763:
+  title: 15 and 290 theorems
+
+Q927051:
+  title: Riemann mapping theorem
+
+Q853067:
+  title: Solutions to Pell's equation
+
+Q2046647:
+  title: "Karhunen\u2013Lo\xE8ve theorem"
+
+Q6344729:
+  title: Kachurovskii's theorem
+
+Q631561:
+  title: Closed range theorem
+
+Q5315060:
+  title: "Dunford\u2013Schwartz theorem"
+
+Q195133:
+  title: "Wigner\u2013Eckart theorem"
+
+Q1938251:
+  title: "Hasse\u2013Minkowski theorem"
+
+Q7359997:
+  title: Rokhlin's theorem
+
+Q744440:
+  title: "Immerman\u2013Szelepcs\xE9nyi theorem"
+
+Q942046:
+  title: "Schwarz\u2013Ahlfors\u2013Pick theorem"
+
+Q2028341:
+  title: Ado's theorem
+
+Q5041175:
+  title: "Carleson\u2013Jacobs theorem"
+
+Q193286:
+  title: Rolle's theorem
+
+Q7795828:
+  title: Thompson uniqueness theorem
+
+Q4948983:
+  title: Bott periodicity theorem
+
+Q7574438:
+  title: Specht's theorem
+
+Q1506253:
+  title: Euclid's theorem
+
+Q4971339:
+  title: British flag theorem
+
+Q7664013:
+  title: Sz.-Nagy's dilation theorem
+
+Q3007384:
+  title: Post's theorem
+
+Q4783822:
+  title: "Arithmetic Riemann\u2013Roch theorem"
+
+Q1687147:
+  title: "Sprague\u2013Grundy theorem"
+
+Q5494134:
+  title: "Fra\u0148kov\xE1\u2013Helly selection theorem"
+
+Q188295:
+  title: Fermat's little theorem
+
+Q2449984:
+  title: Miquel's theorem
+
+Q5026435:
+  title: "Cameron\u2013Martin theorem"
+
+Q5311783:
+  title: Dudley's theorem
+
+Q4832965:
+  title: Aztec diamond theorem
+
+Q5319505:
+  title: "Zeilberger\u2013Bressoud theorem"
+
+Q1396592:
+  title: "Franel\u2013Landau theorem"
+
+Q2799491:
+  title: "Ringel\u2013Youngs theorem"
+
+Q3527095:
+  title: Jacobi's four-square theorem
+
+Q899853:
+  title: H-theorem
+
+Q15895894:
+  title: "Finsler\u2013Hadwiger theorem"
+
+Q2096184:
+  title: Plancherel theorem
+
+Q7432918:
+  title: "Schr\xF6der\u2013Bernstein theorems for operator algebras"
+
+Q17104863:
+  title: "Nielsen\u2013Ninomiya theorem"
+
+Q742833:
+  title: "Gauss\u2013Bonnet theorem"
+
+Q97359729:
+  title: Stahl's theorem
+
+Q4408070:
+  title: De Finetti's theorem
+
+Q8081891:
+  title: "\u015Aleszy\u0144ski\u2013Pringsheim theorem"
+
+Q4700718:
+  title: Akhiezer's theorem
+
+Q7606897:
+  title: Steinitz theorem
+
+Q530152:
+  title: "Picard&ndash;Lindel\xF6f theorem"
+
+Q1077462:
+  title: "K\xF6nig's theorem"
+
+Q679800:
+  title: "Nyquist\u2013Shannon sampling theorem"
+
+Q7455422:
+  title: Swan's theorem
+
+Q3527040:
+  title: "Chomsky\u2013Sch\xFCtzenberger representation theorem"
+
+Q1136043:
+  title: Hurwitz's theorem
+
+Q2226650:
+  title: "Eberlein\u2013\u0160mulian theorem"
+
+Q4751110:
+  title: Analyst's traveling salesman theorem
+
+Q5656674:
+  title: "Hardy\u2013Ramanujan theorem"
+
+Q5988409:
+  title: Identity theorem for Riemann surfaces
+
+Q755986:
+  title: "Atiyah\u2013Bott fixed-point theorem"
+
+Q5443003:
+  title: Fenchel's duality theorem
+
+Q5447238:
+  title: Fieller's theorem
+
+Q191693:
+  title: Lebesgue's decomposition theorem
+
+Q1785610:
+  title: Poncelet's closure theorem
+
+Q7818977:
+  title: Tomita's theorem
+
+Q55647729:
+  title: "Cram\xE9r's theorem (large deviations)"
+
+Q2379128:
+  title: "Lindstr\xF6m's theorem"
+
+Q536640:
+  title: Hall's marriage theorem
+
+Q1306092:
+  title: Nash embedding theorem
+
+Q528955:
+  title: "Kochen\u2013Specker theorem"
+
+Q25304301:
+  title: "Bregman\u2013Minc inequality"
+
+Q6379715:
+  title: Kawasaki's theorem
+
+Q220680:
+  title: Banach fixed-point theorem
+
+Q6501470:
+  title: Lauricella's theorem
+
+Q4880958:
+  title: "Behnke\u2013Stein theorem"
+
+Q1067156:
+  title: Dominated convergence theorem
+
+Q4801169:
+  title: Artin approximation theorem
+
+Q1347094:
+  title: Alternate Interior Angles Theorem
+
+Q6777133:
+  title: Martingale representation theorem
+
+Q1535225:
+  title: "\u0141o\u015B' theorem"
+
+Q2558669:
+  title: "Artin\u2013Zorn theorem"
+
+Q649469:
+  title: Modularity theorem
+
+Q2449984X:
+  title: Pivot theorem
+
+Q810431:
+  title: Basel problem
+
+Q285719:
+  title: Thales's theorem
+
+Q5132839:
+  title: Clifford's circle theorems
+
+Q718875:
+  title: "Erd\u0151s\u2013Ko\u2013Rado theorem"
+
+Q1816952:
+  title: Schur's lemma
+
+Q154210:
+  title: CPCTC
+
+Q4736422:
+  title: Denjoy theorem
+
+Q467205:
+  title: Fundamental theorems of welfare economics
+
+Q1058662:
+  title: Darboux's theorem
+
+Q4712316:
+  title: "Albert\u2013Brauer\u2013Hasse\u2013Noether theorem"
+
+Q16978447:
+  title: "Grauert\u2013Riemenschneider vanishing theorem"
+
+Q7856599:
+  title: "Tur\xE1n\u2013Kubilius theorem"
+
+Q5612131:
+  title: Grunsky's theorem
+
+Q17002391:
+  title: Arrow-Lind theorem
+
+Q25304227:
+  title: Arakelyan's theorem
+
+Q651593:
+  title: Norton's theorem
+
+Q388525:
+  title: Bell's theorem
+
+Q3527196:
+  title: Principal ideal theorem
+
+Q902052:
+  title: "G\xF6del's completeness theorem"
+
+Q7308146:
+  title: Regev's theorem
+
+Q8002487:
+  title: Wilkie's theorem
+
+Q1369453:
+  title: "Kronecker\u2013Weber theorem"
+
+Q7978735:
+  title: Weber's theorem
+
+Q4877965:
+  title: "Beauville\u2013Laszlo theorem"
+
+Q5244361:
+  title: De Franchis theorem
+
+Q2226868:
+  title: Geometric mean theorem
+
+Q7644264:
+  title: Supersymmetry nonrenormalization theorems
+
+Q3229335:
+  title: "Borel\u2013Carath\xE9odory theorem"
+
+Q1346677:
+  title: Tietze extension theorem
+
+Q2310718:
+  title: Pitot theorem
+
+Q2309682:
+  title: Sphere theorem
+
+Q617417:
+  title: Isoperimetric theorem
+
+Q1785872:
+  title: "Berry\u2013Ess\xE9en theorem"
+
+Q3771212:
+  title: Proth's theorem
+
+Q4724004A:
+  title: Chow's theorem
+
+Q459547:
+  title: Ptolemy's theorem
+
+Q193878:
+  title: Chinese remainder theorem
+
+Q1899432:
+  title: "Grothendieck\u2013Hirzebruch\u2013Riemann\u2013Roch theorem"
+
+Q5675112:
+  title: "Hartogs\u2013Rosenthal theorem"
+
+Q779220:
+  title: Hilbert's syzygy theorem
+
+Q729359:
+  title: Hadamard three-circle theorem
+
+Q3527056:
+  title: "De Bruijn\u2013Erd\u0151s theorem (incidence geometry)"
+
+Q17103352:
+  title: Maximum power theorem
+
+Q4454976:
+  title: Liouville's theorem
+
+Q5709171:
+  title: "Helly\u2013Bray theorem"
+
+Q110921617:
+  title: "Feferman\u2013Vaught theorem"
+
+Q1789863:
+  title: Routh's theorem
+
+Q4454925:
+  title: Edge-of-the-wedge theorem
+
+Q6387087:
+  title: "Kempf\u2013Ness theorem"
+
+Q5047048:
+  title: "Cartan\u2013Hadamard theorem"
+
+Q5166389:
+  title: Van Vleck's theorem
+
+Q6516736:
+  title: Lefschetz theorem on (1,1)-classes
+
+Q1630588:
+  title: Hurwitz's theorem
+
+Q7827204:
+  title: Mazur's torsion theorem
+
+Q1547975:
+  title: "Mermin\u2013Wagner theorem"
+
+Q737851:
+  title: "Banach\u2013Tarski theorem"
+
+Q902618:
+  title: Floquet's theorem
+
+Q4884950:
+  title: Belyi's theorem
+
+Q866116:
+  title: "Hahn\u2013Banach theorem"
+
+Q5244285:
+  title: de Bruijn's theorem
+
+Q578555:
+  title: Noether's theorem
+
+Q372037:
+  title: "Seifert\u2013van Kampen theorem"
+
+Q586051:
+  title: "Haag\u2013\u0141opusza\u0144ski\u2013Sohnius theorem"
+
+Q837551:
+  title: Frobenius theorem
+
+Q1067156X:
+  title: Bounded convergence theorem
+
+Q1191862:
+  title: "Rouch\xE9's theorem"
+
+Q620602:
+  title: Virial theorem
+
+Q5178114:
+  title: Courcelle's theorem
+
+Q676413:
+  title: Dandelin's theorem
+
+Q4713046:
+  title: "Alchian\u2013Allen theorem"
+
+Q3527017:
+  title: "Beurling\u2013Lax theorem"
+
+Q5761142:
+  title: Hilbert's irreducibility theorem
+
+Q1194053:
+  title: Metrization theorems
+
+Q1097021:
+  title: Minkowski's theorem
+
+Q107547910:
+  title: "Malgrange\u2013Zerner theorem"
+
+Q3527093:
+  title: "Hilbert\u2013Speiser theorem"
+
+Q487132:
+  title: Infinite monkey theorem
+
+Q7782346:
+  title: Theorem of the cube
+
+Q913849:
+  title: Minimax theorem
+
+Q321237:
+  title: Green's theorem
+
+Q6914794:
+  title: Morton's theorem
+
+Q4666729X:
+  title: Abel's curve theorem
+
+Q1724049:
+  title: Wolstenholme's theorem
+
+Q7516736:
+  title: "Silverman\u2013Toeplitz theorem"
+
+Q5638112:
+  title: Hadwiger's theorem
+
+Q3443426:
+  title: Bondy's theorem
+
+Q1129636:
+  title: "Lehmann\u2013Scheff\xE9 theorem"
+
+Q867839:
+  title: Rosser's theorem
+
+Q583147:
+  title: Sard's theorem
+
+Q6535741:
+  title: Levitzky's theorem
+
+Q476776:
+  title: Solutions of a general quartic equation
+
+Q1566372:
+  title: Haag's theorem
+
+Q1130846:
+  title: Ladner's theorem
+
+Q56291669:
+  title: Alspach's theorem
+
+Q5103861:
+  title: Choi's theorem on completely positive maps
+
+Q1443036:
+  title: Parseval's theorem
+
+Q656176:
+  title: Schauder fixed-point theorem
+
+Q3893473:
+  title: Tameness theorem
+
+Q7139570:
+  title: Parovicenko's theorem
+
+Q5049717:
+  title: "Castelnuovo\u2013de Franchis theorem"
+
+Q257387:
+  title: Vitali theorem
+
+Q6403282:
+  title: Lagrange's theorem
+
+Q4751118:
+  title: Analytic Fredholm theorem
+
+Q6421981:
+  title: Kneser's theorem
+
+Q6867878:
+  title: Minlos's theorem
+
+Q7045226:
+  title: No free lunch theorem
+
+Q3984052:
+  title: Equidistribution theorem
+
+Q1930577:
+  title: Herbrand's theorem
+
+Q48996535:
+  title: "Sol\xE8r's theorem"
+
+Q6455211:
+  title: "K\u014Dmura's theorem"
+
+Q4941364:
+  title: "Bondareva\u2013Shapley theorem"
+
+Q914517:
+  title: Fermat's theorem on sums of two squares
+
+Q6535568:
+  title: Levi's theorem
+
+Q1050932:
+  title: Hartogs's theorem
+
+Q6436753:
+  title: Krener's theorem
+
+Q931001X:
+  title: Constant rank theorem
+
+Q5508482:
+  title: "Fulton\u2013Hansen connectedness theorem"
+
+Q3984053:
+  title: Fourier inversion theorem
+
+Q2226610:
+  title: "Banach\u2013Mazur theorem"
+
+Q1694565:
+  title: Vinogradov's theorem
+
+Q2226624:
+  title: "Bruck\u2013Chowla\u2013Ryser theorem"
+
+Q7106480:
+  title: Oseledec theorem
+
+Q828284:
+  title: Parallel axis theorem
+
+Q3526990:
+  title: Euler's theorem
+
+Q7625164:
+  title: Structure theorem for Gaussian measures
+
+Q7208500:
+  title: Poisson limit theorem
+
+Q720469:
+  title: "Chevalley\u2013Warning theorem"
+
+Q5136698:
+  title: Cluster decomposition theorem
+
+Q504843:
+  title: Mycielski's theorem
+
+Q1564541:
+  title: "Perron\u2013Frobenius theorem"
+
+Q1888583:
+  title: Holditch's theorem
+
+Q6516611:
+  title: "Lee\u2013Yang theorem"
+
+Q6528751:
+  title: "Leray\u2013Hirsch theorem"
+
+Q4958227:
+  title: "Brauer\u2013Nesbitt theorem"
+
+Q3526969:
+  title: AF+BG theorem
+
+Q5157054:
+  title: Compression theorem
+
+Q5697916A:
+  title: "Reidemeister\u2013Singer Theorem"
+
+Q5680041:
+  title: "Hasse\u2013Arf theorem"
+
+Q656772:
+  title: "Cayley\u2013Hamilton theorem"
+
+Q495412:
+  title: "Jordan\u2013Sch\xF6nflies theorem"
+
+Q1141747:
+  title: Carnot's theorem
+
+Q1340623:
+  title: Classification of finite simple groups
+
+Q632546X:
+  title: Sylvester's theorem
+
+Q7825663:
+  title: Torelli theorem
+
+Q671663:
+  title: "Coleman\u2013Mandula theorem"
+
+Q7532192:
+  title: Siu's semicontinuity theorem
+
+Q179467:
+  title: Fourier theorem
+
+Q877489:
+  title: Apollonius's theorem
+
+Q5127710:
+  title: "Clark\u2013Ocone theorem"
+
+Q10859514:
+  title: "Vafa\u2013Witten theorem"
+
+Q17125544:
+  title: "Lickorish\u2013Wallace theorem"
+
+Q865665:
+  title: Birkhoff's theorem
+
+Q1186808:
+  title: Lucas's theorem
+
+Q6795830:
+  title: Separating axis theorem
+
+Q2226803:
+  title: Tennenbaum's theorem
+
+Q1177508:
+  title: "R\xE9dei's theorem"
+
+Q318767:
+  title: Abel's theorem
+
+Q189136:
+  title: Mean value theorem
+
+Q3757563:
+  title: Intercept theorem
+
+Q379048:
+  title: "Riemann\u2013Roch theorem"
+
+Q944297:
+  title: Open mapping theorem
+
+Q4866385X:
+  title: Proper base change theorem
+
+Q1227703:
+  title: Dirichlet's approximation theorem
+
+Q6086104:
+  title: Isomorphism extension theorem
+
+Q2226625:
+  title: Commandino's theorem
+
+Q7809920:
+  title: Titchmarsh convolution theorem
+
+Q1038716:
+  title: Identity theorem
+
+Q1149185X:
+  title: "Kirby\u2013Paris theorem"
+
+Q5094305:
+  title: "Chevalley\u2013Shephard\u2013Todd theorem"
+
+Q7572588:
+  title: Space hierarchy theorem
+
+Q2197859:
+  title: Nicomachus's theorem
+
+Q7601243:
+  title: Star of David theorem
+
+Q22952648:
+  title: Uncountability of the continuum
+
+Q7433182:
+  title: "Schwartz\u2013Zippel theorem"
+
+Q657482:
+  title: "Abel\u2013Ruffini theorem"
+
+Q5047043:
+  title: Cartan's theorems A and B
+
+Q4734002:
+  title: "Gromov\u2013Ruh theorem"
+
+Q1425077:
+  title: Spectral theorem
+
+Q180345:
+  title: Rational root theorem
+
+Q4958218:
+  title: Brauer's theorem on induced characters
+
+Q848810:
+  title: Kronecker's theorem
+
+Q1048874:
+  title: Gauss's Theorema Egregium
+
+Q7857350:
+  title: Tverberg's theorem
+
+Q1075398:
+  title: Jung's theorem
+
+Q2094241:
+  title: "Hopf\u2013Rinow theorem"
+
+Q5638886:
+  title: Hahn embedding theorem
+
+Q5163116:
+  title: Conservativity theorem
+
+Q948664:
+  title: Kneser's theorem
+
+Q2635326:
+  title: Structured program theorem
+
+Q7999144:
+  title: "Wiener\u2013Ikehara theorem"
+
+Q7333126:
+  title: "Riemann\u2013Roch theorem for surfaces"
+
+Q1632433:
+  title: Helly's theorem
+
+Q200787:
+  title: "G\xF6del's incompleteness theorem"
+
+Q117553:
+  title: "Modigliani\u2013Miller theorem"
+
+Q7619449:
+  title: "Stone\u2013von Neumann theorem"
+
+Q3527263:
+  title: Kleene fixed-point theorem
+
+Q2916568:
+  title: Gomory's theorem
+
+Q3527219:
+  title: Weierstrass preparation theorem
+
+Q2995691:
+  title: "Newlander\u2013Niremberg theorem"
+
+Q523876:
+  title: "Spin\u2013statistics theorem"
+
+Q3180727:
+  title: Perlis theorem
+
+Q356895:
+  title: Adiabatic theorem
+
+Q3527129:
+  title: "M\xFCntz\u2013Sz\xE1sz theorem"
+
+Q12524:
+  title: Schwenk's theorem
+
+Q670235:
+  title: Fundamental theorem of arithmetic
+
+Q383238:
+  title: Hartogs's extension theorem
+
+Q6400676:
+  title: Kharitonov's theorem
+
+Q7936914:
+  title: "Vitali\u2013Hahn\u2013Saks theorem"
+
+Q608294:
+  title: Max flow min cut theorem
+
+Q1153441:
+  title: Goldstone's theorem
+
+Q7661308:
+  title: Symmetric hypergraph theorem
+
+Q1187646:
+  title: Fundamental theorem on homomorphisms
+
+Q7795825:
+  title: Thompson transitivity theorem
+
+Q11518:
+  title: Pythagorean theorem
+
+Q5505114:
+  title: Froda's theorem
+
+Q7512855:
+  title: Hirzebruch signature theorem
+
+Q377047:
+  title: Butterfly theorem
+
+Q1065966:
+  title: Isomorphism theorem
+
+Q922012:
+  title: "Green\u2013Tao theorem"
+
+Q7042801:
+  title: No-trade theorem
+
+Q544292:
+  title: Lagrange inversion theorem
+
+Q20971632:
+  title: Lie's theorem
+
+Q1217677:
+  title: Fundamental theorem of calculus
+
+Q2621667:
+  title: "Nagata\u2013Smirnov metrization theorem"
+
+Q105222412:
+  title: Five color theorem
+
+Q7536350:
+  title: Skorokhod's embedding theorem
+
+Q17098379:
+  title: Kaplansky's theorem on quadratic forms
+
+Q6544508:
+  title: "Lie\u2013Palais theorem"
+
+Q4944908:
+  title: Borel fixed-point theorem
+
+Q4454958:
+  title: Min-max theorem
+
+Q7847268:
+  title: Trudinger's theorem
+
+Q4454996:
+  title: Novikov's compact leaf theorem
+
+Q6378596:
+  title: "Katz\u2013Lang finiteness theorem"
+
+Q2733672:
+  title: Price's theorem
+
+Q1188392:
+  title: Zeckendorf's theorem
+
+Q1306095:
+  title: Whitney embedding theorem
+
+Q5501344:
+  title: "Freidlin\u2013Wentzell theorem"
+
+Q6425088:
+  title: Kodaira embedding theorem
+
+Q7432872:
+  title: Schreier refinement theorem
+
+Q7249519:
+  title: Prokhorov's theorem
+
+Q755991:
+  title: "Atiyah\u2013Singer index theorem"
+
+Q422187:
+  title: "Myhill\u2013Nerode theorem"
+
+Q4801563:
+  title: Artstein's theorem
+
+Q7617407:
+  title: Stinespring factorization theorem
+
+Q15080987:
+  title: Lie's third theorem
+
+Q7318284:
+  title: Reversed compound agent theorem
+
+Q25345219:
+  title: BBD decomposition theorem
+
+Q7941491:
+  title: Von Neumann's theorem
+
+Q5125859:
+  title: Clapeyron's theorem
+
+Q7322366:
+  title: Ribet's theorem
+
+Q2518048:
+  title: Kodaira vanishing theorem
+
+Q205966:
+  title: Critical line theorem
+
+Q650738:
+  title: Folk theorem
+
+Q5506929:
+  title: Fuchs's theorem
+
+Q5037752:
+  title: "Carath\xE9odory's existence theorem"
+
+Q1330788:
+  title: Weierstrass factorization theorem
+
+Q1361031:
+  title: Frobenius theorem
+
+Q2000090:
+  title: Art gallery theorem
+
+Q260928:
+  title: Jordan curve theorem
+
+Q62051012:
+  title: Behrend's theorem
+
+Q1037559:
+  title: "P\xF3lya enumeration theorem"
+
+Q7100033B:
+  title: "Rashevsky\u2013Chow theorem"
+
+Q3527011:
+  title: Beck's theorem
+
+Q1966978:
+  title: "L\xE9vy continuity theorem"
+
+Q1472120:
+  title: Hellinger&ndash;Toeplitz theorem
+
+Q7606940:
+  title: "Stein\u2013Str\xF6mberg theorem"
+
+Q2270905:
+  title: "Poincar\xE9\u2013Birkhoff\u2013Witt theorem"
+
+Q1974087:
+  title: Riemann's theorem on removable singularities
+
+Q537618:
+  title: "Banach\u2013Alaoglu theorem"
+
+Q6471668:
+  title: Lafforgue's theorem
+
+Q1068976:
+  title: Hilbert's Nullstellensatz
+
+Q6760432:
+  title: Marginal value theorem
+
+Q3527162:
+  title: Sophie Germain's theorem
+
+Q6481192:
+  title: "Lambek\u2013Moser theorem"
+
+Q5445311:
+  title: "Ferrero\u2013Washington theorem"
+
+Q5047052:
+  title: "Cartan\u2013K\xE4hler theorem"
+
+Q7255475:
+  title: Pseudorandom generator theorem
+
+Q5657833:
+  title: "Harish\u2013Chandra's regularity theorem"
+
+Q6799039:
+  title: Mazur's control theorem
+
+Q3527217:
+  title: M. Riesz extension theorem
+
+Q612021:
+  title: "Gibbard\u2013Satterthwaite theorem"
+
+Q900831:
+  title: Fluctuation theorem
+
+Q3527250:
+  title: Hadamard three-lines theorem
+
+Q5295351:
+  title: Donaldson's theorem
+
+Q3527230:
+  title: "Von Staudt\u2013Clausen theorem"
+
+Q4378868:
+  title: "Phragm\xE9n\u2013Lindel\xF6f theorem"
+
+Q1227061:
+  title: Khinchin's theorem
+
+Q7980241:
+  title: "Weinberg\u2013Witten theorem"
+
+Q846840:
+  title: "Erd\u0151s\u2013Kac theorem"
+
+Q1699024:
+  title: John ellipsoid
+
+Q1242398:
+  title: Doob decomposition theorem
+
+Q174955:
+  title: "Mih\u0103ilescu's theorem"
+
+Q230848:
+  title: "Lam\xE9\u2019s theorem"
+
+Q1855610:
+  title: "Theorem of de Moivre\u2013Laplace"
+
+Q6516731:
+  title: Lefschetz hyperplane theorem
+
+Q7966545:
+  title: Walter theorem
+
+Q7323144:
+  title: "Rice\u2013Shapiro theorem"
+
+Q1119094:
+  title: Paley&ndash;Wiener theorem
+
+Q5437947:
+  title: "Fatou\u2013Lebesgue theorem"
+
+Q2120067:
+  title: "Diller\u2013Dress theorem"
+
+Q857089:
+  title: de Branges's theorem
+
+Q107535899:
+  title: Bochner's tube theorem
+
+Q3527166:
+  title: Steinhaus theorem
+
+Q1146791:
+  title: Fermat polygonal number theorem
+
+Q5609384:
+  title: Grinberg's theorem
+
+Q1276318:
+  title: Schwartz kernel theorem
+
+Q470877:
+  title: Stirling's theorem
+
+Q837506:
+  title: Theorem on friends and strangers
+
+Q2524990:
+  title: Jackson's theorem
+
+Q6276298:
+  title: Jordan's theorem (multiply transitive groups)
+
+Q1716166:
+  title: Mercer's theorem
+
+Q192760:
+  title: Fundamental theorem of algebra
+
+Q2394548:
+  title: Hurewicz theorem
+
+Q4455031:
+  title: "F\xE1ry's theorem"
+
+Q107709489:
+  title: "B\xFCchi-Elgot-Trakhtenbrot theorem"
+
+Q1631749:
+  title: Lester's theorem
+
+Q3527209:
+  title: Hasse norm theorem
+
+Q748233:
+  title: "Sylvester\u2013Gallai theorem"
+
+Q4171386:
+  title: Soul theorem
+
+Q188745:
+  title: Classification of Platonic solids
+
+Q1103054:
+  title: "Lions\u2013Lax\u2013Milgram theorem"
+
+Q1786292:
+  title: Schur's theorem
+
+Q5454965:
+  title: "Fisher\u2013Tippett\u2013Gnedenko theorem"
+
+Q4667501:
+  title: "Abhyankar\u2013Moh theorem"
+
+Q104841721:
+  title: "Jacobson\u2013Morozov theorem"
+
+Q1137014:
+  title: Tychonoff's theorem
+
+Q1140119:
+  title: Morera's theorem
+
+Q7283856:
+  title: Raikov's theorem
+
+Q1317367:
+  title: Japanese theorem for concyclic polygons
+
+Q1683356:
+  title: Japanese theorem for concyclic quadrilaterals
+
+Q1543149:
+  title: "Sokhatsky\u2013Weierstrass theorem"
+
+Q1050203:
+  title: Cantor's intersection theorem
+
+Q3527223:
+  title: Crystallographic restriction theorem
+
+Q922367:
+  title: Master theorem (analysis of algorithms)
+
+Q7272898:
+  title: Quotient of subspace theorem
+
+Q1064471:
+  title: Earnshaw's theorem
+
+Q740093:
+  title: Peano existence theorem
+
+Q5456213:
+  title: Five circles theorem
+
+Q7824894:
+  title: Topkis's theorem
+
+Q4454989:
+  title: Meusnier's theorem
+
+Q474881:
+  title: Cantor's theorem
+
+Q284960:
+  title: "Mordell\u2013Weil theorem"
+
+Q3527233:
+  title: Kolmogorov's three-series theorem
+
+Q3527247:
+  title: Six circles theorem
+
+Q2500408:
+  title: "Th\xE9bault's theorem"
+
+Q7845353:
+  title: "Trombi\u2013Varadarajan theorem"
+
+Q2190744:
+  title: Feuerbach's theorem
+
+Q5282059:
+  title: "Harish\u2013Chandra theorem"
+
+Q3075250:
+  title: "Hardy\u2013Littlewood maximal theorem"
+
+Q1047749:
+  title: "Tur\xE1n's theorem"
+
+Q132469:
+  title: Fermat's Last Theorem
+
+Q1631992:
+  title: "Steiner\u2013Lehmus theorem"
+
+Q2226709:
+  title: "Krull\u2013Schmidt theorem"
+
+Q1134296:
+  title: Supporting hyperplane theorem
+
+Q939927:
+  title: "Stone\u2013Weierstrass theorem"
+  decl: stone_weierstrass
+  author: Scott Morrison and Heather Macbeth
+
+Q7888360:
+  title: Structure theorem for finitely generated modules over a principal ideal domain
+
+Q5132840:
+  title: Clifford's theorem on special divisors
+
+Q8064722:
+  title: Zahorski theorem
+
+Q7510574:
+  title: "Siegel\u2013Walfisz theorem"
+
+Q4378889:
+  title: "Carath\xE9odory's theorem"
+
+Q5362000:
+  title: Elitzur's theorem
+
+Q6927135:
+  title: Moving equilibrium theorem
+
+Q7853325:
+  title: Tunnell's theorem
+
+Q287347:
+  title: Gradient theorem
+
+Q2471737:
+  title: "Carath\xE9odory's theorem"
+
+Q7525341:
+  title: Sion's minimax theorem
+
+Q98831:
+  title: Multiplication theorem
+
+Q6749789:
+  title: "Manin\u2013Drinfeld theorem"
+
+Q790236:
+  title: Baranyai's theorem
+
+Q5643485:
+  title: "Halpern\u2013L\xE4uchli theorem"
+
+Q6484331:
+  title: Landau prime ideal theorem
+
+Q16680059:
+  title: Strong perfect graph theorem
+
+Q3984069:
+  title: Fredholm's theorem
+
+Q472883:
+  title: Quadratic reciprocity theorem
+
+Q3001796:
+  title: "Skolem\u2013Noether theorem"
+
+Q2226606:
+  title: "Beckman\u2013Quarles theorem"
+
+Q7200963:
+  title: Planar separator theorem
+
+Q685437:
+  title: Titchmarsh theorem
+
+Q8062800:
+  title: Z* theorem
+
+Q4848497:
+  title: "Baily\u2013Borel theorem"
+
+Q2222575:
+  title: Shell theorem
+
+Q3526982:
+  title: "Erd\u0151s\u2013Anning theorem"
+
+Q2226750:
+  title: "Malgrange\u2013Ehrenpreis theorem"
+
+Q6402928:
+  title: Lagrange reversion theorem
+
+Q61163749:
+  title: Theorem of the gnomon
+
+Q184410:
+  title: Four color theorem
+
+Q4116459:
+  title: Niven's theorem
+
+Q1149185:
+  title: Goodstein's theorem
+
+Q2500406:
+  title: "Li\xE9nard's theorem"
+
+Q693083:
+  title: Soundness theorem
+
+Q2226640:
+  title: "Cram\xE9r\u2019s decomposition theorem"
+
+Q3526996:
+  title: Kolmogorov extension theorem
+
+Q7130794:
+  title: Pandya theorem
+
+Q6059532:
+  title: "Aronszajn\u2013Smith theorem"
+
+Q5171652:
+  title: Corners theorem
+
+Q280116:
+  title: Odd number theorem
+
+Q7431298:
+  title: Schilder's theorem
+
+Q384142:
+  title: "Herbrand\u2013Ribet theorem"
+
+Q5508973:
+  title: Fundamental theorem of arbitrage-free pricing
+
+Q3527044:
+  title: Pappus's area theorem
+
+Q913447:
+  title: Morley's trisector theorem
+
+Q1423818:
+  title: Euler's theorem in geometry
+
+Q1756194:
+  title: "Shannon\u2013Hartley theorem"
+
+Q3527088:
+  title: Haboush's theorem
+
+Q207244:
+  title: Sela's theorem
+
+Q5161245:
+  title: "Conley\u2013Zehnder theorem"
+
+Q3458641:
+  title: "Szeg\u0151 limit theorems"
+
+Q7245073:
+  title: Principal axis theorem
+
+Q3915398:
+  title: "Brunn\u2013Minkowski theorem"
+
+Q17082552:
+  title: Mutual fund separation theorem
+
+Q6867853:
+  title: Minkowski's second theorem
+
+Q632546:
+  title: Bertrand's postulate
+
+Q1752516:
+  title: Riemann series theorem
+
+Q3527008:
+  title: "Balian\u2013Low theorem"
+
+Q4455043:
+  title: "Cayley\u2013Bacharach theorem"
+
+Q1227702:
+  title: Dirichlet's unit theorem
+
+Q193910:
+  title: Euler's theorem
+
+Q1196538:
+  title: Descartes's theorem
+
+Q4815899:
+  title: Atkinson's theorem
+
+Q523832:
+  title: "Carath\xE9odory\u2013Jacobi\u2013Lie theorem"
+
+Q2793600:
+  title: "Stark\u2013Heegner theorem"
+
+Q107710112:
+  title: Cantor's isomorphism theorem
+
+Q7239984:
+  title: Preimage theorem
+
+Q11722674:
+  title: Takens's theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -3386,7 +3386,7 @@ Q1134296:
 
 Q939927:
   title: "Stone\u2013Weierstrass theorem"
-  decl: stone_weierstrass
+  decl: ContinuousMap.subalgebra_topologicalClosure_eq_top_of_separatesPoints
   author: Scott Morrison and Heather Macbeth
 
 Q7888360:

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -817,7 +817,7 @@ Q931404:
 
 Q939927:
   title: Stone–Weierstrass theorem
-  decl: stone_weierstrass
+  decl: ContinuousMap.subalgebra_topologicalClosure_eq_top_of_separatesPoints
   author: Scott Morrison and Heather Macbeth
   date: 2021-05-01
 

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -9,889 +9,1036 @@
 #   (can this handle formalisation of *statements* also?)
 # - complete the information which theorems are already formalised
 
-Q17001601:
-  title: 2-factor theorem
-
-Q4272645:
-  title: Final value theorem
-
-Q6360586:
-  title: "Kanamori\u2013McAloon theorem"
-
-Q1137206:
-  title: Taylor's theorem
-
-Q5337931:
-  title: Edgeworth's limit theorem
-
-Q339495:
-  title: Symphonic theorem
-
-Q4734844:
-  title: "Alperin\u2013Brauer\u2013Gorenstein theorem"
-
-Q7433295:
-  title: "Osterwalder\u2013Schrader theorem"
-
-Q3527189:
-  title: Lattice theorem
-
-Q995926:
-  title: Perpendicular axis theorem
-
-Q3527071:
-  title: "F\xE1ry\u2013Milnor theorem"
-
-Q26877569:
-  title: Furry's theorem
-
-Q7597317:
-  title: "Stallings\u2013Zeeman theorem"
-
-Q266291:
-  title: Bloch's theorem
-
-Q1621180:
-  title: "Orlicz\u2013Pettis theorem"
-
-Q1148215:
-  title: Mitchell's embedding theorem
-
-Q899002:
-  title: Pascal's theorem
-
-Q5195996:
-  title: "Curtis\u2013Hedlund\u2013Lyndon theorem"
-
-Q5385324:
-  title: "Erd\u0151s\u2013Nagy theorem"
-
-Q1057919:
-  title: Sylow theorems
-
-Q4975963:
-  title: Brown's representability theorem
-
-Q7160302:
-  title: Peeling theorem
-
-Q6528849:
-  title: Lerner symmetry theorem
-
-Q5443005:
-  title: "Fenchel\u2013Moreau theorem"
-
-Q28458131:
-  title: Glivenko's theorem
-
-Q3527100:
-  title: Kruskal's tree theorem
-
-Q656198:
-  title: Maschke's theorem
-
-Q18205730:
-  title: "Byers\u2013Yang theorem"
-
-Q2008549:
-  title: Hilbert's theorem
-
-Q6957141:
-  title: Nachbin's theorem
-
-Q245098:
-  title: Intermediate value theorem
-
-Q9993851:
-  title: "Lax\u2013Milgram theorem"
-
-Q6867867:
-  title: "Minkowski\u2013Hlawka theorem"
-
-Q5299605:
-  title: Glivenko's theorem
-
-Q1050037:
-  title: Coase theorem
-
-Q929547:
-  title: Myers theorem
-
-Q1660147:
-  title: "Mazur\u2013Ulam theorem"
-
-Q943246:
-  title: Wedderburn's little theorem
-
-Q791663:
-  title: Beatty's theorem
-
-Q2345282:
-  title: Shannon's theorem
-
-Q3534036:
-  title: Pompeiu's theorem
-
-Q5005965:
-  title: C-theorem
-
-Q6859648:
-  title: "Milliken\u2013Taylor theorem"
-
-Q25099402:
-  title: "Kolmogorov\u2013Arnold representation theorem"
-
-Q7525845:
-  title: "Sipser\u2013Lautemann theorem"
-
-Q3527102:
-  title: "Kruskal\u2013Katona theorem"
-
-Q5005143:
-  title: "B\xF4cher's theorem"
-
-Q978688:
-  title: Gershgorin circle theorem
-
-Q776578:
-  title: "Artin\u2013Wedderburn theorem"
-
-Q2277040:
-  title: Shannon's expansion theorem
-
-Q576478:
-  title: Liouville's theorem
-
-Q1914905:
-  title: "Ramanujan\u2013Skolem's theorem"
-
-Q909517:
-  title: "Feit\u2013Thompson theorem"
-
-Q4950096:
-  title: "Bourbaki\u2013Witt theorem"
-
-Q3527155:
-  title: "Robertson\u2013Seymour theorem"
-
-Q2226786:
-  title: Sperner's theorem
-
-Q96375449:
-  title: Conway circle theorem
-
-Q7272004:
-  title: "Quillen\u2013Suslin theorem"
-
-Q7849521:
-  title: Tsen's theorem
-
-Q5552370:
-  title: Geroch's splitting theorem
-
-Q737892:
-  title: "Bendixson\u2013Dulac theorem"
-
-Q1530275:
-  title: "Dunford\u2013Pettis theorem"
-
-Q5530454:
-  title: Gell-Mann and Low theorem
-
-Q1179446:
-  title: De Rham's theorem
-
-Q2063099:
-  title: "Poincar\xE9 duality theorem"
-
-Q2734084:
-  title: "Bohr\u2013Mollerup theorem"
-
-Q2226698:
-  title: Kantorovich theorem
-
-Q182505:
-  title: Bayes' theorem
-
-Q765987:
-  title: "Heine\u2013Cantor theorem"
-
-Q11573495:
-  title: Plancherel theorem for spherical functions
-
-Q7269106:
-  title: Quantum threshold theorem
-
-Q2109761:
-  title: Uniformization theorem
-
-Q4979609:
-  title: "Brun\u2013Titchmarsh theorem"
-
-Q2226691:
-  title: Kirchhoff's theorem
-
-Q1068085:
-  title: Closed graph theorem
-
-Q104871594:
-  title: Joubert's theorem
-
-Q6771536:
-  title: "Markus\u2212Yamabe theorem"
-
-Q208416:
-  title: Independence of the continuum hypothesis
-  url: https://github.com/flypitch/flypitch
-  author: Floris van Doorn and Jesse Michael Han
-
-Q1614464:
-  title: "Cauchy\u2013Kowalevski theorem"
-
-Q5221089:
-  title: Danskin's theorem
+Q11518:
+  title: Pythagorean theorem
+
+Q12524:
+  title: Schwenk's theorem
 
 Q26708:
   title: Binomial theorem
 
-Q609612:
-  title: "Knaster\u2013Tarski theorem"
+Q32182:
+  title: Balinski's theorem
 
-Q17018210:
-  title: "Golod\u2013Shafarevich theorem"
+Q33481:
+  title: Arrow's impossibility theorem
 
-Q17104025:
-  title: Riemann singularity theorem
+Q98831:
+  title: Multiplication theorem
 
-Q1727461:
-  title: Intersecting secants theorem
+Q117553:
+  title: Modigliani–Miller theorem
 
-Q1052678:
-  title: Baire category theorem
+Q119450:
+  title: Brianchon's theorem
 
-Q3154003:
-  title: Le Cam's theorem
+Q132427:
+  title: Rademacher's theorem
 
-Q5443004:
-  title: Fenchel's theorem
-
-Q4455037:
-  title: Hardy's theorem
-
-Q1424481:
-  title: Frucht's theorem
-
-Q6722024:
-  title: MacMahon Master theorem
-
-Q4944906:
-  title: Borel determinacy theorem
-
-Q179208:
-  title: Cayley's theorem
-
-Q1307676:
-  title: "K\xFCnneth theorem"
-
-Q6119825:
-  title: "Jacobson\u2013Bourbaki theorem"
-
-Q5505098:
-  title: Frobenius determinant theorem
-
-Q5385323:
-  title: "Erd\u0151s\u2013Gallai theorem"
-
-Q7496252:
-  title: Shift theorem
-
-Q7100033A:
-  title: "Orbit theorem (Nagano\u2013Sussmann)"
-
-Q4455023:
-  title: Sazonov's theorem
-
-Q637418:
-  title: Napoleon's theorem
-
-Q1315949:
-  title: Mittag-Leffler's theorem
-
-Q3345678:
-  title: "Moore\u2013Aronszajn theorem"
-
-Q2525646:
-  title: "Jordan\u2013H\xF6lder theorem"
-
-Q994401:
-  title: Four-vertex theorem
-
-Q5296972:
-  title: "Doob\u2013Meyer decomposition theorem"
-
-Q1076274:
-  title: "Choquet\u2013Bishop\u2013de Leeuw theorem"
-
-Q4916483:
-  title: "Birkhoff\u2013Grothendieck theorem"
-
-Q977912:
-  title: Stolper&ndash;Samuelson theorem
-
-Q716171:
-  title: "Erd\u0151s\u2013Ginzburg\u2013Ziv theorem"
-
-Q1996305:
-  title: Burnside's theorem
-
-Q5709377:
-  title: Helmholtz theorem (classical mechanics)
-
-Q1149522:
-  title: Lami's theorem
-
-Q338886:
-  title: Divergence theorem
-
-Q7782348:
-  title: Theorem of three moments
-
-Q925854:
-  title: Angle bisector theorem
+Q132469:
+  title: Fermat's Last Theorem
 
 Q137164:
   title: Besicovitch covering theorem
 
-Q7031618:
-  title: Nielsen realization problem
+Q154210:
+  title: CPCTC
 
-Q2226800:
-  title: "Schur\u2013Zassenhaus theorem"
+Q164262:
+  title: Lebesgue covering dimension
 
-Q2893695:
-  title: Unmixedness theorem
+Q172298:
+  title: Lasker–Noether theorem
 
-Q207014:
-  title: Independence of the parallel postulate
+Q174955:
+  title: Mihăilescu's theorem
 
-Q1471282:
-  title: Radon's theorem
+Q179208:
+  title: Cayley's theorem
 
-Q31838822:
-  title: Kirchberger's theorem
+Q179467:
+  title: Fourier theorem
 
-Q1841237:
-  title: Fubini's theorem on differentiation
+Q179692:
+  title: Independence of the axiom of choice
 
-Q2275191:
-  title: Lebesgue differentiation theorem
+Q180345X:
+  title: Integral root theorem
 
-Q7127466:
-  title: Paley's theorem
+Q180345:
+  title: Rational root theorem
 
-Q1809539:
-  title: Pizza theorem
+Q182505:
+  title: Bayes' theorem
 
-Q5047046:
-  title: "Brauer\u2013Cartan\u2013Hua theorem"
+Q184410:
+  title: Four color theorem
 
-Q642620:
-  title: "Krein\u2013Milman theorem"
+Q188295:
+  title: Fermat's little theorem
 
-Q2226602:
-  title: "Bauer\u2013Fike theorem"
+Q188745:
+  title: Classification of Platonic solids
 
-Q3527226:
-  title: Linear speedup theorem
+Q189136:
+  title: Mean value theorem
 
-Q5242704:
-  title: "Dawson\u2013G\xE4rtner theorem"
+Q190026:
+  title: Ford's theorem
 
-Q5697927:
-  title: "Gross\u2013Zagier theorem"
+Q190391X:
+  title: Lyapunov's central limit theorem
 
-Q1139041:
-  title: Cauchy's theorem
-
-Q17008559:
-  title: "Davenport\u2013Schmidt theorem"
-
-Q5612871:
-  title: "Gr\xF6tzsch's theorem"
-
-Q848092:
-  title: "Borsuk\u2013Ulam theorem"
-
-Q273037:
-  title: "Bondy\u2013Chv\xE1tal theorem"
-
-Q2338929:
-  title: Exchange theorem
-
-Q967972:
-  title: Open mapping theorem
-
-Q5580171:
-  title: Goldie's theorem
-
-Q7959587:
-  title: Wagner's theorem
-
-Q377276:
-  title: Cook's theorem
-
-Q4865980:
-  title: Barwise compactness theorem
-
-Q852973:
-  title: Euler's polyhedron theorem
-
-Q4949984:
-  title: Bounded inverse theorem
-
-Q2482753:
-  title: Mann's theorem
-
-Q10942247:
-  title: Hironaka theorem
-
-Q2638931:
-  title: Convolution theorem
-
-Q1505529:
-  title: Runge's theorem
-
-Q1054106:
-  title: Cox's theorem
-
-Q386292:
-  title: Prime number theorem
-
-Q733081:
-  title: Impossibility of angle trisection
-
-Q11883897:
-  title: Nagata's compactification theorem
-
-Q1186134:
-  title: "Poncelet\u2013Steiner theorem"
-
-Q1995468:
-  title: "H\xF6lder's theorem"
+Q190391:
+  title: Central limit theorem
 
 Q190556:
   title: De Moivre's theorem
 
-Q2226774:
-  title: "K\xF6nig's theorem"
+Q191693:
+  title: Lebesgue's decomposition theorem
 
-Q619985:
-  title: Multinomial theorem
+Q192760:
+  title: Fundamental theorem of algebra
 
-Q1135706:
-  title: Harnack's theorem
+Q193286:
+  title: Rolle's theorem
 
-Q6783821:
-  title: "Mason\u2013Stothers theorem"
+Q193878:
+  title: Chinese remainder theorem
 
-Q2984415:
-  title: "Hajnal\u2013Szemer\xE9di theorem"
+Q193882:
+  title: Menelaus's theorem
 
-Q4857506:
-  title: "Bapat\u2013Beg theorem"
+Q193910:
+  title: Euler's theorem
 
-Q7296106:
-  title: Rauch comparison theorem
+Q194919:
+  title: Inverse eigenvalues theorem
 
-Q4634017:
-  title: "2\u03C0 theorem"
+Q195133:
+  title: Wigner–Eckart theorem
 
-Q1425529:
-  title: Chebotarev's density theorem
+Q200787:
+  title: Gödel's incompleteness theorem
 
-Q660799:
-  title: Darboux's theorem
+Q203565:
+  title: Solutions of a general cubic equation
 
-Q2309760:
-  title: "Looman\u2013Menchoff theorem"
+Q204884:
+  title: Löb's theorem
 
-Q599876:
-  title: Cochran's theorem
+Q205966:
+  title: Critical line theorem
 
-Q976607:
-  title: "Erd\u0151s\u2013Szekeres theorem"
+Q207014:
+  title: Independence of the parallel postulate
 
-Q7310041:
-  title: Reider's theorem
+Q207244:
+  title: Sela's theorem
 
-Q1134776:
-  title: Dilworth's theorem
+Q208416:
+  title: Independence of the continuum hypothesis
+  url: https://github.com/flypitch/flypitch
+  identifiers:
+  - independence_of_CH
+  author: Floris van Doorn and Jesse Michael Han
+  date: 2019-09-17
 
-Q3424029:
-  title: Chasles's theorems
+Q208756:
+  title: Castelnuovo theorem
 
-Q4942215:
-  title: Bonnet theorem
+Q211981:
+  title: Hartman–Grobman theorem
+
+Q213603:
+  title: Ceva's theorem
+
+Q220680:
+  title: Banach fixed-point theorem
+
+Q225973:
+  title: Ore's theorem
+
+Q226014:
+  title: Poincaré recurrence theorem
+
+Q230848:
+  title: Lamé’s theorem
 
 Q240950:
   title: Faltings's theorem
 
-Q4788680:
-  title: Area theorem (conformal mapping)
+Q241868:
+  title: Thévenin's theorem
 
-Q1751105:
-  title: Blum's speedup theorem
+Q242045:
+  title: Monotone class theorem
 
-Q656645:
-  title: Hilbert's basis theorem
-
-Q7307252:
-  title: Reflection theorem
-
-Q5576268:
-  title: "Goddard\u2013Thorn theorem"
-
-Q1720410:
-  title: Hjelmslev's theorem
-
-Q1551745:
-  title: Binomial inverse theorem
-
-Q834025:
-  title: Cauchy integral theorem
-
-Q11704319:
-  title: "Chern\u2013Gauss\u2013Bonnet theorem"
-
-Q1191709:
-  title: Egorov's theorem
-
-Q973359:
-  title: Rado's theorem
-
-Q1964537:
-  title: Mergelyan's theorem
-
-Q2226682:
-  title: "Gelfand\u2013Naimark theorem"
-
-Q966837:
-  title: "Cram\xE9r\u2013Wold theorem"
-
-Q730222:
-  title: Ham sandwich theorem
-
-Q931001:
-  title: Inverse function theorem
-
-Q850495:
-  title: Wick's theorem
-
-Q2411312:
-  title: Shannon's source coding theorem
-
-Q1305766:
-  title: "Poincar\xE9\u2013Hopf theorem"
-
-Q6735549:
-  title: Maier's theorem
-
-Q18630480:
-  title: Euler's quadrilateral theorem
-
-Q3527110:
-  title: "Lax\u2013Wendroff theorem"
-
-Q4753992:
-  title: Anderson's theorem
-
-Q830513:
-  title: Residue theorem
-
-Q7430892:
-  title: Schaefer's dichotomy theorem
-
-Q3527205:
-  title: Dimension theorem for vector spaces
-
-Q3527009:
-  title: Baker's theorem
-
-Q1048589:
-  title: "Hohenberg\u2013Kohn theorems"
-
-Q1144897:
-  title: Brouwer fixed-point theorem
-
-Q657469:
-  title: Lefschetz fixed-point theorem
-
-Q5165492:
-  title: Continuous mapping theorem
-
-Q5252320:
-  title: Lickorish twist theorem
-
-Q17081508:
-  title: Bing metrization theorem
-
-Q7632041:
-  title: Subspace theorem
-
-Q4958233:
-  title: "Brauer\u2013Suzuki\u2013Wall theorem"
-
-Q380576:
-  title: Measurable Riemann mapping theorem
-
-Q17005116:
-  title: Birkhoff's representation theorem
-
-Q4455033:
-  title: Fatou's theorem
-
-Q1243340:
-  title: "Birkhoff\u2013Von Neumann theorem"
-
-Q1051404:
-  title: "Ces\xE0ro's theorem"
-
-Q5384150:
-  title: Equal incircles theorem
-
-Q3527125:
-  title: Monsky's theorem
-
-Q1082910:
-  title: Euler's partition theorem
-
-Q428134:
-  title: "Gauss\u2013Markov theorem"
-
-Q1059151:
-  title: FWL theorem
-
-Q3505260:
-  title: "Cayley\u2013Salmon theorem"
-
-Q3527118:
-  title: Mahler's theorem
-
-Q11352023:
-  title: Vitali convergence theorem
-
-Q488541:
-  title: Fisher separation theorem
-
-Q1376515:
-  title: No-hair theorem
-
-Q1308502:
-  title: "Church\u2013Rosser theorem"
-
-Q6795637:
-  title: Maximal ergodic theorem
-
-Q5507285:
-  title: Fuglede's theorem
-
-Q2013213:
-  title: Reuschle's theorem
-
-Q1348736:
-  title: Rybczynski theorem
-
-Q1056283:
-  title: May's theorem
-
-Q643826:
-  title: Slutsky's theorem
-
-Q4666729:
-  title: "Abel\u2013Jacobi theorem"
-
-Q3527004:
-  title: BEST theorem
-
-Q5503689:
-  title: "Bombieri\u2013Friedlander\u2013Iwaniec theorem"
-
-Q253214:
-  title: "Heine\u2013Borel theorem"
-
-Q1153584:
-  title: Monotone convergence theorem
-
-Q4054114:
-  title: ATS theorem
-
-Q859122:
-  title: "Cauchy\u2013Hadamard theorem"
-
-Q6528747:
-  title: Leray's theorem
-
-Q544369:
-  title: "Glivenko\u2013Cantelli theorem"
-
-Q3527215:
-  title: Hilbert projection theorem
-
-Q248931:
-  title: "Poincar\xE9\u2013Bendixson theorem"
-
-Q1065257:
-  title: Squeeze theorem
-
-Q255996:
-  title: Equipartition theorem
-
-Q7309601:
-  title: "Whitney\u2013Graustein Theorem"
-
-Q595466:
-  title: Dini's theorem
-
-Q4455046:
-  title: Monodromy theorem
-
-Q1752988:
-  title: "Kutta\u2013Joukowski theorem"
-
-Q245902:
-  title: "Riesz\u2013Thorin theorem"
-
-Q867141:
-  title: Ehresmann's theorem
-
-Q1370316:
-  title: Casey's theorem
-
-Q15844093:
-  title: Van Schooten's theorem
-
-Q7825061:
-  title: Toponogov's theorem
-
-Q588218:
-  title: Koebe 1/4 theorem
+Q245098:
+  title: Intermediate value theorem
 
 Q245098X:
   title: Bolzano's theorem
 
-Q5438320:
-  title: "Faustman\u2013Ohlin theorem"
+Q245902:
+  title: Riesz–Thorin theorem
 
-Q1121027:
-  title: "Krylov\u2013Bogolyubov theorem"
+Q248931:
+  title: Poincaré–Bendixson theorem
 
-Q5597098:
-  title: Graph structure theorem
+Q253214:
+  title: Heine–Borel theorem
 
-Q845088:
-  title: Pappus's centroid theorem
+Q255996:
+  title: Equipartition theorem
 
-Q1077741:
-  title: Hairy ball theorem
+Q256303:
+  title: Lax&ndash;Richtmyer theorem
 
-Q5187911:
-  title: Crooks fluctuation theorem
+Q257387:
+  title: Vitali theorem
 
-Q5094298:
-  title: Chevalley's structure theorem
+Q258374:
+  title: Carathéodory's theorem
 
-Q1752621:
-  title: Sylvester's law of inertia
+Q260928:
+  title: Jordan curve theorem
+
+Q266291:
+  title: Bloch's theorem
+
+Q268031:
+  title: Abel's binomial theorem
+
+Q268132:
+  title: Gauss–Wantzel theorem
+
+Q273037:
+  title: Bondy–Chvátal theorem
+
+Q276082:
+  title: Wilson's theorem
+
+Q280116:
+  title: Odd number theorem
+
+Q282331:
+  title: Addition theorem
+
+Q282649:
+  title: Pentagonal number theorem
+
+Q283690:
+  title: Arrival theorem
+
+Q284960:
+  title: Mordell–Weil theorem
+
+Q285719:
+  title: Thales's theorem
+
+Q287347:
+  title: Gradient theorem
+
+Q288465:
+  title: Orbit-stabilizer theorem
+
+Q303402:
+  title: Rank–nullity theorem
+
+Q318767:
+  title: Abel's theorem
+
+Q321237:
+  title: Green's theorem
+
+Q332465:
+  title: Absolute convergence theorem
+
+Q338886:
+  title: Divergence theorem
+
+Q339495:
+  title: Symphonic theorem
+
+Q356895:
+  title: Adiabatic theorem
+
+Q357192:
+  title: Holland's schema theorem
+
+Q357858:
+  title: Freyd's adjoint functor theorem
+
+Q371685:
+  title: Kraft–McMillan theorem
+
+Q372037:
+  title: Seifert–van Kampen theorem
+
+Q376166:
+  title: Cut-elimination theorem
+
+Q377047:
+  title: Butterfly theorem
+
+Q377276:
+  title: Cook's theorem
+
+Q379048:
+  title: Riemann–Roch theorem
+
+Q380576:
+  title: Measurable Riemann mapping theorem
+
+Q383238:
+  title: Hartogs's extension theorem
+
+Q384142:
+  title: Herbrand–Ribet theorem
+
+Q386292:
+  title: Prime number theorem
+
+Q388525:
+  title: Bell's theorem
+
+Q401319:
+  title: Puiseux's theorem
+
+Q401905:
+  title: Skorokhod's representation theorem
+
+Q420714:
+  title: Akra–Bazzi theorem
+
+Q422187:
+  title: Myhill–Nerode theorem
+
+Q425432:
+  title: Laurent expansion theorem
+
+Q428134:
+  title: Gauss–Markov theorem
+
+Q459547:
+  title: Ptolemy's theorem
+
+Q467205:
+  title: Fundamental theorems of welfare economics
+
+Q467756:
+  title: Stokes's theorem
 
 Q468391:
-  title: "Bolzano\u2013Weierstrass theorem"
+  title: Bolzano–Weierstrass theorem
 
-Q5282247:
-  title: Disintegration theorem
+Q470877:
+  title: Stirling's theorem
 
-Q764287:
-  title: Van der Waerden's theorem
+Q472883:
+  title: Quadratic reciprocity theorem
 
-Q7140218:
-  title: Parthasarathy's theorem
+Q474881:
+  title: Cantor's theorem
 
-Q2226807:
-  title: Vantieghems theorem
+Q476776:
+  title: Solutions of a general quartic equation
 
-Q915474:
-  title: Robin's theorem
+Q487132:
+  title: Infinite monkey theorem
 
-Q1132952:
-  title: Euler's theorem on homogeneous functions
+Q488541:
+  title: Fisher separation theorem
 
-Q3613173:
-  title: Tits alternative
+Q495412:
+  title: Jordan–Schönflies theorem
 
-Q7996769:
-  title: Whitney immersion theorem
+Q504843:
+  title: Mycielski's theorem
 
-Q4677985:
-  title: Acyclic models theorem
+Q505798:
+  title: Lagrange's theorem
 
-Q841893:
-  title: Desargues's theorem
+Q510197:
+  title: Tutte theorem
 
-Q834211:
-  title: "Wallace\u2013Bolyai\u2013Gerwien theorem"
+Q512897:
+  title: Brooks's theorem
 
-Q5567394:
-  title: Gleason's theorem
+Q523832:
+  title: Carathéodory–Jacobi–Lie theorem
 
-Q1739994:
-  title: "Brauer\u2013Suzuki theorem"
+Q523876:
+  title: Spin–statistics theorem
 
-Q1032886:
-  title: "Hales\u2013Jewett theorem"
+Q528955:
+  title: Kochen–Specker theorem
 
-Q96377355:
-  title: "Erd\u0151s\u2013Dushnik\u2013Miller theorem"
+Q528987:
+  title: Von Neumann bicommutant theorem
 
-Q1196729:
-  title: Mertens's theorems
+Q530152:
+  title: Picard&ndash;Lindelöf theorem
 
-Q7190748:
-  title: "Pickands\u2013Balkema\u2013de Haan theorem"
+Q535366:
+  title: Montel's theorem
 
-Q5251122:
-  title: Time hierarchy theorem
+Q536640:
+  title: Hall's marriage theorem
 
-Q5385325:
-  title: "Erd\u0151s\u2013P\xF3sa theorem"
+Q537618:
+  title: Banach–Alaoglu theorem
 
-Q7599389:
-  title: Stanley's reciprocity theorem
+Q544292:
+  title: Lagrange inversion theorem
 
-Q1422083:
-  title: Ryll-Nardzewski fixed-point theorem
+Q544369:
+  title: Glivenko–Cantelli theorem
 
-Q4827308:
-  title: Auxiliary polynomial theorem
+Q550402:
+  title: Dirichlet's theorem on arithmetic progressions
+
+Q552367:
+  title: Berge's theorem
+
+Q567843:
+  title: Hahn–Mazurkiewicz theorem
+
+Q570779:
+  title: Vieta's formulas
 
 Q574902:
   title: Tarski's indefinability theorem
 
-Q1322892:
-  title: Dirac's theorems
+Q576478:
+  title: Liouville's theorem
 
-Q3711848:
-  title: Sobolev embedding theorem
+Q578555:
+  title: Noether's theorem
 
-Q5874979:
-  title: "Hobby\u2013Rice theorem"
+Q579515:
+  title: Rao–Blackwell theorem
 
-Q5504427:
-  title: Friendship theorem
+Q583147:
+  title: Sard's theorem
+
+Q586051:
+  title: Haag–Łopuszański–Sohnius theorem
+
+Q587081:
+  title: Kolmogorov–Arnold–Moser theorem
+
+Q588218:
+  title: Koebe 1/4 theorem
+
+Q594571:
+  title: Van Aubel's theorem
+
+Q595466:
+  title: Dini's theorem
+
+Q599876:
+  title: Cochran's theorem
+
+Q608294:
+  title: Max flow min cut theorem
+
+Q609612:
+  title: Knaster–Tarski theorem
+
+Q612021:
+  title: Gibbard–Satterthwaite theorem
+
+Q617417:
+  title: Isoperimetric theorem
+
+Q619985:
+  title: Multinomial theorem
+
+Q620602:
+  title: Virial theorem
+
+Q631561:
+  title: Closed range theorem
+
+Q632546X:
+  title: Sylvester's theorem
+
+Q632546:
+  title: Bertrand's postulate
+
+Q637418:
+  title: Napoleon's theorem
+
+Q642620:
+  title: Krein–Milman theorem
+
+Q643513:
+  title: Riesz–Fischer theorem
+
+Q643826:
+  title: Slutsky's theorem
+
+Q646523:
+  title: Pick's theorem
+
+Q649469:
+  title: Modularity theorem
+
+Q649977:
+  title: Shirshov–Cohn theorem
+
+Q650738:
+  title: Folk theorem
+
+Q651593:
+  title: Norton's theorem
+
+Q656176:
+  title: Schauder fixed-point theorem
+
+Q656198:
+  title: Maschke's theorem
+
+Q656645:
+  title: Hilbert's basis theorem
+
+Q656772:
+  title: Cayley–Hamilton theorem
+
+Q657469:
+  title: Lefschetz fixed-point theorem
+
+Q657469X:
+  title: Lefschetz–Hopf theorem
+
+Q657482:
+  title: Abel–Ruffini theorem
+
+Q657903:
+  title: Hilbert–Waring theorem
+
+Q660799:
+  title: Darboux's theorem
+
+Q670235:
+  title: Fundamental theorem of arithmetic
+
+Q671663:
+  title: Coleman–Mandula theorem
+
+Q676413:
+  title: Dandelin's theorem
+
+Q679800:
+  title: Nyquist–Shannon sampling theorem
+
+Q681406:
+  title: Euler's rotation theorem
+
+Q685437:
+  title: Titchmarsh theorem
+
+Q693083:
+  title: Soundness theorem
+
+Q716171:
+  title: Erdős–Ginzburg–Ziv theorem
+
+Q718875:
+  title: Erdős–Ko–Rado theorem
+
+Q719966:
+  title: Toda's theorem
+
+Q720469:
+  title: Chevalley–Warning theorem
+
+Q721695:
+  title: Szemerédi–Trotter theorem
+
+Q727102:
+  title: Fermat's theorem (stationary points)
+
+Q729359:
+  title: Hadamard three-circle theorem
+
+Q730222:
+  title: Ham sandwich theorem
+
+Q733081:
+  title: Impossibility of angle trisection
+
+Q737851:
+  title: Banach–Tarski theorem
+
+Q737892:
+  title: Bendixson–Dulac theorem
+
+Q739403:
+  title: Stewart's theorem
+
+Q740093:
+  title: Peano existence theorem
+
+Q742833:
+  title: Gauss–Bonnet theorem
+
+Q744440:
+  title: Immerman–Szelepcsényi theorem
+
+Q748233:
+  title: Sylvester–Gallai theorem
+
+Q751120:
+  title: Thue–Siegel–Roth theorem
+
+Q752375:
+  title: Extreme value theorem
+
+Q755986:
+  title: Atiyah–Bott fixed-point theorem
+
+Q755991:
+  title: Atiyah–Singer index theorem
+
+Q756946:
+  title: Lagrange's four-square theorem
+
+Q764287:
+  title: Van der Waerden's theorem
+
+Q765987:
+  title: Heine–Cantor theorem
+
+Q766722:
+  title: Liouville's theorem
+
+Q776578:
+  title: Artin–Wedderburn theorem
+
+Q777924:
+  title: Tijdeman's theorem
+
+Q779220:
+  title: Hilbert's syzygy theorem
+
+Q780763:
+  title: 15 and 290 theorems
+
+Q784049:
+  title: Blaschke selection theorem
+
+Q790236:
+  title: Baranyai's theorem
+
+Q791258:
+  title: Basu's theorem
+
+Q791663:
+  title: Beatty's theorem
+
+Q794269:
+  title: Betti's theorem
+
+Q810431:
+  title: Basel problem
+
+Q828284:
+  title: Parallel axis theorem
+
+Q830124:
+  title: Girsanov's theorem
+
+Q830513:
+  title: Residue theorem
+
+Q834025:
+  title: Cauchy integral theorem
+
+Q834211:
+  title: Wallace–Bolyai–Gerwien theorem
+
+Q837506:
+  title: Theorem on friends and strangers
+
+Q837551:
+  title: Frobenius theorem
+
+Q841893:
+  title: Desargues's theorem
+
+Q842953:
+  title: Lebesgue's density theorem
+
+Q844612:
+  title: Brun's theorem
+
+Q845088:
+  title: Pappus's centroid theorem
+
+Q846840:
+  title: Erdős–Kac theorem
+
+Q848092:
+  title: Borsuk–Ulam theorem
+
+Q848375:
+  title: Implicit function theorem
+
+Q848810:
+  title: Kronecker's theorem
+
+Q850495:
+  title: Wick's theorem
+
+Q851166:
+  title: Pappus's hexagon theorem
+
+Q852183:
+  title: Viviani's theorem
+
+Q852973:
+  title: Euler's polyhedron theorem
+
+Q853067:
+  title: Solutions to Pell's equation
+
+Q856032:
+  title: CAP theorem
+
+Q856158:
+  title: Midy's theorem
+
+Q857089:
+  title: de Branges's theorem
+
+Q858978:
+  title: Castigliano's first and second theorems
+
+Q859122:
+  title: Cauchy–Hadamard theorem
+
+Q865665:
+  title: Birkhoff's theorem
+
+Q866116:
+  title: Hahn–Banach theorem
+
+Q867141:
+  title: Ehresmann's theorem
+
+Q867839:
+  title: Rosser's theorem
+
+Q869647:
+  title: Szpilrajn extension theorem
+
+Q872088:
+  title: Boolean prime ideal theorem
+
+Q877489:
+  title: Apollonius's theorem
+
+Q890875:
+  title: Bohr–van Leeuwen theorem
+
+Q897769:
+  title: König's theorem
+
+Q899002:
+  title: Pascal's theorem
+
+Q899853:
+  title: H-theorem
+
+Q900831:
+  title: Fluctuation theorem
+
+Q902052:
+  title: Gödel's completeness theorem
+
+Q902618:
+  title: Floquet's theorem
+
+Q906809:
+  title: Hellmann–Feynman theorem
+
+Q909517:
+  title: Feit–Thompson theorem
+
+Q913447:
+  title: Morley's trisector theorem
+
+Q913849:
+  title: Minimax theorem
+
+Q914517:
+  title: Fermat's theorem on sums of two squares
+
+Q915474:
+  title: Robin's theorem
+
+Q918099:
+  title: Ramsey's theorem
+
+Q922012:
+  title: Green–Tao theorem
+
+Q922367:
+  title: Master theorem (analysis of algorithms)
+
+Q925224:
+  title: Sonnenschein–Mantel–Debreu Theorem
+
+Q925854:
+  title: Angle bisector theorem
+
+Q927051:
+  title: Riemann mapping theorem
 
 Q928813:
   title: Menger's theorem
 
-Q3527113:
-  title: "Lie\u2013Kolchin theorem"
+Q929547:
+  title: Myers theorem
+
+Q931001:
+  title: Inverse function theorem
+
+Q931001X:
+  title: Constant rank theorem
+
+Q931404:
+  title: Bertrand–Diquet–Puiseux theorem
+
+Q939927:
+  title: Stone–Weierstrass theorem
+  decl: stone_weierstrass
+  author: Scott Morrison and Heather Macbeth
+  date: 2021-05-01
+
+Q942046:
+  title: Schwarz–Ahlfors–Pick theorem
+
+Q943246:
+  title: Wedderburn's little theorem
+
+Q944297:
+  title: Open mapping theorem
+
+Q948664:
+  title: Kneser's theorem
+
+Q951327:
+  title: Pasch's theorem
+
+Q953062:
+  title: Reynolds transport theorem
+
+Q954210:
+  title: Savitch's theorem
+
+Q965294:
+  title: Thabit ibn Qurra's theorem
+
+Q966837:
+  title: Cramér–Wold theorem
+
+Q967972:
+  title: Open mapping theorem
+
+Q973359:
+  title: Rado's theorem
+
+Q974405:
+  title: Hille–Yosida theorem
+
+Q976033:
+  title: Gelfond–Schneider theorem
+
+Q976607:
+  title: Erdős–Szekeres theorem
+
+Q977912:
+  title: Stolper&ndash;Samuelson theorem
+
+Q978688:
+  title: Gershgorin circle theorem
+
+Q985009:
+  title: Helmholtz's theorems
+
+Q994401:
+  title: Four-vertex theorem
+
+Q995926:
+  title: Perpendicular axis theorem
+
+Q999783:
+  title: Buckingham π theorem
+
+Q1008566:
+  title: Gauss–Lucas theorem
+
+Q1032886:
+  title: Hales–Jewett theorem
+
+Q1033910:
+  title: Cantor–Bernstein–Schroeder theorem
+
+Q1037559:
+  title: Pólya enumeration theorem
+
+Q1038716:
+  title: Identity theorem
+
+Q1046232:
+  title: Szemerédi's theorem
+
+Q1047749:
+  title: Turán's theorem
+
+Q1048589:
+  title: Hohenberg–Kohn theorems
+
+Q1048874:
+  title: Gauss's Theorema Egregium
+
+Q1050037:
+  title: Coase theorem
+
+Q1050203:
+  title: Cantor's intersection theorem
+
+Q1050932:
+  title: Hartogs's theorem
+
+Q1051404:
+  title: Cesàro's theorem
+
+Q1052021:
+  title: Craig's interpolation theorem
+
+Q1052678:
+  title: Baire category theorem
+
+Q1052752:
+  title: Stolz–Cesàro theorem
+
+Q1054106:
+  title: Cox's theorem
+
+Q1056283:
+  title: May's theorem
+
+Q1057919:
+  title: Sylow theorems
+
+Q1058662:
+  title: Darboux's theorem
+
+Q1059151:
+  title: FWL theorem
+
+Q1064471:
+  title: Earnshaw's theorem
+
+Q1065257:
+  title: Squeeze theorem
+
+Q1065966:
+  title: Isomorphism theorem
+
+Q1067156:
+  title: Dominated convergence theorem
+
+Q1067156X:
+  title: Bounded convergence theorem
+
+Q1068085:
+  title: Closed graph theorem
+
+Q1068283:
+  title: Löwenheim–Skolem theorem
+
+Q1068385:
+  title: Clairaut's theorem
+
+Q1068976:
+  title: Hilbert's Nullstellensatz
+
+Q1075398:
+  title: Jung's theorem
+
+Q1076274:
+  title: Choquet–Bishop–de Leeuw theorem
+
+Q1077462:
+  title: König's theorem
+
+Q1077741:
+  title: Hairy ball theorem
+
+Q1082910:
+  title: Euler's partition theorem
+
+Q1095330:
+  title: Apéry's theorem
+
+Q1097021:
+  title: Minkowski's theorem
+
+Q1103054:
+  title: Lions–Lax–Milgram theorem
+
+Q1119094:
+  title: Paley&ndash;Wiener theorem
+
+Q1121027:
+  title: Krylov–Bogolyubov theorem
+
+Q1125462:
+  title: Dinostratus' theorem
+
+Q1129636:
+  title: Lehmann–Scheffé theorem
+
+Q1130846:
+  title: Ladner's theorem
+
+Q1131601:
+  title: Sklar's theorem
+
+Q1132952:
+  title: Euler's theorem on homogeneous functions
+
+Q1134296:
+  title: Supporting hyperplane theorem
+
+Q1134776:
+  title: Dilworth's theorem
+
+Q1135706:
+  title: Harnack's theorem
+
+Q1136043:
+  title: Hurwitz's theorem
+
+Q1136262:
+  title: Optical theorem
+
+Q1137014:
+  title: Tychonoff's theorem
+
+Q1137206:
+  title: Taylor's theorem
+
+Q1139041:
+  title: Cauchy's theorem
 
 Q1139430:
   title: Hurwitz's theorem
@@ -899,2710 +1046,2567 @@ Q1139430:
 Q1139524:
   title: Rationality theorem
 
-Q510197:
-  title: Tutte theorem
-
-Q1152521:
-  title: "Mohr\u2013Mascheroni theorem"
-
-Q3984011:
-  title: Duggan&ndash;Schwartz theorem
-
-Q7536097:
-  title: "Skoda\u2013El Mir theorem"
-
-Q8028529:
-  title: Witt's theorem
-
-Q2588432:
-  title: Wold's theorem
-
-Q2226962:
-  title: "Weierstrass\u2013Casorati theorem"
-
-Q1434805:
-  title: Max Noether's theorem
-
-Q17098075:
-  title: "Jurkat\u2013Richert theorem"
-
-Q7782345:
-  title: Bertini's theorem
-
-Q17102744:
-  title: "Riemann\u2013Roch theorem for smooth manifolds"
-
-Q1366581:
-  title: "Erd\u0151s\u2013Rado theorem"
-
-Q6446396:
-  title: Kurosh subgroup theorem
-
-Q17080564:
-  title: Zariski's connectedness theorem
-
-Q4815879:
-  title: "Atiyah\u2013Segal completion theorem"
-
-Q4272300:
-  title: Initial value theorem
-
-Q1751823:
-  title: No-cloning theorem
-
-Q2800071:
-  title: Perfect graph theorem
-
-Q194919:
-  title: Inverse eigenvalues theorem
-
-Q4944923:
-  title: "Borel\u2013Bott\u2013Weil theorem"
-
-Q5659675:
-  title: Harnack's curve theorem
-
-Q2478371:
-  title: Envelope theorem
-
-Q7043732:
-  title: Kuhn's theorem
-
-Q6757284:
-  title: Marcinkiewicz theorem
-
-Q872088:
-  title: Boolean prime ideal theorem
-
-Q1477053:
-  title: "Arzel\xE0\u2013Ascoli theorem"
-
-Q5141331:
-  title: Cohen structure theorem
-
-Q5499906:
-  title: "Shirshov\u2013Witt theorem"
-
-Q739403:
-  title: Stewart's theorem
-
-Q777924:
-  title: Tijdeman's theorem
-
-Q7999797:
-  title: Beer's theorem
-
-Q5610190:
-  title: Gromov's compactness theorem
-
-Q15830473:
-  title: Morley's categoricity theorem
-
-Q766722:
-  title: Liouville's theorem
-
-Q3527214:
-  title: Non-squeezing theorem
-
-Q3527091:
-  title: Gromov's theorem on groups of polynomial growth
-
-Q204884:
-  title: "L\xF6b's theorem"
-
-Q15859323:
-  title: Anne's theorem
-
-Q1632301:
-  title: Sturm's theorem
-
-Q858978:
-  title: Castigliano's first and second theorems
-
-Q467756:
-  title: Stokes's theorem
-
-Q2071632:
-  title: "Rouch\xE9\u2013Capelli theorem"
-
-Q7047379:
-  title: Noether's theorem on rationality for surfaces
-
-Q241868:
-  title: "Th\xE9venin's theorem"
-
-Q3502015:
-  title: Hasse's theorem on elliptic curves
-
-Q172298:
-  title: "Lasker\u2013Noether theorem"
-
-Q2919401:
-  title: Ostrowski's theorem
-
-Q4455003:
-  title: Pomeranchuk's theorem
-
-Q5645731:
-  title: "Hammersley\u2013Clifford theorem"
-
-Q1896455:
-  title: Varignon's theorem
-
-Q1568612:
-  title: Marden's theorem
-
-Q425432:
-  title: Laurent expansion theorem
-
-Q7295875:
-  title: Ratner's theorems
-
-Q8063120:
-  title: ZJ theorem
-
-Q794269:
-  title: Betti's theorem
-
-Q953062:
-  title: Reynolds transport theorem
-
-Q2993319:
-  title: "Mirsky\u2013Newman theorem"
-
-Q213603:
-  title: Ceva's theorem
-
-Q5612159:
-  title: "Grunwald\u2013Wang theorem"
-
-Q2347139:
-  title: Carnot's theorem
-
-Q2027347:
-  title: Optional stopping theorem
-
-Q5473576:
-  title: Foster's theorem
-
-Q20278711:
-  title: Cramer's theorem (algebraic curves)
-
-Q3889376:
-  title: Carmichael's theorem
-
-Q7437564:
-  title: Scott core theorem
-
-Q1602819:
-  title: "Lumer\u2013Phillips theorem"
-
-Q5188510:
-  title: Crossbar theorem
-
-Q7031621:
-  title: Nielsen fixed-point theorem
-
-Q17089994X:
-  title: Tikhonov fixed-point theorem
-
-Q727102:
-  title: Fermat's theorem (stationary points)
-
-Q6379606:
-  title: "Kawamata\u2013Viehweg vanishing theorem"
-
-Q856032:
-  title: CAP theorem
-
-Q2068227:
-  title: "Artin\u2013Schreier theorem"
-
-Q7928688:
-  title: "Vietoris\u2013Begle mapping theorem"
-
-Q1766814:
-  title: Smn theorem
-
-Q918099:
-  title: Ramsey's theorem
-
-Q1704878:
-  title: "Appell\u2013Humbert theorem"
-
-Q16251580:
-  title: Matiyasevich's theorem
-
-Q856158:
-  title: Midy's theorem
-
-Q1893717:
-  title: Rice's theorem
-
-Q6733278:
-  title: Maharam's theorem
-
-Q2993026:
-  title: Ankeny&ndash;Artin&ndash;Chowla theorem
-
-Q7341043:
-  title: Robbins theorem
-
-Q3088644:
-  title: Goldstine theorem
-
-Q2269888:
-  title: Cohn's irreducibility criterion
-
-Q752375:
-  title: Extreme value theorem
-
-Q5421989:
-  title: Exterior angle theorem
-
-Q5047051:
-  title: "Cartan\u2013Kuranishi prolongation theorem"
-
-Q3984017:
-  title: Helly's selection theorem
-
-Q1068385:
-  title: Clairaut's theorem
-
-Q5385326:
-  title: "Erd\u0151s\u2013Stone theorem"
-
-Q3229352:
-  title: Vitali covering theorem
-
-Q784049:
-  title: Blaschke selection theorem
-
-Q2600653:
-  title: "Taylor\u2013Proudman theorem"
-
-Q4991415:
-  title: "Chowla\u2013Mordell theorem"
-
-Q7137494:
-  title: "Paris\u2013Harrington theorem"
-
-Q17017973:
-  title: Godunov's theorem
-
-Q594571:
-  title: Van Aubel's theorem
-
-Q535366:
-  title: Montel's theorem
-
-Q4455030:
-  title: Stone's theorem on one-parameter unitary groups
-
-Q6967039:
-  title: "Nash\u2013Moser theorem"
-
-Q2226855:
-  title: Sarkovskii's theorem
-
-Q1946642X:
-  title: "S\u2013cobordism theorem"
-
-Q5588002:
-  title: "Gottesman\u2013Knill theorem"
-
-Q3527171:
-  title: Synge's theorem
-
-Q897769:
-  title: "K\xF6nig's theorem"
-
-Q6935007:
-  title: Multiplicity-one theorem
-
-Q242045:
-  title: Monotone class theorem
-
-Q4454973:
-  title: "Lindel\xF6f's theorem"
-
-Q7288988:
-  title: Ramanujam vanishing theorem
-
-Q4956438:
-  title: Branching theorem
-
-Q4998912:
-  title: Burke's theorem
-
-Q119450:
-  title: Brianchon's theorem
-
-Q579515:
-  title: "Rao\u2013Blackwell theorem"
-
-Q1209546:
-  title: Kaplansky density theorem
-
-Q985009:
-  title: Helmholtz's theorems
-
-Q6407842:
-  title: "Killing\u2013Hopf theorem"
-
-Q7269076:
-  title: No-deleting theorem
-
-Q4801183:
-  title: "Artin\u2013Verdier duality theorem"
-
-Q2495664:
-  title: Universal coefficient theorem
-
-Q288465:
-  title: Orbit-stabilizer theorem
-
-Q7269437:
-  title: "Denjoy\u2013Carleman theorem"
-
-Q7431925:
-  title: Schnyder's theorem
-
-Q2376918:
-  title: Abelian and Tauberian theorems
-
-Q976033:
-  title: "Gelfond\u2013Schneider theorem"
-
-Q3526998:
-  title: Excision theorem
-
-Q2428364:
-  title: Clausius theorem
-
-Q3527015:
-  title: Bernstein's theorem
-
-Q132427:
-  title: Rademacher's theorem
-
-Q7312009:
-  title: "Remmert\u2013Stein theorem"
-
-Q721695:
-  title: "Szemer\xE9di\u2013Trotter theorem"
-
-Q1576235:
-  title: Lochs's theorem
-
-Q303402:
-  title: "Rank\u2013nullity theorem"
-
-Q505798:
-  title: Lagrange's theorem
-
-Q3527245:
-  title: Six exponentials theorem
-
-Q19323571:
-  title: "Chomsky\u2013Sch\xFCtzenberger enumeration theorem"
-
-Q268132:
-  title: "Gauss\u2013Wantzel theorem"
-
-Q3699212:
-  title: Saint-Venant's theorem
-
-Q1259814:
-  title: "Nielsen\u2013Schreier theorem"
-
-Q282331:
-  title: Addition theorem
-
-Q357192:
-  title: Holland's schema theorem
-
-Q6860180:
-  title: "Milman\u2013Pettis theorem"
-
-Q2226644:
-  title: Easton's theorem
-
-Q567843:
-  title: "Hahn\u2013Mazurkiewicz theorem"
-
-Q756946:
-  title: Lagrange's four-square theorem
-
-Q681406:
-  title: Euler's rotation theorem
-
-Q7597316:
-  title: Stallings theorem about ends of groups
-
-Q4894565:
-  title: Bernstein's theorem
-
-Q193882:
-  title: Menelaus's theorem
-
-Q4695203:
-  title: Four functions theorem
-
-Q6911202:
-  title: Moreau's theorem
-
-Q7660749:
-  title: Sylvester's determinant theorem
-
-Q4927458:
-  title: Blondel's theorem
-
-Q7841060:
-  title: Trichotomy theorem
-
-Q2253746:
-  title: Bertrand's ballot theorem
-
-Q3527079:
-  title: Freiman's theorem
-
-Q1188504:
-  title: Pitman&ndash;Koopman&ndash;Darmois theorem
-
-Q5579030:
-  title: "Goldberg\u2013Sachs theorem"
-
-Q7269559:
-  title: Sylvester pentahedral theorem
-
-Q190391X:
-  title: Lyapunov's central limit theorem
-
-Q1131601:
-  title: Sklar's theorem
-
-Q5455495:
-  title: Fitting's theorem
-
-Q1149458:
-  title: Compactness theorem
-
-Q2378270:
-  title: Thue's theorem
-
-Q6743217:
-  title: Malgrange preparation theorem
-
-Q6373327:
-  title: "Karp\u2013Lipton theorem"
-
-Q3526976:
-  title: "Ax\u2013Kochen theorem"
-
-Q3527279:
-  title: Wiener's tauberian theorem
-
-Q25378690:
-  title: Ionescu-Tulcea theorem
-
-Q1572474:
-  title: "Lindemann\u2013Weierstrass theorem"
-
-Q7894110:
-  title: Universal approximation theorem
-
-Q4838119:
-  title: "Babu\u0161ka\u2013Lax\u2013Milgram theorem"
-
-Q2862403:
-  title: Bombieri's theorem
-
-Q791258:
-  title: Basu's theorem
-
-Q5278348:
-  title: Galvin's theorem
-
-Q420714:
-  title: "Akra\u2013Bazzi theorem"
-
-Q830124:
-  title: Girsanov's theorem
-
-Q283690:
-  title: Arrival theorem
-
-Q7619060:
-  title: The duality theorem
-
-Q179692:
-  title: Independence of the axiom of choice
-
-Q17089994:
-  title: Fixed-point theorems in infinite-dimensional spaces
-
-Q203565:
-  title: Solutions of a general cubic equation
-
-Q112659261:
-  title: Gamas's Theorem
-
-Q2226677:
-  title: "Gelfand\u2013Mazur theorem"
-
-Q376166:
-  title: Cut-elimination theorem
-
-Q1349282:
-  title: "Eilenberg\u2013Zilber theorem"
-
-Q5876058:
-  title: Hodge index theorem
-
-Q852183:
-  title: Viviani's theorem
-
-Q7996766:
-  title: Whitney extension theorem
-
-Q751120:
-  title: "Thue\u2013Siegel\u2013Roth theorem"
-
-Q7911648:
-  title: "Valiant\u2013Vazirani theorem"
-
-Q1452678:
-  title: "Penrose\u2013Hawking singularity theorems"
-
-Q276082:
-  title: Wilson's theorem
-
-Q5042898:
-  title: Carlson's theorem
-
-Q3527054:
-  title: "De Bruijn\u2013Erd\u0151s theorem (graph theory)"
-
-Q1566341:
-  title: Hindman's theorem
-
-Q1420905:
-  title: Hilbert's theorem 90
-
-Q401319:
-  title: Puiseux's theorem
-
-Q1033910:
-  title: "Cantor\u2013Bernstein\u2013Schroeder theorem"
-
-Q6442276:
-  title: Kuiper's theorem
-
-Q180345X:
-  title: Integral root theorem
-
-Q5463860:
-  title: Focal subgroup theorem
-
-Q17029787:
-  title: Higman's embedding theorem
-
-Q4830725:
-  title: "Ax\u2013Grothendieck theorem"
-
-Q32182:
-  title: Balinski's theorem
-
-Q512897:
-  title: Brooks's theorem
-
-Q258374:
-  title: "Carath\xE9odory's theorem"
-
-Q649977:
-  title: "Shirshov\u2013Cohn theorem"
-
-Q4454954:
-  title: Kirszbraun theorem
-
-Q18206032:
-  title: Cartan's theorem
-
-Q4958230:
-  title: "Brauer\u2013Siegel theorem"
-
-Q357858:
-  title: Freyd's adjoint functor theorem
-
-Q657903:
-  title: "Hilbert\u2013Waring theorem"
-
-Q4756099:
-  title: "Andreotti\u2013Frankel theorem"
-
-Q2607007:
-  title: Hinge theorem
-
-Q5508180:
-  title: Full employment theorem
-
-Q6796056:
-  title: Maxwell's theorem
-
-Q848375:
-  title: Implicit function theorem
-
-Q3527067:
-  title: F. and M. Riesz theorem
-
-Q17101806:
-  title: Intersection theorem
-
-Q6813106:
-  title: Mellin inversion theorem
-
-Q1434158:
-  title: Fluctuation dissipation theorem
-
-Q2093886:
-  title: Primitive element theorem
-
-Q7820874:
-  title: Tonelli's theorem
-
-Q268031:
-  title: Abel's binomial theorem
-
-Q6707093:
-  title: Lyapunov&ndash;Malkin theorem
-
-Q1052752:
-  title: "Stolz\u2013Ces\xE0ro theorem"
-
-Q5445112:
-  title: Fernique's theorem
-
-Q6414200:
-  title: "Kinoshita\u2013Lee\u2013Nauenberg theorem"
-
-Q5091194:
-  title: Cheng's eigenvalue comparison theorem
-
-Q4746948:
-  title: "Amitsur\u2013Levitzki theorem"
-
-Q2374733:
-  title: "Skolem\u2013Mahler\u2013Lech theorem"
-
-Q3984056:
-  title: No-communication theorem
-
-Q999783:
-  title: "Buckingham \u03C0 theorem"
-
-Q3527132:
-  title: "Nagell\u2013Lutz theorem"
-
-Q7433034:
-  title: Great orthogonality theorem
-
-Q550402:
-  title: Dirichlet's theorem on arithmetic progressions
-
-Q7020025:
-  title: Newton's theorem about ovals
-
-Q552367:
-  title: Berge's theorem
-
-Q7160983:
-  title: Peixoto's theorem
-
-Q1457052:
-  title: Well-ordering theorem
-
-Q2266397:
-  title: Intersecting chords theorem
-
-Q15872491:
-  title: Newton's theorem (quadrilateral)
-
-Q570779:
-  title: Vieta's formulas
-
-Q844612:
-  title: Brun's theorem
-
-Q906809:
-  title: "Hellmann\u2013Feynman theorem"
-
-Q1426292:
-  title: "Banach\u2013Steinhaus theorem"
-
-Q6015420:
-  title: Increment theorem
-
-Q4918128:
-  title: "Bishop\u2013Cannings theorem"
-
-Q4866385:
-  title: Base change theorems
-
-Q17019684:
-  title: Grushko theorem
-
-Q6701653:
-  title: Lukacs's proportion-sum independence theorem
-
-Q646523:
-  title: Pick's theorem
-
-Q17098298:
-  title: Jacobson density theorem
-
-Q1136262:
-  title: Optical theorem
-
-Q931404:
-  title: "Bertrand\u2013Diquet\u2013Puiseux theorem"
-
-Q208756:
-  title: Castelnuovo theorem
-
-Q1188048:
-  title: Barbier's theorem
-
-Q1125462:
-  title: Dinostratus' theorem
-
-Q7621715:
-  title: Strassmann's theorem
-
-Q8066611:
-  title: "K\xF6vari\u2013S\xF3s\u2013Tur\xE1n theorem"
-
-Q1052021:
-  title: Craig's interpolation theorem
-
-Q28194853:
-  title: Lovelock's theorem
-
-Q1529941:
-  title: "Peter\u2013Weyl theorem"
-
-Q6935403:
-  title: Mumford vanishing theorem
-
-Q371685:
-  title: "Kraft\u2013McMillan theorem"
-
-Q4455025:
-  title: No wandering domain theorem
-
-Q7524563:
-  title: Sinkhorn's theorem
-
-Q7686760:
-  title: Bang's theorem
-
-Q190391:
-  title: Central limit theorem
-
-Q6734194:
-  title: Mahler's compactness theorem
-
-Q6456122:
-  title: L-balance theorem
-
-Q1361393:
-  title: Luzin's theorem
-
-Q1008566:
-  title: "Gauss\u2013Lucas theorem"
-
-Q4455016:
-  title: Reeb sphere theorem
-
-Q6925496:
-  title: Mountain pass theorem
-
-Q18206266:
-  title: "Euclid\u2013Euler theorem"
-
-Q25303622:
-  title: "Browder\u2013Minty theorem"
-
-Q890875:
-  title: "Bohr\u2013van Leeuwen theorem"
-
-Q869647:
-  title: Szpilrajn extension theorem
-
-Q6711207:
-  title: "L\xE9vy's modulus of continuity theorem"
-
-Q2540738:
-  title: "Cartan\u2013Dieudonn\xE9 theorem"
-
-Q5697916B:
-  title: Waldhausen's theorem
-
-Q974405:
-  title: "Hille\u2013Yosida theorem"
-
-Q1786419:
-  title: Kramers' theorem
-
-Q587081:
-  title: "Kolmogorov\u2013Arnold\u2013Moser theorem"
-
-Q4884789:
-  title: Beltrami's theorem
-
-Q643513:
-  title: "Riesz\u2013Fischer theorem"
-
-Q3527064:
-  title: Donsker's theorem
-
-Q60681777:
-  title: Constant chord theorem
-
-Q6859627:
-  title: Milliken's tree theorem
-
-Q1542114:
-  title: "B\xE9zout's theorem"
-
-Q4826848:
-  title: Autonomous convergence theorem
-
-Q111982312:
-  title: "Friedberg\u2013Muchnik theorem"
-
-Q5656673:
-  title: "Hardy\u2013Littlewood tauberian theorem"
-
-Q7098850:
-  title: Optical equivalence theorem
-
-Q842953:
-  title: Lebesgue's density theorem
-
-Q2379132:
-  title: Going-up and going-down theorems
-
-Q3983972:
-  title: Simplicial approximation theorem
-
-Q5498822:
-  title: Birkhoff's theorem
-
-Q3527241:
-  title: Krull's principal ideal theorem
-
-Q5180651:
-  title: Craig's theorem
-
-Q5566491:
-  title: Glaisher's theorem
-
-Q851166:
-  title: Pappus's hexagon theorem
-
-Q1249069:
-  title: Richardson's theorem
-
-Q1317350:
-  title: Chen's theorem
+Q1140119:
+  title: Morera's theorem
 
 Q1140200:
   title: PCP theorem
 
-Q657469X:
-  title: "Lefschetz\u2013Hopf theorem"
-
-Q1166774:
-  title: Stone's representation theorem for Boolean algebras
-
-Q3527034:
-  title: Cauchy's theorem
-
-Q1555342:
-  title: "Reeh\u2013Schlieder theorem"
-
-Q5610718:
-  title: Grothendieck's connectedness theorem
-
-Q1946642:
-  title: H-cobordism theorem
-
-Q2022775:
-  title: "Hilbert\u2013Schmidt theorem"
-
-Q3983968:
-  title: "Sturm\u2013Picone comparison theorem"
-
-Q33481:
-  title: Arrow's impossibility theorem
-
-Q5001327:
-  title: Busemann's theorem
-
-Q4454919:
-  title: Aumann's agreement theorem
-
-Q4179283:
-  title: Positive energy theorem
-
-Q1046232:
-  title: "Szemer\xE9di's theorem"
-
-Q1143540:
-  title: "Heckscher\u2013Ohlin theorem"
-
-Q3077634:
-  title: Sahlqvist correspondence theorem
-
-Q719966:
-  title: Toda's theorem
-
-Q925224:
-  title: "Sonnenschein\u2013Mantel\u2013Debreu Theorem"
-
-Q5436274:
-  title: "Farrell\u2013Markushevich theorem"
-
-Q4454910:
-  title: "Ostrowski\u2013Hadamard gap theorem"
-
-Q1357684:
-  title: Riesz representation theorem
-
-Q3526993:
-  title: Takagi existence theorem
-
-Q15813392:
-  title: "Barban\u2013Davenport\u2013Halberstam theorem"
-
-Q3527185:
-  title: Whitehead theorem
-
-Q2473965:
-  title: Ugly duckling theorem
-
-Q2360531:
-  title: "Jordan\u2013Schur theorem"
-
-Q7103669:
-  title: Ornstein theorem
-
-Q17003552:
-  title: Alexandrov's uniqueness theorem
-
-Q4937691:
-  title: "Bogoliubov\u2013Parasyuk theorem"
-
-Q1095330:
-  title: "Ap\xE9ry's theorem"
-
-Q2287393:
-  title: Caristi fixed-point theorem
-
-Q7160489:
-  title: Peetre theorem
-
-Q226014:
-  title: "Poincar\xE9 recurrence theorem"
-
-Q190026:
-  title: Ford's theorem
-
-Q2703389:
-  title: Linnik's theorem
-
-Q164262:
-  title: Lebesgue covering dimension
-
-Q211981:
-  title: "Hartman\u2013Grobman theorem"
-
-Q4663326:
-  title: "Hirzebruch\u2013Riemann\u2013Roch theorem"
-
-Q2993308:
-  title: "Cameron\u2013Erd\u0151s theorem"
-
-Q2267175:
-  title: Tangent-secant theorem
-
-Q1425308:
-  title: Brahmagupta theorem
-
-Q10369454:
-  title: Noether's second theorem
-
-Q6513990:
-  title: Lee Hwa Chung theorem
-
-Q3984063:
-  title: Mostow rigidity theorem
-
-Q2631152:
-  title: "Carath\xE9odory's extension theorem"
-
-Q332465:
-  title: Absolute convergence theorem
-
-Q951327:
-  title: Pasch's theorem
-
-Q8074796:
-  title: Zsigmondy's theorem
-
-Q5139948:
-  title: Codd's theorem
-
-Q1182249:
-  title: Deduction theorem
-
-Q7396621:
-  title: "Saccheri\u2013Legendre theorem"
-
-Q1149022:
-  title: Fubini's theorem
-
-Q401905:
-  title: Skorokhod's representation theorem
-
-Q4853767:
-  title: "Banach\u2013Stone theorem"
-
-Q4914101:
-  title: Bing's recognition theorem
-
-Q3527019:
-  title: Birch's theorem
-
-Q8066795:
-  title: Zariski's main theorem
-
-Q282649:
-  title: Pentagonal number theorem
-
-Q5172143:
-  title: Corona theorem
-
-Q1668861:
-  title: Picard theorem
-
-Q1765521:
-  title: Doob's martingale convergence theorems
-
-Q112740521:
-  title: Netto's theorem
-
-Q1455794:
-  title: Freudenthal suspension theorem
-
-Q1568811:
-  title: Hahn decomposition theorem
-
-Q3661294:
-  title: Kelvin's circulation theorem
-
-Q1933521:
-  title: Kleene's recursion theorem
-
-Q225973:
-  title: Ore's theorem
-
-Q4944923X:
-  title: "Borel\u2013Weil theorem"
-
-Q4958221:
-  title: Brauer's three main theorems
-
-Q7432915:
-  title: "Schroeder\u2013Bernstein theorem for measurable spaces"
-
-Q1202608:
-  title: De Gua's theorem
-
-Q2981012:
-  title: Monge's theorem
-
-Q954210:
-  title: Savitch's theorem
-
-Q5610188:
-  title: Gromov's compactness theorem
-
-Q4891633:
-  title: "Berger\u2013Kazdan comparison theorem"
-
-Q2533936:
-  title: Descartes's theorem on total angular defect
-
-Q19779530:
-  title: Thomsen's theorem
-
-Q3984020:
-  title: "Holmstr\xF6m's theorem"
-
-Q256303:
-  title: Lax&ndash;Richtmyer theorem
-
-Q528987:
-  title: Von Neumann bicommutant theorem
-
-Q4724004B:
-  title: Riemann's existence theorem
-
-Q1637085:
-  title: Poynting's theorem
-
-Q4455015:
-  title: "Routh\u2013Hurwitz theorem"
-
-Q1068283:
-  title: "L\xF6wenheim\u2013Skolem theorem"
-
-Q965294:
-  title: Thabit ibn Qurra's theorem
-
-Q4878586:
-  title: Beck's monadicity theorem
-
-Q7042768:
-  title: No-broadcasting theorem
-
-Q1191319:
-  title: "Radon\u2013Nikodym theorem"
-
-Q5155090:
-  title: Commutation theorem
-
-Q2226695:
-  title: Hurwitz's automorphisms theorem
-
-Q48998319:
-  title: Frobenius reciprocity theorem
-
-Q5586067:
-  title: "Gordon\u2013Newell theorem"
-
-Q7352955:
-  title: Robinson's joint consistency theorem
-
-Q780763:
-  title: 15 and 290 theorems
-
-Q927051:
-  title: Riemann mapping theorem
-
-Q853067:
-  title: Solutions to Pell's equation
-
-Q2046647:
-  title: "Karhunen\u2013Lo\xE8ve theorem"
-
-Q6344729:
-  title: Kachurovskii's theorem
-
-Q631561:
-  title: Closed range theorem
-
-Q5315060:
-  title: "Dunford\u2013Schwartz theorem"
-
-Q195133:
-  title: "Wigner\u2013Eckart theorem"
-
-Q1938251:
-  title: "Hasse\u2013Minkowski theorem"
-
-Q7359997:
-  title: Rokhlin's theorem
-
-Q744440:
-  title: "Immerman\u2013Szelepcs\xE9nyi theorem"
-
-Q942046:
-  title: "Schwarz\u2013Ahlfors\u2013Pick theorem"
-
-Q2028341:
-  title: Ado's theorem
-
-Q5041175:
-  title: "Carleson\u2013Jacobs theorem"
-
-Q193286:
-  title: Rolle's theorem
-
-Q7795828:
-  title: Thompson uniqueness theorem
-
-Q4948983:
-  title: Bott periodicity theorem
-
-Q7574438:
-  title: Specht's theorem
-
-Q1506253:
-  title: Euclid's theorem
-
-Q4971339:
-  title: British flag theorem
-
-Q7664013:
-  title: Sz.-Nagy's dilation theorem
-
-Q3007384:
-  title: Post's theorem
-
-Q4783822:
-  title: "Arithmetic Riemann\u2013Roch theorem"
-
-Q1687147:
-  title: "Sprague\u2013Grundy theorem"
-
-Q5494134:
-  title: "Fra\u0148kov\xE1\u2013Helly selection theorem"
-
-Q188295:
-  title: Fermat's little theorem
-
-Q2449984:
-  title: Miquel's theorem
-
-Q5026435:
-  title: "Cameron\u2013Martin theorem"
-
-Q5311783:
-  title: Dudley's theorem
-
-Q4832965:
-  title: Aztec diamond theorem
-
-Q5319505:
-  title: "Zeilberger\u2013Bressoud theorem"
-
-Q1396592:
-  title: "Franel\u2013Landau theorem"
-
-Q2799491:
-  title: "Ringel\u2013Youngs theorem"
-
-Q3527095:
-  title: Jacobi's four-square theorem
-
-Q899853:
-  title: H-theorem
-
-Q15895894:
-  title: "Finsler\u2013Hadwiger theorem"
-
-Q2096184:
-  title: Plancherel theorem
-
-Q7432918:
-  title: "Schr\xF6der\u2013Bernstein theorems for operator algebras"
-
-Q17104863:
-  title: "Nielsen\u2013Ninomiya theorem"
-
-Q742833:
-  title: "Gauss\u2013Bonnet theorem"
-
-Q97359729:
-  title: Stahl's theorem
-
-Q4408070:
-  title: De Finetti's theorem
-
-Q8081891:
-  title: "\u015Aleszy\u0144ski\u2013Pringsheim theorem"
-
-Q4700718:
-  title: Akhiezer's theorem
-
-Q7606897:
-  title: Steinitz theorem
-
-Q530152:
-  title: "Picard&ndash;Lindel\xF6f theorem"
-
-Q1077462:
-  title: "K\xF6nig's theorem"
-
-Q679800:
-  title: "Nyquist\u2013Shannon sampling theorem"
-
-Q7455422:
-  title: Swan's theorem
-
-Q3527040:
-  title: "Chomsky\u2013Sch\xFCtzenberger representation theorem"
-
-Q1136043:
-  title: Hurwitz's theorem
-
-Q2226650:
-  title: "Eberlein\u2013\u0160mulian theorem"
-
-Q4751110:
-  title: Analyst's traveling salesman theorem
-
-Q5656674:
-  title: "Hardy\u2013Ramanujan theorem"
-
-Q5988409:
-  title: Identity theorem for Riemann surfaces
-
-Q755986:
-  title: "Atiyah\u2013Bott fixed-point theorem"
-
-Q5443003:
-  title: Fenchel's duality theorem
-
-Q5447238:
-  title: Fieller's theorem
-
-Q191693:
-  title: Lebesgue's decomposition theorem
-
-Q1785610:
-  title: Poncelet's closure theorem
-
-Q7818977:
-  title: Tomita's theorem
-
-Q55647729:
-  title: "Cram\xE9r's theorem (large deviations)"
-
-Q2379128:
-  title: "Lindstr\xF6m's theorem"
-
-Q536640:
-  title: Hall's marriage theorem
-
-Q1306092:
-  title: Nash embedding theorem
-
-Q528955:
-  title: "Kochen\u2013Specker theorem"
-
-Q25304301:
-  title: "Bregman\u2013Minc inequality"
-
-Q6379715:
-  title: Kawasaki's theorem
-
-Q220680:
-  title: Banach fixed-point theorem
-
-Q6501470:
-  title: Lauricella's theorem
-
-Q4880958:
-  title: "Behnke\u2013Stein theorem"
-
-Q1067156:
-  title: Dominated convergence theorem
-
-Q4801169:
-  title: Artin approximation theorem
-
-Q1347094:
-  title: Alternate Interior Angles Theorem
-
-Q6777133:
-  title: Martingale representation theorem
-
-Q1535225:
-  title: "\u0141o\u015B' theorem"
-
-Q2558669:
-  title: "Artin\u2013Zorn theorem"
-
-Q649469:
-  title: Modularity theorem
-
-Q2449984X:
-  title: Pivot theorem
-
-Q810431:
-  title: Basel problem
-
-Q285719:
-  title: Thales's theorem
-
-Q5132839:
-  title: Clifford's circle theorems
-
-Q718875:
-  title: "Erd\u0151s\u2013Ko\u2013Rado theorem"
-
-Q1816952:
-  title: Schur's lemma
-
-Q154210:
-  title: CPCTC
-
-Q4736422:
-  title: Denjoy theorem
-
-Q467205:
-  title: Fundamental theorems of welfare economics
-
-Q1058662:
-  title: Darboux's theorem
-
-Q4712316:
-  title: "Albert\u2013Brauer\u2013Hasse\u2013Noether theorem"
-
-Q16978447:
-  title: "Grauert\u2013Riemenschneider vanishing theorem"
-
-Q7856599:
-  title: "Tur\xE1n\u2013Kubilius theorem"
-
-Q5612131:
-  title: Grunsky's theorem
-
-Q17002391:
-  title: Arrow-Lind theorem
-
-Q25304227:
-  title: Arakelyan's theorem
-
-Q651593:
-  title: Norton's theorem
-
-Q388525:
-  title: Bell's theorem
-
-Q3527196:
-  title: Principal ideal theorem
-
-Q902052:
-  title: "G\xF6del's completeness theorem"
-
-Q7308146:
-  title: Regev's theorem
-
-Q8002487:
-  title: Wilkie's theorem
-
-Q1369453:
-  title: "Kronecker\u2013Weber theorem"
-
-Q7978735:
-  title: Weber's theorem
-
-Q4877965:
-  title: "Beauville\u2013Laszlo theorem"
-
-Q5244361:
-  title: De Franchis theorem
-
-Q2226868:
-  title: Geometric mean theorem
-
-Q7644264:
-  title: Supersymmetry nonrenormalization theorems
-
-Q3229335:
-  title: "Borel\u2013Carath\xE9odory theorem"
-
-Q1346677:
-  title: Tietze extension theorem
-
-Q2310718:
-  title: Pitot theorem
-
-Q2309682:
-  title: Sphere theorem
-
-Q617417:
-  title: Isoperimetric theorem
-
-Q1785872:
-  title: "Berry\u2013Ess\xE9en theorem"
-
-Q3771212:
-  title: Proth's theorem
-
-Q4724004A:
-  title: Chow's theorem
-
-Q459547:
-  title: Ptolemy's theorem
-
-Q193878:
-  title: Chinese remainder theorem
-
-Q1899432:
-  title: "Grothendieck\u2013Hirzebruch\u2013Riemann\u2013Roch theorem"
-
-Q5675112:
-  title: "Hartogs\u2013Rosenthal theorem"
-
-Q779220:
-  title: Hilbert's syzygy theorem
-
-Q729359:
-  title: Hadamard three-circle theorem
-
-Q3527056:
-  title: "De Bruijn\u2013Erd\u0151s theorem (incidence geometry)"
-
-Q17103352:
-  title: Maximum power theorem
-
-Q4454976:
-  title: Liouville's theorem
-
-Q5709171:
-  title: "Helly\u2013Bray theorem"
-
-Q110921617:
-  title: "Feferman\u2013Vaught theorem"
-
-Q1789863:
-  title: Routh's theorem
-
-Q4454925:
-  title: Edge-of-the-wedge theorem
-
-Q6387087:
-  title: "Kempf\u2013Ness theorem"
-
-Q5047048:
-  title: "Cartan\u2013Hadamard theorem"
-
-Q5166389:
-  title: Van Vleck's theorem
-
-Q6516736:
-  title: Lefschetz theorem on (1,1)-classes
-
-Q1630588:
-  title: Hurwitz's theorem
-
-Q7827204:
-  title: Mazur's torsion theorem
-
-Q1547975:
-  title: "Mermin\u2013Wagner theorem"
-
-Q737851:
-  title: "Banach\u2013Tarski theorem"
-
-Q902618:
-  title: Floquet's theorem
-
-Q4884950:
-  title: Belyi's theorem
-
-Q866116:
-  title: "Hahn\u2013Banach theorem"
-
-Q5244285:
-  title: de Bruijn's theorem
-
-Q578555:
-  title: Noether's theorem
-
-Q372037:
-  title: "Seifert\u2013van Kampen theorem"
-
-Q586051:
-  title: "Haag\u2013\u0141opusza\u0144ski\u2013Sohnius theorem"
-
-Q837551:
-  title: Frobenius theorem
-
-Q1067156X:
-  title: Bounded convergence theorem
-
-Q1191862:
-  title: "Rouch\xE9's theorem"
-
-Q620602:
-  title: Virial theorem
-
-Q5178114:
-  title: Courcelle's theorem
-
-Q676413:
-  title: Dandelin's theorem
-
-Q4713046:
-  title: "Alchian\u2013Allen theorem"
-
-Q3527017:
-  title: "Beurling\u2013Lax theorem"
-
-Q5761142:
-  title: Hilbert's irreducibility theorem
-
-Q1194053:
-  title: Metrization theorems
-
-Q1097021:
-  title: Minkowski's theorem
-
-Q107547910:
-  title: "Malgrange\u2013Zerner theorem"
-
-Q3527093:
-  title: "Hilbert\u2013Speiser theorem"
-
-Q487132:
-  title: Infinite monkey theorem
-
-Q7782346:
-  title: Theorem of the cube
-
-Q913849:
-  title: Minimax theorem
-
-Q321237:
-  title: Green's theorem
-
-Q6914794:
-  title: Morton's theorem
-
-Q4666729X:
-  title: Abel's curve theorem
-
-Q1724049:
-  title: Wolstenholme's theorem
-
-Q7516736:
-  title: "Silverman\u2013Toeplitz theorem"
-
-Q5638112:
-  title: Hadwiger's theorem
-
-Q3443426:
-  title: Bondy's theorem
-
-Q1129636:
-  title: "Lehmann\u2013Scheff\xE9 theorem"
-
-Q867839:
-  title: Rosser's theorem
-
-Q583147:
-  title: Sard's theorem
-
-Q6535741:
-  title: Levitzky's theorem
-
-Q476776:
-  title: Solutions of a general quartic equation
-
-Q1566372:
-  title: Haag's theorem
-
-Q1130846:
-  title: Ladner's theorem
-
-Q56291669:
-  title: Alspach's theorem
-
-Q5103861:
-  title: Choi's theorem on completely positive maps
-
-Q1443036:
-  title: Parseval's theorem
-
-Q656176:
-  title: Schauder fixed-point theorem
-
-Q3893473:
-  title: Tameness theorem
-
-Q7139570:
-  title: Parovicenko's theorem
-
-Q5049717:
-  title: "Castelnuovo\u2013de Franchis theorem"
-
-Q257387:
-  title: Vitali theorem
-
-Q6403282:
-  title: Lagrange's theorem
-
-Q4751118:
-  title: Analytic Fredholm theorem
-
-Q6421981:
-  title: Kneser's theorem
-
-Q6867878:
-  title: Minlos's theorem
-
-Q7045226:
-  title: No free lunch theorem
-
-Q3984052:
-  title: Equidistribution theorem
-
-Q1930577:
-  title: Herbrand's theorem
-
-Q48996535:
-  title: "Sol\xE8r's theorem"
-
-Q6455211:
-  title: "K\u014Dmura's theorem"
-
-Q4941364:
-  title: "Bondareva\u2013Shapley theorem"
-
-Q914517:
-  title: Fermat's theorem on sums of two squares
-
-Q6535568:
-  title: Levi's theorem
-
-Q1050932:
-  title: Hartogs's theorem
-
-Q6436753:
-  title: Krener's theorem
-
-Q931001X:
-  title: Constant rank theorem
-
-Q5508482:
-  title: "Fulton\u2013Hansen connectedness theorem"
-
-Q3984053:
-  title: Fourier inversion theorem
-
-Q2226610:
-  title: "Banach\u2013Mazur theorem"
-
-Q1694565:
-  title: Vinogradov's theorem
-
-Q2226624:
-  title: "Bruck\u2013Chowla\u2013Ryser theorem"
-
-Q7106480:
-  title: Oseledec theorem
-
-Q828284:
-  title: Parallel axis theorem
-
-Q3526990:
-  title: Euler's theorem
-
-Q7625164:
-  title: Structure theorem for Gaussian measures
-
-Q7208500:
-  title: Poisson limit theorem
-
-Q720469:
-  title: "Chevalley\u2013Warning theorem"
-
-Q5136698:
-  title: Cluster decomposition theorem
-
-Q504843:
-  title: Mycielski's theorem
-
-Q1564541:
-  title: "Perron\u2013Frobenius theorem"
-
-Q1888583:
-  title: Holditch's theorem
-
-Q6516611:
-  title: "Lee\u2013Yang theorem"
-
-Q6528751:
-  title: "Leray\u2013Hirsch theorem"
-
-Q4958227:
-  title: "Brauer\u2013Nesbitt theorem"
-
-Q3526969:
-  title: AF+BG theorem
-
-Q5157054:
-  title: Compression theorem
-
-Q5697916A:
-  title: "Reidemeister\u2013Singer Theorem"
-
-Q5680041:
-  title: "Hasse\u2013Arf theorem"
-
-Q656772:
-  title: "Cayley\u2013Hamilton theorem"
-
-Q495412:
-  title: "Jordan\u2013Sch\xF6nflies theorem"
-
 Q1141747:
   title: Carnot's theorem
 
-Q1340623:
-  title: Classification of finite simple groups
-
-Q632546X:
-  title: Sylvester's theorem
-
-Q7825663:
-  title: Torelli theorem
-
-Q671663:
-  title: "Coleman\u2013Mandula theorem"
-
-Q7532192:
-  title: Siu's semicontinuity theorem
-
-Q179467:
-  title: Fourier theorem
-
-Q877489:
-  title: Apollonius's theorem
-
-Q5127710:
-  title: "Clark\u2013Ocone theorem"
-
-Q10859514:
-  title: "Vafa\u2013Witten theorem"
-
-Q17125544:
-  title: "Lickorish\u2013Wallace theorem"
-
-Q865665:
-  title: Birkhoff's theorem
-
-Q1186808:
-  title: Lucas's theorem
-
-Q6795830:
-  title: Separating axis theorem
-
-Q2226803:
-  title: Tennenbaum's theorem
-
-Q1177508:
-  title: "R\xE9dei's theorem"
-
-Q318767:
-  title: Abel's theorem
-
-Q189136:
-  title: Mean value theorem
-
-Q3757563:
-  title: Intercept theorem
-
-Q379048:
-  title: "Riemann\u2013Roch theorem"
-
-Q944297:
-  title: Open mapping theorem
-
-Q4866385X:
-  title: Proper base change theorem
-
-Q1227703:
-  title: Dirichlet's approximation theorem
-
-Q6086104:
-  title: Isomorphism extension theorem
-
-Q2226625:
-  title: Commandino's theorem
-
-Q7809920:
-  title: Titchmarsh convolution theorem
-
-Q1038716:
-  title: Identity theorem
-
-Q1149185X:
-  title: "Kirby\u2013Paris theorem"
-
-Q5094305:
-  title: "Chevalley\u2013Shephard\u2013Todd theorem"
-
-Q7572588:
-  title: Space hierarchy theorem
-
-Q2197859:
-  title: Nicomachus's theorem
-
-Q7601243:
-  title: Star of David theorem
-
-Q22952648:
-  title: Uncountability of the continuum
-
-Q7433182:
-  title: "Schwartz\u2013Zippel theorem"
-
-Q657482:
-  title: "Abel\u2013Ruffini theorem"
-
-Q5047043:
-  title: Cartan's theorems A and B
-
-Q4734002:
-  title: "Gromov\u2013Ruh theorem"
-
-Q1425077:
-  title: Spectral theorem
-
-Q180345:
-  title: Rational root theorem
-
-Q4958218:
-  title: Brauer's theorem on induced characters
-
-Q848810:
-  title: Kronecker's theorem
-
-Q1048874:
-  title: Gauss's Theorema Egregium
-
-Q7857350:
-  title: Tverberg's theorem
-
-Q1075398:
-  title: Jung's theorem
-
-Q2094241:
-  title: "Hopf\u2013Rinow theorem"
-
-Q5638886:
-  title: Hahn embedding theorem
-
-Q5163116:
-  title: Conservativity theorem
-
-Q948664:
-  title: Kneser's theorem
-
-Q2635326:
-  title: Structured program theorem
-
-Q7999144:
-  title: "Wiener\u2013Ikehara theorem"
-
-Q7333126:
-  title: "Riemann\u2013Roch theorem for surfaces"
-
-Q1632433:
-  title: Helly's theorem
-
-Q200787:
-  title: "G\xF6del's incompleteness theorem"
-
-Q117553:
-  title: "Modigliani\u2013Miller theorem"
-
-Q7619449:
-  title: "Stone\u2013von Neumann theorem"
-
-Q3527263:
-  title: Kleene fixed-point theorem
-
-Q2916568:
-  title: Gomory's theorem
-
-Q3527219:
-  title: Weierstrass preparation theorem
-
-Q2995691:
-  title: "Newlander\u2013Niremberg theorem"
-
-Q523876:
-  title: "Spin\u2013statistics theorem"
-
-Q3180727:
-  title: Perlis theorem
-
-Q356895:
-  title: Adiabatic theorem
-
-Q3527129:
-  title: "M\xFCntz\u2013Sz\xE1sz theorem"
-
-Q12524:
-  title: Schwenk's theorem
-
-Q670235:
-  title: Fundamental theorem of arithmetic
-
-Q383238:
-  title: Hartogs's extension theorem
-
-Q6400676:
-  title: Kharitonov's theorem
-
-Q7936914:
-  title: "Vitali\u2013Hahn\u2013Saks theorem"
-
-Q608294:
-  title: Max flow min cut theorem
-
-Q1153441:
-  title: Goldstone's theorem
-
-Q7661308:
-  title: Symmetric hypergraph theorem
-
-Q1187646:
-  title: Fundamental theorem on homomorphisms
-
-Q7795825:
-  title: Thompson transitivity theorem
-
-Q11518:
-  title: Pythagorean theorem
-
-Q5505114:
-  title: Froda's theorem
-
-Q7512855:
-  title: Hirzebruch signature theorem
-
-Q377047:
-  title: Butterfly theorem
-
-Q1065966:
-  title: Isomorphism theorem
-
-Q922012:
-  title: "Green\u2013Tao theorem"
-
-Q7042801:
-  title: No-trade theorem
-
-Q544292:
-  title: Lagrange inversion theorem
-
-Q20971632:
-  title: Lie's theorem
-
-Q1217677:
-  title: Fundamental theorem of calculus
-
-Q2621667:
-  title: "Nagata\u2013Smirnov metrization theorem"
-
-Q105222412:
-  title: Five color theorem
-
-Q7536350:
-  title: Skorokhod's embedding theorem
-
-Q17098379:
-  title: Kaplansky's theorem on quadratic forms
-
-Q6544508:
-  title: "Lie\u2013Palais theorem"
-
-Q4944908:
-  title: Borel fixed-point theorem
-
-Q4454958:
-  title: Min-max theorem
-
-Q7847268:
-  title: Trudinger's theorem
-
-Q4454996:
-  title: Novikov's compact leaf theorem
-
-Q6378596:
-  title: "Katz\u2013Lang finiteness theorem"
-
-Q2733672:
-  title: Price's theorem
-
-Q1188392:
-  title: Zeckendorf's theorem
-
-Q1306095:
-  title: Whitney embedding theorem
-
-Q5501344:
-  title: "Freidlin\u2013Wentzell theorem"
-
-Q6425088:
-  title: Kodaira embedding theorem
-
-Q7432872:
-  title: Schreier refinement theorem
-
-Q7249519:
-  title: Prokhorov's theorem
-
-Q755991:
-  title: "Atiyah\u2013Singer index theorem"
-
-Q422187:
-  title: "Myhill\u2013Nerode theorem"
-
-Q4801563:
-  title: Artstein's theorem
-
-Q7617407:
-  title: Stinespring factorization theorem
-
-Q15080987:
-  title: Lie's third theorem
-
-Q7318284:
-  title: Reversed compound agent theorem
-
-Q25345219:
-  title: BBD decomposition theorem
-
-Q7941491:
-  title: Von Neumann's theorem
-
-Q5125859:
-  title: Clapeyron's theorem
-
-Q7322366:
-  title: Ribet's theorem
-
-Q2518048:
-  title: Kodaira vanishing theorem
-
-Q205966:
-  title: Critical line theorem
-
-Q650738:
-  title: Folk theorem
-
-Q5506929:
-  title: Fuchs's theorem
-
-Q5037752:
-  title: "Carath\xE9odory's existence theorem"
-
-Q1330788:
-  title: Weierstrass factorization theorem
-
-Q1361031:
-  title: Frobenius theorem
-
-Q2000090:
-  title: Art gallery theorem
-
-Q260928:
-  title: Jordan curve theorem
-
-Q62051012:
-  title: Behrend's theorem
-
-Q1037559:
-  title: "P\xF3lya enumeration theorem"
-
-Q7100033B:
-  title: "Rashevsky\u2013Chow theorem"
-
-Q3527011:
-  title: Beck's theorem
-
-Q1966978:
-  title: "L\xE9vy continuity theorem"
-
-Q1472120:
-  title: Hellinger&ndash;Toeplitz theorem
-
-Q7606940:
-  title: "Stein\u2013Str\xF6mberg theorem"
-
-Q2270905:
-  title: "Poincar\xE9\u2013Birkhoff\u2013Witt theorem"
-
-Q1974087:
-  title: Riemann's theorem on removable singularities
-
-Q537618:
-  title: "Banach\u2013Alaoglu theorem"
-
-Q6471668:
-  title: Lafforgue's theorem
-
-Q1068976:
-  title: Hilbert's Nullstellensatz
-
-Q6760432:
-  title: Marginal value theorem
-
-Q3527162:
-  title: Sophie Germain's theorem
-
-Q6481192:
-  title: "Lambek\u2013Moser theorem"
-
-Q5445311:
-  title: "Ferrero\u2013Washington theorem"
-
-Q5047052:
-  title: "Cartan\u2013K\xE4hler theorem"
-
-Q7255475:
-  title: Pseudorandom generator theorem
-
-Q5657833:
-  title: "Harish\u2013Chandra's regularity theorem"
-
-Q6799039:
-  title: Mazur's control theorem
-
-Q3527217:
-  title: M. Riesz extension theorem
-
-Q612021:
-  title: "Gibbard\u2013Satterthwaite theorem"
-
-Q900831:
-  title: Fluctuation theorem
-
-Q3527250:
-  title: Hadamard three-lines theorem
-
-Q5295351:
-  title: Donaldson's theorem
-
-Q3527230:
-  title: "Von Staudt\u2013Clausen theorem"
-
-Q4378868:
-  title: "Phragm\xE9n\u2013Lindel\xF6f theorem"
-
-Q1227061:
-  title: Khinchin's theorem
-
-Q7980241:
-  title: "Weinberg\u2013Witten theorem"
-
-Q846840:
-  title: "Erd\u0151s\u2013Kac theorem"
-
-Q1699024:
-  title: John ellipsoid
-
-Q1242398:
-  title: Doob decomposition theorem
-
-Q174955:
-  title: "Mih\u0103ilescu's theorem"
-
-Q230848:
-  title: "Lam\xE9\u2019s theorem"
-
-Q1855610:
-  title: "Theorem of de Moivre\u2013Laplace"
-
-Q6516731:
-  title: Lefschetz hyperplane theorem
-
-Q7966545:
-  title: Walter theorem
-
-Q7323144:
-  title: "Rice\u2013Shapiro theorem"
-
-Q1119094:
-  title: Paley&ndash;Wiener theorem
-
-Q5437947:
-  title: "Fatou\u2013Lebesgue theorem"
-
-Q2120067:
-  title: "Diller\u2013Dress theorem"
-
-Q857089:
-  title: de Branges's theorem
-
-Q107535899:
-  title: Bochner's tube theorem
-
-Q3527166:
-  title: Steinhaus theorem
+Q1143540:
+  title: Heckscher–Ohlin theorem
+
+Q1144897:
+  title: Brouwer fixed-point theorem
 
 Q1146791:
   title: Fermat polygonal number theorem
 
-Q5609384:
-  title: Grinberg's theorem
+Q1148215:
+  title: Mitchell's embedding theorem
 
-Q1276318:
-  title: Schwartz kernel theorem
+Q1149022:
+  title: Fubini's theorem
 
-Q470877:
-  title: Stirling's theorem
-
-Q837506:
-  title: Theorem on friends and strangers
-
-Q2524990:
-  title: Jackson's theorem
-
-Q6276298:
-  title: Jordan's theorem (multiply transitive groups)
-
-Q1716166:
-  title: Mercer's theorem
-
-Q192760:
-  title: Fundamental theorem of algebra
-
-Q2394548:
-  title: Hurewicz theorem
-
-Q4455031:
-  title: "F\xE1ry's theorem"
-
-Q107709489:
-  title: "B\xFCchi-Elgot-Trakhtenbrot theorem"
-
-Q1631749:
-  title: Lester's theorem
-
-Q3527209:
-  title: Hasse norm theorem
-
-Q748233:
-  title: "Sylvester\u2013Gallai theorem"
-
-Q4171386:
-  title: Soul theorem
-
-Q188745:
-  title: Classification of Platonic solids
-
-Q1103054:
-  title: "Lions\u2013Lax\u2013Milgram theorem"
-
-Q1786292:
-  title: Schur's theorem
-
-Q5454965:
-  title: "Fisher\u2013Tippett\u2013Gnedenko theorem"
-
-Q4667501:
-  title: "Abhyankar\u2013Moh theorem"
-
-Q104841721:
-  title: "Jacobson\u2013Morozov theorem"
-
-Q1137014:
-  title: Tychonoff's theorem
-
-Q1140119:
-  title: Morera's theorem
-
-Q7283856:
-  title: Raikov's theorem
-
-Q1317367:
-  title: Japanese theorem for concyclic polygons
-
-Q1683356:
-  title: Japanese theorem for concyclic quadrilaterals
-
-Q1543149:
-  title: "Sokhatsky\u2013Weierstrass theorem"
-
-Q1050203:
-  title: Cantor's intersection theorem
-
-Q3527223:
-  title: Crystallographic restriction theorem
-
-Q922367:
-  title: Master theorem (analysis of algorithms)
-
-Q7272898:
-  title: Quotient of subspace theorem
-
-Q1064471:
-  title: Earnshaw's theorem
-
-Q740093:
-  title: Peano existence theorem
-
-Q5456213:
-  title: Five circles theorem
-
-Q7824894:
-  title: Topkis's theorem
-
-Q4454989:
-  title: Meusnier's theorem
-
-Q474881:
-  title: Cantor's theorem
-
-Q284960:
-  title: "Mordell\u2013Weil theorem"
-
-Q3527233:
-  title: Kolmogorov's three-series theorem
-
-Q3527247:
-  title: Six circles theorem
-
-Q2500408:
-  title: "Th\xE9bault's theorem"
-
-Q7845353:
-  title: "Trombi\u2013Varadarajan theorem"
-
-Q2190744:
-  title: Feuerbach's theorem
-
-Q5282059:
-  title: "Harish\u2013Chandra theorem"
-
-Q3075250:
-  title: "Hardy\u2013Littlewood maximal theorem"
-
-Q1047749:
-  title: "Tur\xE1n's theorem"
-
-Q132469:
-  title: Fermat's Last Theorem
-
-Q1631992:
-  title: "Steiner\u2013Lehmus theorem"
-
-Q2226709:
-  title: "Krull\u2013Schmidt theorem"
-
-Q1134296:
-  title: Supporting hyperplane theorem
-
-Q939927:
-  title: "Stone\u2013Weierstrass theorem"
-  decl: ContinuousMap.subalgebra_topologicalClosure_eq_top_of_separatesPoints
-  author: Scott Morrison and Heather Macbeth
-
-Q7888360:
-  title: Structure theorem for finitely generated modules over a principal ideal domain
-
-Q5132840:
-  title: Clifford's theorem on special divisors
-
-Q8064722:
-  title: Zahorski theorem
-
-Q7510574:
-  title: "Siegel\u2013Walfisz theorem"
-
-Q4378889:
-  title: "Carath\xE9odory's theorem"
-
-Q5362000:
-  title: Elitzur's theorem
-
-Q6927135:
-  title: Moving equilibrium theorem
-
-Q7853325:
-  title: Tunnell's theorem
-
-Q287347:
-  title: Gradient theorem
-
-Q2471737:
-  title: "Carath\xE9odory's theorem"
-
-Q7525341:
-  title: Sion's minimax theorem
-
-Q98831:
-  title: Multiplication theorem
-
-Q6749789:
-  title: "Manin\u2013Drinfeld theorem"
-
-Q790236:
-  title: Baranyai's theorem
-
-Q5643485:
-  title: "Halpern\u2013L\xE4uchli theorem"
-
-Q6484331:
-  title: Landau prime ideal theorem
-
-Q16680059:
-  title: Strong perfect graph theorem
-
-Q3984069:
-  title: Fredholm's theorem
-
-Q472883:
-  title: Quadratic reciprocity theorem
-
-Q3001796:
-  title: "Skolem\u2013Noether theorem"
-
-Q2226606:
-  title: "Beckman\u2013Quarles theorem"
-
-Q7200963:
-  title: Planar separator theorem
-
-Q685437:
-  title: Titchmarsh theorem
-
-Q8062800:
-  title: Z* theorem
-
-Q4848497:
-  title: "Baily\u2013Borel theorem"
-
-Q2222575:
-  title: Shell theorem
-
-Q3526982:
-  title: "Erd\u0151s\u2013Anning theorem"
-
-Q2226750:
-  title: "Malgrange\u2013Ehrenpreis theorem"
-
-Q6402928:
-  title: Lagrange reversion theorem
-
-Q61163749:
-  title: Theorem of the gnomon
-
-Q184410:
-  title: Four color theorem
-
-Q4116459:
-  title: Niven's theorem
+Q1149185X:
+  title: Kirby–Paris theorem
 
 Q1149185:
   title: Goodstein's theorem
 
-Q2500406:
-  title: "Li\xE9nard's theorem"
+Q1149458:
+  title: Compactness theorem
 
-Q693083:
-  title: Soundness theorem
+Q1149522:
+  title: Lami's theorem
 
-Q2226640:
-  title: "Cram\xE9r\u2019s decomposition theorem"
+Q1152521:
+  title: Mohr–Mascheroni theorem
 
-Q3526996:
-  title: Kolmogorov extension theorem
+Q1153441:
+  title: Goldstone's theorem
 
-Q7130794:
-  title: Pandya theorem
+Q1153584:
+  title: Monotone convergence theorem
 
-Q6059532:
-  title: "Aronszajn\u2013Smith theorem"
+Q1166774:
+  title: Stone's representation theorem for Boolean algebras
 
-Q5171652:
-  title: Corners theorem
+Q1177508:
+  title: Rédei's theorem
 
-Q280116:
-  title: Odd number theorem
+Q1179446:
+  title: De Rham's theorem
 
-Q7431298:
-  title: Schilder's theorem
+Q1182249:
+  title: Deduction theorem
 
-Q384142:
-  title: "Herbrand\u2013Ribet theorem"
+Q1186134:
+  title: Poncelet–Steiner theorem
 
-Q5508973:
-  title: Fundamental theorem of arbitrage-free pricing
+Q1186808:
+  title: Lucas's theorem
 
-Q3527044:
-  title: Pappus's area theorem
+Q1187646:
+  title: Fundamental theorem on homomorphisms
 
-Q913447:
-  title: Morley's trisector theorem
+Q1188048:
+  title: Barbier's theorem
 
-Q1423818:
-  title: Euler's theorem in geometry
+Q1188392:
+  title: Zeckendorf's theorem
 
-Q1756194:
-  title: "Shannon\u2013Hartley theorem"
+Q1188504:
+  title: Pitman&ndash;Koopman&ndash;Darmois theorem
 
-Q3527088:
-  title: Haboush's theorem
+Q1191319:
+  title: Radon–Nikodym theorem
 
-Q207244:
-  title: Sela's theorem
+Q1191709:
+  title: Egorov's theorem
 
-Q5161245:
-  title: "Conley\u2013Zehnder theorem"
+Q1191862:
+  title: Rouché's theorem
 
-Q3458641:
-  title: "Szeg\u0151 limit theorems"
-
-Q7245073:
-  title: Principal axis theorem
-
-Q3915398:
-  title: "Brunn\u2013Minkowski theorem"
-
-Q17082552:
-  title: Mutual fund separation theorem
-
-Q6867853:
-  title: Minkowski's second theorem
-
-Q632546:
-  title: Bertrand's postulate
-
-Q1752516:
-  title: Riemann series theorem
-
-Q3527008:
-  title: "Balian\u2013Low theorem"
-
-Q4455043:
-  title: "Cayley\u2013Bacharach theorem"
-
-Q1227702:
-  title: Dirichlet's unit theorem
-
-Q193910:
-  title: Euler's theorem
+Q1194053:
+  title: Metrization theorems
 
 Q1196538:
   title: Descartes's theorem
 
+Q1196729:
+  title: Mertens's theorems
+
+Q1202608:
+  title: De Gua's theorem
+
+Q1209546:
+  title: Kaplansky density theorem
+
+Q1217677:
+  title: Fundamental theorem of calculus
+
+Q1227061:
+  title: Khinchin's theorem
+
+Q1227702:
+  title: Dirichlet's unit theorem
+
+Q1227703:
+  title: Dirichlet's approximation theorem
+
+Q1242398:
+  title: Doob decomposition theorem
+
+Q1243340:
+  title: Birkhoff–Von Neumann theorem
+
+Q1249069:
+  title: Richardson's theorem
+
+Q1259814:
+  title: Nielsen–Schreier theorem
+
+Q1276318:
+  title: Schwartz kernel theorem
+
+Q1305766:
+  title: Poincaré–Hopf theorem
+
+Q1306092:
+  title: Nash embedding theorem
+
+Q1306095:
+  title: Whitney embedding theorem
+
+Q1307676:
+  title: Künneth theorem
+
+Q1308502:
+  title: Church–Rosser theorem
+
+Q1315949:
+  title: Mittag-Leffler's theorem
+
+Q1317350:
+  title: Chen's theorem
+
+Q1317367:
+  title: Japanese theorem for concyclic polygons
+
+Q1322892:
+  title: Dirac's theorems
+
+Q1330788:
+  title: Weierstrass factorization theorem
+
+Q1340623:
+  title: Classification of finite simple groups
+
+Q1346677:
+  title: Tietze extension theorem
+
+Q1347094:
+  title: Alternate Interior Angles Theorem
+
+Q1348736:
+  title: Rybczynski theorem
+
+Q1349282:
+  title: Eilenberg–Zilber theorem
+
+Q1357684:
+  title: Riesz representation theorem
+
+Q1361031:
+  title: Frobenius theorem
+
+Q1361393:
+  title: Luzin's theorem
+
+Q1366581:
+  title: Erdős–Rado theorem
+
+Q1369453:
+  title: Kronecker–Weber theorem
+
+Q1370316:
+  title: Casey's theorem
+
+Q1376515:
+  title: No-hair theorem
+
+Q1396592:
+  title: Franel–Landau theorem
+
+Q1420905:
+  title: Hilbert's theorem 90
+
+Q1422083:
+  title: Ryll-Nardzewski fixed-point theorem
+
+Q1423818:
+  title: Euler's theorem in geometry
+
+Q1424481:
+  title: Frucht's theorem
+
+Q1425077:
+  title: Spectral theorem
+
+Q1425308:
+  title: Brahmagupta theorem
+
+Q1425529:
+  title: Chebotarev's density theorem
+
+Q1426292:
+  title: Banach–Steinhaus theorem
+
+Q1434158:
+  title: Fluctuation dissipation theorem
+
+Q1434805:
+  title: Max Noether's theorem
+
+Q1443036:
+  title: Parseval's theorem
+
+Q1452678:
+  title: Penrose–Hawking singularity theorems
+
+Q1455794:
+  title: Freudenthal suspension theorem
+
+Q1457052:
+  title: Well-ordering theorem
+
+Q1471282:
+  title: Radon's theorem
+
+Q1472120:
+  title: Hellinger&ndash;Toeplitz theorem
+
+Q1477053:
+  title: Arzelà–Ascoli theorem
+
+Q1505529:
+  title: Runge's theorem
+
+Q1506253:
+  title: Euclid's theorem
+
+Q1529941:
+  title: Peter–Weyl theorem
+
+Q1530275:
+  title: Dunford–Pettis theorem
+
+Q1535225:
+  title: Łoś' theorem
+
+Q1542114:
+  title: Bézout's theorem
+
+Q1543149:
+  title: Sokhatsky–Weierstrass theorem
+
+Q1547975:
+  title: Mermin–Wagner theorem
+
+Q1551745:
+  title: Binomial inverse theorem
+
+Q1555342:
+  title: Reeh–Schlieder theorem
+
+Q1564541:
+  title: Perron–Frobenius theorem
+
+Q1566341:
+  title: Hindman's theorem
+
+Q1566372:
+  title: Haag's theorem
+
+Q1568612:
+  title: Marden's theorem
+
+Q1568811:
+  title: Hahn decomposition theorem
+
+Q1572474:
+  title: Lindemann–Weierstrass theorem
+
+Q1576235:
+  title: Lochs's theorem
+
+Q1602819:
+  title: Lumer–Phillips theorem
+
+Q1614464:
+  title: Cauchy–Kowalevski theorem
+
+Q1621180:
+  title: Orlicz–Pettis theorem
+
+Q1630588:
+  title: Hurwitz's theorem
+
+Q1631749:
+  title: Lester's theorem
+
+Q1631992:
+  title: Steiner–Lehmus theorem
+
+Q1632301:
+  title: Sturm's theorem
+
+Q1632433:
+  title: Helly's theorem
+
+Q1637085:
+  title: Poynting's theorem
+
+Q1660147:
+  title: Mazur–Ulam theorem
+
+Q1668861:
+  title: Picard theorem
+
+Q1683356:
+  title: Japanese theorem for concyclic quadrilaterals
+
+Q1687147:
+  title: Sprague–Grundy theorem
+
+Q1694565:
+  title: Vinogradov's theorem
+
+Q1699024:
+  title: John ellipsoid
+
+Q1704878:
+  title: Appell–Humbert theorem
+
+Q1716166:
+  title: Mercer's theorem
+
+Q1720410:
+  title: Hjelmslev's theorem
+
+Q1724049:
+  title: Wolstenholme's theorem
+
+Q1727461:
+  title: Intersecting secants theorem
+
+Q1739994:
+  title: Brauer–Suzuki theorem
+
+Q1751105:
+  title: Blum's speedup theorem
+
+Q1751823:
+  title: No-cloning theorem
+
+Q1752516:
+  title: Riemann series theorem
+
+Q1752621:
+  title: Sylvester's law of inertia
+
+Q1752988:
+  title: Kutta–Joukowski theorem
+
+Q1756194:
+  title: Shannon–Hartley theorem
+
+Q1765521:
+  title: Doob's martingale convergence theorems
+
+Q1766814:
+  title: Smn theorem
+
+Q1785610:
+  title: Poncelet's closure theorem
+
+Q1785872:
+  title: Berry–Esséen theorem
+
+Q1786292:
+  title: Schur's theorem
+
+Q1786419:
+  title: Kramers' theorem
+
+Q1789863:
+  title: Routh's theorem
+
+Q1809539:
+  title: Pizza theorem
+
+Q1816952:
+  title: Schur's lemma
+
+Q1841237:
+  title: Fubini's theorem on differentiation
+
+Q1855610:
+  title: Theorem of de Moivre–Laplace
+
+Q1888583:
+  title: Holditch's theorem
+
+Q1893717:
+  title: Rice's theorem
+
+Q1896455:
+  title: Varignon's theorem
+
+Q1899432:
+  title: Grothendieck–Hirzebruch–Riemann–Roch theorem
+
+Q1914905:
+  title: Ramanujan–Skolem's theorem
+
+Q1930577:
+  title: Herbrand's theorem
+
+Q1933521:
+  title: Kleene's recursion theorem
+
+Q1938251:
+  title: Hasse–Minkowski theorem
+
+Q1946642X:
+  title: S–cobordism theorem
+
+Q1946642:
+  title: H-cobordism theorem
+
+Q1964537:
+  title: Mergelyan's theorem
+
+Q1966978:
+  title: Lévy continuity theorem
+
+Q1974087:
+  title: Riemann's theorem on removable singularities
+
+Q1995468:
+  title: Hölder's theorem
+
+Q1996305:
+  title: Burnside's theorem
+
+Q2000090:
+  title: Art gallery theorem
+
+Q2008549:
+  title: Hilbert's theorem
+
+Q2013213:
+  title: Reuschle's theorem
+
+Q2022775:
+  title: Hilbert–Schmidt theorem
+
+Q2027347:
+  title: Optional stopping theorem
+
+Q2028341:
+  title: Ado's theorem
+
+Q2046647:
+  title: Karhunen–Loève theorem
+
+Q2063099:
+  title: Poincaré duality theorem
+
+Q2068227:
+  title: Artin–Schreier theorem
+
+Q2071632:
+  title: Rouché–Capelli theorem
+
+Q2093886:
+  title: Primitive element theorem
+
+Q2094241:
+  title: Hopf–Rinow theorem
+
+Q2096184:
+  title: Plancherel theorem
+
+Q2109761:
+  title: Uniformization theorem
+
+Q2120067:
+  title: Diller–Dress theorem
+
+Q2190744:
+  title: Feuerbach's theorem
+
+Q2197859:
+  title: Nicomachus's theorem
+
+Q2222575:
+  title: Shell theorem
+
+Q2226602:
+  title: Bauer–Fike theorem
+
+Q2226606:
+  title: Beckman–Quarles theorem
+
+Q2226610:
+  title: Banach–Mazur theorem
+
+Q2226624:
+  title: Bruck–Chowla–Ryser theorem
+
+Q2226625:
+  title: Commandino's theorem
+
+Q2226640:
+  title: Cramér’s decomposition theorem
+
+Q2226644:
+  title: Easton's theorem
+
+Q2226650:
+  title: Eberlein–Šmulian theorem
+
+Q2226677:
+  title: Gelfand–Mazur theorem
+
+Q2226682:
+  title: Gelfand–Naimark theorem
+
+Q2226691:
+  title: Kirchhoff's theorem
+
+Q2226695:
+  title: Hurwitz's automorphisms theorem
+
+Q2226698:
+  title: Kantorovich theorem
+
+Q2226709:
+  title: Krull–Schmidt theorem
+
+Q2226750:
+  title: Malgrange–Ehrenpreis theorem
+
+Q2226774:
+  title: König's theorem
+
+Q2226786:
+  title: Sperner's theorem
+
+Q2226800:
+  title: Schur–Zassenhaus theorem
+
+Q2226803:
+  title: Tennenbaum's theorem
+
+Q2226807:
+  title: Vantieghems theorem
+
+Q2226855:
+  title: Sarkovskii's theorem
+
+Q2226868:
+  title: Geometric mean theorem
+
+Q2226962:
+  title: Weierstrass–Casorati theorem
+
+Q2253746:
+  title: Bertrand's ballot theorem
+
+Q2266397:
+  title: Intersecting chords theorem
+
+Q2267175:
+  title: Tangent-secant theorem
+
+Q2269888:
+  title: Cohn's irreducibility criterion
+
+Q2270905:
+  title: Poincaré–Birkhoff–Witt theorem
+
+Q2275191:
+  title: Lebesgue differentiation theorem
+
+Q2277040:
+  title: Shannon's expansion theorem
+
+Q2287393:
+  title: Caristi fixed-point theorem
+
+Q2309682:
+  title: Sphere theorem
+
+Q2309760:
+  title: Looman–Menchoff theorem
+
+Q2310718:
+  title: Pitot theorem
+
+Q2338929:
+  title: Exchange theorem
+
+Q2345282:
+  title: Shannon's theorem
+
+Q2347139:
+  title: Carnot's theorem
+
+Q2360531:
+  title: Jordan–Schur theorem
+
+Q2374733:
+  title: Skolem–Mahler–Lech theorem
+
+Q2376918:
+  title: Abelian and Tauberian theorems
+
+Q2378270:
+  title: Thue's theorem
+
+Q2379128:
+  title: Lindström's theorem
+
+Q2379132:
+  title: Going-up and going-down theorems
+
+Q2394548:
+  title: Hurewicz theorem
+
+Q2411312:
+  title: Shannon's source coding theorem
+
+Q2428364:
+  title: Clausius theorem
+
+Q2449984:
+  title: Miquel's theorem
+
+Q2449984X:
+  title: Pivot theorem
+
+Q2471737:
+  title: Carathéodory's theorem
+
+Q2473965:
+  title: Ugly duckling theorem
+
+Q2478371:
+  title: Envelope theorem
+
+Q2482753:
+  title: Mann's theorem
+
+Q2495664:
+  title: Universal coefficient theorem
+
+Q2500406:
+  title: Liénard's theorem
+
+Q2500408:
+  title: Thébault's theorem
+
+Q2518048:
+  title: Kodaira vanishing theorem
+
+Q2524990:
+  title: Jackson's theorem
+
+Q2525646:
+  title: Jordan–Hölder theorem
+
+Q2533936:
+  title: Descartes's theorem on total angular defect
+
+Q2540738:
+  title: Cartan–Dieudonné theorem
+
+Q2558669:
+  title: Artin–Zorn theorem
+
+Q2588432:
+  title: Wold's theorem
+
+Q2600653:
+  title: Taylor–Proudman theorem
+
+Q2607007:
+  title: Hinge theorem
+
+Q2621667:
+  title: Nagata–Smirnov metrization theorem
+
+Q2631152:
+  title: Carathéodory's extension theorem
+
+Q2635326:
+  title: Structured program theorem
+
+Q2638931:
+  title: Convolution theorem
+
+Q2703389:
+  title: Linnik's theorem
+
+Q2733672:
+  title: Price's theorem
+
+Q2734084:
+  title: Bohr–Mollerup theorem
+
+Q2793600:
+  title: Stark–Heegner theorem
+
+Q2799491:
+  title: Ringel–Youngs theorem
+
+Q2800071:
+  title: Perfect graph theorem
+
+Q2862403:
+  title: Bombieri's theorem
+
+Q2893695:
+  title: Unmixedness theorem
+
+Q2916568:
+  title: Gomory's theorem
+
+Q2919401:
+  title: Ostrowski's theorem
+
+Q2981012:
+  title: Monge's theorem
+
+Q2984415:
+  title: Hajnal–Szemerédi theorem
+
+Q2993026:
+  title: Ankeny&ndash;Artin&ndash;Chowla theorem
+
+Q2993308:
+  title: Cameron–Erdős theorem
+
+Q2993319:
+  title: Mirsky–Newman theorem
+
+Q2995691:
+  title: Newlander–Niremberg theorem
+
+Q3001796:
+  title: Skolem–Noether theorem
+
+Q3007384:
+  title: Post's theorem
+
+Q3075250:
+  title: Hardy–Littlewood maximal theorem
+
+Q3077634:
+  title: Sahlqvist correspondence theorem
+
+Q3088644:
+  title: Goldstine theorem
+
+Q3154003:
+  title: Le Cam's theorem
+
+Q3180727:
+  title: Perlis theorem
+
+Q3229335:
+  title: Borel–Carathéodory theorem
+
+Q3229352:
+  title: Vitali covering theorem
+
+Q3345678:
+  title: Moore–Aronszajn theorem
+
+Q3424029:
+  title: Chasles's theorems
+
+Q3443426:
+  title: Bondy's theorem
+
+Q3458641:
+  title: Szegő limit theorems
+
+Q3502015:
+  title: Hasse's theorem on elliptic curves
+
+Q3505260:
+  title: Cayley–Salmon theorem
+
+Q3526969:
+  title: AF+BG theorem
+
+Q3526976:
+  title: Ax–Kochen theorem
+
+Q3526982:
+  title: Erdős–Anning theorem
+
+Q3526990:
+  title: Euler's theorem
+
+Q3526993:
+  title: Takagi existence theorem
+
+Q3526996:
+  title: Kolmogorov extension theorem
+
+Q3526998:
+  title: Excision theorem
+
+Q3527004:
+  title: BEST theorem
+
+Q3527008:
+  title: Balian–Low theorem
+
+Q3527009:
+  title: Baker's theorem
+
+Q3527011:
+  title: Beck's theorem
+
+Q3527015:
+  title: Bernstein's theorem
+
+Q3527017:
+  title: Beurling–Lax theorem
+
+Q3527019:
+  title: Birch's theorem
+
+Q3527034:
+  title: Cauchy's theorem
+
+Q3527040:
+  title: Chomsky–Schützenberger representation theorem
+
+Q3527044:
+  title: Pappus's area theorem
+
+Q3527054:
+  title: De Bruijn–Erdős theorem (graph theory)
+
+Q3527056:
+  title: De Bruijn–Erdős theorem (incidence geometry)
+
+Q3527064:
+  title: Donsker's theorem
+
+Q3527067:
+  title: F. and M. Riesz theorem
+
+Q3527071:
+  title: Fáry–Milnor theorem
+
+Q3527079:
+  title: Freiman's theorem
+
+Q3527088:
+  title: Haboush's theorem
+
+Q3527091:
+  title: Gromov's theorem on groups of polynomial growth
+
+Q3527093:
+  title: Hilbert–Speiser theorem
+
+Q3527095:
+  title: Jacobi's four-square theorem
+
+Q3527100:
+  title: Kruskal's tree theorem
+
+Q3527102:
+  title: Kruskal–Katona theorem
+
+Q3527110:
+  title: Lax–Wendroff theorem
+
+Q3527113:
+  title: Lie–Kolchin theorem
+
+Q3527118:
+  title: Mahler's theorem
+
+Q3527125:
+  title: Monsky's theorem
+
+Q3527129:
+  title: Müntz–Szász theorem
+
+Q3527132:
+  title: Nagell–Lutz theorem
+
+Q3527155:
+  title: Robertson–Seymour theorem
+
+Q3527162:
+  title: Sophie Germain's theorem
+
+Q3527166:
+  title: Steinhaus theorem
+
+Q3527171:
+  title: Synge's theorem
+
+Q3527185:
+  title: Whitehead theorem
+
+Q3527189:
+  title: Lattice theorem
+
+Q3527196:
+  title: Principal ideal theorem
+
+Q3527205:
+  title: Dimension theorem for vector spaces
+
+Q3527209:
+  title: Hasse norm theorem
+
+Q3527214:
+  title: Non-squeezing theorem
+
+Q3527215:
+  title: Hilbert projection theorem
+
+Q3527217:
+  title: M. Riesz extension theorem
+
+Q3527219:
+  title: Weierstrass preparation theorem
+
+Q3527223:
+  title: Crystallographic restriction theorem
+
+Q3527226:
+  title: Linear speedup theorem
+
+Q3527230:
+  title: Von Staudt–Clausen theorem
+
+Q3527233:
+  title: Kolmogorov's three-series theorem
+
+Q3527241:
+  title: Krull's principal ideal theorem
+
+Q3527245:
+  title: Six exponentials theorem
+
+Q3527247:
+  title: Six circles theorem
+
+Q3527250:
+  title: Hadamard three-lines theorem
+
+Q3527263:
+  title: Kleene fixed-point theorem
+
+Q3527279:
+  title: Wiener's tauberian theorem
+
+Q3534036:
+  title: Pompeiu's theorem
+
+Q3613173:
+  title: Tits alternative
+
+Q3661294:
+  title: Kelvin's circulation theorem
+
+Q3699212:
+  title: Saint-Venant's theorem
+
+Q3711848:
+  title: Sobolev embedding theorem
+
+Q3757563:
+  title: Intercept theorem
+
+Q3771212:
+  title: Proth's theorem
+
+Q3889376:
+  title: Carmichael's theorem
+
+Q3893473:
+  title: Tameness theorem
+
+Q3915398:
+  title: Brunn–Minkowski theorem
+
+Q3983968:
+  title: Sturm–Picone comparison theorem
+
+Q3983972:
+  title: Simplicial approximation theorem
+
+Q3984011:
+  title: Duggan&ndash;Schwartz theorem
+
+Q3984017:
+  title: Helly's selection theorem
+
+Q3984020:
+  title: Holmström's theorem
+
+Q3984052:
+  title: Equidistribution theorem
+
+Q3984053:
+  title: Fourier inversion theorem
+
+Q3984056:
+  title: No-communication theorem
+
+Q3984063:
+  title: Mostow rigidity theorem
+
+Q3984069:
+  title: Fredholm's theorem
+
+Q4054114:
+  title: ATS theorem
+
+Q4116459:
+  title: Niven's theorem
+
+Q4171386:
+  title: Soul theorem
+
+Q4179283:
+  title: Positive energy theorem
+
+Q4272300:
+  title: Initial value theorem
+
+Q4272645:
+  title: Final value theorem
+
+Q4378868:
+  title: Phragmén–Lindelöf theorem
+
+Q4378889:
+  title: Carathéodory's theorem
+
+Q4408070:
+  title: De Finetti's theorem
+
+Q4454910:
+  title: Ostrowski–Hadamard gap theorem
+
+Q4454919:
+  title: Aumann's agreement theorem
+
+Q4454925:
+  title: Edge-of-the-wedge theorem
+
+Q4454954:
+  title: Kirszbraun theorem
+
+Q4454958:
+  title: Min-max theorem
+
+Q4454973:
+  title: Lindelöf's theorem
+
+Q4454976:
+  title: Liouville's theorem
+
+Q4454989:
+  title: Meusnier's theorem
+
+Q4454996:
+  title: Novikov's compact leaf theorem
+
+Q4455003:
+  title: Pomeranchuk's theorem
+
+Q4455015:
+  title: Routh–Hurwitz theorem
+
+Q4455016:
+  title: Reeb sphere theorem
+
+Q4455023:
+  title: Sazonov's theorem
+
+Q4455025:
+  title: No wandering domain theorem
+
+Q4455030:
+  title: Stone's theorem on one-parameter unitary groups
+
+Q4455031:
+  title: Fáry's theorem
+
+Q4455033:
+  title: Fatou's theorem
+
+Q4455037:
+  title: Hardy's theorem
+
+Q4455043:
+  title: Cayley–Bacharach theorem
+
+Q4455046:
+  title: Monodromy theorem
+
+Q4634017:
+  title: 2π theorem
+
+Q4663326:
+  title: Hirzebruch–Riemann–Roch theorem
+
+Q4666729:
+  title: Abel–Jacobi theorem
+
+Q4666729X:
+  title: Abel's curve theorem
+
+Q4667501:
+  title: Abhyankar–Moh theorem
+
+Q4677985:
+  title: Acyclic models theorem
+
+Q4695203:
+  title: Four functions theorem
+
+Q4700718:
+  title: Akhiezer's theorem
+
+Q4712316:
+  title: Albert–Brauer–Hasse–Noether theorem
+
+Q4713046:
+  title: Alchian–Allen theorem
+
+Q4724004B:
+  title: Riemann's existence theorem
+
+Q4724004A:
+  title: Chow's theorem
+
+Q4734002:
+  title: Gromov–Ruh theorem
+
+Q4734844:
+  title: Alperin–Brauer–Gorenstein theorem
+
+Q4736422:
+  title: Denjoy theorem
+
+Q4746948:
+  title: Amitsur–Levitzki theorem
+
+Q4751110:
+  title: Analyst's traveling salesman theorem
+
+Q4751118:
+  title: Analytic Fredholm theorem
+
+Q4753992:
+  title: Anderson's theorem
+
+Q4756099:
+  title: Andreotti–Frankel theorem
+
+Q4783822:
+  title: Arithmetic Riemann–Roch theorem
+
+Q4788680:
+  title: Area theorem (conformal mapping)
+
+Q4801169:
+  title: Artin approximation theorem
+
+Q4801183:
+  title: Artin–Verdier duality theorem
+
+Q4801563:
+  title: Artstein's theorem
+
+Q4815879:
+  title: Atiyah–Segal completion theorem
+
 Q4815899:
   title: Atkinson's theorem
 
-Q523832:
-  title: "Carath\xE9odory\u2013Jacobi\u2013Lie theorem"
+Q4826848:
+  title: Autonomous convergence theorem
 
-Q2793600:
-  title: "Stark\u2013Heegner theorem"
+Q4827308:
+  title: Auxiliary polynomial theorem
 
-Q107710112:
-  title: Cantor's isomorphism theorem
+Q4830725:
+  title: Ax–Grothendieck theorem
+
+Q4832965:
+  title: Aztec diamond theorem
+
+Q4838119:
+  title: Babuška–Lax–Milgram theorem
+
+Q4848497:
+  title: Baily–Borel theorem
+
+Q4853767:
+  title: Banach–Stone theorem
+
+Q4857506:
+  title: Bapat–Beg theorem
+
+Q4865980:
+  title: Barwise compactness theorem
+
+Q4866385:
+  title: Base change theorems
+
+Q4866385X:
+  title: Proper base change theorem
+
+Q4877965:
+  title: Beauville–Laszlo theorem
+
+Q4878586:
+  title: Beck's monadicity theorem
+
+Q4880958:
+  title: Behnke–Stein theorem
+
+Q4884789:
+  title: Beltrami's theorem
+
+Q4884950:
+  title: Belyi's theorem
+
+Q4891633:
+  title: Berger–Kazdan comparison theorem
+
+Q4894565:
+  title: Bernstein's theorem
+
+Q4914101:
+  title: Bing's recognition theorem
+
+Q4916483:
+  title: Birkhoff–Grothendieck theorem
+
+Q4918128:
+  title: Bishop–Cannings theorem
+
+Q4927458:
+  title: Blondel's theorem
+
+Q4937691:
+  title: Bogoliubov–Parasyuk theorem
+
+Q4941364:
+  title: Bondareva–Shapley theorem
+
+Q4942215:
+  title: Bonnet theorem
+
+Q4944906:
+  title: Borel determinacy theorem
+
+Q4944908:
+  title: Borel fixed-point theorem
+
+Q4944923:
+  title: Borel–Bott–Weil theorem
+
+Q4944923X:
+  title: Borel–Weil theorem
+
+Q4948983:
+  title: Bott periodicity theorem
+
+Q4949984:
+  title: Bounded inverse theorem
+
+Q4950096:
+  title: Bourbaki–Witt theorem
+
+Q4956438:
+  title: Branching theorem
+
+Q4958218:
+  title: Brauer's theorem on induced characters
+
+Q4958221:
+  title: Brauer's three main theorems
+
+Q4958227:
+  title: Brauer–Nesbitt theorem
+
+Q4958230:
+  title: Brauer–Siegel theorem
+
+Q4958233:
+  title: Brauer–Suzuki–Wall theorem
+
+Q4971339:
+  title: British flag theorem
+
+Q4975963:
+  title: Brown's representability theorem
+
+Q4979609:
+  title: Brun–Titchmarsh theorem
+
+Q4991415:
+  title: Chowla–Mordell theorem
+
+Q4998912:
+  title: Burke's theorem
+
+Q5001327:
+  title: Busemann's theorem
+
+Q5005143:
+  title: Bôcher's theorem
+
+Q5005965:
+  title: C-theorem
+
+Q5026435:
+  title: Cameron–Martin theorem
+
+Q5037752:
+  title: Carathéodory's existence theorem
+
+Q5041175:
+  title: Carleson–Jacobs theorem
+
+Q5042898:
+  title: Carlson's theorem
+
+Q5047043:
+  title: Cartan's theorems A and B
+
+Q5047046:
+  title: Brauer–Cartan–Hua theorem
+
+Q5047048:
+  title: Cartan–Hadamard theorem
+
+Q5047051:
+  title: Cartan–Kuranishi prolongation theorem
+
+Q5047052:
+  title: Cartan–Kähler theorem
+
+Q5049717:
+  title: Castelnuovo–de Franchis theorem
+
+Q5091194:
+  title: Cheng's eigenvalue comparison theorem
+
+Q5094298:
+  title: Chevalley's structure theorem
+
+Q5094305:
+  title: Chevalley–Shephard–Todd theorem
+
+Q5103861:
+  title: Choi's theorem on completely positive maps
+
+Q5125859:
+  title: Clapeyron's theorem
+
+Q5127710:
+  title: Clark–Ocone theorem
+
+Q5132839:
+  title: Clifford's circle theorems
+
+Q5132840:
+  title: Clifford's theorem on special divisors
+
+Q5136698:
+  title: Cluster decomposition theorem
+
+Q5139948:
+  title: Codd's theorem
+
+Q5141331:
+  title: Cohen structure theorem
+
+Q5155090:
+  title: Commutation theorem
+
+Q5157054:
+  title: Compression theorem
+
+Q5161245:
+  title: Conley–Zehnder theorem
+
+Q5163116:
+  title: Conservativity theorem
+
+Q5165492:
+  title: Continuous mapping theorem
+
+Q5166389:
+  title: Van Vleck's theorem
+
+Q5171652:
+  title: Corners theorem
+
+Q5172143:
+  title: Corona theorem
+
+Q5178114:
+  title: Courcelle's theorem
+
+Q5180651:
+  title: Craig's theorem
+
+Q5187911:
+  title: Crooks fluctuation theorem
+
+Q5188510:
+  title: Crossbar theorem
+
+Q5195996:
+  title: Curtis–Hedlund–Lyndon theorem
+
+Q5221089:
+  title: Danskin's theorem
+
+Q5242704:
+  title: Dawson–Gärtner theorem
+
+Q5244285:
+  title: de Bruijn's theorem
+
+Q5244361:
+  title: De Franchis theorem
+
+Q5251122:
+  title: Time hierarchy theorem
+
+Q5252320:
+  title: Lickorish twist theorem
+
+Q5278348:
+  title: Galvin's theorem
+
+Q5282059:
+  title: Harish–Chandra theorem
+
+Q5282247:
+  title: Disintegration theorem
+
+Q5295351:
+  title: Donaldson's theorem
+
+Q5296972:
+  title: Doob–Meyer decomposition theorem
+
+Q5299605:
+  title: Glivenko's theorem
+
+Q5311783:
+  title: Dudley's theorem
+
+Q5315060:
+  title: Dunford–Schwartz theorem
+
+Q5319505:
+  title: Zeilberger–Bressoud theorem
+
+Q5337931:
+  title: Edgeworth's limit theorem
+
+Q5362000:
+  title: Elitzur's theorem
+
+Q5384150:
+  title: Equal incircles theorem
+
+Q5385323:
+  title: Erdős–Gallai theorem
+
+Q5385324:
+  title: Erdős–Nagy theorem
+
+Q5385325:
+  title: Erdős–Pósa theorem
+
+Q5385326:
+  title: Erdős–Stone theorem
+
+Q5421989:
+  title: Exterior angle theorem
+
+Q5436274:
+  title: Farrell–Markushevich theorem
+
+Q5437947:
+  title: Fatou–Lebesgue theorem
+
+Q5438320:
+  title: Faustman–Ohlin theorem
+
+Q5443003:
+  title: Fenchel's duality theorem
+
+Q5443004:
+  title: Fenchel's theorem
+
+Q5443005:
+  title: Fenchel–Moreau theorem
+
+Q5445112:
+  title: Fernique's theorem
+
+Q5445311:
+  title: Ferrero–Washington theorem
+
+Q5447238:
+  title: Fieller's theorem
+
+Q5454965:
+  title: Fisher–Tippett–Gnedenko theorem
+
+Q5455495:
+  title: Fitting's theorem
+
+Q5456213:
+  title: Five circles theorem
+
+Q5463860:
+  title: Focal subgroup theorem
+
+Q5473576:
+  title: Foster's theorem
+
+Q5494134:
+  title: Fraňková–Helly selection theorem
+
+Q5498822:
+  title: Birkhoff's theorem
+
+Q5499906:
+  title: Shirshov–Witt theorem
+
+Q5501344:
+  title: Freidlin–Wentzell theorem
+
+Q5503689:
+  title: Bombieri–Friedlander–Iwaniec theorem
+
+Q5504427:
+  title: Friendship theorem
+
+Q5505098:
+  title: Frobenius determinant theorem
+
+Q5505114:
+  title: Froda's theorem
+
+Q5506929:
+  title: Fuchs's theorem
+
+Q5507285:
+  title: Fuglede's theorem
+
+Q5508180:
+  title: Full employment theorem
+
+Q5508482:
+  title: Fulton–Hansen connectedness theorem
+
+Q5508973:
+  title: Fundamental theorem of arbitrage-free pricing
+
+Q5530454:
+  title: Gell-Mann and Low theorem
+
+Q5552370:
+  title: Geroch's splitting theorem
+
+Q5566491:
+  title: Glaisher's theorem
+
+Q5567394:
+  title: Gleason's theorem
+
+Q5576268:
+  title: Goddard–Thorn theorem
+
+Q5579030:
+  title: Goldberg–Sachs theorem
+
+Q5580171:
+  title: Goldie's theorem
+
+Q5586067:
+  title: Gordon–Newell theorem
+
+Q5588002:
+  title: Gottesman–Knill theorem
+
+Q5597098:
+  title: Graph structure theorem
+
+Q5609384:
+  title: Grinberg's theorem
+
+Q5610188:
+  title: Gromov's compactness theorem
+
+Q5610190:
+  title: Gromov's compactness theorem
+
+Q5610718:
+  title: Grothendieck's connectedness theorem
+
+Q5612131:
+  title: Grunsky's theorem
+
+Q5612159:
+  title: Grunwald–Wang theorem
+
+Q5612871:
+  title: Grötzsch's theorem
+
+Q5638112:
+  title: Hadwiger's theorem
+
+Q5638886:
+  title: Hahn embedding theorem
+
+Q5643485:
+  title: Halpern–Läuchli theorem
+
+Q5645731:
+  title: Hammersley–Clifford theorem
+
+Q5656673:
+  title: Hardy–Littlewood tauberian theorem
+
+Q5656674:
+  title: Hardy–Ramanujan theorem
+
+Q5657833:
+  title: Harish–Chandra's regularity theorem
+
+Q5659675:
+  title: Harnack's curve theorem
+
+Q5675112:
+  title: Hartogs–Rosenthal theorem
+
+Q5680041:
+  title: Hasse–Arf theorem
+
+Q5697916B:
+  title: Waldhausen's theorem
+
+Q5697916A:
+  title: Reidemeister–Singer Theorem
+
+Q5697927:
+  title: Gross–Zagier theorem
+
+Q5709171:
+  title: Helly–Bray theorem
+
+Q5709377:
+  title: Helmholtz theorem (classical mechanics)
+
+Q5761142:
+  title: Hilbert's irreducibility theorem
+
+Q5874979:
+  title: Hobby–Rice theorem
+
+Q5876058:
+  title: Hodge index theorem
+
+Q5988409:
+  title: Identity theorem for Riemann surfaces
+
+Q6015420:
+  title: Increment theorem
+
+Q6059532:
+  title: Aronszajn–Smith theorem
+
+Q6086104:
+  title: Isomorphism extension theorem
+
+Q6119825:
+  title: Jacobson–Bourbaki theorem
+
+Q6276298:
+  title: Jordan's theorem (multiply transitive groups)
+
+Q6344729:
+  title: Kachurovskii's theorem
+
+Q6360586:
+  title: Kanamori–McAloon theorem
+
+Q6373327:
+  title: Karp–Lipton theorem
+
+Q6378596:
+  title: Katz–Lang finiteness theorem
+
+Q6379606:
+  title: Kawamata–Viehweg vanishing theorem
+
+Q6379715:
+  title: Kawasaki's theorem
+
+Q6387087:
+  title: Kempf–Ness theorem
+
+Q6400676:
+  title: Kharitonov's theorem
+
+Q6402928:
+  title: Lagrange reversion theorem
+
+Q6403282:
+  title: Lagrange's theorem
+
+Q6407842:
+  title: Killing–Hopf theorem
+
+Q6414200:
+  title: Kinoshita–Lee–Nauenberg theorem
+
+Q6421981:
+  title: Kneser's theorem
+
+Q6425088:
+  title: Kodaira embedding theorem
+
+Q6436753:
+  title: Krener's theorem
+
+Q6442276:
+  title: Kuiper's theorem
+
+Q6446396:
+  title: Kurosh subgroup theorem
+
+Q6455211:
+  title: Kōmura's theorem
+
+Q6456122:
+  title: L-balance theorem
+
+Q6471668:
+  title: Lafforgue's theorem
+
+Q6481192:
+  title: Lambek–Moser theorem
+
+Q6484331:
+  title: Landau prime ideal theorem
+
+Q6501470:
+  title: Lauricella's theorem
+
+Q6513990:
+  title: Lee Hwa Chung theorem
+
+Q6516611:
+  title: Lee–Yang theorem
+
+Q6516731:
+  title: Lefschetz hyperplane theorem
+
+Q6516736:
+  title: Lefschetz theorem on (1,1)-classes
+
+Q6528747:
+  title: Leray's theorem
+
+Q6528751:
+  title: Leray–Hirsch theorem
+
+Q6528849:
+  title: Lerner symmetry theorem
+
+Q6535568:
+  title: Levi's theorem
+
+Q6535741:
+  title: Levitzky's theorem
+
+Q6544508:
+  title: Lie–Palais theorem
+
+Q6701653:
+  title: Lukacs's proportion-sum independence theorem
+
+Q6707093:
+  title: Lyapunov&ndash;Malkin theorem
+
+Q6711207:
+  title: Lévy's modulus of continuity theorem
+
+Q6722024:
+  title: MacMahon Master theorem
+
+Q6733278:
+  title: Maharam's theorem
+
+Q6734194:
+  title: Mahler's compactness theorem
+
+Q6735549:
+  title: Maier's theorem
+
+Q6743217:
+  title: Malgrange preparation theorem
+
+Q6749789:
+  title: Manin–Drinfeld theorem
+
+Q6757284:
+  title: Marcinkiewicz theorem
+
+Q6760432:
+  title: Marginal value theorem
+
+Q6771536:
+  title: Markus−Yamabe theorem
+
+Q6777133:
+  title: Martingale representation theorem
+
+Q6783821:
+  title: Mason–Stothers theorem
+
+Q6795637:
+  title: Maximal ergodic theorem
+
+Q6795830:
+  title: Separating axis theorem
+
+Q6796056:
+  title: Maxwell's theorem
+
+Q6799039:
+  title: Mazur's control theorem
+
+Q6813106:
+  title: Mellin inversion theorem
+
+Q6859627:
+  title: Milliken's tree theorem
+
+Q6859648:
+  title: Milliken–Taylor theorem
+
+Q6860180:
+  title: Milman–Pettis theorem
+
+Q6867853:
+  title: Minkowski's second theorem
+
+Q6867867:
+  title: Minkowski–Hlawka theorem
+
+Q6867878:
+  title: Minlos's theorem
+
+Q6911202:
+  title: Moreau's theorem
+
+Q6914794:
+  title: Morton's theorem
+
+Q6925496:
+  title: Mountain pass theorem
+
+Q6927135:
+  title: Moving equilibrium theorem
+
+Q6935007:
+  title: Multiplicity-one theorem
+
+Q6935403:
+  title: Mumford vanishing theorem
+
+Q6957141:
+  title: Nachbin's theorem
+
+Q6967039:
+  title: Nash–Moser theorem
+
+Q7020025:
+  title: Newton's theorem about ovals
+
+Q7031618:
+  title: Nielsen realization problem
+
+Q7031621:
+  title: Nielsen fixed-point theorem
+
+Q7042768:
+  title: No-broadcasting theorem
+
+Q7042801:
+  title: No-trade theorem
+
+Q7043732:
+  title: Kuhn's theorem
+
+Q7045226:
+  title: No free lunch theorem
+
+Q7047379:
+  title: Noether's theorem on rationality for surfaces
+
+Q7098850:
+  title: Optical equivalence theorem
+
+Q7100033A:
+  title: Orbit theorem (Nagano–Sussmann)
+
+Q7100033B:
+  title: Rashevsky–Chow theorem
+
+Q7103669:
+  title: Ornstein theorem
+
+Q7106480:
+  title: Oseledec theorem
+
+Q7127466:
+  title: Paley's theorem
+
+Q7130794:
+  title: Pandya theorem
+
+Q7137494:
+  title: Paris–Harrington theorem
+
+Q7139570:
+  title: Parovicenko's theorem
+
+Q7140218:
+  title: Parthasarathy's theorem
+
+Q7160302:
+  title: Peeling theorem
+
+Q7160489:
+  title: Peetre theorem
+
+Q7160983:
+  title: Peixoto's theorem
+
+Q7190748:
+  title: Pickands–Balkema–de Haan theorem
+
+Q7200963:
+  title: Planar separator theorem
+
+Q7208500:
+  title: Poisson limit theorem
 
 Q7239984:
   title: Preimage theorem
 
+Q7245073:
+  title: Principal axis theorem
+
+Q7249519:
+  title: Prokhorov's theorem
+
+Q7255475:
+  title: Pseudorandom generator theorem
+
+Q7269076:
+  title: No-deleting theorem
+
+Q7269106:
+  title: Quantum threshold theorem
+
+Q7269437:
+  title: Denjoy–Carleman theorem
+
+Q7269559:
+  title: Sylvester pentahedral theorem
+
+Q7272004:
+  title: Quillen–Suslin theorem
+
+Q7272898:
+  title: Quotient of subspace theorem
+
+Q7283856:
+  title: Raikov's theorem
+
+Q7288988:
+  title: Ramanujam vanishing theorem
+
+Q7295875:
+  title: Ratner's theorems
+
+Q7296106:
+  title: Rauch comparison theorem
+
+Q7307252:
+  title: Reflection theorem
+
+Q7308146:
+  title: Regev's theorem
+
+Q7309601:
+  title: Whitney–Graustein Theorem
+
+Q7310041:
+  title: Reider's theorem
+
+Q7312009:
+  title: Remmert–Stein theorem
+
+Q7318284:
+  title: Reversed compound agent theorem
+
+Q7322366:
+  title: Ribet's theorem
+
+Q7323144:
+  title: Rice–Shapiro theorem
+
+Q7333126:
+  title: Riemann–Roch theorem for surfaces
+
+Q7341043:
+  title: Robbins theorem
+
+Q7352955:
+  title: Robinson's joint consistency theorem
+
+Q7359997:
+  title: Rokhlin's theorem
+
+Q7396621:
+  title: Saccheri–Legendre theorem
+
+Q7430892:
+  title: Schaefer's dichotomy theorem
+
+Q7431298:
+  title: Schilder's theorem
+
+Q7431925:
+  title: Schnyder's theorem
+
+Q7432872:
+  title: Schreier refinement theorem
+
+Q7432915:
+  title: Schroeder–Bernstein theorem for measurable spaces
+
+Q7432918:
+  title: Schröder–Bernstein theorems for operator algebras
+
+Q7433034:
+  title: Great orthogonality theorem
+
+Q7433182:
+  title: Schwartz–Zippel theorem
+
+Q7433295:
+  title: Osterwalder–Schrader theorem
+
+Q7437564:
+  title: Scott core theorem
+
+Q7455422:
+  title: Swan's theorem
+
+Q7496252:
+  title: Shift theorem
+
+Q7510574:
+  title: Siegel–Walfisz theorem
+
+Q7512855:
+  title: Hirzebruch signature theorem
+
+Q7516736:
+  title: Silverman–Toeplitz theorem
+
+Q7524563:
+  title: Sinkhorn's theorem
+
+Q7525341:
+  title: Sion's minimax theorem
+
+Q7525845:
+  title: Sipser–Lautemann theorem
+
+Q7532192:
+  title: Siu's semicontinuity theorem
+
+Q7536097:
+  title: Skoda–El Mir theorem
+
+Q7536350:
+  title: Skorokhod's embedding theorem
+
+Q7572588:
+  title: Space hierarchy theorem
+
+Q7574438:
+  title: Specht's theorem
+
+Q7597316:
+  title: Stallings theorem about ends of groups
+
+Q7597317:
+  title: Stallings–Zeeman theorem
+
+Q7599389:
+  title: Stanley's reciprocity theorem
+
+Q7601243:
+  title: Star of David theorem
+
+Q7606897:
+  title: Steinitz theorem
+
+Q7606940:
+  title: Stein–Strömberg theorem
+
+Q7617407:
+  title: Stinespring factorization theorem
+
+Q7619060:
+  title: The duality theorem
+
+Q7619449:
+  title: Stone–von Neumann theorem
+
+Q7621715:
+  title: Strassmann's theorem
+
+Q7625164:
+  title: Structure theorem for Gaussian measures
+
+Q7632041:
+  title: Subspace theorem
+
+Q7644264:
+  title: Supersymmetry nonrenormalization theorems
+
+Q7660749:
+  title: Sylvester's determinant theorem
+
+Q7661308:
+  title: Symmetric hypergraph theorem
+
+Q7664013:
+  title: Sz.-Nagy's dilation theorem
+
+Q7686760:
+  title: Bang's theorem
+
+Q7782345:
+  title: Bertini's theorem
+
+Q7782346:
+  title: Theorem of the cube
+
+Q7782348:
+  title: Theorem of three moments
+
+Q7795825:
+  title: Thompson transitivity theorem
+
+Q7795828:
+  title: Thompson uniqueness theorem
+
+Q7809920:
+  title: Titchmarsh convolution theorem
+
+Q7818977:
+  title: Tomita's theorem
+
+Q7820874:
+  title: Tonelli's theorem
+
+Q7824894:
+  title: Topkis's theorem
+
+Q7825061:
+  title: Toponogov's theorem
+
+Q7825663:
+  title: Torelli theorem
+
+Q7827204:
+  title: Mazur's torsion theorem
+
+Q7841060:
+  title: Trichotomy theorem
+
+Q7845353:
+  title: Trombi–Varadarajan theorem
+
+Q7847268:
+  title: Trudinger's theorem
+
+Q7849521:
+  title: Tsen's theorem
+
+Q7853325:
+  title: Tunnell's theorem
+
+Q7856599:
+  title: Turán–Kubilius theorem
+
+Q7857350:
+  title: Tverberg's theorem
+
+Q7888360:
+  title: Structure theorem for finitely generated modules over a principal ideal domain
+
+Q7894110:
+  title: Universal approximation theorem
+
+Q7911648:
+  title: Valiant–Vazirani theorem
+
+Q7928688:
+  title: Vietoris–Begle mapping theorem
+
+Q7936914:
+  title: Vitali–Hahn–Saks theorem
+
+Q7941491:
+  title: Von Neumann's theorem
+
+Q7959587:
+  title: Wagner's theorem
+
+Q7966545:
+  title: Walter theorem
+
+Q7978735:
+  title: Weber's theorem
+
+Q7980241:
+  title: Weinberg–Witten theorem
+
+Q7996766:
+  title: Whitney extension theorem
+
+Q7996769:
+  title: Whitney immersion theorem
+
+Q7999144:
+  title: Wiener–Ikehara theorem
+
+Q7999797:
+  title: Beer's theorem
+
+Q8002487:
+  title: Wilkie's theorem
+
+Q8028529:
+  title: Witt's theorem
+
+Q8062800:
+  title: Z* theorem
+
+Q8063120:
+  title: ZJ theorem
+
+Q8064722:
+  title: Zahorski theorem
+
+Q8066611:
+  title: Kövari–Sós–Turán theorem
+
+Q8066795:
+  title: Zariski's main theorem
+
+Q8074796:
+  title: Zsigmondy's theorem
+
+Q8081891:
+  title: Śleszyński–Pringsheim theorem
+
+Q9993851:
+  title: Lax–Milgram theorem
+
+Q10369454:
+  title: Noether's second theorem
+
+Q10859514:
+  title: Vafa–Witten theorem
+
+Q10942247:
+  title: Hironaka theorem
+
+Q11352023:
+  title: Vitali convergence theorem
+
+Q11573495:
+  title: Plancherel theorem for spherical functions
+
+Q11704319:
+  title: Chern–Gauss–Bonnet theorem
+
 Q11722674:
   title: Takens's theorem
+
+Q11883897:
+  title: Nagata's compactification theorem
+
+Q15080987:
+  title: Lie's third theorem
+
+Q15813392:
+  title: Barban–Davenport–Halberstam theorem
+
+Q15830473:
+  title: Morley's categoricity theorem
+
+Q15844093:
+  title: Van Schooten's theorem
+
+Q15859323:
+  title: Anne's theorem
+
+Q15872491:
+  title: Newton's theorem (quadrilateral)
+
+Q15895894:
+  title: Finsler–Hadwiger theorem
+
+Q16251580:
+  title: Matiyasevich's theorem
+
+Q16680059:
+  title: Strong perfect graph theorem
+
+Q16978447:
+  title: Grauert–Riemenschneider vanishing theorem
+
+Q17001601:
+  title: 2-factor theorem
+
+Q17002391:
+  title: Arrow-Lind theorem
+
+Q17003552:
+  title: Alexandrov's uniqueness theorem
+
+Q17005116:
+  title: Birkhoff's representation theorem
+
+Q17008559:
+  title: Davenport–Schmidt theorem
+
+Q17017973:
+  title: Godunov's theorem
+
+Q17018210:
+  title: Golod–Shafarevich theorem
+
+Q17019684:
+  title: Grushko theorem
+
+Q17029787:
+  title: Higman's embedding theorem
+
+Q17080564:
+  title: Zariski's connectedness theorem
+
+Q17081508:
+  title: Bing metrization theorem
+
+Q17082552:
+  title: Mutual fund separation theorem
+
+Q17089994X:
+  title: Tikhonov fixed-point theorem
+
+Q17089994:
+  title: Fixed-point theorems in infinite-dimensional spaces
+
+Q17098075:
+  title: Jurkat–Richert theorem
+
+Q17098298:
+  title: Jacobson density theorem
+
+Q17098379:
+  title: Kaplansky's theorem on quadratic forms
+
+Q17101806:
+  title: Intersection theorem
+
+Q17102744:
+  title: Riemann–Roch theorem for smooth manifolds
+
+Q17103352:
+  title: Maximum power theorem
+
+Q17104025:
+  title: Riemann singularity theorem
+
+Q17104863:
+  title: Nielsen–Ninomiya theorem
+
+Q17125544:
+  title: Lickorish–Wallace theorem
+
+Q18205730:
+  title: Byers–Yang theorem
+
+Q18206032:
+  title: Cartan's theorem
+
+Q18206266:
+  title: Euclid–Euler theorem
+
+Q18630480:
+  title: Euler's quadrilateral theorem
+
+Q19323571:
+  title: Chomsky–Schützenberger enumeration theorem
+
+Q19779530:
+  title: Thomsen's theorem
+
+Q20278711:
+  title: Cramer's theorem (algebraic curves)
+
+Q20971632:
+  title: Lie's theorem
+
+Q22952648:
+  title: Uncountability of the continuum
+
+Q25099402:
+  title: Kolmogorov–Arnold representation theorem
+
+Q25303622:
+  title: Browder–Minty theorem
+
+Q25304227:
+  title: Arakelyan's theorem
+
+Q25304301:
+  title: Bregman–Minc inequality
+
+Q25345219:
+  title: BBD decomposition theorem
+
+Q25378690:
+  title: Ionescu-Tulcea theorem
+
+Q26877569:
+  title: Furry's theorem
+
+Q28194853:
+  title: Lovelock's theorem
+
+Q28458131:
+  title: Glivenko's theorem
+
+Q31838822:
+  title: Kirchberger's theorem
+
+Q48996535:
+  title: Solèr's theorem
+
+Q48998319:
+  title: Frobenius reciprocity theorem
+
+Q55647729:
+  title: Cramér's theorem (large deviations)
+
+Q56291669:
+  title: Alspach's theorem
+
+Q60681777:
+  title: Constant chord theorem
+
+Q61163749:
+  title: Theorem of the gnomon
+
+Q62051012:
+  title: Behrend's theorem
+
+Q96375449:
+  title: Conway circle theorem
+
+Q96377355:
+  title: Erdős–Dushnik–Miller theorem
+
+Q97359729:
+  title: Stahl's theorem
+
+Q104841721:
+  title: Jacobson–Morozov theorem
+
+Q104871594:
+  title: Joubert's theorem
+
+Q105222412:
+  title: Five color theorem
+
+Q107535899:
+  title: Bochner's tube theorem
+
+Q107547910:
+  title: Malgrange–Zerner theorem
+
+Q107709489:
+  title: Büchi-Elgot-Trakhtenbrot theorem
+
+Q107710112:
+  title: Cantor's isomorphism theorem
+
+Q110921617:
+  title: Feferman–Vaught theorem
+
+Q111982312:
+  title: Friedberg–Muchnik theorem
+
+Q112659261:
+  title: Gamas's Theorem
+
+Q112740521:
+  title: Netto's theorem

--- a/scripts/check-yaml.lean
+++ b/scripts/check-yaml.lean
@@ -7,7 +7,7 @@ import Lean.Util.SearchPath
 import Mathlib.Lean.CoreM
 import Mathlib.Tactic.ToExpr
 
-/-! # Script to check `undergrad.yaml`, `overview.yaml`, and `100.yaml`
+/-! # Script to check `undergrad.yaml`, `overview.yaml`, `100.yaml` and `1000.yaml`
 
 This assumes `yaml_check.py` has first translated these to `json` files.
 
@@ -23,7 +23,7 @@ def readJsonFile (α) [FromJson α] (path : System.FilePath) : IO α := do
   let _ : MonadExceptOf String IO := ⟨throw ∘ IO.userError, fun x _ => x⟩
   liftExcept <| fromJson? <|← liftExcept <| Json.parse <|← IO.FS.readFile path
 
-def databases : List String := ["undergrad", "overview", "100"]
+def databases : List String := ["undergrad", "overview", "100", "1000"]
 
 def processDb (decls : ConstMap) : String → IO Bool
 | file => do

--- a/scripts/yaml_check.py
+++ b/scripts/yaml_check.py
@@ -1,9 +1,9 @@
 """
-This file reads in the three yaml files, and translates them to simpler json files
+This file reads in the four yaml files, and translates them to simpler json files
 that are easier to process in Lean.
 
 Usage:
-  python3 yaml_check.py <100.yaml> <overview.yaml> <undergrad.yaml>
+  python3 yaml_check.py <100.yaml> <1000.yaml> <overview.yaml> <undergrad.yaml>
 
 (Each <name> is the path to a yaml file containing information about the respective class
  of theorems. The order of these files is important.)
@@ -38,17 +38,20 @@ def print_list(fn: str, pairs: List[Tuple[str, str]]) -> None:
       out.write(f'{id}\n{val.strip()}\n\n')
 
 hundred_yaml = sys.argv[1]
-overview_yaml = sys.argv[2]
-undergrad_yaml = sys.argv[3]
+thousand_yaml = sys.argv[2]
+overview_yaml = sys.argv[3]
+undergrad_yaml = sys.argv[4]
 
 with open(hundred_yaml, 'r', encoding='utf8') as hy:
   hundred = yaml.safe_load(hy)
+with open(thousand_yaml, 'r', encoding='utf8') as hy:
+  thousand = yaml.safe_load(hy)
 with open(overview_yaml, 'r', encoding='utf8') as hy:
   overview = yaml.safe_load(hy)
 with open(undergrad_yaml, 'r', encoding='utf8') as hy:
   undergrad = yaml.safe_load(hy)
 
-hundred_decls:List[Tuple[str, str]] = []
+hundred_decls: List[Tuple[str, str]] = []
 
 for index, entry in hundred.items():
   title = entry['title']
@@ -58,6 +61,16 @@ for index, entry in hundred.items():
     if not isinstance(entry['decls'], list):
       raise ValueError(f"For key {index} ({title}): did you mean `decl` instead of `decls`?")
     hundred_decls = hundred_decls + [(f'{index} {title}', d) for d in entry['decls']]
+
+thousand_decls: List[Tuple[str, str]] = []
+for index, entry in thousand.items():
+  title = entry['title']
+  if 'decl' in entry:
+    thousand_decls.append((f'{index} {title}', entry['decl']))
+  elif 'decls' in entry:
+    if not isinstance(entry['decls'], list):
+      raise ValueError(f"For key {index} ({title}): did you mean `decl` instead of `decls`?")
+    thousand_decls = thousand_decls + [(f'{index} {title}', d) for d in entry['decls']]
 
 overview_decls = tiered_extract(overview)
 assert all(len(n) == 3 for n, _ in overview_decls)
@@ -69,6 +82,8 @@ undergrad_decls = flatten_names(undergrad_decls)
 
 with open('100.json', 'w', encoding='utf8') as f:
   json.dump(hundred_decls, f)
+with open('1000.json', 'w', encoding='utf8') as f:
+  json.dump(thousand_decls, f)
 with open('overview.json', 'w', encoding='utf8') as f:
   json.dump(overview_decls, f)
 with open('undergrad.json', 'w', encoding='utf8') as f:


### PR DESCRIPTION
Add a new file `1000.yaml`, tracking the formalisation status of theorems
from the [1000+ theorems project](https://1000-plus.github.io). Make `check-yaml` handle this file also.

Future PRs will
- expose this information on the webpage
- add infrastructure for synchronising this file with the upstream repository
- could add an attribute similar to the `stacks` attribute, and generate this file from the tagging
- add information on existing formalisation projects in Lean.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
