### PR TITLE
[Merged by Bors] - chore(*): use `gcongr` and `omega` here and there

### DIFF
--- a/Archive/Wiedijk100Theorems/AbelRuffini.lean
+++ b/Archive/Wiedijk100Theorems/AbelRuffini.lean
@@ -125,8 +125,7 @@ theorem real_roots_Phi_ge_aux (hab : b < a) :
       calc
         f (-a) = (a : ℝ) ^ 2 - (a : ℝ) ^ 5 + b := by
           norm_num [hf, ← sq, sub_eq_add_neg, add_comm, Odd.neg_pow (by decide : Odd 5)]
-        _ ≤ (a : ℝ) ^ 2 - (a : ℝ) ^ 3 + (a - 1) := by
-          refine add_le_add (sub_le_sub_left (pow_right_mono₀ ha ?_) _) ?_ <;> linarith
+        _ ≤ (a : ℝ) ^ 2 - (a : ℝ) ^ 3 + (a - 1) := by gcongr <;> linarith
         _ = -((a : ℝ) - 1) ^ 2 * (a + 1) := by ring
         _ ≤ 0 := by nlinarith
     have ha' := neg_nonpos.mpr (hle.trans ha)

--- a/Mathlib/Algebra/GeomSum.lean
+++ b/Mathlib/Algebra/GeomSum.lean
@@ -430,9 +430,8 @@ theorem Nat.pred_mul_geom_sum_le (a b n : ℕ) :
       rw [tsub_mul, mul_comm, sum_mul, one_mul, sum_range_succ', sum_range_succ, pow_zero,
         Nat.div_one]
     _ ≤ (∑ i ∈ range n, a / b ^ i) + a * b - ((∑ i ∈ range n, a / b ^ i) + a / b ^ n) := by
-      refine tsub_le_tsub_right (add_le_add_right (sum_le_sum fun i _ => ?_) _) _
-      rw [pow_succ', mul_comm b]
-      rw [← Nat.div_div_eq_div_mul]
+      gcongr with i hi
+      rw [pow_succ, ← Nat.div_div_eq_div_mul]
       exact Nat.div_mul_le_self _ _
     _ = a * b - a / b ^ n := add_tsub_add_eq_tsub_left _ _ _
 

--- a/Mathlib/Algebra/LinearRecurrence.lean
+++ b/Mathlib/Algebra/LinearRecurrence.lean
@@ -69,11 +69,7 @@ def mkSol (init : Fin E.order → α) : ℕ → α
     if h : n < E.order then init ⟨n, h⟩
     else
       ∑ k : Fin E.order,
-        have _ : n - E.order + k < n := by
-          rw [add_comm, ← add_tsub_assoc_of_le (not_lt.mp h), tsub_lt_iff_left]
-          · exact add_lt_add_right k.is_lt n
-          · convert add_le_add (zero_le (k : ℕ)) (not_lt.mp h)
-            simp only [zero_add]
+        have _ : n - E.order + k < n := by omega
         E.coeffs k * mkSol init (n - E.order + k)
 
 /-- `E.mkSol` indeed gives solutions to `E`. -/
@@ -98,11 +94,7 @@ theorem eq_mk_of_is_sol_of_eq_init {u : ℕ → α} {init : Fin E.order → α} 
   · exact mod_cast heq ⟨n, h'⟩
   rw [← tsub_add_cancel_of_le (le_of_not_lt h'), h (n - E.order)]
   congr with k
-  have : n - E.order + k < n := by
-    rw [add_comm, ← add_tsub_assoc_of_le (not_lt.mp h'), tsub_lt_iff_left]
-    · exact add_lt_add_right k.is_lt n
-    · convert add_le_add (zero_le (k : ℕ)) (not_lt.mp h')
-      simp only [zero_add]
+  have : n - E.order + k < n := by omega
   rw [eq_mk_of_is_sol_of_eq_init h heq (n - E.order + k)]
   simp
 

--- a/Mathlib/Algebra/MonoidAlgebra/Degree.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Degree.lean
@@ -299,7 +299,7 @@ theorem supDegree_prod_le {R A B : Type*} [CommSemiring R] [AddCommMonoid A] [Ad
     split_ifs; exacts [bot_le, hzero.le]
   · intro i s his ih
     rw [Finset.prod_insert his, Finset.sum_insert his]
-    exact (supDegree_mul_le hadd).trans (add_le_add_left ih _)
+    exact (supDegree_mul_le hadd).trans (by gcongr)
 
 theorem apply_add_of_supDegree_le (hadd : ∀ a1 a2, D (a1 + a2) = D a1 + D a2)
     [AddLeftStrictMono B] [AddRightStrictMono B]

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -453,7 +453,7 @@ theorem ceil_lt_add_one (ha : 0 ≤ a) : (⌈a⌉₊ : α) < a + 1 :=
 @[bound]
 theorem ceil_add_le (a b : α) : ⌈a + b⌉₊ ≤ ⌈a⌉₊ + ⌈b⌉₊ := by
   rw [ceil_le, Nat.cast_add]
-  exact _root_.add_le_add (le_ceil _) (le_ceil _)
+  gcongr <;> apply le_ceil
 
 end LinearOrderedSemiring
 
@@ -726,7 +726,7 @@ theorem floor_add_one (a : α) : ⌊a + 1⌋ = ⌊a⌋ + 1 := by
 @[bound]
 theorem le_floor_add (a b : α) : ⌊a⌋ + ⌊b⌋ ≤ ⌊a + b⌋ := by
   rw [le_floor, Int.cast_add]
-  exact add_le_add (floor_le _) (floor_le _)
+  gcongr <;> apply floor_le
 
 @[bound]
 theorem le_floor_add_floor (a b : α) : ⌊a + b⌋ - 1 ≤ ⌊a⌋ + ⌊b⌋ := by
@@ -1176,7 +1176,7 @@ theorem ceil_lt_add_one (a : α) : (⌈a⌉ : α) < a + 1 := by
 @[bound]
 theorem ceil_add_le (a b : α) : ⌈a + b⌉ ≤ ⌈a⌉ + ⌈b⌉ := by
   rw [ceil_le, Int.cast_add]
-  exact add_le_add (le_ceil _) (le_ceil _)
+  gcongr <;> apply le_ceil
 
 @[bound]
 theorem ceil_add_ceil_le (a b : α) : ⌈a⌉ + ⌈b⌉ ≤ ⌈a + b⌉ + 1 := by

--- a/Mathlib/Algebra/Order/Group/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Abs.lean
@@ -91,11 +91,9 @@ theorem apply_abs_le_mul_of_one_le {β : Type*} [MulOneClass β] [Preorder β]
   apply_abs_le_mul_of_one_le' (h _) (h _)
 
 /-- The **triangle inequality** in `LinearOrderedAddCommGroup`s. -/
-theorem abs_add (a b : α) : |a + b| ≤ |a| + |b| :=
-  abs_le.2
-    ⟨(neg_add |a| |b|).symm ▸
-        add_le_add (neg_le.2 <| neg_le_abs _) (neg_le.2 <| neg_le_abs _),
-      add_le_add (le_abs_self _) (le_abs_self _)⟩
+theorem abs_add (a b : α) : |a + b| ≤ |a| + |b| := by
+  rw [abs_le, neg_add]
+  constructor <;> gcongr <;> apply_rules [neg_abs_le, le_abs_self]
 
 theorem abs_add' (a b : α) : |a| ≤ |b| + |b + a| := by simpa using abs_add (-b) (b + a)
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
