### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Enriched): Add eHomCongr and related lemmas

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1702,6 +1702,7 @@ import Mathlib.CategoryTheory.Endofunctor.Algebra
 import Mathlib.CategoryTheory.Endomorphism
 import Mathlib.CategoryTheory.Enriched.Basic
 import Mathlib.CategoryTheory.Enriched.FunctorCategory
+import Mathlib.CategoryTheory.Enriched.HomCongr
 import Mathlib.CategoryTheory.Enriched.Opposite
 import Mathlib.CategoryTheory.Enriched.Ordinary
 import Mathlib.CategoryTheory.EpiMono

--- a/Mathlib/CategoryTheory/Enriched/HomCongr.lean
+++ b/Mathlib/CategoryTheory/Enriched/HomCongr.lean
@@ -8,8 +8,14 @@ import Mathlib.CategoryTheory.Enriched.Ordinary
 /-!
 # Congruence of enriched homs
 
-In a `V`-enriched ordinary category `C`, isomorphisms in `C` induce
-isomorphisms between hom-objects in `V`.
+Recall that when `C` is both a category and a `V`-enriched category, we say it
+is an `EnrichedOrdinaryCategory` if it comes equipped with a sufficiently
+compatible equivalence between morphisms `X ⟶ Y` in `C` and morphisms
+`𝟙_ V ⟶ (X ⟶[V] Y)` in `V`.
+
+In such a `V`-enriched ordinary category `C`, isomorphisms in `C` induce
+isomorphisms between hom-objects in `V`. We define this isomorphism in
+`CategoryTheory.Iso.eHomCongr` and prove that it respects composition in `C`.
 
 The treatment here parallels that for unenriched categories in
 `Mathlib/CategoryTheory/HomCongr.lean` and that for sorts in
@@ -28,8 +34,8 @@ open Category MonoidalCategory
 variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
   {C : Type u} [Category.{v} C] [EnrichedOrdinaryCategory V C]
 
-/-- If we have isomorphisms `α : X ≅ X₁` and `β : Y ≅ Y₁` in `C`, then we can
-construct an isomorphism between `V` objects `X ⟶[V] Y` and `X₁ ⟶[V] Y₁`. -/
+/-- Given isomorphisms `α : X ≅ X₁` and `β : Y ≅ Y₁` in `C`, we can construct
+an isomorphism between `V` objects `X ⟶[V] Y` and `X₁ ⟶[V] Y₁`. -/
 @[simps]
 def eHomCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) :
     (X ⟶[V] Y) ≅ (X₁ ⟶[V] Y₁) where

--- a/Mathlib/CategoryTheory/Enriched/HomCongr.lean
+++ b/Mathlib/CategoryTheory/Enriched/HomCongr.lean
@@ -44,7 +44,7 @@ def eHomCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) :
     rw [← eHomWhiskerRight_comp_assoc, inv_hom_id, eHomWhiskerRight_id, id_comp]
     rw [← eHomWhiskerLeft_comp, inv_hom_id, eHomWhiskerLeft_id]
 
-lemma eHomCongr_refl {X Y : C} :
+lemma eHomCongr_refl (X Y : C) :
     eHomCongr V (Iso.refl X) (Iso.refl Y) = Iso.refl _ := by aesop
 
 lemma eHomCongr_trans {X₁ Y₁ X₂ Y₂ X₃ Y₃ : C} (α₁ : X₁ ≅ X₂) (β₁ : Y₁ ≅ Y₂)

--- a/Mathlib/CategoryTheory/Enriched/HomCongr.lean
+++ b/Mathlib/CategoryTheory/Enriched/HomCongr.lean
@@ -57,11 +57,12 @@ lemma eHomCongr_symm {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) :
     (eHomCongr V α β).symm = eHomCongr V α.symm β.symm := rfl
 
 /-- `eHomCongr` respects composition of morphisms. Recall that for any
-pair of composable arrows `f : X ⟶ Y` and `g : Y ⟶ Z` in `C`, the composite
+composable pair of arrows `f : X ⟶ Y` and `g : Y ⟶ Z` in `C`, the composite
 `f ≫ g` in `C` defines a morphism `𝟙_ V ⟶ (X ⟶[V] Z)` in `V`. Composing with
 the isomorphism `eHomCongr V α γ` yields a morphism in `V` that can be factored
 through the enriched composition map as shown:
 `𝟙_ V ⟶ 𝟙_ V ⊗ 𝟙_ V ⟶ (X₁ ⟶[V] Y₁) ⊗ (Y₁ ⟶[V] Z₁) ⟶ (X₁ ⟶[V] Z₁)`. -/
