### PR TITLE
[Merged by Bors] - fix(FieldTheory/AlgebraicClosure): `algebraicClosure.AlgEquiv.algebraicClosure` -> `AlgEquiv.algebraicClosure`

### DIFF
--- a/Mathlib/FieldTheory/AlgebraicClosure.lean
+++ b/Mathlib/FieldTheory/AlgebraicClosure.lean
@@ -94,7 +94,7 @@ def algEquivOfAlgEquiv (i : E ≃ₐ[F] K) :
     algebraicClosure F E ≃ₐ[F] algebraicClosure F K :=
   (intermediateFieldMap i _).trans (equivOfEq (map_eq_of_algEquiv i))
 
-alias AlgEquiv.algebraicClosure := algebraicClosure.algEquivOfAlgEquiv
+alias _root_.AlgEquiv.algebraicClosure := algEquivOfAlgEquiv
 
 variable (F E K)
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

See https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/AlgebraicClosure.html#algebraicClosure.AlgEquiv.algebraicClosure. I remembered that `_root_` is not needed before?