### PR TITLE
feat(AlgebraicTopology/SimplicialSet): Colimit description of boundary

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1075,6 +1075,7 @@ import Mathlib.AlgebraicTopology.SimplicialNerve
 import Mathlib.AlgebraicTopology.SimplicialObject.Basic
 import Mathlib.AlgebraicTopology.SimplicialObject.Coskeletal
 import Mathlib.AlgebraicTopology.SimplicialSet.Basic
+import Mathlib.AlgebraicTopology.SimplicialSet.Boundary
 import Mathlib.AlgebraicTopology.SimplicialSet.Coskeletal
 import Mathlib.AlgebraicTopology.SimplicialSet.HomotopyCat
 import Mathlib.AlgebraicTopology.SimplicialSet.KanComplex

--- a/Mathlib/AlgebraicTopology/SimplexCategory.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory.lean
@@ -517,6 +517,9 @@ theorem σ_comp_σ {n} {i j : Fin (n + 1)} (H : i ≤ j) :
         (Fin.succ_le_castSucc_iff.mpr (H.trans_lt' h)), Fin.predAbove_of_le_castSucc _ k.succ
         (Fin.succ_le_castSucc_iff.mpr h)]
 
+section factor_δ
+open Fin
+
 /--
 If `f : [m] ⟶ [n+1]` is a morphism and `j` is not in the range of `f`,
 then `factor_δ f j` is a morphism `[m] ⟶ [n]` such that
@@ -524,9 +527,8 @@ then `factor_δ f j` is a morphism `[m] ⟶ [n]` such that
 -/
 def factor_δ {m n : ℕ} (f : ([m] : SimplexCategory) ⟶ [n+1]) (j : Fin (n+2)) :
     ([m] : SimplexCategory) ⟶ [n] :=
-  f ≫ σ (Fin.predAbove 0 j)
+  f ≫ σ (predAbove 0 j)
 
-open Fin in
 lemma factor_δ_spec {m n : ℕ} (f : ([m] : SimplexCategory) ⟶ [n+1]) (j : Fin (n+2))
     (hj : ∀ (k : Fin (m+1)), f.toOrderHom k ≠ j) :
     factor_δ f j ≫ δ j = f := by
@@ -553,6 +555,42 @@ lemma factor_δ_spec {m n : ℕ} (f : ([m] : SimplexCategory) ⟶ [n+1]) (j : Fi
       swap
       · rwa [succ_le_castSucc_iff, lt_pred_iff]
       rw [succ_pred]
+
+lemma factor_δ_δ_eq {n : ℕ} (j : Fin (n+2)) :
+    factor_δ (δ j) j = 𝟙 _ := by
+  dsimp only [factor_δ]
+  cases' j using cases with j
+  · exact δ_comp_σ_self' (by rfl)
+  · rw [predAbove_zero_succ, δ_comp_σ_succ]
+
+@[reassoc]
+lemma σ_predAbove_comp_σ_predAbove {n : ℕ} {p : Fin (n + 1)} {i j : Fin (n + 2)}
+    (h : i ≤ j) (hp : j = p.castSucc → i = p.castSucc) :
+    σ (p.castSucc.predAbove j.succ) ≫ σ (p.predAbove i) =
+      σ (p.predAbove i).castSucc ≫ σ (p.predAbove j) := by
+  rw [σ_comp_σ (predAbove_le_predAbove p h)]
+  obtain rfl | hp := or_iff_not_imp_right.mpr <| hp ∘ not_ne_iff.mp
+  · rw [predAbove_castSucc_self, predAbove_succ_of_le _ _ h]
+    rcases lt_or_eq_of_le h with (h | rfl)
+    · rw [predAbove_of_castSucc_lt p j h, succ_pred]
+    · rw [predAbove_castSucc_self, σ_comp_σ (by rfl)]
+  · rcases hp.lt_or_lt with (hp | hp)
+    · rw [predAbove_of_le_castSucc p j (le_of_lt hp),
+        predAbove_succ_of_lt _ _ hp, succ_castPred_eq_castPred_succ]
+    · rw [predAbove_of_castSucc_lt p j hp, succ_pred,
+        predAbove_succ_of_le _ _ (le_of_lt hp)]
+
+@[reassoc]
+lemma σ_predAbove_zero_comp_σ_predAbove_zero {n : ℕ} {i j : Fin (n + 2)}
+    (h : i ≤ j) :
+    σ (predAbove 0 j.succ) ≫ σ (predAbove 0 i) =
+      σ (predAbove 0 i.castSucc) ≫ σ (predAbove 0 j) := by
+  rw [← castSucc_zero, castSucc_predAbove_castSucc,
+    σ_predAbove_comp_σ_predAbove h]
+  rintro rfl
+  exact le_zero_iff.mp h
+
+end factor_δ
 
 @[simp]
 lemma δ_zero_mkOfSucc {n : ℕ} (i : Fin n) :

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
@@ -149,6 +149,9 @@ lemma coe_triangle_down_toOrderHom {n : ℕ} (a b c : Fin (n+1)) (hab : a ≤ b)
     ↑(triangle a b c hab hbc).down.toOrderHom = ![a, b, c] :=
   rfl
 
+/-- If `α` is an `m`-simplex of `Δ[n + 1]` and `j` is not in the image of `α`,
+then `factor_δ α j` is an `m`-simplex of `Δ[n]` such that postcomposition with
+`δ j` yields `α` (as witnessed by `factor_δ_spec`). -/
 def factor_δ {n : ℕ} {m : SimplexCategoryᵒᵖ} (α : Δ[n + 1].obj m)
     (j : Fin (n + 2)) : Δ[n].obj m :=
   standardSimplex.map (σ (Fin.predAbove 0 j)) |>.app m α

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
@@ -149,6 +149,26 @@ lemma coe_triangle_down_toOrderHom {n : ℕ} (a b c : Fin (n+1)) (hab : a ≤ b)
     ↑(triangle a b c hab hbc).down.toOrderHom = ![a, b, c] :=
   rfl
 
+def factor_δ {n : ℕ} {m : SimplexCategoryᵒᵖ} (α : Δ[n + 1].obj m)
+    (j : Fin (n + 2)) : Δ[n].obj m :=
+  standardSimplex.map (σ (Fin.predAbove 0 j)) |>.app m α
+
+lemma factor_δ_spec {n : ℕ} {m : SimplexCategoryᵒᵖ} (α : Δ[n + 1].obj m)
+    (j : Fin (n + 2)) (hj : ∀ k, α.down.toOrderHom k ≠ j) :
+    (standardSimplex.map (δ j)).app m (factor_δ α j) = α := by
+  change { down := SimplexCategory.factor_δ (m := m.unop.len) _ j ≫ δ j } = α
+  rw [SimplexCategory.factor_δ_spec _ j hj]
+  rfl
+
+lemma factor_δ_δ_eq {n : ℕ} {m : SimplexCategoryᵒᵖ}
+    (α : Δ[n].obj m) (j : Fin (n + 2)) :
+    factor_δ ((standardSimplex.map (δ j)).app m α) j = α := by
+  dsimp only [factor_δ]
+  rw [← FunctorToTypes.comp, ← Functor.map_comp]
+  change (standardSimplex.map (SimplexCategory.factor_δ _ _)).app _ _ = _
+  rw [SimplexCategory.factor_δ_δ_eq, CategoryTheory.Functor.map_id]
+  rfl
+
 end standardSimplex
 
 section

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Boundary.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Boundary.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2025 Nick Ward. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nick Ward
+-/
+import Mathlib.AlgebraicTopology.SimplicialSet.Basic
+
+/-!
+# Boundary of the standard simplex
+
+In `AlgebraicTopology.SimplicialSet.Basic`, we define the boundary `∂Δ[n]` of
+the `n`th standard simplex as the simplicial set consisting of all
+`m`-simplices of `Δ[n]` that are not surjective when viewed as monotone
+functions from `[m]` to `[n]`.
+
+In this file, we provide a description of `∂Δ[n]` as a colimit of the standard
+simplices, following the proof in [Kerodon, 0504](https://kerodon.net/tag/0504).
+-/
+
+open Fin CategoryTheory Limits Simplicial SimplexCategory
+
+namespace SSet.boundary
+open standardSimplex
+
+def diagram (n : ℕ) : MultispanIndex SSet where
+  L := { (i, j) : Fin (n + 2) × Fin (n + 3) | i.castSucc < j }
+  R := Fin (n + 3)
+  fstFrom p := p.1.1.castSucc
+  sndFrom p := p.1.2
+  left _ := Δ[n]
+  right _ := Δ[n + 1]
+  fst p := standardSimplex.map <| δ <| p.1.2.pred <| ne_zero_of_lt p.2
+  snd p := standardSimplex.map <| δ p.1.1
+
+abbrev cocone (n : ℕ) : Multicofork (diagram n) := by
+  refine Multicofork.ofπ (diagram n) ∂Δ[n + 2] ?_ ?_
+  · intro k
+    refine {
+      app := fun m α ↦ ⟨standardSimplex.map (δ k) |>.app m α, ?_⟩
+      naturality := fun a b f ↦ rfl }
+    apply succAbove_not_surjective ∘ Function.Surjective.of_comp
+  · intro ⟨⟨i, j⟩, h⟩
+    ext m α
+    apply Subtype.ext
+    rw [NatTrans.comp_app, NatTrans.comp_app]
+    dsimp only [diagram, Set.coe_setOf, Set.mem_setOf_eq, types_comp_apply]
+    rw [← FunctorToTypes.comp, ← Functor.map_comp, ← δ_comp_δ' h]
+    rfl
+
+noncomputable def skips {n : ℕ} {m : SimplexCategoryᵒᵖ} (α : ∂Δ[n].obj m) :
+    Fin (n + 1) := Classical.choose <| not_forall.mp α.property
+
+lemma skips_spec {n : ℕ} {m : SimplexCategoryᵒᵖ} (α : ∂Δ[n].obj m) :
+    ∀ k : Fin (m.unop.len + 1), asOrderHom α.1 k ≠ skips α :=
+  not_exists.mp <| Classical.choose_spec <| not_forall.mp α.2
+
+abbrev factor_δ₂ {n : ℕ} {m : SimplexCategoryᵒᵖ} (α : Δ[n + 2].obj m)
+    (i : Fin (n + 2)) (j : Fin (n + 3)) : Δ[n].obj m :=
+  factor_δ (factor_δ α j) i
+
+lemma δ_factor_δ₂_le {n : ℕ} {m : SimplexCategoryᵒᵖ} (α : Δ[n + 2].obj m)
+    {i j : Fin (n + 2)} (h : i ≤ j) (hi : ∀ x, (asOrderHom α) x ≠ i.castSucc)
+    (hj : ∀ x, (asOrderHom α) x ≠ j.succ) :
+    (standardSimplex.map (δ i)).app m (factor_δ₂ α i j.succ) =
+      factor_δ α j.succ := by
+  simp only [standardSimplex.factor_δ, predAbove_zero_succ]
+  apply standardSimplex.factor_δ_spec
+  intro k; specialize hi k; specialize hj k
+  simp only [σ, asOrderHom, yoneda_obj_obj, standardSimplex, uliftFunctor,
+    Functor.comp_obj, mkHom, Functor.comp_map,
+    SimplicialObject.whiskering_obj_map_app, uliftFunctor_map, yoneda_map_app,
+    comp_toOrderHom, len_mk, Hom.toOrderHom_mk, OrderHom.comp_coe,
+    OrderHom.coe_mk, Function.comp_apply, ne_eq]
+  rcases lt_or_eq_of_le h with (h | rfl)
+  · exact hi ∘ (predAbove_eq_lt_iff h _).mp
+  · exact not_or.mpr (And.intro hi hj) ∘ (predAbove_eq_self_iff i _).mp
+
+lemma δ_factor_δ₂_ge {n : ℕ} {m : SimplexCategoryᵒᵖ} (α : Δ[n + 2].obj m)
+    {i j : Fin (n + 2)} (h : i ≤ j) (hi : ∀ x, (asOrderHom α) x ≠ i.castSucc)
+    (hj : ∀ x, (asOrderHom α) x ≠ j.succ) :
+    (standardSimplex.map (δ j)).app m (factor_δ₂ α i j.succ) =
+      factor_δ α i.castSucc := by
+  simp only [standardSimplex.factor_δ, standardSimplex, uliftFunctor,
+    Functor.comp_obj, SimplicialObject.whiskering_obj_obj_obj, yoneda_obj_obj,
+    uliftFunctor_obj, Functor.comp_map, SimplicialObject.whiskering_obj_map_app,
+    uliftFunctor_map, yoneda_map_app, Category.assoc, ULift.up_inj]
+  rw [σ_predAbove_zero_comp_σ_predAbove_zero_assoc h]
+  change factor_δ (m := m.unop.len) (_ ≫ σ _) _ ≫ δ _ = _
+  apply SimplexCategory.factor_δ_spec
+  intro k; specialize hi k; specialize hj k
+  dsimp [σ]
+  rcases lt_or_eq_of_le h with (h | rfl)
+  · refine hj ∘ (predAbove_eq_gt_iff ?_ _).mp
+    refine lt_of_le_of_lt ?_ h
+    exact castSucc_le_castSucc_iff.mp <| castSucc_predAbove_le _ _
+  · cases' i using cases with i
+    · exact not_or.mpr (And.intro hi hj) ∘ (predAbove_eq_self_iff 0 _).mp
+    · rw [← succ_castSucc, predAbove_zero_succ]
+      exact hj ∘ (predAbove_eq_gt_iff (castSucc_lt_succ i) _).mp
+
+lemma π_factor_δ_lt {n : ℕ} (X : Multicofork (diagram n)) {m : SimplexCategoryᵒᵖ}
+    (α : Δ[n + 2].obj m) {i j : Fin (n + 3)} (h : i < j)
+    (hi : ∀ x, asOrderHom α x ≠ i) (hj : ∀ x, asOrderHom α x ≠ j) :
+    (X.π i).app m (factor_δ α i) = (X.π j).app m (factor_δ α j) := by
+  have hlast := Fin.ne_last_of_lt h
+  have h0 := Fin.ne_zero_of_lt h
+  have hle := Fin.castPred_le_pred_iff hlast h0 |>.mpr h
+  let ij : { (i, j) : Fin (n + 2) × Fin (n + 3) | i.castSucc < j } :=
+    ⟨(i.castPred hlast, j), h⟩
+  rw [← Fin.castSucc_castPred i hlast] at hi ⊢
+  rw [← Fin.succ_pred j h0] at hj ⊢
+  rw [← δ_factor_δ₂_le α hle hi hj, ← δ_factor_δ₂_ge α hle hi hj,
+    ← FunctorToTypes.comp, ← FunctorToTypes.comp, Fin.succ_pred]
+  change ((diagram n).fst ij ≫ X.π _).app m _ =
+    ((diagram n).snd ij ≫ X.π _).app m _
+  rw [X.condition]
+
+lemma π_factor_δ {n : ℕ} (X : Multicofork (diagram n))
+    {m : SimplexCategoryᵒᵖ} (α : Δ[n + 2].obj m)
+    (i : Fin (n + 3)) (hi : ∀ x, asOrderHom α x ≠ i)
+    (j : Fin (n + 3)) (hj : ∀ x, asOrderHom α x ≠ j) :
+    (X.π i).app m (factor_δ α i) = (X.π j).app m (factor_δ α j) := by
+  rcases lt_trichotomy i j with (h | rfl | h)
+  · exact π_factor_δ_lt X α h hi hj
+  · rfl
+  · exact π_factor_δ_lt X α h hj hi |>.symm
+
+noncomputable def isColimit (n : ℕ) : IsColimit (cocone n) := by
+  refine Multicofork.IsColimit.mk (cocone n) ?_ ?_ ?_
+  · intro X
+    refine {
+      app := fun m α ↦ X.π (skips α) |>.app m <| factor_δ α.1 (skips α),
+      naturality := ?_ }
+    intro a b f
+    ext α
+    dsimp only [Multicofork.ofπ_pt, types_comp_apply] at α ⊢
+    rw [π_factor_δ X _ _ _ (skips α)]
+    · rw [← types_comp_apply _ (X.pt.map f), ← NatTrans.naturality]
+      rfl
+    · intro k; apply skips_spec α
+    · exact skips_spec <| ∂Δ[n + 2].map f α
+  · intro X k
+    ext m α
+    dsimp only [diagram] at k α
+    change (X.π _).app _ (factor_δ ((standardSimplex.map _).app _ _) _) = _
+    rw [π_factor_δ X _ _ _ k]
+    · rw [standardSimplex.factor_δ_δ_eq α]
+    · intro j; exact Fin.succAbove_ne k _
+    · exact skips_spec <| cocone n |>.π k |>.app m α
+  · intro X f h
+    ext m α
+    simp only [Multicofork.ofπ_pt, ← h (skips α)]
+    apply congr_arg (f.app m) ∘ Subtype.ext
+    exact standardSimplex.factor_δ_spec _ _ (skips_spec α) |>.symm
+
+end SSet.boundary


### PR DESCRIPTION
We provide a description of the boundary `∂Δ[n]` of the `n`th standard simplex as a colimit of the standard simplices, following the proof of [Kerodon Proposition 1.1.4.13](https://kerodon.net/tag/0504).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
