### PR TITLE
refactor(Algebra/DirectLimit): change definition to quotient of Sigma type

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Limits.lean
@@ -263,6 +263,10 @@ def colimitIsColimit : IsColimit (colimitCocone G f) where
     simp only [this]
     apply Module.Colimit.lift_unique
 
+@[deprecated (since := "2024-12-09")] alias directLimitDiagram := colimitDiagram
+@[deprecated (since := "2024-12-09")] noncomputable alias directLimitCocone := colimitCocone
+@[deprecated (since := "2024-12-09")] noncomputable alias directLimitIsColimit := colimitIsColimit
+
 end Colimit
 
 end ModuleCat

--- a/Mathlib/Algebra/Category/ModuleCat/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Limits.lean
@@ -199,70 +199,70 @@ instance forget₂AddCommGroup_reflectsLimitOfShape :
 instance forget₂AddCommGroup_reflectsLimitOfSize :
     ReflectsLimitsOfSize.{t, v} (forget₂ (ModuleCat.{w} R) AddCommGrp) where
 
-section DirectLimit
+section Colimit
 
 open Module
 
 variable {ι : Type v}
-variable [dec_ι : DecidableEq ι] [Preorder ι]
+variable [DecidableEq ι] [Preorder ι]
 variable (G : ι → Type v)
 variable [∀ i, AddCommGroup (G i)] [∀ i, Module R (G i)]
 variable (f : ∀ i j, i ≤ j → G i →ₗ[R] G j) [DirectedSystem G fun i j h => f i j h]
 
 /-- The diagram (in the sense of `CategoryTheory`)
- of an unbundled `directLimit` of modules. -/
+ of an unbundled `Colimit` of modules. -/
 @[simps]
-def directLimitDiagram : ι ⥤ ModuleCat R where
+def colimitDiagram : ι ⥤ ModuleCat R where
   obj i := ModuleCat.of R (G i)
   map hij := ofHom (f _ _ hij.le)
   map_id i := by
     ext
-    apply Module.DirectedSystem.map_self
+    apply DirectedSystem.map_self
   map_comp hij hjk := by
     ext
     symm
-    apply Module.DirectedSystem.map_map
+    apply DirectedSystem.map_map f
 
 variable [DecidableEq ι]
 
-/-- The `Cocone` on `directLimitDiagram` corresponding to
-the unbundled `directLimit` of modules.
+/-- The `Cocone` on `colimitDiagram` corresponding to
+the unbundled `Colimit` of modules.
 
-In `directLimitIsColimit` we show that it is a colimit cocone. -/
+In `colimitIsColimit` we show that it is a colimit cocone. -/
 @[simps]
-def directLimitCocone : Cocone (directLimitDiagram G f) where
-  pt := ModuleCat.of R <| DirectLimit G f
+def colimitCocone : Cocone (colimitDiagram G f) where
+  pt := ModuleCat.of R <| Colimit G f
   ι :=
-    { app := fun x => ofHom (Module.DirectLimit.of R ι G f x)
+    { app := fun x => ofHom (Module.Colimit.of R ι G f x)
       naturality := fun _ _ hij => by
         ext
-        exact DirectLimit.of_f }
+        exact Colimit.of_f }
 
-/-- The unbundled `directLimit` of modules is a colimit
+/-- The unbundled `Colimit` of modules is a colimit
 in the sense of `CategoryTheory`. -/
 @[simps]
-def directLimitIsColimit [IsDirected ι (· ≤ ·)] : IsColimit (directLimitCocone G f) where
+def colimitIsColimit : IsColimit (colimitCocone G f) where
   desc s := ofHom <|
-    DirectLimit.lift R ι G f (fun i => (s.ι.app i).hom) fun i j h x => by
+    Colimit.lift R ι G f (fun i => (s.ι.app i).hom) fun i j h x => by
       simp only [Functor.const_obj_obj]
       rw [← s.w (homOfLE h)]
       rfl
   fac s i := by
     ext
-    dsimp only [directLimitCocone, CategoryStruct.comp]
+    dsimp only [colimitCocone, CategoryStruct.comp]
     rw [LinearMap.comp_apply]
-    apply DirectLimit.lift_of
+    apply Colimit.lift_of
   uniq s m h := by
     have :
       s.ι.app = fun i =>
