### PR TITLE
[Merged by Bors] - feat(Algebra/Lie): add `LieTower` typeclass abstracting the Leibniz rule

### DIFF
--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -102,23 +102,23 @@ Then the Leibniz rule asserts for all `x : L₁`, `y : L₂`, and `m : M` that
 
 Common examples include the case where `L₁` is a Lie subalgebra of `L₂`
 and the case where `L₂` is a Lie ideal of `L₁`. -/
-class LieTower (L₁ L₂ M : Type*) [Bracket L₁ L₂] [Bracket L₁ M] [Bracket L₂ M] [Add M] where
+class IsLieTower (L₁ L₂ M : Type*) [Bracket L₁ L₂] [Bracket L₁ M] [Bracket L₂ M] [Add M] where
   protected leibniz_lie (x : L₁) (y : L₂) (m : M) : ⁅x, ⁅y, m⁆⁆ = ⁅⁅x, y⁆, m⁆ + ⁅y, ⁅x, m⁆⁆
 
-section LieTower
+section IsLieTower
 
 variable {L₁ L₂ M : Type*} [Bracket L₁ L₂] [Bracket L₁ M] [Bracket L₂ M]
 
-lemma leibniz_lie [Add M] [LieTower L₁ L₂ M] (x : L₁) (y : L₂) (m : M) :
-    ⁅x, ⁅y, m⁆⁆ = ⁅⁅x, y⁆, m⁆ + ⁅y, ⁅x, m⁆⁆ := LieTower.leibniz_lie x y m
+lemma leibniz_lie [Add M] [IsLieTower L₁ L₂ M] (x : L₁) (y : L₂) (m : M) :
+    ⁅x, ⁅y, m⁆⁆ = ⁅⁅x, y⁆, m⁆ + ⁅y, ⁅x, m⁆⁆ := IsLieTower.leibniz_lie x y m
 
-lemma lie_swap_lie [Bracket L₂ L₁] [AddCommGroup M] [LieTower L₁ L₂ M] [LieTower L₂ L₁ M]
+lemma lie_swap_lie [Bracket L₂ L₁] [AddCommGroup M] [IsLieTower L₁ L₂ M] [IsLieTower L₂ L₁ M]
     (x : L₁) (y : L₂) (m : M) : ⁅⁅x, y⁆, m⁆ = -⁅⁅y, x⁆, m⁆ := by
   have h1 := leibniz_lie x y m
   have h2 := leibniz_lie y x m
   convert congr($h1.symm - $h2) using 1 <;> simp only [add_sub_cancel_right, sub_add_cancel_right]
 
-end LieTower
+end IsLieTower
 
 section BasicProperties
 
@@ -144,7 +144,7 @@ theorem smul_lie : ⁅t • x, m⁆ = t • ⁅x, m⁆ :=
 theorem lie_smul : ⁅x, t • m⁆ = t • ⁅x, m⁆ :=
   LieModule.lie_smul t x m
 
-instance : LieTower L L M where
+instance : IsLieTower L L M where
   leibniz_lie x y m := LieRingModule.leibniz_lie x y m
 
 @[simp]

--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -103,7 +103,7 @@ Then the Leibniz rule asserts for all `x : L₁`, `y : L₂`, and `m : M` that
 Common examples include the case where `L₁` is a Lie subalgebra of `L₂`
 and the case where `L₂` is a Lie ideal of `L₁`. -/
 class LieTower (L₁ L₂ M : Type*) [Bracket L₁ L₂] [Bracket L₁ M] [Bracket L₂ M] [Add M] where
-    protected leibniz_lie : ∀ (x : L₁) (y : L₂) (m : M), ⁅x, ⁅y, m⁆⁆ = ⁅⁅x, y⁆, m⁆ + ⁅y, ⁅x, m⁆⁆
+  protected leibniz_lie (x : L₁) (y : L₂) (m : M) : ⁅x, ⁅y, m⁆⁆ = ⁅⁅x, y⁆, m⁆ + ⁅y, ⁅x, m⁆⁆
 
 section LieTower
 

