### PR TITLE
[Merged by Bors] - feat: Estimating a finite sum by an interval integral, for the product of a monotone and an antitone function

### DIFF
--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -15,9 +15,8 @@ It is often the case that error terms in analysis can be computed by comparing
 an infinite sum to the improper integral of an antitone function. This file will eventually enable
 that.
 
-At the moment it contains four lemmas in this direction: `AntitoneOn.integral_le_sum`,
-`AntitoneOn.sum_le_integral` and versions for monotone functions, which can all be paired
-with a `Filter.Tendsto` to estimate some errors.
+At the moment it contains several lemmas in this direction, for antitone or monotone functions
+(or products of antitone and monotone functions), formulated for sums on `range i` or `Ico a b`.
 
 `TODO`: Add more lemmas to the API to directly address limiting issues
 
@@ -31,6 +30,10 @@ with a `Filter.Tendsto` to estimate some errors.
   values at integer steps aligning with the right-hand side of the interval
 * `MonotoneOn.sum_le_integral`: The sum of a monotone function along integer steps aligning with
   the left-hand side of the interval is at most the integral of the function along that interval
+* `sum_mul_Ico_le_integral_of_monotone_antitone`: the sum of `f i * g i` on an interval is bounded
+  by the integral of `f x * g (x - 1)` if `f` is monotone and `g` is antitone.
+* `integral_le_sum_mul_Ico_of_antitone_monotone`: the sum of `f i * g i` on an interval is bounded
+  below by the integral of `f x * g (x - 1)` if `f` is antitone and `g` is monotone.
 
 ## Tags
 
@@ -70,58 +73,6 @@ lemma integral_le_sum_Ico_of_le
     ∫ x in a..b, g x ≤ ∑ i ∈ Finset.Ico a b, f i := by
   convert neg_le_neg (sum_Ico_le_integral_of_le (f := -f) (g := -g) hab
     (fun i hi x hx ↦ neg_le_neg (h i hi x hx)) hg.neg) <;> simp
