### PR TITLE
[Merged by Bors] - feat(Algebra/Category/MonCat/Limits): the forgetful functor on the category of monoids creates all limits

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -143,6 +143,7 @@ import Mathlib.Algebra.Category.MonCat.Adjunctions
 import Mathlib.Algebra.Category.MonCat.Basic
 import Mathlib.Algebra.Category.MonCat.Colimits
 import Mathlib.Algebra.Category.MonCat.FilteredColimits
+import Mathlib.Algebra.Category.MonCat.ForgetCorepresentable
 import Mathlib.Algebra.Category.MonCat.Limits
 import Mathlib.Algebra.Category.Ring.Adjunctions
 import Mathlib.Algebra.Category.Ring.Basic

--- a/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
@@ -6,6 +6,7 @@ Authors: Joël Riou
 import Mathlib.Algebra.Category.Grp.Basic
 import Mathlib.Algebra.Group.ULift
 import Mathlib.CategoryTheory.Yoneda
+import Mathlib.Algebra.Category.MonCat.ForgetCorepresentable
 
 /-!
 # The forget functor is corepresentable
@@ -21,16 +22,6 @@ universe u
 open CategoryTheory Opposite
 
 namespace MonoidHom
-
-/-- The equivalence `(β →* γ) ≃ (α →* γ)` obtained by precomposition with
-a multiplicative equivalence `e : α ≃* β`. -/
-@[simps]
-def precompEquiv {α β : Type*} [Monoid α] [Monoid β] (e : α ≃* β) (γ : Type*) [Monoid γ] :
-    (β →* γ) ≃ (α →* γ) where
-  toFun f := f.comp e
-  invFun g := g.comp e.symm
-  left_inv _ := by ext; simp
-  right_inv _ := by ext; simp
 
 /-- The equivalence `(Multiplicative ℤ →* α) ≃ α` for any group `α`. -/
 @[simps]
@@ -49,16 +40,6 @@ def fromULiftMultiplicativeIntEquiv (α : Type u) [Group α] :
 end MonoidHom
 
 namespace AddMonoidHom
-
-/-- The equivalence `(β →+ γ) ≃ (α →+ γ)` obtained by precomposition with
-an additive equivalence `e : α ≃+ β`. -/
-@[simps]
-def precompEquiv {α β : Type*} [AddMonoid α] [AddMonoid β] (e : α ≃+ β) (γ : Type*) [AddMonoid γ] :
-    (β →+ γ) ≃ (α →+ γ) where
-  toFun f := f.comp e
-  invFun g := g.comp e.symm
-  left_inv _ := by ext; simp
-  right_inv _ := by ext; simp
 
 /-- The equivalence `(ℤ →+ α) ≃ α` for any additive group `α`. -/
 @[simps]

