### PR TITLE
feat(Computability): define oracle computability and Turing degrees

### DIFF
--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -18,11 +18,11 @@ quotient under this relation.
 ## Main Definitions
 
 - `RecursiveIn g f`:
-An inductive definition representing that a partial function `f` is recursive in oracle `g`.
+  An inductive definition representing that a partial function `f` is recursive in oracle `g`.
 - `turing_reducible`: A relation defining Turing reducibility between partial functions.
 - `turing_equivalent`: A relation defining Turing equivalence between partial functions.
 - `TuringDegree`:
-The type of Turing degrees, defined as equivalence classes under `turing_equivalent`.
+  The type of Turing degrees, defined as equivalence classes under `turing_equivalent`.
 
 ## Notation
 
@@ -41,10 +41,11 @@ numbers to the respective functions.
 ## References
 
 * [Carneiro2018] Carneiro, Mario.
-*Formalizing Computability Theory via Partial Recursive Functions*.
-arXiv preprint arXiv:1810.08380, 2018.
+ *Formalizing Computability Theory via Partial Recursive Functions*.
+ arXiv preprint arXiv:1810.08380, 2018.
 * [Odifreddi1989] Odifreddi, Piergiorgio.
-*Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers, Vol. I*. 1989.
+ *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers,
+ Vol. I*. Springer-Verlag, 1989.
 * [Soare1987] Soare, Robert I. *Recursively Enumerable Sets and Degrees*. Springer-Verlag, 1987.
 * [Gu2015] Gu, Yi-Zhi. *Turing Degrees*. Institute for Advanced Study, 2015.
 
@@ -86,7 +87,7 @@ inductive RecursiveIn (g : ℕ →. ℕ) : (ℕ →. ℕ) → Prop
 def turing_reducible (f g : ℕ →. ℕ) : Prop :=
   RecursiveIn g f
 /--
-custom infix notation for `turing_reducible`
+Custom infix notation for `turing_reducible`.
 -/
 infix:50 " ≤ᵀ " => turing_reducible
 
@@ -96,7 +97,7 @@ infix:50 " ≤ᵀ " => turing_reducible
 def turing_equivalent (f g : ℕ →. ℕ) : Prop :=
   f ≤ᵀ g ∧ g ≤ᵀ f
 /--
-custom infix notation for `turing_equivalent`
+Custom infix notation for `turing_equivalent`.
 -/
 infix:50 " ≡ᵀ " => turing_equivalent
 
@@ -105,7 +106,7 @@ A partial function `f` is partial recursive if and only if
 it is recursive in the constant zero function.
 -/
 lemma partrec_iff_partrec_in_zero
-(f : ℕ →. ℕ) : Nat.Partrec f ↔ RecursiveIn (fun _ => pure 0) f := by
+  (f : ℕ →. ℕ) : Nat.Partrec f ↔ RecursiveIn (fun _ => pure 0) f := by
   constructor
   { intro pF
     induction' pF
@@ -146,12 +147,12 @@ lemma partrec_iff_partrec_in_zero
     case mpr.rfind _ _ ih =>
       apply Nat.Partrec.rfind ih }
 
-/--
+ /--
 A partial function `f` is partial recursive if and only if it is recursive in
 every partial function `g`.
 -/
 theorem partrec_iff_partrec_in_everything
-(f : ℕ →. ℕ) : Nat.Partrec f ↔ (∀ g, RecursiveIn g f) := by
+  (f : ℕ →. ℕ) : Nat.Partrec f ↔ (∀ g, RecursiveIn g f) := by
   constructor
   { intro pF
     intro g
@@ -177,43 +178,25 @@ theorem partrec_iff_partrec_in_everything
     rw [← partrec_iff_partrec_in_zero] at lem
     exact lem }
 
-/--
+ /--
 Proof that `turing_reducible` is reflexive.
 -/
 theorem turing_reducible_refl (f : ℕ →. ℕ) : f ≤ᵀ f :=
   RecursiveIn.oracle
 
-/--
-Instance declaring that `turing_reducible` is reflexive.
--/
-instance : Reflexive turing_reducible :=
-  fun f => turing_reducible_refl f
-
-/--
+ /--
 Proof that `turing_equivalent` is reflexive.
 -/
 theorem turing_equivalent_refl (f : ℕ →. ℕ) : f ≡ᵀ f :=
   ⟨turing_reducible_refl f, turing_reducible_refl f⟩
 
-/--
-Instance declaring that `turing_equivalent` is reflexive.
--/
-instance : Reflexive turing_equivalent :=
-  fun f => turing_equivalent_refl f
-
-/--
+ /--
 Proof that `turing_equivalent` is symmetric.
 -/
 theorem turing_equivalent_symm {f g : ℕ →. ℕ} (h : f ≡ᵀ g) : g ≡ᵀ f :=
   ⟨h.2, h.1⟩
 
-/--
-Instance declaring that `turing_equivalent` is symmetric.
--/
-instance : Symmetric turing_equivalent :=
-  fun _ _ h => turing_equivalent_symm h
-
-/--
+ /--
 Proof that `turing_reducible` is transitive.
 -/
 theorem turing_reducible_trans {f g h : ℕ →. ℕ} :
@@ -246,7 +229,7 @@ theorem turing_reducible_trans {f g h : ℕ →. ℕ} :
     apply RecursiveIn.rfind
     { apply hf_ih }
 
-/--
+ /--
 Proof that `turing_equivalent` is transitive.
 -/
 theorem turing_equivalent_trans :
@@ -254,7 +237,7 @@ theorem turing_equivalent_trans :
   fun _ _ _ ⟨fg₁, fg₂⟩ ⟨gh₁, gh₂⟩ =>
     ⟨turing_reducible_trans fg₁ gh₁, turing_reducible_trans gh₂ fg₂⟩
 
-/--
+ /--
 Instance declaring that `turing_equivalent` is an equivalence relation.
 -/
 instance : Equivalence turing_equivalent :=
@@ -273,7 +256,7 @@ def TuringDegree :=
 /--
 The `join` function combines two partial functions `f` and `g` into a single partial function.
 It maps even numbers to the result of `f` applied to half the number,
- and odd numbers to the result of `g` applied to half the number.
+and odd numbers to the result of `g` applied to half the number.
 -/
 def join (f g : ℕ →. ℕ) : ℕ →. ℕ :=
   fun n =>
@@ -284,3 +267,5 @@ def join (f g : ℕ →. ℕ) : ℕ →. ℕ :=
 
 /-- Join notation `f ⊔ g` is the "join" of partial functions `f` and `g`. -/
 infix:99 "⊔" => join
+
+#lint

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -180,7 +180,7 @@ theorem partrec_iff_partrec_in_everything
 /--
 Proof that turing reducibility is reflexive.
 -/
-theorem recursive_in_refl (f : ℕ →. ℕ) : RecursiveIn f f :=
+theorem RecursiveIn.refl (f : ℕ →. ℕ) : RecursiveIn f f :=
   RecursiveIn.oracle
 
 /--

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -88,13 +88,13 @@ inductive RecursiveIn : (ℕ →. ℕ) → (ℕ →. ℕ) → Prop
 /--
 `f` is Turing equivalent to `g` if `f` is reducible to `g` and `g` is reducible to `f`.
 -/
-def turing_equivalent (f g : ℕ →. ℕ) : Prop :=
+def TuringEquivalent (f g : ℕ →. ℕ) : Prop :=
   AntisymmRel RecursiveIn f g
 
 /--
 Custom infix notation for `turing_equivalent`.
 -/
-infix:50 " ≡ᵀ " => turing_equivalent
+infix:50 " ≡ᵀ " => TuringEquivalent
 
 /--
 If a function is partial recursive, then it is recursive in every partial function.
@@ -187,21 +187,21 @@ theorem RecursiveIn.refl (f : ℕ →. ℕ) : RecursiveIn f f :=
 Proof that `turing_equivalent` is reflexive.
 -/
 @[refl]
-theorem turing_equivalent_refl (f : ℕ →. ℕ) : f ≡ᵀ f :=
-  ⟨recursive_in_refl f, recursive_in_refl f⟩
+theorem TuringEquivalent.refl (f : ℕ →. ℕ) : f ≡ᵀ f :=
+  ⟨RecursiveIn.refl f, RecursiveIn.refl f⟩
 
 /--
 Proof that `turing_equivalent` is symmetric.
 -/
 @[symm]
-theorem turing_equivalent_symm {f g : ℕ →. ℕ} (h : f ≡ᵀ g) : g ≡ᵀ f :=
+theorem TuringEquivalent.symm {f g : ℕ →. ℕ} (h : f ≡ᵀ g) : g ≡ᵀ f :=
   ⟨h.2, h.1⟩
 
 /--
 Proof that turing reducibility is transitive.
 -/
 @[trans]
