### PR TITLE
[Merged by Bors] - feat: add optional message for `try_this` tactic, and use it for `ring`

### DIFF
--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -259,9 +259,17 @@ example (x : ℕ) (h : x * 2 > 5): x + x > 5 := by ring; assumption -- suggests 
 ```
 -/
 macro (name := ring) "ring" : tactic =>
-  `(tactic| first | ring1 | try_this ring_nf)
+  `(tactic| first | ring1 | try_this ring_nf
+  "\n\nThe `ring` tactic failed to close the goal. Use `ring_nf` to obtain a normal form.
+  \nNote that `ring` works primarily in *commutative* rings. \
+  If you have a noncommutative ring, abelian group or module, consider using \
+  `noncomm_ring`, `abel` or `module` instead.")
 @[inherit_doc ring] macro "ring!" : tactic =>
-  `(tactic| first | ring1! | try_this ring_nf!)
+  `(tactic| first | ring1! | try_this ring_nf!
+  "\n\nThe `ring!` tactic failed to close the goal. Use `ring_nf!` to obtain a normal form.
+  \nNote that `ring!` works primarily in *commutative* rings. \
+  If you have a noncommutative ring, abelian group or module, consider using \
+  `noncomm_ring`, `abel` or `module` instead.")
 
 /--
 The tactic `ring` evaluates expressions in *commutative* (semi)rings.
@@ -270,9 +278,17 @@ This is the conv tactic version, which rewrites a target which is a ring equalit
 See also the `ring` tactic.
 -/
 macro (name := ringConv) "ring" : conv =>
-  `(conv| first | discharge => ring1 | try_this ring_nf)
+  `(conv| first | discharge => ring1 | try_this ring_nf
+  "\n\nThe `ring` tactic failed to close the goal. Use `ring_nf` to obtain a normal form.
+  \nNote that `ring` works primarily in *commutative* rings. \
+  If you have a noncommutative ring, abelian group or module, consider using \
+  `noncomm_ring`, `abel` or `module` instead.")
 @[inherit_doc ringConv] macro "ring!" : conv =>
-  `(conv| first | discharge => ring1! | try_this ring_nf!)
+  `(conv| first | discharge => ring1! | try_this ring_nf!
+  "\n\nThe `ring!` tactic failed to close the goal. Use `ring_nf!` to obtain a normal form.
+  \nNote that `ring!` works primarily in *commutative* rings. \
+  If you have a noncommutative ring, abelian group or module, consider using \
+  `noncomm_ring`, `abel` or `module` instead.")
 
 end RingNF
 

--- a/Mathlib/Tactic/TryThis.lean
+++ b/Mathlib/Tactic/TryThis.lean
@@ -18,13 +18,17 @@ namespace Mathlib.Tactic
 open Lean
 
 /-- Produces the text `Try this: <tac>` with the given tactic, and then executes it. -/
-elab tk:"try_this" tac:tactic : tactic => do
+elab tk:"try_this" tac:tactic info:(str)? : tactic => do
   Elab.Tactic.evalTactic tac
-  Meta.Tactic.TryThis.addSuggestion tk tac (origSpan? := ← getRef)
+  Meta.Tactic.TryThis.addSuggestion tk
+    { suggestion := tac, postInfo? := TSyntax.getString <$> info }
+    (origSpan? := ← getRef)
 
 /-- Produces the text `Try this: <tac>` with the given conv tactic, and then executes it. -/
-elab tk:"try_this" tac:conv : conv => do
+elab tk:"try_this" tac:conv info:(str)? : conv => do
   Elab.Tactic.evalTactic tac
-  Meta.Tactic.TryThis.addSuggestion tk tac (origSpan? := ← getRef)
+  Meta.Tactic.TryThis.addSuggestion tk
+    { suggestion := tac, postInfo? := TSyntax.getString <$> info }
+    (origSpan? := ← getRef)
 
 end Mathlib.Tactic


### PR DESCRIPTION
This adds a message to the `ring` tactic when `ring1` fails to solve the goal. It informs the user of common pitfalls when using `ring`, and suggests `noncomm_ring`, `abel` and `module` as alternatives.

This confusion occurs repeatedly on Zulip, e.g., [here](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/why.20ring.20doesn't.20work.20on.20ring/near/486365363) and [here](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Behaviour.20of.20ring.20tactic/near/436204738) to name only two examples.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
