### PR TITLE
[Merged by Bors] - feat: more `Int.ediv` lemmas

### DIFF
--- a/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
@@ -46,6 +46,14 @@ theorem natAbs_abs (a : ℤ) : natAbs |a| = natAbs a := by rw [abs_eq_natAbs]; r
 theorem sign_mul_abs (a : ℤ) : sign a * |a| = a := by
   rw [abs_eq_natAbs, sign_mul_natAbs a]
 
+theorem sign_mul_self_eq_natAbs : ∀ a : Int, sign a * a = natAbs a
+  | 0      => rfl
+  | Nat.succ _ => Int.one_mul _
+  | -[_+1] => (Int.neg_eq_neg_one_mul _).symm
+
+theorem sign_mul_self_eq_abs (a : ℤ) : sign a * a = |a| := by
+  rw [abs_eq_natAbs, sign_mul_self_eq_natAbs]
+
 lemma natAbs_le_self_sq (a : ℤ) : (Int.natAbs a : ℤ) ≤ a ^ 2 := by
   rw [← Int.natAbs_sq a, sq]
   norm_cast
@@ -128,6 +136,10 @@ theorem abs_sign_of_nonzero {z : ℤ} (hz : z ≠ 0) : |z.sign| = 1 := by
 protected theorem sign_eq_ediv_abs (a : ℤ) : sign a = a / |a| :=
   if az : a = 0 then by simp [az]
   else (Int.ediv_eq_of_eq_mul_left (mt abs_eq_zero.1 az) (sign_mul_abs _).symm).symm
+
+protected theorem sign_eq_abs_ediv (a : ℤ) : sign a = |a| / a :=
+  if az : a = 0 then by simp [az]
+  else (Int.ediv_eq_of_eq_mul_left az (sign_mul_self_eq_abs _).symm).symm
 
 end Int
 

--- a/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
@@ -46,11 +46,6 @@ theorem natAbs_abs (a : ℤ) : natAbs |a| = natAbs a := by rw [abs_eq_natAbs]; r
 theorem sign_mul_abs (a : ℤ) : sign a * |a| = a := by
   rw [abs_eq_natAbs, sign_mul_natAbs a]
 
-theorem sign_mul_self_eq_natAbs : ∀ a : Int, sign a * a = natAbs a
-  | 0      => rfl
-  | Nat.succ _ => Int.one_mul _
-  | -[_+1] => (Int.neg_eq_neg_one_mul _).symm
-
 theorem sign_mul_self_eq_abs (a : ℤ) : sign a * a = |a| := by
   rw [abs_eq_natAbs, sign_mul_self_eq_natAbs]
 

--- a/Mathlib/Data/Int/Defs.lean
+++ b/Mathlib/Data/Int/Defs.lean
@@ -348,6 +348,11 @@ lemma natAbs_sq (x : ℤ) : (x.natAbs : ℤ) ^ 2 = x ^ 2 := by
 
 alias natAbs_pow_two := natAbs_sq
 
+theorem sign_mul_self_eq_natAbs : ∀ a : Int, sign a * a = natAbs a
+  | 0      => rfl
+  | Nat.succ _ => Int.one_mul _
+  | -[_+1] => (Int.neg_eq_neg_one_mul _).symm
+
 /-! ### `/`  -/
 
 @[simp, norm_cast] lemma natCast_div (m n : ℕ) : ((m / n : ℕ) : ℤ) = m / n := rfl

--- a/Mathlib/Data/Int/Lemmas.lean
+++ b/Mathlib/Data/Int/Lemmas.lean
@@ -134,7 +134,7 @@ theorem div2_bit (b n) : div2 (bit b n) = n := by
 @[deprecated (since := "2024-04-02")] alias coe_nat_nonpos_iff := natCast_nonpos_iff
 
 /-- Like `Int.ediv_emod_unique`, but permitting negative `b`. -/
-theorem _root_.Int.ediv_emod_unique' {a b r q : Int} (h : b ≠ 0) :
+theorem ediv_emod_unique' {a b r q : Int} (h : b ≠ 0) :
   a / b = q ∧ a % b = r ↔ r + b * q = a ∧ 0 ≤ r ∧ r < |b| := by
   constructor
   · intro ⟨rfl, rfl⟩

--- a/Mathlib/Data/Int/Lemmas.lean
+++ b/Mathlib/Data/Int/Lemmas.lean
@@ -133,4 +133,16 @@ theorem div2_bit (b n) : div2 (bit b n) = n := by
 @[deprecated (since := "2024-04-02")] alias abs_coe_nat := abs_natCast
 @[deprecated (since := "2024-04-02")] alias coe_nat_nonpos_iff := natCast_nonpos_iff
 
+/-- Like `Int.ediv_emod_unique`, but permitting negative `b`. -/
+theorem _root_.Int.ediv_emod_unique' {a b r q : Int} (h : b ≠ 0) :
+  a / b = q ∧ a % b = r ↔ r + b * q = a ∧ 0 ≤ r ∧ r < |b| := by
+  constructor
+  · intro ⟨rfl, rfl⟩
+    exact ⟨emod_add_ediv a b, emod_nonneg _ h, emod_lt _ h⟩
+  · intro ⟨rfl, hz, hb⟩
+    constructor
+    · rw [Int.add_mul_ediv_left r q h, ediv_eq_zero_of_lt_abs hz hb]
+      simp [Int.zero_add]
+    · rw [add_mul_emod_self_left, ← emod_abs, emod_eq_of_lt hz hb]
+
 end Int

--- a/Mathlib/Data/Int/Lemmas.lean
+++ b/Mathlib/Data/Int/Lemmas.lean
@@ -135,7 +135,7 @@ theorem div2_bit (b n) : div2 (bit b n) = n := by
 
 /-- Like `Int.ediv_emod_unique`, but permitting negative `b`. -/
 theorem ediv_emod_unique' {a b r q : Int} (h : b ≠ 0) :
-  a / b = q ∧ a % b = r ↔ r + b * q = a ∧ 0 ≤ r ∧ r < |b| := by
+    a / b = q ∧ a % b = r ↔ r + b * q = a ∧ 0 ≤ r ∧ r < |b| := by
   constructor
   · intro ⟨rfl, rfl⟩
     exact ⟨emod_add_ediv a b, emod_nonneg _ h, emod_lt _ h⟩


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
