### PR TITLE
feat: `PFunLike` typeclass for partial homomorphisms and `LinearPMapClass`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -303,6 +303,7 @@ import Mathlib.Algebra.Group.Nat.Units
 import Mathlib.Algebra.Group.NatPowAssoc
 import Mathlib.Algebra.Group.Operations
 import Mathlib.Algebra.Group.Opposite
+import Mathlib.Algebra.Group.PHom
 import Mathlib.Algebra.Group.PNatPowAssoc
 import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Group.Pi.Lemmas
@@ -3245,6 +3246,7 @@ import Mathlib.GroupTheory.GroupAction.FixedPoints
 import Mathlib.GroupTheory.GroupAction.FixingSubgroup
 import Mathlib.GroupTheory.GroupAction.Hom
 import Mathlib.GroupTheory.GroupAction.IterateAct
+import Mathlib.GroupTheory.GroupAction.PHom
 import Mathlib.GroupTheory.GroupAction.Period
 import Mathlib.GroupTheory.GroupAction.Pointwise
 import Mathlib.GroupTheory.GroupAction.Quotient

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2842,6 +2842,7 @@ import Mathlib.Data.Ordmap.Ordnode
 import Mathlib.Data.Ordmap.Ordset
 import Mathlib.Data.PEquiv
 import Mathlib.Data.PFun
+import Mathlib.Data.PFunLike
 import Mathlib.Data.PFunctor.Multivariate.Basic
 import Mathlib.Data.PFunctor.Multivariate.M
 import Mathlib.Data.PFunctor.Multivariate.W

