### PR TITLE
[Merged by Bors] - fix(scripts/yaml_check.py): more consistent error handling

### DIFF
--- a/scripts/yaml_check.py
+++ b/scripts/yaml_check.py
@@ -167,4 +167,5 @@ with open('undergrad.json', 'w', encoding='utf8') as f:
   json.dump(undergrad_decls, f)
 
 if errors:
-  sys.exit(errors)
+  # Return an error code of at most 125 so this return value can be used further in shell scripts.
+  sys.exit(min(errors, 125))

--- a/scripts/yaml_check.py
+++ b/scripts/yaml_check.py
@@ -121,7 +121,8 @@ for index, entry in hundred.items():
     hundred_decls.append((f'{index} {title}', entry['decl']))
   elif 'decls' in entry:
     if not isinstance(entry['decls'], list):
-      raise ValueError(f"For key {index} ({title}): did you mean `decl` instead of `decls`?")
+      print(f"For key {index} ({title}): did you mean `decl` instead of `decls`?")
+      errors += 1
     hundred_decls = hundred_decls + [(f'{index} {title}', d) for d in entry['decls']]
 
 thousand_decls: List[Tuple[str, str]] = []
@@ -131,6 +132,7 @@ for index, entry in thousand.items():
     _thm = ThousandPlusTheorem(index, **entry)
   except TypeError as e:
     print(f"error: entry for theorem {index} is invalid: {e}")
+    errors += 1
   # Also verify that the |decl| and |decls| fields are not *both* provided.
   if _thm.decl and _thm.decls:
       print(f"warning: entry for theorem {index} has both a decl and a decls field; "
@@ -142,7 +144,8 @@ for index, entry in thousand.items():
     thousand_decls.append((f'{index} {title}', entry['decl']))
   elif 'decls' in entry:
     if not isinstance(entry['decls'], list):
-      raise ValueError(f"For key {index} ({title}): did you mean `decl` instead of `decls`?")
+      print(f"For key {index} ({title}): did you mean `decl` instead of `decls`?")
+      errors += 1
     thousand_decls = thousand_decls + [(f'{index} {title}', d) for d in entry['decls']]
 
 overview_decls = tiered_extract(overview)

--- a/scripts/yaml_check.py
+++ b/scripts/yaml_check.py
@@ -110,6 +110,7 @@ for index, entry in hundred.items():
     _thm = HundredTheorem(index, **entry)
   except TypeError as e:
     print(f"error: entry for theorem {index} is invalid: {e}")
+    errors += 1
   # Also verify that the |decl| and |decls| fields are not *both* provided.
   if _thm.decl and _thm.decls:
       print(f"warning: entry for theorem {index} has both a decl and a decls field; "


### PR DESCRIPTION
Invalid fields in the 100.yaml and 1000.yaml files are slipping through CI at the moment, see e.g. [this log](https://github.com/leanprover-community/mathlib4/actions/runs/12690334474/job/35370960547#step:19:8).

After this commit, all errors detected by `yaml_check.py` print a message and increment the `errors` variable, only failing at the end of the script (so that all entries can get checked).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
