### PR TITLE
[Merged by Bors] - feat(GroupTheory/Abelianization): Add `Abelianization.ker_of`

### DIFF
--- a/Mathlib/GroupTheory/Abelianization.lean
+++ b/Mathlib/GroupTheory/Abelianization.lean
@@ -112,6 +112,11 @@ def of : G →* Abelianization G where
 theorem mk_eq_of (a : G) : Quot.mk _ a = of a :=
   rfl
 
+variable (G) in
+@[simp]
+theorem ker_of : of.ker = commutator G :=
+  QuotientGroup.ker_mk' (commutator G)
+
 section lift
 
 -- So far we have built Gᵃᵇ and proved it's an abelian group.


### PR DESCRIPTION
This PR adds `Abelianization.ker_of`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
