### PR TITLE
[Merged by Bors] - feat(Computability/EpsilonNFA): define path relation

### DIFF
--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -42,7 +42,7 @@ structure εNFA (α : Type u) (σ : Type v) where
   /-- Set of acceptance states. -/
   accept : Set σ
 
-variable {α : Type u} {σ : Type v} (M : εNFA α σ) {S : Set σ} {s : σ} {a : α}
+variable {α : Type u} {σ : Type v} (M : εNFA α σ) {S : Set σ} {s t u : σ} {a : α}
 
 namespace εNFA
 
@@ -64,8 +64,7 @@ theorem εClosure_empty : M.εClosure ∅ = ∅ :=
 theorem εClosure_univ : M.εClosure univ = univ :=
   eq_univ_of_univ_subset <| subset_εClosure _ _
 
-theorem mem_εClosure_iff_exists {s : σ} {S : Set σ} :
-    s ∈ M.εClosure S ↔ ∃ t ∈ S, s ∈ M.εClosure {t} where
+theorem mem_εClosure_iff_exists : s ∈ M.εClosure S ↔ ∃ t ∈ S, s ∈ M.εClosure {t} where
   mp h := by
     induction' h with s _ _ _ _ _ ih
     · tauto
@@ -151,12 +150,12 @@ inductive IsPath : σ → σ → List (Option α) → Prop
   | cons (t s u : σ) (a : Option α) (x : List (Option α)) :
       t ∈ M.step s a → IsPath t u x → IsPath s u (a :: x)
 
-theorem IsPath.eq_of_nil {s t : σ} : M.IsPath s t [] → s = t := by
+theorem IsPath.eq_of_nil : M.IsPath s t [] → s = t := by
   rintro ⟨⟩
   rfl
 
 @[simp]
-theorem isPath_singleton {s t : σ} {a : Option α} : M.IsPath s t [a] ↔ t ∈ M.step s a where
+theorem isPath_singleton {a : Option α} : M.IsPath s t [a] ↔ t ∈ M.step s a where
   mp := by
     rintro (_ | ⟨_, _, _, _, _, _, ⟨⟩⟩)
     assumption
@@ -164,7 +163,7 @@ theorem isPath_singleton {s t : σ} {a : Option α} : M.IsPath s t [a] ↔ t ∈
 
 alias ⟨_, IsPath.singleton⟩ := isPath_singleton
 
-theorem isPath_append {s u : σ} {x y : List (Option α)} :
+theorem isPath_append {x y : List (Option α)} :
     M.IsPath s u (x ++ y) ↔ ∃ t, M.IsPath s t x ∧ M.IsPath t u y where
   mp := by
     induction' x with _ _ ih generalizing s

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -212,10 +212,10 @@ theorem evalFrom_Path_iff (s₁ s₂ : σ) (x : List α) :
     constructor
     · intro ⟨n, _⟩
       use List.replicate n none
-      rw [List.reduceOption_replicate_of_none]
+      rw [List.reduceOption_replicate_none]
       trivial
     · intro ⟨_, hx⟩
-      rw [List.reduceOption_eq_nil_replicate_iff] at hx
+      rw [List.reduceOption_eq_nil_iff] at hx
       obtain ⟨⟨_, ⟨⟩⟩, _⟩ := hx
       tauto
   · rw [evalFrom_append_singleton, mem_stepSet_iff]
@@ -228,12 +228,12 @@ theorem evalFrom_Path_iff (s₁ s₂ : σ) (x : List α) :
       obtain ⟨n, _⟩ := h
       use x' ++ some a :: List.replicate n none
       rw [List.reduceOption_append, List.reduceOption_cons_of_some,
-        List.reduceOption_replicate_of_none, Path_append_iff]
+        List.reduceOption_replicate_none, Path_append_iff]
       tauto
     · intro ⟨_, hx, h⟩
       rw [← List.concat_eq_append, List.reduceOption_eq_concat_iff] at hx
       obtain ⟨_, _, ⟨⟩, _, hx₂⟩ := hx