-theorem recursive_in_trans {f g h : ℕ →. ℕ} :
+theorem RecursiveIn.trans {f g h : ℕ →. ℕ} :
   RecursiveIn f g → RecursiveIn g h → RecursiveIn f h := by
     intro hg hh
     induction hg
@@ -241,27 +241,27 @@ theorem recursive_in_trans {f g h : ℕ →. ℕ} :
 /--
 Proof that `turing_equivalent` is transitive.
 -/
-theorem turing_equivalent_trans :
-  Transitive turing_equivalent :=
+theorem TuringEquivalent.trans :
+  Transitive TuringEquivalent :=
   fun _ _ _ ⟨fg₁, fg₂⟩ ⟨gh₁, gh₂⟩ =>
-    ⟨recursive_in_trans fg₁ gh₁, recursive_in_trans gh₂ fg₂⟩
+    ⟨RecursiveIn.trans fg₁ gh₁, RecursiveIn.trans gh₂ fg₂⟩
 
 /--
 Instance declaring that `turing_equivalent` is an equivalence relation.
 -/
-instance : Equivalence turing_equivalent :=
+instance : Equivalence TuringEquivalent :=
   {
-    refl := turing_equivalent_refl,
-    symm := turing_equivalent_symm,
-    trans := @turing_equivalent_trans
+    refl := TuringEquivalent.refl,
+    symm := TuringEquivalent.symm,
+    trans := @TuringEquivalent.trans
   }
 
 /--
 Instance declaring that `RecursiveIn` is a preorder.
 -/
 instance : IsPreorder (ℕ →. ℕ) RecursiveIn where
-  refl := recursive_in_refl
-  trans := @recursive_in_trans
+  refl := RecursiveIn.refl
+  trans := @RecursiveIn.trans
 
 /--
 The Turing degrees as the set of equivalence classes under Turing equivalence.
