### PR TITLE
[Merged by Bors] - feat(CategoryTheory): infer filteredness from filteredness of costructured arrow categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1712,6 +1712,7 @@ import Mathlib.CategoryTheory.FiberedCategory.Fibered
 import Mathlib.CategoryTheory.FiberedCategory.HomLift
 import Mathlib.CategoryTheory.Filtered.Basic
 import Mathlib.CategoryTheory.Filtered.Connected
+import Mathlib.CategoryTheory.Filtered.CostructuredArrow
 import Mathlib.CategoryTheory.Filtered.Final
 import Mathlib.CategoryTheory.Filtered.Grothendieck
 import Mathlib.CategoryTheory.Filtered.OfColimitCommutesFiniteLimit
@@ -1841,6 +1842,7 @@ import Mathlib.CategoryTheory.Limits.Preserves.Basic
 import Mathlib.CategoryTheory.Limits.Preserves.Filtered
 import Mathlib.CategoryTheory.Limits.Preserves.Finite
 import Mathlib.CategoryTheory.Limits.Preserves.FunctorCategory
+import Mathlib.CategoryTheory.Limits.Preserves.Grothendieck
 import Mathlib.CategoryTheory.Limits.Preserves.Limits
 import Mathlib.CategoryTheory.Limits.Preserves.Opposites
 import Mathlib.CategoryTheory.Limits.Preserves.Presheaf

--- a/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
+++ b/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
@@ -43,7 +43,6 @@ theorem isFiltered_of_isFiltered_costructuredArrow (L : A ⥤ T) (R : B ⥤ T)
     colim.map ?_ ≫
     colimit.pre _ R' ≫
     (colimitIsoColimitGrothendieck L (limit F)).inv