-      rw [List.reduceOption_eq_nil_replicate_iff] at hx₂
+      rw [List.reduceOption_eq_nil_iff] at hx₂
       obtain ⟨_, ⟨⟩⟩ := hx₂
       rw [Path_append_iff] at h
       obtain ⟨t, _, _ | _⟩ := h

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -181,7 +181,7 @@ theorem isPath_append {x y : List (Option α)} :
     induction x generalizing s <;> cases hx <;> tauto
 
 theorem mem_εClosure_iff_exists_path {s₁ s₂ : σ} :
-    s₂ ∈ M.εClosure {s₁} ↔ ∃ n, M.IsPath s₁ s₂ (List.replicate n none) where
+    s₂ ∈ M.εClosure {s₁} ↔ ∃ n, M.IsPath s₁ s₂ (.replicate n none) where
   mp h := by
     induction' h with t _ _ _ _ _ ih
     · use 0

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -234,7 +234,7 @@ theorem evalFrom_path {s₁ s₂ : σ} {x : List α} :
       simp_rw [εClosure_path]
       tauto
 
-theorem accepts_path {x : List α} :
+theorem mem_accepts_iff_exists_path {x : List α} :
     x ∈ M.accepts ↔
       ∃ s₁ s₂ x', s₁ ∈ M.start ∧ s₂ ∈ M.accept ∧ x'.reduceOption = x ∧ M.IsPath s₁ s₂ x' where
   mp := by

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -72,7 +72,7 @@ theorem mem_εClosure_iff_exists : s ∈ M.εClosure S ↔ ∃ t ∈ S, s ∈ M.
       use s
       solve_by_elim [εClosure.step]
   mpr := by
-    intro ⟨_, _, h⟩
+    intro ⟨t, _, h⟩
     induction' h <;> subst_vars <;> solve_by_elim [εClosure.step]
 
 /-- `M.stepSet S a` is the union of the ε-closure of `M.step s a` for all `s ∈ S`. -/
@@ -170,14 +170,14 @@ alias ⟨_, IsPath.singleton⟩ := isPath_singleton
 theorem isPath_append {x y : List (Option α)} :
     M.IsPath s u (x ++ y) ↔ ∃ t, M.IsPath s t x ∧ M.IsPath t u y where
   mp := by
-    induction' x with _ _ ih generalizing s
+    induction' x with x a ih generalizing s
     · rw [List.nil_append]
       tauto
-    · rintro (_ | ⟨_, _, _, _, _, _, h⟩)
+    · rintro (_ | ⟨t, _, _, _, _, _, h⟩)
       apply ih at h
       tauto
   mpr := by
-    intro ⟨_, hx, _⟩
+    intro ⟨t, hx, _⟩
     induction x generalizing s <;> cases hx <;> tauto
 
 theorem mem_εClosure_iff_exists_path {s₁ s₂ : σ} :
@@ -198,12 +198,12 @@ theorem mem_εClosure_iff_exists_path {s₁ s₂ : σ} :
       apply IsPath.eq_of_nil at h
       solve_by_elim
     · simp_rw [List.replicate_add, isPath_append, List.replicate_one, isPath_singleton] at h
-      obtain ⟨_, _, _⟩ := h
+      obtain ⟨t, _, _⟩ := h
       solve_by_elim [εClosure.step]
 
 theorem mem_evalFrom_iff_exists_path {s₁ s₂ : σ} {x : List α} :
     s₂ ∈ M.evalFrom {s₁} x ↔ ∃ x', x'.reduceOption = x ∧ M.IsPath s₁ s₂ x' := by
-  induction' x using List.reverseRecOn with _ a ih generalizing s₂
+  induction' x using List.reverseRecOn with x a ih generalizing s₂
   · rw [evalFrom_nil, mem_εClosure_iff_exists_path]
     constructor
     · intro ⟨n, _⟩
