### PR TITLE
[Merged by Bors] - feat: make spanning condition in `RootSystem` symmetric for roots and coroots.

### DIFF
--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -392,6 +392,8 @@ def rootSystem :
         Function.comp_apply, Set.mem_range, Subtype.exists, exists_prop]
       exact ⟨reflectRoot α β, (by simpa using reflectRoot_isNonZero α β <| by simpa using hβ), rfl⟩)
     (by convert span_weight_isNonZero_eq_top K L H; ext; simp)
+    (fun α β ↦
+      ⟨chainBotCoeff β.1 α.1 - chainTopCoeff β.1 α.1, by simp [apply_coroot_eq_cast β.1 α.1]⟩)
 
 @[simp]
 lemma corootForm_rootSystem_eq_killing :

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash, Deepro Choudhury, Scott Carnahan
 -/
 import Mathlib.LinearAlgebra.RootSystem.Defs
+import Mathlib.LinearAlgebra.RootSystem.Finite.Nondegenerate
 
 /-!
 # Root data and root systems
@@ -184,7 +185,7 @@ private lemma coroot_eq_coreflection_of_root_eq' [CharZero R] [NoZeroSMulDivisor
 
 /-- In characteristic zero if there is no torsion, to check that two finite families of roots and
 coroots form a root pairing, it is sufficient to check that they are stable under reflections. -/
-def mk' [Finite ι] [CharZero R] [NoZeroSMulDivisors R M]
+def mk' [CharZero R] [NoZeroSMulDivisors R M]
     (p : PerfectPairing R M N)
     (root : ι ↪ M)
     (coroot : ι ↪ N)
@@ -232,7 +233,7 @@ protected lemma ext [CharZero R] [NoZeroSMulDivisors R M]
   rintro P₁ P₂ he hr - ⟨i, rfl⟩
   use i
   apply P₁.bijectiveRight.injective
-  apply Dual.eq_of_preReflection_mapsTo (finite_range P₁.root) P₁.span_eq_top
+  apply Dual.eq_of_preReflection_mapsTo (finite_range P₁.root) P₁.span_root_eq_top
   · exact hr ▸ he ▸ P₂.coroot_root_two i
   · exact hr ▸ he ▸ P₂.mapsTo_reflection_root i
   · exact P₁.coroot_root_two i
@@ -268,22 +269,28 @@ private lemma coroot_eq_coreflection_of_root_eq_of_span_eq_top [CharZero R] [NoZ
   · rw [hk, hij]
     exact (hs i).comp <| (hs j).comp (hs i)
 
-/-- In characteristic zero if there is no torsion, to check that a finite family of roots form a
-root system, we do not need to check that the coroots are stable under reflections since this
-follows from the corresponding property for the roots. -/
-def mk' [CharZero R] [NoZeroSMulDivisors R M]
-    (p : PerfectPairing R M N)
+/-- Over a field of characteristic zero, to check that a finite family of roots form a
+crystallographic root system, we do not need to check that the coroots are stable under reflections
+since this follows from the corresponding property for the roots. Likewise, we do not need to
+check that the coroots span. -/
+def mk' {k : Type*} [Field k] [CharZero k] [Module k M] [Module k N]
+    (p : PerfectPairing k M N)
     (root : ι ↪ M)
     (coroot : ι ↪ N)
     (hp : ∀ i, p.toLin (root i) (coroot i) = 2)
     (hs : ∀ i, MapsTo (preReflection (root i) (p.toLin.flip (coroot i))) (range root) (range root))
-    (hsp : span R (range root) = ⊤) :
-    RootSystem ι R M N where
-  span_eq_top := hsp
-  toRootPairing := RootPairing.mk' p root coroot hp hs <| by
+    (hsp : span k (range root) = ⊤)
+    (h_int : ∀ i j, ∃ z : ℤ, z = p (root i) (coroot j)) :
+    RootSystem ι k M N :=
+  let P := RootPairing.mk' p root coroot hp hs <| by
     rintro i - ⟨j, rfl⟩
     use RootPairing.equiv_of_mapsTo p root coroot i hs hp j
     refine (coroot_eq_coreflection_of_root_eq_of_span_eq_top p root coroot hp hs hsp ?_)
     rw [equiv_of_mapsTo_apply, (exist_eq_reflection_of_mapsTo  p root coroot i j hs).choose_spec]
+  have _i : P.IsCrystallographic := ⟨h_int⟩
+  have _i : Fintype ι := Fintype.ofFinite ι
+  { toRootPairing := P,
+    span_root_eq_top := hsp,
+    span_coroot_eq_top := P.rootSpan_eq_top_iff.mp hsp }
 
 end RootSystem

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -110,14 +110,16 @@ Note that the latter assumptions `[Free ℤ X₁] [Finite ℤ X₁] [Free ℤ X�
 supplied as mixins. -/
 abbrev RootDatum (X₁ X₂ : Type*) [AddCommGroup X₁] [AddCommGroup X₂] := RootPairing ι ℤ X₁ X₂
 
-/-- A root system is a root pairing for which the roots span their ambient module.
+/-- A root system is a root pairing for which the roots and coroots span their ambient modules.
 
 Note that this is slightly more general than the usual definition in the sense that `N` is not
 required to be the dual of `M`. -/
 structure RootSystem extends RootPairing ι R M N where
-  span_eq_top : span R (range root) = ⊤
+  span_root_eq_top : span R (range root) = ⊤
+  span_coroot_eq_top : span R (range coroot) = ⊤
 
-attribute [simp] RootSystem.span_eq_top
+attribute [simp] RootSystem.span_root_eq_top
+attribute [simp] RootSystem.span_coroot_eq_top
 
 namespace RootPairing
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -184,6 +184,14 @@ lemma orthogonal_corootSpan_eq :
     P.CorootForm.orthogonal P.corootSpan = LinearMap.ker P.CorootForm :=
   P.flip.orthogonal_rootSpan_eq
 
+lemma rootSpan_eq_top_iff :
+    P.rootSpan = ⊤ ↔ P.corootSpan = ⊤ := by
+  have := P.toPerfectPairing.reflexive_left
+  have := P.toPerfectPairing.reflexive_right
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩ <;> apply Submodule.eq_top_of_finrank_eq
+  · rw [P.finrank_corootSpan_eq, h, finrank_top, P.toPerfectPairing.finrank_eq]
+  · rw [← P.finrank_corootSpan_eq, h, finrank_top, P.toPerfectPairing.finrank_eq]
+
 end Field
 
 section LinearOrderedCommRing
@@ -215,7 +223,7 @@ lemma rootForm_pos_of_ne_zero {x : M} (hx : x ∈ P.rootSpan) (h : x ≠ 0) :
 lemma _root_.RootSystem.rootForm_anisotropic (P : RootSystem ι R M N) :
     P.RootForm.toQuadraticMap.Anisotropic :=
   fun x ↦ P.eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero <| by
-    simpa only [rootSpan, P.span_eq_top] using Submodule.mem_top
+    simpa only [rootSpan, P.span_root_eq_top] using Submodule.mem_top
 
 end LinearOrderedCommRing
 


### PR DESCRIPTION
The key change here is the additional axiom which I have added to root systems demanding `span R (range coroot) = ⊤`. 

This means that certain root pairings no longer qualify as root systems. We're in uncharted territory here (the informal literature only considers more specialised situations and so avoids this issue) but I claim the most useful definition will be one with a perfect symmetry between roots and coroots.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
