### PR TITLE
[Merged by Bors] - fix(HashCommandLinter): remove unnecessary, broken workaround for tests

### DIFF
--- a/Mathlib/Tactic/Linter/HashCommandLinter.lean
+++ b/Mathlib/Tactic/Linter/HashCommandLinter.lean
@@ -67,10 +67,8 @@ logs a warning only for the `#`-commands that do not already emit a message. -/
 def hashCommandLinter : Linter where run := withSetOptionIn' fun stx => do
   let mod := (← getMainModule).components
   if Linter.getLinterValue linter.hashCommand (← getOptions) &&
-    ((← get).messages.reportedPlusUnreported.isEmpty || warningAsError.get (← getOptions)) &&
-    -- we check that the module is either not in `test` or, is `test.HashCommandLinter`
-    (mod.getD 0 default != `test || (mod == [`test, `HashCommandLinter]))
-    then
+    ((← get).messages.reportedPlusUnreported.isEmpty || warningAsError.get (← getOptions))
+  then
     if let some sa := stx.getHead? then
       let a := sa.getAtomVal
       if (a.get ⟨0⟩ == '#' && ! allowed_commands.contains a) then

--- a/Mathlib/Tactic/Linter/HashCommandLinter.lean
+++ b/Mathlib/Tactic/Linter/HashCommandLinter.lean
@@ -65,7 +65,6 @@ This means that CI will eventually fail on `#`-commands, but does not stop it fr
 However, in order to avoid local clutter, when `warningAsError` is `false`, the linter
 logs a warning only for the `#`-commands that do not already emit a message. -/
 def hashCommandLinter : Linter where run := withSetOptionIn' fun stx => do
-  let mod := (← getMainModule).components
   if Linter.getLinterValue linter.hashCommand (← getOptions) &&
     ((← get).messages.reportedPlusUnreported.isEmpty || warningAsError.get (← getOptions))
   then


### PR DESCRIPTION
The old workaround for `test` is wrong on two accounts.

1. The test directory is now called `MathlibTest`, not `test`.
2. With the weak-option settings that mathlib uses, the test files are all already opt-in for the linters anyways.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
