### PR TITLE
[Merged by Bors] - feat(Polynomial): `(C a * p).degree = p.degree` if `a * p.leadingCoeff ≠ 0`

### DIFF
--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -94,6 +94,14 @@ theorem natDegree_C_mul_le (a : R) (f : R[X]) : (C a * f).natDegree ≤ f.natDeg
     _ = 0 + f.natDegree := by rw [natDegree_C a]
     _ = f.natDegree := zero_add _
 
+lemma degree_C_mul_le (r : R) (p : R[X]) : (C r * p).degree ≤ p.degree := by
+  by_cases hp : p = 0
+  · simp [hp]
+  by_cases hCp : C r * p = 0
+  · simp [hCp]
+  rw [degree_eq_natDegree hp, degree_eq_natDegree hCp]
+  simpa using natDegree_C_mul_le _ _
+
 theorem natDegree_mul_C_le (f : R[X]) (a : R) : (f * C a).natDegree ≤ f.natDegree :=
   calc
     (f * C a).natDegree ≤ f.natDegree + (C a).natDegree := natDegree_mul_le
@@ -137,6 +145,13 @@ theorem natDegree_C_mul_eq_of_mul_ne_zero (h : a * p.leadingCoeff ≠ 0) :
   refine eq_natDegree_of_le_mem_support (natDegree_C_mul_le a p) ?_
   refine mem_support_iff.mpr ?_
   rwa [coeff_C_mul]
