### PR TITLE
[Merged by Bors] - chore(ModelTheory): restate iInf to a more convenient statement

### DIFF
--- a/Mathlib/FieldTheory/AxGrothendieck.lean
+++ b/Mathlib/FieldTheory/AxGrothendieck.lean
@@ -93,7 +93,7 @@ open MvPolynomial FreeCommRing Language Field Ring BoundedFormula
 variable {ι α : Type*} [Finite α] {K : Type*} [Field K] [CompatibleRing K]
 
 /-- The collection of first order formulas corresponding to the Ax-Grothendieck theorem. -/
-noncomputable def genericPolyMapSurjOnOfInjOn [Fintype ι]
+noncomputable def genericPolyMapSurjOnOfInjOn [Finite ι]
     (φ : ring.Formula (α ⊕ ι))
     (mons : ι → Finset (ι →₀ ℕ)) : Language.ring.Sentence :=
   let l1 : ι → Language.ring.Formula ((Σ i : ι, mons i) ⊕ (Fin 2 × ι)) :=

--- a/Mathlib/FieldTheory/AxGrothendieck.lean
+++ b/Mathlib/FieldTheory/AxGrothendieck.lean
@@ -109,7 +109,7 @@ noncomputable def genericPolyMapSurjOnOfInjOn [Finite ι]
     fun i => .var (Sum.inl (Sum.inr (0, i))) =' .var (Sum.inl (Sum.inr (1, i)))
   -- x = y as a formula
   let f2 : Language.ring.Formula ((Σ i : ι, mons i) ⊕ (Fin 2 × ι)) :=
-    iInf  l2
+    iInf l2
   let injOn : Language.ring.Formula (α ⊕ Σ i : ι, mons i) :=
     Formula.iAlls (γ := Fin 2 × ι) id
       (φ.relabel (Sum.map Sum.inl (fun i => (0, i))) ⟹

--- a/Mathlib/FieldTheory/AxGrothendieck.lean
+++ b/Mathlib/FieldTheory/AxGrothendieck.lean
@@ -109,9 +109,9 @@ noncomputable def genericPolyMapSurjOnOfInjOn [Fintype ι]
     fun i => .var (Sum.inl (Sum.inr (0, i))) =' .var (Sum.inl (Sum.inr (1, i)))
   -- x = y as a formula
   let f2 : Language.ring.Formula ((Σ i : ι, mons i) ⊕ (Fin 2 × ι)) :=
-    iInf l2
+    iInf  l2
   let injOn : Language.ring.Formula (α ⊕ Σ i : ι, mons i) :=
-    Formula.iAlls (Fin 2 × ι)
+    Formula.iAlls (γ := Fin 2 × ι) id
       (φ.relabel (Sum.map Sum.inl (fun i => (0, i))) ⟹
        φ.relabel (Sum.map Sum.inl (fun i => (1, i))) ⟹
         (f1.imp f2).relabel (fun x => (Equiv.sumAssoc _ _ _).symm (Sum.inr x)))
@@ -122,23 +122,23 @@ noncomputable def genericPolyMapSurjOnOfInjOn [Fintype ι]
   let f3 : Language.ring.Formula ((Σ i : ι, mons i) ⊕ (Fin 2 × ι)) :=
     iInf l3
   let surjOn : Language.ring.Formula (α ⊕ Σ i : ι, mons i) :=
-    Formula.iAlls ι
+    Formula.iAlls (γ := ι) id
       (Formula.imp (φ.relabel (Sum.map Sum.inl id)) <|
-        Formula.iExs ι <|
-          ((φ.relabel (Sum.map Sum.inl (fun i => (0, i)))) ⊓
-            (f3.relabel (fun x => (Equiv.sumAssoc _ _ _).symm (Sum.inr x)))).relabel
+        Formula.iExs (γ := ι)
         (fun (i : (α ⊕ (Σ i : ι, mons i)) ⊕ (Fin 2 × ι)) =>
           show ((α ⊕ (Σ i : ι, mons i)) ⊕ ι) ⊕ ι
           from Sum.elim (Sum.inl ∘ Sum.inl)
-            (fun i => if i.1 = 0 then Sum.inr i.2 else (Sum.inl (Sum.inr i.2))) i))
+            (fun i => if i.1 = 0 then Sum.inr i.2 else (Sum.inl (Sum.inr i.2))) i)
+          ((φ.relabel (Sum.map Sum.inl (fun i => (0, i)))) ⊓
+            (f3.relabel (fun x => (Equiv.sumAssoc _ _ _).symm (Sum.inr x)))))
   let mapsTo : Language.ring.Formula (α ⊕ Σ i : ι, mons i) :=
