### PR TITLE
[Merged by Bors] - refactor(GroupTheory/SpecificGroups/Cyclic): Add `isCyclic_iff_exists_zpowers_eq_top` and golf

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -118,7 +118,7 @@ alias isAddCyclic_iff_exists_ofOrder_eq_natCard := isAddCyclic_iff_exists_addOrd
 
 @[deprecated (since := "2024-12-20")]
 alias IsCyclic.iff_exists_ofOrder_eq_natCard_of_Fintype :=
-  isAddCyclic_iff_exists_addOrderOf_eq_natCard
+  isCyclic_iff_exists_orderOf_eq_natCard
 
 @[deprecated (since := "2024-12-20")]
 alias IsAddCyclic.iff_exists_ofOrder_eq_natCard_of_Fintype :=

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -47,8 +47,13 @@ section Cyclic
 open Subgroup
 
 @[to_additive]
-theorem IsCyclic.exists_generator [Group α] [IsCyclic α] : ∃ g : α, ∀ x, x ∈ Subgroup.zpowers g :=
+theorem IsCyclic.exists_generator [Group α] [IsCyclic α] : ∃ g : α, ∀ x, x ∈ zpowers g :=
   exists_zpow_surjective α
+
+@[to_additive]
+theorem isCyclic_iff_exists_zpowers_eq_top [Group α] : IsCyclic α ↔ ∃ g : α, zpowers g = ⊤ := by
+  simp only [eq_top_iff', mem_zpowers_iff]
+  exact ⟨fun ⟨h⟩ ↦ h, fun h ↦ ⟨h⟩⟩
 
 @[to_additive]
 instance (priority := 100) isCyclic_of_subsingleton [Group α] [Subsingleton α] : IsCyclic α :=
@@ -101,13 +106,29 @@ theorem MonoidHom.map_cyclic [h : IsCyclic G] (σ : G →* G) :
 MonoidAddHom.map_add_cyclic := AddMonoidHom.map_addCyclic
 
 @[to_additive]
+lemma isCyclic_iff_exists_orderOf_eq_natCard [Finite α] :
+    IsCyclic α ↔ ∃ g : α, orderOf g = Nat.card α := by
+  simp_rw [isCyclic_iff_exists_zpowers_eq_top, ← card_eq_iff_eq_top, Nat.card_zpowers]
+
+@[deprecated (since := "2024-12-20")]
+alias isCyclic_iff_exists_ofOrder_eq_natCard := isCyclic_iff_exists_orderOf_eq_natCard
+
+@[deprecated (since := "2024-12-20")]
+alias isAddCyclic_iff_exists_ofOrder_eq_natCard := isAddCyclic_iff_exists_addOrderOf_eq_natCard
+
+@[deprecated (since := "2024-12-20")]
+alias IsCyclic.iff_exists_ofOrder_eq_natCard_of_Fintype :=
+  isAddCyclic_iff_exists_addOrderOf_eq_natCard
+
+@[deprecated (since := "2024-12-20")]
+alias IsAddCyclic.iff_exists_ofOrder_eq_natCard_of_Fintype :=
+  isAddCyclic_iff_exists_addOrderOf_eq_natCard
+
+@[to_additive]
 theorem isCyclic_of_orderOf_eq_card [Finite α] (x : α) (hx : orderOf x = Nat.card α) :
-    IsCyclic α := by
-  cases nonempty_fintype α
-  use x
-  rw [← Set.range_eq_univ, ← coe_zpowers]
-  rw [← Nat.card_congr (Equiv.Set.univ α), Nat.card_eq_fintype_card, ← Fintype.card_zpowers] at hx
-  convert Set.eq_of_subset_of_card_le (Set.subset_univ _) (ge_of_eq hx)
+    IsCyclic α :=
+  isCyclic_iff_exists_orderOf_eq_natCard.mpr ⟨x, hx⟩
+
 @[deprecated (since := "2024-02-21")]
 alias isAddCyclic_of_orderOf_eq_card := isAddCyclic_of_addOrderOf_eq_card
 
@@ -318,26 +339,6 @@ lemma IsCyclic.exists_ofOrder_eq_natCard [h : IsCyclic α] : ∃ g : α, orderOf
   use g
   rw [← card_zpowers g, (eq_top_iff' (zpowers g)).mpr hg]
   exact Nat.card_congr (Equiv.Set.univ α)
-
-@[to_additive]
-lemma isCyclic_iff_exists_ofOrder_eq_natCard [Finite α] :
-    IsCyclic α ↔ ∃ g : α, orderOf g = Nat.card α := by
-  refine ⟨fun h ↦ h.exists_ofOrder_eq_natCard, fun h ↦ ?_⟩
-  obtain ⟨g, hg⟩ := h
-  cases nonempty_fintype α
-  refine isCyclic_of_orderOf_eq_card g ?_
-  simp [hg]
-
-@[to_additive]
-protected alias IsCyclic.iff_exists_ofOrder_eq_natCard_of_Fintype :=
-  isCyclic_iff_exists_ofOrder_eq_natCard
-
--- `alias` doesn't add the deprecation suggestion to the `to_additive` version
--- see https://github.com/leanprover-community/mathlib4/issues/19424
-attribute [deprecated isCyclic_iff_exists_ofOrder_eq_natCard (since := "2024-04-20")]
-IsCyclic.iff_exists_ofOrder_eq_natCard_of_Fintype
-attribute [deprecated isAddCyclic_iff_exists_ofOrder_eq_natCard (since := "2024-04-20")]
-IsAddCyclic.iff_exists_ofOrder_eq_natCard_of_Fintype
 
 section
 
@@ -612,9 +613,9 @@ open Monoid
 @[to_additive]
 theorem IsCyclic.exponent_eq_card [Group α] [IsCyclic α] :
     exponent α = Nat.card α := by
-  obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := α)
+  obtain ⟨g, hg⟩ := IsCyclic.exists_ofOrder_eq_natCard (α := α)
   apply Nat.dvd_antisymm Group.exponent_dvd_nat_card
-  rw [← orderOf_eq_card_of_forall_mem_zpowers hg]
+  rw [← hg]
   exact order_dvd_exponent _
 
 @[to_additive]


### PR DESCRIPTION
This PR adds `isCyclic_iff_exists_zpowers_eq_top` and does a little golfing.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
