### PR TITLE
feat: operads and clones: `Operad` and `SymmOperad`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -621,6 +621,7 @@ import Mathlib.Algebra.NoZeroSMulDivisors.Pi
 import Mathlib.Algebra.NoZeroSMulDivisors.Prod
 import Mathlib.Algebra.Notation
 import Mathlib.Algebra.Operad.Basic
+import Mathlib.Algebra.Operad.Operad
 import Mathlib.Algebra.Operad.Perm
 import Mathlib.Algebra.Opposites
 import Mathlib.Algebra.Order.AbsoluteValue

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -620,6 +620,7 @@ import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 import Mathlib.Algebra.NoZeroSMulDivisors.Pi
 import Mathlib.Algebra.NoZeroSMulDivisors.Prod
 import Mathlib.Algebra.Notation
+import Mathlib.Algebra.Operad.Perm
 import Mathlib.Algebra.Opposites
 import Mathlib.Algebra.Order.AbsoluteValue
 import Mathlib.Algebra.Order.AddGroupWithTop

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -620,6 +620,7 @@ import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 import Mathlib.Algebra.NoZeroSMulDivisors.Pi
 import Mathlib.Algebra.NoZeroSMulDivisors.Prod
 import Mathlib.Algebra.Notation
+import Mathlib.Algebra.Operad.Basic
 import Mathlib.Algebra.Opposites
 import Mathlib.Algebra.Order.AbsoluteValue
 import Mathlib.Algebra.Order.AddGroupWithTop

--- a/Mathlib/Algebra/Operad/Basic.lean
+++ b/Mathlib/Algebra/Operad/Basic.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2024 Alex Meiburg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Meiburg
+-/
+import Mathlib.Algebra.Group.Action.Defs
+
+/-! This file defines the typeclasses and notations used for workign with `Operad`, `SymmOperad`,
+  and `Clone`. These all, in some form another, work with graded - or Sigma - types. Below,
+  `A : ℕ → Type*` is always the carrier.
+
+  Classes:
+  - `MultiComposable`: A `compose` operation `A n → Fin n → A m → A (n+m-1)`, for composing an
+    element of grade `m` into one of grade `n` at a location `Fin n`. This is the type of operation
+    used in Operads.
+  - `Superposable`: A `superpose` operation `A n → (Fin n → A m) → A m`. This is the type of
+    operation used in Clones.
+  - `OneGradedOne`: There is a distinguished `1` element at grade 1, a notion of identity.
+  - `SigmaMulAction`: A graded `MulAction M A`, where elements `M i` can act on `A i` at each i.
+
+  Definitions:
+  - `composeAt` bundles the action of `MultiComposable.compose` into `Sigma A`.
+  - `superpose` bundles the action of `Superposable.superpose` into `Sigma A`.
+
+  Notations:
+  - `x ∘⟨p⟩ y` for `MultiComposable.compose` to compose `x ∘ y` at index `p`.
+  - `x ∘[p] y` for the `composeAt` Sigma variant.
+  - `x ∘⚟ y` for `Superposable.superpose x y`. The typography is meant to suggest
+    "many arguments into one".
+-/
+
+/-- A MultiComposable is a structure that allows composition from an m-arity object
+ into a n-arity object at location p (in the range 0 to n-1) to produce an (n+m-1)
+ arity object. `Operad` is the canonical example. -/
+class MultiComposable  (A : ℕ → Type*) where
+  /-- Compose the (n+1)-arity object at location p on the m-arity object. -/
+  compose {n m} : A n → Fin n → A m → A (n+m-1)
+
+/-- A Superposable is a structure that allows "superposition": given an n-arity object
+ and n many m-arity objects, they can all enter and share arguments to make a new m-arity
+object. `Clone` is the canonical example. -/
+class Superposable (A : ℕ → Type*) where
+  /-- Compose the (n+1)-arity object at location p on the m-arity object. -/
+  superpose {n m} : A n → (Fin n → A m) → A m
+
+/-- Families that have a "one" at grading 1. -/
+class OneGradedOne (A : ℕ → Type*) extends One (A 1) where
+
+variable {A} {m : ℕ}
+
+/-- Upgrade `MultiComposable.compose` to an operation on Sigma types. -/
+def composeAt [MultiComposable A] (x : Sigma A) (y : Sigma A) (p : Fin x.fst) : Sigma A :=
+  ⟨_, MultiComposable.compose x.snd p y.snd⟩
+
+/-- Upgrade `Superposable.superpose` to an operation on Sigma types. -/
+def superpose [Superposable A] (x : Sigma A) (y : Fin x.fst → A m) : Sigma A :=
+  ⟨m, Superposable.superpose x.snd y⟩
+
+/-- Notation for `MultiComposable.compose`, for working with `A n` graded types. -/
+notation:70 x:71 " ∘⟨" p:70 "⟩ " y:70  => MultiComposable.compose x p y
+/-- Notation for `composeAt`, for working with Sigma types. -/
+notation:70 x:71 " ∘[" p:70 "] " y:70  => composeAt x y p
+
+/-- Notation for `Superposable.superpose`, for working with `A n` graded types. -/
+infixr:70 " ∘⚟ " => Superposable.superpose
+
+--Commented out since it's currently not used anywhere. Could easily be useful though.
+-- /-- Notation for `superpose`, for working with Sigma types. -/
+-- infixr:70 " ∘∈ " => superpose
+
+/-- `OneGradedOne` yields a `One (Sigma A)` -/
+instance ComposableOne_toOne [OneGradedOne A] : One (Sigma A) :=
+  ⟨⟨1, 1⟩⟩
+
+@[simp]
+theorem eq_id_sigma_id [OneGradedOne A] : (1 : Sigma A).snd = 1 :=
+  rfl
+
+@[simp]
+theorem eq_id_sigma_one [OneGradedOne A] : (1 : Sigma A).fst = 1 :=
+  rfl
+
+section SigmaMul
+
+variable {ι : Type*}
+
+universe s t
+
+/-- A SigmaMulAction exists on two sigma types with the same domain, and gives a MulAction
+  at each matched level. -/
+class SigmaMulAction (M : (ι → Type s)) (A : ι → Type t) [m : ∀ i, Monoid (M i)] where
+  /-- At each ι, there's a MulAction from M i on the type A i -/
+  act_at (i : ι) : @MulAction (M i) (A i) (m i)
+
+variable {M : (ι → Type s)} {A : ι → Type t} [m : ∀ i, Monoid (M i)] [SigmaMulAction M A]
+
+instance sigmaMul_to_MulAction : ∀ (i : ι), MulAction (M i) (A i) :=
+  SigmaMulAction.act_at
+
+end SigmaMul