-    Formula.iAlls ι
+    Formula.iAlls (γ := ι) id
       (Formula.imp (φ.relabel (Sum.map Sum.inl id))
         (φ.subst <| Sum.elim
           (fun a => .var (Sum.inl (Sum.inl a)))
           (fun i => (termOfFreeCommRing (genericPolyMap mons i)).relabel
             (fun i => (Equiv.sumAssoc _ _ _).symm (Sum.inr i)))))
-  Formula.iAlls (α ⊕ Σ i : ι, mons i) ((mapsTo.imp <| injOn.imp <| surjOn).relabel Sum.inr)
+  Formula.iAlls (γ := α ⊕ Σ i : ι, mons i) Sum.inr (mapsTo ⟹ injOn ⟹ surjOn)
 
 theorem realize_genericPolyMapSurjOnOfInjOn
     [Fintype ι] (φ : ring.Formula (α ⊕ ι)) (mons : ι → Finset (ι →₀ ℕ)) :

--- a/Mathlib/FieldTheory/AxGrothendieck.lean
+++ b/Mathlib/FieldTheory/AxGrothendieck.lean
@@ -111,7 +111,7 @@ noncomputable def genericPolyMapSurjOnOfInjOn [Fintype ι]
   let f2 : Language.ring.Formula ((Σ i : ι, mons i) ⊕ (Fin 2 × ι)) :=
     iInf Finset.univ l2
   let injOn : Language.ring.Formula (α ⊕ Σ i : ι, mons i) :=
-    Formula.iAlls (γ := Fin 2 × ι) id
+    Formula.iAlls (Fin 2 × ι)
       (φ.relabel (Sum.map Sum.inl (fun i => (0, i))) ⟹
        φ.relabel (Sum.map Sum.inl (fun i => (1, i))) ⟹
         (f1.imp f2).relabel (fun x => (Equiv.sumAssoc _ _ _).symm (Sum.inr x)))
@@ -122,23 +122,23 @@ noncomputable def genericPolyMapSurjOnOfInjOn [Fintype ι]
   let f3 : Language.ring.Formula ((Σ i : ι, mons i) ⊕ (Fin 2 × ι)) :=
     iInf Finset.univ l3
   let surjOn : Language.ring.Formula (α ⊕ Σ i : ι, mons i) :=
-    Formula.iAlls (γ := ι) id
+    Formula.iAlls ι
       (Formula.imp (φ.relabel (Sum.map Sum.inl id)) <|
-        Formula.iExs (γ := ι)
+        Formula.iExs ι <|
+          ((φ.relabel (Sum.map Sum.inl (fun i => (0, i)))) ⊓
+            (f3.relabel (fun x => (Equiv.sumAssoc _ _ _).symm (Sum.inr x)))).relabel
         (fun (i : (α ⊕ (Σ i : ι, mons i)) ⊕ (Fin 2 × ι)) =>
           show ((α ⊕ (Σ i : ι, mons i)) ⊕ ι) ⊕ ι
           from Sum.elim (Sum.inl ∘ Sum.inl)
-            (fun i => if i.1 = 0 then Sum.inr i.2 else (Sum.inl (Sum.inr i.2))) i)
-          ((φ.relabel (Sum.map Sum.inl (fun i => (0, i)))) ⊓
-            (f3.relabel (fun x => (Equiv.sumAssoc _ _ _).symm (Sum.inr x)))))
+            (fun i => if i.1 = 0 then Sum.inr i.2 else (Sum.inl (Sum.inr i.2))) i))
   let mapsTo : Language.ring.Formula (α ⊕ Σ i : ι, mons i) :=
