### PR TITLE
[Merged by Bors] - feat(Mathlib/Topology/Instances/NNReal): add `IsOrderBornology ℝ≥0`

### DIFF
--- a/Mathlib/Topology/Instances/NNReal.lean
+++ b/Mathlib/Topology/Instances/NNReal.lean
@@ -23,15 +23,12 @@ Instances for the following typeclasses are defined:
 * `TopologicalSemiring ℝ≥0`
 * `SecondCountableTopology ℝ≥0`
 * `OrderTopology ℝ≥0`
-* `IsOrderBornology ℝ≥0`
 * `ProperSpace ℝ≥0`
 * `ContinuousSub ℝ≥0`
 * `HasContinuousInv₀ ℝ≥0` (continuity of `x⁻¹` away from `0`)
 * `ContinuousSMul ℝ≥0 α` (whenever `α` has a continuous `MulAction ℝ α`)
 
 Everything is inherited from the corresponding structures on the reals.
-(TODO: As for `IsOrderBornology`, there might be a general argument to prove it for a subtype with
-appropriate assumtions)
 
 ## Main statements
 

--- a/Mathlib/Topology/Instances/NNReal.lean
+++ b/Mathlib/Topology/Instances/NNReal.lean
@@ -23,12 +23,15 @@ Instances for the following typeclasses are defined:
 * `TopologicalSemiring ℝ≥0`
 * `SecondCountableTopology ℝ≥0`
 * `OrderTopology ℝ≥0`
+* `IsOrderBornology ℝ≥0`
 * `ProperSpace ℝ≥0`
 * `ContinuousSub ℝ≥0`
 * `HasContinuousInv₀ ℝ≥0` (continuity of `x⁻¹` away from `0`)
 * `ContinuousSMul ℝ≥0 α` (whenever `α` has a continuous `MulAction ℝ α`)
 
 Everything is inherited from the corresponding structures on the reals.
+(TODO: As for `IsOrderBornology`, there might be a general argument to prove it for a subtype with
+appropriate assumtions)
 
 ## Main statements
 

--- a/Mathlib/Topology/Instances/NNReal.lean
+++ b/Mathlib/Topology/Instances/NNReal.lean
@@ -73,6 +73,17 @@ instance : CompleteSpace ℝ≥0 :=
 
 instance : ContinuousStar ℝ≥0 where
   continuous_star := continuous_id
+
+instance : IsOrderBornology ℝ≥0 where
+  isBounded_iff_bddBelow_bddAbove s := by
+    refine ⟨fun bdd ↦ ?_, fun h ↦ isBounded_of_bddAbove_of_bddBelow h.2 h.1⟩
+    obtain ⟨r, hr⟩ : ∃ r : ℝ≥0, s ⊆ Icc 0 r := by
+      obtain ⟨rreal, hrreal⟩ := bdd.subset_closedBall 0
+      use rreal.toNNReal
+      simp only [← NNReal.closedBall_zero_eq_Icc', Real.coe_toNNReal']
+      exact subset_trans hrreal (Metric.closedBall_subset_closedBall (le_max_left rreal 0))
+    exact ⟨bddBelow_Icc.mono hr, bddAbove_Icc.mono hr⟩
+
 section coe
 
 lemma isOpen_Ico_zero {x : NNReal} : IsOpen (Set.Ico 0 x) :=

--- a/Mathlib/Topology/Instances/NNReal.lean
+++ b/Mathlib/Topology/Instances/NNReal.lean
@@ -77,6 +77,7 @@ instance : CompleteSpace ℝ≥0 :=
 instance : ContinuousStar ℝ≥0 where
   continuous_star := continuous_id
 
+-- TODO: generalize this to a broader class of subtypes
 instance : IsOrderBornology ℝ≥0 where
   isBounded_iff_bddBelow_bddAbove s := by
     refine ⟨fun bdd ↦ ?_, fun h ↦ isBounded_of_bddAbove_of_bddBelow h.2 h.1⟩


### PR DESCRIPTION
Add instance `IsOrderBornology ℝ≥0`.

motivation: I will need in #20040 (or a later PR) that the range of a compactly supported `NNReal`-valued function is bounded below and above.

see also https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/IsOrderBornology.20.E2.84.9D.E2.89.A50