### PR TITLE
[Merged by Bors] - feat: add `IsLeast {n | p n} (Nat.find hp)` and related lemmas

### DIFF
--- a/Mathlib/Data/Int/LeastGreatest.lean
+++ b/Mathlib/Data/Int/LeastGreatest.lean
@@ -5,6 +5,7 @@ Authors: Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Data.Nat.Find
+import Mathlib.Order.Bounds.Defs
 
 /-! # Least upper bound and greatest lower bound properties for integers
 
@@ -51,6 +52,11 @@ def leastOfBdd {P : ℤ → Prop} [DecidablePred P] (b : ℤ) (Hb : ∀ z : ℤ,
     match z, le.dest (Hb _ h), h with
     | _, ⟨_, rfl⟩, h => add_le_add_left (Int.ofNat_le.2 <| Nat.find_min' _ h) _⟩
 
+/-- `Int.leastOfBdd` is the least integer satisfying a predicate which is false for all `z : ℤ` with
+`z < b` for some fixed `b : ℤ`. -/
+lemma isLeast_coe_leastOfBdd {P : ℤ → Prop} [DecidablePred P] (b : ℤ) (Hb : ∀ z : ℤ, P z → b ≤ z)
+    (Hinh : ∃ z : ℤ, P z) : IsLeast {z | P z} (leastOfBdd b Hb Hinh : ℤ) :=
+  (leastOfBdd b Hb Hinh).2
 
 /--
     If `P : ℤ → Prop` is a predicate such that the set `{m : P m}` is bounded below and nonempty,
@@ -83,6 +89,13 @@ def greatestOfBdd {P : ℤ → Prop} [DecidablePred P] (b : ℤ) (Hb : ∀ z : �
     ⟨-elt, by rw [neg_neg]; exact Helt⟩
   let ⟨lb, Plb, al⟩ := leastOfBdd (-b) Hbdd' Hinh'
   ⟨-lb, Plb, fun z h => le_neg.1 <| al _ <| by rwa [neg_neg]⟩
+
+/-- `Int.greatestOfBdd` is the greatest integer satisfying a predicate which is false for all
+`z : ℤ` with `b < z` for some fixed `b : ℤ`. -/
+lemma isGreatest_coe_greatestOfBdd {P : ℤ → Prop} [DecidablePred P] (b : ℤ)
+    (Hb : ∀ z : ℤ, P z → z ≤ b) (Hinh : ∃ z : ℤ, P z) :
+    IsGreatest {z | P z} (greatestOfBdd b Hb Hinh : ℤ) :=
+  (greatestOfBdd b Hb Hinh).2
 
 /--
     If `P : ℤ → Prop` is a predicate such that the set `{m : P m}` is bounded above and nonempty,

--- a/Mathlib/Order/Nat.lean
+++ b/Mathlib/Order/Nat.lean
@@ -3,7 +3,9 @@ Copyright (c) 2014 Floris van Doorn (c) 2016 Microsoft Corporation. All rights r
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
+import Mathlib.Data.Nat.Find
 import Mathlib.Order.BoundedOrder.Basic
+import Mathlib.Order.Bounds.Defs
 
 /-!
 # The natural numbers form a linear order
@@ -31,4 +33,14 @@ instance instNoMaxOrder : NoMaxOrder ℕ where
 -- We want to use this lemma earlier than the lemma simp can prove it with
 @[simp, nolint simpNF] protected lemma bot_eq_zero : ⊥ = 0 := rfl
 
+/-- `Nat.find` is the minimum natural number satisfying a predicate `p`. -/
+lemma isLeast_find {p : ℕ → Prop} [DecidablePred p] (hp : ∃ n, p n) :
+    IsLeast {n | p n} (Nat.find hp) :=
+  ⟨Nat.find_spec hp, fun _ ↦ Nat.find_min' hp⟩
+
 end Nat
+
+/-- `Nat.find` is the minimum element of a nonempty set of natural numbers. -/
+lemma Set.Nonempty.isLeast_natFind {s : Set ℕ} [DecidablePred (· ∈ s)] (hs : s.Nonempty) :
+    IsLeast s (Nat.find hs) :=
+  Nat.isLeast_find hs


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
