### PR TITLE
[Merged by Bors] - chore(FreeAbelianGroup): don't `dsimp [OfNat.ofNat]`

### DIFF
--- a/Mathlib/GroupTheory/FreeAbelianGroup.lean
+++ b/Mathlib/GroupTheory/FreeAbelianGroup.lean
@@ -402,8 +402,19 @@ instance nonUnitalNonAssocRing : NonUnitalNonAssocRing (FreeAbelianGroup α) :=
 
 end Mul
 
-instance one [One α] : One (FreeAbelianGroup α) :=
+section One
+variable [One α]
+
+instance one : One (FreeAbelianGroup α) :=
   ⟨of 1⟩
+
+theorem one_def : (1 : FreeAbelianGroup α) = of 1 :=
+  rfl
+
+theorem of_one : (of 1 : FreeAbelianGroup α) = 1 :=
+  rfl
+
+end One
 
 instance nonUnitalRing [Semigroup α] : NonUnitalRing (FreeAbelianGroup α) :=
   { FreeAbelianGroup.nonUnitalNonAssocRing with
@@ -430,21 +441,16 @@ instance ring : Ring (FreeAbelianGroup α) :=
   { FreeAbelianGroup.nonUnitalRing _,
     FreeAbelianGroup.one _ with
     mul_one := fun x ↦ by
-      dsimp only [(· * ·), Mul.mul, OfNat.ofNat, One.one]
-      rw [lift.of]
+      rw [mul_def, one_def, lift.of]
       refine FreeAbelianGroup.induction_on x rfl (fun L ↦ ?_) (fun L ih ↦ ?_) fun x1 x2 ih1 ih2 ↦ ?_
-      · rw [lift.of]
-        congr 1
-        exact mul_one L
+      · rw [lift.of, mul_one]
       · rw [map_neg, ih]
       · rw [map_add, ih1, ih2]
     one_mul := fun x ↦ by
-      dsimp only [(· * ·), Mul.mul, OfNat.ofNat, One.one]
+      simp_rw [mul_def, one_def, lift.of]
       refine FreeAbelianGroup.induction_on x rfl ?_ ?_ ?_
       · intro L
-        rw [lift.of, lift.of]
-        congr 1
-        exact one_mul L
+        rw [lift.of, one_mul]
       · intro L ih
         rw [map_neg, ih]
       · intro x1 x2 ih1 ih2
@@ -455,7 +461,7 @@ variable {α}
 /-- `FreeAbelianGroup.of` is a `MonoidHom` when `α` is a `Monoid`. -/
 def ofMulHom : α →* FreeAbelianGroup α where
   toFun := of
-  map_one' := rfl
+  map_one' := of_one _
   map_mul' := of_mul
 
 @[simp]
@@ -503,12 +509,6 @@ theorem liftMonoid_coe (f : α →* R) : ⇑(liftMonoid f) = lift f :=
 -- Porting note: Added a type to `↑f`.
 theorem liftMonoid_symm_coe (f : FreeAbelianGroup α →+* R) :
     ⇑(liftMonoid.symm f) = lift.symm (↑f : FreeAbelianGroup α →+ R) :=
-  rfl
-
-theorem one_def : (1 : FreeAbelianGroup α) = of 1 :=
-  rfl
-
-theorem of_one : (of 1 : FreeAbelianGroup α) = 1 :=
   rfl
 
 end Monoid

--- a/Mathlib/NumberTheory/ADEInequality.lean
+++ b/Mathlib/NumberTheory/ADEInequality.lean
@@ -142,11 +142,9 @@ theorem Admissible.one_lt_sumInv {pqr : Multiset ℕ+} : Admissible pqr → 1 < 
     simp only [lt_add_iff_pos_right, PNat.one_coe, inv_one, Nat.cast_one]
     apply add_pos <;> simp only [PNat.pos, Nat.cast_pos, inv_pos]
   · rw [← H, D', sumInv_pqr]
-    conv_rhs => simp only [OfNat.ofNat, PNat.mk_coe]
     norm_num
   all_goals
     rw [← H, E', sumInv_pqr]
-    conv_rhs => simp only [OfNat.ofNat, PNat.mk_coe]
     norm_num
 
 theorem lt_three {p q r : ℕ+} (hpq : p ≤ q) (hqr : q ≤ r) (H : 1 < sumInv {p, q, r}) : p < 3 := by


### PR DESCRIPTION
There is no need to do this, as there are better lemmas available (at least, after reordering slightly).

This also generalizes the `of_one` and `one_def` lemmas to require `One` and not `Monoid`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
