### PR TITLE
feat(Mathlib/Geometry/Manifold/VectorBundle/Sphere): convert orthogonal smooth `M → 𝕊ⁿ` & `M → ℝⁿ⁺¹` to smooth `M → T𝕊ⁿ`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3192,6 +3192,7 @@ import Mathlib.Geometry.Manifold.VectorBundle.Hom
 import Mathlib.Geometry.Manifold.VectorBundle.MDifferentiable
 import Mathlib.Geometry.Manifold.VectorBundle.Pullback
 import Mathlib.Geometry.Manifold.VectorBundle.SmoothSection
+import Mathlib.Geometry.Manifold.VectorBundle.Sphere
 import Mathlib.Geometry.Manifold.VectorBundle.Tangent
 import Mathlib.Geometry.Manifold.WhitneyEmbedding
 import Mathlib.Geometry.RingedSpace.Basic

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -159,16 +159,19 @@ theorem hasFDerivAt_stereoInvFunAux_comp_coe (v : E) :
     hasFDerivAt_stereoInvFunAux v
   refine this.comp (0 : (ℝ ∙ v)ᗮ) (by apply ContinuousLinearMap.hasFDerivAt)
 
-theorem contDiff_stereoInvFunAux : ContDiff ℝ ω (stereoInvFunAux v) := by
-  have h₀ : ContDiff ℝ ω fun w : E => ‖w‖ ^ 2 := contDiff_norm_sq ℝ
-  have h₁ : ContDiff ℝ ω fun w : E => (‖w‖ ^ 2 + 4)⁻¹ := by
+theorem contDiff_uncurry_stereoInvFunAux : ContDiff ℝ ω (uncurry (stereoInvFunAux (E := E))) := by
+  have h₀ : ContDiff ℝ ω fun p : E × E => ‖p.2‖ ^ 2 := contDiff_norm_sq ℝ |>.comp contDiff_snd
+  have h₁ : ContDiff ℝ ω fun p : E × E => (‖p.2‖ ^ 2 + 4)⁻¹ := by
     refine (h₀.add contDiff_const).inv ?_
     intro x
     nlinarith
-  have h₂ : ContDiff ℝ ω fun w => (4 : ℝ) • w + (‖w‖ ^ 2 - 4) • v := by
-    refine (contDiff_const.smul contDiff_id).add ?_
-    exact (h₀.sub contDiff_const).smul contDiff_const
+  have h₂ : ContDiff ℝ ω fun p : E × E => (4 : ℝ) • p.2 + (‖p.2‖ ^ 2 - 4) • p.1 := by
+    refine (contDiff_const.smul contDiff_snd).add ?_
+    exact (h₀.sub contDiff_const).smul contDiff_fst
   exact h₁.smul h₂
+
+theorem contDiff_stereoInvFunAux : ContDiff ℝ ω (stereoInvFunAux v) :=
+  contDiff_uncurry_stereoInvFunAux.comp (contDiff_prod_mk_right v)
 
 /-- Stereographic projection, reverse direction.  This is a map from the orthogonal complement of a
 unit vector `v` in an inner product space `E` to the unit sphere in `E`. -/
@@ -178,6 +181,10 @@ def stereoInvFun (hv : ‖v‖ = 1) (w : (ℝ ∙ v)ᗮ) : sphere (0 : E) 1 :=
 @[simp]
 theorem stereoInvFun_apply (hv : ‖v‖ = 1) (w : (ℝ ∙ v)ᗮ) :
     (stereoInvFun hv w : E) = (‖w‖ ^ 2 + 4)⁻¹ • ((4 : ℝ) • w + (‖w‖ ^ 2 - 4) • v) :=
+  rfl
+
+theorem coe_sphere_comp_stereoInvFun (hv : ‖v‖ = 1) :
+    ((↑) : ↥(sphere (0 : E) 1) → E) ∘ stereoInvFun hv = stereoInvFunAux v ∘ Subtype.val :=
   rfl
 
 open scoped InnerProductSpace in

