### PR TITLE
[Merged by Bors] - doc/chore: document the fields in 1000.yaml

### DIFF
--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -150,7 +150,7 @@ Q207244:
 
 Q208416:
   title: Independence of the continuum hypothesis
-  url: https://github.com/flypitch/flypitch
+  url: https://github.com/flypitch/flypitch/blob/d72904c17fbb874f01ffe168667ba12663a7b853/src/summary.lean#L90
   author: Floris van Doorn and Jesse Michael Han
   date: 2019-09-17
 

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -2,10 +2,20 @@
 # 1000+ theorems project (https://1000-plus.github.io/).
 # This file and associated infrastructure are work in progress.
 #
+# This file, contains for each theorem in the project,
+# - an entry, labelled by its wikidata entry,
+# - |title|: a human-readable title
+# - (optional) |decl|: if a theorem is formalised in mathlib, the archive or counterexamples,
+#     the name of the corresponding declaration
+# - (optional) |decls|: like |decl|, but a list of declarations
+#     (if one theorem is split into multiple declarations)
+# - (optional) |author|: author(s) of a formalisation
+# - (optional) |date|: date of completion of the first formalisation
+# - (optional) |url|: for external projects, an URL referring to the result
+
 # Current TODOs/unresolved questions:
-# - should this file include further metadata, such as repository links, author names or dates?
 # - add infrastructure for updating the information upstream when formalisations are added
-# - perhaps add a wikidata version of the stacks tag, and generate this file automatically
+# - perhaps add a wikidata version of the stacks attribute, and generate this file automatically
 #   (can this handle formalisation of *statements* also?)
 # - complete the information which theorems are already formalised
 
@@ -141,8 +151,6 @@ Q207244:
 Q208416:
   title: Independence of the continuum hypothesis
   url: https://github.com/flypitch/flypitch
-  identifiers:
-  - independence_of_CH
   author: Floris van Doorn and Jesse Michael Han
   date: 2019-09-17
 


### PR DESCRIPTION
And remove the 'identifiers' field: the field was only kept for the upstream repository, and the field was removed there.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
