### PR TITLE
[Merged by Bors] - feat(SetTheory/Game/PGame): neg_identical_neg_iff

### DIFF
--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1362,6 +1362,9 @@ theorem neg_identical_neg_iff : ∀ {x y : PGame.{u}}, x ≡ y ↔ -x ≡ -y
         simp only [imp_self]
 termination_by x y => (x, y)
 
+theorem Identical.neg {x y : PGame} : x ≡ y ↔ -x ≡ -y :=
+  neg_identical_neg_iff
+
 /-- If `x` has the same moves as `y`, then `-x` has the same moves as `-y`. -/
 def Relabelling.negCongr : ∀ {x y : PGame}, x ≡r y → -x ≡r -y
   | ⟨_, _, _, _⟩, ⟨_, _, _, _⟩, ⟨L, R, hL, hR⟩ =>

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1350,6 +1350,18 @@ theorem moveRight_neg_symm {x : PGame} (i) :
 theorem moveRight_neg_symm' {x : PGame} (i) :
     x.moveRight i = -(-x).moveLeft (toLeftMovesNeg i) := by simp
 
+theorem neg_identical_neg_iff : ∀ {x y : PGame.{u}}, x ≡ y ↔ -x ≡ -y
+  | mk xl xr xL xR, mk yl yr yL yR => by
+    rw [neg_def, identical_iff, identical_iff, ← neg_def, and_comm]
+    simp only [neg_def, rightMoves_mk, moveRight_mk, leftMoves_mk, moveLeft_mk]
+    apply and_congr <;>
+    · constructor
+      · conv in (_ ≡ _) => rw [neg_identical_neg_iff]
+        simp only [imp_self]
+      · conv in (_ ≡ _) => rw [← neg_identical_neg_iff]
+        simp only [imp_self]
+termination_by x y => (x, y)
+
 /-- If `x` has the same moves as `y`, then `-x` has the same moves as `-y`. -/
 def Relabelling.negCongr : ∀ {x y : PGame}, x ≡r y → -x ≡r -y
   | ⟨_, _, _, _⟩, ⟨_, _, _, _⟩, ⟨L, R, hL, hR⟩ =>

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1350,7 +1350,7 @@ theorem moveRight_neg_symm {x : PGame} (i) :
 theorem moveRight_neg_symm' {x : PGame} (i) :
     x.moveRight i = -(-x).moveLeft (toLeftMovesNeg i) := by simp
 
-@[simp] theorem neg_identical_neg_iff : ∀ {x y : PGame.{u}}, -x ≡ -y ↔ x ≡ y 
+@[simp] theorem neg_identical_neg_iff : ∀ {x y : PGame.{u}}, -x ≡ -y ↔ x ≡ y
   | mk xl xr xL xR, mk yl yr yL yR => by
     rw [neg_def, identical_iff, identical_iff, ← neg_def, and_comm]
     simp only [neg_def, rightMoves_mk, moveRight_mk, leftMoves_mk, moveLeft_mk]
@@ -1363,7 +1363,7 @@ theorem moveRight_neg_symm' {x : PGame} (i) :
 termination_by x y => (x, y)
 
 theorem Identical.neg {x y : PGame} : x ≡ y ↔ -x ≡ -y :=
-  neg_identical_neg_iff
+  neg_identical_neg_iff.symm
 
 /-- If `x` has the same moves as `y`, then `-x` has the same moves as `-y`. -/
 def Relabelling.negCongr : ∀ {x y : PGame}, x ≡r y → -x ≡r -y

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1350,7 +1350,7 @@ theorem moveRight_neg_symm {x : PGame} (i) :
 theorem moveRight_neg_symm' {x : PGame} (i) :
     x.moveRight i = -(-x).moveLeft (toLeftMovesNeg i) := by simp
 
-theorem neg_identical_neg_iff : ∀ {x y : PGame.{u}}, x ≡ y ↔ -x ≡ -y
+@[simp] theorem neg_identical_neg_iff : ∀ {x y : PGame.{u}}, -x ≡ -y ↔ x ≡ y 
   | mk xl xr xL xR, mk yl yr yL yR => by
     rw [neg_def, identical_iff, identical_iff, ← neg_def, and_comm]
     simp only [neg_def, rightMoves_mk, moveRight_mk, leftMoves_mk, moveLeft_mk]


### PR DESCRIPTION
Adds `neg_identical_neg_iff`: `x ≡ y ↔ -x ≡ -y`.

This probably has suboptimal golfing! I'm unsure myself of further ways to improve this, but this proof looks very golfable!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
