### PR TITLE
[Merged by Bors] - feat(Data/List/ReduceOption): add replicate theorems

### DIFF
--- a/Mathlib/Data/List/ReduceOption.lean
+++ b/Mathlib/Data/List/ReduceOption.lean
@@ -41,13 +41,12 @@ theorem reduceOption_append (l l' : List (Option α)) :
   filterMap_append l l' id
 
 @[simp]
-theorem reduceOption_replicate_of_none {n : ℕ} :
-    (replicate n (@none α)).reduceOption = [] := by
+theorem reduceOption_replicate_none {n : ℕ} : (replicate n (@none α)).reduceOption = [] := by
   dsimp [reduceOption]
   rw [filterMap_replicate_of_none]
   rfl
 
-theorem reduceOption_eq_nil_replicate_iff (l : List (Option α)) :
+theorem reduceOption_eq_nil_iff (l : List (Option α)) :
     l.reduceOption = [] ↔ ∃ n, l = replicate n none := by
   dsimp [reduceOption]
   rw [filterMap_eq_nil_iff]
@@ -58,7 +57,7 @@ theorem reduceOption_eq_nil_replicate_iff (l : List (Option α)) :
     simp_rw [h, mem_replicate]
     tauto
 
-theorem reduceOption_eq_singleton_replicate_iff (l : List (Option α)) (a : α) :
+theorem reduceOption_eq_singleton_iff (l : List (Option α)) (a : α) :
     l.reduceOption = [a] ↔ ∃ m n, l = replicate m none ++ some a :: replicate n none := by
   dsimp [reduceOption]
   constructor
@@ -93,11 +92,11 @@ theorem reduceOption_eq_concat_iff (l : List (Option α)) (l' : List α) (a : α
   · intro h
     rw [reduceOption_eq_append_iff] at h
     obtain ⟨l₁, _, h, hl₁, hl₂⟩ := h
-    rw [reduceOption_eq_singleton_replicate_iff] at hl₂
+    rw [reduceOption_eq_singleton_iff] at hl₂
     obtain ⟨m, n, hl₂⟩ := hl₂
     use l₁ ++ replicate m none, replicate n none
-    simp_rw [h, reduceOption_append, reduceOption_replicate_of_none, append_assoc, append_nil,
-      hl₁, hl₂]
+    simp_rw [h, reduceOption_append, reduceOption_replicate_none, append_assoc, append_nil, hl₁,
+      hl₂]
     trivial
   · intro ⟨_, _, h, hl₁, hl₂⟩
     rw [h, reduceOption_append, reduceOption_cons_of_some, hl₁, hl₂]

--- a/Mathlib/Data/List/ReduceOption.lean
+++ b/Mathlib/Data/List/ReduceOption.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Yakov Pechersky. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yakov Pechersky
+Authors: Yakov Pechersky, Anthony DeRossi
 -/
 import Mathlib.Data.List.Basic
 
@@ -39,6 +39,68 @@ theorem reduceOption_map {l : List (Option α)} {f : α → β} :
 theorem reduceOption_append (l l' : List (Option α)) :
     (l ++ l').reduceOption = l.reduceOption ++ l'.reduceOption :=
   filterMap_append l l' id
+
+@[simp]
+theorem reduceOption_replicate_of_none {n : ℕ} :
+    (replicate n (@none α)).reduceOption = [] := by
+  dsimp [reduceOption]
+  rw [filterMap_replicate_of_none]
+  rfl
+
+theorem reduceOption_eq_nil_replicate_iff (l : List (Option α)) :
+    l.reduceOption = [] ↔ ∃ n, l = replicate n none := by
+  dsimp [reduceOption]
+  rw [filterMap_eq_nil_iff]
+  constructor
+  · intro h
+    exact ⟨l.length, eq_replicate_of_mem h⟩
+  · intro ⟨_, h⟩
+    simp_rw [h, mem_replicate]
+    tauto
+
+theorem reduceOption_eq_singleton_replicate_iff (l : List (Option α)) (a : α) :
+    l.reduceOption = [a] ↔ ∃ m n, l = replicate m none ++ some a :: replicate n none := by
+  dsimp [reduceOption]
+  constructor
+  · intro h
+    rw [filterMap_eq_cons_iff] at h
+    obtain ⟨l₁, _, l₂, h, hl₁, ⟨⟩, hl₂⟩ := h
+    rw [filterMap_eq_nil_iff] at hl₂
+    apply eq_replicate_of_mem at hl₁
+    apply eq_replicate_of_mem at hl₂
+    rw [h, hl₁, hl₂]
+    use l₁.length, l₂.length
+  · intro ⟨_, _, h⟩
+    simp only [h, filterMap_append, filterMap_cons_some, filterMap_replicate_of_none, id_eq,
+      nil_append, Option.some.injEq]
+
+theorem reduceOption_eq_append_iff (l : List (Option α)) (l'₁ l'₂ : List α) :
+    l.reduceOption = l'₁ ++ l'₂ ↔
+      ∃ l₁ l₂, l = l₁ ++ l₂ ∧ l₁.reduceOption = l'₁ ∧ l₂.reduceOption = l'₂ := by
+  dsimp [reduceOption]
+  constructor
+  · intro h
+    rw [filterMap_eq_append_iff] at h
+    trivial
+  · intro ⟨_, _, h, hl₁, hl₂⟩
+    rw [h, filterMap_append, hl₁, hl₂]
+
+theorem reduceOption_eq_concat_iff (l : List (Option α)) (l' : List α) (a : α) :
+    l.reduceOption = l'.concat a ↔
+      ∃ l₁ l₂, l = l₁ ++ some a :: l₂ ∧ l₁.reduceOption = l' ∧ l₂.reduceOption = [] := by
+  rw [concat_eq_append]
+  constructor
+  · intro h
+    rw [reduceOption_eq_append_iff] at h
+    obtain ⟨l₁, _, h, hl₁, hl₂⟩ := h
+    rw [reduceOption_eq_singleton_replicate_iff] at hl₂
+    obtain ⟨m, n, hl₂⟩ := hl₂
+    use l₁ ++ replicate m none, replicate n none
+    simp_rw [h, reduceOption_append, reduceOption_replicate_of_none, append_assoc, append_nil,
+      hl₁, hl₂]
+    trivial
+  · intro ⟨_, _, h, hl₁, hl₂⟩
+    rw [h, reduceOption_append, reduceOption_cons_of_some, hl₁, hl₂]
 
 theorem reduceOption_length_eq {l : List (Option α)} :
     l.reduceOption.length = (l.filter Option.isSome).length := by


### PR DESCRIPTION
These theorems make it easier to prove statements about `List.reduceOption`, building up to a more general theorem, `reduceOption_eq_concat_iff`, which is useful for inductive proofs.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
