### PR TITLE
chore(Analysis/Normed/Lp/ProdLp): Add WithLp.fst and -.snd to avoid defeq abuse

### DIFF
--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -53,7 +53,10 @@ variable {p 𝕜 α β}
 variable [Semiring 𝕜] [AddCommGroup α] [AddCommGroup β]
 variable (x y : WithLp p (α × β)) (c : 𝕜)
 
+/-- `Prod.fst` lifted to `WithLp` -/
 protected def fst : α := (WithLp.equiv p (α × β) x).fst
+
+/-- `Prod.snd` lifted to `WithLp` -/
 protected def snd : β := (WithLp.equiv p (α × β) x).snd
 
 @[simp]

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -53,6 +53,9 @@ variable {p 𝕜 α β}
 variable [Semiring 𝕜] [AddCommGroup α] [AddCommGroup β]
 variable (x y : WithLp p (α × β)) (c : 𝕜)
 
+protected def fst : α := (WithLp.equiv p (α × β) x).fst
+protected def snd : β := (WithLp.equiv p (α × β) x).snd
+
 @[simp]
 theorem zero_fst : (0 : WithLp p (α × β)).fst = 0 :=
   rfl
@@ -616,7 +619,7 @@ theorem prod_nnnorm_eq_sup (f : WithLp ∞ (α × β)) : ‖f‖₊ = ‖f.fst�
   norm_cast
 
 @[simp] theorem prod_nnnorm_equiv (f : WithLp ∞ (α × β)) : ‖WithLp.equiv ⊤ _ f‖₊ = ‖f‖₊ := by
-  rw [prod_nnnorm_eq_sup, Prod.nnnorm_def', equiv_fst, equiv_snd]
+  rw [Prod.nnnorm_def', equiv_fst, equiv_snd, prod_nnnorm_eq_sup]
 
 @[simp] theorem prod_nnnorm_equiv_symm (f : α × β) : ‖(WithLp.equiv ⊤ _).symm f‖₊ = ‖f‖₊ :=
   (prod_nnnorm_equiv _).symm


### PR DESCRIPTION
Right now, it is a common pattern to use the following notation:
```
variable {A B : Type*} (p : ENNReal ) (x : WithLp p (Prod A B)) in
#check (x.fst : A) 
```
Since `WithLp.fst` does not exist, lean unfolds the type of `x` to find `Prod A B`, resolving `fst` to `Prod.fst`, which has no `WithLp` argument but does have a `Prod A B` argument. this is defeq abuse.
To remedy this, this PR introduces new definitions `WithLp.fst` and `WithLp.snd` with appropriate type and content, making the earlier defeq abuse no longer unfold the type.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
