### PR TITLE
[Merged by Bors] - faet(RingTheory/DiscreteValuationRing/Basic): rename `DiscreteValuationRing` to `IsDiscreteValuationRing`.

### DIFF
--- a/Mathlib/NumberTheory/Padics/PadicIntegers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicIntegers.lean
@@ -543,14 +543,14 @@ theorem prime_p : Prime (p : ℤ_[p]) := by
 
 theorem irreducible_p : Irreducible (p : ℤ_[p]) := Prime.irreducible prime_p
 
-instance : DiscreteValuationRing ℤ_[p] :=
-  DiscreteValuationRing.ofHasUnitMulPowIrreducibleFactorization
+instance : IsDiscreteValuationRing ℤ_[p] :=
+  IsDiscreteValuationRing.ofHasUnitMulPowIrreducibleFactorization
     ⟨p, irreducible_p, fun {x hx} =>
       ⟨x.valuation.natAbs, unitCoeff hx, by rw [mul_comm, ← unitCoeff_spec hx]⟩⟩
 
 theorem ideal_eq_span_pow_p {s : Ideal ℤ_[p]} (hs : s ≠ ⊥) :
     ∃ n : ℕ, s = Ideal.span {(p : ℤ_[p]) ^ n} :=
-  DiscreteValuationRing.ideal_eq_span_pow_irreducible hs irreducible_p
+  IsDiscreteValuationRing.ideal_eq_span_pow_irreducible hs irreducible_p
 
 open CauSeq
 

