### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Localization): HasLocalization holds iff the localized category is locally small

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2000,6 +2000,7 @@ import Mathlib.CategoryTheory.Localization.FiniteProducts
 import Mathlib.CategoryTheory.Localization.HasLocalization
 import Mathlib.CategoryTheory.Localization.HomEquiv
 import Mathlib.CategoryTheory.Localization.LocalizerMorphism
+import Mathlib.CategoryTheory.Localization.LocallySmall
 import Mathlib.CategoryTheory.Localization.Opposite
 import Mathlib.CategoryTheory.Localization.Pi
 import Mathlib.CategoryTheory.Localization.Predicate

--- a/Mathlib/CategoryTheory/Localization/LocallySmall.lean
+++ b/Mathlib/CategoryTheory/Localization/LocallySmall.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import Mathlib.CategoryTheory.Localization.HasLocalization
+import Mathlib.CategoryTheory.EssentiallySmall
+
+/-!
+# Locally small localizations
+
+In this file, given `W : MorphismProperty C` and a universe `w`, we show
+that there exists a term in `HasLocaliaation.{w} W` if and only if
+there exists (or for all) localization functors `L : C ⥤ D` for `W`,
+the category `D` is locally `w`-small.
+
+-/
+
+universe w v₁ v₂ u₁ u₂
+
+namespace CategoryTheory.MorphismProperty
+
+variable {C : Type u₁} [Category.{v₁} C] (W : MorphismProperty C)
+
+/-- If `L : C ⥤ D` is a localization functor for a class of morphisms
+`W : MorphismProperty C`, and `D` is locally `w`-small, we may obtain
+a `HasLocalization.{w} W` instance by shrinking the morphisms in `D`.
+(This version assumes that the types of objects of the categories
+`C` and `D` are in the same universe.) -/
+noncomputable def hasLocalizationOfLocallySmall
+    {D : Type u₁} [Category.{v₂} D] [LocallySmall.{w} D]
+    (L : C ⥤ D) [L.IsLocalization W] :
+    HasLocalization.{w} W where
+  D := ShrinkHoms D
+  L := L ⋙ (ShrinkHoms.equivalence D).functor
+
+/-- If `L : C ⥤ D` is a localization functor for a class of morphisms
+`W : MorphismProperty C`, and `D` is locally `w`-small, we may obtain
+a `HasLocalization.{w} W` instance. This should be used only in the
+unlikely situation where the types of objects of `C` and `D` are in
+different universes. Otherwise, use `hasLocalizationOfLocallySmall`. -/
+noncomputable irreducible_def hasLocalizationOfLocallySmall'
+    {D : Type u₂} [Category.{v₂} D] [LocallySmall.{w} D]
+    (L : C ⥤ D) [L.IsLocalization W] :
+    HasLocalization.{w} W := by
+  have : LocallySmall.{w} (InducedCategory _ L.obj) :=
+    ⟨fun X Y ↦ inferInstanceAs (Small.{w} (L.obj X ⟶ L.obj Y))⟩
+  let L' : C ⥤ (InducedCategory _ L.obj) :=
+    { obj X := X
+      map f := L.map f }
+  have := Localization.essSurj L W
+  have : (inducedFunctor L.obj).EssSurj := ⟨fun Y ↦ ⟨_, ⟨L.objObjPreimageIso Y⟩⟩⟩
+  have : (inducedFunctor L.obj).IsEquivalence := { }
+  let e := (inducedFunctor L.obj).asEquivalence
+  let e' : (L' ⋙ e.functor) ⋙ e.inverse ≅ L' :=
+    Functor.associator _ _ _ ≪≫ isoWhiskerLeft L' e.unitIso.symm ≪≫ L'.rightUnitor
+  have : L'.IsLocalization W :=
+    Functor.IsLocalization.of_iso W (L₁ := L ⋙ e.inverse) e'
+  exact hasLocalizationOfLocallySmall.{w} W L'
+
+/-- If a class of morphisms `W : MorphismProperty C` satisfies `HasLocalization.{w} W`,
+then any localized category for `W` (i.e. any target of a localization functor
+`L : C ⥤ D` for `W`) is locally `w`-small. -/
+lemma locallySmall_of_hasLocalization {D : Type u₂} [Category.{v₂} D]
+    (L : C ⥤ D) [L.IsLocalization W] [HasLocalization.{w} W] :
+    LocallySmall.{w} D where
+  hom_small _ _ := small_of_injective (fun _ _ h ↦
+    (Localization.uniq L W.Q' W).functor.map_injective h)
+
+end CategoryTheory.MorphismProperty

--- a/Mathlib/CategoryTheory/Localization/LocallySmall.lean
+++ b/Mathlib/CategoryTheory/Localization/LocallySmall.lean
@@ -11,7 +11,7 @@ import Mathlib.CategoryTheory.EssentiallySmall
 # Locally small localizations
 
 In this file, given `W : MorphismProperty C` and a universe `w`, we show
-that there exists a term in `HasLocaliaation.{w} W` if and only if
+that there exists a term in `HasLocalization.{w} W` if and only if
 there exists (or for all) localization functors `L : C ⥤ D` for `W`,
 the category `D` is locally `w`-small.
 


### PR DESCRIPTION
In this file, given `W : MorphismProperty C` and a universe `w`, we show that there exists a term in `HasLocaliaation.{w} W` if and only if there exists (or for all) localization functors `L : C ⥤ D` for `W`, the category `D` is locally `w`-small.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
