### PR TITLE
[Merged by Bors] - feat(Counterexamples): irrational a, b with rational a^b

### DIFF
--- a/Counterexamples.lean
+++ b/Counterexamples.lean
@@ -7,6 +7,7 @@ import Counterexamples.DiscreteTopologyNonDiscreteUniformity
 import Counterexamples.GameMultiplication
 import Counterexamples.Girard
 import Counterexamples.HomogeneousPrimeNotPrime
+import Counterexamples.IrrationalPowerOfIrrational
 import Counterexamples.LinearOrderWithPosMulPosEqZero
 import Counterexamples.MapFloor
 import Counterexamples.MonicNonRegular

--- a/Counterexamples/IrrationalPowerOfIrrational.lean
+++ b/Counterexamples/IrrationalPowerOfIrrational.lean
@@ -16,7 +16,10 @@ Consider `c = √2^√2`. If `c` is rational, we are done.
 If `c` is irrational, then `c^√2 = 2` is rational, so we are done.
 -/
 
+
 open Classical Real
+
+namespace Counterexample
 
 /--
 There exist irrational `a`, `b` with rational `a^b`.
@@ -32,3 +35,5 @@ theorem not_irrational_rpow : ¬ ∀ a b : ℝ, Irrational a → Irrational b �
       at ht; simp at ht
   · have ht := h √2 √2 irrational_sqrt_two irrational_sqrt_two (by norm_num)
     exact hc ht
+
+end Counterexample

--- a/Counterexamples/IrrationalPowerOfIrrational.lean
+++ b/Counterexamples/IrrationalPowerOfIrrational.lean
@@ -23,7 +23,7 @@ namespace Counterexample
 
 /--
 There exist irrational `a`, `b` with rational `a^b`.
-Note that the positivity assumption on `a` is required because of the definition of `rpow` for
+Note that the positivity assumption on `a` is imposed because of the definition of `rpow` for
 negative bases. See `Real.rpow_def_of_neg` for more details.
 -/
 theorem not_irrational_rpow : ¬ ∀ a b : ℝ, Irrational a → Irrational b → 0 < a → Irrational (a ^ b)

--- a/Counterexamples/IrrationalPowerOfIrrational.lean
+++ b/Counterexamples/IrrationalPowerOfIrrational.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2024 Seewoo Lee. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Seewoo Lee
+-/
+import Mathlib.Data.Real.Irrational
+import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
+
+/-
+# Irrational power of irrational numbers are not necessarily irrational.
+
+Prove that there exist irrational numbers `a`, `b` such that `a^b` is rational.
+
+We use the following famous argument (based on the law of excluded middle and irrationality of √2).
+Consider `c = √2^√2`. If `c` is rational, we are done.
+If `c` is irrational, then `c^√2 = 2` is rational, so we are done.
+-/
+
+open Classical Real
+
+/--
+There exist irrational `a`, `b` with rational `a^b`.
+Note that the positivity assumption on `a` is required because of the definition of `rpow` for
+negative bases. See `Real.rpow_def_of_neg` for more details.
+-/
+theorem not_irrational_rpow : ¬ ∀ a b : ℝ, Irrational a → Irrational b → 0 < a → Irrational (a ^ b)
+    := by
+  intro h
+  by_cases hc : Irrational (√2 ^ √2)
+  · have ht := h (√2 ^ √2) √2 hc irrational_sqrt_two (NNReal.rpow_pos (by norm_num))
+    rw [← rpow_mul (by norm_num), mul_self_sqrt (by norm_num), rpow_two, sq_sqrt (by norm_num)]
+      at ht; simp at ht
+  · have ht := h √2 √2 irrational_sqrt_two irrational_sqrt_two (by norm_num)
+    exact hc ht

--- a/Counterexamples/IrrationalPowerOfIrrational.lean
+++ b/Counterexamples/IrrationalPowerOfIrrational.lean
@@ -26,8 +26,8 @@ There exist irrational `a`, `b` with rational `a^b`.
 Note that the positivity assumption on `a` is imposed because of the definition of `rpow` for
 negative bases. See `Real.rpow_def_of_neg` for more details.
 -/
-theorem not_irrational_rpow : ¬ ∀ a b : ℝ, Irrational a → Irrational b → 0 < a → Irrational (a ^ b)
-    := by
+theorem not_irrational_rpow :
+   ¬ ∀ a b : ℝ, Irrational a → Irrational b → 0 < a → Irrational (a ^ b) := by
   push_neg
   by_cases hc : Irrational (√2 ^ √2)
   · use (√2 ^ √2), √2, hc, irrational_sqrt_two, by positivity

--- a/Counterexamples/IrrationalPowerOfIrrational.lean
+++ b/Counterexamples/IrrationalPowerOfIrrational.lean
@@ -28,12 +28,10 @@ negative bases. See `Real.rpow_def_of_neg` for more details.
 -/
 theorem not_irrational_rpow : ¬ ∀ a b : ℝ, Irrational a → Irrational b → 0 < a → Irrational (a ^ b)
     := by
-  intro h
+  push_neg
   by_cases hc : Irrational (√2 ^ √2)
-  · have ht := h (√2 ^ √2) √2 hc irrational_sqrt_two (NNReal.rpow_pos (by norm_num))
-    rw [← rpow_mul (by norm_num), mul_self_sqrt (by norm_num), rpow_two, sq_sqrt (by norm_num)]
-      at ht; simp at ht
-  · have ht := h √2 √2 irrational_sqrt_two irrational_sqrt_two (by norm_num)
-    exact hc ht
+  · use (√2 ^ √2), √2, hc, irrational_sqrt_two, by positivity
+    rw [← rpow_mul, mul_self_sqrt, rpow_two, sq_sqrt] <;> norm_num
+  · use √2, √2, irrational_sqrt_two, irrational_sqrt_two, by positivity, hc
 
 end Counterexample


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Proves existences of $a, b \not \in \mathbb{Q}$ with $a^b \in \mathbb{Q}$. See the [zulip thread](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Existence.20of.20irrational.20.5E.20irrational.20becomes.20rational/near/488140274) about a discussion on the topic.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
