### PR TITLE
[Merged by Bors] - chore: fix some notation commands

### DIFF
--- a/Mathlib/Algebra/Category/Grp/EpiMono.lean
+++ b/Mathlib/Algebra/Category/Grp/EpiMono.lean
@@ -88,13 +88,12 @@ theorem mono_iff_injective : Mono f ↔ Function.Injective f :=
 
 namespace SurjectiveOfEpiAuxs
 
-set_option quotPrecheck false in
-local notation "X" => Set.range (· • (f.range : Set B) : B → Set B)
+local notation3 "X" => Set.range (· • (f.range : Set B) : B → Set B)
 
 /-- Define `X'` to be the set of all left cosets with an extra point at "infinity".
 -/
 inductive XWithInfinity
-  | fromCoset : Set.range (· • (f.range : Set B) : B → Set B) → XWithInfinity
+  | fromCoset : X → XWithInfinity
   | infinity : XWithInfinity
 
 open XWithInfinity Equiv.Perm
@@ -222,7 +221,7 @@ The strategy is the following: assuming `epi f`
 -/
 
 
-theorem g_apply_fromCoset (x : B) (y : Set.range (· • (f.range : Set B) : B → Set B)) :
+theorem g_apply_fromCoset (x : B) (y : X) :
     g x (fromCoset y) = fromCoset ⟨x • ↑y,
       by obtain ⟨z, hz⟩ := y.2; exact ⟨x * z, by simp [← hz, smul_smul]⟩⟩ := rfl
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
@@ -89,13 +89,11 @@ open Function
 
 variable {M₀ G₀ : Type*} (α : Type*)
 
-set_option quotPrecheck false in
-/-- Local notation for the nonnegative elements of a type `α`. TODO: actually make local. -/
-notation "α≥0" => { x : α // 0 ≤ x }
+/-- Local notation for the nonnegative elements of a type `α`. -/
+local notation3 "α≥0" => { x : α // 0 ≤ x }
 
-set_option quotPrecheck false in
-/-- Local notation for the positive elements of a type `α`. TODO: actually make local. -/
-notation "α>0" => { x : α // 0 < x }
+/-- Local notation for the positive elements of a type `α`. -/
+local notation3 "α>0" => { x : α // 0 < x }
 
 section Abbreviations
 

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -484,10 +484,9 @@ instance : Category (CosimplicialObject C) := by
 
 namespace CosimplicialObject
 
-set_option quotPrecheck false in
 /-- `X _[n]` denotes the `n`th-term of the cosimplicial object X -/
 scoped[Simplicial]
-  notation:1000 X " _[" n "]" =>
+  notation3:1000 X " _[" n "]" =>
     (X : CategoryTheory.CosimplicialObject _).obj (SimplexCategory.mk n)
 
 instance {J : Type v} [SmallCategory J] [HasLimitsOfShape J C] :

--- a/Mathlib/Geometry/Manifold/Diffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/Diffeomorph.lean
@@ -83,7 +83,7 @@ scoped[Manifold] notation E " ≃ₘ^" n:1000 "[" 𝕜 "] " E' => Diffeomorph �
 
 /-- Infinitely differentiable diffeomorphism between `E` and `E'`. -/
 scoped[Manifold]
-  notation E " ≃ₘ[" 𝕜 "] " E' =>
+  notation3 E " ≃ₘ[" 𝕜 "] " E' =>
     Diffeomorph (modelWithCornersSelf 𝕜 E) (modelWithCornersSelf 𝕜 E') E E' ⊤
 
 namespace Diffeomorph

--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -219,13 +219,13 @@ def modelWithCornersEuclideanQuadrant (n : ℕ) :
 
 /-- The model space used to define `n`-dimensional real manifolds without boundary. -/
 scoped[Manifold]
-  notation "𝓡 " n =>
+  notation3 "𝓡 " n =>
     (modelWithCornersSelf ℝ (EuclideanSpace ℝ (Fin n)) :
       ModelWithCorners ℝ (EuclideanSpace ℝ (Fin n)) (EuclideanSpace ℝ (Fin n)))
 
 /-- The model space used to define `n`-dimensional real manifolds with boundary. -/
 scoped[Manifold]
-  notation "𝓡∂ " n =>
+  notation3 "𝓡∂ " n =>
     (modelWithCornersEuclideanHalfSpace n :
       ModelWithCorners ℝ (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace n))
 

--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -710,9 +710,8 @@ theorem le_iff' : v ≤ w ↔ ∀ i, v i ≤ w i := by
 
 end
 
-set_option quotPrecheck false in -- Porting note: error message suggested to do this
 scoped[MeasureTheory]
-  notation:50 v " ≤[" i:50 "] " w:50 =>
+  notation3:50 v " ≤[" i:50 "] " w:50 =>
     MeasureTheory.VectorMeasure.restrict v i ≤ MeasureTheory.VectorMeasure.restrict w i
 
 section

--- a/Mathlib/RingTheory/WittVector/Isocrystal.lean
+++ b/Mathlib/RingTheory/WittVector/Isocrystal.lean
@@ -90,11 +90,11 @@ instance inv_pair₂ : RingHomInvPair ((FractionRing.frobenius p k).symm : K(p, 
   RingHomInvPair.of_ringEquiv (FractionRing.frobenius p k).symm
 
 scoped[Isocrystal]
-  notation:50 M " →ᶠˡ[" p ", " k "] " M₂ =>
+  notation3:50 M " →ᶠˡ[" p ", " k "] " M₂ =>
     LinearMap (WittVector.FractionRing.frobeniusRingHom p k) M M₂
 
 scoped[Isocrystal]
-  notation:50 M " ≃ᶠˡ[" p ", " k "] " M₂ =>
+  notation3:50 M " ≃ᶠˡ[" p ", " k "] " M₂ =>
     LinearEquiv (WittVector.FractionRing.frobeniusRingHom p k) M M₂
 
 /-! ### Isocrystals -/


### PR DESCRIPTION
* These notations were not used in the pretty-printer. Now they are.
* Exception: The notation in `Mathlib/Algebra/Category/Grp/EpiMono.lean` still doesn't pretty-print correctly. This is still an improvement, because the previous command didn't declare the notation correctly, and it was unused in the rest of the file.
* There is more to do (everything with `set_option quotPrecheck false` is suspicious).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
