### PR TITLE
[Merged by Bors] - chore: don't import conformal maps in Behrend's construction

### DIFF
--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Analysis.Complex.CauchyIntegral
-import Mathlib.Analysis.Normed.Module.Completion
 import Mathlib.Analysis.NormedSpace.Extr
+import Mathlib.Data.Complex.FiniteDimensional
 import Mathlib.Topology.Order.ExtrClosure
 
 /-!

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -8,6 +8,7 @@ import Mathlib.Analysis.Calculus.DiffContOnCl
 import Mathlib.Analysis.Calculus.DSlope
 import Mathlib.Analysis.Calculus.FDeriv.Analytic
 import Mathlib.Analysis.Complex.ReImTopology
+import Mathlib.Data.Real.Cardinality
 import Mathlib.MeasureTheory.Integral.CircleIntegral
 import Mathlib.MeasureTheory.Integral.DivergenceTheorem
 import Mathlib.MeasureTheory.Measure.Lebesgue.Complex

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -3,8 +3,11 @@ Copyright (c) 2021 Yourong Zang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yourong Zang
 -/
+import Mathlib.Analysis.Calculus.Conformal.NormedSpace
+import Mathlib.Analysis.Calculus.Deriv.Basic
+import Mathlib.Analysis.Calculus.FDeriv.Equiv
+import Mathlib.Analysis.Calculus.FDeriv.RestrictScalars
 import Mathlib.Analysis.Complex.Isometry
-import Mathlib.Analysis.NormedSpace.ConformalLinearMap
 import Mathlib.Analysis.Normed.Module.FiniteDimension
 import Mathlib.Data.Complex.FiniteDimensional
 
@@ -25,10 +28,24 @@ to be conformal.
                                                   linear or the composition of
                                                   some complex linear map and `conj`.
 
+* `DifferentiableAt.conformalAt` states that a real-differentiable function with a nonvanishing
+  differential from the complex plane into an arbitrary complex-normed space is conformal at a point
+  if it's holomorphic at that point. This is a version of Cauchy-Riemann equations.
+
+* `conformalAt_iff_differentiableAt_or_differentiableAt_comp_conj` proves that a real-differential
+  function with a nonvanishing differential between the complex plane is conformal at a point if and
+  only if it's holomorphic or antiholomorphic at that point.
+
 ## Warning
 
 Antiholomorphic functions such as the complex conjugate are considered as conformal functions in
 this file.
+
+## TODO
+
+* The classical form of Cauchy-Riemann equations
+* On a connected open set `u`, a function which is `ConformalAt` each point is either holomorphic
+throughout or antiholomorphic throughout.
 -/
 
 
@@ -109,3 +126,37 @@ theorem isConformalMap_iff_is_complex_or_conj_linear :
       simp only [w, restrictScalars_zero, zero_comp]
 
 end ConformalIntoComplexPlane
