### PR TITLE
[Merged by Bors] - chore(RingTheory/Finiteness): rename Module.Finite.out

### DIFF
--- a/Mathlib/Algebra/Module/FinitePresentation.lean
+++ b/Mathlib/Algebra/Module/FinitePresentation.lean
@@ -187,7 +187,7 @@ lemma Module.FinitePresentation.fg_ker [Module.Finite R M]
     exact ⟨_, hy, by simp⟩
   apply Submodule.fg_of_fg_map_of_fg_inf_ker f.range.mkQ
   · rw [this]
-    exact Module.Finite.finite
+    exact Module.Finite.fg_top
   · rw [Submodule.ker_mkQ, inf_comm, ← Submodule.map_comap_eq, ← LinearMap.ker_comp, hf]
     exact hs'.map f
 
@@ -201,8 +201,8 @@ lemma Module.finitePresentation_of_ker [Module.FinitePresentation R N]
     Module.FinitePresentation R M := by
   obtain ⟨s, hs⟩ : (⊤ : Submodule R M).FG := by
     apply Submodule.fg_of_fg_map_of_fg_inf_ker l
-    · rw [Submodule.map_top, LinearMap.range_eq_top.mpr hl]; exact Module.Finite.finite
-    · rw [top_inf_eq, ← Submodule.fg_top]; exact Module.Finite.finite
+    · rw [Submodule.map_top, LinearMap.range_eq_top.mpr hl]; exact Module.Finite.fg_top
+    · rw [top_inf_eq, ← Submodule.fg_top]; exact Module.Finite.fg_top
   refine ⟨s, hs, ?_⟩
   let π := Finsupp.linearCombination R ((↑) : s → M)
   have H : Function.Surjective π :=
@@ -250,7 +250,7 @@ instance {A} [CommRing A] [Algebra R A] [Module.FinitePresentation R M] :
   apply Submodule.FG.map
   have : Module.Finite R (LinearMap.ker f) :=
     ⟨(Submodule.fg_top _).mpr (Module.FinitePresentation.fg_ker f hf)⟩
-  exact Module.Finite.finite (R := A) (M := A ⊗[R] LinearMap.ker f)
+  exact Module.Finite.fg_top (R := A) (M := A ⊗[R] LinearMap.ker f)
 
 open TensorProduct in
 lemma FinitePresentation.of_isBaseChange

--- a/Mathlib/Algebra/Module/FinitePresentation.lean
+++ b/Mathlib/Algebra/Module/FinitePresentation.lean
@@ -187,7 +187,7 @@ lemma Module.FinitePresentation.fg_ker [Module.Finite R M]
     exact ⟨_, hy, by simp⟩
   apply Submodule.fg_of_fg_map_of_fg_inf_ker f.range.mkQ
   · rw [this]
-    exact Module.Finite.out
+    exact Module.Finite.finite
   · rw [Submodule.ker_mkQ, inf_comm, ← Submodule.map_comap_eq, ← LinearMap.ker_comp, hf]
     exact hs'.map f
 
@@ -201,8 +201,8 @@ lemma Module.finitePresentation_of_ker [Module.FinitePresentation R N]
     Module.FinitePresentation R M := by
   obtain ⟨s, hs⟩ : (⊤ : Submodule R M).FG := by
     apply Submodule.fg_of_fg_map_of_fg_inf_ker l
-    · rw [Submodule.map_top, LinearMap.range_eq_top.mpr hl]; exact Module.Finite.out
-    · rw [top_inf_eq, ← Submodule.fg_top]; exact Module.Finite.out
+    · rw [Submodule.map_top, LinearMap.range_eq_top.mpr hl]; exact Module.Finite.finite
+    · rw [top_inf_eq, ← Submodule.fg_top]; exact Module.Finite.finite
   refine ⟨s, hs, ?_⟩
   let π := Finsupp.linearCombination R ((↑) : s → M)
   have H : Function.Surjective π :=
