### PR TITLE
[Merged by Bors] - chore: update benchmark runner for leanprover/lean4#5684

### DIFF
--- a/scripts/bench/temci-config.run.yml
+++ b/scripts/bench/temci-config.run.yml
@@ -7,7 +7,7 @@
     rusage_properties: ['maxrss']
     cmd: |
       # use build cache for proofwidgets, but not for anything else
-      bash -c 'set -eo pipefail; lake clean 1>&2 && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets 1>&2 && rm -f .lake/packages/batteries/.lake/build/bin/runLinter 1>&2 && LEAN=./scripts/bench/fake-root/bin/lean lake build --no-cache -v | ./scripts/bench/accumulate_profile.py | grep -v took'
+      bash -c 'set -eo pipefail; lake clean 1>&2 && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets 1>&2 && rm -f .lake/packages/batteries/.lake/build/bin/runLinter 1>&2 && LAKE_OVERRIDE_LEAN=true LEAN=$(readlink -m ./scripts/bench/fake-root/bin/lean) lake build --no-cache -v | ./scripts/bench/accumulate_profile.py | grep -v took'
     parse_output: true
     runs: 1
 - attributes:


### PR DESCRIPTION
Trying again, this time using [#18354](https://github.com/leanprover-community/mathlib4/pull/18354).