### PR TITLE
[Merged by Bors] - feat: `aeval` a Chebyshev polynomial

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.Data.Complex.Exponential
 import Mathlib.Data.Complex.Module
 import Mathlib.RingTheory.Polynomial.Chebyshev
@@ -22,24 +21,6 @@ open Polynomial
 
 variable {R A : Type*} [CommRing R] [CommRing A] [Algebra R A]
 
-@[simp]
-theorem aeval_T (x : A) (n : ℤ) : aeval x (T R n) = (T A n).eval x := by
-  rw [aeval_def, eval₂_eq_eval_map, map_T]
-
-@[simp]
-theorem aeval_U (x : A) (n : ℤ) : aeval x (U R n) = (U A n).eval x := by
-  rw [aeval_def, eval₂_eq_eval_map, map_U]
-
-@[simp]
-theorem algebraMap_eval_T (x : R) (n : ℤ) :
-    algebraMap R A ((T R n).eval x) = (T A n).eval (algebraMap R A x) := by
-  rw [← aeval_algebraMap_apply_eq_algebraMap_eval, aeval_T]
-
-@[simp]
-theorem algebraMap_eval_U (x : R) (n : ℤ) :
-    algebraMap R A ((U R n).eval x) = (U A n).eval (algebraMap R A x) := by
-  rw [← aeval_algebraMap_apply_eq_algebraMap_eval, aeval_U]
-
 -- Porting note: added type ascriptions to the statement
 @[simp, norm_cast]
 theorem complex_ofReal_eval_T : ∀ (x : ℝ) n, (((T ℝ n).eval x : ℝ) : ℂ) = (T ℂ n).eval (x : ℂ) :=
