### PR TITLE
[Merged by Bors] - fix: remove definitions from module doc that were moved to Defs.lean

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -17,13 +17,6 @@ This file primarily concerns itself with orbits, stabilizers, and other objects 
 actions. Despite this file being called `basic`, low-level helper lemmas for algebraic manipulation
 of `•` belong elsewhere.
 
-## Main definitions
-
-* `MulAction.orbit`
-* `MulAction.fixedPoints`
-* `MulAction.fixedBy`
-* `MulAction.stabilizer`
-
 -/
 
 


### PR DESCRIPTION
---

I thought about replacing this with a "Main results" section but nothing jumped out at me from skimming the `theorem`s in the file - maybe someone who has worked with this material more can advise.