### PR TITLE
[Merged by Bors] - feat(Algebra/Module/CharacterModule): a morphism of abelian groups is bijective if and only if its dual is bijective

### DIFF
--- a/Mathlib/Algebra/Module/CharacterModule.lean
+++ b/Mathlib/Algebra/Module/CharacterModule.lean
@@ -79,11 +79,8 @@ from `B⋆` to `A⋆`.
 
 @[simp]
 lemma dual_zero : dual (0 : A →ₗ[R] B) = 0 := by
-  ext
-  dsimp
-  rw [AddMonoidHom.zero_apply, AddMonoidHom.comp_apply]
-  dsimp
-  rw [AddMonoidHom.map_zero]
+  ext f
+  exact map_zero f
 
 lemma dual_comp {C : Type*} [AddCommGroup C] [Module R C] (f : A →ₗ[R] B) (g : B →ₗ[R] C) :
     dual (g.comp f) = (dual f).comp (dual g) := by

--- a/Mathlib/Algebra/Module/CharacterModule.lean
+++ b/Mathlib/Algebra/Module/CharacterModule.lean
@@ -77,6 +77,27 @@ from `B⋆` to `A⋆`.
   map_add' := by aesop
   map_smul' r c := by ext x; exact congr(c $(f.map_smul r x)).symm
 
+@[simp]
+lemma dual_zero : dual (0 : A →ₗ[R] B) = 0 := by
+  ext
+  dsimp
+  rw [AddMonoidHom.zero_apply, AddMonoidHom.comp_apply]
+  dsimp
+  rw [AddMonoidHom.map_zero]
+
+lemma dual_comp {C : Type*} [AddCommGroup C] [Module R C] (f : A →ₗ[R] B) (g : B →ₗ[R] C) :
+    dual (g.comp f) = (dual f).comp (dual g) := by
+  ext
+  rfl
+
+lemma dual_injective_of_surjective (f : A →ₗ[R] B) (hf : Function.Surjective f) :
+    Function.Injective (dual f) := by
+    intro φ ψ eq
+    ext x
+    obtain ⟨y, rfl⟩ := hf x
+    change (dual f) φ _ = (dual f) ψ _
+    rw [eq]
+
 lemma dual_surjective_of_injective (f : A →ₗ[R] B) (hf : Function.Injective f) :
     Function.Surjective (dual f) :=
   (Module.Baer.of_divisible _).extension_property_addMonoidHom _ hf
