### PR TITLE
[Merged by Bors] - fix: `apply H at h` when type of `H h` depends on proof of `h`

### DIFF
--- a/Mathlib/Tactic/ApplyAt.lean
+++ b/Mathlib/Tactic/ApplyAt.lean
@@ -40,6 +40,6 @@ elab "apply" t:term "at" i:ident : tactic => withSynthesize <| withMainContext d
   let mainGoal ← mainGoal.assert ldecl.userName appliedTy applied
   let (_, mainGoal) ← mainGoal.intro1P
   let mainGoal ← mainGoal.tryClear ldecl.fvarId
-  replaceMainGoal <| [mainGoal] ++ mvs.pop.toList.map fun e => e.mvarId!
+  replaceMainGoal <| [mainGoal] ++ mvs.pop.toList.map (·.mvarId!)
 
 end Mathlib.Tactic

--- a/Mathlib/Tactic/ApplyAt.lean
+++ b/Mathlib/Tactic/ApplyAt.lean
@@ -34,7 +34,7 @@ elab "apply" t:term "at" i:ident : tactic => withSynthesize <| withMainContext d
       try m.mvarId!.inferInstance
       catch _ => continue
   let applied ← mkAppOptM' f (mvs.pop.push ldecl.toExpr |>.map fun e => some e)
-  let appliedTy ← inferType applied
+  let appliedType ← inferType applied
   unless (← isDefEq appliedTy tp) do
     logError m!"assertion failed: {applied} has type {appliedTy}, expected {tp}"
   let mainGoal ← mainGoal.assert ldecl.userName appliedTy applied

--- a/Mathlib/Tactic/ApplyAt.lean
+++ b/Mathlib/Tactic/ApplyAt.lean
@@ -33,7 +33,7 @@ elab "apply" t:term "at" i:ident : tactic => withSynthesize <| withMainContext d
     if b.isInstImplicit && !(← m.mvarId!.isAssigned) then
       try m.mvarId!.inferInstance
       catch _ => continue
-  let applied ← mkAppOptM' f (mvs.pop.push ldecl.toExpr |>.map fun e => some e)
+  let applied ← mkAppOptM' f (mvs.pop.push ldecl.toExpr |>.map some)
   let appliedType ← inferType applied
   unless (← isDefEq appliedTy tp) do
     logError m!"assertion failed: {applied} has type {appliedTy}, expected {tp}"

--- a/MathlibTest/ApplyAt.lean
+++ b/MathlibTest/ApplyAt.lean
@@ -105,3 +105,17 @@ example (a b : ℝ) (h : -a * b = 0) : a = 0 ∨ b = 0 := by
   apply (congrArg (fun x => x / 1)) at h
   simp at h
   assumption
+
+example (h : True) : True := by
+  have (h : True) : h = h := rfl
+  apply this at h
+  simp at h
+  exact h
+
+example (a : List Nat) (k : Nat) (hk : k < a.length) : True := by
+  have thm (k : Nat) {xs ys : List Nat} (hk: k < xs.length)
+    (h : xs = ys) : xs[k] = ys[k]'(h ▸ hk) := h ▸ rfl
+  have : a = a.map id := by simp
+  apply thm k hk at this
+  simp at this
+  exact this

--- a/MathlibTest/ApplyAt.lean
+++ b/MathlibTest/ApplyAt.lean
@@ -106,16 +106,18 @@ example (a b : ℝ) (h : -a * b = 0) : a = 0 ∨ b = 0 := by
   simp at h
   assumption
 
+/-- `apply H at h` when type of `H h` depends on proof of `h` (#20623) -/
 example (h : True) : True := by
-  have (h : True) : h = h := rfl
-  apply this at h
+  have H (h : True) : h = h := rfl
+  apply H at h
   simp at h
   exact h
 
+/-- `apply H at h` when type of `H h` depends on proof of `h` (#20623) -/
 example (a : List Nat) (k : Nat) (hk : k < a.length) : True := by
-  have thm (k : Nat) {xs ys : List Nat} (hk: k < xs.length)
+  have H (k : Nat) {xs ys : List Nat} (hk: k < xs.length)
     (h : xs = ys) : xs[k] = ys[k]'(h ▸ hk) := h ▸ rfl
-  have : a = a.map id := by simp
-  apply thm k hk at this
-  simp at this
-  exact this
+  have h : a = a.map id := by simp
+  apply H k hk at h
+  simp at h
+  exact h


### PR DESCRIPTION
This scenario caused two issues:
1. We were deriving the type of `H h` using `forAllTelescopeReducing`, which does not know the proof of `h`, only the type.
2. We were `tryClear`ing `h` before applying `H`, which does not account for the dependency introduced by `H h` itself.

---

reported at https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/application.20type.20mismatch.20.20.20.E2.8B.AF.2Emp.20argument.20on.20congrArg/near/492685124

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
