### PR TITLE
feat: generalize `ContinuousLinearMap.curry` to TVS

### DIFF
--- a/Mathlib/Analysis/NormedSpace/Multilinear/Curry.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear/Curry.lean
@@ -116,6 +116,36 @@ theorem ContinuousLinearMap.uncurryLeft_apply
     f.uncurryLeft m = f (m 0) (tail m) :=
   rfl
 
+section toMove
+
+/-- The `Fin` version of `inf_iInf_nat_succ`. -/
+theorem Fin.iInf_succ {α} [CompleteLattice α] {n : ℕ} {f : Fin (n + 1) → α} :
+    ⨅ i, f i = f 0 ⊓ ⨅ i, f (.succ i) :=
+  le_antisymm
+    (le_inf (iInf_le _ _) <| iInf_mono' fun _ => ⟨_, le_rfl⟩)
+    (le_iInf <| Fin.cases inf_le_left fun _ => inf_le_right.trans (iInf_le _ _))
+
+theorem IsUniformInducing.finCons
+    {n : ℕ} {α : Type*} {β : Fin n.succ → Type*}
+    [UniformSpace α] [∀ i, UniformSpace (β i)] {x : α → β 0} {xs : α → Π i, β (Fin.succ i)}
+    (hx : IsUniformInducing x) (hxs : IsUniformInducing xs) :
+    IsUniformInducing (fun a => Fin.cons (x a) (xs a)) where
+  comap_uniformity := by
+    replace hx := hx.comap_uniformity
+    replace hxs := hxs.comap_uniformity
+    simp_rw [Pi.uniformity, Filter.comap_iInf, Filter.comap_comap, Function.comp_def] at hxs ⊢
+    rw [Fin.iInf_succ]
+    simp [hx, hxs]
+
+theorem IsUniformEmbedding.finCons
+    {n : ℕ} {α : Type*} {β : Fin n.succ → Type*}
+    [UniformSpace α] [∀ i, UniformSpace (β i)] (x : α → β 0) (xs : α → Π i, β (Fin.succ i))
+    (hx : IsUniformEmbedding x) (hxs : IsUniformEmbedding xs) :
+    IsUniformEmbedding (fun a => Fin.cons (x a) (xs a)) where
+  injective := fun _ _ hab => hx.injective <| congrFun hab 0
+  toIsUniformInducing := hx.isUniformInducing.finCons hxs.isUniformInducing
+
+end toMove
 /-- Given a continuous multilinear map `f` in `n+1` variables, split the first variable to obtain
 a continuous linear map into continuous multilinear maps in `n` variables, given by
 `x ↦ (m ↦ f (cons x m))`. -/
@@ -123,7 +153,7 @@ def ContinuousMultilinearMap.curryLeft (f : ContinuousMultilinearMap 𝕜 Ei G) 
     Ei 0 →L[𝕜] ContinuousMultilinearMap 𝕜 (fun i : Fin n => Ei i.succ) G where
   toFun x :=
     { toMultilinearMap := f.toMultilinearMap.curryLeft x
-      cont :=  (ContinuousMapClass.map_continuous f).comp (continuous_const.finCons continuous_id) }
+      cont := (ContinuousMapClass.map_continuous f).comp (continuous_const.finCons continuous_id) }
   map_add' x y := by
     ext m
     exact f.cons_add m x y
@@ -133,12 +163,14 @@ def ContinuousMultilinearMap.curryLeft (f : ContinuousMultilinearMap 𝕜 Ei G) 
   cont := by
     refine (IsUniformInducing.isInducing ?_).continuous
     dsimp
-    rw [← isUniformInducing_toUniformOnFun.of_comp_iff]
-    refine .comp ?_ isUniformInducing_toUniformOnFun
-    simp [Function.comp_def]
+    have := isUniformInducing_toUniformOnFun (𝕜 := 𝕜) (E := Ei) (F := G)
+    rw [← isUniformEmbedding_toUniformOnFun.of_comp_iff]
+    convert isUniformEmbedding_toUniformOnFun using 4 with s
+    -- rw?
+    -- erw [isUniformInducing_comp_iff]
     -- rw [continuous_induced_rng, UniformOnFun.tendsto_iff_tendstoUniformlyOn ]
