### PR TITLE
feat(Combinatorics/SimpleGraph): prove the Kővári–Sós–Turán theorem

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2634,6 +2634,7 @@ import Mathlib.Combinatorics.SimpleGraph.Diam
 import Mathlib.Combinatorics.SimpleGraph.Ends.Defs
 import Mathlib.Combinatorics.SimpleGraph.Ends.Properties
 import Mathlib.Combinatorics.SimpleGraph.Extremal.Basic
+import Mathlib.Combinatorics.SimpleGraph.Extremal.KovariSosTuran
 import Mathlib.Combinatorics.SimpleGraph.Finite
 import Mathlib.Combinatorics.SimpleGraph.Finsubgraph
 import Mathlib.Combinatorics.SimpleGraph.Girth

--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -251,7 +251,9 @@ variable [Fintype V] {α β γ δ : Type*} [Fintype α] [Fintype β]
 "right" subset of `t` vertices such that every vertex in the "left" subset is adjacent to every
 vertex in the "right" subset. -/
 structure completeBipartiteSubgraph (G : SimpleGraph V) (s t : ℕ) where
+  /-- The "left" subset of size `s`. -/
   left : @univ.powersetCard V s
+  /-- The "right" subset of size `t`. -/
   right : @univ.powersetCard V t
   Adj : ∀ v₁ ∈ left.val, ∀ v₂ ∈ right.val, G.Adj v₁ v₂
 
@@ -269,6 +271,7 @@ theorem card_right : #B.right.val = t := by
   have h := B.right.prop
   rwa [mem_powersetCard_univ] at h
 
+/-- A complete bipartite subgraph gives rise to a copy of a complete bipartite graph. -/
 noncomputable def toCopy : Copy (completeBipartiteGraph (Fin s) (Fin t)) G := by
   haveI : Nonempty (Fin s ↪ B.left) := by
     apply Function.Embedding.nonempty_of_card_le
@@ -299,6 +302,7 @@ noncomputable def toCopy : Copy (completeBipartiteGraph (Fin s) (Fin t)) G := by
       Sum.elim_inl, Sum.elim_inr, adj_comm]
     exact B.Adj (fs _) (by simp) (ft _) (by simp)
 
+/-- A copy of a complete bipartite graph identifies a complete bipartite subgraph. -/
 def ofCopy (f : Copy (completeBipartiteGraph α β) G) :
     G.completeBipartiteSubgraph (card α) (card β) where
   left := by

--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mitchell Horner
 -/
 import Mathlib.Combinatorics.Enumerative.DoubleCounting
+import Mathlib.Combinatorics.SimpleGraph.Copy
 import Mathlib.Combinatorics.SimpleGraph.DegreeSum
 
 /-!
@@ -241,5 +242,88 @@ theorem isBipartiteWith_sum_degrees_eq_card_edges' (h : G.IsBipartiteWith s t) :
     ∑ v ∈ t, G.degree v = #G.edgeFinset := isBipartiteWith_sum_degrees_eq_card_edges h.symm
 
 end IsBipartiteWith
