### PR TITLE
[Merged by Bors] - refactor(IntermediateField/Adjoin): Split off relation to `Algebra.adjoin`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3069,6 +3069,7 @@ import Mathlib.FieldTheory.Galois.Basic
 import Mathlib.FieldTheory.Galois.GaloisClosure
 import Mathlib.FieldTheory.Galois.Infinite
 import Mathlib.FieldTheory.Galois.Profinite
+import Mathlib.FieldTheory.IntermediateField.Adjoin.Algebra
 import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
 import Mathlib.FieldTheory.IntermediateField.Adjoin.Defs
 import Mathlib.FieldTheory.IntermediateField.Algebraic

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2020 Thomas Browning, Patrick Lutz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Browning, Patrick Lutz
+-/
+import Mathlib.FieldTheory.IntermediateField.Adjoin.Defs
+import Mathlib.FieldTheory.IntermediateField.Algebraic
+
+/-!
+# Adjoining Elements to Fields
+
+This file relates `IntermediateField.Adjoin` to `Algebra.adjoin`.
+-/
+
+open Module Polynomial
+
+namespace IntermediateField
+
+section AdjoinDef
+
+variable (F : Type*) [Field F] {E : Type*} [Field E] [Algebra F E] (S : Set E)
+
+theorem algebra_adjoin_le_adjoin : Algebra.adjoin F S ≤ (adjoin F S).toSubalgebra :=
+  Algebra.adjoin_le (subset_adjoin _ _)
+
+theorem adjoin_eq_algebra_adjoin (inv_mem : ∀ x ∈ Algebra.adjoin F S, x⁻¹ ∈ Algebra.adjoin F S) :
+    (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
+  le_antisymm
+    (show adjoin F S ≤
+        { Algebra.adjoin F S with
+          inv_mem' := inv_mem }
+      from adjoin_le_iff.mpr Algebra.subset_adjoin)
+    (algebra_adjoin_le_adjoin _ _)
+
+theorem eq_adjoin_of_eq_algebra_adjoin (K : IntermediateField F E)
+    (h : K.toSubalgebra = Algebra.adjoin F S) : K = adjoin F S := by
+  apply toSubalgebra_injective
+  rw [h]
+  refine (adjoin_eq_algebra_adjoin F _ fun x ↦ ?_).symm
+  rw [← h]
+  exact K.inv_mem
+
+theorem adjoin_eq_top_of_algebra (hS : Algebra.adjoin F S = ⊤) : adjoin F S = ⊤ :=
+  top_le_iff.mp (hS.symm.trans_le <| algebra_adjoin_le_adjoin F S)
+
+section AdjoinSimple
+
+variable (α : E)
+
+@[simp]
+theorem AdjoinSimple.isIntegral_gen : IsIntegral F (AdjoinSimple.gen F α) ↔ IsIntegral F α := by
+  conv_rhs => rw [← AdjoinSimple.algebraMap_gen F α]
+  rw [isIntegral_algebraMap_iff (algebraMap F⟮α⟯ E).injective]
+
+variable {F} {α}
+
+theorem adjoin_algebraic_toSubalgebra {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
+    (IntermediateField.adjoin F S).toSubalgebra = Algebra.adjoin F S :=
+  adjoin_eq_algebra_adjoin _ _ fun _ ↦
+    (Algebra.IsIntegral.adjoin fun x hx ↦ (hS x hx).isIntegral).inv_mem
+
+theorem adjoin_simple_toSubalgebra_of_integral (hα : IsIntegral F α) :
+    F⟮α⟯.toSubalgebra = Algebra.adjoin F {α} := by
+  apply adjoin_algebraic_toSubalgebra
+  rintro x (rfl : x = α)
+  rwa [isAlgebraic_iff_isIntegral]
+
+section Supremum
+
+variable {K L : Type*} [Field K] [Field L] [Algebra K L] (E1 E2 : IntermediateField K L)
+
+theorem le_sup_toSubalgebra : E1.toSubalgebra ⊔ E2.toSubalgebra ≤ (E1 ⊔ E2).toSubalgebra :=
+  sup_le (show E1 ≤ E1 ⊔ E2 from le_sup_left) (show E2 ≤ E1 ⊔ E2 from le_sup_right)
+
+theorem sup_toSubalgebra_of_isAlgebraic_right [Algebra.IsAlgebraic K E2] :
+    (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra := by
+  have : (adjoin E1 (E2 : Set L)).toSubalgebra = _ := adjoin_algebraic_toSubalgebra fun x h ↦
+    IsAlgebraic.tower_top E1 (isAlgebraic_iff.1
+      (Algebra.IsAlgebraic.isAlgebraic (⟨x, h⟩ : E2)))
+  apply_fun Subalgebra.restrictScalars K at this
+  erw [← restrictScalars_toSubalgebra, restrictScalars_adjoin,
+    Algebra.restrictScalars_adjoin] at this
+  exact this
+
+theorem sup_toSubalgebra_of_isAlgebraic_left [Algebra.IsAlgebraic K E1] :
+    (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra := by
+  have := sup_toSubalgebra_of_isAlgebraic_right E2 E1
+  rwa [sup_comm (a := E1), sup_comm (a := E1.toSubalgebra)]
+
+/-- The compositum of two intermediate fields is equal to the compositum of them
+as subalgebras, if one of them is algebraic over the base field. -/
+theorem sup_toSubalgebra_of_isAlgebraic
+    (halg : Algebra.IsAlgebraic K E1 ∨ Algebra.IsAlgebraic K E2) :
+    (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra :=
+  halg.elim (fun _ ↦ sup_toSubalgebra_of_isAlgebraic_left E1 E2)
+    (fun _ ↦ sup_toSubalgebra_of_isAlgebraic_right E1 E2)
+
+theorem sup_toSubalgebra_of_left [FiniteDimensional K E1] :
+    (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra :=
+  sup_toSubalgebra_of_isAlgebraic_left E1 E2
+
+theorem sup_toSubalgebra_of_right [FiniteDimensional K E2] :
+    (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra :=
+  sup_toSubalgebra_of_isAlgebraic_right E1 E2
+
+end Supremum
+
+section Tower
+
+variable (E)
+variable {K : Type*} [Field K] [Algebra F K] [Algebra E K] [IsScalarTower F E K]
+
+/-- If `K / E / F` is a field extension tower, `L` is an intermediate field of `K / F`, such that
+either `E / F` or `L / F` is algebraic, then `E(L) = E[L]`. -/
+theorem adjoin_toSubalgebra_of_isAlgebraic (L : IntermediateField F K)
+    (halg : Algebra.IsAlgebraic F E ∨ Algebra.IsAlgebraic F L) :
+    (adjoin E (L : Set K)).toSubalgebra = Algebra.adjoin E (L : Set K) := by
+  let i := IsScalarTower.toAlgHom F E K
+  let E' := i.fieldRange
+  let i' : E ≃ₐ[F] E' := AlgEquiv.ofInjectiveField i
+  have hi : algebraMap E K = (algebraMap E' K) ∘ i' := by ext x; rfl
+  apply_fun _ using Subalgebra.restrictScalars_injective F
+  erw [← restrictScalars_toSubalgebra, restrictScalars_adjoin_of_algEquiv i' hi,
+    Algebra.restrictScalars_adjoin_of_algEquiv i' hi, restrictScalars_adjoin,
+    Algebra.restrictScalars_adjoin]
+  exact E'.sup_toSubalgebra_of_isAlgebraic L (halg.imp
+    (fun (_ : Algebra.IsAlgebraic F E) ↦ i'.isAlgebraic) id)
+
+theorem adjoin_toSubalgebra_of_isAlgebraic_left (L : IntermediateField F K)
+    [halg : Algebra.IsAlgebraic F E] :
+    (adjoin E (L : Set K)).toSubalgebra = Algebra.adjoin E (L : Set K) :=
+  adjoin_toSubalgebra_of_isAlgebraic E L (Or.inl halg)
+
+theorem adjoin_toSubalgebra_of_isAlgebraic_right (L : IntermediateField F K)
+    [halg : Algebra.IsAlgebraic F L] :
+    (adjoin E (L : Set K)).toSubalgebra = Algebra.adjoin E (L : Set K) :=
+  adjoin_toSubalgebra_of_isAlgebraic E L (Or.inr halg)
+
+end Tower
+
+end AdjoinSimple
+
+end AdjoinDef
+
+section Induction
+
+variable {F : Type*} [Field F] {E : Type*} [Field E] [Algebra F E]
+
+theorem fg_of_fg_toSubalgebra (S : IntermediateField F E) (h : S.toSubalgebra.FG) : S.FG := by
+  cases' h with t ht
+  exact ⟨t, (eq_adjoin_of_eq_algebra_adjoin _ _ _ ht.symm).symm⟩
+
+@[deprecated (since := "2024-10-28")] alias fG_of_fG_toSubalgebra := fg_of_fg_toSubalgebra
+
+theorem fg_of_noetherian (S : IntermediateField F E) [IsNoetherian F E] : S.FG :=
+  S.fg_of_fg_toSubalgebra S.toSubalgebra.fg_of_noetherian
+
+theorem induction_on_adjoin [FiniteDimensional F E] (P : IntermediateField F E → Prop)
+    (base : P ⊥) (ih : ∀ (K : IntermediateField F E) (x : E), P K → P (K⟮x⟯.restrictScalars F))
+    (K : IntermediateField F E) : P K :=
+  letI : IsNoetherian F E := IsNoetherian.iff_fg.2 inferInstance
+  induction_on_adjoin_fg P base ih K K.fg_of_noetherian
+
+end Induction
+
+end IntermediateField
+
+namespace IsFractionRing
+
+variable {F A K L : Type*} [Field F] [CommRing A] [Algebra F A]
+  [Field K] [Algebra F K] [Algebra A K] [IsFractionRing A K] [Field L] [Algebra F L]
+  {g : A →ₐ[F] L} {f : K →ₐ[F] L}
+
+/-- If `F` is a field, `A` is an `F`-algebra with fraction field `K`, `L` is a field,
+`g : A →ₐ[F] L` lifts to `f : K →ₐ[F] L`,
+then the image of `f` is the field generated by the image of `g`.
+Note: this does not require `IsScalarTower F A K`. -/
+theorem algHom_fieldRange_eq_of_comp_eq (h : RingHom.comp f (algebraMap A K) = (g : A →+* L)) :
+    f.fieldRange = IntermediateField.adjoin F g.range := by
+  apply IntermediateField.toSubfield_injective
+  simp_rw [AlgHom.fieldRange_toSubfield, IntermediateField.adjoin_toSubfield]
+  convert ringHom_fieldRange_eq_of_comp_eq h using 2
+  exact Set.union_eq_self_of_subset_left fun _ ⟨x, hx⟩ ↦ ⟨algebraMap F A x, by simp [← hx]⟩
+
+/-- If `F` is a field, `A` is an `F`-algebra with fraction field `K`, `L` is a field,
+`g : A →ₐ[F] L` lifts to `f : K →ₐ[F] L`,
+`s` is a set such that the image of `g` is the subalgebra generated by `s`,
+then the image of `f` is the intermediate field generated by `s`.
+Note: this does not require `IsScalarTower F A K`. -/
+theorem algHom_fieldRange_eq_of_comp_eq_of_range_eq
+    (h : RingHom.comp f (algebraMap A K) = (g : A →+* L))
+    {s : Set L} (hs : g.range = Algebra.adjoin F s) :
+    f.fieldRange = IntermediateField.adjoin F s := by
+  apply IntermediateField.toSubfield_injective
+  simp_rw [AlgHom.fieldRange_toSubfield, IntermediateField.adjoin_toSubfield]
+  refine ringHom_fieldRange_eq_of_comp_eq_of_range_eq h ?_
+  rw [← Algebra.adjoin_eq_ring_closure, ← hs]; rfl
+
+variable [IsScalarTower F A K]
+
+/-- The image of `IsFractionRing.liftAlgHom` is the intermediate field generated by the image
+of the algebra hom. -/
+theorem liftAlgHom_fieldRange (hg : Function.Injective g) :
+    (liftAlgHom hg : K →ₐ[F] L).fieldRange = IntermediateField.adjoin F g.range :=
+  algHom_fieldRange_eq_of_comp_eq (by ext; simp)
+
+/-- The image of `IsFractionRing.liftAlgHom` is the intermediate field generated by `s`,
+if the image of the algebra hom is the subalgebra generated by `s`. -/
+theorem liftAlgHom_fieldRange_eq_of_range_eq (hg : Function.Injective g)
+    {s : Set L} (hs : g.range = Algebra.adjoin F s) :
+    (liftAlgHom hg : K →ₐ[F] L).fieldRange = IntermediateField.adjoin F s :=
+  algHom_fieldRange_eq_of_comp_eq_of_range_eq (by ext; simp) hs
+
+end IsFractionRing

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -9,7 +9,7 @@ import Mathlib.FieldTheory.IntermediateField.Algebraic
 /-!
 # Adjoining Elements to Fields
 
-This file relates `IntermediateField.Adjoin` to `Algebra.adjoin`.
+This file relates `IntermediateField.adjoin` to `Algebra.adjoin`.
 -/
 
 open Module Polynomial

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -100,27 +100,6 @@ theorem adjoin_simple_toSubalgebra_of_integral (hα : IsIntegral F α) :
   rintro x (rfl : x = α)
   rwa [isAlgebraic_iff_isIntegral]
 
-/-- Characterize `IsSplittingField` with `IntermediateField.adjoin` instead of `Algebra.adjoin`. -/
-theorem _root_.isSplittingField_iff_intermediateField {p : F[X]} :
-    p.IsSplittingField F E ↔ p.Splits (algebraMap F E) ∧ adjoin F (p.rootSet E) = ⊤ := by
-  rw [← toSubalgebra_injective.eq_iff,
-      adjoin_algebraic_toSubalgebra fun _ ↦ isAlgebraic_of_mem_rootSet]
-  exact ⟨fun ⟨spl, adj⟩ ↦ ⟨spl, adj⟩, fun ⟨spl, adj⟩ ↦ ⟨spl, adj⟩⟩
-
--- Note: p.Splits (algebraMap F E) also works
-theorem isSplittingField_iff {p : F[X]} {K : IntermediateField F E} :
-    p.IsSplittingField F K ↔ p.Splits (algebraMap F K) ∧ K = adjoin F (p.rootSet E) := by
-  suffices _ → (Algebra.adjoin F (p.rootSet K) = ⊤ ↔ K = adjoin F (p.rootSet E)) by
-    exact ⟨fun h ↦ ⟨h.1, (this h.1).mp h.2⟩, fun h ↦ ⟨h.1, (this h.1).mpr h.2⟩⟩
-  rw [← toSubalgebra_injective.eq_iff,
-      adjoin_algebraic_toSubalgebra fun x ↦ isAlgebraic_of_mem_rootSet]
-  refine fun hp ↦ (adjoin_rootSet_eq_range hp K.val).symm.trans ?_
-  rw [← K.range_val, eq_comm]
-
-theorem adjoin_rootSet_isSplittingField {p : F[X]} (hp : p.Splits (algebraMap F E)) :
-    p.IsSplittingField F (adjoin F (p.rootSet E)) :=
-  isSplittingField_iff.mpr ⟨splits_of_splits hp fun _ hx ↦ subset_adjoin F (p.rootSet E) hx, rfl⟩
-
 section Supremum
 
 variable {K L : Type*} [Field K] [Field L] [Algebra K L] (E1 E2 : IntermediateField K L)

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -49,94 +49,11 @@ theorem mem_adjoin_simple_iff {α : E} (x : E) :
     Algebra.adjoin_singleton_eq_range_aeval, AlgHom.mem_range, exists_exists_eq_and]
   tauto
 
-end AdjoinDef
-
-section AdjoinDef
-
-variable (F : Type*) [Field F] {E : Type*} [Field E] [Algebra F E] (S : Set E)
-
-theorem algebra_adjoin_le_adjoin : Algebra.adjoin F S ≤ (adjoin F S).toSubalgebra :=
-  Algebra.adjoin_le (subset_adjoin _ _)
-
-theorem adjoin_eq_algebra_adjoin (inv_mem : ∀ x ∈ Algebra.adjoin F S, x⁻¹ ∈ Algebra.adjoin F S) :
-    (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
-  le_antisymm
-    (show adjoin F S ≤
-        { Algebra.adjoin F S with
-          inv_mem' := inv_mem }
-      from adjoin_le_iff.mpr Algebra.subset_adjoin)
-    (algebra_adjoin_le_adjoin _ _)
-
-theorem eq_adjoin_of_eq_algebra_adjoin (K : IntermediateField F E)
-    (h : K.toSubalgebra = Algebra.adjoin F S) : K = adjoin F S := by
-  apply toSubalgebra_injective
-  rw [h]
-  refine (adjoin_eq_algebra_adjoin F _ fun x ↦ ?_).symm
-  rw [← h]
-  exact K.inv_mem
-
-theorem adjoin_eq_top_of_algebra (hS : Algebra.adjoin F S = ⊤) : adjoin F S = ⊤ :=
-  top_le_iff.mp (hS.symm.trans_le <| algebra_adjoin_le_adjoin F S)
-
-section AdjoinSimple
-
-variable (α : E)
-
-@[simp]
-theorem AdjoinSimple.isIntegral_gen : IsIntegral F (AdjoinSimple.gen F α) ↔ IsIntegral F α := by
-  conv_rhs => rw [← AdjoinSimple.algebraMap_gen F α]
-  rw [isIntegral_algebraMap_iff (algebraMap F⟮α⟯ E).injective]
-
-variable {F} {α}
-
-theorem adjoin_algebraic_toSubalgebra {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
-    (IntermediateField.adjoin F S).toSubalgebra = Algebra.adjoin F S :=
-  adjoin_eq_algebra_adjoin _ _ fun _ ↦
-    (Algebra.IsIntegral.adjoin fun x hx ↦ (hS x hx).isIntegral).inv_mem
-
-theorem adjoin_simple_toSubalgebra_of_integral (hα : IsIntegral F α) :
-    F⟮α⟯.toSubalgebra = Algebra.adjoin F {α} := by
-  apply adjoin_algebraic_toSubalgebra
-  rintro x (rfl : x = α)
-  rwa [isAlgebraic_iff_isIntegral]
+variable {F}
 
 section Supremum
 
 variable {K L : Type*} [Field K] [Field L] [Algebra K L] (E1 E2 : IntermediateField K L)
-
-theorem le_sup_toSubalgebra : E1.toSubalgebra ⊔ E2.toSubalgebra ≤ (E1 ⊔ E2).toSubalgebra :=
-  sup_le (show E1 ≤ E1 ⊔ E2 from le_sup_left) (show E2 ≤ E1 ⊔ E2 from le_sup_right)
-
-theorem sup_toSubalgebra_of_isAlgebraic_right [Algebra.IsAlgebraic K E2] :
-    (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra := by
-  have : (adjoin E1 (E2 : Set L)).toSubalgebra = _ := adjoin_algebraic_toSubalgebra fun x h ↦
-    IsAlgebraic.tower_top E1 (isAlgebraic_iff.1
-      (Algebra.IsAlgebraic.isAlgebraic (⟨x, h⟩ : E2)))
-  apply_fun Subalgebra.restrictScalars K at this
-  erw [← restrictScalars_toSubalgebra, restrictScalars_adjoin,
-    Algebra.restrictScalars_adjoin] at this
-  exact this
-
-theorem sup_toSubalgebra_of_isAlgebraic_left [Algebra.IsAlgebraic K E1] :
-    (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra := by
-  have := sup_toSubalgebra_of_isAlgebraic_right E2 E1
-  rwa [sup_comm (a := E1), sup_comm (a := E1.toSubalgebra)]
-
-/-- The compositum of two intermediate fields is equal to the compositum of them
-as subalgebras, if one of them is algebraic over the base field. -/
-theorem sup_toSubalgebra_of_isAlgebraic
-    (halg : Algebra.IsAlgebraic K E1 ∨ Algebra.IsAlgebraic K E2) :
-    (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra :=
-  halg.elim (fun _ ↦ sup_toSubalgebra_of_isAlgebraic_left E1 E2)
-    (fun _ ↦ sup_toSubalgebra_of_isAlgebraic_right E1 E2)
-
-theorem sup_toSubalgebra_of_left [FiniteDimensional K E1] :
-    (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra :=
-  sup_toSubalgebra_of_isAlgebraic_left E1 E2
-
-theorem sup_toSubalgebra_of_right [FiniteDimensional K E2] :
-    (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra :=
-  sup_toSubalgebra_of_isAlgebraic_right E1 E2
 
 instance finiteDimensional_sup [FiniteDimensional K E1] [FiniteDimensional K E2] :
     FiniteDimensional K (E1 ⊔ E2 : IntermediateField K L) := by
@@ -243,32 +160,6 @@ variable (E)
 variable {K : Type*} [Field K] [Algebra F K] [Algebra E K] [IsScalarTower F E K]
 
 /-- If `K / E / F` is a field extension tower, `L` is an intermediate field of `K / F`, such that
-either `E / F` or `L / F` is algebraic, then `E(L) = E[L]`. -/
-theorem adjoin_toSubalgebra_of_isAlgebraic (L : IntermediateField F K)
-    (halg : Algebra.IsAlgebraic F E ∨ Algebra.IsAlgebraic F L) :
-    (adjoin E (L : Set K)).toSubalgebra = Algebra.adjoin E (L : Set K) := by
-  let i := IsScalarTower.toAlgHom F E K
-  let E' := i.fieldRange
-  let i' : E ≃ₐ[F] E' := AlgEquiv.ofInjectiveField i
-  have hi : algebraMap E K = (algebraMap E' K) ∘ i' := by ext x; rfl
-  apply_fun _ using Subalgebra.restrictScalars_injective F
-  erw [← restrictScalars_toSubalgebra, restrictScalars_adjoin_of_algEquiv i' hi,
-    Algebra.restrictScalars_adjoin_of_algEquiv i' hi, restrictScalars_adjoin,
-    Algebra.restrictScalars_adjoin]
-  exact E'.sup_toSubalgebra_of_isAlgebraic L (halg.imp
-    (fun (_ : Algebra.IsAlgebraic F E) ↦ i'.isAlgebraic) id)
-
-theorem adjoin_toSubalgebra_of_isAlgebraic_left (L : IntermediateField F K)
-    [halg : Algebra.IsAlgebraic F E] :
-    (adjoin E (L : Set K)).toSubalgebra = Algebra.adjoin E (L : Set K) :=
-  adjoin_toSubalgebra_of_isAlgebraic E L (Or.inl halg)
-
-theorem adjoin_toSubalgebra_of_isAlgebraic_right (L : IntermediateField F K)
-    [halg : Algebra.IsAlgebraic F L] :
-    (adjoin E (L : Set K)).toSubalgebra = Algebra.adjoin E (L : Set K) :=
-  adjoin_toSubalgebra_of_isAlgebraic E L (Or.inr halg)
-
-/-- If `K / E / F` is a field extension tower, `L` is an intermediate field of `K / F`, such that
 either `E / F` or `L / F` is algebraic, then `[E(L) : E] ≤ [L : F]`. A corollary of
 `Subalgebra.adjoin_rank_le` since in this case `E(L) = E[L]`. -/
 theorem adjoin_rank_le_of_isAlgebraic (L : IntermediateField F K)
@@ -355,8 +246,6 @@ theorem exists_finset_of_mem_adjoin {S : Set E} {x : E} (hx : x ∈ adjoin F S) 
   simp_rw [Finset.coe_image, iSup_le_iff, adjoin_le_iff]
   rintro _ h _ rfl
   exact subset_adjoin F _ ⟨_, h, rfl⟩
-
-end AdjoinSimple
 
 end AdjoinDef
 
@@ -730,27 +619,6 @@ theorem _root_.Polynomial.irreducible_comp {f g : K[X]} (hfm : f.Monic) (hgm : g
 
 end AdjoinIntegralElement
 
-section Induction
-
-variable {F : Type*} [Field F] {E : Type*} [Field E] [Algebra F E]
-
-theorem fg_of_fg_toSubalgebra (S : IntermediateField F E) (h : S.toSubalgebra.FG) : S.FG := by
-  cases' h with t ht
-  exact ⟨t, (eq_adjoin_of_eq_algebra_adjoin _ _ _ ht.symm).symm⟩
-
-@[deprecated (since := "2024-10-28")] alias fG_of_fG_toSubalgebra := fg_of_fg_toSubalgebra
-
-theorem fg_of_noetherian (S : IntermediateField F E) [IsNoetherian F E] : S.FG :=
-  S.fg_of_fg_toSubalgebra S.toSubalgebra.fg_of_noetherian
-
-theorem induction_on_adjoin [FiniteDimensional F E] (P : IntermediateField F E → Prop)
-    (base : P ⊥) (ih : ∀ (K : IntermediateField F E) (x : E), P K → P (K⟮x⟯.restrictScalars F))
-    (K : IntermediateField F E) : P K :=
-  letI : IsNoetherian F E := IsNoetherian.iff_fg.2 inferInstance
-  induction_on_adjoin_fg P base ih K K.fg_of_noetherian
-
-end Induction
-
 end IntermediateField
 
 section Minpoly
@@ -892,54 +760,6 @@ theorem equivAdjoinSimple_symm_gen (pb : PowerBasis K L) :
   rw [equivAdjoinSimple, equivOfMinpoly_symm, equivOfMinpoly_gen, adjoin.powerBasis_gen]
 
 end PowerBasis
-
-namespace IsFractionRing
-
-variable {F A K L : Type*} [Field F] [CommRing A] [Algebra F A]
-  [Field K] [Algebra F K] [Algebra A K] [IsFractionRing A K] [Field L] [Algebra F L]
-  {g : A →ₐ[F] L} {f : K →ₐ[F] L}
-
-/-- If `F` is a field, `A` is an `F`-algebra with fraction field `K`, `L` is a field,
-`g : A →ₐ[F] L` lifts to `f : K →ₐ[F] L`,
-then the image of `f` is the field generated by the image of `g`.
-Note: this does not require `IsScalarTower F A K`. -/
-theorem algHom_fieldRange_eq_of_comp_eq (h : RingHom.comp f (algebraMap A K) = (g : A →+* L)) :
-    f.fieldRange = IntermediateField.adjoin F g.range := by
-  apply IntermediateField.toSubfield_injective
-  simp_rw [AlgHom.fieldRange_toSubfield, IntermediateField.adjoin_toSubfield]
-  convert ringHom_fieldRange_eq_of_comp_eq h using 2
-  exact Set.union_eq_self_of_subset_left fun _ ⟨x, hx⟩ ↦ ⟨algebraMap F A x, by simp [← hx]⟩
-
-/-- If `F` is a field, `A` is an `F`-algebra with fraction field `K`, `L` is a field,
-`g : A →ₐ[F] L` lifts to `f : K →ₐ[F] L`,
-`s` is a set such that the image of `g` is the subalgebra generated by `s`,
-then the image of `f` is the intermediate field generated by `s`.
-Note: this does not require `IsScalarTower F A K`. -/
-theorem algHom_fieldRange_eq_of_comp_eq_of_range_eq
-    (h : RingHom.comp f (algebraMap A K) = (g : A →+* L))
-    {s : Set L} (hs : g.range = Algebra.adjoin F s) :
-    f.fieldRange = IntermediateField.adjoin F s := by
-  apply IntermediateField.toSubfield_injective
-  simp_rw [AlgHom.fieldRange_toSubfield, IntermediateField.adjoin_toSubfield]
-  refine ringHom_fieldRange_eq_of_comp_eq_of_range_eq h ?_
-  rw [← Algebra.adjoin_eq_ring_closure, ← hs]; rfl
-
-variable [IsScalarTower F A K]
-
-/-- The image of `IsFractionRing.liftAlgHom` is the intermediate field generated by the image
-of the algebra hom. -/
-theorem liftAlgHom_fieldRange (hg : Function.Injective g) :
-    (liftAlgHom hg : K →ₐ[F] L).fieldRange = IntermediateField.adjoin F g.range :=
-  algHom_fieldRange_eq_of_comp_eq (by ext; simp)
-
-/-- The image of `IsFractionRing.liftAlgHom` is the intermediate field generated by `s`,
-if the image of the algebra hom is the subalgebra generated by `s`. -/
-theorem liftAlgHom_fieldRange_eq_of_range_eq (hg : Function.Injective g)
-    {s : Set L} (hs : g.range = Algebra.adjoin F s) :
-    (liftAlgHom hg : K →ₐ[F] L).fieldRange = IntermediateField.adjoin F s :=
-  algHom_fieldRange_eq_of_comp_eq_of_range_eq (by ext; simp) hs
-
-end IsFractionRing
 
 namespace IntermediateField
 

--- a/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
+++ b/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import Mathlib.RingTheory.Adjoin.Field
-import Mathlib.FieldTheory.IntermediateField.Basic
+import Mathlib.FieldTheory.IntermediateField.Adjoin.Algebra
 
 /-!
 # Splitting fields
@@ -161,3 +161,24 @@ theorem IntermediateField.splits_iff_mem (h : p.Splits (algebraMap K L)) :
 theorem IsIntegral.mem_intermediateField_of_minpoly_splits {x : L} (int : IsIntegral K x)
     {F : IntermediateField K L} (h : Splits (algebraMap K F) (minpoly K x)) : x ∈ F := by
   rw [← F.fieldRange_val]; exact int.mem_range_algebraMap_of_minpoly_splits h
+
+/-- Characterize `IsSplittingField` with `IntermediateField.adjoin` instead of `Algebra.adjoin`. -/
+theorem isSplittingField_iff_intermediateField : p.IsSplittingField K L ↔
+    p.Splits (algebraMap K L) ∧ IntermediateField.adjoin K (p.rootSet L) = ⊤ := by
+  rw [← IntermediateField.toSubalgebra_injective.eq_iff,
+      adjoin_algebraic_toSubalgebra fun _ ↦ isAlgebraic_of_mem_rootSet]
+  exact ⟨fun ⟨spl, adj⟩ ↦ ⟨spl, adj⟩, fun ⟨spl, adj⟩ ↦ ⟨spl, adj⟩⟩
+
+-- Note: p.Splits (algebraMap F E) also works
+theorem IntermediateField.isSplittingField_iff :
+    p.IsSplittingField K F ↔ p.Splits (algebraMap K F) ∧ F = adjoin K (p.rootSet L) := by
+  suffices _ → (Algebra.adjoin F (p.rootSet K) = ⊤ ↔ K = adjoin F (p.rootSet E)) by
+    exact ⟨fun h ↦ ⟨h.1, (this h.1).mp h.2⟩, fun h ↦ ⟨h.1, (this h.1).mpr h.2⟩⟩
+  rw [← toSubalgebra_injective.eq_iff,
+      adjoin_algebraic_toSubalgebra fun x ↦ isAlgebraic_of_mem_rootSet]
+  refine fun hp ↦ (adjoin_rootSet_eq_range hp K.val).symm.trans ?_
+  rw [← K.range_val, eq_comm]
+
+theorem IntermediateField.adjoin_rootSet_isSplittingField (hp : p.Splits (algebraMap K L)) :
+    p.IsSplittingField K (adjoin K (p.rootSet L)) :=
+  isSplittingField_iff.mpr ⟨splits_of_splits hp fun _ hx ↦ subset_adjoin K (p.rootSet L) hx, rfl⟩

--- a/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
+++ b/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
@@ -166,18 +166,18 @@ theorem IsIntegral.mem_intermediateField_of_minpoly_splits {x : L} (int : IsInte
 theorem isSplittingField_iff_intermediateField : p.IsSplittingField K L ↔
     p.Splits (algebraMap K L) ∧ IntermediateField.adjoin K (p.rootSet L) = ⊤ := by
   rw [← IntermediateField.toSubalgebra_injective.eq_iff,
-      adjoin_algebraic_toSubalgebra fun _ ↦ isAlgebraic_of_mem_rootSet]
+      IntermediateField.adjoin_algebraic_toSubalgebra fun _ ↦ isAlgebraic_of_mem_rootSet]
   exact ⟨fun ⟨spl, adj⟩ ↦ ⟨spl, adj⟩, fun ⟨spl, adj⟩ ↦ ⟨spl, adj⟩⟩
 
 -- Note: p.Splits (algebraMap F E) also works
 theorem IntermediateField.isSplittingField_iff :
     p.IsSplittingField K F ↔ p.Splits (algebraMap K F) ∧ F = adjoin K (p.rootSet L) := by
-  suffices _ → (Algebra.adjoin F (p.rootSet K) = ⊤ ↔ K = adjoin F (p.rootSet E)) by
+  suffices _ → (Algebra.adjoin K (p.rootSet F) = ⊤ ↔ F = adjoin K (p.rootSet L)) by
     exact ⟨fun h ↦ ⟨h.1, (this h.1).mp h.2⟩, fun h ↦ ⟨h.1, (this h.1).mpr h.2⟩⟩
   rw [← toSubalgebra_injective.eq_iff,
       adjoin_algebraic_toSubalgebra fun x ↦ isAlgebraic_of_mem_rootSet]
-  refine fun hp ↦ (adjoin_rootSet_eq_range hp K.val).symm.trans ?_
-  rw [← K.range_val, eq_comm]
+  refine fun hp ↦ (adjoin_rootSet_eq_range hp F.val).symm.trans ?_
+  rw [← F.range_val, eq_comm]
 
 theorem IntermediateField.adjoin_rootSet_isSplittingField (hp : p.Splits (algebraMap K L)) :
     p.IsSplittingField K (adjoin K (p.rootSet L)) :=

--- a/Mathlib/RingTheory/AlgebraicIndependent/Adjoin.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/Adjoin.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
+import Mathlib.FieldTheory.IntermediateField.Adjoin.Algebra
 import Mathlib.RingTheory.AlgebraicIndependent.Defs
 
 /-!

--- a/Mathlib/RingTheory/AlgebraicIndependent/RankAndCardinality.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/RankAndCardinality.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
 import Mathlib.FieldTheory.MvRatFunc.Rank
 import Mathlib.RingTheory.Algebraic.Cardinality
 import Mathlib.RingTheory.AlgebraicIndependent.Adjoin

--- a/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
+import Mathlib.FieldTheory.IntermediateField.Adjoin.Algebra
 import Mathlib.RingTheory.AlgebraicIndependent.Transcendental
 
 /-!


### PR DESCRIPTION
Part of `IntermediateField/Adjoin/Basic` is about the relation with `Algebra.adjoin` (e.g., assuming integrality). This PR splits off those results into their own file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
