### PR TITLE
[Merged by Bors] - feat(RingTheory/Flat/Basic): add `Algebra.TensorProduct.include(Left|Right)_injective`

### DIFF
--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -423,3 +423,28 @@ theorem tensorProduct_mapIncl_injective_of_left
 end Flat
 
 end Module
+
+section Injective
+
+open scoped TensorProduct
+
+variable {R S A B : Type*} [CommRing R] [Ring A] [Algebra R A] [Ring B] [Algebra R B]
+  [CommSemiring S] [Algebra S A] [SMulCommClass R S A]
+
+namespace Algebra.TensorProduct
+
+theorem includeLeft_injective [Module.Flat R A] (hb : Function.Injective (algebraMap R B)) :
+    Function.Injective (includeLeft : A →ₐ[S] A ⊗[R] B) := by
+  convert Module.Flat.lTensor_preserves_injective_linearMap (M := A) (Algebra.linearMap R B) hb
+    |>.comp (_root_.TensorProduct.rid R A).symm.injective
+  ext; simp
+
+theorem includeRight_injective [Module.Flat R B] (ha : Function.Injective (algebraMap R A)) :
+    Function.Injective (includeRight : B →ₐ[R] A ⊗[R] B) := by
+  convert Module.Flat.rTensor_preserves_injective_linearMap (M := B) (Algebra.linearMap R A) ha
+    |>.comp (_root_.TensorProduct.lid R B).symm.injective
+  ext; simp
+
+end Algebra.TensorProduct
+
+end Injective


### PR DESCRIPTION
which states that if certain `algebraMap` is injective and certain module is flat, then `Algebra.TensorProduct.include(Left|Right)` is injective.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
