### PR TITLE
[Merged by Bors] - chore: rename `coeff_modByMonic_mem_span_pow_mul_span`

### DIFF
--- a/Mathlib/Algebra/Polynomial/CoeffMem.lean
+++ b/Mathlib/Algebra/Polynomial/CoeffMem.lean
@@ -76,7 +76,7 @@ lemma coeff_divModByMonicAux_mem_span_pow_mul_span : ∀ (p q : S[X]) (hq : q.Mo
 coefficients of `p` and `q`.
 
 Precisely, each summand needs at most one coefficient of `p` and `deg p` coefficients of `q`. -/
-lemma coeff_modByMonic_mem_span_pow_mul_span (p q : S[X])
+lemma coeff_modByMonic_mem_pow_natDegree_mul (p q : S[X])
     (Mp : Submodule R S) (hp : ∀ i, p.coeff i ∈ Mp) (hp' : 1 ∈ Mp)
     (Mq : Submodule R S) (hq : ∀ i, q.coeff i ∈ Mq) (hq' : 1 ∈ Mq) (i : ℕ) :
     (p %ₘ q).coeff i ∈ Mq ^ p.natDegree * Mp := by
@@ -91,7 +91,7 @@ lemma coeff_modByMonic_mem_span_pow_mul_span (p q : S[X])
 coefficients of `p` and `q`.
 
 Precisely, each summand needs at most one coefficient of `p` and `deg p` coefficients of `q`. -/
-lemma coeff_divByMonic_mem_span_pow_mul_span (p q : S[X])
+lemma coeff_divByMonic_mem_pow_natDegree_mul (p q : S[X])
     (Mp : Submodule R S) (hp : ∀ i, p.coeff i ∈ Mp) (hp' : 1 ∈ Mp)
     (Mq : Submodule R S) (hq : ∀ i, q.coeff i ∈ Mq) (hq' : 1 ∈ Mq) (i : ℕ) :
     (p /ₘ q).coeff i ∈ Mq ^ p.natDegree * Mp := by


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I don't think deprecations are necessary because it was just merged yesterday.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