--- a/Mathlib/Geometry/Manifold/VectorBundle/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Sphere.lean
@@ -1,0 +1,270 @@
+/-
+Copyright (c) 2025 Miyahara Kō. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Miyahara Kō
+-/
+
+import Mathlib.Geometry.Manifold.VectorBundle.Tangent
+import Mathlib.Geometry.Manifold.Instances.Sphere
+
+/-!
+# Convert smooth `M → 𝕊ⁿ` & `M → ℝⁿ⁺¹` to smooth `M → T𝕊ⁿ`
+
+## Main definitions
+
+* `sphereTangentMap` : Convert `f : M → 𝕊ⁿ` & `g : M → ℝⁿ⁺¹` which satisfy `∀ x, ⟪f x, g x⟫_ℝ = 0`
+  to `M → T𝕊ⁿ`.
+
+## Main statements
+
+* `mfderiv_coe_sphere_sphereTangentMap_snd` : Let `ι` be an inclusion map from `T𝕊ⁿ` to `Tℝⁿ⁺¹`,
+  then `ι (sphereTangentMap n f g hf x).snd = g x`.
+
+* `contMDiff_sphereTangentMap` : If `f` & `g` are smooth, then `sphereTangentMap n f g hf'` too.
+
+-/
+
+open Metric Module Function
+
+open scoped Manifold ContDiff InnerProductSpace
+
+open private stereographic'_neg from Mathlib.Geometry.Manifold.Instances.Sphere
+
+noncomputable section
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] (v : E)
+
+theorem contDiff_uncurry_stereoInvFunAux : ContDiff ℝ ω (uncurry (stereoInvFunAux (E := E))) := by
+  have h₀ : ContDiff ℝ ω fun p : E × E => ‖p.2‖ ^ 2 := contDiff_norm_sq ℝ |>.comp contDiff_snd
+  have h₁ : ContDiff ℝ ω fun p : E × E => (‖p.2‖ ^ 2 + 4)⁻¹ := by
+    refine (h₀.add contDiff_const).inv ?_
+    intro x
+    nlinarith
+  have h₂ : ContDiff ℝ ω fun p : E × E => (4 : ℝ) • p.2 + (‖p.2‖ ^ 2 - 4) • p.1 := by
+    refine (contDiff_const.smul contDiff_snd).add ?_
+    exact (h₀.sub contDiff_const).smul contDiff_fst
+  exact h₁.smul h₂
+
+theorem coe_sphere_comp_stereoInvFun (hv : ‖v‖ = 1) :
+    ((↑) : ↥(sphere (0 : E) 1) → E) ∘ stereoInvFun hv = stereoInvFunAux v ∘ Subtype.val :=
+  rfl
+
+variable {m : WithTop ℕ∞} {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
+variable {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ F H}
+variable {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I m M]
+
+/-- Convert `f : M → 𝕊ⁿ` & `g : M → ℝⁿ⁺¹` which satisfy `∀ x, ⟪f x, g x⟫_ℝ = 0` to `M → T𝕊ⁿ`. -/
+def sphereTangentMap (n : ℕ) [Fact (finrank ℝ E = n + 1)]
+    (f : M → sphere (0 : E) 1) (g : M → E)
+    (hf : ∀ x, ⟪(↑(f x) : E), g x⟫_ℝ = 0) (x : M) : TangentBundle (𝓡 n) (sphere (0 : E) 1) :=
+  ⟨f x,
+    (OrthonormalBasis.fromOrthogonalSpanSingleton n (ne_zero_of_mem_unit_sphere (-f x))).repr
+      (⟨g x, Submodule.mem_orthogonal_singleton_iff_inner_right.mpr (by simp [hf x])⟩ :
+        (ℝ ∙ (-↑(f x) : E))ᗮ)⟩
+
+omit [TopologicalSpace M] in
+@[simp]
+theorem sphereTangentMap_proj (n : ℕ) [Fact (finrank ℝ E = n + 1)]
+    (f : M → sphere (0 : E) 1) (g : M → E)
+    (hf : ∀ x, ⟪(↑(f x) : E), g x⟫_ℝ = 0) (x : M) : (sphereTangentMap n f g hf x).proj = f x :=
+  rfl
+
+omit [TopologicalSpace M] in
+/-- Let `ι` be an inclusion map from `T𝕊ⁿ` to `Tℝⁿ⁺¹`, then
+`ι (sphereTangentMap n f g hf x).snd = g x`. -/
+@[simp]
+theorem mfderiv_coe_sphere_sphereTangentMap_snd (n : ℕ) [Fact (finrank ℝ E = n + 1)]
+    (f : M → sphere (0 : E) 1) (g : M → E)
+    (hf : ∀ x, ⟪(↑(f x) : E), g x⟫_ℝ = 0) (x : M) :
+    mfderiv (𝓡 n) 𝓘(ℝ, E) ((↑) : sphere (0 : E) 1 → E) (f x) (sphereTangentMap n f g hf x).snd =
+      g x := by
+  rw [((contMDiff_coe_sphere (f x)).mdifferentiableAt le_top).mfderiv]
+  simp only [writtenInExtChartAt, extChartAt, PartialHomeomorph.extend,
+    PartialHomeomorph.refl_partialEquiv, PartialEquiv.refl_source,
+    PartialHomeomorph.singletonChartedSpace_chartAt_eq, modelWithCornersSelf_partialEquiv,
+    PartialEquiv.trans_refl, PartialEquiv.refl_coe, PartialHomeomorph.coe_coe_symm,
+    CompTriple.comp_eq, modelWithCornersSelf_coe, Set.range_id, PartialHomeomorph.toFun_eq_coe,
+    chartAt, ChartedSpace.chartAt, stereographic'_neg, fderivWithin_univ]
+  simp only [chartAt, ChartedSpace.chartAt, stereographic', coe_neg_sphere, stereographic,
+    PartialHomeomorph.coe_trans_symm, PartialHomeomorph.mk_coe_symm, PartialEquiv.coe_symm_mk,
+    Homeomorph.toPartialHomeomorph_symm_apply, LinearIsometryEquiv.toHomeomorph_symm,
+    LinearIsometryEquiv.coe_toHomeomorph, ← comp_assoc, coe_sphere_comp_stereoInvFun]
+  simp only [comp_assoc]
+  conv =>
+    enter [1, 1]
+    tactic =>
+      rw [fderiv_comp]
+      · exact contDiff_stereoInvFunAux.contDiffAt.differentiableAt (right_eq_inf.mp rfl)
+      · exact
+          (((ℝ ∙ (-↑(f x) : E))ᗮ).subtypeL.comp
+            (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := E) n
+              (ne_zero_of_mem_unit_sphere (-f x))
+            ).repr.symm.toContinuousLinearEquiv.toContinuousLinearMap).differentiableAt
+  conv =>
+    enter [1, 1, 2]
+    exact
+      (((ℝ ∙ (-↑(f x) : E))ᗮ).subtypeL.comp
+        (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := E) n
+            (ne_zero_of_mem_unit_sphere (-f x))
+          ).repr.symm.toContinuousLinearEquiv.toContinuousLinearMap).fderiv
+  simp [sphereTangentMap, TangentSpace, (hasFDerivAt_stereoInvFunAux (-(↑(f x) : E))).fderiv]
+
+omit [IsManifold I m M] in
+private theorem contMDiff_sphereTangentMap_aux {n : ℕ} [Fact (finrank ℝ E = n + 1)]
+    {f : M → ↥(sphere (0 : E) 1)} {g : M → E}
+    (hf : ContMDiff I (𝓡 n) m f) (hf' : ∀ x, ⟪(↑(f x) : E), g x⟫_ℝ = 0)
+    (hg : ContMDiff I 𝓘(ℝ, E) m g) (p : ↥(sphere (0 : E) 1)) :
+    ContMDiffOn I 𝓘(ℝ, EuclideanSpace ℝ (Fin n)) m
+      (fun x =>
+        (fderiv ℝ
+            (⇑(chartAt (EuclideanSpace ℝ (Fin n)) p) ∘
+              ⇑(chartAt (EuclideanSpace ℝ (Fin n)) (f x)).symm) 0)
+          (sphereTangentMap n f g hf' x).snd)
+      (f ⁻¹' (chartAt (EuclideanSpace ℝ (Fin n)) p).source) := by
+  conv =>
+    enter [4, x, 1, 2]
+    change ⇑(stereographic' n (-p)) ∘ ⇑(stereographic' n (-f x)).symm
+    simp only [stereographic', coe_neg_sphere, stereographic,
+      PartialHomeomorph.coe_trans, Homeomorph.toPartialHomeomorph_apply,
+      LinearIsometryEquiv.coe_toHomeomorph, PartialHomeomorph.mk_coe,
+      PartialHomeomorph.coe_trans_symm, PartialHomeomorph.mk_coe_symm, PartialEquiv.coe_symm_mk,
+      Homeomorph.toPartialHomeomorph_symm_apply, LinearIsometryEquiv.toHomeomorph_symm,
+      comp_assoc]
+    simp only [← comp_assoc Subtype.val, coe_sphere_comp_stereoInvFun]
+    simp only [← comp_assoc]
+    simp only [comp_assoc _ Subtype.val, comp_assoc _ (stereoToFun (-(↑p : E)))]
+  conv =>
+    tactic =>
+      apply propext ∘ contMDiffOn_congr
+      intro x hx
+      rw [fderiv_comp]
+      · refine
+          (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := E) n
+            (ne_zero_of_mem_unit_sphere (-p))
+          ).repr.toContinuousLinearEquiv.toContinuousLinearMap.differentiableAt.comp _
+            (DifferentiableAt.comp _ ?_
+              (contDiff_stereoInvFunAux.contDiffAt.differentiableAt (right_eq_inf.mp rfl)))
+        simp only [coe_neg_sphere, comp_apply, map_zero, ZeroMemClass.coe_zero,
+          stereoInvFunAux_apply, norm_zero, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
+          zero_pow, zero_add, smul_zero, zero_sub, smul_neg, neg_smul, neg_neg, inv_smul_smul₀]
+        refine
+          ((contDiffOn_stereoToFun (E := E) (v := -(↑p : E))).contDiffAt (IsOpen.mem_nhds ?_ ?_)
+            ).differentiableAt (right_eq_inf.mp rfl)
+        · exact
+            (innerSL ℝ (-(↑p : E))).continuous.isOpen_preimage {1}ᶜ isOpen_compl_singleton
+        · simp only [innerSL_apply, ne_eq, Set.mem_setOf_eq, ← sphere_ext_iff, ← coe_neg_sphere]
+          simpa [chartAt, ChartedSpace.chartAt, eq_comm (a := f x)] using hx
+      · exact
+          (((ℝ ∙ (-↑(f x) : E))ᗮ).subtypeL.comp
+            (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := E) n
+              (ne_zero_of_mem_unit_sphere (-f x))
+            ).repr.symm.toContinuousLinearEquiv.toContinuousLinearMap).differentiableAt
+  conv =>
+    enter [4, x, 1, 2]
+    exact
+      (((ℝ ∙ (-↑(f x) : E))ᗮ).subtypeL.comp
+        (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := E) n
+            (ne_zero_of_mem_unit_sphere (-f x))
+          ).repr.symm.toContinuousLinearEquiv.toContinuousLinearMap).fderiv
+  simp only [comp_apply, map_zero, ZeroMemClass.coe_zero, coe_neg_sphere, sphereTangentMap,
+    ContinuousLinearMap.coe_comp', Submodule.coe_subtypeL', Submodule.coe_subtype,
+    ContinuousLinearEquiv.coe_coe, LinearIsometryEquiv.coe_toContinuousLinearEquiv,
+    LinearIsometryEquiv.symm_apply_apply]
+  refine ContMDiffOn.clm_apply (fun x hx => ContMDiffAt.contMDiffWithinAt ?_) hg.contMDiffOn
+  conv =>
+    arg 4
+    change
+      (fun x => fderiv ℝ ((OrthonormalBasis.fromOrthogonalSpanSingleton n
+        (ne_zero_of_mem_unit_sphere (-p))).repr ∘ stereoToFun (-(↑p : E)) ∘
+          stereoInvFunAux (-x)) 0) ∘ ((↑) : ↥(sphere (0 : E) 1) → E) ∘ f
+  refine
+    ContMDiffAt.comp _ (ContMDiffAt.of_le ?_ le_top)
+      (((contMDiff_coe_sphere (E := E) (n := n)).contMDiffAt.of_le le_top).comp _
+        hf.contMDiffAt)
+  rw [contMDiffAt_iff_contDiffAt]
+  refine ContDiffAt.fderiv (n := ω) ?_ contDiffAt_const (right_eq_inf.mp rfl)
+  conv =>
+    arg 3
+    change
+      (OrthonormalBasis.fromOrthogonalSpanSingleton n (ne_zero_of_mem_unit_sphere (-p))).repr ∘
+        (stereoToFun (-(↑p : E)) ∘ uncurry stereoInvFunAux) ∘ Prod.map Neg.neg id
+  refine
+    (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := E) n
+        (ne_zero_of_mem_unit_sphere (-p))
+      ).repr.toContinuousLinearEquiv.toContinuousLinearMap.contDiff.contDiffAt.comp _ ?_
+  refine ContDiffAt.comp _ ?_ (ContDiffAt.prod_map contDiff_neg.contDiffAt contDiffAt_id)
+  refine ContDiffAt.comp _ ?_ contDiff_uncurry_stereoInvFunAux.contDiffAt
+  simp only [coe_neg_sphere, comp_apply, Prod.map_apply, id_eq, uncurry_apply_pair,
+    stereoInvFunAux_apply, norm_zero, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow,
+    zero_add, smul_zero, zero_sub, smul_neg, neg_smul, neg_neg, inv_smul_smul₀]
+  refine
+    (contDiffOn_stereoToFun (E := E) (v := -(↑p : E))).contDiffAt (IsOpen.mem_nhds ?_ ?_)
+  · exact
+      (innerSL ℝ (-(↑p : E))).continuous.isOpen_preimage {1}ᶜ isOpen_compl_singleton
+  · simp only [map_neg, ContinuousLinearMap.neg_apply, innerSL_apply, ne_eq,
+      Set.mem_setOf_eq]
+    have hp := inner_eq_norm_mul_iff_real (x := (↑p : E)) (y := -(↑(f x) : E))
+    simp only [inner_neg_right, norm_eq_of_mem_sphere, norm_neg, mul_one, one_smul,
+      smul_neg, chartAt, ChartedSpace.chartAt, stereographic'_source, Set.mem_compl_iff,
+      Set.mem_singleton_iff] at hp hx
+    rw [hp, ← coe_neg_sphere, Subtype.val_inj, ← neg_eq_iff_eq_neg, ← ne_eq]
+    symm; exact hx
+
+/-- If `f` & `g` are smooth, then `sphereTangentMap n f g hf'` too. -/
+theorem contMDiff_sphereTangentMap {n : ℕ} [Fact (finrank ℝ E = n + 1)]
+    {f : M → ↥(sphere (0 : E) 1)} {g : M → E}
+    (hf : ContMDiff I (𝓡 n) m f) (hf' : ∀ x, ⟪(↑(f x) : E), g x⟫_ℝ = 0)
+    (hg : ContMDiff I 𝓘(ℝ, E) m g) : ContMDiff I (𝓡 n).tangent m (sphereTangentMap n f g hf') := by
+  rw [contMDiff_iff_target]
+  constructor
+  · rw [continuous_generateFrom_iff]
+    simp only [FiberBundleCore.localTrivAsPartialEquiv_source, FiberBundleCore.proj,
+      FiberBundleCore.localTrivAsPartialEquiv_coe, Set.iUnion_coe_set, Set.mem_iUnion,
+      Set.mem_singleton_iff, exists_prop, forall_exists_index, and_imp]
+    rintro _ _ ⟨p, rfl⟩ s hs rfl; rcases neg_surjective p with ⟨p, rfl⟩
+    rw [Set.preimage_inter]
+    conv =>
+      enter [1, 1]
+      change
+        sphereTangentMap n f g hf' ⁻¹'
+          (Bundle.TotalSpace.proj ⁻¹' (chartAt (EuclideanSpace ℝ (Fin n)) p).source)
+    simp only [stereographic'_source, Set.preimage_compl, Set.preimage_preimage,
+      sphereTangentMap_proj, FiberBundleCore.localTriv_apply,
+      VectorBundleCore.toFiberBundleCore_indexAt, tangentBundleCore_indexAt,
+      VectorBundleCore.coe_coordChange, tangentBundleCore_coordChange, PartialHomeomorph.extend,
+      modelWithCornersSelf_partialEquiv, PartialEquiv.trans_refl, PartialHomeomorph.toFun_eq_coe,
+      coe_achart, PartialHomeomorph.coe_coe_symm, modelWithCornersSelf_coe, Set.range_id,
+      fderivWithin_univ]
+    refine
+      ContinuousOn.isOpen_inter_preimage (ContinuousOn.prod (contMDiff_iff.mp hf).1.continuousOn ?_)
+        ((contMDiff_iff.mp hf).1.isOpen_preimage _
+          (chartAt (EuclideanSpace ℝ (Fin n)) p).open_source) hs
+    simp only [chartAt, ChartedSpace.chartAt, stereographic'_neg]
+    exact (contMDiffOn_iff.mp (contMDiff_sphereTangentMap_aux hf hf' hg p)).1
+  · rintro ⟨p, v⟩
+    conv =>
+      arg 4
+      simp only [extChartAt, PartialHomeomorph.extend, TangentBundle.chartAt,
+        FiberBundleCore.proj, ← TangentBundle.trivializationAt_eq_localTriv,
+        PartialHomeomorph.trans_toPartialEquiv, PartialHomeomorph.prod_toPartialEquiv,
+        PartialHomeomorph.refl_partialEquiv, modelWithCorners_prod_toPartialEquiv,
+        modelWithCornersSelf_partialEquiv, PartialEquiv.refl_prod_refl, PartialEquiv.coe_trans,
+        PartialEquiv.refl_coe, PartialEquiv.prod_coe, PartialHomeomorph.toFun_eq_coe, id_eq,
+        Trivialization.coe_coe, comp_def, TangentBundle.trivializationAt_apply,
+        PartialEquiv.trans_refl, PartialHomeomorph.coe_coe_symm, modelWithCornersSelf_coe,
+        Set.range_id, fderivWithin_univ, CompTriple.comp_eq, sphereTangentMap_proj,
+        chartAt, ChartedSpace.chartAt, stereographic'_neg]
+    conv =>
+      arg 5
+      tactic =>
+        ext x
+        simp only [extChartAt, PartialHomeomorph.extend, modelWithCorners_prod_toPartialEquiv,
+          modelWithCornersSelf_partialEquiv, PartialEquiv.refl_prod_refl, PartialEquiv.trans_source,
+          PartialHomeomorph.toFun_eq_coe, PartialEquiv.refl_source, Set.preimage_univ,
+          Set.inter_univ, Set.mem_preimage, TangentBundle.mem_chart_source_iff,
+          sphereTangentMap_proj]
+        rw [← Set.mem_preimage]
+    apply ContMDiffOn.prod_mk_space
+    · rw [contMDiff_iff_target] at hf
+      simpa using hf.2 p
+    · exact contMDiff_sphereTangentMap_aux hf hf' hg p

--- a/Mathlib/Geometry/Manifold/VectorBundle/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Sphere.lean
@@ -8,7 +8,7 @@ import Mathlib.Geometry.Manifold.VectorBundle.Tangent
 import Mathlib.Geometry.Manifold.Instances.Sphere
 
 /-!
-# Convert smooth `M → 𝕊ⁿ` & `M → ℝⁿ⁺¹` to smooth `M → T𝕊ⁿ`
+# Convert orthogonal smooth `M → 𝕊ⁿ` & `M → ℝⁿ⁺¹` to smooth `M → T𝕊ⁿ`
 
 ## Main definitions
 

--- a/Mathlib/Geometry/Manifold/VectorBundle/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Sphere.lean
@@ -40,7 +40,7 @@ variable {m : WithTop ℕ∞} {F : Type*} [NormedAddCommGroup F] [NormedSpace �
 variable {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ F H}
 variable {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I m M]
 
-/-- Convert `f : M → 𝕊ⁿ` & `g : M → ℝⁿ⁺¹` which satisfy `∀ x, ⟪f x, g x⟫_ℝ = 0` to `M → T𝕊ⁿ`. -/
+/-- Convert `f : M → 𝕊ⁿ` and `g : M → ℝⁿ⁺¹` which satisfy `∀ x, ⟪f x, g x⟫_ℝ = 0` to `M → T𝕊ⁿ`. -/
 def sphereTangentMap (n : ℕ) [Fact (finrank ℝ E = n + 1)]
     (f : M → sphere (0 : E) 1) (g : M → E)
     (hf : ∀ x, ⟪(↑(f x) : E), g x⟫_ℝ = 0) (x : M) : TangentBundle (𝓡 n) (sphere (0 : E) 1) :=
@@ -66,21 +66,16 @@ theorem mfderiv_coe_sphere_sphereTangentMap_snd (n : ℕ) [Fact (finrank ℝ E =
     mfderiv (𝓡 n) 𝓘(ℝ, E) ((↑) : sphere (0 : E) 1 → E) (f x) (sphereTangentMap n f g hf x).snd =
       g x := by
   rw [((contMDiff_coe_sphere (f x)).mdifferentiableAt le_top).mfderiv]
-  simp only [writtenInExtChartAt, extChartAt, PartialHomeomorph.extend,
-    PartialHomeomorph.refl_partialEquiv, PartialEquiv.refl_source,
-    PartialHomeomorph.singletonChartedSpace_chartAt_eq, modelWithCornersSelf_partialEquiv,
-    PartialEquiv.trans_refl, PartialEquiv.refl_coe, PartialHomeomorph.coe_coe_symm,
-    CompTriple.comp_eq, modelWithCornersSelf_coe, Set.range_id, PartialHomeomorph.toFun_eq_coe,
-    chartAt, ChartedSpace.chartAt, stereographic'_neg, fderivWithin_univ]
-  simp only [chartAt, ChartedSpace.chartAt, stereographic', coe_neg_sphere, stereographic,
+  simp only [mfld_simps, chartAt, ChartedSpace.chartAt, stereographic'_neg]
+  simp only [
     PartialHomeomorph.coe_trans_symm, PartialHomeomorph.mk_coe_symm, PartialEquiv.coe_symm_mk,
-    Homeomorph.toPartialHomeomorph_symm_apply, LinearIsometryEquiv.toHomeomorph_symm,
+    stereographic', coe_neg_sphere, stereographic,
     LinearIsometryEquiv.coe_toHomeomorph, ← comp_assoc, coe_sphere_comp_stereoInvFun]
   simp only [comp_assoc]
   conv =>
     enter [1, 1]
     tactic =>
-      rw [fderiv_comp]
+      rw [fderivWithin_univ, fderiv_comp]
       · exact contDiff_stereoInvFunAux.contDiffAt.differentiableAt (right_eq_inf.mp rfl)
       · exact
           (((ℝ ∙ (-↑(f x) : E))ᗮ).subtypeL.comp
@@ -111,14 +106,10 @@ private theorem contMDiff_sphereTangentMap_aux {n : ℕ} [Fact (finrank ℝ E = 
   conv =>
     enter [4, x, 1, 2]
     change ⇑(stereographic' n (-p)) ∘ ⇑(stereographic' n (-f x)).symm
-    simp only [stereographic', coe_neg_sphere, stereographic,
-      PartialHomeomorph.coe_trans, Homeomorph.toPartialHomeomorph_apply,
-      LinearIsometryEquiv.coe_toHomeomorph, PartialHomeomorph.mk_coe,
-      PartialHomeomorph.coe_trans_symm, PartialHomeomorph.mk_coe_symm, PartialEquiv.coe_symm_mk,
-      Homeomorph.toPartialHomeomorph_symm_apply, LinearIsometryEquiv.toHomeomorph_symm,
+    simp only [mfld_simps, stereographic', coe_neg_sphere, stereographic,
+      LinearIsometryEquiv.coe_toHomeomorph, LinearIsometryEquiv.toHomeomorph_symm,
       comp_assoc]
-    simp only [← comp_assoc Subtype.val, coe_sphere_comp_stereoInvFun]
-    simp only [← comp_assoc]
+    simp only [← comp_assoc Subtype.val, coe_sphere_comp_stereoInvFun, ← comp_assoc]
     simp only [comp_assoc _ Subtype.val, comp_assoc _ (stereoToFun (-(↑p : E)))]
   conv =>
     tactic =>
@@ -205,8 +196,7 @@ theorem contMDiff_sphereTangentMap {n : ℕ} [Fact (finrank ℝ E = n + 1)]
   rw [contMDiff_iff_target]
   constructor
   · rw [continuous_generateFrom_iff]
-    simp only [FiberBundleCore.localTrivAsPartialEquiv_source, FiberBundleCore.proj,
-      FiberBundleCore.localTrivAsPartialEquiv_coe, Set.iUnion_coe_set, Set.mem_iUnion,
+    simp only [mfld_simps, Set.iUnion_coe_set, Set.mem_iUnion,
       Set.mem_singleton_iff, exists_prop, forall_exists_index, and_imp]
     rintro _ _ ⟨p, rfl⟩ s hs rfl; rcases neg_surjective p with ⟨p, rfl⟩
     rw [Set.preimage_inter]
@@ -215,13 +205,9 @@ theorem contMDiff_sphereTangentMap {n : ℕ} [Fact (finrank ℝ E = n + 1)]
       change
         sphereTangentMap n f g hf' ⁻¹'
           (Bundle.TotalSpace.proj ⁻¹' (chartAt (EuclideanSpace ℝ (Fin n)) p).source)
-    simp only [stereographic'_source, Set.preimage_compl, Set.preimage_preimage,
+    simp only [mfld_simps, stereographic'_source, Set.preimage_compl, Set.preimage_preimage,
       sphereTangentMap_proj, FiberBundleCore.localTriv_apply,
-      VectorBundleCore.toFiberBundleCore_indexAt, tangentBundleCore_indexAt,
-      VectorBundleCore.coe_coordChange, tangentBundleCore_coordChange, PartialHomeomorph.extend,
-      modelWithCornersSelf_partialEquiv, PartialEquiv.trans_refl, PartialHomeomorph.toFun_eq_coe,
-      coe_achart, PartialHomeomorph.coe_coe_symm, modelWithCornersSelf_coe, Set.range_id,
-      fderivWithin_univ]
+      tangentBundleCore_indexAt, tangentBundleCore_coordChange, Set.range_id, fderivWithin_univ]
     refine
       ContinuousOn.isOpen_inter_preimage (ContinuousOn.prod (contMDiff_iff.mp hf).1.continuousOn ?_)
         ((contMDiff_iff.mp hf).1.isOpen_preimage _
@@ -231,25 +217,14 @@ theorem contMDiff_sphereTangentMap {n : ℕ} [Fact (finrank ℝ E = n + 1)]
   · rintro ⟨p, v⟩
     conv =>
       arg 4
-      simp only [extChartAt, PartialHomeomorph.extend, TangentBundle.chartAt,
-        FiberBundleCore.proj, ← TangentBundle.trivializationAt_eq_localTriv,
-        PartialHomeomorph.trans_toPartialEquiv, PartialHomeomorph.prod_toPartialEquiv,
-        PartialHomeomorph.refl_partialEquiv, modelWithCorners_prod_toPartialEquiv,
-        modelWithCornersSelf_partialEquiv, PartialEquiv.refl_prod_refl, PartialEquiv.coe_trans,
-        PartialEquiv.refl_coe, PartialEquiv.prod_coe, PartialHomeomorph.toFun_eq_coe, id_eq,
-        Trivialization.coe_coe, comp_def, TangentBundle.trivializationAt_apply,
-        PartialEquiv.trans_refl, PartialHomeomorph.coe_coe_symm, modelWithCornersSelf_coe,
-        Set.range_id, fderivWithin_univ, CompTriple.comp_eq, sphereTangentMap_proj,
-        chartAt, ChartedSpace.chartAt, stereographic'_neg]
+      simp only [mfld_simps, TangentBundle.chartAt, ← TangentBundle.trivializationAt_eq_localTriv,
+        comp_def, TangentBundle.trivializationAt_apply,
+        fderivWithin_univ, chartAt, ChartedSpace.chartAt, stereographic'_neg]
     conv =>
       arg 5
       tactic =>
         ext x
-        simp only [extChartAt, PartialHomeomorph.extend, modelWithCorners_prod_toPartialEquiv,
-          modelWithCornersSelf_partialEquiv, PartialEquiv.refl_prod_refl, PartialEquiv.trans_source,
-          PartialHomeomorph.toFun_eq_coe, PartialEquiv.refl_source, Set.preimage_univ,
-          Set.inter_univ, Set.mem_preimage, TangentBundle.mem_chart_source_iff,
-          sphereTangentMap_proj]
+        simp only [mfld_simps, sphereTangentMap_proj]
         rw [← Set.mem_preimage]
     apply ContMDiffOn.prod_mk_space
     · rw [contMDiff_iff_target] at hf

--- a/Mathlib/Geometry/Manifold/VectorBundle/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Sphere.lean
@@ -33,22 +33,6 @@ open private stereographic'_neg from Mathlib.Geometry.Manifold.Instances.Sphere
 noncomputable section
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] (v : E)
-
-theorem contDiff_uncurry_stereoInvFunAux : ContDiff ℝ ω (uncurry (stereoInvFunAux (E := E))) := by
-  have h₀ : ContDiff ℝ ω fun p : E × E => ‖p.2‖ ^ 2 := contDiff_norm_sq ℝ |>.comp contDiff_snd
-  have h₁ : ContDiff ℝ ω fun p : E × E => (‖p.2‖ ^ 2 + 4)⁻¹ := by
-    refine (h₀.add contDiff_const).inv ?_
-    intro x
-    nlinarith
-  have h₂ : ContDiff ℝ ω fun p : E × E => (4 : ℝ) • p.2 + (‖p.2‖ ^ 2 - 4) • p.1 := by
-    refine (contDiff_const.smul contDiff_snd).add ?_
-    exact (h₀.sub contDiff_const).smul contDiff_fst
-  exact h₁.smul h₂
-
-theorem coe_sphere_comp_stereoInvFun (hv : ‖v‖ = 1) :
-    ((↑) : ↥(sphere (0 : E) 1) → E) ∘ stereoInvFun hv = stereoInvFunAux v ∘ Subtype.val :=
-  rfl
-
 variable {m : WithTop ℕ∞} {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
 variable {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ F H}
 variable {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I m M]

--- a/Mathlib/Geometry/Manifold/VectorBundle/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Sphere.lean
@@ -8,19 +8,22 @@ import Mathlib.Geometry.Manifold.VectorBundle.Tangent
 import Mathlib.Geometry.Manifold.Instances.Sphere
 
 /-!
-# Convert orthogonal smooth `M → 𝕊ⁿ` & `M → ℝⁿ⁺¹` to smooth `M → T𝕊ⁿ`
+# Constructing a smooth map to `T𝕊ⁿ` from its components
+
+This file provides a more convenient way to construct a smooth map `M → T𝕊ⁿ`
+from its components: smooth functions `M → 𝕊ⁿ` and `M → ℝⁿ⁺¹` which are orthogonal in `ℝⁿ`.
 
 ## Main definitions
 
-* `sphereTangentMap` : Convert `f : M → 𝕊ⁿ` & `g : M → ℝⁿ⁺¹` which satisfy `∀ x, ⟪f x, g x⟫_ℝ = 0`
-  to `M → T𝕊ⁿ`.
+* `sphereTangentMap f g` : convert map `f : M → 𝕊ⁿ` and `g : M → ℝⁿ⁺¹`
+  which satisfy `∀ x, ⟪f x, g x⟫_ℝ = 0` to a map `M → T𝕊ⁿ`.
 
 ## Main statements
 
 * `mfderiv_coe_sphere_sphereTangentMap_snd` : Let `ι` be an inclusion map from `T𝕊ⁿ` to `Tℝⁿ⁺¹`,
   then `ι (sphereTangentMap n f g hf x).snd = g x`.
 
-* `contMDiff_sphereTangentMap` : If `f` & `g` are smooth, then `sphereTangentMap n f g hf'` too.
+* `contMDiff_sphereTangentMap` : if `f` and `g` are smooth, then so is `sphereTangentMap n f g hf'`
 
 -/
 


### PR DESCRIPTION
Current Mathlib has no easy way to define function from a manifold to tangent bundles of sphere: `T𝕊ⁿ`.

This PR gives this: `sphereTangentMap`. This convert orthogonal smooth `M → 𝕊ⁿ` & `M → ℝⁿ⁺¹` to smooth `M → T𝕊ⁿ`.

I also proved that if `f : M → 𝕊ⁿ` & `g : M → ℝⁿ⁺¹` are smooth then `sphereTangentMap` of `f` & `g` is smooth too.

---

⚠ **CAUTION**

I formalized this in my spare time.
I don't have the energy to maintain the PR, but I create this PR so this may helps everyone.
The only one thing to do is proof cleanup.

TODO:
- [x] `contDiff_uncurry_stereoInvFunAux` & `coe_sphere_comp_stereoInvFun` may have to be moved to `Mathlib.Geometry.Manifold.Instances.Sphere`.
- [ ] Proof cleanup. Current proof may be redundant and ugly.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
