### PR TITLE
feat: generalize `Function.Injective.isDomain` to `Semiring`

### DIFF
--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -124,27 +124,15 @@ section NoZeroDivisors
 
 variable (α)
 
-lemma IsLeftCancelMulZero.to_noZeroDivisors [NonUnitalNonAssocRing α] [IsLeftCancelMulZero α] :
-    NoZeroDivisors α :=
-  { eq_zero_or_eq_zero_of_mul_eq_zero := fun {x y} h ↦ by
-      by_cases hx : x = 0
-      { left
-        exact hx }
-      { right
-        rw [← sub_zero (x * y), ← mul_zero x, ← mul_sub] at h
-        have := (IsLeftCancelMulZero.mul_left_cancel_of_ne_zero) hx h
-        rwa [sub_zero] at this } }
+lemma IsLeftCancelMulZero.to_noZeroDivisors [NonUnitalNonAssocSemiring α]
+    [IsLeftCancelMulZero α] : NoZeroDivisors α where
+  eq_zero_or_eq_zero_of_mul_eq_zero {x y} h :=
+    or_iff_not_imp_left.2 fun hx ↦ mul_left_cancel₀ hx (by rwa [mul_zero])
 
-lemma IsRightCancelMulZero.to_noZeroDivisors [NonUnitalNonAssocRing α] [IsRightCancelMulZero α] :
-    NoZeroDivisors α :=
-  { eq_zero_or_eq_zero_of_mul_eq_zero := fun {x y} h ↦ by
-      by_cases hy : y = 0
-      { right
-        exact hy }
-      { left
-        rw [← sub_zero (x * y), ← zero_mul y, ← sub_mul] at h
-        have := (IsRightCancelMulZero.mul_right_cancel_of_ne_zero) hy h
-        rwa [sub_zero] at this } }
+lemma IsRightCancelMulZero.to_noZeroDivisors [NonUnitalNonAssocSemiring α]
+    [IsRightCancelMulZero α] : NoZeroDivisors α where
+  eq_zero_or_eq_zero_of_mul_eq_zero {x y} h :=
+    or_iff_not_imp_right.2 fun hy ↦ mul_right_cancel₀ hy (by rwa [zero_mul])
 
 instance (priority := 100) NoZeroDivisors.to_isCancelMulZero
     [NonUnitalNonAssocRing α] [NoZeroDivisors α] :

--- a/Mathlib/Algebra/Ring/Hom/Basic.lean
+++ b/Mathlib/Algebra/Ring/Hom/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amelia Livingston, Jireh Loreaux
 -/
 import Mathlib.Algebra.Divisibility.Hom
-import Mathlib.Algebra.GroupWithZero.InjSurj
 import Mathlib.Algebra.Ring.Hom.Defs
 import Mathlib.Data.Set.Basic
 

--- a/Mathlib/Algebra/Ring/Hom/Basic.lean
+++ b/Mathlib/Algebra/Ring/Hom/Basic.lean
@@ -49,9 +49,10 @@ end Semiring
 end RingHom
 
 /-- Pullback `IsDomain` instance along an injective function. -/
-protected theorem Function.Injective.isDomain [Ring α] [IsDomain α] [Ring β] (f : β →+* α)
-    (hf : Injective f) : IsDomain β := by
-  haveI := pullback_nonzero f f.map_zero f.map_one
-  haveI := IsRightCancelMulZero.to_noZeroDivisors α
-  haveI := hf.noZeroDivisors f f.map_zero f.map_mul
-  exact NoZeroDivisors.to_isDomain β
+protected theorem Function.Injective.isDomain [Semiring α] [IsDomain α] [Semiring β] (f : β →+* α)
+    (hf : Injective f) : IsDomain β where
+  mul_left_cancel_of_ne_zero {a b c} h h2 := hf <| mul_left_cancel₀ (f.map_zero ▸ hf.ne h) <| by
+    simpa only [map_mul] using congr(f $(h2))
+  mul_right_cancel_of_ne_zero {a b c} h h2 := hf <| mul_right_cancel₀ (f.map_zero ▸ hf.ne h) <| by
+    simpa only [map_mul] using congr(f $(h2))
+  exists_pair_ne := f.domain_nontrivial.exists_pair_ne


### PR DESCRIPTION
also generalize `Is(Left|Right)CancelMulZero.to_noZeroDivisors`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

In the original proof, `IsRightCancelMulZero.to_noZeroDivisors` and `NoZeroDivisors.to_isDomain` requires `Ring`, and their proof uses subtraction, which is suboptimal. ~~Seems that they can be also generalized, too (?), but I haven't investigated into them yet.~~ Anyways the proof of `NoZeroDivisors.to_isDomain` must use subtraction...

[EDIT] Sorry this duplicates #19768. I will close it soon.