### PR TITLE
[Merged by Bors] - feat(Data/BitVec): Equivalences between `Fin` and `ZMod` and `BitVec`

### DIFF
--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -90,7 +90,7 @@ instance : CommRing (BitVec w) :=
     toFin_zero toFin_one toFin_add toFin_mul toFin_neg toFin_sub
     toFin_nsmul toFin_zsmul toFin_pow toFin_natCast toFin_intCast
 
-/-- The ring `Fin (2 ^ m)` is isomorphic to `BitVec m`. -/
+/-- The ring `BitVec m` is isomorphic to `Fin (2 ^ m)`. -/
 @[simps]
 def equivFin {m : ℕ} : BitVec m ≃+* Fin (2 ^ m) where
   toFun a := a.toFin

--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -90,7 +90,7 @@ instance : CommRing (BitVec w) :=
     toFin_zero toFin_one toFin_add toFin_mul toFin_neg toFin_sub
     toFin_nsmul toFin_zsmul toFin_pow toFin_natCast toFin_intCast
 
-/-- The ring `Fin (2 ^ m)`  is isomorphic to `BitVec m`. -/
+/-- The ring `Fin (2 ^ m)` is isomorphic to `BitVec m`. -/
 @[simps]
 def finEquiv {m : ℕ} : Fin (2 ^ m) ≃+* BitVec m where
   toFun a := ofFin a

--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Harun Khan, Alex Keizer
 -/
 import Mathlib.Algebra.Ring.InjSurj
+import Mathlib.Algebra.Ring.Equiv
 import Mathlib.Data.ZMod.Defs
 
 /-!
@@ -88,5 +89,15 @@ instance : CommRing (BitVec w) :=
   toFin_injective.commRing _
     toFin_zero toFin_one toFin_add toFin_mul toFin_neg toFin_sub
     toFin_nsmul toFin_zsmul toFin_pow toFin_natCast toFin_intCast
+
+/-- The ring `Fin (2 ^ m)`  is isomorphic to `BitVec m`. -/
+@[simps]
+def finEquiv {m : ℕ} : Fin (2 ^ m) ≃+* BitVec m where
+  toFun a := ofFin a
+  invFun a := a.toFin
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_mul' _ _ := rfl
+  map_add' _ _ := rfl
 
 end BitVec

--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -92,9 +92,9 @@ instance : CommRing (BitVec w) :=
 
 /-- The ring `Fin (2 ^ m)` is isomorphic to `BitVec m`. -/
 @[simps]
-def finEquiv {m : ℕ} : Fin (2 ^ m) ≃+* BitVec m where
-  toFun a := ofFin a
-  invFun a := a.toFin
+def equivFin {m : ℕ} : BitVec m ≃+* Fin (2 ^ m) where
+  toFun a := a.toFin
+  invFun a := ofFin a
   left_inv _ := rfl
   right_inv _ := rfl
   map_mul' _ _ := rfl

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -39,7 +39,7 @@ open Function ZMod
 
 namespace ZMod
 
-/-- For non-zero `n : ℕ`, the ring `ZMod n` is equivalent to `Fin n`. -/
+/-- For non-zero `n : ℕ`, the ring `Fin n` is equivalent to `ZMod n`. -/
 def finEquiv : ∀ (n : ℕ) [NeZero n], Fin n ≃+* ZMod n
   | 0, h => (h.ne _ rfl).elim
   | _ + 1, _ => .refl _

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -39,6 +39,11 @@ open Function ZMod
 
 namespace ZMod
 
+/-- For non-zero `n : ℕ`, the ring `ZMod n` is equivalent to `Fin n`. -/
+def finEquiv : ∀ (n : ℕ) [NeZero n], ZMod n ≃+* Fin n
+  | 0, h => (h.ne _ rfl).elim
+  | _ + 1, _ => .refl _
+
 instance charZero : CharZero (ZMod 0) := inferInstanceAs (CharZero ℤ)
 
 /-- `val a` is a natural number defined as:

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -40,7 +40,7 @@ open Function ZMod
 namespace ZMod
 
 /-- For non-zero `n : ℕ`, the ring `ZMod n` is equivalent to `Fin n`. -/
-def finEquiv : ∀ (n : ℕ) [NeZero n], ZMod n ≃+* Fin n
+def finEquiv : ∀ (n : ℕ) [NeZero n], Fin n ≃+* ZMod n
   | 0, h => (h.ne _ rfl).elim
   | _ + 1, _ => .refl _
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
