### PR TITLE
feat(MeasureTheory/Function): Add ContinuousLinearMap.bilinearCompLp(L)

### DIFF
--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -1296,13 +1296,9 @@ end MeasureTheory
 
 namespace ContinuousLinearMap
 
-variable {𝕜 D E F G : Type*} [NontriviallyNormedField 𝕜] [MeasurableSpace D]
-  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
-  [NormedAddCommGroup G] [NormedSpace 𝕜 G]
-  {p q r : ℝ≥0∞} {μ : Measure D}
-
-variable (L : E →L[𝕜] F →L[𝕜] G) (hpqr : p⁻¹ + q⁻¹ = r⁻¹)
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  [NormedSpace 𝕜 E] [NormedSpace 𝕜 F] [NormedSpace 𝕜 G]
+  {p q r : ℝ≥0∞} (L : E →L[𝕜] F →L[𝕜] G) (hpqr : p⁻¹ + q⁻¹ = r⁻¹)
 
 /-- Given `f` in `L^p` and `g` in `L^q`, the composition with a continuous bilinear map
 `fun x ↦ L (f x) (g x)` is in `L^r` where `r⁻¹ = p⁻¹ + q⁻¹`. -/
@@ -1327,7 +1323,7 @@ theorem nnnorm_bilinearCompLp_le (f : Lp E p μ) (g : Lp F q μ) :
   refine ENNReal.toNNReal_mono ?_ ?_
   · exact ENNReal.mul_ne_top ENNReal.coe_ne_top
       (ENNReal.mul_ne_top (Lp.eLpNorm_ne_top f) (Lp.eLpNorm_ne_top g))
-  · rw [eLpNorm_congr_ae (coeFn_bilinearCompLp _ _ _ _), ← mul_assoc]
+  · rw [eLpNorm_congr_ae (coeFn_bilinearCompLp L _ f g), ← mul_assoc]
     exact eLpNorm_le_eLpNorm_mul_eLpNorm'_of_norm' (Lp.aestronglyMeasurable f)
       (Lp.aestronglyMeasurable g) (L · ·) ‖L‖₊ (.of_forall fun x ↦ L.le_opNorm₂ (f x) (g x))
       (by simpa using hpqr.symm)
@@ -1335,10 +1331,10 @@ theorem nnnorm_bilinearCompLp_le (f : Lp E p μ) (g : Lp F q μ) :
 theorem norm_bilinearCompLp_le (f : Lp E p μ) (g : Lp F q μ) :
     ‖L.bilinearCompLp hpqr f g‖ ≤ ‖L‖ * ‖f‖ * ‖g‖ := L.nnnorm_bilinearCompLp_le hpqr f g
 
-variable (𝕜 μ) in
+variable (𝕜) in
 /-- Given `f` in `L^p` and `g` in `L^q`, obtain the composition with a continuous bilinear map
 `x ↦ L (f x) (g x)` in `L^r` as a bilinear map in `f` and `g`. -/
-def bilinearCompLpₗ : Lp E p μ →ₗ[𝕜] Lp F q μ →ₗ[𝕜] Lp G r μ :=
+def bilinearCompLpₗ (μ : Measure α := by volume_tac) : Lp E p μ →ₗ[𝕜] Lp F q μ →ₗ[𝕜] Lp G r μ :=
   LinearMap.mk₂ 𝕜 (L.bilinearCompLp hpqr)
     (fun f₁ f₂ g ↦ by
       ext
@@ -1367,42 +1363,42 @@ def bilinearCompLpₗ : Lp E p μ →ₗ[𝕜] Lp F q μ →ₗ[𝕜] Lp G r μ 
         with a ha1 ha2 ha3 ha4
       simp only [ha1, ha2, ha3, ha4, Pi.smul_apply, ContinuousLinearMap.map_smul])
 
