### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): setup of universal vertices

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2290,6 +2290,7 @@ import Mathlib.Combinatorics.SimpleGraph.Triangle.Counting
 import Mathlib.Combinatorics.SimpleGraph.Triangle.Removal
 import Mathlib.Combinatorics.SimpleGraph.Triangle.Tripartite
 import Mathlib.Combinatorics.SimpleGraph.Turan
+import Mathlib.Combinatorics.SimpleGraph.UniversalVerts
 import Mathlib.Combinatorics.SimpleGraph.Walk
 import Mathlib.Combinatorics.Young.SemistandardTableau
 import Mathlib.Combinatorics.Young.YoungDiagram

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -38,7 +38,7 @@ lemma isClique_universalVerts (G : SimpleGraph V) : G.IsClique G.universalVerts 
 def deleteUniversalVerts (G : SimpleGraph V) : Subgraph G :=
   ((⊤ : Subgraph G).deleteVerts G.universalVerts)
 
-lemma Subgraph.IsMatching.exists_of_universalVerts [Fintype V] [DecidableEq V] {s : Set V}
+lemma Subgraph.IsMatching.exists_of_universalVerts [Fintype V] {s : Set V}
     (h : Disjoint G.universalVerts s) (hc : s.ncard ≤ G.universalVerts.ncard) :
     ∃ t ⊆ G.universalVerts, ∃ (M : Subgraph G), M.IsMatching ∧ M.verts = s ∪ t := by
   obtain ⟨t, ht⟩ := Set.exists_subset_card_eq hc

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -26,13 +26,13 @@ variable {V : Type*} {G : SimpleGraph V}
 /--
   The set of vertices that are connected to all other vertices.
 -/
-def universalVerts (G : SimpleGraph V) : Set V := {v : V | ∀ w, v ≠ w → G.Adj w v}
+def universalVerts (G : SimpleGraph V) : Set V := {v : V | ∀ ⦃w⦄, v ≠ w → G.Adj w v}
 
 lemma isClique_universalVerts (G : SimpleGraph V) : G.IsClique G.universalVerts :=
   fun x _ _ hy hxy ↦ hy x hxy.symm
 
 /--
-  The subgraph of `G` with the universal vertices removed.
+The subgraph of `G` with the universal vertices removed.
 -/
 @[simps!]
 def deleteUniversalVerts (G : SimpleGraph V) : Subgraph G :=

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -36,7 +36,7 @@ lemma isClique_universalVerts (G : SimpleGraph V) : G.IsClique G.universalVerts 
 -/
 @[simps!]
 def deleteUniversalVerts (G : SimpleGraph V) : Subgraph G :=
-  ((⊤ : Subgraph G).deleteVerts G.universalVerts)
+  (⊤ : Subgraph G).deleteVerts G.universalVerts
 
 lemma Subgraph.IsMatching.exists_of_universalVerts [Fintype V] {s : Set V}
     (h : Disjoint G.universalVerts s) (hc : s.ncard ≤ G.universalVerts.ncard) :
@@ -45,7 +45,7 @@ lemma Subgraph.IsMatching.exists_of_universalVerts [Fintype V] {s : Set V}
   use t
   refine ⟨ht.1, ?_⟩
   have f : s ≃ t := by
-    simp only [← Set.Nat.card_coe_set_eq, Nat.card.eq_1] at ht
+    simp only [← Set.Nat.card_coe_set_eq, Nat.card] at ht
     have : Nonempty (s ≃ t) := by
       rw [← Cardinal.eq]
       exact Cardinal.toNat_injOn (Set.mem_Iio.mpr (Set.Finite.lt_aleph0 (s.toFinite)))

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -29,7 +29,7 @@ variable {V : Type*} {G : SimpleGraph V}
 def universalVerts (G : SimpleGraph V) : Set V := {v : V | ∀ ⦃w⦄, v ≠ w → G.Adj w v}
 
 lemma isClique_universalVerts (G : SimpleGraph V) : G.IsClique G.universalVerts :=
-  fun x _ _ hy hxy ↦ hy x hxy.symm
+  fun _ _ _ hy hxy ↦ hy hxy.symm
 
 /--
 The subgraph of `G` with the universal vertices removed.

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -24,7 +24,7 @@ namespace SimpleGraph
 variable {V : Type*} {G : SimpleGraph V}
 
 /--
