### PR TITLE
feat: add a Qq version of AtomM that groups by type

### DIFF
--- a/Mathlib/Data/Ineq.lean
+++ b/Mathlib/Data/Ineq.lean
@@ -104,12 +104,18 @@ set_option linter.unusedVariables.funArgs false in
 /-- Use this to deal with instance diamonds in the `inst` argument, after calling
 `(assert|assume)InstancesCommute`. -/
 def Mathlib.IneqQ.cast
-    {u : Level} {α : Q(Type u)} {inst₁ inst₂ : Q(PartialOrder $α)} {a₁ a₂ b₁ b₂ : Q($α)}
+    {u₁ u₂ : Level} {α₁ : Q(Type u₁)} {α₂ : Q(Type u₂)}
+    {inst₁ : Q(PartialOrder $α₁)}
+    {inst₂ : Q(PartialOrder $α₂)}
+    {a₁ b₁ : Q($α₁)}
+    {a₂ b₂ : Q($α₂)}
     {ineq : Ineq}
     (h : Mathlib.IneqQ inst₁ a₁ b₁ ineq)
+    (hu : u₁ =QL u₂ := by first | exact .rfl | assumption)
+    (hα : $α₁ =Q $α₂ := by first | exact .rfl | assumption)
+    (hinst : $inst₁ =Q $inst₂ := by first | exact .rfl | assumption)
     (ha : $a₁ =Q $a₂ := by first | exact .rfl | assumption)
-    (hb : $b₁ =Q $b₂ := by first | exact .rfl | assumption)
-    (hinst : $inst₁ =Q $inst₂ := by first | exact .rfl | assumption) :
+    (hb : $b₁ =Q $b₂ := by first | exact .rfl | assumption) :
     Mathlib.IneqQ inst₂ a₂ b₂ ineq :=
   match h with
   | .le h => .le q($h)
