### PR TITLE
[Merged by Bors] - feat: boolean subalgebras

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3957,6 +3957,7 @@ import Mathlib.Order.Basic
 import Mathlib.Order.Birkhoff
 import Mathlib.Order.BooleanAlgebra
 import Mathlib.Order.BooleanGenerators
+import Mathlib.Order.BooleanSubalgebra
 import Mathlib.Order.Booleanisation
 import Mathlib.Order.Bounded
 import Mathlib.Order.BoundedOrder.Basic

--- a/Mathlib/Order/BooleanSubalgebra.lean
+++ b/Mathlib/Order/BooleanSubalgebra.lean
@@ -49,7 +49,8 @@ lemma sdiff_mem (ha : a ∈ L) (hb : b ∈ L) : a \ b ∈ L := by
 lemma himp_mem (ha : a ∈ L) (hb : b ∈ L) : a ⇨ b ∈ L := by
   simpa [himp_eq] using L.supClosed hb (compl_mem ha)
 
-@[simp] lemma mem_carrier : a ∈ L.carrier ↔ a ∈ L := .rfl
+lemma mem_carrier : a ∈ L.carrier ↔ a ∈ L := .rfl
+@[simp] lemma mem_toSublattice : a ∈ L.toSublattice ↔ a ∈ L := .rfl
 @[simp] lemma mem_mk {L : Sublattice α} (h_compl h_bot) : a ∈ mk L h_compl h_bot ↔ a ∈ L := .rfl
 @[simp] lemma coe_mk (L : Sublattice α) (h_compl h_bot) : (mk L h_compl h_bot : Set α) = L := rfl
 @[simp] lemma mk_le_mk {L M : Sublattice α} (hL_compl hL_bot hM_compl hM_bot) :

