### PR TITLE
[Merged by Bors] - feat: analytic part of Lindemann-Weierstrass

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3940,6 +3940,7 @@ import Mathlib.NumberTheory.SmoothNumbers
 import Mathlib.NumberTheory.SumFourSquares
 import Mathlib.NumberTheory.SumPrimeReciprocals
 import Mathlib.NumberTheory.SumTwoSquares
+import Mathlib.NumberTheory.Transcendental.Lindemann.Init.AnalyticalPart
 import Mathlib.NumberTheory.Transcendental.Liouville.Basic
 import Mathlib.NumberTheory.Transcendental.Liouville.LiouvilleNumber
 import Mathlib.NumberTheory.Transcendental.Liouville.LiouvilleWith

--- a/Mathlib/Algebra/Polynomial/SumIteratedDerivative.lean
+++ b/Mathlib/Algebra/Polynomial/SumIteratedDerivative.lean
@@ -25,7 +25,7 @@ as a linear map. This is used in particular in the proof of the Lindemann-Weiers
   polynomials
 * `Polynomial.sumIDeriv_map`: `Polynomial.sumIDeriv` commutes with `Polynomial.map`
 * `Polynomial.sumIDeriv_derivative`: `Polynomial.sumIDeriv` commutes with `Polynomial.derivative`
-* `Polynomial.sumIDeriv_eq_self_add`: `sumIDeriv p = p + sumIDeriv (derivative p)`
+* `Polynomial.sumIDeriv_eq_self_add`: `sumIDeriv p = p + derivative (sumIDeriv p)`
 * `Polynomial.exists_iterate_derivative_eq_factorial_smul`: the `k`'th iterated derivative of a
   polynomial has a common factor `k!`
 * `Polynomial.aeval_iterate_derivative_of_lt`, `Polynomial.aeval_iterate_derivative_self`,
@@ -50,7 +50,7 @@ variable [Semiring R] [Semiring S]
 Sum of iterated derivatives of a polynomial, as a linear map
 
 This definition does not allow different weights for the derivatives. It is likely that it could be
