### PR TITLE
[Merged by Bors] - chore(Multiset): make all arguments to `inter_le_left`, etc... implicit

### DIFF
--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -1529,10 +1529,10 @@ instance : Union (Multiset α) :=
 theorem union_def (s t : Multiset α) : s ∪ t = s - t + t :=
   rfl
 
-theorem le_union_left (s t : Multiset α) : s ≤ s ∪ t :=
+theorem le_union_left {s t : Multiset α} : s ≤ s ∪ t :=
   le_tsub_add
 
-theorem le_union_right (s t : Multiset α) : t ≤ s ∪ t :=
+theorem le_union_right {s t : Multiset α} : t ≤ s ∪ t :=
   le_add_left _ _
 
 theorem eq_union_left : t ≤ s → s ∪ t = s :=
@@ -1549,7 +1549,7 @@ theorem union_le (h₁ : s ≤ u) (h₂ : t ≤ u) : s ∪ t ≤ u := by
 @[simp]
 theorem mem_union : a ∈ s ∪ t ↔ a ∈ s ∨ a ∈ t :=
   ⟨fun h => (mem_add.1 h).imp_left (mem_of_le <| Multiset.sub_le_self _ _),
-    (Or.elim · (mem_of_le <| le_union_left _ _) (mem_of_le <| le_union_right _ _))⟩
+    (Or.elim · (mem_of_le le_union_left) (mem_of_le le_union_right))⟩
 
 @[simp]
 theorem map_union [DecidableEq β] {f : α → β} (finj : Function.Injective f) {s t : Multiset α} :
@@ -1591,12 +1591,15 @@ theorem cons_inter_of_pos {a} (s : Multiset α) {t} : a ∈ t → (a ::ₘ s) �
 theorem cons_inter_of_neg {a} (s : Multiset α) {t} : a ∉ t → (a ::ₘ s) ∩ t = s ∩ t :=
   Quotient.inductionOn₂ s t fun _l₁ _l₂ h => congr_arg ofList <| cons_bagInter_of_neg _ h
 
-theorem inter_le_left (s t : Multiset α) : s ∩ t ≤ s :=
+theorem inter_le_left {s t : Multiset α} : s ∩ t ≤ s :=
   Quotient.inductionOn₂ s t fun _l₁ _l₂ => (bagInter_sublist_left _ _).subperm
 
-theorem inter_le_right (s : Multiset α) : ∀ t, s ∩ t ≤ t :=
-  Multiset.induction_on s (fun t => (zero_inter t).symm ▸ zero_le _) fun a s IH t =>
-    if h : a ∈ t then by simpa [h] using cons_le_cons a (IH (t.erase a)) else by simp [h, IH]
+theorem inter_le_right {s t : Multiset α} : s ∩ t ≤ t := by
+  induction' s using Multiset.induction_on with a s IH generalizing t
+  · exact (zero_inter t).symm ▸ zero_le _
+  by_cases h : a ∈ t
+  · simpa [h] using cons_le_cons a (IH (t := t.erase a))
+  · simp [h, IH]
 
 theorem le_inter (h₁ : s ≤ t) (h₂ : s ≤ u) : s ≤ t ∩ u := by
   revert s u; refine @(Multiset.induction_on t ?_ fun a t IH => ?_) <;> intros s u h₁ h₂
@@ -1609,18 +1612,18 @@ theorem le_inter (h₁ : s ≤ t) (h₂ : s ≤ u) : s ≤ t ∩ u := by
 
 @[simp]
 theorem mem_inter : a ∈ s ∩ t ↔ a ∈ s ∧ a ∈ t :=
-  ⟨fun h => ⟨mem_of_le (inter_le_left _ _) h, mem_of_le (inter_le_right _ _) h⟩, fun ⟨h₁, h₂⟩ => by
+  ⟨fun h => ⟨mem_of_le inter_le_left h, mem_of_le inter_le_right h⟩, fun ⟨h₁, h₂⟩ => by
     rw [← cons_erase h₁, cons_inter_of_pos _ h₂]; apply mem_cons_self⟩
 
