### PR TITLE
[Merged by Bors] - docs(LinearAlgebra/Matrix/Determinant/Basic): det_of_*erTriangular

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -633,7 +633,7 @@ theorem det_blockDiagonal {o : Type*} [Fintype o] [DecidableEq o] (M : o → Mat
 
 /-- The determinant of a 2×2 block matrix with the lower-left block equal to zero is the product of
 the determinants of the diagonal blocks. For the generalization to any number of blocks, see
-`Matrix.det_of_upper_triangular`. -/
+`Matrix.det_of_upperTriangular`. -/
 @[simp]
 theorem det_fromBlocks_zero₂₁ (A : Matrix m m R) (B : Matrix m n R) (D : Matrix n n R) :
     (Matrix.fromBlocks A B 0 D).det = A.det * D.det := by
@@ -687,7 +687,7 @@ theorem det_fromBlocks_zero₂₁ (A : Matrix m m R) (B : Matrix m n R) (D : Mat
 
 /-- The determinant of a 2×2 block matrix with the upper-right block equal to zero is the product of
 the determinants of the diagonal blocks. For the generalization to any number of blocks, see
-`Matrix.det_of_lower_triangular`. -/
+`Matrix.det_of_lowerTriangular`. -/
 @[simp]
 theorem det_fromBlocks_zero₁₂ (A : Matrix m m R) (C : Matrix n m R) (D : Matrix n n R) :
     (Matrix.fromBlocks A 0 C D).det = A.det * D.det := by


### PR DESCRIPTION
---

The names in the docstrings do not exist anymore.