### PR TITLE
[Merged by Bors] - feat(Data/Finsupp/Fin): Lemmas relating `Finsupp.{tail/update}`

### DIFF
--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -198,6 +198,9 @@ def equivFunOnFinite [Finite α] : (α →₀ M) ≃ (α → M) where
 theorem equivFunOnFinite_symm_coe {α} [Finite α] (f : α →₀ M) : equivFunOnFinite.symm f = f :=
   equivFunOnFinite.symm_apply_apply f
 
+@[simp]
+lemma coe_equivFunOnFinite_symm {α} [Finite α] (f : α → M) : ⇑(equivFunOnFinite.symm f) = f := rfl
+
 /--
 If `α` has a unique term, the type of finitely supported functions `α →₀ β` is equivalent to `β`.
 -/

--- a/Mathlib/Data/Finsupp/Fin.lean
+++ b/Mathlib/Data/Finsupp/Fin.lean
@@ -50,18 +50,10 @@ theorem tail_cons : tail (cons y s) = s :=
   ext fun k => by simp only [tail_apply, cons_succ]
 
 @[simp]
-theorem tail_update_zero : tail (update t 0 y) = tail t := by
-  simp only [tail, update, coe_mk, EmbeddingLike.apply_eq_iff_eq]
-  convert Fin.tail_update_zero (⇑t) y
+theorem tail_update_zero : tail (update t 0 y) = tail t := by simp [tail]
 
 @[simp]
-theorem tail_update_succ : tail (update t i.succ y) = update (tail t) i y := by
-  ext a
-  have : ⇑(equivFunOnFinite.symm (Fin.tail ⇑t)) = Fin.tail ⇑t := rfl
-  simp only [tail, update, this, coe_mk, equivFunOnFinite_symm_apply_toFun]
-  have : Fin.tail (Function.update (⇑t) i.succ y) a = Function.update (Fin.tail ⇑t) i y a := by
-    simp only [Fin.tail_update_succ]
-  convert this
+theorem tail_update_succ : tail (update t i.succ y) = update (tail t) i y := by ext; simp [tail]
 
 @[simp]
 theorem cons_tail : cons (t 0) (tail t) = t := by

--- a/Mathlib/Data/Finsupp/Fin.lean
+++ b/Mathlib/Data/Finsupp/Fin.lean
@@ -50,6 +50,20 @@ theorem tail_cons : tail (cons y s) = s :=
   ext fun k => by simp only [tail_apply, cons_succ]
 
 @[simp]
+theorem tail_update_zero : tail (update t 0 y) = tail t := by
+  simp only [tail, update, coe_mk, EmbeddingLike.apply_eq_iff_eq]
+  convert Fin.tail_update_zero (⇑t) y
+
+@[simp]
+theorem tail_update_succ : tail (update t i.succ y) = update (tail t) i y := by
+  ext a
+  have : ⇑(equivFunOnFinite.symm (Fin.tail ⇑t)) = Fin.tail ⇑t := rfl
+  simp only [tail, update, this, coe_mk, equivFunOnFinite_symm_apply_toFun]
+  have : Fin.tail (Function.update (⇑t) i.succ y) a = Function.update (Fin.tail ⇑t) i y a := by
+    simp only [Fin.tail_update_succ]
+  convert this
+
+@[simp]
 theorem cons_tail : cons (t 0) (tail t) = t := by
   ext a
   by_cases c_a : a = 0


### PR DESCRIPTION
This is a sub-PR for #19315 as requested by Yaël

It adds two lemmas relating `Finsupp.tail` with `Finsupp.update`, similar to the equivalent version on `Fin`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
