### PR TITLE
[Merged by Bors] - doc(1000.yaml): add some formalisations

### DIFF
--- a/Mathlib/FieldTheory/PrimitiveElement.lean
+++ b/Mathlib/FieldTheory/PrimitiveElement.lean
@@ -14,10 +14,10 @@ In this file we prove the primitive element theorem.
 
 ## Main results
 
-- `exists_primitive_element`: a finite separable extension `E / F` has a primitive element, i.e.
-  there is an `α : E` such that `F⟮α⟯ = (⊤ : Subalgebra F E)`.
+- `Field.exists_primitive_element`: a finite separable extension `E / F` has a primitive element,
+  i.e. there is an `α : E` such that `F⟮α⟯ = (⊤ : Subalgebra F E)`.
 
-- `exists_primitive_element_iff_finite_intermediateField`: a finite extension `E / F` has a
+- `Field.exists_primitive_element_iff_finite_intermediateField`: a finite extension `E / F` has a
   primitive element if and only if there exist only finitely many intermediate fields between `E`
   and `F`.
 

--- a/Mathlib/GroupTheory/Coset/Card.lean
+++ b/Mathlib/GroupTheory/Coset/Card.lean
@@ -8,6 +8,10 @@ import Mathlib.SetTheory.Cardinal.Finite
 
 /-!
 # Lagrange's theorem: the order of a subgroup divides the order of the group.
+
+* `Subgroup.card_subgroup_dvd_card`: Lagrange's theorem (for multiplicative groups);
+there is an analogous version for additive groups
+
 -/
 
 open scoped Pointwise

--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -17,9 +17,11 @@ import Mathlib.GroupTheory.GroupAction.Hom
 # Properties of group actions involving quotient groups
 
 This file proves properties of group actions which use the quotient group construction, notably
-* the orbit-stabilizer theorem `card_orbit_mul_card_stabilizer_eq_card_group`
-* the class formula `card_eq_sum_card_group_div_card_stabilizer'`
-* Burnside's lemma `sum_card_fixedBy_eq_card_orbits_mul_card_group`
+* the orbit-stabilizer theorem `MulAction.card_orbit_mul_card_stabilizer_eq_card_group`
+* the class formula `MulAction.card_eq_sum_card_group_div_card_stabilizer'`
+* Burnside's lemma `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`,
+
+as well as their analogues for additive groups.
 -/
 
 universe u v w

--- a/Mathlib/GroupTheory/SchurZassenhaus.lean
+++ b/Mathlib/GroupTheory/SchurZassenhaus.lean
@@ -12,10 +12,10 @@ In this file we prove the Schur-Zassenhaus theorem.
 
 ## Main results
 
-- `exists_right_complement'_of_coprime`: The **Schur-Zassenhaus** theorem:
+- `Subgroup.exists_right_complement'_of_coprime`: The **Schur-Zassenhaus** theorem:
   If `H : Subgroup G` is normal and has order coprime to its index,
   then there exists a subgroup `K` which is a (right) complement of `H`.
-- `exists_left_complement'_of_coprime`: The **Schur-Zassenhaus** theorem:
+- `Subgroup.exists_left_complement'_of_coprime`: The **Schur-Zassenhaus** theorem:
   If `H : Subgroup G` is normal and has order coprime to its index,
   then there exists a subgroup `K` which is a (left) complement of `H`.
 -/

--- a/Mathlib/LinearAlgebra/QuadraticForm/Real.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Real.lean
@@ -16,7 +16,7 @@ A real quadratic form is equivalent to a weighted
 sum of squares with the weights being ±1 or 0.
 
 When the real quadratic form is nondegenerate we can take the weights to be ±1,
-as in `equivalent_one_zero_neg_one_weighted_sum_squared`.
+as in `QuadraticForm.equivalent_one_zero_neg_one_weighted_sum_squared`.
 
 -/
 

--- a/Mathlib/MeasureTheory/Function/Egorov.lean
+++ b/Mathlib/MeasureTheory/Function/Egorov.lean
@@ -15,8 +15,8 @@ convergence in measure.
 
 ## Main results
 
