### PR TITLE
[Merged by Bors] - feat: `cache get` warns if given module names rather than paths

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           rm -rf .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
-          lake exe cache get Mathlib.Init
+          lake exe cache get Mathlib/Init.lean
           lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           rm -rf .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
-          lake exe cache get Mathlib.Init
+          lake exe cache get Mathlib/Init.lean
           lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           rm -rf .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
-          lake exe cache get Mathlib.Init
+          lake exe cache get Mathlib/Init.lean
           lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           rm -rf .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
-          lake exe cache get Mathlib.Init
+          lake exe cache get Mathlib/Init.lean
           lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -90,7 +90,10 @@ partial def getFileHash (filePath : FilePath) : HashM <| Option UInt64 := do
   | none =>
     let fixedPath := (← IO.getPackageDir filePath) / filePath
     if !(← fixedPath.pathExists) then
-      IO.println s!"Warning: {fixedPath} not found. Skipping all files that depend on it"
+      IO.println s!"Warning: {fixedPath} not found. Skipping all files that depend on it."
+      if fixedPath.extension != "lean" then
+        IO.println s!"Note that `lake exe cache get ...` expects file names \
+          (e.g. `Mathlib/Init.lean`), not module names (e.g. `Mathlib.Init`)."
       modify fun stt => { stt with cache := stt.cache.insert filePath none }
       return none
     let content ← IO.FS.readFile fixedPath


### PR DESCRIPTION
Per [zulip](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Size.20issue/near/492507604) discussion.