### PR TITLE
[Merged by Bors] - fix(scripts/technical-debt-metric): avoid division by 0

### DIFF
--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -167,7 +167,7 @@ then
         {absWeight+=$3+0}
         (($3+0 == $3) && (!($2+0 == 0))) {total+=1 / $2; weight+=$3 / $2}
         END{
-          if (total == "0") {average=absWeight} else {average=weight/total}
+          if (total == 0) {average=absWeight} else {average=weight/total}
           if(average < 0) {change= "Decrease"; average=-average; weight=-weight} else {change= "Increase"}
           printf("<details><summary>%s in tech debt: (relative, absolute) = (%4.2f, %4.2f)</summary>\n\n%s\n", change, average, weight, rep) }'
   fi

--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -160,7 +160,8 @@ then
   then
     printf '<details><summary>No changes to technical debt.</summary>\n'
   else
-    printf '%s\n' "${rep}" |
+    printf '%s\n' "${rep}" |  # outputs lines containing `|Current number|Change|Type|`, so
+                              # `$2` refers to `Current number` and `$3` to `Change`.
       awk -F '|' -v rep="${rep}" '
         BEGIN{total=0; weight=0; absWeight=0}
         {absWeight+=$3+0}

--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -162,10 +162,11 @@ then
   else
     printf '%s\n' "${rep}" |
       awk -F '|' -v rep="${rep}" '
-        BEGIN{total=0; weight=0}
+        BEGIN{total=0; weight=0; absWeight=0}
+        {absWeight+=$3+0}
         (($3+0 == $3) && (!($2+0 == 0))) {total+=1 / $2; weight+=$3 / $2}
         END{
-          average=weight/total
+          if (total == "0") {average=absWeight} else {average=weight/total}
           if(average < 0) {change= "Decrease"; average=-average; weight=-weight} else {change= "Increase"}
           printf("<details><summary>%s in tech debt: (relative, absolute) = (%4.2f, %4.2f)</summary>\n\n%s\n", change, average, weight, rep) }'
   fi


### PR DESCRIPTION
The division by 0 affected #20521: all `ofNat` debts were removed in that PR, so one denominator became 0 giving a [CI error](https://github.com/leanprover-community/mathlib4/actions/runs/12636151506/job/35207580913).

This PR fixes the issue.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