-extended to allow them, but this was not needed for the initial use case (the integration by part
+extended to allow them, but this was not needed for the initial use case (the integration by parts
 of the integral $I_i$ in the
 [Lindemann-Weierstrass](https://en.wikipedia.org/wiki/Lindemann%E2%80%93Weierstrass_theorem)
 theorem).
@@ -95,8 +95,8 @@ theorem sumIDeriv_derivative (p : R[X]) : sumIDeriv (derivative p) = derivative 
     derivative_sum]
   simp_rw [← Function.iterate_succ_apply, Function.iterate_succ_apply']
 
-theorem sumIDeriv_eq_self_add (p : R[X]) : sumIDeriv p = p + sumIDeriv (derivative p) := by
-  rw [sumIDeriv_derivative, sumIDeriv_apply, derivative_sum, sum_range_succ', sum_range_succ,
+theorem sumIDeriv_eq_self_add (p : R[X]) : sumIDeriv p = p + derivative (sumIDeriv p) := by
+  rw [sumIDeriv_apply, derivative_sum, sum_range_succ', sum_range_succ,
     add_comm, ← add_zero (Finset.sum _ _)]
   simp_rw [← Function.iterate_succ_apply' derivative, Nat.succ_eq_add_one,
     Function.iterate_zero_apply, iterate_derivative_eq_zero (Nat.lt_succ_self _)]
@@ -158,32 +158,36 @@ theorem aeval_iterate_derivative_of_ge (p : R[X]) (q : ℕ) {k : ℕ} (hk : q �
   simp_rw [hp', nsmul_eq_mul, map_mul, map_natCast, ← mul_assoc, ← Nat.cast_mul,
     Nat.add_descFactorial_eq_ascFactorial, Nat.factorial_mul_ascFactorial]
 
+theorem aeval_sumIDeriv_eq_eval (p : R[X]) (r : A) :
+    aeval r (sumIDeriv p) = eval r (sumIDeriv (map (algebraMap R A) p)) := by
+  rw [aeval_def, eval, sumIDeriv_map, eval₂_map, RingHom.id_comp]
+
 theorem aeval_sumIDeriv (p : R[X]) (q : ℕ) :
     ∃ gp : R[X], gp.natDegree ≤ p.natDegree - q ∧
-      ∀ (r : A) {p' : A[X]}, p.map (algebraMap R A) = (X - C r) ^ q * p' →
+      ∀ (r : A), (X - C r) ^ q ∣ p.map (algebraMap R A) →
         aeval r (sumIDeriv p) = q ! • aeval r gp := by
   have h (k) :
       ∃ gp : R[X], gp.natDegree ≤ p.natDegree - q ∧
-        ∀ (r : A) {p' : A[X]}, p.map (algebraMap R A) = (X - C r) ^ q * p' →
+        ∀ (r : A), (X - C r) ^ q ∣ p.map (algebraMap R A) →
           aeval r (derivative^[k] p) = q ! • aeval r gp := by
     cases lt_or_ge k q with
     | inl hk =>
       use 0
       rw [natDegree_zero]
       use Nat.zero_le _
-      intro r p' hp
+      intro r ⟨p', hp⟩
       rw [map_zero, smul_zero, aeval_iterate_derivative_of_lt p q r hp hk]
     | inr hk =>
       obtain ⟨gp, gp_le, h⟩ := aeval_iterate_derivative_of_ge A p q hk
-      exact ⟨gp, gp_le.trans (tsub_le_tsub_left hk _), fun r p' _ => h r⟩
+      exact ⟨gp, gp_le.trans (tsub_le_tsub_left hk _), fun r _ => h r⟩
   choose c h using h
   choose c_le hc using h
   refine ⟨(range (p.natDegree + 1)).sum c, ?_, ?_⟩
   · refine (natDegree_sum_le _ _).trans ?_
     rw [fold_max_le]
     exact ⟨Nat.zero_le _, fun i _ => c_le i⟩
-  intro r p' hp
-  rw [sumIDeriv_apply, map_sum]; simp_rw [hc _ r hp, map_sum, smul_sum]
+  intro r ⟨p', hp⟩
+  rw [sumIDeriv_apply, map_sum]; simp_rw [hc _ r ⟨_, hp⟩, map_sum, smul_sum]
 
 theorem aeval_sumIDeriv_of_pos [Nontrivial A] [NoZeroDivisors A] (p : R[X]) {q : ℕ} (hq : 0 < q)
     (inj_amap : Function.Injective (algebraMap R A)) :
@@ -245,5 +249,13 @@ theorem aeval_sumIDeriv_of_pos [Nontrivial A] [NoZeroDivisors A] (p : R[X]) {q :
     exact hx.1.2.not_le hx.2.1
 
 end CommSemiring
+
+theorem eval_sumIDeriv_of_pos
+    [CommRing R] [Nontrivial R] [NoZeroDivisors R] (p : R[X]) {q : ℕ} (hq : 0 < q) :
+    ∃ gp : R[X], gp.natDegree ≤ p.natDegree - q ∧
+      ∀ (r : R) {p' : R[X]},
+        p = ((X : R[X]) - C r) ^ (q - 1) * p' →
+        eval r (sumIDeriv p) = (q - 1)! • p'.eval r + q ! • eval r gp := by
+  simpa using aeval_sumIDeriv_of_pos R p hq Function.injective_id
 
 end Polynomial

--- a/Mathlib/NumberTheory/Transcendental/Lindemann/Init/AnalyticalPart.lean
+++ b/Mathlib/NumberTheory/Transcendental/Lindemann/Init/AnalyticalPart.lean
@@ -11,7 +11,7 @@ import Mathlib.RingTheory.Int.Basic
 import Mathlib.Topology.Algebra.Polynomial
 
 /-!
-# The Lindemann-Weierstrass theorem
+# Analytic part of the Lindemann-Weierstrass theorem
 -/
 
 namespace LindemannWeierstrass
@@ -44,26 +44,31 @@ theorem integral_exp_mul_eval (p : ℂ[X]) (s : ℂ) :
       (ContinuousOn.intervalIntegrable (by fun_prop))]
   simp
 
-private def P (p : ℂ[X]) (s : ℂ) :=
-  exp s * p.sumIDeriv.eval 0 - p.sumIDeriv.eval s
+/--
+`P` is a slightly generalized version of `Iᵢ` in
+[the wikipedia proof](https://en.wikipedia.org/wiki/Lindemann%E2%80%93Weierstrass_theorem):
+`Iᵢ(s) = P(fᵢ, s)`.
+-/
+private def P (f : ℂ[X]) (s : ℂ) :=
+  exp s * f.sumIDeriv.eval 0 - f.sumIDeriv.eval s
 
-private theorem P_eq_integral_exp_mul_eval (p : ℂ[X]) (s : ℂ) :
-    P p s = exp s * (s * ∫ x in (0)..1, exp (-(x • s)) * p.eval (x • s)) := by
+private theorem P_eq_integral_exp_mul_eval (f : ℂ[X]) (s : ℂ) :
+    P f s = exp s * (s * ∫ x in (0)..1, exp (-(x • s)) * f.eval (x • s)) := by
   rw [integral_exp_mul_eval, mul_add, mul_neg, exp_neg, mul_inv_cancel_left₀ (exp_ne_zero s),
     neg_add_eq_sub, P]
 
 /--
-Given a sequence of complex polynomials `p(q)`, a complex constant `s`, and a real constant `c` such
-that `|p(q)(xs)| ≤ c ^ q` for all `q ∈ ℕ` and `x ∈ Ioc 0 1`, then there is also a nonnegative
-constant `c'` such that for all nonzero `q ∈ ℕ`, `|P(p(q), s)| ≤ c' ^ q`.
+Given a sequence of complex polynomials `fₚ`, a complex constant `s`, and a real constant `c` such
+that `|fₚ(xs)| ≤ c ^ p` for all `p ∈ ℕ` and `x ∈ Ioc 0 1`, then there is also a nonnegative
+constant `c'` such that for all nonzero `p ∈ ℕ`, `|P(fₚ, s)| ≤ c' ^ p`.
 -/
-private theorem P_le_aux (p : ℕ → ℂ[X]) (s : ℂ) (c : ℝ)
-    (hc : ∀ q : ℕ, ∀ x ∈ Set.Ioc (0 : ℝ) 1, Complex.abs ((p q).eval (x • s)) ≤ c ^ q) :
-    ∃ c' ≥ 0, ∀ q : ℕ,
-      Complex.abs (P (p q) s) ≤
-        Real.exp s.re * (Real.exp (Complex.abs s) * c' ^ q * (Complex.abs s)) := by
-  refine ⟨|c|, abs_nonneg _, fun q => ?_⟩
-  rw [P_eq_integral_exp_mul_eval (p q) s, mul_comm s, map_mul, map_mul, abs_exp]
+private theorem P_le_aux (f : ℕ → ℂ[X]) (s : ℂ) (c : ℝ)
+    (hc : ∀ p : ℕ, ∀ x ∈ Set.Ioc (0 : ℝ) 1, Complex.abs ((f p).eval (x • s)) ≤ c ^ p) :
+    ∃ c' ≥ 0, ∀ p : ℕ,
+      Complex.abs (P (f p) s) ≤
+        Real.exp s.re * (Real.exp (Complex.abs s) * c' ^ p * (Complex.abs s)) := by
+  refine ⟨|c|, abs_nonneg _, fun p => ?_⟩
+  rw [P_eq_integral_exp_mul_eval (f p) s, mul_comm s, map_mul, map_mul, abs_exp]
   gcongr
   rw [intervalIntegral.integral_of_le zero_le_one, ← norm_eq_abs, ← mul_one (_ * _)]
   convert MeasureTheory.norm_setIntegral_le_of_norm_le_const' _ _ _
@@ -78,26 +83,26 @@ private theorem P_le_aux (p : ℕ → ℂ[X]) (s : ℂ) (c : ℝ)
     rw [← norm_eq_abs, ← norm_eq_abs, norm_neg, norm_smul, Real.norm_of_nonneg hx.1.le]
     exact mul_le_of_le_one_left (norm_nonneg _) hx.2
   · rw [← _root_.abs_pow, norm_eq_abs]
-    exact (hc q x hx).trans (le_abs_self _)
+    exact (hc p x hx).trans (le_abs_self _)
 
 /--
-Given a sequence of complex polynomials `p(q)`, a complex constant `s`, and a real constant `c` such
-that `|p(q)(xs)| ≤ c ^ q` for all `q ∈ ℕ` and `x ∈ Ioc 0 1`, then there is also a nonnegative
-constant `c'` such that for all nonzero `q ∈ ℕ`, `|P(p(q), s)| ≤ c' ^ q`.
+Given a sequence of complex polynomials `fₚ`, a complex constant `s`, and a real constant `c` such
+that `|fₚ(xs)| ≤ c ^ p` for all `p ∈ ℕ` and `x ∈ Ioc 0 1`, then there is also a nonnegative
+constant `c'` such that for all nonzero `p ∈ ℕ`, `|P(fₚ, s)| ≤ c' ^ p`.
 -/
-private theorem P_le (p : ℕ → ℂ[X]) (s : ℂ) (c : ℝ)
-    (hc : ∀ q : ℕ, ∀ x ∈ Set.Ioc (0 : ℝ) 1, Complex.abs ((p q).eval (x • s)) ≤ c ^ q) :
-    ∃ c' ≥ 0, ∀ q ≠ 0, Complex.abs (P (p q) s) ≤ c' ^ q := by
-  obtain ⟨c', hc', h'⟩ := P_le_aux p s c hc; clear c hc
+private theorem P_le (f : ℕ → ℂ[X]) (s : ℂ) (c : ℝ)
+    (hc : ∀ p : ℕ, ∀ x ∈ Set.Ioc (0 : ℝ) 1, Complex.abs ((f p).eval (x • s)) ≤ c ^ p) :
+    ∃ c' ≥ 0, ∀ p ≠ 0, Complex.abs (P (f p) s) ≤ c' ^ p := by
+  obtain ⟨c', hc', h'⟩ := P_le_aux f s c hc; clear c hc
   let c₁ := max (Real.exp s.re) 1
   let c₂ := max (Real.exp (Complex.abs s)) 1
   let c₃ := max (Complex.abs s) 1
   use c₁ * (c₂ * c' * c₃), by positivity
-  intro q hq
-  refine (h' q).trans ?_
+  intro p hp
+  refine (h' p).trans ?_
   simp_rw [mul_pow]
-  have le_max_one_pow {x : ℝ} : x ≤ max x 1 ^ q :=
-    (max_cases x 1).elim (fun h ↦ h.1.symm ▸ le_self_pow₀ h.2 hq)
+  have le_max_one_pow {x : ℝ} : x ≤ max x 1 ^ p :=
+    (max_cases x 1).elim (fun h ↦ h.1.symm ▸ le_self_pow₀ h.2 hp)
       fun h ↦ by rw [h.1, one_pow]; exact h.2.le
   gcongr <;> exact le_max_one_pow
 
@@ -107,21 +112,21 @@ Given a polynomial with integer coefficients `p` and a complex constant `s`, the
 
 Note: Jacobson writes `h(x)` for `x ^ (q - 1) * p(x) ^ q` and `bⱼ` for its coefficients.
 -/
-private theorem exp_polynomial_approx_aux (p : ℤ[X]) (s : ℂ) :
+private theorem exp_polynomial_approx_aux (f : ℤ[X]) (s : ℂ) :
     ∃ c ≥ 0,
-      ∀ q ≠ 0, Complex.abs (P (map (algebraMap ℤ ℂ) (X ^ (q - 1) * p ^ q)) s) ≤ c ^ q := by
+      ∀ p ≠ 0, Complex.abs (P (map (algebraMap ℤ ℂ) (X ^ (p - 1) * f ^ p)) s) ≤ c ^ p := by
   have : Bornology.IsBounded
-      ((fun x : ℝ ↦ max (x * abs s) 1 * Complex.abs (aeval (x * s) p)) '' Set.Ioc 0 1) := by
+      ((fun x : ℝ ↦ max (x * abs s) 1 * Complex.abs (aeval (x * s) f)) '' Set.Ioc 0 1) := by
     have h :
-      (fun x : ℝ ↦ max (x * abs s) 1 * Complex.abs (aeval (x * s) p)) '' Set.Ioc 0 1 ⊆
-        (fun x : ℝ ↦ max (x * abs s) 1 * Complex.abs (aeval (x * s) p)) '' Set.Icc 0 1 :=
+      (fun x : ℝ ↦ max (x * abs s) 1 * Complex.abs (aeval (x * s) f)) '' Set.Ioc 0 1 ⊆
+        (fun x : ℝ ↦ max (x * abs s) 1 * Complex.abs (aeval (x * s) f)) '' Set.Icc 0 1 :=
       Set.image_subset _ Set.Ioc_subset_Icc_self
     refine (IsCompact.image isCompact_Icc ?_).isBounded.subset h
     fun_prop
   obtain ⟨c, h⟩ := this.exists_norm_le
   simp_rw [Real.norm_eq_abs] at h
-  refine P_le _ s c (fun q x hx => ?_)
-  specialize h (max (x * abs s) 1 * Complex.abs (aeval (x * s) p)) (Set.mem_image_of_mem _ hx)
+  refine P_le _ s c (fun p x hx => ?_)
+  specialize h (max (x * abs s) 1 * Complex.abs (aeval (x * s) f)) (Set.mem_image_of_mem _ hx)
   refine le_trans ?_ (pow_le_pow_left₀ (abs_nonneg _) h _)
   simp_rw [Polynomial.map_mul, Polynomial.map_pow, map_X, eval_mul, eval_pow, eval_X, map_mul,
     Complex.abs_pow, real_smul, map_mul, abs_ofReal, ← eval₂_eq_eval_map, ← aeval_def, abs_mul,
@@ -137,68 +142,67 @@ private theorem exp_polynomial_approx_aux (p : ℤ[X]) (s : ℂ) :
 /--
 See equation (68), page 285 of [Jacobson, *Basic Algebra I, 4.12*][jacobson1974].
 
-Given a polynomial `p` with integer coefficients, we can find a constant `c : ℝ` and for each prime
-`q > |p₀|`, `n(q) : ℤ` and `g(q) : ℤ[X]` such that
+Given a polynomial `f` with integer coefficients, we can find a constant `c : ℝ` and for each prime
+`p > |f₀|`, `nₚ : ℤ` and `gₚ : ℤ[X]` such that
 
-* `q` does not divide `n(q)`
-* `deg(g(q)) < q * deg(p)`
-* all complex roots `r` of `p` satisfy `|n(q) * e ^ r - q * g(q)(r)| ≤ c ^ q / (q - 1)!`
+* `p` does not divide `nₚ`
+* `deg(gₚ) < p * deg(f)`
+* all complex roots `r` of `f` satisfy `|nₚ * e ^ r - p * gₚ(r)| ≤ c ^ p / (p - 1)!`
 
-In the proof of Lindemann-Weierstrass, we will take `p` to be a polynomial whose complex roots
+In the proof of Lindemann-Weierstrass, we will take `f` to be a polynomial whose complex roots
 are the algebraic numbers whose exponentials we want to prove to be linearly independent.
 
-Note: Jacobson writes `f` for our `p`, `p` for our `q`, `N_p` for our `n(q)`, `g_p` for our `g(q)`
-and `M` for our `c` (modulo a constant factor).
+Note: Jacobson writes `Nₚ` for our `nₚ` and `M` for our `c` (modulo a constant factor).
 -/
-theorem exp_polynomial_approx (p : ℤ[X]) (hp : p.eval 0 ≠ 0) :
+theorem exp_polynomial_approx (f : ℤ[X]) (hf : f.eval 0 ≠ 0) :
     ∃ c,
-      ∀ q > (eval 0 p).natAbs, q.Prime →
-        ∃ n : ℤ, ¬ ↑q ∣ n ∧ ∃ gq : ℤ[X], gq.natDegree ≤ q * p.natDegree - 1 ∧
-          ∀ {r : ℂ}, r ∈ p.aroots ℂ →
-            Complex.abs (n • exp r - q • aeval r gq : ℂ) ≤ c ^ q / (q - 1)! := by
+      ∀ p > (eval 0 f).natAbs, p.Prime →
+        ∃ n : ℤ, ¬ ↑p ∣ n ∧ ∃ gp : ℤ[X], gp.natDegree ≤ p * f.natDegree - 1 ∧
+          ∀ {r : ℂ}, r ∈ f.aroots ℂ →
+            Complex.abs (n • exp r - p • aeval r gp : ℂ) ≤ c ^ p / (p - 1)! := by
   simp_rw [nsmul_eq_mul, zsmul_eq_mul]
-  choose c' c'0 Pp'_le using exp_polynomial_approx_aux p
+  choose c' c'0 Pp'_le using exp_polynomial_approx_aux f
   use
-    if h : ((p.aroots ℂ).map c').toFinset.Nonempty then ((p.aroots ℂ).map c').toFinset.max' h else 0
-  intro q q_gt prime_q
-  obtain ⟨gq', -, h'⟩ := eval_sumIDeriv_of_pos (X ^ (q - 1) * p ^ q) prime_q.pos
+    if h : ((f.aroots ℂ).map c').toFinset.Nonempty then ((f.aroots ℂ).map c').toFinset.max' h else 0
+  intro p p_gt prime_p
+  obtain ⟨gp', -, h'⟩ := eval_sumIDeriv_of_pos (X ^ (p - 1) * f ^ p) prime_p.pos
   specialize h' 0 (by rw [C_0, sub_zero])
-  use p.eval 0 ^ q + q * gq'.eval 0
+  use f.eval 0 ^ p + p * gp'.eval 0
   constructor
   · rw [dvd_add_left (dvd_mul_right _ _)]
-    contrapose! q_gt with h
-    exact Nat.le_of_dvd (Int.natAbs_pos.mpr hp) (Int.natCast_dvd.mp (Int.Prime.dvd_pow' prime_q h))
-  obtain ⟨gq, gq'_le, h⟩ := aeval_sumIDeriv ℂ (X ^ (q - 1) * p ^ q) q
-  refine ⟨gq, ?_, ?_⟩
-  · refine gq'_le.trans ((tsub_le_tsub_right natDegree_mul_le q).trans ?_)
-    rw [natDegree_X_pow, natDegree_pow, tsub_add_eq_add_tsub prime_q.one_le, tsub_right_comm,
+    contrapose! p_gt with h
+    exact Nat.le_of_dvd (Int.natAbs_pos.mpr hf) (Int.natCast_dvd.mp (Int.Prime.dvd_pow' prime_p h))
+  obtain ⟨gp, gp'_le, h⟩ := aeval_sumIDeriv ℂ (X ^ (p - 1) * f ^ p) p
+  refine ⟨gp, ?_, ?_⟩
+  · refine gp'_le.trans ((tsub_le_tsub_right natDegree_mul_le p).trans ?_)
+    rw [natDegree_X_pow, natDegree_pow, tsub_add_eq_add_tsub prime_p.one_le, tsub_right_comm,
       add_tsub_cancel_left]
   intro r hr
   specialize h r _
   · rw [mem_roots'] at hr
-    rw [Polynomial.map_mul, p.map_pow]
+    rw [Polynomial.map_mul, f.map_pow]
     exact dvd_mul_of_dvd_right (pow_dvd_pow_of_dvd (dvd_iff_isRoot.mpr hr.2) _) _
   rw [nsmul_eq_mul] at h
   have :
-      (↑(eval 0 p ^ q + q * eval 0 gq') * cexp r - q * (aeval r) gq) * (q - 1)! =
-      ((eval 0 p ^ q * cexp r) * (q - 1)! +
-        ↑(q * (q - 1)!) * (eval 0 gq' * cexp r - (aeval r) gq)) := by
+      (↑(eval 0 f ^ p + p * eval 0 gp') * cexp r - p * (aeval r) gp) * (p - 1)! =
+      ((eval 0 f ^ p * cexp r) * (p - 1)! +
+        ↑(p * (p - 1)!) * (eval 0 gp' * cexp r - (aeval r) gp)) := by
     push_cast; ring
   rw [le_div_iff₀ (Nat.cast_pos.mpr (Nat.factorial_pos _) : (0 : ℝ) < _), ← abs_natCast, ← map_mul,
-    this, Nat.mul_factorial_pred prime_q.pos, mul_sub, ← h]
+    this, Nat.mul_factorial_pred prime_p.pos, mul_sub, ← h]
   have :
-      ↑(eval 0 p) ^ q * cexp r * ↑(q - 1)! +
-        (↑q ! * (↑(eval 0 gq') * cexp r) - (aeval r) (sumIDeriv (X ^ (q - 1) * p ^ q))) =
-      ((q - 1)! • ↑(eval 0 (p ^ q)) + q ! • ↑(eval 0 gq') : ℤ) * cexp r -
-        (aeval r) (sumIDeriv (X ^ (q - 1) * p ^ q)) := by
+      ↑(eval 0 f) ^ p * cexp r * ↑(p - 1)! +
+        (↑p ! * (↑(eval 0 gp') * cexp r) - (aeval r) (sumIDeriv (X ^ (p - 1) * f ^ p))) =
+      ((p - 1)! • ↑(eval 0 (f ^ p)) + p ! • ↑(eval 0 gp') : ℤ) * cexp r -
+        (aeval r) (sumIDeriv (X ^ (p - 1) * f ^ p)) := by
     simp; ring
   rw [this, ← h', mul_comm, ← eq_intCast (algebraMap ℤ ℂ),
     ← aeval_algebraMap_apply_eq_algebraMap_eval, map_zero,
     aeval_sumIDeriv_eq_eval, aeval_sumIDeriv_eq_eval, ← P]
-  refine (Pp'_le r q prime_q.ne_zero).trans (pow_le_pow_left₀ (c'0 r) ?_ _)
-  have aux : c' r ∈ (Multiset.map c' (p.aroots ℂ)).toFinset := by
+  refine (Pp'_le r p prime_p.ne_zero).trans (pow_le_pow_left₀ (c'0 r) ?_ _)
+  have aux : c' r ∈ (Multiset.map c' (f.aroots ℂ)).toFinset := by
     simpa only [Multiset.mem_toFinset] using Multiset.mem_map_of_mem _ hr
-  have h : ((p.aroots ℂ).map c').toFinset.Nonempty := ⟨c' r, aux⟩
+  have h : ((f.aroots ℂ).map c').toFinset.Nonempty := ⟨c' r, aux⟩
   simpa only [h, ↓reduceDIte] using Finset.le_max' _ _ aux
 
 end

--- a/Mathlib/NumberTheory/Transcendental/Lindemann/Init/AnalyticalPart.lean
+++ b/Mathlib/NumberTheory/Transcendental/Lindemann/Init/AnalyticalPart.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2022 Yuyang Zhao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yuyang Zhao
+-/
+import Mathlib.Algebra.Polynomial.SumIteratedDerivative
+import Mathlib.Analysis.Calculus.Deriv.Polynomial
+import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+import Mathlib.MeasureTheory.Integral.FundThmCalculus
+import Mathlib.RingTheory.Int.Basic
+import Mathlib.Topology.Algebra.Polynomial
+
+/-!
+# The Lindemann-Weierstrass theorem
+-/
+
+namespace LindemannWeierstrass
+
+noncomputable section
+
+open scoped Nat
+
+open Complex Polynomial
+
+attribute [local fun_prop] Polynomial.differentiable Complex.continuous_abs
+
+theorem hasDerivAt_cexp_mul_sumIDeriv (p : ℂ[X]) (s : ℂ) (x : ℝ) :
+    HasDerivAt (fun x : ℝ ↦ -(cexp (-(x • s)) * p.sumIDeriv.eval (x • s)))
+      (s * (cexp (-(x • s)) * p.eval (x • s))) x := by
+  have h₀ := (hasDerivAt_id' x).smul_const s
+  have h₁ := h₀.neg.cexp
+  have h₂ := ((sumIDeriv p).hasDerivAt (x • s)).comp x h₀
+  convert (h₁.mul h₂).neg using 1
+  nth_rw 1 [sumIDeriv_eq_self_add p]
+  simp only [one_smul, eval_add, Function.comp_apply]
+  ring
+
+theorem integral_exp_mul_eval (p : ℂ[X]) (s : ℂ) :
+    s * ∫ x in (0)..1, exp (-(x • s)) * p.eval (x • s) =
+      -(exp (-s) * p.sumIDeriv.eval s) + p.sumIDeriv.eval 0 := by
+  rw [← intervalIntegral.integral_const_mul,
+    intervalIntegral.integral_eq_sub_of_hasDerivAt
+      (fun x hx => hasDerivAt_cexp_mul_sumIDeriv p s x)
+      (ContinuousOn.intervalIntegrable (by fun_prop))]
+  simp
+
+private def P (p : ℂ[X]) (s : ℂ) :=
+  exp s * p.sumIDeriv.eval 0 - p.sumIDeriv.eval s
+
+private theorem P_eq_integral_exp_mul_eval (p : ℂ[X]) (s : ℂ) :
+    P p s = exp s * (s * ∫ x in (0)..1, exp (-(x • s)) * p.eval (x • s)) := by
+  rw [integral_exp_mul_eval, mul_add, mul_neg, exp_neg, mul_inv_cancel_left₀ (exp_ne_zero s),
+    neg_add_eq_sub, P]
+
+/--
+Given a sequence of complex polynomials `p(q)`, a complex constant `s`, and a real constant `c` such
+that `|p(q)(xs)| ≤ c ^ q` for all `q ∈ ℕ` and `x ∈ Ioc 0 1`, then there is also a nonnegative
+constant `c'` such that for all nonzero `q ∈ ℕ`, `|P(p(q), s)| ≤ c' ^ q`.
+-/
+private theorem P_le_aux (p : ℕ → ℂ[X]) (s : ℂ) (c : ℝ)
+    (hc : ∀ q : ℕ, ∀ x ∈ Set.Ioc (0 : ℝ) 1, Complex.abs ((p q).eval (x • s)) ≤ c ^ q) :
+    ∃ c' ≥ 0, ∀ q : ℕ,
+      Complex.abs (P (p q) s) ≤
+        Real.exp s.re * (Real.exp (Complex.abs s) * c' ^ q * (Complex.abs s)) := by
+  refine ⟨|c|, abs_nonneg _, fun q => ?_⟩
+  rw [P_eq_integral_exp_mul_eval (p q) s, mul_comm s, map_mul, map_mul, abs_exp]
+  gcongr
+  rw [intervalIntegral.integral_of_le zero_le_one, ← norm_eq_abs, ← mul_one (_ * _)]
+  convert MeasureTheory.norm_setIntegral_le_of_norm_le_const' _ _ _
+  · rw [Real.volume_Ioc, sub_zero, ENNReal.toReal_ofReal zero_le_one]
+  · rw [Real.volume_Ioc, sub_zero]; exact ENNReal.ofReal_lt_top
+  · exact measurableSet_Ioc
+  intro x hx
+  rw [norm_mul, norm_eq_abs, abs_exp]
+  gcongr
+  · simp only [Set.mem_Ioc] at hx
+    apply (re_le_abs _).trans
+    rw [← norm_eq_abs, ← norm_eq_abs, norm_neg, norm_smul, Real.norm_of_nonneg hx.1.le]
+    exact mul_le_of_le_one_left (norm_nonneg _) hx.2
+  · rw [← _root_.abs_pow, norm_eq_abs]
+    exact (hc q x hx).trans (le_abs_self _)
+
+/--
+Given a sequence of complex polynomials `p(q)`, a complex constant `s`, and a real constant `c` such
+that `|p(q)(xs)| ≤ c ^ q` for all `q ∈ ℕ` and `x ∈ Ioc 0 1`, then there is also a nonnegative
+constant `c'` such that for all nonzero `q ∈ ℕ`, `|P(p(q), s)| ≤ c' ^ q`.
+-/
+private theorem P_le (p : ℕ → ℂ[X]) (s : ℂ) (c : ℝ)
+    (hc : ∀ q : ℕ, ∀ x ∈ Set.Ioc (0 : ℝ) 1, Complex.abs ((p q).eval (x • s)) ≤ c ^ q) :
+    ∃ c' ≥ 0, ∀ q ≠ 0, Complex.abs (P (p q) s) ≤ c' ^ q := by
+  obtain ⟨c', hc', h'⟩ := P_le_aux p s c hc; clear c hc
+  let c₁ := max (Real.exp s.re) 1
+  let c₂ := max (Real.exp (Complex.abs s)) 1
+  let c₃ := max (Complex.abs s) 1
+  use c₁ * (c₂ * c' * c₃), by positivity
+  intro q hq
+  refine (h' q).trans ?_
+  simp_rw [mul_pow]
+  have le_max_one_pow {x : ℝ} : x ≤ max x 1 ^ q :=
+    (max_cases x 1).elim (fun h ↦ h.1.symm ▸ le_self_pow₀ h.2 hq)
+      fun h ↦ by rw [h.1, one_pow]; exact h.2.le
+  gcongr <;> exact le_max_one_pow
+
+/--
+Given a polynomial with integer coefficients `p` and a complex constant `s`, there is a nonnegative
+`c` such that for all nonzero `q ∈ ℕ`, `|P(X ^ (q - 1) * p ^ q, s)| ≤ c ^ q`.
+
+Note: Jacobson writes `h(x)` for `x ^ (q - 1) * p(x) ^ q` and `bⱼ` for its coefficients.
+-/
+private theorem exp_polynomial_approx_aux (p : ℤ[X]) (s : ℂ) :
+    ∃ c ≥ 0,
+      ∀ q ≠ 0, Complex.abs (P (map (algebraMap ℤ ℂ) (X ^ (q - 1) * p ^ q)) s) ≤ c ^ q := by
+  have : Bornology.IsBounded
+      ((fun x : ℝ ↦ max (x * abs s) 1 * Complex.abs (aeval (x * s) p)) '' Set.Ioc 0 1) := by
+    have h :
+      (fun x : ℝ ↦ max (x * abs s) 1 * Complex.abs (aeval (x * s) p)) '' Set.Ioc 0 1 ⊆
+        (fun x : ℝ ↦ max (x * abs s) 1 * Complex.abs (aeval (x * s) p)) '' Set.Icc 0 1 :=
+      Set.image_subset _ Set.Ioc_subset_Icc_self
+    refine (IsCompact.image isCompact_Icc ?_).isBounded.subset h
+    fun_prop
+  obtain ⟨c, h⟩ := this.exists_norm_le
+  simp_rw [Real.norm_eq_abs] at h
+  refine P_le _ s c (fun q x hx => ?_)
+  specialize h (max (x * abs s) 1 * Complex.abs (aeval (x * s) p)) (Set.mem_image_of_mem _ hx)
+  refine le_trans ?_ (pow_le_pow_left₀ (abs_nonneg _) h _)
+  simp_rw [Polynomial.map_mul, Polynomial.map_pow, map_X, eval_mul, eval_pow, eval_X, map_mul,
+    Complex.abs_pow, real_smul, map_mul, abs_ofReal, ← eval₂_eq_eval_map, ← aeval_def, abs_mul,
+    Complex.abs_abs, mul_pow, abs_of_pos hx.1]
+  refine mul_le_mul_of_nonneg_right ?_ (pow_nonneg (Complex.abs.nonneg _) _)
+  rw [← mul_pow, _root_.abs_of_nonneg (by positivity), max_def]
+  split_ifs with hx1
+  · rw [one_pow]
+    exact pow_le_one₀ (mul_nonneg hx.1.le (Complex.abs.nonneg _)) hx1
+  · push_neg at hx1
+    exact pow_le_pow_right₀ hx1.le (Nat.sub_le _ _)
+
+/--
+See equation (68), page 285 of [Jacobson, *Basic Algebra I, 4.12*][jacobson1974].
+
+Given a polynomial `p` with integer coefficients, we can find a constant `c : ℝ` and for each prime
+`q > |p₀|`, `n(q) : ℤ` and `g(q) : ℤ[X]` such that
+
+* `q` does not divide `n(q)`
+* `deg(g(q)) < q * deg(p)`
+* all complex roots `r` of `p` satisfy `|n(q) * e ^ r - q * g(q)(r)| ≤ c ^ q / (q - 1)!`
+
+In the proof of Lindemann-Weierstrass, we will take `p` to be a polynomial whose complex roots
+are the algebraic numbers whose exponentials we want to prove to be linearly independent.
+
+Note: Jacobson writes `f` for our `p`, `p` for our `q`, `N_p` for our `n(q)`, `g_p` for our `g(q)`
+and `M` for our `c` (modulo a constant factor).
+-/
+theorem exp_polynomial_approx (p : ℤ[X]) (hp : p.eval 0 ≠ 0) :
+    ∃ c,
+      ∀ q > (eval 0 p).natAbs, q.Prime →
+        ∃ n : ℤ, ¬ ↑q ∣ n ∧ ∃ gq : ℤ[X], gq.natDegree ≤ q * p.natDegree - 1 ∧
+          ∀ {r : ℂ}, r ∈ p.aroots ℂ →
+            Complex.abs (n • exp r - q • aeval r gq : ℂ) ≤ c ^ q / (q - 1)! := by
+  simp_rw [nsmul_eq_mul, zsmul_eq_mul]
+  choose c' c'0 Pp'_le using exp_polynomial_approx_aux p
+  use
+    if h : ((p.aroots ℂ).map c').toFinset.Nonempty then ((p.aroots ℂ).map c').toFinset.max' h else 0
+  intro q q_gt prime_q
+  obtain ⟨gq', -, h'⟩ := eval_sumIDeriv_of_pos (X ^ (q - 1) * p ^ q) prime_q.pos
+  specialize h' 0 (by rw [C_0, sub_zero])
+  use p.eval 0 ^ q + q * gq'.eval 0
+  constructor
+  · rw [dvd_add_left (dvd_mul_right _ _)]
+    contrapose! q_gt with h
+    exact Nat.le_of_dvd (Int.natAbs_pos.mpr hp) (Int.natCast_dvd.mp (Int.Prime.dvd_pow' prime_q h))
+  obtain ⟨gq, gq'_le, h⟩ := aeval_sumIDeriv ℂ (X ^ (q - 1) * p ^ q) q
+  refine ⟨gq, ?_, ?_⟩
+  · refine gq'_le.trans ((tsub_le_tsub_right natDegree_mul_le q).trans ?_)
+    rw [natDegree_X_pow, natDegree_pow, tsub_add_eq_add_tsub prime_q.one_le, tsub_right_comm,
+      add_tsub_cancel_left]
+  intro r hr
+  specialize h r _
+  · rw [mem_roots'] at hr
+    rw [Polynomial.map_mul, p.map_pow]
+    exact dvd_mul_of_dvd_right (pow_dvd_pow_of_dvd (dvd_iff_isRoot.mpr hr.2) _) _
+  rw [nsmul_eq_mul] at h
+  have :
+      (↑(eval 0 p ^ q + q * eval 0 gq') * cexp r - q * (aeval r) gq) * (q - 1)! =
+      ((eval 0 p ^ q * cexp r) * (q - 1)! +
+        ↑(q * (q - 1)!) * (eval 0 gq' * cexp r - (aeval r) gq)) := by
+    push_cast; ring
+  rw [le_div_iff₀ (Nat.cast_pos.mpr (Nat.factorial_pos _) : (0 : ℝ) < _), ← abs_natCast, ← map_mul,
+    this, Nat.mul_factorial_pred prime_q.pos, mul_sub, ← h]
+  have :
+      ↑(eval 0 p) ^ q * cexp r * ↑(q - 1)! +
+        (↑q ! * (↑(eval 0 gq') * cexp r) - (aeval r) (sumIDeriv (X ^ (q - 1) * p ^ q))) =
+      ((q - 1)! • ↑(eval 0 (p ^ q)) + q ! • ↑(eval 0 gq') : ℤ) * cexp r -
+        (aeval r) (sumIDeriv (X ^ (q - 1) * p ^ q)) := by
+    simp; ring
+  rw [this, ← h', mul_comm, ← eq_intCast (algebraMap ℤ ℂ),
+    ← aeval_algebraMap_apply_eq_algebraMap_eval, map_zero,
+    aeval_sumIDeriv_eq_eval, aeval_sumIDeriv_eq_eval, ← P]
+  refine (Pp'_le r q prime_q.ne_zero).trans (pow_le_pow_left₀ (c'0 r) ?_ _)
+  have aux : c' r ∈ (Multiset.map c' (p.aroots ℂ)).toFinset := by
+    simpa only [Multiset.mem_toFinset] using Multiset.mem_map_of_mem _ hr
+  have h : ((p.aroots ℂ).map c').toFinset.Nonempty := ⟨c' r, aux⟩
+  simpa only [h, ↓reduceDIte] using Finset.le_max' _ _ aux
+
+end
+
+end LindemannWeierstrass


### PR DESCRIPTION
Co-authored-by: FR <zhao.yu-yang@foxmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

From #6718.

I have to admit I still only understand part of it, so (concrete) suggestions definitely welcome.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
