### PR TITLE
[Merged by Bors] - feat(List): `count a (l₁.diff l₂) = count a l₁ - count a l₂`

### DIFF
--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -41,17 +41,11 @@ lemma countP_diff [DecidableEq α] {l₁ l₂ : List α} (hl : l₂ <+~ l₁) (p
   exact ((subperm_append_diff_self_of_count_le <| subperm_ext_iff.1 hl).symm.trans
     perm_append_comm).countP_eq _
 
-/-! ### count -/
-
-section Count
-
 @[simp]
 theorem count_map_of_injective {β} [DecidableEq α] [DecidableEq β] (l : List α) (f : α → β)
     (hf : Function.Injective f) (x : α) : count (f x) (map f l) = count x l := by
   simp only [count, countP_map]
   unfold Function.comp
   simp only [hf.beq_eq]
-
-end Count
 
 end List

--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -13,15 +13,33 @@ This file proves basic properties of `List.countP` and `List.count`, which count
 elements of a list satisfying a predicate and equal to a given element respectively.
 -/
 
+assert_not_exists Monoid
 assert_not_exists Set.range
-assert_not_exists GroupWithZero
-assert_not_exists Ring
 
 open Nat
 
 variable {α : Type*}
 
 namespace List
+
+lemma countP_erase [DecidableEq α] (p : α → Bool) (l : List α) (a : α) :
+    countP p (l.erase a) = countP p l - if a ∈ l ∧ p a then 1 else 0 := by
+  rw [countP_eq_length_filter, countP_eq_length_filter, ← erase_filter, length_erase]
+  aesop
+
+lemma count_diff [DecidableEq α] (a : α) (l₁ : List α) :
+    ∀ l₂, count a (l₁.diff l₂) = count a l₁ - count a l₂
+  | [] => rfl
+  | b :: l₂ => by
+    simp only [diff_cons, count_diff, count_erase, beq_iff_eq, Nat.sub_right_comm, count_cons,
+      Nat.sub_add_eq]
+
+lemma countP_diff [DecidableEq α] {l₁ l₂ : List α} (hl : l₂ <+~ l₁) (p : α → Bool) :
+    countP p (l₁.diff l₂) = countP p l₁ - countP p l₂ := by
+  refine (Nat.sub_eq_of_eq_add ?_).symm
+  rw [← countP_append]
+  exact ((subperm_append_diff_self_of_count_le <| subperm_ext_iff.1 hl).symm.trans
+    perm_append_comm).countP_eq _
 
 /-! ### count -/
 

--- a/Mathlib/Data/List/Perm/Subperm.lean
+++ b/Mathlib/Data/List/Perm/Subperm.lean
@@ -30,6 +30,11 @@ attribute [trans] Subperm.trans
 
 end Subperm
 
+/-- See also `List.subperm_ext_iff`. -/
+lemma subperm_iff_count [DecidableEq α] : l₁ <+~ l₂ ↔ ∀ a, count a l₁ ≤ count a l₂ :=
+  subperm_ext_iff.trans <| forall_congr' fun a ↦ by
+    by_cases ha : a ∈ l₁ <;> simp [ha, count_eq_zero_of_not_mem]
+
 lemma subperm_iff : l₁ <+~ l₂ ↔ ∃ l, l ~ l₂ ∧ l₁ <+ l := by
   refine ⟨?_, fun ⟨l, h₁, h₂⟩ ↦ h₂.subperm.trans h₁.subperm⟩
   rintro ⟨l, h₁, h₂⟩


### PR DESCRIPTION
This will help not importing algebra when defining multisets


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
