### PR TITLE
[Merged by Bors] - feat(SetTheory/Order/Basic): not_lt_iff_not_le_or_ge

### DIFF
--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -79,6 +79,9 @@ theorem lt_of_le_of_lt' : b ≤ c → a < b → a < c :=
 theorem lt_of_lt_of_le' : b < c → a ≤ b → a < c :=
   flip lt_of_le_of_lt
 
+theorem not_lt_iff_not_le_or_ge : ¬a < b ↔ ¬a ≤ b ∨ b ≤ a := by
+  rw [lt_iff_le_not_le, Classical.not_and_iff_or_not_not, Classical.not_not]
+
 end Preorder
 
 section PartialOrder

--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 import Batteries.Tactic.Trans
+import Mathlib.Logic.Basic
 import Mathlib.Tactic.ExtendDoc
 import Mathlib.Tactic.Lemma
 import Mathlib.Tactic.SplitIfs
@@ -105,7 +106,7 @@ def decidableLTOfDecidableLE [DecidableRel (α := α) (· ≤ ·)] : DecidableRe
     else isFalse fun hab' => hab (le_of_lt hab')
 
 lemma not_lt_iff_not_le_or_ge : ¬a < b ↔ ¬a ≤ b ∨ b ≤ a := by
-  rw [lt_iff_le_not_le, Classical.not_and_iff_or_not_not, Classical.not_not]
+  rw [lt_iff_le_not_le, not_and_or, Classical.not_not]
 
 end Preorder
 

--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -104,18 +104,8 @@ def decidableLTOfDecidableLE [DecidableRel (α := α) (· ≤ ·)] : DecidableRe
       else isTrue <| lt_of_le_not_le hab hba
     else isFalse fun hab' => hab (le_of_lt hab')
 
-namespace Decidable
-
-variable [DecidableRel (α := α) (· ≤ ·)]
-
 lemma not_lt_iff_not_le_or_ge : ¬a < b ↔ ¬a ≤ b ∨ b ≤ a := by
-  rw [lt_iff_le_not_le, not_and_iff_or_not_not, not_not]
-
-end Decidable
-
-attribute [local instance] Classical.propDecidable
-
-lemma not_lt_iff_not_le_or_ge : ¬a < b ↔ ¬a ≤ b ∨ b ≤ a := Decidable.not_lt_iff_not_le_or_ge
+  rw [lt_iff_le_not_le, Classical.not_and_iff_or_not_not, Classical.not_not]
 
 end Preorder
 

--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 import Batteries.Tactic.Trans
-import Mathlib.Logic.Basic
 import Mathlib.Tactic.ExtendDoc
 import Mathlib.Tactic.Lemma
 import Mathlib.Tactic.SplitIfs
@@ -106,7 +105,7 @@ def decidableLTOfDecidableLE [DecidableRel (α := α) (· ≤ ·)] : DecidableRe
     else isFalse fun hab' => hab (le_of_lt hab')
 
 lemma not_lt_iff_not_le_or_ge : ¬a < b ↔ ¬a ≤ b ∨ b ≤ a := by
-  rw [lt_iff_le_not_le, not_and_or, Classical.not_not]
+  rw [lt_iff_le_not_le, Classical.not_and_iff_or_not_not, Classical.not_not]
 
 end Preorder
 

--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -104,6 +104,19 @@ def decidableLTOfDecidableLE [DecidableRel (α := α) (· ≤ ·)] : DecidableRe
       else isTrue <| lt_of_le_not_le hab hba
     else isFalse fun hab' => hab (le_of_lt hab')
 
+namespace Decidable
+
+variable [DecidableRel (α := α) (· ≤ ·)]
+
+lemma not_lt_iff_not_le_or_ge : ¬a < b ↔ ¬a ≤ b ∨ b ≤ a := by
+  rw [lt_iff_le_not_le, not_and_iff_or_not_not, not_not]
+
+end Decidable
+
+attribute [local instance] Classical.propDecidable
+
+lemma not_lt_iff_not_le_or_ge : ¬a < b ↔ ¬a ≤ b ∨ b ≤ a := Decidable.not_lt_iff_not_le_or_ge
+
 end Preorder
 
 section PartialOrder

--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -104,9 +104,6 @@ def decidableLTOfDecidableLE [DecidableRel (α := α) (· ≤ ·)] : DecidableRe
       else isTrue <| lt_of_le_not_le hab hba
     else isFalse fun hab' => hab (le_of_lt hab')
 
-lemma not_lt_iff_not_le_or_ge : ¬a < b ↔ ¬a ≤ b ∨ b ≤ a := by
-  rw [lt_iff_le_not_le, Classical.not_and_iff_or_not_not, Classical.not_not]
-
 end Preorder
 
 section PartialOrder

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Logic.Relation
 import Mathlib.Logic.Small.Defs
 import Mathlib.Order.GameAdd
-import Mathlib.Order.Defs.PartialOrder
 
 /-!
 # Combinatorial (pre-)games.

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -635,7 +635,7 @@ theorem lf_irrefl (x : PGame) : ¬x ⧏ x :=
 instance : IsIrrefl _ (· ⧏ ·) :=
   ⟨lf_irrefl⟩
 
-protected theorem not_lt {x y : PGame} : ¬(x < y) ↔ y ⧏ x ∨ y ≤ x := not_lt_iff_not_le_or_ge
+protected theorem not_lt {x y : PGame} : ¬ x < y ↔ y ⧏ x ∨ y ≤ x := not_lt_iff_not_le_or_ge
 
 @[trans]
 theorem lf_of_le_of_lf {x y z : PGame} (h₁ : x ≤ y) (h₂ : y ⧏ z) : x ⧏ z := by

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -635,7 +635,6 @@ theorem lf_irrefl (x : PGame) : ¬x ⧏ x :=
 instance : IsIrrefl _ (· ⧏ ·) :=
   ⟨lf_irrefl⟩
 
