### PR TITLE
feat(Cache): two small features

### DIFF
--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -5,6 +5,7 @@ Authors: Arthur Paulino
 -/
 
 import Cache.Requests
+import Batteries.Data.String.Matcher
 
 def help : String := "Mathlib4 caching CLI
 Usage: cache [COMMAND]
@@ -14,6 +15,8 @@ Commands:
   get  [ARGS]  Download linked files missing on the local cache and decompress
   get! [ARGS]  Download all linked files and decompress
   get- [ARGS]  Download linked files missing to the local cache, but do no compress
+  miniget      Like get, but only download all files imported in some .lean file
+    from the current directory
   pack         Compress non-compressed build files into the local cache
   pack!        Compress build files into the local cache (no skipping)
   unpack       Decompress linked already downloaded files
@@ -59,13 +62,14 @@ def toPaths (args : List String) : List FilePath :=
 
 /-- Commands which (potentially) call `curl` for downloading files -/
 def curlArgs : List String :=
-  ["get", "get!", "get-", "put", "put!", "put-unpacked", "commit", "commit!"]
+  ["get", "get!", "get-", "miniget", "put", "put!", "put-unpacked", "commit", "commit!"]
 
 /-- Commands which (potentially) call `leantar` for decompressing downloaded files -/
 def leanTarArgs : List String :=
-  ["get", "get!", "pack", "pack!", "unpack", "lookup"]
+  ["get", "get!", "miniget", "pack", "pack!", "unpack", "lookup"]
 
 open Cache IO Hashing Requests System in
+open System.FilePath in
 def main (args : List String) : IO Unit := do
   if Lean.versionString == "4.8.0-rc1" && Lean.githash == "b470eb522bfd68ca96938c23f6a1bce79da8a99f" then do
     println "Unfortunately, you have a broken Lean v4.8.0-rc1 installation."
@@ -87,6 +91,24 @@ def main (args : List String) : IO Unit := do
   let get (args : List String) (force := false) (decompress := true) := do
     let hashMap ← if args.isEmpty then pure hashMap else hashMemo.filterByFilePaths (toPaths args)
     getFiles hashMap force force goodCurl decompress
+  let miniget := do
+    -- Find all .lean files in subdirectories (excluding .lake) of the current directory.
+    let allFiles := System.FilePath.walkDir (← IO.Process.getCurrentDir)
+      (fun p ↦ pure (p.fileName != some ".lake"))
+    let leanFiles := (← allFiles).filter (fun p ↦ p.extension == some "lean")
+    -- For each file, find all lines starting with "import Mathlib.",
+    let mut allModules := #[]
+    for fi in leanFiles do
+      allModules := allModules.append
+        ((← FS.lines fi).filter (·.startsWith "import Mathlib.")|>.map (·.stripPrefix "import "))
+    -- make sure to not barf on lines like "import Mathlib.X.Y -- a comment here":
+    -- strip everything after a comment.
+    allModules := allModules.map fun mod ↦
+      if mod.containsSubstr "--" then ((mod.splitOn "--").get! 0).trimRight else mod
+    -- and turn each "import Mathlib.X.Y.Z" into an argument "Mathlib.X.Y.Z.lean" to `get`.
+    let args := allModules.map fun mod ↦ mkFilePath (mod.splitOn ".") |>.addExtension "lean"
+    let hm ← hashMemo.filterByFilePaths args.toList
+    getFiles hm false false goodCurl true
   let pack (overwrite verbose unpackedOnly := false) := do
     packCache hashMap overwrite verbose unpackedOnly (← getGitCommitHash)
   let put (overwrite unpackedOnly := false) := do
@@ -95,6 +117,7 @@ def main (args : List String) : IO Unit := do
   | "get"  :: args => get args
   | "get!" :: args => get args (force := true)
   | "get-" :: args => get args (decompress := false)
+  | ["miniget"] => miniget
   | ["pack"] => discard <| pack
   | ["pack!"] => discard <| pack (overwrite := true)
   | ["unpack"] => unpackCache hashMap false

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -57,9 +57,11 @@ def toPaths (args : List String) : List FilePath :=
     else
       mkFilePath (arg.toName.components.map Name.toString) |>.withExtension "lean"
 
+/-- Commands which (potentially) call `curl` for downloading files -/
 def curlArgs : List String :=
   ["get", "get!", "get-", "put", "put!", "put-unpacked", "commit", "commit!"]
 
+/-- Commands which (potentially) call `leantar` for decompressing downloaded files -/
 def leanTarArgs : List String :=
   ["get", "get!", "pack", "pack!", "unpack", "lookup"]
 


### PR DESCRIPTION
- add an informational message to the get command (when run without arguments):
when more than 80% of all cache files present were not used in the last command,
tell the user about the `clean` command

---

- [ ] depends on #20568 (for the first feature)
- [ ] TODO: re-design this feature and the clean command: if there are N local copies of mathlib, cache should have a pointer to all of them - to avoid clearing all N-1 from inside the last local copy
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
