### PR TITLE
[Merged by Bors] - chore: deprecate upstreamed theorem List.cons_subperm_of_mem

### DIFF
--- a/Mathlib/Data/List/Perm/Subperm.lean
+++ b/Mathlib/Data/List/Perm/Subperm.lean
@@ -53,7 +53,7 @@ lemma subperm_cons_self : l <+~ a :: l := ⟨l, Perm.refl _, sublist_cons_self _
 
 protected alias ⟨subperm.of_cons, subperm.cons⟩ := subperm_cons
 
-@[deprecated List.cons_subperm_of_not_mem_of_mem (since := "2024-12-11")]
+@[deprecated List.cons_subperm_of_not_mem_of_mem (since := "2024-12-11"), nolint unusedArguments]
 theorem cons_subperm_of_mem {a : α} {l₁ l₂ : List α} (_ : Nodup l₁) (h₁ : a ∉ l₁) (h₂ : a ∈ l₂)
     (s : l₁ <+~ l₂) : a :: l₁ <+~ l₂ :=
   cons_subperm_of_not_mem_of_mem h₁ h₂ s

--- a/Mathlib/Data/List/Perm/Subperm.lean
+++ b/Mathlib/Data/List/Perm/Subperm.lean
@@ -53,30 +53,10 @@ lemma subperm_cons_self : l <+~ a :: l := ⟨l, Perm.refl _, sublist_cons_self _
 
 protected alias ⟨subperm.of_cons, subperm.cons⟩ := subperm_cons
 
-theorem cons_subperm_of_mem {a : α} {l₁ l₂ : List α} (d₁ : Nodup l₁) (h₁ : a ∉ l₁) (h₂ : a ∈ l₂)
-    (s : l₁ <+~ l₂) : a :: l₁ <+~ l₂ := by
-  rcases s with ⟨l, p, s⟩
-  induction s generalizing l₁ with
-  | slnil => cases h₂
-  | @cons r₁ r₂ b s' ih =>
-    simp? at h₂ says simp only [mem_cons] at h₂
-    cases' h₂ with e m
-    · subst b
-      exact ⟨a :: r₁, p.cons a, s'.cons₂ _⟩
-    · rcases ih d₁ h₁ m p with ⟨t, p', s'⟩
-      exact ⟨t, p', s'.cons _⟩
-  | @cons₂ r₁ r₂ b _ ih =>
-    have bm : b ∈ l₁ := p.subset <| mem_cons_self _ _
-    have am : a ∈ r₂ := by
-      simp only [find?, mem_cons] at h₂
-      exact h₂.resolve_left fun e => h₁ <| e.symm ▸ bm
-    rcases append_of_mem bm with ⟨t₁, t₂, rfl⟩
-    have st : t₁ ++ t₂ <+ t₁ ++ b :: t₂ := by simp
-    rcases ih (d₁.sublist st) (mt (fun x => st.subset x) h₁) am
-        (Perm.cons_inv <| p.trans perm_middle) with
-      ⟨t, p', s'⟩
-    exact
-      ⟨b :: t, (p'.cons b).trans <| (swap _ _ _).trans (perm_middle.symm.cons a), s'.cons₂ _⟩
+@[deprecated List.cons_subperm_of_not_mem_of_mem (since := "2024-12-11")]
+theorem cons_subperm_of_mem {a : α} {l₁ l₂ : List α} (_ : Nodup l₁) (h₁ : a ∉ l₁) (h₂ : a ∈ l₂)
+    (s : l₁ <+~ l₂) : a :: l₁ <+~ l₂ :=
+  cons_subperm_of_not_mem_of_mem h₁ h₂ s
 
 protected theorem Nodup.subperm (d : Nodup l₁) (H : l₁ ⊆ l₂) : l₁ <+~ l₂ :=
   subperm_of_subset d H


### PR DESCRIPTION
Deprecates `List.cons_subperm_of_mem`, which was upstreamed to `Batteries` as [`List.cons_subperm_of_not_mem_of_mem`](https://github.com/leanprover-community/batteries/blob/74dffd1a83cdd2969a31c9892b0517e7c6f50668/Batteries/Data/List/Perm.lean#L94) in https://github.com/leanprover-community/batteries/pull/89.

The upstream version is in fact *stronger*, as it does not have a `Nodup l₁` parameter.


This duplication was found by [`tryAtEachStep`](https://github.com/dwrensha/tryAtEachStep).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
