### PR TITLE
[Merged by Bors] - feat: isomorphic rings have isomorphic spectra

### DIFF
--- a/Mathlib/RingTheory/PrimeSpectrum.lean
+++ b/Mathlib/RingTheory/PrimeSpectrum.lean
@@ -46,7 +46,7 @@ assert_not_exists TopologicalSpace
 
 noncomputable section
 
-open scoped Classical
+open scoped Classical Pointwise
 
 universe u v
 
@@ -373,6 +373,18 @@ theorem mem_compl_zeroLocus_iff_not_mem {f : R} {I : PrimeSpectrum R} :
     I ∈ (zeroLocus {f} : Set (PrimeSpectrum R))ᶜ ↔ f ∉ I.asIdeal := by
   rw [Set.mem_compl_iff, mem_zeroLocus, Set.singleton_subset_iff]; rfl
 
+@[simp]
+lemma zeroLocus_union_singleton_zero (s : Set R) : zeroLocus (s ∪ {0}) = zeroLocus s := by
+  rw [zeroLocus_union, zeroLocus_singleton_zero, Set.inter_univ]
+
+@[simp]
+lemma zeroLocus_diff_singleton_zero (s : Set R) : zeroLocus (s \ {0}) = zeroLocus s := by
+  rw [← zeroLocus_union_singleton_zero, ← zeroLocus_union_singleton_zero (s := s)]; simp
+
+lemma zeroLocus_smul_of_isUnit {r : R} (hr : IsUnit r) (s : Set R) :
+    zeroLocus (r • s) = zeroLocus s := by
+  ext; simp [Set.subset_def, ← Set.image_smul, Ideal.unit_mul_mem_iff_mem _ hr]
+
 section Order
 
 /-!
@@ -539,6 +551,20 @@ theorem specComap_injective_of_surjective (f : R →+* S) (hf : Function.Surject
   PrimeSpectrum.ext
     (Ideal.comap_injective_of_surjective f hf
       (congr_arg PrimeSpectrum.asIdeal h : (f.specComap x).asIdeal = (f.specComap y).asIdeal))
+
+/-- `RingHom.specComap` of an isomorphism of rings as an equivalence of their prime spectra. -/
+@[simps apply symm_apply]
+def comapEquiv (e : R ≃+* S) : PrimeSpectrum R ≃ PrimeSpectrum S where
+  toFun := e.symm.toRingHom.specComap
+  invFun := e.toRingHom.specComap
+  left_inv x := by
+    rw [← specComap_comp_apply, RingEquiv.toRingHom_eq_coe,
+      RingEquiv.toRingHom_eq_coe, RingEquiv.symm_comp]
+    rfl
+  right_inv x := by
+    rw [← specComap_comp_apply, RingEquiv.toRingHom_eq_coe,
+      RingEquiv.toRingHom_eq_coe, RingEquiv.comp_symm]
+    rfl
 
 variable (S)
 

--- a/Mathlib/RingTheory/PrimeSpectrum.lean
+++ b/Mathlib/RingTheory/PrimeSpectrum.lean
@@ -374,12 +374,12 @@ theorem mem_compl_zeroLocus_iff_not_mem {f : R} {I : PrimeSpectrum R} :
   rw [Set.mem_compl_iff, mem_zeroLocus, Set.singleton_subset_iff]; rfl
 
 @[simp]
-lemma zeroLocus_union_singleton_zero (s : Set R) : zeroLocus (s ∪ {0}) = zeroLocus s := by
-  rw [zeroLocus_union, zeroLocus_singleton_zero, Set.inter_univ]
+lemma zeroLocus_insert_zero (s : Set R) : zeroLocus (insert 0 s) = zeroLocus s := by
+  rw [← Set.union_singleton, zeroLocus_union, zeroLocus_singleton_zero, Set.inter_univ]
 
 @[simp]
 lemma zeroLocus_diff_singleton_zero (s : Set R) : zeroLocus (s \ {0}) = zeroLocus s := by
-  rw [← zeroLocus_union_singleton_zero, ← zeroLocus_union_singleton_zero (s := s)]; simp
+  rw [← zeroLocus_insert_zero, ← zeroLocus_insert_zero (s := s)]; simp
 
 lemma zeroLocus_smul_of_isUnit {r : R} (hr : IsUnit r) (s : Set R) :
     zeroLocus (r • s) = zeroLocus s := by


### PR DESCRIPTION
... and other simple lemmas about `zeroLocus`.

From GrowthInGroups (LeanCamCombi)

Co-authored-by: Andrew Yang

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
