### PR TITLE
[Merged by Bors] - feat: add some nontriviality results on tensor product

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4568,6 +4568,7 @@ import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.RingTheory.TensorProduct.Finite
 import Mathlib.RingTheory.TensorProduct.Free
 import Mathlib.RingTheory.TensorProduct.MvPolynomial
+import Mathlib.RingTheory.TensorProduct.Nontrivial
 import Mathlib.RingTheory.TensorProduct.Pi
 import Mathlib.RingTheory.Trace.Basic
 import Mathlib.RingTheory.Trace.Defs

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -56,11 +56,13 @@ See <https://stacks.math.columbia.edu/tag/00HD>.
 
 universe v' u v w
 
+open TensorProduct
+
 namespace Module
 
 open Function (Surjective)
 
-open LinearMap Submodule TensorProduct DirectSum
+open LinearMap Submodule DirectSum
 
 variable (R : Type u) (M : Type v) [CommRing R] [AddCommGroup M] [Module R M]
 
@@ -426,8 +428,6 @@ end Module
 
 section Injective
 
-open scoped TensorProduct
-
 variable {R S A B : Type*} [CommRing R] [Ring A] [Algebra R A] [Ring B] [Algebra R B]
   [CommSemiring S] [Algebra S A] [SMulCommClass R S A]
 
