### PR TITLE
[Merged by Bors] - feat(Topology): generalize universes for (co)limits in `TopCat`

### DIFF
--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -23,7 +23,7 @@ noncomputable section
 
 namespace TopCat
 
-variable {J : Type v} [SmallCategory J]
+variable {J : Type v} [Category.{w} J]
 
 local notation "forget" => forget TopCat
 
@@ -103,7 +103,7 @@ def limitConeInfiIsLimit (F : J ⥤ TopCat.{max v u}) : IsLimit (limitConeInfi.{
           (continuous_iff_coinduced_le.mp (s.π.app j).continuous : _))
   · rfl
 
-instance topCat_hasLimitsOfSize : HasLimitsOfSize.{v, v} TopCat.{max v u} where
+instance topCat_hasLimitsOfSize : HasLimitsOfSize.{w, v} TopCat.{max v u} where
   has_limits_of_shape _ :=
     { has_limit := fun F =>
         HasLimit.mk
@@ -114,7 +114,7 @@ instance topCat_hasLimits : HasLimits TopCat.{u} :=
   TopCat.topCat_hasLimitsOfSize.{u, u}
 
 instance forget_preservesLimitsOfSize :
-    PreservesLimitsOfSize.{v, v} (forget : TopCat.{max v u} ⥤ _) where
+    PreservesLimitsOfSize.{w, v} (forget : TopCat.{max v u} ⥤ _) where
   preservesLimitsOfShape {_} :=
     { preservesLimit := fun {F} =>
       preservesLimit_of_preserves_limit_cone (limitConeIsLimit.{v,u} F)
@@ -162,7 +162,7 @@ def colimitCoconeIsColimit (F : J ⥤ TopCat.{max v u}) : IsColimit (colimitCoco
           (continuous_iff_coinduced_le.mp (s.ι.app j).continuous : _))
   · rfl
 
-instance topCat_hasColimitsOfSize : HasColimitsOfSize.{v,v} TopCat.{max v u} where
+instance topCat_hasColimitsOfSize : HasColimitsOfSize.{w,v} TopCat.{max v u} where
   has_colimits_of_shape _ :=
     { has_colimit := fun F =>
         HasColimit.mk

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -173,7 +173,7 @@ instance topCat_hasColimits : HasColimits TopCat.{u} :=
   TopCat.topCat_hasColimitsOfSize.{u, u}
 
 instance forget_preservesColimitsOfSize :
-    PreservesColimitsOfSize.{v, v} (forget : TopCat.{max u v} ⥤ _) where
+    PreservesColimitsOfSize.{w, v} (forget : TopCat.{max u v} ⥤ _) where
   preservesColimitsOfShape :=
     { preservesColimit := fun {F} =>
         preservesColimit_of_preserves_colimit_cocone (colimitCoconeIsColimit F)

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -23,7 +23,7 @@ noncomputable section
 
 namespace TopCat
 
-variable {J : Type u} [Category.{v} J]
+variable {J : Type v} [SmallCategory J]
 
 local notation "forget" => forget TopCat
 
@@ -53,13 +53,13 @@ Generally you should just use `limit.cone F`, unless you need the actual definit
 -/
 def limitConeInfi (F : J ⥤ TopCat.{max v u}) : Cone F where
   pt :=
-    ⟨(Types.limitCone.{u,v} (F ⋙ forget)).pt,
-      ⨅ j, (F.obj j).str.induced ((Types.limitCone.{u,v} (F ⋙ forget)).π.app j)⟩
+    ⟨(Types.limitCone.{v,u} (F ⋙ forget)).pt,
+      ⨅ j, (F.obj j).str.induced ((Types.limitCone.{v,u} (F ⋙ forget)).π.app j)⟩
   π :=
     { app := fun j =>
-        ⟨(Types.limitCone.{u,v} (F ⋙ forget)).π.app j, continuous_iff_le_induced.mpr (iInf_le _ _)⟩
+        ⟨(Types.limitCone.{v,u} (F ⋙ forget)).π.app j, continuous_iff_le_induced.mpr (iInf_le _ _)⟩
       naturality := fun _ _ f =>
-        ContinuousMap.coe_injective ((Types.limitCone.{u,v} (F ⋙ forget)).π.naturality f) }
+        ContinuousMap.coe_injective ((Types.limitCone.{v,u} (F ⋙ forget)).π.naturality f) }
 
 /-- The chosen cone `TopCat.limitCone F` for a functor `F : J ⥤ TopCat` is a limit cone.
 Generally you should just use `limit.isLimit F`, unless you need the actual definition
@@ -88,7 +88,7 @@ Generally you should just use `limit.isLimit F`, unless you need the actual defi
 (which is in terms of `Types.limitConeIsLimit`).
 -/
 def limitConeInfiIsLimit (F : J ⥤ TopCat.{max v u}) : IsLimit (limitConeInfi.{v,u} F) := by
-  refine IsLimit.ofFaithful forget (Types.limitConeIsLimit.{u,v} (F ⋙ forget))
+  refine IsLimit.ofFaithful forget (Types.limitConeIsLimit.{v,u} (F ⋙ forget))
     -- Porting note: previously could infer all ?_ except continuity
     (fun s => ⟨fun v => ⟨fun j => (Functor.mapCone forget s).π.app j v, ?_⟩, ?_⟩) fun s => ?_
   · dsimp [Functor.sections]
@@ -103,7 +103,7 @@ def limitConeInfiIsLimit (F : J ⥤ TopCat.{max v u}) : IsLimit (limitConeInfi.{
           (continuous_iff_coinduced_le.mp (s.π.app j).continuous : _))
   · rfl
 
-instance topCat_hasLimitsOfSize : HasLimitsOfSize.{v, u} TopCat.{max v u} where
+instance topCat_hasLimitsOfSize : HasLimitsOfSize.{v, v} TopCat.{max v u} where
   has_limits_of_shape _ :=
     { has_limit := fun F =>
         HasLimit.mk
@@ -114,11 +114,11 @@ instance topCat_hasLimits : HasLimits TopCat.{u} :=
   TopCat.topCat_hasLimitsOfSize.{u, u}
 
 instance forget_preservesLimitsOfSize :
-    PreservesLimitsOfSize.{v, u} (forget : TopCat.{max v u} ⥤ _) where
+    PreservesLimitsOfSize.{v, v} (forget : TopCat.{max v u} ⥤ _) where
   preservesLimitsOfShape {_} :=
     { preservesLimit := fun {F} =>
       preservesLimit_of_preserves_limit_cone (limitConeIsLimit.{v,u} F)
-          (Types.limitConeIsLimit.{u,v} (F ⋙ forget)) }
+          (Types.limitConeIsLimit.{v,u} (F ⋙ forget)) }
 
 instance forget_preservesLimits : PreservesLimits (forget : TopCat.{u} ⥤ _) :=
   TopCat.forget_preservesLimitsOfSize.{u, u}
@@ -129,7 +129,7 @@ Generally you should just use `colimit.cocone F`, unless you need the actual def
 -/
 def colimitCocone (F : J ⥤ TopCat.{max v u}) : Cocone F where
   pt :=
-    ⟨(Types.TypeMax.colimitCocone.{u,v} (F ⋙ forget)).pt,
+    ⟨(Types.TypeMax.colimitCocone.{v,u} (F ⋙ forget)).pt,
       ⨆ j, (F.obj j).str.coinduced ((Types.TypeMax.colimitCocone (F ⋙ forget)).ι.app j)⟩
   ι :=
     { app := fun j =>
@@ -146,7 +146,7 @@ Generally you should just use `colimit.isColimit F`, unless you need the actual 
 -/
 def colimitCoconeIsColimit (F : J ⥤ TopCat.{max v u}) : IsColimit (colimitCocone F) := by
   refine
-    IsColimit.ofFaithful forget (Types.TypeMax.colimitCoconeIsColimit.{u, v} _) (fun s =>
+    IsColimit.ofFaithful forget (Types.TypeMax.colimitCoconeIsColimit.{v, u} _) (fun s =>
     -- Porting note: it appears notation for forget breaks dot notation (also above)
     -- Porting note: previously function was inferred
       ⟨Quot.lift (fun p => (Functor.mapCocone forget s).ι.app p.fst p.snd) ?_, ?_⟩) fun s => ?_
@@ -162,7 +162,7 @@ def colimitCoconeIsColimit (F : J ⥤ TopCat.{max v u}) : IsColimit (colimitCoco
           (continuous_iff_coinduced_le.mp (s.ι.app j).continuous : _))
   · rfl
 
-instance topCat_hasColimitsOfSize : HasColimitsOfSize.{v,u} TopCat.{max v u} where
+instance topCat_hasColimitsOfSize : HasColimitsOfSize.{v,v} TopCat.{max v u} where
   has_colimits_of_shape _ :=
     { has_colimit := fun F =>
         HasColimit.mk
@@ -173,7 +173,7 @@ instance topCat_hasColimits : HasColimits TopCat.{u} :=
   TopCat.topCat_hasColimitsOfSize.{u, u}
 
 instance forget_preservesColimitsOfSize :
-    PreservesColimitsOfSize.{v, u} (forget : TopCat.{max u v} ⥤ _) where
+    PreservesColimitsOfSize.{v, v} (forget : TopCat.{max u v} ⥤ _) where
   preservesColimitsOfShape :=
     { preservesColimit := fun {F} =>
         preservesColimit_of_preserves_colimit_cocone (colimitCoconeIsColimit F)

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -23,7 +23,7 @@ noncomputable section
 
 namespace TopCat
 
-variable {J : Type v} [SmallCategory J]
+variable {J : Type u} [Category.{v} J]
 
 local notation "forget" => forget TopCat
 
@@ -53,13 +53,13 @@ Generally you should just use `limit.cone F`, unless you need the actual definit
 -/
 def limitConeInfi (F : J ⥤ TopCat.{max v u}) : Cone F where
   pt :=
-    ⟨(Types.limitCone.{v,u} (F ⋙ forget)).pt,
-      ⨅ j, (F.obj j).str.induced ((Types.limitCone.{v,u} (F ⋙ forget)).π.app j)⟩
+    ⟨(Types.limitCone.{u,v} (F ⋙ forget)).pt,
+      ⨅ j, (F.obj j).str.induced ((Types.limitCone.{u,v} (F ⋙ forget)).π.app j)⟩
   π :=
     { app := fun j =>
-        ⟨(Types.limitCone.{v,u} (F ⋙ forget)).π.app j, continuous_iff_le_induced.mpr (iInf_le _ _)⟩
+        ⟨(Types.limitCone.{u,v} (F ⋙ forget)).π.app j, continuous_iff_le_induced.mpr (iInf_le _ _)⟩
       naturality := fun _ _ f =>
-        ContinuousMap.coe_injective ((Types.limitCone.{v,u} (F ⋙ forget)).π.naturality f) }
+        ContinuousMap.coe_injective ((Types.limitCone.{u,v} (F ⋙ forget)).π.naturality f) }
 
 /-- The chosen cone `TopCat.limitCone F` for a functor `F : J ⥤ TopCat` is a limit cone.
 Generally you should just use `limit.isLimit F`, unless you need the actual definition
@@ -88,7 +88,7 @@ Generally you should just use `limit.isLimit F`, unless you need the actual defi
 (which is in terms of `Types.limitConeIsLimit`).
 -/
 def limitConeInfiIsLimit (F : J ⥤ TopCat.{max v u}) : IsLimit (limitConeInfi.{v,u} F) := by
-  refine IsLimit.ofFaithful forget (Types.limitConeIsLimit.{v,u} (F ⋙ forget))
+  refine IsLimit.ofFaithful forget (Types.limitConeIsLimit.{u,v} (F ⋙ forget))
     -- Porting note: previously could infer all ?_ except continuity
     (fun s => ⟨fun v => ⟨fun j => (Functor.mapCone forget s).π.app j v, ?_⟩, ?_⟩) fun s => ?_
   · dsimp [Functor.sections]
@@ -103,7 +103,7 @@ def limitConeInfiIsLimit (F : J ⥤ TopCat.{max v u}) : IsLimit (limitConeInfi.{
           (continuous_iff_coinduced_le.mp (s.π.app j).continuous : _))
   · rfl
 
-instance topCat_hasLimitsOfSize : HasLimitsOfSize.{v, v} TopCat.{max v u} where
+instance topCat_hasLimitsOfSize : HasLimitsOfSize.{v, u} TopCat.{max v u} where
   has_limits_of_shape _ :=
     { has_limit := fun F =>
         HasLimit.mk
@@ -114,11 +114,11 @@ instance topCat_hasLimits : HasLimits TopCat.{u} :=
   TopCat.topCat_hasLimitsOfSize.{u, u}
 
 instance forget_preservesLimitsOfSize :
-    PreservesLimitsOfSize.{v, v} (forget : TopCat.{max v u} ⥤ _) where
+    PreservesLimitsOfSize.{v, u} (forget : TopCat.{max v u} ⥤ _) where
   preservesLimitsOfShape {_} :=
     { preservesLimit := fun {F} =>
       preservesLimit_of_preserves_limit_cone (limitConeIsLimit.{v,u} F)
-          (Types.limitConeIsLimit.{v,u} (F ⋙ forget)) }
+          (Types.limitConeIsLimit.{u,v} (F ⋙ forget)) }
 
 instance forget_preservesLimits : PreservesLimits (forget : TopCat.{u} ⥤ _) :=
   TopCat.forget_preservesLimitsOfSize.{u, u}
@@ -129,7 +129,7 @@ Generally you should just use `colimit.cocone F`, unless you need the actual def
 -/
 def colimitCocone (F : J ⥤ TopCat.{max v u}) : Cocone F where
   pt :=
-    ⟨(Types.TypeMax.colimitCocone.{v,u} (F ⋙ forget)).pt,
+    ⟨(Types.TypeMax.colimitCocone.{u,v} (F ⋙ forget)).pt,
       ⨆ j, (F.obj j).str.coinduced ((Types.TypeMax.colimitCocone (F ⋙ forget)).ι.app j)⟩
   ι :=
     { app := fun j =>
@@ -146,7 +146,7 @@ Generally you should just use `colimit.isColimit F`, unless you need the actual 
 -/
 def colimitCoconeIsColimit (F : J ⥤ TopCat.{max v u}) : IsColimit (colimitCocone F) := by
   refine
-    IsColimit.ofFaithful forget (Types.TypeMax.colimitCoconeIsColimit.{v, u} _) (fun s =>
+    IsColimit.ofFaithful forget (Types.TypeMax.colimitCoconeIsColimit.{u, v} _) (fun s =>
     -- Porting note: it appears notation for forget breaks dot notation (also above)
     -- Porting note: previously function was inferred
       ⟨Quot.lift (fun p => (Functor.mapCocone forget s).ι.app p.fst p.snd) ?_, ?_⟩) fun s => ?_
@@ -162,7 +162,7 @@ def colimitCoconeIsColimit (F : J ⥤ TopCat.{max v u}) : IsColimit (colimitCoco
           (continuous_iff_coinduced_le.mp (s.ι.app j).continuous : _))
   · rfl
 
-instance topCat_hasColimitsOfSize : HasColimitsOfSize.{v,v} TopCat.{max v u} where
+instance topCat_hasColimitsOfSize : HasColimitsOfSize.{v,u} TopCat.{max v u} where
   has_colimits_of_shape _ :=
     { has_colimit := fun F =>
         HasColimit.mk
@@ -173,7 +173,7 @@ instance topCat_hasColimits : HasColimits TopCat.{u} :=
   TopCat.topCat_hasColimitsOfSize.{u, u}
 
 instance forget_preservesColimitsOfSize :
-    PreservesColimitsOfSize.{v, v} (forget : TopCat.{max u v} ⥤ _) where
+    PreservesColimitsOfSize.{v, u} (forget : TopCat.{max u v} ⥤ _) where
   preservesColimitsOfShape :=
     { preservesColimit := fun {F} =>
         preservesColimit_of_preserves_colimit_cocone (colimitCoconeIsColimit F)

--- a/Mathlib/Topology/Category/TopCat/Limits/Cofiltered.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Cofiltered.lean
@@ -29,7 +29,7 @@ namespace TopCat
 
 section CofilteredLimit
 
-variable {J : Type v} [SmallCategory J] [IsCofiltered J] (F : J ⥤ TopCat.{max v u}) (C : Cone F)
+variable {J : Type v} [Category.{w} J] [IsCofiltered J] (F : J ⥤ TopCat.{max v u}) (C : Cone F)
 
 /-- Given a *compatible* collection of topological bases for the factors in a cofiltered limit
 which contain `Set.univ` and are closed under intersections, the induced *naive* collection

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -22,7 +22,7 @@ noncomputable section
 
 namespace TopCat
 
-variable {J : Type v} [SmallCategory J]
+variable {J : Type v} [Category.{w} J]
 
 /-- The projection from the product as a bundled continuous map. -/
 abbrev piπ {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) : TopCat.of (∀ i, α i) ⟶ α i :=

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -21,7 +21,7 @@ noncomputable section
 
 namespace TopCat
 
-variable {J : Type v} [SmallCategory J]
+variable {J : Type v} [Category.{w} J]
 
 section Pullback
 


### PR DESCRIPTION
In order to construct the (co)limit of a functor ` J ⥤ TopCat`, we no longer assume `J` is a small category.
 
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