+@[reassoc]
 lemma eHomCongr_comp {X Y Z X₁ Y₁ Z₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (γ : Z ≅ Z₁)
     (f : X ⟶ Y) (g : Y ⟶ Z) :
     eHomEquiv V (f ≫ g) ≫ (eHomCongr V α γ).hom =
@@ -78,6 +79,7 @@ lemma eHomCongr_comp {X Y Z X₁ Y₁ Z₁ : C} (α : X ≅ X₁) (β : Y ≅ Y�
     ← eHomEquiv_comp_assoc]
 
 /-- The inverse map defined by `eHomCongr` respects composition of morphisms. -/
+@[reassoc]
 lemma eHomCongr_inv_comp {X Y Z X₁ Y₁ Z₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (γ : Z ≅ Z₁)
     (f : X₁ ⟶ Y₁) (g : Y₁ ⟶ Z₁) :
     eHomEquiv V (f ≫ g) ≫ (eHomCongr V α γ).inv =

--- a/Mathlib/CategoryTheory/Enriched/HomCongr.lean
+++ b/Mathlib/CategoryTheory/Enriched/HomCongr.lean
@@ -45,7 +45,7 @@ def eHomCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) :
     simp [← eHomWhiskerLeft_comp]
 
 lemma eHomCongr_refl (X Y : C) :
-    eHomCongr V (Iso.refl X) (Iso.refl Y) = Iso.refl _ := by aesop
+    eHomCongr V (Iso.refl X) (Iso.refl Y) = Iso.refl (X ⟶[V] Y) := by aesop
 
 lemma eHomCongr_trans {X₁ Y₁ X₂ Y₂ X₃ Y₃ : C} (α₁ : X₁ ≅ X₂) (β₁ : Y₁ ≅ Y₂)
     (α₂ : X₂ ≅ X₃) (β₂ : Y₂ ≅ Y₃) :

--- a/Mathlib/CategoryTheory/Enriched/HomCongr.lean
+++ b/Mathlib/CategoryTheory/Enriched/HomCongr.lean
@@ -44,18 +44,15 @@ def eHomCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) :
     rw [← eHomWhiskerRight_comp_assoc, inv_hom_id, eHomWhiskerRight_id, id_comp]
     rw [← eHomWhiskerLeft_comp, inv_hom_id, eHomWhiskerLeft_id]
 
-@[simp]
 lemma eHomCongr_refl {X Y : C} :
     eHomCongr V (Iso.refl X) (Iso.refl Y) = Iso.refl _ := by aesop
 
-@[simp]
 lemma eHomCongr_trans {X₁ Y₁ X₂ Y₂ X₃ Y₃ : C} (α₁ : X₁ ≅ X₂) (β₁ : Y₁ ≅ Y₂)
     (α₂ : X₂ ≅ X₃) (β₂ : Y₂ ≅ Y₃) :
     eHomCongr V (α₁ ≪≫ α₂) (β₁ ≪≫ β₂) =
       eHomCongr V α₁ β₁ ≪≫ eHomCongr V α₂ β₂ := by
   ext; simp [eHom_whisker_exchange_assoc]
 
-@[simp]
 lemma eHomCongr_symm {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) :
     (eHomCongr V α β).symm = eHomCongr V α.symm β.symm := rfl
 

--- a/Mathlib/CategoryTheory/Enriched/HomCongr.lean
+++ b/Mathlib/CategoryTheory/Enriched/HomCongr.lean
@@ -36,13 +36,13 @@ def eHomCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) :
   hom := eHomWhiskerRight V α.inv Y ≫ eHomWhiskerLeft V X₁ β.hom
   inv := eHomWhiskerRight V α.hom Y₁ ≫ eHomWhiskerLeft V X β.inv
   hom_inv_id := by
-    rw [← eHom_whisker_exchange, assoc]
-    rw [← eHomWhiskerRight_comp_assoc, hom_inv_id, eHomWhiskerRight_id, id_comp]
-    rw [← eHomWhiskerLeft_comp, hom_inv_id, eHomWhiskerLeft_id]
+    rw [← eHom_whisker_exchange]
+    slice_lhs 2 3 => rw [← eHomWhiskerRight_comp]
+    simp [← eHomWhiskerLeft_comp]
   inv_hom_id := by
