### PR TITLE
[Merged by Bors] - chore: move results about `DivisionMonoid` + `HasDistribNeg`

### DIFF
--- a/Mathlib/Algebra/Field/Basic.lean
+++ b/Mathlib/Algebra/Field/Basic.lean
@@ -73,47 +73,6 @@ protected theorem Commute.inv_add_inv (hab : Commute a b) (ha : a ≠ 0) (hb : b
 
 end DivisionSemiring
 
-section DivisionMonoid
-
-variable [DivisionMonoid K] [HasDistribNeg K] {a b : K}
-
-theorem one_div_neg_one_eq_neg_one : (1 : K) / -1 = -1 :=
-  have : -1 * -1 = (1 : K) := by rw [neg_mul_neg, one_mul]
-  Eq.symm (eq_one_div_of_mul_eq_one_right this)
-
-theorem one_div_neg_eq_neg_one_div (a : K) : 1 / -a = -(1 / a) :=
-  calc
-    1 / -a = 1 / (-1 * a) := by rw [neg_eq_neg_one_mul]
-    _ = 1 / a * (1 / -1) := by rw [one_div_mul_one_div_rev]
-    _ = 1 / a * -1 := by rw [one_div_neg_one_eq_neg_one]
-    _ = -(1 / a) := by rw [mul_neg, mul_one]
-
-theorem div_neg_eq_neg_div (a b : K) : b / -a = -(b / a) :=
-  calc
-    b / -a = b * (1 / -a) := by rw [← inv_eq_one_div, division_def]
-    _ = b * -(1 / a) := by rw [one_div_neg_eq_neg_one_div]
-    _ = -(b * (1 / a)) := by rw [neg_mul_eq_mul_neg]
-    _ = -(b / a) := by rw [mul_one_div]
-
-theorem neg_div (a b : K) : -b / a = -(b / a) := by
-  rw [neg_eq_neg_one_mul, mul_div_assoc, ← neg_eq_neg_one_mul]
-
-@[field_simps]
-theorem neg_div' (a b : K) : -(b / a) = -b / a := by simp [neg_div]
-
-@[simp]
-theorem neg_div_neg_eq (a b : K) : -a / -b = a / b := by rw [div_neg_eq_neg_div, neg_div, neg_neg]
-
-theorem neg_inv : -a⁻¹ = (-a)⁻¹ := by rw [inv_eq_one_div, inv_eq_one_div, div_neg_eq_neg_div]
-
-theorem div_neg (a : K) : a / -b = -(a / b) := by rw [← div_neg_eq_neg_div]
-
-theorem inv_neg : (-a)⁻¹ = -a⁻¹ := by rw [neg_inv]
-
-theorem inv_neg_one : (-1 : K)⁻¹ = -1 := by rw [← neg_inv, inv_one]
-
-end DivisionMonoid
-
 section DivisionRing
 
 variable [DivisionRing K] {a b c d : K}

--- a/Mathlib/Algebra/Module/Basic.lean
+++ b/Mathlib/Algebra/Module/Basic.lean
@@ -3,12 +3,13 @@ Copyright (c) 2015 Nathaniel Thomas. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
 -/
-import Mathlib.Algebra.Field.Basic
+import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Group.Action.Pi
 import Mathlib.Algebra.Group.Indicator
 import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.Module.NatInt
 import Mathlib.Algebra.NoZeroSMulDivisors.Defs
+import Mathlib.Algebra.Ring.Invertible
 
 /-!
 # Further basic results about modules.

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -183,3 +183,43 @@ lemma noZeroDivisors_iff_isDomain_or_subsingleton [Ring α] :
   rw [← isCancelMulZero_iff_noZeroDivisors, isCancelMulZero_iff_isDomain_or_subsingleton]
 
 end NoZeroDivisors
+
+section DivisionMonoid
+variable [DivisionMonoid R] [HasDistribNeg R] {a b : R}
+
+lemma one_div_neg_one_eq_neg_one : (1 : R) / -1 = -1 :=
+  have : -1 * -1 = (1 : R) := by rw [neg_mul_neg, one_mul]
+  Eq.symm (eq_one_div_of_mul_eq_one_right this)
+
+lemma one_div_neg_eq_neg_one_div (a : R) : 1 / -a = -(1 / a) :=
+  calc
+    1 / -a = 1 / (-1 * a) := by rw [neg_eq_neg_one_mul]
+    _ = 1 / a * (1 / -1) := by rw [one_div_mul_one_div_rev]
+    _ = 1 / a * -1 := by rw [one_div_neg_one_eq_neg_one]
+    _ = -(1 / a) := by rw [mul_neg, mul_one]
+
+lemma div_neg_eq_neg_div (a b : R) : b / -a = -(b / a) :=
+  calc
+    b / -a = b * (1 / -a) := by rw [← inv_eq_one_div, division_def]
+    _ = b * -(1 / a) := by rw [one_div_neg_eq_neg_one_div]
+    _ = -(b * (1 / a)) := by rw [neg_mul_eq_mul_neg]
+    _ = -(b / a) := by rw [mul_one_div]
+
+lemma neg_div (a b : R) : -b / a = -(b / a) := by
+  rw [neg_eq_neg_one_mul, mul_div_assoc, ← neg_eq_neg_one_mul]
+
+@[field_simps]
+lemma neg_div' (a b : R) : -(b / a) = -b / a := by simp [neg_div]
+
+@[simp]
+lemma neg_div_neg_eq (a b : R) : -a / -b = a / b := by rw [div_neg_eq_neg_div, neg_div, neg_neg]
+
+lemma neg_inv : -a⁻¹ = (-a)⁻¹ := by rw [inv_eq_one_div, inv_eq_one_div, div_neg_eq_neg_div]
+
+lemma div_neg (a : R) : a / -b = -(a / b) := by rw [← div_neg_eq_neg_div]
+
+lemma inv_neg : (-a)⁻¹ = -a⁻¹ := by rw [neg_inv]
+
+lemma inv_neg_one : (-1 : R)⁻¹ = -1 := by rw [← neg_inv, inv_one]
+
+end DivisionMonoid


### PR DESCRIPTION
This way, we don't have to import fields to use those lemmas


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
