### PR TITLE
[Merged by Bors] - feat(Order/CompleteBooleanAlgebra): Himp in terms of sSup

### DIFF
--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -914,12 +914,10 @@ theorem isLeast_sdiff [GeneralizedCoheytingAlgebra α] {a b : α} :
     IsLeast {w | a ≤ b ⊔ w} (a \ b) := by
   simp [IsLeast, mem_lowerBounds]
 
-theorem isGreatest_compl [HeytingAlgebra α] {a : α} :
+theorem isGreatest_compl [HeytingAlgebra α] (a : α) :
     IsGreatest {w | Disjoint w a} (aᶜ) := by
-  simp only [← himp_bot,disjoint_iff_inf_le]
-  exact isGreatest_himp
+  simpa only [← himp_bot, disjoint_iff_inf_le] using isGreatest_himp
 
-theorem isLeast_hnot [CoheytingAlgebra α] {a : α} :
+theorem isLeast_hnot [CoheytingAlgebra α] (a : α) :
     IsLeast {w | Codisjoint a w} (￢a) := by
-  simp only [← CoheytingAlgebra.top_sdiff, codisjoint_iff_le_sup]
-  exact isLeast_sdiff
+  simpa only [← top_sdiff, codisjoint_iff_le_sup] using isLeast_sdiff

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -906,18 +906,18 @@ theorem IsGLB.exists_between' (h : IsGLB s a) (h' : a ∉ s) (hb : a < b) : ∃ 
 
 end LinearOrder
 
-theorem isGreatest_himp [GeneralizedHeytingAlgebra α] {a b : α} :
+theorem isGreatest_himp [GeneralizedHeytingAlgebra α] (a b : α) :
     IsGreatest {w | w ⊓ a ≤ b} (a ⇨ b) := by
   simp [IsGreatest, mem_upperBounds]
 
-theorem isLeast_sdiff [GeneralizedCoheytingAlgebra α] {a b : α} :
+theorem isLeast_sdiff [GeneralizedCoheytingAlgebra α] (a b : α) :
     IsLeast {w | a ≤ b ⊔ w} (a \ b) := by
   simp [IsLeast, mem_lowerBounds]
 
 theorem isGreatest_compl [HeytingAlgebra α] (a : α) :
     IsGreatest {w | Disjoint w a} (aᶜ) := by
-  simpa only [← himp_bot, disjoint_iff_inf_le] using isGreatest_himp
+  simpa only [← himp_bot, disjoint_iff_inf_le] using (isGreatest_himp a ⊥)
 
 theorem isLeast_hnot [CoheytingAlgebra α] (a : α) :
     IsLeast {w | Codisjoint a w} (￢a) := by
-  simpa only [← top_sdiff, codisjoint_iff_le_sup] using isLeast_sdiff
+  simpa only [← CoheytingAlgebra.top_sdiff, codisjoint_iff_le_sup] using (isLeast_sdiff ⊤ a)

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -906,10 +906,10 @@ theorem IsGLB.exists_between' (h : IsGLB s a) (h' : a ∉ s) (hb : a < b) : ∃ 
 
 end LinearOrder
 
-theorem isGreatest_himp {α} [GeneralizedHeytingAlgebra α] (a b : α) :
+theorem isGreatest_himp [GeneralizedHeytingAlgebra α] (a b : α) :
     IsGreatest {w | w ⊓ a ≤ b} (a ⇨ b) := by
   simp [IsGreatest, mem_upperBounds]
 
-theorem isLeast_sdiff {α} [GeneralizedCoheytingAlgebra α] (a b : α) :
+theorem isLeast_sdiff [GeneralizedCoheytingAlgebra α] (a b : α) :
     IsLeast {w | a ≤ b ⊔ w} (a \ b) := by
   simp [IsLeast, mem_lowerBounds]

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -916,8 +916,8 @@ theorem isLeast_sdiff [GeneralizedCoheytingAlgebra α] (a b : α) :
 
 theorem isGreatest_compl [HeytingAlgebra α] (a : α) :
     IsGreatest {w | Disjoint w a} (aᶜ) := by
