### PR TITLE
[Merged by Bors] - chore(MeasurableSpace/Prod): rename a lemma

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Real.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Real.lean
@@ -481,7 +481,7 @@ lemma measurable_of_real_prod {f : EReal × β → γ}
     (h_real : Measurable fun p : ℝ × β ↦ f (p.1, p.2))
     (h_bot : Measurable fun x ↦ f (⊥, x)) (h_top : Measurable fun x ↦ f (⊤, x)) : Measurable f :=
   .of_union₃_range_cover (measurableEmbedding_prod_mk_left _) (measurableEmbedding_prod_mk_left _)
-    (measurableEmbedding_coe.prod_mk .id) (by simp [-univ_subset_iff, subset_def, EReal.forall])
+    (measurableEmbedding_coe.prodMap .id) (by simp [-univ_subset_iff, subset_def, EReal.forall])
     h_bot h_top h_real
 
 lemma measurable_of_real_real {f : EReal × EReal → β}

--- a/Mathlib/MeasureTheory/MeasurableSpace/Prod.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Prod.lean
@@ -69,10 +69,10 @@ lemma isPiSystem_prod :
     IsPiSystem (image2 (· ×ˢ ·) { s : Set α | MeasurableSet s } { t : Set β | MeasurableSet t }) :=
   isPiSystem_measurableSet.prod isPiSystem_measurableSet
 
-lemma MeasurableEmbedding.prod_mk {α β γ δ : Type*} {mα : MeasurableSpace α}
+lemma MeasurableEmbedding.prodMap {α β γ δ : Type*} {mα : MeasurableSpace α}
     {mβ : MeasurableSpace β} {mγ : MeasurableSpace γ} {mδ : MeasurableSpace δ} {f : α → β}
     {g : γ → δ} (hg : MeasurableEmbedding g) (hf : MeasurableEmbedding f) :
-    MeasurableEmbedding fun x : γ × α => (g x.1, f x.2) := by
+    MeasurableEmbedding (Prod.map g f) := by
   have h_inj : Function.Injective fun x : γ × α => (g x.fst, f x.snd) := by
     intro x y hxy
     rw [← @Prod.mk.eta _ _ x, ← @Prod.mk.eta _ _ y]
@@ -96,6 +96,9 @@ lemma MeasurableEmbedding.prod_mk {α β γ δ : Type*} {mα : MeasurableSpace �
     · intro g _ _ hg
       simp_rw [Set.image_iUnion]
       exact MeasurableSet.iUnion hg
+
+@[deprecated (since := "2024-12-11")]
+alias MeasurableEmbedding.prod_mk := MeasurableEmbedding.prodMap
 
 lemma MeasurableEmbedding.prod_mk_left {β γ : Type*} [MeasurableSingletonClass α]
     {mβ : MeasurableSpace β} {mγ : MeasurableSpace γ}

--- a/Mathlib/Probability/Kernel/Composition/Basic.lean
+++ b/Mathlib/Probability/Kernel/Composition/Basic.lean
@@ -574,18 +574,12 @@ lemma comapRight_compProd_id_prod {δ : Type*} {mδ : MeasurableSpace δ}
     comapRight (κ ⊗ₖ η) (MeasurableEmbedding.id.prodMap hf) = κ ⊗ₖ (comapRight η hf) := by
   ext a t ht
   rw [comapRight_apply' _ _ _ ht, compProd_apply, compProd_apply ht]
-  swap; · exact (MeasurableEmbedding.id.prod_mk hf).measurableSet_image.mpr ht
-  refine lintegral_congr (fun b ↦ ?_)
-  simp only [id_eq, Set.mem_image, Prod.mk.injEq, Prod.exists]
-  rw [comapRight_apply']
-  swap; · exact measurable_prod_mk_left ht
-  congr with x
-  simp only [Set.mem_setOf_eq, Set.mem_image]
-  constructor
-  · rintro ⟨b', c, h, rfl, rfl⟩
-    exact ⟨c, h, rfl⟩
-  · rintro ⟨c, h, rfl⟩
-    exact ⟨b, c, h, rfl, rfl⟩
+  · refine lintegral_congr fun b ↦ ?_
+    rw [comapRight_apply']
+    · congr with x
+      aesop
+    · exact measurable_prod_mk_left ht
+  · exact (MeasurableEmbedding.id.prodMap hf).measurableSet_image.mpr ht
 
 end CompositionProduct
 

--- a/Mathlib/Probability/Kernel/Composition/Basic.lean
+++ b/Mathlib/Probability/Kernel/Composition/Basic.lean
@@ -571,7 +571,7 @@ lemma compProd_add_right (μ : Kernel α β) (κ η : Kernel (α × β) γ)
 lemma comapRight_compProd_id_prod {δ : Type*} {mδ : MeasurableSpace δ}
     (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ) [IsSFiniteKernel η]
     {f : δ → γ} (hf : MeasurableEmbedding f) :
-    comapRight (κ ⊗ₖ η) (MeasurableEmbedding.id.prod_mk hf) = κ ⊗ₖ (comapRight η hf) := by
+    comapRight (κ ⊗ₖ η) (MeasurableEmbedding.id.prodMap hf) = κ ⊗ₖ (comapRight η hf) := by
   ext a t ht
   rw [comapRight_apply' _ _ _ ht, compProd_apply, compProd_apply ht]
   swap; · exact (MeasurableEmbedding.id.prod_mk hf).measurableSet_image.mpr ht

--- a/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
@@ -242,13 +242,13 @@ lemma compProd_fst_borelMarkovFromReal_eq_comapRight_compProd
       = map κ (Prod.map (id : β → β) (embeddingReal Ω))) :
     fst κ ⊗ₖ borelMarkovFromReal Ω η
       = comapRight (fst (map κ (Prod.map (id : β → β) (embeddingReal Ω))) ⊗ₖ η)
-        (MeasurableEmbedding.id.prod_mk (measurableEmbedding_embeddingReal Ω)) := by
+        (MeasurableEmbedding.id.prodMap (measurableEmbedding_embeddingReal Ω)) := by
   let e := embeddingReal Ω
   let he := measurableEmbedding_embeddingReal Ω
   let κ' := map κ (Prod.map (id : β → β) e)
   have hη' : fst κ' ⊗ₖ η = κ' := hη
   have h_prod_embed : MeasurableEmbedding (Prod.map (id : β → β) e) :=
-    MeasurableEmbedding.id.prod_mk he
+    MeasurableEmbedding.id.prodMap he
   change fst κ ⊗ₖ borelMarkovFromReal Ω η = comapRight (fst κ' ⊗ₖ η) h_prod_embed
   rw [comapRight_compProd_id_prod _ _ he]
   have h_fst : fst κ' = fst κ := by
@@ -295,7 +295,7 @@ lemma compProd_fst_borelMarkovFromReal (κ : Kernel α (β × Ω)) [IsSFiniteKer
   let κ' := map κ (Prod.map (id : β → β) e)
   have hη' : fst κ' ⊗ₖ η = κ' := hη
   have h_prod_embed : MeasurableEmbedding (Prod.map (id : β → β) e) :=
-    MeasurableEmbedding.id.prod_mk he
+    MeasurableEmbedding.id.prodMap he
   have : κ = comapRight κ' h_prod_embed := by
     ext c t : 2
     unfold κ'


### PR DESCRIPTION
Also use `Prod.map` in the statement and golf a proof using `aesop`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