-instance : Lattice (Multiset α) :=
-  { sup := (· ∪ ·)
-    sup_le := @union_le _ _
-    le_sup_left := le_union_left
-    le_sup_right := le_union_right
-    inf := (· ∩ ·)
-    le_inf := @le_inter _ _
-    inf_le_left := inter_le_left
-    inf_le_right := inter_le_right }
+instance : Lattice (Multiset α) where
+  sup := (· ∪ ·)
+  sup_le _ _ _ := union_le
+  le_sup_left _ _ := le_union_left
+  le_sup_right _ _ := le_union_right
+  inf := (· ∩ ·)
+  le_inf _ _ _ := le_inter
+  inf_le_left _ _ := inter_le_left
+  inf_le_right _ _ := inter_le_right
 
 @[simp]
 theorem sup_eq_union (s t : Multiset α) : s ⊔ t = s ∪ t :=
@@ -1662,19 +1665,13 @@ theorem cons_union_distrib (a : α) (s t : Multiset α) : a ::ₘ (s ∪ t) = a 
   simpa using add_union_distrib (a ::ₘ 0) s t
 
 theorem inter_add_distrib (s t u : Multiset α) : s ∩ t + u = (s + u) ∩ (t + u) := by
-  by_contra h
-  cases'
-    lt_iff_cons_le.1
-      (lt_of_le_of_ne
-        (le_inter (add_le_add_right (inter_le_left s t) u)
-          (add_le_add_right (inter_le_right s t) u))
-        h) with
-    a hl
-  rw [← cons_add] at hl
-  exact
-    not_le_of_lt (lt_cons_self (s ∩ t) a)
-      (le_inter (le_of_add_le_add_right (le_trans hl (inter_le_left _ _)))
-        (le_of_add_le_add_right (le_trans hl (inter_le_right _ _))))
+  by_contra! h
+  obtain ⟨a, ha⟩ := lt_iff_cons_le.1 <| h.lt_of_le <| le_inter
+    (add_le_add_right inter_le_left _) (add_le_add_right inter_le_right _)
+  rw [← cons_add] at ha
+  exact (lt_cons_self (s ∩ t) a).not_le <| le_inter
+    (le_of_add_le_add_right (ha.trans inter_le_left))
+    (le_of_add_le_add_right (ha.trans inter_le_right))
 
 theorem add_inter_distrib (s t u : Multiset α) : s + t ∩ u = (s + t) ∩ (s + u) := by
   rw [add_comm, inter_add_distrib, add_comm s, add_comm s]
