### PR TITLE
[Merged by Bors] - chore: don't import `Set.indicator` in `Topology.ContinuousOn`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4959,6 +4959,7 @@ import Mathlib.Topology.Algebra.Group.SubmonoidClosure
 import Mathlib.Topology.Algebra.Group.TopologicalAbelianization
 import Mathlib.Topology.Algebra.GroupCompletion
 import Mathlib.Topology.Algebra.GroupWithZero
+import Mathlib.Topology.Algebra.Indicator
 import Mathlib.Topology.Algebra.InfiniteSum.Basic
 import Mathlib.Topology.Algebra.InfiniteSum.Constructions
 import Mathlib.Topology.Algebra.InfiniteSum.Defs

--- a/Mathlib/Topology/Algebra/Indicator.lean
+++ b/Mathlib/Topology/Algebra/Indicator.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2024 PFR contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: PFR contributors
+-/
+import Mathlib.Algebra.Group.Indicator
+import Mathlib.Topology.ContinuousOn
+
+/-!
+# Continuity of indicator functions
+-/
+
+open Set
+open scoped Topology
+
+variable {α β : Type*} [TopologicalSpace α] [TopologicalSpace β] {f : α → β} {s : Set α} [One β]
+
+@[to_additive]
+lemma continuous_mulIndicator (hs : ∀ a ∈ frontier s, f a = 1) (hf : ContinuousOn f (closure s)) :
+    Continuous (mulIndicator s f) := by
+  classical exact continuous_piecewise hs hf continuousOn_const
+
+@[to_additive]
+protected lemma Continuous.mulIndicator (hs : ∀ a ∈ frontier s, f a = 1) (hf : Continuous f) :
+    Continuous (mulIndicator s f) := by
+  classical exact hf.piecewise hs continuous_const
+
+@[to_additive]
+theorem ContinuousOn.continuousAt_mulIndicator (hf : ContinuousOn f (interior s)) {x : α}
+    (hx : x ∉ frontier s) :
+    ContinuousAt (s.mulIndicator f) x := by
+  rw [← Set.mem_compl_iff, compl_frontier_eq_union_interior] at hx
+  obtain h | h := hx
+  · have hs : interior s ∈ 𝓝 x := mem_interior_iff_mem_nhds.mp (by rwa [interior_interior])
+    exact ContinuousAt.congr (hf.continuousAt hs) <| Filter.eventuallyEq_iff_exists_mem.mpr
+      ⟨interior s, hs, Set.eqOn_mulIndicator.symm.mono interior_subset⟩
+  · exact ContinuousAt.congr continuousAt_const <| Filter.eventuallyEq_iff_exists_mem.mpr
+      ⟨sᶜ, mem_interior_iff_mem_nhds.mp h, Set.eqOn_mulIndicator'.symm⟩

--- a/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
@@ -4,11 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Mario Carneiro, Yury Kudryashov, Heather Macbeth
 -/
 import Mathlib.Algebra.Module.MinimalAxioms
-import Mathlib.Topology.ContinuousMap.Algebra
 import Mathlib.Analysis.Normed.Order.Lattice
 import Mathlib.Analysis.NormedSpace.OperatorNorm.Basic
-import Mathlib.Topology.Bornology.BoundedOperation
 import Mathlib.Tactic.Monotonicity
+import Mathlib.Topology.Algebra.Indicator
+import Mathlib.Topology.Bornology.BoundedOperation
+import Mathlib.Topology.ContinuousMap.Algebra
 
 /-!
 # Bounded continuous functions

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Reid Barton. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import Mathlib.Algebra.Group.Indicator
 import Mathlib.Topology.Constructions
 
 /-!
@@ -1402,33 +1401,6 @@ theorem Continuous.piecewise [∀ a, Decidable (a ∈ s)]
     (hs : ∀ a ∈ frontier s, f a = g a) (hf : Continuous f) (hg : Continuous g) :
     Continuous (piecewise s f g) :=
   hf.if hs hg
-
-section Indicator
-variable [One β]
-
-@[to_additive]
-lemma continuous_mulIndicator (hs : ∀ a ∈ frontier s, f a = 1) (hf : ContinuousOn f (closure s)) :
-    Continuous (mulIndicator s f) := by
-  classical exact continuous_piecewise hs hf continuousOn_const
-
-@[to_additive]
-protected lemma Continuous.mulIndicator (hs : ∀ a ∈ frontier s, f a = 1) (hf : Continuous f) :
-    Continuous (mulIndicator s f) := by
-  classical exact hf.piecewise hs continuous_const
-
-@[to_additive]
-theorem ContinuousOn.continuousAt_mulIndicator (hf : ContinuousOn f (interior s)) {x : α}
-    (hx : x ∉ frontier s) :
-    ContinuousAt (s.mulIndicator f) x := by
-  rw [← Set.mem_compl_iff, compl_frontier_eq_union_interior] at hx
-  obtain h | h := hx
-  · have hs : interior s ∈ 𝓝 x := mem_interior_iff_mem_nhds.mp (by rwa [interior_interior])
-    exact ContinuousAt.congr (hf.continuousAt hs) <| Filter.eventuallyEq_iff_exists_mem.mpr
-      ⟨interior s, hs, Set.eqOn_mulIndicator.symm.mono interior_subset⟩
-  · exact ContinuousAt.congr continuousAt_const <| Filter.eventuallyEq_iff_exists_mem.mpr
-      ⟨sᶜ, mem_interior_iff_mem_nhds.mp h, Set.eqOn_mulIndicator'.symm⟩
-
-end Indicator
 
 theorem IsOpen.ite' (hs : IsOpen s) (hs' : IsOpen s')
     (ht : ∀ x ∈ frontier t, x ∈ s ↔ x ∈ s') : IsOpen (t.ite s s') := by

--- a/Mathlib/Topology/IndicatorConstPointwise.lean
+++ b/Mathlib/Topology/IndicatorConstPointwise.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Kalle Kytölä. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kalle Kytölä
 -/
+import Mathlib.Algebra.Group.Indicator
 import Mathlib.Topology.Separation.Basic
 
 /-!

--- a/Mathlib/Topology/Order/LeftRight.lean
+++ b/Mathlib/Topology/Order/LeftRight.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Anatole Dedecker. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker
 -/
+import Mathlib.Order.Antichain
 import Mathlib.Topology.ContinuousOn
 
 /-!

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.Topology.Compactness.Lindelof
 import Mathlib.Topology.Compactness.SigmaCompact
 import Mathlib.Topology.Connected.TotallyDisconnected
 import Mathlib.Topology.Inseparable
+import Mathlib.Topology.Algebra.Indicator
 
 /-!
 # Separation properties of topological spaces.

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -3,11 +3,11 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import Mathlib.Algebra.Group.Support
 import Mathlib.Topology.Compactness.Lindelof
 import Mathlib.Topology.Compactness.SigmaCompact
 import Mathlib.Topology.Connected.TotallyDisconnected
 import Mathlib.Topology.Inseparable
-import Mathlib.Topology.Algebra.Indicator
 
 /-!
 # Separation properties of topological spaces.


### PR DESCRIPTION
This is a first step towards not depending on algebra in basic topology


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
