### PR TITLE
[Merged by Bors] - chore(Algebra/Category/Ring): use unification hint to clean up proofs

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
@@ -61,7 +61,7 @@ lemma _root_.PresheafOfModules.Sheafify.app_eq_of_isLocallyInjective
     (hr₀ : α.app _ r₀ = α.app _ r₀')
     (hm₀ : φ.app _ m₀ = φ.app _ m₀') :
     φ.app _ (r₀ • m₀) = φ.app _ (r₀' • m₀') := by
-  apply hA _ (Presheaf.equalizerSieve (D := RingCat) r₀ r₀' ⊓
+  apply hA _ (Presheaf.equalizerSieve r₀ r₀' ⊓
       Presheaf.equalizerSieve (F := M₀.presheaf) m₀ m₀')
   · apply J.intersection_covering
     · exact Presheaf.equalizerSieve_mem J α _ _ hr₀

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -126,6 +126,10 @@ instance : ConcreteCategory.{u} SemiRingCat where
       map := fun f => f.hom }
   forget_faithful := ⟨fun h => by ext x; simpa using congrFun h x⟩
 
+/-- This unification hint helps with problems of the form `(forget ?C).obj R =?= carrier C`. -/
+unif_hint forget_obj_eq_coe (R : SemiRingCat) where ⊢
+  (forget SemiRingCat).obj R ≟ SemiRingCat.carrier R
+
 lemma forget_obj {R : SemiRingCat} : (forget SemiRingCat).obj R = R := rfl
 
 lemma forget_map {R S : SemiRingCat} (f : R ⟶ S) :
@@ -264,6 +268,14 @@ instance : ConcreteCategory.{u} RingCat where
     { obj := fun R => R
       map := fun f => f.hom }
   forget_faithful := ⟨fun h => by ext x; simpa using congrFun h x⟩
+
+/-- This unification hint helps with problems of the form `(forget ?C).obj R =?= carrier C`.
+
+An example where this is needed is in applying
+`PresheafOfModules.Sheafify.app_eq_of_isLocallyInjective`.
+-/
+unif_hint forget_obj_eq_coe (R : RingCat) where ⊢
+  (forget RingCat).obj R ≟ RingCat.carrier R
 
 lemma forget_obj {R : RingCat} : (forget RingCat).obj R = R := rfl
 
@@ -404,6 +416,10 @@ instance : ConcreteCategory.{u} CommSemiRingCat where
     { obj := fun R => R
       map := fun f => f.hom }
   forget_faithful := ⟨fun h => by ext x; simpa using congrFun h x⟩
+
+/-- This unification hint helps with problems of the form `(forget ?C).obj R =?= carrier C`. -/
+unif_hint forget_obj_eq_coe (R : CommSemiRingCat) where ⊢
+  (forget CommSemiRingCat).obj R ≟ CommSemiRingCat.carrier R
 
 lemma forget_obj {R : CommSemiRingCat} : (forget CommSemiRingCat).obj R = R := rfl
 
@@ -548,6 +564,13 @@ instance : ConcreteCategory.{u} CommRingCat where
   forget_faithful := ⟨fun h => by ext x; simpa using congrFun h x⟩
 
 lemma forget_obj {R : CommRingCat} : (forget CommRingCat).obj R = R := rfl
+
+/-- This unification hint helps with problems of the form `(forget ?C).obj R =?= carrier C`.
+
+An example where this is needed is in applying `TopCat.Presheaf.restrictOpen` to commutative rings.
+-/
+unif_hint forget_obj_eq_coe (R : CommRingCat) where ⊢
+  (forget CommRingCat).obj R ≟ CommRingCat.carrier R
 
 lemma forget_map {R S : CommRingCat} (f : R ⟶ S) :
     (forget CommRingCat).map f = f :=

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -126,9 +126,10 @@ instance : ConcreteCategory.{u} SemiRingCat where
       map := fun f => f.hom }
   forget_faithful := ⟨fun h => by ext x; simpa using congrFun h x⟩
 
-/-- This unification hint helps with problems of the form `(forget ?C).obj R =?= carrier C`. -/
-unif_hint forget_obj_eq_coe (R : SemiRingCat) where ⊢
-  (forget SemiRingCat).obj R ≟ SemiRingCat.carrier R
+/-- This unification hint helps with problems of the form `(forget ?C).obj R =?= carrier R'`. -/
+unif_hint forget_obj_eq_coe (R R' : SemiRingCat) where
+  R ≟ R' ⊢
+  (forget SemiRingCat).obj R ≟ SemiRingCat.carrier R'
 
 lemma forget_obj {R : SemiRingCat} : (forget SemiRingCat).obj R = R := rfl
 
@@ -269,13 +270,14 @@ instance : ConcreteCategory.{u} RingCat where
       map := fun f => f.hom }
   forget_faithful := ⟨fun h => by ext x; simpa using congrFun h x⟩
 
-/-- This unification hint helps with problems of the form `(forget ?C).obj R =?= carrier C`.
+/-- This unification hint helps with problems of the form `(forget ?C).obj R =?= carrier R'`.
 
 An example where this is needed is in applying
 `PresheafOfModules.Sheafify.app_eq_of_isLocallyInjective`.
 -/
-unif_hint forget_obj_eq_coe (R : RingCat) where ⊢
-  (forget RingCat).obj R ≟ RingCat.carrier R
+unif_hint forget_obj_eq_coe (R R' : RingCat) where
+  R ≟ R' ⊢
+  (forget RingCat).obj R ≟ RingCat.carrier R'
 
 lemma forget_obj {R : RingCat} : (forget RingCat).obj R = R := rfl
 
@@ -417,9 +419,10 @@ instance : ConcreteCategory.{u} CommSemiRingCat where
       map := fun f => f.hom }
   forget_faithful := ⟨fun h => by ext x; simpa using congrFun h x⟩
 
-/-- This unification hint helps with problems of the form `(forget ?C).obj R =?= carrier C`. -/
-unif_hint forget_obj_eq_coe (R : CommSemiRingCat) where ⊢
-  (forget CommSemiRingCat).obj R ≟ CommSemiRingCat.carrier R
+/-- This unification hint helps with problems of the form `(forget ?C).obj R =?= carrier R'`. -/
+unif_hint forget_obj_eq_coe (R R' : CommSemiRingCat) where
+  R ≟ R' ⊢
+  (forget CommSemiRingCat).obj R ≟ CommSemiRingCat.carrier R'
 
 lemma forget_obj {R : CommSemiRingCat} : (forget CommSemiRingCat).obj R = R := rfl
 
@@ -565,12 +568,13 @@ instance : ConcreteCategory.{u} CommRingCat where
 
 lemma forget_obj {R : CommRingCat} : (forget CommRingCat).obj R = R := rfl
 
-/-- This unification hint helps with problems of the form `(forget ?C).obj R =?= carrier C`.
+/-- This unification hint helps with problems of the form `(forget ?C).obj R =?= carrier R'`.
 
 An example where this is needed is in applying `TopCat.Presheaf.restrictOpen` to commutative rings.
 -/
-unif_hint forget_obj_eq_coe (R : CommRingCat) where ⊢
-  (forget CommRingCat).obj R ≟ CommRingCat.carrier R
+unif_hint forget_obj_eq_coe (R R' : CommRingCat) where
+  R ≟ R' ⊢
+  (forget CommRingCat).obj R ≟ CommRingCat.carrier R'
 
 lemma forget_map {R S : CommRingCat} (f : R ⟶ S) :
     (forget CommRingCat).map f = f :=

--- a/Mathlib/AlgebraicGeometry/FunctionField.lean
+++ b/Mathlib/AlgebraicGeometry/FunctionField.lean
@@ -46,7 +46,7 @@ noncomputable instance [IrreducibleSpace X] (U : X.Opens) [Nonempty U] :
 
 noncomputable instance [IsIntegral X] : Field X.functionField := by
   refine .ofIsUnitOrEqZero fun a ↦ ?_
-  obtain ⟨U, m, s, rfl⟩ := TopCat.Presheaf.germ_exist (C := CommRingCat) _ _ a
+  obtain ⟨U, m, s, rfl⟩ := TopCat.Presheaf.germ_exist _ _ a
   rw [or_iff_not_imp_right, ← (X.presheaf.germ _ _ m).hom.map_zero]
   intro ha
   replace ha := ne_of_apply_ne _ ha

--- a/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
@@ -75,7 +75,7 @@ instance (priority := 900) {X Y : Scheme} (f : X ⟶ Y) [IsClosedImmersion f] : 
 /-- Isomorphisms are closed immersions. -/
 instance {X Y : Scheme} (f : X ⟶ Y) [IsIso f] : IsClosedImmersion f where
   base_closed := Homeomorph.isClosedEmbedding <| TopCat.homeoOfIso (asIso f.base)
-  surj_on_stalks := fun _ ↦ (ConcreteCategory.bijective_of_isIso (C := CommRingCat) _).2
+  surj_on_stalks := fun _ ↦ (ConcreteCategory.bijective_of_isIso _).2
 
 instance : MorphismProperty.IsMultiplicative @IsClosedImmersion where
   id_mem _ := inferInstance

--- a/Mathlib/AlgebraicGeometry/Morphisms/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/OpenImmersion.lean
@@ -46,8 +46,7 @@ instance : IsLocalAtTarget (stalkwise (fun f ↦ Function.Bijective f)) := by
   rw [RingHom.toMorphismProperty_respectsIso_iff]
   convert (inferInstanceAs (MorphismProperty.isomorphisms CommRingCat).RespectsIso)
   ext
-  -- Regression in https://github.com/leanprover-community/mathlib4/pull/17583: have to specify C explicitly below.
-  exact (ConcreteCategory.isIso_iff_bijective (C := CommRingCat) _).symm
+  exact (ConcreteCategory.isIso_iff_bijective _).symm
 
 instance isOpenImmersion_isLocalAtTarget : IsLocalAtTarget @IsOpenImmersion :=
   isOpenImmersion_eq_inf ▸ inferInstance

--- a/Mathlib/AlgebraicGeometry/Morphisms/Preimmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Preimmersion.lean
@@ -59,7 +59,7 @@ instance : IsLocalAtTarget @IsPreimmersion :=
 
 instance (priority := 900) {X Y : Scheme} (f : X ⟶ Y) [IsOpenImmersion f] : IsPreimmersion f where
   base_embedding := f.isOpenEmbedding.isEmbedding
-  surj_on_stalks _ := (ConcreteCategory.bijective_of_isIso (C := CommRingCat) _).2
+  surj_on_stalks _ := (ConcreteCategory.bijective_of_isIso _).2
 
 instance : MorphismProperty.IsMultiplicative @IsPreimmersion where
   id_mem _ := inferInstance

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
@@ -245,7 +245,7 @@ theorem compact_open_induction_on {P : X.Opens → Prop} (S : X.Opens)
 
 theorem exists_pow_mul_eq_zero_of_res_basicOpen_eq_zero_of_isAffineOpen (X : Scheme)
     {U : X.Opens} (hU : IsAffineOpen U) (x f : Γ(X, U))
-    (H : x |_ᵣ (X.basicOpen f) = 0) :
+    (H : x |_ (X.basicOpen f) = 0) :
     ∃ n : ℕ, f ^ n * x = 0 := by
   rw [← map_zero (X.presheaf.map (homOfLE <| X.basicOpen_le f : X.basicOpen f ⟶ U).op).hom] at H
   #adaptation_note
@@ -263,7 +263,7 @@ theorem exists_pow_mul_eq_zero_of_res_basicOpen_eq_zero_of_isAffineOpen (X : Sch
 `f ^ n * x = 0` for some `n`. -/
 theorem exists_pow_mul_eq_zero_of_res_basicOpen_eq_zero_of_isCompact (X : Scheme.{u})
     {U : X.Opens} (hU : IsCompact U.1) (x f : Γ(X, U))
-    (H : x |_ᵣ (X.basicOpen f) = 0) :
+    (H : x |_ (X.basicOpen f) = 0) :
     ∃ n : ℕ, f ^ n * x = 0 := by
   obtain ⟨s, hs, e⟩ := (isCompactOpen_iff_eq_finset_affine_union U.1).mp ⟨hU, U.2⟩
   replace e : U = iSup fun i : s => (i : X.Opens) := by
@@ -311,12 +311,12 @@ lemma Scheme.isNilpotent_iff_basicOpen_eq_bot_of_isCompact {X : Scheme.{u}}
     {U : X.Opens} (hU : IsCompact (U : Set X)) (f : Γ(X, U)) :
     IsNilpotent f ↔ X.basicOpen f = ⊥ := by
   refine ⟨X.basicOpen_eq_bot_of_isNilpotent U f, fun hf ↦ ?_⟩
-  have h : (1 : Γ(X, U)) |_ᵣ (X.basicOpen f) = 0 := by
+  have h : (1 : Γ(X, U)) |_ (X.basicOpen f) = 0 := by
     have e : X.basicOpen f ≤ ⊥ := by rw [hf]
-    rw [← CommRingCat.presheaf_restrict_restrict X e bot_le]
+    rw [← TopCat.Presheaf.restrict_restrict e bot_le]
     have : Subsingleton Γ(X, ⊥) :=
       CommRingCat.subsingleton_of_isTerminal X.sheaf.isTerminalOfEmpty
-    rw [Subsingleton.eq_zero (1 |_ᵣ ⊥)]
+    rw [Subsingleton.eq_zero (1 |_ ⊥)]
     show X.presheaf.map _ 0 = 0
     rw [map_zero]
   obtain ⟨n, hn⟩ := exists_pow_mul_eq_zero_of_res_basicOpen_eq_zero_of_isCompact X hU 1 f h

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -185,11 +185,10 @@ theorem QuasiSeparated.of_comp {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z) [Qua
 
 theorem exists_eq_pow_mul_of_isAffineOpen (X : Scheme) (U : X.Opens) (hU : IsAffineOpen U)
     (f : Γ(X, U)) (x : Γ(X, X.basicOpen f)) :
-    ∃ (n : ℕ) (y : Γ(X, U)), y |_ᵣ X.basicOpen f = (f |_ᵣ X.basicOpen f) ^ n * x := by
+    ∃ (n : ℕ) (y : Γ(X, U)), y |_ X.basicOpen f = (f |_ X.basicOpen f) ^ n * x := by
   have := (hU.isLocalization_basicOpen f).2
   obtain ⟨⟨y, _, n, rfl⟩, d⟩ := this x
   use n, y
-  dsimp only [TopCat.Presheaf.restrictOpenCommRingCat_apply]
   simpa [mul_comm x] using d.symm
 
 theorem exists_eq_pow_mul_of_is_compact_of_quasi_separated_space_aux_aux {X : TopCat}
@@ -197,11 +196,11 @@ theorem exists_eq_pow_mul_of_is_compact_of_quasi_separated_space_aux_aux {X : To
     {y₁ : F.obj (op U₁)} {y₂ : F.obj (op U₂)} {f : F.obj (op <| U₁ ⊔ U₂)}
     {x : F.obj (op U₃)} (h₄₁ : U₄ ≤ U₁) (h₄₂ : U₄ ≤ U₂) (h₅₁ : U₅ ≤ U₁) (h₅₃ : U₅ ≤ U₃)
     (h₆₂ : U₆ ≤ U₂) (h₆₃ : U₆ ≤ U₃) (h₇₄ : U₇ ≤ U₄) (h₇₅ : U₇ ≤ U₅) (h₇₆ : U₇ ≤ U₆)
-    (e₁ : y₁ |_ᵣ U₅ = (f |_ᵣ U₁ |_ᵣ U₅) ^ n₁ * x |_ᵣ U₅)
-    (e₂ : y₂ |_ᵣ U₆ = (f |_ᵣ U₂ |_ᵣ U₆) ^ n₂ * x |_ᵣ U₆) :
-    (((f |_ᵣ U₁) ^ n₂ * y₁) |_ᵣ U₄) |_ᵣ U₇ = (((f |_ᵣ U₂) ^ n₁ * y₂) |_ᵣ U₄) |_ᵣ U₇ := by
-  apply_fun (fun x : F.obj (op U₅) ↦ x |_ᵣ U₇) at e₁
-  apply_fun (fun x : F.obj (op U₆) ↦ x |_ᵣ U₇) at e₂
+    (e₁ : y₁ |_ U₅ = (f |_ U₁ |_ U₅) ^ n₁ * x |_ U₅)
+    (e₂ : y₂ |_ U₆ = (f |_ U₂ |_ U₆) ^ n₂ * x |_ U₆) :
+    (((f |_ U₁) ^ n₂ * y₁) |_ U₄) |_ U₇ = (((f |_ U₂) ^ n₁ * y₂) |_ U₄) |_ U₇ := by
+  apply_fun (fun x : F.obj (op U₅) ↦ x |_ U₇) at e₁
+  apply_fun (fun x : F.obj (op U₆) ↦ x |_ U₇) at e₂
   dsimp only [TopCat.Presheaf.restrictOpenCommRingCat_apply] at e₁ e₂ ⊢
   simp only [map_mul, map_pow, ← op_comp, ← F.map_comp, homOfLE_comp, ← CommRingCat.comp_apply]
     at e₁ e₂ ⊢
@@ -211,17 +210,17 @@ theorem exists_eq_pow_mul_of_is_compact_of_quasi_separated_space_aux (X : Scheme
     (S : X.affineOpens) (U₁ U₂ : X.Opens) {n₁ n₂ : ℕ} {y₁ : Γ(X, U₁)}
     {y₂ : Γ(X, U₂)} {f : Γ(X, U₁ ⊔ U₂)}
     {x : Γ(X, X.basicOpen f)} (h₁ : S.1 ≤ U₁) (h₂ : S.1 ≤ U₂)
-    (e₁ : y₁ |_ᵣ X.basicOpen (f |_ᵣ U₁) =
-      ((f |_ᵣ U₁ |_ᵣ X.basicOpen _) ^ n₁) * x |_ᵣ X.basicOpen _)
-    (e₂ : y₂ |_ᵣ X.basicOpen (f |_ᵣ U₂) =
-      ((f |_ᵣ U₂ |_ᵣ X.basicOpen _) ^ n₂) * x |_ᵣ X.basicOpen _) :
+    (e₁ : y₁ |_ X.basicOpen (f |_ U₁) =
+      ((f |_ U₁ |_ X.basicOpen _) ^ n₁) * x |_ X.basicOpen _)
+    (e₂ : y₂ |_ X.basicOpen (f |_ U₂) =
+      ((f |_ U₂ |_ X.basicOpen _) ^ n₂) * x |_ X.basicOpen _) :
     ∃ n : ℕ, ∀ m, n ≤ m →
-      ((f |_ᵣ U₁) ^ (m + n₂) * y₁) |_ᵣ S.1 = ((f |_ᵣ U₂) ^ (m + n₁) * y₂) |_ᵣ S.1 := by
+      ((f |_ U₁) ^ (m + n₂) * y₁) |_ S.1 = ((f |_ U₂) ^ (m + n₁) * y₂) |_ S.1 := by
   obtain ⟨⟨_, n, rfl⟩, e⟩ :=
     (@IsLocalization.eq_iff_exists _ _ _ _ _ _
-      (S.2.isLocalization_basicOpen (f |_ᵣ S.1))
-        (((f |_ᵣ U₁) ^ n₂ * y₁) |_ᵣ S.1)
-        (((f |_ᵣ U₂) ^ n₁ * y₂) |_ᵣ S.1)).mp <| by
+      (S.2.isLocalization_basicOpen (f |_ S.1))
+        (((f |_ U₁) ^ n₂ * y₁) |_ S.1)
+        (((f |_ U₂) ^ n₁ * y₂) |_ S.1)).mp <| by
     apply exists_eq_pow_mul_of_is_compact_of_quasi_separated_space_aux_aux (e₁ := e₁) (e₂ := e₂)
     · show X.basicOpen _ ≤ _
       simp only [TopCat.Presheaf.restrictOpenCommRingCat_apply, Scheme.basicOpen_res]
@@ -239,7 +238,7 @@ theorem exists_eq_pow_mul_of_is_compact_of_quasi_separated_space_aux (X : Scheme
 
 theorem exists_eq_pow_mul_of_isCompact_of_isQuasiSeparated (X : Scheme.{u}) (U : X.Opens)
     (hU : IsCompact U.1) (hU' : IsQuasiSeparated U.1) (f : Γ(X, U)) (x : Γ(X, X.basicOpen f)) :
-    ∃ (n : ℕ) (y : Γ(X, U)), y |_ᵣ X.basicOpen f = (f |_ᵣ X.basicOpen f) ^ n * x := by
+    ∃ (n : ℕ) (y : Γ(X, U)), y |_ X.basicOpen f = (f |_ X.basicOpen f) ^ n * x := by
   dsimp only [TopCat.Presheaf.restrictOpenCommRingCat_apply]
   revert hU' f x
   refine compact_open_induction_on U hU ?_ ?_
@@ -347,19 +346,19 @@ theorem is_localization_basicOpen_of_qcqs {X : Scheme} {U : X.Opens} (hU : IsCom
 
 lemma exists_of_res_eq_of_qcqs {X : Scheme.{u}} {U : TopologicalSpace.Opens X}
     (hU : IsCompact U.carrier) (hU' : IsQuasiSeparated U.carrier)
-    {f g s : Γ(X, U)} (hfg : f |_ᵣ X.basicOpen s = g |_ᵣ X.basicOpen s) :
+    {f g s : Γ(X, U)} (hfg : f |_ X.basicOpen s = g |_ X.basicOpen s) :
     ∃ n, s ^ n * f = s ^ n * g := by
   obtain ⟨n, hc⟩ := (is_localization_basicOpen_of_qcqs hU hU' s).exists_of_eq s hfg
   use n
 
 lemma exists_of_res_eq_of_qcqs_of_top {X : Scheme.{u}} [CompactSpace X] [QuasiSeparatedSpace X]
-    {f g s : Γ(X, ⊤)} (hfg : f |_ᵣ X.basicOpen s = g |_ᵣ X.basicOpen s) :
+    {f g s : Γ(X, ⊤)} (hfg : f |_ X.basicOpen s = g |_ X.basicOpen s) :
     ∃ n, s ^ n * f = s ^ n * g :=
   exists_of_res_eq_of_qcqs (U := ⊤) CompactSpace.isCompact_univ isQuasiSeparated_univ hfg
 
 lemma exists_of_res_zero_of_qcqs {X : Scheme.{u}} {U : TopologicalSpace.Opens X}
     (hU : IsCompact U.carrier) (hU' : IsQuasiSeparated U.carrier)
-    {f s : Γ(X, U)} (hf : f |_ᵣ X.basicOpen s = 0) :
+    {f s : Γ(X, U)} (hf : f |_ X.basicOpen s = 0) :
     ∃ n, s ^ n * f = 0 := by
   suffices h : ∃ n, s ^ n * f = s ^ n * 0 by
     simpa using h
@@ -367,7 +366,7 @@ lemma exists_of_res_zero_of_qcqs {X : Scheme.{u}} {U : TopologicalSpace.Opens X}
   simpa
 
 lemma exists_of_res_zero_of_qcqs_of_top {X : Scheme} [CompactSpace X] [QuasiSeparatedSpace X]
-    {f s : Γ(X, ⊤)} (hf : f |_ᵣ X.basicOpen s = 0) :
+    {f s : Γ(X, ⊤)} (hf : f |_ X.basicOpen s = 0) :
     ∃ n, s ^ n * f = 0 :=
   exists_of_res_zero_of_qcqs (U := ⊤) CompactSpace.isCompact_univ isQuasiSeparated_univ hf
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -395,7 +395,7 @@ lemma isLocal_ringHomProperty_of_isLocalAtSource_of_isLocalAtTarget
       (CommRingCat.ofHom f) r)).mp (IsLocalAtTarget.restrict H (basicOpen r))
   · intros R S _ _ f s hs H
     apply IsLocalAtSource.of_openCover (Scheme.affineOpenCoverOfSpanRangeEqTop
-      (R := CommRingCat.of S) (ι := s) (fun i : s ↦ (i : S)) (by simpa)).openCover
+      (fun i : s ↦ (i : S)) (by simpa)).openCover
     intro i
     simp only [CommRingCat.coe_of, Set.setOf_mem_eq, id_eq, eq_mpr_eq_cast,
       Scheme.AffineOpenCover.openCover_obj, Scheme.affineOpenCoverOfSpanRangeEqTop_obj_carrier,

--- a/Mathlib/AlgebraicGeometry/Morphisms/SurjectiveOnStalks.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/SurjectiveOnStalks.lean
@@ -39,7 +39,7 @@ theorem Scheme.Hom.stalkMap_surjective (f : X.Hom Y) [SurjectiveOnStalks f] (x) 
 namespace SurjectiveOnStalks
 
 instance (priority := 900) [IsOpenImmersion f] : SurjectiveOnStalks f :=
-  ⟨fun _ ↦ (ConcreteCategory.bijective_of_isIso (C := CommRingCat) _).2⟩
+  ⟨fun _ ↦ (ConcreteCategory.bijective_of_isIso _).2⟩
 
 instance : MorphismProperty.IsMultiplicative @SurjectiveOnStalks where
   id_mem _ := inferInstance

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -548,8 +548,7 @@ theorem basicOpen_le : X.basicOpen f ≤ U :=
 
 @[sheaf_restrict]
 lemma basicOpen_restrict (i : V ⟶ U) (f : Γ(X, U)) :
-    -- Help `restrict` to infer which forgetful functor we're taking
-    X.basicOpen (TopCat.Presheaf.restrict (C := CommRingCat) f i) ≤ X.basicOpen f :=
+    X.basicOpen (TopCat.Presheaf.restrict f i) ≤ X.basicOpen f :=
   (Scheme.basicOpen_res _ _ _).trans_le inf_le_right
 
 @[simp]

--- a/Mathlib/AlgebraicGeometry/Sites/SmallAffineZariski.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/SmallAffineZariski.lean
@@ -155,7 +155,7 @@ lemma generate_presieveOfSections
     rw [X.basicOpen_mul, hf₃, inf_eq_right]
     exact X.basicOpen_le _
   · rintro ⟨f₁, hf₁s, f₂, rfl⟩
-    refine ⟨U.basicOpen f₁, ⟨f₂ |_ᵣ _, ?_⟩, ⟨f₁, rfl⟩, ⟨f₁, hf₁s, rfl⟩, rfl⟩
+    refine ⟨U.basicOpen f₁, ⟨f₂ |_ _, ?_⟩, ⟨f₁, rfl⟩, ⟨f₁, hf₁s, rfl⟩, rfl⟩
     exact (X.basicOpen_res _ _).trans (X.basicOpen_mul _ _).symm
 
 lemma generate_presieveOfSections_mem_grothendieckTopology

--- a/Mathlib/AlgebraicGeometry/SpreadingOut.lean
+++ b/Mathlib/AlgebraicGeometry/SpreadingOut.lean
@@ -211,7 +211,7 @@ lemma spread_out_unique_of_isGermInjective {x : X} [X.IsGermInjectiveAt x]
     congr 2
     apply this <;> simp
   rintro U V rfl rfl
-  have := ConcreteCategory.mono_of_injective (C := CommRingCat) _ HU
+  have := ConcreteCategory.mono_of_injective _ HU
   rw [← cancel_mono (X.presheaf.germ U x hxU)]
   simp only [Scheme.Hom.appLE, Category.assoc, X.presheaf.germ_res', ← Scheme.stalkMap_germ, H]
   simp only [TopCat.Presheaf.germ_stalkSpecializes_assoc, Scheme.stalkMap_germ]

--- a/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
+++ b/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
@@ -315,7 +315,6 @@ def smoothSheafCommRing.forgetStalk (x : TopCat.of M) :
       (colimit.ι ((OpenNhds.inclusion x).op ⋙ (smoothSheafCommRing IM I M R).presheaf) U) := by
   rw [Iso.comp_inv_eq, ← smoothSheafCommRing.ι_forgetStalk_hom, CommRingCat.forget_map]
   simp_rw [Functor.comp_obj, Functor.op_obj]
-  rfl
 
 /-- Given a smooth commutative ring `R` and a manifold `M`, and an open neighbourhood `U` of a point
 `x : M`, the evaluation-at-`x` map to `R` from smooth functions from  `U` to `R`. -/

--- a/Mathlib/Geometry/RingedSpace/LocallyRingedSpace/HasColimits.lean
+++ b/Mathlib/Geometry/RingedSpace/LocallyRingedSpace/HasColimits.lean
@@ -226,8 +226,7 @@ theorem coequalizer_π_stalk_isLocalHom (x : Y) :
     IsLocalHom ((coequalizer.π f.toShHom g.toShHom : _).stalkMap x).hom := by
   constructor
   rintro a ha
-  rcases TopCat.Presheaf.germ_exist (C := CommRingCat) _ _ a with ⟨U, hU, s, rfl⟩
-  -- need `erw` to see through `ConcreteCategory.instFunLike`
+  rcases TopCat.Presheaf.germ_exist _ _ a with ⟨U, hU, s, rfl⟩
   rw [← CommRingCat.forget_map_apply, PresheafedSpace.stalkMap_germ_apply
     (coequalizer.π (C := SheafedSpace _) f.toShHom g.toShHom) U _ hU] at ha
   rw [CommRingCat.forget_map_apply]

--- a/Mathlib/Topology/Sheaves/CommRingCat.lean
+++ b/Mathlib/Topology/Sheaves/CommRingCat.lean
@@ -47,37 +47,44 @@ example (X : TopCat.{u₁}) (F : Presheaf CommRingCat.{u₁} X)
     F.IsSheaf :=
 (isSheaf_iff_isSheaf_comp (forget CommRingCat) F).mpr h
 
-/--
-Specialize `restrictOpen` to `CommRingCat` because inferring `C := CommRingCat` isn't reliable.
-Instead of unfolding the definition, rewrite with `restrictOpenCommRingCat_apply` to ensure the
-correct coercion to functions is taken.
+/-- Deprecated: usage of this definition should be replaceable with `TopCat.Presheaf.restrictOpen`.
+
+Before, we had to specialze `restrictOpen` to `CommRingCat` because inferring `C := CommRingCat`
+was not reliable. Unification hints appear to solve that issue.
+
+The following still holds for `restrictOpen`: instead of unfolding the definition, rewrite with
+`restrictOpenCommRingCat_apply` to ensure the correct coercion to functions is taken.
 
 (The correct fix in the longer term is to redesign concrete categories so we don't use `forget`
 everywhere, but the correct `FunLike` instance for the morphisms of those categories.)
 -/
+@[deprecated TopCat.Presheaf.restrictOpen (since := "2024-12-19")]
 abbrev restrictOpenCommRingCat {X : TopCat}
     {F : Presheaf CommRingCat X} {V : Opens ↑X} (f : CommRingCat.carrier (F.obj (op V)))
     (U : Opens ↑X) (e : U ≤ V := by restrict_tac) :
     CommRingCat.carrier (F.obj (op U)) :=
-  TopCat.Presheaf.restrictOpen (C := CommRingCat) f U e
-
-/-- Notation for `TopCat.Presheaf.restrictOpenCommRingCat`. -/
-scoped[AlgebraicGeometry] infixl:80 " |_ᵣ " => TopCat.Presheaf.restrictOpenCommRingCat
+  TopCat.Presheaf.restrictOpen f U e
 
 open AlgebraicGeometry in
+/-- Unfold `restrictOpen` in the category of commutative rings (with the correct carrier type).
+
+Although unification hints help with applying `TopCat.Presheaf.restrictOpenCommRingCat`,
+so it can be safely de-specialized, this lemma needs to be kept to ensure rewrites go right.
+-/
 lemma restrictOpenCommRingCat_apply {X : TopCat}
     {F : Presheaf CommRingCat X} {V : Opens ↑X} (f : CommRingCat.carrier (F.obj (op V)))
     (U : Opens ↑X) (e : U ≤ V := by restrict_tac) :
-    f |_ᵣ U = F.map (homOfLE e).op f :=
+    f |_ U = F.map (homOfLE e).op f :=
   rfl
 
 open AlgebraicGeometry in
+@[deprecated TopCat.Presheaf.restrict_restrict (since := "2024-12-19")]
 lemma _root_.CommRingCat.presheaf_restrict_restrict (X : TopCat)
     {F : TopCat.Presheaf CommRingCat X}
     {U V W : Opens ↑X} (e₁ : U ≤ V := by restrict_tac) (e₂ : V ≤ W := by restrict_tac)
     (f : CommRingCat.carrier (F.obj (op W))) :
-    f |_ᵣ V |_ᵣ U = f |_ᵣ U :=
-  TopCat.Presheaf.restrict_restrict (C := CommRingCat) e₁ e₂ f
+    f |_ V |_ U = f |_ U :=
+  TopCat.Presheaf.restrict_restrict e₁ e₂ f
 
 section SubmonoidPresheaf
 


### PR DESCRIPTION
(Everything below is written for `CommRingCat`, but also holds for the other `RingCat`s.)

As a consequence of #19757, it became harder to unify `(forget ?C).obj R =?= CommRingCat.carrier R` since `?C =?= CommRingCat` would no longer be inferred. This PR adds a unification hint that helps with all but 2 cases where we need to hint `C := CommRingCat`.

The current unification hint uses `CommRingCat` as the argument to `forget`, even though we would like it to be an arbitrary category `C`, which can then trigger downstream unification of `C =?= CommRingCat`. However, it seems that dependent unification hints do not work: I cannot get Lean to typecheck `C =?= CommRingCat; (instC : Category C) =?= CommRingCat.instCategory |- ...`.

I tried doing this for `ModuleCat` too and it did not seem to fix any required hints. Perhaps because `ModuleCat R` depends on the `R`?


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
