### PR TITLE
[Merged by Bors] - perf: improves the performance of the `Repr (Equiv.Perm α)` instance (2/4)

### DIFF
--- a/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
@@ -304,7 +304,6 @@ end CycleOf
 
 section cycleFactors
 
-
 open scoped List in
 /-- Given a list `l : List α` and a permutation `f : Perm α` whose nonfixed points are all in `l`,
   recursively factors `f` into cycles. -/


### PR DESCRIPTION
The instance of `Repr (Equiv.Perm α)` uses the following `truncCycleFactors` function:
```lean
def cycleFactorsAux [DecidableEq α] [Fintype α] (l : List α) (f : Perm α)
    (h : ∀ {x}, f x ≠ x → x ∈ l) :
    { l : List (Perm α) // l.prod = f ∧ (∀ g ∈ l, IsCycle g) ∧ l.Pairwise Disjoint } :=
  match l with
  | [] => ⟨[], ⋯⟩
  | x :: l =>
    if hx : f x = x then cycleFactorsAux l f ⋯
    else
      let ⟨m, hm⟩ := cycleFactorsAux l ((cycleOf f x)⁻¹ * f) ⋯
      ⟨cycleOf f x :: m, ⋯⟩

def truncCycleFactors [DecidableEq α] [Fintype α] (f : Perm α) :
    Trunc { l : List (Perm α) // l.prod = f ∧ (∀ g ∈ l, IsCycle g) ∧ l.Pairwise Disjoint } :=
  Quotient.recOnSubsingleton
    (motive := fun m =>
      (∀ x, f x ≠ x → x ∈ m) →
        Trunc { l // l.prod = f ∧ (∀ g ∈ l, g.IsCycle) ∧ List.Pairwise Disjoint l })
    (Finset.univ : Finset α).val
    (fun l h => Trunc.mk (cycleFactorsAux l f ⋯))
    ⋯
```

However, for a permutation consisted of many disjoint cycles, like `(c[0, 1] * c[2, 3] * c[4, 5] * c[6, 7] : Equiv.Perm (Fin 10))`, evaluating returned permutations takes too long.
This is because the argument `f` in `cycleFactorsAux` gets more complex per step; `f` to `(cycleOf f x)⁻¹ * f`.

To solve this problem, we memorize the first permutation:
```lean
def cycleFactorsAux [DecidableEq α] [Fintype α]
    (l : List α) (f : Perm α) (h : ∀ {x}, f x ≠ x → x ∈ l) :
    { pl : List (Perm α) // pl.prod = f ∧ (∀ g ∈ pl, IsCycle g) ∧ pl.Pairwise Disjoint } :=
  go l f ⋯ ⋯
where
  go (l : List α) (g : Perm α) (hg : ∀ {x}, g x ≠ x → x ∈ l)
    (hfg : ∀ {x}, g x ≠ x → cycleOf f x = cycleOf g x) :
    { pl : List (Perm α) // pl.prod = g ∧ (∀ g' ∈ pl, IsCycle g') ∧ pl.Pairwise Disjoint } :=
  match l with
  | [] => ⟨[], ⋯⟩
  | x :: l =>
    if hx : g x = x then go l g ⋯ ⋯
    else
      let ⟨m, hm₁, hm₂, hm₃⟩ := go l ((cycleOf f x)⁻¹ * g) ⋯ ⋯
      ⟨cycleOf f x :: m, ⋯⟩
```

---

- [x] depends on: #20519
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
