### PR TITLE
feat: formalize regular expression -> εNFA 

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2507,6 +2507,7 @@ import Mathlib.Computability.PostTuringMachine
 import Mathlib.Computability.Primrec
 import Mathlib.Computability.Reduce
 import Mathlib.Computability.RegularExpressions
+import Mathlib.Computability.RegularExpressionsToEpsilonNFA
 import Mathlib.Computability.TMComputable
 import Mathlib.Computability.TMToPartrec
 import Mathlib.Computability.Tape

--- a/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
+++ b/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
@@ -15,7 +15,7 @@ nondeterministic finite automaton from a regular expression and a proof of its c
 
 ## Main definitions
 
-  * `RegularExpression.toεNFA`
+* `RegularExpression.toεNFA`
 
 ## References
 
@@ -42,7 +42,7 @@ private def zero_start : Set Empty := ∅
 private def zero_accept : Set Empty := ∅
 
 /-- The `εNFA` for `epsilon` has only an ε-transition from the starting state to the accepting
-  state. -/
+state. -/
 private def epsilon_step : BinSt → Option α → Set (BinSt)
   | .ini, none => {.fin}
   | _, _ => ∅
@@ -50,7 +50,7 @@ private def epsilon_start : Set (BinSt) := {.ini}
 private def epsilon_accept : Set (BinSt) := {.fin}
 
 /-- The `εNFA` for `char a` has only an `a`-labeled transition from the starting state to the
-  accepting state. -/
+accepting state. -/
 private def char_step (a : α) : BinSt → Option α → Set (BinSt)
   | .ini, some b => {s | s = .fin ∧ a = b}
   | _, _ => ∅
@@ -58,9 +58,9 @@ private def char_start : Set (BinSt) := {.ini}
 private def char_accept : Set (BinSt) := {.fin}
 
 /-- The `εNFA` for `plus P Q` is constructed using a sum type to embed left and right (from the
-  `εNFA`s for `P` and `Q` respectively) states. It has separate starting and accepting states, with
-  ε-transitions from the starting state to the embedded starting states, and from the embedded
-  accepting states to the accepting state. -/
+`εNFA`s for `P` and `Q` respectively) states. It has separate starting and accepting states, with
+ε-transitions from the starting state to the embedded starting states, and from the embedded
+accepting states to the accepting state. -/
 private def plus_step (M₁ : εNFA α σ₁) (M₂ : εNFA α σ₂) :
     BinSt ⊕ σ₁ ⊕ σ₂ → Option α → Set (BinSt ⊕ σ₁ ⊕ σ₂)
   | .inl .ini, none => .inr '' Sum.elim M₁.start M₂.start
