### PR TITLE
[Merged by Bors] - feat(Order/SuccPred/CompleteLinearOrder): `sSup (Iio x) = x ↔ IsSuccPrelimit x`

### DIFF
--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -147,8 +147,7 @@ alias IsLUB.exists_of_not_isSuccLimit := IsLUB.exists_of_not_isSuccPrelimit
 theorem Order.IsSuccPrelimit.sSup_Iio (h : IsSuccPrelimit x) : sSup (Iio x) = x := by
   obtain rfl | hx := eq_bot_or_bot_lt x
   · simp
-  · have hn : (Iio x).Nonempty := ⟨⊥, hx⟩
-    refine (csSup_le hn fun a ha ↦ ha.le).antisymm <| le_of_forall_lt fun a ha ↦ ?_
+  · refine (csSup_le ⟨⊥, hx⟩ fun a ha ↦ ha.le).antisymm <| le_of_forall_lt fun a ha ↦ ?_
     rw [lt_csSup_iff' bddAbove_Iio]
     obtain ⟨b, hb', hb⟩ := (not_covBy_iff ha).1 (h a)
     use b, hb

--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -11,7 +11,7 @@ import Mathlib.Order.SuccPred.Limit
 
 -/
 
-open Order
+open Order Set
 
 variable {ι α : Type*}
 
@@ -143,6 +143,24 @@ lemma IsLUB.exists_of_not_isSuccPrelimit (hf : IsLUB (Set.range f) x) (hx : ¬ I
 
 @[deprecated IsLUB.exists_of_not_isSuccPrelimit (since := "2024-09-05")]
 alias IsLUB.exists_of_not_isSuccLimit := IsLUB.exists_of_not_isSuccPrelimit
+
+theorem Order.IsSuccPrelimit.sSup_Iio (h : IsSuccPrelimit x) : sSup (Iio x) = x := by
+  obtain rfl | hx := eq_bot_or_bot_lt x
+  · simp
+  · have hn : (Iio x).Nonempty := ⟨⊥, hx⟩
+    refine (csSup_le hn fun a ha ↦ ha.le).antisymm <| le_of_forall_lt fun a ha ↦ ?_
+    rw [lt_csSup_iff' bddAbove_Iio]
+    obtain ⟨b, hb', hb⟩ := (not_covBy_iff ha).1 (h a)
+    use b, hb
+
+theorem Order.IsSuccLimit.sSup_Iio (h : IsSuccLimit x) : sSup (Iio x) = x :=
+  h.isSuccPrelimit.sSup_Iio
+
+theorem sSup_Iio_eq_self_iff_isSuccPrelimit : sSup (Iio x) = x ↔ IsSuccPrelimit x := by
+  refine ⟨fun h ↦ ?_, IsSuccPrelimit.sSup_Iio⟩
+  by_contra hx
+  rw [← h] at hx
+  simpa [h] using csSup_mem_of_not_isSuccPrelimit' bddAbove_Iio hx
 
 end ConditionallyCompleteLinearOrderBot
 

--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -152,14 +152,23 @@ theorem Order.IsSuccPrelimit.sSup_Iio (h : IsSuccPrelimit x) : sSup (Iio x) = x 
     obtain ⟨b, hb', hb⟩ := (not_covBy_iff ha).1 (h a)
     use b, hb
 
+theorem Order.IsSuccPrelimit.iSup_Iio (h : IsSuccPrelimit x) : ⨆ a : Iio x, a.1 = x := by
+  rw [← sSup_eq_iSup', h.sSup_Iio]
+
 theorem Order.IsSuccLimit.sSup_Iio (h : IsSuccLimit x) : sSup (Iio x) = x :=
   h.isSuccPrelimit.sSup_Iio
+
+theorem Order.IsSuccLimit.iSup_Iio (h : IsSuccLimit x) : ⨆ a : Iio x, a.1 = x :=
+  h.isSuccPrelimit.iSup_Iio
 
 theorem sSup_Iio_eq_self_iff_isSuccPrelimit : sSup (Iio x) = x ↔ IsSuccPrelimit x := by
   refine ⟨fun h ↦ ?_, IsSuccPrelimit.sSup_Iio⟩
   by_contra hx
   rw [← h] at hx
   simpa [h] using csSup_mem_of_not_isSuccPrelimit' bddAbove_Iio hx
+
+theorem iSup_Iio_eq_self_iff_isSuccPrelimit : ⨆ a : Iio x, a.1 = x ↔ IsSuccPrelimit x := by
+  rw [← sSup_eq_iSup', sSup_Iio_eq_self_iff_isSuccPrelimit]
 
 end ConditionallyCompleteLinearOrderBot
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