@@ -300,9 +300,9 @@ lemma reduce_lifts₁ : ∀ (a b₁ b₂ : ℕ →. ℕ), b₁≡ᵀb₂ → (Re
   apply propext
   constructor
   · intro aRedb₁
-    apply recursive_in_trans aRedb₁ bEqb.1
+    apply RecursiveIn.trans aRedb₁ bEqb.1
   · intro aRedb₂
-    apply recursive_in_trans aRedb₂ bEqb.2
+    apply RecursiveIn.trans aRedb₂ bEqb.2
 
 /--
 For any partial functions `f`, `g`, and `h`, if `f` is Turing equivalent to `g`,
@@ -314,17 +314,17 @@ f ≡ᵀ g → (RecursiveIn f h = RecursiveIn g h) := by
   apply propext
   constructor
   · intro fRedh
-    apply recursive_in_trans fEqg.2 fRedh
+    apply RecursiveIn.trans fEqg.2 fRedh
   · intro gRedh
-    apply recursive_in_trans fEqg.1 gRedh
+    apply RecursiveIn.trans fEqg.1 gRedh
 
 /--
 Here we show how to lift the Turing reducibility relation from
 partial functions to their Turing degrees, using the above lemmas.
 -/
 def TuringDegree.turing_red (d₁ d₂ : TuringDegree) : Prop :=
-  @Quot.lift₂ _ _ Prop (turing_equivalent)
-  (turing_equivalent) (RecursiveIn) (reduce_lifts₁) (reduce_lifts₂) d₁ d₂
+  @Quot.lift₂ _ _ Prop (TuringEquivalent)
+  (TuringEquivalent) (RecursiveIn) (reduce_lifts₁) (reduce_lifts₂) d₁ d₂
 
 /--
 Instance declaring that `TuringDegree.turing_red` is a partial order.
@@ -334,7 +334,7 @@ instance : PartialOrder TuringDegree where
   le_refl := by
     apply Quot.ind
     intro a
-    apply recursive_in_refl
+    apply RecursiveIn.refl
   le_trans := by
     apply Quot.ind
     intro a
@@ -342,7 +342,7 @@ instance : PartialOrder TuringDegree where
     intro b
     apply Quot.ind
     intro c
-    exact recursive_in_trans
+    exact RecursiveIn.trans
   le_antisymm := by
     apply Quot.ind
     intro a

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -164,20 +164,6 @@ lemma partrec_in_zero_implies_partrec
     rw [← h]
 
 /--
-A partial function `f` is partial recursive if and only if it is
-recursive in the constant zero function.
--/
-lemma partrec_iff_partrec_in_zero
-  (f : ℕ →. ℕ) : Nat.Partrec f ↔ RecursiveIn f (fun _ => Part.some 0) := by
-  constructor
-  · intro pF
-    apply partrec_implies_recursive_in_everything
-    assumption
-  · intro h
-    apply partrec_in_zero_implies_partrec
-    assumption
-
-/--
 A partial function `f` is partial recursive if and only if it is recursive in
 every partial function `g`.
 -/
@@ -187,7 +173,7 @@ theorem partrec_iff_partrec_in_everything
   · exact partrec_implies_recursive_in_everything f
   · intro H
     have lem : RecursiveIn f (fun _ => Part.some 0) := H (fun _ => Part.some 0)
-    rw [← partrec_iff_partrec_in_zero] at lem
+    have lem : Nat.Partrec f := partrec_in_zero_implies_partrec f lem
     exact lem
 
 /--

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -21,7 +21,7 @@ quotient under this relation.
   An inductive definition representing that a partial function `f` is recursive in oracle `g`.
 - `turing_equivalent`: A relation defining Turing equivalence between partial functions.
 - `TuringDegree`:
-  The type of Turing degrees, defined as equivalence classes under `turing_equivalent`.
+  The type of Turing degrees, defined as equivalence classes under `TuringEquivalent`.
 - `join`: Combines two partial functions into one by =
   mapping even and odd numbers to respective functions.
 

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -125,7 +125,7 @@ If a function is recursive in the constant zero function,
 then it is partial recursive.
 -/
 lemma RecursiveIn.partrec_of_zero (f : ℕ →. ℕ) (fRecInZero : RecursiveIn f fun _ => Part.some 0) :
-  Nat.Partrec f := by
+    Nat.Partrec f := by
   generalize h : (fun _ => Part.some 0) = fp at *
   induction fRecInZero
   case zero =>

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -1,0 +1,286 @@
+/-
+Copyright (c) 2024 Tanner Duve, Elan Roth
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve, Elan Roth
+-/
+import Mathlib.Computability.Primrec
+import Mathlib.Computability.Partrec
+import Mathlib.Computability.Reduce
+import Mathlib.Data.Part
+
+/-!
+# Oracle Computability and Turing Degrees
+
+This file defines a model of oracle computability, introduces Turing reducibility and equivalence,
+proves that Turing equivalence is an equivalence relation, and defines Turing degrees as the
+quotient under this relation.
+
+## Main Definitions
+
+- `RecursiveIn g f`:
+An inductive definition representing that a partial function `f` is recursive in oracle `g`.
+- `turing_reducible`: A relation defining Turing reducibility between partial functions.
+- `turing_equivalent`: A relation defining Turing equivalence between partial functions.
+- `TuringDegree`:
+The type of Turing degrees, defined as equivalence classes under `turing_equivalent`.
+
+## Notation
+
+- `f ≤ᵀ g` : `f` is Turing reducible to `g`.
+- `f ≡ᵀ g` : `f` is Turing equivalent to `g`.
+- `f ⊔ g` : The join of partial functions `f` and `g`.
+
+## Implementation Notes
+
+The type of partial functions recursive in an oracle `g` is the smallest type containing
+the constant zero, the successor, projections, the oracle `g`, and is closed under
+pairing, composition, primitive recursion, and μ-recursion. The `join` operation
+combines two partial functions into a single partial function by mapping even and odd
+numbers to the respective functions.
+
+## References
+
+* [Carneiro2018] Carneiro, Mario.
+*Formalizing Computability Theory via Partial Recursive Functions*.
+arXiv preprint arXiv:1810.08380, 2018.
+* [Odifreddi1989] Odifreddi, Piergiorgio.
+*Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers, Vol. I*. 1989.
+* [Soare1987] Soare, Robert I. *Recursively Enumerable Sets and Degrees*. Springer-Verlag, 1987.
+* [Gu2015] Gu, Yi-Zhi. *Turing Degrees*. Institute for Advanced Study, 2015.
+
+## Tags
+
+Computability, Oracle, Turing Degrees, Reducibility, Equivalence Relation
+-/
+
+open Primrec Nat.Partrec
+
+/--
+The type of partial functions recursive in an oracle `g` is the smallest type containing
+the constant zero, the successor, left and right projections, the oracle `g`, and is closed under
+pairing, composition, primitive recursion, and μ-recursion.
+-/
+inductive RecursiveIn (g : ℕ →. ℕ) : (ℕ →. ℕ) → Prop
+  | zero : RecursiveIn g (fun _ => 0)
+  | succ : RecursiveIn g Nat.succ
+  | left : RecursiveIn g (fun n => (Nat.unpair n).1)
+  | right : RecursiveIn g (fun n => (Nat.unpair n).2)
+  | oracle : RecursiveIn g g
+  | pair {f h : ℕ →. ℕ} (hf : RecursiveIn g f) (hh : RecursiveIn g h) :
+      RecursiveIn g (fun n => (Nat.pair <$> f n <*> h n))
+  | comp {f h : ℕ →. ℕ} (hf : RecursiveIn g f) (hh : RecursiveIn g h) :
+      RecursiveIn g (fun n => h n >>= f)
+  | prec {f h : ℕ →. ℕ} (hf : RecursiveIn g f) (hh : RecursiveIn g h) :
+      RecursiveIn g (fun p =>
+        let (a, n) := Nat.unpair p
+        n.rec (f a) (fun y ih => do
+          let i ← ih
+          h (Nat.pair a (Nat.pair y i))))
+  | rfind {f : ℕ →. ℕ} (hf : RecursiveIn g f) :
+      RecursiveIn g (fun a =>
+        Nat.rfind (fun n => (fun m => m = 0) <$> f (Nat.pair a n)))
+
+/--
+`f` is Turing reducible to `g` if `f` is recursive in `g`.
+-/
+def turing_reducible (f g : ℕ →. ℕ) : Prop :=
+  RecursiveIn g f
+/--
+custom infix notation for `turing_reducible`
+-/
+infix:50 " ≤ᵀ " => turing_reducible
+
+/--
+`f` is Turing equivalent to `g` if `f` is reducible to `g` and `g` is reducible to `f`.
+-/
+def turing_equivalent (f g : ℕ →. ℕ) : Prop :=
+  f ≤ᵀ g ∧ g ≤ᵀ f
+/--
+custom infix notation for `turing_equivalent`
+-/
+infix:50 " ≡ᵀ " => turing_equivalent
+
+/--
+A partial function `f` is partial recursive if and only if
+it is recursive in the constant zero function.
+-/
+lemma partrec_iff_partrec_in_zero
+(f : ℕ →. ℕ) : Nat.Partrec f ↔ RecursiveIn (fun _ => pure 0) f := by
+  constructor
+  { intro pF
+    induction' pF
+    case mp.zero =>
+      apply RecursiveIn.zero
+    case mp.succ =>
+      apply RecursiveIn.succ
+    case mp.left =>
+      apply RecursiveIn.left
+    case mp.right =>
+      apply RecursiveIn.right
+    case mp.pair _ _ _ _ ih1 ih2 =>
+      apply RecursiveIn.pair ih1 ih2
+    case mp.comp _ _ _ _ ih1 ih2 =>
+      apply RecursiveIn.comp ih1 ih2
+    case mp.prec _ _ _ _ ih1 ih2 =>
+      apply RecursiveIn.prec ih1 ih2
+    case mp.rfind _ _ ih =>
+      apply RecursiveIn.rfind ih }
+  { intro fRecInNone
+    induction' fRecInNone
+    case mpr.zero =>
+      apply Nat.Partrec.zero
+    case mpr.succ =>
+      apply Nat.Partrec.succ
+    case mpr.left =>
+      apply Nat.Partrec.left
+    case mpr.right =>
+      apply Nat.Partrec.right
+    case mpr.oracle =>
+      apply Nat.Partrec.zero
+    case mpr.pair _ _ _ _ ih1 ih2 =>
+      apply Nat.Partrec.pair ih1 ih2
+    case mpr.comp _ _ _ _ ih1 ih2 =>
+      apply Nat.Partrec.comp ih1 ih2
+    case mpr.prec _ _ _ _ ih1 ih2 =>
+      apply Nat.Partrec.prec ih1 ih2
+    case mpr.rfind _ _ ih =>
+      apply Nat.Partrec.rfind ih }
+
+/--
+A partial function `f` is partial recursive if and only if it is recursive in
+every partial function `g`.
+-/
+theorem partrec_iff_partrec_in_everything
+(f : ℕ →. ℕ) : Nat.Partrec f ↔ (∀ g, RecursiveIn g f) := by
+  constructor
+  { intro pF
+    intro g
+    induction pF
+    case zero =>
+      apply RecursiveIn.zero
+    case succ =>
+      apply RecursiveIn.succ
+    case left =>
+      apply RecursiveIn.left
+    case right =>
+      apply RecursiveIn.right
+    case pair _ _ _ _ ih1 ih2 =>
+      apply RecursiveIn.pair ih1 ih2
+    case comp _ _ _ _ ih1 ih2 =>
+      apply RecursiveIn.comp ih1 ih2
+    case prec _ _ _ _ ih1 ih2 =>
+      apply RecursiveIn.prec ih1 ih2
+    case rfind _ _ ih =>
+      apply RecursiveIn.rfind ih }
+  { intro H
+    have lem : RecursiveIn (fun _ => pure 0) f := H (fun _ => pure 0)
+    rw [← partrec_iff_partrec_in_zero] at lem
+    exact lem }
+
+/--
+Proof that `turing_reducible` is reflexive.
+-/
+theorem turing_reducible_refl (f : ℕ →. ℕ) : f ≤ᵀ f :=
+  RecursiveIn.oracle
+
+/--
+Instance declaring that `turing_reducible` is reflexive.
+-/
+instance : Reflexive turing_reducible :=
+  fun f => turing_reducible_refl f
+
+/--
+Proof that `turing_equivalent` is reflexive.
+-/
+theorem turing_equivalent_refl (f : ℕ →. ℕ) : f ≡ᵀ f :=
+  ⟨turing_reducible_refl f, turing_reducible_refl f⟩
+
+/--
+Instance declaring that `turing_equivalent` is reflexive.
+-/
+instance : Reflexive turing_equivalent :=
+  fun f => turing_equivalent_refl f
+
+/--
+Proof that `turing_equivalent` is symmetric.
+-/
+theorem turing_equivalent_symm {f g : ℕ →. ℕ} (h : f ≡ᵀ g) : g ≡ᵀ f :=
+  ⟨h.2, h.1⟩
+
+/--
+Instance declaring that `turing_equivalent` is symmetric.
+-/
+instance : Symmetric turing_equivalent :=
+  fun _ _ h => turing_equivalent_symm h
+
+/--
+Proof that `turing_reducible` is transitive.
+-/
+theorem turing_reducible_trans {f g h : ℕ →. ℕ} :
+  f ≤ᵀ g → g ≤ᵀ h → f ≤ᵀ h := by
+  intro hg hh
+  induction hg
+  case zero =>
+    apply RecursiveIn.zero
+  case succ =>
+    apply RecursiveIn.succ
+  case left =>
+    apply RecursiveIn.left
+  case right =>
+    apply RecursiveIn.right
+  case oracle =>
+    exact hh
+  case pair f' h' _ _ hf_ih hh_ih =>
+    apply RecursiveIn.pair
+    { apply hf_ih }
+    { apply hh_ih }
+  case comp f' h' _ _ hf_ih hh_ih =>
+    apply RecursiveIn.comp
+    { apply hf_ih }
+    { apply hh_ih }
+  case prec f' h' _ _ hf_ih hh_ih =>
+    apply RecursiveIn.prec
+    { apply hf_ih }
+    { apply hh_ih }
+  case rfind f' _ hf_ih =>
+    apply RecursiveIn.rfind
+    { apply hf_ih }
+
+/--
+Proof that `turing_equivalent` is transitive.
+-/
+theorem turing_equivalent_trans :
+  Transitive turing_equivalent :=
+  fun _ _ _ ⟨fg₁, fg₂⟩ ⟨gh₁, gh₂⟩ =>
+    ⟨turing_reducible_trans fg₁ gh₁, turing_reducible_trans gh₂ fg₂⟩
+
+/--
+Instance declaring that `turing_equivalent` is an equivalence relation.
+-/
+instance : Equivalence turing_equivalent :=
+  {
+    refl := turing_equivalent_refl,
+    symm := turing_equivalent_symm,
+    trans := @turing_equivalent_trans
+  }
+
+/--
+The Turing degrees as the set of equivalence classes under Turing equivalence.
+-/
+def TuringDegree :=
+  Quot turing_equivalent
+
+/--
+The `join` function combines two partial functions `f` and `g` into a single partial function.
+It maps even numbers to the result of `f` applied to half the number,
+ and odd numbers to the result of `g` applied to half the number.
+-/
+def join (f g : ℕ →. ℕ) : ℕ →. ℕ :=
+  fun n =>
+    if n % 2 = 0 then
+      (f (n / 2)).map (fun x => 2 * x)
+    else
+      (g (n / 2)).map (fun y => 2 * y + 1)
+
+/-- Join notation `f ⊔ g` is the "join" of partial functions `f` and `g`. -/
+infix:99 "⊔" => join

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -255,7 +255,7 @@ theorem TuringEquivalent.trans :
   fun {_ _ _} h1 h2 => AntisymmRel.trans h1 h2
 
 /--
-Instance declaring that `turing_equivalent` is an equivalence relation.
+Instance declaring that `TuringEquivalent` is an equivalence relation.
 -/
 instance : Equivalence TuringEquivalent :=
   (AntisymmRel.setoid _ _).iseqv

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -27,7 +27,6 @@ quotient under this relation.
 
 ## Notation
 
-- `f ≤ᵀ g` : `f` is Turing reducible to `g`.
 - `f ≡ᵀ g` : `f` is Turing equivalent to `g`.
 - `f ⊕ g` : The join of partial functions `f` and `g`.
 
@@ -66,22 +65,22 @@ Equivalently one can say that `f` is turing reducible to `g` when `f` is recursi
 -/
 
 inductive RecursiveIn : (ℕ →. ℕ) → (ℕ →. ℕ) → Prop
-  | zero {g} : RecursiveIn (fun _ => 0) g
-  | succ {g} : RecursiveIn Nat.succ g
-  | left {g} : RecursiveIn (fun n => (Nat.unpair n).1) g
-  | right {g} : RecursiveIn (fun n => (Nat.unpair n).2) g
-  | oracle {g} : RecursiveIn g g
-  | pair {f h g : ℕ →. ℕ} (hf : RecursiveIn f g) (hh : RecursiveIn h g) :
+  | zero (g) : RecursiveIn (fun _ => 0) g
+  | succ (g) : RecursiveIn Nat.succ g
+  | left (g) : RecursiveIn (fun n => (Nat.unpair n).1) g
+  | right (g) : RecursiveIn (fun n => (Nat.unpair n).2) g
+  | oracle (g) : RecursiveIn g g
+  | pair (f h g : ℕ →. ℕ) (hf : RecursiveIn f g) (hh : RecursiveIn h g) :
       RecursiveIn (fun n => (Nat.pair <$> f n <*> h n)) g
-  | comp {f h g : ℕ →. ℕ} (hf : RecursiveIn f g) (hh : RecursiveIn h g) :
+  | comp (f h g : ℕ →. ℕ) (hf : RecursiveIn f g) (hh : RecursiveIn h g) :
       RecursiveIn (fun n => h n >>= f) g
-  | prec {f h g : ℕ →. ℕ} (hf : RecursiveIn f g) (hh : RecursiveIn h g) :
+  | prec (f h g : ℕ →. ℕ) (hf : RecursiveIn f g) (hh : RecursiveIn h g) :
       RecursiveIn (fun p =>
         let (a, n) := Nat.unpair p
         n.rec (f a) (fun y ih => do
           let i ← ih
           h (Nat.pair a (Nat.pair y i)))) g
-  | rfind {f g : ℕ →. ℕ} (hf : RecursiveIn f g) :
+  | rfind (f g : ℕ →. ℕ) (hf : RecursiveIn f g) :
       RecursiveIn (fun a =>
         Nat.rfind (fun n => (fun m => m = 0) <$> f (Nat.pair a n))) g
 
@@ -93,7 +92,7 @@ abbrev TuringEquivalent (f g : ℕ →. ℕ) : Prop :=
   AntisymmRel RecursiveIn f g
 
 /--
-Custom infix notation for `TuringEquivalent`.
+Custom infix notation for `turing_equivalent`.
 -/
 infix:50 " ≡ᵀ " => TuringEquivalent
 
@@ -125,7 +124,7 @@ If a function is recursive in the constant zero function,
 then it is partial recursive.
 -/
 lemma RecursiveIn.partrec_of_zero (f : ℕ →. ℕ) (fRecInZero : RecursiveIn f fun _ => Part.some 0) :
-    Nat.Partrec f := by
+  Nat.Partrec f := by
   generalize h : (fun _ => Part.some 0) = fp at *
   induction fRecInZero
   case zero =>
@@ -255,7 +254,7 @@ theorem TuringEquivalent.trans :
   fun {_ _ _} h1 h2 => AntisymmRel.trans h1 h2
 
 /--
-Instance declaring that `TuringEquivalent` is an equivalence relation.
+Instance declaring that `turing_equivalent` is an equivalence relation.
 -/
 instance : Equivalence TuringEquivalent :=
   (AntisymmRel.setoid _ _).iseqv

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -164,14 +164,8 @@ lemma RecursiveIn.partrec_of_zero (f : ℕ →. ℕ) (fRecInZero : RecursiveIn f
 A partial function `f` is partial recursive if and only if it is recursive in
 every partial function `g`.
 -/
-theorem partrec_iff_partrec_in_everything
-  (f : ℕ →. ℕ) : Nat.Partrec f ↔ (∀ g, RecursiveIn f g) := by
-  constructor
-  · exact partrec_implies_recursive_in_everything f
-  · intro H
-    have lem : RecursiveIn f (fun _ => Part.some 0) := H (fun _ => Part.some 0)
-    have lem : Nat.Partrec f := partrec_in_zero_implies_partrec f lem
-    exact lem
+theorem partrec_iff_partrec_in_everything (f : ℕ →. ℕ) : Nat.Partrec f ↔ ∀ g, RecursiveIn f g :=
+  ⟨(·.recursiveIn), (· _ |>.partrec_of_zero)⟩
 
 /--
 Proof that turing reducibility is reflexive.

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -23,6 +23,7 @@ quotient under this relation.
 - `turing_equivalent`: A relation defining Turing equivalence between partial functions.
 - `TuringDegree`:
   The type of Turing degrees, defined as equivalence classes under `turing_equivalent`.
+- `join`: Combines two partial functions into one by mapping even and odd numbers to respective functions.
 
 ## Notation
 
@@ -41,11 +42,11 @@ numbers to the respective functions.
 ## References
 
 * [Carneiro2018] Carneiro, Mario.
- *Formalizing Computability Theory via Partial Recursive Functions*.
- arXiv preprint arXiv:1810.08380, 2018.
+  *Formalizing Computability Theory via Partial Recursive Functions*.
+  arXiv preprint arXiv:1810.08380, 2018.
 * [Odifreddi1989] Odifreddi, Piergiorgio.
- *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers,
- Vol. I*. Springer-Verlag, 1989.
+  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers,
+  Vol. I*. Springer-Verlag, 1989.
 * [Soare1987] Soare, Robert I. *Recursively Enumerable Sets and Degrees*. Springer-Verlag, 1987.
 * [Gu2015] Gu, Yi-Zhi. *Turing Degrees*. Institute for Advanced Study, 2015.
 
@@ -86,6 +87,7 @@ inductive RecursiveIn (g : ℕ →. ℕ) : (ℕ →. ℕ) → Prop
 -/
 def turing_reducible (f g : ℕ →. ℕ) : Prop :=
   RecursiveIn g f
+
 /--
 Custom infix notation for `turing_reducible`.
 -/
@@ -96,6 +98,7 @@ infix:50 " ≤ᵀ " => turing_reducible
 -/
 def turing_equivalent (f g : ℕ →. ℕ) : Prop :=
   f ≤ᵀ g ∧ g ≤ᵀ f
+
 /--
 Custom infix notation for `turing_equivalent`.
 -/
@@ -147,7 +150,7 @@ lemma partrec_iff_partrec_in_zero
     case mpr.rfind _ _ ih =>
       apply Nat.Partrec.rfind ih }
 
- /--
+/--
 A partial function `f` is partial recursive if and only if it is recursive in
 every partial function `g`.
 -/
@@ -178,58 +181,58 @@ theorem partrec_iff_partrec_in_everything
     rw [← partrec_iff_partrec_in_zero] at lem
     exact lem }
 
