### PR TITLE
[Merged by Bors] - feat(Radical): `(radical a).natDegree ≤ a.natDegree`

### DIFF
--- a/Mathlib/RingTheory/Polynomial/Radical.lean
+++ b/Mathlib/RingTheory/Polynomial/Radical.lean
@@ -19,6 +19,12 @@ open Polynomial UniqueFactorizationMonoid UniqueFactorizationDomain EuclideanDom
 
 variable {k : Type*} [Field k] [DecidableEq k]
 
+theorem radical_degree_le {a : k[X]} (h : a ≠ 0) :
+  (radical a).degree ≤ a.degree := degree_le_of_dvd (radical_dvd_self a) h
+
+theorem radical_natDegree_le {a : k[X]} (h : a ≠ 0) :
+  (radical a).natDegree ≤ a.natDegree := natDegree_le_of_dvd (radical_dvd_self a) h
+
 theorem divRadical_dvd_derivative (a : k[X]) : divRadical a ∣ derivative a := by
   induction a using induction_on_coprime
   · case h0 =>

--- a/Mathlib/RingTheory/Polynomial/Radical.lean
+++ b/Mathlib/RingTheory/Polynomial/Radical.lean
@@ -19,11 +19,14 @@ open Polynomial UniqueFactorizationMonoid UniqueFactorizationDomain EuclideanDom
 
 variable {k : Type*} [Field k] [DecidableEq k]
 
-theorem radical_degree_le {a : k[X]} (h : a ≠ 0) :
+theorem degree_radical_le {a : k[X]} (h : a ≠ 0) :
   (radical a).degree ≤ a.degree := degree_le_of_dvd (radical_dvd_self a) h
 
-theorem radical_natDegree_le {a : k[X]} (h : a ≠ 0) :
-  (radical a).natDegree ≤ a.natDegree := natDegree_le_of_dvd (radical_dvd_self a) h
+theorem natDegree_radical_le {a : k[X]} :
+    (radical a).natDegree ≤ a.natDegree := by
+  by_cases ha : a = 0
+  · simp [ha]
+  · exact natDegree_le_of_dvd (radical_dvd_self a) ha
 
 theorem divRadical_dvd_derivative (a : k[X]) : divRadical a ∣ derivative a := by
   induction a using induction_on_coprime


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Seperated from #18882. (nat)degree of radical of a polynomial is less than or equal to the original (nat)degree.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
