### PR TITLE
[Merged by Bors] - fix: make `Prod` projection delaborators respond to options, add option to disable

### DIFF
--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -300,21 +300,41 @@ theorem map_involutive [Nonempty α] [Nonempty β] {f : α → α} {g : β → �
     Involutive (map f g) ↔ Involutive f ∧ Involutive g :=
   map_leftInverse
 
-section delaborators
+namespace PrettyPrinting
 open Lean PrettyPrinter Delaborator
+
+/--
+When true, then `Prod.fst x` and `Prod.snd x` pretty print as `x.1` and `x.2`
+rather than as `x.fst` and `x.snd`.
+-/
+register_option pp.numericProj.prod : Bool := {
+  defValue := true
+  descr := "enable pretty printing `Prod.fst x` as `x.1` and `Prod.snd x` as `x.2`."
+}
+
+def getPPNumericProjProd (o : Options) : Bool :=
+  o.get pp.numericProj.prod.name pp.numericProj.prod.defValue
 
 /-- Delaborator for `Prod.fst x` as `x.1`. -/
 @[app_delab Prod.fst]
-def delabProdFst : Delab := withOverApp 3 do
-  let x ← SubExpr.withAppArg delab
-  `($(x).1)
+def delabProdFst : Delab :=
+  whenPPOption getPPNumericProjProd <|
+  whenPPOption getPPFieldNotation <|
+  whenNotPPOption getPPExplicit <|
+  withOverApp 3 do
+    let x ← SubExpr.withAppArg delab
+    `($(x).1)
 
 /-- Delaborator for `Prod.snd x` as `x.2`. -/
 @[app_delab Prod.snd]
-def delabProdSnd : Delab := withOverApp 3 do
-  let x ← SubExpr.withAppArg delab
-  `($(x).2)
+def delabProdSnd : Delab :=
+  whenPPOption getPPNumericProjProd <|
+  whenPPOption getPPFieldNotation <|
+  whenNotPPOption getPPExplicit <|
+  withOverApp 3 do
+    let x ← SubExpr.withAppArg delab
+    `($(x).2)
 
-end delaborators
+end PrettyPrinting
 
 end Prod

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -312,6 +312,8 @@ register_option pp.numericProj.prod : Bool := {
   descr := "enable pretty printing `Prod.fst x` as `x.1` and `Prod.snd x` as `x.2`."
 }
 
+/-- Tell whether pretty-printing should use numeric projection notations `.1`
+and `.2` for `Prod.fst` and `Prod.snd`. -/
 def getPPNumericProjProd (o : Options) : Bool :=
   o.get pp.numericProj.prod.name pp.numericProj.prod.defValue
 

--- a/MathlibTest/delaborators.lean
+++ b/MathlibTest/delaborators.lean
@@ -232,4 +232,33 @@ variable (p : (ℕ → ℕ) × (ℕ → ℕ))
 #guard_msgs in
 #check p.1 22
 
+set_option pp.numericProj.prod false in
+/-- info: x.fst : ℕ -/
+#guard_msgs in
+#check x.1
+
+set_option pp.numericProj.prod false in
+/-- info: x.snd : ℕ -/
+#guard_msgs in
+#check x.2
+
+set_option pp.explicit true in
+/-- info: @Prod.fst Nat Nat x : Nat -/
+#guard_msgs in
+#check x.1
+
+set_option pp.explicit true in
+/-- info: @Prod.snd Nat Nat x : Nat -/
+#guard_msgs in
+#check x.2
+
+set_option pp.fieldNotation false in
+/-- info: Prod.fst x : ℕ -/
+#guard_msgs in
+#check x.1
+
+set_option pp.fieldNotation false in
+/-- info: Prod.snd x : ℕ -/
+#guard_msgs in
+#check x.2
 end prod


### PR DESCRIPTION
Adds option `pp.numericProj.prod` to configure whether or not to use `x.1` and `x.2` rather than `x.fst` and `x.snd`. Fixes the delaborators to make sure they respond to `pp.fieldNotation` and `pp.explicit`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