--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -367,7 +367,7 @@ theorem appr_spec (n : ℕ) : ∀ x : ℤ_[p], x - appr x n ∈ Ideal.span {(p :
       -- TODO: write a `CanLift` instance for units
       rw [Int.natAbs_eq_zero] at hc0
       rw [isUnit_iff, norm_eq_pow_val hc', hc0, neg_zero, zpow_zero]
-    rw [DiscreteValuationRing.unit_mul_pow_congr_unit _ _ _ _ _ hc]
+    rw [IsDiscreteValuationRing.unit_mul_pow_congr_unit _ _ _ _ _ hc]
     exact irreducible_p
   · simp only [zero_pow hc0, sub_zero, ZMod.cast_zero, mul_zero]
     rw [unitCoeff_spec hc']

--- a/Mathlib/RingTheory/DedekindDomain/Dvr.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Dvr.lean
@@ -54,7 +54,7 @@ This is equivalent to `IsDedekindDomain`.
 -/
 class IsDedekindDomainDvr extends IsNoetherian A A : Prop where
   is_dvr_at_nonzero_prime : ∀ P ≠ (⊥ : Ideal A), ∀ _ : P.IsPrime,
-    DiscreteValuationRing (Localization.AtPrime P)
+    IsDiscreteValuationRing (Localization.AtPrime P)
 
 /-- Localizing a domain of Krull dimension `≤ 1` gives another ring of Krull dimension `≤ 1`.
 
@@ -124,16 +124,16 @@ theorem IsLocalization.AtPrime.not_isField {P : Ideal A} (hP : P ≠ ⊥) [pP : 
             x_ne)))
 
 /-- In a Dedekind domain, the localization at every nonzero prime ideal is a DVR. -/
-theorem IsLocalization.AtPrime.discreteValuationRing_of_dedekind_domain [IsDedekindDomain A]
+theorem IsLocalization.AtPrime.isDiscreteValuationRing_of_dedekind_domain [IsDedekindDomain A]
     {P : Ideal A} (hP : P ≠ ⊥) [pP : P.IsPrime] (Aₘ : Type*) [CommRing Aₘ] [IsDomain Aₘ]
-    [Algebra A Aₘ] [IsLocalization.AtPrime Aₘ P] : DiscreteValuationRing Aₘ := by
+    [Algebra A Aₘ] [IsLocalization.AtPrime Aₘ P] : IsDiscreteValuationRing Aₘ := by
   classical
   letI : IsNoetherianRing Aₘ :=
     IsLocalization.isNoetherianRing P.primeCompl _ IsDedekindRing.toIsNoetherian
   letI : IsLocalRing Aₘ := IsLocalization.AtPrime.isLocalRing Aₘ P
   have hnf := IsLocalization.AtPrime.not_isField A hP Aₘ
   exact
-    ((DiscreteValuationRing.TFAE Aₘ hnf).out 0 2).mpr
+    ((IsDiscreteValuationRing.TFAE Aₘ hnf).out 0 2).mpr
       (IsLocalization.AtPrime.isDedekindDomain A P _)
 
 /-- Dedekind domains, in the sense of Noetherian integrally closed domains of Krull dimension ≤ 1,
@@ -141,7 +141,7 @@ are also Dedekind domains in the sense of Noetherian domains where the localizat
 nonzero prime ideal is a DVR. -/
 instance IsDedekindDomain.isDedekindDomainDvr [IsDedekindDomain A] : IsDedekindDomainDvr A where
   is_dvr_at_nonzero_prime := fun _ hP _ =>
-    IsLocalization.AtPrime.discreteValuationRing_of_dedekind_domain A hP _
+    IsLocalization.AtPrime.isDiscreteValuationRing_of_dedekind_domain A hP _
 
 instance IsDedekindDomainDvr.ring_dimensionLEOne [h : IsDedekindDomainDvr A] :
     Ring.DimensionLEOne A where
@@ -156,7 +156,7 @@ instance IsDedekindDomainDvr.ring_dimensionLEOne [h : IsDedekindDomainDvr A] :
     have hp1 : P.1 ≠ ⊥ := fun x => hp ((p.map_eq_bot_iff_of_injective hinj).mp x)
     have hq1 : Q.1 ≠ ⊥ :=
       fun x => (ne_bot_of_le_ne_bot hp hpq) ((q.map_eq_bot_iff_of_injective hinj).mp x)
-    rcases (DiscreteValuationRing.iff_pid_with_one_nonzero_prime (Localization.AtPrime q)).mp
+    rcases (IsDiscreteValuationRing.iff_pid_with_one_nonzero_prime (Localization.AtPrime q)).mp
       (h.is_dvr_at_nonzero_prime q (ne_bot_of_le_ne_bot hp hpq) hq.isPrime) with ⟨_, huq⟩
     rw [show p = q from Subtype.val_inj.mpr <| f.injective <|
       Subtype.val_inj.mp (huq.unique ⟨hp1, P.2⟩ ⟨hq1, Q.2⟩)]
@@ -164,9 +164,9 @@ instance IsDedekindDomainDvr.ring_dimensionLEOne [h : IsDedekindDomainDvr A] :
 
 instance IsDedekindDomainDvr.isIntegrallyClosed [h : IsDedekindDomainDvr A] :
     IsIntegrallyClosed A :=
-  IsIntegrallyClosed.of_localization_maximal <| fun p hp0 hpm =>
-    let ⟨_, _⟩ := (DiscreteValuationRing.iff_pid_with_one_nonzero_prime (Localization.AtPrime p)).mp
-      (h.is_dvr_at_nonzero_prime p hp0 hpm.isPrime)
+  IsIntegrallyClosed.of_localization_maximal <| fun p hp0 hpm ↦
+    let ⟨_ ,_⟩ := (IsDiscreteValuationRing.iff_pid_with_one_nonzero_prime
+      (Localization.AtPrime p)).mp (h.is_dvr_at_nonzero_prime p hp0 hpm.isPrime)
     inferInstance
 
 /-- If an integral domain is Noetherian, and the localization at every nonzero prime is

--- a/Mathlib/RingTheory/DedekindDomain/Dvr.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Dvr.lean
@@ -165,7 +165,7 @@ instance IsDedekindDomainDvr.ring_dimensionLEOne [h : IsDedekindDomainDvr A] :
 instance IsDedekindDomainDvr.isIntegrallyClosed [h : IsDedekindDomainDvr A] :
     IsIntegrallyClosed A :=
   IsIntegrallyClosed.of_localization_maximal <| fun p hp0 hpm ↦
-    let ⟨_ ,_⟩ := (IsDiscreteValuationRing.iff_pid_with_one_nonzero_prime
+    let ⟨_, _⟩ := (IsDiscreteValuationRing.iff_pid_with_one_nonzero_prime
       (Localization.AtPrime p)).mp (h.is_dvr_at_nonzero_prime p hp0 hpm.isPrime)
     inferInstance
 

--- a/Mathlib/RingTheory/DedekindDomain/PID.lean
+++ b/Mathlib/RingTheory/DedekindDomain/PID.lean
@@ -210,8 +210,8 @@ theorem IsLocalization.OverPrime.mem_normalizedFactors_of_isPrime [IsDomain S]
       exact (IsLocalization.map_eq (T := Algebra.algebraMapSubmonoid S (primeCompl p))
         (Submonoid.le_comap_map _) x).symm
   obtain ⟨pid, p', ⟨hp'0, hp'p⟩, hpu⟩ :=
-    (DiscreteValuationRing.iff_pid_with_one_nonzero_prime (Localization.AtPrime p)).mp
-      (IsLocalization.AtPrime.discreteValuationRing_of_dedekind_domain R hp0 _)
+    (IsDiscreteValuationRing.iff_pid_with_one_nonzero_prime (Localization.AtPrime p)).mp
+      (IsLocalization.AtPrime.isDiscreteValuationRing_of_dedekind_domain R hp0 _)
   have : IsLocalRing.maximalIdeal (Localization.AtPrime p) ≠ ⊥ := by
     rw [Submodule.ne_bot_iff] at hp0 ⊢
     obtain ⟨x, x_mem, x_ne⟩ := hp0

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -24,7 +24,7 @@ book "Local Fields").
 
 Let R be an integral domain, assumed to be a principal ideal ring and a local ring.
 
-* `DiscreteValuationRing R` : a predicate expressing that R is a DVR.
+* `IsDiscreteValuationRing R` : a predicate expressing that R is a DVR.
 
 ### Definitions
 
@@ -46,13 +46,13 @@ open Ideal IsLocalRing
 
 /-- An integral domain is a *discrete valuation ring* (DVR) if it's a local PID which
   is not a field. -/
-class DiscreteValuationRing (R : Type u) [CommRing R] [IsDomain R]
+class IsDiscreteValuationRing (R : Type u) [CommRing R] [IsDomain R]
     extends IsPrincipalIdealRing R, IsLocalRing R : Prop where
   not_a_field' : maximalIdeal R ≠ ⊥
 
-namespace DiscreteValuationRing
+namespace IsDiscreteValuationRing
 
-variable (R : Type u) [CommRing R] [IsDomain R] [DiscreteValuationRing R]
+variable (R : Type u) [CommRing R] [IsDomain R] [IsDiscreteValuationRing R]
 
 theorem not_a_field : maximalIdeal R ≠ ⊥ :=
   not_a_field'
@@ -104,7 +104,7 @@ theorem exists_prime : ∃ ϖ : R, Prime ϖ :=
 
 /-- An integral domain is a DVR iff it's a PID with a unique non-zero prime ideal. -/
 theorem iff_pid_with_one_nonzero_prime (R : Type u) [CommRing R] [IsDomain R] :
-    DiscreteValuationRing R ↔ IsPrincipalIdealRing R ∧ ∃! P : Ideal R, P ≠ ⊥ ∧ IsPrime P := by
+    IsDiscreteValuationRing R ↔ IsPrincipalIdealRing R ∧ ∃! P : Ideal R, P ≠ ⊥ ∧ IsPrime P := by
   constructor
   · intro RDVR
     rcases id RDVR with ⟨Rlocal⟩
@@ -137,9 +137,9 @@ theorem associated_of_irreducible {a b : R} (ha : Irreducible a) (hb : Irreducib
   rw [irreducible_iff_uniformizer] at ha hb
   rw [← span_singleton_eq_span_singleton, ← ha, hb]
 
-end DiscreteValuationRing
+end IsDiscreteValuationRing
 
-namespace DiscreteValuationRing
+namespace IsDiscreteValuationRing
 
 variable (R : Type*)
 
@@ -179,7 +179,7 @@ variable [IsDomain R]
 
 /-- An integral domain in which there is an irreducible element `p`
 such that every nonzero element is associated to a power of `p` is a unique factorization domain.
-See `DiscreteValuationRing.ofHasUnitMulPowIrreducibleFactorization`. -/
+See `IsDiscreteValuationRing.ofHasUnitMulPowIrreducibleFactorization`. -/
 theorem toUniqueFactorizationMonoid (hR : HasUnitMulPowIrreducibleFactorization R) :
     UniqueFactorizationMonoid R :=
   let p := Classical.choose hR
@@ -269,7 +269,7 @@ is a discrete valuation ring.
 theorem of_ufd_of_unique_irreducible {R : Type u} [CommRing R] [IsDomain R]
     [UniqueFactorizationMonoid R] (h₁ : ∃ p : R, Irreducible p)
     (h₂ : ∀ ⦃p q : R⦄, Irreducible p → Irreducible q → Associated p q) :
-    DiscreteValuationRing R := by
+    IsDiscreteValuationRing R := by
   rw [iff_pid_with_one_nonzero_prime]
   haveI PID : IsPrincipalIdealRing R := aux_pid_of_ufd_of_unique_irreducible R h₁ h₂
   obtain ⟨p, hp⟩ := h₁
@@ -290,7 +290,7 @@ such that every nonzero element is associated to a power of `p`
 is a discrete valuation ring.
 -/
 theorem ofHasUnitMulPowIrreducibleFactorization {R : Type u} [CommRing R] [IsDomain R]
-    (hR : HasUnitMulPowIrreducibleFactorization R) : DiscreteValuationRing R := by
+    (hR : HasUnitMulPowIrreducibleFactorization R) : IsDiscreteValuationRing R := by
   letI : UniqueFactorizationMonoid R := hR.toUniqueFactorizationMonoid
   apply of_ufd_of_unique_irreducible _ hR.unique_irreducible
   obtain ⟨p, hp, H⟩ := hR
@@ -298,7 +298,7 @@ theorem ofHasUnitMulPowIrreducibleFactorization {R : Type u} [CommRing R] [IsDom
 
 section
 
-variable [CommRing R] [IsDomain R] [DiscreteValuationRing R]
+variable [CommRing R] [IsDomain R] [IsDiscreteValuationRing R]
 variable {R}
 
 theorem associated_pow_irreducible {x : R} (hx : x ≠ 0) {ϖ : R} (hirr : Irreducible ϖ) :
@@ -369,7 +369,7 @@ theorem unit_mul_pow_congr_unit {ϖ : R} (hirr : Irreducible ϖ) (u v : Rˣ) (m 
 
 open Classical in
 /-- The `ℕ∞`-valued additive valuation on a DVR. -/
-noncomputable def addVal (R : Type u) [CommRing R] [IsDomain R] [DiscreteValuationRing R] :
+noncomputable def addVal (R : Type u) [CommRing R] [IsDomain R] [IsDiscreteValuationRing R] :
     AddValuation R ℕ∞ :=
   multiplicity_addValuation (Classical.choose_spec (exists_prime R))
 
@@ -439,7 +439,7 @@ theorem addVal_add {a b : R} : min (addVal R a) (addVal R b) ≤ addVal R (a + b
 
 end
 
-instance (R : Type*) [CommRing R] [IsDomain R] [DiscreteValuationRing R] :
+instance (R : Type*) [CommRing R] [IsDomain R] [IsDiscreteValuationRing R] :
     IsHausdorff (maximalIdeal R) R where
   haus' x hx := by
     obtain ⟨ϖ, hϖ⟩ := exists_irreducible R
@@ -447,14 +447,14 @@ instance (R : Type*) [CommRing R] [IsDomain R] [DiscreteValuationRing R] :
       Ideal.span_singleton_pow, Ideal.mem_span_singleton, ← addVal_le_iff_dvd, hϖ.addVal_pow] at hx
     rwa [← addVal_eq_top_iff, ← WithTop.forall_ge_iff_eq_top]
 
-end DiscreteValuationRing
+end IsDiscreteValuationRing
 
 
 section
 
-variable (A : Type u) [CommRing A] [IsDomain A] [DiscreteValuationRing A]
+variable (A : Type u) [CommRing A] [IsDomain A] [IsDiscreteValuationRing A]
 
 /-- A DVR is a valuation ring. -/
-instance (priority := 100) of_discreteValuationRing : ValuationRing A := inferInstance
+instance (priority := 100) of_IsDiscreteValuationRing : ValuationRing A := inferInstance
 
 end

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -381,6 +381,7 @@ theorem addVal_def (r : R) (u : Rˣ) {ϖ : R} (hϖ : Irreducible ϖ) (n : ℕ) (
     emultiplicity_eq_of_associated_right (Associated.symm ⟨u, mul_comm _ _⟩),
     emultiplicity_pow_self_of_prime (irreducible_iff_prime.1 hϖ)]
 
+/-- An alternative definition of the additive valuation, taking units into account.-/
 theorem addVal_def' (u : Rˣ) {ϖ : R} (hϖ : Irreducible ϖ) (n : ℕ) :
     addVal R ((u : R) * ϖ ^ n) = n :=
   addVal_def _ u hϖ n rfl

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -456,6 +456,6 @@ section
 variable (A : Type u) [CommRing A] [IsDomain A] [IsDiscreteValuationRing A]
 
 /-- A DVR is a valuation ring. -/
-instance (priority := 100) of_IsDiscreteValuationRing : ValuationRing A := inferInstance
+instance (priority := 100) of_isDiscreteValuationRing : ValuationRing A := inferInstance
 
 end

--- a/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
@@ -12,7 +12,7 @@ import Mathlib.RingTheory.Ideal.Cotangent
 
 # Equivalent conditions for DVR
 
-In `DiscreteValuationRing.TFAE`, we show that the following are equivalent for a
+In `IsDiscreteValuationRing.TFAE`, we show that the following are equivalent for a
 noetherian local domain that is not a field `(R, m, k)`:
 - `R` is a discrete valuation ring
 - `R` is a valuation ring
@@ -47,7 +47,7 @@ theorem exists_maximalIdeal_pow_eq_of_principal [IsNoetherianRing R] [IsLocalRin
     rintro rfl
     apply Ring.ne_bot_of_isMaximal_of_not_isField (maximalIdeal.isMaximal R) h
     simp [hx]
-  have hx' := DiscreteValuationRing.irreducible_of_span_eq_maximalIdeal x this hx
+  have hx' := IsDiscreteValuationRing.irreducible_of_span_eq_maximalIdeal x this hx
   have H' : ∀ r : R, r ≠ 0 → r ∈ nonunits R → ∃ n : ℕ, Associated (x ^ n) r := by
     intro r hr₁ hr₂
     obtain ⟨f, hf₁, rfl, hf₂⟩ := (WfDvdMonoid.not_unit_iff_exists_factors_eq r hr₁).mp hr₂
@@ -157,7 +157,7 @@ The following are equivalent:
 5. `dimₖ m/m² ≤ 1`
 6. Every nonzero ideal is a power of `m`.
 
-Also see `DiscreteValuationRing.TFAE` for a version assuming `¬ IsField R`.
+Also see `IsDiscreteValuationRing.TFAE` for a version assuming `¬ IsField R`.
 -/
 theorem tfae_of_isNoetherianRing_of_isLocalRing_of_isDomain
     [IsNoetherianRing R] [IsLocalRing R] [IsDomain R] :
@@ -207,10 +207,10 @@ noetherian local domain that is not a field `(R, m, k)`:
 
 Also see `tfae_of_isNoetherianRing_of_isLocalRing_of_isDomain` for a version without `¬ IsField R`.
 -/
-theorem DiscreteValuationRing.TFAE [IsNoetherianRing R] [IsLocalRing R] [IsDomain R]
+theorem IsDiscreteValuationRing.TFAE [IsNoetherianRing R] [IsLocalRing R] [IsDomain R]
     (h : ¬IsField R) :
     List.TFAE
-      [DiscreteValuationRing R, ValuationRing R, IsDedekindDomain R,
+      [IsDiscreteValuationRing R, ValuationRing R, IsDedekindDomain R,
         IsIntegrallyClosed R ∧ ∃! P : Ideal R, P ≠ ⊥ ∧ P.IsPrime, (maximalIdeal R).IsPrincipal,
         finrank (ResidueField R) (CotangentSpace R) = 1,
         ∀ (I) (_ : I ≠ ⊥), ∃ n : ℕ, I = maximalIdeal R ^ n] := by
@@ -227,19 +227,19 @@ theorem DiscreteValuationRing.TFAE [IsNoetherianRing R] [IsLocalRing R] [IsDomai
 variable {R}
 
 lemma IsLocalRing.finrank_CotangentSpace_eq_one_iff [IsNoetherianRing R] [IsLocalRing R]
-    [IsDomain R] : finrank (ResidueField R) (CotangentSpace R) = 1 ↔ DiscreteValuationRing R := by
+    [IsDomain R] : finrank (ResidueField R) (CotangentSpace R) = 1 ↔ IsDiscreteValuationRing R := by
   by_cases hR : IsField R
   · letI := hR.toField
     simp only [finrank_cotangentSpace_eq_zero, zero_ne_one, false_iff]
     exact fun h ↦ h.3 maximalIdeal_eq_bot
-  · exact (DiscreteValuationRing.TFAE R hR).out 5 0
+  · exact (IsDiscreteValuationRing.TFAE R hR).out 5 0
 
 @[deprecated (since := "2024-11-09")]
 alias LocalRing.finrank_CotangentSpace_eq_one_iff := IsLocalRing.finrank_CotangentSpace_eq_one_iff
 
 variable (R)
 
-lemma IsLocalRing.finrank_CotangentSpace_eq_one [IsDomain R] [DiscreteValuationRing R] :
+lemma IsLocalRing.finrank_CotangentSpace_eq_one [IsDomain R] [IsDiscreteValuationRing R] :
     finrank (ResidueField R) (CotangentSpace R) = 1 :=
   finrank_CotangentSpace_eq_one_iff.mpr ‹_›
 

--- a/Mathlib/RingTheory/PowerSeries/Inverse.lean
+++ b/Mathlib/RingTheory/PowerSeries/Inverse.lean
@@ -284,11 +284,11 @@ instance : IsLocalRing R⟦X⟧ :=
 
 end IsLocalRing
 
-section DiscreteValuationRing
+section IsDiscreteValuationRing
 
 variable {k : Type*} [Field k]
 
-open DiscreteValuationRing
+open IsDiscreteValuationRing
 
 theorem hasUnitMulPowIrreducibleFactorization :
     HasUnitMulPowIrreducibleFactorization k⟦X⟧ :=
@@ -303,7 +303,7 @@ theorem hasUnitMulPowIrreducibleFactorization :
 instance : UniqueFactorizationMonoid k⟦X⟧ :=
   hasUnitMulPowIrreducibleFactorization.toUniqueFactorizationMonoid
 
-instance : DiscreteValuationRing k⟦X⟧ :=
+instance : IsDiscreteValuationRing k⟦X⟧ :=
   ofHasUnitMulPowIrreducibleFactorization hasUnitMulPowIrreducibleFactorization
 
 instance isNoetherianRing : IsNoetherianRing k⟦X⟧ :=
@@ -376,7 +376,7 @@ def residueFieldOfPowerSeries : ResidueField k⟦X⟧ ≃+* k :=
   (Ideal.quotEquivOfEq (ker_coeff_eq_max_ideal).symm).trans
     (RingHom.quotientKerEquivOfSurjective constantCoeff_surj)
 
-end DiscreteValuationRing
+end IsDiscreteValuationRing
 
 
 end PowerSeries

--- a/Mathlib/RingTheory/Valuation/ValuationRing.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationRing.lean
@@ -41,7 +41,7 @@ The `ValuationRing` class is kept to be in sync with the literature.
 
 -/
 
-assert_not_exists DiscreteValuationRing
+assert_not_exists IsDiscreteValuationRing
 
 universe u v w
 

--- a/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
+++ b/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
@@ -21,7 +21,7 @@ When `k` is also a field, this `b` can be chosen to be a unit of `𝕎 k`.
 
 * `WittVector.exists_eq_pow_p_mul`: the existence of this element `b` over a perfect ring
 * `WittVector.exists_eq_pow_p_mul'`: the existence of this unit `b` over a perfect field
-* `WittVector.discreteValuationRing`: `𝕎 k` is a discrete valuation ring if `k` is a perfect field
+* `WittVector.IsDiscreteValuationRing`: `𝕎 k` is a discrete valuation ring if `k` is a perfect field
 
 -/
 
@@ -147,8 +147,8 @@ https://github.com/leanprover/lean4/issues/1102
 -/
 /-- The ring of Witt Vectors of a perfect field of positive characteristic is a DVR.
 -/
-theorem discreteValuationRing : DiscreteValuationRing (𝕎 k) :=
-  DiscreteValuationRing.ofHasUnitMulPowIrreducibleFactorization (by
+theorem IsDiscreteValuationRing : IsDiscreteValuationRing (𝕎 k) :=
+  IsDiscreteValuationRing.ofHasUnitMulPowIrreducibleFactorization (by
     refine ⟨p, irreducible p, fun {x} hx => ?_⟩
     obtain ⟨n, b, hb⟩ := exists_eq_pow_p_mul' x hx
     exact ⟨n, b, hb.symm⟩)

--- a/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
+++ b/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
@@ -21,7 +21,7 @@ When `k` is also a field, this `b` can be chosen to be a unit of `𝕎 k`.
 
 * `WittVector.exists_eq_pow_p_mul`: the existence of this element `b` over a perfect ring
 * `WittVector.exists_eq_pow_p_mul'`: the existence of this unit `b` over a perfect field
-* `WittVector.IsDiscreteValuationRing`: `𝕎 k` is a discrete valuation ring if `k` is a perfect field
+* `WittVector.isDiscreteValuationRing`: `𝕎 k` is a discrete valuation ring if `k` is a perfect field
 
 -/
 

--- a/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
+++ b/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
@@ -147,7 +147,7 @@ https://github.com/leanprover/lean4/issues/1102
 -/
 /-- The ring of Witt Vectors of a perfect field of positive characteristic is a DVR.
 -/
-theorem IsDiscreteValuationRing : IsDiscreteValuationRing (𝕎 k) :=
+theorem isDiscreteValuationRing : IsDiscreteValuationRing (𝕎 k) :=
   IsDiscreteValuationRing.ofHasUnitMulPowIrreducibleFactorization (by
     refine ⟨p, irreducible p, fun {x} hx => ?_⟩
     obtain ⟨n, b, hb⟩ := exists_eq_pow_p_mul' x hx


### PR DESCRIPTION
In this PR we rename `DiscreteValuationRing` to `IsDiscreteValuationRing`, since the latter is `Prop`-valued.