### PR TITLE
[Merged by Bors] - feat: Define ENorm notation class

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1445,7 +1445,7 @@ import Mathlib.Analysis.NormedSpace.BallAction
 import Mathlib.Analysis.NormedSpace.ConformalLinearMap
 import Mathlib.Analysis.NormedSpace.Connected
 import Mathlib.Analysis.NormedSpace.DualNumber
-import Mathlib.Analysis.NormedSpace.ENorm
+import Mathlib.Analysis.NormedSpace.ENormedSpace
 import Mathlib.Analysis.NormedSpace.Extend
 import Mathlib.Analysis.NormedSpace.Extr
 import Mathlib.Analysis.NormedSpace.FunctionSeries

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -63,14 +63,19 @@ class NNNorm (E : Type*) where
   /-- the `ℝ≥0`-valued norm function. -/
   nnnorm : E → ℝ≥0
 
+/-- Auxiliary class, endowing a type `α` with a function `enorm : α → ℝ≥0∞` with notation `‖x‖ₑ`. -/
+@[notation_class]
+class ENorm (E : Type*) where
+  /-- the `ℝ≥0∞`-valued norm function. -/
+  enorm : E → ℝ≥0∞
+
 export Norm (norm)
 export NNNorm (nnnorm)
+export ENorm (enorm)
 
-@[inherit_doc]
-notation "‖" e "‖" => norm e
-
-@[inherit_doc]
-notation "‖" e "‖₊" => nnnorm e
+@[inherit_doc] notation "‖" e "‖" => norm e
+@[inherit_doc] notation "‖" e "‖₊" => nnnorm e
+@[inherit_doc] notation "‖" e "‖ₑ" => enorm e
 
 /-- A seminormed group is an additive group endowed with a norm for which `dist x y = ‖x - y‖`
 defines a pseudometric space structure. -/
@@ -806,6 +811,20 @@ theorem mem_emetric_ball_one_iff {r : ℝ≥0∞} : a ∈ EMetric.ball (1 : E) r
 
 end NNNorm
 
+section ENNNorm
+
+instance {E : Type*} [NNNorm E] : ENorm E where
+  enorm := (‖·‖₊ : E → ℝ≥0∞)
+
+lemma enorm_eq_nnnorm {E : Type*} [NNNorm E] {x : E} : ‖x‖ₑ = ‖x‖₊ := rfl
+
+instance : ENorm ℝ≥0∞ where
+  enorm x := x
+
+@[simp] lemma enorm_eq_self (x : ℝ≥0∞) : ‖x‖ₑ = x := rfl
+
+end ENNNorm
+
 @[to_additive]
 theorem tendsto_iff_norm_div_tendsto_zero {f : α → E} {a : Filter α} {b : E} :
     Tendsto f a (𝓝 b) ↔ Tendsto (fun e => ‖f e / b‖) a (𝓝 0) := by
