### PR TITLE
[Merged by Bors] - chore: simplify variables in LinearAlgebra.Dimension.Torsion.Finite

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/Torsion/Finite.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Torsion/Finite.lean
@@ -11,29 +11,14 @@ import Mathlib.LinearAlgebra.Dimension.Finite
 
 -/
 
-universe u v
+variable {R M : Type*} [CommRing R] [IsDomain R] [AddCommGroup M] [Module R M]
 
-variable {R : Type u} {M : Type v}
-variable [Ring R] [AddCommGroup M]
-
-section RankZero
-
-variable [Nontrivial R]
-
-lemma rank_eq_zero_iff_isTorsion {R M} [CommRing R] [IsDomain R] [AddCommGroup M] [Module R M] :
-    Module.rank R M = 0 ↔ Module.IsTorsion R M := by
+lemma rank_eq_zero_iff_isTorsion: Module.rank R M = 0 ↔ Module.IsTorsion R M := by
   rw [Module.IsTorsion, rank_eq_zero_iff]
   simp [mem_nonZeroDivisors_iff_ne_zero]
 
-end RankZero
-
-section StrongRankCondition
-
 /-- The `StrongRankCondition` is automatic. See `commRing_strongRankCondition`. -/
-theorem Module.finrank_eq_zero_iff_isTorsion {R} [CommRing R] [StrongRankCondition R]
-    [IsDomain R] [Module R M] [Module.Finite R M] :
+theorem Module.finrank_eq_zero_iff_isTorsion [StrongRankCondition R] [Module.Finite R M] :
     finrank R M = 0 ↔ Module.IsTorsion R M := by
   rw [← rank_eq_zero_iff_isTorsion (R := R), ← finrank_eq_rank]
   norm_cast
-
-end StrongRankCondition


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
