### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Adjunction/Opposites): redefine the opposite of an adjunction

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -31,7 +31,7 @@ attribute [local simp] homEquiv_unit homEquiv_counit
 
 /-- If `G.op` is adjoint to `F.op` then `F` is adjoint to `G`. -/
 @[simps]
-def unop (F : C ⥤ D) (G : D ⥤ C) (h : G.op ⊣ F.op) : F ⊣ G where
+def unop {F : Cᵒᵖ ⥤ Dᵒᵖ} {G : Dᵒᵖ ⥤ Cᵒᵖ} (h : G ⊣ F) : F.unop ⊣ G.unop where
   unit := NatTrans.unop h.counit
   counit := NatTrans.unop h.unit
   left_triangle_components _ := Quiver.Hom.op_inj (h.right_triangle_components _)

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -38,46 +38,22 @@ def unop {F : Cᵒᵖ ⥤ Dᵒᵖ} {G : Dᵒᵖ ⥤ Cᵒᵖ} (h : G ⊣ F) : F.u
   right_triangle_components _ := Quiver.Hom.op_inj (h.left_triangle_components _)
 
 @[deprecated (since := "2025-01-01")] alias adjointOfOpAdjointOp := unop
-
-/-- If `G` is adjoint to `F.op` then `F` is adjoint to `G.unop`. -/
-@[deprecated "Use Adjunction.unop instead." (since := "2025-01-01")]
-def adjointUnopOfAdjointOp (F : C ⥤ D) (G : Dᵒᵖ ⥤ Cᵒᵖ) (h : G ⊣ F.op) : F ⊣ G.unop :=
-  unop F G.unop (h.ofNatIsoLeft G.opUnopIso.symm)
-
-/-- If `G.op` is adjoint to `F` then `F.unop` is adjoint to `G`. -/
-@[deprecated "Use Adjunction.unop instead." (since := "2025-01-01")]
-def unopAdjointOfOpAdjoint (F : Cᵒᵖ ⥤ Dᵒᵖ) (G : D ⥤ C) (h : G.op ⊣ F) : F.unop ⊣ G :=
-  unop _ _ (h.ofNatIsoRight F.opUnopIso.symm)
-
-/-- If `G` is adjoint to `F` then `F.unop` is adjoint to `G.unop`. -/
-@[deprecated "Use Adjunction.unop instead." (since := "2025-01-01")]
-def unopAdjointUnopOfAdjoint (F : Cᵒᵖ ⥤ Dᵒᵖ) (G : Dᵒᵖ ⥤ Cᵒᵖ) (h : G ⊣ F) : F.unop ⊣ G.unop :=
-  unop F.unop G.unop (h.ofNatIsoRight F.opUnopIso.symm)
+@[deprecated (since := "2025-01-01")] alias adjointUnopOfAdjointOp := unop
+@[deprecated (since := "2025-01-01")] alias unopAdjointOfOpAdjoint := unop
+@[deprecated (since := "2025-01-01")] alias unopAdjointUnopOfAdjoint := unop
 
 /-- If `G` is adjoint to `F` then `F.op` is adjoint to `G.op`. -/
 @[simps]
-def op (F : C ⥤ D) (G : D ⥤ C) (h : G ⊣ F) : F.op ⊣ G.op where
+def op {F : C ⥤ D} {G : D ⥤ C} (h : G ⊣ F) : F.op ⊣ G.op where
   unit := NatTrans.op h.counit
   counit := NatTrans.op h.unit
   left_triangle_components _ := Quiver.Hom.unop_inj (by simp)
   right_triangle_components _ := Quiver.Hom.unop_inj (by simp)
 
 @[deprecated (since := "2025-01-01")] alias opAdjointOpOfAdjoint := op
