### PR TITLE
[Merged by Bors] - feat: unique differentiability of preimages under projection doesn't need the bundle to be smooth

### DIFF
--- a/Mathlib/Geometry/Manifold/MFDeriv/Tangent.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Tangent.lean
@@ -62,7 +62,7 @@ lemma mfderiv_chartAt_eq_tangentCoordChange {x y : M} (hsrc : x ∈ (chartAt H y
 the basis also has unique differential. -/
 theorem UniqueMDiffOn.tangentBundle_proj_preimage {s : Set M} (hs : UniqueMDiffOn I s) :
     UniqueMDiffOn I.tangent (π E (TangentSpace I) ⁻¹' s) :=
-  hs.smooth_bundle_preimage _
+  hs.bundle_preimage _
 
 /-- To write a linear map between tangent spaces in coordinates amounts to precomposing and
 postcomposing it with derivatives of extended charts.

--- a/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
@@ -139,7 +139,7 @@ private lemma UniqueMDiffWithinAt.bundle_preimage_aux {p : TotalSpace F Z}
   constructor
   · rw [PartialEquiv.prod_symm, PartialEquiv.refl_symm, PartialEquiv.prod_coe,
       ModelWithCorners.toPartialEquiv_coe_symm, PartialEquiv.refl_coe,
-      PartialHomeomorph.prod_symm, PartialHomeomorph.refl_symm, PartialHomeomorph.prod_coe,
+      PartialHomeomorph.prod_symm, PartialHomeomorph.refl_symm, PartialHomeomorph.prod_apply,
       PartialHomeomorph.refl_apply]
     convert hz.1
     apply Trivialization.proj_symm_apply'

--- a/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
@@ -158,6 +158,9 @@ theorem UniqueMDiffWithinAt.bundle_preimage {p : TotalSpace F Z}
   exact IsOpen.mem_nhds (trivializationAt F Z p.proj).open_baseSet
     (FiberBundle.mem_baseSet_trivializationAt' p.proj)
 
+@[deprecated (since := "2024-12-02")]
+alias UniqueMDiffWithinAt.smooth_bundle_preimage := UniqueMDiffWithinAt.bundle_preimage
+
 variable (Z)
 
 /-- In a fiber bundle, the preimage under the projection of a set with unique differentials
@@ -166,18 +169,24 @@ theorem UniqueMDiffWithinAt.bundle_preimage' {b : M} (hs : UniqueMDiffWithinAt I
     (x : Z b) : UniqueMDiffWithinAt (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) ⟨b, x⟩ :=
   hs.bundle_preimage (p := ⟨b, x⟩)
 
+@[deprecated (since := "2024-12-02")]
+alias UniqueMDiffWithinAt.smooth_bundle_preimage' := UniqueMDiffWithinAt.bundle_preimage'
+
 /-- In a fiber bundle, the preimage under the projection of a set with unique differentials
 in the base has unique differentials in the bundle. -/
 theorem UniqueMDiffOn.bundle_preimage (hs : UniqueMDiffOn I s) :
     UniqueMDiffOn (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) := fun _p hp ↦
   (hs _ hp).bundle_preimage
 
-/- TODO: move me -/
+@[deprecated (since := "2024-12-02")]
+alias UniqueMDiffOn.smooth_bundle_preimage := UniqueMDiffOn.bundle_preimage
+
+/- TODO: move me to `Mathlib.Geometry.Manifold.VectorBundle.MDifferentiable` once #19636 is in. -/
 variable [∀ b, AddCommMonoid (Z b)] [∀ b, Module 𝕜 (Z b)] [VectorBundle 𝕜 F Z]
 
 theorem Trivialization.mdifferentiable [SmoothVectorBundle F Z I]
     (e : Trivialization F (π F Z)) [MemTrivializationAtlas e] :
-    e.toPartialHomeomorph.MDifferentiable (I.prod 𝓘(𝕜, F)) (I.prod 𝓘(𝕜, F)) :=
+    e.MDifferentiable (I.prod 𝓘(𝕜, F)) (I.prod 𝓘(𝕜, F)) :=
   ⟨e.contMDiffOn.mdifferentiableOn le_top, e.contMDiffOn_symm.mdifferentiableOn le_top⟩
 
 end UniqueMDiff

--- a/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
@@ -115,36 +115,69 @@ end
 open Bundle
 
 variable {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] {Z : M → Type*}
-  [TopologicalSpace (TotalSpace F Z)] [∀ b, TopologicalSpace (Z b)] [∀ b, AddCommMonoid (Z b)]
-  [∀ b, Module 𝕜 (Z b)] [FiberBundle F Z] [VectorBundle 𝕜 F Z] [SmoothVectorBundle F Z I]
+  [TopologicalSpace (TotalSpace F Z)] [∀ b, TopologicalSpace (Z b)] [FiberBundle F Z]
 
-theorem Trivialization.mdifferentiable (e : Trivialization F (π F Z)) [MemTrivializationAtlas e] :
-    e.toPartialHomeomorph.MDifferentiable (I.prod 𝓘(𝕜, F)) (I.prod 𝓘(𝕜, F)) :=
-  ⟨e.contMDiffOn.mdifferentiableOn le_top, e.contMDiffOn_symm.mdifferentiableOn le_top⟩
+private lemma UniqueMDiffWithinAt.bundle_preimage_aux {p : TotalSpace F Z}
+    (hs : UniqueMDiffWithinAt I s p.proj) (h's : s ⊆ (trivializationAt F Z p.proj).baseSet) :
+    UniqueMDiffWithinAt (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) p := by
+  suffices ((extChartAt I p.proj).symm ⁻¹' s ∩ range I) ×ˢ univ ⊆
+      (extChartAt (I.prod 𝓘(𝕜, F)) p).symm ⁻¹' (TotalSpace.proj ⁻¹' s) ∩ range (I.prod 𝓘(𝕜, F)) by
+    let w := (extChartAt (I.prod 𝓘(𝕜, F)) p p).2
+    have A : extChartAt (I.prod 𝓘(𝕜, F)) p p = (extChartAt I p.1 p.1, w) := by
+      ext
+      · simp [FiberBundle.chartedSpace_chartAt]
+      · rfl
+    simp only [UniqueMDiffWithinAt, A] at hs ⊢
+    exact (hs.prod (uniqueDiffWithinAt_univ (x := w))).mono this
+  rcases p with ⟨x, v⟩
+  dsimp
+  rintro ⟨z, w⟩ ⟨hz, -⟩
+  simp only [ModelWithCorners.target_eq, mem_inter_iff, mem_preimage, Function.comp_apply,
+    mem_range] at hz
+  simp only [FiberBundle.chartedSpace_chartAt, PartialHomeomorph.coe_trans_symm, mem_inter_iff,
+    mem_preimage, Function.comp_apply, mem_range]
+  constructor
+  · rw [PartialEquiv.prod_symm, PartialEquiv.refl_symm, PartialEquiv.prod_coe,
+      ModelWithCorners.toPartialEquiv_coe_symm, PartialEquiv.refl_coe,
+      PartialHomeomorph.prod_symm, PartialHomeomorph.refl_symm, PartialHomeomorph.prod_coe,
+      PartialHomeomorph.refl_apply]
+    convert hz.1
+    apply Trivialization.proj_symm_apply'
+    exact h's hz.1
+  · rcases hz.2 with ⟨u, rfl⟩
+    exact ⟨(u, w), rfl⟩
 
-theorem UniqueMDiffWithinAt.smooth_bundle_preimage {p : TotalSpace F Z}
+/-- In a fiber bundle, the preimage under the projection of a set with unique differentials
+in the base has unique differentials in the bundle. -/
+theorem UniqueMDiffWithinAt.bundle_preimage {p : TotalSpace F Z}
     (hs : UniqueMDiffWithinAt I s p.proj) :
     UniqueMDiffWithinAt (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) p := by
-  set e := trivializationAt F Z p.proj
-  have hp : p ∈ e.source := FiberBundle.mem_trivializationAt_proj_source
-  have : UniqueMDiffWithinAt (I.prod 𝓘(𝕜, F)) (s ×ˢ univ) (e p) := by
-    rw [← Prod.mk.eta (p := e p), FiberBundle.trivializationAt_proj_fst]
-    exact hs.prod (uniqueMDiffWithinAt_univ _)
-  rw [← e.left_inv hp]
-  refine (this.preimage_partialHomeomorph e.mdifferentiable.symm (e.map_source hp)).mono ?_
-  rintro y ⟨hy, hys, -⟩
-  rwa [PartialHomeomorph.symm_symm, e.coe_coe, e.coe_fst hy] at hys
+  suffices UniqueMDiffWithinAt (I.prod 𝓘(𝕜, F))
+    (π F Z ⁻¹' (s ∩ (trivializationAt F Z p.proj).baseSet)) p from this.mono (by simp)
+  apply UniqueMDiffWithinAt.bundle_preimage_aux (hs.inter _) inter_subset_right
+  exact IsOpen.mem_nhds (trivializationAt F Z p.proj).open_baseSet
+    (FiberBundle.mem_baseSet_trivializationAt' p.proj)
 
 variable (Z)
 
-theorem UniqueMDiffWithinAt.smooth_bundle_preimage' {b : M} (hs : UniqueMDiffWithinAt I s b)
+/-- In a fiber bundle, the preimage under the projection of a set with unique differentials
+in the base has unique differentials in the bundle. Version with a point `⟨b, x⟩`. -/
+theorem UniqueMDiffWithinAt.bundle_preimage' {b : M} (hs : UniqueMDiffWithinAt I s b)
     (x : Z b) : UniqueMDiffWithinAt (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) ⟨b, x⟩ :=
-  hs.smooth_bundle_preimage (p := ⟨b, x⟩)
+  hs.bundle_preimage (p := ⟨b, x⟩)
 
-/-- In a smooth fiber bundle, the preimage under the projection of a set with
-unique differential in the basis also has unique differential. -/
-theorem UniqueMDiffOn.smooth_bundle_preimage (hs : UniqueMDiffOn I s) :
+/-- In a fiber bundle, the preimage under the projection of a set with unique differentials
+in the base has unique differentials in the bundle. -/
+theorem UniqueMDiffOn.bundle_preimage (hs : UniqueMDiffOn I s) :
     UniqueMDiffOn (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) := fun _p hp ↦
-  (hs _ hp).smooth_bundle_preimage
+  (hs _ hp).bundle_preimage
+
+/- TODO: move me -/
+variable [∀ b, AddCommMonoid (Z b)] [∀ b, Module 𝕜 (Z b)] [VectorBundle 𝕜 F Z]
+
+theorem Trivialization.mdifferentiable [SmoothVectorBundle F Z I]
+    (e : Trivialization F (π F Z)) [MemTrivializationAtlas e] :
+    e.toPartialHomeomorph.MDifferentiable (I.prod 𝓘(𝕜, F)) (I.prod 𝓘(𝕜, F)) :=
+  ⟨e.contMDiffOn.mdifferentiableOn le_top, e.contMDiffOn_symm.mdifferentiableOn le_top⟩
 
 end UniqueMDiff

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -873,7 +873,7 @@ theorem prod_symm (eX : PartialHomeomorph X X') (eY : PartialHomeomorph Y Y') :
 
 @[simp, mfld_simps]
 theorem prod_coe (eX : PartialHomeomorph X X') (eY : PartialHomeomorph Y Y') :
-    (eX.prod eY : X × Y → X' × Y') = fun p => (eX p.1, eY p.2) :=
+    (eX.prod eY : X × Y → X' × Y') = Prod.map eX eY :=
   rfl
 
 @[simp]

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -871,6 +871,11 @@ theorem prod_symm (eX : PartialHomeomorph X X') (eY : PartialHomeomorph Y Y') :
     (eX.prod eY).symm = eX.symm.prod eY.symm :=
   rfl
 
+@[simp, mfld_simps]
+theorem prod_coe (eX : PartialHomeomorph X X') (eY : PartialHomeomorph Y Y') :
+    (eX.prod eY : X × Y → X' × Y') = fun p => (eX p.1, eY p.2) :=
+  rfl
+
 @[simp]
 theorem refl_prod_refl :
     (PartialHomeomorph.refl X).prod (PartialHomeomorph.refl Y) = PartialHomeomorph.refl (X × Y) :=

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -871,11 +871,6 @@ theorem prod_symm (eX : PartialHomeomorph X X') (eY : PartialHomeomorph Y Y') :
     (eX.prod eY).symm = eX.symm.prod eY.symm :=
   rfl
 
-@[simp, mfld_simps]
-theorem prod_coe (eX : PartialHomeomorph X X') (eY : PartialHomeomorph Y Y') :
-    (eX.prod eY : X × Y → X' × Y') = Prod.map eX eY :=
-  rfl
-
 @[simp]
 theorem refl_prod_refl :
     (PartialHomeomorph.refl X).prod (PartialHomeomorph.refl Y) = PartialHomeomorph.refl (X × Y) :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
