### PR TITLE
[Merged by Bors] - feat(SetTheory/ZFC/Basic): `x ∈ y → ¬ y ⊆ x`

### DIFF
--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -254,6 +254,12 @@ theorem mem_asymm {x y : PSet} : x ∈ y → y ∉ x :=
 theorem mem_irrefl (x : PSet) : x ∉ x :=
   irrefl_of (· ∈ ·) x
 
+theorem not_subset_of_mem {x y : PSet} (h : x ∈ y) : ¬ y ⊆ x :=
+  fun h' ↦ mem_irrefl _ <| mem_of_subset h' h
+
+theorem not_mem_of_subset {x y : PSet} (h : x ⊆ y) : ¬ y ∈ x :=
+  imp_not_comm.2 not_subset_of_mem h
+
 /-- Convert a pre-set to a `Set` of pre-sets. -/
 def toSet (u : PSet.{u}) : Set PSet.{u} :=
   { x | x ∈ u }
@@ -1159,6 +1165,12 @@ theorem mem_asymm {x y : ZFSet} : x ∈ y → y ∉ x :=
 theorem mem_irrefl (x : ZFSet) : x ∉ x :=
   irrefl_of (· ∈ ·) x
 
+theorem not_subset_of_mem {x y : ZFSet} (h : x ∈ y) : ¬ y ⊆ x :=
+  fun h' ↦ mem_irrefl _ (h' h)
+
+theorem not_mem_of_subset {x y : ZFSet} (h : x ⊆ y) : ¬ y ∈ x :=
+  imp_not_comm.2 not_subset_of_mem h
+
 theorem regularity (x : ZFSet.{u}) (h : x ≠ ∅) : ∃ y ∈ x, x ∩ y = ∅ :=
   by_contradiction fun ne =>
     h <| (eq_empty x).2 fun y =>
@@ -1208,9 +1220,9 @@ theorem mem_range {α : Type u} {f : α → ZFSet.{max u v}} {x : ZFSet.{max u v
   Quotient.inductionOn x fun y => by
     constructor
     · rintro ⟨z, hz⟩
-      exact ⟨z.down, Quotient.eq_mk_iff_out.2 hz.symm⟩
+      exact ⟨(equivShrink α).symm z, Quotient.eq_mk_iff_out.2 hz.symm⟩
     · rintro ⟨z, hz⟩
-      use ULift.up z
+      use equivShrink α z
       simpa [hz] using PSet.Equiv.symm (Quotient.mk_out y)
 
 @[simp]

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -257,7 +257,7 @@ theorem mem_irrefl (x : PSet) : x ∉ x :=
 theorem not_subset_of_mem {x y : PSet} (h : x ∈ y) : ¬ y ⊆ x :=
   fun h' ↦ mem_irrefl _ <| mem_of_subset h' h
 
-theorem not_mem_of_subset {x y : PSet} (h : x ⊆ y) : ¬ y ∈ x :=
+theorem not_mem_of_subset {x y : PSet} (h : x ⊆ y) : y ∉ x :=
   imp_not_comm.2 not_subset_of_mem h
 
 /-- Convert a pre-set to a `Set` of pre-sets. -/

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -1168,7 +1168,7 @@ theorem mem_irrefl (x : ZFSet) : x ∉ x :=
 theorem not_subset_of_mem {x y : ZFSet} (h : x ∈ y) : ¬ y ⊆ x :=
   fun h' ↦ mem_irrefl _ (h' h)
 
-theorem not_mem_of_subset {x y : ZFSet} (h : x ⊆ y) : ¬ y ∈ x :=
+theorem not_mem_of_subset {x y : ZFSet} (h : x ⊆ y) : y ∉ x :=
   imp_not_comm.2 not_subset_of_mem h
 
 theorem regularity (x : ZFSet.{u}) (h : x ≠ ∅) : ∃ y ∈ x, x ∩ y = ∅ :=

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -1220,9 +1220,9 @@ theorem mem_range {α : Type u} {f : α → ZFSet.{max u v}} {x : ZFSet.{max u v
   Quotient.inductionOn x fun y => by
     constructor
     · rintro ⟨z, hz⟩
-      exact ⟨(equivShrink α).symm z, Quotient.eq_mk_iff_out.2 hz.symm⟩
+      exact ⟨z.down, Quotient.eq_mk_iff_out.2 hz.symm⟩
     · rintro ⟨z, hz⟩
-      use equivShrink α z
+      use ULift.up z
       simpa [hz] using PSet.Equiv.symm (Quotient.mk_out y)
 
 @[simp]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
