### PR TITLE
[Merged by Bors] - feat(ModelTheory): boundedFormula_realize_eq_realize

### DIFF
--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -568,6 +568,12 @@ theorem realize_graph {f : L.Functions n} {x : Fin n → M} {y : M} :
   simp only [Formula.graph, Term.realize, realize_equal, Fin.cons_zero, Fin.cons_succ]
   rw [eq_comm]
 
+theorem boundedFormula_realize_eq_realize (φ : L.Formula α) (x : α → M) (y : Fin 0 → M) :
+    BoundedFormula.Realize φ x y ↔ φ.Realize x := by
+  rw [Formula.Realize, iff_iff_eq]
+  congr
+  ext i; exact Fin.elim0 i
+
 end Formula
 
 @[simp]


### PR DESCRIPTION
---
Sometimes you cannot use a theorem about the semantics of a `Formula` because it uses `BoundedFormula.Realize` in the goal instead of `Formula.Realize`. This lemma helps with that situation.

Long term I think that there needs to be a better solution to the `Formula`, BoundedFormula` duplication and `Formula` should at least not be reducible in my opinion.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
