### PR TITLE
[Merged by Bors] - chore(CategoryTheory): move Functor.IsWellOrderContinuous

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1928,6 +1928,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.Multiequalizer
 import Mathlib.CategoryTheory.Limits.Shapes.NormalMono.Basic
 import Mathlib.CategoryTheory.Limits.Shapes.NormalMono.Equalizers
 import Mathlib.CategoryTheory.Limits.Shapes.PiProd
+import Mathlib.CategoryTheory.Limits.Shapes.Preorder.WellOrderContinuous
 import Mathlib.CategoryTheory.Limits.Shapes.Products
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Assoc
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq

--- a/Mathlib/CategoryTheory/Limits/Shapes/Preorder/WellOrderContinuous.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Preorder/WellOrderContinuous.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.Data.Nat.SuccPred
+import Mathlib.Order.SuccPred.Limit
+import Mathlib.CategoryTheory.Limits.IsLimit
+import Mathlib.CategoryTheory.Category.Preorder
+
+/-
+# Continuity of functors from well ordered types
+
+Let `F : J ⥤ C` be functor from a well ordered type `J`.
+We introduce the typeclass `F.IsWellOrderContinuous`
+to say that if `m` is a limit element, then `F.obj m`
+is the colimit of the `F.obj j` for `j < m`.
+
+## TODO
+* use the API for initial segments in order to generalize some
+definitions in this file
+* given a morphism `f` in `C`, introduce a structure
+`TransfiniteCompositionOfShape J f` which contains the data
+of a continuous functor `F : J ⥤ C` and an identification
+of `f` to the map from `F.obj ⊥` to the colimit of `F`
+* redefine `MorphismProperty.transfiniteCompositionsOfShape`
+in terms of this structure `TransfiniteCompositionOfShape`
+
+-/
+
+universe w v u
+
+namespace CategoryTheory.Functor
+
+open Category Limits
+
+variable {C : Type u} [Category.{v} C]
+variable {J : Type w} [Preorder J]
+
+/-- Given a functor `F : J ⥤ C` and `m : J`, this is the induced
+functor `Set.Iio j ⥤ C`. -/
+@[simps!]
+def restrictionLT (F : J ⥤ C) (j : J) : Set.Iio j ⥤ C :=
+  Monotone.functor (f := fun k ↦ k.1) (fun _ _ ↦ id) ⋙ F
+
+/-- Given a functor `F : J ⥤ C` and `m : J`, this is the cocone with point `F.obj m`
+for the restriction of `F` to `Set.Iio m`. -/
+@[simps]
+def coconeLT (F : J ⥤ C) (m : J) :
+    Cocone (F.restrictionLT m) where
+  pt := F.obj m
+  ι :=
+    { app := fun ⟨i, hi⟩ ↦ F.map (homOfLE hi.le)
+      naturality := fun ⟨i₁, hi₁⟩ ⟨i₂, hi₂⟩ f ↦ by
+        dsimp
+        rw [← F.map_comp, comp_id]
+        rfl }
+
+/-- A functor `F : J ⥤ C` is well-order-continuous if for any limit element `m : J`,
+`F.obj m` identifies to the colimit of the `F.obj j` for `j < m`. -/
+class IsWellOrderContinuous (F : J ⥤ C) : Prop where
+  nonempty_isColimit (m : J) (hm : Order.IsSuccLimit m) :
+    Nonempty (IsColimit (F.coconeLT m))
+
+/-- If `F : J ⥤ C` is well-order-continuous and `m : J` is a limit element, then
+the cocone `F.coconeLT m` is colimit, i.e. `F.obj m` identifies to the colimit
+of the `F.obj j` for `j < m`. -/
+noncomputable def isColimitOfIsWellOrderContinuous (F : J ⥤ C) [F.IsWellOrderContinuous]
+    (m : J) (hm : Order.IsSuccLimit m) :
+    IsColimit (F.coconeLT m) := (IsWellOrderContinuous.nonempty_isColimit m hm).some
+
+instance (F : ℕ ⥤ C) : F.IsWellOrderContinuous where
+  nonempty_isColimit m hm := by simp at hm
+
+lemma isWellOrderContinuous_of_iso {F G : J ⥤ C} (e : F ≅ G) [F.IsWellOrderContinuous] :
+    G.IsWellOrderContinuous where
+  nonempty_isColimit (m : J) (hm : Order.IsSuccLimit m) :=
+    ⟨(IsColimit.precomposeHomEquiv (isoWhiskerLeft _ e) _).1
+      (IsColimit.ofIsoColimit (F.isColimitOfIsWellOrderContinuous m hm)
+        (Cocones.ext (e.app _)))⟩
+
+end CategoryTheory.Functor

--- a/Mathlib/CategoryTheory/Limits/Shapes/Preorder/WellOrderContinuous.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Preorder/WellOrderContinuous.lean
@@ -3,12 +3,13 @@ Copyright (c) 2024 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
+
 import Mathlib.Data.Nat.SuccPred
 import Mathlib.Order.SuccPred.Limit
 import Mathlib.CategoryTheory.Limits.IsLimit
 import Mathlib.CategoryTheory.Category.Preorder
 
-/-
+/-!
 # Continuity of functors from well ordered types
 
 Let `F : J ⥤ C` be functor from a well ordered type `J`.

--- a/Mathlib/CategoryTheory/Limits/Shapes/Preorder/WellOrderContinuous.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Preorder/WellOrderContinuous.lean
@@ -34,8 +34,7 @@ namespace CategoryTheory.Functor
 
 open Category Limits
 
-variable {C : Type u} [Category.{v} C]
-variable {J : Type w} [Preorder J]
+variable {C : Type u} [Category.{v} C] {J : Type w} [Preorder J]
 
 /-- Given a functor `F : J ⥤ C` and `m : J`, this is the induced
 functor `Set.Iio j ⥤ C`. -/

