### PR TITLE
[Merged by Bors] - feat(RingTheory/Polynomial/HilbertPoly): `Polynomial.hilbertPoly_linearMap`

### DIFF
--- a/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
+++ b/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
@@ -121,21 +121,33 @@ lemma hilbertPoly_X_pow_succ (d k : ℕ) :
     hilbertPoly ((X : F[X]) ^ k) (d + 1) = preHilbertPoly F d k := by
   delta hilbertPoly; simp
 
-theorem fun_hilbertPoly_isLinearMap (d : ℕ) :
-    IsLinearMap F (fun (p : F[X]) => hilbertPoly p d) := by
+variable {F} in
+lemma hilbertPoly_add_nat (p q : F[X]) (d : ℕ) :
+    hilbertPoly (p + q) d = hilbertPoly p d + hilbertPoly q d := by
   delta hilbertPoly
   induction d with
-  | zero => exact ⟨by simp only [add_zero, implies_true], by simp only [smul_zero, implies_true]⟩
-  | succ d _ => exact {
-      map_add := fun _ _ => by
-        simp only [← coeff_add]
-        rw [← sum_def _ fun _ r => r • _]
-        exact sum_add_index _ _ _ (fun _ => zero_smul ..) (fun _ _ _ => add_smul ..)
-      map_smul := fun _ _ => by
-        simp only
-        rw [← sum_def _ fun _ r => r • _, ← sum_def _ fun _ r => r • _, Polynomial.smul_sum,
-          sum_smul_index' _ _ _ fun i => zero_smul F (preHilbertPoly F d i)]
-        simp only [smul_assoc] }
+  | zero => simp only [add_zero]
+  | succ d _ =>
+      simp only [← coeff_add]
+      rw [← sum_def _ fun _ r => r • _]
+      exact sum_add_index _ _ _ (fun _ => zero_smul ..) (fun _ _ _ => add_smul ..)
+
+variable {F} in
+lemma hilbertPoly_smul_nat (a : F) (p : F[X]) (d : ℕ) :
+    hilbertPoly (a • p) d = a • hilbertPoly p d := by
+  delta hilbertPoly
+  induction d with
+  | zero => simp only [smul_zero]
+  | succ d _ =>
+      simp only
+      rw [← sum_def _ fun _ r => r • _, ← sum_def _ fun _ r => r • _, Polynomial.smul_sum,
+        sum_smul_index' _ _ _ fun i => zero_smul F (preHilbertPoly F d i)]
+      simp only [smul_assoc]
+
+theorem fun_hilbertPoly_isLinearMap (d : ℕ) :
+    IsLinearMap F (fun (p : F[X]) => hilbertPoly p d) where
+  map_add := fun _ _ => hilbertPoly_add_nat ..
+  map_smul := fun _ _ ↦ hilbertPoly_smul_nat ..
 
 variable {F} [CharZero F]
 

--- a/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
+++ b/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
@@ -142,10 +142,14 @@ lemma hilbertPoly_smul_nat (a : F) (p : F[X]) (d : ℕ) :
       simp only [smul_assoc]
 
 variable (F) in
-theorem isLinearMap_hilbertPoly (d : ℕ) :
-    IsLinearMap F (fun (p : F[X]) => hilbertPoly p d) where
-  map_add := fun _ _ => hilbertPoly_add_nat ..
-  map_smul := fun _ _ ↦ hilbertPoly_smul_nat ..
+/--
+The function that sends any `p : F[X]` to `Polynomial.hilbertPoly p d` is an `F`-linear map from
+`F[X]` to `F[X]`.
+-/
+noncomputable def hilbertPoly_linearMap (d : ℕ) : F[X] →ₗ[F] F[X] where
+  toFun p := hilbertPoly p d
+  map_add' p q := hilbertPoly_add_nat p q d
+  map_smul' r p := hilbertPoly_smul_nat r p d
 
 variable [CharZero F]
 

--- a/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
+++ b/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
@@ -91,7 +91,8 @@ lemma preHilbertPoly_eq_choose_sub_add [CharZero F] (d : ℕ) {k n : ℕ} (hkn :
     rw [ascPochhammer_nat_eq_natCast_ascFactorial];
     field_simp [ascFactorial_eq_factorial_mul_choose]
 
-variable {F} in
+variable {F}
+
 /--
 `Polynomial.hilbertPoly p 0 = 0`; for any `d : ℕ`, `Polynomial.hilbertPoly p (d + 1)`
 is defined as `∑ i in p.support, (p.coeff i) • Polynomial.preHilbertPoly F d i`. If
@@ -110,10 +111,8 @@ lemma hilbertPoly_zero_nat (d : ℕ) : hilbertPoly (0 : F[X]) d = 0 := by
   | zero => simp only
   | succ d _ => simp only [coeff_zero, zero_smul, Finset.sum_const_zero]
 
-variable {F} in
 lemma hilbertPoly_poly_zero (p : F[X]) : hilbertPoly p 0 = 0 := rfl
 
-variable {F} in
 lemma hilbertPoly_poly_succ (p : F[X]) (d : ℕ) :
     hilbertPoly p (d + 1) = ∑ i in p.support, (p.coeff i) • preHilbertPoly F d i := rfl
 
@@ -121,7 +120,6 @@ lemma hilbertPoly_X_pow_succ (d k : ℕ) :
     hilbertPoly ((X : F[X]) ^ k) (d + 1) = preHilbertPoly F d k := by
   delta hilbertPoly; simp
 
-variable {F} in
 lemma hilbertPoly_add_nat (p q : F[X]) (d : ℕ) :
     hilbertPoly (p + q) d = hilbertPoly p d + hilbertPoly q d := by
   delta hilbertPoly
@@ -132,7 +130,6 @@ lemma hilbertPoly_add_nat (p q : F[X]) (d : ℕ) :
       rw [← sum_def _ fun _ r => r • _]
       exact sum_add_index _ _ _ (fun _ => zero_smul ..) (fun _ _ _ => add_smul ..)
 
-variable {F} in
 lemma hilbertPoly_smul_nat (a : F) (p : F[X]) (d : ℕ) :
     hilbertPoly (a • p) d = a • hilbertPoly p d := by
   delta hilbertPoly
@@ -144,12 +141,13 @@ lemma hilbertPoly_smul_nat (a : F) (p : F[X]) (d : ℕ) :
         sum_smul_index' _ _ _ fun i => zero_smul F (preHilbertPoly F d i)]
       simp only [smul_assoc]
 
-theorem fun_hilbertPoly_isLinearMap (d : ℕ) :
+variable (F) in
+theorem isLinearMap_hilbertPoly (d : ℕ) :
     IsLinearMap F (fun (p : F[X]) => hilbertPoly p d) where
   map_add := fun _ _ => hilbertPoly_add_nat ..
   map_smul := fun _ _ ↦ hilbertPoly_smul_nat ..
 
-variable {F} [CharZero F]
+variable [CharZero F]
 
 /--
 The key property of Hilbert polynomials. If `F` is a field with characteristic `0`, `p : F[X]` and
@@ -263,7 +261,7 @@ theorem natDegree_hilbertPoly_of_ne_zero
   have hp : p ≠ 0 := by
     intro h
     rw [h] at hh
-    exact hh (hilbertPoly_zero_nat F d)
+    exact hh (hilbertPoly_zero_nat d)
   have hpd : p.rootMultiplicity 1 < d := by
     by_contra h
     exact hh (hilbertPoly_eq_zero_of_le_rootMultiplicity_one <| not_lt.1 h)

--- a/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
+++ b/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
@@ -106,21 +106,21 @@ noncomputable def hilbertPoly (p : F[X]) : (d : ℕ) → F[X]
   | 0 => 0
   | d + 1 => ∑ i in p.support, (p.coeff i) • preHilbertPoly F d i
 
-lemma hilbertPoly_zero_nat (d : ℕ) : hilbertPoly (0 : F[X]) d = 0 := by
+lemma hilbertPoly_zero_left (d : ℕ) : hilbertPoly (0 : F[X]) d = 0 := by
   delta hilbertPoly; induction d with
   | zero => simp only
   | succ d _ => simp only [coeff_zero, zero_smul, Finset.sum_const_zero]
 
-lemma hilbertPoly_poly_zero (p : F[X]) : hilbertPoly p 0 = 0 := rfl
+lemma hilbertPoly_zero_right (p : F[X]) : hilbertPoly p 0 = 0 := rfl
 
-lemma hilbertPoly_poly_succ (p : F[X]) (d : ℕ) :
+lemma hilbertPoly_succ (p : F[X]) (d : ℕ) :
     hilbertPoly p (d + 1) = ∑ i in p.support, (p.coeff i) • preHilbertPoly F d i := rfl
 
 lemma hilbertPoly_X_pow_succ (d k : ℕ) :
     hilbertPoly ((X : F[X]) ^ k) (d + 1) = preHilbertPoly F d k := by
   delta hilbertPoly; simp
 
-lemma hilbertPoly_add_nat (p q : F[X]) (d : ℕ) :
+lemma hilbertPoly_add_left (p q : F[X]) (d : ℕ) :
     hilbertPoly (p + q) d = hilbertPoly p d + hilbertPoly q d := by
   delta hilbertPoly
   induction d with
@@ -130,7 +130,7 @@ lemma hilbertPoly_add_nat (p q : F[X]) (d : ℕ) :
       rw [← sum_def _ fun _ r => r • _]
       exact sum_add_index _ _ _ (fun _ => zero_smul ..) (fun _ _ _ => add_smul ..)
 
-lemma hilbertPoly_smul_nat (a : F) (p : F[X]) (d : ℕ) :
+lemma hilbertPoly_smul (a : F) (p : F[X]) (d : ℕ) :
     hilbertPoly (a • p) d = a • hilbertPoly p d := by
   delta hilbertPoly
   induction d with
@@ -148,8 +148,8 @@ The function that sends any `p : F[X]` to `Polynomial.hilbertPoly p d` is an `F`
 -/
 noncomputable def hilbertPoly_linearMap (d : ℕ) : F[X] →ₗ[F] F[X] where
   toFun p := hilbertPoly p d
-  map_add' p q := hilbertPoly_add_nat p q d
-  map_smul' r p := hilbertPoly_smul_nat r p d
+  map_add' p q := hilbertPoly_add_left p q d
+  map_smul' r p := hilbertPoly_smul r p d
 
 variable [CharZero F]
 
@@ -230,7 +230,7 @@ lemma hilbertPoly_eq_zero_of_le_rootMultiplicity_one
     {p : F[X]} {d : ℕ} (hdp : d ≤ p.rootMultiplicity 1) :
     hilbertPoly p d = 0 := by
   by_cases hp : p = 0
-  · rw [hp, hilbertPoly_zero_nat]
+  · rw [hp, hilbertPoly_zero_left]
   · rcases exists_eq_pow_rootMultiplicity_mul_and_not_dvd p hp 1 with ⟨q, hq1, hq2⟩
     have heq : p = q * (- 1) ^ p.rootMultiplicity 1 * (1 - X) ^ p.rootMultiplicity 1 := by
       simp only [mul_assoc, ← mul_pow, neg_mul, one_mul, neg_sub]
@@ -265,7 +265,7 @@ theorem natDegree_hilbertPoly_of_ne_zero
   have hp : p ≠ 0 := by
     intro h
     rw [h] at hh
-    exact hh (hilbertPoly_zero_nat d)
+    exact hh (hilbertPoly_zero_left d)
   have hpd : p.rootMultiplicity 1 < d := by
     by_contra h
     exact hh (hilbertPoly_eq_zero_of_le_rootMultiplicity_one <| not_lt.1 h)

--- a/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
+++ b/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
@@ -37,7 +37,7 @@ the characteristic of `F` to be divisible by `d!`. As `Polynomial.hilbertPoly` m
 * Hilbert polynomials of finitely generated graded modules over Noetherian rings.
 -/
 
-open Nat Polynomial PowerSeries
+open Nat PowerSeries
 
 variable (F : Type*) [Field F]
 
@@ -121,8 +121,6 @@ lemma hilbertPoly_X_pow_succ (d k : ℕ) :
     hilbertPoly ((X : F[X]) ^ k) (d + 1) = preHilbertPoly F d k := by
   delta hilbertPoly; simp
 
-end Polynomial
-
 theorem fun_hilbertPoly_isLinearMap (d : ℕ) :
     IsLinearMap F (fun (p : F[X]) => hilbertPoly p d) := by
   delta hilbertPoly
@@ -138,8 +136,6 @@ theorem fun_hilbertPoly_isLinearMap (d : ℕ) :
         rw [← sum_def _ fun _ r => r • _, ← sum_def _ fun _ r => r • _, Polynomial.smul_sum,
           sum_smul_index' _ _ _ fun i => zero_smul F (preHilbertPoly F d i)]
         simp only [smul_assoc] }
-
-namespace Polynomial
 
 variable {F} [CharZero F]
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The main new declaration created in this pull request is `Polynomial.hilbertPoly_linearMap`, which is the `F`-linear map `fun (p : F[X]) => Polynomial.hilbertPoly p d`.