### PR TITLE
[Merged by Bors] - feat(GroupTheory/Complement): Quotient of complementary subgroup 

### DIFF
--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -613,6 +613,13 @@ theorem IsComplement'.disjoint (h : IsComplement' H K) : Disjoint H K :=
 theorem IsComplement'.index_eq_card (h : IsComplement' H K) : K.index = Nat.card H :=
   (card_left_transversal h).symm
 
+/-- If `H` and `K` are complementary with `K` normal, then `G ⧸ K` is isomorphic to `H`. -/
+noncomputable def _root_.IsComplement'.QuotientMulEquiv [K.Normal] (h : H.IsComplement' K) :
+    G ⧸ K ≃* H :=
+  MulEquiv.symm
+  { (Subgroup.MemLeftTransversals.toEquiv h).symm with
+    map_mul' := fun _ _ ↦ rfl }
+
 theorem IsComplement.card_mul (h : IsComplement S T) :
     Nat.card S * Nat.card T = Nat.card G :=
   (Nat.card_prod _ _).symm.trans (Nat.card_eq_of_bijective _ h)

--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -615,10 +615,10 @@ theorem IsComplement'.index_eq_card (h : IsComplement' H K) : K.index = Nat.card
 
 /-- If `H` and `K` are complementary with `K` normal, then `G ⧸ K` is isomorphic to `H`. -/
 @[simps!]
-noncomputable def _root_.IsComplement'.QuotientMulEquiv [K.Normal] (h : H.IsComplement' K) :
+noncomputable def IsComplement'.QuotientMulEquiv [K.Normal] (h : H.IsComplement' K) :
     G ⧸ K ≃* H :=
   MulEquiv.symm
-  { (Subgroup.MemLeftTransversals.toEquiv h).symm with
+  { (MemLeftTransversals.toEquiv h).symm with
     map_mul' := fun _ _ ↦ rfl }
 
 theorem IsComplement.card_mul (h : IsComplement S T) :

--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -614,6 +614,7 @@ theorem IsComplement'.index_eq_card (h : IsComplement' H K) : K.index = Nat.card
   (card_left_transversal h).symm
 
 /-- If `H` and `K` are complementary with `K` normal, then `G ⧸ K` is isomorphic to `H`. -/
+@[simps!]
 noncomputable def _root_.IsComplement'.QuotientMulEquiv [K.Normal] (h : H.IsComplement' K) :
     G ⧸ K ≃* H :=
   MulEquiv.symm


### PR DESCRIPTION
If `H` and `K` are complementary with `K` normal, then `G/K` is isomorphic to `H`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