-* `MeasureTheory.Egorov`: Egorov's theorem which shows that a sequence of almost everywhere
-  convergent functions converges uniformly except on an arbitrarily small set.
+* `MeasureTheory.tendstoUniformlyOn_of_ae_tendsto`: Egorov's theorem which shows that a sequence of
+  almost everywhere convergent functions converges uniformly except on an arbitrarily small set.
 
 -/
 

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1710,6 +1710,7 @@ Q2226786:
 
 Q2226800:
   title: Schur–Zassenhaus theorem
+  decl: Subgroup.exists_left_complement'_of_coprime
 
 Q2226803:
   title: Tennenbaum's theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1132,7 +1132,7 @@ Q1068085:
 
 Q1068283:
   title: Löwenheim–Skolem theorem
-  decl: exists_elementaryEmbedding_card_eq
+  decl: FirstOrder.Language.exists_elementaryEmbedding_card_eq
 
 Q1068385:
   title: Clairaut's theorem
@@ -1321,7 +1321,7 @@ Q1191319:
 
 Q1191709:
   title: Egorov's theorem
-  decl: MeasureTheory.Egorov
+  decl: MeasureTheory.tendstoUniformlyOn_of_ae_tendsto
   author: Kexing Ying
 
 Q1191862:
@@ -1329,7 +1329,7 @@ Q1191862:
 
 Q1194053:
   title: Metrization theorems
-  decl: metrizableSpace_of_t3_secondCountable
+  decl: TopologicalSpace.metrizableSpace_of_t3_secondCountable
   comment: "Urysohn's metrization theorem (only)"
 
 Q1196538:
@@ -1413,7 +1413,7 @@ Q1340623:
 
 Q1346677:
   title: Tietze extension theorem
-  decl: exists_extension_norm_eq_of_isClosedEmbedding'
+  decl: BoundedContinuousFunction.exists_extension_norm_eq_of_isClosedEmbedding
 
 Q1347094:
   title: Alternate Interior Angles Theorem
@@ -1540,7 +1540,7 @@ Q1564541:
 
 Q1566341:
   title: Hindman's theorem
-  decl: FP_partition_regular
+  decl: Hindman.FP_partition_regular
   author: David Wärn
 
 Q1566372:

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -18,6 +18,8 @@
 # - perhaps add a wikidata version of the stacks attribute, and generate this file automatically
 #   (can this handle formalisation of *statements* also?)
 # - complete the information which theorems are already formalised
+#
+# TODO: display a less ambiguous title for e.g. "Liouville's theorem"
 
 Q11518:
   title: Pythagorean theorem
@@ -85,6 +87,7 @@ Q180345:
 
 Q182505:
   title: Bayes' theorem
+  decl: ProbabilityTheory.cond_eq_inv_mul_cond_mul
 
 Q184410:
   title: Four color theorem
@@ -98,6 +101,8 @@ Q188745:
 Q189136:
   title: Mean value theorem
   decl: exists_deriv_eq_slope
+  # XXX: other branch found exists_ratio_deriv_eq_ratio_slope,
+  # is about Cauchy's vs Lagrange's Mean Value Theorem, TODO decide!
   author: Yury G. Kudryashov
 
 Q190026:
@@ -123,9 +128,11 @@ Q192760:
 
 Q193286:
   title: Rolle's theorem
+  decl: exists_deriv_eq_zero
 
 Q193878:
   title: Chinese remainder theorem
+  decl: Ideal.quotientInfRingEquivPiQuotient
 
 Q193882:
   title: Menelaus's theorem
@@ -182,6 +189,8 @@ Q213603:
 
 Q220680:
   title: Banach fixed-point theorem
+  ## Contraction mapping theorem in mathlib
+  decl: ContractingWith.exists_fixedPoint
 
 Q225973:
   title: Ore's theorem
@@ -208,6 +217,7 @@ Q245098:
 
 Q245098X:
   title: Bolzano's theorem
