### PR TITLE
[Merged by Bors] - doc(RingTheory/Polynomial/HilbertPoly): fix a typo

### DIFF
--- a/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
+++ b/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
@@ -21,10 +21,10 @@ This `h` is unique and is denoted as `Polynomial.hilbertPoly p d`.
 
 For example, given `d : ℕ`, the power series expansion of `1/(1-X)ᵈ⁺¹` in `F[X]`
 is `Σₙ ((d + n).choose d)Xⁿ`, which equals `Σₙ ((n + 1)···(n + d)/d!)Xⁿ` and hence
-`Polynomial.hilbertPoly (1 : F[X]) (d + 1)` is the polynomial `(n + 1)···(n + d)/d!`. Note that
-if `d! = 0` in `F`, then the polynomial `(n + 1)···(n + d)/d!` no longer works, so we do not
-want the characteristic of `F` to be divisible by `d!`. As `Polynomial.hilbertPoly` may take
-any `p : F[X]` and `d : ℕ` as its inputs, it is necessary for us to assume that `CharZero F`.
+`Polynomial.hilbertPoly (1 : F[X]) (d + 1)` is the polynomial `(X + 1)···(X + d)/d!`. Note that
+if `d! = 0` in `F`, then the polynomial `(X + 1)···(X + d)/d!` no longer works, so we do not want
+the characteristic of `F` to be divisible by `d!`. As `Polynomial.hilbertPoly` may take any
+`p : F[X]` and `d : ℕ` as its inputs, it is necessary for us to assume that `CharZero F`.
 
 ## Main definitions
 


### PR DESCRIPTION
In this pull request, we fix a typo in the file RingTheory/Polynomial/HilbertPoly.lean: originally, the docstring at the beginning of the file said "the polynomial `(n + 1)···(n + d)/d!`". But because the polynomial we mention is in `F[X]`, we must change it to `(X + 1)···(X + d)/d!`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)