### PR TITLE
[Merged by Bors] - feat(Algebra/Colimit/ModuleRing): generalize to Semiring/AddCommMonoid

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Limits.lean
@@ -204,10 +204,10 @@ section DirectLimit
 open Module
 
 variable {ι : Type v}
-variable [dec_ι : DecidableEq ι] [Preorder ι]
+variable [DecidableEq ι] [Preorder ι]
 variable (G : ι → Type v)
 variable [∀ i, AddCommGroup (G i)] [∀ i, Module R (G i)]
-variable (f : ∀ i j, i ≤ j → G i →ₗ[R] G j) [DirectedSystem G fun i j h => f i j h]
+variable (f : ∀ i j, i ≤ j → G i →ₗ[R] G j) [DirectedSystem G fun i j h ↦ f i j h]
 
 /-- The diagram (in the sense of `CategoryTheory`)
  of an unbundled `directLimit` of modules. -/
@@ -241,7 +241,7 @@ def directLimitCocone : Cocone (directLimitDiagram G f) where
 /-- The unbundled `directLimit` of modules is a colimit
 in the sense of `CategoryTheory`. -/
 @[simps]
-def directLimitIsColimit [IsDirected ι (· ≤ ·)] : IsColimit (directLimitCocone G f) where
+def directLimitIsColimit : IsColimit (directLimitCocone G f) where
   desc s := ofHom <|
     Module.DirectLimit.lift R ι G f (fun i => (s.ι.app i).hom) fun i j h x => by
       simp only [Functor.const_obj_obj]

--- a/Mathlib/Algebra/Colimit/ModuleRing.lean
+++ b/Mathlib/Algebra/Colimit/ModuleRing.lean
@@ -5,7 +5,6 @@ Authors: Kenny Lau, Chris Hughes, Jujian Zhang
 -/
 import Mathlib.Algebra.DirectSum.Module
 import Mathlib.Data.Finset.Order
-import Mathlib.LinearAlgebra.Quotient.Basic
 import Mathlib.RingTheory.FreeCommRing
 import Mathlib.RingTheory.Ideal.Maps
 import Mathlib.RingTheory.Ideal.Quotient.Defs
@@ -34,45 +33,50 @@ so as to make the operations (addition etc.) "computable".
 
 suppress_compilation
 
-universe u v v' v'' w u₁
+variable {R : Type*} [Semiring R] {ι : Type*} [Preorder ι] {G : ι → Type*}
 
 open Submodule
 
-variable {R : Type u} [Ring R]
-variable {ι : Type v}
-variable [Preorder ι]
-variable (G : ι → Type w)
-
 namespace Module
-
-variable [∀ i, AddCommGroup (G i)] [∀ i, Module R (G i)]
-variable {G}
-variable (f : ∀ i j, i ≤ j → G i →ₗ[R] G j)
 
 alias DirectedSystem.map_self := DirectedSystem.map_self'
 alias DirectedSystem.map_map := DirectedSystem.map_map'
 
+variable [DecidableEq ι]
+variable [∀ i, AddCommMonoid (G i)] [∀ i, Module R (G i)] (f : ∀ i j, i ≤ j → G i →ₗ[R] G j)
+
+/-- The relation on the direct sum that generates the additive congruence that defines the
+colimit as a quotient. -/
+inductive DirectLimit.Eqv : DirectSum ι G → DirectSum ι G → Prop
+  | of_map {i j} (h : i ≤ j) (x : G i) :
+    Eqv (DirectSum.lof R ι G i x) (DirectSum.lof R ι G j <| f i j h x)
+
 variable (G)
 
 /-- The direct limit of a directed system is the modules glued together along the maps. -/
-def DirectLimit [DecidableEq ι] : Type max v w :=
-  DirectSum ι G ⧸
-    (span R <|
-      { a |
-        ∃ (i j : _) (H : i ≤ j) (x : _),
-          DirectSum.lof R ι G i x - DirectSum.lof R ι G j (f i j H x) = a })
+def DirectLimit [DecidableEq ι] : Type _ := (addConGen <| DirectLimit.Eqv f).Quotient
 
 namespace DirectLimit
 
 section Basic
 
-variable [DecidableEq ι]
+instance addCommMonoid : AddCommMonoid (DirectLimit G f) :=
+  AddCon.addCommMonoid _
 
