### PR TITLE
[Merged by Bors] - chore(ENat): don't import fields

### DIFF
--- a/Mathlib/Algebra/Category/Grp/Subobject.lean
+++ b/Mathlib/Algebra/Category/Grp/Subobject.lean
@@ -10,7 +10,6 @@ import Mathlib.Algebra.Category.ModuleCat.Subobject
 # The category of abelian groups is well-powered
 -/
 
-assert_not_exists Field
 
 open CategoryTheory
 

--- a/Mathlib/Algebra/Category/Grp/Subobject.lean
+++ b/Mathlib/Algebra/Category/Grp/Subobject.lean
@@ -10,6 +10,7 @@ import Mathlib.Algebra.Category.ModuleCat.Subobject
 # The category of abelian groups is well-powered
 -/
 
+assert_not_exists Field
 
 open CategoryTheory
 

--- a/Mathlib/Algebra/Group/ConjFinite.lean
+++ b/Mathlib/Algebra/Group/ConjFinite.lean
@@ -10,6 +10,8 @@ import Mathlib.Data.Fintype.Units
 # Conjugacy of elements of finite groups
 -/
 
+assert_not_exists Field
+
 -- TODO: the following `assert_not_exists` should work, but does not
 -- assert_not_exists MonoidWithZero
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
@@ -11,6 +11,8 @@ import Mathlib.SetTheory.Cardinal.Finite
 # Cardinalities of pointwise operations on sets
 -/
 
+assert_not_exists Field
+
 open scoped Cardinal Pointwise
 
 namespace Set

--- a/Mathlib/Algebra/Group/Subgroup/Finite.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Finite.lean
@@ -17,6 +17,8 @@ This file provides some result on multiplicative and additive subgroups in the f
 subgroup, subgroups
 -/
 
+assert_not_exists Field
+
 variable {G : Type*} [Group G]
 variable {A : Type*} [AddGroup A]
 

--- a/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Card.lean
@@ -11,6 +11,8 @@ import Mathlib.SetTheory.Cardinal.Finite
 # Cardinality of sets under pointwise group with zero operations
 -/
 
+assert_not_exists Field
+
 open scoped Cardinal Pointwise
 
 variable {G₀ M₀ : Type*}

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -53,6 +53,8 @@ the colors.
   * develop API for partial colorings, likely as colorings of subgraphs (`H.coe.Coloring α`)
 -/
 
+assert_not_exists Field
+
 open Fintype Function
 
 universe u v

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -17,6 +17,8 @@ This file defines colorings for some common graphs
 
 -/
 
+assert_not_exists Field
+
 namespace SimpleGraph
 
 theorem two_le_chromaticNumber_of_adj {α} {G : SimpleGraph α} {u v : α} (hAdj : G.Adj u v) :

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkCounting.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkCounting.lean
@@ -22,6 +22,8 @@ can also be useful as a recursive description of this set when `V` is finite.
 TODO: should this be extended further?
 -/
 
+assert_not_exists Field
+
 open Finset Function
 
 universe u v w

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -24,6 +24,8 @@ vertices.
 
 -/
 
+assert_not_exists Field
+
 namespace SimpleGraph
 variable {α : Type*} {G G' : SimpleGraph α}
 

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -32,6 +32,7 @@ graph metric, distance
 
 -/
 
+assert_not_exists Field
 
 namespace SimpleGraph
 

--- a/Mathlib/Combinatorics/SimpleGraph/Partition.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Partition.lean
@@ -42,6 +42,7 @@ graph colorings and back is the identity.
 
 -/
 
+assert_not_exists Field
 
 universe u v
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Algebra.CharZero.Lemmas
 import Mathlib.Algebra.Order.Ring.WithTop
 import Mathlib.Algebra.Order.Sub.WithTop
 import Mathlib.Data.ENat.Defs
@@ -32,6 +31,8 @@ of `ENat` and `ENNReal` we are using is that all `a` are either absorbing for ad
 for all `b`), or that it's order-cancellable (`a + b ≤ a + c → b ≤ c` for all `b`, `c`), and
 similarly for multiplication.
 -/
+
+assert_not_exists Field
 
 deriving instance Zero, CanonicallyOrderedCommSemiring, Nontrivial,
   LinearOrder, Bot, CanonicallyLinearOrderedAddCommMonoid, Sub,

--- a/Mathlib/Data/ENat/BigOperators.lean
+++ b/Mathlib/Data/ENat/BigOperators.lean
@@ -10,6 +10,8 @@ import Mathlib.Data.ENat.Lattice
 # Sum of suprema in `ENat`
 -/
 
