### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Shift): fix NatTrans.CommShift

### DIFF
--- a/Mathlib/CategoryTheory/Shift/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Shift/Adjunction.lean
@@ -213,7 +213,7 @@ lemma mk' (h : NatTrans.CommShift adj.unit A) :
     refine (compatibilityCounit_of_compatibilityUnit adj _ _ (fun X ↦ ?_) _).symm
     simpa only [NatTrans.comp_app,
       Functor.commShiftIso_id_hom_app, whiskerRight_app, id_comp,
-      Functor.commShiftIso_comp_hom_app] using congr_app (h.comm' a) X⟩
+      Functor.commShiftIso_comp_hom_app] using congr_app (h.shift_comm a) X⟩
 
 end CommShift
 
@@ -225,14 +225,14 @@ lemma shift_unit_app [adj.CommShift A] (a : A) (X : C) :
       adj.unit.app (X⟦a⟧) ≫
         G.map ((F.commShiftIso a).hom.app X) ≫
           (G.commShiftIso a).hom.app (F.obj X) := by
-  simpa [Functor.commShiftIso_comp_hom_app] using NatTrans.CommShift.comm_app adj.unit a X
+  simpa [Functor.commShiftIso_comp_hom_app] using NatTrans.shift_app_comm adj.unit a X
 
 @[reassoc]
 lemma shift_counit_app [adj.CommShift A] (a : A) (Y : D) :
     (adj.counit.app Y)⟦a⟧' =
       (F.commShiftIso a).inv.app (G.obj Y) ≫ F.map ((G.commShiftIso a).inv.app Y) ≫
         adj.counit.app (Y⟦a⟧) := by
