### PR TITLE
[Merged by Bors] - feat: `simp` lemmas for degenerate uses of `IsCoprime`

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Divisibility.lean
+++ b/Mathlib/Algebra/GroupWithZero/Divisibility.lean
@@ -168,3 +168,18 @@ lemma pow_dvd_pow_iff (ha₀ : a ≠ 0) (ha : ¬IsUnit a) : a ^ n ∣ a ^ m ↔ 
   · apply pow_dvd_pow
 
 end CancelCommMonoidWithZero
+
+section GroupWithZero
+variable [GroupWithZero α]
+
+/-- `∣` is not a useful definition if an inverse is available. -/
+@[simp]
+lemma GroupWithZero.dvd_iff {m n : α} : m ∣ n ↔ (m = 0 → n = 0) := by
+  refine ⟨fun ⟨a, ha⟩ hm => ?_, fun h => ?_⟩
+  · simp [hm, ha]
+  · refine ⟨m⁻¹ * n, ?_⟩
+    obtain rfl | hn := eq_or_ne n 0
+    · simp
+    · rw [mul_inv_cancel_left₀ (mt h hn)]
+
+end GroupWithZero

--- a/Mathlib/RingTheory/Coprime/Basic.lean
+++ b/Mathlib/RingTheory/Coprime/Basic.lean
@@ -413,9 +413,7 @@ lemma Nat.isCoprime_iff {m n : ℕ} : IsCoprime m n ↔ m = 1 ∨ n = 1 := by
     · exact isCoprime_one_right
 
 /-- `IsCoprime` is not a useful definition for `PNat`; consider using `Nat.Coprime` instead. -/
-@[simp]
-lemma PNat.isCoprime_iff {m n : ℕ+} : IsCoprime (m : ℕ) n ↔ m = 1 ∨ n = 1 := by
-  rw [← PNat.coe_inj, ← PNat.coe_inj, PNat.one_coe, Nat.isCoprime_iff]
+lemma PNat.isCoprime_iff {m n : ℕ+} : IsCoprime (m : ℕ) n ↔ m = 1 ∨ n = 1 := by simp
 
 /-- `IsCoprime` is not a useful definition if an inverse is available. -/
 @[simp]

--- a/Mathlib/RingTheory/Coprime/Basic.lean
+++ b/Mathlib/RingTheory/Coprime/Basic.lean
@@ -415,7 +415,7 @@ lemma Nat.isCoprime_iff {m n : ℕ} : IsCoprime m n ↔ m = 1 ∨ n = 1 := by
 /-- `IsCoprime` is not a useful definition for `PNat`; consider using `Nat.Coprime` instead. -/
 @[simp]
 lemma PNat.isCoprime_iff {m n : ℕ+} : IsCoprime (m : ℕ) n ↔ m = 1 ∨ n = 1 := by
-  rw [←PNat.coe_inj, ←PNat.coe_inj, PNat.one_coe, Nat.isCoprime_iff]
+  rw [← PNat.coe_inj, ← PNat.coe_inj, PNat.one_coe, Nat.isCoprime_iff]
 
 /-- `IsCoprime` is not a useful definition if an inverse is available. -/
 @[simp]

--- a/Mathlib/RingTheory/Coprime/Basic.lean
+++ b/Mathlib/RingTheory/Coprime/Basic.lean
@@ -419,11 +419,9 @@ lemma PNat.isCoprime_iff {m n : ℕ+} : IsCoprime (m : ℕ) n ↔ m = 1 ∨ n = 
 @[simp]
 lemma Semifield.isCoprime_iff {R : Type*} [Semifield R] {m n : R} :
     IsCoprime m n ↔ m ≠ 0 ∨ n ≠ 0 := by
-  obtain rfl | hm := eq_or_ne m 0
-  · simp [isCoprime_zero_left]
   obtain rfl | hn := eq_or_ne n 0
   · simp [isCoprime_zero_right]
-  simp only [ne_eq, hm, not_false_eq_true, hn, or_self, iff_true]
+  suffices IsCoprime m n by simpa [hn]
   refine ⟨0, n⁻¹, ?_⟩
   simp [inv_mul_cancel₀ hn]
 

