### PR TITLE
[Merged by Bors] - feat: the successor as a function `WithBot α → α`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -775,6 +775,7 @@ import Mathlib.Algebra.Order.Sub.Unbundled.Hom
 import Mathlib.Algebra.Order.Sub.WithTop
 import Mathlib.Algebra.Order.SuccPred
 import Mathlib.Algebra.Order.SuccPred.TypeTags
+import Mathlib.Algebra.Order.SuccPred.WithBot
 import Mathlib.Algebra.Order.Sum
 import Mathlib.Algebra.Order.ToIntervalMod
 import Mathlib.Algebra.Order.UpperLower
@@ -4156,6 +4157,7 @@ import Mathlib.Order.SuccPred.Limit
 import Mathlib.Order.SuccPred.LinearLocallyFinite
 import Mathlib.Order.SuccPred.Relation
 import Mathlib.Order.SuccPred.Tree
+import Mathlib.Order.SuccPred.WithBot
 import Mathlib.Order.SupClosed
 import Mathlib.Order.SupIndep
 import Mathlib.Order.SymmDiff

--- a/Mathlib/Algebra/Order/SuccPred/WithBot.lean
+++ b/Mathlib/Algebra/Order/SuccPred/WithBot.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2024 Yaël Dillies Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies Andrew Yang
+-/
+import Mathlib.Algebra.Order.Monoid.Unbundled.WithTop
+import Mathlib.Algebra.Order.SuccPred
+import Mathlib.Order.SuccPred.WithBot
+
+/-!
+# Algebraic properties of the successor function on `WithBot`
+-/
+
+namespace WithBot
+variable {α : Type*} [Preorder α] [OrderBot α] [AddMonoidWithOne α] [SuccAddOrder α]
+
+lemma succ_natCast (n : ℕ) : succ (n : WithBot α) = n + 1 := by
+  rw [← WithBot.coe_natCast, succ_coe, Order.succ_eq_add_one]
+
+@[simp] lemma succ_zero : succ (0 : WithBot α) = 1 := by simpa using succ_natCast 0
+
+@[simp]
+lemma succ_one : succ (1 : WithBot α) = 2 := by simpa [one_add_one_eq_two] using succ_natCast 1
+
+@[simp]
+lemma succ_ofNat (n : ℕ) [n.AtLeastTwo] :
+    succ (no_index OfNat.ofNat n : WithBot α) = OfNat.ofNat n + 1 := succ_natCast n
+
+end WithBot
+

--- a/Mathlib/Algebra/Order/SuccPred/WithBot.lean
+++ b/Mathlib/Algebra/Order/SuccPred/WithBot.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2024 Yaël Dillies Andrew Yang. All rights reserved.
+Copyright (c) 2024 Yaël Dillies, Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yaël Dillies Andrew Yang
+Authors: Yaël Dillies, Andrew Yang
 -/
 import Mathlib.Algebra.Order.Monoid.Unbundled.WithTop
 import Mathlib.Algebra.Order.SuccPred
@@ -27,4 +27,3 @@ lemma succ_ofNat (n : ℕ) [n.AtLeastTwo] :
     succ (no_index (OfNat.ofNat n) : WithBot α) = OfNat.ofNat n + 1 := succ_natCast n
 
 end WithBot
-

--- a/Mathlib/Algebra/Order/SuccPred/WithBot.lean
+++ b/Mathlib/Algebra/Order/SuccPred/WithBot.lean
@@ -24,7 +24,7 @@ lemma succ_one : succ (1 : WithBot α) = 2 := by simpa [one_add_one_eq_two] usin
 
 @[simp]
 lemma succ_ofNat (n : ℕ) [n.AtLeastTwo] :
-    succ (no_index OfNat.ofNat n : WithBot α) = OfNat.ofNat n + 1 := succ_natCast n
+    succ (no_index (OfNat.ofNat n) : WithBot α) = OfNat.ofNat n + 1 := succ_natCast n
 
 end WithBot
 

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -77,7 +77,7 @@ theorem splits_of_degree_le_one {f : K[X]} (hf : degree f ≤ 1) : Splits i f :=
   if hif : degree (f.map i) ≤ 0 then splits_of_map_eq_C i (degree_le_zero_iff.mp hif)
   else by
     push_neg at hif
-    rw [← Order.succ_le_iff, ← WithBot.coe_zero, WithBot.succ_coe, Nat.succ_eq_succ] at hif
+    rw [← Order.succ_le_iff, ← WithBot.coe_zero, WithBot.orderSucc_coe, Nat.succ_eq_succ] at hif
     exact splits_of_map_degree_eq_one i ((degree_map_le.trans hf).antisymm hif)
 
 theorem splits_of_degree_eq_one {f : K[X]} (hf : degree f = 1) : Splits i f :=

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -1063,13 +1063,11 @@ instance : PredOrder (WithTop α) where
     · exact coe_le_coe.2 le_top
     exact coe_le_coe.2 (le_pred_of_lt <| coe_lt_coe.1 h)
 
-@[simp]
-theorem pred_top : pred (⊤ : WithTop α) = ↑(⊤ : α) :=
-  rfl
+/-- Not to be confused with `WithTop.pred_bot`, which is about `WithTop.pred`. -/
+@[simp] lemma orderPred_top : pred (⊤ : WithTop α) = ↑(⊤ : α) := rfl
 
-@[simp]
-theorem pred_coe (a : α) : pred (↑a : WithTop α) = ↑(pred a) :=
-  rfl
+/-- Not to be confused with `WithTop.pred_coe`, which is about `WithTop.pred`. -/
+@[simp] lemma orderPred_coe (a : α) : pred (↑a : WithTop α) = ↑(pred a) := rfl
 
 @[simp]
 theorem pred_untop :
