### PR TITLE
[Merged by Bors] - feat(NumberTheory/Divisors): proving that n has at most n divisors.

### DIFF
--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -137,7 +137,7 @@ theorem card_divisors_le_self (n : ℕ) : #n.divisors ≤ n := calc
   _ ≤ #(Ico 1 (n + 1)) := by
     apply card_le_card
     simp only [divisors, filter_subset]
-  _ = n := by simp
+  _ = n := by rw [card_Ico, add_tsub_cancel_right]
 
 theorem divisors_subset_properDivisors {m : ℕ} (hzero : n ≠ 0) (h : m ∣ n) (hdiff : m ≠ n) :
     divisors m ⊆ properDivisors n := by

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -133,6 +133,12 @@ theorem divisor_le {m : ℕ} : n ∈ divisors m → n ≤ m := by
 theorem divisors_subset_of_dvd {m : ℕ} (hzero : n ≠ 0) (h : m ∣ n) : divisors m ⊆ divisors n :=
   Finset.subset_iff.2 fun _x hx => Nat.mem_divisors.mpr ⟨(Nat.mem_divisors.mp hx).1.trans h, hzero⟩
 
+theorem card_divisors_le_self (n : ℕ) : #n.divisors ≤ n := calc
+  _ ≤ #(Ico 1 (n + 1)) := by
+    apply card_le_card
+    simp only [divisors, filter_subset]
+  _ = n := by simp
+
 theorem divisors_subset_properDivisors {m : ℕ} (hzero : n ≠ 0) (h : m ∣ n) (hdiff : m ≠ n) :
     divisors m ⊆ properDivisors n := by
   apply Finset.subset_iff.2


### PR DESCRIPTION
This PR contains a proof that for some `n : ℕ`, `n.divisors` has cardinality at most `n`. It is useful in a number of scenarios, for instance when one wishes to construct upper-bounds for sums over the set of divisors of `n`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
