### PR TITLE
[Merged by Bors] - chore(NumberTheory/NumberField/AdeleRing): refactor adele rings

### DIFF
--- a/Mathlib/NumberTheory/NumberField/AdeleRing.lean
+++ b/Mathlib/NumberTheory/NumberField/AdeleRing.lean
@@ -41,8 +41,6 @@ open InfinitePlace AbsoluteValue.Completion InfinitePlace.Completion DedekindDom
 
 open scoped Classical
 
-variable (K : Type*) [Field K]
-
 /-! ## The infinite adele ring
 
 The infinite adele ring is the finite product of completions of a number field over its
@@ -51,9 +49,11 @@ infinite places. See `NumberField.InfinitePlace` for the definition of an infini
 -/
 
 /-- The infinite adele ring of a number field. -/
-def InfiniteAdeleRing := (v : InfinitePlace K) → v.Completion
+def InfiniteAdeleRing (K : Type*) [Field K] := (v : InfinitePlace K) → v.Completion
 
 namespace InfiniteAdeleRing
+
+variable (K : Type*) [Field K]
 
 instance : CommRing (InfiniteAdeleRing K) := Pi.commRing
 
@@ -115,38 +115,47 @@ theorem mixedEmbedding_eq_algebraMap_comp {x : K} :
 
 end InfiniteAdeleRing
 
-variable [NumberField K]
-
 /-! ## The adele ring  -/
 
-/-- The adele ring of a number field. -/
-def AdeleRing := InfiniteAdeleRing K × FiniteAdeleRing (𝓞 K) K
+/-- `AdeleRing (𝓞 K) K` is the adele ring of a number field `K`.
+
+More generally `AdeleRing R K` can be used if `K` is the field of fractions
+of the Dedekind domain `R`. This enables use of rings like `AdeleRing ℤ ℚ`, which
+in practice are easier to work with than `AdeleRing (𝓞 ℚ) ℚ`.
+
+Note that this definition does not give the correct answer in the function field case.
+-/
+def AdeleRing (R K : Type*) [CommRing R] [IsDedekindDomain R] [Field K]
+  [Algebra R K] [IsFractionRing R K] := InfiniteAdeleRing K × FiniteAdeleRing R K
 
 namespace AdeleRing
 
-instance : CommRing (AdeleRing K) := Prod.instCommRing
+variable (R K : Type*) [CommRing R] [IsDedekindDomain R] [Field K]
+  [Algebra R K] [IsFractionRing R K]
 
-instance : Inhabited (AdeleRing K) := ⟨0⟩
+instance : CommRing (AdeleRing R K) := Prod.instCommRing
 
-instance : TopologicalSpace (AdeleRing K) := instTopologicalSpaceProd
+instance : Inhabited (AdeleRing R K) := ⟨0⟩
 
-instance : TopologicalRing (AdeleRing K) := instTopologicalRingProd
+instance : TopologicalSpace (AdeleRing R K) := instTopologicalSpaceProd
 
-instance : Algebra K (AdeleRing K) := Prod.algebra _ _ _
+instance : TopologicalRing (AdeleRing R K) := instTopologicalRingProd
+
+instance : Algebra K (AdeleRing R K) := Prod.algebra _ _ _
 
 @[simp]
 theorem algebraMap_fst_apply (x : K) (v : InfinitePlace K) :
-    (algebraMap K (AdeleRing K) x).1 v = x := rfl
+    (algebraMap K (AdeleRing R K) x).1 v = x := rfl
 
 @[simp]
-theorem algebraMap_snd_apply (x : K) (v : HeightOneSpectrum (𝓞 K)) :
-    (algebraMap K (AdeleRing K) x).2 v = x := rfl
+theorem algebraMap_snd_apply (x : K) (v : HeightOneSpectrum R) :
+    (algebraMap K (AdeleRing R K) x).2 v = x := rfl
 
-theorem algebraMap_injective : Function.Injective (algebraMap K (AdeleRing K)) :=
+theorem algebraMap_injective [NumberField K] : Function.Injective (algebraMap K (AdeleRing R K)) :=
   fun _ _ hxy => (algebraMap K _).injective (Prod.ext_iff.1 hxy).1
 
 /-- The subgroup of principal adeles `(x)ᵥ` where `x ∈ K`. -/
-abbrev principalSubgroup : AddSubgroup (AdeleRing K) := (algebraMap K _).range.toAddSubgroup
+abbrev principalSubgroup : AddSubgroup (AdeleRing R K) := (algebraMap K _).range.toAddSubgroup
 
 end AdeleRing
 


### PR DESCRIPTION
The current `AdeleRing ℚ` explicitly involves `𝓞 ℚ`  and is not much fun to work with. This PR enables `AdeleRing ℤ ℚ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
