### PR TITLE
[Merged by Bors] - feat(Analysis/Distribution): Add memLp, toLp, toLpCLM, continuous_toLp for SchwartzMap

### DIFF
--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -572,6 +572,7 @@ lemma _root_.ContinuousLinearMap.hasTemperateGrowth (f : E →L[ℝ] F) :
 variable [NormedAddCommGroup D] [MeasurableSpace D]
 
 open MeasureTheory Module
+open scoped ENNReal
 
 /-- A measure `μ` has temperate growth if there is an `n : ℕ` such that `(1 + ‖x‖) ^ (- n)` is
 `μ`-integrable. -/
@@ -661,6 +662,37 @@ lemma integral_pow_mul_le_of_le_of_pow_mul_le
   filter_upwards with v
   exact (pow_mul_le_of_le_of_pow_mul_le (norm_nonneg _) (norm_nonneg _) (hf v) (h'f v)).trans
     (le_of_eq (by ring))
+
+/-- For any `HasTemperateGrowth` measure and `p`, there exists an integer power `k` such that
+`(1 + ‖x‖) ^ (-k)` is in `L^p`. -/
+theorem _root_.MeasureTheory.Measure.HasTemperateGrowth.exists_eLpNorm_lt_top (p : ℝ≥0∞)
+    {μ : Measure D} (hμ : μ.HasTemperateGrowth) :
+    ∃ k : ℕ, eLpNorm (fun x ↦ (1 + ‖x‖) ^ (-k : ℝ)) p μ < ⊤ := by
+  cases p with
+  | top => exact ⟨0, eLpNormEssSup_lt_top_of_ae_bound (C := 1) (by simp)⟩
+  | coe p =>
+    cases Decidable.eq_or_ne (p : ℝ≥0∞) 0 with
+    | inl hp => exact ⟨0, by simp [hp]⟩
+    | inr hp =>
+      have h_one_add (x : D) : 0 < 1 + ‖x‖ := lt_add_of_pos_of_le zero_lt_one (norm_nonneg x)
+      have hp_pos : 0 < (p : ℝ) := by simpa [zero_lt_iff] using hp
+      rcases hμ.exists_integrable with ⟨l, hl⟩
+      have hlk : l ≤ ⌈(l / p : ℝ)⌉₊ * (p : ℝ) := by
+        simpa [div_le_iff₀ hp_pos] using Nat.le_ceil (l / p : ℝ)
+      generalize ⌈(l / p : ℝ)⌉₊ = k at hlk
+      use k
+      suffices HasFiniteIntegral (fun x ↦ ((1 + ‖x‖) ^ (-(k * p) : ℝ))) μ by
+        rw [hasFiniteIntegral_iff_nnnorm] at this
+        rw [eLpNorm_lt_top_iff_lintegral_rpow_nnnorm_lt_top hp ENNReal.coe_ne_top]
+        simp only [ENNReal.coe_toReal]
+        refine Eq.subst (motive := (∫⁻ x, · x ∂μ < ⊤)) (funext fun x ↦ ?_) this
+        rw [← neg_mul, Real.rpow_mul (h_one_add x).le,
+          Real.nnnorm_rpow_of_nonneg (Real.rpow_nonneg (h_one_add x).le _),
+          ENNReal.coe_rpow_of_nonneg _ hp_pos.le]
+      refine hl.hasFiniteIntegral.mono' (ae_of_all μ fun x ↦ ?_)
+      rw [Real.norm_of_nonneg (Real.rpow_nonneg (h_one_add x).le _)]
+      gcongr
+      simp
 
 end TemperateGrowth
 
@@ -1215,45 +1247,15 @@ def toZeroAtInftyCLM : 𝓢(E, F) →L[𝕜] C₀(E, F) :=
 
 end ZeroAtInfty
 
-/-! ### Inclusion into L^p space -/
-
 section Lp
 
+/-! ### Inclusion into L^p space -/
+
 open MeasureTheory
-open scoped ENNReal
+open scoped NNReal ENNReal
 
 variable [NormedAddCommGroup D] [MeasurableSpace D] [MeasurableSpace E] [OpensMeasurableSpace E]
   [NormedField 𝕜] [NormedSpace 𝕜 F] [SMulCommClass ℝ 𝕜 F]
-
-/-- For any `HasTemperateGrowth` measure and `p`, there exists an integer power `k` such that
-`(1 + ‖x‖) ^ (-k)` is in `L^p`. -/
-theorem _root_.MeasureTheory.Measure.HasTemperateGrowth.exists_eLpNorm_lt_top (p : ℝ≥0∞)
-    {μ : Measure D} (hμ : μ.HasTemperateGrowth) :
-    ∃ k : ℕ, eLpNorm (fun x ↦ (1 + ‖x‖) ^ (-k : ℝ)) p μ < ⊤ := by
-  cases p with
-  | top => exact ⟨0, eLpNormEssSup_lt_top_of_ae_bound (C := 1) (by simp)⟩
-  | coe p =>
-    cases Decidable.eq_or_ne (p : ℝ≥0∞) 0 with
-    | inl hp => exact ⟨0, by simp [hp]⟩
-    | inr hp =>
-      have h_one_add (x : D) : 0 < 1 + ‖x‖ := lt_add_of_pos_of_le zero_lt_one (norm_nonneg x)
-      have hp_pos : 0 < (p : ℝ) := by simpa [zero_lt_iff] using hp
-      rcases hμ.exists_integrable with ⟨l, hl⟩
-      have hlk : l ≤ ⌈(l / p : ℝ)⌉₊ * (p : ℝ) := by
-        simpa [div_le_iff₀ hp_pos] using Nat.le_ceil (l / p : ℝ)
-      generalize ⌈(l / p : ℝ)⌉₊ = k at hlk
-      use k
-      suffices HasFiniteIntegral (fun x ↦ ((1 + ‖x‖) ^ (-(k * p) : ℝ))) μ by
-        rw [hasFiniteIntegral_iff_nnnorm] at this
-        rw [eLpNorm_lt_top_iff_lintegral_rpow_nnnorm_lt_top hp ENNReal.coe_ne_top,
-          ENNReal.coe_toReal]
-        refine Eq.subst (motive := (∫⁻ x, · x ∂μ < ⊤)) (funext fun x ↦ ?_) this
-        rw [← neg_mul, Real.rpow_mul (h_one_add x).le,
-          Real.nnnorm_rpow_of_nonneg (Real.rpow_nonneg (h_one_add x).le _),
-          ENNReal.coe_rpow_of_nonneg _ hp_pos.le]
-      refine hl.hasFiniteIntegral.mono' (ae_of_all μ fun x ↦ ?_)
-      rw [Real.norm_of_nonneg (Real.rpow_nonneg (h_one_add x).le _)]
-      exact Real.rpow_le_rpow_of_exponent_le (by simp) (by simpa using hlk)
 
 variable (𝕜 F) in
 /-- The `L^p` norm of a Schwartz function is controlled by a finite family of Schwartz seminorms.
@@ -1262,29 +1264,33 @@ The maximum index `k` and the constant `C` depend on `p` and `μ`.
 -/
 theorem eLpNorm_le_seminorm (p : ℝ≥0∞) (μ : Measure E := by volume_tac)
     [hμ : μ.HasTemperateGrowth] :
-    ∃ (k : ℕ) (C : NNReal), ∀ (f : 𝓢(E, F)), eLpNorm f p μ ≤
+    ∃ (k : ℕ) (C : ℝ≥0), ∀ (f : 𝓢(E, F)), eLpNorm f p μ ≤
       C * ENNReal.ofReal ((Finset.Iic (k, 0)).sup (schwartzSeminormFamily 𝕜 E F) f) := by
   -- Apply Hölder's inequality `‖f‖_p ≤ ‖f₁‖_p * ‖f₂‖_∞` to obtain the `L^p` norm of `f = f₁ • f₂`
   -- using `f₁ = (1 + ‖x‖) ^ (-k)` and `f₂ = (1 + ‖x‖) ^ k • f x`.
   rcases hμ.exists_eLpNorm_lt_top p with ⟨k, hk⟩
   refine ⟨k, (eLpNorm (fun x ↦ (1 + ‖x‖) ^ (-k : ℝ)) p μ).toNNReal * 2 ^ k, fun f ↦ ?_⟩
   have h_one_add (x : E) : 0 < 1 + ‖x‖ := lt_add_of_pos_of_le zero_lt_one (norm_nonneg x)
-  refine le_trans ?_ ?_
-    (b := eLpNorm (fun x ↦ (1 + ‖x‖) ^ (-k : ℝ)) p μ * eLpNorm (fun x ↦ (1 + ‖x‖) ^ k • f x) ⊤ μ)
-  · refine le_of_eq_of_le ?_ (eLpNorm_smul_le_eLpNorm_mul_eLpNorm_top p _ ?_)
-    · congr
-      funext x
-      simp [Real.rpow_neg (h_one_add x).le, (h_one_add x).ne']
-    · refine Continuous.aestronglyMeasurable ?_
-      exact .rpow_const (.add continuous_const continuous_norm) fun x ↦ .inl (h_one_add x).ne'
-  · rw [ENNReal.coe_mul, mul_assoc]
-    refine mul_le_mul' ?_ ?_
-    · rw [ENNReal.coe_toNNReal hk.ne]
-    · rw [eLpNorm_exponent_top, ENNReal.ofReal, ← ENNReal.coe_mul]
-      refine eLpNormEssSup_le_of_ae_nnnorm_bound (ae_of_all μ fun x ↦ ?_)
-      rw [← norm_toNNReal, Real.toNNReal_le_iff_le_coe]
-      simpa [norm_iteratedFDeriv_zero, norm_smul, abs_of_nonneg (h_one_add x).le] using
-        one_add_le_sup_seminorm_apply (m := (k, 0)) (le_refl k) (le_refl 0) f x
+  calc eLpNorm (⇑f) p μ
+  _ = eLpNorm ((fun x : E ↦ (1 + ‖x‖) ^ (-k : ℝ)) • fun x ↦ (1 + ‖x‖) ^ k • f x) p μ := by
+    refine congrArg (eLpNorm · p μ) (funext fun x ↦ ?_)
+    simp [Real.rpow_neg (h_one_add x).le, (h_one_add x).ne']
+  _ ≤ eLpNorm (fun x ↦ (1 + ‖x‖) ^ (-k : ℝ)) p μ * eLpNorm (fun x ↦ (1 + ‖x‖) ^ k • f x) ⊤ μ := by
+    refine eLpNorm_smul_le_eLpNorm_mul_eLpNorm_top p _ ?_
+    refine Continuous.aestronglyMeasurable ?_
+    exact .rpow_const (.add continuous_const continuous_norm) fun x ↦ .inl (h_one_add x).ne'
+  _ ≤ eLpNorm (fun x ↦ (1 + ‖x‖) ^ (-k : ℝ)) p μ *
+      (2 ^ k * ENNReal.ofReal (((Finset.Iic (k, 0)).sup (schwartzSeminormFamily 𝕜 E F)) f)) := by
+    gcongr _ * ?_
+    rw [eLpNorm_exponent_top]
+    refine eLpNormEssSup_le_of_ae_nnnorm_bound (ae_of_all μ fun x ↦ ?_)
+    rw [← norm_toNNReal, Real.toNNReal_le_iff_le_coe]
+    simpa [norm_smul, abs_of_nonneg (h_one_add x).le] using
+      one_add_le_sup_seminorm_apply (m := (k, 0)) (le_refl k) (le_refl 0) f x
+  _ = _ := by
+    rw [ENNReal.coe_mul, ENNReal.coe_toNNReal hk.ne]
+    simp only [ENNReal.coe_pow, ENNReal.coe_ofNat]
+    ring
 
 /-- The `L^p` norm of a Schwartz function is finite. -/
 theorem eLpNorm_lt_top (f : 𝓢(E, F)) (p : ℝ≥0∞) (μ : Measure E := by volume_tac)
@@ -1306,22 +1312,19 @@ theorem memℒp (f : 𝓢(E, F)) (p : ℝ≥0∞) (μ : Measure E := by volume_t
   ⟨f.continuous.aestronglyMeasurable, f.eLpNorm_lt_top p μ⟩
 
 /-- Schwartz functions are in `L^p` for any `p`. -/
-def toLp (f : 𝓢(E, F))  (p : ℝ≥0∞) (μ : Measure E := by volume_tac) [hμ : μ.HasTemperateGrowth] :
+def toLp (f : 𝓢(E, F)) (p : ℝ≥0∞) (μ : Measure E := by volume_tac) [hμ : μ.HasTemperateGrowth] :
     Lp F p μ := (f.memℒp p μ).toLp
 
-theorem coeFn_toLp {f : 𝓢(E, F)} {p : ℝ≥0∞} {μ : Measure E} [hμ : μ.HasTemperateGrowth] :
-    f.toLp p μ =ᵐ[μ] f := (memℒp f p μ).coeFn_toLp
+theorem coeFn_toLp (f : 𝓢(E, F)) (p : ℝ≥0∞) (μ : Measure E := by volume_tac)
+    [hμ : μ.HasTemperateGrowth] : f.toLp p μ =ᵐ[μ] f := (memℒp f p μ).coeFn_toLp
 
 theorem norm_toLp {f : 𝓢(E, F)} {p : ℝ≥0∞} {μ : Measure E} [hμ : μ.HasTemperateGrowth] :
     ‖f.toLp p μ‖ = ENNReal.toReal (eLpNorm f p μ) := by
-  rw [Lp.norm_def, eLpNorm_congr_ae coeFn_toLp]
+  rw [Lp.norm_def, eLpNorm_congr_ae (coeFn_toLp f p μ)]
 
-variable (F) in
-/-- The map from Schwartz to `L^p` is injective when the measure is positive on non-empty sets. -/
-def embedding_toLp (p : ℝ≥0∞) (μ : Measure E := by volume_tac) [hμ : μ.HasTemperateGrowth]
-    [μ.IsOpenPosMeasure] : 𝓢(E, F) ↪ Lp F p μ where
-  toFun f := (f.memℒp p μ).toLp
-  inj' f g := by simpa using (Continuous.ae_eq_iff_eq μ f.continuous g.continuous).mp
+theorem injective_toLp (p : ℝ≥0∞) (μ : Measure E := by volume_tac) [hμ : μ.HasTemperateGrowth]
+    [μ.IsOpenPosMeasure] : Function.Injective (fun f : 𝓢(E, F) ↦ f.toLp p μ) :=
+  fun f g ↦ by simpa [toLp] using (Continuous.ae_eq_iff_eq μ f.continuous g.continuous).mp
 
 variable (𝕜 F) in
 theorem norm_toLp_le_seminorm (p : ℝ≥0∞) (μ : Measure E := by volume_tac)
@@ -1346,9 +1349,6 @@ def toLpCLM (p : ℝ≥0∞) [Fact (1 ≤ p)] (μ : Measure E := by volume_tac)
 
 theorem toLpCLM_apply {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure E} [hμ : μ.HasTemperateGrowth]
     {f : 𝓢(E, F)} : toLpCLM 𝕜 F p μ f = f.toLp p μ := rfl
-
-theorem coeFn_toLpCLM {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure E} [hμ : μ.HasTemperateGrowth]
-    {f : 𝓢(E, F)} : toLpCLM 𝕜 F p μ f =ᵐ[μ] f := coeFn_toLp
 
 theorem continuous_toLp {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure E} [hμ : μ.HasTemperateGrowth] :
     Continuous (fun f : 𝓢(E, F) ↦ f.toLp p μ) := (toLpCLM ℝ F p μ).continuous

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -681,13 +681,12 @@ theorem _root_.MeasureTheory.Measure.HasTemperateGrowth.exists_eLpNorm_lt_top (p
       have hlk : l ≤ k * (p : ℝ) := by simpa [div_le_iff₀ hp_pos] using Nat.le_ceil (l / p : ℝ)
       use k
       suffices HasFiniteIntegral (fun x ↦ ((1 + ‖x‖) ^ (-(k * p) : ℝ))) μ by
-        rw [hasFiniteIntegral_iff_nnnorm] at this
+        rw [hasFiniteIntegral_iff_enorm] at this
         rw [eLpNorm_lt_top_iff_lintegral_rpow_nnnorm_lt_top hp ENNReal.coe_ne_top]
         simp only [ENNReal.coe_toReal]
         refine Eq.subst (motive := (∫⁻ x, · x ∂μ < ⊤)) (funext fun x ↦ ?_) this
-        rw [← neg_mul, Real.rpow_mul (h_one_add x).le,
-          Real.nnnorm_rpow_of_nonneg (Real.rpow_nonneg (h_one_add x).le _),
-          ENNReal.coe_rpow_of_nonneg _ hp_pos.le]
+        rw [← neg_mul, Real.rpow_mul (h_one_add x).le]
+        exact Real.enorm_rpow_of_nonneg (Real.rpow_nonneg (h_one_add x).le _) NNReal.zero_le_coe
       refine hl.hasFiniteIntegral.mono' (ae_of_all μ fun x ↦ ?_)
       rw [Real.norm_of_nonneg (Real.rpow_nonneg (h_one_add x).le _)]
       gcongr

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -671,15 +671,14 @@ theorem _root_.MeasureTheory.Measure.HasTemperateGrowth.exists_eLpNorm_lt_top (p
   cases p with
   | top => exact ⟨0, eLpNormEssSup_lt_top_of_ae_bound (C := 1) (by simp)⟩
   | coe p =>
-    cases Decidable.eq_or_ne (p : ℝ≥0∞) 0 with
+    cases eq_or_ne (p : ℝ≥0∞) 0 with
     | inl hp => exact ⟨0, by simp [hp]⟩
     | inr hp =>
       have h_one_add (x : D) : 0 < 1 + ‖x‖ := lt_add_of_pos_of_le zero_lt_one (norm_nonneg x)
       have hp_pos : 0 < (p : ℝ) := by simpa [zero_lt_iff] using hp
       rcases hμ.exists_integrable with ⟨l, hl⟩
-      have hlk : l ≤ ⌈(l / p : ℝ)⌉₊ * (p : ℝ) := by
-        simpa [div_le_iff₀ hp_pos] using Nat.le_ceil (l / p : ℝ)
-      generalize ⌈(l / p : ℝ)⌉₊ = k at hlk
+      let k := ⌈(l / p : ℝ)⌉₊
+      have hlk : l ≤ k * (p : ℝ) := by simpa [div_le_iff₀ hp_pos] using Nat.le_ceil (l / p : ℝ)
       use k
       suffices HasFiniteIntegral (fun x ↦ ((1 + ‖x‖) ^ (-(k * p) : ℝ))) μ by
         rw [hasFiniteIntegral_iff_nnnorm] at this
@@ -1281,8 +1280,7 @@ theorem eLpNorm_le_seminorm (p : ℝ≥0∞) (μ : Measure E := by volume_tac)
     exact .rpow_const (.add continuous_const continuous_norm) fun x ↦ .inl (h_one_add x).ne'
   _ ≤ eLpNorm (fun x ↦ (1 + ‖x‖) ^ (-k : ℝ)) p μ *
       (2 ^ k * ENNReal.ofReal (((Finset.Iic (k, 0)).sup (schwartzSeminormFamily 𝕜 E F)) f)) := by
-    gcongr _ * ?_
-    rw [eLpNorm_exponent_top]
+    gcongr
     refine eLpNormEssSup_le_of_ae_nnnorm_bound (ae_of_all μ fun x ↦ ?_)
     rw [← norm_toNNReal, Real.toNNReal_le_iff_le_coe]
     simpa [norm_smul, abs_of_nonneg (h_one_add x).le] using
@@ -1342,14 +1340,14 @@ variable (𝕜 F) in
 /-- Continuous linear map from Schwartz functions to `L^p`. -/
 def toLpCLM (p : ℝ≥0∞) [Fact (1 ≤ p)] (μ : Measure E := by volume_tac)
     [hμ : μ.HasTemperateGrowth] : 𝓢(E, F) →L[𝕜] Lp F p μ :=
-  mkCLMtoNormedSpace (fun f ↦ f.toLp p μ) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
-    (by
-      rcases norm_toLp_le_seminorm 𝕜 F p μ with ⟨k, C, hC_pos, hC⟩
-      exact ⟨Finset.Iic (k, 0), C, hC_pos, hC⟩)
+  mkCLMtoNormedSpace (fun f ↦ f.toLp p μ) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) <| by
+    rcases norm_toLp_le_seminorm 𝕜 F p μ with ⟨k, C, hC_pos, hC⟩
+    exact ⟨Finset.Iic (k, 0), C, hC_pos, hC⟩
 
-theorem toLpCLM_apply {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure E} [hμ : μ.HasTemperateGrowth]
+@[simp] theorem toLpCLM_apply {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure E} [hμ : μ.HasTemperateGrowth]
     {f : 𝓢(E, F)} : toLpCLM 𝕜 F p μ f = f.toLp p μ := rfl
 
+@[fun_prop]
 theorem continuous_toLp {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure E} [hμ : μ.HasTemperateGrowth] :
     Continuous (fun f : 𝓢(E, F) ↦ f.toLp p μ) := (toLpCLM ℝ F p μ).continuous
 

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -1309,12 +1309,12 @@ theorem memℒp (f : 𝓢(E, F)) (p : ℝ≥0∞) (μ : Measure E := by volume_t
     [hμ : μ.HasTemperateGrowth] : Memℒp f p μ :=
   ⟨f.continuous.aestronglyMeasurable, f.eLpNorm_lt_top p μ⟩
 
-/-- Schwartz functions are in `L^p` for any `p`. -/
+/-- Map a Schwartz function to an `Lp` function for any `p`. -/
 def toLp (f : 𝓢(E, F)) (p : ℝ≥0∞) (μ : Measure E := by volume_tac) [hμ : μ.HasTemperateGrowth] :
     Lp F p μ := (f.memℒp p μ).toLp
 
 theorem coeFn_toLp (f : 𝓢(E, F)) (p : ℝ≥0∞) (μ : Measure E := by volume_tac)
-    [hμ : μ.HasTemperateGrowth] : f.toLp p μ =ᵐ[μ] f := (memℒp f p μ).coeFn_toLp
+    [hμ : μ.HasTemperateGrowth] : f.toLp p μ =ᵐ[μ] f := (f.memℒp p μ).coeFn_toLp
 
 theorem norm_toLp {f : 𝓢(E, F)} {p : ℝ≥0∞} {μ : Measure E} [hμ : μ.HasTemperateGrowth] :
     ‖f.toLp p μ‖ = ENNReal.toReal (eLpNorm f p μ) := by


### PR DESCRIPTION
---

Some minor questions:
* I proved `Continuous (SchwartzMap.toLp : 𝓢(E, F) → ↥(Lp F p μ))` by bounding the norm of the L^p function using a finite family of Schwartz seminorms. I didn't show that the Schwartz functions are dense in L^p. I wonder whether it's possible/preferable to obtain Continuous using that method?
* Would it be better to remove `toLp` and rename `toLpCLM` to `toLp` to minimize the number of definitions and reduce clutter?

Note: I have also prepared #20372. Combining `ContinuousLinearMap.bilinearCompLpL` with `L1.integralCLM'` and `SchwartzMap.toLpCLM` will make it possible to define tempered distributions from functions in `L^p`.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
