### PR TITLE
[Merged by Bors] - feat(Analysis/MeanInequalitiesPow): add Real.rpow versions of some lemmas

### DIFF
--- a/Mathlib/Analysis/MeanInequalitiesPow.lean
+++ b/Mathlib/Analysis/MeanInequalitiesPow.lean
@@ -184,6 +184,36 @@ theorem rpow_add_le_add_rpow {p : ℝ} (a b : ℝ≥0) (hp : 0 ≤ p) (hp1 : p �
 
 end NNReal
 
+namespace Real
+
+lemma add_rpow_le_rpow_add {p : ℝ} {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hp1 : 1 ≤ p) :
+     a ^ p + b ^ p ≤ (a + b) ^ p := by
+  lift a to NNReal using ha
+  lift b to NNReal using hb
+  exact_mod_cast NNReal.add_rpow_le_rpow_add a b hp1
+
+lemma rpow_add_rpow_le_add {p : ℝ} {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hp1 : 1 ≤ p) :
+    (a ^ p + b ^ p) ^ (1 / p) ≤ a + b := by
+  lift a to NNReal using ha
+  lift b to NNReal using hb
+  exact_mod_cast NNReal.rpow_add_rpow_le_add a b hp1
+
+lemma rpow_add_rpow_le {p q : ℝ} {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hp_pos : 0 < p)
+    (hpq : p ≤ q) :
+    (a ^ q + b ^ q) ^ (1 / q) ≤ (a ^ p + b ^ p) ^ (1 / p) := by
+  lift a to NNReal using ha
+  lift b to NNReal using hb
+  exact_mod_cast NNReal.rpow_add_rpow_le a b hp_pos hpq
+
+lemma rpow_add_le_add_rpow {p : ℝ} {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hp : 0 ≤ p)
+    (hp1 : p ≤ 1) :
+    (a + b) ^ p ≤ a ^ p + b ^ p := by
+  lift a to NNReal using ha
+  lift b to NNReal using hb
+  exact_mod_cast NNReal.rpow_add_le_add_rpow a b hp hp1
+
+end Real
+
 namespace ENNReal
 
 /-- Weighted generalized mean inequality, version for sums over finite sets, with `ℝ≥0∞`-valued


### PR DESCRIPTION
This adds `Real.rpow` versions of four existing lemmas for `{E|}NNreal.rpow`. One of these is useful for showing that the `e`th power (with `0 < e ≤ 1`)  of an absolute value is again an absolute value. We add the other three for consistency.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