@@ -211,24 +211,24 @@ theorem mem_evalFrom_iff_exists_path {s₁ s₂ : σ} {x : List α} :
       rw [List.reduceOption_replicate_none]
       trivial
     · simp_rw [List.reduceOption_eq_nil_iff]
-      rintro ⟨_, ⟨⟨_, rfl⟩, _⟩⟩
-      tauto
+      intro ⟨_, ⟨⟨n, rfl⟩, h⟩⟩
+      exact ⟨n, h⟩
   · rw [evalFrom_append_singleton, mem_stepSet_iff]
     constructor
-    · intro ⟨_, ht, h⟩
+    · intro ⟨t, ht, h⟩
       obtain ⟨x', _, _⟩ := ih.mp ht
       rw [mem_εClosure_iff_exists] at h
       simp_rw [mem_εClosure_iff_exists_path] at h
-      obtain ⟨_, _, ⟨n, _⟩⟩ := h
+      obtain ⟨u, _, ⟨n, _⟩⟩ := h
       use x' ++ some a :: List.replicate n none
       rw [List.reduceOption_append, List.reduceOption_cons_of_some,
         List.reduceOption_replicate_none, isPath_append]
       tauto
     · simp_rw [← List.concat_eq_append, List.reduceOption_eq_concat_iff,
         List.reduceOption_eq_nil_iff]
-      rintro ⟨_, ⟨_, _, rfl, _, _, rfl⟩, h⟩
+      intro ⟨_, ⟨x', _, rfl, _, n, rfl⟩, h⟩
       rw [isPath_append] at h
-      obtain ⟨t, _, _ | _⟩ := h
+      obtain ⟨t, _, _ | u⟩ := h
       use t
       rw [mem_εClosure_iff_exists, ih]
       simp_rw [mem_εClosure_iff_exists_path]
@@ -238,15 +238,15 @@ theorem mem_accepts_iff_exists_path {x : List α} :
     x ∈ M.accepts ↔
       ∃ s₁ s₂ x', s₁ ∈ M.start ∧ s₂ ∈ M.accept ∧ x'.reduceOption = x ∧ M.IsPath s₁ s₂ x' where
   mp := by
-    intro ⟨_, _, h⟩
+    intro ⟨s₂, _, h⟩
     rw [eval, mem_evalFrom_iff_exists] at h
-    obtain ⟨_, _, h⟩ := h
+    obtain ⟨s₁, _, h⟩ := h
     rw [mem_evalFrom_iff_exists_path] at h
     tauto
   mpr := by
-    intro ⟨_, _, _, hs₁, _, h⟩
+    intro ⟨s₁, s₂, x', hs₁, hs₂, h⟩
     have := M.mem_evalFrom_iff_exists.mpr ⟨_, hs₁, M.mem_evalFrom_iff_exists_path.mpr ⟨_, h⟩⟩
-    tauto
+    exact ⟨s₂, hs₂, this⟩
 
 /-! ### Conversions between `εNFA` and `NFA` -/
 

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -145,14 +145,18 @@ def accepts : Language α :=
 
 /-- `M.IsPath` represents a traversal in `M` from a start state to an end state by following a list
 of transitions in order. -/
+@[mk_iff]
 inductive IsPath : σ → σ → List (Option α) → Prop
-  | nil : ∀ s, IsPath s s []
+  | nil (s : σ) : IsPath s s []
   | cons (t s u : σ) (a : Option α) (x : List (Option α)) :
       t ∈ M.step s a → IsPath t u x → IsPath s u (a :: x)
 