-  simpa only [← himp_bot, disjoint_iff_inf_le] using (isGreatest_himp a ⊥)
+  simpa only [himp_bot, disjoint_iff_inf_le] using isGreatest_himp a ⊥
 
 theorem isLeast_hnot [CoheytingAlgebra α] (a : α) :
     IsLeast {w | Codisjoint a w} (￢a) := by
-  simpa only [← CoheytingAlgebra.top_sdiff, codisjoint_iff_le_sup] using (isLeast_sdiff ⊤ a)
+  simpa only [CoheytingAlgebra.top_sdiff, codisjoint_iff_le_sup] using isLeast_sdiff ⊤ a

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -906,10 +906,20 @@ theorem IsGLB.exists_between' (h : IsGLB s a) (h' : a ∉ s) (hb : a < b) : ∃ 
 
 end LinearOrder
 
-theorem isGreatest_himp [GeneralizedHeytingAlgebra α] (a b : α) :
+theorem isGreatest_himp [GeneralizedHeytingAlgebra α] {a b : α} :
     IsGreatest {w | w ⊓ a ≤ b} (a ⇨ b) := by
   simp [IsGreatest, mem_upperBounds]
 
-theorem isLeast_sdiff [GeneralizedCoheytingAlgebra α] (a b : α) :
+theorem isLeast_sdiff [GeneralizedCoheytingAlgebra α] {a b : α} :
     IsLeast {w | a ≤ b ⊔ w} (a \ b) := by
   simp [IsLeast, mem_lowerBounds]
+
+theorem isGreatest_compl [HeytingAlgebra α] {a : α} :
+    IsGreatest {w | Disjoint w a} (aᶜ) := by
+  simp only [← himp_bot,disjoint_iff_inf_le]
+  exact isGreatest_himp
+
+theorem isLeast_hnot [CoheytingAlgebra α] {a : α} :
+    IsLeast {w | Codisjoint a w} (￢a) := by
+  simp only [← CoheytingAlgebra.top_sdiff, codisjoint_iff_le_sup]
+  exact isLeast_sdiff

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -905,3 +905,11 @@ theorem IsGLB.exists_between' (h : IsGLB s a) (h' : a ∉ s) (hb : a < b) : ∃ 
   ⟨c, hcs, hac.lt_of_ne fun hac => h' <| hac.symm ▸ hcs, hcb⟩
 
 end LinearOrder
