### PR TITLE
[Merged by Bors] - feat(Quantale): `⊥ * x = ⊥`

### DIFF
--- a/Mathlib/Algebra/Order/Quantale.lean
+++ b/Mathlib/Algebra/Order/Quantale.lean
@@ -182,19 +182,19 @@ variable {α : Type*} [Semigroup α] [CompleteLattice α] [IsQuantale α]
 variable {x : α}
 
 @[to_additive (attr := simp)]
-theorem bot_mul_eq_bot : ⊥ * x = ⊥ := by
+theorem bot_mul : ⊥ * x = ⊥ := by
   rw [← sSup_empty, sSup_mul_distrib]
   simp only [Set.mem_empty_iff_false, not_false_eq_true, iSup_neg, iSup_bot, sSup_empty]
 
 @[to_additive (attr := simp)]
-theorem mul_bot_eq_bot : x * ⊥ = ⊥ := by
+theorem mul_bot : x * ⊥ = ⊥ := by
   rw [← sSup_empty, mul_sSup_distrib]
   simp only [Set.mem_empty_iff_false, not_false_eq_true, iSup_neg, iSup_bot, sSup_empty]
 
 instance : MulZeroClass α where
   zero := ⊥
-  zero_mul _ := bot_mul_eq_bot
-  mul_zero _ := mul_bot_eq_bot
+  zero_mul _ := bot_mul
+  mul_zero _ := mul_bot
 
 end Zero
 

--- a/Mathlib/Algebra/Order/Quantale.lean
+++ b/Mathlib/Algebra/Order/Quantale.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Pieter Cuijpers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Pieter Cuijpers
 -/
-import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
 import Mathlib.Order.CompleteLattice
 
@@ -190,6 +190,11 @@ theorem bot_mul_eq_bot : ⊥ * x = ⊥ := by
 theorem mul_bot_eq_bot : x * ⊥ = ⊥ := by
   rw [← sSup_empty, mul_sSup_distrib]
   simp only [Set.mem_empty_iff_false, not_false_eq_true, iSup_neg, iSup_bot, sSup_empty]
+
+instance : MulZeroClass α where
+  zero := ⊥
+  zero_mul _ := bot_mul_eq_bot
+  mul_zero _ := mul_bot_eq_bot
 
 end Zero
 

--- a/Mathlib/Algebra/Order/Quantale.lean
+++ b/Mathlib/Algebra/Order/Quantale.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Pieter Cuijpers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Pieter Cuijpers
 -/
-import Mathlib.Algebra.GroupWithZero.Defs
+import Mathlib.Algebra.Group.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
 import Mathlib.Order.CompleteLattice
 

--- a/Mathlib/Algebra/Order/Quantale.lean
+++ b/Mathlib/Algebra/Order/Quantale.lean
@@ -191,11 +191,6 @@ theorem mul_bot : x * ⊥ = ⊥ := by
   rw [← sSup_empty, mul_sSup_distrib]
   simp only [Set.mem_empty_iff_false, not_false_eq_true, iSup_neg, iSup_bot, sSup_empty]
 
-instance : MulZeroClass α where
-  zero := ⊥
-  zero_mul _ := bot_mul
-  mul_zero _ := mul_bot
-
 end Zero
 
 end IsQuantale

--- a/Mathlib/Algebra/Order/Quantale.lean
+++ b/Mathlib/Algebra/Order/Quantale.lean
@@ -181,12 +181,12 @@ section Zero
 variable {α : Type*} [Semigroup α] [CompleteLattice α] [IsQuantale α]
 variable {x : α}
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem bot_mul_eq_bot : ⊥ * x = ⊥ := by
   rw [← sSup_empty, sSup_mul_distrib]
   simp only [Set.mem_empty_iff_false, not_false_eq_true, iSup_neg, iSup_bot, sSup_empty]
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem mul_bot_eq_bot : x * ⊥ = ⊥ := by
   rw [← sSup_empty, mul_sSup_distrib]
   simp only [Set.mem_empty_iff_false, not_false_eq_true, iSup_neg, iSup_bot, sSup_empty]

--- a/Mathlib/Algebra/Order/Quantale.lean
+++ b/Mathlib/Algebra/Order/Quantale.lean
@@ -176,4 +176,21 @@ theorem rightMulResiduation_le_iff_mul_le : x ≤ y ⇨ᵣ z ↔ y * x ≤ z whe
       iSup_le_iff, implies_true]
   mpr h1 := le_sSup h1
 
+section Zero
+
+variable {α : Type*} [Semigroup α] [CompleteLattice α] [IsQuantale α]
+variable {x : α}
+
+@[to_additive]
+theorem bot_mul_eq_bot : ⊥ * x = ⊥ := by
+  rw [← sSup_empty, sSup_mul_distrib]
+  simp only [Set.mem_empty_iff_false, not_false_eq_true, iSup_neg, iSup_bot, sSup_empty]
+
+@[to_additive]
+theorem mul_bot_eq_bot : x * ⊥ = ⊥ := by
+  rw [← sSup_empty, mul_sSup_distrib]
+  simp only [Set.mem_empty_iff_false, not_false_eq_true, iSup_neg, iSup_bot, sSup_empty]
+
+end Zero
+
 end IsQuantale


### PR DESCRIPTION
The bottom element of a quantale is absorbing for multiplication

As this is a basic truth for quantales that one practically always will use, I think it belongs in the main Quantale file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
