### PR TITLE
[Merged by Bors] - feat(SetTheory/Cardinal/Cofinality): generalize `cof_preOmega`

### DIFF
--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -80,9 +80,6 @@ theorem IsSuccPrelimit.isSuccLimit_of_not_isMin (h : IsSuccPrelimit a) (ha : ¬ 
     IsSuccLimit a :=
   ⟨ha, h⟩
 
-theorem IsSuccPrelimit.isMin_or_isSuccLimit (h : IsSuccPrelimit a) : IsMin a ∨ IsSuccLimit a :=
-  or_iff_not_imp_left.2 h.isSuccLimit_of_not_isMin
-
 theorem IsSuccPrelimit.isSuccLimit [NoMinOrder α] (h : IsSuccPrelimit a) : IsSuccLimit a :=
   h.isSuccLimit_of_not_isMin (not_isMin a)
 
@@ -195,10 +192,6 @@ variable [PartialOrder α]
 
 theorem isSuccLimit_iff [OrderBot α] : IsSuccLimit a ↔ a ≠ ⊥ ∧ IsSuccPrelimit a := by
   rw [IsSuccLimit, isMin_iff_eq_bot]
-
-theorem IsSuccPrelimit.eq_bot_or_isSuccLimit [OrderBot α] (h : IsSuccPrelimit a) :
-    a = ⊥ ∨ IsSuccLimit a := by
-  simpa using h.isMin_or_isSuccLimit
 
 theorem IsSuccLimit.bot_lt [OrderBot α] (h : IsSuccLimit a) : ⊥ < a :=
   h.ne_bot.bot_lt
@@ -417,9 +410,6 @@ theorem IsPredPrelimit.isPredLimit_of_not_isMax (h : IsPredPrelimit a) (ha : ¬ 
     IsPredLimit a :=
   ⟨ha, h⟩
 
-theorem IsPredPrelimit.isMax_or_isPredLimit (h : IsPredPrelimit a) : IsMax a ∨ IsPredLimit a :=
-  or_iff_not_imp_left.2 h.isPredLimit_of_not_isMax
-
 theorem IsPredPrelimit.isPredLimit [NoMaxOrder α] (h : IsPredPrelimit a) : IsPredLimit a :=
   h.isPredLimit_of_not_isMax (not_isMax a)
 
@@ -522,10 +512,6 @@ variable [PartialOrder α]
 
 theorem isPredLimit_iff [OrderTop α] : IsPredLimit a ↔ a ≠ ⊤ ∧ IsPredPrelimit a := by
   rw [IsPredLimit, isMax_iff_eq_top]
-
-theorem IsPredPrelimit.eq_top_or_isPredLimit [OrderTop α] (h : IsPredPrelimit a) :
-    a = ⊤ ∨ IsPredLimit a := by
-  simpa using h.isMax_or_isPredLimit
 
 theorem IsPredLimit.lt_top [OrderTop α] (h : IsPredLimit a) : a < ⊤ :=
   h.ne_top.lt_top

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -80,6 +80,9 @@ theorem IsSuccPrelimit.isSuccLimit_of_not_isMin (h : IsSuccPrelimit a) (ha : ¬ 
     IsSuccLimit a :=
   ⟨ha, h⟩
 
+theorem IsSuccPrelimit.isMin_or_isSuccLimit (h : IsSuccPrelimit a) : IsMin a ∨ IsSuccLimit a :=
+  or_iff_not_imp_left.2 h.isSuccLimit_of_not_isMin
+
 theorem IsSuccPrelimit.isSuccLimit [NoMinOrder α] (h : IsSuccPrelimit a) : IsSuccLimit a :=
   h.isSuccLimit_of_not_isMin (not_isMin a)
 
@@ -192,6 +195,10 @@ variable [PartialOrder α]
 
 theorem isSuccLimit_iff [OrderBot α] : IsSuccLimit a ↔ a ≠ ⊥ ∧ IsSuccPrelimit a := by
   rw [IsSuccLimit, isMin_iff_eq_bot]
+
+theorem IsSuccPrelimit.eq_bot_or_isSuccLimit [OrderBot α] (h : IsSuccPrelimit a) :
+    a = ⊥ ∨ IsSuccLimit a := by
+  simpa using h.isMin_or_isSuccLimit
 
 theorem IsSuccLimit.bot_lt [OrderBot α] (h : IsSuccLimit a) : ⊥ < a :=
   h.ne_bot.bot_lt
@@ -410,6 +417,9 @@ theorem IsPredPrelimit.isPredLimit_of_not_isMax (h : IsPredPrelimit a) (ha : ¬ 
     IsPredLimit a :=
   ⟨ha, h⟩
 
+theorem IsPredPrelimit.isMax_or_isPredLimit (h : IsPredPrelimit a) : IsMax a ∨ IsPredLimit a :=
+  or_iff_not_imp_left.2 h.isPredLimit_of_not_isMax
+
 theorem IsPredPrelimit.isPredLimit [NoMaxOrder α] (h : IsPredPrelimit a) : IsPredLimit a :=
   h.isPredLimit_of_not_isMax (not_isMax a)
 
@@ -512,6 +522,10 @@ variable [PartialOrder α]
 
 theorem isPredLimit_iff [OrderTop α] : IsPredLimit a ↔ a ≠ ⊤ ∧ IsPredPrelimit a := by
   rw [IsPredLimit, isMax_iff_eq_top]
+
+theorem IsPredPrelimit.eq_top_or_isPredLimit [OrderTop α] (h : IsPredPrelimit a) :
+    a = ⊤ ∨ IsPredLimit a := by
+  simpa using h.isMax_or_isPredLimit
 
 theorem IsPredLimit.lt_top [OrderTop α] (h : IsPredLimit a) : a < ⊤ :=
   h.ne_top.lt_top

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -667,7 +667,7 @@ theorem aleph0_le_cof {o} : ℵ₀ ≤ cof o ↔ IsLimit o := by
 theorem cof_preOmega {o : Ordinal} (ho : IsSuccPrelimit o) : (preOmega o).cof = o.cof := by
   obtain rfl | h := ho.eq_bot_or_isSuccLimit
   · simp
-  · exact isNormal_preOmega.cof_eq ho
+  · exact isNormal_preOmega.cof_eq h
 
 @[simp]
 theorem cof_omega {o : Ordinal} (ho : o.IsLimit) : (ω_ o).cof = o.cof :=

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -664,8 +664,10 @@ theorem aleph0_le_cof {o} : ℵ₀ ≤ cof o ↔ IsLimit o := by
       exact not_succ_isLimit _ l
 
 @[simp]
-theorem cof_preOmega {o : Ordinal} (ho : o.IsLimit) : (preOmega o).cof = o.cof :=
-  isNormal_preOmega.cof_eq ho
+theorem cof_preOmega {o : Ordinal} (ho : IsSuccPrelimit o) : (preOmega o).cof = o.cof := by
+  obtain rfl | h := ho.eq_bot_or_isSuccLimit
+  · simp
+  · exact isNormal_preOmega.cof_eq ho
 
 @[simp]
 theorem cof_omega {o : Ordinal} (ho : o.IsLimit) : (ω_ o).cof = o.cof :=

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -665,9 +665,9 @@ theorem aleph0_le_cof {o} : ℵ₀ ≤ cof o ↔ IsLimit o := by
 
 @[simp]
 theorem cof_preOmega {o : Ordinal} (ho : IsSuccPrelimit o) : (preOmega o).cof = o.cof := by
-  obtain rfl | h := ho.eq_bot_or_isSuccLimit
-  · simp
-  · exact isNormal_preOmega.cof_eq h
+  by_cases h : IsMin o
+  · simp [h.eq_bot]
+  · exact isNormal_preOmega.cof_eq ⟨h, ho⟩
 
 @[simp]
 theorem cof_omega {o : Ordinal} (ho : o.IsLimit) : (ω_ o).cof = o.cof :=


### PR DESCRIPTION
This lemma is also true for `o = 0`, so we can take a `IsSuccPrelimit` argument instead of an `IsLimit` argument.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
