### PR TITLE
[Merged by Bors] - feat(Rat): `(q₁ + q₂).den ∣ q₁.den.lcm q₂.den`

### DIFF
--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -63,17 +63,12 @@ theorem den_mk (n d : ℤ) : (n /. d).den = if d = 0 then 1 else d.natAbs / n.gc
     simp [divInt, mkRat, Rat.normalize, Nat.succPNat, Int.sign, Int.gcd,
       if_neg (Nat.cast_add_one_ne_zero _), this]
 
-theorem add_den_dvd (q₁ q₂ : ℚ) : (q₁ + q₂).den ∣ q₁.den * q₂.den := by
-  rw [add_def, normalize_eq]
-  apply Nat.div_dvd_of_dvd
-  apply Nat.gcd_dvd_right
-
 theorem add_den_dvd_lcm (q₁ q₂ : ℚ) : (q₁ + q₂).den ∣ q₁.den.lcm q₂.den := by
   rw [Rat.add_def, Rat.normalize_eq,
     Nat.div_dvd_iff_dvd_mul
       (Nat.gcd_dvd_right _ _)
       (Nat.gcd_ne_zero_right (mul_ne_zero (Rat.den_ne_zero _) (Rat.den_ne_zero _))),
-    ← Nat.gcd_mul_lcm _ _,
+    ← Nat.gcd_mul_lcm,
     mul_dvd_mul_iff_right (Nat.lcm_ne_zero (Rat.den_ne_zero _) (Rat.den_ne_zero _)),
     Nat.dvd_gcd_iff]
   constructor
@@ -82,6 +77,11 @@ theorem add_den_dvd_lcm (q₁ q₂ : ℚ) : (q₁ + q₂).den ∣ q₁.den.lcm q
       <;> apply dvd_mul_of_dvd_right <;> rw [Int.natCast_dvd_natCast]
       <;> [exact Nat.gcd_dvd_right _ _; exact Nat.gcd_dvd_left _ _]
   · exact dvd_mul_right _ _
+
+theorem add_den_dvd (q₁ q₂ : ℚ) : (q₁ + q₂).den ∣ q₁.den * q₂.den := by
+  rw [add_def, normalize_eq]
+  apply Nat.div_dvd_of_dvd
+  apply Nat.gcd_dvd_right
 
 theorem mul_den_dvd (q₁ q₂ : ℚ) : (q₁ * q₂).den ∣ q₁.den * q₂.den := by
   rw [mul_def, normalize_eq]

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -68,6 +68,23 @@ theorem add_den_dvd (q₁ q₂ : ℚ) : (q₁ + q₂).den ∣ q₁.den * q₂.de
   apply Nat.div_dvd_of_dvd
   apply Nat.gcd_dvd_right
 
+theorem add_den_dvd_lcm (q₁ q₂: ℚ) : (q₁ + q₂).den ∣ q₁.den.lcm q₂.den := by
+  rw [
+    Rat.add_def, Rat.normalize_eq,
+    Nat.div_dvd_iff_dvd_mul
+      (Nat.gcd_dvd_right _ _)
+      (Nat.gcd_ne_zero_right (mul_ne_zero (Rat.den_ne_zero _) (Rat.den_ne_zero _))),
+    ← Nat.gcd_mul_lcm _ _,
+    mul_dvd_mul_iff_right (Nat.lcm_ne_zero (Rat.den_ne_zero _) (Rat.den_ne_zero _)),
+    Nat.dvd_gcd_iff
+  ]
+  constructor
+  · rw [← Int.natCast_dvd_natCast, Int.dvd_natAbs]
+    apply Int.dvd_add
+      <;> apply Dvd.dvd.mul_left <;> rw [Int.natCast_dvd_natCast]
+      <;> [exact Nat.gcd_dvd_right _ _ ; exact Nat.gcd_dvd_left _ _]
+  · exact dvd_mul_right _ _
+
 theorem mul_den_dvd (q₁ q₂ : ℚ) : (q₁ * q₂).den ∣ q₁.den * q₂.den := by
   rw [mul_def, normalize_eq]
   apply Nat.div_dvd_of_dvd

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -64,19 +64,14 @@ theorem den_mk (n d : ℤ) : (n /. d).den = if d = 0 then 1 else d.natAbs / n.gc
       if_neg (Nat.cast_add_one_ne_zero _), this]
 
 theorem add_den_dvd_lcm (q₁ q₂ : ℚ) : (q₁ + q₂).den ∣ q₁.den.lcm q₂.den := by
