### PR TITLE
[Merged by Bors] - chore(*): drop unneeded imports of OmegaCompletePartialOrder

### DIFF
--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.MonoidAlgebra.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.WithTop
 import Mathlib.Data.Finset.Sort
-import Mathlib.Order.OmegaCompletePartialOrder
 
 /-!
 # Theory of univariate polynomials

--- a/Mathlib/Algebra/Polynomial/Degree/TrailingDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/TrailingDegree.lean
@@ -5,7 +5,6 @@ Authors: Damiano Testa
 -/
 import Mathlib.Algebra.Polynomial.Degree.Support
 import Mathlib.Data.ENat.Basic
-import Mathlib.Data.ENat.Lattice
 
 /-!
 # Trailing degree of univariate polynomials

--- a/Mathlib/Algebra/Polynomial/Div.lean
+++ b/Mathlib/Algebra/Polynomial/Div.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Polynomial.Inductions
 import Mathlib.Algebra.Polynomial.Monic
 import Mathlib.Algebra.Ring.Regular
 import Mathlib.RingTheory.Multiplicity
+import Mathlib.Data.Nat.Lattice
 
 /-!
 # Division of univariate polynomials

--- a/Mathlib/Analysis/Calculus/ContDiff/FTaylorSeries.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FTaylorSeries.lean
@@ -6,6 +6,7 @@ Authors: Sébastien Gouëzel
 import Mathlib.Analysis.Calculus.FDeriv.Add
 import Mathlib.Analysis.Calculus.FDeriv.Equiv
 import Mathlib.Analysis.Calculus.FormalMultilinearSeries
+import Mathlib.Data.ENat.Lattice
 
 /-!
 # Iterated derivatives of a function

--- a/Mathlib/Dynamics/TopologicalEntropy/CoverEntropy.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/CoverEntropy.lean
@@ -6,6 +6,7 @@ Authors: Damien Thomine, Pietro Monticone
 import Mathlib.Analysis.SpecialFunctions.Log.ENNRealLog
 import Mathlib.Data.Real.ENatENNReal
 import Mathlib.Dynamics.TopologicalEntropy.DynamicalEntourage
+import Mathlib.Data.ENat.Lattice
 
 /-!
 # Topological entropy via covers

--- a/Mathlib/Dynamics/TopologicalEntropy/DynamicalEntourage.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/DynamicalEntourage.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damien Thomine, Pietro Monticone
 -/
 import Mathlib.Order.Interval.Finset.Nat
-import Mathlib.Order.OmegaCompletePartialOrder
 import Mathlib.Topology.UniformSpace.Basic
 
 /-!

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -10,6 +10,7 @@ import Mathlib.FieldTheory.IntermediateField.Basic
 import Mathlib.FieldTheory.Minpoly.Field
 import Mathlib.RingTheory.Polynomial.Content
 import Mathlib.RingTheory.PowerBasis
+import Mathlib.Data.ENat.Lattice
 
 /-!
 

--- a/Mathlib/MeasureTheory/Constructions/Cylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne, Peter Pfaffelhuber, Yaël Dillies, Kin Yau James Wong
 -/
 import Mathlib.MeasureTheory.PiSystem
-import Mathlib.Order.OmegaCompletePartialOrder
 import Mathlib.Topology.Constructions
 import Mathlib.MeasureTheory.MeasurableSpace.Basic
 

--- a/Mathlib/RingTheory/PowerSeries/Inverse.lean
+++ b/Mathlib/RingTheory/PowerSeries/Inverse.lean
@@ -11,6 +11,7 @@ import Mathlib.RingTheory.PowerSeries.Basic
 import Mathlib.RingTheory.PowerSeries.Order
 import Mathlib.RingTheory.LocalRing.ResidueField.Defs
 import Mathlib.RingTheory.UniqueFactorizationDomain.Multiplicity
+import Mathlib.Data.ENat.Lattice
 
 /-! # Formal power series - Inverses
 

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -10,7 +10,6 @@ import Mathlib.Topology.Algebra.Ring.Basic
 import Mathlib.Topology.UniformSpace.UniformEmbedding
 import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 import Mathlib.LinearAlgebra.Pi
-import Mathlib.Order.OmegaCompletePartialOrder
 import Mathlib.LinearAlgebra.Quotient.Defs
 
 /-!

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Nailin Guan
 -/
 import Mathlib.Algebra.Module.Submodule.Lattice
-import Mathlib.Order.OmegaCompletePartialOrder
 import Mathlib.RingTheory.Ideal.Defs
 import Mathlib.Topology.Algebra.Group.Quotient
 import Mathlib.Topology.Algebra.Ring.Basic

--- a/Mathlib/Topology/Sheaves/PresheafOfFunctions.lean
+++ b/Mathlib/Topology/Sheaves/PresheafOfFunctions.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
-import Mathlib.Order.OmegaCompletePartialOrder
 import Mathlib.Topology.Sheaves.Presheaf
 /-!
 # Presheaves of functions

--- a/Mathlib/Topology/Sheaves/SheafCondition/PairwiseIntersections.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/PairwiseIntersections.lean
@@ -7,7 +7,6 @@ import Mathlib.CategoryTheory.Category.Pairwise
 import Mathlib.CategoryTheory.Limits.Constructions.BinaryProducts
 import Mathlib.CategoryTheory.Limits.Final
 import Mathlib.CategoryTheory.Limits.Preserves.Basic
-import Mathlib.Order.OmegaCompletePartialOrder
 import Mathlib.Topology.Sheaves.SheafCondition.OpensLeCover
 
 /-!


### PR DESCRIPTION
Linter doesn't catch them,
because files that import it use instances from this file,
but there are other paths in many cases.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
