### PR TITLE
[Merged by Bors] - chore(Algebra/Lie): rename theorems for consistency

### DIFF
--- a/Mathlib/Algebra/Lie/Engel.lean
+++ b/Mathlib/Algebra/Lie/Engel.lean
@@ -198,7 +198,7 @@ theorem LieAlgebra.exists_engelian_lieSubalgebra_of_lt_normalizer {K : LieSubalg
   obtain ⟨I, hI₁ : (I : LieSubalgebra R K') = LieSubalgebra.ofLe hKK'⟩ :=
     LieSubalgebra.exists_nested_lieIdeal_ofLe_normalizer hKK' hK'
   have hI₂ : (R ∙ (⟨x, hxK'⟩ : K')) ⊔ (LieSubmodule.toSubmodule I) = ⊤ := by
-    rw [← LieIdeal.coe_toLieSubalgebra_toSubmodule R K' I, hI₁]
+    rw [← LieIdeal.toLieSubalgebra_toSubmodule R K' I, hI₁]
     apply Submodule.map_injective_of_injective (K' : Submodule R L).injective_subtype
     simp only [LieSubalgebra.coe_ofLe, Submodule.map_sup, Submodule.map_subtype_range_inclusion,
       Submodule.map_top, Submodule.range_subtype]

--- a/Mathlib/Algebra/Lie/InvariantForm.lean
+++ b/Mathlib/Algebra/Lie/InvariantForm.lean
@@ -150,7 +150,7 @@ lemma restrict_nondegenerate (I : LieIdeal K L) (hI : IsAtom I) :
 lemma restrict_orthogonal_nondegenerate (I : LieIdeal K L) (hI : IsAtom I) :
     (Φ.restrict (orthogonal Φ hΦ_inv I)).Nondegenerate := by
   rw [LinearMap.BilinForm.restrict_nondegenerate_iff_isCompl_orthogonal hΦ_refl]
-  simp only [LieIdeal.coe_toLieSubalgebra_toSubmodule, orthogonal_toSubmodule,
+  simp only [LieIdeal.toLieSubalgebra_toSubmodule, orthogonal_toSubmodule,
     LinearMap.BilinForm.orthogonal_orthogonal hΦ_nondeg hΦ_refl]
   exact (orthogonal_isCompl_toSubmodule Φ hΦ_nondeg hΦ_inv hΦ_refl hL I hI).symm
 

--- a/Mathlib/Algebra/Lie/Semisimple/Basic.lean
+++ b/Mathlib/Algebra/Lie/Semisimple/Basic.lean
@@ -159,7 +159,7 @@ lemma isSimple_of_isAtom (I : LieIdeal R L) (hI : IsAtom I) : IsSimple R I where
       intro x hx
       suffices x ∈ J → x = 0 from this hx
       have := @this x.1
-      simp only [LieIdeal.incl_coe, LieIdeal.coe_toLieSubalgebra_toSubmodule,
+      simp only [LieIdeal.incl_coe, LieIdeal.toLieSubalgebra_toSubmodule,
         LieSubmodule.mem_mk_iff', Submodule.mem_map, LieSubmodule.mem_toSubmodule, Subtype.exists,
         LieSubmodule.mem_bot, ZeroMemClass.coe_eq_zero, forall_exists_index, and_imp, J'] at this
       exact fun _ ↦ this (↑x) x.property hx rfl

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -227,6 +227,8 @@ theorem lie_mem_left (I : LieIdeal R L) (x y : L) (h : x ∈ I) : ⁅x, y⁆ ∈
 def LieIdeal.toLieSubalgebra (I : LieIdeal R L) : LieSubalgebra R L :=
   { I.toSubmodule with lie_mem' := by intro x y _ hy; apply lie_mem_right; exact hy }
 
+@[deprecated (since := "2025-01-02")] alias lieIdealSubalgebra := LieIdeal.toLieSubalgebra
+
 instance : Coe (LieIdeal R L) (LieSubalgebra R L) :=
   ⟨LieIdeal.toLieSubalgebra R L⟩
 
@@ -241,6 +243,9 @@ alias LieIdeal.coe_toSubalgebra := LieIdeal.coe_toLieSubalgebra
 theorem LieIdeal.toLieSubalgebra_toSubmodule (I : LieIdeal R L) :
     ((I : LieSubalgebra R L) : Submodule R L) = LieSubmodule.toSubmodule I :=
   rfl
+
+@[deprecated (since := "2025-01-02")]
+alias LieIdeal.coe_toLieSubalgebra_toSubmodule := LieIdeal.toLieSubalgebra_toSubmodule
 
 @[deprecated (since := "2024-12-30")]
 alias LieIdeal.coe_to_lieSubalgebra_to_submodule := LieIdeal.toLieSubalgebra_toSubmodule

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -224,11 +224,11 @@ theorem lie_mem_left (I : LieIdeal R L) (x y : L) (h : x ∈ I) : ⁅x, y⁆ ∈
   rw [← lie_skew, ← neg_lie]; apply lie_mem_right; assumption
 
 /-- An ideal of a Lie algebra is a Lie subalgebra. -/
-def lieIdealSubalgebra (I : LieIdeal R L) : LieSubalgebra R L :=
+def LieIdeal.toLieSubalgebra (I : LieIdeal R L) : LieSubalgebra R L :=
   { I.toSubmodule with lie_mem' := by intro x y _ hy; apply lie_mem_right; exact hy }
 
 instance : Coe (LieIdeal R L) (LieSubalgebra R L) :=
-  ⟨lieIdealSubalgebra R L⟩
+  ⟨LieIdeal.toLieSubalgebra R L⟩
 
 @[simp]
 theorem LieIdeal.coe_toLieSubalgebra (I : LieIdeal R L) : ((I : LieSubalgebra R L) : Set L) = I :=
@@ -238,12 +238,12 @@ theorem LieIdeal.coe_toLieSubalgebra (I : LieIdeal R L) : ((I : LieSubalgebra R 
 alias LieIdeal.coe_toSubalgebra := LieIdeal.coe_toLieSubalgebra
 
 @[simp]
-theorem LieIdeal.coe_toLieSubalgebra_toSubmodule (I : LieIdeal R L) :
+theorem LieIdeal.toLieSubalgebra_toSubmodule (I : LieIdeal R L) :
     ((I : LieSubalgebra R L) : Submodule R L) = LieSubmodule.toSubmodule I :=
   rfl
 
 @[deprecated (since := "2024-12-30")]
-alias LieIdeal.coe_to_lieSubalgebra_to_submodule := LieIdeal.coe_toLieSubalgebra_toSubmodule
+alias LieIdeal.coe_to_lieSubalgebra_to_submodule := LieIdeal.toLieSubalgebra_toSubmodule
 
 /-- An ideal of `L` is a Lie subalgebra of `L`, so it is a Lie ring. -/
 instance LieIdeal.lieRing (I : LieIdeal R L) : LieRing I :=
@@ -300,7 +300,7 @@ theorem mem_toLieSubmodule (x : L) : x ∈ K.toLieSubmodule ↔ x ∈ K :=
 
 theorem exists_lieIdeal_coe_eq_iff :
     (∃ I : LieIdeal R L, ↑I = K) ↔ ∀ x y : L, y ∈ K → ⁅x, y⁆ ∈ K := by
-  simp only [← toSubmodule_inj, LieIdeal.coe_toLieSubalgebra_toSubmodule,
+  simp only [← toSubmodule_inj, LieIdeal.toLieSubalgebra_toSubmodule,
     Submodule.exists_lieSubmodule_coe_eq_iff L]
   exact Iff.rfl
 
@@ -1099,7 +1099,7 @@ theorem IsIdealMorphism.eq (hf : f.IsIdealMorphism) : f.idealRange = f.range := 
 theorem isIdealMorphism_iff : f.IsIdealMorphism ↔ ∀ (x : L') (y : L), ∃ z : L, ⁅x, f y⁆ = f z := by
   simp only [isIdealMorphism_def, idealRange_eq_lieSpan_range, ←
     LieSubalgebra.toSubmodule_inj, ← f.range.coe_toSubmodule,
-    LieIdeal.coe_toLieSubalgebra_toSubmodule, LieSubmodule.coe_lieSpan_submodule_eq_iff,
+    LieIdeal.toLieSubalgebra_toSubmodule, LieSubmodule.coe_lieSpan_submodule_eq_iff,
     LieSubalgebra.mem_toSubmodule, mem_range, exists_imp,
     Submodule.exists_lieSubmodule_coe_eq_iff]
   constructor
@@ -1288,7 +1288,7 @@ theorem ker_incl : I.incl.ker = ⊥ := by ext; simp
 @[simp]
 theorem incl_idealRange : I.incl.idealRange = I := by
   rw [LieHom.idealRange_eq_lieSpan_range, ← LieSubalgebra.coe_toSubmodule, ←
-    LieSubmodule.toSubmodule_inj, incl_range, coe_toLieSubalgebra_toSubmodule,
+    LieSubmodule.toSubmodule_inj, incl_range, toLieSubalgebra_toSubmodule,
     LieSubmodule.coe_lieSpan_submodule_eq_iff]
   use I
 

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -287,7 +287,7 @@ lemma lowerCentralSeries_one_inf_center_le_ker_traceForm [Module.Free R M] [Modu
 lemma isLieAbelian_of_ker_traceForm_eq_bot [Module.Free R M] [Module.Finite R M]
     (h : LinearMap.ker (traceForm R L M) = ⊥) : IsLieAbelian L := by
   simpa only [← disjoint_lowerCentralSeries_maxTrivSubmodule_iff R L L, disjoint_iff_inf_le,
-    LieIdeal.coe_toLieSubalgebra_toSubmodule, LieSubmodule.toSubmodule_eq_bot, h]
+    LieIdeal.toLieSubalgebra_toSubmodule, LieSubmodule.toSubmodule_eq_bot, h]
     using lowerCentralSeries_one_inf_center_le_ker_traceForm R L M
 
 end LieModule


### PR DESCRIPTION
Cleaning up issues raised in #20353

Moves:
lieIdealSubalgebra -> LieIdeal.toLieSubalgebra
LieIdeal.coe_toLieSubalgebra_toSubmodule -> LieIdeal.toLieSubalgebra_toSubmodule

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