--- a/Mathlib/Algebra/Group/PHom.lean
+++ b/Mathlib/Algebra/Group/PHom.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2025 Etienne Marion. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Etienne Marion
+-/
+import Mathlib.Algebra.Group.Subgroup.Defs
+import Mathlib.Data.PFunLike
+
+/-!
+# Partial monoid and group homomorphisms
+
+This file defines the typeclasses for types whose terms can be seen as partial
+group/monoid homomorphisms, namely `MonoidPHomClass` and `AddMonoidPHomClass`. We also define
+`ZeroPHomClass`, `OnePHomClass`, `AddPHomClass` and `MulPHomClass` as building blocks for for other
+partial homomorphisms.
+-/
+
+/-- `ZeroPHomClass F M γ N` states that `F` is a type of partial zero-preserving homomorphisms
+with domains of type `γ`. -/
+class ZeroPHomClass (F : Type*) (M γ N : outParam Type*) [SetLike γ M] [Zero M] [Zero N]
+    [ZeroMemClass γ M] [PFunLike F M γ N] where
+  pmap_zero : ∀ (f : F), f 0 = 0
+
+export ZeroPHomClass (pmap_zero)
+
+attribute [simp] pmap_zero
+
+/-- `OnePHomClass F M γ N` states that `F` is a type of partial one-preserving homomorphisms
+with domains of type `γ`. -/
+@[to_additive]
+class OnePHomClass (F : Type*) (M γ N : outParam Type*) [SetLike γ M] [One M] [One N]
+    [OneMemClass γ M] [PFunLike F M γ N] where
+  pmap_one : ∀ (f : F), f 1 = 1
+
+export OnePHomClass (pmap_one)
+
+attribute [simp] pmap_one
+
+/-- `AddPHomClass F M γ N` states that `F` is a type of partial addition-preserving homomorphisms
+with domains of type `γ`. -/
+class AddPHomClass (F : Type*) (M γ N : outParam Type*)
+    [SetLike γ M] [Add M] [Add N] [AddMemClass γ M] [PFunLike F M γ N] where
+  pmap_add : ∀ (f : F) (x y : PFunLike.domain f), f (x + y) = f x + f y
+
+export AddPHomClass (pmap_add)
+
+attribute [simp] pmap_add
+
+/-- `MulPHomClass F M γ N` states that `F` is a type of partial multiplication-preserving
+homomorphisms with domains of type `γ`. -/
+@[to_additive]
+class MulPHomClass (F : Type*) (M γ N : outParam Type*)
+    [SetLike γ M] [Mul M] [Mul N] [MulMemClass γ M] [PFunLike F M γ N] where
+  pmap_mul : ∀ (f : F) (x y : PFunLike.domain f), f (x * y) = f x * f y
+
+export MulPHomClass (pmap_mul)
+
+attribute [simp] pmap_mul
+
+/-- `AddMonoidPHomClass F M γ N` states that `F` is a type of partial `AddZeroClass`-preserving
+homomorphisms with domains of type `γ`. -/
+class AddMonoidPHomClass (F : Type*) (M γ N : outParam Type*) [SetLike γ M]
+    [AddZeroClass M] [AddZeroClass N] [AddSubmonoidClass γ M] [PFunLike F M γ N]
+    extends AddPHomClass F M γ N, ZeroPHomClass F M γ N
+
+/-- `MonoidPHomClass F M γ N` states that `F` is a type of partial `MulOneClass`-preserving
+homomorphisms with domains of type `γ`. -/
+@[to_additive]
+class MonoidPHomClass (F : Type*) (M γ N : outParam Type*) [SetLike γ M]
+    [MulOneClass M] [MulOneClass N] [SubmonoidClass γ M] [PFunLike F M γ N]
+    extends MulPHomClass F M γ N, OnePHomClass F M γ N
+
+@[to_additive]
+theorem pmap_mul_eq_one {F M γ N : Type*} [MulOneClass M] [MulOneClass N] [SetLike γ M]
+    [SubmonoidClass γ M] [PFunLike F M γ N] [MonoidPHomClass F M γ N]
+    {f : F} {a b : PFunLike.domain f} (h : a * b = 1) : f a * f b = 1 := by
+  rw [← MulPHomClass.pmap_mul, h, OnePHomClass.pmap_one]
+
+@[to_additive, simp]
+theorem pmap_inv {F G γ H : Type*} [Group G] [DivisionMonoid H] [SetLike γ G]
+    [SubgroupClass γ G] [PFunLike F G γ H] [MonoidPHomClass F G γ H]
+    {f : F} (a : PFunLike.domain f) : f (a⁻¹) = (f a)⁻¹ :=
+  eq_inv_of_mul_eq_one_left <| pmap_mul_eq_one <| inv_mul_cancel _
+
+@[to_additive, simp]
+theorem pmap_div {F G γ H : Type*} [Group G] [DivisionMonoid H] [SetLike γ G]
+    [SubgroupClass γ G] [PFunLike F G γ H] [MonoidPHomClass F G γ H]
+    {f : F} (a b : PFunLike.domain f) : f (a / b) = f a / f b := by
+  rw [div_eq_mul_inv, div_eq_mul_inv, MulPHomClass.pmap_mul, pmap_inv]

