### PR TITLE
[Merged by Bors] - chore(Algebra/Category/MonCat/ForgetCorepresentable, Algebra/Group/Equiv/Basic): move definitions and add symmetric version

### DIFF
--- a/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
@@ -4,9 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 import Mathlib.Algebra.Category.Grp.Basic
-import Mathlib.Algebra.Group.ULift
-import Mathlib.CategoryTheory.Yoneda
-import Mathlib.Algebra.Category.MonCat.ForgetCorepresentable
 
 /-!
 # The forget functor is corepresentable

--- a/Mathlib/Algebra/Category/Grp/Limits.lean
+++ b/Mathlib/Algebra/Category/Grp/Limits.lean
@@ -3,6 +3,8 @@ Copyright (c) 2020 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
+
+import Mathlib.Algebra.Category.MonCat.ForgetCorepresentable
 import Mathlib.Algebra.Category.Grp.ForgetCorepresentable
 import Mathlib.Algebra.Category.Grp.Preadditive
 import Mathlib.Algebra.Category.MonCat.Limits

--- a/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
@@ -21,16 +21,6 @@ open CategoryTheory Opposite
 
 namespace MonoidHom
 
-/-- The equivalence `(β →* γ) ≃ (α →* γ)` obtained by precomposition with
-a multiplicative equivalence `e : α ≃* β`. -/
-@[simps]
-def precompEquiv {α β : Type*} [Monoid α] [Monoid β] (e : α ≃* β) (γ : Type*) [Monoid γ] :
-    (β →* γ) ≃ (α →* γ) where
-  toFun f := f.comp e
-  invFun g := g.comp e.symm
-  left_inv _ := by ext; simp
-  right_inv _ := by ext; simp
-
 /-- The equivalence `(Multiplicative ℕ →* α) ≃ α` for any monoid `α`. -/
 @[simps]
 def fromMultiplicativeNatEquiv (α : Type u) [Monoid α] : (Multiplicative ℕ →* α) ≃ α where
@@ -48,16 +38,6 @@ def fromULiftMultiplicativeNatEquiv (α : Type u) [Monoid α] :
 end MonoidHom
 
 namespace AddMonoidHom
-
-/-- The equivalence `(β →+ γ) ≃ (α →+ γ)` obtained by precomposition with
-an additive equivalence `e : α ≃+ β`. -/
-@[simps]
-def precompEquiv {α β : Type*} [AddMonoid α] [AddMonoid β] (e : α ≃+ β) (γ : Type*) [AddMonoid γ] :
-    (β →+ γ) ≃ (α →+ γ) where
-  toFun f := f.comp e
-  invFun g := g.comp e.symm
-  left_inv _ := by ext; simp
-  right_inv _ := by ext; simp
 
 /-- The equivalence `(ℤ →+ α) ≃ α` for any additive group `α`. -/
 @[simps]

--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -634,6 +634,34 @@ protected theorem map_div [Group G] [DivisionMonoid H] (h : G ≃* H) (x y : G) 
 
 end MulEquiv
 
+namespace MonoidHom
+
+/-- The equivalence `(β →+ γ) ≃ (α →+ γ)` obtained by precomposition with
+a multiplicative equivalence `e : α ≃+ β`. -/
+@[to_additive (attr := simps)
+"The equivalence `(β →+ γ) ≃ (α →+ γ)` obtained by precomposition with
+an additive equivalence `e : α ≃+ β`."]
+def precompEquiv {α β : Type*} [Monoid α] [Monoid β] (e : α ≃* β) (γ : Type*) [Monoid γ] :
+    (β →* γ) ≃ (α →* γ) where
+  toFun f := f.comp e
+  invFun g := g.comp e.symm
+  left_inv _ := by ext; simp
+  right_inv _ := by ext; simp
+
+/-- The equivalence `(γ →* α) ≃ (γ →* β)` obtained by postcomposition with
+a multiplicative equivalence `e : α ≃* β`. -/
+@[to_additive (attr := simps)
+"The equivalence `(γ →* α) ≃ (γ →* β)` obtained by postcomposition with
+an additive equivalence `e : α ≃* β`."]
+def postcompEquiv {α β : Type*} [Monoid α] [Monoid β] (e : α ≃* β) (γ : Type*) [Monoid γ] :
+    (γ →* α) ≃ (γ →* β) where
+  toFun f := e.toMonoidHom.comp f
+  invFun g := e.symm.toMonoidHom.comp g
+  left_inv _ := by ext; simp
+  right_inv _ := by ext; simp
+
+end MonoidHom
+
 -- Porting note: we want to add
 -- `@[simps (config := .asFn)]`
 -- here, but it generates simp lemmas which aren't in simp normal form

--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -636,8 +636,8 @@ end MulEquiv
 
 namespace MonoidHom
 
-/-- The equivalence `(β →+ γ) ≃ (α →+ γ)` obtained by precomposition with
-a multiplicative equivalence `e : α ≃+ β`. -/
+/-- The equivalence `(β →* γ) ≃ (α →* γ)` obtained by precomposition with
+a multiplicative equivalence `e : α ≃* β`. -/
 @[to_additive (attr := simps)
 "The equivalence `(β →+ γ) ≃ (α →+ γ)` obtained by precomposition with
 an additive equivalence `e : α ≃+ β`."]
@@ -651,8 +651,8 @@ def precompEquiv {α β : Type*} [Monoid α] [Monoid β] (e : α ≃* β) (γ : 
 /-- The equivalence `(γ →* α) ≃ (γ →* β)` obtained by postcomposition with
 a multiplicative equivalence `e : α ≃* β`. -/
 @[to_additive (attr := simps)
-"The equivalence `(γ →* α) ≃ (γ →* β)` obtained by postcomposition with
-an additive equivalence `e : α ≃* β`."]
+"The equivalence `(γ →+ α) ≃ (γ →+ β)` obtained by postcomposition with
+an additive equivalence `e : α ≃+ β`."]
 def postcompEquiv {α β : Type*} [Monoid α] [Monoid β] (e : α ≃* β) (γ : Type*) [Monoid γ] :
     (γ →* α) ≃ (γ →* β) where
   toFun f := e.toMonoidHom.comp f


### PR DESCRIPTION
Move the two definitions `MonoidHom.precompEquiv` (the equivalence `(β →* γ) ≃ (α →* γ)` obtained by precomposition with a multiplicative equivalence `e : α ≃* β`)  and `AddMonoidHom.precompEquiv` (its additive version) from `Algebra.Category.MonCat.ForgetCorepresentable` to `Algebra.Group.Equiv.Basic`, so they can be used without importing files about `MonCat`. Also merge them into one definition using `@[to_additive]` and add the symmetric definition `(Add)MonoidHom.postcompEquiv`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
