### PR TITLE
[Merged by Bors] - feat(Logic/IsEmpty/Relator): empty on sides

### DIFF
--- a/Mathlib/Logic/IsEmpty.lean
+++ b/Mathlib/Logic/IsEmpty.lean
@@ -213,10 +213,22 @@ variable {α β : Type*} (R : α → β → Prop)
 theorem leftTotal_empty [IsEmpty α] : LeftTotal R := by
   simp only [LeftTotal, IsEmpty.forall_iff]
 
+theorem leftTotal_empty_iff_right_empty [IsEmpty β] : LeftTotal R ↔ IsEmpty α := by
+  simp [LeftTotal, IsEmpty.exists_iff, isEmpty_iff, imp_self]
+
 @[simp]
 theorem rightTotal_empty [IsEmpty β] : RightTotal R := by
   simp only [RightTotal, IsEmpty.forall_iff]
 
+theorem rightTotal_empty_iff_left_empty [IsEmpty α] : RightTotal R ↔ IsEmpty β := by
+  simp only [RightTotal, IsEmpty.exists_iff, isEmpty_iff, imp_self]
+
 @[simp]
 theorem biTotal_empty [IsEmpty α] [IsEmpty β] : BiTotal R :=
   ⟨leftTotal_empty R, rightTotal_empty R⟩
+
+theorem biTotal_empty_iff_left_empty [IsEmpty α] : BiTotal R ↔ IsEmpty β := by
+  simp [BiTotal, rightTotal_empty_iff_left_empty]
+
+theorem biTotal_empty_iff_right_empty [IsEmpty β] : BiTotal R ↔ IsEmpty α := by
+  simp [BiTotal, leftTotal_empty_iff_right_empty]

--- a/Mathlib/Logic/IsEmpty.lean
+++ b/Mathlib/Logic/IsEmpty.lean
@@ -214,7 +214,7 @@ theorem leftTotal_empty [IsEmpty α] : LeftTotal R := by
   simp only [LeftTotal, IsEmpty.forall_iff]
 
 theorem leftTotal_empty_iff_right_empty [IsEmpty β] : LeftTotal R ↔ IsEmpty α := by
-  simp [LeftTotal, IsEmpty.exists_iff, isEmpty_iff, imp_self]
+  simp only [LeftTotal, IsEmpty.exists_iff, isEmpty_iff]
 
 @[simp]
 theorem rightTotal_empty [IsEmpty β] : RightTotal R := by
@@ -228,7 +228,7 @@ theorem biTotal_empty [IsEmpty α] [IsEmpty β] : BiTotal R :=
   ⟨leftTotal_empty R, rightTotal_empty R⟩
 
 theorem biTotal_empty_iff_left_empty [IsEmpty α] : BiTotal R ↔ IsEmpty β := by
-  simp [BiTotal, rightTotal_empty_iff_left_empty]
+  simp only [BiTotal, leftTotal_empty, rightTotal_empty_iff_left_empty, true_and]
 
 theorem biTotal_empty_iff_right_empty [IsEmpty β] : BiTotal R ↔ IsEmpty α := by
-  simp [BiTotal, leftTotal_empty_iff_right_empty]
+  simp only [BiTotal, leftTotal_empty_iff_right_empty, rightTotal_empty, and_true]

--- a/Mathlib/Logic/IsEmpty.lean
+++ b/Mathlib/Logic/IsEmpty.lean
@@ -213,14 +213,14 @@ variable {α β : Type*} (R : α → β → Prop)
 theorem leftTotal_empty [IsEmpty α] : LeftTotal R := by
   simp only [LeftTotal, IsEmpty.forall_iff]
 
-theorem leftTotal_empty_iff_right_empty [IsEmpty β] : LeftTotal R ↔ IsEmpty α := by
+theorem leftTotal_iff_isEmpty_left [IsEmpty β] : LeftTotal R ↔ IsEmpty α := by
   simp only [LeftTotal, IsEmpty.exists_iff, isEmpty_iff]
 
 @[simp]
 theorem rightTotal_empty [IsEmpty β] : RightTotal R := by
   simp only [RightTotal, IsEmpty.forall_iff]
 
-theorem rightTotal_empty_iff_left_empty [IsEmpty α] : RightTotal R ↔ IsEmpty β := by
+theorem rightTotal_iff_isEmpty_right [IsEmpty α] : RightTotal R ↔ IsEmpty β := by
   simp only [RightTotal, IsEmpty.exists_iff, isEmpty_iff, imp_self]
 
 @[simp]
@@ -228,7 +228,7 @@ theorem biTotal_empty [IsEmpty α] [IsEmpty β] : BiTotal R :=
   ⟨leftTotal_empty R, rightTotal_empty R⟩
 
 theorem biTotal_empty_iff_left_empty [IsEmpty α] : BiTotal R ↔ IsEmpty β := by
-  simp only [BiTotal, leftTotal_empty, rightTotal_empty_iff_left_empty, true_and]
+  simp only [BiTotal, leftTotal_empty, rightTotal_iff_isEmpty_right, true_and]
 
 theorem biTotal_empty_iff_right_empty [IsEmpty β] : BiTotal R ↔ IsEmpty α := by
-  simp only [BiTotal, leftTotal_empty_iff_right_empty, rightTotal_empty, and_true]
+  simp only [BiTotal, leftTotal_iff_isEmpty_left, rightTotal_empty, and_true]

--- a/Mathlib/Logic/IsEmpty.lean
+++ b/Mathlib/Logic/IsEmpty.lean
@@ -227,8 +227,8 @@ theorem rightTotal_iff_isEmpty_right [IsEmpty α] : RightTotal R ↔ IsEmpty β 
 theorem biTotal_empty [IsEmpty α] [IsEmpty β] : BiTotal R :=
   ⟨leftTotal_empty R, rightTotal_empty R⟩
 
-theorem biTotal_empty_iff_left_empty [IsEmpty α] : BiTotal R ↔ IsEmpty β := by
+theorem biTotal_iff_isEmpty_right [IsEmpty α] : BiTotal R ↔ IsEmpty β := by
   simp only [BiTotal, leftTotal_empty, rightTotal_iff_isEmpty_right, true_and]
 
-theorem biTotal_empty_iff_right_empty [IsEmpty β] : BiTotal R ↔ IsEmpty α := by
+theorem biTotal_iff_isEmpty_left [IsEmpty β] : BiTotal R ↔ IsEmpty α := by
   simp only [BiTotal, leftTotal_iff_isEmpty_left, rightTotal_empty, and_true]


### PR DESCRIPTION
various proofs of Left/Right/BiTotal guaranteeing emptiness when certain types are empty.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
