### PR TITLE
[Merged by Bors] - chore: protect `Measurable.exp`

### DIFF
--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Basic.lean
@@ -136,32 +136,27 @@ variable {α : Type*} {m : MeasurableSpace α} {f : α → ℝ} (hf : Measurable
 include hf
 
 @[measurability]
-theorem Measurable.exp : Measurable fun x => Real.exp (f x) :=
+protected theorem Measurable.exp : Measurable fun x => Real.exp (f x) :=
   Real.measurable_exp.comp hf
 
 @[measurability]
-theorem Measurable.log : Measurable fun x => log (f x) :=
+protected theorem Measurable.log : Measurable fun x => log (f x) :=
   measurable_log.comp hf
 
 @[measurability]
-theorem Measurable.cos : Measurable fun x => Real.cos (f x) :=
-  Real.measurable_cos.comp hf
+protected theorem Measurable.cos : Measurable fun x ↦ cos (f x) := measurable_cos.comp hf
 
 @[measurability]
-theorem Measurable.sin : Measurable fun x => Real.sin (f x) :=
-  Real.measurable_sin.comp hf
+protected theorem Measurable.sin : Measurable fun x ↦ sin (f x) := measurable_sin.comp hf
 
 @[measurability]
-theorem Measurable.cosh : Measurable fun x => Real.cosh (f x) :=
-  Real.measurable_cosh.comp hf
+protected theorem Measurable.cosh : Measurable fun x ↦ cosh (f x) := measurable_cosh.comp hf
 
 @[measurability]
-theorem Measurable.sinh : Measurable fun x => Real.sinh (f x) :=
-  Real.measurable_sinh.comp hf
+protected theorem Measurable.sinh : Measurable fun x ↦ sinh (f x) := measurable_sinh.comp hf
 
 @[measurability]
-theorem Measurable.sqrt : Measurable fun x => √(f x) :=
-  continuous_sqrt.measurable.comp hf
+protected theorem Measurable.sqrt : Measurable fun x => √(f x) := continuous_sqrt.measurable.comp hf
 
 end RealComposition
 
@@ -210,31 +205,31 @@ variable {α : Type*} {m : MeasurableSpace α} {f : α → ℂ} (hf : Measurable
 include hf
 
 @[measurability]
-theorem Measurable.cexp : Measurable fun x => Complex.exp (f x) :=
+protected theorem Measurable.cexp : Measurable fun x => Complex.exp (f x) :=
   Complex.measurable_exp.comp hf
 
 @[measurability]
-theorem Measurable.ccos : Measurable fun x => Complex.cos (f x) :=
+protected theorem Measurable.ccos : Measurable fun x => Complex.cos (f x) :=
   Complex.measurable_cos.comp hf
 
 @[measurability]
-theorem Measurable.csin : Measurable fun x => Complex.sin (f x) :=
+protected theorem Measurable.csin : Measurable fun x => Complex.sin (f x) :=
   Complex.measurable_sin.comp hf
 
 @[measurability]
-theorem Measurable.ccosh : Measurable fun x => Complex.cosh (f x) :=
+protected theorem Measurable.ccosh : Measurable fun x => Complex.cosh (f x) :=
   Complex.measurable_cosh.comp hf
 
 @[measurability]
-theorem Measurable.csinh : Measurable fun x => Complex.sinh (f x) :=
+protected theorem Measurable.csinh : Measurable fun x => Complex.sinh (f x) :=
   Complex.measurable_sinh.comp hf
 
 @[measurability]
-theorem Measurable.carg : Measurable fun x => arg (f x) :=
+protected theorem Measurable.carg : Measurable fun x => arg (f x) :=
   measurable_arg.comp hf
 
 @[measurability]
-theorem Measurable.clog : Measurable fun x => Complex.log (f x) :=
+protected theorem Measurable.clog : Measurable fun x => Complex.log (f x) :=
   measurable_log.comp hf
 
 end ComplexComposition


### PR DESCRIPTION
… and adjacent theorems. This avoids `exp` being ambiguous between `Real.exp` and `Measurable.exp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
