### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits/Fubini): relax universes constraints and weaken hypotheses

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -35,14 +35,12 @@ All statements have their counterpart for colimits.
 -/
 
 
-universe v u
-
 open CategoryTheory
 
 namespace CategoryTheory.Limits
 
-variable {J K : Type v} [SmallCategory J] [SmallCategory K]
-variable {C : Type u} [Category.{v} C]
+variable {J K : Type*} [Category J] [Category K]
+variable {C : Type*} [Category C]
 variable (F : J ⥤ K ⥤ C)
 
 -- We could try introducing a "dependent functor type" to handle this?
@@ -486,9 +484,9 @@ end
 
 section
 
-variable [HasLimits C]
+variable [HasLimitsOfShape K C] [HasLimitsOfShape J C] [HasLimitsOfShape (K × J) C] [HasLimit G]
+  [HasLimit (curry.obj G ⋙ lim)]
 
--- Certainly one could weaken the hypotheses here.
 open CategoryTheory.prod
 
 /-- A variant of the Fubini theorem for a functor `G : J × K ⥤ C`,
@@ -525,7 +523,8 @@ end
 
 section
 
-variable [HasColimits C]
+variable [HasColimitsOfShape K C] [HasColimitsOfShape J C] [HasColimitsOfShape (K × J) C]
+  [HasColimit G] [HasColimit (curry.obj G ⋙ colim)]
 
 open CategoryTheory.prod
 


### PR DESCRIPTION
Weaken universes constraints in this file, and weaken the hypotheses on `C` for the Fubini theorems.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