- /--
+/--
 Proof that `turing_reducible` is reflexive.
 -/
 theorem turing_reducible_refl (f : ℕ →. ℕ) : f ≤ᵀ f :=
   RecursiveIn.oracle
 
- /--
+/--
 Proof that `turing_equivalent` is reflexive.
 -/
 theorem turing_equivalent_refl (f : ℕ →. ℕ) : f ≡ᵀ f :=
   ⟨turing_reducible_refl f, turing_reducible_refl f⟩
 
- /--
+/--
 Proof that `turing_equivalent` is symmetric.
 -/
 theorem turing_equivalent_symm {f g : ℕ →. ℕ} (h : f ≡ᵀ g) : g ≡ᵀ f :=
   ⟨h.2, h.1⟩
 
- /--
+/--
 Proof that `turing_reducible` is transitive.
 -/
 theorem turing_reducible_trans {f g h : ℕ →. ℕ} :
   f ≤ᵀ g → g ≤ᵀ h → f ≤ᵀ h := by
-  intro hg hh
-  induction hg
-  case zero =>
-    apply RecursiveIn.zero
-  case succ =>
-    apply RecursiveIn.succ
-  case left =>
-    apply RecursiveIn.left
-  case right =>
-    apply RecursiveIn.right
-  case oracle =>
-    exact hh
-  case pair f' h' _ _ hf_ih hh_ih =>
-    apply RecursiveIn.pair
-    { apply hf_ih }
-    { apply hh_ih }
-  case comp f' h' _ _ hf_ih hh_ih =>
-    apply RecursiveIn.comp
-    { apply hf_ih }
-    { apply hh_ih }
-  case prec f' h' _ _ hf_ih hh_ih =>
-    apply RecursiveIn.prec
-    { apply hf_ih }
-    { apply hh_ih }
-  case rfind f' _ hf_ih =>
-    apply RecursiveIn.rfind
-    { apply hf_ih }
+    intro hg hh
+    induction hg
+    case zero =>
+      apply RecursiveIn.zero
+    case succ =>
+      apply RecursiveIn.succ
+    case left =>
+      apply RecursiveIn.left
+    case right =>
+      apply RecursiveIn.right
+    case oracle =>
+      exact hh
+    case pair f' h' _ _ hf_ih hh_ih =>
+      apply RecursiveIn.pair
+      { apply hf_ih }
+      { apply hh_ih }
+    case comp f' h' _ _ hf_ih hh_ih =>
+      apply RecursiveIn.comp
+      { apply hf_ih }
+      { apply hh_ih }
+    case prec f' h' _ _ hf_ih hh_ih =>
+      apply RecursiveIn.prec
+      { apply hf_ih }
+      { apply hh_ih }
+    case rfind f' _ hf_ih =>
+      apply RecursiveIn.rfind
+      { apply hf_ih }
 
