### PR TITLE
[Merged by Bors] - chore(Logic/ExistsUnique): amend usages of existsUnique to follow naming convention

### DIFF
--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -156,17 +156,17 @@ end NonAssocSemiring
 end CharP
 
 /-- Noncomputable function that outputs the unique characteristic of a semiring. -/
-noncomputable def ringChar [NonAssocSemiring R] : ℕ := Classical.choose (CharP.exists_unique R)
+noncomputable def ringChar [NonAssocSemiring R] : ℕ := Classical.choose (CharP.existsUnique R)
 
 namespace ringChar
 variable [NonAssocSemiring R]
 
 lemma spec : ∀ x : ℕ, (x : R) = 0 ↔ ringChar R ∣ x := by
-  letI : CharP R (ringChar R) := (Classical.choose_spec (CharP.exists_unique R)).1
+  letI : CharP R (ringChar R) := (Classical.choose_spec (CharP.existsUnique R)).1
   exact CharP.cast_eq_zero_iff R (ringChar R)
 
 lemma eq (p : ℕ) [C : CharP R p] : ringChar R = p :=
-  ((Classical.choose_spec (CharP.exists_unique R)).2 p C).symm
+  ((Classical.choose_spec (CharP.existsUnique R)).2 p C).symm
 
 instance charP : CharP R (ringChar R) :=
   ⟨spec R⟩

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -146,9 +146,11 @@ lemma «exists» : ∃ p, CharP R p :=
             of_not_not (not_not_of_not_imp <| Nat.find_spec (not_forall.1 H)),
             zero_mul]⟩⟩⟩
 
-lemma exists_unique : ∃! p, CharP R p :=
+lemma existsUnique : ∃! p, CharP R p :=
   let ⟨c, H⟩ := CharP.exists R
   ⟨c, H, fun _y H2 => CharP.eq R H2 H⟩
+
+@[deprecated (since := "2024-12-17")] alias exists_unique := existsUnique
 
 end NonAssocSemiring
 end CharP

--- a/Mathlib/Algebra/Field/IsField.lean
+++ b/Mathlib/Algebra/Field/IsField.lean
@@ -77,7 +77,7 @@ a lemma that there is a unique inverse could be useful.
 theorem uniq_inv_of_isField (R : Type u) [Ring R] (hf : IsField R) :
     ∀ x : R, x ≠ 0 → ∃! y : R, x * y = 1 := by
   intro x hx
-  apply exists_unique_of_exists_of_unique
+  apply existsUnique_of_exists_of_unique
   · exact hf.mul_inv_cancel hx
   · intro y z hxy hxz
     calc

--- a/Mathlib/Algebra/Order/Antidiag/Nat.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Nat.lean
@@ -156,7 +156,7 @@ lemma image_piFinTwoEquiv_finMulAntidiag {n : ℕ} :
   ext x
   simp [(piFinTwoEquiv <| fun _ => ℕ).symm.surjective.exists]
 
-lemma finMulAntidiag_exists_unique_prime_dvd {d n p : ℕ} (hn : Squarefree n)
+lemma finMulAntidiag_existsUnique_prime_dvd {d n p : ℕ} (hn : Squarefree n)
     (hp : p ∈ n.primeFactorsList) (f : Fin d → ℕ) (hf : f ∈ finMulAntidiag d n) :
     ∃! i, p ∣ f i := by
   rw [mem_finMulAntidiag] at hf
@@ -171,6 +171,9 @@ lemma finMulAntidiag_exists_unique_prime_dvd {d n p : ℕ} (hn : Squarefree n)
   rw [← hf.1, ← Finset.mul_prod_erase _ _ (his),
     ← Finset.mul_prod_erase _ _ (mem_erase.mpr ⟨hij, mem_univ _⟩), ← mul_assoc]
   apply Nat.dvd_mul_right
+
+@[deprecated (since := "2024-12-17")]
+alias finMulAntidiag_exists_unique_prime_dvd := finMulAntidiag_existsUnique_prime_dvd
 
 private def primeFactorsPiBij (d n : ℕ) :
     ∀ f ∈ (n.primeFactors.pi fun _ => (univ : Finset <| Fin d)), Fin d → ℕ :=
@@ -212,10 +215,10 @@ private theorem primeFactorsPiBij_inj (d n : ℕ)
 private theorem primeFactorsPiBij_surj (d n : ℕ) (hn : Squarefree n)
     (t : Fin d → ℕ) (ht : t ∈ finMulAntidiag d n) : ∃ (g : _)
     (hg : g ∈ pi n.primeFactors fun _ => univ), Nat.primeFactorsPiBij d n g hg = t := by