--- a/Mathlib/Order/BooleanSubalgebra.lean
+++ b/Mathlib/Order/BooleanSubalgebra.lean
@@ -1,0 +1,378 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Order.Sublattice
+
+/-!
+# Boolean subalgebras
+
+This file defines boolean subalgebras.
+-/
+
+open Function Set
+
+variable {ι : Sort*} {α β γ : Type*}
+
+variable (α) in
+/-- A boolean subalgebra of a boolean algebra is a set containing the bottom and top elements, and
+closed under suprema, infima and complements. -/
+structure BooleanSubalgebra [BooleanAlgebra α] extends Sublattice α where
+  compl_mem' {a} : a ∈ carrier → aᶜ ∈ carrier
+  bot_mem' : ⊥ ∈ carrier
+
+namespace BooleanSubalgebra
+section BooleanAlgebra
+variable [BooleanAlgebra α] [BooleanAlgebra β] [BooleanAlgebra γ] {L M : BooleanSubalgebra α}
+  {f : BoundedLatticeHom α β} {s t : Set α} {a b : α}
+
+initialize_simps_projections BooleanSubalgebra (carrier → coe)
+
+instance instSetLike : SetLike (BooleanSubalgebra α) α where
+  coe L := L.carrier
+  coe_injective' L M h := by obtain ⟨⟨_, _⟩, _⟩ := L; congr
+
+lemma coe_inj : (L : Set α) = M ↔ L = M := SetLike.coe_set_eq
+
+@[simp] lemma supClosed (L : BooleanSubalgebra α) : SupClosed (L : Set α) := L.supClosed'
+@[simp] lemma infClosed (L : BooleanSubalgebra α) : InfClosed (L : Set α) := L.infClosed'
+
+lemma compl_mem (ha : a ∈ L) : aᶜ ∈ L := L.compl_mem' ha
+@[simp] lemma compl_mem_iff : aᶜ ∈ L ↔ a ∈ L := ⟨fun ha ↦ by simpa using compl_mem ha, compl_mem⟩
+@[simp] lemma bot_mem : ⊥ ∈ L := L.bot_mem'
+@[simp] lemma top_mem : ⊤ ∈ L := by simpa using compl_mem L.bot_mem
+lemma sup_mem (ha : a ∈ L) (hb : b ∈ L) : a ⊔ b ∈ L := L.supClosed ha hb
+lemma inf_mem (ha : a ∈ L) (hb : b ∈ L) : a ⊓ b ∈ L := L.infClosed ha hb
+lemma sdiff_mem (ha : a ∈ L) (hb : b ∈ L) : a \ b ∈ L := by
+  simpa [sdiff_eq] using L.infClosed ha (compl_mem hb)
+lemma himp_mem (ha : a ∈ L) (hb : b ∈ L) : a ⇨ b ∈ L := by
+  simpa [himp_eq] using L.supClosed hb (compl_mem ha)
+
+@[simp] lemma mem_carrier : a ∈ L.carrier ↔ a ∈ L := .rfl
+@[simp] lemma mem_mk {L : Sublattice α} (h_compl h_bot) : a ∈ mk L h_compl h_bot ↔ a ∈ L := .rfl
+@[simp] lemma coe_mk (L : Sublattice α) (h_compl h_bot) : (mk L h_compl h_bot : Set α) = L := rfl
+@[simp] lemma mk_le_mk {L M : Sublattice α} (hL_compl hL_bot hM_compl hM_bot) :
+    mk L hL_compl hL_bot ≤ mk M hM_compl hM_bot ↔ L ≤ M := .rfl
+@[simp] lemma mk_lt_mk{L M : Sublattice α} (hL_compl hL_bot hM_compl hM_bot) :
+    mk L hL_compl hL_bot < mk M hM_compl hM_bot ↔ L < M := .rfl
+
+/-- Copy of a boolean subalgebra with a new `carrier` equal to the old one. Useful to fix
+definitional equalities. -/
+protected def copy (L : BooleanSubalgebra α) (s : Set α) (hs : s = L) : BooleanSubalgebra α where
+  toSublattice := L.toSublattice.copy s <| by subst hs; rfl
+  compl_mem' := by subst hs; exact L.compl_mem'
+  bot_mem' := by subst hs; exact L.bot_mem'
+
+@[simp, norm_cast]
+lemma coe_copy (L : BooleanSubalgebra α) (s : Set α) (hs) : L.copy s hs = s := rfl
+
+lemma copy_eq (L : BooleanSubalgebra α) (s : Set α) (hs) : L.copy s hs = L :=
+  SetLike.coe_injective hs
+
+/-- Two boolean subalgebras are equal if they have the same elements. -/
+lemma ext : (∀ a, a ∈ L ↔ a ∈ M) → L = M := SetLike.ext
+
+/-- A boolean subalgebra of a lattice inherits a bottom element. -/
+instance instBotCoe : Bot L where bot := ⟨⊥, bot_mem⟩
+
+/-- A boolean subalgebra of a lattice inherits a top element. -/
+instance instTopCoe : Top L where top := ⟨⊤, top_mem⟩
+
+/-- A boolean subalgebra of a lattice inherits a supremum. -/
+instance instSupCoe : Max L where max a b := ⟨a ⊔ b, L.supClosed a.2 b.2⟩
+
+/-- A boolean subalgebra of a lattice inherits an infimum. -/
+instance instInfCoe : Min L where min a b := ⟨a ⊓ b, L.infClosed a.2 b.2⟩
+
+/-- A boolean subalgebra of a lattice inherits a complement. -/
+instance instHasComplCoe : HasCompl L where compl a := ⟨aᶜ, compl_mem a.2⟩
+
+/-- A boolean subalgebra of a lattice inherits a difference. -/
+instance instSDiffCoe : SDiff L where sdiff a b := ⟨a \ b, sdiff_mem a.2 b.2⟩
+
+/-- A boolean subalgebra of a lattice inherits a Heyting implication. -/
+instance instHImpCoe : HImp L where himp a b := ⟨a ⇨ b, himp_mem a.2 b.2⟩
+
+@[simp, norm_cast] lemma val_bot : (⊥ : L) = (⊥ : α) := rfl
+@[simp, norm_cast] lemma val_top : (⊤ : L) = (⊤ : α) := rfl
+@[simp, norm_cast] lemma val_sup (a b : L) : a ⊔ b = (a : α) ⊔ b := rfl
+@[simp, norm_cast] lemma val_inf (a b : L) : a ⊓ b = (a : α) ⊓ b := rfl
+@[simp, norm_cast] lemma val_compl (a : L) : aᶜ = (a : α)ᶜ := rfl
+@[simp, norm_cast] lemma val_sdiff (a b : L) : a \ b = (a : α) \ b := rfl
+@[simp, norm_cast] lemma val_himp (a b : L) : a ⇨ b = (a : α) ⇨ b := rfl
+
+@[simp] lemma mk_bot : (⟨⊥, bot_mem⟩ : L) = ⊥ := rfl
+@[simp] lemma mk_top : (⟨⊤, top_mem⟩ : L) = ⊤ := rfl
+@[simp] lemma mk_sup_mk (a b : α) (ha hb) : (⟨a, ha⟩ ⊔ ⟨b, hb⟩ : L) = ⟨a ⊔ b, L.supClosed ha hb⟩ :=
+  rfl
+@[simp] lemma mk_inf_mk (a b : α) (ha hb) : (⟨a, ha⟩ ⊓ ⟨b, hb⟩ : L) = ⟨a ⊓ b, L.infClosed ha hb⟩ :=
+  rfl
+@[simp] lemma compl_mk (a : α) (ha) : (⟨a, ha⟩ : L)ᶜ = ⟨aᶜ, compl_mem ha⟩ := rfl
+@[simp] lemma mk_sdiff_mk (a b : α) (ha hb) : (⟨a, ha⟩ \ ⟨b, hb⟩ : L) = ⟨a \ b, sdiff_mem ha hb⟩ :=
+  rfl
+@[simp] lemma mk_himp_mk (a b : α) (ha hb) : (⟨a, ha⟩ ⇨ ⟨b, hb⟩ : L) = ⟨a ⇨ b, himp_mem ha hb⟩ :=
+  rfl
+
+/-- A boolean subalgebra of a lattice inherits a boolean algebra structure. -/
+instance instBooleanAlgebraCoe (L : BooleanSubalgebra α) : BooleanAlgebra L :=
+  Subtype.coe_injective.booleanAlgebra _ val_sup val_inf val_top val_bot val_compl val_sdiff
+    val_himp
+
+/-- The natural lattice hom from a boolean subalgebra to the original lattice. -/
+def subtype (L : BooleanSubalgebra α) : BoundedLatticeHom L α where
+  toFun := ((↑) : L → α)
+  map_bot' := L.val_bot
+  map_top' := L.val_top
+  map_sup' := val_sup
+  map_inf' := val_inf
+
+@[simp, norm_cast] lemma coe_subtype (L : BooleanSubalgebra α) : L.subtype = ((↑) : L → α) := rfl
+lemma subtype_apply (L : BooleanSubalgebra α) (a : L) : L.subtype a = a := rfl
+
+lemma subtype_injective (L : BooleanSubalgebra α) : Injective <| subtype L := Subtype.coe_injective
+
+/-- The inclusion homomorphism from a boolean subalgebra `L` to a bigger boolean subalgebra `M`. -/
+def inclusion (h : L ≤ M) : BoundedLatticeHom L M where
+  toFun := Set.inclusion h
+  map_bot' := rfl
+  map_top' := rfl
+  map_sup' _ _ := rfl
+  map_inf' _ _ := rfl
+
+@[simp] lemma coe_inclusion (h : L ≤ M) : inclusion h = Set.inclusion h := rfl
+lemma inclusion_apply (h : L ≤ M) (a : L) : inclusion h a = Set.inclusion h a := rfl
+
+lemma inclusion_injective (h : L ≤ M) : Injective <| inclusion h := Set.inclusion_injective h
+
+@[simp] lemma inclusion_rfl (L : BooleanSubalgebra α) : inclusion le_rfl = .id L := rfl
+@[simp] lemma subtype_comp_inclusion (h : L ≤ M) : M.subtype.comp (inclusion h) = L.subtype := rfl
+
+/-- The maximum boolean subalgebra of a lattice. -/
+instance instTop : Top (BooleanSubalgebra α) where
+  top.carrier := univ
+  top.bot_mem' := mem_univ _
+  top.compl_mem' _ := mem_univ _
+  top.supClosed' := supClosed_univ
+  top.infClosed' := infClosed_univ
+
+/-- The trivial boolean subalgebra of a lattice. -/
+instance instBot : Bot (BooleanSubalgebra α) where
+  bot.carrier := {⊥, ⊤}
+  bot.bot_mem' := by aesop
+  bot.compl_mem' := by aesop
+  bot.supClosed' _ := by aesop
+  bot.infClosed' _ := by aesop
+
+/-- The inf of two boolean subalgebras is their intersection. -/
+instance instInf : Min (BooleanSubalgebra α) where
+  min L M :=  { carrier := L ∩ M
+                bot_mem' := ⟨bot_mem, bot_mem⟩
+                compl_mem' := fun ha ↦ ⟨compl_mem ha.1, compl_mem ha.2⟩
+                supClosed' := L.supClosed.inter M.supClosed
+                infClosed' := L.infClosed.inter M.infClosed }
+
+/-- The inf of boolean subalgebras is their intersection. -/
+instance instInfSet : InfSet (BooleanSubalgebra α) where
+  sInf S := { carrier := ⋂ L ∈ S, L
+              bot_mem' := mem_iInter₂.2 fun _ _ ↦ bot_mem
+              compl_mem' := fun ha ↦ mem_iInter₂.2 fun L hL ↦ compl_mem <| mem_iInter₂.1 ha L hL
+              supClosed' := supClosed_sInter <| forall_mem_range.2 fun L ↦ supClosed_sInter <|
+                forall_mem_range.2 fun _ ↦ L.supClosed
+              infClosed' := infClosed_sInter <| forall_mem_range.2 fun L ↦ infClosed_sInter <|
+                forall_mem_range.2 fun _ ↦ L.infClosed }
+
+instance instInhabited : Inhabited (BooleanSubalgebra α) := ⟨⊥⟩
+
+/-- The top boolean subalgebra is isomorphic to the lattice.
+
+This is the boolean subalgebra version of `Equiv.Set.univ α`. -/
+def topEquiv : (⊤ : BooleanSubalgebra α) ≃o α where
+  toEquiv := Equiv.Set.univ _
+  map_rel_iff' := .rfl
+
+@[simp, norm_cast] lemma coe_top : (⊤ : BooleanSubalgebra α) = (univ : Set α) := rfl
+@[simp, norm_cast] lemma coe_bot : (⊥ : BooleanSubalgebra α) = ({⊥, ⊤} : Set α) := rfl
+@[simp, norm_cast] lemma coe_inf (L M : BooleanSubalgebra α) : L ⊓ M = (L : Set α) ∩ M := rfl
+
+@[simp, norm_cast]
+lemma coe_sInf (S : Set (BooleanSubalgebra α)) : sInf S = ⋂ L ∈ S, (L : Set α) := rfl
+
+@[simp, norm_cast]
+lemma coe_iInf (f : ι → BooleanSubalgebra α) : ⨅ i, f i = ⋂ i, (f i : Set α) := by simp [iInf]
+
+@[simp, norm_cast] lemma coe_eq_univ : L = (univ : Set α) ↔ L = ⊤ := by rw [← coe_top, coe_inj]
+
+@[simp] lemma mem_bot : a ∈ (⊥ : BooleanSubalgebra α) ↔ a = ⊥ ∨ a = ⊤ := .rfl
+@[simp] lemma mem_top : a ∈ (⊤ : BooleanSubalgebra α) := mem_univ _
+@[simp] lemma mem_inf : a ∈ L ⊓ M ↔ a ∈ L ∧ a ∈ M := .rfl
+@[simp] lemma mem_sInf {S : Set (BooleanSubalgebra α)} : a ∈ sInf S ↔ ∀ L ∈ S, a ∈ L := by
+  rw [← SetLike.mem_coe]; simp
+@[simp] lemma mem_iInf {f : ι → BooleanSubalgebra α} : a ∈ ⨅ i, f i ↔ ∀ i, a ∈ f i := by
+  rw [← SetLike.mem_coe]; simp
+
+/-- BooleanSubalgebras of a lattice form a complete lattice. -/
+instance instCompleteLattice : CompleteLattice (BooleanSubalgebra α) where
+  bot := ⊥
+  bot_le _S _a := by aesop
+  top := ⊤
+  le_top _S a _ha := mem_top
+  inf := (· ⊓ ·)
+  le_inf _L _M _N hM hN _a ha := ⟨hM ha, hN ha⟩
+  inf_le_left _L _M _a := And.left
+  inf_le_right _L _M _a := And.right
+  __ := completeLatticeOfInf (BooleanSubalgebra α)
+      fun _s ↦ IsGLB.of_image SetLike.coe_subset_coe isGLB_biInf
+
+instance [IsEmpty α] : Subsingleton (BooleanSubalgebra α) := SetLike.coe_injective.subsingleton
+instance [IsEmpty α] : Unique (BooleanSubalgebra α) := uniqueOfSubsingleton ⊤
+
+/-- The preimage of a boolean subalgebra along a bounded lattice homomorphism. -/
+def comap (f : BoundedLatticeHom α β) (L : BooleanSubalgebra β) : BooleanSubalgebra α where
+  carrier := f ⁻¹' L
+  bot_mem' := by simp
+  compl_mem' := by simp [map_compl']
+  supClosed' := L.supClosed.preimage _
+  infClosed' := L.infClosed.preimage _
+
+@[simp, norm_cast]
+lemma coe_comap (L : BooleanSubalgebra β) (f : BoundedLatticeHom α β) : L.comap f = f ⁻¹' L := rfl
+
+@[simp] lemma mem_comap {L : BooleanSubalgebra β} : a ∈ L.comap f ↔ f a ∈ L := .rfl
+
+lemma comap_mono : Monotone (comap f) := fun _ _ ↦ preimage_mono
+
+@[simp] lemma comap_id (L : BooleanSubalgebra α) : L.comap (BoundedLatticeHom.id _) = L := rfl
+
+@[simp] lemma comap_comap (L : BooleanSubalgebra γ) (g : BoundedLatticeHom β γ)
+    (f : BoundedLatticeHom α β) : (L.comap g).comap f = L.comap (g.comp f) := rfl
+
+/-- The image of a boolean subalgebra along a monoid homomorphism is a boolean subalgebra. -/
+def map (f : BoundedLatticeHom α β) (L : BooleanSubalgebra α) : BooleanSubalgebra β where
+  carrier := f '' L
+  bot_mem' := ⟨⊥, by simp⟩
+  compl_mem' := by rintro _ ⟨a, ha, rfl⟩; exact ⟨aᶜ, by simpa [map_compl']⟩
+  supClosed' := L.supClosed.image f
+  infClosed' := L.infClosed.image f
+
+@[simp] lemma coe_map (f : BoundedLatticeHom α β) (L : BooleanSubalgebra α) :
+    (L.map f : Set β) = f '' L := rfl
+
+@[simp] lemma mem_map {b : β} : b ∈ L.map f ↔ ∃ a ∈ L, f a = b := .rfl
+
+lemma mem_map_of_mem (f : BoundedLatticeHom α β) {a : α} : a ∈ L → f a ∈ L.map f :=
+  mem_image_of_mem f
+
+lemma apply_coe_mem_map (f : BoundedLatticeHom α β) (a : L) : f a ∈ L.map f :=
+  mem_map_of_mem f a.prop
+
+lemma map_mono : Monotone (map f) := fun _ _ ↦ image_subset _
+
+@[simp] lemma map_id : L.map (.id α) = L := SetLike.coe_injective <| image_id _
+
+@[simp] lemma map_map (g : BoundedLatticeHom β γ) (f : BoundedLatticeHom α β) :
+    (L.map f).map g = L.map (g.comp f) := SetLike.coe_injective <| image_image _ _ _
+
+lemma mem_map_equiv {f : α ≃o β} {a : β} : a ∈ L.map f ↔ f.symm a ∈ L := Set.mem_image_equiv
+
+lemma apply_mem_map_iff (hf : Injective f) : f a ∈ L.map f ↔ a ∈ L := hf.mem_set_image
+
+lemma map_equiv_eq_comap_symm (f : α ≃o β) (L : BooleanSubalgebra α) :
+    L.map f = L.comap (f.symm : BoundedLatticeHom β α) :=
+  SetLike.coe_injective <| f.toEquiv.image_eq_preimage L
+
+lemma comap_equiv_eq_map_symm (f : β ≃o α) (L : BooleanSubalgebra α) :
+    L.comap f = L.map (f.symm : BoundedLatticeHom α β) := (map_equiv_eq_comap_symm f.symm L).symm
+
+lemma map_symm_eq_iff_eq_map {M : BooleanSubalgebra β} {e : β ≃o α} :
+    L.map ↑e.symm = M ↔ L = M.map ↑e := by
+  simp_rw [← coe_inj]; exact (Equiv.eq_image_iff_symm_image_eq _ _ _).symm
+
+lemma map_le_iff_le_comap {f : BoundedLatticeHom α β} {M : BooleanSubalgebra β} :
+    L.map f ≤ M ↔ L ≤ M.comap f := image_subset_iff
+
+lemma gc_map_comap (f : BoundedLatticeHom α β) : GaloisConnection (map f) (comap f) :=
+  fun _ _ ↦ map_le_iff_le_comap
+
+@[simp] lemma map_bot (f : BoundedLatticeHom α β) : (⊥ : BooleanSubalgebra α).map f = ⊥ :=
+  (gc_map_comap f).l_bot
+
+lemma map_sup (f : BoundedLatticeHom α β) (L M : BooleanSubalgebra α) :
+    (L ⊔ M).map f = L.map f ⊔ M.map f := (gc_map_comap f).l_sup
+
+lemma map_iSup (f : BoundedLatticeHom α β) (L : ι → BooleanSubalgebra α) :
+    (⨆ i, L i).map f = ⨆ i, (L i).map f := (gc_map_comap f).l_iSup
+
+@[simp] lemma comap_top (f : BoundedLatticeHom α β) : (⊤ : BooleanSubalgebra β).comap f = ⊤ :=
+  (gc_map_comap f).u_top
+
+lemma comap_inf (L M : BooleanSubalgebra β) (f : BoundedLatticeHom α β) :
+    (L ⊓ M).comap f = L.comap f ⊓ M.comap f := (gc_map_comap f).u_inf
+
+lemma comap_iInf (f : BoundedLatticeHom α β) (L : ι → BooleanSubalgebra β) :
+    (⨅ i, L i).comap f = ⨅ i, (L i).comap f := (gc_map_comap f).u_iInf
+
+lemma map_inf_le (L M : BooleanSubalgebra α) (f : BoundedLatticeHom α β) :
+    map f (L ⊓ M) ≤ map f L ⊓ map f M := map_mono.map_inf_le _ _
+
+lemma le_comap_sup (L M : BooleanSubalgebra β) (f : BoundedLatticeHom α β) :
+    comap f L ⊔ comap f M ≤ comap f (L ⊔ M) := comap_mono.le_map_sup _ _
+
+lemma le_comap_iSup (f : BoundedLatticeHom α β) (L : ι → BooleanSubalgebra β) :
+    ⨆ i, (L i).comap f ≤ (⨆ i, L i).comap f := comap_mono.le_map_iSup
+
+lemma map_inf (L M : BooleanSubalgebra α) (f : BoundedLatticeHom α β) (hf : Injective f) :
+    map f (L ⊓ M) = map f L ⊓ map f M := by
+  rw [← SetLike.coe_set_eq]
+  simp [Set.image_inter hf]
+
+lemma map_top (f : BoundedLatticeHom α β) (h : Surjective f) : BooleanSubalgebra.map f ⊤ = ⊤ :=
+  SetLike.coe_injective <| by simp [h.range_eq]
+
+/-- The minimum boolean algebra containing a given set. -/
+def closure (s : Set α) : BooleanSubalgebra α := sInf {L | s ⊆ L}
+
+variable {s : Set α}
+
+lemma mem_closure {x : α} : x ∈ closure s ↔ ∀ ⦃L : BooleanSubalgebra α⦄, s ⊆ L → x ∈ L := mem_sInf
+
+@[aesop safe 20 apply (rule_sets := [SetLike])]
+lemma subset_closure : s ⊆ closure s := fun _ hx ↦ mem_closure.2 fun _ hK ↦ hK hx
+
+@[simp] lemma closure_le : closure s ≤ L ↔ s ⊆ L := ⟨subset_closure.trans, fun h ↦ sInf_le h⟩
+
+/-- An induction principle for closure membership. If `p` holds for `⊥` and all elements of `s`, and
+is preserved under suprema and complement, then `p` holds for all elements of the closure of `s`. -/
+@[elab_as_elim]
+lemma closure_bot_sup_induction {p : ∀ g ∈ closure s, Prop} (mem : ∀ x hx, p x (subset_closure hx))
+    (bot : p ⊥ bot_mem)
+    (sup : ∀ x hx y hy, p x hx → p y hy → p (x ⊔ y) (supClosed _ hx hy))
+    (compl : ∀ x hx, p x hx → p xᶜ (compl_mem hx)) {x} (hx : x ∈ closure s) : p x hx :=
+  have inf ⦃x hx y hy⦄ (hx' : p x hx) (hy' : p y hy) : p (x ⊓ y) (infClosed _ hx hy) := by
+    simpa using compl _ _ <| sup _ _ _ _ (compl _ _ hx') (compl _ _ hy')
+  let L : BooleanSubalgebra α :=
+    { carrier := { x | ∃ hx, p x hx }
+      supClosed' := fun _a ⟨_, ha⟩ _b ⟨_, hb⟩ ↦ ⟨_, sup _ _ _ _ ha hb⟩
+      infClosed' := fun _a ⟨_, ha⟩ _b ⟨_, hb⟩ ↦ ⟨_, inf ha hb⟩
+      bot_mem' := ⟨_, bot⟩
+      compl_mem' := fun ⟨_, hb⟩ ↦ ⟨_, compl _ _ hb⟩ }
+  closure_le (L := L).mpr (fun y hy ↦ ⟨subset_closure hy, mem y hy⟩) hx |>.elim fun _ ↦ id
+
+end BooleanAlgebra
+
+section CompleteBooleanAlgebra
+variable [CompleteBooleanAlgebra α] {L : BooleanSubalgebra α} {f : ι → α} {s : Set α}
+
+lemma iSup_mem [Finite ι] (hf : ∀ i, f i ∈ L) : ⨆ i, f i ∈ L := L.supClosed.iSup_mem bot_mem hf
+lemma iInf_mem [Finite ι] (hf : ∀ i, f i ∈ L) : ⨅ i, f i ∈ L := L.infClosed.iInf_mem top_mem hf
+lemma sSup_mem (hs : s.Finite) (hsL : s ⊆ L) : sSup s ∈ L := L.supClosed.sSup_mem hs bot_mem hsL
+lemma sInf_mem (hs : s.Finite) (hsL : s ⊆ L) : sInf s ∈ L := L.infClosed.sInf_mem hs top_mem hsL
+
+lemma biSup_mem {ι : Type*} {t : Set ι} {f : ι → α} (ht : t.Finite) (hf : ∀ i ∈ t, f i ∈ L) :
+    ⨆ i ∈ t, f i ∈ L := L.supClosed.biSup_mem ht bot_mem hf
+
+lemma biInf_mem {ι : Type*} {t : Set ι} {f : ι → α} (ht : t.Finite) (hf : ∀ i ∈ t, f i ∈ L) :
+    ⨅ i ∈ t, f i ∈ L := L.infClosed.biInf_mem ht top_mem hf
+
+end CompleteBooleanAlgebra
+end BooleanSubalgebra

--- a/Mathlib/Order/BooleanSubalgebra.lean
+++ b/Mathlib/Order/BooleanSubalgebra.lean
@@ -27,7 +27,7 @@ section BooleanAlgebra
 variable [BooleanAlgebra α] [BooleanAlgebra β] [BooleanAlgebra γ] {L M : BooleanSubalgebra α}
   {f : BoundedLatticeHom α β} {s t : Set α} {a b : α}
 
-initialize_simps_projections BooleanSubalgebra (carrier → coe)
+initialize_simps_projections BooleanSubalgebra (carrier → coe, as_prefix coe)
 
 instance instSetLike : SetLike (BooleanSubalgebra α) α where
   coe L := L.carrier
@@ -185,7 +185,7 @@ instance instInfSet : InfSet (BooleanSubalgebra α) where
 
 instance instInhabited : Inhabited (BooleanSubalgebra α) := ⟨⊥⟩
 
-/-- The top boolean subalgebra is isomorphic to the lattice.
+/-- The top boolean subalgebra is isomorphic to the original boolean algebra.
 
 This is the boolean subalgebra version of `Equiv.Set.univ α`. -/
 def topEquiv : (⊤ : BooleanSubalgebra α) ≃o α where
@@ -330,7 +330,7 @@ lemma map_inf (L M : BooleanSubalgebra α) (f : BoundedLatticeHom α β) (hf : I
 lemma map_top (f : BoundedLatticeHom α β) (h : Surjective f) : BooleanSubalgebra.map f ⊤ = ⊤ :=
   SetLike.coe_injective <| by simp [h.range_eq]
 
-/-- The minimum boolean algebra containing a given set. -/
+/-- The minimum boolean subalgebra containing a given set. -/
 def closure (s : Set α) : BooleanSubalgebra α := sInf {L | s ⊆ L}
 
 variable {s : Set α}
@@ -341,6 +341,8 @@ lemma mem_closure {x : α} : x ∈ closure s ↔ ∀ ⦃L : BooleanSubalgebra α
 lemma subset_closure : s ⊆ closure s := fun _ hx ↦ mem_closure.2 fun _ hK ↦ hK hx
 
 @[simp] lemma closure_le : closure s ≤ L ↔ s ⊆ L := ⟨subset_closure.trans, fun h ↦ sInf_le h⟩
+
+lemma closure_mono (hst : s ⊆ t) : closure s ≤ closure t := sInf_le_sInf fun _L ↦ hst.trans
 
 /-- An induction principle for closure membership. If `p` holds for `⊥` and all elements of `s`, and
 is preserved under suprema and complement, then `p` holds for all elements of the closure of `s`. -/

--- a/Mathlib/Order/Sublattice.lean
+++ b/Mathlib/Order/Sublattice.lean
@@ -34,7 +34,7 @@ structure Sublattice where
 variable {α β γ}
 
 namespace Sublattice
-variable {L M : Sublattice α} {f : LatticeHom α β} {s t : Set α} {a : α}
+variable {L M : Sublattice α} {f : LatticeHom α β} {s t : Set α} {a b : α}
 
 instance instSetLike : SetLike (Sublattice α) α where
   coe L := L.carrier
@@ -52,6 +52,8 @@ lemma coe_inj : (L : Set α) = M ↔ L = M := SetLike.coe_set_eq
 
 @[simp] lemma supClosed (L : Sublattice α) : SupClosed (L : Set α) := L.supClosed'
 @[simp] lemma infClosed (L : Sublattice α) : InfClosed (L : Set α) := L.infClosed'
+lemma sup_mem (ha : a ∈ L) (hb : b ∈ L) : a ⊔ b ∈ L := L.supClosed ha hb
+lemma inf_mem (ha : a ∈ L) (hb : b ∈ L) : a ⊓ b ∈ L := L.infClosed ha hb
 @[simp] lemma isSublattice (L : Sublattice α) : IsSublattice (L : Set α) :=
   ⟨L.supClosed, L.infClosed⟩
 
@@ -154,7 +156,7 @@ instance instInfSet : InfSet (Sublattice α) where
 
 instance instInhabited : Inhabited (Sublattice α) := ⟨⊥⟩
 
-/-- The top sublattice is isomorphic to the lattice.
+/-- The top sublattice is isomorphic to the original lattice.
 
 This is the sublattice version of `Equiv.Set.univ α`. -/
 def topEquiv : (⊤ : Sublattice α) ≃o α where


### PR DESCRIPTION
From GrowthInGroups (LeanCamCombi)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