@@ -250,7 +250,7 @@ instance {A} [CommRing A] [Algebra R A] [Module.FinitePresentation R M] :
   apply Submodule.FG.map
   have : Module.Finite R (LinearMap.ker f) :=
     ⟨(Submodule.fg_top _).mpr (Module.FinitePresentation.fg_ker f hf)⟩
-  exact Module.Finite.out (R := A) (M := A ⊗[R] LinearMap.ker f)
+  exact Module.Finite.finite (R := A) (M := A ⊗[R] LinearMap.ker f)
 
 open TensorProduct in
 lemma FinitePresentation.of_isBaseChange

--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -691,7 +691,7 @@ variable {R M}
 
 theorem _root_.Submodule.annihilator_top_inter_nonZeroDivisors [Module.Finite R M]
     (hM : Module.IsTorsion R M) : ((⊤ : Submodule R M).annihilator : Set R) ∩ R⁰ ≠ ∅ := by
-  obtain ⟨S, hS⟩ := ‹Module.Finite R M›.out
+  obtain ⟨S, hS⟩ := ‹Module.Finite R M›.finite
   refine Set.Nonempty.ne_empty ⟨_, ?_, (∏ x ∈ S, (@hM x).choose : R⁰).prop⟩
   rw [Submonoid.coe_finset_prod, SetLike.mem_coe, ← hS, mem_annihilator_span]
   intro n

--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -691,7 +691,7 @@ variable {R M}
 
 theorem _root_.Submodule.annihilator_top_inter_nonZeroDivisors [Module.Finite R M]
     (hM : Module.IsTorsion R M) : ((⊤ : Submodule R M).annihilator : Set R) ∩ R⁰ ≠ ∅ := by
-  obtain ⟨S, hS⟩ := ‹Module.Finite R M›.finite
+  obtain ⟨S, hS⟩ := ‹Module.Finite R M›.fg_top
   refine Set.Nonempty.ne_empty ⟨_, ?_, (∏ x ∈ S, (@hM x).choose : R⁰).prop⟩
   rw [Submonoid.coe_finset_prod, SetLike.mem_coe, ← hS, mem_annihilator_span]
   intro n

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/LinearMap.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/LinearMap.lean
@@ -210,7 +210,7 @@ theorem LinearMap.exists_monic_and_coeff_mem_pow_and_aeval_eq_zero_of_range_le_s
     cases subsingleton_or_nontrivial R
     · exact ⟨0, Polynomial.monic_of_subsingleton _, by simp⟩
     obtain ⟨s : Finset M, hs : Submodule.span R (s : Set M) = ⊤⟩ :=
-      Module.Finite.finite (R := R) (M := M)
+      Module.Finite.fg_top (R := R) (M := M)
     -- Porting note: `H` was `rfl`
     obtain ⟨A, H, h⟩ :=
       Matrix.isRepresentation.toEnd_exists_mem_ideal R ((↑) : s → M)

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/LinearMap.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/LinearMap.lean
@@ -210,7 +210,7 @@ theorem LinearMap.exists_monic_and_coeff_mem_pow_and_aeval_eq_zero_of_range_le_s
     cases subsingleton_or_nontrivial R
     · exact ⟨0, Polynomial.monic_of_subsingleton _, by simp⟩
     obtain ⟨s : Finset M, hs : Submodule.span R (s : Set M) = ⊤⟩ :=
-      Module.Finite.out (R := R) (M := M)
+      Module.Finite.finite (R := R) (M := M)
     -- Porting note: `H` was `rfl`
     obtain ⟨A, H, h⟩ :=
       Matrix.isRepresentation.toEnd_exists_mem_ideal R ((↑) : s → M)

