### PR TITLE
[Merged by Bors] - chore(discover-lean-pr-testing): Zulip post with command for merging lean-testing PRs

### DIFF
--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -128,15 +128,17 @@ jobs:
       id: zulip-message
       run: |
         BRANCHES="${{ steps.find-branches.outputs.branches }}"
-        printf "msg<<EOF\n" >> "$GITHUB_OUTPUT"
-        printf "We will need to merge the following branches into \`nightly-testing\`:\n" >> "$GITHUB_OUTPUT"
-        printf "\`\`\`bash\n" >> "$GITHUB_OUTPUT"
-        for BRANCH in $BRANCHES; do
-          PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
-          printf "scripts/merge-lean-testing-pr.sh %s   # %s\n" $PR_NUMBER $BRANCH >> "$GITHUB_OUTPUT"
-        done
-        printf "\`\`\`\n" >> "$GITHUB_OUTPUT"
-        printf "EOF" >> "$GITHUB_OUTPUT"
+        {
+          printf "msg<<EOF\n"
+          printf "We will need to merge the following branches into \`nightly-testing\`:\n"
+          printf "\`\`\`bash\n"
+          for BRANCH in $BRANCHES; do
+            PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
+            printf "scripts/merge-lean-testing-pr.sh %s   # %s\n" "$PR_NUMBER" "$BRANCH"
+          done
+          printf "\`\`\`\n"
+          printf "EOF"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Send message on Zulip
       if: env.branches_exist == 'true'

--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -124,6 +124,20 @@ jobs:
           echo "branches_exist=true" >> "$GITHUB_ENV"
         fi
 
+    - name: Prepare Zulip message
+      id: zulip-message
+      run: |
+        BRANCHES="${{ steps.find-branches.outputs.branches }}"
+        printf "msg<<EOF\n" >> "$GITHUB_OUTPUT"
+        printf "We will need to merge the following branches into \`nightly-testing\`:\n" >> "$GITHUB_OUTPUT"
+        printf "\`\`\`bash\n" >> "$GITHUB_OUTPUT"
+        for BRANCH in $BRANCHES; do
+          PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
+          printf "scripts/merge-lean-testing-pr.sh %s   # %s\n" $PR_NUMBER $BRANCH >> "$GITHUB_OUTPUT"
+        done
+        printf "\`\`\`\n" >> "$GITHUB_OUTPUT"
+        printf "EOF" >> "$GITHUB_OUTPUT"
+
     - name: Send message on Zulip
       if: env.branches_exist == 'true'
       uses: zulip/github-actions-zulip/send-message@v1
@@ -135,8 +149,4 @@ jobs:
         type: 'stream'
         topic: 'Mergeable lean testing PRs'
         content: |
-          We will need to merge the following branches into `nightly-testing`:
-
-          ${{ steps.find-branches.outputs.branches }}
-
-          This can be done using the script `scripts/merge-lean-testing-pr.sh`, which takes 1 lean-PR number as argument.
+          ${{ steps.zulip-message.outputs.msg }}

--- a/scripts/merge-lean-testing-pr.sh
+++ b/scripts/merge-lean-testing-pr.sh
@@ -17,7 +17,8 @@ if ! git merge origin/$BRANCH_NAME; then
     git add lean-toolchain lakefile.lean lake-manifest.json
 fi
 
-sed -i "s/$BRANCH_NAME/nightly-testing/g" lakefile.lean
+sed "s/$BRANCH_NAME/nightly-testing/g" < lakefile.lean > lakefile.lean.new
+mv lakefile.lean.new lakefile.lean
 git add lakefile.lean
 
 # Check for merge conflicts


### PR DESCRIPTION
Also make the script for merging the lean-testing PRs a bit more robust:
write sed output to a new file, and move that to the original,
instead of doing inplace updates with `sed -i`
(which doesn't seem to work wel on MacOS).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
