### PR TITLE
feat: Sherman Morrison formula for rank 1 update of the matrix inverse

### DIFF
--- a/Mathlib/Data/Matrix/Invertible.lean
+++ b/Mathlib/Data/Matrix/Invertible.lean
@@ -172,19 +172,57 @@ theorem invOf_add_mul_mul [Invertible (A + U*C*V)] :
   letI := invertibleAddMulMul A U C V
   convert (rfl : ⅟(A + U*C*V) = _)
 
-theorem sherman_morrison_rankOneUpdate1 {ι : Type*} [Unique ι] (u v : n → α)
-    [Invertible (1 + row ι v * ⅟A * col ι u)]
-    [Inv α] [Invertible (A + col ι u * row ι v)] :
-    (⅟A - (⅟A * (col ι u) * ⅟ (1 + row ι v * ⅟A * col ι u) * (row ι v) * ⅟A) ) *
-    (A + col ι u * row ι v) = 1 := by
-  haveI : Invertible (1 : Matrix ι ι α) := by
-    exact invertibleOne
-  haveI : Invertible (⅟ 1 + row ι v * ⅟A * col ι u) := by simpa [invOf_one']
-  have h1 : ⅟ (1 : Matrix ι ι α) = 1 := by exact invOf_one
-  have h2 : ⅟ (⅟1 + row ι v * ⅟A * col ι u) = ⅟ (1 + row ι v * ⅟A * col ι u) := by congr!
-  have h3 :  col ι u * (1: Matrix ι ι α) * row ι v = col ι u * row ι v := by rw [Matrix.mul_one]
+-- variable {(Fin 1) : Type} [DecidableEq (Fin 1)][Unique (Fin 1)]
+variable (u v : n → α)
+
+theorem add_col_mul_row_mul_invOf_eq_one
+    [Invertible (1 + row (Fin 1) v * ⅟A * col (Fin 1) u)] :
+    (⅟A - (⅟A * (col (Fin 1) u) * ⅟(1 + row (Fin 1) v * ⅟A * col (Fin 1) u) *
+      (row (Fin 1) v) * ⅟A) ) * (A + col (Fin 1) u * row (Fin 1) v) = 1 := by
+  haveI : Invertible (1 : Matrix (Fin 1) (Fin 1) α) := invertibleOne
+  haveI : Invertible (⅟ 1 + row (Fin 1) v * ⅟A * col (Fin 1) u) := by simpa [invOf_one']
+  have h1 : ⅟ (1 : Matrix (Fin 1) (Fin 1) α) = 1 := by exact invOf_one
+  have h2 : ⅟ (⅟1 + row (Fin 1) v * ⅟A * col (Fin 1) u) =
+    ⅟ (1 + row (Fin 1) v * ⅟A * col (Fin 1) u):= by congr!
+  have h3 :  col (Fin 1) u * (1: Matrix (Fin 1) (Fin 1) α) * row (Fin 1) v =
+    col (Fin 1) u * row (Fin 1) v := by rw [Matrix.mul_one]
   rw [← h2, ← h3]
   apply add_mul_mul_invOf_mul_eq_one'
+
+/-- Like `add_col_mul_row_mul_invOf_eq_one`, but with multiplication reversed. -/
+theorem add_col_mul_row_mul_invOf_eq_one'
+    [Invertible (1 + row (Fin 1) v * ⅟A * col (Fin 1) u)] :
+    (A + col (Fin 1) u * row (Fin 1) v) *
+    (⅟A - (⅟A * (col (Fin 1) u) * ⅟(1 + row (Fin 1) v * ⅟A * col (Fin 1) u) *
+      (row (Fin 1) v) * ⅟A) ) = 1 := by
+  haveI : Invertible (1 : Matrix (Fin 1) (Fin 1) α) := by
+    exact invertibleOne
+  haveI : Invertible (⅟ 1 + row (Fin 1) v * ⅟A * col (Fin 1) u) := by simpa [invOf_one']
+  have h1 : ⅟ (1 : Matrix (Fin 1) (Fin 1) α) = 1 := by exact invOf_one
+  have h2 : ⅟ (⅟1 + row (Fin 1) v * ⅟A * col (Fin 1) u) =
+    ⅟(1 + row (Fin 1) v * ⅟A * col (Fin 1) u) := by congr!
+  have h3 :  col (Fin 1) u * (1: Matrix (Fin 1) (Fin 1) α) * row (Fin 1) v =
+    col (Fin 1) u * row (Fin 1) v := by rw [Matrix.mul_one]
+  rw [← h2, ← h3]
+  apply add_mul_mul_invOf_mul_eq_one
+
+/-- If matrix `A` and the scalar `(1 + row (Fin 1) v * ⅟A * col (Fin 1) u)` are invertible,
+  then so is (A + col (Fin 1) u * row (Fin 1) v) -/
+def invertibleAddColMulRow [Invertible (1 + row (Fin 1) v * ⅟A * col (Fin 1) u)] :
+    Invertible (A + col (Fin 1) u * row (Fin 1) v) where
+  invOf := (⅟A - (⅟A * (col (Fin 1) u) * ⅟(1 + row (Fin 1) v * ⅟A *
+    col (Fin 1) u) * (row (Fin 1) v) * ⅟A))
+  invOf_mul_self := add_col_mul_row_mul_invOf_eq_one _ _ _
+  mul_invOf_self := add_col_mul_row_mul_invOf_eq_one' _ _ _
+
+-- /-- The **Sherman Morrison Rank-1 Update** (`⅟` version). -/
+theorem invOf_add_col_mul_row_mul [Invertible (1 + row (Fin 1) v * ⅟A * col (Fin 1) u)]
+  [Invertible (A + col (Fin 1) u * row (Fin 1) v)] :
+    ⅟(A + col (Fin 1) u * row (Fin 1) v) =
+    (⅟A - (⅟A * (col (Fin 1) u) * ⅟(1 + row (Fin 1) v * ⅟A * col (Fin 1) u) *
+      (row (Fin 1) v) * ⅟A) ) := by
+  letI := invertibleAddColMulRow A u v
+  convert (rfl : ⅟(A + col (Fin 1) u * row (Fin 1) v) = _)
 
 end Woodbury
 

--- a/Mathlib/Data/Matrix/Invertible.lean
+++ b/Mathlib/Data/Matrix/Invertible.lean
@@ -5,6 +5,7 @@ Authors: Eric Wieser, Ahmad Alkhalawi
 -/
 import Mathlib.Data.Matrix.ConjTranspose
 import Mathlib.Tactic.Abel
+import Mathlib.Data.Matrix.RowCol
 
 /-! # Extra lemmas about invertible matrices
 
@@ -170,6 +171,20 @@ theorem invOf_add_mul_mul [Invertible (A + U*C*V)] :
     ⅟(A + U*C*V) = ⅟A - ⅟A*U*⅟(⅟C + V*⅟A*U)*V*⅟A := by
   letI := invertibleAddMulMul A U C V
   convert (rfl : ⅟(A + U*C*V) = _)
+
+theorem sherman_morrison_rankOneUpdate1 {ι : Type*} [Unique ι] (u v : n → α)
+    [Invertible (1 + row ι v * ⅟A * col ι u)]
+    [Inv α] [Invertible (A + col ι u * row ι v)] :
+    (⅟A - (⅟A * (col ι u) * ⅟ (1 + row ι v * ⅟A * col ι u) * (row ι v) * ⅟A) ) *
+    (A + col ι u * row ι v) = 1 := by
+  haveI : Invertible (1 : Matrix ι ι α) := by
+    exact invertibleOne
+  haveI : Invertible (⅟ 1 + row ι v * ⅟A * col ι u) := by simpa [invOf_one']
+  have h1 : ⅟ (1 : Matrix ι ι α) = 1 := by exact invOf_one
+  have h2 : ⅟ (⅟1 + row ι v * ⅟A * col ι u) = ⅟ (1 + row ι v * ⅟A * col ι u) := by congr!
+  have h3 :  col ι u * (1: Matrix ι ι α) * row ι v = col ι u * row ι v := by rw [Matrix.mul_one]
+  rw [← h2, ← h3]
+  apply add_mul_mul_invOf_mul_eq_one'
 
 end Woodbury
 


### PR DESCRIPTION
Provides the Sherman Morrison rank 1 update of the matrix inverse https://en.wikipedia.org/wiki/Sherman%E2%80%93Morrison_formula.

Note that (Fin 1) makes the code a bit a verbose, but it is the canonical choice according to [`Matrix.col`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Matrix/RowCol.html#Matrix.col)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
