### PR TITLE
fix: make the CI for posting mergable lean-pr-testing branches work again

### DIFF
--- a/.github/workflows/debug_ci.yaml
+++ b/.github/workflows/debug_ci.yaml
@@ -2,7 +2,7 @@ on:
   pull_request:
     types: [labeled, unlabeled]
     branches:
-      - '**/ci_debug_**'
+      - '**/ci_debug**'
 
 jobs:
   print_context:

--- a/.github/workflows/debug_ci.yaml
+++ b/.github/workflows/debug_ci.yaml
@@ -1,0 +1,14 @@
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+    branches:
+      - '**/ci_debug_**'
+
+jobs:
+  print_context:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          EVENT_CONTEXT: ${{ toJSON(github.event) }}
+        run: |
+          echo $EVENT_CONTEXT

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -19,7 +19,7 @@ jobs:
           echo "hi blizzard"
           {
           printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
-          printf $'foo\nEOF'
+          printf $'\`\`\`bash\necho test\n\`\`\`\nEOF'
           # PR_NUMBER= '18818'
           # printf $'# Diff: %s' "[diff goes here]"
           # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -12,4 +12,4 @@ jobs:
       - name: name
         run: |
           # for debugging, we print the available variables
-          echo "github.event.action: '${{ toJSON( github.event.keys ) }}'"
+          echo "github.event.action: '${{ toJSON( github.event.commits ) }}'"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -12,4 +12,4 @@ jobs:
       - name: name
         run: |
           # for debugging, we print the available variables
-          echo "github.event.action: '${{ toJSON( github.event ) }}'"
+          echo "github.event.action: '${{ toJSON( github.event.keys ) }}'"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -18,14 +18,7 @@ jobs:
         run: |
           echo "hi blizzard"
           {
-          printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
-          printf $'\`\`\`bash\n'
-          PR_NUMBER= '18818'
-          printf $'# Diff: %s' "[diff goes here]"
-          printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
-          printf '# # # # #'
-          printf $'\`\`\`\n'
-          printf "EOF"
+          printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\nfoo\nEOF'
           } >> "$GITHUB_OUTPUT"
 
       - name: send zulip test message

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -18,7 +18,14 @@ jobs:
         run: |
           echo "hi blizzard"
           {
-          printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\nfoo\nEOF'
+          printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
+          printf $'foo\nEOF'
+          # PR_NUMBER= '18818'
+          # printf $'# Diff: %s' "[diff goes here]"
+          # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
+          # printf '# # # # #'
+          # printf $'\`\`\`\n'
+          # printf "EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: send zulip test message

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -16,11 +16,12 @@ jobs:
       - name: format message
         id: form_the_message
         run: |
-          echo "hi blizzard"
           {
           printf $'msg<<EOF\nWe will need to merge the following branches into `nightly-testing`:\n'
           printf $'```bash\n'
-          printf $'# Diff: %s\n' "[diff goes here]"
+          PR_NUMBER = '18818'
+          GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
+          printf $'# Diff: %s\n' "$GITHUB_DIFF"
           printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
           printf '# # # # #'
           printf $'```\n'

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -12,4 +12,4 @@ jobs:
       - name: name
         run: |
           # for debugging, we print the available variables
-          echo "github.event.action: ${{ toJSON( github.event ) }}"
+          echo "github.event.action: '${{ toJSON( github.event ) }}'"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -12,4 +12,4 @@ jobs:
       - name: name
         run: |
           # for debugging, we print the available variables
-          echo "github.event.action: '${{ github.event.action }}'"
+          echo "github.event.action: '${{ github.event }}'"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -22,6 +22,7 @@ jobs:
           printf $'```bash\n'
           printf $'# Diff: %s\n' "[diff goes here]"
           printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
+          printf $'# # # # #\n'
 
           printf $'echo test\n'
           printf $'```\n'

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -19,6 +19,9 @@ jobs:
           echo "hi blizzard"
           {
           printf $'msg<<EOF\nWe will need to merge the following branches into `nightly-testing`:\n'
+          printf $'```bash\n'
+          printf $'echo test\n'
+          printf $'```\n'
           printf $'EOF'
           # PR_NUMBER= '18818'
           # printf $'# Diff: %s' "[diff goes here]"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -23,15 +23,17 @@ jobs:
         {
           printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
           printf $'```bash\n'
-          BRANCH='lean-pr-testing-2'
-          PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
-          GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
-          printf $'# Diff: %s\n' "$GITHUB_DIFF"
-          printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "$PR_NUMBER" "$BRANCH"
-          printf '# # # # #\n'
+          for BRANCH in $BRANCHES; do
+            PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
+            GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
+            printf $'# Diff: %s' "$GITHUB_DIFF"
+            printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "$PR_NUMBER" "$BRANCH"
+            printf '# # # # #'
+          done
           printf $'```\n'
           printf "EOF"
         } >> "$GITHUB_OUTPUT"
+
 
     - name: send zulip test message
       uses: zulip/github-actions-zulip/send-message@v1

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -20,8 +20,8 @@ jobs:
           printf $'msg<<EOF\nWe will need to merge the following branches into `nightly-testing`:\n'
           printf $'```bash\n'
           PR_NUMBER = '18818'
-          GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
-          printf "$GITHUB_DIFF"
+          # GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
+          # printf "$GITHUB_DIFF"
           # printf $'# Diff: %s\n' "$GITHUB_DIFF"
           # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
           printf '# # # # #\n'

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -19,15 +19,14 @@ jobs:
           echo "hi blizzard"
           {
 
-            printf 'msg<<EOF\n%s\nEOF' "have a backtick: \`"
-            # printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
-            # printf $'\`\`\`bash\n'
-            # PR_NUMBER= '18818'
-            # printf $'# Diff: %s' "[diff goes here]"
-            # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
-            # printf '# # # # #'
-            # printf $'\`\`\`\n'
-            # printf "EOF"
+          # printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
+          # printf $'\`\`\`bash\n'
+          # PR_NUMBER= '18818'
+          # printf $'# Diff: %s' "[diff goes here]"
+          # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
+          # printf '# # # # #'
+          # printf $'\`\`\`\n'
+          # printf "EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: send zulip test message

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -16,19 +16,19 @@ jobs:
     - name: format message
       id: form_the_message
       run: |
+        BRANCHES='lean-pr-testing-1\nlean-pr-testing-2\nlean-pr-testing-3489\n'
         {
-        printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
-        printf $'```bash\n'
-        BRANCH='lean-pr-testing-18818'
-        PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
-
-        GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
-        # printf "$GITHUB_DIFF"
-        printf $'# Diff: %s\n' "$GITHUB_DIFF"
-        printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "$PR_NUMBER" "$BRANCH"
-        printf $'# # # # #\n'
-        printf $'```\n'
-        printf "EOF"
+          printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
+          printf $'```bash\n'
+          for BRANCH in $BRANCHES; do
+            PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
+            GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
+            printf $'# Diff: %s' "$GITHUB_DIFF"
+            printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "$PR_NUMBER" "$BRANCH"
+            printf '# # # # #'
+          done
+          printf $'```\n'
+          printf "EOF"
         } >> "$GITHUB_OUTPUT"
 
     - name: send zulip test message

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -12,4 +12,4 @@ jobs:
       - name: name
         run: |
           # for debugging, we print the available variables
-          echo "github.event.action: ${{ toJSON( github.event_name) }}"
+          echo "github.event.action: ${{ toJSON( github.event ) }}"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -18,15 +18,14 @@ jobs:
         run: |
           echo "hi blizzard"
           {
-
-          # printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
-          # printf $'\`\`\`bash\n'
-          # PR_NUMBER= '18818'
-          # printf $'# Diff: %s' "[diff goes here]"
-          # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
-          # printf '# # # # #'
-          # printf $'\`\`\`\n'
-          # printf "EOF"
+          printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
+          printf $'\`\`\`bash\n'
+          PR_NUMBER= '18818'
+          printf $'# Diff: %s' "[diff goes here]"
+          printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
+          printf '# # # # #'
+          printf $'\`\`\`\n'
+          printf "EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: send zulip test message

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -22,9 +22,7 @@ jobs:
           printf $'```bash\n'
           printf $'# Diff: %s\n' "[diff goes here]"
           printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
-          printf $'# # # # #\n'
-
-          printf $'echo test\n'
+          printf '# # # # #'
           printf $'```\n'
           printf "EOF"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -18,8 +18,8 @@ jobs:
         run: |
           echo "hi blizzard"
           {
-          printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
-          printf $'\`\`\`bash\necho test\n\`\`\`\nEOF'
+          printf $'msg<<EOF\nWe will need to merge the following branches into `nightly-testing`:\n'
+          printf $'EOF'
           # PR_NUMBER= '18818'
           # printf $'# Diff: %s' "[diff goes here]"
           # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -19,7 +19,7 @@ jobs:
           echo "hi blizzard"
           {
           printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
-          printf $'```bash\necho test\n```\nEOF'
+          printf $'\`\`\`bash\necho test\n\`\`\`\nEOF'
           # PR_NUMBER= '18818'
           # printf $'# Diff: %s' "[diff goes here]"
           # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -26,7 +26,7 @@ jobs:
 
           printf $'echo test\n'
           printf $'```\n'
-          printf 'EOF'
+          printf "EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: send zulip test message

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -26,13 +26,7 @@ jobs:
 
           printf $'echo test\n'
           printf $'```\n'
-          printf $'EOF'
-          # PR_NUMBER= '18818'
-          # printf $'# Diff: %s' "[diff goes here]"
-          # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
-          # printf '# # # # #'
-          # printf $'\`\`\`\n'
-          # printf "EOF"
+          printf 'EOF'
           } >> "$GITHUB_OUTPUT"
 
       - name: send zulip test message

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -29,7 +29,7 @@ jobs:
             # printf '# # # # #'
             # printf $'\`\`\`\n'
             # printf "EOF"
-          } >> "$GITHUB_OUTPUT"
+          } | tee "$GITHUB_OUTPUT"
 
       - name: send zulip test message
         uses: zulip/github-actions-zulip/send-message@v1

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -12,7 +12,25 @@ jobs:
       - name: print event info
         run: |
           # for debugging, we print the available variables
-          echo "github.event.action: '${{ toJSON( github.event.commits ) }}'"
+          # echo "github.event.action: '${{ toJSON( github.event.commits ) }}'"
+          echo "step done"
+      - name: format message
+        id: form_the_message
+        run: |
+          echo "hi blizzard"
+          {
+
+            printf 'msg<<EOF\n%s\nEOF' "have a backtick: `"
+            # printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
+            # printf $'\`\`\`bash\n'
+            # PR_NUMBER= '18818'
+            # printf $'# Diff: %s' "[diff goes here]"
+            # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
+            # printf '# # # # #'
+            # printf $'\`\`\`\n'
+            # printf "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: send zulip test message
         uses: zulip/github-actions-zulip/send-message@v1
         with:
@@ -21,4 +39,4 @@ jobs:
           organization-url: 'https://leanprover.zulipchat.com'
           to: "684366"
           type: 'private'
-          content: 'hi blizzard, ping'
+          content: ${{steps.form_the_message.outputs.msg}}

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -21,7 +21,8 @@ jobs:
           printf $'```bash\n'
           PR_NUMBER = '18818'
           GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
-          printf $'# Diff: %s\n' "$GITHUB_DIFF"
+          printf "$GITHUB_DIFF"
+          # printf $'# Diff: %s\n' "$GITHUB_DIFF"
           # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
           printf '# # # # #\n'
           printf $'```\n'

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -20,6 +20,9 @@ jobs:
           {
           printf $'msg<<EOF\nWe will need to merge the following branches into `nightly-testing`:\n'
           printf $'```bash\n'
+          printf $'# Diff: %s\n' "[diff goes here]"
+          printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
+
           printf $'echo test\n'
           printf $'```\n'
           printf $'EOF'

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -19,7 +19,7 @@ jobs:
           echo "hi blizzard"
           {
 
-            printf 'msg<<EOF\n%s\nEOF' "have a backtick: `"
+            printf 'msg<<EOF\n%s\nEOF' "have a backtick: \`"
             # printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
             # printf $'\`\`\`bash\n'
             # PR_NUMBER= '18818'

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: format message
       id: form_the_message
       run: |
-        BRANCHES='lean-pr-testing-1\nlean-pr-testing-2\nlean-pr-testing-3489\n'
+        BRANCHES='lean-pr-testing-1 lean-pr-testing-2 lean-pr-testing-3489 '
         for BRANCH in $BRANCHES; do
           echo $BRANCH
         done
@@ -26,7 +26,7 @@ jobs:
           BRANCH='lean-pr-testing-2'
           PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
           GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
-          printf $'# Diff: %s' "$GITHUB_DIFF"
+          printf $'# Diff: %s\n' "$GITHUB_DIFF"
           printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "$PR_NUMBER" "$BRANCH"
           printf '# # # # #\n'
           printf $'```\n'

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -12,15 +12,14 @@ jobs:
       - name: print event info
         run: |
           # for debugging, we print the available variables
-          # echo "github.event.action: '${{ toJSON( github.event.commits ) }}'"
-          echo "step done"
+          echo "github.event.action: '${{ toJSON( github.event.commits ) }}'"
       - name: format message
         id: form_the_message
         run: |
           echo "hi blizzard"
           {
 
-            printf 'msg<<EOF\n%s\nEOF' "have a backtick next time"
+            printf 'msg<<EOF\n%s\nEOF' "have a backtick: `"
             # printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
             # printf $'\`\`\`bash\n'
             # PR_NUMBER= '18818'
@@ -29,7 +28,7 @@ jobs:
             # printf '# # # # #'
             # printf $'\`\`\`\n'
             # printf "EOF"
-          } | tee "$GITHUB_OUTPUT"
+          } >> "$GITHUB_OUTPUT"
 
       - name: send zulip test message
         uses: zulip/github-actions-zulip/send-message@v1

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -12,4 +12,4 @@ jobs:
       - name: name
         run: |
           # for debugging, we print the available variables
-          echo "github.event.action: ${{ toJSON(github.event) }}"
+          echo "github.event.action: ${{ toJSON( github.event_name) }}"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -21,7 +21,7 @@ jobs:
           printf $'```bash\n'
           PR_NUMBER='18818'
           GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
-          # printf "$GITHUB_DIFF"
+          printf "$GITHUB_DIFF"
           # printf $'# Diff: %s\n' "$GITHUB_DIFF"
           # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
           printf '# # # # #\n'

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -22,8 +22,8 @@ jobs:
           PR_NUMBER = '18818'
           GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
           printf $'# Diff: %s\n' "$GITHUB_DIFF"
-          printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
-          printf '# # # # #'
+          # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
+          printf '# # # # #\n'
           printf $'```\n'
           printf "EOF"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -9,7 +9,16 @@ jobs:
   log-event-info:
     runs-on: ubuntu-latest
     steps:
-      - name: name
+      - name: print event info
         run: |
           # for debugging, we print the available variables
           echo "github.event.action: '${{ toJSON( github.event.commits ) }}'"
+      - name: send zulip test message
+        uses: zulip/github-actions-zulip/send-message@v1
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+          organization-url: 'https://leanprover.zulipchat.com'
+          to: "684366"
+          type: 'private'
+          content: 'hi blizzard, ping'

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -26,9 +26,9 @@ jobs:
           for BRANCH in $BRANCHES; do
             PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
             GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
-            printf $'# Diff: %s' "$GITHUB_DIFF"
+            printf $'# Diff: %s\n' "$GITHUB_DIFF"
             printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "$PR_NUMBER" "$BRANCH"
-            printf '# # # # #'
+            printf '# # # # #\n'
           done
           printf $'```\n'
           printf "EOF"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -21,9 +21,9 @@ jobs:
           printf $'```bash\n'
           PR_NUMBER='18818'
           GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
-          printf "$GITHUB_DIFF"
-          # printf $'# Diff: %s\n' "$GITHUB_DIFF"
-          # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
+          # printf "$GITHUB_DIFF"
+          printf $'# Diff: %s\n' "$GITHUB_DIFF"
+          printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
           printf '# # # # #\n'
           printf $'```\n'
           printf "EOF"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -17,16 +17,18 @@ jobs:
       id: form_the_message
       run: |
         BRANCHES='lean-pr-testing-1\nlean-pr-testing-2\nlean-pr-testing-3489\n'
+        for BRANCH in $BRANCHES; do
+          echo $BRANCH
+        done
         {
           printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
           printf $'```bash\n'
-          for BRANCH in $BRANCHES; do
-            PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
-            GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
-            printf $'# Diff: %s' "$GITHUB_DIFF"
-            printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "$PR_NUMBER" "$BRANCH"
-            printf '# # # # #'
-          done
+          BRANCH='lean-pr-testing-2'
+          PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
+          GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
+          printf $'# Diff: %s' "$GITHUB_DIFF"
+          printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "$PR_NUMBER" "$BRANCH"
+          printf '# # # # #\n'
           printf $'```\n'
           printf "EOF"
         } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -19,7 +19,7 @@ jobs:
           {
           printf $'msg<<EOF\nWe will need to merge the following branches into `nightly-testing`:\n'
           printf $'```bash\n'
-          PR_NUMBER = '18818'
+          PR_NUMBER='18818'
           # GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
           # printf "$GITHUB_DIFF"
           # printf $'# Diff: %s\n' "$GITHUB_DIFF"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -9,32 +9,34 @@ jobs:
   log-event-info:
     runs-on: ubuntu-latest
     steps:
-      - name: print event info
-        run: |
-          # for debugging, we print the available variables
-          echo "github.event.action: '${{ toJSON( github.event.commits ) }}'"
-      - name: format message
-        id: form_the_message
-        run: |
-          {
-          printf $'msg<<EOF\nWe will need to merge the following branches into `nightly-testing`:\n'
-          printf $'```bash\n'
-          PR_NUMBER='18818'
-          GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
-          # printf "$GITHUB_DIFF"
-          printf $'# Diff: %s\n' "$GITHUB_DIFF"
-          printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
-          printf '# # # # #\n'
-          printf $'```\n'
-          printf "EOF"
-          } >> "$GITHUB_OUTPUT"
+    - name: print event info
+      run: |
+        # for debugging, we print the available variables
+        echo "github.event.action: '${{ toJSON( github.event.commits ) }}'"
+    - name: format message
+      id: form_the_message
+      run: |
+        {
+        printf $'msg<<EOF\nWe will need to merge the following branches into `nightly-testing`:\n'
+        printf $'```bash\n'
+        BRANCH='lean-pr-testing-18818'
+        PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')
 
-      - name: send zulip test message
-        uses: zulip/github-actions-zulip/send-message@v1
-        with:
-          api-key: ${{ secrets.ZULIP_API_KEY }}
-          email: 'github-mathlib4-bot@leanprover.zulipchat.com'
-          organization-url: 'https://leanprover.zulipchat.com'
-          to: "684366"
-          type: 'private'
-          content: ${{steps.form_the_message.outputs.msg}}
+        GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
+        # printf "$GITHUB_DIFF"
+        printf $'# Diff: %s\n' "$GITHUB_DIFF"
+        printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
+        printf $'# # # # #\n'
+        printf $'```\n'
+        printf "EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: send zulip test message
+      uses: zulip/github-actions-zulip/send-message@v1
+      with:
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+        organization-url: 'https://leanprover.zulipchat.com'
+        to: "684366"
+        type: 'private'
+        content: ${{steps.form_the_message.outputs.msg}}

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -25,7 +25,7 @@ jobs:
         GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
         # printf "$GITHUB_DIFF"
         printf $'# Diff: %s\n' "$GITHUB_DIFF"
-        printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"
+        printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "$PR_NUMBER" "$BRANCH"
         printf $'# # # # #\n'
         printf $'```\n'
         printf "EOF"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -20,7 +20,7 @@ jobs:
           printf $'msg<<EOF\nWe will need to merge the following branches into `nightly-testing`:\n'
           printf $'```bash\n'
           PR_NUMBER='18818'
-          # GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
+          GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$PR_NUMBER"
           # printf "$GITHUB_DIFF"
           # printf $'# Diff: %s\n' "$GITHUB_DIFF"
           # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -20,7 +20,7 @@ jobs:
           echo "hi blizzard"
           {
 
-            printf 'msg<<EOF\n%s\nEOF' "have a backtick: `"
+            printf 'msg<<EOF\n%s\nEOF' "have a backtick next time"
             # printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
             # printf $'\`\`\`bash\n'
             # PR_NUMBER= '18818'

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -12,4 +12,4 @@ jobs:
       - name: name
         run: |
           # for debugging, we print the available variables
-          echo "github.event.action: '${{ github.event }}'"
+          echo "github.event.action: ${{ toJSON(github.event) }}"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -19,7 +19,7 @@ jobs:
           echo "hi blizzard"
           {
           printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
-          printf $'\`\`\`bash\necho test\n\`\`\`\nEOF'
+          printf $'```bash\necho test\n```\nEOF'
           # PR_NUMBER= '18818'
           # printf $'# Diff: %s' "[diff goes here]"
           # printf $'scripts/merge-lean-testing-pr.sh %s   # %s\n' "[pr number goes here]" "[branch goes here]"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -17,7 +17,7 @@ jobs:
       id: form_the_message
       run: |
         {
-        printf $'msg<<EOF\nWe will need to merge the following branches into `nightly-testing`:\n'
+        printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
         printf $'```bash\n'
         BRANCH='lean-pr-testing-18818'
         PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -1,0 +1,15 @@
+name: Send Blizzard a message on zulip
+on:
+  push:
+    branches:
+      - blizzard_inc/ci_debug**
+
+
+jobs:
+  log-event-info:
+    runs-on: ubuntu-latest
+    steps:
+      - name: name
+        run: |
+          # for debugging, we print the available variables
+          echo "github.event.action: '${{ github.event.action }}'"

--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -21,7 +21,7 @@ jobs:
           echo $BRANCH
         done
         {
-          printf $'msg<<EOF\nWe will need to merge the following branches into \`nightly-testing\`:\n'
+          printf $'msg<<EOF\nWe will need to merge the following branches into `nightly-testing`:\n'
           printf $'```bash\n'
           for BRANCH in $BRANCHES; do
             PR_NUMBER=$(echo "$BRANCH" | grep -oP '\d+$')

--- a/.github/workflows/zulip_emoji_awaiting_author.yaml
+++ b/.github/workflows/zulip_emoji_awaiting_author.yaml
@@ -9,8 +9,8 @@ jobs:
     - name: Checkout mathlib repository
       uses: actions/checkout@v4
       with:
-          sparse-checkout: |
-            scripts/zulip_emoji_merge_delegate.py
+        sparse-checkout: |
+          scripts/zulip_emoji_merge_delegate.py
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
hopefully this makes it work

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
