### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Pretriangulated/Opposite): split CategoryTheory.Triangulated.Opposite into three files

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2205,7 +2205,9 @@ import Mathlib.CategoryTheory.Thin
 import Mathlib.CategoryTheory.Triangulated.Basic
 import Mathlib.CategoryTheory.Triangulated.Functor
 import Mathlib.CategoryTheory.Triangulated.HomologicalFunctor
-import Mathlib.CategoryTheory.Triangulated.Opposite
+import Mathlib.CategoryTheory.Triangulated.Opposite.Basic
+import Mathlib.CategoryTheory.Triangulated.Opposite.Pretriangulated
+import Mathlib.CategoryTheory.Triangulated.Opposite.Triangle
 import Mathlib.CategoryTheory.Triangulated.Pretriangulated
 import Mathlib.CategoryTheory.Triangulated.Rotate
 import Mathlib.CategoryTheory.Triangulated.Subcategory

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExactSequences.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExactSequences.lean
@@ -3,9 +3,7 @@ Copyright (c) 2024 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-import Mathlib.Algebra.Exact
 import Mathlib.Algebra.Homology.DerivedCategory.Ext.ExtClass
-import Mathlib.Algebra.Homology.ShortComplex.Ab
 import Mathlib.CategoryTheory.Triangulated.Yoneda
 
 /-!

--- a/Mathlib/CategoryTheory/Shift/ShiftedHomOpposite.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftedHomOpposite.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 
-import Mathlib.CategoryTheory.Triangulated.Opposite
+import Mathlib.CategoryTheory.Triangulated.Opposite.Basic
 import Mathlib.CategoryTheory.Shift.ShiftedHom
 
 /-! Shifted morphisms in the opposite category

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Basic.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Basic.lean
@@ -3,18 +3,17 @@ Copyright (c) 2023 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
+import Mathlib.CategoryTheory.Limits.Shapes.RegularMono
 import Mathlib.CategoryTheory.Shift.Opposite
 import Mathlib.CategoryTheory.Shift.Pullback
-import Mathlib.CategoryTheory.Triangulated.HomologicalFunctor
-import Mathlib.Tactic.Linarith
 
 /-!
-# The (pre)triangulated structure on the opposite category
+# The shift on the opposite category of a pretriangulated category
 
-In this file, we shall construct the (pre)triangulated structure
-on the opposite category `Cᵒᵖ` of a (pre)triangulated category `C`.
-
-The shift on `Cᵒᵖ` is obtained by combining the constructions in the files
+Let `C` be a (pre)triangulated category. We already have a shift on `Cᵒᵖ` given
+by `CategoryTheory.Shift.Opposite`, but this is not the shift that we want to
+make `Cᵒᵖ` into a (pre)triangulated category.
+The correct shift on `Cᵒᵖ` is obtained by combining the constructions in the files
 `CategoryTheory.Shift.Opposite` and `CategoryTheory.Shift.Pullback`.
 When the user opens `CategoryTheory.Pretriangulated.Opposite`, the
 category `Cᵒᵖ` is equipped with the shift by `ℤ` such that
@@ -27,12 +26,6 @@ where `hnm : n + m = 0`.
 Some compatibilities between the shifts on `C` and `Cᵒᵖ` are also expressed through
 the equivalence of categories `opShiftFunctorEquivalence C n : Cᵒᵖ ≌ Cᵒᵖ` whose
 functor is `shiftFunctor Cᵒᵖ n` and whose inverse functor is `(shiftFunctor C n).op`.
