### PR TITLE
[Merged by Bors] - chore(Topology/PartitionOfUnity): shorten proof using ParitionOfUnity.le_one

### DIFF
--- a/Mathlib/Topology/PartitionOfUnity.lean
+++ b/Mathlib/Topology/PartitionOfUnity.lean
@@ -665,15 +665,4 @@ theorem exists_continuous_sum_one_of_isOpen_isCompact [T2Space X] [LocallyCompac
           exact hj)]
     rfl
   intro i x
-  refine ⟨f.nonneg i x, ?_⟩
-  by_cases h0 : f i x = 0
-  · rw [h0]
-    exact zero_le_one
-  rw [← Finset.sum_singleton (f ·  x) i]
-  apply le_trans _ (f.sum_le_one' x)
-  rw [finsum_eq_sum (f.toFun ·  x) (by exact toFinite (support (f.toFun · x)))]
-  simp only [Finite.toFinset_setOf, ne_eq]
-  gcongr with z hz
-  · exact fun j _ _ => f.nonneg j x
-  simp only [Finset.singleton_subset_iff, Finset.mem_filter, Finset.mem_univ, true_and]
-  exact h0
+  exact ⟨f.nonneg i x, PartitionOfUnity.le_one f i x⟩


### PR DESCRIPTION
Replaces 11 lines of proof with a single invocation of [`ParitionOfUnity.le_one`](https://github.com/leanprover-community/mathlib4/blob/4411562e4fd2d02aa31e413bc8e948829aa3a62d/Mathlib/Topology/PartitionOfUnity.lean#L171).

I observed this (via `set_option trace.profiler true`) to lower the elaboration time of this theorem from 0.20 seconds to 0.08 seconds.

This simplification was found by [`tryAtEachStep`](https://github.com/dwrensha/tryAtEachStep).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
