### PR TITLE
[Merged by Bors] - feat(Order/Interval/Finset): Lemmas for intervals with bot/top

### DIFF
--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -478,6 +478,7 @@ section PartialOrder
 
 variable [PartialOrder α] [LocallyFiniteOrder α] {a b c : α}
 
+@[simp]
 theorem Icc_self (a : α) : Icc a a = {a} := by rw [← coe_eq_singleton, coe_Icc, Set.Icc_self]
 
 @[simp]
@@ -487,8 +488,10 @@ theorem Icc_eq_singleton_iff : Icc a b = {c} ↔ a = c ∧ b = c := by
 theorem Ico_disjoint_Ico_consecutive (a b c : α) : Disjoint (Ico a b) (Ico b c) :=
   disjoint_left.2 fun _ hab hbc => (mem_Ico.mp hab).2.not_le (mem_Ico.mp hbc).1
 
+@[simp]
 theorem Ici_top [OrderTop α] : Ici (⊤ : α) = {⊤} := Icc_eq_singleton_iff.2 ⟨rfl, rfl⟩
 
+@[simp]
 theorem Iic_bot [OrderBot α] : Iic (⊥ : α) = {⊥} := Icc_eq_singleton_iff.2 ⟨rfl, rfl⟩
 
 section DecidableEq

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -450,6 +450,23 @@ theorem filter_ge_eq_Iic [DecidablePred (· ≤ a)] : ({x | x ≤ a} : Finset _)
 
 end LocallyFiniteOrderBot
 
+section LocallyFiniteOrder
+
+variable [LocallyFiniteOrder α]
+
+theorem Icc_bot [OrderBot α] : Icc (⊥ : α) a = Iic a := rfl
+
+theorem Icc_top [OrderTop α] : Icc a (⊤ : α) = Ici a := rfl
+
+theorem Ico_bot [OrderBot α] : Ico (⊥ : α) a = Iio a := rfl
+
+theorem Ioc_top [OrderTop α] : Ioc a (⊤ : α) = Ioi a := rfl
+
+theorem Icc_bot_top [BoundedOrder α] [Fintype α] : Icc (⊥ : α) (⊤ : α) = univ := by
+  rw [Icc_bot, Iic_top]
+
+end LocallyFiniteOrder
+
 variable [LocallyFiniteOrderTop α] [LocallyFiniteOrderBot α]
 
 theorem disjoint_Ioi_Iio (a : α) : Disjoint (Ioi a) (Iio a) :=
@@ -461,7 +478,6 @@ section PartialOrder
 
 variable [PartialOrder α] [LocallyFiniteOrder α] {a b c : α}
 
-@[simp]
 theorem Icc_self (a : α) : Icc a a = {a} := by rw [← coe_eq_singleton, coe_Icc, Set.Icc_self]
 
 @[simp]
@@ -471,18 +487,9 @@ theorem Icc_eq_singleton_iff : Icc a b = {c} ↔ a = c ∧ b = c := by
 theorem Ico_disjoint_Ico_consecutive (a b c : α) : Disjoint (Ico a b) (Ico b c) :=
   disjoint_left.2 fun _ hab hbc => (mem_Ico.mp hab).2.not_le (mem_Ico.mp hbc).1
 
-@[simp]
-theorem Ici_top [OrderTop α] : Ici (⊤ : α) = {⊤} :=
-  Icc_eq_singleton_iff.2 ⟨rfl, rfl⟩
+theorem Ici_top [OrderTop α] : Ici (⊤ : α) = {⊤} := Icc_eq_singleton_iff.2 ⟨rfl, rfl⟩
 
-@[simp]
-theorem Iic_bot [OrderBot α] : Iic (⊥ : α) = {⊥} :=
-  Icc_eq_singleton_iff.2 ⟨rfl, rfl⟩
-
-@[simp]
-theorem Icc_bot_top [BoundedOrder α] [Fintype α] : Icc (⊥ : α) ⊤ = univ := by
-  ext a
-  simp only [mem_Icc, bot_le, le_top, and_self, mem_univ]
+theorem Iic_bot [OrderBot α] : Iic (⊥ : α) = {⊥} := Icc_eq_singleton_iff.2 ⟨rfl, rfl⟩
 
 section DecidableEq
 

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -309,13 +309,11 @@ section LocallyFiniteOrderTop
 variable [LocallyFiniteOrderTop α]
 
 @[simp]
-theorem Ioi_eq_empty_iff : Ioi a = ∅ ↔ IsMax a := by
+theorem Ioi_eq_empty : Ioi a = ∅ ↔ IsMax a := by
   rw [← coe_eq_empty, coe_Ioi, Set.Ioi_eq_empty_iff]
 
-alias ⟨_, Ioi_eq_empty⟩ := Ioi_eq_empty_iff
-
 @[simp]
-theorem Ioi_top [OrderTop α] : Ioi (⊤ : α) = ∅ := Ioi_eq_empty isMax_top
+theorem Ioi_top [OrderTop α] : Ioi (⊤ : α) = ∅ := Ioi_eq_empty.mpr isMax_top
 
 @[simp]
 theorem Ici_bot [OrderBot α] [Fintype α] : Ici (⊥ : α) = univ := by
@@ -362,12 +360,10 @@ section LocallyFiniteOrderBot
 variable [LocallyFiniteOrderBot α]
 
 @[simp]
