### PR TITLE
[Merged by Bors] - feat: quotienting out a polynomial in a family doesn't change the span

### DIFF
--- a/Mathlib/Algebra/Polynomial/CoeffMem.lean
+++ b/Mathlib/Algebra/Polynomial/CoeffMem.lean
@@ -17,8 +17,6 @@ Precisely, we show that each summand needs at most one coefficient of `p` and `d
 of `q`.
 -/
 
-open Function
-
 namespace Polynomial
 variable {ι R S : Type*} [CommRing R] [Ring S] [Algebra R S]
 
@@ -104,20 +102,12 @@ lemma coeff_divByMonic_mem_pow_natDegree_mul (p q : S[X])
     gcongr <;> exact sup_le (by simpa) (by simpa [Submodule.span_le, Set.range_subset_iff])
   · simp
 
-open Ideal in
-lemma idealSpan_range_update_divByMonic [DecidableEq ι] (v : ι → R[X]) {i j : ι} (hij : i ≠ j)
-    (hi : (v i).Monic) :
-    span (Set.range (Function.update v j (v j %ₘ v i))) = span (Set.range v) := by
-  refine le_antisymm ?_ ?_ <;> simp only [span_le, Set.range_subset_iff, SetLike.mem_coe] <;>
-    intro k <;> obtain rfl | hjk := eq_or_ne j k
-  · rw [update_same, modByMonic_eq_sub_mul_div (v j) hi]
-    exact sub_mem (subset_span ⟨j, rfl⟩) <| mul_mem_right _ _ <| subset_span ⟨i, rfl⟩
-  · exact subset_span ⟨k, (update_noteq (.symm hjk) ..).symm⟩
-  · nth_rw 2 [← modByMonic_add_div (v j) hi]
-    apply add_mem (subset_span ?_) (mul_mem_right _ _ (subset_span ?_))
-    · exact ⟨j, update_same ..⟩
-    · exact ⟨i, update_noteq hij ..⟩
-  · exact subset_span ⟨k, update_noteq (.symm hjk) ..⟩
+variable [DecidableEq ι] {i j : ι}
 
+open Function Ideal in
+lemma idealSpan_range_update_divByMonic (hij : i ≠ j) (v : ι → R[X]) (hi : (v i).Monic) :
+    span (Set.range (Function.update v j (v j %ₘ v i))) = span (Set.range v) := by
+  rw [modByMonic_eq_sub_mul_div _ hi, mul_comm, ← smul_eq_mul, Ideal.span, Ideal.span,
+    Submodule.span_range_update_sub_smul hij]
 
 end Polynomial

--- a/Mathlib/Algebra/Polynomial/CoeffMem.lean
+++ b/Mathlib/Algebra/Polynomial/CoeffMem.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies, Andrew Yang
 -/
 import Mathlib.Algebra.Algebra.Operations
 import Mathlib.Algebra.Polynomial.Div
+import Mathlib.RingTheory.Ideal.Span
 
 /-!
 # Bounding the coefficients of the quotient and remainder of polynomials
@@ -16,8 +17,10 @@ Precisely, we show that each summand needs at most one coefficient of `p` and `d
 of `q`.
 -/
 
+open Function
+
 namespace Polynomial
-variable {R S : Type*} [CommRing R] [Ring S] [Algebra R S]
+variable {ι R S : Type*} [CommRing R] [Ring S] [Algebra R S]
 
 local notation "deg("p")" => natDegree p
 local notation3 "coeffs("p")" => Set.range (coeff p)
@@ -100,5 +103,21 @@ lemma coeff_divByMonic_mem_pow_natDegree_mul (p q : S[X])
   · refine SetLike.le_def.mp ?_ (coeff_divModByMonicAux_mem_span_pow_mul_span (R := R) p q H i).1
     gcongr <;> exact sup_le (by simpa) (by simpa [Submodule.span_le, Set.range_subset_iff])
   · simp
