### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Shift/Opposite): commutation with shifts on the opposite functor

### DIFF
--- a/Mathlib/CategoryTheory/Shift/Opposite.lean
+++ b/Mathlib/CategoryTheory/Shift/Opposite.lean
@@ -117,9 +117,7 @@ end
 variable {C D : Type*} [Category C] [Category D] (F : C ⥤ D) (A : Type*) [AddMonoid A]
   [HasShift C A] [HasShift D A]
 
-namespace CommShift
-
-open Functor
+namespace Functor
 
 /--
 Given a `CommShift` structure on `F`, this is the corresponding `CommShift` structure on
@@ -151,7 +149,7 @@ Given a `CommShift` structure on `F.op` (for the naive shifts on the opposite ca
 this is the corresponding `CommShift` structure on `F`.
 -/
 @[simps]
-noncomputable def commShiftRemoveOp
+noncomputable def commShiftUnop
     [CommShift (C := OppositeShift C A) (D := OppositeShift D A) F.op A] : CommShift F A where
   iso a := NatIso.removeOp (F.op.commShiftIso (C := OppositeShift C A)
     (D := OppositeShift D A) a).symm
@@ -173,6 +171,6 @@ noncomputable def commShiftRemoveOp
     erw [oppositeShiftFunctorAdd_hom_app, oppositeShiftFunctorAdd_inv_app]
     rfl
 
-end CommShift
+end Functor
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Shift/Opposite.lean
+++ b/Mathlib/CategoryTheory/Shift/Opposite.lean
@@ -138,7 +138,7 @@ noncomputable def commShiftOp [CommShift F A] :
   add a b := by
     simp only
     rw [commShiftIso_add]
-    ext _
+    ext
     simp only [op_obj, comp_obj, Iso.symm_hom, NatIso.op_inv, NatTrans.op_app,
       CommShift.isoAdd_inv_app, op_comp, Category.assoc, CommShift.isoAdd_hom_app, op_map]
     erw [oppositeShiftFunctorAdd_inv_app, oppositeShiftFunctorAdd_hom_app]
@@ -156,7 +156,7 @@ noncomputable def commShiftUnop
   zero := by
     simp only
     rw [commShiftIso_zero]
-    ext _
+    ext
     simp only [comp_obj, NatIso.removeOp_hom, Iso.symm_hom, NatTrans.removeOp_app, op_obj,
       CommShift.isoZero_inv_app, op_map, unop_comp, Quiver.Hom.unop_op, CommShift.isoZero_hom_app]
     erw [oppositeShiftFunctorZero_hom_app, oppositeShiftFunctorZero_inv_app]
@@ -164,7 +164,7 @@ noncomputable def commShiftUnop
   add a b := by
     simp only
     rw [commShiftIso_add]
-    ext _
+    ext
     simp only [comp_obj, NatIso.removeOp_hom, Iso.symm_hom, NatTrans.removeOp_app, op_obj,
       CommShift.isoAdd_inv_app, op_map, unop_comp, Quiver.Hom.unop_op, Category.assoc,
       CommShift.isoAdd_hom_app]

--- a/Mathlib/CategoryTheory/Shift/Opposite.lean
+++ b/Mathlib/CategoryTheory/Shift/Opposite.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-import Mathlib.CategoryTheory.Shift.Basic
+import Mathlib.CategoryTheory.Shift.CommShift
 import Mathlib.CategoryTheory.Preadditive.Opposite
 
 /-!
@@ -25,6 +25,8 @@ construction of the "pullback" of a shift by a monoid morphism like `n ↦ -n`.
 namespace CategoryTheory
 
 open Limits
+
+section
 
 variable (C : Type*) [Category C] (A : Type*) [AddMonoid A] [HasShift C A]
 
@@ -109,5 +111,68 @@ lemma oppositeShiftFunctorAdd'_hom_app :
       ((shiftFunctorAdd' C a b c h).inv.app X.unop).op := by
   subst h
   simp only [shiftFunctorAdd'_eq_shiftFunctorAdd, oppositeShiftFunctorAdd_hom_app]
+
+end
+
+variable {C D : Type*} [Category C] [Category D] (F : C ⥤ D) (A : Type*) [AddMonoid A]
+  [HasShift C A] [HasShift D A]
+
+namespace CommShift
+
+open Functor
+
+/--
+Given a `CommShift` structure on `F`, this is the corresponding `CommShift` structure on
+`F.op` (for the naive shifts on the opposite categories).
+-/
+@[simps]
+noncomputable def commShiftOp [CommShift F A] :
+    CommShift (C := OppositeShift C A) (D := OppositeShift D A) F.op A where
+  iso a := (NatIso.op (F.commShiftIso a)).symm
+  zero := by
+    simp only
+    rw [commShiftIso_zero]
+    ext _
+    simp only [op_obj, comp_obj, Iso.symm_hom, NatIso.op_inv, NatTrans.op_app,
+      CommShift.isoZero_inv_app, op_comp, CommShift.isoZero_hom_app, op_map]
+    erw [oppositeShiftFunctorZero_inv_app, oppositeShiftFunctorZero_hom_app]
+    rfl
+  add a b := by
+    simp only
+    rw [commShiftIso_add]
+    ext _
+    simp only [op_obj, comp_obj, Iso.symm_hom, NatIso.op_inv, NatTrans.op_app,
+      CommShift.isoAdd_inv_app, op_comp, Category.assoc, CommShift.isoAdd_hom_app, op_map]
+    erw [oppositeShiftFunctorAdd_inv_app, oppositeShiftFunctorAdd_hom_app]
+    rfl
+
+/--
+Given a `CommShift` structure on `F.op` (for the naive shifts on the opposite categories),
+this is the corresponding `CommShift` structure on `F`.
+-/
+@[simps]
+noncomputable def commShiftRemoveOp
+    [CommShift (C := OppositeShift C A) (D := OppositeShift D A) F.op A] : CommShift F A where
+  iso a := NatIso.removeOp (F.op.commShiftIso (C := OppositeShift C A)
+    (D := OppositeShift D A) a).symm
+  zero := by
+    simp only
+    rw [commShiftIso_zero]
+    ext _
+    simp only [comp_obj, NatIso.removeOp_hom, Iso.symm_hom, NatTrans.removeOp_app, op_obj,
+      CommShift.isoZero_inv_app, op_map, unop_comp, Quiver.Hom.unop_op, CommShift.isoZero_hom_app]
+    erw [oppositeShiftFunctorZero_hom_app, oppositeShiftFunctorZero_inv_app]
+    rfl
+  add a b := by
+    simp only
+    rw [commShiftIso_add]
+    ext _
+    simp only [comp_obj, NatIso.removeOp_hom, Iso.symm_hom, NatTrans.removeOp_app, op_obj,
+      CommShift.isoAdd_inv_app, op_map, unop_comp, Quiver.Hom.unop_op, Category.assoc,
+      CommShift.isoAdd_hom_app]
+    erw [oppositeShiftFunctorAdd_hom_app, oppositeShiftFunctorAdd_inv_app]
+    rfl
+
+end CommShift
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Shift/Opposite.lean
+++ b/Mathlib/CategoryTheory/Shift/Opposite.lean
@@ -130,7 +130,7 @@ noncomputable def commShiftOp [CommShift F A] :
   zero := by
     simp only
     rw [commShiftIso_zero]
-    ext _
+    ext
     simp only [op_obj, comp_obj, Iso.symm_hom, NatIso.op_inv, NatTrans.op_app,
       CommShift.isoZero_inv_app, op_comp, CommShift.isoZero_hom_app, op_map]
     erw [oppositeShiftFunctorZero_inv_app, oppositeShiftFunctorZero_hom_app]


### PR DESCRIPTION
Given a `CommShift` structure on a functor `F` between categories endowed with shifts, construct the corresponding `CommShift` structure on `F.op` for the naive shifts on the opposite categories. (And vice versa.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
