### PR TITLE
[Merged by Bors] - chore: remove choice from `Multiset.pi`

### DIFF
--- a/Mathlib/Data/Multiset/Pi.lean
+++ b/Mathlib/Data/Multiset/Pi.lean
@@ -53,8 +53,8 @@ theorem cons_swap {a a' : α} {b : δ a} {b' : δ a'} {m : Multiset α} {f : ∀
   simp only [heq_iff_eq]
   rintro a'' _ rfl
   refine hfunext (by rw [Multiset.cons_swap]) fun ha₁ ha₂ _ => ?_
-  rcases ne_or_eq a'' a with (h₁ | rfl)
-  on_goal 1 => rcases eq_or_ne a'' a' with (rfl | h₂)
+  rcases Decidable.ne_or_eq a'' a with (h₁ | rfl)
+  on_goal 1 => rcases Decidable.eq_or_ne a'' a' with (rfl | h₂)
   all_goals simp [*, Pi.cons_same, Pi.cons_ne]
 
 @[simp, nolint simpNF] -- Porting note: false positive, this lemma can prove itself


### PR DESCRIPTION
Since this doesn't actually complicate the proof or change the statement, this seems harmless.

Originated from [this Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/236446-Type-theory/topic/Setless.20proof.20of.20.60Fin2.201.20-.3E.20Fin2.201.20.5Cneq.20Fin2.202.20-.3E.20Fin2.202.60/near/489156076)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Doing this for `Finset.pi` requires the following change to core:
```diff
@@ namespace List
 theorem eq_nil_iff_forall_not_mem {l : List α} : l = [] ↔ ∀ a, a ∉ l := by
-  cases l <;> simp? [-not_or]
+  cases l <;> simp? [-not_not, -not_or]
```
which I suspect would be received poorly without a larger proposal.