+
+open Ideal in
+lemma idealSpan_range_update_divByMonic [DecidableEq ι] (v : ι → R[X]) {i j : ι} (hij : i ≠ j)
+    (hi : (v i).Monic) :
+    span (Set.range (Function.update v j (v j %ₘ v i))) = span (Set.range v) := by
+  refine le_antisymm ?_ ?_ <;> simp only [span_le, Set.range_subset_iff, SetLike.mem_coe] <;>
+    intro k <;> obtain rfl | hjk := eq_or_ne j k
+  · rw [update_same, modByMonic_eq_sub_mul_div (v j) hi]
+    exact sub_mem (subset_span ⟨j, rfl⟩) <| mul_mem_right _ _ <| subset_span ⟨i, rfl⟩
+  · exact subset_span ⟨k, (update_noteq (.symm hjk) ..).symm⟩
+  · nth_rw 2 [← modByMonic_add_div (v j) hi]
+    apply add_mem (subset_span ?_) (mul_mem_right _ _ (subset_span ?_))
+    · exact ⟨j, update_same ..⟩
+    · exact ⟨i, update_noteq hij ..⟩
+  · exact subset_span ⟨k, update_noteq (.symm hjk) ..⟩
+
 
 end Polynomial

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -358,12 +358,6 @@ theorem sup_toAddSubmonoid : (p ⊔ p').toAddSubmonoid = p.toAddSubmonoid ⊔ p'
   rw [mem_toAddSubmonoid, mem_sup, AddSubmonoid.mem_sup]
   rfl
 
-theorem sup_toAddSubgroup {R M : Type*} [Ring R] [AddCommGroup M] [Module R M]
-    (p p' : Submodule R M) : (p ⊔ p').toAddSubgroup = p.toAddSubgroup ⊔ p'.toAddSubgroup := by
-  ext x
-  rw [mem_toAddSubgroup, mem_sup, AddSubgroup.mem_sup]
-  rfl
-
 end
 
 theorem mem_span_singleton_self (x : M) : x ∈ R ∙ x :=
@@ -432,6 +426,7 @@ theorem span_insert (x) (s : Set M) : span R (insert x s) = (R ∙ x) ⊔ span R
 
 theorem span_insert_eq_span (h : x ∈ span R s) : span R (insert x s) = span R s :=
   span_eq_of_le _ (Set.insert_subset_iff.mpr ⟨h, subset_span⟩) (span_mono <| subset_insert _ _)
+
 
 theorem span_span : span R (span R s : Set M) = span R s :=
   span_eq _
@@ -521,7 +516,13 @@ end AddCommMonoid
 
 section AddCommGroup
 
-variable [Ring R] [AddCommGroup M] [Module R M]
+variable [Ring R] [AddCommGroup M] [Module R M] {ι : Type*} [DecidableEq ι] {i j : ι}
+
+lemma sup_toAddSubgroup (p p' : Submodule R M) :
+    (p ⊔ p').toAddSubgroup = p.toAddSubgroup ⊔ p'.toAddSubgroup := by
+  ext x
+  rw [mem_toAddSubgroup, mem_sup, AddSubgroup.mem_sup]
+  rfl
 
 theorem mem_span_insert' {x y} {s : Set M} :
     x ∈ span R (insert y s) ↔ ∃ a : R, x + a • y ∈ span R s := by
@@ -530,6 +531,22 @@ theorem mem_span_insert' {x y} {s : Set M} :
     exact ⟨-a, by simp [hz, add_assoc]⟩
   · rintro ⟨a, h⟩
     exact ⟨-a, _, h, by simp [add_comm, add_left_comm]⟩
+
+lemma span_range_update_add_smul (hij : i ≠ j) (v : ι → M) (r : R) :
+    span R (Set.range (Function.update v j (v j + r • v i))) = span R (Set.range v) := by
+  refine le_antisymm ?_ ?_ <;> simp only [span_le, Set.range_subset_iff, SetLike.mem_coe] <;>
+    intro k <;> obtain rfl | hjk := eq_or_ne j k
+  · rw [update_same]
+    exact add_mem (subset_span ⟨j, rfl⟩) <| smul_mem _ _ <| subset_span ⟨i, rfl⟩
+  · exact subset_span ⟨k, (update_noteq hjk.symm ..).symm⟩
+  · nth_rw 2 [← add_sub_cancel_right (v j) (r • v i)]
+    exact sub_mem (subset_span ⟨j, update_same ..⟩)
+      (smul_mem _ _ (subset_span ⟨i, update_noteq hij ..⟩))
+  · exact subset_span ⟨k, update_noteq hjk.symm ..⟩
+
+lemma span_range_update_sub_smul (hij : i ≠ j) (v : ι → M) (r : R) :
+    span R (Set.range (Function.update v j (v j - r • v i))) = span R (Set.range v) := by
+  rw [sub_eq_add_neg, ← neg_smul, span_range_update_add_smul hij]
 
 end AddCommGroup
 

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -427,7 +427,6 @@ theorem span_insert (x) (s : Set M) : span R (insert x s) = (R ∙ x) ⊔ span R
 theorem span_insert_eq_span (h : x ∈ span R s) : span R (insert x s) = span R s :=
   span_eq_of_le _ (Set.insert_subset_iff.mpr ⟨h, subset_span⟩) (span_mono <| subset_insert _ _)
 
-
 theorem span_span : span R (span R s : Set M) = span R s :=
   span_eq _
 
@@ -536,13 +535,13 @@ lemma span_range_update_add_smul (hij : i ≠ j) (v : ι → M) (r : R) :
     span R (Set.range (Function.update v j (v j + r • v i))) = span R (Set.range v) := by
   refine le_antisymm ?_ ?_ <;> simp only [span_le, Set.range_subset_iff, SetLike.mem_coe] <;>
     intro k <;> obtain rfl | hjk := eq_or_ne j k
-  · rw [update_same]
+  · rw [update_self]
     exact add_mem (subset_span ⟨j, rfl⟩) <| smul_mem _ _ <| subset_span ⟨i, rfl⟩
-  · exact subset_span ⟨k, (update_noteq hjk.symm ..).symm⟩
+  · exact subset_span ⟨k, (update_of_ne hjk.symm ..).symm⟩
   · nth_rw 2 [← add_sub_cancel_right (v j) (r • v i)]
-    exact sub_mem (subset_span ⟨j, update_same ..⟩)
-      (smul_mem _ _ (subset_span ⟨i, update_noteq hij ..⟩))
-  · exact subset_span ⟨k, update_noteq hjk.symm ..⟩
+    exact sub_mem (subset_span ⟨j, update_self ..⟩)
+      (smul_mem _ _ (subset_span ⟨i, update_of_ne hij ..⟩))
+  · exact subset_span ⟨k, update_of_ne hjk.symm ..⟩
 
 lemma span_range_update_sub_smul (hij : i ≠ j) (v : ι → M) (r : R) :
     span R (Set.range (Function.update v j (v j - r • v i))) = span R (Set.range v) := by


### PR DESCRIPTION
From GrowthInGroups (LeanCamCombi)

Co-authored-by: Andrew Yang


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
