### PR TITLE
[Merged by Bors] - chore: to_additive various results on groups, group actions

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/Blocks.lean
+++ b/Mathlib/GroupTheory/GroupAction/Blocks.lean
@@ -353,7 +353,7 @@ theorem _root_.AddAction.IsBlock.translate
     AddAction.IsBlock G (g +ᵥ B) := by
   rw [← AddAction.isBlock_top] at hB ⊢
   rw [← AddSubgroup.map_comap_eq_self_of_surjective (G := G) ?_ ⊤]
-  · apply AddAction.IsBlock.of_addsubgroup_of_conjugate
+  · apply AddAction.IsBlock.of_addSubgroup_of_conjugate
     rwa [AddSubgroup.comap_top]
   · exact (AddAut.conj g).surjective
 

--- a/Mathlib/GroupTheory/GroupAction/Blocks.lean
+++ b/Mathlib/GroupTheory/GroupAction/Blocks.lean
@@ -311,7 +311,7 @@ theorem isBlock_subtypeVal {C : SubMulAction G X} {B : Set C} :
   rw [← SubMulAction.inclusion.coe_eq, ← image_smul_set, ← image_smul_set, ne_eq,
     Set.image_eq_image C.inclusion_injective, disjoint_image_iff C.inclusion_injective]
 
-theorem _root_.AddAction.IsBlock.of_addsubgroup_of_conjugate
+theorem _root_.AddAction.IsBlock.of_addSubgroup_of_conjugate
     {G : Type*} [AddGroup G] {X : Type*} [AddAction G X] {B : Set X}
     {H : AddSubgroup G} (hB : AddAction.IsBlock H B) (g : G) :
     AddAction.IsBlock (H.map (AddAut.conj g).toAddMonoidHom) (g +ᵥ B) := by
@@ -330,7 +330,7 @@ theorem _root_.AddAction.IsBlock.of_addsubgroup_of_conjugate
   erw [AddAut.conj_apply]
   simp
 
-@[to_additive existing AddAction.IsBlock.of_addsubgroup_of_conjugate]
+@[to_additive existing]
 theorem IsBlock.of_subgroup_of_conjugate {H : Subgroup G} (hB : IsBlock H B) (g : G) :
     IsBlock (H.map (MulAut.conj g).toMonoidHom) (g • B) := by
   rw [isBlock_iff_smul_eq_or_disjoint]

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
@@ -154,13 +154,6 @@ end OfTower
 
 end SetLike
 
-/-- A SubMulAction is a set which is closed under scalar multiplication. -/
-structure SubMulAction (R : Type u) (M : Type v) [SMul R M] : Type v where
-  /-- The underlying set of a `SubMulAction`. -/
-  carrier : Set M
-  /-- The carrier set is closed under scalar multiplication. -/
-  smul_mem' : ∀ (c : R) {x : M}, x ∈ carrier → c • x ∈ carrier
-
 /-- A SubAddAction is a set which is closed under scalar multiplication. -/
 structure SubAddAction (R : Type u) (M : Type v) [VAdd R M] : Type v where
   /-- The underlying set of a `SubAddAction`. -/
@@ -168,7 +161,13 @@ structure SubAddAction (R : Type u) (M : Type v) [VAdd R M] : Type v where
   /-- The carrier set is closed under scalar multiplication. -/
   vadd_mem' : ∀ (c : R) {x : M}, x ∈ carrier → c +ᵥ x ∈ carrier
 
-attribute [to_additive] SubMulAction
+/-- A SubMulAction is a set which is closed under scalar multiplication. -/
+@[to_additive]
+structure SubMulAction (R : Type u) (M : Type v) [SMul R M] : Type v where
+  /-- The underlying set of a `SubMulAction`. -/
+  carrier : Set M
+  /-- The carrier set is closed under scalar multiplication. -/
+  smul_mem' : ∀ (c : R) {x : M}, x ∈ carrier → c • x ∈ carrier
 
 namespace SubMulAction
 


### PR DESCRIPTION
Two adjustments to  #20498 that had been requested by Yaël but hadn't been implemented on time before merge.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
