### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Archimedean/Basic): powers between two elements

### DIFF
--- a/Mathlib/Algebra/Order/Archimedean/Basic.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Basic.lean
@@ -300,6 +300,41 @@ theorem exists_nat_pow_near_of_lt_one (xpos : 0 < x) (hx : x ≤ 1) (ypos : 0 < 
   · rwa [inv_pow, inv_lt_inv₀ xpos (pow_pos ypos _)] at h'n
   · rwa [inv_pow, inv_le_inv₀ (pow_pos ypos _) xpos] at hn
 
+/-- If `a < b * c`, `0 < b ≤ 1` and `0 < c < 1`, then there is a power `c ^ n` with `n : ℕ`
+strictly between `a` and `b`. -/
+lemma exists_pow_btwn_of_lt_mul {a b c : α} (h : a < b * c) (hb₀ : 0 < b) (hb₁ : b ≤ 1)
+    (hc₀ : 0 < c) (hc₁ : c < 1) :
+    ∃ n : ℕ, a < c ^ n ∧ c ^ n < b := by
+  have := exists_pow_lt_of_lt_one hb₀ hc₁
+  refine ⟨Nat.find this, h.trans_le ?_, Nat.find_spec this⟩
+  by_contra! H
+  have hn : Nat.find this ≠ 0 := by
+    intro hf
+    simp only [hf, pow_zero] at H
+    exact (H.trans <| Left.mul_lt_of_le_of_lt_one_of_pos hb₁ hc₁ hb₀).false
+  rw [(Nat.succ_pred_eq_of_ne_zero hn).symm, pow_succ, mul_lt_mul_right hc₀] at H
+  exact Nat.find_min this (Nat.sub_one_lt hn) H
+
+/-- If `0 < a < b * c` and `0 < c < 1`, then there is a power `c ^ n` with `n : ℤ`
+strictly between `a` and `b`. -/
+lemma exists_zpow_btwn_of_lt_mul {a b c : α} (h : a < b * c) (ha : 0 < a) (hc₀ : 0 < c)
+    (hc₁ : c < 1) :
+    ∃ n : ℤ, a < c ^ n ∧ c ^ n < b := by
+  have hb₀ : 0 < b := pos_of_mul_pos_left (ha.trans h) hc₀.le
+  rcases le_or_lt b 1 with hb₁ | hb₁
+  · obtain ⟨n, hn⟩ := exists_pow_btwn_of_lt_mul h hb₀ hb₁ hc₀ hc₁
+    exact ⟨n, mod_cast hn⟩
+  · rcases lt_or_le a 1 with ha₁ | ha₁
+    · refine ⟨0, ?_⟩
+      rw [zpow_zero]
+      exact ⟨ha₁, hb₁⟩
+    · have : b⁻¹ < a⁻¹ * c := by rwa [lt_inv_mul_iff₀' ha, inv_mul_lt_iff₀ hb₀]
+      obtain ⟨n, hn₁, hn₂⟩ :=
+        exists_pow_btwn_of_lt_mul this (inv_pos_of_pos ha) (inv_le_one_of_one_le₀ ha₁) hc₀ hc₁
+      refine ⟨-n, ?_, ?_⟩
+      · rwa [lt_inv_comm₀ (pow_pos hc₀ n) ha, ← zpow_natCast, ← zpow_neg] at hn₂
+      · rwa [inv_lt_comm₀ hb₀ (pow_pos hc₀ n), ← zpow_natCast, ← zpow_neg] at hn₁
+
 end LinearOrderedSemifield
 
 section LinearOrderedField

--- a/Mathlib/Algebra/Order/Archimedean/Basic.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Basic.lean
@@ -315,25 +315,27 @@ lemma exists_pow_btwn_of_lt_mul {a b c : α} (h : a < b * c) (hb₀ : 0 < b) (hb
   rw [(Nat.succ_pred_eq_of_ne_zero hn).symm, pow_succ, mul_lt_mul_right hc₀] at H
   exact Nat.find_min this (Nat.sub_one_lt hn) H
 
-/-- If `0 < a < b * c` and `0 < c < 1`, then there is a power `c ^ n` with `n : ℤ`
+/-- If `a < b * c`, `b` is positive and `0 < c < 1`, then there is a power `c ^ n` with `n : ℤ`
 strictly between `a` and `b`. -/
-lemma exists_zpow_btwn_of_lt_mul {a b c : α} (h : a < b * c) (ha : 0 < a) (hc₀ : 0 < c)
+lemma exists_zpow_btwn_of_lt_mul {a b c : α} (h : a < b * c) (hb₀ : 0 < b) (hc₀ : 0 < c)
     (hc₁ : c < 1) :
     ∃ n : ℤ, a < c ^ n ∧ c ^ n < b := by
-  have hb₀ : 0 < b := pos_of_mul_pos_left (ha.trans h) hc₀.le
-  rcases le_or_lt b 1 with hb₁ | hb₁
-  · obtain ⟨n, hn⟩ := exists_pow_btwn_of_lt_mul h hb₀ hb₁ hc₀ hc₁
-    exact ⟨n, mod_cast hn⟩
-  · rcases lt_or_le a 1 with ha₁ | ha₁
-    · refine ⟨0, ?_⟩
-      rw [zpow_zero]
-      exact ⟨ha₁, hb₁⟩
-    · have : b⁻¹ < a⁻¹ * c := by rwa [lt_inv_mul_iff₀' ha, inv_mul_lt_iff₀ hb₀]
-      obtain ⟨n, hn₁, hn₂⟩ :=
-        exists_pow_btwn_of_lt_mul this (inv_pos_of_pos ha) (inv_le_one_of_one_le₀ ha₁) hc₀ hc₁
-      refine ⟨-n, ?_, ?_⟩
-      · rwa [lt_inv_comm₀ (pow_pos hc₀ n) ha, ← zpow_natCast, ← zpow_neg] at hn₂
-      · rwa [inv_lt_comm₀ hb₀ (pow_pos hc₀ n), ← zpow_natCast, ← zpow_neg] at hn₁
+  rcases le_or_lt a 0 with ha | ha
+  · obtain ⟨n, hn⟩ := exists_pow_lt_of_lt_one hb₀ hc₁
+    exact ⟨n, ha.trans_lt (zpow_pos hc₀ _), mod_cast hn⟩
+  · rcases le_or_lt b 1 with hb₁ | hb₁
+    · obtain ⟨n, hn⟩ := exists_pow_btwn_of_lt_mul h hb₀ hb₁ hc₀ hc₁
+      exact ⟨n, mod_cast hn⟩
+    · rcases lt_or_le a 1 with ha₁ | ha₁
+      · refine ⟨0, ?_⟩
+        rw [zpow_zero]
+        exact ⟨ha₁, hb₁⟩
+      · have : b⁻¹ < a⁻¹ * c := by rwa [lt_inv_mul_iff₀' ha, inv_mul_lt_iff₀ hb₀]
+        obtain ⟨n, hn₁, hn₂⟩ :=
+          exists_pow_btwn_of_lt_mul this (inv_pos_of_pos ha) (inv_le_one_of_one_le₀ ha₁) hc₀ hc₁
+        refine ⟨-n, ?_, ?_⟩
+        · rwa [lt_inv_comm₀ (pow_pos hc₀ n) ha, ← zpow_natCast, ← zpow_neg] at hn₂
+        · rwa [inv_lt_comm₀ hb₀ (pow_pos hc₀ n), ← zpow_natCast, ← zpow_neg] at hn₁
 
 end LinearOrderedSemifield
 


### PR DESCRIPTION
This adds two lemmas on linearly ordered semifields: if `0 < c < 1` and `a < b * c`, then (under suitable conditions on `b`) there is a power `c ^ n` (with `n` a natural number / an integer) strictly between `a` and `b`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
