### PR TITLE
[Merged by Bors] - feat: product of subalgebras

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -25,6 +25,7 @@ import Mathlib.Algebra.Algebra.Subalgebra.IsSimpleOrder
 import Mathlib.Algebra.Algebra.Subalgebra.MulOpposite
 import Mathlib.Algebra.Algebra.Subalgebra.Operations
 import Mathlib.Algebra.Algebra.Subalgebra.Order
+import Mathlib.Algebra.Algebra.Subalgebra.Pi
 import Mathlib.Algebra.Algebra.Subalgebra.Pointwise
 import Mathlib.Algebra.Algebra.Subalgebra.Prod
 import Mathlib.Algebra.Algebra.Subalgebra.Rank

--- a/Mathlib/Algebra/Algebra/Subalgebra/Pi.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Pi.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2024 Yaël Dillies, Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Andrew Yang
+-/
+import Mathlib.Algebra.Algebra.Pi
+import Mathlib.Algebra.Algebra.Subalgebra.Basic
+import Mathlib.LinearAlgebra.Pi
+
+/-!
+# Products of subalgebras
+
+In this file we define the product of subalgebras as a subalgebra of the product algebra.
+
+## Main definitions
+
+ * `Subalgebra.pi`: the product of subalgebras.
+-/
+
+open Algebra
+
+namespace Subalgebra
+variable {ι R : Type*} {S : ι → Type*} [CommSemiring R] [∀ i, Semiring (S i)] [∀ i, Algebra R (S i)]
+  {t : Set ι} {s s₁ s₂ : ∀ i, Subalgebra R (S i)} {x : ∀ i, S i}
+
+/-- The product of subalgebras as a subalgebra. -/
+@[simps coe toSubsemiring]
+def pi (t : Set ι) (s : ∀ i, Subalgebra R (S i)) : Subalgebra R (Π i, S i) where
+  __ := Submodule.pi t fun i ↦ (s i).toSubmodule
+  mul_mem' hx hy i hi := (s i).mul_mem (hx i hi) (hy i hi)
+  algebraMap_mem' _ i _ := (s i).algebraMap_mem _
+
+@[simp] lemma mem_pi : x ∈ pi t s ↔ ∀ i ∈ t, x i ∈ s i := .rfl
+
+open Subalgebra in
+@[simp] lemma pi_toSubmodule : toSubmodule (pi t s) = .pi t fun i ↦ (s i).toSubmodule := rfl
+
+@[simp]
+lemma pi_top (t : Set ι) : pi t (fun i ↦ (⊤ : Subalgebra R (S i))) = ⊤ :=
+  SetLike.coe_injective <| Set.pi_univ _
+
+@[gcongr] lemma pi_mono (h : ∀ i ∈ t, s₁ i ≤ s₂ i) : pi t s₁ ≤ pi t s₂ := Set.pi_mono h
+
+end Subalgebra

--- a/Mathlib/Algebra/Algebra/Subalgebra/Pi.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Pi.lean
@@ -21,24 +21,24 @@ open Algebra
 
 namespace Subalgebra
 variable {ι R : Type*} {S : ι → Type*} [CommSemiring R] [∀ i, Semiring (S i)] [∀ i, Algebra R (S i)]
-  {t : Set ι} {s s₁ s₂ : ∀ i, Subalgebra R (S i)} {x : ∀ i, S i}
+  {s : Set ι} {t t₁ t₂ : ∀ i, Subalgebra R (S i)} {x : ∀ i, S i}
 
 /-- The product of subalgebras as a subalgebra. -/
 @[simps coe toSubsemiring]
-def pi (t : Set ι) (s : ∀ i, Subalgebra R (S i)) : Subalgebra R (Π i, S i) where
-  __ := Submodule.pi t fun i ↦ (s i).toSubmodule
-  mul_mem' hx hy i hi := (s i).mul_mem (hx i hi) (hy i hi)
-  algebraMap_mem' _ i _ := (s i).algebraMap_mem _
+def pi (s : Set ι) (t : ∀ i, Subalgebra R (S i)) : Subalgebra R (Π i, S i) where
+  __ := Submodule.pi s fun i ↦ (t i).toSubmodule
+  mul_mem' hx hy i hi := (t i).mul_mem (hx i hi) (hy i hi)
+  algebraMap_mem' _ i _ := (t i).algebraMap_mem _
 
-@[simp] lemma mem_pi : x ∈ pi t s ↔ ∀ i ∈ t, x i ∈ s i := .rfl
+@[simp] lemma mem_pi : x ∈ pi s t ↔ ∀ i ∈ s, x i ∈ t i := .rfl
 
 open Subalgebra in
-@[simp] lemma pi_toSubmodule : toSubmodule (pi t s) = .pi t fun i ↦ (s i).toSubmodule := rfl
+@[simp] lemma pi_toSubmodule : toSubmodule (pi s t) = .pi s fun i ↦ (t i).toSubmodule := rfl
 
 @[simp]
