### PR TITLE
[Merged by Bors] - feat: determinant of left multiplication

### DIFF
--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -331,9 +331,7 @@ theorem bot_lt_ker_of_det_eq_zero {𝕜 : Type*} [Field 𝕜] [Module 𝕜 M] {f
 
 /-- When the function is over the base ring, the determinant is the evaluation at `1`. -/
 @[simp] lemma det_ring (f : R →ₗ[R] R) : f.det = f 1 := by
-  classical
-  rw [← det_toMatrix ⟨(Finsupp.LinearEquiv.finsuppUnique R R Unit).symm⟩, Matrix.det_unique]
-  rfl
+  simp [← det_toMatrix (Basis.singleton Unit R)]
 
 lemma det_mulLeft (a : R) : (mulLeft R a).det = a := by simp
 lemma det_mulRight (a : R) : (mulRight R a).det = a := by simp

--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -329,7 +329,7 @@ theorem bot_lt_ker_of_det_eq_zero {𝕜 : Type*} [Field 𝕜] [Module 𝕜 M] {f
   simp only [bot_lt_iff_ne_bot, Classical.not_not, ← isUnit_iff_ker_eq_bot] at hf
   exact isUnit_iff_ne_zero.1 (f.isUnit_det hf)
 
-@[simp] lemma det_mul (a : R) : (mul R R a).det = a := by
+@[simp] lemma det_mulLeft (a : R) : (mulLeft R a).det = a := by
   classical
   rw [← det_toMatrix ⟨(Finsupp.LinearEquiv.finsuppUnique R R Unit).symm⟩, Matrix.det_unique]
   exact mul_one _

--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -329,6 +329,11 @@ theorem bot_lt_ker_of_det_eq_zero {𝕜 : Type*} [Field 𝕜] [Module 𝕜 M] {f
   simp only [bot_lt_iff_ne_bot, Classical.not_not, ← isUnit_iff_ker_eq_bot] at hf
   exact isUnit_iff_ne_zero.1 (f.isUnit_det hf)
 
+@[simp] lemma det_mul (a : R) : (mul R R a).det = a := by
+  classical
+  rw [← det_toMatrix ⟨(Finsupp.LinearEquiv.finsuppUnique R R Unit).symm⟩, Matrix.det_unique]
+  exact mul_one _
+
 end LinearMap
 
 

--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -329,15 +329,14 @@ theorem bot_lt_ker_of_det_eq_zero {𝕜 : Type*} [Field 𝕜] [Module 𝕜 M] {f
   simp only [bot_lt_iff_ne_bot, Classical.not_not, ← isUnit_iff_ker_eq_bot] at hf
   exact isUnit_iff_ne_zero.1 (f.isUnit_det hf)
 
-@[simp] lemma det_mulLeft (a : R) : (mulLeft R a).det = a := by
+/-- When the function is over the base ring, the determinant is the evaluation at `1`. -/
+@[simp] lemma det_ring (f : R →ₗ[R] R) : f.det = f 1 := by
   classical
   rw [← det_toMatrix ⟨(Finsupp.LinearEquiv.finsuppUnique R R Unit).symm⟩, Matrix.det_unique]
-  exact mul_one _
+  rfl
 
-@[simp] lemma det_mulRight (a : R) : (mulRight R a).det = a := by
-  classical
-  rw [← det_toMatrix ⟨(Finsupp.LinearEquiv.finsuppUnique R R Unit).symm⟩, Matrix.det_unique]
-  exact one_mul _
+@[simp] lemma det_mulLeft (a : R) : (mulLeft R a).det = a := by simp
+@[simp] lemma det_mulRight (a : R) : (mulRight R a).det = a := by simp
 
 end LinearMap
 

--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -335,8 +335,8 @@ theorem bot_lt_ker_of_det_eq_zero {𝕜 : Type*} [Field 𝕜] [Module 𝕜 M] {f
   rw [← det_toMatrix ⟨(Finsupp.LinearEquiv.finsuppUnique R R Unit).symm⟩, Matrix.det_unique]
   rfl
 
-@[simp] lemma det_mulLeft (a : R) : (mulLeft R a).det = a := by simp
-@[simp] lemma det_mulRight (a : R) : (mulRight R a).det = a := by simp
+lemma det_mulLeft (a : R) : (mulLeft R a).det = a := by simp
+lemma det_mulRight (a : R) : (mulRight R a).det = a := by simp
 
 end LinearMap
 

--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -334,6 +334,11 @@ theorem bot_lt_ker_of_det_eq_zero {𝕜 : Type*} [Field 𝕜] [Module 𝕜 M] {f
   rw [← det_toMatrix ⟨(Finsupp.LinearEquiv.finsuppUnique R R Unit).symm⟩, Matrix.det_unique]
   exact mul_one _
 
+@[simp] lemma det_mulRight (a : R) : (mulRight R a).det = a := by
+  classical
+  rw [← det_toMatrix ⟨(Finsupp.LinearEquiv.finsuppUnique R R Unit).symm⟩, Matrix.det_unique]
+  exact one_mul _
+
 end LinearMap
 
 

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -562,6 +562,11 @@ theorem LinearMap.toMatrix_one : LinearMap.toMatrix v₁ v₁ 1 = 1 :=
   LinearMap.toMatrix_id v₁
 
 @[simp]
+lemma LinearMap.toMatrix_singleton {ι : Type*} [Unique ι] (f) (i j : ι) :
+    LinearMap.toMatrix (Basis.singleton ι R) (Basis.singleton ι R) f i j = f 1 := by
+  simp [toMatrix, Subsingleton.elim j default]
+
+@[simp]
 theorem Matrix.toLin_one : Matrix.toLin v₁ v₁ 1 = LinearMap.id := by
   rw [← LinearMap.toMatrix_id v₁, Matrix.toLin_toMatrix]
 

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -562,8 +562,8 @@ theorem LinearMap.toMatrix_one : LinearMap.toMatrix v₁ v₁ 1 = 1 :=
   LinearMap.toMatrix_id v₁
 
 @[simp]
-lemma LinearMap.toMatrix_singleton {ι : Type*} [Unique ι] (f) (i j : ι) :
-    LinearMap.toMatrix (Basis.singleton ι R) (Basis.singleton ι R) f i j = f 1 := by
+lemma LinearMap.toMatrix_singleton {ι : Type*} [Unique ι] (f : R →ₗ[R] R) (i j : ι) :
+    f.toMatrix (.singleton ι R) (.singleton ι R) i j = f 1 := by
   simp [toMatrix, Subsingleton.elim j default]
 
 @[simp]

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -403,7 +403,7 @@ theorem det_traceMatrix_ne_zero' [Algebra.IsSeparable K L] : det (traceMatrix K 
   let e : Fin pb.dim ≃ (L →ₐ[K] AlgebraicClosure L) := (Fintype.equivFinOfCardEq ?_).symm
   · rw [RingHom.map_det, RingHom.mapMatrix_apply,
       traceMatrix_eq_embeddingsMatrixReindex_mul_trans K _ _ e,
-      embeddingsMatrixReindex_eq_vandermonde, det_mul, det_transpose]
+      embeddingsMatrixReindex_eq_vandermonde, Matrix.det_mul, det_transpose]
     refine mt mul_self_eq_zero.mp ?_
     simp only [det_vandermonde, Finset.prod_eq_zero_iff, not_exists, sub_eq_zero]
     rintro i ⟨_, j, hij, h⟩
@@ -415,7 +415,7 @@ theorem det_traceForm_ne_zero [Algebra.IsSeparable K L] [DecidableEq ι] (b : Ba
   haveI : FiniteDimensional K L := FiniteDimensional.of_fintype_basis b
   let pb : PowerBasis K L := Field.powerBasisOfFiniteOfSeparable _ _
   rw [← BilinForm.toMatrix_mul_basis_toMatrix pb.basis b, ←
-    det_comm' (pb.basis.toMatrix_mul_toMatrix_flip b) _, ← Matrix.mul_assoc, det_mul]
+    det_comm' (pb.basis.toMatrix_mul_toMatrix_flip b) _, ← Matrix.mul_assoc, Matrix.det_mul]
   swap; · apply Basis.toMatrix_mul_toMatrix_flip
   refine
     mul_ne_zero
@@ -425,7 +425,7 @@ theorem det_traceForm_ne_zero [Algebra.IsSeparable K L] [DecidableEq ι] (b : Ba
             ((b.toMatrix pb.basis)ᵀ * b.toMatrix pb.basis).det =
           (pb.basis.toMatrix b * (b.toMatrix pb.basis * pb.basis.toMatrix b)ᵀ *
               b.toMatrix pb.basis).det := by
-        simp only [← det_mul, Matrix.mul_assoc, Matrix.transpose_mul]
+        simp only [← Matrix.det_mul, Matrix.mul_assoc, Matrix.transpose_mul]
       _ = 1 := by
         simp only [Basis.toMatrix_mul_toMatrix_flip, Matrix.transpose_one, Matrix.mul_one,
           Matrix.det_one]

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -403,7 +403,7 @@ theorem det_traceMatrix_ne_zero' [Algebra.IsSeparable K L] : det (traceMatrix K 
   let e : Fin pb.dim ≃ (L →ₐ[K] AlgebraicClosure L) := (Fintype.equivFinOfCardEq ?_).symm
   · rw [RingHom.map_det, RingHom.mapMatrix_apply,
       traceMatrix_eq_embeddingsMatrixReindex_mul_trans K _ _ e,
-      embeddingsMatrixReindex_eq_vandermonde, Matrix.det_mul, det_transpose]
+      embeddingsMatrixReindex_eq_vandermonde, det_mul, det_transpose]
     refine mt mul_self_eq_zero.mp ?_
     simp only [det_vandermonde, Finset.prod_eq_zero_iff, not_exists, sub_eq_zero]
     rintro i ⟨_, j, hij, h⟩
@@ -415,7 +415,7 @@ theorem det_traceForm_ne_zero [Algebra.IsSeparable K L] [DecidableEq ι] (b : Ba
   haveI : FiniteDimensional K L := FiniteDimensional.of_fintype_basis b
   let pb : PowerBasis K L := Field.powerBasisOfFiniteOfSeparable _ _
   rw [← BilinForm.toMatrix_mul_basis_toMatrix pb.basis b, ←
-    det_comm' (pb.basis.toMatrix_mul_toMatrix_flip b) _, ← Matrix.mul_assoc, Matrix.det_mul]
+    det_comm' (pb.basis.toMatrix_mul_toMatrix_flip b) _, ← Matrix.mul_assoc, det_mul]
   swap; · apply Basis.toMatrix_mul_toMatrix_flip
   refine
     mul_ne_zero
@@ -425,7 +425,7 @@ theorem det_traceForm_ne_zero [Algebra.IsSeparable K L] [DecidableEq ι] (b : Ba
             ((b.toMatrix pb.basis)ᵀ * b.toMatrix pb.basis).det =
           (pb.basis.toMatrix b * (b.toMatrix pb.basis * pb.basis.toMatrix b)ᵀ *
               b.toMatrix pb.basis).det := by
-        simp only [← Matrix.det_mul, Matrix.mul_assoc, Matrix.transpose_mul]
+        simp only [← det_mul, Matrix.mul_assoc, Matrix.transpose_mul]
       _ = 1 := by
         simp only [Basis.toMatrix_mul_toMatrix_flip, Matrix.transpose_one, Matrix.mul_one,
           Matrix.det_one]


### PR DESCRIPTION
From FLT

Co-authored-by: Kevin Buzzard <k.buzzard@imperial.ac.uk>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