@@ -73,9 +73,9 @@ private def plus_start : Set (BinSt ⊕ σ₁ ⊕ σ₂) := {.inl .ini}
 private def plus_accept : Set (BinSt ⊕ σ₁ ⊕ σ₂) := {.inl .fin}
 
 /-- The `εNFA` for `comp P Q` is constructed using a sum type to embed left and right (from the
-  `εNFA`s for `P` and `Q` respectively) states. The starting and accepting states are the embedded
-  left-starting and right-accepting states respectively. An ε-transition exists between the embedded
-  left accepting and right starting states. -/
+`εNFA`s for `P` and `Q` respectively) states. The starting and accepting states are the embedded
+left-starting and right-accepting states respectively. An ε-transition exists between the embedded
+left accepting and right starting states. -/
 private def comp_step (M₁ : εNFA α σ₁) (M₂ : εNFA α σ₂) : σ₁ ⊕ σ₂ → Option α → Set (σ₁ ⊕ σ₂)
   | .inl s', a => .inl '' M₁.step s' a ∪ {s | s ∈ .inr '' M₂.start ∧ a = none ∧ s' ∈ M₁.accept}
   | .inr s', a => .inr '' M₂.step s' a
@@ -83,9 +83,9 @@ private def comp_start (M₁ : εNFA α σ₁) : Set (σ₁ ⊕ σ₂) := .inl '
 private def comp_accept (M₂ : εNFA α σ₂) : Set (σ₁ ⊕ σ₂) := .inr '' M₂.accept
 
 /-- The `εNFA` for `star P` is constructed using a sum type to embed the `εNFA` for `P`, with
-  ε-transitions from the starting and accepting states to the respective embedded states. Additional
-  ε-transitions exist between the starting and accepting state (empty matching), and between the
-  embedded accepting and starting states (repetition). -/
+ε-transitions from the starting and accepting states to the respective embedded states. Additional
+ε-transitions exist between the starting and accepting state (empty matching), and between the
+embedded accepting and starting states (repetition). -/
 private def star_step (M : εNFA α σ) : BinSt ⊕ σ → Option α → Set (BinSt ⊕ σ)
   | .inl .ini, none => .inr '' M.start ∪ {.inl .fin}
   | .inr s', a => .inr '' M.step s' a

--- a/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
+++ b/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
@@ -119,7 +119,7 @@ lemma zero_accepts : zero.toεNFA.accepts = (0 : Language α) := by
 lemma epsilon_accepts : epsilon.toεNFA.accepts = (1 : Language α) := by
   ext x
   constructor <;> rw [mem_accepts_iff_exists_path]
-  · rintro ⟨s₁, s₂, _, ⟨⟩, _, ⟨⟩, h⟩
+  · rintro ⟨s₁, s₂, _, rfl, _, rfl, h⟩
     rw [Language.one_def, mem_singleton_iff, reduceOption_eq_nil_iff]
     use 1
     rcases h with _ | ⟨_, _, _, ⟨⟩, _, ⟨⟩, ⟨⟩⟩ <;> trivial
@@ -130,11 +130,11 @@ lemma epsilon_accepts : epsilon.toεNFA.accepts = (1 : Language α) := by
 lemma char_accepts (a : α) : (char a).toεNFA.accepts = {[a]} := by
   ext x
   constructor <;> rw [mem_accepts_iff_exists_path]
-  · rintro ⟨_, _, _, ⟨⟩, ⟨⟩, ⟨⟩, h⟩
+  · rintro ⟨_, _, _, rfl, _, rfl, h⟩
     rw [mem_singleton_iff, reduceOption_eq_singleton_iff]
     use 0, 0
     rcases h with _ | ⟨_, _, _, ⟨⟩, _, ⟨⟩, ⟨⟩⟩ <;> subst_eqs <;> trivial
-  · rintro ⟨⟩
+  · rintro rfl
     use .ini, .fin, [a]
     repeat constructor
 
@@ -168,19 +168,19 @@ lemma plus_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
 
 lemma plus_no_cross_left (s : P.St) (t : Q.St) (x : List (Option α)) :
     ¬(P + Q).toεNFA.IsPath (.inr (.inl s)) (.inr (.inr t)) x := by
-  induction x generalizing s <;> rintro (_ | ⟨_, _, _, _, _, ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩⟩) <;> tauto
+  induction x generalizing s <;> rintro (_ | ⟨_, _, _, _, _, ⟨_, _, rfl⟩ | ⟨rfl, _⟩⟩) <;> tauto
 
 lemma plus_no_cross_right (s : Q.St) (t : P.St) (x : List (Option α)) :
     ¬(P + Q).toεNFA.IsPath (.inr (.inr s)) (.inr (.inl t)) x := by
-  induction x generalizing s <;> rintro (_ | ⟨_, _, _, _, _, ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩⟩) <;> tauto
+  induction x generalizing s <;> rintro (_ | ⟨_, _, _, _, _, ⟨_, _, rfl⟩ | ⟨rfl, _⟩⟩) <;> tauto
 
 lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.accepts := by
   ext x
   constructor <;> rw [mem_accepts_iff_exists_path]
-  · rintro ⟨_, _, _, ⟨⟩, ⟨⟩, ⟨⟩, h⟩
-    rcases h with _ | ⟨_, _, _, ⟨⟩, x, ⟨_ | _, hs, ⟨⟩⟩, h⟩
+  · rintro ⟨_, _, _, rfl, rfl, rfl, h⟩
+    rcases h with _ | ⟨_, _, _, ⟨⟩, x, ⟨_ | _, hs, rfl⟩, h⟩
       <;> [left; right]
-      <;> rcases eq_nil_or_concat x with ⟨⟨⟩⟩ | ⟨_, a, ⟨⟩⟩
+      <;> rcases eq_nil_or_concat x with rfl | ⟨_, a, rfl⟩
       <;> (try apply IsPath.eq_of_nil at h; contradiction)
       <;> simp_rw [concat_eq_append, isPath_append, isPath_singleton] at h
       <;> rcases h with ⟨⟨_ | _⟩ | ⟨_ | _⟩, h, hs⟩
@@ -188,7 +188,7 @@ lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.acc
       <;> (try apply plus_no_cross_right at h)
       <;> (try contradiction)
       <;> (try cases a <;> rcases hs with ⟨_, _, ⟨⟩⟩; done)
-      <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨_, ⟨⟩, _⟩
+      <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨_, rfl, _⟩
       <;> rw [reduceOption_cons_of_none, reduceOption_concat, Option.toList_none, append_nil,
             mem_accepts_iff_exists_path]
     · rw [← plus_embed_left] at h
@@ -199,7 +199,7 @@ lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.acc
     use .inl .ini, .inl .fin
     rcases h with h | h
       <;> rw [mem_accepts_iff_exists_path] at h
-      <;> obtain ⟨s₁, s₂, x', _, _, ⟨⟩, _⟩ := h
+      <;> obtain ⟨s₁, s₂, x', _, _, rfl, _⟩ := h
       <;> use none :: x' ++ [none]
       <;> simp only [reduceOption_append, reduceOption_cons_of_none, reduceOption_nil, append_nil]
       <;> split_ands
@@ -218,7 +218,7 @@ lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.acc
 
 lemma comp_one_way (s : Q.St) (t : P.St) (x : List (Option α)) :
     ¬(comp P Q).toεNFA.IsPath (.inr s) (.inl t) x := by
-  induction x generalizing s <;> rintro (_ | ⟨_, _, _, _, _, ⟨_, _, ⟨⟩⟩⟩)
+  induction x generalizing s <;> rintro (_ | ⟨_, _, _, _, _, ⟨_, _, rfl⟩⟩)
   tauto
 
 lemma comp_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
@@ -231,7 +231,7 @@ lemma comp_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
     · left
       use s
     · rwa [← ih]
-  · rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, _⟩
+  · rcases hs with ⟨_, _, rfl⟩ | ⟨⟨_, _, rfl⟩, _⟩
     · apply IsPath.cons <;> (try rw [ih]) <;> assumption
     · apply comp_one_way at h
       contradiction
@@ -245,7 +245,7 @@ lemma comp_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
   · apply IsPath.cons
     · use s
     · rwa [← ih]
-  · rcases hs with ⟨_, _, ⟨⟩⟩
+  · rcases hs with ⟨_, _, rfl⟩
     apply IsPath.cons <;> (try rw [ih]) <;> assumption
 
 lemma comp_split (s₁₁ : P.St) (s₂₂ : Q.St) (x : List (Option α)) :
@@ -263,7 +263,7 @@ lemma comp_split (s₁₁ : P.St) (s₂₂ : Q.St) (x : List (Option α)) :
   · induction' x with b x ih generalizing s₁₁ a <;> rcases h with _ | ⟨s, _, _, _, _, hs, h⟩
     · apply IsPath.eq_of_nil at h
       subst s
-      rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, ⟨⟩, _⟩
+      rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, rfl, _⟩
       use s₁₁, s₂₂, [], []
       tauto
     · cases' s with _ s
@@ -271,15 +271,15 @@ lemma comp_split (s₁₁ : P.St) (s₂₂ : Q.St) (x : List (Option α)) :
         use s₁₂, s₂₁, a :: x₁, x₂
         tauto
       · use s₁₁, s, [], b :: x
-        split_ands <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, ⟨⟩, _⟩ <;> tauto
+        split_ands <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, rfl, _⟩ <;> tauto
 
 lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.accepts := by
   ext x
   constructor
   · rw [mem_accepts_iff_exists_path]
-    rintro ⟨_, _, _, ⟨s₁₁, _, ⟨⟩⟩, ⟨s₂₂, _, ⟨⟩⟩, ⟨⟩, h⟩
+    rintro ⟨_, _, _, ⟨s₁₁, _, rfl⟩, ⟨s₂₂, _, rfl⟩, rfl, h⟩
     apply comp_split at h
-    obtain ⟨s₁₂, s₂₁, x₁, x₂, ⟨⟩, _, _, h₁, h₂⟩ := h
+    obtain ⟨s₁₂, s₂₁, x₁, x₂, rfl, _, _, h₁, h₂⟩ := h
     rw [← comp_embed_left] at h₁
     rw [← comp_embed_right] at h₂
     rw [Language.mem_mul]
@@ -292,10 +292,10 @@ lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.
       · use s₂₁, s₂₂, x₂
       · rw [reduceOption_append, reduceOption_cons_of_none]
   · rw [Language.mem_mul]
-    rintro ⟨x₁, h₁, x₂, h₂, ⟨⟩⟩
+    rintro ⟨x₁, h₁, x₂, h₂, rfl⟩
     rw [mem_accepts_iff_exists_path] at *
-    obtain ⟨s₁₁, s₁₂, x₁', _, _, ⟨⟩, _⟩ := h₁
-    obtain ⟨_, s₂₂, x₂', _, _, ⟨⟩, _⟩ := h₂
+    obtain ⟨s₁₁, s₁₂, x₁', _, _, rfl, _⟩ := h₁
+    obtain ⟨_, s₂₂, x₂', _, _, rfl, _⟩ := h₂
     use .inl s₁₁, .inr s₂₂, x₁' ++ none :: x₂'
     split_ands <;> try tauto
     · rw [reduceOption_append, reduceOption_cons_of_none]
@@ -310,13 +310,13 @@ lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.
 
 lemma step_accept_empty (s : P.St) : s ∈ P.toεNFA.accept → ∀ a, P.toεNFA.step s a = ∅ := by
   induction P
-    <;> rintro ⟨_, _, ⟨⟩⟩
+    <;> rintro ⟨_, _, rfl⟩
     <;> simp only [toεNFA, comp_step, comp_def, image_eq_empty]
     <;> tauto
 
 lemma accept_final (s : P.St) : s ∈ P.toεNFA.accept → ∀ t x, x ≠ [] → ¬P.toεNFA.IsPath s t x := by
   simp_rw [ne_nil_iff_exists_cons]
-  rintro _ _ _ ⟨_, _, _, ⟨_, _, ⟨⟩⟩⟩ (_ | ⟨_, _, _, _, _, hs⟩)
+  rintro _ _ _ ⟨_, _, rfl⟩ (_ | ⟨_, _, _, _, _, hs⟩)
   rw [step_accept_empty] at hs <;> assumption
 
 -- N.B. This holds for any `P`, but only the `star P` case is needed.
@@ -338,13 +338,13 @@ lemma star_cons (s : (star P).St) :
         (t = .inl .fin ∨ t ∈ .inr '' P.toεNFA.start) ∧
         (star P).toεNFA.IsPath t (.inl .fin) x' := by
   intro hs x h
-  rcases hs with ⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩
+  rcases hs with rfl | ⟨_, _, rfl⟩
     <;> cases' x with a x
     <;> (try apply IsPath.eq_of_nil at h)
     <;> rcases h with _ | ⟨s, _, _, _, _, hs⟩
     <;> use s, x
     <;> cases a
-    <;> obtain ⟨_, hs, ⟨⟩⟩ | ⟨⟨⟩⟩ := hs
+    <;> obtain ⟨_, hs, rfl⟩ | ⟨⟨⟩⟩ := hs
     <;> (try rw [step_accept_empty] at hs)
     <;> tauto
 
@@ -353,7 +353,7 @@ lemma star_concat (s : (star P).St) :
       ∀ x, (star P).toεNFA.IsPath s (.inl .fin) x →
       ∃ x', x = x' ++ [none] := by
   intro hs x h
-  rcases eq_nil_or_concat' x with ⟨⟨⟩⟩ | ⟨x, a, ⟨⟩⟩
+  rcases eq_nil_or_concat' x with rfl | ⟨x, a, rfl⟩
   · apply IsPath.eq_of_nil at h
     contradiction
   · simp_rw [isPath_append, isPath_singleton] at h
@@ -365,7 +365,7 @@ lemma star_concat (s : (star P).St) :
 lemma star_end (s : (star P).St) :
     s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept → (star P).toεNFA.IsPath s (.inl .fin) [none] := by
   rw [isPath_singleton]
-  rintro (⟨⟨⟩, _⟩ | ⟨_, _, ⟨⟩⟩) <;> (try right; constructor) <;> tauto
+  rintro (⟨rfl, _⟩ | ⟨_, _, rfl⟩) <;> (try right; constructor) <;> tauto
 
 lemma star_split (s₁ : P.St) (x : List (Option α)) :
     (star P).toεNFA.IsPath (.inr s₁) (.inl .fin) x →
@@ -375,7 +375,7 @@ lemma star_split (s₁ : P.St) (x : List (Option α)) :
         P.toεNFA.IsPath s₁ s₂ x₁ ∧
         (star P).toεNFA.IsPath (.inr s₂) (.inl .fin) x' := by
   intro h
-  obtain ⟨x, ⟨⟩⟩ := star_concat _ (by tauto) _ h
+  obtain ⟨x, rfl⟩ := star_concat _ (by tauto) _ h
   simp_rw [isPath_append, isPath_singleton] at h
   rcases h with ⟨⟨_ | _⟩ | t, h, ⟨_, _, ⟨⟩⟩ | ⟨_, _, _⟩⟩
   · apply star_no_restart at h
@@ -385,7 +385,7 @@ lemma star_split (s₁ : P.St) (x : List (Option α)) :
       cases h
       use t, [], [none]
       split_ands <;> (try apply star_end) <;> tauto
-    · rcases h with _ | ⟨_, _, _, _, _, ⟨_, _, ⟨⟩⟩ | ⟨⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩, _, _⟩, h⟩
+    · rcases h with _ | ⟨_, _, _, _, _, ⟨_, _, rfl⟩ | ⟨rfl | ⟨_, _, rfl⟩, _, _⟩, h⟩
       · apply ih at h
         obtain ⟨s₂, x₁, x', _, _, _, _⟩ := h
         use s₂, a :: x₁, x'
@@ -407,11 +407,11 @@ lemma star_parts (s : (star P).St) (x : List (Option α)) :
     s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept → (star P).toεNFA.IsPath s (.inl .fin) x →
       ∃ xs : List (List α), x.reduceOption = xs.flatten ∧ ∀ y ∈ xs, y ∈ P.toεNFA.accepts := by
   intro hs h
-  rcases star_cons _ hs _ h with ⟨_, _, ⟨⟩, ⟨⟨⟩⟩ | ⟨s₁, _, ⟨⟩⟩, h⟩
+  rcases star_cons _ hs _ h with ⟨_, _, rfl, rfl | ⟨s₁, _, rfl⟩, h⟩
   · use []
     rw [reduceOption_cons_of_none, flatten_nil]
     cases h <;> tauto
-  · obtain ⟨s₂, x₁, _, ⟨⟩, _, _, h'⟩ := star_split _ _ h
+  · obtain ⟨s₂, x₁, _, rfl, _, _, h'⟩ := star_split _ _ h
     obtain ⟨xs, hx, _⟩ := star_parts (.inr s₂) _ (by tauto) h'
     use x₁.reduceOption :: xs
     rw [reduceOption_cons_of_none, reduceOption_append, flatten_cons, hx]
@@ -426,10 +426,10 @@ lemma star_embed (s₁ s₂ : P.St) (x : List (Option α)) :
 lemma star_accepts : (star P).toεNFA.accepts = P.toεNFA.accepts∗ := by
   ext x
   constructor <;> rw [mem_accepts_iff_exists_path]
-  · rintro ⟨_, _, x, ⟨⟩, ⟨⟩, ⟨⟩, h⟩
+  · rintro ⟨_, _, x, rfl, rfl, rfl, h⟩
     exact star_parts _ x (by tauto) h
   · rw [Language.mem_kstar]
-    rintro ⟨xs, ⟨⟩, hs⟩
+    rintro ⟨xs, rfl, hs⟩
     use .inl .ini, .inl .fin
     induction' xs with _ _ ih
     · use [none]
@@ -437,16 +437,16 @@ lemma star_accepts : (star P).toεNFA.accepts = P.toεNFA.accepts∗ := by
     · simp only [forall_eq_or_imp, mem_cons] at hs
       obtain ⟨h₁, hs⟩ := hs
       rw [mem_accepts_iff_exists_path] at h₁
-      obtain ⟨_, s₁₂, x₁, _, _, ⟨⟩, _⟩ := h₁
+      obtain ⟨_, s₁₂, x₁, _, _, rfl, _⟩ := h₁
       obtain ⟨_, _, _, hx₂, h₂⟩ := ih hs
-      obtain ⟨_, x₂, ⟨⟩, hs₂₁, _⟩ := star_cons _ (by tauto) _ h₂
+      obtain ⟨_, x₂, rfl, hs₂₁, _⟩ := star_cons _ (by tauto) _ h₂
       use none :: x₁ ++ none :: x₂
       refine ⟨rfl, rfl, ?_, ?_⟩
       · rw [reduceOption_append, reduceOption_cons_of_none, flatten_cons, hx₂]
       · rw [isPath_append]
         use .inr s₁₂
         constructor
-          <;> rcases hs₂₁ with ⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩
+          <;> rcases hs₂₁ with rfl | ⟨_, _, rfl⟩
           <;> apply IsPath.cons
           <;> (try assumption)
           <;> (try left; tauto)

--- a/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
+++ b/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
@@ -118,7 +118,7 @@ lemma zero_accepts : zero.toεNFA.accepts = (0 : Language α) := by
 
 lemma epsilon_accepts : epsilon.toεNFA.accepts = (1 : Language α) := by
   ext x
-  constructor <;> intro h <;> rw [accepts_Path_iff] at *
+  constructor <;> intro h <;> rw [mem_accepts_iff_exists_path] at *
   · obtain ⟨s₁, s₂, _, _, _, _, h⟩ := h
     substs x s₁ s₂
     rw [Language.one_def, mem_singleton_iff, reduceOption_eq_nil_iff]
@@ -132,7 +132,7 @@ lemma epsilon_accepts : epsilon.toεNFA.accepts = (1 : Language α) := by
 
 lemma char_accepts (a : α) : (char a).toεNFA.accepts = {[a]} := by
   ext x
-  constructor <;> intro h <;> rw [accepts_Path_iff] at *
+  constructor <;> intro h <;> rw [mem_accepts_iff_exists_path] at *
   · obtain ⟨s₁, s₂, _, _, _, _, h⟩ := h
     substs x s₁ s₂
     rw [mem_singleton_iff, reduceOption_eq_singleton_iff]
@@ -145,60 +145,60 @@ lemma char_accepts (a : α) : (char a).toεNFA.accepts = {[a]} := by
     repeat constructor
 
 lemma plus_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
-    P.toεNFA.Path s₁ s₂ x ↔ (P + Q).toεNFA.Path (.inr (.inl s₁)) (.inr (.inl s₂)) x := by
+    P.toεNFA.IsPath s₁ s₂ x ↔ (P + Q).toεNFA.IsPath (.inr (.inl s₁)) (.inr (.inl s₂)) x := by
   induction' x with _ _ ih generalizing s₁
     <;> constructor
     <;> intro h
     <;> cases' h with _ s _ _ _ _ hs h
-    <;> (try apply Path.nil)
-  · apply Path.cons
+    <;> (try apply IsPath.nil)
+  · apply IsPath.cons
     · left
       use s
     · rwa [Function.comp_apply, ← ih]
   · cases s <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩ := hs
     · cases' h with _ s _ _ a _ hs
       cases a <;> cases hs
-    · apply Path.cons <;> (try rw [ih]) <;> assumption
+    · apply IsPath.cons <;> (try rw [ih]) <;> assumption
 
 lemma plus_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
-    Q.toεNFA.Path s₁ s₂ x ↔ (P + Q).toεNFA.Path (.inr (.inr s₁)) (.inr (.inr s₂)) x := by
+    Q.toεNFA.IsPath s₁ s₂ x ↔ (P + Q).toεNFA.IsPath (.inr (.inr s₁)) (.inr (.inr s₂)) x := by
   induction' x with _ _ ih generalizing s₁
     <;> constructor
     <;> intro h
     <;> cases' h with _ s _ _ _ _ hs h
-    <;> (try apply Path.nil)
-  · apply Path.cons
+    <;> (try apply IsPath.nil)
+  · apply IsPath.cons
     · left
       use s
     · rwa [Function.comp_apply, ← ih]
   · cases s <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩ := hs
     · cases' h with _ s _ _ a _ hs
       cases a <;> cases hs
-    · apply Path.cons <;> (try rw [ih]) <;> assumption
+    · apply IsPath.cons <;> (try rw [ih]) <;> assumption
 
 lemma plus_no_cross_left (s : P.St) (t : Q.St) (x : List (Option α)) :
-    ¬(P + Q).toεNFA.Path (.inr (.inl s)) (.inr (.inr t)) x := by
+    ¬(P + Q).toεNFA.IsPath (.inr (.inl s)) (.inr (.inr t)) x := by
   intro h
   induction x generalizing s <;> cases' h with _ s _ _ _ _ hs
   obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩ := hs <;> tauto
 
 lemma plus_no_cross_right (s : Q.St) (t : P.St) (x : List (Option α)) :
-    ¬(P + Q).toεNFA.Path (.inr (.inr s)) (.inr (.inl t)) x := by
+    ¬(P + Q).toεNFA.IsPath (.inr (.inr s)) (.inr (.inl t)) x := by
   intro h
   induction x generalizing s <;> cases' h with _ s _ _ _ _ hs
   obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩ := hs <;> tauto
 
 lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.accepts := by
   ext x
-  constructor <;> intro h <;> rw [accepts_Path_iff] at *
+  constructor <;> intro h <;> rw [mem_accepts_iff_exists_path] at *
   · obtain ⟨s₁, s₂, _, _, _, _, h⟩ := h
     substs x s₁ s₂
     cases' h with _ s _ _ a x hs h
     cases a <;> obtain ⟨_ | _, hs, ⟨⟩⟩ := hs
       <;> [left; right]
       <;> rcases eq_nil_or_concat x with ⟨⟨⟩⟩ | ⟨_, a, ⟨⟩⟩
-      <;> (try apply Path_nil_eq at h; contradiction)
-      <;> simp_rw [concat_eq_append, Path_append_iff, Path_singleton_iff] at h
+      <;> (try apply IsPath.eq_of_nil at h; contradiction)
+      <;> simp_rw [concat_eq_append, isPath_append, isPath_singleton] at h
       <;> rcases h with ⟨⟨_ | _⟩ | ⟨_ | _⟩, h, hs⟩
       <;> (try apply plus_no_cross_left at h)
       <;> (try apply plus_no_cross_right at h)
@@ -206,25 +206,25 @@ lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.acc
       <;> (try cases a <;> obtain ⟨_, _, ⟨⟩⟩ := hs; done)
       <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨_, ⟨⟩, _⟩ := hs
       <;> rw [reduceOption_cons_of_none, reduceOption_concat, Option.toList_none, append_nil,
-            accepts_Path_iff]
+            mem_accepts_iff_exists_path]
     · rw [← plus_embed_left] at h
       tauto
     · rw [← plus_embed_right] at h
       tauto
   · use .inl .ini, .inl .fin
     rcases h with h | h
