### PR TITLE
[Merged by Bors] - chore(Order/Ideal): define `Order.Cofinal` in terms of `IsCofinal`

### DIFF
--- a/Mathlib/ModelTheory/PartialEquiv.lean
+++ b/Mathlib/ModelTheory/PartialEquiv.lean
@@ -451,13 +451,13 @@ protected alias ⟨cod, _⟩ := isExtensionPair_iff_cod
 def definedAtLeft
     (h : L.IsExtensionPair M N) (m : M) : Order.Cofinal (FGEquiv L M N) where
   carrier := {f | m ∈ f.val.dom}
-  mem_gt := fun f => h f m
+  isCofinal := fun f => h f m
 
 /-- The cofinal set of finite equivalences with a given element in their codomain. -/
 def definedAtRight
     (h : L.IsExtensionPair N M) (n : N) : Order.Cofinal (FGEquiv L M N) where
   carrier := {f | n ∈ f.val.cod}
-  mem_gt := fun f => h.cod f n
+  isCofinal := fun f => h.cod f n
 
 end IsExtensionPair
 

--- a/Mathlib/Order/CountableDenseLinearOrder.lean
+++ b/Mathlib/Order/CountableDenseLinearOrder.lean
@@ -170,7 +170,7 @@ variable (β)
 def definedAtLeft [DenselyOrdered β] [NoMinOrder β] [NoMaxOrder β] [Nonempty β] (a : α) :
     Cofinal (PartialIso α β) where
   carrier := {f | ∃ b : β, (a, b) ∈ f.val}
-  mem_gt f := by
+  isCofinal f := by
     cases' exists_across f a with b a_b
     refine
       ⟨⟨insert (a, b) f.val, fun p hp q hq ↦ ?_⟩, ⟨b, Finset.mem_insert_self _ _⟩,
@@ -190,8 +190,8 @@ variable (α) {β}
 def definedAtRight [DenselyOrdered α] [NoMinOrder α] [NoMaxOrder α] [Nonempty α] (b : β) :
     Cofinal (PartialIso α β) where
   carrier := {f | ∃ a, (a, b) ∈ f.val}
-  mem_gt f := by
-    rcases (definedAtLeft α b).mem_gt f.comm with ⟨f', ⟨a, ha⟩, hl⟩
+  isCofinal f := by
+    rcases (definedAtLeft α b).isCofinal f.comm with ⟨f', ⟨a, ha⟩, hl⟩
     refine ⟨f'.comm, ⟨a, ?_⟩, ?_⟩
     · change (a, b) ∈ f'.val.image _
       rwa [← Finset.mem_coe, Finset.coe_image, Equiv.image_eq_preimage]

--- a/Mathlib/Order/Ideal.lean
+++ b/Mathlib/Order/Ideal.lean
@@ -6,6 +6,7 @@ Authors: David Wärn
 import Mathlib.Logic.Encodable.Basic
 import Mathlib.Order.Atoms
 import Mathlib.Order.Chain
+import Mathlib.Order.Cofinal
 import Mathlib.Order.UpperLower.Basic
 import Mathlib.Data.Set.Subsingleton
 
@@ -463,15 +464,17 @@ structure Cofinal (P) [Preorder P] where
   /-- The carrier of a `Cofinal` is the underlying set. -/
   carrier : Set P
   /-- The `Cofinal` contains arbitrarily large elements. -/
-  mem_gt : ∀ x : P, ∃ y ∈ carrier, x ≤ y
+  isCofinal : IsCofinal carrier
+
+@[deprecated Cofinal.isCofinal (since := "2024-12-02")]
+alias Cofinal.mem_gt := Cofinal.isCofinal
 
 namespace Cofinal
 
 variable [Preorder P]
 
 instance : Inhabited (Cofinal P) :=
-  ⟨{  carrier := univ
-      mem_gt := fun x ↦ ⟨x, trivial, le_rfl⟩ }⟩
+  ⟨_, .univ⟩
 
 instance : Membership P (Cofinal P) :=
   ⟨fun D x ↦ x ∈ D.carrier⟩
@@ -480,13 +483,13 @@ variable (D : Cofinal P) (x : P)
 
 /-- A (noncomputable) element of a cofinal set lying above a given element. -/
 noncomputable def above : P :=
-  Classical.choose <| D.mem_gt x
+  Classical.choose <| D.isCofinal x
 
 theorem above_mem : D.above x ∈ D :=
-  (Classical.choose_spec <| D.mem_gt x).1
+  (Classical.choose_spec <| D.isCofinal x).1
 
 theorem le_above : x ≤ D.above x :=
-  (Classical.choose_spec <| D.mem_gt x).2
+  (Classical.choose_spec <| D.isCofinal x).2
 
 end Cofinal
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
It might be desirable to get rid of `Order.Cofinal` altogether, but that would significant refactoring in files I'm not at all familiar with.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
