### PR TITLE
[Merged by Bors] - chore(Linter/UnusedTactic): do not exclude `change` from linted tactics

### DIFF
--- a/Mathlib/Algebra/EuclideanDomain/Defs.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Defs.lean
@@ -159,11 +159,8 @@ section
 theorem GCD.induction {P : R → R → Prop} (a b : R) (H0 : ∀ x, P 0 x)
     (H1 : ∀ a b, a ≠ 0 → P (b % a) a → P a b) : P a b := by
   classical
-  exact if a0 : a = 0 then by
-    -- Porting note: required for hygiene, the equation compiler introduces a dummy variable `x`
-    -- See https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/unnecessarily.20tombstoned.20argument/near/314573315
-    change P a b
-    exact a0.symm ▸ H0 b
+  exact if a0 : a = 0 then
+    a0.symm ▸ H0 b
   else
     have _ := mod_lt b a0
     H1 _ _ a0 (GCD.induction (b % a) a H0 H1)

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -267,7 +267,6 @@ theorem exists_multiset_roots [DecidableEq R] :
             rw [← degree_add_divByMonic (monic_X_sub_C x) hdeg, degree_X_sub_C, add_comm]
             exact add_le_add (le_refl (1 : WithBot ℕ)) htd,
         by
-          change ∀ (a : R), count a (x ::ₘ t) = rootMultiplicity a p
           intro a
           conv_rhs => rw [← mul_divByMonic_eq_iff_isRoot.mpr hx]
           rw [rootMultiplicity_mul (mul_ne_zero (X_sub_C_ne_zero x) hdiv0),

--- a/Mathlib/Algebra/Ring/WithZero.lean
+++ b/Mathlib/Algebra/Ring/WithZero.lean
@@ -24,8 +24,7 @@ instance instRightDistribClass [Mul α] [Add α] [RightDistribClass α] :
     RightDistribClass (WithZero α) where
   right_distrib a b c := by
     cases' c with c
-    · change (a + b) * 0 = a * 0 + b * 0
-      simp
+    · simp
     cases' a with a <;> cases' b with b <;> try rfl
     exact congr_arg some (right_distrib _ _ _)
 

--- a/Mathlib/CategoryTheory/Monad/Comonadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Comonadicity.lean
@@ -146,9 +146,7 @@ def counitFork (A : adj.toComonad.Coalgebra)
     [HasEqualizer (G.map A.a) (adj.unit.app (G.obj A.A))] :
     Fork (F.map (G.map A.a)) (F.map (adj.unit.app (G.obj A.A))) :=
   Fork.ofι (F.map (equalizer.ι (G.map A.a) (adj.unit.app (G.obj A.A))))
-    (by
-      change _ = F.map _ ≫ _
-      rw [← F.map_comp, equalizer.condition, F.map_comp])
+    (by rw [← F.map_comp, equalizer.condition, F.map_comp])
 
 @[simp]
 theorem unitFork_ι (A : adj.toComonad.Coalgebra)

--- a/Mathlib/CategoryTheory/Monad/Monadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Monadicity.lean
@@ -160,9 +160,7 @@ def unitCofork (A : adj.toMonad.Algebra)
     [HasCoequalizer (F.map A.a) (adj.counit.app (F.obj A.A))] :
     Cofork (G.map (F.map A.a)) (G.map (adj.counit.app (F.obj A.A))) :=
   Cofork.ofπ (G.map (coequalizer.π (F.map A.a) (adj.counit.app (F.obj A.A))))
-    (by
-      change _ = G.map _ ≫ _
-      rw [← G.map_comp, coequalizer.condition, G.map_comp])
+    (by rw [← G.map_comp, coequalizer.condition, G.map_comp])
 
 @[simp]
 theorem unitCofork_π (A : adj.toMonad.Algebra)

--- a/Mathlib/CategoryTheory/Sites/Sieves.lean
+++ b/Mathlib/CategoryTheory/Sites/Sieves.lean
@@ -626,7 +626,6 @@ theorem pullbackArrows_comm [HasPullbacks C] {X Y : C} (f : Y ⟶ X) (R : Presie
   constructor
   · rintro ⟨_, h, k, hk, rfl⟩
     cases' hk with W g hg
-    change (Sieve.generate R).pullback f (h ≫ pullback.snd g f)
     rw [Sieve.pullback_apply, assoc, ← pullback.condition, ← assoc]
     exact Sieve.downward_closed _ (by exact Sieve.le_generate R W hg) (h ≫ pullback.fst g f)
   · rintro ⟨W, h, k, hk, comm⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
@@ -428,7 +428,6 @@ private theorem edgeDensity_star_not_uniform [Nonempty α]
   set q : ℝ :=
     (∑ ab ∈ (chunk hP G ε hU).parts.product (chunk hP G ε hV).parts,
       (G.edgeDensity ab.1 ab.2 : ℝ)) / (↑4 ^ #P.parts * ↑4 ^ #P.parts)
-  change _ ≤ |p - q|
   set r : ℝ := ↑(G.edgeDensity ((star hP G ε hU V).biUnion id) ((star hP G ε hV U).biUnion id))
   set s : ℝ := ↑(G.edgeDensity (G.nonuniformWitness ε U V) (G.nonuniformWitness ε V U))
   set t : ℝ := ↑(G.edgeDensity U V)

--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -83,7 +83,6 @@ theorem bot_rel_eq_leftRel (H : Subgroup G) :
   rw [rel_iff, QuotientGroup.leftRel_apply]
   constructor
   · rintro ⟨a, rfl : a = 1, b, hb, rfl⟩
-    change a⁻¹ * (1 * a * b) ∈ H
     rwa [one_mul, inv_mul_cancel_left]
   · rintro (h : a⁻¹ * b ∈ H)
     exact ⟨1, rfl, a⁻¹ * b, h, by rw [one_mul, mul_inv_cancel_left]⟩
@@ -94,7 +93,6 @@ theorem rel_bot_eq_right_group_rel (H : Subgroup G) :
   rw [rel_iff, QuotientGroup.rightRel_apply]
   constructor
   · rintro ⟨b, hb, a, rfl : a = 1, rfl⟩
-    change b * a * 1 * a⁻¹ ∈ H
     rwa [mul_one, mul_inv_cancel_right]
   · rintro (h : b * a⁻¹ ∈ H)
     exact ⟨b * a⁻¹, h, 1, rfl, by rw [mul_one, inv_mul_cancel_right]⟩

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -952,8 +952,7 @@ theorem norm_eq_zpow_neg_valuation {x : ℚ_[p]} : x ≠ 0 → ‖x‖ = (p : �
   refine Quotient.inductionOn' x fun f hf => ?_
   change (PadicSeq.norm _ : ℝ) = (p : ℝ) ^ (-PadicSeq.valuation _)
   rw [PadicSeq.norm_eq_zpow_neg_valuation]
-  · change ↑((p : ℚ) ^ (-PadicSeq.valuation f)) = (p : ℝ) ^ (-PadicSeq.valuation f)
-    rw [Rat.cast_zpow, Rat.cast_natCast]
+  · rw [Rat.cast_zpow, Rat.cast_natCast]
   · apply CauSeq.not_limZero_of_not_congr_zero
     -- Porting note: was `contrapose! hf`
     intro hf'

--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -93,7 +93,6 @@ initialize allowedRef : IO.Ref (Std.HashSet SyntaxNodeKind) ←
     `Mathlib.Tactic.Propose.propose',
     `Lean.Parser.Tactic.traceState,
     `Mathlib.Tactic.tacticMatch_target_,
-    ``Lean.Parser.Tactic.change,
     `change?,
     `«tactic#adaptation_note_»,
     `tacticSleep_heartbeats_,

--- a/Mathlib/Topology/Partial.lean
+++ b/Mathlib/Topology/Partial.lean
@@ -62,7 +62,6 @@ theorem pcontinuous_iff' {f : X →. Y} :
   rintro x ⟨y, ys, fxy⟩ t
   rw [mem_principal]
   intro (h : f.preimage s ⊆ t)
-  change t ∈ 𝓝 x
   apply mem_of_superset _ h
   have h' : ∀ s ∈ 𝓝 y, f.preimage s ∈ 𝓝 x := by
     intro s hs

--- a/MathlibTest/UnusedTactic.lean
+++ b/MathlibTest/UnusedTactic.lean
@@ -1,6 +1,23 @@
 import Mathlib.Tactic.Linter.UnusedTactic
 import Mathlib.Tactic.AdaptationNote
 
+example (h : 0 + 1 = 0) : False := by
+  change 1 = 0 at h
+  simp at h
+
+example : 0 + 1 = 1 := by
+  change 1 = 1
+  rfl
+
+/--
+warning: 'change 1 = 1' tactic does nothing
+note: this linter can be disabled with `set_option linter.unusedTactic false`
+-/
+#guard_msgs in
+example : 1 = 1 := by
+  change 1 = 1
+  rfl
+
 def why2 : True → True := (by refine ·)
 
 example : True := by

--- a/MathlibTest/apply_fun.lean
+++ b/MathlibTest/apply_fun.lean
@@ -234,6 +234,7 @@ example (α β : Type u) [Fintype α] [Fintype β] (h : α = β) : True := by
   trivial
 
 -- Check that metavariables in the goal do not prevent apply_fun from detecting the relation
+set_option linter.unusedTactic false in
 example (f : α ≃ β) (x y : α) (h : f x = f y) : x = y := by
   change _
   -- now the goal is a metavariable


### PR DESCRIPTION
An earlier implementation of the `unusedTactic` linter tested for definitional equality.  For this reason, the tactic `change` was excluded from the list of tactics that the linter inspected.

This PR removes the custom exception on `change`, since the linter actually checks changes in the metavariables themselves, rather than definitional equality of the goals.

As a consequence, some `change`s present in mathlib can be removed: in all cases, I verified that the infoview shows no difference before and after `change`.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Persistent.20.23allow_unused_tactic)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