--- a/Mathlib/Algebra/Lie/Subalgebra.lean
+++ b/Mathlib/Algebra/Lie/Subalgebra.lean
@@ -225,7 +225,7 @@ instance : Bracket L' M where
 theorem coe_bracket_of_module (x : L') (m : M) : ⁅x, m⁆ = ⁅(x : L), m⁆ :=
   rfl
 
-instance : LieTower L' L M where
+instance : IsLieTower L' L M where
   leibniz_lie x y m := leibniz_lie x.val y m
 
 /-- Given a Lie algebra `L` containing a Lie subalgebra `L' ⊆ L`, together with a Lie ring module

--- a/Mathlib/Algebra/Lie/Subalgebra.lean
+++ b/Mathlib/Algebra/Lie/Subalgebra.lean
@@ -68,7 +68,7 @@ instance : AddSubgroupClass (LieSubalgebra R L) L where
   neg_mem {L'} x hx := show -x ∈ (L' : Submodule R L) from neg_mem hx
 
 /-- A Lie subalgebra forms a new Lie ring. -/
-instance (L' : LieSubalgebra R L) : LieRing L' where
+instance lieRing (L' : LieSubalgebra R L) : LieRing L' where
   bracket x y := ⟨⁅x.val, y.val⁆, L'.lie_mem' x.property y.property⟩
   lie_add := by
     intros
@@ -113,7 +113,7 @@ instance (L' : LieSubalgebra R L) [IsArtinian R L] : IsArtinian R L' :=
 end
 
 /-- A Lie subalgebra forms a new Lie algebra. -/
-instance (L' : LieSubalgebra R L) : LieAlgebra R L' where
+instance lieAlgebra (L' : LieSubalgebra R L) : LieAlgebra R L' where
   lie_smul := by
     { intros
       apply SetCoe.ext
@@ -230,7 +230,7 @@ instance : IsLieTower L' L M where
 
 /-- Given a Lie algebra `L` containing a Lie subalgebra `L' ⊆ L`, together with a Lie ring module
 `M` of `L`, we may regard `M` as a Lie ring module of `L'` by restriction. -/
-instance : LieRingModule L' M where
+instance lieRingModule : LieRingModule L' M where
   add_lie x y m := add_lie (x : L) y m
   lie_add x y m := lie_add (x : L) y m
   leibniz_lie x y m := leibniz_lie x (y : L) m
@@ -239,7 +239,7 @@ variable [Module R M]
 
 /-- Given a Lie algebra `L` containing a Lie subalgebra `L' ⊆ L`, together with a Lie module `M` of
 `L`, we may regard `M` as a Lie module of `L'` by restriction. -/
-instance [LieModule R L M] : LieModule R L' M where
+instance lieModule [LieModule R L M] : LieModule R L' M where
   smul_lie t x m := by
     rw [coe_bracket_of_module, Submodule.coe_smul_of_tower, smul_lie, coe_bracket_of_module]
   lie_smul t x m := by simp only [coe_bracket_of_module, lie_smul]
@@ -477,7 +477,7 @@ theorem sInf_glb (S : Set (LieSubalgebra R L)) : IsGLB S (sInf S) := by
 
 We provide explicit values for the fields `bot`, `top`, `inf` to get more convenient definitions
 than we would otherwise obtain from `completeLatticeOfInf`. -/
-instance instCompleteLattice : CompleteLattice (LieSubalgebra R L) :=
+instance completeLattice : CompleteLattice (LieSubalgebra R L) :=
   { completeLatticeOfInf _ sInf_glb with
     bot := ⊥
     bot_le := fun N _ h ↦ by
@@ -495,7 +495,7 @@ instance : Add (LieSubalgebra R L) where add := max
 
 instance : Zero (LieSubalgebra R L) where zero := ⊥
 
-instance instAddCommMonoid : AddCommMonoid (LieSubalgebra R L) where
+instance addCommMonoid : AddCommMonoid (LieSubalgebra R L) where
   add_assoc := sup_assoc
   zero_add := bot_sup_eq
   add_zero := sup_bot_eq
@@ -503,8 +503,8 @@ instance instAddCommMonoid : AddCommMonoid (LieSubalgebra R L) where
   nsmul := nsmulRec
 
 instance : CanonicallyOrderedAddCommMonoid (LieSubalgebra R L) :=
-  { LieSubalgebra.instAddCommMonoid,
-    LieSubalgebra.instCompleteLattice with
+  { LieSubalgebra.addCommMonoid,
+    LieSubalgebra.completeLattice with
     add_le_add_left := fun _a _b ↦ sup_le_sup_left
     exists_add_of_le := @fun _a b h ↦ ⟨b, (sup_eq_right.2 h).symm⟩
     le_self_add := fun _a _b ↦ le_sup_left }

--- a/Mathlib/Algebra/Lie/Subalgebra.lean
+++ b/Mathlib/Algebra/Lie/Subalgebra.lean
@@ -68,7 +68,7 @@ instance : AddSubgroupClass (LieSubalgebra R L) L where
   neg_mem {L'} x hx := show -x ∈ (L' : Submodule R L) from neg_mem hx
 
 /-- A Lie subalgebra forms a new Lie ring. -/
-instance lieRing (L' : LieSubalgebra R L) : LieRing L' where
+instance (L' : LieSubalgebra R L) : LieRing L' where
   bracket x y := ⟨⁅x.val, y.val⁆, L'.lie_mem' x.property y.property⟩
   lie_add := by
     intros
@@ -113,7 +113,7 @@ instance (L' : LieSubalgebra R L) [IsArtinian R L] : IsArtinian R L' :=
 end
 
 /-- A Lie subalgebra forms a new Lie algebra. -/
-instance lieAlgebra (L' : LieSubalgebra R L) : LieAlgebra R L' where
+instance (L' : LieSubalgebra R L) : LieAlgebra R L' where
   lie_smul := by
     { intros
       apply SetCoe.ext
@@ -230,7 +230,7 @@ instance : IsLieTower L' L M where
 
 /-- Given a Lie algebra `L` containing a Lie subalgebra `L' ⊆ L`, together with a Lie ring module
 `M` of `L`, we may regard `M` as a Lie ring module of `L'` by restriction. -/
-instance lieRingModule : LieRingModule L' M where
+instance : LieRingModule L' M where
   add_lie x y m := add_lie (x : L) y m
   lie_add x y m := lie_add (x : L) y m
   leibniz_lie x y m := leibniz_lie x (y : L) m
@@ -239,7 +239,7 @@ variable [Module R M]
 
 /-- Given a Lie algebra `L` containing a Lie subalgebra `L' ⊆ L`, together with a Lie module `M` of
 `L`, we may regard `M` as a Lie module of `L'` by restriction. -/
-instance lieModule [LieModule R L M] : LieModule R L' M where
+instance [LieModule R L M] : LieModule R L' M where
   smul_lie t x m := by
     rw [coe_bracket_of_module, Submodule.coe_smul_of_tower, smul_lie, coe_bracket_of_module]
   lie_smul t x m := by simp only [coe_bracket_of_module, lie_smul]
@@ -477,7 +477,7 @@ theorem sInf_glb (S : Set (LieSubalgebra R L)) : IsGLB S (sInf S) := by
 
 We provide explicit values for the fields `bot`, `top`, `inf` to get more convenient definitions
 than we would otherwise obtain from `completeLatticeOfInf`. -/
-instance completeLattice : CompleteLattice (LieSubalgebra R L) :=
+instance instCompleteLattice : CompleteLattice (LieSubalgebra R L) :=
   { completeLatticeOfInf _ sInf_glb with
     bot := ⊥
     bot_le := fun N _ h ↦ by
@@ -495,7 +495,7 @@ instance : Add (LieSubalgebra R L) where add := max
 
 instance : Zero (LieSubalgebra R L) where zero := ⊥
 
-instance addCommMonoid : AddCommMonoid (LieSubalgebra R L) where
+instance instAddCommMonoid : AddCommMonoid (LieSubalgebra R L) where
   add_assoc := sup_assoc
   zero_add := bot_sup_eq
   add_zero := sup_bot_eq
@@ -503,8 +503,8 @@ instance addCommMonoid : AddCommMonoid (LieSubalgebra R L) where
   nsmul := nsmulRec
 
 instance : CanonicallyOrderedAddCommMonoid (LieSubalgebra R L) :=
-  { LieSubalgebra.addCommMonoid,
-    LieSubalgebra.completeLattice with
+  { LieSubalgebra.instAddCommMonoid,
+    LieSubalgebra.instCompleteLattice with
     add_le_add_left := fun _a _b ↦ sup_le_sup_left
     exists_add_of_le := @fun _a b h ↦ ⟨b, (sup_eq_right.2 h).symm⟩
     le_self_add := fun _a _b ↦ le_sup_left }

--- a/Mathlib/Algebra/Lie/Subalgebra.lean
+++ b/Mathlib/Algebra/Lie/Subalgebra.lean
@@ -218,17 +218,22 @@ section LieModule
 variable {M : Type w} [AddCommGroup M] [LieRingModule L M]
 variable {N : Type w₁} [AddCommGroup N] [LieRingModule L N] [Module R N]
 
-/-- Given a Lie algebra `L` containing a Lie subalgebra `L' ⊆ L`, together with a Lie ring module
-`M` of `L`, we may regard `M` as a Lie ring module of `L'` by restriction. -/
-instance lieRingModule : LieRingModule L' M where
+instance : Bracket L' M where
   bracket x m := ⁅(x : L), m⁆
-  add_lie x y m := add_lie (x : L) y m
-  lie_add x y m := lie_add (x : L) y m
-  leibniz_lie x y m := leibniz_lie (x : L) y m
 
 @[simp]
 theorem coe_bracket_of_module (x : L') (m : M) : ⁅x, m⁆ = ⁅(x : L), m⁆ :=
   rfl
+
+instance : LieTower L' L M where
+  leibniz_lie x y m := leibniz_lie x.val y m
+
+/-- Given a Lie algebra `L` containing a Lie subalgebra `L' ⊆ L`, together with a Lie ring module
+`M` of `L`, we may regard `M` as a Lie ring module of `L'` by restriction. -/
+instance lieRingModule : LieRingModule L' M where
+  add_lie x y m := add_lie (x : L) y m
+  lie_add x y m := lie_add (x : L) y m
+  leibniz_lie x y m := leibniz_lie x (y : L) m
 
 variable [Module R M]
 

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -269,10 +269,10 @@ theorem LieIdeal.coe_bracket_of_module {R L : Type*} [CommRing R] [LieRing L] [L
 instance LieIdeal.lieModule (I : LieIdeal R L) : LieModule R I M :=
   LieSubalgebra.lieModule (I : LieSubalgebra R L)
 
-instance (I : LieIdeal R L) : LieTower I L M where
+instance (I : LieIdeal R L) : IsLieTower I L M where
   leibniz_lie x y m := leibniz_lie x.val y m
 
-instance (I : LieIdeal R L) : LieTower L I M where
+instance (I : LieIdeal R L) : IsLieTower L I M where
   leibniz_lie x y m := leibniz_lie x y.val m
 
 end LieIdeal

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -269,6 +269,12 @@ theorem LieIdeal.coe_bracket_of_module {R L : Type*} [CommRing R] [LieRing L] [L
 instance LieIdeal.lieModule (I : LieIdeal R L) : LieModule R I M :=
   LieSubalgebra.lieModule (I : LieSubalgebra R L)
 
+instance (I : LieIdeal R L) : LieTower I L M where
+  leibniz_lie x y m := leibniz_lie x.val y m
+
+instance (I : LieIdeal R L) : LieTower L I M where
+  leibniz_lie x y m := leibniz_lie x y.val m
+
 end LieIdeal
 
 variable {R M}


### PR DESCRIPTION
This PR is a preparation for follow-up work on Lie's theorem.

In the proof of Lie's theorem, there are a number of different ways to infer bracket actions,
and not all of them allowed rewriting by the `leibniz_lie` lemma.
So the proof would be massaging terms of Lie ideals into terms of the ambient Lie algebra, etc...

By abstracting this lemma, and providing suitable instances,
we can now simply rewrite with `leibniz_lie` without the massaging.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
