### PR TITLE
[Merged by Bors] - refactor(Analysis/ODE): weaken Lipschitz condition

### DIFF
--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -314,7 +314,6 @@ theorem ODE_solution_unique_of_mem_Ioo
   · have hss : Icc t' t₀ ⊆ Ioo a b :=
       fun _ ht'' ↦ ⟨lt_of_lt_of_le ht'.1 ht''.1, lt_of_le_of_lt ht''.2 ht.2⟩
     have hs : Ioc t' t₀ ⊆ Ioo a b := Ioc_subset_Icc_self.trans hss
-    -- have : ∀ t ∈ Ioc t' t₀, LipschitzOnWith K (v t) (s t) := by exact fun t a ↦ hv t (hs a)
     exact ODE_solution_unique_of_mem_Icc_left
       (fun t'' ht'' ↦ hv t'' ((Ioc_subset_Icc_self.trans hss) ht''))
       (continuousOn_of_forall_continuousAt fun _ ht'' ↦ (hf _ <| hss ht'').1.continuousAt)

--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -244,8 +244,8 @@ theorem ODE_solution_unique_of_mem_Icc_left
     (hgs : ∀ t ∈ Ioc a b, g t ∈ s t)
     (hb : f b = g b) :
     EqOn f g (Icc a b) := by
-  have hv' t : t ∈ Ico (-b) (-a) → LipschitzOnWith K (Neg.neg ∘ (v (-t))) (s (-t)) := by
-    intro ht
+  have hv' : ∀ t ∈ Ico (-b) (-a), LipschitzOnWith K (Neg.neg ∘ (v (-t))) (s (-t)) := by
+    intro t ht
     replace ht : -t ∈ Ioc a b := by
       simp at ht ⊢
       constructor <;> linarith

