### PR TITLE
[Merged by Bors] - feat(CategoryTheory): products in the category of Ind-objects

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Indization/Category.lean
+++ b/Mathlib/CategoryTheory/Limits/Indization/Category.lean
@@ -8,6 +8,7 @@ import Mathlib.CategoryTheory.Limits.Constructions.Filtered
 import Mathlib.CategoryTheory.Limits.FullSubcategory
 import Mathlib.CategoryTheory.Limits.Indization.LocallySmall
 import Mathlib.CategoryTheory.Limits.Indization.FilteredColimits
+import Mathlib.CategoryTheory.Limits.Indization.Products
 
 /-!
 # The category of Ind-objects
@@ -24,7 +25,10 @@ Adopting the theorem numbering of [Kashiwara2006], we show that
 * `C ⥤ Ind C` preserves finite colimits (6.1.6),
 * if `C` has coproducts indexed by a finite type `α`, then `Ind C` has coproducts indexed by `α`
   (6.1.18(ii)),
-* if `C` has finite coproducts, then `Ind C` has small coproducts (6.1.18(ii)).
+* if `C` has finite coproducts, then `Ind C` has small coproducts (6.1.18(ii)),
+* if `C` has products indexed by `α`, then `Ind C` has products indexed by `α`, and the functor
+  `Ind C ⥤ Cᵒᵖ ⥤ Type v` creates such products, and the functor `C ⥤ Ind C` preserves
+  them (6.1.17).
 
 More limit-colimit properties will follow.
 
@@ -106,6 +110,24 @@ noncomputable instance {J : Type v} [SmallCategory J] [IsFiltered J] :
 instance : HasFilteredColimits (Ind C) where
   HasColimitsOfShape _ _ _ :=
     hasColimitsOfShape_of_hasColimitsOfShape_createsColimitsOfShape (Ind.inclusion C)
+
+noncomputable instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
+    CreatesLimitsOfShape (Discrete J) (Ind.inclusion C) :=
+  letI _ : CreatesLimitsOfShape (Discrete J) (fullSubcategoryInclusion (IsIndObject (C := C))) :=
+    createsLimitsOfShapeFullSubcategoryInclusion (closedUnderLimitsOfShape_of_limit
+      (isIndObject_limit_of_discrete_of_hasLimitsOfShape _))
+  inferInstanceAs <|
+    CreatesLimitsOfShape (Discrete J) ((Ind.equivalence C).functor ⋙ fullSubcategoryInclusion _)
+
+instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
+    HasLimitsOfShape (Discrete J) (Ind C) :=
+  hasLimitsOfShape_of_hasLimitsOfShape_createsLimitsOfShape (Ind.inclusion C)
+
+instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
+    PreservesLimitsOfShape (Discrete J) (Ind.yoneda (C := C)) :=
+  letI _ : PreservesLimitsOfShape (Discrete J) (Ind.yoneda ⋙ Ind.inclusion C) :=
+    preservesLimitsOfShape_of_natIso Ind.yonedaCompInclusion.symm
+  preservesLimitsOfShape_of_reflects_of_preserves Ind.yoneda (Ind.inclusion C)
 
 theorem Ind.isIndObject_inclusion_obj (X : Ind C) : IsIndObject ((Ind.inclusion C).obj X) :=
   X.2

--- a/Mathlib/CategoryTheory/Limits/Indization/Category.lean
+++ b/Mathlib/CategoryTheory/Limits/Indization/Category.lean
@@ -111,19 +111,25 @@ instance : HasFilteredColimits (Ind C) where
   HasColimitsOfShape _ _ _ :=
     hasColimitsOfShape_of_hasColimitsOfShape_createsColimitsOfShape (Ind.inclusion C)
 
-noncomputable instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
-    CreatesLimitsOfShape (Discrete J) (Ind.inclusion C) :=
-  letI _ : CreatesLimitsOfShape (Discrete J) (fullSubcategoryInclusion (IsIndObject (C := C))) :=
-    createsLimitsOfShapeFullSubcategoryInclusion (closedUnderLimitsOfShape_of_limit
-      (isIndObject_limit_of_discrete_of_hasLimitsOfShape _))
-  inferInstanceAs <|
-    CreatesLimitsOfShape (Discrete J) ((Ind.equivalence C).functor ⋙ fullSubcategoryInclusion _)
+-- noncomputable instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
+--     CreatesLimitsOfShape (Discrete J) (Ind.inclusion C) :=
+--   letI _ : CreatesLimitsOfShape (Discrete J) (fullSubcategoryInclusion (IsIndObject (C := C))) :=
+--     createsLimitsOfShapeFullSubcategoryInclusion (closedUnderLimitsOfShape_of_limit
+--       (isIndObject_limit_of_discrete_of_hasLimitsOfShape _))
+--   inferInstanceAs <|
+--     CreatesLimitsOfShape (Discrete J) ((Ind.equivalence C).functor ⋙ fullSubcategoryInclusion _)
 
-instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
-    HasLimitsOfShape (Discrete J) (Ind C) :=
-  hasLimitsOfShape_of_hasLimitsOfShape_createsLimitsOfShape (Ind.inclusion C)
+-- instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
+--     HasLimitsOfShape (Discrete J) (Ind C) :=
+--   hasLimitsOfShape_of_hasLimitsOfShape_createsLimitsOfShape (Ind.inclusion C)
 
-instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
+variable {J : Type v}
+#synth ReflectsLimits (Discrete J) (Ind.inclusion C)
+
+example {J : Type v} : ReflectsLimitsOfShape (Discrete J) (Ind.inclusion C) :=
+  show_term inferInstance
+
+instance {J : Type v} /-[HasLimitsOfShape (Discrete J) C]-/ :
     PreservesLimitsOfShape (Discrete J) (Ind.yoneda (C := C)) :=
   letI _ : PreservesLimitsOfShape (Discrete J) (Ind.yoneda ⋙ Ind.inclusion C) :=
     preservesLimitsOfShape_of_natIso Ind.yonedaCompInclusion.symm

--- a/Mathlib/CategoryTheory/Limits/Indization/Category.lean
+++ b/Mathlib/CategoryTheory/Limits/Indization/Category.lean
@@ -111,26 +111,19 @@ instance : HasFilteredColimits (Ind C) where
   HasColimitsOfShape _ _ _ :=
     hasColimitsOfShape_of_hasColimitsOfShape_createsColimitsOfShape (Ind.inclusion C)
 
--- noncomputable instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
---     CreatesLimitsOfShape (Discrete J) (Ind.inclusion C) :=
---   letI _ : CreatesLimitsOfShape (Discrete J) (fullSubcategoryInclusion (IsIndObject (C := C))) :=
---     createsLimitsOfShapeFullSubcategoryInclusion (closedUnderLimitsOfShape_of_limit
---       (isIndObject_limit_of_discrete_of_hasLimitsOfShape _))
---   inferInstanceAs <|
---     CreatesLimitsOfShape (Discrete J) ((Ind.equivalence C).functor ⋙ fullSubcategoryInclusion _)
+noncomputable instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
+    CreatesLimitsOfShape (Discrete J) (Ind.inclusion C) :=
+  letI _ : CreatesLimitsOfShape (Discrete J) (fullSubcategoryInclusion (IsIndObject (C := C))) :=
+    createsLimitsOfShapeFullSubcategoryInclusion (closedUnderLimitsOfShape_of_limit
+      (isIndObject_limit_of_discrete_of_hasLimitsOfShape _))
+  inferInstanceAs <|
+    CreatesLimitsOfShape (Discrete J) ((Ind.equivalence C).functor ⋙ fullSubcategoryInclusion _)
 
--- instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
---     HasLimitsOfShape (Discrete J) (Ind C) :=
---   hasLimitsOfShape_of_hasLimitsOfShape_createsLimitsOfShape (Ind.inclusion C)
+instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
+    HasLimitsOfShape (Discrete J) (Ind C) :=
+  hasLimitsOfShape_of_hasLimitsOfShape_createsLimitsOfShape (Ind.inclusion C)
 
-variable {J : Type v}
-#synth ReflectsLimits (Discrete J) (Ind.inclusion C)
-
-example {J : Type v} : ReflectsLimitsOfShape (Discrete J) (Ind.inclusion C) :=
-  show_term inferInstance
-
-instance {J : Type v} /-[HasLimitsOfShape (Discrete J) C]-/ :
-    PreservesLimitsOfShape (Discrete J) (Ind.yoneda (C := C)) :=
+instance {J : Type v} : PreservesLimitsOfShape (Discrete J) (Ind.yoneda (C := C)) :=
   letI _ : PreservesLimitsOfShape (Discrete J) (Ind.yoneda ⋙ Ind.inclusion C) :=
     preservesLimitsOfShape_of_natIso Ind.yonedaCompInclusion.symm
   preservesLimitsOfShape_of_reflects_of_preserves Ind.yoneda (Ind.inclusion C)

--- a/Mathlib/CategoryTheory/Limits/Indization/Category.lean
+++ b/Mathlib/CategoryTheory/Limits/Indization/Category.lean
@@ -27,8 +27,8 @@ Adopting the theorem numbering of [Kashiwara2006], we show that
   (6.1.18(ii)),
 * if `C` has finite coproducts, then `Ind C` has small coproducts (6.1.18(ii)),
 * if `C` has products indexed by `α`, then `Ind C` has products indexed by `α`, and the functor
-  `Ind C ⥤ Cᵒᵖ ⥤ Type v` creates such products, and the functor `C ⥤ Ind C` preserves
-  them (6.1.17).
+  `Ind C ⥤ Cᵒᵖ ⥤ Type v` creates such products (6.1.17)
+* the functor `C ⥤ Ind C` preserves small limits.
 
 More limit-colimit properties will follow.
 
@@ -123,10 +123,10 @@ instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
     HasLimitsOfShape (Discrete J) (Ind C) :=
   hasLimitsOfShape_of_hasLimitsOfShape_createsLimitsOfShape (Ind.inclusion C)
 
-instance {J : Type v} : PreservesLimitsOfShape (Discrete J) (Ind.yoneda (C := C)) :=
-  letI _ : PreservesLimitsOfShape (Discrete J) (Ind.yoneda ⋙ Ind.inclusion C) :=
-    preservesLimitsOfShape_of_natIso Ind.yonedaCompInclusion.symm
-  preservesLimitsOfShape_of_reflects_of_preserves Ind.yoneda (Ind.inclusion C)
+instance : PreservesLimits (Ind.yoneda (C := C)) :=
+  letI _ : PreservesLimitsOfSize.{v, v} (Ind.yoneda ⋙ Ind.inclusion C) :=
+    preservesLimits_of_natIso Ind.yonedaCompInclusion.symm
+  preservesLimits_of_reflects_of_preserves Ind.yoneda (Ind.inclusion C)
 
 theorem Ind.isIndObject_inclusion_obj (X : Ind C) : IsIndObject ((Ind.inclusion C).obj X) :=
   X.2


### PR DESCRIPTION
Follow-up to #18988.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
