### PR TITLE
[Merged by Bors] - feat(GroupTheory/SpecificGroups/ZGroup): Finite Z-groups are solvable

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -5,6 +5,7 @@ Authors: Thomas Browning
 -/
 import Mathlib.Algebra.Squarefree.Basic
 import Mathlib.GroupTheory.Nilpotent
+import Mathlib.GroupTheory.Transfer
 
 /-!
 # Z-Groups
@@ -65,6 +66,32 @@ theorem of_surjective [Finite G] [hG : IsZGroup G] (hf : Function.Surjective f) 
 
 instance [Finite G] [IsZGroup G] (H : Subgroup G) [H.Normal] : IsZGroup (G ⧸ H) :=
   of_surjective (QuotientGroup.mk'_surjective H)
+
+section Solvable
+
+variable (G) in
+theorem commutator_lt [Finite G] [IsZGroup G] [Nontrivial G] : commutator G < ⊤ := by
+  let p := (Nat.card G).minFac
+  have hp : p.Prime := Nat.minFac_prime Finite.one_lt_card.ne'
+  have := Fact.mk hp
+  let P : Sylow p G := default
+  have hP := isZGroup p hp P
+  let f := MonoidHom.transferSylow P (hP.normalizer_le_centralizer rfl)
+  refine lt_of_le_of_lt (Abelianization.commutator_subset_ker f) ?_
+  have h := P.ne_bot_of_dvd_card (Nat.card G).minFac_dvd
+  contrapose! h
+  rw [← Subgroup.isComplement'_top_left, ← (not_lt_top_iff.mp h)]
+  exact hP.isComplement' rfl
+
+instance [Finite G] [IsZGroup G] : IsSolvable G := by
+  rw [isSolvable_iff_commutator_lt]
+  intro H h
+  rw [← H.nontrivial_iff_ne_bot] at h
+  rw [← H.range_subtype, MonoidHom.range_eq_map, ← Subgroup.map_commutator,
+    Subgroup.map_subtype_lt_map_subtype]
+  exact commutator_lt H
+
+end Solvable
 
 section Nilpotent
 


### PR DESCRIPTION
This PR shows that finite Z-groups are solvable. A Z-group is a group whose Sylow subgroups are all cyclic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