+
+section CompleteBipartiteSubgraph
+
+variable [Fintype V] {α β γ δ : Type*} [Fintype α] [Fintype β]
+
+/-- A complete bipartite subgraph of `s` and `t` parts is a "left" subset of `s` vertices and a
+"right" subset of `t` vertices such that every vertex in the "left" subset is adjacent to every
+vertex in the "right" subset. -/
+structure completeBipartiteSubgraph (G : SimpleGraph V) (s t : ℕ) where
+  left : @univ.powersetCard V s
+  right : @univ.powersetCard V t
+  Adj : ∀ v₁ ∈ left.val, ∀ v₂ ∈ right.val, G.Adj v₁ v₂
+
+namespace completeBipartiteSubgraph
+
+variable {s t : ℕ} (B : G.completeBipartiteSubgraph s t)
+
+/-- The size of the left part of a `G.completeBipartiteSubgraph s t` is `s`. -/
+theorem card_left : #B.left.val = s := by
+  have h := B.left.prop
+  rwa [mem_powersetCard_univ] at h
+
+/-- The size of the right part of a `G.completeBipartiteSubgraph s t` is `t`. -/
+theorem card_right : #B.right.val = t := by
+  have h := B.right.prop
+  rwa [mem_powersetCard_univ] at h
+
+noncomputable def toCopy : Copy (completeBipartiteGraph (Fin s) (Fin t)) G := by
+  haveI : Nonempty (Fin s ↪ B.left) := by
+    apply Function.Embedding.nonempty_of_card_le
+    rw [Fintype.card_fin, card_coe, card_left]
+  let fs : Fin s ↪ B.left := Classical.arbitrary (Fin s ↪ B.left)
+  haveI : Nonempty (Fin t ↪ B.right) := by
+    apply Function.Embedding.nonempty_of_card_le
+    rw [Fintype.card_fin, card_coe, card_right]
+  let ft : Fin t ↪ B.right := Classical.arbitrary (Fin t ↪ B.right)
+  let f : Fin s ⊕ Fin t ↪ V := by
+    use Sum.elim (Subtype.val ∘ fs) (Subtype.val ∘ ft)
+    intro st₁ st₂
+    match st₁, st₂ with
+    | Sum.inl s₁, Sum.inl s₂ => simp [← Subtype.ext_iff_val]
+    | Sum.inr t₁, Sum.inl s₂ =>
+      simpa using (B.Adj (fs s₂) (fs s₂).prop (ft t₁) (ft t₁).prop).ne'
+    | Sum.inl s₁, Sum.inr t₂ =>
+      simpa using (B.Adj (fs s₁) (fs s₁).prop (ft t₂) (ft t₂).prop).symm.ne'
+    | Sum.inr t₁, Sum.inr t₂ => simp [← Subtype.ext_iff_val]
+  use ⟨f.toFun, ?_⟩, f.injective
+  intro st₁ st₂ hadj
+  rcases hadj with ⟨hst₁, hst₂⟩ | ⟨hst₁, hst₂⟩
+  all_goals dsimp [f]
+  · rw [← Sum.inl_getLeft st₁ hst₁, ← Sum.inr_getRight st₂ hst₂,
+      Sum.elim_inl, Sum.elim_inr]
+    exact B.Adj (fs _) (by simp) (ft _) (by simp)
+  · rw [← Sum.inr_getRight st₁ hst₁, ← Sum.inl_getLeft st₂ hst₂,
+      Sum.elim_inl, Sum.elim_inr, adj_comm]
+    exact B.Adj (fs _) (by simp) (ft _) (by simp)
+
+def ofCopy (f : Copy (completeBipartiteGraph α β) G) :
+    G.completeBipartiteSubgraph (card α) (card β) where
+  left := by
+    use univ.map ⟨f ∘ Sum.inl, f.injective.comp Sum.inl_injective⟩
+    rw [mem_powersetCard_univ, card_map, card_univ]
+  right := by
+    use univ.map ⟨f ∘ Sum.inr, f.injective.comp Sum.inr_injective⟩
+    rw [mem_powersetCard_univ, card_map, card_univ]
+  Adj := by
+    intro v₁ hv₁ v₂ hv₂
+    rw [mem_map] at hv₁ hv₂
+    obtain ⟨a, _, ha⟩ := hv₁
+    obtain ⟨b, _, hb⟩ := hv₂
+    rw [← ha, ← hb]
+    exact f.toHom.map_adj (by simp)
+
+end completeBipartiteSubgraph
+
+/-- Simple graphs contain a copy of a `completeBipartiteGraph α β` iff
+`G.completeBipartiteSubgraph (card α) (card β)` is nonempty. -/
+theorem completeBipartiteGraph_isContained_iff :
+    completeBipartiteGraph α β ⊑ G ↔ Nonempty (G.completeBipartiteSubgraph (card α) (card β)) :=
+  ⟨fun ⟨f⟩ ↦ ⟨completeBipartiteSubgraph.ofCopy f⟩,
+    fun ⟨B⟩ ↦ ⟨B.toCopy.comp <| Iso.toCopy ⟨(equivFin α).sumCongr (equivFin β), by simp⟩⟩⟩
+
+end CompleteBipartiteSubgraph
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/KovariSosTuran.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/KovariSosTuran.lean
@@ -33,8 +33,6 @@ namespace SimpleGraph
 
 variable {V α β : Type*} [Fintype V] [Fintype α] [Fintype β]
 