-variable (𝕜 μ) in
+variable (𝕜) in
 /-- Given `f` in `L^p` and `g` in `L^q`, obtain the composition with a continuous bilinear map
 `x ↦ L (f x) (g x)` in `L^r` as a continuous bilinear map in `f` and `g`. -/
-def bilinearCompLpL [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)] :
+def bilinearCompLpL (μ : Measure α := by volume_tac) [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)] :
     Lp E p μ →L[𝕜] Lp F q μ →L[𝕜] Lp G r μ :=
-  (L.bilinearCompLpₗ 𝕜 μ hpqr).mkContinuous₂ ‖L‖ (L.norm_bilinearCompLp_le hpqr)
+  (L.bilinearCompLpₗ 𝕜 hpqr μ).mkContinuous₂ ‖L‖ (L.norm_bilinearCompLp_le hpqr)
 
 theorem coeFn_bilinearCompLpₗ (f : Lp E p μ) (g : Lp F q μ) :
-    L.bilinearCompLpₗ 𝕜 μ hpqr f g =ᵐ[μ] fun x ↦ L (f x) (g x) := L.coeFn_bilinearCompLp hpqr f g
+    L.bilinearCompLpₗ 𝕜 hpqr μ f g =ᵐ[μ] fun x ↦ L (f x) (g x) := L.coeFn_bilinearCompLp hpqr f g
 
 theorem coeFn_bilinearCompLpL [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)] (f : Lp E p μ)
-    (g : Lp F q μ) : L.bilinearCompLpL 𝕜 μ hpqr f g =ᵐ[μ] fun x ↦ L (f x) (g x) :=
+    (g : Lp F q μ) : L.bilinearCompLpL 𝕜 hpqr μ f g =ᵐ[μ] fun x ↦ L (f x) (g x) :=
   L.coeFn_bilinearCompLp hpqr f g
 
 theorem norm_bilinearCompLpL_le [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)] :
-    ‖L.bilinearCompLpL 𝕜 μ hpqr‖ ≤ ‖L‖ :=
+    ‖L.bilinearCompLpL 𝕜 hpqr μ‖ ≤ ‖L‖ :=
   LinearMap.mkContinuous₂_norm_le _ (norm_nonneg L) (L.norm_bilinearCompLp_le hpqr)
 
 variable (𝕜) in
 /-- Bilinear composition `L (f x) (g x)` as a continuous linear map in `g`, with `f` constant.
 Does not inherit `noncomputable` from `LinearMap.mkContinuous₂`. -/
 def bilinearRightLpL [Fact (1 ≤ q)] [Fact (1 ≤ r)] (f : Lp E p μ) : Lp F q μ →L[𝕜] Lp G r μ :=
-  (L.bilinearCompLpₗ 𝕜 μ hpqr f).mkContinuous (‖L‖ * ‖f‖) (L.norm_bilinearCompLp_le hpqr f)
+  (L.bilinearCompLpₗ 𝕜 hpqr μ f).mkContinuous (‖L‖ * ‖f‖) (L.norm_bilinearCompLp_le hpqr f)
 
 variable (𝕜) in
 /-- Bilinear composition `L (f x) (g x)` as a continuous linear map in `f`, with `g` constant.
 Does not inherit `noncomputable` from `LinearMap.mkContinuous₂`. -/
 def bilinearLeftLpL [Fact (1 ≤ p)] [Fact (1 ≤ r)] (g : Lp F q μ) : Lp E p μ →L[𝕜] Lp G r μ :=
-  ((L.bilinearCompLpₗ 𝕜 μ hpqr).flip g).mkContinuous (‖L‖ * ‖g‖) fun f ↦
+  ((L.bilinearCompLpₗ 𝕜 hpqr μ).flip g).mkContinuous (‖L‖ * ‖g‖) fun f ↦
     (L.norm_bilinearCompLp_le hpqr f g).trans_eq (mul_right_comm _ _ _)
 
 theorem bilinearRightLpL_eq_bilinearCompLpL_apply [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)]