-@[simp]
 protected theorem not_lt {x y : PGame} : ¬(x < y) ↔ y ⧏ x ∨ y ≤ x := by
   rw [lt_iff_le_and_lf, Classical.not_and_iff_or_not_not, PGame.not_le, PGame.not_lf]
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -627,6 +627,9 @@ theorem lt_of_le_of_lf {x y : PGame} (h₁ : x ≤ y) (h₂ : x ⧏ y) : x < y :
 theorem lf_of_lt {x y : PGame} (h : x < y) : x ⧏ y :=
   h.2
 
+theorem not_lt {x y : PGame} : ¬(x < y) ↔ y ⧏ x ∨ y ≤ x := by
+  simp only [lt_iff_le_and_lf, Classical.not_and_iff_or_not_not, PGame.not_le, PGame.not_lf]
+
 alias _root_.LT.lt.lf := lf_of_lt
 
 theorem lf_irrefl (x : PGame) : ¬x ⧏ x :=

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Logic.Relation
 import Mathlib.Logic.Small.Defs
 import Mathlib.Order.GameAdd
+import Mathlib.Order.Defs.PartialOrder
 
 /-!
 # Combinatorial (pre-)games.
@@ -635,8 +636,8 @@ theorem lf_irrefl (x : PGame) : ¬x ⧏ x :=
 instance : IsIrrefl _ (· ⧏ ·) :=
   ⟨lf_irrefl⟩
 
-protected theorem not_lt {x y : PGame} : ¬(x < y) ↔ y ⧏ x ∨ y ≤ x := by
-  rw [lt_iff_le_and_lf, Classical.not_and_iff_or_not_not, PGame.not_le, PGame.not_lf]
+protected theorem not_lt {x y : PGame} : ¬(x < y) ↔ y ⧏ x ∨ y ≤ x := not_lt_iff_not_le_or_ge
+
 
 @[trans]
 theorem lf_of_le_of_lf {x y z : PGame} (h₁ : x ≤ y) (h₂ : y ⧏ z) : x ⧏ z := by

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -627,9 +627,6 @@ theorem lt_of_le_of_lf {x y : PGame} (h₁ : x ≤ y) (h₂ : x ⧏ y) : x < y :
 theorem lf_of_lt {x y : PGame} (h : x < y) : x ⧏ y :=
   h.2
 
-theorem not_lt {x y : PGame} : ¬(x < y) ↔ y ⧏ x ∨ y ≤ x := by
-  rw [lt_iff_le_and_lf, Classical.not_and_iff_or_not_not, PGame.not_le, PGame.not_lf]
-
 alias _root_.LT.lt.lf := lf_of_lt
 
 theorem lf_irrefl (x : PGame) : ¬x ⧏ x :=
@@ -637,6 +634,10 @@ theorem lf_irrefl (x : PGame) : ¬x ⧏ x :=
 
 instance : IsIrrefl _ (· ⧏ ·) :=
   ⟨lf_irrefl⟩
+
+@[simp]
+protected theorem not_lt {x y : PGame} : ¬(x < y) ↔ y ⧏ x ∨ y ≤ x := by
+  rw [lt_iff_le_and_lf, Classical.not_and_iff_or_not_not, PGame.not_le, PGame.not_lf]
 
 @[trans]
 theorem lf_of_le_of_lf {x y z : PGame} (h₁ : x ≤ y) (h₂ : y ⧏ z) : x ⧏ z := by

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -628,7 +628,7 @@ theorem lf_of_lt {x y : PGame} (h : x < y) : x ⧏ y :=
   h.2
 
 theorem not_lt {x y : PGame} : ¬(x < y) ↔ y ⧏ x ∨ y ≤ x := by
-  simp only [lt_iff_le_and_lf, Classical.not_and_iff_or_not_not, PGame.not_le, PGame.not_lf]
+  rw [lt_iff_le_and_lf,Classical.not_and_iff_or_not_not, PGame.not_le, PGame.not_lf]
 
 alias _root_.LT.lt.lf := lf_of_lt
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -628,7 +628,7 @@ theorem lf_of_lt {x y : PGame} (h : x < y) : x ⧏ y :=
   h.2
 
 theorem not_lt {x y : PGame} : ¬(x < y) ↔ y ⧏ x ∨ y ≤ x := by
-  rw [lt_iff_le_and_lf,Classical.not_and_iff_or_not_not, PGame.not_le, PGame.not_lf]
+  rw [lt_iff_le_and_lf, Classical.not_and_iff_or_not_not, PGame.not_le, PGame.not_lf]
 
 alias _root_.LT.lt.lf := lf_of_lt
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -637,7 +637,6 @@ instance : IsIrrefl _ (· ⧏ ·) :=
 
 protected theorem not_lt {x y : PGame} : ¬(x < y) ↔ y ⧏ x ∨ y ≤ x := not_lt_iff_not_le_or_ge
 
-
 @[trans]
 theorem lf_of_le_of_lf {x y z : PGame} (h₁ : x ≤ y) (h₂ : y ⧏ z) : x ⧏ z := by
   rw [← PGame.not_le] at h₂ ⊢


### PR DESCRIPTION
Adds `not_lt_iff_not_le_or_ge` to produce `not_lt` in complement of `not_lf` and `not_le`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
