### PR TITLE
[Merged by Bors] - feat: specialize `IsDenseInducing.extend` to the case of a subset

### DIFF
--- a/Mathlib/Topology/DenseEmbedding.lean
+++ b/Mathlib/Topology/DenseEmbedding.lean
@@ -39,6 +39,10 @@ structure IsDenseInducing [TopologicalSpace α] [TopologicalSpace β] (i : α �
 namespace IsDenseInducing
 
 variable [TopologicalSpace α] [TopologicalSpace β]
+
+theorem _root_.Dense.isDenseInducing_val {s : Set α} (hs : Dense s) :
+    IsDenseInducing (@Subtype.val α s) := ⟨IsInducing.subtypeVal, hs.denseRange_val⟩
+
 variable {i : α → β}
 
 lemma isInducing (di : IsDenseInducing i) : IsInducing i := di.toIsInducing

--- a/Mathlib/Topology/DenseEmbedding.lean
+++ b/Mathlib/Topology/DenseEmbedding.lean
@@ -209,6 +209,51 @@ theorem mk' (i : α → β) (c : Continuous i) (dense : ∀ x, x ∈ closure (ra
 
 end IsDenseInducing
 
+namespace Dense
+
+variable [TopologicalSpace α] [TopologicalSpace β] {s : Set α}
+
+/-- This is a shortcut for `hs.isDenseInducing_val.extend f`. It is useful because if `s : Set α`
+is dense then the coercion `(↑) : s → α` automatically satisfies `IsUniformInducing` and
+`IsDenseInducing` so this gives access to the theorems satisfied by a uniform extension by simply
+mentioning the density hypothesis. -/
+noncomputable def extend (hs : Dense s) (f : s → β) : α → β :=
+    hs.isDenseInducing_val.extend f
+
+variable {f : s → β}
+
+theorem extend_eq_of_tendsto [T2Space β] (hs : Dense s) {a : α} {b : β}
+    (hf : Tendsto f (comap (↑) (𝓝 a)) (𝓝 b)) : hs.extend f a = b :=
+  hs.isDenseInducing_val.extend_eq_of_tendsto hf
+
+theorem extend_eq_at [T2Space β] (hs : Dense s) {f : s → β} {x : s}
+    (hf : ContinuousAt f x) : hs.extend f x = f x :=
+  hs.isDenseInducing_val.extend_eq_at hf
+
+theorem extend_eq [T2Space β] (hs : Dense s) (hf : Continuous f) (x : s) :
+    hs.extend f x = f x :=
+  hs.extend_eq_at hf.continuousAt
+
+theorem extend_unique_at [T2Space β] {a : α} {g : α → β} (hs : Dense s)
+    (hf : ∀ᶠ x : s in comap (↑) (𝓝 a), g x = f x) (hg : ContinuousAt g a) :
+    hs.extend f a = g a :=
+  hs.isDenseInducing_val.extend_unique_at hf hg
+
+theorem extend_unique [T2Space β] {g : α → β} (hs : Dense s)
+    (hf : ∀ x : s, g x = f x) (hg : Continuous g) : hs.extend f = g :=
+  hs.isDenseInducing_val.extend_unique hf hg
+
+theorem continuousAt_extend [T3Space β] {a : α} (hs : Dense s)
+    (hf : ∀ᶠ x in 𝓝 a, ∃ b, Tendsto f (comap (↑) <| 𝓝 x) (𝓝 b)) :
+    ContinuousAt (hs.extend f) a :=
+  hs.isDenseInducing_val.continuousAt_extend hf
+
+theorem continuous_extend [T3Space β] (hs : Dense s)
+    (hf : ∀ a : α, ∃ b, Tendsto f (comap (↑) (𝓝 a)) (𝓝 b)) : Continuous (hs.extend f) :=
+  hs.isDenseInducing_val.continuous_extend hf
+
+end Dense
+
 /-- A dense embedding is an embedding with dense image. -/
 structure IsDenseEmbedding [TopologicalSpace α] [TopologicalSpace β] (e : α → β) extends
   IsDenseInducing e : Prop where

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -623,6 +623,13 @@ theorem uniformly_extend_spec [CompleteSpace γ] (a : α) : Tendsto f (comap e (
   simpa only [IsDenseInducing.extend] using
     tendsto_nhds_limUnder (uniformly_extend_exists h_e ‹_› h_f _)
 
+include h_e h_f in
+theorem uniformly_extend_tendsto {δ : Type*} [CompleteSpace γ] {a : α} {x : δ → β} {ℱ : Filter δ}
+    (hx : Tendsto (e ∘ x) ℱ (𝓝 a)) : Tendsto (f ∘ x) ℱ (𝓝 (ψ a)) := by
+  rw [← Filter.tendsto_map'_iff]
+  rw [← Filter.tendsto_comap_iff] at hx
+  exact (uniformly_extend_spec h_e h_dense h_f a).mono_left hx
+
 include h_f in
 theorem uniformContinuous_uniformly_extend [CompleteSpace γ] : UniformContinuous ψ := fun d hd =>
   let ⟨s, hs, hs_comp⟩ := comp3_mem_uniformity hd
@@ -660,3 +667,53 @@ theorem uniformly_extend_unique {g : α → γ} (hg : ∀ b, g (e b) = f b) (hc 
   IsDenseInducing.extend_unique _ hg hc
 
 end UniformExtension
+
+section DenseExtension
+
+variable {α β : Type*}
+
+theorem Dense.isDenseInducing_val [TopologicalSpace α] {s : Set α} (hs : Dense s) :
+    IsDenseInducing (@Subtype.val α s) := ⟨IsInducing.subtypeVal, hs.denseRange_val⟩
+
+/-- This is a shortcut for `hs.isDenseInducing_val.extend f`. It is useful because if `s : Set α`
+is dense then the coercion `(↑) : s → α` automatically satisfies `IsUniformInducing` and
+`IsDenseInducing` so this gives access to the theorems satisfied by a uniform extension by simply
+mentioning the density hypothesis. -/
+noncomputable def Dense.extend [TopologicalSpace α] [TopologicalSpace β]
+    {s : Set α} (hs : Dense s) (f : s → β) : α → β := hs.isDenseInducing_val.extend f
+
+variable [UniformSpace α] [UniformSpace β]
+
+theorem isUniformInducing_val (s : Set α) :
+    IsUniformInducing (@Subtype.val α s) := ⟨uniformity_setCoe⟩
+
+variable {s : Set α} {f : s → β}
+
+theorem Dense.extend_exists [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) (a : α) :
+    ∃ b, Tendsto f (comap (↑) (𝓝 a)) (𝓝 b) :=
+  uniformly_extend_exists (isUniformInducing_val s) hs.denseRange_val hf a
+
+theorem Dense.extend_spec [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) (a : α) :
+    Tendsto f (comap (↑) (𝓝 a)) (𝓝 (hs.extend f a)) :=
+  uniformly_extend_spec (isUniformInducing_val s) hs.denseRange_val hf a
+
+theorem Dense.extend_tendsto [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) {γ : Type*}
+    {a : α} {x : γ → s} {ℱ : Filter γ} (hx : Tendsto ((↑) ∘ x) ℱ (𝓝 a)) :
+    Tendsto (f ∘ x) ℱ (𝓝 (hs.extend f a)) :=
+  uniformly_extend_tendsto (isUniformInducing_val s) hs.denseRange_val hf hx
+
+theorem Dense.uniformContinuous_extend [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) :
+    UniformContinuous (hs.extend f) :=
+  uniformContinuous_uniformly_extend (isUniformInducing_val s) hs.denseRange_val hf
+
+variable [T0Space β]
+
+theorem Dense.extend_of_ind (hs : Dense s) (hf : UniformContinuous f) (x : s) :
+    hs.extend f x = f x :=
+  IsDenseInducing.extend_eq_at _ hf.continuous.continuousAt
+
+theorem Dense.extend_unique (hs : Dense s) {g : α → β} (hg : ∀ x : s, g x = f x)
+    (hc : Continuous g) : hs.extend f = g :=
+  IsDenseInducing.extend_unique _ hg hc
+
+end DenseExtension

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -670,47 +670,38 @@ end UniformExtension
 
 section DenseExtension
 
-variable {α β : Type*}
-
-/-- This is a shortcut for `hs.isDenseInducing_val.extend f`. It is useful because if `s : Set α`
-is dense then the coercion `(↑) : s → α` automatically satisfies `IsUniformInducing` and
-`IsDenseInducing` so this gives access to the theorems satisfied by a uniform extension by simply
-mentioning the density hypothesis. -/
-noncomputable def Dense.extend [TopologicalSpace α] [TopologicalSpace β]
-    {s : Set α} (hs : Dense s) (f : s → β) : α → β := hs.isDenseInducing_val.extend f
-
-variable [UniformSpace α] [UniformSpace β]
+variable {α β : Type*} [UniformSpace α] [UniformSpace β]
 
 theorem isUniformInducing_val (s : Set α) :
     IsUniformInducing (@Subtype.val α s) := ⟨uniformity_setCoe⟩
 
+namespace Dense
+
 variable {s : Set α} {f : s → β}
 
-theorem Dense.extend_exists [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) (a : α) :
+theorem extend_exists [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) (a : α) :
     ∃ b, Tendsto f (comap (↑) (𝓝 a)) (𝓝 b) :=
   uniformly_extend_exists (isUniformInducing_val s) hs.denseRange_val hf a
 
-theorem Dense.extend_spec [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) (a : α) :
+theorem extend_spec [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) (a : α) :
     Tendsto f (comap (↑) (𝓝 a)) (𝓝 (hs.extend f a)) :=
   uniformly_extend_spec (isUniformInducing_val s) hs.denseRange_val hf a
 
-theorem Dense.extend_tendsto [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) {γ : Type*}
+theorem extend_tendsto [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) {γ : Type*}
     {a : α} {x : γ → s} {ℱ : Filter γ} (hx : Tendsto ((↑) ∘ x) ℱ (𝓝 a)) :
     Tendsto (f ∘ x) ℱ (𝓝 (hs.extend f a)) :=
   uniformly_extend_tendsto (isUniformInducing_val s) hs.denseRange_val hf hx
 
-theorem Dense.uniformContinuous_extend [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) :
+theorem uniformContinuous_extend [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) :
     UniformContinuous (hs.extend f) :=
   uniformContinuous_uniformly_extend (isUniformInducing_val s) hs.denseRange_val hf
 
 variable [T0Space β]
 
-theorem Dense.extend_of_ind (hs : Dense s) (hf : UniformContinuous f) (x : s) :
+theorem extend_of_ind (hs : Dense s) (hf : UniformContinuous f) (x : s) :
     hs.extend f x = f x :=
   IsDenseInducing.extend_eq_at _ hf.continuous.continuousAt
 
-theorem Dense.extend_unique (hs : Dense s) {g : α → β} (hg : ∀ x : s, g x = f x)
-    (hc : Continuous g) : hs.extend f = g :=
-  IsDenseInducing.extend_unique _ hg hc
+end Dense
 
 end DenseExtension

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -623,13 +623,6 @@ theorem uniformly_extend_spec [CompleteSpace γ] (a : α) : Tendsto f (comap e (
   simpa only [IsDenseInducing.extend] using
     tendsto_nhds_limUnder (uniformly_extend_exists h_e ‹_› h_f _)
 
-include h_e h_f in
-theorem uniformly_extend_tendsto {δ : Type*} [CompleteSpace γ] {a : α} {x : δ → β} {ℱ : Filter δ}
-    (hx : Tendsto (e ∘ x) ℱ (𝓝 a)) : Tendsto (f ∘ x) ℱ (𝓝 (ψ a)) := by
-  rw [← Filter.tendsto_map'_iff]
-  rw [← Filter.tendsto_comap_iff] at hx
-  exact (uniformly_extend_spec h_e h_dense h_f a).mono_left hx
-
 include h_f in
 theorem uniformContinuous_uniformly_extend [CompleteSpace γ] : UniformContinuous ψ := fun d hd =>
   let ⟨s, hs, hs_comp⟩ := comp3_mem_uniformity hd
@@ -686,11 +679,6 @@ theorem extend_exists [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous 
 theorem extend_spec [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) (a : α) :
     Tendsto f (comap (↑) (𝓝 a)) (𝓝 (hs.extend f a)) :=
   uniformly_extend_spec (isUniformInducing_val s) hs.denseRange_val hf a
-
-theorem extend_tendsto [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) {γ : Type*}
-    {a : α} {x : γ → s} {ℱ : Filter γ} (hx : Tendsto ((↑) ∘ x) ℱ (𝓝 a)) :
-    Tendsto (f ∘ x) ℱ (𝓝 (hs.extend f a)) :=
-  uniformly_extend_tendsto (isUniformInducing_val s) hs.denseRange_val hf hx
 
 theorem uniformContinuous_extend [CompleteSpace β] (hs : Dense s) (hf : UniformContinuous f) :
     UniformContinuous (hs.extend f) :=

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -672,9 +672,6 @@ section DenseExtension
 
 variable {α β : Type*}
 
-theorem Dense.isDenseInducing_val [TopologicalSpace α] {s : Set α} (hs : Dense s) :
-    IsDenseInducing (@Subtype.val α s) := ⟨IsInducing.subtypeVal, hs.denseRange_val⟩
-
 /-- This is a shortcut for `hs.isDenseInducing_val.extend f`. It is useful because if `s : Set α`
 is dense then the coercion `(↑) : s → α` automatically satisfies `IsUniformInducing` and
 `IsDenseInducing` so this gives access to the theorems satisfied by a uniform extension by simply


### PR DESCRIPTION
Introduce a shortcut for `hs.isDenseInducing_val.extend f`. It is useful because if `s : Set α` is dense then the coercion `(↑) : s → α` automatically satisfies `IsUniformInducing` and `IsDenseInducing` so this gives access to the theorems satisfied by a uniform extension by simply mentioning the density hypothesis.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