-    rw [← eHom_whisker_exchange, assoc]
-    rw [← eHomWhiskerRight_comp_assoc, inv_hom_id, eHomWhiskerRight_id, id_comp]
-    rw [← eHomWhiskerLeft_comp, inv_hom_id, eHomWhiskerLeft_id]
+    rw [← eHom_whisker_exchange]
+    slice_lhs 2 3 => rw [← eHomWhiskerRight_comp]
+    simp [← eHomWhiskerLeft_comp]
 
 lemma eHomCongr_refl (X Y : C) :
     eHomCongr V (Iso.refl X) (Iso.refl Y) = Iso.refl _ := by aesop
@@ -68,20 +68,18 @@ lemma eHomCongr_comp {X Y Z X₁ Y₁ Z₁ : C} (α : X ≅ X₁) (β : Y ≅ Y�
     eHomEquiv V (f ≫ g) ≫ (eHomCongr V α γ).hom =
       (λ_ _).inv ≫ (eHomEquiv V f ≫ (eHomCongr V α β).hom) ▷ _ ≫
         _ ◁ (eHomEquiv V g ≫ (eHomCongr V β γ).hom) ≫ eComp V X₁ Y₁ Z₁ := by
-  dsimp only [eHomCongr]
-  simp only [assoc, MonoidalCategory.whiskerRight_id,
+  simp only [eHomCongr, MonoidalCategory.whiskerRight_id, assoc,
     MonoidalCategory.whiskerLeft_comp]
   rw [rightUnitor_inv_naturality_assoc, rightUnitor_inv_naturality_assoc,
-    rightUnitor_inv_naturality_assoc, hom_inv_id_assoc]
-  rw [← whisker_exchange_assoc, ← whisker_exchange_assoc, ← eComp_eHomWhiskerLeft]
-  rw [eHom_whisker_cancel_assoc]
-  rw [← eComp_eHomWhiskerRight_assoc, ← tensorHom_def_assoc,
+    rightUnitor_inv_naturality_assoc, hom_inv_id_assoc, ← whisker_exchange_assoc,
+    ← whisker_exchange_assoc, ← eComp_eHomWhiskerLeft, eHom_whisker_cancel_assoc,
+    ← eComp_eHomWhiskerRight_assoc, ← tensorHom_def_assoc,
     ← eHomEquiv_comp_assoc]
 
 /-- The inverse map defined by `eHomCongr` respects composition of morphisms. -/
 @[reassoc]
-lemma eHomCongr_inv_comp {X Y Z X₁ Y₁ Z₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (γ : Z ≅ Z₁)
-    (f : X₁ ⟶ Y₁) (g : Y₁ ⟶ Z₁) :
+lemma eHomCongr_inv_comp {X Y Z X₁ Y₁ Z₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁)
+    (γ : Z ≅ Z₁) (f : X₁ ⟶ Y₁) (g : Y₁ ⟶ Z₁) :
     eHomEquiv V (f ≫ g) ≫ (eHomCongr V α γ).inv =
       (λ_ _).inv ≫ (eHomEquiv V f ≫ (eHomCongr V α β).inv) ▷ _ ≫
         _ ◁ (eHomEquiv V g ≫ (eHomCongr V β γ).inv) ≫ eComp V X Y Z :=

--- a/Mathlib/CategoryTheory/Enriched/HomCongr.lean
+++ b/Mathlib/CategoryTheory/Enriched/HomCongr.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2024 Nick Ward. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nick Ward
+-/
+import Mathlib.CategoryTheory.Enriched.Ordinary
+
+/-!
+# Congruence of enriched homs
+
+In a `V`-enriched ordinary category `C`, isomorphisms in `C` induce
+isomorphisms between hom-objects in `V`.
+
+The treatment here parallels that for unenriched categories in
+`Mathlib/CategoryTheory/HomCongr.lean` and that for sorts in
+`Mathlib/Logic/Equiv/Defs.lean` (cf. `Equiv.arrowCongr`). Note, however, that
+they construct equivalences between `Type`s and `Sort`s, respectively, while
+in this file we construct isomorphisms between objects in `V`.
+-/
+
+universe v' v u u'
+
+namespace CategoryTheory
+namespace Iso
+
+open Category MonoidalCategory
+
+variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
+  {C : Type u} [Category.{v} C] [EnrichedOrdinaryCategory V C]
+
+/-- If we have isomorphisms `α : X ≅ X₁` and `β : Y ≅ Y₁` in `C`, then we can
+construct an isomorphism between `V` objects `X ⟶[V] Y` and `X₁ ⟶[V] Y₁`. -/
+@[simp]
+def eHomCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) :
+    (X ⟶[V] Y) ≅ (X₁ ⟶[V] Y₁) where
+  hom := eHomWhiskerRight V α.inv Y ≫ eHomWhiskerLeft V X₁ β.hom
+  inv := eHomWhiskerRight V α.hom Y₁ ≫ eHomWhiskerLeft V X β.inv
+  hom_inv_id := by
+    rw [← eHom_whisker_exchange, assoc]
+    rw [← eHomWhiskerRight_comp_assoc, hom_inv_id, eHomWhiskerRight_id, id_comp]
+    rw [← eHomWhiskerLeft_comp, hom_inv_id, eHomWhiskerLeft_id]
+  inv_hom_id := by
+    rw [← eHom_whisker_exchange, assoc]
+    rw [← eHomWhiskerRight_comp_assoc, inv_hom_id, eHomWhiskerRight_id, id_comp]
+    rw [← eHomWhiskerLeft_comp, inv_hom_id, eHomWhiskerLeft_id]
+
+@[simp]
+lemma eHomCongr_refl {X Y : C} :
+    eHomCongr V (Iso.refl X) (Iso.refl Y) = Iso.refl _ := by aesop
+
+@[simp]
+lemma eHomCongr_trans {X₁ Y₁ X₂ Y₂ X₃ Y₃ : C} (α₁ : X₁ ≅ X₂) (β₁ : Y₁ ≅ Y₂)
+    (α₂ : X₂ ≅ X₃) (β₂ : Y₂ ≅ Y₃) :
+    eHomCongr V (α₁ ≪≫ α₂) (β₁ ≪≫ β₂) =
+      eHomCongr V α₁ β₁ ≪≫ eHomCongr V α₂ β₂ := by
+  ext; simp [eHom_whisker_exchange_assoc]
+
+@[simp]
+lemma eHomCongr_symm {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) :
+    (eHomCongr V α β).symm = eHomCongr V α.symm β.symm := rfl
+
+/-- `eHomCongr` respects composition of morphisms. Recall that for any
+pair of composable arrows `f : X ⟶ Y` and `g : Y ⟶ Z` in `C`, the composite
+`f ≫ g` in `C` defines a morphism `𝟙_ V ⟶ (X ⟶[V] Z)` in `V`. Composing with
+the isomorphism `eHomCongr V α γ` yields a morphism in `V` that can be factored
+through the enriched composition map as shown:
+`𝟙_ V ⟶ 𝟙_ V ⊗ 𝟙_ V ⟶ (X₁ ⟶[V] Y₁) ⊗ (Y₁ ⟶[V] Z₁) ⟶ (X₁ ⟶[V] Z₁)`. -/
+lemma eHomCongr_comp {X Y Z X₁ Y₁ Z₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (γ : Z ≅ Z₁)
+    (f : X ⟶ Y) (g : Y ⟶ Z) :
+    eHomEquiv V (f ≫ g) ≫ (eHomCongr V α γ).hom =
+      (λ_ _).inv ≫ (eHomEquiv V f ≫ (eHomCongr V α β).hom) ▷ _ ≫
+        _ ◁ (eHomEquiv V g ≫ (eHomCongr V β γ).hom) ≫ eComp V X₁ Y₁ Z₁ := by
+  dsimp only [eHomCongr]
+  simp only [assoc, MonoidalCategory.whiskerRight_id,
+    MonoidalCategory.whiskerLeft_comp]
+  rw [rightUnitor_inv_naturality_assoc, rightUnitor_inv_naturality_assoc,
+    rightUnitor_inv_naturality_assoc, hom_inv_id_assoc]
+  rw [← whisker_exchange_assoc, ← whisker_exchange_assoc, ← eComp_eHomWhiskerLeft]
+  rw [eHom_whisker_cancel_assoc]
+  rw [← eComp_eHomWhiskerRight_assoc, ← tensorHom_def_assoc,
+    ← eHomEquiv_comp_assoc]
+
+/-- The inverse map defined by `eHomCongr` respects composition of morphisms. -/
+lemma eHomCongr_inv_comp {X Y Z X₁ Y₁ Z₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (γ : Z ≅ Z₁)
+    (f : X₁ ⟶ Y₁) (g : Y₁ ⟶ Z₁) :
+    eHomEquiv V (f ≫ g) ≫ (eHomCongr V α γ).inv =
+      (λ_ _).inv ≫ (eHomEquiv V f ≫ (eHomCongr V α β).inv) ▷ _ ≫
+        _ ◁ (eHomEquiv V g ≫ (eHomCongr V β γ).inv) ≫ eComp V X Y Z :=
+  eHomCongr_comp V α.symm β.symm γ.symm f g
+
+end Iso
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Enriched/HomCongr.lean
+++ b/Mathlib/CategoryTheory/Enriched/HomCongr.lean
@@ -30,7 +30,7 @@ variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
 
 /-- If we have isomorphisms `α : X ≅ X₁` and `β : Y ≅ Y₁` in `C`, then we can
 construct an isomorphism between `V` objects `X ⟶[V] Y` and `X₁ ⟶[V] Y₁`. -/
-@[simp]
+@[simps]
 def eHomCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) :
     (X ⟶[V] Y) ≅ (X₁ ⟶[V] Y₁) where
   hom := eHomWhiskerRight V α.inv Y ≫ eHomWhiskerLeft V X₁ β.hom

--- a/Mathlib/CategoryTheory/Enriched/Ordinary.lean
+++ b/Mathlib/CategoryTheory/Enriched/Ordinary.lean
@@ -81,6 +81,15 @@ lemma eHomWhiskerRight_comp {X X' X'' : C} (f : X ⟶ X') (f' : X' ⟶ X'') (Y :
     ← associator_inv_naturality_left_assoc, Iso.inv_hom_id_assoc,
     ← whisker_exchange_assoc, id_whiskerLeft_assoc, Iso.inv_hom_id_assoc]
 
+/-- Whiskering commutes with the enriched composition. -/
+@[reassoc]
+lemma eComp_eHomWhiskerRight {X X' : C} (f : X ⟶ X') (Y Z : C) :
+    eComp V X' Y Z ≫ eHomWhiskerRight V f Z =
+      eHomWhiskerRight V f Y ▷ _ ≫ eComp V X Y Z := by
+  unfold eHomWhiskerRight
+  rw [leftUnitor_inv_naturality_assoc, whisker_exchange_assoc]
+  simp [e_assoc']
+
 /-- The morphism `(X ⟶[V] Y) ⟶ (X ⟶[V] Y')` induced by a morphism `Y ⟶ Y'`. -/
 def eHomWhiskerLeft (X : C) {Y Y' : C} (g : Y ⟶ Y') :
     (X ⟶[V] Y) ⟶ (X ⟶[V] Y') :=
@@ -103,6 +112,35 @@ lemma eHomWhiskerLeft_comp (X : C) {Y Y' Y'' : C} (g : Y ⟶ Y') (g' : Y' ⟶ Y'
     Iso.hom_inv_id_assoc, Iso.inv_hom_id_assoc,
     associator_inv_naturality_right_assoc, Iso.hom_inv_id_assoc,
     whisker_exchange_assoc, MonoidalCategory.whiskerRight_id_assoc, Iso.inv_hom_id_assoc]
+
+/-- Whiskering commutes with the enriched composition. -/
+@[reassoc]
+lemma eComp_eHomWhiskerLeft (X Y : C) {Z Z' : C} (g : Z ⟶ Z') :
+    eComp V X Y Z ≫ eHomWhiskerLeft V X g =
+      _ ◁ eHomWhiskerLeft V Y g ≫ eComp V X Y Z' := by
+  unfold eHomWhiskerLeft
+  rw [rightUnitor_inv_naturality_assoc, ← whisker_exchange_assoc]
+  simp [e_assoc']
+
+/-- Given an isomorphism `α : Y ≅ Y₁` in C, the enriched composition map
+`eComp V X Y Z : (X ⟶[V] Y) ⊗ (Y ⟶[V] Z) ⟶ (X ⟶[V] Z)` factors through the `V`
+object `(X ⟶[V] Y₁) ⊗ (Y₁ ⟶[V] Z)` via the map defined by whiskering in the
+middle with `α.hom` and `α.inv`. -/
+@[reassoc]
+lemma eHom_whisker_cancel {X Y Y₁ Z : C} (α : Y  ≅ Y₁) :
+    eHomWhiskerLeft V X α.hom ▷ _ ≫ _ ◁ eHomWhiskerRight V α.inv Z ≫
+      eComp V X Y₁ Z = eComp V X Y Z := by
+  unfold eHomWhiskerLeft eHomWhiskerRight
+  simp only [MonoidalCategory.whiskerLeft_comp_assoc, whisker_assoc_symm,
+    triangle_assoc_comp_left_inv_assoc, e_assoc', assoc]
+  simp only [← comp_whiskerRight_assoc]
+  change (eHomWhiskerLeft V X α.hom ≫ eHomWhiskerLeft V X α.inv) ▷ _ ≫ _ = _
+  simp [← eHomWhiskerLeft_comp]
+
+@[reassoc]
+lemma eHom_whisker_cancel_inv {X Y Y₁ Z : C} (α : Y  ≅ Y₁) :
+    eHomWhiskerLeft V X α.inv ▷ _ ≫ _ ◁ eHomWhiskerRight V α.hom Z ≫
+      eComp V X Y Z = eComp V X Y₁ Z := eHom_whisker_cancel V α.symm
 
 @[reassoc]
 lemma eHom_whisker_exchange {X X' Y Y' : C} (f : X ⟶ X') (g : Y ⟶ Y') :

--- a/Mathlib/CategoryTheory/Enriched/Ordinary.lean
+++ b/Mathlib/CategoryTheory/Enriched/Ordinary.lean
@@ -86,7 +86,7 @@ lemma eHomWhiskerRight_comp {X X' X'' : C} (f : X ⟶ X') (f' : X' ⟶ X'') (Y :
 lemma eComp_eHomWhiskerRight {X X' : C} (f : X ⟶ X') (Y Z : C) :
     eComp V X' Y Z ≫ eHomWhiskerRight V f Z =
       eHomWhiskerRight V f Y ▷ _ ≫ eComp V X Y Z := by
-  unfold eHomWhiskerRight
+  dsimp [eHomWhiskerRight]
   rw [leftUnitor_inv_naturality_assoc, whisker_exchange_assoc]
   simp [e_assoc']
 
@@ -118,7 +118,7 @@ lemma eHomWhiskerLeft_comp (X : C) {Y Y' Y'' : C} (g : Y ⟶ Y') (g' : Y' ⟶ Y'
 lemma eComp_eHomWhiskerLeft (X Y : C) {Z Z' : C} (g : Z ⟶ Z') :
     eComp V X Y Z ≫ eHomWhiskerLeft V X g =
       _ ◁ eHomWhiskerLeft V Y g ≫ eComp V X Y Z' := by
-  unfold eHomWhiskerLeft
+  dsimp [eHomWhiskerLeft]
   rw [rightUnitor_inv_naturality_assoc, ← whisker_exchange_assoc]
   simp [e_assoc']
 
@@ -130,7 +130,7 @@ middle with `α.hom` and `α.inv`. -/
 lemma eHom_whisker_cancel {X Y Y₁ Z : C} (α : Y  ≅ Y₁) :
     eHomWhiskerLeft V X α.hom ▷ _ ≫ _ ◁ eHomWhiskerRight V α.inv Z ≫
       eComp V X Y₁ Z = eComp V X Y Z := by
-  unfold eHomWhiskerLeft eHomWhiskerRight
+  dsimp [eHomWhiskerLeft, eHomWhiskerRight]
   simp only [MonoidalCategory.whiskerLeft_comp_assoc, whisker_assoc_symm,
     triangle_assoc_comp_left_inv_assoc, e_assoc', assoc]
   simp only [← comp_whiskerRight_assoc]


### PR DESCRIPTION
Recall that when `C` is both a category and a `V`-enriched category, we say it is an `EnrichedOrdinaryCategory` if it comes equipped with an equivalence between morphisms `X ⟶ Y` in `C`  and morphisms `𝟙_ V ⟶ (X ⟶[V] Y)` in `V` that preserves identities and composition in `C`.

In such a `V`-enriched ordinary category `C`, isomorphisms in `C` induce isomorphisms between hom-objects in `V`. We define this isomorphism, `CategoryTheory.Iso.eHomCongr`, and prove that it behaves nicely with respect to composition in `C`.

The lemmas here parallel those for unenriched categories in [`Mathlib/CategoryTheory/HomCongr.lean`](https://github.com/leanprover-community/mathlib4/blob/a1c80a59b69da977f8519230ef96b3b95e31bc1d/Mathlib/CategoryTheory/HomCongr.lean) and those for sorts in [`Mathlib/Logic/Equiv/Defs.lean`](https://github.com/leanprover-community/mathlib4/blob/a1c80a59b69da977f8519230ef96b3b95e31bc1d/Mathlib/Logic/Equiv/Defs.lean#L428) (cf. `Equiv.arrowCongr`). Note, however, that they construct equivalences between `Type`s and `Sort`s, respectively, while in this PR we construct isomorphisms between objects in `V`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
