### PR TITLE
[Merged by Bors] - chore: generalize OrderMonoidIso to OrderMulIso

### DIFF
--- a/Mathlib/Algebra/Order/Hom/Monoid.lean
+++ b/Mathlib/Algebra/Order/Hom/Monoid.lean
@@ -90,8 +90,8 @@ structure.
 When possible, instead of parametrizing results over `(f : α ≃+o β)`,
 you should parametrize over
 `(F : Type*) [FunLike F M N] [AddEquivClass F M N] [OrderIsoClass F M N] (f : F)`. -/
-structure OrderAddMonoidIso (α β : Type*) [Preorder α] [Preorder β] [AddZeroClass α]
-  [AddZeroClass β] extends α ≃+ β where
+structure OrderAddMonoidIso (α β : Type*) [Preorder α] [Preorder β] [Add α] [Add β]
+  extends α ≃+ β where
   /-- An `OrderAddMonoidIso` respects `≤`. -/
   map_le_map_iff' {a b : α} : toFun a ≤ toFun b ↔ a ≤ b
 
@@ -146,8 +146,8 @@ When possible, instead of parametrizing results over `(f : α ≃*o β)`,
 you should parametrize over
 `(F : Type*) [FunLike F M N] [MulEquivClass F M N] [OrderIsoClass F M N] (f : F)`. -/
 @[to_additive]
-structure OrderMonoidIso (α β : Type*) [Preorder α] [Preorder β] [MulOneClass α]
-  [MulOneClass β] extends α ≃* β where
+structure OrderMonoidIso (α β : Type*) [Preorder α] [Preorder β] [Mul α] [Mul β]
+  extends α ≃* β where
   /-- An `OrderMonoidIso` respects `≤`. -/
   map_le_map_iff' {a b : α} : toFun a ≤ toFun b ↔ a ≤ b
 
@@ -513,8 +513,8 @@ namespace OrderMonoidIso
 
 section Preorder
 
-variable [Preorder α] [Preorder β] [Preorder γ] [Preorder δ] [MulOneClass α] [MulOneClass β]
-  [MulOneClass γ] [MulOneClass δ] {f g : α ≃*o β}
+variable [Preorder α] [Preorder β] [Preorder γ] [Preorder δ] [Mul α] [Mul β]
+  [Mul γ] [Mul δ] {f g : α ≃*o β}
 
 @[to_additive]
 instance : EquivLike (α ≃*o β) α β where


### PR DESCRIPTION
An OrderMonoidIso actually does not depend on the fact that the type has a One, so the assumption [MulOneClass] can be relaxed to [Mul] in the definition, and similar for the AddOrderMonoidIso.

For the time being, let's not rename the definition yet, just relax it.

(I need this for my work on Quantales, as a OrderMulIso is also a QuantaleIso, but Quantales do not necessarily have a One).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