-        (ofHom (DirectLimit.of R ι (fun i => G i) (fun i j H => f i j H) i)) ≫ m := by
+        (ofHom (Colimit.of R ι (fun i => G i) (fun i j H => f i j H) i)) ≫ m := by
       funext i
       rw [← h]
       rfl
     ext
     simp only [this]
-    apply Module.DirectLimit.lift_unique
+    apply Module.Colimit.lift_unique
 
-end DirectLimit
+end Colimit
 
 end ModuleCat

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -220,6 +220,11 @@ theorem eq_intCast' [AddGroupWithOne α] [FunLike F ℤ α] [AddMonoidHomClass F
     ∀ n : ℤ, f n = n :=
   DFunLike.ext_iff.1 <| (f : ℤ →+ α).eq_intCastAddHom h₁
 
+/-- This version is primed so that the `RingHomClass` versions aren't. -/
+theorem map_intCast' [AddGroupWithOne α] [AddGroupWithOne β] [FunLike F α β]
+    [AddMonoidHomClass F α β] (f : F) (h₁ : f 1 = 1) : ∀ n : ℤ, f n = n :=
+  eq_intCast' ((f : α →+ β).comp <| Int.castAddHom _) (by simpa)
+
 @[simp]
 theorem Int.castAddHom_int : Int.castAddHom ℤ = AddMonoidHom.id ℤ :=
   ((AddMonoidHom.id ℤ).eq_intCastAddHom rfl).symm

--- a/Mathlib/Data/Nat/Cast/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Basic.lean
@@ -118,10 +118,8 @@ theorem eq_natCast' [AddMonoidHomClass F ℕ A] (f : F) (h1 : f 1 = 1) : ∀ n :
 
 theorem map_natCast' {A} [AddMonoidWithOne A] [FunLike F A B] [AddMonoidHomClass F A B]
     (f : F) (h : f 1 = 1) :
-    ∀ n : ℕ, f n = n
-  | 0 => by simp [map_zero f]
-  | n + 1 => by
-    rw [Nat.cast_add, map_add, Nat.cast_add, map_natCast' f h n, Nat.cast_one, h, Nat.cast_one]
+    ∀ n : ℕ, f n = n :=
+  eq_natCast' ((f : A →+ B).comp <| Nat.castAddMonoidHom _) (by simpa)
 
 theorem map_ofNat' {A} [AddMonoidWithOne A] [FunLike F A B] [AddMonoidHomClass F A B]
     (f : F) (h : f 1 = 1) (n : ℕ) [n.AtLeastTwo] : f (OfNat.ofNat n) = OfNat.ofNat n :=

--- a/Mathlib/GroupTheory/Congruence/Defs.lean
+++ b/Mathlib/GroupTheory/Congruence/Defs.lean
@@ -764,6 +764,17 @@ instance group : Group c.Quotient :=
     toInv := Con.hasInv _
     toDiv := Con.hasDiv _ }
 
