### PR TITLE
[Merged by Bors] - feat(GroupTheory/SpecificGroups/ZGroup): a finite Z-group has cyclic abelianization

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -81,6 +81,9 @@ def IsCyclic.commGroup [hg : Group α] [IsCyclic α] : CommGroup α :=
       let ⟨_, hm⟩ := hg y
       hm ▸ hn ▸ zpow_mul_comm _ _ _ }
 
+instance [Group G] (H : Subgroup G) [IsCyclic H] : H.IsCommutative :=
+  ⟨⟨IsCyclic.commGroup.mul_comm⟩⟩
+
 variable [Group α] [Group G] [Group G']
 
 /-- A non-cyclic multiplicative group is non-trivial. -/

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -13,11 +13,11 @@ A Z-group is a group whose Sylow subgroups are all cyclic.
 
 ## Main definitions
 
-* `IsZGroup G`: A predicate stating that all Sylow subgroups of `G` are cyclic.
+* `IsZGroup G`: a predicate stating that all Sylow subgroups of `G` are cyclic.
 
 ## Main results
 
-* `IsZGroup.isCyclic_abelianization`: A finite Z-group has cyclic abelianization.
+* `IsZGroup.isCyclic_abelianization`: a finite Z-group has cyclic abelianization.
 
 TODO: Show that if `G` is a Z-group with commutator subgroup `G'`, then `G = G' ⋊ G/G'` where `G'`
 and `G/G'` are cyclic of coprime orders.

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -17,7 +17,7 @@ A Z-group is a group whose Sylow subgroups are all cyclic.
 
 ## Main results
 
-* `isCyclic_abelianization`: A Z-group has cyclic abelianization.
+* `IsZGroup.isCyclic_abelianization`: A finite Z-group has cyclic abelianization.
 
 TODO: Show that if `G` is a Z-group with commutator subgroup `G'`, then `G = G' ⋊ G/G'` where `G'`
 and `G/G'` are cyclic of coprime orders.

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -88,6 +88,7 @@ instance [Finite G] [IsZGroup G] [hG : Group.IsNilpotent G] : IsCyclic G := by
     ⟨fun g h ↦ by rw [← ϕ.symm.injective.eq_iff, map_mul, mul_comm, ← map_mul]⟩
   exact IsCyclic.of_exponent_eq_card (exponent_eq_card G)
 
+/-- A finite Z-group has cyclic abelianization. -/
 instance isCyclic_abelianization [Finite G] [IsZGroup G] : IsCyclic (Abelianization G) :=
   let _ : IsZGroup (Abelianization G) := inferInstanceAs (IsZGroup (G ⧸ commutator G))
   inferInstance

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -68,8 +68,7 @@ instance [Finite G] [IsZGroup G] (H : Subgroup G) [H.Normal] : IsZGroup (G ⧸ H
 
 section Nilpotent
 
-variable (G)
-
+variable (G) in
 theorem exponent_eq_card [Finite G] [IsZGroup G] : Monoid.exponent G = Nat.card G := by
   refine dvd_antisymm Group.exponent_dvd_nat_card ?_
   rw [← Nat.factorization_prime_le_iff_dvd Nat.card_pos.ne' Monoid.exponent_ne_zero_of_finite]

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -15,6 +15,10 @@ A Z-group is a group whose Sylow subgroups are all cyclic.
 
 * `IsZGroup G`: A predicate stating that all Sylow subgroups of `G` are cyclic.
 
+## Main results
+
+* `isCyclic_abelianization`: A Z-group has cyclic abelianization.
+
 TODO: Show that if `G` is a Z-group with commutator subgroup `G'`, then `G = G' ⋊ G/G'` where `G'`
 and `G/G'` are cyclic of coprime orders.
 
@@ -62,6 +66,10 @@ theorem of_surjective [Finite G] [hG : IsZGroup G] (hf : Function.Surjective f) 
 instance [Finite G] [IsZGroup G] (H : Subgroup G) [H.Normal] : IsZGroup (G ⧸ H) :=
   of_surjective (QuotientGroup.mk'_surjective H)
 
+section Nilpotent
+
+variable (G)
+
 theorem exponent_eq_card [Finite G] [IsZGroup G] : Monoid.exponent G = Nat.card G := by
   refine dvd_antisymm Group.exponent_dvd_nat_card ?_
   rw [← Nat.factorization_prime_le_iff_dvd Nat.card_pos.ne' Monoid.exponent_ne_zero_of_finite]
@@ -75,11 +83,15 @@ theorem exponent_eq_card [Finite G] [IsZGroup G] : Monoid.exponent G = Nat.card 
 instance [Finite G] [IsZGroup G] [hG : Group.IsNilpotent G] : IsCyclic G := by
   have (p : { x // x ∈ (Nat.card G).primeFactors }) : Fact p.1.Prime :=
     ⟨Nat.prime_of_mem_primeFactors p.2⟩
-  let h (p : { x // x ∈ (Nat.card G).primeFactors }) (P : Sylow p G) : CommGroup P :=
-    IsCyclic.commGroup
   obtain ⟨ϕ⟩ := ((isNilpotent_of_finite_tfae (G := G)).out 0 4).mp hG
   let _ : CommGroup G :=
     ⟨fun g h ↦ by rw [← ϕ.symm.injective.eq_iff, map_mul, mul_comm, ← map_mul]⟩
-  exact IsCyclic.of_exponent_eq_card exponent_eq_card
+  exact IsCyclic.of_exponent_eq_card (exponent_eq_card G)
+
+instance isCyclic_abelianization [Finite G] [IsZGroup G] : IsCyclic (Abelianization G) :=
+  let _ : IsZGroup (Abelianization G) := inferInstanceAs (IsZGroup (G ⧸ commutator G))
+  inferInstance
+
+end Nilpotent
 
 end IsZGroup


### PR DESCRIPTION
This is one step towards showing that a finite Z-group `G` is the semidirect product of the commutator subgroup `G'` and the abelianziation `G/G'` and that `G'` and `G/G'` are cyclic of coprime orders.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
