### PR TITLE
[Merged by Bors] - chore(Coxeter/Inversion): use `getElem?`

### DIFF
--- a/Mathlib/GroupTheory/Coxeter/Inversion.lean
+++ b/Mathlib/GroupTheory/Coxeter/Inversion.lean
@@ -245,7 +245,7 @@ theorem leftInvSeq_reverse (ω : List B) :
 theorem getD_rightInvSeq (ω : List B) (j : ℕ) :
     (ris ω).getD j 1 =
       (π (ω.drop (j + 1)))⁻¹
-        * (Option.map (cs.simple) (ω.get? j)).getD 1
+        * (Option.map (cs.simple) ω[j]?).getD 1
         * π (ω.drop (j + 1)) := by
   induction' ω with i ω ih generalizing j
   · simp
@@ -258,14 +258,14 @@ theorem getD_rightInvSeq (ω : List B) (j : ℕ) :
 lemma getElem_rightInvSeq (ω : List B) (j : ℕ) (h : j < ω.length) :
     (ris ω)[j]'(by simp[h]) =
     (π (ω.drop (j + 1)))⁻¹
-      * (Option.map (cs.simple) (ω.get? j)).getD 1
+      * (Option.map (cs.simple) ω[j]?).getD 1
       * π (ω.drop (j + 1)) := by
   rw [← List.getD_eq_getElem (ris ω) 1, getD_rightInvSeq]
 
 theorem getD_leftInvSeq (ω : List B) (j : ℕ) :
     (lis ω).getD j 1 =
       π (ω.take j)
-        * (Option.map (cs.simple) (ω.get? j)).getD 1
+        * (Option.map (cs.simple) ω[j]?).getD 1
         * (π (ω.take j))⁻¹ := by
   induction' ω with i ω ih generalizing j
   · simp
@@ -288,18 +288,18 @@ theorem getD_rightInvSeq_mul_self (ω : List B) (j : ℕ) :
     ((ris ω).getD j 1) * ((ris ω).getD j 1) = 1 := by
   simp_rw [getD_rightInvSeq, mul_assoc]
   rcases em (j < ω.length) with hj | nhj
-  · rw [get?_eq_get hj]
+  · rw [getElem?_eq_getElem hj]
     simp [← mul_assoc]
-  · rw [get?_eq_none_iff.mpr (by omega)]
+  · rw [getElem?_eq_none_iff.mpr (by omega)]
     simp
 
 theorem getD_leftInvSeq_mul_self (ω : List B) (j : ℕ) :
     ((lis ω).getD j 1) * ((lis ω).getD j 1) = 1 := by
   simp_rw [getD_leftInvSeq, mul_assoc]
   rcases em (j < ω.length) with hj | nhj
-  · rw [get?_eq_get hj]
+  · rw [getElem?_eq_getElem hj]
     simp [← mul_assoc]
-  · rw [get?_eq_none_iff.mpr (by omega)]
+  · rw [getElem?_eq_none_iff.mpr (by omega)]
     simp
 
 theorem rightInvSeq_drop (ω : List B) (j : ℕ) :
@@ -417,9 +417,8 @@ theorem IsReduced.nodup_rightInvSeq {ω : List B} (rω : cs.IsReduced ω) : List
       drop_drop, nil_append, min_eq_left_of_lt (j_lt_j'.trans j'_lt_length), Nat.add_comm,
       ← add_assoc, Nat.sub_add_cancel (by omega), mul_left_inj, mul_right_inj]
     congr 2
-    show get? (take j ω ++ drop (j + 1) ω) (j' - 1) = get? ω j'
-    rw [get?_eq_getElem?, get?_eq_getElem?,
-      getElem?_append_right (by simp [Nat.le_sub_one_of_lt j_lt_j']), getElem?_drop]
+    show (take j ω ++ drop (j + 1) ω)[j' - 1]? = ω[j']?
+    rw [getElem?_append_right (by simp [Nat.le_sub_one_of_lt j_lt_j']), getElem?_drop]
     congr
     show j + 1 + (j' - 1 - List.length (take j ω)) = j'
     rw [length_take]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)