--- a/Mathlib/Algebra/Operad/Basic.lean
+++ b/Mathlib/Algebra/Operad/Basic.lean
@@ -1,0 +1,255 @@
+/-
+Copyright (c) 2024 Alex Meiburg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Meiburg
+-/
+import Mathlib.Data.Fin.Basic
+import Mathlib.Data.Fintype.Card
+
+/-!
+This file defines various operations on permutations, necessary for working with `SymmOperad`s.
+They seem unlikely to be of much use elsewhere, hence why they are all under the Operad folder.
+
+Definitions:
+  - `PermFinPadLeftRight`: Extend a permutation on `Fin n` to a permutation on `Fim (m+n+k)`,
+    by acting as the identity on the first m and last k elements.
+  - `PermFinPadTo`: HEq to `PermfinPadLeftRight`, but with a different type. It
+    starts the permutation on `Fin m` at location k out of n, and creates a perm of length `n+m-1`.
+  - `PermFinPadAt`: Takes the permutation on `Fim m` and "expands" location k out of m, into a
+    block of n indices that get permuted together, and creates a perm of length `m+n-1`.
+-/
+open Equiv
+
+/-- Extend a permutation on Fin n to a permutation on Fim (m+n+k), by acting as the identity
+ on the first m and last k elements. -/
+def PermFinPadLeftRight {n : ℕ} (p : Perm (Fin n)) (m k : ℕ) : (Perm (Fin (m + n + k))) :=
+  Perm.extendDomain p (p := fun x ↦ m ≤ x ∧ x < m + n) ⟨
+    fun x ↦ ⟨(Fin.natAdd m x).castAdd k, by simp [Fin.natAdd, Fin.addNat]⟩,
+    fun x ↦ ⟨(Fin.castLT x.1 (show x < n + m by omega)).subNat m (by simp [x.2.1]),
+      Nat.sub_lt_left_of_lt_add x.2.1 x.2.2⟩,
+    fun x ↦ by simp,
+    fun x ↦ by
+      ext
+      simp only [Fin.coe_subNat, Fin.coe_castLT, Fin.natAdd_mk, Fin.castAdd_mk]
+      omega
+    ⟩
+
+/-- PermfindPadTo is morally equivalent (`HEq`) to PermfinPadLeftRight, but with a different type.
+ It starts the permutation Sm at location k out of n, and creates a perm of length (n+m-1). -/
+@[irreducible]
+def PermFinPadTo {m : ℕ} (p : Perm (Fin m)) (n : ℕ) (k : Fin n) : Perm (Fin (n+m-1)) :=
+  have h : (k + m + (n - (k + 1))) = n + m - 1 := by
+    omega
+  h ▸ PermFinPadLeftRight p k (n-(k+1))
+
+section PermFinPadTo
+
+theorem PermFinPadTo_eq_PermFinPadLeftRight {m : ℕ} (p : Perm (Fin m)) (n : ℕ) (k) (x) {pf} :
+    (PermFinPadTo p n k ⟨x, pf⟩ : ℕ) = PermFinPadLeftRight p k (n-(k+1)) ⟨x, by omega⟩ := by
+  rw [PermFinPadTo]
+  have : n + m - 1 = ↑k + m + (n - (↑k + 1)) := by omega
+  congr! 1
+  congr!
+  simp
+
+/-- These three theorems specify the action of PermFinPadTo, based on whether the input is below,
+  within, or above the interval [m,m+n) that the permutation is mapped to -/
+theorem PermFinPadTo_eq_position {m : ℕ} (p : Perm (Fin m)) (n : ℕ) (k : Fin n) (x : Fin m) {pf} :
+    PermFinPadTo p n k ⟨k + x, pf⟩ = (k : ℕ) + (p x) := by
+  rw [PermFinPadTo_eq_PermFinPadLeftRight, PermFinPadLeftRight,
+    Equiv.Perm.extendDomain_apply_subtype]
+  · simp
+  · dsimp
+    constructor <;> omega
+
+theorem PermFinPadTo_lt_position {m : ℕ} (p : Perm (Fin m)) (n : ℕ) (k : Fin n) (x : ℕ) (h : x < k)
+    {pf} : PermFinPadTo p n k ⟨x, pf⟩ = x := by
+  rw [PermFinPadTo_eq_PermFinPadLeftRight, PermFinPadLeftRight,
+    Equiv.Perm.extendDomain_apply_not_subtype]
+  simp only [not_and, not_lt]
+  omega
+
+theorem PermFinPadTo_gt_position {m : ℕ} (p : Perm (Fin m)) (n : ℕ) (k : Fin n) (x : ℕ)
+    (h : x + 1 > k + m) {pf} : PermFinPadTo p n k ⟨x, pf⟩ = x := by
+  rw [PermFinPadTo_eq_PermFinPadLeftRight, PermFinPadLeftRight,
+    Equiv.Perm.extendDomain_apply_not_subtype]
+  simp only [not_and, not_lt]
+  omega
+
+end PermFinPadTo
+
+/-- Forward function that powers `PermFinPadAt`. Proofs should avoid unfolding into this and use
+one of the `PermFinPadAt_*_position` theorems instead.
+-/
+def PermFinPadAt_core {m n : ℕ} (p : Perm (Fin m)) (hn : 0 < n) (k : Fin m) (x : Fin (m+n-1)) :
+    Fin (m+n-1) :=
+  if h : k.1 ≤ x.1 ∧ x.1 ≤ k + n - 1 then
+    ⟨p k + x - k.1, by omega⟩
+  else (
+    let x' := if h₂ : x < k.1 then p ⟨x.1, h₂.trans k.2⟩ else p ⟨x.1 - (n-1), by omega⟩;
+    if h₃ : x' < p k then ⟨x', by omega⟩ else ⟨x'+n-1, by omega⟩
+  )
+
+theorem PermFinPadAt_core.LeftInverse {m n : ℕ} (p : Perm (Fin m)) (hn : 0 < n) (k : Fin m) :
+    Function.LeftInverse (PermFinPadAt_core p.symm hn (p k)) (PermFinPadAt_core p hn k) := by
+  intro x
+  rw [PermFinPadAt_core]
+  split
+  · suffices (k:ℕ) ≤ ↑x ∧ (x:ℕ) ≤ ↑k + n - 1 by
+      suffices h : (PermFinPadAt_core p hn k x : ℕ) = (p k) + x - k ∧ (k:ℕ) ≤ x by
+        ext
+        simp only [symm_apply_apply]
+        omega
+      simp [PermFinPadAt_core, this]
+    rename_i h₁
+    rcases h₁ with ⟨h₁,h₂⟩
+    by_contra h₃
+    rw [PermFinPadAt_core, dif_neg h₃] at h₁ h₂
+    rw [Decidable.not_and_iff_or_not_not] at h₃
+    push_neg at h₃
+    have h₄ : p ⟨x - (n-1), proof_3 hn k x⟩ ≠ p k := by
+      simpa using Fin.ne_of_val_ne (show x - (n-1) ≠ k by omega)
+    rcases h₃ with h₃|h₃
+    · simp only [dif_pos h₃] at h₁ h₂
+      split at h₁
+      <;> rename_i h₄
+      <;> simp only [h₄, ↓reduceDIte] at h₂
+      · dsimp at h₁
+        omega
+      · refine (?_:¬_) (show (p ⟨↑x, proof_2 k x (of_eq_true (eq_true h₃))⟩) = p k by omega)
+        simpa [Fin.ext_iff] using Nat.ne_of_lt h₃
+    · simp [show ¬(x:ℕ) < k by omega] at h₁ h₂
+      split at h₁
+      <;> rename_i h₄
+      <;> simp only [h₄, ↓reduceDIte] at h₂
+      <;> simp only [Fin.val_fin_le] at h₁
+      <;> omega
+  · rename_i h₁
+    rw [Decidable.not_and_iff_or_not_not] at h₁
+    push_neg at h₁
+    rcases h₁ with h₁|h₁
+    · simp only [dif_pos h₁, symm_apply_apply]
+      by_cases h₂ : (k:ℕ) ≤ x
+      · simp [PermFinPadAt_core, h₂, Nat.not_lt.mpr h₂]
+        have h₃ : ¬(x:ℕ) ≤ ↑k + n - 1 := by
+          by_contra! h₃
+          simp only [PermFinPadAt_core, h₂, Nat.not_lt.mpr h₂, h₃, true_and, ↓reduceDIte] at h₁
+          omega
+        simp only [PermFinPadAt_core, h₂, Nat.not_lt.mpr h₂, h₃, and_false, ↓reduceDIte] at h₁
+        simp only [h₃, ↓reduceDIte, and_false]
+        split at h₁
+        · rename_i h₄
+          simp only [h₄, ↓reduceDIte, Fin.eta, symm_apply_apply]
+          split
+          · exfalso
+            rename_i h₅
+            simp only [Fin.lt_def] at h₅
+            omega
+          · ext
+            dsimp
+            omega
+        · absurd h₁
+          dsimp
+          omega
+      · simp [PermFinPadAt_core, h₂, Nat.gt_of_not_le h₂]
+        split
+        · simpa using fun h ↦ (h₂ h).elim
+        · rename_i h₃
+          simp only [PermFinPadAt_core, h₂, Nat.gt_of_not_le h₂, h₃, false_and, ↓reduceDIte] at h₁
+          omega
+    · simp only [dif_neg (show ¬(PermFinPadAt_core p hn k x : ℕ) < p k by omega), symm_apply_apply]
+      by_cases h₂ : (k:ℕ) ≤ x
+      · simp only [PermFinPadAt_core, h₂, true_and, dif_neg (Nat.not_lt.mpr h₂)]
+        have h₃ : ¬(x:ℕ) ≤ ↑k + n - 1 := by
+          by_contra! h₃
+          simp only [PermFinPadAt_core, h₂, Nat.not_lt.mpr h₂, h₃, true_and, ↓reduceDIte] at h₁
+          omega
+        simp only [PermFinPadAt_core, h₂, Nat.not_lt.mpr h₂, h₃, and_false, ↓reduceDIte] at h₁
+        simp only [dif_neg h₃]
+        split at h₁
+        · absurd h₁
+          dsimp
+          omega
+        · rename_i h₄
+          simp only [dif_neg h₄]
+          generalize_proofs pf1 pf2
+          have h₆ : (⟨↑(p ⟨↑x - (n - 1), pf1⟩) + n - 1 - (n - 1), pf2⟩ : Fin m) =
+              p ⟨↑x - (n - 1), pf1⟩ := by
+            ext
+            dsimp
+            omega
+          split
+          · exfalso
+            rename_i h₅
+            simp only [h₆, symm_apply_apply, Fin.lt_def] at h₅
+            omega
+          · rename_i h₅
+            simp only [h₆, symm_apply_apply, Fin.ext_iff]
+            omega
+      · simp only [PermFinPadAt_core, h₂, false_and, ↓reduceDIte, Nat.gt_of_not_le h₂]
+        split
+        · rename_i h₃
+          simp only [h₂, false_and]
+          simp only [PermFinPadAt_core, h₂, false_and, ↓reduceDIte, Nat.gt_of_not_le h₂, h₃] at h₁
+          omega
+        · rename_i h₃
+          simp only [PermFinPadAt_core, h₂, Nat.gt_of_not_le h₂, h₃, false_and, ↓reduceDIte] at h₁
+          dsimp
+          generalize_proofs pf1 pf2 pf3 pf4
+          have h₄ : (⟨(p ⟨↑x, pf1⟩) + n - 1 - (n - 1), pf2⟩ : Fin m) = p ⟨↑x, pf1⟩ := by
+            ext
+            dsimp
+            omega
+          simpa [h₄] using fun h ↦ (h₂ h).elim
+
+/-- PermfindPadAt takes the permutation in Sm and "expands" location k out of m, into a block
+ of n indices that get permuted together, and creates a perm of length (m+n-1). Proofs should
+ avoid unfolding this and use one of the `PermFinPadAt_*_position` theorems instead. -/
+@[irreducible]
+def PermFinPadAt {n m : ℕ} (p : Perm (Fin m)) (hn : 0 < n) (k : Fin m) : Perm (Fin (m+n-1)) :=
+  ⟨PermFinPadAt_core p hn k, PermFinPadAt_core p.symm hn (p k),
+    PermFinPadAt_core.LeftInverse p hn k,
+  by
+    apply Function.LeftInverse.rightInverse_of_card_le (PermFinPadAt_core.LeftInverse p hn k)
+    simp only [Fintype.card_fin, le_refl]⟩
+
+section PermFinPadAt
+
+variable {n m : ℕ} (p : Perm (Fin n)) (h : 0 < m) (k : Fin n) (x : Fin n)
+
+theorem PermFinPadAt_symm : (PermFinPadAt p h k).symm = PermFinPadAt p.symm h (p k) := by
+  ext
+  simp [PermFinPadAt]
+
+/-- These five theorems fully specify the functionality of PermFinPadAt, based on whether x is
+ equal to, less than, or greater than k; and in the latter two cases, whether `s x` is greater
+ or less than `s k`. -/
+theorem PermFinPadAt_eq_position (w : Fin m) {pf} :
+    PermFinPadAt p h k ⟨k + w, pf⟩ = (p k : ℕ) + w := by
+  have h₂ : (k:ℕ) + w ≤ k + m - 1 := by omega
+  have h₃ : (p k) + (k + w : ℕ) - k = (p k) + ↑w := by omega
+  simp [PermFinPadAt, PermFinPadAt_core,  h₂, h₃]
+
+theorem PermFinPadAt_lt_lt_position (h₁ : x < k) (h₂ : p x < p k) {pf} :
+    PermFinPadAt p h k ⟨x, pf⟩ = (p x : ℕ) := by
+  simp [PermFinPadAt, PermFinPadAt_core, h₁, Nat.not_le_of_lt h₁, h₂]
+
+theorem PermFinPadAt_lt_gt_position (h₁ : x < k) (h₂ : p x > p k) {pf} :
+    PermFinPadAt p h k ⟨x, pf⟩ = (p x + m - 1: ℕ) := by
+  simp [PermFinPadAt, PermFinPadAt_core, h₁, Nat.not_le_of_lt h₁, Fin.lt_asymm h₂]
+
+theorem PermFinPadAt_gt_lt_position (h₁ : x > k) (h₂ : p x < p k) {pf} :
+    PermFinPadAt p h k ⟨x + m - 1, pf⟩ = (p x : ℕ) := by
+  have h₃ : ¬(↑x + m ≤ ↑k + m - 1 + 1) := by omega
+  have h₄ : ¬(x + m - 1 < k) := by omega
+  have h₅ : ↑x + m - 1 - (m - 1) = x := by omega
+  simp [PermFinPadAt, PermFinPadAt_core, h₂, h₃, h₄, h₅]
+
+theorem PermFinPadAt_gt_gt_position (h₁ : x > k) (h₂ : p x > p k) {pf} :
+    PermFinPadAt p h k ⟨x + m - 1, pf⟩ = (p x + m - 1 : ℕ) := by
+  have h₃ : ¬(↑x + m ≤ k + m - 1 + 1) := by omega
+  have h₄ : ¬(↑x + m - 1 < k) := by omega
+  have h₅ : ↑x + m - 1 - (m - 1) = x := by omega
+  simp [PermFinPadAt, PermFinPadAt_core, Fin.lt_asymm h₂, h₃, h₄, h₅]
+
+end PermFinPadAt