+  # variant of the intermediate value theorem above, TODO should exist in mathlib, add decl
 
 Q245902:
   title: Riesz–Thorin theorem
@@ -217,6 +227,9 @@ Q248931:
 
 Q253214:
   title: Heine–Borel theorem
+  # TODO: two versions in mathlib, which one do we want?
+  # decl: Metric.isCompact_iff_isClosed_bounded
+  # decl: FiniteDimensional.proper
 
 Q255996:
   title: Equipartition theorem
@@ -273,12 +286,18 @@ Q287347:
 
 Q288465:
   title: Orbit-stabilizer theorem
+  decl: orbitEquivQuotientStabilizer
 
 Q303402:
   title: Rank–nullity theorem
+  # TODO: this is also in mathlib, TODO add decl (and mention in overview)
 
 Q318767:
   title: Abel's theorem
+  decls:
+    - Complex.tendsto_tsum_powerSeries_nhdsWithin_stolzCone
+    - Real.tendsto_tsum_powerSeries_nhdsWithin_lt
+  author: Jeremy Tan
 
 Q321237:
   title: Green's theorem
@@ -330,21 +349,27 @@ Q384142:
 
 Q386292:
   title: Prime number theorem
+  # also in 100.yaml
 
 Q388525:
   title: Bell's theorem
 
 Q401319:
   title: Puiseux's theorem
+  # also in 100.yaml
 
 Q401905:
   title: Skorokhod's representation theorem
 
 Q420714:
   title: Akra–Bazzi theorem
+  decl: AkraBazziRecurrence.isBigO_asympBound
 
 Q422187:
   title: Myhill–Nerode theorem
+  # two in-progress formalisations, none merged as of end of 2024
+  # https://github.com/atarnoam/lean-automata/blob/main/src/regular_languages.lean
+  # https://github.com/leanprover-community/mathlib4/pull/11311
 
 Q425432:
   title: Laurent expansion theorem
@@ -365,6 +390,9 @@ Q467756:
 
 Q468391:
   title: Bolzano–Weierstrass theorem
+  decls:
+    - tendsto_subseq_of_frequently_bounded # less standard version
+    - tendsto_subseq_of_bounded
 
 Q470877:
   title: Stirling's theorem
@@ -403,6 +431,8 @@ Q504843:
 
 Q505798:
   title: Lagrange's theorem
+  # group theorem result; exist additive and multiplicative version
+  decl: card_subgroup_dvd_card
 
 Q510197:
   title: Tutte theorem
@@ -424,15 +454,18 @@ Q528987:
 
 Q530152:
   title: Picard&ndash;Lindelöf theorem
+  decl: IsPicardLindelof.exists_forall_hasDerivWithinAt_Icc_eq
 
 Q535366:
   title: Montel's theorem
 
 Q536640:
   title: Hall's marriage theorem
+  decl: Finset.all_card_le_biUnion_card_iff_exists_injective
 
 Q537618:
   title: Banach–Alaoglu theorem
+  decl: WeakDual.isCompact_polar
 
 Q544292:
   title: Lagrange inversion theorem
@@ -453,12 +486,14 @@ Q567843:
 
 Q570779:
   title: Vieta's formulas
+  decl: Multiset.prod_X_add_C_eq_sum_esymm
 
 Q574902:
   title: Tarski's indefinability theorem
 
 Q576478:
   title: Liouville's theorem
+  decl: Differentiable.apply_eq_apply_of_bounded
 
 Q578555:
   title: Noether's theorem
@@ -468,6 +503,8 @@ Q579515:
 
 Q583147:
   title: Sard's theorem
+  # exists a statement in Lean, WIP formalisations in https://github.com/urkud/SardMoreira
+  # and https://github.com/fpvandoorn/sard (manifold version)
 
 Q586051:
   title: Haag–Łopuszański–Sohnius theorem
@@ -501,12 +538,15 @@ Q617417:
 
 Q619985:
   title: Multinomial theorem
