### PR TITLE
[Merged by Bors] - feat(GroupTheory/Coxeter): add auxiliary lemmas for alternating words and left inverse sequences

### DIFF
--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -458,6 +458,40 @@ lemma getElem_alternatingWord_swapIndices (i j : B) (p k : ℕ) (h : k + 1 < p) 
   · rw [if_neg h_even, ← add_assoc]
     simp [Odd.add_one (Nat.not_even_iff_odd.mp h_even)]
 
+lemma listTake_alternatingWord (i j : B) (p k : ℕ) (h : k < 2 * p) :
+    List.take k (alternatingWord i j (2 * p)) =
+    if Even k then alternatingWord i j k else alternatingWord j i k := by
+  induction k with
+    | zero =>
+      simp[alternatingWord]
+    | succ k h' =>
+      have hk : k < 2 * p := by omega
+      apply h' at hk
+
+      by_cases h_even : Even k
+      · simp [h_even] at hk
+        simp [h_even, Nat.not_even_iff_odd.mpr (Even.add_one h_even)]
+        rw[← List.take_concat_get _ _ (by simp[h]; omega), alternatingWord_succ, ← hk]
+        apply congr_arg
+        rw[getElem_alternatingWord i j (2*p) k (by omega)]
+        simp[(by apply Nat.even_add.mpr; simp[h_even]: Even (2 * p + k))]
+      · simp [h_even] at hk
+        simp [h_even, (by simp at h_even; exact Odd.add_one h_even: Even (k + 1))]
+        rw[← List.take_concat_get _ _ (by simp[h]; omega), alternatingWord_succ, hk]
+        apply congr_arg
+        rw[getElem_alternatingWord i j (2*p) k (by omega)]
+        simp[(by apply Nat.odd_add.mpr; simp[h_even]: Odd (2 * p + k))]
+
+lemma listTake_succ_alternatingWord (i j : B) (p : ℕ) (k : ℕ) (h : k + 1 < 2 * p) :
+    List.take (k + 1) (alternatingWord i j (2 * p)) =
+    i :: (List.take k (alternatingWord j i (2 * p))) := by
+  rw[listTake_alternatingWord j i p k (by omega), listTake_alternatingWord i j p (k+1) h]
+
+  by_cases h_even : Even k
+  · simp [h_even, Nat.not_even_iff_odd.mpr (Even.add_one h_even), alternatingWord_succ', h_even]
+  · simp [h_even, (by simp at h_even; exact Odd.add_one h_even: Even (k + 1)),
+    alternatingWord_succ', h_even]
+
 theorem prod_alternatingWord_eq_mul_pow (i i' : B) (m : ℕ) :
     π (alternatingWord i i' m) = (if Even m then 1 else s i') * (s i * s i') ^ (m / 2) := by
   induction' m with m ih

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -411,6 +411,59 @@ theorem length_alternatingWord (i i' : B) (m : ℕ) :
   · dsimp [alternatingWord]
   · simpa [alternatingWord] using ih i' i
 
+private lemma getElem_alternatingWord_aux (i j : B) (p : ℕ)
+    (k : Fin ((alternatingWord i j p).length)) :
+    (alternatingWord i j p)[k] = (if Even (p + k) then i else j) := by
+  induction p with
+  | zero =>
+    rcases k with ⟨k, hk⟩
+    simp[alternatingWord] at hk
+  | succ n h =>
+    revert k
+    rw [alternatingWord_succ' i j n]
+    rintro ⟨k, hk⟩
+
+    induction k with
+    | zero =>
+      by_cases h2 : Even n
+      · have : ¬ Even (n + 1) := by
+          simp
+          exact Even.add_one h2
+        simp [h2, this]
+      · have : Even (n + 1) := by
+          simp at h2
+          exact Odd.add_one h2
+        simp [h2, this]
+    | succ k _ =>
+      have : k < (alternatingWord i j n).length := by
+        simp
+        simp at hk
+        exact hk
+      simp[List.getElem_cons_succ]
+      simp at h
+      rw[h ⟨k, this⟩ ]
+      simp
+      ring_nf
+      have (m : ℕ) : Even (2 + m) ↔ Even m := by
+        have aux : m ≤ 2 + m := by omega
+        apply (Nat.even_sub aux).mp
+        simp
+      by_cases h_even : Even (n + k)
+      · simp [if_pos h_even]
+        rw[← this (n+k)] at h_even
+        rw[← Nat.add_assoc 2 n k] at h_even
+        simp [if_pos h_even]
+      · simp [if_neg h_even]
+        rw[← this (n+k)] at h_even
+        rw[← Nat.add_assoc 2 n k] at h_even
+        simp [if_neg h_even]
+
+lemma getElem_alternatingWord (i j : B) (p k : ℕ) (h : k < p) :
+    (alternatingWord i j p)[k]'(by simp; exact h) =  (if Even (p + k) then i else j) := by
+  have h' : k < (alternatingWord i j p).length := by simp[h]
+  rw[← getElem_alternatingWord_aux i j p ⟨k, h'⟩]
+  simp
+
 theorem prod_alternatingWord_eq_mul_pow (i i' : B) (m : ℕ) :
     π (alternatingWord i i' m) = (if Even m then 1 else s i') * (s i * s i') ^ (m / 2) := by
   induction' m with m ih

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -447,6 +447,17 @@ lemma getElem_alternatingWord (i j : B) (p k : ℕ) (h : k < p) :
     (alternatingWord i j p)[k]'(by simp; exact h) =  (if Even (p + k) then i else j) := by
   simp[← getElem_alternatingWord_aux i j p ⟨k, (by simp[h])⟩]
 
+lemma getElem_alternatingWord_swapIndices (i j : B) (p k : ℕ) (h : k + 1 < p) :
+   (alternatingWord i j p)[k+1]'(by simp; exact h) =
+   (alternatingWord j i p)[k]'(by simp [h]; omega) := by
+  rw[ getElem_alternatingWord i j p (k+1) (by omega), getElem_alternatingWord j i p k (by omega)]
+
+  by_cases h_even : Even (p + k)
+  · rw[if_pos h_even, ← add_assoc]
+    simp [Even.add_one h_even]
+  · rw [if_neg h_even, ← add_assoc]
+    simp [Odd.add_one (Nat.not_even_iff_odd.mp h_even)]
+
 theorem prod_alternatingWord_eq_mul_pow (i i' : B) (m : ℕ) :
     π (alternatingWord i i' m) = (if Even m then 1 else s i') * (s i * s i') ^ (m / 2) := by
   induction' m with m ih

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -468,14 +468,13 @@ lemma listTake_alternatingWord (i j : B) (p k : ℕ) (h : k < 2 * p) :
         rw [← List.take_concat_get _ _ (by simp[h]; omega), alternatingWord_succ, ← hk]
         apply congr_arg
         rw [getElem_alternatingWord i j (2*p) k (by omega)]
-        simp only [(by apply Nat.even_add.mpr; simp [h_even] : Even (2 * p + k)), ↓reduceIte]
+        simp [(by apply Nat.even_add.mpr; simp[h_even]: Even (2 * p + k))]
       · simp only [h_even, ↓reduceIte] at hk
         simp only [(by simp at h_even; exact Odd.add_one h_even : Even (k + 1)), ↓reduceIte]
         rw [← List.take_concat_get _ _ (by simp[h]; omega), alternatingWord_succ, hk]
         apply congr_arg
         rw [getElem_alternatingWord i j (2*p) k (by omega)]
-        simp only [ite_eq_right_iff, isEmpty_Prop, Nat.not_even_iff_odd,
-          (by apply Nat.odd_add.mpr; simp [h_even] : Odd (2 * p + k)), IsEmpty.forall_iff]
+        simp [(by apply Nat.odd_add.mpr; simp[h_even]: Odd (2 * p + k))]
 
 lemma listTake_succ_alternatingWord (i j : B) (p : ℕ) (k : ℕ) (h : k + 1 < 2 * p) :
     List.take (k + 1) (alternatingWord i j (2 * p)) =

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -422,7 +422,6 @@ private lemma getElem_alternatingWord_aux (i j : B) (p : ℕ)
     revert k
     rw [alternatingWord_succ' i j n]
     rintro ⟨k, hk⟩
-
     match k with
     | 0 =>
       by_cases h2 : Even n
@@ -451,7 +450,6 @@ lemma getElem_alternatingWord_swapIndices (i j : B) (p k : ℕ) (h : k + 1 < p) 
    (alternatingWord i j p)[k+1]'(by simp; exact h) =
    (alternatingWord j i p)[k]'(by simp [h]; omega) := by
   rw[ getElem_alternatingWord i j p (k+1) (by omega), getElem_alternatingWord j i p k (by omega)]
-
   by_cases h_even : Even (p + k)
   · rw[if_pos h_even, ← add_assoc]
     simp [Even.add_one h_even]
@@ -467,7 +465,6 @@ lemma listTake_alternatingWord (i j : B) (p k : ℕ) (h : k < 2 * p) :
     | succ k h' =>
       have hk : k < 2 * p := by omega
       apply h' at hk
-
       by_cases h_even : Even k
       · simp [h_even] at hk
         simp [h_even, Nat.not_even_iff_odd.mpr (Even.add_one h_even)]

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -417,36 +417,39 @@ lemma getElem_alternatingWord (i j : B) (p k : ℕ) (hk : k < p) :
   induction p with
   | zero =>
     intro k hk
-    simp [alternatingWord] at hk
+    simp only [not_lt_zero'] at hk
   | succ n h =>
     intro k hk
     simp_rw [alternatingWord_succ' i j n]
     match k with
     | 0 =>
       by_cases h2 : Even n
-      · simp [h2, (by simp[Even.add_one, h2]: ¬ Even (n + 1))]
-      · simp [h2, Odd.add_one (Nat.not_even_iff_odd.mp h2)]
+      · simp only [h2, ↓reduceIte, getElem_cons_zero, add_zero,
+        (by simp [Even.add_one, h2] : ¬Even (n + 1))]
+      · simp only [h2, ↓reduceIte, getElem_cons_zero, add_zero,
+        Odd.add_one (Nat.not_even_iff_odd.mp h2)]
     | k + 1 =>
-      simp at hk h
-      simp[List.getElem_cons_succ, h k hk]
+      simp only [add_lt_add_iff_right] at hk h
+      simp only [getElem_cons_succ, h k hk]
       ring_nf
       have even_add_two (m : ℕ) : Even (2 + m) ↔ Even m := by
-        simp[(Nat.even_sub (by omega: m ≤ 2 + m)).mp]
+        simp only [add_tsub_cancel_right, even_two, (Nat.even_sub (by omega : m ≤ 2 + m)).mp]
       by_cases h_even : Even (n + k)
       · rw [if_pos h_even]
-        rw[← even_add_two (n+k), ← Nat.add_assoc 2 n k] at h_even
+        rw [← even_add_two (n+k), ← Nat.add_assoc 2 n k] at h_even
         rw [if_pos h_even]
       · rw [if_neg h_even]
-        rw[← even_add_two (n+k), ← Nat.add_assoc 2 n k] at h_even
+        rw [← even_add_two (n+k), ← Nat.add_assoc 2 n k] at h_even
         rw [if_neg h_even]
 
 lemma getElem_alternatingWord_swapIndices (i j : B) (p k : ℕ) (h : k + 1 < p) :
    (alternatingWord i j p)[k+1]'(by simp; exact h) =
    (alternatingWord j i p)[k]'(by simp [h]; omega) := by
-  rw[ getElem_alternatingWord i j p (k+1) (by omega), getElem_alternatingWord j i p k (by omega)]
+  rw [getElem_alternatingWord i j p (k+1) (by omega), getElem_alternatingWord j i p k (by omega)]
   by_cases h_even : Even (p + k)
-  · rw[if_pos h_even, ← add_assoc]
-    simp [Even.add_one h_even]
+  · rw [if_pos h_even, ← add_assoc]
+    simp only [ite_eq_right_iff, isEmpty_Prop, Nat.not_even_iff_odd, Even.add_one h_even,
+      IsEmpty.forall_iff]
   · rw [if_neg h_even, ← add_assoc]
     simp [Odd.add_one (Nat.not_even_iff_odd.mp h_even)]
 
@@ -455,28 +458,29 @@ lemma listTake_alternatingWord (i j : B) (p k : ℕ) (h : k < 2 * p) :
     if Even k then alternatingWord i j k else alternatingWord j i k := by
   induction k with
     | zero =>
-      simp[alternatingWord]
+      simp only [take_zero, even_zero, ↓reduceIte, alternatingWord]
     | succ k h' =>
       have hk : k < 2 * p := by omega
       apply h' at hk
       by_cases h_even : Even k
-      · simp [h_even] at hk
-        simp [h_even, Nat.not_even_iff_odd.mpr (Even.add_one h_even)]
-        rw[← List.take_concat_get _ _ (by simp[h]; omega), alternatingWord_succ, ← hk]
+      · simp only [h_even, ↓reduceIte] at hk
+        simp only [Nat.not_even_iff_odd.mpr (Even.add_one h_even), ↓reduceIte]
+        rw [← List.take_concat_get _ _ (by simp[h]; omega), alternatingWord_succ, ← hk]
         apply congr_arg
-        rw[getElem_alternatingWord i j (2*p) k (by omega)]
-        simp[(by apply Nat.even_add.mpr; simp[h_even]: Even (2 * p + k))]
-      · simp [h_even] at hk
-        simp [h_even, (by simp at h_even; exact Odd.add_one h_even: Even (k + 1))]
-        rw[← List.take_concat_get _ _ (by simp[h]; omega), alternatingWord_succ, hk]
+        rw [getElem_alternatingWord i j (2*p) k (by omega)]
+        simp only [(by apply Nat.even_add.mpr; simp [h_even] : Even (2 * p + k)), ↓reduceIte]
+      · simp only [h_even, ↓reduceIte] at hk
+        simp only [(by simp at h_even; exact Odd.add_one h_even : Even (k + 1)), ↓reduceIte]
+        rw [← List.take_concat_get _ _ (by simp[h]; omega), alternatingWord_succ, hk]
         apply congr_arg
-        rw[getElem_alternatingWord i j (2*p) k (by omega)]
-        simp[(by apply Nat.odd_add.mpr; simp[h_even]: Odd (2 * p + k))]
+        rw [getElem_alternatingWord i j (2*p) k (by omega)]
+        simp only [ite_eq_right_iff, isEmpty_Prop, Nat.not_even_iff_odd,
+          (by apply Nat.odd_add.mpr; simp [h_even] : Odd (2 * p + k)), IsEmpty.forall_iff]
 
 lemma listTake_succ_alternatingWord (i j : B) (p : ℕ) (k : ℕ) (h : k + 1 < 2 * p) :
     List.take (k + 1) (alternatingWord i j (2 * p)) =
     i :: (List.take k (alternatingWord j i (2 * p))) := by
-  rw[listTake_alternatingWord j i p k (by omega), listTake_alternatingWord i j p (k+1) h]
+  rw [listTake_alternatingWord j i p k (by omega), listTake_alternatingWord i j p (k+1) h]
 
   by_cases h_even : Even k
   · simp [h_even, Nat.not_even_iff_odd.mpr (Even.add_one h_even), alternatingWord_succ', h_even]

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -417,7 +417,7 @@ lemma getElem_alternatingWord (i j : B) (p k : ℕ) (hk : k < p) :
   induction p with
   | zero =>
     intro k hk
-    simp[alternatingWord] at hk
+    simp [alternatingWord] at hk
   | succ n h =>
     intro k hk
     simp_rw [alternatingWord_succ' i j n]

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Newell Jensen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Newell Jensen, Mitchell Lee
+Authors: Newell Jensen, Mitchell Lee, Óscar Álvarez
 -/
 import Mathlib.Algebra.Group.Subgroup.Pointwise
 import Mathlib.Algebra.Ring.Int.Parity

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -423,46 +423,29 @@ private lemma getElem_alternatingWord_aux (i j : B) (p : ℕ)
     rw [alternatingWord_succ' i j n]
     rintro ⟨k, hk⟩
 
-    induction k with
-    | zero =>
+    match k with
+    | 0 =>
       by_cases h2 : Even n
-      · have : ¬ Even (n + 1) := by
-          simp
-          exact Even.add_one h2
-        simp [h2, this]
-      · have : Even (n + 1) := by
-          simp at h2
-          exact Odd.add_one h2
-        simp [h2, this]
-    | succ k _ =>
-      have : k < (alternatingWord i j n).length := by
-        simp
-        simp at hk
-        exact hk
+      · simp [h2, (by simp[Even.add_one, h2]: ¬ Even (n + 1))]
+      · simp [h2, Odd.add_one (Nat.not_even_iff_odd.mp h2)]
+    | k + 1 =>
+      simp at hk h
       simp[List.getElem_cons_succ]
-      simp at h
-      rw[h ⟨k, this⟩ ]
-      simp
+      simp[h ⟨k, (by simp[hk])⟩ ]
       ring_nf
-      have (m : ℕ) : Even (2 + m) ↔ Even m := by
-        have aux : m ≤ 2 + m := by omega
-        apply (Nat.even_sub aux).mp
-        simp
+      have even_add_two (m : ℕ) : Even (2 + m) ↔ Even m := by
+        simp[(Nat.even_sub (by omega: m ≤ 2 + m)).mp]
       by_cases h_even : Even (n + k)
-      · simp [if_pos h_even]
-        rw[← this (n+k)] at h_even
-        rw[← Nat.add_assoc 2 n k] at h_even
-        simp [if_pos h_even]
-      · simp [if_neg h_even]
-        rw[← this (n+k)] at h_even
-        rw[← Nat.add_assoc 2 n k] at h_even
-        simp [if_neg h_even]
+      · rw [if_pos h_even]
+        rw[← even_add_two (n+k), ← Nat.add_assoc 2 n k] at h_even
+        rw [if_pos h_even]
+      · rw [if_neg h_even]
+        rw[← even_add_two (n+k), ← Nat.add_assoc 2 n k] at h_even
+        rw [if_neg h_even]
 
 lemma getElem_alternatingWord (i j : B) (p k : ℕ) (h : k < p) :
     (alternatingWord i j p)[k]'(by simp; exact h) =  (if Even (p + k) then i else j) := by
-  have h' : k < (alternatingWord i j p).length := by simp[h]
-  rw[← getElem_alternatingWord_aux i j p ⟨k, h'⟩]
-  simp
+  simp[← getElem_alternatingWord_aux i j p ⟨k, (by simp[h])⟩]
 
 theorem prod_alternatingWord_eq_mul_pow (i i' : B) (m : ℕ) :
     π (alternatingWord i i' m) = (if Even m then 1 else s i') * (s i * s i') ^ (m / 2) := by

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -411,9 +411,15 @@ theorem length_alternatingWord (i i' : B) (m : ℕ) :
   · dsimp [alternatingWord]
   · simpa [alternatingWord] using ih i' i
 
-private lemma getElem_alternatingWord_aux (i j : B) (p : ℕ)
-    (k : Fin ((alternatingWord i j p).length)) :
-    (alternatingWord i j p)[k] = (if Even (p + k) then i else j) := by
+lemma getElem_alternatingWord (i j : B) (p k : ℕ) (h : k < p) :
+    (alternatingWord i j p)[k]'(by simp; exact h) =  (if Even (p + k) then i else j) := by
+  /- State the proof in terms of a finite index to simplify induction -/
+  revert i j p k h
+  suffices ∀ (i j : B) (p : ℕ) (k : Fin ((alternatingWord i j p).length)),
+   (alternatingWord i j p)[k] = if Even (p + k) then i else j from by
+    intro i j p k h
+    simp [← this i j p ⟨k, (by simp[h])⟩]
+  intro i j p k
   induction p with
   | zero =>
     rcases k with ⟨k, hk⟩
@@ -441,10 +447,6 @@ private lemma getElem_alternatingWord_aux (i j : B) (p : ℕ)
       · rw [if_neg h_even]
         rw[← even_add_two (n+k), ← Nat.add_assoc 2 n k] at h_even
         rw [if_neg h_even]
-
-lemma getElem_alternatingWord (i j : B) (p k : ℕ) (h : k < p) :
-    (alternatingWord i j p)[k]'(by simp; exact h) =  (if Even (p + k) then i else j) := by
-  simp[← getElem_alternatingWord_aux i j p ⟨k, (by simp[h])⟩]
 
 lemma getElem_alternatingWord_swapIndices (i j : B) (p k : ℕ) (h : k + 1 < p) :
    (alternatingWord i j p)[k+1]'(by simp; exact h) =

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -411,23 +411,16 @@ theorem length_alternatingWord (i i' : B) (m : ℕ) :
   · dsimp [alternatingWord]
   · simpa [alternatingWord] using ih i' i
 
-lemma getElem_alternatingWord (i j : B) (p k : ℕ) (h : k < p) :
-    (alternatingWord i j p)[k]'(by simp; exact h) =  (if Even (p + k) then i else j) := by
-  /- State the proof in terms of a finite index to simplify induction -/
-  revert i j p k h
-  suffices ∀ (i j : B) (p : ℕ) (k : Fin ((alternatingWord i j p).length)),
-   (alternatingWord i j p)[k] = if Even (p + k) then i else j from by
-    intro i j p k h
-    simp [← this i j p ⟨k, (by simp[h])⟩]
-  intro i j p k
+lemma getElem_alternatingWord (i j : B) (p k : ℕ) (hk : k < p) :
+    (alternatingWord i j p)[k]'(by simp; exact hk) =  (if Even (p + k) then i else j) := by
+  revert k
   induction p with
   | zero =>
-    rcases k with ⟨k, hk⟩
+    intro k hk
     simp[alternatingWord] at hk
   | succ n h =>
-    revert k
-    rw [alternatingWord_succ' i j n]
-    rintro ⟨k, hk⟩
+    intro k hk
+    simp_rw [alternatingWord_succ' i j n]
     match k with
     | 0 =>
       by_cases h2 : Even n
@@ -435,8 +428,7 @@ lemma getElem_alternatingWord (i j : B) (p k : ℕ) (h : k < p) :
       · simp [h2, Odd.add_one (Nat.not_even_iff_odd.mp h2)]
     | k + 1 =>
       simp at hk h
-      simp[List.getElem_cons_succ]
-      simp[h ⟨k, (by simp[hk])⟩ ]
+      simp[List.getElem_cons_succ, h k hk]
       ring_nf
       have even_add_two (m : ℕ) : Even (2 + m) ↔ Even m := by
         simp[(Nat.even_sub (by omega: m ≤ 2 + m)).mp]

--- a/Mathlib/GroupTheory/Coxeter/Inversion.lean
+++ b/Mathlib/GroupTheory/Coxeter/Inversion.lean
@@ -282,7 +282,7 @@ lemma getElem_leftInvSeq (ω : List B) (j : ℕ) (h : j < ω.length) :
     (lis ω)[j]'(by simp[h]) =
     cs.wordProd (List.take j ω) * s ω[j] * (cs.wordProd (List.take j ω))⁻¹ := by
   rw [← List.getD_eq_getElem (lis ω) 1, getD_leftInvSeq]
-  simp[h]
+  simp
 
 theorem getD_rightInvSeq_mul_self (ω : List B) (j : ℕ) :
     ((ris ω).getD j 1) * ((ris ω).getD j 1) = 1 := by
@@ -457,10 +457,11 @@ lemma getElem_succ_leftInvSeq_alternatingWord
     (lis (alternatingWord i j (2 * p)))[k + 1]'(by simp; exact h) =
     MulAut.conj (s i) ((lis (alternatingWord j i (2 * p)))[k]'(by simp; linarith)) := by
   rw [cs.getElem_leftInvSeq (alternatingWord i j (2 * p)) (k + 1) (by simp[h]),
-      cs.getElem_leftInvSeq (alternatingWord j i (2 * p)) k (by simp[h]; omega)]
-  simp only [MulAut.conj]
-  simp [listTake_succ_alternatingWord i j p k h, cs.wordProd_cons, mul_assoc]
-  rw[getElem_alternatingWord_swapIndices i j (2 * p) k]
+    cs.getElem_leftInvSeq (alternatingWord j i (2 * p)) k (by simp[h]; omega)]
+  simp only [MulAut.conj, listTake_succ_alternatingWord i j p k h, cs.wordProd_cons, mul_assoc,
+    mul_inv_rev, inv_simple, MonoidHom.coe_mk, OneHom.coe_mk, MulEquiv.coe_mk, Equiv.coe_fn_mk,
+    mul_right_inj, mul_left_inj]
+  rw [getElem_alternatingWord_swapIndices i j (2 * p) k]
   omega
 
 theorem getElem_leftInvSeq_alternatingWord
@@ -471,15 +472,18 @@ theorem getElem_leftInvSeq_alternatingWord
   induction k with
   | zero =>
     intro i j
-    simp[alternatingWord,
-      CoxeterSystem.getElem_leftInvSeq cs (alternatingWord i j (2 * p)) 0 (by simp[h])]
+    simp only [CoxeterSystem.getElem_leftInvSeq cs (alternatingWord i j (2 * p)) 0 (by simp [h]),
+      take_zero, wordProd_nil, one_mul, inv_one, mul_one, alternatingWord, concat_eq_append,
+      nil_append, wordProd_singleton]
     apply congr_arg
-    simp[getElem_alternatingWord i j (2 * p) 0 (by simp[h])]
+    simp only [getElem_alternatingWord i j (2 * p) 0 (by simp [h]), add_zero, even_two,
+      Even.mul_right, ↓reduceIte]
   | succ k hk =>
     intro i j
-    simp[getElem_succ_leftInvSeq_alternatingWord cs i j p k h, hk (by omega),
-    alternatingWord_succ' j i, wordProd_cons]
-    rw[(by ring: 2 * (k + 1) = 2 * k + 1 + 1), alternatingWord_succ j i, wordProd_concat]
-    simp[mul_assoc]
+    simp only [getElem_succ_leftInvSeq_alternatingWord cs i j p k h, hk (by omega),
+      MulAut.conj_apply, inv_simple, alternatingWord_succ' j i, even_two, Even.mul_right,
+      ↓reduceIte, wordProd_cons]
+    rw [(by ring: 2 * (k + 1) = 2 * k + 1 + 1), alternatingWord_succ j i, wordProd_concat]
+    simp [mul_assoc]
 
 end CoxeterSystem

--- a/Mathlib/GroupTheory/Coxeter/Inversion.lean
+++ b/Mathlib/GroupTheory/Coxeter/Inversion.lean
@@ -282,7 +282,7 @@ lemma getElem_leftInvSeq (ω : List B) (j : ℕ) (h : j < ω.length) :
     (lis ω)[j]'(by simp[h]) =
     cs.wordProd (List.take j ω) * s ω[j] * (cs.wordProd (List.take j ω))⁻¹ := by
   rw [← List.getD_eq_getElem (lis ω) 1, getD_leftInvSeq]
-  simp
+  simp [h]
 
 theorem getD_rightInvSeq_mul_self (ω : List B) (j : ℕ) :
     ((ris ω).getD j 1) * ((ris ω).getD j 1) = 1 := by

--- a/Mathlib/GroupTheory/Coxeter/Inversion.lean
+++ b/Mathlib/GroupTheory/Coxeter/Inversion.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Mitchell Lee. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mitchell Lee
+Authors: Mitchell Lee, Óscar Álvarez
 -/
 import Mathlib.GroupTheory.Coxeter.Length
 import Mathlib.Data.List.GetD

--- a/Mathlib/GroupTheory/Coxeter/Inversion.lean
+++ b/Mathlib/GroupTheory/Coxeter/Inversion.lean
@@ -255,12 +255,12 @@ theorem getD_rightInvSeq (ω : List B) (j : ℕ) :
     · simp only [getD_eq_getElem?_getD, get?_eq_getElem?] at ih
       simp [getD_cons_succ, ih j']
 
-lemma getElem_rightInvSeq (l : List B) (j : ℕ) (h : j < l.length) :
-    (cs.rightInvSeq l)[j]'(by simp[h]) =
-    (π (l.drop (j + 1)))⁻¹
-      * (Option.map (cs.simple) (l.get? j)).getD 1
-      * π (l.drop (j + 1)) := by
-  rw [← List.getD_eq_getElem (cs.rightInvSeq l) 1, getD_rightInvSeq]
+lemma getElem_rightInvSeq (ω : List B) (j : ℕ) (h : j < ω.length) :
+    (ris ω)[j]'(by simp[h]) =
+    (π (ω.drop (j + 1)))⁻¹
+      * (Option.map (cs.simple) (ω.get? j)).getD 1
+      * π (ω.drop (j + 1)) := by
+  rw [← List.getD_eq_getElem (ris ω) 1, getD_rightInvSeq]
 
 theorem getD_leftInvSeq (ω : List B) (j : ℕ) :
     (lis ω).getD j 1 =
@@ -278,10 +278,10 @@ theorem getD_leftInvSeq (ω : List B) (j : ℕ) :
       rw [ih j']
       simp [← mul_assoc, wordProd_cons]
 
-lemma getElem_leftInvSeq (l : List B) (j : ℕ) (h : j < l.length) :
-    (cs.leftInvSeq l)[j]'(by simp[h]) =
-    cs.wordProd (List.take j l) * s l[j] * (cs.wordProd (List.take j l))⁻¹ := by
-  rw [← List.getD_eq_getElem (cs.leftInvSeq l) 1, getD_leftInvSeq]
+lemma getElem_leftInvSeq (ω : List B) (j : ℕ) (h : j < ω.length) :
+    (lis ω)[j]'(by simp[h]) =
+    cs.wordProd (List.take j ω) * s ω[j] * (cs.wordProd (List.take j ω))⁻¹ := by
+  rw [← List.getD_eq_getElem (lis ω) 1, getD_leftInvSeq]
   simp[h]
 
 theorem getD_rightInvSeq_mul_self (ω : List B) (j : ℕ) :
@@ -453,7 +453,7 @@ theorem IsReduced.nodup_leftInvSeq {ω : List B} (rω : cs.IsReduced ω) : List.
   rwa [isReduced_reverse]
 
 lemma getElem_succ_leftInvSeq_alternatingWord
-    (i j : B) (p : ℕ) (k : ℕ) (h : k + 1 < 2 * p) :
+    (i j : B) (p k : ℕ) (h : k + 1 < 2 * p) :
     (lis (alternatingWord i j (2 * p)))[k + 1]'(by simp; exact h) =
     MulAut.conj (s i) ((lis (alternatingWord j i (2 * p)))[k]'(by simp; linarith)) := by
   rw [cs.getElem_leftInvSeq (alternatingWord i j (2 * p)) (k + 1) (by simp[h]),
@@ -465,7 +465,7 @@ lemma getElem_succ_leftInvSeq_alternatingWord
   omega
 
 theorem getElem_leftInvSeq_alternatingWord
-    (i j : B) (p : ℕ) (k : ℕ) (h : k < 2 * p) :
+    (i j : B) (p k : ℕ) (h : k < 2 * p) :
     (lis (alternatingWord i j (2 * p)))[k]'(by simp; linarith) =
     π alternatingWord j i (2 * k + 1) := by
   revert i j

--- a/Mathlib/GroupTheory/Coxeter/Inversion.lean
+++ b/Mathlib/GroupTheory/Coxeter/Inversion.lean
@@ -255,6 +255,13 @@ theorem getD_rightInvSeq (ω : List B) (j : ℕ) :
     · simp only [getD_eq_getElem?_getD, get?_eq_getElem?] at ih
       simp [getD_cons_succ, ih j']
 
+lemma getElem_rightInvSeq (l : List B) (j : ℕ) (h : j < l.length) :
+    (cs.rightInvSeq l)[j]'(by simp[h]) =
+    (π (l.drop (j + 1)))⁻¹
+      * (Option.map (cs.simple) (l.get? j)).getD 1
+      * π (l.drop (j + 1)) := by
+  rw [← List.getD_eq_getElem (cs.rightInvSeq l) 1, getD_rightInvSeq]
+
 theorem getD_leftInvSeq (ω : List B) (j : ℕ) :
     (lis ω).getD j 1 =
       π (ω.take j)
@@ -270,6 +277,12 @@ theorem getD_leftInvSeq (ω : List B) (j : ℕ) :
       rw [getD_map]
       rw [ih j']
       simp [← mul_assoc, wordProd_cons]
+
+lemma getElem_leftInvSeq (l : List B) (j : ℕ) (h : j < l.length) :
+    (cs.leftInvSeq l)[j]'(by simp[h]) =
+    cs.wordProd (List.take j l) * s l[j] * (cs.wordProd (List.take j l))⁻¹ := by
+  rw [← List.getD_eq_getElem (cs.leftInvSeq l) 1, getD_leftInvSeq]
+  simp[h]
 
 theorem getD_rightInvSeq_mul_self (ω : List B) (j : ℕ) :
     ((ris ω).getD j 1) * ((ris ω).getD j 1) = 1 := by

--- a/Mathlib/GroupTheory/Coxeter/Inversion.lean
+++ b/Mathlib/GroupTheory/Coxeter/Inversion.lean
@@ -459,7 +459,6 @@ lemma getElem_succ_leftInvSeq_alternatingWord
   rw [cs.getElem_leftInvSeq (alternatingWord i j (2 * p)) (k + 1) (by simp[h]),
       cs.getElem_leftInvSeq (alternatingWord j i (2 * p)) k (by simp[h]; omega)]
   simp only [MulAut.conj]
-
   simp [listTake_succ_alternatingWord i j p k h, cs.wordProd_cons, mul_assoc]
   rw[getElem_alternatingWord_swapIndices i j (2 * p) k]
   omega
@@ -482,6 +481,5 @@ theorem getElem_leftInvSeq_alternatingWord
     alternatingWord_succ' j i, wordProd_cons]
     rw[(by ring: 2 * (k + 1) = 2 * k + 1 + 1), alternatingWord_succ j i, wordProd_concat]
     simp[mul_assoc]
-
 
 end CoxeterSystem

--- a/Mathlib/GroupTheory/Coxeter/Inversion.lean
+++ b/Mathlib/GroupTheory/Coxeter/Inversion.lean
@@ -452,4 +452,36 @@ theorem IsReduced.nodup_leftInvSeq {ω : List B} (rω : cs.IsReduced ω) : List.
   apply nodup_rightInvSeq
   rwa [isReduced_reverse]
 
+lemma getElem_succ_leftInvSeq_alternatingWord
+    (i j : B) (p : ℕ) (k : ℕ) (h : k + 1 < 2 * p) :
+    (lis (alternatingWord i j (2 * p)))[k + 1]'(by simp; exact h) =
+    MulAut.conj (s i) ((lis (alternatingWord j i (2 * p)))[k]'(by simp; linarith)) := by
+  rw [cs.getElem_leftInvSeq (alternatingWord i j (2 * p)) (k + 1) (by simp[h]),
+      cs.getElem_leftInvSeq (alternatingWord j i (2 * p)) k (by simp[h]; omega)]
+  simp only [MulAut.conj]
+
+  simp [listTake_succ_alternatingWord i j p k h, cs.wordProd_cons, mul_assoc]
+  rw[getElem_alternatingWord_swapIndices i j (2 * p) k]
+  omega
+
+theorem getElem_leftInvSeq_alternatingWord
+    (i j : B) (p : ℕ) (k : ℕ) (h : k < 2 * p) :
+    (lis (alternatingWord i j (2 * p)))[k]'(by simp; linarith) =
+    π alternatingWord j i (2 * k + 1) := by
+  revert i j
+  induction k with
+  | zero =>
+    intro i j
+    simp[alternatingWord,
+      CoxeterSystem.getElem_leftInvSeq cs (alternatingWord i j (2 * p)) 0 (by simp[h])]
+    apply congr_arg
+    simp[getElem_alternatingWord i j (2 * p) 0 (by simp[h])]
+  | succ k hk =>
+    intro i j
+    simp[getElem_succ_leftInvSeq_alternatingWord cs i j p k h, hk (by omega),
+    alternatingWord_succ' j i, wordProd_cons]
+    rw[(by ring: 2 * (k + 1) = 2 * k + 1 + 1), alternatingWord_succ j i, wordProd_concat]
+    simp[mul_assoc]
+
+
 end CoxeterSystem


### PR DESCRIPTION
Add some auxiliary lemmas of alternating words and left inverse sequences of Coxeter groups that will be useful to prove the Strong Exchange Theorem (among other uses). They are mainly taken from pages 12-13 of [Combinatorics of Coxeter groups by Anders Bjorner , Francesco Brenti](https://link.springer.com/book/10.1007/3-540-27596-7).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