-    dsimp [Function.comp_def, toUniformOnFun]
-    simp_rw [ContinuousLinearMap.coe_mk]
+    -- dsimp [Function.comp_def, toUniformOnFun]
+    -- simp_rw [ContinuousLinearMap.coe_mk]
 
 @[simp]
 theorem ContinuousMultilinearMap.curryLeft_apply (f : ContinuousMultilinearMap 𝕜 Ei G) (x : Ei 0)

--- a/Mathlib/Analysis/NormedSpace/Multilinear/Curry.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear/Curry.lean
@@ -102,10 +102,13 @@ construct the corresponding continuous multilinear map on `n+1` variables obtain
 the variables, given by `m ↦ f (m 0) (tail m)`-/
 def ContinuousLinearMap.uncurryLeft
     (f : Ei 0 →L[𝕜] ContinuousMultilinearMap 𝕜 (fun i : Fin n => Ei i.succ) G) :
-    ContinuousMultilinearMap 𝕜 Ei G :=
-  (@LinearMap.uncurryLeft 𝕜 n Ei G _ _ _ _ _
-      (ContinuousMultilinearMap.toMultilinearMapLinear.comp f.toLinearMap)).mkContinuous
-    ‖f‖ fun m => by exact ContinuousLinearMap.norm_map_tail_le f m
+    ContinuousMultilinearMap 𝕜 Ei G where
+  toMultilinearMap :=
+    (@LinearMap.uncurryLeft 𝕜 n Ei G _ _ _ _ _
+        (ContinuousMultilinearMap.toMultilinearMapLinear.comp f.toLinearMap))
+  cont := by
+    dsimp [LinearMap.uncurryLeft]
+    continuity
 
 @[simp]
 theorem ContinuousLinearMap.uncurryLeft_apply
@@ -117,22 +120,27 @@ theorem ContinuousLinearMap.uncurryLeft_apply
 a continuous linear map into continuous multilinear maps in `n` variables, given by
 `x ↦ (m ↦ f (cons x m))`. -/
 def ContinuousMultilinearMap.curryLeft (f : ContinuousMultilinearMap 𝕜 Ei G) :
-    Ei 0 →L[𝕜] ContinuousMultilinearMap 𝕜 (fun i : Fin n => Ei i.succ) G :=
-  LinearMap.mkContinuous
-    { -- define a linear map into `n` continuous multilinear maps
-      -- from an `n+1` continuous multilinear map
-      toFun := fun x =>
-        (f.toMultilinearMap.curryLeft x).mkContinuous (‖f‖ * ‖x‖) (f.norm_map_cons_le x)
-      map_add' := fun x y => by
-        ext m
-        exact f.cons_add m x y
-      map_smul' := fun c x => by
-        ext m
-        exact
-          f.cons_smul m c x }-- then register its continuity thanks to its boundedness properties.
-    ‖f‖ fun x => by
-      rw [LinearMap.coe_mk, AddHom.coe_mk]
-      exact MultilinearMap.mkContinuous_norm_le _ (mul_nonneg (norm_nonneg _) (norm_nonneg _)) _
+    Ei 0 →L[𝕜] ContinuousMultilinearMap 𝕜 (fun i : Fin n => Ei i.succ) G where
+  toFun x :=
+    { toMultilinearMap := (f.toMultilinearMap.curryLeft x)
+      cont :=
+        (ContinuousMapClass.map_continuous f).comp (continuous_const.fin_cons continuous_id) }
+  map_add' := fun x y => by
+    ext m
+    exact f.cons_add m x y
+  map_smul' := fun c x => by
+    ext m
+    exact
+      f.cons_smul m c x
+  cont := by
+    refine (IsUniformInducing.isInducing ?_).continuous
+    dsimp
+    rw [← isUniformInducing_toUniformOnFun.of_comp_iff]
+    refine .comp ?_ isUniformInducing_toUniformOnFun
+    simp [Function.comp_def]
+    -- rw [continuous_induced_rng, UniformOnFun.tendsto_iff_tendstoUniformlyOn ]
+    dsimp [Function.comp_def, toUniformOnFun]
+    simp_rw [ContinuousLinearMap.coe_mk]
 
 @[simp]
 theorem ContinuousMultilinearMap.curryLeft_apply (f : ContinuousMultilinearMap 𝕜 Ei G) (x : Ei 0)

