### PR TITLE
[Merged by Bors] - ci(dependabot.yml): use glob syntax in config...

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
   # Configuration for dependency updates
   - package-ecosystem: "github-actions"  # Specifies the ecosystem to check for updates
     directories: 
-      - "/"  # Specifies the directory to check for dependencies; "/" means the root directory
-      - "/.github/" # covers `build.in.yml` as well, which is not in `.github/workflows/` because it shouldn't be run in CI.
+      - "/.github/*" # covers `build.in.yml` as well, which is not in `.github/workflows/` because it shouldn't be run in CI.
     schedule:
       # Check for updates to GitHub Actions every month
       interval: "monthly"


### PR DESCRIPTION
to try to get dependabot to create only one PR instead of several, cf. #19655, #19658