-theorem IsPath.eq_of_nil : M.IsPath s t [] → s = t := by
-  rintro ⟨⟩
-  rfl
+@[simp]
+theorem isPath_nil : M.IsPath s t [] ↔ s = t := by
+  rw [isPath_iff]
+  simp [eq_comm]
+
+alias ⟨IsPath.eq_of_nil, _⟩ := isPath_nil
 
 @[simp]
 theorem isPath_singleton {a : Option α} : M.IsPath s t [a] ↔ t ∈ M.step s a where

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -167,7 +167,6 @@ theorem isPath_singleton {s t : σ} {a : Option α} : M.IsPath s t [a] ↔ t ∈
 
 alias ⟨_, IsPath.singleton⟩ := isPath_singleton
 
-@[simp]
 theorem isPath_append {s u : σ} {x y : List (Option α)} :
     M.IsPath s u (x ++ y) ↔ ∃ t, M.IsPath s t x ∧ M.IsPath t u y where
   mp := by

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -152,16 +152,13 @@ inductive IsPath : σ → σ → List (Option α) → Prop
       t ∈ M.step s a → IsPath t u x → IsPath s u (a :: x)
 
 theorem IsPath.eq_of_nil {s t : σ} : M.IsPath s t [] → s = t := by
-  intro h
-  cases h
+  rintro ⟨⟩
   rfl
 
 @[simp]
 theorem isPath_singleton {s t : σ} {a : Option α} : M.IsPath s t [a] ↔ t ∈ M.step s a where
   mp := by
-    rintro (_ | ⟨_, _, _, _, _, _, h⟩)
-    apply IsPath.eq_of_nil at h
-    subst t
+    rintro (_ | ⟨_, _, _, _, _, _, ⟨⟩⟩)
     assumption
   mpr := by tauto
 

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -65,15 +65,15 @@ theorem εClosure_univ : M.εClosure univ = univ :=
   eq_univ_of_univ_subset <| subset_εClosure _ _
 
 theorem mem_εClosure_choice {s : σ} {S : Set σ} :
-    s ∈ M.εClosure S ↔ ∃ t ∈ S, s ∈ M.εClosure {t} := by
-  constructor
-  · intro h
+    s ∈ M.εClosure S ↔ ∃ t ∈ S, s ∈ M.εClosure {t} where
+  mp h := by
     induction' h with s _ _ _ _ _ ih
     · tauto
     · obtain ⟨s, _, _⟩ := ih
       use s
       solve_by_elim [εClosure.step]
-  · intro ⟨_, _, h⟩
+  mpr := by
+    intro ⟨_, _, h⟩
     induction' h <;> subst_vars <;> solve_by_elim [εClosure.step]
 
 /-- `M.stepSet S a` is the union of the ε-closure of `M.step s a` for all `s ∈ S`. -/
@@ -163,33 +163,33 @@ theorem Path.eq_of_nil (s t : σ) : M.Path s t [] → s = t := by
   rfl
 
 @[simp]
-theorem path_singleton {s t : σ} {a : Option α} : M.Path s t [a] ↔ t ∈ M.step s a := by
-  constructor
-  · intro h
+theorem path_singleton {s t : σ} {a : Option α} : M.Path s t [a] ↔ t ∈ M.step s a where
+  mp := by
+    intro h
     cases' h with _ _ _ _ _ _ _ h
     apply Path.eq_of_nil at h
     subst t
     assumption
-  · tauto
+  mpr := by tauto
 
 @[simp]
 theorem path_append {s u : σ} {x y : List (Option α)} :
-    M.Path s u (x ++ y) ↔ ∃ t, M.Path s t x ∧ M.Path t u y := by
-  constructor
-  · induction' x with _ _ ih generalizing s
+    M.Path s u (x ++ y) ↔ ∃ t, M.Path s t x ∧ M.Path t u y where
+  mp := by
+    induction' x with _ _ ih generalizing s
     · rw [List.nil_append]
       tauto
     · intro h
       cases' h with _ _ _ _ _ _ _ h
       obtain ⟨_, _, _⟩ := ih h
       tauto