@@ -125,12 +131,16 @@ structure Mathlib.IneqResult {u : Level} (α : Q(Type u)) (inst : Q(PartialOrder
 /-- Use this to deal with instance diamonds in the `inst` argument, after calling
 `(assert|assume)InstancesCommute`. -/
 def Mathlib.IneqResult.cast
-    {u : Level} {α : Q(Type u)} {inst₁ inst₂ : Q(PartialOrder $α)}
+    {u₁ u₂ : Level} {α₁ : Q(Type u₁)} {α₂ : Q(Type u₂)}
+    {inst₁ : Q(PartialOrder $α₁)}
+    {inst₂ : Q(PartialOrder $α₂)}
+    (hu : u₁ =QL u₂ := by first | exact .rfl | assumption)
+    (hα : $α₁ =Q $α₂ := by first | exact .rfl | assumption)
     (hinst : $inst₁ =Q $inst₂ := by first | exact .rfl | assumption)
-    (h : Mathlib.IneqResult α inst₁):
-    Mathlib.IneqResult α inst₂ :=
+    (h : Mathlib.IneqResult α₁ inst₁):
+    Mathlib.IneqResult α₂ inst₂ :=
   let ⟨ineq, a, b, h⟩ := h
-  { a := a, b := b, pf := h.cast }
+  { ineq, a, b, pf := h.cast }
 
 /-! ### Parsing inequalities -/
 

--- a/Mathlib/Data/Ineq.lean
+++ b/Mathlib/Data/Ineq.lean
@@ -94,6 +94,12 @@ inductive Mathlib.IneqQ {u : Level} {α : Q(Type u)} (inst : Q(PartialOrder $α)
   | le (h : Q($a ≤ $b)) : IneqQ inst a b .le
   | lt (h : Q($a < $b)) : IneqQ inst a b .lt
 
+def Mathlib.IneqQ.raw {u : Level} {α : Q(Type u)} {inst : Q(PartialOrder $α)} {a b : Q($α)}
+    {ineq}
+    (h : Mathlib.IneqQ inst a b ineq) : Expr :=
+  match h with
+  | .eq h | .le h | .lt h => h
+
 set_option linter.unusedVariables.funArgs false in
 /-- Use this to deal with instance diamonds in the `inst` argument, after calling
 `(assert|assume)InstancesCommute`. -/

--- a/Mathlib/Data/Ineq.lean
+++ b/Mathlib/Data/Ineq.lean
@@ -94,6 +94,7 @@ inductive Mathlib.IneqQ {u : Level} {α : Q(Type u)} (inst : Q(PartialOrder $α)
   | le (h : Q($a ≤ $b)) : IneqQ inst a b .le
   | lt (h : Q($a < $b)) : IneqQ inst a b .lt
 
+/-- Throw away the type information and extract only the proof. -/
 def Mathlib.IneqQ.raw {u : Level} {α : Q(Type u)} {inst : Q(PartialOrder $α)} {a b : Q($α)}
     {ineq}
     (h : Mathlib.IneqQ inst a b ineq) : Expr :=
@@ -103,6 +104,7 @@ def Mathlib.IneqQ.raw {u : Level} {α : Q(Type u)} {inst : Q(PartialOrder $α)} 
 set_option linter.unusedVariables.funArgs false in
 /-- Use this to deal with instance diamonds in the `inst` argument, after calling
 `(assert|assume)InstancesCommute`. -/
+@[nolint unusedArguments]
 def Mathlib.IneqQ.cast
     {u₁ u₂ : Level} {α₁ : Q(Type u₁)} {α₂ : Q(Type u₂)}
     {inst₁ : Q(PartialOrder $α₁)}
@@ -122,10 +124,15 @@ def Mathlib.IneqQ.cast
   | .eq h => .eq q($h)
   | .lt h => .lt q($h)
 
+/-- TODO -/
 structure Mathlib.IneqResult {u : Level} (α : Q(Type u)) (inst : Q(PartialOrder $α)) : Type where
+  /-- The inequality-/
   ineq : Ineq
+  /-- The LHS -/
   a : Q($α)
+  /-- The RHS -/
   b : Q($α)
+  /-- The proof -/
   pf : IneqQ inst a b ineq
 
 /-- Use this to deal with instance diamonds in the `inst` argument, after calling

--- a/Mathlib/Tactic/Linarith/Datatypes.lean
+++ b/Mathlib/Tactic/Linarith/Datatypes.lean
@@ -335,14 +335,15 @@ set_option linter.unusedVariables.funArgs false in
 @[nolint unusedArguments]
 def Mathlib.IneqZeroResult.cast
     {u₁ u₂ : Level} {α₁ : Q(Type u₁)} {α₂ : Q(Type u₂)}
-    {inst₁ : Q(PartialOrder $α₁)}
-    {inst₂ : Q(PartialOrder $α₂)}
+    {inst₁ : Q(StrictOrderedCommSemiring $α₁)}
+    {inst₂ : Q(StrictOrderedCommSemiring $α₂)}
     (hu : u₁ =QL u₂ := by first | exact .rfl | assumption)
     (hα : $α₁ =Q $α₂ := by first | exact .rfl | assumption)
     (hinst : $inst₁ =Q $inst₂ := by first | exact .rfl | assumption)
-    (h : Mathlib.IneqZeroResult α₁ inst₁):
-    Mathlib.IneqZeroResult α₂ inst₂ :=
+    (h : Mathlib.IneqZeroResult α₁ q($inst₁)):
+    Mathlib.IneqZeroResult α₂ q($inst₂) :=
   let ⟨ineq, x, h⟩ := h
+  let _ := hinst
   -- TODO: why does `hinst` not work here?
   { ineq, x, pf := h.cast hu hα (hinst := .unsafeIntro) (hb := .unsafeIntro) }
 

--- a/Mathlib/Tactic/Linarith/Datatypes.lean
+++ b/Mathlib/Tactic/Linarith/Datatypes.lean
@@ -287,11 +287,14 @@ def parseCompAndExpr (e : Expr) : MetaM (Ineq × Expr) := do
 structure Mathlib.IneqZeroResult
     {u : Level} (α : Q(Type u)) (inst : Q(StrictOrderedCommSemiring $α)) :
     Type where
+  /-- The inequality. -/
   ineq : Ineq
+  /-- The term. -/
   x : Q($α)
+  /-- The proof. -/
   pf : IneqQ q(delta% inferInstance) q($x) q(0) ineq
 
--- TODO: remove?
+/-- Comparisons with zero can be viewed as general comparisons. -/
 def Mathlib.IneqZeroResult.toIneqResult
     {u : Level} {α : Q(Type u)} {inst : Q(StrictOrderedCommSemiring $α)}
     (h : IneqZeroResult α inst) :
@@ -315,6 +318,7 @@ def _root_.Mathlib.IneqResult.toIneqZeroResult?
   else
     return none
 
+/-- The Qq version of `parseCompAndExpr`. -/
 def parseCompAndExprQ  {p : Q(Prop)} (e : Q($p)) :
     MetaM <| ((u : Level) × (α : Q(Type $u)) × (inst : _) × Mathlib.IneqZeroResult α inst) := do
   let ⟨u, α, _, r⟩ ← Lean.Expr.ineqQ? e
@@ -327,6 +331,8 @@ def parseCompAndExprQ  {p : Q(Prop)} (e : Q($p)) :
     throwError "invalid comparison, rhs not zero: {r.b}"
 
 set_option linter.unusedVariables.funArgs false in
+/-- Cast the type parameters of IneqZeroResult through Qq's defeq machinery. -/
+@[nolint unusedArguments]
 def Mathlib.IneqZeroResult.cast
     {u₁ u₂ : Level} {α₁ : Q(Type u₁)} {α₂ : Q(Type u₂)}
     {inst₁ : Q(PartialOrder $α₁)}
@@ -340,6 +346,7 @@ def Mathlib.IneqZeroResult.cast
   -- TODO: why does `hinst` not work here?
   { ineq, x, pf := h.cast hu hα (hinst := .unsafeIntro) (hb := .unsafeIntro) }
 
+/-- Prove that `-(a * b) R 0` from `a R 0` and `b R 0`. -/
 def Mathlib.IneqZeroResult.mul {u : Level} {α : Q(Type $u)} {inst : _}
     (ha hb : Mathlib.IneqZeroResult α inst) :
     MetaM <| Mathlib.IneqZeroResult α inst := do

--- a/Mathlib/Tactic/Linarith/Datatypes.lean
+++ b/Mathlib/Tactic/Linarith/Datatypes.lean
@@ -326,8 +326,22 @@ def parseCompAndExprQ  {p : Q(Prop)} (e : Q($p)) :
   else
     throwError "invalid comparison, rhs not zero: {r.b}"
 
+-- set_option pp.explicit true
 
-def Mathlib.IneqZeroResult.mul (u : Level) (α : Q(Type $u)) (inst : _)
+def Mathlib.IneqZeroResult.cast
+    {u₁ u₂ : Level} {α₁ : Q(Type u₁)} {α₂ : Q(Type u₂)}
+    {inst₁ : Q(PartialOrder $α₁)}
+    {inst₂ : Q(PartialOrder $α₂)}
+    (hu : u₁ =QL u₂ := by first | exact .rfl | assumption)
+    (hα : $α₁ =Q $α₂ := by first | exact .rfl | assumption)
+    (hinst : $inst₁ =Q $inst₂ := by first | exact .rfl | assumption)
+    (h : Mathlib.IneqZeroResult α₁ inst₁):
+    Mathlib.IneqZeroResult α₂ inst₂ :=
+  let ⟨ineq, x, h⟩ := h
+  -- TODO: why does `hinst` not work here?
+  { ineq, x, pf := h.cast hu hα (hinst := .unsafeIntro) (hb := .unsafeIntro) }
+
+def Mathlib.IneqZeroResult.mul {u : Level} {α : Q(Type $u)} {inst : _}
     (ha hb : Mathlib.IneqZeroResult α inst) :
     MetaM <| Mathlib.IneqZeroResult α inst := do
   let ⟨posa, a, ha⟩ := ha

--- a/Mathlib/Tactic/Linarith/Datatypes.lean
+++ b/Mathlib/Tactic/Linarith/Datatypes.lean
@@ -326,8 +326,7 @@ def parseCompAndExprQ  {p : Q(Prop)} (e : Q($p)) :
   else
     throwError "invalid comparison, rhs not zero: {r.b}"
 
--- set_option pp.explicit true
-
+set_option linter.unusedVariables.funArgs false in
 def Mathlib.IneqZeroResult.cast
     {u₁ u₂ : Level} {α₁ : Q(Type u₁)} {α₂ : Q(Type u₂)}
     {inst₁ : Q(PartialOrder $α₁)}

--- a/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm.lean
@@ -23,7 +23,7 @@ def preprocess (matType : ℕ → ℕ → Type) [UsableInSimplexAlgorithm matTyp
   let values : List (ℕ × ℕ × ℚ) := hyps.foldlIdx (init := []) fun idx cur comp =>
     cur ++ comp.coeffs.map fun (var, c) => (var, idx, c)
 
-  let strictIndexes := hyps.findIdxs (·.str == Ineq.lt)
+  let strictIndexes := hyps.findIdxs (·.str == .lt)
   (ofValues values, strictIndexes)
 
 /--

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -311,21 +311,21 @@ def nlinarithExtras : GlobalPreprocessor where
     trace[linarith] "{s}"
     linarithTraceProofs "so we added proofs" new_es
     let with_comps ← (new_es ++ ls).filterMapM (fun e => do
-      let ⟨0, P, e⟩ ← inferTypeQ e | throwError "wat"
-      some <$> parseCompAndExprQ q($e))
+      let ⟨0, _P, e⟩ ← inferTypeQ e | throwError "nlinarith preprocessor got a non-prop"
+      observing? <| parseCompAndExprQ q($e))
     let products : List (Option <|
         (u : Level) × (α : Q(Type u)) ×  (inst : _) × IneqZeroResult α inst)
       ← with_comps.mapDiagM fun ⟨ua, αa, ia, ha⟩ ⟨ub, αb, ib, hb⟩ => do
       bif ua == ub then
         have hu : ub =QL ua := ⟨⟩
         withNewMCtxDepth do
-          let .defEq hα := ← isDefEqQ (u := ub.succ.succ) q($αb) q($αa) | pure none
-          let .defEq hi := ← isDefEqQ (u := ub.succ) q($ib) q($ia) | pure none
+          let .defEq _hα := ← isDefEqQ (u := ub.succ.succ) q($αb) q($αa) | pure none
+          let .defEq _hi := ← isDefEqQ (u := ub.succ) q($ib) q($ia) | pure none
           -- TODO: why don't `hα` and `hi` work here? Do we need `QuotedDefEq.cast`?
           return some ⟨ua, αa, ia, ← ha.mul <| hb.cast hu .unsafeIntro .unsafeIntro⟩
       else
         return none
-    return ls ++ new_es ++ products.reduceOption.map fun ⟨u, α, i, h⟩ => h.pf.raw
+    return ls ++ new_es ++ products.reduceOption.map fun ⟨_u, _α, _i, h⟩ => h.pf.raw
 
 end nlinarith
 

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -375,7 +375,6 @@ so the size of the list may change.
 -/
 def preprocess (pps : List GlobalBranchingPreprocessor) (g : MVarId) (l : List Expr) :
     MetaM (List Branch) :=
-  withTraceNode `linarith.preprocess (fun m => return "") <| g.withContext <|
   pps.foldlM (fun ls pp => return (← ls.mapM fun (g, l) => do pp.process g l).flatten) [(g, l)]
 
 end Linarith

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -374,7 +374,8 @@ Note that a preprocessor may produce multiple or no expressions from each input 
 so the size of the list may change.
 -/
 def preprocess (pps : List GlobalBranchingPreprocessor) (g : MVarId) (l : List Expr) :
-    MetaM (List Branch) := g.withContext <|
+    MetaM (List Branch) :=
+  withTraceNode `linarith.preprocess (fun m => return "") <| g.withContext <|
   pps.foldlM (fun ls pp => return (← ls.mapM fun (g, l) => do pp.process g l).flatten) [(g, l)]
 
 end Linarith

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -59,7 +59,7 @@ partial def filterComparisons : Preprocessor where
     let tp ← instantiateMVars (← inferType h)
     try
       let (b, rel, _) ← tp.ineqOrNotIneq?
-      if b || rel != Ineq.eq then pure [h] else pure []
+      if b || rel != Mathlib.Ineq.eq then pure [h] else pure []
     catch _ => pure []
 
 section removeNegations
@@ -182,9 +182,9 @@ and similarly if `pf` proves a negated weak inequality.
 -/
 def mkNonstrictIntProof (pf : Expr) : MetaM (Option Expr) := do
   match ← (← inferType pf).ineqOrNotIneq? with
-  | (true, Ineq.lt, .const ``Int [], a, b) =>
+  | (true, .lt, .const ``Int [], a, b) =>
     return mkApp (← mkAppM ``Iff.mpr #[← mkAppOptM ``Int.add_one_le_iff #[a, b]]) pf
-  | (false, Ineq.le, .const ``Int [], a, b) =>
+  | (false, .le, .const ``Int [], a, b) =>
     return mkApp (← mkAppM ``Iff.mpr #[← mkAppOptM ``Int.add_one_le_iff #[b, a]])
       (← mkAppM ``lt_of_not_ge #[pf])
   | _ => return none
@@ -205,9 +205,9 @@ and turns it into a proof of a comparison `_ R 0`, where `R ∈ {=, ≤, <}`.
  -/
 partial def rearrangeComparison (e : Expr) : MetaM (Option Expr) := do
   match ← (← inferType e).ineq? with
-  | (Ineq.le, _) => try? <| mkAppM ``Linarith.sub_nonpos_of_le #[e]
-  | (Ineq.lt, _) => try? <| mkAppM ``Linarith.sub_neg_of_lt #[e]
-  | (Ineq.eq, _) => try? <| mkAppM ``sub_eq_zero_of_eq #[e]
+  | (.le, _) => try? <| mkAppM ``Linarith.sub_nonpos_of_le #[e]
+  | (.lt, _) => try? <| mkAppM ``Linarith.sub_neg_of_lt #[e]
+  | (.eq, _) => try? <| mkAppM ``sub_eq_zero_of_eq #[e]
 
 /--
 `compWithZero h` takes a proof `h` of an equality, inequality, or negation thereof,
@@ -310,28 +310,25 @@ def nlinarithExtras : GlobalPreprocessor where
     trace[linarith] "nlinarith preprocessing found squares"
     trace[linarith] "{s}"
     linarithTraceProofs "so we added proofs" new_es
-    let with_comps ← (new_es ++ ls).mapM (fun e => do
-      let tp ← inferType e
-      try
-        let ⟨ine, _⟩ ← parseCompAndExpr tp
-        pure (ine, e)
-      catch _ => pure (Ineq.lt, e))
-    let products ← with_comps.mapDiagM fun (⟨posa, a⟩ : Ineq × Expr) ⟨posb, b⟩ =>
-      try
-        (some <$> match posa, posb with
-          | Ineq.eq, _ => mkAppM ``zero_mul_eq #[a, b]
-          | _, Ineq.eq => mkAppM ``mul_zero_eq #[a, b]
-          | Ineq.lt, Ineq.lt => mkAppM ``mul_pos_of_neg_of_neg #[a, b]
-          | Ineq.lt, Ineq.le => do
-              let a ← mkAppM ``le_of_lt #[a]
-              mkAppM ``mul_nonneg_of_nonpos_of_nonpos #[a, b]
-          | Ineq.le, Ineq.lt => do
-              let b ← mkAppM ``le_of_lt #[b]
-              mkAppM ``mul_nonneg_of_nonpos_of_nonpos #[a, b]
-          | Ineq.le, Ineq.le => mkAppM ``mul_nonneg_of_nonpos_of_nonpos #[a, b])
-      catch _ => pure none
-    let products ← compWithZero.globalize.transform products.reduceOption
-    return (new_es ++ ls ++ products)
+    let with_comps ← (new_es ++ ls).filterMapM (fun e => do
+      let ⟨0, P, e⟩ ← inferTypeQ e | throwError "wat"
+      some <$> parseCompAndExprQ q($e))
+    let products : List (Option <|
+        (u : Level) × (α : Q(Type u)) ×  (inst : _) × IneqZeroResult α inst)
+      ← with_comps.mapDiagM fun ⟨ua, αa, ia, ha⟩ ⟨ub, αb, ib, ha⟩ => do
+      bif ua == ub then
+        have _ : ua =QL ub := ⟨⟩
+        withNewMCtxDepth do
+          let .defEq h := ← isDefEqQ (u := ub.succ.succ) q($αa) q($αb) | pure none
+          let .defEq (h : _ =Q _) := ← isDefEqQ (u := ub.succ.succ) q($ia) q($ib) | pure none
+          -- return some ⟨ua, αa, ia, ha.mul hb⟩
+          return none
+      else
+        return none
+    -- return products.reduceOption.map fun ⟨u, α, i, h⟩ => h.pf.raw
+    return []
+
+#print nlinarithExtras
 
 end nlinarith
 

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -319,10 +319,9 @@ def nlinarithExtras : GlobalPreprocessor where
       bif ua == ub then
         have hu : ub =QL ua := ⟨⟩
         withNewMCtxDepth do
-          let .defEq _hα := ← isDefEqQ (u := ub.succ.succ) q($αb) q($αa) | pure none
-          let .defEq _hi := ← isDefEqQ (u := ub.succ) q($ib) q($ia) | pure none
-          -- TODO: why don't `hα` and `hi` work here? Do we need `QuotedDefEq.cast`?
-          return some ⟨ua, αa, ia, ← ha.mul <| hb.cast hu .unsafeIntro .unsafeIntro⟩
+          let .defEq hα := ← isDefEqQ q($αb) q($αa) | pure none
+          let .defEq hi := ← isDefEqQ q($ib) q($ia) | pure none
+          return some ⟨ua, αa, ia, ← ha.mul <| hb.cast hu hα hi⟩
       else
         return none
     return ls ++ new_es ++ products.reduceOption.map fun ⟨_u, _α, _i, h⟩ => h.pf.raw

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -315,20 +315,17 @@ def nlinarithExtras : GlobalPreprocessor where
       some <$> parseCompAndExprQ q($e))
     let products : List (Option <|
         (u : Level) × (α : Q(Type u)) ×  (inst : _) × IneqZeroResult α inst)
-      ← with_comps.mapDiagM fun ⟨ua, αa, ia, ha⟩ ⟨ub, αb, ib, ha⟩ => do
+      ← with_comps.mapDiagM fun ⟨ua, αa, ia, ha⟩ ⟨ub, αb, ib, hb⟩ => do
       bif ua == ub then
-        have _ : ua =QL ub := ⟨⟩
+        have hu : ub =QL ua := ⟨⟩
         withNewMCtxDepth do
-          let .defEq h := ← isDefEqQ (u := ub.succ.succ) q($αa) q($αb) | pure none
-          let .defEq (h : _ =Q _) := ← isDefEqQ (u := ub.succ.succ) q($ia) q($ib) | pure none
-          -- return some ⟨ua, αa, ia, ha.mul hb⟩
-          return none
+          let .defEq hα := ← isDefEqQ (u := ub.succ.succ) q($αb) q($αa) | pure none
+          let .defEq hi := ← isDefEqQ (u := ub.succ) q($ib) q($ia) | pure none
+          -- TODO: why don't `hα` and `hi` work here? Do we need `QuotedDefEq.cast`?
+          return some ⟨ua, αa, ia, ← ha.mul <| hb.cast hu .unsafeIntro .unsafeIntro⟩
       else
         return none
-    -- return products.reduceOption.map fun ⟨u, α, i, h⟩ => h.pf.raw
-    return []
-
-#print nlinarithExtras
+    return ls ++ new_es ++ products.reduceOption.map fun ⟨u, α, i, h⟩ => h.pf.raw
 
 end nlinarith
 

--- a/Mathlib/Util/AtomM.lean
+++ b/Mathlib/Util/AtomM.lean
@@ -74,4 +74,74 @@ def AtomM.addAtomQ {u : Level} {α : Q(Type u)} (e : Q($α)) :
   let (n, e') ← AtomM.addAtom e
   return (n, ⟨e', ⟨⟩⟩)
 
+section AtomQM
+
+open scoped Qq
+
+/-- The mutable state of the `AtomQM` monad. -/
+structure AtomQM.State where
+  data : Array <| (u : Level) × (Array <| (α : Q(Type u)) × Array Q($α)) := #[]
+
+/-- The context (read-only state) of the `AtomQM` monad. -/
+structure AtomQM.Context where
+  /-- A simplification to apply to atomic expressions when they are encountered,
+  before interning them in the atom list. -/
+  evalAtom {u : Level} {α : Q(Type u)} (a : Q($α)) : MetaM ((x : Q($α)) × Q($x = $a)) :=
+    pure ⟨a, q(rfl)⟩
+  deriving Inhabited
+
+/-- The monad that `ring` works in. This is only used for collecting atoms. -/
+abbrev AtomQM := ReaderT AtomQM.Context <| StateRefT AtomQM.State MetaM
+
+/-- Run a computation in the `AtomQM` monad. -/
+def AtomQM.run {α : Type} (m : AtomQM α)
+    (evalAtom : ∀ {u : Level} {α : Q(Type u)} (a : Q($α)), MetaM ((x : Q($α)) × Q($x = $a)) :=
+    fun a => pure ⟨a, q(rfl)⟩) :
+    MetaM α :=
+  (m { evalAtom }).run' {}
+
+/-- If an atomic expression has already been encountered, get the index and the stored form of the
+atom (which will be defeq at the specified transparency, but not necessarily syntactically equal).
+If the atomic expression has *not* already been encountered, store it in the list of atoms, and
+return the new index (and the stored form of the atom, which will be itself).
+
+In a normalizing tactic, the expression returned by `addAtomQ` should be considered the normal form.
+-/
+def AtomQM.addAtomQ {u : Level} {α : Q(Type u)} (a : Q($α)) :
+    AtomQM
+      ((Nat × Nat × Nat) × (u' : Level) × (α' : Q(Type u')) × (a' : Q($α')) ×'
+        (hu : u =QL u') ×' (hα : $α =Q $α') ×' (by exact $a : $α') =Q $a') := do
+  let c ← get
+  for hiu : iu in [:c.data.size] do
+    let ⟨u', αs⟩ := c.data[iu]
+    unless ← isLevelDefEq u u' do continue
+    have hu : u =QL u' := .unsafeIntro
+    for hiα : iα in [:αs.size] do
+      let ⟨α', as⟩ := αs[iα]
+      let .defEq hα ← Qq.isDefEqQ (α := q(Type u')) α α' | continue
+      for hia : ia in [:as.size] do
+        have a' := as[ia]
+        let .defEq ha ← Qq.isDefEqQ (α := α') a a' | continue
+        return ⟨(iu, iα, ia), u', α', a', hu, hα, ha⟩
+      -- add a new atom
+      modify fun c : State =>
+        { data :=
+          c.data.modify iu fun ⟨u, αs⟩ =>
+            ⟨u, αs.modify iα fun ⟨α, as⟩ =>
+              ⟨α, as.push a⟩⟩}
+      return ⟨(iu, iα, as.size), u', α', a, hu, hα, .unsafeIntro⟩
+    -- add a new type and atom
+    modify fun c : State =>
+      { data :=
+        c.data.modify iu fun ⟨u, αs⟩ =>
+          ⟨u, αs.push ⟨α, #[a]⟩⟩}
+    return ⟨(iu, αs.size, 0), u', α, a, hu, .unsafeIntro, .unsafeIntro⟩
+  -- add a new level, type, and atom
+  modify fun c : State =>
+    { data := c.data.push ⟨u, #[⟨α, #[a]⟩]⟩}
+  return ⟨(c.data.size, 0, 0), u, α, a, .unsafeIntro, .unsafeIntro, .unsafeIntro⟩
+
+
+end AtomQM
+
 end Mathlib.Tactic

--- a/Mathlib/Util/Qq.lean
+++ b/Mathlib/Util/Qq.lean
@@ -26,7 +26,8 @@ def inferTypeQ' (e : Expr) : MetaM ((u : Level) × (α : Q(Type $u)) × Q($α)) 
   let some v := (← instantiateLevelMVars u).dec | throwError "not a Type{indentExpr e}"
   pure ⟨v, α, e⟩
 
-@[refl]
 theorem QuotedDefEq.rfl {u : Level} {α : Q(Sort u)} {a : Q($α)} : @QuotedDefEq u α a a := ⟨⟩
+
+theorem QuotedLevelDefEq.rfl {u : Level} : @QuotedLevelDefEq u u := ⟨⟩
 
 end Qq

--- a/Mathlib/Util/Qq.lean
+++ b/Mathlib/Util/Qq.lean
@@ -26,6 +26,7 @@ def inferTypeQ' (e : Expr) : MetaM ((u : Level) × (α : Q(Type $u)) × Q($α)) 
   let some v := (← instantiateLevelMVars u).dec | throwError "not a Type{indentExpr e}"
   pure ⟨v, α, e⟩
 
+@[refl]
 theorem QuotedDefEq.rfl {u : Level} {α : Q(Sort u)} {a : Q($α)} : @QuotedDefEq u α a a := ⟨⟩
 
 end Qq


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
