### PR TITLE
[Merged by Bors] - feat(RingTheory/Polynomial/HilbertPoly): `Polynomial.natDegree_hilbertPoly_of_ne_zero`

### DIFF
--- a/Mathlib/Algebra/Polynomial/Degree/Domain.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Domain.lean
@@ -40,6 +40,15 @@ lemma natDegree_mul (hp : p ≠ 0) (hq : q ≠ 0) : (p*q).natDegree = p.natDegre
   rw [← Nat.cast_inj (R := WithBot ℕ), ← degree_eq_natDegree (mul_ne_zero hp hq),
     Nat.cast_add, ← degree_eq_natDegree hp, ← degree_eq_natDegree hq, degree_mul]
 
+variable (p) in
+lemma natDegree_smul (ha : a ≠ 0) : (a • p).natDegree = p.natDegree := by
+  by_cases hp : p = 0
+  · simp only [hp, smul_zero]
+  · apply natDegree_eq_of_le_of_coeff_ne_zero
+    · exact (natDegree_smul_le _ _).trans (le_refl _)
+    · simpa only [coeff_smul, coeff_natDegree, smul_eq_mul, ne_eq, mul_eq_zero,
+        leadingCoeff_eq_zero, not_or] using ⟨ha, hp⟩
+
 @[simp]
 lemma natDegree_pow (p : R[X]) (n : ℕ) : natDegree (p ^ n) = n * natDegree p := by
   classical

--- a/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
+++ b/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
@@ -78,6 +78,10 @@ lemma coeff_preHilbertPoly_self [CharZero F] (d k : ℕ) :
     simp only [leadingCoeff_comp (ne_of_eq_of_ne (natDegree_X_sub_C _) one_ne_zero), Monic.def.1
       (monic_ascPochhammer _ _), one_mul, leadingCoeff_X_sub_C, one_pow, smul_eq_mul, mul_one]
 
+lemma leadingCoeff_preHilbertPoly [CharZero F] (d k : ℕ) :
+    (preHilbertPoly F d k).leadingCoeff = (d ! : F)⁻¹ := by
+  rw [leadingCoeff, natDegree_preHilbertPoly, coeff_preHilbertPoly_self]
+
 lemma preHilbertPoly_eq_choose_sub_add [CharZero F] (d : ℕ) {k n : ℕ} (hkn : k ≤ n):
     (preHilbertPoly F d k).eval (n : F) = (n - k + d).choose d := by
   have : (d ! : F) ≠ 0 := by norm_cast; positivity
@@ -95,7 +99,7 @@ is defined as `∑ i in p.support, (p.coeff i) • Polynomial.preHilbertPoly F d
 `M` is a graded module whose Poincaré series can be written as `p(X)/(1 - X)ᵈ` for some
 `p : ℚ[X]` with integer coefficients, then `Polynomial.hilbertPoly p d` is the Hilbert
 polynomial of `M`. See also `Polynomial.coeff_mul_invOneSubPow_eq_hilbertPoly_eval`,
-which says that `PowerSeries.coeff F n (p * (PowerSeries.invOneSubPow F d))` equals
+which says that `PowerSeries.coeff F n (p * PowerSeries.invOneSubPow F d)` equals
 `(Polynomial.hilbertPoly p d).eval (n : F)` for any large enough `n : ℕ`.
 -/
 noncomputable def hilbertPoly (p : F[X]) : (d : ℕ) → F[X]
@@ -127,7 +131,7 @@ coefficient of `Xⁿ` in the power series expansion of `p/(1 - X)ᵈ`.
 -/
 theorem coeff_mul_invOneSubPow_eq_hilbertPoly_eval
     {p : F[X]} (d : ℕ) {n : ℕ} (hn : p.natDegree < n) :
-    PowerSeries.coeff F n (p * (invOneSubPow F d)) = (hilbertPoly p d).eval (n : F) := by
+    PowerSeries.coeff F n (p * invOneSubPow F d) = (hilbertPoly p d).eval (n : F) := by
   delta hilbertPoly; induction d with
   | zero => simp only [invOneSubPow_zero, Units.val_one, mul_one, coeff_coe, eval_zero]
             exact coeff_eq_zero_of_natDegree_lt hn
@@ -155,8 +159,8 @@ theorem coeff_mul_invOneSubPow_eq_hilbertPoly_eval
 The polynomial satisfying the key property of `Polynomial.hilbertPoly p d` is unique.
 -/
 theorem exists_unique_hilbertPoly (p : F[X]) (d : ℕ) :
-    ∃! (h : F[X]), (∃ (N : ℕ), (∀ (n : ℕ) (_ : N < n),
-    PowerSeries.coeff F n (p * (invOneSubPow F d)) = h.eval (n : F))) := by
+    ∃! h : F[X], ∃ N : ℕ, ∀ n > N,
+    PowerSeries.coeff F n (p * invOneSubPow F d) = h.eval (n : F) := by
   use hilbertPoly p d; constructor
   · use p.natDegree
     exact fun n => coeff_mul_invOneSubPow_eq_hilbertPoly_eval d
@@ -169,12 +173,12 @@ theorem exists_unique_hilbertPoly (p : F[X]) (d : ℕ) :
 
 /--
 If `h : F[X]` and there exists some `N : ℕ` such that for any number `n : ℕ` bigger than `N`
-we have `PowerSeries.coeff F n (p * (invOneSubPow F d)) = h.eval (n : F)`, then `h` is exactly
+we have `PowerSeries.coeff F n (p * invOneSubPow F d) = h.eval (n : F)`, then `h` is exactly
 `Polynomial.hilbertPoly p d`.
 -/
 theorem eq_hilbertPoly_of_forall_coeff_eq_eval
-    {p h : F[X]} {d : ℕ} (N : ℕ) (hhN : ∀ (n : ℕ) (_ : N < n),
-    PowerSeries.coeff F n (p * (invOneSubPow F d)) = h.eval (n : F)) :
+    {p h : F[X]} {d : ℕ} (N : ℕ) (hhN : ∀ n > N,
+    PowerSeries.coeff F n (p * invOneSubPow F d) = h.eval (n : F)) :
     h = hilbertPoly p d :=
   ExistsUnique.unique (exists_unique_hilbertPoly p d) ⟨N, hhN⟩
     ⟨p.natDegree, fun _ x => coeff_mul_invOneSubPow_eq_hilbertPoly_eval d x⟩


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The main result achieved in this pull request is `Polynomial.natDegree_hilbertPoly_of_ne_zero`, which can tell us the specific degree of any non-zero Hilbert polynomial.