### PR TITLE
[Merged by Bors] - feat: AbsoluteValue.IsNontrivial

### DIFF
--- a/Mathlib/Algebra/Order/AbsoluteValue/Basic.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue/Basic.lean
@@ -324,7 +324,7 @@ of `· = 0` in `R`. -/
 def IsNontrivial (v : AbsoluteValue R S) : Prop :=
   ∃ x ≠ 0, v x ≠ 1
 
-lemma isNontrivial_iff_not_eq_trivial [DecidablePred fun x : R ↦ x = 0] [NoZeroDivisors R]
+lemma isNontrivial_iff_ne_trivial [DecidablePred fun x : R ↦ x = 0] [NoZeroDivisors R]
     [Nontrivial S] (v : AbsoluteValue R S) :
     v.IsNontrivial ↔ v ≠ .trivial := by
   refine ⟨fun ⟨x, hx₀, hx₁⟩ h ↦ hx₁ <| h.symm ▸ trivial_apply hx₀, fun H ↦ ?_⟩

--- a/Mathlib/Algebra/Order/AbsoluteValue/Basic.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue/Basic.lean
@@ -312,6 +312,62 @@ lemma trivial_apply {x : R} (hx : x ≠ 0) : AbsoluteValue.trivial (S := S) x = 
 
 end trivial
 
+section nontrivial
+
+variable {R : Type*} [Semiring R] {S : Type*} [OrderedSemiring S]
+
+/-- An absolute value on a semiring `R` without zero divisors is *nontrivial* if it takes
+a value `≠ 1` on a nonzero element.
+
+This has the advantage over `v ≠ .trivial` that it does not require decidability
+of `· = 0` in `R`. -/
+def IsNontrivial (v : AbsoluteValue R S) : Prop :=
+  ∃ x ≠ 0, v x ≠ 1
+
+lemma isNontrivial_iff_not_eq_trivial [DecidablePred fun x : R ↦ x = 0] [NoZeroDivisors R]
+    [Nontrivial S] (v : AbsoluteValue R S) :
+    v.IsNontrivial ↔ v ≠ .trivial := by
+  refine ⟨fun ⟨x, hx₀, hx₁⟩ h ↦ hx₁ <| h.symm ▸ trivial_apply hx₀, fun H ↦ ?_⟩
+  contrapose! H
+  simp only [IsNontrivial] at H
+  push_neg at H
+  ext1 x
+  rcases eq_or_ne x 0 with rfl | hx
+  · simp
+  · simp [H, hx]
+
+lemma not_isNontrivial_iff (v : AbsoluteValue R S) :
+    ¬ v.IsNontrivial ↔ ∀ x ≠ 0, v x = 1 := by
+  simp only [IsNontrivial]
+  push_neg
+  rfl
+
+@[simp]
+lemma not_isNontrivial_apply {v : AbsoluteValue R S} (hv : ¬ v.IsNontrivial) {x : R} (hx : x ≠ 0) :
+    v x = 1 :=
+  v.not_isNontrivial_iff.mp hv _ hx
+
+lemma IsNontrivial.exists_abv_gt_one {F S : Type*} [Field F] [LinearOrderedField S]
+    {v : AbsoluteValue F S} (h : v.IsNontrivial) :
+    ∃ x, 1 < v x := by
+  obtain ⟨x, hx₀, hx₁⟩ := h
+  rcases hx₁.lt_or_lt with h | h
+  · refine ⟨x⁻¹, ?_⟩
+    rw [map_inv₀]
+    exact (one_lt_inv₀ <| v.pos hx₀).mpr h
+  · exact ⟨x, h⟩
+
+lemma IsNontrivial.exists_abv_lt_one {F S : Type*} [Field F] [LinearOrderedField S]
+    {v : AbsoluteValue F S} (h : v.IsNontrivial) :
+    ∃ x ≠ 0, v x < 1 := by
+  obtain ⟨y, hy⟩ := h.exists_abv_gt_one
+  have hy₀ := v.ne_zero_iff.mp <| (zero_lt_one.trans hy).ne'
+  refine ⟨y⁻¹, inv_ne_zero hy₀, ?_⟩
+  rw [map_inv₀]
+  exact (inv_lt_one₀ <| v.pos hy₀).mpr hy
+
+end nontrivial
+
 end AbsoluteValue
 
 -- Porting note: Removed [] in fields, see

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -121,7 +121,7 @@ lemma padic_le_one (p : ℕ) [Fact p.Prime] (n : ℤ) : padic p n ≤ 1 := by
 
 -- ## Step 1: define `p = minimal n s. t. 0 < f n < 1`
 