-
-/-- If `G` is adjoint to `F.unop` then `F` is adjoint to `G.op`. -/
-@[deprecated "Use Adjunction.op instead." (since := "2025-01-01")]
-def adjointOpOfAdjointUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) (G : D ⥤ C) (h : G ⊣ F.unop) : F ⊣ G.op :=
-  (op F.unop _ h).ofNatIsoLeft F.opUnopIso
-
-/-- If `G.unop` is adjoint to `F` then `F.op` is adjoint to `G`. -/
-@[deprecated "Use Adjunction.op instead." (since := "2025-01-01")]
-def opAdjointOfUnopAdjoint (F : C ⥤ D) (G : Dᵒᵖ ⥤ Cᵒᵖ) (h : G.unop ⊣ F) : F.op ⊣ G :=
-  (op _ G.unop h).ofNatIsoRight G.opUnopIso
-
-/-- If `G.unop` is adjoint to `F.unop` then `F` is adjoint to `G`. -/
-@[deprecated "Use Adjunction.op instead." (since := "2025-01-01")]
-def adjointOfUnopAdjointUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) (G : Dᵒᵖ ⥤ Cᵒᵖ) (h : G.unop ⊣ F.unop) : F ⊣ G :=
-  (op _ _ h).ofNatIsoRight G.opUnopIso
+@[deprecated (since := "2025-01-01")] alias adjointOpOfAdjointUnop := op
+@[deprecated (since := "2025-01-01")] alias opAdjointOfUnopAdjoint := op
+@[deprecated (since := "2025-01-01")] alias adjointOfUnopAdjointUnop := op
 
 /-- If `F` and `F'` are both adjoint to `G`, there is a natural isomorphism
 `F.op ⋙ coyoneda ≅ F'.op ⋙ coyoneda`.

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -29,7 +29,7 @@ namespace CategoryTheory.Adjunction
 
 attribute [local simp] homEquiv_unit homEquiv_counit
 
-/-- If `G.op` is adjoint to `F.op` then `F` is adjoint to `G`. -/
+/-- If `G` is adjoint to `F` then `F.unop` is adjoint to `G.unop`. -/
 @[simps]
 def unop {F : Cᵒᵖ ⥤ Dᵒᵖ} {G : Dᵒᵖ ⥤ Cᵒᵖ} (h : G ⊣ F) : F.unop ⊣ G.unop where
   unit := NatTrans.unop h.counit

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -30,7 +30,7 @@ namespace CategoryTheory.Adjunction
 attribute [local simp] homEquiv_unit homEquiv_counit
 
 /-- If `G.op` is adjoint to `F.op` then `F` is adjoint to `G`. -/
-@[simps! unit_app counit_app]
+@[simps]
 def unop (F : C ⥤ D) (G : D ⥤ C) (h : G.op ⊣ F.op) : F ⊣ G where
   unit := NatTrans.unop h.counit
   counit := NatTrans.unop h.unit

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -31,64 +31,53 @@ attribute [local simp] homEquiv_unit homEquiv_counit
 
 /-- If `G.op` is adjoint to `F.op` then `F` is adjoint to `G`. -/
 @[simps! unit_app counit_app]
-def adjointOfOpAdjointOp (F : C ⥤ D) (G : D ⥤ C) (h : G.op ⊣ F.op) : F ⊣ G :=
-  Adjunction.mkOfHomEquiv {
-    homEquiv := fun {X Y} =>
-      ((h.homEquiv (Opposite.op Y) (Opposite.op X)).trans (opEquiv _ _)).symm.trans
-        (opEquiv _ _)
-    homEquiv_naturality_left_symm := by
-      -- Porting note: This proof was handled by `obviously` in mathlib3. The only obstruction to
-      -- automation fully kicking in here is that the `@[simps]` lemmas of `opEquiv` and
-      -- `homEquiv` aren't firing.
-      intros
-      simp [opEquiv, homEquiv]
-    homEquiv_naturality_right := by
-      -- Porting note: This proof was handled by `obviously` in mathlib3. The only obstruction to
-      -- automation fully kicking in here is that the `@[simps]` lemmas of `opEquiv` and
-      -- `homEquiv` aren't firing.
-      intros
-      simp [opEquiv, homEquiv] }
+def unop (F : C ⥤ D) (G : D ⥤ C) (h : G.op ⊣ F.op) : F ⊣ G where
+  unit := NatTrans.unop h.counit
+  counit := NatTrans.unop h.unit
+  left_triangle_components _ := Quiver.Hom.op_inj (h.right_triangle_components _)
+  right_triangle_components _ := Quiver.Hom.op_inj (h.left_triangle_components _)
+
+@[deprecated (since := "2025-01-01")] alias adjointOfOpAdjointOp := unop
 
 /-- If `G` is adjoint to `F.op` then `F` is adjoint to `G.unop`. -/
