### PR TITLE
[Merged by Bors] - feat(Algebra/Algebra/Subalgebra/Basic): add `AlgHom.subalgebraMap`

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -948,9 +948,7 @@ variable {S} in
 theorem _root_.AlgHom.subalgebraMap_coe_apply (x : S) : f.subalgebraMap S x = f x := rfl
 
 theorem _root_.AlgHom.subalgebraMap_surjective : Function.Surjective (f.subalgebraMap S) := by
-  simp only [AlgHom.subalgebraMap, AlgEquiv.toAlgHom_eq_coe, AlgHom.coe_comp, AlgHom.coe_coe,
-    EquivLike.comp_surjective]
-  exact AlgHom.rangeRestrict_surjective _
+  simpa [AlgHom.subalgebraMap] using (f.comp S.val).rangeRestrict_surjective
 
 variable (hf : Function.Injective f)
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -941,14 +941,14 @@ theorem range_comp_val : (f.comp S.val).range = S.map f := by
 /-- An `AlgHom` between two rings restricts to an `AlgHom` from any subalgebra of the
 domain onto the image of that subalgebra. -/
 def _root_.AlgHom.subalgebraMap : S →ₐ[R] S.map f :=
-  (equivOfEq _ _ (range_comp_val S f)).toAlgHom.comp (f.comp S.val).rangeRestrict
+  (f.comp S.val).codRestrict _ fun x ↦ ⟨_, x.2, rfl⟩
 
 variable {S} in
 @[simp]
 theorem _root_.AlgHom.subalgebraMap_coe_apply (x : S) : f.subalgebraMap S x = f x := rfl
 
-theorem _root_.AlgHom.subalgebraMap_surjective : Function.Surjective (f.subalgebraMap S) := by
-  simpa [AlgHom.subalgebraMap] using (f.comp S.val).rangeRestrict_surjective
+theorem _root_.AlgHom.subalgebraMap_surjective : Function.Surjective (f.subalgebraMap S) :=
+  f.toAddMonoidHom.addSubmonoidMap_surjective S.toAddSubmonoid
 
 variable (hf : Function.Injective f)
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -938,6 +938,20 @@ variable (f : A →ₐ[R] B)
 theorem range_comp_val : (f.comp S.val).range = S.map f := by
   rw [AlgHom.range_comp, range_val]
 
+/-- An `AlgHom` between two rings restricts to an `AlgHom` from any subalgebra of the
+domain onto the image of that subalgebra. -/
+def _root_.AlgHom.subalgebraMap : S →ₐ[R] S.map f :=
+  (equivOfEq _ _ (range_comp_val S f)).toAlgHom.comp (f.comp S.val).rangeRestrict
+
+variable {S} in
+@[simp]
+theorem _root_.AlgHom.subalgebraMap_coe_apply (x : S) : f.subalgebraMap S x = f x := rfl
+
+theorem _root_.AlgHom.subalgebraMap_surjective : Function.Surjective (f.subalgebraMap S) := by
+  simp only [AlgHom.subalgebraMap, AlgEquiv.toAlgHom_eq_coe, AlgHom.coe_comp, AlgHom.coe_coe,
+    EquivLike.comp_surjective]
+  exact AlgHom.rangeRestrict_surjective _
+
 variable (hf : Function.Injective f)
 
 /-- A subalgebra is isomorphic to its image under an injective `AlgHom` -/


### PR DESCRIPTION
which is parallel to `LinearMap.submoduleMap`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

(easy?)