### PR TITLE
[Merged by Bors] - fix: try with a bash escape to avoid backticks

### DIFF
--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -129,14 +129,13 @@ jobs:
       run: |
         BRANCHES="${{ steps.find-branches.outputs.branches }}"
         {
-          printf "msg<<EOF\n"
-          printf "We will need to merge the following branches into \`nightly-testing\`:\n"
-          printf "\`\`\`bash\n"
+          printf $'msg<<EOF\nWe will need to merge the following branches into `nightly-testing`:\n'
+          printf $'```bash\n'
           for BRANCH in $BRANCHES; do
             PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
-            printf "scripts/merge-lean-testing-pr.sh %s   # %s\n" "$PR_NUMBER" "$BRANCH"
+            printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "$PR_NUMBER" "$BRANCH"
           done
-          printf "\`\`\`\n"
+          printf $'```\n'
           printf "EOF"
         } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
[Reported on Zulip](https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/Mergeable.20lean.20testing.20PRs/near/489182290)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
