### PR TITLE
[Merged by Bors] - feat(GroupTheory/SpecificGroups/ZGroup): Extension of coprime Z-groups is a Z-group

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Ker.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Ker.lean
@@ -484,6 +484,10 @@ theorem map_injective_of_ker_le {H K : Subgroup G} (hH : f.ker ≤ H) (hK : f.ke
   rwa [comap_map_eq, comap_map_eq, sup_of_le_left hH, sup_of_le_left hK] at hf
 
 @[to_additive]
+theorem ker_subgroupMap : (f.subgroupMap H).ker = f.ker.subgroupOf H :=
+  ext fun _ ↦ Subtype.ext_iff
+
+@[to_additive]
 theorem closure_preimage_eq_top (s : Set G) : closure ((closure s).subtype ⁻¹' s) = ⊤ := by
   apply map_injective (closure s).subtype_injective
   rw [MonoidHom.map_closure, ← MonoidHom.range_eq_map, range_subtype,

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -285,8 +285,8 @@ theorem index_dvd_card : H.index ∣ Nat.card G :=
   ⟨Nat.card H, H.index_mul_card.symm⟩
 
 @[to_additive]
-theorem relindex_dvd_card : H.relindex K ∣ Nat.card G :=
-  (H.subgroupOf K).index_dvd_card.trans K.card_subgroup_dvd_card
+theorem relindex_dvd_card : H.relindex K ∣ Nat.card K :=
+  (H.subgroupOf K).index_dvd_card
 
 variable {H K L}
 

--- a/Mathlib/GroupTheory/PGroup.lean
+++ b/Mathlib/GroupTheory/PGroup.lean
@@ -309,6 +309,32 @@ theorem disjoint_of_ne (p₁ p₂ : ℕ) [hp₁ : Fact p₁.Prime] [hp₂ : Fact
   · simpa using hn₁
   · exact absurd (eq_of_prime_pow_eq hp₁.out.prime hp₂.out.prime hn₁ this) hne
 
+theorem le_or_disjoint_of_coprime [hp : Fact p.Prime] {P : Subgroup G} (hP : IsPGroup p P)
+    {H : Subgroup G} [H.Normal] (h_cop : (Nat.card H).Coprime H.index) :
+    P ≤ H ∨ Disjoint H P := by
+  by_cases h1 : Nat.card H = 0
+  · rw [h1, Nat.coprime_zero_left, Subgroup.index_eq_one] at h_cop
+    rw [h_cop]
+    exact Or.inl le_top
+  by_cases h2 : H.index = 0
+  · rw [h2, Nat.coprime_zero_right, Subgroup.card_eq_one] at h_cop
+    rw [h_cop]
+    exact Or.inr disjoint_bot_left
+  have : Finite G := by
+    apply Nat.finite_of_card_ne_zero
+    rw [← H.card_mul_index]
+    exact mul_ne_zero h1 h2
+  have h3 : (Nat.card H).Coprime (Nat.card P) ∨ H.index.Coprime (Nat.card P) := by
+    obtain ⟨k, hk⟩ := hP.exists_card_eq
+    refine hk ▸ Or.imp hp.out.coprime_pow_of_not_dvd hp.out.coprime_pow_of_not_dvd ?_
+    contrapose! h_cop
+    exact Nat.Prime.not_coprime_iff_dvd.mpr ⟨p, hp.out, h_cop⟩
+  refine h3.symm.imp (fun h4 ↦ ?_) (fun h4 ↦ ?_)
+  · rw [← Subgroup.relindex_eq_one]
+    exact Nat.eq_one_of_dvd_coprimes h4 (H.relindex_dvd_index_of_normal P)
+      (Subgroup.relindex_dvd_card H P)
+  · exact disjoint_iff.mpr (Subgroup.inf_eq_bot_of_coprime h4)
+
 section P2comm
 
 variable [Fact p.Prime] {n : ℕ}

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -109,7 +109,7 @@ theorem isZGroup_of_coprime [Finite G] [IsZGroup G] [IsZGroup G'']
   have := Fact.mk hp
   replace h_cop := (h_cop.of_dvd ((Subgroup.card_dvd_of_le h_le).trans
     (Subgroup.card_range_dvd f)) (Subgroup.index_ker f' ▸ f'.range.card_subgroup_dvd_card))
-  rcases P.2.le_or_disjoint_of_coprime h_cop P with h | h
+  rcases P.2.le_or_disjoint_of_coprime h_cop with h | h
   · replace h_le : P ≤ f.range := h.trans h_le
     suffices IsCyclic (P.subgroupOf f.range) by
       have key := Subgroup.subgroupOfEquivOfLe h_le

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -101,8 +101,6 @@ end Nilpotent
 
 section Classification
 
-#where
-
 /-- An extension of coprime Z-groups is a Z-group. -/
 theorem isZGroup_of_coprime
     [Finite G] [IsZGroup G] [IsZGroup G''] (h_le : f'.ker ≤ f.range)

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -37,7 +37,7 @@ namespace IsZGroup
 instance [IsZGroup G] {p : ℕ} [Fact p.Prime] (P : Sylow p G) : IsCyclic P :=
   isZGroup p Fact.out P
 
-theorem _root_.IsPGroup.isCyclic_of_zgroup [IsZGroup G] {p : ℕ} [Fact p.Prime]
+theorem _root_.IsPGroup.isCyclic_of_isZGroup [IsZGroup G] {p : ℕ} [Fact p.Prime]
     {P : Subgroup G} (hP : IsPGroup p P) : IsCyclic P := by
   obtain ⟨Q, hQ⟩ := hP.exists_le_sylow
   exact Subgroup.isCyclic_of_le hQ
@@ -124,7 +124,7 @@ theorem isZGroup_of_coprime
     contrapose! h_cop
     exact Nat.Prime.not_coprime_iff_dvd.mpr ⟨p, hp, h_cop⟩
   rcases h_cop with hP | hP
-  · have := (P.2.map f').isCyclic_of_zgroup
+  · have := (P.2.map f').isCyclic_of_isZGroup
     refine isCyclic_of_injective (f'.subgroupMap P) ?_
     rw [← MonoidHom.ker_eq_bot_iff, P.ker_subgroupMap f', Subgroup.subgroupOf_eq_bot, disjoint_iff]
     exact Subgroup.inf_eq_bot_of_coprime (hP.coprime_dvd_left h_dvd)

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -102,42 +102,24 @@ end Nilpotent
 section Classification
 
 /-- An extension of coprime Z-groups is a Z-group. -/
-theorem isZGroup_of_coprime
-    [Finite G] [IsZGroup G] [IsZGroup G''] (h_le : f'.ker ≤ f.range)
-    (h_cop : (Nat.card G).Coprime (Nat.card G'')) : IsZGroup G' := by
-  have h_dvd : Nat.card f'.ker ∣ Nat.card G :=
-    (Subgroup.card_dvd_of_le h_le).trans (Subgroup.card_range_dvd f)
-  by_cases hG'' : Nat.card G'' = 0
-  · rw [hG'', Nat.coprime_zero_right] at h_cop
-    rw [h_cop, Nat.dvd_one, Subgroup.card_eq_one, MonoidHom.ker_eq_bot_iff] at h_dvd
-    exact IsZGroup.of_injective h_dvd
-  have : Finite G'' := Nat.finite_of_card_ne_zero hG''
-  have : Finite G' := by
-    refine Nat.finite_of_card_ne_zero ?_
-    rw [← f'.ker.card_mul_index, Subgroup.index_ker]
-    exact mul_ne_zero (ne_zero_of_dvd_ne_zero Finite.card_pos.ne' h_dvd) Finite.card_pos.ne'
+theorem isZGroup_of_coprime [Finite G] [IsZGroup G] [IsZGroup G'']
+    (h_le : f'.ker ≤ f.range) (h_cop : (Nat.card G).Coprime (Nat.card G'')) :
+    IsZGroup G' := by
   refine ⟨fun p hp P ↦ ?_⟩
   have := Fact.mk hp
-  replace h_cop : (Nat.card G).Coprime (Nat.card P) ∨ (Nat.card G'').Coprime (Nat.card P) := by
-    obtain ⟨k, hk⟩ := P.2.exists_card_eq
-    refine hk ▸ Or.imp hp.coprime_pow_of_not_dvd hp.coprime_pow_of_not_dvd ?_
-    contrapose! h_cop
-    exact Nat.Prime.not_coprime_iff_dvd.mpr ⟨p, hp, h_cop⟩
-  rcases h_cop with hP | hP
-  · have := (P.2.map f').isCyclic_of_isZGroup
-    refine isCyclic_of_injective (f'.subgroupMap P) ?_
-    rw [← MonoidHom.ker_eq_bot_iff, P.ker_subgroupMap f', Subgroup.subgroupOf_eq_bot, disjoint_iff]
-    exact Subgroup.inf_eq_bot_of_coprime (hP.coprime_dvd_left h_dvd)
-  · replace h_le : P ≤ f.range := by
-      refine le_trans ?_ h_le
-      rw [← Subgroup.map_eq_bot_iff, ← Subgroup.card_eq_one]
-      exact Nat.eq_one_of_dvd_coprimes hP (P.map f').card_subgroup_dvd_card (P.card_map_dvd f')
+  replace h_cop := (h_cop.of_dvd ((Subgroup.card_dvd_of_le h_le).trans
+    (Subgroup.card_range_dvd f)) (Subgroup.index_ker f' ▸ f'.range.card_subgroup_dvd_card))
+  rcases P.2.le_or_disjoint_of_coprime h_cop P with h | h
+  · replace h_le : P ≤ f.range := h.trans h_le
     suffices IsCyclic (P.subgroupOf f.range) by
       have key := Subgroup.subgroupOfEquivOfLe h_le
       exact isCyclic_of_surjective key key.surjective
     obtain ⟨Q, hQ⟩ := Sylow.mapSurjective_surjective f.rangeRestrict_surjective p (P.subtype h_le)
     rw [Sylow.ext_iff, Sylow.coe_mapSurjective, Sylow.coe_subtype] at hQ
     exact hQ ▸ isCyclic_of_surjective _ (f.rangeRestrict.subgroupMap_surjective Q)
+  · have := (P.2.map f').isCyclic_of_isZGroup
+    apply isCyclic_of_injective (f'.subgroupMap P)
+    rwa [← MonoidHom.ker_eq_bot_iff, P.ker_subgroupMap f', Subgroup.subgroupOf_eq_bot]
 
 end Classification
 

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -24,13 +24,13 @@ and `G/G'` are cyclic of coprime orders.
 
 -/
 
-variable (G G' : Type*) [Group G] [Group G'] (f : G →* G')
+variable (G G' G'' : Type*) [Group G] [Group G'] [Group G''] (f : G →* G') (f' : G' →* G'')
 
 /-- A Z-group is a group whose Sylow subgroups are all cyclic. -/
 @[mk_iff] class IsZGroup : Prop where
   isZGroup : ∀ p : ℕ, p.Prime → ∀ P : Sylow p G, IsCyclic P
 
-variable {G G' f}
+variable {G G' G'' f f'}
 
 namespace IsZGroup
 
@@ -99,42 +99,48 @@ instance isCyclic_abelianization [Finite G] [IsZGroup G] : IsCyclic (Abelianizat
 
 end Nilpotent
 
-end IsZGroup
+section Classification
+
+#where
 
 /-- An extension of coprime Z-groups is a Z-group. -/
-theorem isZGroup_of_coprime {G H K : Type*} [Group G] [Group H] [Group K]
-    [Finite G] [IsZGroup G] [IsZGroup K] (f : G →* H) (g : H →* K) (h_le : g.ker ≤ f.range)
-    (h_cop : (Nat.card G).Coprime (Nat.card K)) : IsZGroup H := by
-  have h_dvd : Nat.card g.ker ∣ Nat.card G :=
+theorem isZGroup_of_coprime
+    [Finite G] [IsZGroup G] [IsZGroup G''] (h_le : f'.ker ≤ f.range)
+    (h_cop : (Nat.card G).Coprime (Nat.card G'')) : IsZGroup G' := by
+  have h_dvd : Nat.card f'.ker ∣ Nat.card G :=
     (Subgroup.card_dvd_of_le h_le).trans (Subgroup.card_range_dvd f)
-  by_cases hK : Nat.card K = 0
-  · rw [hK, Nat.coprime_zero_right] at h_cop
+  by_cases hG'' : Nat.card G'' = 0
+  · rw [hG'', Nat.coprime_zero_right] at h_cop
     rw [h_cop, Nat.dvd_one, Subgroup.card_eq_one, MonoidHom.ker_eq_bot_iff] at h_dvd
     exact IsZGroup.of_injective h_dvd
-  have : Finite K := Nat.finite_of_card_ne_zero hK
-  have : Finite H := by
+  have : Finite G'' := Nat.finite_of_card_ne_zero hG''
+  have : Finite G' := by
     refine Nat.finite_of_card_ne_zero ?_
-    rw [← g.ker.card_mul_index, Subgroup.index_ker]
+    rw [← f'.ker.card_mul_index, Subgroup.index_ker]
     exact mul_ne_zero (ne_zero_of_dvd_ne_zero Finite.card_pos.ne' h_dvd) Finite.card_pos.ne'
   refine ⟨fun p hp P ↦ ?_⟩
   have := Fact.mk hp
-  replace h_cop : (Nat.card G).Coprime (Nat.card P) ∨ (Nat.card K).Coprime (Nat.card P) := by
+  replace h_cop : (Nat.card G).Coprime (Nat.card P) ∨ (Nat.card G'').Coprime (Nat.card P) := by
     obtain ⟨k, hk⟩ := P.2.exists_card_eq
     refine hk ▸ Or.imp hp.coprime_pow_of_not_dvd hp.coprime_pow_of_not_dvd ?_
     contrapose! h_cop
     exact Nat.Prime.not_coprime_iff_dvd.mpr ⟨p, hp, h_cop⟩
   rcases h_cop with hP | hP
-  · have := (P.2.map g).isCyclic_of_zgroup
-    refine isCyclic_of_injective (g.subgroupMap P) ?_
-    rw [← MonoidHom.ker_eq_bot_iff, P.ker_subgroupMap g, Subgroup.subgroupOf_eq_bot, disjoint_iff]
+  · have := (P.2.map f').isCyclic_of_zgroup
+    refine isCyclic_of_injective (f'.subgroupMap P) ?_
+    rw [← MonoidHom.ker_eq_bot_iff, P.ker_subgroupMap f', Subgroup.subgroupOf_eq_bot, disjoint_iff]
     exact Subgroup.inf_eq_bot_of_coprime (hP.coprime_dvd_left h_dvd)
   · replace h_le : P ≤ f.range := by
       refine le_trans ?_ h_le
       rw [← Subgroup.map_eq_bot_iff, ← Subgroup.card_eq_one]
-      exact Nat.eq_one_of_dvd_coprimes hP (P.map g).card_subgroup_dvd_card (P.card_map_dvd g)
+      exact Nat.eq_one_of_dvd_coprimes hP (P.map f').card_subgroup_dvd_card (P.card_map_dvd f')
     suffices IsCyclic (P.subgroupOf f.range) by
       have key := Subgroup.subgroupOfEquivOfLe h_le
       exact isCyclic_of_surjective key key.surjective
     obtain ⟨Q, hQ⟩ := Sylow.mapSurjective_surjective f.rangeRestrict_surjective p (P.subtype h_le)
     rw [Sylow.ext_iff, Sylow.coe_mapSurjective, Sylow.coe_subtype] at hQ
     exact hQ ▸ isCyclic_of_surjective _ (f.rangeRestrict.subgroupMap_surjective Q)
+
+end Classification
+
+end IsZGroup

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -37,6 +37,11 @@ namespace IsZGroup
 instance [IsZGroup G] {p : ℕ} [Fact p.Prime] (P : Sylow p G) : IsCyclic P :=
   isZGroup p Fact.out P
 
+theorem _root_.IsPGroup.isCyclic_of_zgroup [IsZGroup G] {p : ℕ} [Fact p.Prime]
+    {P : Subgroup G} (hP : IsPGroup p P) : IsCyclic P := by
+  obtain ⟨Q, hQ⟩ := hP.exists_le_sylow
+  exact Subgroup.isCyclic_of_le hQ
+
 theorem of_squarefree (hG : Squarefree (Nat.card G)) : IsZGroup G := by
   have : Finite G := Nat.finite_of_card_ne_zero hG.ne_zero
   refine ⟨fun p hp P ↦ ?_⟩
@@ -95,3 +100,41 @@ instance isCyclic_abelianization [Finite G] [IsZGroup G] : IsCyclic (Abelianizat
 end Nilpotent
 
 end IsZGroup
+
+/-- An extension of coprime Z-groups is a Z-group. -/
+theorem isZGroup_of_coprime {G H K : Type*} [Group G] [Group H] [Group K]
+    [Finite G] [IsZGroup G] [IsZGroup K] (f : G →* H) (g : H →* K) (h_le : g.ker ≤ f.range)
+    (h_cop : (Nat.card G).Coprime (Nat.card K)) : IsZGroup H := by
+  have h_dvd : Nat.card g.ker ∣ Nat.card G :=
+    (Subgroup.card_dvd_of_le h_le).trans (Subgroup.card_range_dvd f)
+  by_cases hK : Nat.card K = 0
+  · rw [hK, Nat.coprime_zero_right] at h_cop
+    rw [h_cop, Nat.dvd_one, Subgroup.card_eq_one, MonoidHom.ker_eq_bot_iff] at h_dvd
+    exact IsZGroup.of_injective h_dvd
+  have : Finite K := Nat.finite_of_card_ne_zero hK
+  have : Finite H := by
+    refine Nat.finite_of_card_ne_zero ?_
+    rw [← g.ker.card_mul_index, Subgroup.index_ker]
+    exact mul_ne_zero (ne_zero_of_dvd_ne_zero Finite.card_pos.ne' h_dvd) Finite.card_pos.ne'
+  refine ⟨fun p hp P ↦ ?_⟩
+  have := Fact.mk hp
+  replace h_cop : (Nat.card G).Coprime (Nat.card P) ∨ (Nat.card K).Coprime (Nat.card P) := by
+    obtain ⟨k, hk⟩ := P.2.exists_card_eq
+    refine hk ▸ Or.imp hp.coprime_pow_of_not_dvd hp.coprime_pow_of_not_dvd ?_
+    contrapose! h_cop
+    exact Nat.Prime.not_coprime_iff_dvd.mpr ⟨p, hp, h_cop⟩
+  rcases h_cop with hP | hP
+  · have := (P.2.map g).isCyclic_of_zgroup
+    refine isCyclic_of_injective (g.subgroupMap P) ?_
+    rw [← MonoidHom.ker_eq_bot_iff, P.ker_subgroupMap g, Subgroup.subgroupOf_eq_bot, disjoint_iff]
+    exact Subgroup.inf_eq_bot_of_coprime (hP.coprime_dvd_left h_dvd)
+  · replace h_le : P ≤ f.range := by
+      refine le_trans ?_ h_le
+      rw [← Subgroup.map_eq_bot_iff, ← Subgroup.card_eq_one]
+      exact Nat.eq_one_of_dvd_coprimes hP (P.map g).card_subgroup_dvd_card (P.card_map_dvd g)
+    suffices IsCyclic (P.subgroupOf f.range) by
+      have key := Subgroup.subgroupOfEquivOfLe h_le
+      exact isCyclic_of_surjective key key.surjective
+    obtain ⟨Q, hQ⟩ := Sylow.mapSurjective_surjective f.rangeRestrict_surjective p (P.subtype h_le)
+    rw [Sylow.ext_iff, Sylow.coe_mapSurjective, Sylow.coe_subtype] at hQ
+    exact hQ ▸ isCyclic_of_surjective _ (f.rangeRestrict.subgroupMap_surjective Q)

--- a/Mathlib/GroupTheory/Transfer.lean
+++ b/Mathlib/GroupTheory/Transfer.lean
@@ -332,7 +332,8 @@ theorem normalizer_le_centralizer (hP : IsCyclic P) : P.normalizer ≤ centraliz
     apply Nat.Coprime.coprime_dvd_left (relindex_dvd_index_of_le P.le_normalizer)
     rw [Nat.coprime_comm, Nat.Prime.coprime_iff_not_dvd Fact.out]
     exact P.not_dvd_index
-  · apply Nat.Coprime.coprime_dvd_left (relindex_dvd_card (centralizer P) P.normalizer)
+  · apply Nat.Coprime.coprime_dvd_left (card_subgroup_dvd_card P.normalizer)
+    apply Nat.Coprime.coprime_dvd_left (relindex_dvd_card (centralizer P) P.normalizer)
     have h1 := Nat.gcd_dvd_left (Nat.card G) ((Nat.card G).minFac - 1)
     have h2 := Nat.gcd_le_right (m := Nat.card G) ((Nat.card G).minFac - 1)
       (tsub_pos_iff_lt.mpr (Nat.minFac_prime hn).one_lt)

--- a/Mathlib/GroupTheory/Transfer.lean
+++ b/Mathlib/GroupTheory/Transfer.lean
@@ -332,8 +332,8 @@ theorem normalizer_le_centralizer (hP : IsCyclic P) : P.normalizer ≤ centraliz
     apply Nat.Coprime.coprime_dvd_left (relindex_dvd_index_of_le P.le_normalizer)
     rw [Nat.coprime_comm, Nat.Prime.coprime_iff_not_dvd Fact.out]
     exact P.not_dvd_index
-  · apply Nat.Coprime.coprime_dvd_left (card_subgroup_dvd_card P.normalizer)
-    apply Nat.Coprime.coprime_dvd_left (relindex_dvd_card (centralizer P) P.normalizer)
+  · apply Nat.Coprime.coprime_dvd_left (relindex_dvd_card (centralizer P) P.normalizer)
+    apply Nat.Coprime.coprime_dvd_left (card_subgroup_dvd_card P.normalizer)
     have h1 := Nat.gcd_dvd_left (Nat.card G) ((Nat.card G).minFac - 1)
     have h2 := Nat.gcd_le_right (m := Nat.card G) ((Nat.card G).minFac - 1)
       (tsub_pos_iff_lt.mpr (Nat.minFac_prime hn).one_lt)


### PR DESCRIPTION
One more step towards showing that every finite Z-group is a semidirect product of cyclic groups of coprime order.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
