### PR TITLE
[Merged by Bors] - fix(scripts/bench_summary): input jobID as a Nat, rather than a String

### DIFF
--- a/scripts/bench_summary.lean
+++ b/scripts/bench_summary.lean
@@ -163,7 +163,7 @@ Here is a summary of the steps:
 * process the final string to produce a summary (using `benchOutput`),
 * finally post the resulting output to the PR (using `gh pr comment ...`).
 -/
-def addBenchSummaryComment (PR : Nat) (repo : String) (jobID : String := "")
+def addBenchSummaryComment (PR : Nat) (repo : String) (jobID : Nat := 0)
     (author : String := "leanprover-bot") (tempFile : String := "benchOutput.json") :
     CommandElabM Unit := do
   let job_msg := s!"\n[CI run](https://github.com/{repo}/actions/runs/{jobID})"

--- a/scripts/bench_summary.lean
+++ b/scripts/bench_summary.lean
@@ -147,7 +147,9 @@ open Lean Elab Command in
 as a comment to a pull request.  It takes as input
 * the number `PR` and the name `repo` as a `String` containing the relevant pull-request
   (it reads and posts comments there)
-* the optional `jobID` string for reporting the action that produced the output
+* the optional `jobID` numeral for reporting the action that produced the output
+  (`jobID` is a natural number, even though it gets converted to a `String` -- this is mostly
+  due to the fact that it is easier to get CI to pass a number, than a string with quotations)
 * the `String` `tempFile` of a temporary file where the command stores transient information.
 
 The code itself interfaces with the shell to retrieve and process json data and eventually


### PR DESCRIPTION
Hopefully, this fixes the bench_summary bot.

You can see the error that the bot reports [here](https://github.com/leanprover-community/mathlib4/actions/runs/12648073160/job/35241690249), specifically it says
```lean
<stdin>:248:81: error: failed to synthesize
  OfNat String 12648073160
numerals are polymorphic in Lean, but the numeral `12648073160` cannot be used in a context where the expected type is
  String
due to the absence of the instance above
Additional diagnostic information may be available using the `set_option diagnostics true` command.
```
The issue is that the (lean) script takes the jobID as a `String`, since it wants to print the jobID url.  However, due to quotation handling, the script receives a numeric literal, since the double quotes get lost in translation.  If instead we ask Lean to do the conversion of a natural number to a string internally, everything should work.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