@@ -1496,3 +1515,5 @@ instance (priority := 75) normedCommGroup [NormedCommGroup E] {S : Type*} [SetLi
 end SubgroupClass
 
 lemma tendsto_norm_atTop_atTop : Tendsto (norm : ℝ → ℝ) atTop atTop := tendsto_abs_atTop_atTop
+
+set_option linter.style.longFile 1700

--- a/Mathlib/Analysis/NormedSpace/ENorm.lean
+++ b/Mathlib/Analysis/NormedSpace/ENorm.lean
@@ -9,14 +9,14 @@ import Mathlib.LinearAlgebra.Basis.VectorSpace
 /-!
 # Extended norm
 
-In this file we define a structure `ENorm 𝕜 V` representing an extended norm (i.e., a norm that can
-take the value `∞`) on a vector space `V` over a normed field `𝕜`. We do not use `class` for
-an `ENorm` because the same space can have more than one extended norm. For example, the space of
-measurable functions `f : α → ℝ` has a family of `L_p` extended norms.
+In this file we define a structure `ENormedSpace 𝕜 V` representing an extended norm (i.e., a norm
+that can take the value `∞`) on a vector space `V` over a normed field `𝕜`. We do not use `class`
+for an `ENormedSpace` because the same space can have more than one extended norm.
+For example, the space of measurable functions `f : α → ℝ` has a family of `L_p` extended norms.
 
 We prove some basic inequalities, then define
 
-* `EMetricSpace` structure on `V` corresponding to `e : ENorm 𝕜 V`;
+* `EMetricSpace` structure on `V` corresponding to `e : ENormedSpace 𝕜 V`;
 * the subspace of vectors with finite norm, called `e.finiteSubspace`;
 * a `NormedSpace` structure on this space.
 
@@ -35,38 +35,41 @@ normed space, extended norm
 noncomputable section
 
 attribute [local instance] Classical.propDecidable
+set_option linter.deprecated false
 
 open ENNReal
 
 /-- Extended norm on a vector space. As in the case of normed spaces, we require only
 `‖c • x‖ ≤ ‖c‖ * ‖x‖` in the definition, then prove an equality in `map_smul`. -/
-structure ENorm (𝕜 : Type*) (V : Type*) [NormedField 𝕜] [AddCommGroup V] [Module 𝕜 V] where
+structure ENormedSpace (𝕜 : Type*) (V : Type*) [NormedField 𝕜] [AddCommGroup V] [Module 𝕜 V] where
   toFun : V → ℝ≥0∞
   eq_zero' : ∀ x, toFun x = 0 → x = 0
   map_add_le' : ∀ x y : V, toFun (x + y) ≤ toFun x + toFun y
   map_smul_le' : ∀ (c : 𝕜) (x : V), toFun (c • x) ≤ ‖c‖₊ * toFun x
 
-namespace ENorm
+namespace ENormedSpace
 
-variable {𝕜 : Type*} {V : Type*} [NormedField 𝕜] [AddCommGroup V] [Module 𝕜 V] (e : ENorm 𝕜 V)
+variable {𝕜 : Type*} {V : Type*} [NormedField 𝕜] [AddCommGroup V] [Module 𝕜 V]
+  (e : ENormedSpace 𝕜 V)
 
 -- Porting note: added to appease norm_cast complaints
-attribute [coe] ENorm.toFun
+attribute [coe] ENormedSpace.toFun
 
-instance : CoeFun (ENorm 𝕜 V) fun _ => V → ℝ≥0∞ :=
-  ⟨ENorm.toFun⟩
+instance : CoeFun (ENormedSpace 𝕜 V) fun _ => V → ℝ≥0∞ :=
+  ⟨ENormedSpace.toFun⟩
 
-theorem coeFn_injective : Function.Injective ((↑) : ENorm 𝕜 V → V → ℝ≥0∞) := fun e₁ e₂ h => by
+theorem coeFn_injective : Function.Injective ((↑) : ENormedSpace 𝕜 V → V → ℝ≥0∞) := by
+  intro e₁ e₂ h
   cases e₁
   cases e₂
   congr
 
 @[ext]
-theorem ext {e₁ e₂ : ENorm 𝕜 V} (h : ∀ x, e₁ x = e₂ x) : e₁ = e₂ :=
+theorem ext {e₁ e₂ : ENormedSpace 𝕜 V} (h : ∀ x, e₁ x = e₂ x) : e₁ = e₂ :=
   coeFn_injective <| funext h
 
 @[simp, norm_cast]
-theorem coe_inj {e₁ e₂ : ENorm 𝕜 V} : (e₁ : V → ℝ≥0∞) = e₂ ↔ e₁ = e₂ :=
+theorem coe_inj {e₁ e₂ : ENormedSpace 𝕜 V} : (e₁ : V → ℝ≥0∞) = e₂ ↔ e₁ = e₂ :=
   coeFn_injective.eq_iff
 
 @[simp]
@@ -108,14 +111,14 @@ theorem map_sub_le (x y : V) : e (x - y) ≤ e x + e y :=
     _ ≤ e x + e (-y) := e.map_add_le x (-y)
     _ = e x + e y := by rw [e.map_neg]
 
-instance partialOrder : PartialOrder (ENorm 𝕜 V) where
+instance partialOrder : PartialOrder (ENormedSpace 𝕜 V) where
   le e₁ e₂ := ∀ x, e₁ x ≤ e₂ x
   le_refl _ _ := le_rfl
   le_trans _ _ _ h₁₂ h₂₃ x := le_trans (h₁₂ x) (h₂₃ x)
   le_antisymm _ _ h₁₂ h₂₁ := ext fun x => le_antisymm (h₁₂ x) (h₂₁ x)
 
-/-- The `ENorm` sending each non-zero vector to infinity. -/
-noncomputable instance : Top (ENorm 𝕜 V) :=
+/-- The `ENormedSpace` sending each non-zero vector to infinity. -/
+noncomputable instance : Top (ENormedSpace 𝕜 V) :=
   ⟨{  toFun := fun x => if x = 0 then 0 else ⊤
       eq_zero' := fun x => by simp only; split_ifs <;> simp [*]
       map_add_le' := fun x y => by
@@ -131,18 +134,18 @@ noncomputable instance : Top (ENorm 𝕜 V) :=
         · tauto
         · simpa [mul_top'] using hcx.1 }⟩
 
-noncomputable instance : Inhabited (ENorm 𝕜 V) :=
+noncomputable instance : Inhabited (ENormedSpace 𝕜 V) :=
   ⟨⊤⟩
 
-theorem top_map {x : V} (hx : x ≠ 0) : (⊤ : ENorm 𝕜 V) x = ⊤ :=
+theorem top_map {x : V} (hx : x ≠ 0) : (⊤ : ENormedSpace 𝕜 V) x = ⊤ :=
   if_neg hx
 
-noncomputable instance : OrderTop (ENorm 𝕜 V) where
+noncomputable instance : OrderTop (ENormedSpace 𝕜 V) where
   top := ⊤
   le_top e x := if h : x = 0 then by simp [h] else by simp [top_map h]
 
-noncomputable instance : SemilatticeSup (ENorm 𝕜 V) :=
-  { ENorm.partialOrder with
+noncomputable instance : SemilatticeSup (ENormedSpace 𝕜 V) :=
+  { ENormedSpace.partialOrder with
     le := (· ≤ ·)
     lt := (· < ·)
     sup := fun e₁ e₂ =>
@@ -157,11 +160,11 @@ noncomputable instance : SemilatticeSup (ENorm 𝕜 V) :=
     sup_le := fun _ _ _ h₁ h₂ x => max_le (h₁ x) (h₂ x) }
 
 @[simp, norm_cast]
-theorem coe_max (e₁ e₂ : ENorm 𝕜 V) : ⇑(e₁ ⊔ e₂) = fun x => max (e₁ x) (e₂ x) :=
+theorem coe_max (e₁ e₂ : ENormedSpace 𝕜 V) : ⇑(e₁ ⊔ e₂) = fun x => max (e₁ x) (e₂ x) :=
   rfl
 
 @[norm_cast]
-theorem max_map (e₁ e₂ : ENorm 𝕜 V) (x : V) : (e₁ ⊔ e₂) x = max (e₁ x) (e₂ x) :=
+theorem max_map (e₁ e₂ : ENormedSpace 𝕜 V) (x : V) : (e₁ ⊔ e₂) x = max (e₁ x) (e₂ x) :=
   rfl
 
 /-- Structure of an `EMetricSpace` defined by an extended norm. -/
@@ -175,7 +178,7 @@ abbrev emetricSpace : EMetricSpace V where
       e (x - z) = e (x - y + (y - z)) := by rw [sub_add_sub_cancel]
       _ ≤ e (x - y) + e (y - z) := e.map_add_le (x - y) (y - z)
 
-/-- The subspace of vectors with finite enorm. -/
+/-- The subspace of vectors with finite ENormedSpace. -/
 def finiteSubspace : Subspace 𝕜 V where
   carrier := { x | e x < ⊤ }
   zero_mem' := by simp
@@ -212,4 +215,4 @@ theorem finite_norm_eq (x : e.finiteSubspace) : ‖x‖ = (e x).toReal :=
 instance normedSpace : NormedSpace 𝕜 e.finiteSubspace where
   norm_smul_le c x := le_of_eq <| by simp [finite_norm_eq, ENNReal.toReal_mul]
 
-end ENorm
+end ENormedSpace

--- a/Mathlib/Analysis/NormedSpace/ENormedSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/ENormedSpace.lean
@@ -42,7 +42,7 @@ open ENNReal
 /-- Extended norm on a vector space. As in the case of normed spaces, we require only
 `‖c • x‖ ≤ ‖c‖ * ‖x‖` in the definition, then prove an equality in `map_smul`. -/
 structure ENormedSpace (𝕜 : Type*) (V : Type*) [NormedField 𝕜] [AddCommGroup V] [Module 𝕜 V] where
-  /-- The underlying function of an ENormedspace -/
+  /-- The norm of an ENormedspace, taking values into `ℝ≥0∞`. -/
   toFun : V → ℝ≥0∞
   eq_zero' : ∀ x, toFun x = 0 → x = 0
   map_add_le' : ∀ x y : V, toFun (x + y) ≤ toFun x + toFun y

--- a/Mathlib/Analysis/NormedSpace/ENormedSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/ENormedSpace.lean
@@ -42,6 +42,7 @@ open ENNReal
 /-- Extended norm on a vector space. As in the case of normed spaces, we require only
 `‖c • x‖ ≤ ‖c‖ * ‖x‖` in the definition, then prove an equality in `map_smul`. -/
 structure ENormedSpace (𝕜 : Type*) (V : Type*) [NormedField 𝕜] [AddCommGroup V] [Module 𝕜 V] where
+  /-- The underlying function of an ENormedspace -/
   toFun : V → ℝ≥0∞
   eq_zero' : ∀ x, toFun x = 0 → x = 0
   map_add_le' : ∀ x y : V, toFun (x + y) ≤ toFun x + toFun y


### PR DESCRIPTION
* This PR only defines the notation class and two instances, but doesn't use it yet.
* There is an existing unused definition of `ENorm`. Since I might use it in the future, I kept it around, but renamed it (and the file) `ENormedSpace`. I did not modify anything, and didn't add deprecations since it is unused and the main definition now has a different meaning.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/ENorm.20for.20measure.20theory)