### PR TITLE
[Merged by Bors] - feat(RingTheory/Invariant): Galois extensions satisfy `Algebra.IsInvariant`

### DIFF
--- a/Mathlib/RingTheory/Invariant.lean
+++ b/Mathlib/RingTheory/Invariant.lean
@@ -3,8 +3,9 @@ Copyright (c) 2024 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
-import Mathlib.FieldTheory.Fixed
+import Mathlib.FieldTheory.Galois.Basic
 import Mathlib.RingTheory.Ideal.Over
+import Mathlib.RingTheory.IntegralClosure.IntegralRestrict
 
 /-!
 # Invariant Extensions of Rings and Frobenius Elements
@@ -45,6 +46,40 @@ by `G` is `smul_algebraMap` (assuming `SMulCommClass A B G`). -/
   isInvariant : ∀ b : B, (∀ g : G, g • b = b) → ∃ a : A, algebraMap A B a = b
 
 end Algebra
+
+section Galois
+
+variable (A K L B : Type*) [CommRing A] [CommRing B] [Field K] [Field L]
+  [Algebra A K] [Algebra B L] [IsFractionRing A K] [IsFractionRing B L]
+  [Algebra A B] [Algebra K L] [Algebra A L] [IsScalarTower A K L] [IsScalarTower A B L]
+  [IsIntegrallyClosed A] [IsIntegralClosure B A L]
+
+/-- In the AKLB setup, the Galois group of `L/K` acts on `B`. -/
+noncomputable def IsIntegralClosure.MulSemiringAction [Algebra.IsAlgebraic K L] :
+    MulSemiringAction (L ≃ₐ[K] L) B :=
+  MulSemiringAction.compHom B (galRestrict A K L B).toMonoidHom
+
+/-- In the AKLB setup, every fixed point of `B` lies in the image of `A`. -/
+theorem Algebra.isInvariant_of_isGalois [FiniteDimensional K L] [h : IsGalois K L] :
+    letI := IsIntegralClosure.MulSemiringAction A K L B
+    Algebra.IsInvariant A B (L ≃ₐ[K] L) := by
+  replace h := ((IsGalois.tfae (F := K) (E := L)).out 0 1).mp h
+  letI := IsIntegralClosure.MulSemiringAction A K L B
+  refine ⟨fun b hb ↦ ?_⟩
+  replace hb : algebraMap B L b ∈ IntermediateField.fixedField (⊤ : Subgroup (L ≃ₐ[K] L)) := by
+    rintro ⟨g, -⟩
+    exact (algebraMap_galRestrict_apply A g b).symm.trans (congrArg (algebraMap B L) (hb g))
+  rw [h, IntermediateField.mem_bot] at hb
+  obtain ⟨k, hk⟩ := hb
+  have hb : IsIntegral A b := IsIntegralClosure.isIntegral A L b
+  rw [← isIntegral_algebraMap_iff (NoZeroSMulDivisors.algebraMap_injective B L), ← hk,
+    isIntegral_algebraMap_iff (NoZeroSMulDivisors.algebraMap_injective K L)] at hb
+  obtain ⟨a, rfl⟩ := IsIntegrallyClosed.algebraMap_eq_of_integral hb
+  rw [← IsScalarTower.algebraMap_apply, IsScalarTower.algebraMap_apply A B L,
+    (NoZeroSMulDivisors.algebraMap_injective B L).eq_iff] at hk
+  exact ⟨a, hk⟩
+
+end Galois
 
 section transitivity
 


### PR DESCRIPTION
This PR shows that Galois extensions satisfy `Algebra.IsInvariant`. This enables the theory of Frobenius elements to be applied to Galois extensions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