@@ -1682,16 +1679,16 @@ theorem add_inter_distrib (s t u : Multiset α) : s + t ∩ u = (s + t) ∩ (s +
 theorem cons_inter_distrib (a : α) (s t : Multiset α) : a ::ₘ s ∩ t = (a ::ₘ s) ∩ (a ::ₘ t) := by
   simp
 
-theorem union_add_inter (s t : Multiset α) : s ∪ t + s ∩ t = s + t := by
+lemma union_add_inter (s t : Multiset α) : s ∪ t + s ∩ t = s + t := by
   apply _root_.le_antisymm
   · rw [union_add_distrib]
-    refine union_le (add_le_add_left (inter_le_right _ _) _) ?_
+    refine union_le (add_le_add_left inter_le_right _) ?_
     rw [add_comm]
-    exact add_le_add_right (inter_le_left _ _) _
+    exact add_le_add_right inter_le_left _
   · rw [add_comm, add_inter_distrib]
-    refine le_inter (add_le_add_right (le_union_right _ _) _) ?_
+    refine le_inter (add_le_add_right le_union_right _) ?_
     rw [add_comm]
-    exact add_le_add_right (le_union_left _ _) _
+    exact add_le_add_right le_union_left _
 
 theorem sub_add_inter (s t : Multiset α) : s - t + s ∩ t = s := by
   rw [inter_comm]
@@ -1702,7 +1699,7 @@ theorem sub_add_inter (s t : Multiset α) : s - t + s ∩ t = s := by
 
 theorem sub_inter (s t : Multiset α) : s - s ∩ t = s - t :=
   add_right_cancel (b := s ∩ t) <| by
-    rw [sub_add_inter s t, tsub_add_cancel_of_le (inter_le_left s t)]
+    rw [sub_add_inter s t, tsub_add_cancel_of_le inter_le_left]
 
 end
 
@@ -1836,12 +1833,9 @@ theorem filter_union [DecidableEq α] (s t : Multiset α) :
 @[simp]
 theorem filter_inter [DecidableEq α] (s t : Multiset α) :
     filter p (s ∩ t) = filter p s ∩ filter p t :=
-  le_antisymm
-      (le_inter (filter_le_filter _ <| inter_le_left _ _)
-        (filter_le_filter _ <| inter_le_right _ _)) <|
-    le_filter.2
-      ⟨inf_le_inf (filter_le _ _) (filter_le _ _), fun _a h =>
-        of_mem_filter (mem_of_le (inter_le_left _ _) h)⟩
+  le_antisymm (le_inter (filter_le_filter _ inter_le_left) (filter_le_filter _ inter_le_right)) <|
+    le_filter.2 ⟨inf_le_inf (filter_le _ _) (filter_le _ _), fun _a h =>
+      of_mem_filter (mem_of_le inter_le_left h)⟩
 
 @[simp]
 theorem filter_filter (q) [DecidablePred q] (s : Multiset α) :

--- a/Mathlib/Data/Multiset/FinsetOps.lean
+++ b/Mathlib/Data/Multiset/FinsetOps.lean
@@ -164,7 +164,7 @@ theorem le_ndunion_left {s} (t : Multiset α) (d : Nodup s) : s ≤ ndunion s t 
   (le_iff_subset d).2 <| subset_ndunion_left _ _
 
 theorem ndunion_le_union (s t : Multiset α) : ndunion s t ≤ s ∪ t :=
-  ndunion_le.2 ⟨subset_of_le (le_union_left _ _), le_union_right _ _⟩
+  ndunion_le.2 ⟨subset_of_le le_union_left, le_union_right⟩
 
 theorem Nodup.ndunion (s : Multiset α) {t : Multiset α} : Nodup t → Nodup (ndunion s t) :=
   Quot.induction_on₂ s t fun _ _ => List.Nodup.union _
@@ -236,7 +236,7 @@ theorem ndinter_le_right {s} (t : Multiset α) (d : Nodup s) : ndinter s t ≤ t
   (le_iff_subset <| d.ndinter _).2 <| ndinter_subset_right _ _
 
 theorem inter_le_ndinter (s t : Multiset α) : s ∩ t ≤ ndinter s t :=
-  le_ndinter.2 ⟨inter_le_left _ _, subset_of_le <| inter_le_right _ _⟩
+  le_ndinter.2 ⟨inter_le_left, subset_of_le inter_le_right⟩
 
 @[simp]
 theorem ndinter_eq_inter {s t : Multiset α} (d : Nodup s) : ndinter s t = s ∩ t :=

--- a/Mathlib/Data/Multiset/Nodup.lean
+++ b/Mathlib/Data/Multiset/Nodup.lean
@@ -167,15 +167,12 @@ protected theorem Nodup.filterMap (f : α → Option β) (H : ∀ a a' b, b ∈ 
 theorem nodup_range (n : ℕ) : Nodup (range n) :=
   List.nodup_range _
 
-theorem Nodup.inter_left [DecidableEq α] (t) : Nodup s → Nodup (s ∩ t) :=
-  nodup_of_le <| inter_le_left _ _
-
-theorem Nodup.inter_right [DecidableEq α] (s) : Nodup t → Nodup (s ∩ t) :=
-  nodup_of_le <| inter_le_right _ _
+lemma Nodup.inter_left [DecidableEq α] (t) : Nodup s → Nodup (s ∩ t) := nodup_of_le inter_le_left
+lemma Nodup.inter_right [DecidableEq α] (s) : Nodup t → Nodup (s ∩ t) := nodup_of_le inter_le_right
 
 @[simp]
 theorem nodup_union [DecidableEq α] {s t : Multiset α} : Nodup (s ∪ t) ↔ Nodup s ∧ Nodup t :=
-  ⟨fun h => ⟨nodup_of_le (le_union_left _ _) h, nodup_of_le (le_union_right _ _) h⟩, fun ⟨h₁, h₂⟩ =>
+  ⟨fun h => ⟨nodup_of_le le_union_left h, nodup_of_le le_union_right h⟩, fun ⟨h₁, h₂⟩ =>
     nodup_iff_count_le_one.2 fun a => by
       rw [count_union]
       exact max_le (nodup_iff_count_le_one.1 h₁ a) (nodup_iff_count_le_one.1 h₂ a)⟩


### PR DESCRIPTION
This follows what we already do for `Set`, `Finset`, general lattices


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