+
+theorem isGreatest_himp {α} [GeneralizedHeytingAlgebra α] (a b : α) :
+    IsGreatest {w | w ⊓ a ≤ b} (a ⇨ b) := by
+  simp [IsGreatest, mem_upperBounds]
+
+theorem isLeast_sdiff {α} [GeneralizedCoheytingAlgebra α] (a b : α) :
+    IsLeast {w | a ≤ b ⊔ w} (a \ b) := by
+  simp [IsLeast, mem_lowerBounds]

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -418,7 +418,6 @@ theorem iSup_inf_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (swap (·
 theorem himp_eq_sSup : a ⇨ b = sSup {w | w ⊓ a ≤ b} :=
   (isGreatest_himp a b).isLUB.sSup_eq.symm
 
-
 -- see Note [lower instance priority]
 instance (priority := 100) Frame.toDistribLattice : DistribLattice α :=
   DistribLattice.ofInfSupLe fun a b c => by

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -418,6 +418,9 @@ theorem iSup_inf_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (swap (·
 theorem himp_eq_sSup : a ⇨ b = sSup {w | w ⊓ a ≤ b} :=
   (isGreatest_himp a b).isLUB.sSup_eq.symm
 
+theorem compl_eq_sSup_disjoint : aᶜ = sSup {w | Disjoint a w} := by
+  simp_rw [← himp_bot,himp_eq_sSup,disjoint_iff_inf_le,inf_comm]
+
 -- see Note [lower instance priority]
 instance (priority := 100) Frame.toDistribLattice : DistribLattice α :=
   DistribLattice.ofInfSupLe fun a b c => by
@@ -485,6 +488,9 @@ theorem iInf_sup_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (· ≤ �
 
 theorem sdiff_eq_sInf : a \ b = sInf {w | a ≤ b ⊔ w} :=
   (isLeast_sdiff a b).isGLB.sInf_eq.symm
+
+theorem hnot_eq_sInf_codisjoint : ￢a = sInf {w | Codisjoint a w} := by
+  simp_rw [← Coframe.top_sdiff,sdiff_eq_sInf,codisjoint_iff]
 
 -- see Note [lower instance priority]
 instance (priority := 100) Coframe.toDistribLattice : DistribLattice α where

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -490,7 +490,7 @@ theorem sdiff_eq_sInf : a \ b = sInf {w | a ≤ b ⊔ w} :=
   (isLeast_sdiff a b).isGLB.sInf_eq.symm
 
 theorem hnot_eq_sInf_codisjoint : ￢a = sInf {w | Codisjoint a w} := by
-  simp_rw [← Coframe.top_sdiff,sdiff_eq_sInf,codisjoint_iff]
+  simp [← Coframe.top_sdiff,sdiff_eq_sInf,codisjoint_iff,sup_comm]
 
 -- see Note [lower instance priority]
 instance (priority := 100) Coframe.toDistribLattice : DistribLattice α where

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -416,10 +416,10 @@ theorem iSup_inf_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (swap (·
   @iSup_inf_of_monotone α _ ιᵒᵈ _ _ f g hf.dual_left hg.dual_left
 
 theorem himp_eq_sSup : a ⇨ b = sSup {w | w ⊓ a ≤ b} :=
-  (isGreatest_himp a b).isLUB.sSup_eq.symm
+  isGreatest_himp.isLUB.sSup_eq.symm
 
-theorem compl_eq_sSup_disjoint : aᶜ = sSup {w | Disjoint a w} := by
-  simp_rw [← himp_bot,himp_eq_sSup,disjoint_iff_inf_le,inf_comm]
+theorem compl_eq_sSup_disjoint : aᶜ = sSup {w | Disjoint w a} :=
+  isGreatest_compl.isLUB.sSup_eq.symm
 
 -- see Note [lower instance priority]
 instance (priority := 100) Frame.toDistribLattice : DistribLattice α :=
@@ -487,10 +487,10 @@ theorem iInf_sup_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (· ≤ �
   @iSup_inf_of_monotone αᵒᵈ _ _ _ _ _ _ hf.dual_right hg.dual_right
 
 theorem sdiff_eq_sInf : a \ b = sInf {w | a ≤ b ⊔ w} :=
-  (isLeast_sdiff a b).isGLB.sInf_eq.symm
+  isLeast_sdiff.isGLB.sInf_eq.symm
 
-theorem hnot_eq_sInf_codisjoint : ￢a = sInf {w | Codisjoint a w} := by
-  simp [← Coframe.top_sdiff,sdiff_eq_sInf,codisjoint_iff,sup_comm]
+theorem hnot_eq_sInf_codisjoint : ￢a = sInf {w | Codisjoint a w} :=
+  isLeast_hnot.isGLB.sInf_eq.symm
 
 -- see Note [lower instance priority]
 instance (priority := 100) Coframe.toDistribLattice : DistribLattice α where

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -416,10 +416,10 @@ theorem iSup_inf_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (swap (·
   @iSup_inf_of_monotone α _ ιᵒᵈ _ _ f g hf.dual_left hg.dual_left
 
 theorem himp_eq_sSup : a ⇨ b = sSup {w | w ⊓ a ≤ b} :=
-  isGreatest_himp.isLUB.sSup_eq.symm
+  (isGreatest_himp a b).isLUB.sSup_eq.symm
 
 theorem compl_eq_sSup_disjoint : aᶜ = sSup {w | Disjoint w a} :=
-  isGreatest_compl.isLUB.sSup_eq.symm
+  (isGreatest_compl a).isLUB.sSup_eq.symm
 
 -- see Note [lower instance priority]
 instance (priority := 100) Frame.toDistribLattice : DistribLattice α :=
@@ -487,10 +487,10 @@ theorem iInf_sup_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (· ≤ �
   @iSup_inf_of_monotone αᵒᵈ _ _ _ _ _ _ hf.dual_right hg.dual_right
 
 theorem sdiff_eq_sInf : a \ b = sInf {w | a ≤ b ⊔ w} :=
-  isLeast_sdiff.isGLB.sInf_eq.symm
+  (isLeast_sdiff a b).isGLB.sInf_eq.symm
 
 theorem hnot_eq_sInf_codisjoint : ￢a = sInf {w | Codisjoint a w} :=
-  isLeast_hnot.isGLB.sInf_eq.symm
+  (isLeast_hnot a).isGLB.sInf_eq.symm
 
 -- see Note [lower instance priority]
 instance (priority := 100) Coframe.toDistribLattice : DistribLattice α where

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -424,7 +424,7 @@ theorem isLeast_sdiff {α} [GeneralizedCoheytingAlgebra α] (a b : α) :
   simp [IsLeast, mem_lowerBounds]
 
 theorem himp_eq_sSup : a ⇨ b = sSup {w | w ⊓ a ≤ b} :=
-  Eq.symm (isGreatest_himp a b).isLUB.sSup_eq
+  (isGreatest_himp a b).isLUB.sSup_eq.symm
 
 
 -- see Note [lower instance priority]
@@ -493,7 +493,7 @@ theorem iInf_sup_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (· ≤ �
   @iSup_inf_of_monotone αᵒᵈ _ _ _ _ _ _ hf.dual_right hg.dual_right
 
 theorem sdiff_eq_sInf : a \ b = sInf {w | a ≤ b ⊔ w} :=
-  Eq.symm (isLeast_sdiff a b).isGLB.sInf_eq
+  (isLeast_sdiff a b).isGLB.sInf_eq.symm
 
 -- see Note [lower instance priority]
 instance (priority := 100) Coframe.toDistribLattice : DistribLattice α where

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -415,6 +415,17 @@ theorem iSup_inf_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (swap (·
     (hf : Antitone f) (hg : Antitone g) : ⨆ i, f i ⊓ g i = (⨆ i, f i) ⊓ ⨆ i, g i :=
   @iSup_inf_of_monotone α _ ιᵒᵈ _ _ f g hf.dual_left hg.dual_left
 
+theorem himp_eq_sSup : a ⇨ b = sSup {w | w ⊓ a ≤ b} := by
+  apply le_antisymm
+  · rw [le_sSup_iff]
+    simp only [upperBounds, mem_setOf_eq]
+    intro a1 b1
+    simp_all only [himp_inf_self, inf_le_left]
+  · rw [sSup_le_iff]
+    exact fun b_1 a_1 ↦ (fun {α} [Frame α] (a b c : α) ↦ (Frame.le_himp_iff a b c).mpr) b_1 a b a_1
+
+
+
 -- see Note [lower instance priority]
 instance (priority := 100) Frame.toDistribLattice : DistribLattice α :=
   DistribLattice.ofInfSupLe fun a b c => by

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -415,13 +415,6 @@ theorem iSup_inf_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (swap (·
     (hf : Antitone f) (hg : Antitone g) : ⨆ i, f i ⊓ g i = (⨆ i, f i) ⊓ ⨆ i, g i :=
   @iSup_inf_of_monotone α _ ιᵒᵈ _ _ f g hf.dual_left hg.dual_left
 
-theorem isGreatest_himp {α} [GeneralizedHeytingAlgebra α] (a b : α) :
-    IsGreatest {w | w ⊓ a ≤ b} (a ⇨ b) := by
-  simp [IsGreatest, mem_upperBounds]
-
-theorem isLeast_sdiff {α} [GeneralizedCoheytingAlgebra α] (a b : α) :
-    IsLeast {w | a ≤ b ⊔ w} (a \ b) := by
-  simp [IsLeast, mem_lowerBounds]
 
 theorem himp_eq_sSup : a ⇨ b = sSup {w | w ⊓ a ≤ b} :=
   (isGreatest_himp a b).isLUB.sSup_eq.symm

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -423,12 +423,12 @@ theorem isLeast_sdiff {α} [GeneralizedCoheytingAlgebra α] (a b : α) :
     IsLeast {w | a ≤ b ⊔ w} (a \ b) := by
   simp [IsLeast, mem_lowerBounds]
 
-theorem himp_eq_sSup : sSup {w | w ⊓ a ≤ b} = a ⇨ b :=
-  (isGreatest_himp a b).isLUB.sSup_eq
+theorem himp_eq_sSup : a ⇨ b = sSup {w | w ⊓ a ≤ b} :=
+  Eq.symm (isGreatest_himp a b).isLUB.sSup_eq
 
 theorem sdiff_eq_sInf {α} [Coframe α]  (a b : α) :
-    sInf {w | a ≤ b ⊔ w} = a \ b :=
-  (isLeast_sdiff a b).isGLB.sInf_eq
+    a \ b = sInf {w | a ≤ b ⊔ w}  :=
+  Eq.symm (isLeast_sdiff a b).isGLB.sInf_eq
 
 -- see Note [lower instance priority]
 instance (priority := 100) Frame.toDistribLattice : DistribLattice α :=

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -417,29 +417,18 @@ theorem iSup_inf_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (swap (·
 
 theorem isGreatest_himp {α} [GeneralizedHeytingAlgebra α] (a b : α) :
     IsGreatest {w | w ⊓ a ≤ b} (a ⇨ b) := by
-  simp only [IsGreatest, mem_setOf_eq, himp_inf_self, inf_le_left, mem_upperBounds, le_himp_iff,
-    imp_self, implies_true, and_self]
+  simp [IsGreatest, mem_upperBounds]
 
 theorem isLeast_sdiff {α} [GeneralizedCoheytingAlgebra α] (a b : α) :
     IsLeast {w | a ≤ b ⊔ w} (a \ b) := by
-  simp only [IsLeast, mem_setOf_eq, sup_sdiff_self, le_sup_right, mem_lowerBounds, sdiff_le_iff,
-    imp_self, implies_true, and_self]
-
-lemma isGreatest_sSup {α} [CompleteSemilatticeSup α] (a : α) (s : Set α) :
-  IsGreatest s a → sSup s = a :=
-    fun h ↦ IsLUB.sSup_eq (IsGreatest.isLUB h)
-
-lemma isLeast_sInf {α} [CompleteSemilatticeInf α] (a : α) (s : Set α) :
-  IsLeast s a → sInf s = a :=
-    fun h ↦ IsGLB.sInf_eq (IsLeast.isGLB h)
+  simp [IsLeast, mem_lowerBounds]
 
 theorem himp_eq_sSup : sSup {w | w ⊓ a ≤ b} = a ⇨ b :=
-  (isGreatest_sSup _ _ (isGreatest_himp a b))
+  (isGreatest_himp a b).isLUB.sSup_eq
 
 theorem sdiff_eq_sInf {α} [Coframe α]  (a b : α) :
-    sInf {w | a ≤ b ⊔ w} = a \ b := by
-  exact (isLeast_sInf _ _ (isLeast_sdiff a b))
-
+    sInf {w | a ≤ b ⊔ w} = a \ b :=
+  (isLeast_sdiff a b).isGLB.sInf_eq
 
 -- see Note [lower instance priority]
 instance (priority := 100) Frame.toDistribLattice : DistribLattice α :=

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -415,7 +415,6 @@ theorem iSup_inf_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (swap (·
     (hf : Antitone f) (hg : Antitone g) : ⨆ i, f i ⊓ g i = (⨆ i, f i) ⊓ ⨆ i, g i :=
   @iSup_inf_of_monotone α _ ιᵒᵈ _ _ f g hf.dual_left hg.dual_left
 
-
 theorem himp_eq_sSup : a ⇨ b = sSup {w | w ⊓ a ≤ b} :=
   (isGreatest_himp a b).isLUB.sSup_eq.symm
 

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -426,9 +426,6 @@ theorem isLeast_sdiff {α} [GeneralizedCoheytingAlgebra α] (a b : α) :
 theorem himp_eq_sSup : a ⇨ b = sSup {w | w ⊓ a ≤ b} :=
   Eq.symm (isGreatest_himp a b).isLUB.sSup_eq
 
-theorem sdiff_eq_sInf {α} [Coframe α]  (a b : α) :
-    a \ b = sInf {w | a ≤ b ⊔ w}  :=
-  Eq.symm (isLeast_sdiff a b).isGLB.sInf_eq
 
 -- see Note [lower instance priority]
 instance (priority := 100) Frame.toDistribLattice : DistribLattice α :=
@@ -494,6 +491,9 @@ theorem iInf_sup_of_monotone {ι : Type*} [Preorder ι] [IsDirected ι (swap (·
 theorem iInf_sup_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (· ≤ ·)] {f g : ι → α}
     (hf : Antitone f) (hg : Antitone g) : ⨅ i, f i ⊔ g i = (⨅ i, f i) ⊔ ⨅ i, g i :=
   @iSup_inf_of_monotone αᵒᵈ _ _ _ _ _ _ hf.dual_right hg.dual_right
+
+theorem sdiff_eq_sInf : a \ b = sInf {w | a ≤ b ⊔ w} :=
+  Eq.symm (isLeast_sdiff a b).isGLB.sInf_eq
 
 -- see Note [lower instance priority]
 instance (priority := 100) Coframe.toDistribLattice : DistribLattice α where

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -415,15 +415,30 @@ theorem iSup_inf_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (swap (·
     (hf : Antitone f) (hg : Antitone g) : ⨆ i, f i ⊓ g i = (⨆ i, f i) ⊓ ⨆ i, g i :=
   @iSup_inf_of_monotone α _ ιᵒᵈ _ _ f g hf.dual_left hg.dual_left
 
-theorem himp_eq_sSup : a ⇨ b = sSup {w | w ⊓ a ≤ b} := by
-  apply le_antisymm
-  · rw [le_sSup_iff]
-    simp only [upperBounds, mem_setOf_eq]
-    intro a1 b1
-    simp_all only [himp_inf_self, inf_le_left]
-  · rw [sSup_le_iff]
-    exact fun b_1 a_1 ↦ (fun {α} [Frame α] (a b c : α) ↦ (Frame.le_himp_iff a b c).mpr) b_1 a b a_1
+theorem isGreatest_himp {α} [GeneralizedHeytingAlgebra α] (a b : α) :
+    IsGreatest {w | w ⊓ a ≤ b} (a ⇨ b) := by
+  simp only [IsGreatest, mem_setOf_eq, himp_inf_self, inf_le_left, mem_upperBounds, le_himp_iff,
+    imp_self, implies_true, and_self]
 
+theorem isLeast_sdiff {α} [GeneralizedCoheytingAlgebra α] (a b : α) :
+    IsLeast {w | a ≤ b ⊔ w} (a \ b) := by
+  simp only [IsLeast, mem_setOf_eq, sup_sdiff_self, le_sup_right, mem_lowerBounds, sdiff_le_iff,
+    imp_self, implies_true, and_self]
+
+lemma isGreatest_sSup {α} [CompleteSemilatticeSup α] (a : α) (s : Set α) :
+  IsGreatest s a → sSup s = a :=
+    fun h ↦ IsLUB.sSup_eq (IsGreatest.isLUB h)
+
+lemma isLeast_sInf {α} [CompleteSemilatticeInf α] (a : α) (s : Set α) :
+  IsLeast s a → sInf s = a :=
+    fun h ↦ IsGLB.sInf_eq (IsLeast.isGLB h)
+
+theorem himp_eq_sSup : sSup {w | w ⊓ a ≤ b} = a ⇨ b :=
+  (isGreatest_sSup _ _ (isGreatest_himp a b))
+
+theorem sdiff_eq_sInf {α} [Coframe α]  (a b : α) :
+    sInf {w | a ≤ b ⊔ w} = a \ b := by
+  exact (isLeast_sInf _ _ (isLeast_sdiff a b))
 
 
 -- see Note [lower instance priority]


### PR DESCRIPTION
---
Himp can be expressed in terms of sSup. Does this fit into mathlib?

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