@@ -210,5 +231,27 @@ lemma dual_surjective_iff_injective {f : A →ₗ[R] A'} :
 theorem _root_.rTensor_injective_iff_lcomp_surjective {f : A →ₗ[R] A'} :
     Function.Injective (f.rTensor B) ↔ Function.Surjective (f.lcomp R <| CharacterModule B) := by
   simp [← dual_rTensor_conj_homEquiv, dual_surjective_iff_injective]
+
+lemma surjective_of_dual_injective (f : A →ₗ[R] A') (hf : Function.Injective (dual f)) :
+    Function.Surjective f := by
+  rw [← LinearMap.range_eq_top, ← Submodule.unique_quotient_iff_eq_top]
+  refine Nonempty.intro (Unique.mk inferInstance
+    (fun a ↦ (eq_zero_of_character_apply (fun c ↦ ?_))))
+  obtain ⟨b, rfl⟩ := QuotientAddGroup.mk'_surjective _ a
+  suffices eq : dual (Submodule.mkQ _) c = 0 by
+    change (dual (Submodule.mkQ _) c) b = 0
+    rw [eq, AddMonoidHom.zero_apply]
+  refine hf ?_
+  rw [← LinearMap.comp_apply, ← dual_comp, LinearMap.range_mkQ_comp, dual_zero]
+  dsimp
+
+lemma dual_injective_iff_surjective {f : A →ₗ[R] A'} :
+    Function.Injective (dual f) ↔ Function.Surjective f :=
+  ⟨fun h ↦ surjective_of_dual_injective f h, fun h ↦ dual_injective_of_surjective f h⟩
+
+lemma dual_bijective_iff_bijective {f : A →ₗ[R] A'} :
+    Function.Bijective (dual f) ↔ Function.Bijective f :=
+  ⟨fun h ↦ ⟨dual_surjective_iff_injective.mp h.2, dual_injective_iff_surjective.mp h.1⟩,
+  fun h ↦ ⟨dual_injective_iff_surjective.mpr h.2, dual_surjective_iff_injective.mpr h.1⟩⟩
 
 end CharacterModule

--- a/Mathlib/Algebra/Module/CharacterModule.lean
+++ b/Mathlib/Algebra/Module/CharacterModule.lean
@@ -238,9 +238,7 @@ lemma surjective_of_dual_injective (f : A →ₗ[R] A') (hf : Function.Injective
   refine Nonempty.intro (Unique.mk inferInstance
     (fun a ↦ (eq_zero_of_character_apply (fun c ↦ ?_))))
   obtain ⟨b, rfl⟩ := QuotientAddGroup.mk'_surjective _ a
-  suffices eq : dual (Submodule.mkQ _) c = 0 by
-    change (dual (Submodule.mkQ _) c) b = 0
-    rw [eq, AddMonoidHom.zero_apply]
+  suffices eq : dual (Submodule.mkQ _) c = 0 from congr($eq b)
   refine hf ?_
   rw [← LinearMap.comp_apply, ← dual_comp, LinearMap.range_mkQ_comp, dual_zero]
   dsimp

--- a/Mathlib/Algebra/Module/CharacterModule.lean
+++ b/Mathlib/Algebra/Module/CharacterModule.lean
@@ -92,11 +92,11 @@ lemma dual_comp {C : Type*} [AddCommGroup C] [Module R C] (f : A →ₗ[R] B) (g
 
 lemma dual_injective_of_surjective (f : A →ₗ[R] B) (hf : Function.Surjective f) :
     Function.Injective (dual f) := by
-    intro φ ψ eq
-    ext x
-    obtain ⟨y, rfl⟩ := hf x
-    change (dual f) φ _ = (dual f) ψ _
-    rw [eq]
+  intro φ ψ eq
+  ext x
+  obtain ⟨y, rfl⟩ := hf x
+  change (dual f) φ _ = (dual f) ψ _
+  rw [eq]
 
 lemma dual_surjective_of_injective (f : A →ₗ[R] B) (hf : Function.Injective f) :
     Function.Surjective (dual f) :=
@@ -235,15 +235,12 @@ theorem _root_.rTensor_injective_iff_lcomp_surjective {f : A →ₗ[R] A'} :
 lemma surjective_of_dual_injective (f : A →ₗ[R] A') (hf : Function.Injective (dual f)) :
     Function.Surjective f := by
   rw [← LinearMap.range_eq_top, ← Submodule.unique_quotient_iff_eq_top]
-  refine Nonempty.intro (Unique.mk inferInstance
-    (fun a ↦ (eq_zero_of_character_apply (fun c ↦ ?_))))
+  refine ⟨Unique.mk inferInstance fun a ↦ eq_zero_of_character_apply fun c ↦ ?_⟩
   obtain ⟨b, rfl⟩ := QuotientAddGroup.mk'_surjective _ a
-  suffices eq : dual (Submodule.mkQ _) c = 0 by
-    change (dual (Submodule.mkQ _) c) b = 0
-    rw [eq, AddMonoidHom.zero_apply]
+  suffices eq : dual (Submodule.mkQ _) c = 0 from congr($eq b)
   refine hf ?_
   rw [← LinearMap.comp_apply, ← dual_comp, LinearMap.range_mkQ_comp, dual_zero]
-  dsimp
+  rfl
 
 lemma dual_injective_iff_surjective {f : A →ₗ[R] A'} :
     Function.Injective (dual f) ↔ Function.Surjective f :=


### PR DESCRIPTION
Prove that a morphism of abelian groups `f` is surjective if and only if its dual is injective, deduce that `f` is bijective if and only if its dual is bijective.

Note: here we use duality with coefficients in `ℚ ⧸ ℤ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