- /--
+/--
 Proof that `turing_equivalent` is transitive.
 -/
 theorem turing_equivalent_trans :
@@ -237,7 +240,7 @@ theorem turing_equivalent_trans :
   fun _ _ _ ⟨fg₁, fg₂⟩ ⟨gh₁, gh₂⟩ =>
     ⟨turing_reducible_trans fg₁ gh₁, turing_reducible_trans gh₂ fg₂⟩
 
- /--
+/--
 Instance declaring that `turing_equivalent` is an equivalence relation.
 -/
 instance : Equivalence turing_equivalent :=
@@ -268,4 +271,67 @@ def join (f g : ℕ →. ℕ) : ℕ →. ℕ :=
 /-- Join notation `f ⊔ g` is the "join" of partial functions `f` and `g`. -/
 infix:99 "⊔" => join
 
-#lint
+/--
+For any partial functions `a`, `b₁`, and `b₂`, if `b₁` is Turing equivalent to `b₂`,
+then `a` is Turing reducible to `b₁` if and only if `a` is Turing reducible to `b₂`.
+-/
+lemma reduce_lifts₁ : ∀ (a b₁ b₂ : ℕ →. ℕ), b₁≡ᵀb₂ → (a≤ᵀb₁) = (a≤ᵀb₂) := by
+  intros a b₁ b₂ bEqb
+  apply propext
+  constructor
+  · intro aRedb₁
+    apply turing_reducible_trans aRedb₁ bEqb.1
+  · intro aRedb₂
+    apply turing_reducible_trans aRedb₂ bEqb.2
+
+/--
+For any partial functions `f`, `g`, and `h`, if `f` is Turing equivalent to `g`,
+then `f` is Turing reducible to `h` if and only if `g` is Turing reducible to `h`.
+-/
+lemma reduce_lifts₂ : ∀ (f g h : ℕ →. ℕ),
+f ≡ᵀ g → (turing_reducible f h = turing_reducible g h) := by
+  intros f g h fEqg
+  apply propext
+  constructor
+  · intro fRedh
+    apply turing_reducible_trans fEqg.2 fRedh
+  · intro gRedh
+    apply turing_reducible_trans fEqg.1 gRedh
+
+/--
+Here we show how to lift the Turing reducibility relation from
+partial functions to theit Turing degrees, using the above lemmas.
+-/
+def TuringDegree.turing_red (d₁ d₂ : TuringDegree) : Prop :=
+  @Quot.lift₂ _ _ Prop (turing_equivalent)
+  (turing_equivalent) (turing_reducible) (reduce_lifts₁) (reduce_lifts₂) d₁ d₂
+
+/--
+Instance declaring that `TuringDegree.turing_red` is a partial order.
+-/
+instance : PartialOrder TuringDegree where
+  le := TuringDegree.turing_red
+  le_refl := by
+    apply Quot.ind
+    intro a
+    apply turing_reducible_refl
+  le_trans := by
+    apply Quot.ind
+    intro a
+    apply Quot.ind
+    intro b
+    apply Quot.ind
+    intro c
+    exact turing_reducible_trans
+  le_antisymm := by
+    apply Quot.ind
+    intro a
+    apply Quot.ind
+    intro b
+    intros aRedb bReda
+    apply Quot.sound
+    have aRedb' : a ≤ᵀ b := aRedb
+    have bReda' : b ≤ᵀ a := bReda
+    constructor
+    · exact aRedb'
+    · exact bReda'

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -56,7 +56,7 @@ numbers to the respective functions.
 Computability, Oracle, Turing Degrees, Reducibility, Equivalence Relation
 -/
 
-open Primrec Nat.Partrec
+open Primrec Nat.Partrec Part
 
 /--
 The type of partial functions `f` that are recursive in an oracle `g` is the smallest type
@@ -125,9 +125,9 @@ If a function is recursive in the constant zero function,
 then it is partial recursive.
 -/
 lemma partrec_in_zero_implies_partrec
-(f : ℕ →. ℕ) : RecursiveIn f (fun _ => pure 0) → Nat.Partrec f := by
+(f : ℕ →. ℕ) : RecursiveIn f (fun _ => Part.some 0) → Nat.Partrec f := by
   intro fRecInZero
-  generalize h : (fun _ => pure 0) = fp at *
+  generalize h : (fun _ => Part.some 0) = fp at *
   induction fRecInZero
   case zero =>
     apply Nat.Partrec.zero
@@ -137,19 +137,38 @@ lemma partrec_in_zero_implies_partrec
     apply Nat.Partrec.left
   case right =>
     apply Nat.Partrec.right
-  case oracle =>
+  case oracle g =>
+    rw [← h]
     apply Nat.Partrec.zero
   case pair _ _ _ _ ih1 ih2 =>
-    apply Nat.Partrec.pair ih1 ih2
+    apply Nat.Partrec.pair
+    · apply ih1
+      rw [← h]
+    · apply ih2
+      rw [← h]
   case comp _ _ _ _ ih1 ih2 =>
-    apply Nat.Partrec.comp ih1 ih2
+    apply Nat.Partrec.comp
+    · apply ih1
+      rw [← h]
+    · apply ih2
+      rw [← h]
   case prec _ _ _ _ ih1 ih2 =>
-    apply Nat.Partrec.prec ih1 ih2
+    apply Nat.Partrec.prec
+    · apply ih1
+      rw [← h]
+    · apply ih2
+      rw [← h]
   case rfind _ _ ih =>
-    apply Nat.Partrec.rfind ih
+    apply Nat.Partrec.rfind
+    apply ih
+    rw [← h]
 
+/--
+A partial function `f` is partial recursive if and only if it is
+recursive in the constant zero function.
+-/
 lemma partrec_iff_partrec_in_zero
-  (f : ℕ →. ℕ) : Nat.Partrec f ↔ RecursiveIn f (fun _ => pure 0) := by
+  (f : ℕ →. ℕ) : Nat.Partrec f ↔ RecursiveIn f (fun _ => Part.some 0) := by
   constructor
   · intro pF
     apply partrec_implies_recursive_in_everything
@@ -167,7 +186,7 @@ theorem partrec_iff_partrec_in_everything
   constructor
   · exact partrec_implies_recursive_in_everything f
   · intro H
-    have lem : RecursiveIn f (fun _ => pure 0) := H (fun _ => pure 0)
+    have lem : RecursiveIn f (fun _ => Part.some 0) := H (fun _ => Part.some 0)
     rw [← partrec_iff_partrec_in_zero] at lem
     exact lem
 

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -19,7 +19,6 @@ quotient under this relation.
 
 - `RecursiveIn g f`:
   An inductive definition representing that a partial function `f` is recursive in oracle `g`.
-- `turing_reducible`: A relation defining Turing reducibility between partial functions.
 - `turing_equivalent`: A relation defining Turing equivalence between partial functions.
 - `TuringDegree`:
   The type of Turing degrees, defined as equivalence classes under `turing_equivalent`.
