### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Shift): commutation with pulled back shifts 

### DIFF
--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -55,6 +55,10 @@ noncomputable def isoZero' (a : A) (ha : a = 0) : shiftFunctor C a ⋙ F ≅ F �
   isoWhiskerRight (shiftFunctorZero' C a ha) F ≪≫ F.leftUnitor ≪≫
      F.rightUnitor.symm ≪≫ isoWhiskerLeft F (shiftFunctorZero' D a ha).symm
 
+@[simp]
+lemma isoZero'_eq_isoZero : isoZero' F A 0 rfl = isoZero F A := by
+  ext; simp [isoZero', shiftFunctorZero']
+
 variable {F A}
 
 /-- If a functor `F : C ⥤ D` is equipped with "commutation isomorphisms" with the
@@ -141,14 +145,9 @@ lemma commShiftIso_zero :
   CommShift.zero
 
 set_option linter.docPrime false in
-lemma commShiftIso_zero' (a : A) (ha : a = 0) :
-    F.commShiftIso a = CommShift.isoZero' F A a ha := by
-  ext X
-  rw [← cancel_epi (F.mapIso (eqToIso (X := X⟦(0 : A)⟧) (Y := X⟦a⟧) (by rw [← ha]))).hom,
-    Functor.mapIso_hom, eqToIso.hom, eqToHom_map]
-  rw [← eqToHom_naturality (fun (a : A) ↦ (F.commShiftIso a).hom.app X) ha.symm]
-  rw [commShiftIso_zero, CommShift.isoZero']
-  simp [shiftFunctorZero', eqToHom_map]
+lemma commShiftIso_zero' (a : A) (h : a = 0) :
+    F.commShiftIso a = CommShift.isoZero' F A a h := by
+  subst h; rw [CommShift.isoZero'_eq_isoZero, commShiftIso_zero]
 
 variable {A}
 

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -47,7 +47,7 @@ noncomputable def isoZero : shiftFunctor C (0 : A) ⋙ F ≅ F ⋙ shiftFunctor 
   isoWhiskerRight (shiftFunctorZero C A) F ≪≫ F.leftUnitor ≪≫
      F.rightUnitor.symm ≪≫ isoWhiskerLeft F (shiftFunctorZero D A).symm
 
-/-- For any functor `F : C ⥤ D` and any `a` in `A` such that `a=0`,
+/-- For any functor `F : C ⥤ D` and any `a` in `A` such that `a = 0`,
 this is the obvious isomorphism `shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a` deduced from the
 isomorphisms `shiftFunctorZero'` on both categories `C` and `D`. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -47,6 +47,14 @@ noncomputable def isoZero : shiftFunctor C (0 : A) ⋙ F ≅ F ⋙ shiftFunctor 
   isoWhiskerRight (shiftFunctorZero C A) F ≪≫ F.leftUnitor ≪≫
      F.rightUnitor.symm ≪≫ isoWhiskerLeft F (shiftFunctorZero D A).symm
 
+/-- For any functor `F : C ⥤ D` and any `a` in `A` such that `a=0`,
+this is the obvious isomorphism `shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a` deduced from the
+isomorphisms `shiftFunctorZero'` on both categories `C` and `D`. -/
+@[simps!]
+noncomputable def isoZero' (a : A) (ha : a = 0) : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a :=
+  isoWhiskerRight (shiftFunctorZero' C a ha) F ≪≫ F.leftUnitor ≪≫
+     F.rightUnitor.symm ≪≫ isoWhiskerLeft F (shiftFunctorZero' D a ha).symm
+
 variable {F A}
 
 /-- If a functor `F : C ⥤ D` is equipped with "commutation isomorphisms" with the
@@ -131,6 +139,16 @@ variable (A)
 lemma commShiftIso_zero :
     F.commShiftIso (0 : A) = CommShift.isoZero F A :=
   CommShift.zero
+
+set_option linter.docPrime false in
+lemma commShiftIso_zero' (a : A) (ha : a = 0) :
+    F.commShiftIso a = CommShift.isoZero' F A a ha := by
+  ext X
+  rw [← cancel_epi (F.mapIso (eqToIso (X := X⟦(0 : A)⟧) (Y := X⟦a⟧) (by rw [← ha]))).hom,
+    Functor.mapIso_hom, eqToIso.hom, eqToHom_map]
+  rw [← eqToHom_naturality (fun (a : A) ↦ (F.commShiftIso a).hom.app X) ha.symm]
+  rw [commShiftIso_zero, CommShift.isoZero']
+  simp [shiftFunctorZero', eqToHom_map]
 
 variable {A}
 

--- a/Mathlib/CategoryTheory/Shift/Pullback.lean
+++ b/Mathlib/CategoryTheory/Shift/Pullback.lean
@@ -133,7 +133,7 @@ noncomputable def Pullback.CommShift :
   iso a := isoWhiskerRight (pullbackShiftIso C φ a (φ a) rfl) F ≪≫
     CommShift.iso (F := F) (φ a) ≪≫ isoWhiskerLeft _  (pullbackShiftIso D φ a (φ a) rfl).symm
   zero := by
-    ext _
+    ext
     simp only [comp_obj, Iso.trans_hom, isoWhiskerRight_hom, isoWhiskerLeft_hom, Iso.symm_hom,
       NatTrans.comp_app, whiskerRight_app, whiskerLeft_app, CommShift.isoZero_hom_app,
       pullbackShiftFunctorZero'_hom_app, id_obj, map_comp, pullbackShiftFunctorZero'_inv_app, assoc]
@@ -141,7 +141,7 @@ noncomputable def Pullback.CommShift :
                 rw [F.commShiftIso_zero' (A := B) (φ 0) (by rw [map_zero])]
     simp only [CommShift.isoZero'_hom_app, assoc]
   add a b := by
-    ext _
+    ext
     simp only [comp_obj, Iso.trans_hom, isoWhiskerRight_hom, isoWhiskerLeft_hom, Iso.symm_hom,
       NatTrans.comp_app, whiskerRight_app, whiskerLeft_app, CommShift.isoAdd_hom_app, map_comp,
       assoc]

--- a/Mathlib/CategoryTheory/Shift/Pullback.lean
+++ b/Mathlib/CategoryTheory/Shift/Pullback.lean
@@ -84,7 +84,7 @@ lemma pullbackShiftFunctorZero'_inv_app :
 
 lemma pullbackShiftFunctorZero'_hom_app :
     (shiftFunctorZero _ A).hom.app X = (pullbackShiftIso C φ 0 (φ 0) rfl).hom.app X ≫
-    (shiftFunctorZero' C (φ 0) (by rw [map_zero])).hom.app X := by
+      (shiftFunctorZero' C (φ 0) (by rw [map_zero])).hom.app X := by
   rw [← cancel_epi ((shiftFunctorZero _ A).inv.app X), Iso.inv_hom_id_app,
     pullbackShiftFunctorZero'_inv_app, assoc, Iso.inv_hom_id_app_assoc, Iso.inv_hom_id_app]
   rfl

--- a/Mathlib/CategoryTheory/Shift/Pullback.lean
+++ b/Mathlib/CategoryTheory/Shift/Pullback.lean
@@ -125,19 +125,18 @@ variable {D : Type*} [Category D] [HasShift D B] (F : C ⥤ D) [F.CommShift B]
 /-- If `F : C ⥤ D` commutes with the shifts on `C` and `D`, then it also commutes with
 their pullbacks by an additive map.
 -/
-@[simps]
 noncomputable def commShiftPullback :
     F.CommShift A (C := PullbackShift C φ) (D := PullbackShift D φ) where
   iso a := isoWhiskerRight (pullbackShiftIso C φ a (φ a) rfl) F ≪≫
-    CommShift.iso (F := F) (φ a) ≪≫ isoWhiskerLeft _  (pullbackShiftIso D φ a (φ a) rfl).symm
+    F.commShiftIso (φ a) ≪≫ isoWhiskerLeft _  (pullbackShiftIso D φ a (φ a) rfl).symm
   zero := by
     ext
-    simp only [comp_obj, Iso.trans_hom, isoWhiskerRight_hom, isoWhiskerLeft_hom, Iso.symm_hom,
-      NatTrans.comp_app, whiskerRight_app, whiskerLeft_app, CommShift.isoZero_hom_app,
-      pullbackShiftFunctorZero'_hom_app, id_obj, map_comp, pullbackShiftFunctorZero'_inv_app, assoc]
-    conv_lhs => congr; rfl; congr; change (F.commShiftIso (φ 0)).hom.app _
-                rw [F.commShiftIso_zero' (A := B) (φ 0) (by rw [map_zero])]
-    simp only [CommShift.isoZero'_hom_app, assoc]
+    dsimp
+    simp only [F.commShiftIso_zero' (A := B) (φ 0) (by rw [map_zero]), CommShift.isoZero'_hom_app,
+      assoc, CommShift.isoZero_hom_app, pullbackShiftFunctorZero'_hom_app, map_comp,
+      pullbackShiftFunctorZero'_inv_app]
+    dsimp
+    rfl
   add a b := by
     ext
     dsimp

--- a/Mathlib/CategoryTheory/Shift/Pullback.lean
+++ b/Mathlib/CategoryTheory/Shift/Pullback.lean
@@ -127,8 +127,7 @@ their pullbacks by an additive map.
 -/
 @[simps]
 noncomputable def commShiftPullback :
-    F.CommShift A (C := PullbackShift C φ) (D := PullbackShift D φ)
-    where
+    F.CommShift A (C := PullbackShift C φ) (D := PullbackShift D φ) where
   iso a := isoWhiskerRight (pullbackShiftIso C φ a (φ a) rfl) F ≪≫
     CommShift.iso (F := F) (φ a) ≪≫ isoWhiskerLeft _  (pullbackShiftIso D φ a (φ a) rfl).symm
   zero := by

--- a/Mathlib/CategoryTheory/Shift/Pullback.lean
+++ b/Mathlib/CategoryTheory/Shift/Pullback.lean
@@ -158,6 +158,14 @@ noncomputable def commShiftPullback :
     slice_rhs 4 5 => rw [← map_comp]; erw [← map_comp]; rw [Iso.inv_hom_id_app, map_id, map_id]
     rw [id_comp, id_comp, assoc, assoc]; rfl
 
+lemma commShiftPullback_iso_eq (a : A) (b : B) (h : b = φ a) :
+    letI : F.CommShift (C := PullbackShift C φ) (D := PullbackShift D φ) A := F.commShiftPullback φ
+    F.commShiftIso a (C := PullbackShift C φ) (D := PullbackShift D φ) =
+      isoWhiskerRight (pullbackShiftIso C φ a b h) F ≪≫ (F.commShiftIso b) ≪≫
+        isoWhiskerLeft F (pullbackShiftIso D φ a b h).symm := by
+  obtain rfl : b = φ a := h
+  rfl
+
 end Functor
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Shift/Pullback.lean
+++ b/Mathlib/CategoryTheory/Shift/Pullback.lean
@@ -126,7 +126,7 @@ variable {D : Type*} [Category D] [HasShift D B] (F : C ⥤ D) [F.CommShift B]
 their pullbacks by an additive map.
 -/
 @[simps]
-noncomputable def CommShift.pullback :
+noncomputable def commShiftPullback :
     F.CommShift A (C := PullbackShift C φ) (D := PullbackShift D φ)
     where
   iso a := isoWhiskerRight (pullbackShiftIso C φ a (φ a) rfl) F ≪≫

--- a/Mathlib/CategoryTheory/Shift/Pullback.lean
+++ b/Mathlib/CategoryTheory/Shift/Pullback.lean
@@ -140,15 +140,15 @@ noncomputable def commShiftPullback :
     simp only [CommShift.isoZero'_hom_app, assoc]
   add a b := by
     ext
-    simp only [comp_obj, Iso.trans_hom, isoWhiskerRight_hom, isoWhiskerLeft_hom, Iso.symm_hom,
-      NatTrans.comp_app, whiskerRight_app, whiskerLeft_app, CommShift.isoAdd_hom_app, map_comp,
-      assoc]
-    conv_lhs => congr; rfl; congr; change (F.commShiftIso (φ (a + b))).hom.app _
-                rw [F.commShiftIso_add' (a := φ a) (b := φ b) (by rw [φ.map_add])]
-    rw [← shiftFunctorAdd'_eq_shiftFunctorAdd, ← shiftFunctorAdd'_eq_shiftFunctorAdd]
-    rw [pullbackShiftFunctorAdd'_hom_app φ _ a b (a + b) rfl (φ a) (φ b) (φ (a + b)) rfl rfl rfl]
-    rw [pullbackShiftFunctorAdd'_inv_app φ _ a b (a + b) rfl (φ a) (φ b) (φ (a + b)) rfl rfl rfl]
-    simp only [CommShift.isoAdd'_hom_app, assoc, comp_obj, map_comp, NatTrans.naturality_assoc,
+    dsimp
+    simp only [CommShift.isoAdd_hom_app, map_comp, assoc]
+    dsimp
+    rw [F.commShiftIso_add' (a := φ a) (b := φ b) (by rw [φ.map_add]),
+      ← shiftFunctorAdd'_eq_shiftFunctorAdd, ← shiftFunctorAdd'_eq_shiftFunctorAdd,
+      pullbackShiftFunctorAdd'_hom_app φ _ a b (a + b) rfl (φ a) (φ b) (φ (a + b)) rfl rfl rfl,
+      pullbackShiftFunctorAdd'_inv_app φ _ a b (a + b) rfl (φ a) (φ b) (φ (a + b)) rfl rfl rfl]
+    dsimp
+    simp only [CommShift.isoAdd'_hom_app, assoc, map_comp, NatTrans.naturality_assoc,
       Iso.inv_hom_id_app_assoc]
     slice_rhs 9 10 => rw [← map_comp, Iso.inv_hom_id_app, map_id]
     erw [id_comp]

--- a/Mathlib/CategoryTheory/Shift/Pullback.lean
+++ b/Mathlib/CategoryTheory/Shift/Pullback.lean
@@ -118,16 +118,15 @@ lemma pullbackShiftFunctorAdd'_hom_app :
     ← Functor.map_comp, Iso.hom_inv_id_app, Functor.map_id]
   rfl
 
-namespace CommShift
+namespace Functor
 
 variable {D : Type*} [Category D] [HasShift D B] (F : C ⥤ D) [F.CommShift B]
 
-open Functor in
 /-- If `F : C ⥤ D` commutes with the shifts on `C` and `D`, then it also commutes with
 their pullbacks by an additive map.
 -/
 @[simps]
-noncomputable def Pullback.CommShift :
+noncomputable def CommShift.pullback :
     F.CommShift A (C := PullbackShift C φ) (D := PullbackShift D φ)
     where
   iso a := isoWhiskerRight (pullbackShiftIso C φ a (φ a) rfl) F ≪≫
@@ -161,6 +160,6 @@ noncomputable def Pullback.CommShift :
     slice_rhs 4 5 => rw [← map_comp]; erw [← map_comp]; rw [Iso.inv_hom_id_app, map_id, map_id]
     rw [id_comp, id_comp, assoc, assoc]; rfl
 
-end CommShift
+end Functor
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Shift/Pullback.lean
+++ b/Mathlib/CategoryTheory/Shift/Pullback.lean
@@ -76,7 +76,7 @@ lemma pullbackShiftFunctorZero_hom_app :
 
 lemma pullbackShiftFunctorZero'_inv_app :
     (shiftFunctorZero _ A).inv.app X = (shiftFunctorZero' C (φ 0) (by rw [map_zero])).inv.app X ≫
-    (pullbackShiftIso C φ 0 (φ 0) rfl).inv.app X := by
+      (pullbackShiftIso C φ 0 (φ 0) rfl).inv.app X := by
   rw [pullbackShiftFunctorZero_inv_app]
   simp only [Functor.id_obj, pullbackShiftIso, eqToIso.inv, eqToHom_app, shiftFunctorZero',
     Iso.trans_inv, NatTrans.comp_app, eqToIso_refl, Iso.refl_inv, NatTrans.id_app, assoc]


### PR DESCRIPTION
If we have shifts by an additive monoid `B` on categories `C` and `D`, if a functor `F : C ⥤ D` commutes with the shifts, and if we have a morphism of additive monoids `φ : A →+ B`, then `F` also commutes with the pullbacks of the shifts by `φ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
