### PR TITLE
[Merged by Bors] - feat(Polynomial): `(a^n)' = 0` iff `a' = 0` when `n` doesn't divide the characteristic

### DIFF
--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -664,7 +664,7 @@ section CommSemiringNoZeroDivisors
 
 variable [CommSemiring R] [NoZeroDivisors R]
 
-theorem derivative_pow_eq_zero_iff {n : ℕ} (chn : (n : R) ≠ 0) {a : R[X]} :
+theorem derivative_pow_eq_zero {n : ℕ} (chn : (n : R) ≠ 0) {a : R[X]} :
     derivative (a ^ n) = 0 ↔ derivative a = 0 := by
   nontriviality R
   rw [← C_ne_zero, C_eq_natCast] at chn

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -668,7 +668,7 @@ theorem derivative_pow_eq_zero_iff {n : ℕ} (chn : (n : k) ≠ 0) {a : k[X]} :
     derivative (a ^ n) = 0 ↔ derivative a = 0 where
   mp apd := by
     rw [derivative_pow, C_eq_natCast, mul_eq_zero, mul_eq_zero] at apd
-    rcases apd with nz | powz | goal
+    rcases apd with (nz | powz) | goal
     · rw [← C_eq_natCast, C_eq_zero] at nz
       tauto
     · have az : a = 0 := pow_eq_zero powz

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker
 -/
+import Mathlib.Algebra.CharP.Defs
 import Mathlib.Algebra.GroupPower.IterateHom
 import Mathlib.Algebra.Polynomial.Degree.Domain
 import Mathlib.Algebra.Polynomial.Degree.Support
@@ -660,6 +661,26 @@ theorem dvd_derivative_iff {P : R[X]} : P ∣ derivative P ↔ derivative P = 0 
   mpr h := by simp [h]
 
 end NoZeroDivisors
+
+section Field
+
+variable {k : Type u} [Field k]
+
+theorem derivative_pow_eq_zero_iff {n : ℕ} (chn : (n : k) ≠ 0) {a : k[X]} :
+    derivative (a ^ n) = 0 ↔ derivative a = 0 := by
+  constructor
+  · intro apd
+    rw [derivative_pow, C_eq_natCast, mul_eq_zero, mul_eq_zero] at apd
+    rcases apd with (nz | powz) | goal
+    · rw [← C_eq_natCast, C_eq_zero] at nz
+      tauto
+    · have az : a = 0 := pow_eq_zero powz
+      rw [az, map_zero]
+    · exact goal
+  · intro hd
+    rw [derivative_pow, hd, MulZeroClass.mul_zero]
+
+end Field
 
 end Derivative
 

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -665,9 +665,8 @@ section Field
 variable {k : Type u} [Field k]
 
 theorem derivative_pow_eq_zero_iff {n : ℕ} (chn : (n : k) ≠ 0) {a : k[X]} :
-    derivative (a ^ n) = 0 ↔ derivative a = 0 := by
-  constructor
-  · intro apd
+    derivative (a ^ n) = 0 ↔ derivative a = 0 where
+  mp apd := by
     rw [derivative_pow, C_eq_natCast, mul_eq_zero, mul_eq_zero] at apd
     rcases apd with (nz | powz) | goal
     · rw [← C_eq_natCast, C_eq_zero] at nz

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -3,8 +3,6 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Johannes Hölzl, Kim Morrison, Jens Wagemaker
 -/
-import Mathlib.Algebra.CharP.Defs
-import Mathlib.Algebra.GroupPower.IterateHom
 import Mathlib.Algebra.Polynomial.Degree.Domain
 import Mathlib.Algebra.Polynomial.Degree.Support
 import Mathlib.Algebra.Polynomial.Eval.Coeff

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -668,14 +668,13 @@ theorem derivative_pow_eq_zero_iff {n : ℕ} (chn : (n : k) ≠ 0) {a : k[X]} :
     derivative (a ^ n) = 0 ↔ derivative a = 0 where
   mp apd := by
     rw [derivative_pow, C_eq_natCast, mul_eq_zero, mul_eq_zero] at apd
-    rcases apd with (nz | powz) | goal
+    rcases apd with nz | powz | goal
     · rw [← C_eq_natCast, C_eq_zero] at nz
       tauto
     · have az : a = 0 := pow_eq_zero powz
       rw [az, map_zero]
     · exact goal
-  · intro hd
-    rw [derivative_pow, hd, MulZeroClass.mul_zero]
+  mpr hd := by rw [derivative_pow, hd, MulZeroClass.mul_zero]
 
 end Field
 

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -660,23 +660,17 @@ theorem dvd_derivative_iff {P : R[X]} : P ∣ derivative P ↔ derivative P = 0 
 
 end NoZeroDivisors
 
-section Field
+section CommSemiringNoZeroDivisors
 
-variable {k : Type u} [Field k]
+variable [CommSemiring R] [NoZeroDivisors R]
 
-theorem derivative_pow_eq_zero_iff {n : ℕ} (chn : (n : k) ≠ 0) {a : k[X]} :
-    derivative (a ^ n) = 0 ↔ derivative a = 0 where
-  mp apd := by
-    rw [derivative_pow, C_eq_natCast, mul_eq_zero, mul_eq_zero] at apd
-    rcases apd with (nz | powz) | goal
-    · rw [← C_eq_natCast, C_eq_zero] at nz
-      tauto
-    · have az : a = 0 := pow_eq_zero powz
-      rw [az, map_zero]
-    · exact goal
-  mpr hd := by rw [derivative_pow, hd, MulZeroClass.mul_zero]
+theorem derivative_pow_eq_zero_iff {n : ℕ} (chn : (n : R) ≠ 0) {a : R[X]} :
+    derivative (a ^ n) = 0 ↔ derivative a = 0 := by
+  nontriviality R
+  rw [← C_ne_zero, C_eq_natCast] at chn
+  simp +contextual [derivative_pow, or_imp, chn]
 
-end Field
+end CommSemiringNoZeroDivisors
 
 end Derivative
 


### PR DESCRIPTION

For a polynomial $a \in k[X]$ and $n$ with $n \ne 0$ in $k$, $(a^n)' = 0$ if and only if $a' = 0$.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Seperated from #18882. See [this](https://github.com/leanprover-community/mathlib4/pull/18882/files#r1893722111) comment.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