--- a/Mathlib/RingTheory/Artinian/Module.lean
+++ b/Mathlib/RingTheory/Artinian/Module.lean
@@ -390,7 +390,7 @@ theorem isArtinian_of_fg_of_artinian {R M} [Ring R] [AddCommGroup M] [Module R M
 
 instance isArtinian_of_fg_of_artinian' {R M} [Ring R] [AddCommGroup M] [Module R M]
     [IsArtinianRing R] [Module.Finite R M] : IsArtinian R M :=
-  have : IsArtinian R (⊤ : Submodule R M) := isArtinian_of_fg_of_artinian _ Module.Finite.out
+  have : IsArtinian R (⊤ : Submodule R M) := isArtinian_of_fg_of_artinian _ Module.Finite.finite
   isArtinian_of_linearEquiv (LinearEquiv.ofTop (⊤ : Submodule R M) rfl)
 
 theorem IsArtinianRing.of_finite (R S) [CommRing R] [Ring S] [Algebra R S]

--- a/Mathlib/RingTheory/Artinian/Module.lean
+++ b/Mathlib/RingTheory/Artinian/Module.lean
@@ -390,7 +390,7 @@ theorem isArtinian_of_fg_of_artinian {R M} [Ring R] [AddCommGroup M] [Module R M
 
 instance isArtinian_of_fg_of_artinian' {R M} [Ring R] [AddCommGroup M] [Module R M]
     [IsArtinianRing R] [Module.Finite R M] : IsArtinian R M :=
-  have : IsArtinian R (⊤ : Submodule R M) := isArtinian_of_fg_of_artinian _ Module.Finite.finite
+  have : IsArtinian R (⊤ : Submodule R M) := isArtinian_of_fg_of_artinian _ Module.Finite.fg_top
   isArtinian_of_linearEquiv (LinearEquiv.ofTop (⊤ : Submodule R M) rfl)
 
 theorem IsArtinianRing.of_finite (R S) [CommRing R] [Ring S] [Algebra R S]

--- a/Mathlib/RingTheory/Finiteness/Basic.lean
+++ b/Mathlib/RingTheory/Finiteness/Basic.lean
@@ -257,7 +257,7 @@ variable (R M)
 
 instance bot : Module.Finite R (⊥ : Submodule R M) := iff_fg.mpr fg_bot
 
-instance top [Module.Finite R M] : Module.Finite R (⊤ : Submodule R M) := iff_fg.mpr out
+instance top [Module.Finite R M] : Module.Finite R (⊤ : Submodule R M) := iff_fg.mpr finite
 
 variable {M}
 

--- a/Mathlib/RingTheory/Finiteness/Basic.lean
+++ b/Mathlib/RingTheory/Finiteness/Basic.lean
@@ -251,13 +251,14 @@ theorem equiv_iff (e : M ≃ₗ[R] N) : Module.Finite R M ↔ Module.Finite R N 
 
 instance ulift [Module.Finite R M] : Module.Finite R (ULift M) := equiv ULift.moduleEquiv.symm
 
-theorem iff_fg {N : Submodule R M} : Module.Finite R N ↔ N.FG := Module.finite_def.trans (fg_top _)
+theorem iff_fg {N : Submodule R M} : Module.Finite R N ↔ N.FG :=
+  Module.finite_def.trans (Submodule.fg_top _)
 
 variable (R M)
 
 instance bot : Module.Finite R (⊥ : Submodule R M) := iff_fg.mpr fg_bot
 
-instance top [Module.Finite R M] : Module.Finite R (⊤ : Submodule R M) := iff_fg.mpr finite
+instance top [Module.Finite R M] : Module.Finite R (⊤ : Submodule R M) := iff_fg.mpr fg_top
 
 variable {M}
 

--- a/Mathlib/RingTheory/Finiteness/Basic.lean
+++ b/Mathlib/RingTheory/Finiteness/Basic.lean
@@ -251,8 +251,7 @@ theorem equiv_iff (e : M ≃ₗ[R] N) : Module.Finite R M ↔ Module.Finite R N 
 
 instance ulift [Module.Finite R M] : Module.Finite R (ULift M) := equiv ULift.moduleEquiv.symm
 
-theorem iff_fg {N : Submodule R M} : Module.Finite R N ↔ N.FG :=
-  Module.finite_def.trans (Submodule.fg_top _)
+theorem iff_fg {N : Submodule R M} : Module.Finite R N ↔ N.FG := Module.finite_def.trans N.fg_top
 
 variable (R M)
 

--- a/Mathlib/RingTheory/Finiteness/Defs.lean
+++ b/Mathlib/RingTheory/Finiteness/Defs.lean
@@ -103,9 +103,9 @@ variable (R A B M N : Type*)
 
 /-- A module over a semiring is `Module.Finite` if it is finitely generated as a module. -/
 protected class Module.Finite [Semiring R] [AddCommMonoid M] [Module R M] : Prop where
-  out : (⊤ : Submodule R M).FG
+  finite : (⊤ : Submodule R M).FG
 
-attribute [inherit_doc Module.Finite] Module.Finite.out
+attribute [inherit_doc Module.Finite] Module.Finite.finite
 
 namespace Module
 
@@ -131,7 +131,7 @@ variable {R M N}
 
 /-- See also `Module.Finite.exists_fin'`. -/
 lemma exists_fin [Module.Finite R M] : ∃ (n : ℕ) (s : Fin n → M), Submodule.span R (range s) = ⊤ :=
-  Submodule.fg_iff_exists_fin_generating_family.mp out
+  Submodule.fg_iff_exists_fin_generating_family.mp finite
 
 end Finite
 

--- a/Mathlib/RingTheory/Finiteness/Defs.lean
+++ b/Mathlib/RingTheory/Finiteness/Defs.lean
@@ -103,9 +103,9 @@ variable (R A B M N : Type*)
 
 /-- A module over a semiring is `Module.Finite` if it is finitely generated as a module. -/
 protected class Module.Finite [Semiring R] [AddCommMonoid M] [Module R M] : Prop where
-  finite : (⊤ : Submodule R M).FG
+  fg_top : (⊤ : Submodule R M).FG
 
-attribute [inherit_doc Module.Finite] Module.Finite.finite
+attribute [inherit_doc Module.Finite] Module.Finite.fg_top
 
 namespace Module
 
@@ -131,7 +131,7 @@ variable {R M N}
 
 /-- See also `Module.Finite.exists_fin'`. -/
 lemma exists_fin [Module.Finite R M] : ∃ (n : ℕ) (s : Fin n → M), Submodule.span R (range s) = ⊤ :=
-  Submodule.fg_iff_exists_fin_generating_family.mp finite
+  Submodule.fg_iff_exists_fin_generating_family.mp fg_top
 
 end Finite
 

--- a/Mathlib/RingTheory/Finiteness/Nilpotent.lean
+++ b/Mathlib/RingTheory/Finiteness/Nilpotent.lean
@@ -20,7 +20,7 @@ namespace Finite
 theorem Module.End.isNilpotent_iff_of_finite [Module.Finite R M] {f : End R M} :
     IsNilpotent f ↔ ∀ m : M, ∃ n : ℕ, (f ^ n) m = 0 := by
   refine ⟨fun ⟨n, hn⟩ m ↦ ⟨n, by simp [hn]⟩, fun h ↦ ?_⟩
-  rcases Module.Finite.out (R := R) (M := M) with ⟨S, hS⟩
+  rcases Module.Finite.finite (R := R) (M := M) with ⟨S, hS⟩
   choose g hg using h
   use Finset.sup S g
   ext m

--- a/Mathlib/RingTheory/Finiteness/Nilpotent.lean
+++ b/Mathlib/RingTheory/Finiteness/Nilpotent.lean
@@ -20,7 +20,7 @@ namespace Finite
 theorem Module.End.isNilpotent_iff_of_finite [Module.Finite R M] {f : End R M} :
     IsNilpotent f ↔ ∀ m : M, ∃ n : ℕ, (f ^ n) m = 0 := by
   refine ⟨fun ⟨n, hn⟩ m ↦ ⟨n, by simp [hn]⟩, fun h ↦ ?_⟩
-  rcases Module.Finite.finite (R := R) (M := M) with ⟨S, hS⟩
+  rcases Module.Finite.fg_top (R := R) (M := M) with ⟨S, hS⟩
   choose g hg using h
   use Finset.sup S g
   ext m

--- a/Mathlib/RingTheory/Finiteness/TensorProduct.lean
+++ b/Mathlib/RingTheory/Finiteness/TensorProduct.lean
@@ -85,7 +85,7 @@ noncomputable local instance
 instance Module.Finite.base_change [CommSemiring R] [Semiring A] [Algebra R A] [AddCommMonoid M]
     [Module R M] [h : Module.Finite R M] : Module.Finite A (TensorProduct R A M) := by
   classical
-    obtain ⟨s, hs⟩ := h.out
+    obtain ⟨s, hs⟩ := h.finite
     refine ⟨⟨s.image (TensorProduct.mk R A M 1), eq_top_iff.mpr ?_⟩⟩
     rintro x -
     induction x with
@@ -103,7 +103,7 @@ instance Module.Finite.base_change [CommSemiring R] [Semiring A] [Algebra R A] [
 instance Module.Finite.tensorProduct [CommSemiring R] [AddCommMonoid M] [Module R M]
     [AddCommMonoid N] [Module R N] [hM : Module.Finite R M] [hN : Module.Finite R N] :
     Module.Finite R (TensorProduct R M N) where
-  out := (TensorProduct.map₂_mk_top_top_eq_top R M N).subst (hM.out.map₂ _ hN.out)
+  finite := (TensorProduct.map₂_mk_top_top_eq_top R M N).subst (hM.finite.map₂ _ hN.finite)
 
 end ModuleAndAlgebra
 

--- a/Mathlib/RingTheory/Finiteness/TensorProduct.lean
+++ b/Mathlib/RingTheory/Finiteness/TensorProduct.lean
@@ -85,7 +85,7 @@ noncomputable local instance
 instance Module.Finite.base_change [CommSemiring R] [Semiring A] [Algebra R A] [AddCommMonoid M]
     [Module R M] [h : Module.Finite R M] : Module.Finite A (TensorProduct R A M) := by
   classical
-    obtain ⟨s, hs⟩ := h.finite
+    obtain ⟨s, hs⟩ := h.fg_top
     refine ⟨⟨s.image (TensorProduct.mk R A M 1), eq_top_iff.mpr ?_⟩⟩
     rintro x -
     induction x with
@@ -103,7 +103,7 @@ instance Module.Finite.base_change [CommSemiring R] [Semiring A] [Algebra R A] [
 instance Module.Finite.tensorProduct [CommSemiring R] [AddCommMonoid M] [Module R M]
     [AddCommMonoid N] [Module R N] [hM : Module.Finite R M] [hN : Module.Finite R N] :
     Module.Finite R (TensorProduct R M N) where
-  finite := (TensorProduct.map₂_mk_top_top_eq_top R M N).subst (hM.finite.map₂ _ hN.finite)
+  fg_top := (TensorProduct.map₂_mk_top_top_eq_top R M N).subst (hM.fg_top.map₂ _ hN.fg_top)
 
 end ModuleAndAlgebra
 

--- a/Mathlib/RingTheory/Flat/EquationalCriterion.lean
+++ b/Mathlib/RingTheory/Flat/EquationalCriterion.lean
@@ -273,7 +273,7 @@ theorem exists_factorization_of_comp_eq_zero_of_free [Flat R M] {K N : Type u} [
       use κ₂, hκ₂, a₂ ∘ₗ a₁, y₂
       simp_rw [comp_assoc]
       exact ⟨trivial, sup_le (ha₁.trans (ker_le_ker_comp _ _)) ha₂⟩
-  convert this ⊤ Finite.out
+  convert this ⊤ Finite.finite
   simp only [top_le_iff, ker_eq_top]
 
 /-- Every homomorphism from a finitely presented module to a flat module factors through a finite

--- a/Mathlib/RingTheory/Flat/EquationalCriterion.lean
+++ b/Mathlib/RingTheory/Flat/EquationalCriterion.lean
@@ -273,7 +273,7 @@ theorem exists_factorization_of_comp_eq_zero_of_free [Flat R M] {K N : Type u} [
       use κ₂, hκ₂, a₂ ∘ₗ a₁, y₂
       simp_rw [comp_assoc]
       exact ⟨trivial, sup_le (ha₁.trans (ker_le_ker_comp _ _)) ha₂⟩
-  convert this ⊤ Finite.finite
+  convert this ⊤ Finite.fg_top
   simp only [top_le_iff, ker_eq_top]
 
 /-- Every homomorphism from a finitely presented module to a flat module factors through a finite

--- a/Mathlib/RingTheory/LocalProperties/Projective.lean
+++ b/Mathlib/RingTheory/LocalProperties/Projective.lean
@@ -121,7 +121,7 @@ theorem Module.projective_of_localization_maximal (H : ∀ (I : Ideal R) (_ : I.
     Module.Projective (Localization.AtPrime I) (LocalizedModule I.primeCompl M))
     [Module.FinitePresentation R M] : Module.Projective R M := by
   have : Module.Finite R M := by infer_instance
-  have : (⊤ : Submodule R M).FG := this.out
+  have : (⊤ : Submodule R M).FG := this.finite
   have : ∃ (s : Finset M), _ := this
   obtain ⟨s, hs⟩ := this
   let N := s →₀ R

--- a/Mathlib/RingTheory/LocalProperties/Projective.lean
+++ b/Mathlib/RingTheory/LocalProperties/Projective.lean
@@ -121,7 +121,7 @@ theorem Module.projective_of_localization_maximal (H : ∀ (I : Ideal R) (_ : I.
     Module.Projective (Localization.AtPrime I) (LocalizedModule I.primeCompl M))
     [Module.FinitePresentation R M] : Module.Projective R M := by
   have : Module.Finite R M := by infer_instance
-  have : (⊤ : Submodule R M).FG := this.finite
+  have : (⊤ : Submodule R M).FG := this.fg_top
   have : ∃ (s : Finset M), _ := this
   obtain ⟨s, hs⟩ := this
   let N := s →₀ R

--- a/Mathlib/RingTheory/LocalRing/Module.lean
+++ b/Mathlib/RingTheory/LocalRing/Module.lean
@@ -61,7 +61,7 @@ theorem map_mkQ_eq {N₁ N₂ : Submodule R M} (h : N₁ ≤ N₂) (h' : N₂.FG
 
 theorem map_mkQ_eq_top {N : Submodule R M} [Module.Finite R M] :
     N.map (Submodule.mkQ (𝔪 • ⊤)) = ⊤ ↔ N = ⊤ := by
-  rw [← map_mkQ_eq (N₁ := N) le_top Module.Finite.out, Submodule.map_top, Submodule.range_mkQ]
+  rw [← map_mkQ_eq (N₁ := N) le_top Module.Finite.finite, Submodule.map_top, Submodule.range_mkQ]
 
 theorem map_tensorProduct_mk_eq_top {N : Submodule R M} [Module.Finite R M] :
     N.map (TensorProduct.mk R k M 1) = ⊤ ↔ N = ⊤ := by
@@ -267,7 +267,7 @@ theorem free_of_lTensor_residueField_injective (hg : Surjective g) (h : Exact f 
     (hf : Function.Injective (f.lTensor k)) :
     Module.Free R P := by
   have := Module.finitePresentation_of_free_of_surjective g hg
-    (by rw [h.linearMap_ker_eq, LinearMap.range_eq_map]; exact (Module.Finite.out).map f)
+    (by rw [h.linearMap_ker_eq, LinearMap.range_eq_map]; exact (Module.Finite.finite).map f)
   apply free_of_maximalIdeal_rTensor_injective
   rw [← LinearMap.lTensor_inj_iff_rTensor_inj]
   apply lTensor_injective_of_exact_of_exact_of_rTensor_injective

--- a/Mathlib/RingTheory/LocalRing/Module.lean
+++ b/Mathlib/RingTheory/LocalRing/Module.lean
@@ -61,7 +61,7 @@ theorem map_mkQ_eq {N₁ N₂ : Submodule R M} (h : N₁ ≤ N₂) (h' : N₂.FG
 
 theorem map_mkQ_eq_top {N : Submodule R M} [Module.Finite R M] :
     N.map (Submodule.mkQ (𝔪 • ⊤)) = ⊤ ↔ N = ⊤ := by
-  rw [← map_mkQ_eq (N₁ := N) le_top Module.Finite.finite, Submodule.map_top, Submodule.range_mkQ]
+  rw [← map_mkQ_eq (N₁ := N) le_top Module.Finite.fg_top, Submodule.map_top, Submodule.range_mkQ]
 
 theorem map_tensorProduct_mk_eq_top {N : Submodule R M} [Module.Finite R M] :
     N.map (TensorProduct.mk R k M 1) = ⊤ ↔ N = ⊤ := by
@@ -267,7 +267,7 @@ theorem free_of_lTensor_residueField_injective (hg : Surjective g) (h : Exact f 
     (hf : Function.Injective (f.lTensor k)) :
     Module.Free R P := by
   have := Module.finitePresentation_of_free_of_surjective g hg
-    (by rw [h.linearMap_ker_eq, LinearMap.range_eq_map]; exact (Module.Finite.finite).map f)
+    (by rw [h.linearMap_ker_eq, LinearMap.range_eq_map]; exact (Module.Finite.fg_top).map f)
   apply free_of_maximalIdeal_rTensor_injective
   rw [← LinearMap.lTensor_inj_iff_rTensor_inj]
   apply lTensor_injective_of_exact_of_exact_of_rTensor_injective

--- a/Mathlib/RingTheory/Nakayama.lean
+++ b/Mathlib/RingTheory/Nakayama.lean
@@ -84,7 +84,7 @@ lemma eq_bot_of_set_smul_eq_of_subset_jacobson_annihilator {s : Set R}
 lemma top_ne_ideal_smul_of_le_jacobson_annihilator [Nontrivial M]
     [Module.Finite R M] {I} (h : I ≤ (Module.annihilator R M).jacobson) :
     (⊤ : Submodule R M) ≠ I • ⊤ := fun H => top_ne_bot <|
-  eq_bot_of_eq_ideal_smul_of_le_jacobson_annihilator Module.Finite.finite H <|
+  eq_bot_of_eq_ideal_smul_of_le_jacobson_annihilator Module.Finite.fg_top H <|
     (congrArg (I ≤ Ideal.jacobson ·) annihilator_top).mpr h
 
 open Pointwise in

--- a/Mathlib/RingTheory/Nakayama.lean
+++ b/Mathlib/RingTheory/Nakayama.lean
@@ -84,7 +84,7 @@ lemma eq_bot_of_set_smul_eq_of_subset_jacobson_annihilator {s : Set R}
 lemma top_ne_ideal_smul_of_le_jacobson_annihilator [Nontrivial M]
     [Module.Finite R M] {I} (h : I ≤ (Module.annihilator R M).jacobson) :
     (⊤ : Submodule R M) ≠ I • ⊤ := fun H => top_ne_bot <|
-  eq_bot_of_eq_ideal_smul_of_le_jacobson_annihilator Module.Finite.out H <|
+  eq_bot_of_eq_ideal_smul_of_le_jacobson_annihilator Module.Finite.finite H <|
     (congrArg (I ≤ Ideal.jacobson ·) annihilator_top).mpr h
 
 open Pointwise in


### PR DESCRIPTION
Right now it's impossible to do
```
-- finite projective modules
class IsFiniteProjective extends Module.Projective R M, Module.Finite R M : Prop where -- oops
```
because of a nameclash (both axioms are called `out`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
