### PR TITLE
feat(CategoryTheory): Left/right-canceling for isomorphisms

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Adjunction.lean
@@ -273,6 +273,26 @@ def mkOfAdjointifyCounit (η : 𝟙 a ≅ f ≫ g) (ε : g ≫ f ≅ 𝟙 b) : a
 
 end Equivalence
 
+section CancelingLemmas
+
+/--
+In a bicategory, if a morphism `f` is an equivalence, then right-cancellation is possible in the
+sense that `g₁ ≫ f ≅ g₂ ≫ f` induces `g₁ ≅ g₂`.
+-/
+def isoCancelRight {C : Type*} [Bicategory C] {c d e : C} {f : Equivalence d e} {g₁ g₂ : c ⟶ d}
+    (α : g₁ ≫ f.hom ≅ g₂ ≫ f.hom) : g₁ ≅ g₂ :=
+  isoCancelRightOfWeaklyLeftInvertible f.unit α
+
+/--
+In a bicategory, if a morphism `f` is an equivalence, then left-cancellation is possible in the
+sense that `f ≫ g₁ ≅ f ≫ g₂` induces `g₁ ≅ g₂`.
+-/
+def isoCancelLeft {C : Type*} [Bicategory C] {c d e : C} {f : Equivalence e d} {g₁ g₂ : d ⟶ c}
+    (α : f.hom ≫ g₁ ≅ f.hom ≫ g₂) : g₁ ≅ g₂ :=
+  isoCancelLeftOfWeaklyRightInvertible f.counit α
+
+end CancelingLemmas
+
 end
 
 noncomputable

--- a/Mathlib/CategoryTheory/Bicategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Basic.lean
@@ -383,6 +383,36 @@ theorem whiskerLeft_rightUnitor_inv (f : a ⟶ b) (g : b ⟶ c) :
     f ◁ (ρ_ g).inv = (ρ_ (f ≫ g)).inv ≫ (α_ f g (𝟙 c)).hom :=
   eq_of_inv_eq_inv (by simp)
 
+/--
+In a bicategory, if a morphism `f` has a left inverse (up to isomorphism), then right-cancellation
+is possible in the sense that `g₁ ≫ f ≅ g₂ ≫ f` induces `g₁ ≅ g₂`.
+-/
+def isoCancelRightOfWeaklyLeftInvertible {C : Type*} [Bicategory C] {c d e : C} {f : d ⟶ e}
+    {finv : e ⟶ d} {g₁ g₂ : c ⟶ d} (η : 𝟙 _ ≅ f ≫ finv) (α : g₁ ≫ f ≅ g₂ ≫ f) : g₁ ≅ g₂ := by
+  calc
+    g₁ ≅ g₁ ≫ 𝟙 _ := rightUnitor _ |>.symm
+    _ ≅ g₁ ≫ f ≫ finv := whiskerLeftIso _ η
+    _ ≅ (g₁ ≫ f) ≫ finv := associator _ _ _ |>.symm
+    _ ≅ (g₂ ≫ f) ≫ finv := whiskerRightIso α _
+    _ ≅ g₂ ≫ f ≫ finv := associator _ _ _
+    _ ≅ g₂ ≫ 𝟙 _ := whiskerLeftIso _ η.symm
+    _ ≅ g₂ := rightUnitor _
+
+/--
+In a bicategory, if a morphism `f` has a right inverse (up to isomorphism), then left-cancellation
+is possible in the sense that `f ≫ g₁ ≅ f ≫ g₂` induces `g₁ ≅ g₂`.
+-/
+def isoCancelLeftOfWeaklyRightInvertible {C : Type*} [Bicategory C] {c d e : C} {f : e ⟶ d}
+    {finv : d ⟶ e} {g₁ g₂ : d ⟶ c} (ε : finv ≫ f ≅ 𝟙 _) (α : f ≫ g₁ ≅ f ≫ g₂) : g₁ ≅ g₂ := by
+  calc
+    g₁ ≅ 𝟙 _ ≫ g₁ := leftUnitor _ |>.symm
+    _ ≅ (finv ≫ f) ≫ g₁ := whiskerRightIso ε.symm _
+    _ ≅ finv ≫ f ≫ g₁ := associator _ _ _
+    _ ≅ finv ≫ f ≫ g₂ := whiskerLeftIso  _ α
+    _ ≅ (finv ≫ f) ≫ g₂ := associator _ _ _ |>.symm
+    _ ≅ 𝟙 _ ≫ g₂ := whiskerRightIso ε _
+    _ ≅ g₂ := leftUnitor _
+
 /-
 It is not so obvious whether `leftUnitor_whiskerRight` or `leftUnitor_comp` should be a simp
 lemma. Our choice is the former. One reason is that the latter yields the following loop:

--- a/Mathlib/CategoryTheory/EqToHom.lean
+++ b/Mathlib/CategoryTheory/EqToHom.lean
@@ -252,6 +252,7 @@ theorem hext {F G : C ⥤ D} (h_obj : ∀ X, F.obj X = G.obj X)
 -- Using equalities between functors.
 theorem congr_obj {F G : C ⥤ D} (h : F = G) (X) : F.obj X = G.obj X := by rw [h]
 
