### PR TITLE
refactor(Algebra/Category/ModuleCat): try to use a type synonym for `Module.compHom` instead of adding it as a local instance

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Differentials/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Differentials/Basic.lean
@@ -121,6 +121,8 @@ lemma ext {M : ModuleCat B} {α β : KaehlerDifferential f ⟶ M}
   ext : 1
   exact this
 
+open ModuleCat.restrictScalars
+
 /-- The map `KaehlerDifferential f ⟶ (ModuleCat.restrictScalars g').obj (KaehlerDifferential f')`
 induced by a commutative square (given by an equality `g ≫ f' = f ≫ g'`)
 in the category `CommRingCat`. -/
@@ -134,15 +136,13 @@ noncomputable def map :
   letI := (g ≫ f').toAlgebra
   have : IsScalarTower A A' B' := IsScalarTower.of_algebraMap_eq' rfl
   have := IsScalarTower.of_algebraMap_eq' fac
-  -- TODO: after https://github.com/leanprover-community/mathlib4/pull/19511 we need to hint `(Y := ...)`.
-  -- This suggests `restrictScalars` needs to be redesigned.
-  ModuleCat.ofHom (Y := (ModuleCat.restrictScalars g').obj (KaehlerDifferential f'))
-  { toFun := fun x ↦ _root_.KaehlerDifferential.map A A' B B' x
-    map_add' := by simp
-    map_smul' := by simp }
+  ModuleCat.ofHom
+  { toFun x := into _ <| _root_.KaehlerDifferential.map A A' B B' x
+    map_add' x y := by dsimp; rw [map_add]; rfl
+    map_smul' m x := by dsimp; rw [map_smul]; rfl }
 
 @[simp]
-lemma map_d (b : B) : map fac (d b) = d (g' b) := by
+lemma map_d (b : B) : map fac (d b) = into _ (d (g' b)) := by
   letI := f.toAlgebra
   letI := f'.toAlgebra
   letI := g.toAlgebra
@@ -150,6 +150,7 @@ lemma map_d (b : B) : map fac (d b) = d (g' b) := by
   letI := (f'.comp g).toAlgebra
   have : IsScalarTower A A' B' := IsScalarTower.of_algebraMap_eq' rfl
   have := IsScalarTower.of_algebraMap_eq' fac
+  ext
   exact _root_.KaehlerDifferential.map_D A A' B B' b
 
 end KaehlerDifferential

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/ChangeOfRings.lean
@@ -56,14 +56,25 @@ noncomputable def restrictScalars (α : R ⟶ R') :
 
 instance (α : R ⟶ R') : (restrictScalars.{v} α).Additive where
 
-instance : (restrictScalars (𝟙 R)).Full := sorry -- inferInstanceAs (𝟭 _).Full
-
-instance (α : R ⟶ R') : (restrictScalars α).Faithful where
-  map_injective h := (toPresheaf R').map_injective sorry -- ((toPresheaf R).congr_map h)
-
 /-- The isomorphism `restrictScalars α ⋙ toPresheaf R ≅ toPresheaf R'` for any
 morphism of presheaves of rings `α : R ⟶ R'`. -/
 noncomputable def restrictScalarsCompToPresheaf (α : R ⟶ R') :
-    restrictScalars.{v} α ⋙ toPresheaf R ≅ toPresheaf R' := sorry -- Iso.refl _
+    restrictScalars.{v} α ⋙ toPresheaf R ≅ toPresheaf R' where
+  hom.app X := { app M := AddCommGrp.ofHom <|
+    (Module.RestrictScalars.outAddEquiv _ _).toAddMonoidHom }
+  inv.app X := { app M := AddCommGrp.ofHom <|
+    (Module.RestrictScalars.outAddEquiv _ _).symm.toAddMonoidHom }
+
+def restrictScalarsId : 𝟭 (PresheafOfModules R) ≅ restrictScalars (𝟙 R) where
+  hom.app X := { app M := ModuleCat.ofHom <| Module.RestrictScalars.idEquiv.symm.toLinearMap }
+  inv.app X := { app M := ModuleCat.ofHom <| Module.RestrictScalars.idEquiv.toLinearMap }
+
+instance : (restrictScalars (𝟙 R)).Full :=
+  CategoryTheory.Functor.Full.of_iso (F := (𝟭 _)) restrictScalarsId
+
+instance (α : R ⟶ R') : (restrictScalars α).Faithful :=
+  have _ : (restrictScalars α ⋙ toPresheaf R).Faithful := Functor.Faithful.of_iso
+    (restrictScalarsCompToPresheaf _).symm
+  Functor.Faithful.of_comp (restrictScalars α) (toPresheaf R)
 
 end PresheafOfModules

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/ChangeOfRings.lean
@@ -23,24 +23,24 @@ namespace PresheafOfModules
 
 variable {C : Type u'} [Category.{v'} C] {R R' : Cᵒᵖ ⥤ RingCat.{u}}
 
+open ModuleCat.restrictScalars
+
 /-- The restriction of scalars of presheaves of modules, on objects. -/
 @[simps]
 noncomputable def restrictScalarsObj (M' : PresheafOfModules.{v} R') (α : R ⟶ R') :
     PresheafOfModules R where
   obj := fun X ↦ (ModuleCat.restrictScalars (α.app X)).obj (M'.obj X)
-  -- TODO: after https://github.com/leanprover-community/mathlib4/pull/19511 we need to hint `(X := ...)` and `(Y := ...)`.
-  -- This suggests `restrictScalars` needs to be redesigned.
   map := fun {X Y} f ↦ ModuleCat.ofHom
-      (X := (ModuleCat.restrictScalars (α.app X)).obj (M'.obj X))
-      (Y := (ModuleCat.restrictScalars (R.map f)).obj
-        ((ModuleCat.restrictScalars (α.app Y)).obj (M'.obj Y)))
-    { toFun := M'.map f
-      map_add' := map_add _
-      map_smul' := fun r x ↦ (M'.map_smul f (α.app _ r) x).trans (by
+    { toFun x := into _ (into _ (out _ ((M'.map f).hom (out _ x))))
+      map_add' _ _ := by simp
+      map_smul' r x := by
+        ext
+        dsimp
+        rw [smul_def, out_into, M'.map_smul, smul_def]
         have eq := RingHom.congr_fun (α.naturality f) r
         dsimp at eq
         rw [← eq]
-        rfl ) }
+        simp }
 
 /-- The restriction of scalars functor `PresheafOfModules R' ⥤ PresheafOfModules R`
 induced by a morphism of presheaves of rings `R ⟶ R'`. -/
@@ -52,18 +52,18 @@ noncomputable def restrictScalars (α : R ⟶ R') :
     { app := fun X ↦ (ModuleCat.restrictScalars (α.app X)).map (Hom.app φ' X)
       naturality := fun {X Y} f ↦ by
         ext x
-        exact naturality_apply φ' f x }
+        exact congr_arg (into _) (naturality_apply φ' f (out _ x)) }
 
 instance (α : R ⟶ R') : (restrictScalars.{v} α).Additive where
 
-instance : (restrictScalars (𝟙 R)).Full := inferInstanceAs (𝟭 _).Full
+instance : (restrictScalars (𝟙 R)).Full := sorry -- inferInstanceAs (𝟭 _).Full
 
 instance (α : R ⟶ R') : (restrictScalars α).Faithful where
-  map_injective h := (toPresheaf R').map_injective ((toPresheaf R).congr_map h)
+  map_injective h := (toPresheaf R').map_injective sorry -- ((toPresheaf R).congr_map h)
 
 /-- The isomorphism `restrictScalars α ⋙ toPresheaf R ≅ toPresheaf R'` for any
 morphism of presheaves of rings `α : R ⟶ R'`. -/
 noncomputable def restrictScalarsCompToPresheaf (α : R ⟶ R') :
-    restrictScalars.{v} α ⋙ toPresheaf R ≅ toPresheaf R' := Iso.refl _
+    restrictScalars.{v} α ⋙ toPresheaf R ≅ toPresheaf R' := sorry -- Iso.refl _
 
 end PresheafOfModules

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Free.lean
@@ -31,13 +31,15 @@ namespace PresheafOfModules
 
 variable {C : Type u₁} [Category.{v₁} C] (R : Cᵒᵖ ⥤ RingCat.{u})
 
+open ModuleCat.restrictScalars
+
 variable {R} in
 /-- Given a presheaf of types `F : Cᵒᵖ ⥤ Type u`, this is the presheaf
 of modules over `R` which sends `X : Cᵒᵖ` to the free `R.obj X`-module on `F.obj X`. -/
 @[simps]
 noncomputable def freeObj (F : Cᵒᵖ ⥤ Type u) : PresheafOfModules.{u} R where
   obj X := (ModuleCat.free (R.obj X)).obj (F.obj X)
-  map {X Y} f := ModuleCat.freeDesc (fun x ↦ ModuleCat.freeMk (F.map f x))
+  map {X Y} f := ModuleCat.freeDesc (fun x ↦ into _ (ModuleCat.freeMk (F.map f x)))
   map_id := by aesop
 
 /-- The free presheaf of modules functor `(Cᵒᵖ ⥤ Type u) ⥤ PresheafOfModules.{u} R`. -/

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Pushforward.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Pushforward.lean
@@ -26,8 +26,12 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 
 namespace PresheafOfModules
 
+open ModuleCat.restrictScalars
+
 variable (F : C ⥤ D)
 
+set_option maxHeartbeats 400000 in
+-- After squeezing simps, this costs 209009 heartbeats...
 /-- The pushforward functor on presheaves of modules for a functor `F : C ⥤ D` and
 `R : Dᵒᵖ ⥤ RingCat`. On the underlying presheaves of abelian groups, it is induced
 by the precomposition with `F.op`. -/
@@ -37,15 +41,21 @@ def pushforward₀ (R : Dᵒᵖ ⥤ RingCat.{u}) :
     { obj := fun X ↦ ModuleCat.of _ (M.obj (F.op.obj X))
       map := fun {X Y} f ↦ M.map (F.op.map f)
       map_id := fun X ↦ by
-        refine ModuleCat.hom_ext
-          -- Work around an instance diamond for `restrictScalarsId'`
-          (@LinearMap.ext _ _ _ _ _ _ _ _ (_) (_) _ _ _ (fun x => ?_))
-        exact (M.congr_map_apply (F.op.map_id X) x).trans (by simp)
+        refine ModuleCat.hom_ext (LinearMap.ext fun x => ?_)
+        exact (M.congr_map_apply (F.op.map_id X) x).trans (by
+          simp only [Functor.op_obj, Functor.op_map, unop_id, map_id,
+            ModuleCat.restrictScalarsId'_inv_app, ModuleCat.restrictScalarsId'App_inv_apply,
+            out_into, Functor.comp_obj, Functor.comp_map, ModuleCat.of_coe])
       map_comp := fun f g ↦ by
-        refine ModuleCat.hom_ext
-          -- Work around an instance diamond for `restrictScalarsId'`
-          (@LinearMap.ext _ _ _ _ _ _ _ _ (_) (_) _ _ _ (fun x => ?_))
-        exact (M.congr_map_apply (F.op.map_comp f g) x).trans (by ext; simp) }
+        refine ModuleCat.hom_ext (LinearMap.ext fun x => ?_)
+        exact (M.congr_map_apply (F.op.map_comp f g) x).trans (by
+          ext
+          simp only [Functor.op_obj, Functor.op_map, unop_comp, map_comp,
+            ModuleCat.restrictScalarsComp'_inv_app, ModuleCat.restrictScalarsComp'App,
+            ModuleCat.hom_comp, LinearEquiv.toModuleIso_inv_hom, LinearMap.coe_comp,
+            LinearEquiv.coe_coe, AddEquiv.coe_toLinearEquiv_symm, AddEquiv.symm_mk, AddEquiv.coe_mk,
+            Equiv.coe_fn_symm_mk, coe_map, Function.comp_apply, out_into, Functor.comp_obj,
+            ModuleCat.of_coe, Functor.comp_map]) }
   map {M₁ M₂} φ := { app := fun X ↦ φ.app _ }
 
 /-- The pushforward of presheaves of modules commutes with the forgetful functor
@@ -68,11 +78,14 @@ noncomputable def pushforward : PresheafOfModules.{v} R ⥤ PresheafOfModules.{v
 to presheaves of abelian groups. -/
 noncomputable def pushforwardCompToPresheaf :
     pushforward.{v} φ ⋙ toPresheaf _ ≅ toPresheaf _ ⋙ (whiskeringLeft _ _ _).obj F.op :=
-  Iso.refl _
+  Functor.associator _ _ _ ≪≫
+    (isoWhiskerLeft _ (restrictScalarsCompToPresheaf _)) ≪≫
+    (pushforward₀CompToPresheaf _ _)
 
 lemma pushforward_obj_map_apply (M : PresheafOfModules.{v} R) {X Y : Cᵒᵖ} (f : X ⟶ Y)
     (m : (ModuleCat.restrictScalars (φ.app X)).obj (M.obj (Opposite.op (F.obj X.unop)))) :
-      (((pushforward φ).obj M).map f).hom m = M.map (F.map f.unop).op m := rfl
+      (((pushforward φ).obj M).map f).hom m =
+        into _ (into _ (out _ (M.map (F.map f.unop).op (out _ m)))) := rfl
 
 /-- `@[simp]`-normal form of `pushforward_obj_map_apply`. -/
 @[simp]
@@ -81,11 +94,13 @@ lemma pushforward_obj_map_apply' (M : PresheafOfModules.{v} R) {X Y : Cᵒᵖ} (
       DFunLike.coe
         (F := ↑((ModuleCat.restrictScalars _).obj _) →ₗ[_]
           ↑((ModuleCat.restrictScalars (S.map f)).obj ((ModuleCat.restrictScalars _).obj _)))
-        (((pushforward φ).obj M).map f).hom m = M.map (F.map f.unop).op m := rfl
+        (((pushforward φ).obj M).map f).hom m =
+          into _ (into _ (out _ (M.map (F.map f.unop).op (out _ m)))) := rfl
 
 lemma pushforward_map_app_apply {M N : PresheafOfModules.{v} R} (α : M ⟶ N) (X : Cᵒᵖ)
     (m : (ModuleCat.restrictScalars (φ.app X)).obj (M.obj (Opposite.op (F.obj X.unop)))) :
-    (((pushforward φ).map α).app X).hom m = α.app (Opposite.op (F.obj X.unop)) m := rfl
+    (((pushforward φ).map α).app X).hom m =
+      into _ (α.app (Opposite.op (F.obj X.unop)) (out _ m)) := rfl
 
 /-- `@[simp]`-normal form of `pushforward_map_app_apply`. -/
 @[simp]
@@ -93,6 +108,7 @@ lemma pushforward_map_app_apply' {M N : PresheafOfModules.{v} R} (α : M ⟶ N) 
     (m : (ModuleCat.restrictScalars (φ.app X)).obj (M.obj (Opposite.op (F.obj X.unop)))) :
     DFunLike.coe
       (F := ↑((ModuleCat.restrictScalars _).obj _) →ₗ[_] ↑((ModuleCat.restrictScalars _).obj _))
-      (((pushforward φ).map α).app X).hom m = α.app (Opposite.op (F.obj X.unop)) m := rfl
+      (((pushforward φ).map α).app X).hom m =
+        into _ (α.app (Opposite.op (F.obj X.unop)) (out _ m)) := rfl
 
 end PresheafOfModules

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Pushforward.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Pushforward.lean
@@ -45,7 +45,7 @@ def pushforward₀ (R : Dᵒᵖ ⥤ RingCat.{u}) :
         refine ModuleCat.hom_ext
           -- Work around an instance diamond for `restrictScalarsId'`
           (@LinearMap.ext _ _ _ _ _ _ _ _ (_) (_) _ _ _ (fun x => ?_))
-        exact (M.congr_map_apply (F.op.map_comp f g) x).trans (by simp) }
+        exact (M.congr_map_apply (F.op.map_comp f g) x).trans (by ext; simp) }
   map {M₁ M₂} φ := { app := fun X ↦ φ.app _ }
 
 /-- The pushforward of presheaves of modules commutes with the forgetful functor

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafification.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafification.lean
@@ -83,23 +83,26 @@ lemma toPresheaf_map_sheafificationHomEquiv_def
     {P : PresheafOfModules.{v} R₀} {F : SheafOfModules.{v} R}
     (f : (sheafification α).obj P ⟶ F) :
     (toPresheaf R₀).map (sheafificationHomEquiv α f) =
-      CategoryTheory.toSheafify J P.presheaf ≫ (toPresheaf R.val).map f.val := rfl
+      CategoryTheory.toSheafify J P.presheaf ≫ (toPresheaf R.val).map f.val ≫
+        ((restrictScalarsCompToPresheaf _).inv.app _) := rfl
 
 lemma toPresheaf_map_sheafificationHomEquiv
     {P : PresheafOfModules.{v} R₀} {F : SheafOfModules.{v} R}
     (f : (sheafification α).obj P ⟶ F) :
     (toPresheaf R₀).map (sheafificationHomEquiv α f) =
-      (sheafificationAdjunction J AddCommGrp).homEquiv P.presheaf
-        ((SheafOfModules.toSheaf _).obj F) ((SheafOfModules.toSheaf _).map f) := by
+      ((sheafificationAdjunction J AddCommGrp).homEquiv P.presheaf
+        ((SheafOfModules.toSheaf _).obj F) ((SheafOfModules.toSheaf _).map f)) ≫
+         ((restrictScalarsCompToPresheaf _).inv.app _) := by
   rw [toPresheaf_map_sheafificationHomEquiv_def, Adjunction.homEquiv_unit]
-  dsimp
+  simp
 
 lemma toSheaf_map_sheafificationHomEquiv_symm
     {P : PresheafOfModules.{v} R₀} {F : SheafOfModules.{v} R}
     (g : P ⟶ (restrictScalars α).obj ((SheafOfModules.forget _).obj F)) :
     (SheafOfModules.toSheaf _).map ((sheafificationHomEquiv α).symm g) =
       (((sheafificationAdjunction J AddCommGrp).homEquiv
-        P.presheaf ((SheafOfModules.toSheaf R).obj F)).symm ((toPresheaf R₀).map g)) := by
+        P.presheaf ((SheafOfModules.toSheaf R).obj F)).symm
+          (((toPresheaf R₀).map g) ≫ ((restrictScalarsCompToPresheaf _).hom.app _))) := by
   obtain ⟨f, rfl⟩ := (sheafificationHomEquiv α).surjective g
   apply ((sheafificationAdjunction J AddCommGrp).homEquiv _ _).injective
   rw [Equiv.apply_symm_apply, Adjunction.homEquiv_unit, Equiv.symm_apply_apply]
@@ -118,6 +121,8 @@ noncomputable def sheafificationAdjunction :
         erw [toSheaf_map_sheafificationHomEquiv_symm,
           toSheaf_map_sheafificationHomEquiv_symm α g]
         rw [Functor.map_comp]
+        simp only [sheafToPresheaf_obj, SheafOfModules.toSheaf_obj_val, SheafOfModules.forget_obj,
+          restrictScalars_obj, assoc]
         apply (CategoryTheory.sheafificationAdjunction J
           AddCommGrp.{v}).homEquiv_naturality_left_symm
       homEquiv_naturality_right := fun {P₀ M N} f g ↦ by
@@ -131,7 +136,9 @@ lemma sheafificationAdjunction_homEquiv_apply {P : PresheafOfModules.{v} R₀}
 @[simp]
 lemma toPresheaf_map_sheafificationAdjunction_unit_app (M₀ : PresheafOfModules.{v} R₀) :
     (toPresheaf _).map ((sheafificationAdjunction α).unit.app M₀) =
-      CategoryTheory.toSheafify J M₀.presheaf := rfl
+      CategoryTheory.toSheafify J M₀.presheaf ≫
+        { app X := AddCommGrp.ofHom <|
+          (Module.RestrictScalars.outAddEquiv _ _).symm.toAddMonoidHom } := rfl
 
 instance : (sheafification.{v} α).IsLeftAdjoint :=
   (sheafificationAdjunction α).isLeftAdjoint

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
@@ -25,6 +25,7 @@ and the presheaf of modules.
 universe w v v₁ u₁ u
 
 open CategoryTheory
+open ModuleCat.restrictScalars
 
 variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
 
@@ -66,8 +67,11 @@ lemma _root_.PresheafOfModules.Sheafify.app_eq_of_isLocallyInjective
     · exact Presheaf.equalizerSieve_mem J α _ _ hr₀
     · exact Presheaf.equalizerSieve_mem J φ _ _ hm₀
   · intro Z g hg
-    erw [← NatTrans.naturality_apply, ← NatTrans.naturality_apply, M₀.map_smul, M₀.map_smul,
-      hg.1, hg.2]
+    rw [← NatTrans.naturality_apply, ← NatTrans.naturality_apply]
+    change (φ.app _) (out _ ((M₀.map g.op) (r₀ • m₀))) =
+      (φ.app _) (out _ ((M₀.map g.op) (r₀' • m₀')))
+    rw [M₀.map_smul, M₀.map_smul, hg.1]
+    erw [hg.2]
     rfl
 
 lemma isCompatible_map_smul_aux {Y Z : C} (f : Y ⟶ X) (g : Z ⟶ Y)
@@ -75,9 +79,10 @@ lemma isCompatible_map_smul_aux {Y Z : C} (f : Y ⟶ X) (g : Z ⟶ Y)
     (m₀ : M₀.obj (Opposite.op Y)) (m₀' : M₀.obj (Opposite.op Z))
     (hr₀ : α.app _ r₀ = R.map f.op r) (hr₀' : α.app _ r₀' = R.map (f.op ≫ g.op) r)
     (hm₀ : φ.app _ m₀ = A.map f.op m) (hm₀' : φ.app _ m₀' = A.map (f.op ≫ g.op) m) :
-    φ.app _ (M₀.map g.op (r₀ • m₀)) = φ.app _ (r₀' • m₀') := by
+    φ.app _ (out _ (M₀.map g.op (r₀ • m₀))) = φ.app _ (r₀' • m₀') := by
   rw [← PresheafOfModules.Sheafify.app_eq_of_isLocallyInjective α φ hA (R₀.map g.op r₀) r₀'
-    (M₀.map g.op m₀) m₀', M₀.map_smul]
+    (out _ (M₀.map g.op m₀)) m₀', M₀.map_smul]
+  · simp
   · rw [hr₀', R.map_comp, comp_apply, ← hr₀, NatTrans.naturality_apply]
   · rw [hm₀', A.map_comp, AddCommGrp.coe_comp, Function.comp_apply, ← hm₀]
     erw [NatTrans.naturality_apply]
@@ -101,17 +106,17 @@ lemma isCompatible_map_smul : ((r₀.smul m₀).map (whiskerRight φ (forget _))
   have ha₀ : (α.app (Opposite.op Z)) a₀ = (R.map (f₁.op ≫ g₁.op)) r := by
     dsimp [a₀]
     rw [NatTrans.naturality_apply, ha₁, Functor.map_comp, comp_apply]
-  have hb₀ : (φ.app (Opposite.op Z)) b₀ = (A.map (f₁.op ≫ g₁.op)) m := by
+  have hb₀ : (φ.app (Opposite.op Z)) (out _ b₀) = (A.map (f₁.op ≫ g₁.op)) m := by
     dsimp [b₀]
     erw [NatTrans.naturality_apply, hb₁, Functor.map_comp, comp_apply]
   have ha₀' : (α.app (Opposite.op Z)) a₀ = (R.map (f₂.op ≫ g₂.op)) r := by
     rw [ha₀, ← op_comp, fac, op_comp]
-  have hb₀' : (φ.app (Opposite.op Z)) b₀ = (A.map (f₂.op ≫ g₂.op)) m := by
+  have hb₀' : (φ.app (Opposite.op Z)) (out _ b₀) = (A.map (f₂.op ≫ g₂.op)) m := by
     rw [hb₀, ← op_comp, fac, op_comp]
   dsimp
   erw [← NatTrans.naturality_apply, ← NatTrans.naturality_apply]
-  exact (isCompatible_map_smul_aux α φ hA r m f₁ g₁ a₁ a₀ b₁ b₀ ha₁ ha₀ hb₁ hb₀).trans
-    (isCompatible_map_smul_aux α φ hA r m f₂ g₂ a₂ a₀ b₂ b₀ ha₂ ha₀' hb₂ hb₀').symm
+  exact (isCompatible_map_smul_aux α φ hA r m f₁ g₁ a₁ a₀ b₁ (out _ b₀) ha₁ ha₀ hb₁ hb₀).trans
+    (isCompatible_map_smul_aux α φ hA r m f₂ g₂ a₂ a₀ b₂ (out _ b₀) ha₂ ha₀' hb₂ hb₀').symm
 
 end
 
@@ -158,7 +163,9 @@ def SMulCandidate.mk' (S : Sieve X.unop) (hS : S ∈ J X.unop)
     apply A.isSeparated _ _ (J.pullback_stable f.unop hS)
     rintro Z g hg
     dsimp at hg
-    erw [← comp_apply, ← A.val.map_comp, ← NatTrans.naturality_apply, M₀.map_smul]
+    rw [← comp_apply, ← A.val.map_comp, ← NatTrans.naturality_apply]
+    show (A.val.map (f ≫ g.op)) a = (φ.app (Opposite.op Z)) (out _ ((M₀.map g.op) (a₀ • b₀)))
+    rw [M₀.map_smul]
     refine (ha _ hg).trans (app_eq_of_isLocallyInjective α φ A.isSeparated _ _ _ _ ?_ ?_)
     · rw [NatTrans.naturality_apply, ha₀]
       apply (hr₀ _ hg).symm.trans
@@ -308,29 +315,52 @@ noncomputable def sheafify : SheafOfModules.{v} R where
   val := letI := Sheafify.module α φ; ofPresheaf A.val (Sheafify.map_smul _ _)
   isSheaf := A.cond
 
+@[simps]
+noncomputable def intoRestrictScalars :
+    A.val ⟶ ((restrictScalars α).obj (sheafify α φ).val).presheaf where
+  app X := (AddCommGrp.ofHom (Module.RestrictScalars.outAddEquiv _ _).symm.toAddMonoidHom)
+
 /-- The canonical morphism from a presheaf of modules to its associated sheaf. -/
-def toSheafify : M₀ ⟶ (restrictScalars α).obj (sheafify α φ).val :=
-  homMk φ (fun X r₀ m₀ ↦ by
+noncomputable def toSheafify : M₀ ⟶ (restrictScalars α).obj (sheafify α φ).val :=
+  homMk
+  (φ ≫ (intoRestrictScalars _ _))
+  (fun X r₀ m₀ ↦ ModuleCat.restrictScalars.obj_ext _ _ _ <| by 
     simpa using (Sheafify.map_smul_eq α φ (α.app _ r₀) (φ.app _ m₀) (𝟙 _)
       r₀ (by aesop) m₀ (by simp)).symm)
 
 lemma toSheafify_app_apply (X : Cᵒᵖ) (x : M₀.obj X) :
-    ((toSheafify α φ).app X).hom x = φ.app X x := rfl
+    ((toSheafify α φ).app X).hom x = into _ (φ.app X x) := rfl
 
 /-- `@[simp]`-normal form of `toSheafify_app_apply`. -/
 @[simp]
 lemma toSheafify_app_apply' (X : Cᵒᵖ) (x : M₀.obj X) :
     DFunLike.coe (F := (_ →ₗ[_] ↑((ModuleCat.restrictScalars (α.app X)).obj _)))
-    ((toSheafify α φ).app X).hom x = φ.app X x := rfl
+    ((toSheafify α φ).app X).hom x = into _ (φ.app X x) := rfl
 
 @[simp]
-lemma toPresheaf_map_toSheafify : (toPresheaf R₀).map (toSheafify α φ) = φ := rfl
+lemma toPresheaf_map_toSheafify : (toPresheaf R₀).map (toSheafify α φ) =
+    φ ≫ (intoRestrictScalars _ _) :=
+  rfl
+
+instance : Presheaf.IsLocallyInjective J (intoRestrictScalars α φ) where
+  equalizerSieve_mem x y h := by
+    rw [show x = y from congr_arg Module.RestrictScalars.out h, Presheaf.equalizerSieve_self_eq_top]
+    exact GrothendieckTopology.top_mem _ _
 
 instance : IsLocallyInjective J (toSheafify α φ) := by
-  dsimp [IsLocallyInjective]; infer_instance
+  dsimp only [restrictScalars_obj, IsLocallyInjective, toPresheaf_map_toSheafify,
+    toPresheaf_obj_coe, restrictScalarsObj_obj, AddEquiv.toAddMonoidHom_eq_coe, id_eq]
+  apply Presheaf.isLocallyInjective_comp
+
+instance : Presheaf.IsLocallySurjective J (intoRestrictScalars α φ) where
+  imageSieve_mem s := by
+    erw [Presheaf.imageSieve_app]
+    exact GrothendieckTopology.top_mem _ _
 
 instance : IsLocallySurjective J (toSheafify α φ) := by
-  dsimp [IsLocallySurjective]; infer_instance
+  dsimp only [restrictScalars_obj, IsLocallySurjective, toPresheaf_map_toSheafify,
+    toPresheaf_obj_coe, restrictScalarsObj_obj, AddEquiv.toAddMonoidHom_eq_coe, id_eq]
+  apply Presheaf.isLocallySurjective_comp
 
 variable [J.WEqualsLocallyBijective AddCommGrp.{v}]
 
@@ -341,13 +371,16 @@ noncomputable def sheafifyHomEquiv' {F : PresheafOfModules.{v} R.val}
     (hF : Presheaf.IsSheaf J F.presheaf) :
     ((sheafify α φ).val ⟶ F) ≃ (M₀ ⟶ (restrictScalars α).obj F) :=
   (restrictHomEquivOfIsLocallySurjective α hF).trans
-    (homEquivOfIsLocallyBijective (f := toSheafify α φ)
-      (N := (restrictScalars α).obj F) hF)
+    (homEquivOfIsLocallyBijective (J := J) (f := toSheafify α φ)
+      (N := (restrictScalars α).obj F)
+      ((Presheaf.isSheaf_of_iso_iff ((restrictScalarsCompToPresheaf _).app _)).mpr hF))
 
 lemma comp_toPresheaf_map_sheafifyHomEquiv'_symm_hom {F : PresheafOfModules.{v} R.val}
     (hF : Presheaf.IsSheaf J F.presheaf) (f : M₀ ⟶ (restrictScalars α).obj F) :
-    φ ≫ (toPresheaf R.val).map ((sheafifyHomEquiv' α φ hF).symm f) = (toPresheaf R₀).map f :=
-  (toPresheaf _).congr_map ((sheafifyHomEquiv' α φ hF).apply_symm_apply f)
+    φ ≫ (toPresheaf R.val).map ((sheafifyHomEquiv' α φ hF).symm f) =
+      (toPresheaf R₀).map f ≫ ((restrictScalarsCompToPresheaf _).hom.app _) := by
+  rw [← ((toPresheaf _).congr_map ((sheafifyHomEquiv' α φ hF).apply_symm_apply f))]
+  rfl
 
 /-- The bijection
 `(sheafify α φ ⟶ F) ≃ (M₀ ⟶ (restrictScalars α).obj ((SheafOfModules.forget _).obj F))`
@@ -378,7 +411,8 @@ def sheafifyMap (fac : (toPresheaf R₀).map τ₀ ≫ φ' = φ ≫ τ.val) :
     apply ((J.W_of_isLocallyBijective φ).homEquiv _ A'.cond).injective
     dsimp [f]
     erw [comp_toPresheaf_map_sheafifyHomEquiv'_symm_hom]
-    rw [← fac, Functor.map_comp, toPresheaf_map_toSheafify])
+    rw [← fac, Functor.map_comp, toPresheaf_map_toSheafify]
+    rfl)
 
 end
 

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf.lean
@@ -97,7 +97,9 @@ noncomputable def forgetToSheafModuleCat
     SheafOfModules.{w} R ⥤ Sheaf J (ModuleCat.{w} (R.1.obj X)) where
   obj M := ⟨(PresheafOfModules.forgetToPresheafModuleCat X hX).obj M.1,
     Presheaf.isSheaf_of_isSheaf_comp _ _
-      (forget₂ (ModuleCat.{w} (R.1.obj X)) AddCommGrp.{w}) M.isSheaf⟩
+      (forget₂ (ModuleCat.{w} (R.1.obj X)) AddCommGrp.{w})
+        sorry
+        /- M.isSheaf -/⟩
   map f := { val := (PresheafOfModules.forgetToPresheafModuleCat X hX).map f.1 }
 
 /-- The canonical isomorphism between
@@ -198,6 +200,8 @@ variable {N : PresheafOfModules.{v} R} (hN : Presheaf.IsSheaf J N.presheaf)
 
 variable {J}
 
+open ModuleCat.restrictScalars
+
 /-- The bijection `(M₂ ⟶ N) ≃ (M₁ ⟶ N)` induced by a locally bijective morphism
 `f : M₁ ⟶ M₂` of presheaves of modules, when `N` is a sheaf. -/
 @[simps]
@@ -215,12 +219,12 @@ noncomputable def homEquivOfIsLocallyBijective : (M₂ ⟶ N) ≃ (M₁ ⟶ N) w
         intro X r y
         apply hN.isSeparated _ _
           (Presheaf.imageSieve_mem J ((toPresheaf R).map f) y)
-        rintro Y p ⟨x : M₁.obj _, hx : f.app _ x = M₂.map p.op y⟩
-        have hφ' : ∀ (z : M₂.obj X), φ.app _ (M₂.map p.op z) =
-            N.map p.op (φ.app _ z) := congr_fun ((forget _).congr_map (φ.naturality p.op))
-        change N.map p.op (φ.app X (r • y)) = N.map p.op (r • φ.app X y)
-        rw [← hφ', M₂.map_smul, ← hx, ← (f.app _).hom.map_smul, hφ, (ψ.app _).hom.map_smul,
-          ← hφ, hx, N.map_smul, hφ'])
+        rintro Y p ⟨x : M₁.obj _, hx : f.app _ x = out _ (M₂.map p.op y)⟩
+        have hφ' : ∀ (z : M₂.obj X), φ.app _ (out _ (M₂.map p.op z)) =
+            out _ (N.map p.op (φ.app _ z)) := congr_fun ((forget _).congr_map (φ.naturality p.op))
+        change out _ (N.map p.op (φ.app X (r • y))) = out _ (N.map p.op (r • φ.app X y))
+        rw [← hφ', M₂.map_smul, ← hx, ← (f.app _).hom.map_smul, out_into, hφ,
+          (ψ.app _).hom.map_smul, ← hφ, hx, N.map_smul, hφ', out_into])
   left_inv φ := (toPresheaf _).map_injective
     (((J.W_of_isLocallyBijective
       ((PresheafOfModules.toPresheaf R).map f)).homEquiv _ hN).left_inv

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf.lean
@@ -97,9 +97,13 @@ noncomputable def forgetToSheafModuleCat
     SheafOfModules.{w} R ⥤ Sheaf J (ModuleCat.{w} (R.1.obj X)) where
   obj M := ⟨(PresheafOfModules.forgetToPresheafModuleCat X hX).obj M.1,
     Presheaf.isSheaf_of_isSheaf_comp _ _
-      (forget₂ (ModuleCat.{w} (R.1.obj X)) AddCommGrp.{w})
-        sorry
-        /- M.isSheaf -/⟩
+      (forget₂ (ModuleCat.{w} (R.1.obj X)) AddCommGrp.{w}) 
+        ((Presheaf.isSheaf_of_iso_iff
+        { hom.app X :=
+            AddCommGrp.ofHom (Module.RestrictScalars.outAddEquiv _ _).symm.toAddMonoidHom
+          inv.app X :=
+            AddCommGrp.ofHom (Module.RestrictScalars.outAddEquiv _ _).toAddMonoidHom }).mp
+        M.isSheaf)⟩
   map f := { val := (PresheafOfModules.forgetToPresheafModuleCat X hX).map f.1 }
 
 /-- The canonical isomorphism between

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Colimits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Colimits.lean
@@ -29,7 +29,13 @@ instance [HasColimitsOfShape K (PresheafOfModules.{v} R.val)] :
     HasColimitsOfShape K (SheafOfModules.{v} R) where
   has_colimit F := by
     let e : F ≅ (F ⋙ forget R) ⋙ PresheafOfModules.sheafification (𝟙 R.val) :=
-      isoWhiskerLeft F (asIso (PresheafOfModules.sheafificationAdjunction (𝟙 R.val)).counit).symm
+      (isoWhiskerLeft F
+        (asIso (PresheafOfModules.sheafificationAdjunction (𝟙 R.val)).counit).symm) ≪≫ 
+        (isoWhiskerLeft F (Functor.associator (forget _)
+          (PresheafOfModules.restrictScalars (𝟙 R.val)) (PresheafOfModules.sheafification _) ≪≫
+            isoWhiskerLeft (forget R) (isoWhiskerRight PresheafOfModules.restrictScalarsId.symm _ ≪≫
+              Functor.leftUnitor _))) ≪≫
+        (Functor.associator F (forget _) (PresheafOfModules.sheafification (𝟙 R.val))).symm
     exact hasColimitOfIso e
 
 end SheafOfModules

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/PushforwardContinuous.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/PushforwardContinuous.lean
@@ -30,13 +30,19 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
   [Functor.IsContinuous.{u} F J K] [Functor.IsContinuous.{v} F J K]
   (φ : S ⟶ (F.sheafPushforwardContinuous RingCat.{u} J K).obj R)
 
+set_option maxHeartbeats 400000 in -- Not sure why this is so slow...
 /-- The pushforward of sheaves of modules that is induced by a continuous functor `F`
 and a morphism of sheaves of rings `φ : S ⟶ (F.sheafPushforwardContinuous RingCat J K).obj R`. -/
 @[simps]
 noncomputable def pushforward : SheafOfModules.{v} R ⥤ SheafOfModules.{v} S where
   obj M :=
     { val := (PresheafOfModules.pushforward φ.val).obj M.val
-      isSheaf := ((F.sheafPushforwardContinuous _ J K).obj ⟨_, M.isSheaf⟩).cond }
+      isSheaf := (Presheaf.isSheaf_of_iso_iff
+          { hom.app X :=
+              AddCommGrp.ofHom ((Module.RestrictScalars.outAddEquiv _ _).symm.toAddMonoidHom)
+            inv.app X :=
+              AddCommGrp.ofHom ((Module.RestrictScalars.outAddEquiv _ _).toAddMonoidHom) }).mp
+        ((F.sheafPushforwardContinuous _ J K).obj ⟨_, M.isSheaf⟩).cond }
   map f :=
     { val := (PresheafOfModules.pushforward φ.val).map f.val }
 


### PR DESCRIPTION
This is an attempt to get rid of annoying defeq issues involving `ModuleCat.restrictScalars`: this was previously just a `def` but with a lot of its own instances. This meant it got unfolded all the time, resulting in failing instance search. Instead we try to define a `structure` that carries the right instances. Irreducibility should ensure we don't get confused between which type we want an instance on.

First I tried making `Module.RestrictScalars` a `def` and inserting `out` and `into` wherever necessary to define maps, but that runs into the issue that the unfolding happens before we give a value to the maps. (Namely, it happens whenever defining a map because `ofHom` wants to unfold `ModuleCat.restrictScalars` into a `Type`.)

I absolutely do not understand enough of the category theory library to have done this by anything else but brute force. Needed to insert a lot of `restrictScalars`-based natural transformations, especially for sheaves. They usually wouldn't apply as a `def` so I had to write their fields out by hand each time.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
