### PR TITLE
[Merged by Bors] - feat(Algebra/Group/Aut): Automorphism groups of `Multiplicative G` and `Additive G`

### DIFF
--- a/Mathlib/Algebra/Group/Aut.lean
+++ b/Mathlib/Algebra/Group/Aut.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
 -/
+import Mathlib.Algebra.Group.Equiv.TypeTags
 import Mathlib.GroupTheory.Perm.Basic
 
 /-!
@@ -276,3 +277,13 @@ def congr [AddGroup G] {H : Type*} [AddGroup H] (ϕ : G ≃+ H) :
   map_mul' := by simp [DFunLike.ext_iff]
 
 end AddAut
+
+/-- `Multiplicative G` and `G` have isomorphic automorphism groups. -/
+@[simps!]
+def MulAutMultiplicative [AddGroup G] : MulAut (Multiplicative G) ≃* AddAut G :=
+  { AddEquiv.toMultiplicative.symm with map_mul' := fun _ _ ↦ rfl }
+
+/-- `Additive G` and `G` have isomorphic automorphism groups. -/
+@[simps!]
+def AddAutAdditive [Group G] : AddAut (Additive G) ≃* MulAut G :=
+  { MulEquiv.toAdditive.symm with map_mul' := fun _ _ ↦ rfl }

--- a/Mathlib/Algebra/Group/Aut.lean
+++ b/Mathlib/Algebra/Group/Aut.lean
@@ -278,6 +278,8 @@ def congr [AddGroup G] {H : Type*} [AddGroup H] (ϕ : G ≃+ H) :
 
 end AddAut
 
+variable (G)
+
 /-- `Multiplicative G` and `G` have isomorphic automorphism groups. -/
 @[simps!]
 def MulAutMultiplicative [AddGroup G] : MulAut (Multiplicative G) ≃* AddAut G :=

--- a/Mathlib/Algebra/Group/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Equiv/TypeTags.lean
@@ -52,6 +52,16 @@ def MulEquiv.toAdditive [MulOneClass G] [MulOneClass H] :
   left_inv x := by ext; rfl
   right_inv x := by ext; rfl
 
+/-- `Multiplicative G` has the same automorphisms as `G`. -/
+@[simps]
+def MulAutMultiplicative [AddGroup G] : MulAut (Multiplicative G) ≃* AddAut G :=
+  { AddEquiv.toMultiplicative.symm with map_mul' := fun _ _ ↦ rfl }
+
+/-- `Additive G` has the same automorphisms as `G`. -/
+@[simps]
+def AddAutAdditive [Group G] : AddAut (Additive G) ≃* MulAut G :=
+  { MulEquiv.toAdditive.symm with map_mul' := fun _ _ ↦ rfl }
+
 /-- Reinterpret `Additive G ≃+ H` as `G ≃* Multiplicative H`. -/
 @[simps]
 def AddEquiv.toMultiplicative' [MulOneClass G] [AddZeroClass H] :

--- a/Mathlib/Algebra/Group/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Equiv/TypeTags.lean
@@ -52,16 +52,6 @@ def MulEquiv.toAdditive [MulOneClass G] [MulOneClass H] :
   left_inv x := by ext; rfl
   right_inv x := by ext; rfl
 
-/-- `Multiplicative G` has the same automorphisms as `G`. -/
-@[simps]
-def MulAutMultiplicative [AddGroup G] : MulAut (Multiplicative G) ≃* AddAut G :=
-  { AddEquiv.toMultiplicative.symm with map_mul' := fun _ _ ↦ rfl }
-
-/-- `Additive G` has the same automorphisms as `G`. -/
-@[simps]
-def AddAutAdditive [Group G] : AddAut (Additive G) ≃* MulAut G :=
-  { MulEquiv.toAdditive.symm with map_mul' := fun _ _ ↦ rfl }
-
 /-- Reinterpret `Additive G ≃+ H` as `G ≃* Multiplicative H`. -/
 @[simps]
 def AddEquiv.toMultiplicative' [MulOneClass G] [AddZeroClass H] :


### PR DESCRIPTION
This PR adds isomorphisms `MulAut (Multiplicative G) ≃* AddAut G` and `AddAut (Additive G) ≃* MulAut G`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
