### PR TITLE
[Merged by Bors] - feat(Order/KrullDimension): equivalent conditions for zero-dimensional, one-dimensional etc

### DIFF
--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -461,3 +461,17 @@ protected def _root_.RingHom.ENatMap {S : Type*} [CanonicallyOrderedCommSemiring
   {MonoidWithZeroHom.ENatMap f.toMonoidWithZeroHom hf, f.toAddMonoidHom.ENatMap with}
 
 end ENat
+
+lemma WithBot.lt_add_one_iff {n : WithBot ℕ∞} {m : ℕ} : n < m + 1 ↔ n ≤ m := by
+  rw [← WithBot.coe_one, ← ENat.coe_one, WithBot.coe_natCast, ← Nat.cast_add, ← WithBot.coe_natCast]
+  cases n
+  · simp only [bot_le, iff_true, WithBot.bot_lt_coe]
+  · rw [WithBot.coe_lt_coe, Nat.cast_add, ENat.coe_one, ENat.lt_add_one_iff (ENat.coe_ne_top _),
+      ← WithBot.coe_le_coe, WithBot.coe_natCast]
+
+lemma WithBot.add_one_le_iff {n : ℕ} {m : WithBot ℕ∞} : n + 1 ≤ m ↔ n < m := by
+  rw [← WithBot.coe_one, ← ENat.coe_one, WithBot.coe_natCast, ← Nat.cast_add, ← WithBot.coe_natCast]
+  cases m
+  · simp
+  · rw [WithBot.coe_le_coe, ENat.coe_add, ENat.coe_one, ENat.add_one_le_iff (ENat.coe_ne_top n),
+      ← WithBot.coe_lt_coe, WithBot.coe_natCast]

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -512,9 +512,7 @@ lemma LTSeries.length_le_krullDim (p : LTSeries α) : p.length ≤ krullDim α :
 lemma krullDim_eq_bot_iff : krullDim α = ⊥ ↔ IsEmpty α := by
   rw [eq_bot_iff, krullDim, iSup_le_iff]
   simp only [le_bot_iff, WithBot.natCast_ne_bot, isEmpty_iff]
-  constructor
-  · exact fun H x ↦ H ⟨0, fun _ ↦ x, by simp⟩
-  · exact fun H x ↦ H (x 1)
+  exact ⟨fun H x ↦ H ⟨0, fun _ ↦ x, by simp⟩, (· <| · 1)⟩
 
 lemma krullDim_nonneg_iff : 0 ≤ krullDim α ↔ Nonempty α := by
   rw [← not_iff_not, not_le, not_nonempty_iff, ← krullDim_eq_bot_iff, ← WithBot.lt_coe_bot,
@@ -530,11 +528,9 @@ lemma krullDim_nonneg [Nonempty α] : 0 ≤ krullDim α := krullDim_nonneg_iff.m
 
 lemma krullDim_nonpos_iff_forall_isMax : krullDim α ≤ 0 ↔ ∀ x : α, IsMax x := by
   simp only [krullDim, iSup_le_iff, isMax_iff_forall_not_lt]
-  constructor
-  · intro H x y h
-    exact (H ⟨1, ![x, y], fun i ↦ by obtain rfl := Subsingleton.elim i 0; simpa⟩).not_lt (by simp)
-  · rintro H ⟨n, l, h⟩
-    cases' n with n
+  refine ⟨fun H x y h ↦ (H ⟨1, ![x, y],
+    fun i ↦ by obtain rfl := Subsingleton.elim i 0; simpa⟩).not_lt (by simp), ?_⟩
+  · rintro H ⟨_ | n, l, h⟩
     · simp
     · cases H (l 0) (l 1) (h 0)
 
@@ -547,9 +543,8 @@ lemma krullDim_le_one_iff : krullDim α ≤ 1 ↔ ∀ x : α, IsMin x ∨ IsMax 
   simp_rw [isMax_iff_forall_not_lt, isMin_iff_forall_not_lt, krullDim, iSup_le_iff]
   push_neg
   constructor
-  · rintro ⟨⟨n, l, hl⟩, hl'⟩
-    cases' n with n; · cases hl'.not_le (by simp)
-    cases' n with n; · cases hl'.not_le (by simp)
+  · rintro ⟨⟨_ | _ | n, l, hl⟩, hl'⟩
+    iterate 2 · cases hl'.not_le (by simp)
     exact ⟨l 1, ⟨l 0, hl 0⟩, l 2, hl 1⟩
   · rintro ⟨x, ⟨y, hxy⟩, z, hzx⟩
     exact ⟨⟨2, ![y, x, z], fun i ↦ by fin_cases i <;> simpa⟩, by simp⟩
@@ -633,7 +628,7 @@ lemma krullDim_lt_coe_iff {n : ℕ} : krullDim α < n ↔ ∀ l : LTSeries α, l
   · simp [WithBot.lt_add_one_iff, WithBot.coe_natCast, Nat.lt_succ]
 
 lemma krullDim_le_of_strictMono (f : α → β) (hf : StrictMono f) : krullDim α ≤ krullDim β :=
-  iSup_le <| fun p ↦ le_sSup ⟨p.map f hf, rfl⟩
+  iSup_le fun p ↦ le_sSup ⟨p.map f hf, rfl⟩
 
 lemma krullDim_le_of_strictComono_and_surj
     (f : α → β) (hf : ∀ ⦃a b⦄, f a < f b → a < b) (hf' : Function.Surjective f) :

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Order.Group.Int
 import Mathlib.Data.ENat.Lattice
 import Mathlib.Order.Minimal
 import Mathlib.Order.RelSeries
+import Mathlib.Tactic.FinCases
 
 /-!
 # Krull dimension of a preordered set and height of an element
@@ -508,19 +509,82 @@ variable [Preorder α] [Preorder β]
 
 lemma LTSeries.length_le_krullDim (p : LTSeries α) : p.length ≤ krullDim α := le_sSup ⟨_, rfl⟩
 
-lemma krullDim_nonneg_of_nonempty [Nonempty α] : 0 ≤ krullDim α :=
-  le_sSup ⟨⟨0, fun _ ↦ @Nonempty.some α inferInstance, fun f ↦ f.elim0⟩, rfl⟩
+lemma krullDim_eq_bot_iff : krullDim α = ⊥ ↔ IsEmpty α := by
+  rw [eq_bot_iff, krullDim, iSup_le_iff]
+  simp only [le_bot_iff, WithBot.natCast_ne_bot, isEmpty_iff]
+  constructor
+  · exact fun H x ↦ H ⟨0, fun _ ↦ x, by simp⟩
+  · exact fun H x ↦ H (x 1)
 
-/-- A definition of krullDim for nonempty `α` that avoids `WithBot` -/
-lemma krullDim_eq_iSup_length [Nonempty α] :
-    krullDim α = ⨆ (p : LTSeries α), (p.length : ℕ∞) := by
-  unfold krullDim
-  rw [WithBot.coe_iSup (OrderTop.bddAbove _)]
-  rfl
+lemma krullDim_nonneg_iff : 0 ≤ krullDim α ↔ Nonempty α := by
+  rw [← not_iff_not, not_le, not_nonempty_iff, ← krullDim_eq_bot_iff, ← WithBot.lt_coe_bot,
+    bot_eq_zero, WithBot.coe_zero]
 
-lemma krullDim_eq_bot_of_isEmpty [IsEmpty α] : krullDim α = ⊥ := WithBot.ciSup_empty _
+lemma krullDim_eq_bot [IsEmpty α] : krullDim α = ⊥ := krullDim_eq_bot_iff.mpr ‹_›
 
-lemma krullDim_eq_top_of_infiniteDimensionalOrder [InfiniteDimensionalOrder α] :
+@[deprecated (since := "2024-12-22")] alias krullDim_eq_bot_of_isEmpty := krullDim_eq_bot
+
+lemma krullDim_nonneg [Nonempty α] : 0 ≤ krullDim α := krullDim_nonneg_iff.mpr ‹_›
+
+@[deprecated (since := "2024-12-22")] alias krullDim_nonneg_of_nonempty := krullDim_nonneg
+
+lemma krullDim_nonpos_iff_forall_isMax : krullDim α ≤ 0 ↔ ∀ x : α, IsMax x := by
+  simp only [krullDim, iSup_le_iff, isMax_iff_forall_not_lt]
+  constructor
+  · intro H x y h
+    exact (H ⟨1, ![x, y], fun i ↦ by obtain rfl := Subsingleton.elim i 0; simpa⟩).not_lt (by simp)
+  · rintro H ⟨n, l, h⟩
+    cases' n with n
+    · simp
+    · cases H (l 0) (l 1) (h 0)
+
+lemma krullDim_nonpos_iff_forall_isMin : krullDim α ≤ 0 ↔ ∀ x : α, IsMin x := by
+  simp only [krullDim_nonpos_iff_forall_isMax, IsMax, IsMin]
+  exact forall_swap
+
+lemma krullDim_le_one_iff : krullDim α ≤ 1 ↔ ∀ x : α, IsMin x ∨ IsMax x := by
+  rw [← not_iff_not]
+  simp_rw [isMax_iff_forall_not_lt, isMin_iff_forall_not_lt, krullDim, iSup_le_iff]
+  push_neg
+  constructor
+  · rintro ⟨⟨n, l, hl⟩, hl'⟩
+    cases' n with n; · cases hl'.not_le (by simp)
+    cases' n with n; · cases hl'.not_le (by simp)
+    exact ⟨l 1, ⟨l 0, hl 0⟩, l 2, hl 1⟩
+  · rintro ⟨x, ⟨y, hxy⟩, z, hzx⟩
+    exact ⟨⟨2, ![y, x, z], fun i ↦ by fin_cases i <;> simpa⟩, by simp⟩
+
+lemma krullDim_le_one_iff_forall_isMax {α : Type*} [PartialOrder α] [OrderBot α] :
+    krullDim α ≤ 1 ↔ ∀ x : α, x ≠ ⊥ → IsMax x := by
+  simp [krullDim_le_one_iff, ← or_iff_not_imp_left]
+
+lemma krullDim_le_one_iff_forall_isMin {α : Type*} [PartialOrder α] [OrderTop α] :
+    krullDim α ≤ 1 ↔ ∀ x : α, x ≠ ⊤ → IsMin x := by
+  simp [krullDim_le_one_iff, ← or_iff_not_imp_right]
+
+lemma krullDim_pos_iff : 0 < krullDim α ↔ ∃ x y : α, x < y := by
+  rw [← not_iff_not]
+  push_neg
+  simp_rw [← isMax_iff_forall_not_lt, ← krullDim_nonpos_iff_forall_isMax]
+
+lemma one_le_krullDim_iff : 1 ≤ krullDim α ↔ ∃ x y : α, x < y := by
+  rw [← krullDim_pos_iff, ← Nat.cast_zero, ← WithBot.add_one_le_iff, Nat.cast_zero, zero_add]
+
+lemma krullDim_nonpos_of_subsingleton [Subsingleton α] : krullDim α ≤ 0 := by
+  rw [krullDim_nonpos_iff_forall_isMax]
+  exact fun x y h ↦ (Subsingleton.elim x y).ge
+
+lemma krullDim_eq_zero_of_unique [Unique α] : krullDim α = 0 :=
+  le_antisymm krullDim_nonpos_of_subsingleton krullDim_nonneg
+
+lemma krullDim_eq_length_of_finiteDimensionalOrder [FiniteDimensionalOrder α] :
+    krullDim α = (LTSeries.longestOf α).length :=
+  le_antisymm
+    (iSup_le <| fun _ ↦ WithBot.coe_le_coe.mpr <| WithTop.coe_le_coe.mpr <|
+      RelSeries.length_le_length_longestOf _ _) <|
+    le_iSup (fun (i : LTSeries _) ↦ (i.length : WithBot (WithTop ℕ))) <| LTSeries.longestOf _
+
+lemma krullDim_eq_top [InfiniteDimensionalOrder α] :
     krullDim α = ⊤ :=
   le_antisymm le_top <| le_iSup_iff.mpr <| fun m hm ↦ match m, hm with
   | ⊥, hm => False.elim <| by
@@ -532,29 +596,44 @@ lemma krullDim_eq_top_of_infiniteDimensionalOrder [InfiniteDimensionalOrder α] 
     erw [WithBot.coe_lt_coe, WithTop.coe_lt_coe]
     simp
 
+@[deprecated (since := "2024-12-22")]
+alias krullDim_eq_top_of_infiniteDimensionalOrder := krullDim_eq_top
+
+lemma krullDim_eq_top_iff : krullDim α = ⊤ ↔ InfiniteDimensionalOrder α := by
+  refine ⟨fun h ↦ ?_, fun _ ↦ krullDim_eq_top⟩
+  cases isEmpty_or_nonempty α
+  · simp [krullDim_eq_bot] at h
+  cases finiteDimensionalOrder_or_infiniteDimensionalOrder α
+  · rw [krullDim_eq_length_of_finiteDimensionalOrder] at h
+    cases h
+  · infer_instance
+
+lemma le_krullDim_iff {n : ℕ} : n ≤ krullDim α ↔ ∃ l : LTSeries α, l.length = n := by
+  cases isEmpty_or_nonempty α
+  · simp [krullDim_eq_bot]
+  cases finiteDimensionalOrder_or_infiniteDimensionalOrder α
+  · rw [krullDim_eq_length_of_finiteDimensionalOrder, Nat.cast_le]
+    constructor
+    · exact fun H ↦ ⟨(LTSeries.longestOf α).take ⟨_, Nat.lt_succ.mpr H⟩, rfl⟩
+    · exact fun ⟨l, hl⟩ ↦ hl ▸ l.longestOf_is_longest
+  · simpa [krullDim_eq_top] using Rel.InfiniteDimensional.exists_relSeries_with_length n
+
+/-- A definition of krullDim for nonempty `α` that avoids `WithBot` -/
+lemma krullDim_eq_iSup_length [Nonempty α] :
+    krullDim α = ⨆ (p : LTSeries α), (p.length : ℕ∞) := by
+  unfold krullDim
+  rw [WithBot.coe_iSup (OrderTop.bddAbove _)]
+  rfl
+
+lemma krullDim_lt_coe_iff {n : ℕ} : krullDim α < n ↔ ∀ l : LTSeries α, l.length < n := by
+  rw [krullDim, ← WithBot.coe_natCast]
+  cases' n with n
+  · rw [ENat.coe_zero, ← bot_eq_zero, WithBot.lt_coe_bot]
+    simp
+  · simp [WithBot.lt_add_one_iff, WithBot.coe_natCast, Nat.lt_succ]
+
 lemma krullDim_le_of_strictMono (f : α → β) (hf : StrictMono f) : krullDim α ≤ krullDim β :=
   iSup_le <| fun p ↦ le_sSup ⟨p.map f hf, rfl⟩
-
-lemma krullDim_eq_length_of_finiteDimensionalOrder [FiniteDimensionalOrder α] :
-    krullDim α = (LTSeries.longestOf α).length :=
-  le_antisymm
-    (iSup_le <| fun _ ↦ WithBot.coe_le_coe.mpr <| WithTop.coe_le_coe.mpr <|
-      RelSeries.length_le_length_longestOf _ _) <|
-    le_iSup (fun (i : LTSeries _) ↦ (i.length : WithBot (WithTop ℕ))) <| LTSeries.longestOf _
-
-lemma krullDim_eq_zero_of_unique [Unique α] : krullDim α = 0 := by
-  rw [krullDim_eq_length_of_finiteDimensionalOrder (α := α), Nat.cast_eq_zero]
-  refine (LTSeries.longestOf_len_unique (default : LTSeries α) fun q ↦ show _ ≤ 0 from ?_).symm
-  by_contra r
-  exact ne_of_lt (q.step ⟨0, not_le.mp r⟩) <| Subsingleton.elim _ _
-
-lemma krullDim_nonpos_of_subsingleton [Subsingleton α] : krullDim α ≤ 0 := by
-  by_cases hα : Nonempty α
-  · have := uniqueOfSubsingleton (Classical.choice hα)
-    exact le_of_eq krullDim_eq_zero_of_unique
-  · have := not_nonempty_iff.mp hα
-    exact le_of_lt <| lt_of_eq_of_lt krullDim_eq_bot_of_isEmpty <|
-      Batteries.compareOfLessAndEq_eq_lt.mp rfl
 
 lemma krullDim_le_of_strictComono_and_surj
     (f : α → β) (hf : ∀ ⦃a b⦄, f a < f b → a < b) (hf' : Function.Surjective f) :
@@ -644,7 +723,7 @@ If `α` is `Nonempty`, then `krullDim_eq_iSup_height_of_nonempty`, with the coer
 -/
 lemma krullDim_eq_iSup_height : krullDim α = ⨆ (a : α), ↑(height a) := by
   cases isEmpty_or_nonempty α with
-  | inl h => rw [krullDim_eq_bot_of_isEmpty, ciSup_of_empty]
+  | inl h => rw [krullDim_eq_bot, ciSup_of_empty]
   | inr h => rw [krullDim_eq_iSup_height_of_nonempty, WithBot.coe_iSup (OrderTop.bddAbove _)]
 
 /--
@@ -655,7 +734,7 @@ If `α` is `Nonempty`, then `krullDim_eq_iSup_coheight_of_nonempty`, with the co
 -/
 lemma krullDim_eq_iSup_coheight : krullDim α = ⨆ (a : α), ↑(coheight a) := by
   cases isEmpty_or_nonempty α with
-  | inl h => rw [krullDim_eq_bot_of_isEmpty, ciSup_of_empty]
+  | inl h => rw [krullDim_eq_bot, ciSup_of_empty]
   | inr h => rw [krullDim_eq_iSup_coheight_of_nonempty, WithBot.coe_iSup (OrderTop.bddAbove _)]
 
 @[simp] -- not as useful as a simp lemma as it looks, due to the coe on the left

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Fintype.Pi
 import Mathlib.Data.Fintype.Sigma
 import Mathlib.Data.Rel
+import Mathlib.Data.Fin.VecNotation
 
 /-!
 # Series of a relation
@@ -129,6 +130,7 @@ namespace Rel
 
 /-- A relation `r` is said to be finite dimensional iff there is a relation series of `r` with the
   maximum length. -/
+@[mk_iff]
 class FiniteDimensional : Prop where
   /-- A relation `r` is said to be finite dimensional iff there is a relation series of `r` with the
     maximum length. -/
@@ -136,6 +138,7 @@ class FiniteDimensional : Prop where
 
 /-- A relation `r` is said to be infinite dimensional iff there exists relation series of arbitrary
   length. -/
+@[mk_iff]
 class InfiniteDimensional : Prop where
   /-- A relation `r` is said to be infinite dimensional iff there exists relation series of
     arbitrary length. -/
@@ -622,6 +625,33 @@ lemma last_drop (p : RelSeries r) (i : Fin (p.length + 1)) : (p.drop i).last = p
 
 end RelSeries
 
+variable {r} in
+lemma Rel.not_finiteDimensional_iff [Nonempty α] :
+    ¬ r.FiniteDimensional ↔ r.InfiniteDimensional := by
+  rw [finiteDimensional_iff, infiniteDimensional_iff]
+  push_neg
+  constructor
+  · intro H n
+    induction n with
+    | zero => refine ⟨⟨0, ![Nonempty.some ‹_›], by simp⟩, by simp⟩
+    | succ n IH =>
+      obtain ⟨l, hl⟩ := IH
+      obtain ⟨l', hl'⟩ := H l
+      exact ⟨l'.take ⟨n + 1, by simpa [hl] using hl'⟩, rfl⟩
+  · intro H l
+    obtain ⟨l', hl'⟩ := H (l.length + 1)
+    exact ⟨l', by simp [hl']⟩
+
+variable {r} in
+lemma Rel.not_infiniteDimensional_iff [Nonempty α] :
+    ¬ r.InfiniteDimensional ↔ r.FiniteDimensional := by
+  rw [← not_finiteDimensional_iff, not_not]
+
+lemma Rel.finiteDimensional_or_infiniteDimensional [Nonempty α] :
+    r.FiniteDimensional ∨ r.InfiniteDimensional := by
+  rw [← not_finiteDimensional_iff]
+  exact em r.FiniteDimensional
+
 /-- A type is finite dimensional if its `LTSeries` has bounded length. -/
 abbrev FiniteDimensionalOrder (γ : Type*) [Preorder γ] :=
   Rel.FiniteDimensional ((· < ·) : γ → γ → Prop)
@@ -816,6 +846,19 @@ end Fintype
 end LTSeries
 
 end LTSeries
+
+lemma not_finiteDimensionalOrder_iff [Preorder α] [Nonempty α] :
+    ¬ FiniteDimensionalOrder α ↔ InfiniteDimensionalOrder α :=
+  Rel.not_finiteDimensional_iff
+
+lemma not_infiniteDimensionalOrder_iff [Preorder α] [Nonempty α] :
+    ¬ InfiniteDimensionalOrder α ↔ FiniteDimensionalOrder α :=
+  Rel.not_infiniteDimensional_iff
+
+variable (α) in
+lemma finiteDimensionalOrder_or_infiniteDimensionalOrder [Preorder α] [Nonempty α] :
+    FiniteDimensionalOrder α ∨ InfiniteDimensionalOrder α :=
+  Rel.finiteDimensional_or_infiniteDimensional _
 
 /-- If `f : α → β` is a strictly monotonic function and `α` is an infinite dimensional type then so
   is `β`. -/

--- a/Mathlib/RingTheory/KrullDimension/Basic.lean
+++ b/Mathlib/RingTheory/KrullDimension/Basic.lean
@@ -29,7 +29,7 @@ variable {R S : Type*} [CommRing R] [CommRing S]
 @[nontriviality]
 lemma ringKrullDim_eq_bot_of_subsingleton [Subsingleton R] :
     ringKrullDim R = ⊥ :=
-  krullDim_eq_bot_of_isEmpty
+  krullDim_eq_bot
 
 lemma ringKrullDim_nonneg_of_nontrivial [Nontrivial R] :
     0 ≤ ringKrullDim R :=

--- a/Mathlib/RingTheory/KrullDimension/Basic.lean
+++ b/Mathlib/RingTheory/KrullDimension/Basic.lean
@@ -33,7 +33,7 @@ lemma ringKrullDim_eq_bot_of_subsingleton [Subsingleton R] :
 
 lemma ringKrullDim_nonneg_of_nontrivial [Nontrivial R] :
     0 ≤ ringKrullDim R :=
-  krullDim_nonneg_of_nonempty
+  krullDim_nonneg
 
 /-- If `f : R →+* S` is surjective, then `ringKrullDim S ≤ ringKrullDim R`. -/
 theorem ringKrullDim_le_of_surjective (f : R →+* S) (hf : Function.Surjective f) :


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
