### PR TITLE
[Merged by Bors] - style(Algebra/Category/Grp/Basic and Algebra/Category/MonCat/Basic): universe order in `uliftFunctor`

### DIFF
--- a/Mathlib/Algebra/Category/Grp/Basic.lean
+++ b/Mathlib/Algebra/Category/Grp/Basic.lean
@@ -142,8 +142,8 @@ example {R S : Grp} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 := by simp [h]
 /-- Universe lift functor for groups. -/
 @[to_additive (attr := simps)
   "Universe lift functor for additive groups."]
-def uliftFunctor : Grp.{u} ⥤ Grp.{max u v} where
-  obj X := Grp.of (ULift.{v, u} X)
+def uliftFunctor : Grp.{v} ⥤ Grp.{max v u} where
+  obj X := Grp.of (ULift.{u, v} X)
   map {_ _} f := Grp.ofHom <|
     MulEquiv.ulift.symm.toMonoidHom.comp <| f.comp MulEquiv.ulift.toMonoidHom
   map_id X := by rfl
@@ -283,8 +283,8 @@ example {R S : CommGrp} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 := by simp [
 /-- Universe lift functor for commutative groups. -/
 @[to_additive (attr := simps)
   "Universe lift functor for additive commutative groups."]
-def uliftFunctor : CommGrp.{u} ⥤ CommGrp.{max u v} where
-  obj X := CommGrp.of (ULift.{v, u} X)
+def uliftFunctor : CommGrp.{v} ⥤ CommGrp.{max v u} where
+  obj X := CommGrp.of (ULift.{u, v} X)
   map {_ _} f := CommGrp.ofHom <|
     MulEquiv.ulift.symm.toMonoidHom.comp <| f.comp MulEquiv.ulift.toMonoidHom
   map_id X := by rfl

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -143,8 +143,8 @@ instance {G : Type*} [Group G] : Group (MonCat.of G) := by assumption
 /-- Universe lift functor for monoids. -/
 @[to_additive (attr := simps)
   "Universe lift functor for additive monoids."]
-def uliftFunctor : MonCat.{u} ⥤ MonCat.{max u v} where
-  obj X := MonCat.of (ULift.{v, u} X)
+def uliftFunctor : MonCat.{v} ⥤ MonCat.{max v u} where
+  obj X := MonCat.of (ULift.{u, v} X)
   map {_ _} f := MonCat.ofHom <|
     MulEquiv.ulift.symm.toMonoidHom.comp <| f.comp MulEquiv.ulift.toMonoidHom
   map_id X := by rfl
@@ -247,8 +247,8 @@ lemma ofHom_apply {X Y : Type u} [CommMonoid X] [CommMonoid Y] (f : X →* Y) (x
 /-- Universe lift functor for commutative monoids. -/
 @[to_additive (attr := simps)
   "Universe lift functor for additive commutative monoids."]
-def uliftFunctor : CommMonCat.{u} ⥤ CommMonCat.{max u v} where
-  obj X := CommMonCat.of (ULift.{v, u} X)
+def uliftFunctor : CommMonCat.{v} ⥤ CommMonCat.{max v u} where
+  obj X := CommMonCat.of (ULift.{u, v} X)
   map {_ _} f := CommMonCat.ofHom <|
     MulEquiv.ulift.symm.toMonoidHom.comp <| f.comp MulEquiv.ulift.toMonoidHom
   map_id X := by rfl


### PR DESCRIPTION
Change the order of universes in the `uliftFunctor`s on the group and monoid categories so they will agree with the order used for `CategoryTheory.uliftFunctor` and `SSet.uliftFunctor` (that is, `uliftFunctor.{u,v}` should go from the category of doodads in `Type v` to the category of similar doodads in `Type (max v u)`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
