### PR TITLE
[Merged by Bors] - feat: roots have non-zero length wrt the canonical form of a finite crystallographic root pairing

### DIFF
--- a/Mathlib/LinearAlgebra/PerfectPairing.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing.lean
@@ -165,6 +165,23 @@ include p in
 theorem reflexive_right : IsReflexive R N :=
   p.flip.reflexive_left
 
+instance : EquivLike (PerfectPairing R M N) M (Dual R N) where
+  coe p := p.toDualLeft
+  inv p := p.toDualLeft.symm
+  left_inv p x := LinearEquiv.symm_apply_apply _ _
+  right_inv p x := LinearEquiv.apply_symm_apply _ _
+  coe_injective' p q h h' := by
+    cases p
+    cases q
+    simp only [mk.injEq]
+    ext m n
+    simp only [DFunLike.coe_fn_eq] at h
+    exact LinearMap.congr_fun (LinearEquiv.congr_fun h m) n
+
+instance : LinearEquivClass (PerfectPairing R M N) R M (Dual R N) where
+  map_add p m₁ m₂ := p.toLin.map_add m₁ m₂
+  map_smulₛₗ p t m := p.toLin.map_smul t m
+
 include p in
 theorem finrank_eq [Module.Finite R M] [Module.Free R M] :
     finrank R M = finrank R N :=

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -161,7 +161,8 @@ private lemma coroot_eq_coreflection_of_root_eq' [CharZero R] [NoZeroSMulDivisor
   rw [← hl]
   have hkl : (p.flip (coroot l)) (root k) = 2 := by
     simp only [hl, preReflection_apply, hk, PerfectPairing.flip_apply_apply, map_sub, hp j,
-      map_smul, smul_eq_mul, hp i, mul_sub, sα, α, α', β, mul_two, mul_add]
+      map_smul, smul_eq_mul, hp i, mul_sub, sα, α, α', β, mul_two, mul_add, LinearMap.sub_apply,
+      LinearMap.smul_apply]
     rw [mul_comm (p (root i) (coroot j))]
     abel
   suffices p.flip (coroot k) = p.flip (coroot l) from p.bijectiveRight.injective this

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -359,6 +359,12 @@ lemma isCrystallographic_iff :
   · simpa [AddSubgroup.mem_zmultiples_iff] using h i (mem_range_self j)
   · simpa [← hj, AddSubgroup.mem_zmultiples_iff] using h i j
 
+variable {P} in
+lemma IsCrystallographic.flip (h : P.IsCrystallographic) :
+    P.flip.IsCrystallographic := by
+  rw [isCrystallographic_iff, forall_comm]
+  exact P.isCrystallographic_iff.mp h
+
 /-- A root pairing is said to be reduced if any linearly dependent pair of roots is related by a
 sign. -/
 def IsReduced : Prop :=

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -91,8 +91,32 @@ def CorootForm : LinearMap.BilinForm R N :=
   ∑ i, (P.root' i).smulRight (P.root' i)
 
 lemma rootForm_apply_apply (x y : M) : P.RootForm x y =
-    ∑ (i : ι), P.coroot' i x * P.coroot' i y := by
+    ∑ i, P.coroot' i x * P.coroot' i y := by
   simp [RootForm]
+
+lemma corootForm_apply_apply (x y : N) : P.CorootForm x y =
+    ∑ i, P.root' i x * P.root' i y := by
+  simp [CorootForm]
+
+lemma flip_comp_polarization_eq_rootForm :
+    P.flip.toLin ∘ₗ P.Polarization = P.RootForm := by
+  ext; simp [rootForm_apply_apply, RootPairing.flip]
+
+lemma self_comp_coPolarization_eq_corootForm :
+    P.toLin ∘ₗ P.CoPolarization = P.CorootForm := by
+  ext; simp [corootForm_apply_apply]
+
+lemma polarization_apply_eq_zero_iff (m : M) :
+    P.Polarization m = 0 ↔ P.RootForm m = 0 := by
+  rw [← flip_comp_polarization_eq_rootForm]
+  refine ⟨fun h ↦ by simp [h], fun h ↦ ?_⟩
+  change P.toDualRight (P.Polarization m) = 0 at h
+  simp only [EmbeddingLike.map_eq_zero_iff] at h
+  exact h
+
+lemma coPolarization_apply_eq_zero_iff (n : N) :
+    P.CoPolarization n = 0 ↔ P.CorootForm n = 0 :=
+  P.flip.polarization_apply_eq_zero_iff n
 
 lemma rootForm_symmetric :
     LinearMap.IsSymm P.RootForm := by
@@ -157,7 +181,12 @@ lemma prod_rootForm_smul_coroot_mem_range_domRestrict (i : ι) :
   use ⟨(c • 2 • P.root i), by aesop⟩
   simp
 
-lemma rootForm_apply_root_self_ne_zero [CharZero R] (h : P.IsCrystallographic) (i : ι) :
+section IsCrystallographic
+
+variable [CharZero R] (h : P.IsCrystallographic) (i : ι)
+include h
+
+lemma rootForm_apply_root_self_ne_zero :
     P.RootForm (P.root i) (P.root i) ≠ 0 := by
   choose z hz using P.isCrystallographic_iff.mp h i
   simp only [rootForm_apply_apply, PerfectPairing.flip_apply_apply, root_coroot_eq_pairing, ← hz]
@@ -168,6 +197,12 @@ lemma rootForm_apply_root_self_ne_zero [CharZero R] (h : P.IsCrystallographic) (
     rw [pairing_same] at hz
     norm_cast at hz
   simp [hzi]
+
+lemma corootForm_apply_coroot_self_ne_zero :
+    P.CorootForm (P.coroot i) (P.coroot i) ≠ 0 :=
+  P.flip.rootForm_apply_root_self_ne_zero h.flip i
+
+end IsCrystallographic
 
 end CommRing
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -53,16 +53,12 @@ namespace RootPairing
 variable {ι R M N : Type*}
 
 variable [Fintype ι] [LinearOrderedCommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N]
-[Module R N] (P : RootPairing ι R M N)
+  [Module R N] (P : RootPairing ι R M N)
 
 lemma rootForm_rootPositive : IsRootPositive P P.RootForm where
   zero_lt_apply_root i := P.rootForm_root_self_pos i
   symm := P.rootForm_symmetric
   apply_reflection_eq := P.rootForm_reflection_reflection_apply
-
-instance : Module.Finite R P.rootSpan := Finite.span_of_finite R <| finite_range P.root
-
-instance : Module.Finite R P.corootSpan := Finite.span_of_finite R <| finite_range P.coroot
 
 @[simp]
 lemma finrank_rootSpan_map_polarization_eq_finrank_corootSpan :


### PR DESCRIPTION
We also relocate some other unrelated lemmas in order to relax the assumptions on their scalars, and add fill out some loosely-related API.

The only mathematical result is `RootPairing.rootForm_apply_root_self_ne_zero`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