--- a/Mathlib/RingTheory/Coprime/Basic.lean
+++ b/Mathlib/RingTheory/Coprime/Basic.lean
@@ -367,6 +367,29 @@ theorem neg_neg {x y : R} (h : IsCoprime x y) : IsCoprime (-x) (-y) :=
 theorem neg_neg_iff (x y : R) : IsCoprime (-x) (-y) ↔ IsCoprime x y :=
   (neg_left_iff _ _).trans (neg_right_iff _ _)
 
+section abs
+
+variable [LinearOrder R] [AddLeftMono R]
+
+lemma abs_left_iff (x y : R) : IsCoprime |x| y ↔ IsCoprime x y := by
+  cases le_or_lt 0 x with
+  | inl h => rw [abs_of_nonneg h]
+  | inr h => rw [abs_of_neg h, IsCoprime.neg_left_iff]
+
+lemma abs_left {x y : R} (h : IsCoprime x y) : IsCoprime |x| y := abs_left_iff _ _ |>.2 h
+
+lemma abs_right_iff (x y : R) : IsCoprime x |y| ↔ IsCoprime x y := by
+  rw [isCoprime_comm, IsCoprime.abs_left_iff, isCoprime_comm]
+
+lemma abs_right {x y : R} (h : IsCoprime x y) : IsCoprime x |y| := abs_right_iff _ _ |>.2 h
+
+theorem abs_abs_iff (x y : R) : IsCoprime |x| |y| ↔ IsCoprime x y :=
+  (abs_left_iff _ _).trans (abs_right_iff _ _)
+
+theorem abs_abs {x y : R} (h : IsCoprime x y) : IsCoprime |x| |y| := h.abs_left.abs_right
+
+end abs
+
 end CommRing
 
 theorem sq_add_sq_ne_zero {R : Type*} [LinearOrderedCommRing R] {a b : R} (h : IsCoprime a b) :
@@ -378,6 +401,33 @@ theorem sq_add_sq_ne_zero {R : Type*} [LinearOrderedCommRing R] {a b : R} (h : I
   exact not_isCoprime_zero_zero h
 
 end IsCoprime
+
+/-- `IsCoprime` is not a useful definition for `Nat`; consider using `Nat.Coprime` instead. -/
+@[simp]
+lemma Nat.isCoprime_iff {m n : ℕ} : IsCoprime m n ↔ m = 1 ∨ n = 1 := by
+  refine ⟨fun ⟨a, b, H⟩ => ?_, fun h => ?_⟩
+  · simp_rw [Nat.add_eq_one_iff, mul_eq_one, mul_eq_zero] at H
+    exact H.symm.imp (·.1.2) (·.2.2)
+  · obtain rfl | rfl := h
+    · exact isCoprime_one_left
+    · exact isCoprime_one_right
+
+/-- `IsCoprime` is not a useful definition for `PNat`; consider using `Nat.Coprime` instead. -/
+@[simp]
+lemma PNat.isCoprime_iff {m n : ℕ+} : IsCoprime (m : ℕ) n ↔ m = 1 ∨ n = 1 := by
+  rw [←PNat.coe_inj, ←PNat.coe_inj, PNat.one_coe, Nat.isCoprime_iff]
+
+/-- `IsCoprime` is not a useful definition if an inverse is available. -/
+@[simp]
+lemma Semifield.isCoprime_iff {R : Type*} [Semifield R] {m n : R} :
+    IsCoprime m n ↔ m ≠ 0 ∨ n ≠ 0 := by
+  obtain rfl | hm := eq_or_ne m 0
+  · simp [isCoprime_zero_left]
+  obtain rfl | hn := eq_or_ne n 0
+  · simp [isCoprime_zero_right]
+  simp only [ne_eq, hm, not_false_eq_true, hn, or_self, iff_true]
+  refine ⟨0, n⁻¹, ?_⟩
+  simp [inv_mul_cancel₀ hn]
 
 namespace IsRelPrime
 


### PR DESCRIPTION
@erdOne had another proof of `Nat.isCoprime_iff` [on Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Create.20instance.20.60CommSemiring.20.E2.84.95.2B.60.2C.20.20err.20.60expected.20structure.60/near/487351085)

Also adds some unrelated `abs` lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
