### PR TITLE
[Merged by Bors] - chore(Mathlib/Algebra/Lie): rename theorems for consistency

### DIFF
--- a/Mathlib/Algebra/Lie/Abelian.lean
+++ b/Mathlib/Algebra/Lie/Abelian.lean
@@ -213,10 +213,18 @@ theorem toLinearMap_maxTrivLinearMapEquivLieModuleHom (f : maxTrivSubmodule R L 
     (maxTrivLinearMapEquivLieModuleHom (M := M) (N := N) f : M →ₗ[R] N) = (f : M →ₗ[R] N) := by
   ext; rfl
 
+@[deprecated (since := "2024-12-30")]
+alias coe_linearMap_maxTrivLinearMapEquivLieModuleHom :=
+  toLinearMap_maxTrivLinearMapEquivLieModuleHom
+
 @[simp]
 theorem toLinearMap_maxTrivLinearMapEquivLieModuleHom_symm (f : M →ₗ⁅R,L⁆ N) :
     (maxTrivLinearMapEquivLieModuleHom (M := M) (N := N) |>.symm f : M →ₗ[R] N) = (f : M →ₗ[R] N) :=
   rfl
+
+@[deprecated (since := "2024-12-30")]
+alias coe_linearMap_maxTrivLinearMapEquivLieModuleHom_symm :=
+  toLinearMap_maxTrivLinearMapEquivLieModuleHom_symm
 
 end LieModule
 

--- a/Mathlib/Algebra/Lie/Abelian.lean
+++ b/Mathlib/Algebra/Lie/Abelian.lean
@@ -121,8 +121,8 @@ instance : IsTrivial L (maxTrivSubmodule R L M) where trivial x m := Subtype.ext
 @[simp]
 theorem ideal_oper_maxTrivSubmodule_eq_bot (I : LieIdeal R L) :
     ⁅I, maxTrivSubmodule R L M⁆ = ⊥ := by
-  rw [← LieSubmodule.coe_toSubmodule_inj, LieSubmodule.lieIdeal_oper_eq_linear_span,
-    LieSubmodule.bot_coeSubmodule, Submodule.span_eq_bot]
+  rw [← LieSubmodule.toSubmodule_inj, LieSubmodule.lieIdeal_oper_eq_linear_span,
+    LieSubmodule.bot_toSubmodule, Submodule.span_eq_bot]
   rintro m ⟨⟨x, hx⟩, ⟨⟨m, hm⟩, rfl⟩⟩
   exact hm x
 
@@ -167,8 +167,8 @@ def maxTrivEquiv (e : M ≃ₗ⁅R,L⁆ N) : maxTrivSubmodule R L M ≃ₗ⁅R,L
   { maxTrivHom (e : M →ₗ⁅R,L⁆ N) with
     toFun := maxTrivHom (e : M →ₗ⁅R,L⁆ N)
     invFun := maxTrivHom (e.symm : N →ₗ⁅R,L⁆ M)
-    left_inv := fun m => by ext; simp [LieModuleEquiv.coe_to_lieModuleHom]
-    right_inv := fun n => by ext; simp [LieModuleEquiv.coe_to_lieModuleHom] }
+    left_inv := fun m => by ext; simp [LieModuleEquiv.coe_toLieModuleHom]
+    right_inv := fun n => by ext; simp [LieModuleEquiv.coe_toLieModuleHom] }
 
 @[norm_cast, simp]
 theorem coe_maxTrivEquiv_apply (e : M ≃ₗ⁅R,L⁆ N) (m : maxTrivSubmodule R L M) :
@@ -209,12 +209,12 @@ theorem coe_maxTrivLinearMapEquivLieModuleHom_symm (f : M →ₗ⁅R,L⁆ N) :
   rfl
 
 @[simp]
-theorem coe_linearMap_maxTrivLinearMapEquivLieModuleHom (f : maxTrivSubmodule R L (M →ₗ[R] N)) :
+theorem toLinearMap_maxTrivLinearMapEquivLieModuleHom (f : maxTrivSubmodule R L (M →ₗ[R] N)) :
     (maxTrivLinearMapEquivLieModuleHom (M := M) (N := N) f : M →ₗ[R] N) = (f : M →ₗ[R] N) := by
   ext; rfl
 
 @[simp]
-theorem coe_linearMap_maxTrivLinearMapEquivLieModuleHom_symm (f : M →ₗ⁅R,L⁆ N) :
+theorem toLinearMap_maxTrivLinearMapEquivLieModuleHom_symm (f : M →ₗ⁅R,L⁆ N) :
     (maxTrivLinearMapEquivLieModuleHom (M := M) (N := N) |>.symm f : M →ₗ[R] N) = (f : M →ₗ[R] N) :=
   rfl
 

--- a/Mathlib/Algebra/Lie/BaseChange.lean
+++ b/Mathlib/Algebra/Lie/BaseChange.lean
@@ -200,13 +200,13 @@ lemma mem_baseChange_iff {m : A ⊗[R] M} :
 
 @[simp]
 lemma baseChange_bot : (⊥ : LieSubmodule R L M).baseChange A = ⊥ := by
