### PR TITLE
[Merged by Bors] - chore: make use of `let` more robust

### DIFF
--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -37,7 +37,7 @@ def primeFactorsList : ℕ → List ℕ
   | k + 2 =>
     let m := minFac (k + 2)
     m :: primeFactorsList ((k + 2) / m)
-decreasing_by show (k + 2) / m < (k + 2); exact factors_lemma
+decreasing_by exact factors_lemma
 
 @[deprecated (since := "2024-06-14")] alias factors := primeFactorsList
 

--- a/Mathlib/Logic/Equiv/TransferInstance.lean
+++ b/Mathlib/Logic/Equiv/TransferInstance.lean
@@ -621,10 +621,9 @@ protected abbrev algebra (e : α ≃ β) [Semiring β] :
     simp only [apply_symm_apply, Algebra.mul_smul_comm]
 
 lemma algebraMap_def (e : α ≃ β) [Semiring β] [Algebra R β] (r : R) :
-    let _ := Equiv.semiring e
-    let _ := Equiv.algebra R e
-    (algebraMap R α) r = e.symm ((algebraMap R β) r) := by
-  intros
+    (@algebraMap R α _ (Equiv.semiring e) (Equiv.algebra R e)) r = e.symm ((algebraMap R β) r) := by
+  let _ := Equiv.semiring e
+  let _ := Equiv.algebra R e
   simp only [Algebra.algebraMap_eq_smul_one]
   show e.symm (r • e 1) = e.symm (r • 1)
   simp only [Equiv.one_def, apply_symm_apply]


### PR DESCRIPTION
We are considering changing the behaviour of term mode let.

Mathlib would largely be unscathed; approximately 300 out of the 3000 term mode lets would need to change (either to the existing `letI`, or we might give that a new name).

However these two declarations would break, and the changes in this PR, which hopefully are fairly neutral, will avoid the problem.