### PR TITLE
[Merged by Bors] - feat: `HasFDerivAt` for `Fin.cons`

### DIFF
--- a/Mathlib/Analysis/Calculus/Deriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Prod.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Gabriel Ebner, Yury Kudryashov
+Authors: Gabriel Ebner, Yury Kudryashov, Eric Wieser
 -/
 import Mathlib.Analysis.Calculus.Deriv.Basic
 import Mathlib.Analysis.Calculus.FDeriv.Prod

--- a/Mathlib/Analysis/Calculus/Deriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Prod.lean
@@ -13,7 +13,7 @@ In this file we prove lemmas about derivatives of functions `f : 𝕜 → E × F
 `f : 𝕜 → (Π i, E i)`.
 
 For a more detailed overview of one-dimensional derivatives in mathlib, see the module docstring of
-`analysis/calculus/deriv/basic`.
+`Mathlib/Analysis/Calculus/Deriv/Basic.lean`.
 
 ## Keywords
 
@@ -88,3 +88,99 @@ theorem deriv_pi (h : ∀ i, DifferentiableAt 𝕜 (fun x => φ x i) x) :
   (hasDerivAt_pi.2 fun i => (h i).hasDerivAt).deriv
 
 end Pi
+
+
+/-!
+### Derivatives of tuples `f : 𝕜 → Π i : Fin n.succ, F' i`
+
+These can be used to prove results about functions of the form `fun x ↦ ![f x, g x, h x]`,
+as `Matrix.vecCons` is defeq to `Fin.cons`.
+-/
+section PiFin
+
+variable {n : Nat} {F' : Fin n.succ → Type*}
+variable [∀ i, NormedAddCommGroup (F' i)] [∀ i, NormedSpace 𝕜 (F' i)]
+variable {φ : 𝕜 → F' 0} {φs : 𝕜 → ∀ i, F' (Fin.succ i)}
+
+theorem hasStrictDerivAt_finCons {φ' : Π i, F' i} :
+    HasStrictDerivAt (fun x => Fin.cons (φ x) (φs x)) φ' x ↔
+      HasStrictDerivAt φ (φ' 0) x ∧ HasStrictDerivAt φs (fun i => φ' i.succ) x :=
+  hasStrictFDerivAt_finCons
+
+/-- A variant of `hasStrictDerivAt_finCons` where the derivative variables are free on the RHS
+instead. -/
+theorem hasStrictDerivAt_finCons'
+    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} :
+    HasStrictDerivAt (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') x ↔
+      HasStrictDerivAt φ φ' x ∧ HasStrictDerivAt φs φs' x :=
+  hasStrictDerivAt_finCons
+
+theorem HasStrictDerivAt.finCons
+    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)}
+    (h : HasStrictDerivAt φ φ' x) (hs : HasStrictDerivAt φs φs' x) :
+    HasStrictDerivAt (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') x :=
+  hasStrictDerivAt_finCons'.mpr ⟨h, hs⟩
+
+theorem hasDerivAtFilter_finCons
+    {φ' : Π i, F' i} {l : Filter 𝕜} :
+    HasDerivAtFilter (fun x => Fin.cons (φ x) (φs x)) φ' x l ↔
+      HasDerivAtFilter φ (φ' 0) x l ∧ HasDerivAtFilter φs (fun i => φ' i.succ) x l :=
+  hasFDerivAtFilter_finCons
+
+/-- A variant of `hasDerivAtFilter_finCons` where the derivative variables are free on the RHS
+instead. -/
+theorem hasDerivAtFilter_finCons'
+    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} {l : Filter 𝕜} :
+    HasDerivAtFilter (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') x l ↔
+      HasDerivAtFilter φ φ' x l ∧ HasDerivAtFilter φs φs' x l :=
+  hasDerivAtFilter_finCons
+
+theorem hasDerivAtFilter.finCons
+    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} {l : Filter 𝕜}
+    (h : HasDerivAtFilter φ φ' x l) (hs : HasDerivAtFilter φs φs' x l) :
+    HasDerivAtFilter (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') x l :=
+  hasDerivAtFilter_finCons'.mpr ⟨h, hs⟩
+
+theorem HasDerivAt_finCons
+    {φ' : Π i, F' i} :
+    HasDerivAt (fun x => Fin.cons (φ x) (φs x)) φ' x ↔
+      HasDerivAt φ (φ' 0) x ∧ HasDerivAt φs (fun i => φ' i.succ) x :=
+  hasDerivAtFilter_finCons
+
+/-- A variant of `hasDerivAt_finCons` where the derivative variables are free on the RHS
+instead. -/
+theorem hasDerivAt_finCons'
+    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} :
+    HasDerivAt (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') x ↔
+      HasDerivAt φ φ' x ∧ HasDerivAt φs φs' x :=
+  HasDerivAt_finCons
+
+theorem HasDerivAt.finCons
+    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)}
+    (h : HasDerivAt φ φ' x) (hs : HasDerivAt φs φs' x) :
+    HasDerivAt (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') x :=
+  hasDerivAt_finCons'.mpr ⟨h, hs⟩
+
+theorem hasDerivWithinAt_finCons
+    {φ' : Π i, F' i} :
+    HasDerivWithinAt (fun x => Fin.cons (φ x) (φs x)) φ' s x ↔
+      HasDerivWithinAt φ (φ' 0) s x ∧ HasDerivWithinAt φs (fun i => φ' i.succ) s x :=
+  hasDerivAtFilter_finCons
+
+/-- A variant of `hasDerivWithinAt_finCons` where the derivative variables are free on the RHS
+instead. -/
+theorem hasDerivWithinAt_finCons'
+    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} :
+    HasDerivWithinAt (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') s x ↔
+      HasDerivWithinAt φ φ' s x ∧ HasDerivWithinAt φs φs' s x :=
+  hasDerivAtFilter_finCons
+
+theorem HasDerivWithinAt.finCons
+    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)}
+    (h : HasDerivWithinAt φ φ' s x) (hs : HasDerivWithinAt φs φs' s x) :
+    HasDerivWithinAt (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') s x :=
+  hasDerivWithinAt_finCons'.mpr ⟨h, hs⟩
+
+-- TODO: write the `Fin.cons` versions of `derivWithin_pi` and `deriv_pi`
+
+end PiFin

--- a/Mathlib/Analysis/Calculus/Deriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Prod.lean
@@ -109,74 +109,63 @@ theorem hasStrictDerivAt_finCons {φ' : Π i, F' i} :
 
 /-- A variant of `hasStrictDerivAt_finCons` where the derivative variables are free on the RHS
 instead. -/
-theorem hasStrictDerivAt_finCons'
-    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} :
+theorem hasStrictDerivAt_finCons' {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} :
     HasStrictDerivAt (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') x ↔
       HasStrictDerivAt φ φ' x ∧ HasStrictDerivAt φs φs' x :=
   hasStrictDerivAt_finCons
 
-theorem HasStrictDerivAt.finCons
-    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)}
+theorem HasStrictDerivAt.finCons {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)}
     (h : HasStrictDerivAt φ φ' x) (hs : HasStrictDerivAt φs φs' x) :
     HasStrictDerivAt (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') x :=
   hasStrictDerivAt_finCons'.mpr ⟨h, hs⟩
 
-theorem hasDerivAtFilter_finCons
-    {φ' : Π i, F' i} {l : Filter 𝕜} :
+theorem hasDerivAtFilter_finCons {φ' : Π i, F' i} {l : Filter 𝕜} :
     HasDerivAtFilter (fun x => Fin.cons (φ x) (φs x)) φ' x l ↔
       HasDerivAtFilter φ (φ' 0) x l ∧ HasDerivAtFilter φs (fun i => φ' i.succ) x l :=
   hasFDerivAtFilter_finCons
 
 /-- A variant of `hasDerivAtFilter_finCons` where the derivative variables are free on the RHS
 instead. -/
-theorem hasDerivAtFilter_finCons'
-    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} {l : Filter 𝕜} :
+theorem hasDerivAtFilter_finCons' {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} {l : Filter 𝕜} :
     HasDerivAtFilter (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') x l ↔
       HasDerivAtFilter φ φ' x l ∧ HasDerivAtFilter φs φs' x l :=
   hasDerivAtFilter_finCons
 
-theorem hasDerivAtFilter.finCons
-    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} {l : Filter 𝕜}
+theorem HasDerivAtFilter.finCons {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} {l : Filter 𝕜}
     (h : HasDerivAtFilter φ φ' x l) (hs : HasDerivAtFilter φs φs' x l) :
     HasDerivAtFilter (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') x l :=
   hasDerivAtFilter_finCons'.mpr ⟨h, hs⟩
 
-theorem HasDerivAt_finCons
-    {φ' : Π i, F' i} :
+theorem hasDerivAt_finCons {φ' : Π i, F' i} :
     HasDerivAt (fun x => Fin.cons (φ x) (φs x)) φ' x ↔
       HasDerivAt φ (φ' 0) x ∧ HasDerivAt φs (fun i => φ' i.succ) x :=
   hasDerivAtFilter_finCons
 
 /-- A variant of `hasDerivAt_finCons` where the derivative variables are free on the RHS
 instead. -/
-theorem hasDerivAt_finCons'
-    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} :
+theorem hasDerivAt_finCons' {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} :
     HasDerivAt (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') x ↔
       HasDerivAt φ φ' x ∧ HasDerivAt φs φs' x :=
-  HasDerivAt_finCons
+  hasDerivAt_finCons
 
-theorem HasDerivAt.finCons
-    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)}
+theorem HasDerivAt.finCons {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)}
     (h : HasDerivAt φ φ' x) (hs : HasDerivAt φs φs' x) :
     HasDerivAt (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') x :=
   hasDerivAt_finCons'.mpr ⟨h, hs⟩
 
-theorem hasDerivWithinAt_finCons
-    {φ' : Π i, F' i} :
+theorem hasDerivWithinAt_finCons {φ' : Π i, F' i} :
     HasDerivWithinAt (fun x => Fin.cons (φ x) (φs x)) φ' s x ↔
       HasDerivWithinAt φ (φ' 0) s x ∧ HasDerivWithinAt φs (fun i => φ' i.succ) s x :=
   hasDerivAtFilter_finCons
 
 /-- A variant of `hasDerivWithinAt_finCons` where the derivative variables are free on the RHS
 instead. -/
-theorem hasDerivWithinAt_finCons'
-    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} :
+theorem hasDerivWithinAt_finCons' {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)} :
     HasDerivWithinAt (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') s x ↔
       HasDerivWithinAt φ φ' s x ∧ HasDerivWithinAt φs φs' s x :=
   hasDerivAtFilter_finCons
 
-theorem HasDerivWithinAt.finCons
-    {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)}
+theorem HasDerivWithinAt.finCons {φ' : F' 0} {φs' : Π i, F' (Fin.succ i)}
     (h : HasDerivWithinAt φ φ' s x) (hs : HasDerivWithinAt φs φs' s x) :
     HasDerivWithinAt (fun x => Fin.cons (φ x) (φs x)) (Fin.cons φ' φs') s x :=
   hasDerivWithinAt_finCons'.mpr ⟨h, hs⟩

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -491,7 +491,7 @@ end Pi
 ### Derivatives of tuples `f : E → Π i : Fin n.succ, F' i`
 
 These can be used to prove results about functions of the form `fun x ↦ ![f x, g x, h x]`,