-      <;> rw [accepts_Path_iff] at h
+      <;> rw [mem_accepts_iff_exists_path] at h
       <;> obtain ⟨s₁, s₂, x', _, _, _, _⟩ := h
       <;> subst x
       <;> use none :: x' ++ [none]
       <;> simp only [reduceOption_append, reduceOption_cons_of_none, reduceOption_nil, append_nil]
       <;> split_ands
       <;> (try trivial)
-      <;> rw [Path_append_iff]
+      <;> rw [isPath_append]
       <;> [use .inr (.inl s₂); use .inr (.inr s₂)]
       <;> constructor
-      <;> (try apply Path.cons <;> tauto)
-      <;> apply Path.cons
+      <;> (try apply IsPath.cons <;> tauto)
+      <;> apply IsPath.cons
     · use .inl s₁
       trivial
     · rwa [← plus_embed_left]
@@ -233,55 +233,55 @@ lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.acc
     · rwa [← plus_embed_right]
 
 lemma comp_one_way (s : Q.St) (t : P.St) (x : List (Option α)) :
-    ¬(comp P Q).toεNFA.Path (.inr s) (.inl t) x := by
+    ¬(comp P Q).toεNFA.IsPath (.inr s) (.inl t) x := by
   intro h
   induction x generalizing s <;> cases' h with _ s _ _ _ _ hs
   obtain ⟨_, _, ⟨⟩⟩ := hs
   tauto
 
 lemma comp_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
-    P.toεNFA.Path s₁ s₂ x ↔ (comp P Q).toεNFA.Path (.inl s₁) (.inl s₂) x := by
+    P.toεNFA.IsPath s₁ s₂ x ↔ (comp P Q).toεNFA.IsPath (.inl s₁) (.inl s₂) x := by
   induction' x with _ _ ih generalizing s₁
     <;> constructor
     <;> intro h
     <;> cases' h with _ s _ _ _ _ hs h
-    <;> (try apply Path.nil)
-  · apply Path.cons
+    <;> (try apply IsPath.nil)
+  · apply IsPath.cons
     · left
       use s
     · rwa [← ih]
   · obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, _⟩ := hs
-    · apply Path.cons <;> (try rw [ih]) <;> assumption
+    · apply IsPath.cons <;> (try rw [ih]) <;> assumption
     · apply comp_one_way at h
       contradiction
 
 lemma comp_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
-    Q.toεNFA.Path s₁ s₂ x ↔ (comp P Q).toεNFA.Path (.inr s₁) (.inr s₂) x := by
+    Q.toεNFA.IsPath s₁ s₂ x ↔ (comp P Q).toεNFA.IsPath (.inr s₁) (.inr s₂) x := by
   induction' x with _ _ ih generalizing s₁
     <;> constructor
     <;> intro h
     <;> cases' h with _ s _ _ _ _ hs h
-    <;> (try apply Path.nil)
-  · apply Path.cons
+    <;> (try apply IsPath.nil)
+  · apply IsPath.cons
     · use s
     · rwa [← ih]
   · obtain ⟨_, _, ⟨⟩⟩ := hs
-    apply Path.cons <;> (try rw [ih]) <;> assumption
+    apply IsPath.cons <;> (try rw [ih]) <;> assumption
 
 lemma comp_split (s₁₁ : P.St) (s₂₂ : Q.St) (x : List (Option α)) :
-    (comp P Q).toεNFA.Path (.inl s₁₁) (.inr s₂₂) x →
+    (comp P Q).toεNFA.IsPath (.inl s₁₁) (.inr s₂₂) x →
       ∃ s₁₂ s₂₁ x₁ x₂,
         x = x₁ ++ none :: x₂ ∧
         s₁₂ ∈ P.toεNFA.accept ∧
         s₂₁ ∈ Q.toεNFA.start ∧
-        (comp P Q).toεNFA.Path (.inl s₁₁) (.inl s₁₂) x₁ ∧
-        (comp P Q).toεNFA.Path (.inr s₂₁) (.inr s₂₂) x₂ := by
+        (comp P Q).toεNFA.IsPath (.inl s₁₁) (.inl s₁₂) x₁ ∧
+        (comp P Q).toεNFA.IsPath (.inr s₂₁) (.inr s₂₂) x₂ := by
   intro h
   cases' x with a x
-  · apply Path_nil_eq at h
+  · apply IsPath.eq_of_nil at h
     contradiction
   · induction' x with b x ih generalizing s₁₁ a <;> cases' h with _ s _ _ _ _ hs h
-    · apply Path_nil_eq at h
+    · apply IsPath.eq_of_nil at h
       subst s
       obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, ⟨⟩, _⟩ := hs
       use s₁₁, s₂₂, [], []
@@ -296,14 +296,14 @@ lemma comp_split (s₁₁ : P.St) (s₂₂ : Q.St) (x : List (Option α)) :
 lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.accepts := by
   ext x
   constructor <;> intro h
-  · rw [accepts_Path_iff] at h
+  · rw [mem_accepts_iff_exists_path] at h
     obtain ⟨_, _, _, ⟨s₁₁, _, ⟨⟩⟩, ⟨s₂₂, _, ⟨⟩⟩, ⟨⟩, h⟩ := h
     apply comp_split at h
     obtain ⟨s₁₂, s₂₁, x₁, x₂, ⟨⟩, _, _, h₁, h₂⟩ := h
     rw [← comp_embed_left] at h₁
     rw [← comp_embed_right] at h₂
     rw [Language.mem_mul]
-    simp_rw [accepts_Path_iff]
+    simp_rw [mem_accepts_iff_exists_path]
     use x₁.reduceOption
     constructor
     · use s₁₁, s₁₂, x₁
@@ -313,18 +313,18 @@ lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.
       · rw [reduceOption_append, reduceOption_cons_of_none]
   · rw [Language.mem_mul] at h
     obtain ⟨x₁, h₁, x₂, h₂, ⟨⟩⟩ := h
-    rw [accepts_Path_iff] at *
+    rw [mem_accepts_iff_exists_path] at *
     obtain ⟨s₁₁, s₁₂, x₁', _, _, _, _⟩ := h₁
     obtain ⟨_, s₂₂, x₂', _, _, _, _⟩ := h₂
     substs x₁ x₂
     use .inl s₁₁, .inr s₂₂, x₁' ++ none :: x₂'
     split_ands <;> try tauto
     · rw [reduceOption_append, reduceOption_cons_of_none]
-    · rw [Path_append_iff]
+    · rw [isPath_append]
       use .inl s₁₂
       constructor
       · rwa [← comp_embed_left]
-      · apply Path.cons
+      · apply IsPath.cons
         · right
           constructor <;> tauto
         · rwa [← comp_embed_right]
@@ -336,7 +336,7 @@ lemma step_accept_empty (s : P.St) : s ∈ P.toεNFA.accept → ∀ a, P.toεNFA
     <;> simp only [toεNFA, comp_step, comp_def, image_eq_empty]
     <;> tauto
 
-lemma accept_final (s : P.St) : s ∈ P.toεNFA.accept → ∀ t x, x ≠ [] → ¬P.toεNFA.Path s t x := by
+lemma accept_final (s : P.St) : s ∈ P.toεNFA.accept → ∀ t x, x ≠ [] → ¬P.toεNFA.IsPath s t x := by
   intro hs _ _ hx
   rw [ne_nil_iff_exists_cons] at hx
   obtain ⟨_, _, ⟨⟩⟩ := hx
@@ -346,26 +346,26 @@ lemma accept_final (s : P.St) : s ∈ P.toεNFA.accept → ∀ t x, x ≠ [] →
 
 -- N.B. This holds for any `P`, but only the `star P` case is needed.
 lemma star_no_restart (s : P.St) (x : List (Option α)) :
-    ¬(star P).toεNFA.Path (.inr s) (.inl .ini) x := by
+    ¬(star P).toεNFA.IsPath (.inr s) (.inl .ini) x := by
   intro h
   cases' x using reverseRecOn with x a
-  · apply Path_nil_eq at h
+  · apply IsPath.eq_of_nil at h
     contradiction
-  · simp_rw [Path_append_iff, Path_singleton_iff] at h
+  · simp_rw [isPath_append, isPath_singleton] at h
     obtain ⟨s, _, hs⟩ := h
     rcases s with ⟨_ | _⟩ | _ <;> cases a <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩, _⟩ := hs
 
 lemma star_cons (s : (star P).St) :
     s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept →
-      ∀ x, (star P).toεNFA.Path s (.inl .fin) x →
+      ∀ x, (star P).toεNFA.IsPath s (.inl .fin) x →
       ∃ t x',
         x = none :: x' ∧
         (t = .inl .fin ∨ t ∈ .inr '' P.toεNFA.start) ∧
-        (star P).toεNFA.Path t (.inl .fin) x' := by
+        (star P).toεNFA.IsPath t (.inl .fin) x' := by
   intro hs x h
   obtain ⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩ := hs
     <;> cases' x with a x
-    <;> (try apply Path_nil_eq at h)
+    <;> (try apply IsPath.eq_of_nil at h)
     <;> cases' h with _ s _ _ _ _ hs
     <;> use s, x
     <;> cases a
@@ -375,40 +375,40 @@ lemma star_cons (s : (star P).St) :
 
 lemma star_concat (s : (star P).St) :
     s ≠ .inl .fin →
-      ∀ x, (star P).toεNFA.Path s (.inl .fin) x →
+      ∀ x, (star P).toεNFA.IsPath s (.inl .fin) x →
       ∃ x', x = x' ++ [none] := by
   intro hs x h
   rcases eq_nil_or_concat' x with ⟨⟨⟩⟩ | ⟨x, a, ⟨⟩⟩
-  · apply Path_nil_eq at h
+  · apply IsPath.eq_of_nil at h
     contradiction
-  · simp_rw [Path_append_iff, Path_singleton_iff] at h
+  · simp_rw [isPath_append, isPath_singleton] at h
     obtain ⟨s, _, hs⟩ := h
     cases a
     · use x
     · rcases s with ⟨_ | _⟩ | _ <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨_, ⟨⟩, _⟩ := hs
 
 lemma star_end (s : (star P).St) :
-    s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept → (star P).toεNFA.Path s (.inl .fin) [none] := by
-  rw [Path_singleton_iff]
+    s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept → (star P).toεNFA.IsPath s (.inl .fin) [none] := by
+  rw [isPath_singleton]
   intro h
   rcases h with ⟨⟨⟩, _⟩ | ⟨_, _, ⟨⟩⟩ <;> (try right; constructor) <;> tauto
 
 lemma star_split (s₁ : P.St) (x : List (Option α)) :
-    (star P).toεNFA.Path (.inr s₁) (.inl .fin) x →
+    (star P).toεNFA.IsPath (.inr s₁) (.inl .fin) x →
       ∃ s₂ x₁ x',
         x = x₁ ++ x' ∧
         s₂ ∈ P.toεNFA.accept ∧
-        P.toεNFA.Path s₁ s₂ x₁ ∧
-        (star P).toεNFA.Path (.inr s₂) (.inl .fin) x' := by
+        P.toεNFA.IsPath s₁ s₂ x₁ ∧
+        (star P).toεNFA.IsPath (.inr s₂) (.inl .fin) x' := by
   intro h
   obtain ⟨x, ⟨⟩⟩ := star_concat _ (by tauto) _ h
-  simp_rw [Path_append_iff, Path_singleton_iff] at h
+  simp_rw [isPath_append, isPath_singleton] at h
   obtain ⟨t, h, ht⟩ := h
   rcases t with ⟨_ | _⟩ | t <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨_, _, _⟩ := ht
   · apply star_no_restart at h
     contradiction
   · induction' x with a x ih generalizing s₁
-    · apply Path_nil_eq at h
+    · apply IsPath.eq_of_nil at h
       cases h
       use t, [], [none]
       split_ands <;> (try apply star_end) <;> tauto
@@ -421,18 +421,18 @@ lemma star_split (s₁ : P.St) (x : List (Option α)) :
       · apply accept_final at h <;> trivial
       · use s₁, [], none :: x ++ [none]
         split_ands <;> (try rw [cons_append, nil_append]) <;> try tauto
-        · apply Path.cons
+        · apply IsPath.cons
           · right
             constructor
             · right
               solve_by_elim
             · trivial
-          · simp_rw [append_eq, Path_append_iff]
+          · simp_rw [append_eq, isPath_append]
             use .inr t
             split_ands <;> (try apply star_end) <;> tauto
 
 lemma star_parts (s : (star P).St) (x : List (Option α)) :
-    s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept → (star P).toεNFA.Path s (.inl .fin) x →
+    s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept → (star P).toεNFA.IsPath s (.inl .fin) x →
       ∃ xs : List (List α), x.reduceOption = xs.flatten ∧ ∀ y ∈ xs, y ∈ P.toεNFA.accepts := by
   intro hs h
   rcases star_cons _ hs _ h with ⟨_, _, ⟨⟩, ⟨⟨⟩⟩ | ⟨s₁, _, ⟨⟩⟩, h⟩
