### PR TITLE
[Merged by Bors] - feat: `Ico`, `Ioc`, and `Ioo` are not closed or compact

### DIFF
--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -492,6 +492,54 @@ theorem not_mem_Ioo_of_le (ha : c ≤ a) : c ∉ Ioo a b := fun h => lt_irrefl _
 
 theorem not_mem_Ioo_of_ge (hb : b ≤ c) : c ∉ Ioo a b := fun h => lt_irrefl _ <| h.2.trans_le hb
 
+section matched_intervals
+
+@[simp] theorem Icc_eq_Ioc_same_iff : Icc a b = Ioc a b ↔ ¬a ≤ b where
+  mp h := by simpa using Set.ext_iff.mp h a
+  mpr h := by rw [Icc_eq_empty h, Ioc_eq_empty (mt le_of_lt h)]
+
+@[simp] theorem Icc_eq_Ico_same_iff : Icc a b = Ico a b ↔ ¬a ≤ b where
+  mp h := by simpa using Set.ext_iff.mp h b
+  mpr h := by rw [Icc_eq_empty h, Ico_eq_empty (mt le_of_lt h)]
+
+@[simp] theorem Icc_eq_Ioo_same_iff : Icc a b = Ioo a b ↔ ¬a ≤ b where
+  mp h := by simpa using Set.ext_iff.mp h b
+  mpr h := by rw [Icc_eq_empty h, Ioo_eq_empty (mt le_of_lt h)]
+
+@[simp] theorem Ioc_eq_Ico_same_iff : Ioc a b = Ico a b ↔ ¬a < b where
+  mp h := by simpa using Set.ext_iff.mp h a
+  mpr h := by rw [Ioc_eq_empty h, Ico_eq_empty h]
+
+@[simp] theorem Ioo_eq_Ioc_same_iff : Ioo a b = Ioc a b ↔ ¬a < b where
+  mp h := by simpa using Set.ext_iff.mp h b
+  mpr h := by rw [Ioo_eq_empty h, Ioc_eq_empty h]
+
+@[simp] theorem Ioo_eq_Ico_same_iff : Ioo a b = Ico a b ↔ ¬a < b where
+  mp h := by simpa using Set.ext_iff.mp h a
+  mpr h := by rw [Ioo_eq_empty h, Ico_eq_empty h]
+
+-- Mirrored versions of the above for `simp`.
+
+@[simp] theorem Ioc_eq_Icc_same_iff : Ioc a b = Icc a b ↔ ¬a ≤ b :=
+  eq_comm.trans Icc_eq_Ioc_same_iff
+
+@[simp] theorem Ico_eq_Icc_same_iff : Ico a b = Icc a b ↔ ¬a ≤ b :=
+  eq_comm.trans Icc_eq_Ico_same_iff
+
+@[simp] theorem Ioo_eq_Icc_same_iff : Ioo a b = Icc a b ↔ ¬a ≤ b :=
+  eq_comm.trans Icc_eq_Ioo_same_iff
+
+@[simp] theorem Ico_eq_Ioc_same_iff : Ico a b = Ioc a b ↔ ¬a < b :=
+  eq_comm.trans Ioc_eq_Ico_same_iff
+
+@[simp] theorem Ioc_eq_Ioo_same_iff : Ioc a b = Ioo a b ↔ ¬a < b :=
+  eq_comm.trans Ioo_eq_Ioc_same_iff
+
+@[simp] theorem Ico_eq_Ioo_same_iff : Ico a b = Ioo a b ↔ ¬a < b :=
+  eq_comm.trans Ioo_eq_Ico_same_iff
+
+end matched_intervals
+
 end Preorder
 
 section PartialOrder
@@ -692,54 +740,6 @@ theorem Ici_inj : Ici a = Ici b ↔ a = b :=
 
 theorem Iic_inj : Iic a = Iic b ↔ a = b :=
   Iic_injective.eq_iff
