### PR TITLE
[Merged by Bors] - feat: add theorems about isLUB and isGLB for Finset.sup and Finset.inf

### DIFF
--- a/Mathlib/Data/Finset/Lattice/Fold.lean
+++ b/Mathlib/Data/Finset/Lattice/Fold.lean
@@ -154,8 +154,8 @@ theorem sup_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) 
     (s ×ˢ t).sup f = t.sup fun i' => s.sup fun i => f ⟨i, i'⟩ := by
   rw [sup_product_left, Finset.sup_comm]
 
-theorem isLUB_sup {α : Type} [SemilatticeSup α] [OrderBot α] (F : Finset α) :
-    IsLUB F (sup F id) :=
+theorem isLUB_sup {α : Type} [SemilatticeSup α] [OrderBot α] (s : Finset α) :
+    IsLUB s (sup s id) :=
   ⟨fun x h => id_eq x ▸ le_sup h, fun _ h => Finset.sup_le h⟩
 
 section Prod
@@ -381,8 +381,8 @@ theorem inf_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) 
     (s ×ˢ t).inf f = t.inf fun i' => s.inf fun i => f ⟨i, i'⟩ :=
   @sup_product_right αᵒᵈ _ _ _ _ _ _ _
 
-theorem isGLB_inf {α : Type} [SemilatticeInf α] [OrderTop α] (F : Finset α) :
-    IsGLB F (inf F id) :=
+theorem isGLB_inf {α : Type} [SemilatticeInf α] [OrderTop α] (s : Finset α) :
+    IsGLB s (inf s id) :=
   ⟨fun x h => id_eq x ▸ inf_le h, fun _ h => Finset.le_inf h⟩
 
 section Prod
@@ -791,9 +791,10 @@ theorem sup'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × 
     (s ×ˢ t).sup' h f = t.sup' h.snd fun i' => s.sup' h.fst fun i => f ⟨i, i'⟩ := by
   rw [sup'_product_left, Finset.sup'_comm]
 