-  have eq := NatTrans.CommShift.comm_app adj.counit a Y
+  have eq := NatTrans.shift_app_comm adj.counit a Y
   simp only [Functor.comp_obj, Functor.id_obj, Functor.commShiftIso_comp_hom_app, assoc,
     Functor.commShiftIso_id_hom_app, comp_id] at eq
   simp only [← eq, Functor.comp_obj, Functor.id_obj, ← F.map_comp_assoc, Iso.inv_hom_id_app,

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -264,90 +264,86 @@ variable {C D E J : Type*} [Category C] [Category D] [Category E] [Category J]
 which commute with a shift by an additive monoid `A`, this typeclass
 asserts a compatibility of `τ` with these shifts. -/
 class CommShift : Prop where
-  comm' (a : A) : (F₁.commShiftIso a).hom ≫ whiskerRight τ _ =
-    whiskerLeft _ τ ≫ (F₂.commShiftIso a).hom
-
-namespace CommShift
+  shift_comm (a : A) : (F₁.commShiftIso a).hom ≫ whiskerRight τ _ =
+    whiskerLeft _ τ ≫ (F₂.commShiftIso a).hom := by aesop_cat
 
 section
 
-variable {A}
-variable [NatTrans.CommShift τ A]
-
-lemma comm (a : A) : (F₁.commShiftIso a).hom ≫ whiskerRight τ _ =
-    whiskerLeft _ τ ≫ (F₂.commShiftIso a).hom := by
-  apply comm'
+variable {A} [NatTrans.CommShift τ A]
 
 @[reassoc]
-lemma comm_app (a : A) (X : C) :
+lemma shift_comm (a : A) :
+    (F₁.commShiftIso a).hom ≫ whiskerRight τ _ =
+      whiskerLeft _ τ ≫ (F₂.commShiftIso a).hom := by
+  apply CommShift.shift_comm
+
+@[reassoc]
+lemma shift_app_comm (a : A) (X : C) :
     (F₁.commShiftIso a).hom.app X ≫ (τ.app X)⟦a⟧' =
       τ.app (X⟦a⟧) ≫ (F₂.commShiftIso a).hom.app X :=
-  NatTrans.congr_app (comm τ a) X
+  congr_app (shift_comm τ a) X
 
 @[reassoc]
 lemma shift_app (a : A) (X : C) :
     (τ.app X)⟦a⟧' = (F₁.commShiftIso a).inv.app X ≫
       τ.app (X⟦a⟧) ≫ (F₂.commShiftIso a).hom.app X := by
-  rw [← comm_app, Iso.inv_hom_id_app_assoc]
+  rw [← shift_app_comm, Iso.inv_hom_id_app_assoc]
 
 @[reassoc]
 lemma app_shift (a : A) (X : C) :
     τ.app (X⟦a⟧) = (F₁.commShiftIso a).hom.app X ≫ (τ.app X)⟦a⟧' ≫
       (F₂.commShiftIso a).inv.app X := by
-  erw [comm_app_assoc, Iso.hom_inv_id_app, Category.comp_id]
+  simp [shift_app_comm_assoc τ a X]
+
+@[deprecated (since := "2024-12-31")] alias CommShift.comm' := shift_comm
+@[deprecated (since := "2024-12-31")] alias CommShift.comm := shift_comm
+@[deprecated (since := "2024-12-31")] alias CommShift.comm_app := shift_app_comm
+@[deprecated (since := "2024-12-31")] alias CommShift.shift_app := shift_app
+@[deprecated (since := "2024-12-31")] alias CommShift.app_shift := app_shift
 
 end
+
+namespace CommShift
 
 instance of_iso_inv [NatTrans.CommShift e.hom A] :
   NatTrans.CommShift e.inv A := ⟨fun a => by
   ext X
   dsimp
-  rw [← cancel_epi (e.hom.app (X⟦a⟧)), e.hom_inv_id_app_assoc, ← comm_app_assoc,
-    ← Functor.map_comp, e.hom_inv_id_app, Functor.map_id]
-  rw [Category.comp_id]⟩
+  rw [← cancel_epi (e.hom.app (X⟦a⟧)), e.hom_inv_id_app_assoc, ← shift_app_comm_assoc,
+    ← Functor.map_comp, e.hom_inv_id_app, Functor.map_id, Category.comp_id]⟩
 
 lemma of_isIso [IsIso τ] [NatTrans.CommShift τ A] :
     NatTrans.CommShift (inv τ) A := by
-  haveI : NatTrans.CommShift (asIso τ).hom A := by
-    dsimp
-    infer_instance
+  haveI : NatTrans.CommShift (asIso τ).hom A := by assumption
   change NatTrans.CommShift (asIso τ).inv A
   infer_instance
 
 variable (F₁) in
-instance id : NatTrans.CommShift (𝟙 F₁) A := ⟨by aesop_cat⟩
+instance id : NatTrans.CommShift (𝟙 F₁) A where
+
+attribute [local simp] Functor.commShiftIso_comp_hom_app
+  shift_app_comm shift_app_comm_assoc
 
 instance comp [NatTrans.CommShift τ A] [NatTrans.CommShift τ' A] :
-    NatTrans.CommShift (τ ≫ τ') A := ⟨fun a => by
-  ext X
-  simp [comm_app_assoc, comm_app]⟩
+    NatTrans.CommShift (τ ≫ τ') A where
 
 instance whiskerRight [NatTrans.CommShift τ A] :
     NatTrans.CommShift (whiskerRight τ G) A := ⟨fun a => by
   ext X
-  simp only [Functor.comp_obj, whiskerRight_twice, comp_app,
+  simp only [whiskerRight_twice, comp_app,
     whiskerRight_app, Functor.comp_map, whiskerLeft_app,
-    Functor.commShiftIso_comp_hom_app, Category.assoc]
-  erw [← NatTrans.naturality]
-  dsimp
-  simp only [← G.map_comp_assoc, comm_app]⟩
-
-variable {G G'} (F₁)
+    Functor.commShiftIso_comp_hom_app, Category.assoc,
+    ← Functor.commShiftIso_hom_naturality,
+    ← G.map_comp_assoc, shift_app_comm]⟩
 
 instance whiskerLeft [NatTrans.CommShift τ'' A] :
-    NatTrans.CommShift (whiskerLeft F₁ τ'') A := ⟨fun a => by
-  ext X
-  simp only [Functor.comp_obj, comp_app, whiskerRight_app, whiskerLeft_app, whiskerLeft_twice,
-    Functor.commShiftIso_comp_hom_app, Category.assoc, ← NatTrans.naturality_assoc, comm_app]⟩
+    NatTrans.CommShift (whiskerLeft F₁ τ'') A where
 
 instance associator : CommShift (Functor.associator F₁ G H).hom A where
-  comm' a := by ext X; simp [Functor.commShiftIso_comp_hom_app]
 
 instance leftUnitor : CommShift F₁.leftUnitor.hom A where
-  comm' a := by ext X; simp [Functor.commShiftIso_comp_hom_app]
 
 instance rightUnitor : CommShift F₁.rightUnitor.hom A where
-  comm' a := by ext X; simp [Functor.commShiftIso_comp_hom_app]
 
 end CommShift
 

--- a/Mathlib/CategoryTheory/Shift/Quotient.lean
+++ b/Mathlib/CategoryTheory/Shift/Quotient.lean
@@ -136,7 +136,7 @@ noncomputable instance liftCommShift :
 
 instance liftCommShift_compatibility :
     NatTrans.CommShift (Quotient.lift.isLift r F hF).hom A where
-  comm' a := by
+  shift_comm a := by
     ext X
     dsimp
     erw [Functor.map_id, id_comp, comp_id]

--- a/Mathlib/CategoryTheory/Shift/SingleFunctors.lean
+++ b/Mathlib/CategoryTheory/Shift/SingleFunctors.lean
@@ -250,7 +250,7 @@ def postcompIsoOfIso {G G' : D ⥤ E} (e : G ≅ G') [G.CommShift A] [G'.CommShi
   isoMk (fun a => isoWhiskerLeft (F.functor a) e) (fun n a a' ha' => by
     ext X
     dsimp
-    simp [NatTrans.CommShift.shift_app e.hom n])
+    simp [NatTrans.shift_app e.hom n])
 
 end SingleFunctors
 

--- a/Mathlib/CategoryTheory/Triangulated/Functor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Functor.lean
@@ -135,7 +135,7 @@ def mapTriangleIso {F₁ F₂ : C ⥤ D} (e : F₁ ≅ F₂) [F₁.CommShift ℤ
   NatIso.ofComponents (fun T =>
     Triangle.isoMk _ _ (e.app _) (e.app _) (e.app _) (by simp) (by simp) (by
       dsimp
-      simp only [assoc, NatTrans.CommShift.comm_app e.hom (1 : ℤ) T.obj₁,
+      simp only [assoc, NatTrans.shift_app_comm e.hom (1 : ℤ) T.obj₁,
         NatTrans.naturality_assoc])) (by aesop_cat)
 
 end Additive


### PR DESCRIPTION
This PR improves some proofs about `NatTrans.CommShift` (the commutation of a natural transformation to shifts). The field `comm'` of `NatTrans.CommShift` had an unnecessary `'` in it, it is renamed `shift_comm`, and API lemmas are moved from `NatTrans.CommShift` to the `NatTrans` namespace (where `comm` becomes `shift_comm` and `comm_app` becomes `shift_app_comm`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