--- a/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2024 Sophie Morel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sophie Morel
+-/
+import Mathlib.Algebra.Category.MonCat.Basic
+import Mathlib.Data.Nat.Cast.Basic
+
+/-!
+# The forget functor is corepresentable
+
+The forgetful functor `AddCommMonCat.{u} ⥤ Type u` is corepresentable
+by `ULift ℕ`. Similar results are obtained for the variants `CommMonCat`, `AddMonCat`
+and `MonCat`.
+
+-/
+
+universe u
+
+open CategoryTheory Opposite
+
+namespace MonoidHom
+
+/-- The equivalence `(β →* γ) ≃ (α →* γ)` obtained by precomposition with
+a multiplicative equivalence `e : α ≃* β`. -/
+@[simps]
+def precompEquiv {α β : Type*} [Monoid α] [Monoid β] (e : α ≃* β) (γ : Type*) [Monoid γ] :
+    (β →* γ) ≃ (α →* γ) where
+  toFun f := f.comp e
+  invFun g := g.comp e.symm
+  left_inv _ := by ext; simp
+  right_inv _ := by ext; simp
+
+/-- The equivalence `(Multiplicative ℕ →* α) ≃ α` for any monoid `α`. -/
+@[simps]
+def fromMultiplicativeNatEquiv (α : Type u) [Monoid α] : (Multiplicative ℕ →* α) ≃ α where
+  toFun φ := φ (Multiplicative.ofAdd 1)
+  invFun x := powersHom α x
+  left_inv φ := by ext; simp
+  right_inv x := by simp
+
+/-- The equivalence `(ULift (Multiplicative ℕ) →* α) ≃ α` for any monoid `α`. -/
+@[simps!]
+def fromULiftMultiplicativeNatEquiv (α : Type u) [Monoid α] :
+    (ULift.{u} (Multiplicative ℕ) →* α) ≃ α :=
+  (precompEquiv (MulEquiv.ulift.symm) _).trans (fromMultiplicativeNatEquiv α)
+
+end MonoidHom
+
+namespace AddMonoidHom
+
+/-- The equivalence `(β →+ γ) ≃ (α →+ γ)` obtained by precomposition with
+an additive equivalence `e : α ≃+ β`. -/
+@[simps]
+def precompEquiv {α β : Type*} [AddMonoid α] [AddMonoid β] (e : α ≃+ β) (γ : Type*) [AddMonoid γ] :
+    (β →+ γ) ≃ (α →+ γ) where
+  toFun f := f.comp e
+  invFun g := g.comp e.symm
+  left_inv _ := by ext; simp
+  right_inv _ := by ext; simp
+
+/-- The equivalence `(ℤ →+ α) ≃ α` for any additive group `α`. -/
+@[simps]
+def fromNatEquiv (α : Type u) [AddMonoid α] : (ℕ →+ α) ≃ α where
+  toFun φ := φ 1
+  invFun x := multiplesHom α x
+  left_inv φ := by ext; simp
+  right_inv x := by simp
+
+/-- The equivalence `(ULift ℕ →+ α) ≃ α` for any additive monoid `α`. -/
+@[simps!]
+def fromULiftNatEquiv (α : Type u) [AddMonoid α] : (ULift.{u} ℕ →+ α) ≃ α :=
+  (precompEquiv (AddEquiv.ulift.symm) _).trans (fromNatEquiv α)
+
+end AddMonoidHom
+
+/-- The forgetful functor `MonCat.{u} ⥤ Type u` is corepresentable. -/
+def MonCat.coyonedaObjIsoForget :
+    coyoneda.obj (op (of (ULift.{u} (Multiplicative ℕ)))) ≅ forget MonCat.{u} :=
+  (NatIso.ofComponents (fun M => (MonoidHom.fromULiftMultiplicativeNatEquiv M.α).toIso))
+
+
+/-- The forgetful functor `CommMonCat.{u} ⥤ Type u` is corepresentable. -/
+def CommMonCat.coyonedaObjIsoForget :
+    coyoneda.obj (op (of (ULift.{u} (Multiplicative ℕ)))) ≅ forget CommMonCat.{u} :=
+  (NatIso.ofComponents (fun M => (MonoidHom.fromULiftMultiplicativeNatEquiv M.α).toIso))
+
+/-- The forgetful functor `AddMonCat.{u} ⥤ Type u` is corepresentable. -/
+def AddMonCat.coyonedaObjIsoForget :
+    coyoneda.obj (op (of (ULift.{u} ℕ))) ≅ forget AddMonCat.{u} :=
+  (NatIso.ofComponents (fun M => (AddMonoidHom.fromULiftNatEquiv M.α).toIso))
+
+/-- The forgetful functor `AddCommMonCat.{u} ⥤ Type u` is corepresentable. -/
+def AddCommMonCat.coyonedaObjIsoForget :
+    coyoneda.obj (op (of (ULift.{u} ℕ))) ≅ forget AddCommMonCat.{u} :=
+  (NatIso.ofComponents (fun M => (AddMonoidHom.fromULiftNatEquiv M.α).toIso))
+
+instance MonCat.forget_isCorepresentable :
+    (forget MonCat.{u}).IsCorepresentable :=
+  Functor.IsCorepresentable.mk' MonCat.coyonedaObjIsoForget
+
+instance CommMonCat.forget_isCorepresentable :
+    (forget CommMonCat.{u}).IsCorepresentable :=
+  Functor.IsCorepresentable.mk' CommMonCat.coyonedaObjIsoForget
+
+instance AddMonCat.forget_isCorepresentable :
+    (forget AddMonCat.{u}).IsCorepresentable :=
+  Functor.IsCorepresentable.mk' AddMonCat.coyonedaObjIsoForget
+
+instance AddCommMonCat.forget_isCorepresentable :
+    (forget AddCommMonCat.{u}).IsCorepresentable :=
+  Functor.IsCorepresentable.mk' AddCommMonCat.coyonedaObjIsoForget

--- a/Mathlib/Algebra/Category/MonCat/Limits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Limits.lean
@@ -157,6 +157,44 @@ noncomputable instance forget_preservesLimitsOfSize [UnivLE.{v, u}] :
 noncomputable instance forget_preservesLimits : PreservesLimits (forget MonCat.{u}) :=
   MonCat.forget_preservesLimitsOfSize.{u, u}
 
