### PR TITLE
[Merged by Bors] - feat: transversals of a finite index subgroup are finite

### DIFF
--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -149,11 +149,11 @@ lemma not_isComplement_empty_right : ¬ IsComplement S ∅ :=
   fun h ↦ by simpa [eq_comm (a := ∅)] using h.mul_eq
 
 @[to_additive]
-lemma IsComplement.nonempty_of_left (hst : IsComplement S T) : S.Nonempty := by
+lemma IsComplement.nonempty_left (hst : IsComplement S T) : S.Nonempty := by
   contrapose! hst; simp [hst]
 
 @[to_additive]
-lemma IsComplement.nonempty_of_right (hst : IsComplement S T) : T.Nonempty := by
+lemma IsComplement.nonempty_right (hst : IsComplement S T) : T.Nonempty := by
   contrapose! hst; simp [hst]
 
 @[to_additive] lemma IsComplement.pairwiseDisjoint_smul (hst : IsComplement S T) :

--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -140,6 +140,27 @@ theorem isComplement_univ_right : IsComplement S univ ↔ ∃ g : G, S = {g} := 
 lemma IsComplement.mul_eq (h : IsComplement S T) : S * T = univ :=
   eq_univ_of_forall fun x ↦ by simpa [mem_mul] using (h.existsUnique x).exists
 
+@[to_additive (attr := simp)]
+lemma not_isComplement_empty_left : ¬ IsComplement ∅ T :=
+  fun h ↦ by simpa [eq_comm (a := ∅)] using h.mul_eq
+
+@[to_additive (attr := simp)]
+lemma not_isComplement_empty_right : ¬ IsComplement S ∅ :=
+  fun h ↦ by simpa [eq_comm (a := ∅)] using h.mul_eq
+
+@[to_additive]
+lemma IsComplement.nonempty_of_left (hst : IsComplement S T) : S.Nonempty := by
+  contrapose! hst; simp [hst]
+
+@[to_additive]
+lemma IsComplement.nonempty_of_right (hst : IsComplement S T) : T.Nonempty := by
+  contrapose! hst; simp [hst]
+
+@[to_additive] lemma IsComplement.pairwiseDisjoint_smul (hst : IsComplement S T) :
+    S.PairwiseDisjoint (· • T) := fun a ha b hb hab ↦ disjoint_iff_forall_ne.2 <| by
+  rintro _ ⟨c, hc, rfl⟩ _ ⟨d, hd, rfl⟩
+  exact hst.1.ne (a₁ := (⟨a, ha⟩, ⟨c, hc⟩)) (a₂:= (⟨b, hb⟩, ⟨d, hd⟩)) (by simp [hab])
+
 @[to_additive AddSubgroup.IsComplement.card_mul_card]
 lemma IsComplement.card_mul_card (h : IsComplement S T) : Nat.card S * Nat.card T = Nat.card G :=
   (Nat.card_prod _ _).symm.trans <| Nat.card_congr <| Equiv.ofBijective _ h
@@ -578,6 +599,9 @@ theorem finite_left_iff (h : IsComplement S H) : Finite S ↔ H.FiniteIndex := b
 alias _root_.Subgroup.MemLeftTransversals.finite_iff := finite_left_iff
 
 @[to_additive]
+lemma finite_left [H.FiniteIndex] (hS : IsComplement S H) : S.Finite := hS.finite_left_iff.2 ‹_›
+
+@[to_additive]
 theorem quotientGroupMk_leftQuotientEquiv (hS : IsComplement S H) (q : G ⧸ H) :
     Quotient.mk'' (leftQuotientEquiv hS q : G) = q :=
   hS.leftQuotientEquiv.symm_apply_apply q
@@ -637,6 +661,9 @@ theorem finite_right_iff (h : IsComplement H T) : Finite T ↔ H.FiniteIndex := 
 
 @[deprecated (since := "2024-12-28")]
 alias _root_.Subgroup.MemRightTransversals.finite_iff := finite_right_iff
+
+@[to_additive]
+lemma finite_right [H.FiniteIndex] (hT : IsComplement H T) : T.Finite := hT.finite_right_iff.2 ‹_›
 
 @[to_additive]
 theorem mk''_rightQuotientEquiv (hT : IsComplement H T)


### PR DESCRIPTION
From FLT


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [x] depends on: #abc [optional extra text]
- [x] depends on: #xyz [optional extra text]

-->
- [x] depends on: #20041
- [x] depends on: #20042

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
