### PR TITLE
[Merged by Bors] - perf(Linter/HaveLetLinter): some local optimisations

### DIFF
--- a/Mathlib/Tactic/Linter/HaveLetLinter.lean
+++ b/Mathlib/Tactic/Linter/HaveLetLinter.lean
@@ -101,8 +101,8 @@ def nonPropHaves : InfoTree → CommandElabM (Array (Syntax × Format)) :=
     -- so that we can then isolate the `fvarId`s that are created by `have`
     let oldMvdecls := i.goalsBefore.filterMap (mctx.decls.find? ·)
     let oldFVars := (oldMvdecls.map (·.lctx.decls.toList.reduceOption)).flatten.map (·.fvarId)
-    -- `newDecls` are the local declarations whose `FVarID` did not exist before the `have`
-    -- effectively they are the declarations that we want to test for being in `Prop` or not.
+    -- `newDecls` are the local declarations whose `FVarID` did not exist before the `have`.
+    -- Effectively they are the declarations that we want to test for being in `Prop` or not.
     let newDecls := lc.decls.toList.reduceOption.filter (! oldFVars.contains ·.fvarId)
     -- Now, we get the `MetaM` state up and running to find the types of each entry of `newDecls`.
     -- For each entry which is a `Type`, we print a warning on `have`.

--- a/Mathlib/Tactic/Linter/HaveLetLinter.lean
+++ b/Mathlib/Tactic/Linter/HaveLetLinter.lean
@@ -100,8 +100,7 @@ def nonPropHaves : InfoTree → CommandElabM (Array (Syntax × Format)) :=
     -- we also accumulate all `fvarId`s from all local contexts before the use of `have`
     -- so that we can then isolate the `fvarId`s that are created by `have`
     let oldMvdecls := i.goalsBefore.filterMap (mctx.decls.find? ·)
-    let oldDecls := (oldMvdecls.map (·.lctx.decls.toList.reduceOption)).flatten
-    let oldFVars := oldDecls.map (·.fvarId)
+    let oldFVars := (oldMvdecls.map (·.lctx.decls.toList.reduceOption)).flatten.map (·.fvarId)
     -- `newDecls` are the local declarations whose `FVarID` did not exist before the `have`
     -- effectively they are the declarations that we want to test for being in `Prop` or not.
     let newDecls := lc.decls.toList.reduceOption.filter (! oldFVars.contains ·.fvarId)

--- a/Mathlib/Tactic/Linter/HaveLetLinter.lean
+++ b/Mathlib/Tactic/Linter/HaveLetLinter.lean
@@ -93,11 +93,10 @@ def nonPropHaves : InfoTree → CommandElabM (Array (Syntax × Format)) :=
     unless isHave? stx do return #[]
     let mctx := i.mctxAfter
     let mvdecls := i.goalsAfter.filterMap (mctx.decls.find? ·)
-    -- we extract the `MetavarDecl` with largest index after a `have`, since this one
-    -- holds information about the metavariable where `have` introduces the new hypothesis.
-    let largestIdx := mvdecls.toArray.qsort (·.index > ·.index)
-    -- the relevant `LocalContext`
-    let lc := (largestIdx.getD 0 default).lctx
+    -- We extract the `MetavarDecl` with largest index after a `have`, since this one
+    -- holds information about the metavariable where `have` introduces the new hypothesis,
+    -- and determine the relevant `LocalContext`.
+    let lc := mvdecls.toArray.getMax? (·.index < ·.index) |>.getD default |>.lctx
     -- we also accumulate all `fvarId`s from all local contexts before the use of `have`
     -- so that we can then isolate the `fvarId`s that are created by `have`
     let oldMvdecls := i.goalsBefore.filterMap (mctx.decls.find? ·)

--- a/Mathlib/Tactic/Linter/HaveLetLinter.lean
+++ b/Mathlib/Tactic/Linter/HaveLetLinter.lean
@@ -100,8 +100,7 @@ def nonPropHaves : InfoTree → CommandElabM (Array (Syntax × Format)) :=
     -- we also accumulate all `fvarId`s from all local contexts before the use of `have`
     -- so that we can then isolate the `fvarId`s that are created by `have`
     let oldMvdecls := i.goalsBefore.filterMap (mctx.decls.find? ·)
-    let oldLctx := oldMvdecls.map (·.lctx)
-    let oldDecls := (oldLctx.map (·.decls.toList.reduceOption)).flatten
+    let oldDecls := (oldMvdecls.map (·.lctx.decls.toList.reduceOption)).flatten
     let oldFVars := oldDecls.map (·.fvarId)
     -- `newDecls` are the local declarations whose `FVarID` did not exist before the `have`
     -- effectively they are the declarations that we want to test for being in `Prop` or not.


### PR DESCRIPTION
Suggested by `kim-em` on [Zulip](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2312190.20.60have.60.20vs.20.60let.60.20linter/near/486013460).

---

Commits can be reviewed independently. I welcome further opportunities for improvement, or for me to learn about better ways to write this.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