+assert_not_exists Field
+
 namespace ENat
 
 lemma sum_iSup {α ι : Type*} {s : Finset α} {f : α → ι → ℕ∞}

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -23,6 +23,8 @@ corresponding `noshake.json` entry.
 
 -/
 
+assert_not_exists Field
+
 open Set
 
 -- Porting note: was `deriving instance` but "default handlers have not been implemented yet"

--- a/Mathlib/Data/Finite/Card.lean
+++ b/Mathlib/Data/Finite/Card.lean
@@ -25,6 +25,7 @@ it. We generally put such theorems into the `SetTheory.Cardinal.Finite` module.
 
 -/
 
+assert_not_exists Field
 
 noncomputable section
 

--- a/Mathlib/Data/Fintype/Units.lean
+++ b/Mathlib/Data/Fintype/Units.lean
@@ -12,6 +12,7 @@ import Mathlib.SetTheory.Cardinal.Finite
 # fintype instances relating to units
 -/
 
+assert_not_exists Field
 
 variable {α : Type*}
 

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -166,6 +166,8 @@ There are a few design decisions worth discussing.
   Proc. Amer. Math. Soc. 144 (2016), 459-471]
 -/
 
+assert_not_exists Field
+
 open Set
 
 /-- A predicate `P` on sets satisfies the **exchange property** if,

--- a/Mathlib/Data/Matroid/Closure.lean
+++ b/Mathlib/Data/Matroid/Closure.lean
@@ -76,6 +76,8 @@ In lemma names, the words `spanning` and `flat` are used as suffixes,
 for instance we have `ground_spanning` rather than `spanning_ground`.
 -/
 
+assert_not_exists Field
+
 open Set
 namespace Matroid
 

--- a/Mathlib/Data/Matroid/Constructions.lean
+++ b/Mathlib/Data/Matroid/Constructions.lean
@@ -29,6 +29,8 @@ and then construct the other examples using duality and restriction.
 
 -/
 
+assert_not_exists Field
+
 variable {α : Type*} {M : Matroid α} {E B I X R J : Set α}
 
 namespace Matroid

--- a/Mathlib/Data/Matroid/Dual.lean
+++ b/Mathlib/Data/Matroid/Dual.lean
@@ -28,6 +28,8 @@ This is an abbreviation for `M✶.Indep X`, but has its own name for the sake of
   base `B` of `M`.
 -/
 
+assert_not_exists Field
+
 open Set
 
 namespace Matroid

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -82,6 +82,8 @@ for the inverse of `e`).
 * `Matroid.ofBaseOfFinite` constructs a `Finite` matroid from its bases.
 -/
 
+assert_not_exists Field
+
 open Set Matroid
 
 variable {α : Type*}

--- a/Mathlib/Data/Matroid/Map.lean
+++ b/Mathlib/Data/Matroid/Map.lean
@@ -101,6 +101,8 @@ For this reason, `Matroid.map` requires injectivity to be well-defined in genera
 * [J. Oxley, Matroid Theory][oxley2011]
 -/
 
+assert_not_exists Field
+
 open Set Function Set.Notation
 namespace Matroid
 variable {α β : Type*} {f : α → β} {E I : Set α} {M : Matroid α} {N : Matroid β}

--- a/Mathlib/Data/Matroid/Restrict.lean
+++ b/Mathlib/Data/Matroid/Restrict.lean
@@ -62,6 +62,8 @@ We define the restriction order `≤r` to give a `PartialOrder` instance on the 
 reserved for the more mathematically important 'minor' order.
 -/
 
+assert_not_exists Field
+
 open Set
 
 namespace Matroid

--- a/Mathlib/Data/Matroid/Sum.lean
+++ b/Mathlib/Data/Matroid/Sum.lean
@@ -40,6 +40,8 @@ We only directly define a matroid for `Matroid.sigma`. All other versions of sum
 defined indirectly, using `Matroid.sigma` and the API in `Matroid.map`.
 -/
 
+assert_not_exists Field
+
 universe u v
 
 open Set

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
+import Mathlib.Algebra.CharZero.Lemmas
 import Mathlib.GroupTheory.Abelianization
 import Mathlib.GroupTheory.GroupAction.CardCommute
 import Mathlib.GroupTheory.SpecificGroups.Dihedral

--- a/Mathlib/GroupTheory/Coset/Card.lean
+++ b/Mathlib/GroupTheory/Coset/Card.lean
@@ -14,6 +14,8 @@ there is an analogous version for additive groups
 
 -/
 
+assert_not_exists Field
+
 open scoped Pointwise
 
 namespace Subgroup

