### PR TITLE
[Merged by Bors] - chore: redefine `Nat.bit`

### DIFF
--- a/Mathlib/Data/Nat/BinaryRec.lean
+++ b/Mathlib/Data/Nat/BinaryRec.lean
@@ -23,7 +23,7 @@ universe u
 namespace Nat
 
 /-- `bit b` appends the digit `b` to the little end of the binary representation of
-  its natural number input. -/
+its natural number input. -/
 def bit (b : Bool) (n : Nat) : Nat :=
   cond b (2 * n + 1) (2 * n)
 

--- a/Mathlib/Data/Nat/BinaryRec.lean
+++ b/Mathlib/Data/Nat/BinaryRec.lean
@@ -27,11 +27,6 @@ namespace Nat
 def bit (b : Bool) (n : Nat) : Nat :=
   cond b (2 * n + 1) (2 * n)
 
-private def bitImpl (b : Bool) (n : Nat) : Nat :=
-  cond b (n <<< 1 + 1) (n <<< 1)
-
-@[csimp] theorem bit_eq_bitImpl : bit = bitImpl := rfl
-
 theorem shiftRight_one (n) : n >>> 1 = n / 2 := rfl
 
 @[simp]

--- a/Mathlib/Data/Nat/BinaryRec.lean
+++ b/Mathlib/Data/Nat/BinaryRec.lean
@@ -22,8 +22,15 @@ universe u
 
 namespace Nat
 
-/-- `bit b` appends the digit `b` to the binary representation of its natural number input. -/
-def bit (b : Bool) : Nat → Nat := cond b (2 * · + 1) (2 * ·)
+/-- `bit b` appends the digit `b` to the little end of the binary representation of
+  its natural number input. -/
+def bit (b : Bool) (n : Nat) : Nat :=
+  cond b (2 * n + 1) (2 * n)
+
+private def bitImpl (b : Bool) (n : Nat) : Nat :=
+  cond b (n <<< 1 + 1) (n <<< 1)
+
+@[csimp] theorem bit_eq_bitImpl : bit = bitImpl := rfl
 
 theorem shiftRight_one (n) : n >>> 1 = n / 2 := rfl
 

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -64,7 +64,6 @@ lemma bitwise_of_ne_zero {n m : Nat} (hn : n ≠ 0) (hm : m ≠ 0) :
   have mod_two_iff_bod x : (x % 2 = 1 : Bool) = bodd x := by
     simp only [mod_two_of_bodd, cond]; cases bodd x <;> rfl
   simp only [hn, hm, mod_two_iff_bod, ite_false, bit, two_mul, Bool.cond_eq_ite]
-  split_ifs <;> rfl
 
 theorem binaryRec_of_ne_zero {C : Nat → Sort*} (z : C 0) (f : ∀ b n, C n → C (bit b n)) {n}
     (h : n ≠ 0) :
@@ -152,7 +151,6 @@ lemma bitwise_bit' {f : Bool → Bool → Bool} (a : Bool) (m : Nat) (b : Bool) 
   simp only [ham, hbn, bit_mod_two_eq_one_iff, Bool.decide_coe, ← div2_val, div2_bit, ne_eq,
     ite_false]
   conv_rhs => simp only [bit, two_mul, Bool.cond_eq_ite]
-  split_ifs with hf <;> rfl
 
 lemma bitwise_eq_binaryRec (f : Bool → Bool → Bool) :
     bitwise f =


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

split from #13649

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
