### PR TITLE
[Merged by Bors] - chore(Combinatorics/Enumerative/Partition): auto-derive DecidableEq

### DIFF
--- a/Mathlib/Combinatorics/Enumerative/Partition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition.lean
@@ -54,14 +54,9 @@ structure Partition (n : ℕ) where
   parts_pos : ∀ {i}, i ∈ parts → 0 < i
   /-- proof that the `parts` sum to `n`-/
   parts_sum : parts.sum = n
-  -- Porting note: chokes on `parts_pos`
-  --deriving DecidableEq
+deriving DecidableEq
 
 namespace Partition
-
--- TODO: This should be automatically derived, see https://github.com/leanprover/lean4/issues/2914
-instance decidableEqPartition {n : ℕ} : DecidableEq (Partition n) :=
-  fun _ _ => decidable_of_iff' _ Partition.ext_iff
 
 /-- A composition induces a partition (just convert the list to a multiset). -/
 @[simps]

--- a/Mathlib/Combinatorics/Enumerative/Partition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition.lean
@@ -58,6 +58,10 @@ deriving DecidableEq
 
 namespace Partition
 
+@[deprecated "Partition now derives an instance of DecidableEq." (since := "2024-12-28")]
+instance decidableEqPartition {n : ℕ} : DecidableEq (Partition n) :=
+  fun _ _ => decidable_of_iff' _ Partition.ext_iff
+
 /-- A composition induces a partition (just convert the list to a multiset). -/
 @[simps]
 def ofComposition (n : ℕ) (c : Composition n) : Partition n where


### PR DESCRIPTION
Original bug fixed in https://github.com/leanprover/lean4/pull/2918.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