-as `Matrix.vecCons` is defeq to `Fincons`.
+as `Matrix.vecCons` is defeq to `Fin.cons`.
 -/
 section PiFin
 
@@ -542,7 +542,7 @@ theorem hasStrictFDerivAt_finCons'
   hasStrictFDerivAt_finCons
 
 @[fun_prop]
-theorem hasStrictFDerivAt.finCons
+theorem HasStrictFDerivAt.finCons
     {φ' : E →L[𝕜] F' 0} {φs' : E →L[𝕜] Π i, F' (Fin.succ i)}
     (h : HasStrictFDerivAt φ φ' x) (hs : HasStrictFDerivAt φs φs' x) :
     HasStrictFDerivAt (fun x => Fin.cons (φ x) (φs x)) (φ'.finCons φs') x :=

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -500,9 +500,11 @@ variable {n : Nat} {F' : Fin n.succ → Type*}
 variable [∀ i, NormedAddCommGroup (F' i)] [∀ i, NormedSpace 𝕜 (F' i)]
 variable {φ : E → F' 0} {φs : E → ∀ i, F' (Fin.succ i)}
 
--- TODO: generalize to TVS, find a home
 variable (𝕜 F') in
-/-- `Fin.consEquiv` as a continuous linear equivalence -/
+/-- `Fin.consEquiv` as a continuous linear equivalence.
+
+TODO: generalize to TVS, find a home. -/
+@[simps]
 def Fin.consEquivL : (F' 0 × Π i, F' (Fin.succ i)) ≃L[𝕜] (Π i, F' i) where
   __ := Fin.consEquiv F'
   map_add' x y := funext <| Fin.cases rfl (by simp)

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jeremy Avigad, Sébastien Gouëzel, Yury Kudryashov
+Authors: Jeremy Avigad, Sébastien Gouëzel, Yury Kudryashov, Eric Wieser
 -/
 import Mathlib.Analysis.Calculus.FDeriv.Linear
 import Mathlib.Analysis.Calculus.FDeriv.Comp

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -495,30 +495,6 @@ as `Matrix.vecCons` is defeq to `Fin.cons`.
 -/
 section PiFin
 
-section TVS
-
-variable {n : ℕ} {𝕜 : Type*} {α : Fin n.succ → Type*}
-variable [Semiring 𝕜]
-variable [∀ i, AddCommMonoid (α i)] [∀ i, Module 𝕜 (α i)] [∀ i, TopologicalSpace (α i)]
-
--- TODO: find a better home for this definition
-variable (𝕜 α) in
-/-- `Fin.consEquiv` as a continuous linear equivalence.  -/
-@[simps]
-def Fin.consEquivL : (α 0 × Π i, α (Fin.succ i)) ≃L[𝕜] (Π i, α i) where
-  __ := Fin.consLinearEquiv 𝕜 α
-  continuous_toFun := continuous_id.fst.finCons continuous_id.snd
-  continuous_invFun := .prod_mk (continuous_apply 0) (by continuity)
-
-/-- `Fin.cons` in the codomain of continuous linear maps. -/
-abbrev ContinuousLinearMap.finCons
-    {E : Type*} [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E]
-    (φ' : E →L[𝕜] α 0) (φs' : E →L[𝕜] Π i, α (Fin.succ i)) :
-    E →L[𝕜] Π i, α i :=
-  Fin.consEquivL 𝕜 α ∘L φ'.prod φs'
-
-end TVS
-
 variable {n : Nat} {F' : Fin n.succ → Type*}
 variable [∀ i, NormedAddCommGroup (F' i)] [∀ i, NormedSpace 𝕜 (F' i)]
 variable {φ : E → F' 0} {φs : E → ∀ i, F' (Fin.succ i)}

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -565,13 +565,13 @@ theorem hasFDerivAtFilter_finCons'
       HasFDerivAtFilter φ φ' x l ∧ HasFDerivAtFilter φs φs' x l :=
   hasFDerivAtFilter_finCons
 
-theorem hasFDerivAtFilter.finCons
+theorem HasFDerivAtFilter.finCons
     {φ' : E →L[𝕜] F' 0} {φs' : E →L[𝕜] Π i, F' (Fin.succ i)} {l : Filter E}
     (h : HasFDerivAtFilter φ φ' x l) (hs : HasFDerivAtFilter φs φs' x l) :
     HasFDerivAtFilter (fun x => Fin.cons (φ x) (φs x)) (φ'.finCons φs') x l :=
   hasFDerivAtFilter_finCons'.mpr ⟨h, hs⟩
 
-theorem HasFDerivAt_finCons
+theorem hasFDerivAt_finCons
     {φ' : E →L[𝕜] Π i, F' i} :
     HasFDerivAt (fun x => Fin.cons (φ x) (φs x)) φ' x ↔
       HasFDerivAt φ (.proj 0 ∘L φ') x ∧ HasFDerivAt φs (Pi.compRightL 𝕜 F' Fin.succ ∘L φ') x :=
@@ -583,7 +583,7 @@ theorem hasFDerivAt_finCons'
     {φ' : E →L[𝕜] F' 0} {φs' : E →L[𝕜] Π i, F' (Fin.succ i)} :
     HasFDerivAt (fun x => Fin.cons (φ x) (φs x)) (φ'.finCons φs') x ↔
       HasFDerivAt φ φ' x ∧ HasFDerivAt φs φs' x :=
-  HasFDerivAt_finCons
+  hasFDerivAt_finCons
 
 @[fun_prop]
 theorem HasFDerivAt.finCons

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -485,7 +485,202 @@ theorem fderiv_pi (h : ∀ i, DifferentiableAt 𝕜 (φ i) x) :
     fderiv 𝕜 (fun x i => φ i x) x = pi fun i => fderiv 𝕜 (φ i) x :=
   (hasFDerivAt_pi.2 fun i => (h i).hasFDerivAt).fderiv
 
+
 end Pi
+
+/-!
+### Derivatives of tuples `f : E → Π i : Fin n.succ, F' i`
+
+These can be used to prove results about functions of the form `fun x ↦ ![f x, g x, h x]`,
+as `Matrix.vecCons` is defeq to `Fincons`.
+-/
+section PiFin
+
+variable {n : Nat} {F' : Fin n.succ → Type*}
+variable [∀ i, NormedAddCommGroup (F' i)] [∀ i, NormedSpace 𝕜 (F' i)]
+variable {φ : E → F' 0} {φs : E → ∀ i, F' (Fin.succ i)}
+
+-- TODO: generalize to TVS, find a home
+/-- `Fin.cons` in the codomain of continuous linear maps. -/
+def ContinuousLinearMap.finCons (φ' : E →L[𝕜] F' 0) (φs' : E →L[𝕜] Π i, F' (Fin.succ i)) :
+    E →L[𝕜] Π i, F' i where
+  toFun x := Fin.cons (φ' x) (φs' x)
+  map_add' x y := funext <| Fin.cases (map_add φ' x y) (by simp)
+  map_smul' c x := funext <| Fin.cases (map_smul φ' c x) (by simp)
+  cont := φ'.continuous.finCons φs'.continuous
+
+theorem hasStrictFDerivAt_finCons {φ' : E →L[𝕜] Π i, F' i} :
+    HasStrictFDerivAt (fun x => Fin.cons (φ x) (φs x)) φ' x ↔
+      HasStrictFDerivAt φ (.proj 0 ∘L φ') x ∧
+      HasStrictFDerivAt φs (Pi.compRightL 𝕜 F' Fin.succ ∘L φ') x := by
+  rw [hasStrictFDerivAt_pi', Fin.forall_fin_succ, hasStrictFDerivAt_pi']
+  dsimp [ContinuousLinearMap.comp, LinearMap.comp, Function.comp_def]
+  simp only [Fin.cons_zero, Fin.cons_succ]
+
+/-- A variant of `hasStrictFDerivAt_finCons` where the derivative variables are free on the RHS
+instead. -/
+theorem hasStrictFDerivAt_finCons'
+    {φ' : E →L[𝕜] F' 0} {φs' : E →L[𝕜] Π i, F' (Fin.succ i)} :
+    HasStrictFDerivAt (fun x => Fin.cons (φ x) (φs x)) (φ'.finCons φs') x ↔
+      HasStrictFDerivAt φ φ' x ∧ HasStrictFDerivAt φs φs' x :=
+  hasStrictFDerivAt_finCons
+
+@[fun_prop]
+theorem hasStrictFDerivAt.finCons
+    {φ' : E →L[𝕜] F' 0} {φs' : E →L[𝕜] Π i, F' (Fin.succ i)}
+    (h : HasStrictFDerivAt φ φ' x) (hs : HasStrictFDerivAt φs φs' x) :
+    HasStrictFDerivAt (fun x => Fin.cons (φ x) (φs x)) (φ'.finCons φs') x :=
+  hasStrictFDerivAt_finCons'.mpr ⟨h, hs⟩
+
+theorem hasFDerivAtFilter_finCons
+    {φ' : E →L[𝕜] Π i, F' i} {l : Filter E} :
+    HasFDerivAtFilter (fun x => Fin.cons (φ x) (φs x)) φ' x l ↔
+      HasFDerivAtFilter φ (.proj 0 ∘L φ') x l ∧
+      HasFDerivAtFilter φs (Pi.compRightL 𝕜 F' Fin.succ ∘L φ') x l := by
+  rw [hasFDerivAtFilter_pi', Fin.forall_fin_succ, hasFDerivAtFilter_pi']
+  dsimp [ContinuousLinearMap.comp, LinearMap.comp, Function.comp_def]
+  simp only [Fin.cons_zero, Fin.cons_succ]
+
+/-- A variant of `hasFDerivAtFilter_finCons` where the derivative variables are free on the RHS
+instead. -/
+theorem hasFDerivAtFilter_finCons'
+    {φ' : E →L[𝕜] F' 0} {φs' : E →L[𝕜] Π i, F' (Fin.succ i)} {l : Filter E} :
+    HasFDerivAtFilter (fun x => Fin.cons (φ x) (φs x)) (φ'.finCons φs') x l ↔
+      HasFDerivAtFilter φ φ' x l ∧ HasFDerivAtFilter φs φs' x l :=
+  hasFDerivAtFilter_finCons
+
+theorem hasFDerivAtFilter.finCons
+    {φ' : E →L[𝕜] F' 0} {φs' : E →L[𝕜] Π i, F' (Fin.succ i)} {l : Filter E}
+    (h : HasFDerivAtFilter φ φ' x l) (hs : HasFDerivAtFilter φs φs' x l) :
+    HasFDerivAtFilter (fun x => Fin.cons (φ x) (φs x)) (φ'.finCons φs') x l :=
+  hasFDerivAtFilter_finCons'.mpr ⟨h, hs⟩
+
+theorem HasFDerivAt_finCons
+    {φ' : E →L[𝕜] Π i, F' i} :
+    HasFDerivAt (fun x => Fin.cons (φ x) (φs x)) φ' x ↔
+      HasFDerivAt φ (.proj 0 ∘L φ') x ∧ HasFDerivAt φs (Pi.compRightL 𝕜 F' Fin.succ ∘L φ') x :=
+  hasFDerivAtFilter_finCons
+
+/-- A variant of `hasFDerivAt_finCons` where the derivative variables are free on the RHS
+instead. -/
+theorem hasFDerivAt_finCons'
+    {φ' : E →L[𝕜] F' 0} {φs' : E →L[𝕜] Π i, F' (Fin.succ i)} :
+    HasFDerivAt (fun x => Fin.cons (φ x) (φs x)) (φ'.finCons φs') x ↔
+      HasFDerivAt φ φ' x ∧ HasFDerivAt φs φs' x :=
+  HasFDerivAt_finCons
+
+@[fun_prop]
+theorem HasFDerivAt.finCons
+    {φ' : E →L[𝕜] F' 0} {φs' : E →L[𝕜] Π i, F' (Fin.succ i)}
+    (h : HasFDerivAt φ φ' x) (hs : HasFDerivAt φs φs' x) :
+    HasFDerivAt (fun x => Fin.cons (φ x) (φs x)) (φ'.finCons φs') x :=
+  hasFDerivAt_finCons'.mpr ⟨h, hs⟩
+
+theorem hasFDerivWithinAt_finCons
+    {φ' : E →L[𝕜] Π i, F' i} :
+    HasFDerivWithinAt (fun x => Fin.cons (φ x) (φs x)) φ' s x ↔
+      HasFDerivWithinAt φ (.proj 0 ∘L φ') s x ∧
+      HasFDerivWithinAt φs (Pi.compRightL 𝕜 F' Fin.succ ∘L φ') s x :=
+  hasFDerivAtFilter_finCons
+
+/-- A variant of `hasFDerivWithinAt_finCons` where the derivative variables are free on the RHS
+instead. -/
+theorem hasFDerivWithinAt_finCons'
+    {φ' : E →L[𝕜] F' 0} {φs' : E →L[𝕜] Π i, F' (Fin.succ i)} :
+    HasFDerivWithinAt (fun x => Fin.cons (φ x) (φs x)) (φ'.finCons φs') s x ↔
+      HasFDerivWithinAt φ φ' s x ∧ HasFDerivWithinAt φs φs' s x :=
+  hasFDerivAtFilter_finCons
+
+@[fun_prop]
+theorem HasFDerivWithinAt.finCons
+    {φ' : E →L[𝕜] F' 0} {φs' : E →L[𝕜] Π i, F' (Fin.succ i)}
+    (h : HasFDerivWithinAt φ φ' s x) (hs : HasFDerivWithinAt φs φs' s x) :
+    HasFDerivWithinAt (fun x => Fin.cons (φ x) (φs x)) (φ'.finCons φs') s x :=
+  hasFDerivWithinAt_finCons'.mpr ⟨h, hs⟩
+
+theorem differentiableWithinAt_finCons:
+    DifferentiableWithinAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) s x ↔
+      DifferentiableWithinAt 𝕜 φ s x ∧
+      DifferentiableWithinAt 𝕜 φs s x := by
+  rw [differentiableWithinAt_pi, Fin.forall_fin_succ, differentiableWithinAt_pi]
+  simp only [Fin.cons_zero, Fin.cons_succ]
+
+/-- A variant of `differentiableWithinAt_finCons` where the derivative variables are free on the RHS
+instead. -/
+theorem differentiableWithinAt_finCons' :
+    DifferentiableWithinAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) s x ↔
+      DifferentiableWithinAt 𝕜 φ s x ∧ DifferentiableWithinAt 𝕜 φs s x :=
+  differentiableWithinAt_finCons
+
+@[fun_prop]
+theorem DifferentiableWithinAt.finCons
+    (h : DifferentiableWithinAt 𝕜 φ s x) (hs : DifferentiableWithinAt 𝕜 φs s x) :
+    DifferentiableWithinAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) s x :=
+  differentiableWithinAt_finCons'.mpr ⟨h, hs⟩
+
+theorem differentiableAt_finCons:
+    DifferentiableAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) x ↔
+      DifferentiableAt 𝕜 φ x ∧
+      DifferentiableAt 𝕜 φs x := by
+  rw [differentiableAt_pi, Fin.forall_fin_succ, differentiableAt_pi]
+  simp only [Fin.cons_zero, Fin.cons_succ]
+
+/-- A variant of `differentiableAt_finCons` where the derivative variables are free on the RHS
+instead. -/
+theorem differentiableAt_finCons' :
+    DifferentiableAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) x ↔
+      DifferentiableAt 𝕜 φ x ∧ DifferentiableAt 𝕜 φs x :=
+  differentiableAt_finCons
+
+@[fun_prop]
+theorem DifferentiableAt.finCons
+    (h : DifferentiableAt 𝕜 φ x) (hs : DifferentiableAt 𝕜 φs x) :
+    DifferentiableAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) x :=
+  differentiableAt_finCons'.mpr ⟨h, hs⟩
+
+theorem differentiableOn_finCons:
+    DifferentiableOn 𝕜 (fun x => Fin.cons (φ x) (φs x)) s ↔
+      DifferentiableOn 𝕜 φ s ∧
+      DifferentiableOn 𝕜 φs s := by
+  rw [differentiableOn_pi, Fin.forall_fin_succ, differentiableOn_pi]
+  simp only [Fin.cons_zero, Fin.cons_succ]
+
+/-- A variant of `differentiableOn_finCons` where the derivative variables are free on the RHS
+instead. -/
+theorem differentiableOn_finCons' :
+    DifferentiableOn 𝕜 (fun x => Fin.cons (φ x) (φs x)) s ↔
+      DifferentiableOn 𝕜 φ s ∧ DifferentiableOn 𝕜 φs s :=
+  differentiableOn_finCons
+
+@[fun_prop]
+theorem DifferentiableOn.finCons
+    (h : DifferentiableOn 𝕜 φ s) (hs : DifferentiableOn 𝕜 φs s) :
+    DifferentiableOn 𝕜 (fun x => Fin.cons (φ x) (φs x)) s :=
+  differentiableOn_finCons'.mpr ⟨h, hs⟩
+
+theorem differentiable_finCons :
+    Differentiable 𝕜 (fun x => Fin.cons (φ x) (φs x)) ↔
+      Differentiable 𝕜 φ ∧
+      Differentiable 𝕜 φs := by
+  rw [differentiable_pi, Fin.forall_fin_succ, differentiable_pi]
+  simp only [Fin.cons_zero, Fin.cons_succ]
+
+/-- A variant of `differentiable_finCons` where the derivative variables are free on the RHS
+instead. -/
+theorem differentiable_finCons' :
+    Differentiable 𝕜 (fun x => Fin.cons (φ x) (φs x)) ↔
+      Differentiable 𝕜 φ ∧ Differentiable 𝕜 φs :=
+  differentiable_finCons
+
+@[fun_prop]
+theorem Differentiable.finCons
+    (h : Differentiable 𝕜 φ) (hs : Differentiable 𝕜 φs) :
+    Differentiable 𝕜 (fun x => Fin.cons (φ x) (φs x)) :=
+  differentiable_finCons'.mpr ⟨h, hs⟩
+
+-- TODO: write the `Fin.cons` versions of `fderivWithin_pi` and `fderiv_pi`
+
+end PiFin
 
 end CartesianProduct
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -496,26 +496,35 @@ as `Matrix.vecCons` is defeq to `Fincons`.
 -/
 section PiFin
 
-variable {n : Nat} {F' : Fin n.succ → Type*}
-variable [∀ i, NormedAddCommGroup (F' i)] [∀ i, NormedSpace 𝕜 (F' i)]
-variable {φ : E → F' 0} {φs : E → ∀ i, F' (Fin.succ i)}
+section TVS
 
-variable (𝕜 F') in
-/-- `Fin.consEquiv` as a continuous linear equivalence.
+variable {n : ℕ} {𝕜 : Type*} {α : Fin n.succ → Type*}
+variable [Semiring 𝕜]
+variable [∀ i, AddCommMonoid (α i)] [∀ i, Module 𝕜 (α i)] [∀ i, TopologicalSpace (α i)]
 
-TODO: generalize to TVS, find a home. -/
+-- TODO: find a better home for this definition
+variable (𝕜 α) in
+/-- `Fin.consEquiv` as a continuous linear equivalence.  -/
 @[simps]
-def Fin.consEquivL : (F' 0 × Π i, F' (Fin.succ i)) ≃L[𝕜] (Π i, F' i) where
-  __ := Fin.consEquiv F'
+def Fin.consEquivL : (α 0 × Π i, α (Fin.succ i)) ≃L[𝕜] (Π i, α i) where
+  __ := Fin.consEquiv α
   map_add' x y := funext <| Fin.cases rfl (by simp)
   map_smul' c x := funext <| Fin.cases rfl (by simp)
   continuous_toFun := continuous_id.fst.finCons continuous_id.snd
   continuous_invFun := .prod_mk (continuous_apply 0) (by continuity)
 
 /-- `Fin.cons` in the codomain of continuous linear maps. -/
-abbrev ContinuousLinearMap.finCons (φ' : E →L[𝕜] F' 0) (φs' : E →L[𝕜] Π i, F' (Fin.succ i)) :
-    E →L[𝕜] Π i, F' i :=
-  Fin.consEquivL 𝕜 F' ∘L φ'.prod φs'
+abbrev ContinuousLinearMap.finCons
+    {E : Type*} [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E]
+    (φ' : E →L[𝕜] α 0) (φs' : E →L[𝕜] Π i, α (Fin.succ i)) :
+    E →L[𝕜] Π i, α i :=
+  Fin.consEquivL 𝕜 α ∘L φ'.prod φs'
+
+end TVS
+
+variable {n : Nat} {F' : Fin n.succ → Type*}
+variable [∀ i, NormedAddCommGroup (F' i)] [∀ i, NormedSpace 𝕜 (F' i)]
+variable {φ : E → F' 0} {φs : E → ∀ i, F' (Fin.succ i)}
 
 theorem hasStrictFDerivAt_finCons {φ' : E →L[𝕜] Π i, F' i} :
     HasStrictFDerivAt (fun x => Fin.cons (φ x) (φs x)) φ' x ↔

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -485,7 +485,6 @@ theorem fderiv_pi (h : ∀ i, DifferentiableAt 𝕜 (φ i) x) :
     fderiv 𝕜 (fun x i => φ i x) x = pi fun i => fderiv 𝕜 (φ i) x :=
   (hasFDerivAt_pi.2 fun i => (h i).hasFDerivAt).fderiv
 
-
 end Pi
 
 /-!

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -501,13 +501,19 @@ variable [∀ i, NormedAddCommGroup (F' i)] [∀ i, NormedSpace 𝕜 (F' i)]
 variable {φ : E → F' 0} {φs : E → ∀ i, F' (Fin.succ i)}
 
 -- TODO: generalize to TVS, find a home
+variable (𝕜 F') in
+/-- `Fin.consEquiv` as a continuous linear equivalence -/
+def Fin.consEquivL : (F' 0 × Π i, F' (Fin.succ i)) ≃L[𝕜] (Π i, F' i) where
+  __ := Fin.consEquiv F'
+  map_add' x y := funext <| Fin.cases rfl (by simp)
+  map_smul' c x := funext <| Fin.cases rfl (by simp)
+  continuous_toFun := continuous_id.fst.finCons continuous_id.snd
+  continuous_invFun := .prod_mk (continuous_apply 0) (by continuity)
+
 /-- `Fin.cons` in the codomain of continuous linear maps. -/
-def ContinuousLinearMap.finCons (φ' : E →L[𝕜] F' 0) (φs' : E →L[𝕜] Π i, F' (Fin.succ i)) :
-    E →L[𝕜] Π i, F' i where
-  toFun x := Fin.cons (φ' x) (φs' x)
-  map_add' x y := funext <| Fin.cases (map_add φ' x y) (by simp)
-  map_smul' c x := funext <| Fin.cases (map_smul φ' c x) (by simp)
-  cont := φ'.continuous.finCons φs'.continuous
+abbrev ContinuousLinearMap.finCons (φ' : E →L[𝕜] F' 0) (φs' : E →L[𝕜] Π i, F' (Fin.succ i)) :
+    E →L[𝕜] Π i, F' i :=
+  Fin.consEquivL 𝕜 F' ∘L φ'.prod φs'
 
 theorem hasStrictFDerivAt_finCons {φ' : E →L[𝕜] Π i, F' i} :
     HasStrictFDerivAt (fun x => Fin.cons (φ x) (φs x)) φ' x ↔

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -506,9 +506,7 @@ variable (𝕜 α) in
 /-- `Fin.consEquiv` as a continuous linear equivalence.  -/
 @[simps]
 def Fin.consEquivL : (α 0 × Π i, α (Fin.succ i)) ≃L[𝕜] (Π i, α i) where
-  __ := Fin.consEquiv α
-  map_add' x y := funext <| Fin.cases rfl (by simp)
-  map_smul' c x := funext <| Fin.cases rfl (by simp)
+  __ := Fin.consLinearEquiv 𝕜 α
   continuous_toFun := continuous_id.fst.finCons continuous_id.snd
   continuous_invFun := .prod_mk (continuous_apply 0) (by continuity)
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -614,10 +614,9 @@ theorem HasFDerivWithinAt.finCons
     HasFDerivWithinAt (fun x => Fin.cons (φ x) (φs x)) (φ'.finCons φs') s x :=
   hasFDerivWithinAt_finCons'.mpr ⟨h, hs⟩
 
-theorem differentiableWithinAt_finCons:
+theorem differentiableWithinAt_finCons :
     DifferentiableWithinAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) s x ↔
-      DifferentiableWithinAt 𝕜 φ s x ∧
-      DifferentiableWithinAt 𝕜 φs s x := by
+      DifferentiableWithinAt 𝕜 φ s x ∧ DifferentiableWithinAt 𝕜 φs s x := by
   rw [differentiableWithinAt_pi, Fin.forall_fin_succ, differentiableWithinAt_pi]
   simp only [Fin.cons_zero, Fin.cons_succ]
 
@@ -634,10 +633,9 @@ theorem DifferentiableWithinAt.finCons
     DifferentiableWithinAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) s x :=
   differentiableWithinAt_finCons'.mpr ⟨h, hs⟩
 
-theorem differentiableAt_finCons:
+theorem differentiableAt_finCons :
     DifferentiableAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) x ↔
-      DifferentiableAt 𝕜 φ x ∧
-      DifferentiableAt 𝕜 φs x := by
+      DifferentiableAt 𝕜 φ x ∧ DifferentiableAt 𝕜 φs x := by
   rw [differentiableAt_pi, Fin.forall_fin_succ, differentiableAt_pi]
   simp only [Fin.cons_zero, Fin.cons_succ]
 
@@ -654,10 +652,9 @@ theorem DifferentiableAt.finCons
     DifferentiableAt 𝕜 (fun x => Fin.cons (φ x) (φs x)) x :=
   differentiableAt_finCons'.mpr ⟨h, hs⟩
 
-theorem differentiableOn_finCons:
+theorem differentiableOn_finCons :
     DifferentiableOn 𝕜 (fun x => Fin.cons (φ x) (φs x)) s ↔
-      DifferentiableOn 𝕜 φ s ∧
-      DifferentiableOn 𝕜 φs s := by
+      DifferentiableOn 𝕜 φ s ∧ DifferentiableOn 𝕜 φs s := by
   rw [differentiableOn_pi, Fin.forall_fin_succ, differentiableOn_pi]
   simp only [Fin.cons_zero, Fin.cons_succ]
 
@@ -676,8 +673,7 @@ theorem DifferentiableOn.finCons
 
 theorem differentiable_finCons :
     Differentiable 𝕜 (fun x => Fin.cons (φ x) (φs x)) ↔
-      Differentiable 𝕜 φ ∧
-      Differentiable 𝕜 φs := by
+      Differentiable 𝕜 φ ∧ Differentiable 𝕜 φs := by
   rw [differentiable_pi, Fin.forall_fin_succ, differentiable_pi]
   simp only [Fin.cons_zero, Fin.cons_succ]
 

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -11,6 +11,7 @@ import Mathlib.Algebra.Module.Submodule.Ker
 import Mathlib.Algebra.Module.Submodule.Range
 import Mathlib.Algebra.Module.Equiv.Basic
 import Mathlib.Logic.Equiv.Fin
+import Mathlib.LinearAlgebra.Prod
 
 /-!
 # Pi types of modules
@@ -571,6 +572,17 @@ noncomputable def Function.ExtendByZero.linearMap : (ι → R) →ₗ[R] η → 
 
 end Extend
 
+variable (R) in
+/-- `Fin.consEquiv` as a continuous linear equivalence.  -/
+@[simps]
+def Fin.consLinearEquiv
+    {n : ℕ} (M : Fin n.succ → Type*) [Semiring R] [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)] :
+    (M 0 × Π i, M (Fin.succ i)) ≃ₗ[R] (Π i, M i) where
+  __ := Fin.consEquiv M
+  map_add' x y := funext <| Fin.cases rfl (by simp)
+  map_smul' c x := funext <| Fin.cases rfl (by simp)
+
+
 /-! ### Bundled versions of `Matrix.vecCons` and `Matrix.vecEmpty`
 
 The idea of these definitions is to be able to define a map as `x ↦ ![f₁ x, f₂ x, f₃ x]`, where
@@ -604,14 +616,8 @@ theorem LinearMap.vecEmpty_apply (m : M) : (LinearMap.vecEmpty : M →ₗ[R] Fin
 
 /-- A linear map into `Fin n.succ → M₃` can be built out of a map into `M₃` and a map into
 `Fin n → M₃`. -/
-def LinearMap.vecCons {n} (f : M →ₗ[R] M₂) (g : M →ₗ[R] Fin n → M₂) : M →ₗ[R] Fin n.succ → M₂ where
-  toFun m := Matrix.vecCons (f m) (g m)
-  map_add' x y := by
-    simp only []
-    rw [f.map_add, g.map_add, Matrix.cons_add_cons (f x)]
-  map_smul' c x := by
-    simp only []
-    rw [f.map_smul, g.map_smul, RingHom.id_apply, Matrix.smul_cons c (f x)]
+def LinearMap.vecCons {n} (f : M →ₗ[R] M₂) (g : M →ₗ[R] Fin n → M₂) : M →ₗ[R] Fin n.succ → M₂ :=
+  Fin.consLinearEquiv R (fun _ : Fin n.succ => M₂) ∘ₗ f.prod g
 
 @[simp]
 theorem LinearMap.vecCons_apply {n} (f : M →ₗ[R] M₂) (g : M →ₗ[R] Fin n → M₂) (m : M) :

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -820,6 +820,28 @@ def piFinTwo (M : Fin 2 → Type*) [∀ i, AddCommMonoid (M i)] [∀ i, Module R
 def finTwoArrow : (Fin 2 → M) ≃L[R] M × M :=
   { piFinTwo R fun _ => M with toLinearEquiv := LinearEquiv.finTwoArrow R M }
 
+section
+variable {n : ℕ} {R : Type*} {M : Fin n.succ → Type*} {N : Type*}
+variable [Semiring R]
+variable [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)] [∀ i, TopologicalSpace (M i)]
+
+variable (R M) in
+/-- `Fin.consEquiv` as a continuous linear equivalence.  -/
+@[simps!]
+def _root_.Fin.consEquivL : (M 0 × Π i, M (Fin.succ i)) ≃L[R] (Π i, M i) where
+  __ := Fin.consLinearEquiv R M
+  continuous_toFun := continuous_id.fst.finCons continuous_id.snd
+  continuous_invFun := .prod_mk (continuous_apply 0) (by continuity)
+
+/-- `Fin.cons` in the codomain of continuous linear maps. -/
+abbrev _root_.ContinuousLinearMap.finCons
+    [AddCommMonoid N] [Module R N] [TopologicalSpace N]
+    (f : N →L[R] M 0) (fs : N →L[R] Π i, M (Fin.succ i)) :
+    N →L[R] Π i, M i :=
+  Fin.consEquivL R M ∘L f.prod fs
+
+end
+
 end
 
 end ContinuousLinearEquiv


### PR DESCRIPTION
I'm too lazy to add these for `Fin.snoc` as well, and I suspect people care much less about that.

Strictly we need to repeat all these for `Matrix.vecCons` as well...


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