-
-section matched_intervals
-
-@[simp] theorem Icc_eq_Ioc_same_iff : Icc a b = Ioc a b ↔ ¬a ≤ b where
-  mp h := by simpa using Set.ext_iff.mp h a
-  mpr h := by rw [Icc_eq_empty h, Ioc_eq_empty (mt le_of_lt h)]
-
-@[simp] theorem Icc_eq_Ico_same_iff : Icc a b = Ico a b ↔ ¬a ≤ b where
-  mp h := by simpa using Set.ext_iff.mp h b
-  mpr h := by rw [Icc_eq_empty h, Ico_eq_empty (mt le_of_lt h)]
-
-@[simp] theorem Icc_eq_Ioo_same_iff : Icc a b = Ioo a b ↔ ¬a ≤ b where
-  mp h := by simpa using Set.ext_iff.mp h b
-  mpr h := by rw [Icc_eq_empty h, Ioo_eq_empty (mt le_of_lt h)]
-
-@[simp] theorem Ioc_eq_Ico_same_iff : Ioc a b = Ico a b ↔ ¬a < b where
-  mp h := by simpa using Set.ext_iff.mp h a
-  mpr h := by rw [Ioc_eq_empty h, Ico_eq_empty h]
-
-@[simp] theorem Ioo_eq_Ioc_same_iff : Ioo a b = Ioc a b ↔ ¬a < b where
-  mp h := by simpa using Set.ext_iff.mp h b
-  mpr h := by rw [Ioo_eq_empty h, Ioc_eq_empty h]
-
-@[simp] theorem Ioo_eq_Ico_same_iff : Ioo a b = Ico a b ↔ ¬a < b where
-  mp h := by simpa using Set.ext_iff.mp h a
-  mpr h := by rw [Ioo_eq_empty h, Ico_eq_empty h]
-
--- Mirrored versions of the above for `simp`.
-
-@[simp] theorem Ioc_eq_Icc_same_iff : Ioc a b = Icc a b ↔ ¬a ≤ b :=
-  eq_comm.trans Icc_eq_Ioc_same_iff
-
-@[simp] theorem Ico_eq_Icc_same_iff : Ico a b = Icc a b ↔ ¬a ≤ b :=
-  eq_comm.trans Icc_eq_Ico_same_iff
-
-@[simp] theorem Ioo_eq_Icc_same_iff : Ioo a b = Icc a b ↔ ¬a ≤ b :=
-  eq_comm.trans Icc_eq_Ioo_same_iff
-
-@[simp] theorem Ico_eq_Ioc_same_iff : Ico a b = Ioc a b ↔ ¬a < b :=
-  eq_comm.trans Ioc_eq_Ico_same_iff
-
-@[simp] theorem Ioc_eq_Ioo_same_iff : Ioc a b = Ioo a b ↔ ¬a < b :=
-  eq_comm.trans Ioo_eq_Ioc_same_iff
-
-@[simp] theorem Ico_eq_Ioo_same_iff : Ico a b = Ioo a b ↔ ¬a < b :=
-  eq_comm.trans Ioo_eq_Ico_same_iff
-
-end matched_intervals
 
 end PartialOrder
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -1509,8 +1509,6 @@ theorem Ioc_union_Ioc_union_Ioc_cycle :
   solve_by_elim (config := { maxDepth := 5 }) [min_le_of_left_le, min_le_of_right_le,
        le_max_of_le_left, le_max_of_le_right, le_refl]
 
-
-#exit
 end LinearOrder
 
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -693,6 +693,54 @@ theorem Ici_inj : Ici a = Ici b ↔ a = b :=
 theorem Iic_inj : Iic a = Iic b ↔ a = b :=
   Iic_injective.eq_iff
 
