### PR TITLE
feat(SetTheory/Game/PGame): removing options

### DIFF
--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1313,6 +1313,8 @@ def toRightMovesNeg {x : PGame} : x.LeftMoves ≃ (-x).RightMoves :=
 def asLeftMovesNeg {x : PGame} (i : x.RightMoves) : (-x).LeftMoves :=
   (leftMoves_neg x).mpr i
 
+def asRightMovesNeg {x : PGame} (i : x.LeftMoves) : (-x).RightMoves :=
+  (rightMoves_neg x).mpr i
 
 @[simp]
 theorem moveLeft_neg {x : PGame} (i) :

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1310,9 +1310,11 @@ between them. -/
 def toRightMovesNeg {x : PGame} : x.LeftMoves ≃ (-x).RightMoves :=
   Equiv.cast (rightMoves_neg x).symm
 
+/-- Converts x.RightMoves to (-x).LeftMoves, as proved in `toLeftMovesNeg`. -/
 def asLeftMovesNeg {x : PGame} (i : x.RightMoves) : (-x).LeftMoves :=
   (leftMoves_neg x).mpr i
 
+/-- Converts x.LeftMoves to (-x).RightMoves, as proved in `toRightMovesNeg`. -/
 def asRightMovesNeg {x : PGame} (i : x.LeftMoves) : (-x).RightMoves :=
   (rightMoves_neg x).mpr i
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1904,7 +1904,7 @@ theorem insertRight_insertLeft {x x' x'' : PGame} :
 
 /-! ### Removing an option -/
 
-/-- The pregame constructed by removing `'x` as a left option from `x`. -/
+/-- The PGame constructed by removing `'x` as a left option from `x`. -/
 def removeLeft (x x' : PGame.{u}) : PGame :=
   match x with
   | mk _ xr xL xR => mk { x // ¬(xL x ≡ x') } xr (fun i ↦ xL (↑i)) xR
@@ -1926,6 +1926,7 @@ theorem removeLeft_le (x x' : PGame) : x.removeLeft x' ≤ x := by
     use j
     rfl
 
+/-- The PGame constructed by removing `'x` as a right option from `x`. -/
 def removeRight (x x' : PGame.{u}) : PGame :=
   match x with
   | mk xl _ xL xR => mk xl { x // ¬(xR x ≡ x') } xL (fun i ↦ xR (↑i))

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1902,6 +1902,49 @@ theorem insertRight_insertLeft {x x' x'' : PGame} :
   cases x; cases x'; cases x''
   dsimp [insertLeft, insertRight]
 
+/-! ### Removing an option -/
+
+/-- The pregame constructed by removing `'x` as a left option from `x`. -/
+def removeLeft (x x' : PGame.{u}) : PGame :=
+  match x with
+  | mk _ xr xL xR => mk { x // ¬(xL x ≡ x') } xr (fun i ↦ xL (↑i)) xR
+
+/-- One less left option will not empower Left. -/
+theorem removeLeft_le (x x' : PGame) : x.removeLeft x' ≤ x := by
+  rw [le_def]
+  constructor
+  · intro i
+    left
+    rcases x with ⟨xl, xr, xL, xR⟩
+    simp only [moveLeft_mk]
+    constructor
+    rfl
+  · intro j
+    right
+    rcases x with ⟨xl, xr, xL, xR⟩
+    simp only [moveRight_mk]
+    use j
+    rfl
+
+def removeRight (x x' : PGame.{u}) : PGame :=
+  match x with
+  | mk xl _ xL xR => mk xl { x // ¬(xR x ≡ x') } xL (fun i ↦ xR (↑i))
+
+theorem neg_removeRight_neg (x x' : PGame.{u}) : (-x).removeLeft (-x') = -x.removeRight x' := by
+  induction x with | mk =>
+    rw [neg_def, removeLeft, removeRight, neg_def]
+    simp only [mk.injEq, neg_identical_neg_iff, heq_eq_eq, and_true, true_and]
+    refine Function.hfunext (congrArg Subtype (by simp)) ?_
+    simp only [heq_eq_eq, neg_inj, Subtype.forall, neg_identical_neg_iff]
+    rintro a ha b hb h
+    simp only [neg_identical_neg_iff, implies_true, Subtype.heq_iff_coe_eq] at h
+    rw [h]
+
+/-- One less right option will not empower Right. -/
+theorem removeRight_le (x x' : PGame) : x ≤ x.removeRight x' := by
+  rw [← neg_le_neg_iff, ← neg_removeRight_neg]
+  simp only [removeLeft_le]
+
 /-! ### Special pre-games -/
 
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1310,14 +1310,6 @@ between them. -/
 def toRightMovesNeg {x : PGame} : x.LeftMoves ≃ (-x).RightMoves :=
   Equiv.cast (rightMoves_neg x).symm
 
-/-- Converts x.RightMoves to (-x).LeftMoves, as proved in `toLeftMovesNeg`. -/
-def asLeftMovesNeg {x : PGame} (i : x.RightMoves) : (-x).LeftMoves :=
-  (leftMoves_neg x).mpr i
-
-/-- Converts x.LeftMoves to (-x).RightMoves, as proved in `toRightMovesNeg`. -/
-def asRightMovesNeg {x : PGame} (i : x.LeftMoves) : (-x).RightMoves :=
-  (rightMoves_neg x).mpr i
-
 @[simp]
 theorem moveLeft_neg {x : PGame} (i) :
     (-x).moveLeft i = -x.moveRight (toLeftMovesNeg.symm i) := by
@@ -1940,7 +1932,7 @@ def removeRight (x : PGame.{u}) (i : x.RightMoves) : PGame :=
   | mk xl _ xL xR => mk xl { x // x ≠ i } xL (xR ·.val)
 
 theorem neg_removeRight_neg (x : PGame.{u}) (i : x.RightMoves) :
-    (-x).removeLeft (asLeftMovesNeg i) = -x.removeRight i := by
+    (-x).removeLeft (toLeftMovesNeg i) = -x.removeRight i := by
   cases x
   dsimp [insertRight, insertLeft]
   congr! with (i | j)

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1915,7 +1915,7 @@ theorem insertRight_insertLeft {x x' x'' : PGame} :
 /-- The PGame constructed by removing `'x` as a left option from `x`. -/
 def removeLeft (x : PGame.{u}) (i : x.LeftMoves) : PGame :=
   match x with
-  | mk _ xr xL xR => mk ({ x // x ≠ i }) xr (fun k ↦ xL (k.val)) xR
+  | mk _ xr xL xR => mk { x // x ≠ i } xr (xL ·.val) xR
 
 /-- One less left option will not empower Left. -/
 theorem removeLeft_le (x : PGame) (i : x.LeftMoves) : x.removeLeft i ≤ x := by
@@ -1937,7 +1937,7 @@ theorem removeLeft_le (x : PGame) (i : x.LeftMoves) : x.removeLeft i ≤ x := by
 /-- The PGame constructed by removing `'x` as a right option from `x`. -/
 def removeRight (x : PGame.{u}) (i : x.RightMoves) : PGame :=
   match x with
-  | mk xl _ xL xR => mk xl { x // x ≠ i } xL (fun i ↦ xR (i.val))
+  | mk xl _ xL xR => mk xl { x // x ≠ i } xL (xR ·.val)
 
 theorem neg_removeRight_neg (x : PGame.{u}) (i : x.RightMoves) :
     (-x).removeLeft (asLeftMovesNeg i) = -x.removeRight i := by


### PR DESCRIPTION
Allows PGame options to be removed. To build up to the replacement lemma, necessary for the equivalence of games to their undominated selves.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
