### PR TITLE
[Merged by Bors] - feat: add `ENNReal.finStronglyMeasurable_of_measurable`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3693,6 +3693,7 @@ import Mathlib.MeasureTheory.Function.SpecialFunctions.Basic
 import Mathlib.MeasureTheory.Function.SpecialFunctions.Inner
 import Mathlib.MeasureTheory.Function.SpecialFunctions.RCLike
 import Mathlib.MeasureTheory.Function.StronglyMeasurable.Basic
+import Mathlib.MeasureTheory.Function.StronglyMeasurable.ENNReal
 import Mathlib.MeasureTheory.Function.StronglyMeasurable.Inner
 import Mathlib.MeasureTheory.Function.StronglyMeasurable.Lemmas
 import Mathlib.MeasureTheory.Function.StronglyMeasurable.Lp

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -779,6 +779,12 @@ theorem eapprox_comp [MeasurableSpace γ] {f : γ → ℝ≥0∞} {g : α → γ
     (hg : Measurable g) : (eapprox (f ∘ g) n : α → ℝ≥0∞) = (eapprox f n : γ →ₛ ℝ≥0∞) ∘ g :=
   funext fun a => approx_comp a hf hg
 
+lemma tendsto_eapprox {f : α → ℝ≥0∞} (hf_meas : Measurable f) (a : α) :
+    Tendsto (fun n ↦ SimpleFunc.eapprox f n a) atTop (𝓝 (f a)) := by
+  nth_rw 2 [← SimpleFunc.iSup_coe_eapprox hf_meas]
+  rw [iSup_apply]
+  exact tendsto_atTop_iSup fun _ _ hnm ↦ SimpleFunc.monotone_eapprox f hnm a
+
 /-- Approximate a function `α → ℝ≥0∞` by a series of simple functions taking their values
 in `ℝ≥0`. -/
 def eapproxDiff (f : α → ℝ≥0∞) : ℕ → α →ₛ ℝ≥0
@@ -1013,6 +1019,13 @@ theorem measurableSet_support [MeasurableSpace α] (f : α →ₛ β) : Measurab
   rw [f.support_eq]
   exact Finset.measurableSet_biUnion _ fun y _ => measurableSet_fiber _ _
 
+lemma measure_support_lt_top (f : α →ₛ β) (hf : ∀ y, y ≠ 0 → μ (f ⁻¹' {y}) < ∞) :
+    μ (support f) < ∞ := by
+  rw [support_eq]
+  refine (measure_biUnion_finset_le _ _).trans_lt (ENNReal.sum_lt_top.mpr fun y hy => ?_)
+  rw [Finset.mem_filter] at hy
+  exact hf y hy.2
+
 /-- A `SimpleFunc` has finite measure support if it is equal to `0` outside of a set of finite
 measure. -/
 protected def FinMeasSupp {_m : MeasurableSpace α} (f : α →ₛ β) (μ : Measure α) : Prop :=
@@ -1089,6 +1102,12 @@ theorem iff_lintegral_lt_top {f : α →ₛ ℝ≥0∞} (hf : ∀ᵐ a ∂μ, f 
   ⟨fun h => h.lintegral_lt_top hf, fun h => of_lintegral_ne_top h.ne⟩
 
 end FinMeasSupp
+
+lemma measure_support_lt_top_of_lintegral_ne_top {f : α →ₛ ℝ≥0∞} (hf : f.lintegral μ ≠ ∞) :
+    μ (support f) < ∞ := by
+  refine measure_support_lt_top f ?_
+  rw [← finMeasSupp_iff]
+  exact FinMeasSupp.of_lintegral_ne_top hf
 
 end FinMeasSupp
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -780,10 +780,10 @@ theorem eapprox_comp [MeasurableSpace γ] {f : γ → ℝ≥0∞} {g : α → γ
   funext fun a => approx_comp a hf hg
 
 lemma tendsto_eapprox {f : α → ℝ≥0∞} (hf_meas : Measurable f) (a : α) :
-    Tendsto (fun n ↦ SimpleFunc.eapprox f n a) atTop (𝓝 (f a)) := by
-  nth_rw 2 [← SimpleFunc.iSup_coe_eapprox hf_meas]
+    Tendsto (fun n ↦ eapprox f n a) atTop (𝓝 (f a)) := by
+  nth_rw 2 [← iSup_coe_eapprox hf_meas]
   rw [iSup_apply]
-  exact tendsto_atTop_iSup fun _ _ hnm ↦ SimpleFunc.monotone_eapprox f hnm a
+  exact tendsto_atTop_iSup fun _ _ hnm ↦ monotone_eapprox f hnm a
 
 /-- Approximate a function `α → ℝ≥0∞` by a series of simple functions taking their values
 in `ℝ≥0`. -/

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
@@ -366,13 +366,6 @@ theorem measure_preimage_lt_top_of_integrable (f : α →ₛ E) (hf : Integrable
     (hx : x ≠ 0) : μ (f ⁻¹' {x}) < ∞ :=
   integrable_iff.mp hf x hx
 
-theorem measure_support_lt_top [Zero β] (f : α →ₛ β) (hf : ∀ y, y ≠ 0 → μ (f ⁻¹' {y}) < ∞) :
-    μ (support f) < ∞ := by
-  rw [support_eq]
-  refine (measure_biUnion_finset_le _ _).trans_lt (ENNReal.sum_lt_top.mpr fun y hy => ?_)
-  rw [Finset.mem_filter] at hy
-  exact hf y hy.2
-
 theorem measure_support_lt_top_of_memℒp (f : α →ₛ E) (hf : Memℒp f p μ) (hp_ne_zero : p ≠ 0)
     (hp_ne_top : p ≠ ∞) : μ (support f) < ∞ :=
   f.measure_support_lt_top ((memℒp_iff hp_ne_zero hp_ne_top).mp hf)

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/ENNReal.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/ENNReal.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2025 Rémy Degenne. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne
+-/
+
+import Mathlib.MeasureTheory.Function.StronglyMeasurable.Basic
+import Mathlib.MeasureTheory.Integral.Lebesgue
+
+/-!
+# Finitely strongly measurable functions with value in ENNReal
+
+A measurable function with finite Lebesgue integral can be approximated by simple functions
+whose support has finite measure.
+
+-/
+
+open MeasureTheory
+open scoped ENNReal
+
+variable {α : Type*} {m : MeasurableSpace α} {μ : Measure α} {f : α → ℝ≥0∞}
+
+lemma ENNReal.finStronglyMeasurable_of_measurable (hf : ∫⁻ x, f x ∂μ ≠ ∞)
+    (hf_meas : Measurable f) :
+    FinStronglyMeasurable f μ :=
+  ⟨SimpleFunc.eapprox f, measure_support_eapprox_lt_top hf_meas hf,
+    SimpleFunc.tendsto_eapprox hf_meas⟩
+
+lemma ENNReal.aefinStronglyMeasurable_of_aemeasurable (hf : ∫⁻ x, f x ∂μ ≠ ∞)
+    (hf_meas : AEMeasurable f μ) :
+    AEFinStronglyMeasurable f μ := by
+  refine ⟨hf_meas.mk f, ENNReal.finStronglyMeasurable_of_measurable ?_ hf_meas.measurable_mk,
+    hf_meas.ae_eq_mk⟩
+  rwa [lintegral_congr_ae hf_meas.ae_eq_mk.symm]

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lemmas.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lemmas.lean
@@ -39,20 +39,6 @@ theorem MeasureTheory.MeasurePreserving.aestronglyMeasurable_comp_iff {β : Type
     AEStronglyMeasurable (g ∘ f) μa ↔ AEStronglyMeasurable g μb := by
   rw [← hf.map_eq, h₂.aestronglyMeasurable_map_iff]
 
-lemma ENNReal.finStronglyMeasurable_of_measurable {f : α → ℝ≥0∞} (hf : ∫⁻ x, f x ∂μ ≠ ∞)
-    (hf_meas : Measurable f) :
-    FinStronglyMeasurable f μ := by
-  exact ⟨SimpleFunc.eapprox f, measure_support_eapprox_lt_top hf_meas hf,
-    SimpleFunc.tendsto_eapprox hf_meas⟩
-
-lemma ENNReal.aefinStronglyMeasurable_of_aemeasurable {f : α → ℝ≥0∞} (hf : ∫⁻ x, f x ∂μ ≠ ∞)
-    (hf_meas : AEMeasurable f μ) :
-    AEFinStronglyMeasurable f μ := by
-  have h := ENNReal.finStronglyMeasurable_of_measurable (μ := μ) (f := hf_meas.mk f) ?_
-    hf_meas.measurable_mk
-  · exact ⟨hf_meas.mk f, h, hf_meas.ae_eq_mk⟩
-  · rwa [lintegral_congr_ae hf_meas.ae_eq_mk.symm]
-
 section NormedSpace
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lemmas.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lemmas.lean
@@ -39,6 +39,20 @@ theorem MeasureTheory.MeasurePreserving.aestronglyMeasurable_comp_iff {β : Type
     AEStronglyMeasurable (g ∘ f) μa ↔ AEStronglyMeasurable g μb := by
   rw [← hf.map_eq, h₂.aestronglyMeasurable_map_iff]
 
+lemma ENNReal.finStronglyMeasurable_of_measurable {f : α → ℝ≥0∞} (hf : ∫⁻ x, f x ∂μ ≠ ∞)
+    (hf_meas : Measurable f) :
+    FinStronglyMeasurable f μ := by
+  exact ⟨SimpleFunc.eapprox f, measure_support_eapprox_lt_top hf_meas hf,
+    SimpleFunc.tendsto_eapprox hf_meas⟩
+
+lemma ENNReal.aefinStronglyMeasurable_of_aemeasurable {f : α → ℝ≥0∞} (hf : ∫⁻ x, f x ∂μ ≠ ∞)
+    (hf_meas : AEMeasurable f μ) :
+    AEFinStronglyMeasurable f μ := by
+  have h := ENNReal.finStronglyMeasurable_of_measurable (μ := μ) (f := hf_meas.mk f) ?_
+    hf_meas.measurable_mk
+  · exact ⟨hf_meas.mk f, h, hf_meas.ae_eq_mk⟩
+  · rwa [lintegral_congr_ae hf_meas.ae_eq_mk.symm]
+
 section NormedSpace
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -449,6 +449,17 @@ theorem lintegral_eq_iSup_eapprox_lintegral {f : α → ℝ≥0∞} (hf : Measur
     _ = ⨆ n, (eapprox f n).lintegral μ := by
       congr; ext n; rw [(eapprox f n).lintegral_eq_lintegral]
 
+lemma lintegral_eapprox_le_lintegral {f : α → ℝ≥0∞} (hf : Measurable f) (n : ℕ) :
+    (eapprox f n).lintegral μ ≤ ∫⁻ x, f x ∂μ := by
+  rw [lintegral_eq_iSup_eapprox_lintegral hf]
+  exact le_iSup (fun n ↦ (eapprox f n).lintegral μ) n
+
+lemma measure_support_eapprox_lt_top {f : α → ℝ≥0∞} (hf_meas : Measurable f)
+    (hf : ∫⁻ x, f x ∂μ ≠ ∞) (n : ℕ) :
+    μ (support (eapprox f n)) < ∞ :=
+  measure_support_lt_top_of_lintegral_ne_top <|
+    ((lintegral_eapprox_le_lintegral hf_meas n).trans_lt hf.lt_top).ne
+
 /-- If `f` has finite integral, then `∫⁻ x in s, f x ∂μ` is absolutely continuous in `s`: it tends
 to zero as `μ s` tends to zero. This lemma states this fact in terms of `ε` and `δ`. -/
 theorem exists_pos_setLIntegral_lt_of_measure_lt {f : α → ℝ≥0∞} (h : ∫⁻ x, f x ∂μ ≠ ∞) {ε : ℝ≥0∞}


### PR DESCRIPTION
A measurable function with finite Lebesgue integral can be approximated by simple functions whose support has finite measure.

I created a new file StronglyMeasurable/ENNReal instead of using StronglyMeasurable/Lemmas because those lemmas will be useful in places that should not import things like the Bochner integral.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
