### PR TITLE
[Merged by Bors] - chore(CategoryTheory/MorphismProperty/IsInvertedBy): simplify proof of isoClosure_iff

### DIFF
--- a/Mathlib/CategoryTheory/MorphismProperty/IsInvertedBy.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/IsInvertedBy.lean
@@ -126,10 +126,7 @@ lemma IsInvertedBy.isoClosure_iff (W : MorphismProperty C) (F : C ⥤ D) :
   · intro h X Y f hf
     exact h _ (W.le_isoClosure _ hf)
   · intro h X Y f ⟨X', Y', f', hf', ⟨e⟩⟩
-    have : f = e.inv.left ≫ f' ≫ e.hom.right := by
-      erw [← e.hom.w, ← Arrow.comp_left_assoc, e.inv_hom_id, Category.id_comp]
-      rfl
-    simp only [this, F.map_comp]
+    simp only [Arrow.iso_w' e, F.map_comp]
     have := h _ hf'
     infer_instance
 


### PR DESCRIPTION
* `have : f = e.inv.left ≫ f' ≫ e.hom.right` can be directly proved via [`Arrow.iso_w'`](https://github.com/leanprover-community/mathlib4/blob/ebd71de74db22aaa0abbfab6799a22bcecda3476/Mathlib/CategoryTheory/Comma/Arrow.lean#L156). This removes an `erw`.
* Once the `have` is shortened like that, we might as well inline it at its usage in the subsequent `simp`.


This change was suggested by [tryAtEachStep](https://github.com/dwrensha/tryAtEachStep).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
