### PR TITLE
[Merged by Bors] - perf: mark some definitions as non-computable

### DIFF
--- a/Mathlib/Algebra/Category/Ring/Under/Limits.lean
+++ b/Mathlib/Algebra/Category/Ring/Under/Limits.lean
@@ -82,6 +82,7 @@ def tensorProductFanIsLimit [Finite ι] : IsLimit (tensorProductFan S P) :=
   (IsLimit.equivIsoLimit (tensorProductFanIso P)).symm (Under.piFanIsLimit _)
 
 /-- `tensorProd R S` preserves the limit of the canonical fan on `P`. -/
+noncomputable -- marked noncomputable for performance (only)
 def piFanTensorProductIsLimit [Finite ι] : IsLimit ((tensorProd R S).mapCone (Under.piFan P)) :=
   (isLimitMapConeFanMkEquiv (tensorProd R S) P _).symm <| tensorProductFanIsLimit P
 
@@ -135,7 +136,8 @@ lemma equalizerFork'_ι {A B : Type u} [CommRing A] [CommRing B] [Algebra R A] [
     (Under.equalizerFork' f g).ι = (AlgHom.equalizer f g).val.toUnder := rfl
 
 /-- The canonical fork on `f g : A ⟶ B` is limiting. -/
-def equalizerForkIsLimit {A B : Under R} (f g : A ⟶ B) :
+-- marked noncomputable for performance (only)
+noncomputable def equalizerForkIsLimit {A B : Under R} (f g : A ⟶ B) :
     IsLimit (Under.equalizerFork f g) :=
   isLimitOfReflects (Under.forget R) <|
     (isLimitMapConeForkEquiv (Under.forget R) (equalizer_comp f g)).invFun <|
@@ -161,7 +163,8 @@ lemma tensorProdEqualizer_ι {A B : Under R} (f g : A ⟶ B) :
   rfl
 
 /-- If `S` is `R`-flat, `S ⊗[R] eq(f, g)` is isomorphic to `eq(𝟙 ⊗[R] f, 𝟙 ⊗[R] g)`. -/
-def equalizerForkTensorProdIso [Module.Flat R S] {A B : Under R} (f g : A ⟶ B) :
+-- marked noncomputable for performance (only)
+noncomputable def equalizerForkTensorProdIso [Module.Flat R S] {A B : Under R} (f g : A ⟶ B) :
     tensorProdEqualizer f g ≅ Under.equalizerFork'
         (Algebra.TensorProduct.map (AlgHom.id S S) (toAlgHom f))
         (Algebra.TensorProduct.map (AlgHom.id S S) (toAlgHom g)) :=
@@ -170,6 +173,7 @@ def equalizerForkTensorProdIso [Module.Flat R S] {A B : Under R} (f g : A ⟶ B)
     apply AlgHom.coe_tensorEqualizer
 
 /-- If `S` is `R`-flat, `tensorProd R S` preserves the equalizer of `f` and `g`. -/
+noncomputable -- marked noncomputable for performance (only)
 def tensorProdMapEqualizerForkIsLimit [Module.Flat R S] {A B : Under R} (f g : A ⟶ B) :
     IsLimit ((tensorProd R S).mapCone <| Under.equalizerFork f g) :=
   (isLimitMapConeForkEquiv (tensorProd R S) _).symm <|

--- a/Mathlib/AlgebraicTopology/DoldKan/GammaCompN.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/GammaCompN.lean
@@ -6,6 +6,7 @@ Authors: Joël Riou
 import Mathlib.AlgebraicTopology.DoldKan.FunctorGamma
 import Mathlib.AlgebraicTopology.DoldKan.SplitSimplicialObject
 import Mathlib.CategoryTheory.Idempotents.HomologicalComplex
+import Mathlib.Tactic.SuppressCompilation
 
 /-! The counit isomorphism of the Dold-Kan equivalence
 
@@ -17,6 +18,7 @@ and `N₂Γ₂ : Γ₂ ⋙ N₂ ≅ 𝟭 (Karoubi (ChainComplex C ℕ))`.
 
 -/
 
+suppress_compilation
 
 noncomputable section
 

--- a/Mathlib/CategoryTheory/Comma/Over.lean
+++ b/Mathlib/CategoryTheory/Comma/Over.lean
@@ -852,7 +852,8 @@ def ofDiagEquivalence (X : T × T) :
 
 /-- A version of `StructuredArrow.ofDiagEquivalence` with the roles of the first and second
 projection swapped. -/
-def ofDiagEquivalence' (X : T × T) :
+-- noncomputability is only for performance
+noncomputable def ofDiagEquivalence' (X : T × T) :
     StructuredArrow X (Functor.diag _) ≌ StructuredArrow X.1 (Under.forget X.2) :=
   (ofDiagEquivalence X).trans <|
     (ofStructuredArrowProjEquivalence (𝟭 T) X.1 X.2).trans <|
@@ -919,7 +920,8 @@ def ofDiagEquivalence (X : T × T) :
 
 /-- A version of `CostructuredArrow.ofDiagEquivalence` with the roles of the first and second
 projection swapped. -/
-def ofDiagEquivalence' (X : T × T) :
+-- noncomputability is only for performance
+noncomputable def ofDiagEquivalence' (X : T × T) :
     CostructuredArrow (Functor.diag _) X ≌ CostructuredArrow (Over.forget X.2) X.1 :=
   (ofDiagEquivalence X).trans <|
     (ofCostructuredArrowProjEquivalence (𝟭 T) X.1 X.2).trans <|

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -570,7 +570,8 @@ instance : HasProduct (op <| Z ·) := hasLimitOfIso
 def Cofan.op (c : Cofan Z) : Fan (op <| Z ·) := Fan.mk _ (fun a ↦ (c.inj a).op)
 
 /-- If a `Cofan` is colimit, then its opposite is limit. -/
-def Cofan.IsColimit.op {c : Cofan Z} (hc : IsColimit c) : IsLimit c.op := by
+-- noncomputability is just for performance (compilation takes a while)
+noncomputable def Cofan.IsColimit.op {c : Cofan Z} (hc : IsColimit c) : IsLimit c.op := by
   let e : Discrete.functor (Opposite.op <| Z ·) ≅ (Discrete.opposite α).inverse ⋙
     (Discrete.functor Z).op := Discrete.natIso (fun _ ↦ Iso.refl _)
   refine IsLimit.ofIsoLimit ((IsLimit.postcomposeInvEquiv e _).2
@@ -666,7 +667,8 @@ instance : HasCoproduct (op <| Z ·) := hasColimitOfIso
 def Fan.op (f : Fan Z) : Cofan (op <| Z ·) := Cofan.mk _ (fun a ↦ (f.proj a).op)
 
 /-- If a `Fan` is limit, then its opposite is colimit. -/
-def Fan.IsLimit.op {f : Fan Z} (hf : IsLimit f) : IsColimit f.op := by
+-- noncomputability is just for performance (compilation takes a while)
+noncomputable def Fan.IsLimit.op {f : Fan Z} (hf : IsLimit f) : IsColimit f.op := by
   let e : Discrete.functor (Opposite.op <| Z ·) ≅ (Discrete.opposite α).inverse ⋙
     (Discrete.functor Z).op := Discrete.natIso (fun _ ↦ Iso.refl _)
   refine IsColimit.ofIsoColimit ((IsColimit.precomposeHomEquiv e _).2
@@ -950,6 +952,7 @@ def unopOp {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g)
 
 /-- A pushout cone is a colimit cocone if and only if the corresponding pullback cone
 in the opposite category is a limit cone. -/
+noncomputable -- just for performance; compilation takes several seconds
 def isColimitEquivIsLimitOp {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
     IsColimit c ≃ IsLimit c.op := by
   apply equivOfSubsingletonOfSubsingleton
@@ -963,6 +966,7 @@ def isColimitEquivIsLimitOp {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} (c : Pushout
 
 /-- A pushout cone is a colimit cocone in `Cᵒᵖ` if and only if the corresponding pullback cone
 in `C` is a limit cone. -/
+noncomputable -- just for performance; compilation takes several seconds
 def isColimitEquivIsLimitUnop {X Y Z : Cᵒᵖ} {f : X ⟶ Y} {g : X ⟶ Z} (c : PushoutCocone f g) :
     IsColimit c ≃ IsLimit c.unop := by
   apply equivOfSubsingletonOfSubsingleton

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -288,7 +288,7 @@ def whiskerToCocone {f : J → C} (c : Bicone f) (g : K ≃ J) :
   Cocones.ext (Iso.refl _) (by aesop_cat)
 
 /-- Whiskering a bicone with an equivalence between types preserves being a bilimit bicone. -/
-def whiskerIsBilimitIff {f : J → C} (c : Bicone f) (g : K ≃ J) :
+noncomputable def whiskerIsBilimitIff {f : J → C} (c : Bicone f) (g : K ≃ J) :
     (c.whisker g).IsBilimit ≃ c.IsBilimit := by
   refine equivOfSubsingletonOfSubsingleton (fun hc => ⟨?_, ?_⟩) fun hc => ⟨?_, ?_⟩
   · let this := IsLimit.ofIsoLimit hc.isLimit (Bicone.whiskerToCone c g)


### PR DESCRIPTION
See individual commits for details about each change. This saves about 300*10⁹ instructions on all of mathlib.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
