### PR TITLE
[Merged by Bors] - feat: differentiability of functions on manifolds  built by applying linear maps to a section of a vector bundle

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3084,6 +3084,7 @@ import Mathlib.Geometry.Manifold.SmoothManifoldWithCorners
 import Mathlib.Geometry.Manifold.VectorBundle.Basic
 import Mathlib.Geometry.Manifold.VectorBundle.FiberwiseLinear
 import Mathlib.Geometry.Manifold.VectorBundle.Hom
+import Mathlib.Geometry.Manifold.VectorBundle.MDifferentiable
 import Mathlib.Geometry.Manifold.VectorBundle.Pullback
 import Mathlib.Geometry.Manifold.VectorBundle.SmoothSection
 import Mathlib.Geometry.Manifold.VectorBundle.Tangent

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -105,7 +105,6 @@ lemma MDifferentiableWithinAt.clm_apply_of_inCoordinates
     (hb₂ : MDifferentiableWithinAt IM IB₂ b₂ s m₀) :
     MDifferentiableWithinAt IM (IB₂.prod 𝓘(𝕜, F₂))
       (fun m ↦ (ϕ m (v m) : TotalSpace F₂ E₂)) s m₀ := by
-  --rw [← mdifferentiableWithinAt_insert_self] at hϕ hv hb₂ ⊢
   rw [mdifferentiableWithinAt_totalSpace] at hv ⊢
   refine ⟨hb₂, ?_⟩
   apply (MDifferentiableWithinAt.clm_apply hϕ hv.2).congr_of_eventuallyEq_insert

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2024 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+-/
+import Mathlib.Geometry.Manifold.VectorBundle.Basic
+import Mathlib.Geometry.Manifold.MFDeriv.NormedSpace
+import Mathlib.Geometry.Manifold.MFDeriv.SpecificFunctions
+
+
+/-!
+# Differentiability of functions in vector bundles
+
+-/
+
+open Bundle Set PartialHomeomorph ContinuousLinearMap Pretrivialization Filter
+
+open scoped Manifold Bundle Topology
+
+section
+
+
+variable {𝕜 B B' F M : Type*} {E : B → Type*}
+
+variable [NontriviallyNormedField 𝕜] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  [TopologicalSpace (TotalSpace F E)] [∀ x, TopologicalSpace (E x)] {EB : Type*}
+  [NormedAddCommGroup EB] [NormedSpace 𝕜 EB] {HB : Type*} [TopologicalSpace HB]
+  (IB : ModelWithCorners 𝕜 EB HB) (E' : B → Type*) [∀ x, Zero (E' x)] {EM : Type*}
+  [NormedAddCommGroup EM] [NormedSpace 𝕜 EM] {HM : Type*} [TopologicalSpace HM]
+  {IM : ModelWithCorners 𝕜 EM HM} [TopologicalSpace M] [ChartedSpace HM M]
+  {n : ℕ∞}
+
+
+variable [TopologicalSpace B] [ChartedSpace HB B] [FiberBundle F E]
+
+/-- Characterization of differentiable functions into a smooth vector bundle. -/
+theorem mdifferentiableWithinAt_totalSpace (f : M → TotalSpace F E) {s : Set M} {x₀ : M} :
+    MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F)) f s x₀ ↔
+      MDifferentiableWithinAt IM IB (fun x => (f x).proj) s x₀ ∧
+      MDifferentiableWithinAt IM 𝓘(𝕜, F)
+        (fun x ↦ (trivializationAt F E (f x₀).proj (f x)).2) s x₀ := by
+  simp (config := { singlePass := true }) only [mdifferentiableWithinAt_iff_target]
+  rw [and_and_and_comm, ← FiberBundle.continuousWithinAt_totalSpace, and_congr_right_iff]
+  intro hf
+  simp_rw [modelWithCornersSelf_prod, FiberBundle.extChartAt, Function.comp_def,
+    PartialEquiv.trans_apply, PartialEquiv.prod_coe, PartialEquiv.refl_coe,
+    extChartAt_self_apply, modelWithCornersSelf_coe, Function.id_def, ← chartedSpaceSelf_prod]
+  refine (mdifferentiableWithinAt_prod_iff _).trans (and_congr ?_ Iff.rfl)
+  have h1 : (fun x => (f x).proj) ⁻¹' (trivializationAt F E (f x₀).proj).baseSet ∈ 𝓝[s] x₀ :=
+    ((FiberBundle.continuous_proj F E).continuousWithinAt.comp hf (mapsTo_image f s))
+      ((Trivialization.open_baseSet _).mem_nhds (mem_baseSet_trivializationAt F E _))
+  refine EventuallyEq.mdifferentiableWithinAt_iff (eventually_of_mem h1 fun x hx => ?_) ?_
+  · simp_rw [Function.comp, PartialHomeomorph.coe_coe, Trivialization.coe_coe]
+    rw [Trivialization.coe_fst']
+    exact hx
+  · simp only [mfld_simps]
+
+end
+
+
+section
+
+/- Declare two manifolds `B₁` and `B₂` (with models `IB₁ : HB₁ → EB₁` and `IB₂ : HB₂ → EB₂`),
+and two vector bundles `E₁` and `E₂` respectively over `B₁` and `B₂` (with model fibers
+`F₁` and `F₂`).
+
+Also a third manifold `M`, which will be the source of all our maps.
+-/
+variable {𝕜 F₁ F₂ B₁ B₂ M : Type*} {E₁ : B₁ → Type*} {E₂ : B₂ → Type*} [NontriviallyNormedField 𝕜]
+  [∀ x, AddCommGroup (E₁ x)] [∀ x, Module 𝕜 (E₁ x)] [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁]
+  [TopologicalSpace (TotalSpace F₁ E₁)] [∀ x, TopologicalSpace (E₁ x)] [∀ x, AddCommGroup (E₂ x)]
+  [∀ x, Module 𝕜 (E₂ x)] [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
+  [TopologicalSpace (TotalSpace F₂ E₂)] [∀ x, TopologicalSpace (E₂ x)]
+  {EB₁ : Type*}
+  [NormedAddCommGroup EB₁] [NormedSpace 𝕜 EB₁] {HB₁ : Type*} [TopologicalSpace HB₁]
+  {IB₁ : ModelWithCorners 𝕜 EB₁ HB₁} [TopologicalSpace B₁] [ChartedSpace HB₁ B₁]
+  {EB₂ : Type*}
+  [NormedAddCommGroup EB₂] [NormedSpace 𝕜 EB₂] {HB₂ : Type*} [TopologicalSpace HB₂]
+  {IB₂ : ModelWithCorners 𝕜 EB₂ HB₂} [TopologicalSpace B₂] [ChartedSpace HB₂ B₂]
+  {EM : Type*}
+  [NormedAddCommGroup EM] [NormedSpace 𝕜 EM] {HM : Type*} [TopologicalSpace HM]
+  {IM : ModelWithCorners 𝕜 EM HM} [TopologicalSpace M] [ChartedSpace HM M]
+  {n : ℕ∞} [FiberBundle F₁ E₁] [VectorBundle 𝕜 F₁ E₁]
+  [FiberBundle F₂ E₂] [VectorBundle 𝕜 F₂ E₂]
+  {b₁ : M → B₁} {b₂ : M → B₂} {m₀ : M}
+  {ϕ : Π (m : M), E₁ (b₁ m) →L[𝕜] E₂ (b₂ m)} {v : Π (m : M), E₁ (b₁ m)} {s : Set M}
+
+/-- Consider a smooth map `v : M → E₁` to a vector bundle, over a basemap `b₁ : M → B₁`, and
+another basemap `b₂ : M → B₂`. Given linear maps `ϕ m : E₁ (b₁ m) → E₂ (b₂ m)` depending smoothly
+on `m`, one can apply `ϕ m` to `g m`, and the resulting map is smooth.
+
+Note that the smoothness of `ϕ` can not be always be stated as smoothness of a map into a manifold,
+as the pullback bundles `b₁ *ᵖ E₁` and `b₂ *ᵖ E₂` only make sense when `b₁` and `b₂` are globally
+smooth, but we want to apply this lemma with only local information. Therefore, we formulate it
+using smoothness of `ϕ` read in coordinates.
+
+Version for `MDifferentiableWithinAt`. We also give a version for `MDifferentiableAt`, but no
+version for `MDifferentiableOn` or `MDifferentiable` as our assumption, written in coordinates,
+only makes sense around a point.
+ -/
+lemma MDifferentiableWithinAt.clm_apply_of_inCoordinates
+    (hϕ : MDifferentiableWithinAt IM 𝓘(𝕜, F₁ →L[𝕜] F₂)
+      (fun m ↦ inCoordinates F₁ E₁ F₂ E₂ (b₁ m₀) (b₁ m) (b₂ m₀) (b₂ m) (ϕ m)) s m₀)
+    (hv : MDifferentiableWithinAt IM (IB₁.prod 𝓘(𝕜, F₁)) (fun m ↦ (v m : TotalSpace F₁ E₁)) s m₀)
+    (hb₂ : MDifferentiableWithinAt IM IB₂ b₂ s m₀) :
+    MDifferentiableWithinAt IM (IB₂.prod 𝓘(𝕜, F₂))
+      (fun m ↦ (ϕ m (v m) : TotalSpace F₂ E₂)) s m₀ := by
+  --rw [← mdifferentiableWithinAt_insert_self] at hϕ hv hb₂ ⊢
+  rw [mdifferentiableWithinAt_totalSpace] at hv ⊢
+  refine ⟨hb₂, ?_⟩
+  apply (MDifferentiableWithinAt.clm_apply hϕ hv.2).congr_of_eventuallyEq_insert
+  have A : ∀ᶠ m in 𝓝[insert m₀ s] m₀, b₁ m ∈ (trivializationAt F₁ E₁ (b₁ m₀)).baseSet := by
+    apply hv.1.insert.continuousWithinAt
+    apply (trivializationAt F₁ E₁ (b₁ m₀)).open_baseSet.mem_nhds
+    exact FiberBundle.mem_baseSet_trivializationAt' (b₁ m₀)
+  have A' : ∀ᶠ m in 𝓝[insert m₀ s] m₀, b₂ m ∈ (trivializationAt F₂ E₂ (b₂ m₀)).baseSet := by
+    apply hb₂.insert.continuousWithinAt
+    apply (trivializationAt F₂ E₂ (b₂ m₀)).open_baseSet.mem_nhds
+    exact FiberBundle.mem_baseSet_trivializationAt' (b₂ m₀)
+  filter_upwards [A, A'] with m hm h'm
+  rw [inCoordinates_eq hm h'm]
+  simp only [coe_comp', ContinuousLinearEquiv.coe_coe, Trivialization.continuousLinearEquivAt_apply,
+    Trivialization.continuousLinearEquivAt_symm_apply, Function.comp_apply]
+  congr
+  rw [Trivialization.symm_apply_apply_mk (trivializationAt F₁ E₁ (b₁ m₀)) hm (v m)]
+
+/-- Consider a smooth map `v : M → E₁` to a vector bundle, over a basemap `b₁ : M → B₁`, and
+another basemap `b₂ : M → B₂`. Given linear maps `ϕ m : E₁ (b₁ m) → E₂ (b₂ m)` depending smoothly
+on `m`, one can apply `ϕ m` to `g m`, and the resulting map is smooth.
+
+Note that the smoothness of `ϕ` can not be always be stated as smoothness of a map into a manifold,
+as the pullback bundles `b₁ *ᵖ E₁` and `b₂ *ᵖ E₂` only make sense when `b₁` and `b₂` are globally
+smooth, but we want to apply this lemma with only local information. Therefore, we formulate it
+using smoothness of `ϕ` read in coordinates.
+
+Version for `MDifferentiableAt`. We also give a version for `MDifferentiableWithinAt`,
+but no version for `MDifferentiableOn` or `MDifferentiable` as our assumption, written
+in coordinates, only makes sense around a point.
+ -/
+lemma MDifferentiableAt.clm_apply_of_inCoordinates
+    (hϕ : MDifferentiableAt IM 𝓘(𝕜, F₁ →L[𝕜] F₂)
+      (fun m ↦ inCoordinates F₁ E₁ F₂ E₂ (b₁ m₀) (b₁ m) (b₂ m₀) (b₂ m) (ϕ m)) m₀)
+    (hv : MDifferentiableAt IM (IB₁.prod 𝓘(𝕜, F₁)) (fun m ↦ (v m : TotalSpace F₁ E₁)) m₀)
+    (hb₂ : MDifferentiableAt IM IB₂ b₂ m₀) :
+    MDifferentiableAt IM (IB₂.prod 𝓘(𝕜, F₂)) (fun m ↦ (ϕ m (v m) : TotalSpace F₂ E₂)) m₀ := by
+  rw [← mdifferentiableWithinAt_univ] at hϕ hv hb₂ ⊢
+  exact MDifferentiableWithinAt.clm_apply_of_inCoordinates hϕ hv hb₂
+
+end

--- a/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
@@ -300,6 +300,14 @@ end TangentBundleInstances
 
 /-! ## The tangent bundle to the model space -/
 
+@[simp, mfld_simps]
+theorem trivializationAt_model_space_apply (p : TangentBundle I H) (x : H) :
+    trivializationAt E (TangentSpace I) x p = (p.1, p.2) := by
+  simp [TangentBundle.trivializationAt_apply]
+  have : fderivWithin 𝕜 (↑I ∘ ↑I.symm) (range I) (I p.proj) =
+      fderivWithin 𝕜 id (range I) (I p.proj) :=
+    fderivWithin_congr' (fun y hy ↦ by simp [hy]) (mem_range_self p.proj)
+  simp [this, fderivWithin_id (ModelWithCorners.uniqueDiffWithinAt_image I)]
 
 /-- In the tangent bundle to the model space, the charts are just the canonical identification
 between a product type and a sigma type, a.k.a. `TotalSpace.toProd`. -/
@@ -336,7 +344,7 @@ theorem tangentBundleCore_coordChange_model_space (x x' z : H) :
 
 variable (I) in
 /-- The canonical identification between the tangent bundle to the model space and the product,
-as a homeomorphism -/
+as a homeomorphism. For the diffeomorphism version, see `tangentBundleModelSpaceDiffeomorph`. -/
 def tangentBundleModelSpaceHomeomorph : TangentBundle I H ≃ₜ ModelProd H E :=
   { TotalSpace.toProd H E with
     continuous_toFun := by
@@ -366,11 +374,83 @@ theorem tangentBundleModelSpaceHomeomorph_coe_symm :
       (TotalSpace.toProd H E).symm :=
   rfl
 
+theorem contMDiff_tangentBundleModelSpaceHomeomorph {n : ℕ∞} :
+    ContMDiff I.tangent (I.prod 𝓘(𝕜, E)) n
+    (tangentBundleModelSpaceHomeomorph I : TangentBundle I H → ModelProd H E) := by
+  apply contMDiff_iff.2 ⟨Homeomorph.continuous _, fun x y ↦ ?_⟩
+  apply contDiffOn_id.congr
+  simp only [mfld_simps, mem_range, TotalSpace.toProd, Equiv.coe_fn_symm_mk, forall_exists_index,
+    Prod.forall, Prod.mk.injEq]
+  rintro a b x rfl
+  simp [PartialEquiv.prod]
+
+theorem contMDiff_tangentBundleModelSpaceHomeomorph_symm {n : ℕ∞} :
+    ContMDiff (I.prod 𝓘(𝕜, E)) I.tangent n
+    ((tangentBundleModelSpaceHomeomorph I).symm : ModelProd H E → TangentBundle I H) := by
+  apply contMDiff_iff.2 ⟨Homeomorph.continuous _, fun x y ↦ ?_⟩
+  apply contDiffOn_id.congr
+  simp only [mfld_simps, mem_range, TotalSpace.toProd, Equiv.coe_fn_symm_mk, forall_exists_index,
+    Prod.forall, Prod.mk.injEq]
+  rintro a b x rfl
+  simp [PartialEquiv.prod]
+  exact ⟨rfl, rfl⟩
+
+variable (H I) in
+/-- In the tangent bundle to the model space, the second projection is smooth. -/
+lemma contMDiff_snd_tangentBundle_modelSpace {n : ℕ∞} :
+    ContMDiff I.tangent 𝓘(𝕜, E) n (fun (p : TangentBundle I H) ↦ p.2) := by
+  change ContMDiff I.tangent 𝓘(𝕜, E) n
+    ((id Prod.snd : ModelProd H E → E) ∘ (tangentBundleModelSpaceHomeomorph I))
+  apply ContMDiff.comp (I' := I.prod 𝓘(𝕜, E))
+  · convert contMDiff_snd
+    rw [chartedSpaceSelf_prod]
+    rfl
+  · exact contMDiff_tangentBundleModelSpaceHomeomorph
+
+/-- A vector field on a vector space is smooth in the manifold sense iff it is smoooth in the vector
+space sense-/
+lemma contMDiffWithinAt_vectorSpace_iff_contDiffWithinAt
+    {V : Π (x : E), TangentSpace 𝓘(𝕜, E) x} {n : ℕ∞} {s : Set E} {x : E} :
+    ContMDiffWithinAt 𝓘(𝕜, E) 𝓘(𝕜, E).tangent n (fun x ↦ (V x : TangentBundle 𝓘(𝕜, E) E)) s x ↔
+      ContDiffWithinAt 𝕜 n V s x := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · exact ContMDiffWithinAt.contDiffWithinAt <|
+      (contMDiff_snd_tangentBundle_modelSpace E 𝓘(𝕜, E)).contMDiffAt.comp_contMDiffWithinAt _ h
+  · apply (Bundle.contMDiffWithinAt_totalSpace _).2
+    refine ⟨contMDiffWithinAt_id, ?_⟩
+    convert h.contMDiffWithinAt with y
+    simp
+
+/-- A vector field on a vector space is smooth in the manifold sense iff it is smoooth in the vector
+space sense-/
+lemma contMDiffAt_vectorSpace_iff_contDiffAt
+    {V : Π (x : E), TangentSpace 𝓘(𝕜, E) x} {n : ℕ∞} {x : E} :
+    ContMDiffAt 𝓘(𝕜, E) 𝓘(𝕜, E).tangent n (fun x ↦ (V x : TangentBundle 𝓘(𝕜, E) E)) x ↔
+      ContDiffAt 𝕜 n V x := by
+  simp only [← contMDiffWithinAt_univ, ← contDiffWithinAt_univ,
+    contMDiffWithinAt_vectorSpace_iff_contDiffWithinAt]
+
+/-- A vector field on a vector space is smooth in the manifold sense iff it is smoooth in the vector
+space sense-/
+lemma contMDiffOn_vectorSpace_iff_contDiffOn
+    {V : Π (x : E), TangentSpace 𝓘(𝕜, E) x} {n : ℕ∞} {s : Set E} :
+    ContMDiffOn 𝓘(𝕜, E) 𝓘(𝕜, E).tangent n (fun x ↦ (V x : TangentBundle 𝓘(𝕜, E) E)) s ↔
+      ContDiffOn 𝕜 n V s := by
+  simp only [ContMDiffOn, ContDiffOn, contMDiffWithinAt_vectorSpace_iff_contDiffWithinAt ]
+
+/-- A vector field on a vector space is smooth in the manifold sense iff it is smoooth in the vector
+space sense-/
+lemma contMDiff_vectorSpace_iff_contDiff
+    {V : Π (x : E), TangentSpace 𝓘(𝕜, E) x} {n : ℕ∞} :
+    ContMDiff 𝓘(𝕜, E) 𝓘(𝕜, E).tangent n (fun x ↦ (V x : TangentBundle 𝓘(𝕜, E) E)) ↔
+      ContDiff 𝕜 n V := by
+  simp only [← contMDiffOn_univ, ← contDiffOn_univ, contMDiffOn_vectorSpace_iff_contDiffOn]
+
 section inTangentCoordinates
 
 variable {N : Type*}
 
-/-- The map `in_coordinates` for the tangent bundle is trivial on the model spaces -/
+/-- The map `inCoordinates` for the tangent bundle is trivial on the model spaces -/
 theorem inCoordinates_tangent_bundle_core_model_space (x₀ x : H) (y₀ y : H') (ϕ : E →L[𝕜] E') :
     inCoordinates E (TangentSpace I) E' (TangentSpace I') x₀ x y₀ y ϕ = ϕ := by
   erw [VectorBundleCore.inCoordinates_eq] <;> try trivial
@@ -397,6 +477,10 @@ theorem inTangentCoordinates_model_space (f : N → H) (g : N → H') (ϕ : N �
   simp (config := { unfoldPartialApp := true }) only [inTangentCoordinates,
     inCoordinates_tangent_bundle_core_model_space]
 
+/-- To write a linear map between tangent spaces in coordinates amounts to precomposing and
+postcomposing it with suitable coordinate changes. For a concrete version expressing the
+change of coordinates as derivatives of extended charts,
+see `inTangentCoordinates_eq_mfderiv_comp`. -/
 theorem inTangentCoordinates_eq (f : N → M) (g : N → M') (ϕ : N → E →L[𝕜] E') {x₀ x : N}
     (hx : f x ∈ (chartAt H (f x₀)).source) (hy : g x ∈ (chartAt H' (g x₀)).source) :
     inTangentCoordinates I I' f g ϕ x₀ x =

--- a/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
@@ -300,14 +300,6 @@ end TangentBundleInstances
 
 /-! ## The tangent bundle to the model space -/
 
-@[simp, mfld_simps]
-theorem trivializationAt_model_space_apply (p : TangentBundle I H) (x : H) :
-    trivializationAt E (TangentSpace I) x p = (p.1, p.2) := by
-  simp [TangentBundle.trivializationAt_apply]
-  have : fderivWithin 𝕜 (↑I ∘ ↑I.symm) (range I) (I p.proj) =
-      fderivWithin 𝕜 id (range I) (I p.proj) :=
-    fderivWithin_congr' (fun y hy ↦ by simp [hy]) (mem_range_self p.proj)
-  simp [this, fderivWithin_id (ModelWithCorners.uniqueDiffWithinAt_image I)]
 
 /-- In the tangent bundle to the model space, the charts are just the canonical identification
 between a product type and a sigma type, a.k.a. `TotalSpace.toProd`. -/
@@ -344,7 +336,7 @@ theorem tangentBundleCore_coordChange_model_space (x x' z : H) :
 
 variable (I) in
 /-- The canonical identification between the tangent bundle to the model space and the product,
-as a homeomorphism. For the diffeomorphism version, see `tangentBundleModelSpaceDiffeomorph`. -/
+as a homeomorphism -/
 def tangentBundleModelSpaceHomeomorph : TangentBundle I H ≃ₜ ModelProd H E :=
   { TotalSpace.toProd H E with
     continuous_toFun := by
@@ -374,83 +366,11 @@ theorem tangentBundleModelSpaceHomeomorph_coe_symm :
       (TotalSpace.toProd H E).symm :=
   rfl
 
-theorem contMDiff_tangentBundleModelSpaceHomeomorph {n : ℕ∞} :
-    ContMDiff I.tangent (I.prod 𝓘(𝕜, E)) n
-    (tangentBundleModelSpaceHomeomorph I : TangentBundle I H → ModelProd H E) := by
-  apply contMDiff_iff.2 ⟨Homeomorph.continuous _, fun x y ↦ ?_⟩
-  apply contDiffOn_id.congr
-  simp only [mfld_simps, mem_range, TotalSpace.toProd, Equiv.coe_fn_symm_mk, forall_exists_index,
-    Prod.forall, Prod.mk.injEq]
-  rintro a b x rfl
-  simp [PartialEquiv.prod]
-
-theorem contMDiff_tangentBundleModelSpaceHomeomorph_symm {n : ℕ∞} :
-    ContMDiff (I.prod 𝓘(𝕜, E)) I.tangent n
-    ((tangentBundleModelSpaceHomeomorph I).symm : ModelProd H E → TangentBundle I H) := by
-  apply contMDiff_iff.2 ⟨Homeomorph.continuous _, fun x y ↦ ?_⟩
-  apply contDiffOn_id.congr
-  simp only [mfld_simps, mem_range, TotalSpace.toProd, Equiv.coe_fn_symm_mk, forall_exists_index,
-    Prod.forall, Prod.mk.injEq]
-  rintro a b x rfl
-  simp [PartialEquiv.prod]
-  exact ⟨rfl, rfl⟩
-
-variable (H I) in
-/-- In the tangent bundle to the model space, the second projection is smooth. -/
-lemma contMDiff_snd_tangentBundle_modelSpace {n : ℕ∞} :
-    ContMDiff I.tangent 𝓘(𝕜, E) n (fun (p : TangentBundle I H) ↦ p.2) := by
-  change ContMDiff I.tangent 𝓘(𝕜, E) n
-    ((id Prod.snd : ModelProd H E → E) ∘ (tangentBundleModelSpaceHomeomorph I))
-  apply ContMDiff.comp (I' := I.prod 𝓘(𝕜, E))
-  · convert contMDiff_snd
-    rw [chartedSpaceSelf_prod]
-    rfl
-  · exact contMDiff_tangentBundleModelSpaceHomeomorph
-
-/-- A vector field on a vector space is smooth in the manifold sense iff it is smoooth in the vector
-space sense-/
-lemma contMDiffWithinAt_vectorSpace_iff_contDiffWithinAt
-    {V : Π (x : E), TangentSpace 𝓘(𝕜, E) x} {n : ℕ∞} {s : Set E} {x : E} :
-    ContMDiffWithinAt 𝓘(𝕜, E) 𝓘(𝕜, E).tangent n (fun x ↦ (V x : TangentBundle 𝓘(𝕜, E) E)) s x ↔
-      ContDiffWithinAt 𝕜 n V s x := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · exact ContMDiffWithinAt.contDiffWithinAt <|
-      (contMDiff_snd_tangentBundle_modelSpace E 𝓘(𝕜, E)).contMDiffAt.comp_contMDiffWithinAt _ h
-  · apply (Bundle.contMDiffWithinAt_totalSpace _).2
-    refine ⟨contMDiffWithinAt_id, ?_⟩
-    convert h.contMDiffWithinAt with y
-    simp
-
-/-- A vector field on a vector space is smooth in the manifold sense iff it is smoooth in the vector
-space sense-/
-lemma contMDiffAt_vectorSpace_iff_contDiffAt
-    {V : Π (x : E), TangentSpace 𝓘(𝕜, E) x} {n : ℕ∞} {x : E} :
-    ContMDiffAt 𝓘(𝕜, E) 𝓘(𝕜, E).tangent n (fun x ↦ (V x : TangentBundle 𝓘(𝕜, E) E)) x ↔
-      ContDiffAt 𝕜 n V x := by
-  simp only [← contMDiffWithinAt_univ, ← contDiffWithinAt_univ,
-    contMDiffWithinAt_vectorSpace_iff_contDiffWithinAt]
-
-/-- A vector field on a vector space is smooth in the manifold sense iff it is smoooth in the vector
-space sense-/
-lemma contMDiffOn_vectorSpace_iff_contDiffOn
-    {V : Π (x : E), TangentSpace 𝓘(𝕜, E) x} {n : ℕ∞} {s : Set E} :
-    ContMDiffOn 𝓘(𝕜, E) 𝓘(𝕜, E).tangent n (fun x ↦ (V x : TangentBundle 𝓘(𝕜, E) E)) s ↔
-      ContDiffOn 𝕜 n V s := by
-  simp only [ContMDiffOn, ContDiffOn, contMDiffWithinAt_vectorSpace_iff_contDiffWithinAt ]
-
-/-- A vector field on a vector space is smooth in the manifold sense iff it is smoooth in the vector
-space sense-/
-lemma contMDiff_vectorSpace_iff_contDiff
-    {V : Π (x : E), TangentSpace 𝓘(𝕜, E) x} {n : ℕ∞} :
-    ContMDiff 𝓘(𝕜, E) 𝓘(𝕜, E).tangent n (fun x ↦ (V x : TangentBundle 𝓘(𝕜, E) E)) ↔
-      ContDiff 𝕜 n V := by
-  simp only [← contMDiffOn_univ, ← contDiffOn_univ, contMDiffOn_vectorSpace_iff_contDiffOn]
-
 section inTangentCoordinates
 
 variable {N : Type*}
 
-/-- The map `inCoordinates` for the tangent bundle is trivial on the model spaces -/
+/-- The map `in_coordinates` for the tangent bundle is trivial on the model spaces -/
 theorem inCoordinates_tangent_bundle_core_model_space (x₀ x : H) (y₀ y : H') (ϕ : E →L[𝕜] E') :
     inCoordinates E (TangentSpace I) E' (TangentSpace I') x₀ x y₀ y ϕ = ϕ := by
   erw [VectorBundleCore.inCoordinates_eq] <;> try trivial
@@ -477,10 +397,6 @@ theorem inTangentCoordinates_model_space (f : N → H) (g : N → H') (ϕ : N �
   simp (config := { unfoldPartialApp := true }) only [inTangentCoordinates,
     inCoordinates_tangent_bundle_core_model_space]
 
-/-- To write a linear map between tangent spaces in coordinates amounts to precomposing and
-postcomposing it with suitable coordinate changes. For a concrete version expressing the
-change of coordinates as derivatives of extended charts,
-see `inTangentCoordinates_eq_mfderiv_comp`. -/
 theorem inTangentCoordinates_eq (f : N → M) (g : N → M') (ϕ : N → E →L[𝕜] E') {x₀ x : N}
     (hx : f x ∈ (chartAt H (f x₀)).source) (hy : g x ∈ (chartAt H' (g x₀)).source) :
     inTangentCoordinates I I' f g ϕ x₀ x =


### PR DESCRIPTION
We already have the same kind of statement for higher smoothness, but not for mere differentiability.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