@@ -1125,13 +1123,11 @@ instance : SuccOrder (WithBot α) where
     · exact coe_le_coe.2 bot_le
     · exact coe_le_coe.2 (succ_le_of_lt <| coe_lt_coe.1 h)
 
-@[simp]
-theorem succ_bot : succ (⊥ : WithBot α) = ↑(⊥ : α) :=
-  rfl
+/-- Not to be confused with `WithBot.succ_bot`, which is about `WithBot.succ`. -/
+@[simp] lemma orderSucc_bot : succ (⊥ : WithBot α) = ↑(⊥ : α) := rfl
 
-@[simp]
-theorem succ_coe (a : α) : succ (↑a : WithBot α) = ↑(succ a) :=
-  rfl
+/-- Not to be confused with `WithBot.succ_coe`, which is about `WithBot.succ`. -/
+@[simp] lemma orderSucc_coe (a : α) : succ (↑a : WithBot α) = ↑(succ a) := rfl
 
 @[simp]
 theorem succ_unbot :

--- a/Mathlib/Order/SuccPred/WithBot.lean
+++ b/Mathlib/Order/SuccPred/WithBot.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2024 Yaël Dillies Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies Andrew Yang
+-/
+import Mathlib.Order.SuccPred.Basic
+
+/-!
+# Successor function on `WithBot`
+
+This file defines the successor of `a : WithBot α` as an element of `α`, and dually for `WithTop`.
+-/
+
+namespace WithBot
+variable {α : Type*} [Preorder α] [OrderBot α] [SuccOrder α] {x y : WithBot α}
+
+/-- The successor of `a : WithBot α` as an element of `α`. -/
+def succ (a : WithBot α) : α := a.recBotCoe ⊥ Order.succ
+
+/-- Not to be confused with `WithBot.orderSucc_bot`, which is about `Order.succ`. -/
+@[simp] lemma succ_bot : succ (⊥ : WithBot α) = ⊥ := rfl
+
+/-- Not to be confused with `WithBot.orderSucc_coe`, which is about `Order.succ`. -/
+@[simp] lemma succ_coe (a : α) : succ (a : WithBot α) = Order.succ a := rfl
+
+lemma succ_eq_succ : ∀ a : WithBot α, succ a = Order.succ a
+  | ⊥ => rfl
+  | (a : α) => rfl
+
+lemma succ_mono : Monotone (succ : WithBot α → α)
+  | ⊥, _, _ => by simp
+  | (a : α), ⊥, hab => by simp at hab
+  | (a : α), (b : α), hab => Order.succ_le_succ (by simpa using hab)
+
+lemma succ_strictMono [NoMaxOrder α] : StrictMono (succ : WithBot α → α)
+  | ⊥, (b : α), hab => by simp
+  | (a : α), (b : α), hab => Order.succ_lt_succ (by simpa using hab)
+
+@[gcongr] lemma succ_le_succ (hxy : x ≤ y) : x.succ ≤ y.succ := succ_mono hxy
+@[gcongr] lemma succ_lt_succ [NoMaxOrder α] (hxy : x < y) : x.succ < y.succ := succ_strictMono hxy
+
+end WithBot
+
+namespace WithTop
+variable {α : Type*} [Preorder α] [OrderTop α] [PredOrder α] {x y : WithTop α}
+
+/-- The predessor of `a : WithTop α` as an element of `α`. -/
+def pred (a : WithTop α) : α := a.recTopCoe ⊤ Order.pred
+
+/-- Not to be confused with `WithTop.orderPred_top`, which is about `Order.pred`. -/
+@[simp] lemma pred_top : pred (⊤ : WithTop α) = ⊤ := rfl
+
+/-- Not to be confused with `WithTop.orderPred_coe`, which is about `Order.pred`. -/
+@[simp] lemma pred_coe (a : α) : pred (a : WithTop α) = Order.pred a := rfl
+
+lemma pred_eq_pred : ∀ a : WithTop α, pred a = Order.pred a
+  | ⊤ => rfl
+  | (a : α) => rfl
+
+lemma pred_mono : Monotone (pred : WithTop α → α)
+  | _, ⊤, _ => by simp
+  | ⊤, (a : α), hab => by simp at hab
+  | (a : α), (b : α), hab => Order.pred_le_pred (by simpa using hab)
+
+lemma pred_strictMono [NoMinOrder α] : StrictMono (pred : WithTop α → α)
+  | (b : α), ⊤, hab => by simp
+  | (a : α), (b : α), hab => Order.pred_lt_pred (by simpa using hab)
+
+@[gcongr] lemma pred_le_pred (hxy : x ≤ y) : x.pred ≤ y.pred := pred_mono hxy
+@[gcongr] lemma pred_lt_pred [NoMinOrder α] (hxy : x < y) : x.pred < y.pred := pred_strictMono hxy
+
+end WithTop

--- a/Mathlib/Order/SuccPred/WithBot.lean
+++ b/Mathlib/Order/SuccPred/WithBot.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2024 Yaël Dillies Andrew Yang. All rights reserved.
+Copyright (c) 2024 Yaël Dillies, Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yaël Dillies Andrew Yang
+Authors: Yaël Dillies, Andrew Yang
 -/
 import Mathlib.Order.SuccPred.Basic
 


### PR DESCRIPTION
This will be useful to do induction on a family of polynomials by the sum of the successor of their degree.

From GrowthInGroups (LeanCamCombi)

Co-authored-by: Andrew Yang


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
