### PR TITLE
[Merged by Bors] - feat: add `Set.preimage_image_univ` and associated `GaloisConnection` result

### DIFF
--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -424,7 +424,7 @@ theorem subset_preimage_image (f : α → β) (s : Set α) : s ⊆ f ⁻¹' (f '
 theorem preimage_image_univ {f : α → β} : f ⁻¹' (f '' univ) = univ :=
   Subset.antisymm (fun _ _ => trivial) (subset_preimage_image f univ)
 
-theorem image_preimage_empty {f : α → β} : f '' (f ⁻¹' ∅) = ∅ := 
+theorem image_preimage_empty {f : α → β} : f '' (f ⁻¹' ∅) = ∅ :=
   Subset.antisymm (image_preimage_subset f ∅) (fun _ h => False.elim h)
 
 theorem preimage_image_empty {f : α → β} : f ⁻¹' (f '' ∅) = ∅ := by

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -9,6 +9,7 @@ import Batteries.Tactic.Congr
 import Mathlib.Order.TypeTags
 import Mathlib.Data.Option.Basic
 import Mathlib.Data.Set.SymmDiff
+--import Mathlib.Data.Set.Lattice
 
 /-!
 # Images and preimages of sets
@@ -420,6 +421,10 @@ theorem image_preimage_subset (f : α → β) (s : Set β) : f '' (f ⁻¹' s) �
 
 theorem subset_preimage_image (f : α → β) (s : Set α) : s ⊆ f ⁻¹' (f '' s) := fun _ =>
   mem_image_of_mem f
+
+@[simp]
+theorem preimage_image_univ (f : α → β) : f ⁻¹' (f '' univ) = univ :=
+  Set.image_preimage.l_u_top
 
 @[simp]
 theorem preimage_image_eq {f : α → β} (s : Set α) (h : Injective f) : f ⁻¹' (f '' s) = s :=

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -9,7 +9,6 @@ import Batteries.Tactic.Congr
 import Mathlib.Order.TypeTags
 import Mathlib.Data.Option.Basic
 import Mathlib.Data.Set.SymmDiff
-import Mathlib.Data.Set.Lattice
 
 /-!
 # Images and preimages of sets
@@ -423,8 +422,8 @@ theorem subset_preimage_image (f : α → β) (s : Set α) : s ⊆ f ⁻¹' (f '
   mem_image_of_mem f
 
 @[simp]
-theorem preimage_image_univ (f : α → β) : f ⁻¹' (f '' univ) = univ :=
-  Set.image_preimage.l_u_top
+theorem preimage_image_univ {f : α → β} : f ⁻¹' (f '' univ) = univ :=
+  subset_antisymm (fun _ _ => trivial) (subset_preimage_image f univ)
 
 @[simp]
 theorem preimage_image_eq {f : α → β} (s : Set α) (h : Injective f) : f ⁻¹' (f '' s) = s :=

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -9,7 +9,7 @@ import Batteries.Tactic.Congr
 import Mathlib.Order.TypeTags
 import Mathlib.Data.Option.Basic
 import Mathlib.Data.Set.SymmDiff
---import Mathlib.Data.Set.Lattice
+import Mathlib.Data.Set.Lattice
 
 /-!
 # Images and preimages of sets

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -424,12 +424,6 @@ theorem subset_preimage_image (f : α → β) (s : Set α) : s ⊆ f ⁻¹' (f '
 theorem preimage_image_univ {f : α → β} : f ⁻¹' (f '' univ) = univ :=
   Subset.antisymm (fun _ _ => trivial) (subset_preimage_image f univ)
 
-theorem image_preimage_empty {f : α → β} : f '' (f ⁻¹' ∅) = ∅ := 
-  Subset.antisymm (image_preimage_subset f ∅) (fun _ h => False.elim h)
-
-theorem preimage_image_empty {f : α → β} : f ⁻¹' (f '' ∅) = ∅ := by
-  rw [image_empty, preimage_empty]
-
 @[simp]
 theorem preimage_image_eq {f : α → β} (s : Set α) (h : Injective f) : f ⁻¹' (f '' s) = s :=
   Subset.antisymm (fun _ ⟨_, hy, e⟩ => h e ▸ hy) (subset_preimage_image f s)

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -424,6 +424,12 @@ theorem subset_preimage_image (f : α → β) (s : Set α) : s ⊆ f ⁻¹' (f '
 theorem preimage_image_univ {f : α → β} : f ⁻¹' (f '' univ) = univ :=
   Subset.antisymm (fun _ _ => trivial) (subset_preimage_image f univ)
 
+theorem image_preimage_empty {f : α → β} : f '' (f ⁻¹' ∅) = ∅ := 
+  Subset.antisymm (image_preimage_subset f ∅) (fun _ h => False.elim h)
+
+theorem preimage_image_empty {f : α → β} : f ⁻¹' (f '' ∅) = ∅ := by
+  rw [image_empty, preimage_empty]
+
 @[simp]
 theorem preimage_image_eq {f : α → β} (s : Set α) (h : Injective f) : f ⁻¹' (f '' s) = s :=
   Subset.antisymm (fun _ ⟨_, hy, e⟩ => h e ▸ hy) (subset_preimage_image f s)

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -424,12 +424,6 @@ theorem subset_preimage_image (f : α → β) (s : Set α) : s ⊆ f ⁻¹' (f '
 theorem preimage_image_univ {f : α → β} : f ⁻¹' (f '' univ) = univ :=
   Subset.antisymm (fun _ _ => trivial) (subset_preimage_image f univ)
 
-theorem image_preimage_empty {f : α → β} : f '' (f ⁻¹' ∅) = ∅ :=
-  Subset.antisymm (image_preimage_subset f ∅) (fun _ h => False.elim h)
-
-theorem preimage_image_empty {f : α → β} : f ⁻¹' (f '' ∅) = ∅ := by
-  rw [image_empty, preimage_empty]
-
 @[simp]
 theorem preimage_image_eq {f : α → β} (s : Set α) (h : Injective f) : f ⁻¹' (f '' s) = s :=
   Subset.antisymm (fun _ ⟨_, hy, e⟩ => h e ▸ hy) (subset_preimage_image f s)

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -421,9 +421,8 @@ theorem image_preimage_subset (f : α → β) (s : Set β) : f '' (f ⁻¹' s) �
 theorem subset_preimage_image (f : α → β) (s : Set α) : s ⊆ f ⁻¹' (f '' s) := fun _ =>
   mem_image_of_mem f
 
-@[simp]
 theorem preimage_image_univ {f : α → β} : f ⁻¹' (f '' univ) = univ :=
-  subset_antisymm (fun _ _ => trivial) (subset_preimage_image f univ)
+  Subset.antisymm (fun _ _ => trivial) (subset_preimage_image f univ)
 
 @[simp]
 theorem preimage_image_eq {f : α → β} (s : Set α) (h : Injective f) : f ⁻¹' (f '' s) = s :=

--- a/Mathlib/Order/GaloisConnection.lean
+++ b/Mathlib/Order/GaloisConnection.lean
@@ -204,7 +204,7 @@ theorem u_eq_top {l : α → β} {u : β → α} (gc : GaloisConnection l u) {x}
 theorem u_top [OrderTop β] {l : α → β} {u : β → α} (gc : GaloisConnection l u) : u ⊤ = ⊤ :=
   gc.u_eq_top.2 le_top
 
-theorem l_u_top {l : α → β} {u : β → α} (gc : GaloisConnection l u) : u (l ⊤) = ⊤ :=
+theorem u_l_top {l : α → β} {u : β → α} (gc : GaloisConnection l u) : u (l ⊤) = ⊤ :=
   gc.u_eq_top.mpr le_rfl
 
 end OrderTop
@@ -219,7 +219,7 @@ theorem l_eq_bot {l : α → β} {u : β → α} (gc : GaloisConnection l u) {x}
 theorem l_bot [OrderBot α] {l : α → β} {u : β → α} (gc : GaloisConnection l u) : l ⊥ = ⊥ :=
   gc.dual.u_top
 
-theorem u_l_bot {l : α → β} {u : β → α} (gc : GaloisConnection l u) : l (u ⊥) = ⊥ :=
+theorem l_u_bot {l : α → β} {u : β → α} (gc : GaloisConnection l u) : l (u ⊥) = ⊥ :=
   gc.l_eq_bot.mpr le_rfl
 
 end OrderBot

--- a/Mathlib/Order/GaloisConnection.lean
+++ b/Mathlib/Order/GaloisConnection.lean
@@ -219,6 +219,9 @@ theorem l_eq_bot {l : α → β} {u : β → α} (gc : GaloisConnection l u) {x}
 theorem l_bot [OrderBot α] {l : α → β} {u : β → α} (gc : GaloisConnection l u) : l ⊥ = ⊥ :=
   gc.dual.u_top
 
+theorem u_l_bot {l : α → β} {u : β → α} (gc : GaloisConnection l u) : l (u ⊥) = ⊥ :=
+  gc.l_eq_bot.mpr le_rfl
+
 end OrderBot
 
 section SemilatticeSup

--- a/Mathlib/Order/GaloisConnection.lean
+++ b/Mathlib/Order/GaloisConnection.lean
@@ -204,6 +204,9 @@ theorem u_eq_top {l : α → β} {u : β → α} (gc : GaloisConnection l u) {x}
 theorem u_top [OrderTop β] {l : α → β} {u : β → α} (gc : GaloisConnection l u) : u ⊤ = ⊤ :=
   gc.u_eq_top.2 le_top
 
+theorem l_u_top [OrderTop β] {l : α → β} {u : β → α} (gc : GaloisConnection l u) : u (l ⊤) = ⊤ :=
+  gc.u_eq_top.mpr le_rfl
+
 end OrderTop
 
 section OrderBot

--- a/Mathlib/Order/GaloisConnection.lean
+++ b/Mathlib/Order/GaloisConnection.lean
@@ -204,7 +204,7 @@ theorem u_eq_top {l : α → β} {u : β → α} (gc : GaloisConnection l u) {x}
 theorem u_top [OrderTop β] {l : α → β} {u : β → α} (gc : GaloisConnection l u) : u ⊤ = ⊤ :=
   gc.u_eq_top.2 le_top
 
-theorem l_u_top [OrderTop β] {l : α → β} {u : β → α} (gc : GaloisConnection l u) : u (l ⊤) = ⊤ :=
+theorem l_u_top {l : α → β} {u : β → α} (gc : GaloisConnection l u) : u (l ⊤) = ⊤ :=
   gc.u_eq_top.mpr le_rfl
 
 end OrderTop


### PR DESCRIPTION
this function shows that the preimage of the image of a universal set is the universal set.  Since preimage and image form a Galois connection, this is a special case of a more general theorem that I added there.  I chose not to use the general theorem in the special theorem since doing so would require either putting the preimage_image_univ function in an unnatural spot or solving a circular import problem.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
