### PR TITLE
refactor: review the `simps` projections of `OneHom`, `MulHom`, `MonoidHom`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Multiset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Multiset/Basic.lean
@@ -198,7 +198,7 @@ theorem prod_map_div : (m.map fun i => f i / g i).prod = (m.map f).prod / (m.map
 @[to_additive]
 theorem prod_map_zpow {n : ℤ} : (m.map fun i => f i ^ n).prod = (m.map f).prod ^ n := by
   convert (m.map f).prod_hom (zpowGroupHom n : G →* G)
-  simp only [map_map, Function.comp_apply, zpowGroupHom_apply]
+  simp [map_map, Function.comp_apply]
 
 end DivisionCommMonoid
 

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -515,68 +515,95 @@ section Coes
 
 /-! Bundled morphisms can be down-cast to weaker bundlings -/
 
+namespace OneHom
+variable [One M] [One N]
+
+/-- See Note [custom simps projection]. We want to generate
+`coe_concreteHom : ⇑concreteHom = unbundledFun` rather than
+`concreteHom_apply a : ⇑concreteHom a = unbundledFun a`. -/
+@[to_additive
+/-- See Note [custom simps projection]. We want to generate
+`coe_concreteHom : ⇑concreteHom = unbundledFun` rather than
+`concreteHom_apply a : ⇑concreteHom a = unbundledFun a`. -/]
+def Simps.coe (f : OneHom M N) : M → N := f
+
+initialize_simps_projections OneHom (toFun → coe, as_prefix coe)
+initialize_simps_projections ZeroHom (toFun → coe, as_prefix coe)
+
+@[to_additive (attr := simp)] lemma toFun_eq_coe (f : OneHom M N) : f.toFun = f := rfl
+@[to_additive (attr := simp)] lemma coe_mk (f : M → N) (hone) : (mk f hone : M → N) = f := rfl
+@[to_additive (attr := simp)] lemma mk_coe (f : OneHom M N) : mk f f.map_one' = f := rfl
+
+@[to_additive (attr := ext)]
+lemma ext ⦃f g : OneHom M N⦄ (h : ∀ x, f x = g x) : f = g := DFunLike.ext _ _ h
+
+end OneHom
+
+namespace MulHom
+variable [Mul M] [Mul N]
+
+/-- See Note [custom simps projection]. We want to generate
+`coe_concreteHom : ⇑concreteHom = unbundledFun` rather than
+`concreteHom_apply a : ⇑concreteHom a = unbundledFun a`. -/
+@[to_additive
+/-- See Note [custom simps projection]. We want to generate
+`coe_concreteHom : ⇑concreteHom = unbundledFun` rather than
+`concreteHom_apply a : ⇑concreteHom a = unbundledFun a`. -/]
+def Simps.coe (f : M →ₙ* N) : M → N := f
+
+initialize_simps_projections MulHom (toFun → coe, as_prefix coe)
+initialize_simps_projections AddHom (toFun → coe, as_prefix coe)
+
+@[to_additive (attr := simp)] lemma toFun_eq_coe (f : M →ₙ* N) : f.toFun = f := rfl
+@[to_additive (attr := simp)] lemma coe_mk (f : M → N) (hmul) : (mk f hmul : M → N) = f := rfl
+@[to_additive (attr := simp)] lemma mk_coe (f : M →ₙ* N) : mk f f.map_mul' = f := rfl
+
+@[to_additive (attr := ext)]
+lemma ext ⦃f g : M →ₙ* N⦄ (h : ∀ x, f x = g x) : f = g := DFunLike.ext _ _ h
+
+end MulHom
+
+namespace MonoidHom
+variable [MulOne M] [MulOne N]
+
 attribute [coe] MonoidHom.toOneHom
 attribute [coe] AddMonoidHom.toZeroHom
-
-/-- `MonoidHom` down-cast to a `OneHom`, forgetting the multiplicative property. -/
-@[to_additive /-- `AddMonoidHom` down-cast to a `ZeroHom`, forgetting the additive property -/]
-instance MonoidHom.coeToOneHom [MulOne M] [MulOne N] : Coe (M →* N) (OneHom M N) :=
-  ⟨MonoidHom.toOneHom⟩
-
 attribute [coe] MonoidHom.toMulHom
 attribute [coe] AddMonoidHom.toAddHom
 
+/-- `MonoidHom` down-cast to a `OneHom`, forgetting the multiplicative property. -/
+@[to_additive /-- `AddMonoidHom` down-cast to a `ZeroHom`, forgetting the additive property -/]
+instance coeToOneHom : Coe (M →* N) (OneHom M N) := ⟨MonoidHom.toOneHom⟩
+
 /-- `MonoidHom` down-cast to a `MulHom`, forgetting the 1-preserving property. -/
 @[to_additive /-- `AddMonoidHom` down-cast to an `AddHom`, forgetting the 0-preserving property. -/]
-instance MonoidHom.coeToMulHom [MulOne M] [MulOne N] : Coe (M →* N) (M →ₙ* N) :=
+instance coeToMulHom [MulOne M] [MulOne N] : Coe (M →* N) (M →ₙ* N) :=
   ⟨MonoidHom.toMulHom⟩
 
--- these must come after the coe_toFun definitions
-initialize_simps_projections ZeroHom (toFun → apply)
-initialize_simps_projections AddHom (toFun → apply)
-initialize_simps_projections AddMonoidHom (toFun → apply)
-initialize_simps_projections OneHom (toFun → apply)
-initialize_simps_projections MulHom (toFun → apply)
-initialize_simps_projections MonoidHom (toFun → apply)
+/-- See Note [custom simps projection]. We want to generate
+`coe_concreteHom : ⇑concreteHom = unbundledFun` rather than
+`concreteHom_apply a : ⇑concreteHom a = unbundledFun a`. -/
+@[to_additive
+/-- See Note [custom simps projection]. We want to generate
+`coe_concreteHom : ⇑concreteHom = unbundledFun` rather than
+`concreteHom_apply a : ⇑concreteHom a = unbundledFun a`. -/]
+def Simps.coe (f : M →* N) : M → N := f
 
-@[to_additive (attr := simp)]
-theorem OneHom.coe_mk [One M] [One N] (f : M → N) (h1) : (OneHom.mk f h1 : M → N) = f := rfl
+initialize_simps_projections MonoidHom (toFun → coe, as_prefix coe)
+initialize_simps_projections AddMonoidHom (toFun → coe, as_prefix coe)
 
-@[to_additive (attr := simp)]
-theorem OneHom.toFun_eq_coe [One M] [One N] (f : OneHom M N) : f.toFun = f := rfl
+@[to_additive (attr := simp)] lemma coe_toOneHom (f : M →* N) : f.toOneHom = f := rfl
+@[to_additive (attr := simp)] lemma coe_toMulHom (f : M →* N) : f.toMulHom = f := rfl
+@[to_additive (attr := simp)] lemma coe_mk (f hmul) : (mk f hmul : M → N) = f := rfl
+@[to_additive (attr := simp)] lemma mk_coe (f : M →* N) : mk f f.map_mul' = f := rfl
 
-@[to_additive (attr := simp)]
-theorem MulHom.coe_mk [Mul M] [Mul N] (f : M → N) (hmul) : (MulHom.mk f hmul : M → N) = f := rfl
-
-@[to_additive (attr := simp)]
-theorem MulHom.toFun_eq_coe [Mul M] [Mul N] (f : M →ₙ* N) : f.toFun = f := rfl
-
-@[to_additive (attr := simp)]
-theorem MonoidHom.coe_mk [MulOne M] [MulOne N] (f hmul) :
-    (MonoidHom.mk f hmul : M → N) = f := rfl
-
-@[to_additive (attr := simp)]
-theorem MonoidHom.toOneHom_coe [MulOne M] [MulOne N] (f : M →* N) :
-    (f.toOneHom : M → N) = f := rfl
-
-@[to_additive (attr := simp)]
-theorem MonoidHom.toMulHom_coe [MulOne M] [MulOne N] (f : M →* N) :
-    f.toMulHom.toFun = f := rfl
-
-@[to_additive]
-theorem MonoidHom.toFun_eq_coe [MulOne M] [MulOne N] (f : M →* N) : f.toFun = f := rfl
+@[to_additive] lemma toFun_eq_coe (f : M →* N) : f.toFun = f := rfl
 
 @[to_additive (attr := ext)]
-theorem OneHom.ext [One M] [One N] ⦃f g : OneHom M N⦄ (h : ∀ x, f x = g x) : f = g :=
-  DFunLike.ext _ _ h
+lemma ext ⦃f g : M →* N⦄ (h : ∀ x, f x = g x) : f = g := DFunLike.ext _ _ h
 
-@[to_additive (attr := ext)]
-theorem MulHom.ext [Mul M] [Mul N] ⦃f g : M →ₙ* N⦄ (h : ∀ x, f x = g x) : f = g :=
-  DFunLike.ext _ _ h
-
-@[to_additive (attr := ext)]
-theorem MonoidHom.ext [MulOne M] [MulOne N] ⦃f g : M →* N⦄ (h : ∀ x, f x = g x) : f = g :=
-  DFunLike.ext _ _ h
+end MonoidHom
+end Coes
 
 namespace MonoidHom
 
@@ -593,34 +620,15 @@ def mk' (f : M → G) (map_mul : ∀ a b : M, f (a * b) = f a * f b) : M →* G 
 
 end MonoidHom
 
-@[to_additive (attr := simp)]
-theorem OneHom.mk_coe [One M] [One N] (f : OneHom M N) (h1) : OneHom.mk f h1 = f :=
-  OneHom.ext fun _ => rfl
-
-@[to_additive (attr := simp)]
-theorem MulHom.mk_coe [Mul M] [Mul N] (f : M →ₙ* N) (hmul) : MulHom.mk f hmul = f :=
-  MulHom.ext fun _ => rfl
-
-@[to_additive (attr := simp)]
-theorem MonoidHom.mk_coe [MulOne M] [MulOne N] (f : M →* N) (hmul) :
-    MonoidHom.mk f hmul = f := MonoidHom.ext fun _ => rfl
-
-end Coes
-
 /-- Copy of a `OneHom` with a new `toFun` equal to the old one. Useful to fix definitional
 equalities. -/
-@[to_additive
+@[to_additive (attr := simps)
   /-- Copy of a `ZeroHom` with a new `toFun` equal to the old one. Useful to fix
   definitional equalities. -/]
 protected def OneHom.copy [One M] [One N] (f : OneHom M N) (f' : M → N) (h : f' = f) :
     OneHom M N where
   toFun := f'
   map_one' := h.symm ▸ f.map_one'
-
-@[to_additive (attr := simp)]
-theorem OneHom.coe_copy {_ : One M} {_ : One N} (f : OneHom M N) (f' : M → N) (h : f' = f) :
-    (f.copy f' h) = f' :=
-  rfl
 
 @[to_additive]
 theorem OneHom.coe_copy_eq {_ : One M} {_ : One N} (f : OneHom M N) (f' : M → N) (h : f' = f) :
@@ -629,18 +637,13 @@ theorem OneHom.coe_copy_eq {_ : One M} {_ : One N} (f : OneHom M N) (f' : M → 
 
 /-- Copy of a `MulHom` with a new `toFun` equal to the old one. Useful to fix definitional
 equalities. -/
-@[to_additive
+@[to_additive (attr := simps)
   /-- Copy of an `AddHom` with a new `toFun` equal to the old one. Useful to fix
   definitional equalities. -/]
 protected def MulHom.copy [Mul M] [Mul N] (f : M →ₙ* N) (f' : M → N) (h : f' = f) :
     M →ₙ* N where
   toFun := f'
   map_mul' := h.symm ▸ f.map_mul'
-
-@[to_additive (attr := simp)]
-theorem MulHom.coe_copy {_ : Mul M} {_ : Mul N} (f : M →ₙ* N) (f' : M → N) (h : f' = f) :
-    (f.copy f' h) = f' :=
-  rfl
 
 @[to_additive]
 theorem MulHom.coe_copy_eq {_ : Mul M} {_ : Mul N} (f : M →ₙ* N) (f' : M → N) (h : f' = f) :
@@ -649,17 +652,12 @@ theorem MulHom.coe_copy_eq {_ : Mul M} {_ : Mul N} (f : M →ₙ* N) (f' : M →
 
 /-- Copy of a `MonoidHom` with a new `toFun` equal to the old one. Useful to fix
 definitional equalities. -/
-@[to_additive
+@[to_additive (attr := simps!)
   /-- Copy of an `AddMonoidHom` with a new `toFun` equal to the old one. Useful to fix
   definitional equalities. -/]
 protected def MonoidHom.copy [MulOne M] [MulOne N] (f : M →* N) (f' : M → N)
     (h : f' = f) : M →* N :=
   { f.toOneHom.copy f' h, f.toMulHom.copy f' h with }
-
-@[to_additive (attr := simp)]
-theorem MonoidHom.coe_copy {_ : MulOne M} {_ : MulOne N} (f : M →* N) (f' : M → N)
-    (h : f' = f) : (f.copy f' h) = f' :=
-  rfl
 
 @[to_additive]
 theorem MonoidHom.copy_eq {_ : MulOne M} {_ : MulOne N} (f : M →* N) (f' : M → N)
@@ -717,64 +715,49 @@ alias isDedekindFiniteMonoid_of_injective := IsDedekindFiniteMonoid.of_injective
 end MonoidHom
 
 /-- The identity map from a type with 1 to itself. -/
-@[to_additive (attr := simps) /-- The identity map from a type with zero to itself. -/]
+@[to_additive (attr := simps)
+/-- The identity map from a type with zero to itself. -/]
 def OneHom.id (M : Type*) [One M] : OneHom M M where
   toFun x := x
   map_one' := rfl
 
 /-- The identity map from a type with multiplication to itself. -/
-@[to_additive (attr := simps) /-- The identity map from a type with addition to itself. -/]
+@[to_additive (attr := simps)
+/-- The identity map from a type with addition to itself. -/]
 def MulHom.id (M : Type*) [Mul M] : M →ₙ* M where
   toFun x := x
   map_mul' _ _ := rfl
 
 /-- The identity map from a monoid to itself. -/
-@[to_additive (attr := simps) /-- The identity map from an additive monoid to itself. -/]
+@[to_additive (attr := simps)
+/-- The identity map from an additive monoid to itself. -/]
 def MonoidHom.id (M : Type*) [MulOne M] : M →* M where
   toFun x := x
   map_one' := rfl
   map_mul' _ _ := rfl
 
-@[to_additive (attr := simp)]
-lemma OneHom.coe_id {M : Type*} [One M] : (OneHom.id M : M → M) = _root_.id := rfl
-
-@[to_additive (attr := simp)]
-lemma MulHom.coe_id {M : Type*} [Mul M] : (MulHom.id M : M → M) = _root_.id := rfl
-
-@[to_additive (attr := simp)]
-lemma MonoidHom.coe_id {M : Type*} [MulOne M] : (MonoidHom.id M : M → M) = _root_.id := rfl
-
 /-- Composition of `OneHom`s as a `OneHom`. -/
-@[to_additive /-- Composition of `ZeroHom`s as a `ZeroHom`. -/]
+@[to_additive (attr := simps)
+/-- Composition of `ZeroHom`s as a `ZeroHom`. -/]
 def OneHom.comp [One M] [One N] [One P] (hnp : OneHom N P) (hmn : OneHom M N) : OneHom M P where
   toFun := hnp ∘ hmn
   map_one' := by simp
 
 /-- Composition of `MulHom`s as a `MulHom`. -/
-@[to_additive /-- Composition of `AddHom`s as an `AddHom`. -/]
+@[to_additive (attr := simps)
+/-- Composition of `AddHom`s as an `AddHom`. -/]
 def MulHom.comp [Mul M] [Mul N] [Mul P] (hnp : N →ₙ* P) (hmn : M →ₙ* N) : M →ₙ* P where
   toFun := hnp ∘ hmn
   map_mul' x y := by simp
 
 /-- Composition of monoid morphisms as a monoid morphism. -/
-@[to_additive /-- Composition of additive monoid morphisms as an additive monoid morphism. -/]
+@[to_additive (attr := simps)
+/-- Composition of additive monoid morphisms as an additive monoid morphism. -/]
 def MonoidHom.comp [MulOne M] [MulOne N] [MulOne P] (hnp : N →* P) (hmn : M →* N) :
     M →* P where
   toFun := hnp ∘ hmn
   map_one' := by simp
   map_mul' := by simp
-
-@[to_additive (attr := simp)]
-theorem OneHom.coe_comp [One M] [One N] [One P] (g : OneHom N P) (f : OneHom M N) :
-    ↑(g.comp f) = g ∘ f := rfl
-
-@[to_additive (attr := simp)]
-theorem MulHom.coe_comp [Mul M] [Mul N] [Mul P] (g : N →ₙ* P) (f : M →ₙ* N) :
-    ↑(g.comp f) = g ∘ f := rfl
-
-@[to_additive (attr := simp)]
-theorem MonoidHom.coe_comp [MulOne M] [MulOne N] [MulOne P]
-    (g : N →* P) (f : M →* N) : ↑(g.comp f) = g ∘ f := rfl
 
 @[to_additive]
 theorem OneHom.comp_apply [One M] [One N] [One P] (g : OneHom N P) (f : OneHom M N) (x : M) :
@@ -888,9 +871,9 @@ protected theorem MonoidHom.map_zpow' [DivInvMonoid M] [DivInvMonoid N] (f : M �
 @[to_additive (attr := simps)
 /-- Make a `ZeroHom` inverse from the bijective inverse of a `ZeroHom` -/]
 def OneHom.inverse [One M] [One N] (f : OneHom M N) (g : N → M) (h₁ : Function.LeftInverse g f) :
-    OneHom N M :=
-  { toFun := g,
-    map_one' := by rw [← f.map_one, h₁] }
+    OneHom N M where
+  toFun := g
+  map_one' := by rw [← f.map_one, h₁]
 
 /-- Makes a multiplicative inverse from a bijection which preserves multiplication. -/
 @[to_additive (attr := simps)

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -222,7 +222,7 @@ instance (priority := 75) toCommGroup {G : Type*} [CommGroup G] [SetLike S G] [S
     (fun _ _ => rfl) fun _ _ => rfl
 
 /-- The natural group hom from a subgroup of group `G` to `G`. -/
-@[to_additive (attr := coe)
+@[to_additive (attr := simps (config := .asFn))
   /-- The natural group hom from an additive subgroup of `AddGroup` `G` to `G`. -/]
 protected def subtype : H →* G where
   toFun := ((↑) : H → G); map_one' := rfl; map_mul' := fun _ _ => rfl
@@ -236,10 +236,6 @@ lemma subtype_apply (x : H) :
 lemma subtype_injective :
     Function.Injective (SubgroupClass.subtype H) :=
   Subtype.coe_injective
-
-@[to_additive (attr := simp)]
-theorem coe_subtype : (SubgroupClass.subtype H : H → G) = ((↑) : H → G) := by
-  rfl
 
 variable {H}
 
@@ -594,8 +590,7 @@ def inclusion {H K : Subgroup G} (h : H ≤ K) : H →* K :=
   MonoidHom.mk' (fun x => ⟨x, h x.2⟩) fun _ _ => rfl
 
 @[to_additive (attr := simp)]
-theorem coe_inclusion {H K : Subgroup G} (h : H ≤ K) (a : H) : (inclusion h a : G) = a :=
-  Set.coe_inclusion h a
+theorem coe_inclusion {H K : Subgroup G} (h : H ≤ K) (a : H) : (inclusion h a : G) = a := rfl
 
 @[to_additive]
 theorem inclusion_injective {H K : Subgroup G} (h : H ≤ K) : Function.Injective <| inclusion h :=

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -723,7 +723,7 @@ theorem restrict_mrange (f : M →* N) : mrange (f.restrict S) = S.map f := by
   simp [SetLike.ext_iff]
 
 /-- Restriction of a monoid hom to a submonoid of the codomain. -/
-@[to_additive (attr := simps apply)
+@[to_additive (attr := simps (config := .asFn))
   /-- Restriction of an `AddMonoid` hom to an `AddSubmonoid` of the codomain. -/]
 def codRestrict {S} [SetLike S N] [SubmonoidClass S N] (f : M →* N) (s : S) (h : ∀ x, f x ∈ s) :
     M →* s where

--- a/Mathlib/Algebra/Group/WithOne/Basic.lean
+++ b/Mathlib/Algebra/Group/WithOne/Basic.lean
@@ -38,7 +38,7 @@ instance instInvolutiveInv [InvolutiveInv α] : InvolutiveInv (WithOne α) where
 section
 
 /-- `WithOne.coe` as a bundled morphism -/
-@[to_additive (attr := simps apply) /-- `WithZero.coe` as a bundled morphism -/]
+@[to_additive (attr := simps) /-- `WithZero.coe` as a bundled morphism -/]
 def coeMulHom [Mul α] : α →ₙ* WithOne α where
   toFun := coe
   map_mul' _ _ := rfl

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -93,7 +93,7 @@ instance instMulZeroOneClass [MulOneClass α] : MulZeroOneClass (WithZero α) wh
 
 set_option linter.style.whitespace false in -- manual alignment is not recognised
 /-- Coercion as a monoid hom. -/
-@[simps apply]
+@[simps (config := .asFn)]
 def coeMonoidHom : α →* WithZero α where
   toFun        := (↑)
   map_one'     := rfl
@@ -112,7 +112,7 @@ theorem monoidWithZeroHom_ext ⦃f g : WithZero α →*₀ β⦄
     | (g : α) => DFunLike.congr_fun h g
 
 /-- The (multiplicative) universal property of `WithZero`. -/
-@[simps! symm_apply_apply]
+@[simps! (config := .asFn)]
 nonrec def lift' : (α →* β) ≃ (WithZero α →*₀ β) where
   toFun f :=
     { toFun := recZeroCoe 0 f

--- a/Mathlib/Algebra/Module/End.lean
+++ b/Mathlib/Algebra/Module/End.lean
@@ -38,7 +38,7 @@ variable (R M)
 /-- `(•)` as an `AddMonoidHom`.
 
 This is a stronger version of `DistribMulAction.toAddMonoidEnd` -/
-@[simps! apply_apply]
+@[simps!]
 def Module.toAddMonoidEnd : R →+* AddMonoid.End M :=
   { DistribMulAction.toAddMonoidEnd R M with
     map_zero' := AddMonoidHom.ext fun r => by simp

--- a/Mathlib/GroupTheory/NoncommCoprod.lean
+++ b/Mathlib/GroupTheory/NoncommCoprod.lean
@@ -92,8 +92,7 @@ def noncommCoprod : M × N →* P where
 @[to_additive
   /-- Variant of `AddMonoidHom.noncommCoprod_apply` with the sum written in the other direction -/]
 theorem noncommCoprod_apply' (comm) (mn : M × N) :
-    (f.noncommCoprod g comm) mn = g mn.2 * f mn.1 := by
-  rw [← comm, MonoidHom.noncommCoprod_apply]
+    (f.noncommCoprod g comm) mn = g mn.2 * f mn.1 := by simp [(comm _ _).eq]
 
 @[to_additive (attr := simp)]
 theorem noncommCoprod_comp_inl : (f.noncommCoprod g comm).comp (inl M N) = f :=


### PR DESCRIPTION
Make `simps` generate `coe_concreteHom` rather than`concreteHom_apply`.

From FLT


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
In fact, I would love to have both the `coe_` and `_apply` projections simultaneously and also to not have to specify ` simps (config := .asFn))` every single time we want to generate the `coe_` projection, but `simps ` seems to not be able to do that? cc @fpvandoorn
I must say, after four years of working on mathlib, I still don't understand how one is supposed to use `simps`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
