### PR TITLE
[Merged by Bors] - chore(GroupTheory/Index): rename `relindex` to `relIndex`

### DIFF
--- a/Mathlib/Algebra/Module/ZLattice/Covolume.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Covolume.lean
@@ -25,7 +25,7 @@ Let `L` be a `ℤ`-lattice `L` defined as a discrete `ℤ`-submodule of `E` that
 * `ZLattice.covolume_eq_det`: if `L` is a lattice in `ℝ^n`, then its covolume is the absolute
   value of the determinant of any `ℤ`-basis of `L`.
 
-* `ZLattice.covolume_div_covolume_eq_relindex`: Let `L₁` be a sub-`ℤ`-lattice of `L₂`. Then the
+* `ZLattice.covolume_div_covolume_eq_relIndex`: Let `L₁` be a sub-`ℤ`-lattice of `L₂`. Then the
 index of `L₁` inside `L₂` is equal to `covolume L₁ / covolume L₂`.
 
 * `ZLattice.covolume.tendsto_card_div_pow`: Let `s` be a bounded measurable set of `ι → ℝ`, then
@@ -138,13 +138,13 @@ theorem covolume_eq_det_inv {ι : Type*} [Fintype ι] (L : Submodule ℤ (ι →
 Let `L₁` be a sub-`ℤ`-lattice of `L₂`. Then the index of `L₁` inside `L₂` is equal to
 `covolume L₁ / covolume L₂`.
 -/
-theorem covolume_div_covolume_eq_relindex {ι : Type*} [Fintype ι] (L₁ L₂ : Submodule ℤ (ι → ℝ))
+theorem covolume_div_covolume_eq_relIndex {ι : Type*} [Fintype ι] (L₁ L₂ : Submodule ℤ (ι → ℝ))
     [DiscreteTopology L₁] [IsZLattice ℝ L₁] [DiscreteTopology L₂] [IsZLattice ℝ L₂] (h : L₁ ≤ L₂) :
-    covolume L₁ / covolume L₂ = L₁.toAddSubgroup.relindex L₂.toAddSubgroup := by
+    covolume L₁ / covolume L₂ = L₁.toAddSubgroup.relIndex L₂.toAddSubgroup := by
   classical
   let b₁ := IsZLattice.basis L₁
   let b₂ := IsZLattice.basis L₂
-  rw [AddSubgroup.relindex_eq_natAbs_det L₁.toAddSubgroup L₂.toAddSubgroup h b₁ b₂,
+  rw [AddSubgroup.relIndex_eq_natAbs_det L₁.toAddSubgroup L₂.toAddSubgroup h b₁ b₂,
     Nat.cast_natAbs, Int.cast_abs]
   trans |(b₂.ofZLatticeBasis ℝ).det (b₁.ofZLatticeBasis ℝ)|
   · rw [← Basis.det_mul_det _ (Pi.basisFun ℝ ι) _, abs_mul, Pi.basisFun_det_apply,
@@ -157,23 +157,23 @@ theorem covolume_div_covolume_eq_relindex {ι : Type*} [Fintype ι] (L₁ L₂ :
     exact (b₂.ofZLatticeBasis_repr_apply ℝ L₂ ⟨b₁ j, h (coe_mem _)⟩ i)
 
 /--
-A more general version of `covolume_div_covolume_eq_relindex`;
+A more general version of `covolume_div_covolume_eq_relIndex`;
 see the `Naming conventions` section in the introduction.
 -/
-theorem covolume_div_covolume_eq_relindex' {E : Type*} [NormedAddCommGroup E]
+theorem covolume_div_covolume_eq_relIndex' {E : Type*} [NormedAddCommGroup E]
     [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [MeasurableSpace E] [BorelSpace E]
     (L₁ L₂ : Submodule ℤ E) [DiscreteTopology L₁] [IsZLattice ℝ L₁] [DiscreteTopology L₂]
     [IsZLattice ℝ L₂] (h : L₁ ≤ L₂) :
-    covolume L₁ / covolume L₂ = L₁.toAddSubgroup.relindex L₂.toAddSubgroup := by
+    covolume L₁ / covolume L₂ = L₁.toAddSubgroup.relIndex L₂.toAddSubgroup := by
   let f := (EuclideanSpace.equiv _ ℝ).symm.trans
     (stdOrthonormalBasis ℝ E).repr.toContinuousLinearEquiv.symm
   have hf : MeasurePreserving f := (stdOrthonormalBasis ℝ E).measurePreserving_repr_symm.comp
     (EuclideanSpace.volume_preserving_measurableEquiv _).symm
   rw [← covolume_comap L₁ volume volume hf, ← covolume_comap L₂ volume volume hf,
-    covolume_div_covolume_eq_relindex _ _ (fun _ h' ↦ h h'), ZLattice.comap_toAddSubgroup,
+    covolume_div_covolume_eq_relIndex _ _ (fun _ h' ↦ h h'), ZLattice.comap_toAddSubgroup,
     ZLattice.comap_toAddSubgroup, Nat.cast_inj, LinearEquiv.toAddMonoidHom_commutes,
     AddSubgroup.comap_equiv_eq_map_symm', AddSubgroup.comap_equiv_eq_map_symm',
-    AddSubgroup.relindex_map_map_of_injective _ _ f.symm.injective]
+    AddSubgroup.relIndex_map_map_of_injective _ _ f.symm.injective]
 
 theorem volume_image_eq_volume_div_covolume {ι : Type*} [Fintype ι] (L : Submodule ℤ (ι → ℝ))
     [DiscreteTopology L] [IsZLattice ℝ L] (b : Basis ι ℤ L) {s : Set (ι → ℝ)} :

--- a/Mathlib/Algebra/Module/ZLattice/Covolume.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Covolume.lean
@@ -156,6 +156,9 @@ theorem covolume_div_covolume_eq_relIndex {ι : Type*} [Fintype ι] (L₁ L₂ :
     rw [Matrix.map_apply, Basis.toMatrix_apply, Basis.toMatrix_apply, Basis.ofZLatticeBasis_apply]
     exact (b₂.ofZLatticeBasis_repr_apply ℝ L₂ ⟨b₁ j, h (coe_mem _)⟩ i)
 
+@[deprecated (since := "2025-08-12")]
+alias covolume_div_covolume_eq_relindex := covolume_div_covolume_eq_relIndex
+
 /--
 A more general version of `covolume_div_covolume_eq_relIndex`;
 see the `Naming conventions` section in the introduction.
@@ -174,6 +177,9 @@ theorem covolume_div_covolume_eq_relIndex' {E : Type*} [NormedAddCommGroup E]
     ZLattice.comap_toAddSubgroup, Nat.cast_inj, LinearEquiv.toAddMonoidHom_commutes,
     AddSubgroup.comap_equiv_eq_map_symm', AddSubgroup.comap_equiv_eq_map_symm',
     AddSubgroup.relIndex_map_map_of_injective _ _ f.symm.injective]
+
+@[deprecated (since := "2025-08-12")]
+alias covolume_div_covolume_eq_relindex' := covolume_div_covolume_eq_relIndex'
 
 theorem volume_image_eq_volume_div_covolume {ι : Type*} [Fintype ι] (L : Submodule ℤ (ι → ℝ))
     [DiscreteTopology L] [IsZLattice ℝ L] (b : Basis ι ℤ L) {s : Set (ι → ℝ)} :

--- a/Mathlib/FieldTheory/Relrank.lean
+++ b/Mathlib/FieldTheory/Relrank.lean
@@ -16,12 +16,12 @@ This file contains basics about the relative rank of subfields and intermediate 
 - `Subfield.relrank A B`, `IntermediateField.relrank A B`:
   defined to be `[B : A ⊓ B]` as a `Cardinal`.
   In particular, when `A ≤ B` it is `[B : A]`, the degree of the field extension `B / A`.
-  This is similar to `Subgroup.relindex` but it is `Cardinal` valued.
+  This is similar to `Subgroup.relIndex` but it is `Cardinal` valued.
 
 - `Subfield.relfinrank A B`, `IntermediateField.relfinrank A B`:
   the `Nat` version of `Subfield.relrank A B` and `IntermediateField.relrank A B`, respectively.
   If `B / A ⊓ B` is an infinite extension, then it is zero.
-  This is similar to `Subgroup.relindex`.
+  This is similar to `Subgroup.relIndex`.
 
 -/
 
@@ -37,7 +37,7 @@ variable (A B C : Subfield E)
 
 /-- `Subfield.relrank A B` is defined to be `[B : A ⊓ B]` as a `Cardinal`, in particular,
 when `A ≤ B` it is `[B : A]`, the degree of the field extension `B / A`.
-This is similar to `Subgroup.relindex` but it is `Cardinal` valued. -/
+This is similar to `Subgroup.relIndex` but it is `Cardinal` valued. -/
 noncomputable def relrank := Module.rank ↥(A ⊓ B) (extendScalars (inf_le_right : A ⊓ B ≤ B))
 
 /-- The `Nat` version of `Subfield.relrank`.
@@ -279,7 +279,7 @@ variable (A B C : IntermediateField F E)
 
 /-- `IntermediateField.relrank A B` is defined to be `[B : A ⊓ B]` as a `Cardinal`, in particular,
 when `A ≤ B` it is `[B : A]`, the degree of the field extension `B / A`.
-This is similar to `Subgroup.relindex` but it is `Cardinal` valued. -/
+This is similar to `Subgroup.relIndex` but it is `Cardinal` valued. -/
 noncomputable def relrank := A.toSubfield.relrank B.toSubfield
 
 /-- The `Nat` version of `IntermediateField.relrank`.

--- a/Mathlib/GroupTheory/Commensurable.lean
+++ b/Mathlib/GroupTheory/Commensurable.lean
@@ -33,7 +33,7 @@ variable {G : Type*} [Group G]
 
 /-- Two subgroups `H K` of `G` are commensurable if `H ⊓ K` has finite index in both `H` and `K` -/
 def Commensurable (H K : Subgroup G) : Prop :=
-  H.relindex K ≠ 0 ∧ K.relindex H ≠ 0
+  H.relIndex K ≠ 0 ∧ K.relIndex H ≠ 0
 
 namespace Commensurable
 
@@ -50,7 +50,7 @@ theorem symm {H K : Subgroup G} : Commensurable H K → Commensurable K H := And
 @[trans]
 theorem trans {H K L : Subgroup G} (hhk : Commensurable H K) (hkl : Commensurable K L) :
     Commensurable H L :=
-  ⟨Subgroup.relindex_ne_zero_trans hhk.1 hkl.1, Subgroup.relindex_ne_zero_trans hkl.2 hhk.2⟩
+  ⟨Subgroup.relIndex_ne_zero_trans hhk.1 hkl.1, Subgroup.relIndex_ne_zero_trans hkl.2 hhk.2⟩
 
 theorem equivalence : Equivalence (@Commensurable G _) :=
   ⟨Commensurable.refl, fun h => Commensurable.symm h, fun h₁ h₂ => Commensurable.trans h₁ h₂⟩

--- a/Mathlib/GroupTheory/CosetCover.lean
+++ b/Mathlib/GroupTheory/CosetCover.lean
@@ -258,7 +258,7 @@ theorem leftCoset_cover_filter_FiniteIndex_aux
       Finset.sum_sigma, Finset.sum_coe_sort_eq_attach]
     refine Finset.sum_congr rfl fun i _ => ?_
     by_cases hfi : (H i).FiniteIndex
-    · rw [← relindex_mul_index (hD_le i.2 hfi), Nat.cast_mul, mul_comm,
+    · rw [← relIndex_mul_index (hD_le i.2 hfi), Nat.cast_mul, mul_comm,
         mul_inv_cancel_right₀ (Nat.cast_ne_zero.mpr hfi.index_ne_zero)]
       simpa [K, hfi] using (ht i.1 i.2 hfi).1.card_left
     · rw [of_not_not (FiniteIndex.mk.mt hfi), Nat.cast_zero, inv_zero, zero_mul]

--- a/Mathlib/GroupTheory/GroupAction/Blocks.lean
+++ b/Mathlib/GroupTheory/GroupAction/Blocks.lean
@@ -669,11 +669,11 @@ namespace IsBlock
 variable [IsPretransitive G X] {B : Set X}
 
 @[to_additive]
-theorem ncard_block_eq_relindex (hB : IsBlock G B) {x : X} (hx : x ∈ B) :
-    B.ncard = (stabilizer G x).relindex (stabilizer G B) := by
+theorem ncard_block_eq_relIndex (hB : IsBlock G B) {x : X} (hx : x ∈ B) :
+    B.ncard = (stabilizer G x).relIndex (stabilizer G B) := by
   have key : (stabilizer G x).subgroupOf (stabilizer G B) = stabilizer (stabilizer G B) x := by
     ext; rfl
-  rw [Subgroup.relindex, key, index_stabilizer, hB.orbit_stabilizer_eq hx]
+  rw [Subgroup.relIndex, key, index_stabilizer, hB.orbit_stabilizer_eq hx]
 
 /-- The cardinality of the ambient space is the product of the cardinality of a block
   by the cardinality of the set of translates of that block -/
@@ -683,8 +683,8 @@ theorem ncard_block_eq_relindex (hB : IsBlock G B) {x : X} (hx : x ∈ B) :
 theorem ncard_block_mul_ncard_orbit_eq (hB : IsBlock G B) (hB_ne : B.Nonempty) :
     Set.ncard B * Set.ncard (orbit G B) = Nat.card X := by
   obtain ⟨x, hx⟩ := hB_ne
-  rw [ncard_block_eq_relindex hB hx, ← index_stabilizer,
-      Subgroup.relindex_mul_index (hB.stabilizer_le hx), index_stabilizer_of_transitive]
+  rw [ncard_block_eq_relIndex hB hx, ← index_stabilizer,
+      Subgroup.relIndex_mul_index (hB.stabilizer_le hx), index_stabilizer_of_transitive]
 
 /-- The cardinality of a block divides the cardinality of the ambient type -/
 @[to_additive /-- The cardinality of a block divides the cardinality of the ambient type -/]

--- a/Mathlib/GroupTheory/GroupAction/Blocks.lean
+++ b/Mathlib/GroupTheory/GroupAction/Blocks.lean
@@ -675,6 +675,8 @@ theorem ncard_block_eq_relIndex (hB : IsBlock G B) {x : X} (hx : x ∈ B) :
     ext; rfl
   rw [Subgroup.relIndex, key, index_stabilizer, hB.orbit_stabilizer_eq hx]
 
+@[deprecated (since := "2025-08-12")] alias ncard_block_eq_relindex := ncard_block_eq_relIndex
+
 /-- The cardinality of the ambient space is the product of the cardinality of a block
   by the cardinality of the set of translates of that block -/
 @[to_additive

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -22,7 +22,7 @@ Several theorems proved in this file are known as Lagrange's theorem.
 
 - `H.index` : the index of `H : Subgroup G` as a natural number,
   and returns 0 if the index is infinite.
-- `H.relindex K` : the relative index of `H : Subgroup G` in `K : Subgroup G` as a natural number,
+- `H.relIndex K` : the relative index of `H : Subgroup G` in `K : Subgroup G` as a natural number,
   and returns 0 if the relative index is infinite.
 
 # Main results
@@ -30,9 +30,9 @@ Several theorems proved in this file are known as Lagrange's theorem.
 - `card_mul_index` : `Nat.card H * H.index = Nat.card G`
 - `index_mul_card` : `H.index * Nat.card H = Nat.card G`
 - `index_dvd_card` : `H.index ∣ Nat.card G`
-- `relindex_mul_index` : If `H ≤ K`, then `H.relindex K * K.index = H.index`
+- `relIndex_mul_index` : If `H ≤ K`, then `H.relindex K * K.index = H.index`
 - `index_dvd_of_le` : If `H ≤ K`, then `K.index ∣ H.index`
-- `relindex_mul_relindex` : `relindex` is multiplicative in towers
+- `relIndex_mul_relIndex` : `relIndex` is multiplicative in towers
 - `MulAction.index_stabilizer`: the index of the stabilizer is the cardinality of the orbit
 -/
 
@@ -52,11 +52,11 @@ Returns 0 if the index is infinite. -/]
 noncomputable def index : ℕ :=
   Nat.card (G ⧸ H)
 
-/-- If `H` and `K` are subgroups of a group `G`, then `relindex H K : ℕ` is the index
+/-- If `H` and `K` are subgroups of a group `G`, then `relIndex H K : ℕ` is the index
 of `H ∩ K` in `K`. The function returns `0` if the index is infinite. -/
-@[to_additive /-- If `H` and `K` are subgroups of an additive group `G`, then `relindex H K : ℕ`
+@[to_additive /-- If `H` and `K` are subgroups of an additive group `G`, then `relIndex H K : ℕ`
 is the index of `H ∩ K` in `K`. The function returns `0` if the index is infinite. -/]
-noncomputable def relindex : ℕ :=
+noncomputable def relIndex : ℕ :=
   (H.subgroupOf K).index
 
 @[to_additive]
@@ -77,83 +77,83 @@ theorem index_comap_of_surjective {f : G' →* G} (hf : Function.Surjective f) :
 
 @[to_additive]
 theorem index_comap (f : G' →* G) :
-    (H.comap f).index = H.relindex f.range :=
+    (H.comap f).index = H.relIndex f.range :=
   Eq.trans (congr_arg index (by rfl))
     ((H.subgroupOf f.range).index_comap_of_surjective f.rangeRestrict_surjective)
 
 @[to_additive]
-theorem relindex_comap (f : G' →* G) (K : Subgroup G') :
-    relindex (comap f H) K = relindex H (map f K) := by
-  rw [relindex, subgroupOf, comap_comap, index_comap, ← f.map_range, K.range_subtype]
+theorem relIndex_comap (f : G' →* G) (K : Subgroup G') :
+    relIndex (comap f H) K = relIndex H (map f K) := by
+  rw [relIndex, subgroupOf, comap_comap, index_comap, ← f.map_range, K.range_subtype]
 
 @[to_additive]
-theorem relindex_map_map_of_injective {f : G →* G'} (H K : Subgroup G) (hf : Function.Injective f) :
-    relindex (map f H) (map f K) = relindex H K := by
-  rw [← Subgroup.relindex_comap, Subgroup.comap_map_eq_self_of_injective hf]
+theorem relIndex_map_map_of_injective {f : G →* G'} (H K : Subgroup G) (hf : Function.Injective f) :
+    relIndex (map f H) (map f K) = relIndex H K := by
+  rw [← Subgroup.relIndex_comap, Subgroup.comap_map_eq_self_of_injective hf]
 
 @[to_additive]
-theorem relindex_map_map (f : G →* G') (H K : Subgroup G) :
-    (map f H).relindex (map f K) = (H ⊔ f.ker).relindex (K ⊔ f.ker) := by
-  rw [← comap_map_eq, ← comap_map_eq, relindex_comap, (gc_map_comap f).l_u_l_eq_l]
+theorem relIndex_map_map (f : G →* G') (H K : Subgroup G) :
+    (map f H).relIndex (map f K) = (H ⊔ f.ker).relIndex (K ⊔ f.ker) := by
+  rw [← comap_map_eq, ← comap_map_eq, relIndex_comap, (gc_map_comap f).l_u_l_eq_l]
 
 variable {H K L}
 
-@[to_additive relindex_mul_index]
-theorem relindex_mul_index (h : H ≤ K) : H.relindex K * K.index = H.index :=
+@[to_additive relIndex_mul_index]
+theorem relIndex_mul_index (h : H ≤ K) : H.relIndex K * K.index = H.index :=
   ((mul_comm _ _).trans (Cardinal.toNat_mul _ _).symm).trans
     (congr_arg Cardinal.toNat (Equiv.cardinal_eq (quotientEquivProdOfLE h))).symm
 
 @[to_additive]
 theorem index_dvd_of_le (h : H ≤ K) : K.index ∣ H.index :=
-  dvd_of_mul_left_eq (H.relindex K) (relindex_mul_index h)
+  dvd_of_mul_left_eq (H.relIndex K) (relIndex_mul_index h)
 
 @[to_additive]
-theorem relindex_dvd_index_of_le (h : H ≤ K) : H.relindex K ∣ H.index :=
-  dvd_of_mul_right_eq K.index (relindex_mul_index h)
+theorem relIndex_dvd_index_of_le (h : H ≤ K) : H.relIndex K ∣ H.index :=
+  dvd_of_mul_right_eq K.index (relIndex_mul_index h)
 
 @[to_additive]
-theorem relindex_subgroupOf (hKL : K ≤ L) :
-    (H.subgroupOf L).relindex (K.subgroupOf L) = H.relindex K :=
+theorem relIndex_subgroupOf (hKL : K ≤ L) :
+    (H.subgroupOf L).relIndex (K.subgroupOf L) = H.relIndex K :=
   ((index_comap (H.subgroupOf L) (inclusion hKL)).trans (congr_arg _ (inclusion_range hKL))).symm
 
 variable (H K L)
 
-@[to_additive relindex_mul_relindex]
-theorem relindex_mul_relindex (hHK : H ≤ K) (hKL : K ≤ L) :
-    H.relindex K * K.relindex L = H.relindex L := by
-  rw [← relindex_subgroupOf hKL]
-  exact relindex_mul_index fun x hx => hHK hx
+@[to_additive relIndex_mul_relIndex]
+theorem relIndex_mul_relIndex (hHK : H ≤ K) (hKL : K ≤ L) :
+    H.relIndex K * K.relIndex L = H.relIndex L := by
+  rw [← relIndex_subgroupOf hKL]
+  exact relIndex_mul_index fun x hx => hHK hx
 
 @[to_additive]
-theorem inf_relindex_right : (H ⊓ K).relindex K = H.relindex K := by
-  rw [relindex, relindex, inf_subgroupOf_right]
+theorem inf_relIndex_right : (H ⊓ K).relIndex K = H.relIndex K := by
+  rw [relIndex, relIndex, inf_subgroupOf_right]
 
 @[to_additive]
-theorem inf_relindex_left : (H ⊓ K).relindex H = K.relindex H := by
-  rw [inf_comm, inf_relindex_right]
+theorem inf_relIndex_left : (H ⊓ K).relIndex H = K.relIndex H := by
+  rw [inf_comm, inf_relIndex_right]
 
-@[to_additive relindex_inf_mul_relindex]
-theorem relindex_inf_mul_relindex : H.relindex (K ⊓ L) * K.relindex L = (H ⊓ K).relindex L := by
-  rw [← inf_relindex_right H (K ⊓ L), ← inf_relindex_right K L, ← inf_relindex_right (H ⊓ K) L,
-    inf_assoc, relindex_mul_relindex (H ⊓ (K ⊓ L)) (K ⊓ L) L inf_le_right inf_le_right]
+@[to_additive relIndex_inf_mul_relIndex]
+theorem relIndex_inf_mul_relIndex : H.relIndex (K ⊓ L) * K.relIndex L = (H ⊓ K).relIndex L := by
+  rw [← inf_relIndex_right H (K ⊓ L), ← inf_relIndex_right K L, ← inf_relIndex_right (H ⊓ K) L,
+    inf_assoc, relIndex_mul_relIndex (H ⊓ (K ⊓ L)) (K ⊓ L) L inf_le_right inf_le_right]
 
 @[to_additive (attr := simp)]
-theorem relindex_sup_right [K.Normal] : K.relindex (H ⊔ K) = K.relindex H :=
+theorem relIndex_sup_right [K.Normal] : K.relIndex (H ⊔ K) = K.relIndex H :=
   Nat.card_congr (QuotientGroup.quotientInfEquivProdNormalQuotient H K).toEquiv.symm
 
 @[to_additive (attr := simp)]
-theorem relindex_sup_left [K.Normal] : K.relindex (K ⊔ H) = K.relindex H := by
-  rw [sup_comm, relindex_sup_right]
+theorem relIndex_sup_left [K.Normal] : K.relIndex (K ⊔ H) = K.relIndex H := by
+  rw [sup_comm, relIndex_sup_right]
 
 @[to_additive]
-theorem relindex_dvd_index_of_normal [H.Normal] : H.relindex K ∣ H.index :=
-  relindex_sup_right K H ▸ relindex_dvd_index_of_le le_sup_right
+theorem relIndex_dvd_index_of_normal [H.Normal] : H.relIndex K ∣ H.index :=
+  relIndex_sup_right K H ▸ relIndex_dvd_index_of_le le_sup_right
 
 variable {H K}
 
 @[to_additive]
-theorem relindex_dvd_of_le_left (hHK : H ≤ K) : K.relindex L ∣ H.relindex L :=
-  inf_of_le_left hHK ▸ dvd_of_mul_left_eq _ (relindex_inf_mul_relindex _ _ _)
+theorem relIndex_dvd_of_le_left (hHK : H ≤ K) : K.relIndex L ∣ H.relIndex L :=
+  inf_of_le_left hHK ▸ dvd_of_mul_left_eq _ (relIndex_inf_mul_relIndex _ _ _)
 
 /-- A subgroup has index two if and only if there exists `a` such that for all `b`, exactly one
 of `b * a` and `b` belong to `H`. -/
@@ -199,35 +199,35 @@ theorem index_bot : (⊥ : Subgroup G).index = Nat.card G :=
   Cardinal.toNat_congr QuotientGroup.quotientBot.toEquiv
 
 @[to_additive (attr := simp)]
-theorem relindex_top_left : (⊤ : Subgroup G).relindex H = 1 :=
+theorem relIndex_top_left : (⊤ : Subgroup G).relIndex H = 1 :=
   index_top
 
 @[to_additive (attr := simp)]
-theorem relindex_top_right : H.relindex ⊤ = H.index := by
-  rw [← relindex_mul_index (show H ≤ ⊤ from le_top), index_top, mul_one]
+theorem relIndex_top_right : H.relIndex ⊤ = H.index := by
+  rw [← relIndex_mul_index (show H ≤ ⊤ from le_top), index_top, mul_one]
 
 @[to_additive (attr := simp)]
-theorem relindex_bot_left : (⊥ : Subgroup G).relindex H = Nat.card H := by
-  rw [relindex, bot_subgroupOf, index_bot]
+theorem relIndex_bot_left : (⊥ : Subgroup G).relIndex H = Nat.card H := by
+  rw [relIndex, bot_subgroupOf, index_bot]
 
 @[to_additive (attr := simp)]
-theorem relindex_bot_right : H.relindex ⊥ = 1 := by rw [relindex, subgroupOf_bot_eq_top, index_top]
+theorem relIndex_bot_right : H.relIndex ⊥ = 1 := by rw [relIndex, subgroupOf_bot_eq_top, index_top]
 
 @[to_additive (attr := simp)]
-theorem relindex_self : H.relindex H = 1 := by rw [relindex, subgroupOf_self, index_top]
+theorem relIndex_self : H.relIndex H = 1 := by rw [relIndex, subgroupOf_self, index_top]
 
 @[to_additive]
 theorem index_ker (f : G →* G') : f.ker.index = Nat.card f.range := by
-  rw [← MonoidHom.comap_bot, index_comap, relindex_bot_left]
+  rw [← MonoidHom.comap_bot, index_comap, relIndex_bot_left]
 
 @[to_additive]
-theorem relindex_ker (f : G →* G') : f.ker.relindex K = Nat.card (K.map f) := by
-  rw [← MonoidHom.comap_bot, relindex_comap, relindex_bot_left]
+theorem relIndex_ker (f : G →* G') : f.ker.relIndex K = Nat.card (K.map f) := by
+  rw [← MonoidHom.comap_bot, relIndex_comap, relIndex_bot_left]
 
 @[to_additive (attr := simp) card_mul_index]
 theorem card_mul_index : Nat.card H * H.index = Nat.card G := by
-  rw [← relindex_bot_left, ← index_bot]
-  exact relindex_mul_index bot_le
+  rw [← relIndex_bot_left, ← index_bot]
+  exact relIndex_mul_index bot_le
 
 @[to_additive]
 theorem card_dvd_of_surjective (f : G →* G') (hf : Function.Surjective f) :
@@ -246,7 +246,7 @@ theorem card_map_dvd (f : G →* G') : Nat.card (H.map f) ∣ Nat.card H :=
 @[to_additive]
 theorem index_map (f : G →* G') :
     (H.map f).index = (H ⊔ f.ker).index * f.range.index := by
-  rw [← comap_map_eq, index_comap, relindex_mul_index (H.map_le_range f)]
+  rw [← comap_map_eq, index_comap, relIndex_mul_index (H.map_le_range f)]
 
 @[to_additive]
 theorem index_map_dvd {f : G →* G'} (hf : Function.Surjective f) :
@@ -295,107 +295,107 @@ theorem index_dvd_card : H.index ∣ Nat.card G :=
   ⟨Nat.card H, H.index_mul_card.symm⟩
 
 @[to_additive]
-theorem relindex_dvd_card : H.relindex K ∣ Nat.card K :=
+theorem relIndex_dvd_card : H.relIndex K ∣ Nat.card K :=
   (H.subgroupOf K).index_dvd_card
 
 variable {H K L}
 
 @[to_additive]
-theorem relindex_eq_zero_of_le_left (hHK : H ≤ K) (hKL : K.relindex L = 0) : H.relindex L = 0 :=
-  eq_zero_of_zero_dvd (hKL ▸ relindex_dvd_of_le_left L hHK)
+theorem relIndex_eq_zero_of_le_left (hHK : H ≤ K) (hKL : K.relIndex L = 0) : H.relIndex L = 0 :=
+  eq_zero_of_zero_dvd (hKL ▸ relIndex_dvd_of_le_left L hHK)
 
 @[to_additive]
-theorem relindex_eq_zero_of_le_right (hKL : K ≤ L) (hHK : H.relindex K = 0) : H.relindex L = 0 :=
+theorem relIndex_eq_zero_of_le_right (hKL : K ≤ L) (hHK : H.relIndex K = 0) : H.relIndex L = 0 :=
   Finite.card_eq_zero_of_embedding (quotientSubgroupOfEmbeddingOfLE H hKL) hHK
 
 /-- If `J` has finite index in `K`, then the same holds for their comaps under any group hom. -/
 @[to_additive /-- If `J` has finite index in `K`, then the same holds for their comaps under any
 additive group hom. -/]
-lemma relindex_comap_ne_zero (f : G →* G') {J K : Subgroup G'} (hJK : J.relindex K ≠ 0) :
-    (J.comap f).relindex (K.comap f) ≠ 0 := by
-  rw [relindex_comap]
-  exact fun h ↦ hJK <| relindex_eq_zero_of_le_right (map_comap_le _ _) h
+lemma relIndex_comap_ne_zero (f : G →* G') {J K : Subgroup G'} (hJK : J.relIndex K ≠ 0) :
+    (J.comap f).relIndex (K.comap f) ≠ 0 := by
+  rw [relIndex_comap]
+  exact fun h ↦ hJK <| relIndex_eq_zero_of_le_right (map_comap_le _ _) h
 
 @[to_additive]
-theorem index_eq_zero_of_relindex_eq_zero (h : H.relindex K = 0) : H.index = 0 :=
-  H.relindex_top_right.symm.trans (relindex_eq_zero_of_le_right le_top h)
+theorem index_eq_zero_of_relIndex_eq_zero (h : H.relIndex K = 0) : H.index = 0 :=
+  H.relIndex_top_right.symm.trans (relIndex_eq_zero_of_le_right le_top h)
 
 @[to_additive]
-theorem relindex_le_of_le_left (hHK : H ≤ K) (hHL : H.relindex L ≠ 0) :
-    K.relindex L ≤ H.relindex L :=
-  Nat.le_of_dvd (Nat.pos_of_ne_zero hHL) (relindex_dvd_of_le_left L hHK)
+theorem relIndex_le_of_le_left (hHK : H ≤ K) (hHL : H.relIndex L ≠ 0) :
+    K.relIndex L ≤ H.relIndex L :=
+  Nat.le_of_dvd (Nat.pos_of_ne_zero hHL) (relIndex_dvd_of_le_left L hHK)
 
 @[to_additive]
-theorem relindex_le_of_le_right (hKL : K ≤ L) (hHL : H.relindex L ≠ 0) :
-    H.relindex K ≤ H.relindex L :=
+theorem relIndex_le_of_le_right (hKL : K ≤ L) (hHL : H.relIndex L ≠ 0) :
+    H.relIndex K ≤ H.relIndex L :=
   Finite.card_le_of_embedding' (quotientSubgroupOfEmbeddingOfLE H hKL) fun h => (hHL h).elim
 
 @[to_additive]
-theorem relindex_ne_zero_trans (hHK : H.relindex K ≠ 0) (hKL : K.relindex L ≠ 0) :
-    H.relindex L ≠ 0 := fun h =>
-  mul_ne_zero (mt (relindex_eq_zero_of_le_right (show K ⊓ L ≤ K from inf_le_left)) hHK) hKL
-    ((relindex_inf_mul_relindex H K L).trans (relindex_eq_zero_of_le_left inf_le_left h))
+theorem relIndex_ne_zero_trans (hHK : H.relIndex K ≠ 0) (hKL : K.relIndex L ≠ 0) :
+    H.relIndex L ≠ 0 := fun h =>
+  mul_ne_zero (mt (relIndex_eq_zero_of_le_right (show K ⊓ L ≤ K from inf_le_left)) hHK) hKL
+    ((relIndex_inf_mul_relIndex H K L).trans (relIndex_eq_zero_of_le_left inf_le_left h))
 
 @[to_additive]
-theorem relindex_inf_ne_zero (hH : H.relindex L ≠ 0) (hK : K.relindex L ≠ 0) :
-    (H ⊓ K).relindex L ≠ 0 := by
-  replace hH : H.relindex (K ⊓ L) ≠ 0 := mt (relindex_eq_zero_of_le_right inf_le_right) hH
-  rw [← inf_relindex_right] at hH hK ⊢
+theorem relIndex_inf_ne_zero (hH : H.relIndex L ≠ 0) (hK : K.relIndex L ≠ 0) :
+    (H ⊓ K).relIndex L ≠ 0 := by
+  replace hH : H.relIndex (K ⊓ L) ≠ 0 := mt (relIndex_eq_zero_of_le_right inf_le_right) hH
+  rw [← inf_relIndex_right] at hH hK ⊢
   rw [inf_assoc]
-  exact relindex_ne_zero_trans hH hK
+  exact relIndex_ne_zero_trans hH hK
 
 @[to_additive]
 theorem index_inf_ne_zero (hH : H.index ≠ 0) (hK : K.index ≠ 0) : (H ⊓ K).index ≠ 0 := by
-  rw [← relindex_top_right] at hH hK ⊢
-  exact relindex_inf_ne_zero hH hK
+  rw [← relIndex_top_right] at hH hK ⊢
+  exact relIndex_inf_ne_zero hH hK
 
 /-- If `J` has finite index in `K`, then `J ⊓ L` has finite index in `K ⊓ L` for any `L`. -/
 @[to_additive /-- If `J` has finite index in `K`, then `J ⊓ L` has finite index in `K ⊓ L` for any
 `L`. -/]
-lemma relindex_inter_ne_zero {J K : Subgroup G} (hJK : J.relindex K ≠ 0) (L : Subgroup G) :
-    (J ⊓ L).relindex (K ⊓ L) ≠ 0 := by
-  rw [← range_subtype L, inf_comm, ← map_comap_eq, inf_comm, ← map_comap_eq, ← relindex_comap,
+lemma relIndex_inter_ne_zero {J K : Subgroup G} (hJK : J.relIndex K ≠ 0) (L : Subgroup G) :
+    (J ⊓ L).relIndex (K ⊓ L) ≠ 0 := by
+  rw [← range_subtype L, inf_comm, ← map_comap_eq, inf_comm, ← map_comap_eq, ← relIndex_comap,
     comap_map_eq_self_of_injective (subtype_injective L)]
-  exact relindex_comap_ne_zero _ hJK
+  exact relIndex_comap_ne_zero _ hJK
 
 @[to_additive]
-theorem relindex_inf_le : (H ⊓ K).relindex L ≤ H.relindex L * K.relindex L := by
-  by_cases h : H.relindex L = 0
-  · exact (le_of_eq (relindex_eq_zero_of_le_left inf_le_left h)).trans (zero_le _)
-  rw [← inf_relindex_right, inf_assoc, ← relindex_mul_relindex _ _ L inf_le_right inf_le_right,
-    inf_relindex_right, inf_relindex_right]
-  exact mul_le_mul_right' (relindex_le_of_le_right inf_le_right h) (K.relindex L)
+theorem relIndex_inf_le : (H ⊓ K).relIndex L ≤ H.relIndex L * K.relIndex L := by
+  by_cases h : H.relIndex L = 0
+  · exact (le_of_eq (relIndex_eq_zero_of_le_left inf_le_left h)).trans (zero_le _)
+  rw [← inf_relIndex_right, inf_assoc, ← relIndex_mul_relIndex _ _ L inf_le_right inf_le_right,
+    inf_relIndex_right, inf_relIndex_right]
+  exact mul_le_mul_right' (relIndex_le_of_le_right inf_le_right h) (K.relIndex L)
 
 @[to_additive]
 theorem index_inf_le : (H ⊓ K).index ≤ H.index * K.index := by
-  simp_rw [← relindex_top_right, relindex_inf_le]
+  simp_rw [← relIndex_top_right, relIndex_inf_le]
 
 @[to_additive]
-theorem relindex_iInf_ne_zero {ι : Type*} [_hι : Finite ι] {f : ι → Subgroup G}
-    (hf : ∀ i, (f i).relindex L ≠ 0) : (⨅ i, f i).relindex L ≠ 0 :=
+theorem relIndex_iInf_ne_zero {ι : Type*} [_hι : Finite ι] {f : ι → Subgroup G}
+    (hf : ∀ i, (f i).relIndex L ≠ 0) : (⨅ i, f i).relIndex L ≠ 0 :=
   haveI := Fintype.ofFinite ι
   (Finset.prod_ne_zero_iff.mpr fun i _hi => hf i) ∘
     Nat.card_pi.symm.trans ∘
       Finite.card_eq_zero_of_embedding (quotientiInfSubgroupOfEmbedding f L)
 
 @[to_additive]
-theorem relindex_iInf_le {ι : Type*} [Fintype ι] (f : ι → Subgroup G) :
-    (⨅ i, f i).relindex L ≤ ∏ i, (f i).relindex L :=
+theorem relIndex_iInf_le {ι : Type*} [Fintype ι] (f : ι → Subgroup G) :
+    (⨅ i, f i).relIndex L ≤ ∏ i, (f i).relIndex L :=
   le_of_le_of_eq
     (Finite.card_le_of_embedding' (quotientiInfSubgroupOfEmbedding f L) fun h =>
       let ⟨i, _hi, h⟩ := Finset.prod_eq_zero_iff.mp (Nat.card_pi.symm.trans h)
-      relindex_eq_zero_of_le_left (iInf_le f i) h)
+      relIndex_eq_zero_of_le_left (iInf_le f i) h)
     Nat.card_pi
 
 @[to_additive]
 theorem index_iInf_ne_zero {ι : Type*} [Finite ι] {f : ι → Subgroup G}
     (hf : ∀ i, (f i).index ≠ 0) : (⨅ i, f i).index ≠ 0 := by
-  simp_rw [← relindex_top_right] at hf ⊢
-  exact relindex_iInf_ne_zero hf
+  simp_rw [← relIndex_top_right] at hf ⊢
+  exact relIndex_iInf_ne_zero hf
 
 @[to_additive]
 theorem index_iInf_le {ι : Type*} [Fintype ι] (f : ι → Subgroup G) :
-    (⨅ i, f i).index ≤ ∏ i, (f i).index := by simp_rw [← relindex_top_right, relindex_iInf_le]
+    (⨅ i, f i).index ≤ ∏ i, (f i).index := by simp_rw [← relIndex_top_right, relIndex_iInf_le]
 
 @[to_additive (attr := simp) index_eq_one]
 theorem index_eq_one : H.index = 1 ↔ H = ⊤ :=
@@ -403,13 +403,13 @@ theorem index_eq_one : H.index = 1 ↔ H = ⊤ :=
     QuotientGroup.subgroup_eq_top_of_subsingleton H (Nat.card_eq_one_iff_unique.mp h).1,
     fun h => (congr_arg index h).trans index_top⟩
 
-@[to_additive (attr := simp) relindex_eq_one]
-theorem relindex_eq_one : H.relindex K = 1 ↔ K ≤ H :=
+@[to_additive (attr := simp) relIndex_eq_one]
+theorem relIndex_eq_one : H.relIndex K = 1 ↔ K ≤ H :=
   index_eq_one.trans subgroupOf_eq_top
 
 @[to_additive (attr := simp) card_eq_one]
 theorem card_eq_one : Nat.card H = 1 ↔ H = ⊥ :=
-  H.relindex_bot_left ▸ relindex_eq_one.trans le_bot_iff
+  H.relIndex_bot_left ▸ relIndex_eq_one.trans le_bot_iff
 
 @[to_additive]
 lemma inf_eq_bot_of_coprime (h : Nat.Coprime (Nat.card H) (Nat.card K)) : H ⊓ K = ⊥ :=
@@ -483,8 +483,8 @@ lemma exists_pow_mem_of_index_ne_zero (h : H.index ≠ 0) (a : G) :
   simp [← index_eq_card] at hcard
 
 @[to_additive]
-lemma exists_pow_mem_of_relindex_ne_zero (h : H.relindex K ≠ 0) {a : G} (ha : a ∈ K) :
-    ∃ n, 0 < n ∧ n ≤ H.relindex K ∧ a ^ n ∈ H ⊓ K := by
+lemma exists_pow_mem_of_relIndex_ne_zero (h : H.relIndex K ≠ 0) {a : G} (ha : a ∈ K) :
+    ∃ n, 0 < n ∧ n ≤ H.relIndex K ∧ a ^ n ∈ H ⊓ K := by
   rcases exists_pow_mem_of_index_ne_zero h ⟨a, ha⟩ with ⟨n, hlt, hle, he⟩
   refine ⟨n, hlt, hle, ?_⟩
   simpa [pow_mem ha, mem_subgroupOf] using he
@@ -498,8 +498,8 @@ lemma pow_mem_of_index_ne_zero_of_dvd (h : H.index ≠ 0) (a : G) {n : ℕ}
   exact pow_mem he _
 
 @[to_additive]
-lemma pow_mem_of_relindex_ne_zero_of_dvd (h : H.relindex K ≠ 0) {a : G} (ha : a ∈ K) {n : ℕ}
-    (hn : ∀ m, 0 < m → m ≤ H.relindex K → m ∣ n) : a ^ n ∈ H ⊓ K := by
+lemma pow_mem_of_relIndex_ne_zero_of_dvd (h : H.relIndex K ≠ 0) {a : G} (ha : a ∈ K) {n : ℕ}
+    (hn : ∀ m, 0 < m → m ≤ H.relIndex K → m ∣ n) : a ^ n ∈ H ⊓ K := by
   convert pow_mem_of_index_ne_zero_of_dvd h ⟨a, ha⟩ hn
   simp [pow_mem ha, mem_subgroupOf]
 
@@ -531,13 +531,13 @@ lemma _root_.AddSubgroup.index_toSubgroup {G : Type*} [AddGroup G] (H : AddSubgr
   rfl
 
 @[simp]
-lemma relindex_toAddSubgroup :
-    (Subgroup.toAddSubgroup H).relindex (Subgroup.toAddSubgroup K) = H.relindex K :=
+lemma relIndex_toAddSubgroup :
+    (Subgroup.toAddSubgroup H).relIndex (Subgroup.toAddSubgroup K) = H.relIndex K :=
   rfl
 
 @[simp]
-lemma _root_.AddSubgroup.relindex_toSubgroup {G : Type*} [AddGroup G] (H K : AddSubgroup G) :
-    (AddSubgroup.toSubgroup H).relindex (AddSubgroup.toSubgroup K) = H.relindex K :=
+lemma _root_.AddSubgroup.relIndex_toSubgroup {G : Type*} [AddGroup G] (H K : AddSubgroup G) :
+    (AddSubgroup.toSubgroup H).relIndex (AddSubgroup.toSubgroup K) = H.relIndex K :=
   rfl
 
 section FiniteIndex
@@ -563,20 +563,20 @@ variable (H) in
 /-- Typeclass for a subgroup `H` to have finite index in a subgroup `K`. -/
 class _root_.AddSubgroup.IsFiniteRelIndex {G : Type*} [AddGroup G] (H K : AddSubgroup G) :
     Prop where
-  protected relindex_ne_zero : H.relindex K ≠ 0
+  protected relIndex_ne_zero : H.relIndex K ≠ 0
 
 variable (H K) in
 /-- Typeclass for a subgroup `H` to have finite index in a subgroup `K`. -/
 @[to_additive] class IsFiniteRelIndex : Prop where
-  protected relindex_ne_zero : H.relindex K ≠ 0
+  protected relIndex_ne_zero : H.relIndex K ≠ 0
 
-@[to_additive] lemma relindex_ne_zero [H.IsFiniteRelIndex K] : H.relindex K ≠ 0 :=
-  IsFiniteRelIndex.relindex_ne_zero
+@[to_additive] lemma relIndex_ne_zero [H.IsFiniteRelIndex K] : H.relIndex K ≠ 0 :=
+  IsFiniteRelIndex.relIndex_ne_zero
 
 @[to_additive]
 instance IsFiniteRelIndex.to_finiteIndex_subgroupOf [H.IsFiniteRelIndex K] :
     (H.subgroupOf K).FiniteIndex where
-  index_ne_zero := relindex_ne_zero
+  index_ne_zero := relIndex_ne_zero
 
 @[to_additive]
 theorem finiteIndex_iff : H.FiniteIndex ↔ H.index ≠ 0 :=
@@ -643,7 +643,7 @@ theorem finiteIndex_iInf' {ι : Type*} {s : Finset ι}
 @[to_additive]
 instance instFiniteIndex_subgroupOf (H K : Subgroup G) [H.FiniteIndex] :
     (H.subgroupOf K).FiniteIndex :=
-  ⟨fun h => H.index_ne_zero_of_finite <| H.index_eq_zero_of_relindex_eq_zero h⟩
+  ⟨fun h => H.index_ne_zero_of_finite <| H.index_eq_zero_of_relIndex_eq_zero h⟩
 
 @[to_additive]
 theorem finiteIndex_of_le [FiniteIndex H] (h : H ≤ K) : FiniteIndex K :=
@@ -657,7 +657,7 @@ lemma index_antitone (h : H ≤ K) [H.FiniteIndex] : K.index ≤ H.index :=
 lemma index_strictAnti (h : H < K) [H.FiniteIndex] : K.index < H.index := by
   have h0 : K.index ≠ 0 := (finiteIndex_of_le h.le).index_ne_zero
   apply lt_of_le_of_ne (index_antitone h.le)
-  rw [← relindex_mul_index h.le, Ne, eq_comm, mul_eq_right₀ h0, relindex_eq_one]
+  rw [← relIndex_mul_index h.le, Ne, eq_comm, mul_eq_right₀ h0, relIndex_eq_one]
   exact h.not_ge
 
 variable (H K)
@@ -690,14 +690,14 @@ variable {G H : Type*} [Group H] (h : H)
 -- NB: `to_additive` does not work to generate the second lemma from the first here, because it
 -- would need to additivize `G`, but not `H`.
 
-lemma Subgroup.relindex_pointwise_smul [Group G] [MulDistribMulAction H G] (J K : Subgroup G) :
-    (h • J).relindex (h • K) = J.relindex K := by
-  rw [pointwise_smul_def K, ← relindex_comap, pointwise_smul_def,
+lemma Subgroup.relIndex_pointwise_smul [Group G] [MulDistribMulAction H G] (J K : Subgroup G) :
+    (h • J).relIndex (h • K) = J.relIndex K := by
+  rw [pointwise_smul_def K, ← relIndex_comap, pointwise_smul_def,
     comap_map_eq_self_of_injective (by intro a b; simp)]
 
-lemma AddSubgroup.relindex_pointwise_smul [AddGroup G] [DistribMulAction H G]
-    (J K : AddSubgroup G) : (h • J).relindex (h • K) = J.relindex K := by
-  rw [pointwise_smul_def K, ← relindex_comap, pointwise_smul_def,
+lemma AddSubgroup.relIndex_pointwise_smul [AddGroup G] [DistribMulAction H G]
+    (J K : AddSubgroup G) : (h • J).relIndex (h • K) = J.relIndex K := by
+  rw [pointwise_smul_def K, ← relIndex_comap, pointwise_smul_def,
     comap_map_eq_self_of_injective (by intro a b; simp)]
 
 end Pointwise

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -59,6 +59,8 @@ is the index of `H ∩ K` in `K`. The function returns `0` if the index is infin
 noncomputable def relIndex : ℕ :=
   (H.subgroupOf K).index
 
+@[deprecated (since := "2025-08-12")] alias relindex := relIndex
+
 @[to_additive]
 theorem index_comap_of_surjective {f : G' →* G} (hf : Function.Surjective f) :
     (H.comap f).index = H.index := by
@@ -86,10 +88,15 @@ theorem relIndex_comap (f : G' →* G) (K : Subgroup G') :
     relIndex (comap f H) K = relIndex H (map f K) := by
   rw [relIndex, subgroupOf, comap_comap, index_comap, ← f.map_range, K.range_subtype]
 
+@[deprecated (since := "2025-08-12")] alias relindex_comap := relIndex_comap
+
 @[to_additive]
 theorem relIndex_map_map_of_injective {f : G →* G'} (H K : Subgroup G) (hf : Function.Injective f) :
     relIndex (map f H) (map f K) = relIndex H K := by
   rw [← Subgroup.relIndex_comap, Subgroup.comap_map_eq_self_of_injective hf]
+
+@[deprecated (since := "2025-08-12")]
+alias relindex_map_map_of_injective := relIndex_map_map_of_injective
 
 @[to_additive]
 theorem relIndex_map_map (f : G →* G') (H K : Subgroup G) :
@@ -103,6 +110,8 @@ theorem relIndex_mul_index (h : H ≤ K) : H.relIndex K * K.index = H.index :=
   ((mul_comm _ _).trans (Cardinal.toNat_mul _ _).symm).trans
     (congr_arg Cardinal.toNat (Equiv.cardinal_eq (quotientEquivProdOfLE h))).symm
 
+@[deprecated (since := "2025-08-12")] alias relindex_mul_index := relIndex_mul_index
+
 @[to_additive]
 theorem index_dvd_of_le (h : H ≤ K) : K.index ∣ H.index :=
   dvd_of_mul_left_eq (H.relIndex K) (relIndex_mul_index h)
@@ -111,10 +120,14 @@ theorem index_dvd_of_le (h : H ≤ K) : K.index ∣ H.index :=
 theorem relIndex_dvd_index_of_le (h : H ≤ K) : H.relIndex K ∣ H.index :=
   dvd_of_mul_right_eq K.index (relIndex_mul_index h)
 
+@[deprecated (since := "2025-08-12")] alias relindex_dvd_index_of_le := relIndex_dvd_index_of_le
+
 @[to_additive]
 theorem relIndex_subgroupOf (hKL : K ≤ L) :
     (H.subgroupOf L).relIndex (K.subgroupOf L) = H.relIndex K :=
   ((index_comap (H.subgroupOf L) (inclusion hKL)).trans (congr_arg _ (inclusion_range hKL))).symm
+
+@[deprecated (since := "2025-08-12")] alias relindex_subgroupOf := relIndex_subgroupOf
 
 variable (H K L)
 
@@ -124,36 +137,53 @@ theorem relIndex_mul_relIndex (hHK : H ≤ K) (hKL : K ≤ L) :
   rw [← relIndex_subgroupOf hKL]
   exact relIndex_mul_index fun x hx => hHK hx
 
+@[deprecated (since := "2025-08-12")] alias relindex_mul_relindex := relIndex_mul_relIndex
+
 @[to_additive]
 theorem inf_relIndex_right : (H ⊓ K).relIndex K = H.relIndex K := by
   rw [relIndex, relIndex, inf_subgroupOf_right]
 
+@[deprecated (since := "2025-08-12")] alias inf_relindex_right := inf_relIndex_right
+
 @[to_additive]
 theorem inf_relIndex_left : (H ⊓ K).relIndex H = K.relIndex H := by
   rw [inf_comm, inf_relIndex_right]
+
+@[deprecated (since := "2025-08-12")] alias inf_relindex_left := inf_relIndex_left
 
 @[to_additive relIndex_inf_mul_relIndex]
 theorem relIndex_inf_mul_relIndex : H.relIndex (K ⊓ L) * K.relIndex L = (H ⊓ K).relIndex L := by
   rw [← inf_relIndex_right H (K ⊓ L), ← inf_relIndex_right K L, ← inf_relIndex_right (H ⊓ K) L,
     inf_assoc, relIndex_mul_relIndex (H ⊓ (K ⊓ L)) (K ⊓ L) L inf_le_right inf_le_right]
 
+@[deprecated (since := "2025-08-12")] alias relindex_inf_mul_relindex := relIndex_inf_mul_relIndex
+
 @[to_additive (attr := simp)]
 theorem relIndex_sup_right [K.Normal] : K.relIndex (H ⊔ K) = K.relIndex H :=
   Nat.card_congr (QuotientGroup.quotientInfEquivProdNormalQuotient H K).toEquiv.symm
+
+@[deprecated (since := "2025-08-12")] alias relindex_sup_right := relIndex_sup_right
 
 @[to_additive (attr := simp)]
 theorem relIndex_sup_left [K.Normal] : K.relIndex (K ⊔ H) = K.relIndex H := by
   rw [sup_comm, relIndex_sup_right]
 
+@[deprecated (since := "2025-08-12")] alias relindex_sup_left := relIndex_sup_left
+
 @[to_additive]
 theorem relIndex_dvd_index_of_normal [H.Normal] : H.relIndex K ∣ H.index :=
   relIndex_sup_right K H ▸ relIndex_dvd_index_of_le le_sup_right
+
+@[deprecated (since := "2025-08-12")]
+alias relindex_dvd_index_of_normal := relIndex_dvd_index_of_normal
 
 variable {H K}
 
 @[to_additive]
 theorem relIndex_dvd_of_le_left (hHK : H ≤ K) : K.relIndex L ∣ H.relIndex L :=
   inf_of_le_left hHK ▸ dvd_of_mul_left_eq _ (relIndex_inf_mul_relIndex _ _ _)
+
+@[deprecated (since := "2025-08-12")] alias relindex_dvd_of_le_left := relIndex_dvd_of_le_left
 
 /-- A subgroup has index two if and only if there exists `a` such that for all `b`, exactly one
 of `b * a` and `b` belong to `H`. -/
@@ -202,19 +232,29 @@ theorem index_bot : (⊥ : Subgroup G).index = Nat.card G :=
 theorem relIndex_top_left : (⊤ : Subgroup G).relIndex H = 1 :=
   index_top
 
+@[deprecated (since := "2025-08-12")] alias relindex_top_left := relIndex_top_left
+
 @[to_additive (attr := simp)]
 theorem relIndex_top_right : H.relIndex ⊤ = H.index := by
   rw [← relIndex_mul_index (show H ≤ ⊤ from le_top), index_top, mul_one]
+
+@[deprecated (since := "2025-08-12")] alias relindex_top_right := relIndex_top_right
 
 @[to_additive (attr := simp)]
 theorem relIndex_bot_left : (⊥ : Subgroup G).relIndex H = Nat.card H := by
   rw [relIndex, bot_subgroupOf, index_bot]
 
+@[deprecated (since := "2025-08-12")] alias relindex_bot_left := relIndex_bot_left
+
 @[to_additive (attr := simp)]
 theorem relIndex_bot_right : H.relIndex ⊥ = 1 := by rw [relIndex, subgroupOf_bot_eq_top, index_top]
 
+@[deprecated (since := "2025-08-12")] alias relindex_bot_right := relIndex_bot_right
+
 @[to_additive (attr := simp)]
 theorem relIndex_self : H.relIndex H = 1 := by rw [relIndex, subgroupOf_self, index_top]
+
+@[deprecated (since := "2025-08-12")] alias relindex_self := relIndex_self
 
 @[to_additive]
 theorem index_ker (f : G →* G') : f.ker.index = Nat.card f.range := by
@@ -223,6 +263,8 @@ theorem index_ker (f : G →* G') : f.ker.index = Nat.card f.range := by
 @[to_additive]
 theorem relIndex_ker (f : G →* G') : f.ker.relIndex K = Nat.card (K.map f) := by
   rw [← MonoidHom.comap_bot, relIndex_comap, relIndex_bot_left]
+
+@[deprecated (since := "2025-08-12")] alias relindex_ker := relIndex_ker
 
 @[to_additive (attr := simp) card_mul_index]
 theorem card_mul_index : Nat.card H * H.index = Nat.card G := by
@@ -298,15 +340,23 @@ theorem index_dvd_card : H.index ∣ Nat.card G :=
 theorem relIndex_dvd_card : H.relIndex K ∣ Nat.card K :=
   (H.subgroupOf K).index_dvd_card
 
+@[deprecated (since := "2025-08-12")] alias relindex_dvd_card := relIndex_dvd_card
+
 variable {H K L}
 
 @[to_additive]
 theorem relIndex_eq_zero_of_le_left (hHK : H ≤ K) (hKL : K.relIndex L = 0) : H.relIndex L = 0 :=
   eq_zero_of_zero_dvd (hKL ▸ relIndex_dvd_of_le_left L hHK)
 
+@[deprecated (since := "2025-08-12")]
+alias relindex_eq_zero_of_le_left := relIndex_eq_zero_of_le_left
+
 @[to_additive]
 theorem relIndex_eq_zero_of_le_right (hKL : K ≤ L) (hHK : H.relIndex K = 0) : H.relIndex L = 0 :=
   Finite.card_eq_zero_of_embedding (quotientSubgroupOfEmbeddingOfLE H hKL) hHK
+
+@[deprecated (since := "2025-08-12")]
+alias relindex_eq_zero_of_le_right := relIndex_eq_zero_of_le_right
 
 /-- If `J` has finite index in `K`, then the same holds for their comaps under any group hom. -/
 @[to_additive /-- If `J` has finite index in `K`, then the same holds for their comaps under any
@@ -316,25 +366,36 @@ lemma relIndex_comap_ne_zero (f : G →* G') {J K : Subgroup G'} (hJK : J.relInd
   rw [relIndex_comap]
   exact fun h ↦ hJK <| relIndex_eq_zero_of_le_right (map_comap_le _ _) h
 
+@[deprecated (since := "2025-08-12")] alias relindex_comap_ne_zero := relIndex_comap_ne_zero
+
 @[to_additive]
 theorem index_eq_zero_of_relIndex_eq_zero (h : H.relIndex K = 0) : H.index = 0 :=
   H.relIndex_top_right.symm.trans (relIndex_eq_zero_of_le_right le_top h)
+
+@[deprecated (since := "2025-08-12")]
+alias index_eq_zero_of_relindex_eq_zero := index_eq_zero_of_relIndex_eq_zero
 
 @[to_additive]
 theorem relIndex_le_of_le_left (hHK : H ≤ K) (hHL : H.relIndex L ≠ 0) :
     K.relIndex L ≤ H.relIndex L :=
   Nat.le_of_dvd (Nat.pos_of_ne_zero hHL) (relIndex_dvd_of_le_left L hHK)
 
+@[deprecated (since := "2025-08-12")] alias relindex_le_of_le_left := relIndex_le_of_le_left
+
 @[to_additive]
 theorem relIndex_le_of_le_right (hKL : K ≤ L) (hHL : H.relIndex L ≠ 0) :
     H.relIndex K ≤ H.relIndex L :=
   Finite.card_le_of_embedding' (quotientSubgroupOfEmbeddingOfLE H hKL) fun h => (hHL h).elim
+
+@[deprecated (since := "2025-08-12")] alias relindex_le_of_le_right := relIndex_le_of_le_right
 
 @[to_additive]
 theorem relIndex_ne_zero_trans (hHK : H.relIndex K ≠ 0) (hKL : K.relIndex L ≠ 0) :
     H.relIndex L ≠ 0 := fun h =>
   mul_ne_zero (mt (relIndex_eq_zero_of_le_right (show K ⊓ L ≤ K from inf_le_left)) hHK) hKL
     ((relIndex_inf_mul_relIndex H K L).trans (relIndex_eq_zero_of_le_left inf_le_left h))
+
+@[deprecated (since := "2025-08-12")] alias relindex_ne_zero_trans := relIndex_ne_zero_trans
 
 @[to_additive]
 theorem relIndex_inf_ne_zero (hH : H.relIndex L ≠ 0) (hK : K.relIndex L ≠ 0) :
@@ -343,6 +404,8 @@ theorem relIndex_inf_ne_zero (hH : H.relIndex L ≠ 0) (hK : K.relIndex L ≠ 0)
   rw [← inf_relIndex_right] at hH hK ⊢
   rw [inf_assoc]
   exact relIndex_ne_zero_trans hH hK
+
+@[deprecated (since := "2025-08-12")] alias relindex_inf_ne_zero := relIndex_inf_ne_zero
 
 @[to_additive]
 theorem index_inf_ne_zero (hH : H.index ≠ 0) (hK : K.index ≠ 0) : (H ⊓ K).index ≠ 0 := by
@@ -358,6 +421,8 @@ lemma relIndex_inter_ne_zero {J K : Subgroup G} (hJK : J.relIndex K ≠ 0) (L : 
     comap_map_eq_self_of_injective (subtype_injective L)]
   exact relIndex_comap_ne_zero _ hJK
 
+@[deprecated (since := "2025-08-12")] alias relindex_inter_ne_zero := relIndex_inter_ne_zero
+
 @[to_additive]
 theorem relIndex_inf_le : (H ⊓ K).relIndex L ≤ H.relIndex L * K.relIndex L := by
   by_cases h : H.relIndex L = 0
@@ -365,6 +430,8 @@ theorem relIndex_inf_le : (H ⊓ K).relIndex L ≤ H.relIndex L * K.relIndex L :
   rw [← inf_relIndex_right, inf_assoc, ← relIndex_mul_relIndex _ _ L inf_le_right inf_le_right,
     inf_relIndex_right, inf_relIndex_right]
   exact mul_le_mul_right' (relIndex_le_of_le_right inf_le_right h) (K.relIndex L)
+
+@[deprecated (since := "2025-08-12")] alias relindex_inf_le := relIndex_inf_le
 
 @[to_additive]
 theorem index_inf_le : (H ⊓ K).index ≤ H.index * K.index := by
@@ -378,6 +445,8 @@ theorem relIndex_iInf_ne_zero {ι : Type*} [_hι : Finite ι] {f : ι → Subgro
     Nat.card_pi.symm.trans ∘
       Finite.card_eq_zero_of_embedding (quotientiInfSubgroupOfEmbedding f L)
 
+@[deprecated (since := "2025-08-12")] alias relindex_iInf_ne_zero := relIndex_iInf_ne_zero
+
 @[to_additive]
 theorem relIndex_iInf_le {ι : Type*} [Fintype ι] (f : ι → Subgroup G) :
     (⨅ i, f i).relIndex L ≤ ∏ i, (f i).relIndex L :=
@@ -386,6 +455,8 @@ theorem relIndex_iInf_le {ι : Type*} [Fintype ι] (f : ι → Subgroup G) :
       let ⟨i, _hi, h⟩ := Finset.prod_eq_zero_iff.mp (Nat.card_pi.symm.trans h)
       relIndex_eq_zero_of_le_left (iInf_le f i) h)
     Nat.card_pi
+
+@[deprecated (since := "2025-08-12")] alias relindex_iInf_le := relIndex_iInf_le
 
 @[to_additive]
 theorem index_iInf_ne_zero {ι : Type*} [Finite ι] {f : ι → Subgroup G}
@@ -406,6 +477,8 @@ theorem index_eq_one : H.index = 1 ↔ H = ⊤ :=
 @[to_additive (attr := simp) relIndex_eq_one]
 theorem relIndex_eq_one : H.relIndex K = 1 ↔ K ≤ H :=
   index_eq_one.trans subgroupOf_eq_top
+
+@[deprecated (since := "2025-08-12")] alias relindex_eq_one := relIndex_eq_one
 
 @[to_additive (attr := simp) card_eq_one]
 theorem card_eq_one : Nat.card H = 1 ↔ H = ⊥ :=
@@ -489,6 +562,9 @@ lemma exists_pow_mem_of_relIndex_ne_zero (h : H.relIndex K ≠ 0) {a : G} (ha : 
   refine ⟨n, hlt, hle, ?_⟩
   simpa [pow_mem ha, mem_subgroupOf] using he
 
+@[deprecated (since := "2025-08-12")]
+alias exists_pow_mem_of_relindex_ne_zero := exists_pow_mem_of_relIndex_ne_zero
+
 @[to_additive]
 lemma pow_mem_of_index_ne_zero_of_dvd (h : H.index ≠ 0) (a : G) {n : ℕ}
     (hn : ∀ m, 0 < m → m ≤ H.index → m ∣ n) : a ^ n ∈ H := by
@@ -502,6 +578,9 @@ lemma pow_mem_of_relIndex_ne_zero_of_dvd (h : H.relIndex K ≠ 0) {a : G} (ha : 
     (hn : ∀ m, 0 < m → m ≤ H.relIndex K → m ∣ n) : a ^ n ∈ H ⊓ K := by
   convert pow_mem_of_index_ne_zero_of_dvd h ⟨a, ha⟩ hn
   simp [pow_mem ha, mem_subgroupOf]
+
+@[deprecated (since := "2025-08-12")]
+alias pow_mem_of_relindex_ne_zero_of_dvd := pow_mem_of_relIndex_ne_zero_of_dvd
 
 @[to_additive (attr := simp) index_prod]
 lemma index_prod (H : Subgroup G) (K : Subgroup G') : (H.prod K).index = H.index * K.index := by
@@ -535,10 +614,15 @@ lemma relIndex_toAddSubgroup :
     (Subgroup.toAddSubgroup H).relIndex (Subgroup.toAddSubgroup K) = H.relIndex K :=
   rfl
 
+@[deprecated (since := "2025-08-12")] alias relindex_toAddSubgroup := relIndex_toAddSubgroup
+
 @[simp]
 lemma _root_.AddSubgroup.relIndex_toSubgroup {G : Type*} [AddGroup G] (H K : AddSubgroup G) :
     (AddSubgroup.toSubgroup H).relIndex (AddSubgroup.toSubgroup K) = H.relIndex K :=
   rfl
+
+@[deprecated (since := "2025-08-12")]
+alias _root_.AddSubgroup.relindex_toSubgroup := _root_.AddSubgroup.relIndex_toSubgroup
 
 section FiniteIndex
 
@@ -572,6 +656,8 @@ variable (H K) in
 
 @[to_additive] lemma relIndex_ne_zero [H.IsFiniteRelIndex K] : H.relIndex K ≠ 0 :=
   IsFiniteRelIndex.relIndex_ne_zero
+
+@[deprecated (since := "2025-08-12")] alias relindex_ne_zero := relIndex_ne_zero
 
 @[to_additive]
 instance IsFiniteRelIndex.to_finiteIndex_subgroupOf [H.IsFiniteRelIndex K] :
@@ -695,10 +781,16 @@ lemma Subgroup.relIndex_pointwise_smul [Group G] [MulDistribMulAction H G] (J K 
   rw [pointwise_smul_def K, ← relIndex_comap, pointwise_smul_def,
     comap_map_eq_self_of_injective (by intro a b; simp)]
 
+@[deprecated (since := "2025-08-12")]
+alias Subgroup.relindex_pointwise_smul := Subgroup.relIndex_pointwise_smul
+
 lemma AddSubgroup.relIndex_pointwise_smul [AddGroup G] [DistribMulAction H G]
     (J K : AddSubgroup G) : (h • J).relIndex (h • K) = J.relIndex K := by
   rw [pointwise_smul_def K, ← relIndex_comap, pointwise_smul_def,
     comap_map_eq_self_of_injective (by intro a b; simp)]
+
+@[deprecated (since := "2025-08-12")]
+alias AddSubgroup.relindex_pointwise_smul := AddSubgroup.relIndex_pointwise_smul
 
 end Pointwise
 

--- a/Mathlib/GroupTheory/IndexNormal.lean
+++ b/Mathlib/GroupTheory/IndexNormal.lean
@@ -46,12 +46,12 @@ theorem normal_of_index_eq_minFac_card (hHp : H.index = (Nat.card G).minFac) :
   by_cases hG1 : Nat.card G = 1
   · rw [hG1, minFac_one] at hHp
     exact normal_of_index_eq_one hHp
-  suffices H.normalCore.relindex H = 1 by
+  suffices H.normalCore.relIndex H = 1 by
     convert H.normalCore_normal
-    exact le_antisymm (relindex_eq_one.mp this) (normalCore_le H)
+    exact le_antisymm (relIndex_eq_one.mp this) (normalCore_le H)
   have : Finite G := finite_of_card_ne_zero hG0
   have index_ne_zero : H.index ≠ 0 := index_ne_zero_of_finite
-  rw [← mul_left_inj' index_ne_zero, one_mul, relindex_mul_index H.normalCore_le]
+  rw [← mul_left_inj' index_ne_zero, one_mul, relIndex_mul_index H.normalCore_le]
   have hp : Nat.Prime H.index := hHp ▸ minFac_prime hG1
   have h : H.normalCore.index ∣ H.index ! := by
     rw [normalCore_eq_ker, index_ker, index_eq_card, ← Nat.card_perm]

--- a/Mathlib/GroupTheory/PGroup.lean
+++ b/Mathlib/GroupTheory/PGroup.lean
@@ -330,9 +330,9 @@ theorem le_or_disjoint_of_coprime [hp : Fact p.Prime] {P : Subgroup G} (hP : IsP
     contrapose! h_cop
     exact Nat.Prime.not_coprime_iff_dvd.mpr ⟨p, hp.out, h_cop⟩
   refine h3.symm.imp (fun h4 ↦ ?_) (fun h4 ↦ ?_)
-  · rw [← Subgroup.relindex_eq_one]
-    exact Nat.eq_one_of_dvd_coprimes h4 (H.relindex_dvd_index_of_normal P)
-      (Subgroup.relindex_dvd_card H P)
+  · rw [← Subgroup.relIndex_eq_one]
+    exact Nat.eq_one_of_dvd_coprimes h4 (H.relIndex_dvd_index_of_normal P)
+      (Subgroup.relIndex_dvd_card H P)
   · exact disjoint_iff.mpr (Subgroup.inf_eq_bot_of_coprime h4)
 
 section P2comm

--- a/Mathlib/GroupTheory/Schreier.lean
+++ b/Mathlib/GroupTheory/Schreier.lean
@@ -175,7 +175,7 @@ theorem card_commutator_dvd_index_center_pow [Finite (commutatorSet G)] :
   -- Rewrite as `|Z(G) ∩ G'| * [G' : Z(G) ∩ G'] ∣ [G : Z(G)] ^ ([G : Z(G)] * n) * [G : Z(G)]`
   rw [← ((center G).subgroupOf (_root_.commutator G)).card_mul_index, pow_succ]
   -- We have `h1 : [G' : Z(G) ∩ G'] ∣ [G : Z(G)]`
-  have h1 := relindex_dvd_index_of_normal (center G) (_root_.commutator G)
+  have h1 := relIndex_dvd_index_of_normal (center G) (_root_.commutator G)
   -- So we can reduce to proving `|Z(G) ∩ G'| ∣ [G : Z(G)] ^ ([G : Z(G)] * n)`
   refine mul_dvd_mul ?_ h1
   -- We know that `[G' : Z(G) ∩ G'] < ∞` by `h1` and `hG`

--- a/Mathlib/GroupTheory/SchurZassenhaus.lean
+++ b/Mathlib/GroupTheory/SchurZassenhaus.lean
@@ -159,8 +159,8 @@ include h2 in
 private theorem step1 (K : Subgroup G) (hK : K ⊔ N = ⊤) : K = ⊤ := by
   contrapose! h3
   have h4 : (N.comap K.subtype).index = N.index := by
-    rw [← N.relindex_top_right, ← hK]
-    exact (relindex_sup_right K N).symm
+    rw [← N.relIndex_top_right, ← hK]
+    exact (relIndex_sup_right K N).symm
   have h5 : Nat.card K < Nat.card G := by
     rw [← K.index_mul_card]
     exact lt_mul_of_one_lt_left Nat.card_pos (one_lt_index_of_ne_top h3)
@@ -169,9 +169,9 @@ private theorem step1 (K : Subgroup G) (hK : K ⊔ N = ⊤) : K = ⊤ := by
     exact h1.coprime_dvd_left (card_comap_dvd_of_injective N K.subtype Subtype.coe_injective)
   obtain ⟨H, hH⟩ := h2 K h5 h6
   replace hH : Nat.card (H.map K.subtype) = N.index := by
-    rw [← relindex_bot_left, ← relindex_comap, MonoidHom.comap_bot, Subgroup.ker_subtype,
-      relindex_bot_left, ← IsComplement'.index_eq_card (IsComplement'.symm hH), index_comap,
-      range_subtype, ← relindex_sup_right, hK, relindex_top_right]
+    rw [← relIndex_bot_left, ← relIndex_comap, MonoidHom.comap_bot, Subgroup.ker_subtype,
+      relIndex_bot_left, ← IsComplement'.index_eq_card (IsComplement'.symm hH), index_comap,
+      range_subtype, ← relIndex_sup_right, hK, relIndex_top_right]
   have h7 : Nat.card N * Nat.card (H.map K.subtype) = Nat.card G := by
     rw [hH, ← N.index_mul_card, mul_comm]
   have h8 : (Nat.card N).Coprime (Nat.card (H.map K.subtype)) := by

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -81,9 +81,9 @@ def _root_.IsPGroup.toSylow [Fact p.Prime] {P : Subgroup G}
       have : P.FiniteIndex := ⟨fun h ↦ hP2 (h ▸ (dvd_zero p))⟩
       obtain ⟨k, hk⟩ := (hQ.to_quotient (P.normalCore.subgroupOf Q)).exists_card_eq
       have h := hk ▸ Nat.Prime.coprime_pow_of_not_dvd (m := k) Fact.out hP2
-      exact le_antisymm (Subgroup.relindex_eq_one.mp
-        (Nat.eq_one_of_dvd_coprimes h (Subgroup.relindex_dvd_index_of_le hPQ)
-        (Subgroup.relindex_dvd_of_le_left Q P.normalCore_le))) hPQ }
+      exact le_antisymm (Subgroup.relIndex_eq_one.mp
+        (Nat.eq_one_of_dvd_coprimes h (Subgroup.relIndex_dvd_index_of_le hPQ)
+        (Subgroup.relIndex_dvd_of_le_left Q P.normalCore_le))) hPQ }
 
 @[simp] theorem _root_.IsPGroup.toSylow_coe [Fact p.Prime] {P : Subgroup G}
     (hP1 : IsPGroup p P) (hP2 : ¬ p ∣ P.index) : (hP1.toSylow hP2) = P :=
@@ -414,8 +414,8 @@ private theorem not_dvd_index_aux [hp : Fact p.Prime] (P : Sylow p G) [P.Normal]
 
 /-- A Sylow p-subgroup has index indivisible by `p`, assuming [N(P) : P] < ∞. -/
 theorem not_dvd_index' [hp : Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
-    (hP : P.relindex P.normalizer ≠ 0) : ¬ p ∣ P.index := by
-  rw [← relindex_mul_index le_normalizer, ← card_eq_index_normalizer]
+    (hP : P.relIndex P.normalizer ≠ 0) : ¬ p ∣ P.index := by
+  rw [← relIndex_mul_index le_normalizer, ← card_eq_index_normalizer]
   haveI : (P.subtype le_normalizer).Normal :=
     Subgroup.normal_in_normalizer
   haveI : (P.subtype le_normalizer).FiniteIndex := ⟨hP⟩

--- a/Mathlib/GroupTheory/Transfer.lean
+++ b/Mathlib/GroupTheory/Transfer.lean
@@ -310,19 +310,19 @@ theorem normalizer_le_centralizer (hP : IsCyclic P) : P.normalizer ≤ centraliz
     rw [Subsingleton.elim P.normalizer (centralizer P)]
   have := Fact.mk (Nat.minFac_prime hn)
   have key := card_dvd_of_injective _ (QuotientGroup.kerLift_injective P.normalizerMonoidHom)
-  rw [normalizerMonoidHom_ker, ← index, ← relindex] at key
-  refine relindex_eq_one.mp (Nat.eq_one_of_dvd_coprimes ?_ dvd_rfl key)
+  rw [normalizerMonoidHom_ker, ← index, ← relIndex] at key
+  refine relIndex_eq_one.mp (Nat.eq_one_of_dvd_coprimes ?_ dvd_rfl key)
   obtain ⟨k, hk⟩ := P.2.exists_card_eq
   rcases eq_zero_or_pos k with h0 | h0
   · rw [hP.card_mulAut, hk, h0, pow_zero, Nat.totient_one]
     apply Nat.coprime_one_right
   rw [hP.card_mulAut, hk, Nat.totient_prime_pow Fact.out h0]
   refine (Nat.Coprime.pow_right _ ?_).mul_right ?_
-  · apply Nat.Coprime.coprime_dvd_left (relindex_dvd_of_le_left P.normalizer P.le_centralizer)
-    apply Nat.Coprime.coprime_dvd_left (relindex_dvd_index_of_le P.le_normalizer)
+  · apply Nat.Coprime.coprime_dvd_left (relIndex_dvd_of_le_left P.normalizer P.le_centralizer)
+    apply Nat.Coprime.coprime_dvd_left (relIndex_dvd_index_of_le P.le_normalizer)
     rw [Nat.coprime_comm, Nat.Prime.coprime_iff_not_dvd Fact.out]
     exact P.not_dvd_index
-  · apply Nat.Coprime.coprime_dvd_left (relindex_dvd_card (centralizer P) P.normalizer)
+  · apply Nat.Coprime.coprime_dvd_left (relIndex_dvd_card (centralizer P) P.normalizer)
     apply Nat.Coprime.coprime_dvd_left (card_subgroup_dvd_card P.normalizer)
     have h1 := Nat.gcd_dvd_left (Nat.card G) ((Nat.card G).minFac - 1)
     have h2 := Nat.gcd_le_right (n := (Nat.card G).minFac - 1) (Nat.card G)

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/CardQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/CardQuotient.lean
@@ -107,6 +107,9 @@ theorem AddSubgroup.relIndex_eq_natAbs_det {E : Type*} [AddCommGroup E]
   rw [relIndex, index_eq_natAbs_det b₂ _ (b₁.map (addSubgroupOfEquivOfLe H).toIntLinearEquiv.symm)]
   rfl
 
+@[deprecated (since := "2025-08-12")]
+alias AddSubgroup.relindex_eq_natAbs_det := AddSubgroup.relIndex_eq_natAbs_det
+
 theorem AddSubgroup.relIndex_eq_abs_det {E : Type*} [AddCommGroup E] [Module ℚ E]
     (L₁ L₂ : AddSubgroup E) (H : L₁ ≤ L₂) {ι : Type*} [DecidableEq ι] [Fintype ι]
     (b₁ b₂ : Basis ι ℚ E) (h₁ : L₁ = .closure (Set.range b₁)) (h₂ : L₂ = .closure (Set.range b₂)) :
@@ -117,5 +120,8 @@ theorem AddSubgroup.relIndex_eq_abs_det {E : Type*} [AddCommGroup E] [Module ℚ
   rw [Basis.det_apply, Basis.det_apply, RingHom.map_det]
   congr; ext
   simp [Basis.toMatrix_apply]
+
+@[deprecated (since := "2025-08-12")]
+alias AddSubgroup.relindex_eq_abs_det := AddSubgroup.relIndex_eq_abs_det
 
 end AddSubgroup

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/CardQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/CardQuotient.lean
@@ -100,18 +100,18 @@ theorem AddSubgroup.index_eq_natAbs_det {E : Type*} [AddCommGroup E] {ι : Type*
   have : Module.Finite ℤ E := Module.Finite.of_basis bE
   (Submodule.natAbs_det_basis_change bE N.toIntSubmodule bN).symm
 
-theorem AddSubgroup.relindex_eq_natAbs_det {E : Type*} [AddCommGroup E]
+theorem AddSubgroup.relIndex_eq_natAbs_det {E : Type*} [AddCommGroup E]
     (L₁ L₂ : AddSubgroup E) (H : L₁ ≤ L₂) {ι : Type*} [DecidableEq ι] [Fintype ι]
     (b₁ : Basis ι ℤ L₁.toIntSubmodule) (b₂ : Basis ι ℤ L₂.toIntSubmodule) :
-    L₁.relindex L₂ = (b₂.det (fun i ↦ ⟨b₁ i, (H (SetLike.coe_mem _))⟩)).natAbs := by
-  rw [relindex, index_eq_natAbs_det b₂ _ (b₁.map (addSubgroupOfEquivOfLe H).toIntLinearEquiv.symm)]
+    L₁.relIndex L₂ = (b₂.det (fun i ↦ ⟨b₁ i, (H (SetLike.coe_mem _))⟩)).natAbs := by
+  rw [relIndex, index_eq_natAbs_det b₂ _ (b₁.map (addSubgroupOfEquivOfLe H).toIntLinearEquiv.symm)]
   rfl
 
-theorem AddSubgroup.relindex_eq_abs_det {E : Type*} [AddCommGroup E] [Module ℚ E]
+theorem AddSubgroup.relIndex_eq_abs_det {E : Type*} [AddCommGroup E] [Module ℚ E]
     (L₁ L₂ : AddSubgroup E) (H : L₁ ≤ L₂) {ι : Type*} [DecidableEq ι] [Fintype ι]
     (b₁ b₂ : Basis ι ℚ E) (h₁ : L₁ = .closure (Set.range b₁)) (h₂ : L₂ = .closure (Set.range b₂)) :
-    L₁.relindex L₂ = |b₂.det b₁| := by
-  rw [AddSubgroup.relindex_eq_natAbs_det L₁ L₂ H (b₁.addSubgroupOfClosure L₁ h₁)
+    L₁.relIndex L₂ = |b₂.det b₁| := by
+  rw [AddSubgroup.relIndex_eq_natAbs_det L₁ L₂ H (b₁.addSubgroupOfClosure L₁ h₁)
     (b₂.addSubgroupOfClosure L₂ h₂), Nat.cast_natAbs, Int.cast_abs]
   change |algebraMap ℤ ℚ _| = _
   rw [Basis.det_apply, Basis.det_apply, RingHom.map_det]

--- a/Mathlib/NumberTheory/ModularForms/ArithmeticSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/ArithmeticSubgroups.lean
@@ -38,7 +38,7 @@ instance : IsArithmetic 𝒮ℒ where is_commensurable := .refl 𝒮ℒ
 lemma isArithmetic_iff_finiteIndex {Γ : Subgroup SL(2, ℤ)} : IsArithmetic Γ ↔ Γ.FiniteIndex := by
   constructor <;>
   · refine fun ⟨h⟩ ↦ ⟨?_⟩
-    simpa [Commensurable, MonoidHom.range_eq_map, ← relindex_comap,
+    simpa [Commensurable, MonoidHom.range_eq_map, ← relIndex_comap,
       comap_map_eq_self_of_injective mapGL_injective] using h
 
 /-- Images in `GL(2, ℝ)` of finite-index subgroups of `SL(2, ℤ)` are arithmetic. -/

--- a/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -316,8 +316,8 @@ open Subgroup in
 lemma finiteIndex_conjGL (g : GL (Fin 2) ℚ) : (conjGL ⊤ (g.map <| Rat.castHom ℝ)).FiniteIndex := by
   constructor
   let t := (toConjAct <| g.map <| Rat.castHom ℝ)⁻¹
-  suffices (t • 𝒮ℒ ⊓ 𝒮ℒ).relindex 𝒮ℒ ≠ 0 by
-    rwa [conjGL, index_comap, ← inf_relindex_right, ← MonoidHom.range_eq_map]
+  suffices (t • 𝒮ℒ ⊓ 𝒮ℒ).relIndex 𝒮ℒ ≠ 0 by
+    rwa [conjGL, index_comap, ← inf_relIndex_right, ← MonoidHom.range_eq_map]
   obtain ⟨N, hN, hN'⟩ := exists_Gamma_le_conj' g 1
   rw [Gamma_one_top, ← MonoidHom.range_eq_map] at hN'
   suffices Γ(N) ≤ (t • 𝒮ℒ ⊓ 𝒮ℒ).comap (mapGL ℝ) by
@@ -333,10 +333,10 @@ lemma isArithmetic_conj_SL2Z (g : GL (Fin 2) ℚ) :
   constructor
   rw [MonoidHom.range_eq_map]
   constructor
-  · rw [← Subgroup.relindex_comap, Subgroup.relindex_top_right]
+  · rw [← Subgroup.relIndex_comap, Subgroup.relIndex_top_right]
     exact (finiteIndex_conjGL g⁻¹).index_ne_zero
-  · rw [← Subgroup.relindex_pointwise_smul (toConjAct (g.map (Rat.castHom ℝ)))⁻¹,
-      inv_smul_smul, ← Subgroup.relindex_comap, Subgroup.relindex_top_right]
+  · rw [← Subgroup.relIndex_pointwise_smul (toConjAct (g.map (Rat.castHom ℝ)))⁻¹,
+      inv_smul_smul, ← Subgroup.relIndex_comap, Subgroup.relIndex_top_right]
     exact (finiteIndex_conjGL g).index_ne_zero
 
 /-- Conjugation by `GL(2, ℚ)` preserves arithmetic subgroups. -/

--- a/Mathlib/NumberTheory/ModularForms/Cusps.lean
+++ b/Mathlib/NumberTheory/ModularForms/Cusps.lean
@@ -68,6 +68,9 @@ lemma isCusp_iff_of_relIndex_ne_zero {𝒢 𝒢' : Subgroup (GL (Fin 2) ℝ)}
   rw [Nat.pos_iff_ne_zero] at hn
   rwa [(hgp.pow hn).smul_eq_self_iff, hgp.parabolicFixedPoint_pow hn, ← hgp.smul_eq_self_iff]
 
+@[deprecated (since := "2025-09-13")]
+alias isCusp_iff_of_relindex_ne_zero := isCusp_iff_of_relIndex_ne_zero
+
 lemma Commensurable.isCusp_iff {𝒢 𝒢' : Subgroup (GL (Fin 2) ℝ)}
     (h𝒢 : Commensurable 𝒢 𝒢') {c : OnePoint ℝ} :
     IsCusp c 𝒢 ↔ IsCusp c 𝒢' := by

--- a/Mathlib/NumberTheory/ModularForms/Cusps.lean
+++ b/Mathlib/NumberTheory/ModularForms/Cusps.lean
@@ -59,11 +59,11 @@ lemma IsCusp.smul_of_mem {c : OnePoint ℝ} {𝒢 : Subgroup (GL (Fin 2) ℝ)} (
     ConjAct.toConjAct_smul, inv_inv, Subgroup.mul_mem_cancel_right _ hg,
     Subgroup.mul_mem_cancel_left _ (inv_mem hg)]
 
-lemma isCusp_iff_of_relindex_ne_zero {𝒢 𝒢' : Subgroup (GL (Fin 2) ℝ)}
-    (h𝒢 : 𝒢' ≤ 𝒢) (h𝒢' : 𝒢'.relindex 𝒢 ≠ 0) (c : OnePoint ℝ) :
+lemma isCusp_iff_of_relIndex_ne_zero {𝒢 𝒢' : Subgroup (GL (Fin 2) ℝ)}
+    (h𝒢 : 𝒢' ≤ 𝒢) (h𝒢' : 𝒢'.relIndex 𝒢 ≠ 0) (c : OnePoint ℝ) :
     IsCusp c 𝒢' ↔ IsCusp c 𝒢 := by
   refine ⟨fun ⟨g, hg, hgp, hgc⟩ ↦ ⟨g, h𝒢 hg, hgp, hgc⟩, fun ⟨g, hg, hgp, hgc⟩ ↦ ?_⟩
-  obtain ⟨n, hn, -, hgn⟩ := Subgroup.exists_pow_mem_of_relindex_ne_zero h𝒢' hg
+  obtain ⟨n, hn, -, hgn⟩ := Subgroup.exists_pow_mem_of_relIndex_ne_zero h𝒢' hg
   refine ⟨g ^ n, (Subgroup.mem_inf.mpr hgn).1, hgp.pow hn.ne', ?_⟩
   rw [Nat.pos_iff_ne_zero] at hn
   rwa [(hgp.pow hn).smul_eq_self_iff, hgp.parabolicFixedPoint_pow hn, ← hgp.smul_eq_self_iff]
@@ -71,9 +71,9 @@ lemma isCusp_iff_of_relindex_ne_zero {𝒢 𝒢' : Subgroup (GL (Fin 2) ℝ)}
 lemma Commensurable.isCusp_iff {𝒢 𝒢' : Subgroup (GL (Fin 2) ℝ)}
     (h𝒢 : Commensurable 𝒢 𝒢') {c : OnePoint ℝ} :
     IsCusp c 𝒢 ↔ IsCusp c 𝒢' := by
-  rw [← isCusp_iff_of_relindex_ne_zero inf_le_left, isCusp_iff_of_relindex_ne_zero inf_le_right]
-  · simpa [Subgroup.inf_relindex_right] using h𝒢.1
-  · simpa [Subgroup.inf_relindex_left] using h𝒢.2
+  rw [← isCusp_iff_of_relIndex_ne_zero inf_le_left, isCusp_iff_of_relIndex_ne_zero inf_le_right]
+  · simpa [Subgroup.inf_relIndex_right] using h𝒢.1
+  · simpa [Subgroup.inf_relIndex_left] using h𝒢.2
 
 /-- The cusps of `SL(2, ℤ)` are precisely the elements of `ℙ¹(ℚ)`. -/
 lemma isCusp_SL2Z_iff {c : OnePoint ℝ} : IsCusp c 𝒮ℒ ↔ c ∈ Set.range (OnePoint.map Rat.cast) := by

--- a/Mathlib/NumberTheory/NumberField/Discriminant/Different.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant/Different.lean
@@ -26,10 +26,10 @@ variable [Module.Finite ℤ 𝒪]
 open nonZeroDivisors
 
 lemma NumberField.absNorm_differentIdeal : (differentIdeal ℤ 𝒪).absNorm = (discr K).natAbs := by
-  refine (differentIdeal ℤ 𝒪).toAddSubgroup.relindex_top_right.symm.trans ?_
+  refine (differentIdeal ℤ 𝒪).toAddSubgroup.relIndex_top_right.symm.trans ?_
   rw [← Submodule.comap_map_eq_of_injective (f := Algebra.linearMap 𝒪 K)
     (FaithfulSMul.algebraMap_injective 𝒪 K) (differentIdeal ℤ 𝒪)]
-  refine (AddSubgroup.relindex_comap (IsLocalization.coeSubmodule K
+  refine (AddSubgroup.relIndex_comap (IsLocalization.coeSubmodule K
     (differentIdeal ℤ 𝒪)).toAddSubgroup (algebraMap 𝒪 K).toAddMonoidHom ⊤).trans ?_
   have := FractionalIdeal.quotientEquiv (R := 𝒪) (K := K) 1 (differentIdeal ℤ 𝒪)
     (differentIdeal ℤ 𝒪)⁻¹ 1 (by simp [differentIdeal_ne_bot]) FractionalIdeal.coeIdeal_le_one
@@ -45,7 +45,7 @@ lemma NumberField.absNorm_differentIdeal : (differentIdeal ℤ 𝒪).absNorm = (
     let e := IsIntegralClosure.equiv ℤ (RingOfIntegers K) K 𝒪
     simpa [e.symm.exists_congr_left, e] using mem_span_integralBasis K
   qify
-  refine (AddSubgroup.relindex_eq_abs_det (1 : Submodule 𝒪 K).toAddSubgroup (FractionalIdeal.dual
+  refine (AddSubgroup.relIndex_eq_abs_det (1 : Submodule 𝒪 K).toAddSubgroup (FractionalIdeal.dual
     ℤ ℚ 1 : FractionalIdeal 𝒪⁰ K).coeToSubmodule.toAddSubgroup ?_ b b' ?_ ?_).trans ?_
   · rw [Submodule.toAddSubgroup_le, ← FractionalIdeal.coe_one]
     exact FractionalIdeal.one_le_dual_one ℤ ℚ (L := K) (B := 𝒪)

--- a/Mathlib/NumberTheory/NumberField/Units/Regulator.lean
+++ b/Mathlib/NumberTheory/NumberField/Units/Regulator.lean
@@ -90,9 +90,9 @@ theorem span_basisOfIsMaxRank {u : Fin (rank K) → (𝓞 K)ˣ} (hu : IsMaxRank 
 theorem finiteIndex_iff_sup_torsion_finiteIndex (s : Subgroup (𝓞 K)ˣ) :
     s.FiniteIndex ↔ (s ⊔ torsion K).FiniteIndex := by
   refine ⟨fun h ↦ Subgroup.finiteIndex_of_le le_sup_left, fun h ↦ ?_⟩
-  rw [Subgroup.finiteIndex_iff, ← Subgroup.relindex_mul_index (le_sup_left : s ≤ s ⊔ torsion K)]
+  rw [Subgroup.finiteIndex_iff, ← Subgroup.relIndex_mul_index (le_sup_left : s ≤ s ⊔ torsion K)]
   refine Nat.mul_ne_zero ?_ (Subgroup.finiteIndex_iff.mp h)
-  rw [Subgroup.relindex_sup_left]
+  rw [Subgroup.relIndex_sup_left]
   exact Subgroup.FiniteIndex.index_ne_zero
 
 open Subgroup in
@@ -324,7 +324,7 @@ Let `u` and `v` be two families of units. Assume that the subgroup `U` generated
 -/
 theorem regOfFamily_div_regOfFamily {u v : Fin (rank K) → (𝓞 K)ˣ} (hv : IsMaxRank v)
     (h : Subgroup.closure (Set.range u) ⊔ torsion K ≤ Subgroup.closure (Set.range v) ⊔ torsion K) :
-    regOfFamily u / regOfFamily v = (Subgroup.closure (Set.range u) ⊔ (torsion K)).relindex
+    regOfFamily u / regOfFamily v = (Subgroup.closure (Set.range u) ⊔ (torsion K)).relIndex
       (Subgroup.closure (Set.range v) ⊔ (torsion K)) := by
   classical
   by_cases hu : IsMaxRank u
@@ -335,14 +335,14 @@ theorem regOfFamily_div_regOfFamily {u v : Fin (rank K) → (𝓞 K)ˣ} (hv : Is
         ← SupHomClass.map_sup, ← SupHomClass.map_sup]
       exact AddSubgroup.map_mono <| (OrderIso.le_iff_le Subgroup.toAddSubgroup).mpr h
     rw [regOfFamily_of_isMaxRank hu, regOfFamily_of_isMaxRank hv,
-      covolume_div_covolume_eq_relindex _ _ this, span_basisOfIsMaxRank hu,
-      span_basisOfIsMaxRank hv, AddSubgroup.relindex_map_map, logEmbedding_ker,
-      ← OrderIso.map_sup, ← OrderIso.map_sup, ← Subgroup.relindex_toAddSubgroup]
+      covolume_div_covolume_eq_relIndex _ _ this, span_basisOfIsMaxRank hu,
+      span_basisOfIsMaxRank hv, AddSubgroup.relIndex_map_map, logEmbedding_ker,
+      ← OrderIso.map_sup, ← OrderIso.map_sup, ← Subgroup.relIndex_toAddSubgroup]
   · rw [regOfFamily_eq_zero hu, zero_div, eq_comm, Nat.cast_eq_zero]
     have : (Subgroup.closure (Set.range v) ⊔ torsion K).index ≠ 0 := by
       rw [← Subgroup.finiteIndex_iff, ← finiteIndex_iff_sup_torsion_finiteIndex]
       exact isMaxRank_iff_closure_finiteIndex.mp hv
-    rwa [← mul_eq_zero_iff_right this, Subgroup.relindex_mul_index h,
+    rwa [← mul_eq_zero_iff_right this, Subgroup.relIndex_mul_index h,
       ← Subgroup.not_finiteIndex_iff, ← finiteIndex_iff_sup_torsion_finiteIndex,
       ← isMaxRank_iff_closure_finiteIndex.not]
 
@@ -354,7 +354,7 @@ theorem regOfFamily_div_regulator (u : Fin (rank K) → (𝓞 K)ˣ) :
     regOfFamily u / regulator K = (Subgroup.closure (Set.range u) ⊔ (torsion K)).index := by
   rw [regulator_eq_regOfFamily_fundSystem, regOfFamily_div_regOfFamily (isMaxRank_fundSystem K)
     (by simp only [closure_fundSystem_sup_torsion_eq_top, le_top]),
-    closure_fundSystem_sup_torsion_eq_top, Subgroup.relindex_top_right]
+    closure_fundSystem_sup_torsion_eq_top, Subgroup.relIndex_top_right]
 
 end index
 

--- a/Mathlib/RingTheory/Ideal/Quotient/Index.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Index.lean
@@ -38,7 +38,7 @@ lemma Submodule.finite_quotient_smul [Finite (R ⧸ I)] [Finite (M ⧸ N)] (hN :
     exact (I • N).toAddSubgroup.finite_quotient_of_finiteIndex
   suffices Nat.card (N ⧸ (I • N).comap N.subtype) ≠ 0 by
     constructor
-    rw [← AddSubgroup.relindex_mul_index
+    rw [← AddSubgroup.relIndex_mul_index
       (H := (I • N).toAddSubgroup) (K := N.toAddSubgroup) Submodule.smul_le_right]
     have inst : Finite (M ⧸ N.toAddSubgroup) := ‹_›
     exact mul_ne_zero this AddSubgroup.index_ne_zero_of_finite
@@ -60,7 +60,7 @@ lemma Submodule.index_smul_le [Finite (R ⧸ I)]
     (I • N).toAddSubgroup.index ≤ I.toAddSubgroup.index ^ s.card * N.toAddSubgroup.index := by
   classical
   cases nonempty_fintype (R ⧸ I)
-  rw [← AddSubgroup.relindex_mul_index
+  rw [← AddSubgroup.relIndex_mul_index
     (H := (I • N).toAddSubgroup) (K := N.toAddSubgroup) Submodule.smul_le_right]
   gcongr
   change (Nat.card (N ⧸ (I • N).comap N.subtype)) ≤ Nat.card (R ⧸ I) ^ s.card


### PR DESCRIPTION
Zulip discussion about renaming: [#PR reviews > #19872 rename relindex to relIndex @ 💬](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2319872.20rename.20relindex.20to.20relIndex/near/515908054)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]

-->
- [x] depends on: #24044

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
