### PR TITLE
Exponentiation of rational numbers to integer powers

### DIFF
--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -214,6 +214,14 @@ instance instPowNat : Pow ℚ ℕ where
   pow q n := ⟨q.num ^ n, q.den ^ n, by simp [Nat.pow_eq_zero], by
     rw [Int.natAbs_pow]; exact q.reduced.pow _ _⟩
 
+def pow_int_exponent (q : ℚ) (n : ℤ) : ℚ :=
+  if n ≥ 0
+  then q ^ (Int.toNat n)
+  else q ^ (Int.toNat (-n))
+
+instance instPowInt : Pow ℚ ℤ where
+  pow q n := pow_int_exponent q n
+
 lemma pow_def (q : ℚ) (n : ℕ) :
     q ^ n = ⟨q.num ^ n, q.den ^ n,
       by simp [Nat.pow_eq_zero],


### PR DESCRIPTION
`r^x` for rational `r` and integer `x` is just `r^x` for natural x, or `1/(r^(-x))` for negative integers. To my surprise, I couldn't find this in the mathlib, though I may well have missed something. The only thing available here is a type class; if a lemma or two would be desired, I'd be happy to continue working on this.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
