### PR TITLE
[Merged by Bors] - feat(DiscreteValuationRing/Basic): a ring equivalent to a DVR is a DVR

### DIFF
--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -307,7 +307,6 @@ theorem RingEquiv.isDiscreteValuationRing {A B : Type*} [CommRing A] [IsDomain A
     rw [IsLocalRing.mem_maximalIdeal, map_mem_nonunits_iff e, ← IsLocalRing.mem_maximalIdeal]
     exact a.2
 
-
 section
 
 variable [CommRing R] [IsDomain R] [IsDiscreteValuationRing R]

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -5,6 +5,7 @@ Authors: Kevin Buzzard
 -/
 import Mathlib.RingTheory.AdicCompletion.Basic
 import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
+import Mathlib.RingTheory.LocalRing.RingHom.Basic
 import Mathlib.RingTheory.UniqueFactorizationDomain.Basic
 import Mathlib.RingTheory.Valuation.PrimeMultiplicity
 import Mathlib.RingTheory.Valuation.ValuationRing
@@ -136,10 +137,6 @@ theorem associated_of_irreducible {a b : R} (ha : Irreducible a) (hb : Irreducib
     Associated a b := by
   rw [irreducible_iff_uniformizer] at ha hb
   rw [← span_singleton_eq_span_singleton, ← ha, hb]
-
-end IsDiscreteValuationRing
-
-namespace IsDiscreteValuationRing
 
 variable (R : Type*)
 
@@ -295,6 +292,21 @@ theorem ofHasUnitMulPowIrreducibleFactorization {R : Type u} [CommRing R] [IsDom
   apply of_ufd_of_unique_irreducible _ hR.unique_irreducible
   obtain ⟨p, hp, H⟩ := hR
   exact ⟨p, hp⟩
+
+/- If a ring is equivalent to a DVR, it is itself a DVR. -/
+theorem RingEquiv.isDiscreteValuationRing {A B : Type*} [CommRing A] [IsDomain A] [CommRing B]
+    [IsDomain B] [IsDiscreteValuationRing A] (e : A ≃+* B) : IsDiscreteValuationRing B where
+  principal := (isPrincipalIdealRing_iff _).1 <| IsPrincipalIdealRing.of_surjective _ e.surjective
+  __ : IsLocalRing B := e.isLocalRing
+  not_a_field' := by
+    obtain ⟨a, ha⟩ := Submodule.nonzero_mem_of_bot_lt (bot_lt_iff_ne_bot.mpr
+      <| IsDiscreteValuationRing.not_a_field A)
+    rw [Submodule.ne_bot_iff]
+    refine ⟨e a, ⟨?_, by simp only [ne_eq, EmbeddingLike.map_eq_zero_iff, ZeroMemClass.coe_eq_zero,
+      ha, not_false_eq_true]⟩⟩
+    rw [IsLocalRing.mem_maximalIdeal, map_mem_nonunits_iff e, ← IsLocalRing.mem_maximalIdeal]
+    exact a.2
+
 
 section
 

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -294,10 +294,12 @@ theorem ofHasUnitMulPowIrreducibleFactorization {R : Type u} [CommRing R] [IsDom
   exact ⟨p, hp⟩
 
 /- If a ring is equivalent to a DVR, it is itself a DVR. -/
-theorem RingEquiv.isDiscreteValuationRing {A B : Type*} [CommRing A] [IsDomain A] [CommRing B]
-    [IsDomain B] [IsDiscreteValuationRing A] (e : A ≃+* B) : IsDiscreteValuationRing B where
-  principal := (isPrincipalIdealRing_iff _).1 <| IsPrincipalIdealRing.of_surjective _ e.surjective
-  __ : IsLocalRing B := e.isLocalRing
+theorem RingEquivClass.isDiscreteValuationRing {A B E : Type*} [CommRing A] [IsDomain A]
+    [CommRing B] [IsDomain B] [IsDiscreteValuationRing A] [EquivLike E A B] [RingEquivClass E A B]
+    (e : E) : IsDiscreteValuationRing B where
+  principal := (isPrincipalIdealRing_iff _).1 <|
+    IsPrincipalIdealRing.of_surjective _ (e : A ≃+* B).surjective
+  __ : IsLocalRing B := (e : A ≃+* B).isLocalRing
   not_a_field' := by
     obtain ⟨a, ha⟩ := Submodule.nonzero_mem_of_bot_lt (bot_lt_iff_ne_bot.mpr
       <| IsDiscreteValuationRing.not_a_field A)
@@ -306,7 +308,6 @@ theorem RingEquiv.isDiscreteValuationRing {A B : Type*} [CommRing A] [IsDomain A
       ha, not_false_eq_true]⟩⟩
     rw [IsLocalRing.mem_maximalIdeal, map_mem_nonunits_iff e, ← IsLocalRing.mem_maximalIdeal]
     exact a.2
-
 
 section
 


### PR DESCRIPTION
We add the lemma saying that if a ring is isomorphic to a DVR it is itself a DVR.

Co-authored-by: María Ines de Frutos Fernández @mariainesdff 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