@@ -62,6 +61,8 @@ open Primrec Nat.Partrec Part
 The type of partial functions `f` that are recursive in an oracle `g` is the smallest type
 containing the constant zero, the successor, left and right projections, the oracle `g`,
 and is closed under pairing, composition, primitive recursion, and μ-recursion.
+
+Equivalently one can say that `f` is turing reducible to `g` when `f` is recursive in `g`.
 -/
 inductive RecursiveIn : (ℕ →. ℕ) → (ℕ →. ℕ) → Prop
   | zero {g} : RecursiveIn (fun _ => 0) g
@@ -177,9 +178,9 @@ theorem partrec_iff_partrec_in_everything
     exact lem
 
 /--
-Proof that `turing_reducible` is reflexive.
+Proof that turing reducibility is reflexive.
 -/
-theorem turing_reducible_refl (f : ℕ →. ℕ) : RecursiveIn f f :=
+theorem recursive_in_refl (f : ℕ →. ℕ) : RecursiveIn f f :=
   RecursiveIn.oracle
 
 /--
@@ -187,7 +188,7 @@ Proof that `turing_equivalent` is reflexive.
 -/
 @[refl]
 theorem turing_equivalent_refl (f : ℕ →. ℕ) : f ≡ᵀ f :=
-  ⟨turing_reducible_refl f, turing_reducible_refl f⟩
+  ⟨recursive_in_refl f, recursive_in_refl f⟩
 
 /--
 Proof that `turing_equivalent` is symmetric.
@@ -197,10 +198,10 @@ theorem turing_equivalent_symm {f g : ℕ →. ℕ} (h : f ≡ᵀ g) : g ≡ᵀ 
   ⟨h.2, h.1⟩
 
 /--
-Proof that `turing_reducible` is transitive.
+Proof that turing reducibility is transitive.
 -/
 @[trans]
-theorem turing_reducible_trans {f g h : ℕ →. ℕ} :
+theorem recursive_in_trans {f g h : ℕ →. ℕ} :
   RecursiveIn f g → RecursiveIn g h → RecursiveIn f h := by
     intro hg hh
     induction hg
@@ -243,7 +244,7 @@ Proof that `turing_equivalent` is transitive.
 theorem turing_equivalent_trans :
   Transitive turing_equivalent :=
   fun _ _ _ ⟨fg₁, fg₂⟩ ⟨gh₁, gh₂⟩ =>
-    ⟨turing_reducible_trans fg₁ gh₁, turing_reducible_trans gh₂ fg₂⟩
+    ⟨recursive_in_trans fg₁ gh₁, recursive_in_trans gh₂ fg₂⟩
 
 /--
 Instance declaring that `turing_equivalent` is an equivalence relation.
@@ -259,8 +260,8 @@ instance : Equivalence turing_equivalent :=
 Instance declaring that `RecursiveIn` is a preorder.
 -/
 instance : IsPreorder (ℕ →. ℕ) RecursiveIn where
-  refl := turing_reducible_refl
-  trans := @turing_reducible_trans
+  refl := recursive_in_refl
+  trans := @recursive_in_trans
 
 /--
 The Turing degrees as the set of equivalence classes under Turing equivalence.
@@ -299,9 +300,9 @@ lemma reduce_lifts₁ : ∀ (a b₁ b₂ : ℕ →. ℕ), b₁≡ᵀb₂ → (Re
   apply propext
   constructor
   · intro aRedb₁
-    apply turing_reducible_trans aRedb₁ bEqb.1
+    apply recursive_in_trans aRedb₁ bEqb.1
   · intro aRedb₂
-    apply turing_reducible_trans aRedb₂ bEqb.2
+    apply recursive_in_trans aRedb₂ bEqb.2
 
 /--
 For any partial functions `f`, `g`, and `h`, if `f` is Turing equivalent to `g`,
@@ -313,9 +314,9 @@ f ≡ᵀ g → (RecursiveIn f h = RecursiveIn g h) := by
   apply propext
   constructor
   · intro fRedh
-    apply turing_reducible_trans fEqg.2 fRedh
+    apply recursive_in_trans fEqg.2 fRedh
   · intro gRedh
-    apply turing_reducible_trans fEqg.1 gRedh
+    apply recursive_in_trans fEqg.1 gRedh
 
 /--
 Here we show how to lift the Turing reducibility relation from
@@ -333,7 +334,7 @@ instance : PartialOrder TuringDegree where
   le_refl := by
     apply Quot.ind
     intro a
-    apply turing_reducible_refl
+    apply recursive_in_refl
   le_trans := by
     apply Quot.ind
     intro a
@@ -341,7 +342,7 @@ instance : PartialOrder TuringDegree where
     intro b
     apply Quot.ind
     intro c
-    exact turing_reducible_trans
+    exact recursive_in_trans
   le_antisymm := by
     apply Quot.ind
     intro a

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -19,7 +19,7 @@ quotient under this relation.
 
 - `RecursiveIn g f`:
   An inductive definition representing that a partial function `f` is recursive in oracle `g`.
-- `turing_equivalent`: A relation defining Turing equivalence between partial functions.
+- `TuringEquivalent`: A relation defining Turing equivalence between partial functions.
 - `TuringDegree`:
   The type of Turing degrees, defined as equivalence classes under `TuringEquivalent`.
 - `join`: Combines two partial functions into one by =

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -99,10 +99,7 @@ infix:50 " ≡ᵀ " => TuringEquivalent
 /--
 If a function is partial recursive, then it is recursive in every partial function.
 -/
-lemma partrec_implies_recursive_in_everything
-  (f : ℕ →. ℕ) : Nat.Partrec f → (∀ g, RecursiveIn f g) := by
-    intro pF
-    intro g
+lemma Nat.Partrec.recursiveIn (f : ℕ →. ℕ) (pF : Nat.Partrec f) (g : ℕ →. ℕ) : RecursiveIn f g := by
     induction pF
     case zero =>
       apply RecursiveIn.zero

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Tanner Duve, Elan Roth
+Copyright (c) 2024 Tanner Duve. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tanner Duve, Elan Roth
 -/
@@ -7,7 +7,7 @@ import Mathlib.Computability.Primrec
 import Mathlib.Computability.Partrec
 import Mathlib.Computability.Reduce
 import Mathlib.Data.Part
-
+import Mathlib.Order.Antisymmetrization
 /-!
 # Oracle Computability and Turing Degrees
 
@@ -23,13 +23,14 @@ quotient under this relation.
 - `turing_equivalent`: A relation defining Turing equivalence between partial functions.
 - `TuringDegree`:
   The type of Turing degrees, defined as equivalence classes under `turing_equivalent`.
-- `join`: Combines two partial functions into one by mapping even and odd numbers to respective functions.
+- `join`: Combines two partial functions into one by =
+  mapping even and odd numbers to respective functions.
 
 ## Notation
 
 - `f ≤ᵀ g` : `f` is Turing reducible to `g`.
 - `f ≡ᵀ g` : `f` is Turing equivalent to `g`.
-- `f ⊔ g` : The join of partial functions `f` and `g`.
+- `f ⊕ g` : The join of partial functions `f` and `g`.
 
 ## Implementation Notes
 
@@ -83,7 +84,8 @@ inductive RecursiveIn (g : ℕ →. ℕ) : (ℕ →. ℕ) → Prop
         Nat.rfind (fun n => (fun m => m = 0) <$> f (Nat.pair a n)))
 
 /--
-`f` is Turing reducible to `g` if `f` is recursive in `g`.
+`f` is Turing reducible to `g` if `f` is recursive in `g`. This is a more convenient shorthand
+for `RecursiveIn g f`.
 -/
 def turing_reducible (f g : ℕ →. ℕ) : Prop :=
   RecursiveIn g f
@@ -97,7 +99,7 @@ infix:50 " ≤ᵀ " => turing_reducible
 `f` is Turing equivalent to `g` if `f` is reducible to `g` and `g` is reducible to `f`.
 -/
 def turing_equivalent (f g : ℕ →. ℕ) : Prop :=
-  f ≤ᵀ g ∧ g ≤ᵀ f
+  AntisymmRel turing_reducible f g
 
 /--
 Custom infix notation for `turing_equivalent`.
@@ -105,59 +107,11 @@ Custom infix notation for `turing_equivalent`.
 infix:50 " ≡ᵀ " => turing_equivalent
 
 /--
-A partial function `f` is partial recursive if and only if
-it is recursive in the constant zero function.
+If a function is partial recursive, then it is recursive in every partial function.
 -/
