### PR TITLE
[Merged by Bors] - feat(NumberTheory/NumberField/Completion): API for `InfinitePlace ℚ`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Completion.lean
+++ b/Mathlib/NumberTheory/NumberField/Completion.lean
@@ -70,8 +70,24 @@ instance : NormedField v.completion :=
   letI := (WithAbs.isUniformInducing_of_comp v.norm_embedding_eq).completableTopField
   UniformSpace.Completion.instNormedFieldOfCompletableTopField (WithAbs v.1)
 
+lemma norm_coe (x : WithAbs v.1) :
+    ‖(x : v.completion)‖ = v (WithAbs.equiv v.1 x) :=
+  UniformSpace.Completion.norm_coe x
+
 instance : Algebra K v.completion :=
   inferInstanceAs <| Algebra (WithAbs v.1) v.1.completion
+
+/-- The coercion from the rationals to its completion along an infinite place is `Rat.cast`. -/
+lemma WithAbs.ratCast_equiv (v : InfinitePlace ℚ) (x : WithAbs v.1) :
+    Rat.cast (WithAbs.equiv _ x) = (x : v.completion) :=
+  (eq_ratCast (UniformSpace.Completion.coeRingHom.comp
+    (WithAbs.ringEquiv v.1).symm.toRingHom) x).symm
+
+lemma Rat.norm_infinitePlace_completion (v : InfinitePlace ℚ) (x : ℚ) :
+    ‖(x : v.completion)‖ = |x| := by
+  rw [← (WithAbs.equiv v.1).apply_symm_apply x, WithAbs.ratCast_equiv,
+    norm_coe, (WithAbs.equiv v.1).apply_symm_apply,
+    Rat.infinitePlace_apply]
 
 /-- The completion of a number field at an infinite place is locally compact. -/
 instance locallyCompactSpace : LocallyCompactSpace (v.completion) :=

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -1087,14 +1087,13 @@ open NumberField
 /-- The infinite place of `ℚ`, coming from the canonical map `ℚ → ℂ`. -/
 noncomputable def infinitePlace : InfinitePlace ℚ := .mk (Rat.castHom _)
 
+@[simp]
 lemma infinitePlace_apply (v : InfinitePlace ℚ) (x : ℚ) : v x = |x| := by
   rw [NumberField.InfinitePlace.coe_apply]
   obtain ⟨_, _, rfl⟩ := v
   simp
 
 instance : Subsingleton (InfinitePlace ℚ) where
-  allEq a b := by
-    ext
-    simp [infinitePlace_apply]
+  allEq a b := by ext; simp
 
 end Rat

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -259,6 +259,9 @@ instance {K : Type*} [Field K] : FunLike (InfinitePlace K) K ℝ where
   coe w x := w.1 x
   coe_injective' _ _ h := Subtype.eq (AbsoluteValue.ext fun x => congr_fun h x)
 
+lemma coe_apply {K : Type*} [Field K] (v : InfinitePlace K) (x : K) :
+  v x = v.1 x := rfl
+
 instance : MonoidWithZeroHomClass (InfinitePlace K) K ℝ where
   map_mul w _ _ := w.1.map_mul _ _
   map_one w := w.1.map_one
@@ -1066,3 +1069,29 @@ theorem nrRealPlaces_eq_zero_of_two_lt (hk : 2 < k) (hζ : IsPrimitiveRoot ζ k)
     linarith
 
 end IsPrimitiveRoot
+
+/-!
+
+## The infinite place of the rationals.
+
+-/
+
+namespace Rat
+
+open NumberField
+
+noncomputable def infinitePlace : InfinitePlace ℚ := .mk (Rat.castHom _)
+
+instance : Subsingleton (InfinitePlace ℚ) where
+  allEq a b := Subtype.ext <| by
+    obtain ⟨_, _, rfl⟩ := a
+    obtain ⟨_, _, rfl⟩ := b
+    ext
+    simp
+
+lemma infinitePlace_apply (v : InfinitePlace ℚ) (x : ℚ) : v x = |x| := by
+  rw [NumberField.InfinitePlace.coe_apply]
+  obtain ⟨_, _, rfl⟩ := v
+  simp
+
+end Rat

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -262,6 +262,10 @@ instance {K : Type*} [Field K] : FunLike (InfinitePlace K) K ℝ where
 lemma coe_apply {K : Type*} [Field K] (v : InfinitePlace K) (x : K) :
   v x = v.1 x := rfl
 
+@[ext]
+lemma ext {K : Type*} [Field K] (v₁ v₂ : InfinitePlace K) (h : ∀ k, v₁ k = v₂ k) : v₁ = v₂ :=
+  Subtype.ext <| AbsoluteValue.ext h
+
 instance : MonoidWithZeroHomClass (InfinitePlace K) K ℝ where
   map_mul w _ _ := w.1.map_mul _ _
   map_one w := w.1.map_one
@@ -1083,16 +1087,14 @@ open NumberField
 /-- The infinite place of `ℚ`, coming from the canonical map `ℚ → ℂ`. -/
 noncomputable def infinitePlace : InfinitePlace ℚ := .mk (Rat.castHom _)
 
-instance : Subsingleton (InfinitePlace ℚ) where
-  allEq a b := Subtype.ext <| by
-    obtain ⟨_, _, rfl⟩ := a
-    obtain ⟨_, _, rfl⟩ := b
-    ext
-    simp
-
 lemma infinitePlace_apply (v : InfinitePlace ℚ) (x : ℚ) : v x = |x| := by
   rw [NumberField.InfinitePlace.coe_apply]
   obtain ⟨_, _, rfl⟩ := v
   simp
+
+instance : Subsingleton (InfinitePlace ℚ) where
+  allEq a b := by
+    ext
+    simp [infinitePlace_apply]
 
 end Rat

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -1080,6 +1080,7 @@ namespace Rat
 
 open NumberField
 
+/-- The infinite place of `ℚ`, coming from the canonical map `ℚ → ℂ`. -/
 noncomputable def infinitePlace : InfinitePlace ℚ := .mk (Rat.castHom _)
 
 instance : Subsingleton (InfinitePlace ℚ) where


### PR DESCRIPTION
From the FLT project.

When trying to do some calculations on adeles for FLT I realised that the completion of `ℚ` at its infinite place was not equal to `ℝ` and moreover we basically knew nothing about it. After this PR we at least know which rationals are in its open unit ball (which was what I needed). 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
