### PR TITLE
[Merged by Bors] - feat(Algebra/Category/Grp/ForgetCorepresentable, Algebra/Category/MonCat/ForgetCorepresentable): the forgetful functor on the category of monoids is corepresentable

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -143,6 +143,7 @@ import Mathlib.Algebra.Category.MonCat.Adjunctions
 import Mathlib.Algebra.Category.MonCat.Basic
 import Mathlib.Algebra.Category.MonCat.Colimits
 import Mathlib.Algebra.Category.MonCat.FilteredColimits
+import Mathlib.Algebra.Category.MonCat.ForgetCorepresentable
 import Mathlib.Algebra.Category.MonCat.Limits
 import Mathlib.Algebra.Category.Ring.Adjunctions
 import Mathlib.Algebra.Category.Ring.Basic

--- a/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
@@ -6,6 +6,7 @@ Authors: Joël Riou
 import Mathlib.Algebra.Category.Grp.Basic
 import Mathlib.Algebra.Group.ULift
 import Mathlib.CategoryTheory.Yoneda
+import Mathlib.Algebra.Category.MonCat.ForgetCorepresentable
 
 /-!
 # The forget functor is corepresentable
@@ -21,16 +22,6 @@ universe u
 open CategoryTheory Opposite
 
 namespace MonoidHom
-
-/-- The equivalence `(β →* γ) ≃ (α →* γ)` obtained by precomposition with
-a multiplicative equivalence `e : α ≃* β`. -/
-@[simps]
-def precompEquiv {α β : Type*} [Monoid α] [Monoid β] (e : α ≃* β) (γ : Type*) [Monoid γ] :
-    (β →* γ) ≃ (α →* γ) where
-  toFun f := f.comp e
-  invFun g := g.comp e.symm
-  left_inv _ := by ext; simp
-  right_inv _ := by ext; simp
 
 /-- The equivalence `(Multiplicative ℤ →* α) ≃ α` for any group `α`. -/
 @[simps]
@@ -49,16 +40,6 @@ def fromULiftMultiplicativeIntEquiv (α : Type u) [Group α] :
 end MonoidHom
 
 namespace AddMonoidHom
-
-/-- The equivalence `(β →+ γ) ≃ (α →+ γ)` obtained by precomposition with
-an additive equivalence `e : α ≃+ β`. -/
-@[simps]
-def precompEquiv {α β : Type*} [AddMonoid α] [AddMonoid β] (e : α ≃+ β) (γ : Type*) [AddMonoid γ] :
-    (β →+ γ) ≃ (α →+ γ) where
-  toFun f := f.comp e
-  invFun g := g.comp e.symm
-  left_inv _ := by ext; simp
-  right_inv _ := by ext; simp
 
 /-- The equivalence `(ℤ →+ α) ≃ α` for any additive group `α`. -/
 @[simps]

