### PR TITLE
[Merged by Bors] - feat(Algebra/BigOperators/Group/Finset) : Finset.prod_disjoint_filters

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -404,17 +404,6 @@ theorem prod_disjiUnion (s : Finset ι) (t : ι → Finset α) (h) :
   exact prod_const_one.symm
 
 @[to_additive]
-theorem prod_disjoint_filters (p q : α → Prop) [DecidablePred p] [DecidablePred q]
-    (h : ∀ x ∈ s.filter (fun x => p x ∨ q x), ¬ (p x ∧ q x)) :
-    (∏ x ∈ s with (p x ∨ q x), f x) = (∏ x ∈ s with p x, f x) * (∏ x ∈ s with q x, f x) := by
-  rw [← prod_disjUnion (disjoint_of_or_not_and (fun x ↦ p x) (fun x ↦ q x) h)]
-  exact prod_congr (by
-    ext _
-    simp only [mem_filter, mem_disjUnion]
-    exact and_or_left
-  ) (fun _ _ ↦ rfl)
-
-@[to_additive]
 theorem prod_union_inter [DecidableEq α] :
     (∏ x ∈ s₁ ∪ s₂, f x) * ∏ x ∈ s₁ ∩ s₂, f x = (∏ x ∈ s₁, f x) * ∏ x ∈ s₂, f x :=
   fold_union_inter