+section matched_intervals
+
+@[simp] theorem Icc_eq_Ioc_same_iff : Icc a b = Ioc a b ↔ ¬a ≤ b where
+  mp h := by simpa using Set.ext_iff.mp h a
+  mpr h := by rw [Icc_eq_empty h, Ioc_eq_empty (mt le_of_lt h)]
+
+@[simp] theorem Icc_eq_Ico_same_iff : Icc a b = Ico a b ↔ ¬a ≤ b where
+  mp h := by simpa using Set.ext_iff.mp h b
+  mpr h := by rw [Icc_eq_empty h, Ico_eq_empty (mt le_of_lt h)]
+
+@[simp] theorem Icc_eq_Ioo_same_iff : Icc a b = Ioo a b ↔ ¬a ≤ b where
+  mp h := by simpa using Set.ext_iff.mp h b
+  mpr h := by rw [Icc_eq_empty h, Ioo_eq_empty (mt le_of_lt h)]
+
+@[simp] theorem Ioc_eq_Ico_same_iff : Ioc a b = Ico a b ↔ ¬a < b where
+  mp h := by simpa using Set.ext_iff.mp h a
+  mpr h := by rw [Ioc_eq_empty h, Ico_eq_empty h]
+
+@[simp] theorem Ioo_eq_Ioc_same_iff : Ioo a b = Ioc a b ↔ ¬a < b where
+  mp h := by simpa using Set.ext_iff.mp h b
+  mpr h := by rw [Ioo_eq_empty h, Ioc_eq_empty h]
+
+@[simp] theorem Ioo_eq_Ico_same_iff : Ioo a b = Ico a b ↔ ¬a < b where
+  mp h := by simpa using Set.ext_iff.mp h a
+  mpr h := by rw [Ioo_eq_empty h, Ico_eq_empty h]
+
+-- Mirrored versions of the above for `simp`.
+
+@[simp] theorem Ioc_eq_Icc_same_iff : Ioc a b = Icc a b ↔ ¬a ≤ b :=
+  eq_comm.trans Icc_eq_Ioc_same_iff
+
+@[simp] theorem Ico_eq_Icc_same_iff : Ico a b = Icc a b ↔ ¬a ≤ b :=
+  eq_comm.trans Icc_eq_Ico_same_iff
+
+@[simp] theorem Ioo_eq_Icc_same_iff : Ioo a b = Icc a b ↔ ¬a ≤ b :=
+  eq_comm.trans Icc_eq_Ioo_same_iff
+
+@[simp] theorem Ico_eq_Ioc_same_iff : Ico a b = Ioc a b ↔ ¬a < b :=
+  eq_comm.trans Ioc_eq_Ico_same_iff
+
+@[simp] theorem Ioc_eq_Ioo_same_iff : Ioc a b = Ioo a b ↔ ¬a < b :=
+  eq_comm.trans Ioo_eq_Ioc_same_iff
+
+@[simp] theorem Ico_eq_Ioo_same_iff : Ico a b = Ioo a b ↔ ¬a < b :=
+  eq_comm.trans Ioo_eq_Ico_same_iff
+
+end matched_intervals
+
 end PartialOrder
 
 section OrderTop
@@ -1460,7 +1508,11 @@ theorem Ioc_union_Ioc_union_Ioc_cycle :
   all_goals
   solve_by_elim (config := { maxDepth := 5 }) [min_le_of_left_le, min_le_of_right_le,
        le_max_of_le_left, le_max_of_le_right, le_refl]
+
+
+#exit
 end LinearOrder
+
 
 /-!
 ### Closed intervals in `α × β`

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -1511,7 +1511,6 @@ theorem Ioc_union_Ioc_union_Ioc_cycle :
 
 end LinearOrder
 
-
 /-!
 ### Closed intervals in `α × β`
 -/

