### PR TITLE
perf(ModelTheory/Algebra/Ring/Definability): re-squeeze a slow simp

### DIFF
--- a/Mathlib/ModelTheory/Algebra/Ring/Definability.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Definability.lean
@@ -38,8 +38,11 @@ theorem mvPolynomial_zeroLocus_definable {ι K : Type*} [Field K]
           (Sum.map (fun p => ⟨p.1.1.coeff p.2.1, by
             simp only [Set.mem_iUnion]
             exact ⟨p.1.1, p.1.2, Set.mem_image_of_mem _ p.2.2⟩⟩) id)) 0), ?_⟩
-  simp [Formula.Realize, Term.equal, Function.comp_def, p']
-
+  simp? [Formula.Realize, Term.equal, Function.comp_def, p'] says
+    simp only [Finset.mem_coe, Formula.Realize, Term.equal, Term.relabel_relabel, Function.comp_def,
+    realize_iInf, Finset.mem_attach, realize_bdEqual, Term.realize_relabel, Sum.elim_inl,
+    realize_termOfFreeCommRing, lift_genericPolyMap, Sum.map_inr, id_eq, Sum.elim_inr, Sum.map_inl,
+    MvPolynomialSupportLEEquiv_symm_apply_coeff, realize_zero, forall_const, Subtype.forall, p']
 
 end Ring
 


### PR DESCRIPTION
The simp alone takes about as long as the remaining file.
This regressed in #20097.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
