### PR TITLE
[Merged by Bors] - feat(CategoryTheory): infer connectedness of comma categories from finality/initiality of the functor

### DIFF
--- a/Mathlib/CategoryTheory/Comma/Final.lean
+++ b/Mathlib/CategoryTheory/Comma/Final.lean
@@ -79,6 +79,11 @@ connected.-/
 instance isConnected_comma_of_final [IsConnected A] [R.Final] : IsConnected (Comma L R) := by
   rwa [Types.isConnected_iff_of_final (fst L R)]
 
+/-- `Comma L R` with `L : A ⥤ T` and `R : B ⥤ T` is connected if `L` is initial and `B` is
+connected.-/
+instance isConnected_comma_of_initial [IsConnected B] [L.Initial] : IsConnected (Comma L R) := by
+  rwa [Types.isConnected_iff_of_initial (snd L R)]
+
 end Comma
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Comma/Final.lean
+++ b/Mathlib/CategoryTheory/Comma/Final.lean
@@ -4,13 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jakob von Raumer
 -/
 import Mathlib.CategoryTheory.Functor.KanExtension.Adjunction
-import Mathlib.CategoryTheory.Limits.Final
+import Mathlib.CategoryTheory.Limits.IsConnected
 import Mathlib.CategoryTheory.Grothendieck
 
 /-!
 # Finality of Projections in Comma Categories
 
 We show that `fst L R` is final if `R` is and that `snd L R` is initial if `L` is.
+As a corollary, we show that `Comma L R` with `L : A ⥤ T` and `R : B ⥤ T` is connected if `R` is
+final and `A` is connected.
 -/
 
 universe v₁ v₂ v₃ u₁ u₂ u₃
@@ -71,6 +73,11 @@ instance initial_snd [L.Initial] : (snd L R).Initial := by
     final_equivalence_comp (opEquiv L R).functor.leftOp (fst R.op L.op)
   haveI : (snd L R).op.Final := final_of_natIso (opFunctorCompFst _ _)
   apply initial_of_final_op
+
+/-- `Comma L R` with `L : A ⥤ T` and `R : B ⥤ T` is connected if `R` is final and `A` is
+connected.-/
+instance isConnected_comma_of_final [IsConnected A] [R.Final] : IsConnected (Comma L R) := by
+  rwa [Types.isConnected_iff_of_final (fst L R)]
 
 end Comma
 

--- a/Mathlib/CategoryTheory/Comma/Final.lean
+++ b/Mathlib/CategoryTheory/Comma/Final.lean
@@ -13,6 +13,10 @@ import Mathlib.CategoryTheory.Grothendieck
 We show that `fst L R` is final if `R` is and that `snd L R` is initial if `L` is.
 As a corollary, we show that `Comma L R` with `L : A ⥤ T` and `R : B ⥤ T` is connected if `R` is
 final and `A` is connected.
+
+## References
+
+* [M. Kashiwara, P. Schapira, *Categories and Sheaves*][Kashiwara2006], Lemma 3.4.3
 -/
 
 universe v₁ v₂ v₃ u₁ u₂ u₃
@@ -75,12 +79,12 @@ instance initial_snd [L.Initial] : (snd L R).Initial := by
   apply initial_of_final_op
 
 /-- `Comma L R` with `L : A ⥤ T` and `R : B ⥤ T` is connected if `R` is final and `A` is
-connected.-/
+connected. -/
 instance isConnected_comma_of_final [IsConnected A] [R.Final] : IsConnected (Comma L R) := by
   rwa [isConnected_iff_of_final (fst L R)]
 
 /-- `Comma L R` with `L : A ⥤ T` and `R : B ⥤ T` is connected if `L` is initial and `B` is
-connected.-/
+connected. -/
 instance isConnected_comma_of_initial [IsConnected B] [L.Initial] : IsConnected (Comma L R) := by
   rwa [isConnected_iff_of_initial (snd L R)]
 

--- a/Mathlib/CategoryTheory/Comma/Final.lean
+++ b/Mathlib/CategoryTheory/Comma/Final.lean
@@ -77,12 +77,12 @@ instance initial_snd [L.Initial] : (snd L R).Initial := by
 /-- `Comma L R` with `L : A ⥤ T` and `R : B ⥤ T` is connected if `R` is final and `A` is
 connected.-/
 instance isConnected_comma_of_final [IsConnected A] [R.Final] : IsConnected (Comma L R) := by
-  rwa [Types.isConnected_iff_of_final (fst L R)]
+  rwa [isConnected_iff_of_final (fst L R)]
 
 /-- `Comma L R` with `L : A ⥤ T` and `R : B ⥤ T` is connected if `L` is initial and `B` is
 connected.-/
 instance isConnected_comma_of_initial [IsConnected B] [L.Initial] : IsConnected (Comma L R) := by
-  rwa [Types.isConnected_iff_of_initial (snd L R)]
+  rwa [isConnected_iff_of_initial (snd L R)]
 
 end Comma
 

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -259,6 +259,10 @@ theorem isPreconnected_of_isPreconnected_op [IsPreconnected Jᵒᵖ] : IsPreconn
 theorem isConnected_of_isConnected_op [IsConnected Jᵒᵖ] : IsConnected J :=
   isConnected_of_equivalent (opOpEquivalence J)
 
