### PR TITLE
[Merged by Bors] - feat: monovarying functions are simultaneously monotone

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4118,6 +4118,7 @@ import Mathlib.Order.ModularLattice
 import Mathlib.Order.Monotone.Basic
 import Mathlib.Order.Monotone.Extension
 import Mathlib.Order.Monotone.Monovary
+import Mathlib.Order.Monotone.MonovaryOrder
 import Mathlib.Order.Monotone.Odd
 import Mathlib.Order.Monotone.Union
 import Mathlib.Order.Nat

--- a/Mathlib/Order/Monotone/MonovaryOrder.lean
+++ b/Mathlib/Order/Monotone/MonovaryOrder.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2022 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel, Yury Kudryashov
+-/
+import Mathlib.Order.Monotone.Monovary
+import Mathlib.SetTheory.Cardinal.Basic
+
+/-!
+# Interpreting monovarying functions as monotone functions
+
+This file proves that monovarying functions to linear orders can be made simultaneously monotone by
+setting the correct order on their shared indexing type.
+-/
+
+open Function Set
+
+variable {ι ι' α β γ : Type*}
+
+section
+variable [LinearOrder α] [LinearOrder β] (f : ι → α) (g : ι → β) {s : Set ι}
+
+/-- If `f : ι → α` and `g : ι → β` are monovarying, then `MonovaryOrder f g` is a linear order on
+`ι` that makes `f` and `g` simultaneously monotone.
+We define `i < j` if `f i < f j`, or if `f i = f j` and `g i < g j`, breaking ties arbitrarily. -/
+def MonovaryOrder (i j : ι) : Prop :=
+  Prod.Lex (· < ·) (Prod.Lex (· < ·) WellOrderingRel) (f i, g i, i) (f j, g j, j)
+
+instance : IsStrictTotalOrder ι (MonovaryOrder f g)
+    where
+  trichotomous i j := by
+    convert trichotomous_of (Prod.Lex (· < ·) <| Prod.Lex (· < ·) WellOrderingRel) _ _
+    · simp only [Prod.ext_iff, ← and_assoc, imp_and, eq_iff_iff, iff_and_self]
+      exact ⟨congr_arg _, congr_arg _⟩
+    · infer_instance
+  irrefl i := by rw [MonovaryOrder]; exact irrefl _
+  trans i j k := by rw [MonovaryOrder]; exact _root_.trans
+
+variable {f g}
+
+lemma monovaryOn_iff_exists_monotoneOn :
+    MonovaryOn f g s ↔ ∃ (_ : LinearOrder ι), MonotoneOn f s ∧ MonotoneOn g s := by
+  classical
+  letI := linearOrderOfSTO (MonovaryOrder f g)
+  refine ⟨fun hfg => ⟨‹_›, monotoneOn_iff_forall_lt.2 fun i hi j hj hij => ?_,
+    monotoneOn_iff_forall_lt.2 fun i hi j hj hij => ?_⟩, ?_⟩
+  · obtain h | ⟨h, -⟩ := Prod.lex_iff.1 hij <;> exact h.le
+  · obtain h | ⟨-, h⟩ := Prod.lex_iff.1 hij
+    · exact hfg.symm hi hj h
+    obtain h | ⟨h, -⟩ := Prod.lex_iff.1 h <;> exact h.le
+  · rintro ⟨_, hf, hg⟩
+    exact hf.monovaryOn hg
+
+lemma antivaryOn_iff_exists_monotoneOn_antitoneOn :
+    AntivaryOn f g s ↔ ∃ (_ : LinearOrder ι), MonotoneOn f s ∧ AntitoneOn g s := by
+  simp_rw [← monovaryOn_toDual_right, monovaryOn_iff_exists_monotoneOn, monotoneOn_toDual_comp_iff]
+
+lemma monovaryOn_iff_exists_antitoneOn :
+    MonovaryOn f g s ↔ ∃ (_ : LinearOrder ι), AntitoneOn f s ∧ AntitoneOn g s := by
+  simp_rw [← antivaryOn_toDual_left, antivaryOn_iff_exists_monotoneOn_antitoneOn,
+    monotoneOn_toDual_comp_iff]
+
+lemma antivaryOn_iff_exists_antitoneOn_monotoneOn :
+    AntivaryOn f g s ↔ ∃ (_ : LinearOrder ι), AntitoneOn f s ∧ MonotoneOn g s := by
+  simp_rw [← monovaryOn_toDual_left, monovaryOn_iff_exists_monotoneOn, monotoneOn_toDual_comp_iff]
+
+lemma monovary_iff_exists_monotone :
+    Monovary f g ↔ ∃ (_ : LinearOrder ι), Monotone f ∧ Monotone g := by
+  simp [← monovaryOn_univ, monovaryOn_iff_exists_monotoneOn]
+
+lemma monovary_iff_exists_antitone :
+    Monovary f g ↔ ∃ (_ : LinearOrder ι), Antitone f ∧ Antitone g := by
+  simp [← monovaryOn_univ, monovaryOn_iff_exists_antitoneOn]
+
+lemma antivary_iff_exists_monotone_antitone :
+    Antivary f g ↔ ∃ (_ : LinearOrder ι), Monotone f ∧ Antitone g := by
+  simp [← antivaryOn_univ, antivaryOn_iff_exists_monotoneOn_antitoneOn]
+
+lemma antivary_iff_exists_antitone_monotone :
+    Antivary f g ↔ ∃ (_ : LinearOrder ι), Antitone f ∧ Monotone g := by
+  simp [← antivaryOn_univ, antivaryOn_iff_exists_antitoneOn_monotoneOn]
+
+alias ⟨MonovaryOn.exists_monotoneOn, _⟩ := monovaryOn_iff_exists_monotoneOn
+alias ⟨MonovaryOn.exists_antitoneOn, _⟩ := monovaryOn_iff_exists_antitoneOn
+alias ⟨AntivaryOn.exists_monotoneOn_antitoneOn, _⟩ := antivaryOn_iff_exists_monotoneOn_antitoneOn
+alias ⟨AntivaryOn.exists_antitoneOn_monotoneOn, _⟩ := antivaryOn_iff_exists_antitoneOn_monotoneOn
+alias ⟨Monovary.exists_monotone, _⟩ := monovary_iff_exists_monotone
+alias ⟨Monovary.exists_antitone, _⟩ := monovary_iff_exists_antitone
+alias ⟨Antivary.exists_monotone_antitone, _⟩ := antivary_iff_exists_monotone_antitone
+alias ⟨Antivary.exists_antitone_monotone, _⟩ := antivary_iff_exists_antitone_monotone
+
+end

--- a/Mathlib/Order/Monotone/MonovaryOrder.lean
+++ b/Mathlib/Order/Monotone/MonovaryOrder.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2022 Sébastien Gouëzel. All rights reserved.
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sébastien Gouëzel, Yury Kudryashov
+Authors: Yaël Dillies
 -/
 import Mathlib.Order.Monotone.Monovary
 import Mathlib.SetTheory.Cardinal.Basic


### PR DESCRIPTION
From LeanCamCombi


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
