### PR TITLE
[Merged by Bors] - chore(Denumerable): simplify proof of ofNat_surjective

### DIFF
--- a/Mathlib/Logic/Denumerable.lean
+++ b/Mathlib/Logic/Denumerable.lean
@@ -234,32 +234,22 @@ def ofNat (s : Set ℕ) [DecidablePred (· ∈ s)] [Infinite s] : ℕ → s
   | 0 => ⊥
   | n + 1 => succ (ofNat s n)
 
-theorem ofNat_surjective_aux : ∀ {x : ℕ} (hx : x ∈ s), ∃ n, ofNat s n = ⟨x, hx⟩
-  | x => fun hx => by
+theorem ofNat_surjective : Surjective (ofNat s)
+  | ⟨x, hx⟩ => by
     set t : List s :=
       ((List.range x).filter fun y => y ∈ s).pmap
         (fun (y : ℕ) (hy : y ∈ s) => ⟨y, hy⟩)
         (by intros a ha; simpa using (List.mem_filter.mp ha).2) with ht
     have hmt : ∀ {y : s}, y ∈ t ↔ y < ⟨x, hx⟩ := by
       simp [List.mem_filter, Subtype.ext_iff_val, ht]
-    have wf : ∀ m : s, List.maximum t = m → ↑m < x := fun m hmax => by
-      simpa using hmt.mp (List.maximum_mem hmax)
     cases' hmax : List.maximum t with m
     · refine ⟨0, le_antisymm bot_le (le_of_not_gt fun h => List.not_mem_nil (⊥ : s) ?_)⟩
       rwa [← List.maximum_eq_bot.1 hmax, hmt]
-    cases' ofNat_surjective_aux m.2 with a ha
-    refine ⟨a + 1, le_antisymm ?_ ?_⟩ <;> rw [ofNat]
-    · refine succ_le_of_lt ?_
-      rw [ha]
-      exact wf _ hmax
-    · refine le_succ_of_forall_lt_le fun z hz => ?_
-      rw [ha]
-      cases m
-      exact List.le_maximum_of_mem (hmt.2 hz) hmax
-decreasing_by
-  tauto
-
-theorem ofNat_surjective : Surjective (ofNat s) := fun ⟨_, hx⟩ => ofNat_surjective_aux hx
+    have wf : ↑m < x := by simpa using hmt.mp (List.maximum_mem hmax)
+    rcases ofNat_surjective m with ⟨a, rfl⟩
+    refine ⟨a + 1, le_antisymm (succ_le_of_lt wf) ?_⟩
+    exact le_succ_of_forall_lt_le fun z hz => List.le_maximum_of_mem (hmt.2 hz) hmax
+  termination_by n => n.val
 
 @[simp]
 theorem ofNat_range : Set.range (ofNat s) = Set.univ :=


### PR DESCRIPTION

No need for auxiliary theorem, and a bit of simplification.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
