### PR TITLE
[Merged by Bors] - chore: make `Decidable` instance for `SimpleGraph.Connected` be reducible

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkCounting.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkCounting.lean
@@ -206,9 +206,9 @@ instance : Fintype G.ConnectedComponent :=
 instance : Decidable G.Preconnected :=
   inferInstanceAs <| Decidable (∀ u v, G.Reachable u v)
 
-instance : Decidable G.Connected := by
-  rw [connected_iff, ← Finset.univ_nonempty_iff]
-  infer_instance
+instance : Decidable G.Connected :=
+  decidable_of_iff (G.Preconnected ∧ (Finset.univ : Finset V).Nonempty) <| by
+    rw [connected_iff, ← Finset.univ_nonempty_iff]
 
 instance Path.instFintype {u v : V} : Fintype (G.Path u v) where
   elems := (univ (α := { p : G.Walk u v | p.IsPath ∧ p.length < Fintype.card V })).map


### PR DESCRIPTION
Suggested by @kmill.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