-
-lemma sum_mul_le_integral_of_monotone_antitone
-    (hab : a ≤ b) (hf : MonotoneOn f (Icc a b)) (hg : AntitoneOn g (Icc (a - 1) (b - 1)))
-    (fpos : 0 ≤ f a) (gpos : 0 ≤ g (b - 1)) :
-    ∑ i ∈ Finset.Ico a b, f i * g i ≤ ∫ x in a..b, f x * g (x - 1) := by
-  apply sum_Ico_le_integral_of_le (f := fun x ↦ f x * g x) hab
-  · intro i hi x hx
-    simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
-    have I0 : (i : ℝ) ≤ b - 1 := by
-      simp only [le_sub_iff_add_le]
-      norm_cast
-      omega
-    have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
-      simp only [mem_Icc, tsub_le_iff_right]
-      exact ⟨by norm_cast; omega, I0⟩
-    have I2 : x ∈ Icc (a : ℝ) b := by
-      refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
-      norm_cast
-      omega
-    apply mul_le_mul
-    · apply hf
-      · simp only [mem_Icc, Nat.cast_le]
-        exact ⟨hi.1, hi.2.le⟩
-      · exact I2
-      · exact hx.1
-    · apply hg
-      · simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
-        refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
-        norm_cast
-        omega
-      · exact I1
-      · simpa [sub_le_iff_le_add] using hx.2.le
-    · apply gpos.trans
-      apply hg I1 (by simp [hab]) I0
-    · apply fpos.trans
-      apply hf (by simp [hab]) I2
-      exact le_trans (mod_cast hi.1) hx.1
-  · rw [IntegrableOn, ← memℒp_one_iff_integrable]
-    apply Memℒp.mono_measure (μ := volume.restrict (Icc (a : ℝ) b))
-    · apply Measure.restrict_mono_set
-      exact Ico_subset_Icc_self
-    apply Memℒp.memℒp_of_exponent_le_of_measure_support_ne_top (s := univ)
-      _ (by simp) (by simp) le_top
-    apply Memℒp.mul_of_top_left
-    · apply AntitoneOn.memℒp_isCompact isCompact_Icc
-      intro x hx y hy hxy
-      apply hg
-      · simpa using hx
-      · simpa using hy
-      · simpa using hxy
-    · exact hf.memℒp_isCompact isCompact_Icc
-
 
 theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
     (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ Finset.range a, f (x₀ + i) := by
@@ -241,3 +192,104 @@ theorem MonotoneOn.integral_le_sum_Ico (hab : a ≤ b) (hf : MonotoneOn f (Set.I
     (∫ x in a..b, f x) ≤ ∑ i ∈ Finset.Ico a b, f (i + 1 : ℕ) := by
   rw [← neg_le_neg_iff, ← Finset.sum_neg_distrib, ← intervalIntegral.integral_neg]
   exact hf.neg.sum_le_integral_Ico hab
+
+lemma sum_mul_Ico_le_integral_of_monotone_antitone
+    (hab : a ≤ b) (hf : MonotoneOn f (Icc a b)) (hg : AntitoneOn g (Icc (a - 1) (b - 1)))
+    (fpos : 0 ≤ f a) (gpos : 0 ≤ g (b - 1)) :
+    ∑ i ∈ Finset.Ico a b, f i * g i ≤ ∫ x in a..b, f x * g (x - 1) := by
+  apply sum_Ico_le_integral_of_le (f := fun x ↦ f x * g x) hab
+  · intro i hi x hx
+    simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
+    have I0 : (i : ℝ) ≤ b - 1 := by
+      simp only [le_sub_iff_add_le]
+      norm_cast
+      omega
+    have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
+      simp only [mem_Icc, tsub_le_iff_right]
+      exact ⟨by norm_cast; omega, I0⟩
+    have I2 : x ∈ Icc (a : ℝ) b := by
+      refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
+      norm_cast
+      omega
+    apply mul_le_mul
+    · apply hf
+      · simp only [mem_Icc, Nat.cast_le]
+        exact ⟨hi.1, hi.2.le⟩
+      · exact I2
+      · exact hx.1
+    · apply hg
+      · simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
+        refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
+        norm_cast
+        omega
+      · exact I1
+      · simpa [sub_le_iff_le_add] using hx.2.le
+    · apply gpos.trans
+      apply hg I1 (by simp [hab]) I0
+    · apply fpos.trans
+      apply hf (by simp [hab]) I2
+      exact le_trans (mod_cast hi.1) hx.1
+  · rw [IntegrableOn, ← memℒp_one_iff_integrable]
+    apply Memℒp.mono_measure (μ := volume.restrict (Icc (a : ℝ) b))
+    · apply Measure.restrict_mono_set
+      exact Ico_subset_Icc_self
+    apply Memℒp.memℒp_of_exponent_le_of_measure_support_ne_top (s := univ)
+      _ (by simp) (by simp) le_top
+    apply Memℒp.mul_of_top_left
+    · apply AntitoneOn.memℒp_isCompact isCompact_Icc
+      intro x hx y hy hxy
+      apply hg
+      · simpa using hx
+      · simpa using hy
+      · simpa using hxy
+    · exact hf.memℒp_isCompact isCompact_Icc
+
+lemma integral_le_sum_mul_Ico_of_antitone_monotone
+    (hab : a ≤ b) (hf : AntitoneOn f (Icc a b)) (hg : MonotoneOn g (Icc (a - 1) (b - 1)))
+    (fpos : 0 ≤ f b) (gpos : 0 ≤ g (a - 1)) :
+    ∫ x in a..b, f x * g (x - 1) ≤ ∑ i ∈ Finset.Ico a b, f i * g i := by
+  apply integral_le_sum_Ico_of_le (f := fun x ↦ f x * g x) hab
+  · intro i hi x hx
+    simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
+    have I0 : (i : ℝ) ≤ b - 1 := by
+      simp only [le_sub_iff_add_le]
+      norm_cast
+      omega
+    have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
+      simp only [mem_Icc, tsub_le_iff_right]
+      exact ⟨by norm_cast; omega, I0⟩
+    have I2 : x ∈ Icc (a : ℝ) b := by
+      refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
+      norm_cast
+      omega
+    apply mul_le_mul
+    · apply hf
+      · simp only [mem_Icc, Nat.cast_le]
+        exact ⟨hi.1, hi.2.le⟩
+      · exact I2
+      · exact hx.1
+    · apply hg
+      · simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
+        refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
+        norm_cast
+        omega
+      · exact I1
+      · simpa [sub_le_iff_le_add] using hx.2.le
+    · apply gpos.trans
+      apply hg (by simp [hab]) (by simpa using I2) (by simpa using I2.1)
+    · apply fpos.trans
+      apply hf ⟨mod_cast hi.1, mod_cast hi.2.le⟩ (by simpa using hab) (mod_cast hi.2.le)
+  · rw [IntegrableOn, ← memℒp_one_iff_integrable]
+    apply Memℒp.mono_measure (μ := volume.restrict (Icc (a : ℝ) b))
+    · apply Measure.restrict_mono_set
+      exact Ico_subset_Icc_self
+    apply Memℒp.memℒp_of_exponent_le_of_measure_support_ne_top (s := univ)
+      _ (by simp) (by simp) le_top
+    apply Memℒp.mul_of_top_left
+    · apply MonotoneOn.memℒp_isCompact isCompact_Icc
+      intro x hx y hy hxy
+      apply hg
+      · simpa using hx
+      · simpa using hy
+      · simpa using hxy
+    · exact hf.memℒp_isCompact isCompact_Icc

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -42,8 +42,7 @@ open Set MeasureTheory MeasureSpace
 
 variable {x₀ : ℝ} {a b : ℕ} {f g : ℝ → ℝ}
 
-
-lemma sum_le_integral_of_le
+lemma sum_Ico_le_integral_of_le
     (hab : a ≤ b) (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) (i + 1 : ℕ), f i ≤ g x)
     (hg : IntegrableOn g (Set.Ico a b)) :
     ∑ i ∈ Finset.Ico a b, f i ≤ ∫ x in a..b, g x := by
@@ -65,11 +64,18 @@ lemma sum_le_integral_of_le
     intro i hi
     exact A _ (by simpa using hi)
 
+lemma integral_le_sum_Ico_of_le
+    (hab : a ≤ b) (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) (i + 1 : ℕ), g x ≤ f i)
+    (hg : IntegrableOn g (Set.Ico a b)) :
+    ∫ x in a..b, g x ≤ ∑ i ∈ Finset.Ico a b, f i := by
+  convert neg_le_neg (sum_Ico_le_integral_of_le (f := -f) (g := -g) hab
+    (fun i hi x hx ↦ neg_le_neg (h i hi x hx)) hg.neg) <;> simp
+
 lemma sum_mul_le_integral_of_monotone_antitone
     (hab : a ≤ b) (hf : MonotoneOn f (Icc a b)) (hg : AntitoneOn g (Icc (a - 1) (b - 1)))
     (fpos : 0 ≤ f a) (gpos : 0 ≤ g (b - 1)) :
     ∑ i ∈ Finset.Ico a b, f i * g i ≤ ∫ x in a..b, f x * g (x - 1) := by
-  apply sum_le_integral_of_le (f := fun x ↦ f x * g x) hab
+  apply sum_Ico_le_integral_of_le (f := fun x ↦ f x * g x) hab
   · intro i hi x hx
     simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
     have I0 : (i : ℝ) ≤ b - 1 := by

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -229,20 +229,15 @@ lemma sum_mul_Ico_le_integral_of_monotone_antitone
     · apply fpos.trans
       apply hf (by simp [hab]) I2
       exact le_trans (mod_cast hi.1) hx.1
-  · rw [IntegrableOn, ← memℒp_one_iff_integrable]
-    apply Memℒp.mono_measure (μ := volume.restrict (Icc (a : ℝ) b))
-    · apply Measure.restrict_mono_set
-      exact Ico_subset_Icc_self
-    apply Memℒp.memℒp_of_exponent_le_of_measure_support_ne_top (s := univ)
-      _ (by simp) (by simp) le_top
-    apply Memℒp.mul_of_top_left
+  · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
+    apply Integrable.mul_of_top_left
+    · exact hf.integrableOn_isCompact isCompact_Icc
     · apply AntitoneOn.memℒp_isCompact isCompact_Icc
       intro x hx y hy hxy
       apply hg
       · simpa using hx
       · simpa using hy
       · simpa using hxy
-    · exact hf.memℒp_isCompact isCompact_Icc
 
 lemma integral_le_sum_mul_Ico_of_antitone_monotone
     (hab : a ≤ b) (hf : AntitoneOn f (Icc a b)) (hg : MonotoneOn g (Icc (a - 1) (b - 1)))
@@ -279,17 +274,12 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
       apply hg (by simp [hab]) (by simpa using I2) (by simpa using I2.1)
     · apply fpos.trans
       apply hf ⟨mod_cast hi.1, mod_cast hi.2.le⟩ (by simpa using hab) (mod_cast hi.2.le)
-  · rw [IntegrableOn, ← memℒp_one_iff_integrable]
-    apply Memℒp.mono_measure (μ := volume.restrict (Icc (a : ℝ) b))
-    · apply Measure.restrict_mono_set
-      exact Ico_subset_Icc_self
-    apply Memℒp.memℒp_of_exponent_le_of_measure_support_ne_top (s := univ)
-      _ (by simp) (by simp) le_top
-    apply Memℒp.mul_of_top_left
+  · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
+    apply Integrable.mul_of_top_left
+    · exact hf.integrableOn_isCompact isCompact_Icc
     · apply MonotoneOn.memℒp_isCompact isCompact_Icc
       intro x hx y hy hxy
       apply hg
       · simpa using hx
       · simpa using hy
       · simpa using hxy
-    · exact hf.memℒp_isCompact isCompact_Icc

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -38,9 +38,84 @@ analysis, comparison, asymptotics
 -/
 
 
-open Set MeasureTheory.MeasureSpace
+open Set MeasureTheory MeasureSpace
 
-variable {x₀ : ℝ} {a b : ℕ} {f : ℝ → ℝ}
+variable {x₀ : ℝ} {a b : ℕ} {f g : ℝ → ℝ}
+
+
+lemma sum_le_integral_of_le
+    (hab : a ≤ b) (h : ∀ i ∈ Ico a b, ∀ x ∈ Ico (i : ℝ) (i + 1 : ℕ), f i ≤ g x)
+    (hg : IntegrableOn g (Set.Ico a b)) :
+    ∑ i ∈ Finset.Ico a b, f i ≤ ∫ x in a..b, g x := by
+  have A i (hi : i ∈ Finset.Ico a b) : IntervalIntegrable g volume i (i + 1 : ℕ) := by
+    rw [intervalIntegrable_iff_integrableOn_Ico_of_le (by simp)]
+    apply hg.mono _ le_rfl
+    rintro x ⟨hx, h'x⟩
+    simp only [Finset.mem_Ico, mem_Ico] at hi ⊢
+    exact ⟨le_trans (mod_cast hi.1) hx, h'x.trans_le (mod_cast hi.2)⟩
+  calc
+  ∑ i ∈ Finset.Ico a b, f i
+  _ = ∑ i ∈ Finset.Ico a b, (∫ x in (i : ℝ)..(i + 1 : ℕ), f i) := by simp
+  _ ≤ ∑ i ∈ Finset.Ico a b, (∫ x in (i : ℝ)..(i + 1 : ℕ), g x) := by
+    apply Finset.sum_le_sum (fun i hi ↦ ?_)
+    apply intervalIntegral.integral_mono_on_of_le_Ioo (by simp) (by simp) (A _ hi) (fun x hx ↦ ?_)
+    exact h _ (by simpa using hi) _ (Ioo_subset_Ico_self hx)
+  _ = ∫ x in a..b, g x := by
+    rw [intervalIntegral.sum_integral_adjacent_intervals_Ico (a := fun i ↦ i) hab]
+    intro i hi
+    exact A _ (by simpa using hi)
+
+lemma sum_mul_le_integral_of_monotone_antitone
+    (hab : a ≤ b) (hf : MonotoneOn f (Icc a b)) (hg : AntitoneOn g (Icc (a - 1) (b - 1)))
+    (fpos : 0 ≤ f a) (gpos : 0 ≤ g (b - 1)) :
+    ∑ i ∈ Finset.Ico a b, f i * g i ≤ ∫ x in a..b, f x * g (x - 1) := by
+  apply sum_le_integral_of_le (f := fun x ↦ f x * g x) hab
+  · intro i hi x hx
+    simp only [Nat.cast_add, Nat.cast_one, mem_Ico] at hx hi
+    have I0 : (i : ℝ) ≤ b - 1 := by
+      simp only [le_sub_iff_add_le]
+      norm_cast
+      omega
+    have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
+      simp only [mem_Icc, tsub_le_iff_right]
+      exact ⟨by norm_cast; omega, I0⟩
+    have I2 : x ∈ Icc (a : ℝ) b := by
+      refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
+      norm_cast
+      omega
+    apply mul_le_mul
+    · apply hf
+      · simp only [mem_Icc, Nat.cast_le]
+        exact ⟨hi.1, hi.2.le⟩
+      · exact I2
+      · exact hx.1
+    · apply hg
+      · simp only [mem_Icc, tsub_le_iff_right, sub_add_cancel]
+        refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
+        norm_cast
+        omega
+      · exact I1
+      · simpa [sub_le_iff_le_add] using hx.2.le
+    · apply gpos.trans
+      apply hg I1 (by simp [hab]) I0
+    · apply fpos.trans
+      apply hf (by simp [hab]) I2
+      exact le_trans (mod_cast hi.1) hx.1
+  · rw [IntegrableOn, ← memℒp_one_iff_integrable]
+    apply Memℒp.mono_measure (μ := volume.restrict (Icc (a : ℝ) b))
+    · apply Measure.restrict_mono_set
+      exact Ico_subset_Icc_self
+    apply Memℒp.memℒp_of_exponent_le_of_measure_support_ne_top (s := univ)
+      _ (by simp) (by simp) le_top
+    apply Memℒp.mul_of_top_left
+    · apply AntitoneOn.memℒp_isCompact isCompact_Icc
+      intro x hx y hy hxy
+      apply hg
+      · simpa using hx
+      · simpa using hy
+      · simpa using hxy
+    · exact hf.memℒp_isCompact isCompact_Icc
+
 
 theorem AntitoneOn.integral_le_sum (hf : AntitoneOn f (Icc x₀ (x₀ + a))) :
     (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ Finset.range a, f (x₀ + i) := by

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -1199,6 +1199,14 @@ theorem Integrable.bdd_mul' {f g : α → 𝕜} {c : ℝ} (hg : Integrable g μ)
   rw [Pi.smul_apply, smul_eq_mul]
   exact (norm_mul_le _ _).trans (mul_le_mul_of_nonneg_right hx (norm_nonneg _))
 
+theorem Integrable.mul_of_top_right {f : α → 𝕜} {φ : α → 𝕜} (hf : Integrable f μ)
+    (hφ : Memℒp φ ∞ μ) : Integrable (φ * f) μ :=
+  hf.smul_of_top_right hφ
+
+theorem Integrable.mul_of_top_left {f : α → 𝕜} {φ : α → 𝕜} (hφ : Integrable φ μ)
+    (hf : Memℒp f ∞ μ) : Integrable (φ * f) μ :=
+  hφ.smul_of_top_left hf
+
 end NormedRing
 
 section NormedDivisionRing

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -542,7 +542,7 @@ theorem AntitoneOn.integrableOn_of_measure_ne_top (hanti : AntitoneOn f s) {a b 
     IntegrableOn f s μ :=
   memℒp_one_iff_integrable.1 (hanti.memℒp_of_measure_ne_top ha hb hs h's)
 
-theorem AntioneOn.integrableOn_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
+theorem AntitoneOn.integrableOn_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
     (hanti : AntitoneOn f s) : IntegrableOn f s μ :=
   memℒp_one_iff_integrable.1 (hanti.memℒp_isCompact hs)
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -1067,6 +1067,15 @@ theorem integral_mono_on (h : ∀ x ∈ Icc a b, f x ≤ g x) :
   let H x hx := h x <| Ioc_subset_Icc_self hx
   simpa only [integral_of_le hab] using setIntegral_mono_on hf.1 hg.1 measurableSet_Ioc H
 
+theorem integral_mono_on_of_le_Ioo [NoAtoms μ] (h : ∀ x ∈ Ioo a b, f x ≤ g x) :
+    (∫ u in a..b, f u ∂μ) ≤ ∫ u in a..b, g u ∂μ := by
+  simp only [integral_of_le hab, integral_Ioc_eq_integral_Ioo]
+  apply setIntegral_mono_on
+  · apply hf.1.mono Ioo_subset_Ioc_self le_rfl
+  · apply hg.1.mono Ioo_subset_Ioc_self le_rfl
+  · exact measurableSet_Ioo
+  · exact h
+
 theorem integral_mono (h : f ≤ g) : (∫ u in a..b, f u ∂μ) ≤ ∫ u in a..b, g u ∂μ :=
   integral_mono_ae hab hf hg <| ae_of_all _ h
 


### PR DESCRIPTION
From the Carleson project

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
