### PR TITLE
[Merged by Bors] - chore(LpSpace): move results about the L^p norm earlier

### DIFF
--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -822,7 +822,7 @@ theorem Integrable.prod_mk {f : α → β} {g : α → γ} (hf : Integrable f μ
 
 theorem Memℒp.integrable {q : ℝ≥0∞} (hq1 : 1 ≤ q) {f : α → β} [IsFiniteMeasure μ]
     (hfq : Memℒp f q μ) : Integrable f μ :=
-  memℒp_one_iff_integrable.mp (hfq.memℒp_of_exponent_le hq1)
+  memℒp_one_iff_integrable.mp (hfq.mono_exponent hq1)
 
 /-- A non-quantitative version of Markov inequality for integrable functions: the measure of points
 where `‖f x‖ ≥ ε` is finite for all positive `ε`. -/

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -252,7 +252,7 @@ theorem Memℒp.locallyIntegrable [IsLocallyFiniteMeasure μ] {f : X → E} {p :
   have : Fact (μ U < ⊤) := ⟨h'U⟩
   refine ⟨U, hU, ?_⟩
   rw [IntegrableOn, ← memℒp_one_iff_integrable]
-  apply (hf.restrict U).memℒp_of_exponent_le hp
+  apply (hf.restrict U).mono_exponent hp
 
 theorem locallyIntegrable_const [IsLocallyFiniteMeasure μ] (c : E) :
     LocallyIntegrable (fun _ => c) μ :=
@@ -504,7 +504,7 @@ theorem MonotoneOn.memℒp_top (hmono : MonotoneOn f s) {a b : X}
 theorem MonotoneOn.memℒp_of_measure_ne_top (hmono : MonotoneOn f s) {a b : X}
     (ha : IsLeast s a) (hb : IsGreatest s b) (hs : μ s ≠ ∞) (h's : MeasurableSet s) :
     Memℒp f p (μ.restrict s) :=
-  (hmono.memℒp_top ha hb h's).memℒp_of_exponent_le_of_measure_support_ne_top (s := univ)
+  (hmono.memℒp_top ha hb h's).mono_exponent_of_measure_support_ne_top (s := univ)
     (by simp) (by simpa using hs) le_top
 
 theorem MonotoneOn.memℒp_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -872,7 +872,7 @@ lemma eLpNorm_indicator_const_le (c : G) (p : ℝ≥0∞) :
     eLpNorm (s.indicator fun _ => c) p μ ≤ eLpNorm (t.indicator fun _ => c) p μ :=
       eLpNorm_mono (norm_indicator_le_of_subset (subset_toMeasurable _ _) _)
     _ = ‖c‖₊ * μ t ^ (1 / p.toReal) :=
-      (eLpNorm_indicator_const (measurableSet_toMeasurable _ _) hp h'p)
+      eLpNorm_indicator_const (measurableSet_toMeasurable ..) hp h'p
     _ = ‖c‖₊ * μ s ^ (1 / p.toReal) := by rw [measure_toMeasurable]
 
 lemma Memℒp.indicator (hs : MeasurableSet s) (hf : Memℒp f p μ) : Memℒp (s.indicator f) p μ :=
@@ -1191,6 +1191,12 @@ lemma eLpNorm_lt_top_of_finite [Finite α] [IsFiniteMeasure μ] : eLpNorm f p μ
 
 @[simp] lemma eLpNorm_of_isEmpty [IsEmpty α] (f : α → E) (p : ℝ≥0∞) : eLpNorm f p μ = 0 := by
   simp [Subsingleton.elim f 0]
+
+@[deprecated (since := "2024-07-27")]
+alias snormEssSup_piecewise := eLpNormEssSup_piecewise
+
+@[deprecated (since := "2024-07-27")]
+alias snorm_top_piecewise := eLpNorm_top_piecewise
 
 section MapMeasure
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -788,6 +788,9 @@ lemma eLpNorm_indicator_eq_eLpNorm_restrict (hs : MeasurableSet s) :
   --               `∘` well.
   exact (Set.indicator_comp_of_zero (g := fun x : ℝ≥0∞ => x ^ p.toReal) h_zero).symm
 
+@[deprecated (since := "2024-07-27")]
+alias snorm_indicator_eq_restrict := eLpNorm_indicator_eq_eLpNorm_restrict
+
 @[deprecated (since := "2025-01-07")]
 alias eLpNorm_indicator_eq_restrict := eLpNorm_indicator_eq_eLpNorm_restrict
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -346,21 +346,6 @@ theorem memℒp_neg_iff {f : α → E} : Memℒp (-f) p μ ↔ Memℒp f p μ :=
 
 end Neg
 
-theorem eLpNorm_indicator_eq_restrict {f : α → E} {s : Set α} (hs : MeasurableSet s) :
-    eLpNorm (s.indicator f) p μ = eLpNorm f p (μ.restrict s) := by
-  rcases eq_or_ne p ∞ with rfl | hp
-  · simp only [eLpNorm_exponent_top, eLpNormEssSup_eq_essSup_nnnorm,
-      ← ENNReal.essSup_indicator_eq_essSup_restrict hs, ENNReal.coe_indicator,
-      nnnorm_indicator_eq_indicator_nnnorm]
-  · rcases eq_or_ne p 0 with rfl | hp₀; · simp
-    simp only [eLpNorm_eq_lintegral_rpow_nnnorm hp₀ hp, ← lintegral_indicator hs,
-      ENNReal.coe_indicator, nnnorm_indicator_eq_indicator_nnnorm]
-    congr with x
-    by_cases hx : x ∈ s <;> simp [ENNReal.toReal_pos, *]
-
-@[deprecated (since := "2024-07-27")]
-alias snorm_indicator_eq_restrict := eLpNorm_indicator_eq_restrict
-
 section Const
 
 theorem eLpNorm'_const (c : F) (hq_pos : 0 < q) :
@@ -780,12 +765,167 @@ alias snorm_mono_measure := eLpNorm_mono_measure
 theorem Memℒp.mono_measure {f : α → E} (hμν : ν ≤ μ) (hf : Memℒp f p μ) : Memℒp f p ν :=
   ⟨hf.1.mono_measure hμν, (eLpNorm_mono_measure f hμν).trans_lt hf.2⟩
 
+section Indicator
+variable {c : F} {hf : AEStronglyMeasurable f μ} {s : Set α}
+
+lemma eLpNorm_indicator_eq_eLpNorm_restrict (hs : MeasurableSet s) :
+    eLpNorm (s.indicator f) p μ = eLpNorm f p (μ.restrict s) := by
+  by_cases hp_zero : p = 0
+  · simp only [hp_zero, eLpNorm_exponent_zero]
+  by_cases hp_top : p = ∞
+  · simp_rw [hp_top, eLpNorm_exponent_top, eLpNormEssSup_eq_essSup_nnnorm,
+       nnnorm_indicator_eq_indicator_nnnorm, ENNReal.coe_indicator,
+       ENNReal.essSup_indicator_eq_essSup_restrict hs]
+  simp_rw [eLpNorm_eq_lintegral_rpow_nnnorm hp_zero hp_top]
+  suffices (∫⁻ x, (‖s.indicator f x‖₊ : ℝ≥0∞) ^ p.toReal ∂μ) =
+      ∫⁻ x in s, (‖f x‖₊ : ℝ≥0∞) ^ p.toReal ∂μ by rw [this]
+  rw [← lintegral_indicator hs]
+  congr
+  simp_rw [nnnorm_indicator_eq_indicator_nnnorm, ENNReal.coe_indicator]
+  have h_zero : (fun x => x ^ p.toReal) (0 : ℝ≥0∞) = 0 := by
+    simp [ENNReal.toReal_pos hp_zero hp_top]
+  -- Porting note: The implicit argument should be specified because the elaborator can't deal with
+  --               `∘` well.
+  exact (Set.indicator_comp_of_zero (g := fun x : ℝ≥0∞ => x ^ p.toReal) h_zero).symm
+
+@[deprecated (since := "2025-01-07")]
+alias eLpNorm_indicator_eq_restrict := eLpNorm_indicator_eq_eLpNorm_restrict
+
+lemma eLpNormEssSup_indicator_eq_eLpNormEssSup_restrict (hs : MeasurableSet s) :
+    eLpNormEssSup (s.indicator f) μ = eLpNormEssSup f (μ.restrict s) := by
+  simp_rw [← eLpNorm_exponent_top, eLpNorm_indicator_eq_eLpNorm_restrict hs]
+
 lemma eLpNorm_restrict_le (f : α → F) (p : ℝ≥0∞) (μ : Measure α) (s : Set α) :
     eLpNorm f p (μ.restrict s) ≤ eLpNorm f p μ :=
   eLpNorm_mono_measure f Measure.restrict_le_self
 
 @[deprecated (since := "2024-07-27")]
 alias snorm_restrict_le := eLpNorm_restrict_le
+
+lemma eLpNorm_indicator_le (f : α → E) : eLpNorm (s.indicator f) p μ ≤ eLpNorm f p μ := by
+  refine eLpNorm_mono_ae <| .of_forall fun x ↦ ?_
+  suffices ‖s.indicator f x‖₊ ≤ ‖f x‖₊ by exact NNReal.coe_mono this
+  rw [nnnorm_indicator_eq_indicator_nnnorm]
+  exact s.indicator_le_self _ x
+
+lemma eLpNormEssSup_indicator_le (s : Set α) (f : α → G) :
+    eLpNormEssSup (s.indicator f) μ ≤ eLpNormEssSup f μ := by
+  refine essSup_mono_ae (Eventually.of_forall fun x => ?_)
+  simp_rw [enorm_eq_nnnorm, ENNReal.coe_le_coe, nnnorm_indicator_eq_indicator_nnnorm]
+  exact Set.indicator_le_self s _ x
+
+lemma eLpNormEssSup_indicator_const_le (s : Set α) (c : G) :
+    eLpNormEssSup (s.indicator fun _ : α => c) μ ≤ ‖c‖₊ := by
+  by_cases hμ0 : μ = 0
+  · rw [hμ0, eLpNormEssSup_measure_zero]
+    exact zero_le _
+  · exact (eLpNormEssSup_indicator_le s fun _ => c).trans (eLpNormEssSup_const c hμ0).le
+
+lemma eLpNormEssSup_indicator_const_eq (s : Set α) (c : G) (hμs : μ s ≠ 0) :
+    eLpNormEssSup (s.indicator fun _ : α => c) μ = ‖c‖₊ := by
+  refine le_antisymm (eLpNormEssSup_indicator_const_le s c) ?_
+  by_contra! h
+  have h' := ae_iff.mp (ae_lt_of_essSup_lt h)
+  push_neg at h'
+  refine hμs (measure_mono_null (fun x hx_mem => ?_) h')
+  rw [Set.mem_setOf_eq, Set.indicator_of_mem hx_mem, enorm_eq_nnnorm]
+
+lemma eLpNorm_indicator_const₀ (hs : NullMeasurableSet s μ) (hp : p ≠ 0) (hp_top : p ≠ ∞) :
+    eLpNorm (s.indicator fun _ => c) p μ = ‖c‖₊ * μ s ^ (1 / p.toReal) :=
+  have hp_pos : 0 < p.toReal := ENNReal.toReal_pos hp hp_top
+  calc
+    eLpNorm (s.indicator fun _ => c) p μ
+      = (∫⁻ x, ((‖(s.indicator fun _ ↦ c) x‖₊ : ℝ≥0∞) ^ p.toReal) ∂μ) ^ (1 / p.toReal) :=
+          eLpNorm_eq_lintegral_rpow_nnnorm hp hp_top
+    _ = (∫⁻ x, (s.indicator fun _ ↦ (‖c‖₊ : ℝ≥0∞) ^ p.toReal) x ∂μ) ^ (1 / p.toReal) := by
+      congr 2
+      refine (Set.comp_indicator_const c (fun x ↦ (‖x‖₊ : ℝ≥0∞) ^ p.toReal) ?_)
+      simp [hp_pos]
+    _ = ‖c‖₊ * μ s ^ (1 / p.toReal) := by
+      rw [lintegral_indicator_const₀ hs, ENNReal.mul_rpow_of_nonneg, ← ENNReal.rpow_mul,
+        mul_one_div_cancel hp_pos.ne', ENNReal.rpow_one]
+      positivity
+
+lemma eLpNorm_indicator_const (hs : MeasurableSet s) (hp : p ≠ 0) (hp_top : p ≠ ∞) :
+    eLpNorm (s.indicator fun _ => c) p μ = ‖c‖₊ * μ s ^ (1 / p.toReal) :=
+  eLpNorm_indicator_const₀ hs.nullMeasurableSet hp hp_top
+
+lemma eLpNorm_indicator_const' (hs : MeasurableSet s) (hμs : μ s ≠ 0) (hp : p ≠ 0) :
+    eLpNorm (s.indicator fun _ => c) p μ = ‖c‖₊ * μ s ^ (1 / p.toReal) := by
+  by_cases hp_top : p = ∞
+  · simp [hp_top, eLpNormEssSup_indicator_const_eq s c hμs]
+  · exact eLpNorm_indicator_const hs hp hp_top
+
+lemma eLpNorm_indicator_const_le (c : G) (p : ℝ≥0∞) :
+    eLpNorm (s.indicator fun _ => c) p μ ≤ ‖c‖₊ * μ s ^ (1 / p.toReal) := by
+  obtain rfl | hp := eq_or_ne p 0
+  · simp only [eLpNorm_exponent_zero, zero_le']
+  obtain rfl | h'p := eq_or_ne p ∞
+  · simp only [eLpNorm_exponent_top, ENNReal.top_toReal, _root_.div_zero, ENNReal.rpow_zero,
+      mul_one]
+    exact eLpNormEssSup_indicator_const_le _ _
+  let t := toMeasurable μ s
+  calc
+    eLpNorm (s.indicator fun _ => c) p μ ≤ eLpNorm (t.indicator fun _ => c) p μ :=
+      eLpNorm_mono (norm_indicator_le_of_subset (subset_toMeasurable _ _) _)
+    _ = ‖c‖₊ * μ t ^ (1 / p.toReal) :=
+      (eLpNorm_indicator_const (measurableSet_toMeasurable _ _) hp h'p)
+    _ = ‖c‖₊ * μ s ^ (1 / p.toReal) := by rw [measure_toMeasurable]
+
+lemma Memℒp.indicator (hs : MeasurableSet s) (hf : Memℒp f p μ) : Memℒp (s.indicator f) p μ :=
+  ⟨hf.aestronglyMeasurable.indicator hs, lt_of_le_of_lt (eLpNorm_indicator_le f) hf.eLpNorm_lt_top⟩
+
+lemma memℒp_indicator_iff_restrict (hs : MeasurableSet s) :
+    Memℒp (s.indicator f) p μ ↔ Memℒp f p (μ.restrict s) := by
+  simp [Memℒp, aestronglyMeasurable_indicator_iff hs, eLpNorm_indicator_eq_eLpNorm_restrict hs]
+
+lemma memℒp_indicator_const (p : ℝ≥0∞) (hs : MeasurableSet s) (c : E) (hμsc : c = 0 ∨ μ s ≠ ∞) :
+    Memℒp (s.indicator fun _ => c) p μ := by
+  rw [memℒp_indicator_iff_restrict hs]
+  obtain rfl | hμ := hμsc
+  · exact zero_memℒp
+  · have := Fact.mk hμ.lt_top
+    apply memℒp_const
+
+lemma eLpNormEssSup_piecewise (f g : α → E) [DecidablePred (· ∈ s)] (hs : MeasurableSet s) :
+    eLpNormEssSup (Set.piecewise s f g) μ
+      = max (eLpNormEssSup f (μ.restrict s)) (eLpNormEssSup g (μ.restrict sᶜ)) := by
+  simp only [eLpNormEssSup, ← ENNReal.essSup_piecewise hs]
+  congr with x
+  by_cases hx : x ∈ s <;> simp [hx]
+
+lemma eLpNorm_top_piecewise (f g : α → E) [DecidablePred (· ∈ s)] (hs : MeasurableSet s) :
+    eLpNorm (Set.piecewise s f g) ∞ μ
+      = max (eLpNorm f ∞ (μ.restrict s)) (eLpNorm g ∞ (μ.restrict sᶜ)) :=
+  eLpNormEssSup_piecewise f g hs
+
+protected lemma Memℒp.piecewise [DecidablePred (· ∈ s)] {g} (hs : MeasurableSet s)
+   (hf : Memℒp f p (μ.restrict s)) (hg : Memℒp g p (μ.restrict sᶜ)) :
+    Memℒp (s.piecewise f g) p μ := by
+  by_cases hp_zero : p = 0
+  · simp only [hp_zero, memℒp_zero_iff_aestronglyMeasurable]
+    exact AEStronglyMeasurable.piecewise hs hf.1 hg.1
+  refine ⟨AEStronglyMeasurable.piecewise hs hf.1 hg.1, ?_⟩
+  obtain rfl | hp_top := eq_or_ne p ∞
+  · rw [eLpNorm_top_piecewise f g hs]
+    exact max_lt hf.2 hg.2
+  rw [eLpNorm_lt_top_iff_lintegral_rpow_nnnorm_lt_top hp_zero hp_top, ← lintegral_add_compl _ hs,
+    ENNReal.add_lt_top]
+  constructor
+  · have h : ∀ᵐ x ∂μ, x ∈ s →
+        (‖Set.piecewise s f g x‖₊ : ℝ≥0∞) ^ p.toReal = (‖f x‖₊ : ℝ≥0∞) ^ p.toReal := by
+      filter_upwards with a ha using by simp [ha]
+    rw [setLIntegral_congr_fun hs h]
+    exact lintegral_rpow_nnnorm_lt_top_of_eLpNorm_lt_top hp_zero hp_top hf.2
+  · have h : ∀ᵐ x ∂μ, x ∈ sᶜ →
+        (‖Set.piecewise s f g x‖₊ : ℝ≥0∞) ^ p.toReal = (‖g x‖₊ : ℝ≥0∞) ^ p.toReal := by
+      filter_upwards with a ha
+      have ha' : a ∉ s := ha
+      simp [ha']
+    rw [setLIntegral_congr_fun hs.compl h]
+    exact lintegral_rpow_nnnorm_lt_top_of_eLpNorm_lt_top hp_zero hp_top hg.2
+
+end Indicator
 
 /-- For a function `f` with support in `s`, the Lᵖ norms of `f` with respect to `μ` and
 `μ.restrict s` are the same. -/
@@ -1048,26 +1188,6 @@ lemma eLpNorm_lt_top_of_finite [Finite α] [IsFiniteMeasure μ] : eLpNorm f p μ
 
 @[simp] lemma eLpNorm_of_isEmpty [IsEmpty α] (f : α → E) (p : ℝ≥0∞) : eLpNorm f p μ = 0 := by
   simp [Subsingleton.elim f 0]
-
-lemma eLpNormEssSup_piecewise {s : Set α} (f g : α → E) [DecidablePred (· ∈ s)]
-    (hs : MeasurableSet s) :
-    eLpNormEssSup (Set.piecewise s f g) μ
-      = max (eLpNormEssSup f (μ.restrict s)) (eLpNormEssSup g (μ.restrict sᶜ)) := by
-  simp only [eLpNormEssSup, ← ENNReal.essSup_piecewise hs]
-  congr with x
-  by_cases hx : x ∈ s <;> simp [hx]
-
-@[deprecated (since := "2024-07-27")]
-alias snormEssSup_piecewise := eLpNormEssSup_piecewise
-
-lemma eLpNorm_top_piecewise {s : Set α} (f g : α → E) [DecidablePred (· ∈ s)]
-    (hs : MeasurableSet s) :
-    eLpNorm (Set.piecewise s f g) ∞ μ
-      = max (eLpNorm f ∞ (μ.restrict s)) (eLpNorm g ∞ (μ.restrict sᶜ)) :=
-  eLpNormEssSup_piecewise f g hs
-
-@[deprecated (since := "2024-07-27")]
-alias snorm_top_piecewise := eLpNorm_top_piecewise
 
 section MapMeasure
 
@@ -1462,8 +1582,8 @@ theorem Memℒp.exists_eLpNorm_indicator_compl_lt {β : Type*} [NormedAddCommGro
       · exact ((eLpNorm_lt_top_iff_lintegral_rpow_nnnorm_lt_top hp₀ hp_top).1 hf.2).ne
       · simp [*]
     refine ⟨s, hsm, hs, ?_⟩
-    rwa [eLpNorm_indicator_eq_restrict hsm.compl, eLpNorm_eq_lintegral_rpow_nnnorm hp₀ hp_top,
-      one_div, ENNReal.rpow_inv_lt_iff]
+    rwa [eLpNorm_indicator_eq_eLpNorm_restrict hsm.compl,
+      eLpNorm_eq_lintegral_rpow_nnnorm hp₀ hp_top, one_div, ENNReal.rpow_inv_lt_iff]
     simp [ENNReal.toReal_pos, *]
 
 @[deprecated (since := "2024-07-27")]
@@ -1473,3 +1593,5 @@ end UnifTight
 end ℒp
 
 end MeasureTheory
+
+set_option linter.style.longFile 1700

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/CompareExp.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/CompareExp.lean
@@ -132,7 +132,7 @@ theorem eLpNorm'_lt_top_of_eLpNorm'_lt_top_of_exponent_le {p q : ℝ} [IsFiniteM
 alias snorm'_lt_top_of_snorm'_lt_top_of_exponent_le :=
   eLpNorm'_lt_top_of_eLpNorm'_lt_top_of_exponent_le
 
-theorem Memℒp.memℒp_of_exponent_le {p q : ℝ≥0∞} [IsFiniteMeasure μ] {f : α → E} (hfq : Memℒp f q μ)
+theorem Memℒp.mono_exponent {p q : ℝ≥0∞} [IsFiniteMeasure μ] {f : α → E} (hfq : Memℒp f q μ)
     (hpq : p ≤ q) : Memℒp f p μ := by
   cases' hfq with hfq_m hfq_lt_top
   by_cases hp0 : p = 0
@@ -159,6 +159,25 @@ theorem Memℒp.memℒp_of_exponent_le {p q : ℝ≥0∞} [IsFiniteMeasure μ] {
   rw [eLpNorm_eq_eLpNorm' hp0 hp_top]
   rw [eLpNorm_eq_eLpNorm' hq0 hq_top] at hfq_lt_top
   exact eLpNorm'_lt_top_of_eLpNorm'_lt_top_of_exponent_le hfq_m hfq_lt_top hp_pos.le hpq_real
+
+@[deprecated (since := "2025-01-07")] alias Memℒp.memℒp_of_exponent_le := Memℒp.mono_exponent
+
+/-- If a function is supported on a finite-measure set and belongs to `ℒ^p`, then it belongs to
+`ℒ^q` for any `q ≤ p`. -/
+lemma Memℒp.mono_exponent_of_measure_support_ne_top {p q : ℝ≥0∞} {f : α → E} (hfq : Memℒp f q μ)
+    {s : Set α} (hf : ∀ x, x ∉ s → f x = 0) (hs : μ s ≠ ∞) (hpq : p ≤ q) : Memℒp f p μ := by
+  have : (toMeasurable μ s).indicator f = f := by
+    apply Set.indicator_eq_self.2
+    apply Function.support_subset_iff'.2 fun x hx ↦ hf x ?_
+    contrapose! hx
+    exact subset_toMeasurable μ s hx
+  rw [← this, memℒp_indicator_iff_restrict (measurableSet_toMeasurable μ s)] at hfq ⊢
+  have : Fact (μ (toMeasurable μ s) < ∞) := ⟨by simpa [lt_top_iff_ne_top] using hs⟩
+  exact hfq.mono_exponent hpq
+
+@[deprecated (since := "2025-01-07")]
+alias Memℒp.memℒp_of_exponent_le_of_measure_support_ne_top :=
+  Memℒp.mono_exponent_of_measure_support_ne_top
 
 end SameSpace
 

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -495,6 +495,37 @@ For a set `s` with `(hs : MeasurableSet s)` and `(hμs : μ s < ∞)`, we build
 `indicatorConstLp p hs hμs c`, the element of `Lp` corresponding to `s.indicator (fun _ => c)`.
 -/
 
+@[deprecated (since := "2024-07-27")]
+alias snormEssSup_indicator_le := eLpNormEssSup_indicator_le
+
+@[deprecated (since := "2024-07-27")]
+alias snormEssSup_indicator_const_le := eLpNormEssSup_indicator_const_le
+
+@[deprecated (since := "2024-07-27")]
+alias snormEssSup_indicator_const_eq := eLpNormEssSup_indicator_const_eq
+
+@[deprecated (since := "2024-07-27")]
+alias snorm_indicator_le := eLpNorm_indicator_le
+
+@[deprecated (since := "2024-07-27")]
+alias snorm_indicator_const₀ := eLpNorm_indicator_const₀
+
+@[deprecated (since := "2024-07-27")]
+alias snorm_indicator_const := eLpNorm_indicator_const
+
+@[deprecated (since := "2024-07-27")]
+alias snorm_indicator_const' := eLpNorm_indicator_const'
+
+@[deprecated (since := "2024-07-27")]
+alias snorm_indicator_const_le := eLpNorm_indicator_const_le
+
+@[deprecated (since := "2024-07-27")]
+alias snormEssSup_indicator_eq_snormEssSup_restrict :=
+  eLpNormEssSup_indicator_eq_eLpNormEssSup_restrict
+
+@[deprecated (since := "2024-07-27")]
+alias snorm_indicator_eq_snorm_restrict := eLpNorm_indicator_eq_eLpNorm_restrict
+
 /-- The `ℒ^p` norm of the indicator of a set is uniformly small if the set itself has small measure,
 for any `p < ∞`. Given here as an existential `∀ ε > 0, ∃ η > 0, ...` to avoid later
 management of `ℝ≥0∞`-arithmetic. -/

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -170,7 +170,7 @@ theorem mem_Lp_iff_memℒp {f : α →ₘ[μ] E} : f ∈ Lp E p μ ↔ Memℒp f
   simp [mem_Lp_iff_eLpNorm_lt_top, Memℒp, f.stronglyMeasurable.aestronglyMeasurable]
 
 protected theorem antitone [IsFiniteMeasure μ] {p q : ℝ≥0∞} (hpq : p ≤ q) : Lp E q μ ≤ Lp E p μ :=
-  fun f hf => (Memℒp.memℒp_of_exponent_le ⟨f.aestronglyMeasurable, hf⟩ hpq).2
+  fun f hf => (Memℒp.mono_exponent ⟨f.aestronglyMeasurable, hf⟩ hpq).2
 
 @[simp]
 theorem coeFn_mk {f : α →ₘ[μ] E} (hf : eLpNorm f p μ < ∞) : ((⟨f, hf⟩ : Lp E p μ) : α → E) = f :=
@@ -495,165 +495,6 @@ For a set `s` with `(hs : MeasurableSet s)` and `(hμs : μ s < ∞)`, we build
 `indicatorConstLp p hs hμs c`, the element of `Lp` corresponding to `s.indicator (fun _ => c)`.
 -/
 
-
-section Indicator
-
-variable {c : E} {f : α → E} {hf : AEStronglyMeasurable f μ} {s : Set α}
-
-theorem eLpNormEssSup_indicator_le (s : Set α) (f : α → G) :
-    eLpNormEssSup (s.indicator f) μ ≤ eLpNormEssSup f μ := by
-  refine essSup_mono_ae (Eventually.of_forall fun x => ?_)
-  simp_rw [enorm_eq_nnnorm, ENNReal.coe_le_coe, nnnorm_indicator_eq_indicator_nnnorm]
-  exact Set.indicator_le_self s _ x
-
-@[deprecated (since := "2024-07-27")]
-alias snormEssSup_indicator_le := eLpNormEssSup_indicator_le
-
-theorem eLpNormEssSup_indicator_const_le (s : Set α) (c : G) :
-    eLpNormEssSup (s.indicator fun _ : α => c) μ ≤ ‖c‖₊ := by
-  by_cases hμ0 : μ = 0
-  · rw [hμ0, eLpNormEssSup_measure_zero]
-    exact zero_le _
-  · exact (eLpNormEssSup_indicator_le s fun _ => c).trans (eLpNormEssSup_const c hμ0).le
-
-@[deprecated (since := "2024-07-27")]
-alias snormEssSup_indicator_const_le := eLpNormEssSup_indicator_const_le
-
-theorem eLpNormEssSup_indicator_const_eq (s : Set α) (c : G) (hμs : μ s ≠ 0) :
-    eLpNormEssSup (s.indicator fun _ : α => c) μ = ‖c‖₊ := by
-  refine le_antisymm (eLpNormEssSup_indicator_const_le s c) ?_
-  by_contra! h
-  have h' := ae_iff.mp (ae_lt_of_essSup_lt h)
-  push_neg at h'
-  refine hμs (measure_mono_null (fun x hx_mem => ?_) h')
-  rw [Set.mem_setOf_eq, Set.indicator_of_mem hx_mem, enorm_eq_nnnorm]
-
-@[deprecated (since := "2024-07-27")]
-alias snormEssSup_indicator_const_eq := eLpNormEssSup_indicator_const_eq
-
-theorem eLpNorm_indicator_le (f : α → E) : eLpNorm (s.indicator f) p μ ≤ eLpNorm f p μ := by
-  refine eLpNorm_mono_ae (Eventually.of_forall fun x => ?_)
-  suffices ‖s.indicator f x‖₊ ≤ ‖f x‖₊ by exact NNReal.coe_mono this
-  rw [nnnorm_indicator_eq_indicator_nnnorm]
-  exact s.indicator_le_self _ x
-
-@[deprecated (since := "2024-07-27")]
-alias snorm_indicator_le := eLpNorm_indicator_le
-
-lemma eLpNorm_indicator_const₀ {c : G} (hs : NullMeasurableSet s μ) (hp : p ≠ 0) (hp_top : p ≠ ∞) :
-    eLpNorm (s.indicator fun _ => c) p μ = ‖c‖₊ * μ s ^ (1 / p.toReal) :=
-  have hp_pos : 0 < p.toReal := ENNReal.toReal_pos hp hp_top
-  calc
-    eLpNorm (s.indicator fun _ => c) p μ
-      = (∫⁻ x, ((‖(s.indicator fun _ ↦ c) x‖₊ : ℝ≥0∞) ^ p.toReal) ∂μ) ^ (1 / p.toReal) :=
-          eLpNorm_eq_lintegral_rpow_nnnorm hp hp_top
-    _ = (∫⁻ x, (s.indicator fun _ ↦ (‖c‖₊ : ℝ≥0∞) ^ p.toReal) x ∂μ) ^ (1 / p.toReal) := by
-      congr 2
-      refine (Set.comp_indicator_const c (fun x : G ↦ (‖x‖₊ : ℝ≥0∞) ^ p.toReal) ?_)
-      simp [hp_pos]
-    _ = ‖c‖₊ * μ s ^ (1 / p.toReal) := by
-      rw [lintegral_indicator_const₀ hs, ENNReal.mul_rpow_of_nonneg, ← ENNReal.rpow_mul,
-        mul_one_div_cancel hp_pos.ne', ENNReal.rpow_one]
-      positivity
-
-@[deprecated (since := "2024-07-27")]
-alias snorm_indicator_const₀ := eLpNorm_indicator_const₀
-
-theorem eLpNorm_indicator_const {c : G} (hs : MeasurableSet s) (hp : p ≠ 0) (hp_top : p ≠ ∞) :
-    eLpNorm (s.indicator fun _ => c) p μ = ‖c‖₊ * μ s ^ (1 / p.toReal) :=
-  eLpNorm_indicator_const₀ hs.nullMeasurableSet hp hp_top
-
-@[deprecated (since := "2024-07-27")]
-alias snorm_indicator_const := eLpNorm_indicator_const
-
-theorem eLpNorm_indicator_const' {c : G} (hs : MeasurableSet s) (hμs : μ s ≠ 0) (hp : p ≠ 0) :
-    eLpNorm (s.indicator fun _ => c) p μ = ‖c‖₊ * μ s ^ (1 / p.toReal) := by
-  by_cases hp_top : p = ∞
-  · simp [hp_top, eLpNormEssSup_indicator_const_eq s c hμs]
-  · exact eLpNorm_indicator_const hs hp hp_top
-
-@[deprecated (since := "2024-07-27")]
-alias snorm_indicator_const' := eLpNorm_indicator_const'
-
-theorem eLpNorm_indicator_const_le (c : G) (p : ℝ≥0∞) :
-    eLpNorm (s.indicator fun _ => c) p μ ≤ ‖c‖₊ * μ s ^ (1 / p.toReal) := by
-  rcases eq_or_ne p 0 with (rfl | hp)
-  · simp only [eLpNorm_exponent_zero, zero_le']
-  rcases eq_or_ne p ∞ with (rfl | h'p)
-  · simp only [eLpNorm_exponent_top, ENNReal.top_toReal, _root_.div_zero, ENNReal.rpow_zero,
-      mul_one]
-    exact eLpNormEssSup_indicator_const_le _ _
-  let t := toMeasurable μ s
-  calc
-    eLpNorm (s.indicator fun _ => c) p μ ≤ eLpNorm (t.indicator fun _ => c) p μ :=
-      eLpNorm_mono (norm_indicator_le_of_subset (subset_toMeasurable _ _) _)
-    _ = ‖c‖₊ * μ t ^ (1 / p.toReal) :=
-      (eLpNorm_indicator_const (measurableSet_toMeasurable _ _) hp h'p)
-    _ = ‖c‖₊ * μ s ^ (1 / p.toReal) := by rw [measure_toMeasurable]
-
-@[deprecated (since := "2024-07-27")]
-alias snorm_indicator_const_le := eLpNorm_indicator_const_le
-
-theorem Memℒp.indicator (hs : MeasurableSet s) (hf : Memℒp f p μ) : Memℒp (s.indicator f) p μ :=
-  ⟨hf.aestronglyMeasurable.indicator hs, lt_of_le_of_lt (eLpNorm_indicator_le f) hf.eLpNorm_lt_top⟩
-
-theorem eLpNormEssSup_indicator_eq_eLpNormEssSup_restrict {f : α → F} (hs : MeasurableSet s) :
-    eLpNormEssSup (s.indicator f) μ = eLpNormEssSup f (μ.restrict s) := by
-  simp_rw [eLpNormEssSup_eq_essSup_nnnorm, nnnorm_indicator_eq_indicator_nnnorm,
-    ENNReal.coe_indicator, ENNReal.essSup_indicator_eq_essSup_restrict hs]
-
-@[deprecated (since := "2024-07-27")]
-alias snormEssSup_indicator_eq_snormEssSup_restrict :=
-  eLpNormEssSup_indicator_eq_eLpNormEssSup_restrict
-
-theorem eLpNorm_indicator_eq_eLpNorm_restrict {f : α → F} (hs : MeasurableSet s) :
-    eLpNorm (s.indicator f) p μ = eLpNorm f p (μ.restrict s) := by
-  by_cases hp_zero : p = 0
-  · simp only [hp_zero, eLpNorm_exponent_zero]
-  by_cases hp_top : p = ∞
-  · simp_rw [hp_top, eLpNorm_exponent_top]
-    exact eLpNormEssSup_indicator_eq_eLpNormEssSup_restrict hs
-  simp_rw [eLpNorm_eq_lintegral_rpow_nnnorm hp_zero hp_top]
-  suffices (∫⁻ x, (‖s.indicator f x‖₊ : ℝ≥0∞) ^ p.toReal ∂μ) =
-      ∫⁻ x in s, (‖f x‖₊ : ℝ≥0∞) ^ p.toReal ∂μ by rw [this]
-  rw [← lintegral_indicator hs]
-  congr
-  simp_rw [nnnorm_indicator_eq_indicator_nnnorm, ENNReal.coe_indicator]
-  have h_zero : (fun x => x ^ p.toReal) (0 : ℝ≥0∞) = 0 := by
-    simp [ENNReal.toReal_pos hp_zero hp_top]
-  -- Porting note: The implicit argument should be specified because the elaborator can't deal with
-  --               `∘` well.
-  exact (Set.indicator_comp_of_zero (g := fun x : ℝ≥0∞ => x ^ p.toReal) h_zero).symm
-
-@[deprecated (since := "2024-07-27")]
-alias snorm_indicator_eq_snorm_restrict := eLpNorm_indicator_eq_eLpNorm_restrict
-
-theorem memℒp_indicator_iff_restrict (hs : MeasurableSet s) :
-    Memℒp (s.indicator f) p μ ↔ Memℒp f p (μ.restrict s) := by
-  simp [Memℒp, aestronglyMeasurable_indicator_iff hs, eLpNorm_indicator_eq_eLpNorm_restrict hs]
-
-/-- If a function is supported on a finite-measure set and belongs to `ℒ^p`, then it belongs to
-`ℒ^q` for any `q ≤ p`. -/
-theorem Memℒp.memℒp_of_exponent_le_of_measure_support_ne_top
-    {p q : ℝ≥0∞} {f : α → E} (hfq : Memℒp f q μ) {s : Set α} (hf : ∀ x, x ∉ s → f x = 0)
-    (hs : μ s ≠ ∞) (hpq : p ≤ q) : Memℒp f p μ := by
-  have : (toMeasurable μ s).indicator f = f := by
-    apply Set.indicator_eq_self.2
-    apply Function.support_subset_iff'.2 (fun x hx ↦ hf x ?_)
-    contrapose! hx
-    exact subset_toMeasurable μ s hx
-  rw [← this, memℒp_indicator_iff_restrict (measurableSet_toMeasurable μ s)] at hfq ⊢
-  have : Fact (μ (toMeasurable μ s) < ∞) := ⟨by simpa [lt_top_iff_ne_top] using hs⟩
-  exact memℒp_of_exponent_le hfq hpq
-
-theorem memℒp_indicator_const (p : ℝ≥0∞) (hs : MeasurableSet s) (c : E) (hμsc : c = 0 ∨ μ s ≠ ∞) :
-    Memℒp (s.indicator fun _ => c) p μ := by
-  rw [memℒp_indicator_iff_restrict hs]
-  rcases hμsc with rfl | hμ
-  · exact zero_memℒp
-  · have := Fact.mk hμ.lt_top
-    apply memℒp_const
-
 /-- The `ℒ^p` norm of the indicator of a set is uniformly small if the set itself has small measure,
 for any `p < ∞`. Given here as an existential `∀ ε > 0, ∃ η > 0, ...` to avoid later
 management of `ℝ≥0∞`-arithmetic. -/
@@ -685,34 +526,6 @@ theorem exists_eLpNorm_indicator_le (hp : p ≠ ∞) (c : E) {ε : ℝ≥0∞} (
 @[deprecated (since := "2024-07-27")]
 alias exists_snorm_indicator_le := exists_eLpNorm_indicator_le
 
-protected lemma Memℒp.piecewise [DecidablePred (· ∈ s)] {g}
-    (hs : MeasurableSet s) (hf : Memℒp f p (μ.restrict s)) (hg : Memℒp g p (μ.restrict sᶜ)) :
-    Memℒp (s.piecewise f g) p μ := by
-  by_cases hp_zero : p = 0
-  · simp only [hp_zero, memℒp_zero_iff_aestronglyMeasurable]
-    exact AEStronglyMeasurable.piecewise hs hf.1 hg.1
-  refine ⟨AEStronglyMeasurable.piecewise hs hf.1 hg.1, ?_⟩
-  rcases eq_or_ne p ∞ with rfl | hp_top
-  · rw [eLpNorm_top_piecewise f g hs]
-    exact max_lt hf.2 hg.2
-  rw [eLpNorm_lt_top_iff_lintegral_rpow_nnnorm_lt_top hp_zero hp_top, ← lintegral_add_compl _ hs,
-    ENNReal.add_lt_top]
-  constructor
-  · have h : ∀ᵐ (x : α) ∂μ, x ∈ s →
-        (‖Set.piecewise s f g x‖₊ : ℝ≥0∞) ^ p.toReal = (‖f x‖₊ : ℝ≥0∞) ^ p.toReal := by
-      filter_upwards with a ha using by simp [ha]
-    rw [setLIntegral_congr_fun hs h]
-    exact lintegral_rpow_nnnorm_lt_top_of_eLpNorm_lt_top hp_zero hp_top hf.2
-  · have h : ∀ᵐ (x : α) ∂μ, x ∈ sᶜ →
-        (‖Set.piecewise s f g x‖₊ : ℝ≥0∞) ^ p.toReal = (‖g x‖₊ : ℝ≥0∞) ^ p.toReal := by
-      filter_upwards with a ha
-      have ha' : a ∉ s := ha
-      simp [ha']
-    rw [setLIntegral_congr_fun hs.compl h]
-    exact lintegral_rpow_nnnorm_lt_top_of_eLpNorm_lt_top hp_zero hp_top hg.2
-
-end Indicator
-
 section Topology
 variable {X : Type*} [TopologicalSpace X] [MeasurableSpace X]
   {μ : Measure X} [IsFiniteMeasureOnCompacts μ]
@@ -721,14 +534,14 @@ variable {X : Type*} [TopologicalSpace X] [MeasurableSpace X]
 theorem _root_.HasCompactSupport.memℒp_of_bound {f : X → E} (hf : HasCompactSupport f)
     (h2f : AEStronglyMeasurable f μ) (C : ℝ) (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) : Memℒp f p μ := by
   have := memℒp_top_of_bound h2f C hfC
-  exact this.memℒp_of_exponent_le_of_measure_support_ne_top
+  exact this.mono_exponent_of_measure_support_ne_top
     (fun x ↦ image_eq_zero_of_nmem_tsupport) (hf.measure_lt_top.ne) le_top
 
 /-- A continuous function with compact support is in L^p. -/
 theorem _root_.Continuous.memℒp_of_hasCompactSupport [OpensMeasurableSpace X]
     {f : X → E} (hf : Continuous f) (h'f : HasCompactSupport f) : Memℒp f p μ := by
   have := hf.memℒp_top_of_hasCompactSupport h'f μ
-  exact this.memℒp_of_exponent_le_of_measure_support_ne_top
+  exact this.mono_exponent_of_measure_support_ne_top
     (fun x ↦ image_eq_zero_of_nmem_tsupport) (h'f.measure_lt_top.ne) le_top
 
 end Topology
@@ -1926,4 +1739,4 @@ end Lp
 
 end MeasureTheory
 
-set_option linter.style.longFile 2100
+set_option linter.style.longFile 1900

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -332,7 +332,7 @@ theorem integrableOn_Lp_of_measure_ne_top {E} [NormedAddCommGroup E] {p : ℝ≥
   have hμ_restrict_univ : (μ.restrict s) Set.univ < ∞ := by
     simpa only [Set.univ_inter, MeasurableSet.univ, Measure.restrict_apply, lt_top_iff_ne_top]
   haveI hμ_finite : IsFiniteMeasure (μ.restrict s) := ⟨hμ_restrict_univ⟩
-  exact ((Lp.memℒp _).restrict s).memℒp_of_exponent_le hp
+  exact ((Lp.memℒp _).restrict s).mono_exponent hp
 
 theorem Integrable.lintegral_lt_top {f : α → ℝ} (hf : Integrable f μ) :
     (∫⁻ x, ENNReal.ofReal (f x) ∂μ) < ∞ :=


### PR DESCRIPTION
`MeasureTheory.Function.LpSpace` is supposed to be about the L^p space itself, but contains a bunch of results about the L^p norm as well. Move those results to `MeasureTheory.Function.LpSeminorm.Basic` and `MeasureTheory.Function.LpSeminorm.CompareExp`. Also rename lemmas about nesting of L^p norms.

From LeanAPAP

Moves:
* `Memℒp.memℒp_of_exponent_le_of_measure_support_ne_top` -> `Memℒp.mono_exponent_of_measure_support_ne_top`
* `Memℒp.memℒp_of_exponent_le` -> `Memℒp.mono_exponent`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
