### PR TITLE
[Merged by Bors] - doc(Mathlib/Algebra/CharP/LinearMaps.lean): Fix doc errors

### DIFF
--- a/Mathlib/Algebra/CharP/LinearMaps.lean
+++ b/Mathlib/Algebra/CharP/LinearMaps.lean
@@ -35,8 +35,7 @@ namespace Module
 variable {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 /-- For a commutative semiring `R` and a `R`-module `M`, if `M` contains an
-  element `x` such that `r • x = 0` implies `r = 0` (finding such element usually
-  depends on specific `•`), then the characteristic of `R` is equal to the
+  element `x` that is not torsion, then the characteristic of `R` is equal to the
   characteristic of the `R`-linear endomorphisms of `M`.-/
 theorem charP_end {p : ℕ} [hchar : CharP R p]
     (htorsion : ∃ x : M, Ideal.torsionOf R M x = ⊥) : CharP (M →ₗ[R] M) p where

--- a/Mathlib/Algebra/CharP/LinearMaps.lean
+++ b/Mathlib/Algebra/CharP/LinearMaps.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Wanyi He, Huanyu Zheng
 -/
 import Mathlib.Algebra.CharP.Algebra
+import Mathlib.Algebra.Module.Torsion
 /-!
 # Characteristic of the ring of linear Maps
 
@@ -12,7 +13,7 @@ The characteristic of the ring of linear maps is determined by its base ring.
 
 ## Main Results
 
-- `CharP_if` : For a commutative semiring `R` and a `R`-module `M`,
+- `Module.charP_end` : For a commutative semiring `R` and a `R`-module `M`,
   the characteristic of `R` is equal to the characteristic of the `R`-linear
   endomorphisms of `M` when `M` contains an element `x` such that
   `r • x = 0` implies `r = 0`.
@@ -39,8 +40,11 @@ variable {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
   depends on specific `•`), then the characteristic of `R` is equal to the
   characteristic of the `R`-linear endomorphisms of `M`.-/
 theorem charP_end {p : ℕ} [hchar : CharP R p]
-    (hreduction : ∃ x : M, ∀ r : R, r • x = 0 → r = 0) : CharP (M →ₗ[R] M) p where
+    (htorsion : ∃ x : M, Ideal.torsionOf R M x = ⊥) : CharP (M →ₗ[R] M) p where
   cast_eq_zero_iff' n := by
+    have hreduction : ∃ x : M, ∀ r : R, r • x = 0 → r = 0 :=
+      Exists.casesOn htorsion fun x hx ↦
+        Exists.intro x fun r a ↦ (hx ▸ Ideal.mem_torsionOf_iff x r).mpr a
     have exact : (n : M →ₗ[R] M) = (n : R) • 1 := by
       simp only [Nat.cast_smul_eq_nsmul, nsmul_eq_mul, mul_one]
     rw [exact, LinearMap.ext_iff, ← hchar.1]

--- a/Mathlib/Algebra/CharP/LinearMaps.lean
+++ b/Mathlib/Algebra/CharP/LinearMaps.lean
@@ -15,8 +15,7 @@ The characteristic of the ring of linear maps is determined by its base ring.
 
 - `Module.charP_end` : For a commutative semiring `R` and a `R`-module `M`,
   the characteristic of `R` is equal to the characteristic of the `R`-linear
-  endomorphisms of `M` when `M` contains an element `x` such that
-  `r • x = 0` implies `r = 0`.
+  endomorphisms of `M` when `M` contains a non-torsion element `x`.
 
 ## Notations
 
@@ -27,7 +26,7 @@ The characteristic of the ring of linear maps is determined by its base ring.
 
 One can also deduce similar result via `charP_of_injective_ringHom` and
   `R → (M →ₗ[R] M) : r ↦ (fun (x : M) ↦ r • x)`. But this will require stronger condition
-  compared to `CharP_if`.
+  compared to `Module.charP_end`.
 
 -/
 


### PR DESCRIPTION
1. Fix the doc-string of `Mathlib/Algebra/CharP/LinearMaps.lean`: the name `CharP_if` is outdated and is now corrected as `Module.charP_end`.
2. Express the condition of `Module.charP_end` in the term of torsion.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