-lemma partrec_iff_partrec_in_zero
-  (f : ℕ →. ℕ) : Nat.Partrec f ↔ RecursiveIn (fun _ => pure 0) f := by
-  constructor
-  { intro pF
-    induction' pF
-    case mp.zero =>
-      apply RecursiveIn.zero
-    case mp.succ =>
-      apply RecursiveIn.succ
-    case mp.left =>
-      apply RecursiveIn.left
-    case mp.right =>
-      apply RecursiveIn.right
-    case mp.pair _ _ _ _ ih1 ih2 =>
-      apply RecursiveIn.pair ih1 ih2
-    case mp.comp _ _ _ _ ih1 ih2 =>
-      apply RecursiveIn.comp ih1 ih2
-    case mp.prec _ _ _ _ ih1 ih2 =>
-      apply RecursiveIn.prec ih1 ih2
-    case mp.rfind _ _ ih =>
-      apply RecursiveIn.rfind ih }
-  { intro fRecInNone
-    induction' fRecInNone
-    case mpr.zero =>
-      apply Nat.Partrec.zero
-    case mpr.succ =>
-      apply Nat.Partrec.succ
-    case mpr.left =>
-      apply Nat.Partrec.left
-    case mpr.right =>
-      apply Nat.Partrec.right
-    case mpr.oracle =>
-      apply Nat.Partrec.zero
-    case mpr.pair _ _ _ _ ih1 ih2 =>
-      apply Nat.Partrec.pair ih1 ih2
-    case mpr.comp _ _ _ _ ih1 ih2 =>
-      apply Nat.Partrec.comp ih1 ih2
-    case mpr.prec _ _ _ _ ih1 ih2 =>
-      apply Nat.Partrec.prec ih1 ih2
-    case mpr.rfind _ _ ih =>
-      apply Nat.Partrec.rfind ih }
-
-/--
-A partial function `f` is partial recursive if and only if it is recursive in
-every partial function `g`.
--/
-theorem partrec_iff_partrec_in_everything
-  (f : ℕ →. ℕ) : Nat.Partrec f ↔ (∀ g, RecursiveIn g f) := by
-  constructor
-  { intro pF
+lemma partrec_implies_recursive_in_everything
+  (f : ℕ →. ℕ) : Nat.Partrec f → (∀ g, RecursiveIn g f) := by
+    intro pF
     intro g
     induction pF
     case zero =>
@@ -175,11 +129,69 @@ theorem partrec_iff_partrec_in_everything
     case prec _ _ _ _ ih1 ih2 =>
       apply RecursiveIn.prec ih1 ih2
     case rfind _ _ ih =>
-      apply RecursiveIn.rfind ih }
-  { intro H
+      apply RecursiveIn.rfind ih
+
+/--
+If a function is recursive in the constant zero function,
+then it is partial recursive.
+-/
+lemma partrec_in_zero_implies_partrec
+(f : ℕ →. ℕ) : RecursiveIn (fun _ => pure 0) f → Nat.Partrec f := by
+  intro fRecInZero
+  induction fRecInZero
+  case zero =>
+    apply Nat.Partrec.zero
+  case succ =>
+    apply Nat.Partrec.succ
+  case left =>
+    apply Nat.Partrec.left
+  case right =>
+    apply Nat.Partrec.right
+  case oracle =>
+    apply Nat.Partrec.zero
+  case pair _ _ _ _ ih1 ih2 =>
+    apply Nat.Partrec.pair ih1 ih2
+  case comp _ _ _ _ ih1 ih2 =>
+    apply Nat.Partrec.comp ih1 ih2
+  case prec _ _ _ _ ih1 ih2 =>
+    apply Nat.Partrec.prec ih1 ih2
+  case rfind _ _ ih =>
+    apply Nat.Partrec.rfind ih
+
+lemma partrec_iff_partrec_in_zero
+  (f : ℕ →. ℕ) : Nat.Partrec f ↔ RecursiveIn (fun _ => pure 0) f := by
+  constructor
+  · intro pF
+    apply partrec_implies_recursive_in_everything
+    assumption
+  · intro h
+    apply partrec_in_zero_implies_partrec
+    assumption
+
+/-
+Alternative definition of partial recursive using the above lemma.
+-/
+def Partrec₀ (f : ℕ →. ℕ) : Prop :=
+  RecursiveIn (fun _ => pure 0) f
+
+/--
+A partial function `f` is partial recursive if and only if it is recursive in
+every partial function `g`.
+-/
+theorem partrec_iff_partrec_in_everything
+  (f : ℕ →. ℕ) : Nat.Partrec f ↔ (∀ g, RecursiveIn g f) := by
+  constructor
+  · exact partrec_implies_recursive_in_everything f
+  · intro H
     have lem : RecursiveIn (fun _ => pure 0) f := H (fun _ => pure 0)
     rw [← partrec_iff_partrec_in_zero] at lem
-    exact lem }
+    exact lem
+
+/--
+ Alternative definition of partial recursive using the above lemma.
+-/
+def Partrec₁ (f : ℕ →. ℕ) : Prop :=
+  ∀ g, RecursiveIn g f
 
 /--
 Proof that `turing_reducible` is reflexive.
@@ -190,18 +202,21 @@ theorem turing_reducible_refl (f : ℕ →. ℕ) : f ≤ᵀ f :=
 /--
 Proof that `turing_equivalent` is reflexive.
 -/
+@[refl]
 theorem turing_equivalent_refl (f : ℕ →. ℕ) : f ≡ᵀ f :=
   ⟨turing_reducible_refl f, turing_reducible_refl f⟩
 
 /--
 Proof that `turing_equivalent` is symmetric.
 -/
+@[symm]
 theorem turing_equivalent_symm {f g : ℕ →. ℕ} (h : f ≡ᵀ g) : g ≡ᵀ f :=
   ⟨h.2, h.1⟩
 
 /--
 Proof that `turing_reducible` is transitive.
 -/
+@[trans]
 theorem turing_reducible_trans {f g h : ℕ →. ℕ} :
   f ≤ᵀ g → g ≤ᵀ h → f ≤ᵀ h := by
     intro hg hh
@@ -218,19 +233,19 @@ theorem turing_reducible_trans {f g h : ℕ →. ℕ} :
       exact hh
     case pair f' h' _ _ hf_ih hh_ih =>
       apply RecursiveIn.pair
-      { apply hf_ih }
-      { apply hh_ih }
+      · apply hf_ih
+      · apply hh_ih
     case comp f' h' _ _ hf_ih hh_ih =>
       apply RecursiveIn.comp
-      { apply hf_ih }
-      { apply hh_ih }
+      · apply hf_ih
+      · apply hh_ih
     case prec f' h' _ _ hf_ih hh_ih =>
       apply RecursiveIn.prec
-      { apply hf_ih }
-      { apply hh_ih }
+      · apply hf_ih
+      · apply hh_ih
     case rfind f' _ hf_ih =>
       apply RecursiveIn.rfind
-      { apply hf_ih }
+      · apply hf_ih
 
 /--
 Proof that `turing_equivalent` is transitive.
@@ -251,15 +266,29 @@ instance : Equivalence turing_equivalent :=
   }
 
 /--
+Instance declaring that `RecursiveIn` is a preorder.
+-/
+instance : IsPreorder (ℕ →. ℕ) turing_reducible where
+  refl := turing_reducible_refl
+  trans := @turing_reducible_trans
+
+/--
 The Turing degrees as the set of equivalence classes under Turing equivalence.
 -/
 def TuringDegree :=
-  Quot turing_equivalent
+  Antisymmetrization _ turing_reducible
 
 /--
 The `join` function combines two partial functions `f` and `g` into a single partial function.
-It maps even numbers to the result of `f` applied to half the number,
-and odd numbers to the result of `g` applied to half the number.
+For a given input `n`:
+
+- **If `n` is even**:
+  - It checks if `f` is defined at `n / 2`.
+  - If so, `join f g` is defined at `n` with the value `2 * f(n / 2)`.
+
+- **If `n` is odd**:
+  - It checks if `g` is defined at `n / 2`.
+  - If so, `join f g` is defined at `n` with the value `2 * g(n / 2) + 1`.
 -/
 def join (f g : ℕ →. ℕ) : ℕ →. ℕ :=
   fun n =>
@@ -268,8 +297,8 @@ def join (f g : ℕ →. ℕ) : ℕ →. ℕ :=
     else
       (g (n / 2)).map (fun y => 2 * y + 1)
 
-/-- Join notation `f ⊔ g` is the "join" of partial functions `f` and `g`. -/
-infix:99 "⊔" => join
+/-- Join notation `f ⊕ g` is the "join" of partial functions `f` and `g`. -/
+infix:99 "⊕" => join
 
 /--
 For any partial functions `a`, `b₁`, and `b₂`, if `b₁` is Turing equivalent to `b₂`,
@@ -300,7 +329,7 @@ f ≡ᵀ g → (turing_reducible f h = turing_reducible g h) := by
 
 /--
 Here we show how to lift the Turing reducibility relation from
