### PR TITLE
[Merged by Bors] - feat: establish integrability and integrals of Real.log on arbitrary intervals

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -235,28 +235,30 @@ theorem intervalIntegrable_log (h : (0 : ℝ) ∉ [[a, b]]) : IntervalIntegrable
 interval. See `intervalIntegrable_log` for a version applying to any locally finite measure,
 but with an additional hypothesis on the interval. -/
 @[simp]
-theorem intervalIntegrable_log' :
-  IntervalIntegrable log volume a b := by
+theorem intervalIntegrable_log' : IntervalIntegrable log volume a b := by
   -- Log is even, so it suffices to consider the case 0 < a and b = 0
-  apply intervalIntegrable_of_even (fun a ↦ Eq.symm (log_neg_eq_log a))
-
+  apply intervalIntegrable_of_even (log_neg_eq_log · |>.symm)
   intro x hx
   -- Split integral
   apply IntervalIntegrable.trans (b := 1)
   · -- Show integrability on [0…1] using non-negativity of the derivative
     rw [← neg_neg log]
     apply IntervalIntegrable.neg
-    apply intervalIntegrable_deriv_of_nonneg
+    apply intervalIntegrable_deriv_of_nonneg (g := fun x ↦ -(x * log x - x))
     · exact (continuous_mul_log.continuousOn.sub continuous_id.continuousOn).neg
-    · intro s hs; norm_num at hs
-      convert ((hasDerivAt_mul_log hs.left.ne.symm).sub (hasDerivAt_id s)).neg using 1
-      norm_num
-    · intro s hs; norm_num at hs; simp
-      exact (log_nonpos_iff hs.left).mpr hs.right.le
+    · intro s ⟨hs, _⟩
+      norm_num at *
+      have h := (hasDerivAt_id s).sub (hasDerivAt_mul_log hs.ne.symm)
+      simp only [id_eq, sub_add_cancel_right] at h
+      exact h
+    · intro s ⟨hs₁, hs₂⟩
+      norm_num at *
+      exact (log_nonpos_iff hs₁).mpr hs₂.le
   · -- Show integrability on [1…t] by continuity
     apply ContinuousOn.intervalIntegrable
-    apply (ContinuousOn.mono Real.continuousOn_log)
-    simpa using Set.not_mem_uIcc_of_lt zero_lt_one hx
+    apply ContinuousOn.mono Real.continuousOn_log
+    apply Set.not_mem_uIcc_of_lt zero_lt_one at hx
+    simpa
 
 @[simp]
 theorem intervalIntegrable_sin : IntervalIntegrable sin μ a b :=

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -484,31 +484,25 @@ theorem integral_exp_mul_complex {c : ℂ} (hc : c ≠ 0) :
 
 /-- Helper lemma for `integral_log`: case where `a = 0` and `b` is positive. -/
 lemma integral_log_from_zero_of_pos (ht : 0 < b) : ∫ s in (0)..b, log s = b * log b - b := by