+  decl: Finset.sum_pow_eq_sum_piAntidiag_of_commute
+  # TODO: is Finset.sum_pow_of_commute better?
 
 Q620602:
   title: Virial theorem
 
 Q631561:
   title: Closed range theorem
+  # TODO: this surely exists in mathlib, add decl!
 
 Q632546X:
   title: Sylvester's theorem
@@ -521,6 +561,7 @@ Q637418:
 
 Q642620:
   title: Krein–Milman theorem
+  decl: closure_convexHull_extremePoints
 
 Q643513:
   title: Riesz–Fischer theorem
@@ -534,6 +575,7 @@ Q646523:
 
 Q649469:
   title: Modularity theorem
+  # far away; FLT project is working on a special case
 
 Q649977:
   title: Shirshov–Cohn theorem
@@ -549,9 +591,11 @@ Q656176:
 
 Q656198:
   title: Maschke's theorem
+  # `RepresentationTheory/Maschke` comes very close, but doesn't prove the standard form yet...
 
 Q656645:
   title: Hilbert's basis theorem
+  # search mathlib or zulip; mathlib is close to this!
 
 Q656772:
   title: Cayley–Hamilton theorem
@@ -574,6 +618,8 @@ Q657903:
 
 Q660799:
   title: Darboux's theorem
+  # "all derivatives have the intermediate value property"
+  # TODO should exist in mathlib, add decl!
 
 Q670235:
   title: Fundamental theorem of arithmetic
@@ -606,6 +652,7 @@ Q693083:
 
 Q716171:
   title: Erdős–Ginzburg–Ziv theorem
+  decl: ZMod.erdos_ginzburg_ziv
 
 Q718875:
   title: Erdős–Ko–Rado theorem
@@ -630,9 +677,11 @@ Q730222:
 
 Q733081:
   title: Impossibility of angle trisection
+  # first part of problem 8 in 100.yaml
 
 Q737851:
   title: Banach–Tarski theorem
+  # WIP formalisation at https://github.com/Bergschaf/banach-tarski
 
 Q737892:
   title: Bendixson–Dulac theorem
@@ -657,6 +706,7 @@ Q751120:
 
 Q752375:
   title: Extreme value theorem
+  decl: IsCompact.exists_isMinOn
 
 Q755986:
   title: Atiyah–Bott fixed-point theorem
@@ -671,15 +721,20 @@ Q756946:
 
 Q764287:
   title: Van der Waerden's theorem
+  decl: Combinatorics.exists_mono_homothetic_copy
+  # TODO: this is only some version; should this entry be modified accordingly?
 
 Q765987:
   title: Heine–Cantor theorem
+  # XXX: does mathlib have this?
 
 Q766722:
   title: Liouville's theorem
+  # theorem about Hamiltonian mechanics
 
 Q776578:
   title: Artin–Wedderburn theorem
+  # WIP formalisation, but not complete yet (Dec 1, 2024)
 
 Q777924:
   title: Tijdeman's theorem
@@ -750,6 +805,7 @@ Q848092:
 
 Q848375:
   title: Implicit function theorem
+  decl: ImplicitFunctionData.implicitFunction
 
 Q848810:
   title: Kronecker's theorem
@@ -794,6 +850,7 @@ Q865665:
 
 Q866116:
   title: Hahn–Banach theorem
+  decl: exists_extension_norm_eq
 
 Q867141:
   title: Ehresmann's theorem
@@ -880,6 +937,7 @@ Q929547:
 
 Q931001:
   title: Inverse function theorem
+  decl: HasStrictFDerivAt.to_localInverse
 
 Q931001X:
   title: Constant rank theorem
@@ -898,12 +956,16 @@ Q942046:
 
 Q943246:
   title: Wedderburn's little theorem
+  decl: littleWedderburn
 
 Q944297:
   title: Open mapping theorem
+  # TODO: this entry points to Wikipedia's disambiguation page => wikipedia should be fixed
+  # Banach open mapping theorem/Banach-Schauder theorem in functional analysis is in mathlib (ContinuousLinearMap.isOpenMap)
 
 Q948664:
   title: Kneser's theorem