-  The set of vertices that are connected to all other vertices.
+The set of vertices that are connected to all other vertices.
 -/
 def universalVerts (G : SimpleGraph V) : Set V := {v : V | ∀ ⦃w⦄, v ≠ w → G.Adj w v}
 

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -40,25 +40,13 @@ def deleteUniversalVerts (G : SimpleGraph V) : Subgraph G :=
 
 lemma Subgraph.IsMatching.exists_of_universalVerts [Fintype V] {s : Set V}
     (h : Disjoint G.universalVerts s) (hc : s.ncard ≤ G.universalVerts.ncard) :
-    ∃ t ⊆ G.universalVerts, ∃ (M : Subgraph G), M.IsMatching ∧ M.verts = s ∪ t := by
+    ∃ t ⊆ G.universalVerts, ∃ (M : Subgraph G), M.verts = s ∪ t ∧ M.IsMatching := by
   obtain ⟨t, ht⟩ := Set.exists_subset_card_eq hc
-  use t
-  refine ⟨ht.1, ?_⟩
-  have f : s ≃ t := by
-    simp only [← Set.Nat.card_coe_set_eq, Nat.card] at ht
-    have : Nonempty (s ≃ t) := by
-      rw [← Cardinal.eq]
-      exact Cardinal.toNat_injOn (Set.mem_Iio.mpr s.toFinite.lt_aleph0)
-        (Set.mem_Iio.mpr t.toFinite.lt_aleph0) ht.2.symm
-    exact Classical.arbitrary _
-  have hd := (Set.disjoint_of_subset_left ht.1 h).symm
-  have hadj : ∀ (v : s), G.Adj v (f v) := by
-    intro v
-    have : ((f v) : V) ∈ G.universalVerts := ht.1 (f v).coe_prop
-    simp only [universalVerts, Set.mem_setOf_eq] at this
-    apply this
-    exact (hd.ne_of_mem v.coe_prop (f v).coe_prop).symm
-  obtain ⟨M1, hM1⟩ := Subgraph.IsMatching.exists_of_disjoint_sets_of_equiv hd f hadj
-  aesop
+  refine ⟨t, ht.1, ?_⟩
+  obtain ⟨f⟩ : Nonempty (s ≃ t) := by
+    rw [← Cardinal.eq, ← t.toFinite.cast_ncard, ← s.toFinite.cast_ncard, ht.2]
+  letI hd := Set.disjoint_of_subset_left ht.1 h
+  have hadj (v : s) : G.Adj v (f v) := ht.1 (f v).2 (hd.ne_of_mem (f v).2 v.2)
+  exact Subgraph.IsMatching.exists_of_disjoint_sets_of_equiv hd.symm f hadj
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -57,7 +57,7 @@ lemma Subgraph.IsMatching.exists_of_universalVerts [Fintype V] {s : Set V}
     have : ((f v) : V) ∈ G.universalVerts := ht.1 (f v).coe_prop
     simp only [universalVerts, Set.mem_setOf_eq] at this
     apply this
-    exact (Disjoint.ne_of_mem hd v.coe_prop (f v).coe_prop).symm
+    exact (hd.ne_of_mem v.coe_prop (f v).coe_prop).symm
   obtain ⟨M1, hM1⟩ := Subgraph.IsMatching.exists_of_disjoint_sets_of_equiv hd f hadj
   aesop
 

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -52,16 +52,13 @@ lemma Subgraph.IsMatching.exists_of_universalVerts [Fintype V] [DecidableEq V] {
         (Set.mem_Iio.mpr (Set.Finite.lt_aleph0 (Set.toFinite t))) ht.2.symm
     exact (Classical.inhabited_of_nonempty this).default
   have hd := (Set.disjoint_of_subset_left ht.1 h).symm
-  obtain ⟨M1, hM1⟩ := Subgraph.IsMatching.exists_of_disjoint_sets_of_equiv
-    hd
-    f
+  obtain ⟨M1, hM1⟩ := Subgraph.IsMatching.exists_of_disjoint_sets_of_equiv hd f
     (by
       intro v
       have : ((f v) : V) ∈ G.universalVerts := ht.1 (f v).coe_prop
       simp only [universalVerts, Set.mem_setOf_eq] at this
       apply this
-      rw [ne_comm]
-      exact Disjoint.ne_of_mem hd v.coe_prop (f v).coe_prop)
+      exact (Disjoint.ne_of_mem hd v.coe_prop (f v).coe_prop).symm)
   aesop
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -52,7 +52,7 @@ lemma Subgraph.IsMatching.exists_of_universalVerts [Fintype V] {s : Set V}
         (Set.mem_Iio.mpr t.toFinite.lt_aleph0) ht.2.symm
     exact Classical.arbitrary _
   have hd := (Set.disjoint_of_subset_left ht.1 h).symm