-    Formula.iAlls (γ := ι) id
+    Formula.iAlls ι
       (Formula.imp (φ.relabel (Sum.map Sum.inl id))
         (φ.subst <| Sum.elim
           (fun a => .var (Sum.inl (Sum.inl a)))
           (fun i => (termOfFreeCommRing (genericPolyMap mons i)).relabel
             (fun i => (Equiv.sumAssoc _ _ _).symm (Sum.inr i)))))
-  Formula.iAlls (γ := α ⊕ Σ i : ι, mons i) Sum.inr (mapsTo ⟹ injOn ⟹ surjOn)
+  Formula.iAlls (α ⊕ Σ i : ι, mons i) ((mapsTo.imp <| injOn.imp <| surjOn).relabel Sum.inr)
 
 theorem realize_genericPolyMapSurjOnOfInjOn
     [Fintype ι] (φ : ring.Formula (α ⊕ ι)) (mons : ι → Finset (ι →₀ ℕ)) :

--- a/Mathlib/FieldTheory/AxGrothendieck.lean
+++ b/Mathlib/FieldTheory/AxGrothendieck.lean
@@ -104,12 +104,12 @@ noncomputable def genericPolyMapSurjOnOfInjOn [Fintype ι]
         (Sum.inl ∘ Sum.map id (fun i => (1, i)))
   -- p(x) = p(y) as a formula
   let f1 : Language.ring.Formula ((Σ i : ι, mons i) ⊕ (Fin 2 × ι)) :=
-    iInf Finset.univ l1
+    iInf l1
   let l2 : ι → Language.ring.Formula ((Σ i : ι, mons i) ⊕ (Fin 2 × ι)) :=
     fun i => .var (Sum.inl (Sum.inr (0, i))) =' .var (Sum.inl (Sum.inr (1, i)))
   -- x = y as a formula
   let f2 : Language.ring.Formula ((Σ i : ι, mons i) ⊕ (Fin 2 × ι)) :=