+  # TODO: is this in mathlib already?
 
 Q951327:
   title: Pasch's theorem
@@ -922,6 +984,7 @@ Q966837:
 
 Q967972:
   title: Open mapping theorem
+  # result in complex analysis. TODO does mathlib have this?
 
 Q973359:
   title: Rado's theorem
@@ -960,6 +1023,7 @@ Q1008566:
 
 Q1032886:
   title: Hales–Jewett theorem
+  decl: Combinatorics.Line.exists_mono_in_high_dimension
 
 Q1033910:
   title: Cantor–Bernstein–Schroeder theorem
@@ -971,12 +1035,15 @@ Q1037559:
 
 Q1038716:
   title: Identity theorem
+  # complex analysis, holomorphic functions: TODO add decl!
 
 Q1046232:
   title: Szemerédi's theorem
 
 Q1047749:
   title: Turán's theorem
+  decl: SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph
+  author: Jeremy Tan
 
 Q1048589:
   title: Hohenberg–Kohn theorems
@@ -1517,6 +1584,7 @@ Q1752516:
 
 Q1752621:
   title: Sylvester's law of inertia
+  decl: equivalent_one_zero_neg_one_weighted_sum_squared
 
 Q1752988:
   title: Kutta–Joukowski theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1634,6 +1634,7 @@ Q2071632:
 
 Q2093886:
   title: Primitive element theorem
+  decl: Field.exists_primitive_element
 
 Q2094241:
   title: Hopf–Rinow theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -286,7 +286,7 @@ Q287347:
 
 Q288465:
   title: Orbit-stabilizer theorem
-  decl: orbitEquivQuotientStabilizer
+  decl: MulAction.orbitEquivQuotientStabilizer
 
 Q303402:
   title: Rank–nullity theorem
@@ -432,7 +432,7 @@ Q504843:
 Q505798:
   title: Lagrange's theorem
   # group theorem result; exist additive and multiplicative version
-  decl: card_subgroup_dvd_card
+  decl: Subgroup.card_subgroup_dvd_card
 
 Q510197:
   title: Tutte theorem
@@ -1584,7 +1584,7 @@ Q1752516:
 
 Q1752621:
   title: Sylvester's law of inertia
-  decl: equivalent_one_zero_neg_one_weighted_sum_squared
+  decl: QuadraticForm.equivalent_one_zero_neg_one_weighted_sum_squared
 
 Q1752988:
   title: Kutta–Joukowski theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1056,9 +1056,14 @@ Q1050037:
 
 Q1050203:
   title: Cantor's intersection theorem
+  # many versions; are this (and friends, in the same file) all of the wikipedia article?
+  decl: IsCompact.nonempty_sInter_of_directed_nonempty_isCompact_isClosed
 
 Q1050932:
   title: Hartogs's theorem
+  url: https://github.com/girving/ray/blob/main/Ray/Hartogs/Hartogs.lean
+  identifiers: Pair.hartogs
+  author: Geoffrey Irving
 
 Q1051404:
   title: Cesàro's theorem
@@ -1068,6 +1073,7 @@ Q1052021:
 
 Q1052678:
   title: Baire category theorem
+  decl: dense_sInter_of_isOpen
 
 Q1052752:
   title: Stolz–Cesàro theorem
@@ -1088,6 +1094,7 @@ Q1057919:
 
 Q1058662:
   title: Darboux's theorem
+  # symplectic geometry result
 
 Q1059151:
   title: FWL theorem
@@ -1097,27 +1104,38 @@ Q1064471:
 
 Q1065257:
   title: Squeeze theorem
+  decl: tendsto_of_tendsto_of_tendsto_of_le_of_le'
 
 Q1065966:
   title: Isomorphism theorem
+  # Three isomorphism theorems in abstract algebra
+  decls:
+    - QuotientGroup.quotientKerEquivRange
+    - QuotientGroup.quotientInfEquivProdNormalQuotient
+    - QuotientGroup.quotientQuotientEquivQuotient
 
 Q1067156:
   title: Dominated convergence theorem
