### PR TITLE
[Merged by Bors] - feat(Algebra/Group): Units in pi types

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -302,6 +302,7 @@ import Mathlib.Algebra.Group.Opposite
 import Mathlib.Algebra.Group.PNatPowAssoc
 import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Group.Pi.Lemmas
+import Mathlib.Algebra.Group.Pi.Units
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 import Mathlib.Algebra.Group.Pointwise.Finset.Interval
 import Mathlib.Algebra.Group.Pointwise.Set.Basic

--- a/Mathlib/Algebra/Group/Pi/Units.lean
+++ b/Mathlib/Algebra/Group/Pi/Units.lean
@@ -14,7 +14,7 @@ variable {ι : Type*} {M : ι → Type*} [∀ i, Monoid (M i)] {x : Π i, M i}
 
 open Units in
 /-- The monoid equivalence between units of a product,
-  and the product of the units of each monoid. -/
+and the product of the units of each monoid. -/
 @[to_additive (attr := simps)
   "The additive-monoid equivalence between (additive) units of a product,
   and the product of the (additive) units of each monoid."]

--- a/Mathlib/Algebra/Group/Pi/Units.lean
+++ b/Mathlib/Algebra/Group/Pi/Units.lean
@@ -10,7 +10,7 @@ import Mathlib.Util.Delaborators
 
 /-! # Units in pi types -/
 
-variable {ι} {M : ι → Type*} [∀ i, Monoid (M i)] {x : Π i, M i}
+variable {ι : Type*} {M : ι → Type*} [∀ i, Monoid (M i)] {x : Π i, M i}
 
 open Units in
 /-- The monoid equivalence between units of a product,

--- a/Mathlib/Algebra/Group/Pi/Units.lean
+++ b/Mathlib/Algebra/Group/Pi/Units.lean
@@ -12,10 +12,13 @@ import Mathlib.Util.Delaborators
 
 variable {ι} {M : ι → Type*} [∀ i, Monoid (M i)] {x : Π i, M i}
 
-/-- The units of a product is isomorpic to the product of the units. -/
+open Units in
+/-- The monoid equivalence between units of a product,
+  and the product of the units of each monoid. -/
 @[to_additive (attr := simps)
-  "The (additive) units of a product is isomorpic to the product of the (additive) units."]
-def Units.piEquiv : (Π i, M i)ˣ ≃* Π i, (M i)ˣ where
+  "The additive-monoid equivalence between (additive) units of a product,
+  and the product of the (additive) units of each monoid."]
+def MulEquiv.piUnits : (Π i, M i)ˣ ≃* Π i, (M i)ˣ where
   toFun f i := ⟨f.val i, f.inv i, congr_fun f.val_inv i, congr_fun f.inv_val i⟩
   invFun f := ⟨(val <| f ·), (inv <| f ·), funext (val_inv <| f ·), funext (inv_val <| f ·)⟩
   left_inv _ := rfl
@@ -23,14 +26,14 @@ def Units.piEquiv : (Π i, M i)ˣ ≃* Π i, (M i)ˣ where
   map_mul' _ _ := rfl
 
 @[to_additive]
-lemma IsUnit.pi_iff :
+lemma Pi.isUnit_iff :
     IsUnit x ↔ ∀ i, IsUnit (x i) := by
   simp_rw [isUnit_iff_exists, funext_iff, ← forall_and]
   exact Classical.skolem (p := fun i y ↦ x i * y = 1 ∧ y * x i = 1).symm
 
 @[to_additive]
-alias ⟨IsUnit.apply, _⟩ := IsUnit.pi_iff
+alias ⟨IsUnit.apply, _⟩ := Pi.isUnit_iff
 
 @[to_additive]
 lemma IsUnit.val_inv_apply (hx : IsUnit x) (i) : (hx.unit⁻¹).1 i = (hx.apply i).unit⁻¹ := by
-  rw [← Units.inv_eq_val_inv, ← Units.val_inv_piEquiv_apply]; congr; ext; rfl
+  rw [← Units.inv_eq_val_inv, ← MulEquiv.val_inv_piUnits_apply]; congr; ext; rfl

--- a/Mathlib/Algebra/Group/Pi/Units.lean
+++ b/Mathlib/Algebra/Group/Pi/Units.lean
@@ -35,5 +35,5 @@ lemma Pi.isUnit_iff :
 alias ⟨IsUnit.apply, _⟩ := Pi.isUnit_iff
 
 @[to_additive]
-lemma IsUnit.val_inv_apply (hx : IsUnit x) (i) : (hx.unit⁻¹).1 i = (hx.apply i).unit⁻¹ := by
+lemma IsUnit.val_inv_apply (hx : IsUnit x) (i : ι) : (hx.unit⁻¹).1 i = (hx.apply i).unit⁻¹ := by
   rw [← Units.inv_eq_val_inv, ← MulEquiv.val_inv_piUnits_apply]; congr; ext; rfl

--- a/Mathlib/Algebra/Group/Pi/Units.lean
+++ b/Mathlib/Algebra/Group/Pi/Units.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2024 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang
+-/
+import Mathlib.Algebra.Group.Pi.Basic
+import Mathlib.Algebra.Group.Units.Defs
+import Mathlib.Algebra.Group.Equiv.Basic
+import Mathlib.Util.Delaborators
+
+/-! # Units in pi types -/
+
+variable {ι} {M : ι → Type*} [∀ i, Monoid (M i)] {x : Π i, M i}
+
+/-- The units of a product is isomorpic to the product of the units. -/
+@[to_additive (attr := simps)
+  "The (additive) units of a product is isomorpic to the product of the (additive) units."]
+def Units.piEquiv : (Π i, M i)ˣ ≃* Π i, (M i)ˣ where
+  toFun f i := ⟨f.val i, f.inv i, congr_fun f.val_inv i, congr_fun f.inv_val i⟩
+  invFun f := ⟨(val <| f ·), (inv <| f ·), funext (val_inv <| f ·), funext (inv_val <| f ·)⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_mul' _ _ := rfl
+
+@[to_additive]
+lemma IsUnit.pi_iff :
+    IsUnit x ↔ ∀ i, IsUnit (x i) := by
+  simp_rw [isUnit_iff_exists, funext_iff, ← forall_and]
+  exact Classical.skolem (p := fun i y ↦ x i * y = 1 ∧ y * x i = 1).symm
+
+@[to_additive]
+alias ⟨IsUnit.apply, _⟩ := IsUnit.pi_iff
+
+@[to_additive]
+lemma IsUnit.val_inv_apply (hx : IsUnit x) (i) : (hx.unit⁻¹).1 i = (hx.apply i).unit⁻¹ := by
+  rw [← Units.inv_eq_val_inv, ← Units.val_inv_piEquiv_apply]; congr; ext; rfl


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
