### PR TITLE
[Merged by Bors] - feat: A monotone function on a segment belongs to all `L^p` spaces

### DIFF
--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -485,40 +485,68 @@ open scoped ENNReal
 section Monotone
 
 variable [BorelSpace X] [ConditionallyCompleteLinearOrder X] [ConditionallyCompleteLinearOrder E]
-  [OrderTopology X] [OrderTopology E] [SecondCountableTopology E]
+  [OrderTopology X] [OrderTopology E] [SecondCountableTopology E] {p : ℝ≥0∞}
 
-theorem MonotoneOn.integrableOn_of_measure_ne_top (hmono : MonotoneOn f s) {a b : X}
-    (ha : IsLeast s a) (hb : IsGreatest s b) (hs : μ s ≠ ∞) (h's : MeasurableSet s) :
-    IntegrableOn f s μ := by
+theorem MonotoneOn.memℒp_top (hmono : MonotoneOn f s) {a b : X}
+    (ha : IsLeast s a) (hb : IsGreatest s b) (h's : MeasurableSet s) :
+    Memℒp f ⊤ (μ.restrict s) := by
   borelize E
-  obtain rfl | _ := s.eq_empty_or_nonempty
-  · exact integrableOn_empty
+  have : CompactIccSpace E := by infer_instance
   have hbelow : BddBelow (f '' s) := ⟨f a, fun x ⟨y, hy, hyx⟩ => hyx ▸ hmono ha.1 hy (ha.2 hy)⟩
   have habove : BddAbove (f '' s) := ⟨f b, fun x ⟨y, hy, hyx⟩ => hyx ▸ hmono hy hb.1 (hb.2 hy)⟩
   have : IsBounded (f '' s) := Metric.isBounded_of_bddAbove_of_bddBelow habove hbelow
   rcases isBounded_iff_forall_norm_le.mp this with ⟨C, hC⟩
-  have A : IntegrableOn (fun _ => C) s μ := by
-    simp only [hs.lt_top, integrableOn_const, or_true]
-  exact
-    Integrable.mono' A (aemeasurable_restrict_of_monotoneOn h's hmono).aestronglyMeasurable
-      ((ae_restrict_iff' h's).mpr <| ae_of_all _ fun y hy => hC (f y) (mem_image_of_mem f hy))
+  have A : Memℒp (fun _ => C) ⊤ (μ.restrict s) := memℒp_top_const _
+  apply Memℒp.mono A (aemeasurable_restrict_of_monotoneOn h's hmono).aestronglyMeasurable
+  apply (ae_restrict_iff' h's).mpr
+  apply ae_of_all _ fun y hy ↦ ?_
+  exact (hC _ (mem_image_of_mem f hy)).trans (le_abs_self _)
+
+theorem MonotoneOn.memℒp_of_measure_ne_top (hmono : MonotoneOn f s) {a b : X}
+    (ha : IsLeast s a) (hb : IsGreatest s b) (hs : μ s ≠ ∞) (h's : MeasurableSet s) :
+    Memℒp f p (μ.restrict s) :=
+  (hmono.memℒp_top ha hb h's).memℒp_of_exponent_le_of_measure_support_ne_top (s := univ)
+    (by simp) (by simpa using hs) le_top
+
+theorem MonotoneOn.memℒp_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
+    (hmono : MonotoneOn f s) : Memℒp f p (μ.restrict s) := by
+  obtain rfl | h := s.eq_empty_or_nonempty
+  · simp
+  · exact
+      hmono.memℒp_of_measure_ne_top (hs.isLeast_sInf h) (hs.isGreatest_sSup h)
+        hs.measure_lt_top.ne hs.measurableSet
+
+theorem AntitoneOn.memℒp_top (hanti : AntitoneOn f s) {a b : X}
+    (ha : IsLeast s a) (hb : IsGreatest s b) (h's : MeasurableSet s) :
+    Memℒp f ⊤ (μ.restrict s) :=
+  MonotoneOn.memℒp_top (E := Eᵒᵈ) hanti ha hb h's
+
+theorem AntitoneOn.memℒp_of_measure_ne_top (hanti : AntitoneOn f s) {a b : X}
+    (ha : IsLeast s a) (hb : IsGreatest s b) (hs : μ s ≠ ∞) (h's : MeasurableSet s) :
+    Memℒp f p (μ.restrict s) :=
+  MonotoneOn.memℒp_of_measure_ne_top (E := Eᵒᵈ) hanti ha hb hs h's
+
+theorem AntitoneOn.memℒp_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
+    (hanti : AntitoneOn f s) : Memℒp f p (μ.restrict s) :=
+  MonotoneOn.memℒp_isCompact (E := Eᵒᵈ) hs hanti
+
+theorem MonotoneOn.integrableOn_of_measure_ne_top (hmono : MonotoneOn f s) {a b : X}
+    (ha : IsLeast s a) (hb : IsGreatest s b) (hs : μ s ≠ ∞) (h's : MeasurableSet s) :
+    IntegrableOn f s μ :=
+  memℒp_one_iff_integrable.1 (hmono.memℒp_of_measure_ne_top ha hb hs h's)
 
 theorem MonotoneOn.integrableOn_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
-    (hmono : MonotoneOn f s) : IntegrableOn f s μ := by
-  obtain rfl | h := s.eq_empty_or_nonempty
-  · exact integrableOn_empty
-  · exact
-      hmono.integrableOn_of_measure_ne_top (hs.isLeast_sInf h) (hs.isGreatest_sSup h)
-        hs.measure_lt_top.ne hs.measurableSet
+    (hmono : MonotoneOn f s) : IntegrableOn f s μ :=
+  memℒp_one_iff_integrable.1 (hmono.memℒp_isCompact hs)
 
 theorem AntitoneOn.integrableOn_of_measure_ne_top (hanti : AntitoneOn f s) {a b : X}
     (ha : IsLeast s a) (hb : IsGreatest s b) (hs : μ s ≠ ∞) (h's : MeasurableSet s) :
     IntegrableOn f s μ :=
-  hanti.dual_right.integrableOn_of_measure_ne_top ha hb hs h's
+  memℒp_one_iff_integrable.1 (hanti.memℒp_of_measure_ne_top ha hb hs h's)
 
 theorem AntioneOn.integrableOn_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
     (hanti : AntitoneOn f s) : IntegrableOn f s μ :=
-  hanti.dual_right.integrableOn_isCompact (E := Eᵒᵈ) hs
+  memℒp_one_iff_integrable.1 (hanti.memℒp_isCompact hs)
 
 theorem Monotone.locallyIntegrable [IsLocallyFiniteMeasure μ] (hmono : Monotone f) :
     LocallyIntegrable f μ := by

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -489,9 +489,8 @@ variable [BorelSpace X] [ConditionallyCompleteLinearOrder X] [ConditionallyCompl
 
 theorem MonotoneOn.memℒp_top (hmono : MonotoneOn f s) {a b : X}
     (ha : IsLeast s a) (hb : IsGreatest s b) (h's : MeasurableSet s) :
-    Memℒp f ⊤ (μ.restrict s) := by
+    Memℒp f ∞ (μ.restrict s) := by
   borelize E
-  have : CompactIccSpace E := by infer_instance
   have hbelow : BddBelow (f '' s) := ⟨f a, fun x ⟨y, hy, hyx⟩ => hyx ▸ hmono ha.1 hy (ha.2 hy)⟩
   have habove : BddAbove (f '' s) := ⟨f b, fun x ⟨y, hy, hyx⟩ => hyx ▸ hmono hy hb.1 (hb.2 hy)⟩
   have : IsBounded (f '' s) := Metric.isBounded_of_bddAbove_of_bddBelow habove hbelow
@@ -512,13 +511,12 @@ theorem MonotoneOn.memℒp_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsComp
     (hmono : MonotoneOn f s) : Memℒp f p (μ.restrict s) := by
   obtain rfl | h := s.eq_empty_or_nonempty
   · simp
-  · exact
-      hmono.memℒp_of_measure_ne_top (hs.isLeast_sInf h) (hs.isGreatest_sSup h)
-        hs.measure_lt_top.ne hs.measurableSet
+  · exact hmono.memℒp_of_measure_ne_top (hs.isLeast_sInf h) (hs.isGreatest_sSup h)
+      hs.measure_lt_top.ne hs.measurableSet
 
 theorem AntitoneOn.memℒp_top (hanti : AntitoneOn f s) {a b : X}
     (ha : IsLeast s a) (hb : IsGreatest s b) (h's : MeasurableSet s) :
-    Memℒp f ⊤ (μ.restrict s) :=
+    Memℒp f ∞ (μ.restrict s) :=
   MonotoneOn.memℒp_top (E := Eᵒᵈ) hanti ha hb h's
 
 theorem AntitoneOn.memℒp_of_measure_ne_top (hanti : AntitoneOn f s) {a b : X}

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -311,6 +311,8 @@ theorem eLpNorm_measure_zero {f : α → F} : eLpNorm f p (0 : Measure α) = 0 :
 @[deprecated (since := "2024-07-27")]
 alias snorm_measure_zero := eLpNorm_measure_zero
 
+@[simp] lemma memℒp_measure_zero {f : α → F} : Memℒp f p (0 : Measure α) := by simp [Memℒp]
+
 end Zero
 
 section Neg

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/CompareExp.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/CompareExp.lean
@@ -357,4 +357,39 @@ theorem Memℒp.smul_of_top_left {p : ℝ≥0∞} {f : α → E} {φ : α → �
 
 end BoundedSMul
 
+section Mul
+
+variable {α : Type*} [MeasurableSpace α] {𝕜 : Type*} [NormedRing 𝕜] {μ : Measure α}
+  {p q r : ℝ≥0∞} {f : α → 𝕜} {φ : α → 𝕜}
+
+theorem Memℒp.mul (hf : Memℒp f r μ) (hφ : Memℒp φ q μ) (hpqr : 1 / p = 1 / q + 1 / r) :
+    Memℒp (φ * f) p μ :=
+  Memℒp.smul hf hφ hpqr
+
+/-- Variant of `Memℒp.mul` where the function is written as `fun x ↦ φ x * f x`
+instead of `φ * f`. -/
+theorem Memℒp.mul' (hf : Memℒp f r μ) (hφ : Memℒp φ q μ) (hpqr : 1 / p = 1 / q + 1 / r) :
+    Memℒp (fun x ↦ φ x * f x) p μ :=
+  Memℒp.smul hf hφ hpqr
+
+theorem Memℒp.mul_of_top_right (hf : Memℒp f p μ) (hφ : Memℒp φ ∞ μ) : Memℒp (φ * f) p μ :=
+  Memℒp.smul_of_top_right hf hφ
+
+/-- Variant of `Memℒp.mul_of_top_right` where the function is written as `fun x ↦ φ x * f x`
+instead of `φ * f`. -/
+theorem Memℒp.mul_of_top_right' (hf : Memℒp f p μ) (hφ : Memℒp φ ∞ μ) :
+    Memℒp (fun x ↦ φ x * f x) p μ :=
+  Memℒp.smul_of_top_right hf hφ
+
+theorem Memℒp.mul_of_top_left (hf : Memℒp f ∞ μ) (hφ : Memℒp φ p μ) : Memℒp (φ * f) p μ :=
+  Memℒp.smul_of_top_left hf hφ
+
+/-- Variant of `Memℒp.mul_of_top_left` where the function is written as `fun x ↦ φ x * f x`
+instead of `φ * f`. -/
+theorem Memℒp.mul_of_top_left' (hf : Memℒp f ∞ μ) (hφ : Memℒp φ p μ) :
+    Memℒp (fun x ↦ φ x * f x) p μ :=
+  Memℒp.smul_of_top_left hf hφ
+
+end Mul
+
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -375,6 +375,21 @@ theorem of_uncurry_right [TopologicalSpace β] {_ : MeasurableSpace α} {_ : Mea
     StronglyMeasurable fun x => f x y :=
   hf.comp_measurable measurable_prod_mk_right
 
+protected theorem prod_swap {_ : MeasurableSpace α} {_ : MeasurableSpace β} [TopologicalSpace γ]
+    {f : β × α → γ} (hf : StronglyMeasurable f) :
+    StronglyMeasurable (fun z : α × β => f z.swap) :=
+  hf.comp_measurable measurable_swap
+
+protected theorem fst {_ : MeasurableSpace α} [mβ : MeasurableSpace β] [TopologicalSpace γ]
+    {f : α → γ} (hf : StronglyMeasurable f) :
+    StronglyMeasurable (fun z : α × β => f z.1) :=
+  hf.comp_measurable measurable_fst
+
+protected theorem snd [mα : MeasurableSpace α] {_ : MeasurableSpace β} [TopologicalSpace γ]
+    {f : β → γ} (hf : StronglyMeasurable f) :
+    StronglyMeasurable (fun z : α × β => f z.2) :=
+  hf.comp_measurable measurable_snd
+
 section Arithmetic
 
 variable {mα : MeasurableSpace α} [TopologicalSpace β]


### PR DESCRIPTION
Currently, we have the fact that a monotone function on a segment is integrable. This PR generalizes it to all `L^p` spaces (with the same proof), and deduces the integrability result from the general one.

From the Carleson project

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
