### PR TITLE
[Merged by Bors] - refactor: split `Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances` in a principled way

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/ApproximateUnit.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ApproximateUnit.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Order
-import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Isometric
 import Mathlib.Analysis.CStarAlgebra.SpecialFunctions.PosPart
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow
 import Mathlib.Topology.ApproximateUnit

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Basic.lean
@@ -3,8 +3,9 @@ Copyright (c) 2022 Jireh Loreaux. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Isometric
 import Mathlib.Analysis.CStarAlgebra.GelfandDuality
-import Mathlib.Topology.Algebra.StarSubalgebra
+import Mathlib.Analysis.CStarAlgebra.Unitization
 
 /-! # Continuous functional calculus
 
@@ -40,6 +41,10 @@ relevant instances on C⋆-algebra can be found in the `Instances` file.
   by evaluating a character `φ` at `a`, and noting that `φ a ∈ spectrum ℂ a` since `φ` is an
   algebra homomorphism. Moreover, this map is continuous and bijective and since the spaces involved
   are compact Hausdorff, it is a homeomorphism.
+* `IsStarNormal.instContinuousFunctionalCalculus`: the continuous functional calculus for normal
+  elements in a unital C⋆-algebra over `ℂ`.
+* `CStarAlgebra.instNonnegSpectrumClass`: In a unital C⋆-algebra over `ℂ` which is also a
+  `StarOrderedRing`, the spectrum of a nonnegative element is nonnegative.
 
  -/
 
@@ -137,3 +142,366 @@ theorem continuousFunctionalCalculus_map_id :
     continuousFunctionalCalculus a ((ContinuousMap.id ℂ).restrict (spectrum ℂ a)) =
       ⟨a, self_mem ℂ a⟩ :=
   (gelfandStarTransform (elemental ℂ a)).symm_apply_apply _