+variable (J) in
+theorem isConnected_iff_isConnected_op : IsConnected J ↔ IsConnected Jᵒᵖ :=
+  ⟨fun _ => isConnected_op, fun _ => isConnected_of_isConnected_op⟩
+
 /-- j₁ and j₂ are related by `Zag` if there is a morphism between them. -/
 def Zag (j₁ j₂ : J) : Prop :=
   Nonempty (j₁ ⟶ j₂) ∨ Nonempty (j₂ ⟶ j₁)

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -260,8 +260,9 @@ theorem isConnected_of_isConnected_op [IsConnected Jᵒᵖ] : IsConnected J :=
   isConnected_of_equivalent (opOpEquivalence J)
 
 variable (J) in
-theorem isConnected_iff_isConnected_op : IsConnected J ↔ IsConnected Jᵒᵖ :=
-  ⟨fun _ => isConnected_op, fun _ => isConnected_of_isConnected_op⟩
+@[simp]
+theorem isConnected_op_iff_isConnected : IsConnected Jᵒᵖ ↔ IsConnected J :=
+  ⟨fun _ => isConnected_of_isConnected_op, fun _ => isConnected_op⟩
 
 /-- j₁ and j₂ are related by `Zag` if there is a morphism between them. -/
 def Zag (j₁ j₂ : J) : Prop :=

--- a/Mathlib/CategoryTheory/Limits/IsConnected.lean
+++ b/Mathlib/CategoryTheory/Limits/IsConnected.lean
@@ -39,7 +39,9 @@ unit-valued, singleton, colimit
 
 universe w v u
 
-namespace CategoryTheory.Limits.Types
+namespace CategoryTheory
+
+namespace Limits.Types
 
 variable (C : Type u) [Category.{v} C]
 
@@ -111,8 +113,15 @@ theorem isConnected_iff_isColimit_pUnitCocone :
   simp only [isConnected_iff_colimit_constPUnitFunctor_iso_pUnit.{w} C]
   exact ⟨colimit.isoColimitCocone colimitCocone⟩
 
+end Limits.Types
+
+namespace Functor
+
+open Limits.Types
+
 universe v₂ u₂
-variable {C : Type u} {D : Type u₂} [Category.{v} C] [Category.{v₂} D]
+
+variable {C : Type u} [Category.{v} C] {D : Type u₂} [Category.{v₂} D]
 
 /-- The domain of a final functor is connected if and only if its codomain is connected. -/
 theorem isConnected_iff_of_final (F : C ⥤ D) [F.Final] : IsConnected C ↔ IsConnected D := by
@@ -126,4 +135,6 @@ theorem isConnected_iff_of_initial (F : C ⥤ D) [F.Initial] : IsConnected C ↔
   rw [isConnected_iff_isConnected_op C, isConnected_iff_isConnected_op D]
   exact isConnected_iff_of_final F.op
 
-end CategoryTheory.Limits.Types
+end Functor
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/IsConnected.lean
+++ b/Mathlib/CategoryTheory/Limits/IsConnected.lean
@@ -132,7 +132,7 @@ theorem isConnected_iff_of_final (F : C ⥤ D) [F.Final] : IsConnected C ↔ IsC
 
 /-- The domain of an initial functor is connected if and only if its codomain is connected. -/
 theorem isConnected_iff_of_initial (F : C ⥤ D) [F.Initial] : IsConnected C ↔ IsConnected D := by
-  rw [isConnected_iff_isConnected_op C, isConnected_iff_isConnected_op D]
+  rw [← isConnected_op_iff_isConnected C, ← isConnected_op_iff_isConnected D]
   exact isConnected_iff_of_final F.op
 
 end Functor

--- a/Mathlib/CategoryTheory/Limits/IsConnected.lean
+++ b/Mathlib/CategoryTheory/Limits/IsConnected.lean
@@ -115,11 +115,15 @@ universe v₂ u₂
 variable {C : Type u} {D : Type u₂} [Category.{v} C] [Category.{v₂} D]
 
 /-- The domain of a final functor is connected if and only if its codomain is connected. -/
-theorem isConnected_iff_of_final (F : C ⥤ D) [CategoryTheory.Functor.Final F] :
-    IsConnected C ↔ IsConnected D := by
+theorem isConnected_iff_of_final (F : C ⥤ D) [F.Final] : IsConnected C ↔ IsConnected D := by
   rw [isConnected_iff_colimit_constPUnitFunctor_iso_pUnit.{max v u v₂ u₂} C,
     isConnected_iff_colimit_constPUnitFunctor_iso_pUnit.{max v u v₂ u₂} D]
   exact Equiv.nonempty_congr <| Iso.isoCongrLeft <|
     CategoryTheory.Functor.Final.colimitIso F <| constPUnitFunctor.{max u v u₂ v₂} D
+
+/-- The domain of an initial functor is connected if and only if its codomain is connected. -/
+theorem isConnected_iff_of_initial (F : C ⥤ D) [F.Initial] : IsConnected C ↔ IsConnected D := by
+  rw [isConnected_iff_isConnected_op C, isConnected_iff_isConnected_op D]
+  exact isConnected_iff_of_final F.op
 
 end CategoryTheory.Limits.Types


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