--- a/Mathlib/Algebra/Operad/Operad.lean
+++ b/Mathlib/Algebra/Operad/Operad.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2024 Alex Meiburg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Meiburg
+-/
+import Mathlib.Algebra.Operad.Basic
+import Mathlib.Algebra.Operad.Perm
+import Mathlib.GroupTheory.Perm.Basic
+
+/-! Defines `Operad` and `SymmOperad`. An `Operad` is a ℕ-graded set of operations that are
+  closed under composition, with an identity, that obey the "natural" commutative and associative
+  constraints - the ones satisfied by composition of arbitrary multi-argument functions.
+
+  A `SymmOperad` is an `Operad` equipped with a `MulAction` by `Perm (Fin n)` for all n, that
+  rearrange the arguments in the natural way.
+-/
+
+section Operad
+
+/-- An `Operad` is a ℕ-graded set of operations that are closed under composition and
+  with an identity. The composition operation has to be appropriately associative and
+  commutative:
+  - Composing a into b and then into c is assocative as to the order of composition.
+  - Composing a and b into two different arguments of c is commutative as to which is
+    composed in first.
+
+  Operads are sometimes defined instead with "superposition" as the basic operation, where
+  all n arguments are composed at once instead of just one. This is an equivalent structure,
+  as superposition can be built from progressively composing each in and using identity in
+  the other arguments. This notion of superposition is rather unwieldly in Lean, since
+  the *type* of the result is the sum of the arities of all the arguments, and associativity
+  laws require statements about partial sums of lists of arities. Also note this kind of
+  superposition is distinct from `Superposable`, which combines the inputs, instead of adding
+  the arities.
+  -/
+class Operad (A) extends MultiComposable A, OneGradedOne A where
+  /-- The identity element 'one' doesn't change under left composition. -/
+  id_left (a : Sigma A) : 1 ∘[0] a = a
+  /-- The identity element 'one' doesn't change under right composition. -/
+  id_right (a : Sigma A) (p : Fin a.fst) : a ∘[p] 1 = a
+  /-- Composing f3 into f2 and then into f1 is associative. -/
+  assoc (a b c : Sigma A) (p1 : Fin a.fst) (p2 : Fin b.fst) :
+    a ∘[p1] (b ∘[p2] c) = (a ∘[p1] b) ∘[ p1.hAdd p2 ] c
+  /-- Composing argument into two different holes is a right-commutative operation. This statement
+   assumes that p1 is less than p2; this is necessary because the indices get shifted over. -/
+  comm {a : Sigma A} (b c : Sigma A) {p1 p2 : Fin a.fst} (hp : p1.val < p2.val) :
+    let p1' : Fin (a.fst + c.fst - 1) := ⟨p1, by omega⟩;
+    let p2' : Fin (a.fst + b.fst - 1) := ⟨p2 + b.fst - 1, by omega⟩;
+    (a ∘[p1] b) ∘[ p2' ] c = (a ∘[p2] c) ∘[ p1' ] b
+
+variable {A} [Operad A]
+
+@[simp]
+theorem id_composeAt (a : Sigma A) : 1 ∘[0] a = a :=
+  Operad.id_left a
+
+@[simp]
+theorem composeAt_id (a : Sigma A) (p : Fin a.fst) : a ∘[p] 1 = a :=
+  Operad.id_right a p
+
+/-- Composition in an `Operad` is associative, as long as they go into each other's slots. -/
+theorem composeAt_assoc (a b c : Sigma A) (p1 : Fin a.fst) (p2 : Fin b.fst) :
+    a ∘[p1] (b ∘[p2] c) = (a ∘[p1] b) ∘[ p1.hAdd p2 ] c :=
+  Operad.assoc a b c p1 p2
+
+/-- Alias for `composeAt_assoc` where the arities are separate parameters. -/
+theorem composeAt_assoc_Fin {i j k : ℕ} (a : A i) (b : A j) (c : A k) (p1 : Fin i) (p2 : Fin j) :
+    ⟨i,a⟩ ∘[p1] (⟨j,b⟩ ∘[p2] ⟨k,c⟩) = (⟨i,a⟩ ∘[p1] ⟨j,b⟩) ∘[ p1.hAdd p2 ] ⟨k,c⟩ :=
+  Operad.assoc ⟨i,a⟩ ⟨j,b⟩ ⟨k,c⟩ p1 p2
+
+/-- Composition on the right in an `Operad` commutes, as long as the two elements go into
+ different slots. This version takes the two "left" slots and computes the other two. -/
+theorem composeAt_comm_swap (a b c : Sigma A) {p1 p2 : Fin a.fst} (hp : p1.val < p2.val) :
+    let p1' : Fin (a.fst + c.fst - 1) := ⟨p1, by omega⟩;
+    let p2' : Fin (a.fst + b.fst - 1) := ⟨p2 + b.fst - 1, by omega⟩;
+    (a ∘[p1] b) ∘[ p2' ] c = (a ∘[p2] c) ∘[ p1' ] b :=
+  Operad.comm b c hp
+
+/-- Like `composeAt_comm`, but with all four slot numbers as separate parameters. -/
+theorem composeAt_comm_four (a b c : Sigma A) {p1 p2 : Fin a.fst}
+  {p3 : Fin (a.fst + c.fst - 1)} {p4 : Fin (a.fst + b.fst - 1)}
+  (hp12 : p1.val < p2) (hp31 : p3.val = p1) (hp42 : p4.val = p2 + b.fst - 1) :
+    (a ∘[p1] b) ∘[ p4 ] c = (a ∘[p2] c) ∘[ p3 ] b := by
+  convert Operad.comm b c hp12
+
+/-- Alias for `composeAt_comm_four` where the arities are separate parameters. -/
+theorem composeAt_comm_Fin {i j k : ℕ} (a : A i) (b : A j) (c : A k) {p1 p2 : Fin i}
+  {p3 : Fin (i + k - 1)} {p4 : Fin (i + j - 1)}
+  (hp12 : p1.val < p2) (hp31 : p3.val = p1) (hp42 : p4.val = p2 + j - 1) :
+    (⟨i,a⟩ ∘[p1] ⟨j,b⟩) ∘[ p4 ] ⟨k,c⟩ = (⟨i,a⟩ ∘[p2] ⟨k,c⟩) ∘[ p3 ] ⟨j,b⟩ :=
+  composeAt_comm_four ⟨i,a⟩ ⟨j,b⟩ ⟨k,c⟩ hp12 hp31 hp42
+
+/-- Composition on the right in an `Operad` commutes, as long as the two elements go into
+ different slots. This version rewrites from the LHS to the RHS. -/
+theorem composeAt_comm (a b c : Sigma A) {p1 : Fin a.fst} {p2 : Fin (a.fst + b.fst - 1)}
+    (hp : p1 + b.fst < p2 + 1) :
+    (a ∘[p1] b) ∘[p2] c = (a ∘[⟨p2 + 1 - b.fst, by omega⟩] c) ∘[@Fin.mk (_-1) p1 (by omega)] b := by
+  apply composeAt_comm_four a b c <;> dsimp <;> omega
+
+end Operad
+
+section SymmOperad
+
+open Equiv
+
+/-- A symmetric operad is an `Operad` that admits a permutation operation on arguments, with
+ appropriate action on resulting compositions. -/
+class SymmOperad (A) extends Operad A, SigmaMulAction (Perm <| Fin ·) A where
+  /-- Permutations on the left side of function composition permute where it gets composed. -/
+  perm_left {n m : ℕ} (s : Perm (Fin n)) (k : Fin n) (hm : 0 < m) (x : A n) (y : A m) :
+    s • x ∘⟨k⟩ y = PermFinPadAt s hm (s.symm k) • (x ∘⟨s.symm k⟩ y)
+  /-- Permutations on the right side of function composition extend to a
+    permutation of the whole object. -/
+  perm_right {n m : ℕ} (s : Perm (Fin m)) (k : Fin n) (x : A n) (y : A m) :
+    x ∘⟨k⟩ s • y = PermFinPadTo s n k • (x ∘⟨k⟩ y)
+
+variable {A} [SymmOperad A]
+
+--Need this as a hint to find the SMul instance
+instance : ∀ (i : ℕ), MulAction (Perm (Fin i)) (A i) :=
+  SigmaMulAction.act_at
+
+open MultiComposable
+
+/-- Alias of `SymmOperad.perm_left` -/
+theorem SymmOperad.smul_compose {n m : ℕ} (s : Perm (Fin n)) (k : Fin n)
+    (hm : 0 < m) (x : A n) (y : A m) :
+    s • x ∘⟨k⟩ y = PermFinPadAt s hm (s.symm k) • (x ∘⟨s.symm k⟩ y) :=
+  SymmOperad.perm_left s k hm x y
+
+/-- Alias of `SymmOperad.perm_right` -/
+theorem SymmOperad.compose_smul {n m : ℕ} (s : Perm (Fin m)) (k : Fin n) (x : A n) (y : A m) :
+    x ∘⟨k⟩ s • y = PermFinPadTo s n k • (x ∘⟨k⟩ y):=
+  SymmOperad.perm_right s k x y
+
+end SymmOperad