+@[to_additive]
+noncomputable instance forget_createsLimit :
+    CreatesLimit F (forget MonCat.{u}) := by
+  apply createsLimitOfReflectsIso
+  intro c t
+  have : Small.{u} (Functor.sections (F ⋙ forget MonCat)) :=
+    (Types.hasLimit_iff_small_sections _).mp (HasLimit.mk {cone := c, isLimit := t})
+  refine LiftsToLimit.mk (LiftableCone.mk
+    {pt := MonCat.of (Types.Small.limitCone (F ⋙ forget MonCat)).pt, π := NatTrans.mk
+      (limitπMonoidHom F) (MonCat.HasLimits.limitCone F).π.naturality} (Cones.ext
+      ((Types.isLimitEquivSections t).trans (equivShrink _)).symm.toIso
+      (fun _ ↦ funext (fun _ ↦ by simp; rfl)))) ?_
+  refine IsLimit.ofFaithful (forget MonCat.{u}) (Types.Small.limitConeIsLimit.{v,u} _) ?_ ?_
+  · intro _
+    refine {toFun := (Types.Small.limitConeIsLimit.{v,u} _).lift ((forget MonCat).mapCone _),
+                      map_one' := by simp; rfl, map_mul' := ?_ }
+    · intro x y
+      simp only [Types.Small.limitConeIsLimit_lift, Functor.comp_obj, Functor.mapCone_pt,
+          Functor.mapCone_π_app, forget_map, map_mul, mul_of]
+      congr
+      simp only [Functor.comp_obj, Equiv.symm_apply_apply]
+      rfl
+  · exact fun _ ↦ rfl
+
+@[to_additive]
+noncomputable instance forget_createsLimitsOfShape :
+    CreatesLimitsOfShape J (forget MonCat.{u}) where
+      CreatesLimit := inferInstance
+
+@[to_additive]
+noncomputable instance forget_createsLimitsOfSize :
+    CreatesLimitsOfSize.{w,v} (forget MonCat.{u}) where
+      CreatesLimitsOfShape := inferInstance
+
+@[to_additive]
+noncomputable instance forget_createsLimits :
+    CreatesLimits (forget MonCat.{u}) := MonCat.forget_createsLimitsOfSize.{u,u}
+
 end MonCat
 
 open MonCat
@@ -291,5 +329,26 @@ instance _root_.AddCommMonCat.forget_preservesLimits :
 @[to_additive existing]
 instance forget_preservesLimits : PreservesLimits (forget CommMonCat.{u}) :=
   CommMonCat.forget_preservesLimitsOfSize.{u, u}
+
+@[to_additive]
+noncomputable instance forget_createsLimit :
+    CreatesLimit F (forget CommMonCat.{u}) := by
+  set e : forget CommMonCat.{u} ≅ forget₂ CommMonCat.{u} MonCat.{u} ⋙ forget MonCat.{u} :=
+    NatIso.ofComponents (fun _ ↦ Iso.refl _) (fun _ ↦ rfl)
+  exact createsLimitOfNatIso e.symm
+
+@[to_additive]
+noncomputable instance forget_createsLimitsOfShape :
+    CreatesLimitsOfShape J (forget MonCat.{u}) where
+      CreatesLimit := inferInstance
+
+@[to_additive]
+noncomputable instance forget_createsLimitsOfSize :
+    CreatesLimitsOfSize.{w,v} (forget MonCat.{u}) where
+      CreatesLimitsOfShape := inferInstance
+
+@[to_additive]
+noncomputable instance forget_createsLimits :
+    CreatesLimits (forget MonCat.{u}) := CommMonCat.forget_createsLimitsOfSize.{u,u}
 
 end CommMonCat

--- a/Mathlib/Algebra/Category/MonCat/Limits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Limits.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Category.MonCat.Basic
-import Mathlib.Algebra.Group.Pi.Lemmas
-import Mathlib.Algebra.Group.Submonoid.Operations
 import Mathlib.CategoryTheory.Limits.Creates
 import Mathlib.CategoryTheory.Limits.Types
 import Mathlib.Logic.Small.Group

--- a/Mathlib/Algebra/Category/MonCat/Limits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Limits.lean
@@ -186,7 +186,11 @@ noncomputable instance forget_createsLimitsOfShape :
     CreatesLimitsOfShape J (forget MonCat.{u}) where
       CreatesLimit := inferInstance
 
-@[to_additive]
+/-- The forgetful functor from monoids to types preserves all limits.
+-/
+@[to_additive
+"The forgetful functor from additive monoids to types preserves all limits."
+]
 noncomputable instance forget_createsLimitsOfSize :
     CreatesLimitsOfSize.{w,v} (forget MonCat.{u}) where
       CreatesLimitsOfShape := inferInstance
@@ -342,7 +346,11 @@ noncomputable instance forget_createsLimitsOfShape :
     CreatesLimitsOfShape J (forget MonCat.{u}) where
       CreatesLimit := inferInstance
 
-@[to_additive]
+/-- The forgetful functor from commutative monoids to types preserves all limits.
+-/
+@[to_additive
+"The forgetful functor from commutative additive monoids to types preserves all limits."
+]
 noncomputable instance forget_createsLimitsOfSize :
     CreatesLimitsOfSize.{w,v} (forget MonCat.{u}) where
       CreatesLimitsOfShape := inferInstance


### PR DESCRIPTION
The forgetful functor on the category of monoids (commutative or not) creates all limits.

The only non-trivial lemma is `MonCat.forget_createsLimit`, but even that is easy because it uses that limits in the category of monoids are literally constructed by taking limits in the category of types and putting a monoid structure on the result. The only "innovation" is noticing that the limit of `F` existing in the category of types already forces the sections of `F ⋙ forget MonCat``` to be small, so we don't need to impose any smallness condition on our functors.

- [x] depends on: #19964 [the forgetful functor on `MonCat` is corepresentable]

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