-partial functions to theit Turing degrees, using the above lemmas.
+partial functions to their Turing degrees, using the above lemmas.
 -/
 def TuringDegree.turing_red (d₁ d₂ : TuringDegree) : Prop :=
   @Quot.lift₂ _ _ Prop (turing_equivalent)

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -93,7 +93,7 @@ abbrev TuringEquivalent (f g : ℕ →. ℕ) : Prop :=
   AntisymmRel RecursiveIn f g
 
 /--
-Custom infix notation for `turing_equivalent`.
+Custom infix notation for `TuringEquivalent`.
 -/
 infix:50 " ≡ᵀ " => TuringEquivalent
 

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -191,9 +191,8 @@ theorem TuringEquivalent.symm {f g : ℕ →. ℕ} (h : f ≡ᵀ g) : g ≡ᵀ f
 Proof that turing reducibility is transitive.
 -/
 @[trans]
-theorem RecursiveIn.trans {f g h : ℕ →. ℕ} :
-  RecursiveIn f g → RecursiveIn g h → RecursiveIn f h := by
-    intro hg hh
+theorem RecursiveIn.trans {f g h : ℕ →. ℕ} (hg : RecursiveIn f g) (hh : RecursiveIn g h) :
+    RecursiveIn f h := by
     induction hg
     case zero =>
       apply RecursiveIn.zero

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -102,31 +102,30 @@ If a function is partial recursive, then it is recursive in every partial functi
 -/
 
 lemma Nat.Partrec.recursiveIn (f : ℕ →. ℕ) (pF : Nat.Partrec f) (g : ℕ →. ℕ) : RecursiveIn f g := by
-    induction pF
-    case zero =>
-      apply RecursiveIn.zero
-    case succ =>
-      apply RecursiveIn.succ
-    case left =>
-      apply RecursiveIn.left
-    case right =>
-      apply RecursiveIn.right
-    case pair _ _ _ _ ih1 ih2 =>
-      apply RecursiveIn.pair ih1 ih2
-    case comp _ _ _ _ ih1 ih2 =>
-      apply RecursiveIn.comp ih1 ih2
-    case prec _ _ _ _ ih1 ih2 =>
-      apply RecursiveIn.prec ih1 ih2
-    case rfind _ _ ih =>
-      apply RecursiveIn.rfind ih
+  induction pF
+  case zero =>
+    apply RecursiveIn.zero
+  case succ =>
+    apply RecursiveIn.succ
+  case left =>
+    apply RecursiveIn.left
+  case right =>
+    apply RecursiveIn.right
+  case pair _ _ _ _ ih1 ih2 =>
+    apply RecursiveIn.pair ih1 ih2
+  case comp _ _ _ _ ih1 ih2 =>
+    apply RecursiveIn.comp ih1 ih2
+  case prec _ _ _ _ ih1 ih2 =>
+    apply RecursiveIn.prec ih1 ih2
+  case rfind _ _ ih =>
+    apply RecursiveIn.rfind ih
 
 /--
 If a function is recursive in the constant zero function,
 then it is partial recursive.
 -/
-
 lemma RecursiveIn.partrec_of_zero (f : ℕ →. ℕ) (fRecInZero : RecursiveIn f fun _ => Part.some 0) :
-    Nat.Partrec f := by
+  Nat.Partrec f := by
   generalize h : (fun _ => Part.some 0) = fp at *
   induction fRecInZero
   case zero =>
@@ -200,40 +199,41 @@ theorem TuringEquivalent.symm {f g : ℕ →. ℕ} (h : f ≡ᵀ g) : g ≡ᵀ f
 Proof that turing reducibility is transitive.
 -/
 theorem RecursiveIn.trans {f g h : ℕ →. ℕ} (hg : RecursiveIn f g) (hh : RecursiveIn g h) :
-    RecursiveIn f h := by
-    induction hg
-    case zero =>
-      apply RecursiveIn.zero
-    case succ =>
-      apply RecursiveIn.succ
-    case left =>
-      apply RecursiveIn.left
-    case right =>
-      apply RecursiveIn.right
-    case oracle =>
-      exact hh
-    case pair f' h' _ _ hf_ih hh_ih =>
-      apply RecursiveIn.pair
-      · apply hf_ih
-        apply hh
-      · apply hh_ih
-        apply hh
-    case comp f' h' _ _ hf_ih hh_ih =>
-      apply RecursiveIn.comp
-      · apply hf_ih
-        apply hh
-      · apply hh_ih
-        apply hh
-    case prec f' h' _ _ hf_ih hh_ih =>
-      apply RecursiveIn.prec
-      · apply hf_ih
-        apply hh
-      · apply hh_ih
-        apply hh
-    case rfind f' _ hf_ih =>
-      apply RecursiveIn.rfind
-      · apply hf_ih
-        apply hh
+  RecursiveIn f h := by
+  induction hg
+  case zero =>
+    apply RecursiveIn.zero
+  case succ =>
+    apply RecursiveIn.succ
+  case left =>
+    apply RecursiveIn.left
+  case right =>
+    apply RecursiveIn.right
+  case oracle =>
+    exact hh
+  case pair f' h' _ _ hf_ih hh_ih =>
+    apply RecursiveIn.pair
+    · apply hf_ih
+      apply hh
+    · apply hh_ih
+      apply hh
+  case comp f' h' _ _ hf_ih hh_ih =>
+    apply RecursiveIn.comp
+    · apply hf_ih
+      apply hh
+    · apply hh_ih
+      apply hh
+  case prec f' h' _ _ hf_ih hh_ih =>
+    apply RecursiveIn.prec
+    · apply hf_ih
+      apply hh
+    · apply hh_ih
+      apply hh
+  case rfind f' _ hf_ih =>
+    apply RecursiveIn.rfind
+    · apply hf_ih
+      apply hh
+
 
 /--
 Instance declaring that `RecursiveIn` is transitive.

--- a/Mathlib/Computability/TuringDegrees.lean
+++ b/Mathlib/Computability/TuringDegrees.lean
@@ -122,9 +122,8 @@ lemma Nat.Partrec.recursiveIn (f : ℕ →. ℕ) (pF : Nat.Partrec f) (g : ℕ �
 If a function is recursive in the constant zero function,
 then it is partial recursive.
 -/
-lemma partrec_in_zero_implies_partrec
-(f : ℕ →. ℕ) : RecursiveIn f (fun _ => Part.some 0) → Nat.Partrec f := by
-  intro fRecInZero
+lemma RecursiveIn.partrec_of_zero (f : ℕ →. ℕ) (fRecInZero : RecursiveIn f fun _ => Part.some 0) :
+    Nat.Partrec f := by
   generalize h : (fun _ => Part.some 0) = fp at *
   induction fRecInZero
   case zero =>


### PR DESCRIPTION
Some initial definitions introducing a model of oracle computability via partial recursive functions, define Turing reducibility and equivalence, and prove that Turing equivalence is an equivalence relation. Define the type of Turing degrees as equivalence classes under Turing equivalence. This PR includes:

- `RecursiveIn g f`: An inductive definition representing that a partial function `f` is recursive in oracle `g`.
- `turing_reducible`: A relation defining Turing reducibility between partial functions.
- `turing_equivalent`: A relation defining Turing equivalence between partial functions.
- `TuringDegree`: The type of Turing degrees, defined as equivalence classes under `turing_equivalent`.
- A proof that TuringDegree is a partial order when reducibility is lifted to degrees

### Implementation Notes

The type `RecursiveIn g f` is inductively defined to include basic functions such as `zero`, `succ`, projections, and the oracle `g`, and is closed under pairing, composition, primitive recursion, and μ-recursion. The `join` operation combines two partial functions by mapping even and odd numbers to the respective functions.

### Notation

- `f ≤ᵀ g`: `f` is Turing reducible to `g`.
- `f ≡ᵀ g`: `f` is Turing equivalent to `g`.
- `f ⊔ g`: The join of partial functions `f` and `g`.

## In Progress
The work here is just the basic definitions for the theory being developed. Some current in-progress work involves proving the upper-semilattice structure of Turing degrees, proving the existence of a _relativized_ universal partial recursive function, and proving properties of the jump operator.

### References

* [Carneiro2018] Carneiro, Mario. *Formalizing Computability Theory via Partial Recursive Functions*. arXiv preprint arXiv:1810.08380, 2018.
* [Odifreddi1989] Odifreddi, Piergiorgio. *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers, Vol. I*. Springer-Verlag, 1989.
* [Soare1987] Soare, Robert I. *Recursively Enumerable Sets and Degrees*. Springer-Verlag, 1987.
* [Gu2015] Gu, Yi-Zhi. *Turing Degrees*. Institute for Advanced Study, 2015.

### Tags

Computability, Oracle, Turing Degrees, Reducibility, Equivalence Relation
