### PR TITLE
[Merged by Bors] - feat: Prove `r_one_zpow`

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -98,10 +98,6 @@ theorem inv_r (i : ZMod n) : (r i)⁻¹ = r (-i) := by
 theorem inv_sr (i : ZMod n) : (sr i)⁻¹ = sr (i) := by
   rfl
 
-@[simp]
-theorem r_zero (i : ZMod n) : (r i) ^ 0 = r 0 := by
-  rfl
-
 theorem one_def : (1 : DihedralGroup n) = r 0 :=
   rfl
 
@@ -146,6 +142,7 @@ theorem r_one_pow (k : ℕ) : (r 1 : DihedralGroup n) ^ k = r k := by
     norm_cast
     rw [Nat.one_add]
 
+@[simp]
 theorem r_one_zpow (k : ℤ) : (r 1 : DihedralGroup n) ^ k = r k := by
   cases k <;> simp
 

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -91,11 +91,11 @@ theorem sr_mul_sr (i j : ZMod n) : sr i * sr j = r (j - i) :=
   rfl
 
 @[simp]
-theorem inv_r (i : ZMod n) : (r i)⁻¹ = r (-i) := by
+theorem inv_r (i : ZMod n) : (r i)⁻¹ = r (-i) :=
   rfl
 
 @[simp]
-theorem inv_sr (i : ZMod n) : (sr i)⁻¹ = sr (i) := by
+theorem inv_sr (i : ZMod n) : (sr i)⁻¹ = sr i :=
   rfl
 
 theorem one_def : (1 : DihedralGroup n) = r 0 :=

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -134,6 +134,22 @@ theorem r_one_pow (k : ℕ) : (r 1 : DihedralGroup n) ^ k = r k := by
     norm_cast
     rw [Nat.one_add]
 
+theorem r_inv (i : ZMod n) : (r i)⁻¹ = r (-i) := by
+  rfl
+
+theorem r_one_zpow (k : ℤ) : (r 1 : DihedralGroup n) ^ k = r k := by
+  rcases (le_or_lt 0 k) with pos | neg
+  · lift k to ℕ using pos
+    simp only [zpow_natCast, r_one_pow, Int.cast_natCast]
+  · have : ∃ l : ℤ, l = -k ∧ k = -l ∧ l ≥ 0 := by
+      use -k
+      simp only [neg_neg, ge_iff_le, Left.nonneg_neg_iff, true_and]
+      linarith
+    cases' this with l conds
+    rw [conds.2.1]
+    lift l to ℕ using conds.2.2
+    simp [r_inv]
+
 -- @[simp] -- Porting note: simp changes the goal to `r 0 = 1`. `r_one_pow_n` is no longer useful.
 theorem r_one_pow_n : r (1 : ZMod n) ^ n = 1 := by
   rw [r_one_pow, one_def]

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -138,17 +138,7 @@ theorem r_inv (i : ZMod n) : (r i)⁻¹ = r (-i) := by
   rfl
 
 theorem r_one_zpow (k : ℤ) : (r 1 : DihedralGroup n) ^ k = r k := by
-  rcases (le_or_lt 0 k) with pos | neg
-  · lift k to ℕ using pos
-    simp only [zpow_natCast, r_one_pow, Int.cast_natCast]
-  · have : ∃ l : ℤ, k = -l ∧ l ≥ 0 := by
-      use -k
-      simp only [neg_neg, ge_iff_le, Left.nonneg_neg_iff, true_and]
-      linarith
-    cases' this with l conds
-    rw [conds.1]
-    lift l to ℕ using conds.2
-    simp [r_inv]
+  cases k <;> simp [r_inv]
 
 -- @[simp] -- Porting note: simp changes the goal to `r 0 = 1`. `r_one_pow_n` is no longer useful.
 theorem r_one_pow_n : r (1 : ZMod n) ^ n = 1 := by

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -90,6 +90,18 @@ theorem sr_mul_r (i j : ZMod n) : sr i * r j = sr (i + j) :=
 theorem sr_mul_sr (i j : ZMod n) : sr i * sr j = r (j - i) :=
   rfl
 
+@[simp]
+theorem inv_r (i : ZMod n) : (r i)⁻¹ = r (-i) := by
+  rfl
+
+@[simp]
+theorem inv_sr (i : ZMod n) : (sr i)⁻¹ = sr (i) := by
+  rfl
+
+@[simp]
+theorem r_zero (i : ZMod n) : (r i) ^ 0 = r 0 := by
+  rfl
+
 theorem one_def : (1 : DihedralGroup n) = r 0 :=
   rfl
 
@@ -134,11 +146,8 @@ theorem r_one_pow (k : ℕ) : (r 1 : DihedralGroup n) ^ k = r k := by
     norm_cast
     rw [Nat.one_add]
 
-theorem r_inv (i : ZMod n) : (r i)⁻¹ = r (-i) := by
-  rfl
-
 theorem r_one_zpow (k : ℤ) : (r 1 : DihedralGroup n) ^ k = r k := by
-  cases k <;> simp [r_inv]
+  cases k <;> simp
 
 -- @[simp] -- Porting note: simp changes the goal to `r 0 = 1`. `r_one_pow_n` is no longer useful.
 theorem r_one_pow_n : r (1 : ZMod n) ^ n = 1 := by

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -141,13 +141,13 @@ theorem r_one_zpow (k : ℤ) : (r 1 : DihedralGroup n) ^ k = r k := by
   rcases (le_or_lt 0 k) with pos | neg
   · lift k to ℕ using pos
     simp only [zpow_natCast, r_one_pow, Int.cast_natCast]
-  · have : ∃ l : ℤ, l = -k ∧ k = -l ∧ l ≥ 0 := by
+  · have : ∃ l : ℤ, k = -l ∧ l ≥ 0 := by
       use -k
       simp only [neg_neg, ge_iff_le, Left.nonneg_neg_iff, true_and]
       linarith
     cases' this with l conds
-    rw [conds.2.1]
-    lift l to ℕ using conds.2.2
+    rw [conds.1]
+    lift l to ℕ using conds.2
     simp [r_inv]
 
 -- @[simp] -- Porting note: simp changes the goal to `r 0 = 1`. `r_one_pow_n` is no longer useful.


### PR DESCRIPTION
Prove `DihedralGroup.r_one_zpow`, which extends `r_one_pow` to the integers.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