-instance addCommGroup : AddCommGroup (DirectLimit G f) :=
-  Quotient.addCommGroup _
+instance module : Module R (DirectLimit G f) where
+  smul r := AddCon.lift _ ((AddCon.mk' _).comp <| smulAddHom R _ r) <|
+    AddCon.addConGen_le fun x y ⟨_, _⟩ ↦ (AddCon.eq _).mpr <| by
+      simpa only [smulAddHom_apply, ← map_smul] using .of _ _ (.of_map _ _)
+  one_smul := by rintro ⟨⟩; exact congr_arg _ (one_smul _ _)
+  mul_smul _ _ := by rintro ⟨⟩; exact congr_arg _ (mul_smul _ _ _)
+  smul_zero _ := congr_arg _ (smul_zero _)
+  smul_add _ := by rintro ⟨⟩ ⟨⟩; exact congr_arg _ (smul_add _ _ _)
+  add_smul _ _ := by rintro ⟨⟩; exact congr_arg _ (add_smul _ _ _)
+  zero_smul := by rintro ⟨⟩; exact congr_arg _ (zero_smul _ _)
 
-instance module : Module R (DirectLimit G f) :=
-  Quotient.module _
+instance addCommGroup (G : ι → Type*) [∀ i, AddCommGroup (G i)] [∀ i, Module R (G i)]
+    (f : ∀ i j, i ≤ j → G i →ₗ[R] G j) : AddCommGroup (DirectLimit G f) :=
+  inferInstanceAs (AddCommGroup <| AddCon.Quotient _)
 
 instance inhabited : Inhabited (DirectLimit G f) :=
   ⟨0⟩
@@ -84,26 +88,35 @@ variable (R ι)
 
 /-- The canonical map from a component to the direct limit. -/
 def of (i) : G i →ₗ[R] DirectLimit G f :=
-  (mkQ _).comp <| DirectSum.lof R ι G i
+  .comp { __ := AddCon.mk' _, map_smul' := fun _ _ ↦ rfl } <| DirectSum.lof R ι G i
 
 variable {R ι G f}
 
+theorem quotMk_of (i x) : Quot.mk _ (.of G i x) = of R ι G f i x := rfl
+
 @[simp]
 theorem of_f {i j hij x} : of R ι G f j (f i j hij x) = of R ι G f i x :=
-  Eq.symm <| (Submodule.Quotient.eq _).2 <| subset_span ⟨i, j, hij, x, rfl⟩
+  (AddCon.eq _).mpr <| .symm <| .of _ _ (.of_map _ _)
 
 /-- Every element of the direct limit corresponds to some element in
 some component of the directed system. -/
 theorem exists_of [Nonempty ι] [IsDirected ι (· ≤ ·)] (z : DirectLimit G f) :
     ∃ i x, of R ι G f i x = z :=
-  Nonempty.elim (by infer_instance) fun ind : ι =>
-    Quotient.inductionOn' z fun z =>
-      DirectSum.induction_on z ⟨ind, 0, LinearMap.map_zero _⟩ (fun i x => ⟨i, x, rfl⟩)
-        fun p q ⟨i, x, ihx⟩ ⟨j, y, ihy⟩ =>
+  Nonempty.elim (by infer_instance) fun ind : ι ↦
+    Quotient.inductionOn' z fun z ↦
+      DirectSum.induction_on z ⟨ind, 0, LinearMap.map_zero _⟩ (fun i x ↦ ⟨i, x, rfl⟩)
+        fun p q ⟨i, x, ihx⟩ ⟨j, y, ihy⟩ ↦
         let ⟨k, hik, hjk⟩ := exists_ge_ge i j
         ⟨k, f i k hik x + f j k hjk y, by
           rw [LinearMap.map_add, of_f, of_f, ihx, ihy]
           rfl ⟩
+
+theorem exists_of₂ [Nonempty ι] [IsDirected ι (· ≤ ·)] (z w : DirectLimit G f) :
+    ∃ i x y, of R ι G f i x = z ∧ of R ι G f i y = w :=
+  have ⟨i, x, hx⟩ := exists_of z
+  have ⟨j, y, hy⟩ := exists_of w
+  have ⟨k, hik, hjk⟩ := exists_ge_ge i j
+  ⟨k, f i k hik x, f j k hjk y, by rw [of_f, hx], by rw [of_f, hy]⟩
 
 @[elab_as_elim]
 protected theorem induction_on [Nonempty ι] [IsDirected ι (· ≤ ·)] {C : DirectLimit G f → Prop}
@@ -111,49 +124,43 @@ protected theorem induction_on [Nonempty ι] [IsDirected ι (· ≤ ·)] {C : Di
   let ⟨i, x, h⟩ := exists_of z
   h ▸ ih i x
 
-variable {P : Type u₁} [AddCommGroup P] [Module R P]
+variable {P : Type*} [AddCommMonoid P] [Module R P]
 
 variable (R ι G f) in
 /-- The universal property of the direct limit: maps from the components to another module
 that respect the directed system structure (i.e. make some diagram commute) give rise
 to a unique map out of the direct limit. -/
 def lift (g : ∀ i, G i →ₗ[R] P) (Hg : ∀ i j hij x, g j (f i j hij x) = g i x) :
-    DirectLimit G f →ₗ[R] P :=
-  liftQ _ (DirectSum.toModule R ι P g)
-    (span_le.2 fun a ⟨i, j, hij, x, hx⟩ => by
-      rw [← hx, SetLike.mem_coe, LinearMap.sub_mem_ker_iff, DirectSum.toModule_lof,
-        DirectSum.toModule_lof, Hg])
+    DirectLimit G f →ₗ[R] P where
+  __ := AddCon.lift _ (DirectSum.toModule R ι P g) <|
+    AddCon.addConGen_le fun _ _ ⟨_, _⟩ ↦ by simpa using (Hg _ _ _ _).symm
+  map_smul' r := by rintro ⟨x⟩; exact map_smul (DirectSum.toModule R ι P g) r x
 
 variable (g : ∀ i, G i →ₗ[R] P) (Hg : ∀ i j hij x, g j (f i j hij x) = g i x)
 
 @[simp] theorem lift_of {i} (x) : lift R ι G f g Hg (of R ι G f i x) = g i x :=
   DirectSum.toModule_lof R _ _
 
-theorem lift_unique [IsDirected ι (· ≤ ·)] (F : DirectLimit G f →ₗ[R] P) (x) :
-    F x =
-      lift R ι G f (fun i => F.comp <| of R ι G f i)
-        (fun i j hij x => by rw [LinearMap.comp_apply, of_f]; rfl) x := by
-  cases isEmpty_or_nonempty ι
-  · simp_rw [Subsingleton.elim x 0, _root_.map_zero]
-  · exact DirectLimit.induction_on x fun i x => by rw [lift_of]; rfl
+theorem lift_unique (F : DirectLimit G f →ₗ[R] P) (x) :
+    F x = lift R ι G f (fun i ↦ F.comp <| of R ι G f i) (fun i j hij x ↦ by simp) x := by
+  rcases x with ⟨x⟩
+  exact x.induction_on (by simp) (fun _ _ ↦ .symm <| lift_of ..) (by simp +contextual)
 
 lemma lift_injective [IsDirected ι (· ≤ ·)]
     (injective : ∀ i, Function.Injective <| g i) :
     Function.Injective (lift R ι G f g Hg) := by
   cases isEmpty_or_nonempty ι
   · apply Function.injective_of_subsingleton
-  simp_rw [injective_iff_map_eq_zero] at injective ⊢
-  intros z hz
-  induction z using DirectLimit.induction_on with
-  | ih _ g =>
-    rw [lift_of] at hz
-    rw [injective _ g hz, _root_.map_zero]
+  intros z w eq
+  obtain ⟨i, x, y, rfl, rfl⟩ := exists_of₂ z w
+  simp_rw [lift_of] at eq
+  rw [injective _ eq]
 
 section functorial
 
-variable {G' : ι → Type v'} [∀ i, AddCommGroup (G' i)] [∀ i, Module R (G' i)]
+variable {G' : ι → Type*} [∀ i, AddCommMonoid (G' i)] [∀ i, Module R (G' i)]
 variable {f' : ∀ i j, i ≤ j → G' i →ₗ[R] G' j}
-variable {G'' : ι → Type v''} [∀ i, AddCommGroup (G'' i)] [∀ i, Module R (G'' i)]
+variable {G'' : ι → Type*} [∀ i, AddCommMonoid (G'' i)] [∀ i, Module R (G'' i)]
 variable {f'' : ∀ i j, i ≤ j → G'' i →ₗ[R] G'' j}
 
 /--
@@ -164,11 +171,9 @@ family of linear maps `gᵢ : Gᵢ ⟶ G'ᵢ` such that `g ∘ f = f' ∘ g` ind
 def map (g : (i : ι) → G i →ₗ[R] G' i) (hg : ∀ i j h, g j ∘ₗ f i j h = f' i j h ∘ₗ g i) :
     DirectLimit G f →ₗ[R] DirectLimit G' f' :=
   lift _ _ _ _ (fun i ↦ of _ _ _ _ _ ∘ₗ g i) fun i j h g ↦ by
-    cases isEmpty_or_nonempty ι
-    · subsingleton
-    · have eq1 := LinearMap.congr_fun (hg i j h) g
-      simp only [LinearMap.coe_comp, Function.comp_apply] at eq1 ⊢
-      rw [eq1, of_f]
+    have eq1 := LinearMap.congr_fun (hg i j h) g
+    simp only [LinearMap.coe_comp, Function.comp_apply] at eq1 ⊢
+    rw [eq1, of_f]
 
 @[simp] lemma map_apply_of (g : (i : ι) → G i →ₗ[R] G' i)
     (hg : ∀ i j h, g j ∘ₗ f i j h = f' i j h ∘ₗ g i)
@@ -176,13 +181,12 @@ def map (g : (i : ι) → G i →ₗ[R] G' i) (hg : ∀ i j h, g j ∘ₗ f i j 
     map g hg (of _ _ G f _ x) = of R ι G' f' i (g i x) :=
   lift_of _ _ _
 
-@[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
+@[simp] lemma map_id :
     map (fun _ ↦ LinearMap.id) (fun _ _ _ ↦ rfl) = LinearMap.id (R := R) (M := DirectLimit G f) :=
-  DFunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (by subsingleton) fun _ ↦
-    x.induction_on fun i g ↦ by simp
+  DFunLike.ext _ _ <| by
+    rintro ⟨x⟩; refine x.induction_on (by simp) (fun _ ↦ map_apply_of _ _) (by simp +contextual)
 
-lemma map_comp [IsDirected ι (· ≤ ·)]
-    (g₁ : (i : ι) → G i →ₗ[R] G' i) (g₂ : (i : ι) → G' i →ₗ[R] G'' i)
+lemma map_comp (g₁ : (i : ι) → G i →ₗ[R] G' i) (g₂ : (i : ι) → G' i →ₗ[R] G'' i)
     (hg₁ : ∀ i j h, g₁ j ∘ₗ f i j h = f' i j h ∘ₗ g₁ i)
     (hg₂ : ∀ i j h, g₂ j ∘ₗ f' i j h = f'' i j h ∘ₗ g₂ i) :
     (map g₂ hg₂ ∘ₗ map g₁ hg₁ :
@@ -190,8 +194,10 @@ lemma map_comp [IsDirected ι (· ≤ ·)]
     (map (fun i ↦ g₂ i ∘ₗ g₁ i) fun i j h ↦ by
         rw [LinearMap.comp_assoc, hg₁ i, ← LinearMap.comp_assoc, hg₂ i, LinearMap.comp_assoc] :
       DirectLimit G f →ₗ[R] DirectLimit G'' f'') :=
-  DFunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (by subsingleton) fun _ ↦
-    x.induction_on fun i g ↦ by simp
+  DFunLike.ext _ _ <| by
+    rintro ⟨x⟩; refine x.induction_on (by simp) (fun _ _ ↦ ?_) (by simp +contextual)
+    show map g₂ hg₂ (map g₁ hg₁ <| of _ _ _ _ _ _) = map _ _ (of _ _ _ _ _ _)
+    simp_rw [map_apply_of]; rfl
 
 open LinearEquiv LinearMap in
 /--
@@ -199,8 +205,7 @@ Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` resp
 family of equivalences `eᵢ : Gᵢ ≅ G'ᵢ` such that `e ∘ f = f' ∘ e` induces an equivalence
 `lim G ≅ lim G'`.
 -/
-def congr [IsDirected ι (· ≤ ·)]
-    (e : (i : ι) → G i ≃ₗ[R] G' i) (he : ∀ i j h, e j ∘ₗ f i j h = f' i j h ∘ₗ e i) :
+def congr (e : (i : ι) → G i ≃ₗ[R] G' i) (he : ∀ i j h, e j ∘ₗ f i j h = f' i j h ∘ₗ e i) :
     DirectLimit G f ≃ₗ[R] DirectLimit G' f' :=
   LinearEquiv.ofLinear (map (e ·) he)
     (map (fun i ↦ (e i).symm) fun i j h ↦ by
@@ -208,14 +213,13 @@ def congr [IsDirected ι (· ≤ ·)]
         refl_toLinearMap, comp_id])
     (by simp [map_comp]) (by simp [map_comp])
 
-lemma congr_apply_of [IsDirected ι (· ≤ ·)]
-    (e : (i : ι) → G i ≃ₗ[R] G' i) (he : ∀ i j h, e j ∘ₗ f i j h = f' i j h ∘ₗ e i)
+lemma congr_apply_of (e : (i : ι) → G i ≃ₗ[R] G' i) (he : ∀ i j h, e j ∘ₗ f i j h = f' i j h ∘ₗ e i)
     {i : ι} (g : G i) :
     congr e he (of _ _ G f i g) = of _ _ G' f' i (e i g) :=
   map_apply_of _ he _
 
 open LinearEquiv LinearMap in
-lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
+lemma congr_symm_apply_of
     (e : (i : ι) → G i ≃ₗ[R] G' i) (he : ∀ i j h, e j ∘ₗ f i j h = f' i j h ∘ₗ e i)
     {i : ι} (g : G' i) :
     (congr e he).symm (of _ _ G' f' i g) = of _ _ G f i ((e i).symm g) :=
@@ -229,7 +233,7 @@ end Basic
 
 section equiv
 
-variable [Nonempty ι] [IsDirected ι (· ≤ ·)] [DecidableEq ι] [DirectedSystem G (f · · ·)]
+variable [Nonempty ι] [IsDirected ι (· ≤ ·)] [DirectedSystem G (f · · ·)]
 open _root_.DirectLimit
 
 /-- The direct limit constructed as a quotient of the direct sum is isomorphic to
@@ -237,8 +241,9 @@ the direct limit constructed as a quotient of the disjoint union. -/
 def linearEquiv : DirectLimit G f ≃ₗ[R] _root_.DirectLimit G f :=
   .ofLinear (lift _ _ _ _ (Module.of _ _ _ _) fun _ _ _ _ ↦ .symm <| eq_of_le ..)
     (Module.lift _ _ _ _ (of _ _ _ _) fun _ _ _ _ ↦ of_f ..)
-    (by ext ⟨_⟩; rw [← Quotient.mk]; simp [Module.lift, _root_.DirectLimit.lift_def]; rfl)
-    (by ext x; refine x.induction_on fun i x ↦ ?_; simp; rfl)
+    (by ext ⟨_⟩; rw [← Quotient.mk]; simp [Module.lift, _root_.DirectLimit.lift_def]; rfl) <| by
+      ext ⟨x⟩; refine x.induction_on (by simp) (fun i x ↦ ?_) (by simp+contextual)
+      rw [quotMk_of, LinearMap.comp_apply, lift_of, Module.lift_of, LinearMap.id_apply]
 
 theorem linearEquiv_of {i g} : linearEquiv _ _ (of _ _ G f i g) = ⟦⟨i, g⟩⟧ := by
   simp [linearEquiv]; rfl
@@ -251,7 +256,7 @@ variable {G f}
 
 /-- A component that corresponds to zero in the direct limit is already zero in some
 bigger module in the directed system. -/
-theorem of.zero_exact [DirectedSystem G (f · · ·)] [IsDirected ι (· ≤ ·)] [DecidableEq ι]
+theorem of.zero_exact [DirectedSystem G (f · · ·)] [IsDirected ι (· ≤ ·)]
     {i x} (H : of R ι G f i x = 0) :
     ∃ j hij, f i j hij x = (0 : G j) := by
   haveI : Nonempty ι := ⟨i⟩
@@ -264,26 +269,28 @@ end Module
 
 namespace AddCommGroup
 
-variable [∀ i, AddCommGroup (G i)]
+variable (G) [∀ i, AddCommMonoid (G i)]
 
 /-- The direct limit of a directed system is the abelian groups glued together along the maps. -/
 def DirectLimit [DecidableEq ι] (f : ∀ i j, i ≤ j → G i →+ G j) : Type _ :=
-  @Module.DirectLimit ℤ _ ι _ G _ _ (fun i j hij => (f i j hij).toIntLinearMap) _
+  @Module.DirectLimit ℕ _ ι _ G _ _ (fun i j hij ↦ (f i j hij).toNatLinearMap) _
 
 namespace DirectLimit
 
 variable (f : ∀ i j, i ≤ j → G i →+ G j)
 
-protected theorem directedSystem [h : DirectedSystem G fun i j h => f i j h] :
-    DirectedSystem G fun i j hij => (f i j hij).toIntLinearMap :=
+local instance directedSystem [h : DirectedSystem G fun i j h ↦ f i j h] :
+    DirectedSystem G fun i j hij ↦ (f i j hij).toNatLinearMap :=
   h
-
-attribute [local instance] DirectLimit.directedSystem
 
 variable [DecidableEq ι]
 
-instance : AddCommGroup (DirectLimit G f) :=
-  Module.DirectLimit.addCommGroup G fun i j hij => (f i j hij).toIntLinearMap
+instance : AddCommMonoid (DirectLimit G f) :=
+  Module.DirectLimit.addCommMonoid G fun i j hij ↦ (f i j hij).toNatLinearMap
+
+instance addCommGroup (G : ι → Type*) [∀ i, AddCommGroup (G i)]
+    (f : ∀ i j, i ≤ j → G i →+ G j) : AddCommGroup (DirectLimit G f) :=
+  Module.DirectLimit.addCommGroup G fun i j hij ↦ (f i j hij).toNatLinearMap
 
 instance : Inhabited (DirectLimit G f) :=
   ⟨0⟩
@@ -292,7 +299,7 @@ instance [IsEmpty ι] : Unique (DirectLimit G f) := Module.DirectLimit.unique _ 
 
 /-- The canonical map from a component to the direct limit. -/
 def of (i) : G i →+ DirectLimit G f :=
-  (Module.DirectLimit.of ℤ ι G (fun i j hij => (f i j hij).toIntLinearMap) i).toAddMonoidHom
+  (Module.DirectLimit.of ℕ ι G _ i).toAddMonoidHom
 
 variable {G f}
 
@@ -307,11 +314,11 @@ protected theorem induction_on [Nonempty ι] [IsDirected ι (· ≤ ·)] {C : Di
 
 /-- A component that corresponds to zero in the direct limit is already zero in some
 bigger module in the directed system. -/
-theorem of.zero_exact [IsDirected ι (· ≤ ·)] [DirectedSystem G fun i j h => f i j h] (i x)
+theorem of.zero_exact [IsDirected ι (· ≤ ·)] [DirectedSystem G fun i j h ↦ f i j h] (i x)
     (h : of G f i x = 0) : ∃ j hij, f i j hij x = 0 :=
   Module.DirectLimit.of.zero_exact h
 
-variable (P : Type u₁) [AddCommGroup P]
+variable (P : Type*) [AddCommMonoid P]
 variable (g : ∀ i, G i →+ P)
 variable (Hg : ∀ i j hij x, g j (f i j hij x) = g i x)
 variable (G f)
@@ -320,8 +327,8 @@ variable (G f)
 that respect the directed system structure (i.e. make some diagram commute) give rise
 to a unique map out of the direct limit. -/
 def lift : DirectLimit G f →+ P :=
-  (Module.DirectLimit.lift ℤ ι G (fun i j hij => (f i j hij).toIntLinearMap)
-    (fun i => (g i).toIntLinearMap) Hg).toAddMonoidHom
+  (Module.DirectLimit.lift ℕ ι G (fun i j hij ↦ (f i j hij).toNatLinearMap)
+    (fun i ↦ (g i).toNatLinearMap) Hg).toAddMonoidHom
 
 variable {G f}
 
@@ -329,32 +336,26 @@ variable {G f}
 theorem lift_of (i x) : lift G f P g Hg (of G f i x) = g i x :=
   Module.DirectLimit.lift_of
     -- Note: had to make these arguments explicit https://github.com/leanprover-community/mathlib4/pull/8386
-    (f := (fun i j hij => (f i j hij).toIntLinearMap))
-    (fun i => (g i).toIntLinearMap)
+    (f := fun i j hij ↦ (f i j hij).toNatLinearMap)
+    (fun i ↦ (g i).toNatLinearMap)
     Hg
     x
 
-theorem lift_unique [IsDirected ι (· ≤ ·)] (F : DirectLimit G f →+ P) (x) :
-    F x = lift G f P (fun i => F.comp (of G f i)) (fun i j hij x => by simp) x := by
-  cases isEmpty_or_nonempty ι
-  · simp_rw [Subsingleton.elim x 0, _root_.map_zero]
-  · exact DirectLimit.induction_on x fun i x => by simp
+theorem lift_unique (F : DirectLimit G f →+ P) (x) :
+    F x = lift G f P (fun i ↦ F.comp (of G f i)) (fun i j hij x ↦ by simp) x := by
+  rcases x with ⟨x⟩
+  exact x.induction_on (by simp) (fun _ _ ↦ .symm <| lift_of ..) (by simp +contextual)
 
 lemma lift_injective [IsDirected ι (· ≤ ·)]
     (injective : ∀ i, Function.Injective <| g i) :
-    Function.Injective (lift G f P g Hg) := by
-  cases isEmpty_or_nonempty ι
-  · apply Function.injective_of_subsingleton
-  simp_rw [injective_iff_map_eq_zero] at injective ⊢
-  intros z hz
-  induction z using DirectLimit.induction_on with
-  | ih _ g => rw [lift_of] at hz; rw [injective _ g hz, _root_.map_zero]
+    Function.Injective (lift G f P g Hg) :=
+  Module.DirectLimit.lift_injective (f := fun i j hij ↦ (f i j hij).toNatLinearMap) _ Hg injective
 
 section functorial
 
-variable {G' : ι → Type v'} [∀ i, AddCommGroup (G' i)]
+variable {G' : ι → Type*} [∀ i, AddCommMonoid (G' i)]
 variable {f' : ∀ i j, i ≤ j → G' i →+ G' j}
-variable {G'' : ι → Type v''} [∀ i, AddCommGroup (G'' i)]
+variable {G'' : ι → Type*} [∀ i, AddCommMonoid (G'' i)]
 variable {f'' : ∀ i j, i ≤ j → G'' i →+ G'' j}
 
 /--
@@ -366,11 +367,9 @@ def map (g : (i : ι) → G i →+ G' i)
     (hg : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i)) :
     DirectLimit G f →+ DirectLimit G' f' :=
   lift _ _ _ (fun i ↦ (of _ _ _).comp (g i)) fun i j h g ↦ by
-    cases isEmpty_or_nonempty ι
-    · subsingleton
-    · have eq1 := DFunLike.congr_fun (hg i j h) g
-      simp only [AddMonoidHom.coe_comp, Function.comp_apply] at eq1 ⊢
-      rw [eq1, of_f]
+    have eq1 := DFunLike.congr_fun (hg i j h) g
+    simp only [AddMonoidHom.coe_comp, Function.comp_apply] at eq1 ⊢
+    rw [eq1, of_f]
 
 @[simp] lemma map_apply_of (g : (i : ι) → G i →+ G' i)
     (hg : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i))
@@ -378,12 +377,12 @@ def map (g : (i : ι) → G i →+ G' i)
     map g hg (of G f _ x) = of G' f' i (g i x) :=
   lift_of _ _ _ _ _
 
-@[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
+@[simp] lemma map_id :
     map (fun _ ↦ AddMonoidHom.id _) (fun _ _ _ ↦ rfl) = AddMonoidHom.id (DirectLimit G f) :=
-  DFunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (by subsingleton) fun _ ↦
-    x.induction_on fun i g ↦ by simp
+  DFunLike.ext _ _ <| by
+    rintro ⟨x⟩; refine x.induction_on (by simp) (fun _ ↦ map_apply_of _ _) (by simp +contextual)
 
-lemma map_comp [IsDirected ι (· ≤ ·)]
+lemma map_comp
     (g₁ : (i : ι) → G i →+ G' i) (g₂ : (i : ι) → G' i →+ G'' i)
     (hg₁ : ∀ i j h, (g₁ j).comp (f i j h) = (f' i j h).comp (g₁ i))
     (hg₂ : ∀ i j h, (g₂ j).comp (f' i j h) = (f'' i j h).comp (g₂ i)) :
@@ -393,16 +392,17 @@ lemma map_comp [IsDirected ι (· ≤ ·)]
       rw [AddMonoidHom.comp_assoc, hg₁ i, ← AddMonoidHom.comp_assoc, hg₂ i,
         AddMonoidHom.comp_assoc] :
       DirectLimit G f →+ DirectLimit G'' f'') :=
-  DFunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (by subsingleton) fun _ ↦
-    x.induction_on fun i g ↦ by simp
+  DFunLike.ext _ _ <| by
+    rintro ⟨x⟩; refine x.induction_on (by simp) (fun _ _ ↦ ?_) (by simp +contextual)
+    show map g₂ hg₂ (map g₁ hg₁ <| of _ _ _ _) = map _ _ (of _ _ _ _)
+    simp_rw [map_apply_of]; rfl
 
 /--
 Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
 family of equivalences `eᵢ : Gᵢ ≅ G'ᵢ` such that `e ∘ f = f' ∘ e` induces an equivalence
 `lim G ⟶ lim G'`.
 -/
-def congr [IsDirected ι (· ≤ ·)]
-    (e : (i : ι) → G i ≃+ G' i)
+def congr (e : (i : ι) → G i ≃+ G' i)
     (he : ∀ i j h, (e j).toAddMonoidHom.comp (f i j h) = (f' i j h).comp (e i)) :
     DirectLimit G f ≃+ DirectLimit G' f' :=
   AddMonoidHom.toAddEquiv (map (e ·) he)
@@ -411,17 +411,16 @@ def congr [IsDirected ι (· ≤ ·)]
       simp only [AddMonoidHom.coe_comp, AddEquiv.coe_toAddMonoidHom, Function.comp_apply,
         AddMonoidHom.coe_coe, AddEquiv.apply_symm_apply] at eq1 ⊢
       simp [← eq1, of_f])
-    (by rw [map_comp]; convert map_id <;> aesop)
-    (by rw [map_comp]; convert map_id <;> aesop)
+    (by simp [map_comp]) (by simp [map_comp])
 
-lemma congr_apply_of [IsDirected ι (· ≤ ·)]
+lemma congr_apply_of
     (e : (i : ι) → G i ≃+ G' i)
     (he : ∀ i j h, (e j).toAddMonoidHom.comp (f i j h) = (f' i j h).comp (e i))
     {i : ι} (g : G i) :
     congr e he (of G f i g) = of G' f' i (e i g) :=
   map_apply_of _ he _
 
-lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
+lemma congr_symm_apply_of
     (e : (i : ι) → G i ≃+ G' i)
     (he : ∀ i j h, (e j).toAddMonoidHom.comp (f i j h) = (f' i j h).comp (e i))
     {i : ι} (g : G' i) :
@@ -436,7 +435,7 @@ end AddCommGroup
 
 namespace Ring
 
-variable [∀ i, CommRing (G i)]
+variable (G) [∀ i, CommRing (G i)]
 
 section
 
@@ -445,14 +444,14 @@ variable (f : ∀ i j, i ≤ j → G i → G j)
 open FreeCommRing
 
 /-- The direct limit of a directed system is the rings glued together along the maps. -/
-def DirectLimit : Type max v w :=
-  FreeCommRing (Σi, G i) ⧸
+def DirectLimit : Type _ :=
+  FreeCommRing (Σ i, G i) ⧸
     Ideal.span
       { a |
-        (∃ i j H x, of (⟨j, f i j H x⟩ : Σi, G i) - of ⟨i, x⟩ = a) ∨
-          (∃ i, of (⟨i, 1⟩ : Σi, G i) - 1 = a) ∨
-            (∃ i x y, of (⟨i, x + y⟩ : Σi, G i) - (of ⟨i, x⟩ + of ⟨i, y⟩) = a) ∨
-              ∃ i x y, of (⟨i, x * y⟩ : Σi, G i) - of ⟨i, x⟩ * of ⟨i, y⟩ = a }
+        (∃ i j H x, of (⟨j, f i j H x⟩ : Σ i, G i) - of ⟨i, x⟩ = a) ∨
+          (∃ i, of (⟨i, 1⟩ : Σ i, G i) - 1 = a) ∨
+            (∃ i x y, of (⟨i, x + y⟩ : Σ i, G i) - (of ⟨i, x⟩ + of ⟨i, y⟩) = a) ∨
+              ∃ i x y, of (⟨i, x * y⟩ : Σ i, G i) - of ⟨i, x⟩ * of ⟨i, y⟩ = a }
 
 namespace DirectLimit
 
@@ -473,13 +472,16 @@ instance : Inhabited (DirectLimit G f) :=
 /-- The canonical map from a component to the direct limit. -/
 nonrec def of (i) : G i →+* DirectLimit G f :=
   RingHom.mk'
-    { toFun := fun x => Ideal.Quotient.mk _ (of (⟨i, x⟩ : Σi, G i))
+    { toFun := fun x ↦ Ideal.Quotient.mk _ (of (⟨i, x⟩ : Σ i, G i))
       map_one' := Ideal.Quotient.eq.2 <| subset_span <| Or.inr <| Or.inl ⟨i, rfl⟩
-      map_mul' := fun x y =>
+      map_mul' := fun x y ↦
         Ideal.Quotient.eq.2 <| subset_span <| Or.inr <| Or.inr <| Or.inr ⟨i, x, y, rfl⟩ }
-    fun x y => Ideal.Quotient.eq.2 <| subset_span <| Or.inr <| Or.inr <| Or.inl ⟨i, x, y, rfl⟩
+    fun x y ↦ Ideal.Quotient.eq.2 <| subset_span <| Or.inr <| Or.inr <| Or.inl ⟨i, x, y, rfl⟩
 
 variable {G f}
+
+theorem quotientMk_of (i x) : Ideal.Quotient.mk _ (.of ⟨i, x⟩) = of G f i x :=
+  rfl
 
 @[simp] theorem of_f {i j} (hij) (x) : of G f j (f i j hij x) = of G f i x :=
   Ideal.Quotient.eq.2 <| subset_span <| Or.inl ⟨i, j, hij, x, rfl⟩
@@ -488,11 +490,11 @@ variable {G f}
 some component of the directed system. -/
 theorem exists_of [Nonempty ι] [IsDirected ι (· ≤ ·)] (z : DirectLimit G f) :
     ∃ i x, of G f i x = z :=
-  Nonempty.elim (by infer_instance) fun ind : ι =>
-    Quotient.inductionOn' z fun x =>
+  Nonempty.elim (by infer_instance) fun ind : ι ↦
+    Quotient.inductionOn' z fun x ↦
       FreeAbelianGroup.induction_on x ⟨ind, 0, (of _ _ ind).map_zero⟩
-        (fun s =>
-          Multiset.induction_on s ⟨ind, 1, (of _ _ ind).map_one⟩ fun a s ih =>
+        (fun s ↦
+          Multiset.induction_on s ⟨ind, 1, (of _ _ ind).map_one⟩ fun a s ih ↦
             let ⟨i, x⟩ := a
             let ⟨j, y, hs⟩ := ih
             let ⟨k, hik, hjk⟩ := exists_ge_ge i j
@@ -503,10 +505,10 @@ theorem exists_of [Nonempty ι] [IsDirected ι (· ≤ ·)] (z : DirectLimit G f
               apply congr_arg Quotient.mk''
               symm
               apply FreeCommRing.of_cons⟩)
-        (fun s ⟨i, x, ih⟩ => ⟨i, -x, by
+        (fun s ⟨i, x, ih⟩ ↦ ⟨i, -x, by
           rw [(of G _ _).map_neg, ih]
           rfl⟩)
-        fun p q ⟨i, x, ihx⟩ ⟨j, y, ihy⟩ =>
+        fun p q ⟨i, x, ihx⟩ ⟨j, y, ihy⟩ ↦
         let ⟨k, hik, hjk⟩ := exists_ge_ge i j
         ⟨k, f i k hik x + f j k hjk y, by rw [(of _ _ _).map_add, of_f, of_f, ihx, ihy]; rfl⟩
 
@@ -517,18 +519,18 @@ open Polynomial
 variable {f' : ∀ i j, i ≤ j → G i →+* G j}
 
 nonrec theorem Polynomial.exists_of [Nonempty ι] [IsDirected ι (· ≤ ·)]
-    (q : Polynomial (DirectLimit G fun i j h => f' i j h)) :
-    ∃ i p, Polynomial.map (of G (fun i j h => f' i j h) i) p = q :=
+    (q : Polynomial (DirectLimit G fun i j h ↦ f' i j h)) :
+    ∃ i p, Polynomial.map (of G (fun i j h ↦ f' i j h) i) p = q :=
   Polynomial.induction_on q
-    (fun z =>
+    (fun z ↦
       let ⟨i, x, h⟩ := exists_of z
       ⟨i, C x, by rw [map_C, h]⟩)
-    (fun q₁ q₂ ⟨i₁, p₁, ih₁⟩ ⟨i₂, p₂, ih₂⟩ =>
+    (fun q₁ q₂ ⟨i₁, p₁, ih₁⟩ ⟨i₂, p₂, ih₂⟩ ↦
       let ⟨i, h1, h2⟩ := exists_ge_ge i₁ i₂
       ⟨i, p₁.map (f' i₁ i h1) + p₂.map (f' i₂ i h2), by
         rw [Polynomial.map_add, map_map, map_map, ← ih₁, ← ih₂]
         congr 2 <;> ext x <;> simp_rw [RingHom.comp_apply, of_f]⟩)
-    fun n z _ =>
+    fun n z _ ↦
     let ⟨i, x, h⟩ := exists_of z
     ⟨i, C x * X ^ (n + 1), by rw [Polynomial.map_mul, map_C, h, Polynomial.map_pow, map_X]⟩
 
@@ -540,7 +542,7 @@ theorem induction_on [Nonempty ι] [IsDirected ι (· ≤ ·)] {C : DirectLimit 
   let ⟨i, x, hx⟩ := exists_of z
   hx ▸ ih i x
 
-variable (P : Type u₁) [CommRing P]
+variable (P : Type*) [CommRing P]
 
 open FreeCommRing
 
@@ -551,10 +553,10 @@ to a unique map out of the direct limit.
 -/
 def lift (g : ∀ i, G i →+* P) (Hg : ∀ i j hij x, g j (f i j hij x) = g i x) :
     DirectLimit G f →+* P :=
-  Ideal.Quotient.lift _ (FreeCommRing.lift fun x : Σi, G i => g x.1 x.2)
+  Ideal.Quotient.lift _ (FreeCommRing.lift fun x : Σ i, G i ↦ g x.1 x.2)
     (by
       suffices Ideal.span _ ≤
-          Ideal.comap (FreeCommRing.lift fun x : Σi : ι, G i => g x.fst x.snd) ⊥ by
+          Ideal.comap (FreeCommRing.lift fun x : Σ i : ι, G i ↦ g x.fst x.snd) ⊥ by
         intro x hx
         exact (mem_bot P).1 (this hx)
       rw [Ideal.span_le]
@@ -569,14 +571,11 @@ variable (g : ∀ i, G i →+* P) (Hg : ∀ i j hij x, g j (f i j hij x) = g i x
 @[simp] theorem lift_of (i x) : lift G f P g Hg (of G f i x) = g i x :=
   FreeCommRing.lift_of _ _
 
-theorem lift_unique [IsDirected ι (· ≤ ·)] (F : DirectLimit G f →+* P) (x) :
-    F x = lift G f P (fun i => F.comp <| of G f i) (fun i j hij x => by simp [of_f]) x := by
-  cases isEmpty_or_nonempty ι
-  · apply DFunLike.congr_fun
-    apply Ideal.Quotient.ringHom_ext
-    refine FreeCommRing.hom_ext fun ⟨i, _⟩ ↦ ?_
-    exact IsEmpty.elim' inferInstance i
-  · exact DirectLimit.induction_on x fun i x => by simp
+theorem lift_unique (F : DirectLimit G f →+* P) (x) :
+    F x = lift G f P (fun i ↦ F.comp <| of G f i) (fun i j hij x ↦ by simp) x := by
+  obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective x
+  exact x.induction_on (by simp) (fun _ ↦ .symm <| lift_of ..)
+    (by simp +contextual) (by simp+contextual)
 
 lemma lift_injective [Nonempty ι] [IsDirected ι (· ≤ ·)]
     (injective : ∀ i, Function.Injective <| g i) :
@@ -589,7 +588,7 @@ lemma lift_injective [Nonempty ι] [IsDirected ι (· ≤ ·)]
 section OfZeroExact
 
 variable (f' : ∀ i j, i ≤ j → G i →+* G j)
-variable [DirectedSystem G fun i j h => f' i j h] [IsDirected ι (· ≤ ·)]
+variable [DirectedSystem G fun i j h ↦ f' i j h] [IsDirected ι (· ≤ ·)]
 variable (G f)
 
 open _root_.DirectLimit in
@@ -621,25 +620,19 @@ variable (f' : ∀ i j, i ≤ j → G i →+* G j)
 
 /-- If the maps in the directed system are injective, then the canonical maps
 from the components to the direct limits are injective. -/
-theorem of_injective [IsDirected ι (· ≤ ·)] [DirectedSystem G fun i j h => f' i j h]
+theorem of_injective [IsDirected ι (· ≤ ·)] [DirectedSystem G fun i j h ↦ f' i j h]
     (hf : ∀ i j hij, Function.Injective (f' i j hij)) (i) :
-    Function.Injective (of G (fun i j h => f' i j h) i) := by
-  suffices ∀ x, of G (fun i j h => f' i j h) i x = 0 → x = 0 by
-    intro x y hxy
-    rw [← sub_eq_zero]
-    apply this
-    rw [(of G _ i).map_sub, hxy, sub_self]
-  intro x hx
-  rcases of.zero_exact hx with ⟨j, hij, hfx⟩
-  apply hf i j hij
-  rw [hfx, (f' i j hij).map_zero]
+    Function.Injective (of G (fun i j h ↦ f' i j h) i) :=
+  haveI := Nonempty.intro i
+  ((ringEquiv _ _).comp_injective _).mp
+    fun _ _ eq ↦  DirectLimit.mk_injective f' hf _ (by simpa only [← ringEquiv_of])
 
 section functorial
 
 variable {f : ∀ i j, i ≤ j → G i →+* G j}
-variable {G' : ι → Type v'} [∀ i, CommRing (G' i)]
+variable {G' : ι → Type*} [∀ i, CommRing (G' i)]
 variable {f' : ∀ i j, i ≤ j → G' i →+* G' j}
-variable {G'' : ι → Type v''} [∀ i, CommRing (G'' i)]
+variable {G'' : ι → Type*} [∀ i, CommRing (G'' i)]
 variable {f'' : ∀ i j, i ≤ j → G'' i →+* G'' j}
 
 /--
@@ -661,15 +654,14 @@ def map (g : (i : ι) → G i →+* G' i)
     map g hg (of G _ _ x) = of G' (fun _ _ h ↦ f' _ _ h) i (g i x) :=
   lift_of _ _ _ _ _
 
-variable [Nonempty ι]
+@[simp] lemma map_id :
+    map (fun _ ↦ RingHom.id _) (fun _ _ _ ↦ rfl) = RingHom.id (DirectLimit G fun _ _ h ↦ f _ _ h) :=
+  DFunLike.ext _ _ fun x ↦ by
+    obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective x
+    refine x.induction_on (by simp) (fun _ ↦ ?_) (by simp+contextual) (by simp+contextual)
+    rw [quotientMk_of, map_apply_of]; rfl
 
-@[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
-    map (fun _ ↦ RingHom.id _) (fun _ _ _ ↦ rfl) =
-    RingHom.id (DirectLimit G fun _ _ h ↦ f _ _ h) :=
-  DFunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp
-
-lemma map_comp [IsDirected ι (· ≤ ·)]
-    (g₁ : (i : ι) → G i →+* G' i) (g₂ : (i : ι) → G' i →+* G'' i)
+lemma map_comp (g₁ : (i : ι) → G i →+* G' i) (g₂ : (i : ι) → G' i →+* G'' i)
     (hg₁ : ∀ i j h, (g₁ j).comp (f i j h) = (f' i j h).comp (g₁ i))
     (hg₂ : ∀ i j h, (g₂ j).comp (f' i j h) = (f'' i j h).comp (g₂ i)) :
     ((map g₂ hg₂).comp (map g₁ hg₁) :
@@ -677,40 +669,41 @@ lemma map_comp [IsDirected ι (· ≤ ·)]
     (map (fun i ↦ (g₂ i).comp (g₁ i)) fun i j h ↦ by
       rw [RingHom.comp_assoc, hg₁ i, ← RingHom.comp_assoc, hg₂ i, RingHom.comp_assoc] :
       DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' fun _ _ h ↦ f'' _ _ h) :=
-  DFunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp
+  DFunLike.ext _ _ fun x ↦ by
+    obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective x
+    refine x.induction_on (by simp) (fun _ ↦ ?_) (by simp+contextual) (by simp+contextual)
+    rw [RingHom.comp_apply, quotientMk_of]
+    simp_rw [map_apply_of]
+    rfl
 
 /--
 Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
 family of equivalences `eᵢ : Gᵢ ≅ G'ᵢ` such that `e ∘ f = f' ∘ e` induces an equivalence
 `lim G ⟶ lim G'`.
 -/
-def congr [IsDirected ι (· ≤ ·)]
-    (e : (i : ι) → G i ≃+* G' i)
+def congr (e : (i : ι) → G i ≃+* G' i)
     (he : ∀ i j h, (e j).toRingHom.comp (f i j h) = (f' i j h).comp (e i)) :
     DirectLimit G (fun _ _ h ↦ f _ _ h) ≃+* DirectLimit G' fun _ _ h ↦ f' _ _ h :=
-  RingEquiv.ofHomInv
+  RingEquiv.ofRingHom
     (map (e ·) he)
     (map (fun i ↦ (e i).symm) fun i j h ↦ DFunLike.ext _ _ fun x ↦ by
       have eq1 := DFunLike.congr_fun (he i j h) ((e i).symm x)
       simp only [RingEquiv.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply,
         RingEquiv.apply_symm_apply] at eq1 ⊢
       simp [← eq1, of_f])
-    (DFunLike.ext _ _ fun x ↦ x.induction_on <| by simp)
-    (DFunLike.ext _ _ fun x ↦ x.induction_on <| by simp)
+    (by simp [map_comp]) (by simp [map_comp])
 
-lemma congr_apply_of [IsDirected ι (· ≤ ·)]
-    (e : (i : ι) → G i ≃+* G' i)
+lemma congr_apply_of (e : (i : ι) → G i ≃+* G' i)
     (he : ∀ i j h, (e j).toRingHom.comp (f i j h) = (f' i j h).comp (e i))
     {i : ι} (g : G i) :
     congr e he (of G _ i g) = of G' (fun _ _ h ↦ f' _ _ h) i (e i g) :=
   map_apply_of _ he _
 
-lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
-    (e : (i : ι) → G i ≃+* G' i)
+lemma congr_symm_apply_of (e : (i : ι) → G i ≃+* G' i)
     (he : ∀ i j h, (e j).toRingHom.comp (f i j h) = (f' i j h).comp (e i))
     {i : ι} (g : G' i) :
     (congr e he).symm (of G' _ i g) = of G (fun _ _ h ↦ f _ _ h) i ((e i).symm g) := by
-  simp only [congr, RingEquiv.ofHomInv_symm_apply, map_apply_of, RingHom.coe_coe]
+  simp only [congr, RingEquiv.ofRingHom_symm_apply, map_apply_of, RingHom.coe_coe]
 
 end functorial
 
@@ -722,7 +715,7 @@ end Ring
 
 namespace Field
 
-variable [Nonempty ι] [IsDirected ι (· ≤ ·)] [∀ i, Field (G i)]
+variable [Nonempty ι] [IsDirected ι (· ≤ ·)] [∀ i, Field (G i)] (G)
 variable (f : ∀ i j, i ≤ j → G i → G j)
 variable (f' : ∀ i j, i ≤ j → G i →+* G j)
 
@@ -731,7 +724,7 @@ namespace DirectLimit
 instance nontrivial [DirectedSystem G (f' · · ·)] :
     Nontrivial (Ring.DirectLimit G (f' · · ·)) :=
   ⟨⟨0, 1,
-      Nonempty.elim (by infer_instance) fun i : ι => by
+      Nonempty.elim (by infer_instance) fun i : ι ↦ by
         change (0 : Ring.DirectLimit G (f' · · ·)) ≠ 1
         rw [← (Ring.DirectLimit.of _ _ _).map_one]
         · intro H; rcases Ring.DirectLimit.of.zero_exact H.symm with ⟨j, hij, hf⟩
@@ -739,10 +732,10 @@ instance nontrivial [DirectedSystem G (f' · · ·)] :
           exact one_ne_zero hf⟩⟩
 
 theorem exists_inv {p : Ring.DirectLimit G f} : p ≠ 0 → ∃ y, p * y = 1 :=
-  Ring.DirectLimit.induction_on p fun i x H =>
+  Ring.DirectLimit.induction_on p fun i x H ↦
     ⟨Ring.DirectLimit.of G f i x⁻¹, by
       rw [← (Ring.DirectLimit.of _ _ _).map_mul,
-        mul_inv_cancel₀ fun h : x = 0 => H <| by rw [h, (Ring.DirectLimit.of _ _ _).map_zero],
+        mul_inv_cancel₀ fun h : x = 0 ↦ H <| by rw [h, (Ring.DirectLimit.of _ _ _).map_zero],
         (Ring.DirectLimit.of _ _ _).map_one]⟩
 
 section
@@ -766,12 +759,12 @@ protected noncomputable abbrev field [DirectedSystem G (f' · · ·)] :
   -- This used to include the parent CommRing and Nontrivial instances,
   -- but leaving them implicit avoids a very expensive (2-3 minutes!) eta expansion.
   inv := inv G (f' · · ·)
-  mul_inv_cancel := fun _ => DirectLimit.mul_inv_cancel G (f' · · ·)
+  mul_inv_cancel := fun _ ↦ DirectLimit.mul_inv_cancel G (f' · · ·)
   inv_zero := dif_pos rfl
   nnqsmul := _
-  nnqsmul_def := fun _ _ => rfl
+  nnqsmul_def _ _ := rfl
   qsmul := _
-  qsmul_def := fun _ _ => rfl
+  qsmul_def _ _ := rfl
 
 end
 

--- a/Mathlib/GroupTheory/Congruence/Defs.lean
+++ b/Mathlib/GroupTheory/Congruence/Defs.lean
@@ -764,6 +764,17 @@ instance group : Group c.Quotient :=
     toInv := Con.hasInv _
     toDiv := Con.hasDiv _ }
 
+/-- The quotient of a `CommGroup` by a congruence relation is a `CommGroup`. -/
+@[to_additive "The quotient of an `AddCommGroup` by an additive congruence
+relation is an `AddCommGroup`."]
+instance commGroup {M : Type*} [CommGroup M] (c : Con M) : CommGroup c.Quotient :=
+  { (Function.Surjective.commGroup _ Quotient.mk''_surjective rfl (fun _ _ => rfl) (fun _ => rfl)
+      (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) : CommGroup c.Quotient) with
+    /- The `toGroup` field is given explicitly for performance reasons.
+    This avoids any need to unfold `Function.Surjective.commGroup` when the type checker is
+    checking that instance diagrams commute -/
+    toGroup := Con.group _ }
+
 end Groups
 
 section Units

--- a/Mathlib/LinearAlgebra/TensorProduct/DirectLimit.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/DirectLimit.lean
@@ -68,19 +68,17 @@ variable {M} in
   rw [toDirectLimit, lift.tmul, lift_of]
   rfl
 
-variable [IsDirected ι (· ≤ ·)]
-
 /--
 `limᵢ (Gᵢ ⊗ M)` and `(limᵢ Gᵢ) ⊗ M` are isomorphic as modules
 -/
 noncomputable def directLimitLeft :
     DirectLimit G f ⊗[R] M ≃ₗ[R] DirectLimit (G · ⊗[R] M) (f ▷ M) := by
-  refine LinearEquiv.ofLinear (toDirectLimit f M) (fromDirectLimit f M) ?_ ?_
-    <;> cases isEmpty_or_nonempty ι
-  · ext; subsingleton
-  · refine DFunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ g.induction_on ?_ ?_ ?_ <;> aesop
-  · ext; subsingleton
-  · exact ext (DFunLike.ext _ _ fun g ↦ DFunLike.ext _ _ fun _ ↦ g.induction_on <| by aesop)
+  refine LinearEquiv.ofLinear (toDirectLimit f M) (fromDirectLimit f M) ?_ (ext ?_)
+  · ext ⟨x⟩
+    exact x.induction_on (by simp) (fun i x ↦ x.induction_on (by simp)
+      (fun _ _ ↦ by rw [quotMk_of]; simp) <| by simp+contextual) (by simp+contextual)
+  · ext ⟨x⟩ m
+    exact x.induction_on (by simp) (fun _ _ ↦ by rw [quotMk_of]; simp) (by simp+contextual)
 
 @[simp] lemma directLimitLeft_tmul_of {i : ι} (g : G i) (m : M) :
     directLimitLeft f M (of _ _ _ _ _ g ⊗ₜ m) = of _ _ _ (f ▷ M) _ (g ⊗ₜ m) :=

--- a/Mathlib/LinearAlgebra/TensorProduct/DirectLimit.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/DirectLimit.lean
@@ -22,13 +22,13 @@ as `R`-modules.
 
 open TensorProduct Module Module.DirectLimit
 
-variable {R : Type*} [CommRing R]
+variable {R : Type*} [CommSemiring R]
 variable {ι : Type*}
 variable [DecidableEq ι] [Preorder ι]
 variable {G : ι → Type*}
-variable [∀ i, AddCommGroup (G i)] [∀ i, Module R (G i)]
+variable [∀ i, AddCommMonoid (G i)] [∀ i, Module R (G i)]
 variable (f : ∀ i j, i ≤ j → G i →ₗ[R] G j)
-variable (M : Type*) [AddCommGroup M] [Module R M]
+variable (M : Type*) [AddCommMonoid M] [Module R M]
 
 -- alluding to the notation in `CategoryTheory.Monoidal`
 local notation M " ◁ " f => fun i j h ↦ LinearMap.lTensor M (f _ _ h)


### PR DESCRIPTION
and remove all unnecessary IsDirected assumptions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