-  rw [← Functor.assoc, ← Functor.assoc]
   exact (limitCompWhiskeringLeftIsoCompLimit F (R' ⋙ CostructuredArrow.grothendieckProj L)).hom⟩
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
+++ b/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
@@ -8,6 +8,7 @@ import Mathlib.CategoryTheory.Functor.KanExtension.Adjunction
 import Mathlib.CategoryTheory.Limits.FilteredColimitCommutesFiniteLimit
 import Mathlib.CategoryTheory.Limits.Preserves.Grothendieck
 import Mathlib.CategoryTheory.Limits.Final
+
 /-!
 # Inferring Filteredness from Filteredness of Costructured Arrow Categories
 

--- a/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
+++ b/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
@@ -7,6 +7,14 @@ import Mathlib.CategoryTheory.Filtered.OfColimitCommutesFiniteLimit
 import Mathlib.CategoryTheory.Functor.KanExtension.Adjunction
 import Mathlib.CategoryTheory.Limits.FilteredColimitCommutesFiniteLimit
 import Mathlib.CategoryTheory.Limits.Final
+/-!
+# Inferring Filteredness from Filteredness of Costructured Arrow Categories
+
+# References
+
+* [M. Kashiwara, P. Schapira, *Categories and Sheaves*][Kashiwara2006], Proposition 3.1.8
+
+-/
 
 universe w v₁ u₁
 
@@ -17,13 +25,15 @@ open Limits Functor
 variable {A : Type u₁} [SmallCategory A] {B : Type u₁} [SmallCategory B]
 variable {T : Type u₁} [SmallCategory T]
 
-def isFiltered_of_isFiltered_costructuredArrow (L : A ⥤ T) (R : B ⥤ T)
+/-- Given functors `L : A ⥤ T` and `R : B ⥤ T` with a common codomain we can conclude that `A`
+is filtered given that `R` is final, `B` is filtered and each costructured arrow category
+`CostructuredArrow L (R.obj b)` is filtered. -/
+theorem isFiltered_of_isFiltered_costructuredArrow (L : A ⥤ T) (R : B ⥤ T)
     [IsFiltered B] [Final R] [∀ b, IsFiltered (CostructuredArrow L (R.obj b))] : IsFiltered A :=
   isFiltered_of_nonempty_limit_colimit_to_colimit_limit fun J {_ _} F => ⟨by
   let R' := Grothendieck.pre (CostructuredArrow.functor L) R
   haveI : ∀ b, PreservesLimitsOfShape J
-      (colim (J := (R ⋙ CostructuredArrow.functor L).obj b) (C := Type u₁)) := by
-    intro b
+      (colim (J := (R ⋙ CostructuredArrow.functor L).obj b) (C := Type u₁)) := fun b => by
     simp only [comp_obj, CostructuredArrow.functor_obj, Cat.of_α]
     exact filtered_colim_preservesFiniteLimits
   refine lim.map ((colimitIsoColimitGrothendieck L F.flip).hom ≫

--- a/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
+++ b/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2024 Jakob von Raumer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jakob von Raumer
+-/
+import Mathlib.CategoryTheory.Filtered.OfColimitCommutesFiniteLimit
+import Mathlib.CategoryTheory.Functor.KanExtension.Adjunction
+import Mathlib.CategoryTheory.Limits.Final
+
+universe w v₁ v₂ v₃ u₁ u₂ u₃
+
+namespace CategoryTheory
+
+open Limits Functor
+
+variable {A : Type u₁} [SmallCategory A]
+variable {B : Type u₁} [SmallCategory B]
+variable {T : Type u₁} [SmallCategory T]
+variable (L : A ⥤ T) (R : B ⥤ T)
+
+variable [IsFiltered B] [Final R] [∀ b : B, IsFiltered (CostructuredArrow L (R.obj b))]
+
+def foo : IsFiltered A := by
+  apply isFiltered_of_nonempty_limit_colimit_to_colimit_limit
+  intro J _ _ F
+  constructor
+  let R' := Grothendieck.pre (CostructuredArrow.functor L) R
+  haveI : IsIso (colimit.pre (CostructuredArrow.grothendieckProj L ⋙ F.flip) R') :=
+    Final.colimit_pre_isIso R'
+  refine lim.map (colimitIsoColimitGrothendieck L F.flip).hom ≫
+    lim.map (inv (colimit.pre (CostructuredArrow.grothendieckProj L ⋙ F.flip) R')) ≫ ?_
+  sorry
+
+#check IsIso
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
+++ b/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
@@ -8,36 +8,24 @@ import Mathlib.CategoryTheory.Functor.KanExtension.Adjunction
 import Mathlib.CategoryTheory.Limits.FilteredColimitCommutesFiniteLimit
 import Mathlib.CategoryTheory.Limits.Final
 
-universe w v₁ v₂ v₃ u₁ u₂ u₃
+universe w v₁ u₁
 
 namespace CategoryTheory
 
 open Limits Functor
 
-variable {A : Type u₁} [SmallCategory A]
-variable {B : Type u₁} [SmallCategory B]
+variable {A : Type u₁} [SmallCategory A] {B : Type u₁} [SmallCategory B]
 variable {T : Type u₁} [SmallCategory T]
-variable (L : A ⥤ T) (R : B ⥤ T)
 
-variable [IsFiltered B] [Final R] [∀ b, IsFiltered (CostructuredArrow L (R.obj b))]
-
-def isFiltered_of_isFiltered_costructuredArrow : IsFiltered A := by
-  apply isFiltered_of_nonempty_limit_colimit_to_colimit_limit
-  intro J _ _ F
-  constructor
+def isFiltered_of_isFiltered_costructuredArrow (L : A ⥤ T) (R : B ⥤ T)
+    [IsFiltered B] [Final R] [∀ b, IsFiltered (CostructuredArrow L (R.obj b))] : IsFiltered A :=
+  isFiltered_of_nonempty_limit_colimit_to_colimit_limit fun J {_ _} F => ⟨by
   let R' := Grothendieck.pre (CostructuredArrow.functor L) R
-  haveI : IsIso (colimit.pre (CostructuredArrow.grothendieckProj L ⋙ F.flip) R') :=
-    Final.colimit_pre_isIso R'
-  haveI : PreservesLimitsOfShape J (colim (J := B) (C := Type u₁)) :=
-    inferInstance
   haveI : ∀ b, PreservesLimitsOfShape J
       (colim (J := (R ⋙ CostructuredArrow.functor L).obj b) (C := Type u₁)) := by
     intro b
     simp only [comp_obj, CostructuredArrow.functor_obj, Cat.of_α]
     exact filtered_colim_preservesFiniteLimits
-  haveI : PreservesLimitsOfShape J
-      (colim (J := (Grothendieck (R ⋙ CostructuredArrow.functor L))) (C := Type u₁)) := by
-    sorry  -- TODO general lemma on `Grothendieck`
   refine lim.map ((colimitIsoColimitGrothendieck L F.flip).hom ≫
     (inv (colimit.pre (CostructuredArrow.grothendieckProj L ⋙ F.flip) R'))) ≫
     (colimitLimitIso (R' ⋙ CostructuredArrow.grothendieckProj L ⋙ F.flip).flip).inv ≫
@@ -45,6 +33,6 @@ def isFiltered_of_isFiltered_costructuredArrow : IsFiltered A := by
     colimit.pre _ R' ≫
     (colimitIsoColimitGrothendieck L (limit F)).inv
   rw [← Functor.assoc, ← Functor.assoc]
-  exact (limitCompWhiskeringLeftIsoCompLimit F (R' ⋙ CostructuredArrow.grothendieckProj L)).hom
+  exact (limitCompWhiskeringLeftIsoCompLimit F (R' ⋙ CostructuredArrow.grothendieckProj L)).hom⟩
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
+++ b/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
@@ -6,6 +6,7 @@ Authors: Jakob von Raumer
 import Mathlib.CategoryTheory.Filtered.OfColimitCommutesFiniteLimit
 import Mathlib.CategoryTheory.Functor.KanExtension.Adjunction
 import Mathlib.CategoryTheory.Limits.FilteredColimitCommutesFiniteLimit
+import Mathlib.CategoryTheory.Limits.Preserves.Grothendieck
 import Mathlib.CategoryTheory.Limits.Final
 /-!
 # Inferring Filteredness from Filteredness of Costructured Arrow Categories

--- a/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
+++ b/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
@@ -5,6 +5,7 @@ Authors: Jakob von Raumer
 -/
 import Mathlib.CategoryTheory.Filtered.OfColimitCommutesFiniteLimit
 import Mathlib.CategoryTheory.Functor.KanExtension.Adjunction
+import Mathlib.CategoryTheory.Limits.FilteredColimitCommutesFiniteLimit
 import Mathlib.CategoryTheory.Limits.Final
 
 universe w v₁ v₂ v₃ u₁ u₂ u₃
@@ -18,19 +19,32 @@ variable {B : Type u₁} [SmallCategory B]
 variable {T : Type u₁} [SmallCategory T]
 variable (L : A ⥤ T) (R : B ⥤ T)
 
-variable [IsFiltered B] [Final R] [∀ b : B, IsFiltered (CostructuredArrow L (R.obj b))]
+variable [IsFiltered B] [Final R] [∀ b, IsFiltered (CostructuredArrow L (R.obj b))]
 
-def foo : IsFiltered A := by
+def isFiltered_of_isFiltered_costructuredArrow : IsFiltered A := by
   apply isFiltered_of_nonempty_limit_colimit_to_colimit_limit
   intro J _ _ F
   constructor
   let R' := Grothendieck.pre (CostructuredArrow.functor L) R
   haveI : IsIso (colimit.pre (CostructuredArrow.grothendieckProj L ⋙ F.flip) R') :=
     Final.colimit_pre_isIso R'
-  refine lim.map (colimitIsoColimitGrothendieck L F.flip).hom ≫
-    lim.map (inv (colimit.pre (CostructuredArrow.grothendieckProj L ⋙ F.flip) R')) ≫ ?_
-  sorry
-
-#check IsIso
+  haveI : PreservesLimitsOfShape J (colim (J := B) (C := Type u₁)) :=
+    inferInstance
+  haveI : ∀ b, PreservesLimitsOfShape J
+      (colim (J := (R ⋙ CostructuredArrow.functor L).obj b) (C := Type u₁)) := by
+    intro b
+    simp only [comp_obj, CostructuredArrow.functor_obj, Cat.of_α]
+    exact filtered_colim_preservesFiniteLimits
+  haveI : PreservesLimitsOfShape J
+      (colim (J := (Grothendieck (R ⋙ CostructuredArrow.functor L))) (C := Type u₁)) := by
+    sorry  -- TODO general lemma on `Grothendieck`
+  refine lim.map ((colimitIsoColimitGrothendieck L F.flip).hom ≫
+    (inv (colimit.pre (CostructuredArrow.grothendieckProj L ⋙ F.flip) R'))) ≫
+    (colimitLimitIso (R' ⋙ CostructuredArrow.grothendieckProj L ⋙ F.flip).flip).inv ≫
+    colim.map ?_ ≫
+    colimit.pre _ R' ≫
+    (colimitIsoColimitGrothendieck L (limit F)).inv
+  rw [← Functor.assoc, ← Functor.assoc]
+  exact (limitCompWhiskeringLeftIsoCompLimit F (R' ⋙ CostructuredArrow.grothendieckProj L)).hom
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Filtered/OfColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Filtered/OfColimitCommutesFiniteLimit.lean
@@ -18,7 +18,7 @@ variable {K : Type v} [SmallCategory K]
 
 open Limits
 
-/-- A converse to `colimitLimitIsoLimitColimit`: if colimits of shape `K` commute with finite
+/-- A converse to `colimitLimitIso`: if colimits of shape `K` commute with finite
 limits, then `K` is filtered. -/
 theorem isFiltered_of_nonempty_limit_colimit_to_colimit_limit
     (h : ∀ {J : Type v} [SmallCategory J] [FinCategory J] (F : J ⥤ K ⥤ Type v),

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -59,7 +59,7 @@ variable (C) (F) in
 /-- If `colim` on a category `C` preserves limits of shape `J` and if it does so for `colim` on
 every `F.obj c` for a functor `F : C ⥤ Cat`, then `colim` on `Grothendieck F` also preserves limits
 of shape `J`. -/
-instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H] [HasLimitsOfShape J H]
+instance preservesLimitsOfShape_colim_grothendieck [HasColimitsOfShape C H] [HasLimitsOfShape J H]
     [∀ c, HasColimitsOfShape (↑(F.obj c)) H] [PreservesLimitsOfShape J (colim (J := C) (C := H))]
     [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
     PreservesLimitsOfShape J (colim (J := Grothendieck F) (C := H)) := by

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -6,10 +6,36 @@ namespace CategoryTheory
 
 namespace Limits
 
+noncomputable section
+
 variable {C : Type u₁} [Category.{v₁} C]
 variable {H : Type u₂} [Category.{v₂} H]
 variable {J : Type u₁} [Category.{v₁} J]
 variable {F : C ⥤ Cat}
+
+def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H) [HasLimit K]
+    [∀ {X Y : C} (f : X ⟶ Y), HasColimit (F.map f ⋙ Grothendieck.ι F Y ⋙ limit K)]
+    [∀ (G : Grothendieck F ⥤ H) {X Y : C} (f : X ⟶ Y),
+       HasColimit (F.map f ⋙ Grothendieck.ι F Y ⋙ G)]
+    [HasLimit (K ⋙ fiberwiseColimit')]
+    [∀ c, HasColimit (Grothendieck.ι F c ⋙ limit K)]
+    [∀ c, HasLimit ((K ⋙ fiberwiseColimit') ⋙ (evaluation C H).obj c)]
+    [HasLimitsOfShape J H]
+    [HasColimitsOfShape C H]
+    [∀ c, HasColimitsOfShape (↑(F.obj c)) H]
+    [hC : PreservesLimitsOfShape J (colim (J := C) (C := H))]
+    [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
+    fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColimit') :=
+  NatIso.ofComponents
+    (fun c => HasColimit.isoOfNatIso
+       (limitCompWhiskeringLeftIsoCompLimit K (Grothendieck.ι F c)).symm ≪≫
+      preservesLimitIso colim _ ≪≫
+      HasLimit.isoOfNatIso
+        (Functor.associator _ _ _ ≪≫
+        isoWhiskerLeft _ sorry ≪≫
+        (Functor.associator _ _ _).symm) ≪≫
+      (limitObjIsoLimitCompEvaluation _ c).symm)
+    sorry
 
 variable (C) (F) in
 instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
@@ -19,27 +45,17 @@ instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
     PreservesLimitsOfShape J (colim (J := Grothendieck F) (C := H)) := by
   haveI : HasLimitsOfShape J (Grothendieck F ⥤ H) := sorry
   haveI : HasLimitsOfShape J (C ⥤ H) := sorry
-  haveI : HasLimitsOfShape J H := sorry
   haveI : HasLimitsOfShape C H := sorry
   haveI : HasColimitsOfShape J (C ⥤ H) := sorry
+  haveI : HasLimitsOfShape J H := sorry
   constructor
   intro K
-  haveI : ∀ c, HasLimit (K ⋙ (whiskeringLeft (↑(F.obj c)) (Grothendieck F) H).obj (Grothendieck.ι F c)) := sorry
-  let i₀ : ∀ c, Grothendieck.ι F c ⋙ limit K ≅
-    limit (K ⋙ (whiskeringLeft _ _ _).obj (Grothendieck.ι F c)) := sorry
-  let i₁ : fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColimit') :=
-    NatIso.ofComponents
-      (fun c => HasColimit.isoOfNatIso (i₀ c) ≪≫
-        preservesLimitIso colim _ ≪≫
-        HasLimit.isoOfNatIso
-          (Functor.associator _ _ _ ≪≫
-          isoWhiskerLeft _ _ ≪≫
-          (Functor.associator _ _ _).symm) ≪≫
-        (limitObjIsoLimitCompEvaluation _ c).symm)
-      _
+  haveI : ∀ c, HasLimit (K ⋙
+    (whiskeringLeft (↑(F.obj c)) (Grothendieck F) H).obj (Grothendieck.ι F c)) := sorry
   let i₂ := calc colimit (limit K)
     _ ≅ colimit (fiberwiseColimit (limit K)) := (colimitFiberwiseColimitIso _).symm
-    _ ≅ colimit (limit (K ⋙ fiberwiseColimit')) := HasColimit.isoOfNatIso i₁
+    _ ≅ colimit (limit (K ⋙ fiberwiseColimit')) :=
+          HasColimit.isoOfNatIso (fiberwiseColimitLimitIso _)
     _ ≅ limit ((K ⋙ fiberwiseColimit') ⋙ colim) :=
           preservesLimitIso colim (K ⋙ fiberwiseColimit')
     _ ≅ limit (K ⋙ colim) := by sorry  -- TODO functorialisation of `colimitFiberwiseColimitIso`
@@ -51,9 +67,7 @@ instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
     sorry
   apply preservesLimit_of_isIso_post
 
-#check limitCompWhiskeringRightIsoLimitComp
-#check limitObjIsoLimitCompEvaluation
-#check Functor.associator
+end
 
 end Limits
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -31,7 +31,7 @@ then the fiberwise colimit of the limit of a functor `K : J ⥤ Grothendieck F �
 isomorphic to taking the limit of the composition `K ⋙ fiberwiseColim F H`. -/
 @[simps!]
 def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H)
-    [∀ (c : C), HasColimitsOfShape (↑(F.obj c)) H] [HasLimitsOfShape J H] [HasColimitsOfShape C H]
+    [∀ (c : C), HasColimitsOfShape (↑(F.obj c)) H] [HasLimitsOfShape J H]
     [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
     fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColim F H) :=
   NatIso.ofComponents
@@ -58,9 +58,8 @@ variable (C) (F) in
 /-- If `colim` on a category `C` preserves limits of shape `J` and if it does so for `colim` on
 every `F.obj c` for a functor `F : C ⥤ Cat`, then `colim` on `Grothendieck F` also preserves limits
 of shape `J`. -/
-instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
-    [∀ c, HasColimitsOfShape (↑(F.obj c)) H] [∀ c, HasLimitsOfShape J ((F.obj c) ⥤ H)]
-    [HasLimitsOfShape J H] [PreservesLimitsOfShape J (colim (J := C) (C := H))]
+instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H] [HasLimitsOfShape J H]
+    [∀ c, HasColimitsOfShape (↑(F.obj c)) H] [PreservesLimitsOfShape J (colim (J := C) (C := H))]
     [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
     PreservesLimitsOfShape J (colim (J := Grothendieck F) (C := H)) := by
   constructor

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -13,6 +13,7 @@ variable {H : Type u₂} [Category.{v₂} H]
 variable {J : Type u₁} [Category.{v₁} J]
 variable {F : C ⥤ Cat}
 
+@[simps!]
 def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H)
     [∀ (c : C), HasColimitsOfShape (↑(F.obj c)) H] [HasLimitsOfShape J H] [HasColimitsOfShape C H]
     [hC : PreservesLimitsOfShape J (colim (J := C) (C := H))]
@@ -27,23 +28,22 @@ def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H)
         isoWhiskerLeft _ (fiberwiseColimcompEvaluationIso _).symm ≪≫
         (Functor.associator _ _ _).symm) ≪≫
       (limitObjIsoLimitCompEvaluation _ c).symm)
-    sorry
+    fun {c₁ c₂} f => by
+      simp
+      apply colimit.hom_ext
+      intro d
+      simp
+      sorry
 
 variable (C) (F) in
 instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
     [∀ c, HasColimitsOfShape (↑(F.obj c)) H]
+    [∀ c, HasLimitsOfShape J ((F.obj c) ⥤ H)] [HasLimitsOfShape J H]
     [hC : PreservesLimitsOfShape J (colim (J := C) (C := H))]
     [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
     PreservesLimitsOfShape J (colim (J := Grothendieck F) (C := H)) := by
-  haveI : HasLimitsOfShape J (Grothendieck F ⥤ H) := sorry
-  haveI : HasLimitsOfShape J (C ⥤ H) := sorry
-  haveI : HasLimitsOfShape C H := sorry
-  haveI : HasColimitsOfShape J (C ⥤ H) := sorry
-  haveI : HasLimitsOfShape J H := sorry
   constructor
   intro K
-  haveI : ∀ c, HasLimit (K ⋙
-    (whiskeringLeft (↑(F.obj c)) (Grothendieck F) H).obj (Grothendieck.ι F c)) := sorry
   let i₂ := calc colimit (limit K)
     _ ≅ colimit (fiberwiseColimit (limit K)) := (colimitFiberwiseColimitIso _).symm
     _ ≅ colimit (limit (K ⋙ fiberwiseColim _ _)) :=
@@ -55,9 +55,12 @@ instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
        (Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ fiberwiseColimCompColimIso)
   haveI : IsIso (limit.post K colim) := by
     convert Iso.isIso_hom i₂
-    apply colimit.hom_ext
+    apply limit.hom_ext
     intro d
-    ext d'
+    simp [i₂]
+    apply colimit.hom_ext
+    intro d'
+    simp
     sorry
   apply preservesLimit_of_isIso_post
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -1,0 +1,60 @@
+import Mathlib.CategoryTheory.Limits.Preserves.FunctorCategory
+
+universe v₁ v₂ u₁ u₂
+
+namespace CategoryTheory
+
+namespace Limits
+
+variable {C : Type u₁} [Category.{v₁} C]
+variable {H : Type u₂} [Category.{v₂} H]
+variable {J : Type u₁} [Category.{v₁} J]
+variable {F : C ⥤ Cat}
+
+variable (C) (F) in
+instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
+    [∀ c, HasColimitsOfShape (↑(F.obj c)) H]
+    [hC : PreservesLimitsOfShape J (colim (J := C) (C := H))]
+    [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
+    PreservesLimitsOfShape J (colim (J := Grothendieck F) (C := H)) := by
+  haveI : HasLimitsOfShape J (Grothendieck F ⥤ H) := sorry
+  haveI : HasLimitsOfShape J (C ⥤ H) := sorry
+  haveI : HasLimitsOfShape J H := sorry
+  haveI : HasLimitsOfShape C H := sorry
+  haveI : HasColimitsOfShape J (C ⥤ H) := sorry
+  constructor
+  intro K
+  haveI : ∀ c, HasLimit (K ⋙ (whiskeringLeft (↑(F.obj c)) (Grothendieck F) H).obj (Grothendieck.ι F c)) := sorry
+  let i₀ : ∀ c, Grothendieck.ι F c ⋙ limit K ≅
+    limit (K ⋙ (whiskeringLeft _ _ _).obj (Grothendieck.ι F c)) := sorry
+  let i₁ : fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColimit') :=
+    NatIso.ofComponents
+      (fun c => HasColimit.isoOfNatIso (i₀ c) ≪≫
+        preservesLimitIso colim _ ≪≫
+        HasLimit.isoOfNatIso
+          (Functor.associator _ _ _ ≪≫
+          isoWhiskerLeft _ _ ≪≫
+          (Functor.associator _ _ _).symm) ≪≫
+        (limitObjIsoLimitCompEvaluation _ c).symm)
+      _
+  let i₂ := calc colimit (limit K)
+    _ ≅ colimit (fiberwiseColimit (limit K)) := (colimitFiberwiseColimitIso _).symm
+    _ ≅ colimit (limit (K ⋙ fiberwiseColimit')) := HasColimit.isoOfNatIso i₁
+    _ ≅ limit ((K ⋙ fiberwiseColimit') ⋙ colim) :=
+          preservesLimitIso colim (K ⋙ fiberwiseColimit')
+    _ ≅ limit (K ⋙ colim) := by sorry  -- TODO functorialisation of `colimitFiberwiseColimitIso`
+  haveI : IsIso (limit.post K colim) := by
+    convert Iso.isIso_hom i₂
+    apply colimit.hom_ext
+    intro d
+    ext d'
+    sorry
+  apply preservesLimit_of_isIso_post
+
+#check limitCompWhiskeringRightIsoLimitComp
+#check limitObjIsoLimitCompEvaluation
+#check Functor.associator
+
+end Limits
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -5,7 +5,15 @@ Authors: Jakob von Raumer
 -/
 import Mathlib.CategoryTheory.Limits.Preserves.FunctorCategory
 
-universe v₁ v₂ u₁ u₂
+/-!
+# Colimits on Grothendieck constructions preserving limits
+
+We characterize the condition in which colimits on Grothendieck constructions preserve limits: By
+preserving limits on the Grothendieck construction's base category as well as on each of its fibers.
+-/
+
+
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 namespace CategoryTheory
 
@@ -15,14 +23,17 @@ noncomputable section
 
 variable {C : Type u₁} [Category.{v₁} C]
 variable {H : Type u₂} [Category.{v₂} H]
-variable {J : Type u₁} [Category.{v₁} J]
-variable {F : C ⥤ Cat}
+variable {J : Type u₃} [Category.{v₃} J]
+variable {F : C ⥤ Cat.{v₄, u₄}}
 
+/-- If `colim` on each fiber `F.obj c` of a functor `F : C ⥤ Cat` preserves limits of shape `J`,
+then the fiberwise colimit of the limit of a functor `K : J ⥤ Grothendieck F ⥤ H` is naturally
+isomorphic to taking the limit of the composition `K ⋙ fiberwiseColim F H`. -/
 @[simps!]
 def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H)
     [∀ (c : C), HasColimitsOfShape (↑(F.obj c)) H] [HasLimitsOfShape J H] [HasColimitsOfShape C H]
     [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
-    fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColim _ _) :=
+    fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColim F H) :=
   NatIso.ofComponents
     (fun c => HasColimit.isoOfNatIso
        (limitCompWhiskeringLeftIsoCompLimit K (Grothendieck.ι F c)).symm ≪≫
@@ -44,6 +55,9 @@ def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H)
       simp [← NatTrans.comp_app_assoc]
 
 variable (C) (F) in
+/-- If `colim` on a category `C` preserves limits of shape `J` and if it does so for `colim` on
+every `F.obj c` for a functor `F : C ⥤ Cat`, then `colim` on `Grothendieck F` also preserves limits
+of shape `J`. -/
 instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
     [∀ c, HasColimitsOfShape (↑(F.obj c)) H] [∀ c, HasLimitsOfShape J ((F.obj c) ⥤ H)]
     [HasLimitsOfShape J H] [PreservesLimitsOfShape J (colim (J := C) (C := H))]

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -13,19 +13,11 @@ variable {H : Type u₂} [Category.{v₂} H]
 variable {J : Type u₁} [Category.{v₁} J]
 variable {F : C ⥤ Cat}
 
-def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H) [HasLimit K]
-    [∀ {X Y : C} (f : X ⟶ Y), HasColimit (F.map f ⋙ Grothendieck.ι F Y ⋙ limit K)]
-    [∀ (G : Grothendieck F ⥤ H) {X Y : C} (f : X ⟶ Y),
-       HasColimit (F.map f ⋙ Grothendieck.ι F Y ⋙ G)]
-    [HasLimit (K ⋙ fiberwiseColimit')]
-    [∀ c, HasColimit (Grothendieck.ι F c ⋙ limit K)]
-    [∀ c, HasLimit ((K ⋙ fiberwiseColimit') ⋙ (evaluation C H).obj c)]
-    [HasLimitsOfShape J H]
-    [HasColimitsOfShape C H]
-    [∀ c, HasColimitsOfShape (↑(F.obj c)) H]
+def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H)
+    [∀ (c : C), HasColimitsOfShape (↑(F.obj c)) H] [HasLimitsOfShape J H] [HasColimitsOfShape C H]
     [hC : PreservesLimitsOfShape J (colim (J := C) (C := H))]
     [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
-    fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColimit') :=
+    fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColim) :=
   NatIso.ofComponents
     (fun c => HasColimit.isoOfNatIso
        (limitCompWhiskeringLeftIsoCompLimit K (Grothendieck.ι F c)).symm ≪≫
@@ -54,10 +46,10 @@ instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
     (whiskeringLeft (↑(F.obj c)) (Grothendieck F) H).obj (Grothendieck.ι F c)) := sorry
   let i₂ := calc colimit (limit K)
     _ ≅ colimit (fiberwiseColimit (limit K)) := (colimitFiberwiseColimitIso _).symm
-    _ ≅ colimit (limit (K ⋙ fiberwiseColimit')) :=
+    _ ≅ colimit (limit (K ⋙ fiberwiseColim)) :=
           HasColimit.isoOfNatIso (fiberwiseColimitLimitIso _)
-    _ ≅ limit ((K ⋙ fiberwiseColimit') ⋙ colim) :=
-          preservesLimitIso colim (K ⋙ fiberwiseColimit')
+    _ ≅ limit ((K ⋙ fiberwiseColim) ⋙ colim) :=
+          preservesLimitIso colim (K ⋙ fiberwiseColim)
     _ ≅ limit (K ⋙ colim) := by sorry  -- TODO functorialisation of `colimitFiberwiseColimitIso`
   haveI : IsIso (limit.post K colim) := by
     convert Iso.isIso_hom i₂

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -17,14 +17,14 @@ def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H)
     [∀ (c : C), HasColimitsOfShape (↑(F.obj c)) H] [HasLimitsOfShape J H] [HasColimitsOfShape C H]
     [hC : PreservesLimitsOfShape J (colim (J := C) (C := H))]
     [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
-    fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColim) :=
+    fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColim _ _) :=
   NatIso.ofComponents
     (fun c => HasColimit.isoOfNatIso
        (limitCompWhiskeringLeftIsoCompLimit K (Grothendieck.ι F c)).symm ≪≫
       preservesLimitIso colim _ ≪≫
       HasLimit.isoOfNatIso
         (Functor.associator _ _ _ ≪≫
-        isoWhiskerLeft _ sorry ≪≫
+        isoWhiskerLeft _ (fiberwiseColimcompEvaluationIso _).symm ≪≫
         (Functor.associator _ _ _).symm) ≪≫
       (limitObjIsoLimitCompEvaluation _ c).symm)
     sorry
@@ -46,11 +46,13 @@ instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
     (whiskeringLeft (↑(F.obj c)) (Grothendieck F) H).obj (Grothendieck.ι F c)) := sorry
   let i₂ := calc colimit (limit K)
     _ ≅ colimit (fiberwiseColimit (limit K)) := (colimitFiberwiseColimitIso _).symm
-    _ ≅ colimit (limit (K ⋙ fiberwiseColim)) :=
+    _ ≅ colimit (limit (K ⋙ fiberwiseColim _ _)) :=
           HasColimit.isoOfNatIso (fiberwiseColimitLimitIso _)
-    _ ≅ limit ((K ⋙ fiberwiseColim) ⋙ colim) :=
-          preservesLimitIso colim (K ⋙ fiberwiseColim)
-    _ ≅ limit (K ⋙ colim) := by sorry  -- TODO functorialisation of `colimitFiberwiseColimitIso`
+    _ ≅ limit ((K ⋙ fiberwiseColim _ _) ⋙ colim) :=
+          preservesLimitIso colim (K ⋙ fiberwiseColim _ _)
+    _ ≅ limit (K ⋙ colim) :=
+      HasLimit.isoOfNatIso
+       (Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ fiberwiseColimCompColimIso)
   haveI : IsIso (limit.post K colim) := by
     convert Iso.isIso_hom i₂
     apply colimit.hom_ext

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -41,7 +41,7 @@ def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H)
       preservesLimitIso colim _ ≪≫
       HasLimit.isoOfNatIso
         (Functor.associator _ _ _ ≪≫
-        isoWhiskerLeft _ (fiberwiseColimcompEvaluationIso _).symm ≪≫
+        isoWhiskerLeft _ (fiberwiseColimCompEvaluationIso _).symm ≪≫
         (Functor.associator _ _ _).symm) ≪≫
       (limitObjIsoLimitCompEvaluation _ c).symm)
     fun {c₁ c₂} f => by
@@ -89,7 +89,7 @@ instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H] [Has
       Functor.comp_obj, fiberwiseColim_obj, HasLimit.isoOfNatIso_hom_π_assoc,
       whiskeringLeft_obj_obj, colim_obj, evaluation_obj_obj, Iso.trans_hom, isoWhiskerLeft_hom,
       NatTrans.comp_app, Functor.associator_hom_app, whiskerLeft_app,
-      fiberwiseColimcompEvaluationIso_inv_app, Functor.associator_inv_app, Category.comp_id,
+      fiberwiseColimCompEvaluationIso_inv_app, Functor.associator_inv_app, Category.comp_id,
       Category.id_comp, preservesLimitIso_hom_π_assoc, colim_map, Grothendieck.ι_obj,
       ι_colimitFiberwiseColimitIso_hom]
     simp [← Category.assoc, ← NatTrans.comp_app]

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2024 Jakob von Raumer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jakob von Raumer
+-/
 import Mathlib.CategoryTheory.Limits.Preserves.FunctorCategory
 
 universe v₁ v₂ u₁ u₂
@@ -16,7 +21,6 @@ variable {F : C ⥤ Cat}
 @[simps!]
 def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H)
     [∀ (c : C), HasColimitsOfShape (↑(F.obj c)) H] [HasLimitsOfShape J H] [HasColimitsOfShape C H]
-    [hC : PreservesLimitsOfShape J (colim (J := C) (C := H))]
     [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
     fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColim _ _) :=
   NatIso.ofComponents
@@ -29,11 +33,15 @@ def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H)
         (Functor.associator _ _ _).symm) ≪≫
       (limitObjIsoLimitCompEvaluation _ c).symm)
     fun {c₁ c₂} f => by
-      simp
+      simp only [fiberwiseColimit_obj, fiberwiseColimit_map, Iso.trans_hom, Iso.symm_hom,
+        Category.assoc, limitObjIsoLimitCompEvaluation_inv_limit_map]
       apply colimit.hom_ext
       intro d
-      simp
-      sorry
+      simp only [← Category.assoc]
+      congr 1
+      apply limit.hom_ext
+      intro e
+      simp [← NatTrans.comp_app_assoc]
 
 variable (C) (F) in
 instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -62,13 +62,23 @@ instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
        (Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ fiberwiseColimCompColimIso)
   haveI : IsIso (limit.post K colim) := by
     convert Iso.isIso_hom i₂
-    apply limit.hom_ext
-    intro d
-    simp [i₂]
-    apply colimit.hom_ext
-    intro d'
-    simp
-    sorry
+    ext
+    simp only [colim_obj, Functor.comp_obj, limit.post_π, colim_map, Iso.instTransIso_trans,
+      Iso.trans_assoc, Iso.trans_hom, Category.assoc, HasLimit.isoOfNatIso_hom_π,
+      fiberwiseColim_obj, isoWhiskerLeft_hom, NatTrans.comp_app, Functor.associator_hom_app,
+      whiskerLeft_app, fiberwiseColimCompColimIso_hom_app, Category.id_comp,
+      preservesLimitIso_hom_π_assoc, i₂]
+    ext
+    simp only [ι_colimMap, Trans.trans, Iso.symm_hom, ι_colimitFiberwiseColimitIso_inv_assoc,
+      HasColimit.isoOfNatIso_ι_hom_assoc, fiberwiseColimit_obj, fiberwiseColimitLimitIso_hom_app,
+      ι_colimMap_assoc, Category.assoc, limitObjIsoLimitCompEvaluation_inv_π_app_assoc,
+      Functor.comp_obj, fiberwiseColim_obj, HasLimit.isoOfNatIso_hom_π_assoc,
+      whiskeringLeft_obj_obj, colim_obj, evaluation_obj_obj, Iso.trans_hom, isoWhiskerLeft_hom,
+      NatTrans.comp_app, Functor.associator_hom_app, whiskerLeft_app,
+      fiberwiseColimcompEvaluationIso_inv_app, Functor.associator_inv_app, Category.comp_id,
+      Category.id_comp, preservesLimitIso_hom_π_assoc, colim_map, Grothendieck.ι_obj,
+      ι_colimitFiberwiseColimitIso_hom]
+    simp [← Category.assoc, ← NatTrans.comp_app]
   apply preservesLimit_of_isIso_post
 
 end

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -37,9 +37,8 @@ def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H)
 
 variable (C) (F) in
 instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
-    [∀ c, HasColimitsOfShape (↑(F.obj c)) H]
-    [∀ c, HasLimitsOfShape J ((F.obj c) ⥤ H)] [HasLimitsOfShape J H]
-    [hC : PreservesLimitsOfShape J (colim (J := C) (C := H))]
+    [∀ c, HasColimitsOfShape (↑(F.obj c)) H] [∀ c, HasLimitsOfShape J ((F.obj c) ⥤ H)]
+    [HasLimitsOfShape J H] [PreservesLimitsOfShape J (colim (J := C) (C := H))]
     [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
     PreservesLimitsOfShape J (colim (J := Grothendieck F) (C := H)) := by
   constructor

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -3,7 +3,8 @@ Copyright (c) 2024 Jakob von Raumer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jakob von Raumer
 -/
-import Mathlib.CategoryTheory.Limits.Preserves.FunctorCategory
+import Mathlib.CategoryTheory.Limits.FunctorCategory.Basic
+import Mathlib.CategoryTheory.Limits.Shapes.Grothendieck
 
 /-!
 # Colimits on Grothendieck constructions preserving limits

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -129,7 +129,7 @@ def isColimitCoconeFiberwiseColimitOfCocone {c : Cocone G} (hc : IsColimit c) :
       coconeFiberwiseColimitOfCocone_ι_app] at this
     simp [← this]
 
-lemma hasColimit_fiberwiseColim [HasColimit G] : HasColimit (fiberwiseColimit G) where
+lemma hasColimit_fiberwiseColimit [HasColimit G] : HasColimit (fiberwiseColimit G) where
   exists_colimit := ⟨⟨_, isColimitCoconeFiberwiseColimitOfCocone (colimit.isColimit _)⟩⟩
 
 variable {G}
@@ -220,7 +220,7 @@ naturally isomorphic to precomposing the Grothendieck inclusion `Grothendieck.ι
 @[simps!]
 def fiberwiseColimCompEvaluationIso (c : C) :
     fiberwiseColim F H ⋙ (evaluation C H).obj c ≅
-    (whiskeringLeft _ _ _).obj (Grothendieck.ι F c) ⋙ colim :=
+      (whiskeringLeft _ _ _).obj (Grothendieck.ι F c) ⋙ colim :=
   Iso.refl _
 
 end FiberwiseColim

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -134,7 +134,7 @@ lemma hasColimit_fiberwiseColimit [HasColimit G] : HasColimit (fiberwiseColimit 
 
 variable {G}
 
-/-- For a functor `G : Grothendieck F ⥤ H`, every cocone over `fiberwiseColim G` induces a
+/-- For a functor `G : Grothendieck F ⥤ H`, every cocone over `fiberwiseColimit G` induces a
 cocone over `G` itself. -/
 @[simps]
 def coconeOfCoconeFiberwiseColimit (c : Cocone (fiberwiseColimit G)) : Cocone G where

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -5,7 +5,6 @@ Authors: Jakob von Raumer
 -/
 import Mathlib.CategoryTheory.Grothendieck
 import Mathlib.CategoryTheory.Limits.HasLimits
-import Mathlib.CategoryTheory.Limits.Preserves.Limits
 
 /-!
 # (Co)limits on the (strict) Grothendieck Construction

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -207,10 +207,12 @@ noncomputable section FiberwiseColim
 
 variable [∀ (c : C), HasColimitsOfShape (↑(F.obj c)) H] [HasColimitsOfShape C H]
 
+@[simps!]
 def fiberwiseColimCompColimIso : fiberwiseColim F H ⋙ colim ≅ colim :=
   NatIso.ofComponents (fun G => colimitFiberwiseColimitIso G)
     fun _ => by (iterate 2 apply colimit.hom_ext; intro); simp
 
+@[simps!]
 def fiberwiseColimcompEvaluationIso (c : C) : fiberwiseColim F H ⋙ (evaluation C H).obj c ≅
     (whiskeringLeft _ _ _).obj (Grothendieck.ι F c) ⋙ colim :=
   Iso.refl _

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -203,10 +203,19 @@ theorem hasColimitsOfShape_grothendieck [∀ X, HasColimitsOfShape (F.obj X) H]
     [HasColimitsOfShape C H] : HasColimitsOfShape (Grothendieck F) H where
   has_colimit _ := hasColimit_of_hasColimit_fiberwiseColimit_of_hasColimit _
 
-noncomputable def fiberwiseColimCompColimIso [∀ (c : C), HasColimitsOfShape (↑(F.obj c)) H]
-    [HasColimitsOfShape C H] : fiberwiseColim F H ⋙ colim ≅ colim :=
+noncomputable section FiberwiseColim
+
+variable [∀ (c : C), HasColimitsOfShape (↑(F.obj c)) H] [HasColimitsOfShape C H]
+
+def fiberwiseColimCompColimIso : fiberwiseColim F H ⋙ colim ≅ colim :=
   NatIso.ofComponents (fun G => colimitFiberwiseColimitIso G)
     fun _ => by (iterate 2 apply colimit.hom_ext; intro); simp
+
+def fiberwiseColimcompEvaluationIso (c : C) : fiberwiseColim F H ⋙ (evaluation C H).obj c ≅
+    (whiskeringLeft _ _ _).obj (Grothendieck.ι F c) ⋙ colim :=
+  Iso.refl _
+
+end FiberwiseColim
 
 end Limits
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -198,58 +198,6 @@ theorem hasColimitsOfShape_grothendieck [∀ X, HasColimitsOfShape (F.obj X) H]
     [HasColimitsOfShape C H] : HasColimitsOfShape (Grothendieck F) H where
   has_colimit _ := hasColimit_of_hasColimit_fiberwiseColimit_of_hasColimit _
 
-namespace Functor
-
-variable (J : Type u₃) [Category.{v₃} J]
-
-example (K : J ⥤ Grothendieck F ⥤ H) {c : Cone K} (hc : IsLimit c)
-    [HasColimitsOfShape (Grothendieck F) H]
-    [∀ {X Y : C} (f : X ⟶ Y), HasColimit (F.map f ⋙ Grothendieck.ι F Y ⋙ G)]
-    [∀ {X Y : C} (f : X ⟶ Y), HasColimit (F.map f ⋙ Grothendieck.ι F Y ⋙ c.pt)]
-    [HasColimit (fiberwiseColimit c.pt)] :
-  colim.mapCone c ≅ _ := sorry
-
-variable (C) (F) in
-instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
-    [∀ c, HasColimitsOfShape (↑(F.obj c)) H]
-    [hC : PreservesLimitsOfShape J (colim (J := C) (C := H))]
-    [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
-    PreservesLimitsOfShape J (colim (J := Grothendieck F) (C := H)) := by
-  haveI : HasLimitsOfShape J (Grothendieck F ⥤ H) := sorry
-  haveI : HasLimitsOfShape J (C ⥤ H) := sorry
-  haveI : HasLimitsOfShape J H := sorry
-  haveI : HasLimitsOfShape C H := sorry
-  haveI : HasColimitsOfShape J (C ⥤ H) := sorry
-  constructor
-  intro K
-  haveI : ∀ c, HasLimit (K ⋙ (whiskeringLeft (↑(F.obj c)) (Grothendieck F) H).obj (Grothendieck.ι F c)) := sorry
-  let i₀ : ∀ c, Grothendieck.ι F c ⋙ limit K ≅
-    limit (K ⋙ (whiskeringLeft _ _ _).obj (Grothendieck.ι F c)) := sorry
-  let i₁ : fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColimit') :=
-    NatIso.ofComponents
-      (fun c => HasColimit.isoOfNatIso (i₀ c) ≪≫
-        preservesLimitIso colim _ ≪≫
-        _)
-      _
-  let i₂ := calc colimit (limit K)
-    _ ≅ colimit (fiberwiseColimit (limit K)) := (colimitFiberwiseColimitIso _).symm
-    _ ≅ colimit (limit (K ⋙ fiberwiseColimit')) := HasColimit.isoOfNatIso i₁
-    _ ≅ limit ((K ⋙ fiberwiseColimit') ⋙ colim) :=
-          preservesLimitIso colim (K ⋙ fiberwiseColimit')
-    _ ≅ limit (K ⋙ colim) := by sorry  -- TODO functorialisation of `colimitFiberwiseColimitIso`
-  haveI : IsIso (limit.post K colim) := by
-    convert Iso.isIso_hom i₂
-    apply colimit.hom_ext
-    intro d
-    ext d'
-    sorry
-  apply preservesLimit_of_isIso_post
-
-#check whiskeringRight
-#check preservesLimitIso
-
-end Functor
-
 end Limits
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -194,9 +194,10 @@ theorem hasColimitsOfShape_grothendieck [∀ X, HasColimitsOfShape (F.obj X) H]
 
 namespace Functor
 
-variable {J : Type u₂} [Category.{v₂} J]
+variable (J : Type u₃) [Category.{v₃} J]
 
-theorem preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
+variable (C) (F) in
+instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
     [∀ c, HasColimitsOfShape (↑(F.obj c)) H] [PreservesLimitsOfShape J (colim (J := C) (C := H))]
     [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
     PreservesLimitsOfShape J (colim (J := Grothendieck F) (C := H)) :=

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -45,7 +45,7 @@ lemma hasColimit_ι_comp : ∀ X, HasColimit (Grothendieck.ι F X ⋙ G) :=
 
 /-- A functor taking a colimit on each fiber of a functor `G : Grothendieck F ⥤ H`. -/
 @[simps]
-def fiberwiseColimitObj : C ⥤ H where
+def fiberwiseColimit : C ⥤ H where
   obj X := colimit (Grothendieck.ι F X ⋙ G)
   map {X Y} f := colimMap (whiskerRight (Grothendieck.ιNatTrans f) G ≫
     (Functor.associator _ _ _).hom) ≫ colimit.pre (Grothendieck.ι F Y ⋙ G) (F.map f)
@@ -77,8 +77,8 @@ def fiberwiseColimitObj : C ⥤ H where
       conv_rhs => rw [eqToHom_trans, eqToHom_trans]
 
 @[simps]
-def fiberwiseColimit [∀ c, HasColimitsOfShape (F.obj c) H] : (Grothendieck F ⥤ H) ⥤ (C ⥤ H) where
-  obj G := fiberwiseColimitObj G
+def fiberwiseColim [∀ c, HasColimitsOfShape (F.obj c) H] : (Grothendieck F ⥤ H) ⥤ (C ⥤ H) where
+  obj G := fiberwiseColimit G
   map α :=
     { app := fun c => colim.map (whiskerLeft _ α)
       naturality := fun c₁ c₂ f => by apply colimit.hom_ext; simp }
@@ -89,11 +89,11 @@ def fiberwiseColimit [∀ c, HasColimitsOfShape (F.obj c) H] : (Grothendieck F �
 composition of the forgetful functor on `Grothendieck F` with the fiberwise colimit on `G`. -/
 @[simps]
 def natTransIntoForgetCompFiberwiseColimit :
-    G ⟶ Grothendieck.forget F ⋙ fiberwiseColimitObj G where
+    G ⟶ Grothendieck.forget F ⋙ fiberwiseColimit G where
   app X := colimit.ι (Grothendieck.ι F X.base ⋙ G) X.fiber
   naturality _ _ f := by
-    simp only [Functor.comp_obj, Grothendieck.forget_obj, fiberwiseColimit_obj, Functor.comp_map,
-      Grothendieck.forget_map, fiberwiseColimitObj_map, ι_colimMap_assoc, Grothendieck.ι_obj,
+    simp only [Functor.comp_obj, Grothendieck.forget_obj, fiberwiseColim_obj, Functor.comp_map,
+      Grothendieck.forget_map, fiberwiseColimit_map, ι_colimMap_assoc, Grothendieck.ι_obj,
       NatTrans.comp_app, whiskerRight_app, Functor.associator_hom_app, Category.comp_id,
       colimit.ι_pre]
     rw [← colimit.w (Grothendieck.ι F _ ⋙ G) f.fiber]
@@ -105,7 +105,7 @@ variable {G} in
 /-- A cocone on a functor `G : Grothendieck F ⥤ H` induces a cocone on the fiberwise colimit
 on `G`. -/
 @[simps]
-def coconeFiberwiseColimitOfCocone (c : Cocone G) : Cocone (fiberwiseColimitObj G) where
+def coconeFiberwiseColimitOfCocone (c : Cocone G) : Cocone (fiberwiseColimit G) where
   pt := c.pt
   ι := { app := fun X => colimit.desc _ (c.whisker (Grothendieck.ι F X)),
          naturality := fun _ _ f => by dsimp; ext; simp }
@@ -121,27 +121,27 @@ def isColimitCoconeFiberwiseColimitOfCocone {c : Cocone G} (hc : IsColimit c) :
   uniq s m hm := hc.hom_ext fun X => by
     have := hm X.base
     simp only [Functor.const_obj_obj, IsColimit.fac, NatTrans.comp_app, Functor.comp_obj,
-      Grothendieck.forget_obj, fiberwiseColimit_obj, natTransIntoForgetCompFiberwiseColimit_app,
+      Grothendieck.forget_obj, fiberwiseColim_obj, natTransIntoForgetCompFiberwiseColimit_app,
       whiskerLeft_app]
-    simp only [fiberwiseColimit_obj, coconeFiberwiseColimitOfCocone_pt, Functor.const_obj_obj,
+    simp only [fiberwiseColim_obj, coconeFiberwiseColimitOfCocone_pt, Functor.const_obj_obj,
       coconeFiberwiseColimitOfCocone_ι_app] at this
     simp [← this]
 
-lemma hasColimit_fiberwiseColimit [HasColimit G] : HasColimit (fiberwiseColimitObj G) where
+lemma hasColimit_fiberwiseColim [HasColimit G] : HasColimit (fiberwiseColimit G) where
   exists_colimit := ⟨⟨_, isColimitCoconeFiberwiseColimitOfCocone (colimit.isColimit _)⟩⟩
 
 variable {G}
 
-/-- For a functor `G : Grothendieck F ⥤ H`, every cocone over `fiberwiseColimit G` induces a
+/-- For a functor `G : Grothendieck F ⥤ H`, every cocone over `fiberwiseColim G` induces a
 cocone over `G` itself. -/
 @[simps]
-def coconeOfCoconeFiberwiseColimit (c : Cocone (fiberwiseColimitObj G)) : Cocone G where
+def coconeOfCoconeFiberwiseColimit (c : Cocone (fiberwiseColimit G)) : Cocone G where
   pt := c.pt
   ι := { app := fun X => colimit.ι (Grothendieck.ι F X.base ⋙ G) X.fiber ≫ c.ι.app X.base
          naturality := fun {X Y} ⟨f, g⟩ => by
           simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id]
           rw [← Category.assoc, ← c.w f, ← Category.assoc]
-          simp only [fiberwiseColimitObj_obj, fiberwiseColimitObj_map, ι_colimMap_assoc,
+          simp only [fiberwiseColimit_obj, fiberwiseColimit_map, ι_colimMap_assoc,
             Functor.comp_obj, Grothendieck.ι_obj, NatTrans.comp_app, whiskerRight_app,
             Functor.associator_hom_app, Category.comp_id, colimit.ι_pre]
           rw [← colimit.w _ g, ← Category.assoc, Functor.comp_map, ← G.map_comp]
@@ -149,12 +149,12 @@ def coconeOfCoconeFiberwiseColimit (c : Cocone (fiberwiseColimitObj G)) : Cocone
 
 /-- If a cocone `c` over a functor `G : Grothendieck F ⥤ H` is a colimit, than the induced cocone
 `coconeOfFiberwiseCocone G c` -/
-def isColimitCoconeOfFiberwiseCocone {c : Cocone (fiberwiseColimitObj G)} (hc : IsColimit c) :
+def isColimitCoconeOfFiberwiseCocone {c : Cocone (fiberwiseColimit G)} (hc : IsColimit c) :
     IsColimit (coconeOfCoconeFiberwiseColimit c) where
   desc s := hc.desc <| Cocone.mk s.pt <|
     { app := fun X => colimit.desc (Grothendieck.ι F X ⋙ G) (s.whisker _) }
   uniq s m hm := hc.hom_ext <| fun X => by
-    simp only [fiberwiseColimitObj_obj, Functor.const_obj_obj, fiberwiseColimitObj_map,
+    simp only [fiberwiseColimit_obj, Functor.const_obj_obj, fiberwiseColimit_map,
       Functor.const_obj_map, Cocone.whisker_pt, id_eq, Functor.comp_obj, Cocone.whisker_ι,
       whiskerLeft_app, NatTrans.comp_app, whiskerRight_app, Functor.associator_hom_app,
       whiskerLeft_twice, eq_mpr_eq_cast, IsColimit.fac]
@@ -163,7 +163,7 @@ def isColimitCoconeOfFiberwiseCocone {c : Cocone (fiberwiseColimitObj G)} (hc : 
     ext d
     simp [hm ⟨X, d⟩]
 
-variable [HasColimit (fiberwiseColimitObj G)]
+variable [HasColimit (fiberwiseColimit G)]
 
 variable (G)
 
@@ -177,13 +177,13 @@ lemma hasColimit_of_hasColimit_fiberwiseColimit_of_hasColimit : HasColimit G whe
 /-- For every functor `G` on the Grothendieck construction `Grothendieck F`, if `G` has a colimit
 and every fiber of `G` has a colimit, then taking this colimit is isomorphic to first taking the
 fiberwise colimit and then the colimit of the resulting functor. -/
-def colimitFiberwiseColimitIso : colimit (fiberwiseColimitObj G) ≅ colimit G :=
-  IsColimit.coconePointUniqueUpToIso (colimit.isColimit (fiberwiseColimitObj G))
+def colimitFiberwiseColimitIso : colimit (fiberwiseColimit G) ≅ colimit G :=
+  IsColimit.coconePointUniqueUpToIso (colimit.isColimit (fiberwiseColimit G))
     (isColimitCoconeFiberwiseColimitOfCocone (colimit.isColimit _))
 
 @[reassoc (attr := simp)]
 lemma ι_colimitFiberwiseColimitIso_hom (X : C) (d : F.obj X) :
-    colimit.ι (Grothendieck.ι F X ⋙ G) d ≫ colimit.ι (fiberwiseColimitObj G) X ≫
+    colimit.ι (Grothendieck.ι F X ⋙ G) d ≫ colimit.ι (fiberwiseColimit G) X ≫
       (colimitFiberwiseColimitIso G).hom = colimit.ι G ⟨X, d⟩ := by
   simp [colimitFiberwiseColimitIso]
 
@@ -191,7 +191,7 @@ lemma ι_colimitFiberwiseColimitIso_hom (X : C) (d : F.obj X) :
 lemma ι_colimitFiberwiseColimitIso_inv (X : Grothendieck F) :
     colimit.ι G X ≫ (colimitFiberwiseColimitIso G).inv =
     colimit.ι (Grothendieck.ι F X.base ⋙ G) X.fiber ≫
-      colimit.ι (fiberwiseColimitObj G) X.base := by
+      colimit.ι (fiberwiseColimit G) X.base := by
   rw [Iso.comp_inv_eq]
   simp
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -77,6 +77,8 @@ def fiberwiseColimit : C ⥤ H where
       conv_rhs => rw [eqToHom_trans, eqToHom_trans]
 
 variable (H) (F) in
+/-- Similar to `colimit` and `colim`, taking fiberwise colimits is a functor
+`(Grothendieck F ⥤ H) ⥤ (C ⥤ H)` between functor categories. -/
 @[simps]
 def fiberwiseColim [∀ c, HasColimitsOfShape (F.obj c) H] : (Grothendieck F ⥤ H) ⥤ (C ⥤ H) where
   obj G := fiberwiseColimit G
@@ -207,13 +209,18 @@ noncomputable section FiberwiseColim
 
 variable [∀ (c : C), HasColimitsOfShape (↑(F.obj c)) H] [HasColimitsOfShape C H]
 
+/-- The isomorphism `colimitFiberwiseColimitIso` induces an isomorphism of functors `(J ⥤ C) ⥤ C`
+between `fiberwiseColim F H ⋙ colim` and `colim`. -/
 @[simps!]
 def fiberwiseColimCompColimIso : fiberwiseColim F H ⋙ colim ≅ colim :=
   NatIso.ofComponents (fun G => colimitFiberwiseColimitIso G)
     fun _ => by (iterate 2 apply colimit.hom_ext; intro); simp
 
+/-- Composing `fiberwiseColim F H` with the evaluation functor `(evaluation C H).obj c` is
+naturally isomorphic to precomposing the Grothendieck inclusion `Grothendieck.ι` to `colim`. -/
 @[simps!]
-def fiberwiseColimcompEvaluationIso (c : C) : fiberwiseColim F H ⋙ (evaluation C H).obj c ≅
+def fiberwiseColimcompEvaluationIso (c : C) :
+    fiberwiseColim F H ⋙ (evaluation C H).obj c ≅
     (whiskeringLeft _ _ _).obj (Grothendieck.ι F c) ⋙ colim :=
   Iso.refl _
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -76,6 +76,7 @@ def fiberwiseColimit : C ⥤ H where
       conv_rhs => enter [2, 1]; rw [eqToHom_map (F.map (𝟙 Z))]
       conv_rhs => rw [eqToHom_trans, eqToHom_trans]
 
+variable (H) (F) in
 @[simps]
 def fiberwiseColim [∀ c, HasColimitsOfShape (F.obj c) H] : (Grothendieck F ⥤ H) ⥤ (C ⥤ H) where
   obj G := fiberwiseColimit G
@@ -201,6 +202,11 @@ end
 theorem hasColimitsOfShape_grothendieck [∀ X, HasColimitsOfShape (F.obj X) H]
     [HasColimitsOfShape C H] : HasColimitsOfShape (Grothendieck F) H where
   has_colimit _ := hasColimit_of_hasColimit_fiberwiseColimit_of_hasColimit _
+
+noncomputable def fiberwiseColimCompColimIso [∀ (c : C), HasColimitsOfShape (↑(F.obj c)) H]
+    [HasColimitsOfShape C H] : fiberwiseColim F H ⋙ colim ≅ colim :=
+  NatIso.ofComponents (fun G => colimitFiberwiseColimitIso G)
+    fun _ => by (iterate 2 apply colimit.hom_ext; intro); simp
 
 end Limits
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -5,7 +5,7 @@ Authors: Jakob von Raumer
 -/
 import Mathlib.CategoryTheory.Grothendieck
 import Mathlib.CategoryTheory.Limits.HasLimits
-import Mathlib.CategoryTheory.Limits.Preserves.Basic
+import Mathlib.CategoryTheory.Limits.Preserves.Limits
 
 /-!
 # (Co)limits on the (strict) Grothendieck Construction
@@ -75,6 +75,12 @@ def fiberwiseColimit : C ⥤ H where
         Grothendieck.comp_base, Category.comp_id, Grothendieck.comp_fiber, Functor.map_id]
       conv_rhs => enter [2, 1]; rw [eqToHom_map (F.map (𝟙 Z))]
       conv_rhs => rw [eqToHom_trans, eqToHom_trans]
+
+def fiberwiseColimit'
+    [∀ (G : Grothendieck F ⥤ H), ∀ {X Y : C} (f : X ⟶ Y),
+      HasColimit (F.map f ⋙ Grothendieck.ι F Y ⋙ G)]: (Grothendieck F ⥤ H) ⥤ (C ⥤ H) where
+  obj G := fiberwiseColimit G
+  map {F G} α := sorry
 
 /-- Every functor `G : Grothendieck F ⥤ H` induces a natural transformation from `G` to the
 composition of the forgetful functor on `Grothendieck F` with the fiberwise colimit on `G`. -/
@@ -196,12 +202,51 @@ namespace Functor
 
 variable (J : Type u₃) [Category.{v₃} J]
 
+example (K : J ⥤ Grothendieck F ⥤ H) {c : Cone K} (hc : IsLimit c)
+    [HasColimitsOfShape (Grothendieck F) H]
+    [∀ {X Y : C} (f : X ⟶ Y), HasColimit (F.map f ⋙ Grothendieck.ι F Y ⋙ G)]
+    [∀ {X Y : C} (f : X ⟶ Y), HasColimit (F.map f ⋙ Grothendieck.ι F Y ⋙ c.pt)]
+    [HasColimit (fiberwiseColimit c.pt)] :
+  colim.mapCone c ≅ _ := sorry
+
 variable (C) (F) in
 instance preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
-    [∀ c, HasColimitsOfShape (↑(F.obj c)) H] [PreservesLimitsOfShape J (colim (J := C) (C := H))]
+    [∀ c, HasColimitsOfShape (↑(F.obj c)) H]
+    [hC : PreservesLimitsOfShape J (colim (J := C) (C := H))]
     [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
-    PreservesLimitsOfShape J (colim (J := Grothendieck F) (C := H)) :=
-  ⟨fun {K} => ⟨fun {c} hc => ⟨sorry⟩⟩⟩
+    PreservesLimitsOfShape J (colim (J := Grothendieck F) (C := H)) := by
+  haveI : HasLimitsOfShape J (Grothendieck F ⥤ H) := sorry
+  haveI : HasLimitsOfShape J (C ⥤ H) := sorry
+  haveI : HasLimitsOfShape J H := sorry
+  haveI : HasLimitsOfShape C H := sorry
+  haveI : HasColimitsOfShape J (C ⥤ H) := sorry
+  constructor
+  intro K
+  haveI : ∀ c, HasLimit (K ⋙ (whiskeringLeft (↑(F.obj c)) (Grothendieck F) H).obj (Grothendieck.ι F c)) := sorry
+  let i₀ : ∀ c, Grothendieck.ι F c ⋙ limit K ≅
+    limit (K ⋙ (whiskeringLeft _ _ _).obj (Grothendieck.ι F c)) := sorry
+  let i₁ : fiberwiseColimit (limit K) ≅ limit (K ⋙ fiberwiseColimit') :=
+    NatIso.ofComponents
+      (fun c => HasColimit.isoOfNatIso (i₀ c) ≪≫
+        preservesLimitIso colim _ ≪≫
+        _)
+      _
+  let i₂ := calc colimit (limit K)
+    _ ≅ colimit (fiberwiseColimit (limit K)) := (colimitFiberwiseColimitIso _).symm
+    _ ≅ colimit (limit (K ⋙ fiberwiseColimit')) := HasColimit.isoOfNatIso i₁
+    _ ≅ limit ((K ⋙ fiberwiseColimit') ⋙ colim) :=
+          preservesLimitIso colim (K ⋙ fiberwiseColimit')
+    _ ≅ limit (K ⋙ colim) := by sorry  -- TODO functorialisation of `colimitFiberwiseColimitIso`
+  haveI : IsIso (limit.post K colim) := by
+    convert Iso.isIso_hom i₂
+    apply colimit.hom_ext
+    intro d
+    ext d'
+    sorry
+  apply preservesLimit_of_isIso_post
+
+#check whiskeringRight
+#check preservesLimitIso
 
 end Functor
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -45,7 +45,7 @@ lemma hasColimit_ι_comp : ∀ X, HasColimit (Grothendieck.ι F X ⋙ G) :=
 
 /-- A functor taking a colimit on each fiber of a functor `G : Grothendieck F ⥤ H`. -/
 @[simps]
-def fiberwiseColimit : C ⥤ H where
+def fiberwiseColimitObj : C ⥤ H where
   obj X := colimit (Grothendieck.ι F X ⋙ G)
   map {X Y} f := colimMap (whiskerRight (Grothendieck.ιNatTrans f) G ≫
     (Functor.associator _ _ _).hom) ≫ colimit.pre (Grothendieck.ι F Y ⋙ G) (F.map f)
@@ -76,21 +76,24 @@ def fiberwiseColimit : C ⥤ H where
       conv_rhs => enter [2, 1]; rw [eqToHom_map (F.map (𝟙 Z))]
       conv_rhs => rw [eqToHom_trans, eqToHom_trans]
 
-def fiberwiseColimit'
-    [∀ (G : Grothendieck F ⥤ H), ∀ {X Y : C} (f : X ⟶ Y),
-      HasColimit (F.map f ⋙ Grothendieck.ι F Y ⋙ G)]: (Grothendieck F ⥤ H) ⥤ (C ⥤ H) where
-  obj G := fiberwiseColimit G
-  map {F G} α := sorry
+@[simps]
+def fiberwiseColimit [∀ c, HasColimitsOfShape (F.obj c) H] : (Grothendieck F ⥤ H) ⥤ (C ⥤ H) where
+  obj G := fiberwiseColimitObj G
+  map α :=
+    { app := fun c => colim.map (whiskerLeft _ α)
+      naturality := fun c₁ c₂ f => by apply colimit.hom_ext; simp }
+  map_id G := by ext; simp; apply Functor.map_id colim
+  map_comp α β := by ext; simp; apply Functor.map_comp colim
 
 /-- Every functor `G : Grothendieck F ⥤ H` induces a natural transformation from `G` to the
 composition of the forgetful functor on `Grothendieck F` with the fiberwise colimit on `G`. -/
 @[simps]
 def natTransIntoForgetCompFiberwiseColimit :
-    G ⟶ Grothendieck.forget F ⋙ fiberwiseColimit G where
+    G ⟶ Grothendieck.forget F ⋙ fiberwiseColimitObj G where
   app X := colimit.ι (Grothendieck.ι F X.base ⋙ G) X.fiber
   naturality _ _ f := by
     simp only [Functor.comp_obj, Grothendieck.forget_obj, fiberwiseColimit_obj, Functor.comp_map,
-      Grothendieck.forget_map, fiberwiseColimit_map, ι_colimMap_assoc, Grothendieck.ι_obj,
+      Grothendieck.forget_map, fiberwiseColimitObj_map, ι_colimMap_assoc, Grothendieck.ι_obj,
       NatTrans.comp_app, whiskerRight_app, Functor.associator_hom_app, Category.comp_id,
       colimit.ι_pre]
     rw [← colimit.w (Grothendieck.ι F _ ⋙ G) f.fiber]
@@ -102,7 +105,7 @@ variable {G} in
 /-- A cocone on a functor `G : Grothendieck F ⥤ H` induces a cocone on the fiberwise colimit
 on `G`. -/
 @[simps]
-def coconeFiberwiseColimitOfCocone (c : Cocone G) : Cocone (fiberwiseColimit G) where
+def coconeFiberwiseColimitOfCocone (c : Cocone G) : Cocone (fiberwiseColimitObj G) where
   pt := c.pt
   ι := { app := fun X => colimit.desc _ (c.whisker (Grothendieck.ι F X)),
          naturality := fun _ _ f => by dsimp; ext; simp }
@@ -124,7 +127,7 @@ def isColimitCoconeFiberwiseColimitOfCocone {c : Cocone G} (hc : IsColimit c) :
       coconeFiberwiseColimitOfCocone_ι_app] at this
     simp [← this]
 
-lemma hasColimit_fiberwiseColimit [HasColimit G] : HasColimit (fiberwiseColimit G) where
+lemma hasColimit_fiberwiseColimit [HasColimit G] : HasColimit (fiberwiseColimitObj G) where
   exists_colimit := ⟨⟨_, isColimitCoconeFiberwiseColimitOfCocone (colimit.isColimit _)⟩⟩
 
 variable {G}
@@ -132,26 +135,26 @@ variable {G}
 /-- For a functor `G : Grothendieck F ⥤ H`, every cocone over `fiberwiseColimit G` induces a
 cocone over `G` itself. -/
 @[simps]
-def coconeOfCoconeFiberwiseColimit (c : Cocone (fiberwiseColimit G)) : Cocone G where
+def coconeOfCoconeFiberwiseColimit (c : Cocone (fiberwiseColimitObj G)) : Cocone G where
   pt := c.pt
   ι := { app := fun X => colimit.ι (Grothendieck.ι F X.base ⋙ G) X.fiber ≫ c.ι.app X.base
          naturality := fun {X Y} ⟨f, g⟩ => by
           simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id]
           rw [← Category.assoc, ← c.w f, ← Category.assoc]
-          simp only [fiberwiseColimit_obj, fiberwiseColimit_map, ι_colimMap_assoc, Functor.comp_obj,
-            Grothendieck.ι_obj, NatTrans.comp_app, whiskerRight_app, Functor.associator_hom_app,
-            Category.comp_id, colimit.ι_pre]
+          simp only [fiberwiseColimitObj_obj, fiberwiseColimitObj_map, ι_colimMap_assoc,
+            Functor.comp_obj, Grothendieck.ι_obj, NatTrans.comp_app, whiskerRight_app,
+            Functor.associator_hom_app, Category.comp_id, colimit.ι_pre]
           rw [← colimit.w _ g, ← Category.assoc, Functor.comp_map, ← G.map_comp]
           congr <;> simp }
 
 /-- If a cocone `c` over a functor `G : Grothendieck F ⥤ H` is a colimit, than the induced cocone
 `coconeOfFiberwiseCocone G c` -/
-def isColimitCoconeOfFiberwiseCocone {c : Cocone (fiberwiseColimit G)} (hc : IsColimit c) :
+def isColimitCoconeOfFiberwiseCocone {c : Cocone (fiberwiseColimitObj G)} (hc : IsColimit c) :
     IsColimit (coconeOfCoconeFiberwiseColimit c) where
   desc s := hc.desc <| Cocone.mk s.pt <|
     { app := fun X => colimit.desc (Grothendieck.ι F X ⋙ G) (s.whisker _) }
   uniq s m hm := hc.hom_ext <| fun X => by
-    simp only [fiberwiseColimit_obj, Functor.const_obj_obj, fiberwiseColimit_map,
+    simp only [fiberwiseColimitObj_obj, Functor.const_obj_obj, fiberwiseColimitObj_map,
       Functor.const_obj_map, Cocone.whisker_pt, id_eq, Functor.comp_obj, Cocone.whisker_ι,
       whiskerLeft_app, NatTrans.comp_app, whiskerRight_app, Functor.associator_hom_app,
       whiskerLeft_twice, eq_mpr_eq_cast, IsColimit.fac]
@@ -160,7 +163,7 @@ def isColimitCoconeOfFiberwiseCocone {c : Cocone (fiberwiseColimit G)} (hc : IsC
     ext d
     simp [hm ⟨X, d⟩]
 
-variable [HasColimit (fiberwiseColimit G)]
+variable [HasColimit (fiberwiseColimitObj G)]
 
 variable (G)
 
@@ -174,20 +177,21 @@ lemma hasColimit_of_hasColimit_fiberwiseColimit_of_hasColimit : HasColimit G whe
 /-- For every functor `G` on the Grothendieck construction `Grothendieck F`, if `G` has a colimit
 and every fiber of `G` has a colimit, then taking this colimit is isomorphic to first taking the
 fiberwise colimit and then the colimit of the resulting functor. -/
-def colimitFiberwiseColimitIso : colimit (fiberwiseColimit G) ≅ colimit G :=
-  IsColimit.coconePointUniqueUpToIso (colimit.isColimit (fiberwiseColimit G))
+def colimitFiberwiseColimitIso : colimit (fiberwiseColimitObj G) ≅ colimit G :=
+  IsColimit.coconePointUniqueUpToIso (colimit.isColimit (fiberwiseColimitObj G))
     (isColimitCoconeFiberwiseColimitOfCocone (colimit.isColimit _))
 
 @[reassoc (attr := simp)]
 lemma ι_colimitFiberwiseColimitIso_hom (X : C) (d : F.obj X) :
-    colimit.ι (Grothendieck.ι F X ⋙ G) d ≫ colimit.ι (fiberwiseColimit G) X ≫
+    colimit.ι (Grothendieck.ι F X ⋙ G) d ≫ colimit.ι (fiberwiseColimitObj G) X ≫
       (colimitFiberwiseColimitIso G).hom = colimit.ι G ⟨X, d⟩ := by
   simp [colimitFiberwiseColimitIso]
 
 @[reassoc (attr := simp)]
 lemma ι_colimitFiberwiseColimitIso_inv (X : Grothendieck F) :
     colimit.ι G X ≫ (colimitFiberwiseColimitIso G).inv =
-    colimit.ι (Grothendieck.ι F X.base ⋙ G) X.fiber ≫ colimit.ι (fiberwiseColimit G) X.base := by
+    colimit.ι (Grothendieck.ι F X.base ⋙ G) X.fiber ≫
+      colimit.ι (fiberwiseColimitObj G) X.base := by
   rw [Iso.comp_inv_eq]
   simp
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -95,7 +95,7 @@ def natTransIntoForgetCompFiberwiseColimit :
     G ⟶ Grothendieck.forget F ⋙ fiberwiseColimit G where
   app X := colimit.ι (Grothendieck.ι F X.base ⋙ G) X.fiber
   naturality _ _ f := by
-    simp only [Functor.comp_obj, Grothendieck.forget_obj, fiberwiseColim_obj, Functor.comp_map,
+    simp only [Functor.comp_obj, Grothendieck.forget_obj, fiberwiseColimit_obj, Functor.comp_map,
       Grothendieck.forget_map, fiberwiseColimit_map, ι_colimMap_assoc, Grothendieck.ι_obj,
       NatTrans.comp_app, whiskerRight_app, Functor.associator_hom_app, Category.comp_id,
       colimit.ι_pre]

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -218,7 +218,7 @@ def fiberwiseColimCompColimIso : fiberwiseColim F H ⋙ colim ≅ colim :=
 /-- Composing `fiberwiseColim F H` with the evaluation functor `(evaluation C H).obj c` is
 naturally isomorphic to precomposing the Grothendieck inclusion `Grothendieck.ι` to `colim`. -/
 @[simps!]
-def fiberwiseColimcompEvaluationIso (c : C) :
+def fiberwiseColimCompEvaluationIso (c : C) :
     fiberwiseColim F H ⋙ (evaluation C H).obj c ≅
     (whiskeringLeft _ _ _).obj (Grothendieck.ι F c) ⋙ colim :=
   Iso.refl _

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -5,6 +5,7 @@ Authors: Jakob von Raumer
 -/
 import Mathlib.CategoryTheory.Grothendieck
 import Mathlib.CategoryTheory.Limits.HasLimits
+import Mathlib.CategoryTheory.Limits.Preserves.Basic
 
 /-!
 # (Co)limits on the (strict) Grothendieck Construction
@@ -190,6 +191,18 @@ end
 theorem hasColimitsOfShape_grothendieck [∀ X, HasColimitsOfShape (F.obj X) H]
     [HasColimitsOfShape C H] : HasColimitsOfShape (Grothendieck F) H where
   has_colimit _ := hasColimit_of_hasColimit_fiberwiseColimit_of_hasColimit _
+
+namespace Functor
+
+variable {J : Type u₂} [Category.{v₂} J]
+
+theorem preservesLimitsOfShape_colim_Grothendieck [HasColimitsOfShape C H]
+    [∀ c, HasColimitsOfShape (↑(F.obj c)) H] [PreservesLimitsOfShape J (colim (J := C) (C := H))]
+    [∀ c, PreservesLimitsOfShape J (colim (J := F.obj c) (C := H))] :
+    PreservesLimitsOfShape J (colim (J := Grothendieck F) (C := H)) :=
+  ⟨fun {K} => ⟨fun {c} hc => ⟨sorry⟩⟩⟩
+
+end Functor
 
 end Limits
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