-section KovariSosTuran
-
 namespace KovariSosTuran
 
 /-- `bound` is the upper bound in the statement of the **Kővári–Sós–Turán theorem**.
@@ -52,8 +50,8 @@ theorem bound_nonneg {n s t : ℕ} (hs : 1 ≤ s) (ht : s ≤ t) : 0 ≤ bound n
 
 variable [DecidableEq V]
 
-/-- `aux` is the set of pairs `(t, v)` s.t. `t : Finset V` is an `n`-sized subset of the neighbor
-finset of `v : V` in `G : SimpleGraph V`.
+/-- `aux` is the set of pairs `(t, v)` such that `t : Finset V` is an `n`-sized subset of the
+neighbor finset of `v : V` in `G : SimpleGraph V`.
 
 This is an auxiliary definition for the **Kővári–Sós–Turán theorem**. -/
 private abbrev aux (G : SimpleGraph V) [DecidableRel G.Adj] (n : ℕ) :=
@@ -136,16 +134,16 @@ private lemma card_edgeFinset_le_bound [Nonempty V] [Nonempty α] [Nonempty β]
       rw [Nat.one_le_cast]
       apply Nat.succ_le_of_lt
     any_goals positivity
-  -- double-counting t ⊆ G.neighborSet v
+  -- double-counting `(t, v) ↦ t ⊆ G.neighborSet v`
   trans (#X : ℝ)
-  -- counting t
+  -- counting `t`
   · trans (card V)*((descPochhammer ℝ (card α)).eval
         ((∑ v, G.degree v : ℝ)/card V)/(card α).factorial)
     · rw [← Nat.cast_two, ← Nat.cast_mul, ← sum_degrees_eq_twice_card_edges, Nat.cast_sum,
         mul_div, div_le_div_iff_of_pos_right (by positivity), mul_le_mul_left (by positivity)]
       exact pow_le_descPochhammer_eval h_avg
     · exact le_card_aux h_avg
-  -- counting v
+  -- counting `v`
   · trans ((card V).choose (card α))*(card β-1)
     · exact card_aux_le h_free
     · apply mul_le_mul_of_nonneg_right (Nat.choose_le_pow_div (card α) (card V))
@@ -168,12 +166,10 @@ theorem card_edgeFinset_le_of_completeBipartiteGraph_free
     rw [← card_pos_iff]
     exact card_pos.trans_le hcard_le
   cases isEmpty_or_nonempty V
-  -- if no vertices
   · have h_two_sub_one_div_ne_zero : 2 - (card α : ℝ)⁻¹ ≠ 0 := by
       apply sub_ne_zero_of_ne ∘ ne_of_gt
       exact (card α).cast_inv_le_one.trans_lt one_lt_two
     simp [h_two_sub_one_div_ne_zero]
-  -- if vertices
   · rcases lt_or_le (∑ v, G.degree v : ℝ) ((card V)*(card α-1) : ℝ) with h_sum_lt | h_avg
     -- if avg degree less than `card a-1`
     · rw [← Nat.cast_sum, sum_degrees_eq_twice_card_edges,
@@ -200,7 +196,5 @@ theorem extremalNumber_completeBipartiteGraph_le (n : ℕ) [Nonempty α] (hcard_
     extremalNumber_le_iff_of_nonneg _ <| KovariSosTuran.bound_nonneg card_pos hcard_le]
   intro G _ h_free
   exact card_edgeFinset_le_of_completeBipartiteGraph_free hcard_le h_free
-
-end KovariSosTuran
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/KovariSosTuran.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/KovariSosTuran.lean
@@ -40,14 +40,14 @@ namespace KovariSosTuran
 /-- `bound` is the upper bound in the statement of the **Kővári–Sós–Turán theorem**.
 
 This is an auxiliary definition for the **Kővári–Sós–Turán theorem**. -/
-noncomputable abbrev bound (V : Type*) [Fintype V] (s t : ℕ) : ℝ :=
-  (t-1)^(1/s : ℝ)*(card V)^(2-1/s : ℝ)/2 + (card V)*(s-1)/2
+noncomputable abbrev bound (n s t : ℕ) : ℝ :=
+  (t-1)^(1/s : ℝ)*n^(2-1/s : ℝ)/2 + n*(s-1)/2
 
-theorem bound_nonneg {s t : ℕ} (hs : 1 ≤ s) (ht : s ≤ t) : 0 ≤ bound V s t := by
+theorem bound_nonneg {n s t : ℕ} (hs : 1 ≤ s) (ht : s ≤ t) : 0 ≤ bound n s t := by
     apply add_nonneg <;> apply div_nonneg _ zero_le_two <;> apply mul_nonneg
     · apply Real.rpow_nonneg <| sub_nonneg_of_le (mod_cast hs.trans ht)
-    · apply Real.rpow_nonneg (card V).cast_nonneg
-    · exact (card V).cast_nonneg
+    · apply Real.rpow_nonneg n.cast_nonneg
+    · exact n.cast_nonneg
     · exact sub_nonneg_of_le (mod_cast hs)
 
 variable [DecidableEq V]
@@ -111,7 +111,7 @@ This is an auxiliary definition for the **Kővári–Sós–Turán theorem**. -/
 private lemma card_edgeFinset_le_bound [Nonempty V] [Nonempty α] [Nonempty β]
     (h_avg : card α-1 ≤ (∑ v : V, G.degree v : ℝ) / card V)
     (h_free : (completeBipartiteGraph α β).Free G) :
-    #G.edgeFinset ≤ bound V (card α) (card β) := by
+    #G.edgeFinset ≤ bound (card V) (card α) (card β) := by
   have h_avg_sub_nonneg : 0 ≤ (2*#G.edgeFinset/card V-card α+1 : ℝ) := by
     rwa [← Nat.cast_sum, sum_degrees_eq_twice_card_edges, Nat.cast_mul,
       Nat.cast_two, ← sub_nonneg, ← sub_add] at h_avg

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/KovariSosTuran.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/KovariSosTuran.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2025 Mitchell Horner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mitchell Horner
+-/
+import Mathlib.Analysis.SpecialFunctions.Pochhammer
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Combinatorics.SimpleGraph.Bipartite
+import Mathlib.Combinatorics.SimpleGraph.DegreeSum
+import Mathlib.Combinatorics.SimpleGraph.Extremal.Basic
+
+/-!
+# The Kővári–Sós–Turán theorem
+
+This file proves the **Kővári–Sós–Turán theorem** for simple graphs.
+
+## Main definitions
+
+* `SimpleGraph.card_edgeFinset_le_of_completeBipartiteGraph_free` is the proof of the
+  **Kővári–Sós–Turán theorem** for simple graphs:
+
+  The `(completeBipartiteGraph α β).Free` simple graphs for `card α ≤ card β` on the vertex type `V`
+  have at most `(card β-1)^(1/(card α))*(card V)^(2-1/(card α))/2 + (card V)*(card α-1)/2` edges.
+
+* `SimpleGraph.extremalNumber_completeBipartiteGraph_le` is the corollary of the
+  **Kővári–Sós–Turán theorem** upper bounding the extremal numbers of `completeBipartiteGraph α β`.
+-/
+
+
+open Finset Fintype
+
+namespace SimpleGraph
+
+variable {V α β : Type*} [Fintype V] [Fintype α] [Fintype β]
+
+section KovariSosTuran
+
+namespace KovariSosTuran
+
+/-- `bound` is the upper bound in the statement of the **Kővári–Sós–Turán theorem**.
+
+This is an auxiliary definition for the **Kővári–Sós–Turán theorem**. -/
+noncomputable abbrev bound (V : Type*) [Fintype V] (s t : ℕ) : ℝ :=
+  (t-1)^(1/s : ℝ)*(card V)^(2-1/s : ℝ)/2 + (card V)*(s-1)/2
+
+theorem bound_nonneg {s t : ℕ} (hs : 1 ≤ s) (ht : s ≤ t) : 0 ≤ bound V s t := by
+    apply add_nonneg <;> apply div_nonneg _ zero_le_two <;> apply mul_nonneg
+    · apply Real.rpow_nonneg <| sub_nonneg_of_le (mod_cast hs.trans ht)
+    · apply Real.rpow_nonneg (card V).cast_nonneg
+    · exact (card V).cast_nonneg
+    · exact sub_nonneg_of_le (mod_cast hs)
+
+variable [DecidableEq V]
+
+/-- `aux` is the set of pairs `(t, v)` s.t. `t : Finset V` is an `n`-sized subset of the neighbor
+finset of `v : V` in `G : SimpleGraph V`.
+
+This is an auxiliary definition for the **Kővári–Sós–Turán theorem**. -/
+private abbrev aux (G : SimpleGraph V) [DecidableRel G.Adj] (n : ℕ) :=
+  (univ.powersetCard n ×ˢ univ).filter fun (t, v) ↦ t ⊆ G.neighborFinset v
+
+variable {G : SimpleGraph V} [DecidableRel G.Adj]
+
+local notation "X" => aux G (card α)
+
+/-- If `G` is `(completeBipartiteGraph α β).Free`, then `#X` is at most the number
+of ways to choose `card α` vertices from `card V` vertices `card β-1` times.
+
+This is an auxiliary definition for the **Kővári–Sós–Turán theorem**. -/
+private lemma card_aux_le [Nonempty β] (h : (completeBipartiteGraph α β).Free G) :
+    #X ≤ (((card V).choose (card α))*(card β-1) : ℝ) := by
+  simp_rw [card_filter _, sum_product, ← card_filter, ← @card_univ V, ← card_powersetCard,
+    ← nsmul_eq_mul, ← sum_const, ← Nat.cast_pred card_pos, ← Nat.cast_sum, Nat.cast_le]
+  apply sum_le_sum
+  intro t ht_mem
+  contrapose! h
+  rw [not_free, completeBipartiteGraph_isContained_iff]
+  have ⟨t', ht'_sub⟩ := exists_subset_card_eq h
+  rw [← Nat.pred_eq_sub_one, Nat.succ_pred_eq_of_pos card_pos] at ht'_sub
+  have ht'_mem : t' ∈ univ.powersetCard (Fintype.card β) := by
+    simpa [mem_powersetCard_univ] using ht'_sub.2
+  use ⟨t, ht_mem⟩, ⟨t', ht'_mem⟩
+  intro v₁ hv₁ v₂ hv₂
+  replace hv₂ := ht'_sub.1 hv₂
+  rw [mem_filter] at hv₂
+  replace hv₁ := hv₂.2 hv₁
+  rw [mem_neighborFinset] at hv₁
+  exact hv₁.symm
+
+/-- If the average degree of vertices in `G` is at least `card α-1`, then it follows from a special
+case of Jensen's inequality for `Nat.choose` that `#X` is at least `card α` times
+the desending pochhammer function evaluated at the average divided by `(card α).factorial`.
+
+This is an auxiliary definition for the **Kővári–Sós–Turán theorem**. -/
+private lemma le_card_aux [Nonempty V] [Nonempty α]
+    (h_avg : card α-1 ≤ (∑ v : V, G.degree v : ℝ)/card V) :
+    ((card V)*((descPochhammer ℝ (card α)).eval
+        ((∑ v, G.degree v : ℝ)/card V)/(card α).factorial) : ℝ) ≤ #X := by
+  simp_rw [card_filter _, sum_product_right, ← card_filter, powersetCard_eq_filter,
+    filter_comm, powerset_univ, filter_subset_univ, ← powersetCard_eq_filter,
+    card_powersetCard, card_neighborFinset_eq_degree, Nat.cast_sum,
+    ← le_inv_mul_iff₀ (mod_cast card_pos : 0 < (card V : ℝ)), mul_sum,
+    div_eq_mul_inv _ (card V : ℝ), mul_comm _ (card V : ℝ)⁻¹, mul_sum]
+  apply descPochhammer_eval_div_factorial_le_sum_choose (by positivity) _ _ (by simp) (by simp)
+  rwa [div_eq_inv_mul, mul_sum] at h_avg
+
+/-- If the average degree of vertices in `G` is at least `card α-1` and `G` is
+`(completeBipartiteGraph α β).Free`, then `G` has at most `KovariSosTuran.bound` edges.
+
+This is an auxiliary definition for the **Kővári–Sós–Turán theorem**. -/
+private lemma card_edgeFinset_le_bound [Nonempty V] [Nonempty α] [Nonempty β]
+    (h_avg : card α-1 ≤ (∑ v : V, G.degree v : ℝ) / card V)
+    (h_free : (completeBipartiteGraph α β).Free G) :
+    #G.edgeFinset ≤ bound V (card α) (card β) := by
+  have h_avg_sub_nonneg : 0 ≤ (2*#G.edgeFinset/card V-card α+1 : ℝ) := by
+    rwa [← Nat.cast_sum, sum_degrees_eq_twice_card_edges, Nat.cast_mul,
+      Nat.cast_two, ← sub_nonneg, ← sub_add] at h_avg
+  suffices h : ((card V)*(2*#G.edgeFinset/card V-card α+1)^(card α)/(card α).factorial : ℝ)
+      ≤ (((card V)^(card α)/(card α).factorial)*(card β-1) : ℝ) by
+    rwa [mul_comm _ (card β-1 : ℝ), mul_div, div_le_div_iff_of_pos_right,
+      mul_comm (card β-1 : ℝ) _, ← Real.rpow_natCast, ← Real.rpow_natCast,
+      mul_comm _ ((card β)-1 : ℝ), ← Real.rpow_le_rpow_iff, Real.mul_rpow, Real.mul_rpow,
+      Real.rpow_rpow_inv, Real.rpow_rpow_inv, sub_add, mul_sub, sub_le_iff_le_add, mul_div,
+      div_le_iff₀, ← mul_assoc, ← le_div_iff₀', add_mul, add_div, ← div_div,
+      div_eq_mul_inv _ (_^(card α : ℝ)⁻¹: ℝ), ← Real.rpow_neg_one (_^(card α : ℝ)⁻¹ : ℝ),
+      ← Real.rpow_mul, mul_neg_one, mul_assoc, mul_comm (card V : ℝ) _, ← Real.rpow_add_one,
+      mul_assoc, mul_comm (card V : ℝ) _, ← Real.rpow_add_one, add_assoc, one_add_one_eq_two,
+      add_comm _ 2, ← sub_eq_add_neg, ← div_div, div_eq_mul_inv _ (_^(card α : ℝ)⁻¹ : ℝ),
+      ← Real.rpow_neg_one (_^(card α : ℝ)⁻¹ : ℝ), ← Real.rpow_mul, mul_neg_one, mul_assoc,
+      mul_comm (card V : ℝ) _, ← Real.rpow_add_one, mul_assoc, mul_comm (card α-1 : ℝ) _,
+      ← mul_assoc, ← Real.rpow_add, ← add_assoc, add_neg_cancel, zero_add, Real.rpow_one,
+      inv_eq_one_div] at h
+    any_goals apply mul_nonneg
+    any_goals
+      apply sub_nonneg_of_le
+      rw [Nat.one_le_cast]
+      apply Nat.succ_le_of_lt
+    any_goals positivity
+  -- double-counting t ⊆ G.neighborSet v
+  trans (#X : ℝ)
+  -- counting t
+  · trans (card V)*((descPochhammer ℝ (card α)).eval
+        ((∑ v, G.degree v : ℝ)/card V)/(card α).factorial)
+    · rw [← Nat.cast_two, ← Nat.cast_mul, ← sum_degrees_eq_twice_card_edges, Nat.cast_sum,
+        mul_div, div_le_div_iff_of_pos_right (by positivity), mul_le_mul_left (by positivity)]
+      exact pow_le_descPochhammer_eval h_avg
+    · exact le_card_aux h_avg
+  -- counting v
+  · trans ((card V).choose (card α))*(card β-1)
+    · exact card_aux_le h_free
+    · apply mul_le_mul_of_nonneg_right (Nat.choose_le_pow_div (card α) (card V))
+      exact sub_nonneg_of_le (mod_cast Nat.succ_le_of_lt card_pos)
+
+end KovariSosTuran
+
+variable [DecidableEq V]
+
+/-- The `(completeBipartiteGraph α β).Free` simple graphs on the vertex type `V` have at most
+`(card β-1)^(1/(card α))*(card V)^(2-1/(card α))/2 + (card V)*(card α-1)/2` edges.
+
+This is the **Kővári–Sós–Turán theorem**. -/
+theorem card_edgeFinset_le_of_completeBipartiteGraph_free
+    [Nonempty α] (hcard_le : card α ≤ card β) {G : SimpleGraph V} [DecidableRel G.Adj]
+    (h_free : (completeBipartiteGraph α β).Free G) :
+    #G.edgeFinset
+      ≤ ((card β-1)^(1/card α : ℝ)*(card V)^(2-1/card α : ℝ)/2 + (card V)*(card α-1)/2 : ℝ) := by
+  haveI : Nonempty β := by
+    rw [← card_pos_iff]
+    exact card_pos.trans_le hcard_le
+  cases isEmpty_or_nonempty V
+  -- if no vertices
+  · have h_two_sub_one_div_ne_zero : 2 - (card α : ℝ)⁻¹ ≠ 0 := by
+      apply sub_ne_zero_of_ne ∘ ne_of_gt
+      exact (card α).cast_inv_le_one.trans_lt one_lt_two
+    simp [h_two_sub_one_div_ne_zero]
+  -- if vertices
+  · rcases lt_or_le (∑ v, G.degree v : ℝ) ((card V)*(card α-1) : ℝ) with h_sum_lt | h_avg
+    -- if avg degree less than `card a-1`
+    · rw [← Nat.cast_sum, sum_degrees_eq_twice_card_edges,
+        Nat.cast_mul, Nat.cast_two, ← lt_div_iff₀' zero_lt_two] at h_sum_lt
+      apply h_sum_lt.le.trans
+      apply le_add_of_nonneg_left
+      apply div_nonneg _ zero_le_two
+      apply mul_nonneg
+      · apply Real.rpow_nonneg _ (1/card α)
+        exact sub_nonneg_of_le (mod_cast Nat.succ_le_of_lt card_pos)
+      · exact Real.rpow_nonneg (card V).cast_nonneg (2-1/card α)
+    -- -- if avg degree at least `card α-1`
+    · rw [← le_div_iff₀' (mod_cast card_pos)] at h_avg
+      exact KovariSosTuran.card_edgeFinset_le_bound h_avg h_free
+
+/-- The extremal numbers of `completeBipartiteGraph α β` are at most
+`(card β-1)^(1/card α)*n^(2-1/card α)/2 + n*(card α-1)/2`.
+
+This is the corollary of the **Kővári–Sós–Turán theorem** for extremal numbers. -/
+theorem extremalNumber_completeBipartiteGraph_le (n : ℕ) [Nonempty α] (hcard_le : card α ≤ card β) :
+  extremalNumber n (completeBipartiteGraph α β)
+    ≤ ((card β-1)^(1/card α : ℝ)*n^(2-1/card α : ℝ)/2 + n*(card α-1)/2 : ℝ) := by
+  rw [← Fintype.card_fin n,
+    extremalNumber_le_iff_of_nonneg _ <| KovariSosTuran.bound_nonneg card_pos hcard_le]
+  intro G _ h_free
+  exact card_edgeFinset_le_of_completeBipartiteGraph_free hcard_le h_free
+
+end KovariSosTuran
+
+end SimpleGraph


### PR DESCRIPTION
Prove the Kővári–Sós–Turán theorem for simple graphs: the `(completeBipartiteGraph α β).Free` simple graphs for `card α ≤ card β` on the vertex type `V` have at most `(card β-1)^(1/(card α))*(card V)^(2-1/(card α))/2 + (card V)*(card α-1)/2` edges.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #19865
- [x] depends on: #20738

I'd like to make `aux` not private in the `KovariSosTuran` namespace to enable reuse of the double-counting here, but I don't know what to call it.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
