### PR TITLE
[Merged by Bors] - feat: `(C a * p).leadingCoeff = a * p.leadingCoeff`

### DIFF
--- a/Mathlib/Algebra/Polynomial/Degree/Operations.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Operations.lean
@@ -375,16 +375,35 @@ theorem leadingCoeff_mul_monic {p q : R[X]} (hq : Monic q) :
       rw [leadingCoeff_mul', hq.leadingCoeff, mul_one]
       rwa [hq.leadingCoeff, mul_one]
 
-lemma natDegree_C_mul (ha : IsUnit a) (p : R[X]) : (C a * p).natDegree = p.natDegree := by
+lemma degree_C_mul_of_isUnit (ha : IsUnit a) (p : R[X]) : (C a * p).degree = p.degree := by
   obtain rfl | hp := eq_or_ne p 0
   · simp
-  · rw [natDegree_mul', natDegree_C]
-    · simp
-    · simpa [ha.mul_right_eq_zero]
+  nontriviality R
+  rw [degree_mul', degree_C ha.ne_zero]
+  · simp
+  · simpa [ha.mul_right_eq_zero]
 
-lemma leadingCoeff_C_mul (ha : IsUnit a) (p : R[X]) :
+lemma degree_mul_C_of_isUnit (ha : IsUnit a) (p : R[X]) : (p * C a).degree = p.degree := by
+  obtain rfl | hp := eq_or_ne p 0
+  · simp
+  nontriviality R
+  rw [degree_mul', degree_C ha.ne_zero]
+  · simp
+  · simpa [ha.mul_left_eq_zero]
+
+lemma natDegree_C_mul_of_isUnit (ha : IsUnit a) (p : R[X]) : (C a * p).natDegree = p.natDegree := by
+  simp [natDegree, degree_C_mul_of_isUnit ha]
+
+lemma natDegree_mul_C_of_isUnit (ha : IsUnit a) (p : R[X]) : (p * C a).natDegree = p.natDegree := by
+  simp [natDegree, degree_mul_C_of_isUnit ha]
+
+lemma leadingCoeff_C_mul_of_isUnit (ha : IsUnit a) (p : R[X]) :
     (C a * p).leadingCoeff = a * p.leadingCoeff := by
-  rwa [leadingCoeff, coeff_C_mul, natDegree_C_mul, leadingCoeff]
+  rwa [leadingCoeff, coeff_C_mul, natDegree_C_mul_of_isUnit, leadingCoeff]
+
+lemma leadingCoeff_mul_C_of_isUnit (ha : IsUnit a) (p : R[X]) :
+    (p * C a).leadingCoeff = p.leadingCoeff * a := by
+  rwa [leadingCoeff, coeff_mul_C, natDegree_mul_C_of_isUnit, leadingCoeff]
 
 @[simp]
 theorem leadingCoeff_mul_X_pow {p : R[X]} {n : ℕ} : leadingCoeff (p * X ^ n) = leadingCoeff p :=

--- a/Mathlib/Algebra/Polynomial/Degree/Operations.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Operations.lean
@@ -375,12 +375,16 @@ theorem leadingCoeff_mul_monic {p q : R[X]} (hq : Monic q) :
       rw [leadingCoeff_mul', hq.leadingCoeff, mul_one]
       rwa [hq.leadingCoeff, mul_one]
 
-lemma leadingCoeff_C_mul (ha : IsUnit a) (p : R[X]) :
-    (C a * p).leadingCoeff = a * p.leadingCoeff := by
+lemma natDegree_C_mul (ha : IsUnit a) (p : R[X]) : (C a * p).natDegree = p.natDegree := by
   obtain rfl | hp := eq_or_ne p 0
   · simp
-  · rw [leadingCoeff_mul', leadingCoeff_C]
-    simpa [ha.mul_right_eq_zero]
+  · rw [natDegree_mul', natDegree_C]
+    · simp
+    · simpa [ha.mul_right_eq_zero]
+
+lemma leadingCoeff_C_mul (ha : IsUnit a) (p : R[X]) :
+    (C a * p).leadingCoeff = a * p.leadingCoeff := by
+  rwa [leadingCoeff, coeff_C_mul, natDegree_C_mul, leadingCoeff]
 
 @[simp]
 theorem leadingCoeff_mul_X_pow {p : R[X]} {n : ℕ} : leadingCoeff (p * X ^ n) = leadingCoeff p :=

--- a/Mathlib/Algebra/Polynomial/Degree/Operations.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Operations.lean
@@ -375,6 +375,13 @@ theorem leadingCoeff_mul_monic {p q : R[X]} (hq : Monic q) :
       rw [leadingCoeff_mul', hq.leadingCoeff, mul_one]
       rwa [hq.leadingCoeff, mul_one]
 
+lemma leadingCoeff_C_mul (ha : IsUnit a) (p : R[X]) : 
+    (C a * p).leadingCoeff = a * p.leadingCoeff := by
+  obtain rfl | hp := eq_or_ne p 0
+  · simp
+  · rw [leadingCoeff_mul', leadingCoeff_C]
+    simpa [ha.mul_right_eq_zero]
+
 @[simp]
 theorem leadingCoeff_mul_X_pow {p : R[X]} {n : ℕ} : leadingCoeff (p * X ^ n) = leadingCoeff p :=
   leadingCoeff_mul_monic (monic_X_pow n)

--- a/Mathlib/Algebra/Polynomial/Degree/Operations.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Operations.lean
@@ -375,7 +375,7 @@ theorem leadingCoeff_mul_monic {p q : R[X]} (hq : Monic q) :
       rw [leadingCoeff_mul', hq.leadingCoeff, mul_one]
       rwa [hq.leadingCoeff, mul_one]
 
-lemma leadingCoeff_C_mul (ha : IsUnit a) (p : R[X]) : 
+lemma leadingCoeff_C_mul (ha : IsUnit a) (p : R[X]) :
     (C a * p).leadingCoeff = a * p.leadingCoeff := by
   obtain rfl | hp := eq_or_ne p 0
   · simp


### PR DESCRIPTION
From GrowthInGroups (LeanCamCombi)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
