### PR TITLE
chore: reduce prio of `instIsScalarTowerSubtypeMem` instances

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -248,7 +248,7 @@ instance instIsScalarTower' [Semiring R'] [SMul R' R] [Module R' A] [IsScalarTow
     IsScalarTower R' R S :=
   S.toSubmodule.isScalarTower
 
-instance [IsScalarTower R A A] : IsScalarTower R S S where
+instance (priority := 900) [IsScalarTower R A A] : IsScalarTower R S S where
   smul_assoc r x y := Subtype.ext <| smul_assoc r (x : A) (y : A)
 
 instance instSMulCommClass' [Semiring R'] [SMul R' R] [Module R' A] [IsScalarTower R' R A]

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -264,7 +264,8 @@ instance (priority := low) module' [Semiring R'] [SMul R' R] [Module R' A] [IsSc
 instance : Module R S :=
   S.module'
 
-instance [Semiring R'] [SMul R' R] [Module R' A] [IsScalarTower R' R A] : IsScalarTower R' R S :=
+instance (priority := 900) [Semiring R'] [SMul R' R] [Module R' A] [IsScalarTower R' R A] :
+    IsScalarTower R' R S :=
   inferInstanceAs (IsScalarTower R' R (toSubmodule S))
 
 /- More general form of `Subalgebra.algebra`.

--- a/Mathlib/Algebra/Field/Subfield/Basic.lean
+++ b/Mathlib/Algebra/Field/Subfield/Basic.lean
@@ -616,7 +616,7 @@ instance smulCommClass_right [SMul X Y] [SMul K Y] [SMulCommClass X K Y] (F : Su
   inferInstanceAs (SMulCommClass X F.toSubsemiring Y)
 
 /-- Note that this provides `IsScalarTower F K K` which is needed by `smul_mul_assoc`. -/
-instance [SMul X Y] [SMul K X] [SMul K Y] [IsScalarTower K X Y] (F : Subfield K) :
+instance (priority := 900) [SMul X Y] [SMul K X] [SMul K Y] [IsScalarTower K X Y] (F : Subfield K) :
     IsScalarTower F X Y :=
   inferInstanceAs (IsScalarTower F.toSubsemiring X Y)
 

--- a/Mathlib/Algebra/Group/Subgroup/Actions.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Actions.lean
@@ -45,8 +45,8 @@ instance smulCommClass_right [SMul α β] [MulAction G β] [SMulCommClass α G �
   S.toSubmonoid.smulCommClass_right
 
 /-- Note that this provides `IsScalarTower S G G` which is needed by `smul_mul_assoc`. -/
-instance [SMul α β] [MulAction G α] [MulAction G β] [IsScalarTower G α β] (S : Subgroup G) :
-    IsScalarTower S α β :=
+instance (priority := 900) [SMul α β] [MulAction G α] [MulAction G β] [IsScalarTower G α β]
+    (S : Subgroup G) : IsScalarTower S α β :=
   inferInstanceAs (IsScalarTower S.toSubmonoid α β)
 
 instance [MulAction G α] [FaithfulSMul G α] (S : Subgroup G) : FaithfulSMul S α :=

--- a/Mathlib/Algebra/Lie/Subalgebra.lean
+++ b/Mathlib/Algebra/Lie/Subalgebra.lean
@@ -100,8 +100,8 @@ instance [SMul R₁ R] [SMul R₁ᵐᵒᵖ R] [Module R₁ L] [Module R₁ᵐᵒ
     IsCentralScalar R₁ L' :=
   L'.toSubmodule.isCentralScalar
 
-instance [SMul R₁ R] [Module R₁ L] [IsScalarTower R₁ R L] (L' : LieSubalgebra R L) :
-    IsScalarTower R₁ R L' :=
+instance (priority := 900) [SMul R₁ R] [Module R₁ L] [IsScalarTower R₁ R L]
+    (L' : LieSubalgebra R L) : IsScalarTower R₁ R L' :=
   L'.toSubmodule.isScalarTower
 
 instance (L' : LieSubalgebra R L) [IsNoetherian R L] : IsNoetherian R L' :=

--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -963,8 +963,8 @@ theorem smul_def [SMul R α] {S : Subring R} (g : S) (m : α) : g • m = (g : R
   rfl
 
 -- Porting note: Lean can find this instance already
-instance smulCommClass_left [SMul R β] [SMul α β] [SMulCommClass R α β] (S : Subring R) :
-    SMulCommClass S α β :=
+instance (priority := 900) smulCommClass_left [SMul R β] [SMul α β] [SMulCommClass R α β]
+    (S : Subring R) : SMulCommClass S α β :=
   inferInstanceAs (SMulCommClass S.toSubsemiring α β)
 
 -- Porting note: Lean can find this instance already

--- a/Mathlib/FieldTheory/Extension.lean
+++ b/Mathlib/FieldTheory/Extension.lean
@@ -167,6 +167,7 @@ theorem union_isExtendible [alg : Algebra.IsAlgebraic F E]
 
 end Chain
 
+set_option synthInstance.maxHeartbeats 40000 in
 theorem nonempty_algHom_of_exist_lifts_finset [alg : Algebra.IsAlgebraic F E]
     (h : ∀ S : Finset E, ∃ σ : Lifts F E K, (S : Set E) ⊆ σ.carrier) :
     Nonempty (E →ₐ[F] K) := by
@@ -224,6 +225,7 @@ end Lifts
 
 section
 
+set_option synthInstance.maxHeartbeats 40000 in
 private theorem exists_algHom_adjoin_of_splits'' {L : IntermediateField F E}
     (f : L →ₐ[F] K) (hK : ∀ s ∈ S, IsIntegral L s ∧ (minpoly L s).Splits f.toRingHom) :
     ∃ φ : adjoin L S →ₐ[F] K, φ.restrictDomain L = f := by

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -410,7 +410,8 @@ variable {E} [Field E] [Algebra L E] (T : IntermediateField S E) {S}
 instance : Algebra S T := T.algebra
 instance : Module S T := Algebra.toModule
 instance : SMul S T := Algebra.toSMul
-instance [Algebra K E] [IsScalarTower K L E] : IsScalarTower K S T := T.isScalarTower
+instance (priority := 900) [Algebra K E] [IsScalarTower K L E] : IsScalarTower K S T :=
+  T.isScalarTower
 end shortcut_instances
 
 /-- Given `f : L →ₐ[K] L'`, `S.comap f` is the intermediate field between `K` and `L`

--- a/Mathlib/FieldTheory/NormalClosure.lean
+++ b/Mathlib/FieldTheory/NormalClosure.lean
@@ -183,12 +183,12 @@ noncomputable instance algebra :
     { ⨆ f : K →ₐ[F] L, f.fieldRange with
       algebraMap_mem' := fun r ↦ (toAlgHom F K L).fieldRange_le_normalClosure ⟨r, rfl⟩ }
 
-instance : IsScalarTower F K (normalClosure F K L) := by
+instance (priority := 900) : IsScalarTower F K (normalClosure F K L) := by
   apply of_algebraMap_eq'
   ext x
   exact algebraMap_apply F K L x
 
-instance : IsScalarTower K (normalClosure F K L) L :=
+instance (priority := 900) : IsScalarTower K (normalClosure F K L) L :=
   of_algebraMap_eq' rfl
 
 lemma restrictScalars_eq :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