-  have hadj : ∀ (v : ↑s), G.Adj v (f v) := by
+  have hadj : ∀ (v : s), G.Adj v (f v) := by
     intro v
     have : ((f v) : V) ∈ G.universalVerts := ht.1 (f v).coe_prop
     simp only [universalVerts, Set.mem_setOf_eq] at this

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -44,7 +44,7 @@ lemma Subgraph.IsMatching.exists_of_universalVerts [Fintype V] {s : Set V}
   obtain ⟨t, ht⟩ := Set.exists_subset_card_eq hc
   refine ⟨t, ht.1, ?_⟩
   obtain ⟨f⟩ : Nonempty (s ≃ t) := by
-    rw [← Cardinal.eq, ← t.toFinite.cast_ncard, ← s.toFinite.cast_ncard, ht.2]
+    rw [← Cardinal.eq, ← t.cast_ncard t.toFinite, ← s.cast_ncard s.toFinite, ht.2]
   letI hd := Set.disjoint_of_subset_left ht.1 h
   have hadj (v : s) : G.Adj v (f v) := ht.1 (f v).2 (hd.ne_of_mem (f v).2 v.2)
   exact Subgraph.IsMatching.exists_of_disjoint_sets_of_equiv hd.symm f hadj

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -48,17 +48,17 @@ lemma Subgraph.IsMatching.exists_of_universalVerts [Fintype V] {s : Set V}
     simp only [← Set.Nat.card_coe_set_eq, Nat.card] at ht
     have : Nonempty (s ≃ t) := by
       rw [← Cardinal.eq]
-      exact Cardinal.toNat_injOn (Set.mem_Iio.mpr (Set.Finite.lt_aleph0 (s.toFinite)))
-        (Set.mem_Iio.mpr (Set.Finite.lt_aleph0 (Set.toFinite t))) ht.2.symm
-    exact (Classical.inhabited_of_nonempty this).default
+      exact Cardinal.toNat_injOn (Set.mem_Iio.mpr s.toFinite.lt_aleph0)
+        (Set.mem_Iio.mpr t.toFinite.lt_aleph0) ht.2.symm
+    exact Classical.arbitrary _
   have hd := (Set.disjoint_of_subset_left ht.1 h).symm