+@[deprecated "Use Adjunction.unop instead." (since := "2025-01-01")]
 def adjointUnopOfAdjointOp (F : C ⥤ D) (G : Dᵒᵖ ⥤ Cᵒᵖ) (h : G ⊣ F.op) : F ⊣ G.unop :=
-  adjointOfOpAdjointOp F G.unop (h.ofNatIsoLeft G.opUnopIso.symm)
+  unop F G.unop (h.ofNatIsoLeft G.opUnopIso.symm)
 
 /-- If `G.op` is adjoint to `F` then `F.unop` is adjoint to `G`. -/
+@[deprecated "Use Adjunction.unop instead." (since := "2025-01-01")]
 def unopAdjointOfOpAdjoint (F : Cᵒᵖ ⥤ Dᵒᵖ) (G : D ⥤ C) (h : G.op ⊣ F) : F.unop ⊣ G :=
-  adjointOfOpAdjointOp _ _ (h.ofNatIsoRight F.opUnopIso.symm)
+  unop _ _ (h.ofNatIsoRight F.opUnopIso.symm)
 
 /-- If `G` is adjoint to `F` then `F.unop` is adjoint to `G.unop`. -/
+@[deprecated "Use Adjunction.unop instead." (since := "2025-01-01")]
 def unopAdjointUnopOfAdjoint (F : Cᵒᵖ ⥤ Dᵒᵖ) (G : Dᵒᵖ ⥤ Cᵒᵖ) (h : G ⊣ F) : F.unop ⊣ G.unop :=
-  adjointUnopOfAdjointOp F.unop G (h.ofNatIsoRight F.opUnopIso.symm)
+  unop F.unop G.unop (h.ofNatIsoRight F.opUnopIso.symm)
 
 /-- If `G` is adjoint to `F` then `F.op` is adjoint to `G.op`. -/
 @[simps! unit_app counit_app]
-def opAdjointOpOfAdjoint (F : C ⥤ D) (G : D ⥤ C) (h : G ⊣ F) : F.op ⊣ G.op :=
-  Adjunction.mkOfHomEquiv {
-    homEquiv := fun X Y =>
-      (opEquiv _ Y).trans ((h.homEquiv _ _).symm.trans (opEquiv X (Opposite.op _)).symm)
-    homEquiv_naturality_left_symm := by
-      -- Porting note: This proof was handled by `obviously` in mathlib3. The only obstruction to
-      -- automation fully kicking in here is that the `@[simps]` lemmas of `opEquiv` aren't firing.
-      intros
-      simp [opEquiv]
-    homEquiv_naturality_right := by
-      -- Porting note: This proof was handled by `obviously` in mathlib3. The only obstruction to
-      -- automation fully kicking in here is that the `@[simps]` lemmas of `opEquiv` aren't firing.
-      intros
-      simp [opEquiv] }
+def op (F : C ⥤ D) (G : D ⥤ C) (h : G ⊣ F) : F.op ⊣ G.op where
+  unit := NatTrans.op h.counit
+  counit := NatTrans.op h.unit
+  left_triangle_components _ := Quiver.Hom.unop_inj (by simp)
+  right_triangle_components _ := Quiver.Hom.unop_inj (by simp)
+
+@[deprecated (since := "2025-01-01")] alias opAdjointOpOfAdjoint := op
 
 /-- If `G` is adjoint to `F.unop` then `F` is adjoint to `G.op`. -/
+@[deprecated "Use Adjunction.op instead." (since := "2025-01-01")]
 def adjointOpOfAdjointUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) (G : D ⥤ C) (h : G ⊣ F.unop) : F ⊣ G.op :=
-  (opAdjointOpOfAdjoint F.unop _ h).ofNatIsoLeft F.opUnopIso
+  (op F.unop _ h).ofNatIsoLeft F.opUnopIso
 
 /-- If `G.unop` is adjoint to `F` then `F.op` is adjoint to `G`. -/
