### PR TITLE
[Merged by Bors] - feat: A disjoint union is finite iff all sets are finite, and all but finitely many are empty

### DIFF
--- a/Mathlib/Data/Set/Finite/Lattice.lean
+++ b/Mathlib/Data/Set/Finite/Lattice.lean
@@ -154,7 +154,7 @@ theorem Finite.iUnion {ι : Type*} {s : ι → Set α} {t : Set ι} (ht : t.Fini
 
 /-- An indexed union of pairwise disjoint sets is finite iff all sets are finite, and all but
 finitely many are empty. -/
-lemma finite_biUnion_iff_of_pairwiseDisjoint {f : β → Set α} {s : Set β}
+lemma PairwiseDisjoint.finite_biUnion_iff {f : β → Set α} {s : Set β}
     (hs : s.PairwiseDisjoint f) :
     Set.Finite (⋃ i ∈ s, f i)
       ↔ (∀ i ∈ s, Set.Finite (f i)) ∧ Set.Finite {i ∈ s | (f i).Nonempty} := by
@@ -162,25 +162,20 @@ lemma finite_biUnion_iff_of_pairwiseDisjoint {f : β → Set α} {s : Set β}
   · intro h
     refine ⟨fun i hi ↦ ?_, ?_⟩
     · have : f i ⊆ ⋃ i ∈ s, f i := subset_biUnion_of_mem hi
-      exact Finite.subset h this
-    · let u : {i ∈ s | (f i).Nonempty} → ⋃ i ∈ s, f i := fun i ↦ ⟨i.2.2.choose, by
-        have : i.2.2.choose ∈ f i := i.2.2.choose_spec
-        simp only [mem_setOf_eq, mem_iUnion, exists_prop]
-        exact ⟨i, i.2.1, this⟩⟩
+      exact h.subset this
+    · let u : {i ∈ s | (f i).Nonempty} → ⋃ i ∈ s, f i :=
+        fun i ↦ ⟨i.2.2.choose, mem_biUnion i.2.1 i.2.2.choose_spec⟩
       have u_inj : Function.Injective u := by
         rintro ⟨i, hi⟩ ⟨j, hj⟩ hij
-        simp only [coe_setOf, mem_setOf_eq, Subtype.mk.injEq]
-        by_contra h'ij
-        have : Disjoint (f i) (f j) := hs hi.1 hj.1 h'ij
         have ui : (u ⟨i, hi⟩ : α) ∈ f i := hi.2.choose_spec
         rw [hij] at ui
         have uj : (u ⟨j, hj⟩ : α) ∈ f j := hj.2.choose_spec
-        exact disjoint_left.1 this ui uj
+        ext
+        exact hs.elim_set hi.1 hj.1 _ ui uj
       have : Finite (⋃ i ∈ s, f i) := h
       exact Finite.of_injective u u_inj
   · rintro ⟨h, h'⟩
-    have : ⋃ i ∈ s, f i = ⋃ i ∈ {i ∈ s | (f i).Nonempty}, f i := by
-      ext; simp; tauto
+    have : ⋃ i ∈ s, f i = ⋃ i ∈ {i ∈ s | (f i).Nonempty}, f i := by simp [iUnion_and]
     rw [this]
     apply Set.Finite.biUnion h'
     intro i hi

--- a/Mathlib/Data/Set/Finite/Lattice.lean
+++ b/Mathlib/Data/Set/Finite/Lattice.lean
@@ -183,9 +183,9 @@ lemma PairwiseDisjoint.finite_biUnion_iff {f : β → Set α} {s : Set β}
 
 /-- An indexed union of pairwise disjoint sets is finite iff all sets are finite, and all but
 finitely many are empty. -/
-lemma finite_iUnion_iff_of_pairwiseDisjoint {f : β → Set α} (hs : univ.PairwiseDisjoint f) :
+lemma PairwiseDisjoint.finite_iUnion_iff {f : β → Set α} (hs : univ.PairwiseDisjoint f) :
     Set.Finite (⋃ i, f i) ↔ (∀ i, Set.Finite (f i)) ∧ Set.Finite {i | (f i).Nonempty} := by
-  rw [← biUnion_univ, Set.finite_biUnion_iff_of_pairwiseDisjoint hs]
+  rw [← biUnion_univ, hs.finite_biUnion_iff]
   simp
 
 section preimage

--- a/Mathlib/Data/Set/Finite/Lattice.lean
+++ b/Mathlib/Data/Set/Finite/Lattice.lean
@@ -154,32 +154,32 @@ theorem Finite.iUnion {ι : Type*} {s : ι → Set α} {t : Set ι} (ht : t.Fini
 
 /-- An indexed union of pairwise disjoint sets is finite iff all sets are finite, and all but
 finitely many are empty. -/
-lemma PairwiseDisjoint.finite_biUnion_iff {f : β → Set α} {s : Set β}
-    (hs : s.PairwiseDisjoint f) :
-    Set.Finite (⋃ i ∈ s, f i)
-      ↔ (∀ i ∈ s, Set.Finite (f i)) ∧ Set.Finite {i ∈ s | (f i).Nonempty} := by
-  constructor
-  · intro h
-    refine ⟨fun i hi ↦ ?_, ?_⟩
-    · have : f i ⊆ ⋃ i ∈ s, f i := subset_biUnion_of_mem hi
-      exact h.subset this
-    · let u : {i ∈ s | (f i).Nonempty} → ⋃ i ∈ s, f i :=
-        fun i ↦ ⟨i.2.2.choose, mem_biUnion i.2.1 i.2.2.choose_spec⟩
-      have u_inj : Function.Injective u := by
-        rintro ⟨i, hi⟩ ⟨j, hj⟩ hij
-        have ui : (u ⟨i, hi⟩ : α) ∈ f i := hi.2.choose_spec
-        rw [hij] at ui
-        have uj : (u ⟨j, hj⟩ : α) ∈ f j := hj.2.choose_spec
-        ext
-        exact hs.elim_set hi.1 hj.1 _ ui uj
-      have : Finite (⋃ i ∈ s, f i) := h
-      exact Finite.of_injective u u_inj
-  · rintro ⟨h, h'⟩
-    have : ⋃ i ∈ s, f i = ⋃ i ∈ {i ∈ s | (f i).Nonempty}, f i := by simp [iUnion_and]
-    rw [this]
-    apply Set.Finite.biUnion h'
-    intro i hi
-    exact h i hi.1
+lemma finite_iUnion_iff {ι : Type*} {s : ι → Set α} (hs : Pairwise fun i j ↦ Disjoint (s i) (s j)) :
+    (⋃ i, s i).Finite ↔ (∀ i, (s i).Finite) ∧ {i | (s i).Nonempty}.Finite where
+  mp h := by
+    refine ⟨fun i ↦ h.subset <| subset_iUnion _ _, ?_⟩
+    let u (i : {i | (s i).Nonempty}) : ⋃ i, s i := ⟨i.2.choose, mem_iUnion.2 ⟨i.1, i.2.choose_spec⟩⟩
+    have u_inj : Function.Injective u := by
+      rintro ⟨i, hi⟩ ⟨j, hj⟩ hij
+      ext
+      refine hs.eq <| not_disjoint_iff.2 ⟨u ⟨i, hi⟩, hi.choose_spec, ?_⟩
+      rw [hij]
+      exact hj.choose_spec
+    have : Finite (⋃ i, s i) := h
+    exact .of_injective u u_inj
+  mpr h := h.2.iUnion (fun _ _ ↦ h.1 _) (by simp [not_nonempty_iff_eq_empty])
+
+@[simp] lemma finite_iUnion_of_subsingleton {ι : Sort*} [Subsingleton ι] {s : ι → Set α} :
+    (⋃ i, s i).Finite ↔ ∀ i, (s i).Finite := by
+  rw [← iUnion_plift_down, finite_iUnion_iff _root_.Subsingleton.pairwise]
+  simp [PLift.forall, Finite.of_subsingleton]
+
+/-- An indexed union of pairwise disjoint sets is finite iff all sets are finite, and all but
+finitely many are empty. -/
+lemma PairwiseDisjoint.finite_biUnion_iff {f : β → Set α} {s : Set β} (hs : s.PairwiseDisjoint f) :
+    (⋃ i ∈ s, f i).Finite ↔ (∀ i ∈ s, (f i).Finite) ∧ {i ∈ s | (f i).Nonempty}.Finite := by
+  rw [finite_iUnion_iff (by aesop (add unfold safe [Pairwise, PairwiseDisjoint, Set.Pairwise]))]
+  simp
 
 /-- An indexed union of pairwise disjoint sets is finite iff all sets are finite, and all but
 finitely many are empty. -/

--- a/Mathlib/Data/Set/Finite/Lattice.lean
+++ b/Mathlib/Data/Set/Finite/Lattice.lean
@@ -152,6 +152,47 @@ theorem Finite.iUnion {ι : Type*} {s : ι → Set α} {t : Set ι} (ht : t.Fini
   · rw [he i hi, mem_empty_iff_false] at hx
     contradiction
 
+/-- An indexed union of pairwise disjoint sets is finite iff all sets are finite, and all but
+finitely many are empty. -/
+lemma finite_biUnion_iff_of_pairwiseDisjoint {f : β → Set α} {s : Set β}
+    (hs : s.PairwiseDisjoint f) :
+    Set.Finite (⋃ i ∈ s, f i)
+      ↔ (∀ i ∈ s, Set.Finite (f i)) ∧ Set.Finite {i ∈ s | (f i).Nonempty} := by
+  constructor
+  · intro h
+    refine ⟨fun i hi ↦ ?_, ?_⟩
+    · have : f i ⊆ ⋃ i ∈ s, f i := subset_biUnion_of_mem hi
+      exact Finite.subset h this
+    · let u : {i ∈ s | (f i).Nonempty} → ⋃ i ∈ s, f i := fun i ↦ ⟨i.2.2.choose, by
+        have : i.2.2.choose ∈ f i := i.2.2.choose_spec
+        simp only [mem_setOf_eq, mem_iUnion, exists_prop]
+        exact ⟨i, i.2.1, this⟩⟩
+      have u_inj : Function.Injective u := by
+        rintro ⟨i, hi⟩ ⟨j, hj⟩ hij
+        simp only [coe_setOf, mem_setOf_eq, Subtype.mk.injEq]
+        by_contra h'ij
+        have : Disjoint (f i) (f j) := hs hi.1 hj.1 h'ij
+        have ui : (u ⟨i, hi⟩ : α) ∈ f i := hi.2.choose_spec
+        rw [hij] at ui
+        have uj : (u ⟨j, hj⟩ : α) ∈ f j := hj.2.choose_spec
+        exact disjoint_left.1 this ui uj
+      have : Finite (⋃ i ∈ s, f i) := h
+      exact Finite.of_injective u u_inj
+  · rintro ⟨h, h'⟩
+    have : ⋃ i ∈ s, f i = ⋃ i ∈ {i ∈ s | (f i).Nonempty}, f i := by
+      ext; simp; tauto
+    rw [this]
+    apply Set.Finite.biUnion h'
+    intro i hi
+    exact h i hi.1
+
+/-- An indexed union of pairwise disjoint sets is finite iff all sets are finite, and all but
+finitely many are empty. -/
+lemma finite_iUnion_iff_of_pairwiseDisjoint {f : β → Set α} (hs : univ.PairwiseDisjoint f) :
+    Set.Finite (⋃ i, f i) ↔ (∀ i, Set.Finite (f i)) ∧ Set.Finite {i | (f i).Nonempty} := by
+  rw [← biUnion_univ, Set.finite_biUnion_iff_of_pairwiseDisjoint hs]
+  simp
+
 section preimage
 variable {f : α → β} {s : Set β}
 

--- a/Mathlib/Data/Set/Finite/Lattice.lean
+++ b/Mathlib/Data/Set/Finite/Lattice.lean
@@ -181,13 +181,6 @@ lemma PairwiseDisjoint.finite_biUnion_iff {f : β → Set α} {s : Set β} (hs :
   rw [finite_iUnion_iff (by aesop (add unfold safe [Pairwise, PairwiseDisjoint, Set.Pairwise]))]
   simp
 
-/-- An indexed union of pairwise disjoint sets is finite iff all sets are finite, and all but
-finitely many are empty. -/
-lemma PairwiseDisjoint.finite_iUnion_iff {f : β → Set α} (hs : univ.PairwiseDisjoint f) :
-    Set.Finite (⋃ i, f i) ↔ (∀ i, Set.Finite (f i)) ∧ Set.Finite {i | (f i).Nonempty} := by
-  rw [← biUnion_univ, hs.finite_biUnion_iff]
-  simp
-
 section preimage
 variable {f : α → β} {s : Set β}
 


### PR DESCRIPTION
From the Carleson project

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
