### PR TITLE
[Merged by Bors] - chore: replace manually ported proof with aesop

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -589,24 +589,7 @@ theorem mul_nonneg_of_three [ExistsAddOfLE α] [MulPosStrictMono α] [PosMulStri
   have or_a := le_total 0 a
   have or_b := le_total 0 b
   have or_c := le_total 0 c
-  -- Porting note used to be by `itauto` from here
-  exact Or.elim or_c
-    (fun (h0 : 0 ≤ c) =>
-      Or.elim or_b
-        (fun (h1 : 0 ≤ b) =>
-            Or.elim or_a (fun (h2 : 0 ≤ a) => Or.inl (Or.inl ⟨h2, h1⟩))
-              (fun (_ : a ≤ 0) => Or.inr (Or.inl (Or.inl ⟨h1, h0⟩))))
-        (fun (h1 : b ≤ 0) =>
-            Or.elim or_a (fun (h3 : 0 ≤ a) => Or.inr (Or.inr (Or.inl ⟨h0, h3⟩)))
-              (fun (h3 : a ≤ 0) => Or.inl (Or.inr ⟨h3, h1⟩))))
-    (fun (h0 : c ≤ 0) =>
-      Or.elim or_b
-        (fun (h4 : 0 ≤ b) =>
-            Or.elim or_a (fun (h5 : 0 ≤ a) => Or.inl (Or.inl ⟨h5, h4⟩))
-              (fun (h5 : a ≤ 0) => Or.inr (Or.inr (Or.inr ⟨h0, h5⟩))))
-        (fun (h4 : b ≤ 0) =>
-            Or.elim or_a (fun (_ : 0 ≤ a) => Or.inr (Or.inl (Or.inr ⟨h4, h0⟩)))
-              (fun (h6 : a ≤ 0) => Or.inl (Or.inr ⟨h6, h4⟩))))
+  aesop
 
 lemma mul_nonneg_iff_pos_imp_nonneg [ExistsAddOfLE α] [PosMulStrictMono α] [MulPosStrictMono α]
     [AddLeftMono α] [AddLeftReflectLE α] :


### PR DESCRIPTION
`itauto` wasn't available during the port, so someone pasted in a term proof. Now, either `itauto` or `aesop` handles this fine. I went with `aesop` as we don't actually use `itauto` anywhere in Mathlib currently, and if that's easy to preserve it seems valuable.