### PR TITLE
[Merged by Bors] - doc(100,1000.yaml): tweak resp. add entry for Cantor's diagonal argument

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -236,9 +236,7 @@
   author : Kexing Ying
 63:
   title  : Cantor’s Theorem
-  decls  :
-    - Cardinal.cantor
-    - cantor_surjective
+  decl: Function.cantor_surjective
   author : Johannes Hölzl and Mario Carneiro
 64:
   title  : L’Hopital’s Rule

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -236,8 +236,10 @@
   author : Kexing Ying
 63:
   title  : Cantor’s Theorem
-  decl   : Cardinal.cantor
-  author : mathlib <!-- Mario and/or Johannes -->
+  decls  :
+    - Cardinal.cantor
+    - cantor_surjective
+  author : Johannes Hölzl and Mario Carneiro
 64:
   title  : L’Hopital’s Rule
   decl   : deriv.lhopital_zero_nhds

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -352,9 +352,7 @@ Q472883:
 Q474881:
   title: Cantor's theorem
   # a.k.a. Cantor's diagonal argument
-  decls:
-    - Cardinal.cantor
-    - cantor_surjective
+  decl: Function.cantor_surjective
   author: Johannes Hölzl and Mario Carneiro
 
 Q476776:

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -351,6 +351,11 @@ Q472883:
 
 Q474881:
   title: Cantor's theorem
+  # a.k.a. Cantor's diagonal argument
+  decls:
+    - Cardinal.cantor
+    - cantor_surjective
+  author: Johannes Hölzl and Mario Carneiro
 
 Q476776:
   title: Solutions of a general quartic equation


### PR DESCRIPTION
- document the second informal name in a comment, for future readers of the yaml file
- point to a different declaration (which matches what wikipedia has); one could also add both declarations, if preferred
- properly attribute Johannes Hölzl and Mario Carneiro as authors

---------------------

I didn't follow blame all the way back, but Johannes and Mario are two main authors of this file, so them sharing credit seems certainly not wrong.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
