### PR TITLE
[Merged by Bors] - chore: make uniqueness of conditionally complete linearly ordered archimedean fields independent of the construction of `Real`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2866,6 +2866,7 @@ import Mathlib.Data.Rat.Star
 import Mathlib.Data.Real.Archimedean
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Real.Cardinality
+import Mathlib.Data.Real.CompleteField
 import Mathlib.Data.Real.ConjExponents
 import Mathlib.Data.Real.ENatENNReal
 import Mathlib.Data.Real.EReal

--- a/Mathlib/Algebra/Order/Archimedean/Basic.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Basic.lean
@@ -303,11 +303,52 @@ theorem exists_nat_pow_near_of_lt_one (xpos : 0 < x) (hx : x ≤ 1) (ypos : 0 < 
 end LinearOrderedSemifield
 
 section LinearOrderedField
-variable [LinearOrderedField α] [Archimedean α] {x y ε : α}
+variable [LinearOrderedField α]
 
-theorem exists_rat_gt (x : α) : ∃ q : ℚ, x < q :=
-  let ⟨n, h⟩ := exists_nat_gt x
-  ⟨n, by rwa [Rat.cast_natCast]⟩
+theorem archimedean_iff_nat_lt : Archimedean α ↔ ∀ x : α, ∃ n : ℕ, x < n :=
+  ⟨@exists_nat_gt α _, fun H =>
+    ⟨fun x y y0 =>
+      (H (x / y)).imp fun n h => le_of_lt <| by rwa [div_lt_iff₀ y0, ← nsmul_eq_mul] at h⟩⟩
+
+theorem archimedean_iff_nat_le : Archimedean α ↔ ∀ x : α, ∃ n : ℕ, x ≤ n :=
+  archimedean_iff_nat_lt.trans
+    ⟨fun H x => (H x).imp fun _ => le_of_lt, fun H x =>
+      let ⟨n, h⟩ := H x
+      ⟨n + 1, lt_of_le_of_lt h (Nat.cast_lt.2 (lt_add_one _))⟩⟩
+
+theorem archimedean_iff_int_lt : Archimedean α ↔ ∀ x : α, ∃ n : ℤ, x < n :=
+  ⟨@exists_int_gt α _, by
+    rw [archimedean_iff_nat_lt]
+    intro h x
+    obtain ⟨n, h⟩ := h x
+    refine ⟨n.toNat, h.trans_le ?_⟩
+    exact mod_cast Int.self_le_toNat _⟩
+
+theorem archimedean_iff_int_le : Archimedean α ↔ ∀ x : α, ∃ n : ℤ, x ≤ n :=
+  archimedean_iff_int_lt.trans
+    ⟨fun H x => (H x).imp fun _ => le_of_lt, fun H x =>
+      let ⟨n, h⟩ := H x
+      ⟨n + 1, lt_of_le_of_lt h (Int.cast_lt.2 (lt_add_one _))⟩⟩
+
+theorem archimedean_iff_rat_lt : Archimedean α ↔ ∀ x : α, ∃ q : ℚ, x < q where
+  mp _ x :=
+    let ⟨n, h⟩ := exists_nat_gt x
+    ⟨n, by rwa [Rat.cast_natCast]⟩
+  mpr H := archimedean_iff_nat_lt.2 fun x ↦
+    let ⟨q, h⟩ := H x; ⟨⌈q⌉₊, lt_of_lt_of_le h <| mod_cast Nat.le_ceil _⟩
+
+theorem archimedean_iff_rat_le : Archimedean α ↔ ∀ x : α, ∃ q : ℚ, x ≤ q :=
+  archimedean_iff_rat_lt.trans
+    ⟨fun H x => (H x).imp fun _ => le_of_lt, fun H x =>
+      let ⟨n, h⟩ := H x
+      ⟨n + 1, lt_of_le_of_lt h (Rat.cast_lt.2 (lt_add_one _))⟩⟩
+
+instance : Archimedean ℚ :=
+  archimedean_iff_rat_le.2 fun q => ⟨q, by rw [Rat.cast_id]⟩
+
+variable [Archimedean α] {x y ε : α}
+
+theorem exists_rat_gt (x : α) : ∃ q : ℚ, x < q := archimedean_iff_rat_lt.mp ‹_› _
 
 theorem exists_rat_lt (x : α) : ∃ q : ℚ, (q : α) < x :=
   let ⟨n, h⟩ := exists_int_lt x
@@ -331,84 +372,35 @@ theorem exists_rat_btwn {x y : α} (h : x < y) : ∃ q : ℚ, x < q ∧ (q : α)
     subst H
     cases n0
 
-theorem Rat.one_add_pow_le {r : ℚ} {n : ℕ} (hr : 0 ≤ r) :
-    (1 + r) ^ n ≤ (2 ^ n - 1) * max 1 r ^ (n - 1) + r ^ n := by
-  induction n with
-  | zero => simp
-  | succ n ih =>
-    set m := max 1 r with hm
-    simp only [add_tsub_cancel_right] at ih ⊢
-    calc (1 + r) ^ (n + 1)
-        = (1 + r) ^ n * (1 + r) := by rw [pow_succ]
-      _ ≤ ((2 ^ n - 1) * m ^ (n - 1) + r ^ n) * (1 + r) :=
-          mul_le_mul_of_nonneg_right ih (add_nonneg zero_le_one hr)
-      _ = ((2 ^ n - 1) * m ^ (n - 1)) * (1 + r) + r ^ n + r ^ (n + 1) := by ring
-      _ ≤ _ := ?_
-    apply add_le_add_right
-    have h₁ : 1 + r ≤ 2 * m := by
-      rw [two_mul, hm]
-      apply add_le_add <;> simp only [le_sup_left, le_sup_right]
-    have h₂ : r ^ n ≤ m ^ n := pow_le_pow_left₀ hr le_sup_right n
-    calc (2 ^ n - 1) * m ^ (n - 1) * (1 + r) + r ^ n
-        ≤ (2 ^ n - 1) * m ^ (n - 1) * (2 * m) + m ^ n := by
-          apply add_le_add _ h₂
-          apply mul_le_mul_of_nonneg_left h₁
-          apply mul_nonneg _ (pow_nonneg (by simp [hm]) _)
-          apply sub_nonneg.mpr (one_le_pow₀ rfl)
-      _ = _ := ?_
-    cases n with
-    | zero => simp; ring
-    | succ n => simp only [add_tsub_cancel_right]; ring
+theorem exists_pow_btwn {n : ℕ} (hn : n ≠ 0) {x y : α} (h : x < y) (hy : 0 < y) :
+    ∃ q : α, 0 < q ∧ x < q ^ n ∧ q ^ n < y := by
+  have ⟨δ, δ_pos, cont⟩ := uniform_continuous_npow_on_bounded (max 1 y)
+    (sub_pos.mpr <| max_lt_iff.mpr ⟨h, hy⟩) n
+  have ex : ∃ m : ℕ, y ≤ (m * δ) ^ n := by
+    have ⟨m, hm⟩ := exists_nat_ge (y / δ + 1 / δ)
+    refine ⟨m, le_trans ?_ (le_self_pow₀ ?_ hn)⟩ <;> rw [← div_le_iff₀ δ_pos]
+    · exact (lt_add_of_pos_right _ <| by positivity).le.trans hm
+    · exact (le_add_of_nonneg_left <| by positivity).trans hm
+  let m := Nat.find ex
+  have m_pos : 0 < m := (Nat.find_pos _).mpr <| by simpa [zero_pow hn] using hy
+  let q := m.pred * δ
+  have qny : q ^ n < y := lt_of_not_le (Nat.find_min ex <| Nat.pred_lt m_pos.ne')
+  have q1y : |q| < max 1 y := (abs_eq_self.mpr <| by positivity).trans_lt <| lt_max_iff.mpr
+    (or_iff_not_imp_left.mpr fun q1 ↦ (le_self_pow₀ (le_of_not_lt q1) hn).trans_lt qny)
+  have xqn : max x 0 < q ^ n :=
+    calc _ = y - (y - max x 0) := by rw [sub_sub_cancel]
+      _ ≤ (m * δ) ^ n - (y - max x 0) := sub_le_sub_right (Nat.find_spec ex) _
+      _ < (m * δ) ^ n - ((m * δ) ^ n - q ^ n) := by
+        refine sub_lt_sub_left ((le_abs_self _).trans_lt <| cont _ _ q1y.le ?_) _
+        rw [← Nat.succ_pred_eq_of_pos m_pos, Nat.cast_succ, ← sub_mul,
+          add_sub_cancel_left, one_mul, abs_eq_self.mpr (by positivity)]
+      _ = q ^ n := sub_sub_cancel ..
+  exact ⟨q, lt_of_le_of_ne (by positivity) fun q0 ↦
+    (le_sup_right.trans_lt xqn).ne <| q0 ▸ (zero_pow hn).symm, le_sup_left.trans_lt xqn, qny⟩
 
 theorem exists_rat_pow_btwn_rat {n : ℕ} (hn : n ≠ 0) {x y : ℚ} (h : x < y) (hy : 0 < y) :
-    ∃ q : ℚ, 0 < q ∧ x < q ^ n ∧ q ^ n < y := by
-  wlog hx : 0 ≤ x generalizing x
-  · have ⟨q, q_pos, qn_pos, lt_y⟩ := this hy le_rfl
-    exact ⟨q, q_pos, (le_of_not_le hx).trans_lt qn_pos, lt_y⟩
-  have yx_pos := sub_pos.mpr h
-  obtain rfl | hn1 := (Nat.one_le_iff_ne_zero.mpr hn).eq_or_lt
-  · exact ⟨(x + y) / 2, by positivity, by linarith, by linarith⟩
-  let d := (2 ^ n * max 1 y) / (y - x)
-  have h1d : 1 < d := (one_lt_div yx_pos).mpr <| ((sub_le_self _ hx).trans le_sup_right).trans_lt
-    (lt_mul_of_one_lt_left (by positivity) <| one_lt_pow₀ one_lt_two hn)
-  have d_pos : 0 < d := zero_lt_one.trans h1d
-  have ex : ∃ m : ℕ, y ≤ (m / d) ^ n := by
-    refine ⟨⌈y * d + d⌉₊, le_trans ?_ (le_self_pow₀ ?_ hn)⟩
-    · rw [le_div_iff₀ d_pos]
-      exact ((lt_add_of_pos_right _ d_pos).le.trans <| Nat.le_ceil _)
-    · rw [le_div_iff₀ d_pos, one_mul]
-      exact (le_add_of_nonneg_left <| by positivity).trans (Nat.le_ceil _)
-  let num := Nat.find ex
-  have num_pos : 0 < num := (Nat.find_pos _).mpr <| by simpa [zero_pow hn] using hy
-  let q := num.pred / d
-  have qny : q ^ n < y := lt_of_not_le (Nat.find_min ex <| Nat.pred_lt num_pos.ne')
-  have key : max 1 ↑num.pred ^ (n - 1) / d ^ n < max 1 y / d := by
-    conv in (d ^ _) => rw [← Nat.sub_one_add_one hn, pow_add, pow_one]
-    rw [← div_div, ← div_pow, div_lt_div_iff_of_pos_right d_pos, lt_max_iff, or_iff_not_imp_left,
-      not_lt, one_le_pow_iff_of_nonneg (by positivity) (Nat.sub_pos_of_lt hn1).ne']
-    refine fun h ↦ (pow_le_pow_right₀ h <| n.sub_le 1).trans_lt ?_
-    have : (1 : ℚ) ≤ num.pred := Nat.cast_le.mpr <| Nat.one_le_iff_ne_zero.mpr fun eq ↦ by
-      rw [← max_div_div_right d_pos.le, le_max_iff, or_iff_not_imp_left, not_le, one_div,
-        inv_lt_one₀ d_pos, eq, Nat.cast_zero, zero_div] at h
-      exact zero_lt_one.not_le (h h1d)
-    rwa [max_eq_right this]
-  have aux : (1 + (num.pred : ℚ)) ^ n ≤ num.pred ^ n + 2 ^ n * (max 1 ↑num.pred) ^ (n - 1) := by
-    apply (Rat.one_add_pow_le <| Nat.cast_nonneg' num.pred).trans
-    rw [add_comm, sub_mul, one_mul]
-    apply add_le_add_left <| sub_le_self _ <| pow_nonneg (zero_le_one.trans (le_max_left _ _)) _
-  have xqn : x < q ^ n :=
-    calc x = y - (y - x) := (sub_sub_cancel _ _).symm
-      _ ≤ (num / d) ^ n - 2 ^ n * max 1 y / d :=
-        sub_le_sub (Nat.find_spec ex) (div_div_cancel₀ <| by positivity).le
-      _ = (1 + num.pred) ^ n / d ^ n - _ := by rw [← Nat.cast_one, ← Nat.cast_add,
-        Nat.cast_one, ← Nat.succ_eq_one_add, Nat.succ_pred num_pos.ne', div_pow]
-      _ ≤ num.pred ^ n / d ^ n + 2 ^ n * (max 1 ↑num.pred ^ (n - 1) / d ^ n - max 1 y / d) :=
-        (sub_le_sub_right (div_le_div_of_nonneg_right aux <| by positivity) _).trans <| by
-          simp_rw [add_div, mul_sub, add_sub, mul_div, le_rfl]
-      _ = q ^ n + _ := by rw [← div_pow]
-      _ < q ^ n := add_lt_of_neg_right _ (mul_neg_of_pos_of_neg (by positivity) <| sub_neg.mpr key)
-  refine ⟨q, lt_of_le_of_ne (by positivity) fun hq ↦ hx.not_lt ?_, xqn, qny⟩
-  rwa [← hq, zero_pow hn] at xqn
+    ∃ q : ℚ, 0 < q ∧ x < q ^ n ∧ q ^ n < y :=
+  exists_pow_btwn hn h hy
 
 /-- There is a rational power between any two positive elements of an archimedean ordered field. -/
 theorem exists_rat_pow_btwn {n : ℕ} (hn : n ≠ 0) {x y : α} (h : x < y) (hy : 0 < y) :
@@ -454,48 +446,6 @@ theorem exists_rat_near (x : α) (ε0 : 0 < ε) : ∃ q : ℚ, |x - q| < ε :=
 
 end LinearOrderedField
 
-section LinearOrderedField
-
-variable [LinearOrderedField α]
-
-theorem archimedean_iff_nat_lt : Archimedean α ↔ ∀ x : α, ∃ n : ℕ, x < n :=
-  ⟨@exists_nat_gt α _, fun H =>
-    ⟨fun x y y0 =>
-      (H (x / y)).imp fun n h => le_of_lt <| by rwa [div_lt_iff₀ y0, ← nsmul_eq_mul] at h⟩⟩
-
-theorem archimedean_iff_nat_le : Archimedean α ↔ ∀ x : α, ∃ n : ℕ, x ≤ n :=
-  archimedean_iff_nat_lt.trans
-    ⟨fun H x => (H x).imp fun _ => le_of_lt, fun H x =>
-      let ⟨n, h⟩ := H x
-      ⟨n + 1, lt_of_le_of_lt h (Nat.cast_lt.2 (lt_add_one _))⟩⟩
-
-theorem archimedean_iff_int_lt : Archimedean α ↔ ∀ x : α, ∃ n : ℤ, x < n :=
-  ⟨@exists_int_gt α _, by
-    rw [archimedean_iff_nat_lt]
-    intro h x
-    obtain ⟨n, h⟩ := h x
-    refine ⟨n.toNat, h.trans_le ?_⟩
-    exact mod_cast Int.self_le_toNat _⟩
-
-theorem archimedean_iff_int_le : Archimedean α ↔ ∀ x : α, ∃ n : ℤ, x ≤ n :=
-  archimedean_iff_int_lt.trans
-    ⟨fun H x => (H x).imp fun _ => le_of_lt, fun H x =>
-      let ⟨n, h⟩ := H x
-      ⟨n + 1, lt_of_le_of_lt h (Int.cast_lt.2 (lt_add_one _))⟩⟩
-
-theorem archimedean_iff_rat_lt : Archimedean α ↔ ∀ x : α, ∃ q : ℚ, x < q where
-  mp := @exists_rat_gt α _
-  mpr H := archimedean_iff_nat_lt.2 fun x ↦
-    let ⟨q, h⟩ := H x; ⟨⌈q⌉₊, lt_of_lt_of_le h <| mod_cast Nat.le_ceil _⟩
-
-theorem archimedean_iff_rat_le : Archimedean α ↔ ∀ x : α, ∃ q : ℚ, x ≤ q :=
-  archimedean_iff_rat_lt.trans
-    ⟨fun H x => (H x).imp fun _ => le_of_lt, fun H x =>
-      let ⟨n, h⟩ := H x
-      ⟨n + 1, lt_of_le_of_lt h (Rat.cast_lt.2 (lt_add_one _))⟩⟩
-
-end LinearOrderedField
-
 instance : Archimedean ℕ :=
   ⟨fun n m m0 => ⟨n, by
     rw [← mul_one n, smul_eq_mul, mul_assoc, one_mul m]
@@ -507,9 +457,6 @@ instance : Archimedean ℤ :=
       le_trans (Int.self_le_toNat _) <| by
         simpa only [nsmul_eq_mul, zero_add, mul_one] using
           mul_le_mul_of_nonneg_left (Int.add_one_le_iff.2 m0) (Int.ofNat_zero_le n.toNat)⟩⟩
-
-instance : Archimedean ℚ :=
-  archimedean_iff_rat_le.2 fun q => ⟨q, by rw [Rat.cast_id]⟩
 
 instance Nonneg.instArchimedean [OrderedAddCommMonoid α] [Archimedean α] :
     Archimedean { x : α // 0 ≤ x } :=

--- a/Mathlib/Algebra/Order/Archimedean/Basic.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Basic.lean
@@ -398,9 +398,7 @@ theorem exists_pow_btwn {n : ℕ} (hn : n ≠ 0) {x y : α} (h : x < y) (hy : 0 
   exact ⟨q, lt_of_le_of_ne (by positivity) fun q0 ↦
     (le_sup_right.trans_lt xqn).ne <| q0 ▸ (zero_pow hn).symm, le_sup_left.trans_lt xqn, qny⟩
 
-theorem exists_rat_pow_btwn_rat {n : ℕ} (hn : n ≠ 0) {x y : ℚ} (h : x < y) (hy : 0 < y) :
-    ∃ q : ℚ, 0 < q ∧ x < q ^ n ∧ q ^ n < y :=
-  exists_pow_btwn hn h hy
+@[deprecated (since := "2024-12-26")] alias exists_rat_pow_btwn_rat := exists_pow_btwn
 
 /-- There is a rational power between any two positive elements of an archimedean ordered field. -/
 theorem exists_rat_pow_btwn {n : ℕ} (hn : n ≠ 0) {x y : α} (h : x < y) (hy : 0 < y) :
@@ -409,7 +407,7 @@ theorem exists_rat_pow_btwn {n : ℕ} (hn : n ≠ 0) {x y : α} (h : x < y) (hy 
   obtain ⟨q₁, hx₁, hq₁₂⟩ := exists_rat_btwn hx₂
   have : (0 : α) < q₂ := (le_max_right _ _).trans_lt hx₂
   norm_cast at hq₁₂ this
-  obtain ⟨q, hq, hq₁, hq₂⟩ := exists_rat_pow_btwn_rat hn hq₁₂ this
+  obtain ⟨q, hq, hq₁, hq₂⟩ := exists_pow_btwn hn hq₁₂ this
   refine ⟨q, hq, (le_max_left _ _).trans_lt <| hx₁.trans ?_, hy₂.trans' ?_⟩ <;> assumption_mod_cast
 
 theorem le_of_forall_rat_lt_imp_le (h : ∀ q : ℚ, (q : α) < x → (q : α) ≤ y) : x ≤ y :=

--- a/Mathlib/Algebra/Order/CompleteField.lean
+++ b/Mathlib/Algebra/Order/CompleteField.lean
@@ -5,7 +5,6 @@ Authors: Alex J. Best, Yaël Dillies
 -/
 import Mathlib.Algebra.Order.Archimedean.Hom
 import Mathlib.Algebra.Order.Group.Pointwise.CompleteLattice
-import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 /-!
 # Conditionally complete linear ordered fields
@@ -46,7 +45,7 @@ variable {F α β γ : Type*}
 
 noncomputable section
 
-open Function Rat Real Set
+open Function Rat Set
 
 open scoped Pointwise
 
@@ -68,11 +67,6 @@ instance (priority := 100) ConditionallyCompleteLinearOrderedField.to_archimedea
         (forall_mem_range.2 fun m =>
           le_sub_iff_add_le.2 <| le_csSup _ _ ⟨x, forall_mem_range.2 h⟩ ⟨m+1, Nat.cast_succ m⟩)
       linarith)
-
-/-- The reals are a conditionally complete linearly ordered field. -/
-instance : ConditionallyCompleteLinearOrderedField ℝ :=
-  { (inferInstance : LinearOrderedField ℝ),
-    (inferInstance : ConditionallyCompleteLinearOrder ℝ) with }
 
 namespace LinearOrderedField
 
@@ -328,11 +322,5 @@ variable {R S : Type*} [OrderedRing R] [LinearOrderedRing S]
 theorem ringHom_monotone (hR : ∀ r : R, 0 ≤ r → ∃ s : R, s ^ 2 = r) (f : R →+* S) : Monotone f :=
   (monotone_iff_map_nonneg f).2 fun r h => by
     obtain ⟨s, rfl⟩ := hR r h; rw [map_pow]; apply sq_nonneg
-
-/-- There exists no nontrivial ring homomorphism `ℝ →+* ℝ`. -/
-instance Real.RingHom.unique : Unique (ℝ →+* ℝ) where
-  default := RingHom.id ℝ
-  uniq f := congr_arg OrderRingHom.toRingHom (@Subsingleton.elim (ℝ →+*o ℝ) _
-      ⟨f, ringHom_monotone (fun r hr => ⟨√r, sq_sqrt hr⟩) f⟩ default)
 
 end Real

--- a/Mathlib/Algebra/Order/Field/Basic.lean
+++ b/Mathlib/Algebra/Order/Field/Basic.lean
@@ -799,6 +799,24 @@ theorem abs_div (a b : α) : |a / b| = |a| / |b| :=
 
 theorem abs_one_div (a : α) : |1 / a| = 1 / |a| := by rw [abs_div, abs_one]
 
+theorem uniform_continuous_npow_on_bounded (B : α) {ε : α} (hε : 0 < ε) (n : ℕ) :
+    ∃ δ > 0, ∀ q r : α, |r| ≤ B → |q - r| ≤ δ → |q ^ n - r ^ n| < ε := by
+  wlog B_pos : 0 < B generalizing B
+  · have ⟨δ, δ_pos, cont⟩ := this 1 zero_lt_one
+    exact ⟨δ, δ_pos, fun q r hr ↦ cont q r (hr.trans ((le_of_not_lt B_pos).trans zero_le_one))⟩
+  have pos : 0 < 1 + ↑n * (B + 1) ^ (n - 1) := zero_lt_one.trans_le <| le_add_of_nonneg_right <|
+    mul_nonneg n.cast_nonneg <| (pow_pos (B_pos.trans <| lt_add_of_pos_right _ zero_lt_one) _).le
+  refine ⟨min 1 (ε / (1 + n * (B + 1) ^ (n - 1))), lt_min zero_lt_one (div_pos hε pos),
+    fun q r hr hqr ↦ (abs_pow_sub_pow_le ..).trans_lt ?_⟩
+  rw [le_inf_iff, le_div_iff₀ pos, mul_one_add, ← mul_assoc] at hqr
+  obtain h | h := (abs_nonneg (q - r)).eq_or_lt
+  · simpa only [← h, zero_mul] using hε
+  refine (lt_of_le_of_lt ?_ <| lt_add_of_pos_left _ h).trans_le hqr.2
+  refine mul_le_mul_of_nonneg_left (pow_le_pow_left₀ ((abs_nonneg _).trans le_sup_left) ?_ _)
+    (mul_nonneg (abs_nonneg _) n.cast_nonneg)
+  refine max_le ?_ (hr.trans <| le_add_of_nonneg_right zero_le_one)
+  exact add_sub_cancel r q ▸ (abs_add_le ..).trans (add_le_add hr hqr.1)
+
 end
 
 namespace Mathlib.Meta.Positivity

--- a/Mathlib/Algebra/Order/Ring/Abs.lean
+++ b/Mathlib/Algebra/Order/Ring/Abs.lean
@@ -143,7 +143,7 @@ end LinearOrderedRing
 
 section LinearOrderedCommRing
 
-variable [LinearOrderedCommRing α]
+variable [LinearOrderedCommRing α] (a b : α) (n : ℕ)
 
 theorem abs_sub_sq (a b : α) : |a - b| * |a - b| = a * a + b * b - (1 + 1) * a * b := by
   rw [abs_mul_abs_self]
@@ -152,6 +152,30 @@ theorem abs_sub_sq (a b : α) : |a - b| * |a - b| = a * a + b * b - (1 + 1) * a 
 
 lemma abs_unit_intCast (a : ℤˣ) : |((a : ℤ) : α)| = 1 := by
   cases Int.units_eq_one_or a <;> simp_all
+
+private def geomSum : ℕ → α
+  | 0 => 1
+  | n + 1 => a * geomSum n + b ^ (n + 1)
+
+private theorem abs_geomSum_le : |geomSum a b n| ≤ (n + 1) * max |a| |b| ^ n := by
+  induction' n with n ih; · simp [geomSum]
+  refine (abs_add_le ..).trans ?_
+  rw [abs_mul, abs_pow, Nat.cast_succ, add_one_mul]
+  refine add_le_add ?_ (pow_le_pow_left₀ (abs_nonneg _) le_sup_right _)
+  rw [pow_succ, ← mul_assoc, mul_comm |a|]
+  exact mul_le_mul ih le_sup_left (abs_nonneg _) (mul_nonneg
+    (@Nat.cast_succ α .. ▸ Nat.cast_nonneg _) <| pow_nonneg ((abs_nonneg _).trans le_sup_left) _)
+
+private theorem pow_sub_pow_eq_sub_mul_geomSum :
+    a ^ (n + 1) - b ^ (n + 1) = (a - b) * geomSum a b n := by
+  induction' n with n ih; · simp [geomSum]
+  rw [geomSum, mul_add, mul_comm a, ← mul_assoc, ← ih,
+    sub_mul, sub_mul, ← pow_succ, ← pow_succ', mul_comm, sub_add_sub_cancel]
+
+theorem abs_pow_sub_pow_le : |a ^ n - b ^ n| ≤ |a - b| * n * max |a| |b| ^ (n - 1) := by
+  obtain _ | n := n; · simp
+  rw [Nat.add_sub_cancel, pow_sub_pow_eq_sub_mul_geomSum, abs_mul, mul_assoc, Nat.cast_succ]
+  exact mul_le_mul_of_nonneg_left (abs_geomSum_le ..) (abs_nonneg _)
 
 end LinearOrderedCommRing
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -973,36 +973,6 @@ theorem rpow_div_two_eq_sqrt {x : ℝ} (r : ℝ) (hx : 0 ≤ x) : x ^ (r / 2) = 
 
 end Sqrt
 
-variable {n : ℕ}
-
-theorem exists_rat_pow_btwn_rat_aux (hn : n ≠ 0) (x y : ℝ) (h : x < y) (hy : 0 < y) :
-    ∃ q : ℚ, 0 < q ∧ x < (q : ℝ) ^ n ∧ (q : ℝ) ^ n < y := by
-  have hn' : 0 < (n : ℝ) := mod_cast hn.bot_lt
-  obtain ⟨q, hxq, hqy⟩ :=
-    exists_rat_btwn (rpow_lt_rpow (le_max_left 0 x) (max_lt hy h) <| inv_pos.mpr hn')
-  have := rpow_nonneg (le_max_left 0 x) n⁻¹
-  have hq := this.trans_lt hxq
-  replace hxq := rpow_lt_rpow this hxq hn'
-  replace hqy := rpow_lt_rpow hq.le hqy hn'
-  rw [rpow_natCast, rpow_natCast, rpow_inv_natCast_pow _ hn] at hxq hqy
-  · exact ⟨q, mod_cast hq, (le_max_right _ _).trans_lt hxq, hqy⟩
-  · exact hy.le
-  · exact le_max_left _ _
-
-theorem exists_rat_pow_btwn_rat (hn : n ≠ 0) {x y : ℚ} (h : x < y) (hy : 0 < y) :
-    ∃ q : ℚ, 0 < q ∧ x < q ^ n ∧ q ^ n < y := by
-  apply_mod_cast exists_rat_pow_btwn_rat_aux hn x y <;> assumption
-
-/-- There is a rational power between any two positive elements of an archimedean ordered field. -/
-theorem exists_rat_pow_btwn {α : Type*} [LinearOrderedField α] [Archimedean α] (hn : n ≠ 0)
-    {x y : α} (h : x < y) (hy : 0 < y) : ∃ q : ℚ, 0 < q ∧ x < (q : α) ^ n ∧ (q : α) ^ n < y := by
-  obtain ⟨q₂, hx₂, hy₂⟩ := exists_rat_btwn (max_lt h hy)
-  obtain ⟨q₁, hx₁, hq₁₂⟩ := exists_rat_btwn hx₂
-  have : (0 : α) < q₂ := (le_max_right _ _).trans_lt hx₂
-  norm_cast at hq₁₂ this
-  obtain ⟨q, hq, hq₁, hq₂⟩ := exists_rat_pow_btwn_rat hn hq₁₂ this
-  refine ⟨q, hq, (le_max_left _ _).trans_lt <| hx₁.trans ?_, hy₂.trans' ?_⟩ <;> assumption_mod_cast
-
 end Real
 
 namespace Complex

--- a/Mathlib/Data/Real/CompleteField.lean
+++ b/Mathlib/Data/Real/CompleteField.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2024 Alex J. Best. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex J. Best
+-/
+import Mathlib.Algebra.Order.CompleteField
+import Mathlib.Data.Real.Sqrt
+
+/-!
+# The reals are a conditionally complete linearly ordered field
+-/
+
+/-- The reals are a conditionally complete linearly ordered field. -/
+noncomputable instance : ConditionallyCompleteLinearOrderedField ℝ :=
+  { (inferInstance : LinearOrderedField ℝ),
+    (inferInstance : ConditionallyCompleteLinearOrder ℝ) with }
+
+/-- There exists no nontrivial ring homomorphism `ℝ →+* ℝ`. -/
+instance Real.RingHom.unique : Unique (ℝ →+* ℝ) where
+  default := RingHom.id ℝ
+  uniq f := congr_arg OrderRingHom.toRingHom (@Subsingleton.elim (ℝ →+*o ℝ) _
+      ⟨f, ringHom_monotone (fun r hr => ⟨√r, sq_sqrt hr⟩) f⟩ default)


### PR DESCRIPTION
Also avoid one import of `Analysis/` in `Algebra/`.

Co-authored-by: Junyan Xu <junyanxumath@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
