### PR TITLE
[Merged by Bors] - chore(Topology/UniformSpace/Completion): make coe' argument implicit

### DIFF
--- a/Mathlib/Topology/UniformSpace/Completion.lean
+++ b/Mathlib/Topology/UniformSpace/Completion.lean
@@ -310,8 +310,9 @@ instance completeSpace : CompleteSpace (Completion α) :=
 
 instance t0Space : T0Space (Completion α) := SeparationQuotient.instT0Space
 
+variable {α} in
 /-- The map from a uniform space to its completion. -/
-@[coe] def coe' {α} [UniformSpace α] : α → Completion α := SeparationQuotient.mk ∘ pureCauchy
+@[coe] def coe' : α → Completion α := SeparationQuotient.mk ∘ pureCauchy
 
 /-- Automatic coercion from `α` to its completion. Not always injective. -/
 instance : Coe α (Completion α) :=

--- a/Mathlib/Topology/UniformSpace/Completion.lean
+++ b/Mathlib/Topology/UniformSpace/Completion.lean
@@ -311,11 +311,11 @@ instance completeSpace : CompleteSpace (Completion α) :=
 instance t0Space : T0Space (Completion α) := SeparationQuotient.instT0Space
 
 /-- The map from a uniform space to its completion. -/
-@[coe] def coe' : α → Completion α := SeparationQuotient.mk ∘ pureCauchy
+@[coe] def coe' {α} [UniformSpace α] : α → Completion α := SeparationQuotient.mk ∘ pureCauchy
 
 /-- Automatic coercion from `α` to its completion. Not always injective. -/
 instance : Coe α (Completion α) :=
-  ⟨coe' α⟩
+  ⟨coe'⟩
 
 -- note [use has_coe_t]
 protected theorem coe_eq : ((↑) : α → Completion α) = SeparationQuotient.mk ∘ pureCauchy := rfl


### PR DESCRIPTION
Right now coercions to completions of uniform spaces print weirdly:

```lean
import Mathlib.Topology.UniformSpace.Completion

variable (α : Type) [UniformSpace α] (x : α)

open UniformSpace

#check (x : Completion α) -- ↑α x : Completion α
```

This is because the coercion from `α` to `Completion α` is `UniformSpace.Completion.coe'` which (accidentally?)
has `α` explicit. We make it implicit, so now we get the expected

```lean
#check (x : Completion α) -- ↑x : Completion α
```

Zulip discussion: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/notation.20for.20coercion.20to.20completion/near/439560582

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
