### PR TITLE
[Merged by Bors] - doc(Order/BoundedOrder/Lattice): fix typos

### DIFF
--- a/Mathlib/Order/BoundedOrder/Lattice.lean
+++ b/Mathlib/Order/BoundedOrder/Lattice.lean
@@ -7,15 +7,15 @@ import Mathlib.Order.BoundedOrder.Basic
 import Mathlib.Order.Lattice
 
 /-!
-# bounded lattices
+# Bounded lattices
 
 This file defines top and bottom elements (greatest and least elements) of a type, the bounded
-variants of different kinds of lattices, sets up the typeclass hierarchy between them and provides
+variants of different kinds of lattices, sets up the typeclass hierarchy between them, and provides
 instances for `Prop` and `fun`.
 
 ## Common lattices
 
-* Distributive lattices with a bottom element. Notated by `[DistribLattice α] [OrderBot α]`
+* Distributive lattices with a bottom element. Notated by `[DistribLattice α] [OrderBot α]`.
   It captures the properties of `Disjoint` that are common to `GeneralizedBooleanAlgebra` and
   `DistribLattice` when `OrderBot`.
 * Bounded and distributive lattice. Notated by `[DistribLattice α] [BoundedOrder α]`.

--- a/Mathlib/Order/BoundedOrder/Lattice.lean
+++ b/Mathlib/Order/BoundedOrder/Lattice.lean
@@ -19,7 +19,7 @@ instances for `Prop` and `fun`.
   It captures the properties of `Disjoint` that are common to `GeneralizedBooleanAlgebra` and
   `DistribLattice` when `OrderBot`.
 * Bounded and distributive lattice. Notated by `[DistribLattice α] [BoundedOrder α]`.
-  Typical examples include `Prop` and `Det α`.
+  Typical examples include `Prop` and `Set α`.
 -/
 
 open Function OrderDual


### PR DESCRIPTION
Change the sentence "Typical examples include `Prop` and `Det α`." to "Typical examples include `Prop` and `Set α`." Also, fix a few other typos.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