+
+/-!
+### Continuous functional calculus for normal elements
+-/
+
+local notation "σₙ" => quasispectrum
+
+section Normal
+
+instance IsStarNormal.instContinuousFunctionalCalculus {A : Type*} [CStarAlgebra A] :
+    ContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop) where
+  predicate_zero := .zero
+  spectrum_nonempty a _ := spectrum.nonempty a
+  exists_cfc_of_predicate a ha := by
+    refine ⟨(StarAlgebra.elemental ℂ a).subtype.comp <| continuousFunctionalCalculus a,
+      ?hom_isClosedEmbedding, ?hom_id, ?hom_map_spectrum, ?predicate_hom⟩
+    case hom_isClosedEmbedding =>
+      exact Isometry.isClosedEmbedding <|
+        isometry_subtype_coe.comp <| StarAlgEquiv.isometry (continuousFunctionalCalculus a)
+    case hom_id => exact congr_arg Subtype.val <| continuousFunctionalCalculus_map_id a
+    case hom_map_spectrum =>
+      intro f
+      simp only [StarAlgHom.comp_apply, StarAlgHom.coe_coe, StarSubalgebra.coe_subtype]
+      rw [← StarSubalgebra.spectrum_eq (hS := StarAlgebra.elemental.isClosed ℂ a),
+        AlgEquiv.spectrum_eq (continuousFunctionalCalculus a), ContinuousMap.spectrum_eq_range]
+    case predicate_hom => exact fun f ↦ ⟨by rw [← map_star]; exact Commute.all (star f) f |>.map _⟩
+
+lemma cfcHom_eq_of_isStarNormal {A : Type*} [CStarAlgebra A] (a : A) [ha : IsStarNormal a] :
+    cfcHom ha = (StarAlgebra.elemental ℂ a).subtype.comp (continuousFunctionalCalculus a) := by
+  refine cfcHom_eq_of_continuous_of_map_id ha _ ?_ ?_
+  · exact continuous_subtype_val.comp <|
+      (StarAlgEquiv.isometry (continuousFunctionalCalculus a)).continuous
+  · simp [continuousFunctionalCalculus_map_id a]
+
+instance IsStarNormal.instNonUnitalContinuousFunctionalCalculus {A : Type*}
+    [NonUnitalCStarAlgebra A] : NonUnitalContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop) :=
+  RCLike.nonUnitalContinuousFunctionalCalculus Unitization.isStarNormal_inr
+
+open Unitization CStarAlgebra in
+lemma inr_comp_cfcₙHom_eq_cfcₙAux {A : Type*} [NonUnitalCStarAlgebra A] (a : A)
+    [ha : IsStarNormal a] : (inrNonUnitalStarAlgHom ℂ A).comp (cfcₙHom ha) =
+      cfcₙAux (isStarNormal_inr (R := ℂ) (A := A)) a ha := by
+  have h (a : A) := isStarNormal_inr (R := ℂ) (A := A) (a := a)
+  refine @UniqueNonUnitalContinuousFunctionalCalculus.eq_of_continuous_of_map_id
+    _ _ _ _ _ _ _ _ _ _ _ inferInstance inferInstance _ (σₙ ℂ a) _ _ rfl _ _ ?_ ?_ ?_
+  · show Continuous (fun f ↦ (cfcₙHom ha f : A⁺¹)); fun_prop
+  · exact isClosedEmbedding_cfcₙAux @(h) a ha |>.continuous
+  · trans (a : A⁺¹)
+    · congrm(inr $(cfcₙHom_id ha))
+    · exact cfcₙAux_id @(h) a ha |>.symm
+
+end Normal
+
+/-!
+### The spectrum of a nonnegative element is nonnegative
+-/
+
+section SpectrumRestricts
+
+open NNReal ENNReal
+
+variable {A : Type*} [CStarAlgebra A]
+
+lemma SpectrumRestricts.nnreal_iff_nnnorm {a : A} {t : ℝ≥0} (ha : IsSelfAdjoint a) (ht : ‖a‖₊ ≤ t) :
+    SpectrumRestricts a ContinuousMap.realToNNReal ↔ ‖algebraMap ℝ A t - a‖₊ ≤ t := by
+  have : IsSelfAdjoint (algebraMap ℝ A t - a) := IsSelfAdjoint.algebraMap A (.all (t : ℝ)) |>.sub ha
+  rw [← ENNReal.coe_le_coe, ← IsSelfAdjoint.spectralRadius_eq_nnnorm,
+    ← SpectrumRestricts.spectralRadius_eq (f := Complex.reCLM)] at ht ⊢
+  · exact SpectrumRestricts.nnreal_iff_spectralRadius_le ht
+  all_goals
+    try apply IsSelfAdjoint.spectrumRestricts
+    assumption
+
+lemma SpectrumRestricts.nnreal_add {a b : A} (ha₁ : IsSelfAdjoint a)
+    (hb₁ : IsSelfAdjoint b) (ha₂ : SpectrumRestricts a ContinuousMap.realToNNReal)
+    (hb₂ : SpectrumRestricts b ContinuousMap.realToNNReal) :
+    SpectrumRestricts (a + b) ContinuousMap.realToNNReal := by
+  rw [SpectrumRestricts.nnreal_iff_nnnorm (ha₁.add hb₁) (nnnorm_add_le a b), NNReal.coe_add,
+    map_add, add_sub_add_comm]
+  refine nnnorm_add_le _ _ |>.trans ?_
+  gcongr
+  all_goals rw [← SpectrumRestricts.nnreal_iff_nnnorm] <;> first | rfl | assumption
+
+lemma IsSelfAdjoint.sq_spectrumRestricts {a : A} (ha : IsSelfAdjoint a) :
+    SpectrumRestricts (a ^ 2) ContinuousMap.realToNNReal := by
+  rw [SpectrumRestricts.nnreal_iff, ← cfc_id (R := ℝ) a, ← cfc_pow .., cfc_map_spectrum ..]
+  rintro - ⟨x, -, rfl⟩
+  exact sq_nonneg x
+
+open ComplexStarModule
+
+lemma SpectrumRestricts.eq_zero_of_neg {a : A} (ha : IsSelfAdjoint a)
+    (ha₁ : SpectrumRestricts a ContinuousMap.realToNNReal)
+    (ha₂ : SpectrumRestricts (-a) ContinuousMap.realToNNReal) :
+    a = 0 := by
+  nontriviality A
+  rw [SpectrumRestricts.nnreal_iff] at ha₁ ha₂
+  apply CFC.eq_zero_of_spectrum_subset_zero (R := ℝ) a
+  rw [Set.subset_singleton_iff]
+  simp only [← spectrum.neg_eq, Set.mem_neg] at ha₂
+  peel ha₁ with x hx _
+  linarith [ha₂ (-x) ((neg_neg x).symm ▸ hx)]
+
+lemma SpectrumRestricts.smul_of_nonneg {A : Type*} [Ring A] [Algebra ℝ A] {a : A}
+    (ha : SpectrumRestricts a ContinuousMap.realToNNReal) {r : ℝ} (hr : 0 ≤ r) :
+    SpectrumRestricts (r • a) ContinuousMap.realToNNReal := by
+  rw [SpectrumRestricts.nnreal_iff] at ha ⊢
+  nontriviality A
+  intro x hx
+  by_cases hr' : r = 0
+  · simp [hr'] at hx ⊢
+    exact hx.symm.le
+  · lift r to ℝˣ using IsUnit.mk0 r hr'
+    rw [← Units.smul_def, spectrum.unit_smul_eq_smul, Set.mem_smul_set_iff_inv_smul_mem] at hx
+    refine le_of_smul_le_smul_left ?_ (inv_pos.mpr <| lt_of_le_of_ne hr <| ne_comm.mpr hr')
+    simpa [Units.smul_def] using ha _ hx
+
+lemma spectrum_star_mul_self_nonneg {b : A} : ∀ x ∈ spectrum ℝ (star b * b), 0 ≤ x := by
+  set a := star b * b
+  have a_def : a = star b * b := rfl
+  let a_neg : A := cfc (fun x ↦ (- ContinuousMap.id ℝ ⊔ 0) x) a
+  set c := b * a_neg
+  have h_eq_a_neg : - (star c * c) = a_neg ^ 3 := by
+    simp only [c, a_neg, star_mul]
+    rw [← mul_assoc, mul_assoc _ _ b, ← cfc_star, ← cfc_id' ℝ (star b * b), a_def, ← neg_mul]
+    rw [← cfc_mul _ _ (star b * b) (by simp; fun_prop), neg_mul]
+    simp only [ContinuousMap.coe_neg, ContinuousMap.coe_id, Pi.sup_apply, Pi.neg_apply,
+      star_trivial]
+    rw [← cfc_mul .., ← cfc_neg .., ← cfc_pow ..]
+    congr
+    ext x
+    by_cases hx : x ≤ 0
+    · rw [← neg_nonneg] at hx
+      simp [sup_eq_left.mpr hx, pow_succ]
+    · rw [not_le, ← neg_neg_iff_pos] at hx
+      simp [sup_eq_right.mpr hx.le]
+  have h_c_spec₀ : SpectrumRestricts (- (star c * c)) (ContinuousMap.realToNNReal ·) := by
+    simp only [SpectrumRestricts.nnreal_iff, h_eq_a_neg]
+    rw [← cfc_pow _ _ (ha := .star_mul_self b)]
+    simp only [a, cfc_map_spectrum (R := ℝ) (fun x => (-ContinuousMap.id ℝ ⊔ 0) x ^ 3) (star b * b)]
+    rintro - ⟨x, -, rfl⟩
+    simp
+  have c_eq := star_mul_self_add_self_mul_star c
+  rw [← eq_sub_iff_add_eq', sub_eq_add_neg, ← sq, ← sq] at c_eq
+  have h_c_spec₁ : SpectrumRestricts (c * star c) ContinuousMap.realToNNReal := by
+    rw [c_eq]
+    refine SpectrumRestricts.nnreal_add ?_ ?_ ?_ h_c_spec₀
+    · exact IsSelfAdjoint.smul (by rfl) <| ((ℜ c).prop.pow 2).add ((ℑ c).prop.pow 2)
+    · exact (IsSelfAdjoint.star_mul_self c).neg
+    · rw [← Nat.cast_smul_eq_nsmul ℝ]
+      refine (ℜ c).2.sq_spectrumRestricts.nnreal_add ((ℜ c).2.pow 2) ((ℑ c).2.pow 2)
+        (ℑ c).2.sq_spectrumRestricts |>.smul_of_nonneg <| by norm_num
+  have h_c_spec₂ : SpectrumRestricts (star c * c) ContinuousMap.realToNNReal := by
+    rw [SpectrumRestricts.nnreal_iff] at h_c_spec₁ ⊢
+    intro x hx
+    replace hx := Set.subset_diff_union _ {(0 : ℝ)} hx
+    rw [spectrum.nonzero_mul_eq_swap_mul, Set.diff_union_self, Set.union_singleton,
+      Set.mem_insert_iff] at hx
+    obtain (rfl | hx) := hx
+    exacts [le_rfl, h_c_spec₁ x hx]
+  rw [h_c_spec₂.eq_zero_of_neg (.star_mul_self c) h_c_spec₀, neg_zero] at h_eq_a_neg
+  simp only [a_neg] at h_eq_a_neg
+  rw [← cfc_pow _ _ (ha := .star_mul_self b), ← cfc_zero a (R := ℝ)] at h_eq_a_neg
+  intro x hx
+  by_contra! hx'
+  rw [← neg_pos] at hx'
+  apply (pow_pos hx' 3).ne
+  have h_eqOn := eqOn_of_cfc_eq_cfc (ha := IsSelfAdjoint.star_mul_self b) h_eq_a_neg
+  simpa [sup_eq_left.mpr hx'.le] using h_eqOn hx
+
+lemma IsSelfAdjoint.coe_mem_spectrum_complex {A : Type*} [TopologicalSpace A] [Ring A]
+    [StarRing A] [Algebra ℂ A] [ContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop)]
+    {a : A} {x : ℝ} (ha : IsSelfAdjoint a := by cfc_tac) :
+    (x : ℂ) ∈ spectrum ℂ a ↔ x ∈ spectrum ℝ a := by
+  simp [← ha.spectrumRestricts.algebraMap_image]
+
+end SpectrumRestricts
+
+section NonnegSpectrumClass
+
+variable {A : Type*} [CStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
+
+instance CStarAlgebra.instNonnegSpectrumClass : NonnegSpectrumClass ℝ A :=
+  .of_spectrum_nonneg fun a ha ↦ by
+    rw [StarOrderedRing.nonneg_iff] at ha
+    induction ha using AddSubmonoid.closure_induction with
+    | mem x hx =>
+      obtain ⟨b, rfl⟩ := hx
+      exact spectrum_star_mul_self_nonneg
+    | one =>
+      nontriviality A
+      simp
+    | mul x y x_mem y_mem hx hy =>
+      rw [← SpectrumRestricts.nnreal_iff] at hx hy ⊢
+      rw [← StarOrderedRing.nonneg_iff] at x_mem y_mem
+      exact hx.nnreal_add (.of_nonneg x_mem) (.of_nonneg y_mem) hy
+
+open ComplexOrder in
+instance CStarAlgebra.instNonnegSpectrumClassComplexUnital : NonnegSpectrumClass ℂ A where
+  quasispectrum_nonneg_of_nonneg a ha x := by
+    rw [mem_quasispectrum_iff]
+    refine (Or.elim · ge_of_eq fun hx ↦ ?_)
+    obtain ⟨y, hy, rfl⟩ := (IsSelfAdjoint.of_nonneg ha).spectrumRestricts.algebraMap_image ▸ hx
+    simpa using spectrum_nonneg_of_nonneg ha hy
+
+end NonnegSpectrumClass
+
+section SpectralOrder
+
+variable (A : Type*) [CStarAlgebra A]
+
+/-- The partial order on a unital C⋆-algebra defined by `x ≤ y` if and only if `y - x` is
+selfadjoint and has nonnegative spectrum.
+
+This is not declared as an instance because one may already have a partial order with better
+definitional properties. However, it can be useful to invoke this as an instance in proofs. -/
+@[reducible]
+def CStarAlgebra.spectralOrder : PartialOrder A where
+  le x y := IsSelfAdjoint (y - x) ∧ SpectrumRestricts (y - x) ContinuousMap.realToNNReal
+  le_refl := by
+    simp only [sub_self, IsSelfAdjoint.zero, true_and, forall_const]
+    rw [SpectrumRestricts.nnreal_iff]
+    nontriviality A
+    simp
+  le_antisymm x y hxy hyx := by
+    rw [← sub_eq_zero]
+    exact hyx.2.eq_zero_of_neg hyx.1 (neg_sub x y ▸ hxy.2)
+  le_trans x y z hxy hyz :=
+    ⟨by simpa using hyz.1.add hxy.1, by simpa using hyz.2.nnreal_add hyz.1 hxy.1 hxy.2⟩
+
+/-- The `CStarAlgebra.spectralOrder` on a unital C⋆-algebra is a `StarOrderedRing`. -/
+lemma CStarAlgebra.spectralOrderedRing : @StarOrderedRing A _ (CStarAlgebra.spectralOrder A) _ :=
+  let _ := CStarAlgebra.spectralOrder A
+  { le_iff := by
+      intro x y
+      constructor
+      · intro h
+        obtain ⟨s, hs₁, _, hs₂⟩ := CFC.exists_sqrt_of_isSelfAdjoint_of_spectrumRestricts h.1 h.2
+        refine ⟨s ^ 2, ?_, by rwa [eq_sub_iff_add_eq', eq_comm] at hs₂⟩
+        exact AddSubmonoid.subset_closure ⟨s, by simp [hs₁.star_eq, sq]⟩
+      · rintro ⟨p, hp, rfl⟩
+        suffices IsSelfAdjoint p ∧ SpectrumRestricts p ContinuousMap.realToNNReal from
+          ⟨by simpa using this.1, by simpa using this.2⟩
+        induction hp using AddSubmonoid.closure_induction with
+        | mem x hx =>
+          obtain ⟨s, rfl⟩ := hx
+          refine ⟨IsSelfAdjoint.star_mul_self s, ?_⟩
+          rw [SpectrumRestricts.nnreal_iff]
+          exact spectrum_star_mul_self_nonneg
+        | one =>
+          rw [SpectrumRestricts.nnreal_iff]
+          nontriviality A
+          simp
+        | mul x y _ _ hx hy =>
+          exact ⟨hx.1.add hy.1, hx.2.nnreal_add hx.1 hy.1 hy.2⟩ }
+
+end SpectralOrder
+
+section NonnegSpectrumClass
+
+variable {A : Type*} [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
+
+open scoped CStarAlgebra in
+instance CStarAlgebra.instNonnegSpectrumClass' : NonnegSpectrumClass ℝ A where
+  quasispectrum_nonneg_of_nonneg a ha := by
+    rw [Unitization.quasispectrum_eq_spectrum_inr' _ ℂ]
+    -- should this actually be an instance on the `Unitization`? (probably scoped)
+    let _ := CStarAlgebra.spectralOrder A⁺¹
+    have := CStarAlgebra.spectralOrderedRing A⁺¹
+    apply spectrum_nonneg_of_nonneg
+    rw [StarOrderedRing.nonneg_iff] at ha ⊢
+    have := AddSubmonoid.mem_map_of_mem (Unitization.inrNonUnitalStarAlgHom ℂ A) ha
+    rw [AddMonoidHom.map_mclosure, ← Set.range_comp] at this
+    apply AddSubmonoid.closure_mono ?_ this
+    rintro _ ⟨s, rfl⟩
+    exact ⟨s, by simp⟩
+
+end NonnegSpectrumClass
+
+section cfc_inr
+
+open CStarAlgebra
+
+variable {A : Type*} [NonUnitalCStarAlgebra A]
+
+open scoped NonUnitalContinuousFunctionalCalculus in
+/-- This lemma requires a lot from type class synthesis, and so one should instead favor the bespoke
+versions for `ℝ≥0`, `ℝ`, and `ℂ`. -/
+lemma Unitization.cfcₙ_eq_cfc_inr {R : Type*} [Semifield R] [StarRing R] [MetricSpace R]
+    [TopologicalSemiring R] [ContinuousStar R] [Module R A] [IsScalarTower R A A]
+    [SMulCommClass R A A] [CompleteSpace R] [Algebra R ℂ] [IsScalarTower R ℂ A]
+    {p : A → Prop} {p' : A⁺¹ → Prop} [NonUnitalContinuousFunctionalCalculus R p]
+    [ContinuousFunctionalCalculus R p']
+    [UniqueNonUnitalContinuousFunctionalCalculus R (Unitization ℂ A)]
+    (hp : ∀ {a : A}, p' (a : A⁺¹) ↔ p a) (a : A) (f : R → R) (hf₀ : f 0 = 0 := by cfc_zero_tac) :
+    cfcₙ f a = cfc f (a : A⁺¹) := by
+  by_cases h : ContinuousOn f (σₙ R a) ∧ p a
+  · obtain ⟨hf, ha⟩ := h
+    rw [← cfcₙ_eq_cfc (quasispectrum_inr_eq R ℂ a ▸ hf)]
+    exact (inrNonUnitalStarAlgHom ℂ A).map_cfcₙ f a
+  · obtain (hf | ha) := not_and_or.mp h
+    · rw [cfcₙ_apply_of_not_continuousOn a hf, inr_zero,
+        cfc_apply_of_not_continuousOn _ (quasispectrum_eq_spectrum_inr' R ℂ a ▸ hf)]
+    · rw [cfcₙ_apply_of_not_predicate a ha, inr_zero,
+        cfc_apply_of_not_predicate _ (not_iff_not.mpr hp |>.mpr ha)]
+
+lemma Unitization.complex_cfcₙ_eq_cfc_inr (a : A) (f : ℂ → ℂ) (hf₀ : f 0 = 0 := by cfc_zero_tac) :
+    cfcₙ f a = cfc f (a : A⁺¹) :=
+  Unitization.cfcₙ_eq_cfc_inr isStarNormal_inr ..
+
+/-- note: the version for `ℝ≥0`, `Unization.nnreal_cfcₙ_eq_cfc_inr`, can be found in
+`Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Order` -/
+lemma Unitization.real_cfcₙ_eq_cfc_inr (a : A) (f : ℝ → ℝ) (hf₀ : f 0 = 0 := by cfc_zero_tac) :
+    cfcₙ f a = cfc f (a : A⁺¹) :=
+  Unitization.cfcₙ_eq_cfc_inr isSelfAdjoint_inr ..
+
+end cfc_inr
+
+/-! ### Instances of isometric continuous functional calculi -/
+
+section Instances
+
+section Unital
+
+variable {A : Type*} [CStarAlgebra A]
+
+instance IsStarNormal.instIsometricContinuousFunctionalCalculus :
+    IsometricContinuousFunctionalCalculus ℂ A IsStarNormal where
+  isometric a ha := by
+    rw [cfcHom_eq_of_isStarNormal]
+    exact isometry_subtype_coe.comp <| StarAlgEquiv.isometry (continuousFunctionalCalculus a)
+
+instance IsSelfAdjoint.instIsometricContinuousFunctionalCalculus :
+    IsometricContinuousFunctionalCalculus ℝ A IsSelfAdjoint :=
+  SpectrumRestricts.isometric_cfc Complex.reCLM Complex.isometry_ofReal (.zero _)
+    fun _ ↦ isSelfAdjoint_iff_isStarNormal_and_spectrumRestricts
+
+end Unital
+
+section NonUnital
+
+variable {A : Type*} [NonUnitalCStarAlgebra A]
+
+open Unitization
+
+open ContinuousMapZero in
+instance IsStarNormal.instNonUnitalIsometricContinuousFunctionalCalculus :
+    NonUnitalIsometricContinuousFunctionalCalculus ℂ A IsStarNormal where
+  isometric a ha := by
+    refine AddMonoidHomClass.isometry_of_norm _ fun f ↦ ?_
+    rw [← norm_inr (𝕜 := ℂ), ← inrNonUnitalStarAlgHom_apply, ← NonUnitalStarAlgHom.comp_apply,
+      inr_comp_cfcₙHom_eq_cfcₙAux a, cfcₙAux]
+    simp only [NonUnitalStarAlgHom.comp_assoc, NonUnitalStarAlgHom.comp_apply,
+      toContinuousMapHom_apply, NonUnitalStarAlgHom.coe_coe]
+    rw [norm_cfcHom (a : Unitization ℂ A), StarAlgEquiv.norm_map]
+    rfl
+
+instance IsSelfAdjoint.instNonUnitalIsometricContinuousFunctionalCalculus :
+    NonUnitalIsometricContinuousFunctionalCalculus ℝ A IsSelfAdjoint :=
+  QuasispectrumRestricts.isometric_cfc Complex.reCLM Complex.isometry_ofReal (.zero _)
+    fun _ ↦ isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts
+
+end NonUnital

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Basic.lean
@@ -462,8 +462,6 @@ end cfc_inr
 
 /-! ### Instances of isometric continuous functional calculi -/
 
-section Instances
-
 section Unital
 
 variable {A : Type*} [CStarAlgebra A]

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
@@ -4,17 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Restrict
-import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
 import Mathlib.Analysis.CStarAlgebra.Spectrum
-import Mathlib.Analysis.CStarAlgebra.Unitization
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Unique
 
 /-! # Instances of the continuous functional calculus
 
 ## Main theorems
 
-* `IsStarNormal.instContinuousFunctionalCalculus`: the continuous functional calculus for normal
-  elements in a unital C⋆-algebra over `ℂ`.
 * `IsSelfAdjoint.instContinuousFunctionalCalculus`: the continuous functional calculus for
   selfadjoint elements in a `ℂ`-algebra with a continuous functional calculus for normal elements
   and where every element has compact spectrum. In particular, this includes unital C⋆-algebras
@@ -23,8 +19,6 @@ import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Unique
   elements in an `ℝ`-algebra with a continuous functional calculus for selfadjoint elements,
   where every element has compact spectrum, and where nonnegative elements have nonnegative
   spectrum. In particular, this includes unital C⋆-algebras over `ℝ`.
-* `CStarAlgebra.instNonnegSpectrumClass`: In a unital C⋆-algebra over `ℂ` which is also a
-  `StarOrderedRing`, the spectrum of a nonnegative element is nonnegative.
 
 ## Tags
 
@@ -146,56 +140,6 @@ theorem RCLike.nonUnitalContinuousFunctionalCalculus :
     case isStarNormal => exact hp₁.mp <| coe_ψ _ ▸ cfcHom_predicate (R := 𝕜) (hp₁.mpr ha) _
 
 end RCLike
-
-/-!
-### Continuous functional calculus for normal elements
--/
-
-section Normal
-
-instance IsStarNormal.instContinuousFunctionalCalculus {A : Type*} [CStarAlgebra A] :
-    ContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop) where
-  predicate_zero := .zero
-  spectrum_nonempty a _ := spectrum.nonempty a
-  exists_cfc_of_predicate a ha := by
-    refine ⟨(StarAlgebra.elemental ℂ a).subtype.comp <| continuousFunctionalCalculus a,
-      ?hom_isClosedEmbedding, ?hom_id, ?hom_map_spectrum, ?predicate_hom⟩
-    case hom_isClosedEmbedding =>
-      exact Isometry.isClosedEmbedding <|
-        isometry_subtype_coe.comp <| StarAlgEquiv.isometry (continuousFunctionalCalculus a)
-    case hom_id => exact congr_arg Subtype.val <| continuousFunctionalCalculus_map_id a
-    case hom_map_spectrum =>
-      intro f
-      simp only [StarAlgHom.comp_apply, StarAlgHom.coe_coe, StarSubalgebra.coe_subtype]
-      rw [← StarSubalgebra.spectrum_eq (hS := StarAlgebra.elemental.isClosed ℂ a),
-        AlgEquiv.spectrum_eq (continuousFunctionalCalculus a), ContinuousMap.spectrum_eq_range]
-    case predicate_hom => exact fun f ↦ ⟨by rw [← map_star]; exact Commute.all (star f) f |>.map _⟩
-
-lemma cfcHom_eq_of_isStarNormal {A : Type*} [CStarAlgebra A] (a : A) [ha : IsStarNormal a] :
-    cfcHom ha = (StarAlgebra.elemental ℂ a).subtype.comp (continuousFunctionalCalculus a) := by
-  refine cfcHom_eq_of_continuous_of_map_id ha _ ?_ ?_
-  · exact continuous_subtype_val.comp <|
-      (StarAlgEquiv.isometry (continuousFunctionalCalculus a)).continuous
-  · simp [continuousFunctionalCalculus_map_id a]
-
-instance IsStarNormal.instNonUnitalContinuousFunctionalCalculus {A : Type*}
-    [NonUnitalCStarAlgebra A] : NonUnitalContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop) :=
-  RCLike.nonUnitalContinuousFunctionalCalculus Unitization.isStarNormal_inr
-
-open Unitization CStarAlgebra in
-lemma inr_comp_cfcₙHom_eq_cfcₙAux {A : Type*} [NonUnitalCStarAlgebra A] (a : A)
-    [ha : IsStarNormal a] : (inrNonUnitalStarAlgHom ℂ A).comp (cfcₙHom ha) =
-      cfcₙAux (isStarNormal_inr (R := ℂ) (A := A)) a ha := by
-  have h (a : A) := isStarNormal_inr (R := ℂ) (A := A) (a := a)
-  refine @UniqueNonUnitalContinuousFunctionalCalculus.eq_of_continuous_of_map_id
-    _ _ _ _ _ _ _ _ _ _ _ inferInstance inferInstance _ (σₙ ℂ a) _ _ rfl _ _ ?_ ?_ ?_
-  · show Continuous (fun f ↦ (cfcₙHom ha f : A⁺¹)); fun_prop
-  · exact isClosedEmbedding_cfcₙAux @(h) a ha |>.continuous
-  · trans (a : A⁺¹)
-    · congrm(inr $(cfcₙHom_id ha))
-    · exact cfcₙAux_id @(h) a ha |>.symm
-
-end Normal
 
 /-!
 ### Continuous functional calculus for selfadjoint elements
@@ -380,232 +324,6 @@ instance Nonneg.instContinuousFunctionalCalculus :
 end Nonneg
 
 /-!
-### The spectrum of a nonnegative element is nonnegative
--/
-
-section SpectrumRestricts
-
-open NNReal ENNReal
-
-variable {A : Type*} [CStarAlgebra A]
-
-lemma SpectrumRestricts.nnreal_iff_nnnorm {a : A} {t : ℝ≥0} (ha : IsSelfAdjoint a) (ht : ‖a‖₊ ≤ t) :
-    SpectrumRestricts a ContinuousMap.realToNNReal ↔ ‖algebraMap ℝ A t - a‖₊ ≤ t := by
-  have : IsSelfAdjoint (algebraMap ℝ A t - a) := IsSelfAdjoint.algebraMap A (.all (t : ℝ)) |>.sub ha
-  rw [← ENNReal.coe_le_coe, ← IsSelfAdjoint.spectralRadius_eq_nnnorm,
-    ← SpectrumRestricts.spectralRadius_eq (f := Complex.reCLM)] at ht ⊢
-  · exact SpectrumRestricts.nnreal_iff_spectralRadius_le ht
-  all_goals
-    try apply IsSelfAdjoint.spectrumRestricts
-    assumption
-
-lemma SpectrumRestricts.nnreal_add {a b : A} (ha₁ : IsSelfAdjoint a)
-    (hb₁ : IsSelfAdjoint b) (ha₂ : SpectrumRestricts a ContinuousMap.realToNNReal)
-    (hb₂ : SpectrumRestricts b ContinuousMap.realToNNReal) :
-    SpectrumRestricts (a + b) ContinuousMap.realToNNReal := by
-  rw [SpectrumRestricts.nnreal_iff_nnnorm (ha₁.add hb₁) (nnnorm_add_le a b), NNReal.coe_add,
-    map_add, add_sub_add_comm]
-  refine nnnorm_add_le _ _ |>.trans ?_
-  gcongr
-  all_goals rw [← SpectrumRestricts.nnreal_iff_nnnorm] <;> first | rfl | assumption
-
-lemma IsSelfAdjoint.sq_spectrumRestricts {a : A} (ha : IsSelfAdjoint a) :
-    SpectrumRestricts (a ^ 2) ContinuousMap.realToNNReal := by
-  rw [SpectrumRestricts.nnreal_iff, ← cfc_id (R := ℝ) a, ← cfc_pow .., cfc_map_spectrum ..]
-  rintro - ⟨x, -, rfl⟩
-  exact sq_nonneg x
-
-open ComplexStarModule
-
-lemma SpectrumRestricts.eq_zero_of_neg {a : A} (ha : IsSelfAdjoint a)
-    (ha₁ : SpectrumRestricts a ContinuousMap.realToNNReal)
-    (ha₂ : SpectrumRestricts (-a) ContinuousMap.realToNNReal) :
-    a = 0 := by
-  nontriviality A
-  rw [SpectrumRestricts.nnreal_iff] at ha₁ ha₂
-  apply CFC.eq_zero_of_spectrum_subset_zero (R := ℝ) a
-  rw [Set.subset_singleton_iff]
-  simp only [← spectrum.neg_eq, Set.mem_neg] at ha₂
-  peel ha₁ with x hx _
-  linarith [ha₂ (-x) ((neg_neg x).symm ▸ hx)]
-
-lemma SpectrumRestricts.smul_of_nonneg {A : Type*} [Ring A] [Algebra ℝ A] {a : A}
-    (ha : SpectrumRestricts a ContinuousMap.realToNNReal) {r : ℝ} (hr : 0 ≤ r) :
-    SpectrumRestricts (r • a) ContinuousMap.realToNNReal := by
-  rw [SpectrumRestricts.nnreal_iff] at ha ⊢
-  nontriviality A
-  intro x hx
-  by_cases hr' : r = 0
-  · simp [hr'] at hx ⊢
-    exact hx.symm.le
-  · lift r to ℝˣ using IsUnit.mk0 r hr'
-    rw [← Units.smul_def, spectrum.unit_smul_eq_smul, Set.mem_smul_set_iff_inv_smul_mem] at hx
-    refine le_of_smul_le_smul_left ?_ (inv_pos.mpr <| lt_of_le_of_ne hr <| ne_comm.mpr hr')
-    simpa [Units.smul_def] using ha _ hx
-
-lemma spectrum_star_mul_self_nonneg {b : A} : ∀ x ∈ spectrum ℝ (star b * b), 0 ≤ x := by
-  set a := star b * b
-  have a_def : a = star b * b := rfl
-  let a_neg : A := cfc (fun x ↦ (- ContinuousMap.id ℝ ⊔ 0) x) a
-  set c := b * a_neg
-  have h_eq_a_neg : - (star c * c) = a_neg ^ 3 := by
-    simp only [c, a_neg, star_mul]
-    rw [← mul_assoc, mul_assoc _ _ b, ← cfc_star, ← cfc_id' ℝ (star b * b), a_def, ← neg_mul]
-    rw [← cfc_mul _ _ (star b * b) (by simp; fun_prop), neg_mul]
-    simp only [ContinuousMap.coe_neg, ContinuousMap.coe_id, Pi.sup_apply, Pi.neg_apply,
-      star_trivial]
-    rw [← cfc_mul .., ← cfc_neg .., ← cfc_pow ..]
-    congr
-    ext x
-    by_cases hx : x ≤ 0
-    · rw [← neg_nonneg] at hx
-      simp [sup_eq_left.mpr hx, pow_succ]
-    · rw [not_le, ← neg_neg_iff_pos] at hx
-      simp [sup_eq_right.mpr hx.le]
-  have h_c_spec₀ : SpectrumRestricts (- (star c * c)) (ContinuousMap.realToNNReal ·) := by
-    simp only [SpectrumRestricts.nnreal_iff, h_eq_a_neg]
-    rw [← cfc_pow _ _ (ha := .star_mul_self b)]
-    simp only [a, cfc_map_spectrum (R := ℝ) (fun x => (-ContinuousMap.id ℝ ⊔ 0) x ^ 3) (star b * b)]
-    rintro - ⟨x, -, rfl⟩
-    simp
-  have c_eq := star_mul_self_add_self_mul_star c
-  rw [← eq_sub_iff_add_eq', sub_eq_add_neg, ← sq, ← sq] at c_eq
-  have h_c_spec₁ : SpectrumRestricts (c * star c) ContinuousMap.realToNNReal := by
-    rw [c_eq]
-    refine SpectrumRestricts.nnreal_add ?_ ?_ ?_ h_c_spec₀
-    · exact IsSelfAdjoint.smul (by rfl) <| ((ℜ c).prop.pow 2).add ((ℑ c).prop.pow 2)
-    · exact (IsSelfAdjoint.star_mul_self c).neg
-    · rw [← Nat.cast_smul_eq_nsmul ℝ]
-      refine (ℜ c).2.sq_spectrumRestricts.nnreal_add ((ℜ c).2.pow 2) ((ℑ c).2.pow 2)
-        (ℑ c).2.sq_spectrumRestricts |>.smul_of_nonneg <| by norm_num
-  have h_c_spec₂ : SpectrumRestricts (star c * c) ContinuousMap.realToNNReal := by
-    rw [SpectrumRestricts.nnreal_iff] at h_c_spec₁ ⊢
-    intro x hx
-    replace hx := Set.subset_diff_union _ {(0 : ℝ)} hx
-    rw [spectrum.nonzero_mul_eq_swap_mul, Set.diff_union_self, Set.union_singleton,
-      Set.mem_insert_iff] at hx
-    obtain (rfl | hx) := hx
-    exacts [le_rfl, h_c_spec₁ x hx]
-  rw [h_c_spec₂.eq_zero_of_neg (.star_mul_self c) h_c_spec₀, neg_zero] at h_eq_a_neg
-  simp only [a_neg] at h_eq_a_neg
-  rw [← cfc_pow _ _ (ha := .star_mul_self b), ← cfc_zero a (R := ℝ)] at h_eq_a_neg
-  intro x hx
-  by_contra! hx'
-  rw [← neg_pos] at hx'
-  apply (pow_pos hx' 3).ne
-  have h_eqOn := eqOn_of_cfc_eq_cfc (ha := IsSelfAdjoint.star_mul_self b) h_eq_a_neg
-  simpa [sup_eq_left.mpr hx'.le] using h_eqOn hx
-
-lemma IsSelfAdjoint.coe_mem_spectrum_complex {A : Type*} [TopologicalSpace A] [Ring A]
-    [StarRing A] [Algebra ℂ A] [ContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop)]
-    {a : A} {x : ℝ} (ha : IsSelfAdjoint a := by cfc_tac) :
-    (x : ℂ) ∈ spectrum ℂ a ↔ x ∈ spectrum ℝ a := by
-  simp [← ha.spectrumRestricts.algebraMap_image]
-
-end SpectrumRestricts
-
-section NonnegSpectrumClass
-
-variable {A : Type*} [CStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
-
-instance CStarAlgebra.instNonnegSpectrumClass : NonnegSpectrumClass ℝ A :=
-  .of_spectrum_nonneg fun a ha ↦ by
-    rw [StarOrderedRing.nonneg_iff] at ha
-    induction ha using AddSubmonoid.closure_induction with
-    | mem x hx =>
-      obtain ⟨b, rfl⟩ := hx
-      exact spectrum_star_mul_self_nonneg
-    | one =>
-      nontriviality A
-      simp
-    | mul x y x_mem y_mem hx hy =>
-      rw [← SpectrumRestricts.nnreal_iff] at hx hy ⊢
-      rw [← StarOrderedRing.nonneg_iff] at x_mem y_mem
-      exact hx.nnreal_add (.of_nonneg x_mem) (.of_nonneg y_mem) hy
-
-open ComplexOrder in
-instance CStarAlgebra.instNonnegSpectrumClassComplexUnital : NonnegSpectrumClass ℂ A where
-  quasispectrum_nonneg_of_nonneg a ha x := by
-    rw [mem_quasispectrum_iff]
-    refine (Or.elim · ge_of_eq fun hx ↦ ?_)
-    obtain ⟨y, hy, rfl⟩ := (IsSelfAdjoint.of_nonneg ha).spectrumRestricts.algebraMap_image ▸ hx
-    simpa using spectrum_nonneg_of_nonneg ha hy
-
-end NonnegSpectrumClass
-
-section SpectralOrder
-
-variable (A : Type*) [CStarAlgebra A]
-
-/-- The partial order on a unital C⋆-algebra defined by `x ≤ y` if and only if `y - x` is
-selfadjoint and has nonnegative spectrum.
-
-This is not declared as an instance because one may already have a partial order with better
-definitional properties. However, it can be useful to invoke this as an instance in proofs. -/
-@[reducible]
-def CStarAlgebra.spectralOrder : PartialOrder A where
-  le x y := IsSelfAdjoint (y - x) ∧ SpectrumRestricts (y - x) ContinuousMap.realToNNReal
-  le_refl := by
-    simp only [sub_self, IsSelfAdjoint.zero, true_and, forall_const]
-    rw [SpectrumRestricts.nnreal_iff]
-    nontriviality A
-    simp
-  le_antisymm x y hxy hyx := by
-    rw [← sub_eq_zero]
-    exact hyx.2.eq_zero_of_neg hyx.1 (neg_sub x y ▸ hxy.2)
-  le_trans x y z hxy hyz :=
-    ⟨by simpa using hyz.1.add hxy.1, by simpa using hyz.2.nnreal_add hyz.1 hxy.1 hxy.2⟩
-
-/-- The `CStarAlgebra.spectralOrder` on a unital C⋆-algebra is a `StarOrderedRing`. -/
-lemma CStarAlgebra.spectralOrderedRing : @StarOrderedRing A _ (CStarAlgebra.spectralOrder A) _ :=
-  let _ := CStarAlgebra.spectralOrder A
-  { le_iff := by
-      intro x y
-      constructor
-      · intro h
-        obtain ⟨s, hs₁, _, hs₂⟩ := CFC.exists_sqrt_of_isSelfAdjoint_of_spectrumRestricts h.1 h.2
-        refine ⟨s ^ 2, ?_, by rwa [eq_sub_iff_add_eq', eq_comm] at hs₂⟩
-        exact AddSubmonoid.subset_closure ⟨s, by simp [hs₁.star_eq, sq]⟩
-      · rintro ⟨p, hp, rfl⟩
-        suffices IsSelfAdjoint p ∧ SpectrumRestricts p ContinuousMap.realToNNReal from
-          ⟨by simpa using this.1, by simpa using this.2⟩
-        induction hp using AddSubmonoid.closure_induction with
-        | mem x hx =>
-          obtain ⟨s, rfl⟩ := hx
-          refine ⟨IsSelfAdjoint.star_mul_self s, ?_⟩
-          rw [SpectrumRestricts.nnreal_iff]
-          exact spectrum_star_mul_self_nonneg
-        | one =>
-          rw [SpectrumRestricts.nnreal_iff]
-          nontriviality A
-          simp
-        | mul x y _ _ hx hy =>
-          exact ⟨hx.1.add hy.1, hx.2.nnreal_add hx.1 hy.1 hy.2⟩ }
-
-end SpectralOrder
-
-section NonnegSpectrumClass
-
-variable {A : Type*} [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
-
-open scoped CStarAlgebra in
-instance CStarAlgebra.instNonnegSpectrumClass' : NonnegSpectrumClass ℝ A where
-  quasispectrum_nonneg_of_nonneg a ha := by
-    rw [Unitization.quasispectrum_eq_spectrum_inr' _ ℂ]
-    -- should this actually be an instance on the `Unitization`? (probably scoped)
-    let _ := CStarAlgebra.spectralOrder A⁺¹
-    have := CStarAlgebra.spectralOrderedRing A⁺¹
-    apply spectrum_nonneg_of_nonneg
-    rw [StarOrderedRing.nonneg_iff] at ha ⊢
-    have := AddSubmonoid.mem_map_of_mem (Unitization.inrNonUnitalStarAlgHom ℂ A) ha
-    rw [AddMonoidHom.map_mclosure, ← Set.range_comp] at this
-    apply AddSubmonoid.closure_mono ?_ this
-    rintro _ ⟨s, rfl⟩
-    exact ⟨s, by simp⟩
-
-end NonnegSpectrumClass
-
-/-!
 ### The restriction of a continuous functional calculus is equal to the original one
 -/
 section RealEqComplex
@@ -692,44 +410,5 @@ lemma cfcₙ_nnreal_eq_real {a : A} (f : ℝ≥0 → ℝ≥0) (ha : 0 ≤ a := b
     isUniformEmbedding_subtype_val ha (.of_nonneg ha)
 
 end NNRealEqRealNonUnital
-
-section cfc_inr
-
-open CStarAlgebra
-
-variable {A : Type*} [NonUnitalCStarAlgebra A]
-
-open scoped NonUnitalContinuousFunctionalCalculus in
-/-- This lemma requires a lot from type class synthesis, and so one should instead favor the bespoke
-versions for `ℝ≥0`, `ℝ`, and `ℂ`. -/
-lemma Unitization.cfcₙ_eq_cfc_inr {R : Type*} [Semifield R] [StarRing R] [MetricSpace R]
-    [TopologicalSemiring R] [ContinuousStar R] [Module R A] [IsScalarTower R A A]
-    [SMulCommClass R A A] [CompleteSpace R] [Algebra R ℂ] [IsScalarTower R ℂ A]
-    {p : A → Prop} {p' : A⁺¹ → Prop} [NonUnitalContinuousFunctionalCalculus R p]
-    [ContinuousFunctionalCalculus R p']
-    [UniqueNonUnitalContinuousFunctionalCalculus R (Unitization ℂ A)]
-    (hp : ∀ {a : A}, p' (a : A⁺¹) ↔ p a) (a : A) (f : R → R) (hf₀ : f 0 = 0 := by cfc_zero_tac) :
-    cfcₙ f a = cfc f (a : A⁺¹) := by
-  by_cases h : ContinuousOn f (σₙ R a) ∧ p a
-  · obtain ⟨hf, ha⟩ := h
-    rw [← cfcₙ_eq_cfc (quasispectrum_inr_eq R ℂ a ▸ hf)]
-    exact (inrNonUnitalStarAlgHom ℂ A).map_cfcₙ f a
-  · obtain (hf | ha) := not_and_or.mp h
-    · rw [cfcₙ_apply_of_not_continuousOn a hf, inr_zero,
-        cfc_apply_of_not_continuousOn _ (quasispectrum_eq_spectrum_inr' R ℂ a ▸ hf)]
-    · rw [cfcₙ_apply_of_not_predicate a ha, inr_zero,
-        cfc_apply_of_not_predicate _ (not_iff_not.mpr hp |>.mpr ha)]
-
-lemma Unitization.complex_cfcₙ_eq_cfc_inr (a : A) (f : ℂ → ℂ) (hf₀ : f 0 = 0 := by cfc_zero_tac) :
-    cfcₙ f a = cfc f (a : A⁺¹) :=
-  Unitization.cfcₙ_eq_cfc_inr isStarNormal_inr ..
-
-/-- note: the version for `ℝ≥0`, `Unization.nnreal_cfcₙ_eq_cfc_inr`, can be found in
-`Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Order` -/
-lemma Unitization.real_cfcₙ_eq_cfc_inr (a : A) (f : ℝ → ℝ) (hf₀ : f 0 = 0 := by cfc_zero_tac) :
-    cfcₙ f a = cfc f (a : A⁺¹) :=
-  Unitization.cfcₙ_eq_cfc_inr isSelfAdjoint_inr ..
-
-end cfc_inr
 
 end

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Restrict
-import Mathlib.Analysis.CStarAlgebra.Spectrum
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Unique
+import Mathlib.Analysis.CStarAlgebra.Unitization
+import Mathlib.Analysis.Normed.Algebra.Spectrum
 
 /-! # Instances of the continuous functional calculus
 

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Isometric.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Isometric.lean
@@ -353,30 +353,17 @@ end QuasispectrumRestricts
 
 end NonUnital
 
-/-! ### Instances of isometric continuous functional calculi -/
+/-! ### Instances of isometric continuous functional calculi
+
+The instances for `ℝ` and `ℂ` can be found in
+`Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic`, as those require an actual
+`CStarAlgebra` instance on `A`, whereas the one for `ℝ≥0` is simply inherited from an existing
+instance for `ℝ`.
+-/
 
 section Instances
 
 section Unital
-
-section Complex
-
-variable {A : Type*} [CStarAlgebra A]
-
-instance IsStarNormal.instIsometricContinuousFunctionalCalculus :
-    IsometricContinuousFunctionalCalculus ℂ A IsStarNormal where
-  isometric a ha := by
-    rw [cfcHom_eq_of_isStarNormal]
-    exact isometry_subtype_coe.comp <| StarAlgEquiv.isometry (continuousFunctionalCalculus a)
-
-instance IsSelfAdjoint.instIsometricContinuousFunctionalCalculus :
-    IsometricContinuousFunctionalCalculus ℝ A IsSelfAdjoint :=
-  SpectrumRestricts.isometric_cfc Complex.reCLM Complex.isometry_ofReal (.zero _)
-    fun _ ↦ isSelfAdjoint_iff_isStarNormal_and_spectrumRestricts
-
-end Complex
-
-section NNReal
 
 variable {A : Type*} [NormedRing A] [PartialOrder A] [StarRing A] [StarOrderedRing A]
 variable [NormedAlgebra ℝ A] [IsometricContinuousFunctionalCalculus ℝ A IsSelfAdjoint]
@@ -388,39 +375,9 @@ instance Nonneg.instIsometricContinuousFunctionalCalculus :
   SpectrumRestricts.isometric_cfc (q := IsSelfAdjoint) ContinuousMap.realToNNReal
     isometry_subtype_coe le_rfl (fun _ ↦ nonneg_iff_isSelfAdjoint_and_spectrumRestricts)
 
-end NNReal
-
 end Unital
 
 section NonUnital
-
-section Complex
-
-variable {A : Type*} [NonUnitalCStarAlgebra A]
-
-open Unitization
-
-
-open ContinuousMapZero in
-instance IsStarNormal.instNonUnitalIsometricContinuousFunctionalCalculus :
-    NonUnitalIsometricContinuousFunctionalCalculus ℂ A IsStarNormal where
-  isometric a ha := by
-    refine AddMonoidHomClass.isometry_of_norm _ fun f ↦ ?_
-    rw [← norm_inr (𝕜 := ℂ), ← inrNonUnitalStarAlgHom_apply, ← NonUnitalStarAlgHom.comp_apply,
-      inr_comp_cfcₙHom_eq_cfcₙAux a, cfcₙAux]
-    simp only [NonUnitalStarAlgHom.comp_assoc, NonUnitalStarAlgHom.comp_apply,
-      toContinuousMapHom_apply, NonUnitalStarAlgHom.coe_coe]
-    rw [norm_cfcHom (a : Unitization ℂ A), StarAlgEquiv.norm_map]
-    rfl
-
-instance IsSelfAdjoint.instNonUnitalIsometricContinuousFunctionalCalculus :
-    NonUnitalIsometricContinuousFunctionalCalculus ℝ A IsSelfAdjoint :=
-  QuasispectrumRestricts.isometric_cfc Complex.reCLM Complex.isometry_ofReal (.zero _)
-    fun _ ↦ isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts
-
-end Complex
-
-section NNReal
 
 variable {A : Type*} [NonUnitalNormedRing A] [PartialOrder A] [StarRing A] [StarOrderedRing A]
 variable [NormedSpace ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A]
@@ -432,8 +389,6 @@ instance Nonneg.instNonUnitalIsometricContinuousFunctionalCalculus :
     NonUnitalIsometricContinuousFunctionalCalculus ℝ≥0 A (0 ≤ ·) :=
   QuasispectrumRestricts.isometric_cfc (q := IsSelfAdjoint) ContinuousMap.realToNNReal
     isometry_subtype_coe le_rfl (fun _ ↦ nonneg_iff_isSelfAdjoint_and_quasispectrumRestricts)
-
-end NNReal
 
 end NonUnital
 

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis
 -/
 
-import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
 import Mathlib.Analysis.CStarAlgebra.Unitization
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow
 import Mathlib.Topology.ContinuousMap.StarOrdered

--- a/Mathlib/Analysis/CStarAlgebra/SpecialFunctions/PosPart.lean
+++ b/Mathlib/Analysis/CStarAlgebra/SpecialFunctions/PosPart.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.PosPart
-import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
 
 /-! # C⋆-algebraic facts about `a⁺` and `a⁻`. -/
 

--- a/Mathlib/Analysis/InnerProductSpace/StarOrder.lean
+++ b/Mathlib/Analysis/InnerProductSpace/StarOrder.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
 import Mathlib.Analysis.InnerProductSpace.Positive
-import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
 import Mathlib.Analysis.CStarAlgebra.ContinuousLinearMap
 
 /-!


### PR DESCRIPTION
Before this PR, there were three files in which one could find instances of continuous functional calculi: `Analysis.CStarAlgebra.ContinuousFunctionalCalculus.{Instances, Isometric, Unital}`, which contained, respectively,

1. All generic instances of the CFC over `ℂ`, `ℝ`, `ℝ≥0` for unital and non-unital algebras
2. All the instances of the isometric CFC.
3. The non-unital CFC for unital algebras.

Note that importing `Instances` was therefore the general way to obtain a CFC on a `CStarAlgebra`. In this PR, the last one stays where it is, but there is a bit of shuffling for the others which we now explain.

Here the problem with the above distribution of instances: if you are working on a generic CFC file (e.g., defining `CFC.abs a := CFC.sqrt (star a * a)`, then you want to work in maximum generality. But to apply `CFC.sqrt` you need an instance of the `ℝ≥0` functional calculus. The *correct* (i.e., well-behaved) way to do this is to assume that you have an `ℝ`-algebra (*not* an `ℝ≥0`-algebra, because those are ill-behaved) with the appropriate hypotheses. However, in order to get that instance, prior to this PR you would need to import `Instances`, which would pull in `CStarAlgebra` theory not relevant to the development of your file (and potentially, not even relevant to certain files downstream of the one on which you are working).

The solution is to separate the instances which are *inferred from existing instances* (i.e., for obtaining `ℝ` from `ℂ`, or `ℝ≥0` from `ℝ`) from the *base level instances* (i.e., the ones for `ℂ` which require `CStarAlgebra`). The former instances are left in either `Instances` or `Isometric` as the case may be, and the latter are moved into `Basic`.

This means that `Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic` is now the entry point for getting all the relevant CFC instances for a `CStarAlgebra`. The rest of the files in this folder are for the more generic development of the CFC (with the exception of `Order`, which should likely be moved outside of this subfolder at some point.

This should explain the large changes in the import hierarchy. The purpose of this refactor is to allow for more principled development of generic CFC functions, without importing more than necessary.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
