### PR TITLE
[Merged by Bors] - chore: cleanup imports in PrimePow/Divisors

### DIFF
--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -4,10 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import Mathlib.Algebra.Associated.Basic
-import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.Ring.Nat
-import Mathlib.Data.Nat.PrimeFin
-import Mathlib.Order.Interval.Finset.Nat
+import Mathlib.Order.Nat
+import Mathlib.Data.Nat.Prime.Basic
 
 /-!
 # Prime powers

--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -4,14 +4,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import Mathlib.Algebra.Associated.Basic
-import Mathlib.NumberTheory.Divisors
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Algebra.Order.Ring.Nat
+import Mathlib.Data.Nat.PrimeFin
+import Mathlib.Order.Interval.Finset.Nat
 
 /-!
 # Prime powers
 
 This file deals with prime powers: numbers which are positive integer powers of a single prime.
 -/
-
+assert_not_exists Nat.divisors
 
 variable {R : Type*} [CommMonoidWithZero R] (n p : R) (k : ℕ)
 
@@ -86,12 +89,6 @@ theorem IsPrimePow.dvd {n m : ℕ} (hn : IsPrimePow n) (hm : m ∣ n) (hm₁ : m
   apply Nat.pos_of_ne_zero
   rintro rfl
   simp only [pow_zero, ne_eq, not_true_eq_false] at hm₁
-
-theorem Nat.disjoint_divisors_filter_isPrimePow {a b : ℕ} (hab : a.Coprime b) :
-    Disjoint (a.divisors.filter IsPrimePow) (b.divisors.filter IsPrimePow) := by
-  simp only [Finset.disjoint_left, Finset.mem_filter, and_imp, Nat.mem_divisors, not_and]
-  rintro n han _ha hn hbn _hb -
-  exact hn.ne_one (Nat.eq_one_of_dvd_coprimes hab han hbn)
 
 theorem IsPrimePow.two_le : ∀ {n : ℕ}, IsPrimePow n → 2 ≤ n
   | 0, h => (not_isPrimePow_zero h).elim

--- a/Mathlib/Data/Nat/Factorization/PrimePow.lean
+++ b/Mathlib/Data/Nat/Factorization/PrimePow.lean
@@ -6,6 +6,7 @@ Authors: Bhavik Mehta
 import Mathlib.Algebra.IsPrimePow
 import Mathlib.Data.Nat.Factorization.Basic
 import Mathlib.Data.Nat.Prime.Pow
+import Mathlib.NumberTheory.Divisors
 
 /-!
 # Prime powers and factorizations

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -5,6 +5,7 @@ Authors: Aaron Anderson
 -/
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.Ring.Nat
+import Mathlib.Algebra.IsPrimePow
 import Mathlib.Data.Nat.PrimeFin
 import Mathlib.Order.Interval.Finset.Nat
 
@@ -520,5 +521,11 @@ theorem prod_div_divisors {α : Type*} [CommMonoid α] (n : ℕ) (f : ℕ → α
   · intro x hx y hy h
     rw [mem_divisors] at hx hy
     exact (div_eq_iff_eq_of_dvd_dvd hn hx.1 hy.1).mp h
+
+theorem disjoint_divisors_filter_isPrimePow {a b : ℕ} (hab : a.Coprime b) :
+    Disjoint (a.divisors.filter IsPrimePow) (b.divisors.filter IsPrimePow) := by
+  simp only [Finset.disjoint_left, Finset.mem_filter, and_imp, Nat.mem_divisors, not_and]
+  rintro n han _ha hn hbn _hb -
+  exact hn.ne_one (Nat.eq_one_of_dvd_coprimes hab han hbn)
 
 end Nat


### PR DESCRIPTION
Moves a theorem to reduce the `NumberTheory` -> `Algebra` imports.