+
+/-! ### Conformality of real-differentiable complex maps -/
+
+section Conformality
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] {z : ℂ} {f : ℂ → E}
+
+/-- A real differentiable function of the complex plane into some complex normed space `E` is
+conformal at a point `z` if it is holomorphic at that point with a nonvanishing differential.
+This is a version of the Cauchy-Riemann equations. -/
+theorem DifferentiableAt.conformalAt (h : DifferentiableAt ℂ f z) (hf' : deriv f z ≠ 0) :
+    ConformalAt f z := by
+  rw [conformalAt_iff_isConformalMap_fderiv, (h.hasFDerivAt.restrictScalars ℝ).fderiv]
+  apply isConformalMap_complex_linear
+  simpa only [Ne, ContinuousLinearMap.ext_ring_iff]
+
+/-- A complex function is conformal if and only if the function is holomorphic or antiholomorphic
+with a nonvanishing differential. -/
+theorem conformalAt_iff_differentiableAt_or_differentiableAt_comp_conj {f : ℂ → ℂ} {z : ℂ} :
+    ConformalAt f z ↔
+      (DifferentiableAt ℂ f z ∨ DifferentiableAt ℂ (f ∘ conj) (conj z)) ∧ fderiv ℝ f z ≠ 0 := by
+  rw [conformalAt_iff_isConformalMap_fderiv]
+  rw [isConformalMap_iff_is_complex_or_conj_linear]
+  apply and_congr_left
+  intro h
+  have h_diff := h.imp_symm fderiv_zero_of_not_differentiableAt
+  apply or_congr
+  · rw [differentiableAt_iff_restrictScalars ℝ h_diff]
+  rw [← conj_conj z] at h_diff
+  rw [differentiableAt_iff_restrictScalars ℝ (h_diff.comp _ conjCLE.differentiableAt)]
+  refine exists_congr fun g => rfl.congr ?_
+  have : fderiv ℝ conj (conj z) = _ := conjCLE.fderiv
+  simp [fderiv_comp _ h_diff conjCLE.differentiableAt, this, conj_conj]
+
+end Conformality

--- a/Mathlib/Analysis/Complex/RealDeriv.lean
+++ b/Mathlib/Analysis/Complex/RealDeriv.lean
@@ -5,34 +5,17 @@ Authors: Sébastien Gouëzel, Yourong Zang
 -/
 import Mathlib.Analysis.Calculus.ContDiff.Basic
 import Mathlib.Analysis.Calculus.Deriv.Linear
-import Mathlib.Analysis.Complex.Conformal
-import Mathlib.Analysis.Calculus.Conformal.NormedSpace
+import Mathlib.Analysis.Complex.Basic
 
 /-! # Real differentiability of complex-differentiable functions
 
 `HasDerivAt.real_of_complex` expresses that, if a function on `ℂ` is differentiable (over `ℂ`),
 then its restriction to `ℝ` is differentiable over `ℝ`, with derivative the real part of the
 complex derivative.
-
-`DifferentiableAt.conformalAt` states that a real-differentiable function with a nonvanishing
-differential from the complex plane into an arbitrary complex-normed space is conformal at a point
-if it's holomorphic at that point. This is a version of Cauchy-Riemann equations.
-
-`conformalAt_iff_differentiableAt_or_differentiableAt_comp_conj` proves that a real-differential
-function with a nonvanishing differential between the complex plane is conformal at a point if and
-only if it's holomorphic or antiholomorphic at that point.
-
-## TODO
-
-* The classical form of Cauchy-Riemann equations
-* On a connected open set `u`, a function which is `ConformalAt` each point is either holomorphic
-throughout or antiholomorphic throughout.
-
-## Warning
-
-We do NOT require conformal functions to be orientation-preserving in this file.
 -/
 
+assert_not_exists IsConformalMap
+assert_not_exists Conformal
 
 section RealDerivOfComplex
 
@@ -131,42 +114,3 @@ theorem HasDerivAt.ofReal_comp {f : ℝ → ℝ} {u : ℝ} (hf : HasDerivAt f u 
     ofRealCLM.hasDerivAt.scomp z hf
 
 end RealDerivOfComplex
-
-section Conformality
-
-/-! ### Conformality of real-differentiable complex maps -/
-
-open Complex ContinuousLinearMap
-
-open scoped ComplexConjugate
-
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] {z : ℂ} {f : ℂ → E}
-
-/-- A real differentiable function of the complex plane into some complex normed space `E` is
-    conformal at a point `z` if it is holomorphic at that point with a nonvanishing differential.
-    This is a version of the Cauchy-Riemann equations. -/
-theorem DifferentiableAt.conformalAt (h : DifferentiableAt ℂ f z) (hf' : deriv f z ≠ 0) :
-    ConformalAt f z := by
-  rw [conformalAt_iff_isConformalMap_fderiv, (h.hasFDerivAt.restrictScalars ℝ).fderiv]
-  apply isConformalMap_complex_linear
-  simpa only [Ne, ContinuousLinearMap.ext_ring_iff]
-
-/-- A complex function is conformal if and only if the function is holomorphic or antiholomorphic
-    with a nonvanishing differential. -/
-theorem conformalAt_iff_differentiableAt_or_differentiableAt_comp_conj {f : ℂ → ℂ} {z : ℂ} :
-    ConformalAt f z ↔
-      (DifferentiableAt ℂ f z ∨ DifferentiableAt ℂ (f ∘ conj) (conj z)) ∧ fderiv ℝ f z ≠ 0 := by
-  rw [conformalAt_iff_isConformalMap_fderiv]
-  rw [isConformalMap_iff_is_complex_or_conj_linear]
-  apply and_congr_left
-  intro h
-  have h_diff := h.imp_symm fderiv_zero_of_not_differentiableAt
-  apply or_congr
-  · rw [differentiableAt_iff_restrictScalars ℝ h_diff]
-  rw [← conj_conj z] at h_diff
-  rw [differentiableAt_iff_restrictScalars ℝ (h_diff.comp _ conjCLE.differentiableAt)]
-  refine exists_congr fun g => rfl.congr ?_
-  have : fderiv ℝ conj (conj z) = _ := conjCLE.fderiv
-  simp [fderiv_comp _ h_diff conjCLE.differentiableAt, this, conj_conj]
-
-end Conformality

--- a/Mathlib/Analysis/SpecialFunctions/Complex/LogDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/LogDeriv.lean
@@ -13,6 +13,8 @@ import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 
 -/
 
+assert_not_exists IsConformalMap
+assert_not_exists Conformal
 
 open Set Filter
 

--- a/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
@@ -3,10 +3,10 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne
 -/
-import Mathlib.Analysis.Complex.RealDeriv
 import Mathlib.Analysis.Calculus.ContDiff.RCLike
-import Mathlib.Analysis.Calculus.FDeriv.Analytic
 import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
+import Mathlib.Analysis.Complex.RealDeriv
+import Mathlib.Analysis.SpecialFunctions.Exp
 import Mathlib.Analysis.SpecialFunctions.Exponential
 
 /-!
@@ -18,6 +18,9 @@ In this file we prove that `Complex.exp` and `Real.exp` are infinitely smooth fu
 
 exp, derivative
 -/
+
+assert_not_exists IsConformalMap
+assert_not_exists Conformal
 
 noncomputable section
 

--- a/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
@@ -42,6 +42,9 @@ integer points on that sphere and map them onto `ℕ` in a way that preserves ar
 3AP-free, Salem-Spencer, Behrend construction, arithmetic progression, sphere, strictly convex
 -/
 
+assert_not_exists IsConformalMap
+assert_not_exists Conformal
+
 open Nat hiding log
 open Finset Metric Real
 open scoped Pointwise

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -4,10 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Heather Macbeth
 -/
 import Mathlib.Analysis.Calculus.Deriv.Inv
+import Mathlib.Analysis.Complex.Circle
 import Mathlib.Analysis.NormedSpace.BallAction
 import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 import Mathlib.Analysis.InnerProductSpace.Calculus
 import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Data.Complex.FiniteDimensional
 import Mathlib.Geometry.Manifold.Algebra.LieGroup
 import Mathlib.Geometry.Manifold.Instances.Real
 import Mathlib.Geometry.Manifold.MFDeriv.Basic

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -3,10 +3,11 @@ Copyright (c) 2023 Xavier Roblot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Xavier Roblot
 -/
+import Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup
+import Mathlib.Data.Complex.FiniteDimensional
 import Mathlib.MeasureTheory.Constructions.HaarToSphere
 import Mathlib.MeasureTheory.Integral.Gamma
 import Mathlib.MeasureTheory.Integral.Pi
-import Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup
 
 /-!
 # Volume of balls

--- a/Mathlib/NumberTheory/EulerProduct/ExpLog.lean
+++ b/Mathlib/NumberTheory/EulerProduct/ExpLog.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
 import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
+import Mathlib.Data.Complex.FiniteDimensional
 import Mathlib.NumberTheory.EulerProduct.Basic
 
 /-!

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/TwoVariable.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/TwoVariable.lean
@@ -3,9 +3,10 @@ Copyright (c) 2023 David Loeffler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Loeffler
 -/
-import Mathlib.Analysis.SpecialFunctions.Gaussian.PoissonSummation
 import Mathlib.Analysis.Calculus.SmoothSeries
 import Mathlib.Analysis.NormedSpace.OperatorNorm.Prod
+import Mathlib.Analysis.SpecialFunctions.Gaussian.PoissonSummation
+import Mathlib.Data.Complex.FiniteDimensional
 
 /-!
 # The two-variable Jacobi theta function


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