-    (f : Lp E p μ): L.bilinearRightLpL 𝕜 hpqr f = L.bilinearCompLpL 𝕜 μ hpqr f := rfl
+    (f : Lp E p μ): L.bilinearRightLpL 𝕜 hpqr f = L.bilinearCompLpL 𝕜 hpqr μ f := rfl
 
 theorem bilinearLeftLpL_eq_bilinearCompLpL_flip_apply [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)]
-    (g : Lp F q μ) : L.bilinearLeftLpL 𝕜 hpqr g = (L.bilinearCompLpL 𝕜 μ hpqr).flip g := rfl
+    (g : Lp F q μ) : L.bilinearLeftLpL 𝕜 hpqr g = (L.bilinearCompLpL 𝕜 hpqr μ).flip g := rfl
 
 theorem coeFn_bilinearRightLpL [Fact (1 ≤ q)] [Fact (1 ≤ r)] (f : Lp E p μ) (g : Lp F q μ) :
     L.bilinearRightLpL 𝕜 hpqr f g =ᵐ[μ] fun x ↦ L (f x) (g x) := L.coeFn_bilinearCompLp hpqr f g

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne, Sébastien Gouëzel
 -/
 import Mathlib.Analysis.Normed.Group.Hom
+import Mathlib.Analysis.Normed.Operator.BoundedLinearMaps
 import Mathlib.Analysis.NormedSpace.IndicatorFunction
 import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
 import Mathlib.Data.Set.Image
@@ -1290,6 +1291,134 @@ end PosPart
 end Lp
 
 end MeasureTheory