--- a/Mathlib/Analysis/NormedSpace/Multilinear/Curry.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear/Curry.lean
@@ -162,15 +162,10 @@ def ContinuousMultilinearMap.curryLeft (f : ContinuousMultilinearMap 𝕜 Ei G) 
     exact f.cons_smul m c x
   cont := by
     refine (IsUniformInducing.isInducing ?_).continuous
-    dsimp
-    have := isUniformInducing_toUniformOnFun (𝕜 := 𝕜) (E := Ei) (F := G)
-    rw [← isUniformEmbedding_toUniformOnFun.of_comp_iff]
-    convert isUniformEmbedding_toUniformOnFun using 4 with s
-    -- rw?
-    -- erw [isUniformInducing_comp_iff]
-    -- rw [continuous_induced_rng, UniformOnFun.tendsto_iff_tendstoUniformlyOn ]
-    -- dsimp [Function.comp_def, toUniformOnFun]
-    -- simp_rw [ContinuousLinearMap.coe_mk]
+    rw [← isUniformInducing_toUniformOnFun.of_comp_iff]
+    dsimp [Function.comp_def]
+    rw [isUniformInducing_iff_uniformSpace]
+    sorry
 
 @[simp]
 theorem ContinuousMultilinearMap.curryLeft_apply (f : ContinuousMultilinearMap 𝕜 Ei G) (x : Ei 0)

--- a/Mathlib/Analysis/NormedSpace/Multilinear/Curry.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear/Curry.lean
@@ -122,16 +122,14 @@ a continuous linear map into continuous multilinear maps in `n` variables, given
 def ContinuousMultilinearMap.curryLeft (f : ContinuousMultilinearMap 𝕜 Ei G) :
     Ei 0 →L[𝕜] ContinuousMultilinearMap 𝕜 (fun i : Fin n => Ei i.succ) G where
   toFun x :=
-    { toMultilinearMap := (f.toMultilinearMap.curryLeft x)
-      cont :=
-        (ContinuousMapClass.map_continuous f).comp (continuous_const.fin_cons continuous_id) }
-  map_add' := fun x y => by
+    { toMultilinearMap := f.toMultilinearMap.curryLeft x
+      cont :=  (ContinuousMapClass.map_continuous f).comp (continuous_const.finCons continuous_id) }
+  map_add' x y := by
     ext m
     exact f.cons_add m x y
-  map_smul' := fun c x => by
+  map_smul' c x := by
     ext m
-    exact
-      f.cons_smul m c x
+    exact f.cons_smul m c x
   cont := by
     refine (IsUniformInducing.isInducing ?_).continuous
     dsimp
@@ -181,11 +179,10 @@ def continuousMultilinearCurryLeftEquiv :
       left_inv := ContinuousMultilinearMap.uncurry_curryLeft
       right_inv := ContinuousLinearMap.curry_uncurryLeft }
     (fun f => by
-      simp only [LinearEquiv.coe_mk]
-      exact LinearMap.mkContinuous_norm_le _ (norm_nonneg f) _)
-    (fun f => by
-      simp only [LinearEquiv.coe_symm_mk]
-      exact MultilinearMap.mkContinuous_norm_le _ (norm_nonneg f) _)
+      refine ContinuousLinearMap.opNorm_le_bound _ (norm_nonneg f) fun x => ?_
+      refine opNorm_le_bound (mul_nonneg (norm_nonneg _) (norm_nonneg _)) fun m => ?_
+      exact ContinuousMultilinearMap.norm_map_cons_le f x m)
+    (fun f => opNorm_le_bound (norm_nonneg f) (ContinuousLinearMap.norm_map_tail_le f))
 
 variable {𝕜 Ei G}
 


### PR DESCRIPTION
Follow on from #10777

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
