### PR TITLE
[Merged by Bors] - chore: remove last few instances of `set_option tactic.skipAssignedInstances false`

### DIFF
--- a/Mathlib/Algebra/Group/Hom/CompTypeclasses.lean
+++ b/Mathlib/Algebra/Group/Hom/CompTypeclasses.lean
@@ -93,7 +93,6 @@ lemma comp_apply
     ψ (φ x) = χ x := by
   rw [← h.comp_eq, MonoidHom.comp_apply]
 
-@[simp]
 theorem comp_assoc {Q : Type*} [Monoid Q]
     {φ₁ : M →* N} {φ₂ : N →* P} {φ₁₂ : M →* P}
     (κ : CompTriple φ₁ φ₂ φ₁₂)

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -437,8 +437,7 @@ noncomputable def limitIsoLimitCurryCompLim : limit G ≅ limit (curry.obj G ⋙
 @[simp, reassoc]
 theorem limitIsoLimitCurryCompLim_hom_π_π {j} {k} :
     (limitIsoLimitCurryCompLim G).hom ≫ limit.π _ j ≫ limit.π _ k = limit.π _ (j, k) := by
-  set_option tactic.skipAssignedInstances false in
-  simp [limitIsoLimitCurryCompLim, Trans.simple, HasLimit.isoOfNatIso, limitUncurryIsoLimitCompLim]
+  simp [limitIsoLimitCurryCompLim, Trans.simple]
 
 -- Porting note: Added type annotation `limit (_ ⋙ lim) ⟶ _`
 @[simp, reassoc]
@@ -471,9 +470,7 @@ noncomputable def colimitIsoColimitCurryCompColim : colimit G ≅ colimit (curry
 theorem colimitIsoColimitCurryCompColim_ι_ι_inv {j} {k} :
     colimit.ι ((curry.obj G).obj j) k ≫ colimit.ι (curry.obj G ⋙ colim) j ≫
       (colimitIsoColimitCurryCompColim G).inv  = colimit.ι _ (j, k) := by
-  set_option tactic.skipAssignedInstances false in
-  simp [colimitIsoColimitCurryCompColim, Trans.simple, HasColimit.isoOfNatIso,
-    colimitUncurryIsoColimitCompColim]
+  simp [colimitIsoColimitCurryCompColim, Trans.simple, colimitUncurryIsoColimitCompColim]
 
 @[simp, reassoc]
 theorem colimitIsoColimitCurryCompColim_ι_hom {j} {k} :

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -269,7 +269,6 @@ theorem normalize_naturality (n : NormalMonoidalObject C) {X Y : F C} (f : X ⟶
 
 end
 
-set_option tactic.skipAssignedInstances false in
 /-- The isomorphism between `n ⊗ X` and `normalize X n` is natural (in both `X` and `n`, but
     naturality in `n` is trivial and was "proved" in `normalizeIsoAux`). This is the real heart
     of our proof of the coherence theorem. -/
@@ -278,7 +277,8 @@ def normalizeIso : tensorFunc C ≅ normalize' C :=
     intro X Y f
     ext ⟨n⟩
     convert normalize_naturality n f using 1
-    any_goals dsimp [NatIso.ofComponents]; congr; apply normalizeIsoApp_eq
+    any_goals dsimp; rw [normalizeIsoApp_eq]
+    rfl
 
 /-- The isomorphism between an object and its normal form is natural. -/
 def fullNormalizeIso : 𝟭 (F C) ≅ fullNormalize C ⋙ inclusion :=

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Module.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Module.lean
@@ -133,12 +133,10 @@ def inverseObj (A : AlgebraCat.{u} R) : Mon_ (ModuleCat.{u} R) where
     dsimp
   mul_assoc := by
     ext : 1
-    set_option tactic.skipAssignedInstances false in
     -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` did not pick up `TensorProduct.ext`
     refine TensorProduct.ext <| TensorProduct.ext <| LinearMap.ext fun x => LinearMap.ext fun y =>
       LinearMap.ext fun z => ?_
     dsimp only [compr₂_apply, TensorProduct.mk_apply]
-    rw [compr₂_apply, compr₂_apply]
     rw [hom_comp, LinearMap.comp_apply, hom_comp, LinearMap.comp_apply, hom_comp,
         LinearMap.comp_apply]
     erw [LinearMap.mul'_apply, LinearMap.mul'_apply]

--- a/Mathlib/Combinatorics/SetFamily/Shadow.lean
+++ b/Mathlib/Combinatorics/SetFamily/Shadow.lean
@@ -119,7 +119,6 @@ lemma mem_shadow_iterate_iff_exists_card :
     t ∈ ∂^[k] 𝒜 ↔ ∃ u : Finset α, #u = k ∧ Disjoint t u ∧ t ∪ u ∈ 𝒜 := by
   induction' k with k ih generalizing t
   · simp
-  set_option tactic.skipAssignedInstances false in
   simp only [mem_shadow_iff_insert_mem, ih, Function.iterate_succ_apply', card_eq_succ]
   aesop
 

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -492,7 +492,6 @@ theorem image_symmDiff [DecidableEq α] {f : α → β} (s t : Finset α) (hf : 
     (s ∆ t).image f = s.image f ∆ t.image f :=
   mod_cast Set.image_symmDiff hf s t
 
-@[simp]
 theorem _root_.Disjoint.of_image_finset {s t : Finset α} {f : α → β}
     (h : Disjoint (s.image f) (t.image f)) : Disjoint s t :=
   disjoint_iff_ne.2 fun _ ha _ hb =>

--- a/Mathlib/Data/ZMod/Units.lean
+++ b/Mathlib/Data/ZMod/Units.lean
@@ -32,9 +32,10 @@ lemma unitsMap_comp {d : ℕ} (hm : n ∣ m) (hd : m ∣ d) :
 lemma unitsMap_self (n : ℕ) : unitsMap (dvd_refl n) = MonoidHom.id _ := by
   simp [unitsMap, castHom_self]
 
-@[simp]
-def val_unitsMap {m n : Nat} (h : n ∣ m) (a : Units (ZMod m)) :
-    ↑(ZMod.unitsMap h a) = ((a : ZMod m).cast : ZMod n) := rfl
+/-- `unitsMap_val` shows that coercing from `(ZMod m)ˣ` to `ZMod n` gives the same result
+when going via `(ZMod n)ˣ` and `ZMod m`. -/
+lemma unitsMap_val (h : n ∣ m) (a : (ZMod m)ˣ) :
+    ↑(unitsMap h a) = ((a : ZMod m).cast : ZMod n) := rfl
 
 lemma isUnit_cast_of_dvd (hm : n ∣ m) (a : Units (ZMod m)) : IsUnit (cast (a : ZMod m) : ZMod n) :=
   Units.isUnit (unitsMap hm a)

--- a/Mathlib/Data/ZMod/Units.lean
+++ b/Mathlib/Data/ZMod/Units.lean
@@ -32,6 +32,10 @@ lemma unitsMap_comp {d : ℕ} (hm : n ∣ m) (hd : m ∣ d) :
 lemma unitsMap_self (n : ℕ) : unitsMap (dvd_refl n) = MonoidHom.id _ := by
   simp [unitsMap, castHom_self]
 
+@[simp]
+def val_unitsMap {m n : Nat} (h : n ∣ m) (a : Units (ZMod m)) :
+    ↑(ZMod.unitsMap h a) = ((a : ZMod m).cast : ZMod n) := rfl
+
 lemma isUnit_cast_of_dvd (hm : n ∣ m) (a : Units (ZMod m)) : IsUnit (cast (a : ZMod m) : ZMod n) :=
   Units.isUnit (unitsMap hm a)
 @[deprecated (since := "2024-12-16")] alias IsUnit_cast_of_dvd := isUnit_cast_of_dvd

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -740,7 +740,6 @@ open GCDMonoid Polynomial
 
 variable [Field K]
 
-set_option tactic.skipAssignedInstances false in
 /-- `RatFunc.numDenom` are numerator and denominator of a rational function over a field,
 normalized such that the denominator is monic. -/
 def numDenom (x : RatFunc K) : K[X] × K[X] :=

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
@@ -560,7 +560,7 @@ theorem ker_noncommProd_eq_of_supIndep_ker [FiniteDimensional K V] {ι : Type*} 
     ker (s.noncommProd f comm) = ⨆ i ∈ s, ker (f i) := by
   classical
   induction' s using Finset.induction_on with i s hi ih
-  · simp [LinearMap.one_eq_id]
+  · simp [one_eq_id]
   replace ih : ker (Finset.noncommProd s f <| Set.Pairwise.mono (s.subset_insert i) comm) =
       ⨆ x ∈ s, ker (f x) := ih _ (h.subset (s.subset_insert i))
   rw [Finset.noncommProd_insert_of_not_mem _ _ _ _ hi, mul_eq_comp,

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
@@ -560,8 +560,7 @@ theorem ker_noncommProd_eq_of_supIndep_ker [FiniteDimensional K V] {ι : Type*} 
     ker (s.noncommProd f comm) = ⨆ i ∈ s, ker (f i) := by
   classical
   induction' s using Finset.induction_on with i s hi ih
-  · set_option tactic.skipAssignedInstances false in
-    simpa using LinearMap.ker_id
+  · simp [LinearMap.one_eq_id]
   replace ih : ker (Finset.noncommProd s f <| Set.Pairwise.mono (s.subset_insert i) comm) =
       ⨆ x ∈ s, ker (f x) := ih _ (h.subset (s.subset_insert i))
   rw [Finset.noncommProd_insert_of_not_mem _ _ _ _ hi, mul_eq_comp,

--- a/Mathlib/NumberTheory/DirichletCharacter/Basic.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/Basic.lean
@@ -91,7 +91,7 @@ lemma changeLevel_trans {m d : ℕ} (hm : n ∣ m) (hd : m ∣ d) :
 
 lemma changeLevel_eq_cast_of_dvd {m : ℕ} (hm : n ∣ m) (a : Units (ZMod m)) :
     (changeLevel hm χ) a = χ (ZMod.cast (a : ZMod m)) := by
-  simp [changeLevel_def]
+  simp [changeLevel_def, ZMod.unitsMap_val]
 
 /-- `χ` of level `n` factors through a Dirichlet character `χ₀` of level `d` if `d ∣ n` and
 `χ₀ = χ ∘ (ZMod n → ZMod d)`. -/

--- a/Mathlib/NumberTheory/DirichletCharacter/Basic.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/Basic.lean
@@ -91,9 +91,9 @@ lemma changeLevel_trans {m d : ℕ} (hm : n ∣ m) (hd : m ∣ d) :
 
 lemma changeLevel_eq_cast_of_dvd {m : ℕ} (hm : n ∣ m) (a : Units (ZMod m)) :
     (changeLevel hm χ) a = χ (ZMod.cast (a : ZMod m)) := by
-  set_option tactic.skipAssignedInstances false in
-  simpa [changeLevel_def, Function.comp_apply, MonoidHom.coe_comp] using
-      toUnitHom_eq_char' _ <| ZMod.isUnit_cast_of_dvd hm a
+  simp only [changeLevel_def, toUnitHom_eq, ofUnitHom_eq, equivToUnitHom_symm_coe,
+    MonoidHom.coe_comp, Function.comp_apply, coe_equivToUnitHom]
+  rfl
 
 /-- `χ` of level `n` factors through a Dirichlet character `χ₀` of level `d` if `d ∣ n` and
 `χ₀ = χ ∘ (ZMod n → ZMod d)`. -/

--- a/Mathlib/NumberTheory/DirichletCharacter/Basic.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/Basic.lean
@@ -91,9 +91,7 @@ lemma changeLevel_trans {m d : ℕ} (hm : n ∣ m) (hd : m ∣ d) :
 
 lemma changeLevel_eq_cast_of_dvd {m : ℕ} (hm : n ∣ m) (a : Units (ZMod m)) :
     (changeLevel hm χ) a = χ (ZMod.cast (a : ZMod m)) := by
-  simp only [changeLevel_def, toUnitHom_eq, ofUnitHom_eq, equivToUnitHom_symm_coe,
-    MonoidHom.coe_comp, Function.comp_apply, coe_equivToUnitHom]
-  rfl
+  simp [changeLevel_def]
 
 /-- `χ` of level `n` factors through a Dirichlet character `χ₀` of level `d` if `d ∣ n` and
 `χ₀ = χ ∘ (ZMod n → ZMod d)`. -/

--- a/Mathlib/NumberTheory/MulChar/Basic.lean
+++ b/Mathlib/NumberTheory/MulChar/Basic.lean
@@ -195,10 +195,12 @@ theorem toUnitHom_eq (χ : MulChar R R') : toUnitHom χ = equivToUnitHom χ :=
 theorem ofUnitHom_eq (χ : Rˣ →* R'ˣ) : ofUnitHom χ = equivToUnitHom.symm χ :=
   rfl
 
-theorem coe_equivToUnitHom (χ : MulChar R R') (a : Rˣ) : ↑(equivToUnitHom χ a) = χ ↑a :=
+@[simp]
+theorem coe_equivToUnitHom (χ : MulChar R R') (a : Rˣ) : ↑(equivToUnitHom χ a) = χ a :=
   coe_toUnitHom χ a
 
-theorem equivToUnitHom_symm_coe (f : Rˣ →* R'ˣ) (a : Rˣ) : equivToUnitHom.symm f ↑a = ↑(f a) :=
+@[simp]
+theorem equivToUnitHom_symm_coe (f : Rˣ →* R'ˣ) (a : Rˣ) : equivToUnitHom.symm f ↑a = f a :=
   ofUnitHom_coe f a
 
 @[simp]
@@ -362,22 +364,6 @@ def mulEquivToUnitHom : MulChar R R' ≃* (Rˣ →* R'ˣ) :=
       simp only [Equiv.toFun_as_coe, coe_equivToUnitHom, coeToFun_mul, Pi.mul_apply,
         MonoidHom.mul_apply, Units.val_mul]
   }
-
-@[simp]
-theorem equivToUnitHom_eq (χ : MulChar R R') : equivToUnitHom χ = mulEquivToUnitHom χ :=
-  rfl
-
-@[simp]
-theorem equivToUnitHom_symm_eq (χ : Rˣ →* R'ˣ) : equivToUnitHom.symm χ = mulEquivToUnitHom.symm χ :=
-  rfl
-
-@[simp]
-theorem coe_mulEquivToUnitHom (χ : MulChar R R') (a : Rˣ) : ↑(mulEquivToUnitHom χ a) = χ ↑a :=
-  coe_toUnitHom χ a
-
-@[simp]
-theorem mulEquivToUnitHom_symm_coe (f : Rˣ →* R'ˣ) (a : Rˣ) : mulEquivToUnitHom.symm f ↑a = f a :=
-  ofUnitHom_coe f a
 
 end Group
 

--- a/Mathlib/NumberTheory/MulChar/Basic.lean
+++ b/Mathlib/NumberTheory/MulChar/Basic.lean
@@ -195,12 +195,10 @@ theorem toUnitHom_eq (χ : MulChar R R') : toUnitHom χ = equivToUnitHom χ :=
 theorem ofUnitHom_eq (χ : Rˣ →* R'ˣ) : ofUnitHom χ = equivToUnitHom.symm χ :=
   rfl
 
-@[simp]
-theorem coe_equivToUnitHom (χ : MulChar R R') (a : Rˣ) : ↑(equivToUnitHom χ a) = χ a :=
+theorem coe_equivToUnitHom (χ : MulChar R R') (a : Rˣ) : ↑(equivToUnitHom χ a) = χ ↑a :=
   coe_toUnitHom χ a
 
-@[simp]
-theorem equivToUnitHom_symm_coe (f : Rˣ →* R'ˣ) (a : Rˣ) : equivToUnitHom.symm f ↑a = f a :=
+theorem equivToUnitHom_symm_coe (f : Rˣ →* R'ˣ) (a : Rˣ) : equivToUnitHom.symm f ↑a = ↑(f a) :=
   ofUnitHom_coe f a
 
 @[simp]
@@ -364,6 +362,22 @@ def mulEquivToUnitHom : MulChar R R' ≃* (Rˣ →* R'ˣ) :=
       simp only [Equiv.toFun_as_coe, coe_equivToUnitHom, coeToFun_mul, Pi.mul_apply,
         MonoidHom.mul_apply, Units.val_mul]
   }
+
+@[simp]
+theorem equivToUnitHom_eq (χ : MulChar R R') : equivToUnitHom χ = mulEquivToUnitHom χ :=
+  rfl
+
+@[simp]
+theorem equivToUnitHom_symm_eq (χ : Rˣ →* R'ˣ) : equivToUnitHom.symm χ = mulEquivToUnitHom.symm χ :=
+  rfl
+
+@[simp]
+theorem coe_mulEquivToUnitHom (χ : MulChar R R') (a : Rˣ) : ↑(mulEquivToUnitHom χ a) = χ ↑a :=
+  coe_toUnitHom χ a
+
+@[simp]
+theorem mulEquivToUnitHom_symm_coe (f : Rˣ →* R'ˣ) (a : Rˣ) : mulEquivToUnitHom.symm f ↑a = f a :=
+  ofUnitHom_coe f a
 
 end Group
 

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -574,11 +574,7 @@ def counitIso (M : ModuleCat.{u} (MonoidAlgebra k G)) :
   LinearEquiv.toModuleIso
     { counitIsoAddEquiv with
       map_smul' := fun r x => by
-        set_option tactic.skipAssignedInstances false in
         dsimp [counitIsoAddEquiv]
-        /- Porting note: rest of broken proof was `simp`. -/
-        rw [AddEquiv.trans_apply]
-        rw [AddEquiv.trans_apply]
         erw [@Representation.ofModule_asAlgebraHom_apply_apply k G _ _ _ _ (_)]
         exact AddEquiv.symm_apply_apply _ _}
 

--- a/Mathlib/RingTheory/Polynomial/ScaleRoots.lean
+++ b/Mathlib/RingTheory/Polynomial/ScaleRoots.lean
@@ -152,6 +152,7 @@ theorem scaleRoots_aeval_eq_zero [Algebra R A] {p : R[X]} {a : A} {r : R} (ha : 
 theorem scaleRoots_eval₂_eq_zero_of_eval₂_div_eq_zero {p : S[X]} {f : S →+* K}
     (hf : Function.Injective f) {r s : S} (hr : eval₂ f (f r / f s) p = 0)
     (hs : s ∈ nonZeroDivisors S) : eval₂ f (f r) (scaleRoots p s) = 0 := by
+  -- if we don't specify the type with `(_ : S)`, the proof is much slower
   nontriviality S using Subsingleton.eq_zero (_ : S)
   convert @scaleRoots_eval₂_eq_zero _ _ _ _ p f _ s hr
   rw [← mul_div_assoc, mul_comm, mul_div_cancel_right₀]

--- a/Mathlib/RingTheory/Polynomial/ScaleRoots.lean
+++ b/Mathlib/RingTheory/Polynomial/ScaleRoots.lean
@@ -152,9 +152,7 @@ theorem scaleRoots_aeval_eq_zero [Algebra R A] {p : R[X]} {a : A} {r : R} (ha : 
 theorem scaleRoots_eval₂_eq_zero_of_eval₂_div_eq_zero {p : S[X]} {f : S →+* K}
     (hf : Function.Injective f) {r s : S} (hr : eval₂ f (f r / f s) p = 0)
     (hs : s ∈ nonZeroDivisors S) : eval₂ f (f r) (scaleRoots p s) = 0 := by
-  -- The proof works without this option, but *much* slower.
-  set_option tactic.skipAssignedInstances false in
-  nontriviality S using Subsingleton.eq_zero
+  nontriviality S using Subsingleton.eq_zero (_ : S)
   convert @scaleRoots_eval₂_eq_zero _ _ _ _ p f _ s hr
   rw [← mul_div_assoc, mul_comm, mul_div_cancel_right₀]
   exact map_ne_zero_of_mem_nonZeroDivisors _ hf hs

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -29,15 +29,13 @@ variable {X Y Z : TopCat.{u}}
 
 /-- The first projection from the pullback. -/
 abbrev pullbackFst (f : X ⟶ Z) (g : Y ⟶ Z) : TopCat.of { p : X × Y // f p.1 = g p.2 } ⟶ X :=
-  ⟨Prod.fst ∘ Subtype.val, by
-    apply Continuous.comp <;> set_option tactic.skipAssignedInstances false in continuity⟩
+  ⟨Prod.fst ∘ Subtype.val, by fun_prop⟩
 
 lemma pullbackFst_apply (f : X ⟶ Z) (g : Y ⟶ Z) (x) : pullbackFst f g x = x.1.1 := rfl
 
 /-- The second projection from the pullback. -/
 abbrev pullbackSnd (f : X ⟶ Z) (g : Y ⟶ Z) : TopCat.of { p : X × Y // f p.1 = g p.2 } ⟶ Y :=
-  ⟨Prod.snd ∘ Subtype.val, by
-    apply Continuous.comp <;> set_option tactic.skipAssignedInstances false in continuity⟩
+  ⟨Prod.snd ∘ Subtype.val, by fun_prop⟩
 
 lemma pullbackSnd_apply (f : X ⟶ Z) (g : Y ⟶ Z) (x) : pullbackSnd f g x = x.1.2 := rfl
 

--- a/Mathlib/Topology/Order.lean
+++ b/Mathlib/Topology/Order.lean
@@ -894,9 +894,8 @@ theorem isOpen_sSup_iff {s : Set α} {T : Set (TopologicalSpace α)} :
     IsOpen[sSup T] s ↔ ∀ t ∈ T, IsOpen[t] s := by
   simp only [sSup_eq_iSup, isOpen_iSup_iff]
 
-set_option tactic.skipAssignedInstances false in
 theorem isClosed_iSup_iff {s : Set α} : IsClosed[⨆ i, t i] s ↔ ∀ i, IsClosed[t i] s := by
-  simp [← @isOpen_compl_iff _ _ (⨆ i, t i), ← @isOpen_compl_iff _ _ (t _), isOpen_iSup_iff]
+  simp only [← @isOpen_compl_iff _ _ (⨆ i, t i), ← @isOpen_compl_iff _ _ (t _), isOpen_iSup_iff]
 
 theorem isClosed_sSup_iff {s : Set α} {T : Set (TopologicalSpace α)} :
     IsClosed[sSup T] s ↔ ∀ t ∈ T, IsClosed[t] s := by


### PR DESCRIPTION
This PR removes the last few instances of the backward compatability option `set_option tactic.skipAssignedInstances false`.

To achieve this, the `simp` tag from `Disjoint.of_image_finset` is removed, which I think shouldn't have been a simp lemma in the first place.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
