### PR TITLE
[Merged by Bors] - feat(Computability/DFA): implement `isRegular_iff`

### DIFF
--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -253,9 +253,9 @@ def Language.IsRegular {T : Type u} (L : Language T) : Prop :=
 
 /-- Lifts the state type `σ` inside `Language.IsRegular` to a different universe. -/
 private lemma Language.isRegular_iff.helper.{v'} {T : Type u} {L : Language T}
-    (h : ∃ σ : Type v, ∃ _ : Fintype σ, ∃ M : DFA T σ, M.accepts = L) :
+    (hL : ∃ σ : Type v, ∃ _ : Fintype σ, ∃ M : DFA T σ, M.accepts = L) :
     ∃ σ' : Type v', ∃ _ : Fintype σ', ∃ M : DFA T σ', M.accepts = L :=
-  have ⟨σ, _, M, hM⟩ := h
+  have ⟨σ, _, M, hM⟩ := hL
   have ⟨σ', ⟨f⟩⟩ := Small.equiv_small.{v', v} (α := σ)
   ⟨σ', Fintype.ofEquiv σ f, M.reindex f, hM ▸ DFA.accepts_reindex M f⟩
 

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fox Thomson, Chris Wong
 -/
 import Mathlib.Computability.Language
+import Mathlib.Data.Countable.Small
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.List.Indexes
 import Mathlib.Tactic.NormNum
@@ -250,6 +251,20 @@ end DFA
 def Language.IsRegular {T : Type u} (L : Language T) : Prop :=
   ∃ σ : Type, ∃ _ : Fintype σ, ∃ M : DFA T σ, M.accepts = L
 
-proof_wanted Language.isRegular_iff {T : Type u} {L : Language T} :
-    L.IsRegular ↔ ∃ σ : Type v, ∃ _ : Fintype σ, ∃ M : DFA T σ, M.accepts = L
--- probably needs `import Mathlib.Data.Countable.Small`
+/-- Lifts the state type `σ` inside `Language.IsRegular` to a different universe. -/
+private lemma Language.isRegular_iff.helper.{v'} {T : Type u} {L : Language T}
+    (h : ∃ σ : Type v, ∃ _ : Fintype σ, ∃ M : DFA T σ, M.accepts = L) :
+    ∃ σ' : Type v', ∃ _ : Fintype σ', ∃ M : DFA T σ', M.accepts = L :=
+  have ⟨σ, _, M, hM⟩ := h
+  have ⟨σ', ⟨f⟩⟩ := Small.equiv_small.{v', v} (α := σ)
+  ⟨σ', Fintype.ofEquiv σ f, M.reindex f, hM ▸ DFA.accepts_reindex M f⟩
+
+/--
+A language is regular if and only if is defined by a DFA with finite states.
+
+This is more general than using the definition of `Language.IsRegular` directly, as the state type
+`σ` is universe-polymorphic.
+-/
+theorem Language.isRegular_iff {T : Type u} {L : Language T} :
+    L.IsRegular ↔ ∃ σ : Type v, ∃ _ : Fintype σ, ∃ M : DFA T σ, M.accepts = L :=
+  ⟨Language.isRegular_iff.helper, Language.isRegular_iff.helper⟩

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -260,7 +260,7 @@ private lemma Language.isRegular_iff.helper.{v'} {T : Type u} {L : Language T}
   ⟨σ', Fintype.ofEquiv σ f, M.reindex f, hM ▸ DFA.accepts_reindex M f⟩
 
 /--
-A language is regular if and only if is defined by a DFA with finite states.
+A language is regular if and only if it is defined by a DFA with finite states.
 
 This is more general than using the definition of `Language.IsRegular` directly, as the state type
 `σ` is universe-polymorphic.


### PR DESCRIPTION
An alternative is to use `Fin` and `Fintype.equivFin`, which are available via the existing import of `Data.Fintype.Card`. However, since `Fin _ : Type 0`, it needs to be wrapped in `ULift` to be universe-polymorphic, so the result is messier than the `Small` approach.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