@@ -448,3 +448,47 @@ theorem includeRight_injective [Module.Flat R B] (ha : Function.Injective (algeb
 end Algebra.TensorProduct
 
 end Injective
+
+section Nontrivial
+
+variable (R : Type*) [CommRing R]
+
+namespace TensorProduct
+
+variable (M N : Type*) [AddCommGroup M] [AddCommGroup N] [Module R M] [Module R N]
+
+/-- If `M`, `N` are `R`-modules, there exists an injective `R`-linear map from `R` to `N`,
+and `M` is a nontrivial flat `R`-module, then `M ⊗[R] N` is nontrivial. -/
+theorem nontrivial_of_linearMap_injective_of_flat_left (f : R →ₗ[R] N) (h : Function.Injective f)
+    [Module.Flat R M] [Nontrivial M] : Nontrivial (M ⊗[R] N) :=
+  Module.Flat.lTensor_preserves_injective_linearMap (M := M) f h |>.comp
+    (TensorProduct.rid R M).symm.injective |>.nontrivial
+
+/-- If `M`, `N` are `R`-modules, there exists an injective `R`-linear map from `R` to `M`,
+and `N` is a nontrivial flat `R`-module, then `M ⊗[R] N` is nontrivial. -/
+theorem nontrivial_of_linearMap_injective_of_flat_right (f : R →ₗ[R] M) (h : Function.Injective f)
+    [Module.Flat R N] [Nontrivial N] : Nontrivial (M ⊗[R] N) :=
+  Module.Flat.rTensor_preserves_injective_linearMap (M := N) f h |>.comp
+    (TensorProduct.lid R N).symm.injective |>.nontrivial
+
+end TensorProduct
+
+namespace Algebra.TensorProduct
+
+variable (A B : Type*) [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
+
+/-- If `A`, `B` are `R`-algebras, `R` injects into `B`,
+and `A` is a nontrivial flat `R`-algebra, then `A ⊗[R] B` is nontrivial. -/
+theorem nontrivial_of_algebraMap_injective_of_flat_left (h : Function.Injective (algebraMap R B))
+    [Module.Flat R A] [Nontrivial A] : Nontrivial (A ⊗[R] B) :=
+  TensorProduct.nontrivial_of_linearMap_injective_of_flat_left R A B (Algebra.linearMap R B) h
+
+/-- If `A`, `B` are `R`-algebras, `R` injects into `A`,
+and `B` is a nontrivial flat `R`-algebra, then `A ⊗[R] B` is nontrivial. -/
+theorem nontrivial_of_algebraMap_injective_of_flat_right (h : Function.Injective (algebraMap R A))
+    [Module.Flat R B] [Nontrivial B] : Nontrivial (A ⊗[R] B) :=
+  TensorProduct.nontrivial_of_linearMap_injective_of_flat_right R A B (Algebra.linearMap R A) h
+
+end Algebra.TensorProduct
+
+end Nontrivial

--- a/Mathlib/RingTheory/TensorProduct/Nontrivial.lean
+++ b/Mathlib/RingTheory/TensorProduct/Nontrivial.lean
@@ -19,12 +19,13 @@ open TensorProduct
 
 namespace Algebra.TensorProduct
 
-/-- If `A`, `B` are `R`-algebras, `R` injects into `A` and `B`,
-and all of them are domains, then `A ⊗[R] B` is nontrivial. -/
+/-- If `A`, `B` are `R`-algebras, `R` injects into `A` and `B`, and `A` and `B` are domains
+(which implies `R` is also a domain), then `A ⊗[R] B` is nontrivial. -/
 theorem nontrivial_of_algebraMap_injective_of_isDomain
     (R A B : Type*) [CommRing R] [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
     (ha : Function.Injective (algebraMap R A)) (hb : Function.Injective (algebraMap R B))
-    [IsDomain R] [IsDomain A] [IsDomain B] : Nontrivial (A ⊗[R] B) := by
+    [IsDomain A] [IsDomain B] : Nontrivial (A ⊗[R] B) := by
+  haveI := ha.isDomain _
   let FR := FractionRing R
   let FA := FractionRing A
   let FB := FractionRing B

--- a/Mathlib/RingTheory/TensorProduct/Nontrivial.lean
+++ b/Mathlib/RingTheory/TensorProduct/Nontrivial.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jz Pan
 -/
 import Mathlib.LinearAlgebra.Basis.VectorSpace
-import Mathlib.RingTheory.Flat.Basic
+import Mathlib.RingTheory.Flat.FaithfullyFlat
 import Mathlib.RingTheory.Localization.FractionRing
 
 /-!
@@ -18,12 +18,6 @@ This file contains some more results on nontriviality of tensor product of algeb
 open TensorProduct
 
 namespace Algebra.TensorProduct
-
-/-- If `A`, `B` are nontrivial algebras over a field `F`, then `A ⊗[F] B` is nontrivial. -/
-theorem nontrivial_of_field
-    (F A B : Type*) [Field F] [CommRing A] [CommRing B] [Algebra F A] [Algebra F B]
-    [Nontrivial A] [Nontrivial B] : Nontrivial (A ⊗[F] B) :=
-  nontrivial_of_algebraMap_injective_of_flat_left F A B (RingHom.injective _)
 
 /-- If `A`, `B` are `R`-algebras, `R` injects into `A` and `B`,
 and all of them are domains, then `A ⊗[R] B` is nontrivial. -/
@@ -39,7 +33,6 @@ theorem nontrivial_of_algebraMap_injective_of_isDomain
   let fb : FR →ₐ[R] FB := IsFractionRing.liftAlgHom (g := Algebra.ofId R FB)
     ((IsFractionRing.injective B FB).comp hb)
   algebraize_only [fa.toRingHom, fb.toRingHom]
-  have := nontrivial_of_field FR FA FB
   exact Algebra.TensorProduct.mapOfCompatibleSMul FR R FA FB |>.comp
     (Algebra.TensorProduct.map (IsScalarTower.toAlgHom R A FA) (IsScalarTower.toAlgHom R B FB))
     |>.toRingHom.domain_nontrivial

--- a/Mathlib/RingTheory/TensorProduct/Nontrivial.lean
+++ b/Mathlib/RingTheory/TensorProduct/Nontrivial.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2024 Jz Pan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jz Pan
+-/
+import Mathlib.LinearAlgebra.Basis.VectorSpace
+import Mathlib.RingTheory.Flat.Basic
+import Mathlib.RingTheory.Localization.FractionRing
+
+/-!
+
+# Nontriviality of tensor product of algebras
+
+This file contains some more results on nontriviality of tensor product of algebras.
+
+-/
+
+open TensorProduct
+
+namespace Algebra.TensorProduct
+
+/-- If `A`, `B` are nontrivial algebras over a field `F`, then `A ⊗[F] B` is nontrivial. -/
+theorem nontrivial_of_field
+    (F A B : Type*) [Field F] [CommRing A] [CommRing B] [Algebra F A] [Algebra F B]
+    [Nontrivial A] [Nontrivial B] : Nontrivial (A ⊗[F] B) :=
+  nontrivial_of_algebraMap_injective_of_flat_left F A B (RingHom.injective _)
+
+/-- If `A`, `B` are `R`-algebras, `R` injects into `A` and `B`,
+and all of them are domains, then `A ⊗[R] B` is nontrivial. -/
+theorem nontrivial_of_algebraMap_injective_of_isDomain
+    (R A B : Type*) [CommRing R] [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
+    (ha : Function.Injective (algebraMap R A)) (hb : Function.Injective (algebraMap R B))
+    [IsDomain R] [IsDomain A] [IsDomain B] : Nontrivial (A ⊗[R] B) := by
+  let FR := FractionRing R
+  let FA := FractionRing A
+  let FB := FractionRing B
+  let fa : FR →ₐ[R] FA := IsFractionRing.liftAlgHom (g := Algebra.ofId R FA)
+    ((IsFractionRing.injective A FA).comp ha)
+  let fb : FR →ₐ[R] FB := IsFractionRing.liftAlgHom (g := Algebra.ofId R FB)
+    ((IsFractionRing.injective B FB).comp hb)
+  algebraize_only [fa.toRingHom, fb.toRingHom]
+  have := nontrivial_of_field FR FA FB
+  exact Algebra.TensorProduct.mapOfCompatibleSMul FR R FA FB |>.comp
+    (Algebra.TensorProduct.map (IsScalarTower.toAlgHom R A FA) (IsScalarTower.toAlgHom R B FB))
+    |>.toRingHom.domain_nontrivial
+
+end Algebra.TensorProduct


### PR DESCRIPTION
- `TensorProduct.nontrivial_of_linearMap_injective_of_flat_(left|right)`: if there is an injective linear map from the base ring to a module, and another module is nontrivial and flat, then their tensor product is nontrivial.
- `Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_flat_(left|right)`: if there is an algebra whose algebra map is injective, and there is another nontrivial flat algebra, then their tensor product is nontrivial.
- `Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_isDomain`: tensor product of two domains is nontrivial, provided that two algebra maps are injective.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
