### PR TITLE
[Merged by Bors] - refactor/fix: don't use RingHom.toAlgebra in Ideal.quotientAlgebra

### DIFF
--- a/Mathlib/NumberTheory/RamificationInertia/Basic.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Basic.lean
@@ -181,7 +181,9 @@ theorem ramificationIdx_ne_zero (hp0 : map f p ≠ ⊥) (hP : P.IsPrime) (le : m
 
 end IsDedekindDomain
 
-variable (f p P)
+variable (f p P) [Algebra R S]
+
+local notation "f" => algebraMap R S
 
 open Classical in
 /-- The inertia degree of `P : Ideal S` lying over `p : Ideal R` is the degree of the
@@ -194,31 +196,31 @@ and there is an algebra structure `R / p → S / P`.
 -/
 noncomputable def inertiaDeg : ℕ :=
   if hPp : comap f P = p then
-    letI : Algebra (R ⧸ p) (S ⧸ P) := Quotient.algebraQuotientOfLEComap (le_of_eq hPp.symm)
+    letI : Algebra (R ⧸ p) (S ⧸ P) := Quotient.algebraQuotientOfLEComap hPp.ge
     finrank (R ⧸ p) (S ⧸ P)
   else 0
 
 -- Useful for the `nontriviality` tactic using `comap_eq_of_scalar_tower_quotient`.
 @[simp]
 theorem inertiaDeg_of_subsingleton [hp : p.IsMaximal] [hQ : Subsingleton (S ⧸ P)] :
-    inertiaDeg f p P = 0 := by
+    inertiaDeg p P = 0 := by
   have := Ideal.Quotient.subsingleton_iff.mp hQ
   subst this
   exact dif_neg fun h => hp.ne_top <| h.symm.trans comap_top
 
 @[simp]
-theorem inertiaDeg_algebraMap [Algebra R S] [P.LiesOver p] [p.IsMaximal] :
-    inertiaDeg (algebraMap R S) p P = finrank (R ⧸ p) (S ⧸ P) := by
+theorem inertiaDeg_algebraMap [P.LiesOver p] [p.IsMaximal] :
+    inertiaDeg p P = finrank (R ⧸ p) (S ⧸ P) := by
   nontriviality S ⧸ P using inertiaDeg_of_subsingleton, finrank_zero_of_subsingleton
   rw [inertiaDeg, dif_pos (over_def P p).symm]
 
-theorem inertiaDeg_pos [p.IsMaximal] [Algebra R S] [Module.Finite R S]
-    [P.LiesOver p] : 0 < inertiaDeg (algebraMap R S) p P :=
+theorem inertiaDeg_pos [p.IsMaximal] [Module.Finite R S]
+    [P.LiesOver p] : 0 < inertiaDeg p P :=
   haveI : Nontrivial (S ⧸ P) := Quotient.nontrivial_of_liesOver_of_isPrime P p
   finrank_pos.trans_eq (inertiaDeg_algebraMap p P).symm
 
-lemma inertiaDeg_comap_eq [Algebra R S] (e : S ≃ₐ[R] S₁) (P : Ideal S₁) [p.IsMaximal] :
-    inertiaDeg (algebraMap R S) p (P.comap e) = inertiaDeg (algebraMap R S₁) p P := by
+lemma inertiaDeg_comap_eq (e : S ≃ₐ[R] S₁) (P : Ideal S₁) [p.IsMaximal] :
+    inertiaDeg p (P.comap e) = inertiaDeg p P := by
   have he : (P.comap e).comap (algebraMap R S) = p ↔ P.comap (algebraMap R S₁) = p := by
     rw [← comap_coe e, comap_comap, ← e.toAlgHom_toRingHom, AlgHom.comp_algebraMap]
   by_cases h : P.LiesOver p
@@ -227,9 +229,9 @@ lemma inertiaDeg_comap_eq [Algebra R S] (e : S ≃ₐ[R] S₁) (P : Ideal S₁) 
   · rw [inertiaDeg, dif_neg (fun eq => h ⟨(he.mp eq).symm⟩)]
     rw [inertiaDeg, dif_neg (fun eq => h ⟨eq.symm⟩)]
 
-lemma inertiaDeg_map_eq [p.IsMaximal] [Algebra R S] (P : Ideal S)
+lemma inertiaDeg_map_eq [p.IsMaximal] (P : Ideal S)
     {E : Type*} [EquivLike E S S₁] [AlgEquivClass E R S S₁] (e : E) :
-    inertiaDeg (algebraMap R S₁) p (P.map e) = inertiaDeg (algebraMap R S) p P := by
+    inertiaDeg p (P.map e) = inertiaDeg p P := by
   rw [show P.map e = _ from map_comap_of_equiv (e : S ≃+* S₁)]
   exact p.inertiaDeg_comap_eq (e : S ≃ₐ[R] S₁).symm P
 
@@ -447,6 +449,9 @@ end FinrankQuotientMap
 
 section FactLeComap
 
+variable [Algebra R S]
+
+local notation "f" => algebraMap R S
 local notation "e" => ramificationIdx f p P
 
 /-- `R / p` has a canonical map to `S / (P ^ e)`, where `e` is the ramification index
@@ -462,17 +467,15 @@ theorem Quotient.algebraMap_quotient_pow_ramificationIdx (x : R) :
 
 This can't be an instance since the map `f : R → S` is generally not inferrable.
 -/
-def Quotient.algebraQuotientOfRamificationIdxNeZero [hfp : NeZero (ramificationIdx f p P)] :
+def Quotient.algebraQuotientOfRamificationIdxNeZero [hfp : NeZero e] :
     Algebra (R ⧸ p) (S ⧸ P) :=
   Quotient.algebraQuotientOfLEComap (le_comap_of_ramificationIdx_ne_zero hfp.out)
 
-set_option synthInstance.checkSynthOrder false -- Porting note: this is okay by the remark below
--- In this file, the value for `f` can be inferred.
 attribute [local instance] Ideal.Quotient.algebraQuotientOfRamificationIdxNeZero
 
 @[simp]
 theorem Quotient.algebraMap_quotient_of_ramificationIdx_neZero
-    [NeZero (ramificationIdx f p P)] (x : R) :
+    [NeZero e] (x : R) :
     algebraMap (R ⧸ p) (S ⧸ P) (Ideal.Quotient.mk p x) = Ideal.Quotient.mk P (f x) := rfl
 
 /-- The inclusion `(P^(i + 1) / P^e) ⊂ (P^i / P^e)`. -/
@@ -485,7 +488,7 @@ def powQuotSuccInclusion (i : ℕ) :
   map_smul' _ _ := rfl
 
 theorem powQuotSuccInclusion_injective (i : ℕ) :
-    Function.Injective (powQuotSuccInclusion f p P i) := by
+    Function.Injective (powQuotSuccInclusion p P i) := by
   rw [← LinearMap.ker_eq_bot, LinearMap.ker_eq_bot']
   rintro ⟨x, hx⟩ hx0
   rw [Subtype.ext_iff] at hx0 ⊢
@@ -497,7 +500,7 @@ and `quotientRangePowQuotSuccInclusionEquiv` for this as a linear equivalence.
 -/
 noncomputable def quotientToQuotientRangePowQuotSuccAux {i : ℕ} {a : S} (a_mem : a ∈ P ^ i) :
     S ⧸ P →
-      (P ^ i).map (Ideal.Quotient.mk (P ^ e)) ⧸ LinearMap.range (powQuotSuccInclusion f p P i) :=
+      (P ^ i).map (Ideal.Quotient.mk (P ^ e)) ⧸ LinearMap.range (powQuotSuccInclusion p P i) :=
   Quotient.map' (fun x : S => ⟨_, Ideal.mem_map_of_mem _ (Ideal.mul_mem_right x _ a_mem)⟩)
     fun x y h => by
     rw [Submodule.quotientRel_def] at h ⊢
@@ -508,18 +511,19 @@ noncomputable def quotientToQuotientRangePowQuotSuccAux {i : ℕ} {a : S} (a_mem
       Subtype.coe_mk, _root_.map_mul, map_sub, mul_sub]
 
 theorem quotientToQuotientRangePowQuotSuccAux_mk {i : ℕ} {a : S} (a_mem : a ∈ P ^ i) (x : S) :
-    quotientToQuotientRangePowQuotSuccAux f p P a_mem (Submodule.Quotient.mk x) =
+    quotientToQuotientRangePowQuotSuccAux p P a_mem (Submodule.Quotient.mk x) =
       Submodule.Quotient.mk ⟨_, Ideal.mem_map_of_mem _ (Ideal.mul_mem_right x _ a_mem)⟩ := by
   apply Quotient.map'_mk''
 
 section
-variable [hfp : NeZero (ramificationIdx f p P)]
+variable [hfp : NeZero (ramificationIdx (algebraMap R S) p P)]
 
 /-- `S ⧸ P` embeds into the quotient by `P^(i+1) ⧸ P^e` as a subspace of `P^i ⧸ P^e`. -/
-noncomputable def quotientToQuotientRangePowQuotSucc {i : ℕ} {a : S} (a_mem : a ∈ P ^ i) :
+noncomputable def quotientToQuotientRangePowQuotSucc
+    {i : ℕ} {a : S} (a_mem : a ∈ P ^ i) :
     S ⧸ P →ₗ[R ⧸ p]
-      (P ^ i).map (Ideal.Quotient.mk (P ^ e)) ⧸ LinearMap.range (powQuotSuccInclusion f p P i) where
-  toFun := quotientToQuotientRangePowQuotSuccAux f p P a_mem
+      (P ^ i).map (Ideal.Quotient.mk (P ^ e)) ⧸ LinearMap.range (powQuotSuccInclusion p P i) where
+  toFun := quotientToQuotientRangePowQuotSuccAux p P a_mem
   map_add' := by
     intro x y; refine Quotient.inductionOn' x fun x => Quotient.inductionOn' y fun y => ?_
     simp only [Submodule.Quotient.mk''_eq_mk, ← Submodule.Quotient.mk_add,
@@ -536,13 +540,13 @@ noncomputable def quotientToQuotientRangePowQuotSucc {i : ℕ} {a : S} (a_mem : 
     ring
 
 theorem quotientToQuotientRangePowQuotSucc_mk {i : ℕ} {a : S} (a_mem : a ∈ P ^ i) (x : S) :
-    quotientToQuotientRangePowQuotSucc f p P a_mem (Submodule.Quotient.mk x) =
+    quotientToQuotientRangePowQuotSucc p P a_mem (Submodule.Quotient.mk x) =
       Submodule.Quotient.mk ⟨_, Ideal.mem_map_of_mem _ (Ideal.mul_mem_right x _ a_mem)⟩ :=
-  quotientToQuotientRangePowQuotSuccAux_mk f p P a_mem x
+  quotientToQuotientRangePowQuotSuccAux_mk p P a_mem x
 
 theorem quotientToQuotientRangePowQuotSucc_injective [IsDedekindDomain S] [P.IsPrime]
     {i : ℕ} (hi : i < e) {a : S} (a_mem : a ∈ P ^ i) (a_not_mem : a ∉ P ^ (i + 1)) :
-    Function.Injective (quotientToQuotientRangePowQuotSucc f p P a_mem) := fun x =>
+    Function.Injective (quotientToQuotientRangePowQuotSucc p P a_mem) := fun x =>
   Quotient.inductionOn' x fun x y =>
     Quotient.inductionOn' y fun y h => by
       have Pe_le_Pi1 : P ^ e ≤ P ^ (i + 1) := Ideal.pow_le_pow_right hi
@@ -562,7 +566,7 @@ theorem quotientToQuotientRangePowQuotSucc_injective [IsDedekindDomain S] [P.IsP
 theorem quotientToQuotientRangePowQuotSucc_surjective [IsDedekindDomain S]
     (hP0 : P ≠ ⊥) [hP : P.IsPrime] {i : ℕ} (hi : i < e) {a : S} (a_mem : a ∈ P ^ i)
     (a_not_mem : a ∉ P ^ (i + 1)) :
-    Function.Surjective (quotientToQuotientRangePowQuotSucc f p P a_mem) := by
+    Function.Surjective (quotientToQuotientRangePowQuotSucc p P a_mem) := by
   rintro ⟨⟨⟨x⟩, hx⟩⟩
   have Pe_le_Pi : P ^ e ≤ P ^ i := Ideal.pow_le_pow_right hi.le
   rw [Submodule.Quotient.quot_mk_eq_mk, Ideal.Quotient.mk_eq_mk, Ideal.mem_quotient_iff_mem_sup,
@@ -592,15 +596,15 @@ theorem quotientToQuotientRangePowQuotSucc_surjective [IsDedekindDomain S]
 `R ⧸ p`-linearly isomorphic to `S ⧸ P`. -/
 noncomputable def quotientRangePowQuotSuccInclusionEquiv [IsDedekindDomain S]
     [P.IsPrime] (hP : P ≠ ⊥) {i : ℕ} (hi : i < e) :
-    ((P ^ i).map (Ideal.Quotient.mk (P ^ e)) ⧸ LinearMap.range (powQuotSuccInclusion f p P i))
+    ((P ^ i).map (Ideal.Quotient.mk (P ^ e)) ⧸ LinearMap.range (powQuotSuccInclusion p P i))
       ≃ₗ[R ⧸ p] S ⧸ P := by
   choose a a_mem a_not_mem using
     SetLike.exists_of_lt
       (Ideal.pow_right_strictAnti P hP (Ideal.IsPrime.ne_top inferInstance) (le_refl i.succ))
   refine (LinearEquiv.ofBijective ?_ ⟨?_, ?_⟩).symm
-  · exact quotientToQuotientRangePowQuotSucc f p P a_mem
-  · exact quotientToQuotientRangePowQuotSucc_injective f p P hi a_mem a_not_mem
-  · exact quotientToQuotientRangePowQuotSucc_surjective f p P hP hi a_mem a_not_mem
+  · exact quotientToQuotientRangePowQuotSucc p P a_mem
+  · exact quotientToQuotientRangePowQuotSucc_injective p P hi a_mem a_not_mem
+  · exact quotientToQuotientRangePowQuotSucc_surjective p P hP hi a_mem a_not_mem
 
 /-- Since the inclusion `(P^(i + 1) / P^e) ⊂ (P^i / P^e)` has a kernel isomorphic to `P / S`,
 `[P^i / P^e : R / p] = [P^(i+1) / P^e : R / p] + [P / S : R / p]` -/
@@ -609,9 +613,9 @@ theorem rank_pow_quot_aux [IsDedekindDomain S] [p.IsMaximal] [P.IsPrime] (hP0 : 
     Module.rank (R ⧸ p) (Ideal.map (Ideal.Quotient.mk (P ^ e)) (P ^ i)) =
       Module.rank (R ⧸ p) (S ⧸ P) +
         Module.rank (R ⧸ p) (Ideal.map (Ideal.Quotient.mk (P ^ e)) (P ^ (i + 1))) := by
-  rw [← rank_range_of_injective _ (powQuotSuccInclusion_injective f p P i),
-    (quotientRangePowQuotSuccInclusionEquiv f p P hP0 hi).symm.rank_eq]
-  exact (Submodule.rank_quotient_add_rank (LinearMap.range (powQuotSuccInclusion f p P i))).symm
+  rw [← rank_range_of_injective _ (powQuotSuccInclusion_injective p P i),
+    (quotientRangePowQuotSuccInclusionEquiv p P hP0 hi).symm.rank_eq]
+  exact (Submodule.rank_quotient_add_rank (LinearMap.range (powQuotSuccInclusion p P i))).symm
 
 theorem rank_pow_quot [IsDedekindDomain S] [p.IsMaximal] [P.IsPrime] (hP0 : P ≠ ⊥)
     (i : ℕ) (hi : i ≤ e) :
@@ -623,7 +627,7 @@ theorem rank_pow_quot [IsDedekindDomain S] [p.IsMaximal] [P.IsPrime] (hP0 : P �
       = (e - i) • Module.rank (R ⧸ p) (S ⧸ P)
   refine Nat.decreasingInduction' (P := Q) (fun j lt_e _le_j ih => ?_) hi ?_
   · dsimp only [Q]
-    rw [rank_pow_quot_aux f p P _ lt_e, ih, ← succ_nsmul', Nat.sub_succ, ← Nat.succ_eq_add_one,
+    rw [rank_pow_quot_aux p P _ lt_e, ih, ← succ_nsmul', Nat.sub_succ, ← Nat.succ_eq_add_one,
       Nat.succ_pred_eq_of_pos (Nat.sub_pos_of_lt lt_e)]
     assumption
   · dsimp only [Q]
@@ -642,7 +646,7 @@ theorem rank_prime_pow_ramificationIdx [IsDedekindDomain S] [p.IsMaximal] [P.IsP
           (@Algebra.toModule _ _ _ _ <|
             @Quotient.algebraQuotientOfRamificationIdxNeZero _ _ _ _ _ _ _ ⟨he⟩) := by
   letI : NeZero e := ⟨he⟩
-  have := rank_pow_quot f p P hP0 0 (Nat.zero_le e)
+  have := rank_pow_quot p P hP0 0 (Nat.zero_le e)
   rw [pow_zero, Nat.sub_zero, Ideal.one_eq_top, Ideal.map_top] at this
   exact (rank_top (R ⧸ p) _).symm.trans this
 
@@ -656,8 +660,8 @@ theorem finrank_prime_pow_ramificationIdx [IsDedekindDomain S] (hP0 : P ≠ ⊥)
           (@Algebra.toModule _ _ _ _ <|
             @Quotient.algebraQuotientOfRamificationIdxNeZero _ _ _ _ _ _ _ ⟨he⟩) := by
   letI : NeZero e := ⟨he⟩
-  letI : Algebra (R ⧸ p) (S ⧸ P) := Quotient.algebraQuotientOfRamificationIdxNeZero f p P
-  have hdim := rank_prime_pow_ramificationIdx _ _ _ hP0 he
+  letI : Algebra (R ⧸ p) (S ⧸ P) := Quotient.algebraQuotientOfRamificationIdxNeZero p P
+  have hdim := rank_prime_pow_ramificationIdx _ _ hP0 he
   by_cases hP : FiniteDimensional (R ⧸ p) (S ⧸ P)
   · haveI := hP
     haveI := (finiteDimensional_iff_of_rank_eq_nsmul he hdim).mpr hP
@@ -709,7 +713,7 @@ instance Factors.liesOver [p.IsMaximal] (P : (factors (map (algebraMap R S) p)).
 theorem Factors.finrank_pow_ramificationIdx [p.IsMaximal]
     (P : (factors (map (algebraMap R S) p)).toFinset) :
     finrank (R ⧸ p) (S ⧸ (P : Ideal S) ^ ramificationIdx (algebraMap R S) p P) =
-      ramificationIdx (algebraMap R S) p P * inertiaDeg (algebraMap R S) p P := by
+      ramificationIdx (algebraMap R S) p P * inertiaDeg p (P : Ideal S) := by
   rw [finrank_prime_pow_ramificationIdx, inertiaDeg_algebraMap]
   exacts [Factors.ne_bot p P, NeZero.ne _]
 
@@ -772,10 +776,10 @@ theorem sum_ramification_inertia (K L : Type*) [Field K] [Field L] [IsDedekindDo
     [Algebra R L] [IsScalarTower R S L] [IsScalarTower R K L] [Module.Finite R S]
     [p.IsMaximal] (hp0 : p ≠ ⊥) :
     (∑ P ∈ (factors (map (algebraMap R S) p)).toFinset,
-        ramificationIdx (algebraMap R S) p P * inertiaDeg (algebraMap R S) p P) =
+        ramificationIdx (algebraMap R S) p P * inertiaDeg p P) =
       finrank K L := by
   set e := ramificationIdx (algebraMap R S) p
-  set f := inertiaDeg (algebraMap R S) p
+  set f := inertiaDeg p (S := S)
   calc
     (∑ P ∈ (factors (map (algebraMap R S) p)).toFinset, e P * f P) =
         ∑ P ∈ (factors (map (algebraMap R S) p)).toFinset.attach,
@@ -822,17 +826,6 @@ theorem ramificationIdx_tower [IsDedekindDomain S] [IsDedekindDomain T] {f : R �
   exact add_right_eq_self.mpr <| Decidable.byContradiction fun h ↦ hntq <| hcp.trans_le <|
     sup_le hg <| le_of_dvd <| dvd_of_mem_normalizedFactors <| Multiset.count_ne_zero.mp h
 
-theorem inertiaDeg_tower {f : R →+* S} {g : S →+* T} {p : Ideal R} {P : Ideal S} {I : Ideal T}
-    [p.IsMaximal] [P.IsMaximal] (hp : p = comap f P) (hP : P = comap g I) :
-    inertiaDeg (g.comp f) p I = inertiaDeg f p P * inertiaDeg g P I := by
-  have h : comap (g.comp f) I = p := by rw [hp, hP, comap_comap]
-  simp only [inertiaDeg, dif_pos hp.symm, dif_pos hP.symm, dif_pos h]
-  letI : Algebra (R ⧸ p) (S ⧸ P) := Ideal.Quotient.algebraQuotientOfLEComap (le_of_eq hp)
-  letI : Algebra (S ⧸ P) (T ⧸ I) := Ideal.Quotient.algebraQuotientOfLEComap (le_of_eq hP)
-  letI : Algebra (R ⧸ p) (T ⧸ I) := Ideal.Quotient.algebraQuotientOfLEComap (le_of_eq h.symm)
-  letI : IsScalarTower (R ⧸ p) (S ⧸ P) (T ⧸ I) := IsScalarTower.of_algebraMap_eq (by rintro ⟨⟩; rfl)
-  exact (finrank_mul_finrank (R ⧸ p) (S ⧸ P) (T ⧸ I)).symm
-
 variable [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
 
 /-- Let `T / S / R` be a tower of algebras, `p, P, Q` be ideals in `R, S, T` respectively,
@@ -850,10 +843,20 @@ theorem ramificationIdx_algebra_tower [IsDedekindDomain S] [IsDedekindDomain T]
   and `p` and `P` are maximal. If `p = P ∩ S` and `P = I ∩ S`,
   then `f (I | p) = f (P | p) * f (I | P)`. -/
 theorem inertiaDeg_algebra_tower (p : Ideal R) (P : Ideal S) (I : Ideal T) [p.IsMaximal]
-    [P.IsMaximal] [P.LiesOver p] [I.LiesOver P] : inertiaDeg (algebraMap R T) p I =
-    inertiaDeg (algebraMap R S) p P * inertiaDeg (algebraMap S T) P I := by
-  rw [IsScalarTower.algebraMap_eq R S T]
-  exact inertiaDeg_tower (over_def P p) (over_def I P)
+    [P.IsMaximal] [P.LiesOver p] [I.LiesOver P] : inertiaDeg p I =
+    inertiaDeg p P * inertiaDeg P I := by
+  have h₁ := P.over_def p
+  have h₂ := I.over_def P
+  have h₃ := (LiesOver.trans I P p).over
+  simp only [inertiaDeg, dif_pos h₁.symm, dif_pos h₂.symm, dif_pos h₃.symm]
+  letI : Algebra (R ⧸ p) (S ⧸ P) := Ideal.Quotient.algebraQuotientOfLEComap h₁.le
+  letI : Algebra (S ⧸ P) (T ⧸ I) := Ideal.Quotient.algebraQuotientOfLEComap h₂.le
+  letI : Algebra (R ⧸ p) (T ⧸ I) := Ideal.Quotient.algebraQuotientOfLEComap h₃.le
+  letI : IsScalarTower (R ⧸ p) (S ⧸ P) (T ⧸ I) := IsScalarTower.of_algebraMap_eq <| by
+    rintro ⟨x⟩; exact congr_arg _ (IsScalarTower.algebraMap_apply R S T x)
+  exact (finrank_mul_finrank (R ⧸ p) (S ⧸ P) (T ⧸ I)).symm
+
+@[deprecated (since := "2024-12-09")] alias inertiaDeg_tower := inertiaDeg_algebra_tower
 
 end tower
 

--- a/Mathlib/RingTheory/Ideal/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Over.lean
@@ -138,24 +138,24 @@ theorem comap_eq_of_scalar_tower_quotient [Algebra R S] [Algebra (R ⧸ p) (S �
   · intro hx
     rw [hx, RingHom.map_zero]
 
-/-- If `P` lies over `p`, then `R / p` has a canonical map to `S / P`. -/
-def Quotient.algebraQuotientOfLEComap (h : p ≤ comap f P) : Algebra (R ⧸ p) (S ⧸ P) :=
-  RingHom.toAlgebra <| quotientMap _ f h
+variable [Algebra R S]
 
 /-- `R / p` has a canonical map to `S / pS`. -/
-instance Quotient.algebraQuotientMapQuotient : Algebra (R ⧸ p) (S ⧸ map f p) :=
+instance Quotient.algebraQuotientMapQuotient : Algebra (R ⧸ p) (S ⧸ map (algebraMap R S) p) :=
   Ideal.Quotient.algebraQuotientOfLEComap le_comap_map
 
 @[simp]
 theorem Quotient.algebraMap_quotient_map_quotient (x : R) :
+    letI f := algebraMap R S
     algebraMap (R ⧸ p) (S ⧸ map f p) (Ideal.Quotient.mk p x) =
     Ideal.Quotient.mk (map f p) (f x) :=
   rfl
 
 @[simp]
 theorem Quotient.mk_smul_mk_quotient_map_quotient (x : R) (y : S) :
+    letI f := algebraMap R S
     Quotient.mk p x • Quotient.mk (map f p) y = Quotient.mk (map f p) (f x * y) :=
-  rfl
+  Algebra.smul_def _ _
 
 instance Quotient.tower_quotient_map_quotient [Algebra R S] :
     IsScalarTower R (R ⧸ p) (S ⧸ map (algebraMap R S) p) :=
@@ -164,7 +164,7 @@ instance Quotient.tower_quotient_map_quotient [Algebra R S] :
       Quotient.mk_algebraMap]
 
 instance QuotientMapQuotient.isNoetherian [Algebra R S] [IsNoetherian R S] (I : Ideal R) :
-    IsNoetherian (R ⧸ I) (S ⧸ Ideal.map (algebraMap R S) I) :=
+    IsNoetherian (R ⧸ I) (S ⧸ I.map (algebraMap R S)) :=
   isNoetherian_of_tower R <|
     isNoetherian_of_surjective S (Ideal.Quotient.mkₐ R _).toLinearMap <|
       LinearMap.range_eq_top.mpr Ideal.Quotient.mk_surjective

--- a/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
@@ -590,9 +590,21 @@ def quotientEquivAlg (I : Ideal A) (J : Ideal B) (f : A ≃ₐ[R₁] B) (hIJ : J
 
 end
 
+/-- If `P` lies over `p`, then `R / p` has a canonical map to `A / P`. -/
+abbrev Quotient.algebraQuotientOfLEComap [Algebra R A] {p : Ideal R} {P : Ideal A}
+    (h : p ≤ comap (algebraMap R A) P) : Algebra (R ⧸ p) (A ⧸ P) where
+  toRingHom := quotientMap P (algebraMap R A) h
+  smul := Quotient.lift₂ (⟦· • ·⟧) fun r₁ a₁ r₂ a₂ hr ha ↦ Quotient.sound <| by
+    have := h (p.quotientRel_def.mp hr)
+    rw [mem_comap, map_sub] at this
+    simpa only [Algebra.smul_def] using P.quotientRel_def.mpr
+      (P.mul_sub_mul_mem this <| P.quotientRel_def.mp ha)
+  smul_def' := by rintro ⟨_⟩ ⟨_⟩; exact congr_arg (⟦·⟧) (Algebra.smul_def _ _)
+  commutes' := by rintro ⟨_⟩ ⟨_⟩; exact congr_arg (⟦·⟧) (Algebra.commutes _ _)
+
 instance (priority := 100) quotientAlgebra {I : Ideal A} [Algebra R A] :
     Algebra (R ⧸ I.comap (algebraMap R A)) (A ⧸ I) :=
-  (quotientMap I (algebraMap R A) (le_of_eq rfl)).toAlgebra
+  Quotient.algebraQuotientOfLEComap le_rfl
 
 theorem algebraMap_quotient_injective {I : Ideal A} [Algebra R A] :
     Function.Injective (algebraMap (R ⧸ I.comap (algebraMap R A)) (A ⧸ I)) := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
