### PR TITLE
[Merged by Bors] - feat: induction principle for finitely presented ring homs

### DIFF
--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -452,7 +452,6 @@ end RingHom
 
 namespace RingHom.FinitePresentation
 universe u v
-variable {R : Type u} [CommRing R]
 
 open Polynomial
 
@@ -460,7 +459,13 @@ open Polynomial
 
 For a property to hold for all finitely presented ring homs, it suffices for it to hold for
 `Polynomial.C : R → R[X]`, surjective ring homs with finitely generated kernels, and to be closed
-under composition. -/
+under composition.
+
+Note that to state this conveniently for ring homs between rings of different universes, we carry
+around two predicates `P` and `Q`, which should be "the same" apart from universes:
+* `P`, for ring homs `(R : Type u) → (S : Type u)`.
+* `Q`, for ring homs `(R : Type u) → (S : Type v)`.
+-/
 lemma polynomial_induction
     (P : ∀ (R : Type u) [CommRing R] (S : Type u) [CommRing S], (R →+* S) → Prop)
     (Q : ∀ (R : Type u) [CommRing R] (S : Type v) [CommRing S], (R →+* S) → Prop)
@@ -469,13 +474,14 @@ lemma polynomial_induction
       Surjective f → (ker f).FG → Q R S f)
     (comp : ∀ (R) [CommRing R] (S) [CommRing S] (T) [CommRing T] (f : R →+* S) (g : S →+* T),
       P R S f → Q S T g → Q R T (g.comp f))
-    {R S} [CommRing R] [CommRing S] (f : R →+* S) (hf : f.FinitePresentation) :
+    {R : Type u} {S : Type v} [CommRing R] [CommRing S] (f : R →+* S) (hf : f.FinitePresentation) :
     Q R S f := by
+  letI := f.toAlgebra
   obtain ⟨n, g, hg, hg'⟩ := hf
-  let g' := letI := f.toAlgebra; g.toRingHom
-  replace hg : Surjective g' := hg
-  replace hg' : (ker g').FG := hg'
-  have : g'.comp MvPolynomial.C = f := letI := f.toAlgebra; g.comp_algebraMap
+  let g' := g.toRingHom
+  change Surjective g' at hg
+  change (ker g').FG at hg'
+  have : g'.comp MvPolynomial.C = f := g.comp_algebraMap
   clear_value g'
   subst this
   clear g

--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -450,6 +450,57 @@ end FinitePresentation
 
 end RingHom
 
+namespace RingHom.FinitePresentation
+universe u v
+variable {R : Type u} [CommRing R]
+
+open Polynomial
+
+/-- Induction principle for finitely presented ring homomorphisms.
+
+For a property to hold for all finitely presented ring homs, it suffices for it to hold for
+`Polynomial.C : R → R[X]`, surjective ring homs with finitely generated kernels, and to be closed
+under composition. -/
+lemma polynomial_induction
+    (P : ∀ (R : Type u) [CommRing R] (S : Type u) [CommRing S], (R →+* S) → Prop)
+    (Q : ∀ (R : Type u) [CommRing R] (S : Type v) [CommRing S], (R →+* S) → Prop)
+    (polynomial : ∀ (R) [CommRing R], P R R[X] C)
+    (fg_ker : ∀ (R : Type u) [CommRing R] (S : Type v) [CommRing S] (f : R →+* S),
+      Surjective f → (ker f).FG → Q R S f)
+    (comp : ∀ (R) [CommRing R] (S) [CommRing S] (T) [CommRing T] (f : R →+* S) (g : S →+* T),
+      P R S f → Q S T g → Q R T (g.comp f))
+    {R S} [CommRing R] [CommRing S] (f : R →+* S) (hf : f.FinitePresentation) :
+    Q R S f := by
+  obtain ⟨n, g, hg, hg'⟩ := hf
+  let g' := letI := f.toAlgebra; g.toRingHom
+  replace hg : Surjective g' := hg
+  replace hg' : (ker g').FG := hg'
+  have : g'.comp MvPolynomial.C = f := letI := f.toAlgebra; g.comp_algebraMap
+  clear_value g'
+  subst this
+  clear g
+  induction n generalizing R S with
+  | zero =>
+    refine fg_ker _ _ _ (hg.comp (MvPolynomial.C_surjective (Fin 0))) ?_
+    rw [← comap_ker]
+    convert hg'.map (MvPolynomial.isEmptyRingEquiv R (Fin 0)).toRingHom using 1
+    simp only [RingEquiv.toRingHom_eq_coe]
+    exact Ideal.comap_symm (MvPolynomial.isEmptyRingEquiv R (Fin 0))
+  | succ n IH =>
+    let e : MvPolynomial (Fin (n + 1)) R ≃ₐ[R] MvPolynomial (Fin n) R[X] :=
+      (MvPolynomial.renameEquiv R (finSuccEquiv n)).trans (MvPolynomial.optionEquivRight R (Fin n))
+    have he : (ker (g'.comp <| RingHomClass.toRingHom e.symm)).FG := by
+      rw [← RingHom.comap_ker]
+      convert hg'.map e.toAlgHom.toRingHom using 1
+      exact Ideal.comap_symm e.toRingEquiv
+    have := IH (R := R[X]) (S := S) (g'.comp e.symm) (hg.comp e.symm.surjective) he
+    convert comp _ _ _ _ _ (polynomial _) this using 1
+    rw [comp_assoc, comp_assoc]
+    congr 1 with r
+    simp [e]
+
+end RingHom.FinitePresentation
+
 namespace AlgHom
 
 variable {R A B C : Type*} [CommRing R]


### PR DESCRIPTION
For a property to hold for all finitely presented ring homs, it suffices for it to hold for `Polynomial.C : R → R[X]`, surjective ring homs with finitely generated kernels, and to be closed under composition.

From GrowthInGroups (LeanCamCombi)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
