### PR TITLE
[Merged by Bors] - chore(1000): remove nonexistent fields

### DIFF
--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1329,7 +1329,7 @@ Q1191862:
 Q1194053:
   title: Metrization theorems
   decl: TopologicalSpace.metrizableSpace_of_t3_secondCountable
-  comment: "Urysohn's metrization theorem (only)"
+  # comment: "Urysohn's metrization theorem (only)"
 
 Q1196538:
   title: Descartes's theorem
@@ -1384,7 +1384,7 @@ Q1306092:
 Q1306095:
   title: Whitney embedding theorem
   decl: exists_embedding_euclidean_of_compact
-  comment: "baby version: for compact manifolds; embedding into some *n*"
+  # comment: "baby version: for compact manifolds; embedding into some *n*"
 
 Q1307676:
   title: Künneth theorem


### PR DESCRIPTION
`comment` is not a supported field and so the website build is [broken](https://github.com/leanprover-community/leanprover-community.github.io/actions/runs/12616366640/job/35157520815).

Changes to the website to actually support this would be welcome.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