+@[reassoc]
 theorem congr_hom {F G : C ⥤ D} (h : F = G) {X Y} (f : X ⟶ Y) :
     F.map f = eqToHom (congr_obj h X) ≫ G.map f ≫ eqToHom (congr_obj h Y).symm := by
   subst h; simp

--- a/Mathlib/CategoryTheory/EqToHom.lean
+++ b/Mathlib/CategoryTheory/EqToHom.lean
@@ -252,7 +252,6 @@ theorem hext {F G : C ⥤ D} (h_obj : ∀ X, F.obj X = G.obj X)
 -- Using equalities between functors.
 theorem congr_obj {F G : C ⥤ D} (h : F = G) (X) : F.obj X = G.obj X := by rw [h]
 
-@[reassoc]
 theorem congr_hom {F G : C ⥤ D} (h : F = G) {X Y} (f : X ⟶ Y) :
     F.map f = eqToHom (congr_obj h X) ≫ G.map f ≫ eqToHom (congr_obj h Y).symm := by
   subst h; simp

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -388,6 +388,22 @@ theorem cancel_counitInv_right_assoc' {W X X' Y Y' Z : D} (f : W ⟶ X) (g : X �
     f ≫ g ≫ h ≫ e.counitInv.app Z = f' ≫ g' ≫ h' ≫ e.counitInv.app Z ↔
     f ≫ g ≫ h = f' ≫ g' ≫ h' := by simp only [← Category.assoc, cancel_mono]
 
+/--
+If a functor `F` is an equivalence, then right-cancellation is possible in the sense that
+`G₁ ⋙ F ≅ G₂ ⋙ F` induces `G₁ ≅ G₂`.
+-/
+def isoCancelRight {E : Type*} [Category E] {G₁ G₂ : E ⥤ D} (F : D ≌ C)
+    (α : G₁ ⋙ F.functor ≅ G₂ ⋙ F.functor) : (G₁ ≅ G₂) :=
+  isoCancelRightOfWeaklyLeftInvertible F.unitIso α
+
+/--
+If a functor `F` is an equivalence, then left-cancellation is possible in the sense that
+`F ⋙ G₁ ≅ F ⋙ G₂` induces `G₁ ≅ G₂`.
+-/
+def isoCancelLeft {E : Type*} [Category E] {G₁ G₂ : D ⥤ E} (F : C ≌ D)
+    (α : F.functor ⋙ G₁ ≅ F.functor ⋙ G₂) : (G₁ ≅ G₂) :=
+  isoCancelLeftOfWeaklyRightInvertible F.counitIso.symm α
+
 end CancellationLemmas
 
 section

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -245,6 +245,30 @@ theorem whiskerRight_left (F : B ⥤ C) {G H : C ⥤ D} (α : G ⟶ H) (K : D �
     whiskerRight (whiskerLeft F α) K = whiskerLeft F (whiskerRight α K) :=
   rfl
 
+/--
+If a functor `F` has a left inverse (up to natural isomorphism), then right-cancellation
+is possible in the sense that `G₁ ⋙ F ≅ G₂ ⋙ F` induces `G₁ ≅ G₂`.
+-/
+def isoCancelRightOfWeaklyLeftInvertible
+    {F : D ⥤ E} {Finv : E ⥤ D} {G₁ G₂ : C ⥤ D} (η : 𝟭 _ ≅ F ⋙ Finv)
+    (α : G₁ ⋙ F ≅ G₂ ⋙ F) : (G₁ ≅ G₂) := by
+  calc
+    G₁ ⋙ 𝟭 _ ≅ G₁ ⋙ F ⋙ Finv := isoWhiskerLeft _ η
+    _ ≅ G₂ ⋙ F ⋙ Finv := isoWhiskerRight α _
+    _ ≅ G₂ ⋙ 𝟭 _ := isoWhiskerLeft _ η.symm
+
+/--
+If a functor `F` has a right inverse (up to natural isomorphism), then left-cancellation
+is possible in the sense that `F ⋙ G₁ ≅ F ⋙ G₂` induces `G₁ ≅ G₂`.
+-/
+def isoCancelLeftOfWeaklyRightInvertible
+    {F : E ⥤ D} {Finv : D ⥤ E} {G₁ G₂ : D ⥤ C} (η : 𝟭 _ ≅ Finv ⋙ F)
+    (α : F ⋙ G₁ ≅ F ⋙ G₂) : (G₁ ≅ G₂) := by
+  calc
+    𝟭 _ ⋙ G₁ ≅ Finv ⋙ F ⋙ G₁ := isoWhiskerRight η _
+    _ ≅ Finv ⋙ F ⋙ G₂ := isoWhiskerLeft _ α
+    _ ≅ 𝟭 _ ⋙ G₂ := isoWhiskerRight η.symm _
+
 end
 
 namespace Functor


### PR DESCRIPTION
This change implements various canceling lemmas for isomorphisms, in the abstract setting of 1-morphisms and 2-morphisms in bicategories as well as for functors and natural isomorphisms.

Note: This is a spin-off of #19484, which is part of the effort to formalize the Freyd-Mitchell embedding theorem, although only one of the various lemmas is used in #19484.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