-lemma pi_top (t : Set ι) : pi t (fun i ↦ (⊤ : Subalgebra R (S i))) = ⊤ :=
+lemma pi_top (s : Set ι) : pi s (fun i ↦ (⊤ : Subalgebra R (S i))) = ⊤ :=
   SetLike.coe_injective <| Set.pi_univ _
 
-@[gcongr] lemma pi_mono (h : ∀ i ∈ t, s₁ i ≤ s₂ i) : pi t s₁ ≤ pi t s₂ := Set.pi_mono h
+@[gcongr] lemma pi_mono (h : ∀ i ∈ s, t₁ i ≤ t₂ i) : pi s t₁ ≤ pi s t₂ := Set.pi_mono h
 
 end Subalgebra

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -356,7 +356,7 @@ variable (H K : Subgroup G)
 
 /-- Copy of a subgroup with a new `carrier` equal to the old one. Useful to fix definitional
 equalities. -/
-@[to_additive
+@[to_additive (attr := simps)
       "Copy of an additive subgroup with a new `carrier` equal to the old one.
       Useful to fix definitional equalities"]
 protected def copy (K : Subgroup G) (s : Set G) (hs : s = K) : Subgroup G where
@@ -364,10 +364,6 @@ protected def copy (K : Subgroup G) (s : Set G) (hs : s = K) : Subgroup G where
   one_mem' := hs.symm ▸ K.one_mem'
   mul_mem' := hs.symm ▸ K.mul_mem'
   inv_mem' hx := by simpa [hs] using hx -- Porting note: `▸` didn't work here
-
-@[to_additive (attr := simp)]
-theorem coe_copy (K : Subgroup G) (s : Set G) (hs : s = ↑K) : (K.copy s hs : Set G) = s :=
-  rfl
 
 @[to_additive]
 theorem copy_eq (K : Subgroup G) (s : Set G) (hs : s = ↑K) : K.copy s hs = K :=

--- a/Mathlib/Algebra/Module/Submodule/Defs.lean
+++ b/Mathlib/Algebra/Module/Submodule/Defs.lean
@@ -57,6 +57,8 @@ instance addSubmonoidClass : AddSubmonoidClass (Submodule R M) M where
 instance smulMemClass : SMulMemClass (Submodule R M) R M where
   smul_mem {s} c _ h := SubMulAction.smul_mem' s.toSubMulAction c h
 
+initialize_simps_projections Submodule (carrier → coe, as_prefix coe)
+
 @[simp]
 theorem mem_toAddSubmonoid (p : Submodule R M) (x : M) : x ∈ p.toAddSubmonoid ↔ x ∈ p :=
   Iff.rfl

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -333,6 +333,8 @@ def pi (I : Set ι) (p : (i : ι) → Submodule R (φ i)) : Submodule R ((i : ι
   add_mem' {_ _} hx hy i hi := (p i).add_mem (hx i hi) (hy i hi)
   smul_mem' c _ hx i hi := (p i).smul_mem c (hx i hi)
 
+attribute [norm_cast] coe_pi
+
 variable {I : Set ι} {p q : (i : ι) → Submodule R (φ i)} {x : (i : ι) → φ i}
 
 @[simp]

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -326,6 +326,7 @@ open LinearMap
 /-- A version of `Set.pi` for submodules. Given an index set `I` and a family of submodules
 `p : (i : ι) → Submodule R (φ i)`, `pi I s` is the submodule of dependent functions
 `f : (i : ι) → φ i` such that `f i` belongs to `p a` whenever `i ∈ I`. -/
+@[simps]
 def pi (I : Set ι) (p : (i : ι) → Submodule R (φ i)) : Submodule R ((i : ι) → φ i) where
   carrier := Set.pi I fun i => p i
   zero_mem' i _ := (p i).zero_mem
@@ -338,10 +339,6 @@ variable {I : Set ι} {p q : (i : ι) → Submodule R (φ i)} {x : (i : ι) → 
 theorem mem_pi : x ∈ pi I p ↔ ∀ i ∈ I, x i ∈ p i :=
   Iff.rfl
 
-@[simp, norm_cast]
-theorem coe_pi : (pi I p : Set ((i : ι) → φ i)) = Set.pi I fun i => p i :=
-  rfl
-
 @[simp]
 theorem pi_empty (p : (i : ι) → Submodule R (φ i)) : pi ∅ p = ⊤ :=
   SetLike.coe_injective <| Set.empty_pi _
@@ -350,6 +347,7 @@ theorem pi_empty (p : (i : ι) → Submodule R (φ i)) : pi ∅ p = ⊤ :=
 theorem pi_top (s : Set ι) : (pi s fun i : ι => (⊤ : Submodule R (φ i))) = ⊤ :=
   SetLike.coe_injective <| Set.pi_univ _
 
+@[gcongr]
 theorem pi_mono {s : Set ι} (h : ∀ i ∈ s, p i ≤ q i) : pi s p ≤ pi s q :=
   Set.pi_mono h
 


### PR DESCRIPTION
From FLT

Co-authored-by: Andrew Yang

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
