### PR TITLE
[Merged by Bors] - feat: volume of Euclidean balls in even and odd dimensions

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean
@@ -6,6 +6,7 @@ Authors: Sébastien Gouëzel
 import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
 import Mathlib.Analysis.SpecialFunctions.PolarCoord
 import Mathlib.Analysis.Complex.Convex
+import Mathlib.Data.Nat.Factorial.DoubleFactorial
 
 /-!
 # Gaussian integral
@@ -351,3 +352,15 @@ theorem Complex.Gamma_one_half_eq : Complex.Gamma (1 / 2) = (π : ℂ) ^ (1 / 2 
   convert congr_arg ((↑) : ℝ → ℂ) Real.Gamma_one_half_eq
   · simpa only [one_div, ofReal_inv, ofReal_ofNat] using Gamma_ofReal (1 / 2)
   · rw [sqrt_eq_rpow, ofReal_cpow pi_pos.le, ofReal_div, ofReal_ofNat, ofReal_one]
+
+open scoped Nat in
+/-- The special-value formula `Γ(k + 1 + 1/2) = (2 * k + 1)‼ * √π / (2 ^ (k + 1))` for half-integer
+values of the gamma function in terms of `Nat.doubleFactorial`. -/
+lemma Real.Gamma_nat_add_one_add_half (k : ℕ) :
+    Gamma (k + 1 + 1 / 2) = (2 * k + 1 : ℕ)‼ * √π / (2 ^ (k + 1)) := by
+  induction k with
+  | zero => simp [- one_div, add_comm (1 : ℝ), Gamma_add_one, Gamma_one_half_eq]; ring
+  | succ k ih =>
+    rw [add_right_comm, Gamma_add_one (by positivity), Nat.cast_add, Nat.cast_one, ih]
+    field_simp
+    ring

--- a/Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean
@@ -359,8 +359,17 @@ values of the gamma function in terms of `Nat.doubleFactorial`. -/
 lemma Real.Gamma_nat_add_one_add_half (k : ℕ) :
     Gamma (k + 1 + 1 / 2) = (2 * k + 1 : ℕ)‼ * √π / (2 ^ (k + 1)) := by
   induction k with
-  | zero => simp [- one_div, add_comm (1 : ℝ), Gamma_add_one, Gamma_one_half_eq]; ring
+  | zero => simp [-one_div, add_comm (1 : ℝ), Gamma_add_one, Gamma_one_half_eq]; ring
   | succ k ih =>
     rw [add_right_comm, Gamma_add_one (by positivity), Nat.cast_add, Nat.cast_one, ih]
     field_simp
     ring
+
+open scoped Nat in
+/-- The special-value formula `Γ(k + 1/2) = (2 * k - 1)‼ * √π / (2 ^ k))` for half-integer
+values of the gamma function in terms of `Nat.doubleFactorial`. -/
+lemma Real.Gamma_nat_add_half (k : ℕ) :
+    Gamma (k + 1 / 2) = (2 * k - 1 : ℕ)‼ * √π / (2 ^ k) := by
+  cases k with
+  | zero => simp [- one_div, Gamma_one_half_eq]
+  | succ k => simpa [-one_div, mul_add] using Gamma_nat_add_one_add_half k

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -316,14 +316,9 @@ end LpSpace
 
 namespace EuclideanSpace
 
-variable (ι : Type*) [Fintype ι]
+variable (ι : Type*) [Nonempty ι] [Fintype ι]
 
-open scoped Nat
-open Fintype Real MeasureTheory MeasureTheory.Measure ENNReal Metric
-
-section Nonempty
-
-variable [Nonempty ι]
+open Fintype Real MeasureTheory MeasureTheory.Measure ENNReal
 
 theorem volume_ball (x : EuclideanSpace ℝ ι) (r : ℝ) :
     volume (Metric.ball x r) = (.ofReal r) ^ card ι *
@@ -352,60 +347,21 @@ alias Euclidean_space.volume_ball := EuclideanSpace.volume_ball
 @[deprecated (since := "2024-04-06")]
 alias Euclidean_space.volume_closedBall := EuclideanSpace.volume_closedBall
 
-lemma volume_ball_of_dim_even {k : ℕ} (hk : card ι = 2 * k) (x : EuclideanSpace ℝ ι) {r : ℝ}
-    (hr : 0 ≤ r) : volume (ball x r) = .ofReal (π ^ k * r ^ (card ι) / (k : ℕ)!) := by
-  rw [volume_ball, ← ofReal_pow hr, ← ofReal_mul (pow_nonneg hr _), hk,
-    pow_mul, pow_mul, sq_sqrt pi_nonneg]
-  simp only [Nat.cast_mul, Nat.cast_ofNat, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
-    mul_div_cancel_left₀]
-  rw [Real.Gamma_nat_eq_factorial]
-  ring_nf
-
-lemma volume_closedBall_of_dim_even {k : ℕ} (hk : card ι = 2 * k) (x : EuclideanSpace ℝ ι) {r : ℝ}
-    (hr : 0 ≤ r) : volume (closedBall x r) = .ofReal (π ^ k * r ^ (card ι) / (k : ℕ)!) := by
-  rw [addHaar_closedBall_eq_addHaar_ball, volume_ball_of_dim_even ι hk x hr]
-
-end Nonempty
-
-lemma volume_ball_of_dim_odd {k : ℕ} (hk : card ι = 2 * k + 1)
-    (x : EuclideanSpace ℝ ι) {r : ℝ} (hr : 0 ≤ r) :
-    volume (ball x r) = .ofReal (π ^ k * r ^ (card ι) * 2 ^ (k + 1) / (card ι : ℕ)‼) := by
-  have : Nonempty ι := card_pos_iff.mp (hk ▸ Nat.succ_pos _)
-  rw [volume_ball, ← ofReal_pow hr, ← ofReal_mul (pow_nonneg hr _), hk,
-    pow_succ (√π), pow_mul, sq_sqrt pi_nonneg]
-  simp? [add_div, add_right_comm, -one_div, Gamma_nat_add_one_add_half] says
-    simp only [Nat.cast_add, Nat.cast_mul, Nat.cast_ofNat, Nat.cast_one, add_div, ne_eq,
-      OfNat.ofNat_ne_zero, not_false_eq_true, mul_div_cancel_left₀, add_right_comm,
-      Gamma_nat_add_one_add_half]
-  have : 0 < √π := sqrt_pos_of_pos pi_pos
-  field_simp
-  ring
-
-lemma volume_closedBall_of_dim_odd {k : ℕ} (hk : card ι = 2 * k + 1)
-    (x : EuclideanSpace ℝ ι) {r : ℝ} (hr : 0 ≤ r) :
-    volume (closedBall x r) = .ofReal (π ^ k * r ^ (card ι) * 2 ^ (k + 1) / (card ι : ℕ)‼) := by
-  have : Nonempty ι := card_pos_iff.mp (hk ▸ Nat.succ_pos _)
-  rw [addHaar_closedBall_eq_addHaar_ball, volume_ball_of_dim_odd ι hk x hr]
-
-lemma volume_ball_of_dim_three (h_card : card ι = 3) (x : EuclideanSpace ℝ ι) {r : ℝ} (hr : 0 ≤ r) :
-    volume (ball x r) = .ofReal (π * r ^ 3 * 4 / 3) := by
-  norm_num [volume_ball_of_dim_odd ι (k := 1) (by simp [h_card]) x hr, h_card]
-
-lemma volume_closedBall_of_dim_three (h_card : card ι = 3) (x : EuclideanSpace ℝ ι) {r : ℝ}
-    (hr : 0 ≤ r) : volume (closedBall x r) = .ofReal (π * r ^ 3 * 4 / 3) := by
-  have : Nonempty ι := card_pos_iff.mp (h_card ▸ Nat.succ_pos _)
-  rw [addHaar_closedBall_eq_addHaar_ball, volume_ball_of_dim_three ι h_card x hr]
-
 end EuclideanSpace
 
-section InnerProductSpace
+namespace InnerProductSpace
 
-open MeasureTheory MeasureTheory.Measure ENNReal Real Module
+open scoped Nat
+open MeasureTheory MeasureTheory.Measure ENNReal Real Module Metric
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
-  [MeasurableSpace E] [BorelSpace E] [Nontrivial E]
+  [MeasurableSpace E] [BorelSpace E]
 
-theorem InnerProductSpace.volume_ball (x : E) (r : ℝ) :
+section Nontrivial
+
+variable [Nontrivial E]
+
+theorem volume_ball (x : E) (r : ℝ) :
     volume (Metric.ball x r) = (.ofReal r) ^ finrank ℝ E *
       .ofReal (sqrt π ^ finrank ℝ E / Gamma (finrank ℝ E / 2 + 1)) := by
   rw [← ((stdOrthonormalBasis ℝ E).measurePreserving_repr_symm).measure_preimage
@@ -416,12 +372,69 @@ theorem InnerProductSpace.volume_ball (x : E) (r : ℝ) :
   convert this
   simp only [LinearIsometryEquiv.preimage_ball, LinearIsometryEquiv.symm_symm, _root_.map_zero]
 
-theorem InnerProductSpace.volume_closedBall (x : E) (r : ℝ) :
+theorem volume_closedBall (x : E) (r : ℝ) :
     volume (Metric.closedBall x r) = (.ofReal r) ^ finrank ℝ E *
       .ofReal (sqrt π ^ finrank ℝ E / Gamma (finrank ℝ E / 2 + 1)) := by
   rw [addHaar_closedBall_eq_addHaar_ball, InnerProductSpace.volume_ball _]
 
+lemma volume_ball_of_dim_even {k : ℕ} (hk : finrank ℝ E = 2 * k) (x : E) (r : ℝ) :
+    volume (ball x r) = .ofReal r ^ finrank ℝ E * .ofReal (π ^ k / (k : ℕ)!) := by
+  rw [volume_ball, hk, pow_mul, pow_mul, sq_sqrt pi_nonneg]
+  congr
+  simp [Gamma_nat_eq_factorial]
+
+lemma volume_closedBall_of_dim_even {k : ℕ} (hk : finrank ℝ E = 2 * k) (x : E) (r : ℝ) :
+    volume (closedBall x r) = .ofReal r ^ finrank ℝ E * .ofReal (π ^ k / (k : ℕ)!) := by
+  rw [addHaar_closedBall_eq_addHaar_ball, volume_ball_of_dim_even hk x]
+
+end Nontrivial
+
+lemma volume_ball_of_dim_odd {k : ℕ} (hk : finrank ℝ E = 2 * k + 1) (x : E) (r : ℝ) :
+    volume (ball x r) =
+      .ofReal r ^ finrank ℝ E * .ofReal (π ^ k * 2 ^ (k + 1) / (finrank ℝ E : ℕ)‼) := by
+  have : Nontrivial E := Module.nontrivial_of_finrank_pos (R := ℝ) (hk ▸ (2 * k).succ_pos)
+  rw [volume_ball, hk, pow_succ (√π), pow_mul, sq_sqrt pi_nonneg, mul_div_assoc, mul_div_assoc]
+  congr 3
+  simp? [add_div, add_right_comm, -one_div, Gamma_nat_add_one_add_half] says
+    simp only [Nat.cast_add, Nat.cast_mul, Nat.cast_ofNat, Nat.cast_one, add_div, ne_eq,
+      OfNat.ofNat_ne_zero, not_false_eq_true, mul_div_cancel_left₀, add_right_comm,
+      Gamma_nat_add_one_add_half]
+  field_simp
+  ring
+
+lemma volume_closedBall_of_dim_odd {k : ℕ} (hk : finrank ℝ E = 2 * k + 1) (x : E) (r : ℝ) :
+    volume (closedBall x r) =
+      .ofReal r ^ finrank ℝ E * .ofReal (π ^ k * 2 ^ (k + 1) / (finrank ℝ E : ℕ)‼) := by
+  have : Nontrivial E := Module.nontrivial_of_finrank_pos (R := ℝ) (hk ▸ (2 * k).succ_pos)
+  rw [addHaar_closedBall_eq_addHaar_ball, volume_ball_of_dim_odd hk x r]
+
 end InnerProductSpace
+
+namespace EuclideanSpace
+
+open Real MeasureTheory MeasureTheory.Measure ENNReal Metric
+
+@[simp]
+lemma volume_ball_fin_two (x : EuclideanSpace ℝ (Fin 2)) (r : ℝ) :
+    volume (ball x r) = .ofReal r ^ 2 * .ofReal π := by
+  norm_num [InnerProductSpace.volume_ball_of_dim_even (k := 1) (by simp) x]
+
+@[simp]
+lemma volume_closedBall_fin_two (x : EuclideanSpace ℝ (Fin 2)) (r : ℝ) :
+    volume (closedBall x r) = .ofReal r ^ 2 * .ofReal π := by
+  rw [addHaar_closedBall_eq_addHaar_ball, volume_ball_fin_two x r]
+
+@[simp]
+lemma volume_ball_fin_three (x : EuclideanSpace ℝ (Fin 3)) (r : ℝ) :
+    volume (ball x r) = .ofReal r ^ 3 * .ofReal (π * 4 / 3) := by
+  norm_num [InnerProductSpace.volume_ball_of_dim_odd (k := 1) (by simp) x]
+
+@[simp]
+lemma volume_closedBall_fin_three (x : EuclideanSpace ℝ (Fin 3)) (r : ℝ) :
+    volume (closedBall x r) = .ofReal r ^ 3 * .ofReal (π * 4 / 3) := by
+  rw [addHaar_closedBall_eq_addHaar_ball, volume_ball_fin_three x]
+
+end EuclideanSpace
 
 section Complex
 

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -3,11 +3,11 @@ Copyright (c) 2023 Xavier Roblot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Xavier Roblot
 -/
-import Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup
 import Mathlib.Data.Complex.FiniteDimensional
 import Mathlib.MeasureTheory.Constructions.HaarToSphere
 import Mathlib.MeasureTheory.Integral.Gamma
 import Mathlib.MeasureTheory.Integral.Pi
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
 
 /-!
 # Volume of balls

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -314,13 +314,18 @@ theorem Complex.volume_sum_rpow_le [Nonempty ι] {p : ℝ} (hp : 1 ≤ p) (r : �
 
 end LpSpace
 
-section EuclideanSpace
+namespace EuclideanSpace
 
-variable (ι : Type*) [Nonempty ι] [Fintype ι]
+variable (ι : Type*) [Fintype ι]
 
-open Fintype Real MeasureTheory MeasureTheory.Measure ENNReal
+open scoped Nat
+open Fintype Real MeasureTheory MeasureTheory.Measure ENNReal Metric
 
-theorem EuclideanSpace.volume_ball (x : EuclideanSpace ℝ ι) (r : ℝ) :
+section Nonempty
+
+variable [Nonempty ι]
+
+theorem volume_ball (x : EuclideanSpace ℝ ι) (r : ℝ) :
     volume (Metric.ball x r) = (.ofReal r) ^ card ι *
       .ofReal (Real.sqrt π ^ card ι / Gamma (card ι / 2 + 1)) := by
   obtain hr | hr := le_total r 0
@@ -329,15 +334,15 @@ theorem EuclideanSpace.volume_ball (x : EuclideanSpace ℝ ι) (r : ℝ) :
   · suffices volume (Metric.ball (0 : EuclideanSpace ℝ ι) 1) =
         .ofReal (Real.sqrt π ^ card ι / Gamma (card ι / 2 + 1)) by
       rw [Measure.addHaar_ball _ _ hr, this, ofReal_pow hr, finrank_euclideanSpace]
-    rw [← ((EuclideanSpace.volume_preserving_measurableEquiv _).symm).measure_preimage
+    rw [← ((volume_preserving_measurableEquiv _).symm).measure_preimage
       measurableSet_ball.nullMeasurableSet]
     convert (volume_sum_rpow_lt_one ι one_le_two) using 4
-    · simp_rw [EuclideanSpace.ball_zero_eq _ zero_le_one, one_pow, Real.rpow_two, sq_abs,
+    · simp_rw [ball_zero_eq _ zero_le_one, one_pow, Real.rpow_two, sq_abs,
         Set.setOf_app_iff]
     · rw [Gamma_add_one (by norm_num), Gamma_one_half_eq, ← mul_assoc, mul_div_cancel₀ _
         two_ne_zero, one_mul]
 
-theorem EuclideanSpace.volume_closedBall (x : EuclideanSpace ℝ ι) (r : ℝ) :
+theorem volume_closedBall (x : EuclideanSpace ℝ ι) (r : ℝ) :
     volume (Metric.closedBall x r) = (.ofReal r) ^ card ι *
       .ofReal (sqrt π ^ card ι / Gamma (card ι / 2 + 1)) := by
   rw [addHaar_closedBall_eq_addHaar_ball, EuclideanSpace.volume_ball]
@@ -346,6 +351,50 @@ theorem EuclideanSpace.volume_closedBall (x : EuclideanSpace ℝ ι) (r : ℝ) :
 alias Euclidean_space.volume_ball := EuclideanSpace.volume_ball
 @[deprecated (since := "2024-04-06")]
 alias Euclidean_space.volume_closedBall := EuclideanSpace.volume_closedBall
+
+lemma volume_ball_of_dim_even {k : ℕ} (hk : card ι = 2 * k) (x : EuclideanSpace ℝ ι) {r : ℝ}
+    (hr : 0 ≤ r) : volume (ball x r) = .ofReal (π ^ k * r ^ (card ι) / (k : ℕ)!) := by
+  rw [volume_ball, ← ofReal_pow hr, ← ofReal_mul (pow_nonneg hr _), hk,
+    pow_mul, pow_mul, sq_sqrt pi_nonneg]
+  simp only [Nat.cast_mul, Nat.cast_ofNat, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
+    mul_div_cancel_left₀]
+  rw [Real.Gamma_nat_eq_factorial]
+  ring_nf
+
+lemma volume_closedBall_of_dim_even {k : ℕ} (hk : card ι = 2 * k) (x : EuclideanSpace ℝ ι) {r : ℝ}
+    (hr : 0 ≤ r) : volume (closedBall x r) = .ofReal (π ^ k * r ^ (card ι) / (k : ℕ)!) := by
+  rw [addHaar_closedBall_eq_addHaar_ball, volume_ball_of_dim_even ι hk x hr]
+
+end Nonempty
+
+lemma volume_ball_of_dim_odd {k : ℕ} (hk : card ι = 2 * k + 1)
+    (x : EuclideanSpace ℝ ι) {r : ℝ} (hr : 0 ≤ r) :
+    volume (ball x r) = .ofReal (π ^ k * r ^ (card ι) * 2 ^ (k + 1) / (card ι : ℕ)‼) := by
+  have : Nonempty ι := card_pos_iff.mp (hk ▸ Nat.succ_pos _)
+  rw [volume_ball, ← ofReal_pow hr, ← ofReal_mul (pow_nonneg hr _), hk,
+    pow_succ (√π), pow_mul, sq_sqrt pi_nonneg]
+  simp? [add_div, add_right_comm, -one_div, Gamma_nat_add_one_add_half] says
+    simp only [Nat.cast_add, Nat.cast_mul, Nat.cast_ofNat, Nat.cast_one, add_div, ne_eq,
+      OfNat.ofNat_ne_zero, not_false_eq_true, mul_div_cancel_left₀, add_right_comm,
+      Gamma_nat_add_one_add_half]
+  have : 0 < √π := sqrt_pos_of_pos pi_pos
+  field_simp
+  ring
+
+lemma volume_closedBall_of_dim_odd {k : ℕ} (hk : card ι = 2 * k + 1)
+    (x : EuclideanSpace ℝ ι) {r : ℝ} (hr : 0 ≤ r) :
+    volume (closedBall x r) = .ofReal (π ^ k * r ^ (card ι) * 2 ^ (k + 1) / (card ι : ℕ)‼) := by
+  have : Nonempty ι := card_pos_iff.mp (hk ▸ Nat.succ_pos _)
+  rw [addHaar_closedBall_eq_addHaar_ball, volume_ball_of_dim_odd ι hk x hr]
+
+lemma volume_ball_of_dim_three (h_card : card ι = 3) (x : EuclideanSpace ℝ ι) {r : ℝ} (hr : 0 ≤ r) :
+    volume (ball x r) = .ofReal (π * r ^ 3 * 4 / 3) := by
+  norm_num [volume_ball_of_dim_odd ι (k := 1) (by simp [h_card]) x hr, h_card]
+
+lemma volume_closedBall_of_dim_three (h_card : card ι = 3) (x : EuclideanSpace ℝ ι) {r : ℝ}
+    (hr : 0 ≤ r) : volume (closedBall x r) = .ofReal (π * r ^ 3 * 4 / 3) := by
+  have : Nonempty ι := card_pos_iff.mp (h_card ▸ Nat.succ_pos _)
+  rw [addHaar_closedBall_eq_addHaar_ball, volume_ball_of_dim_three ι h_card x hr]
 
 end EuclideanSpace
 

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -443,8 +443,7 @@ open MeasureTheory MeasureTheory.Measure ENNReal
 @[simp]
 theorem Complex.volume_ball (a : ℂ) (r : ℝ) :
     volume (Metric.ball a r) = .ofReal r ^ 2 * NNReal.pi := by
-  rw [InnerProductSpace.volume_ball a r, finrank_real_complex, Nat.cast_ofNat, div_self two_ne_zero,
-    one_add_one_eq_two, Real.Gamma_two, div_one, Real.sq_sqrt (by positivity),
+  simp [InnerProductSpace.volume_ball_of_dim_even (k := 1) (by simp) a,
     ← NNReal.coe_real_pi, ofReal_coe_nnreal]
 
 @[simp]

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -6,6 +6,7 @@ Authors: Xavier Roblot
 import Mathlib.MeasureTheory.Group.GeometryOfNumbers
 import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
 import Mathlib.NumberTheory.NumberField.CanonicalEmbedding.Basic
+import Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup
 
 /-!
 # Convex Bodies


### PR DESCRIPTION
The formula in terms of the Gamma function is nice, as it is not necessary to split on whether the dimension is even or odd, but for specific calculations (e.g., the volume of a ball in three dimensions), it's nice to have these more specific versions.

Written as a consequence of [Zulip](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/How.20can.20I.20convert.20a.20sphere.20into.20a.20ball.3F).

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
