### PR TITLE
[Merged by Bors] - chore(MvPolynomial/Degrees): append `_le` in lemma names

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/CommRing.lean
+++ b/Mathlib/Algebra/MvPolynomial/CommRing.lean
@@ -87,9 +87,11 @@ section Degrees
 theorem degrees_neg (p : MvPolynomial σ R) : (-p).degrees = p.degrees := by
   rw [degrees, support_neg]; rfl
 
-theorem degrees_sub [DecidableEq σ] (p q : MvPolynomial σ R) :
-    (p - q).degrees ≤ p.degrees ⊔ q.degrees := by
-  simpa only [sub_eq_add_neg] using le_trans (degrees_add p (-q)) (by rw [degrees_neg])
+theorem degrees_sub_le [DecidableEq σ] {p q : MvPolynomial σ R} :
+    (p - q).degrees ≤ p.degrees ∪ q.degrees := by
+  simpa [degrees_def] using AddMonoidAlgebra.supDegree_sub_le
+
+@[deprecated (since := "2024-12-28")] alias degrees_sub := degrees_sub_le
 
 end Degrees
 

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -110,7 +110,7 @@ theorem degrees_zero : degrees (0 : MvPolynomial σ R) = 0 := by
 theorem degrees_one : degrees (1 : MvPolynomial σ R) = 0 :=
   degrees_C 1
 
-theorem degrees_add_le [DecidableEq σ] (p q : MvPolynomial σ R) :
+theorem degrees_add_le [DecidableEq σ] {p q : MvPolynomial σ R} :
     (p + q).degrees ≤ p.degrees ⊔ q.degrees := by
   simp_rw [degrees_def]; exact supDegree_add_le
 
@@ -141,8 +141,7 @@ theorem mem_degrees {p : MvPolynomial σ R} {i : σ} :
   classical
   simp only [degrees_def, Multiset.mem_sup, ← mem_support_iff, Finsupp.mem_toMultiset, exists_prop]
 
-theorem le_degrees_add {p q : MvPolynomial σ R} (h : Disjoint p.degrees q.degrees) :
-    p.degrees ≤ (p + q).degrees := by
+theorem le_degrees_add_left (h : Disjoint p.degrees q.degrees) : p.degrees ≤ (p + q).degrees := by
   classical
   apply Finset.sup_le
   intro d hd
