### PR TITLE
[Merged by Bors] - feat(GroupTheory/QuotientGroup): group correspondence theorem

### DIFF
--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -27,6 +27,9 @@ proves Noether's first and second isomorphism theorems.
   `N` of a group `G`.
 * `QuotientGroup.quotientQuotientEquivQuotient`: Noether's third isomorphism theorem,
   the canonical isomorphism between `(G / N) / (M / N)` and `G / M`, where `N ≤ M`.
+* `QuotientGroup.comapMk'OrderIso`: The correspondence theorem, a lattice
+  isomorphism between the lattice of subgroups of `G ⧸ N` and the sublattice
+  of subgroups of `G` containing `N`.
 
 ## Tags
 
@@ -320,6 +323,34 @@ def quotientQuotientEquivQuotient : (G ⧸ N) ⧸ M.map (QuotientGroup.mk' N) �
     (by ext; simp)
 
 end ThirdIsoThm
+
+section CorrespTheorem
+
+set_option linter.docPrime false
+
+@[to_additive]
+theorem le_comap_mk' (N : Subgroup G) [N.Normal] (H : Subgroup (G ⧸ N)) :
+    N ≤ Subgroup.comap (QuotientGroup.mk' N) H := by
+  simpa using Subgroup.comap_mono (f := mk' N) bot_le
+
+@[to_additive (attr := simp)]
+theorem comap_map_mk' (N H : Subgroup G) [N.Normal] :
+    Subgroup.comap (mk' N) (Subgroup.map (mk' N) H) = N ⊔ H :=
+  by simp [Subgroup.comap_map_eq, sup_comm]
+
+/-- The **correspondence theorem**, or lattice theorem,
+  or fourth isomorphism theorem for multiplicative groups-/
+@[to_additive "The **correspondence theorem**, or lattice theorem,
+  or fourth isomorphism theorem for additive groups"]
+def comap_mk'_OrderIso (N : Subgroup G) [hn : N.Normal] :
+    Subgroup (G ⧸ N) ≃o { H : Subgroup G // N ≤ H } where
+  toFun H' := ⟨Subgroup.comap (mk' N) H', le_comap_mk' N _⟩
+  invFun H := Subgroup.map (mk' N) H
+  left_inv H' := Subgroup.map_comap_eq_self <| by simp
+  right_inv := fun ⟨H, hH⟩ => Subtype.ext_val <| by simpa
+  map_rel_iff' := Subgroup.comap_le_comap_of_surjective <| mk'_surjective _
+
+end CorrespTheorem
 
 section trivial
 

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -342,7 +342,7 @@ theorem comap_map_mk' (N H : Subgroup G) [N.Normal] :
   or fourth isomorphism theorem for multiplicative groups-/
 @[to_additive "The **correspondence theorem**, or lattice theorem,
   or fourth isomorphism theorem for additive groups"]
-def comap_mk'_OrderIso (N : Subgroup G) [hn : N.Normal] :
+def comapMk'OrderIso (N : Subgroup G) [hn : N.Normal] :
     Subgroup (G ⧸ N) ≃o { H : Subgroup G // N ≤ H } where
   toFun H' := ⟨Subgroup.comap (mk' N) H', le_comap_mk' N _⟩
   invFun H := Subgroup.map (mk' N) H

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -326,6 +326,7 @@ end ThirdIsoThm
 
 section CorrespTheorem
 
+-- All these theorems are primed because `QuotientGroup.mk'` is.
 set_option linter.docPrime false
 
 @[to_additive]
@@ -335,8 +336,8 @@ theorem le_comap_mk' (N : Subgroup G) [N.Normal] (H : Subgroup (G ⧸ N)) :
 
 @[to_additive (attr := simp)]
 theorem comap_map_mk' (N H : Subgroup G) [N.Normal] :
-    Subgroup.comap (mk' N) (Subgroup.map (mk' N) H) = N ⊔ H :=
-  by simp [Subgroup.comap_map_eq, sup_comm]
+    Subgroup.comap (mk' N) (Subgroup.map (mk' N) H) = N ⊔ H := by
+  simp [Subgroup.comap_map_eq, sup_comm]
 
 /-- The **correspondence theorem**, or lattice theorem,
   or fourth isomorphism theorem for multiplicative groups-/

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -91,6 +91,10 @@ theorem eq_one_iff {N : Subgroup G} [N.Normal] (x : G) : (x : G ⧸ N) = 1 ↔ x
   refine QuotientGroup.eq.trans ?_
   rw [mul_one, Subgroup.inv_mem_iff]
 
+@[to_additive (attr := simp)]
+theorem range_mk' : (QuotientGroup.mk' N).range = ⊤ :=
+  (Subgroup.eq_top_iff' _).2 <| by rintro ⟨x⟩; exact ⟨x, rfl⟩
+
 @[to_additive]
 theorem ker_le_range_iff {I : Type w} [Group I] (f : G →* H) [f.range.Normal] (g : H →* I) :
     g.ker ≤ f.range ↔ (mk' f.range).comp g.ker.subtype = 1 :=
@@ -101,6 +105,11 @@ theorem ker_le_range_iff {I : Type w} [Group I] (f : G →* H) [f.range.Normal] 
 theorem ker_mk' : MonoidHom.ker (QuotientGroup.mk' N : G →* G ⧸ N) = N :=
   Subgroup.ext eq_one_iff
 -- Porting note: I think this is misnamed without the prime
+
+@[to_additive]
+theorem le_comap_mk' (N : Subgroup G) [N.Normal] (H : Subgroup (G ⧸ N)) :
+    N ≤ Subgroup.comap (QuotientGroup.mk' N) H := by
+  simpa using (Subgroup.comap_mono bot_le : (mk' N).ker ≤ Subgroup.comap (mk' N) H)
 
 @[to_additive]
 theorem eq_iff_div_mem {N : Subgroup G} [nN : N.Normal] {x y : G} :
@@ -215,6 +224,23 @@ theorem map_comp_map {I : Type*} [Group I] (M : Subgroup H) (O : Subgroup I) [M.
       hf.trans ((Subgroup.comap_mono hg).trans_eq (Subgroup.comap_comap _ _ _))) :
     (map M O g hg).comp (map N M f hf) = map N O (g.comp f) hgf :=
   MonoidHom.ext (map_map N M O f g hf hg hgf)
+
+@[to_additive (attr := simp)]
+theorem comap_map_mk' (N H : Subgroup G) [N.Normal] :
+    Subgroup.comap (mk' N) (Subgroup.map (mk' N) H) = N ⊔ H :=
+  by simp [Subgroup.comap_map_eq, sup_comm]
+
+/-- The **correspondence theorem**, or lattice theorem,
+  or fourth isomorphism theorem for multiplicative groups-/
+@[to_additive "The **correspondence theorem**, or lattice theorem,
+  or fourth isomorphism theorem for additive groups"]
+def comap_mk'_OrderIso (N : Subgroup G) [hn : N.Normal] :
+    Subgroup (G ⧸ N) ≃o { H : Subgroup G // N ≤ H } where
+  toFun H' := ⟨Subgroup.comap (mk' N) H', le_comap_mk' N _⟩
+  invFun H := Subgroup.map (mk' N) H
+  left_inv H' := Subgroup.map_comap_eq_self <| by simp
+  right_inv := fun ⟨H, hH⟩ => Subtype.ext_val <| by simpa
+  map_rel_iff' := Subgroup.comap_le_comap_of_surjective <| mk'_surjective _
 
 section Pointwise
 open Set

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -91,9 +91,11 @@ theorem eq_one_iff {N : Subgroup G} [N.Normal] (x : G) : (x : G ⧸ N) = 1 ↔ x
   refine QuotientGroup.eq.trans ?_
   rw [mul_one, Subgroup.inv_mem_iff]
 
+/-- Note: `range_mk'` is a lemma about the primed constructor `QuotientGroup.mk'`, not a
+  modified version of some `range_mk` -/
 @[to_additive (attr := simp)]
 theorem range_mk' : (QuotientGroup.mk' N).range = ⊤ :=
-  (Subgroup.eq_top_iff' _).2 <| by rintro ⟨x⟩; exact ⟨x, rfl⟩
+  MonoidHom.range_eq_top.mpr (mk'_surjective N)
 
 @[to_additive]
 theorem ker_le_range_iff {I : Type w} [Group I] (f : G →* H) [f.range.Normal] (g : H →* I) :
@@ -105,11 +107,6 @@ theorem ker_le_range_iff {I : Type w} [Group I] (f : G →* H) [f.range.Normal] 
 theorem ker_mk' : MonoidHom.ker (QuotientGroup.mk' N : G →* G ⧸ N) = N :=
   Subgroup.ext eq_one_iff
 -- Porting note: I think this is misnamed without the prime
-
-@[to_additive]
-theorem le_comap_mk' (N : Subgroup G) [N.Normal] (H : Subgroup (G ⧸ N)) :
-    N ≤ Subgroup.comap (QuotientGroup.mk' N) H := by
-  simpa using (Subgroup.comap_mono bot_le : (mk' N).ker ≤ Subgroup.comap (mk' N) H)
 
 @[to_additive]
 theorem eq_iff_div_mem {N : Subgroup G} [nN : N.Normal] {x y : G} :
@@ -224,23 +221,6 @@ theorem map_comp_map {I : Type*} [Group I] (M : Subgroup H) (O : Subgroup I) [M.
       hf.trans ((Subgroup.comap_mono hg).trans_eq (Subgroup.comap_comap _ _ _))) :
     (map M O g hg).comp (map N M f hf) = map N O (g.comp f) hgf :=
   MonoidHom.ext (map_map N M O f g hf hg hgf)
-
-@[to_additive (attr := simp)]
-theorem comap_map_mk' (N H : Subgroup G) [N.Normal] :
-    Subgroup.comap (mk' N) (Subgroup.map (mk' N) H) = N ⊔ H :=
-  by simp [Subgroup.comap_map_eq, sup_comm]
-
-/-- The **correspondence theorem**, or lattice theorem,
-  or fourth isomorphism theorem for multiplicative groups-/
-@[to_additive "The **correspondence theorem**, or lattice theorem,
-  or fourth isomorphism theorem for additive groups"]
-def comap_mk'_OrderIso (N : Subgroup G) [hn : N.Normal] :
-    Subgroup (G ⧸ N) ≃o { H : Subgroup G // N ≤ H } where
-  toFun H' := ⟨Subgroup.comap (mk' N) H', le_comap_mk' N _⟩
-  invFun H := Subgroup.map (mk' N) H
-  left_inv H' := Subgroup.map_comap_eq_self <| by simp
-  right_inv := fun ⟨H, hH⟩ => Subtype.ext_val <| by simpa
-  map_rel_iff' := Subgroup.comap_le_comap_of_surjective <| mk'_surjective _
 
 section Pointwise
 open Set

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -91,8 +91,9 @@ theorem eq_one_iff {N : Subgroup G} [N.Normal] (x : G) : (x : G ⧸ N) = 1 ↔ x
   refine QuotientGroup.eq.trans ?_
   rw [mul_one, Subgroup.inv_mem_iff]
 
-/-- Note: `range_mk'` is a lemma about the primed constructor `QuotientGroup.mk'`, not a
-  modified version of some `range_mk` -/
+/- Note: `range_mk'` is a lemma about the primed constructor `QuotientGroup.mk'`, not a
+  modified version of some `range_mk`. -/
+set_option linter.docPrime false in
 @[to_additive (attr := simp)]
 theorem range_mk' : (QuotientGroup.mk' N).range = ⊤ :=
   MonoidHom.range_eq_top.mpr (mk'_surjective N)


### PR DESCRIPTION
add the group correspondence theorem (a.k.a. lattice theorem, fourth isomorphism theorem).

---

edit: forgot to give credit; most of this PR is a translation from [Submodule.comapMkQRelIso](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Quotient/Basic.html#Submodule.comapMkQRelIso)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