+
+lemma degree_C_mul_eq_of_mul_ne_zero (r : R) (p : R[X]) (h : r * p.leadingCoeff ≠ 0) :
+    (C r * p).degree = p.degree := by
+  by_cases hp : p = 0
+  · simp [hp]
+  rw [degree_eq_natDegree hp, degree_eq_natDegree, natDegree_C_mul_eq_of_mul_ne_zero h]
+  exact fun e ↦ h (by simpa using congr(($e).coeff p.natDegree))
 
 theorem natDegree_add_coeff_mul (f g : R[X]) :
     (f * g).coeff (f.natDegree + g.natDegree) = f.coeff f.natDegree * g.coeff g.natDegree := by

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -88,25 +88,13 @@ theorem natDegree_add_le_iff_right {n : ℕ} (p q : R[X]) (pn : p.natDegree ≤ 
   rw [add_comm]
   exact natDegree_add_le_iff_left _ _ pn
 
-theorem natDegree_C_mul_le (a : R) (f : R[X]) : (C a * f).natDegree ≤ f.natDegree :=
-  calc
-    (C a * f).natDegree ≤ (C a).natDegree + f.natDegree := natDegree_mul_le
-    _ = 0 + f.natDegree := by rw [natDegree_C a]
-    _ = f.natDegree := zero_add _
+-- TODO: Do we really want the following two lemmas? They are straightforward consequences of a
+-- more atomic lemma
+theorem natDegree_C_mul_le (a : R) (f : R[X]) : (C a * f).natDegree ≤ f.natDegree := by
+  simpa using natDegree_mul_le (p := C a)
 
-lemma degree_C_mul_le (r : R) (p : R[X]) : (C r * p).degree ≤ p.degree := by
-  by_cases hp : p = 0
-  · simp [hp]
-  by_cases hCp : C r * p = 0
-  · simp [hCp]
-  rw [degree_eq_natDegree hp, degree_eq_natDegree hCp]
-  simpa using natDegree_C_mul_le _ _
-
-theorem natDegree_mul_C_le (f : R[X]) (a : R) : (f * C a).natDegree ≤ f.natDegree :=
-  calc
-    (f * C a).natDegree ≤ f.natDegree + (C a).natDegree := natDegree_mul_le
-    _ = f.natDegree + 0 := by rw [natDegree_C a]
-    _ = f.natDegree := add_zero _
+theorem natDegree_mul_C_le (f : R[X]) (a : R) : (f * C a).natDegree ≤ f.natDegree := by
+  simpa using natDegree_mul_le (q := C a)
 
 theorem eq_natDegree_of_le_mem_support (pn : p.natDegree ≤ n) (ns : n ∈ p.support) :
     p.natDegree = n :=
@@ -140,18 +128,18 @@ theorem natDegree_mul_C_eq_of_mul_ne_zero (h : p.leadingCoeff * a ≠ 0) :
 /-- Although not explicitly stated, the assumptions of lemma `nat_degree_C_mul_eq_of_mul_ne_zero`
 force the polynomial `p` to be non-zero, via `p.leading_coeff ≠ 0`.
 -/
-theorem natDegree_C_mul_eq_of_mul_ne_zero (h : a * p.leadingCoeff ≠ 0) :
+theorem natDegree_C_mul_of_mul_ne_zero (h : a * p.leadingCoeff ≠ 0) :
     (C a * p).natDegree = p.natDegree := by
   refine eq_natDegree_of_le_mem_support (natDegree_C_mul_le a p) ?_
   refine mem_support_iff.mpr ?_
   rwa [coeff_C_mul]
 
-lemma degree_C_mul_eq_of_mul_ne_zero (r : R) (p : R[X]) (h : r * p.leadingCoeff ≠ 0) :
+@[deprecated (since := "2025-01-03")]
+alias natDegree_C_mul_eq_of_mul_ne_zero := natDegree_C_mul_of_mul_ne_zero
+
+lemma degree_C_mul_of_mul_ne_zero (r : R) (p : R[X]) (h : r * p.leadingCoeff ≠ 0) :
     (C r * p).degree = p.degree := by
-  by_cases hp : p = 0
-  · simp [hp]
-  rw [degree_eq_natDegree hp, degree_eq_natDegree, natDegree_C_mul_eq_of_mul_ne_zero h]
-  exact fun e ↦ h (by simpa using congr(($e).coeff p.natDegree))
+  rw [degree_mul' (by simpa)]; simp [left_ne_zero_of_mul h]
 
 theorem natDegree_add_coeff_mul (f g : R[X]) :
     (f * g).coeff (f.natDegree + g.natDegree) = f.coeff f.natDegree * g.coeff g.natDegree := by

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -137,8 +137,7 @@ theorem natDegree_C_mul_of_mul_ne_zero (h : a * p.leadingCoeff ≠ 0) :
 @[deprecated (since := "2025-01-03")]
 alias natDegree_C_mul_eq_of_mul_ne_zero := natDegree_C_mul_of_mul_ne_zero
 
-lemma degree_C_mul_of_mul_ne_zero (r : R) (p : R[X]) (h : r * p.leadingCoeff ≠ 0) :
-    (C r * p).degree = p.degree := by
+lemma degree_C_mul_of_mul_ne_zero (h : a * p.leadingCoeff ≠ 0) : (C a * p).degree = p.degree := by
   rw [degree_mul' (by simpa)]; simp [left_ne_zero_of_mul h]
 
 theorem natDegree_add_coeff_mul (f g : R[X]) :

--- a/Mathlib/Algebra/Polynomial/Taylor.lean
+++ b/Mathlib/Algebra/Polynomial/Taylor.lean
@@ -83,7 +83,7 @@ theorem natDegree_taylor (p : R[X]) (r : R) : natDegree (taylor r p) = natDegree
   refine map_natDegree_eq_natDegree _ ?_
   nontriviality R
   intro n c c0
-  simp [taylor_monomial, natDegree_C_mul_eq_of_mul_ne_zero, natDegree_pow_X_add_C, c0]
+  simp [taylor_monomial, natDegree_C_mul_of_mul_ne_zero, natDegree_pow_X_add_C, c0]
 
 @[simp]
 theorem taylor_mul {R} [CommSemiring R] (r : R) (p q : R[X]) :


### PR DESCRIPTION
From GrowthInGroups (LeanCamCombi)

Co-authored-by: Andrew Yang


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
