### PR TITLE
[Merged by Bors] - feat(GroupTheory/Subgroup/Centralizer): `f(C(S)) ≤ C(f(S))`

### DIFF
--- a/Mathlib/GroupTheory/Subgroup/Centralizer.lean
+++ b/Mathlib/GroupTheory/Subgroup/Centralizer.lean
@@ -11,7 +11,7 @@ import Mathlib.GroupTheory.Submonoid.Centralizer
 # Centralizers of subgroups
 -/
 
-variable {G : Type*} [Group G]
+variable {G G' : Type*} [Group G] [Group G']
 
 namespace Subgroup
 
@@ -77,6 +77,12 @@ variable (H)
 @[to_additive]
 theorem le_centralizer [h : H.IsCommutative] : H ≤ centralizer H :=
   le_centralizer_iff_isCommutative.mpr h
+
+@[to_additive]
+theorem map_centralizer_le_centralizer_map (f : G →* G') :
+    H.centralizer.map f ≤ Subgroup.centralizer (H.map f) := by
+  rintro - ⟨g, hg, rfl⟩ - ⟨h, hh, rfl⟩
+  rw [← map_mul, ← map_mul, hg h hh]
 
 variable {H} in
 @[to_additive]

--- a/Mathlib/GroupTheory/Subgroup/Centralizer.lean
+++ b/Mathlib/GroupTheory/Subgroup/Centralizer.lean
@@ -61,6 +61,12 @@ theorem centralizer_eq_top_iff_subset {s : Set G} : centralizer s = ⊤ ↔ s �
   SetLike.ext'_iff.trans Set.centralizer_eq_top_iff_subset
 
 @[to_additive]
+theorem map_centralizer_le_centralizer_image (s : Set G) (f : G →* G') :
+    (Subgroup.centralizer s).map f ≤ Subgroup.centralizer (f '' s) := by
+  rintro - ⟨g, hg, rfl⟩ - ⟨h, hh, rfl⟩
+  rw [← map_mul, ← map_mul, hg h hh]
+
+@[to_additive]
 instance Centralizer.characteristic [hH : H.Characteristic] :
     (centralizer (H : Set G)).Characteristic := by
   refine Subgroup.characteristic_iff_comap_le.mpr fun ϕ g hg h hh => ϕ.injective ?_
@@ -77,12 +83,6 @@ variable (H)
 @[to_additive]
 theorem le_centralizer [h : H.IsCommutative] : H ≤ centralizer H :=
   le_centralizer_iff_isCommutative.mpr h
-
-@[to_additive]
-theorem map_centralizer_le_centralizer_map (f : G →* G') :
-    H.centralizer.map f ≤ Subgroup.centralizer (H.map f) := by
-  rintro - ⟨g, hg, rfl⟩ - ⟨h, hh, rfl⟩
-  rw [← map_mul, ← map_mul, hg h hh]
 
 variable {H} in
 @[to_additive]


### PR DESCRIPTION
This PR proves that the image of a centralizer is contained in the centralizer of the image.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