-  · intro ⟨_, hx, _⟩
+  mpr := by
+    intro ⟨_, hx, _⟩
     induction' x generalizing s <;> cases hx <;> tauto
 
 theorem εClosure_path {s₁ s₂ : σ} :
-    s₂ ∈ M.εClosure {s₁} ↔ ∃ n, M.Path s₁ s₂ (List.replicate n none) := by
-  constructor
-  · intro h
+    s₂ ∈ M.εClosure {s₁} ↔ ∃ n, M.Path s₁ s₂ (List.replicate n none) where
+  mp h := by
     induction' h with t _ _ _ _ _ ih
     · use 0
       subst t
@@ -198,7 +198,8 @@ theorem εClosure_path {s₁ s₂ : σ} :
       use n + 1
       rw [List.replicate_add, path_append]
       tauto
-  · intro ⟨n, h⟩
+  mpr := by
+    intro ⟨n, h⟩
     induction' n generalizing s₂
     · rw [List.replicate_zero] at h
       apply Path.eq_of_nil at h
@@ -246,14 +247,15 @@ theorem evalFrom_path {s₁ s₂ : σ} {x : List α} :
 
 theorem accepts_path {x : List α} :
     x ∈ M.accepts ↔
-      ∃ s₁ s₂ x', s₁ ∈ M.start ∧ s₂ ∈ M.accept ∧ x'.reduceOption = x ∧ M.Path s₁ s₂ x' := by
-  constructor
-  · intro ⟨_, _, h⟩
+      ∃ s₁ s₂ x', s₁ ∈ M.start ∧ s₂ ∈ M.accept ∧ x'.reduceOption = x ∧ M.Path s₁ s₂ x' where
+  mp := by
+    intro ⟨_, _, h⟩
     rw [eval, mem_evalFrom_choice] at h
     obtain ⟨_, _, h⟩ := h
     rw [evalFrom_path] at h
     tauto
-  · intro ⟨_, _, _, hs₁, _, h⟩
+  mpr := by
+    intro ⟨_, _, _, hs₁, _, h⟩
     have := M.evalFrom_path.mpr ⟨_, h⟩
     have := M.mem_evalFrom_choice.mpr ⟨_, hs₁, this⟩
     tauto

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -64,7 +64,7 @@ theorem εClosure_empty : M.εClosure ∅ = ∅ :=
 theorem εClosure_univ : M.εClosure univ = univ :=
   eq_univ_of_univ_subset <| subset_εClosure _ _
 
-theorem mem_εClosure_choice {s : σ} {S : Set σ} :
+theorem mem_εClosure_iff_exists {s : σ} {S : Set σ} :
     s ∈ M.εClosure S ↔ ∃ t ∈ S, s ∈ M.εClosure {t} where
   mp h := by
     induction' h with s _ _ _ _ _ ih
@@ -116,10 +116,10 @@ theorem evalFrom_empty (x : List α) : M.evalFrom ∅ x = ∅ := by
   · rw [evalFrom_nil, εClosure_empty]
   · rw [evalFrom_append_singleton, ih, stepSet_empty]
 
-theorem mem_evalFrom_choice {s : σ} {S : Set σ} {x : List α} :
+theorem mem_evalFrom_iff_exists {s : σ} {S : Set σ} {x : List α} :
     s ∈ M.evalFrom S x ↔ ∃ t ∈ S, s ∈ M.evalFrom {t} x := by
   induction' x using List.reverseRecOn with _ _ ih generalizing s
-  · apply mem_εClosure_choice
+  · apply mem_εClosure_iff_exists
   · simp_rw [evalFrom_append_singleton, mem_stepSet_iff, ih]
     tauto
 
@@ -217,7 +217,7 @@ theorem evalFrom_path {s₁ s₂ : σ} {x : List α} :
     constructor
     · intro ⟨_, ht, h⟩
       obtain ⟨x', _, _⟩ := ih.mp ht
