### PR TITLE
[Merged by Bors] - feat: non-degeneracy of root pairing form without assuming ordered scalars

### DIFF
--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -407,9 +407,9 @@ alias rootSystem_toLin_apply := rootSystem_toPerfectPairing_apply
 @[simp] lemma rootSystem_root_apply (α) : (rootSystem H).root α = α := rfl
 @[simp] lemma rootSystem_coroot_apply (α) : (rootSystem H).coroot α = coroot α := rfl
 
-theorem isCrystallographic_rootSystem : (rootSystem H).IsCrystallographic := by
-  rintro α _ ⟨β, rfl⟩
-  exact ⟨chainBotCoeff β.1 α.1 - chainTopCoeff β.1 α.1, by simp [apply_coroot_eq_cast β.1 α.1]⟩
+instance : (rootSystem H).IsCrystallographic where
+  exists_int α β :=
+    ⟨chainBotCoeff β.1 α.1 - chainTopCoeff β.1 α.1, by simp [apply_coroot_eq_cast β.1 α.1]⟩
 
 theorem isReduced_rootSystem : (rootSystem H).IsReduced := by
   intro ⟨α, hα⟩ ⟨β, hβ⟩ e

--- a/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -148,7 +148,11 @@ theorem orthogonal_le (h : N ≤ L) : B.orthogonal L ≤ B.orthogonal N := fun _
 theorem le_orthogonal_orthogonal (b : B.IsRefl) : N ≤ B.orthogonal (B.orthogonal N) :=
   fun n hn _ hm => b _ _ (hm n hn)
 
-lemma orthogonal_top (hB : B.Nondegenerate) (hB₀ : B.IsRefl) :
+lemma orthogonal_top_eq_ker (hB : B.IsRefl) :
+    B.orthogonal ⊤ = LinearMap.ker B := by
+  ext; simp [LinearMap.BilinForm.IsOrtho, LinearMap.ext_iff, hB.eq_iff]
+
+lemma orthogonal_top_eq_bot (hB : B.Nondegenerate) (hB₀ : B.IsRefl) :
     B.orthogonal ⊤ = ⊥ :=
   (Submodule.eq_bot_iff _).mpr fun _ hx ↦ hB _ fun y ↦ hB₀ _ _ <| hx y Submodule.mem_top
 
@@ -320,7 +324,7 @@ theorem finrank_add_finrank_orthogonal (b₁ : B.IsRefl) (W : Submodule K V) :
 lemma finrank_orthogonal (hB : B.Nondegenerate) (hB₀ : B.IsRefl) (W : Submodule K V) :
     finrank K (B.orthogonal W) = finrank K V - finrank K W := by
   have := finrank_add_finrank_orthogonal hB₀ (W := W)
-  rw [B.orthogonal_top hB hB₀, inf_bot_eq, finrank_bot, add_zero] at this
+  rw [B.orthogonal_top_eq_bot hB hB₀, inf_bot_eq, finrank_bot, add_zero] at this
   have : finrank K W ≤ finrank K V := finrank_le W
   omega
 