+  decl: MeasureTheory.tendsto_integral_of_dominated_convergence
 
 Q1067156X:
   title: Bounded convergence theorem
+  # TODO: is this in mathlib already?
 
 Q1068085:
   title: Closed graph theorem
+  decl: LinearMap.continuous_of_isClosed_graph
 
 Q1068283:
   title: Löwenheim–Skolem theorem
+  decl: exists_elementaryEmbedding_card_eq
 
 Q1068385:
   title: Clairaut's theorem
 
 Q1068976:
   title: Hilbert's Nullstellensatz
+  decl: MvPolynomial.vanishingIdeal_zeroLocus_eq_radical
 
 Q1075398:
   title: Jung's theorem
@@ -1138,6 +1156,8 @@ Q1082910:
 
 Q1095330:
   title: Apéry's theorem
+  url: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/pi.20is.20irrational.3F/near/478674074
+  # TODO: insert a link to a repository, and perhaps get that into mathlib :-)
 
 Q1097021:
   title: Minkowski's theorem
@@ -1185,6 +1205,7 @@ Q1136262:
 
 Q1137014:
   title: Tychonoff's theorem
+  decl: isCompact_pi_infinite
 
 Q1137206:
   title: Taylor's theorem
@@ -1195,6 +1216,8 @@ Q1137206:
 
 Q1139041:
   title: Cauchy's theorem
+  # for finite groups
+  decl: exists_prime_orderOf_dvd_card
 
 Q1139430:
   title: Hurwitz's theorem
@@ -1225,9 +1248,11 @@ Q1146791:
 
 Q1148215:
   title: Mitchell's embedding theorem
+  # there was a project talking about this; very in progress, I believe. statement exists.
 
 Q1149022:
   title: Fubini's theorem
+  decl: MeasureTheory.integral_prod
 
 Q1149185X:
   title: Kirby–Paris theorem
@@ -1237,6 +1262,7 @@ Q1149185:
 
 Q1149458:
   title: Compactness theorem
+  decl: FirstOrder.Language.Theory.isSatisfiable_iff_isFinitelySatisfiable
 
 Q1149522:
   title: Lami's theorem
@@ -1249,6 +1275,9 @@ Q1153441:
 
 Q1153584:
   title: Monotone convergence theorem
+  # TODO: many versions in mathlib, choose one
+  # e.g. integral_tendsto_of_tendsto_of_antitone (Bochner integral)
+  # or lintegral_tendsto_of_tendsto_of_monotone (Lebesgue integral)
 
 Q1166774:
   title: Stone's representation theorem for Boolean algebras
@@ -1267,6 +1296,7 @@ Q1186134:
 
 Q1186808:
   title: Lucas's theorem
+  decl: Choose.lucas_theorem
 
 Q1187646:
   title: Fundamental theorem on homomorphisms
@@ -1276,21 +1306,26 @@ Q1188048:
 
 Q1188392:
   title: Zeckendorf's theorem
+  decl: Nat.zeckendorfEquiv
 
 Q1188504:
   title: Pitman&ndash;Koopman&ndash;Darmois theorem
 
 Q1191319:
   title: Radon–Nikodym theorem
+  decl: MeasureTheory.Measure.absolutelyContinuous_iff_withDensity_rnDeriv_eq
 
 Q1191709:
   title: Egorov's theorem
+  decl: MeasureTheory.Egorov
 
 Q1191862:
   title: Rouché's theorem
 
 Q1194053:
   title: Metrization theorems
+  decl: metrizableSpace_of_t3_secondCountable
+  comment: "Urysohn's metrization theorem (only)"
 
 Q1196538:
   title: Descartes's theorem
@@ -1331,6 +1366,7 @@ Q1249069:
 
 Q1259814:
   title: Nielsen–Schreier theorem
+  decl: subgroupIsFreeOfIsFree
 
 Q1276318:
   title: Schwartz kernel theorem