-
-If `X ⟶ Y ⟶ Z ⟶ X⟦1⟧` is a distinguished triangle in `C`, then the triangle
-`op Z ⟶ op Y ⟶ op X ⟶ (op Z)⟦1⟧` that is deduced *without introducing signs*
-shall be a distinguished triangle in `Cᵒᵖ`. This is equivalent to the definition
-in [Verdiers's thesis, p. 96][verdier1996] which would require that the triangle
-`(op X)⟦-1⟧ ⟶ op Z ⟶ op Y ⟶ op X` (without signs) is *antidistinguished*.
 
 ## References
 * [Jean-Louis Verdier, *Des catégories dérivées des catégories abéliennes*][verdier1996]
@@ -248,239 +241,6 @@ lemma opShiftFunctorEquivalence_counitIso_hom_app_shift (X : Cᵒᵖ) (n : ℤ) 
       ((opShiftFunctorEquivalence C n).unitIso.inv.app X)⟦n⟧' :=
   (opShiftFunctorEquivalence C n).counit_app_functor X
 
-variable (C)
-
-namespace TriangleOpEquivalence
-
-/-- The functor which sends a triangle `X ⟶ Y ⟶ Z ⟶ X⟦1⟧` in `C` to the triangle
-`op Z ⟶ op Y ⟶ op X ⟶ (op Z)⟦1⟧` in `Cᵒᵖ` (without introducing signs). -/
-@[simps]
-noncomputable def functor : (Triangle C)ᵒᵖ ⥤ Triangle Cᵒᵖ where
-  obj T := Triangle.mk T.unop.mor₂.op T.unop.mor₁.op
-      ((opShiftFunctorEquivalence C 1).counitIso.inv.app (Opposite.op T.unop.obj₁) ≫
-        T.unop.mor₃.op⟦(1 : ℤ)⟧')
-  map {T₁ T₂} φ :=
-    { hom₁ := φ.unop.hom₃.op
-      hom₂ := φ.unop.hom₂.op
-      hom₃ := φ.unop.hom₁.op
-      comm₁ := Quiver.Hom.unop_inj φ.unop.comm₂.symm
-      comm₂ := Quiver.Hom.unop_inj φ.unop.comm₁.symm
-      comm₃ := by
-        dsimp
-        rw [assoc, ← Functor.map_comp, ← op_comp, ← φ.unop.comm₃, op_comp, Functor.map_comp,
-          opShiftFunctorEquivalence_counitIso_inv_naturality_assoc]
-        rfl }
-
-/-- The functor which sends a triangle `X ⟶ Y ⟶ Z ⟶ X⟦1⟧` in `Cᵒᵖ` to the triangle
-`Z.unop ⟶ Y.unop ⟶ X.unop ⟶ Z.unop⟦1⟧` in `C` (without introducing signs). -/
-@[simps]
-noncomputable def inverse : Triangle Cᵒᵖ ⥤ (Triangle C)ᵒᵖ where
-  obj T := Opposite.op (Triangle.mk T.mor₂.unop T.mor₁.unop
-      (((opShiftFunctorEquivalence C 1).unitIso.inv.app T.obj₁).unop ≫ T.mor₃.unop⟦(1 : ℤ)⟧'))
-  map {T₁ T₂} φ := Quiver.Hom.op
-    { hom₁ := φ.hom₃.unop
-      hom₂ := φ.hom₂.unop
-      hom₃ := φ.hom₁.unop
-      comm₁ := Quiver.Hom.op_inj φ.comm₂.symm
-      comm₂ := Quiver.Hom.op_inj φ.comm₁.symm
-      comm₃ := Quiver.Hom.op_inj (by
-        dsimp
-        rw [assoc, ← opShiftFunctorEquivalence_unitIso_inv_naturality,
-          ← op_comp_assoc, ← Functor.map_comp, ← unop_comp, ← φ.comm₃,
-          unop_comp, Functor.map_comp, op_comp, assoc]) }
-
-/-- The unit isomorphism of the
-equivalence `triangleOpEquivalence C : (Triangle C)ᵒᵖ ≌ Triangle Cᵒᵖ` . -/
-@[simps!]
-noncomputable def unitIso : 𝟭 _ ≅ functor C ⋙ inverse C :=
-  NatIso.ofComponents (fun T => Iso.op
-    (Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (Iso.refl _) (by aesop_cat) (by aesop_cat)
-      (Quiver.Hom.op_inj
-        (by simp [shift_unop_opShiftFunctorEquivalence_counitIso_inv_app]))))
-    (fun {T₁ T₂} f => Quiver.Hom.unop_inj (by aesop_cat))
-
-/-- The counit isomorphism of the
-equivalence `triangleOpEquivalence C : (Triangle C)ᵒᵖ ≌ Triangle Cᵒᵖ` . -/
-@[simps!]
-noncomputable def counitIso : inverse C ⋙ functor C ≅ 𝟭 _ :=
-  NatIso.ofComponents (fun T => by
-    refine Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (Iso.refl _) ?_ ?_ ?_
-    · aesop_cat
-    · aesop_cat
-    · dsimp
-      rw [Functor.map_id, comp_id, id_comp, Functor.map_comp,
-        ← opShiftFunctorEquivalence_counitIso_inv_naturality_assoc,
-        opShiftFunctorEquivalence_counitIso_inv_app_shift, ← Functor.map_comp,
-        Iso.hom_inv_id_app, Functor.map_id]
-      simp only [Functor.id_obj, comp_id])
-    (by aesop_cat)
-
-end TriangleOpEquivalence
-
-/-- An anti-equivalence between the categories of triangles in `C` and in `Cᵒᵖ`.
-A triangle in `Cᵒᵖ` shall be distinguished iff it correspond to a distinguished
-triangle in `C` via this equivalence. -/
-@[simps]
-noncomputable def triangleOpEquivalence :
-    (Triangle C)ᵒᵖ ≌ Triangle Cᵒᵖ where
-  functor := TriangleOpEquivalence.functor C
-  inverse := TriangleOpEquivalence.inverse C
-  unitIso := TriangleOpEquivalence.unitIso C
-  counitIso := TriangleOpEquivalence.counitIso C
-
-variable [HasZeroObject C] [Preadditive C] [∀ (n : ℤ), (shiftFunctor C n).Additive]
-  [Pretriangulated C]
-
-namespace Opposite
-
-/-- A triangle in `Cᵒᵖ` shall be distinguished iff it corresponds to a distinguished
-triangle in `C` via the equivalence `triangleOpEquivalence C : (Triangle C)ᵒᵖ ≌ Triangle Cᵒᵖ`. -/
-def distinguishedTriangles : Set (Triangle Cᵒᵖ) :=
-  fun T => ((triangleOpEquivalence C).inverse.obj T).unop ∈ distTriang C
-
-variable {C}
-
-lemma mem_distinguishedTriangles_iff (T : Triangle Cᵒᵖ) :
-    T ∈ distinguishedTriangles C ↔
-      ((triangleOpEquivalence C).inverse.obj T).unop ∈ distTriang C := by
-  rfl
-
-lemma mem_distinguishedTriangles_iff' (T : Triangle Cᵒᵖ) :
-    T ∈ distinguishedTriangles C ↔
-      ∃ (T' : Triangle C) (_ : T' ∈ distTriang C),
-        Nonempty (T ≅ (triangleOpEquivalence C).functor.obj (Opposite.op T')) := by
-  rw [mem_distinguishedTriangles_iff]
-  constructor
-  · intro hT
-    exact ⟨_ ,hT, ⟨(triangleOpEquivalence C).counitIso.symm.app T⟩⟩
-  · rintro ⟨T', hT', ⟨e⟩⟩
-    refine isomorphic_distinguished _ hT' _ ?_
-    exact Iso.unop ((triangleOpEquivalence C).unitIso.app (Opposite.op T') ≪≫
-      (triangleOpEquivalence C).inverse.mapIso e.symm)
-
-lemma isomorphic_distinguished (T₁ : Triangle Cᵒᵖ)
-    (hT₁ : T₁ ∈ distinguishedTriangles C) (T₂ : Triangle Cᵒᵖ) (e : T₂ ≅ T₁) :
-    T₂ ∈ distinguishedTriangles C := by
-  simp only [mem_distinguishedTriangles_iff] at hT₁ ⊢
-  exact Pretriangulated.isomorphic_distinguished _ hT₁ _
-    ((triangleOpEquivalence C).inverse.mapIso e).unop.symm
-
-/-- Up to rotation, the contractible triangle `X ⟶ X ⟶ 0 ⟶ X⟦1⟧` for `X : Cᵒᵖ` corresponds
-to the contractible triangle for `X.unop` in `C`. -/
-@[simps!]
-noncomputable def contractibleTriangleIso (X : Cᵒᵖ) :
-    contractibleTriangle X ≅ (triangleOpEquivalence C).functor.obj
-      (Opposite.op (contractibleTriangle X.unop).invRotate) :=
-  Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _)
-    (IsZero.iso (isZero_zero _) (by
-      dsimp
-      rw [IsZero.iff_id_eq_zero]
-      change (𝟙 ((0 : C)⟦(-1 : ℤ)⟧)).op = 0
-      rw [← Functor.map_id, id_zero, Functor.map_zero, op_zero]))
-    (by aesop_cat) (by aesop_cat) (by aesop_cat)
-
-lemma contractible_distinguished (X : Cᵒᵖ) :
-    contractibleTriangle X ∈ distinguishedTriangles C := by
-  rw [mem_distinguishedTriangles_iff']
-  exact ⟨_, inv_rot_of_distTriang _ (Pretriangulated.contractible_distinguished X.unop),
-    ⟨contractibleTriangleIso X⟩⟩
-
-/-- Isomorphism expressing a compatibility of the equivalence `triangleOpEquivalence C`
-with the rotation of triangles. -/
-noncomputable def rotateTriangleOpEquivalenceInverseObjRotateUnopIso (T : Triangle Cᵒᵖ) :
-    ((triangleOpEquivalence C).inverse.obj T.rotate).unop.rotate ≅
-      ((triangleOpEquivalence C).inverse.obj T).unop :=
-  Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _)
-      (-((opShiftFunctorEquivalence C 1).unitIso.app T.obj₁).unop) (by simp)
-        (Quiver.Hom.op_inj (by aesop_cat)) (by aesop_cat)
-
-lemma rotate_distinguished_triangle (T : Triangle Cᵒᵖ) :
-    T ∈ distinguishedTriangles C ↔ T.rotate ∈ distinguishedTriangles C := by
-  simp only [mem_distinguishedTriangles_iff, Pretriangulated.rotate_distinguished_triangle
-    ((triangleOpEquivalence C).inverse.obj (T.rotate)).unop]
-  exact distinguished_iff_of_iso (rotateTriangleOpEquivalenceInverseObjRotateUnopIso T).symm
-
-lemma distinguished_cocone_triangle {X Y : Cᵒᵖ} (f : X ⟶ Y) :
-    ∃ (Z : Cᵒᵖ) (g : Y ⟶ Z) (h : Z ⟶ X⟦(1 : ℤ)⟧),
-      Triangle.mk f g h ∈ distinguishedTriangles C := by
-  obtain ⟨Z, g, h, H⟩ := Pretriangulated.distinguished_cocone_triangle₁ f.unop
-  refine ⟨_, g.op, (opShiftFunctorEquivalence C 1).counitIso.inv.app (Opposite.op Z) ≫
-    (shiftFunctor Cᵒᵖ (1 : ℤ)).map h.op, ?_⟩
-  simp only [mem_distinguishedTriangles_iff]
-  refine Pretriangulated.isomorphic_distinguished _ H _ ?_
-  exact Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (Iso.refl _) (by aesop_cat) (by aesop_cat)
-    (Quiver.Hom.op_inj (by simp [shift_unop_opShiftFunctorEquivalence_counitIso_inv_app]))
-
-lemma complete_distinguished_triangle_morphism (T₁ T₂ : Triangle Cᵒᵖ)
-    (hT₁ : T₁ ∈ distinguishedTriangles C) (hT₂ : T₂ ∈ distinguishedTriangles C)
-    (a : T₁.obj₁ ⟶ T₂.obj₁) (b : T₁.obj₂ ⟶ T₂.obj₂) (comm : T₁.mor₁ ≫ b = a ≫ T₂.mor₁) :
-    ∃ (c : T₁.obj₃ ⟶ T₂.obj₃), T₁.mor₂ ≫ c = b ≫ T₂.mor₂ ∧
-      T₁.mor₃ ≫ a⟦1⟧' = c ≫ T₂.mor₃ := by
-  rw [mem_distinguishedTriangles_iff] at hT₁ hT₂
-  obtain ⟨c, hc₁, hc₂⟩ :=
-    Pretriangulated.complete_distinguished_triangle_morphism₁ _ _ hT₂ hT₁
-      b.unop a.unop (Quiver.Hom.op_inj comm.symm)
-  dsimp at c hc₁ hc₂
-  replace hc₂ := ((opShiftFunctorEquivalence C 1).unitIso.hom.app T₂.obj₁).unop ≫= hc₂
-  dsimp at hc₂
-  simp only [assoc, Iso.unop_hom_inv_id_app_assoc] at hc₂
-  refine ⟨c.op, Quiver.Hom.unop_inj hc₁.symm, Quiver.Hom.unop_inj ?_⟩
-  apply (shiftFunctor C (1 : ℤ)).map_injective
-  rw [unop_comp, unop_comp, Functor.map_comp, Functor.map_comp,
-    Quiver.Hom.unop_op, hc₂, ← unop_comp_assoc, ← unop_comp_assoc,
-    ← opShiftFunctorEquivalence_unitIso_inv_naturality]
-  simp
-
-/-- The pretriangulated structure on the opposite category of
-a pretriangulated category. It is a scoped instance, so that we need to
-`open CategoryTheory.Pretriangulated.Opposite` in order to be able
-to use it: the reason is that it relies on the definition of the shift
-on the opposite category `Cᵒᵖ`, for which it is unclear whether it should
-be a global instance or not. -/
-scoped instance : Pretriangulated Cᵒᵖ where
-  distinguishedTriangles := distinguishedTriangles C
-  isomorphic_distinguished := isomorphic_distinguished
-  contractible_distinguished := contractible_distinguished
-  distinguished_cocone_triangle := distinguished_cocone_triangle
-  rotate_distinguished_triangle := rotate_distinguished_triangle
-  complete_distinguished_triangle_morphism := complete_distinguished_triangle_morphism
-
-end Opposite
-
-variable {C}
-
-lemma mem_distTriang_op_iff (T : Triangle Cᵒᵖ) :
-    (T ∈ distTriang Cᵒᵖ) ↔ ((triangleOpEquivalence C).inverse.obj T).unop ∈ distTriang C := by
-  rfl
-
-lemma mem_distTriang_op_iff' (T : Triangle Cᵒᵖ) :
-    (T ∈ distTriang Cᵒᵖ) ↔ ∃ (T' : Triangle C) (_ : T' ∈ distTriang C),
-      Nonempty (T ≅ (triangleOpEquivalence C).functor.obj (Opposite.op T')) :=
-  Opposite.mem_distinguishedTriangles_iff' T
-
-lemma op_distinguished (T : Triangle C) (hT : T ∈ distTriang C) :
-    ((triangleOpEquivalence C).functor.obj (Opposite.op T)) ∈ distTriang Cᵒᵖ := by
-  rw [mem_distTriang_op_iff']
-  exact ⟨T, hT, ⟨Iso.refl _⟩⟩
-
-lemma unop_distinguished (T : Triangle Cᵒᵖ) (hT : T ∈ distTriang Cᵒᵖ) :
-    ((triangleOpEquivalence C).inverse.obj T).unop ∈ distTriang C := hT
-
 end Pretriangulated
-
-namespace Functor
-
-open Pretriangulated.Opposite Pretriangulated
-
-variable {C}
-
-lemma map_distinguished_op_exact [HasShift C ℤ] [HasZeroObject C] [Preadditive C]
-    [∀ (n : ℤ), (shiftFunctor C n).Additive]
-    [Pretriangulated C]{A : Type*} [Category A] [Abelian A] (F : Cᵒᵖ ⥤ A)
-    [F.IsHomological] (T : Triangle C) (hT : T ∈ distTriang C) :
-    ((shortComplexOfDistTriangle T hT).op.map F).Exact :=
-  F.map_distinguished_exact _ (op_distinguished T hT)
-
-end Functor
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Pretriangulated.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Pretriangulated.lean
@@ -1,0 +1,195 @@
+/-
+Copyright (c) 2023 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Triangulated.Opposite.Triangle
+import Mathlib.CategoryTheory.Triangulated.HomologicalFunctor
+
+/-!
+# The (pre)triangulated structure on the opposite category
+
+In this file, we shall construct the (pre)triangulated structure
+on the opposite category `Cᵒᵖ` of a (pre)triangulated category `C`.
+
+The shift on `Cᵒᵖ` was constructed in ``CategoryTheory.Triangulated.Opposite.Basic`,
+and is such that shifting by `n : ℤ` on `Cᵒᵖ` corresponds to the shift by
+`-n` on `C`. In `CategoryTheory.Triangulated.Opposite.Triangle`, we constructed
+an equivalence `(Triangle C)ᵒᵖ ≌ Triangle Cᵒᵖ`, called
+`CategoryTheory.Pretriangulated.triangleOpEquivalence`.
+
+Here, we defined the notion of distinguished triangles in `Cᵒᵖ`, such that
+`triangleOpEquivalence` sends distinguished triangles in `C` to distinguished triangles
+in `Cᵒᵖ`. In other words, if `X ⟶ Y ⟶ Z ⟶ X⟦1⟧` is a distinguished triangle in `C`,
+then the triangle `op Z ⟶ op Y ⟶ op X ⟶ (op Z)⟦1⟧` that is deduced *without introducing signs*
+shall be a distinguished triangle in `Cᵒᵖ`. This is equivalent to the definition
+in [Verdiers's thesis, p. 96][verdier1996] which would require that the triangle
+`(op X)⟦-1⟧ ⟶ op Z ⟶ op Y ⟶ op X` (without signs) is *antidistinguished*.
+
+## References
+* [Jean-Louis Verdier, *Des catégories dérivées des catégories abéliennes*][verdier1996]
+
+-/
+
+namespace CategoryTheory
+
+open Category Limits Preadditive ZeroObject
+
+variable (C : Type*) [Category C] [HasShift C ℤ] [HasZeroObject C] [Preadditive C]
+  [∀ (n : ℤ), (shiftFunctor C n).Additive] [Pretriangulated C]
+
+namespace Pretriangulated
+
+open Opposite
+
+namespace Opposite
+
+/-- A triangle in `Cᵒᵖ` shall be distinguished iff it corresponds to a distinguished
+triangle in `C` via the equivalence `triangleOpEquivalence C : (Triangle C)ᵒᵖ ≌ Triangle Cᵒᵖ`. -/
+def distinguishedTriangles : Set (Triangle Cᵒᵖ) :=
+  fun T => ((triangleOpEquivalence C).inverse.obj T).unop ∈ distTriang C
+
+variable {C}
+
+lemma mem_distinguishedTriangles_iff (T : Triangle Cᵒᵖ) :
+    T ∈ distinguishedTriangles C ↔
+      ((triangleOpEquivalence C).inverse.obj T).unop ∈ distTriang C := by
+  rfl
+
+lemma mem_distinguishedTriangles_iff' (T : Triangle Cᵒᵖ) :
+    T ∈ distinguishedTriangles C ↔
+      ∃ (T' : Triangle C) (_ : T' ∈ distTriang C),
+        Nonempty (T ≅ (triangleOpEquivalence C).functor.obj (Opposite.op T')) := by
+  rw [mem_distinguishedTriangles_iff]
+  constructor
+  · intro hT
+    exact ⟨_ ,hT, ⟨(triangleOpEquivalence C).counitIso.symm.app T⟩⟩
+  · rintro ⟨T', hT', ⟨e⟩⟩
+    refine isomorphic_distinguished _ hT' _ ?_
+    exact Iso.unop ((triangleOpEquivalence C).unitIso.app (Opposite.op T') ≪≫
+      (triangleOpEquivalence C).inverse.mapIso e.symm)
+
+lemma isomorphic_distinguished (T₁ : Triangle Cᵒᵖ)
+    (hT₁ : T₁ ∈ distinguishedTriangles C) (T₂ : Triangle Cᵒᵖ) (e : T₂ ≅ T₁) :
+    T₂ ∈ distinguishedTriangles C := by
+  simp only [mem_distinguishedTriangles_iff] at hT₁ ⊢
+  exact Pretriangulated.isomorphic_distinguished _ hT₁ _
+    ((triangleOpEquivalence C).inverse.mapIso e).unop.symm
+
+/-- Up to rotation, the contractible triangle `X ⟶ X ⟶ 0 ⟶ X⟦1⟧` for `X : Cᵒᵖ` corresponds
+to the contractible triangle for `X.unop` in `C`. -/
+@[simps!]
+noncomputable def contractibleTriangleIso (X : Cᵒᵖ) :
+    contractibleTriangle X ≅ (triangleOpEquivalence C).functor.obj
+      (Opposite.op (contractibleTriangle X.unop).invRotate) :=
+  Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _)
+    (IsZero.iso (isZero_zero _) (by
+      dsimp
+      rw [IsZero.iff_id_eq_zero]
+      change (𝟙 ((0 : C)⟦(-1 : ℤ)⟧)).op = 0
+      rw [← Functor.map_id, id_zero, Functor.map_zero, op_zero]))
+    (by aesop_cat) (by aesop_cat) (by aesop_cat)
+
+lemma contractible_distinguished (X : Cᵒᵖ) :
+    contractibleTriangle X ∈ distinguishedTriangles C := by
+  rw [mem_distinguishedTriangles_iff']
+  exact ⟨_, inv_rot_of_distTriang _ (Pretriangulated.contractible_distinguished X.unop),
+    ⟨contractibleTriangleIso X⟩⟩
+
+/-- Isomorphism expressing a compatibility of the equivalence `triangleOpEquivalence C`
+with the rotation of triangles. -/
+noncomputable def rotateTriangleOpEquivalenceInverseObjRotateUnopIso (T : Triangle Cᵒᵖ) :
+    ((triangleOpEquivalence C).inverse.obj T.rotate).unop.rotate ≅
+      ((triangleOpEquivalence C).inverse.obj T).unop :=
+  Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _)
+      (-((opShiftFunctorEquivalence C 1).unitIso.app T.obj₁).unop) (by simp)
+        (Quiver.Hom.op_inj (by aesop_cat)) (by aesop_cat)
+
+lemma rotate_distinguished_triangle (T : Triangle Cᵒᵖ) :
+    T ∈ distinguishedTriangles C ↔ T.rotate ∈ distinguishedTriangles C := by
+  simp only [mem_distinguishedTriangles_iff, Pretriangulated.rotate_distinguished_triangle
+    ((triangleOpEquivalence C).inverse.obj (T.rotate)).unop]
+  exact distinguished_iff_of_iso (rotateTriangleOpEquivalenceInverseObjRotateUnopIso T).symm
+
+lemma distinguished_cocone_triangle {X Y : Cᵒᵖ} (f : X ⟶ Y) :
+    ∃ (Z : Cᵒᵖ) (g : Y ⟶ Z) (h : Z ⟶ X⟦(1 : ℤ)⟧),
+      Triangle.mk f g h ∈ distinguishedTriangles C := by
+  obtain ⟨Z, g, h, H⟩ := Pretriangulated.distinguished_cocone_triangle₁ f.unop
+  refine ⟨_, g.op, (opShiftFunctorEquivalence C 1).counitIso.inv.app (Opposite.op Z) ≫
+    (shiftFunctor Cᵒᵖ (1 : ℤ)).map h.op, ?_⟩
+  simp only [mem_distinguishedTriangles_iff]
+  refine Pretriangulated.isomorphic_distinguished _ H _ ?_
+  exact Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (Iso.refl _) (by aesop_cat) (by aesop_cat)
+    (Quiver.Hom.op_inj (by simp [shift_unop_opShiftFunctorEquivalence_counitIso_inv_app]))
+
+lemma complete_distinguished_triangle_morphism (T₁ T₂ : Triangle Cᵒᵖ)
+    (hT₁ : T₁ ∈ distinguishedTriangles C) (hT₂ : T₂ ∈ distinguishedTriangles C)
+    (a : T₁.obj₁ ⟶ T₂.obj₁) (b : T₁.obj₂ ⟶ T₂.obj₂) (comm : T₁.mor₁ ≫ b = a ≫ T₂.mor₁) :
+    ∃ (c : T₁.obj₃ ⟶ T₂.obj₃), T₁.mor₂ ≫ c = b ≫ T₂.mor₂ ∧
+      T₁.mor₃ ≫ a⟦1⟧' = c ≫ T₂.mor₃ := by
+  rw [mem_distinguishedTriangles_iff] at hT₁ hT₂
+  obtain ⟨c, hc₁, hc₂⟩ :=
+    Pretriangulated.complete_distinguished_triangle_morphism₁ _ _ hT₂ hT₁
+      b.unop a.unop (Quiver.Hom.op_inj comm.symm)
+  dsimp at c hc₁ hc₂
+  replace hc₂ := ((opShiftFunctorEquivalence C 1).unitIso.hom.app T₂.obj₁).unop ≫= hc₂
+  dsimp at hc₂
+  simp only [assoc, Iso.unop_hom_inv_id_app_assoc] at hc₂
+  refine ⟨c.op, Quiver.Hom.unop_inj hc₁.symm, Quiver.Hom.unop_inj ?_⟩
+  apply (shiftFunctor C (1 : ℤ)).map_injective
+  rw [unop_comp, unop_comp, Functor.map_comp, Functor.map_comp,
+    Quiver.Hom.unop_op, hc₂, ← unop_comp_assoc, ← unop_comp_assoc,
+    ← opShiftFunctorEquivalence_unitIso_inv_naturality]
+  simp
+
+/-- The pretriangulated structure on the opposite category of
+a pretriangulated category. It is a scoped instance, so that we need to
+`open CategoryTheory.Pretriangulated.Opposite` in order to be able
+to use it: the reason is that it relies on the definition of the shift
+on the opposite category `Cᵒᵖ`, for which it is unclear whether it should
+be a global instance or not. -/
+scoped instance : Pretriangulated Cᵒᵖ where
+  distinguishedTriangles := distinguishedTriangles C
+  isomorphic_distinguished := isomorphic_distinguished
+  contractible_distinguished := contractible_distinguished
+  distinguished_cocone_triangle := distinguished_cocone_triangle
+  rotate_distinguished_triangle := rotate_distinguished_triangle
+  complete_distinguished_triangle_morphism := complete_distinguished_triangle_morphism
+
+end Opposite
+
+variable {C}
+
+lemma mem_distTriang_op_iff (T : Triangle Cᵒᵖ) :
+    (T ∈ distTriang Cᵒᵖ) ↔ ((triangleOpEquivalence C).inverse.obj T).unop ∈ distTriang C := by
+  rfl
+
+lemma mem_distTriang_op_iff' (T : Triangle Cᵒᵖ) :
+    (T ∈ distTriang Cᵒᵖ) ↔ ∃ (T' : Triangle C) (_ : T' ∈ distTriang C),
+      Nonempty (T ≅ (triangleOpEquivalence C).functor.obj (Opposite.op T')) :=
+  Opposite.mem_distinguishedTriangles_iff' T
+
+lemma op_distinguished (T : Triangle C) (hT : T ∈ distTriang C) :
+    ((triangleOpEquivalence C).functor.obj (Opposite.op T)) ∈ distTriang Cᵒᵖ := by
+  rw [mem_distTriang_op_iff']
+  exact ⟨T, hT, ⟨Iso.refl _⟩⟩
+
+lemma unop_distinguished (T : Triangle Cᵒᵖ) (hT : T ∈ distTriang Cᵒᵖ) :
+    ((triangleOpEquivalence C).inverse.obj T).unop ∈ distTriang C := hT
+
+end Pretriangulated
+
+namespace Functor
+
+open Pretriangulated.Opposite Pretriangulated
+
+variable {C}
+
+lemma map_distinguished_op_exact {A : Type*} [Category A] [Abelian A] (F : Cᵒᵖ ⥤ A)
+    [F.IsHomological] (T : Triangle C) (hT : T ∈ distTriang C) :
+    ((shortComplexOfDistTriangle T hT).op.map F).Exact :=
+  F.map_distinguished_exact _ (op_distinguished T hT)
+
+end Functor
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Triangle.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Triangle.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2023 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Triangulated.Basic
+import Mathlib.CategoryTheory.Triangulated.Opposite.Basic
+
+/-!
+# Triangles in the opposite category of a (pre)triangulated category
+
+Let `C` be a (pre)triangulated category.
+In `CategoryTheory.Triangulated.Opposite.Basic`, we have constructed
+a shift on `Cᵒᵖ` that will be part of a structure of (pre)triangulated
+category. In this file, we construct an equivalence of categories
+between `(Triangle C)ᵒᵖ` and `Triangle Cᵒᵖ`, called
+`CategoryTheory.Pretriangulated.triangleOpEquivalence`. It sends a triangle
+`X ⟶ Y ⟶ Z ⟶ X⟦1⟧` in `C` to the triangle `op Z ⟶ op Y ⟶ op X ⟶ (op Z)⟦1⟧` in `Cᵒᵖ`
+(without introducing signs).
+
+## References
+* [Jean-Louis Verdier, *Des catégories dérivées des catégories abéliennes*][verdier1996]
+
+-/
+
+namespace CategoryTheory.Pretriangulated
+
+open Category Limits Preadditive ZeroObject Opposite
+
+variable (C : Type*) [Category C] [HasShift C ℤ]
+
+namespace TriangleOpEquivalence
+
+/-- The functor which sends a triangle `X ⟶ Y ⟶ Z ⟶ X⟦1⟧` in `C` to the triangle
+`op Z ⟶ op Y ⟶ op X ⟶ (op Z)⟦1⟧` in `Cᵒᵖ` (without introducing signs). -/
+@[simps]
+noncomputable def functor : (Triangle C)ᵒᵖ ⥤ Triangle Cᵒᵖ where
+  obj T := Triangle.mk T.unop.mor₂.op T.unop.mor₁.op
+      ((opShiftFunctorEquivalence C 1).counitIso.inv.app (Opposite.op T.unop.obj₁) ≫
+        T.unop.mor₃.op⟦(1 : ℤ)⟧')
+  map {T₁ T₂} φ :=
+    { hom₁ := φ.unop.hom₃.op
+      hom₂ := φ.unop.hom₂.op
+      hom₃ := φ.unop.hom₁.op
+      comm₁ := Quiver.Hom.unop_inj φ.unop.comm₂.symm
+      comm₂ := Quiver.Hom.unop_inj φ.unop.comm₁.symm
+      comm₃ := by
+        dsimp
+        rw [assoc, ← Functor.map_comp, ← op_comp, ← φ.unop.comm₃, op_comp, Functor.map_comp,
+          opShiftFunctorEquivalence_counitIso_inv_naturality_assoc]
+        rfl }
+
+/-- The functor which sends a triangle `X ⟶ Y ⟶ Z ⟶ X⟦1⟧` in `Cᵒᵖ` to the triangle
+`Z.unop ⟶ Y.unop ⟶ X.unop ⟶ Z.unop⟦1⟧` in `C` (without introducing signs). -/
+@[simps]
+noncomputable def inverse : Triangle Cᵒᵖ ⥤ (Triangle C)ᵒᵖ where
+  obj T := Opposite.op (Triangle.mk T.mor₂.unop T.mor₁.unop
+      (((opShiftFunctorEquivalence C 1).unitIso.inv.app T.obj₁).unop ≫ T.mor₃.unop⟦(1 : ℤ)⟧'))
+  map {T₁ T₂} φ := Quiver.Hom.op
+    { hom₁ := φ.hom₃.unop
+      hom₂ := φ.hom₂.unop
+      hom₃ := φ.hom₁.unop
+      comm₁ := Quiver.Hom.op_inj φ.comm₂.symm
+      comm₂ := Quiver.Hom.op_inj φ.comm₁.symm
+      comm₃ := Quiver.Hom.op_inj (by
+        dsimp
+        rw [assoc, ← opShiftFunctorEquivalence_unitIso_inv_naturality,
+          ← op_comp_assoc, ← Functor.map_comp, ← unop_comp, ← φ.comm₃,
+          unop_comp, Functor.map_comp, op_comp, assoc]) }
+
+/-- The unit isomorphism of the
+equivalence `triangleOpEquivalence C : (Triangle C)ᵒᵖ ≌ Triangle Cᵒᵖ` . -/
+@[simps!]
+noncomputable def unitIso : 𝟭 _ ≅ functor C ⋙ inverse C :=
+  NatIso.ofComponents (fun T => Iso.op
+    (Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (Iso.refl _) (by aesop_cat) (by aesop_cat)
+      (Quiver.Hom.op_inj
+        (by simp [shift_unop_opShiftFunctorEquivalence_counitIso_inv_app]))))
+    (fun {T₁ T₂} f => Quiver.Hom.unop_inj (by aesop_cat))
+
+/-- The counit isomorphism of the
+equivalence `triangleOpEquivalence C : (Triangle C)ᵒᵖ ≌ Triangle Cᵒᵖ` . -/
+@[simps!]
+noncomputable def counitIso : inverse C ⋙ functor C ≅ 𝟭 _ :=
+  NatIso.ofComponents (fun T => by
+    refine Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (Iso.refl _) ?_ ?_ ?_
+    · aesop_cat
+    · aesop_cat
+    · dsimp
+      rw [Functor.map_id, comp_id, id_comp, Functor.map_comp,
+        ← opShiftFunctorEquivalence_counitIso_inv_naturality_assoc,
+        opShiftFunctorEquivalence_counitIso_inv_app_shift, ← Functor.map_comp,
+        Iso.hom_inv_id_app, Functor.map_id]
+      simp only [Functor.id_obj, comp_id])
+    (by aesop_cat)
+
+end TriangleOpEquivalence
+
+/-- An anti-equivalence between the categories of triangles in `C` and in `Cᵒᵖ`.
+A triangle in `Cᵒᵖ` shall be distinguished iff it correspond to a distinguished
+triangle in `C` via this equivalence. -/
+@[simps]
+noncomputable def triangleOpEquivalence :
+    (Triangle C)ᵒᵖ ≌ Triangle Cᵒᵖ where
+  functor := TriangleOpEquivalence.functor C
+  inverse := TriangleOpEquivalence.inverse C
+  unitIso := TriangleOpEquivalence.unitIso C
+  counitIso := TriangleOpEquivalence.counitIso C
+
+end CategoryTheory.Pretriangulated

--- a/Mathlib/CategoryTheory/Triangulated/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Yoneda.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Homology.ShortComplex.Ab
 import Mathlib.CategoryTheory.Preadditive.Yoneda.Basic
 import Mathlib.CategoryTheory.Shift.ShiftedHomOpposite
 import Mathlib.CategoryTheory.Triangulated.HomologicalFunctor
-import Mathlib.CategoryTheory.Triangulated.Opposite
+import Mathlib.CategoryTheory.Triangulated.Opposite.Pretriangulated
 
 /-!
 # The Yoneda functors are homological


### PR DESCRIPTION
This splits the long (and getting longer with a new PR) file `CatgeoryTheory.Triangulated.Opposite` in three files:
- `Triangulated.Opposite.Basic`: just the shift on the opposite category + lemmas
- `Triangulated.Opposite.Triangle`: the equivalence `triangleOpEquivalence`
- `Triangulated.Opposite.Pretriangulated`: the pretriangulated structure

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