+/-- The quotient of a `CommGroup` by a congruence relation is a `CommGroup`. -/
+@[to_additive "The quotient of an `AddCommGroup` by an additive congruence
+relation is an `AddCommGroup`."]
+instance commGroup {M : Type*} [CommGroup M] (c : Con M) : CommGroup c.Quotient :=
+  { (Function.Surjective.commGroup _ Quotient.mk''_surjective rfl (fun _ _ => rfl) (fun _ => rfl)
+      (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) : CommGroup c.Quotient) with
+    /- The `toGroup` field is given explicitly for performance reasons.
+    This avoids any need to unfold `Function.Surjective.commGroup` when the type checker is
+    checking that instance diagrams commute -/
+    toGroup := Con.group _ }
+
 end Groups
 
 section Units

--- a/Mathlib/LinearAlgebra/TensorProduct/DirectLimit.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/DirectLimit.lean
@@ -22,13 +22,13 @@ as `R`-modules.
 
 open TensorProduct Module Module.DirectLimit
 
-variable {R : Type*} [CommRing R]
+variable {R : Type*} [CommSemiring R]
 variable {ι : Type*}
 variable [DecidableEq ι] [Preorder ι]
 variable {G : ι → Type*}
-variable [∀ i, AddCommGroup (G i)] [∀ i, Module R (G i)]
+variable [∀ i, AddCommMonoid (G i)] [∀ i, Module R (G i)]
 variable (f : ∀ i j, i ≤ j → G i →ₗ[R] G j)
-variable (M : Type*) [AddCommGroup M] [Module R M]
+variable (M : Type*) [AddCommMonoid M] [Module R M]
 
 -- alluding to the notation in `CategoryTheory.Monoidal`
 local notation M " ◁ " f => fun i j h ↦ LinearMap.lTensor M (f _ _ h)

--- a/Mathlib/ModelTheory/DirectLimit.lean
+++ b/Mathlib/ModelTheory/DirectLimit.lean
@@ -42,17 +42,6 @@ variable (f : ∀ i j, i ≤ j → G i ↪[L] G j)
 
 namespace DirectedSystem
 
-/-- A copy of `DirectedSystem.map_self` specialized to `L`-embeddings, as otherwise the
-`fun i j h ↦ f i j h` can confuse the simplifier. -/
-nonrec theorem map_self [DirectedSystem G fun i j h => f i j h] (i x h) : f i i h x = x :=
-  DirectedSystem.map_self (f := (f · · ·)) x
-
-/-- A copy of `DirectedSystem.map_map` specialized to `L`-embeddings, as otherwise the
-`fun i j h ↦ f i j h` can confuse the simplifier. -/
-nonrec theorem map_map [DirectedSystem G fun i j h => f i j h] {i j k} (hij hjk x) :
-    f j k hjk (f i j hij x) = f i k (le_trans hij hjk) x :=
-  DirectedSystem.map_map (f := (f · · ·)) hij hjk x
-
 variable {G' : ℕ → Type w} [∀ i, L.Structure (G' i)] (f' : ∀ n : ℕ, G' n ↪[L] G' (n + 1))
 
 /-- Given a chain of embeddings of structures indexed by `ℕ`, defines a `DirectedSystem` by
@@ -444,8 +433,8 @@ variable [Nonempty ι] [IsDirected ι (· ≤ ·)]
 variable {M : Type*} [L.Structure M] (S : ι →o L.Substructure M)
 
 instance : DirectedSystem (fun i ↦ S i) (fun _ _ h ↦ Substructure.inclusion (S.monotone h)) where
-  map_self _ _ := rfl
-  map_map _ _ _ _ _ _ := rfl
+  map_self' _ _ := rfl
+  map_map' _ _ _ _ _ _ := rfl
 
 namespace DirectLimit
 

--- a/Mathlib/ModelTheory/Fraisse.lean
+++ b/Mathlib/ModelTheory/Fraisse.lean
@@ -218,7 +218,6 @@ theorem age_directLimit {ι : Type w} [Preorder ι] [IsDirected ι (· ≤ ·)] 
     rw [Embedding.coe_toHom, DirectLimit.of_apply, @Quotient.mk_eq_iff_out _ (_),
       DirectLimit.equiv_iff G f _ (hi (out x).1 (Finset.mem_image_of_mem _ hx)),
       DirectedSystem.map_self]
-    rfl
   · rintro ⟨i, Mfg, ⟨e⟩⟩
     exact ⟨Mfg, ⟨Embedding.comp (DirectLimit.of L ι G f i) e⟩⟩
 

--- a/Mathlib/ModelTheory/PartialEquiv.lean
+++ b/Mathlib/ModelTheory/PartialEquiv.lean
@@ -303,13 +303,13 @@ variable (S : ι →o M ≃ₚ[L] N)
 
 instance : DirectedSystem (fun i ↦ (S i).dom)
     (fun _ _ h ↦ Substructure.inclusion (dom_le_dom (S.monotone h))) where
-  map_self _ _ := rfl
-  map_map _ _ _ _ _ _ := rfl
+  map_self' _ _ := rfl
+  map_map' _ _ _ _ _ _ := rfl
 
 instance : DirectedSystem (fun i ↦ (S i).cod)
     (fun _ _ h ↦ Substructure.inclusion (cod_le_cod (S.monotone h))) where
-  map_self _ _ := rfl
-  map_map _ _ _ _ _ _ := rfl
+  map_self' _ _ := rfl
+  map_map' _ _ _ _ _ _ := rfl
 
 /-- The limit of a directed system of PartialEquivs. -/
 noncomputable def partialEquivLimit : M ≃ₚ[L] N where

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -123,6 +123,12 @@ class IsDirected (α : Type*) (r : α → α → Prop) : Prop where
 theorem directed_of (r : α → α → Prop) [IsDirected α r] (a b : α) : ∃ c, r a c ∧ r b c :=
   IsDirected.directed _ _
 
+theorem directed_of₃ (r : α → α → Prop) [IsDirected α r] [IsTrans α r] (a b c : α) :
+    ∃ d, r a d ∧ r b d ∧ r c d :=
+  have ⟨e, hae, hbe⟩ := directed_of r a b
+  have ⟨f, hef, hcf⟩ := directed_of r e c
+  ⟨f, Trans.trans hae hef, Trans.trans hbe hef, hcf⟩
+
 theorem directed_id [IsDirected α r] : Directed r id := directed_of r
 
 theorem directed_id_iff : Directed r id ↔ IsDirected α r :=

--- a/Mathlib/Order/DirectedInverseSystem.lean
+++ b/Mathlib/Order/DirectedInverseSystem.lean
@@ -71,13 +71,13 @@ variable [∀ ⦃i j⦄ (h : i ≤ j), FunLike (T h) (F i) (F j)] [DirectedSyste
 
 /-- A copy of `DirectedSystem.map_self` specialized to FunLike, as otherwise the
 `fun i j h ↦ f i j h` can confuse the simplifier. -/
-nonrec theorem DirectedSystem.map_self (i x) : f i i le_rfl x = x :=
+nonrec theorem DirectedSystem.map_self ⦃i⦄ (x) : f i i le_rfl x = x :=
   DirectedSystem.map_self' (f := (f · · ·)) x
 
 /-- A copy of `DirectedSystem.map_map` specialized to FunLike, as otherwise the
 `fun i j h ↦ f i j h` can confuse the simplifier. -/
-nonrec theorem DirectedSystem.map_map {i j k} (hij hjk x) :
-    f j k hjk (f i j hij x) = f i k (le_trans hij hjk) x :=
+nonrec theorem DirectedSystem.map_map ⦃i j k⦄ (hij hjk x) :
+    f j k hjk (f i j hij x) = f i k (hij.trans hjk) x :=
   DirectedSystem.map_map' (f := (f · · ·)) hij hjk x
 
 namespace DirectLimit

--- a/Mathlib/Order/DirectedInverseSystem.lean
+++ b/Mathlib/Order/DirectedInverseSystem.lean
@@ -52,13 +52,185 @@ the distinguished bijection that is compatible with the projections to all `X i`
 
 open Order Set
 
-variable {ι : Type*} [Preorder ι] {F X : ι → Type*}
+variable {ι : Type*} [Preorder ι] {F₁ F₂ F X : ι → Type*}
 
 variable (F) in
 /-- A directed system is a functor from a category (directed poset) to another category. -/
 class DirectedSystem (f : ∀ ⦃i j⦄, i ≤ j → F i → F j) : Prop where
-  map_self ⦃i⦄ (x : F i) : f le_rfl x = x
-  map_map ⦃k j i⦄ (hij : i ≤ j) (hjk : j ≤ k) (x : F i) : f hjk (f hij x) = f (hij.trans hjk) x
+  map_self' ⦃i⦄ (x : F i) : f le_rfl x = x
+  map_map' ⦃k j i⦄ (hij : i ≤ j) (hjk : j ≤ k) (x : F i) : f hjk (f hij x) = f (hij.trans hjk) x
+
+section DirectedSystem
+
+variable {T₁ : ∀ ⦃i j : ι⦄, i ≤ j → Sort*} (f₁ : ∀ i j (h : i ≤ j), T₁ h)
+variable [∀ ⦃i j⦄ (h : i ≤ j), FunLike (T₁ h) (F₁ i) (F₁ j)] [DirectedSystem F₁ (f₁ · · ·)]
+variable {T₂ : ∀ ⦃i j : ι⦄, i ≤ j → Sort*} (f₂ : ∀ i j (h : i ≤ j), T₂ h)
+variable [∀ ⦃i j⦄ (h : i ≤ j), FunLike (T₂ h) (F₂ i) (F₂ j)] [DirectedSystem F₂ (f₂ · · ·)]
+variable {T : ∀ ⦃i j : ι⦄, i ≤ j → Sort*} (f : ∀ i j (h : i ≤ j), T h)
+variable [∀ ⦃i j⦄ (h : i ≤ j), FunLike (T h) (F i) (F j)] [DirectedSystem F (f · · ·)]
+
+/-- A copy of `DirectedSystem.map_self` specialized to FunLike, as otherwise the
+`fun i j h ↦ f i j h` can confuse the simplifier. -/
+nonrec theorem DirectedSystem.map_self (i x) : f i i le_rfl x = x :=
+  DirectedSystem.map_self' (f := (f · · ·)) x
+
+/-- A copy of `DirectedSystem.map_map` specialized to FunLike, as otherwise the
+`fun i j h ↦ f i j h` can confuse the simplifier. -/
+nonrec theorem DirectedSystem.map_map {i j k} (hij hjk x) :
+    f j k hjk (f i j hij x) = f i k (le_trans hij hjk) x :=
+  DirectedSystem.map_map' (f := (f · · ·)) hij hjk x
+
+namespace DirectLimit
+open DirectedSystem
+
+variable [IsDirected ι (· ≤ ·)]
+
+/-- The setoid on the sigma type defining the direct limit. -/
+def setoid : Setoid (Σ i, F i) where
+  r x y := ∃ᵉ (i) (hx : x.1 ≤ i) (hy : y.1 ≤ i), f _ _ hx x.2 = f _ _ hy y.2
+  iseqv := ⟨fun x ↦ ⟨x.1, le_rfl, le_rfl, rfl⟩, fun ⟨i, hx, hy, eq⟩ ↦ ⟨i, hy, hx, eq.symm⟩,
+    fun ⟨j, hx, _, jeq⟩ ⟨k, _, hz, keq⟩ ↦
+      have ⟨i, hji, hki⟩ := exists_ge_ge j k
+      ⟨i, hx.trans hji, hz.trans hki, by
+        rw [← map_map _ hx hji, ← map_map _ hz hki, jeq, ← keq, map_map, map_map]⟩⟩
+
+theorem r_of_le (x : Σ i, F i) (i : ι) (h : x.1 ≤ i) : (setoid f).r x ⟨i, f _ _ h x.2⟩ :=
+  ⟨i, h, le_rfl, (map_map _ _ _ _).symm⟩
+
+variable (F) in
+/-- The direct limit of a directed system. -/
+abbrev _root_.DirectLimit : Type _ := Quotient (setoid f)
+
+variable {f} in
+theorem eq_of_le (x : Σ i, F i) (i : ι) (h : x.1 ≤ i) :
+    (⟦x⟧ : DirectLimit F f) = ⟦⟨i, f _ _ h x.2⟩⟧ :=
+  Quotient.sound (r_of_le _ x i h)
+
+@[elab_as_elim] protected theorem induction {C : DirectLimit F f → Prop}
+    (ih : ∀ i x, C ⟦⟨i, x⟩⟧) (x : DirectLimit F f) : C x :=
+  Quotient.ind (fun _ ↦ ih _ _) x
+
+theorem exists_eq₂ (z w : DirectLimit F f) : ∃ i x y, z = ⟦⟨i, x⟩⟧ ∧ w = ⟦⟨i, y⟩⟧ :=
+  z.inductionOn₂ w fun x y ↦
+    have ⟨i, hxi, hyi⟩ := exists_ge_ge x.1 y.1
+    ⟨i, _, _, eq_of_le x i hxi, eq_of_le y i hyi⟩
+
+theorem exists_eq₃ (w u v : DirectLimit F f) :
+    ∃ i x y z, w = ⟦⟨i, x⟩⟧ ∧ u = ⟦⟨i, y⟩⟧ ∧ v = ⟦⟨i, z⟩⟧ :=
+  w.inductionOn₃ u v fun x y z ↦
+    have ⟨i, hxi, hyi, hzi⟩ := directed_of₃ (· ≤ ·) x.1 y.1 z.1
+    ⟨i, _, _, _, eq_of_le x i hxi, eq_of_le y i hyi, eq_of_le z i hzi⟩
+
+@[elab_as_elim] protected theorem induction₂ {C : DirectLimit F f → DirectLimit F f → Prop}
+    (ih : ∀ i x y, C ⟦⟨i, x⟩⟧ ⟦⟨i, y⟩⟧) (x y : DirectLimit F f) : C x y := by
+  obtain ⟨_, _, _, rfl, rfl⟩ := exists_eq₂ f x y; apply ih
+
+@[elab_as_elim] protected theorem induction₃
+    {C : DirectLimit F f → DirectLimit F f → DirectLimit F f → Prop}
+    (ih : ∀ i x y z, C ⟦⟨i, x⟩⟧ ⟦⟨i, y⟩⟧ ⟦⟨i, z⟩⟧) (x y z : DirectLimit F f) : C x y z := by
+  obtain ⟨_, _, _, _, rfl, rfl, rfl⟩ := exists_eq₃ f x y z; apply ih
+
+section fullRec₀
+
+open Classical (arbitrary)
+
+variable [Nonempty ι] (ih : ∀ i, F i) (compat : ∀ i j h, f i j h (ih i) = ih j)
+
+/-- "Full recursion" with domain and codomain both being `DirectLimit`s.
+For the nullary full recursion, there is no domain. -/
+noncomputable def fullRec₀ : DirectLimit F f := ⟦⟨arbitrary ι, ih _⟩⟧
+
+include compat
+theorem fullRec₀_spec (i) : fullRec₀ f ih = ⟦⟨i, ih i⟩⟧ :=
+  have ⟨j, hcj, hij⟩ := exists_ge_ge (arbitrary ι) i
+  Quotient.sound ⟨j, hcj, hij, (compat ..).trans (compat ..).symm⟩
+
+end fullRec₀
+
+section rec
+
+variable {C : Sort*} (ih : ∀ i, F i → C) (compat : ∀ i j h x, ih i x = ih j (f i j h x))
+
+/-- To define a function from the direct limit, it suffices to provide one function from each
+component subject to a compatibility condition. -/
+protected def rec (z : DirectLimit F f) : C :=
+  z.recOn (fun x ↦ ih x.1 x.2) fun x y ⟨k, hxk, hyk, eq⟩ ↦ by
+    simp_rw [eq_rec_constant, compat _ _ hxk, compat _ _ hyk, eq]
+
+theorem rec_spec (x) : DirectLimit.rec f ih compat ⟦x⟧ = ih x.1 x.2 := rfl
+
+end rec
+
+section fullRec
+
+variable (ih : ∀ i, F₁ i → F₂ i) (compat : ∀ i j h x, f₂ i j h (ih i x) = ih j (f₁ i j h x))
+
+/-- To define a function from the direct limit, it suffices to provide one function from each
+component subject to a compatibility condition. -/
+def fullRec (z : DirectLimit F₁ f₁) : DirectLimit F₂ f₂ :=
+  z.rec _ (fun i x ↦ ⟦⟨i, ih i x⟩⟧) fun j k h x ↦ Quotient.sound <|
+    have ⟨i, hji, hki⟩ := exists_ge_ge j k
+    ⟨i, hji, hki, by simp_rw [compat, map_map]⟩
+
+theorem fullRec_spec (x) : fullRec f₁ f₂ ih compat ⟦x⟧ = ⟦⟨x.1, ih x.1 x.2⟩⟧ := rfl
+
+end fullRec
+
+section rec₂
+
+variable {C : Sort*} (ih : ∀ i, F₁ i → F₂ i → C)
+  (compat : ∀ i j h x y, ih i x y = ih j (f₁ i j h x) (f₂ i j h y))
+
+private noncomputable def rec₂Aux (z : Σ i, F₁ i) (w : Σ i, F₂ i) :
+    {x : C // ∀ i (hzi : z.1 ≤ i) (hwi : w.1 ≤ i), x = ih i (f₁ _ _ hzi z.2) (f₂ _ _ hwi w.2)} := by
+  choose j hzj hwj using exists_ge_ge z.1 w.1
+  refine ⟨ih j (f₁ _ _ hzj z.2) (f₂ _ _ hwj w.2), fun k hzk hwk ↦ ?_⟩
+  have ⟨i, hji, hki⟩ := exists_ge_ge j k
+  simp_rw [compat _ _ hji, compat _ _ hki, map_map]
+
+/-- To define a binary function from the direct limit, it suffices to provide one binary function
+from each component subject to a compatibility condition. -/
+protected noncomputable def rec₂ (z : DirectLimit F₁ f₁) (w : DirectLimit F₂ f₂) : C :=
+  z.hrecOn₂ w (φ := fun _ _ ↦ C) (rec₂Aux f₁ f₂ ih compat · ·)
+    fun _ _ _ _ ⟨j, hx, hyj, jeq⟩ ⟨k, hyk, hz, keq⟩ ↦ heq_of_eq <| by
+      have ⟨i, hji, hki⟩ := exists_ge_ge j k
+      simp_rw [(rec₂Aux ..).2 _ (hx.trans hji) (hyk.trans hki),
+        (rec₂Aux ..).2 _ (hyj.trans hji) (hz.trans hki),
+        ← map_map _ hx hji, jeq, ← map_map _ hz hki, ← keq, map_map]
+
+theorem rec₂_spec₂ (x : Σ i, F₁ i) (y : Σ i, F₂ i) (i) (hxi : x.1 ≤ i) (hyi : y.1 ≤ i) :
+    DirectLimit.rec₂ f₁ f₂ ih compat ⟦x⟧ ⟦y⟧ = ih i (f₁ _ _ hxi x.2) (f₂ _ _ hyi y.2) :=
+  (rec₂Aux _ _ _ compat _ _).2 ..
+
+theorem rec₂_spec (i x y) : DirectLimit.rec₂ f₁ f₂ ih compat ⟦⟨i, x⟩⟧ ⟦⟨i, y⟩⟧ = ih i x y := by
+  rw [rec₂_spec₂ _ _ _ _ _ _ i le_rfl le_rfl, map_self, map_self]
+
+end rec₂
+
+section fullRec₂
+
+variable (ih : ∀ i, F₁ i → F₂ i → F i)
+  (compat : ∀ i j h x y, f i j h (ih i x y) = ih j (f₁ i j h x) (f₂ i j h y))
+
+/-- To define a function from the direct limit, it suffices to provide one function from each
+component subject to a compatibility condition. -/
+noncomputable def fullRec₂ : DirectLimit F₁ f₁ → DirectLimit F₂ f₂ → DirectLimit F f :=
+  DirectLimit.rec₂ f₁ f₂ (fun i x y ↦ ⟦⟨i, ih i x y⟩⟧) fun j k h x y ↦ Quotient.sound <|
+    have ⟨i, hji, hki⟩ := exists_ge_ge j k
+    ⟨i, hji, hki, by simp_rw [compat, map_map]⟩
+
+theorem fullRec₂_spec₂ (x y) (i) (hxi : x.1 ≤ i) (hyi : y.1 ≤ i) :
+    fullRec₂ f₁ f₂ f ih compat ⟦x⟧ ⟦y⟧ = ⟦⟨i, ih i (f₁ _ _ hxi x.2) (f₂ _ _ hyi y.2)⟩⟧ :=
+  rec₂_spec₂ ..
+
+theorem fullRec₂_spec (i x y) : fullRec₂ f₁ f₂ f ih compat ⟦⟨i, x⟩⟧ ⟦⟨i, y⟩⟧ = ⟦⟨i, ih i x y⟩⟧ :=
+  rec₂_spec ..
+
+end fullRec₂
+
+end DirectLimit
+
+end DirectedSystem
 
 variable (f : ∀ ⦃i j : ι⦄, i ≤ j → F j → F i) ⦃i j : ι⦄ (h : i ≤ j)
 


### PR DESCRIPTION
Revamp the DirectLimit API that was introduced by @kckennylau into Mathlib 5 years ago in [mathlib3#754](https://github.com/leanprover-community/mathlib3/pull/754).

In DirectedInverseSystem.lean, we define the setoid associated to a directed system of types, and use the quotient as the underlying type for all kinds of DirectLimit: making use of hom classes allows us to put all kinds of algebraic instances on the same type. We define recursion/induction principles for DirectLimit and use it to define all kinds of algebraic operations in Algebra/DirectLimit.lean.

This definition makes it super easy (basically by definition) to prove [the `zero_exact` lemmas](https://github.com/leanprover-community/mathlib4/blob/5255add1b2ea28533d99d582c7cfcc20ad22939a/Mathlib/Algebra/DirectLimit.lean#L309-L322) which currently takes a huge effort and also require separate proofs for Module and Ring.

The current definition of Module/Ring.DirectLimit have different underlying type, because they are quotients of different universal objects. They are not needed for DirectLimit now, but they are actually good for **arbitrary** colimits indexed by a preorder, so we retain them and rename them to Colimit. (It shouldn't be hard to generalize to arbitrary indexing category, but that doesn't fit in the DirectedSystem framework.) We also generalize Module.DirectLimit from Ring/AddCommGroup to Semiring/AddCommMonoid by making use of AddCon.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