-  have exists_unique := fun (p : ℕ) (hp : p ∈ n.primeFactors) =>
-    (finMulAntidiag_exists_unique_prime_dvd hn
+  have existsUnique := fun (p : ℕ) (hp : p ∈ n.primeFactors) =>
+    (finMulAntidiag_existsUnique_prime_dvd hn
       (mem_primeFactors_iff_mem_primeFactorsList.mp hp) t ht)
-  choose f hf hf_unique using exists_unique
+  choose f hf hf_unique using existsUnique
   refine ⟨f, ?_, ?_⟩
   · simp only [mem_pi, mem_univ, forall_true_iff]
   funext i

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -799,7 +799,7 @@ lemma basicOpen_injOn_isIdempotentElem :
 @[stacks 00EE]
 lemma existsUnique_idempotent_basicOpen_eq_of_isClopen {s : Set (PrimeSpectrum R)}
     (hs : IsClopen s) : ∃! e : R, IsIdempotentElem e ∧ s = basicOpen e := by
-  refine exists_unique_of_exists_of_unique ?_ ?_; swap
+  refine existsUnique_of_exists_of_unique ?_ ?_; swap
   · rintro x y ⟨hx, rfl⟩ ⟨hy, eq⟩
     exact basicOpen_injOn_isIdempotentElem hx hy (SetLike.ext' eq)
   cases subsingleton_or_nontrivial R

--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -220,7 +220,7 @@ instance types.finitaryExtensive : FinitaryExtensive (Type u) := by
         intro x
         cases' h : s.fst x with val val
         · simp only [Types.binaryCoproductCocone_pt, Functor.const_obj_obj, Sum.inl.injEq,
-            exists_unique_eq']
+            existsUnique_eq']
         · apply_fun f at h
           cases ((congr_fun s.condition x).symm.trans h).trans (congr_fun hαY val : _).symm
       delta ExistsUnique at this
@@ -235,7 +235,7 @@ instance types.finitaryExtensive : FinitaryExtensive (Type u) := by
         · apply_fun f at h
           cases ((congr_fun s.condition x).symm.trans h).trans (congr_fun hαX val : _).symm
         · simp only [Types.binaryCoproductCocone_pt, Functor.const_obj_obj, Sum.inr.injEq,
-            exists_unique_eq']
+            existsUnique_eq']
       delta ExistsUnique at this
       choose l hl hl' using this
       exact ⟨l, (funext hl).symm, Types.isTerminalPunit.hom_ext _ _,

--- a/Mathlib/CategoryTheory/Limits/Preserves/Ulift.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Ulift.lean
@@ -105,20 +105,22 @@ lemma descSet_inter_of_ne (x y : lc.pt) (hn : x ≠ y) : descSet hc {x} ∩ desc
   rw [mem_descSet_singleton] at hx hy
   exact hn (hx ▸ hy)
 
-lemma exists_unique_mem_descSet (x : c.pt) : ∃! y : lc.pt, x ∈ descSet hc {y} :=
-  exists_unique_of_exists_of_unique
+lemma existsUnique_mem_descSet (x : c.pt) : ∃! y : lc.pt, x ∈ descSet hc {y} :=
+  existsUnique_of_exists_of_unique
     (Set.mem_iUnion.mp <| Set.eq_univ_iff_forall.mp (iUnion_descSet_singleton hc lc) x)
     fun y₁ y₂ h₁ h₂ ↦ by_contra fun hn ↦
       Set.eq_empty_iff_forall_not_mem.1 (descSet_inter_of_ne hc lc y₁ y₂ hn) x ⟨h₁, h₂⟩
+
+@[deprecated (since := "2024-12-17")] alias exists_unique_mem_descSet := existsUnique_mem_descSet
 
 /-- Given a colimit cocone in `Type u` and an arbitrary cocone over the diagram lifted to
   `Type (max u v)`, produce a function from the cocone point of the colimit cocone to the
   cocone point of the other cocone, that witnesses the colimit cocone also being a colimit
   in the higher universe. -/
-noncomputable def descFun (x : c.pt) : lc.pt := (exists_unique_mem_descSet hc lc x).exists.choose
+noncomputable def descFun (x : c.pt) : lc.pt := (existsUnique_mem_descSet hc lc x).exists.choose
 
 lemma descFun_apply_spec {x : c.pt} {y : lc.pt} : descFun hc lc x = y ↔ x ∈ descSet hc {y} :=
-  have hu := exists_unique_mem_descSet hc lc x
+  have hu := existsUnique_mem_descSet hc lc x
   have hm := hu.exists.choose_spec
   ⟨fun he ↦ he ▸ hm, hu.unique hm⟩
 

--- a/Mathlib/CategoryTheory/Sites/CoverPreserving.lean
+++ b/Mathlib/CategoryTheory/Sites/CoverPreserving.lean
@@ -164,7 +164,7 @@ This result is basically <https://stacks.math.columbia.edu/tag/00WW>.
 lemma Functor.isContinuous_of_coverPreserving (hF₁ : CompatiblePreserving.{w} K F)
     (hF₂ : CoverPreserving J K F) : Functor.IsContinuous.{w} F J K where
   op_comp_isSheaf_of_types G X S hS x hx := by
-    apply exists_unique_of_exists_of_unique
+    apply existsUnique_of_exists_of_unique
     · have H := (isSheaf_iff_isSheaf_of_type _ _).1 G.2 _ (hF₂.cover_preserve hS)
       exact ⟨H.amalgamate (x.functorPushforward F) (hx.functorPushforward hF₁),
         fun V f hf => (H.isAmalgamation (hx.functorPushforward hF₁) (F.map f) _).trans

--- a/Mathlib/CategoryTheory/Sites/CoversTop.lean
+++ b/Mathlib/CategoryTheory/Sites/CoversTop.lean
@@ -14,7 +14,7 @@ When there is a terminal object `X : C`, then `J.CoversTop Y`
 holds iff `Sieve.ofObjects Y X` is covering for `J`.
 
 We introduce a notion of compatible family of elements on objects `Y`
-and obtain `Presheaf.FamilyOfElementsOnObjects.IsCompatible.exists_unique_section`
+and obtain `Presheaf.FamilyOfElementsOnObjects.IsCompatible.existsUnique_section`
 which asserts that if a presheaf of types is a sheaf, then any compatible
 family of elements on objects `Y` which cover the final object extends as
 a section of this presheaf.
@@ -121,10 +121,10 @@ lemma familyOfElements_isCompatible (hx : x.IsCompatible) (X : C) :
 
 variable {J}
 
-lemma exists_unique_section (hx : x.IsCompatible) (hY : J.CoversTop Y) (hF : IsSheaf J F) :
+lemma existsUnique_section (hx : x.IsCompatible) (hY : J.CoversTop Y) (hF : IsSheaf J F) :
     ∃! (s : F.sections), ∀ (i : I), s.1 (Opposite.op (Y i)) = x i := by
   have H := (isSheaf_iff_isSheaf_of_type _ _).1 hF
-  apply exists_unique_of_exists_of_unique
+  apply existsUnique_of_exists_of_unique
   · let s := fun (X : C) => (H _ (hY X)).amalgamate _
       (hx.familyOfElements_isCompatible X)
     have hs : ∀ {X : C} (i : I) (f : X ⟶ Y i), s X = F.map f.op (x i) := fun {X} i f => by
@@ -147,15 +147,17 @@ lemma exists_unique_section (hx : x.IsCompatible) (hY : J.CoversTop Y) (hF : IsS
   · intro y₁ y₂ hy₁ hy₂
     exact hY.sections_ext ⟨F, hF⟩ (fun i => by rw [hy₁, hy₂])
 
+@[deprecated (since := "2024-12-17")] alias exists_unique_section := existsUnique_section
+
 variable (hx : x.IsCompatible) (hY : J.CoversTop Y) (hF : IsSheaf J F)
 
 /-- The section of a sheaf of types which lifts a compatible family of elements indexed
 by objects which cover the terminal object. -/
-noncomputable def section_ : F.sections := (hx.exists_unique_section hY hF).choose
+noncomputable def section_ : F.sections := (hx.existsUnique_section hY hF).choose
 
 @[simp]
 lemma section_apply (i : I) : (hx.section_ hY hF).1 (Opposite.op (Y i)) = x i :=
-  (hx.exists_unique_section hY hF).choose_spec.1 i
+  (hx.existsUnique_section hY hF).choose_spec.1 i
 
 end IsCompatible
 

--- a/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
+++ b/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
@@ -533,7 +533,7 @@ theorem isSeparatedFor_and_exists_isAmalgamation_iff_isSheafFor :
   intro x
   constructor
   · intro z hx
-    exact exists_unique_of_exists_of_unique (z.2 hx) z.1
+    exact existsUnique_of_exists_of_unique (z.2 hx) z.1
   · intro h
     refine ⟨?_, ExistsUnique.exists ∘ h⟩
     intro t₁ t₂ ht₁ ht₂

--- a/Mathlib/CategoryTheory/Sites/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheaf.lean
@@ -149,12 +149,12 @@ theorem isLimit_iff_isSheafFor :
   · intro hu E x hx
     specialize hu hx.cone
     rw [(homEquivAmalgamation hx).uniqueCongr.nonempty_congr] at hu
-    exact (unique_subtype_iff_exists_unique _).1 hu
+    exact (unique_subtype_iff_existsUnique _).1 hu
   · rintro h ⟨E, π⟩
     let eqv := conesEquivSieveCompatibleFamily P S (op E)
     rw [← eqv.left_inv π]
     erw [(homEquivAmalgamation (eqv π).2).uniqueCongr.nonempty_congr]
-    rw [unique_subtype_iff_exists_unique]
+    rw [unique_subtype_iff_existsUnique]
     exact h _ _ (eqv π).2
 
 /-- Given sieve `S` and presheaf `P : Cᵒᵖ ⥤ A`, their natural associated cone admits at most one
@@ -267,21 +267,24 @@ variable {P : Cᵒᵖ ⥤ A} (hP : Presheaf.IsSheaf J P) {I : Type*} {S : C} {X 
     a ≫ f i = b ≫ f j → x i ≫ P.map a.op = x j ≫ P.map b.op)
 include hP hf hx
 
-lemma IsSheaf.exists_unique_amalgamation_ofArrows :
+lemma IsSheaf.existsUnique_amalgamation_ofArrows :
     ∃! (g : E ⟶ P.obj (op S)), ∀ (i : I), g ≫ P.map (f i).op = x i :=
   (Presieve.isSheafFor_arrows_iff _ _).1
     ((Presieve.isSheafFor_iff_generate _).2 (hP E _ hf)) x (fun _ _ _ _ _ w => hx _ _ w)
+
+@[deprecated (since := "2024-12-17")]
+alias IsSheaf.exists_unique_amalgamation_ofArrows := IsSheaf.existsUnique_amalgamation_ofArrows
 
 /-- If `P : Cᵒᵖ ⥤ A` is a sheaf and `f i : X i ⟶ S` is a covering family, then
 a morphism `E ⟶ P.obj (op S)` can be constructed from a compatible family of
 morphisms `x : E ⟶ P.obj (op (X i))`. -/
 def IsSheaf.amalgamateOfArrows : E ⟶ P.obj (op S) :=
-  (hP.exists_unique_amalgamation_ofArrows f hf x hx).choose
+  (hP.existsUnique_amalgamation_ofArrows f hf x hx).choose
 
 @[reassoc (attr := simp)]
 lemma IsSheaf.amalgamateOfArrows_map (i : I) :
     hP.amalgamateOfArrows f hf x hx ≫ P.map (f i).op = x i :=
-  (hP.exists_unique_amalgamation_ofArrows f hf x hx).choose_spec.1 i
+  (hP.existsUnique_amalgamation_ofArrows f hf x hx).choose_spec.1 i
 
 end
 

--- a/Mathlib/CategoryTheory/Sites/SheafHom.lean
+++ b/Mathlib/CategoryTheory/Sites/SheafHom.lean
@@ -165,7 +165,7 @@ open PresheafHom.IsSheafFor in
 lemma presheafHom_isSheafFor  :
     Presieve.IsSheafFor (presheafHom F G) S.arrows := by
   intro x hx
-  apply exists_unique_of_exists_of_unique
+  apply existsUnique_of_exists_of_unique
   · refine ⟨
       { app := fun Y => app hG x hx Y.unop.hom
         naturality := by

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -540,12 +540,14 @@ theorem exists_pair_of_one_lt_card (h : 1 < card α) : ∃ a b : α, a ≠ b :=
 theorem card_eq_one_of_forall_eq {i : α} (h : ∀ j, j = i) : card α = 1 :=
   Fintype.card_eq_one_iff.2 ⟨i, h⟩
 
-theorem exists_unique_iff_card_one {α} [Fintype α] (p : α → Prop) [DecidablePred p] :
+theorem existsUnique_iff_card_one {α} [Fintype α] (p : α → Prop) [DecidablePred p] :
     (∃! a : α, p a) ↔ #{x | p x} = 1 := by
   rw [Finset.card_eq_one]
   refine exists_congr fun x => ?_
   simp only [forall_true_left, Subset.antisymm_iff, subset_singleton_iff', singleton_subset_iff,
       true_and, and_comm, mem_univ, mem_filter]
+
+@[deprecated (since := "2024-12-17")] alias exists_unique_iff_card_one := existsUnique_iff_card_one
 
 theorem one_lt_card [h : Nontrivial α] : 1 < Fintype.card α :=
   Fintype.one_lt_card_iff_nontrivial.mpr h

--- a/Mathlib/Data/Int/ModEq.lean
+++ b/Mathlib/Data/Int/ModEq.lean
@@ -244,17 +244,21 @@ theorem mod_coprime {a b : ℕ} (hab : Nat.Coprime a b) : ∃ y : ℤ, a * y ≡
       _ ≡ 1 [ZMOD ↑b] := by rw [← Nat.gcd_eq_gcd_ab, hgcd]; rfl
       ⟩
 
-theorem exists_unique_equiv (a : ℤ) {b : ℤ} (hb : 0 < b) :
+theorem existsUnique_equiv (a : ℤ) {b : ℤ} (hb : 0 < b) :
     ∃ z : ℤ, 0 ≤ z ∧ z < b ∧ z ≡ a [ZMOD b] :=
   ⟨a % b, emod_nonneg _ (ne_of_gt hb),
     by
       have : a % b < |b| := emod_lt _ (ne_of_gt hb)
       rwa [abs_of_pos hb] at this, by simp [ModEq]⟩
 
-theorem exists_unique_equiv_nat (a : ℤ) {b : ℤ} (hb : 0 < b) : ∃ z : ℕ, ↑z < b ∧ ↑z ≡ a [ZMOD b] :=
-  let ⟨z, hz1, hz2, hz3⟩ := exists_unique_equiv a hb
+@[deprecated (since := "2024-12-17")] alias exists_unique_equiv := existsUnique_equiv
+
+theorem existsUnique_equiv_nat (a : ℤ) {b : ℤ} (hb : 0 < b) : ∃ z : ℕ, ↑z < b ∧ ↑z ≡ a [ZMOD b] :=
+  let ⟨z, hz1, hz2, hz3⟩ := existsUnique_equiv a hb
   ⟨z.natAbs, by
     constructor <;> rw [natAbs_of_nonneg hz1] <;> assumption⟩
+
+@[deprecated (since := "2024-12-17")] alias exists_unique_equiv_nat := existsUnique_equiv_nat
 
 theorem mod_mul_right_mod (a b c : ℤ) : a % (b * c) % b = a % b :=
   (mod_modEq _ _).of_mul_right _

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -1116,15 +1116,9 @@ theorem Injective.mem_range_iff_existsUnique (hf : Injective f) {b : β} :
 alias ⟨Injective.existsUnique_of_mem_range, _⟩ := Injective.mem_range_iff_existsUnique
 
 @[deprecated (since := "2024-09-25")]
-alias Injective.mem_range_iff_existsUnique := Injective.mem_range_iff_existsUnique
-
-@[deprecated (since := "2024-12-17")]
 alias Injective.mem_range_iff_exists_unique := Injective.mem_range_iff_existsUnique
 
 @[deprecated (since := "2024-09-25")]
-alias Injective.existsUnique_of_mem_range := Injective.existsUnique_of_mem_range
-
-@[deprecated (since := "2024-12-17")]
 alias Injective.exists_unique_of_mem_range := Injective.existsUnique_of_mem_range
 
 theorem Injective.compl_image_eq (hf : Injective f) (s : Set α) :

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -1116,9 +1116,15 @@ theorem Injective.mem_range_iff_existsUnique (hf : Injective f) {b : β} :
 alias ⟨Injective.existsUnique_of_mem_range, _⟩ := Injective.mem_range_iff_existsUnique
 
 @[deprecated (since := "2024-09-25")]
+alias Injective.mem_range_iff_existsUnique := Injective.mem_range_iff_existsUnique
+
+@[deprecated (since := "2024-12-17")]
 alias Injective.mem_range_iff_exists_unique := Injective.mem_range_iff_existsUnique
 
 @[deprecated (since := "2024-09-25")]
+alias Injective.existsUnique_of_mem_range := Injective.existsUnique_of_mem_range
+
+@[deprecated (since := "2024-12-17")]
 alias Injective.exists_unique_of_mem_range := Injective.existsUnique_of_mem_range
 
 theorem Injective.compl_image_eq (hf : Injective f) (s : Set α) :

--- a/Mathlib/Data/Set/Pairwise/Lattice.lean
+++ b/Mathlib/Data/Set/Pairwise/Lattice.lean
@@ -154,7 +154,7 @@ theorem Pairwise.biUnion_injective (h₀ : Pairwise (Disjoint on f)) (h₁ : ∀
 theorem pairwiseDisjoint_unique {y : α}
     (h_disjoint : PairwiseDisjoint s f)
     (hy : y ∈ (⋃ i ∈ s, f i)) : ∃! i, i ∈ s ∧ y ∈ f i := by
-  refine exists_unique_of_exists_of_unique ?ex ?unique
+  refine existsUnique_of_exists_of_unique ?ex ?unique
   · simpa only [mem_iUnion, exists_prop] using hy
   · rintro i j ⟨his, hi⟩ ⟨hjs, hj⟩
     exact h_disjoint.elim his hjs <| not_disjoint_iff.mpr ⟨y, ⟨hi, hj⟩⟩

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -201,7 +201,7 @@ theorem IsPartition.pairwiseDisjoint {c : Set (Set α)} (hc : IsPartition c) :
 lemma _root_.Set.PairwiseDisjoint.isPartition_of_exists_of_ne_empty {α : Type*} {s : Set (Set α)}
     (h₁ : s.PairwiseDisjoint id) (h₂ : ∀ a : α, ∃ x ∈ s, a ∈ x) (h₃ : ∅ ∉ s) :
     Setoid.IsPartition s := by
-  refine ⟨h₃, fun a ↦ exists_unique_of_exists_of_unique (h₂ a) ?_⟩
+  refine ⟨h₃, fun a ↦ existsUnique_of_exists_of_unique (h₂ a) ?_⟩
   intro b₁ b₂ hb₁ hb₂
   apply h₁.elim hb₁.1 hb₂.1
   simp only [Set.not_disjoint_iff]
@@ -212,7 +212,7 @@ theorem IsPartition.sUnion_eq_univ {c : Set (Set α)} (hc : IsPartition c) : ⋃
     Set.mem_sUnion.2 <|
       let ⟨t, ht⟩ := hc.2 x
       ⟨t, by
-        simp only [exists_unique_iff_exists] at ht
+        simp only [existsUnique_iff_exists] at ht
         tauto⟩
 
 /-- All elements of a partition of α are the equivalence class of some y ∈ α. -/

--- a/Mathlib/Dynamics/Newton.lean
+++ b/Mathlib/Dynamics/Newton.lean
@@ -125,4 +125,7 @@ theorem existsUnique_nilpotent_sub_and_aeval_eq_zero
     refine IsNilpotent.isUnit_add_left_of_commute ?_ this (Commute.all _ _)
     exact (Commute.all _ _).isNilpotent_mul_right <| (Commute.all _ _).isNilpotent_sub hr₂ hr₁
 
+@[deprecated (since := "2024-12-17")]
+alias exists_unique_nilpotent_sub_and_aeval_eq_zero := existsUnique_nilpotent_sub_and_aeval_eq_zero
+
 end Polynomial

--- a/Mathlib/Dynamics/Newton.lean
+++ b/Mathlib/Dynamics/Newton.lean
@@ -24,7 +24,7 @@ such as Hensel's lemma and Jordan-Chevalley decomposition.
    polynomial `P`.
  * `Polynomial.isFixedPt_newtonMap_of_isUnit_iff`: `x` is a fixed point for Newton iteration iff
    it is a root of `P` (provided `P'(x)` is a unit).
- * `Polynomial.exists_unique_nilpotent_sub_and_aeval_eq_zero`: if `x` is almost a root of `P` in the
+ * `Polynomial.existsUnique_nilpotent_sub_and_aeval_eq_zero`: if `x` is almost a root of `P` in the
    sense that `P(x)` is nilpotent (and `P'(x)` is a unit) then we may write `x` as a sum
    `x = n + r` where `n` is nilpotent and `r` is a root of `P`. This can be used to prove the
    Jordan-Chevalley decomposition of linear endomorphims.
@@ -77,7 +77,7 @@ theorem isFixedPt_newtonMap_of_isUnit_iff (h : IsUnit <| aeval x (derivative P))
   rw [IsFixedPt, newtonMap_apply, sub_eq_self, Ring.inverse_mul_eq_iff_eq_mul _ _ _ h, mul_zero]
 
 /-- This is really an auxiliary result, en route to
-`Polynomial.exists_unique_nilpotent_sub_and_aeval_eq_zero`. -/
+`Polynomial.existsUnique_nilpotent_sub_and_aeval_eq_zero`. -/
 theorem aeval_pow_two_pow_dvd_aeval_iterate_newtonMap
     (h : IsNilpotent (aeval x P)) (h' : IsUnit (aeval x <| derivative P)) (n : ℕ) :
     (aeval x P) ^ (2 ^ n) ∣ aeval (P.newtonMap^[n] x) P := by
@@ -103,11 +103,11 @@ unit) then we may write `x` as a sum `x = n + r` where `n` is nilpotent and `r` 
 Moreover, `n` and `r` are unique.
 
 This can be used to prove the Jordan-Chevalley decomposition of linear endomorphims. -/
-theorem exists_unique_nilpotent_sub_and_aeval_eq_zero
+theorem existsUnique_nilpotent_sub_and_aeval_eq_zero
     (h : IsNilpotent (aeval x P)) (h' : IsUnit (aeval x <| derivative P)) :
     ∃! r, IsNilpotent (x - r) ∧ aeval r P = 0 := by
   simp_rw [(neg_sub _ x).symm, isNilpotent_neg_iff]
-  refine exists_unique_of_exists_of_unique ?_ fun r₁ r₂ ⟨hr₁, hr₁'⟩ ⟨hr₂, hr₂'⟩ ↦ ?_
+  refine existsUnique_of_exists_of_unique ?_ fun r₁ r₂ ⟨hr₁, hr₁'⟩ ⟨hr₂, hr₂'⟩ ↦ ?_
   · -- Existence
     obtain ⟨n, hn⟩ := id h
     refine ⟨P.newtonMap^[n] x, isNilpotent_iterate_newtonMap_sub_of_isNilpotent h n, ?_⟩

--- a/Mathlib/GroupTheory/GroupAction/Blocks.lean
+++ b/Mathlib/GroupTheory/GroupAction/Blocks.lean
@@ -345,7 +345,7 @@ theorem IsBlock.isBlockSystem [hGX : MulAction.IsPretransitive G X]
     obtain ⟨b : X, hb : b ∈ B⟩ := hBe
     obtain ⟨g, rfl⟩ := exists_smul_eq G b a
     use g • B
-    simp only [Set.smul_mem_smul_set_iff, hb, exists_unique_iff_exists, Set.mem_range,
+    simp only [Set.smul_mem_smul_set_iff, hb, existsUnique_iff_exists, Set.mem_range,
       exists_apply_eq_apply, exists_const, exists_prop, and_imp, forall_exists_index,
       forall_apply_eq_imp_iff, true_and]
     exact fun g' ha ↦ hB.smul_eq_smul_of_nonempty ⟨g • b, ha, ⟨b, hb, rfl⟩⟩

--- a/Mathlib/LinearAlgebra/JordanChevalley.lean
+++ b/Mathlib/LinearAlgebra/JordanChevalley.lean
@@ -57,7 +57,7 @@ theorem exists_isNilpotent_isSemisimple_of_separable_of_dvd_pow {P : K[X]} {k : 
         using (aeval f).congr_arg h
     refine isUnit_of_mul_eq_one_right (aeval ff b) _ (Subtype.ext_iff.mpr ?_)
     simpa [ff, coe_aeval_mk_apply] using h
-  obtain ⟨⟨s, mem⟩, ⟨⟨k, hk⟩, hss⟩, -⟩ := exists_unique_nilpotent_sub_and_aeval_eq_zero nil' sep'
+  obtain ⟨⟨s, mem⟩, ⟨⟨k, hk⟩, hss⟩, -⟩ := existsUnique_nilpotent_sub_and_aeval_eq_zero nil' sep'
   refine ⟨f - s, ?_, s, mem, ⟨k, ?_⟩, ?_, (sub_add_cancel f s).symm⟩
   · exact sub_mem (self_mem_adjoin_singleton K f) mem
   · rw [Subtype.ext_iff] at hk

--- a/Mathlib/LinearAlgebra/LinearPMap.lean
+++ b/Mathlib/LinearAlgebra/LinearPMap.lean
@@ -867,7 +867,7 @@ section SubmoduleToLinearPMap
 theorem existsUnique_from_graph {g : Submodule R (E × F)}
     (hg : ∀ {x : E × F} (_hx : x ∈ g) (_hx' : x.fst = 0), x.snd = 0) {a : E}
     (ha : a ∈ g.map (LinearMap.fst R E F)) : ∃! b : F, (a, b) ∈ g := by
-  refine exists_unique_of_exists_of_unique ?_ ?_
+  refine existsUnique_of_exists_of_unique ?_ ?_
   · convert ha
     simp
   intro y₁ y₂ hy₁ hy₂

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -745,19 +745,15 @@ protected lemma existsUnique_congr_left : (∃! a, p a) ↔ ∃! b, p (e.symm b)
   e.symm.existsUnique_congr_right.symm
 
 @[deprecated (since := "2024-06-11")]
-alias existsUnique_congr_left := Equiv.existsUnique_congr_right
-
-@[deprecated (since := "2024-12-17")] alias exists_unique_congr_left := existsUnique_congr_left
+alias exists_unique_congr_left := Equiv.existsUnique_congr_right
 
 @[deprecated (since := "2024-06-11")]
-alias existsUnique_congr_left' := Equiv.existsUnique_congr_left
-
-@[deprecated (since := "2024-12-17")] alias exists_unique_congr_left' := existsUnique_congr_left'
+alias exists_unique_congr_left' := Equiv.existsUnique_congr_left
 
 protected lemma existsUnique_congr (h : ∀ a, p a ↔ q (e a)) : (∃! a, p a) ↔ ∃! b, q b :=
   e.existsUnique_congr_left.trans <| by simp [h]
 
-@[deprecated (since := "2024-06-11")] alias existsUnique_congr := Equiv.existsUnique_congr
+@[deprecated (since := "2024-06-11")] alias exists_unique_congr := Equiv.existsUnique_congr
 
 protected lemma existsUnique_congr' (h : ∀ b, p (e.symm b) ↔ q b) : (∃! a, p a) ↔ ∃! b, q b :=
   e.existsUnique_congr_left.trans <| by simp [h]

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -745,15 +745,19 @@ protected lemma existsUnique_congr_left : (∃! a, p a) ↔ ∃! b, p (e.symm b)
   e.symm.existsUnique_congr_right.symm
 
 @[deprecated (since := "2024-06-11")]
-alias exists_unique_congr_left := Equiv.existsUnique_congr_right
+alias existsUnique_congr_left := Equiv.existsUnique_congr_right
+
+@[deprecated (since := "2024-12-17")] alias exists_unique_congr_left := existsUnique_congr_left
 
 @[deprecated (since := "2024-06-11")]
-alias exists_unique_congr_left' := Equiv.existsUnique_congr_left
+alias existsUnique_congr_left' := Equiv.existsUnique_congr_left
+
+@[deprecated (since := "2024-12-17")] alias exists_unique_congr_left' := existsUnique_congr_left'
 
 protected lemma existsUnique_congr (h : ∀ a, p a ↔ q (e a)) : (∃! a, p a) ↔ ∃! b, q b :=
   e.existsUnique_congr_left.trans <| by simp [h]
 
-@[deprecated (since := "2024-06-11")] alias exists_unique_congr := Equiv.existsUnique_congr
+@[deprecated (since := "2024-06-11")] alias existsUnique_congr := Equiv.existsUnique_congr
 
 protected lemma existsUnique_congr' (h : ∀ b, p (e.symm b) ↔ q b) : (∃! a, p a) ↔ ∃! b, q b :=
   e.existsUnique_congr_left.trans <| by simp [h]

--- a/Mathlib/Logic/ExistsUnique.lean
+++ b/Mathlib/Logic/ExistsUnique.lean
@@ -116,6 +116,7 @@ theorem existsUnique_const {b : Prop} (α : Sort*) [i : Nonempty α] [Subsinglet
 
 @[deprecated (since := "2024-12-17")] alias exists_unique_eq := existsUnique_eq
 
+/-- The difference with `existsUnique_eq` is that the equality is reversed. -/
 @[simp] theorem existsUnique_eq' {a' : α} : ∃! a, a' = a := by
   simp only [ExistsUnique, and_self, forall_eq', exists_eq']
 

--- a/Mathlib/Logic/ExistsUnique.lean
+++ b/Mathlib/Logic/ExistsUnique.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Floris van Doorn
 -/
 import Mathlib.Tactic.TypeStar
+import Batteries.Tactic.Alias
 
 /-!
 # `ExistsUnique`
@@ -78,9 +79,12 @@ theorem ExistsUnique.elim {p : α → Prop} {b : Prop}
     (h₂ : ∃! x, p x) (h₁ : ∀ x, p x → (∀ y, p y → y = x) → b) : b :=
   Exists.elim h₂ (fun w hw ↦ h₁ w (And.left hw) (And.right hw))
 
-theorem exists_unique_of_exists_of_unique {p : α → Prop}
+theorem existsUnique_of_exists_of_unique {p : α → Prop}
     (hex : ∃ x, p x) (hunique : ∀ y₁ y₂, p y₁ → p y₂ → y₁ = y₂) : ∃! x, p x :=
   Exists.elim hex (fun x px ↦ ExistsUnique.intro x px (fun y (h : p y) ↦ hunique y x h px))
+
+@[deprecated (since := "2024-12-17")]
+alias exists_unique_of_exists_of_unique := existsUnique_of_exists_of_unique
 
 theorem ExistsUnique.exists {p : α → Prop} : (∃! x, p x) → ∃ x, p x | ⟨x, h, _⟩ => ⟨x, h⟩
 
@@ -96,37 +100,51 @@ theorem ExistsUnique.unique {p : α → Prop}
 theorem existsUnique_congr {p q : α → Prop} (h : ∀ a, p a ↔ q a) : (∃! a, p a) ↔ ∃! a, q a :=
   exists_congr fun _ ↦ and_congr (h _) <| forall_congr' fun _ ↦ imp_congr_left (h _)
 
-@[simp] theorem exists_unique_iff_exists [Subsingleton α] {p : α → Prop} :
+@[simp] theorem existsUnique_iff_exists [Subsingleton α] {p : α → Prop} :
     (∃! x, p x) ↔ ∃ x, p x :=
   ⟨fun h ↦ h.exists, Exists.imp fun x hx ↦ ⟨hx, fun y _ ↦ Subsingleton.elim y x⟩⟩
 
-theorem exists_unique_const {b : Prop} (α : Sort*) [i : Nonempty α] [Subsingleton α] :
+@[deprecated (since := "2024-12-17")] alias exists_unique_iff_exists := existsUnique_iff_exists
+
+theorem existsUnique_const {b : Prop} (α : Sort*) [i : Nonempty α] [Subsingleton α] :
     (∃! _ : α, b) ↔ b := by simp
 
-@[simp] theorem exists_unique_eq {a' : α} : ∃! a, a = a' := by
+@[deprecated (since := "2024-12-17")] alias exists_unique_const := existsUnique_const
+
+@[simp] theorem existsUnique_eq {a' : α} : ∃! a, a = a' := by
   simp only [eq_comm, ExistsUnique, and_self, forall_eq', exists_eq']
 
-@[simp] theorem exists_unique_eq' {a' : α} : ∃! a, a' = a := by
+@[deprecated (since := "2024-12-17")] alias exists_unique_eq := existsUnique_eq
+
+@[simp] theorem existsUnique_eq' {a' : α} : ∃! a, a' = a := by
   simp only [ExistsUnique, and_self, forall_eq', exists_eq']
 
-theorem exists_unique_prop {p q : Prop} : (∃! _ : p, q) ↔ p ∧ q := by simp
+@[deprecated (since := "2024-12-17")] alias exists_unique_eq' := existsUnique_eq'
 
-@[simp] theorem exists_unique_false : ¬∃! _ : α, False := fun ⟨_, h, _⟩ ↦ h
+theorem existsUnique_prop {p q : Prop} : (∃! _ : p, q) ↔ p ∧ q := by simp
 
-theorem exists_unique_prop_of_true {p : Prop} {q : p → Prop} (h : p) : (∃! h' : p, q h') ↔ q h :=
-  @exists_unique_const (q h) p ⟨h⟩ _
+@[deprecated (since := "2024-12-17")] alias exists_unique_prop := existsUnique_prop
+
+@[simp] theorem existsUnique_false : ¬∃! _ : α, False := fun ⟨_, h, _⟩ ↦ h
+
+@[deprecated (since := "2024-12-17")] alias exists_unique_false := existsUnique_false
+
+theorem existsUnique_prop_of_true {p : Prop} {q : p → Prop} (h : p) : (∃! h' : p, q h') ↔ q h :=
+  @existsUnique_const (q h) p ⟨h⟩ _
+
+@[deprecated (since := "2024-12-17")] alias exists_unique_prop_of_true := existsUnique_prop_of_true
 
 theorem ExistsUnique.elim₂ {p : α → Sort*} [∀ x, Subsingleton (p x)]
     {q : ∀ (x) (_ : p x), Prop} {b : Prop} (h₂ : ∃! x, ∃! h : p x, q x h)
     (h₁ : ∀ (x) (h : p x), q x h → (∀ (y) (hy : p y), q y hy → y = x) → b) : b := by
-  simp only [exists_unique_iff_exists] at h₂
+  simp only [existsUnique_iff_exists] at h₂
   apply h₂.elim
   exact fun x ⟨hxp, hxq⟩ H ↦ h₁ x hxp hxq fun y hyp hyq ↦ H y ⟨hyp, hyq⟩
 
 theorem ExistsUnique.intro₂ {p : α → Sort*} [∀ x, Subsingleton (p x)]
     {q : ∀ (x : α) (_ : p x), Prop} (w : α) (hp : p w) (hq : q w hp)
     (H : ∀ (y) (hy : p y), q y hy → y = w) : ∃! x, ∃! hx : p x, q x hx := by
-  simp only [exists_unique_iff_exists]
+  simp only [existsUnique_iff_exists]
   exact ExistsUnique.intro w ⟨hp, hq⟩ fun y ⟨hyp, hyq⟩ ↦ H y hyp hyq
 
 theorem ExistsUnique.exists₂ {p : α → Sort*} {q : ∀ (x : α) (_ : p x), Prop}
@@ -136,5 +154,5 @@ theorem ExistsUnique.exists₂ {p : α → Sort*} {q : ∀ (x : α) (_ : p x), P
 theorem ExistsUnique.unique₂ {p : α → Sort*} [∀ x, Subsingleton (p x)]
     {q : ∀ (x : α) (_ : p x), Prop} (h : ∃! x, ∃! hx : p x, q x hx) {y₁ y₂ : α}
     (hpy₁ : p y₁) (hqy₁ : q y₁ hpy₁) (hpy₂ : p y₂) (hqy₂ : q y₂ hpy₂) : y₁ = y₂ := by
-  simp only [exists_unique_iff_exists] at h
+  simp only [existsUnique_iff_exists] at h
   exact h.unique ⟨hpy₁, hqy₁⟩ ⟨hpy₂, hqy₂⟩

--- a/Mathlib/Logic/Unique.lean
+++ b/Mathlib/Logic/Unique.lean
@@ -54,16 +54,21 @@ attribute [class] Unique
 -- The simplifier can already prove this using `eq_iff_true_of_subsingleton`
 attribute [nolint simpNF] Unique.mk.injEq
 
-theorem unique_iff_exists_unique (α : Sort u) : Nonempty (Unique α) ↔ ∃! _ : α, True :=
+theorem unique_iff_existsUnique (α : Sort u) : Nonempty (Unique α) ↔ ∃! _ : α, True :=
   ⟨fun ⟨u⟩ ↦ ⟨u.default, trivial, fun a _ ↦ u.uniq a⟩,
    fun ⟨a, _, h⟩ ↦ ⟨⟨⟨a⟩, fun _ ↦ h _ trivial⟩⟩⟩
 
-theorem unique_subtype_iff_exists_unique {α} (p : α → Prop) :
+@[deprecated (since := "2024-12-17")] alias unique_iff_exists_unique := unique_iff_existsUnique
+
+theorem unique_subtype_iff_existsUnique {α} (p : α → Prop) :
     Nonempty (Unique (Subtype p)) ↔ ∃! a, p a :=
   ⟨fun ⟨u⟩ ↦ ⟨u.default.1, u.default.2, fun a h ↦ congr_arg Subtype.val (u.uniq ⟨a, h⟩)⟩,
    fun ⟨a, ha, he⟩ ↦ ⟨⟨⟨⟨a, ha⟩⟩, fun ⟨b, hb⟩ ↦ by
       congr
       exact he b hb⟩⟩⟩
+
+@[deprecated (since := "2024-12-17")]
+alias unique_subtype_iff_exists_unique := unique_subtype_iff_existsUnique
 
 /-- Given an explicit `a : α` with `Subsingleton α`, we can construct
 a `Unique α` instance. This is a def because the typeclass search cannot

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
@@ -256,11 +256,14 @@ theorem mem_integerSet {a : mixedSpace K} :
 
 /-- If `a` is in `integerSet`, then there is a *unique* algebraic integer in `𝓞 K` such
 that `mixedEmbedding K x = a`. -/
-theorem exists_unique_preimage_of_mem_integerSet {a : mixedSpace K} (ha : a ∈ integerSet K) :
+theorem existsUnique_preimage_of_mem_integerSet {a : mixedSpace K} (ha : a ∈ integerSet K) :
     ∃! x : 𝓞 K, mixedEmbedding K x = a := by
   obtain ⟨_, ⟨x, rfl⟩⟩ := mem_integerSet.mp ha
   refine Function.Injective.existsUnique_of_mem_range ?_ (Set.mem_range_self x)
   exact (mixedEmbedding_injective K).comp RingOfIntegers.coe_injective
+
+@[deprecated (since := "2024-12-17")]
+alias exists_unique_preimage_of_mem_integerSet := existsUnique_preimage_of_mem_integerSet
 
 theorem ne_zero_of_mem_integerSet (a : integerSet K) : (a : mixedSpace K) ≠ 0 := by
   by_contra!

--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -181,23 +181,25 @@ theorem exists_mem_range : ∃ n : ℕ, n < p ∧ x - n ∈ maximalIdeal ℤ_[p]
   apply max_lt hr
   simpa using hn
 
-theorem exists_unique_mem_range : ∃! n : ℕ, n < p ∧ x - n ∈ maximalIdeal ℤ_[p] := by
+theorem existsUnique_mem_range : ∃! n : ℕ, n < p ∧ x - n ∈ maximalIdeal ℤ_[p] := by
   obtain ⟨n, hn₁, hn₂⟩ := exists_mem_range x
   use n, ⟨hn₁, hn₂⟩, fun m ⟨hm₁, hm₂⟩ ↦ ?_
   have := (zmod_congr_of_sub_mem_max_ideal x n m hn₂ hm₂).symm
   rwa [ZMod.natCast_eq_natCast_iff, ModEq, mod_eq_of_lt hn₁, mod_eq_of_lt hm₁] at this
 
+@[deprecated (since := "2024-12-17")] alias exists_unique_mem_range := existsUnique_mem_range
+
 /-- `zmod_repr x` is the unique natural number smaller than `p`
 satisfying `‖(x - zmod_repr x : ℤ_[p])‖ < 1`.
 -/
 def zmodRepr : ℕ :=
-  Classical.choose (exists_unique_mem_range x).exists
+  Classical.choose (existsUnique_mem_range x).exists
 
 theorem zmodRepr_spec : zmodRepr x < p ∧ x - zmodRepr x ∈ maximalIdeal ℤ_[p] :=
-  Classical.choose_spec (exists_unique_mem_range x).exists
+  Classical.choose_spec (existsUnique_mem_range x).exists
 
 theorem zmodRepr_unique (y : ℕ) (hy₁ : y < p) (hy₂ : x - y ∈ maximalIdeal ℤ_[p]) : y = zmodRepr x :=
-  have h := (Classical.choose_spec (exists_unique_mem_range x)).right
+  have h := (Classical.choose_spec (existsUnique_mem_range x)).right
   (h y ⟨hy₁, hy₂⟩).trans (h (zmodRepr x) (zmodRepr_spec x)).symm
 
 theorem zmodRepr_lt_p : zmodRepr x < p :=

--- a/Mathlib/RingTheory/Localization/Away/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Away/Basic.lean
@@ -416,7 +416,7 @@ theorem existsUnique_algebraMap_eq_of_span_eq_top (s : Set R) (span_eq : Ideal.s
       h ⟨a, hts a.2⟩ ⟨b, hts b.2⟩) (Ideal.span_mono (fun _ ↦ .inr) mem) ⟨{a.1} ∪ t, by simp⟩
     exact (congr_arg _ (uniq _ fun b ↦ eq ⟨b, .inr b.2⟩).symm).trans (eq ⟨a, .inl rfl⟩)
   have span_eq := (Ideal.eq_top_iff_one _).mpr mem
-  refine exists_unique_of_exists_of_unique ?_ fun x y hx hy ↦
+  refine existsUnique_of_exists_of_unique ?_ fun x y hx hy ↦
     algebraMap_injective_of_span_eq_top s span_eq (funext fun a ↦ (hx a).trans (hy a).symm)
   obtain ⟨s, rfl⟩ := finset_eq
   choose n r eq using fun a ↦ Away.surj a.1 (f a)

--- a/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
+++ b/Mathlib/RingTheory/Polynomial/HilbertPoly.lean
@@ -158,7 +158,7 @@ theorem coeff_mul_invOneSubPow_eq_hilbertPoly_eval
 /--
 The polynomial satisfying the key property of `Polynomial.hilbertPoly p d` is unique.
 -/
-theorem exists_unique_hilbertPoly (p : F[X]) (d : ℕ) :
+theorem existsUnique_hilbertPoly (p : F[X]) (d : ℕ) :
     ∃! h : F[X], ∃ N : ℕ, ∀ n > N,
     PowerSeries.coeff F n (p * invOneSubPow F d) = h.eval (n : F) := by
   use hilbertPoly p d; constructor
@@ -171,6 +171,8 @@ theorem exists_unique_hilbertPoly (p : F[X]) (d : ℕ) :
     simp only [Set.mem_Ioi, sup_lt_iff, Set.mem_setOf_eq] at hn ⊢
     rw [← coeff_mul_invOneSubPow_eq_hilbertPoly_eval d hn.2, hhN n hn.1]
 
+@[deprecated (since := "2024-12-17")] alias exists_unique_hilbertPoly := existsUnique_hilbertPoly
+
 /--
 If `h : F[X]` and there exists some `N : ℕ` such that for any number `n : ℕ` bigger than `N`
 we have `PowerSeries.coeff F n (p * invOneSubPow F d) = h.eval (n : F)`, then `h` is exactly
@@ -180,7 +182,7 @@ theorem eq_hilbertPoly_of_forall_coeff_eq_eval
     {p h : F[X]} {d : ℕ} (N : ℕ) (hhN : ∀ n > N,
     PowerSeries.coeff F n (p * invOneSubPow F d) = h.eval (n : F)) :
     h = hilbertPoly p d :=
-  ExistsUnique.unique (exists_unique_hilbertPoly p d) ⟨N, hhN⟩
+  ExistsUnique.unique (existsUnique_hilbertPoly p d) ⟨N, hhN⟩
     ⟨p.natDegree, fun _ x => coeff_mul_invOneSubPow_eq_hilbertPoly_eval d x⟩
 
 lemma hilbertPoly_mul_one_sub_succ (p : F[X]) (d : ℕ) :

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
@@ -174,10 +174,6 @@ theorem irreducible_iff_prime_of_existsUnique_irreducible_factors [CancelCommMon
             _ ~ᵤ fa.prod * fb.prod := hfa.2.symm.mul_mul hfb.2.symm
             _ = _ := by rw [Multiset.prod_add]
 
-@[deprecated (since := "2024-12-17")]
-alias irreducible_iff_prime_of_exists_unique_irreducible_factors :=
-  irreducible_iff_prime_of_existsUnique_irreducible_factors
-
         exact
           let ⟨q, hqf, hq⟩ := Multiset.exists_mem_of_rel_of_mem h (Multiset.mem_cons_self p _)
           (Multiset.mem_add.1 hqf).elim
@@ -186,6 +182,10 @@ alias irreducible_iff_prime_of_exists_unique_irreducible_factors :=
             fun hqb =>
             Or.inr <| hq.dvd_iff_dvd_left.2 <| hfb.2.dvd_iff_dvd_right.1 (Multiset.dvd_prod hqb)⟩,
     Prime.irreducible⟩
+
+@[deprecated (since := "2024-12-17")]
+alias irreducible_iff_prime_of_exists_unique_irreducible_factors :=
+  irreducible_iff_prime_of_existsUnique_irreducible_factors
 
 namespace UniqueFactorizationMonoid
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
@@ -144,7 +144,7 @@ theorem prime_factors_irreducible [CancelCommMonoidWithZero α] {a : α} {f : Mu
     simp only [mul_one, Multiset.prod_cons, Multiset.prod_zero, hs0] at *
     exact ⟨Associated.symm ⟨u, hu⟩, rfl⟩
 
-theorem irreducible_iff_prime_of_exists_unique_irreducible_factors [CancelCommMonoidWithZero α]
+theorem irreducible_iff_prime_of_existsUnique_irreducible_factors [CancelCommMonoidWithZero α]
     (eif : ∀ a : α, a ≠ 0 → ∃ f : Multiset α, (∀ b ∈ f, Irreducible b) ∧ f.prod ~ᵤ a)
     (uif :
       ∀ f g : Multiset α,
@@ -173,6 +173,10 @@ theorem irreducible_iff_prime_of_exists_unique_irreducible_factors [CancelCommMo
               rw [hx, Multiset.prod_cons]; exact hfx.2.mul_left _
             _ ~ᵤ fa.prod * fb.prod := hfa.2.symm.mul_mul hfb.2.symm
             _ = _ := by rw [Multiset.prod_add]
+
+@[deprecated (since := "2024-12-17")]
+alias irreducible_iff_prime_of_exists_unique_irreducible_factors :=
+  irreducible_iff_prime_of_existsUnique_irreducible_factors
 
         exact
           let ⟨q, hqf, hq⟩ := Multiset.exists_mem_of_rel_of_mem h (Multiset.mem_cons_self p _)
@@ -401,7 +405,7 @@ end
 
 namespace UniqueFactorizationMonoid
 
-theorem of_exists_unique_irreducible_factors [CancelCommMonoidWithZero α]
+theorem of_existsUnique_irreducible_factors [CancelCommMonoidWithZero α]
     (eif : ∀ a : α, a ≠ 0 → ∃ f : Multiset α, (∀ b ∈ f, Irreducible b) ∧ f.prod ~ᵤ a)
     (uif :
       ∀ f g : Multiset α,
@@ -411,7 +415,10 @@ theorem of_exists_unique_irreducible_factors [CancelCommMonoidWithZero α]
   UniqueFactorizationMonoid.of_exists_prime_factors
     (by
       convert eif using 7
-      simp_rw [irreducible_iff_prime_of_exists_unique_irreducible_factors eif uif])
+      simp_rw [irreducible_iff_prime_of_existsUnique_irreducible_factors eif uif])
+
+@[deprecated (since := "2024-12-17")]
+alias of_exists_unique_irreducible_factors := of_existsUnique_irreducible_factors
 
 variable {R : Type*} [CancelCommMonoidWithZero R] [UniqueFactorizationMonoid R]
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Defs.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Defs.lean
@@ -120,7 +120,7 @@ Each element (except zero) is non-uniquely represented as a multiset
 of prime factors.
 
 To define a UFD using the definition in terms of multisets
-of irreducible factors, use the definition `of_exists_unique_irreducible_factors`
+of irreducible factors, use the definition `of_existsUnique_irreducible_factors`
 
 To define a UFD using the definition in terms of multisets
 of prime factors, use the definition `of_exists_prime_factors`

--- a/Mathlib/Topology/Algebra/Module/LinearPMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearPMap.lean
@@ -28,7 +28,7 @@ underlying spaces are normed.
 
 * `LinearPMap.closable_iff_exists_closed_extension`: an unbounded operator is closable iff it has a
   closed extension.
-* `LinearPMap.closable.exists_unique`: there exists a unique closure
+* `LinearPMap.closable.existsUnique`: there exists a unique closure
 * `LinearPMap.closureHasCore`: the domain of `f` is a core of its closure
 
 ## References
@@ -82,7 +82,7 @@ theorem IsClosable.leIsClosable {f g : E →ₗ.[R] F} (hf : f.IsClosable) (hfg 
 /-- The closure is unique. -/
 theorem IsClosable.existsUnique {f : E →ₗ.[R] F} (hf : f.IsClosable) :
     ∃! f' : E →ₗ.[R] F, f.graph.topologicalClosure = f'.graph := by
-  refine exists_unique_of_exists_of_unique hf fun _ _ hy₁ hy₂ => eq_of_eq_graph ?_
+  refine existsUnique_of_exists_of_unique hf fun _ _ hy₁ hy₂ => eq_of_eq_graph ?_
   rw [← hy₁, ← hy₂]
 
 open Classical in

--- a/Mathlib/Topology/Sheaves/PUnit.lean
+++ b/Mathlib/Topology/Sheaves/PUnit.lean
@@ -24,7 +24,7 @@ theorem isSheaf_of_isTerminal_of_indiscrete {X : TopCat.{w}} (hind : X.str = ⊤
     (it : IsTerminal <| F.obj <| op ⊥) : F.IsSheaf := fun c U s hs => by
   obtain rfl | hne := eq_or_ne U ⊥
   · intro _ _
-    rw [@exists_unique_iff_exists _ ⟨fun _ _ => _⟩]
+    rw [@existsUnique_iff_exists _ ⟨fun _ _ => _⟩]
     · refine ⟨it.from _, fun U hU hs => IsTerminal.hom_ext ?_ _ _⟩
       rwa [le_bot_iff.1 hU.le]
     · apply it.hom_ext


### PR DESCRIPTION
As a definition `ExistsUnique`, the spelling of usages should be `existsUnique` rather than `exists_unique`. The majority of applications already conform to this (96), but there are some (30) exceptions. This PR fixes those.

The large import is the import of Tactic.Alias to Logic.ExistsUnique, and is necessary if deprecations are to be performed here.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
