### PR TITLE
[Merged by Bors] - chore(Data/List/AList): Rename `insert_of_neg` and similar to `insert_of_not_mem`

### DIFF
--- a/Mathlib/Data/Finmap.lean
+++ b/Mathlib/Data/Finmap.lean
@@ -417,13 +417,13 @@ theorem insert_toFinmap (a : α) (b : β a) (s : AList β) :
     insert a b (AList.toFinmap s) = AList.toFinmap (s.insert a b) := by
   simp [insert]
 
-theorem insert_entries_of_not_mem {a : α} {b : β a} {s : Finmap β} :
+theorem entries_insert_of_not_mem {a : α} {b : β a} {s : Finmap β} :
     a ∉ s → (insert a b s).entries = ⟨a, b⟩ ::ₘ s.entries :=
   induction_on s fun s h => by
     -- Porting note: `-insert_entries` required
-    simp [AList.insert_entries_of_not_mem (mt mem_toFinmap.1 h), -insert_entries]
+    simp [AList.entries_insert_of_not_mem (mt mem_toFinmap.1 h), -insert_entries]
 
-@[deprecated (since := "2024-12-14")] alias insert_entries_of_neg := insert_entries_of_not_mem
+@[deprecated (since := "2024-12-14")] alias insert_entries_of_neg := entries_insert_of_not_mem
 
 @[simp]
 theorem mem_insert {a a' : α} {b' : β a'} {s : Finmap β} : a ∈ insert a' b' s ↔ a = a' ∨ a ∈ s :=

--- a/Mathlib/Data/Finmap.lean
+++ b/Mathlib/Data/Finmap.lean
@@ -417,11 +417,13 @@ theorem insert_toFinmap (a : α) (b : β a) (s : AList β) :
     insert a b (AList.toFinmap s) = AList.toFinmap (s.insert a b) := by
   simp [insert]
 
-theorem insert_entries_of_neg {a : α} {b : β a} {s : Finmap β} :
+theorem insert_entries_of_not_mem {a : α} {b : β a} {s : Finmap β} :
     a ∉ s → (insert a b s).entries = ⟨a, b⟩ ::ₘ s.entries :=
   induction_on s fun s h => by
     -- Porting note: `-insert_entries` required
-    simp [AList.insert_entries_of_neg (mt mem_toFinmap.1 h), -insert_entries]
+    simp [AList.insert_entries_of_not_mem (mt mem_toFinmap.1 h), -insert_entries]
+
+@[deprecated (since := "2024-12-14")] alias insert_entries_of_neg := insert_entries_of_not_mem
 
 @[simp]
 theorem mem_insert {a a' : α} {b' : β a'} {s : Finmap β} : a ∈ insert a' b' s ↔ a = a' ∨ a ∈ s :=

--- a/Mathlib/Data/Finmap.lean
+++ b/Mathlib/Data/Finmap.lean
@@ -420,8 +420,8 @@ theorem insert_toFinmap (a : α) (b : β a) (s : AList β) :
 theorem entries_insert_of_not_mem {a : α} {b : β a} {s : Finmap β} :
     a ∉ s → (insert a b s).entries = ⟨a, b⟩ ::ₘ s.entries :=
   induction_on s fun s h => by
-    -- Porting note: `-insert_entries` required
-    simp [AList.entries_insert_of_not_mem (mt mem_toFinmap.1 h), -insert_entries]
+    -- Porting note: `-entries_insert` required
+    simp [AList.entries_insert_of_not_mem (mt mem_toFinmap.1 h), -entries_insert]
 
 @[deprecated (since := "2024-12-14")] alias insert_entries_of_neg := entries_insert_of_not_mem
 

--- a/Mathlib/Data/List/AList.lean
+++ b/Mathlib/Data/List/AList.lean
@@ -241,13 +241,15 @@ theorem insert_entries {a} {b : β a} {s : AList β} :
     (insert a b s).entries = Sigma.mk a b :: kerase a s.entries :=
   rfl
 
-theorem insert_entries_of_neg {a} {b : β a} {s : AList β} (h : a ∉ s) :
+theorem insert_entries_of_not_mem {a} {b : β a} {s : AList β} (h : a ∉ s) :
     (insert a b s).entries = ⟨a, b⟩ :: s.entries := by rw [insert_entries, kerase_of_not_mem_keys h]
 
--- Todo: rename to `insert_of_not_mem`.
-theorem insert_of_neg {a} {b : β a} {s : AList β} (h : a ∉ s) :
+theorem insert_of_not_mem {a} {b : β a} {s : AList β} (h : a ∉ s) :
     insert a b s = ⟨⟨a, b⟩ :: s.entries, nodupKeys_cons.2 ⟨h, s.2⟩⟩ :=
-  ext <| insert_entries_of_neg h
+  ext <| insert_entries_of_not_mem h
+
+@[deprecated (since := "2024-12-14")] alias insert_entries_of_neg := insert_entries_of_not_mem
+@[deprecated (since := "2024-12-14")] alias insert_of_neg := insert_of_not_mem
 
 @[simp]
 theorem insert_empty (a) (b : β a) : insert a b ∅ = singleton a b :=
@@ -342,7 +344,7 @@ theorem insertRec_insert {C : AList β → Sort*} (H0 : C ∅)
       (IH c.1 c.2 ⟨l, hl⟩ h (@insertRec α β _ C H0 IH ⟨l, hl⟩)) by
     cases c
     apply eq_of_heq
-    convert this <;> rw [insert_of_neg h]
+    convert this <;> rw [insert_of_not_mem h]
   rw [insertRec]
   apply cast_heq
 

--- a/Mathlib/Data/List/AList.lean
+++ b/Mathlib/Data/List/AList.lean
@@ -241,14 +241,14 @@ theorem insert_entries {a} {b : β a} {s : AList β} :
     (insert a b s).entries = Sigma.mk a b :: kerase a s.entries :=
   rfl
 
-theorem insert_entries_of_not_mem {a} {b : β a} {s : AList β} (h : a ∉ s) :
+theorem entries_insert_of_not_mem {a} {b : β a} {s : AList β} (h : a ∉ s) :
     (insert a b s).entries = ⟨a, b⟩ :: s.entries := by rw [insert_entries, kerase_of_not_mem_keys h]
 
 theorem insert_of_not_mem {a} {b : β a} {s : AList β} (h : a ∉ s) :
     insert a b s = ⟨⟨a, b⟩ :: s.entries, nodupKeys_cons.2 ⟨h, s.2⟩⟩ :=
-  ext <| insert_entries_of_not_mem h
+  ext <| entries_insert_of_not_mem h
 
-@[deprecated (since := "2024-12-14")] alias insert_entries_of_neg := insert_entries_of_not_mem
+@[deprecated (since := "2024-12-14")] alias insert_entries_of_neg := entries_insert_of_not_mem
 @[deprecated (since := "2024-12-14")] alias insert_of_neg := insert_of_not_mem
 
 @[simp]

--- a/Mathlib/Data/List/AList.lean
+++ b/Mathlib/Data/List/AList.lean
@@ -237,12 +237,14 @@ def insert (a : α) (b : β a) (s : AList β) : AList β :=
   ⟨kinsert a b s.entries, kinsert_nodupKeys a b s.nodupKeys⟩
 
 @[simp]
-theorem insert_entries {a} {b : β a} {s : AList β} :
+theorem entries_insert {a} {b : β a} {s : AList β} :
     (insert a b s).entries = Sigma.mk a b :: kerase a s.entries :=
   rfl
 
+@[deprecated (since := "2024-12-17")] alias insert_entries := entries_insert
+
 theorem entries_insert_of_not_mem {a} {b : β a} {s : AList β} (h : a ∉ s) :
-    (insert a b s).entries = ⟨a, b⟩ :: s.entries := by rw [insert_entries, kerase_of_not_mem_keys h]
+    (insert a b s).entries = ⟨a, b⟩ :: s.entries := by rw [entries_insert, kerase_of_not_mem_keys h]
 
 theorem insert_of_not_mem {a} {b : β a} {s : AList β} (h : a ∉ s) :
     insert a b s = ⟨⟨a, b⟩ :: s.entries, nodupKeys_cons.2 ⟨h, s.2⟩⟩ :=
@@ -265,7 +267,7 @@ theorem keys_insert {a} {b : β a} (s : AList β) : (insert a b s).keys = a :: s
 
 theorem perm_insert {a} {b : β a} {s₁ s₂ : AList β} (p : s₁.entries ~ s₂.entries) :
     (insert a b s₁).entries ~ (insert a b s₂).entries := by
-  simp only [insert_entries]; exact p.kinsert s₁.nodupKeys
+  simp only [entries_insert]; exact p.kinsert s₁.nodupKeys
 
 @[simp]
 theorem lookup_insert {a} {b : β a} (s : AList β) : lookup a (insert a b s) = some b := by
@@ -289,17 +291,17 @@ theorem lookup_to_alist {a} (s : List (Sigma β)) : lookup a s.toAList = s.dlook
 @[simp]
 theorem insert_insert {a} {b b' : β a} (s : AList β) :
     (s.insert a b).insert a b' = s.insert a b' := by
-  ext : 1; simp only [AList.insert_entries, List.kerase_cons_eq]
+  ext : 1; simp only [AList.entries_insert, List.kerase_cons_eq]
 
 theorem insert_insert_of_ne {a a'} {b : β a} {b' : β a'} (s : AList β) (h : a ≠ a') :
     ((s.insert a b).insert a' b').entries ~ ((s.insert a' b').insert a b).entries := by
-  simp only [insert_entries]; rw [kerase_cons_ne, kerase_cons_ne, kerase_comm] <;>
+  simp only [entries_insert]; rw [kerase_cons_ne, kerase_cons_ne, kerase_comm] <;>
     [apply Perm.swap; exact h; exact h.symm]
 
 @[simp]
 theorem insert_singleton_eq {a : α} {b b' : β a} : insert a b (singleton a b') = singleton a b :=
   ext <| by
-    simp only [AList.insert_entries, List.kerase_cons_eq, and_self_iff, AList.singleton_entries,
+    simp only [AList.entries_insert, List.kerase_cons_eq, and_self_iff, AList.singleton_entries,
       heq_iff_eq, eq_self_iff_true]
 
 @[simp]


### PR DESCRIPTION
completes a todo, also mentioned in #7987 

also deprecates the old things

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
