### PR TITLE
[Merged by Bors] - feat: the iterated derivative of an analytic function

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1072,6 +1072,7 @@ import Mathlib.Analysis.Analytic.Composition
 import Mathlib.Analysis.Analytic.Constructions
 import Mathlib.Analysis.Analytic.Inverse
 import Mathlib.Analysis.Analytic.IsolatedZeros
+import Mathlib.Analysis.Analytic.IteratedFDeriv
 import Mathlib.Analysis.Analytic.Linear
 import Mathlib.Analysis.Analytic.Meromorphic
 import Mathlib.Analysis.Analytic.OfScalars

--- a/Mathlib/Analysis/Analytic/IteratedFDeriv.lean
+++ b/Mathlib/Analysis/Analytic/IteratedFDeriv.lean
@@ -1,0 +1,274 @@
+/-
+Copyright (c) 2024 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+-/
+import Mathlib.Analysis.Calculus.ContDiff.Basic
+import Mathlib.Analysis.Calculus.ContDiff.CPolynomial
+import Mathlib.Data.Fintype.Perm
+
+/-!
+# The iterated derivative of an analytic function
+
+If a function is analytic, written as `f (x + y) = ∑ pₙ (y, ..., y)` then its `n`-th iterated
+derivative at `x` is given by `(v₁, ..., vₙ) ↦ ∑ pₙ (v_{σ (1)}, ..., v_{σ (n)})` where the sum
+is over all permutations of `{1, ..., n}`. In particular, it is symmetric.
+
+## Main result
+
+* `HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum` shows that
+  `iteratedFDeriv 𝕜 n f x v = ∑ σ : Perm (Fin n), p n (fun i ↦ v (σ i))`,
+  when `f` has `p` as power series within the set `s` on the ball `B (x, r)`.
+* `ContDiffAt.iteratedFDeriv_comp_perm` proves the symmetry of the iterated derivative of an
+  analytic function, in the form `iteratedFDeriv 𝕜 n f x (v ∘ σ) = iteratedFDeriv 𝕜 n f x v`
+  for any permutation `σ` of `Fin n`.
+
+Versions within sets are also given.
+
+## Implementation
+
+To prove the formula for the iterated derivative, se decompose an analytic function as
+the sum of `fun y ↦ pₙ (y, ..., y)` and the rest. For the former, its iterated derivative follows
+from the formula for iterated derivatives of multilinear maps
+(see `ContinuousMultilinearMap.iteratedFDeriv_comp_diagonal`). For the latter, we show by
+induction on `n` that if the `n`-th term in a power series is zero, then the `n`-th iterated
+derivative vanishes (see `HasFPowerSeriesWithinOnBall.iteratedFDerivWithin_eq_zero`).
+
+All these results are proved assuming additionally that the function is analytic on the relevant
+set (which does not follow from the fact that the function has a power series, if the target space
+is not complete). This makes it possible to avoid all completeness assumptions in the final
+statements. When needed, we give versions of some statements assuming completeness and dropping
+analyticity, for ease of use.
+-/
+
+open scoped ENNReal Topology ContDiff
+open Equiv Set
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  {f : E → F} {p : FormalMultilinearSeries 𝕜 E F} {s : Set E} {x : E} {r : ℝ≥0∞}
+
+/-- Formal multilinear series associated to the iterated derivative, defined by iterating
+`p ↦ p.derivSeries` and currying suitably. It is defined so that, if a function has `p` has a power
+series, then its iterated derivative of order `k` has `p.iteratedFDerivSeries k` as a power
+series. -/
+noncomputable def FormalMultilinearSeries.iteratedFDerivSeries
+    (p : FormalMultilinearSeries 𝕜 E F) (k : ℕ) :
+    FormalMultilinearSeries 𝕜 E (E [×k]→L[𝕜] F) :=
+  match k with
+  | 0 => (continuousMultilinearCurryFin0 𝕜 E F).symm
+      |>.toContinuousLinearEquiv.toContinuousLinearMap.compFormalMultilinearSeries p
+  | (k + 1) => (continuousMultilinearCurryLeftEquiv 𝕜 (fun _ : Fin (k + 1) ↦ E) F).symm
+      |>.toContinuousLinearEquiv.toContinuousLinearMap.compFormalMultilinearSeries
+      (p.iteratedFDerivSeries k).derivSeries
+
+/-- If a function has a power series on a ball, then so do its iterated derivatives. -/
+protected theorem HasFPowerSeriesWithinOnBall.iteratedFDerivWithin
+    (h : HasFPowerSeriesWithinOnBall f p s x r) (h' : AnalyticOn 𝕜 f s)
+    (k : ℕ) (hs : UniqueDiffOn 𝕜 s) (hx : x ∈ s) :
+    HasFPowerSeriesWithinOnBall (iteratedFDerivWithin 𝕜 k f s)
+      (p.iteratedFDerivSeries k) s x r := by
+  induction k with
+  | zero =>
+    exact (continuousMultilinearCurryFin0 𝕜 E F).symm
+      |>.toContinuousLinearEquiv.toContinuousLinearMap.comp_hasFPowerSeriesWithinOnBall h
+  | succ k ih =>
+    rw [iteratedFDerivWithin_succ_eq_comp_left]
+    apply (continuousMultilinearCurryLeftEquiv 𝕜 (fun _ : Fin (k + 1) ↦ E) F).symm
+      |>.toContinuousLinearEquiv.toContinuousLinearMap.comp_hasFPowerSeriesWithinOnBall
+        (ih.fderivWithin_of_mem_of_analyticOn (h'.iteratedFDerivWithin hs _) hs hx)
+
+lemma FormalMultilinearSeries.iteratedFDerivSeries_eq_zero {k n : ℕ}
+    (h : p (n + k) = 0) : p.iteratedFDerivSeries k n = 0 := by
+  induction k generalizing n with
+  | zero =>
+    ext
+    have : p n = 0 := p.congr_zero rfl h
+    simp [FormalMultilinearSeries.iteratedFDerivSeries, this]
+  | succ k ih =>
+    ext
+    simp only [iteratedFDerivSeries, Nat.succ_eq_add_one,
+      ContinuousLinearMap.compFormalMultilinearSeries_apply,
+      ContinuousLinearMap.compContinuousMultilinearMap_coe, ContinuousLinearEquiv.coe_coe,
+      LinearIsometryEquiv.coe_toContinuousLinearEquiv, Function.comp_apply,
+      continuousMultilinearCurryLeftEquiv_symm_apply, ContinuousMultilinearMap.zero_apply]
+    rw [derivSeries_eq_zero]
+    · rfl
+    · apply ih
+      apply p.congr_zero (by abel) h
+
+/-- If the `n`-th term in a power series is zero, then the `n`-th derivative of the corresponding
+function vanished. -/
+lemma HasFPowerSeriesWithinOnBall.iteratedFDerivWithin_eq_zero
+    (h : HasFPowerSeriesWithinOnBall f p s x r) (h' : AnalyticOn 𝕜 f s)
+    (hu : UniqueDiffOn 𝕜 s) (hx : x ∈ s) {n : ℕ} (hn : p n = 0) :
+    iteratedFDerivWithin 𝕜 n f s x = 0 := by
+  have : iteratedFDerivWithin 𝕜 n f s x = p.iteratedFDerivSeries n 0 (fun _ ↦ 0) :=
+    ((h.iteratedFDerivWithin h' n hu hx).coeff_zero _).symm
+  rw [this, p.iteratedFDerivSeries_eq_zero (p.congr_zero (Nat.zero_add n).symm hn)]
+  rfl
+
+lemma ContinuousMultilinearMap.iteratedFDeriv_comp_diagonal
+    {n : ℕ} (f : E [×n]→L[𝕜] F) (x : E) (v : Fin n → E) :
+    iteratedFDeriv 𝕜 n (fun x ↦ f (fun _ ↦ x)) x v = ∑ σ : Perm (Fin n), f (fun i ↦ v (σ i)) := by
+  rw [← sum_comp (Equiv.inv (Perm (Fin n)))]
+  let g : E →L[𝕜] (Fin n → E) := ContinuousLinearMap.pi (fun i ↦ ContinuousLinearMap.id 𝕜 E)
+  change iteratedFDeriv 𝕜 n (f ∘ g) x v = _
+  rw [ContinuousLinearMap.iteratedFDeriv_comp_right _ f.contDiff _ le_rfl, f.iteratedFDeriv_eq]
+  simp only [ContinuousMultilinearMap.iteratedFDeriv,
+    ContinuousMultilinearMap.compContinuousLinearMap_apply, ContinuousMultilinearMap.sum_apply,
+    ContinuousMultilinearMap.iteratedFDerivComponent_apply, Set.mem_range, Pi.compRightL_apply]
+  rw [← sum_comp (Equiv.embeddingEquivOfFinite (Fin n))]
+  congr with σ
+  congr with i
+  have A : ∃ y, σ y = i := by
+    have : Function.Bijective σ := (Fintype.bijective_iff_injective_and_card _).2 ⟨σ.injective, rfl⟩
+    exact this.surjective i
+  rcases A with ⟨y, rfl⟩
+  simp only [EmbeddingLike.apply_eq_iff_eq, exists_eq, ↓reduceDIte,
+    Function.Embedding.toEquivRange_symm_apply_self, ContinuousLinearMap.coe_pi',
+    ContinuousLinearMap.coe_id', id_eq, g]
+  congr 1
+  symm
+  simp [coe_fn_mk, inv_apply, Perm.inv_def,
+    ofBijective_symm_apply_apply, Function.Embedding.equivOfFiniteSelfEmbedding]
+
+private lemma HasFPowerSeriesWithinOnBall.iteratedFDerivWithin_eq_sum_of_subset
+    (h : HasFPowerSeriesWithinOnBall f p s x r) (h' : AnalyticOn 𝕜 f s)
+    (hs : UniqueDiffOn 𝕜 s) (hx : x ∈ s)
+    {n : ℕ} (v : Fin n → E) (h's : s ⊆ EMetric.ball x r) :
+    iteratedFDerivWithin 𝕜 n f s x v = ∑ σ : Perm (Fin n), p n (fun i ↦ v (σ i)) := by
+  have I : insert x s ∩ EMetric.ball x r = s := by
+    rw [Set.insert_eq_of_mem hx]
+    exact Set.inter_eq_left.2 h's
+  have fcont : ContDiffOn 𝕜 (↑n) f s := by
+    apply AnalyticOn.contDiffOn _ hs
+    simpa [I] using h'
+  let g : E → F := fun z ↦ p n (fun _ ↦ z - x)
+  have gcont : ContDiff 𝕜 ω g := by
+    apply (p n).contDiff.comp
+    exact contDiff_pi.2 (fun i ↦ contDiff_id.sub contDiff_const)
+  let q : FormalMultilinearSeries 𝕜 E F := fun k ↦ if h : n = k then (h ▸ p n) else 0
+  have A : HasFiniteFPowerSeriesOnBall g q x (n + 1) r := by
+    apply HasFiniteFPowerSeriesOnBall.mk' _ h.r_pos
+    · intro y hy
+      rw [Finset.sum_eq_single_of_mem n]
+      · simp [q, g]
+      · simp
+      · intro i hi h'i
+        simp [q, h'i.symm]
+    · intro m hm
+      have : n ≠ m := by omega
+      simp [q, this]
+  have B : HasFPowerSeriesWithinOnBall g q s x r :=
+    A.toHasFPowerSeriesOnBall.hasFPowerSeriesWithinOnBall
+  have J1 : iteratedFDerivWithin 𝕜 n f s x =
+      iteratedFDerivWithin 𝕜 n g s x + iteratedFDerivWithin 𝕜 n (f - g) s x := by
+    have : f = g + (f - g) := by abel
+    nth_rewrite 1 [this]
+    rw [iteratedFDerivWithin_add_apply (gcont.of_le le_top).contDiffOn
+      (by exact fcont.sub (gcont.of_le le_top).contDiffOn) hs hx]
+  have J2 : iteratedFDerivWithin 𝕜 n (f - g) s x = 0 := by
+    apply (h.sub B).iteratedFDerivWithin_eq_zero (h'.sub ?_) hs hx
+    · simp [q]
+    · apply gcont.contDiffOn.analyticOn
+  have J3 : iteratedFDerivWithin 𝕜 n g s x = iteratedFDeriv 𝕜 n g x :=
+    iteratedFDerivWithin_eq_iteratedFDeriv hs (gcont.of_le le_top).contDiffAt hx
+  simp only [J1, J3, J2, add_zero]
+  let g' : E → F := fun z ↦ p n (fun _ ↦ z)
+  have : g = fun z ↦ g' (z - x) := rfl
+  rw [this, iteratedFDeriv_comp_sub]
+  exact (p n).iteratedFDeriv_comp_diagonal _ v
+
+/-- If a function has a power series in a ball, then its `n`-th iterated derivative is given by
+`(v₁, ..., vₙ) ↦ ∑ pₙ (v_{σ (1)}, ..., v_{σ (n)})` where the sum is over all
+permutations of `{1, ..., n}`.-/
+theorem HasFPowerSeriesWithinOnBall.iteratedFDerivWithin_eq_sum
+    (h : HasFPowerSeriesWithinOnBall f p s x r) (h' : AnalyticOn 𝕜 f s)
+    (hs : UniqueDiffOn 𝕜 s) (hx : x ∈ s) {n : ℕ} (v : Fin n → E) :
+    iteratedFDerivWithin 𝕜 n f s x v = ∑ σ : Perm (Fin n), p n (fun i ↦ v (σ i)) := by
+  have : iteratedFDerivWithin 𝕜 n f s x
+      = iteratedFDerivWithin 𝕜 n f (s ∩ EMetric.ball x r) x :=
+    (iteratedFDerivWithin_inter_open EMetric.isOpen_ball (EMetric.mem_ball_self h.r_pos)).symm
+  rw [this]
+  apply HasFPowerSeriesWithinOnBall.iteratedFDerivWithin_eq_sum_of_subset
+  · exact h.mono inter_subset_left
+  · exact h'.mono inter_subset_left
+  · exact hs.inter EMetric.isOpen_ball
+  · exact ⟨hx, EMetric.mem_ball_self h.r_pos⟩
+  · exact inter_subset_right
+
+/-- If a function has a power series in a ball, then its `n`-th iterated derivative is given by
+`(v₁, ..., vₙ) ↦ ∑ pₙ (v_{σ (1)}, ..., v_{σ (n)})` where the sum is over all
+permutations of `{1, ..., n}`.-/
+theorem HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum
+    (h : HasFPowerSeriesOnBall f p x r) (h' : AnalyticOn 𝕜 f univ) {n : ℕ} (v : Fin n → E) :
+    iteratedFDeriv 𝕜 n f x v = ∑ σ : Perm (Fin n), p n (fun i ↦ v (σ i)) := by
+  simp only [← iteratedFDerivWithin_univ, ← hasFPowerSeriesWithinOnBall_univ] at h ⊢
+  exact h.iteratedFDerivWithin_eq_sum h' uniqueDiffOn_univ (mem_univ x) v
+
+/-- If a function has a power series in a ball, then its `n`-th iterated derivative is given by
+`(v₁, ..., vₙ) ↦ ∑ pₙ (v_{σ (1)}, ..., v_{σ (n)})` where the sum is over all
+permutations of `{1, ..., n}`.-/
+theorem HasFPowerSeriesWithinOnBall.iteratedFDerivWithin_eq_sum_of_completeSpace [CompleteSpace F]
+    (h : HasFPowerSeriesWithinOnBall f p s x r)
+    (hs : UniqueDiffOn 𝕜 s) (hx : x ∈ s) {n : ℕ} (v : Fin n → E) :
+    iteratedFDerivWithin 𝕜 n f s x v = ∑ σ : Perm (Fin n), p n (fun i ↦ v (σ i)) := by
+  have : iteratedFDerivWithin 𝕜 n f s x
+      = iteratedFDerivWithin 𝕜 n f (s ∩ EMetric.ball x r) x :=
+    (iteratedFDerivWithin_inter_open EMetric.isOpen_ball (EMetric.mem_ball_self h.r_pos)).symm
+  rw [this]
+  apply HasFPowerSeriesWithinOnBall.iteratedFDerivWithin_eq_sum_of_subset
+  · exact h.mono inter_subset_left
+  · apply h.analyticOn.mono
+    rw [insert_eq_of_mem hx]
+  · exact hs.inter EMetric.isOpen_ball
+  · exact ⟨hx, EMetric.mem_ball_self h.r_pos⟩
+  · exact inter_subset_right
+
+/-- If a function has a power series in a ball, then its `n`-th iterated derivative is given by
+`(v₁, ..., vₙ) ↦ ∑ pₙ (v_{σ (1)}, ..., v_{σ (n)})` where the sum is over all
+permutations of `{1, ..., n}`.-/
+theorem HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum_of_completeSpace [CompleteSpace F]
+    (h : HasFPowerSeriesOnBall f p x r) {n : ℕ} (v : Fin n → E) :
+    iteratedFDeriv 𝕜 n f x v = ∑ σ : Perm (Fin n), p n (fun i ↦ v (σ i)) := by
+  simp only [← iteratedFDerivWithin_univ, ← hasFPowerSeriesWithinOnBall_univ] at h ⊢
+  exact h.iteratedFDerivWithin_eq_sum_of_completeSpace uniqueDiffOn_univ (mem_univ _) v
+
+/-- The `n`-th iterated derivative of an analytic function on a set is symmetric. -/
+theorem AnalyticOn.iteratedFDerivWithin_comp_perm
+    (h : AnalyticOn 𝕜 f s) (hs : UniqueDiffOn 𝕜 s) (hx : x ∈ s) {n : ℕ} (v : Fin n → E)
+    (σ : Perm (Fin n)) :
+    iteratedFDerivWithin 𝕜 n f s x (v ∘ σ) = iteratedFDerivWithin 𝕜 n f s x v := by
+  rcases h x hx with ⟨p, r, hp⟩
+  rw [hp.iteratedFDerivWithin_eq_sum h hs hx, hp.iteratedFDerivWithin_eq_sum h hs hx]
+  let e := Equiv.mulLeft σ
+  conv_rhs => rw [← Equiv.sum_comp e]
+  rfl
+
+/-- The `n`-th iterated derivative of an analytic function on a set is symmetric. -/
+theorem ContDiffWithinAt.iteratedFDerivWithin_comp_perm
+    (h : ContDiffWithinAt 𝕜 ω f s x) (hs : UniqueDiffOn 𝕜 s) (hx : x ∈ s) {n : ℕ} (v : Fin n → E)
+    (σ : Perm (Fin n)) :
+    iteratedFDerivWithin 𝕜 n f s x (v ∘ σ) = iteratedFDerivWithin 𝕜 n f s x v := by
+  rcases h.contDiffOn' le_rfl (by simp) with ⟨u, u_open, xu, hu⟩
+  rw [insert_eq_of_mem hx] at hu
+  have : iteratedFDerivWithin 𝕜 n f (s ∩ u) x = iteratedFDerivWithin 𝕜 n f s x :=
+    iteratedFDerivWithin_inter_open u_open xu
+  rw [← this]
+  exact AnalyticOn.iteratedFDerivWithin_comp_perm hu.analyticOn (hs.inter u_open) ⟨hx, xu⟩ _ _
+
+/-- The `n`-th iterated derivative of an analytic function is symmetric. -/
+theorem AnalyticOn.iteratedFDeriv_comp_perm
+    (h : AnalyticOn 𝕜 f univ) {n : ℕ} (v : Fin n → E) (σ : Perm (Fin n)) :
+    iteratedFDeriv 𝕜 n f x (v ∘ σ) = iteratedFDeriv 𝕜 n f x v := by
+  rw [← iteratedFDerivWithin_univ]
+  exact h.iteratedFDerivWithin_comp_perm uniqueDiffOn_univ (mem_univ x) _ _
+
+/-- The `n`-th iterated derivative of an analytic function is symmetric. -/
+theorem ContDiffAt.iteratedFDeriv_comp_perm
+    (h : ContDiffAt 𝕜 ω f x) {n : ℕ} (v : Fin n → E) (σ : Perm (Fin n)) :
+    iteratedFDeriv 𝕜 n f x (v ∘ σ) = iteratedFDeriv 𝕜 n f x v := by
+  rw [← iteratedFDerivWithin_univ]
+  exact h.iteratedFDerivWithin_comp_perm uniqueDiffOn_univ (mem_univ x) _ _

--- a/Mathlib/Analysis/Analytic/IteratedFDeriv.lean
+++ b/Mathlib/Analysis/Analytic/IteratedFDeriv.lean
@@ -30,7 +30,7 @@ Versions within sets are also given.
 
 ## Implementation
 
-To prove the formula for the iterated derivative, se decompose an analytic function as
+To prove the formula for the iterated derivative, we decompose an analytic function as
 the sum of `fun y ↦ pₙ (y, ..., y)` and the rest. For the former, its iterated derivative follows
 from the formula for iterated derivatives of multilinear maps
 (see `ContinuousMultilinearMap.iteratedFDeriv_comp_diagonal`). For the latter, we show by
@@ -53,7 +53,7 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {f : E → F} {p : FormalMultilinearSeries 𝕜 E F} {s : Set E} {x : E} {r : ℝ≥0∞}
 
 /-- Formal multilinear series associated to the iterated derivative, defined by iterating
-`p ↦ p.derivSeries` and currying suitably. It is defined so that, if a function has `p` has a power
+`p ↦ p.derivSeries` and currying suitably. It is defined so that, if a function has `p` as a power
 series, then its iterated derivative of order `k` has `p.iteratedFDerivSeries k` as a power
 series. -/
 noncomputable def FormalMultilinearSeries.iteratedFDerivSeries
@@ -102,7 +102,7 @@ lemma FormalMultilinearSeries.iteratedFDerivSeries_eq_zero {k n : ℕ}
       apply p.congr_zero (by abel) h
 
 /-- If the `n`-th term in a power series is zero, then the `n`-th derivative of the corresponding
-function vanished. -/
+function vanishes. -/
 lemma HasFPowerSeriesWithinOnBall.iteratedFDerivWithin_eq_zero
     (h : HasFPowerSeriesWithinOnBall f p s x r) (h' : AnalyticOn 𝕜 f s)
     (hu : UniqueDiffOn 𝕜 s) (hx : x ∈ s) {n : ℕ} (hn : p n = 0) :

--- a/Mathlib/Analysis/Analytic/IteratedFDeriv.lean
+++ b/Mathlib/Analysis/Analytic/IteratedFDeriv.lean
@@ -14,6 +14,9 @@ If a function is analytic, written as `f (x + y) = ∑ pₙ (y, ..., y)` then it
 derivative at `x` is given by `(v₁, ..., vₙ) ↦ ∑ pₙ (v_{σ (1)}, ..., v_{σ (n)})` where the sum
 is over all permutations of `{1, ..., n}`. In particular, it is symmetric.
 
+This generalizes the result of `HasFPowerSeriesOnBall.factorial_smul` giving
+`D^n f (v, ..., v) = n! * pₙ (v, ..., v)`.
+
 ## Main result
 
 * `HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum` shows that

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -762,6 +762,10 @@ private theorem factorial_smul' {n : ℕ} : ∀ {F : Type max u v} [NormedAddCom
 variable [CompleteSpace F]
 include h
 
+/-- The iterated derivative of an analytic function, on vectors `(y, ..., y)`, is given by `n!`
+times the `n`-th term in the power series. For a more general result giving the full iterated
+derivative as a sum over the permutations of `Fin n`, see
+`HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum`. -/
 theorem factorial_smul (n : ℕ) :
     n ! • p n (fun _ ↦ y) = iteratedFDeriv 𝕜 n f x (fun _ ↦ y) := by
   cases n


### PR DESCRIPTION
Prove the formula `D^n f (x ; v_1, ..., v_n) = ∑ pₙ (v_{σ (1)}, ..., v_{σ (n)})` if `pₙ` is the `n`-th term in a power series expansion of `f`, where the sum is over all permutations of `Fin n`. Deduce that the iterated derivative is symmetric.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