--- a/Mathlib/Algebra/Operad/Perm.lean
+++ b/Mathlib/Algebra/Operad/Perm.lean
@@ -1,0 +1,255 @@
+/-
+Copyright (c) 2024 Alex Meiburg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Meiburg
+-/
+import Mathlib.Data.Fin.Basic
+import Mathlib.Data.Fintype.Card
+
+/-!
+This file defines various operations on permutations, necessary for working with `SymmOperad`s.
+They seem unlikely to be of much use elsewhere, hence why they are all under the Operad folder.
+
+Definitions:
+  - `PermFinPadLeftRight`: Extend a permutation on `Fin n` to a permutation on `Fim (m+n+k)`,
+    by acting as the identity on the first m and last k elements.
+  - `PermFinPadTo`: HEq to `PermfinPadLeftRight`, but with a different type. It
+    starts the permutation on `Fin m` at location k out of n, and creates a perm of length `n+m-1`.
+  - `PermFinPadAt`: Takes the permutation on `Fim m` and "expands" location k out of m, into a
+    block of n indices that get permuted together, and creates a perm of length `m+n-1`.
+-/
+open Equiv
+
+/-- Extend a permutation on Fin n to a permutation on Fim (m+n+k), by acting as the identity
+ on the first m and last k elements. -/
+def PermFinPadLeftRight {n : ℕ} (p : Perm (Fin n)) (m k : ℕ) : (Perm (Fin (m + n + k))) :=
+  Perm.extendDomain p (p := fun x ↦ m ≤ x ∧ x < m + n) ⟨
+    fun x ↦ ⟨(Fin.natAdd m x).castAdd k, by simp [Fin.natAdd, Fin.addNat]⟩,
+    fun x ↦ ⟨(Fin.castLT x.1 (show x < n + m by omega)).subNat m (by simp [x.2.1]),
+      Nat.sub_lt_left_of_lt_add x.2.1 x.2.2⟩,
+    fun x ↦ by simp,
+    fun x ↦ by
+      ext
+      simp only [Fin.coe_subNat, Fin.coe_castLT, Fin.natAdd_mk, Fin.castAdd_mk]
+      omega
+    ⟩
+
+/-- PermfindPadTo is morally equivalent (`HEq`) to PermfinPadLeftRight, but with a different type.
+ It starts the permutation Sm at location k out of n, and creates a perm of length (n+m-1). -/
+@[irreducible]
+def PermFinPadTo {m : ℕ} (p : Perm (Fin m)) (n : ℕ) (k : Fin n) : Perm (Fin (n+m-1)) :=
+  have h : (k + m + (n - (k + 1))) = n + m - 1 := by
+    omega
+  h ▸ PermFinPadLeftRight p k (n-(k+1))
+
+section PermFinPadTo
+
+theorem PermFinPadTo_eq_PermFinPadLeftRight {m : ℕ} (p : Perm (Fin m)) (n : ℕ) (k) (x) {pf} :
+    (PermFinPadTo p n k ⟨x, pf⟩ : ℕ) = PermFinPadLeftRight p k (n-(k+1)) ⟨x, by omega⟩ := by
+  rw [PermFinPadTo]
+  have : n + m - 1 = ↑k + m + (n - (↑k + 1)) := by omega
+  congr! 1
+  congr!
+  simp
+
+/-- These three theorems specify the action of PermFinPadTo, based on whether the input is below,
+  within, or above the interval [m,m+n) that the permutation is mapped to -/
+theorem PermFinPadTo_eq_position {m : ℕ} (p : Perm (Fin m)) (n : ℕ) (k : Fin n) (x : Fin m) {pf} :
+    PermFinPadTo p n k ⟨k + x, pf⟩ = (k : ℕ) + (p x) := by
+  rw [PermFinPadTo_eq_PermFinPadLeftRight, PermFinPadLeftRight,
+    Equiv.Perm.extendDomain_apply_subtype]
+  · simp
+  · dsimp
+    constructor <;> omega
+
+theorem PermFinPadTo_lt_position {m : ℕ} (p : Perm (Fin m)) (n : ℕ) (k : Fin n) (x : ℕ) (h : x < k)
+    {pf} : PermFinPadTo p n k ⟨x, pf⟩ = x := by
+  rw [PermFinPadTo_eq_PermFinPadLeftRight, PermFinPadLeftRight,
+    Equiv.Perm.extendDomain_apply_not_subtype]
+  simp only [not_and, not_lt]
+  omega
+
+theorem PermFinPadTo_gt_position {m : ℕ} (p : Perm (Fin m)) (n : ℕ) (k : Fin n) (x : ℕ)
+    (h : x + 1 > k + m) {pf} : PermFinPadTo p n k ⟨x, pf⟩ = x := by
+  rw [PermFinPadTo_eq_PermFinPadLeftRight, PermFinPadLeftRight,
+    Equiv.Perm.extendDomain_apply_not_subtype]
+  simp only [not_and, not_lt]
+  omega
+
+end PermFinPadTo
+
+/-- Forward function that powers `PermFinPadAt`. Proofs should avoid unfolding into this and use
+one of the `PermFinPadAt_*_position` theorems instead.
+-/
+def PermFinPadAt_core {m n : ℕ} (p : Perm (Fin m)) (hn : 0 < n) (k : Fin m) (x : Fin (m+n-1)) :
+    Fin (m+n-1) :=
+  if h : k.1 ≤ x.1 ∧ x.1 ≤ k + n - 1 then
+    ⟨p k + x - k.1, by omega⟩
+  else (
+    let x' := if h₂ : x < k.1 then p ⟨x.1, h₂.trans k.2⟩ else p ⟨x.1 - (n-1), by omega⟩;
+    if h₃ : x' < p k then ⟨x', by omega⟩ else ⟨x'+n-1, by omega⟩
+  )
+
+theorem PermFinPadAt_core.LeftInverse {m n : ℕ} (p : Perm (Fin m)) (hn : 0 < n) (k : Fin m) :
+    Function.LeftInverse (PermFinPadAt_core p.symm hn (p k)) (PermFinPadAt_core p hn k) := by
+  intro x
+  rw [PermFinPadAt_core]
+  split
+  · suffices (k:ℕ) ≤ ↑x ∧ (x:ℕ) ≤ ↑k + n - 1 by
+      suffices h : (PermFinPadAt_core p hn k x : ℕ) = (p k) + x - k ∧ (k:ℕ) ≤ x by
+        ext
+        simp only [symm_apply_apply]
+        omega
+      simp [PermFinPadAt_core, this]
+    rename_i h₁
+    rcases h₁ with ⟨h₁,h₂⟩
+    by_contra h₃
+    rw [PermFinPadAt_core, dif_neg h₃] at h₁ h₂
+    rw [Decidable.not_and_iff_or_not_not] at h₃
+    push_neg at h₃
+    have h₄ : p ⟨x - (n-1), proof_3 hn k x⟩ ≠ p k := by
+      simpa using Fin.ne_of_val_ne (show x - (n-1) ≠ k by omega)
+    rcases h₃ with h₃|h₃
+    · simp only [dif_pos h₃] at h₁ h₂
+      split at h₁
+      <;> rename_i h₄
+      <;> simp only [h₄, ↓reduceDIte] at h₂
+      · dsimp at h₁
+        omega
+      · refine (?_:¬_) (show (p ⟨↑x, proof_2 k x (of_eq_true (eq_true h₃))⟩) = p k by omega)
+        simpa [Fin.ext_iff] using Nat.ne_of_lt h₃
+    · simp [show ¬(x:ℕ) < k by omega] at h₁ h₂
+      split at h₁
+      <;> rename_i h₄
+      <;> simp only [h₄, ↓reduceDIte] at h₂
+      <;> simp only [Fin.val_fin_le] at h₁
+      <;> omega
+  · rename_i h₁
+    rw [Decidable.not_and_iff_or_not_not] at h₁
+    push_neg at h₁
+    rcases h₁ with h₁|h₁
+    · simp only [dif_pos h₁, symm_apply_apply]
+      by_cases h₂ : (k:ℕ) ≤ x
+      · simp [PermFinPadAt_core, h₂, Nat.not_lt.mpr h₂]
+        have h₃ : ¬(x:ℕ) ≤ ↑k + n - 1 := by
+          by_contra! h₃
+          simp only [PermFinPadAt_core, h₂, Nat.not_lt.mpr h₂, h₃, true_and, ↓reduceDIte] at h₁
+          omega
+        simp only [PermFinPadAt_core, h₂, Nat.not_lt.mpr h₂, h₃, and_false, ↓reduceDIte] at h₁
+        simp only [h₃, ↓reduceDIte, and_false]
+        split at h₁
+        · rename_i h₄
+          simp only [h₄, ↓reduceDIte, Fin.eta, symm_apply_apply]
+          split
+          · exfalso
+            rename_i h₅
+            simp only [Fin.lt_def] at h₅
+            omega
+          · ext
+            dsimp
+            omega
+        · absurd h₁
+          dsimp
+          omega
+      · simp [PermFinPadAt_core, h₂, Nat.gt_of_not_le h₂]
+        split
+        · simpa using fun h ↦ (h₂ h).elim
+        · rename_i h₃
+          simp only [PermFinPadAt_core, h₂, Nat.gt_of_not_le h₂, h₃, false_and, ↓reduceDIte] at h₁
+          omega
+    · simp only [dif_neg (show ¬(PermFinPadAt_core p hn k x : ℕ) < p k by omega), symm_apply_apply]
+      by_cases h₂ : (k:ℕ) ≤ x
+      · simp only [PermFinPadAt_core, h₂, true_and, dif_neg (Nat.not_lt.mpr h₂)]
+        have h₃ : ¬(x:ℕ) ≤ ↑k + n - 1 := by
+          by_contra! h₃
+          simp only [PermFinPadAt_core, h₂, Nat.not_lt.mpr h₂, h₃, true_and, ↓reduceDIte] at h₁
+          omega
+        simp only [PermFinPadAt_core, h₂, Nat.not_lt.mpr h₂, h₃, and_false, ↓reduceDIte] at h₁
+        simp only [dif_neg h₃]
+        split at h₁
+        · absurd h₁
+          dsimp
+          omega
+        · rename_i h₄
+          simp only [dif_neg h₄]
+          generalize_proofs pf1 pf2
+          have h₆ : (⟨↑(p ⟨↑x - (n - 1), pf1⟩) + n - 1 - (n - 1), pf2⟩ : Fin m) =
+              p ⟨↑x - (n - 1), pf1⟩ := by
+            ext
+            dsimp
+            omega
+          split
+          · exfalso
+            rename_i h₅
+            simp only [h₆, symm_apply_apply, Fin.lt_def] at h₅
+            omega
+          · rename_i h₅
+            simp only [h₆, symm_apply_apply, Fin.ext_iff]
+            omega
+      · simp only [PermFinPadAt_core, h₂, false_and, ↓reduceDIte, Nat.gt_of_not_le h₂]
+        split
+        · rename_i h₃
+          simp only [h₂, false_and]
+          simp only [PermFinPadAt_core, h₂, false_and, ↓reduceDIte, Nat.gt_of_not_le h₂, h₃] at h₁
+          omega
+        · rename_i h₃
+          simp only [PermFinPadAt_core, h₂, Nat.gt_of_not_le h₂, h₃, false_and, ↓reduceDIte] at h₁
+          dsimp
+          generalize_proofs pf1 pf2 pf3 pf4
+          have h₄ : (⟨(p ⟨↑x, pf1⟩) + n - 1 - (n - 1), pf2⟩ : Fin m) = p ⟨↑x, pf1⟩ := by
+            ext
+            dsimp
+            omega
+          simpa [h₄] using fun h ↦ (h₂ h).elim
+
+/-- PermfindPadAt takes the permutation in Sm and "expands" location k out of m, into a block
+ of n indices that get permuted together, and creates a perm of length (m+n-1). Proofs should
+ avoid unfolding this and use one of the `PermFinPadAt_*_position` theorems instead. -/
+@[irreducible]
+def PermFinPadAt {n m : ℕ} (p : Perm (Fin m)) (hn : 0 < n) (k : Fin m) : Perm (Fin (m+n-1)) :=
+  ⟨PermFinPadAt_core p hn k, PermFinPadAt_core p.symm hn (p k),
+    PermFinPadAt_core.LeftInverse p hn k,
+  by
+    apply Function.LeftInverse.rightInverse_of_card_le (PermFinPadAt_core.LeftInverse p hn k)
+    simp only [Fintype.card_fin, le_refl]⟩
+
+section PermFinPadAt
+
+variable {n m : ℕ} (p : Perm (Fin n)) (h : 0 < m) (k : Fin n) (x : Fin n)
+
+theorem PermFinPadAt_symm : (PermFinPadAt p h k).symm = PermFinPadAt p.symm h (p k) := by
+  ext
+  simp [PermFinPadAt]
+
+/-- These five theorems fully specify the functionality of PermFinPadAt, based on whether x is
+ equal to, less than, or greater than k; and in the latter two cases, whether `s x` is greater
+ or less than `s k`. -/
+theorem PermFinPadAt_eq_position (w : Fin m) {pf} :
+    PermFinPadAt p h k ⟨k + w, pf⟩ = (p k : ℕ) + w := by
+  have h₂ : (k:ℕ) + w ≤ k + m - 1 := by omega
+  have h₃ : (p k) + (k + w : ℕ) - k = (p k) + ↑w := by omega
+  simp [PermFinPadAt, PermFinPadAt_core,  h₂, h₃]
+
+theorem PermFinPadAt_lt_lt_position (h₁ : x < k) (h₂ : p x < p k) {pf} :
+    PermFinPadAt p h k ⟨x, pf⟩ = (p x : ℕ) := by
+  simp [PermFinPadAt, PermFinPadAt_core, h₁, Nat.not_le_of_lt h₁, h₂]
+
+theorem PermFinPadAt_lt_gt_position (h₁ : x < k) (h₂ : p x > p k) {pf} :
+    PermFinPadAt p h k ⟨x, pf⟩ = (p x + m - 1: ℕ) := by
+  simp [PermFinPadAt, PermFinPadAt_core, h₁, Nat.not_le_of_lt h₁, Fin.lt_asymm h₂]
+
+theorem PermFinPadAt_gt_lt_position (h₁ : x > k) (h₂ : p x < p k) {pf} :
+    PermFinPadAt p h k ⟨x + m - 1, pf⟩ = (p x : ℕ) := by
+  have h₃ : ¬(↑x + m ≤ ↑k + m - 1 + 1) := by omega
+  have h₄ : ¬(x + m - 1 < k) := by omega
+  have h₅ : ↑x + m - 1 - (m - 1) = x := by omega
+  simp [PermFinPadAt, PermFinPadAt_core, h₂, h₃, h₄, h₅]
+
+theorem PermFinPadAt_gt_gt_position (h₁ : x > k) (h₂ : p x > p k) {pf} :
+    PermFinPadAt p h k ⟨x + m - 1, pf⟩ = (p x + m - 1 : ℕ) := by
+  have h₃ : ¬(↑x + m ≤ k + m - 1 + 1) := by omega
+  have h₄ : ¬(↑x + m - 1 < k) := by omega
+  have h₅ : ↑x + m - 1 - (m - 1) = x := by omega
+  simp [PermFinPadAt, PermFinPadAt_core, Fin.lt_asymm h₂, h₃, h₄, h₅]
+
+end PermFinPadAt

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -513,13 +513,6 @@ theorem val_hAdd (x : Fin n) (y : Fin m) : (x.hAdd y).val = x.val + y.val :=
 theorem hAdd_comm (x : Fin n) (y : Fin m) : (x.hAdd y).val = (y.hAdd x).val :=
   (x.val_hAdd y).trans <| (x.val.add_comm _).trans <| y.val_hAdd x
 