-  simp only [baseChange, bot_coeSubmodule, Submodule.baseChange_bot,
+  simp only [baseChange, bot_toSubmodule, Submodule.baseChange_bot,
     Submodule.bot_toAddSubmonoid]
   rfl
 
 @[simp]
 lemma baseChange_top : (⊤ : LieSubmodule R L M).baseChange A = ⊤ := by
-  simp only [baseChange, top_coeSubmodule, Submodule.baseChange_top,
+  simp only [baseChange, top_toSubmodule, Submodule.baseChange_top,
     Submodule.bot_toAddSubmonoid]
   rfl
 
@@ -214,7 +214,7 @@ lemma lie_baseChange {I : LieIdeal R L} {N : LieSubmodule R L M} :
     ⁅I, N⁆.baseChange A = ⁅I.baseChange A, N.baseChange A⁆ := by
   set s : Set (A ⊗[R] M) := { m | ∃ x ∈ I, ∃ n ∈ N, 1 ⊗ₜ ⁅x, n⁆ = m}
   have : (TensorProduct.mk R A M 1) '' {m | ∃ x ∈ I, ∃ n ∈ N, ⁅x, n⁆ = m} = s := by ext; simp [s]
-  rw [← coe_toSubmodule_inj, coe_baseChange, lieIdeal_oper_eq_linear_span',
+  rw [← toSubmodule_inj, coe_baseChange, lieIdeal_oper_eq_linear_span',
     Submodule.baseChange_span, this, lieIdeal_oper_eq_linear_span']
   refine le_antisymm (Submodule.span_mono ?_) (Submodule.span_le.mpr ?_)
   · rintro - ⟨x, hx, m, hm, rfl⟩

--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -384,6 +384,8 @@ theorem toLinearMap_comp (f : L₂ →ₗ⁅R⁆ L₃) (g : L₁ →ₗ⁅R⁆ L
     (f.comp g : L₁ →ₗ[R] L₃) = (f : L₂ →ₗ[R] L₃).comp (g : L₁ →ₗ[R] L₂) :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias coe_linearMap_comp := toLinearMap_comp
+
 @[simp]
 theorem comp_id (f : L₁ →ₗ⁅R⁆ L₂) : f.comp (id : L₁ →ₗ⁅R⁆ L₁) = f :=
   rfl
@@ -481,9 +483,13 @@ instance : EquivLike (L₁ ≃ₗ⁅R⁆ L₂) L₁ L₂ where
 theorem coe_toLieHom (e : L₁ ≃ₗ⁅R⁆ L₂) : ⇑(e : L₁ →ₗ⁅R⁆ L₂) = e :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias coe_to_lieHom := coe_toLieHom
+
 @[simp]
 theorem coe_toLinearEquiv (e : L₁ ≃ₗ⁅R⁆ L₂) : ⇑(e : L₁ ≃ₗ[R] L₂) = e :=
   rfl
+
+@[deprecated (since := "2024-12-30")] alias coe_to_linearEquiv := coe_toLinearEquiv
 
 @[simp]
 theorem toLinearEquiv_mk (f : L₁ →ₗ⁅R⁆ L₂) (g h₁ h₂) :
@@ -494,12 +500,16 @@ theorem toLinearEquiv_mk (f : L₁ →ₗ⁅R⁆ L₂) (g h₁ h₂) :
         right_inv := h₂ } :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias to_linearEquiv_mk := toLinearEquiv_mk
+
 theorem toLinearEquiv_injective : Injective ((↑) : (L₁ ≃ₗ⁅R⁆ L₂) → L₁ ≃ₗ[R] L₂) := by
   rintro ⟨⟨⟨⟨f, -⟩, -⟩, -⟩, f_inv⟩ ⟨⟨⟨⟨g, -⟩, -⟩, -⟩, g_inv⟩
   intro h
   simp only [toLinearEquiv_mk, LinearEquiv.mk.injEq, LinearMap.mk.injEq, AddHom.mk.injEq] at h
   congr
   exacts [h.1, h.2]
+
+@[deprecated (since := "2024-12-30")] alias coe_linearEquiv_injective := toLinearEquiv_injective
 
 theorem coe_injective : @Injective (L₁ ≃ₗ⁅R⁆ L₂) (L₁ → L₂) (↑) :=
   LinearEquiv.coe_injective.comp toLinearEquiv_injective
@@ -731,6 +741,8 @@ theorem toLinearMap_comp (f : N →ₗ⁅R,L⁆ P) (g : M →ₗ⁅R,L⁆ N) :
     (f.comp g : M →ₗ[R] P) = (f : N →ₗ[R] P).comp (g : M →ₗ[R] N) :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias coe_linearMap_comp := toLinearMap_comp
+
 /-- The inverse of a bijective morphism of Lie modules is a morphism of Lie modules. -/
 def inverse (f : M →ₗ⁅R,L⁆ N) (g : N → M) (h₁ : Function.LeftInverse g f)
     (h₂ : Function.RightInverse g f) : N →ₗ⁅R,L⁆ M :=
@@ -881,9 +893,13 @@ theorem coe_mk (f : M →ₗ⁅R,L⁆ N) (invFun h₁ h₂) :
 theorem coe_toLieModuleHom (e : M ≃ₗ⁅R,L⁆ N) : ⇑(e : M →ₗ⁅R,L⁆ N) = e :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias coe_to_lieModuleHom := coe_toLieModuleHom
+
 @[simp]
 theorem coe_toLinearEquiv (e : M ≃ₗ⁅R,L⁆ N) : ((e : M ≃ₗ[R] N) : M → N) = e :=
   rfl
+
+@[deprecated (since := "2024-12-30")] alias coe_to_linearEquiv := coe_toLinearEquiv
 
 theorem toEquiv_injective : Function.Injective (toEquiv : (M ≃ₗ⁅R,L⁆ N) → M ≃ N) := by
   rintro ⟨⟨⟨⟨f, -⟩, -⟩, -⟩, f_inv⟩ ⟨⟨⟨⟨g, -⟩, -⟩, -⟩, g_inv⟩

--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -380,7 +380,7 @@ theorem coe_comp (f : L₂ →ₗ⁅R⁆ L₃) (g : L₁ →ₗ⁅R⁆ L₂) : (
   rfl
 
 @[norm_cast, simp]
-theorem coe_linearMap_comp (f : L₂ →ₗ⁅R⁆ L₃) (g : L₁ →ₗ⁅R⁆ L₂) :
+theorem toLinearMap_comp (f : L₂ →ₗ⁅R⁆ L₃) (g : L₁ →ₗ⁅R⁆ L₂) :
     (f.comp g : L₁ →ₗ[R] L₃) = (f : L₂ →ₗ[R] L₃).comp (g : L₁ →ₗ[R] L₂) :=
   rfl
 
@@ -478,15 +478,15 @@ instance : EquivLike (L₁ ≃ₗ⁅R⁆ L₂) L₁ L₂ where
   right_inv f := f.right_inv
   coe_injective' f g h₁ h₂ := by cases f; cases g; simp at h₁ h₂; simp [*]
 
-theorem coe_to_lieHom (e : L₁ ≃ₗ⁅R⁆ L₂) : ⇑(e : L₁ →ₗ⁅R⁆ L₂) = e :=
+theorem coe_toLieHom (e : L₁ ≃ₗ⁅R⁆ L₂) : ⇑(e : L₁ →ₗ⁅R⁆ L₂) = e :=
   rfl
 
 @[simp]
-theorem coe_to_linearEquiv (e : L₁ ≃ₗ⁅R⁆ L₂) : ⇑(e : L₁ ≃ₗ[R] L₂) = e :=
+theorem coe_toLinearEquiv (e : L₁ ≃ₗ⁅R⁆ L₂) : ⇑(e : L₁ ≃ₗ[R] L₂) = e :=
   rfl
 
 @[simp]
-theorem to_linearEquiv_mk (f : L₁ →ₗ⁅R⁆ L₂) (g h₁ h₂) :
+theorem toLinearEquiv_mk (f : L₁ →ₗ⁅R⁆ L₂) (g h₁ h₂) :
     (mk f g h₁ h₂ : L₁ ≃ₗ[R] L₂) =
       { f with
         invFun := g
@@ -494,15 +494,15 @@ theorem to_linearEquiv_mk (f : L₁ →ₗ⁅R⁆ L₂) (g h₁ h₂) :
         right_inv := h₂ } :=
   rfl
 
-theorem coe_linearEquiv_injective : Injective ((↑) : (L₁ ≃ₗ⁅R⁆ L₂) → L₁ ≃ₗ[R] L₂) := by
+theorem toLinearEquiv_injective : Injective ((↑) : (L₁ ≃ₗ⁅R⁆ L₂) → L₁ ≃ₗ[R] L₂) := by
   rintro ⟨⟨⟨⟨f, -⟩, -⟩, -⟩, f_inv⟩ ⟨⟨⟨⟨g, -⟩, -⟩, -⟩, g_inv⟩
   intro h
-  simp only [to_linearEquiv_mk, LinearEquiv.mk.injEq, LinearMap.mk.injEq, AddHom.mk.injEq] at h
+  simp only [toLinearEquiv_mk, LinearEquiv.mk.injEq, LinearMap.mk.injEq, AddHom.mk.injEq] at h
   congr
   exacts [h.1, h.2]
 
 theorem coe_injective : @Injective (L₁ ≃ₗ⁅R⁆ L₂) (L₁ → L₂) (↑) :=
-  LinearEquiv.coe_injective.comp coe_linearEquiv_injective
+  LinearEquiv.coe_injective.comp toLinearEquiv_injective
 
 @[ext]
 theorem ext {f g : L₁ ≃ₗ⁅R⁆ L₂} (h : ∀ x, f x = g x) : f = g :=
@@ -727,7 +727,7 @@ theorem coe_comp (f : N →ₗ⁅R,L⁆ P) (g : M →ₗ⁅R,L⁆ N) : ⇑(f.com
   rfl
 
 @[norm_cast, simp]
-theorem coe_linearMap_comp (f : N →ₗ⁅R,L⁆ P) (g : M →ₗ⁅R,L⁆ N) :
+theorem toLinearMap_comp (f : N →ₗ⁅R,L⁆ P) (g : M →ₗ⁅R,L⁆ N) :
     (f.comp g : M →ₗ[R] P) = (f : N →ₗ[R] P).comp (g : M →ₗ[R] N) :=
   rfl
 
@@ -878,11 +878,11 @@ theorem coe_mk (f : M →ₗ⁅R,L⁆ N) (invFun h₁ h₂) :
     ((⟨f, invFun, h₁, h₂⟩ : M ≃ₗ⁅R,L⁆ N) : M → N) = f :=
   rfl
 
-theorem coe_to_lieModuleHom (e : M ≃ₗ⁅R,L⁆ N) : ⇑(e : M →ₗ⁅R,L⁆ N) = e :=
+theorem coe_toLieModuleHom (e : M ≃ₗ⁅R,L⁆ N) : ⇑(e : M →ₗ⁅R,L⁆ N) = e :=
   rfl
 
 @[simp]
-theorem coe_to_linearEquiv (e : M ≃ₗ⁅R,L⁆ N) : ((e : M ≃ₗ[R] N) : M → N) = e :=
+theorem coe_toLinearEquiv (e : M ≃ₗ⁅R,L⁆ N) : ((e : M ≃ₗ[R] N) : M → N) = e :=
   rfl
 
 theorem toEquiv_injective : Function.Injective (toEquiv : (M ≃ₗ⁅R,L⁆ N) → M ≃ N) := by

--- a/Mathlib/Algebra/Lie/CartanExists.lean
+++ b/Mathlib/Algebra/Lie/CartanExists.lean
@@ -246,8 +246,9 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
     -- From this we deduce that there exists an `n` such that `⁅x, _⁆ ^ n` vanishes on `⁅x, z⁆`.
     -- On the other hand, our goal is to show `z = 0` in `Q`,
     -- which is equivalent to showing that `⁅x, _⁆ ^ n` vanishes on `z`, for some `n`.
-    simp only [coe_bracket_of_module, LieSubmodule.mem_mk_iff', mem_toSubmodule, mem_engel_iff,
-      LieSubmodule.Quotient.mk'_apply, LieSubmodule.Quotient.mk_eq_zero', E, Q] at this ⊢
+    simp only [coe_bracket_of_module, LieSubmodule.mem_mk_iff', LieSubalgebra.mem_toSubmodule,
+      mem_engel_iff, LieSubmodule.Quotient.mk'_apply, LieSubmodule.Quotient.mk_eq_zero', E, Q]
+      at this ⊢
     -- Hence we win.
     obtain ⟨n, hn⟩ := this
     use n+1

--- a/Mathlib/Algebra/Lie/CartanExists.lean
+++ b/Mathlib/Algebra/Lie/CartanExists.lean
@@ -152,7 +152,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
   obtain hr|hr : r = finrank K L ∨ r < finrank K L := (Submodule.finrank_le _).eq_or_lt
   · suffices engel K y ≤ engel K x from hmin Ey this
     suffices engel K x = ⊤ by simp_rw [this, le_top]
-    apply LieSubalgebra.to_submodule_injective
+    apply LieSubalgebra.toSubmodule_injective
     apply Submodule.eq_top_of_finrank_eq hr
   -- So from now on, we assume that `r < finrank K L`.
   -- We denote by `x'` and `y'` the elements `x` and `y` viewed as terms of `U`.
@@ -246,7 +246,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
     -- From this we deduce that there exists an `n` such that `⁅x, _⁆ ^ n` vanishes on `⁅x, z⁆`.
     -- On the other hand, our goal is to show `z = 0` in `Q`,
     -- which is equivalent to showing that `⁅x, _⁆ ^ n` vanishes on `z`, for some `n`.
-    simp only [coe_bracket_of_module, LieSubmodule.mem_mk_iff', mem_coe_submodule, mem_engel_iff,
+    simp only [coe_bracket_of_module, LieSubmodule.mem_mk_iff', mem_toSubmodule, mem_engel_iff,
       LieSubmodule.Quotient.mk'_apply, LieSubmodule.Quotient.mk_eq_zero', E, Q] at this ⊢
     -- Hence we win.
     obtain ⟨n, hn⟩ := this
@@ -359,7 +359,7 @@ lemma exists_isCartanSubalgebra_engel_of_finrank_le_card (h : finrank K L ≤ #K
   rintro ⟨_, y, hy, rfl⟩ hyx
   suffices finrank K (engel K x) ≤ finrank K (engel K y) by
     suffices engel K y = engel K x from this.ge
-    apply LieSubalgebra.to_submodule_injective
+    apply LieSubalgebra.toSubmodule_injective
     exact Submodule.eq_of_le_of_finrank_le hyx this
   rw [(isRegular_iff_finrank_engel_eq_rank K x).mp hx]
   apply rank_le_finrank_engel

--- a/Mathlib/Algebra/Lie/CartanSubalgebra.lean
+++ b/Mathlib/Algebra/Lie/CartanSubalgebra.lean
@@ -53,7 +53,7 @@ instance [H.IsCartanSubalgebra] : LieAlgebra.IsNilpotent R H :=
 @[simp]
 theorem normalizer_eq_self_of_isCartanSubalgebra (H : LieSubalgebra R L) [H.IsCartanSubalgebra] :
     H.toLieSubmodule.normalizer = H.toLieSubmodule := by
-  rw [← LieSubmodule.coe_toSubmodule_inj, coe_normalizer_eq_normalizer,
+  rw [← LieSubmodule.toSubmodule_inj, coe_normalizer_eq_normalizer,
     IsCartanSubalgebra.self_normalizing, coe_toLieSubmodule]
 
 @[simp]
@@ -84,7 +84,7 @@ theorem isCartanSubalgebra_iff_isUcsLimit : H.IsCartanSubalgebra ↔ H.toLieSubm
         self_normalizing := by
           have hk' := hk (k + 1) k.le_succ
           rw [LieSubmodule.ucs_succ, hk k (le_refl k)] at hk'
-          rw [← LieSubalgebra.coe_to_submodule_inj, ← LieSubalgebra.coe_normalizer_eq_normalizer,
+          rw [← LieSubalgebra.toSubmodule_inj, ← LieSubalgebra.coe_normalizer_eq_normalizer,
             hk', LieSubalgebra.coe_toLieSubmodule] }
 
 lemma ne_bot_of_isCartanSubalgebra [Nontrivial L] (H : LieSubalgebra R L) [H.IsCartanSubalgebra] :
@@ -116,4 +116,4 @@ open LieIdeal
 instance LieAlgebra.top_isCartanSubalgebra_of_nilpotent [LieAlgebra.IsNilpotent R L] :
     LieSubalgebra.IsCartanSubalgebra (⊤ : LieSubalgebra R L) where
   nilpotent := inferInstance
-  self_normalizing := by rw [← top_coe_lieSubalgebra, normalizer_eq_top, top_coe_lieSubalgebra]
+  self_normalizing := by rw [← top_toLieSubalgebra, normalizer_eq_top, top_toLieSubalgebra]

--- a/Mathlib/Algebra/Lie/Character.lean
+++ b/Mathlib/Algebra/Lie/Character.lean
@@ -48,7 +48,7 @@ theorem lieCharacter_apply_lie' (χ : LieCharacter R L) (x y : L) : ⁅χ x, χ 
 theorem lieCharacter_apply_of_mem_derived (χ : LieCharacter R L) {x : L}
     (h : x ∈ derivedSeries R L 1) : χ x = 0 := by
   rw [derivedSeries_def, derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_zero, ←
-    LieSubmodule.mem_coeSubmodule, LieSubmodule.lieIdeal_oper_eq_linear_span] at h
+    LieSubmodule.mem_toSubmodule, LieSubmodule.lieIdeal_oper_eq_linear_span] at h
   refine Submodule.span_induction ?_ ?_ ?_ ?_ h
   · rintro y ⟨⟨z, hz⟩, ⟨⟨w, hw⟩, rfl⟩⟩; apply lieCharacter_apply_lie
   · exact χ.map_zero

--- a/Mathlib/Algebra/Lie/Derivation/Killing.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Killing.lean
@@ -61,7 +61,7 @@ variable {R L}
 any `x : L`, `ad (D x)` is also in this orthogonal. -/
 lemma ad_mem_orthogonal_of_mem_orthogonal {D : LieDerivation R L L} (hD : D ∈ 𝕀ᗮ) (x : L) :
     ad R L (D x) ∈ 𝕀ᗮ := by
-  simp only [ad_apply_lieDerivation, LieHom.range_coeSubmodule, neg_mem_iff]
+  simp only [ad_apply_lieDerivation, LieHom.range_toSubmodule, neg_mem_iff]
   exact (rangeAdOrthogonal R L).lie_mem hD
 
 variable [Module.Finite R L]
@@ -94,7 +94,7 @@ lemma killingForm_restrict_range_ad_nondegenerate :
 /-- The range of the adjoint action on a finite-dimensional Killing Lie algebra is full. -/
 @[simp]
 lemma range_ad_eq_top : 𝕀 = ⊤ := by
-  rw [← LieSubalgebra.coe_to_submodule_inj]
+  rw [← LieSubalgebra.toSubmodule_inj]
   apply LinearMap.BilinForm.eq_top_of_restrict_nondegenerate_of_orthogonal_eq_bot
     (LieModule.traceForm_isSymm R 𝔻 𝔻).isRefl (killingForm_restrict_range_ad_nondegenerate R L)
   refine (Submodule.eq_bot_iff _).mpr fun D hD ↦ ext fun x ↦ ?_

--- a/Mathlib/Algebra/Lie/Engel.lean
+++ b/Mathlib/Algebra/Lie/Engel.lean
@@ -128,7 +128,7 @@ theorem isNilpotentOfIsNilpotentSpanSupEqTop (hnp : IsNilpotent <| toEnd R L M x
   obtain ⟨n, hn⟩ := hnp
   obtain ⟨k, hk⟩ := hIM
   have hk' : I.lcs M k = ⊥ := by
-    simp only [← coe_toSubmodule_inj, I.coe_lcs_eq, hk, bot_coeSubmodule]
+    simp only [← toSubmodule_inj, I.coe_lcs_eq, hk, bot_toSubmodule]
   suffices ∀ l, lowerCentralSeries R L M (l * n) ≤ I.lcs M l by
     use k * n
     simpa [hk'] using this k
@@ -189,16 +189,16 @@ theorem LieAlgebra.exists_engelian_lieSubalgebra_of_lt_normalizer {K : LieSubalg
     { (R ∙ x) ⊔ (K : Submodule R L) with
       lie_mem' := fun {y z} => LieSubalgebra.lie_mem_sup_of_mem_normalizer hx₁ }
   have hxK' : x ∈ K' := Submodule.mem_sup_left (Submodule.subset_span (Set.mem_singleton _))
-  have hKK' : K ≤ K' := (LieSubalgebra.coe_submodule_le_coe_submodule K K').mp le_sup_right
+  have hKK' : K ≤ K' := (LieSubalgebra.toSubmodule_le_toSubmodule K K').mp le_sup_right
   have hK' : K' ≤ K.normalizer := by
-    rw [← LieSubalgebra.coe_submodule_le_coe_submodule]
+    rw [← LieSubalgebra.toSubmodule_le_toSubmodule]
     exact sup_le ((Submodule.span_singleton_le_iff_mem _ _).mpr hx₁) hK₂.le
   refine ⟨K', ?_, lt_iff_le_and_ne.mpr ⟨hKK', fun contra => hx₂ (contra.symm ▸ hxK')⟩⟩
   intro M _i1 _i2 _i3 _i4 h
   obtain ⟨I, hI₁ : (I : LieSubalgebra R K') = LieSubalgebra.ofLe hKK'⟩ :=
     LieSubalgebra.exists_nested_lieIdeal_ofLe_normalizer hKK' hK'
   have hI₂ : (R ∙ (⟨x, hxK'⟩ : K')) ⊔ (LieSubmodule.toSubmodule I) = ⊤ := by
-    rw [← LieIdeal.coe_to_lieSubalgebra_to_submodule R K' I, hI₁]
+    rw [← LieIdeal.coe_toLieSubalgebra_toSubmodule R K' I, hI₁]
     apply Submodule.map_injective_of_injective (K' : Submodule R L).injective_subtype
     simp only [LieSubalgebra.coe_ofLe, Submodule.map_sup, Submodule.map_subtype_range_inclusion,
       Submodule.map_top, Submodule.range_subtype]
@@ -238,9 +238,9 @@ theorem LieAlgebra.isEngelian_of_isNoetherian [IsNoetherian R L] : LieAlgebra.Is
       LieSubmodule.nontrivial_iff_ne_bot R K]
     have : Nontrivial (L' ⧸ K.toLieSubmodule) := by
       replace hK₂ : K.toLieSubmodule ≠ ⊤ := by
-        rwa [Ne, ← LieSubmodule.coe_toSubmodule_inj, K.coe_toLieSubmodule,
-          LieSubmodule.top_coeSubmodule, ← LieSubalgebra.top_coe_submodule,
-          K.coe_to_submodule_inj]
+        rwa [Ne, ← LieSubmodule.toSubmodule_inj, K.coe_toLieSubmodule,
+          LieSubmodule.top_toSubmodule, ← LieSubalgebra.top_toSubmodule,
+          K.toSubmodule_inj]
       exact Submodule.Quotient.nontrivial_of_lt_top _ hK₂.lt_top
     have : LieModule.IsNilpotent R K (L' ⧸ K.toLieSubmodule) := by
       -- Porting note: was refine' hK₁ _ fun x => _
@@ -250,9 +250,9 @@ theorem LieAlgebra.isEngelian_of_isNoetherian [IsNoetherian R L] : LieAlgebra.Is
       apply Module.End.IsNilpotent.mapQ ?_ hx
       -- Porting note: mathlib3 solved this on its own with `submodule.mapq_linear._proof_5`
       intro X HX
-      simp only [LieSubalgebra.coe_toLieSubmodule, LieSubalgebra.mem_coe_submodule] at HX
+      simp only [LieSubalgebra.coe_toLieSubmodule, LieSubalgebra.mem_toSubmodule] at HX
       simp only [LieSubalgebra.coe_toLieSubmodule, Submodule.mem_comap, ad_apply,
-        LieSubalgebra.mem_coe_submodule]
+        LieSubalgebra.mem_toSubmodule]
       exact LieSubalgebra.lie_mem K x.prop HX
     exact nontrivial_max_triv_of_isNilpotent R K (L' ⧸ K.toLieSubmodule)
   haveI _i5 : IsNoetherian R L' := by
@@ -260,7 +260,7 @@ theorem LieAlgebra.isEngelian_of_isNoetherian [IsNoetherian R L] : LieAlgebra.Is
     -- isNoetherian_of_surjective L _ (LinearMap.range_rangeRestrict (toEnd R L M))
     -- abusing the relation between `LieHom.rangeRestrict` and `LinearMap.rangeRestrict`
     refine isNoetherian_of_surjective L (LieHom.rangeRestrict (toEnd R L M)) ?_
-    simp only [LieHom.range_coeSubmodule, LieHom.coe_toLinearMap,
+    simp only [LieHom.range_toSubmodule, LieHom.coe_toLinearMap,
       LinearMap.range_eq_top]
     exact LieHom.surjective_rangeRestrict (toEnd R L M)
   obtain ⟨K, hK₁, hK₂⟩ := (LieSubalgebra.wellFoundedGT_of_noetherian R L').wf.has_min s hs

--- a/Mathlib/Algebra/Lie/EngelSubalgebra.lean
+++ b/Mathlib/Algebra/Lie/EngelSubalgebra.lean
@@ -122,7 +122,7 @@ lemma normalizer_eq_self_of_engel_le [IsArtinian R L]
     apply le_sup_of_le_left
     rw [Submodule.map_le_iff_le_comap]
     intro y hy
-    simp only [Submodule.mem_comap, mem_engel_iff, mem_coe_submodule]
+    simp only [Submodule.mem_comap, mem_engel_iff, mem_toSubmodule]
     use k+1
     clear hk; revert hy
     generalize k+1 = k
@@ -135,7 +135,7 @@ lemma normalizer_eq_self_of_engel_le [IsArtinian R L]
     apply le_sup_of_le_right
     rw [Submodule.map_le_iff_le_comap]
     rintro _ ⟨y, rfl⟩
-    simp only [pow_succ', LinearMap.mul_apply, Submodule.mem_comap, mem_coe_submodule]
+    simp only [pow_succ', LinearMap.mul_apply, Submodule.mem_comap, mem_toSubmodule]
     apply aux₁
     simp only [Submodule.coe_subtype, SetLike.coe_mem]
 

--- a/Mathlib/Algebra/Lie/IdealOperations.lean
+++ b/Mathlib/Algebra/Lie/IdealOperations.lean
@@ -61,7 +61,7 @@ theorem comap_map_eq (hf : f.ker = ⊥) : comap f (map f N) = N := by
 
 @[simp]
 theorem map_comap_incl : map N.incl (comap N.incl N') = N ⊓ N' := by
-  rw [← coe_toSubmodule_inj]
+  rw [← toSubmodule_inj]
   exact (N : Submodule R M).map_comap_subtype N'
 
 variable [LieAlgebra R L] [LieModule R L M₂] (I J : LieIdeal R L)
@@ -201,7 +201,7 @@ theorem inf_lie : ⁅I ⊓ J, N⁆ ≤ ⁅I, N⁆ ⊓ ⁅J, N⁆ := by
   apply mono_lie_left <;> [exact inf_le_left; exact inf_le_right]
 
 theorem map_bracket_eq [LieModule R L M] : map f ⁅I, N⁆ = ⁅I, map f N⁆ := by
-  rw [← coe_toSubmodule_inj, coeSubmodule_map, lieIdeal_oper_eq_linear_span,
+  rw [← toSubmodule_inj, toSubmodule_map, lieIdeal_oper_eq_linear_span,
     lieIdeal_oper_eq_linear_span, Submodule.map_span]
   congr
   ext m
@@ -244,7 +244,7 @@ theorem map_bracket_le {I₁ I₂ : LieIdeal R L} : map f ⁅I₁, I₂⁆ ≤ �
 theorem map_bracket_eq {I₁ I₂ : LieIdeal R L} (h : Function.Surjective f) :
     map f ⁅I₁, I₂⁆ = ⁅map f I₁, map f I₂⁆ := by
   suffices ⁅map f I₁, map f I₂⁆ ≤ map f ⁅I₁, I₂⁆ by exact le_antisymm (map_bracket_le f) this
-  rw [← LieSubmodule.coeSubmodule_le_coeSubmodule, coe_map_of_surjective h,
+  rw [← LieSubmodule.toSubmodule_le_toSubmodule, coe_map_of_surjective h,
     LieSubmodule.lieIdeal_oper_eq_linear_span, LieSubmodule.lieIdeal_oper_eq_linear_span,
     LinearMap.map_span]
   apply Submodule.span_mono
@@ -266,8 +266,8 @@ theorem map_comap_incl {I₁ I₂ : LieIdeal R L} : map I₁.incl (comap I₁.in
 
 theorem comap_bracket_eq {J₁ J₂ : LieIdeal R L'} (h : f.IsIdealMorphism) :
     comap f ⁅f.idealRange ⊓ J₁, f.idealRange ⊓ J₂⁆ = ⁅comap f J₁, comap f J₂⁆ ⊔ f.ker := by
-  rw [← LieSubmodule.coe_toSubmodule_inj, comap_coeSubmodule,
-    LieSubmodule.sup_coe_toSubmodule, f.ker_coeSubmodule, ← Submodule.comap_map_eq,
+  rw [← LieSubmodule.toSubmodule_inj, comap_toSubmodule,
+    LieSubmodule.sup_toSubmodule, f.ker_toSubmodule, ← Submodule.comap_map_eq,
     LieSubmodule.lieIdeal_oper_eq_linear_span, LieSubmodule.lieIdeal_oper_eq_linear_span,
     LinearMap.map_span]
   congr; simp only [LieHom.coe_toLinearMap, Set.mem_setOf_eq]; ext y

--- a/Mathlib/Algebra/Lie/InvariantForm.lean
+++ b/Mathlib/Algebra/Lie/InvariantForm.lean
@@ -72,7 +72,7 @@ def orthogonal (hΦ_inv : Φ.lieInvariant L) (N : LieSubmodule R L M) : LieSubmo
     suffices (∀ n ∈ N, Φ n y = 0) → ∀ n ∈ N, Φ n ⁅x, y⁆ = 0 by
       simpa only [LinearMap.BilinForm.isOrtho_def, -- and some default simp lemmas
         AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup, Submodule.mem_toAddSubmonoid,
-        LinearMap.BilinForm.mem_orthogonal_iff, LieSubmodule.mem_coeSubmodule]
+        LinearMap.BilinForm.mem_orthogonal_iff, LieSubmodule.mem_toSubmodule]
     intro H a ha
     rw [← neg_eq_zero, ← hΦ_inv]
     exact H _ <| N.lie_mem ha
@@ -125,31 +125,31 @@ variable (hL : ∀ I : LieIdeal K L, IsAtom I → ¬IsLieAbelian I)
 include hΦ_nondeg hΦ_refl hL
 
 open Module Submodule in
-lemma orthogonal_isCompl_coe_submodule (I : LieIdeal K L) (hI : IsAtom I) :
+lemma orthogonal_isCompl_toSubmodule (I : LieIdeal K L) (hI : IsAtom I) :
     IsCompl I.toSubmodule (orthogonal Φ hΦ_inv I).toSubmodule := by
   rw [orthogonal_toSubmodule, LinearMap.BilinForm.isCompl_orthogonal_iff_disjoint hΦ_refl,
-      ← orthogonal_toSubmodule _ hΦ_inv, ← LieSubmodule.disjoint_iff_coe_toSubmodule]
+      ← orthogonal_toSubmodule _ hΦ_inv, ← LieSubmodule.disjoint_iff_toSubmodule]
   exact orthogonal_disjoint Φ hΦ_nondeg hΦ_inv hL I hI
 
 open Module Submodule in
 lemma orthogonal_isCompl (I : LieIdeal K L) (hI : IsAtom I) :
     IsCompl I (orthogonal Φ hΦ_inv I) := by
-  rw [LieSubmodule.isCompl_iff_coe_toSubmodule]
-  exact orthogonal_isCompl_coe_submodule Φ hΦ_nondeg hΦ_inv hΦ_refl hL I hI
+  rw [LieSubmodule.isCompl_iff_toSubmodule]
+  exact orthogonal_isCompl_toSubmodule Φ hΦ_nondeg hΦ_inv hΦ_refl hL I hI
 
 include hΦ_inv
 
 lemma restrict_nondegenerate (I : LieIdeal K L) (hI : IsAtom I) :
     (Φ.restrict I).Nondegenerate := by
   rw [LinearMap.BilinForm.restrict_nondegenerate_iff_isCompl_orthogonal hΦ_refl]
-  exact orthogonal_isCompl_coe_submodule Φ hΦ_nondeg hΦ_inv hΦ_refl hL I hI
+  exact orthogonal_isCompl_toSubmodule Φ hΦ_nondeg hΦ_inv hΦ_refl hL I hI
 
 lemma restrict_orthogonal_nondegenerate (I : LieIdeal K L) (hI : IsAtom I) :
     (Φ.restrict (orthogonal Φ hΦ_inv I)).Nondegenerate := by
   rw [LinearMap.BilinForm.restrict_nondegenerate_iff_isCompl_orthogonal hΦ_refl]
-  simp only [LieIdeal.coe_to_lieSubalgebra_to_submodule, orthogonal_toSubmodule,
+  simp only [LieIdeal.coe_toLieSubalgebra_toSubmodule, orthogonal_toSubmodule,
     LinearMap.BilinForm.orthogonal_orthogonal hΦ_nondeg hΦ_refl]
-  exact (orthogonal_isCompl_coe_submodule Φ hΦ_nondeg hΦ_inv hΦ_refl hL I hI).symm
+  exact (orthogonal_isCompl_toSubmodule Φ hΦ_nondeg hΦ_inv hΦ_refl hL I hI).symm
 
 open Module Submodule in
 lemma atomistic : ∀ I : LieIdeal K L, sSup {J : LieIdeal K L | IsAtom J ∧ J ≤ I} = I := by

--- a/Mathlib/Algebra/Lie/InvariantForm.lean
+++ b/Mathlib/Algebra/Lie/InvariantForm.lean
@@ -131,6 +131,9 @@ lemma orthogonal_isCompl_toSubmodule (I : LieIdeal K L) (hI : IsAtom I) :
       ← orthogonal_toSubmodule _ hΦ_inv, ← LieSubmodule.disjoint_iff_toSubmodule]
   exact orthogonal_disjoint Φ hΦ_nondeg hΦ_inv hL I hI
 
+@[deprecated (since := "2024-12-30")]
+alias orthogonal_isCompl_coe_submodule := orthogonal_isCompl_toSubmodule
+
 open Module Submodule in
 lemma orthogonal_isCompl (I : LieIdeal K L) (hI : IsAtom I) :
     IsCompl I (orthogonal Φ hΦ_inv I) := by

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -428,7 +428,7 @@ theorem coe_lcs_range_toEnd_eq (k : ℕ) :
   | zero => simp
   | succ k ih =>
     simp only [lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span', ←
-      (lowerCentralSeries R (toEnd R L M).range M k).mem_coeSubmodule, ih]
+      (lowerCentralSeries R (toEnd R L M).range M k).mem_toSubmodule, ih]
     congr
     ext m
     constructor
@@ -442,7 +442,7 @@ theorem coe_lcs_range_toEnd_eq (k : ℕ) :
 theorem isNilpotent_range_toEnd_iff :
     IsNilpotent R (toEnd R L M).range M ↔ IsNilpotent R L M := by
   constructor <;> rintro ⟨k, hk⟩ <;> use k <;>
-      rw [← LieSubmodule.coe_toSubmodule_inj] at hk ⊢ <;>
+      rw [← LieSubmodule.toSubmodule_inj] at hk ⊢ <;>
     simpa using hk
 
 end LieModule
@@ -550,13 +550,13 @@ theorem Function.Surjective.lieModule_lcs_map_eq (k : ℕ) :
     suffices
       g '' {m | ∃ (x : L) (n : _), n ∈ lowerCentralSeries R L M k ∧ ⁅x, n⁆ = m} =
         {m | ∃ (x : L₂) (n : _), n ∈ lowerCentralSeries R L M k ∧ ⁅x, g n⁆ = m} by
-      simp only [← LieSubmodule.mem_coeSubmodule] at this
+      simp only [← LieSubmodule.mem_toSubmodule] at this
       -- Porting note: was
-      -- simp [← LieSubmodule.mem_coeSubmodule, ← ih, LieSubmodule.lieIdeal_oper_eq_linear_span',
+      -- simp [← LieSubmodule.mem_toSubmodule, ← ih, LieSubmodule.lieIdeal_oper_eq_linear_span',
       --   Submodule.map_span, -Submodule.span_image, this,
-      --   -LieSubmodule.mem_coeSubmodule]
+      --   -LieSubmodule.mem_toSubmodule]
       simp_rw [lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span',
-        Submodule.map_span, LieSubmodule.mem_top, true_and, ← LieSubmodule.mem_coeSubmodule, this,
+        Submodule.map_span, LieSubmodule.mem_top, true_and, ← LieSubmodule.mem_toSubmodule, this,
         ← ih, Submodule.mem_map, exists_exists_and_eq_and]
     ext m₂
     constructor
@@ -570,7 +570,7 @@ include hf hg hfg in
 theorem Function.Surjective.lieModuleIsNilpotent [IsNilpotent R L M] : IsNilpotent R L₂ M₂ := by
   obtain ⟨k, hk⟩ := id (by infer_instance : IsNilpotent R L M)
   use k
-  rw [← LieSubmodule.coe_toSubmodule_inj] at hk ⊢
+  rw [← LieSubmodule.toSubmodule_inj] at hk ⊢
   simp [← hf.lieModule_lcs_map_eq hg hfg k, hk]
 
 theorem Equiv.lieModule_isNilpotent_iff (f : L ≃ₗ⁅R⁆ L₂) (g : M ≃ₗ[R] M₂)
@@ -580,7 +580,7 @@ theorem Equiv.lieModule_isNilpotent_iff (f : L ≃ₗ⁅R⁆ L₂) (g : M ≃ₗ
     exact f.surjective.lieModuleIsNilpotent hg hfg
   · have hg : Surjective (g.symm : M₂ →ₗ[R] M) := g.symm.surjective
     refine f.symm.surjective.lieModuleIsNilpotent hg fun x m => ?_
-    rw [LinearEquiv.coe_coe, LieEquiv.coe_to_lieHom, ← g.symm_apply_apply ⁅f.symm x, g.symm m⁆, ←
+    rw [LinearEquiv.coe_coe, LieEquiv.coe_toLieHom, ← g.symm_apply_apply ⁅f.symm x, g.symm m⁆, ←
       hfg, f.apply_symm_apply, g.apply_symm_apply]
 
 @[simp]
@@ -637,18 +637,18 @@ theorem coe_lowerCentralSeries_ideal_quot_eq {I : LieIdeal R L} (k : ℕ) :
       LieSubmodule.toSubmodule (lowerCentralSeries R (L ⧸ I) (L ⧸ I) k) := by
   induction k with
   | zero =>
-    simp only [LieModule.lowerCentralSeries_zero, LieSubmodule.top_coeSubmodule,
-      LieIdeal.top_coe_lieSubalgebra, LieSubalgebra.top_coe_submodule]
+    simp only [LieModule.lowerCentralSeries_zero, LieSubmodule.top_toSubmodule,
+      LieIdeal.top_toLieSubalgebra, LieSubalgebra.top_toSubmodule]
   | succ k ih =>
     simp only [LieModule.lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span]
     congr
     ext x
     constructor
     · rintro ⟨⟨y, -⟩, ⟨z, hz⟩, rfl : ⁅y, z⁆ = x⟩
-      rw [← LieSubmodule.mem_coeSubmodule, ih, LieSubmodule.mem_coeSubmodule] at hz
+      rw [← LieSubmodule.mem_toSubmodule, ih, LieSubmodule.mem_toSubmodule] at hz
       exact ⟨⟨LieSubmodule.Quotient.mk y, LieSubmodule.mem_top _⟩, ⟨z, hz⟩, rfl⟩
     · rintro ⟨⟨⟨y⟩, -⟩, ⟨z, hz⟩, rfl : ⁅y, z⁆ = x⟩
-      rw [← LieSubmodule.mem_coeSubmodule, ← ih, LieSubmodule.mem_coeSubmodule] at hz
+      rw [← LieSubmodule.mem_toSubmodule, ← ih, LieSubmodule.mem_toSubmodule] at hz
       exact ⟨⟨y, LieSubmodule.mem_top _⟩, ⟨z, hz⟩, rfl⟩
 
 /-- Note that the below inequality can be strict. For example the ideal of strictly-upper-triangular
@@ -671,7 +671,7 @@ theorem LieAlgebra.nilpotent_of_nilpotent_quotient {I : LieIdeal R L} (h₁ : I 
     exact LieModule.nilpotentOfNilpotentQuotient R L L h₁ this
   obtain ⟨k, hk⟩ := h₂
   use k
-  simp [← LieSubmodule.coe_toSubmodule_inj, coe_lowerCentralSeries_ideal_quot_eq, hk]
+  simp [← LieSubmodule.toSubmodule_inj, coe_lowerCentralSeries_ideal_quot_eq, hk]
 
 theorem LieAlgebra.non_trivial_center_of_isNilpotent [Nontrivial L] [IsNilpotent R L] :
     Nontrivial <| center R L :=
@@ -773,7 +773,7 @@ theorem coe_lcs_eq [LieModule R L M] :
   | zero => simp
   | succ k ih =>
     simp_rw [lowerCentralSeries_succ, lcs_succ, LieSubmodule.lieIdeal_oper_eq_linear_span', ←
-      (I.lcs M k).mem_coeSubmodule, ih, LieSubmodule.mem_coeSubmodule, LieSubmodule.mem_top,
+      (I.lcs M k).mem_toSubmodule, ih, LieSubmodule.mem_toSubmodule, LieSubmodule.mem_top,
       true_and, (I : LieSubalgebra R L).coe_bracket_of_module]
     congr
     ext m

--- a/Mathlib/Algebra/Lie/Normalizer.lean
+++ b/Mathlib/Algebra/Lie/Normalizer.lean
@@ -147,7 +147,7 @@ theorem lie_mem_sup_of_mem_normalizer {x y z : L} (hx : x ∈ H.normalizer) (hy 
   obtain ⟨t, rfl⟩ := Submodule.mem_span_singleton.mp hu₁
   obtain ⟨s, rfl⟩ := Submodule.mem_span_singleton.mp hu₂
   apply Submodule.mem_sup_right
-  simp only [LieSubalgebra.mem_coe_submodule, smul_lie, add_lie, zero_add, lie_add, smul_zero,
+  simp only [LieSubalgebra.mem_toSubmodule, smul_lie, add_lie, zero_add, lie_add, smul_zero,
     lie_smul, lie_self]
   refine H.add_mem (H.smul_mem s ?_) (H.add_mem (H.smul_mem t ?_) (H.lie_mem hv hw))
   exacts [(H.mem_normalizer_iff' x).mp hx v hv, (H.mem_normalizer_iff x).mp hx w hw]
@@ -172,7 +172,7 @@ theorem normalizer_eq_self_iff :
   refine ⟨fun h => ?_, fun h => le_antisymm ?_ H.le_normalizer⟩
   · rintro ⟨x⟩ hx
     suffices x ∈ H by rwa [Submodule.Quotient.quot_mk_eq_mk, Submodule.Quotient.mk_eq_zero,
-      coe_toLieSubmodule, mem_coe_submodule]
+      coe_toLieSubmodule, mem_toSubmodule]
     rw [← h, H.mem_normalizer_iff']
     intro y hy
     replace hx : ⁅_, LieSubmodule.Quotient.mk' _ x⁆ = 0 := hx ⟨y, hy⟩

--- a/Mathlib/Algebra/Lie/OfAssociative.lean
+++ b/Mathlib/Algebra/Lie/OfAssociative.lean
@@ -398,7 +398,7 @@ of the endomorphism `ad(x)` of `L` by `e` is the endomorphism `ad(e x)` of `L'`.
 @[simp]
 lemma conj_ad_apply (e : L ≃ₗ⁅R⁆ L') (x : L) : LinearEquiv.conj e (ad R L x) = ad R L' (e x) := by
   ext y'
-  rw [LinearEquiv.conj_apply_apply, ad_apply, ad_apply, coe_to_linearEquiv, map_lie,
-    ← coe_to_linearEquiv, LinearEquiv.apply_symm_apply]
+  rw [LinearEquiv.conj_apply_apply, ad_apply, ad_apply, coe_toLinearEquiv, map_lie,
+    ← coe_toLinearEquiv, LinearEquiv.apply_symm_apply]
 
 end LieAlgebra

--- a/Mathlib/Algebra/Lie/Semisimple/Basic.lean
+++ b/Mathlib/Algebra/Lie/Semisimple/Basic.lean
@@ -140,7 +140,7 @@ lemma isSimple_of_isAtom (I : LieIdeal R L) (hI : IsAtom I) : IsSimple R I where
           Submodule.mem_toAddSubmonoid]
         apply add_mem
         -- Now `⁅a, y⁆ ∈ J` since `a ∈ I`, `y ∈ J`, and `J` is an ideal of `I`.
-        · simp only [Submodule.mem_map, LieSubmodule.mem_coeSubmodule, Subtype.exists]
+        · simp only [Submodule.mem_map, LieSubmodule.mem_toSubmodule, Subtype.exists]
           erw [Submodule.coe_subtype]
           simp only [exists_and_right, exists_eq_right, ha, lie_mem_left, exists_true_left]
           exact lie_mem_right R I J ⟨a, ha⟩ y hy
@@ -159,8 +159,8 @@ lemma isSimple_of_isAtom (I : LieIdeal R L) (hI : IsAtom I) : IsSimple R I where
       intro x hx
       suffices x ∈ J → x = 0 from this hx
       have := @this x.1
-      simp only [LieIdeal.incl_coe, LieIdeal.coe_to_lieSubalgebra_to_submodule,
-        LieSubmodule.mem_mk_iff', Submodule.mem_map, LieSubmodule.mem_coeSubmodule, Subtype.exists,
+      simp only [LieIdeal.incl_coe, LieIdeal.coe_toLieSubalgebra_toSubmodule,
+        LieSubmodule.mem_mk_iff', Submodule.mem_map, LieSubmodule.mem_toSubmodule, Subtype.exists,
         LieSubmodule.mem_bot, ZeroMemClass.coe_eq_zero, forall_exists_index, and_imp, J'] at this
       exact fun _ ↦ this (↑x) x.property hx rfl
     -- We need to show that `J = ⊥`.

--- a/Mathlib/Algebra/Lie/Subalgebra.lean
+++ b/Mathlib/Algebra/Lie/Subalgebra.lean
@@ -147,7 +147,7 @@ theorem mem_mk_iff (S : Set L) (h₁ h₂ h₃ h₄) {x : L} :
   Iff.rfl
 
 @[simp]
-theorem mem_coe_submodule {x : L} : x ∈ (L' : Submodule R L) ↔ x ∈ L' :=
+theorem mem_toSubmodule {x : L} : x ∈ (L' : Submodule R L) ↔ x ∈ L' :=
   Iff.rfl
 
 theorem mem_coe {x : L} : x ∈ (L' : Set L) ↔ x ∈ L' :=
@@ -175,7 +175,7 @@ theorem mk_coe (S : Set L) (h₁ h₂ h₃ h₄) :
     ((⟨⟨⟨⟨S, h₁⟩, h₂⟩, h₃⟩, h₄⟩ : LieSubalgebra R L) : Set L) = S :=
   rfl
 
-theorem coe_to_submodule_mk (p : Submodule R L) (h) :
+theorem toSubmodule_mk (p : Submodule R L) (h) :
     (({ p with lie_mem' := h } : LieSubalgebra R L) : Submodule R L) = p := by
   cases p
   rfl
@@ -187,20 +187,20 @@ theorem coe_injective : Function.Injective ((↑) : LieSubalgebra R L → Set L)
 theorem coe_set_eq (L₁' L₂' : LieSubalgebra R L) : (L₁' : Set L) = L₂' ↔ L₁' = L₂' :=
   SetLike.coe_set_eq
 
-theorem to_submodule_injective : Function.Injective ((↑) : LieSubalgebra R L → Submodule R L) :=
+theorem toSubmodule_injective : Function.Injective ((↑) : LieSubalgebra R L → Submodule R L) :=
   fun L₁' L₂' h ↦ by
   rw [SetLike.ext'_iff] at h
   rw [← coe_set_eq]
   exact h
 
 @[simp]
-theorem coe_to_submodule_inj (L₁' L₂' : LieSubalgebra R L) :
+theorem toSubmodule_inj (L₁' L₂' : LieSubalgebra R L) :
     (L₁' : Submodule R L) = (L₂' : Submodule R L) ↔ L₁' = L₂' :=
-  to_submodule_injective.eq_iff
+  toSubmodule_injective.eq_iff
 
-@[deprecated (since := "2024-12-29")] alias coe_to_submodule_eq_iff := coe_to_submodule_inj
+@[deprecated (since := "2024-12-29")] alias toSubmodule_eq_iff := toSubmodule_inj
 
-theorem coe_to_submodule : ((L' : Submodule R L) : Set L) = L' :=
+theorem toSubmodule : ((L' : Submodule R L) : Set L) = L' :=
   rfl
 
 section LieModule
@@ -329,7 +329,7 @@ variable (K K' : LieSubalgebra R L) (K₂ : LieSubalgebra R L₂)
 
 @[simp]
 theorem incl_range : K.incl.range = K := by
-  rw [← coe_to_submodule_inj]
+  rw [← toSubmodule_inj]
   exact (K : Submodule R L).range_subtype
 
 /-- The image of a Lie subalgebra under a Lie algebra morphism is a Lie subalgebra of the
@@ -375,7 +375,7 @@ theorem le_def : K ≤ K' ↔ (K : Set L) ⊆ K' :=
   Iff.rfl
 
 @[simp]
-theorem coe_submodule_le_coe_submodule : (K : Submodule R L) ≤ K' ↔ K ≤ K' :=
+theorem toSubmodule_le_toSubmodule : (K : Submodule R L) ≤ K' ↔ K ≤ K' :=
   Iff.rfl
 
 instance : Bot (LieSubalgebra R L) :=
@@ -386,7 +386,7 @@ theorem bot_coe : ((⊥ : LieSubalgebra R L) : Set L) = {0} :=
   rfl
 
 @[simp]
-theorem bot_coe_submodule : ((⊥ : LieSubalgebra R L) : Submodule R L) = ⊥ :=
+theorem bot_toSubmodule : ((⊥ : LieSubalgebra R L) : Submodule R L) = ⊥ :=
   rfl
 
 @[simp]
@@ -401,7 +401,7 @@ theorem top_coe : ((⊤ : LieSubalgebra R L) : Set L) = univ :=
   rfl
 
 @[simp]
-theorem top_coe_submodule : ((⊤ : LieSubalgebra R L) : Submodule R L) = ⊤ :=
+theorem top_toSubmodule : ((⊤ : LieSubalgebra R L) : Submodule R L) = ⊤ :=
   rfl
 
 @[simp]
@@ -431,13 +431,13 @@ theorem inf_coe : (↑(K ⊓ K') : Set L) = (K : Set L) ∩ (K' : Set L) :=
   rfl
 
 @[simp]
-theorem sInf_coe_to_submodule (S : Set (LieSubalgebra R L)) :
+theorem sInf_toSubmodule (S : Set (LieSubalgebra R L)) :
     (↑(sInf S) : Submodule R L) = sInf {(s : Submodule R L) | s ∈ S} :=
   rfl
 
 @[simp]
 theorem sInf_coe (S : Set (LieSubalgebra R L)) : (↑(sInf S) : Set L) = ⋂ s ∈ S, (s : Set L) := by
-  rw [← coe_to_submodule, sInf_coe_to_submodule, Submodule.sInf_coe]
+  rw [← toSubmodule, sInf_toSubmodule, Submodule.sInf_coe]
   ext x
   simp
 
@@ -490,13 +490,13 @@ theorem add_eq_sup : K + K' = K ⊔ K' :=
   rfl
 
 @[simp]
-theorem inf_coe_to_submodule :
+theorem inf_toSubmodule :
     (↑(K ⊓ K') : Submodule R L) = (K : Submodule R L) ⊓ (K' : Submodule R L) :=
   rfl
 
 @[simp]
 theorem mem_inf (x : L) : x ∈ K ⊓ K' ↔ x ∈ K ∧ x ∈ K' := by
-  rw [← mem_coe_submodule, ← mem_coe_submodule, ← mem_coe_submodule, inf_coe_to_submodule,
+  rw [← mem_toSubmodule, ← mem_toSubmodule, ← mem_toSubmodule, inf_toSubmodule,
     Submodule.mem_inf]
 
 theorem eq_bot_iff : K = ⊥ ↔ ∀ x : L, x ∈ K → x = 0 := by
@@ -623,9 +623,9 @@ theorem coe_lieSpan_submodule_eq_iff {p : Submodule R L} :
     (lieSpan R L (p : Set L) : Submodule R L) = p ↔ ∃ K : LieSubalgebra R L, ↑K = p := by
   rw [p.exists_lieSubalgebra_coe_eq_iff]; constructor <;> intro h
   · intro x m hm
-    rw [← h, mem_coe_submodule]
+    rw [← h, mem_toSubmodule]
     exact lie_mem _ (subset_lieSpan hm)
-  · rw [← coe_to_submodule_mk p @h, coe_to_submodule, coe_to_submodule_inj, lieSpan_eq]
+  · rw [← toSubmodule_mk p @h, toSubmodule, toSubmodule_inj, lieSpan_eq]
 
 variable (R L)
 

--- a/Mathlib/Algebra/Lie/Subalgebra.lean
+++ b/Mathlib/Algebra/Lie/Subalgebra.lean
@@ -150,6 +150,8 @@ theorem mem_mk_iff (S : Set L) (h₁ h₂ h₃ h₄) {x : L} :
 theorem mem_toSubmodule {x : L} : x ∈ (L' : Submodule R L) ↔ x ∈ L' :=
   Iff.rfl
 
+@[deprecated (since := "2024-12-30")] alias mem_coe_submodule := mem_toSubmodule
+
 theorem mem_coe {x : L} : x ∈ (L' : Set L) ↔ x ∈ L' :=
   Iff.rfl
 
@@ -180,6 +182,8 @@ theorem toSubmodule_mk (p : Submodule R L) (h) :
   cases p
   rfl
 
+@[deprecated (since := "2024-12-30")] alias coe_to_submodule_mk := toSubmodule_mk
+
 theorem coe_injective : Function.Injective ((↑) : LieSubalgebra R L → Set L) :=
   SetLike.coe_injective
 
@@ -193,15 +197,21 @@ theorem toSubmodule_injective : Function.Injective ((↑) : LieSubalgebra R L �
   rw [← coe_set_eq]
   exact h
 
+@[deprecated (since := "2024-12-30")] alias to_submodule_injective := toSubmodule_injective
+
 @[simp]
 theorem toSubmodule_inj (L₁' L₂' : LieSubalgebra R L) :
     (L₁' : Submodule R L) = (L₂' : Submodule R L) ↔ L₁' = L₂' :=
   toSubmodule_injective.eq_iff
 
+@[deprecated (since := "2024-12-30")] alias coe_to_submodule_inj := toSubmodule_inj
+
 @[deprecated (since := "2024-12-29")] alias toSubmodule_eq_iff := toSubmodule_inj
 
 theorem toSubmodule : ((L' : Submodule R L) : Set L) = L' :=
   rfl
+
+@[deprecated (since := "2024-12-30")] alias coe_to_submodule := toSubmodule
 
 section LieModule
 
@@ -378,6 +388,9 @@ theorem le_def : K ≤ K' ↔ (K : Set L) ⊆ K' :=
 theorem toSubmodule_le_toSubmodule : (K : Submodule R L) ≤ K' ↔ K ≤ K' :=
   Iff.rfl
 
+@[deprecated (since := "2024-12-30")]
+alias coe_submodule_le_coe_submodule := toSubmodule_le_toSubmodule
+
 instance : Bot (LieSubalgebra R L) :=
   ⟨0⟩
 
@@ -388,6 +401,8 @@ theorem bot_coe : ((⊥ : LieSubalgebra R L) : Set L) = {0} :=
 @[simp]
 theorem bot_toSubmodule : ((⊥ : LieSubalgebra R L) : Submodule R L) = ⊥ :=
   rfl
+
+@[deprecated (since := "2024-12-30")] alias bot_coe_submodule := bot_toSubmodule
 
 @[simp]
 theorem mem_bot (x : L) : x ∈ (⊥ : LieSubalgebra R L) ↔ x = 0 :=
@@ -403,6 +418,8 @@ theorem top_coe : ((⊤ : LieSubalgebra R L) : Set L) = univ :=
 @[simp]
 theorem top_toSubmodule : ((⊤ : LieSubalgebra R L) : Submodule R L) = ⊤ :=
   rfl
+
+@[deprecated (since := "2024-12-30")] alias top_coe_submodule := top_toSubmodule
 
 @[simp]
 theorem mem_top (x : L) : x ∈ (⊤ : LieSubalgebra R L) :=
@@ -434,6 +451,8 @@ theorem inf_coe : (↑(K ⊓ K') : Set L) = (K : Set L) ∩ (K' : Set L) :=
 theorem sInf_toSubmodule (S : Set (LieSubalgebra R L)) :
     (↑(sInf S) : Submodule R L) = sInf {(s : Submodule R L) | s ∈ S} :=
   rfl
+
+@[deprecated (since := "2024-12-30")] alias sInf_coe_to_submodule := sInf_toSubmodule
 
 @[simp]
 theorem sInf_coe (S : Set (LieSubalgebra R L)) : (↑(sInf S) : Set L) = ⋂ s ∈ S, (s : Set L) := by
@@ -493,6 +512,8 @@ theorem add_eq_sup : K + K' = K ⊔ K' :=
 theorem inf_toSubmodule :
     (↑(K ⊓ K') : Submodule R L) = (K : Submodule R L) ⊓ (K' : Submodule R L) :=
   rfl
+
+@[deprecated (since := "2024-12-30")] alias inf_coe_to_submodule := inf_toSubmodule
 
 @[simp]
 theorem mem_inf (x : L) : x ∈ K ⊓ K' ↔ x ∈ K ∧ x ∈ K' := by

--- a/Mathlib/Algebra/Lie/Subalgebra.lean
+++ b/Mathlib/Algebra/Lie/Subalgebra.lean
@@ -208,10 +208,10 @@ theorem toSubmodule_inj (L₁' L₂' : LieSubalgebra R L) :
 
 @[deprecated (since := "2024-12-29")] alias toSubmodule_eq_iff := toSubmodule_inj
 
-theorem toSubmodule : ((L' : Submodule R L) : Set L) = L' :=
+theorem coe_toSubmodule : ((L' : Submodule R L) : Set L) = L' :=
   rfl
 
-@[deprecated (since := "2024-12-30")] alias coe_to_submodule := toSubmodule
+@[deprecated (since := "2024-12-30")] alias coe_to_submodule := coe_toSubmodule
 
 section LieModule
 

--- a/Mathlib/Algebra/Lie/Subalgebra.lean
+++ b/Mathlib/Algebra/Lie/Subalgebra.lean
@@ -456,7 +456,7 @@ theorem sInf_toSubmodule (S : Set (LieSubalgebra R L)) :
 
 @[simp]
 theorem sInf_coe (S : Set (LieSubalgebra R L)) : (↑(sInf S) : Set L) = ⋂ s ∈ S, (s : Set L) := by
-  rw [← toSubmodule, sInf_toSubmodule, Submodule.sInf_coe]
+  rw [← coe_toSubmodule, sInf_toSubmodule, Submodule.sInf_coe]
   ext x
   simp
 
@@ -646,7 +646,7 @@ theorem coe_lieSpan_submodule_eq_iff {p : Submodule R L} :
   · intro x m hm
     rw [← h, mem_toSubmodule]
     exact lie_mem _ (subset_lieSpan hm)
-  · rw [← toSubmodule_mk p @h, toSubmodule, toSubmodule_inj, lieSpan_eq]
+  · rw [← toSubmodule_mk p @h, coe_toSubmodule, toSubmodule_inj, lieSpan_eq]
 
 variable (R L)
 

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -542,6 +542,7 @@ theorem iSup_induction' {ι} (N : ι → LieSubmodule R L M) {C : (x : M) → (x
   · rintro ⟨_, Cx⟩ ⟨_, Cy⟩
     exact ⟨_, hadd _ _ _ _ Cx Cy⟩
 
+-- TODO(Yaël): turn around
 theorem disjoint_iff_toSubmodule :
     Disjoint N N' ↔ Disjoint (N : Submodule R M) (N' : Submodule R M) := by
   rw [disjoint_iff, disjoint_iff, ← toSubmodule_inj, inf_toSubmodule, bot_toSubmodule,

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -75,9 +75,8 @@ instance : Inhabited (LieSubmodule R L M) :=
 instance (priority := high) coeSort : CoeSort (LieSubmodule R L M) (Type w) where
   coe N := { x : M // x ∈ N }
 
-instance (priority := mid) toSubmodule : CoeOut (LieSubmodule R L M) (Submodule R M) :=
+instance (priority := mid) coeSubmodule : CoeOut (LieSubmodule R L M) (Submodule R M) :=
   ⟨toSubmodule⟩
-
 
 @[norm_cast]
 theorem coe_toSubmodule : ((N : Submodule R M) : Set M) = N :=

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -102,6 +102,8 @@ theorem mem_mk_iff' (p : Submodule R M) (h) {x : M} :
 theorem mem_toSubmodule {x : M} : x ∈ (N : Submodule R M) ↔ x ∈ N :=
   Iff.rfl
 
+@[deprecated (since := "2024-12-30")] alias mem_coeSubmodule := mem_toSubmodule
+
 theorem mem_coe {x : M} : x ∈ (N : Set M) ↔ x ∈ N :=
   Iff.rfl
 
@@ -121,9 +123,13 @@ theorem coe_toSet_mk (S : Set M) (h₁ h₂ h₃ h₄) :
 theorem toSubmodule_mk (p : Submodule R M) (h) :
     (({ p with lie_mem := h } : LieSubmodule R L M) : Submodule R M) = p := by cases p; rfl
 
+@[deprecated (since := "2024-12-30")] alias coe_toSubmodule_mk := toSubmodule_mk
+
 theorem toSubmodule_injective :
     Function.Injective (toSubmodule : LieSubmodule R L M → Submodule R M) := fun x y h ↦ by
   cases x; cases y; congr
+
+@[deprecated (since := "2024-12-30")] alias coeSubmodule_injective := toSubmodule_injective
 
 @[ext]
 theorem ext (h : ∀ m, m ∈ N ↔ m ∈ N') : N = N' :=
@@ -132,6 +138,8 @@ theorem ext (h : ∀ m, m ∈ N ↔ m ∈ N') : N = N' :=
 @[simp]
 theorem toSubmodule_inj : (N : Submodule R M) = (N' : Submodule R M) ↔ N = N' :=
   toSubmodule_injective.eq_iff
+
+@[deprecated (since := "2024-12-30")] alias coe_toSubmodule_inj := toSubmodule_inj
 
 @[deprecated (since := "2024-12-29")] alias toSubmodule_eq_iff := toSubmodule_inj
 
@@ -228,10 +236,16 @@ instance : Coe (LieIdeal R L) (LieSubalgebra R L) :=
 theorem LieIdeal.coe_toLieSubalgebra (I : LieIdeal R L) : ((I : LieSubalgebra R L) : Set L) = I :=
   rfl
 
+@[deprecated (since := "2024-12-30")]
+alias LieIdeal.coe_toSubalgebra := LieIdeal.coe_toLieSubalgebra
+
 @[simp]
 theorem LieIdeal.coe_toLieSubalgebra_toSubmodule (I : LieIdeal R L) :
     ((I : LieSubalgebra R L) : Submodule R L) = LieSubmodule.toSubmodule I :=
   rfl
+
+@[deprecated (since := "2024-12-30")]
+alias LieIdeal.coe_to_lieSubalgebra_to_submodule := LieIdeal.coe_toLieSubalgebra_toSubmodule
 
 /-- An ideal of `L` is a Lie subalgebra of `L`, so it is a Lie ring. -/
 instance LieIdeal.lieRing (I : LieIdeal R L) : LieRing I :=
@@ -321,6 +335,9 @@ theorem coe_injective : Function.Injective ((↑) : LieSubmodule R L M → Set M
 theorem toSubmodule_le_toSubmodule : (N : Submodule R M) ≤ N' ↔ N ≤ N' :=
   Iff.rfl
 
+@[deprecated (since := "2024-12-30")]
+alias coeSubmodule_le_coeSubmodule := toSubmodule_le_toSubmodule
+
 instance : Bot (LieSubmodule R L M) :=
   ⟨0⟩
 
@@ -335,9 +352,13 @@ theorem bot_coe : ((⊥ : LieSubmodule R L M) : Set M) = {0} :=
 theorem bot_toSubmodule : ((⊥ : LieSubmodule R L M) : Submodule R M) = ⊥ :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias bot_coeSubmodule := bot_toSubmodule
+
 @[simp]
 theorem toSubmodule_eq_bot_iff : (N : Submodule R M) = ⊥ ↔ N = ⊥ := by
   rw [← toSubmodule_inj, bot_toSubmodule]
+
+@[deprecated (since := "2024-12-30")] alias coeSubmodule_eq_bot_iff := toSubmodule_eq_bot_iff
 
 @[simp] theorem mk_eq_bot_iff {N : Submodule R M} {h} :
     (⟨N, h⟩ : LieSubmodule R L M) = ⊥ ↔ N = ⊥ := by
@@ -358,9 +379,13 @@ theorem top_coe : ((⊤ : LieSubmodule R L M) : Set M) = univ :=
 theorem top_toSubmodule : ((⊤ : LieSubmodule R L M) : Submodule R M) = ⊤ :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias top_coeSubmodule := top_toSubmodule
+
 @[simp]
 theorem toSubmodule_eq_top_iff : (N : Submodule R M) = ⊤ ↔ N = ⊤ := by
   rw [← toSubmodule_inj, top_toSubmodule]
+
+@[deprecated (since := "2024-12-30")] alias coeSubmodule_eq_top_iff := toSubmodule_eq_top_iff
 
 @[simp] theorem mk_eq_top_iff {N : Submodule R M} {h} :
     (⟨N, h⟩ : LieSubmodule R L M) = ⊤ ↔ N = ⊤ := by
@@ -392,19 +417,27 @@ theorem inf_toSubmodule :
     (↑(N ⊓ N') : Submodule R M) = (N : Submodule R M) ⊓ (N' : Submodule R M) :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias inf_coe_toSubmodule := inf_toSubmodule
+
 @[simp]
 theorem sInf_toSubmodule (S : Set (LieSubmodule R L M)) :
     (↑(sInf S) : Submodule R M) = sInf {(s : Submodule R M) | s ∈ S} :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias sInf_coe_toSubmodule := sInf_toSubmodule
+
 theorem sInf_toSubmodule' (S : Set (LieSubmodule R L M)) :
     (↑(sInf S) : Submodule R M) = ⨅ N ∈ S, (N : Submodule R M) := by
   rw [sInf_toSubmodule, ← Set.image, sInf_image]
+
+@[deprecated (since := "2024-12-30")] alias sInf_coe_toSubmodule' := sInf_toSubmodule'
 
 @[simp]
 theorem iInf_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
     (↑(⨅ i, p i) : Submodule R M) = ⨅ i, (p i : Submodule R M) := by
   rw [iInf, sInf_toSubmodule]; ext; simp
+
+@[deprecated (since := "2024-12-30")] alias iInf_coe_toSubmodule := iInf_toSubmodule
 
 @[simp]
 theorem sInf_coe (S : Set (LieSubmodule R L M)) : (↑(sInf S) : Set M) = ⋂ s ∈ S, (s : Set M) := by
@@ -459,19 +492,27 @@ theorem sup_toSubmodule :
     (↑(N ⊔ N') : Submodule R M) = (N : Submodule R M) ⊔ (N' : Submodule R M) := by
   rfl
 
+@[deprecated (since := "2024-12-30")] alias sup_coe_toSubmodule := sup_toSubmodule
+
 @[simp]
 theorem sSup_toSubmodule (S : Set (LieSubmodule R L M)) :
     (↑(sSup S) : Submodule R M) = sSup {(s : Submodule R M) | s ∈ S} :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias sSup_coe_toSubmodule := sSup_toSubmodule
+
 theorem sSup_toSubmodule' (S : Set (LieSubmodule R L M)) :
     (↑(sSup S) : Submodule R M) = ⨆ N ∈ S, (N : Submodule R M) := by
   rw [sSup_toSubmodule, ← Set.image, sSup_image]
+
+@[deprecated (since := "2024-12-30")] alias sSup_coe_toSubmodule' := sSup_toSubmodule'
 
 @[simp]
 theorem iSup_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
     (↑(⨆ i, p i) : Submodule R M) = ⨆ i, (p i : Submodule R M) := by
   rw [iSup, sSup_toSubmodule]; ext; simp [Submodule.mem_sSup, Submodule.mem_iSup]
+
+@[deprecated (since := "2024-12-30")] alias iSup_coe_toSubmodule := iSup_toSubmodule
 
 /-- The set of Lie submodules of a Lie module form a complete lattice. -/
 instance : CompleteLattice (LieSubmodule R L M) :=
@@ -507,25 +548,41 @@ theorem disjoint_iff_toSubmodule :
   rw [disjoint_iff, disjoint_iff, ← toSubmodule_inj, inf_toSubmodule, bot_toSubmodule,
     ← disjoint_iff]
 
+@[deprecated (since := "2024-12-30")] alias disjoint_iff_coe_toSubmodule := disjoint_iff_toSubmodule
+
 theorem codisjoint_iff_toSubmodule :
     Codisjoint N N' ↔ Codisjoint (N : Submodule R M) (N' : Submodule R M) := by
   rw [codisjoint_iff, codisjoint_iff, ← toSubmodule_inj, sup_toSubmodule,
     top_toSubmodule, ← codisjoint_iff]
 
+@[deprecated (since := "2024-12-30")]
+alias codisjoint_iff_coe_toSubmodule := codisjoint_iff_toSubmodule
+
 theorem isCompl_iff_toSubmodule :
     IsCompl N N' ↔ IsCompl (N : Submodule R M) (N' : Submodule R M) := by
   simp only [isCompl_iff, disjoint_iff_toSubmodule, codisjoint_iff_toSubmodule]
+
+@[deprecated (since := "2024-12-30")] alias isCompl_iff_coe_toSubmodule := isCompl_iff_toSubmodule
 
 theorem iSupIndep_iff_toSubmodule {ι : Type*} {N : ι → LieSubmodule R L M} :
     iSupIndep N ↔ iSupIndep fun i ↦ (N i : Submodule R M) := by
   simp [iSupIndep_def, disjoint_iff_toSubmodule]
 
+@[deprecated (since := "2024-12-30")]
+alias iSupIndep_iff_coe_toSubmodule := iSupIndep_iff_toSubmodule
+
 @[deprecated (since := "2024-11-24")]
 alias independent_iff_toSubmodule := iSupIndep_iff_toSubmodule
+
+@[deprecated (since := "2024-12-30")]
+alias independent_iff_coe_toSubmodule := independent_iff_toSubmodule
 
 theorem iSup_eq_top_iff_toSubmodule {ι : Sort*} {N : ι → LieSubmodule R L M} :
     ⨆ i, N i = ⊤ ↔ ⨆ i, (N i : Submodule R M) = ⊤ := by
   rw [← iSup_toSubmodule, ← top_toSubmodule (L := L), toSubmodule_inj]
+
+@[deprecated (since := "2024-12-30")]
+alias iSup_eq_top_iff_coe_toSubmodule := iSup_eq_top_iff_toSubmodule
 
 instance : Add (LieSubmodule R L M) where add := max
 
@@ -775,6 +832,8 @@ def map : LieSubmodule R L M' :=
 theorem toSubmodule_map : (N.map f : Submodule R M') = (N : Submodule R M).map (f : M →ₗ[R] M') :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias coeSubmodule_map := toSubmodule_map
+
 /-- A morphism of Lie modules `f : M → M'` pulls back Lie submodules of `M'` to Lie submodules of
 `M`. -/
 def comap : LieSubmodule R L M :=
@@ -787,6 +846,8 @@ def comap : LieSubmodule R L M :=
 theorem toSubmodule_comap :
     (N'.comap f : Submodule R M) = (N' : Submodule R M').comap (f : M →ₗ[R] M') :=
   rfl
+
+@[deprecated (since := "2024-12-30")] alias coeSubmodule_comap := toSubmodule_comap
 
 variable {f N N₂ N'}
 
@@ -903,6 +964,8 @@ variable (f : L →ₗ⁅R⁆ L') (I I₂ : LieIdeal R L) (J : LieIdeal R L')
 theorem top_toLieSubalgebra : ((⊤ : LieIdeal R L) : LieSubalgebra R L) = ⊤ :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias top_coe_lieSubalgebra := top_toLieSubalgebra
+
 /-- A morphism of Lie algebras `f : L → L'` pushes forward Lie ideals of `L` to Lie ideals of `L'`.
 
 Note that unlike `LieSubmodule.map`, we must take the `lieSpan` of the image. Mathematically
@@ -930,10 +993,14 @@ theorem map_toSubmodule (h : ↑(map f I) = f '' I) :
     LieSubmodule.toSubmodule (map f I) = (LieSubmodule.toSubmodule I).map (f : L →ₗ[R] L') := by
   rw [SetLike.ext'_iff, LieSubmodule.coe_toSubmodule, h, Submodule.map_coe]; rfl
 
+@[deprecated (since := "2024-12-30")] alias map_coeSubmodule := map_toSubmodule
+
 @[simp]
 theorem comap_toSubmodule :
     (LieSubmodule.toSubmodule (comap f J)) = (LieSubmodule.toSubmodule J).comap (f : L →ₗ[R] L') :=
   rfl
+
+@[deprecated (since := "2024-12-30")] alias comap_coeSubmodule := comap_toSubmodule
 
 theorem map_le : map f I ≤ J ↔ f '' I ⊆ J :=
   LieSubmodule.lieSpan_le
@@ -1054,6 +1121,8 @@ theorem ker_le_comap : f.ker ≤ J.comap f :=
 theorem ker_toSubmodule : LieSubmodule.toSubmodule (ker f) = LinearMap.ker (f : L →ₗ[R] L') :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias ker_coeSubmodule := ker_toSubmodule
+
 variable {f} in
 @[simp]
 theorem mem_ker {x : L} : x ∈ ker f ↔ f x = 0 :=
@@ -1082,6 +1151,8 @@ theorem ker_eq_bot : f.ker = ⊥ ↔ Function.Injective f := by
 @[simp]
 theorem range_toSubmodule : (f.range : Submodule R L') = LinearMap.range (f : L →ₗ[R] L') :=
   rfl
+
+@[deprecated (since := "2024-12-30")] alias range_coeSubmodule := range_toSubmodule
 
 theorem range_eq_top : f.range = ⊤ ↔ Function.Surjective f := by
   rw [← LieSubalgebra.toSubmodule_inj, range_toSubmodule, LieSubalgebra.top_toSubmodule]
@@ -1246,6 +1317,8 @@ def ker : LieSubmodule R L M :=
 theorem ker_toSubmodule : (f.ker : Submodule R M) = LinearMap.ker (f : M →ₗ[R] N) :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias ker_coeSubmodule := ker_toSubmodule
+
 theorem ker_eq_bot : f.ker = ⊥ ↔ Function.Injective f := by
   rw [← LieSubmodule.toSubmodule_inj, ker_toSubmodule, LieSubmodule.bot_toSubmodule,
     LinearMap.ker_eq_bot, coe_toLinearMap]
@@ -1280,6 +1353,8 @@ theorem coe_range : f.range = Set.range f :=
 @[simp]
 theorem toSubmodule_range : f.range = LinearMap.range (f : M →ₗ[R] N) :=
   rfl
+
+@[deprecated (since := "2024-12-30")] alias coeSubmodule_range := toSubmodule_range
 
 @[simp]
 theorem mem_range (n : N) : n ∈ f.range ↔ ∃ m, f m = n :=

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -425,11 +425,11 @@ theorem sInf_toSubmodule (S : Set (LieSubmodule R L M)) :
 
 @[deprecated (since := "2024-12-30")] alias sInf_coe_toSubmodule := sInf_toSubmodule
 
-theorem sInf_toSubmodule' (S : Set (LieSubmodule R L M)) :
+theorem sInf_toSubmodule_eq_iInf (S : Set (LieSubmodule R L M)) :
     (↑(sInf S) : Submodule R M) = ⨅ N ∈ S, (N : Submodule R M) := by
   rw [sInf_toSubmodule, ← Set.image, sInf_image]
 
-@[deprecated (since := "2024-12-30")] alias sInf_coe_toSubmodule' := sInf_toSubmodule'
+@[deprecated (since := "2024-12-30")] alias sInf_coe_toSubmodule' := sInf_toSubmodule_eq_iInf
 
 @[simp]
 theorem iInf_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
@@ -500,11 +500,11 @@ theorem sSup_toSubmodule (S : Set (LieSubmodule R L M)) :
 
 @[deprecated (since := "2024-12-30")] alias sSup_coe_toSubmodule := sSup_toSubmodule
 
-theorem sSup_toSubmodule' (S : Set (LieSubmodule R L M)) :
+theorem sSup_toSubmodule_eq_iSup (S : Set (LieSubmodule R L M)) :
     (↑(sSup S) : Submodule R M) = ⨆ N ∈ S, (N : Submodule R M) := by
   rw [sSup_toSubmodule, ← Set.image, sSup_image]
 
-@[deprecated (since := "2024-12-30")] alias sSup_coe_toSubmodule' := sSup_toSubmodule'
+@[deprecated (since := "2024-12-30")] alias sSup_coe_toSubmodule' := sSup_toSubmodule_eq_iSup
 
 @[simp]
 theorem iSup_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
@@ -516,7 +516,7 @@ theorem iSup_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
 /-- The set of Lie submodules of a Lie module form a complete lattice. -/
 instance : CompleteLattice (LieSubmodule R L M) :=
   { toSubmodule_injective.completeLattice toSubmodule sup_toSubmodule inf_toSubmodule
-      sSup_toSubmodule' sInf_toSubmodule' rfl rfl with
+      sSup_toSubmodule_eq_iSup sInf_toSubmodule_eq_iInf rfl rfl with
     toPartialOrder := SetLike.instPartialOrder }
 
 theorem mem_iSup_of_mem {ι} {b : M} {N : ι → LieSubmodule R L M} (i : ι) (h : b ∈ N i) :

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -355,10 +355,10 @@ theorem bot_toSubmodule : ((⊥ : LieSubmodule R L M) : Submodule R M) = ⊥ :=
 @[deprecated (since := "2024-12-30")] alias bot_coeSubmodule := bot_toSubmodule
 
 @[simp]
-theorem toSubmodule_eq_bot_iff : (N : Submodule R M) = ⊥ ↔ N = ⊥ := by
+theorem toSubmodule_eq_bot : (N : Submodule R M) = ⊥ ↔ N = ⊥ := by
   rw [← toSubmodule_inj, bot_toSubmodule]
 
-@[deprecated (since := "2024-12-30")] alias coeSubmodule_eq_bot_iff := toSubmodule_eq_bot_iff
+@[deprecated (since := "2024-12-30")] alias coeSubmodule_eq_bot_iff := toSubmodule_eq_bot
 
 @[simp] theorem mk_eq_bot_iff {N : Submodule R M} {h} :
     (⟨N, h⟩ : LieSubmodule R L M) = ⊥ ↔ N = ⊥ := by
@@ -382,10 +382,10 @@ theorem top_toSubmodule : ((⊤ : LieSubmodule R L M) : Submodule R M) = ⊤ :=
 @[deprecated (since := "2024-12-30")] alias top_coeSubmodule := top_toSubmodule
 
 @[simp]
-theorem toSubmodule_eq_top_iff : (N : Submodule R M) = ⊤ ↔ N = ⊤ := by
+theorem toSubmodule_eq_top : (N : Submodule R M) = ⊤ ↔ N = ⊤ := by
   rw [← toSubmodule_inj, top_toSubmodule]
 
-@[deprecated (since := "2024-12-30")] alias coeSubmodule_eq_top_iff := toSubmodule_eq_top_iff
+@[deprecated (since := "2024-12-30")] alias coeSubmodule_eq_top_iff := toSubmodule_eq_top
 
 @[simp] theorem mk_eq_top_iff {N : Submodule R M} {h} :
     (⟨N, h⟩ : LieSubmodule R L M) = ⊤ ↔ N = ⊤ := by

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -1099,7 +1099,7 @@ theorem IsIdealMorphism.eq (hf : f.IsIdealMorphism) : f.idealRange = f.range := 
 
 theorem isIdealMorphism_iff : f.IsIdealMorphism ↔ ∀ (x : L') (y : L), ∃ z : L, ⁅x, f y⁆ = f z := by
   simp only [isIdealMorphism_def, idealRange_eq_lieSpan_range, ←
-    LieSubalgebra.toSubmodule_inj, ← f.range.toSubmodule,
+    LieSubalgebra.toSubmodule_inj, ← f.range.coe_toSubmodule,
     LieIdeal.coe_toLieSubalgebra_toSubmodule, LieSubmodule.coe_lieSpan_submodule_eq_iff,
     LieSubalgebra.mem_toSubmodule, mem_range, exists_imp,
     Submodule.exists_lieSubmodule_coe_eq_iff]
@@ -1161,7 +1161,7 @@ theorem range_eq_top : f.range = ⊤ ↔ Function.Surjective f := by
 @[simp]
 theorem idealRange_eq_top_of_surjective (h : Function.Surjective f) : f.idealRange = ⊤ := by
   rw [← f.range_eq_top] at h
-  rw [idealRange_eq_lieSpan_range, h, ← LieSubalgebra.toSubmodule, ←
+  rw [idealRange_eq_lieSpan_range, h, ← LieSubalgebra.coe_toSubmodule, ←
     LieSubmodule.toSubmodule_inj, LieSubmodule.top_toSubmodule,
     LieSubalgebra.top_toSubmodule, LieSubmodule.coe_lieSpan_submodule_eq_iff]
   use ⊤
@@ -1288,7 +1288,7 @@ theorem ker_incl : I.incl.ker = ⊥ := by ext; simp
 
 @[simp]
 theorem incl_idealRange : I.incl.idealRange = I := by
-  rw [LieHom.idealRange_eq_lieSpan_range, ← LieSubalgebra.toSubmodule, ←
+  rw [LieHom.idealRange_eq_lieSpan_range, ← LieSubalgebra.coe_toSubmodule, ←
     LieSubmodule.toSubmodule_inj, incl_range, coe_toLieSubalgebra_toSubmodule,
     LieSubmodule.coe_lieSpan_submodule_eq_iff]
   use I

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -75,7 +75,7 @@ instance : Inhabited (LieSubmodule R L M) :=
 instance (priority := high) coeSort : CoeSort (LieSubmodule R L M) (Type w) where
   coe N := { x : M // x ∈ N }
 
-instance (priority := mid) coeSubmodule : CoeOut (LieSubmodule R L M) (Submodule R M) :=
+instance (priority := mid) toSubmodule : CoeOut (LieSubmodule R L M) (Submodule R M) :=
   ⟨toSubmodule⟩
 
 
@@ -83,7 +83,7 @@ instance (priority := mid) coeSubmodule : CoeOut (LieSubmodule R L M) (Submodule
 theorem coe_toSubmodule : ((N : Submodule R M) : Set M) = N :=
   rfl
 
--- `simp` can prove this after `mem_coeSubmodule` is added to the simp set,
+-- `simp` can prove this after `mem_toSubmodule` is added to the simp set,
 -- but `dsimp` can't.
 @[simp, nolint simpNF]
 theorem mem_carrier {x : M} : x ∈ N.carrier ↔ x ∈ (N : Set M) :=
@@ -99,7 +99,7 @@ theorem mem_mk_iff' (p : Submodule R M) (h) {x : M} :
   Iff.rfl
 
 @[simp]
-theorem mem_coeSubmodule {x : M} : x ∈ (N : Submodule R M) ↔ x ∈ N :=
+theorem mem_toSubmodule {x : M} : x ∈ (N : Submodule R M) ↔ x ∈ N :=
   Iff.rfl
 
 theorem mem_coe {x : M} : x ∈ (N : Set M) ↔ x ∈ N :=
@@ -118,10 +118,10 @@ theorem coe_toSet_mk (S : Set M) (h₁ h₂ h₃ h₄) :
     ((⟨⟨⟨⟨S, h₁⟩, h₂⟩, h₃⟩, h₄⟩ : LieSubmodule R L M) : Set M) = S :=
   rfl
 
-theorem coe_toSubmodule_mk (p : Submodule R M) (h) :
+theorem toSubmodule_mk (p : Submodule R M) (h) :
     (({ p with lie_mem := h } : LieSubmodule R L M) : Submodule R M) = p := by cases p; rfl
 
-theorem coeSubmodule_injective :
+theorem toSubmodule_injective :
     Function.Injective (toSubmodule : LieSubmodule R L M → Submodule R M) := fun x y h ↦ by
   cases x; cases y; congr
 
@@ -130,10 +130,10 @@ theorem ext (h : ∀ m, m ∈ N ↔ m ∈ N') : N = N' :=
   SetLike.ext h
 
 @[simp]
-theorem coe_toSubmodule_inj : (N : Submodule R M) = (N' : Submodule R M) ↔ N = N' :=
-  coeSubmodule_injective.eq_iff
+theorem toSubmodule_inj : (N : Submodule R M) = (N' : Submodule R M) ↔ N = N' :=
+  toSubmodule_injective.eq_iff
 
-@[deprecated (since := "2024-12-29")] alias coe_toSubmodule_eq_iff := coe_toSubmodule_inj
+@[deprecated (since := "2024-12-29")] alias toSubmodule_eq_iff := toSubmodule_inj
 
 /-- Copy of a `LieSubmodule` with a new `carrier` equal to the old one. Useful to fix definitional
 equalities. -/
@@ -200,7 +200,7 @@ instance instLieModule : LieModule R L N where
   smul_lie := by intro t x y; apply SetCoe.ext; apply smul_lie
 
 instance [Subsingleton M] : Unique (LieSubmodule R L M) :=
-  ⟨⟨0⟩, fun _ ↦ (coe_toSubmodule_inj _ _).mp (Subsingleton.elim _ _)⟩
+  ⟨⟨0⟩, fun _ ↦ (toSubmodule_inj _ _).mp (Subsingleton.elim _ _)⟩
 
 end LieSubmodule
 
@@ -225,11 +225,11 @@ instance : Coe (LieIdeal R L) (LieSubalgebra R L) :=
   ⟨lieIdealSubalgebra R L⟩
 
 @[simp]
-theorem LieIdeal.coe_toSubalgebra (I : LieIdeal R L) : ((I : LieSubalgebra R L) : Set L) = I :=
+theorem LieIdeal.coe_toLieSubalgebra (I : LieIdeal R L) : ((I : LieSubalgebra R L) : Set L) = I :=
   rfl
 
 @[simp]
-theorem LieIdeal.coe_to_lieSubalgebra_to_submodule (I : LieIdeal R L) :
+theorem LieIdeal.coe_toLieSubalgebra_toSubmodule (I : LieIdeal R L) :
     ((I : LieSubalgebra R L) : Submodule R L) = LieSubmodule.toSubmodule I :=
   rfl
 
@@ -288,7 +288,7 @@ theorem mem_toLieSubmodule (x : L) : x ∈ K.toLieSubmodule ↔ x ∈ K :=
 
 theorem exists_lieIdeal_coe_eq_iff :
     (∃ I : LieIdeal R L, ↑I = K) ↔ ∀ x y : L, y ∈ K → ⁅x, y⁆ ∈ K := by
-  simp only [← coe_to_submodule_inj, LieIdeal.coe_to_lieSubalgebra_to_submodule,
+  simp only [← toSubmodule_inj, LieIdeal.coe_toLieSubalgebra_toSubmodule,
     Submodule.exists_lieSubmodule_coe_eq_iff L]
   exact Iff.rfl
 
@@ -318,7 +318,7 @@ theorem coe_injective : Function.Injective ((↑) : LieSubmodule R L M → Set M
   SetLike.coe_injective
 
 @[simp, norm_cast]
-theorem coeSubmodule_le_coeSubmodule : (N : Submodule R M) ≤ N' ↔ N ≤ N' :=
+theorem toSubmodule_le_toSubmodule : (N : Submodule R M) ≤ N' ↔ N ≤ N' :=
   Iff.rfl
 
 instance : Bot (LieSubmodule R L M) :=
@@ -332,16 +332,16 @@ theorem bot_coe : ((⊥ : LieSubmodule R L M) : Set M) = {0} :=
   rfl
 
 @[simp]
-theorem bot_coeSubmodule : ((⊥ : LieSubmodule R L M) : Submodule R M) = ⊥ :=
+theorem bot_toSubmodule : ((⊥ : LieSubmodule R L M) : Submodule R M) = ⊥ :=
   rfl
 
 @[simp]
-theorem coeSubmodule_eq_bot_iff : (N : Submodule R M) = ⊥ ↔ N = ⊥ := by
-  rw [← coe_toSubmodule_inj, bot_coeSubmodule]
+theorem toSubmodule_eq_bot_iff : (N : Submodule R M) = ⊥ ↔ N = ⊥ := by
+  rw [← toSubmodule_inj, bot_toSubmodule]
 
 @[simp] theorem mk_eq_bot_iff {N : Submodule R M} {h} :
     (⟨N, h⟩ : LieSubmodule R L M) = ⊥ ↔ N = ⊥ := by
-  rw [← coe_toSubmodule_inj, bot_coeSubmodule]
+  rw [← toSubmodule_inj, bot_toSubmodule]
 
 @[simp]
 theorem mem_bot (x : M) : x ∈ (⊥ : LieSubmodule R L M) ↔ x = 0 :=
@@ -355,16 +355,16 @@ theorem top_coe : ((⊤ : LieSubmodule R L M) : Set M) = univ :=
   rfl
 
 @[simp]
-theorem top_coeSubmodule : ((⊤ : LieSubmodule R L M) : Submodule R M) = ⊤ :=
+theorem top_toSubmodule : ((⊤ : LieSubmodule R L M) : Submodule R M) = ⊤ :=
   rfl
 
 @[simp]
-theorem coeSubmodule_eq_top_iff : (N : Submodule R M) = ⊤ ↔ N = ⊤ := by
-  rw [← coe_toSubmodule_inj, top_coeSubmodule]
+theorem toSubmodule_eq_top_iff : (N : Submodule R M) = ⊤ ↔ N = ⊤ := by
+  rw [← toSubmodule_inj, top_toSubmodule]
 
 @[simp] theorem mk_eq_top_iff {N : Submodule R M} {h} :
     (⟨N, h⟩ : LieSubmodule R L M) = ⊤ ↔ N = ⊤ := by
-  rw [← coe_toSubmodule_inj, top_coeSubmodule]
+  rw [← toSubmodule_inj, top_toSubmodule]
 
 @[simp]
 theorem mem_top (x : M) : x ∈ (⊤ : LieSubmodule R L M) :=
@@ -388,30 +388,30 @@ theorem inf_coe : (↑(N ⊓ N') : Set M) = ↑N ∩ ↑N' :=
   rfl
 
 @[norm_cast, simp]
-theorem inf_coe_toSubmodule :
+theorem inf_toSubmodule :
     (↑(N ⊓ N') : Submodule R M) = (N : Submodule R M) ⊓ (N' : Submodule R M) :=
   rfl
 
 @[simp]
-theorem sInf_coe_toSubmodule (S : Set (LieSubmodule R L M)) :
+theorem sInf_toSubmodule (S : Set (LieSubmodule R L M)) :
     (↑(sInf S) : Submodule R M) = sInf {(s : Submodule R M) | s ∈ S} :=
   rfl
 
-theorem sInf_coe_toSubmodule' (S : Set (LieSubmodule R L M)) :
+theorem sInf_toSubmodule' (S : Set (LieSubmodule R L M)) :
     (↑(sInf S) : Submodule R M) = ⨅ N ∈ S, (N : Submodule R M) := by
-  rw [sInf_coe_toSubmodule, ← Set.image, sInf_image]
+  rw [sInf_toSubmodule, ← Set.image, sInf_image]
 
 @[simp]
-theorem iInf_coe_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
+theorem iInf_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
     (↑(⨅ i, p i) : Submodule R M) = ⨅ i, (p i : Submodule R M) := by
-  rw [iInf, sInf_coe_toSubmodule]; ext; simp
+  rw [iInf, sInf_toSubmodule]; ext; simp
 
 @[simp]
 theorem sInf_coe (S : Set (LieSubmodule R L M)) : (↑(sInf S) : Set M) = ⋂ s ∈ S, (s : Set M) := by
-  rw [← LieSubmodule.coe_toSubmodule, sInf_coe_toSubmodule, Submodule.sInf_coe]
+  rw [← LieSubmodule.coe_toSubmodule, sInf_toSubmodule, Submodule.sInf_coe]
   ext m
   simp only [mem_iInter, mem_setOf_eq, forall_apply_eq_imp_iff₂, exists_imp,
-    and_imp, SetLike.mem_coe, mem_coeSubmodule]
+    and_imp, SetLike.mem_coe, mem_toSubmodule]
 
 @[simp]
 theorem iInf_coe {ι} (p : ι → LieSubmodule R L M) : (↑(⨅ i, p i) : Set M) = ⋂ i, ↑(p i) := by
@@ -455,28 +455,28 @@ instance : SupSet (LieSubmodule R L M) where
           exact le_sSup ⟨p, hp, rfl⟩ }
 
 @[norm_cast, simp]
-theorem sup_coe_toSubmodule :
+theorem sup_toSubmodule :
     (↑(N ⊔ N') : Submodule R M) = (N : Submodule R M) ⊔ (N' : Submodule R M) := by
   rfl
 
 @[simp]
-theorem sSup_coe_toSubmodule (S : Set (LieSubmodule R L M)) :
+theorem sSup_toSubmodule (S : Set (LieSubmodule R L M)) :
     (↑(sSup S) : Submodule R M) = sSup {(s : Submodule R M) | s ∈ S} :=
   rfl
 
-theorem sSup_coe_toSubmodule' (S : Set (LieSubmodule R L M)) :
+theorem sSup_toSubmodule' (S : Set (LieSubmodule R L M)) :
     (↑(sSup S) : Submodule R M) = ⨆ N ∈ S, (N : Submodule R M) := by
-  rw [sSup_coe_toSubmodule, ← Set.image, sSup_image]
+  rw [sSup_toSubmodule, ← Set.image, sSup_image]
 
 @[simp]
-theorem iSup_coe_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
+theorem iSup_toSubmodule {ι} (p : ι → LieSubmodule R L M) :
     (↑(⨆ i, p i) : Submodule R M) = ⨆ i, (p i : Submodule R M) := by
-  rw [iSup, sSup_coe_toSubmodule]; ext; simp [Submodule.mem_sSup, Submodule.mem_iSup]
+  rw [iSup, sSup_toSubmodule]; ext; simp [Submodule.mem_sSup, Submodule.mem_iSup]
 
 /-- The set of Lie submodules of a Lie module form a complete lattice. -/
 instance : CompleteLattice (LieSubmodule R L M) :=
-  { coeSubmodule_injective.completeLattice toSubmodule sup_coe_toSubmodule inf_coe_toSubmodule
-      sSup_coe_toSubmodule' sInf_coe_toSubmodule' rfl rfl with
+  { toSubmodule_injective.completeLattice toSubmodule sup_toSubmodule inf_toSubmodule
+      sSup_toSubmodule' sInf_toSubmodule' rfl rfl with
     toPartialOrder := SetLike.instPartialOrder }
 
 theorem mem_iSup_of_mem {ι} {b : M} {N : ι → LieSubmodule R L M} (i : ι) (h : b ∈ N i) :
@@ -486,7 +486,7 @@ theorem mem_iSup_of_mem {ι} {b : M} {N : ι → LieSubmodule R L M} (i : ι) (h
 lemma iSup_induction {ι} (N : ι → LieSubmodule R L M) {C : M → Prop} {x : M}
     (hx : x ∈ ⨆ i, N i) (hN : ∀ i, ∀ y ∈ N i, C y) (h0 : C 0)
     (hadd : ∀ y z, C y → C z → C (y + z)) : C x := by
-  rw [← LieSubmodule.mem_coeSubmodule, LieSubmodule.iSup_coe_toSubmodule] at hx
+  rw [← LieSubmodule.mem_toSubmodule, LieSubmodule.iSup_toSubmodule] at hx
   exact Submodule.iSup_induction (C := C) (fun i ↦ (N i : Submodule R M)) hx hN h0 hadd
 
 @[elab_as_elim]
@@ -502,30 +502,30 @@ theorem iSup_induction' {ι} (N : ι → LieSubmodule R L M) {C : (x : M) → (x
   · rintro ⟨_, Cx⟩ ⟨_, Cy⟩
     exact ⟨_, hadd _ _ _ _ Cx Cy⟩
 
-theorem disjoint_iff_coe_toSubmodule :
+theorem disjoint_iff_toSubmodule :
     Disjoint N N' ↔ Disjoint (N : Submodule R M) (N' : Submodule R M) := by
-  rw [disjoint_iff, disjoint_iff, ← coe_toSubmodule_inj, inf_coe_toSubmodule, bot_coeSubmodule,
+  rw [disjoint_iff, disjoint_iff, ← toSubmodule_inj, inf_toSubmodule, bot_toSubmodule,
     ← disjoint_iff]
 
-theorem codisjoint_iff_coe_toSubmodule :
+theorem codisjoint_iff_toSubmodule :
     Codisjoint N N' ↔ Codisjoint (N : Submodule R M) (N' : Submodule R M) := by
-  rw [codisjoint_iff, codisjoint_iff, ← coe_toSubmodule_inj, sup_coe_toSubmodule,
-    top_coeSubmodule, ← codisjoint_iff]
+  rw [codisjoint_iff, codisjoint_iff, ← toSubmodule_inj, sup_toSubmodule,
+    top_toSubmodule, ← codisjoint_iff]
 
-theorem isCompl_iff_coe_toSubmodule :
+theorem isCompl_iff_toSubmodule :
     IsCompl N N' ↔ IsCompl (N : Submodule R M) (N' : Submodule R M) := by
-  simp only [isCompl_iff, disjoint_iff_coe_toSubmodule, codisjoint_iff_coe_toSubmodule]
+  simp only [isCompl_iff, disjoint_iff_toSubmodule, codisjoint_iff_toSubmodule]
 
-theorem iSupIndep_iff_coe_toSubmodule {ι : Type*} {N : ι → LieSubmodule R L M} :
+theorem iSupIndep_iff_toSubmodule {ι : Type*} {N : ι → LieSubmodule R L M} :
     iSupIndep N ↔ iSupIndep fun i ↦ (N i : Submodule R M) := by
-  simp [iSupIndep_def, disjoint_iff_coe_toSubmodule]
+  simp [iSupIndep_def, disjoint_iff_toSubmodule]
 
 @[deprecated (since := "2024-11-24")]
-alias independent_iff_coe_toSubmodule := iSupIndep_iff_coe_toSubmodule
+alias independent_iff_toSubmodule := iSupIndep_iff_toSubmodule
 
-theorem iSup_eq_top_iff_coe_toSubmodule {ι : Sort*} {N : ι → LieSubmodule R L M} :
+theorem iSup_eq_top_iff_toSubmodule {ι : Sort*} {N : ι → LieSubmodule R L M} :
     ⨆ i, N i = ⊤ ↔ ⨆ i, (N i : Submodule R M) = ⊤ := by
-  rw [← iSup_coe_toSubmodule, ← top_coeSubmodule (L := L), coe_toSubmodule_inj]
+  rw [← iSup_toSubmodule, ← top_toSubmodule (L := L), toSubmodule_inj]
 
 instance : Add (LieSubmodule R L M) where add := max
 
@@ -544,11 +544,11 @@ theorem add_eq_sup : N + N' = N ⊔ N' :=
 
 @[simp]
 theorem mem_inf (x : M) : x ∈ N ⊓ N' ↔ x ∈ N ∧ x ∈ N' := by
-  rw [← mem_coeSubmodule, ← mem_coeSubmodule, ← mem_coeSubmodule, inf_coe_toSubmodule,
+  rw [← mem_toSubmodule, ← mem_toSubmodule, ← mem_toSubmodule, inf_toSubmodule,
     Submodule.mem_inf]
 
 theorem mem_sup (x : M) : x ∈ N ⊔ N' ↔ ∃ y ∈ N, ∃ z ∈ N', y + z = x := by
-  rw [← mem_coeSubmodule, sup_coe_toSubmodule, Submodule.mem_sup]; exact Iff.rfl
+  rw [← mem_toSubmodule, sup_toSubmodule, Submodule.mem_sup]; exact Iff.rfl
 
 nonrec theorem eq_bot_iff : N = ⊥ ↔ ∀ m : M, m ∈ N → m = 0 := by rw [eq_bot_iff]; exact Iff.rfl
 
@@ -560,7 +560,7 @@ instance subsingleton_of_bot : Subsingleton (LieSubmodule R L (⊥ : LieSubmodul
 
 instance : IsModularLattice (LieSubmodule R L M) where
   sup_inf_le_assoc_of_le _ _ := by
-    simp only [← coeSubmodule_le_coeSubmodule, sup_coe_toSubmodule, inf_coe_toSubmodule]
+    simp only [← toSubmodule_le_toSubmodule, sup_toSubmodule, inf_toSubmodule]
     exact IsModularLattice.sup_inf_le_assoc_of_le _
 
 variable (R L M)
@@ -568,7 +568,7 @@ variable (R L M)
 /-- The natural functor that forgets the action of `L` as an order embedding. -/
 @[simps] def toSubmodule_orderEmbedding : LieSubmodule R L M ↪o Submodule R M :=
   { toFun := (↑)
-    inj' := coeSubmodule_injective
+    inj' := toSubmodule_injective
     map_rel_iff' := Iff.rfl }
 
 instance wellFoundedGT_of_noetherian [IsNoetherian R M] : WellFoundedGT (LieSubmodule R L M) :=
@@ -583,8 +583,8 @@ instance [IsArtinian R M] : IsAtomic (LieSubmodule R L M) :=
 @[simp]
 theorem subsingleton_iff : Subsingleton (LieSubmodule R L M) ↔ Subsingleton M :=
   have h : Subsingleton (LieSubmodule R L M) ↔ Subsingleton (Submodule R M) := by
-    rw [← subsingleton_iff_bot_eq_top, ← subsingleton_iff_bot_eq_top, ← coe_toSubmodule_inj,
-      top_coeSubmodule, bot_coeSubmodule]
+    rw [← subsingleton_iff_bot_eq_top, ← subsingleton_iff_bot_eq_top, ← toSubmodule_inj,
+      top_toSubmodule, bot_toSubmodule]
   h.trans <| Submodule.subsingleton_iff R
 
 @[simp]
@@ -686,8 +686,8 @@ theorem lieSpan_eq : lieSpan R L (N : Set M) = N :=
 theorem coe_lieSpan_submodule_eq_iff {p : Submodule R M} :
     (lieSpan R L (p : Set M) : Submodule R M) = p ↔ ∃ N : LieSubmodule R L M, ↑N = p := by
   rw [p.exists_lieSubmodule_coe_eq_iff L]; constructor <;> intro h
-  · intro x m hm; rw [← h, mem_coeSubmodule]; exact lie_mem _ (subset_lieSpan hm)
-  · rw [← coe_toSubmodule_mk p @h, coe_toSubmodule, coe_toSubmodule_inj, lieSpan_eq]
+  · intro x m hm; rw [← h, mem_toSubmodule]; exact lie_mem _ (subset_lieSpan hm)
+  · rw [← toSubmodule_mk p @h, coe_toSubmodule, toSubmodule_inj, lieSpan_eq]
 
 variable (R L M)
 
@@ -728,13 +728,13 @@ lemma isCompactElement_lieSpan_singleton (m : M) :
     exact ⟨N, hN, by simpa⟩
   replace hne : Nonempty s := Set.nonempty_coe_sort.mpr hne
   have := Submodule.coe_iSup_of_directed _ hdir.directed_val
-  simp_rw [← iSup_coe_toSubmodule, Set.iUnion_coe_set, coe_toSubmodule] at this
+  simp_rw [← iSup_toSubmodule, Set.iUnion_coe_set, coe_toSubmodule] at this
   rw [← this, SetLike.coe_set_eq, sSup_eq_iSup, iSup_subtype]
 
 @[simp]
 lemma sSup_image_lieSpan_singleton : sSup ((fun x ↦ lieSpan R L {x}) '' N) = N := by
   refine le_antisymm (sSup_le <| by simp) ?_
-  simp_rw [← coeSubmodule_le_coeSubmodule, sSup_coe_toSubmodule, Set.mem_image, SetLike.mem_coe]
+  simp_rw [← toSubmodule_le_toSubmodule, sSup_toSubmodule, Set.mem_image, SetLike.mem_coe]
   refine fun m hm ↦ Submodule.mem_sSup.mpr fun N' hN' ↦ ?_
   replace hN' : ∀ m ∈ N, lieSpan R L {m} ≤ N' := by simpa using hN'
   exact hN' _ hm (subset_lieSpan rfl)
@@ -772,7 +772,7 @@ def map : LieSubmodule R L M' :=
 @[simp] theorem coe_map : (N.map f : Set M') = f '' N := rfl
 
 @[simp]
-theorem coeSubmodule_map : (N.map f : Submodule R M') = (N : Submodule R M).map (f : M →ₗ[R] M') :=
+theorem toSubmodule_map : (N.map f : Submodule R M') = (N : Submodule R M).map (f : M →ₗ[R] M') :=
   rfl
 
 /-- A morphism of Lie modules `f : M → M'` pulls back Lie submodules of `M'` to Lie submodules of
@@ -784,7 +784,7 @@ def comap : LieSubmodule R L M :=
       apply N'.lie_mem h }
 
 @[simp]
-theorem coeSubmodule_comap :
+theorem toSubmodule_comap :
     (N'.comap f : Submodule R M) = (N' : Submodule R M').comap (f : M →ₗ[R] M') :=
   rfl
 
@@ -832,12 +832,12 @@ theorem mem_comap {m : M} : m ∈ comap f N' ↔ f m ∈ N' :=
   Iff.rfl
 
 theorem comap_incl_eq_top : N₂.comap N.incl = ⊤ ↔ N ≤ N₂ := by
-  rw [← LieSubmodule.coe_toSubmodule_inj, LieSubmodule.coeSubmodule_comap, LieSubmodule.incl_coe,
-    LieSubmodule.top_coeSubmodule, Submodule.comap_subtype_eq_top, coeSubmodule_le_coeSubmodule]
+  rw [← LieSubmodule.toSubmodule_inj, LieSubmodule.toSubmodule_comap, LieSubmodule.incl_coe,
+    LieSubmodule.top_toSubmodule, Submodule.comap_subtype_eq_top, toSubmodule_le_toSubmodule]
 
 theorem comap_incl_eq_bot : N₂.comap N.incl = ⊥ ↔ N ⊓ N₂ = ⊥ := by
-  simp only [← coe_toSubmodule_inj, coeSubmodule_comap, incl_coe, bot_coeSubmodule,
-    inf_coe_toSubmodule]
+  simp only [← toSubmodule_inj, toSubmodule_comap, incl_coe, bot_toSubmodule,
+    inf_toSubmodule]
   rw [← Submodule.disjoint_iff_comap_eq_bot, disjoint_iff]
 
 @[gcongr, mono]
@@ -900,7 +900,7 @@ variable [LieAlgebra R L] [LieModule R L M] [LieModule R L M']
 variable (f : L →ₗ⁅R⁆ L') (I I₂ : LieIdeal R L) (J : LieIdeal R L')
 
 @[simp]
-theorem top_coe_lieSubalgebra : ((⊤ : LieIdeal R L) : LieSubalgebra R L) = ⊤ :=
+theorem top_toLieSubalgebra : ((⊤ : LieIdeal R L) : LieSubalgebra R L) = ⊤ :=
   rfl
 
 /-- A morphism of Lie algebras `f : L → L'` pushes forward Lie ideals of `L` to Lie ideals of `L'`.
@@ -921,17 +921,17 @@ def comap : LieIdeal R L :=
       suffices ⁅f x, f y⁆ ∈ J by
         simp only [AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup,
           Submodule.mem_toAddSubmonoid, Submodule.mem_comap, LieHom.coe_toLinearMap, LieHom.map_lie,
-          LieSubalgebra.mem_coe_submodule]
+          LieSubalgebra.mem_toSubmodule]
         exact this
       apply J.lie_mem h }
 
 @[simp]
-theorem map_coeSubmodule (h : ↑(map f I) = f '' I) :
+theorem map_toSubmodule (h : ↑(map f I) = f '' I) :
     LieSubmodule.toSubmodule (map f I) = (LieSubmodule.toSubmodule I).map (f : L →ₗ[R] L') := by
   rw [SetLike.ext'_iff, LieSubmodule.coe_toSubmodule, h, Submodule.map_coe]; rfl
 
 @[simp]
-theorem comap_coeSubmodule :
+theorem comap_toSubmodule :
     (LieSubmodule.toSubmodule (comap f J)) = (LieSubmodule.toSubmodule J).comap (f : L →ₗ[R] L') :=
   rfl
 
@@ -1032,9 +1032,9 @@ theorem IsIdealMorphism.eq (hf : f.IsIdealMorphism) : f.idealRange = f.range := 
 
 theorem isIdealMorphism_iff : f.IsIdealMorphism ↔ ∀ (x : L') (y : L), ∃ z : L, ⁅x, f y⁆ = f z := by
   simp only [isIdealMorphism_def, idealRange_eq_lieSpan_range, ←
-    LieSubalgebra.coe_to_submodule_inj, ← f.range.coe_to_submodule,
-    LieIdeal.coe_to_lieSubalgebra_to_submodule, LieSubmodule.coe_lieSpan_submodule_eq_iff,
-    LieSubalgebra.mem_coe_submodule, mem_range, exists_imp,
+    LieSubalgebra.toSubmodule_inj, ← f.range.toSubmodule,
+    LieIdeal.coe_toLieSubalgebra_toSubmodule, LieSubmodule.coe_lieSpan_submodule_eq_iff,
+    LieSubalgebra.mem_toSubmodule, mem_range, exists_imp,
     Submodule.exists_lieSubmodule_coe_eq_iff]
   constructor
   · intro h x y; obtain ⟨z, hz⟩ := h x (f y) y rfl; use z; exact hz.symm
@@ -1051,14 +1051,14 @@ theorem ker_le_comap : f.ker ≤ J.comap f :=
   LieIdeal.comap_mono bot_le
 
 @[simp]
-theorem ker_coeSubmodule : LieSubmodule.toSubmodule (ker f) = LinearMap.ker (f : L →ₗ[R] L') :=
+theorem ker_toSubmodule : LieSubmodule.toSubmodule (ker f) = LinearMap.ker (f : L →ₗ[R] L') :=
   rfl
 
 variable {f} in
 @[simp]
 theorem mem_ker {x : L} : x ∈ ker f ↔ f x = 0 :=
   show x ∈ LieSubmodule.toSubmodule (f.ker) ↔ _ by
-    simp only [ker_coeSubmodule, LinearMap.mem_ker, coe_toLinearMap]
+    simp only [ker_toSubmodule, LinearMap.mem_ker, coe_toLinearMap]
 
 theorem mem_idealRange (x : L) : f x ∈ idealRange f := by
   rw [idealRange_eq_map]
@@ -1068,7 +1068,7 @@ theorem mem_idealRange (x : L) : f x ∈ idealRange f := by
 theorem mem_idealRange_iff (h : IsIdealMorphism f) {y : L'} :
     y ∈ idealRange f ↔ ∃ x : L, f x = y := by
   rw [f.isIdealMorphism_def] at h
-  rw [← LieSubmodule.mem_coe, ← LieIdeal.coe_toSubalgebra, h, f.range_coe, Set.mem_range]
+  rw [← LieSubmodule.mem_coe, ← LieIdeal.coe_toLieSubalgebra, h, f.range_coe, Set.mem_range]
 
 theorem le_ker_iff : I ≤ f.ker ↔ ∀ x, x ∈ I → f x = 0 := by
   constructor <;> intro h x hx
@@ -1076,29 +1076,29 @@ theorem le_ker_iff : I ≤ f.ker ↔ ∀ x, x ∈ I → f x = 0 := by
   · rw [mem_ker]; apply h x hx
 
 theorem ker_eq_bot : f.ker = ⊥ ↔ Function.Injective f := by
-  rw [← LieSubmodule.coe_toSubmodule_inj, ker_coeSubmodule, LieSubmodule.bot_coeSubmodule,
+  rw [← LieSubmodule.toSubmodule_inj, ker_toSubmodule, LieSubmodule.bot_toSubmodule,
     LinearMap.ker_eq_bot, coe_toLinearMap]
 
 @[simp]
-theorem range_coeSubmodule : (f.range : Submodule R L') = LinearMap.range (f : L →ₗ[R] L') :=
+theorem range_toSubmodule : (f.range : Submodule R L') = LinearMap.range (f : L →ₗ[R] L') :=
   rfl
 
 theorem range_eq_top : f.range = ⊤ ↔ Function.Surjective f := by
-  rw [← LieSubalgebra.coe_to_submodule_inj, range_coeSubmodule, LieSubalgebra.top_coe_submodule]
+  rw [← LieSubalgebra.toSubmodule_inj, range_toSubmodule, LieSubalgebra.top_toSubmodule]
   exact LinearMap.range_eq_top
 
 @[simp]
 theorem idealRange_eq_top_of_surjective (h : Function.Surjective f) : f.idealRange = ⊤ := by
   rw [← f.range_eq_top] at h
-  rw [idealRange_eq_lieSpan_range, h, ← LieSubalgebra.coe_to_submodule, ←
-    LieSubmodule.coe_toSubmodule_inj, LieSubmodule.top_coeSubmodule,
-    LieSubalgebra.top_coe_submodule, LieSubmodule.coe_lieSpan_submodule_eq_iff]
+  rw [idealRange_eq_lieSpan_range, h, ← LieSubalgebra.toSubmodule, ←
+    LieSubmodule.toSubmodule_inj, LieSubmodule.top_toSubmodule,
+    LieSubalgebra.top_toSubmodule, LieSubmodule.coe_lieSpan_submodule_eq_iff]
   use ⊤
-  exact LieSubmodule.top_coeSubmodule
+  exact LieSubmodule.top_toSubmodule
 
 theorem isIdealMorphism_of_surjective (h : Function.Surjective f) : f.IsIdealMorphism := by
   rw [isIdealMorphism_def, f.idealRange_eq_top_of_surjective h, f.range_eq_top.mpr h,
-    LieIdeal.top_coe_lieSubalgebra]
+    LieIdeal.top_toLieSubalgebra]
 
 end LieHom
 
@@ -1120,7 +1120,7 @@ theorem coe_map_of_surjective (h : Function.Surjective f) :
         obtain ⟨z₂, hz₂, rfl⟩ := hy'
         obtain ⟨z₁, rfl⟩ := h x
         simp only [LieHom.coe_toLinearMap, SetLike.mem_coe, Set.mem_image,
-          LieSubmodule.mem_coeSubmodule, Submodule.mem_carrier, Submodule.map_coe]
+          LieSubmodule.mem_toSubmodule, Submodule.mem_carrier, Submodule.map_coe]
         use ⁅z₁, z₂⁆
         exact ⟨I.lie_mem hz₂, f.map_lie z₁ z₂⟩ }
   erw [LieSubmodule.coe_lieSpan_submodule_eq_iff]
@@ -1128,7 +1128,7 @@ theorem coe_map_of_surjective (h : Function.Surjective f) :
 
 theorem mem_map_of_surjective {y : L'} (h₁ : Function.Surjective f) (h₂ : y ∈ I.map f) :
     ∃ x : I, f x = y := by
-  rw [← LieSubmodule.mem_coeSubmodule, coe_map_of_surjective h₁, Submodule.mem_map] at h₂
+  rw [← LieSubmodule.mem_toSubmodule, coe_map_of_surjective h₁, Submodule.mem_map] at h₂
   obtain ⟨x, hx, rfl⟩ := h₂
   use ⟨x, hx⟩
   rw [LieHom.coe_toLinearMap]
@@ -1179,13 +1179,13 @@ theorem map_comap_eq (h : f.IsIdealMorphism) : map f (comap f J) = f.idealRange 
   apply le_antisymm
   · rw [le_inf_iff]; exact ⟨f.map_le_idealRange _, map_comap_le⟩
   · rw [f.isIdealMorphism_def] at h
-    rw [← SetLike.coe_subset_coe, LieSubmodule.inf_coe, ← coe_toSubalgebra, h]
+    rw [← SetLike.coe_subset_coe, LieSubmodule.inf_coe, ← coe_toLieSubalgebra, h]
     rintro y ⟨⟨x, h₁⟩, h₂⟩; rw [← h₁] at h₂ ⊢; exact mem_map h₂
 
 @[simp]
 theorem comap_map_eq (h : ↑(map f I) = f '' I) : comap f (map f I) = I ⊔ f.ker := by
-  rw [← LieSubmodule.coe_toSubmodule_inj, comap_coeSubmodule, I.map_coeSubmodule f h,
-    LieSubmodule.sup_coe_toSubmodule, f.ker_coeSubmodule, Submodule.comap_map_eq]
+  rw [← LieSubmodule.toSubmodule_inj, comap_toSubmodule, I.map_toSubmodule f h,
+    LieSubmodule.sup_toSubmodule, f.ker_toSubmodule, Submodule.comap_map_eq]
 
 variable (f I J)
 
@@ -1217,8 +1217,8 @@ theorem ker_incl : I.incl.ker = ⊥ := by ext; simp
 
 @[simp]
 theorem incl_idealRange : I.incl.idealRange = I := by
-  rw [LieHom.idealRange_eq_lieSpan_range, ← LieSubalgebra.coe_to_submodule, ←
-    LieSubmodule.coe_toSubmodule_inj, incl_range, coe_to_lieSubalgebra_to_submodule,
+  rw [LieHom.idealRange_eq_lieSpan_range, ← LieSubalgebra.toSubmodule, ←
+    LieSubmodule.toSubmodule_inj, incl_range, coe_toLieSubalgebra_toSubmodule,
     LieSubmodule.coe_lieSpan_submodule_eq_iff]
   use I
 
@@ -1243,11 +1243,11 @@ def ker : LieSubmodule R L M :=
   LieSubmodule.comap f ⊥
 
 @[simp]
-theorem ker_coeSubmodule : (f.ker : Submodule R M) = LinearMap.ker (f : M →ₗ[R] N) :=
+theorem ker_toSubmodule : (f.ker : Submodule R M) = LinearMap.ker (f : M →ₗ[R] N) :=
   rfl
 
 theorem ker_eq_bot : f.ker = ⊥ ↔ Function.Injective f := by
-  rw [← LieSubmodule.coe_toSubmodule_inj, ker_coeSubmodule, LieSubmodule.bot_coeSubmodule,
+  rw [← LieSubmodule.toSubmodule_inj, ker_toSubmodule, LieSubmodule.bot_toSubmodule,
     LinearMap.ker_eq_bot, coe_toLinearMap]
 
 variable {f}
@@ -1278,7 +1278,7 @@ theorem coe_range : f.range = Set.range f :=
   rfl
 
 @[simp]
-theorem coeSubmodule_range : f.range = LinearMap.range (f : M →ₗ[R] N) :=
+theorem toSubmodule_range : f.range = LinearMap.range (f : M →ₗ[R] N) :=
   rfl
 
 @[simp]
@@ -1318,12 +1318,12 @@ theorem ker_incl : N.incl.ker = ⊥ := (LieModuleHom.ker_eq_bot N.incl).mpr <| i
 
 @[simp]
 theorem range_incl : N.incl.range = N := by
-  simp only [← coe_toSubmodule_inj, LieModuleHom.coeSubmodule_range, incl_coe]
+  simp only [← toSubmodule_inj, LieModuleHom.toSubmodule_range, incl_coe]
   rw [Submodule.range_subtype]
 
 @[simp]
 theorem comap_incl_self : comap N.incl N = ⊤ := by
-  simp only [← coe_toSubmodule_inj, coeSubmodule_comap, incl_coe, top_coeSubmodule]
+  simp only [← toSubmodule_inj, toSubmodule_comap, incl_coe, top_toSubmodule]
   rw [Submodule.comap_subtype_self]
 
 theorem map_incl_top : (⊤ : LieSubmodule R L N).map N.incl = N := by simp

--- a/Mathlib/Algebra/Lie/TensorProduct.lean
+++ b/Mathlib/Algebra/Lie/TensorProduct.lean
@@ -136,6 +136,8 @@ theorem toLinearMap_map (f : M →ₗ⁅R,L⁆ P) (g : N →ₗ⁅R,L⁆ Q) :
     (map f g : M ⊗[R] N →ₗ[R] P ⊗[R] Q) = TensorProduct.map (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :=
   rfl
 
+@[deprecated (since := "2024-12-30")] alias coe_linearMap_map := toLinearMap_map
+
 @[simp]
 nonrec theorem map_tmul (f : M →ₗ⁅R,L⁆ P) (g : N →ₗ⁅R,L⁆ Q) (m : M) (n : N) :
     map f g (m ⊗ₜ n) = f m ⊗ₜ g n :=

--- a/Mathlib/Algebra/Lie/TensorProduct.lean
+++ b/Mathlib/Algebra/Lie/TensorProduct.lean
@@ -108,9 +108,9 @@ theorem coe_liftLie_eq_lift_coe (f : M →ₗ⁅R,L⁆ N →ₗ[R] P) :
   suffices (liftLie R L M N P f : M ⊗[R] N →ₗ[R] P) = lift R L M N P f by
     rw [← this, LieModuleHom.coe_toLinearMap]
   ext m n
-  simp only [liftLie, LinearEquiv.trans_apply, LieModuleEquiv.coe_to_linearEquiv,
-    coe_linearMap_maxTrivLinearMapEquivLieModuleHom, coe_maxTrivEquiv_apply,
-    coe_linearMap_maxTrivLinearMapEquivLieModuleHom_symm]
+  simp only [liftLie, LinearEquiv.trans_apply, LieModuleEquiv.coe_toLinearEquiv,
+    toLinearMap_maxTrivLinearMapEquivLieModuleHom, coe_maxTrivEquiv_apply,
+    toLinearMap_maxTrivLinearMapEquivLieModuleHom_symm]
 
 theorem liftLie_apply (f : M →ₗ⁅R,L⁆ N →ₗ[R] P) (m : M) (n : N) :
     liftLie R L M N P f (m ⊗ₜ n) = f m n := by
@@ -132,7 +132,7 @@ nonrec def map (f : M →ₗ⁅R,L⁆ P) (g : N →ₗ⁅R,L⁆ Q) : M ⊗[R] N 
       · intro t₁ t₂ ht₁ ht₂; simp only [ht₁, ht₂, lie_add, LinearMap.map_add] }
 
 @[simp]
-theorem coe_linearMap_map (f : M →ₗ⁅R,L⁆ P) (g : N →ₗ⁅R,L⁆ Q) :
+theorem toLinearMap_map (f : M →ₗ⁅R,L⁆ P) (g : N →ₗ⁅R,L⁆ Q) :
     (map f g : M ⊗[R] N →ₗ[R] P ⊗[R] Q) = TensorProduct.map (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :=
   rfl
 
@@ -196,8 +196,8 @@ applying the action of `L` on `M`, we obtain morphism of Lie modules `f : I ⊗ 
 This lemma states that `⁅I, N⁆ = range f`. -/
 theorem lieIdeal_oper_eq_tensor_map_range :
     ⁅I, N⁆ = ((toModuleHom R L M).comp (mapIncl I N : I ⊗[R] N →ₗ⁅R,L⁆ L ⊗[R] M)).range := by
-  rw [← coe_toSubmodule_inj, lieIdeal_oper_eq_linear_span, LieModuleHom.coeSubmodule_range,
-    LieModuleHom.coe_linearMap_comp, LinearMap.range_comp, mapIncl_def, coe_linearMap_map,
+  rw [← toSubmodule_inj, lieIdeal_oper_eq_linear_span, LieModuleHom.toSubmodule_range,
+    LieModuleHom.toLinearMap_comp, LinearMap.range_comp, mapIncl_def, toLinearMap_map,
     TensorProduct.map_range_eq_span_tmul, Submodule.map_span]
   congr; ext m; constructor
   · rintro ⟨⟨x, hx⟩, ⟨n, hn⟩, rfl⟩; use x ⊗ₜ n; constructor

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -133,7 +133,7 @@ lemma traceForm_eq_zero_if_mem_lcs_of_mem_ucs {x y : L} (k : ℕ)
     simp [hy]
   | succ k ih =>
     rw [LieSubmodule.ucs_succ, LieSubmodule.mem_normalizer] at hy
-    simp_rw [LieIdeal.lcs_succ, ← LieSubmodule.mem_coeSubmodule,
+    simp_rw [LieIdeal.lcs_succ, ← LieSubmodule.mem_toSubmodule,
       LieSubmodule.lieIdeal_oper_eq_linear_span', LieSubmodule.mem_top, true_and] at hx
     refine Submodule.span_induction ?_ ?_ (fun z w _ _ hz hw ↦ ?_) (fun t z _ hz ↦ ?_) hx
     · rintro - ⟨z, w, hw, rfl⟩
@@ -189,7 +189,7 @@ lemma trace_toEnd_eq_zero_of_mem_lcs
     trace R _ (toEnd R L M x) = 0 := by
   replace hx : x ∈ lowerCentralSeries R L L 1 := antitone_lowerCentralSeries _ _ _ hk hx
   replace hx : x ∈ Submodule.span R {m | ∃ u v : L, ⁅u, v⁆ = m} := by
-    rw [lowerCentralSeries_succ, ← LieSubmodule.mem_coeSubmodule,
+    rw [lowerCentralSeries_succ, ← LieSubmodule.mem_toSubmodule,
       LieSubmodule.lieIdeal_oper_eq_linear_span'] at hx
     simpa using hx
   refine Submodule.span_induction (p := fun x _ ↦ trace R _ (toEnd R L M x) = 0)
@@ -225,11 +225,11 @@ lemma traceForm_eq_sum_genWeightSpaceOf
     fun χ m hm ↦ LieSubmodule.lie_mem _ <| LieSubmodule.lie_mem _ hm
   have hfin : {χ : R | (genWeightSpaceOf M χ z : Submodule R M) ≠ ⊥}.Finite := by
     convert finite_genWeightSpaceOf_ne_bot R L M z
-    exact LieSubmodule.coeSubmodule_eq_bot_iff (genWeightSpaceOf M _ _)
+    exact LieSubmodule.toSubmodule_eq_bot_iff (genWeightSpaceOf M _ _)
   classical
-  have h := LieSubmodule.iSupIndep_iff_coe_toSubmodule.mp <| iSupIndep_genWeightSpaceOf R L M z
+  have h := LieSubmodule.iSupIndep_iff_toSubmodule.mp <| iSupIndep_genWeightSpaceOf R L M z
   have hds := DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top h <| by
-    simp [← LieSubmodule.iSup_coe_toSubmodule]
+    simp [← LieSubmodule.iSup_toSubmodule]
   simp only [LinearMap.coeFn_sum, Finset.sum_apply, traceForm_apply_apply,
     LinearMap.trace_eq_sum_trace_restrict' hds hfin hxy]
   exact Finset.sum_congr (by simp) (fun χ _ ↦ rfl)
@@ -287,7 +287,7 @@ lemma lowerCentralSeries_one_inf_center_le_ker_traceForm [Module.Free R M] [Modu
 lemma isLieAbelian_of_ker_traceForm_eq_bot [Module.Free R M] [Module.Finite R M]
     (h : LinearMap.ker (traceForm R L M) = ⊥) : IsLieAbelian L := by
   simpa only [← disjoint_lowerCentralSeries_maxTrivSubmodule_iff R L L, disjoint_iff_inf_le,
-    LieIdeal.coe_to_lieSubalgebra_to_submodule, LieSubmodule.coeSubmodule_eq_bot_iff, h]
+    LieIdeal.coe_toLieSubalgebra_toSubmodule, LieSubmodule.toSubmodule_eq_bot_iff, h]
     using lowerCentralSeries_one_inf_center_le_ker_traceForm R L M
 
 end LieModule
@@ -409,8 +409,8 @@ lemma traceForm_eq_sum_finrank_nsmul_mul (x y : L) :
     fun χ m hm ↦ LieSubmodule.lie_mem _ <| LieSubmodule.lie_mem _ hm
   classical
   have hds := DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top
-    (LieSubmodule.iSupIndep_iff_coe_toSubmodule.mp <| iSupIndep_genWeightSpace' K L M)
-    (LieSubmodule.iSup_eq_top_iff_coe_toSubmodule.mp <| iSup_genWeightSpace_eq_top' K L M)
+    (LieSubmodule.iSupIndep_iff_toSubmodule.mp <| iSupIndep_genWeightSpace' K L M)
+    (LieSubmodule.iSup_eq_top_iff_toSubmodule.mp <| iSup_genWeightSpace_eq_top' K L M)
   simp_rw [traceForm_apply_apply, LinearMap.trace_eq_sum_trace_restrict hds hxy,
     ← traceForm_genWeightSpace_eq K L M _ x y]
   rfl

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -225,7 +225,7 @@ lemma traceForm_eq_sum_genWeightSpaceOf
     fun χ m hm ↦ LieSubmodule.lie_mem _ <| LieSubmodule.lie_mem _ hm
   have hfin : {χ : R | (genWeightSpaceOf M χ z : Submodule R M) ≠ ⊥}.Finite := by
     convert finite_genWeightSpaceOf_ne_bot R L M z
-    exact LieSubmodule.toSubmodule_eq_bot_iff (genWeightSpaceOf M _ _)
+    exact LieSubmodule.toSubmodule_eq_bot (genWeightSpaceOf M _ _)
   classical
   have h := LieSubmodule.iSupIndep_iff_toSubmodule.mp <| iSupIndep_genWeightSpaceOf R L M z
   have hds := DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top h <| by
@@ -287,7 +287,7 @@ lemma lowerCentralSeries_one_inf_center_le_ker_traceForm [Module.Free R M] [Modu
 lemma isLieAbelian_of_ker_traceForm_eq_bot [Module.Free R M] [Module.Finite R M]
     (h : LinearMap.ker (traceForm R L M) = ⊥) : IsLieAbelian L := by
   simpa only [← disjoint_lowerCentralSeries_maxTrivSubmodule_iff R L L, disjoint_iff_inf_le,
-    LieIdeal.coe_toLieSubalgebra_toSubmodule, LieSubmodule.toSubmodule_eq_bot_iff, h]
+    LieIdeal.coe_toLieSubalgebra_toSubmodule, LieSubmodule.toSubmodule_eq_bot, h]
     using lowerCentralSeries_one_inf_center_le_ker_traceForm R L M
 
 end LieModule

--- a/Mathlib/Algebra/Lie/UniversalEnveloping.lean
+++ b/Mathlib/Algebra/Lie/UniversalEnveloping.lean
@@ -117,7 +117,7 @@ def lift : (L →ₗ⁅R⁆ A) ≃ (UniversalEnvelopingAlgebra R L →ₐ[R] A) 
     ext
     -- Porting note: was
     -- simp only [ι, mkAlgHom, TensorAlgebra.lift_ι_apply, LieHom.coe_toLinearMap,
-    --   LinearMap.toFun_eq_coe, LinearMap.coe_comp, LieHom.coe_linearMap_comp,
+    --   LinearMap.toFun_eq_coe, LinearMap.coe_comp, LieHom.toLinearMap_comp,
     --   AlgHom.comp_toLinearMap, Function.comp_apply, AlgHom.toLinearMap_apply,
     --   RingQuot.liftAlgHom_mkAlgHom_apply, AlgHom.coe_toLieHom, LieHom.coe_mk]
     -- extra `rfl` after https://github.com/leanprover/lean4/pull/2644

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -306,7 +306,7 @@ theorem zero_genWeightSpace_eq_top_of_nilpotent' [IsNilpotent R L M] :
 theorem coe_genWeightSpace_of_top (χ : L → R) :
     (genWeightSpace M (χ ∘ (⊤ : LieSubalgebra R L).incl) : Submodule R M) = genWeightSpace M χ := by
   ext m
-  simp only [mem_genWeightSpace, LieSubmodule.mem_coeSubmodule, Subtype.forall]
+  simp only [mem_genWeightSpace, LieSubmodule.mem_toSubmodule, Subtype.forall]
   apply forall_congr'
   simp
 
@@ -478,7 +478,7 @@ lemma posFittingComp_le_iInf_lowerCentralSeries :
   set F := posFittingComp R L M
   replace hk : (toEnd R L M x ^ k) m ∈ F := by
     apply posFittingCompOf_le_posFittingComp R L M x
-    simp_rw [← LieSubmodule.mem_coeSubmodule, posFittingCompOf, hk k (le_refl k)]
+    simp_rw [← LieSubmodule.mem_toSubmodule, posFittingCompOf, hk k (le_refl k)]
     apply LinearMap.mem_range_self
   suffices (toEnd R L (M ⧸ F) x ^ k) (LieSubmodule.Quotient.mk (N := F) m) =
     LieSubmodule.Quotient.mk (N := F) ((toEnd R L M x ^ k) m)
@@ -589,9 +589,9 @@ variable [IsNoetherian R M] [IsArtinian R M]
 
 lemma isCompl_genWeightSpaceOf_zero_posFittingCompOf (x : L) :
     IsCompl (genWeightSpaceOf M 0 x) (posFittingCompOf R M x) := by
-  simpa only [isCompl_iff, codisjoint_iff, disjoint_iff, ← LieSubmodule.coe_toSubmodule_inj,
-    LieSubmodule.sup_coe_toSubmodule, LieSubmodule.inf_coe_toSubmodule,
-    LieSubmodule.top_coeSubmodule, LieSubmodule.bot_coeSubmodule, coe_genWeightSpaceOf_zero] using
+  simpa only [isCompl_iff, codisjoint_iff, disjoint_iff, ← LieSubmodule.toSubmodule_inj,
+    LieSubmodule.sup_toSubmodule, LieSubmodule.inf_toSubmodule,
+    LieSubmodule.top_toSubmodule, LieSubmodule.bot_toSubmodule, coe_genWeightSpaceOf_zero] using
     (toEnd R L M x).isCompl_iSup_ker_pow_iInf_range_pow
 
 /-- This lemma exists only to simplify the proof of
@@ -648,7 +648,7 @@ end fitting_decomposition
 
 lemma disjoint_genWeightSpaceOf [NoZeroSMulDivisors R M] {x : L} {φ₁ φ₂ : R} (h : φ₁ ≠ φ₂) :
     Disjoint (genWeightSpaceOf M φ₁ x) (genWeightSpaceOf M φ₂ x) := by
-  rw [LieSubmodule.disjoint_iff_coe_toSubmodule]
+  rw [LieSubmodule.disjoint_iff_toSubmodule]
   dsimp [genWeightSpaceOf]
   exact Module.End.disjoint_genEigenspace _ h _ _
 
@@ -669,8 +669,8 @@ lemma injOn_genWeightSpace [NoZeroSMulDivisors R M] :
 See also `LieModule.iSupIndep_genWeightSpace'`. -/
 lemma iSupIndep_genWeightSpace [NoZeroSMulDivisors R M] :
     iSupIndep fun χ : L → R ↦ genWeightSpace M χ := by
-  simp only [LieSubmodule.iSupIndep_iff_coe_toSubmodule, genWeightSpace,
-    LieSubmodule.iInf_coe_toSubmodule]
+  simp only [LieSubmodule.iSupIndep_iff_toSubmodule, genWeightSpace,
+    LieSubmodule.iInf_toSubmodule]
   exact Module.End.independent_iInf_maxGenEigenspace_of_forall_mapsTo (toEnd R L M)
     (fun x y φ z ↦ (genWeightSpaceOf M φ y).lie_mem)
 
@@ -685,7 +685,7 @@ lemma iSupIndep_genWeightSpace' [NoZeroSMulDivisors R M] :
 
 lemma iSupIndep_genWeightSpaceOf [NoZeroSMulDivisors R M] (x : L) :
     iSupIndep fun (χ : R) ↦ genWeightSpaceOf M χ x := by
-  rw [LieSubmodule.iSupIndep_iff_coe_toSubmodule]
+  rw [LieSubmodule.iSupIndep_iff_toSubmodule]
   dsimp [genWeightSpaceOf]
   exact (toEnd R L M x).independent_genEigenspace _
 
@@ -728,8 +728,8 @@ instance [IsTriangularizable R L M] : IsTriangularizable R (LieModule.toEnd R L 
 @[simp]
 lemma iSup_genWeightSpaceOf_eq_top [IsTriangularizable R L M] (x : L) :
     ⨆ (φ : R), genWeightSpaceOf M φ x = ⊤ := by
-  rw [← LieSubmodule.coe_toSubmodule_inj, LieSubmodule.iSup_coe_toSubmodule,
-    LieSubmodule.top_coeSubmodule]
+  rw [← LieSubmodule.toSubmodule_inj, LieSubmodule.iSup_toSubmodule,
+    LieSubmodule.top_toSubmodule]
   dsimp [genWeightSpaceOf]
   exact IsTriangularizable.maxGenEigenspace_eq_top x
 
@@ -766,8 +766,8 @@ instance (N : LieSubmodule K L M) [IsTriangularizable K L M] : IsTriangularizabl
 See also `LieModule.iSup_genWeightSpace_eq_top'`. -/
 lemma iSup_genWeightSpace_eq_top [IsTriangularizable K L M] :
     ⨆ χ : L → K, genWeightSpace M χ = ⊤ := by
-  simp only [← LieSubmodule.coe_toSubmodule_inj, LieSubmodule.iSup_coe_toSubmodule,
-    LieSubmodule.iInf_coe_toSubmodule, LieSubmodule.top_coeSubmodule, genWeightSpace]
+  simp only [← LieSubmodule.toSubmodule_inj, LieSubmodule.iSup_toSubmodule,
+    LieSubmodule.iInf_toSubmodule, LieSubmodule.top_toSubmodule, genWeightSpace]
   refine Module.End.iSup_iInf_maxGenEigenspace_eq_top_of_forall_mapsTo (toEnd K L M)
     (fun x y φ z ↦ (genWeightSpaceOf M φ y).lie_mem) ?_
   apply IsTriangularizable.maxGenEigenspace_eq_top

--- a/Mathlib/Algebra/Lie/Weights/Cartan.lean
+++ b/Mathlib/Algebra/Lie/Weights/Cartan.lean
@@ -195,8 +195,8 @@ instance [Nontrivial H] : Nontrivial (genWeightSpace L (0 : H → R)) := by
     ⟨y, toLieSubmodule_le_rootSpace_zero R L H hy⟩, by simpa using e⟩
 
 theorem le_zeroRootSubalgebra : H ≤ zeroRootSubalgebra R L H := by
-  rw [← LieSubalgebra.coe_submodule_le_coe_submodule, ← H.coe_toLieSubmodule,
-    coe_zeroRootSubalgebra, LieSubmodule.coeSubmodule_le_coeSubmodule]
+  rw [← LieSubalgebra.toSubmodule_le_toSubmodule, ← H.coe_toLieSubmodule,
+    coe_zeroRootSubalgebra, LieSubmodule.toSubmodule_le_toSubmodule]
   exact toLieSubmodule_le_rootSpace_zero R L H
 
 @[simp]
@@ -240,7 +240,7 @@ theorem zeroRootSubalgebra_eq_iff_is_cartan [IsNoetherian R L] :
 @[simp]
 theorem rootSpace_zero_eq (H : LieSubalgebra R L) [H.IsCartanSubalgebra] [IsNoetherian R L] :
     rootSpace H 0 = H.toLieSubmodule := by
-  rw [← LieSubmodule.coe_toSubmodule_inj, ← coe_zeroRootSubalgebra,
+  rw [← LieSubmodule.toSubmodule_inj, ← coe_zeroRootSubalgebra,
     zeroRootSubalgebra_eq_of_is_cartan R L H, LieSubalgebra.coe_toLieSubmodule]
 
 variable {R L H}
@@ -271,8 +271,8 @@ lemma mem_corootSpace {x : H} :
     simp only [rootSpaceProduct_def, LieModuleHom.mem_range, LieSubmodule.mem_map,
       LieSubmodule.incl_apply, SetLike.coe_eq_coe, exists_eq_right]
     rfl
-  simp_rw [this, corootSpace, ← LieModuleHom.map_top, ← LieSubmodule.mem_coeSubmodule,
-    LieSubmodule.coeSubmodule_map, LieSubmodule.top_coeSubmodule, ← TensorProduct.span_tmul_eq_top,
+  simp_rw [this, corootSpace, ← LieModuleHom.map_top, ← LieSubmodule.mem_toSubmodule,
+    LieSubmodule.toSubmodule_map, LieSubmodule.top_toSubmodule, ← TensorProduct.span_tmul_eq_top,
     LinearMap.map_span, Set.image, Set.mem_setOf_eq, exists_exists_exists_and_eq]
   change (x : L) ∈ Submodule.span R
     {x | ∃ (a : rootSpace H α) (b : rootSpace H (-α)), ⁅(a : L), (b : L)⁆ = x} ↔ _
@@ -289,7 +289,7 @@ lemma mem_corootSpace' {x : H} :
     simp_rw [SetLike.mem_coe]
     rw [← Submodule.mem_map, Submodule.coe_subtype, Submodule.map_span, mem_corootSpace, ← this]
   ext u
-  simp only [Submodule.coe_subtype, mem_image, Subtype.exists, LieSubalgebra.mem_coe_submodule,
+  simp only [Submodule.coe_subtype, mem_image, Subtype.exists, LieSubalgebra.mem_toSubmodule,
     exists_and_right, exists_eq_right, mem_setOf_eq, s]
   refine ⟨fun ⟨_, y, hy, z, hz, hyz⟩ ↦ ⟨y, hy, z, hz, hyz⟩,
     fun ⟨y, hy, z, hz, hyz⟩ ↦ ⟨?_, y, hy, z, hz, hyz⟩⟩

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -208,12 +208,12 @@ lemma exists_forall_mem_corootSpace_smul_add_eq_zero
   refine ⟨a, b, Int.ofNat_pos.mpr hb, fun x hx ↦ ?_⟩
   let N : ℤ → Submodule R M := fun k ↦ genWeightSpace M (k • α + χ)
   have h₁ : iSupIndep fun (i : Finset.Ioo p q) ↦ N i := by
-    rw [← LieSubmodule.iSupIndep_iff_coe_toSubmodule]
+    rw [← LieSubmodule.iSupIndep_iff_toSubmodule]
     refine (iSupIndep_genWeightSpace R H M).comp fun i j hij ↦ ?_
     exact SetCoe.ext <| smul_left_injective ℤ hα <| by rwa [add_left_inj] at hij
   have h₂ : ∀ i, MapsTo (toEnd R H M x) ↑(N i) ↑(N i) := fun _ _ ↦ LieSubmodule.lie_mem _
   have h₃ : genWeightSpaceChain M α χ p q = ⨆ i ∈ Finset.Ioo p q, N i := by
-    simp_rw [N, genWeightSpaceChain_def', LieSubmodule.iSup_coe_toSubmodule]
+    simp_rw [N, genWeightSpaceChain_def', LieSubmodule.iSup_toSubmodule]
   rw [← trace_toEnd_genWeightSpaceChain_eq_zero M α χ p q hp hq hx,
     ← LieSubmodule.toEnd_restrict_eq_toEnd]
   -- The lines below illustrate the cost of treating `LieSubmodule` as both a

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -412,7 +412,7 @@ lemma coe_corootSpace_eq_span_singleton (α : Weight K H L) :
 @[simp]
 lemma corootSpace_eq_bot_iff {α : Weight K H L} :
     corootSpace α = ⊥ ↔ α.IsZero := by
-  simp [← LieSubmodule.toSubmodule_eq_bot_iff, coe_corootSpace_eq_span_singleton α]
+  simp [← LieSubmodule.toSubmodule_eq_bot, coe_corootSpace_eq_span_singleton α]
 
 lemma isCompl_ker_weight_span_coroot (α : Weight K H L) :
     IsCompl α.ker (K ∙ coroot α) := by

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -54,8 +54,8 @@ lemma ker_restrict_eq_bot_of_isCartanSubalgebra
   have h : Codisjoint (rootSpace H 0) (LieModule.posFittingComp R H L) :=
     (LieModule.isCompl_genWeightSpace_zero_posFittingComp R H L).codisjoint
   replace h : Codisjoint (H : Submodule R L) (LieModule.posFittingComp R H L : Submodule R L) := by
-    rwa [codisjoint_iff, ← LieSubmodule.coe_toSubmodule_inj, LieSubmodule.sup_coe_toSubmodule,
-      LieSubmodule.top_coeSubmodule, rootSpace_zero_eq R L H, LieSubalgebra.coe_toLieSubmodule,
+    rwa [codisjoint_iff, ← LieSubmodule.toSubmodule_inj, LieSubmodule.sup_toSubmodule,
+      LieSubmodule.top_toSubmodule, rootSpace_zero_eq R L H, LieSubalgebra.coe_toLieSubmodule,
       ← codisjoint_iff] at h
   suffices this : ∀ m₀ ∈ H, ∀ m₁ ∈ LieModule.posFittingComp R H L, killingForm R L m₀ m₁ = 0 by
     simp [LinearMap.BilinForm.ker_restrict_eq_of_codisjoint h this]
@@ -113,8 +113,8 @@ lemma killingForm_apply_eq_zero_of_mem_rootSpace_of_add_ne_zero {α β : H → K
       mapsTo_toEnd_genWeightSpace_add_of_mem_rootSpace K L H L β γ hy
   classical
   have hds := DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top
-    (LieSubmodule.iSupIndep_iff_coe_toSubmodule.mp <| iSupIndep_genWeightSpace K H L)
-    (LieSubmodule.iSup_eq_top_iff_coe_toSubmodule.mp <| iSup_genWeightSpace_eq_top K H L)
+    (LieSubmodule.iSupIndep_iff_toSubmodule.mp <| iSupIndep_genWeightSpace K H L)
+    (LieSubmodule.iSup_eq_top_iff_toSubmodule.mp <| iSup_genWeightSpace_eq_top K H L)
   exact LinearMap.trace_eq_zero_of_mapsTo_ne hds σ hσ hf
 
 /-- Elements of the `α` root space which are Killing-orthogonal to the `-α` root space are
@@ -337,7 +337,7 @@ lemma coe_corootSpace_eq_span_singleton' (α : Weight K H L) :
       rw [lie_eq_killingForm_smul_of_mem_rootSpace_of_mem_rootSpace_neg heα hfα, SetLike.mem_coe,
         Submodule.mem_span_singleton]
       exact ⟨killingForm K L e f, rfl⟩
-    simp only [LieSubmodule.mem_coeSubmodule, mem_corootSpace] at hx'
+    simp only [LieSubmodule.mem_toSubmodule, mem_corootSpace] at hx'
     replace this := Submodule.span_mono this hx'
     rw [Submodule.span_span] at this
     rw [Submodule.mem_span_singleton] at this ⊢
@@ -345,7 +345,7 @@ lemma coe_corootSpace_eq_span_singleton' (α : Weight K H L) :
     use t
     simp only [Subtype.ext_iff]
     rw [Submodule.coe_smul_of_tower]
-  · simp only [Submodule.span_singleton_le_iff_mem, LieSubmodule.mem_coeSubmodule]
+  · simp only [Submodule.span_singleton_le_iff_mem, LieSubmodule.mem_toSubmodule]
     exact cartanEquivDual_symm_apply_mem_corootSpace α
 
 end PerfectField
@@ -412,7 +412,7 @@ lemma coe_corootSpace_eq_span_singleton (α : Weight K H L) :
 @[simp]
 lemma corootSpace_eq_bot_iff {α : Weight K H L} :
     corootSpace α = ⊥ ↔ α.IsZero := by
-  simp [← LieSubmodule.coeSubmodule_eq_bot_iff, coe_corootSpace_eq_span_singleton α]
+  simp [← LieSubmodule.toSubmodule_eq_bot_iff, coe_corootSpace_eq_span_singleton α]
 
 lemma isCompl_ker_weight_span_coroot (α : Weight K H L) :
     IsCompl α.ker (K ∙ coroot α) := by
@@ -424,12 +424,12 @@ lemma isCompl_ker_weight_span_coroot (α : Weight K H L) :
     apply Module.Dual.isCompl_ker_of_disjoint_of_ne_bot (by aesop)
       (disjoint_ker_weight_corootSpace α)
     replace hα : corootSpace α ≠ ⊥ := by simpa using hα
-    rwa [ne_eq, ← LieSubmodule.coe_toSubmodule_inj] at hα
+    rwa [ne_eq, ← LieSubmodule.toSubmodule_inj] at hα
 
 lemma traceForm_eq_zero_of_mem_ker_of_mem_span_coroot {α : Weight K H L} {x y : H}
     (hx : x ∈ α.ker) (hy : y ∈ K ∙ coroot α) :
     traceForm K H L x y = 0 := by
-  rw [← coe_corootSpace_eq_span_singleton, LieSubmodule.mem_coeSubmodule, mem_corootSpace'] at hy
+  rw [← coe_corootSpace_eq_span_singleton, LieSubmodule.mem_toSubmodule, mem_corootSpace'] at hy
   induction hy using Submodule.span_induction with
   | mem z hz =>
     obtain ⟨u, hu, v, -, huv⟩ := hz

--- a/Mathlib/Algebra/Lie/Weights/Linear.lean
+++ b/Mathlib/Algebra/Lie/Weights/Linear.lean
@@ -97,14 +97,14 @@ instance instLinearWeightsOfIsLieAbelian [IsLieAbelian L] [NoZeroSMulDivisors R 
     have h : ∀ x y, Commute (toEnd R L M x) (toEnd R L M y) := fun x y ↦ by
       rw [commute_iff_lie_eq, ← LieHom.map_lie, trivial_lie_zero, LieHom.map_zero]
     intro χ hχ x y
-    simp_rw [Ne, ← LieSubmodule.coe_toSubmodule_inj, genWeightSpace, genWeightSpaceOf,
-      LieSubmodule.iInf_coe_toSubmodule, LieSubmodule.bot_coeSubmodule] at hχ
+    simp_rw [Ne, ← LieSubmodule.toSubmodule_inj, genWeightSpace, genWeightSpaceOf,
+      LieSubmodule.iInf_toSubmodule, LieSubmodule.bot_toSubmodule] at hχ
     exact Module.End.map_add_of_iInf_genEigenspace_ne_bot_of_commute
       (toEnd R L M).toLinearMap χ _ hχ h x y
   { map_add := aux
     map_smul := fun χ hχ t x ↦ by
-      simp_rw [Ne, ← LieSubmodule.coe_toSubmodule_inj, genWeightSpace, genWeightSpaceOf,
-        LieSubmodule.iInf_coe_toSubmodule, LieSubmodule.bot_coeSubmodule] at hχ
+      simp_rw [Ne, ← LieSubmodule.toSubmodule_inj, genWeightSpace, genWeightSpaceOf,
+        LieSubmodule.iInf_toSubmodule, LieSubmodule.bot_toSubmodule] at hχ
       exact Module.End.map_smul_of_iInf_genEigenspace_ne_bot
         (toEnd R L M).toLinearMap χ _ hχ t x
     map_lie := fun χ hχ t x ↦ by


### PR DESCRIPTION
Moves:
- `*coeSubmodule*`, `*coe_toSubmodule*`, `*to_submodule*`, `*coe_submodule*`, `*coe_to_submodule*` -> `*toSubmodule*`
- `*coe_linearMap*` -> `*toLinearMap*`
- `*to_lieHom*` -> `*toLieHom*`
- `*coe_linearEquiv*`, `*to_linearEquiv*` -> `*toLinearEquiv*`
- `*coe_lieSubalgebra*`, `*to_lieSubalgebra*` -> `*toLieSubalgebra*`

special cases:
* `LieIdeal.coe_toSubalgebra` -> `LieIdeal.coe_toLieSubalgebra`
* `LieSubalgebra.coe_to_submodule` -> `LieSubalgebra.coe_toSubmodule`
* `LieSubmodule.coe_toSubmodule` and similar: unchanged
* `sInf_coe_toSubmodule'` -> `sInf_toSubmodule_eq_iInf`
* `sSup_coe_toSubmodule'` -> `sSup_toSubmodule_eq_iSup`

PR follows [this Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Algebra.2ELie.2ESubmodule.2C.20Algebra.2ELie.2ESubalgebra.20naming)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
