### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits/Fubini): relax `HasLimits` hypotheses

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -311,16 +311,9 @@ noncomputable def isLimitConeOfHasLimitCurryCompLim : IsLimit (coneOfHasLimitCur
   { lift c' := limit.lift (F := curry.obj G ⋙ lim) (coneOfConeCurry G Q' c')
     fac c' f := by simp [coneOfHasLimitCurryCompLim, Q, Q']
     uniq c' f h := by
-      dsimp only [coneOfHasLimitCurryCompLim, limit.cone_x, Functor.const_obj_obj, Functor.comp_obj,
-        lim_obj, limit.cone_π, DiagramOfCones.mkOfHasLimits_obj, coneOfConeCurry,
-        DiagramOfCones.mkOfHasLimits_conePoints, limit.isLimit_lift, Q, Q'] at f h ⊢
-      rw [IsLimit.hom_lift (limit.isLimit _) f]
-      simp only [Functor.const_obj_obj, limit.cone_x, Functor.comp_obj, lim_obj, limit.cone_π,
-        Functor.comp_map, lim_map, limit.isLimit_lift, Q, Q']
-      congr; ext j k
-      simp only [Prod.forall, Q', coneOfHasLimitCurryCompLim, Q] at h
-      specialize h j k
-      simpa using h }
+      dsimp [coneOfHasLimitCurryCompLim] at f h ⊢
+      refine limit.hom_ext (F := curry.obj G ⋙ lim) (fun j ↦ limit.hom_ext (fun k ↦ ?_))
+      simp [h ⟨j, k⟩, Q'] }
 
 /-- The functor `G` has a limit if `C` has `K`-shaped limits and `(curry.obj G ⋙ lim)` has a limit.
 -/
@@ -414,16 +407,9 @@ noncomputable def isColimitCoconeOfHasColimitCurryCompColim :
   { desc c' := colimit.desc (F := curry.obj G ⋙ colim) (coconeOfCoconeCurry G Q' c')
     fac c' f := by simp [coconeOfHasColimitCurryCompColim, Q, Q']
     uniq c' f h := by
-      dsimp only [coconeOfHasColimitCurryCompColim, colimit.cocone_x,
-        DiagramOfCocones.mkOfHasColimits_obj, Functor.const_obj_obj, colimit.cocone_ι, Q', Q]
-        at f h ⊢
-      rw [IsColimit.hom_desc (colimit.isColimit _) f]
-      simp only [Functor.comp_obj, colim_obj, colimit.cocone_x, Functor.const_obj_obj,
-        colimit.cocone_ι, Functor.comp_map, colim_map, colimit.isColimit_desc, Q', Q]
-      congr; ext j k
-      simp only [Prod.forall, Q', coconeOfHasColimitCurryCompColim, Q] at h
-      specialize h j k
-      simpa using h }
+      dsimp [coconeOfHasColimitCurryCompColim] at f h ⊢
+      refine colimit.hom_ext (F := curry.obj G ⋙ colim) (fun j ↦ colimit.hom_ext (fun k ↦ ?_))
+      simp [← h ⟨j, k⟩, Q'] }
 
 /-- The functor `G` has a colimit if `C` has `K`-shaped colimits and `(curry.obj G ⋙ colim)` has a
 colimit. -/

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -179,8 +179,7 @@ def coconeOfCoconeCurry {D : DiagramOfCocones (curry.obj G)} (Q : ∀ j, IsColim
   ι :=
     { app j := (Q j).desc
         { pt := c.pt
-          ι := { app k := c.ι.app (j, k)
-                 naturality _ _ _ := by simp } }
+          ι := { app k := c.ι.app (j, k) } }
       naturality {j _} _ := (Q j).hom_ext (by simp) }
 
 /-- `coneOfConeUncurry Q c` is a limit cone when `c` is a limit cone.

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -132,8 +132,7 @@ def coneOfConeCurry {D : DiagramOfCones (curry.obj G)} (Q : ∀ j, IsLimit (D.ob
   π :=
     { app j := (Q j).lift
         { pt := c.pt
-          π := { app k := c.π.app (j, k)
-                 naturality _ _ _ := by simp } }
+          π := { app k := c.π.app (j, k) } }
       naturality {_ j'} _ := (Q j').hom_ext (by simp) }
 
 /-- Given a diagram `D` of colimit cocones over the `F.obj j`, and a cocone over `uncurry.obj F`,

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -291,21 +291,17 @@ variable [HasLimit (curry.obj G ⋙ lim)]
 /-- Given a functor `G : J × K ⥤ C` such that `(curry.obj G ⋙ lim)` makes sense and has a limit,
 we can construct a cone over `G` with `limit (curry.obj G ⋙ lim)` as a cone point -/
 noncomputable def coneOfHasLimitCurryCompLim : Cone G :=
-  let c := limit.cone (curry.obj G ⋙ lim)
   let Q : DiagramOfCones (curry.obj G) := .mkOfHasLimits _
-  { pt := c.pt,
+  { pt := limit (curry.obj G ⋙ lim),
     π :=
-    { app x := (c.π.app x.fst) ≫ (Q.obj x.fst).π.app x.snd
-      naturality {x y} f := by
-        dsimp only [Functor.const_obj_obj, Functor.const_obj_map, Functor.comp_obj, lim_obj]
-        simp only [limit.cone_x, limit.cone_π, ← limit.w (F := curry.obj G ⋙ lim) (f := f.1),
-          Functor.comp_obj, lim_obj, Functor.comp_map, lim_map, Category.assoc, Category.id_comp, c]
-        haveI : f = (Prod.sectR _ _).map f.2 ≫ (Prod.sectL _ _).map f.1 := by ext <;> simp
-        rw [this, G.map_comp]
-        dsimp only [Prod.sectR_obj, Prod.sectR_map, Prod.sectL_map]
-        rw [← curry_obj_obj_map G, ← (Q.obj x.1).π.naturality_assoc]
-        simp [Q] }}
-
+    { app x := limit.π (curry.obj G ⋙ lim) x.fst ≫ (Q.obj x.fst).π.app x.snd
+      naturality {x y} := fun ⟨f₁, f₂⟩ ↦ by
+        have := (Q.obj x.1).w f₂
+        dsimp [Q] at this ⊢
+        rw [← limit.w (F := curry.obj G ⋙ lim) (f := f₁)]
+        dsimp
+        simp only [Category.assoc, Category.id_comp, Prod.fac (f₁, f₂),
+          G.map_comp, limMap_π, curry_obj_map_app, reassoc_of% this] } }
 
 /-- The cone `coneOfHasLimitCurryCompLim` is in fact a limit cone.
 -/
@@ -396,22 +392,17 @@ variable [HasColimit (curry.obj G ⋙ colim)]
 /-- Given a functor `G : J × K ⥤ C` such that `(curry.obj G ⋙ colim)` makes sense and has a colimit,
 we can construct a cocone under `G` with `colimit (curry.obj G ⋙ colim)` as a cocone point -/
 noncomputable def coconeOfHasColimitCurryCompColim : Cocone G :=
-  let c := colimit.cocone (curry.obj G ⋙ colim)
   let Q : DiagramOfCocones (curry.obj G) := .mkOfHasColimits _
-  { pt := c.pt,
+  { pt := colimit (curry.obj G ⋙ colim),
     ι :=
-    { app x := (Q.obj x.fst).ι.app x.snd ≫ (c.ι.app x.fst)
-      naturality {x y} f := by
-        dsimp only [Functor.const_obj_obj, Functor.const_obj_map, Functor.comp_obj, lim_obj]
-        simp only [colimit.cocone_x, colimit.cocone_ι,
-          ← colimit.w (F := curry.obj G ⋙ colim) (f := f.1), Functor.comp_obj, colim_obj,
-          Functor.comp_map, colim_map, Category.comp_id, c]
-        haveI : f = (Prod.sectL _ _).map f.1 ≫ (Prod.sectR _ _).map f.2  := by ext <;> simp
-        rw [this, G.map_comp]
-        dsimp only [Prod.sectR_obj, Prod.sectR_map, Prod.sectL_map]
-        rw [← curry_obj_obj_map G]
-        simp only [Category.assoc, (Q.obj y.1).ι.naturality_assoc]
-        simp [Q] }}
+    { app x := (Q.obj x.fst).ι.app x.snd ≫ colimit.ι (curry.obj G ⋙ colim) x.fst
+      naturality {x y} := fun ⟨f₁, f₂⟩ ↦ by
+        have := (Q.obj y.1).w f₂
+        dsimp [Q] at this ⊢
+        rw [← colimit.w (F := curry.obj G ⋙ colim) (f := f₁)]
+        dsimp
+        simp [Category.assoc, Category.comp_id, Prod.fac' (f₁, f₂),
+          G.map_comp, ι_colimMap_assoc, curry_obj_map_app, reassoc_of% this] } }
 
 
 /-- The cocone `coconeOfHasColimitCurryCompColim` is in fact a limit cocone.

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -130,15 +130,11 @@ def coneOfConeCurry {D : DiagramOfCones (curry.obj G)} (Q : ∀ j, IsLimit (D.ob
     (c : Cone G) : Cone D.conePoints where
   pt := c.pt
   π :=
-    { app := fun j =>
-        (Q j).lift
-          { pt := c.pt
-            π :=
-              { app := fun k => c.π.app (j, k)
-                naturality := fun k k' f => by
-                  simp } }
-      naturality := fun j j' f => (Q j').hom_ext (by simp) }
-
+    { app j := (Q j).lift
+        { pt := c.pt
+          π := { app k := c.π.app (j, k)
+                 naturality _ _ _ := by simp } }
+      naturality {_ j'} _ := (Q j').hom_ext (by simp) }
 
 /-- Given a diagram `D` of colimit cocones over the `F.obj j`, and a cocone over `uncurry.obj F`,
 we can construct a cocone over the diagram consisting of the cocone points from `D`.
@@ -182,13 +178,11 @@ def coconeOfCoconeCurry {D : DiagramOfCocones (curry.obj G)} (Q : ∀ j, IsColim
     (c : Cocone G) : Cocone D.coconePoints where
   pt := c.pt
   ι :=
-    { app := fun j =>
-        (Q j).desc
-          { pt := c.pt
-            ι :=
-              { app := fun k => c.ι.app (j, k)
-                naturality := fun k k' f => by simp } }
-      naturality := fun j j' f => (Q j).hom_ext (by simp) }
+    { app j := (Q j).desc
+        { pt := c.pt
+          ι := { app k := c.ι.app (j, k)
+                 naturality _ _ _ := by simp } }
+      naturality {j _} _ := (Q j).hom_ext (by simp) }
 
 /-- `coneOfConeUncurry Q c` is a limit cone when `c` is a limit cone.
 -/
@@ -302,8 +296,7 @@ noncomputable def coneOfHasLimitCurryCompLim : Cone G :=
   { pt := c.pt,
     π :=
     { app x := (c.π.app x.fst) ≫ (Q.obj x.fst).π.app x.snd
-      naturality := by
-        intro x y f
+      naturality {x y} f := by
         dsimp only [Functor.const_obj_obj, Functor.const_obj_map, Functor.comp_obj, lim_obj]
         simp only [limit.cone_x, limit.cone_π, ← limit.w (F := curry.obj G ⋙ lim) (f := f.1),
           Functor.comp_obj, lim_obj, Functor.comp_map, lim_map, Category.assoc, Category.id_comp, c]
@@ -408,8 +401,7 @@ noncomputable def coconeOfHasColimitCurryCompColim : Cocone G :=
   { pt := c.pt,
     ι :=
     { app x := (Q.obj x.fst).ι.app x.snd ≫ (c.ι.app x.fst)
-      naturality := by
-        intro x y f
+      naturality {x y} f := by
         dsimp only [Functor.const_obj_obj, Functor.const_obj_map, Functor.comp_obj, lim_obj]
         simp only [colimit.cocone_x, colimit.cocone_ι,
           ← colimit.w (F := curry.obj G ⋙ colim) (f := f.1), Functor.comp_obj, colim_obj,

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -165,6 +165,20 @@ def braiding : C × D ≌ D × C where
 instance swapIsEquivalence : (swap C D).IsEquivalence :=
   (by infer_instance : (braiding C D).functor.IsEquivalence)
 
+variable {C D}
+
+/-- Any morphism in a product factors as a morphsim whose left component is an identity
+followed by a morphism whose right component is an identity. -/
+@[reassoc]
+lemma fac {x y : C × D} (f : x ⟶ y) :
+    f = ((𝟙 x.1, f.2) : _ ⟶ ⟨x.1, y.2⟩) ≫ (f.1, 𝟙 y.2) := by aesop
+
+/-- Any morphism in a product factors as a morphsim whose right component is an identity
+followed by a morphism whose left component is an identity. -/
+@[reassoc]
+lemma fac' {x y : C × D} (f : x ⟶ y) :
+    f = ((f.1, 𝟙 x.2) : _ ⟶ ⟨y.1, x.2⟩) ≫ (𝟙 y.1, f.2) := by aesop
+
 end Prod
 
 section


### PR DESCRIPTION
Add a proof that one can construct a limit cone for a functor `(G : J × K ⥤ C)` out of a limit cone for `curry.obj G ⋙ lim` (provided the latter makes sense). From this deduce that `C` has limits of shape `J × K` if it has limits of shape `J` and of shape `K`. Remove the now unnecessary assumptions in the Fubini theorem for limits. All statements have their colimit counterpart.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