-variable (hf_nontriv : f ≠ .trivial) (bdd : ∀ n : ℕ, f n ≤ 1)
+variable (hf_nontriv : f.IsNontrivial) (bdd : ∀ n : ℕ, f n ≤ 1)
 
 include hf_nontriv bdd in
 /-- There exists a minimal positive integer with absolute value smaller than 1. -/
@@ -130,11 +130,10 @@ lemma exists_minimal_nat_zero_lt_and_lt_one :
   -- There is a positive integer with absolute value different from one.
   obtain ⟨n, hn1, hn2⟩ : ∃ n : ℕ, n ≠ 0 ∧ f n ≠ 1 := by
     contrapose! hf_nontriv
-    rw [AbsoluteValue.trivial, ← eq_on_nat_iff_eq]
-    intro n
-    rcases eq_or_ne n 0 with rfl | hn0
+    refine (isNontrivial_iff_not_eq_trivial f).not_left.mpr <| eq_on_nat_iff_eq.mp fun n ↦ ?_
+    rcases eq_or_ne n 0 with rfl | hn
     · simp
-    · simp [hn0, hf_nontriv n hn0]
+    · simp [hf_nontriv, hn]
   set P := {m : ℕ | 0 < f ↑m ∧ f ↑m < 1} -- p is going to be the minimum of this set.
   have hP : P.Nonempty :=
     ⟨n, map_pos_of_ne_zero f (Nat.cast_ne_zero.mpr hn1), lt_of_le_of_ne (bdd n) hn2⟩
@@ -465,7 +464,7 @@ end Archimedean
 
 /-- **Ostrowski's Theorem**: every absolute value (with values in `ℝ`) on `ℚ` is equivalent
 to either the standard absolute value or a `p`-adic absolute value for a prime `p`. -/
-theorem equiv_real_or_padic (f : AbsoluteValue ℚ ℝ) (hf_nontriv : f ≠ .trivial) :
+theorem equiv_real_or_padic (f : AbsoluteValue ℚ ℝ) (hf_nontriv : f.IsNontrivial) :
     f ≈ real ∨ ∃! p, ∃ (_ : Fact p.Prime), f ≈ (padic p) := by
   by_cases bdd : ∀ n : ℕ, f n ≤ 1
   · exact .inr <| equiv_padic_of_bounded hf_nontriv bdd

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -130,7 +130,7 @@ lemma exists_minimal_nat_zero_lt_and_lt_one :
   -- There is a positive integer with absolute value different from one.
   obtain ⟨n, hn1, hn2⟩ : ∃ n : ℕ, n ≠ 0 ∧ f n ≠ 1 := by
     contrapose! hf_nontriv
-    refine (isNontrivial_iff_not_eq_trivial f).not_left.mpr <| eq_on_nat_iff_eq.mp fun n ↦ ?_
+    refine (isNontrivial_iff_ne_trivial f).not_left.mpr <| eq_on_nat_iff_eq.mp fun n ↦ ?_
     rcases eq_or_ne n 0 with rfl | hn
     · simp
     · simp [hf_nontriv, hn]


### PR DESCRIPTION
This introduces `v.IsNontrivial : Prop` for `v : AbsoluteValue R S`; this states that `v x  ≠ 1` for some `x ≠ 0`.

This is more convenient to use than `v ≠ .trivial` since it does not require additional assumptions on `R` or `S` (whereas `AbsoluteValue.trivial` needs `x = 0` to be decidable in `R`, `R` to have no zero divisors and `S` to be nontrivial).

We also adapt `NumberTheory.Ostrowski` to use `IsNontrivial` instead of `≠ .trivial`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
