### PR TITLE
[Merged by Bors] - fix(Cache): always invoke `lake` to fetch ProofWidgets

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -183,7 +183,6 @@ def getProofWidgets (buildDir : FilePath) : IO Unit := do
   catch e =>
     throw <| IO.userError s!"Failed to prune ProofWidgets cloud release: {e}"
 
-
 /-- Downloads missing files, and unpacks files. -/
 def getFiles (hashMap : IO.HashMap) (forceDownload forceUnpack parallel decompress : Bool) :
     IO.CacheM Unit := do

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -161,25 +161,28 @@ into the `lean-toolchain` file at the root directory of your project"
 
 /-- Fetches the ProofWidgets cloud release and prunes non-JS files. -/
 def getProofWidgets (buildDir : FilePath) : IO Unit := do
-  -- Check if ProofWidgets is out-of-date via `lake`.
-  -- This is done through Lake as cache has no simple heuristic
-  -- to determine whether the ProofWidgets JS is out-of-date.
-  let exitCode ← (← IO.Process.spawn {cmd := "lake", args := #["-q", "build", "--no-build", "proofwidgets:release"]}).wait
-  if exitCode == 0 then -- up-to-date
-    return
-  else if exitCode == 3 then -- needs fetch (`--no-build` triggered)
-    -- Download and unpack the ProofWidgets cloud release (for its `.js` files)
-    let exitCode ← (← IO.Process.spawn {cmd := "lake", args := #["-q", "build", "proofwidgets:release"]}).wait
-    if exitCode != 0 then
-      throw <| IO.userError s!"Failed to fetch ProofWidgets cloud release: lake failed with error code {exitCode}"
-    -- Prune non-JS ProofWidgets files (e.g., `olean`, `.c`)
-    try
-      IO.FS.removeDirAll (buildDir / "lib")
-      IO.FS.removeDirAll (buildDir / "ir")
-    catch e =>
-      throw <| IO.userError s!"Failed to prune ProofWidgets cloud release: {e}"
-  else
-    throw <| IO.userError s!"Failed to validate ProofWidgets cloud release: lake failed with error code {exitCode}"
+  if (← buildDir.pathExists) then
+    -- Check if the ProofWidgets build is out-of-date via `lake`.
+    -- This is done through Lake as cache has no simple heuristic
+    -- to determine whether the ProofWidgets JS is out-of-date.
+    let exitCode ← (← IO.Process.spawn {cmd := "lake", args := #["-q", "build", "--no-build", "proofwidgets:release"]}).wait
+    if exitCode == 0 then -- up-to-date
+      return
+    else if exitCode == 3 then -- needs fetch (`--no-build` triggered)
+      pure ()
+    else
+      throw <| IO.userError s!"Failed to validate ProofWidgets cloud release: lake failed with error code {exitCode}"
+  -- Download and unpack the ProofWidgets cloud release (for its `.js` files)
+  let exitCode ← (← IO.Process.spawn {cmd := "lake", args := #["-q", "build", "proofwidgets:release"]}).wait
+  if exitCode != 0 then
+    throw <| IO.userError s!"Failed to fetch ProofWidgets cloud release: lake failed with error code {exitCode}"
+  -- Prune non-JS ProofWidgets files (e.g., `olean`, `.c`)
+  try
+    IO.FS.removeDirAll (buildDir / "lib")
+    IO.FS.removeDirAll (buildDir / "ir")
+  catch e =>
+    throw <| IO.userError s!"Failed to prune ProofWidgets cloud release: {e}"
+
 
 /-- Downloads missing files, and unpacks files. -/
 def getFiles (hashMap : IO.HashMap) (forceDownload forceUnpack parallel decompress : Bool) :


### PR DESCRIPTION
Always invoke `lake` to fetch the latest ProofWidgets cloud release on a `lake exe cache get`.  This requires `lake` because cache has no simple heuristic to determine whether the ProofWidgets JS is out-of-date.
