### PR TITLE
[Merged by Bors] - feat: pointwise set operations commute with cartesian product

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -1084,7 +1084,7 @@ lemma map_op_pow (s : Finset α) :
 @[to_additive]
 lemma product_pow [Monoid β] (s : Finset α) (t : Finset β) : ∀ n, (s ×ˢ t) ^ n = (s ^ n) ×ˢ (t ^ n)
   | 0 => by simp
-  | n+1 => by simp [pow_succ, product_pow _ _ n]
+  | n + 1 => by simp [pow_succ, product_pow _ _ n]
 
 end Monoid
 

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -178,6 +178,9 @@ lemma image_op_one [DecidableEq α] : (1 : Finset α).image op = 1 := rfl
 @[to_additive (attr := simp)]
 lemma map_op_one : (1 : Finset α).map opEquiv.toEmbedding = 1 := rfl
 
+@[to_additive (attr := simp)]
+lemma one_product_one [One β] : (1 ×ˢ 1 : Finset (α × β)) = 1 := by ext; simp [Prod.ext_iff]
+
 end One
 
 /-! ### Finset negation/inversion -/
@@ -294,6 +297,10 @@ lemma inv_univ [Fintype α] : (univ : Finset α)⁻¹ = univ := by ext; simp
 
 @[to_additive (attr := simp)]
 lemma inv_inter (s t : Finset α) : (s ∩ t)⁻¹ = s⁻¹ ∩ t⁻¹ := coe_injective <| by simp
+
+@[to_additive (attr := simp)]
+lemma inv_product [DecidableEq β] [InvolutiveInv β] (s : Finset α) (t : Finset β) :
+    (s ×ˢ t)⁻¹ = s⁻¹ ×ˢ t⁻¹ := mod_cast s.toSet.inv_prod t.toSet
 
 end InvolutiveInv
 
@@ -599,6 +606,11 @@ theorem image_mul [DecidableEq β] : (s * t).image (f : α → β) = s.image f *
 @[to_additive]
 lemma image_op_mul (s t : Finset α) : (s * t).image op = t.image op * s.image op :=
   image_image₂_antidistrib op_mul
+
+@[to_additive (attr := simp)]
+lemma product_mul_product_comm [DecidableEq β] (s₁ s₂ : Finset α) (t₁ t₂ : Finset β) :
+    (s₁ ×ˢ t₁) * (s₂ ×ˢ t₂) = (s₁ * s₂) ×ˢ (t₁ * t₂) :=
+  mod_cast s₁.toSet.prod_mul_prod_comm s₂ t₁.toSet t₂
 
 @[to_additive]
 lemma map_op_mul (s t : Finset α) :