-    iInf Finset.univ l2
+    iInf l2
   let injOn : Language.ring.Formula (α ⊕ Σ i : ι, mons i) :=
     Formula.iAlls (Fin 2 × ι)
       (φ.relabel (Sum.map Sum.inl (fun i => (0, i))) ⟹
@@ -120,7 +120,7 @@ noncomputable def genericPolyMapSurjOnOfInjOn [Fintype ι]
         (Sum.inl ∘ Sum.map id (fun i => (0, i))) ='
       .var (Sum.inl (Sum.inr (1, i)))
   let f3 : Language.ring.Formula ((Σ i : ι, mons i) ⊕ (Fin 2 × ι)) :=
-    iInf Finset.univ l3
+    iInf l3
   let surjOn : Language.ring.Formula (α ⊕ Σ i : ι, mons i) :=
     Formula.iAlls ι
       (Formula.imp (φ.relabel (Sum.map Sum.inl id)) <|

--- a/Mathlib/ModelTheory/Algebra/Ring/Definability.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Definability.lean
@@ -33,7 +33,7 @@ theorem mvPolynomial_zeroLocus_definable {ι K : Type*} [Field K]
   letI := Classical.decEq K
   rw [MvPolynomial.zeroLocus_span]
   refine ⟨BoundedFormula.iInf
-      (fun i : S.attach => Term.equal
+      (fun i : S => Term.equal
         ((termOfFreeCommRing (p' i)).relabel
           (Sum.map (fun p => ⟨p.1.1.coeff p.2.1, by
             simp only [Set.mem_iUnion]

--- a/Mathlib/ModelTheory/Algebra/Ring/Definability.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Definability.lean
@@ -32,8 +32,8 @@ theorem mvPolynomial_zeroLocus_definable {ι K : Type*} [Field K]
   letI := Classical.decEq ι
   letI := Classical.decEq K
   rw [MvPolynomial.zeroLocus_span]
-  refine ⟨BoundedFormula.iInf S.attach
-      (fun i => Term.equal
+  refine ⟨BoundedFormula.iInf
+      (fun i : S.attach => Term.equal
         ((termOfFreeCommRing (p' i)).relabel
           (Sum.map (fun p => ⟨p.1.1.coeff p.2.1, by
             simp only [Set.mem_iUnion]

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -830,7 +830,7 @@ theorem realize_toFormula (φ : L.BoundedFormula α n) (v : α ⊕ (Fin n) → M
     · exact Fin.elim0 x
 
 @[simp]
-theorem realize_iSup [Finite β](f : β → L.BoundedFormula α n)
+theorem realize_iSup [Finite β] (f : β → L.BoundedFormula α n)
     (v : α → M) (v' : Fin n → M) :
     (iSup f).Realize v v' ↔ ∃ b, (f b).Realize v v' := by
   simp only [iSup, realize_foldr_sup, List.mem_map, Finset.mem_toList, Finset.mem_univ, true_and,

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -748,10 +748,9 @@ theorem realize_exs {φ : L.BoundedFormula α n} {v : α → M} :
 
 @[simp]
 theorem _root_.FirstOrder.Language.Formula.realize_iAlls
-    [Finite γ] {f : α → β ⊕ γ}
-    {φ : L.Formula α} {v : β → M} : (φ.iAlls f).Realize v ↔
-      ∀ (i : γ → M), φ.Realize (fun a => Sum.elim v i (f a)) := by
-  let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin γ))
+    [Finite β] {φ : L.Formula (α ⊕ β)} {v : α → M} : (φ.iAlls β).Realize v ↔
+      ∀ (i : β → M), φ.Realize (fun a => Sum.elim v i a) := by
+  let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin β))
   rw [Formula.iAlls]
   simp only [Nat.add_zero, realize_alls, realize_relabel, Function.comp_def,
     castAdd_zero, finCongr_refl, OrderIso.refl_apply, Sum.elim_map, id_eq]
@@ -766,23 +765,20 @@ theorem _root_.FirstOrder.Language.Formula.realize_iAlls
     exact i.elim0
 
 @[simp]
-theorem realize_iAlls [Finite γ] {f : α → β ⊕ γ}
-    {φ : L.Formula α} {v : β → M} {v' : Fin 0 → M} :
-    BoundedFormula.Realize (φ.iAlls f) v v' ↔
-      ∀ (i : γ → M), φ.Realize (fun a => Sum.elim v i (f a)) := by
+theorem realize_iAlls [Finite β] {φ : L.Formula (α ⊕ β)} {v : α → M} {v' : Fin 0 → M} :
+    BoundedFormula.Realize (φ.iAlls β) v v' ↔
+      ∀ (i : β → M), φ.Realize (fun a => Sum.elim v i a) := by
   rw [← Formula.realize_iAlls, iff_iff_eq]; congr; simp [eq_iff_true_of_subsingleton]
 
 @[simp]
 theorem _root_.FirstOrder.Language.Formula.realize_iExs
-    [Finite γ] {f : α → β ⊕ γ}
-    {φ : L.Formula α} {v : β → M} : (φ.iExs f).Realize v ↔
-      ∃ (i : γ → M), φ.Realize (fun a => Sum.elim v i (f a)) := by
+    [Finite γ] {φ : L.Formula (α ⊕ γ)} {v : α → M} : (φ.iExs γ).Realize v ↔
+      ∃ (i : γ → M), φ.Realize (Sum.elim v i) := by
   let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin γ))
   rw [Formula.iExs]
   simp only [Nat.add_zero, realize_exs, realize_relabel, Function.comp_def,
     castAdd_zero, finCongr_refl, OrderIso.refl_apply, Sum.elim_map, id_eq]
-  rw [← not_iff_not, not_exists, not_exists]
-  refine Equiv.forall_congr ?_ ?_
+  refine Equiv.exists_congr ?_ ?_
   · exact ⟨fun v => v ∘ e, fun v => v ∘ e.symm,
       fun _ => by simp [Function.comp_def],
       fun _ => by simp [Function.comp_def]⟩
@@ -793,10 +789,9 @@ theorem _root_.FirstOrder.Language.Formula.realize_iExs
     exact i.elim0
 
 @[simp]
-theorem realize_iExs [Finite γ] {f : α → β ⊕ γ}
-    {φ : L.Formula α} {v : β → M} {v' : Fin 0 → M} :
-    BoundedFormula.Realize (φ.iExs f) v v' ↔
-      ∃ (i : γ → M), φ.Realize (fun a => Sum.elim v i (f a)) := by
+theorem realize_iExs [Finite γ] {φ : L.Formula (α ⊕ γ)} {v : α → M} {v' : Fin 0 → M} :
+    BoundedFormula.Realize (φ.iExs γ) v v' ↔
+      ∃ (i : γ → M), φ.Realize (Sum.elim v i) := by
   rw [← Formula.realize_iExs, iff_iff_eq]; congr; simp [eq_iff_true_of_subsingleton]
 
 @[simp]

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -800,12 +800,6 @@ theorem realize_iExs [Finite γ] {f : α → β ⊕ γ}
   rw [← Formula.realize_iExs, iff_iff_eq]; congr; simp [eq_iff_true_of_subsingleton]
 
 @[simp]
-theorem realize_iExs [Finite γ] {φ : L.Formula (α ⊕ γ)} {v : α → M} {v' : Fin 0 → M} :
-    BoundedFormula.Realize (φ.iExs γ) v v' ↔
-      ∃ (i : γ → M), φ.Realize (Sum.elim v i) := by
-  rw [← Formula.realize_iExs, iff_iff_eq]; congr; simp [eq_iff_true_of_subsingleton]
-
-@[simp]
 theorem realize_toFormula (φ : L.BoundedFormula α n) (v : α ⊕ (Fin n) → M) :
     φ.toFormula.Realize v ↔ φ.Realize (v ∘ Sum.inl) (v ∘ Sum.inr) := by
   induction φ with

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -748,9 +748,10 @@ theorem realize_exs {φ : L.BoundedFormula α n} {v : α → M} :
 
 @[simp]
 theorem _root_.FirstOrder.Language.Formula.realize_iAlls
-    [Finite β] {φ : L.Formula (α ⊕ β)} {v : α → M} : (φ.iAlls β).Realize v ↔
-      ∀ (i : β → M), φ.Realize (fun a => Sum.elim v i a) := by
-  let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin β))
+    [Finite γ] {f : α → β ⊕ γ}
+    {φ : L.Formula α} {v : β → M} : (φ.iAlls f).Realize v ↔
+      ∀ (i : γ → M), φ.Realize (fun a => Sum.elim v i (f a)) := by
+  let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin γ))
   rw [Formula.iAlls]
   simp only [Nat.add_zero, realize_alls, realize_relabel, Function.comp_def,
     castAdd_zero, finCongr_refl, OrderIso.refl_apply, Sum.elim_map, id_eq]
@@ -765,20 +766,23 @@ theorem _root_.FirstOrder.Language.Formula.realize_iAlls
     exact i.elim0
 
 @[simp]
-theorem realize_iAlls [Finite β] {φ : L.Formula (α ⊕ β)} {v : α → M} {v' : Fin 0 → M} :
-    BoundedFormula.Realize (φ.iAlls β) v v' ↔
-      ∀ (i : β → M), φ.Realize (fun a => Sum.elim v i a) := by
+theorem realize_iAlls [Finite γ] {f : α → β ⊕ γ}
+    {φ : L.Formula α} {v : β → M} {v' : Fin 0 → M} :
+    BoundedFormula.Realize (φ.iAlls f) v v' ↔
+      ∀ (i : γ → M), φ.Realize (fun a => Sum.elim v i (f a)) := by
   rw [← Formula.realize_iAlls, iff_iff_eq]; congr; simp [eq_iff_true_of_subsingleton]
 
 @[simp]
 theorem _root_.FirstOrder.Language.Formula.realize_iExs
-    [Finite γ] {φ : L.Formula (α ⊕ γ)} {v : α → M} : (φ.iExs γ).Realize v ↔
-      ∃ (i : γ → M), φ.Realize (Sum.elim v i) := by
+    [Finite γ] {f : α → β ⊕ γ}
+    {φ : L.Formula α} {v : β → M} : (φ.iExs f).Realize v ↔
+      ∃ (i : γ → M), φ.Realize (fun a => Sum.elim v i (f a)) := by
   let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin γ))
   rw [Formula.iExs]
   simp only [Nat.add_zero, realize_exs, realize_relabel, Function.comp_def,
     castAdd_zero, finCongr_refl, OrderIso.refl_apply, Sum.elim_map, id_eq]
-  refine Equiv.exists_congr ?_ ?_
+  rw [← not_iff_not, not_exists, not_exists]
+  refine Equiv.forall_congr ?_ ?_
   · exact ⟨fun v => v ∘ e, fun v => v ∘ e.symm,
       fun _ => by simp [Function.comp_def],
       fun _ => by simp [Function.comp_def]⟩
@@ -787,6 +791,13 @@ theorem _root_.FirstOrder.Language.Formula.realize_iExs
     congr
     funext i
     exact i.elim0
+
+@[simp]
+theorem realize_iExs [Finite γ] {f : α → β ⊕ γ}
+    {φ : L.Formula α} {v : β → M} {v' : Fin 0 → M} :
+    BoundedFormula.Realize (φ.iExs f) v v' ↔
+      ∃ (i : γ → M), φ.Realize (fun a => Sum.elim v i (f a)) := by
+  rw [← Formula.realize_iExs, iff_iff_eq]; congr; simp [eq_iff_true_of_subsingleton]
 
 @[simp]
 theorem realize_iExs [Finite γ] {φ : L.Formula (α ⊕ γ)} {v : α → M} {v' : Fin 0 → M} :

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -825,18 +825,18 @@ theorem realize_toFormula (φ : L.BoundedFormula α n) (v : α ⊕ (Fin n) → M
     · exact Fin.elim0 x
 
 @[simp]
-theorem realize_iSup (s : Finset β) (f : β → L.BoundedFormula α n)
+theorem realize_iSup [Finite β](f : β → L.BoundedFormula α n)
     (v : α → M) (v' : Fin n → M) :
-    (iSup s f).Realize v v' ↔ ∃ b ∈ s, (f b).Realize v v' := by
-  simp only [iSup, realize_foldr_sup, List.mem_map, Finset.mem_toList,
-    exists_exists_and_eq_and]
+    (iSup f).Realize v v' ↔ ∃ b, (f b).Realize v v' := by
+  simp only [iSup, realize_foldr_sup, List.mem_map, Finset.mem_toList, Finset.mem_univ, true_and,
+    exists_exists_eq_and]
 
 @[simp]
-theorem realize_iInf (s : Finset β) (f : β → L.BoundedFormula α n)
+theorem realize_iInf [Finite β] (f : β → L.BoundedFormula α n)
     (v : α → M) (v' : Fin n → M) :
-    (iInf s f).Realize v v' ↔ ∀ b ∈ s, (f b).Realize v v' := by
-  simp only [iInf, realize_foldr_inf, List.mem_map, Finset.mem_toList,
-    forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+    (iInf f).Realize v v' ↔ ∀ b, (f b).Realize v v' := by
+  simp only [iInf, realize_foldr_inf, List.mem_map, Finset.mem_toList, Finset.mem_univ, true_and,
+    forall_exists_index, forall_apply_eq_imp_iff]
 
 end BoundedFormula
 

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -601,12 +601,14 @@ def toFormula : ∀ {n : ℕ}, L.BoundedFormula α n → L.Formula (α ⊕ (Fin 
         (Sum.elim (Sum.inl ∘ Sum.inl) (Sum.map Sum.inr id ∘ finSumFinEquiv.symm))).all
 
 /-- take the disjunction of a finite set of formulas -/
-noncomputable def iSup (s : Finset β) (f : β → L.BoundedFormula α n) : L.BoundedFormula α n :=
-  (s.toList.map f).foldr (· ⊔ ·) ⊥
+noncomputable def iSup [Finite β] (f : β → L.BoundedFormula α n) : L.BoundedFormula α n :=
+  let _ := Fintype.ofFinite β
+  ((Finset.univ : Finset β).toList.map f).foldr (· ⊔ ·) ⊥
 
 /-- take the conjunction of a finite set of formulas -/
-noncomputable def iInf (s : Finset β) (f : β → L.BoundedFormula α n) : L.BoundedFormula α n :=
-  (s.toList.map f).foldr (· ⊓ ·) ⊤
+noncomputable def iInf [Finite β] (f : β → L.BoundedFormula α n) : L.BoundedFormula α n :=
+  let _ := Fintype.ofFinite β
+  ((Finset.univ : Finset β).toList.map f).foldr (· ⊓ ·) ⊤
 
 end BoundedFormula
 

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -744,18 +744,21 @@ protected nonrec abbrev not (φ : L.Formula α) : L.Formula α :=
 protected abbrev imp : L.Formula α → L.Formula α → L.Formula α :=
   BoundedFormula.imp
 
-variable (β)
-/-- `iAlls f φ` transforms a `L.Formula (α ⊕ β)` into a `L.Formula β` by universally
+/-- Given a map `f : α → β ⊕ γ`, `iAlls f φ` transforms a `L.Formula α`
+into a `L.Formula β` by renaming variables with the map `f` and then universally
 quantifying over all variables `Sum.inr _`. -/
-noncomputable def iAlls [Finite β] (φ : L.Formula (α ⊕ β)) : L.Formula α :=
-  let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin β))
-  (BoundedFormula.relabel (fun a => Sum.map id e a) φ).alls
+noncomputable def iAlls [Finite γ] (f : α → β ⊕ γ)
+    (φ : L.Formula α) : L.Formula β :=
+  let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin γ))
+  (BoundedFormula.relabel (fun a => Sum.map id e (f a)) φ).alls
 
-/-- `iExs f φ` transforms a `L.Formula (α ⊕ β)` into a `L.Formula β` by existentially
+/-- Given a map `f : α → β ⊕ γ`, `iExs f φ` transforms a `L.Formula α`
+into a `L.Formula β` by renaming variables with the map `f` and then existentially
 quantifying over all variables `Sum.inr _`. -/
-noncomputable def iExs [Finite β] (φ : L.Formula (α ⊕ β)) : L.Formula α :=
-  let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin β))
-  (BoundedFormula.relabel (fun a => Sum.map id e a) φ).exs
+noncomputable def iExs [Finite γ] (f : α → β ⊕ γ)
+    (φ : L.Formula α) : L.Formula β :=
+  let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin γ))
+  (BoundedFormula.relabel (fun a => Sum.map id e (f a)) φ).exs
 
 /-- The biimplication between formulas, as a formula. -/
 protected nonrec abbrev iff (φ ψ : L.Formula α) : L.Formula α :=

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -742,21 +742,18 @@ protected nonrec abbrev not (φ : L.Formula α) : L.Formula α :=
 protected abbrev imp : L.Formula α → L.Formula α → L.Formula α :=
   BoundedFormula.imp
 
-/-- Given a map `f : α → β ⊕ γ`, `iAlls f φ` transforms a `L.Formula α`
-into a `L.Formula β` by renaming variables with the map `f` and then universally
+variable (β)
+/-- `iAlls f φ` transforms a `L.Formula (α ⊕ β)` into a `L.Formula β` by universally
 quantifying over all variables `Sum.inr _`. -/
-noncomputable def iAlls [Finite γ] (f : α → β ⊕ γ)
-    (φ : L.Formula α) : L.Formula β :=
-  let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin γ))
-  (BoundedFormula.relabel (fun a => Sum.map id e (f a)) φ).alls
+noncomputable def iAlls [Finite β] (φ : L.Formula (α ⊕ β)) : L.Formula α :=
+  let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin β))
+  (BoundedFormula.relabel (fun a => Sum.map id e a) φ).alls
 
-/-- Given a map `f : α → β ⊕ γ`, `iExs f φ` transforms a `L.Formula α`
-into a `L.Formula β` by renaming variables with the map `f` and then existentially
+/-- `iExs f φ` transforms a `L.Formula (α ⊕ β)` into a `L.Formula β` by existentially
 quantifying over all variables `Sum.inr _`. -/
-noncomputable def iExs [Finite γ] (f : α → β ⊕ γ)
-    (φ : L.Formula α) : L.Formula β :=
-  let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin γ))
-  (BoundedFormula.relabel (fun a => Sum.map id e (f a)) φ).exs
+noncomputable def iExs [Finite β] (φ : L.Formula (α ⊕ β)) : L.Formula α :=
+  let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin β))
+  (BoundedFormula.relabel (fun a => Sum.map id e a) φ).exs
 
 /-- The biimplication between formulas, as a formula. -/
 protected nonrec abbrev iff (φ ψ : L.Formula α) : L.Formula α :=


### PR DESCRIPTION
---
I often found myself locally introducing `Fintype.ofFinite`. This statement means you don't have to do that.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