-theorem isLUB_sup' {α : Type} [SemilatticeSup α] {F : Finset α} (ne : F.Nonempty) :
-    IsLUB F (sup' F ne id) :=
-  ⟨fun x h => id_eq x ▸ le_sup' id h, fun _ h => Finset.sup'_le ne id h⟩
+/-- Analog of `Finset.isLUB_sup` requiring a nonempty set. -/
+theorem isLUB_sup' {α : Type} [SemilatticeSup α] {s : Finset α} (hs : s.Nonempty) :
+    IsLUB s (sup' s hs id) :=
+  ⟨fun x h => id_eq x ▸ le_sup' id h, fun _ h => Finset.sup'_le hs id h⟩
 
 section Prod
 variable {ι κ α β : Type*} [SemilatticeSup α] [SemilatticeSup β] {s : Finset ι} {t : Finset κ}
@@ -960,9 +961,10 @@ theorem inf'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × 
     (s ×ˢ t).inf' h f = t.inf' h.snd fun i' => s.inf' h.fst fun i => f ⟨i, i'⟩ :=
   sup'_product_right (α := αᵒᵈ) h f
 
-theorem isGLB_inf' {α : Type} [SemilatticeInf α] {F : Finset α} (ne : F.Nonempty) :
-    IsGLB F (inf' F ne id) :=
-  ⟨fun x h => id_eq x ▸ inf'_le id h, fun _ h => Finset.le_inf' ne id h⟩
+/-- Analog of `Finset.isGLB_inf` requiring a nonempty set. -/
+theorem isGLB_inf' {α : Type} [SemilatticeInf α] {s : Finset α} (hs : s.Nonempty) :
+    IsGLB s (inf' s hs id) :=
+  ⟨fun x h => id_eq x ▸ inf'_le id h, fun _ h => Finset.le_inf' hs id h⟩
 
 section Prod
 variable {ι κ α β : Type*} [SemilatticeInf α] [SemilatticeInf β] {s : Finset ι} {t : Finset κ}

--- a/Mathlib/Data/Finset/Lattice/Fold.lean
+++ b/Mathlib/Data/Finset/Lattice/Fold.lean
@@ -791,7 +791,7 @@ theorem sup'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × 
     (s ×ˢ t).sup' h f = t.sup' h.snd fun i' => s.sup' h.fst fun i => f ⟨i, i'⟩ := by
   rw [sup'_product_left, Finset.sup'_comm]
 
-/-- Analog of `Finset.isLUB_sup` requiring a nonempty set. -/
+set_option linter.docPrime false in
 theorem isLUB_sup' {α : Type} [SemilatticeSup α] {s : Finset α} (hs : s.Nonempty) :
     IsLUB s (sup' s hs id) :=
   ⟨fun x h => id_eq x ▸ le_sup' id h, fun _ h => Finset.sup'_le hs id h⟩
@@ -961,7 +961,7 @@ theorem inf'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × 
     (s ×ˢ t).inf' h f = t.inf' h.snd fun i' => s.inf' h.fst fun i => f ⟨i, i'⟩ :=
   sup'_product_right (α := αᵒᵈ) h f
 
-/-- Analog of `Finset.isGLB_inf` requiring a nonempty set. -/
+set_option linter.docPrime false in
 theorem isGLB_inf' {α : Type} [SemilatticeInf α] {s : Finset α} (hs : s.Nonempty) :
     IsGLB s (inf' s hs id) :=
   ⟨fun x h => id_eq x ▸ inf'_le id h, fun _ h => Finset.le_inf' hs id h⟩

--- a/Mathlib/Data/Finset/Lattice/Fold.lean
+++ b/Mathlib/Data/Finset/Lattice/Fold.lean
@@ -106,6 +106,9 @@ theorem sup_const_le : (s.sup fun _ => a) ≤ a :=
 theorem le_sup {b : β} (hb : b ∈ s) : f b ≤ s.sup f :=
   Finset.sup_le_iff.1 le_rfl _ hb
 
+theorem isLUB_sup (s : Finset α) : IsLUB s (sup s id) :=
+  ⟨fun x h => id_eq x ▸ le_sup h, fun _ h => Finset.sup_le h⟩
+
 theorem le_sup_of_le {b : β} (hb : b ∈ s) (h : a ≤ f b) : a ≤ s.sup f := h.trans <| le_sup hb
 
 theorem sup_union [DecidableEq β] : (s₁ ∪ s₂).sup f = s₁.sup f ⊔ s₂.sup f :=
@@ -153,10 +156,6 @@ theorem sup_product_left (s : Finset β) (t : Finset γ) (f : β × γ → α) :
 theorem sup_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) :
     (s ×ˢ t).sup f = t.sup fun i' => s.sup fun i => f ⟨i, i'⟩ := by
   rw [sup_product_left, Finset.sup_comm]
-
-theorem isLUB_sup {α : Type} [SemilatticeSup α] [OrderBot α] (s : Finset α) :
-    IsLUB s (sup s id) :=
-  ⟨fun x h => id_eq x ▸ le_sup h, fun _ h => Finset.sup_le h⟩
 
 section Prod
 variable {ι κ α β : Type*} [SemilatticeSup α] [SemilatticeSup β] [OrderBot α] [OrderBot β]
@@ -341,6 +340,9 @@ theorem le_inf_const_le : a ≤ s.inf fun _ => a :=
 theorem inf_le {b : β} (hb : b ∈ s) : s.inf f ≤ f b :=
   Finset.le_inf_iff.1 le_rfl _ hb
 
+theorem isGLB_inf (s : Finset α) : IsGLB s (inf s id) :=
+  ⟨fun x h => id_eq x ▸ inf_le h, fun _ h => Finset.le_inf h⟩
+
 theorem inf_le_of_le {b : β} (hb : b ∈ s) (h : f b ≤ a) : s.inf f ≤ a := (inf_le hb).trans h
 
 theorem inf_union [DecidableEq β] : (s₁ ∪ s₂).inf f = s₁.inf f ⊓ s₂.inf f :=
@@ -380,10 +382,6 @@ theorem inf_product_left (s : Finset β) (t : Finset γ) (f : β × γ → α) :
 theorem inf_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) :
     (s ×ˢ t).inf f = t.inf fun i' => s.inf fun i => f ⟨i, i'⟩ :=
   @sup_product_right αᵒᵈ _ _ _ _ _ _ _
-
-theorem isGLB_inf {α : Type} [SemilatticeInf α] [OrderTop α] (s : Finset α) :
-    IsGLB s (inf s id) :=
-  ⟨fun x h => id_eq x ▸ inf_le h, fun _ h => Finset.le_inf h⟩
 
 section Prod
 variable {ι κ α β : Type*} [SemilatticeInf α] [SemilatticeInf β] [OrderTop α] [OrderTop β]
@@ -754,6 +752,10 @@ alias ⟨_, sup'_le⟩ := sup'_le_iff
 theorem le_sup' {b : β} (h : b ∈ s) : f b ≤ s.sup' ⟨b, h⟩ f :=
   (sup'_le_iff ⟨b, h⟩ f).1 le_rfl b h
 
+set_option linter.docPrime false in
+theorem isLUB_sup' {s : Finset α} (hs : s.Nonempty) : IsLUB s (sup' s hs id) :=
+  ⟨fun x h => id_eq x ▸ le_sup' id h, fun _ h => Finset.sup'_le hs id h⟩
+
 theorem le_sup'_of_le {a : α} {b : β} (hb : b ∈ s) (h : a ≤ f b) : a ≤ s.sup' ⟨b, hb⟩ f :=
   h.trans <| le_sup' _ hb
 
@@ -790,11 +792,6 @@ theorem sup'_product_left {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × �
 theorem sup'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × γ → α) :
     (s ×ˢ t).sup' h f = t.sup' h.snd fun i' => s.sup' h.fst fun i => f ⟨i, i'⟩ := by
   rw [sup'_product_left, Finset.sup'_comm]
-
-set_option linter.docPrime false in
-theorem isLUB_sup' {α : Type} [SemilatticeSup α] {s : Finset α} (hs : s.Nonempty) :
-    IsLUB s (sup' s hs id) :=
-  ⟨fun x h => id_eq x ▸ le_sup' id h, fun _ h => Finset.sup'_le hs id h⟩
 
 section Prod
 variable {ι κ α β : Type*} [SemilatticeSup α] [SemilatticeSup β] {s : Finset ι} {t : Finset κ}
@@ -929,6 +926,10 @@ theorem le_inf' {a : α} (hs : ∀ b ∈ s, a ≤ f b) : a ≤ s.inf' H f :=
 theorem inf'_le {b : β} (h : b ∈ s) : s.inf' ⟨b, h⟩ f ≤ f b :=
   le_sup' (α := αᵒᵈ) f h
 
+set_option linter.docPrime false in
+theorem isGLB_inf' {s : Finset α} (hs : s.Nonempty) : IsGLB s (inf' s hs id) :=
+  ⟨fun x h => id_eq x ▸ inf'_le id h, fun _ h => Finset.le_inf' hs id h⟩
+
 theorem inf'_le_of_le {a : α} {b : β} (hb : b ∈ s) (h : f b ≤ a) :
     s.inf' ⟨b, hb⟩ f ≤ a := (inf'_le _ hb).trans h
 
@@ -960,11 +961,6 @@ theorem inf'_product_left {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × �
 theorem inf'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × γ → α) :
     (s ×ˢ t).inf' h f = t.inf' h.snd fun i' => s.inf' h.fst fun i => f ⟨i, i'⟩ :=
   sup'_product_right (α := αᵒᵈ) h f
-
-set_option linter.docPrime false in
-theorem isGLB_inf' {α : Type} [SemilatticeInf α] {s : Finset α} (hs : s.Nonempty) :
-    IsGLB s (inf' s hs id) :=
-  ⟨fun x h => id_eq x ▸ inf'_le id h, fun _ h => Finset.le_inf' hs id h⟩
 
 section Prod
 variable {ι κ α β : Type*} [SemilatticeInf α] [SemilatticeInf β] {s : Finset ι} {t : Finset κ}

--- a/Mathlib/Data/Finset/Lattice/Fold.lean
+++ b/Mathlib/Data/Finset/Lattice/Fold.lean
@@ -154,6 +154,9 @@ theorem sup_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) 
     (s ×ˢ t).sup f = t.sup fun i' => s.sup fun i => f ⟨i, i'⟩ := by
   rw [sup_product_left, Finset.sup_comm]
 
+theorem isLUB_sup {α : Type} [SemilatticeSup α] [OrderBot α] (F : Finset α) :
+    IsLUB F (sup F id) := ⟨fun x h => id_eq x ▸ le_sup h, fun _ h => Finset.sup_le h⟩
+
 section Prod
 variable {ι κ α β : Type*} [SemilatticeSup α] [SemilatticeSup β] [OrderBot α] [OrderBot β]
   {s : Finset ι} {t : Finset κ}
@@ -376,6 +379,9 @@ theorem inf_product_left (s : Finset β) (t : Finset γ) (f : β × γ → α) :
 theorem inf_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) :
     (s ×ˢ t).inf f = t.inf fun i' => s.inf fun i => f ⟨i, i'⟩ :=
   @sup_product_right αᵒᵈ _ _ _ _ _ _ _
+
+theorem isGLB_inf {α : Type} [SemilatticeInf α] [OrderTop α] (F : Finset α) :
+    IsGLB F (inf F id) := ⟨fun x h => id_eq x ▸ inf_le h, fun _ h => Finset.le_inf h⟩
 
 section Prod
 variable {ι κ α β : Type*} [SemilatticeInf α] [SemilatticeInf β] [OrderTop α] [OrderTop β]
@@ -783,6 +789,9 @@ theorem sup'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × 
     (s ×ˢ t).sup' h f = t.sup' h.snd fun i' => s.sup' h.fst fun i => f ⟨i, i'⟩ := by
   rw [sup'_product_left, Finset.sup'_comm]
 
+theorem isLUB_sup' {α : Type} [SemilatticeSup α] {F : Finset α} (ne : F.Nonempty) :
+    IsLUB F (sup' F ne id) := ⟨fun x h => id_eq x ▸ le_sup' id h, fun _ h => Finset.sup'_le ne id h⟩
+
 section Prod
 variable {ι κ α β : Type*} [SemilatticeSup α] [SemilatticeSup β] {s : Finset ι} {t : Finset κ}
 
@@ -947,6 +956,9 @@ theorem inf'_product_left {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × �
 theorem inf'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × γ → α) :
     (s ×ˢ t).inf' h f = t.inf' h.snd fun i' => s.inf' h.fst fun i => f ⟨i, i'⟩ :=
   sup'_product_right (α := αᵒᵈ) h f
+
+theorem isGLB_inf' {α : Type} [SemilatticeInf α] {F : Finset α} (ne : F.Nonempty) :
+    IsGLB F (inf' F ne id) := ⟨fun x h => id_eq x ▸ inf'_le id h, fun _ h => Finset.le_inf' ne id h⟩
 
 section Prod
 variable {ι κ α β : Type*} [SemilatticeInf α] [SemilatticeInf β] {s : Finset ι} {t : Finset κ}

--- a/Mathlib/Data/Finset/Lattice/Fold.lean
+++ b/Mathlib/Data/Finset/Lattice/Fold.lean
@@ -155,7 +155,8 @@ theorem sup_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) 
   rw [sup_product_left, Finset.sup_comm]
 
 theorem isLUB_sup {α : Type} [SemilatticeSup α] [OrderBot α] (F : Finset α) :
-    IsLUB F (sup F id) := ⟨fun x h => id_eq x ▸ le_sup h, fun _ h => Finset.sup_le h⟩
+    IsLUB F (sup F id) :=
+  ⟨fun x h => id_eq x ▸ le_sup h, fun _ h => Finset.sup_le h⟩
 
 section Prod
 variable {ι κ α β : Type*} [SemilatticeSup α] [SemilatticeSup β] [OrderBot α] [OrderBot β]
@@ -381,7 +382,8 @@ theorem inf_product_right (s : Finset β) (t : Finset γ) (f : β × γ → α) 
   @sup_product_right αᵒᵈ _ _ _ _ _ _ _
 
 theorem isGLB_inf {α : Type} [SemilatticeInf α] [OrderTop α] (F : Finset α) :
-    IsGLB F (inf F id) := ⟨fun x h => id_eq x ▸ inf_le h, fun _ h => Finset.le_inf h⟩
+    IsGLB F (inf F id) :=
+  ⟨fun x h => id_eq x ▸ inf_le h, fun _ h => Finset.le_inf h⟩
 
 section Prod
 variable {ι κ α β : Type*} [SemilatticeInf α] [SemilatticeInf β] [OrderTop α] [OrderTop β]
@@ -790,7 +792,8 @@ theorem sup'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × 
   rw [sup'_product_left, Finset.sup'_comm]
 
 theorem isLUB_sup' {α : Type} [SemilatticeSup α] {F : Finset α} (ne : F.Nonempty) :
-    IsLUB F (sup' F ne id) := ⟨fun x h => id_eq x ▸ le_sup' id h, fun _ h => Finset.sup'_le ne id h⟩
+    IsLUB F (sup' F ne id) :=
+  ⟨fun x h => id_eq x ▸ le_sup' id h, fun _ h => Finset.sup'_le ne id h⟩
 
 section Prod
 variable {ι κ α β : Type*} [SemilatticeSup α] [SemilatticeSup β] {s : Finset ι} {t : Finset κ}
@@ -958,7 +961,8 @@ theorem inf'_product_right {t : Finset γ} (h : (s ×ˢ t).Nonempty) (f : β × 
   sup'_product_right (α := αᵒᵈ) h f
 
 theorem isGLB_inf' {α : Type} [SemilatticeInf α] {F : Finset α} (ne : F.Nonempty) :
-    IsGLB F (inf' F ne id) := ⟨fun x h => id_eq x ▸ inf'_le id h, fun _ h => Finset.le_inf' ne id h⟩
+    IsGLB F (inf' F ne id) :=
+  ⟨fun x h => id_eq x ▸ inf'_le id h, fun _ h => Finset.le_inf' ne id h⟩
 
 section Prod
 variable {ι κ α β : Type*} [SemilatticeInf α] [SemilatticeInf β] {s : Finset ι} {t : Finset κ}


### PR DESCRIPTION
feat: add theorems regarding isLUB and isGLB for Finset.sup and Finset.inf

theorems were previously missing stating that `Finset.sup` produces a least upper bound and `Finset.inf` produces a greatest lower bound. This commit adds those theorems as well as the corresponding one for `Finset.sup'` and `Finset.inf'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