--- a/Mathlib/CategoryTheory/MorphismProperty/TransfiniteComposition.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/TransfiniteComposition.lean
@@ -3,11 +3,8 @@ Copyright (c) 2024 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-import Mathlib.Data.Nat.SuccPred
-import Mathlib.Order.SuccPred.Limit
-import Mathlib.CategoryTheory.Category.Preorder
-import Mathlib.CategoryTheory.Limits.IsLimit
 import Mathlib.CategoryTheory.MorphismProperty.Composition
+import Mathlib.CategoryTheory.Limits.Shapes.Preorder.WellOrderContinuous
 
 /-!
 # Classes of morphisms that are stable under transfinite composition
@@ -47,59 +44,10 @@ open Category Limits
 
 variable {C : Type u} [Category.{v} C]
 
-namespace Functor
-
-variable {J : Type w} [Preorder J]
-
-/-- Given a functor `F : J ⥤ C` and `m : J`, this is the induced
-functor `Set.Iio j ⥤ C`. -/
-@[simps!]
-def restrictionLT (F : J ⥤ C) (j : J) : Set.Iio j ⥤ C :=
-  Monotone.functor (f := fun k ↦ k.1) (fun _ _ ↦ id) ⋙ F
-
-/-- Given a functor `F : J ⥤ C` and `m : J`, this is the cocone with point `F.obj m`
-for the restriction of `F` to `Set.Iio m`. -/
-@[simps]
-def coconeLT (F : J ⥤ C) (m : J) :
-    Cocone (F.restrictionLT m) where
-  pt := F.obj m
-  ι :=
-    { app := fun ⟨i, hi⟩ ↦ F.map (homOfLE hi.le)
-      naturality := fun ⟨i₁, hi₁⟩ ⟨i₂, hi₂⟩ f ↦ by
-        dsimp
-        rw [← F.map_comp, comp_id]
-        rfl }
-
-/-- A functor `F : J ⥤ C` is well-order-continuous if for any limit element `m : J`,
-`F.obj m` identifies to the colimit of the `F.obj j` for `j < m`. -/
-class IsWellOrderContinuous (F : J ⥤ C) : Prop where
-  nonempty_isColimit (m : J) (hm : Order.IsSuccLimit m) :
-    Nonempty (IsColimit (F.coconeLT m))
-
-/-- If `F : J ⥤ C` is well-order-continuous and `m : J` is a limit element, then
-the cocone `F.coconeLT m` is colimit, i.e. `F.obj m` identifies to the colimit
-of the `F.obj j` for `j < m`. -/
-noncomputable def isColimitOfIsWellOrderContinuous (F : J ⥤ C) [F.IsWellOrderContinuous]
-    (m : J) (hm : Order.IsSuccLimit m) :
-    IsColimit (F.coconeLT m) := (IsWellOrderContinuous.nonempty_isColimit m hm).some
-
-instance (F : ℕ ⥤ C) : F.IsWellOrderContinuous where
-  nonempty_isColimit m hm := by simp at hm
-
-lemma isWellOrderContinuous_of_iso {F G : J ⥤ C} (e : F ≅ G) [F.IsWellOrderContinuous] :
-    G.IsWellOrderContinuous where
-  nonempty_isColimit (m : J) (hm : Order.IsSuccLimit m) :=
-    ⟨(IsColimit.precomposeHomEquiv (isoWhiskerLeft _ e) _).1
-      (IsColimit.ofIsoColimit (F.isColimitOfIsWellOrderContinuous m hm)
-        (Cocones.ext (e.app _)))⟩
-
-end Functor
-
 namespace MorphismProperty
 
 variable (W : MorphismProperty C)
 
--- for Basic.lean
 section
 
 variable (J : Type w) [LinearOrder J] [SuccOrder J] [OrderBot J]

--- a/Mathlib/CategoryTheory/SmallObject/TransfiniteCompositionLifting.lean
+++ b/Mathlib/CategoryTheory/SmallObject/TransfiniteCompositionLifting.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 import Mathlib.CategoryTheory.SmallObject.WellOrderInductionData
-import Mathlib.CategoryTheory.MorphismProperty.TransfiniteComposition
-import Mathlib.CategoryTheory.LiftingProperties.Basic
+import Mathlib.CategoryTheory.Limits.Shapes.Preorder.WellOrderContinuous
+import Mathlib.CategoryTheory.MorphismProperty.Basic
 
 /-!
 # The left lifting property is stable under transfinite composition

--- a/Mathlib/CategoryTheory/SmallObject/TransfiniteCompositionLifting.lean
+++ b/Mathlib/CategoryTheory/SmallObject/TransfiniteCompositionLifting.lean
@@ -5,7 +5,6 @@ Authors: Joël Riou
 -/
 import Mathlib.CategoryTheory.SmallObject.WellOrderInductionData
 import Mathlib.CategoryTheory.Limits.Shapes.Preorder.WellOrderContinuous
-import Mathlib.CategoryTheory.MorphismProperty.Basic
 
 /-!
 # The left lifting property is stable under transfinite composition
@@ -56,8 +55,7 @@ variable {C : Type u} [Category.{v} C]
 
 namespace HasLiftingProperty
 
-variable {W : MorphismProperty C}
-  {J : Type w} [LinearOrder J] [OrderBot J]
+variable {J : Type w} [LinearOrder J] [OrderBot J]
 
 namespace transfiniteComposition
 


### PR DESCRIPTION
The definition of `Functor.IsWellOrderContinuous` is moved to a better place `Limits.Shapes.Preorder.WellOrderContinuous` (see also #20335).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
