### PR TITLE
[Merged by Bors] - feat: `Fin.cons` and `Fin.snoc` are continuous

### DIFF
--- a/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
@@ -383,7 +383,7 @@ theorem continuousOn_face_Icc {X} [TopologicalSpace X] {n} {f : (Fin (n + 1) →
     {I : Box (Fin (n + 1))} (h : ContinuousOn f (Box.Icc I)) {i : Fin (n + 1)} {x : ℝ}
     (hx : x ∈ Icc (I.lower i) (I.upper i)) :
     ContinuousOn (f ∘ i.insertNth x) (Box.Icc (I.face i)) :=
-  h.comp (continuousOn_const.fin_insertNth i continuousOn_id) (I.mapsTo_insertNth_face_Icc hx)
+  h.comp (continuousOn_const.finInsertNth i continuousOn_id) (I.mapsTo_insertNth_face_Icc hx)
 
 /-!
 ### Covering of the interior of a box by a monotone sequence of smaller boxes

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot
 -/
 import Mathlib.Data.Finset.Piecewise
+import Mathlib.Data.Fin.VecNotation
 import Mathlib.Order.Filter.Curry
 import Mathlib.Topology.Maps.Basic
 import Mathlib.Topology.NhdsSet
@@ -1419,57 +1420,78 @@ theorem continuous_mulSingle [∀ i, One (π i)] [DecidableEq ι] (i : ι) :
 section Fin
 variable {n : ℕ} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
 
-theorem Filter.Tendsto.fin_cons
-    {f : Y → π 0} {l : Filter Y} {x : π 0} (hf : Tendsto f l (𝓝 x))
-    {g : Y → ∀ j : Fin n, π j.succ} {y : ∀ j, π (Fin.succ j)} (hg : Tendsto g l (𝓝 y)) :
+theorem Filter.Tendsto.finCons
+    {f : Y → π 0} {g : Y → ∀ j : Fin n, π j.succ} {l : Filter Y} {x : π 0} {y : ∀ j, π (Fin.succ j)}
+    (hf : Tendsto f l (𝓝 x)) (hg : Tendsto g l (𝓝 y)) :
     Tendsto (fun a => Fin.cons (f a) (g a)) l (𝓝 <| Fin.cons x y) :=
   tendsto_pi_nhds.2 fun j => Fin.cases (by simpa) (by simpa using tendsto_pi_nhds.1 hg) j
 
-theorem ContinuousAt.fin_cons
-    {f : X → π 0} {x : X} (hf : ContinuousAt f x)
-    {g : X → ∀ j : Fin n, π (Fin.succ j)} (hg : ContinuousAt g x) :
+theorem ContinuousAt.finCons {f : X → π 0} {g : X → ∀ j : Fin n, π (Fin.succ j)} {x : X}
+    (hf : ContinuousAt f x) (hg : ContinuousAt g x) :
     ContinuousAt (fun a => Fin.cons (f a) (g a)) x :=
-  hf.tendsto.fin_cons hg
+  hf.tendsto.finCons hg
 
-theorem Continuous.fin_cons
-    {f : X → π 0} (hf : Continuous f) {g : X → ∀ j : Fin n, π (Fin.succ j)}
-    (hg : Continuous g) : Continuous fun a => Fin.cons (f a) (g a) :=
-  continuous_iff_continuousAt.2 fun _ => hf.continuousAt.fin_cons hg.continuousAt
+theorem Continuous.finCons {f : X → π 0} {g : X → ∀ j : Fin n, π (Fin.succ j)}
+    (hf : Continuous f) (hg : Continuous g) : Continuous fun a => Fin.cons (f a) (g a) :=
+  continuous_iff_continuousAt.2 fun _ => hf.continuousAt.finCons hg.continuousAt
 
-theorem Filter.Tendsto.fin_snoc
-    {f : Y → ∀ j : Fin n, π j.castSucc} {l : Filter Y} {x : ∀ j, π (Fin.castSucc j)}
-    (hf : Tendsto f l (𝓝 x))
-    {g : Y → π (Fin.last _)} {y : π (Fin.last _)} (hg : Tendsto g l (𝓝 y)) :
+theorem Filter.Tendsto.matrixVecCons
+    {f : Y → Z} {g : Y → Fin n → Z} {l : Filter Y} {x : Z} {y : Fin n → Z}
+    (hf : Tendsto f l (𝓝 x)) (hg : Tendsto g l (𝓝 y)) :
+    Tendsto (fun a => Matrix.vecCons (f a) (g a)) l (𝓝 <| Matrix.vecCons x y) :=
+  hf.finCons hg
+
+theorem ContinuousAt.matrixVecCons
+    {f : X → Z} {g : X → Fin n → Z} {x : X} (hf : ContinuousAt f x) (hg : ContinuousAt g x) :
+    ContinuousAt (fun a => Matrix.vecCons (f a) (g a)) x :=
+  hf.finCons hg
+
+theorem Continuous.matrixVecCons
+    {f : X → Z} {g : X → Fin n → Z} (hf : Continuous f) (hg : Continuous g) :
+    Continuous fun a => Matrix.vecCons (f a) (g a) :=
+  hf.finCons hg
+
+theorem Filter.Tendsto.finSnoc
+    {f : Y → ∀ j : Fin n, π j.castSucc} {g : Y → π (Fin.last _)}
+    {l : Filter Y} {x : ∀ j, π (Fin.castSucc j)} {y : π (Fin.last _)}
+    (hf : Tendsto f l (𝓝 x)) (hg : Tendsto g l (𝓝 y)) :
     Tendsto (fun a => Fin.snoc (f a) (g a)) l (𝓝 <| Fin.snoc x y) :=
   tendsto_pi_nhds.2 fun j => Fin.lastCases (by simpa) (by simpa using tendsto_pi_nhds.1 hf) j
 
-theorem ContinuousAt.fin_snoc
-    {f : X → ∀ j : Fin n, π j.castSucc} {x : X} (hf : ContinuousAt f x)
-    {g : X → π (Fin.last _)} (hg : ContinuousAt g x) :
+theorem ContinuousAt.finSnoc {f : X → ∀ j : Fin n, π j.castSucc} {g : X → π (Fin.last _)} {x : X}
+    (hf : ContinuousAt f x) (hg : ContinuousAt g x) :
     ContinuousAt (fun a => Fin.snoc (f a) (g a)) x :=
-  hf.tendsto.fin_snoc hg
+  hf.tendsto.finSnoc hg
 
-theorem Continuous.fin_snoc
-    {f : X → ∀ j : Fin n, π j.castSucc} (hf : Continuous f) {g : X → π (Fin.last _)}
-    (hg : Continuous g) : Continuous fun a => Fin.snoc (f a) (g a) :=
-  continuous_iff_continuousAt.2 fun _ => hf.continuousAt.fin_snoc hg.continuousAt
+theorem Continuous.finSnoc {f : X → ∀ j : Fin n, π j.castSucc} {g : X → π (Fin.last _)}
+    (hf : Continuous f) (hg : Continuous g) : Continuous fun a => Fin.snoc (f a) (g a) :=
+  continuous_iff_continuousAt.2 fun _ => hf.continuousAt.finSnoc hg.continuousAt
 
-theorem Filter.Tendsto.fin_insertNth
-    (i : Fin (n + 1)) {f : Y → π i} {l : Filter Y} {x : π i} (hf : Tendsto f l (𝓝 x))
-    {g : Y → ∀ j : Fin n, π (i.succAbove j)} {y : ∀ j, π (i.succAbove j)} (hg : Tendsto g l (𝓝 y)) :
+theorem Filter.Tendsto.finInsertNth
+    (i : Fin (n + 1)) {f : Y → π i} {g : Y → ∀ j : Fin n, π (i.succAbove j)} {l : Filter Y}
+    {x : π i} {y : ∀ j, π (i.succAbove j)} (hf : Tendsto f l (𝓝 x)) (hg : Tendsto g l (𝓝 y)) :
     Tendsto (fun a => i.insertNth (f a) (g a)) l (𝓝 <| i.insertNth x y) :=
   tendsto_pi_nhds.2 fun j => Fin.succAboveCases i (by simpa) (by simpa using tendsto_pi_nhds.1 hg) j
 
-theorem ContinuousAt.fin_insertNth
-    (i : Fin (n + 1)) {f : X → π i} {x : X} (hf : ContinuousAt f x)
-    {g : X → ∀ j : Fin n, π (i.succAbove j)} (hg : ContinuousAt g x) :
-    ContinuousAt (fun a => i.insertNth (f a) (g a)) x :=
-  hf.tendsto.fin_insertNth i hg
+@[deprecated (since := "2025-01-02")]
+alias Filter.Tendsto.fin_insertNth := Filter.Tendsto.finInsertNth
 
-theorem Continuous.fin_insertNth
-    (i : Fin (n + 1)) {f : X → π i} (hf : Continuous f) {g : X → ∀ j : Fin n, π (i.succAbove j)}
-    (hg : Continuous g) : Continuous fun a => i.insertNth (f a) (g a) :=
-  continuous_iff_continuousAt.2 fun _ => hf.continuousAt.fin_insertNth i hg.continuousAt
+theorem ContinuousAt.finInsertNth
+    (i : Fin (n + 1)) {f : X → π i} {g : X → ∀ j : Fin n, π (i.succAbove j)} {x : X}
+    (hf : ContinuousAt f x) (hg : ContinuousAt g x) :
+    ContinuousAt (fun a => i.insertNth (f a) (g a)) x :=
+  hf.tendsto.finInsertNth i hg
+
+@[deprecated (since := "2025-01-02")]
+alias ContinuousAt.fin_insertNth := ContinuousAt.finInsertNth
+
+theorem Continuous.finInsertNth
+    (i : Fin (n + 1)) {f : X → π i} {g : X → ∀ j : Fin n, π (i.succAbove j)}
+    (hf : Continuous f) (hg : Continuous g) : Continuous fun a => i.insertNth (f a) (g a) :=
+  continuous_iff_continuousAt.2 fun _ => hf.continuousAt.finInsertNth i hg.continuousAt
+
+@[deprecated (since := "2025-01-02")]
+alias Continuous.fin_insertNth := Continuous.finInsertNth
 
 end Fin
 

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1416,57 +1416,62 @@ theorem continuous_mulSingle [∀ i, One (π i)] [DecidableEq ι] (i : ι) :
     Continuous fun x => (Pi.mulSingle i x : ∀ i, π i) :=
   continuous_const.update _ continuous_id
 
-theorem Filter.Tendsto.fin_cons {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+section Fin
+variable {n : ℕ} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+
+theorem Filter.Tendsto.fin_cons
     {f : Y → π 0} {l : Filter Y} {x : π 0} (hf : Tendsto f l (𝓝 x))
     {g : Y → ∀ j : Fin n, π j.succ} {y : ∀ j, π (Fin.succ j)} (hg : Tendsto g l (𝓝 y)) :
     Tendsto (fun a => Fin.cons (f a) (g a)) l (𝓝 <| Fin.cons x y) :=
   tendsto_pi_nhds.2 fun j => Fin.cases (by simpa) (by simpa using tendsto_pi_nhds.1 hg) j
 
-theorem ContinuousAt.fin_cons {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+theorem ContinuousAt.fin_cons
     {f : X → π 0} {x : X} (hf : ContinuousAt f x)
     {g : X → ∀ j : Fin n, π (Fin.succ j)} (hg : ContinuousAt g x) :
     ContinuousAt (fun a => Fin.cons (f a) (g a)) x :=
   hf.tendsto.fin_cons hg
 
-theorem Continuous.fin_cons {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+theorem Continuous.fin_cons
     {f : X → π 0} (hf : Continuous f) {g : X → ∀ j : Fin n, π (Fin.succ j)}
     (hg : Continuous g) : Continuous fun a => Fin.cons (f a) (g a) :=
   continuous_iff_continuousAt.2 fun _ => hf.continuousAt.fin_cons hg.continuousAt
 
-theorem Filter.Tendsto.fin_snoc {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+theorem Filter.Tendsto.fin_snoc
     {f : Y → ∀ j : Fin n, π j.castSucc} {l : Filter Y} {x : ∀ j, π (Fin.castSucc j)}
     (hf : Tendsto f l (𝓝 x))
     {g : Y → π (Fin.last _)} {y : π (Fin.last _)} (hg : Tendsto g l (𝓝 y)) :
     Tendsto (fun a => Fin.snoc (f a) (g a)) l (𝓝 <| Fin.snoc x y) :=
   tendsto_pi_nhds.2 fun j => Fin.lastCases (by simpa) (by simpa using tendsto_pi_nhds.1 hf) j
 
-theorem ContinuousAt.fin_snoc {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+theorem ContinuousAt.fin_snoc
     {f : X → ∀ j : Fin n, π j.castSucc} {x : X} (hf : ContinuousAt f x)
     {g : X → π (Fin.last _)} (hg : ContinuousAt g x) :
     ContinuousAt (fun a => Fin.snoc (f a) (g a)) x :=
   hf.tendsto.fin_snoc hg
 
-theorem Continuous.fin_snoc {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+theorem Continuous.fin_snoc
     {f : X → ∀ j : Fin n, π j.castSucc} (hf : Continuous f) {g : X → π (Fin.last _)}
     (hg : Continuous g) : Continuous fun a => Fin.snoc (f a) (g a) :=
   continuous_iff_continuousAt.2 fun _ => hf.continuousAt.fin_snoc hg.continuousAt
 
-theorem Filter.Tendsto.fin_insertNth {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+theorem Filter.Tendsto.fin_insertNth
     (i : Fin (n + 1)) {f : Y → π i} {l : Filter Y} {x : π i} (hf : Tendsto f l (𝓝 x))
     {g : Y → ∀ j : Fin n, π (i.succAbove j)} {y : ∀ j, π (i.succAbove j)} (hg : Tendsto g l (𝓝 y)) :
     Tendsto (fun a => i.insertNth (f a) (g a)) l (𝓝 <| i.insertNth x y) :=
   tendsto_pi_nhds.2 fun j => Fin.succAboveCases i (by simpa) (by simpa using tendsto_pi_nhds.1 hg) j
 
-theorem ContinuousAt.fin_insertNth {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+theorem ContinuousAt.fin_insertNth
     (i : Fin (n + 1)) {f : X → π i} {x : X} (hf : ContinuousAt f x)
     {g : X → ∀ j : Fin n, π (i.succAbove j)} (hg : ContinuousAt g x) :
     ContinuousAt (fun a => i.insertNth (f a) (g a)) x :=
   hf.tendsto.fin_insertNth i hg
 
-theorem Continuous.fin_insertNth {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+theorem Continuous.fin_insertNth
     (i : Fin (n + 1)) {f : X → π i} (hf : Continuous f) {g : X → ∀ j : Fin n, π (i.succAbove j)}
     (hg : Continuous g) : Continuous fun a => i.insertNth (f a) (g a) :=
   continuous_iff_continuousAt.2 fun _ => hf.continuousAt.fin_insertNth i hg.continuousAt
+
+end Fin
 
 theorem isOpen_set_pi {i : Set ι} {s : ∀ a, Set (π a)} (hi : i.Finite)
     (hs : ∀ a ∈ i, IsOpen (s a)) : IsOpen (pi i s) := by

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1416,6 +1416,41 @@ theorem continuous_mulSingle [∀ i, One (π i)] [DecidableEq ι] (i : ι) :
     Continuous fun x => (Pi.mulSingle i x : ∀ i, π i) :=
   continuous_const.update _ continuous_id
 
+theorem Filter.Tendsto.fin_cons {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+    {f : Y → π 0} {l : Filter Y} {x : π 0} (hf : Tendsto f l (𝓝 x))
+    {g : Y → ∀ j : Fin n, π j.succ} {y : ∀ j, π (Fin.succ j)} (hg : Tendsto g l (𝓝 y)) :
+    Tendsto (fun a => Fin.cons (f a) (g a)) l (𝓝 <| Fin.cons x y) :=
+  tendsto_pi_nhds.2 fun j => Fin.cases (by simpa) (by simpa using tendsto_pi_nhds.1 hg) j
+
+theorem ContinuousAt.fin_cons {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+    {f : X → π 0} {x : X} (hf : ContinuousAt f x)
+    {g : X → ∀ j : Fin n, π (Fin.succ j)} (hg : ContinuousAt g x) :
+    ContinuousAt (fun a => Fin.cons (f a) (g a)) x :=
+  hf.tendsto.fin_cons hg
+
+theorem Continuous.fin_cons {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+    {f : X → π 0} (hf : Continuous f) {g : X → ∀ j : Fin n, π (Fin.succ j)}
+    (hg : Continuous g) : Continuous fun a => Fin.cons (f a) (g a) :=
+  continuous_iff_continuousAt.2 fun _ => hf.continuousAt.fin_cons hg.continuousAt
+
+theorem Filter.Tendsto.fin_snoc {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+    {f : Y → ∀ j : Fin n, π j.castSucc} {l : Filter Y} {x : ∀ j, π (Fin.castSucc j)}
+    (hf : Tendsto f l (𝓝 x))
+    {g : Y → π (Fin.last _)} {y : π (Fin.last _)} (hg : Tendsto g l (𝓝 y)) :
+    Tendsto (fun a => Fin.snoc (f a) (g a)) l (𝓝 <| Fin.snoc x y) :=
+  tendsto_pi_nhds.2 fun j => Fin.lastCases (by simpa) (by simpa using tendsto_pi_nhds.1 hf) j
+
+theorem ContinuousAt.fin_snoc {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+    {f : X → ∀ j : Fin n, π j.castSucc} {x : X} (hf : ContinuousAt f x)
+    {g : X → π (Fin.last _)} (hg : ContinuousAt g x) :
+    ContinuousAt (fun a => Fin.snoc (f a) (g a)) x :=
+  hf.tendsto.fin_snoc hg
+
+theorem Continuous.fin_snoc {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
+    {f : X → ∀ j : Fin n, π j.castSucc} (hf : Continuous f) {g : X → π (Fin.last _)}
+    (hg : Continuous g) : Continuous fun a => Fin.snoc (f a) (g a) :=
+  continuous_iff_continuousAt.2 fun _ => hf.continuousAt.fin_snoc hg.continuousAt
+
 theorem Filter.Tendsto.fin_insertNth {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
     (i : Fin (n + 1)) {f : Y → π i} {l : Filter Y} {x : π i} (hf : Tendsto f l (𝓝 x))
     {g : Y → ∀ j : Fin n, π (i.succAbove j)} {y : ∀ j, π (i.succAbove j)} (hg : Tendsto g l (𝓝 y)) :

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -1201,17 +1201,60 @@ protected theorem ContinuousOn.iterate {f : α → α} {s : Set α} (hcont : Con
   | 0 => continuousOn_id
   | (n + 1) => (hcont.iterate hmaps n).comp hcont hmaps
 
-theorem ContinuousWithinAt.fin_insertNth {n} {π : Fin (n + 1) → Type*}
-    [∀ i, TopologicalSpace (π i)] (i : Fin (n + 1)) {f : α → π i} {a : α} {s : Set α}
-    (hf : ContinuousWithinAt f s a) {g : α → ∀ j : Fin n, π (i.succAbove j)}
-    (hg : ContinuousWithinAt g s a) : ContinuousWithinAt (fun a => i.insertNth (f a) (g a)) s a :=
-  hf.tendsto.fin_insertNth i hg
+section Fin
+variable {n : ℕ} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
 
-nonrec theorem ContinuousOn.fin_insertNth {n} {π : Fin (n + 1) → Type*}
-    [∀ i, TopologicalSpace (π i)] (i : Fin (n + 1)) {f : α → π i} {s : Set α}
-    (hf : ContinuousOn f s) {g : α → ∀ j : Fin n, π (i.succAbove j)} (hg : ContinuousOn g s) :
+theorem ContinuousWithinAt.finCons
+    {f : α → π 0} {g : α → ∀ j : Fin n, π (Fin.succ j)} {a : α} {s : Set α}
+    (hf : ContinuousWithinAt f s a) (hg : ContinuousWithinAt g s a) :
+    ContinuousWithinAt (fun a => Fin.cons (f a) (g a)) s a :=
+  hf.tendsto.finCons hg
+nonrec theorem ContinuousOn.finCons {f : α → π 0} {s : Set α} {g : α → ∀ j : Fin n, π (Fin.succ j)}
+    (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
+    ContinuousOn (fun a => Fin.cons (f a) (g a)) s := fun a ha =>
+  (hf a ha).finCons (hg a ha)
+
+theorem ContinuousWithinAt.matrixVecCons {f : α → β} {g : α → Fin n → β} {a : α} {s : Set α}
+    (hf : ContinuousWithinAt f s a) (hg : ContinuousWithinAt g s a) :
+    ContinuousWithinAt (fun a => Matrix.vecCons (f a) (g a)) s a :=
+  hf.tendsto.matrixVecCons hg
+
+nonrec theorem ContinuousOn.matrixVecCons {f : α → β} {g : α → Fin n → β} {s : Set α}
+    (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
+    ContinuousOn (fun a => Matrix.vecCons (f a) (g a)) s := fun a ha =>
+  (hf a ha).matrixVecCons (hg a ha)
+
+theorem ContinuousWithinAt.finSnoc
+    {f : α → ∀ j : Fin n, π (Fin.castSucc j)} {g : α → π (Fin.last _)} {a : α} {s : Set α}
+    (hf : ContinuousWithinAt f s a) (hg : ContinuousWithinAt g s a) :
+    ContinuousWithinAt (fun a => Fin.snoc (f a) (g a)) s a :=
+  hf.tendsto.finSnoc hg
+
+nonrec theorem ContinuousOn.finSnoc
+    {f : α → ∀ j : Fin n, π (Fin.castSucc j)} {g : α → π (Fin.last _)} {s : Set α}
+    (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
+    ContinuousOn (fun a => Fin.snoc (f a) (g a)) s := fun a ha =>
+  (hf a ha).finSnoc (hg a ha)
+
+theorem ContinuousWithinAt.finInsertNth
+    (i : Fin (n + 1)) {f : α → π i} {g : α → ∀ j : Fin n, π (i.succAbove j)} {a : α} {s : Set α}
+    (hf : ContinuousWithinAt f s a) (hg : ContinuousWithinAt g s a) :
+    ContinuousWithinAt (fun a => i.insertNth (f a) (g a)) s a :=
+  hf.tendsto.finInsertNth i hg
+
+@[deprecated (since := "2025-01-02")]
+alias ContinuousWithinAt.fin_insertNth := ContinuousWithinAt.finInsertNth
+
+nonrec theorem ContinuousOn.finInsertNth
+    (i : Fin (n + 1)) {f : α → π i} {g : α → ∀ j : Fin n, π (i.succAbove j)} {s : Set α}
+    (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
     ContinuousOn (fun a => i.insertNth (f a) (g a)) s := fun a ha =>
-  (hf a ha).fin_insertNth i (hg a ha)
+  (hf a ha).finInsertNth i (hg a ha)
+
+@[deprecated (since := "2025-01-02")]
+alias ContinuousOn.fin_insertNth := ContinuousOn.finInsertNth
+
+end Fin
 
 theorem Set.LeftInvOn.map_nhdsWithin_eq {f : α → β} {g : β → α} {x : β} {s : Set β}
     (h : LeftInvOn f g s) (hx : f (g x) = x) (hf : ContinuousWithinAt f (g '' s) (g x))

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -1209,7 +1209,7 @@ theorem ContinuousWithinAt.finCons
     (hf : ContinuousWithinAt f s a) (hg : ContinuousWithinAt g s a) :
     ContinuousWithinAt (fun a => Fin.cons (f a) (g a)) s a :=
   hf.tendsto.finCons hg
-nonrec theorem ContinuousOn.finCons {f : α → π 0} {s : Set α} {g : α → ∀ j : Fin n, π (Fin.succ j)}
+theorem ContinuousOn.finCons {f : α → π 0} {s : Set α} {g : α → ∀ j : Fin n, π (Fin.succ j)}
     (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
     ContinuousOn (fun a => Fin.cons (f a) (g a)) s := fun a ha =>
   (hf a ha).finCons (hg a ha)
@@ -1219,7 +1219,7 @@ theorem ContinuousWithinAt.matrixVecCons {f : α → β} {g : α → Fin n → �
     ContinuousWithinAt (fun a => Matrix.vecCons (f a) (g a)) s a :=
   hf.tendsto.matrixVecCons hg
 
-nonrec theorem ContinuousOn.matrixVecCons {f : α → β} {g : α → Fin n → β} {s : Set α}
+theorem ContinuousOn.matrixVecCons {f : α → β} {g : α → Fin n → β} {s : Set α}
     (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
     ContinuousOn (fun a => Matrix.vecCons (f a) (g a)) s := fun a ha =>
   (hf a ha).matrixVecCons (hg a ha)
@@ -1230,7 +1230,7 @@ theorem ContinuousWithinAt.finSnoc
     ContinuousWithinAt (fun a => Fin.snoc (f a) (g a)) s a :=
   hf.tendsto.finSnoc hg
 
-nonrec theorem ContinuousOn.finSnoc
+theorem ContinuousOn.finSnoc
     {f : α → ∀ j : Fin n, π (Fin.castSucc j)} {g : α → π (Fin.last _)} {s : Set α}
     (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
     ContinuousOn (fun a => Fin.snoc (f a) (g a)) s := fun a ha =>
@@ -1245,7 +1245,7 @@ theorem ContinuousWithinAt.finInsertNth
 @[deprecated (since := "2025-01-02")]
 alias ContinuousWithinAt.fin_insertNth := ContinuousWithinAt.finInsertNth
 
-nonrec theorem ContinuousOn.finInsertNth
+theorem ContinuousOn.finInsertNth
     (i : Fin (n + 1)) {f : α → π i} {g : α → ∀ j : Fin n, π (i.succAbove j)} {s : Set α}
     (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
     ContinuousOn (fun a => i.insertNth (f a) (g a)) s := fun a ha =>

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -1209,6 +1209,7 @@ theorem ContinuousWithinAt.finCons
     (hf : ContinuousWithinAt f s a) (hg : ContinuousWithinAt g s a) :
     ContinuousWithinAt (fun a => Fin.cons (f a) (g a)) s a :=
   hf.tendsto.finCons hg
+
 theorem ContinuousOn.finCons {f : α → π 0} {s : Set α} {g : α → ∀ j : Fin n, π (Fin.succ j)}
     (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
     ContinuousOn (fun a => Fin.cons (f a) (g a)) s := fun a ha =>


### PR DESCRIPTION
These are adapted from the results for `insertNth`, which now appear immediately below the new results.

I've also:
* extracted `section`s with appropriate `variables`s for these `Fin` results.
* renamed from `fin_insertNth` to `finInsertNth`, to match the naming rules
* reordered the parameters to put all the continuity assumptions at the end
* not tagged these with `@[continuity]` as it doesn't seem to help solve `Continuous fun x : X => ![x, x]`. We can look at this in a follow-up.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