--- a/Mathlib/Topology/Order/Compact.lean
+++ b/Mathlib/Topology/Order/Compact.lean
@@ -136,7 +136,6 @@ theorem isCompact_uIcc {α : Type*} [LinearOrder α] [TopologicalSpace α] [Comp
     {a b : α} : IsCompact (uIcc a b) :=
   isCompact_Icc
 
-
 -- See note [lower instance priority]
 /-- A complete linear order is a compact space.
 

--- a/Mathlib/Topology/Order/Compact.lean
+++ b/Mathlib/Topology/Order/Compact.lean
@@ -136,6 +136,7 @@ theorem isCompact_uIcc {α : Type*} [LinearOrder α] [TopologicalSpace α] [Comp
     {a b : α} : IsCompact (uIcc a b) :=
   isCompact_Icc
 
+
 -- See note [lower instance priority]
 /-- A complete linear order is a compact space.
 
@@ -154,6 +155,26 @@ instance compactSpace_Icc (a b : α) : CompactSpace (Icc a b) :=
   isCompact_iff_compactSpace.mp isCompact_Icc
 
 end
+
+section openIntervals
+variable {α : Type*} [LinearOrder α] [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α]
+
+/-- `Set.Ico a b` is only compact if it is empty. -/
+@[simp]
+theorem isCompact_Ico_iff {a b : α} : IsCompact (Set.Ico a b) ↔ b ≤ a :=
+  ⟨fun h => isClosed_Ico_iff.mp h.isClosed, by simp_all⟩
+
+/-- `Set.Ioc a b` is only compact if it is empty. -/
+@[simp]
+theorem isCompact_Ioc_iff {a b : α} : IsCompact (Set.Ioc a b) ↔ b ≤ a :=
+  ⟨fun h => isClosed_Ioc_iff.mp h.isClosed, by simp_all⟩
+
+/-- `Set.Ioo a b` is only compact if it is empty. -/
+@[simp]
+theorem isCompact_Ioo_iff {a b : α} : IsCompact (Set.Ioo a b) ↔ b ≤ a :=
+  ⟨fun h => isClosed_Ioo_iff.mp h.isClosed, by simp_all⟩
+
+end openIntervals
 
 /-!
 ### Extreme value theorem
@@ -484,30 +505,6 @@ variable {α β γ : Type*} [ConditionallyCompleteLinearOrder α] [TopologicalSp
 theorem eq_Icc_of_connected_compact {s : Set α} (h₁ : IsConnected s) (h₂ : IsCompact s) :
     s = Icc (sInf s) (sSup s) :=
   eq_Icc_csInf_csSup_of_connected_bdd_closed h₁ h₂.bddBelow h₂.bddAbove h₂.isClosed
-
-/-- `Set.Ico a b` is only compact if it is empty. -/
-@[simp]
-theorem isCompact_Ico_iff [DenselyOrdered α] {a b : α} : IsCompact (Set.Ico a b) ↔ b ≤ a := by
-  refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
-  have := Set.ext_iff.mp (eq_Icc_of_connected_compact (isConnected_Ico hab) h) b
-  rw [csInf_Ico hab, csSup_Ico hab, Set.right_mem_Icc, Set.right_mem_Ico, false_iff] at this
-  exact this hab.le
-
-/-- `Set.Ioc a b` is only compact if it is empty. -/
-@[simp]
-theorem isCompact_Ioc_iff [DenselyOrdered α] {a b : α} : IsCompact (Set.Ioc a b) ↔ b ≤ a := by
-  refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
-  have := Set.ext_iff.mp (eq_Icc_of_connected_compact (isConnected_Ioc hab) h) a
-  rw [csInf_Ioc hab, csSup_Ioc hab, Set.left_mem_Icc, Set.left_mem_Ioc, false_iff] at this
-  exact this hab.le
-
-/-- `Set.Ioo a b` is only compact if it is empty. -/
-@[simp]
-theorem isCompact_Ioo_iff [DenselyOrdered α] {a b : α} : IsCompact (Set.Ioo a b) ↔ b ≤ a := by
-  refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
-  have := Set.ext_iff.mp (eq_Icc_of_connected_compact (isConnected_Ioo hab) h) a
-  rw [csInf_Ioo hab, csSup_Ioo hab, Set.left_mem_Icc, Set.left_mem_Ioo, false_iff] at this
-  exact this hab.le
 
 /-- If `f : γ → β → α` is a function that is continuous as a function on `γ × β`, `α` is a
 conditionally complete linear order, and `K : Set β` is a compact set, then

--- a/Mathlib/Topology/Order/Compact.lean
+++ b/Mathlib/Topology/Order/Compact.lean
@@ -485,6 +485,30 @@ theorem eq_Icc_of_connected_compact {s : Set α} (h₁ : IsConnected s) (h₂ : 
     s = Icc (sInf s) (sSup s) :=
   eq_Icc_csInf_csSup_of_connected_bdd_closed h₁ h₂.bddBelow h₂.bddAbove h₂.isClosed
 
+/-- `Set.Ico a b` is only compact if it is empty. -/
+@[simp]
+theorem isCompact_Ico_iff [DenselyOrdered α] {a b : α} : IsCompact (Set.Ico a b) ↔ b ≤ a := by
+  refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
+  have := Set.ext_iff.mp (eq_Icc_of_connected_compact (isConnected_Ico hab) h) b
+  rw [csInf_Ico hab, csSup_Ico hab, Set.right_mem_Icc, Set.right_mem_Ico, false_iff] at this
+  exact this hab.le
+
+/-- `Set.Ioc a b` is only compact if it is empty. -/
+@[simp]
+theorem isCompact_Ioc_iff [DenselyOrdered α] {a b : α} : IsCompact (Set.Ioc a b) ↔ b ≤ a := by
+  refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
+  have := Set.ext_iff.mp (eq_Icc_of_connected_compact (isConnected_Ioc hab) h) a
+  rw [csInf_Ioc hab, csSup_Ioc hab, Set.left_mem_Icc, Set.left_mem_Ioc, false_iff] at this
+  exact this hab.le
+
+/-- `Set.Ioo a b` is only compact if it is empty. -/
+@[simp]
+theorem isCompact_Ioo_iff [DenselyOrdered α] {a b : α} : IsCompact (Set.Ioo a b) ↔ b ≤ a := by
+  refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
+  have := Set.ext_iff.mp (eq_Icc_of_connected_compact (isConnected_Ioo hab) h) a
+  rw [csInf_Ioo hab, csSup_Ioo hab, Set.left_mem_Icc, Set.left_mem_Ioo, false_iff] at this
+  exact this hab.le
+
 /-- If `f : γ → β → α` is a function that is continuous as a function on `γ × β`, `α` is a
 conditionally complete linear order, and `K : Set β` is a compact set, then
 `fun x ↦ sSup (f x '' K)` is a continuous function. -/

--- a/Mathlib/Topology/Order/DenselyOrdered.lean
+++ b/Mathlib/Topology/Order/DenselyOrdered.lean
@@ -383,7 +383,7 @@ theorem exists_countable_dense_no_bot_top [SeparableSpace α] [Nontrivial α] :
     ∃ s : Set α, s.Countable ∧ Dense s ∧ (∀ x, IsBot x → x ∉ s) ∧ ∀ x, IsTop x → x ∉ s := by
   simpa using dense_univ.exists_countable_dense_subset_no_bot_top
 
-/-- `Set.Ico a b` is only compact if it is empty. -/
+/-- `Set.Ico a b` is only closed if it is empty. -/
 @[simp]
 theorem isClosed_Ico_iff {a b : α} : IsClosed (Set.Ico a b) ↔ b ≤ a := by
   refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
@@ -393,7 +393,7 @@ theorem isClosed_Ico_iff {a b : α} : IsClosed (Set.Ico a b) ↔ b ≤ a := by
   rw [Set.right_mem_Icc, Set.right_mem_Ico, iff_false] at this
   exact this hab.le
 
-/-- `Set.Ioc a b` is only compact if it is empty. -/
+/-- `Set.Ioc a b` is only closed if it is empty. -/
 @[simp]
 theorem isClosed_Ioc_iff {a b : α} : IsClosed (Set.Ioc a b) ↔ b ≤ a := by
   refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
@@ -403,7 +403,7 @@ theorem isClosed_Ioc_iff {a b : α} : IsClosed (Set.Ioc a b) ↔ b ≤ a := by
   rw [Set.left_mem_Icc, Set.left_mem_Ioc, iff_false] at this
   exact this hab.le
 
-/-- `Set.Ioo a b` is only compact if it is empty. -/
+/-- `Set.Ioo a b` is only closed if it is empty. -/
 @[simp]
 theorem isClosed_Ioo_iff {a b : α} : IsClosed (Set.Ioo a b) ↔ b ≤ a := by
   refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩

--- a/Mathlib/Topology/Order/DenselyOrdered.lean
+++ b/Mathlib/Topology/Order/DenselyOrdered.lean
@@ -374,8 +374,7 @@ theorem Dense.exists_countable_dense_subset_no_bot_top [Nontrivial α] {s : Set 
   · simp [hx]
   · simp [hx]
 
-variable (α)
-
+variable (α) in
 /-- If `α` is a nontrivial separable dense linear order, then there exists a
 countable dense set `s : Set α` that contains neither top nor bottom elements of `α`.
 For a dense set containing both bot and top elements, see
@@ -383,5 +382,35 @@ For a dense set containing both bot and top elements, see
 theorem exists_countable_dense_no_bot_top [SeparableSpace α] [Nontrivial α] :
     ∃ s : Set α, s.Countable ∧ Dense s ∧ (∀ x, IsBot x → x ∉ s) ∧ ∀ x, IsTop x → x ∉ s := by
   simpa using dense_univ.exists_countable_dense_subset_no_bot_top
+
+/-- `Set.Ico a b` is only compact if it is empty. -/
+@[simp]
+theorem isClosed_Ico_iff {a b : α} : IsClosed (Set.Ico a b) ↔ b ≤ a := by
+  refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
+  have := h.closure_eq
+  rw [closure_Ico hab.ne, Set.ext_iff] at this
+  specialize this b
+  rw [Set.right_mem_Icc, Set.right_mem_Ico, iff_false] at this
+  exact this hab.le
+
+/-- `Set.Ioc a b` is only compact if it is empty. -/
+@[simp]
+theorem isClosed_Ioc_iff {a b : α} : IsClosed (Set.Ioc a b) ↔ b ≤ a := by
+  refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
+  have := h.closure_eq
+  rw [closure_Ioc hab.ne, Set.ext_iff] at this
+  specialize this a
+  rw [Set.left_mem_Icc, Set.left_mem_Ioc, iff_false] at this
+  exact this hab.le
+
+/-- `Set.Ioo a b` is only compact if it is empty. -/
+@[simp]
+theorem isClosed_Ioo_iff {a b : α} : IsClosed (Set.Ioo a b) ↔ b ≤ a := by
+  refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
+  have := h.closure_eq
+  rw [closure_Ioo hab.ne, Set.ext_iff] at this
+  specialize this a
+  rw [Set.left_mem_Icc, Set.left_mem_Ioo, iff_false] at this
+  exact this hab.le
 
 end DenselyOrdered

--- a/Mathlib/Topology/Order/DenselyOrdered.lean
+++ b/Mathlib/Topology/Order/DenselyOrdered.lean
@@ -388,9 +388,7 @@ theorem exists_countable_dense_no_bot_top [SeparableSpace α] [Nontrivial α] :
 theorem isClosed_Ico_iff {a b : α} : IsClosed (Set.Ico a b) ↔ b ≤ a := by
   refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
   have := h.closure_eq
-  rw [closure_Ico hab.ne, Set.ext_iff] at this
-  specialize this b
-  rw [Set.right_mem_Icc, Set.right_mem_Ico, iff_false] at this
+  rw [closure_Ico hab.ne, Icc_eq_Ico_same_iff] at this
   exact this hab.le
 
 /-- `Set.Ioc a b` is only closed if it is empty. -/
@@ -398,9 +396,7 @@ theorem isClosed_Ico_iff {a b : α} : IsClosed (Set.Ico a b) ↔ b ≤ a := by
 theorem isClosed_Ioc_iff {a b : α} : IsClosed (Set.Ioc a b) ↔ b ≤ a := by
   refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
   have := h.closure_eq
-  rw [closure_Ioc hab.ne, Set.ext_iff] at this
-  specialize this a
-  rw [Set.left_mem_Icc, Set.left_mem_Ioc, iff_false] at this
+  rw [closure_Ioc hab.ne, Icc_eq_Ioc_same_iff] at this
   exact this hab.le
 
 /-- `Set.Ioo a b` is only closed if it is empty. -/
@@ -408,9 +404,7 @@ theorem isClosed_Ioc_iff {a b : α} : IsClosed (Set.Ioc a b) ↔ b ≤ a := by
 theorem isClosed_Ioo_iff {a b : α} : IsClosed (Set.Ioo a b) ↔ b ≤ a := by
   refine ⟨fun h => le_of_not_lt fun hab => ?_, by simp_all⟩
   have := h.closure_eq
-  rw [closure_Ioo hab.ne, Set.ext_iff] at this
-  specialize this a
-  rw [Set.left_mem_Icc, Set.left_mem_Ioo, iff_false] at this
+  rw [closure_Ioo hab.ne, Icc_eq_Ioo_same_iff] at this
   exact this hab.le
 
 end DenselyOrdered


### PR DESCRIPTION
Inspired by [this Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Proving.20compactness.20of.20.280.2Cr.5D.20from.20.5B0.2Cr.5D/near/491839141) which tried to prove a false result.

Also includes 12 stupid lemmas about interval equalities to make `simp` slightly more helpful.

I don't know if the topological results can be generalized further, but these lemmas at least work for `Real` as was needed on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