@@ -159,14 +158,14 @@ theorem le_degrees_add {p q : MvPolynomial σ R} (h : Disjoint p.degrees q.degre
     refine ⟨j, ?_, j, ?_, rfl⟩
     all_goals rw [mem_degrees]; refine ⟨d, ?_, hj⟩; assumption
 
-theorem degrees_add_of_disjoint [DecidableEq σ] {p q : MvPolynomial σ R}
-    (h : Disjoint p.degrees q.degrees) : (p + q).degrees = p.degrees ∪ q.degrees := by
-  apply le_antisymm
-  · apply degrees_add_le
-  · apply Multiset.union_le
-    · apply le_degrees_add h
-    · rw [add_comm]
-      apply le_degrees_add h.symm
+@[deprecated (since := "2024-12-28")] alias le_degrees_add := le_degrees_add_left
+
+lemma le_degrees_add_right (h : Disjoint p.degrees q.degrees) : q.degrees ≤ (p + q).degrees := by
+  simpa [add_comm] using le_degrees_add_left h.symm
+
+theorem degrees_add_of_disjoint [DecidableEq σ] (h : Disjoint p.degrees q.degrees) :
+    (p + q).degrees = p.degrees ∪ q.degrees :=
+  degrees_add_le.antisymm <| Multiset.union_le (le_degrees_add_left h) (le_degrees_add_right h)
 
 theorem degrees_map [CommSemiring S] (p : MvPolynomial σ R) (f : R →+* S) :
     (map f p).degrees ⊆ p.degrees := by

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -167,13 +167,10 @@ theorem degrees_add_of_disjoint [DecidableEq σ] (h : Disjoint p.degrees q.degre
     (p + q).degrees = p.degrees ∪ q.degrees :=
   degrees_add_le.antisymm <| Multiset.union_le (le_degrees_add_left h) (le_degrees_add_right h)
 
-theorem degrees_map [CommSemiring S] (p : MvPolynomial σ R) (f : R →+* S) :
-    (map f p).degrees ⊆ p.degrees := by
-  classical
-  dsimp only [degrees]
-  apply Multiset.subset_of_le
-  apply Finset.sup_mono
-  apply MvPolynomial.support_map_subset
+lemma degrees_map_le [CommSemiring S] {f : R →+* S} : (map f p).degrees ≤ p.degrees := by
+  classical exact Finset.sup_mono <| support_map_subset ..
+
+@[deprecated (since := "2024-12-28")] alias degrees_map := degrees_map_le
 
 theorem degrees_rename (f : σ → τ) (φ : MvPolynomial σ R) :
     (rename f φ).degrees ⊆ φ.degrees.map f := by

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -110,25 +110,31 @@ theorem degrees_zero : degrees (0 : MvPolynomial σ R) = 0 := by
 theorem degrees_one : degrees (1 : MvPolynomial σ R) = 0 :=
   degrees_C 1
 
-theorem degrees_add [DecidableEq σ] (p q : MvPolynomial σ R) :
+theorem degrees_add_le [DecidableEq σ] (p q : MvPolynomial σ R) :
     (p + q).degrees ≤ p.degrees ⊔ q.degrees := by
   simp_rw [degrees_def]; exact supDegree_add_le
 
-theorem degrees_sum {ι : Type*} [DecidableEq σ] (s : Finset ι) (f : ι → MvPolynomial σ R) :
+theorem degrees_sum_le {ι : Type*} [DecidableEq σ] (s : Finset ι) (f : ι → MvPolynomial σ R) :
     (∑ i ∈ s, f i).degrees ≤ s.sup fun i => (f i).degrees := by
   simp_rw [degrees_def]; exact supDegree_sum_le
 
-theorem degrees_mul (p q : MvPolynomial σ R) : (p * q).degrees ≤ p.degrees + q.degrees := by
+theorem degrees_mul_le {p q : MvPolynomial σ R} : (p * q).degrees ≤ p.degrees + q.degrees := by
   classical
   simp_rw [degrees_def]
   exact supDegree_mul_le (map_add _)
 
-theorem degrees_prod {ι : Type*} (s : Finset ι) (f : ι → MvPolynomial σ R) :
+theorem degrees_prod_le {ι : Type*} {s : Finset ι} {f : ι → MvPolynomial σ R} :
     (∏ i ∈ s, f i).degrees ≤ ∑ i ∈ s, (f i).degrees := by
   classical exact supDegree_prod_le (map_zero _) (map_add _)
 
-theorem degrees_pow (p : MvPolynomial σ R) (n : ℕ) : (p ^ n).degrees ≤ n • p.degrees := by
-  simpa using degrees_prod (Finset.range n) fun _ ↦ p
+theorem degrees_pow_le {p : MvPolynomial σ R} {n : ℕ} : (p ^ n).degrees ≤ n • p.degrees := by
+  simpa using degrees_prod_le (s := .range n) (f := fun _ ↦ p)
+
+@[deprecated (since := "2024-12-28")] alias degrees_add := degrees_add_le
+@[deprecated (since := "2024-12-28")] alias degrees_sum := degrees_sum_le
+@[deprecated (since := "2024-12-28")] alias degrees_mul := degrees_mul_le
+@[deprecated (since := "2024-12-28")] alias degrees_prod := degrees_prod_le
+@[deprecated (since := "2024-12-28")] alias degrees_pow := degrees_pow_le
 
 theorem mem_degrees {p : MvPolynomial σ R} {i : σ} :
     i ∈ p.degrees ↔ ∃ d, p.coeff d ≠ 0 ∧ i ∈ d.support := by
@@ -156,7 +162,7 @@ theorem le_degrees_add {p q : MvPolynomial σ R} (h : Disjoint p.degrees q.degre
 theorem degrees_add_of_disjoint [DecidableEq σ] {p q : MvPolynomial σ R}
     (h : Disjoint p.degrees q.degrees) : (p + q).degrees = p.degrees ∪ q.degrees := by
   apply le_antisymm
-  · apply degrees_add
+  · apply degrees_add_le
   · apply Multiset.union_le
     · apply le_degrees_add h
     · rw [add_comm]
@@ -262,7 +268,7 @@ theorem degreeOf_mul_le (i : σ) (f g : MvPolynomial σ R) :
     degreeOf i (f * g) ≤ degreeOf i f + degreeOf i g := by
   classical
   simp only [degreeOf]
-  convert Multiset.count_le_of_le i (degrees_mul f g)
+  convert Multiset.count_le_of_le i degrees_mul_le
   rw [Multiset.count_add]
 
 theorem degreeOf_sum_le {ι : Type*} (i : σ) (s : Finset ι) (f : ι → MvPolynomial σ R) :
@@ -297,7 +303,7 @@ theorem degreeOf_mul_X_self (j : σ) (f : MvPolynomial σ R) :
     degreeOf j (f * X j) ≤ degreeOf j f + 1 := by
   classical
   simp only [degreeOf]
-  apply (Multiset.count_le_of_le j (degrees_mul f (X j))).trans
+  apply (Multiset.count_le_of_le j degrees_mul_le).trans
   simp only [Multiset.count_add, add_le_add_iff_left]
   convert Multiset.count_le_of_le j <| degrees_X' j
   rw [Multiset.count_singleton_self]
@@ -320,13 +326,13 @@ theorem degreeOf_mul_X_eq_degreeOf_add_one_iff (j : σ) (f : MvPolynomial σ R) 
 theorem degreeOf_C_mul_le (p : MvPolynomial σ R) (i : σ) (c : R) :
     (C c * p).degreeOf i ≤ p.degreeOf i := by
   unfold degreeOf
-  convert Multiset.count_le_of_le i <| degrees_mul (C c) p
+  convert Multiset.count_le_of_le i degrees_mul_le
   simp only [degrees_C, zero_add]
 
 theorem degreeOf_mul_C_le (p : MvPolynomial σ R) (i : σ) (c : R) :
     (p * C c).degreeOf i ≤ p.degreeOf i := by
   unfold degreeOf
-  convert Multiset.count_le_of_le i <| degrees_mul p (C c)
+  convert Multiset.count_le_of_le i degrees_mul_le
   simp only [degrees_C, add_zero]
 
 theorem degreeOf_rename_of_injective {p : MvPolynomial σ R} {f : σ → τ} (h : Function.Injective f)

--- a/Mathlib/Algebra/MvPolynomial/Variables.lean
+++ b/Mathlib/Algebra/MvPolynomial/Variables.lean
@@ -194,7 +194,8 @@ section Map
 variable [CommSemiring S] (f : R →+* S)
 variable (p)
 
-theorem vars_map : (map f p).vars ⊆ p.vars := by classical simp [vars_def, degrees_map]
+theorem vars_map : (map f p).vars ⊆ p.vars := by
+  classical simp [vars_def, Multiset.subset_of_le degrees_map_le]
 
 variable {f}
 

--- a/Mathlib/Algebra/MvPolynomial/Variables.lean
+++ b/Mathlib/Algebra/MvPolynomial/Variables.lean
@@ -110,7 +110,7 @@ section Mul
 
 theorem vars_mul [DecidableEq σ] (φ ψ : MvPolynomial σ R) : (φ * ψ).vars ⊆ φ.vars ∪ ψ.vars := by
   simp_rw [vars_def, ← Multiset.toFinset_add, Multiset.toFinset_subset]
-  exact Multiset.subset_of_le (degrees_mul φ ψ)
+  exact Multiset.subset_of_le degrees_mul_le
 
 @[simp]
 theorem vars_one : (1 : MvPolynomial σ R).vars = ∅ :=

--- a/Mathlib/Algebra/MvPolynomial/Variables.lean
+++ b/Mathlib/Algebra/MvPolynomial/Variables.lean
@@ -98,7 +98,7 @@ theorem vars_add_subset [DecidableEq σ] (p q : MvPolynomial σ R) :
     (p + q).vars ⊆ p.vars ∪ q.vars := by
   intro x hx
   simp only [vars_def, Finset.mem_union, Multiset.mem_toFinset] at hx ⊢
-  simpa using Multiset.mem_of_le (degrees_add _ _) hx
+  simpa using Multiset.mem_of_le degrees_add_le hx
 
 theorem vars_add_of_disjoint [DecidableEq σ] (h : Disjoint p.vars q.vars) :
     (p + q).vars = p.vars ∪ q.vars := by

--- a/Mathlib/FieldTheory/Finite/Polynomial.lean
+++ b/Mathlib/FieldTheory/Finite/Polynomial.lean
@@ -71,13 +71,12 @@ theorem eval_indicator_apply_eq_one (a : σ → K) : eval a (indicator a) = 1 :=
 theorem degrees_indicator (c : σ → K) :
     degrees (indicator c) ≤ ∑ s : σ, (Fintype.card K - 1) • {s} := by
   rw [indicator]
-  refine le_trans (degrees_prod _ _) (Finset.sum_le_sum fun s _ => ?_)
   classical
-  refine le_trans (degrees_sub _ _) ?_
-  rw [degrees_one, ← bot_eq_zero, bot_sup_eq]
-  refine le_trans (degrees_pow _ _) (nsmul_le_nsmul_right ?_ _)
-  refine le_trans (degrees_sub _ _) ?_
-  rw [degrees_C, ← bot_eq_zero, sup_bot_eq]
+  refine degrees_prod_le.trans <| Finset.sum_le_sum fun s _ ↦ degrees_sub_le.trans ?_
+  rw [degrees_one, Multiset.zero_union]
+  refine le_trans degrees_pow_le (nsmul_le_nsmul_right ?_ _)
+  refine degrees_sub_le.trans ?_
+  rw [degrees_C, Multiset.union_zero]
   exact degrees_X' _
 
 theorem indicator_mem_restrictDegree (c : σ → K) :


### PR DESCRIPTION
The current names are incorrect.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
