### PR TITLE
[Merged by Bors] - fix(Linter/DocPrime): don't flag anonymous examples and instances

### DIFF
--- a/Mathlib/Tactic/Linter/DocPrime.lean
+++ b/Mathlib/Tactic/Linter/DocPrime.lean
@@ -45,6 +45,8 @@ def docPrimeLinter : Linter where run := withSetOptionIn fun stx ↦ do
   unless [``Lean.Parser.Command.declaration, `lemma].contains stx.getKind do return
   -- ignore private declarations
   if (stx.find? (·.isOfKind ``Lean.Parser.Command.private)).isSome then return
+  -- ignore examples
+  if (stx.find? (·.isOfKind ``Lean.Parser.Command.example)).isSome then return
   let docstring := stx[0][0]
   -- The current declaration's id, possibly followed by a list of universe names.
   let declId :=
@@ -52,6 +54,7 @@ def docPrimeLinter : Linter where run := withSetOptionIn fun stx ↦ do
       stx[1][3][0]
     else
       stx[1][1]
+  if let .missing := declId then return
   -- The name of the current declaration, with namespaces resolved.
   let declName : Name :=
     if let `_root_ :: rest := declId[0].getId.components then

--- a/MathlibTest/DocPrime.lean
+++ b/MathlibTest/DocPrime.lean
@@ -78,3 +78,11 @@ note: this linter can be disabled with `set_option linter.docPrime false`
 -/
 #guard_msgs in
 def def_no_doc' : True := .intro
+
+-- Anonymous declarations in a primed namespace should not get flagged by the linter.
+namespace Foo'
+
+example : True := .intro
+instance : True := .intro
+
+end Foo'


### PR DESCRIPTION
Fixes a bug reported [in Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/strange.20docPrime.20linter.20behaviour/near/489550515).

When an `example` or anonymous `instance` occurs within a primed namespace, the `docPrime` linter
should *not* report a message.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