--- a/Mathlib/Algebra/Module/Injective.lean
+++ b/Mathlib/Algebra/Module/Injective.lean
@@ -240,12 +240,12 @@ def ExtensionOfMaxAdjoin.idealTo (y : N) : ExtensionOfMaxAdjoin.ideal i f y →�
   toFun (z : { x // x ∈ ideal i f y }) := (extensionOfMax i f).toLinearPMap ⟨(↑z : R) • y, z.prop⟩
   map_add' (z1 z2 : { x // x ∈ ideal i f y }) := by
     -- Porting note: a single simp took care of the goal before reenableeta
-    simp_rw [← (extensionOfMax i f).toLinearPMap.map_add]
+    simp_rw [← pmap_add (extensionOfMax i f).toLinearPMap]
     congr
     apply add_smul
   map_smul' z1 (z2 : {x // x ∈ ideal i f y}) := by
     -- Porting note: a single simp took care of the goal before reenableeta
-    simp_rw [← (extensionOfMax i f).toLinearPMap.map_smul]
+    simp_rw [← pmap_smul (extensionOfMax i f).toLinearPMap]
     congr 2
     apply mul_smul
 
@@ -268,7 +268,7 @@ theorem ExtensionOfMaxAdjoin.extendIdealTo_wd' (h : Module.Baer R Q) {y : N} (r 
   rw [ExtensionOfMaxAdjoin.extendIdealTo_is_extension i f h y r this]
   dsimp [ExtensionOfMaxAdjoin.idealTo]
   simp only [LinearMap.coe_mk, eq1, Subtype.coe_mk, ← ZeroMemClass.zero_def,
-    (extensionOfMax i f).toLinearPMap.map_zero]
+    pmap_zero (extensionOfMax i f).toLinearPMap]
 
 theorem ExtensionOfMaxAdjoin.extendIdealTo_wd (h : Module.Baer R Q) {y : N} (r r' : R)
     (eq1 : r • y = r' • y) : ExtensionOfMaxAdjoin.extendIdealTo i f h y r =
@@ -307,7 +307,7 @@ theorem ExtensionOfMaxAdjoin.extensionToFun_wd (h : Module.Baer R Q) {y : N}
       (by rw [← eq2]; exact Submodule.sub_mem _ (ExtensionOfMaxAdjoin.fst i x).2 ha)
   simp only [map_sub, sub_smul, sub_eq_iff_eq_add] at eq3
   unfold ExtensionOfMaxAdjoin.extensionToFun
-  rw [eq3, ← add_assoc, ← (extensionOfMax i f).toLinearPMap.map_add, AddMemClass.mk_add_mk]
+  rw [eq3, ← add_assoc, ← pmap_add (extensionOfMax i f).toLinearPMap, AddMemClass.mk_add_mk]
   congr
   ext
   dsimp
@@ -327,8 +327,8 @@ def extensionOfMaxAdjoin (h : Module.Baer R Q) (y : N) : ExtensionOf i f where
               (ExtensionOfMaxAdjoin.snd i a + ExtensionOfMaxAdjoin.snd i b) • y := by
           rw [ExtensionOfMaxAdjoin.eqn, ExtensionOfMaxAdjoin.eqn, add_smul, Submodule.coe_add]
           ac_rfl
-        rw [ExtensionOfMaxAdjoin.extensionToFun_wd (y := y) i f h (a + b) _ _ eq1,
-          LinearPMap.map_add, map_add]
+        rw [ExtensionOfMaxAdjoin.extensionToFun_wd (y := y) i f h (a + b) _ _ eq1, pmap_add,
+          map_add]
         unfold ExtensionOfMaxAdjoin.extensionToFun
         abel
       map_smul' := fun r a => by
@@ -339,7 +339,7 @@ def extensionOfMaxAdjoin (h : Module.Baer R Q) (y : N) : ExtensionOf i f where
           rw [ExtensionOfMaxAdjoin.eqn, smul_add, smul_eq_mul, mul_smul]
           rfl
         rw [ExtensionOfMaxAdjoin.extensionToFun_wd i f h (r • a :) _ _ eq1, LinearMap.map_smul,
-          LinearPMap.map_smul, ← smul_add]
+          pmap_smul, ← smul_add]
         congr }
   is_extension m := by
     dsimp
@@ -368,9 +368,10 @@ protected theorem extension_property (h : Module.Baer R Q)
   haveI : Fact (Function.Injective f) := ⟨hf⟩
   Exists.intro
     { toFun := ((extensionOfMax f g).toLinearPMap
-        ⟨·, (extensionOfMax_to_submodule_eq_top f g h).symm ▸ ⟨⟩⟩)
-      map_add' := fun x y ↦ by rw [← LinearPMap.map_add]; congr
-      map_smul' := fun r x ↦ by rw [← LinearPMap.map_smul]; dsimp } <|
+        ⟨·, have : ⊤ = PFunLike.domain (extensionOfMax f g).toLinearPMap :=
+          (extensionOfMax_to_submodule_eq_top f g h).symm; this ▸ ⟨⟩⟩)
+      map_add' := fun x y ↦ by rw [← pmap_add]; congr
+      map_smul' := fun r x ↦ by rw [← pmap_smul]; dsimp } <|
     LinearMap.ext fun x ↦ ((extensionOfMax f g).is_extension x).symm
 
 theorem extension_property_addMonoidHom (h : Module.Baer ℤ Q)

--- a/Mathlib/Analysis/Convex/Cone/Extension.lean
+++ b/Mathlib/Analysis/Convex/Cone/Extension.lean
@@ -77,7 +77,7 @@ theorem step (nonneg : ∀ x : f.domain, (x : E) ∈ s → 0 ≤ f x)
     have := s.add_mem hxp hxn
     rw [add_assoc, add_sub_cancel, ← sub_eq_add_neg, ← AddSubgroupClass.coe_sub] at this
     replace := nonneg _ this
-    rwa [f.map_sub, sub_nonneg] at this
+    rwa [pmap_sub, sub_nonneg] at this
   -- Porting note: removed an unused `have`
   refine ⟨f.supSpanSingleton y (-c) hy, ?_, ?_⟩
   · refine lt_iff_le_not_le.2 ⟨f.left_le_sup _ _, fun H => ?_⟩
@@ -95,7 +95,7 @@ theorem step (nonneg : ∀ x : f.domain, (x : E) ∈ s → 0 ≤ f x)
           mul_inv_cancel₀ hr.ne, one_smul, sub_eq_add_neg, neg_smul, neg_neg]
       -- Porting note: added type annotation and `by exact`
       replace : f (r⁻¹ • ⟨x, hx⟩) ≤ c := le_c (r⁻¹ • ⟨x, hx⟩) (by exact this)
