### PR TITLE
[Merged by Bors] - feat: dot notation for composition of `AEMeasurable` functions with standard functions

### DIFF
--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Basic.lean
@@ -24,7 +24,7 @@ assert_not_exists FiniteDimensional.proper
 
 noncomputable section
 
-open NNReal ENNReal
+open NNReal ENNReal MeasureTheory
 
 namespace Real
 
@@ -165,6 +165,43 @@ theorem Measurable.sqrt : Measurable fun x => √(f x) :=
 
 end RealComposition
 
+section RealComposition
+
+open Real
+
+variable {α : Type*} {m : MeasurableSpace α} {μ : Measure α} {f : α → ℝ} (hf : AEMeasurable f μ)
+include hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.exp : AEMeasurable (fun x ↦ exp (f x)) μ :=
+  measurable_exp.comp_aemeasurable hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.log : AEMeasurable (fun x ↦ log (f x)) μ :=
+  measurable_log.comp_aemeasurable hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.cos : AEMeasurable (fun x ↦ cos (f x)) μ :=
+  measurable_cos.comp_aemeasurable hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.sin : AEMeasurable (fun x ↦ sin (f x)) μ :=
+  measurable_sin.comp_aemeasurable hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.cosh : AEMeasurable (fun x ↦ cosh (f x)) μ :=
+  measurable_cosh.comp_aemeasurable hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.sinh : AEMeasurable (fun x ↦ sinh (f x)) μ :=
+  measurable_sinh.comp_aemeasurable hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.sqrt : AEMeasurable (fun x ↦ √(f x)) μ :=
+  continuous_sqrt.measurable.comp_aemeasurable hf
+
+end RealComposition
+
 section ComplexComposition
 
 open Complex
@@ -199,6 +236,43 @@ theorem Measurable.carg : Measurable fun x => arg (f x) :=
 @[measurability]
 theorem Measurable.clog : Measurable fun x => Complex.log (f x) :=
   measurable_log.comp hf
+
+end ComplexComposition
+
+section ComplexComposition
+
+open Complex
+
+variable {α : Type*} {m : MeasurableSpace α} {μ : Measure α} {f : α → ℂ} (hf : AEMeasurable f μ)
+include hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.cexp : AEMeasurable (fun x ↦ exp (f x)) μ :=
+  measurable_exp.comp_aemeasurable hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.ccos : AEMeasurable (fun x ↦ cos (f x)) μ :=
+  measurable_cos.comp_aemeasurable hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.csin : AEMeasurable (fun x ↦ sin (f x)) μ :=
+  measurable_sin.comp_aemeasurable hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.ccosh : AEMeasurable (fun x ↦ cosh (f x)) μ :=
+  measurable_cosh.comp_aemeasurable hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.csinh : AEMeasurable (fun x ↦ sinh (f x)) μ :=
+  measurable_sinh.comp_aemeasurable hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.carg : AEMeasurable (fun x ↦ arg (f x)) μ :=
+  measurable_arg.comp_aemeasurable hf
+
+@[measurability, fun_prop]
+protected lemma AEMeasurable.clog : AEMeasurable (fun x ↦ log (f x)) μ :=
+  measurable_log.comp_aemeasurable hf
 
 end ComplexComposition
 


### PR DESCRIPTION
These are consistent with the statements about composition of `Measurable` functions that appear immediately above.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
