### PR TITLE
[Merged by Bors] - perf: micro-optimise some syntax linters

### DIFF
--- a/Mathlib/Tactic/Linter/FlexibleLinter.lean
+++ b/Mathlib/Tactic/Linter/FlexibleLinter.lean
@@ -343,8 +343,7 @@ Otherwise, if an `FVarId` with the same `userName` exists in the new context, us
 If both of these fail, return `default` (i.e. "fail"). -/
 def persistFVars (fv : FVarId) (before after : LocalContext) : FVarId :=
   let ldecl := (before.find? fv).getD default
-  let name := ldecl.userName
-  (getFVarIdCandidates fv name after).getD 0 default
+  (getFVarIdCandidates fv ldecl.userName after).getD 0 default
 
 /-- `reallyPersist` converts an array of pairs `(fvar, mvar)` to another array of the same type. -/
 def reallyPersist
@@ -376,11 +375,11 @@ def flexibleLinter : Linter where run := withSetOptionIn fun _stx => do
   if (← MonadState.get).messages.hasErrors then
     return
   let trees ← getInfoTrees
-  let x := trees.toList.map (extractCtxAndGoals (fun _ => true))
+  let x := trees.map (extractCtxAndGoals (fun _ => true))
   -- `stains` records pairs `(location, mvar)`, where
   -- * `location` is either a hypothesis or the main goal modified by a flexible tactic and
   -- * `mvar` is the metavariable containing the modified location
-  let mut stains : Array ((FVarId × MVarId) × (Stained × Syntax)) := .empty
+  let mut stains : Array ((FVarId × MVarId) × (Stained × Syntax)) := #[]
   let mut msgs : Array (Syntax × Syntax × Stained) := #[]
   for d in x do for (s, ctx0, ctx1, mvs0, mvs1) in d do
     let skind := s.getKind
@@ -389,17 +388,14 @@ def flexibleLinter : Linter where run := withSetOptionIn fun _stx => do
     for d in getStained! s do
       if shouldStain? then
         for currMVar1 in mvs1 do
-          let lctx1 := ((ctx1.decls.find? currMVar1).getD default).lctx
+          let lctx1 := (ctx1.decls.findD currMVar1 default).lctx
           let locsAfter := d.toFMVarId currMVar1 lctx1
-
-          for l in locsAfter do
-            stains := stains.push (l, (d, s))
-
+          stains := stains.append (locsAfter.map (fun l ↦ (l, (d, s))))
       else
         let stained_in_syntax := if usesGoal? skind then (toStained s).insert d else toStained s
         if !flexible.contains skind then
           for currMv0 in mvs0 do
-            let lctx0 := ((ctx0.decls.find? currMv0).getD default).lctx
+            let lctx0 := (ctx0.decls.findD currMv0 default).lctx
             let mut foundFvs : Std.HashSet (FVarId × MVarId):= {}
             for st in stained_in_syntax do
               for d in st.toFMVarId currMv0 lctx0 do

--- a/Mathlib/Tactic/Linter/FlexibleLinter.lean
+++ b/Mathlib/Tactic/Linter/FlexibleLinter.lean
@@ -390,7 +390,7 @@ def flexibleLinter : Linter where run := withSetOptionIn fun _stx => do
         for currMVar1 in mvs1 do
           let lctx1 := (ctx1.decls.findD currMVar1 default).lctx
           let locsAfter := d.toFMVarId currMVar1 lctx1
-          stains := stains.append (locsAfter.map (fun l ↦ (l, (d, s))))
+          stains := stains ++ locsAfter.map (fun l ↦ (l, (d, s)))
       else
         let stained_in_syntax := if usesGoal? skind then (toStained s).insert d else toStained s
         if !flexible.contains skind then

--- a/Mathlib/Tactic/Linter/Multigoal.lean
+++ b/Mathlib/Tactic/Linter/Multigoal.lean
@@ -61,7 +61,7 @@ There is some overlap in scope between `ignoreBranch` and `exclusions`.
 
 Tactic combinators like `repeat` or `try` are a mix of both.
 -/
