### PR TITLE
[Merged by Bors] - feat(SetTheory): the predicate HasCardinalLT

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4660,6 +4660,7 @@ import Mathlib.SetTheory.Cardinal.ENat
 import Mathlib.SetTheory.Cardinal.Finite
 import Mathlib.SetTheory.Cardinal.Finsupp
 import Mathlib.SetTheory.Cardinal.Free
+import Mathlib.SetTheory.Cardinal.HasCardinalLT
 import Mathlib.SetTheory.Cardinal.SchroederBernstein
 import Mathlib.SetTheory.Cardinal.Subfield
 import Mathlib.SetTheory.Cardinal.ToNat

--- a/Mathlib/SetTheory/Cardinal/HasCardinalLT.lean
+++ b/Mathlib/SetTheory/Cardinal/HasCardinalLT.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-import Mathlib.SetTheory.Cardinal.UnivLE
+import Mathlib.SetTheory.Ordinal.Basic
 
 /-!
 # The property of being of cardinality less than a cardinal

--- a/Mathlib/SetTheory/Cardinal/HasCardinalLT.lean
+++ b/Mathlib/SetTheory/Cardinal/HasCardinalLT.lean
@@ -73,6 +73,6 @@ lemma hasCardinalLT_iff_of_equiv {X : Type u} {Y : Type u'} (e : X ≃ Y) (κ : 
     fun h ↦ h.of_injective _ e.injective⟩
 
 @[simp]
-lemma hasCardinalLT_aleph0 (X : Type u) :
+lemma hasCardinalLT_aleph0_iff (X : Type u) :
     HasCardinalLT X Cardinal.aleph0.{v} ↔ Finite X := by
   simpa [HasCardinalLT] using Cardinal.mk_lt_aleph0_iff

--- a/Mathlib/SetTheory/Cardinal/HasCardinalLT.lean
+++ b/Mathlib/SetTheory/Cardinal/HasCardinalLT.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.SetTheory.Cardinal.Basic
+
+/-!
+# The property of being of cardinality less than a cardinal
+
+Given `X : Type u` and `κ : Cardinal.{v}`, we introduce a predicate
+`HasCardinalLT X κ` expressing that
+`Cardinal.mk (ULift.{v} X) < Cardinal.lift κ`.
+
+-/
+
+universe w v u u'
+
+/-- The property that the cardinal of a type `X : Type u` is less than `κ : Cardinal.{v}`. -/
+def HasCardinalLT (X : Type u) (κ : Cardinal.{v}) : Prop :=
+  Cardinal.mk (ULift.{v} X) < Cardinal.lift κ
+
+lemma hasCardinalLT_iff_cardinal_mk_lt (X : Type u) (κ : Cardinal.{u}) :
+    HasCardinalLT X κ ↔ Cardinal.mk X < κ := by
+  simp [HasCardinalLT]
+
+namespace HasCardinalLT
+
+section
+
+variable {X : Type u} {κ : Cardinal.{v}} (h : HasCardinalLT X κ)
+
+include h
+
+lemma small : Small.{v} X := by
+  induction' κ using Cardinal.inductionOn  with Y
+  replace h := (Cardinal.le_def _ _).1 h.le
+  obtain ⟨f, hf⟩ := h
+  exact small_of_injective (Function.Injective.comp ULift.down_injective
+    (Function.Injective.comp hf ULift.up_injective))
+
+lemma of_le {κ' : Cardinal.{v}} (hκ' : κ ≤ κ') :
+    HasCardinalLT X κ' :=
+  lt_of_lt_of_le h (by simpa only [Cardinal.lift_le] using hκ')
+
+variable {Y : Type u'}
+
+lemma of_injective (f : Y → X) (hf : Function.Injective f) :
+    HasCardinalLT Y κ := by
+  dsimp [HasCardinalLT] at h ⊢
+  rw [← Cardinal.lift_lt.{_, u}, Cardinal.lift_lift, Cardinal.lift_lift]
+  rw [← Cardinal.lift_lt.{_, u'}, Cardinal.lift_lift, Cardinal.lift_lift] at h
+  exact lt_of_le_of_lt (Cardinal.mk_le_of_injective
+    (Function.Injective.comp ULift.up_injective
+      (Function.Injective.comp hf ULift.down_injective))) h
+
+lemma of_surjective (f : X → Y) (hf : Function.Surjective f) :
+    HasCardinalLT Y κ := by
+  dsimp [HasCardinalLT] at h ⊢
+  rw [← Cardinal.lift_lt.{_, u}, Cardinal.lift_lift, Cardinal.lift_lift]
+  rw [← Cardinal.lift_lt.{_, u'}, Cardinal.lift_lift, Cardinal.lift_lift] at h
+  exact lt_of_le_of_lt (Cardinal.mk_le_of_surjective
+    (Function.Surjective.comp ULift.up_surjective (Function.Surjective.comp hf
+      ULift.down_surjective))) h
+
+end
+
+end HasCardinalLT
+
+lemma hasCardinalLT_iff_of_equiv {X : Type u} {Y : Type u'} (e : X ≃ Y) (κ : Cardinal.{v}) :
+    HasCardinalLT X κ ↔ HasCardinalLT Y κ :=
+  ⟨fun h ↦ h.of_injective _ e.symm.injective,
+    fun h ↦ h.of_injective _ e.injective⟩
+
+@[simp]
+lemma hasCardinalLT_aleph0 (X : Type u) :
+    HasCardinalLT X Cardinal.aleph0.{v} ↔ Finite X := by
+  simpa [HasCardinalLT] using Cardinal.mk_lt_aleph0_iff

--- a/Mathlib/SetTheory/Cardinal/HasCardinalLT.lean
+++ b/Mathlib/SetTheory/Cardinal/HasCardinalLT.lean
@@ -10,7 +10,7 @@ import Mathlib.SetTheory.Cardinal.UnivLE
 
 Given `X : Type u` and `κ : Cardinal.{v}`, we introduce a predicate
 `HasCardinalLT X κ` expressing that
-`Cardinal.mk (ULift.{v} X) < Cardinal.lift κ`.
+`Cardinal.lift.{v} (Cardinal.mk X) < Cardinal.lift κ`.
 
 -/
 

--- a/Mathlib/SetTheory/Cardinal/HasCardinalLT.lean
+++ b/Mathlib/SetTheory/Cardinal/HasCardinalLT.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-import Mathlib.SetTheory.Cardinal.Basic
+import Mathlib.SetTheory.Cardinal.UnivLE
 
 /-!
 # The property of being of cardinality less than a cardinal
@@ -18,7 +18,7 @@ universe w v u u'
 
 /-- The property that the cardinal of a type `X : Type u` is less than `κ : Cardinal.{v}`. -/
 def HasCardinalLT (X : Type u) (κ : Cardinal.{v}) : Prop :=
-  Cardinal.mk (ULift.{v} X) < Cardinal.lift κ
+  Cardinal.lift.{v} (Cardinal.mk X) < Cardinal.lift κ
 
 lemma hasCardinalLT_iff_cardinal_mk_lt (X : Type u) (κ : Cardinal.{u}) :
     HasCardinalLT X κ ↔ Cardinal.mk X < κ := by
@@ -33,11 +33,9 @@ variable {X : Type u} {κ : Cardinal.{v}} (h : HasCardinalLT X κ)
 include h
 
 lemma small : Small.{v} X := by
-  induction' κ using Cardinal.inductionOn  with Y
-  replace h := (Cardinal.le_def _ _).1 h.le
-  obtain ⟨f, hf⟩ := h
-  exact small_of_injective (Function.Injective.comp ULift.down_injective
-    (Function.Injective.comp hf ULift.up_injective))
+  dsimp [HasCardinalLT] at h
+  rw [← Cardinal.lift_lt.{_, v + 1}, Cardinal.lift_lift, Cardinal.lift_lift] at h
+  simpa only [Cardinal.small_iff_lift_mk_lt_univ] using h.trans (Cardinal.lift_lt_univ' κ)
 
 lemma of_le {κ' : Cardinal.{v}} (hκ' : κ ≤ κ') :
     HasCardinalLT X κ' :=


### PR DESCRIPTION
We introduce the universe-heterogeneous predicate `HasCardinalLT X κ` for `X : Type u` and `κ : Cardinal.{v}` saying that the cardinal of `X` is (strictly) less than `κ`. (This shall be used in the formalization of `κ`-filtered categories, which generalize filtered categories.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
