### PR TITLE
[Merged by Bors] - feat: drop an assumption in `mfderivWithin_const`

### DIFF
--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -700,14 +700,8 @@ protected theorem HasMFDerivWithinAt.mfderivWithin (h : HasMFDerivWithinAt I I' 
 
 theorem HasMFDerivWithinAt.mfderivWithin_eq_zero (h : HasMFDerivWithinAt I I' f s x 0) :
     mfderivWithin I I' f s x = 0 := by
-  simp only [mfderivWithin, h.mdifferentiableWithinAt, ↓reduceIte, writtenInExtChartAt, extChartAt,
-    PartialHomeomorph.extend, PartialEquiv.coe_trans, ModelWithCorners.toPartialEquiv_coe,
-    PartialHomeomorph.toFun_eq_coe, PartialEquiv.coe_trans_symm, PartialHomeomorph.coe_coe_symm,
-    ModelWithCorners.toPartialEquiv_coe_symm, Function.comp_apply]
-  simp only [HasMFDerivWithinAt, writtenInExtChartAt, extChartAt, PartialHomeomorph.extend,
-    PartialEquiv.coe_trans, ModelWithCorners.toPartialEquiv_coe, PartialHomeomorph.toFun_eq_coe,
-    PartialEquiv.coe_trans_symm, PartialHomeomorph.coe_coe_symm,
-    ModelWithCorners.toPartialEquiv_coe_symm, Function.comp_apply] at h
+  simp only [mfld_simps, mfderivWithin, h.mdifferentiableWithinAt, ↓reduceIte]
+  simp only [HasMFDerivWithinAt, mfld_simps] at h
   rw [fderivWithin, if_pos]
   exact h.2
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -693,10 +693,23 @@ protected theorem MDifferentiableAt.mfderiv (h : MDifferentiableAt I I' f x) :
 protected theorem HasMFDerivAt.mfderiv (h : HasMFDerivAt I I' f x f') : mfderiv I I' f x = f' :=
   (hasMFDerivAt_unique h h.mdifferentiableAt.hasMFDerivAt).symm
 
-theorem HasMFDerivWithinAt.mfderivWithin (h : HasMFDerivWithinAt I I' f s x f')
+protected theorem HasMFDerivWithinAt.mfderivWithin (h : HasMFDerivWithinAt I I' f s x f')
     (hxs : UniqueMDiffWithinAt I s x) : mfderivWithin I I' f s x = f' := by
   ext
   rw [hxs.eq h h.mdifferentiableWithinAt.hasMFDerivWithinAt]
+
+theorem HasMFDerivWithinAt.mfderivWithin_eq_zero (h : HasMFDerivWithinAt I I' f s x 0) :
+    mfderivWithin I I' f s x = 0 := by
+  simp only [mfderivWithin, h.mdifferentiableWithinAt, ↓reduceIte, writtenInExtChartAt, extChartAt,
+    PartialHomeomorph.extend, PartialEquiv.coe_trans, ModelWithCorners.toPartialEquiv_coe,
+    PartialHomeomorph.toFun_eq_coe, PartialEquiv.coe_trans_symm, PartialHomeomorph.coe_coe_symm,
+    ModelWithCorners.toPartialEquiv_coe_symm, Function.comp_apply]
+  simp only [HasMFDerivWithinAt, writtenInExtChartAt, extChartAt, PartialHomeomorph.extend,
+    PartialEquiv.coe_trans, ModelWithCorners.toPartialEquiv_coe, PartialHomeomorph.toFun_eq_coe,
+    PartialEquiv.coe_trans_symm, PartialHomeomorph.coe_coe_symm,
+    ModelWithCorners.toPartialEquiv_coe_symm, Function.comp_apply] at h
+  rw [fderivWithin, if_pos]
+  exact h.2
 
 theorem MDifferentiable.mfderivWithin (h : MDifferentiableAt I I' f x)
     (hxs : UniqueMDiffWithinAt I s x) : mfderivWithin I I' f s x = mfderiv I I' f x := by

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -198,9 +198,10 @@ theorem mfderiv_const :
     mfderiv I I' (fun _ : M => c) x = (0 : TangentSpace I x →L[𝕜] TangentSpace I' c) :=
   HasMFDerivAt.mfderiv (hasMFDerivAt_const c x)
 
-theorem mfderivWithin_const (hxs : UniqueMDiffWithinAt I s x) :
-    mfderivWithin I I' (fun _ : M => c) s x = (0 : TangentSpace I x →L[𝕜] TangentSpace I' c) :=
-  (hasMFDerivWithinAt_const _ _ _).mfderivWithin hxs
+theorem mfderivWithin_const :
+    mfderivWithin I I' (fun _ : M => c) s x = (0 : TangentSpace I x →L[𝕜] TangentSpace I' c) := by
+  apply HasMFDerivWithinAt.mfderivWithin_eq_zero
+  exact hasMFDerivWithinAt_const _ _ _
 
 end Const
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -199,9 +199,8 @@ theorem mfderiv_const :
   HasMFDerivAt.mfderiv (hasMFDerivAt_const c x)
 
 theorem mfderivWithin_const :
-    mfderivWithin I I' (fun _ : M => c) s x = (0 : TangentSpace I x →L[𝕜] TangentSpace I' c) := by
-  apply HasMFDerivWithinAt.mfderivWithin_eq_zero
-  exact hasMFDerivWithinAt_const _ _ _
+    mfderivWithin I I' (fun _ : M => c) s x = (0 : TangentSpace I x →L[𝕜] TangentSpace I' c) :=
+  (hasMFDerivWithinAt_const _ _ _).mfderivWithin_eq_zero
 
 end Const
 


### PR DESCRIPTION
Followup to #19694 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
