### PR TITLE
[Merged by Bors] - refactor(Combinatorics/Additive): strengthen the classification of sets with no doubling

### DIFF
--- a/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
+++ b/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
@@ -25,38 +25,41 @@ open MulOpposite MulAction
 open scoped Pointwise RightActions
 
 namespace Finset
-variable {G : Type*} [Group G] [DecidableEq G] {A : Finset G}
+variable {G : Type*} [Group G] [DecidableEq G] {A : Finset G} {a : G}
 
-/-- A set with no doubling is either empty or the translate of a subgroup.
-
-Precisely, if `A` has no doubling then there exists a subgroup `H` such `aH = Ha = A` for all
-`a ∈ A`. -/
-@[to_additive "A set with no doubling is either empty or the translate of a subgroup.
-
-Precisely, if `A` has no doubling then there exists a subgroup `H` such `a + H = H + a = A` for all
-`a ∈ A`."]
-lemma exists_subgroup_of_no_doubling (hA : #(A * A) ≤ #A) :
-    ∃ H : Subgroup G, ∀ a ∈ A, a •> (H : Set G) = A ∧ (H : Set G) <• a = A := by
+@[to_additive]
+private lemma smul_stabilizer_of_no_doubling_aux (hA : #(A * A) ≤ #A) (ha : a ∈ A) :
+    a •> (stabilizer G A : Set G) = A ∧ (stabilizer G A : Set G) <• a = A := by
   have smul_A {a} (ha : a ∈ A) : a •> A = A * A :=
     eq_of_subset_of_card_le (smul_finset_subset_mul ha) (by simpa)
-  have A_smul {a} (ha : a ∈ A) : A <• a = A * A :=
+  have op_smul_A {a} (ha : a ∈ A) : A <• a = A * A :=
     eq_of_subset_of_card_le (op_smul_finset_subset_mul ha) (by simpa)
-  have smul_A_eq_op_smul_A {a} (ha : a ∈ A) : a •> A = A <• a := by rw [smul_A ha, A_smul ha]
-  have smul_A_eq_op_smul_A' {a} (ha : a ∈ A) : a⁻¹ •> A = A <• a⁻¹ := by
-    rw [inv_smul_eq_iff, smul_comm, smul_A_eq_op_smul_A ha, op_inv, inv_smul_smul]
+  have smul_A_eq_op_smul_A {a} (ha : a ∈ A) : a •> A = A <• a := by rw [smul_A ha, op_smul_A ha]
+  have mul_mem_A_comm {x a} (ha : a ∈ A) : x * a ∈ A ↔ a * x ∈ A := by
+    rw [← smul_mem_smul_finset_iff a, smul_A_eq_op_smul_A ha, ← op_smul_eq_mul, smul_comm,
+      smul_mem_smul_finset_iff, smul_eq_mul]
   let H := stabilizer G A
   have inv_smul_A {a} (ha : a ∈ A) : a⁻¹ • (A : Set G) = H := by
     ext x
-    refine ⟨?_, fun hx ↦ ?_⟩
-    · rintro ⟨b, hb, rfl⟩
-      simp [H, mul_smul, inv_smul_eq_iff, smul_A ha, smul_A hb]
+    rw [Set.mem_inv_smul_set_iff, smul_eq_mul]
+    refine ⟨fun hx ↦ ?_, fun hx ↦ ?_⟩
+    · simpa [← smul_A ha, mul_smul] using smul_A hx
     · norm_cast
-      rwa [smul_A_eq_op_smul_A' ha, op_inv, mem_inv_smul_finset_iff, op_smul_eq_mul, ← smul_eq_mul,
-        ← mem_inv_smul_finset_iff, inv_mem hx]
-  refine ⟨H, fun a ha ↦ ⟨?_, ?_⟩⟩
+      rwa [← mul_mem_A_comm ha, ← smul_eq_mul, ← mem_inv_smul_finset_iff, inv_mem hx]
+  refine ⟨?_, ?_⟩
   · rw [← inv_smul_A ha, smul_inv_smul]
   · rw [← inv_smul_A ha, smul_comm]
     norm_cast
     rw [← smul_A_eq_op_smul_A ha, inv_smul_smul]
+
+/-- A non-empty set with no doubling is the left translate of its stabilizer. -/
+@[to_additive "A non-empty set with no doubling is the left-translate of its stabilizer."]
+lemma smul_stabilizer_of_no_doubling (hA : #(A * A) ≤ #A) (ha : a ∈ A) :
+    a •> (stabilizer G A : Set G) = A := (smul_stabilizer_of_no_doubling_aux hA ha).1
+
+/-- A non-empty set with no doubling is the right translate of its stabilizer. -/
+@[to_additive "A non-empty set with no doubling is the right translate of its stabilizer."]
+lemma op_smul_stabilizer_of_no_doubling (hA : #(A * A) ≤ #A) (ha : a ∈ A) :
+    (stabilizer G A : Set G) <• a = A := (smul_stabilizer_of_no_doubling_aux hA ha).2
 
 end Finset

--- a/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
+++ b/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
@@ -32,11 +32,11 @@ private lemma smul_stabilizer_of_no_doubling_aux (hA : #(A * A) ≤ #A) (ha : a 
     a •> (stabilizer G A : Set G) = A ∧ (stabilizer G A : Set G) <• a = A := by
   have smul_A {a} (ha : a ∈ A) : a •> A = A * A :=
     eq_of_subset_of_card_le (smul_finset_subset_mul ha) (by simpa)
-  have op_smul_A {a} (ha : a ∈ A) : A <• a = A * A :=
+  have A_smul {a} (ha : a ∈ A) : A <• a = A * A :=
     eq_of_subset_of_card_le (op_smul_finset_subset_mul ha) (by simpa)
-  have smul_A_eq_op_smul_A {a} (ha : a ∈ A) : a •> A = A <• a := by rw [smul_A ha, op_smul_A ha]
+  have smul_A_eq_A_smul {a} (ha : a ∈ A) : a •> A = A <• a := by rw [smul_A ha, A_smul ha]
   have mul_mem_A_comm {x a} (ha : a ∈ A) : x * a ∈ A ↔ a * x ∈ A := by
-    rw [← smul_mem_smul_finset_iff a, smul_A_eq_op_smul_A ha, ← op_smul_eq_mul, smul_comm,
+    rw [← smul_mem_smul_finset_iff a, smul_A_eq_A_smul ha, ← op_smul_eq_mul, smul_comm,
       smul_mem_smul_finset_iff, smul_eq_mul]
   let H := stabilizer G A
   have inv_smul_A {a} (ha : a ∈ A) : a⁻¹ • (A : Set G) = H := by
@@ -50,7 +50,7 @@ private lemma smul_stabilizer_of_no_doubling_aux (hA : #(A * A) ≤ #A) (ha : a 
   · rw [← inv_smul_A ha, smul_inv_smul]
   · rw [← inv_smul_A ha, smul_comm]
     norm_cast
-    rw [← smul_A_eq_op_smul_A ha, inv_smul_smul]
+    rw [← smul_A_eq_A_smul ha, inv_smul_smul]
 
 /-- A non-empty set with no doubling is the left translate of its stabilizer. -/
 @[to_additive "A non-empty set with no doubling is the left-translate of its stabilizer."]


### PR DESCRIPTION
It turns out that the current statement is too weak for me to classify finite 1-approximate subgroups.

From GrowthInGroups (LeanCamCombi)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