-  -- Compute the integral by giving a primitive and considering it limit as x
-  -- approaches 0 from the right. The following lines were suggested by Gareth
-  -- Ma on Zulip.
+  -- Compute the integral by giving a primitive and considering it limit as x approaches 0 from the
+  -- right. The following lines were suggested by Gareth Ma on Zulip.
   rw [integral_eq_sub_of_hasDerivAt_of_tendsto (f := fun x ↦ x * log x - x)
     (fa := 0) (fb := b * log b - b) (hint := intervalIntegrable_log')]
   · abel
   · exact ht
   · intro s ⟨hs, _ ⟩
     simpa using (hasDerivAt_mul_log hs.ne.symm).sub (hasDerivAt_id s)
-  · have h := tendsto_log_mul_rpow_nhds_zero zero_lt_one
-    simp_rw [rpow_one, mul_comm] at h
-    replace h := h.sub (tendsto_nhdsWithin_of_tendsto_nhds Filter.tendsto_id)
-    simp only [id_eq, sub_self] at h
-    assumption
-  · apply tendsto_nhdsWithin_of_tendsto_nhds
-    apply ContinuousAt.tendsto
-    fun_prop
+  · simpa [mul_comm] using ((tendsto_log_mul_rpow_nhds_zero zero_lt_one).sub
+      (tendsto_nhdsWithin_of_tendsto_nhds Filter.tendsto_id))
+  · exact tendsto_nhdsWithin_of_tendsto_nhds (ContinuousAt.tendsto (by fun_prop))
 
 /-- Helper lemma for `integral_log`: case where `a = 0`. -/
 lemma integral_log_from_zero {b : ℝ} : ∫ s in (0)..b, log s = b * log b - b := by
     rcases lt_trichotomy b 0 with h | h | h
     · -- If t is negative, use that log is an even function to reduce to the positive case.
       conv => arg 1; arg 1; intro t; rw [← log_neg_eq_log]
-      rw [intervalIntegral.integral_comp_neg, intervalIntegral.integral_symm, neg_zero]
-      rw [integral_log_from_zero_of_pos (Left.neg_pos_iff.mpr h), log_neg_eq_log]
+      rw [intervalIntegral.integral_comp_neg, intervalIntegral.integral_symm, neg_zero,
+        integral_log_from_zero_of_pos (Left.neg_pos_iff.mpr h), log_neg_eq_log]
       ring
     · simp [h]
     · exact integral_log_from_zero_of_pos h

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -525,6 +525,12 @@ theorem integral_log : ∫ s in a..b, log s = b * log b - a * log a - b + a := b
     ring
   repeat exact intervalIntegrable_log'
 
+@[deprecated (since := "2025-01-12")]
+alias integral_log_of_pos := integral_log
+
+@[deprecated (since := "2025-01-12")]
+alias integral_log_of_neg := integral_log
+
 @[simp]
 theorem integral_sin : ∫ x in a..b, sin x = cos a - cos b := by
   rw [integral_deriv_eq_sub' fun x => -cos x]

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -256,8 +256,7 @@ theorem intervalIntegrable_log' :
   · -- Show integrability on [1…t] by continuity
     apply ContinuousOn.intervalIntegrable
     apply (ContinuousOn.mono Real.continuousOn_log)
-    simp
-    exact Set.not_mem_uIcc_of_lt zero_lt_one hx
+    simpa using Set.not_mem_uIcc_of_lt zero_lt_one hx
 
 @[simp]
 theorem intervalIntegrable_sin : IntervalIntegrable sin μ a b :=
@@ -511,9 +510,8 @@ theorem integral_log : ∫ s in a..b, log s = b * log b - a * log a - b + a := b
   have case₂ {t : ℝ} : ∫ s in (0)..t, log s = t * log t - t := by
     rcases lt_trichotomy t 0 with h | h | h
     · -- If t is negative, use that log is an even function to reduce to the positive case.
-      conv => arg 1; arg 1; intro t; rw [← log_neg_eq_log]
-      rw [intervalIntegral.integral_comp_neg]
-      rw [intervalIntegral.integral_symm]
+      conv => arg 1; arg 1; intro t; rw [← log_neg_eq_log,]
+      rw [intervalIntegral.integral_comp_neg, intervalIntegral.integral_symm]
       simp
       rw [case₁ (Left.neg_pos_iff.mpr h)]
       simp; abel
@@ -523,8 +521,7 @@ theorem integral_log : ∫ s in a..b, log s = b * log b - a * log a - b + a := b
 
   -- General case
   rw [←intervalIntegral.integral_add_adjacent_intervals (b := 0)]
-  · rw [intervalIntegral.integral_symm]
-    rw [case₂, case₂]
+  · rw [intervalIntegral.integral_symm, case₂, case₂]
     ring
   repeat exact intervalIntegrable_log'
 

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -3,10 +3,11 @@ Copyright (c) 2021 Benjamin Davidson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Benjamin Davidson
 -/
-import Mathlib.MeasureTheory.Integral.FundThmCalculus
-import Mathlib.Analysis.SpecialFunctions.Trigonometric.ArctanDeriv
+import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
 import Mathlib.Analysis.SpecialFunctions.NonIntegrable
 import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.ArctanDeriv
+import Mathlib.MeasureTheory.Integral.FundThmCalculus
 
 /-!
 # Integration of specific interval integrals
@@ -224,9 +225,39 @@ theorem _root_.IntervalIntegrable.log (hf : ContinuousOn f [[a, b]])
     IntervalIntegrable (fun x => log (f x)) μ a b :=
   (ContinuousOn.log hf h).intervalIntegrable
 
+/-- See `intervalIntegrable_log'` for a version without any hypothesis on the interval, but
+assuming the measure is volume. -/
 @[simp]
 theorem intervalIntegrable_log (h : (0 : ℝ) ∉ [[a, b]]) : IntervalIntegrable log μ a b :=
   IntervalIntegrable.log continuousOn_id fun _ hx => ne_of_mem_of_not_mem hx h
+
+/-- The real logarithm is interval integrable (with respect to the volume measure) on every
+interval. See `intervalIntegrable_log` for a version applying to any locally finite measure,
+but with an additional hypothesis on the interval. -/
+@[simp]
+theorem intervalIntegrable_log' :
+  IntervalIntegrable log volume a b := by
+  -- Log is even, so it suffices to consider the case 0 < a and b = 0
+  apply intervalIntegrable_of_even (fun a ↦ Eq.symm (log_neg_eq_log a))
+
+  intro x hx
+  -- Split integral
+  apply IntervalIntegrable.trans (b := 1)
+  · -- Show integrability on [0…1] using non-negativity of the derivative
+    rw [← neg_neg log]
+    apply IntervalIntegrable.neg
+    apply intervalIntegrable_deriv_of_nonneg
+    · exact (continuous_mul_log.continuousOn.sub continuous_id.continuousOn).neg
+    · intro s hs; norm_num at hs
+      convert ((hasDerivAt_mul_log hs.left.ne.symm).sub (hasDerivAt_id s)).neg using 1
+      norm_num
+    · intro s hs; norm_num at hs; simp
+      exact (log_nonpos_iff hs.left).mpr hs.right.le
+  · -- Show integrability on [1…t] by continuity
+    apply ContinuousOn.intervalIntegrable
+    apply (ContinuousOn.mono Real.continuousOn_log)
+    simp
+    exact Set.not_mem_uIcc_of_lt zero_lt_one hx
 
 @[simp]
 theorem intervalIntegrable_sin : IntervalIntegrable sin μ a b :=
@@ -453,25 +484,60 @@ theorem integral_exp_mul_complex {c : ℂ} (hc : c ≠ 0) :
   · fun_prop
 
 @[simp]
-theorem integral_log (h : (0 : ℝ) ∉ [[a, b]]) :
-    ∫ x in a..b, log x = b * log b - a * log a - b + a := by
-  have h' := fun x (hx : x ∈ [[a, b]]) => ne_of_mem_of_not_mem hx h
-  have heq := fun x hx => mul_inv_cancel₀ (h' x hx)
-  convert integral_mul_deriv_eq_deriv_mul (fun x hx => hasDerivAt_log (h' x hx))
-    (fun x _ => hasDerivAt_id x) (continuousOn_inv₀.mono <|
-      subset_compl_singleton_iff.mpr h).intervalIntegrable
-        continuousOn_const.intervalIntegrable using 1 <;>
-  simp [integral_congr heq, mul_comm, ← sub_add]
+theorem integral_log : ∫ s in a..b, log s = b * log b - a * log a - b + a := by
 
-@[simp]
-theorem integral_log_of_pos (ha : 0 < a) (hb : 0 < b) :
-    ∫ x in a..b, log x = b * log b - a * log a - b + a :=
-  integral_log <| not_mem_uIcc_of_lt ha hb
+  -- Simple case one: x is positive, y is zero
+  have case₁ {t : ℝ} (ht : 0 < t) : ∫ s in (0)..t, log s = t * log t - t := by
+    -- Compute the integral by giving a primitive and considering it limit as x
+    -- approaches 0 from the right. The following lines were suggested by Gareth
+    -- Ma on Zulip.
+    rw [integral_eq_sub_of_hasDerivAt_of_tendsto (f := fun x ↦ x * log x - x)
+      (fa := 0) (fb := t * log t - t)]
+    · abel
+    · exact ht
+    · intro s hs
+      norm_num at hs
+      convert (hasDerivAt_mul_log hs.left.ne.symm).sub (hasDerivAt_id s) using 1
+      abel
+    · exact intervalIntegrable_log'
+    · have := tendsto_log_mul_rpow_nhds_zero zero_lt_one
+      simp_rw [rpow_one, mul_comm] at this
+      convert this.sub (tendsto_nhdsWithin_of_tendsto_nhds Filter.tendsto_id)
+      abel
+    · apply tendsto_nhdsWithin_of_tendsto_nhds
+      apply ContinuousAt.tendsto
+      fun_prop
 
-@[simp]
-theorem integral_log_of_neg (ha : a < 0) (hb : b < 0) :
+  -- Simple case two: y is zero
+  have case₂ {t : ℝ} : ∫ s in (0)..t, log s = t * log t - t := by
+    rcases lt_trichotomy t 0 with h|h|h
+    · -- If t is negative, use that log is an even function to reduce to the positive case.
+      conv => arg 1; arg 1; intro t; rw [← log_neg_eq_log]
+      rw [intervalIntegral.integral_comp_neg]
+      rw [intervalIntegral.integral_symm]
+      simp
+      rw [case₁ (Left.neg_pos_iff.mpr h)]
+      simp; abel
+    · rw [h]; simp
+    · exact case₁ h
+  clear case₁
+
+  -- General case
+  rw [←intervalIntegral.integral_add_adjacent_intervals (b := 0)]
+  · rw [intervalIntegral.integral_symm]
+    rw [case₂, case₂]
+    ring
+  repeat exact intervalIntegrable_log'
+
+@[deprecated "The theorem integral_log proves the result w/o hypothesis." (since := "2025-01-11")]
+theorem integral_log_of_pos (_ : 0 < a) (_ : 0 < b) :
     ∫ x in a..b, log x = b * log b - a * log a - b + a :=
-  integral_log <| not_mem_uIcc_of_gt ha hb
+  integral_log
+
+@[deprecated "The theorem integral_log proves the result w/o hypothesis." (since := "2025-01-11")]
+theorem integral_log_of_neg (_ : a < 0) (_ : b < 0) :
+    ∫ x in a..b, log x = b * log b - a * log a - b + a :=
+  integral_log
 
 @[simp]
 theorem integral_sin : ∫ x in a..b, sin x = cos a - cos b := by

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -248,15 +248,13 @@ theorem intervalIntegrable_log' : IntervalIntegrable log volume a b := by
     · exact (continuous_mul_log.continuousOn.sub continuous_id.continuousOn).neg
     · intro s ⟨hs, _⟩
       norm_num at *
-      have h := (hasDerivAt_id s).sub (hasDerivAt_mul_log hs.ne.symm)
-      simp only [id_eq, sub_add_cancel_right] at h
-      exact h
+      simpa using (hasDerivAt_id s).sub (hasDerivAt_mul_log hs.ne.symm)
     · intro s ⟨hs₁, hs₂⟩
       norm_num at *
       exact (log_nonpos_iff hs₁).mpr hs₂.le
   · -- Show integrability on [1…t] by continuity
     apply ContinuousOn.intervalIntegrable
-    apply ContinuousOn.mono Real.continuousOn_log
+    apply Real.continuousOn_log.mono
     apply Set.not_mem_uIcc_of_lt zero_lt_one at hx
     simpa
 
@@ -494,9 +492,7 @@ lemma integral_log_from_zero_of_pos (ht : 0 < b) : ∫ s in (0)..b, log s = b * 
   · abel
   · exact ht
   · intro s ⟨hs, _ ⟩
-    have h := (hasDerivAt_mul_log hs.ne.symm).sub (hasDerivAt_id s)
-    simp only [id_eq, add_sub_cancel_right] at h
-    exact h
+    simpa using (hasDerivAt_mul_log hs.ne.symm).sub (hasDerivAt_id s)
   · have h := tendsto_log_mul_rpow_nhds_zero zero_lt_one
     simp_rw [rpow_one, mul_comm] at h
     replace h := h.sub (tendsto_nhdsWithin_of_tendsto_nhds Filter.tendsto_id)

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -484,7 +484,6 @@ theorem integral_exp_mul_complex {c : ℂ} (hc : c ≠ 0) :
   · ring
   · fun_prop
 
-@[simp]
 /-- Helper lemma for `integral_log`: case where `a = 0` and `b` is positive. -/
 lemma integral_log_from_zero_of_pos (ht : 0 < b) : ∫ s in (0)..b, log s = b * log b - b := by
   -- Compute the integral by giving a primitive and considering it limit as x
@@ -524,12 +523,6 @@ theorem integral_log : ∫ s in a..b, log s = b * log b - a * log a - b + a := b
   · rw [intervalIntegral.integral_symm, integral_log_from_zero, integral_log_from_zero]
     ring
   all_goals exact intervalIntegrable_log'
-
-@[deprecated (since := "2025-01-12")]
-alias integral_log_of_pos := integral_log
-
-@[deprecated (since := "2025-01-12")]
-alias integral_log_of_neg := integral_log
 
 @[deprecated (since := "2025-01-12")]
 alias integral_log_of_pos := integral_log

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -485,47 +485,51 @@ theorem integral_exp_mul_complex {c : ℂ} (hc : c ≠ 0) :
   · fun_prop
 
 @[simp]
-theorem integral_log : ∫ s in a..b, log s = b * log b - a * log a - b + a := by
-  -- Simple case one: x is positive, y is zero
-  have case₁ {t : ℝ} (ht : 0 < t) : ∫ s in (0)..t, log s = t * log t - t := by
-    -- Compute the integral by giving a primitive and considering it limit as x
-    -- approaches 0 from the right. The following lines were suggested by Gareth
-    -- Ma on Zulip.
-    rw [integral_eq_sub_of_hasDerivAt_of_tendsto (f := fun x ↦ x * log x - x)
-      (fa := 0) (fb := t * log t - t)]
-    · abel
-    · exact ht
-    · intro s hs
-      norm_num at hs
-      convert (hasDerivAt_mul_log hs.left.ne.symm).sub (hasDerivAt_id s) using 1
-      abel
-    · exact intervalIntegrable_log'
-    · have := tendsto_log_mul_rpow_nhds_zero zero_lt_one
-      simp_rw [rpow_one, mul_comm] at this
-      convert this.sub (tendsto_nhdsWithin_of_tendsto_nhds Filter.tendsto_id)
-      abel
-    · apply tendsto_nhdsWithin_of_tendsto_nhds
-      apply ContinuousAt.tendsto
-      fun_prop
+/-- Helper lemma for `integral_log`: case where `a = 0` and `b` is positive. -/
+lemma integral_log_from_zero_of_pos (ht : 0 < b) : ∫ s in (0)..b, log s = b * log b - b := by
+  -- Compute the integral by giving a primitive and considering it limit as x
+  -- approaches 0 from the right. The following lines were suggested by Gareth
+  -- Ma on Zulip.
+  rw [integral_eq_sub_of_hasDerivAt_of_tendsto (f := fun x ↦ x * log x - x)
+    (fa := 0) (fb := b * log b - b) (hint := intervalIntegrable_log')]
+  · abel
+  · exact ht
+  · intro s ⟨hs, _ ⟩
+    have h := (hasDerivAt_mul_log hs.ne.symm).sub (hasDerivAt_id s)
+    simp only [id_eq, add_sub_cancel_right] at h
+    exact h
+  · have h := tendsto_log_mul_rpow_nhds_zero zero_lt_one
+    simp_rw [rpow_one, mul_comm] at h
+    replace h := h.sub (tendsto_nhdsWithin_of_tendsto_nhds Filter.tendsto_id)
+    simp only [id_eq, sub_self] at h
+    assumption
+  · apply tendsto_nhdsWithin_of_tendsto_nhds
+    apply ContinuousAt.tendsto
+    fun_prop
 
-  -- Simple case two: y is zero
-  have case₂ {t : ℝ} : ∫ s in (0)..t, log s = t * log t - t := by
-    rcases lt_trichotomy t 0 with h | h | h
+/-- Helper lemma for `integral_log`: case where `a = 0`. -/
+lemma integral_log_from_zero {b : ℝ} : ∫ s in (0)..b, log s = b * log b - b := by
+    rcases lt_trichotomy b 0 with h | h | h
     · -- If t is negative, use that log is an even function to reduce to the positive case.
-      conv => arg 1; arg 1; intro t; rw [← log_neg_eq_log,]
-      rw [intervalIntegral.integral_comp_neg, intervalIntegral.integral_symm]
-      simp
-      rw [case₁ (Left.neg_pos_iff.mpr h)]
-      simp; abel
-    · rw [h]; simp
-    · exact case₁ h
-  clear case₁
+      conv => arg 1; arg 1; intro t; rw [← log_neg_eq_log]
+      rw [intervalIntegral.integral_comp_neg, intervalIntegral.integral_symm, neg_zero]
+      rw [integral_log_from_zero_of_pos (Left.neg_pos_iff.mpr h), log_neg_eq_log]
+      ring
+    · simp [h]
+    · exact integral_log_from_zero_of_pos h
 
-  -- General case
-  rw [←intervalIntegral.integral_add_adjacent_intervals (b := 0)]
-  · rw [intervalIntegral.integral_symm, case₂, case₂]
+@[simp]
+theorem integral_log : ∫ s in a..b, log s = b * log b - a * log a - b + a := by
+  rw [← intervalIntegral.integral_add_adjacent_intervals (b := 0)]
+  · rw [intervalIntegral.integral_symm, integral_log_from_zero, integral_log_from_zero]
     ring
-  repeat exact intervalIntegrable_log'
+  all_goals exact intervalIntegrable_log'
+
+@[deprecated (since := "2025-01-12")]
+alias integral_log_of_pos := integral_log
+
+@[deprecated (since := "2025-01-12")]
+alias integral_log_of_neg := integral_log
 
 @[deprecated (since := "2025-01-12")]
 alias integral_log_of_pos := integral_log

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -485,7 +485,6 @@ theorem integral_exp_mul_complex {c : ℂ} (hc : c ≠ 0) :
 
 @[simp]
 theorem integral_log : ∫ s in a..b, log s = b * log b - a * log a - b + a := by
-
   -- Simple case one: x is positive, y is zero
   have case₁ {t : ℝ} (ht : 0 < t) : ∫ s in (0)..t, log s = t * log t - t := by
     -- Compute the integral by giving a primitive and considering it limit as x
@@ -528,16 +527,6 @@ theorem integral_log : ∫ s in a..b, log s = b * log b - a * log a - b + a := b
     rw [case₂, case₂]
     ring
   repeat exact intervalIntegrable_log'
-
-@[deprecated "The theorem integral_log proves the result w/o hypothesis." (since := "2025-01-11")]
-theorem integral_log_of_pos (_ : 0 < a) (_ : 0 < b) :
-    ∫ x in a..b, log x = b * log b - a * log a - b + a :=
-  integral_log
-
-@[deprecated "The theorem integral_log proves the result w/o hypothesis." (since := "2025-01-11")]
-theorem integral_log_of_neg (_ : a < 0) (_ : b < 0) :
-    ∫ x in a..b, log x = b * log b - a * log a - b + a :=
-  integral_log
 
 @[simp]
 theorem integral_sin : ∫ x in a..b, sin x = cos a - cos b := by

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -509,7 +509,7 @@ theorem integral_log : ∫ s in a..b, log s = b * log b - a * log a - b + a := b
 
   -- Simple case two: y is zero
   have case₂ {t : ℝ} : ∫ s in (0)..t, log s = t * log t - t := by
-    rcases lt_trichotomy t 0 with h|h|h
+    rcases lt_trichotomy t 0 with h | h | h
     · -- If t is negative, use that log is an even function to reduce to the positive case.
       conv => arg 1; arg 1; intro t; rw [← log_neg_eq_log]
       rw [intervalIntegral.integral_comp_neg]

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -385,11 +385,9 @@ of the form `0..x` if it is interval integrable (with respect to the volume meas
 interval of the form `0..x`, for positive `x`.
 
 See `intervalIntegrable_of_even` for a stronger result.-/
-lemma intervalIntegrable_of_even₀
-  (h₁f : ∀ x, f x = f (-x))
-  (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x)
-  (t : ℝ) :
-  IntervalIntegrable f volume 0 t := by
+lemma intervalIntegrable_of_even₀ (h₁f : ∀ x, f x = f (-x))
+    (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) (t : ℝ) :
+    IntervalIntegrable f volume 0 t := by
   rcases lt_trichotomy t 0 with h | h | h
   · rw [IntervalIntegrable.iff_comp_neg]
     conv => arg 1; intro t; rw [← h₁f]

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -380,48 +380,62 @@ section
 
 variable {f : ℝ → E}
 
-/-- An even function is interval integrable (with respect to the volume measure)
-on every interval if it is interval integrable (with respect to the volume
-measure) on every interval of the form `0..x`, for positive `x`. -/
+/-- An even function is interval integrable (with respect to the volume measure) on every interval
+of the form `0..x` if it is interval integrable (with respect to the volume measure) on every
+interval of the form `0..x`, for positive `x`.
+
+See `intervalIntegrable_of_even` for a stronger result.-/
+lemma intervalIntegrable_of_even₀
+  (h₁f : ∀ x, f x = f (-x))
+  (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x)
+  (t : ℝ) :
+  IntervalIntegrable f volume 0 t := by
+  rcases lt_trichotomy t 0 with h | h | h
+  · rw [IntervalIntegrable.iff_comp_neg]
+    conv => arg 1; intro t; rw [← h₁f]
+    simp [h₂f (-t) (by norm_num [h])]
+  · rw [h]
+  · exact h₂f t h
+
+/-- An even function is interval integrable (with respect to the volume measure) on every interval
+if it is interval integrable (with respect to the volume measure) on every interval of the form
+`0..x`, for positive `x`. -/
 theorem intervalIntegrable_of_even
   (h₁f : ∀ x, f x = f (-x))
   (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) :
-  ∀ x y, IntervalIntegrable f volume x y := by
-  -- Lemma: Prove statement first in case where x = 0
-  have : ∀ t, IntervalIntegrable f volume 0 t := by
-    intro t
-    rcases lt_trichotomy t 0 with h|h|h
-    · rw [IntervalIntegrable.iff_comp_neg]
-      conv => arg 1; intro t; rw [← h₁f]
-      simp [h₂f (-t) (by norm_num [h])]
-    · rw [h]
-    · exact h₂f t h
+  ∀ x y, IntervalIntegrable f volume x y :=
   -- Split integral and apply lemma
-  intro x y
-  exact IntervalIntegrable.trans (b := 0) (IntervalIntegrable.symm (this x)) (this y)
+  fun x y ↦ (intervalIntegrable_of_even₀ h₁f h₂f x).symm.trans (b := 0)
+    (intervalIntegrable_of_even₀ h₁f h₂f y)
 
+/-- An odd function is interval integrable (with respect to the volume measure) on every interval
+of the form `0..x` if it is interval integrable (with respect to the volume measure) on every
+interval of the form `0..x`, for positive `x`.
 
-/-- An odd function is interval integrable (with respect to the volume measure)
-on every interval iff it is interval integrable (with respect to the volume
-measure) on every interval of the form `0..x`, for positive `x`. -/
+See `intervalIntegrable_of_odd` for a stronger result.-/
+lemma intervalIntegrable_of_odd₀
+  (h₁f : ∀ x, -f x = f (-x))
+  (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x)
+  (t : ℝ) :
+  IntervalIntegrable f volume 0 t := by
+  rcases lt_trichotomy t 0 with h | h | h
+  · rw [IntervalIntegrable.iff_comp_neg]
+    conv => arg 1; intro t; rw [← h₁f]
+    apply IntervalIntegrable.neg
+    simp [h₂f (-t) (by norm_num [h])]
+  · rw [h]
+  · exact h₂f t h
+
+/-- An odd function is interval integrable (with respect to the volume measure) on every interval
+iff it is interval integrable (with respect to the volume measure) on every interval of the form
+`0..x`, for positive `x`. -/
 theorem intervalIntegrable_of_odd
-  {f : ℝ → ℝ}
   (h₁f : ∀ x, -f x = f (-x))
   (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) :
-  ∀ x y, IntervalIntegrable f volume x y := by
-  -- Lemma: Prove statement first in case where x = 0
-  have : ∀ t, IntervalIntegrable f volume 0 t := by
-    intro t
-    rcases lt_trichotomy t 0 with h|h|h
-    · rw [IntervalIntegrable.iff_comp_neg]
-      conv => arg 1; intro t; rw [← h₁f]
-      apply IntervalIntegrable.neg
-      simp [h₂f (-t) (by norm_num [h])]
-    · rw [h]
-    · exact h₂f t h
+  ∀ x y, IntervalIntegrable f volume x y :=
   -- Split integral and apply lemma
-  intro x y
-exact (this x).symm.trans (b := 0) (this y)
+  fun x y ↦ (intervalIntegrable_of_odd₀ h₁f h₂f x).symm.trans (b := 0)
+    (intervalIntegrable_of_odd₀ h₁f h₂f y)
 
 end
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -383,7 +383,6 @@ variable {f : ℝ → E}
 /-- An even function is interval integrable (with respect to the volume measure)
 on every interval if it is interval integrable (with respect to the volume
 measure) on every interval of the form `0..x`, for positive `x`. -/
-
 theorem intervalIntegrable_of_even
   (h₁f : ∀ x, f x = f (-x))
   (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) :

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -373,6 +373,64 @@ theorem Antitone.intervalIntegrable {u : ℝ → E} {a b : ℝ} (hu : Antitone u
 
 end
 
+/-!
+## Interval integrability of functions with even or odd parity
+-/
+section
+
+variable {f : ℝ → E}
+
+/-- An even function is interval integrable (with respect to the volume measure)
+on every interval if it is interval integrable (with respect to the volume
+measure) on every interval of the form `0..x`, for positive `x`. -/
+
+theorem intervalIntegrable_of_even
+  (h₁f : ∀ x, f x = f (-x))
+  (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) :
+  ∀ x y, IntervalIntegrable f volume x y := by
+  -- Lemma: Prove statement first in case where x = 0
+  have : ∀ t, IntervalIntegrable f volume 0 t := by
+    intro t
+    rcases lt_trichotomy t 0 with h|h|h
+    · rw [IntervalIntegrable.iff_comp_neg]
+      conv => arg 1; intro t; rw [← h₁f]
+      simp [h₂f (-t) (by norm_num [h])]
+    · rw [h]
+    · exact h₂f t h
+  -- Split integral and apply lemma
+  intro x y
+  exact IntervalIntegrable.trans (b := 0) (IntervalIntegrable.symm (this x)) (this y)
+
+
+/-- An odd function is interval integrable (with respect to the volume measure)
+on every interval iff it is interval integrable (with respect to the volume
+measure) on every interval of the form `0..x`, for positive `x`. -/
+
+theorem intervalIntegrable_of_odd
+  {f : ℝ → ℝ}
+  (h₁f : ∀ x, -f x = f (-x))
+  (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) :
+  ∀ x y, IntervalIntegrable f volume x y := by
+  -- Lemma: Prove statement first in case where x = 0
+  have : ∀ t, IntervalIntegrable f volume 0 t := by
+    intro t
+    rcases lt_trichotomy t 0 with h|h|h
+    · rw [IntervalIntegrable.iff_comp_neg]
+      conv => arg 1; intro t; rw [← h₁f]
+      apply IntervalIntegrable.neg
+      simp [h₂f (-t) (by norm_num [h])]
+    · rw [h]
+    · exact h₂f t h
+  -- Split integral and apply lemma
+  intro x y
+  exact IntervalIntegrable.trans (b := 0) (IntervalIntegrable.symm (this x)) (this y)
+
+end
+
+/-!
+## Limits of intervals
+-/
+
 /-- Let `l'` be a measurably generated filter; let `l` be a of filter such that each `s ∈ l'`
 eventually includes `Ioc u v` as both `u` and `v` tend to `l`. Let `μ` be a measure finite at `l'`.
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -421,7 +421,7 @@ theorem intervalIntegrable_of_odd
     · exact h₂f t h
   -- Split integral and apply lemma
   intro x y
-  exact IntervalIntegrable.trans (b := 0) (IntervalIntegrable.symm (this x)) (this y)
+exact (this x).symm.trans (b := 0) (this y)
 
 end
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -399,12 +399,11 @@ lemma intervalIntegrable_of_even₀ (h₁f : ∀ x, f x = f (-x))
 if it is interval integrable (with respect to the volume measure) on every interval of the form
 `0..x`, for positive `x`. -/
 theorem intervalIntegrable_of_even
-  (h₁f : ∀ x, f x = f (-x))
-  (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) :
-  ∀ x y, IntervalIntegrable f volume x y :=
+  (h₁f : ∀ x, f x = f (-x)) (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) (a b : ℝ) :
+  IntervalIntegrable f volume a b :=
   -- Split integral and apply lemma
-  fun x y ↦ (intervalIntegrable_of_even₀ h₁f h₂f x).symm.trans (b := 0)
-    (intervalIntegrable_of_even₀ h₁f h₂f y)
+  (intervalIntegrable_of_even₀ h₁f h₂f a).symm.trans (b := 0)
+    (intervalIntegrable_of_even₀ h₁f h₂f b)
 
 /-- An odd function is interval integrable (with respect to the volume measure) on every interval
 of the form `0..x` if it is interval integrable (with respect to the volume measure) on every
@@ -412,9 +411,7 @@ interval of the form `0..x`, for positive `x`.
 
 See `intervalIntegrable_of_odd` for a stronger result.-/
 lemma intervalIntegrable_of_odd₀
-  (h₁f : ∀ x, -f x = f (-x))
-  (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x)
-  (t : ℝ) :
+  (h₁f : ∀ x, -f x = f (-x)) (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) (t : ℝ) :
   IntervalIntegrable f volume 0 t := by
   rcases lt_trichotomy t 0 with h | h | h
   · rw [IntervalIntegrable.iff_comp_neg]
@@ -428,12 +425,10 @@ lemma intervalIntegrable_of_odd₀
 iff it is interval integrable (with respect to the volume measure) on every interval of the form
 `0..x`, for positive `x`. -/
 theorem intervalIntegrable_of_odd
-  (h₁f : ∀ x, -f x = f (-x))
-  (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) :
-  ∀ x y, IntervalIntegrable f volume x y :=
+  (h₁f : ∀ x, -f x = f (-x)) (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) (a b : ℝ) :
+  IntervalIntegrable f volume a b :=
   -- Split integral and apply lemma
-  fun x y ↦ (intervalIntegrable_of_odd₀ h₁f h₂f x).symm.trans (b := 0)
-    (intervalIntegrable_of_odd₀ h₁f h₂f y)
+  (intervalIntegrable_of_odd₀ h₁f h₂f a).symm.trans (b := 0) (intervalIntegrable_of_odd₀ h₁f h₂f b)
 
 end
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -404,7 +404,6 @@ theorem intervalIntegrable_of_even
 /-- An odd function is interval integrable (with respect to the volume measure)
 on every interval iff it is interval integrable (with respect to the volume
 measure) on every interval of the form `0..x`, for positive `x`. -/
-
 theorem intervalIntegrable_of_odd
   {f : ℝ → ℝ}
   (h₁f : ∀ x, -f x = f (-x))


### PR DESCRIPTION
Establish interval integrability for Real.log on arbitrary intervals, remove an unnecessary assumption in the theorem
 `integral_log` which computes the integrals, and remove the theorems `integral_log_of_pos` and `integral_log_of_neg` which are now superfluous. Add theorems concerning integrability of even/odd functions; these are used in the proof and might be of general interest. Minor docu change: Add a missing section heading in Mathlib/MeasureTheory/Integral/IntervalIntegral.lean

Rationale: I considered adding a new theorem rather than changing  `integral_log`, but I see no value in having a theorem with unnecessary assumptions.  For improved compatibility, I also considered depreciating `integral_log_of_pos` and `integral_log_of_neg` rather than removing them, but then the linter complained about unused assumptions in those theorems.

Breaking change: Deleted assumptions in `integral_log`. Removed theorems `integral_log_of_pos` and `integral_log_of_neg`. These are replaced by `integral_log`, which gives the same conclusion without assumption.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