--- a/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2024 Sophie Morel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sophie Morel
+-/
+import Mathlib.Algebra.Category.MonCat.Basic
+import Mathlib.Data.Nat.Cast.Basic
+
+/-!
+# The forget functor is corepresentable
+
+The forgetful functor `AddCommMonCat.{u} ⥤ Type u` is corepresentable
+by `ULift ℕ`. Similar results are obtained for the variants `CommMonCat`, `AddMonCat`
+and `MonCat`.
+
+-/
+
+universe u
+
+open CategoryTheory Opposite
+
+namespace MonoidHom
+
+/-- The equivalence `(β →* γ) ≃ (α →* γ)` obtained by precomposition with
+a multiplicative equivalence `e : α ≃* β`. -/
+@[simps]
+def precompEquiv {α β : Type*} [Monoid α] [Monoid β] (e : α ≃* β) (γ : Type*) [Monoid γ] :
+    (β →* γ) ≃ (α →* γ) where
+  toFun f := f.comp e
+  invFun g := g.comp e.symm
+  left_inv _ := by ext; simp
+  right_inv _ := by ext; simp
+
+/-- The equivalence `(Multiplicative ℕ →* α) ≃ α` for any monoid `α`. -/
+@[simps]
+def fromMultiplicativeNatEquiv (α : Type u) [Monoid α] : (Multiplicative ℕ →* α) ≃ α where
+  toFun φ := φ (Multiplicative.ofAdd 1)
+  invFun x := powersHom α x
+  left_inv φ := by ext; simp
+  right_inv x := by simp
+
+/-- The equivalence `(ULift (Multiplicative ℕ) →* α) ≃ α` for any monoid `α`. -/
+@[simps!]
+def fromULiftMultiplicativeNatEquiv (α : Type u) [Monoid α] :
+    (ULift.{u} (Multiplicative ℕ) →* α) ≃ α :=
+  (precompEquiv (MulEquiv.ulift.symm) _).trans (fromMultiplicativeNatEquiv α)
+
+end MonoidHom
+
+namespace AddMonoidHom
+
+/-- The equivalence `(β →+ γ) ≃ (α →+ γ)` obtained by precomposition with
+an additive equivalence `e : α ≃+ β`. -/
+@[simps]
+def precompEquiv {α β : Type*} [AddMonoid α] [AddMonoid β] (e : α ≃+ β) (γ : Type*) [AddMonoid γ] :
+    (β →+ γ) ≃ (α →+ γ) where
+  toFun f := f.comp e
+  invFun g := g.comp e.symm
+  left_inv _ := by ext; simp
+  right_inv _ := by ext; simp
+
+/-- The equivalence `(ℤ →+ α) ≃ α` for any additive group `α`. -/
+@[simps]
+def fromNatEquiv (α : Type u) [AddMonoid α] : (ℕ →+ α) ≃ α where
+  toFun φ := φ 1
+  invFun x := multiplesHom α x
+  left_inv φ := by ext; simp
+  right_inv x := by simp
+
+/-- The equivalence `(ULift ℕ →+ α) ≃ α` for any additive monoid `α`. -/
+@[simps!]
+def fromULiftNatEquiv (α : Type u) [AddMonoid α] : (ULift.{u} ℕ →+ α) ≃ α :=
+  (precompEquiv (AddEquiv.ulift.symm) _).trans (fromNatEquiv α)
+
+end AddMonoidHom
+
+/-- The forgetful functor `MonCat.{u} ⥤ Type u` is corepresentable. -/
+def MonCat.coyonedaObjIsoForget :
+    coyoneda.obj (op (of (ULift.{u} (Multiplicative ℕ)))) ≅ forget MonCat.{u} :=
+  (NatIso.ofComponents (fun M => (MonoidHom.fromULiftMultiplicativeNatEquiv M.α).toIso))
+
+
+/-- The forgetful functor `CommMonCat.{u} ⥤ Type u` is corepresentable. -/
+def CommMonCat.coyonedaObjIsoForget :
+    coyoneda.obj (op (of (ULift.{u} (Multiplicative ℕ)))) ≅ forget CommMonCat.{u} :=
+  (NatIso.ofComponents (fun M => (MonoidHom.fromULiftMultiplicativeNatEquiv M.α).toIso))
+
+/-- The forgetful functor `AddMonCat.{u} ⥤ Type u` is corepresentable. -/
+def AddMonCat.coyonedaObjIsoForget :
+    coyoneda.obj (op (of (ULift.{u} ℕ))) ≅ forget AddMonCat.{u} :=
+  (NatIso.ofComponents (fun M => (AddMonoidHom.fromULiftNatEquiv M.α).toIso))
+
+/-- The forgetful functor `AddCommMonCat.{u} ⥤ Type u` is corepresentable. -/
+def AddCommMonCat.coyonedaObjIsoForget :
+    coyoneda.obj (op (of (ULift.{u} ℕ))) ≅ forget AddCommMonCat.{u} :=
+  (NatIso.ofComponents (fun M => (AddMonoidHom.fromULiftNatEquiv M.α).toIso))
+
+instance MonCat.forget_isCorepresentable :
+    (forget MonCat.{u}).IsCorepresentable :=
+  Functor.IsCorepresentable.mk' MonCat.coyonedaObjIsoForget
+
+instance CommMonCat.forget_isCorepresentable :
+    (forget CommMonCat.{u}).IsCorepresentable :=
+  Functor.IsCorepresentable.mk' CommMonCat.coyonedaObjIsoForget
+
+instance AddMonCat.forget_isCorepresentable :
+    (forget AddMonCat.{u}).IsCorepresentable :=
+  Functor.IsCorepresentable.mk' AddMonCat.coyonedaObjIsoForget
+
+instance AddCommMonCat.forget_isCorepresentable :
+    (forget AddCommMonCat.{u}).IsCorepresentable :=
+  Functor.IsCorepresentable.mk' AddCommMonCat.coyonedaObjIsoForget


### PR DESCRIPTION
The forgetful functor on the various categories of monoids (additive/multiplicative/commutative/etc) are representable by the natural numbers.

This basically copies the corresponding code for the group categories, and moves two lemmas from `Algebra.Category.Grp.ForgetCorepresentable` to `Algebra.Category.MonCat.ForgetCorepresentable`, to avoid having a `MonCat` file importing a `Grp` file.

Will be used to proved that to prove that the forgetful functor on `MonCat` creates all limits.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