@@ -436,6 +425,21 @@ lemma prod_filter_not_mul_prod_filter (s : Finset α) (p : α → Prop) [Decidab
     [∀ x, Decidable (¬p x)] (f : α → β) :
     (∏ x ∈ s.filter fun x ↦ ¬p x, f x) * ∏ x ∈ s.filter p, f x = ∏ x ∈ s, f x := by
   rw [mul_comm, prod_filter_mul_prod_filter_not]
+
+@[to_additive]
+theorem prod_disjoint_filters (p q : α → Prop) [DecidableEq α] [DecidablePred p] [DecidablePred q] :
+    (∏ x ∈ s with (Xor' (p x) (q x)), f x) =
+      (∏ x ∈ s with (p x ∧ ¬ q x), f x) * (∏ x ∈ s with (q x ∧ ¬ p x), f x) := by
+  rw [← prod_union (by
+    apply disjoint_of_or_not_and
+    simp only [mem_filter, not_and, Decidable.not_not, and_imp]
+    exact fun x a a a a_1 a_2 ↦ a
+  ) ]
+  exact prod_congr (by
+    ext _
+    simp only [mem_filter, mem_union]
+    exact and_or_left
+  ) (fun _ _ ↦ rfl)
 
 section ToList
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -427,7 +427,7 @@ lemma prod_filter_not_mul_prod_filter (s : Finset α) (p : α → Prop) [Decidab
   rw [mul_comm, prod_filter_mul_prod_filter_not]
 
 @[to_additive]
-theorem prod_disjoint_filters (p q : α → Prop) [DecidableEq α] [DecidablePred p] [DecidablePred q] :
+theorem prod_filter_xor (p q : α → Prop) [DecidableEq α] [DecidablePred p] [DecidablePred q] :
     (∏ x ∈ s with (Xor' (p x) (q x)), f x) =
       (∏ x ∈ s with (p x ∧ ¬ q x), f x) * (∏ x ∈ s with (q x ∧ ¬ p x), f x) := by
   rw [← prod_union (disjoint_filter_and_not_filter _ _), ← filter_or]

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -404,10 +404,10 @@ theorem prod_disjiUnion (s : Finset ι) (t : ι → Finset α) (h) :
   exact prod_const_one.symm
 
 @[to_additive]
-theorem prod_disjoint_filters_on_set (s : Finset α) (p q : α → Prop) [DecidablePred p]
-    [DecidablePred q] (h : ∀ x ∈ s.filter (fun x => p x ∨ q x), ¬ (p x ∧ q x)) (f : α → β) :
+theorem prod_disjoint_filters (p q : α → Prop) [DecidablePred p] [DecidablePred q]
+    (h : ∀ x ∈ s.filter (fun x => p x ∨ q x), ¬ (p x ∧ q x)) :
     (∏ x ∈ s with (p x ∨ q x), f x) = (∏ x ∈ s with p x, f x) * (∏ x ∈ s with q x, f x) := by
-  rw [← prod_disjUnion (disjoint_of_not_and_on_set (fun x ↦ p x) (fun x ↦ q x) h)]
+  rw [← prod_disjUnion (disjoint_of_or_not_and (fun x ↦ p x) (fun x ↦ q x) h)]
   exact prod_congr (by
     ext _
     simp only [mem_filter, mem_disjUnion]

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -426,16 +426,16 @@ lemma prod_filter_not_mul_prod_filter (s : Finset α) (p : α → Prop) [Decidab
     (∏ x ∈ s.filter fun x ↦ ¬p x, f x) * ∏ x ∈ s.filter p, f x = ∏ x ∈ s, f x := by
   rw [mul_comm, prod_filter_mul_prod_filter_not]
 
+lemma filtertest (p q : α → Prop) [DecidableEq α] [DecidablePred p] [DecidablePred q] :
+    filter (fun x ↦ p x ∨ q x) s  = filter (fun x ↦ p x ) s ∪ filter (fun x ↦ q x ) s := by
+  exact filter_or p q s
+
 @[to_additive]
 theorem prod_disjoint_filters (p q : α → Prop) [DecidableEq α] [DecidablePred p] [DecidablePred q] :
     (∏ x ∈ s with (Xor' (p x) (q x)), f x) =
       (∏ x ∈ s with (p x ∧ ¬ q x), f x) * (∏ x ∈ s with (q x ∧ ¬ p x), f x) := by
-  rw [← prod_union (disjoint_filter_and_not_filter _ _)]
-  exact prod_congr (by
-    ext _
-    simp only [mem_filter, mem_union]
-    exact and_or_left
-  ) (fun _ _ ↦ rfl)
+  rw [← prod_union (disjoint_filter_and_not_filter _ _), ← filter_or]
+  rfl
 
 section ToList
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -404,6 +404,17 @@ theorem prod_disjiUnion (s : Finset ι) (t : ι → Finset α) (h) :
   exact prod_const_one.symm
 
 @[to_additive]
+theorem prod_disjoint_filters_on_set (s : Finset α) (p q : α → Prop) [DecidablePred p]
+    [DecidablePred q] (h : ∀ x ∈ s.filter (fun x => p x ∨ q x), ¬ (p x ∧ q x)) (f : α → β) :
+    (∏ x ∈ s with (p x ∨ q x), f x) = (∏ x ∈ s with p x, f x) * (∏ x ∈ s with q x, f x) := by
+  rw [← prod_disjUnion (disjoint_of_not_and_on_set (fun x ↦ p x) (fun x ↦ q x) h)]
+  exact prod_congr (by
+    ext _
+    simp only [mem_filter, mem_disjUnion]
+    exact and_or_left
+  ) (fun _ _ ↦ rfl)
+
+@[to_additive]
 theorem prod_union_inter [DecidableEq α] :
     (∏ x ∈ s₁ ∪ s₂, f x) * ∏ x ∈ s₁ ∩ s₂, f x = (∏ x ∈ s₁, f x) * ∏ x ∈ s₂, f x :=
   fold_union_inter

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -430,11 +430,7 @@ lemma prod_filter_not_mul_prod_filter (s : Finset α) (p : α → Prop) [Decidab
 theorem prod_disjoint_filters (p q : α → Prop) [DecidableEq α] [DecidablePred p] [DecidablePred q] :
     (∏ x ∈ s with (Xor' (p x) (q x)), f x) =
       (∏ x ∈ s with (p x ∧ ¬ q x), f x) * (∏ x ∈ s with (q x ∧ ¬ p x), f x) := by
-  rw [← prod_union (by
-    apply disjoint_of_or_not_and
-    simp only [mem_filter, not_and, Decidable.not_not, and_imp]
-    exact fun x a a a a_1 a_2 ↦ a
-  ) ]
+  rw [← prod_union (disjoint_filter_and_not_filter _ _)]
   exact prod_congr (by
     ext _
     simp only [mem_filter, mem_union]

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -426,10 +426,6 @@ lemma prod_filter_not_mul_prod_filter (s : Finset α) (p : α → Prop) [Decidab
     (∏ x ∈ s.filter fun x ↦ ¬p x, f x) * ∏ x ∈ s.filter p, f x = ∏ x ∈ s, f x := by
   rw [mul_comm, prod_filter_mul_prod_filter_not]
 
-lemma filtertest (p q : α → Prop) [DecidableEq α] [DecidablePred p] [DecidablePred q] :
-    filter (fun x ↦ p x ∨ q x) s  = filter (fun x ↦ p x ) s ∪ filter (fun x ↦ q x ) s := by
-  exact filter_or p q s
-
 @[to_additive]
 theorem prod_disjoint_filters (p q : α → Prop) [DecidableEq α] [DecidablePred p] [DecidablePred q] :
     (∏ x ∈ s with (Xor' (p x) (q x)), f x) =

--- a/Mathlib/Data/Finset/Filter.lean
+++ b/Mathlib/Data/Finset/Filter.lean
@@ -220,7 +220,7 @@ theorem disjoint_filter_and_not_filter :
   simp [bot_eq_empty, le_eq_subset, subset_empty]
   by_contra hn
   rw [← not_nonempty_iff_eq_empty, not_not] at hn
-  obtain ⟨x, hx⟩ := hn
+  obtain ⟨_, hx⟩ := hn
   exact (mem_filter.mp (htq hx)).2.2 (mem_filter.mp (htp hx)).2.1
 
 variable {p q}

--- a/Mathlib/Data/Finset/Filter.lean
+++ b/Mathlib/Data/Finset/Filter.lean
@@ -214,17 +214,14 @@ lemma _root_.Set.pairwiseDisjoint_filter [DecidableEq β] (f : α → β) (s : S
   obtain ⟨-, rfl⟩ : x ∈ t ∧ f x = j := by simpa using hj hx
   contradiction
 
-theorem disjoint_of_or_not_and (h : ∀ x ∈ s.filter (fun x => p x ∨ q x), ¬ (p x ∧ q x)) :
-    Disjoint (s.filter p) (s.filter q) := by
+theorem disjoint_filter_and_not_filter :
+    Disjoint (s.filter (fun x ↦ p x ∧ ¬q x)) (s.filter (fun x ↦ q x ∧ ¬p x)) := by
   intro _ htp htq
-  simp only [bot_eq_empty, le_eq_subset, subset_empty]
+  simp [bot_eq_empty, le_eq_subset, subset_empty]
   by_contra hn
   rw [← not_nonempty_iff_eq_empty, not_not] at hn
   obtain ⟨x, hx⟩ := hn
-  have px : p x := (mem_filter.mp (htp hx)).2
-  have qx : q x := (mem_filter.mp (htq hx)).2
-  simp_all only [mem_filter, not_and, and_imp, le_eq_subset, filter_subset]
-  exact h x (filter_subset p s (htp hx)) (Or.inr qx) px qx
+  exact (mem_filter.mp (htq hx)).2.2 (mem_filter.mp (htp hx)).2.1
 
 variable {p q}
 

--- a/Mathlib/Data/Finset/Filter.lean
+++ b/Mathlib/Data/Finset/Filter.lean
@@ -214,6 +214,18 @@ lemma _root_.Set.pairwiseDisjoint_filter [DecidableEq β] (f : α → β) (s : S
   obtain ⟨-, rfl⟩ : x ∈ t ∧ f x = j := by simpa using hj hx
   contradiction
 
+theorem disjoint_of_not_and_on_set (h : ∀ x ∈ s.filter (fun x => p x ∨ q x), ¬ (p x ∧ q x)) :
+    Disjoint (s.filter p) (s.filter q) := by
+  intro _ htp htq
+  simp only [bot_eq_empty, le_eq_subset, subset_empty]
+  by_contra hn
+  rw [← not_nonempty_iff_eq_empty, not_not] at hn
+  obtain ⟨x, hx⟩ := hn
+  have px : p x := (mem_filter.mp (htp hx)).2
+  have qx : q x := (mem_filter.mp (htq hx)).2
+  simp_all only [mem_filter, not_and, and_imp, le_eq_subset, filter_subset]
+  exact h x (filter_subset p s (htp hx)) (Or.inr qx) px qx
+
 variable {p q}
 
 lemma filter_inj : s.filter p = t.filter p ↔ ∀ ⦃a⦄, p a → (a ∈ s ↔ a ∈ t) := by

--- a/Mathlib/Data/Finset/Filter.lean
+++ b/Mathlib/Data/Finset/Filter.lean
@@ -214,7 +214,7 @@ lemma _root_.Set.pairwiseDisjoint_filter [DecidableEq β] (f : α → β) (s : S
   obtain ⟨-, rfl⟩ : x ∈ t ∧ f x = j := by simpa using hj hx
   contradiction
 
-theorem disjoint_of_not_and_on_set (h : ∀ x ∈ s.filter (fun x => p x ∨ q x), ¬ (p x ∧ q x)) :
+theorem disjoint_of_or_not_and (h : ∀ x ∈ s.filter (fun x => p x ∨ q x), ¬ (p x ∧ q x)) :
     Disjoint (s.filter p) (s.filter q) := by
   intro _ htp htq
   simp only [bot_eq_empty, le_eq_subset, subset_empty]


### PR DESCRIPTION
Decomposes the product(sum) over two filters where they are pointwise disjoint.

Used in #19432

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