-  rw [Rat.add_def, Rat.normalize_eq,
-    Nat.div_dvd_iff_dvd_mul
-      (Nat.gcd_dvd_right _ _)
-      (Nat.gcd_ne_zero_right (mul_ne_zero (Rat.den_ne_zero _) (Rat.den_ne_zero _))),
-    ← Nat.gcd_mul_lcm,
-    mul_dvd_mul_iff_right (Nat.lcm_ne_zero (Rat.den_ne_zero _) (Rat.den_ne_zero _)),
-    Nat.dvd_gcd_iff]
-  constructor
-  · rw [← Int.natCast_dvd_natCast, Int.dvd_natAbs]
-    apply Int.dvd_add
-      <;> apply dvd_mul_of_dvd_right <;> rw [Int.natCast_dvd_natCast]
-      <;> [exact Nat.gcd_dvd_right _ _; exact Nat.gcd_dvd_left _ _]
-  · exact dvd_mul_right _ _
+  rw [add_def, normalize_eq, Nat.div_dvd_iff_dvd_mul (Nat.gcd_dvd_right _ _)
+    (Nat.gcd_ne_zero_right (by simp)), ← Nat.gcd_mul_lcm,
+    mul_dvd_mul_iff_right (Nat.lcm_ne_zero (by simp) (by simp)), Nat.dvd_gcd_iff]
+  refine ⟨?_, dvd_mul_right _ _⟩
+  rw [← Int.natCast_dvd_natCast, Int.dvd_natAbs]
+  apply Int.dvd_add
+    <;> apply dvd_mul_of_dvd_right <;> rw [Int.natCast_dvd_natCast]
+    <;> [exact Nat.gcd_dvd_right _ _; exact Nat.gcd_dvd_left _ _]
 
 theorem add_den_dvd (q₁ q₂ : ℚ) : (q₁ + q₂).den ∣ q₁.den * q₂.den := by
   rw [add_def, normalize_eq]

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -68,20 +68,18 @@ theorem add_den_dvd (q₁ q₂ : ℚ) : (q₁ + q₂).den ∣ q₁.den * q₂.de
   apply Nat.div_dvd_of_dvd
   apply Nat.gcd_dvd_right
 
-theorem add_den_dvd_lcm (q₁ q₂: ℚ) : (q₁ + q₂).den ∣ q₁.den.lcm q₂.den := by
-  rw [
-    Rat.add_def, Rat.normalize_eq,
+theorem add_den_dvd_lcm (q₁ q₂ : ℚ) : (q₁ + q₂).den ∣ q₁.den.lcm q₂.den := by
+  rw [Rat.add_def, Rat.normalize_eq,
     Nat.div_dvd_iff_dvd_mul
       (Nat.gcd_dvd_right _ _)
       (Nat.gcd_ne_zero_right (mul_ne_zero (Rat.den_ne_zero _) (Rat.den_ne_zero _))),
     ← Nat.gcd_mul_lcm _ _,
     mul_dvd_mul_iff_right (Nat.lcm_ne_zero (Rat.den_ne_zero _) (Rat.den_ne_zero _)),
-    Nat.dvd_gcd_iff
-  ]
+    Nat.dvd_gcd_iff]
   constructor
   · rw [← Int.natCast_dvd_natCast, Int.dvd_natAbs]
     apply Int.dvd_add
-      <;> apply Dvd.dvd.mul_left <;> rw [Int.natCast_dvd_natCast]
+      <;> apply dvd_mul_of_dvd_right <;> rw [Int.natCast_dvd_natCast]
       <;> [exact Nat.gcd_dvd_right _ _; exact Nat.gcd_dvd_left _ _]
   · exact dvd_mul_right _ _
 

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -82,7 +82,7 @@ theorem add_den_dvd_lcm (q₁ q₂: ℚ) : (q₁ + q₂).den ∣ q₁.den.lcm q�
   · rw [← Int.natCast_dvd_natCast, Int.dvd_natAbs]
     apply Int.dvd_add
       <;> apply Dvd.dvd.mul_left <;> rw [Int.natCast_dvd_natCast]
-      <;> [exact Nat.gcd_dvd_right _ _ ; exact Nat.gcd_dvd_left _ _]
+      <;> [exact Nat.gcd_dvd_right _ _; exact Nat.gcd_dvd_left _ _]
   · exact dvd_mul_right _ _
 
 theorem mul_den_dvd (q₁ q₂ : ℚ) : (q₁ * q₂).den ∣ q₁.den * q₂.den := by


### PR DESCRIPTION
add a useful theorem `Rat.add_den_dvd_lcm` that claims that the denominator of the addition of two rational numbers divides the LCM of the denominators of its terms. A stronger result than `Rat.add_den_dvd` that is already present, which still remains useful in many cases.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