+
+/-! ### Composition of a bilinear map with `L^p` and `L^q` -/
+
+namespace ContinuousLinearMap
+
+variable {𝕜 D E F G : Type*} [NontriviallyNormedField 𝕜] [MeasurableSpace D]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  [NormedAddCommGroup G] [NormedSpace 𝕜 G]
+  {p q r : ℝ≥0∞} {μ : Measure D}
+
+variable (L : E →L[𝕜] F →L[𝕜] G) (hpqr : p⁻¹ + q⁻¹ = r⁻¹)
+
+/-- Given `f` in `L^p` and `g` in `L^q`, the composition with a continuous bilinear map
+`fun x ↦ L (f x) (g x)` is in `L^r` where `r⁻¹ = p⁻¹ + q⁻¹`. -/
+def bilinearCompLp (f : Lp E p μ) (g : Lp F q μ) : Lp G r μ :=
+  ⟨AEEqFun.comp₂ _ L.continuous₂ f g, by
+    refine Lp.mem_Lp_iff_eLpNorm_lt_top.mpr ?_
+    rw [eLpNorm_congr_ae (AEEqFun.coeFn_comp₂ _ L.continuous₂ f.val g.val)]
+    refine lt_of_le_of_lt (eLpNorm_le_eLpNorm_mul_eLpNorm'_of_norm' (Lp.aestronglyMeasurable f)
+      (Lp.aestronglyMeasurable g) (L · ·) ‖L‖₊ (.of_forall fun x ↦ L.le_opNorm₂ (f x) (g x))
+      (by simpa using hpqr.symm)) ?_
+    exact ENNReal.mul_lt_top (ENNReal.mul_lt_top ENNReal.coe_lt_top (Lp.eLpNorm_lt_top f))
+      (Lp.eLpNorm_lt_top g)⟩
+
+theorem coeFn_bilinearCompLp (f : Lp E p μ) (g : Lp F q μ) :
+    L.bilinearCompLp hpqr f g =ᵐ[μ] fun x ↦ L (f x) (g x) :=
+  AEEqFun.coeFn_comp₂ _ L.continuous₂ f.val g.val
+
+theorem nnnorm_bilinearCompLp_le (f : Lp E p μ) (g : Lp F q μ) :
+    ‖L.bilinearCompLp hpqr f g‖₊ ≤ ‖L‖₊ * ‖f‖₊ * ‖g‖₊ := by
+  simp only [Lp.nnnorm_def]
+  rw [mul_assoc, ← ENNReal.toNNReal_mul, ← ENNReal.smul_toNNReal, ENNReal.smul_def, smul_eq_mul]
+  refine ENNReal.toNNReal_mono ?_ ?_
+  · exact ENNReal.mul_ne_top ENNReal.coe_ne_top
+      (ENNReal.mul_ne_top (Lp.eLpNorm_ne_top f) (Lp.eLpNorm_ne_top g))
+  · rw [eLpNorm_congr_ae (coeFn_bilinearCompLp _ _ _ _), ← mul_assoc]
+    exact eLpNorm_le_eLpNorm_mul_eLpNorm'_of_norm' (Lp.aestronglyMeasurable f)
+      (Lp.aestronglyMeasurable g) (L · ·) ‖L‖₊ (.of_forall fun x ↦ L.le_opNorm₂ (f x) (g x))
+      (by simpa using hpqr.symm)
+
+theorem norm_bilinearCompLp_le (f : Lp E p μ) (g : Lp F q μ) :
+    ‖L.bilinearCompLp hpqr f g‖ ≤ ‖L‖ * ‖f‖ * ‖g‖ := L.nnnorm_bilinearCompLp_le hpqr f g
+
+variable (𝕜 μ) in
+/-- Given `f` in `L^p` and `g` in `L^q`, obtain the composition with a continuous bilinear map
+`x ↦ L (f x) (g x)` in `L^r` as a bilinear map in `f` and `g`. -/
+def bilinearCompLpₗ : Lp E p μ →ₗ[𝕜] Lp F q μ →ₗ[𝕜] Lp G r μ :=
+  LinearMap.mk₂ 𝕜 (L.bilinearCompLp hpqr)
+    (fun f₁ f₂ g ↦ by
+      ext
+      filter_upwards [Lp.coeFn_add f₁ f₂,
+        Lp.coeFn_add (L.bilinearCompLp hpqr f₁ g) (L.bilinearCompLp hpqr f₂ g),
+        L.coeFn_bilinearCompLp hpqr f₁ g, L.coeFn_bilinearCompLp hpqr f₂ g,
+        L.coeFn_bilinearCompLp hpqr (f₁ + f₂) g] with a ha1 ha2 ha3 ha4 ha5
+      simp only [ha1, ha2, ha3, ha4, ha5, Pi.add_apply, ContinuousLinearMap.map_add₂])
+    (fun c f g ↦ by
+      ext
+      filter_upwards [Lp.coeFn_smul c f, Lp.coeFn_smul c (L.bilinearCompLp hpqr f g),
+        L.coeFn_bilinearCompLp hpqr f g, L.coeFn_bilinearCompLp hpqr (c • f) g]
+        with a ha1 ha2 ha3 ha4
+      simp only [ha1, ha2, ha3, ha4, Pi.smul_apply, ContinuousLinearMap.map_smul₂])
+    (fun f g₁ g₂ ↦ by
+      ext
+      filter_upwards [Lp.coeFn_add g₁ g₂,
+        Lp.coeFn_add (L.bilinearCompLp hpqr f g₁) (L.bilinearCompLp hpqr f g₂),
+        L.coeFn_bilinearCompLp hpqr f g₁, L.coeFn_bilinearCompLp hpqr f g₂,
+        L.coeFn_bilinearCompLp hpqr f (g₁ + g₂)] with a ha1 ha2 ha3 ha4 ha5
+      simp only [ha1, ha2, ha3, ha4, ha5, Pi.add_apply, ContinuousLinearMap.map_add])
+    (fun c f g ↦ by
+      ext
+      filter_upwards [Lp.coeFn_smul c g, Lp.coeFn_smul c (L.bilinearCompLp hpqr f g),
+        L.coeFn_bilinearCompLp hpqr f g, L.coeFn_bilinearCompLp hpqr f (c • g)]
+        with a ha1 ha2 ha3 ha4
+      simp only [ha1, ha2, ha3, ha4, Pi.smul_apply, ContinuousLinearMap.map_smul])
+
+variable (𝕜 μ) in
+/-- Given `f` in `L^p` and `g` in `L^q`, obtain the composition with a continuous bilinear map
+`x ↦ L (f x) (g x)` in `L^r` as a continuous bilinear map in `f` and `g`. -/
+def bilinearCompLpL [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)] :
+    Lp E p μ →L[𝕜] Lp F q μ →L[𝕜] Lp G r μ :=
+  (L.bilinearCompLpₗ 𝕜 μ hpqr).mkContinuous₂ ‖L‖ (L.norm_bilinearCompLp_le hpqr)
+
+theorem coeFn_bilinearCompLpₗ (f : Lp E p μ) (g : Lp F q μ) :
+    L.bilinearCompLpₗ 𝕜 μ hpqr f g =ᵐ[μ] fun x ↦ L (f x) (g x) := L.coeFn_bilinearCompLp hpqr f g
+
+theorem coeFn_bilinearCompLpL [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)] (f : Lp E p μ)
+    (g : Lp F q μ) : L.bilinearCompLpL 𝕜 μ hpqr f g =ᵐ[μ] fun x ↦ L (f x) (g x) :=
+  L.coeFn_bilinearCompLp hpqr f g
+
+theorem norm_bilinearCompLpL_le [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)] :
+    ‖L.bilinearCompLpL 𝕜 μ hpqr‖ ≤ ‖L‖ :=
+  LinearMap.mkContinuous₂_norm_le _ (norm_nonneg L) (L.norm_bilinearCompLp_le hpqr)
+
+variable (𝕜) in
+/-- Bilinear composition `L (f x) (g x)` as a continuous linear map in `g`, with `f` constant.
+Does not inherit `noncomputable` from `LinearMap.mkContinuous₂`. -/
+def bilinearRightLpL [Fact (1 ≤ q)] [Fact (1 ≤ r)] (f : Lp E p μ) : Lp F q μ →L[𝕜] Lp G r μ :=
+  (L.bilinearCompLpₗ 𝕜 μ hpqr f).mkContinuous (‖L‖ * ‖f‖) (L.norm_bilinearCompLp_le hpqr f)
+
+variable (𝕜) in
+/-- Bilinear composition `L (f x) (g x)` as a continuous linear map in `f`, with `g` constant.
+Does not inherit `noncomputable` from `LinearMap.mkContinuous₂`. -/
+def bilinearLeftLpL [Fact (1 ≤ p)] [Fact (1 ≤ r)] (g : Lp F q μ) : Lp E p μ →L[𝕜] Lp G r μ :=
+  ((L.bilinearCompLpₗ 𝕜 μ hpqr).flip g).mkContinuous (‖L‖ * ‖g‖) fun f ↦
+    (L.norm_bilinearCompLp_le hpqr f g).trans_eq (mul_right_comm _ _ _)
+
+theorem bilinearRightLpL_eq_bilinearCompLpL_apply [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)]
+    (f : Lp E p μ): L.bilinearRightLpL 𝕜 hpqr f = L.bilinearCompLpL 𝕜 μ hpqr f := rfl
+
+theorem bilinearLeftLpL_eq_bilinearCompLpL_flip_apply [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)]
+    (g : Lp F q μ) : L.bilinearLeftLpL 𝕜 hpqr g = (L.bilinearCompLpL 𝕜 μ hpqr).flip g := rfl
+
+theorem coeFn_bilinearRightLpL [Fact (1 ≤ q)] [Fact (1 ≤ r)] (f : Lp E p μ) (g : Lp F q μ) :
+    L.bilinearRightLpL 𝕜 hpqr f g =ᵐ[μ] fun x ↦ L (f x) (g x) := L.coeFn_bilinearCompLp hpqr f g
+
+theorem coeFn_bilinearLeftLpL [Fact (1 ≤ p)] [Fact (1 ≤ r)] (f : Lp E p μ) (g : Lp F q μ) :
+    L.bilinearLeftLpL 𝕜 hpqr g f =ᵐ[μ] fun x ↦ L (f x) (g x) := L.coeFn_bilinearCompLp hpqr f g
+
+theorem norm_bilinearRightLpL_le [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)] (f : Lp E p μ) :
+    ‖L.bilinearRightLpL 𝕜 hpqr f‖ ≤ ‖L‖ * ‖f‖ :=
+  LinearMap.mkContinuous_norm_le _ (mul_nonneg (norm_nonneg L) (norm_nonneg f)) _
+
+theorem norm_bilinearLeftLpL_le [Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)] (g : Lp F q μ) :
+    ‖L.bilinearLeftLpL 𝕜 hpqr g‖ ≤ ‖L‖ * ‖g‖ :=
+  LinearMap.mkContinuous_norm_le _ (mul_nonneg (norm_nonneg L) (norm_nonneg g)) _
+
+end ContinuousLinearMap
 
 end Composition
 


