### PR TITLE
[Merged by Bors] - chore(AssociatedPrime): use `ker toSpanSingleton` instead of `annihilator span singleton`

### DIFF
--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -515,10 +515,16 @@ theorem span_singleton_eq_range (x : M) : (R ∙ x) = range (toSpanSingleton R M
 theorem toSpanSingleton_one (x : M) : toSpanSingleton R M x 1 = x :=
   one_smul _ _
 
+theorem toSpanSingleton_injective : Function.Injective (toSpanSingleton R M) :=
+  fun _ _ eq ↦ by simpa using congr($eq 1)
+
 @[simp]
 theorem toSpanSingleton_zero : toSpanSingleton R M 0 = 0 := by
   ext
   simp
+
+theorem toSpanSingleton_eq_zero_iff {x : M} : toSpanSingleton R M x = 0 ↔ x = 0 := by
+  rw [← toSpanSingleton_zero, (toSpanSingleton_injective R M).eq_iff]
 
 variable {R M}
 

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime.lean
@@ -34,9 +34,11 @@ Generalize this to a non-commutative setting once there are annihilator for non-
 
 variable {R : Type*} [CommRing R] (I J : Ideal R) (M : Type*) [AddCommGroup M] [Module R M]
 
+open LinearMap
+
 /-- `IsAssociatedPrime I M` if the prime ideal `I` is the annihilator of some `x : M`. -/
 def IsAssociatedPrime : Prop :=
-  I.IsPrime ∧ ∃ x : M, I = (R ∙ x).annihilator
+  I.IsPrime ∧ ∃ x : M, I = ker (toSpanSingleton R M x)
 
 variable (R)
 
@@ -55,8 +57,7 @@ theorem IsAssociatedPrime.map_of_injective (h : IsAssociatedPrime I M) (hf : Fun
   obtain ⟨x, rfl⟩ := h.2
   refine ⟨h.1, ⟨f x, ?_⟩⟩
   ext r
-  rw [Submodule.mem_annihilator_span_singleton, Submodule.mem_annihilator_span_singleton, ←
-    map_smul, ← f.map_zero, hf.eq_iff]
+  simp_rw [mem_ker, toSpanSingleton_apply, ← map_smul, ← f.map_zero, hf.eq_iff]
 
 theorem LinearEquiv.isAssociatedPrime_iff (l : M ≃ₗ[R] M') :
     IsAssociatedPrime I M ↔ IsAssociatedPrime I M' :=
@@ -66,32 +67,31 @@ theorem LinearEquiv.isAssociatedPrime_iff (l : M ≃ₗ[R] M') :
 theorem not_isAssociatedPrime_of_subsingleton [Subsingleton M] : ¬IsAssociatedPrime I M := by
   rintro ⟨hI, x, hx⟩
   apply hI.ne_top
-  rwa [Subsingleton.elim x 0, Submodule.span_singleton_eq_bot.mpr rfl, Submodule.annihilator_bot]
-    at hx
+  simpa [Subsingleton.elim x 0] using hx
 
 variable (R)
 
 theorem exists_le_isAssociatedPrime_of_isNoetherianRing [H : IsNoetherianRing R] (x : M)
-    (hx : x ≠ 0) : ∃ P : Ideal R, IsAssociatedPrime P M ∧ (R ∙ x).annihilator ≤ P := by
-  have : (R ∙ x).annihilator ≠ ⊤ := by
-    rwa [Ne, Ideal.eq_top_iff_one, Submodule.mem_annihilator_span_singleton, one_smul]
+    (hx : x ≠ 0) : ∃ P : Ideal R, IsAssociatedPrime P M ∧ ker (toSpanSingleton R M x) ≤ P := by
+  have : ker (toSpanSingleton R M x) ≠ ⊤ := by
+    rwa [Ne, Ideal.eq_top_iff_one, mem_ker, toSpanSingleton_apply, one_smul]
   obtain ⟨P, ⟨l, h₁, y, rfl⟩, h₃⟩ :=
     set_has_maximal_iff_noetherian.mpr H
-      { P | (R ∙ x).annihilator ≤ P ∧ P ≠ ⊤ ∧ ∃ y : M, P = (R ∙ y).annihilator }
-      ⟨(R ∙ x).annihilator, rfl.le, this, x, rfl⟩
+      { P | ker (toSpanSingleton R M x) ≤ P ∧ P ≠ ⊤ ∧ ∃ y : M, P = ker (toSpanSingleton R M y) }
+      ⟨_, rfl.le, this, x, rfl⟩
   refine ⟨_, ⟨⟨h₁, ?_⟩, y, rfl⟩, l⟩
   intro a b hab
   rw [or_iff_not_imp_left]
   intro ha
-  rw [Submodule.mem_annihilator_span_singleton] at ha hab
-  have H₁ : (R ∙ y).annihilator ≤ (R ∙ a • y).annihilator := by
+  rw [mem_ker, toSpanSingleton_apply] at ha hab
+  have H₁ : ker (toSpanSingleton R M y) ≤ ker (toSpanSingleton R M (a • y)) := by
     intro c hc
-    rw [Submodule.mem_annihilator_span_singleton] at hc ⊢
+    rw [mem_ker, toSpanSingleton_apply] at hc ⊢
     rw [smul_comm, hc, smul_zero]
-  have H₂ : (Submodule.span R {a • y}).annihilator ≠ ⊤ := by
-    rwa [Ne, Submodule.annihilator_eq_top_iff, Submodule.span_singleton_eq_bot]
-  rwa [H₁.eq_of_not_lt (h₃ (R ∙ a • y).annihilator ⟨l.trans H₁, H₂, _, rfl⟩),
-    Submodule.mem_annihilator_span_singleton, smul_comm, smul_smul]
+  have H₂ : ker (toSpanSingleton R M (a • y)) ≠ ⊤ := by
+    rwa [Ne, ker_eq_top, toSpanSingleton_eq_zero_iff]
+  rwa [H₁.eq_of_not_lt (h₃ _ ⟨l.trans H₁, H₂, _, rfl⟩),
+    mem_ker, toSpanSingleton_apply, smul_comm, smul_smul]
 
 variable {R}
 
@@ -117,11 +117,9 @@ theorem associatedPrimes.nonempty [IsNoetherianRing R] [Nontrivial M] :
 
 theorem biUnion_associatedPrimes_eq_zero_divisors [IsNoetherianRing R] :
     ⋃ p ∈ associatedPrimes R M, p = { r : R | ∃ x : M, x ≠ 0 ∧ r • x = 0 } := by
-  simp_rw [← Submodule.mem_annihilator_span_singleton]
   refine subset_antisymm (Set.iUnion₂_subset ?_) ?_
   · rintro _ ⟨h, x, ⟨⟩⟩ r h'
     refine ⟨x, ne_of_eq_of_ne (one_smul R x).symm ?_, h'⟩
-    refine mt (Submodule.mem_annihilator_span_singleton _ _).mpr ?_
     exact (Ideal.ne_top_iff_one _).mp h.ne_top
   · intro r ⟨x, h, h'⟩
     obtain ⟨P, hP, hx⟩ := exists_le_isAssociatedPrime_of_isNoetherianRing R x h
@@ -132,6 +130,7 @@ variable {R M}
 theorem IsAssociatedPrime.annihilator_le (h : IsAssociatedPrime I M) :
     (⊤ : Submodule R M).annihilator ≤ I := by
   obtain ⟨hI, x, rfl⟩ := h
+  rw [← Submodule.annihilator_span_singleton]
   exact Submodule.annihilator_mono le_top
 
 theorem IsAssociatedPrime.eq_radical (hI : I.IsPrimary) (h : IsAssociatedPrime J (R ⧸ I)) :
@@ -140,11 +139,11 @@ theorem IsAssociatedPrime.eq_radical (hI : I.IsPrimary) (h : IsAssociatedPrime J
   have : x ≠ 0 := by
     rintro rfl
     apply hJ.1
-    rwa [Submodule.span_singleton_eq_bot.mpr rfl, Submodule.annihilator_bot] at e
+    rwa [toSpanSingleton_zero, ker_zero] at e
   obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective R _ x
   replace e : ∀ {y}, y ∈ J ↔ x * y ∈ I := by
     intro y
-    rw [e, Submodule.mem_annihilator_span_singleton, ← map_smul, smul_eq_mul, mul_comm,
+    rw [e, mem_ker, toSpanSingleton_apply, ← map_smul, smul_eq_mul, mul_comm,
       Ideal.Quotient.mkₐ_eq_mk, ← Ideal.Quotient.mk_eq_mk, Submodule.Quotient.mk_eq_zero]
   apply le_antisymm
   · intro y hy

--- a/Mathlib/RingTheory/Ideal/Maps.lean
+++ b/Mathlib/RingTheory/Ideal/Maps.lean
@@ -793,6 +793,16 @@ theorem mem_annihilator_span (s : Set M) (r : R) :
 theorem mem_annihilator_span_singleton (g : M) (r : R) :
     r ∈ (Submodule.span R ({g} : Set M)).annihilator ↔ r • g = 0 := by simp [mem_annihilator_span]
 
+open LinearMap in
+theorem annihilator_span (s : Set M) :
+    (Submodule.span R s).annihilator = ⨅ g : s, ker (toSpanSingleton R M g.1) := by
+  ext; simp [mem_annihilator_span]
+
+open LinearMap in
+theorem annihilator_span_singleton (g : M) :
+    (Submodule.span R {g}).annihilator = ker (toSpanSingleton R M g) := by
+  simp [annihilator_span]
+
 @[simp]
 theorem mul_annihilator (I : Ideal R) : I * annihilator I = ⊥ := by rw [mul_comm, annihilator_mul]
 


### PR DESCRIPTION
Maybe better in terms of defeq, not sure if this is really an improvement.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