--- a/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
+++ b/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
@@ -209,16 +209,17 @@ lemma Submodule.finrank_quotient [Module.Finite R M] {S : Type*} [Ring S] [SMul 
   rw [← (N.restrictScalars R).finrank_quotient_add_finrank]
   exact Nat.eq_sub_of_add_eq rfl
 
-lemma Submodule.disjoint_ker_of_finrank_eq [NoZeroSMulDivisors R M] {N : Type*} [AddCommGroup N]
+lemma Submodule.disjoint_ker_of_finrank_le [NoZeroSMulDivisors R M] {N : Type*} [AddCommGroup N]
     [Module R N] {L : Submodule R M} [Module.Finite R L] (f : M →ₗ[R] N)
-    (h : finrank R (L.map f) = finrank R L) :
+    (h : finrank R L ≤ finrank R (L.map f)) :
     Disjoint L (LinearMap.ker f) := by
   refine disjoint_iff.mpr <| LinearMap.injective_domRestrict_iff.mp <| LinearMap.ker_eq_bot.mp <|
     Submodule.rank_eq_zero.mp ?_
   rw [← Submodule.finrank_eq_rank, Nat.cast_eq_zero]
   rw [← LinearMap.range_domRestrict] at h
   have := (LinearMap.ker (f.domRestrict L)).finrank_quotient_add_finrank
-  rwa [LinearEquiv.finrank_eq (f.domRestrict L).quotKerEquivRange, h, Nat.add_eq_left] at this
+  rw [LinearEquiv.finrank_eq (f.domRestrict L).quotKerEquivRange] at this
+  omega
 
 end Finrank
 

--- a/Mathlib/LinearAlgebra/Dual.lean
+++ b/Mathlib/LinearAlgebra/Dual.lean
@@ -1246,6 +1246,11 @@ noncomputable def quotEquivAnnihilator (W : Subspace K V) : (V ⧸ W) ≃ₗ[K] 
 
 open Module
 
+theorem finrank_add_finrank_dualAnnihilator_eq (W : Subspace K V) :
+    finrank K W + finrank K W.dualAnnihilator = finrank K V := by
+  rw [← W.quotEquivAnnihilator.finrank_eq (M₂ := dualAnnihilator W),
+    add_comm, Submodule.finrank_quotient_add_finrank]
+
 @[simp]
 theorem finrank_dualCoannihilator_eq {Φ : Subspace K (Module.Dual K V)} :
     finrank K Φ.dualCoannihilator = finrank K Φ.dualAnnihilator := by
@@ -1254,12 +1259,7 @@ theorem finrank_dualCoannihilator_eq {Φ : Subspace K (Module.Dual K V)} :
 
 theorem finrank_add_finrank_dualCoannihilator_eq (W : Subspace K (Module.Dual K V)) :
     finrank K W + finrank K W.dualCoannihilator = finrank K V := by
-  rw [finrank_dualCoannihilator_eq]
-  -- Porting note: LinearEquiv.finrank_eq needs help
-  let equiv := W.quotEquivAnnihilator
-  have eq := LinearEquiv.finrank_eq (R := K) (M := (Module.Dual K V) ⧸ W)
-    (M₂ := { x // x ∈ dualAnnihilator W }) equiv
-  rw [eq.symm, add_comm, Submodule.finrank_quotient_add_finrank, Subspace.dual_finrank_eq]
+  rw [finrank_dualCoannihilator_eq, finrank_add_finrank_dualAnnihilator_eq, dual_finrank_eq]
 
 end
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Triangularizable.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Triangularizable.lean
@@ -134,7 +134,7 @@ theorem iSup_maxGenEigenspace_eq_top [IsAlgClosed K] [FiniteDimensional K V] (f 
     -- Since the dimensions of `ER` and `ES` add up to the dimension of `V`, it follows that the
     -- span of all generalized eigenvectors is all of `V`.
     show ⨆ (μ : K), f.maxGenEigenspace μ = ⊤
-    rw [← top_le_iff, ← Submodule.eq_top_of_disjoint ER ES (le_of_eq h_dim_add.symm) h_disjoint]
+    rw [← top_le_iff, ← Submodule.eq_top_of_disjoint ER ES h_dim_add.ge h_disjoint]
     apply sup_le hER hES
 
 -- Lemma 8.21 of [axler2015]

--- a/Mathlib/LinearAlgebra/Eigenspace/Triangularizable.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Triangularizable.lean
@@ -134,7 +134,7 @@ theorem iSup_maxGenEigenspace_eq_top [IsAlgClosed K] [FiniteDimensional K V] (f 
     -- Since the dimensions of `ER` and `ES` add up to the dimension of `V`, it follows that the
     -- span of all generalized eigenvectors is all of `V`.
     show ⨆ (μ : K), f.maxGenEigenspace μ = ⊤
-    rw [← top_le_iff, ← Submodule.eq_top_of_disjoint ER ES h_dim_add h_disjoint]
+    rw [← top_le_iff, ← Submodule.eq_top_of_disjoint ER ES (le_of_eq h_dim_add.symm) h_disjoint]
     apply sup_le hER hES
 
 -- Lemma 8.21 of [axler2015]

--- a/Mathlib/LinearAlgebra/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional.lean
@@ -54,22 +54,29 @@ theorem finrank_add_le_finrank_add_finrank (s t : Submodule K V) [FiniteDimensio
   rw [← finrank_sup_add_finrank_inf_eq]
   exact self_le_add_right _ _
 
-theorem eq_top_of_disjoint [FiniteDimensional K V] (s t : Submodule K V)
-    (hdim : finrank K s + finrank K t = finrank K V) (hdisjoint : Disjoint s t) : s ⊔ t = ⊤ := by
-  have h_finrank_inf : finrank K ↑(s ⊓ t) = 0 := by
-    rw [disjoint_iff_inf_le, le_bot_iff] at hdisjoint
-    rw [hdisjoint, finrank_bot]
-  apply eq_top_of_finrank_eq
-  rw [← hdim]
-  convert s.finrank_sup_add_finrank_inf_eq t
-  rw [h_finrank_inf]
-  rfl
-
 theorem finrank_add_finrank_le_of_disjoint [FiniteDimensional K V]
     {s t : Submodule K V} (hdisjoint : Disjoint s t) :
     finrank K s + finrank K t ≤ finrank K V := by
   rw [← Submodule.finrank_sup_add_finrank_inf_eq s t, hdisjoint.eq_bot, finrank_bot, add_zero]
   exact Submodule.finrank_le _
+
+theorem eq_top_of_disjoint [FiniteDimensional K V] (s t : Submodule K V)
+    (hdim : finrank K V ≤ finrank K s + finrank K t) (hdisjoint : Disjoint s t) : s ⊔ t = ⊤ := by
+  have h_finrank_inf : finrank K ↑(s ⊓ t) = 0 := by
+    rw [disjoint_iff_inf_le, le_bot_iff] at hdisjoint
+    rw [hdisjoint, finrank_bot]
+  apply eq_top_of_finrank_eq
+  replace hdim : finrank K V = finrank K s + finrank K t :=
+    le_antisymm hdim (finrank_add_finrank_le_of_disjoint hdisjoint)
+  rw [hdim]
+  convert s.finrank_sup_add_finrank_inf_eq t
+  rw [h_finrank_inf]
+  rfl
+
+theorem disjoint_iff_isCompl [FiniteDimensional K V] (s t : Submodule K V)
+    (hdim : finrank K V ≤ finrank K s + finrank K t) :
+    IsCompl s t ↔ Disjoint s t :=
+  ⟨fun h ↦ h.1, fun h ↦ ⟨h, codisjoint_iff.mpr <| eq_top_of_disjoint s t hdim h⟩⟩
 
 end DivisionRing
 

--- a/Mathlib/LinearAlgebra/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional.lean
@@ -73,7 +73,7 @@ theorem eq_top_of_disjoint [FiniteDimensional K V] (s t : Submodule K V)
   rw [h_finrank_inf]
   rfl
 
-theorem disjoint_iff_isCompl [FiniteDimensional K V] (s t : Submodule K V)
+theorem isCompl_iff_disjoint [FiniteDimensional K V] (s t : Submodule K V)
     (hdim : finrank K V ≤ finrank K s + finrank K t) :
     IsCompl s t ↔ Disjoint s t :=
   ⟨fun h ↦ h.1, fun h ↦ ⟨h, codisjoint_iff.mpr <| eq_top_of_disjoint s t hdim h⟩⟩

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -353,21 +353,20 @@ lemma pairing_reflection_perm_self_right (i j : ι) :
 
 /-- A root pairing is said to be crystallographic if the pairing between a root and coroot is
 always an integer. -/
-def IsCrystallographic : Prop :=
-  ∀ i, MapsTo (P.root' i) (range P.coroot) (zmultiples (1 : R))
+class IsCrystallographic : Prop where
+  exists_int : ∀ i j, ∃ z : ℤ, z = P.pairing i j
+
+protected lemma exists_int [P.IsCrystallographic] (i j : ι) :
+    ∃ z : ℤ, z = P.pairing i j :=
+  IsCrystallographic.exists_int i j
 
 lemma isCrystallographic_iff :
-    P.IsCrystallographic ↔ ∀ i j, ∃ z : ℤ, z = P.pairing i j := by
-  rw [IsCrystallographic]
-  refine ⟨fun h i j ↦ ?_, fun h i _ ⟨j, hj⟩ ↦ ?_⟩
-  · simpa [AddSubgroup.mem_zmultiples_iff] using h i (mem_range_self j)
-  · simpa [← hj, AddSubgroup.mem_zmultiples_iff] using h i j
+    P.IsCrystallographic ↔ ∀ i j, ∃ z : ℤ, z = P.pairing i j :=
+  ⟨fun ⟨h⟩ ↦ h, fun h ↦ ⟨h⟩⟩
 
-variable {P} in
-lemma IsCrystallographic.flip (h : P.IsCrystallographic) :
-    P.flip.IsCrystallographic := by
+instance [P.IsCrystallographic] : P.flip.IsCrystallographic := by
   rw [isCrystallographic_iff, forall_comm]
-  exact P.isCrystallographic_iff.mp h
+  exact P.exists_int
 
 /-- A root pairing is said to be reduced if any linearly dependent pair of roots is related by a
 sign. -/
@@ -389,6 +388,30 @@ abbrev rootSpan := span R (range P.root)
 
 /-- The linear span of coroots. -/
 abbrev corootSpan := span R (range P.coroot)
+
+lemma coe_rootSpan_dualAnnihilator_map :
+    P.rootSpan.dualAnnihilator.map P.toDualRight.symm = {x | ∀ i, P.root' i x = 0} := by
+  ext x
+  rw [rootSpan, Submodule.map_coe, Submodule.coe_dualAnnihilator_span]
+  change x ∈ P.toDualRight.toEquiv.symm '' _ ↔ _
+  rw [← Equiv.setOf_apply_symm_eq_image_setOf, Equiv.symm_symm]
+  simp [Set.range_subset_iff]
+
+lemma coe_corootSpan_dualAnnihilator_map :
+    P.corootSpan.dualAnnihilator.map P.toDualLeft.symm = {x | ∀ i, P.coroot' i x = 0} :=
+  P.flip.coe_rootSpan_dualAnnihilator_map
+
+lemma rootSpan_dualAnnihilator_map_eq :
+    P.rootSpan.dualAnnihilator.map P.toDualRight.symm =
+      (span R (range P.root')).dualCoannihilator := by
+  apply SetLike.coe_injective
+  rw [Submodule.coe_dualCoannihilator_span, coe_rootSpan_dualAnnihilator_map]
+  simp
+
+lemma corootSpan_dualAnnihilator_map_eq :
+    P.corootSpan.dualAnnihilator.map P.toDualLeft.symm =
+      (span R (range P.coroot')).dualCoannihilator :=
+  P.flip.rootSpan_dualAnnihilator_map_eq
 
 /-- The `Weyl group` of a root pairing is the group of automorphisms of the weight space generated
 by reflections in roots. -/
@@ -541,10 +564,10 @@ def coxeterWeight : R := pairing P i j * pairing P j i
 lemma coxeterWeight_swap : coxeterWeight P i j = coxeterWeight P j i := by
   simp only [coxeterWeight, mul_comm]
 
-lemma exists_int_eq_coxeterWeight (h : P.IsCrystallographic) (i j : ι) :
+lemma exists_int_eq_coxeterWeight [P.IsCrystallographic] (i j : ι) :
     ∃ z : ℤ, P.coxeterWeight i j = z := by
-  obtain ⟨a, ha⟩ := P.isCrystallographic_iff.mp h i j
-  obtain ⟨b, hb⟩ := P.isCrystallographic_iff.mp h j i
+  obtain ⟨a, ha⟩ := P.exists_int i j
+  obtain ⟨b, hb⟩ := P.exists_int j i
   exact ⟨a * b, by simp [coxeterWeight, ha, hb]⟩
 
 /-- Two roots are orthogonal when they are fixed by each others' reflections. -/

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -126,6 +126,14 @@ lemma coPolarization_apply_eq_zero_iff (n : N) :
     P.CoPolarization n = 0 ↔ P.CorootForm n = 0 :=
   P.flip.polarization_apply_eq_zero_iff n
 
+lemma ker_polarization_eq_ker_rootForm :
+    LinearMap.ker P.Polarization = LinearMap.ker P.RootForm := by
+  ext; simp only [LinearMap.mem_ker, P.polarization_apply_eq_zero_iff]
+
+lemma ker_copolarization_eq_ker_corootForm :
+    LinearMap.ker P.CoPolarization = LinearMap.ker P.CorootForm :=
+  P.flip.ker_polarization_eq_ker_rootForm
+
 lemma rootForm_symmetric :
     LinearMap.IsSymm P.RootForm := by
   simp [LinearMap.IsSymm, mul_comm, rootForm_apply_apply]
@@ -196,6 +204,18 @@ theorem range_polarization_domRestrict_le_span_coroot :
   use fun i => (P.toPerfectPairing x) (P.coroot i)
   simp
 
+theorem corootSpan_dualAnnihilator_le_ker_rootForm :
+    P.corootSpan.dualAnnihilator.map P.toDualLeft.symm ≤ LinearMap.ker P.RootForm := by
+  rw [← SetLike.coe_subset_coe, coe_corootSpan_dualAnnihilator_map]
+  intro x hx
+  simp only [coroot', PerfectPairing.flip_apply_apply, mem_setOf_eq] at hx
+  ext y
+  simp [rootForm_apply_apply, hx]
+
+theorem rootSpan_dualAnnihilator_le_ker_rootForm :
+    P.rootSpan.dualAnnihilator.map P.toDualRight.symm ≤ LinearMap.ker P.CorootForm :=
+  P.flip.corootSpan_dualAnnihilator_le_ker_rootForm
+
 lemma prod_rootForm_smul_coroot_mem_range_domRestrict (i : ι) :
     (∏ a : ι, P.RootForm (P.root a) (P.root a)) • P.coroot i ∈
       LinearMap.range (P.Polarization.domRestrict (P.rootSpan)) := by
@@ -205,29 +225,6 @@ lemma prod_rootForm_smul_coroot_mem_range_domRestrict (i : ι) :
   refine LinearMap.mem_range.mpr ?_
   use ⟨(c • 2 • P.root i), by aesop⟩
   simp
-
-section IsCrystallographic
-
-variable [CharZero R] (h : P.IsCrystallographic) (i : ι)
-include h
-
-lemma rootForm_apply_root_self_ne_zero :
-    P.RootForm (P.root i) (P.root i) ≠ 0 := by
-  choose z hz using P.isCrystallographic_iff.mp h i
-  simp only [rootForm_apply_apply, PerfectPairing.flip_apply_apply, root_coroot_eq_pairing, ← hz]
-  suffices 0 < ∑ i, z i * z i by norm_cast; exact this.ne'
-  refine Finset.sum_pos' (fun i _ ↦ mul_self_nonneg (z i)) ⟨i, Finset.mem_univ i, ?_⟩
-  have hzi : z i = 2 := by
-    specialize hz i
-    rw [pairing_same] at hz
-    norm_cast at hz
-  simp [hzi]
-
-lemma corootForm_apply_coroot_self_ne_zero :
-    P.CorootForm (P.coroot i) (P.coroot i) ≠ 0 :=
-  P.flip.rootForm_apply_root_self_ne_zero h.flip i
-
-end IsCrystallographic
 
 end CommRing
 
@@ -239,20 +236,14 @@ variable [Fintype ι] [LinearOrderedCommRing R] [AddCommGroup M] [Module R M] [A
 theorem rootForm_self_non_neg (x : M) : 0 ≤ P.RootForm x x :=
   IsSumSq.nonneg (P.rootForm_self_sum_of_squares x)
 
-theorem rootForm_self_zero_iff (x : M) :
-    P.RootForm x x = 0 ↔ ∀ i, P.coroot' i x = 0 := by
-  simp only [rootForm_apply_apply, PerfectPairing.toLin_apply, LinearMap.coe_comp, comp_apply,
-    Polarization_apply, map_sum, map_smul, smul_eq_mul]
-  convert Finset.sum_mul_self_eq_zero_iff Finset.univ fun i => P.coroot' i x
-  simp
+lemma rootForm_self_eq_zero_iff {x : M} :
+    P.RootForm x x = 0 ↔ x ∈ LinearMap.ker P.RootForm :=
+  P.RootForm.apply_apply_same_eq_zero_iff P.rootForm_self_non_neg P.rootForm_symmetric
 
-lemma rootForm_root_self_pos (j : ι) :
-    0 < P.RootForm (P.root j) (P.root j) := by
-  simp only [LinearMap.coe_mk, AddHom.coe_mk, LinearMap.coe_comp, comp_apply,
-    rootForm_apply_apply, toLin_toPerfectPairing]
-  refine Finset.sum_pos' (fun i _ => (sq (P.pairing j i)) ▸ sq_nonneg (P.pairing j i)) ?_
-  use j
-  simp
+lemma rootForm_root_self_pos (i : ι) :
+    0 < P.RootForm (P.root i) (P.root i) := by
+  simp only [rootForm_apply_apply]
+  exact Finset.sum_pos' (fun j _ ↦ mul_self_nonneg _) ⟨i, by simp⟩
 
 /-- SGA3 XXI Prop. 2.3.1 -/
 lemma coxeterWeight_le_four (i j : ι) : P.coxeterWeight i j ≤ 4 := by
@@ -274,10 +265,10 @@ instance instIsRootPositiveRootForm : IsRootPositive P P.RootForm where
   symm := P.rootForm_symmetric
   apply_reflection_eq := P.rootForm_reflection_reflection_apply
 
-lemma coxeterWeight_mem_set_of_isCrystallographic (i j : ι) (hP : P.IsCrystallographic) :
+lemma coxeterWeight_mem_set_of_isCrystallographic (i j : ι) [P.IsCrystallographic] :
     P.coxeterWeight i j ∈ ({0, 1, 2, 3, 4} : Set R) := by
   obtain ⟨n, hcn⟩ : ∃ n : ℕ, P.coxeterWeight i j = n := by
-    obtain ⟨z, hz⟩ := P.exists_int_eq_coxeterWeight hP i j
+    obtain ⟨z, hz⟩ := P.exists_int_eq_coxeterWeight i j
     have hz₀ : 0 ≤ z := by simpa [hz] using P.coxeterWeight_non_neg P.RootForm i j
     obtain ⟨n, rfl⟩ := Int.eq_ofNat_of_zero_le hz₀
     exact ⟨n, by simp [hz]⟩
@@ -285,10 +276,6 @@ lemma coxeterWeight_mem_set_of_isCrystallographic (i j : ι) (hP : P.IsCrystallo
   simp only [hcn, mem_insert_iff, mem_singleton_iff] at this ⊢
   norm_cast at this ⊢
   omega
-
-lemma prod_rootForm_root_self_pos :
-    0 < ∏ i, P.RootForm (P.root i) (P.root i) :=
-  Finset.prod_pos fun i _ => rootForm_root_self_pos P i
 
 end LinearOrderedCommRing
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -174,8 +174,8 @@ lemma orthogonal_rootSpan_eq :
   refine le_antisymm ?_ (by intro; aesop)
   rintro x hx y -
   simp only [LinearMap.BilinForm.mem_orthogonal_iff, LinearMap.BilinForm.IsOrtho] at hx ⊢
-  obtain ⟨⟨u, hu⟩, ⟨v, hv⟩, rfl, -⟩ :=
-    (Submodule.existsUnique_add_of_isCompl P.isCompl_rootSpan_ker_rootForm y)
+  obtain ⟨u, hu, v, hv, rfl⟩ : ∃ᵉ (u ∈ P.rootSpan) (v ∈ LinearMap.ker P.RootForm), u + v = y := by
+    rw [← Submodule.mem_sup, P.isCompl_rootSpan_ker_rootForm.sup_eq_top]; exact Submodule.mem_top
   simp only [LinearMap.mem_ker] at hv
   simp [hx _ hu, hv]
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Carnahan
 -/
 import Mathlib.LinearAlgebra.BilinearForm.Basic
+import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
 import Mathlib.LinearAlgebra.Dimension.Localization
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
 import Mathlib.LinearAlgebra.RootSystem.Finite.CanonicalBilinear
@@ -22,13 +23,16 @@ Another application is to the faithfulness of the Weyl group action on roots, an
 Weyl group.
 
 ## Main results:
- * `RootPairing.rootForm_rootPositive`: `RootForm` is root-positive.
- * `RootPairing.polarization_domRestrict_injective`: The polarization restricted to the span of
-   roots is injective.
+ * `RootPairing.IsAnisotropic`: We say a finite root pairing is anisotropic if there are no roots /
+   coroots which have length zero wrt the root / coroot forms.
  * `RootPairing.rootForm_pos_of_nonzero`: `RootForm` is strictly positive on non-zero linear
   combinations of roots. This gives us a convenient way to eliminate certain Dynkin diagrams from
   the classification, since it suffices to produce a nonzero linear combination of simple roots with
   non-positive norm.
+ * `RootPairing.rootForm_restrict_nondegenerate_of_ordered`: The root form is non-degenerate if
+   the coefficients are ordered.
+ * `RootPairing.rootForm_restrict_nondegenerate_of_isAnisotropic`: the root form is
+   non-degenerate if the coefficients are a field and the pairing is crystallographic.
 
 ## References:
  * [N. Bourbaki, *Lie groups and {L}ie algebras. {C}hapters 4--6*][bourbaki1968]
@@ -49,10 +53,50 @@ open Submodule (span)
 
 namespace RootPairing
 
-variable {ι R M N : Type*}
+variable {ι R M N : Type*} [Fintype ι] [AddCommGroup M] [AddCommGroup N]
 
-variable [Fintype ι] [LinearOrderedCommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N]
-  [Module R N] (P : RootPairing ι R M N)
+section CommRing
+
+variable [CommRing R] [Module R M] [Module R N] (P : RootPairing ι R M N)
+
+/-- We say a finite root pairing is anisotropic if there are no roots / coroots which have length
+zero wrt the root / coroot forms.
+
+Examples include crystallographic pairings in characteristic zero
+`RootPairing.instIsAnisotropicOfIsCrystallographic` and pairings over ordered scalars.
+`RootPairing.instIsAnisotropicOfLinearOrderedCommRing`. -/
+class IsAnisotropic : Prop where
+  rootForm_root_ne_zero (i : ι) : P.RootForm (P.root i) (P.root i) ≠ 0
+  corootForm_coroot_ne_zero (i : ι) : P.CorootForm (P.coroot i) (P.coroot i) ≠ 0
+
+instance [P.IsAnisotropic] : P.flip.IsAnisotropic where
+  rootForm_root_ne_zero := IsAnisotropic.corootForm_coroot_ne_zero
+  corootForm_coroot_ne_zero := IsAnisotropic.rootForm_root_ne_zero
+
+/-- An auxiliary lemma en route to `RootPairing.instIsAnisotropicOfIsCrystallographic`. -/
+private lemma rootForm_root_ne_zero_aux [CharZero R] [P.IsCrystallographic] (i : ι) :
+    P.RootForm (P.root i) (P.root i) ≠ 0 := by
+  choose z hz using P.exists_int i
+  simp only [rootForm_apply_apply, PerfectPairing.flip_apply_apply, root_coroot_eq_pairing, ← hz]
+  suffices 0 < ∑ i, z i * z i by norm_cast; exact this.ne'
+  refine Finset.sum_pos' (fun i _ ↦ mul_self_nonneg (z i)) ⟨i, Finset.mem_univ i, ?_⟩
+  have hzi : z i = 2 := by
+    specialize hz i
+    rw [pairing_same] at hz
+    norm_cast at hz
+  simp [hzi]
+
+instance instIsAnisotropicOfIsCrystallographic [CharZero R] [P.IsCrystallographic] :
+    IsAnisotropic P where
+  rootForm_root_ne_zero := P.rootForm_root_ne_zero_aux
+  corootForm_coroot_ne_zero := P.flip.rootForm_root_ne_zero_aux
+
+end CommRing
+
+section IsDomain
+
+variable [CommRing R] [IsDomain R] [Module R M] [Module R N] (P : RootPairing ι R M N)
+  [P.IsAnisotropic]
 
 @[simp]
 lemma finrank_rootSpan_map_polarization_eq_finrank_corootSpan :
@@ -60,9 +104,11 @@ lemma finrank_rootSpan_map_polarization_eq_finrank_corootSpan :
   rw [← LinearMap.range_domRestrict]
   apply (Submodule.finrank_mono P.range_polarization_domRestrict_le_span_coroot).antisymm
   have : IsReflexive R N := PerfectPairing.reflexive_right P.toPerfectPairing
+  have h_ne : ∏ i, P.RootForm (P.root i) (P.root i) ≠ 0 :=
+    Finset.prod_ne_zero_iff.mpr fun i _ ↦ IsAnisotropic.rootForm_root_ne_zero i
   refine LinearMap.finrank_le_of_isSMulRegular P.corootSpan
     (LinearMap.range (P.Polarization.domRestrict P.rootSpan))
-    (smul_right_injective N (Ne.symm (ne_of_lt P.prod_rootForm_root_self_pos)))
+    (smul_right_injective N h_ne)
     fun _ hx => ?_
   obtain ⟨c, hc⟩ := (mem_span_range_iff_exists_fun R).mp hx
   rw [← hc, Finset.smul_sum]
@@ -80,39 +126,97 @@ lemma finrank_corootSpan_eq :
     finrank R P.corootSpan = finrank R P.rootSpan :=
   le_antisymm P.finrank_corootSpan_le P.flip.finrank_corootSpan_le
 
-lemma disjoint_rootSpan_ker_polarization :
-    Disjoint P.rootSpan (LinearMap.ker P.Polarization) := by
+lemma disjoint_rootSpan_ker_rootForm :
+    Disjoint P.rootSpan (LinearMap.ker P.RootForm) := by
   have : IsReflexive R M := PerfectPairing.reflexive_left P.toPerfectPairing
-  refine Submodule.disjoint_ker_of_finrank_eq (L := P.rootSpan) P.Polarization ?_
-  rw [finrank_rootSpan_map_polarization_eq_finrank_corootSpan, finrank_corootSpan_eq]
+  rw [← P.ker_polarization_eq_ker_rootForm]
+  refine Submodule.disjoint_ker_of_finrank_le (L := P.rootSpan) P.Polarization ?_
+  rw [P.finrank_rootSpan_map_polarization_eq_finrank_corootSpan, P.finrank_corootSpan_eq]
 
-lemma mem_ker_polarization_of_rootForm_self_eq_zero {x : M} (hx : P.RootForm x x = 0) :
-    x ∈ LinearMap.ker P.Polarization := by
-  rw [LinearMap.mem_ker, Polarization_apply]
-  rw [rootForm_self_zero_iff] at hx
-  exact Fintype.sum_eq_zero _ fun i ↦ by simp [hx i]
+lemma disjoint_corootSpan_ker_corootForm :
+    Disjoint P.corootSpan (LinearMap.ker P.CorootForm) :=
+  P.flip.disjoint_rootSpan_ker_rootForm
+
+end IsDomain
+
+section Field
+
+variable [Field R] [Module R M] [Module R N] (P : RootPairing ι R M N) [P.IsAnisotropic]
+
+lemma isCompl_rootSpan_ker_rootForm :
+    IsCompl P.rootSpan (LinearMap.ker P.RootForm) := by
+  have _iM : IsReflexive R M := PerfectPairing.reflexive_left P.toPerfectPairing
+  have _iN : IsReflexive R N := PerfectPairing.reflexive_right P.toPerfectPairing
+  refine (Submodule.disjoint_iff_isCompl _ _ ?_).mpr P.disjoint_rootSpan_ker_rootForm
+  have aux : finrank R M = finrank R P.rootSpan + finrank R P.corootSpan.dualAnnihilator := by
+    rw [P.toPerfectPairing.finrank_eq, ← P.finrank_corootSpan_eq,
+      Subspace.finrank_add_finrank_dualAnnihilator_eq P.corootSpan]
+  rw [aux, add_le_add_iff_left]
+  convert Submodule.finrank_mono P.corootSpan_dualAnnihilator_le_ker_rootForm
+  exact (LinearEquiv.finrank_map_eq _ _).symm
+
+lemma isCompl_corootSpan_ker_corootForm :
+    IsCompl P.corootSpan (LinearMap.ker P.CorootForm) :=
+  P.flip.isCompl_rootSpan_ker_rootForm
+
+/-- See also `RootPairing.rootForm_restrict_nondegenerate_of_ordered`.
+
+Note that this applies to crystallographic root systems in characteristic zero via
+`RootPairing.instIsAnisotropicOfIsCrystallographic`. -/
+lemma rootForm_restrict_nondegenerate_of_isAnisotropic :
+    LinearMap.Nondegenerate (P.RootForm.restrict P.rootSpan) :=
+  P.rootForm_symmetric.nondegenerate_restrict_of_isCompl_ker P.isCompl_rootSpan_ker_rootForm
+
+@[simp]
+lemma orthogonal_rootSpan_eq :
+    P.RootForm.orthogonal P.rootSpan = LinearMap.ker P.RootForm := by
+  rw [← LinearMap.BilinForm.orthogonal_top_eq_ker P.rootForm_symmetric.isRefl]
+  refine le_antisymm ?_ (by intro; aesop)
+  rintro x hx y -
+  simp only [LinearMap.BilinForm.mem_orthogonal_iff, LinearMap.BilinForm.IsOrtho] at hx ⊢
+  obtain ⟨⟨u, hu⟩, ⟨v, hv⟩, rfl, -⟩ :=
+    (Submodule.existsUnique_add_of_isCompl P.isCompl_rootSpan_ker_rootForm y)
+  simp only [LinearMap.mem_ker] at hv
+  simp [hx _ hu, hv]
+
+@[simp]
+lemma orthogonal_corootSpan_eq :
+    P.CorootForm.orthogonal P.corootSpan = LinearMap.ker P.CorootForm :=
+  P.flip.orthogonal_rootSpan_eq
+
+end Field
+
+section LinearOrderedCommRing
+
+variable [LinearOrderedCommRing R] [Module R M] [Module R N] (P : RootPairing ι R M N)
+
+instance instIsAnisotropicOfLinearOrderedCommRing : IsAnisotropic P where
+  rootForm_root_ne_zero i := (P.rootForm_root_self_pos i).ne'
+  corootForm_coroot_ne_zero i := (P.flip.rootForm_root_self_pos i).ne'
+
+/-- See also `RootPairing.rootForm_restrict_nondegenerate_of_isAnisotropic`. -/
+lemma rootForm_restrict_nondegenerate_of_ordered :
+    LinearMap.Nondegenerate (P.RootForm.restrict P.rootSpan) :=
+  (P.RootForm.nondegenerate_restrict_iff_disjoint_ker (rootForm_self_non_neg P)
+    P.rootForm_symmetric).mpr P.disjoint_rootSpan_ker_rootForm
 
 lemma eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero {x : M}
     (hx : x ∈ P.rootSpan) (hx' : P.RootForm x x = 0) :
     x = 0 := by
-  rw [← Submodule.mem_bot (R := R), ← P.disjoint_rootSpan_ker_polarization.eq_bot]
-  exact ⟨hx, P.mem_ker_polarization_of_rootForm_self_eq_zero hx'⟩
+  have : x ∈ P.rootSpan ⊓ LinearMap.ker P.RootForm := ⟨hx, P.rootForm_self_eq_zero_iff.mp hx'⟩
+  simpa [P.disjoint_rootSpan_ker_rootForm.eq_bot] using this
+
+lemma rootForm_pos_of_ne_zero {x : M} (hx : x ∈ P.rootSpan) (h : x ≠ 0) :
+    0 < P.RootForm x x := by
+  apply (P.rootForm_self_non_neg x).lt_of_ne
+  contrapose! h
+  exact P.eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero hx h.symm
 
 lemma _root_.RootSystem.rootForm_anisotropic (P : RootSystem ι R M N) :
     P.RootForm.toQuadraticMap.Anisotropic :=
   fun x ↦ P.eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero <| by
     simpa only [rootSpan, P.span_eq_top] using Submodule.mem_top
 
-lemma rootForm_pos_of_nonzero {x : M} (hx : x ∈ P.rootSpan) (h : x ≠ 0) :
-    0 < P.RootForm x x := by
-  apply (P.rootForm_self_non_neg x).lt_of_ne
-  contrapose! h
-  exact eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero P hx h.symm
-
-lemma rootForm_restrict_nondegenerate :
-    (P.RootForm.restrict P.rootSpan).Nondegenerate :=
-  LinearMap.IsRefl.nondegenerate_of_separatingLeft (LinearMap.IsSymm.isRefl fun x y => by
-    simp [rootForm_apply_apply, mul_comm]) fun x h => SetLike.coe_eq_coe.mp
-    (P.eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero (Submodule.coe_mem x) (h x))
+end LinearOrderedCommRing
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -147,7 +147,7 @@ lemma isCompl_rootSpan_ker_rootForm :
     IsCompl P.rootSpan (LinearMap.ker P.RootForm) := by
   have _iM : IsReflexive R M := PerfectPairing.reflexive_left P.toPerfectPairing
   have _iN : IsReflexive R N := PerfectPairing.reflexive_right P.toPerfectPairing
-  refine (Submodule.disjoint_iff_isCompl _ _ ?_).mpr P.disjoint_rootSpan_ker_rootForm
+  refine (Submodule.isCompl_iff_disjoint _ _ ?_).mpr P.disjoint_rootSpan_ker_rootForm
   have aux : finrank R M = finrank R P.rootSpan + finrank R P.corootSpan.dualAnnihilator := by
     rw [P.toPerfectPairing.finrank_eq, ← P.finrank_corootSpan_eq,
       Subspace.finrank_add_finrank_dualAnnihilator_eq P.corootSpan]


### PR DESCRIPTION
The motivation, and headline item is the new lemma `RootPairing.rootForm_restrict_nondegenerate_of_isAnisotropic` which establishes non-degeneracy of the root form without assuming ordered scalars, at the cost of requiring the crystallographic assumption and field coefficients. Since we also want to keep the old lemma (renamed to) `RootPairing.rootForm_restrict_nondegenerate_of_ordered` which establishes the same result over an ordered ring, we need to do some work in order to unify things as much as possible.

With this in mind I have:
- Turned `RootPairing.IsCrystallographic` into a typeclass
- Introduced `RootPairing.IsAnisotropic` (which I've just made up but seems to be a good way to unify things; I also considered the idea that the pairing should take values in an ordered subring but decided this was inferior)

In order to prove the new results, a certain amount of API for bilinear forms needed to be added. This also enabled me to golf some of the proofs of the existing non-degeneracy result (for order scalars).

I also included a small amount of golfing / moving, and to standardise on `LinearMap.ker P.RootForm` rather than `LinearMap.ker P.Polarisation` (since it interfaced better with the bilinear form API). As compensation I added the convenience lemma `RootPairing.ker_polarization_eq_ker_rootForm`.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