@@ -1068,6 +1080,11 @@ lemma map_op_pow (s : Finset α) :
     ∀ n : ℕ, (s ^ n).map opEquiv.toEmbedding = s.map opEquiv.toEmbedding ^ n
   | 0 => by simp [singleton_one]
   | n + 1 => by rw [pow_succ, pow_succ', map_op_mul, map_op_pow]
+
+@[to_additive]
+lemma product_pow [Monoid β] (s : Finset α) (t : Finset β) : ∀ n, (s ×ˢ t) ^ n = (s ^ n) ×ˢ (t ^ n)
+  | 0 => by simp
+  | n+1 => by simp [pow_succ, product_pow _ _ n]
 
 end Monoid
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -1179,7 +1179,7 @@ protected theorem _root_.IsUnit.set : IsUnit a → IsUnit ({a} : Set α) :=
 @[to_additive]
 lemma prod_pow [Monoid β] (s : Set α) (t : Set β) : ∀ n, (s ×ˢ t) ^ n = (s ^ n) ×ˢ (t ^ n)
   | 0 => by simp
-  | n+1 => by simp [pow_succ, prod_pow _ _ n]
+  | n + 1 => by simp [pow_succ, prod_pow _ _ n]
 
 end Monoid
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -1,9 +1,10 @@
 /-
 Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johan Commelin, Floris van Doorn
+Authors: Johan Commelin, Floris van Doorn, Yaël Dillies
 -/
 import Mathlib.Algebra.Group.Equiv.Basic
+import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Group.Units.Hom
 import Mathlib.Algebra.Opposites
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
@@ -134,6 +135,9 @@ theorem coe_singletonOneHom : (singletonOneHom : α → Set α) = singleton :=
 
 @[to_additive] lemma image_op_one : (1 : Set α).image op = 1 := image_singleton
 
+@[to_additive (attr := simp)]
+lemma one_prod_one [One β] : (1 ×ˢ 1 : Set (α × β)) = 1 := by ext; simp [Prod.ext_iff]
+
 end One
 
 /-! ### Set negation/inversion -/
@@ -200,6 +204,9 @@ theorem sUnion_inv (S : Set (Set α)) : (⋃₀ S)⁻¹ = ⋃ s ∈ S, s⁻¹ :=
 @[to_additive (attr := simp)]
 theorem compl_inv : sᶜ⁻¹ = s⁻¹ᶜ :=
   preimage_compl
+
+@[to_additive (attr := simp)]
+lemma inv_prod [Inv β] (s : Set α) (t : Set β) : (s ×ˢ t)⁻¹ = s⁻¹ ×ˢ t⁻¹ := rfl
 
 end Inv
 
@@ -466,6 +473,10 @@ open MulOpposite
 @[to_additive (attr := simp)]
 theorem image_op_mul : op '' (s * t) = op '' t * op '' s :=
   image_image2_antidistrib op_mul
+
+@[to_additive (attr := simp)]
+lemma prod_mul_prod_comm [Mul β] (s₁ s₂: Set α) (t₁ t₂ : Set β) :
+   (s₁ ×ˢ t₁) * (s₂ ×ˢ t₂) = (s₁ * s₂) ×ˢ (t₁ * t₂) := by ext; simp [mem_mul]; aesop
 
 end Mul
 
@@ -1165,6 +1176,11 @@ theorem univ_pow : ∀ {n : ℕ}, n ≠ 0 → (univ : Set α) ^ n = univ
 protected theorem _root_.IsUnit.set : IsUnit a → IsUnit ({a} : Set α) :=
   IsUnit.map (singletonMonoidHom : α →* Set α)
 
+@[to_additive]
+lemma prod_pow [Monoid β] (s : Set α) (t : Set β) : ∀ n, (s ×ˢ t) ^ n = (s ^ n) ×ˢ (t ^ n)
+  | 0 => by simp
+  | n+1 => by simp [pow_succ, prod_pow _ _ n]
+
 end Monoid
 
 section IsLeftCancelMul
@@ -1495,3 +1511,5 @@ lemma MapsTo.div [DivisionCommMonoid β] {A : Set α} {B₁ B₂ : Set β} {f₁
 end Pointwise
 
 end Set
+
+set_option linter.style.longFile 1700

--- a/Mathlib/Algebra/MvPolynomial/Equiv.lean
+++ b/Mathlib/Algebra/MvPolynomial/Equiv.lean
@@ -367,12 +367,12 @@ theorem finSuccEquiv_coeff_coeff (m : Fin n →₀ ℕ) (f : MvPolynomial (Fin (
   induction' f using MvPolynomial.induction_on' with j r p q hp hq generalizing i m
   swap
   · simp only [map_add, Polynomial.coeff_add, coeff_add, hp, hq]
-  simp only [finSuccEquiv_apply, coe_eval₂Hom, eval₂_monomial, RingHom.coe_comp, prod_pow,
+  simp only [finSuccEquiv_apply, coe_eval₂Hom, eval₂_monomial, RingHom.coe_comp, Finsupp.prod_pow,
     Polynomial.coeff_C_mul, coeff_C_mul, coeff_monomial, Fin.prod_univ_succ, Fin.cases_zero,
     Fin.cases_succ, ← map_prod, ← RingHom.map_pow, Function.comp_apply]
   rw [← mul_boole, mul_comm (Polynomial.X ^ j 0), Polynomial.coeff_C_mul_X_pow]; congr 1
   obtain rfl | hjmi := eq_or_ne j (m.cons i)
-  · simpa only [cons_zero, cons_succ, if_pos rfl, monomial_eq, C_1, one_mul, prod_pow] using
+  · simpa only [cons_zero, cons_succ, if_pos rfl, monomial_eq, C_1, one_mul, Finsupp.prod_pow] using
       coeff_monomial m m (1 : R)
   · simp only [hjmi, if_false]
     obtain hij | rfl := ne_or_eq i (j 0)
@@ -382,7 +382,7 @@ theorem finSuccEquiv_coeff_coeff (m : Fin n →₀ ℕ) (f : MvPolynomial (Fin (
       rintro rfl
       rw [cons_tail] at hjmi
       contradiction
-    simpa only [monomial_eq, C_1, one_mul, prod_pow, Finsupp.tail_apply, if_neg hmj.symm] using
+    simpa only [monomial_eq, C_1, one_mul, Finsupp.prod_pow, tail_apply, if_neg hmj.symm] using
       coeff_monomial m j.tail (1 : R)
 
 theorem eval_eq_eval_mv_eval' (s : Fin n → R) (y : R) (f : MvPolynomial (Fin (n + 1)) R) :


### PR DESCRIPTION
From GrowthInGroups (LeanCamCombi)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