-theorem Iio_eq_empty_iff : Iio a = ∅ ↔ IsMin a := Ioi_eq_empty_iff (α := αᵒᵈ)
-
-alias ⟨_, Iio_eq_empty⟩ := Iio_eq_empty_iff
+theorem Iio_eq_empty : Iio a = ∅ ↔ IsMin a := Ioi_eq_empty (α := αᵒᵈ)
 
 @[simp]
-theorem Iio_bot [OrderBot α] : Iio (⊥ : α) = ∅ := Iio_eq_empty isMin_bot
+theorem Iio_bot [OrderBot α] : Iio (⊥ : α) = ∅ := Iio_eq_empty.mpr isMin_bot
 
 @[simp]
 theorem Iic_top [OrderTop α] [Fintype α] : Iic (⊤ : α) = univ := by
@@ -454,12 +450,16 @@ section LocallyFiniteOrder
 
 variable [LocallyFiniteOrder α]
 
+@[simp]
 theorem Icc_bot [OrderBot α] : Icc (⊥ : α) a = Iic a := rfl
 
+@[simp]
 theorem Icc_top [OrderTop α] : Icc a (⊤ : α) = Ici a := rfl
 
+@[simp]
 theorem Ico_bot [OrderBot α] : Ico (⊥ : α) a = Iio a := rfl
 
+@[simp]
 theorem Ioc_top [OrderTop α] : Ioc a (⊤ : α) = Ioi a := rfl
 
 theorem Icc_bot_top [BoundedOrder α] [Fintype α] : Icc (⊥ : α) (⊤ : α) = univ := by

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -308,6 +308,19 @@ section LocallyFiniteOrderTop
 
 variable [LocallyFiniteOrderTop α]
 
+@[simp]
+theorem Ioi_eq_empty_iff : Ioi a = ∅ ↔ IsMax a := by
+  rw [← coe_eq_empty, coe_Ioi, Set.Ioi_eq_empty_iff]
+
+alias ⟨_, Ioi_eq_empty⟩ := Ioi_eq_empty_iff
+
+@[simp]
+theorem Ioi_top [OrderTop α] : Ioi (⊤ : α) = ∅ := Ioi_eq_empty isMax_top
+
+@[simp]
+theorem Ici_bot [OrderBot α] [Fintype α] : Ici (⊥ : α) = univ := by
+  ext a; simp only [mem_Ici, bot_le, mem_univ]
+
 @[simp, aesop safe apply (rule_sets := [finsetNonempty])]
 lemma nonempty_Ici : (Ici a).Nonempty := ⟨a, mem_Ici.2 le_rfl⟩
 @[simp]
@@ -347,6 +360,14 @@ end LocallyFiniteOrderTop
 section LocallyFiniteOrderBot
 
 variable [LocallyFiniteOrderBot α]
+
+@[simp]
+theorem Iio_eq_empty_iff : Iio a = ∅ ↔ IsMin a := Ioi_eq_empty_iff (α := αᵒᵈ)
+
+alias ⟨_, Iio_eq_empty⟩ := Iio_eq_empty_iff
+
+@[simp]
+theorem Iio_bot [OrderBot α] : Iio (⊥ : α) = ∅ := Iio_eq_empty isMin_bot
 
 @[simp, aesop safe apply (rule_sets := [finsetNonempty])]
 lemma nonempty_Iic : (Iic a).Nonempty := ⟨a, mem_Iic.2 le_rfl⟩
@@ -445,6 +466,19 @@ theorem Icc_eq_singleton_iff : Icc a b = {c} ↔ a = c ∧ b = c := by
 
 theorem Ico_disjoint_Ico_consecutive (a b c : α) : Disjoint (Ico a b) (Ico b c) :=
   disjoint_left.2 fun _ hab hbc => (mem_Ico.mp hab).2.not_le (mem_Ico.mp hbc).1
+
+@[simp]
+theorem Ici_top [OrderTop α] : Ici (⊤ : α) = {⊤} :=
+  Icc_eq_singleton_iff.2 ⟨rfl, rfl⟩
+
+@[simp]
+theorem Iic_bot [OrderBot α] : Iic (⊥ : α) = {⊥} :=
+  Icc_eq_singleton_iff.2 ⟨rfl, rfl⟩
+
+@[simp]
+theorem Icc_bot_top [BoundedOrder α] [Fintype α] : Icc (⊥ : α) ⊤ = univ := by
+  ext a
+  simp only [mem_Icc, bot_le, le_top, and_self, mem_univ]
 
 section DecidableEq
 

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -369,6 +369,10 @@ alias ⟨_, Iio_eq_empty⟩ := Iio_eq_empty_iff
 @[simp]
 theorem Iio_bot [OrderBot α] : Iio (⊥ : α) = ∅ := Iio_eq_empty isMin_bot
 
+@[simp]
+theorem Iic_top [OrderTop α] [Fintype α] : Iic (⊤ : α) = univ := by
+  ext a; simp only [mem_Iic, le_top, mem_univ]
+
 @[simp, aesop safe apply (rule_sets := [finsetNonempty])]
 lemma nonempty_Iic : (Iic a).Nonempty := ⟨a, mem_Iic.2 le_rfl⟩
 @[simp]


### PR DESCRIPTION
Add some lemmas on intervals containing bot / top elements, mirroring existing results in `Order/Interval/Set/Basic.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This is a sub-PR of #19697 as requested by @YaelDillies.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
