### PR TITLE
[Merged by Bors] - feat: Make `PNat.recOn` induction eliminator

### DIFF
--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -77,9 +77,9 @@ lemma superadditive {m n : ℕ+} : f m + f n ≤ f (m + n) := by
   · rw [hr]; nth_rewrite 1 [← add_zero (f n), ← add_assoc]; apply add_le_add_right (by norm_num)
 
 lemma superhomogeneous {m n : ℕ+} : ↑n * f m ≤ f (n * m) := by
-  induction n using PNat.recOn
-  case p1 => simp
-  case hp n' ih =>
+  induction n with
+  | one => simp
+  | succ n' ih =>
     calc
     ↑(n' + 1) * f m = ↑n' * f m + f m := by rw [PNat.add_coe, add_mul, PNat.val_ofNat, one_mul]
     _ ≤ f (n' * m) + f m := add_le_add_right ih (f m)

--- a/Mathlib/Algebra/Group/PNatPowAssoc.lean
+++ b/Mathlib/Algebra/Group/PNatPowAssoc.lean
@@ -66,9 +66,9 @@ theorem ppow_mul_comm (m n : ℕ+) (x : M) :
     x ^ m * x ^ n = x ^ n * x ^ m := by simp only [← ppow_add, add_comm]
 
 theorem ppow_mul (x : M) (m n : ℕ+) : x ^ (m * n) = (x ^ m) ^ n := by
-  refine PNat.recOn n ?_ fun k hk ↦ ?_
-  · rw [ppow_one, mul_one]
-  · rw [ppow_add, ppow_one, mul_add, ppow_add, mul_one, hk]
+  induction n with
+  | one => rw [ppow_one, mul_one]
+  | succ k hk => rw [ppow_add, ppow_one, mul_add, ppow_add, mul_one, hk]
 
 theorem ppow_mul' (x : M) (m n : ℕ+) : x ^ (m * n) = (x ^ n) ^ m := by
   rw [mul_comm]
@@ -88,6 +88,6 @@ instance Prod.instPNatPowAssoc {N : Type*} [Mul M] [Pow M ℕ+] [PNatPowAssoc M]
 
 theorem ppow_eq_pow [Monoid M] [Pow M ℕ+] [PNatPowAssoc M] (x : M) (n : ℕ+) :
     x ^ n = x ^ (n : ℕ) := by
-  refine PNat.recOn n ?_ fun k hk ↦ ?_
-  · rw [ppow_one, PNat.one_coe, pow_one]
-  · rw [ppow_add, ppow_one, PNat.add_coe, pow_add, PNat.one_coe, pow_one, ← hk]
+  induction n with
+  | one => rw [ppow_one, PNat.one_coe, pow_one]
+  | succ k hk => rw [ppow_add, ppow_one, PNat.add_coe, pow_add, PNat.one_coe, pow_one, ← hk]

--- a/Mathlib/Data/PNat/Basic.lean
+++ b/Mathlib/Data/PNat/Basic.lean
@@ -161,14 +161,14 @@ def caseStrongInductionOn {p : ℕ+ → Sort*} (a : ℕ+) (hz : p 1)
 
 /-- An induction principle for `ℕ+`: it takes values in `Sort*`, so it applies also to Types,
 not only to `Prop`. -/
-@[elab_as_elim]
-def recOn (n : ℕ+) {p : ℕ+ → Sort*} (p1 : p 1) (hp : ∀ n, p n → p (n + 1)) : p n := by
+@[elab_as_elim, induction_eliminator]
+def recOn (n : ℕ+) {p : ℕ+ → Sort*} (one : p 1) (succ : ∀ n, p n → p (n + 1)) : p n := by
   rcases n with ⟨n, h⟩
   induction' n with n IH
   · exact absurd h (by decide)
   · cases' n with n
-    · exact p1
-    · exact hp _ (IH n.succ_pos)
+    · exact one
+    · exact succ _ (IH n.succ_pos)
 
 @[simp]
 theorem recOn_one {p} (p1 hp) : @PNat.recOn 1 p p1 hp = p1 :=

--- a/Mathlib/Data/PNat/Basic.lean
+++ b/Mathlib/Data/PNat/Basic.lean
@@ -171,12 +171,12 @@ def recOn (n : ℕ+) {p : ℕ+ → Sort*} (one : p 1) (succ : ∀ n, p n → p (
     · exact succ _ (IH n.succ_pos)
 
 @[simp]
-theorem recOn_one {p} (p1 hp) : @PNat.recOn 1 p p1 hp = p1 :=
+theorem recOn_one {p} (one succ) : @PNat.recOn 1 p one succ = one :=
   rfl
 
 @[simp]
-theorem recOn_succ (n : ℕ+) {p : ℕ+ → Sort*} (p1 hp) :
-    @PNat.recOn (n + 1) p p1 hp = hp n (@PNat.recOn n p p1 hp) := by
+theorem recOn_succ (n : ℕ+) {p : ℕ+ → Sort*} (one succ) :
+    @PNat.recOn (n + 1) p one succ = succ n (@PNat.recOn n p one succ) := by
   cases' n with n h
   cases n <;> [exact absurd h (by decide); rfl]
 

--- a/Mathlib/Data/PNat/Find.lean
+++ b/Mathlib/Data/PNat/Find.lean
@@ -101,10 +101,12 @@ theorem find_le {h : ∃ n, p n} (hn : p n) : PNat.find h ≤ n :=
 
 theorem find_comp_succ (h : ∃ n, p n) (h₂ : ∃ n, p (n + 1)) (h1 : ¬p 1) :
     PNat.find h = PNat.find h₂ + 1 := by
-  refine (find_eq_iff _).2 ⟨PNat.find_spec h₂, fun n => PNat.recOn n ?_ ?_⟩
-  · simp [h1]
-  intro m _ hm
-  simp only [add_lt_add_iff_right, lt_find_iff] at hm
-  exact hm _ le_rfl
+  refine (find_eq_iff _).2 ⟨PNat.find_spec h₂, fun n ↦ ?_⟩
+  induction n with
+  | one => simp [h1]
+  | succ m _ =>
+    intro hm
+    simp only [add_lt_add_iff_right, lt_find_iff] at hm
+    exact hm _ le_rfl
 
 end PNat


### PR DESCRIPTION
Following this discussion on Zulip:
https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Base.20Case.20for.20Induction.20on.20N.2B/near/492807806

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