-      rwa [← mul_le_mul_left (neg_pos.2 hr), neg_mul, neg_mul, neg_le_neg_iff, f.map_smul,
+      rwa [← mul_le_mul_left (neg_pos.2 hr), neg_mul, neg_mul, neg_le_neg_iff, pmap_smul,
         smul_eq_mul, ← mul_assoc, mul_inv_cancel₀ hr.ne, one_mul] at this
     · subst r
       simp only [zero_smul, add_zero] at hzs ⊢
@@ -105,7 +105,7 @@ theorem step (nonneg : ∀ x : f.domain, (x : E) ∈ s → 0 ≤ f x)
         rwa [← s.smul_mem_iff hr, smul_add, smul_smul, mul_inv_cancel₀ hr.ne', one_smul]
       -- Porting note: added type annotation and `by exact`
       replace : c ≤ f (r⁻¹ • ⟨x, hx⟩) := c_le (r⁻¹ • ⟨x, hx⟩) (by exact this)
-      rwa [← mul_le_mul_left hr, f.map_smul, smul_eq_mul, ← mul_assoc, mul_inv_cancel₀ hr.ne',
+      rwa [← mul_le_mul_left hr, pmap_smul, smul_eq_mul, ← mul_assoc, mul_inv_cancel₀ hr.ne',
         one_mul] at this
 
 theorem exists_top (p : E →ₗ.[ℝ] ℝ) (hp_nonneg : ∀ x : p.domain, (x : E) ∈ s → 0 ≤ p x)

--- a/Mathlib/Data/PFunLike.lean
+++ b/Mathlib/Data/PFunLike.lean
@@ -34,7 +34,9 @@ This typeclass is used in the definition of the homomorphism typeclasses,
 such as `ZeroPHomClass`, `MulPHomClass`, `MonoidPHomClass`...
 -/
 class PFunLike (F : Type*) (α γ β : outParam Type*) [SetLike γ α] where
+/-- Each `f : F` has a domain which is a subset of `α`. -/
 domain : F → γ
+/-- A coercion which sends each `f : F` to the corresponding map `α → β`. -/
 coe : Π (f : F), (domain f) → β
 coe_injective : Π (f g : F), domain f = domain g →
   (∀ (x : domain f) (y : domain g), (x : α) = (y : α) → coe f x = coe g y) → f = g

--- a/Mathlib/Data/PFunLike.lean
+++ b/Mathlib/Data/PFunLike.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2025 Etienne Marion. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Etienne Marion
+-/
+import Mathlib.Data.SetLike.Basic
+
+/-!
+# Typeclass `PFunLike` for a type whose elements are partial functions
+
+This typeclass is intended to be used in a similar way to `FunLike` but each function is partial,
+i.e. it is defined over a subtype. It is implemented to allow for partial homomorphisms such as
+`LinearPMap` to work with the same system as classical homomorphisms do.
+
+This typeclass is **not** intended to be used as a generalization of `FunLike`, but rather as a
+parallel system. The links between partial homomorphisms and classical homomorphisms should be
+implemented separately.
+
+## Implementation notes
+
+As it is the case with `FunLike` the type class `PFunLike` should not be extended when defining
+a new typeclass for partial homomorphisms, but rather added as an assumption. Here is an example
+with the class of partial morphisms which map 0 to 0:
+
+class ZeroPHomClass (F : Type*) (M γ N : outParam Type*) [SetLike γ M] [Zero M] [Zero N]
+    [ZeroMemClass γ M] [PFunLike F M γ N] where
+  pmap_zero : ∀ (f : F), f 0 = 0
+-/
+
+/-- The class `PFunLike F α γ β` expresses that a term `f : F` can be seen as a function from
+`domain f` to `β`, where `domain f : γ` can be seen as a subset of `α` (see `SetLike`).
+
+This typeclass is used in the definition of the homomorphism typeclasses,
+such as `ZeroPHomClass`, `MulPHomClass`, `MonoidPHomClass`...
+-/
+class PFunLike (F : Type*) (α γ β : outParam Type*) [SetLike γ α] where
+domain : F → γ
+coe : Π (f : F), (domain f) → β
+coe_injective : Π (f g : F), domain f = domain g →
+  (∀ (x : domain f) (y : domain g), (x : α) = (y : α) → coe f x = coe g y) → f = g
+
+attribute [coe] PFunLike.coe
+
+namespace PFunLike
+
+variable {F α γ β : Type*} [SetLike γ α] [PFunLike F α γ β]
+
+instance (priority := 100) CoeFun : CoeFun F (fun f ↦ domain f → β) := ⟨coe⟩
+
+lemma ext {f g : F} (hd : domain f = domain g)
+    (h : ∀ ⦃x : domain f⦄ ⦃y : domain g⦄, (x : α) = y → f x = g y) : f = g :=
+  coe_injective f g hd h
+
+lemma ext_iff {f g : F} :
+    f = g ↔ domain f = domain g ∧ ∀ ⦃x : domain f⦄ ⦃y : domain g⦄, (x : α) = y → f x = g y where
+  mp h := by cases h; simp
+  mpr := fun ⟨hd, h⟩ ↦ ext hd h
+
+end PFunLike

--- a/Mathlib/GroupTheory/GroupAction/PHom.lean
+++ b/Mathlib/GroupTheory/GroupAction/PHom.lean
@@ -26,8 +26,6 @@ class AddActionPSemiHomClass (F : Type*) {M N : outParam Type*} (φ : outParam (
 
 export AddActionPSemiHomClass (pmap_vaddₛₗ)
 
-attribute [simp] pmap_vaddₛₗ
-
 /-- `AddActionPSemiHomClass F φ X γ Y` states that `F` is a type of partial bundled `X → Y` homs
   which are `φ`-equivariant and whose domains are of type `γ`. -/
 @[to_additive]
@@ -38,15 +36,13 @@ class MulActionPSemiHomClass (F : Type*) {M N : outParam Type*} (φ : outParam (
 
 export MulActionPSemiHomClass (pmap_smulₛₗ)
 
-attribute [simp] pmap_smulₛₗ
-
 /-- `MulActionHomClass F M X γ Y` is an abbrev for `MulActionPSemiHomClass F id X γ Y`. -/
 @[to_additive "`AddActionHomClass F M X γ Y` is an abbrev for `AddActionPSemiHomClass F id X γ Y`."]
 abbrev MulActionPHomClass (F : Type*) (M X γ Y : outParam Type*) [SetLike γ X]
     [SMul M X] [SMul M Y] [PFunLike F X γ Y] [SMulMemClass γ M X] :=
   MulActionPSemiHomClass F (@id M) X γ Y
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 lemma pmap_smul {F M X γ Y : Type*} [SetLike γ X] [SMul M X] [SMul M Y] [PFunLike F X γ Y]
     [SMulMemClass γ M X] [MulActionPHomClass F M X γ Y]
     (f : F) (c : M) (x : PFunLike.domain f) : f (c • x) = c • f x := pmap_smulₛₗ f c x

--- a/Mathlib/GroupTheory/GroupAction/PHom.lean
+++ b/Mathlib/GroupTheory/GroupAction/PHom.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2025 Etienne Marion. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Etienne Marion
+-/
+import Mathlib.Data.PFunLike
+import Mathlib.GroupTheory.GroupAction.SubMulAction
+
+/-!
+# Partial equivariant homomorphisms
+
+## Main definitions
+
+* `MulActionPSemiHomClass F φ X γ Y` states that `F` is a type of partial bundled `X → Y` homs
+  which are `φ`-equivariant and whose domains are of type `γ`;
+  `AddActionPSemiHomClass F φ X Y` is its additive version.
+* `MulActionHomClass F M X γ Y` is an abbrev for `MulActionPSemiHomClass F id X γ Y`.
+-/
+
+/-- `MulActionPSemiHomClass F φ X γ Y` states that `F` is a type of partial bundled `X → Y` homs
+  which are `φ`-equivariant and whose domains are of type `γ`. -/
+class AddActionPSemiHomClass (F : Type*) {M N : outParam Type*} (φ : outParam (M → N))
+    (X γ Y : outParam Type*) [SetLike γ X] [VAdd M X] [VAdd N Y] [PFunLike F X γ Y]
+    [VAddMemClass γ M X] where
+  pmap_vaddₛₗ : ∀ (f : F) (c : M) (x : PFunLike.domain f), f (c +ᵥ x) = φ c +ᵥ f x
+
+export AddActionPSemiHomClass (pmap_vaddₛₗ)
+
+attribute [simp] pmap_vaddₛₗ
+
+/-- `AddActionPSemiHomClass F φ X γ Y` states that `F` is a type of partial bundled `X → Y` homs
+  which are `φ`-equivariant and whose domains are of type `γ`. -/
+@[to_additive]
+class MulActionPSemiHomClass (F : Type*) {M N : outParam Type*} (φ : outParam (M → N))
+    (X γ Y : outParam Type*) [SetLike γ X] [SMul M X] [SMul N Y] [PFunLike F X γ Y]
+    [SMulMemClass γ M X] where
+  pmap_smulₛₗ : ∀ (f : F) (c : M) (x : PFunLike.domain f), f (c • x) = φ c • f x
+
+export MulActionPSemiHomClass (pmap_smulₛₗ)
+
+attribute [simp] pmap_smulₛₗ
+
+/-- `MulActionHomClass F M X γ Y` is an abbrev for `MulActionPSemiHomClass F id X γ Y`. -/
+@[to_additive "`AddActionHomClass F M X γ Y` is an abbrev for `AddActionPSemiHomClass F id X γ Y`."]
+abbrev MulActionPHomClass (F : Type*) (M X γ Y : outParam Type*) [SetLike γ X]
+    [SMul M X] [SMul M Y] [PFunLike F X γ Y] [SMulMemClass γ M X] :=
+  MulActionPSemiHomClass F (@id M) X γ Y
+
+@[to_additive, simp]
+lemma pmap_smul {F M X γ Y : Type*} [SetLike γ X] [SMul M X] [SMul M Y] [PFunLike F X γ Y]
+    [SMulMemClass γ M X] [MulActionPHomClass F M X γ Y]
+    (f : F) (c : M) (x : PFunLike.domain f) : f (c • x) = c • f x := pmap_smulₛₗ f c x

--- a/Mathlib/LinearAlgebra/LinearPMap.lean
+++ b/Mathlib/LinearAlgebra/LinearPMap.lean
@@ -553,7 +553,6 @@ theorem domain_supSpanSingleton (f : E →ₗ.[K] F) (x : E) (y : F) (hx : x ∉
     (f.supSpanSingleton x y hx).domain = f.domain ⊔ K ∙ x :=
   rfl
 
-@[simp]
 theorem supSpanSingleton_apply_mk (f : E →ₗ.[K] F) (x : E) (y : F) (hx : x ∉ f.domain) (x' : E)
     (hx' : x' ∈ f.domain) (c : K) :
     f.supSpanSingleton x y hx


### PR DESCRIPTION
A test PR implementing a typeclass `PFunLike` to represent partial homomorphisms and building a `LinearPMapClass` typeclass. Started from [this](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/ContinuousLinearPMap) discussion.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