--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -128,7 +128,6 @@ theorem norm_le_gronwallBound_of_norm_deriv_right_le {f f' : ℝ → E} {δ K ε
 
 variable {v : ℝ → E → E} {s : ℝ → Set E} {K : ℝ≥0} {f g f' g' : ℝ → E} {a b t₀ : ℝ} {εf εg δ : ℝ}
 
--- include hv in
 /-- If `f` and `g` are two approximate solutions of the same ODE, then the distance between them
 can't grow faster than exponentially. This is a simple corollary of Grönwall's inequality, and some
 people call this Grönwall's inequality too.
@@ -301,35 +300,6 @@ theorem ODE_solution_unique_of_mem_Icc
       (fun _ ht' ↦ (hf' _ (hss ht')).hasDerivWithinAt) (fun _ ht' ↦ (hfs _ (hss ht')))
       (hg.mono <| Icc_subset_Icc_left <| le_of_lt ht.1)
       (fun _ ht' ↦ (hg' _ (hss ht')).hasDerivWithinAt) (fun _ ht' ↦ (hgs _ (hss ht'))) heq
-
--- theorem ODE_solution_unique_of_mem_Icc'
---     (hv : ∀ t ∈ Set.Ioo a b, LipschitzOnWith K (v t) (s t))
---     (ht : t₀ ∈ Set.Ioo a b)
---     (hf : ContinuousOn f (Set.Icc a b)) (hf' : ∀ t ∈ Set.Ioo a b, HasDerivAt f (v t (f t)) t)
---     (hfs : ∀ t ∈ Set.Ioo a b, f t ∈ s t) (hg : ContinuousOn g (Set.Icc a b))
---     (hg' : ∀ t ∈ Set.Ioo a b, HasDerivAt g (v t (g t)) t)
---     (hgs : ∀ t ∈ Set.Ioo a b, g t ∈ s t) (heq : f t₀ = g t₀) :
---     Set.EqOn f g (Set.Icc a b) := by
---   let v' : ℝ → E → E := fun t x ↦ if t ∈ Set.Ioo a b then v t x else 0
---   apply ODE_solution_unique_of_mem_Icc (v := v') (s := s) (t₀ := t₀) (K := K)
---   all_goals try assumption
---   · intro t
---     by_cases h : t ∈ Set.Ioo a b
---     · simp only [v', h]
---       simp
---       apply hv _ h
---     · simp only [v', h]
---       simp
---       apply LipschitzWith.lipschitzOnWith
---       apply LipschitzWith.const'
---   · intro t ht
---     simp only [v', ht]
---     simp
---     apply hf' _ ht
---   · intro t ht
---     simp only [v', ht]
---     simp
---     apply hg' _ ht
 
 /-- A version of `ODE_solution_unique_of_mem_Icc` for uniqueness in an open interval. -/
 theorem ODE_solution_unique_of_mem_Ioo

--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -127,9 +127,8 @@ theorem norm_le_gronwallBound_of_norm_deriv_right_le {f f' : ℝ → E} {δ K ε
     (fun x hx _r hr => (hf' x hx).liminf_right_slope_norm_le hr) ha bound
 
 variable {v : ℝ → E → E} {s : ℝ → Set E} {K : ℝ≥0} {f g f' g' : ℝ → E} {a b t₀ : ℝ} {εf εg δ : ℝ}
-  (hv : ∀ t, LipschitzOnWith K (v t) (s t))
 
-include hv in
+-- include hv in
 /-- If `f` and `g` are two approximate solutions of the same ODE, then the distance between them
 can't grow faster than exponentially. This is a simple corollary of Grönwall's inequality, and some
 people call this Grönwall's inequality too.
@@ -137,6 +136,7 @@ people call this Grönwall's inequality too.
 This version assumes all inequalities to be true in some time-dependent set `s t`,
 and assumes that the solutions never leave this set. -/
 theorem dist_le_of_approx_trajectories_ODE_of_mem
+    (hv : ∀ t ∈ Ico a b, LipschitzOnWith K (v t) (s t))
     (hf : ContinuousOn f (Icc a b))
     (hf' : ∀ t ∈ Ico a b, HasDerivWithinAt f (f' t) (Ici t) t)
     (f_bound : ∀ t ∈ Ico a b, dist (f' t) (v t (f t)) ≤ εf)
@@ -153,7 +153,7 @@ theorem dist_le_of_approx_trajectories_ODE_of_mem
   apply norm_le_gronwallBound_of_norm_deriv_right_le (hf.sub hg) h_deriv ha
   intro t ht
   have := dist_triangle4_right (f' t) (g' t) (v t (f t)) (v t (g t))
-  have hv := (hv t).dist_le_mul _ (hfs t ht) _ (hgs t ht)
+  have hv := (hv t ht).dist_le_mul _ (hfs t ht) _ (hgs t ht)
   rw [← dist_eq_norm, ← dist_eq_norm]
   refine this.trans ((add_le_add (add_le_add (f_bound t ht) (g_bound t ht)) hv).trans ?_)
   rw [add_comm]
@@ -174,10 +174,9 @@ theorem dist_le_of_approx_trajectories_ODE
     (ha : dist (f a) (g a) ≤ δ) :
     ∀ t ∈ Icc a b, dist (f t) (g t) ≤ gronwallBound δ K (εf + εg) (t - a) :=
   have hfs : ∀ t ∈ Ico a b, f t ∈ @univ E := fun _ _ => trivial
-  dist_le_of_approx_trajectories_ODE_of_mem (fun t => (hv t).lipschitzOnWith) hf hf'
+  dist_le_of_approx_trajectories_ODE_of_mem (fun t _ => (hv t).lipschitzOnWith) hf hf'
     f_bound hfs hg hg' g_bound (fun _ _ => trivial) ha
 
-include hv in
 /-- If `f` and `g` are two exact solutions of the same ODE, then the distance between them
 can't grow faster than exponentially. This is a simple corollary of Grönwall's inequality, and some
 people call this Grönwall's inequality too.
@@ -185,6 +184,7 @@ people call this Grönwall's inequality too.
 This version assumes all inequalities to be true in some time-dependent set `s t`,
 and assumes that the solutions never leave this set. -/
 theorem dist_le_of_trajectories_ODE_of_mem
+    (hv : ∀ t ∈ Ico a b, LipschitzOnWith K (v t) (s t))
     (hf : ContinuousOn f (Icc a b))
     (hf' : ∀ t ∈ Ico a b, HasDerivWithinAt f (v t (f t)) (Ici t) t)
     (hfs : ∀ t ∈ Ico a b, f t ∈ s t)
@@ -212,16 +212,16 @@ theorem dist_le_of_trajectories_ODE
     (ha : dist (f a) (g a) ≤ δ) :
     ∀ t ∈ Icc a b, dist (f t) (g t) ≤ δ * exp (K * (t - a)) :=
   have hfs : ∀ t ∈ Ico a b, f t ∈ @univ E := fun _ _ => trivial
-  dist_le_of_trajectories_ODE_of_mem (fun t => (hv t).lipschitzOnWith) hf hf' hfs hg
+  dist_le_of_trajectories_ODE_of_mem (fun t _ => (hv t).lipschitzOnWith) hf hf' hfs hg
     hg' (fun _ _ => trivial) ha
 
-include hv in
 /-- There exists only one solution of an ODE \(\dot x=v(t, x)\) in a set `s ⊆ ℝ × E` with
 a given initial value provided that the RHS is Lipschitz continuous in `x` within `s`,
 and we consider only solutions included in `s`.
 
 This version shows uniqueness in a closed interval `Icc a b`, where `a` is the initial time. -/
 theorem ODE_solution_unique_of_mem_Icc_right
+    (hv : ∀ t ∈ Ico a b, LipschitzOnWith K (v t) (s t))
     (hf : ContinuousOn f (Icc a b))
     (hf' : ∀ t ∈ Ico a b, HasDerivWithinAt f (v t (f t)) (Ici t) t)
     (hfs : ∀ t ∈ Ico a b, f t ∈ s t)
@@ -233,10 +233,10 @@ theorem ODE_solution_unique_of_mem_Icc_right
   have := dist_le_of_trajectories_ODE_of_mem hv hf hf' hfs hg hg' hgs (dist_le_zero.2 ha) t ht
   rwa [zero_mul, dist_le_zero] at this
 
-include hv in
 /-- A time-reversed version of `ODE_solution_unique_of_mem_Icc_right`. Uniqueness is shown in a
 closed interval `Icc a b`, where `b` is the "initial" time. -/
 theorem ODE_solution_unique_of_mem_Icc_left
+    (hv : ∀ t ∈ Ioc a b, LipschitzOnWith K (v t) (s t))
     (hf : ContinuousOn f (Icc a b))
     (hf' : ∀ t ∈ Ioc a b, HasDerivWithinAt f (v t (f t)) (Iic t) t)
     (hfs : ∀ t ∈ Ioc a b, f t ∈ s t)
@@ -245,9 +245,13 @@ theorem ODE_solution_unique_of_mem_Icc_left
     (hgs : ∀ t ∈ Ioc a b, g t ∈ s t)
     (hb : f b = g b) :
     EqOn f g (Icc a b) := by
-  have hv' t : LipschitzOnWith K (Neg.neg ∘ (v (-t))) (s (-t)) := by
+  have hv' t : t ∈ Ico (-b) (-a) → LipschitzOnWith K (Neg.neg ∘ (v (-t))) (s (-t)) := by
+    intro ht
+    replace ht : -t ∈ Ioc a b := by
+      simp at ht ⊢
+      constructor <;> linarith
     rw [← one_mul K]
-    exact LipschitzWith.id.neg.comp_lipschitzOnWith (hv _)
+    exact LipschitzWith.id.neg.comp_lipschitzOnWith (hv _ ht)
   have hmt1 : MapsTo Neg.neg (Icc (-b) (-a)) (Icc a b) :=
     fun _ ht ↦ ⟨le_neg.mp ht.2, neg_le.mp ht.1⟩
   have hmt2 : MapsTo Neg.neg (Ico (-b) (-a)) (Ioc a b) :=
@@ -270,10 +274,10 @@ theorem ODE_solution_unique_of_mem_Icc_left
       (hasDerivAt_neg t).hasDerivWithinAt (hmt3 t)
     simp
 
-include hv in
 /-- A version of `ODE_solution_unique_of_mem_Icc_right` for uniqueness in a closed interval whose
 interior contains the initial time. -/
 theorem ODE_solution_unique_of_mem_Icc
+    (hv : ∀ t ∈ Ioo a b, LipschitzOnWith K (v t) (s t))
     (ht : t₀ ∈ Ioo a b)
     (hf : ContinuousOn f (Icc a b))
     (hf' : ∀ t ∈ Ioo a b, HasDerivAt f (v t (f t)) t)
@@ -286,21 +290,50 @@ theorem ODE_solution_unique_of_mem_Icc
   rw [← Icc_union_Icc_eq_Icc (le_of_lt ht.1) (le_of_lt ht.2)]
   apply EqOn.union
   · have hss : Ioc a t₀ ⊆ Ioo a b := Ioc_subset_Ioo_right ht.2
-    exact ODE_solution_unique_of_mem_Icc_left hv
+    exact ODE_solution_unique_of_mem_Icc_left (fun t ht ↦ hv t (hss ht))
       (hf.mono <| Icc_subset_Icc_right <| le_of_lt ht.2)
       (fun _ ht' ↦ (hf' _ (hss ht')).hasDerivWithinAt) (fun _ ht' ↦ (hfs _ (hss ht')))
       (hg.mono <| Icc_subset_Icc_right <| le_of_lt ht.2)
       (fun _ ht' ↦ (hg' _ (hss ht')).hasDerivWithinAt) (fun _ ht' ↦ (hgs _ (hss ht'))) heq
   · have hss : Ico t₀ b ⊆ Ioo a b := Ico_subset_Ioo_left ht.1
-    exact ODE_solution_unique_of_mem_Icc_right hv
+    exact ODE_solution_unique_of_mem_Icc_right (fun t ht ↦ hv t (hss ht))
       (hf.mono <| Icc_subset_Icc_left <| le_of_lt ht.1)
       (fun _ ht' ↦ (hf' _ (hss ht')).hasDerivWithinAt) (fun _ ht' ↦ (hfs _ (hss ht')))
       (hg.mono <| Icc_subset_Icc_left <| le_of_lt ht.1)
       (fun _ ht' ↦ (hg' _ (hss ht')).hasDerivWithinAt) (fun _ ht' ↦ (hgs _ (hss ht'))) heq
 
-include hv in
+-- theorem ODE_solution_unique_of_mem_Icc'
+--     (hv : ∀ t ∈ Set.Ioo a b, LipschitzOnWith K (v t) (s t))
+--     (ht : t₀ ∈ Set.Ioo a b)
+--     (hf : ContinuousOn f (Set.Icc a b)) (hf' : ∀ t ∈ Set.Ioo a b, HasDerivAt f (v t (f t)) t)
+--     (hfs : ∀ t ∈ Set.Ioo a b, f t ∈ s t) (hg : ContinuousOn g (Set.Icc a b))
+--     (hg' : ∀ t ∈ Set.Ioo a b, HasDerivAt g (v t (g t)) t)
+--     (hgs : ∀ t ∈ Set.Ioo a b, g t ∈ s t) (heq : f t₀ = g t₀) :
+--     Set.EqOn f g (Set.Icc a b) := by
+--   let v' : ℝ → E → E := fun t x ↦ if t ∈ Set.Ioo a b then v t x else 0
+--   apply ODE_solution_unique_of_mem_Icc (v := v') (s := s) (t₀ := t₀) (K := K)
+--   all_goals try assumption
+--   · intro t
+--     by_cases h : t ∈ Set.Ioo a b
+--     · simp only [v', h]
+--       simp
+--       apply hv _ h
+--     · simp only [v', h]
+--       simp
+--       apply LipschitzWith.lipschitzOnWith
+--       apply LipschitzWith.const'
+--   · intro t ht
+--     simp only [v', ht]
+--     simp
+--     apply hf' _ ht
+--   · intro t ht
+--     simp only [v', ht]
+--     simp
+--     apply hg' _ ht
+
 /-- A version of `ODE_solution_unique_of_mem_Icc` for uniqueness in an open interval. -/
 theorem ODE_solution_unique_of_mem_Ioo
+    (hv : ∀ t ∈ Ioo a b, LipschitzOnWith K (v t) (s t))
     (ht : t₀ ∈ Ioo a b)
     (hf : ∀ t ∈ Ioo a b, HasDerivAt f (v t (f t)) t ∧ f t ∈ s t)
     (hg : ∀ t ∈ Ioo a b, HasDerivAt g (v t (g t)) t ∧ g t ∈ s t)
@@ -310,7 +343,10 @@ theorem ODE_solution_unique_of_mem_Ioo
   rcases lt_or_le t' t₀ with (h | h)
   · have hss : Icc t' t₀ ⊆ Ioo a b :=
       fun _ ht'' ↦ ⟨lt_of_lt_of_le ht'.1 ht''.1, lt_of_le_of_lt ht''.2 ht.2⟩
-    exact ODE_solution_unique_of_mem_Icc_left hv
+    have hs : Ioc t' t₀ ⊆ Ioo a b := Ioc_subset_Icc_self.trans hss
+    -- have : ∀ t ∈ Ioc t' t₀, LipschitzOnWith K (v t) (s t) := by exact fun t a ↦ hv t (hs a)
+    exact ODE_solution_unique_of_mem_Icc_left
+      (fun t'' ht'' ↦ hv t'' ((Ioc_subset_Icc_self.trans hss) ht''))
       (continuousOn_of_forall_continuousAt fun _ ht'' ↦ (hf _ <| hss ht'').1.continuousAt)
       (fun _ ht'' ↦ (hf _ <| hss <| Ioc_subset_Icc_self ht'').1.hasDerivWithinAt)
       (fun _ ht'' ↦ (hf _ <| hss <| Ioc_subset_Icc_self ht'').2)
@@ -320,7 +356,8 @@ theorem ODE_solution_unique_of_mem_Ioo
       ⟨le_rfl, le_of_lt h⟩
   · have hss : Icc t₀ t' ⊆ Ioo a b :=
       fun _ ht'' ↦ ⟨lt_of_lt_of_le ht.1 ht''.1, lt_of_le_of_lt ht''.2 ht'.2⟩
-    exact ODE_solution_unique_of_mem_Icc_right hv
+    exact ODE_solution_unique_of_mem_Icc_right
+      (fun t'' ht'' ↦ hv t'' ((Ico_subset_Icc_self.trans hss) ht''))
       (continuousOn_of_forall_continuousAt fun _ ht'' ↦ (hf _ <| hss ht'').1.continuousAt)
       (fun _ ht'' ↦ (hf _ <| hss <| Ico_subset_Icc_self ht'').1.hasDerivWithinAt)
       (fun _ ht'' ↦ (hf _ <| hss <| Ico_subset_Icc_self ht'').2)
@@ -329,18 +366,19 @@ theorem ODE_solution_unique_of_mem_Ioo
       (fun _ ht'' ↦ (hg _ <| hss <| Ico_subset_Icc_self ht'').2) heq
       ⟨h, le_rfl⟩
 
-include hv in
 /-- Local unqueness of ODE solutions. -/
 theorem ODE_solution_unique_of_eventually
+    (hv : ∀ᶠ t in 𝓝 t₀, LipschitzOnWith K (v t) (s t))
     (hf : ∀ᶠ t in 𝓝 t₀, HasDerivAt f (v t (f t)) t ∧ f t ∈ s t)
     (hg : ∀ᶠ t in 𝓝 t₀, HasDerivAt g (v t (g t)) t ∧ g t ∈ s t)
     (heq : f t₀ = g t₀) : f =ᶠ[𝓝 t₀] g := by
-  obtain ⟨ε, hε, h⟩ := eventually_nhds_iff_ball.mp (hf.and hg)
+  obtain ⟨ε, hε, h⟩ := eventually_nhds_iff_ball.mp (hv.and (hf.and hg))
   rw [Filter.eventuallyEq_iff_exists_mem]
   refine ⟨ball t₀ ε, ball_mem_nhds _ hε, ?_⟩
   simp_rw [Real.ball_eq_Ioo] at *
-  apply ODE_solution_unique_of_mem_Ioo hv (Real.ball_eq_Ioo t₀ ε ▸ mem_ball_self hε)
-    (fun _ ht ↦ (h _ ht).1) (fun _ ht ↦ (h _ ht).2) heq
+  apply ODE_solution_unique_of_mem_Ioo (fun _ ht ↦ (h _ ht).1)
+    (Real.ball_eq_Ioo t₀ ε ▸ mem_ball_self hε)
+    (fun _ ht ↦ (h _ ht).2.1) (fun _ ht ↦ (h _ ht).2.2) heq
 
 /-- There exists only one solution of an ODE \(\dot x=v(t, x)\) with
 a given initial value provided that the RHS is Lipschitz continuous in `x`. -/
@@ -353,5 +391,5 @@ theorem ODE_solution_unique
     (ha : f a = g a) :
     EqOn f g (Icc a b) :=
   have hfs : ∀ t ∈ Ico a b, f t ∈ @univ E := fun _ _ => trivial
-  ODE_solution_unique_of_mem_Icc_right (fun t => (hv t).lipschitzOnWith) hf hf' hfs hg hg'
+  ODE_solution_unique_of_mem_Icc_right (fun t _ => (hv t).lipschitzOnWith) hf hf' hfs hg hg'
     (fun _ _ => trivial) ha

--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -313,7 +313,6 @@ theorem ODE_solution_unique_of_mem_Ioo
   rcases lt_or_le t' t₀ with (h | h)
   · have hss : Icc t' t₀ ⊆ Ioo a b :=
       fun _ ht'' ↦ ⟨lt_of_lt_of_le ht'.1 ht''.1, lt_of_le_of_lt ht''.2 ht.2⟩
-    have hs : Ioc t' t₀ ⊆ Ioo a b := Ioc_subset_Icc_self.trans hss
     exact ODE_solution_unique_of_mem_Icc_left
       (fun t'' ht'' ↦ hv t'' ((Ioc_subset_Icc_self.trans hss) ht''))
       (continuousOn_of_forall_continuousAt fun _ ht'' ↦ (hf _ <| hss ht'').1.continuousAt)

--- a/Mathlib/Geometry/Manifold/IntegralCurve/ExistUnique.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/ExistUnique.lean
@@ -162,7 +162,7 @@ theorem isIntegralCurveAt_eventuallyEq_of_contMDiffAt (hγt₀ : I.IsInteriorPoi
   -- main proof
   suffices (extChartAt I (γ t₀)) ∘ γ =ᶠ[𝓝 t₀] (extChartAt I (γ' t₀)) ∘ γ' from
     (heq hγ).trans <| (this.fun_comp (extChartAt I (γ t₀)).symm).trans (h ▸ (heq hγ').symm)
-  exact ODE_solution_unique_of_eventually hlip
+  exact ODE_solution_unique_of_eventually (Filter.Eventually.of_forall hlip)
     (hdrv hγ rfl) (hdrv hγ' h) (by rw [Function.comp_apply, Function.comp_apply, h])
 
 theorem isIntegralCurveAt_eventuallyEq_of_contMDiffAt_boundaryless [BoundarylessManifold I M]

--- a/Mathlib/Geometry/Manifold/IntegralCurve/ExistUnique.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/ExistUnique.lean
@@ -162,7 +162,7 @@ theorem isIntegralCurveAt_eventuallyEq_of_contMDiffAt (hγt₀ : I.IsInteriorPoi
   -- main proof
   suffices (extChartAt I (γ t₀)) ∘ γ =ᶠ[𝓝 t₀] (extChartAt I (γ' t₀)) ∘ γ' from
     (heq hγ).trans <| (this.fun_comp (extChartAt I (γ t₀)).symm).trans (h ▸ (heq hγ').symm)
-  exact ODE_solution_unique_of_eventually (Filter.Eventually.of_forall hlip)
+  exact ODE_solution_unique_of_eventually (.of_forall hlip)
     (hdrv hγ rfl) (hdrv hγ' h) (by rw [Function.comp_apply, Function.comp_apply, h])
 
 theorem isIntegralCurveAt_eventuallyEq_of_contMDiffAt_boundaryless [BoundarylessManifold I M]


### PR DESCRIPTION
Replace the assumption `∀ t, LipschitzOnWith K (v t) (s t)` with `∀ t ∈ I, LipschitzOnWith K (v t) (s t)` with an appropriate interval `I` in lemmas from `Analysis.ODE.Gronwall`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
