### PR TITLE
[Merged by Bors] - feat: disjoint union of charted spaces

### DIFF
--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -849,11 +849,9 @@ theorem piChartedSpace_chartAt {ι : Type*} [Finite ι] (H : ι → Type*)
     chartAt (H := ModelPi H) f = PartialHomeomorph.pi fun i ↦ chartAt (H i) (f i) :=
   rfl
 
-variable [TopologicalSpace H] [TopologicalSpace M] [TopologicalSpace M']
-    [Nonempty H] [Nonempty M] [Nonempty M']
-
 /-- The disjoint union of two charted spaces on `H` is a charted space over `H`. -/
-def ChartedSpace.sum (cm : ChartedSpace H M) (cm' : ChartedSpace H M') :
+instance ChartedSpace.sum [TopologicalSpace H] [TopologicalSpace M] [TopologicalSpace M']
+    [cm : ChartedSpace H M] [cm' : ChartedSpace H M'] [Nonempty H] [Nonempty M] [Nonempty M']:
     ChartedSpace H (M ⊕ M') where
   atlas := ((fun e ↦ e.lift_openEmbedding IsOpenEmbedding.inl) '' cm.atlas) ∪
     ((fun e ↦ e.lift_openEmbedding IsOpenEmbedding.inr) '' cm'.atlas)
@@ -882,24 +880,6 @@ def ChartedSpace.sum (cm : ChartedSpace H M) (cm' : ChartedSpace H M') :
       right
       let x := Sum.getRight p h'
       use ChartedSpace.chartAt x, cm'.chart_mem_atlas x
-
-lemma ChartedSpace.sum_chartAt_inl (cm : ChartedSpace H M) (cm' : ChartedSpace H M') (x : M) :
-    (cm.sum cm').chartAt (Sum.inl x) = (cm.chartAt x).lift_openEmbedding IsOpenEmbedding.inl := rfl
-
-lemma ChartedSpace.sum_chartAt_inr (cm : ChartedSpace H M) (cm' : ChartedSpace H M') (x' : M') :
-    (cm.sum cm').chartAt (Sum.inr x') = (cm'.chartAt x').lift_openEmbedding IsOpenEmbedding.inr :=
-  rfl
-
-attribute [instance] ChartedSpace.sum
-
-lemma ChartedSpace.mem_atlas_sum (cm : ChartedSpace H M) (cm' : ChartedSpace H M')
-    {e : PartialHomeomorph (M ⊕ M') H} (he : e ∈ (cm.sum cm').atlas) :
-    (∃ f : PartialHomeomorph M H, f ∈ cm.atlas ∧ e = (f.lift_openEmbedding IsOpenEmbedding.inl))
-    ∨ (∃ f' : PartialHomeomorph M' H, f' ∈ cm'.atlas ∧
-      e = (f'.lift_openEmbedding IsOpenEmbedding.inr)) := by
-    obtain (⟨x, hx, hxe⟩ | ⟨x, hx, hxe⟩) := he
-    · rw [← hxe]; left; use x
-    · rw [← hxe]; right; use x
 
 end ChartedSpace
 

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -1358,3 +1358,41 @@ def PartialHomeomorph.toStructomorph {e : PartialHomeomorph M H} (he : e ∈ atl
       mem_groupoid := fun _ c' _ ⟨_, ⟨x, _⟩, _⟩ ↦ (this.false x).elim }
 
 end HasGroupoid
+
+
+/-- The disjoint union of two charted spaces on `H` is a charted space over `H`. -/
+instance ChartedSpace.sum : ChartedSpace H (M ⊕ M') where
+  atlas := (foo '' cm.atlas) ∪ (bar '' cm'.atlas)
+  -- At `x : M`, the chart is the chart in `M`; at `x' ∈ M'`, it is the chart in `M'`.
+  chartAt := Sum.elim (fun x ↦ (cm.chartAt x).lift_openEmbedding IsOpenEmbedding.inl)
+    (fun x ↦ (cm'.chartAt x).lift_openEmbedding IsOpenEmbedding.inr)
+  mem_chart_source p := by
+    by_cases h : Sum.isLeft p
+    · let x := Sum.getLeft p h
+      rw [Sum.eq_left_getLeft_of_isLeft h]
+      let aux := cm.mem_chart_source x
+      dsimp
+      rw [PartialHomeomorph.lift_openEmbedding_source]
+      use x
+    · have h' : Sum.isRight p := Sum.not_isLeft.mp h
+      let x := Sum.getRight p h'
+      rw [Sum.eq_right_getRight_of_isRight h']
+      let aux := cm'.mem_chart_source x
+      dsimp
+      rw [PartialHomeomorph.lift_openEmbedding_source]
+      use x
+  chart_mem_atlas p := by
+    by_cases h : Sum.isLeft p
+    · let x := Sum.getLeft p h
+      rw [Sum.eq_left_getLeft_of_isLeft h]
+      dsimp
+      left
+      let aux := cm.chart_mem_atlas x
+      use ChartedSpace.chartAt x
+    · have h' : Sum.isRight p := Sum.not_isLeft.mp h
+      let x := Sum.getRight p h'
+      rw [Sum.eq_right_getRight_of_isRight h']
+      dsimp
+      right
+      let aux := cm'.chart_mem_atlas x
+      use ChartedSpace.chartAt x

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -849,10 +849,13 @@ theorem piChartedSpace_chartAt {ι : Type*} [Finite ι] (H : ι → Type*)
     chartAt (H := ModelPi H) f = PartialHomeomorph.pi fun i ↦ chartAt (H i) (f i) :=
   rfl
 
+section sum
+
+variable [TopologicalSpace H] [TopologicalSpace M] [TopologicalSpace M']
+    [cm : ChartedSpace H M] [cm' : ChartedSpace H M'] [Nonempty H] [Nonempty M] [Nonempty M']
+
 /-- The disjoint union of two charted spaces on `H` is a charted space over `H`. -/
-instance ChartedSpace.sum [TopologicalSpace H] [TopologicalSpace M] [TopologicalSpace M']
-    [cm : ChartedSpace H M] [cm' : ChartedSpace H M'] [Nonempty H] [Nonempty M] [Nonempty M']:
-    ChartedSpace H (M ⊕ M') where
+instance ChartedSpace.sum : ChartedSpace H (M ⊕ M') where
   atlas := ((fun e ↦ e.lift_openEmbedding IsOpenEmbedding.inl) '' cm.atlas) ∪
     ((fun e ↦ e.lift_openEmbedding IsOpenEmbedding.inr) '' cm'.atlas)
   -- At `x : M`, the chart is the chart in `M`; at `x' ∈ M'`, it is the chart in `M'`.
@@ -880,6 +883,24 @@ instance ChartedSpace.sum [TopologicalSpace H] [TopologicalSpace M] [Topological
       right
       let x := Sum.getRight p h'
       use ChartedSpace.chartAt x, cm'.chart_mem_atlas x
+
+lemma ChartedSpace.sum_chartAt_inl (x : M) :
+    chartAt H (Sum.inl x) = (chartAt H x).lift_openEmbedding (X' := M ⊕ M') IsOpenEmbedding.inl :=
+  rfl
+
+lemma ChartedSpace.sum_chartAt_inr (x' : M') :
+    chartAt H (Sum.inr x') = (chartAt H x').lift_openEmbedding (X' := M ⊕ M') IsOpenEmbedding.inr :=
+  rfl
+
+lemma ChartedSpace.mem_atlas_sum {e : PartialHomeomorph (M ⊕ M') H} (he : e ∈ atlas H (M ⊕ M')) :
+    (∃ f : PartialHomeomorph M H, f ∈ (atlas H M) ∧ e = (f.lift_openEmbedding IsOpenEmbedding.inl))
+    ∨ (∃ f' : PartialHomeomorph M' H, f' ∈ (atlas H M') ∧
+      e = (f'.lift_openEmbedding IsOpenEmbedding.inr)) := by
+    obtain (⟨x, hx, hxe⟩ | ⟨x, hx, hxe⟩) := he
+    · rw [← hxe]; left; use x
+    · rw [← hxe]; right; use x
+
+end sum
 
 end ChartedSpace
 

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -849,6 +849,38 @@ theorem piChartedSpace_chartAt {ι : Type*} [Finite ι] (H : ι → Type*)
     chartAt (H := ModelPi H) f = PartialHomeomorph.pi fun i ↦ chartAt (H i) (f i) :=
   rfl
 
+/-- The disjoint union of two charted spaces on `H` is a charted space over `H`. -/
+instance ChartedSpace.sum [TopologicalSpace H] [TopologicalSpace M] [TopologicalSpace M']
+    [cm : ChartedSpace H M] [cm' : ChartedSpace H M'] [Nonempty H] [Nonempty M] [Nonempty M']:
+    ChartedSpace H (M ⊕ M') where
+  atlas := ((fun e ↦ e.lift_openEmbedding IsOpenEmbedding.inl) '' cm.atlas) ∪
+    ((fun e ↦ e.lift_openEmbedding IsOpenEmbedding.inr) '' cm'.atlas)
+  -- At `x : M`, the chart is the chart in `M`; at `x' ∈ M'`, it is the chart in `M'`.
+  chartAt := Sum.elim (fun x ↦ (cm.chartAt x).lift_openEmbedding IsOpenEmbedding.inl)
+    (fun x ↦ (cm'.chartAt x).lift_openEmbedding IsOpenEmbedding.inr)
+  mem_chart_source p := by
+    by_cases h : Sum.isLeft p
+    · let x := Sum.getLeft p h
+      rw [Sum.eq_left_getLeft_of_isLeft h, Sum.elim_inl, lift_openEmbedding_source,
+        ← PartialHomeomorph.lift_openEmbedding_source _ IsOpenEmbedding.inl]
+      use x, cm.mem_chart_source x
+    · have h' : Sum.isRight p := Sum.not_isLeft.mp h
+      let x := Sum.getRight p h'
+      rw [Sum.eq_right_getRight_of_isRight h', Sum.elim_inr, lift_openEmbedding_source,
+        ← PartialHomeomorph.lift_openEmbedding_source _ IsOpenEmbedding.inr]
+      use x, cm'.mem_chart_source x
+  chart_mem_atlas p := by
+    by_cases h : Sum.isLeft p
+    · rw [Sum.eq_left_getLeft_of_isLeft h, Sum.elim_inl]
+      left
+      let x := Sum.getLeft p h
+      use ChartedSpace.chartAt x, cm.chart_mem_atlas x
+    · have h' : Sum.isRight p := Sum.not_isLeft.mp h
+      rw [Sum.eq_right_getRight_of_isRight h', Sum.elim_inr]
+      right
+      let x := Sum.getRight p h'
+      use ChartedSpace.chartAt x, cm'.chart_mem_atlas x
+
 end ChartedSpace
 
 /-! ### Constructing a topology from an atlas -/
@@ -1358,41 +1390,3 @@ def PartialHomeomorph.toStructomorph {e : PartialHomeomorph M H} (he : e ∈ atl
       mem_groupoid := fun _ c' _ ⟨_, ⟨x, _⟩, _⟩ ↦ (this.false x).elim }
 
 end HasGroupoid
-
-
-/-- The disjoint union of two charted spaces on `H` is a charted space over `H`. -/
-instance ChartedSpace.sum : ChartedSpace H (M ⊕ M') where
-  atlas := (foo '' cm.atlas) ∪ (bar '' cm'.atlas)
-  -- At `x : M`, the chart is the chart in `M`; at `x' ∈ M'`, it is the chart in `M'`.
-  chartAt := Sum.elim (fun x ↦ (cm.chartAt x).lift_openEmbedding IsOpenEmbedding.inl)
-    (fun x ↦ (cm'.chartAt x).lift_openEmbedding IsOpenEmbedding.inr)
-  mem_chart_source p := by
-    by_cases h : Sum.isLeft p
-    · let x := Sum.getLeft p h
-      rw [Sum.eq_left_getLeft_of_isLeft h]
-      let aux := cm.mem_chart_source x
-      dsimp
-      rw [PartialHomeomorph.lift_openEmbedding_source]
-      use x
-    · have h' : Sum.isRight p := Sum.not_isLeft.mp h
-      let x := Sum.getRight p h'
-      rw [Sum.eq_right_getRight_of_isRight h']
-      let aux := cm'.mem_chart_source x
-      dsimp
-      rw [PartialHomeomorph.lift_openEmbedding_source]
-      use x
-  chart_mem_atlas p := by
-    by_cases h : Sum.isLeft p
-    · let x := Sum.getLeft p h
-      rw [Sum.eq_left_getLeft_of_isLeft h]
-      dsimp
-      left
-      let aux := cm.chart_mem_atlas x
-      use ChartedSpace.chartAt x
-    · have h' : Sum.isRight p := Sum.not_isLeft.mp h
-      let x := Sum.getRight p h'
-      rw [Sum.eq_right_getRight_of_isRight h']
-      dsimp
-      right
-      let aux := cm'.chart_mem_atlas x
-      use ChartedSpace.chartAt x

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -849,9 +849,11 @@ theorem piChartedSpace_chartAt {ι : Type*} [Finite ι] (H : ι → Type*)
     chartAt (H := ModelPi H) f = PartialHomeomorph.pi fun i ↦ chartAt (H i) (f i) :=
   rfl
 
+variable [TopologicalSpace H] [TopologicalSpace M] [TopologicalSpace M']
+    [Nonempty H] [Nonempty M] [Nonempty M']
+
 /-- The disjoint union of two charted spaces on `H` is a charted space over `H`. -/
-instance ChartedSpace.sum [TopologicalSpace H] [TopologicalSpace M] [TopologicalSpace M']
-    [cm : ChartedSpace H M] [cm' : ChartedSpace H M'] [Nonempty H] [Nonempty M] [Nonempty M']:
+def ChartedSpace.sum (cm : ChartedSpace H M) (cm' : ChartedSpace H M') :
     ChartedSpace H (M ⊕ M') where
   atlas := ((fun e ↦ e.lift_openEmbedding IsOpenEmbedding.inl) '' cm.atlas) ∪
     ((fun e ↦ e.lift_openEmbedding IsOpenEmbedding.inr) '' cm'.atlas)
@@ -880,6 +882,24 @@ instance ChartedSpace.sum [TopologicalSpace H] [TopologicalSpace M] [Topological
       right
       let x := Sum.getRight p h'
       use ChartedSpace.chartAt x, cm'.chart_mem_atlas x
+
+lemma ChartedSpace.sum_chartAt_inl (cm : ChartedSpace H M) (cm' : ChartedSpace H M') (x : M) :
+    (cm.sum cm').chartAt (Sum.inl x) = (cm.chartAt x).lift_openEmbedding IsOpenEmbedding.inl := rfl
+
+lemma ChartedSpace.sum_chartAt_inr (cm : ChartedSpace H M) (cm' : ChartedSpace H M') (x' : M') :
+    (cm.sum cm').chartAt (Sum.inr x') = (cm'.chartAt x').lift_openEmbedding IsOpenEmbedding.inr :=
+  rfl
+
+attribute [instance] ChartedSpace.sum
+
+lemma ChartedSpace.mem_atlas_sum (cm : ChartedSpace H M) (cm' : ChartedSpace H M')
+    {e : PartialHomeomorph (M ⊕ M') H} (he : e ∈ (cm.sum cm').atlas) :
+    (∃ f : PartialHomeomorph M H, f ∈ cm.atlas ∧ e = (f.lift_openEmbedding IsOpenEmbedding.inl))
+    ∨ (∃ f' : PartialHomeomorph M' H, f' ∈ cm'.atlas ∧
+      e = (f'.lift_openEmbedding IsOpenEmbedding.inr)) := by
+    obtain (⟨x, hx, hxe⟩ | ⟨x, hx, hxe⟩) := he
+    · rw [← hxe]; left; use x
+    · rw [← hxe]; right; use x
 
 end ChartedSpace
 

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1387,10 +1387,4 @@ lemma lift_openEmbedding_source (e : PartialHomeomorph X Z) (hf : IsOpenEmbeddin
 lemma lift_openEmbedding_target (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
     (e.lift_openEmbedding hf).target = e.target := rfl
 
-noncomputable example (e : PartialHomeomorph X Z) : PartialHomeomorph (X ⊕ X') Z :=
-    e.lift_openEmbedding IsOpenEmbedding.inl
-
-noncomputable example (e : PartialHomeomorph X Z) : PartialHomeomorph (X' ⊕ X) Z :=
-    e.lift_openEmbedding IsOpenEmbedding.inr
-
 end PartialHomeomorph

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1325,4 +1325,35 @@ theorem subtypeRestr_symm_eqOn_of_le {U V : Opens X} (hU : Nonempty U) (hV : Non
 
 end subtypeRestr
 
+variable {X X' Z : Type*} [TopologicalSpace X] [TopologicalSpace X'] [TopologicalSpace Z]
+    [Nonempty Z] {f : X → X'}
+
+/-- Extend a partial homeomorphism `e : X → Z` to `X' → Z`, using an open embedding `X → X'`.
+
+-/
+noncomputable def lift_openEmbedding
+    (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
+    PartialHomeomorph X' Z where
+  toFun := extend f e (Classical.arbitrary (α := X' → Z))
+  invFun := sorry
+  source := f '' e.source
+  target := sorry
+  map_source' := sorry
+  map_target' := sorry
+  left_inv' := sorry
+  right_inv' := sorry
+  open_source := sorry
+  open_target := sorry
+  continuousOn_toFun := sorry
+  continuousOn_invFun := sorry
+
+@[simp]
+lemma lift_openEmbedding_toFun (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
+    (e.lift_openEmbedding hf) = extend f e (Classical.arbitrary (α := (X' → Z))) := rfl
+
+lemma lift_openEmbedding_apply (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) {x : X} :
+    (lift_openEmbedding e hf) (f x) = e x := by
+  simp_rw [e.lift_openEmbedding_toFun]
+  apply hf.injective.extend_apply
+
 end PartialHomeomorph

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1387,4 +1387,10 @@ lemma lift_openEmbedding_source (e : PartialHomeomorph X Z) (hf : IsOpenEmbeddin
 lemma lift_openEmbedding_target (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
     (e.lift_openEmbedding hf).target = e.target := rfl
 
+noncomputable example (e : PartialHomeomorph X Z) : PartialHomeomorph (X ⊕ X') Z :=
+    e.lift_openEmbedding IsOpenEmbedding.inl
+
+noncomputable example (e : PartialHomeomorph X Z) : PartialHomeomorph (X' ⊕ X) Z :=
+    e.lift_openEmbedding IsOpenEmbedding.inr
+
 end PartialHomeomorph

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1352,7 +1352,6 @@ noncomputable def lift_openEmbedding
   open_source := hf.isOpenMap _ e.open_source
   open_target := e.open_target
   continuousOn_toFun := by
-    --dsimp
     set F := (extend f (↑e) (Classical.arbitrary (X' → Z))) with F_eq
     have heq : EqOn F (e ∘ (hf.toPartialHomeomorph).symm) (f '' e.source) := by
       intro x ⟨x₀, hx₀, hxx₀⟩
@@ -1361,13 +1360,9 @@ noncomputable def lift_openEmbedding
       apply e.continuousOn_toFun.comp; swap
       · intro x' ⟨x, hx, hx'x⟩
         rw [← hx'x, hf.toPartialHomeomorph_left_inv]; exact hx
-      apply Continuous.continuousOn  -- risky move, too strong?
-      rw [continuous_iff_continuousOn_univ]
-      convert PartialHomeomorph.continuousOn_toFun (hf.toPartialHomeomorph).symm
-      rw [PartialHomeomorph.symm_source]
-
-      -- easy missing lemma
-      sorry
+      have : ContinuousOn (hf.toPartialHomeomorph).symm (f '' univ) := by
+        apply (hf.toPartialHomeomorph).continuousOn_invFun
+      apply this.mono; gcongr; exact fun ⦃a⦄ a ↦ trivial
     apply ContinuousOn.congr this heq
   continuousOn_invFun := hf.continuous.comp_continuousOn e.continuousOn_invFun
 


### PR DESCRIPTION
As the main technical tool to do so, we introduce a new definition `PartialHomeomorph.lift_openEmbedding`, lifting a PartialHomeomorph under an `OpenEmbedding`. (The left or right inclusion into a disjoint union are open embeddings; this abstract allows proving lemmas only once, and avoids having to deal with subtypes.)

From the bordism theory project branch: future steps include proving that the disjoint union of `C^n` manifolds is a `C^n` manifold.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
