### PR TITLE
[Merged by Bors] - doc: tidy the docstring of `Subgroup.centralizer`

### DIFF
--- a/Mathlib/GroupTheory/Subgroup/Centralizer.lean
+++ b/Mathlib/GroupTheory/Subgroup/Centralizer.lean
@@ -17,9 +17,9 @@ namespace Subgroup
 
 variable {H K : Subgroup G}
 
-/-- The `centralizer` of `H` is the subgroup of `g : G` commuting with every `h : H`. -/
+/-- The `centralizer` of `s` is the subgroup of `g : G` commuting with every `h : s`. -/
 @[to_additive
-      "The `centralizer` of `H` is the additive subgroup of `g : G` commuting with every `h : H`."]
+      "The `centralizer` of `s` is the additive subgroup of `g : G` commuting with every `h : s`."]
 def centralizer (s : Set G) : Subgroup G :=
   { Submonoid.centralizer s with
     carrier := Set.centralizer s


### PR DESCRIPTION
The argument is now named `s` as it has type `Set G` (not `Subgroup G`)

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