@@ -443,41 +443,41 @@ lemma star_parts (s : (star P).St) (x : List (Option α)) :
     obtain ⟨xs, hx, _⟩ := star_parts (.inr s₂) _ (by tauto) h'
     use x₁.reduceOption :: xs
     rw [reduceOption_cons_of_none, reduceOption_append, flatten_cons, hx]
-    have h₁ := (accepts_Path_iff _ _).mpr ⟨s₁, s₂, x₁, (by trivial)⟩
+    have h₁ := (mem_accepts_iff_exists_path _).mpr ⟨s₁, s₂, x₁, (by trivial)⟩
     constructor <;> (try intro _ hy; cases hy) <;> tauto
   termination_by x.length
 
 lemma star_embed (s₁ s₂ : P.St) (x : List (Option α)) :
-    P.toεNFA.Path s₁ s₂ x → (star P).toεNFA.Path (.inr s₁) (.inr s₂) x := by
-  induction' x generalizing s₁ <;> intro h <;> cases h <;> (try apply Path.cons; left) <;> tauto
+    P.toεNFA.IsPath s₁ s₂ x → (star P).toεNFA.IsPath (.inr s₁) (.inr s₂) x := by
+  induction' x generalizing s₁ <;> intro h <;> cases h <;> (try apply IsPath.cons; left) <;> tauto
 
 lemma star_accepts : (star P).toεNFA.accepts = P.toεNFA.accepts∗ := by
   ext x
   constructor <;> intro h
-  · rw [accepts_Path_iff] at h
+  · rw [mem_accepts_iff_exists_path] at h
     obtain ⟨_, _, x, ⟨⟩, ⟨⟩, ⟨⟩, h⟩ := h
     exact star_parts _ x (by tauto) h
   · rw [Language.mem_kstar] at h
     obtain ⟨xs, ⟨⟩, hs⟩ := h
-    rw [accepts_Path_iff]
+    rw [mem_accepts_iff_exists_path]
     use .inl .ini, .inl .fin
     induction' xs with _ _ ih
     · use [none]
-      split_ands <;> (try rw [Path_singleton_iff]; right) <;> rfl
+      split_ands <;> (try rw [isPath_singleton]; right) <;> rfl
     · simp only [forall_eq_or_imp, mem_cons] at hs
       obtain ⟨h₁, hs⟩ := hs
-      rw [accepts_Path_iff] at h₁
+      rw [mem_accepts_iff_exists_path] at h₁
       obtain ⟨_, s₁₂, x₁, _, _, ⟨⟩, _⟩ := h₁
       obtain ⟨_, _, _, hx₂, h₂⟩ := ih hs
       obtain ⟨_, x₂, ⟨⟩, hs₂₁, _⟩ := star_cons _ (by tauto) _ h₂
       use none :: x₁ ++ none :: x₂
       split_ands <;> try rfl
       · rw [reduceOption_append, reduceOption_cons_of_none, flatten_cons, hx₂]
-      · rw [Path_append_iff]
+      · rw [isPath_append]
         use .inr s₁₂
         constructor
           <;> rcases hs₂₁ with ⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩
-          <;> apply Path.cons
+          <;> apply IsPath.cons
           <;> (try assumption)
           <;> (try left; tauto)
           <;> (try right; constructor)