-abbrev exclusions : Std.HashSet SyntaxNodeKind := .ofList [
+abbrev exclusions : Std.HashSet SyntaxNodeKind := .ofArray #[
     -- structuring a proof
     ``Lean.Parser.Term.cdot,
     ``cdot,
@@ -112,7 +112,7 @@ Reasons for ignoring these tactics include
 
 There is some overlap in scope between `exclusions` and `ignoreBranch`.
 -/
-abbrev ignoreBranch : Std.HashSet SyntaxNodeKind := .ofList [
+abbrev ignoreBranch : Std.HashSet SyntaxNodeKind := .ofArray #[
     ``Lean.Parser.Tactic.Conv.conv,
     `Mathlib.Tactic.Conv.convLHS,
     `Mathlib.Tactic.Conv.convRHS,

--- a/Mathlib/Tactic/Linter/Multigoal.lean
+++ b/Mathlib/Tactic/Linter/Multigoal.lean
@@ -161,7 +161,7 @@ def multiGoalLinter : Linter where run := withSetOptionIn fun _stx ↦ do
     if (← get).messages.hasErrors then
       return
     let trees ← getInfoTrees
-    for t in trees.toArray do
+    for t in trees do
       for (s, before, after, n) in getManyGoals t do
         let goals (k : Nat) := if k == 1 then f!"1 goal" else f!"{k} goals"
         let fmt ← Command.liftCoreM

--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -72,7 +72,7 @@ abbrev M := StateRefT (Std.HashMap String.Range Syntax) IO
 This can be increased dynamically, using `#allow_unused_tactic`.
 -/
 initialize allowedRef : IO.Ref (Std.HashSet SyntaxNodeKind) ←
-  IO.mkRef <| .ofList [
+  IO.mkRef <| .ofArray #[
     `Mathlib.Tactic.Says.says,
     `Batteries.Tactic.«tacticOn_goal-_=>_»,
     -- attempt to speed up, by ignoring more tactics
@@ -97,7 +97,7 @@ initialize allowedRef : IO.Ref (Std.HashSet SyntaxNodeKind) ←
     `change?,
     `«tactic#adaptation_note_»,
     `tacticSleep_heartbeats_,
-    `Mathlib.Tactic.«tacticRename_bvar_→__»,
+    `Mathlib.Tactic.«tacticRename_bvar_→__»
   ]
 
 /-- `#allow_unused_tactic` takes an input a space-separated list of identifiers.
@@ -120,7 +120,7 @@ A list of blacklisted syntax kinds, which are expected to have subterms that con
 unevaluated tactics.
 -/
 initialize ignoreTacticKindsRef : IO.Ref NameHashSet ←
-  IO.mkRef <| .ofList [
+  IO.mkRef <| .ofArray #[
     `Mathlib.Tactic.Says.says,
     ``Parser.Term.binderTactic,
     ``Lean.Parser.Term.dynamicQuot,
@@ -140,7 +140,7 @@ initialize ignoreTacticKindsRef : IO.Ref NameHashSet ←
     -- the following `SyntaxNodeKind`s play a role in silencing `test`s
     ``Lean.Parser.Tactic.failIfSuccess,
     `Mathlib.Tactic.successIfFailWithMsg,
-    `Mathlib.Tactic.failIfNoProgress,
+    `Mathlib.Tactic.failIfNoProgress
   ]
 
 /-- Is this a syntax kind that contains intentionally unused tactic subterms? -/

--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -147,9 +147,8 @@ initialize ignoreTacticKindsRef : IO.Ref NameHashSet ←
 def isIgnoreTacticKind (ignoreTacticKinds : NameHashSet) (k : SyntaxNodeKind) : Bool :=
   k.components.contains `Conv ||
   "slice".isPrefixOf k.toString ||
-  match k with
-  | .str _ "quot" => true
-  | _ => ignoreTacticKinds.contains k
+  k matches .str _ "quot" ||
+  ignoreTacticKinds.contains k
 
 /--
 Adds a new syntax kind whose children will be ignored by the `unusedTactic` linter.

--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -72,32 +72,33 @@ abbrev M := StateRefT (Std.HashMap String.Range Syntax) IO
 This can be increased dynamically, using `#allow_unused_tactic`.
 -/
 initialize allowedRef : IO.Ref (Std.HashSet SyntaxNodeKind) ←
-  IO.mkRef <| Std.HashSet.empty
-    |>.insert `Mathlib.Tactic.Says.says
-    |>.insert `Batteries.Tactic.«tacticOn_goal-_=>_»
+  IO.mkRef <| .ofList [
+    `Mathlib.Tactic.Says.says,
+    `Batteries.Tactic.«tacticOn_goal-_=>_»,
     -- attempt to speed up, by ignoring more tactics
-    |>.insert `by
-    |>.insert `null
-    |>.insert `«]»
-    |>.insert ``Lean.Parser.Term.byTactic
-    |>.insert ``Lean.Parser.Tactic.tacticSeq
-    |>.insert ``Lean.Parser.Tactic.tacticSeq1Indented
-    |>.insert ``Lean.Parser.Tactic.tacticTry_
+    `by,
+    `null,
+    `«]»,
+    ``Lean.Parser.Term.byTactic,
+    ``Lean.Parser.Tactic.tacticSeq,
+    ``Lean.Parser.Tactic.tacticSeq1Indented,
+    ``Lean.Parser.Tactic.tacticTry_,
     -- the following `SyntaxNodeKind`s play a role in silencing `test`s
-    |>.insert ``Lean.Parser.Tactic.guardHyp
-    |>.insert ``Lean.Parser.Tactic.guardTarget
-    |>.insert ``Lean.Parser.Tactic.failIfSuccess
-    |>.insert `Mathlib.Tactic.successIfFailWithMsg
-    |>.insert `Mathlib.Tactic.failIfNoProgress
-    |>.insert `Mathlib.Tactic.ExtractGoal.extractGoal
-    |>.insert `Mathlib.Tactic.Propose.propose'
-    |>.insert `Lean.Parser.Tactic.traceState
-    |>.insert `Mathlib.Tactic.tacticMatch_target_
-    |>.insert ``Lean.Parser.Tactic.change
-    |>.insert `change?
-    |>.insert `«tactic#adaptation_note_»
-    |>.insert `tacticSleep_heartbeats_
-    |>.insert `Mathlib.Tactic.«tacticRename_bvar_→__»
+    ``Lean.Parser.Tactic.guardHyp,
+    ``Lean.Parser.Tactic.guardTarget,
+    ``Lean.Parser.Tactic.failIfSuccess,
+    `Mathlib.Tactic.successIfFailWithMsg,
+    `Mathlib.Tactic.failIfNoProgress,
+    `Mathlib.Tactic.ExtractGoal.extractGoal,
+    `Mathlib.Tactic.Propose.propose',
+    `Lean.Parser.Tactic.traceState,
+    `Mathlib.Tactic.tacticMatch_target_,
+    ``Lean.Parser.Tactic.change,
+    `change?,
+    `«tactic#adaptation_note_»,
+    `tacticSleep_heartbeats_,
+    `Mathlib.Tactic.«tacticRename_bvar_→__»,
+  ]
 
 /-- `#allow_unused_tactic` takes an input a space-separated list of identifiers.
 These identifiers are then allowed by the unused tactic linter:
@@ -119,27 +120,28 @@ A list of blacklisted syntax kinds, which are expected to have subterms that con
 unevaluated tactics.
 -/
 initialize ignoreTacticKindsRef : IO.Ref NameHashSet ←
-  IO.mkRef <| Std.HashSet.empty
-    |>.insert `Mathlib.Tactic.Says.says
-    |>.insert ``Parser.Term.binderTactic
-    |>.insert ``Lean.Parser.Term.dynamicQuot
-    |>.insert ``Lean.Parser.Tactic.quotSeq
-    |>.insert ``Lean.Parser.Tactic.tacticStop_
-    |>.insert ``Lean.Parser.Command.notation
-    |>.insert ``Lean.Parser.Command.mixfix
-    |>.insert ``Lean.Parser.Tactic.discharger
-    |>.insert ``Lean.Parser.Tactic.Conv.conv
-    |>.insert `Batteries.Tactic.seq_focus
-    |>.insert `Mathlib.Tactic.Hint.registerHintStx
-    |>.insert `Mathlib.Tactic.LinearCombination.linearCombination
-    |>.insert `Mathlib.Tactic.LinearCombination'.linearCombination'
-    |>.insert `Aesop.Frontend.Parser.addRules
-    |>.insert `Aesop.Frontend.Parser.aesopTactic
-    |>.insert `Aesop.Frontend.Parser.aesopTactic?
+  IO.mkRef <| .ofList [
+    `Mathlib.Tactic.Says.says,
+    ``Parser.Term.binderTactic,
+    ``Lean.Parser.Term.dynamicQuot,
+    ``Lean.Parser.Tactic.quotSeq,
+    ``Lean.Parser.Tactic.tacticStop_,
+    ``Lean.Parser.Command.notation,
+    ``Lean.Parser.Command.mixfix,
+    ``Lean.Parser.Tactic.discharger,
+    ``Lean.Parser.Tactic.Conv.conv,
+    `Batteries.Tactic.seq_focus,
+    `Mathlib.Tactic.Hint.registerHintStx,
+    `Mathlib.Tactic.LinearCombination.linearCombination,
+    `Mathlib.Tactic.LinearCombination'.linearCombination',
+    `Aesop.Frontend.Parser.addRules,
+    `Aesop.Frontend.Parser.aesopTactic,
+    `Aesop.Frontend.Parser.aesopTactic?,
     -- the following `SyntaxNodeKind`s play a role in silencing `test`s
-    |>.insert ``Lean.Parser.Tactic.failIfSuccess
-    |>.insert `Mathlib.Tactic.successIfFailWithMsg
-    |>.insert `Mathlib.Tactic.failIfNoProgress
+    ``Lean.Parser.Tactic.failIfSuccess,
+    `Mathlib.Tactic.successIfFailWithMsg,
+    `Mathlib.Tactic.failIfNoProgress,
+  ]
 
 /-- Is this a syntax kind that contains intentionally unused tactic subterms? -/
 def isIgnoreTacticKind (ignoreTacticKinds : NameHashSet) (k : SyntaxNodeKind) : Bool :=


### PR DESCRIPTION
Perform a few local tweaks - which may or may not improve performance, but surely are more readable.
- remove superfluous toArray or toList calls
- use `HashSet.ofArray` instead of `ofList` or calling `insert` many times
- use `findD` instead of `find?` followed by `getD`
- replace `Array.push` in a loop with `Array.append` (currently performance-neutral, but this might change in the future)

Inspired by #19730.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