-      rw [mem_εClosure_choice] at h
+      rw [mem_εClosure_iff_exists] at h
       simp_rw [εClosure_path] at h
       obtain ⟨_, _, ⟨n, _⟩⟩ := h
       use x' ++ some a :: List.replicate n none
@@ -230,7 +230,7 @@ theorem evalFrom_path {s₁ s₂ : σ} {x : List α} :
       rw [isPath_append] at h
       obtain ⟨t, _, _ | _⟩ := h
       use t
-      rw [mem_εClosure_choice, ih]
+      rw [mem_εClosure_iff_exists, ih]
       simp_rw [εClosure_path]
       tauto
 
@@ -239,13 +239,13 @@ theorem accepts_path {x : List α} :
       ∃ s₁ s₂ x', s₁ ∈ M.start ∧ s₂ ∈ M.accept ∧ x'.reduceOption = x ∧ M.IsPath s₁ s₂ x' where
   mp := by
     intro ⟨_, _, h⟩
-    rw [eval, mem_evalFrom_choice] at h
+    rw [eval, mem_evalFrom_iff_exists] at h
     obtain ⟨_, _, h⟩ := h
     rw [evalFrom_path] at h
     tauto
   mpr := by
     intro ⟨_, _, _, hs₁, _, h⟩
-    have := M.mem_evalFrom_choice.mpr ⟨_, hs₁, M.evalFrom_path.mpr ⟨_, h⟩⟩
+    have := M.mem_evalFrom_iff_exists.mpr ⟨_, hs₁, M.evalFrom_path.mpr ⟨_, h⟩⟩
     tauto
 
 /-! ### Conversions between `εNFA` and `NFA` -/

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -211,7 +211,7 @@ theorem mem_evalFrom_iff_exists_path {s₁ s₂ : σ} {x : List α} :
       rw [List.reduceOption_replicate_none]
       trivial
     · simp_rw [List.reduceOption_eq_nil_iff]
-      intro ⟨_, ⟨⟨n, rfl⟩, h⟩⟩
+      intro ⟨_, ⟨n, rfl⟩, h⟩
       exact ⟨n, h⟩
   · rw [evalFrom_append_singleton, mem_stepSet_iff]
     constructor
@@ -219,7 +219,7 @@ theorem mem_evalFrom_iff_exists_path {s₁ s₂ : σ} {x : List α} :
       obtain ⟨x', _, _⟩ := ih.mp ht
       rw [mem_εClosure_iff_exists] at h
       simp_rw [mem_εClosure_iff_exists_path] at h
-      obtain ⟨u, _, ⟨n, _⟩⟩ := h
+      obtain ⟨u, _, n, _⟩ := h
       use x' ++ some a :: List.replicate n none
       rw [List.reduceOption_append, List.reduceOption_cons_of_some,
         List.reduceOption_replicate_none, isPath_append]

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -211,7 +211,7 @@ theorem mem_evalFrom_iff_exists_path {s₁ s₂ : σ} {x : List α} :
       rw [List.reduceOption_replicate_none]
       trivial
     · simp_rw [List.reduceOption_eq_nil_iff]
-      rintro ⟨_, ⟨⟨_, ⟨⟩⟩, _⟩⟩
+      rintro ⟨_, ⟨⟨_, rfl⟩, _⟩⟩
       tauto
   · rw [evalFrom_append_singleton, mem_stepSet_iff]
     constructor
@@ -226,7 +226,7 @@ theorem mem_evalFrom_iff_exists_path {s₁ s₂ : σ} {x : List α} :
       tauto
     · simp_rw [← List.concat_eq_append, List.reduceOption_eq_concat_iff,
         List.reduceOption_eq_nil_iff]
-      rintro ⟨_, ⟨_, _, ⟨⟩, _, ⟨_, ⟨⟩⟩⟩, h⟩
+      rintro ⟨_, ⟨_, _, rfl, _, _, rfl⟩, h⟩
       rw [isPath_append] at h
       obtain ⟨t, _, _ | _⟩ := h
       use t

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -145,7 +145,7 @@ def accepts : Language α :=
   { x | ∃ S ∈ M.accept, S ∈ M.eval x }
 
 /-- `M.IsPath` represents a traversal in `M` from a start state to an end state by following a list