-/-- `Fin.hAdd` with a Nat on the right is `Fin.addNat`. -/
-@[simp]
-theorem hAdd_Nat_eq_addNat (x : Fin n) (y : ℕ) :
-    (x.hAdd y : Fin (n + (y+1)-1)) = x.addNat y := by
-  ext
-  simp
-
 /-- `Fin.hAdd` with `Fin.last` on the right is `Fin.addNat`. -/
 @[simp]
 theorem hAdd_last_eq_addNat (x : Fin n) (y : ℕ) :

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -500,6 +500,47 @@ lemma natCast_strictMono (hbn : b ≤ n) (hab : a < b) : (a : Fin (n + 1)) < b :
 
 end OfNatCoe
 
+section hAdd
+
+/-- Add two Fin's of different ranges, growing the range appropriately. -/
+def hAdd (x : Fin n) (y : Fin m) : Fin (n+m-1) :=
+  ⟨x.val + y.val, Nat.lt_sub_of_add_lt (add_succ_lt_add x.2 y.2)⟩
+
+@[simp]
+theorem val_hAdd (x : Fin n) (y : Fin m) : (x.hAdd y).val = x.val + y.val :=
+  rfl
+
+theorem hAdd_comm (x : Fin n) (y : Fin m) : (x.hAdd y).val = (y.hAdd x).val :=
+  (x.val_hAdd y).trans <| (x.val.add_comm _).trans <| y.val_hAdd x
+
+/-- `Fin.hAdd` with a Nat on the right is `Fin.addNat`. -/
+@[simp]
+theorem hAdd_Nat_eq_addNat (x : Fin n) (y : ℕ) :
+    (x.hAdd y : Fin (n + (y+1)-1)) = x.addNat y := by
+  ext
+  simp
+
+/-- `Fin.hAdd` with `Fin.last` on the right is `Fin.addNat`. -/
+@[simp]
+theorem hAdd_last_eq_addNat (x : Fin n) (y : ℕ) :
+    x.hAdd (Fin.last y) = x.addNat y := by
+  rfl
+
+/-- `Fin.hAdd` with 0 on the right is `Fin.castAdd`. -/
+@[simp]
+theorem hAdd_zero_eq_castNat (x : Fin n) (y : ℕ) :
+    (x.hAdd 0 : Fin (n + (y+1)-1)) = x.castAdd y := by
+  rfl
+
+/-- `Fin.hAdd` with 0 on the left is `Fin.castLE`. -/
+@[simp]
+theorem zero_hAdd_eq_castNat (x : Fin n) (y : ℕ) [NeZero y] :
+    hAdd 0 x = x.castLE (y.add_comm n ▸ y.add_sub_assoc size_positive' n ▸ le_add_right n _) := by
+  ext
+  simp
+
+end hAdd
+
 end Add
 
 section Succ


### PR DESCRIPTION
Defines `Operad` and `SymmOperad`. The latter is symmetric operads. Also defines `Fin.hAdd : (Fin n) -> (Fin m) -> (Fin (n+m-1)`, which is a needed helper here; it has some simp lemmas associated.

Part of #20051 .

---

- [x] depends on: #20133 [basics and notations]
- [x] depends on: #20134 [permutations]

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