@@ -1343,6 +1379,8 @@ Q1306092:
 
 Q1306095:
   title: Whitney embedding theorem
+  decl: exists_embedding_euclidean_of_compact
+  comment: "baby version: for compact manifolds; embedding into some *n*"
 
 Q1307676:
   title: Künneth theorem
@@ -1370,6 +1408,7 @@ Q1340623:
 
 Q1346677:
   title: Tietze extension theorem
+  decl: exists_extension_norm_eq_of_isClosedEmbedding'
 
 Q1347094:
   title: Alternate Interior Angles Theorem
@@ -1427,6 +1466,7 @@ Q1425529:
 
 Q1426292:
   title: Banach–Steinhaus theorem
+  decl: banach_steinhaus
 
 Q1434158:
   title: Fluctuation dissipation theorem
@@ -1454,6 +1494,7 @@ Q1472120:
 
 Q1477053:
   title: Arzelà–Ascoli theorem
+  decl: BoundedContinuousFunction.arzela_ascoli
 
 Q1505529:
   title: Runge's theorem
@@ -1494,6 +1535,7 @@ Q1564541:
 
 Q1566341:
   title: Hindman's theorem
+  decl: FP_partition_regular
 
 Q1566372:
   title: Haag's theorem
@@ -1503,9 +1545,11 @@ Q1568612:
 
 Q1568811:
   title: Hahn decomposition theorem
+  decl: MeasureTheory.SignedMeasure.exists_isCompl_positive_negative
 
 Q1572474:
   title: Lindemann–Weierstrass theorem
+  # WIP PR: https://github.com/leanprover-community/mathlib4/pull/6718
 
 Q1576235:
   title: Lochs's theorem
@@ -3437,6 +3481,7 @@ Q7818977:
 
 Q7820874:
   title: Tonelli's theorem
+  # TODO: this is on mathlib, right?
 
 Q7824894:
   title: Topkis's theorem
@@ -3449,6 +3494,7 @@ Q7825663:
 
 Q7827204:
   title: Mazur's torsion theorem
+  # TODO: is this used in FLT?
 
 Q7841060:
   title: Trichotomy theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -562,6 +562,7 @@ Q637418:
 Q642620:
   title: Krein–Milman theorem
   decl: closure_convexHull_extremePoints
+  author: Yaël Dillies
 
 Q643513:
   title: Riesz–Fischer theorem
@@ -653,6 +654,7 @@ Q693083:
 Q716171:
   title: Erdős–Ginzburg–Ziv theorem
   decl: ZMod.erdos_ginzburg_ziv
+  author: Yaël Dillies
 
 Q718875:
   title: Erdős–Ko–Rado theorem
@@ -722,6 +724,7 @@ Q756946:
 Q764287:
   title: Van der Waerden's theorem
   decl: Combinatorics.exists_mono_homothetic_copy
+  author: David Wärn
   # TODO: this is only some version; should this entry be modified accordingly?
 
 Q765987:
@@ -1024,6 +1027,7 @@ Q1008566:
 Q1032886:
   title: Hales–Jewett theorem
   decl: Combinatorics.Line.exists_mono_in_high_dimension
+  author: David Wärn
 
 Q1033910:
   title: Cantor–Bernstein–Schroeder theorem
@@ -1318,6 +1322,7 @@ Q1191319:
 Q1191709:
   title: Egorov's theorem
   decl: MeasureTheory.Egorov
+  author: Kexing Ying
 
 Q1191862:
   title: Rouché's theorem
@@ -1536,6 +1541,7 @@ Q1564541:
 Q1566341:
   title: Hindman's theorem
   decl: FP_partition_regular
+  author: David Wärn
 
 Q1566372:
   title: Haag's theorem


### PR DESCRIPTION
---

See https://github.com/leanprover-community/mathlib4/tree/MR-1000-add-entries for some more entries. In case where the data differs, this PR has more polished data. Help porting these over is welcome.
Mostly created by skimming the overview page for "theorems" (and occasionally, by noticing something that "had to be in mathlib").

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
