### PR TITLE
[Merged by Bors] - chore(Data/List/Lemmas): deprecate tail_reverse_eq_reverse_dropLast

### DIFF
--- a/Mathlib/Data/List/Lemmas.lean
+++ b/Mathlib/Data/List/Lemmas.lean
@@ -31,16 +31,7 @@ lemma count_flatMap [BEq β] (l : List α) (f : α → List β) (x : β) :
 
 @[deprecated (since := "2024-08-20")] alias getElem_reverse' := getElem_reverse
 
-theorem tail_reverse_eq_reverse_dropLast (l : List α) :
-    l.reverse.tail = l.dropLast.reverse := by
-  ext i v; by_cases hi : i < l.length - 1
-  · simp only [← drop_one]
-    rw [getElem?_eq_getElem (by simpa), getElem?_eq_getElem (by simpa),
-      ← getElem_drop' _, getElem_reverse, getElem_reverse, getElem_dropLast]
-    · simp [show l.length - 1 - (1 + i) = l.length - 1 - 1 - i by omega]
-    all_goals ((try simp); omega)
-  · rw [getElem?_eq_none, getElem?_eq_none]
-    all_goals (simp; omega)
+@[deprecated (since := "2024-12-10")] alias tail_reverse_eq_reverse_dropLast := tail_reverse
 
 @[deprecated (since := "2024-08-19")] alias nthLe_tail := getElem_tail
 


### PR DESCRIPTION
Makes `tail_reverse_eq_reverse_dropLast` a deprecated alias to [`tail_reverse`](https://github.com/leanprover/lean4/blob/938651121f3d8819109eee75722a1de087feff71/src/Init/Data/List/Lemmas.lean#L2990-L2994), which was added to core in https://github.com/leanprover/lean4/pull/5360.

This duplicated lemma was found by [`tryAtEachStep`](https://github.com/dwrensha/tryAtEachStep).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
