### PR TITLE
[Merged by Bors] - feat: coe theorems in FiniteAdeleRing

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -336,10 +336,6 @@ instance : Algebra R (FiniteAdeleRing R K) :=
 instance : IsScalarTower R K (FiniteAdeleRing R K) :=
   IsScalarTower.of_algebraMap_eq' rfl
 
-/-- Coercion `FiniteAdeleRing R K → K_hat R K`. -/
-@[coe]
-def coe (x : FiniteAdeleRing R K) : K_hat R K := x.1
-
 instance : Coe (FiniteAdeleRing R K) (K_hat R K) where
   coe x := x.1
 
@@ -382,17 +378,6 @@ instance : Algebra (R_hat R K) (FiniteAdeleRing R K) where
 instance : CoeFun (FiniteAdeleRing R K)
     (fun _ ↦ ∀ (v : HeightOneSpectrum R), adicCompletion K v) where
   coe a v := a.1 v
-
-section Algebra
-
-variable (L : Type*) [Field L] [Algebra L K] [Algebra L (FiniteAdeleRing R K)]
-  [IsScalarTower L K (FiniteAdeleRing R K)]
-
-theorem algebraMap_extension (r : L) :
-  algebraMap L (FiniteAdeleRing R K) r = algebraMap K (FiniteAdeleRing R K) (algebraMap L K r) :=
-  IsScalarTower.algebraMap_apply L K (FiniteAdeleRing R K) r
-
-end Algebra
 
 open scoped algebraMap -- coercion from R to `FiniteAdeleRing R K`
 

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -336,6 +336,7 @@ instance : Algebra R (FiniteAdeleRing R K) :=
 instance : IsScalarTower R K (FiniteAdeleRing R K) :=
   IsScalarTower.of_algebraMap_eq' rfl
 
+/-- Coercion `FiniteAdeleRing R K → K_hat R K`. -/
 @[coe]
 def coe (x : FiniteAdeleRing R K) : K_hat R K := x.1
 

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -385,13 +385,12 @@ instance : CoeFun (FiniteAdeleRing R K)
 
 section Algebra
 
-variable (R' L : Type*) [CommRing R'] [Field L] [Algebra R L] [IsDedekindDomain R']
-  [Algebra R' L] [IsFractionRing R' L] [Algebra K (FiniteAdeleRing R' L)] [IsFractionRing R L]
-  [Algebra K L]  [IsScalarTower K L (FiniteAdeleRing R' L)]
+variable (L : Type*) [Field L] [Algebra L K] [Algebra L (FiniteAdeleRing R K)]
+  [IsScalarTower L K (FiniteAdeleRing R K)]
 
-theorem algebraMap_extension (r : K) :
-  algebraMap K (FiniteAdeleRing R' L) r = algebraMap L (FiniteAdeleRing R' L) (algebraMap K L r) :=
-  IsScalarTower.algebraMap_apply K L (FiniteAdeleRing R' L) r
+theorem algebraMap_extension (r : L) :
+  algebraMap L (FiniteAdeleRing R K) r = algebraMap K (FiniteAdeleRing R K) (algebraMap L K r) :=
+  IsScalarTower.algebraMap_apply L K (FiniteAdeleRing R K) r
 
 end Algebra
 

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -336,8 +336,29 @@ instance : Algebra R (FiniteAdeleRing R K) :=
 instance : IsScalarTower R K (FiniteAdeleRing R K) :=
   IsScalarTower.of_algebraMap_eq' rfl
 
+@[coe]
+def coe (x : FiniteAdeleRing R K) : K_hat R K := x.1
+
 instance : Coe (FiniteAdeleRing R K) (K_hat R K) where
   coe x := x.1
+
+@[simp, norm_cast]
+theorem coe_one : (1 : FiniteAdeleRing R K) = (1 : K_hat R K) := rfl
+
+@[simp, norm_cast]
+theorem coe_zero: (0 : FiniteAdeleRing R K) = (0 : K_hat R K) := rfl
+
+@[simp, norm_cast]
+theorem coe_add (x y : FiniteAdeleRing R K) : (x + y : FiniteAdeleRing R K) =
+  (x : K_hat R K) + (y : K_hat R K) := rfl
+
+@[simp, norm_cast]
+theorem coe_mul (x y : FiniteAdeleRing R K) : (x * y : FiniteAdeleRing R K) =
+  (x : K_hat R K) * (y : K_hat R K) := rfl
+
+@[simp, norm_cast]
+theorem coe_algebraMap (x : K) : (((algebraMap K (FiniteAdeleRing R K)) x) : K_hat R K) =
+      (algebraMap K (ProdAdicCompletions R K)) x := rfl
 
 @[ext]
 lemma ext {a₁ a₂ : FiniteAdeleRing R K} (h : (a₁ : K_hat R K) = a₂) : a₁ = a₂ :=
@@ -360,6 +381,18 @@ instance : Algebra (R_hat R K) (FiniteAdeleRing R K) where
 instance : CoeFun (FiniteAdeleRing R K)
     (fun _ ↦ ∀ (v : HeightOneSpectrum R), adicCompletion K v) where
   coe a v := a.1 v
+
+section Algebra
+
+variable (R' L : Type*) [CommRing R'] [Field L] [Algebra R L] [IsDedekindDomain R']
+  [Algebra R' L] [IsFractionRing R' L] [Algebra K (FiniteAdeleRing R' L)] [IsFractionRing R L]
+  [Algebra K L]  [IsScalarTower K L (FiniteAdeleRing R' L)]
+
+theorem algebraMap_extension (r : K) :
+  algebraMap K (FiniteAdeleRing R' L) r = algebraMap L (FiniteAdeleRing R' L) (algebraMap K L r) :=
+  IsScalarTower.algebraMap_apply K L (FiniteAdeleRing R' L) r
+
+end Algebra
 
 open scoped algebraMap -- coercion from R to `FiniteAdeleRing R K`
 


### PR DESCRIPTION
add coercion theorems for: one, zero, add and mul; an interaction with algebraMap; and a theorem showing how algebraMaps of extensions are built. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