-  obtain ⟨M1, hM1⟩ := Subgraph.IsMatching.exists_of_disjoint_sets_of_equiv hd f
-    (by
-      intro v
-      have : ((f v) : V) ∈ G.universalVerts := ht.1 (f v).coe_prop
-      simp only [universalVerts, Set.mem_setOf_eq] at this
-      apply this
-      exact (Disjoint.ne_of_mem hd v.coe_prop (f v).coe_prop).symm)
+  have hadj : ∀ (v : ↑s), G.Adj v (f v) := by
+    intro v
+    have : ((f v) : V) ∈ G.universalVerts := ht.1 (f v).coe_prop
+    simp only [universalVerts, Set.mem_setOf_eq] at this
+    apply this
+    exact (Disjoint.ne_of_mem hd v.coe_prop (f v).coe_prop).symm
+  obtain ⟨M1, hM1⟩ := Subgraph.IsMatching.exists_of_disjoint_sets_of_equiv hd f hadj
   aesop
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2024 Pim Otte. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pim Otte
+-/
+import Mathlib.Combinatorics.SimpleGraph.Clique
+import Mathlib.Combinatorics.SimpleGraph.Matching
+
+/-!
+# Universal Vertices
+
+This file defines the set of universal vertices: those vertices that are connected
+to all others. In addition, it describes results when considering connected components
+of the graph where universal vertices are deleted. This particular graph plays a role
+in the proof of Tutte's Theorem.
+
+## Main definitions
+
+* `G.universalVerts` is the set of vertices that are connected to all other vertices.
+* `G.deleteUniversalVerts` is the subgraph of `G` with the universal vertices removed.
+-/
+
+namespace SimpleGraph
+variable {V : Type*} {G : SimpleGraph V}
+
+/--
+  The set of vertices that are connected to all other vertices.
+-/
+def universalVerts (G : SimpleGraph V) : Set V := {v : V | ∀ w, v ≠ w → G.Adj w v}
+
+lemma isClique_universalVerts (G : SimpleGraph V) : G.IsClique G.universalVerts :=
+  fun x _ _ hy hxy ↦ hy x hxy.symm
+
+/--
+  The subgraph of `G` with the universal vertices removed.
+-/
+@[simps!]
+def deleteUniversalVerts (G : SimpleGraph V) : Subgraph G :=
+  ((⊤ : Subgraph G).deleteVerts G.universalVerts)
+
+lemma Subgraph.IsMatching.exists_of_universalVerts [Fintype V] [DecidableEq V] {s : Set V}
+    (h : Disjoint G.universalVerts s) (hc : s.ncard ≤ G.universalVerts.ncard) :
+    ∃ t ⊆ G.universalVerts, ∃ (M : Subgraph G), M.IsMatching ∧ M.verts = s ∪ t := by
+  obtain ⟨t, ht⟩ := Set.exists_subset_card_eq hc
+  use t
+  refine ⟨ht.1, ?_⟩
+  have f : s ≃ t := by
+    simp only [← Set.Nat.card_coe_set_eq, Nat.card.eq_1] at ht
+    have : Nonempty (s ≃ t) := by
+      rw [← Cardinal.eq]
+      exact Cardinal.toNat_injOn (Set.mem_Iio.mpr (Set.Finite.lt_aleph0 (s.toFinite)))
+        (Set.mem_Iio.mpr (Set.Finite.lt_aleph0 (Set.toFinite t))) ht.2.symm
+    exact (Classical.inhabited_of_nonempty this).default
+  have hd := (Set.disjoint_of_subset_left ht.1 h).symm
+  obtain ⟨M1, hM1⟩ := Subgraph.IsMatching.exists_of_disjoint_sets_of_equiv
+    hd
+    f
+    (by
+      intro v
+      have : ((f v) : V) ∈ G.universalVerts := ht.1 (f v).coe_prop
+      simp only [universalVerts, Set.mem_setOf_eq] at this
+      apply this
+      rw [ne_comm]
+      exact Disjoint.ne_of_mem hd v.coe_prop (f v).coe_prop)
+  aesop
+
+end SimpleGraph

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -492,6 +492,9 @@ theorem ncard_eq_toFinset_card' (s : Set α) [Fintype s] :
     s.ncard = s.toFinset.card := by
   simp [← Nat.card_coe_set_eq, Nat.card_eq_fintype_card]
 
+lemma cast_ncard {s : Set α} (hs : s.Finite) :
+    (s.ncard : Cardinal) = Cardinal.mk s := @Nat.cast_card _ hs
+
 theorem encard_le_coe_iff_finite_ncard_le {k : ℕ} : s.encard ≤ k ↔ s.Finite ∧ s.ncard ≤ k := by
   rw [encard_le_coe_iff, and_congr_right_iff]
   exact fun hfin ↦ ⟨fun ⟨n₀, hn₀, hle⟩ ↦ by rwa [ncard_def, hn₀, ENat.toNat_coe],

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -58,6 +58,10 @@ lemma card_eq_card_finite_toFinset {s : Set α} (hs : s.Finite) : Nat.card s = h
 
 @[simp] lemma card_eq_zero_of_infinite [Infinite α] : Nat.card α = 0 := mk_toNat_of_infinite
 
+lemma cast_card [Finite α] : (Nat.card α : Cardinal) = Cardinal.mk α := by
+  rw [Nat.card, Cardinal.cast_toNat_of_lt_aleph0]
+  exact Cardinal.lt_aleph0_of_finite _
+
 lemma _root_.Set.Infinite.card_eq_zero {s : Set α} (hs : s.Infinite) : Nat.card s = 0 :=
   @card_eq_zero_of_infinite _ hs.to_subtype
 


### PR DESCRIPTION
Added the defintion of `universalVerts` and `deleteUniversalVerts` along with some initial results.
This is in preparation for a proof of Tutte's theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Zulip thread on Tutte's](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Tutte's.20theorem)

This PR is the result of cleaning up [this file](https://github.com/pimotte/TutteLean/blob/main/TutteLean/PartNew.lean) which gives some context to how this will be used further.