### PR TITLE
[Merged by Bors] - chore(Algebra/Category/MonCat/Colimits): remove smallness condition

### DIFF
--- a/Mathlib/Algebra/Category/MonCat/Colimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Colimits.lean
@@ -47,7 +47,7 @@ Monoid.mk : {M : Type u} →
 -/
 
 
-universe v
+universe v u
 
 open CategoryTheory
 
@@ -63,7 +63,7 @@ and the identifications given by the morphisms in the diagram.
 -/
 
 
-variable {J : Type v} [SmallCategory J] (F : J ⥤ MonCat.{v})
+variable {J : Type v} [Category.{u} J] (F : J ⥤ MonCat.{v})
 
 /-- An inductive type representing all monoid expressions (without relations)
 on a collection of types indexed by the objects of `J`.


### PR DESCRIPTION
The file constructed colimits of functors `F : J ⥤ MonCat.{v}` under the assumption that `J` is a `SmallCategory.{v}`. It turns out that the smallness conditions on the `Hom` types of `J` is unnecessary and can simply be removed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
