### PR TITLE
[Merged by Bors] - feat(Algebra/Group/Subgroup/Ker): Add `map_lt_map_iff_of_injective`

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Ker.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Ker.lean
@@ -465,7 +465,7 @@ theorem map_subtype_le_map_subtype {G' : Subgroup G} {H K : Subgroup G'} :
 @[to_additive]
 theorem map_lt_map_iff_of_injective {f : G →* N} (hf : Function.Injective f) {H K : Subgroup G} :
     H.map f < K.map f ↔ H < K :=
-  by simp_rw [lt_iff_le_not_le, map_le_map_iff_of_injective hf]
+  lt_iff_lt_of_le_iff_le' (map_le_map_iff_of_injective hf) (map_le_map_iff_of_injective hf)
 
 @[to_additive (attr := simp)]
 theorem map_subtype_lt_map_subtype {G' : Subgroup G} {H K : Subgroup G'} :

--- a/Mathlib/Algebra/Group/Subgroup/Ker.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Ker.lean
@@ -460,7 +460,17 @@ theorem map_le_map_iff_of_injective {f : G →* N} (hf : Function.Injective f) {
 @[to_additive (attr := simp)]
 theorem map_subtype_le_map_subtype {G' : Subgroup G} {H K : Subgroup G'} :
     H.map G'.subtype ≤ K.map G'.subtype ↔ H ≤ K :=
-  map_le_map_iff_of_injective <| by apply Subtype.coe_injective
+  map_le_map_iff_of_injective G'.subtype_injective
+
+@[to_additive]
+theorem map_lt_map_iff_of_injective {f : G →* N} (hf : Function.Injective f) {H K : Subgroup G} :
+    H.map f < K.map f ↔ H < K :=
+  by simp_rw [lt_iff_le_not_le, map_le_map_iff_of_injective hf]
+
+@[to_additive (attr := simp)]
+theorem map_subtype_lt_map_subtype {G' : Subgroup G} {H K : Subgroup G'} :
+    H.map G'.subtype < K.map G'.subtype ↔ H < K :=
+  map_lt_map_iff_of_injective G'.subtype_injective
 
 @[to_additive]
 theorem map_injective {f : G →* N} (h : Function.Injective f) : Function.Injective (map f) :=


### PR DESCRIPTION
This PR adds `lt` versions of `map_le_map_iff_of_injective` and `map_subtype_le_map_subtype`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