### PR DESCRIPTION
Introduce ContinuousLinearMap.bilinearCompLp and bilinearCompLpL.
Generalize eLpNorm_le_eLpNorm_mul_eLpNorm theorems to include constant C in bound condition.

---

Expect this may be useful for defining tempered distributions from functions in `L^p`.

The definitions more or less follow `ContinuousLinearMap.compLp...`. Names are loosely analogous to `ContinuousLinearMap.bilinearComp` and `SchwartzMap.bilinLeftCLM`.

Note: I preferred the spelling `hpqr : p⁻¹ + q⁻¹ = r⁻¹` with `f` in `L^p` and `g` in `L^q` to `hpqr : 1 / p = 1 / q + 1 / r`. It's easier to obtain from `ENNReal.IsConjExponent` too.

A few questions:
- [ ] I defined `bilinear{Left,Right}LpL` in addition to `bilinearCompLpL` because `LinearMap.mkContinuous₂` is marked as `noncomputable` and `LinearMap.mkContinuous` is not. Is this worth the extra definitions? (Note: This is not visible in the source due to `noncomputable section`.)
- [ ] Should I use `C : ℝ` instead of `C : NNReal` for `eLpNorm_le_eLpNorm_mul_eLpNorm'_of_norm'`?
- [ ] Is it going to be painful to have `[Fact (1 ≤ p)] [Fact (1 ≤ q)] [Fact (1 ≤ r)]`? I don't think there's a way to avoid it though. Maybe providing specialized versions for `p.IsConjExponent q` with `L^1`?

Naming:
- [ ] Is it satisfactory to add a `'` to the `eLpNorm_le_eLpNorm_mul_eLpNorm ` definitions in `CompareExp.lean` where `≤ ‖f x‖ * ‖g x‖` has been replaced with `≤ C * ‖f x‖ * ‖g x‖`? These could replace the existing theorems, although I don't want to break backwards compatibility. There are 5 instances: `eLpNorm_le_eLpNorm_top_mul_eLpNorm'`, `eLpNorm_le_eLpNorm_mul_eLpNorm_top'`, `eLpNorm'_le_eLpNorm'_mul_eLpNorm''`, `eLpNorm_le_eLpNorm_mul_eLpNorm_of_nnnorm'`, `eLpNorm_le_eLpNorm_mul_eLpNorm'_of_norm'` (I'm not sure why the existing theorem `eLpNorm_le_eLpNorm_mul_eLpNorm'_of_norm` has an internal `'`)
- [ ] Is `bilinearLeftLpL` a suitable name? Other options: `bilinearCompLpLeftL`, `bilinearCompLeftLpL`, `bilinLeftLpL` (analogous to `SchwartzMap.bilinLeftCLM`)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
