### PR TITLE
[Merged by Bors] - chore(RingTheory/Localization): prove isUnit_den_iff.mp by isInteger_of_isUnit_den

### DIFF
--- a/Mathlib/RingTheory/Localization/NumDen.lean
+++ b/Mathlib/RingTheory/Localization/NumDen.lean
@@ -105,16 +105,7 @@ theorem isInteger_of_isUnit_den {x : K} (h : IsUnit (den A x : A)) : IsInteger A
   rw [← mul_assoc, mul_inv_cancel₀ d_ne_zero, one_mul, mk'_spec']
 
 theorem isUnit_den_iff (x : K) : IsUnit (den A x : A) ↔ IsLocalization.IsInteger A x where
-  mp h := by
-    obtain ⟨den, hd⟩ := IsUnit.exists_right_inv h
-    use (num A x) * den
-    conv => rhs; rw [← mk'_num_den' A x]
-    rw [map_mul, div_eq_mul_inv]
-    congr 1
-    apply eq_inv_of_mul_eq_one_right
-    rw [← map_mul]
-    norm_cast
-    simp only [hd, OneMemClass.coe_one, map_one]
+  mp := isInteger_of_isUnit_den
   mpr h := by
     have ⟨v, h⟩ := h
     apply IsRelPrime.isUnit_of_dvd (num_den_reduced A x).symm


### PR DESCRIPTION
Replaces the 9-line proof of `isUnit_den_iff.mp` with a direct application of the existing lemma `sInteger_of_isUnit_den` (which is in fact the preceding item in the file).

For reference, `isUnit_den_iff` was first added in #14643.

This simplification was found by [`tryAtEachStep`](https://github.com/dwrensha/tryAtEachStep).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