--- a/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
+++ b/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
@@ -1,0 +1,502 @@
+/-
+Copyright (c) 2024 Anthony DeRossi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anthony DeRossi
+-/
+import Mathlib.Computability.RegularExpressions
+import Mathlib.Computability.EpsilonNFA
+import Mathlib.Computability.Language
+
+/-!
+# Constructing Automata from Regular Expressions
+
+This file contains a formal definition of [Thompson's method][thompson1968] for constructing a
+nondeterministic finite automaton from a regular expression and a proof of its correctness.
+
+## Main definitions
+
+  * `RegularExpression.toεNFA`
+
+## References
+
+* [Ken Thompson, *Regular expression search algorithm*][thompson1968]
+
+-/
+
+open Computability List Set εNFA
+
+universe u v
+variable {α : Type u} {σ σ₁ σ₂ : Type v} {P Q : RegularExpression α}
+variable [DecidableEq α]
+
+namespace RegularExpression
+
+inductive BinSt where
+  | ini
+  | fin
+
+/-- The `εNFA` for `zero` has no transitions. -/
+def zero_step : Empty → Option α → Set Empty
+  | _, _ => ∅
+def zero_start : Set Empty := ∅
+def zero_accept : Set Empty := ∅
+
+/-- The `εNFA` for `epsilon` has only an ε-transition from the starting state to the accepting
+  state. -/
+def epsilon_step : BinSt → Option α → Set (BinSt)
+  | .ini, none => {.fin}
+  | _, _ => ∅
+def epsilon_start : Set (BinSt) := {.ini}
+def epsilon_accept : Set (BinSt) := {.fin}
+
+/-- The `εNFA` for `char a` has only an `a`-labeled transition from the starting state to the
+  accepting state. -/
+def char_step (a : α) : BinSt → Option α → Set (BinSt)
+  | .ini, some b => {s | s = .fin ∧ a = b}
+  | _, _ => ∅
+def char_start : Set (BinSt) := {.ini}
+def char_accept : Set (BinSt) := {.fin}
+
+/-- The `εNFA` for `plus P Q` is constructed using a sum type to embed left and right (from the
+  `εNFA`s for `P` and `Q` respectively) states. It has separate starting and accepting states, with
+  ε-transitions from the starting state to the embedded starting states, and from the embedded
+  accepting states to the accepting state. -/
+def plus_step (M₁ : εNFA α σ₁) (M₂ : εNFA α σ₂) : BinSt ⊕ σ₁ ⊕ σ₂ → Option α → Set (BinSt ⊕ σ₁ ⊕ σ₂)
+  | .inl .ini, none => .inr '' Sum.elim M₁.start M₂.start
+  | .inr (.inl s'), a => .inr ∘ .inl '' M₁.step s' a
+      ∪ {s | s = .inl .fin ∧ a = none ∧ s' ∈ M₁.accept}
+  | .inr (.inr s'), a => .inr ∘ .inr '' M₂.step s' a
+      ∪ {s | s = .inl .fin ∧ a = none ∧ s' ∈ M₂.accept}
+  | _, _ => ∅
+def plus_start : Set (BinSt ⊕ σ₁ ⊕ σ₂) := {.inl .ini}
+def plus_accept : Set (BinSt ⊕ σ₁ ⊕ σ₂) := {.inl .fin}
+
+/-- The `εNFA` for `comp P Q` is constructed using a sum type to embed left and right (from the
+  `εNFA`s for `P` and `Q` respectively) states. The starting and accepting states are the embedded
+  left-starting and right-accepting states respectively. An ε-transition exists between the embedded
+  left accepting and right starting states. -/
+def comp_step (M₁ : εNFA α σ₁) (M₂ : εNFA α σ₂) : σ₁ ⊕ σ₂ → Option α → Set (σ₁ ⊕ σ₂)
+  | .inl s', a => .inl '' M₁.step s' a ∪ {s | s ∈ .inr '' M₂.start ∧ a = none ∧ s' ∈ M₁.accept}
+  | .inr s', a => .inr '' M₂.step s' a
+def comp_start (M₁ : εNFA α σ₁) : Set (σ₁ ⊕ σ₂) := .inl '' M₁.start
+def comp_accept (M₂ : εNFA α σ₂) : Set (σ₁ ⊕ σ₂) := .inr '' M₂.accept
+
+/-- The `εNFA` for `star P` is constructed using a sum type to embed the `εNFA` for `P`, with
+  ε-transitions from the starting and accepting states to the respective embedded states. Additional
+  ε-transitions exist between the starting and accepting state (empty matching), and between the
+  embedded accepting and starting states (repetition). -/
+def star_step (M : εNFA α σ) : BinSt ⊕ σ → Option α → Set (BinSt ⊕ σ)
+  | .inl .ini, none => .inr '' M.start ∪ {.inl .fin}
+  | .inr s', a => .inr '' M.step s' a
+      ∪ {s | (s = .inl .fin ∨ s ∈ .inr '' M.start) ∧ a = none ∧ s' ∈ M.accept}
+  | _, _ => ∅
+def star_start : Set (BinSt ⊕ σ) := {.inl .ini}
+def star_accept : Set (BinSt ⊕ σ) := {.inl .fin}
+
+/-- The state type for the `εNFA` constructed by `toεNFA` -/
+def St : RegularExpression α → Type
+  | 0 => Empty
+  | 1 => BinSt
+  | char _ => BinSt
+  | P + Q => BinSt ⊕ St P ⊕ St Q
+  | comp P Q => St P ⊕ St Q
+  | star P => BinSt ⊕ St P
+
+/-- Construct an `εNFA` from a `RegularExpression` -/
+def toεNFA [DecidableEq α] : (P : RegularExpression α) → εNFA α P.St
+  | 0 => ⟨zero_step, zero_start, zero_accept⟩
+  | 1 => ⟨epsilon_step, epsilon_start, epsilon_accept⟩
+  | char a => ⟨char_step a, char_start, char_accept⟩
+  | P + Q => ⟨plus_step P.toεNFA Q.toεNFA, plus_start, plus_accept⟩
+  | comp P Q => ⟨comp_step P.toεNFA Q.toεNFA, comp_start P.toεNFA, comp_accept Q.toεNFA⟩
+  | star P => ⟨star_step P.toεNFA, star_start, star_accept⟩
+
+lemma zero_accepts : zero.toεNFA.accepts = (0 : Language α) := by
+  simp only [accepts, toεNFA, zero_accept, exists_false, false_and, mem_empty_iff_false]
+  rfl
+
+lemma epsilon_accepts : epsilon.toεNFA.accepts = (1 : Language α) := by
+  ext x
+  constructor <;> intro h <;> rw [accepts_Path_iff] at *
+  · obtain ⟨s₁, s₂, _, _, _, _, h⟩ := h
+    substs x s₁ s₂
+    rw [Language.one_def, mem_singleton_iff, reduceOption_eq_nil_replicate_iff]
+    use 1
+    cases' h with _ _ _ _ a _ hs h
+    cases a <;> cases hs
+    cases h <;> trivial
+  · subst x
+    use .ini, .fin, [none]
+    repeat constructor
+
+lemma char_accepts (a : α) : (char a).toεNFA.accepts = {[a]} := by
+  ext x
+  constructor <;> intro h <;> rw [accepts_Path_iff] at *
+  · obtain ⟨s₁, s₂, _, _, _, _, h⟩ := h
+    substs x s₁ s₂
+    rw [mem_singleton_iff, reduceOption_eq_singleton_replicate_iff]
+    use 0, 0
+    cases' h with _ _ _ _ a _ hs h
+    cases a <;> cases hs
+    cases h <;> subst_eqs <;> trivial
+  · subst x
+    use .ini, .fin, [a]
+    repeat constructor
+
+lemma plus_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
+    P.toεNFA.Path s₁ s₂ x ↔ (P + Q).toεNFA.Path (.inr (.inl s₁)) (.inr (.inl s₂)) x := by
+  induction' x with _ _ ih generalizing s₁
+    <;> constructor
+    <;> intro h
+    <;> cases' h with _ s _ _ _ _ hs h
+    <;> (try apply Path.nil)
+  · apply Path.cons
+    · left
+      use s
+    · rwa [Function.comp_apply, ← ih]
+  · cases s <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩ := hs
+    · cases' h with _ s _ _ a _ hs
+      cases a <;> cases hs
+    · apply Path.cons <;> (try rw [ih]) <;> assumption
+
+lemma plus_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
+    Q.toεNFA.Path s₁ s₂ x ↔ (P + Q).toεNFA.Path (.inr (.inr s₁)) (.inr (.inr s₂)) x := by
+  induction' x with _ _ ih generalizing s₁
+    <;> constructor
+    <;> intro h
+    <;> cases' h with _ s _ _ _ _ hs h
+    <;> (try apply Path.nil)
+  · apply Path.cons
+    · left
+      use s
+    · rwa [Function.comp_apply, ← ih]
+  · cases s <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩ := hs
+    · cases' h with _ s _ _ a _ hs
+      cases a <;> cases hs
+    · apply Path.cons <;> (try rw [ih]) <;> assumption
+
+lemma plus_no_cross_left (s : P.St) (t : Q.St) (x : List (Option α)) :
+    ¬(P + Q).toεNFA.Path (.inr (.inl s)) (.inr (.inr t)) x := by
+  intro h
+  induction x generalizing s <;> cases' h with _ s _ _ _ _ hs
+  obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩ := hs <;> tauto
+
+lemma plus_no_cross_right (s : Q.St) (t : P.St) (x : List (Option α)) :
+    ¬(P + Q).toεNFA.Path (.inr (.inr s)) (.inr (.inl t)) x := by
+  intro h
+  induction x generalizing s <;> cases' h with _ s _ _ _ _ hs
+  obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩ := hs <;> tauto
+
+lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.accepts := by
+  ext x
+  constructor <;> intro h <;> rw [accepts_Path_iff] at *
+  · obtain ⟨s₁, s₂, _, _, _, _, h⟩ := h
+    substs x s₁ s₂
+    cases' h with _ s _ _ a x hs h
+    cases a <;> obtain ⟨_ | _, hs, ⟨⟩⟩ := hs
+      <;> [left; right]
+      <;> rcases eq_nil_or_concat x with ⟨⟨⟩⟩ | ⟨_, a, ⟨⟩⟩
+      <;> (try apply Path_nil_eq at h; contradiction)
+      <;> simp_rw [concat_eq_append, Path_append_iff, Path_singleton_iff] at h
+      <;> rcases h with ⟨⟨_ | _⟩ | ⟨_ | _⟩, h, hs⟩
+      <;> (try apply plus_no_cross_left at h)
+      <;> (try apply plus_no_cross_right at h)
+      <;> (try contradiction)
+      <;> (try cases a <;> obtain ⟨_, _, ⟨⟩⟩ := hs; done)
+      <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨_, ⟨⟩, _⟩ := hs
+      <;> rw [reduceOption_cons_of_none, reduceOption_concat, Option.toList_none, append_nil,
+            accepts_Path_iff]
+    · rw [← plus_embed_left] at h
+      tauto
+    · rw [← plus_embed_right] at h
+      tauto
+  · use .inl .ini, .inl .fin
+    rcases h with h | h
+      <;> rw [accepts_Path_iff] at h
+      <;> obtain ⟨s₁, s₂, x', _, _, _, _⟩ := h
+      <;> subst x
+      <;> use none :: x' ++ [none]
+      <;> simp only [reduceOption_append, reduceOption_cons_of_none, reduceOption_nil, append_nil]
+      <;> split_ands
+      <;> (try trivial)
+      <;> rw [Path_append_iff]
+      <;> [use .inr (.inl s₂); use .inr (.inr s₂)]
+      <;> constructor
+      <;> (try apply Path.cons <;> tauto)
+      <;> apply Path.cons
+    · use .inl s₁
+      trivial
+    · rwa [← plus_embed_left]
+    · use .inr s₁
+      trivial
+    · rwa [← plus_embed_right]
+
+lemma comp_one_way (s : Q.St) (t : P.St) (x : List (Option α)) :
+    ¬(comp P Q).toεNFA.Path (.inr s) (.inl t) x := by
+  intro h
+  induction x generalizing s <;> cases' h with _ s _ _ _ _ hs
+  obtain ⟨_, _, ⟨⟩⟩ := hs
+  tauto
+
+lemma comp_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
+    P.toεNFA.Path s₁ s₂ x ↔ (comp P Q).toεNFA.Path (.inl s₁) (.inl s₂) x := by
+  induction' x with _ _ ih generalizing s₁
+    <;> constructor
+    <;> intro h
+    <;> cases' h with _ s _ _ _ _ hs h
+    <;> (try apply Path.nil)
+  · apply Path.cons
+    · left
+      use s
+    · rwa [← ih]
+  · obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, _⟩ := hs
+    · apply Path.cons <;> (try rw [ih]) <;> assumption
+    · apply comp_one_way at h
+      contradiction
+
+lemma comp_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
+    Q.toεNFA.Path s₁ s₂ x ↔ (comp P Q).toεNFA.Path (.inr s₁) (.inr s₂) x := by
+  induction' x with _ _ ih generalizing s₁
+    <;> constructor
+    <;> intro h
+    <;> cases' h with _ s _ _ _ _ hs h
+    <;> (try apply Path.nil)
+  · apply Path.cons
+    · use s
+    · rwa [← ih]
+  · obtain ⟨_, _, ⟨⟩⟩ := hs
+    apply Path.cons <;> (try rw [ih]) <;> assumption
+
+lemma comp_split (s₁₁ : P.St) (s₂₂ : Q.St) (x : List (Option α)) :
+    (comp P Q).toεNFA.Path (.inl s₁₁) (.inr s₂₂) x →
+      ∃ s₁₂ s₂₁ x₁ x₂,
+        x = x₁ ++ none :: x₂ ∧
+        s₁₂ ∈ P.toεNFA.accept ∧
+        s₂₁ ∈ Q.toεNFA.start ∧
+        (comp P Q).toεNFA.Path (.inl s₁₁) (.inl s₁₂) x₁ ∧
+        (comp P Q).toεNFA.Path (.inr s₂₁) (.inr s₂₂) x₂ := by
+  intro h
+  cases' x with a x
+  · apply Path_nil_eq at h
+    contradiction
+  · induction' x with b x ih generalizing s₁₁ a <;> cases' h with _ s _ _ _ _ hs h
+    · apply Path_nil_eq at h
+      subst s
+      obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, ⟨⟩, _⟩ := hs
+      use s₁₁, s₂₂, [], []
+      tauto
+    · cases' s with _ s
+      · obtain ⟨s₁₂, s₂₁, x₁, x₂, _⟩ := ih _ _ h
+        use s₁₂, s₂₁, a :: x₁, x₂
+        tauto
+      · use s₁₁, s, [], b :: x
+        split_ands <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, ⟨⟩, _⟩ <;> tauto
+
+lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.accepts := by
+  ext x
+  constructor <;> intro h
+  · rw [accepts_Path_iff] at h
+    obtain ⟨_, _, _, ⟨s₁₁, _, ⟨⟩⟩, ⟨s₂₂, _, ⟨⟩⟩, ⟨⟩, h⟩ := h
+    apply comp_split at h
+    obtain ⟨s₁₂, s₂₁, x₁, x₂, ⟨⟩, _, _, h₁, h₂⟩ := h
+    rw [← comp_embed_left] at h₁
+    rw [← comp_embed_right] at h₂
+    rw [Language.mem_mul]
+    simp_rw [accepts_Path_iff]
+    use x₁.reduceOption
+    constructor
+    · use s₁₁, s₁₂, x₁
+    · use x₂.reduceOption
+      constructor
+      · use s₂₁, s₂₂, x₂
+      · rw [reduceOption_append, reduceOption_cons_of_none]
+  · rw [Language.mem_mul] at h
+    obtain ⟨x₁, h₁, x₂, h₂, ⟨⟩⟩ := h
+    rw [accepts_Path_iff] at *
+    obtain ⟨s₁₁, s₁₂, x₁', _, _, _, _⟩ := h₁
+    obtain ⟨_, s₂₂, x₂', _, _, _, _⟩ := h₂
+    substs x₁ x₂
+    use .inl s₁₁, .inr s₂₂, x₁' ++ none :: x₂'
+    split_ands <;> try tauto
+    · rw [reduceOption_append, reduceOption_cons_of_none]
+    · rw [Path_append_iff]
+      use .inl s₁₂
+      constructor
+      · rwa [← comp_embed_left]
+      · apply Path.cons
+        · right
+          constructor <;> tauto
+        · rwa [← comp_embed_right]
+
+lemma step_accept_empty (s : P.St) : s ∈ P.toεNFA.accept → ∀ a, P.toεNFA.step s a = ∅ := by
+  intro hs
+  induction P
+    <;> rcases hs with ⟨_, _, ⟨⟩⟩
+    <;> simp only [toεNFA, comp_step, comp_def, image_eq_empty]
+    <;> tauto
+
+lemma accept_final (s : P.St) : s ∈ P.toεNFA.accept → ∀ t x, x ≠ [] → ¬P.toεNFA.Path s t x := by
+  intro hs _ _ hx
+  rw [ne_nil_iff_exists_cons] at hx
+  obtain ⟨_, _, ⟨⟩⟩ := hx
+  intro h
+  cases' h with _ _ _ _ _ _ hs'
+  rw [step_accept_empty] at hs' <;> assumption
+
+-- N.B. This holds for any `P`, but only the `star P` case is needed.
+lemma star_no_restart (s : P.St) (x : List (Option α)) :
+    ¬(star P).toεNFA.Path (.inr s) (.inl .ini) x := by
+  intro h
+  cases' x using reverseRecOn with x a
+  · apply Path_nil_eq at h
+    contradiction
+  · simp_rw [Path_append_iff, Path_singleton_iff] at h
+    obtain ⟨s, _, hs⟩ := h
+    rcases s with ⟨_ | _⟩ | _ <;> cases a <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩, _⟩ := hs
+
+lemma star_cons (s : (star P).St) :
+    s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept →
+      ∀ x, (star P).toεNFA.Path s (.inl .fin) x →
+      ∃ t x',
+        x = none :: x' ∧
+        (t = .inl .fin ∨ t ∈ .inr '' P.toεNFA.start) ∧
+        (star P).toεNFA.Path t (.inl .fin) x' := by
+  intro hs x h
+  obtain ⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩ := hs
+    <;> cases' x with a x
+    <;> (try apply Path_nil_eq at h)
+    <;> cases' h with _ s _ _ _ _ hs
+    <;> use s, x
+    <;> cases a
+    <;> obtain ⟨_, hs, ⟨⟩⟩ | ⟨⟨⟩⟩ := hs
+    <;> (try rw [step_accept_empty] at hs)
+    <;> tauto
+
+lemma star_concat (s : (star P).St) :
+    s ≠ .inl .fin →
+      ∀ x, (star P).toεNFA.Path s (.inl .fin) x →
+      ∃ x', x = x' ++ [none] := by
+  intro hs x h
+  rcases eq_nil_or_concat' x with ⟨⟨⟩⟩ | ⟨x, a, ⟨⟩⟩
+  · apply Path_nil_eq at h
+    contradiction
+  · simp_rw [Path_append_iff, Path_singleton_iff] at h
+    obtain ⟨s, _, hs⟩ := h
+    cases a
+    · use x
+    · rcases s with ⟨_ | _⟩ | _ <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨_, ⟨⟩, _⟩ := hs
+
+lemma star_end (s : (star P).St) :
+    s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept → (star P).toεNFA.Path s (.inl .fin) [none] := by
+  rw [Path_singleton_iff]
+  intro h
+  rcases h with ⟨⟨⟩, _⟩ | ⟨_, _, ⟨⟩⟩ <;> (try right; constructor) <;> tauto
+
+lemma star_split (s₁ : P.St) (x : List (Option α)) :
+    (star P).toεNFA.Path (.inr s₁) (.inl .fin) x →
+      ∃ s₂ x₁ x',
+        x = x₁ ++ x' ∧
+        s₂ ∈ P.toεNFA.accept ∧
+        P.toεNFA.Path s₁ s₂ x₁ ∧
+        (star P).toεNFA.Path (.inr s₂) (.inl .fin) x' := by
+  intro h
+  obtain ⟨x, ⟨⟩⟩ := star_concat _ (by tauto) _ h
+  simp_rw [Path_append_iff, Path_singleton_iff] at h
+  obtain ⟨t, h, ht⟩ := h
+  rcases t with ⟨_ | _⟩ | t <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨_, _, _⟩ := ht
+  · apply star_no_restart at h
+    contradiction
+  · induction' x with a x ih generalizing s₁
+    · apply Path_nil_eq at h
+      cases h
+      use t, [], [none]
+      split_ands <;> (try apply star_end) <;> tauto
+    · cases' h with _ s _ _ _ _ hs h
+      rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩, _, _⟩
+      · apply ih at h
+        obtain ⟨s₂, x₁, x', _, _, _, _⟩ := h
+        use s₂, a :: x₁, x'
+        split_ands <;> (try rw [cons_append]) <;> tauto
+      · apply accept_final at h <;> trivial
+      · use s₁, [], none :: x ++ [none]
+        split_ands <;> (try rw [cons_append, nil_append]) <;> try tauto
+        · apply Path.cons
+          · right
+            constructor
+            · right
+              solve_by_elim
+            · trivial
+          · simp_rw [append_eq, Path_append_iff]
+            use .inr t
+            split_ands <;> (try apply star_end) <;> tauto
+
+lemma star_parts (s : (star P).St) (x : List (Option α)) :
+    s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept → (star P).toεNFA.Path s (.inl .fin) x →
+      ∃ xs : List (List α), x.reduceOption = xs.flatten ∧ ∀ y ∈ xs, y ∈ P.toεNFA.accepts := by
+  intro hs h
+  rcases star_cons _ hs _ h with ⟨_, _, ⟨⟩, ⟨⟨⟩⟩ | ⟨s₁, _, ⟨⟩⟩, h⟩
+  · use []
+    rw [reduceOption_cons_of_none, flatten_nil]
+    cases h <;> tauto
+  · obtain ⟨s₂, x₁, _, ⟨⟩, _, _, h'⟩ := star_split _ _ h
+    obtain ⟨xs, hx, _⟩ := star_parts (.inr s₂) _ (by tauto) h'
+    use x₁.reduceOption :: xs
+    rw [reduceOption_cons_of_none, reduceOption_append, flatten_cons, hx]
+    have h₁ := (accepts_Path_iff _ _).mpr ⟨s₁, s₂, x₁, (by trivial)⟩
+    constructor <;> (try intro _ hy; cases hy) <;> tauto
+  termination_by x.length
+
+lemma star_embed (s₁ s₂ : P.St) (x : List (Option α)) :
+    P.toεNFA.Path s₁ s₂ x → (star P).toεNFA.Path (.inr s₁) (.inr s₂) x := by
+  induction' x generalizing s₁ <;> intro h <;> cases h <;> (try apply Path.cons; left) <;> tauto
+
+lemma star_accepts : (star P).toεNFA.accepts = P.toεNFA.accepts∗ := by
+  ext x
+  constructor <;> intro h
+  · rw [accepts_Path_iff] at h
+    obtain ⟨_, _, x, ⟨⟩, ⟨⟩, ⟨⟩, h⟩ := h
+    exact star_parts _ x (by tauto) h
+  · rw [Language.mem_kstar] at h
+    obtain ⟨xs, ⟨⟩, hs⟩ := h
+    rw [accepts_Path_iff]
+    use .inl .ini, .inl .fin
+    induction' xs with _ _ ih
+    · use [none]
+      split_ands <;> (try rw [Path_singleton_iff]; right) <;> rfl
+    · simp only [forall_eq_or_imp, mem_cons] at hs
+      obtain ⟨h₁, hs⟩ := hs
+      rw [accepts_Path_iff] at h₁
+      obtain ⟨_, s₁₂, x₁, _, _, ⟨⟩, _⟩ := h₁
+      obtain ⟨_, _, _, hx₂, h₂⟩ := ih hs
+      obtain ⟨_, x₂, ⟨⟩, hs₂₁, _⟩ := star_cons _ (by tauto) _ h₂
+      use none :: x₁ ++ none :: x₂
+      split_ands <;> try rfl
+      · rw [reduceOption_append, reduceOption_cons_of_none, flatten_cons, hx₂]
+      · rw [Path_append_iff]
+        use .inr s₁₂
+        constructor
+          <;> rcases hs₂₁ with ⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩
+          <;> apply Path.cons
+          <;> (try assumption)
+          <;> (try left; tauto)
+          <;> (try right; constructor)
+          <;> (try apply star_embed)
+          <;> tauto
+
+theorem toεNFA_correct (P : RegularExpression α) :
+    P.toεNFA.accepts = P.matches' := by
+  induction P with
+  | zero => exact zero_accepts
+  | epsilon => exact epsilon_accepts
+  | char a => exact char_accepts a
+  | plus P Q hP hQ =>
+    rw [plus_def, matches'_add, ← hP, ← hQ]
+    exact plus_accepts
+  | comp P Q hP hQ =>
+    rw [comp_def, matches'_mul, ← hP, ← hQ]
+    exact comp_accepts
+  | star P hP =>
+    rw [matches'_star, ← hP]
+    exact star_accepts
+
+end RegularExpression

--- a/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
+++ b/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
@@ -112,11 +112,11 @@ def toεNFA : (P : RegularExpression α) → εNFA α P.St
   | comp P Q => ⟨comp_step P.toεNFA Q.toεNFA, comp_start P.toεNFA, comp_accept Q.toεNFA⟩
   | star P => ⟨star_step P.toεNFA, star_start, star_accept⟩
 
-lemma zero_accepts : zero.toεNFA.accepts = (0 : Language α) := by
+private lemma zero_accepts : zero.toεNFA.accepts = (0 : Language α) := by
   simp only [accepts, toεNFA, zero_accept, exists_false, false_and, mem_empty_iff_false]
   rfl
 
-lemma epsilon_accepts : epsilon.toεNFA.accepts = (1 : Language α) := by
+private lemma epsilon_accepts : epsilon.toεNFA.accepts = (1 : Language α) := by
   ext x
   constructor <;> rw [mem_accepts_iff_exists_path]
   · rintro ⟨s₁, s₂, x', rfl, _, rfl, h⟩
@@ -127,7 +127,7 @@ lemma epsilon_accepts : epsilon.toεNFA.accepts = (1 : Language α) := by
     use .ini, .fin, [none]
     repeat constructor
 
-lemma char_accepts (a : α) : (char a).toεNFA.accepts = {[a]} := by
+private lemma char_accepts (a : α) : (char a).toεNFA.accepts = {[a]} := by
   ext x
   constructor <;> rw [mem_accepts_iff_exists_path]
   · rintro ⟨s₁, s₂, x', rfl, _, rfl, h⟩
@@ -138,7 +138,7 @@ lemma char_accepts (a : α) : (char a).toεNFA.accepts = {[a]} := by
     use .ini, .fin, [a]
     repeat constructor
 
-lemma plus_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
+private lemma plus_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
     P.toεNFA.IsPath s₁ s₂ x ↔ (P + Q).toεNFA.IsPath (.inr (.inl s₁)) (.inr (.inl s₂)) x := by
   induction' x with a x ih generalizing s₁
     <;> constructor
@@ -152,7 +152,7 @@ lemma plus_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
     · rcases h with _ | ⟨_, _, _, ⟨⟩, _, ⟨⟩⟩
     · apply IsPath.cons <;> (try rw [ih]) <;> assumption
 
-lemma plus_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
+private lemma plus_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
     Q.toεNFA.IsPath s₁ s₂ x ↔ (P + Q).toεNFA.IsPath (.inr (.inr s₁)) (.inr (.inr s₂)) x := by
   induction' x with a x ih generalizing s₁
     <;> constructor
@@ -166,15 +166,15 @@ lemma plus_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
     · rcases h with _ | ⟨_, _, _, ⟨⟩, _, ⟨⟩⟩
     · apply IsPath.cons <;> (try rw [ih]) <;> assumption
 
-lemma plus_no_cross_left (s : P.St) (t : Q.St) (x : List (Option α)) :
+private lemma plus_no_cross_left (s : P.St) (t : Q.St) (x : List (Option α)) :
     ¬(P + Q).toεNFA.IsPath (.inr (.inl s)) (.inr (.inr t)) x := by
   induction x generalizing s <;> rintro (_ | ⟨_, _, _, _, _, ⟨_, _, rfl⟩ | ⟨rfl, _⟩⟩) <;> tauto
 
-lemma plus_no_cross_right (s : Q.St) (t : P.St) (x : List (Option α)) :
+private lemma plus_no_cross_right (s : Q.St) (t : P.St) (x : List (Option α)) :
     ¬(P + Q).toεNFA.IsPath (.inr (.inr s)) (.inr (.inl t)) x := by
   induction x generalizing s <;> rintro (_ | ⟨_, _, _, _, _, ⟨_, _, rfl⟩ | ⟨rfl, _⟩⟩) <;> tauto
 
-lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.accepts := by
+private lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.accepts := by
   ext x
   constructor <;> rw [mem_accepts_iff_exists_path]
   · rintro ⟨s₁, s₂, x', rfl, rfl, rfl, h⟩
@@ -216,12 +216,12 @@ lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.acc
       trivial
     · rwa [← plus_embed_right]
 
-lemma comp_one_way (s : Q.St) (t : P.St) (x : List (Option α)) :
+private lemma comp_one_way (s : Q.St) (t : P.St) (x : List (Option α)) :
     ¬(comp P Q).toεNFA.IsPath (.inr s) (.inl t) x := by
   induction x generalizing s <;> rintro (_ | ⟨_, _, _, _, _, ⟨_, _, rfl⟩⟩)
   tauto
 
-lemma comp_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
+private lemma comp_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
     P.toεNFA.IsPath s₁ s₂ x ↔ (comp P Q).toεNFA.IsPath (.inl s₁) (.inl s₂) x := by
   induction' x with a x ih generalizing s₁
     <;> constructor
@@ -236,7 +236,7 @@ lemma comp_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
     · apply comp_one_way at h
       contradiction
 
-lemma comp_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
+private lemma comp_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
     Q.toεNFA.IsPath s₁ s₂ x ↔ (comp P Q).toεNFA.IsPath (.inr s₁) (.inr s₂) x := by
   induction' x with _ _ ih generalizing s₁
     <;> constructor
@@ -248,7 +248,7 @@ lemma comp_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
   · rcases hs with ⟨_, _, rfl⟩
     apply IsPath.cons <;> (try rw [ih]) <;> assumption
 
-lemma comp_split (s₁₁ : P.St) (s₂₂ : Q.St) (x : List (Option α)) :
+private lemma comp_split (s₁₁ : P.St) (s₂₂ : Q.St) (x : List (Option α)) :
     (comp P Q).toεNFA.IsPath (.inl s₁₁) (.inr s₂₂) x →
       ∃ s₁₂ s₂₁ x₁ x₂,
         x = x₁ ++ none :: x₂ ∧
@@ -273,7 +273,7 @@ lemma comp_split (s₁₁ : P.St) (s₂₂ : Q.St) (x : List (Option α)) :
       · use s₁₁, s, [], b :: x
         split_ands <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, rfl, _⟩ <;> tauto
 
-lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.accepts := by
+private lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.accepts := by
   ext x
   constructor
   · rw [mem_accepts_iff_exists_path]
@@ -308,19 +308,20 @@ lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.
           constructor <;> tauto
         · rwa [← comp_embed_right]
 
-lemma step_accept_empty (s : P.St) : s ∈ P.toεNFA.accept → ∀ a, P.toεNFA.step s a = ∅ := by
+private lemma step_accept_empty (s : P.St) : s ∈ P.toεNFA.accept → ∀ a, P.toεNFA.step s a = ∅ := by
   induction P
     <;> rintro ⟨_, _, rfl⟩
     <;> simp only [toεNFA, comp_step, comp_def, image_eq_empty]
     <;> tauto
 
-lemma accept_final (s : P.St) : s ∈ P.toεNFA.accept → ∀ t x, x ≠ [] → ¬P.toεNFA.IsPath s t x := by
+private lemma accept_final (s : P.St) :
+    s ∈ P.toεNFA.accept → ∀ t x, x ≠ [] → ¬P.toεNFA.IsPath s t x := by
   simp_rw [ne_nil_iff_exists_cons]
   rintro _ _ _ ⟨_, _, rfl⟩ (_ | ⟨_, _, _, _, _, hs⟩)
   rw [step_accept_empty] at hs <;> assumption
 
 -- N.B. This holds for any `P`, but only the `star P` case is needed.
-lemma star_no_restart (s : P.St) (x : List (Option α)) :
+private lemma star_no_restart (s : P.St) (x : List (Option α)) :
     ¬(star P).toεNFA.IsPath (.inr s) (.inl .ini) x := by
   intro h
   cases' x using reverseRecOn with x a
@@ -330,7 +331,7 @@ lemma star_no_restart (s : P.St) (x : List (Option α)) :
     obtain ⟨s, _, hs⟩ := h
     rcases s with ⟨_ | _⟩ | _ <;> cases a <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩, _⟩
 
-lemma star_cons (s : (star P).St) :
+private lemma star_cons (s : (star P).St) :
     s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept →
       ∀ x, (star P).toεNFA.IsPath s (.inl .fin) x →
       ∃ t x',
@@ -348,7 +349,7 @@ lemma star_cons (s : (star P).St) :
     <;> (try rw [step_accept_empty] at hs)
     <;> tauto
 
-lemma star_concat (s : (star P).St) :
+private lemma star_concat (s : (star P).St) :
     s ≠ .inl .fin →
       ∀ x, (star P).toεNFA.IsPath s (.inl .fin) x →
       ∃ x', x = x' ++ [none] := by
@@ -362,12 +363,12 @@ lemma star_concat (s : (star P).St) :
     · use x
     · rcases s with ⟨_ | _⟩ | _ <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨_, ⟨⟩, _⟩
 
-lemma star_end (s : (star P).St) :
+private lemma star_end (s : (star P).St) :
     s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept → (star P).toεNFA.IsPath s (.inl .fin) [none] := by
   rw [isPath_singleton]
   rintro (⟨rfl, _⟩ | ⟨_, _, rfl⟩) <;> (try right; constructor) <;> tauto
 
-lemma star_split (s₁ : P.St) (x : List (Option α)) :
+private lemma star_split (s₁ : P.St) (x : List (Option α)) :
     (star P).toεNFA.IsPath (.inr s₁) (.inl .fin) x →
       ∃ s₂ x₁ x',
         x = x₁ ++ x' ∧
@@ -403,7 +404,7 @@ lemma star_split (s₁ : P.St) (x : List (Option α)) :
             use .inr t
             split_ands <;> (try apply star_end) <;> tauto
 
-lemma star_parts (s : (star P).St) (x : List (Option α)) :
+private lemma star_parts (s : (star P).St) (x : List (Option α)) :
     s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept → (star P).toεNFA.IsPath s (.inl .fin) x →
       ∃ xs : List (List α), x.reduceOption = xs.flatten ∧ ∀ y ∈ xs, y ∈ P.toεNFA.accepts := by
   intro hs h
@@ -419,11 +420,11 @@ lemma star_parts (s : (star P).St) (x : List (Option α)) :
     constructor <;> (try intro _ hy; cases hy) <;> tauto
   termination_by x.length
 
-lemma star_embed (s₁ s₂ : P.St) (x : List (Option α)) :
+private lemma star_embed (s₁ s₂ : P.St) (x : List (Option α)) :
     P.toεNFA.IsPath s₁ s₂ x → (star P).toεNFA.IsPath (.inr s₁) (.inr s₂) x := by
   induction x generalizing s₁ <;> rintro (_ | _) <;> (try apply IsPath.cons; left) <;> tauto
 
-lemma star_accepts : (star P).toεNFA.accepts = P.toεNFA.accepts∗ := by
+private lemma star_accepts : (star P).toεNFA.accepts = P.toεNFA.accepts∗ := by
   ext x
   constructor <;> rw [mem_accepts_iff_exists_path]
   · rintro ⟨s₁, s₂, x, rfl, rfl, rfl, h⟩

--- a/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
+++ b/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
@@ -119,7 +119,7 @@ lemma zero_accepts : zero.toεNFA.accepts = (0 : Language α) := by
 lemma epsilon_accepts : epsilon.toεNFA.accepts = (1 : Language α) := by
   ext x
   constructor <;> rw [mem_accepts_iff_exists_path]
-  · rintro ⟨s₁, s₂, _, rfl, _, rfl, h⟩
+  · rintro ⟨s₁, s₂, x', rfl, _, rfl, h⟩
     rw [Language.one_def, mem_singleton_iff, reduceOption_eq_nil_iff]
     use 1
     rcases h with _ | ⟨_, _, _, ⟨⟩, _, ⟨⟩, ⟨⟩⟩ <;> trivial
@@ -130,7 +130,7 @@ lemma epsilon_accepts : epsilon.toεNFA.accepts = (1 : Language α) := by
 lemma char_accepts (a : α) : (char a).toεNFA.accepts = {[a]} := by
   ext x
   constructor <;> rw [mem_accepts_iff_exists_path]
-  · rintro ⟨_, _, _, rfl, _, rfl, h⟩
+  · rintro ⟨s₁, s₂, x', rfl, _, rfl, h⟩
     rw [mem_singleton_iff, reduceOption_eq_singleton_iff]
     use 0, 0
     rcases h with _ | ⟨_, _, _, ⟨⟩, _, ⟨⟩, ⟨⟩⟩ <;> subst_eqs <;> trivial
@@ -140,7 +140,7 @@ lemma char_accepts (a : α) : (char a).toεNFA.accepts = {[a]} := by
 
 lemma plus_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
     P.toεNFA.IsPath s₁ s₂ x ↔ (P + Q).toεNFA.IsPath (.inr (.inl s₁)) (.inr (.inl s₂)) x := by
-  induction' x with _ _ ih generalizing s₁
+  induction' x with a x ih generalizing s₁
     <;> constructor
     <;> rintro (_ | ⟨s, _, _, _, _, hs, h⟩)
     <;> (try apply IsPath.nil)
@@ -154,7 +154,7 @@ lemma plus_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
 
 lemma plus_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
     Q.toεNFA.IsPath s₁ s₂ x ↔ (P + Q).toεNFA.IsPath (.inr (.inr s₁)) (.inr (.inr s₂)) x := by
-  induction' x with _ _ ih generalizing s₁
+  induction' x with a x ih generalizing s₁
     <;> constructor
     <;> rintro (_ | ⟨s, _, _, _, _, hs, h⟩)
     <;> (try apply IsPath.nil)
@@ -177,10 +177,10 @@ lemma plus_no_cross_right (s : Q.St) (t : P.St) (x : List (Option α)) :
 lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.accepts := by
   ext x
   constructor <;> rw [mem_accepts_iff_exists_path]
-  · rintro ⟨_, _, _, rfl, rfl, rfl, h⟩
-    rcases h with _ | ⟨_, _, _, ⟨⟩, x, ⟨_ | _, hs, rfl⟩, h⟩
+  · rintro ⟨s₁, s₂, x', rfl, rfl, rfl, h⟩
+    rcases h with _ | ⟨_, _, _, ⟨⟩, x', ⟨_ | _, hs, rfl⟩, h⟩
       <;> [left; right]
-      <;> rcases eq_nil_or_concat x with rfl | ⟨_, a, rfl⟩
+      <;> rcases eq_nil_or_concat x' with rfl | ⟨_, a, rfl⟩
       <;> (try apply IsPath.eq_of_nil at h; contradiction)
       <;> simp_rw [concat_eq_append, isPath_append, isPath_singleton] at h
       <;> rcases h with ⟨⟨_ | _⟩ | ⟨_ | _⟩, h, hs⟩
@@ -223,7 +223,7 @@ lemma comp_one_way (s : Q.St) (t : P.St) (x : List (Option α)) :
 
 lemma comp_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
     P.toεNFA.IsPath s₁ s₂ x ↔ (comp P Q).toεNFA.IsPath (.inl s₁) (.inl s₂) x := by
-  induction' x with _ _ ih generalizing s₁
+  induction' x with a x ih generalizing s₁
     <;> constructor
     <;> rintro (_ | ⟨s, _, _, _, _, hs, h⟩)
     <;> (try apply IsPath.nil)
@@ -277,7 +277,7 @@ lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.
   ext x
   constructor
   · rw [mem_accepts_iff_exists_path]
-    rintro ⟨_, _, _, ⟨s₁₁, _, rfl⟩, ⟨s₂₂, _, rfl⟩, rfl, h⟩
+    rintro ⟨s₁, s₂, x', ⟨s₁₁, _, rfl⟩, ⟨s₂₂, _, rfl⟩, rfl, h⟩
     apply comp_split at h
     obtain ⟨s₁₂, s₂₁, x₁, x₂, rfl, _, _, h₁, h₂⟩ := h
     rw [← comp_embed_left] at h₁
@@ -426,7 +426,7 @@ lemma star_embed (s₁ s₂ : P.St) (x : List (Option α)) :
 lemma star_accepts : (star P).toεNFA.accepts = P.toεNFA.accepts∗ := by
   ext x
   constructor <;> rw [mem_accepts_iff_exists_path]
-  · rintro ⟨_, _, x, rfl, rfl, rfl, h⟩
+  · rintro ⟨s₁, s₂, x, rfl, rfl, rfl, h⟩
     exact star_parts _ x (by tauto) h
   · rw [Language.mem_kstar]
     rintro ⟨xs, rfl, hs⟩

--- a/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
+++ b/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
@@ -118,29 +118,23 @@ lemma zero_accepts : zero.toεNFA.accepts = (0 : Language α) := by
 
 lemma epsilon_accepts : epsilon.toεNFA.accepts = (1 : Language α) := by
   ext x
-  constructor <;> intro h <;> rw [mem_accepts_iff_exists_path] at *
-  · obtain ⟨s₁, s₂, _, _, _, _, h⟩ := h
-    substs x s₁ s₂
+  constructor <;> rw [mem_accepts_iff_exists_path]
+  · rintro ⟨s₁, s₂, _, ⟨⟩, _, ⟨⟩, h⟩
     rw [Language.one_def, mem_singleton_iff, reduceOption_eq_nil_iff]
     use 1
-    cases' h with _ _ _ _ a _ hs h
-    cases a <;> cases hs
-    cases h <;> trivial
-  · subst x
+    rcases h with _ | ⟨_, _, _, ⟨⟩, _, ⟨⟩, ⟨⟩⟩ <;> trivial
+  · rintro rfl
     use .ini, .fin, [none]
     repeat constructor
 
 lemma char_accepts (a : α) : (char a).toεNFA.accepts = {[a]} := by
   ext x
-  constructor <;> intro h <;> rw [mem_accepts_iff_exists_path] at *
-  · obtain ⟨s₁, s₂, _, _, _, _, h⟩ := h
-    substs x s₁ s₂
+  constructor <;> rw [mem_accepts_iff_exists_path]
+  · rintro ⟨_, _, _, ⟨⟩, ⟨⟩, ⟨⟩, h⟩
     rw [mem_singleton_iff, reduceOption_eq_singleton_iff]
     use 0, 0
-    cases' h with _ _ _ _ a _ hs h
-    cases a <;> cases hs
-    cases h <;> subst_eqs <;> trivial
-  · subst x
+    rcases h with _ | ⟨_, _, _, ⟨⟩, _, ⟨⟩, ⟨⟩⟩ <;> subst_eqs <;> trivial
+  · rintro ⟨⟩
     use .ini, .fin, [a]
     repeat constructor
 
@@ -148,53 +142,43 @@ lemma plus_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
     P.toεNFA.IsPath s₁ s₂ x ↔ (P + Q).toεNFA.IsPath (.inr (.inl s₁)) (.inr (.inl s₂)) x := by
   induction' x with _ _ ih generalizing s₁
     <;> constructor
-    <;> intro h
-    <;> cases' h with _ s _ _ _ _ hs h
+    <;> rintro (_ | ⟨s, _, _, _, _, hs, h⟩)
     <;> (try apply IsPath.nil)
   · apply IsPath.cons
     · left
       use s
     · rwa [Function.comp_apply, ← ih]
-  · cases s <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩ := hs
-    · cases' h with _ s _ _ a _ hs
-      cases a <;> cases hs
+  · cases s <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩
+    · rcases h with _ | ⟨_, _, _, ⟨⟩, _, ⟨⟩⟩
     · apply IsPath.cons <;> (try rw [ih]) <;> assumption
 
 lemma plus_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
     Q.toεNFA.IsPath s₁ s₂ x ↔ (P + Q).toεNFA.IsPath (.inr (.inr s₁)) (.inr (.inr s₂)) x := by
   induction' x with _ _ ih generalizing s₁
     <;> constructor
-    <;> intro h
-    <;> cases' h with _ s _ _ _ _ hs h
+    <;> rintro (_ | ⟨s, _, _, _, _, hs, h⟩)
     <;> (try apply IsPath.nil)
   · apply IsPath.cons
     · left
       use s
     · rwa [Function.comp_apply, ← ih]
-  · cases s <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩ := hs
-    · cases' h with _ s _ _ a _ hs
-      cases a <;> cases hs
+  · cases s <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩
+    · rcases h with _ | ⟨_, _, _, ⟨⟩, _, ⟨⟩⟩
     · apply IsPath.cons <;> (try rw [ih]) <;> assumption
 
 lemma plus_no_cross_left (s : P.St) (t : Q.St) (x : List (Option α)) :
     ¬(P + Q).toεNFA.IsPath (.inr (.inl s)) (.inr (.inr t)) x := by
-  intro h
-  induction x generalizing s <;> cases' h with _ s _ _ _ _ hs
-  obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩ := hs <;> tauto
+  induction x generalizing s <;> rintro (_ | ⟨_, _, _, _, _, ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩⟩) <;> tauto
 
 lemma plus_no_cross_right (s : Q.St) (t : P.St) (x : List (Option α)) :
     ¬(P + Q).toεNFA.IsPath (.inr (.inr s)) (.inr (.inl t)) x := by
-  intro h
-  induction x generalizing s <;> cases' h with _ s _ _ _ _ hs
-  obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩ := hs <;> tauto
+  induction x generalizing s <;> rintro (_ | ⟨_, _, _, _, _, ⟨_, _, ⟨⟩⟩ | ⟨⟨⟩, _⟩⟩) <;> tauto
 
 lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.accepts := by
   ext x
-  constructor <;> intro h <;> rw [mem_accepts_iff_exists_path] at *
-  · obtain ⟨s₁, s₂, _, _, _, _, h⟩ := h
-    substs x s₁ s₂
-    cases' h with _ s _ _ a x hs h
-    cases a <;> obtain ⟨_ | _, hs, ⟨⟩⟩ := hs
+  constructor <;> rw [mem_accepts_iff_exists_path]
+  · rintro ⟨_, _, _, ⟨⟩, ⟨⟩, ⟨⟩, h⟩
+    rcases h with _ | ⟨_, _, _, ⟨⟩, x, ⟨_ | _, hs, ⟨⟩⟩, h⟩
       <;> [left; right]
       <;> rcases eq_nil_or_concat x with ⟨⟨⟩⟩ | ⟨_, a, ⟨⟩⟩
       <;> (try apply IsPath.eq_of_nil at h; contradiction)
@@ -203,19 +187,19 @@ lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.acc
       <;> (try apply plus_no_cross_left at h)
       <;> (try apply plus_no_cross_right at h)
       <;> (try contradiction)
-      <;> (try cases a <;> obtain ⟨_, _, ⟨⟩⟩ := hs; done)
-      <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨_, ⟨⟩, _⟩ := hs
+      <;> (try cases a <;> rcases hs with ⟨_, _, ⟨⟩⟩; done)
+      <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨_, ⟨⟩, _⟩
       <;> rw [reduceOption_cons_of_none, reduceOption_concat, Option.toList_none, append_nil,
             mem_accepts_iff_exists_path]
     · rw [← plus_embed_left] at h
       tauto
     · rw [← plus_embed_right] at h
       tauto
-  · use .inl .ini, .inl .fin
+  · intro h
+    use .inl .ini, .inl .fin
     rcases h with h | h
       <;> rw [mem_accepts_iff_exists_path] at h
-      <;> obtain ⟨s₁, s₂, x', _, _, _, _⟩ := h
-      <;> subst x
+      <;> obtain ⟨s₁, s₂, x', _, _, ⟨⟩, _⟩ := h
       <;> use none :: x' ++ [none]
       <;> simp only [reduceOption_append, reduceOption_cons_of_none, reduceOption_nil, append_nil]
       <;> split_ands
@@ -234,23 +218,20 @@ lemma plus_accepts : (P + Q).toεNFA.accepts = P.toεNFA.accepts + Q.toεNFA.acc
 
 lemma comp_one_way (s : Q.St) (t : P.St) (x : List (Option α)) :
     ¬(comp P Q).toεNFA.IsPath (.inr s) (.inl t) x := by
-  intro h
-  induction x generalizing s <;> cases' h with _ s _ _ _ _ hs
-  obtain ⟨_, _, ⟨⟩⟩ := hs
+  induction x generalizing s <;> rintro (_ | ⟨_, _, _, _, _, ⟨_, _, ⟨⟩⟩⟩)
   tauto
 
 lemma comp_embed_left (s₁ s₂ : P.St) (x : List (Option α)) :
     P.toεNFA.IsPath s₁ s₂ x ↔ (comp P Q).toεNFA.IsPath (.inl s₁) (.inl s₂) x := by
   induction' x with _ _ ih generalizing s₁
     <;> constructor
-    <;> intro h
-    <;> cases' h with _ s _ _ _ _ hs h
+    <;> rintro (_ | ⟨s, _, _, _, _, hs, h⟩)
     <;> (try apply IsPath.nil)
   · apply IsPath.cons
     · left
       use s
     · rwa [← ih]
-  · obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, _⟩ := hs
+  · rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, _⟩
     · apply IsPath.cons <;> (try rw [ih]) <;> assumption
     · apply comp_one_way at h
       contradiction
@@ -259,13 +240,12 @@ lemma comp_embed_right (s₁ s₂ : Q.St) (x : List (Option α)) :
     Q.toεNFA.IsPath s₁ s₂ x ↔ (comp P Q).toεNFA.IsPath (.inr s₁) (.inr s₂) x := by
   induction' x with _ _ ih generalizing s₁
     <;> constructor
-    <;> intro h
-    <;> cases' h with _ s _ _ _ _ hs h
+    <;> rintro (_ | ⟨s, _, _, _, _, hs, h⟩)
     <;> (try apply IsPath.nil)
   · apply IsPath.cons
     · use s
     · rwa [← ih]
-  · obtain ⟨_, _, ⟨⟩⟩ := hs
+  · rcases hs with ⟨_, _, ⟨⟩⟩
     apply IsPath.cons <;> (try rw [ih]) <;> assumption
 
 lemma comp_split (s₁₁ : P.St) (s₂₂ : Q.St) (x : List (Option α)) :
@@ -280,10 +260,10 @@ lemma comp_split (s₁₁ : P.St) (s₂₂ : Q.St) (x : List (Option α)) :
   cases' x with a x
   · apply IsPath.eq_of_nil at h
     contradiction
-  · induction' x with b x ih generalizing s₁₁ a <;> cases' h with _ s _ _ _ _ hs h
+  · induction' x with b x ih generalizing s₁₁ a <;> rcases h with _ | ⟨s, _, _, _, _, hs, h⟩
     · apply IsPath.eq_of_nil at h
       subst s
-      obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, ⟨⟩, _⟩ := hs
+      rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨_, _, ⟨⟩⟩, ⟨⟩, _⟩
       use s₁₁, s₂₂, [], []
       tauto
     · cases' s with _ s
@@ -295,9 +275,9 @@ lemma comp_split (s₁₁ : P.St) (s₂₂ : Q.St) (x : List (Option α)) :
 
 lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.accepts := by
   ext x
-  constructor <;> intro h
-  · rw [mem_accepts_iff_exists_path] at h
-    obtain ⟨_, _, _, ⟨s₁₁, _, ⟨⟩⟩, ⟨s₂₂, _, ⟨⟩⟩, ⟨⟩, h⟩ := h
+  constructor
+  · rw [mem_accepts_iff_exists_path]
+    rintro ⟨_, _, _, ⟨s₁₁, _, ⟨⟩⟩, ⟨s₂₂, _, ⟨⟩⟩, ⟨⟩, h⟩
     apply comp_split at h
     obtain ⟨s₁₂, s₂₁, x₁, x₂, ⟨⟩, _, _, h₁, h₂⟩ := h
     rw [← comp_embed_left] at h₁
@@ -311,12 +291,11 @@ lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.
       constructor
       · use s₂₁, s₂₂, x₂
       · rw [reduceOption_append, reduceOption_cons_of_none]
-  · rw [Language.mem_mul] at h
-    obtain ⟨x₁, h₁, x₂, h₂, ⟨⟩⟩ := h
+  · rw [Language.mem_mul]
+    rintro ⟨x₁, h₁, x₂, h₂, ⟨⟩⟩
     rw [mem_accepts_iff_exists_path] at *
-    obtain ⟨s₁₁, s₁₂, x₁', _, _, _, _⟩ := h₁
-    obtain ⟨_, s₂₂, x₂', _, _, _, _⟩ := h₂
-    substs x₁ x₂
+    obtain ⟨s₁₁, s₁₂, x₁', _, _, ⟨⟩, _⟩ := h₁
+    obtain ⟨_, s₂₂, x₂', _, _, ⟨⟩, _⟩ := h₂
     use .inl s₁₁, .inr s₂₂, x₁' ++ none :: x₂'
     split_ands <;> try tauto
     · rw [reduceOption_append, reduceOption_cons_of_none]
@@ -330,19 +309,15 @@ lemma comp_accepts : (comp P Q).toεNFA.accepts = P.toεNFA.accepts * Q.toεNFA.
         · rwa [← comp_embed_right]
 
 lemma step_accept_empty (s : P.St) : s ∈ P.toεNFA.accept → ∀ a, P.toεNFA.step s a = ∅ := by
-  intro hs
   induction P
-    <;> rcases hs with ⟨_, _, ⟨⟩⟩
+    <;> rintro ⟨_, _, ⟨⟩⟩
     <;> simp only [toεNFA, comp_step, comp_def, image_eq_empty]
     <;> tauto
 
 lemma accept_final (s : P.St) : s ∈ P.toεNFA.accept → ∀ t x, x ≠ [] → ¬P.toεNFA.IsPath s t x := by
-  intro hs _ _ hx
-  rw [ne_nil_iff_exists_cons] at hx
-  obtain ⟨_, _, ⟨⟩⟩ := hx
-  intro h
-  cases' h with _ _ _ _ _ _ hs'
-  rw [step_accept_empty] at hs' <;> assumption
+  simp_rw [ne_nil_iff_exists_cons]
+  rintro _ _ _ ⟨_, _, _, ⟨_, _, ⟨⟩⟩⟩ (_ | ⟨_, _, _, _, _, hs⟩)
+  rw [step_accept_empty] at hs <;> assumption
 
 -- N.B. This holds for any `P`, but only the `star P` case is needed.
 lemma star_no_restart (s : P.St) (x : List (Option α)) :
@@ -353,7 +328,7 @@ lemma star_no_restart (s : P.St) (x : List (Option α)) :
     contradiction
   · simp_rw [isPath_append, isPath_singleton] at h
     obtain ⟨s, _, hs⟩ := h
-    rcases s with ⟨_ | _⟩ | _ <;> cases a <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩, _⟩ := hs
+    rcases s with ⟨_ | _⟩ | _ <;> cases a <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩, _⟩
 
 lemma star_cons (s : (star P).St) :
     s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept →
@@ -363,10 +338,10 @@ lemma star_cons (s : (star P).St) :
         (t = .inl .fin ∨ t ∈ .inr '' P.toεNFA.start) ∧
         (star P).toεNFA.IsPath t (.inl .fin) x' := by
   intro hs x h
-  obtain ⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩ := hs
+  rcases hs with ⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩
     <;> cases' x with a x
     <;> (try apply IsPath.eq_of_nil at h)
-    <;> cases' h with _ s _ _ _ _ hs
+    <;> rcases h with _ | ⟨s, _, _, _, _, hs⟩
     <;> use s, x
     <;> cases a
     <;> obtain ⟨_, hs, ⟨⟩⟩ | ⟨⟨⟩⟩ := hs
@@ -385,13 +360,12 @@ lemma star_concat (s : (star P).St) :
     obtain ⟨s, _, hs⟩ := h
     cases a
     · use x
-    · rcases s with ⟨_ | _⟩ | _ <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨_, ⟨⟩, _⟩ := hs
+    · rcases s with ⟨_ | _⟩ | _ <;> rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨_, ⟨⟩, _⟩
 
 lemma star_end (s : (star P).St) :
     s = .inl .ini ∨ s ∈ .inr '' P.toεNFA.accept → (star P).toεNFA.IsPath s (.inl .fin) [none] := by
   rw [isPath_singleton]
-  intro h
-  rcases h with ⟨⟨⟩, _⟩ | ⟨_, _, ⟨⟩⟩ <;> (try right; constructor) <;> tauto
+  rintro (⟨⟨⟩, _⟩ | ⟨_, _, ⟨⟩⟩) <;> (try right; constructor) <;> tauto
 
 lemma star_split (s₁ : P.St) (x : List (Option α)) :
     (star P).toεNFA.IsPath (.inr s₁) (.inl .fin) x →
@@ -403,8 +377,7 @@ lemma star_split (s₁ : P.St) (x : List (Option α)) :
   intro h
   obtain ⟨x, ⟨⟩⟩ := star_concat _ (by tauto) _ h
   simp_rw [isPath_append, isPath_singleton] at h
-  obtain ⟨t, h, ht⟩ := h
-  rcases t with ⟨_ | _⟩ | t <;> obtain ⟨_, _, ⟨⟩⟩ | ⟨_, _, _⟩ := ht
+  rcases h with ⟨⟨_ | _⟩ | t, h, ⟨_, _, ⟨⟩⟩ | ⟨_, _, _⟩⟩
   · apply star_no_restart at h
     contradiction
   · induction' x with a x ih generalizing s₁
@@ -412,8 +385,7 @@ lemma star_split (s₁ : P.St) (x : List (Option α)) :
       cases h
       use t, [], [none]
       split_ands <;> (try apply star_end) <;> tauto
-    · cases' h with _ s _ _ _ _ hs h
-      rcases hs with ⟨_, _, ⟨⟩⟩ | ⟨⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩, _, _⟩
+    · rcases h with _ | ⟨_, _, _, _, _, ⟨_, _, ⟨⟩⟩ | ⟨⟨⟨⟩⟩ | ⟨_, _, ⟨⟩⟩, _, _⟩, h⟩
       · apply ih at h
         obtain ⟨s₂, x₁, x', _, _, _, _⟩ := h
         use s₂, a :: x₁, x'
@@ -443,23 +415,21 @@ lemma star_parts (s : (star P).St) (x : List (Option α)) :
     obtain ⟨xs, hx, _⟩ := star_parts (.inr s₂) _ (by tauto) h'
     use x₁.reduceOption :: xs
     rw [reduceOption_cons_of_none, reduceOption_append, flatten_cons, hx]
-    have h₁ := (mem_accepts_iff_exists_path _).mpr ⟨s₁, s₂, x₁, (by trivial)⟩
+    have := (mem_accepts_iff_exists_path _).mpr ⟨s₁, s₂, x₁, (by trivial)⟩
     constructor <;> (try intro _ hy; cases hy) <;> tauto
   termination_by x.length
 
 lemma star_embed (s₁ s₂ : P.St) (x : List (Option α)) :
     P.toεNFA.IsPath s₁ s₂ x → (star P).toεNFA.IsPath (.inr s₁) (.inr s₂) x := by
-  induction' x generalizing s₁ <;> intro h <;> cases h <;> (try apply IsPath.cons; left) <;> tauto
+  induction x generalizing s₁ <;> rintro (_ | _) <;> (try apply IsPath.cons; left) <;> tauto
 
 lemma star_accepts : (star P).toεNFA.accepts = P.toεNFA.accepts∗ := by
   ext x
-  constructor <;> intro h
-  · rw [mem_accepts_iff_exists_path] at h
-    obtain ⟨_, _, x, ⟨⟩, ⟨⟩, ⟨⟩, h⟩ := h
+  constructor <;> rw [mem_accepts_iff_exists_path]
+  · rintro ⟨_, _, x, ⟨⟩, ⟨⟩, ⟨⟩, h⟩
     exact star_parts _ x (by tauto) h
-  · rw [Language.mem_kstar] at h
-    obtain ⟨xs, ⟨⟩, hs⟩ := h
-    rw [mem_accepts_iff_exists_path]
+  · rw [Language.mem_kstar]
+    rintro ⟨xs, ⟨⟩, hs⟩
     use .inl .ini, .inl .fin
     induction' xs with _ _ ih
     · use [none]
@@ -471,7 +441,7 @@ lemma star_accepts : (star P).toεNFA.accepts = P.toεNFA.accepts∗ := by
       obtain ⟨_, _, _, hx₂, h₂⟩ := ih hs
       obtain ⟨_, x₂, ⟨⟩, hs₂₁, _⟩ := star_cons _ (by tauto) _ h₂
       use none :: x₁ ++ none :: x₂
-      split_ands <;> try rfl
+      refine ⟨rfl, rfl, ?_, ?_⟩
       · rw [reduceOption_append, reduceOption_cons_of_none, flatten_cons, hx₂]
       · rw [isPath_append]
         use .inr s₁₂
@@ -484,8 +454,7 @@ lemma star_accepts : (star P).toεNFA.accepts = P.toεNFA.accepts∗ := by
           <;> (try apply star_embed)
           <;> tauto
 
-theorem toεNFA_correct (P : RegularExpression α) :
-    P.toεNFA.accepts = P.matches' := by
+theorem toεNFA_correct : P.toεNFA.accepts = P.matches' := by
   induction P with
   | zero => exact zero_accepts
   | epsilon => exact epsilon_accepts

--- a/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
+++ b/Mathlib/Computability/RegularExpressionsToEpsilonNFA.lean
@@ -121,7 +121,7 @@ lemma epsilon_accepts : epsilon.toεNFA.accepts = (1 : Language α) := by
   constructor <;> intro h <;> rw [accepts_Path_iff] at *
   · obtain ⟨s₁, s₂, _, _, _, _, h⟩ := h
     substs x s₁ s₂
-    rw [Language.one_def, mem_singleton_iff, reduceOption_eq_nil_replicate_iff]
+    rw [Language.one_def, mem_singleton_iff, reduceOption_eq_nil_iff]
     use 1
     cases' h with _ _ _ _ a _ hs h
     cases a <;> cases hs
@@ -135,7 +135,7 @@ lemma char_accepts (a : α) : (char a).toεNFA.accepts = {[a]} := by
   constructor <;> intro h <;> rw [accepts_Path_iff] at *
   · obtain ⟨s₁, s₂, _, _, _, _, h⟩ := h
     substs x s₁ s₂
-    rw [mem_singleton_iff, reduceOption_eq_singleton_replicate_iff]
+    rw [mem_singleton_iff, reduceOption_eq_singleton_iff]
     use 0, 0
     cases' h with _ _ _ _ a _ hs h
     cases a <;> cases hs

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -3720,6 +3720,22 @@
   collection    = {Lecture Notes in Logic}
 }
 
+@Article{         thompson1968,
+  author        = {Thompson, Ken},
+  title         = {Regular expression search algorithm},
+  year          = {1968},
+  month         = jun,
+  fjournal      = {Communications of the ACM},
+  journal       = {Commun. ACM},
+  volume        = {11},
+  number        = {6},
+  pages         = {419--422},
+  issn          = {1557-7317},
+  doi           = {10.1145/363347.363387},
+  publisher     = {Association for Computing Machinery (ACM)},
+  language      = {English}
+}
+
 @Article{         tochiori_bertrand,
   author        = {Tochiori, Shigenori},
   title         = {Considering the Proof of "There is a Prime between n and


### PR DESCRIPTION
The file `Computability/RegularExpressionsToEpsilonNFA.lean` contains a formal definition of Thompson's method for constructing an `εNFA` from a `RegularExpression` and a proof of its correctness.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #20644 
- [x] depends on: #20645 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