-  of transitions in order. -/
+of transitions in order. -/
 inductive IsPath : σ → σ → List (Option α) → Prop
   | nil : ∀ s, IsPath s s []
   | cons (t s u : σ) (a : Option α) (x : List (Option α)) :

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -180,7 +180,7 @@ theorem isPath_append {x y : List (Option α)} :
     intro ⟨_, hx, _⟩
     induction x generalizing s <;> cases hx <;> tauto
 
-theorem εClosure_path {s₁ s₂ : σ} :
+theorem mem_εClosure_iff_exists_path {s₁ s₂ : σ} :
     s₂ ∈ M.εClosure {s₁} ↔ ∃ n, M.IsPath s₁ s₂ (List.replicate n none) where
   mp h := by
     induction' h with t _ _ _ _ _ ih
@@ -201,10 +201,10 @@ theorem εClosure_path {s₁ s₂ : σ} :
       obtain ⟨_, _, _⟩ := h
       solve_by_elim [εClosure.step]
 
-theorem evalFrom_path {s₁ s₂ : σ} {x : List α} :
+theorem mem_evalFrom_iff_exists_path {s₁ s₂ : σ} {x : List α} :
     s₂ ∈ M.evalFrom {s₁} x ↔ ∃ x', x'.reduceOption = x ∧ M.IsPath s₁ s₂ x' := by
   induction' x using List.reverseRecOn with _ a ih generalizing s₂
-  · rw [evalFrom_nil, εClosure_path]
+  · rw [evalFrom_nil, mem_εClosure_iff_exists_path]
     constructor
     · intro ⟨n, _⟩
       use List.replicate n none
@@ -218,7 +218,7 @@ theorem evalFrom_path {s₁ s₂ : σ} {x : List α} :
     · intro ⟨_, ht, h⟩
       obtain ⟨x', _, _⟩ := ih.mp ht
       rw [mem_εClosure_iff_exists] at h
-      simp_rw [εClosure_path] at h
+      simp_rw [mem_εClosure_iff_exists_path] at h
       obtain ⟨_, _, ⟨n, _⟩⟩ := h
       use x' ++ some a :: List.replicate n none
       rw [List.reduceOption_append, List.reduceOption_cons_of_some,
@@ -231,7 +231,7 @@ theorem evalFrom_path {s₁ s₂ : σ} {x : List α} :
       obtain ⟨t, _, _ | _⟩ := h
       use t
       rw [mem_εClosure_iff_exists, ih]
-      simp_rw [εClosure_path]
+      simp_rw [mem_εClosure_iff_exists_path]
       tauto
 
 theorem mem_accepts_iff_exists_path {x : List α} :
@@ -241,11 +241,11 @@ theorem mem_accepts_iff_exists_path {x : List α} :
     intro ⟨_, _, h⟩
     rw [eval, mem_evalFrom_iff_exists] at h
     obtain ⟨_, _, h⟩ := h
-    rw [evalFrom_path] at h
+    rw [mem_evalFrom_iff_exists_path] at h
     tauto
   mpr := by
     intro ⟨_, _, _, hs₁, _, h⟩
-    have := M.mem_evalFrom_iff_exists.mpr ⟨_, hs₁, M.evalFrom_path.mpr ⟨_, h⟩⟩
+    have := M.mem_evalFrom_iff_exists.mpr ⟨_, hs₁, M.mem_evalFrom_iff_exists_path.mpr ⟨_, h⟩⟩
     tauto
 
 /-! ### Conversions between `εNFA` and `NFA` -/


### PR DESCRIPTION
`IsPath` enables path-based reasoning in proofs involving `εNFA`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #20644 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