+@[deprecated "Use Adjunction.op instead." (since := "2025-01-01")]
 def opAdjointOfUnopAdjoint (F : C ⥤ D) (G : Dᵒᵖ ⥤ Cᵒᵖ) (h : G.unop ⊣ F) : F.op ⊣ G :=
-  (opAdjointOpOfAdjoint _ G.unop h).ofNatIsoRight G.opUnopIso
+  (op _ G.unop h).ofNatIsoRight G.opUnopIso
 
 /-- If `G.unop` is adjoint to `F.unop` then `F` is adjoint to `G`. -/
+@[deprecated "Use Adjunction.op instead." (since := "2025-01-01")]
 def adjointOfUnopAdjointUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) (G : Dᵒᵖ ⥤ Cᵒᵖ) (h : G.unop ⊣ F.unop) : F ⊣ G :=
-  (adjointOpOfAdjointUnop _ _ h).ofNatIsoRight G.opUnopIso
+  (op _ _ h).ofNatIsoRight G.opUnopIso
 
 /-- If `F` and `F'` are both adjoint to `G`, there is a natural isomorphism
 `F.op ⋙ coyoneda ≅ F'.op ⋙ coyoneda`.
@@ -119,7 +108,7 @@ Note: it is generally better to use `Adjunction.natIsoEquiv`, see the file `Adju
 -/
 def natIsoOfLeftAdjointNatIso {F F' : C ⥤ D} {G G' : D ⥤ C}
     (adj1 : F ⊣ G) (adj2 : F' ⊣ G') (l : F ≅ F') : G ≅ G' :=
-  NatIso.removeOp (natIsoOfRightAdjointNatIso (opAdjointOpOfAdjoint _ F' adj2)
-    (opAdjointOpOfAdjoint _ _ adj1) (NatIso.op l))
+  NatIso.removeOp (natIsoOfRightAdjointNatIso (op _ F' adj2)
+    (op _ _ adj1) (NatIso.op l))
 
 end CategoryTheory.Adjunction

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -84,7 +84,6 @@ Note: it is generally better to use `Adjunction.natIsoEquiv`, see the file `Adju
 -/
 def natIsoOfLeftAdjointNatIso {F F' : C ⥤ D} {G G' : D ⥤ C}
     (adj1 : F ⊣ G) (adj2 : F' ⊣ G') (l : F ≅ F') : G ≅ G' :=
-  NatIso.removeOp (natIsoOfRightAdjointNatIso (op _ F' adj2)
-    (op _ _ adj1) (NatIso.op l))
+  NatIso.removeOp (natIsoOfRightAdjointNatIso (op adj2) (op adj1) (NatIso.op l))
 
 end CategoryTheory.Adjunction

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -55,7 +55,7 @@ def unopAdjointUnopOfAdjoint (F : Cᵒᵖ ⥤ Dᵒᵖ) (G : Dᵒᵖ ⥤ Cᵒᵖ)
   unop F.unop G.unop (h.ofNatIsoRight F.opUnopIso.symm)
 
 /-- If `G` is adjoint to `F` then `F.op` is adjoint to `G.op`. -/
-@[simps! unit_app counit_app]
+@[simps]
 def op (F : C ⥤ D) (G : D ⥤ C) (h : G ⊣ F) : F.op ⊣ G.op where
   unit := NatTrans.op h.counit
   counit := NatTrans.op h.unit


### PR DESCRIPTION
Change the definition of `Adjunction.adjointOfOpAdjointOp` and `Adjunction.opAdjointOpOfAdjoint` to be more in line with the new definition of adjunctions from #16317 (which removes the `homEquiv` field), and rename these to `Adjunction.op` and `Adjunction.unop` to be consistent with `Equivalence.op` and `Equivalence.unop`. The 6 other variants of opposite adjunctions are all defined from `Adjunction.op` or `Adjunction.unop` and should not be needed anymore, they have been marked as `deprecated`, as well as `Adjunction.adjointOfOpAdjointOp` and `Adjunction.opAdjointOpOfAdjoint`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