--- a/Mathlib/GroupTheory/HNNExtension.lean
+++ b/Mathlib/GroupTheory/HNNExtension.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+import Mathlib.Algebra.CharZero.Lemmas
 import Mathlib.Algebra.Ring.Int.Units
 import Mathlib.GroupTheory.Coprod.Basic
 import Mathlib.GroupTheory.Complement

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
@@ -3,10 +3,11 @@ Copyright (c) 2021 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
+import Mathlib.Algebra.CharZero.Lemmas
+import Mathlib.Data.Fintype.Units
 import Mathlib.GroupTheory.Perm.Fin
 import Mathlib.GroupTheory.Subgroup.Simple
 import Mathlib.Tactic.IntervalCases
-import Mathlib.Data.Fintype.Units
 
 /-!
 # Alternating Groups

--- a/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
@@ -18,6 +18,8 @@ assumptions on `p`. The `p`-adic valuations on `ℕ` and `ℤ` agree with that o
 The valuation induces a norm on `ℚ`. This norm is defined in padicNorm.lean.
 -/
 
+assert_not_exists Field
+
 universe u
 
 open Nat

--- a/Mathlib/Order/Height.lean
+++ b/Mathlib/Order/Height.lean
@@ -40,6 +40,7 @@ This is defined as the maximum of the lengths of `Set.subchain`s, valued in `ℕ
 
 -/
 
+assert_not_exists Field
 
 open List hiding le_antisymm
 open OrderDual

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -59,6 +59,8 @@ in this file would generalize as well. But we don't think it would be useful, so
 Krull dimension of a preorder.
 -/
 
+assert_not_exists Field
+
 namespace Order
 
 section definitions

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Chris Hughes, Daniel Weber
 -/
+import Batteries.Data.Nat.Gcd
 import Mathlib.Algebra.Associated.Basic
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.Ring.Divisibility.Basic
@@ -25,6 +26,7 @@ several basic results on it.
 * `FiniteMultiplicity a b`: a predicate denoting that the multiplicity of `a` in `b` is finite.
 -/
 
+assert_not_exists Field
 
 variable {α β : Type*}
 

--- a/Mathlib/SetTheory/Cardinal/Aleph.lean
+++ b/Mathlib/SetTheory/Cardinal/Aleph.lean
@@ -34,7 +34,7 @@ The following notations are scoped to the `Cardinal` namespace.
   `Mathlib.SetTheory.Cardinal.Continuum`.
 -/
 
-assert_not_exists Module Finsupp Cardinal.mul_eq_self
+assert_not_exists Field Finsupp Module Cardinal.mul_eq_self
 
 noncomputable section
 

--- a/Mathlib/SetTheory/Cardinal/ENat.lean
+++ b/Mathlib/SetTheory/Cardinal/ENat.lean
@@ -28,6 +28,8 @@ Since it is not registered as a coercion, the argument about delaboration does n
 set theory, cardinals, extended natural numbers
 -/
 
+assert_not_exists Field
+
 open Function Set
 universe u v
 

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -21,6 +21,8 @@ import Mathlib.SetTheory.Cardinal.ENat
   (using the legacy definition `PartENat := Part ℕ`). If `α` is infinite, `PartENat.card α = ⊤`.
 -/
 
+assert_not_exists Field
+
 open Cardinal Function
 
 noncomputable section

--- a/Mathlib/SetTheory/Cardinal/ToNat.lean
+++ b/Mathlib/SetTheory/Cardinal/ToNat.lean
@@ -13,6 +13,8 @@ sending all infinite cardinals to zero.
 We also prove basic lemmas about this definition.
 -/
 
+assert_not_exists Field
+
 universe u v
 open Function Set
 

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -14,7 +14,6 @@ collection of all its subsets that are closed and irreducible. Unfolding this de
 the length of longest series of closed irreducible subsets ordered by inclusion.
 -/
 
-assert_not_exists Field
 
 open Order TopologicalSpace Topology
 

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -14,7 +14,6 @@ collection of all its subsets that are closed and irreducible. Unfolding this de
 the length of longest series of closed irreducible subsets ordered by inclusion.
 -/
 
-
 open Order TopologicalSpace Topology
 
 /--

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -14,6 +14,8 @@ collection of all its subsets that are closed and irreducible. Unfolding this de
 the length of longest series of closed irreducible subsets ordered by inclusion.
 -/
 
+assert_not_exists Field
+
 open Order TopologicalSpace Topology
 
 /--


### PR DESCRIPTION
Not sure why this wasn't picked up by shake


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
