### PR TITLE
[Merged by Bors] - chore(Ideal/Basic): dependent generalization of `Ideal.pi`

### DIFF
--- a/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
+++ b/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
@@ -280,8 +280,8 @@ variable {R : Type u} [CommRing R] (I : Ideal R) {ι : Type v} [Fintype ι] {ι'
 
 /-- An `R`-linear map `R^n → R^m` induces a function `R^n/I^n → R^m/I^m`. -/
 private def induced_map (I : Ideal R) (e : (ι → R) →ₗ[R] ι' → R) :
-    (ι → R) ⧸ I.pi ι → (ι' → R) ⧸ I.pi ι' := fun x =>
-  Quotient.liftOn' x (fun y => Ideal.Quotient.mk (I.pi ι') (e y))
+    (ι → R) ⧸ Ideal.pi (fun _ ↦ I) → (ι' → R) ⧸ Ideal.pi fun _ ↦ I := fun x =>
+  Quotient.liftOn' x (fun y => Ideal.Quotient.mk _ (e y))
     (by
       refine fun a b hab => Ideal.Quotient.eq.2 fun h => ?_
       rw [Submodule.quotientRel_def] at hab
@@ -291,30 +291,14 @@ private def induced_map (I : Ideal R) (e : (ι → R) →ₗ[R] ι' → R) :
 /-- An isomorphism of `R`-modules `R^n ≃ R^m` induces an isomorphism of `R/I`-modules
     `R^n/I^n ≃ R^m/I^m`. -/
 private def induced_equiv [Fintype ι'] (I : Ideal R) (e : (ι → R) ≃ₗ[R] ι' → R) :
-    ((ι → R) ⧸ I.pi ι) ≃ₗ[R ⧸ I] (ι' → R) ⧸ I.pi ι' where
+    ((ι → R) ⧸ Ideal.pi fun _ ↦ I) ≃ₗ[R ⧸ I] (ι' → R) ⧸ Ideal.pi fun _ ↦ I where
   -- Porting note: Lean couldn't correctly infer `(I.pi ι)` and `(I.pi ι')` on their own
   toFun := induced_map I e
   invFun := induced_map I e.symm
-  map_add' := by
-    rintro ⟨a⟩ ⟨b⟩
-    convert_to Ideal.Quotient.mk (I.pi ι') _ = Ideal.Quotient.mk (I.pi ι') _
-    congr
-    simp only [map_add]
-  map_smul' := by
-    rintro ⟨a⟩ ⟨b⟩
-    convert_to Ideal.Quotient.mk (I.pi ι') _ = Ideal.Quotient.mk (I.pi ι') _
-    congr
-    simp only [LinearEquiv.coe_coe, LinearEquiv.map_smulₛₗ, RingHom.id_apply]
-  left_inv := by
-    rintro ⟨a⟩
-    convert_to Ideal.Quotient.mk (I.pi ι) _ = Ideal.Quotient.mk (I.pi ι) _
-    congr
-    simp only [LinearEquiv.coe_coe, LinearEquiv.symm_apply_apply]
-  right_inv := by
-    rintro ⟨a⟩
-    convert_to Ideal.Quotient.mk (I.pi ι') _ = Ideal.Quotient.mk (I.pi ι') _
-    congr
-    simp only [LinearEquiv.coe_coe,  LinearEquiv.apply_symm_apply]
+  map_add' := by rintro ⟨a⟩ ⟨b⟩; exact congr_arg _ (map_add ..)
+  map_smul' := by rintro ⟨a⟩ ⟨b⟩; exact congr_arg _ (map_smul ..)
+  left_inv := by rintro ⟨a⟩; exact congr_arg _ (e.left_inv ..)
+  right_inv := by rintro ⟨a⟩; exact congr_arg _ (e.right_inv ..)
 
 end
 
@@ -332,6 +316,6 @@ instance (priority := 100) invariantBasisNumber_of_nontrivial_of_commRing {R : T
   ⟨fun e =>
     let ⟨I, _hI⟩ := Ideal.exists_maximal R
     eq_of_fin_equiv (R ⧸ I)
-      ((Ideal.piQuotEquiv _ _).symm ≪≫ₗ (induced_equiv _ e ≪≫ₗ Ideal.piQuotEquiv _ _))⟩
+      ((Ideal.piQuotEquiv _ _).symm ≪≫ₗ induced_equiv _ e ≪≫ₗ Ideal.piQuotEquiv _ _)⟩
 
 end

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -42,7 +42,7 @@ variable {α : ι → Type*} [Π i, Semiring (α i)] (I : Π i, Ideal (α i))
 
 section Pi
 
-/-- `I^n` as an ideal of `R^n`. -/
+/-- `Πᵢ Iᵢ` as an ideal of `Πᵢ Rᵢ`. -/
 def pi : Ideal (Π i, α i) where
   carrier := { x | ∀ i, x i ∈ I i }
   zero_mem' i := (I i).zero_mem

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -28,9 +28,7 @@ Support right ideals, and two-sided ideals over non-commutative rings.
 -/
 
 
-universe u v w
-
-variable {α : Type u} {β : Type v} {F : Type w}
+variable {ι α β F : Type*}
 
 open Set Function
 
@@ -40,20 +38,18 @@ section Semiring
 
 namespace Ideal
 
-variable [Semiring α] (I : Ideal α) {a b : α}
+variable {α : ι → Type*} [Π i, Semiring (α i)] (I : Π i, Ideal (α i))
 
 section Pi
 
-variable (ι : Type v)
-
 /-- `I^n` as an ideal of `R^n`. -/
-def pi : Ideal (ι → α) where
-  carrier := { x | ∀ i, x i ∈ I }
-  zero_mem' _i := I.zero_mem
-  add_mem' ha hb i := I.add_mem (ha i) (hb i)
-  smul_mem' a _b hb i := I.mul_mem_left (a i) (hb i)
+def pi : Ideal (Π i, α i) where
+  carrier := { x | ∀ i, x i ∈ I i }
+  zero_mem' i := (I i).zero_mem
+  add_mem' ha hb i := (I i).add_mem (ha i) (hb i)
+  smul_mem' a _b hb i := (I i).mul_mem_left (a i) (hb i)
 
-theorem mem_pi (x : ι → α) : x ∈ I.pi ι ↔ ∀ i, x i ∈ I :=
+theorem mem_pi (x : Π i, α i) : x ∈ pi I ↔ ∀ i, x i ∈ I i :=
   Iff.rfl
 
 end Pi
@@ -166,7 +162,7 @@ end CommSemiring
 
 section DivisionSemiring
 
-variable {K : Type u} [DivisionSemiring K] (I : Ideal K)
+variable {K : Type*} [DivisionSemiring K] (I : Ideal K)
 
 namespace Ideal
 
@@ -254,7 +250,7 @@ end Ring
 
 namespace Ideal
 
-variable {R : Type u} [CommSemiring R] [Nontrivial R]
+variable {R : Type*} [CommSemiring R] [Nontrivial R]
 
 theorem bot_lt_of_maximal (M : Ideal R) [hm : M.IsMaximal] (non_field : ¬IsField R) : ⊥ < M := by
   rcases Ring.not_isField_iff_exists_ideal_bot_lt_and_lt_top.1 non_field with ⟨I, Ibot, Itop⟩

--- a/Mathlib/RingTheory/Ideal/Quotient/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Basic.lean
@@ -151,55 +151,32 @@ section Pi
 variable (ι : Type v)
 
 /-- `R^n/I^n` is a `R/I`-module. -/
-instance modulePi : Module (R ⧸ I) ((ι → R) ⧸ I.pi ι) where
+instance modulePi : Module (R ⧸ I) ((ι → R) ⧸ pi fun _ ↦ I) where
   smul c m :=
-    Quotient.liftOn₂' c m (fun r m => Submodule.Quotient.mk <| r • m) <| by
+    Quotient.liftOn₂' c m (fun r m ↦ Submodule.Quotient.mk <| r • m) <| by
       intro c₁ m₁ c₂ m₂ hc hm
       apply Ideal.Quotient.eq.2
       rw [Submodule.quotientRel_def] at hc hm
       intro i
       exact I.mul_sub_mul_mem hc (hm i)
-  one_smul := by
-    rintro ⟨a⟩
-    convert_to Ideal.Quotient.mk (I.pi ι) _ = Ideal.Quotient.mk (I.pi ι) _
-    congr with i; exact one_mul (a i)
-  mul_smul := by
-    rintro ⟨a⟩ ⟨b⟩ ⟨c⟩
-    convert_to Ideal.Quotient.mk (I.pi ι) _ = Ideal.Quotient.mk (I.pi ι) _
-    congr 1; funext i; exact mul_assoc a b (c i)
-  smul_add := by
-    rintro ⟨a⟩ ⟨b⟩ ⟨c⟩
-    convert_to Ideal.Quotient.mk (I.pi ι) _ = Ideal.Quotient.mk (I.pi ι) _
-    congr with i; exact mul_add a (b i) (c i)
-  smul_zero := by
-    rintro ⟨a⟩
-    convert_to Ideal.Quotient.mk (I.pi ι) _ = Ideal.Quotient.mk (I.pi ι) _
-    congr with _; exact mul_zero a
-  add_smul := by
-    rintro ⟨a⟩ ⟨b⟩ ⟨c⟩
-    convert_to Ideal.Quotient.mk (I.pi ι) _ = Ideal.Quotient.mk (I.pi ι) _
-    congr with i; exact add_mul a b (c i)
-  zero_smul := by
-    rintro ⟨a⟩
-    convert_to Ideal.Quotient.mk (I.pi ι) _ = Ideal.Quotient.mk (I.pi ι) _
-    congr with i; exact zero_mul (a i)
+  one_smul := by rintro ⟨a⟩; exact congr_arg _ (one_smul _ _)
+  mul_smul := by rintro ⟨a⟩ ⟨b⟩ ⟨c⟩; exact congr_arg _ (mul_smul _ _ _)
+  smul_add := by rintro ⟨a⟩ ⟨b⟩ ⟨c⟩; exact congr_arg _ (smul_add _ _ _)
+  smul_zero := by rintro ⟨a⟩; exact congr_arg _ (smul_zero _)
+  add_smul := by rintro ⟨a⟩ ⟨b⟩ ⟨c⟩; exact congr_arg _ (add_smul _ _ _)
+  zero_smul := by rintro ⟨a⟩; exact congr_arg _ (zero_smul _ _)
 
 /-- `R^n/I^n` is isomorphic to `(R/I)^n` as an `R/I`-module. -/
-noncomputable def piQuotEquiv : ((ι → R) ⧸ I.pi ι) ≃ₗ[R ⧸ I] ι → (R ⧸ I) where
-  toFun := fun x ↦
-      Quotient.liftOn' x (fun f i => Ideal.Quotient.mk I (f i)) fun _ _ hab =>
-        funext fun i => (Submodule.Quotient.eq' _).2 (QuotientAddGroup.leftRel_apply.mp hab i)
+noncomputable def piQuotEquiv : ((ι → R) ⧸ pi fun _ ↦ I) ≃ₗ[R ⧸ I] ι → (R ⧸ I) where
+  toFun x := Quotient.liftOn' x (fun f i ↦ Ideal.Quotient.mk I (f i)) fun _ _ hab ↦
+    funext fun i ↦ (Submodule.Quotient.eq' _).2 (QuotientAddGroup.leftRel_apply.mp hab i)
   map_add' := by rintro ⟨_⟩ ⟨_⟩; rfl
   map_smul' := by rintro ⟨_⟩ ⟨_⟩; rfl
-  invFun := fun x ↦ Ideal.Quotient.mk (I.pi ι) fun i ↦ Quotient.out (x i)
+  invFun x := Ideal.Quotient.mk _ (Quotient.out <| x ·)
   left_inv := by
     rintro ⟨x⟩
-    exact Ideal.Quotient.eq.2 fun i => Ideal.Quotient.eq.1 (Quotient.out_eq' _)
-  right_inv := by
-    intro x
-    ext i
-    obtain ⟨_, _⟩ := @Quot.exists_rep _ _ (x i)
-    convert Quotient.out_eq' (x i)
+    exact Ideal.Quotient.eq.2 fun i ↦ Ideal.Quotient.eq.1 (Quotient.out_eq' _)
+  right_inv x := funext fun i ↦ Quotient.out_eq' (x i)
 
 /-- If `f : R^n → R^m` is an `R`-linear map and `I ⊆ R` is an ideal, then the image of `I^n` is
     contained in `I^m`. -/


### PR DESCRIPTION
Also golf some proofs.

TODO: similar to `Ideal.idealProdEquiv`, we may construct OrderEmbedding from `Πᵢ Ideal Rᵢ` to `Ideal (Πᵢ Rᵢ)`, which is an OrderIso if the indexing type is finite. This can then be used to show e.g. that a finite product of Noetherian rings is Noetherian without using an inductive argument.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
