### PR TITLE
[Merged by Bors] - chore(Algebra/Lie): make IsNilpotent and IsSolvable independent of scalars

### DIFF
--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -221,6 +221,10 @@ theorem lie_jacobi : ⁅x, ⁅y, z⁆⁆ + ⁅y, ⁅z, x⁆⁆ + ⁅z, ⁅x, y�
 
 instance LieRing.instLieAlgebra : LieAlgebra ℤ L where lie_smul n x y := lie_zsmul x y n
 
+instance : LieModule ℤ L M where
+  smul_lie n x m := zsmul_lie x m n
+  lie_smul n x m := lie_zsmul x m n
+
 instance LinearMap.instLieRingModule : LieRingModule L (M →ₗ[R] N) where
   bracket x f :=
     { toFun := fun m => ⁅x, f m⁆ - f ⁅x, m⁆

--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -200,13 +200,11 @@ theorem lie_nsmul (n : ℕ) : ⁅x, n • m⁆ = n • ⁅x, m⁆ :=
     { toFun := fun m : M => ⁅x, m⁆, map_zero' := lie_zero x, map_add' := fun _ _ => lie_add _ _ _}
     _ _
 
-@[simp]
 theorem zsmul_lie (a : ℤ) : ⁅a • x, m⁆ = a • ⁅x, m⁆ :=
   AddMonoidHom.map_zsmul
     { toFun := fun x : L => ⁅x, m⁆, map_zero' := zero_lie m, map_add' := fun _ _ => add_lie _ _ _ }
     _ _
 
-@[simp]
 theorem lie_zsmul (a : ℤ) : ⁅x, a • m⁆ = a • ⁅x, m⁆ :=
   AddMonoidHom.map_zsmul
     { toFun := fun m : M => ⁅x, m⁆, map_zero' := lie_zero x, map_add' := fun _ _ => lie_add _ _ _ }

--- a/Mathlib/Algebra/Lie/CartanSubalgebra.lean
+++ b/Mathlib/Algebra/Lie/CartanSubalgebra.lean
@@ -44,10 +44,10 @@ namespace LieSubalgebra
 
 A _splitting_ Cartan subalgebra can be defined by mixing in `LieModule.IsTriangularizable R H L`. -/
 class IsCartanSubalgebra : Prop where
-  nilpotent : LieAlgebra.IsNilpotent R H
+  nilpotent : LieRing.IsNilpotent H
   self_normalizing : H.normalizer = H
 
-instance [H.IsCartanSubalgebra] : LieAlgebra.IsNilpotent R H :=
+instance [H.IsCartanSubalgebra] : LieRing.IsNilpotent H :=
   IsCartanSubalgebra.nilpotent
 
 @[simp]
@@ -66,7 +66,7 @@ theorem ucs_eq_self_of_isCartanSubalgebra (H : LieSubalgebra R L) [H.IsCartanSub
 theorem isCartanSubalgebra_iff_isUcsLimit : H.IsCartanSubalgebra ↔ H.toLieSubmodule.IsUcsLimit := by
   constructor
   · intro h
-    have h₁ : LieAlgebra.IsNilpotent R H := by infer_instance
+    have h₁ : LieRing.IsNilpotent H := by infer_instance
     obtain ⟨k, hk⟩ := H.toLieSubmodule.isNilpotent_iff_exists_self_le_ucs.mp h₁
     replace hk : H.toLieSubmodule = LieSubmodule.ucs k ⊥ :=
       le_antisymm hk
@@ -77,7 +77,7 @@ theorem isCartanSubalgebra_iff_isUcsLimit : H.IsCartanSubalgebra ↔ H.toLieSubm
   · rintro ⟨k, hk⟩
     exact
       { nilpotent := by
-          dsimp only [LieAlgebra.IsNilpotent]
+          dsimp only [LieRing.IsNilpotent]
           erw [H.toLieSubmodule.isNilpotent_iff_exists_lcs_eq_bot]
           use k
           rw [_root_.eq_bot_iff, LieSubmodule.lcs_le_iff, hk k (le_refl k)]
@@ -113,7 +113,7 @@ theorem LieIdeal.normalizer_eq_top {R : Type u} {L : Type v} [CommRing R] [LieRi
 open LieIdeal
 
 /-- A nilpotent Lie algebra is its own Cartan subalgebra. -/
-instance LieAlgebra.top_isCartanSubalgebra_of_nilpotent [LieAlgebra.IsNilpotent R L] :
+instance LieAlgebra.top_isCartanSubalgebra_of_nilpotent [LieRing.IsNilpotent L] :
     LieSubalgebra.IsCartanSubalgebra (⊤ : LieSubalgebra R L) where
   nilpotent := inferInstance
   self_normalizing := by rw [← top_toLieSubalgebra, normalizer_eq_top, top_toLieSubalgebra]

--- a/Mathlib/Algebra/Lie/Engel.lean
+++ b/Mathlib/Algebra/Lie/Engel.lean
@@ -162,8 +162,7 @@ variable {R L}
 theorem LieAlgebra.isEngelian_of_subsingleton [Subsingleton L] : LieAlgebra.IsEngelian R L := by
   intro M _i1 _i2 _i3 _i4 _h
   use 1
-  suffices (⊤ : LieIdeal R L) = ⊥ by simp [this]
-  subsingleton [(LieSubmodule.subsingleton_iff R L L).mpr inferInstance]
+  simp
 
 theorem Function.Surjective.isEngelian {f : L →ₗ⁅R⁆ L₂} (hf : Function.Surjective f)
     (h : LieAlgebra.IsEngelian.{u₁, u₂, u₄} R L) : LieAlgebra.IsEngelian.{u₁, u₃, u₄} R L₂ := by

--- a/Mathlib/Algebra/Lie/Engel.lean
+++ b/Mathlib/Algebra/Lie/Engel.lean
@@ -124,12 +124,13 @@ theorem lcs_le_lcs_of_is_nilpotent_span_sup_eq_top {n i j : ℕ}
       exact antitone_lowerCentralSeries R L M le_self_add
 
 theorem isNilpotentOfIsNilpotentSpanSupEqTop (hnp : IsNilpotent <| toEnd R L M x)
-    (hIM : IsNilpotent R I M) : IsNilpotent R L M := by
+    (hIM : IsNilpotent I M) : IsNilpotent L M := by
   obtain ⟨n, hn⟩ := hnp
-  obtain ⟨k, hk⟩ := hIM
+  obtain ⟨k, hk⟩ := IsNilpotent.nilpotent R I M
   have hk' : I.lcs M k = ⊥ := by
     simp only [← toSubmodule_inj, I.coe_lcs_eq, hk, bot_toSubmodule]
   suffices ∀ l, lowerCentralSeries R L M (l * n) ≤ I.lcs M l by
+    rw [isNilpotent_iff R]
     use k * n
     simpa [hk'] using this k
   intro l
@@ -154,7 +155,7 @@ Engel's theorem `LieAlgebra.isEngelian_of_isNoetherian` states that any Noetheri
 Engelian. -/
 def LieAlgebra.IsEngelian : Prop :=
   ∀ (M : Type u₄) [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M],
-    (∀ x : L, _root_.IsNilpotent (toEnd R L M x)) → LieModule.IsNilpotent R L M
+    (∀ x : L, _root_.IsNilpotent (toEnd R L M x)) → LieModule.IsNilpotent L M
 
 variable {R L}
 
@@ -171,7 +172,7 @@ theorem Function.Surjective.isEngelian {f : L →ₗ⁅R⁆ L₂} (hf : Function
   letI : LieModule R L M := compLieHom M f
   have hnp : ∀ x, IsNilpotent (toEnd R L M x) := fun x => h' (f x)
   have surj_id : Function.Surjective (LinearMap.id : M →ₗ[R] M) := Function.surjective_id
-  haveI : LieModule.IsNilpotent R L M := h M hnp
+  haveI : LieModule.IsNilpotent L M := h M hnp
   apply hf.lieModuleIsNilpotent surj_id
   -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10745): was `simp`
   intros; simp only [LinearMap.id_coe, id_eq]; rfl
@@ -218,16 +219,16 @@ Note that this implies all traditional forms of Engel's theorem via
 `LieAlgebra.isNilpotent_iff_forall`. -/
 theorem LieAlgebra.isEngelian_of_isNoetherian [IsNoetherian R L] : LieAlgebra.IsEngelian R L := by
   intro M _i1 _i2 _i3 _i4 h
-  rw [← isNilpotent_range_toEnd_iff]
+  rw [← isNilpotent_range_toEnd_iff R]
   let L' := (toEnd R L M).range
   replace h : ∀ y : L', _root_.IsNilpotent (y : Module.End R M) := by
     rintro ⟨-, ⟨y, rfl⟩⟩
     simp [h]
-  change LieModule.IsNilpotent R L' M
+  change LieModule.IsNilpotent L' M
   let s := {K : LieSubalgebra R L' | LieAlgebra.IsEngelian R K}
   have hs : s.Nonempty := ⟨⊥, LieAlgebra.isEngelian_of_subsingleton⟩
   suffices ⊤ ∈ s by
-    rw [← isNilpotent_of_top_iff]
+    rw [← isNilpotent_of_top_iff (R := R)]
     apply this M
     simp [LieSubalgebra.toEnd_eq, h]
   have : ∀ K ∈ s, K ≠ ⊤ → ∃ K' ∈ s, K < K' := by
@@ -242,7 +243,7 @@ theorem LieAlgebra.isEngelian_of_isNoetherian [IsNoetherian R L] : LieAlgebra.Is
           LieSubmodule.top_toSubmodule, ← LieSubalgebra.top_toSubmodule,
           K.toSubmodule_inj]
       exact Submodule.Quotient.nontrivial_of_lt_top _ hK₂.lt_top
-    have : LieModule.IsNilpotent R K (L' ⧸ K.toLieSubmodule) := by
+    have : LieModule.IsNilpotent K (L' ⧸ K.toLieSubmodule) := by
       -- Porting note: was refine' hK₁ _ fun x => _
       apply hK₁
       intro x
@@ -274,18 +275,18 @@ theorem LieAlgebra.isEngelian_of_isNoetherian [IsNoetherian R L] : LieAlgebra.Is
 
 See also `LieModule.isNilpotent_iff_forall'` which assumes that `M` is Noetherian instead of `L`. -/
 theorem LieModule.isNilpotent_iff_forall [IsNoetherian R L] :
-    LieModule.IsNilpotent R L M ↔ ∀ x, _root_.IsNilpotent <| toEnd R L M x :=
+    LieModule.IsNilpotent L M ↔ ∀ x, _root_.IsNilpotent <| toEnd R L M x :=
   ⟨fun _ ↦ isNilpotent_toEnd_of_isNilpotent R L M,
    fun h => LieAlgebra.isEngelian_of_isNoetherian M h⟩
 
 /-- Engel's theorem. -/
 theorem LieModule.isNilpotent_iff_forall' [IsNoetherian R M] :
-    LieModule.IsNilpotent R L M ↔ ∀ x, _root_.IsNilpotent <| toEnd R L M x := by
-  rw [← isNilpotent_range_toEnd_iff, LieModule.isNilpotent_iff_forall]; simp
+    LieModule.IsNilpotent L M ↔ ∀ x, _root_.IsNilpotent <| toEnd R L M x := by
+  rw [← isNilpotent_range_toEnd_iff (R := R), LieModule.isNilpotent_iff_forall (R := R)]; simp
 
 /-- Engel's theorem. -/
 theorem LieAlgebra.isNilpotent_iff_forall [IsNoetherian R L] :
-    LieAlgebra.IsNilpotent R L ↔ ∀ x, _root_.IsNilpotent <| LieAlgebra.ad R L x :=
+    LieRing.IsNilpotent L ↔ ∀ x, _root_.IsNilpotent <| LieAlgebra.ad R L x :=
   LieModule.isNilpotent_iff_forall
 
 end LieAlgebra

--- a/Mathlib/Algebra/Lie/EngelSubalgebra.lean
+++ b/Mathlib/Algebra/Lie/EngelSubalgebra.lean
@@ -143,8 +143,8 @@ lemma normalizer_eq_self_of_engel_le [IsArtinian R L]
 if it is contained in the Engel subalgebra of all its elements. -/
 lemma isNilpotent_of_forall_le_engel [IsNoetherian R L]
     (H : LieSubalgebra R L) (h : ∀ x ∈ H, H ≤ engel R x) :
-    LieAlgebra.IsNilpotent R H := by
-  rw [LieAlgebra.isNilpotent_iff_forall]
+    LieRing.IsNilpotent H := by
+  rw [LieAlgebra.isNilpotent_iff_forall (R := R)]
   intro x
   let K : ℕ →o Submodule R H :=
     ⟨fun n ↦ LinearMap.ker ((ad R H x) ^ n), fun m n hmn ↦ ?mono⟩

--- a/Mathlib/Algebra/Lie/IdealOperations.lean
+++ b/Mathlib/Algebra/Lie/IdealOperations.lean
@@ -69,19 +69,18 @@ variable [LieAlgebra R L] [LieModule R L M₂] (I J : LieIdeal R L)
 /-- Given a Lie module `M` over a Lie algebra `L`, the set of Lie ideals of `L` acts on the set
 of submodules of `M`. -/
 instance hasBracket : Bracket (LieIdeal R L) (LieSubmodule R L M) :=
-  ⟨fun I N => lieSpan R L { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m }⟩
+  ⟨fun I N => lieSpan R L { ⁅(x : L), (n : M)⁆ | (x : I) (n : N) }⟩
 
 theorem lieIdeal_oper_eq_span :
-    ⁅I, N⁆ = lieSpan R L { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m } :=
+    ⁅I, N⁆ = lieSpan R L { ⁅(x : L), (n : M)⁆ | (x : I) (n : N) } :=
   rfl
 
 /-- See also `LieSubmodule.lieIdeal_oper_eq_linear_span'` and
 `LieSubmodule.lieIdeal_oper_eq_tensor_map_range`. -/
 theorem lieIdeal_oper_eq_linear_span [LieModule R L M] :
-    (↑⁅I, N⁆ : Submodule R M) =
-      Submodule.span R { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m } := by
+    (↑⁅I, N⁆ : Submodule R M) = Submodule.span R { ⁅(x : L), (n : M)⁆ | (x : I) (n : N) } := by
   apply le_antisymm
-  · let s := { m : M | ∃ (x : ↥I) (n : ↥N), ⁅(x : L), (n : M)⁆ = m }
+  · let s := { ⁅(x : L), (n : M)⁆ | (x : I) (n : N) }
     have aux : ∀ (y : L), ∀ m' ∈ Submodule.span R s, ⁅y, m'⁆ ∈ Submodule.span R s := by
       intro y m' hm'
       refine Submodule.span_induction (R := R) (M := M) (s := s)
@@ -99,7 +98,7 @@ theorem lieIdeal_oper_eq_linear_span [LieModule R L M] :
   · rw [lieIdeal_oper_eq_span]; apply submodule_span_le_lieSpan
 
 theorem lieIdeal_oper_eq_linear_span' [LieModule R L M] :
-    (↑⁅I, N⁆ : Submodule R M) = Submodule.span R { m | ∃ x ∈ I, ∃ n ∈ N, ⁅x, n⁆ = m } := by
+    (↑⁅I, N⁆ : Submodule R M) = Submodule.span R { ⁅x, n⁆ | (x ∈ I) (n ∈ N) } := by
   rw [lieIdeal_oper_eq_linear_span]
   congr
   ext m

--- a/Mathlib/Algebra/Lie/LieTheorem.lean
+++ b/Mathlib/Algebra/Lie/LieTheorem.lean
@@ -204,7 +204,7 @@ open LieAlgebra
 -- except that it additionally assumes a finiteness hypothesis.
 private lemma exists_forall_lie_eq_smul_of_isSolvable_of_finite
     (L : Type*) [LieRing L] [LieAlgebra k L] [LieRingModule L V] [LieModule k L V]
-    [IsSolvable k L] [LieModule.IsTriangularizable k L V] [Module.Finite k L] :
+    [IsSolvable L] [LieModule.IsTriangularizable k L V] [Module.Finite k L] :
     ∃ χ : Module.Dual k L, Nontrivial (weightSpace V χ) := by
   obtain H|⟨A, hA, hAL⟩ := eq_top_or_exists_le_coatom (derivedSeries k L 1).toSubmodule
   · obtain _|_ := subsingleton_or_nontrivial L
@@ -231,7 +231,7 @@ have a common eigenvector for the action of all elements of the Lie algebra.
 See `LieModule.exists_nontrivial_weightSpace_of_isNilpotent` for the variant that
 assumes that `L` is nilpotent and drops the condition that `k` is of characteristic zero. -/
 theorem exists_nontrivial_weightSpace_of_isSolvable
-    [IsSolvable k L] [LieModule.IsTriangularizable k L V] :
+    [IsSolvable L] [LieModule.IsTriangularizable k L V] :
     ∃ χ : Module.Dual k L, Nontrivial (weightSpace V χ) := by
   let imL := (toEnd k L V).range
   let toEndo : L →ₗ[k] imL := LinearMap.codRestrict imL.toSubmodule (toEnd k L V)

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -88,7 +88,7 @@ theorem lowerCentralSeries_succ :
     lowerCentralSeries R L M (k + 1) = ⁅(⊤ : LieIdeal R L), lowerCentralSeries R L M k⁆ :=
   (⊤ : LieSubmodule R L M).lcs_succ k
 
-theorem lowerCentralSeries_scalars_aux (R₁ R₂ L M : Type*)
+private theorem coe_lowerCentralSeries_eq_int_aux (R₁ R₂ L M : Type*)
     [CommRing R₁] [CommRing R₂] [AddCommGroup M]
     [LieRing L] [LieAlgebra R₁ L] [LieAlgebra R₂ L] [Module R₁ M] [Module R₂ M] [LieRingModule L M]
     [LieModule R₁ L M] (k : ℕ) :
@@ -104,12 +104,10 @@ theorem lowerCentralSeries_scalars_aux (R₁ R₂ L M : Type*)
       rw [← smul_lie]
       exact Submodule.subset_span ⟨c • a, b, hb, rfl⟩
 
-theorem lowerCentralSeries_scalars (R₁ R₂ L M : Type*) [CommRing R₁] [CommRing R₂] [AddCommGroup M]
-    [LieRing L] [LieAlgebra R₁ L] [LieAlgebra R₂ L] [Module R₁ M] [Module R₂ M] [LieRingModule L M]
-    [LieModule R₁ L M] [LieModule R₂ L M] (k : ℕ) :
-    (lowerCentralSeries R₁ L M k : Set M) = (lowerCentralSeries R₂ L M k : Set M) := by
-  show ((lowerCentralSeries R₁ L M k).toSubmodule : Set M) =
-       ((lowerCentralSeries R₂ L M k).toSubmodule : Set M)
+theorem coe_lowerCentralSeries_eq_int [LieModule R L M] (k : ℕ) :
+    (lowerCentralSeries R L M k : Set M) = (lowerCentralSeries ℤ L M k : Set M) := by
+  show ((lowerCentralSeries R L M k).toSubmodule : Set M) =
+       ((lowerCentralSeries ℤ L M k).toSubmodule : Set M)
   induction k with
   | zero => rfl
   | succ k ih =>
@@ -119,9 +117,9 @@ theorem lowerCentralSeries_scalars (R₁ R₂ L M : Type*) [CommRing R₁] [Comm
     simp only [SetLike.mem_coe, LieSubmodule.mem_toSubmodule] at ih
     simp only [LieSubmodule.mem_top, ih, true_and]
     apply le_antisymm
-    · exact lowerCentralSeries_scalars_aux _ _ L M k
+    · exact coe_lowerCentralSeries_eq_int_aux _ _ L M k
     · simp only [← ih]
-      exact lowerCentralSeries_scalars_aux _ _ L M k
+      exact coe_lowerCentralSeries_eq_int_aux _ _ L M k
 
 end LieModule
 
@@ -252,11 +250,6 @@ theorem derivedSeries_le_lowerCentralSeries (k : ℕ) :
 
 /-- A Lie module is nilpotent if its lower central series reaches 0 (in a finite number of
 steps). -/
-class IsNilpotent' : Prop where
-  nilpotent : ∃ k, lowerCentralSeries R L M k = ⊥
-
-/-- A Lie module is nilpotent if its lower central series reaches 0 (in a finite number of
-steps). -/
 @[mk_iff isNilpotent_iff_int]
 class IsNilpotent : Prop where
   mk_int ::
@@ -269,7 +262,7 @@ variable [LieModule R L M]
 /-- See also `LieModule.isNilpotent_iff_exists_ucs_eq_top`. -/
 lemma isNilpotent_iff :
     IsNilpotent L M ↔ ∃ k, lowerCentralSeries R L M k = ⊥ := by
-  simp [isNilpotent_iff_int, SetLike.ext'_iff, lowerCentralSeries_scalars R ℤ L M]
+  simp [isNilpotent_iff_int, SetLike.ext'_iff, coe_lowerCentralSeries_eq_int R L M]
 
 lemma IsNilpotent.nilpotent [IsNilpotent L M] : ∃ k, lowerCentralSeries R L M k = ⊥ :=
   (isNilpotent_iff R L M).mp ‹_›
@@ -400,7 +393,7 @@ theorem nilpotencyLength_eq_succ_iff (k : ℕ) :
     nilpotencyLength L M = k + 1 ↔
       lowerCentralSeries R L M (k + 1) = ⊥ ∧ lowerCentralSeries R L M k ≠ ⊥ := by
   have aux (k : ℕ) : lowerCentralSeries R L M k = ⊥ ↔ lowerCentralSeries ℤ L M k = ⊥ := by
-    simp [SetLike.ext'_iff, lowerCentralSeries_scalars R ℤ L M]
+    simp [SetLike.ext'_iff, coe_lowerCentralSeries_eq_int R L M]
   let s := {k | lowerCentralSeries ℤ L M k = ⊥}
   rw [aux, ne_eq, aux]
   change sInf s = k + 1 ↔ k + 1 ∈ s ∧ k ∉ s

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -262,11 +262,6 @@ class IsNilpotent : Prop where
   mk_int ::
   nilpotent_int : ∃ k, lowerCentralSeries ℤ L M k = ⊥
 
--- move this
-instance : LieModule ℤ L M where
-  smul_lie n x m := zsmul_lie x m n
-  lie_smul n x m := lie_zsmul x m n
-
 section
 
 variable [LieModule R L M]

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -102,7 +102,7 @@ theorem lowerCentralSeries_scalars_aux (R₁ R₂ L M : Type*)
   | smul_mem c y hy =>
       obtain ⟨a, b, hb, rfl⟩ := hy
       rw [← smul_lie]
-      refine Submodule.subset_span ⟨c • a, b, hb, rfl⟩ 
+      exact Submodule.subset_span ⟨c • a, b, hb, rfl⟩ 
 
 theorem lowerCentralSeries_scalars (R₁ R₂ L M : Type*) [CommRing R₁] [CommRing R₂] [AddCommGroup M]
     [LieRing L] [LieAlgebra R₁ L] [LieAlgebra R₂ L] [Module R₁ M] [Module R₂ M] [LieRingModule L M]
@@ -252,57 +252,83 @@ theorem derivedSeries_le_lowerCentralSeries (k : ℕ) :
 
 /-- A Lie module is nilpotent if its lower central series reaches 0 (in a finite number of
 steps). -/
+class IsNilpotent' : Prop where
+  nilpotent : ∃ k, lowerCentralSeries R L M k = ⊥
+
+/-- A Lie module is nilpotent if its lower central series reaches 0 (in a finite number of
+steps). -/
+@[mk_iff isNilpotent_iff_int]
 class IsNilpotent : Prop where
   mk_int ::
   nilpotent_int : ∃ k, lowerCentralSeries ℤ L M k = ⊥
 
+-- move this
+instance : LieModule ℤ L M where
+  smul_lie n x m := zsmul_lie x m n
+  lie_smul n x m := lie_zsmul x m n
+
+section
+
+variable [LieModule R L M]
+
+/-- See also `LieModule.isNilpotent_iff_exists_ucs_eq_top`. -/
+lemma isNilpotent_iff :
+    IsNilpotent L M ↔ ∃ k, lowerCentralSeries R L M k = ⊥ := by
+  simp [isNilpotent_iff_int, SetLike.ext'_iff, lowerCentralSeries_scalars R ℤ L M]
+
+lemma IsNilpotent.nilpotent [IsNilpotent L M] : ∃ k, lowerCentralSeries R L M k = ⊥ :=
+  (isNilpotent_iff R L M).mp ‹_›
+
+variable {R L} in
+lemma IsNilpotent.mk {k : ℕ} (h : lowerCentralSeries R L M k = ⊥) : IsNilpotent L M :=
+  (isNilpotent_iff R L M).mpr ⟨k, h⟩
+
+@[deprecated IsNilpotent.nilpotent (since := "2025-01-07")]
 theorem exists_lowerCentralSeries_eq_bot_of_isNilpotent [IsNilpotent L M] :
     ∃ k, lowerCentralSeries R L M k = ⊥ :=
-  IsNilpotent.nilpotent
+  IsNilpotent.nilpotent R L M
 
-@[simp] lemma iInf_lowerCentralSeries_eq_bot_of_isNilpotent [IsNilpotent R L M] :
+@[simp] lemma iInf_lowerCentralSeries_eq_bot_of_isNilpotent [IsNilpotent L M] :
     ⨅ k, lowerCentralSeries R L M k = ⊥ := by
-  obtain ⟨k, hk⟩ := exists_lowerCentralSeries_eq_bot_of_isNilpotent R L M
+  obtain ⟨k, hk⟩ := IsNilpotent.nilpotent R L M
   rw [eq_bot_iff, ← hk]
   exact iInf_le _ _
 
-/-- See also `LieModule.isNilpotent_iff_exists_ucs_eq_top`. -/
-theorem isNilpotent_iff : IsNilpotent R L M ↔ ∃ k, lowerCentralSeries R L M k = ⊥ :=
-  ⟨fun h => h.nilpotent, fun h => ⟨h⟩⟩
+end
 
 section
 variable {R L M}
 variable [LieModule R L M]
 
 theorem _root_.LieSubmodule.isNilpotent_iff_exists_lcs_eq_bot (N : LieSubmodule R L M) :
-    LieModule.IsNilpotent R L N ↔ ∃ k, N.lcs k = ⊥ := by
-  rw [isNilpotent_iff]
+    LieModule.IsNilpotent L N ↔ ∃ k, N.lcs k = ⊥ := by
+  rw [isNilpotent_iff R L N]
   refine exists_congr fun k => ?_
   rw [N.lowerCentralSeries_eq_lcs_comap k, LieSubmodule.comap_incl_eq_bot,
     inf_eq_right.mpr (N.lcs_le_self k)]
 
 variable (R L M)
 
-instance (priority := 100) trivialIsNilpotent [IsTrivial L M] : IsNilpotent R L M :=
+instance (priority := 100) trivialIsNilpotent [IsTrivial L M] : IsNilpotent L M :=
   ⟨by use 1; change ⁅⊤, ⊤⁆ = ⊥; simp⟩
 
-theorem exists_forall_pow_toEnd_eq_zero [hM : IsNilpotent R L M] :
+theorem exists_forall_pow_toEnd_eq_zero [IsNilpotent L M] :
     ∃ k : ℕ, ∀ x : L, toEnd R L M x ^ k = 0 := by
-  obtain ⟨k, hM⟩ := hM
+  obtain ⟨k, hM⟩ := IsNilpotent.nilpotent R L M
   use k
   intro x; ext m
   rw [LinearMap.pow_apply, LinearMap.zero_apply, ← @LieSubmodule.mem_bot R L M, ← hM]
   exact iterate_toEnd_mem_lowerCentralSeries R L M x m k
 
-theorem isNilpotent_toEnd_of_isNilpotent [IsNilpotent R L M] (x : L) :
+theorem isNilpotent_toEnd_of_isNilpotent [IsNilpotent L M] (x : L) :
     _root_.IsNilpotent (toEnd R L M x) := by
   change ∃ k, toEnd R L M x ^ k = 0
   have := exists_forall_pow_toEnd_eq_zero R L M
   tauto
 
-theorem isNilpotent_toEnd_of_isNilpotent₂ [IsNilpotent R L M] (x y : L) :
+theorem isNilpotent_toEnd_of_isNilpotent₂ [IsNilpotent L M] (x y : L) :
     _root_.IsNilpotent (toEnd R L M x ∘ₗ toEnd R L M y) := by
-  obtain ⟨k, hM⟩ := exists_lowerCentralSeries_eq_bot_of_isNilpotent R L M
+  obtain ⟨k, hM⟩ := IsNilpotent.nilpotent R L M
   replace hM : lowerCentralSeries R L M (2 * k) = ⊥ := by
     rw [eq_bot_iff, ← hM]; exact antitone_lowerCentralSeries R L M (by omega)
   use k
@@ -310,7 +336,7 @@ theorem isNilpotent_toEnd_of_isNilpotent₂ [IsNilpotent R L M] (x y : L) :
   rw [LinearMap.pow_apply, LinearMap.zero_apply, ← LieSubmodule.mem_bot (R := R) (L := L), ← hM]
   exact iterate_toEnd_mem_lowerCentralSeries₂ R L M x y m k
 
-@[simp] lemma maxGenEigenSpace_toEnd_eq_top [IsNilpotent R L M] (x : L) :
+@[simp] lemma maxGenEigenSpace_toEnd_eq_top [IsNilpotent L M] (x : L) :
     ((toEnd R L M x).maxGenEigenspace 0) = ⊤ := by
   ext m
   simp only [Module.End.mem_maxGenEigenspace, zero_smul, sub_zero, Submodule.mem_top,
@@ -325,7 +351,8 @@ This is essentially the Lie module equivalent of the fact that a central
 extension of nilpotent Lie algebras is nilpotent. See `LieAlgebra.nilpotent_of_nilpotent_quotient`
 below for the corresponding result for Lie algebras. -/
 theorem nilpotentOfNilpotentQuotient {N : LieSubmodule R L M} (h₁ : N ≤ maxTrivSubmodule R L M)
-    (h₂ : IsNilpotent R L (M ⧸ N)) : IsNilpotent R L M := by
+    (h₂ : IsNilpotent L (M ⧸ N)) : IsNilpotent L M := by
+  rw [isNilpotent_iff R L] at h₂ ⊢
   obtain ⟨k, hk⟩ := h₂
   use k + 1
   simp only [lowerCentralSeries_succ]
@@ -336,13 +363,13 @@ theorem nilpotentOfNilpotentQuotient {N : LieSubmodule R L M} (h₁ : N ≤ maxT
   exact map_lowerCentralSeries_le k (LieSubmodule.Quotient.mk' N)
 
 theorem isNilpotent_quotient_iff :
-    IsNilpotent R L (M ⧸ N) ↔ ∃ k, lowerCentralSeries R L M k ≤ N := by
-  rw [LieModule.isNilpotent_iff]
+    IsNilpotent L (M ⧸ N) ↔ ∃ k, lowerCentralSeries R L M k ≤ N := by
+  rw [isNilpotent_iff R L]
   refine exists_congr fun k ↦ ?_
   rw [← LieSubmodule.Quotient.map_mk'_eq_bot_le, map_lowerCentralSeries_eq k
     (LieSubmodule.Quotient.surjective_mk' N)]
 
-theorem iInf_lcs_le_of_isNilpotent_quot (h : IsNilpotent R L (M ⧸ N)) :
+theorem iInf_lcs_le_of_isNilpotent_quot (h : IsNilpotent L (M ⧸ N)) :
     ⨅ k, lowerCentralSeries R L M k ≤ N := by
   obtain ⟨k, hk⟩ := (isNilpotent_quotient_iff R L M N).mp h
   exact iInf_le_of_le k hk
@@ -354,44 +381,53 @@ the natural number `k` (the number of inclusions).
 
 For a non-nilpotent module, we use the junk value 0. -/
 noncomputable def nilpotencyLength : ℕ :=
-  sInf {k | lowerCentralSeries R L M k = ⊥}
+  sInf {k | lowerCentralSeries ℤ L M k = ⊥}
 
 @[simp]
-theorem nilpotencyLength_eq_zero_iff [IsNilpotent R L M] :
-    nilpotencyLength R L M = 0 ↔ Subsingleton M := by
-  let s := {k | lowerCentralSeries R L M k = ⊥}
+theorem nilpotencyLength_eq_zero_iff [IsNilpotent L M] :
+    nilpotencyLength L M = 0 ↔ Subsingleton M := by
+  let s := {k | lowerCentralSeries ℤ L M k = ⊥}
   have hs : s.Nonempty := by
-    obtain ⟨k, hk⟩ := (by infer_instance : IsNilpotent R L M)
+    obtain ⟨k, hk⟩ := IsNilpotent.nilpotent ℤ L M
     exact ⟨k, hk⟩
   change sInf s = 0 ↔ _
-  rw [← LieSubmodule.subsingleton_iff R L M, ← subsingleton_iff_bot_eq_top, ←
-    lowerCentralSeries_zero, @eq_comm (LieSubmodule R L M)]
+  rw [← LieSubmodule.subsingleton_iff ℤ L M, ← subsingleton_iff_bot_eq_top, ←
+    lowerCentralSeries_zero, @eq_comm (LieSubmodule ℤ L M)]
   refine ⟨fun h => h ▸ Nat.sInf_mem hs, fun h => ?_⟩
   rw [Nat.sInf_eq_zero]
   exact Or.inl h
 
+section
+
+variable [LieModule R L M]
+
 theorem nilpotencyLength_eq_succ_iff (k : ℕ) :
-    nilpotencyLength R L M = k + 1 ↔
+    nilpotencyLength L M = k + 1 ↔
       lowerCentralSeries R L M (k + 1) = ⊥ ∧ lowerCentralSeries R L M k ≠ ⊥ := by
-  let s := {k | lowerCentralSeries R L M k = ⊥}
+  have aux (k : ℕ) : lowerCentralSeries R L M k = ⊥ ↔ lowerCentralSeries ℤ L M k = ⊥ := by
+    simp [SetLike.ext'_iff, lowerCentralSeries_scalars R ℤ L M]
+  let s := {k | lowerCentralSeries ℤ L M k = ⊥}
+  rw [aux, ne_eq, aux]
   change sInf s = k + 1 ↔ k + 1 ∈ s ∧ k ∉ s
   have hs : ∀ k₁ k₂, k₁ ≤ k₂ → k₁ ∈ s → k₂ ∈ s := by
-    rintro k₁ k₂ h₁₂ (h₁ : lowerCentralSeries R L M k₁ = ⊥)
-    exact eq_bot_iff.mpr (h₁ ▸ antitone_lowerCentralSeries R L M h₁₂)
+    rintro k₁ k₂ h₁₂ (h₁ : lowerCentralSeries ℤ L M k₁ = ⊥)
+    exact eq_bot_iff.mpr (h₁ ▸ antitone_lowerCentralSeries ℤ L M h₁₂)
   exact Nat.sInf_upward_closed_eq_succ_iff hs k
 
 @[simp]
 theorem nilpotencyLength_eq_one_iff [Nontrivial M] :
-    nilpotencyLength R L M = 1 ↔ IsTrivial L M := by
-  rw [nilpotencyLength_eq_succ_iff, ← trivial_iff_lower_central_eq_bot]
+    nilpotencyLength L M = 1 ↔ IsTrivial L M := by
+  rw [nilpotencyLength_eq_succ_iff ℤ, ← trivial_iff_lower_central_eq_bot]
   simp
 
-theorem isTrivial_of_nilpotencyLength_le_one [IsNilpotent R L M] (h : nilpotencyLength R L M ≤ 1) :
+theorem isTrivial_of_nilpotencyLength_le_one [IsNilpotent L M] (h : nilpotencyLength L M ≤ 1) :
     IsTrivial L M := by
   nontriviality M
   cases' Nat.le_one_iff_eq_zero_or_eq_one.mp h with h h
   · rw [nilpotencyLength_eq_zero_iff] at h; infer_instance
   · rwa [nilpotencyLength_eq_one_iff] at h
+
+end
 
 /-- Given a non-trivial nilpotent Lie module `M` with lower central series
 `M = C₀ ≥ C₁ ≥ ⋯ ≥ Cₖ = ⊥`, this is the `k-1`th term in the lower central series (the last
@@ -399,36 +435,36 @@ non-trivial term).
 
 For a trivial or non-nilpotent module, this is the bottom submodule, `⊥`. -/
 noncomputable def lowerCentralSeriesLast : LieSubmodule R L M :=
-  match nilpotencyLength R L M with
+  match nilpotencyLength L M with
   | 0 => ⊥
   | k + 1 => lowerCentralSeries R L M k
 
 theorem lowerCentralSeriesLast_le_max_triv [LieModule R L M] :
     lowerCentralSeriesLast R L M ≤ maxTrivSubmodule R L M := by
   rw [lowerCentralSeriesLast]
-  cases' h : nilpotencyLength R L M with k
+  cases' h : nilpotencyLength L M with k
   · exact bot_le
   · rw [le_max_triv_iff_bracket_eq_bot]
-    rw [nilpotencyLength_eq_succ_iff, lowerCentralSeries_succ] at h
+    rw [nilpotencyLength_eq_succ_iff R, lowerCentralSeries_succ] at h
     exact h.1
 
-theorem nontrivial_lowerCentralSeriesLast [Nontrivial M] [IsNilpotent R L M] :
+theorem nontrivial_lowerCentralSeriesLast [LieModule R L M] [Nontrivial M] [IsNilpotent L M] :
     Nontrivial (lowerCentralSeriesLast R L M) := by
   rw [LieSubmodule.nontrivial_iff_ne_bot, lowerCentralSeriesLast]
-  cases h : nilpotencyLength R L M
+  cases h : nilpotencyLength L M
   · rw [nilpotencyLength_eq_zero_iff, ← not_nontrivial_iff_subsingleton] at h
     contradiction
-  · rw [nilpotencyLength_eq_succ_iff] at h
+  · rw [nilpotencyLength_eq_succ_iff R] at h
     exact h.2
 
-theorem lowerCentralSeriesLast_le_of_not_isTrivial [IsNilpotent R L M] (h : ¬ IsTrivial L M) :
+theorem lowerCentralSeriesLast_le_of_not_isTrivial [IsNilpotent L M] (h : ¬ IsTrivial L M) :
     lowerCentralSeriesLast R L M ≤ lowerCentralSeries R L M 1 := by
   rw [lowerCentralSeriesLast]
-  replace h : 1 < nilpotencyLength R L M := by
+  replace h : 1 < nilpotencyLength L M := by
     by_contra contra
-    have := isTrivial_of_nilpotencyLength_le_one R L M (not_lt.mp contra)
+    have := isTrivial_of_nilpotencyLength_le_one L M (not_lt.mp contra)
     contradiction
-  cases' hk : nilpotencyLength R L M with k <;> rw [hk] at h
+  cases' hk : nilpotencyLength L M with k <;> rw [hk] at h
   · contradiction
   · exact antitone_lowerCentralSeries _ _ _ (Nat.lt_succ.mp h)
 
@@ -439,7 +475,7 @@ of `M` contains a non-zero element on which `L` acts trivially unless the entire
 
 Taking `M = L`, this provides a useful characterisation of Abelian-ness for nilpotent Lie
 algebras. -/
-lemma disjoint_lowerCentralSeries_maxTrivSubmodule_iff [IsNilpotent R L M] :
+lemma disjoint_lowerCentralSeries_maxTrivSubmodule_iff [IsNilpotent L M] :
     Disjoint (lowerCentralSeries R L M 1) (maxTrivSubmodule R L M) ↔ IsTrivial L M := by
   refine ⟨fun h ↦ ?_, fun h ↦ by simp⟩
   nontriviality M
@@ -452,7 +488,7 @@ lemma disjoint_lowerCentralSeries_maxTrivSubmodule_iff [IsNilpotent R L M] :
   rw [h.eq_bot, le_bot_iff] at this
   exact this ▸ not_nontrivial _
 
-theorem nontrivial_max_triv_of_isNilpotent [Nontrivial M] [IsNilpotent R L M] :
+theorem nontrivial_max_triv_of_isNilpotent [Nontrivial M] [IsNilpotent L M] :
     Nontrivial (maxTrivSubmodule R L M) :=
   Set.nontrivial_mono (lowerCentralSeriesLast_le_max_triv R L M)
     (nontrivial_lowerCentralSeriesLast R L M)
@@ -477,7 +513,8 @@ theorem coe_lcs_range_toEnd_eq (k : ℕ) :
 
 @[simp]
 theorem isNilpotent_range_toEnd_iff :
-    IsNilpotent R (toEnd R L M).range M ↔ IsNilpotent R L M := by
+    IsNilpotent (toEnd R L M).range M ↔ IsNilpotent L M := by
+  simp only [isNilpotent_iff R _ M]
   constructor <;> rintro ⟨k, hk⟩ <;> use k <;>
       rw [← LieSubmodule.toSubmodule_inj] at hk ⊢ <;>
     simpa using hk
@@ -549,9 +586,10 @@ theorem gc_lcs_ucs (k : ℕ) :
 theorem ucs_eq_top_iff (k : ℕ) : N.ucs k = ⊤ ↔ LieModule.lowerCentralSeries R L M k ≤ N := by
   rw [eq_top_iff, ← lcs_le_iff]; rfl
 
+variable (R) in
 theorem _root_.LieModule.isNilpotent_iff_exists_ucs_eq_top :
-    LieModule.IsNilpotent R L M ↔ ∃ k, (⊥ : LieSubmodule R L M).ucs k = ⊤ := by
-  rw [LieModule.isNilpotent_iff]; exact exists_congr fun k => by simp [ucs_eq_top_iff]
+    LieModule.IsNilpotent L M ↔ ∃ k, (⊥ : LieSubmodule R L M).ucs k = ⊤ := by
+  rw [LieModule.isNilpotent_iff R]; exact exists_congr fun k => by simp [ucs_eq_top_iff]
 
 theorem ucs_comap_incl (k : ℕ) :
     ((⊥ : LieSubmodule R L M).ucs k).comap N.incl = (⊥ : LieSubmodule R L N).ucs k := by
@@ -560,8 +598,8 @@ theorem ucs_comap_incl (k : ℕ) :
   | succ k ih => simp [← ih]
 
 theorem isNilpotent_iff_exists_self_le_ucs :
-    LieModule.IsNilpotent R L N ↔ ∃ k, N ≤ (⊥ : LieSubmodule R L M).ucs k := by
-  simp_rw [LieModule.isNilpotent_iff_exists_ucs_eq_top, ← ucs_comap_incl, comap_incl_eq_top]
+    LieModule.IsNilpotent L N ↔ ∃ k, N ≤ (⊥ : LieSubmodule R L M).ucs k := by
+  simp_rw [LieModule.isNilpotent_iff_exists_ucs_eq_top R, ← ucs_comap_incl, comap_incl_eq_top]
 
 theorem ucs_bot_one : (⊥ : LieSubmodule R L M).ucs 1 = LieModule.maxTrivSubmodule R L M := by
   simp [LieSubmodule.normalizer_bot_eq_maxTrivSubmodule]
@@ -604,14 +642,15 @@ theorem Function.Surjective.lieModule_lcs_map_eq (k : ℕ) :
       exact ⟨⁅y, n⁆, ⟨y, n, hn, rfl⟩, (hfg y n).symm⟩
 
 include hf hg hfg in
-theorem Function.Surjective.lieModuleIsNilpotent [IsNilpotent R L M] : IsNilpotent R L₂ M₂ := by
-  obtain ⟨k, hk⟩ := id (by infer_instance : IsNilpotent R L M)
+theorem Function.Surjective.lieModuleIsNilpotent [IsNilpotent L M] : IsNilpotent L₂ M₂ := by
+  obtain ⟨k, hk⟩ := IsNilpotent.nilpotent R L M
+  rw [isNilpotent_iff R]
   use k
   rw [← LieSubmodule.toSubmodule_inj] at hk ⊢
   simp [← hf.lieModule_lcs_map_eq hg hfg k, hk]
 
 theorem Equiv.lieModule_isNilpotent_iff (f : L ≃ₗ⁅R⁆ L₂) (g : M ≃ₗ[R] M₂)
-    (hfg : ∀ x m, ⁅f x, g m⁆ = g ⁅x, m⁆) : IsNilpotent R L M ↔ IsNilpotent R L₂ M₂ := by
+    (hfg : ∀ x m, ⁅f x, g m⁆ = g ⁅x, m⁆) : IsNilpotent L M ↔ IsNilpotent L₂ M₂ := by
   constructor <;> intro h
   · have hg : Surjective (g : M →ₗ[R] M₂) := g.surjective
     exact f.surjective.lieModuleIsNilpotent hg hfg
@@ -622,38 +661,37 @@ theorem Equiv.lieModule_isNilpotent_iff (f : L ≃ₗ⁅R⁆ L₂) (g : M ≃ₗ
 
 @[simp]
 theorem LieModule.isNilpotent_of_top_iff :
-    IsNilpotent R (⊤ : LieSubalgebra R L) M ↔ IsNilpotent R L M :=
+    IsNilpotent (⊤ : LieSubalgebra R L) M ↔ IsNilpotent L M :=
   Equiv.lieModule_isNilpotent_iff LieSubalgebra.topEquiv (1 : M ≃ₗ[R] M) fun _ _ => rfl
 
 @[simp] lemma LieModule.isNilpotent_of_top_iff' :
-    IsNilpotent R L {x // x ∈ (⊤ : LieSubmodule R L M)} ↔ IsNilpotent R L M :=
+    IsNilpotent L {x // x ∈ (⊤ : LieSubmodule R L M)} ↔ IsNilpotent L M :=
   Equiv.lieModule_isNilpotent_iff 1 (LinearEquiv.ofTop ⊤ rfl) fun _ _ ↦ rfl
 
 end Morphisms
 
 end NilpotentModules
 
-instance (priority := 100) LieAlgebra.isSolvable_of_isNilpotent (R : Type u) (L : Type v)
-    [CommRing R] [LieRing L] [LieAlgebra R L] [hL : LieModule.IsNilpotent R L L] :
+instance (priority := 100) LieAlgebra.isSolvable_of_isNilpotent (L : Type v)
+    [LieRing L] [hL : LieModule.IsNilpotent L L] :
     LieAlgebra.IsSolvable L := by
-  obtain ⟨k, h⟩ : ∃ k, LieModule.lowerCentralSeries R L L k = ⊥ := hL.nilpotent
+  obtain ⟨k, h⟩ : ∃ k, LieModule.lowerCentralSeries ℤ L L k = ⊥ := hL.nilpotent_int
   use k; rw [← le_bot_iff] at h ⊢
-  exact le_trans (LieModule.derivedSeries_le_lowerCentralSeries R L k) h
+  exact le_trans (LieModule.derivedSeries_le_lowerCentralSeries ℤ L k) h
 
 section NilpotentAlgebras
 
 variable (R : Type u) (L : Type v) (L' : Type w)
 variable [CommRing R] [LieRing L] [LieAlgebra R L] [LieRing L'] [LieAlgebra R L']
 
-/-- We say a Lie algebra is nilpotent when it is nilpotent as a Lie module over itself via the
+/-- We say a Lie ring is nilpotent when it is nilpotent as a Lie module over itself via the
 adjoint representation. -/
-abbrev LieAlgebra.IsNilpotent (R : Type u) (L : Type v) [CommRing R] [LieRing L] [LieAlgebra R L] :
-    Prop :=
-  LieModule.IsNilpotent R L L
+abbrev LieRing.IsNilpotent (L : Type v) [LieRing L] : Prop :=
+  LieModule.IsNilpotent L L
 
-open LieAlgebra
+open LieRing
 
-theorem LieAlgebra.nilpotent_ad_of_nilpotent_algebra [IsNilpotent R L] :
+theorem LieAlgebra.nilpotent_ad_of_nilpotent_algebra [IsNilpotent L] :
     ∃ k : ℕ, ∀ x : L, ad R L x ^ k = 0 :=
   LieModule.exists_forall_pow_toEnd_eq_zero R L L
 
@@ -703,14 +741,14 @@ theorem LieModule.coe_lowerCentralSeries_ideal_le {I : LieIdeal R L} (k : ℕ) :
 
 /-- A central extension of nilpotent Lie algebras is nilpotent. -/
 theorem LieAlgebra.nilpotent_of_nilpotent_quotient {I : LieIdeal R L} (h₁ : I ≤ center R L)
-    (h₂ : IsNilpotent R (L ⧸ I)) : IsNilpotent R L := by
-  suffices LieModule.IsNilpotent R L (L ⧸ I) by
+    (h₂ : IsNilpotent (L ⧸ I)) : IsNilpotent L := by
+  suffices LieModule.IsNilpotent L (L ⧸ I) by
     exact LieModule.nilpotentOfNilpotentQuotient R L L h₁ this
-  obtain ⟨k, hk⟩ := h₂
-  use k
+  simp only [LieRing.IsNilpotent, LieModule.isNilpotent_iff R] at h₂ ⊢
+  peel h₂ with k hk
   simp [← LieSubmodule.toSubmodule_inj, coe_lowerCentralSeries_ideal_quot_eq, hk]
 
-theorem LieAlgebra.non_trivial_center_of_isNilpotent [Nontrivial L] [IsNilpotent R L] :
+theorem LieAlgebra.non_trivial_center_of_isNilpotent [Nontrivial L] [IsNilpotent L] :
     Nontrivial <| center R L :=
   LieModule.nontrivial_max_triv_of_isNilpotent R L L
 
@@ -731,29 +769,27 @@ theorem LieIdeal.lowerCentralSeries_map_eq (k : ℕ) {f : L →ₗ⁅R⁆ L'} (h
   | zero => simp only [LieModule.lowerCentralSeries_zero]; exact h'
   | succ k ih => simp only [LieModule.lowerCentralSeries_succ, LieIdeal.map_bracket_eq f h, ih, h']
 
-theorem Function.Injective.lieAlgebra_isNilpotent [h₁ : IsNilpotent R L'] {f : L →ₗ⁅R⁆ L'}
-    (h₂ : Function.Injective f) : IsNilpotent R L :=
-  { nilpotent := by
-      obtain ⟨k, hk⟩ := id h₁
-      use k
-      apply LieIdeal.bot_of_map_eq_bot h₂; rw [eq_bot_iff, ← hk]
-      apply LieIdeal.map_lowerCentralSeries_le }
+theorem Function.Injective.lieAlgebra_isNilpotent [h₁ : IsNilpotent L'] {f : L →ₗ⁅R⁆ L'}
+    (h₂ : Function.Injective f) : IsNilpotent L := by
+  rw [LieRing.IsNilpotent, LieModule.isNilpotent_iff R] at h₁ ⊢
+  peel h₁ with k hk
+  apply LieIdeal.bot_of_map_eq_bot h₂; rw [eq_bot_iff, ← hk]
+  apply LieIdeal.map_lowerCentralSeries_le
 
-theorem Function.Surjective.lieAlgebra_isNilpotent [h₁ : IsNilpotent R L] {f : L →ₗ⁅R⁆ L'}
-    (h₂ : Function.Surjective f) : IsNilpotent R L' :=
-  { nilpotent := by
-      obtain ⟨k, hk⟩ := id h₁
-      use k
-      rw [← LieIdeal.lowerCentralSeries_map_eq k h₂, hk]
-      simp only [LieIdeal.map_eq_bot_iff, bot_le] }
+theorem Function.Surjective.lieAlgebra_isNilpotent [h₁ : IsNilpotent L] {f : L →ₗ⁅R⁆ L'}
+    (h₂ : Function.Surjective f) : IsNilpotent L' := by
+  rw [LieRing.IsNilpotent, LieModule.isNilpotent_iff R] at h₁ ⊢
+  peel h₁ with k hk
+  rw [← LieIdeal.lowerCentralSeries_map_eq k h₂, hk]
+  simp only [LieIdeal.map_eq_bot_iff, bot_le]
 
 theorem LieEquiv.nilpotent_iff_equiv_nilpotent (e : L ≃ₗ⁅R⁆ L') :
-    IsNilpotent R L ↔ IsNilpotent R L' := by
+    IsNilpotent L ↔ IsNilpotent L' := by
   constructor <;> intro h
   · exact e.symm.injective.lieAlgebra_isNilpotent
   · exact e.injective.lieAlgebra_isNilpotent
 
-theorem LieHom.isNilpotent_range [IsNilpotent R L] (f : L →ₗ⁅R⁆ L') : IsNilpotent R f.range :=
+theorem LieHom.isNilpotent_range [IsNilpotent L] (f : L →ₗ⁅R⁆ L') : IsNilpotent f.range :=
   f.surjective_rangeRestrict.lieAlgebra_isNilpotent
 
 /-- Note that this result is not quite a special case of
@@ -761,7 +797,7 @@ theorem LieHom.isNilpotent_range [IsNilpotent R L] (f : L →ₗ⁅R⁆ L') : Is
 `(ad R L).range`-module `L`, whereas this result concerns nilpotency of the `(ad R L).range`-module
 `(ad R L).range`. -/
 @[simp]
-theorem LieAlgebra.isNilpotent_range_ad_iff : IsNilpotent R (ad R L).range ↔ IsNilpotent R L := by
+theorem LieAlgebra.isNilpotent_range_ad_iff : IsNilpotent (ad R L).range ↔ IsNilpotent L := by
   refine ⟨fun h => ?_, ?_⟩
   · have : (ad R L).ker = center R L := by simp
     exact
@@ -770,7 +806,7 @@ theorem LieAlgebra.isNilpotent_range_ad_iff : IsNilpotent R (ad R L).range ↔ I
   · intro h
     exact (ad R L).isNilpotent_range
 
-instance [h : LieAlgebra.IsNilpotent R L] : LieAlgebra.IsNilpotent R (⊤ : LieSubalgebra R L) :=
+instance [h : LieRing.IsNilpotent L] : LieRing.IsNilpotent (⊤ : LieSubalgebra R L) :=
   LieSubalgebra.topEquiv.nilpotent_iff_equiv_nilpotent.mpr h
 
 end NilpotentAlgebras
@@ -865,9 +901,10 @@ lemma LieSubmodule.lowerCentralSeries_tensor_eq_baseChange (k : ℕ) :
   | zero => simp
   | succ k ih => simp only [lowerCentralSeries_succ, ih, ← baseChange_top, lie_baseChange]
 
-instance LieModule.instIsNilpotentTensor [IsNilpotent R L M] :
-    IsNilpotent A (A ⊗[R] L) (A ⊗[R] M) := by
-  obtain ⟨k, hk⟩ := inferInstanceAs (IsNilpotent R L M)
+instance LieModule.instIsNilpotentTensor [IsNilpotent L M] :
+    IsNilpotent (A ⊗[R] L) (A ⊗[R] M) := by
+  obtain ⟨k, hk⟩ := IsNilpotent.nilpotent R L M
+  rw [isNilpotent_iff A]
   exact ⟨k, by simp [hk]⟩
 
 end ExtendScalars

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -91,7 +91,7 @@ theorem lowerCentralSeries_succ :
 theorem lowerCentralSeries_scalars_aux (R₁ R₂ L M : Type*)
     [CommRing R₁] [CommRing R₂] [AddCommGroup M]
     [LieRing L] [LieAlgebra R₁ L] [LieAlgebra R₂ L] [Module R₁ M] [Module R₂ M] [LieRingModule L M]
-    [LieModule R₁ L M] [LieModule R₂ L M] (k : ℕ) :
+    [LieModule R₁ L M] (k : ℕ) :
     let I := lowerCentralSeries R₂ L M k; let S : Set M := {⁅a, b⁆ | (a : L) (b ∈ I)}
     (Submodule.span R₁ S : Set M) ≤ (Submodule.span R₂ S : Set M) := by
   intro I S x hx
@@ -102,7 +102,7 @@ theorem lowerCentralSeries_scalars_aux (R₁ R₂ L M : Type*)
   | smul_mem c y hy =>
       obtain ⟨a, b, hb, rfl⟩ := hy
       rw [← smul_lie]
-      exact Submodule.subset_span ⟨c • a, b, hb, rfl⟩ 
+      exact Submodule.subset_span ⟨c • a, b, hb, rfl⟩
 
 theorem lowerCentralSeries_scalars (R₁ R₂ L M : Type*) [CommRing R₁] [CommRing R₂] [AddCommGroup M]
     [LieRing L] [LieAlgebra R₁ L] [LieAlgebra R₂ L] [Module R₁ M] [Module R₂ M] [LieRingModule L M]

--- a/Mathlib/Algebra/Lie/Semisimple/Basic.lean
+++ b/Mathlib/Algebra/Lie/Semisimple/Basic.lean
@@ -48,7 +48,7 @@ variable (R L : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]
 
 variable {R L} in
 theorem HasTrivialRadical.eq_bot_of_isSolvable [HasTrivialRadical R L]
-    (I : LieIdeal R L) [hI : IsSolvable R I] : I = ⊥ :=
+    (I : LieIdeal R L) [hI : IsSolvable I] : I = ⊥ :=
   sSup_eq_bot.mp radical_eq_bot _ hI
 
 @[simp]
@@ -56,19 +56,19 @@ theorem HasTrivialRadical.center_eq_bot [HasTrivialRadical R L] : center R L = �
   HasTrivialRadical.eq_bot_of_isSolvable _
 
 variable {R L} in
-theorem hasTrivialRadical_of_no_solvable_ideals (h : ∀ I : LieIdeal R L, IsSolvable R I → I = ⊥) :
+theorem hasTrivialRadical_of_no_solvable_ideals (h : ∀ I : LieIdeal R L, IsSolvable I → I = ⊥) :
     HasTrivialRadical R L :=
   ⟨sSup_eq_bot.mpr h⟩
 
 theorem hasTrivialRadical_iff_no_solvable_ideals :
-    HasTrivialRadical R L ↔ ∀ I : LieIdeal R L, IsSolvable R I → I = ⊥ :=
+    HasTrivialRadical R L ↔ ∀ I : LieIdeal R L, IsSolvable I → I = ⊥ :=
   ⟨@HasTrivialRadical.eq_bot_of_isSolvable _ _ _ _ _, hasTrivialRadical_of_no_solvable_ideals⟩
 
 theorem hasTrivialRadical_iff_no_abelian_ideals :
     HasTrivialRadical R L ↔ ∀ I : LieIdeal R L, IsLieAbelian I → I = ⊥ := by
   rw [hasTrivialRadical_iff_no_solvable_ideals]
   constructor <;> intro h₁ I h₂
-  · exact h₁ _ <| LieAlgebra.ofAbelianIsSolvable R I
+  · exact h₁ _ <| LieAlgebra.ofAbelianIsSolvable I
   · rw [← abelian_of_solvable_ideal_eq_bot_iff]
     exact h₁ _ <| abelian_derivedAbelianOfIdeal I
 
@@ -318,7 +318,7 @@ to be reductive.
 Note that there is absolutely [no agreement](https://mathoverflow.net/questions/284713/) on what
 the label 'reductive' should mean when the coefficients are not a field of characteristic zero. -/
 theorem abelian_radical_iff_solvable_is_abelian [IsNoetherian R L] :
-    IsLieAbelian (radical R L) ↔ ∀ I : LieIdeal R L, IsSolvable R I → IsLieAbelian I := by
+    IsLieAbelian (radical R L) ↔ ∀ I : LieIdeal R L, IsSolvable I → IsLieAbelian I := by
   constructor
   · rintro h₁ I h₂
     rw [LieIdeal.solvable_iff_le_radical] at h₂

--- a/Mathlib/Algebra/Lie/Solvable.lean
+++ b/Mathlib/Algebra/Lie/Solvable.lean
@@ -203,7 +203,7 @@ theorem derivedSeries_scalars_aux (R₁ R₂ L : Type*) [CommRing R₁] [CommRin
   | smul_mem c y hy =>
       obtain ⟨a, ha, b, hb, rfl⟩ := hy
       rw [← smul_lie]
-      refine Submodule.subset_span ⟨c • a, ?_, b, hb, rfl⟩ 
+      refine Submodule.subset_span ⟨c • a, ?_, b, hb, rfl⟩
       rw [← ih] at ha ⊢
       exact Submodule.smul_mem _ _ ha
 

--- a/Mathlib/Algebra/Lie/Solvable.lean
+++ b/Mathlib/Algebra/Lie/Solvable.lean
@@ -193,18 +193,19 @@ theorem derivedSeries_eq_top (n : ℕ) (h : derivedSeries R L 1 = ⊤) :
 theorem derivedSeries_scalars_aux (R₁ R₂ L : Type*) [CommRing R₁] [CommRing R₂]
     [LieRing L] [LieAlgebra R₁ L] [LieAlgebra R₂ L] (k : ℕ)
     (ih : ∀ (x : L), x ∈ derivedSeriesOfIdeal R₁ L k ⊤ ↔ x ∈ derivedSeriesOfIdeal R₂ L k ⊤) :
-    let I := derivedSeriesOfIdeal R₂ L k ⊤
-    (Submodule.span R₁ {⁅a, b⁆ | (a ∈ I) (b ∈ I)} : Set L) ≤
-    (Submodule.span R₂ {⁅a, b⁆ | (a ∈ I) (b ∈ I)} : Set L) := by
-  intro I x hx
+    let I := derivedSeriesOfIdeal R₂ L k ⊤; let S : Set L := {⁅a, b⁆ | (a ∈ I) (b ∈ I)}
+    (Submodule.span R₁ S : Set L) ≤ (Submodule.span R₂ S : Set L) := by
+  intro I S x hx
   simp only [SetLike.mem_coe] at hx ⊢
-  induction hx using Submodule.span_induction with
-  | mem y hy =>
-    obtain ⟨a, ha, b, hb, rfl⟩ := hy
-    exact Submodule.subset_span ⟨a, ha, b, hb, rfl⟩
-  | zero => sorry
-  | add => sorry
-  | smul => sorry
+  induction hx using Submodule.closure_induction with
+  | zero => exact Submodule.zero_mem _
+  | add y z hy₁ hz₁ hy₂ hz₂ => exact Submodule.add_mem _ hy₂ hz₂
+  | smul_mem c y hy =>
+      obtain ⟨a, ha, b, hb, rfl⟩ := hy
+      rw [← smul_lie]
+      refine Submodule.subset_span ⟨c • a, ?_, b, hb, rfl⟩ 
+      rw [← ih] at ha ⊢
+      exact Submodule.smul_mem _ _ ha
 
 theorem derivedSeries_scalars (R₁ R₂ L : Type*) [CommRing R₁] [CommRing R₂]
     [LieRing L] [LieAlgebra R₁ L] [LieAlgebra R₂ L] (k : ℕ) :
@@ -231,18 +232,31 @@ end LieIdeal
 namespace LieAlgebra
 
 /-- A Lie algebra is solvable if its derived series reaches 0 (in a finite number of steps). -/
+@[mk_iff isSolvable_iff_int]
 class IsSolvable : Prop where
-  solvable : ∃ k, derivedSeries R L k = ⊥
+  mk_int ::
+  solvable_int : ∃ k, derivedSeries ℤ L k = ⊥
 
-instance isSolvableBot : IsSolvable R (⊥ : LieIdeal R L) :=
+instance isSolvableBot : IsSolvable (⊥ : LieIdeal R L) :=
   ⟨⟨0, Subsingleton.elim _ ⊥⟩⟩
 
-instance isSolvableAdd {I J : LieIdeal R L} [hI : IsSolvable R I] [hJ : IsSolvable R J] :
-    IsSolvable R (I + J) := by
-  obtain ⟨k, hk⟩ := id hI; obtain ⟨l, hl⟩ := id hJ
-  exact ⟨⟨k + l, LieIdeal.derivedSeries_add_eq_bot hk hl⟩⟩
+lemma isSolvable_iff : IsSolvable L ↔ ∃ k, derivedSeries R L k = ⊥ := by
+  simp [isSolvable_iff_int, SetLike.ext'_iff, LieIdeal.derivedSeries_scalars R ℤ L]
 
-theorem derivedSeries_lt_top_of_solvable [IsSolvable R L] [Nontrivial L] :
+lemma IsSolvable.solvable [IsSolvable L] : ∃ k, derivedSeries R L k = ⊥ :=
+  (isSolvable_iff R L).mp ‹_›
+
+variable {R L} in
+lemma IsSolvable.mk {k : ℕ} (h : derivedSeries R L k = ⊥) : IsSolvable L :=
+  (isSolvable_iff R L).mpr ⟨k, h⟩
+
+instance isSolvableAdd {I J : LieIdeal R L} [IsSolvable I] [IsSolvable J] :
+    IsSolvable (I + J) := by
+  obtain ⟨k, hk⟩ := IsSolvable.solvable R I
+  obtain ⟨l, hl⟩ := IsSolvable.solvable R J
+  exact IsSolvable.mk (LieIdeal.derivedSeries_add_eq_bot hk hl)
+
+theorem derivedSeries_lt_top_of_solvable [IsSolvable L] [Nontrivial L] :
     derivedSeries R L 1 < ⊤ := by
   obtain ⟨n, hn⟩ := IsSolvable.solvable (R := R) (L := L)
   rw [lt_top_iff_ne_top]
@@ -258,76 +272,78 @@ namespace Function
 
 open LieAlgebra
 
-theorem Injective.lieAlgebra_isSolvable [h₁ : IsSolvable R L] (h₂ : Injective f) :
-    IsSolvable R L' := by
-  obtain ⟨k, hk⟩ := id h₁
-  use k
-  apply LieIdeal.bot_of_map_eq_bot h₂; rw [eq_bot_iff, ← hk]
+theorem Injective.lieAlgebra_isSolvable [hL : IsSolvable L] (h : Injective f) :
+    IsSolvable L' := by
+  rw [isSolvable_iff R] at hL ⊢
+  apply hL.imp
+  intro k hk
+  apply LieIdeal.bot_of_map_eq_bot h; rw [eq_bot_iff, ← hk]
   apply LieIdeal.derivedSeries_map_le
 
-instance (A : LieIdeal R L) [IsSolvable R L] : IsSolvable R A :=
+instance (A : LieIdeal R L) [IsSolvable L] : IsSolvable A :=
   A.incl_injective.lieAlgebra_isSolvable
 
-theorem Surjective.lieAlgebra_isSolvable [h₁ : IsSolvable R L'] (h₂ : Surjective f) :
-    IsSolvable R L := by
-  obtain ⟨k, hk⟩ := id h₁
-  use k
-  rw [← LieIdeal.derivedSeries_map_eq k h₂, hk]
+theorem Surjective.lieAlgebra_isSolvable [hL' : IsSolvable L'] (h : Surjective f) :
+    IsSolvable L := by
+  rw [isSolvable_iff R] at hL' ⊢
+  apply hL'.imp
+  intro k hk
+  rw [← LieIdeal.derivedSeries_map_eq k h, hk]
   simp only [LieIdeal.map_eq_bot_iff, bot_le]
 
 end Function
 
-instance LieHom.isSolvable_range (f : L' →ₗ⁅R⁆ L) [LieAlgebra.IsSolvable R L'] :
-    LieAlgebra.IsSolvable R f.range :=
+instance LieHom.isSolvable_range (f : L' →ₗ⁅R⁆ L) [LieAlgebra.IsSolvable L'] :
+    LieAlgebra.IsSolvable f.range :=
   f.surjective_rangeRestrict.lieAlgebra_isSolvable
 
 namespace LieAlgebra
 
-theorem solvable_iff_equiv_solvable (e : L' ≃ₗ⁅R⁆ L) : IsSolvable R L' ↔ IsSolvable R L := by
+theorem solvable_iff_equiv_solvable (e : L' ≃ₗ⁅R⁆ L) : IsSolvable L' ↔ IsSolvable L := by
   constructor <;> intro h
   · exact e.symm.injective.lieAlgebra_isSolvable
   · exact e.injective.lieAlgebra_isSolvable
 
-theorem le_solvable_ideal_solvable {I J : LieIdeal R L} (h₁ : I ≤ J) (_ : IsSolvable R J) :
-    IsSolvable R I :=
+theorem le_solvable_ideal_solvable {I J : LieIdeal R L} (h₁ : I ≤ J) (_ : IsSolvable J) :
+    IsSolvable I :=
   (LieIdeal.inclusion_injective h₁).lieAlgebra_isSolvable
 
 variable (R L)
 
-instance (priority := 100) ofAbelianIsSolvable [IsLieAbelian L] : IsSolvable R L := by
+instance (priority := 100) ofAbelianIsSolvable [IsLieAbelian L] : IsSolvable L := by
   use 1
   rw [← abelian_iff_derived_one_eq_bot, lie_abelian_iff_equiv_lie_abelian LieIdeal.topEquiv]
   infer_instance
 
 /-- The (solvable) radical of Lie algebra is the `sSup` of all solvable ideals. -/
 def radical :=
-  sSup { I : LieIdeal R L | IsSolvable R I }
+  sSup { I : LieIdeal R L | IsSolvable I }
 
 /-- The radical of a Noetherian Lie algebra is solvable. -/
-instance radicalIsSolvable [IsNoetherian R L] : IsSolvable R (radical R L) := by
+instance radicalIsSolvable [IsNoetherian R L] : IsSolvable (radical R L) := by
   have hwf := LieSubmodule.wellFoundedGT_of_noetherian R L L
   rw [← CompleteLattice.isSupClosedCompact_iff_wellFoundedGT] at hwf
-  refine hwf { I : LieIdeal R L | IsSolvable R I } ⟨⊥, ?_⟩ fun I hI J hJ => ?_
+  refine hwf { I : LieIdeal R L | IsSolvable I } ⟨⊥, ?_⟩ fun I hI J hJ => ?_
   · exact LieAlgebra.isSolvableBot R L
   · rw [Set.mem_setOf_eq] at hI hJ ⊢
     apply LieAlgebra.isSolvableAdd R L
 
 /-- The `→` direction of this lemma is actually true without the `IsNoetherian` assumption. -/
 theorem LieIdeal.solvable_iff_le_radical [IsNoetherian R L] (I : LieIdeal R L) :
-    IsSolvable R I ↔ I ≤ radical R L :=
+    IsSolvable I ↔ I ≤ radical R L :=
   ⟨fun h => le_sSup h, fun h => le_solvable_ideal_solvable h inferInstance⟩
 
 theorem center_le_radical : center R L ≤ radical R L :=
-  have h : IsSolvable R (center R L) := inferInstance
+  have h : IsSolvable (center R L) := inferInstance
   le_sSup h
 
-instance [IsSolvable R L] : IsSolvable R (⊤ : LieSubalgebra R L) := by
+instance [IsSolvable L] : IsSolvable (⊤ : LieSubalgebra R L) := by
   rwa [solvable_iff_equiv_solvable LieSubalgebra.topEquiv]
 
-@[simp] lemma radical_eq_top_of_isSolvable [IsSolvable R L] :
+@[simp] lemma radical_eq_top_of_isSolvable [IsSolvable L] :
     radical R L = ⊤ := by
   rw [eq_top_iff]
-  have h : IsSolvable R (⊤ : LieSubalgebra R L) := inferInstance
+  have h : IsSolvable (⊤ : LieSubalgebra R L) := inferInstance
   exact le_sSup h
 
 /-- Given a solvable Lie ideal `I` with derived series `I = D₀ ≥ D₁ ≥ ⋯ ≥ Dₖ = ⊥`, this is the
@@ -384,17 +400,17 @@ theorem abelian_derivedAbelianOfIdeal (I : LieIdeal R L) :
   · dsimp; infer_instance
   · rw [derivedSeries_of_derivedLength_succ] at h; exact h.1
 
-theorem derivedLength_zero (I : LieIdeal R L) [hI : IsSolvable R I] :
+theorem derivedLength_zero (I : LieIdeal R L) [IsSolvable I] :
     derivedLengthOfIdeal R L I = 0 ↔ I = ⊥ := by
   let s := { k | derivedSeriesOfIdeal R L k I = ⊥ }
   change sInf s = 0 ↔ _
   have hne : s ≠ ∅ := by
-    obtain ⟨k, hk⟩ := id hI
+    obtain ⟨k, hk⟩ := IsSolvable.solvable R I
     refine Set.Nonempty.ne_empty ⟨k, ?_⟩
     rw [derivedSeries_def, LieIdeal.derivedSeries_eq_bot_iff] at hk; exact hk
   simp [s, hne]
 
-theorem abelian_of_solvable_ideal_eq_bot_iff (I : LieIdeal R L) [h : IsSolvable R I] :
+theorem abelian_of_solvable_ideal_eq_bot_iff (I : LieIdeal R L) [h : IsSolvable I] :
     derivedAbelianOfIdeal I = ⊥ ↔ I = ⊥ := by
   dsimp only [derivedAbelianOfIdeal]
   split -- Porting note: Original tactic was `cases' h : derivedAbelianOfIdeal R L I with k`

--- a/Mathlib/Algebra/Lie/Solvable.lean
+++ b/Mathlib/Algebra/Lie/Solvable.lean
@@ -190,7 +190,7 @@ theorem derivedSeries_eq_top (n : ℕ) (h : derivedSeries R L 1 = ⊤) :
   · rfl
   · rwa [derivedSeries_succ_eq_top_iff]
 
-theorem derivedSeries_scalars_aux (R₁ R₂ L : Type*) [CommRing R₁] [CommRing R₂]
+private theorem coe_derivedSeries_eq_int_aux (R₁ R₂ L : Type*) [CommRing R₁] [CommRing R₂]
     [LieRing L] [LieAlgebra R₁ L] [LieAlgebra R₂ L] (k : ℕ)
     (ih : ∀ (x : L), x ∈ derivedSeriesOfIdeal R₁ L k ⊤ ↔ x ∈ derivedSeriesOfIdeal R₂ L k ⊤) :
     let I := derivedSeriesOfIdeal R₂ L k ⊤; let S : Set L := {⁅a, b⁆ | (a ∈ I) (b ∈ I)}
@@ -207,11 +207,9 @@ theorem derivedSeries_scalars_aux (R₁ R₂ L : Type*) [CommRing R₁] [CommRin
       rw [← ih] at ha ⊢
       exact Submodule.smul_mem _ _ ha
 
-theorem derivedSeries_scalars (R₁ R₂ L : Type*) [CommRing R₁] [CommRing R₂]
-    [LieRing L] [LieAlgebra R₁ L] [LieAlgebra R₂ L] (k : ℕ) :
-    (derivedSeries R₁ L k : Set L) = (derivedSeries R₂ L k : Set L) := by
-  show ((derivedSeries R₁ L k).toSubmodule : Set L) =
-       ((derivedSeries R₂ L k).toSubmodule : Set L)
+theorem coe_derivedSeries_eq_int (k : ℕ) :
+    (derivedSeries R L k : Set L) = (derivedSeries ℤ L k : Set L) := by
+  show ((derivedSeries R L k).toSubmodule : Set L) = ((derivedSeries ℤ L k).toSubmodule : Set L)
   rw [derivedSeries_def, derivedSeries_def]
   induction k with
   | zero => rfl
@@ -222,9 +220,9 @@ theorem derivedSeries_scalars (R₁ R₂ L : Type*) [CommRing R₁] [CommRing R�
     simp only [SetLike.mem_coe, LieSubmodule.mem_toSubmodule] at ih
     simp only [Subtype.exists, exists_prop, ih]
     apply le_antisymm
-    · exact derivedSeries_scalars_aux _ _ L k ih
+    · exact coe_derivedSeries_eq_int_aux _ _ L k ih
     · simp only [← ih]
-      apply derivedSeries_scalars_aux _ _ L k
+      apply coe_derivedSeries_eq_int_aux _ _ L k
       simp [ih]
 
 end LieIdeal
@@ -241,7 +239,7 @@ instance isSolvableBot : IsSolvable (⊥ : LieIdeal R L) :=
   ⟨⟨0, Subsingleton.elim _ ⊥⟩⟩
 
 lemma isSolvable_iff : IsSolvable L ↔ ∃ k, derivedSeries R L k = ⊥ := by
-  simp [isSolvable_iff_int, SetLike.ext'_iff, LieIdeal.derivedSeries_scalars R ℤ L]
+  simp [isSolvable_iff_int, SetLike.ext'_iff, LieIdeal.coe_derivedSeries_eq_int]
 
 lemma IsSolvable.solvable [IsSolvable L] : ∃ k, derivedSeries R L k = ⊥ :=
   (isSolvable_iff R L).mp ‹_›

--- a/Mathlib/Algebra/Lie/Solvable.lean
+++ b/Mathlib/Algebra/Lie/Solvable.lean
@@ -190,6 +190,42 @@ theorem derivedSeries_eq_top (n : ℕ) (h : derivedSeries R L 1 = ⊤) :
   · rfl
   · rwa [derivedSeries_succ_eq_top_iff]
 
+theorem derivedSeries_scalars_aux (R₁ R₂ L : Type*) [CommRing R₁] [CommRing R₂]
+    [LieRing L] [LieAlgebra R₁ L] [LieAlgebra R₂ L] (k : ℕ)
+    (ih : ∀ (x : L), x ∈ derivedSeriesOfIdeal R₁ L k ⊤ ↔ x ∈ derivedSeriesOfIdeal R₂ L k ⊤) :
+    let I := derivedSeriesOfIdeal R₂ L k ⊤
+    (Submodule.span R₁ {⁅a, b⁆ | (a ∈ I) (b ∈ I)} : Set L) ≤
+    (Submodule.span R₂ {⁅a, b⁆ | (a ∈ I) (b ∈ I)} : Set L) := by
+  intro I x hx
+  simp only [SetLike.mem_coe] at hx ⊢
+  induction hx using Submodule.span_induction with
+  | mem y hy =>
+    obtain ⟨a, ha, b, hb, rfl⟩ := hy
+    exact Submodule.subset_span ⟨a, ha, b, hb, rfl⟩
+  | zero => sorry
+  | add => sorry
+  | smul => sorry
+
+theorem derivedSeries_scalars (R₁ R₂ L : Type*) [CommRing R₁] [CommRing R₂]
+    [LieRing L] [LieAlgebra R₁ L] [LieAlgebra R₂ L] (k : ℕ) :
+    (derivedSeries R₁ L k : Set L) = (derivedSeries R₂ L k : Set L) := by
+  show ((derivedSeries R₁ L k).toSubmodule : Set L) =
+       ((derivedSeries R₂ L k).toSubmodule : Set L)
+  rw [derivedSeries_def, derivedSeries_def]
+  induction k with
+  | zero => rfl
+  | succ k ih =>
+    rw [derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_succ]
+    rw [LieSubmodule.lieIdeal_oper_eq_linear_span', LieSubmodule.lieIdeal_oper_eq_linear_span']
+    rw [Set.ext_iff] at ih
+    simp only [SetLike.mem_coe, LieSubmodule.mem_toSubmodule] at ih
+    simp only [Subtype.exists, exists_prop, ih]
+    apply le_antisymm
+    · exact derivedSeries_scalars_aux _ _ L k ih
+    · simp only [← ih]
+      apply derivedSeries_scalars_aux _ _ L k
+      simp [ih]
+
 end LieIdeal
 
 namespace LieAlgebra

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -94,7 +94,7 @@ lemma traceForm_lieInvariant : (traceForm R L M).lieInvariant L := by
   rw [LieHom.lie_apply, LinearMap.sub_apply, Module.Dual.lie_apply, LinearMap.zero_apply,
     LinearMap.zero_apply, traceForm_apply_lie_apply', sub_self]
 
-@[simp] lemma traceForm_eq_zero_of_isNilpotent [IsReduced R] [IsNilpotent R L M] :
+@[simp] lemma traceForm_eq_zero_of_isNilpotent [IsReduced R] [IsNilpotent L M] :
     traceForm R L M = 0 := by
   ext x y
   simp only [traceForm_apply_apply, LinearMap.zero_apply, ← isNilpotent_iff_eq_zero]
@@ -104,7 +104,7 @@ lemma traceForm_lieInvariant : (traceForm R L M).lieInvariant L := by
 @[simp]
 lemma traceForm_genWeightSpace_eq [Module.Free R M]
     [IsDomain R] [IsPrincipalIdealRing R]
-    [LieAlgebra.IsNilpotent R L] [IsNoetherian R M] [LinearWeights R L M] (χ : L → R) (x y : L) :
+    [LieRing.IsNilpotent L] [IsNoetherian R M] [LinearWeights R L M] (χ : L → R) (x y : L) :
     traceForm R L (genWeightSpace M χ) x y = finrank R (genWeightSpace M χ) • (χ x * χ y) := by
   set d := finrank R (genWeightSpace M χ)
   have h₁ : χ y • d • χ x - χ y • χ x • (d : R) = 0 := by simp [mul_comm (χ x)]
@@ -160,7 +160,7 @@ lemma traceForm_apply_eq_zero_of_mem_lcs_of_mem_center {x y : L}
 /-- Given a bilinear form `B` on a representation `M` of a nilpotent Lie algebra `L`, if `B` is
 invariant (in the sense that the action of `L` is skew-adjoint wrt `B`) then components of the
 Fitting decomposition of `M` are orthogonal wrt `B`. -/
-lemma eq_zero_of_mem_genWeightSpace_mem_posFitting [LieAlgebra.IsNilpotent R L]
+lemma eq_zero_of_mem_genWeightSpace_mem_posFitting [LieRing.IsNilpotent L]
     {B : LinearMap.BilinForm R M} (hB : ∀ (x : L) (m n : M), B ⁅x, m⁆ n = - B m ⁅x, n⁆)
     {m₀ m₁ : M} (hm₀ : m₀ ∈ genWeightSpace M (0 : L → R)) (hm₁ : m₁ ∈ posFittingComp R L M) :
     B m₀ m₁ = 0 := by
@@ -211,7 +211,7 @@ lemma traceForm_lieSubalgebra_mk_right (L' : LieSubalgebra R L) {x : L'} {y : L}
 
 open TensorProduct
 
-variable [LieAlgebra.IsNilpotent R L] [IsDomain R] [IsPrincipalIdealRing R]
+variable [LieRing.IsNilpotent L] [IsDomain R] [IsPrincipalIdealRing R]
 
 lemma traceForm_eq_sum_genWeightSpaceOf
     [NoZeroSMulDivisors R M] [IsNoetherian R M] [IsTriangularizable R L M] (z : L) :
@@ -344,7 +344,7 @@ lemma killingForm_apply_apply (x y : L) : killingForm R L x y = trace R L (ad R 
   LieModule.traceForm_apply_apply R L L x y
 
 lemma killingForm_eq_zero_of_mem_zeroRoot_mem_posFitting
-    (H : LieSubalgebra R L) [LieAlgebra.IsNilpotent R H]
+    (H : LieSubalgebra R L) [LieRing.IsNilpotent H]
     {x₀ x₁ : L}
     (hx₀ : x₀ ∈ LieAlgebra.zeroRootSubalgebra R L H)
     (hx₁ : x₁ ∈ LieModule.posFittingComp R H L) :
@@ -399,7 +399,7 @@ open Submodule (span subset_span)
 namespace LieModule
 
 variable [Field K] [LieAlgebra K L] [Module K M] [LieModule K L M] [FiniteDimensional K M]
-variable [LieAlgebra.IsNilpotent K L] [LinearWeights K L M] [IsTriangularizable K L M]
+variable [LieRing.IsNilpotent L] [LinearWeights K L M] [IsTriangularizable K L M]
 
 lemma traceForm_eq_sum_finrank_nsmul_mul (x y : L) :
     traceForm K L M x y = ∑ χ : Weight K L M, finrank K (genWeightSpace M χ) • (χ x * χ y) := by

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -156,7 +156,7 @@ variable (M)
 `genWeightSpaceOf M χ x` is the maximal generalized `χ`-eigenspace of the action of `x` on `M`.
 
 It is a Lie submodule because `L` is nilpotent. -/
-def genWeightSpaceOf [LieAlgebra.IsNilpotent R L] (χ : R) (x : L) : LieSubmodule R L M :=
+def genWeightSpaceOf [LieRing.IsNilpotent L] (χ : R) (x : L) : LieSubmodule R L M :=
   { 𝕎(M, χ, x) with
     lie_mem := by
       intro y m hm
@@ -168,7 +168,7 @@ def genWeightSpaceOf [LieAlgebra.IsNilpotent R L] (χ : R) (x : L) : LieSubmodul
 end notation_genWeightSpaceOf
 
 variable (M)
-variable [LieAlgebra.IsNilpotent R L]
+variable [LieRing.IsNilpotent L]
 
 theorem mem_genWeightSpaceOf (χ : R) (x : L) (m : M) :
     m ∈ genWeightSpaceOf M χ x ↔ ∃ k : ℕ, ((toEnd R L M x - χ • ↑1) ^ k) m = 0 := by
@@ -298,7 +298,7 @@ end Weight
 
 /-- See also the more useful form `LieModule.zero_genWeightSpace_eq_top_of_nilpotent`. -/
 @[simp]
-theorem zero_genWeightSpace_eq_top_of_nilpotent' [IsNilpotent R L M] :
+theorem zero_genWeightSpace_eq_top_of_nilpotent' [IsNilpotent L M] :
     genWeightSpace M (0 : L → R) = ⊤ := by
   ext
   simp [genWeightSpace, genWeightSpaceOf]
@@ -311,7 +311,7 @@ theorem coe_genWeightSpace_of_top (χ : L → R) :
   simp
 
 @[simp]
-theorem zero_genWeightSpace_eq_top_of_nilpotent [IsNilpotent R L M] :
+theorem zero_genWeightSpace_eq_top_of_nilpotent [IsNilpotent L M] :
     genWeightSpace M (0 : (⊤ : LieSubalgebra R L) → R) = ⊤ := by
   ext m
   simp only [mem_genWeightSpace, Pi.zero_apply, zero_smul, sub_zero, Subtype.forall,
@@ -356,7 +356,7 @@ theorem isNilpotent_toEnd_genWeightSpace_zero [IsNoetherian R M] (x : L) :
 
 /-- By Engel's theorem, the zero weight space of a Noetherian Lie module is nilpotent. -/
 instance [IsNoetherian R M] :
-    IsNilpotent R L (genWeightSpace M (0 : L → R)) :=
+    IsNilpotent L (genWeightSpace M (0 : L → R)) :=
   isNilpotent_iff_forall'.mpr <| isNilpotent_toEnd_genWeightSpace_zero M
 
 variable (R L)
@@ -437,7 +437,7 @@ lemma mem_posFittingCompOf (x : L) (m : M) :
     exact LieSubmodule.lie_mem_lie (LieSubmodule.mem_top x) ih
 
 @[simp] lemma posFittingCompOf_eq_bot_of_isNilpotent
-    [IsNilpotent R L M] (x : L) :
+    [IsNilpotent L M] (x : L) :
     posFittingCompOf R M x = ⊥ := by
   simp_rw [eq_bot_iff, ← iInf_lowerCentralSeries_eq_bot_of_isNilpotent, le_iInf_iff,
     posFittingCompOf_le_lowerCentralSeries, forall_const]
@@ -470,7 +470,7 @@ lemma posFittingComp_le_iInf_lowerCentralSeries :
     ⨅ k, lowerCentralSeries R L M k = posFittingComp R L M := by
   refine le_antisymm ?_ (posFittingComp_le_iInf_lowerCentralSeries R L M)
   apply iInf_lcs_le_of_isNilpotent_quot
-  rw [LieModule.isNilpotent_iff_forall']
+  rw [LieModule.isNilpotent_iff_forall' (R := R)]
   intro x
   obtain ⟨k, hk⟩ := Filter.eventually_atTop.mp (toEnd R L M x).eventually_iInf_range_pow_eq
   use k
@@ -488,7 +488,7 @@ lemma posFittingComp_le_iInf_lowerCentralSeries :
   simpa using this
 
 @[simp] lemma posFittingComp_eq_bot_of_isNilpotent
-    [IsNilpotent R L M] :
+    [IsNilpotent L M] :
     posFittingComp R L M = ⊥ := by
   simp [posFittingComp]
 
@@ -603,9 +603,9 @@ private lemma isCompl_genWeightSpace_zero_posFittingComp_aux
   set M₁ := posFittingComp R L M
   rcases forall_or_exists_not (fun (x : L) ↦ genWeightSpaceOf M (0 : R) x = ⊤)
     with h | ⟨x, hx : genWeightSpaceOf M (0 : R) x ≠ ⊤⟩
-  · suffices IsNilpotent R L M by simp [M₀, M₁, isCompl_top_bot]
+  · suffices IsNilpotent L M by simp [M₀, M₁, isCompl_top_bot]
     replace h : M₀ = ⊤ := by simpa [M₀, genWeightSpace]
-    rw [← LieModule.isNilpotent_of_top_iff', ← h]
+    rw [← LieModule.isNilpotent_of_top_iff' (R := R), ← h]
     infer_instance
   · set M₀ₓ := genWeightSpaceOf M (0 : R) x
     set M₁ₓ := posFittingCompOf R M x
@@ -750,8 +750,7 @@ section field
 open Module
 
 variable (K)
-variable [Field K] [LieAlgebra K L] [Module K M] [LieModule K L M] [LieAlgebra.IsNilpotent K L]
-  [FiniteDimensional K M]
+variable [Field K] [LieAlgebra K L] [Module K M] [LieModule K L M] [FiniteDimensional K M]
 
 instance instIsTriangularizableOfIsAlgClosed [IsAlgClosed K] : IsTriangularizable K L M :=
   ⟨fun _ ↦ Module.End.iSup_maxGenEigenspace_eq_top _⟩

--- a/Mathlib/Algebra/Lie/Weights/Cartan.lean
+++ b/Mathlib/Algebra/Lie/Weights/Cartan.lean
@@ -31,7 +31,7 @@ suppress_compilation
 open Set
 
 variable {R L : Type*} [CommRing R] [LieRing L] [LieAlgebra R L]
-  (H : LieSubalgebra R L) [LieAlgebra.IsNilpotent R H]
+  (H : LieSubalgebra R L) [LieRing.IsNilpotent H]
   {M : Type*} [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
 
 namespace LieAlgebra
@@ -44,7 +44,7 @@ space of `L` regarded as a module of `H` via the adjoint action. -/
 abbrev rootSpace (χ : H → R) : LieSubmodule R H L :=
   genWeightSpace L χ
 
-theorem zero_rootSpace_eq_top_of_nilpotent [IsNilpotent R L] :
+theorem zero_rootSpace_eq_top_of_nilpotent [LieRing.IsNilpotent L] :
     rootSpace (⊤ : LieSubalgebra R L) 0 = ⊤ :=
   zero_genWeightSpace_eq_top_of_nilpotent L
 
@@ -170,7 +170,7 @@ theorem toLieSubmodule_le_rootSpace_zero : H.toLieSubmodule ≤ rootSpace H 0 :=
   simp only [LieSubalgebra.mem_toLieSubmodule] at hx
   simp only [mem_genWeightSpace, Pi.zero_apply, sub_zero, zero_smul]
   intro y
-  obtain ⟨k, hk⟩ := (inferInstance : IsNilpotent R H)
+  obtain ⟨k, hk⟩ := IsNilpotent.nilpotent R H H
   use k
   let f : Module.End R H := toEnd R H H y
   let g : Module.End R L := toEnd R H L y

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -50,7 +50,7 @@ namespace LieModule
 
 section IsNilpotent
 
-variable [LieAlgebra.IsNilpotent R L] (χ₁ χ₂ : L → R) (p q : ℤ)
+variable [LieRing.IsNilpotent L] (χ₁ χ₂ : L → R) (p q : ℤ)
 
 section
 
@@ -121,7 +121,7 @@ open LieAlgebra
 
 variable {H : LieSubalgebra R L} (α χ : H → R) (p q : ℤ)
 
-lemma lie_mem_genWeightSpaceChain_of_genWeightSpace_eq_bot_right [LieAlgebra.IsNilpotent R H]
+lemma lie_mem_genWeightSpaceChain_of_genWeightSpace_eq_bot_right [LieRing.IsNilpotent H]
     (hq : genWeightSpace M (q • α + χ) = ⊥)
     {x : L} (hx : x ∈ rootSpace H α)
     {y : M} (hy : y ∈ genWeightSpaceChain M α χ p q) :
@@ -144,7 +144,7 @@ lemma lie_mem_genWeightSpaceChain_of_genWeightSpace_eq_bot_right [LieAlgebra.IsN
   | h0 => simp
   | hadd _ _ _ _ hz₁ hz₂ => rw [lie_add]; exact add_mem hz₁ hz₂
 
-lemma lie_mem_genWeightSpaceChain_of_genWeightSpace_eq_bot_left [LieAlgebra.IsNilpotent R H]
+lemma lie_mem_genWeightSpaceChain_of_genWeightSpace_eq_bot_left [LieRing.IsNilpotent H]
     (hp : genWeightSpace M (p • α + χ) = ⊥)
     {x : L} (hx : x ∈ rootSpace H (-α))
     {y : M} (hy : y ∈ genWeightSpaceChain M α χ p q) :
@@ -234,7 +234,7 @@ end LieSubalgebra
 section
 
 variable {M}
-variable [LieAlgebra.IsNilpotent R L]
+variable [LieRing.IsNilpotent L]
 variable [NoZeroSMulDivisors ℤ R] [NoZeroSMulDivisors R M] [IsNoetherian R M]
 variable (α : L → R) (β : Weight R L M)
 

--- a/Mathlib/Algebra/Lie/Weights/Linear.lean
+++ b/Mathlib/Algebra/Lie/Weights/Linear.lean
@@ -48,14 +48,14 @@ namespace LieModule
 
 /-- A typeclass encoding the fact that a given Lie module has linear weights, vanishing on the
 derived ideal. -/
-class LinearWeights [LieAlgebra.IsNilpotent R L] : Prop where
+class LinearWeights [LieRing.IsNilpotent L] : Prop where
   map_add : ∀ χ : L → R, genWeightSpace M χ ≠ ⊥ → ∀ x y, χ (x + y) = χ x + χ y
   map_smul : ∀ χ : L → R, genWeightSpace M χ ≠ ⊥ → ∀ (t : R) x, χ (t • x) = t • χ x
   map_lie : ∀ χ : L → R, genWeightSpace M χ ≠ ⊥ → ∀ x y : L, χ ⁅x, y⁆ = 0
 
 namespace Weight
 
-variable [LieAlgebra.IsNilpotent R L] [LinearWeights R L M] (χ : Weight R L M)
+variable [LieRing.IsNilpotent L] [LinearWeights R L M] (χ : Weight R L M)
 
 /-- A weight of a Lie module, bundled as a linear map. -/
 @[simps]
@@ -115,7 +115,7 @@ section FiniteDimensional
 open Module
 
 variable [IsDomain R] [IsPrincipalIdealRing R] [Module.Free R M] [Module.Finite R M]
-  [LieAlgebra.IsNilpotent R L]
+  [LieRing.IsNilpotent L]
 
 lemma trace_comp_toEnd_genWeightSpace_eq (χ : L → R) :
     LinearMap.trace R _ ∘ₗ (toEnd R L (genWeightSpace M χ)).toLinearMap =
@@ -154,7 +154,7 @@ instance instLinearWeightsOfCharZero [CharZero R] :
 
 end FiniteDimensional
 
-variable [LieAlgebra.IsNilpotent R L] (χ : L → R)
+variable [LieRing.IsNilpotent L] (χ : L → R)
 
 /-- A type synonym for the `χ`-weight space but with the action of `x : L`
 on `m : genWeightSpace M χ`, shifted to act as `⁅x, m⁆ - χ x • m`. -/
@@ -222,15 +222,15 @@ lemma toEnd_eq (x : L) :
 
 /-- By Engel's theorem, if `M` is Noetherian, the shifted action `⁅x, m⁆ - χ x • m` makes the
 `χ`-weight space into a nilpotent Lie module. -/
-instance [IsNoetherian R M] : IsNilpotent R L (shiftedGenWeightSpace R L M χ) :=
+instance [IsNoetherian R M] : IsNilpotent L (shiftedGenWeightSpace R L M χ) :=
   LieModule.isNilpotent_iff_forall'.mpr fun x ↦ isNilpotent_toEnd_sub_algebraMap M χ x
 
 end shiftedGenWeightSpace
 
 open shiftedGenWeightSpace in
-/-- Given a Lie module `M` of a Lie algebra `L` with coefficients in `R`, if a function `χ : L → R`
-has a simultaneous generalized eigenvector for the action of `L` then it has a simultaneous true
-eigenvector, provided `M` is Noetherian and has linear weights. -/
+/-- Given a Lie module `M` of a nilpotent Lie algebra `L` with coefficients in `R`,
+if a function `χ : L → R` has a simultaneous generalized eigenvector for the action of `L`
+then it has a simultaneous true eigenvector, provided `M` is Noetherian and has linear weights. -/
 lemma exists_forall_lie_eq_smul [LinearWeights R L M] [IsNoetherian R M] (χ : Weight R L M) :
     ∃ m : M, m ≠ 0 ∧ ∀ x : L, ⁅x, m⁆ = χ x • m := by
   replace hχ : Nontrivial (shiftedGenWeightSpace R L M χ) :=
@@ -247,7 +247,7 @@ lemma exists_forall_lie_eq_smul [LinearWeights R L M] [IsNoetherian R M] (χ : W
 /-- See `LieModule.exists_nontrivial_weightSpace_of_isSolvable` for the variant that
 only assumes that `L` is solvable but additionally requires `k` to be of characteristic zero. -/
 lemma exists_nontrivial_weightSpace_of_isNilpotent [Field k] [LieAlgebra k L] [Module k M]
-    [Module.Finite k M] [LieModule k L M] [LieAlgebra.IsNilpotent k L] [LinearWeights k L M]
+    [Module.Finite k M] [LieModule k L M] [LinearWeights k L M]
     [IsTriangularizable k L M] [Nontrivial M] :
     ∃ χ : Module.Dual k L, Nontrivial (weightSpace M χ) := by
   obtain ⟨χ⟩ : Nonempty (Weight k L M) := by


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