@@ -49,6 +30,14 @@ theorem complex_ofReal_eval_T : ∀ (x : ℝ) n, (((T ℝ n).eval x : ℝ) : ℂ
 @[simp, norm_cast]
 theorem complex_ofReal_eval_U : ∀ (x : ℝ) n, (((U ℝ n).eval x : ℝ) : ℂ) = (U ℂ n).eval (x : ℂ) :=
   @algebraMap_eval_U ℝ ℂ _ _ _
+
+@[simp, norm_cast]
+theorem complex_ofReal_eval_C : ∀ (x : ℝ) n, (((C ℝ n).eval x : ℝ) : ℂ) = (C ℂ n).eval (x : ℂ) :=
+  @algebraMap_eval_C ℝ ℂ _ _ _
+
+@[simp, norm_cast]
+theorem complex_ofReal_eval_S : ∀ (x : ℝ) n, (((S ℝ n).eval x : ℝ) : ℂ) = (S ℂ n).eval (x : ℂ) :=
+  @algebraMap_eval_S ℝ ℂ _ _ _
 
 /-! ### Complex versions -/
 
@@ -130,14 +119,14 @@ theorem U_real_cos : (U ℝ n).eval (cos θ) * sin θ = sin ((n + 1) * θ) :=
 /-- The `n`-th rescaled Chebyshev polynomial of the first kind (Vieta–Lucas polynomial) evaluates on
 `2 * cos θ` to the value `2 * cos (n * θ)`. -/
 @[simp]
-theorem C_two_mul_real_cos : (C ℝ n).eval (2 * cos θ) = 2 * cos (n * θ) := by
-  simp [C_eq_two_mul_T_comp_half_mul_X]
+theorem C_two_mul_real_cos : (C ℝ n).eval (2 * cos θ) = 2 * cos (n * θ) :=
+  mod_cast C_two_mul_complex_cos θ n
 
 /-- The `n`-th rescaled Chebyshev polynomial of the second kind (Vieta–Fibonacci polynomial)
 evaluates on `2 * cos θ` to the value `sin ((n + 1) * θ) / sin θ`. -/
 @[simp]
-theorem S_two_mul_real_cos : (S ℝ n).eval (2 * cos θ) * sin θ = sin ((n + 1) * θ) := by
-  simp [S_eq_U_comp_half_mul_X]
+theorem S_two_mul_real_cos : (S ℝ n).eval (2 * cos θ) * sin θ = sin ((n + 1) * θ) :=
+  mod_cast S_two_mul_complex_cos θ n
 
 end Real
 

--- a/Mathlib/RingTheory/Polynomial/Chebyshev.lean
+++ b/Mathlib/RingTheory/Polynomial/Chebyshev.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Julian Kuelshammer, Heather Macbeth, Mitchell Lee
 -/
+import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.Algebra.Polynomial.Derivative
 import Mathlib.Tactic.LinearCombination
 
@@ -452,6 +453,42 @@ theorem map_S (f : R →+* R') (n : ℤ) : map f (S R n) = S R' n := by
     simp_rw [S_add_two, Polynomial.map_sub, Polynomial.map_mul, map_X, ih1, ih2]
   | neg_add_one n ih1 ih2 =>
     simp_rw [S_sub_one, Polynomial.map_sub, Polynomial.map_mul, map_X, ih1, ih2]
+
+@[simp]
+theorem aeval_T [Algebra R R'] (x : R') (n : ℤ) : aeval x (T R n) = (T R' n).eval x := by
+  rw [aeval_def, eval₂_eq_eval_map, map_T]
+
+@[simp]
+theorem aeval_U [Algebra R R'] (x : R') (n : ℤ) : aeval x (U R n) = (U R' n).eval x := by
+  rw [aeval_def, eval₂_eq_eval_map, map_U]
+
+@[simp]
+theorem aeval_C [Algebra R R'] (x : R') (n : ℤ) : aeval x (C R n) = (C R' n).eval x := by
+  rw [aeval_def, eval₂_eq_eval_map, map_C]
+
+@[simp]
+theorem aeval_S [Algebra R R'] (x : R') (n : ℤ) : aeval x (S R n) = (S R' n).eval x := by
+  rw [aeval_def, eval₂_eq_eval_map, map_S]
+
+@[simp]
+theorem algebraMap_eval_T [Algebra R R'] (x : R) (n : ℤ) :
+    algebraMap R R' ((T R n).eval x) = (T R' n).eval (algebraMap R R' x) := by
+  rw [← aeval_algebraMap_apply_eq_algebraMap_eval, aeval_T]
+
+@[simp]
+theorem algebraMap_eval_U [Algebra R R'] (x : R) (n : ℤ) :
+    algebraMap R R' ((U R n).eval x) = (U R' n).eval (algebraMap R R' x) := by
+  rw [← aeval_algebraMap_apply_eq_algebraMap_eval, aeval_U]
+
+@[simp]
+theorem algebraMap_eval_C [Algebra R R'] (x : R) (n : ℤ) :
+    algebraMap R R' ((C R n).eval x) = (C R' n).eval (algebraMap R R' x) := by
+  rw [← aeval_algebraMap_apply_eq_algebraMap_eval, aeval_C]
+
+@[simp]
+theorem algebraMap_eval_S [Algebra R R'] (x : R) (n : ℤ) :
+    algebraMap R R' ((S R n).eval x) = (S R' n).eval (algebraMap R R' x) := by
+  rw [← aeval_algebraMap_apply_eq_algebraMap_eval, aeval_S]
 
 theorem T_derivative_eq_U (n : ℤ) : derivative (T R n) = n * U R (n - 1) := by
   induction n using Polynomial.Chebyshev.induct with


### PR DESCRIPTION
The theorem `Polynomial.Chebyshev.aeval_T` states that if `R'` is an algebra over `R`, then `aeval x (T R n) = (T R' n).eval x`. We move this theorem and the equivalent `Polynomial.Chebyshev.algebraMap_eval_T`  from `Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev.lean` to `Mathlib/RingTheory/Polynomial/Chebyshev.lean`. We also add variants of this theorem for the Chebyshev C and S polynomials.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
