### PR TITLE
[Merged by Bors] - fix: do not keep only the first line of hints

### DIFF
--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -72,7 +72,7 @@ def suggestion (tac : TSyntax `tactic) (msgs : MessageLog := {}) : TacticM Sugge
   let msg? ← msgs.toList.findM? fun m => do pure <|
     m.severity == MessageSeverity.information && (← m.data.toString).startsWith "Try this: "
   let suggestion ← match msg? with
-  | some m => pure <| SuggestionText.string (((← m.data.toString).drop 10).takeWhile (· != '\n'))
+  | some m => pure <| SuggestionText.string ((← m.data.toString).drop 10)
   | none => pure <| SuggestionText.tsyntax tac
   return { suggestion, postInfo?, style? }
 

--- a/MathlibTest/hint.lean
+++ b/MathlibTest/hint.lean
@@ -51,3 +51,26 @@ info: Try these:
 -/
 #guard_msgs in
 example {P : Nat → Prop} (h : { x // P x }) : ∃ x, P x ∧ 0 ≤ x := by hint
+
+section multiline_hint
+
+local macro "this_is_a_multiline_exact" ppLine t:term : tactic => `(tactic| exact $t)
+
+local elab tk:"long_trivial" : tactic => do
+  let triv := Lean.mkIdent ``trivial
+  let actual ← `(tactic| this_is_a_multiline_exact $triv)
+  Lean.Meta.Tactic.TryThis.addSuggestion tk { suggestion := .tsyntax actual}
+  Lean.Elab.Tactic.evalTactic actual
+
+register_hint long_trivial
+
+/--
+info: Try these:
+• this_is_a_multiline_exact
+  trivial
+-/
+#guard_msgs in
+example : True := by
+  hint
+
+end multiline_hint


### PR DESCRIPTION
This is still not really the right approach, but it's clearly less wrong.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
