### PR TITLE
[Merged by Bors] - feat: implement tauto_set tactic for set-theoretic trivialities

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5045,6 +5045,7 @@ import Mathlib.Tactic.SuppressCompilation
 import Mathlib.Tactic.SwapVar
 import Mathlib.Tactic.TFAE
 import Mathlib.Tactic.Tauto
+import Mathlib.Tactic.TautoSet
 import Mathlib.Tactic.TermCongr
 import Mathlib.Tactic.ToAdditive
 import Mathlib.Tactic.ToAdditive.Frontend

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -239,6 +239,7 @@ import Mathlib.Tactic.SuppressCompilation
 import Mathlib.Tactic.SwapVar
 import Mathlib.Tactic.TFAE
 import Mathlib.Tactic.Tauto
+import Mathlib.Tactic.TautoSet
 import Mathlib.Tactic.TermCongr
 import Mathlib.Tactic.ToAdditive
 import Mathlib.Tactic.ToAdditive.Frontend

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -48,6 +48,10 @@ macro "tauto_set" : tactic => `(tactic|
     <;> tauto
 )
 
+-- verify the two examples in the docstring
+example {α} (A B C D : Set α) (h1 : A ⊆ B) (h2 : C ⊆ D) : C \ B ⊆ D \ A := by tauto_set
+
+example {α} (A B C : Set α) (h1 : A ⊆ B ∪ C) : (A ∩ B) ∪ (A ∩ C) = A := by tauto_set
 
 
 end Mathlib.Tactic.TautoSet

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -37,6 +37,8 @@ elab (name := specialize_all) "specialize_all" x:term : tactic => withMainContex
     tauto_set
   ```
 -/
+
+
 macro "tauto_set" : tactic => `(tactic|
   · simp_all only [
       Set.diff_eq, Set.disjoint_iff, Set.symmDiff_def,

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -25,9 +25,10 @@ elab (name := specialize_all) "specialize_all" x:term : tactic => withMainContex
 
 
 /--
-  `tauto_set` attempts to prove tautologies involving hypotheses and goals of the form X ⊆ Y
-  or X = Y, where X, Y are expressions built using ∪, ∩, \, and ᶜ from finitely many variables of
-  type Set α. It also unfolds expressions of the form Disjoint A B and symmDiff A B.
+  `tauto_set` attempts to prove tautologies involving hypotheses and goals of the form `X ⊆ Y`
+  or `X = Y`, where `X`, `Y` are expressions built using ∪, ∩, \, and ᶜ from finitely many
+  variables of type `Set α`. It also unfolds expressions of the form `Disjoint A B` and
+  `symmDiff A B`.
 
   Examples:
   ```lean

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -5,7 +5,6 @@ Authors: Lenny Taelman
 -/
 
 import Mathlib.Tactic.Tauto
-import Mathlib.Data.Set.Basic
 import Mathlib.Data.Set.SymmDiff
 
 /-!

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -48,10 +48,5 @@ macro "tauto_set" : tactic => `(tactic|
     <;> tauto
 )
 
--- verify the two examples in the docstring
-example {α} (A B C D : Set α) (h1 : A ⊆ B) (h2 : C ⊆ D) : C \ B ⊆ D \ A := by tauto_set
-
-example {α} (A B C : Set α) (h1 : A ⊆ B ∪ C) : (A ∩ B) ∪ (A ∩ C) = A := by tauto_set
-
 
 end Mathlib.Tactic.TautoSet

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -28,6 +28,15 @@ elab (name := specialize_all) "specialize_all" x:term : tactic => withMainContex
   `tauto_set` attempts to prove tautologies involving hypotheses and goals of the form X ⊆ Y
   or X = Y, where X, Y are expressions built using ∪, ∩, \, and ᶜ from finitely many variables of
   type Set α. It also unfolds expressions of the form Disjoint A B and symmDiff A B.
+
+  Examples:
+  ```lean
+  example {α} (A B C D : Set α) (h1 : A ⊆ B) (h2 : C ⊆ D) : C \ B ⊆ D \ A := by
+    tauto_set
+
+  example {α} (A B C : Set α) (h1 : A ⊆ B ∪ C) : (A ∩ B) ∪ (A ∩ C) = A := by
+    tauto_set
+  ```
 -/
 macro "tauto_set" : tactic => `(tactic|
   · simp_all only [
@@ -39,6 +48,7 @@ macro "tauto_set" : tactic => `(tactic|
     try specialize_all x
     <;> tauto
 )
+
 
 
 end Mathlib.Tactic.TautoSet

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -37,8 +37,6 @@ elab (name := specialize_all) "specialize_all" x:term : tactic => withMainContex
     tauto_set
   ```
 -/
-
-
 macro "tauto_set" : tactic => `(tactic|
   · simp_all only [
       Set.ext_iff, Set.subset_def,

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lenny Taelman
 -/
 
-import Mathlib.Tactic.Tauto
 import Mathlib.Data.Set.SymmDiff
 
 /-!

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -7,7 +7,7 @@ Authors: Lenny Taelman
 import Mathlib.Data.Set.SymmDiff
 
 /-!
-  The `tauto_set` tactic
+# The `tauto_set` tactic
 -/
 
 namespace Mathlib.Tactic.TautoSet

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -15,7 +15,7 @@ namespace Mathlib.Tactic.TautoSet
 open Lean Elab.Tactic
 
 /--
-  `specialize_all x` runs `specialize h x` for all hypotheses `h` where this tactic succeeds.
+`specialize_all x` runs `specialize h x` for all hypotheses `h` where this tactic succeeds.
 -/
 elab (name := specialize_all) "specialize_all" x:term : tactic => withMainContext do
   for h in ← getLCtx do

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -41,9 +41,9 @@ elab (name := specialize_all) "specialize_all" x:term : tactic => withMainContex
 
 macro "tauto_set" : tactic => `(tactic|
   · simp_all only [
-      Set.diff_eq, Set.disjoint_iff, Set.symmDiff_def,
       Set.ext_iff, Set.subset_def,
-      Set.mem_union, Set.mem_compl_iff, Set.mem_inter_iff
+      Set.mem_union, Set.mem_compl_iff, Set.mem_inter_iff,
+      Set.symmDiff_def, Set.diff_eq, Set.disjoint_iff
     ]
     try intro x
     try specialize_all x

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2025 Lenny Taelman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lenny Taelman
+-/
+
+import Mathlib.Tactic.Tauto
+import Mathlib.Data.Set.Basic
+import Mathlib.Data.Set.SymmDiff
+
+/-!
+  The `tauto_set` tactic
+-/
+
+namespace Mathlib.Tactic.TautoSet
+
+open Lean Elab.Tactic
+
+/--
+  `specialize_all x` runs `specialize h x` for all hypotheses `h` where this tactic succeeds.
+-/
+elab (name := specialize_all) "specialize_all" x:term : tactic => withMainContext do
+  for h in ← getLCtx do
+    evalTactic (← `(tactic|specialize $(mkIdent h.userName) $x)) <|> pure ()
+
+
+/--
+  `tauto_set` attempts to prove tautologies involving hypotheses and goals of the form X ⊆ Y
+  or X = Y, where X, Y are expressions built using ∪, ∩, \, and ᶜ from finitely many variables of
+  type Set α. It also unfolds expressions of the form Disjoint A B and symmDiff A B.
+-/
+macro "tauto_set" : tactic => `(tactic|
+  · simp_all only [
+      Set.diff_eq, Set.disjoint_iff, Set.symmDiff_def,
+      Set.ext_iff, Set.subset_def,
+      Set.mem_union, Set.mem_compl_iff, Set.mem_inter_iff
+    ]
+    try intro x
+    try specialize_all x
+    <;> tauto
+)
+
+
+end Mathlib.Tactic.TautoSet

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -79,73 +79,69 @@ example (hAB : A ⊆ B) (hBC : B ⊆ C) (hCD : C ⊆ D) (hDE : D = E) (hEA : E �
 -/
 
 -- setminus_inter_union_eq_union
-example {X Y : Set α} : X \ (X ∩ Y) ∪ Y = X ∪ Y := by tauto_set
+example : A \ (A ∩ B) ∪ B = A ∪ B := by tauto_set
 
 -- sub_parts_eq
-example {A E₁ E₂ : Set α} (hA : A ⊆ E₁ ∪ E₂) : (A ∩ E₁) ∪ (A ∩ E₂) = A := by tauto_set
+example (hA : A ⊆ B ∪ C) : (A ∩ B) ∪ (A ∩ C) = A := by tauto_set
 
 -- elem_notin_set_minus_singleton
-example (a : α) (X : Set α) : a ∉ X \ {a} := by tauto_set
+example (a : α) : a ∉ A \ {a} := by tauto_set
 
 -- sub_union_diff_sub_union
-example {A B C : Set α} (hA : A ⊆ B \ C) : A ⊆ B := by tauto_set
+example (hA : A ⊆ B \ C) : A ⊆ B := by tauto_set
 
 -- singleton_inter_subset_left
-example {X Y : Set α} {a : α} (ha : X ∩ Y = {a}) : {a} ⊆ X := by tauto_set
+example (hAB : A ∩ B = {a}) : {a} ⊆ A := by tauto_set
 
 -- singleton_inter_subset_right
-example {X Y : Set α} {a : α} (ha : X ∩ Y = {a}) : {a} ⊆ Y := by tauto_set
+example (hAB : A ∩ B = {a}) : {a} ⊆ B := by tauto_set
 
 -- diff_subset_parent
-example {X₁ X₂ E : Set α} (hX₁E : X₁ ⊆ E) : X₁ \ X₂ ⊆ E := by tauto_set
+example (hAB : A ⊆ C) : A \ B ⊆ C := by tauto_set
 
 -- inter_subset_parent_left
-example {X₁ X₂ E : Set α} (hX₁E : X₁ ⊆ E) : X₁ ∩ X₂ ⊆ E := by tauto_set
+example (hAC : A ⊆ C) : A ∩ B ⊆ C := by tauto_set
 
 -- inter_subset_parent_right
-example {X₁ X₂ E : Set α} (hX₂E : X₂ ⊆ E) : X₁ ∩ X₂ ⊆ E := by tauto_set
+example (hBC : B ⊆ C) : A ∩ B ⊆ C := by tauto_set
 
 -- inter_subset_union
-example {X₁ X₂ : Set α} : X₁ ∩ X₂ ⊆ X₁ ∪ X₂ := by tauto_set
+example : A ∩ B ⊆ A ∪ B := by tauto_set
 
 -- subset_diff_empty_eq
-example {A B : Set α} (hAB : A ⊆ B) (hBA : B \ A = ∅) : A = B := by tauto_set
+example (hAB : A ⊆ B) (hBA : B \ A = ∅) : A = B := by tauto_set
 
 -- Disjoint.ni_of_in
-example {X Y : Set α} {a : α} (hXY : Disjoint X Y) (ha : a ∈ X) :
-    a ∉ Y := by tauto_set
+example (hAB : Disjoint A B) (ha : a ∈ A) : a ∉ B := by tauto_set
 
 -- disjoint_of_singleton_inter_left_wo
-example {X Y : Set α} {a : α} (hXY : X ∩ Y = {a}) :
-    Disjoint (X \ {a}) Y := by tauto_set
+example (hAB : A ∩ B = {a}) : Disjoint (A \ {a}) B := by tauto_set
 
 -- disjoint_of_singleton_inter_right_wo
-example {X Y : Set α} {a : α} (hXY : X ∩ Y = {a}) :
-    Disjoint X (Y \ {a}) := by tauto_set
+example (hAB : A ∩ B = {a}) : Disjoint A (B \ {a}) := by tauto_set
 
 -- disjoint_of_singleton_inter_both_wo
-example {X Y : Set α} {a : α} (hXY : X ∩ Y = {a}) :
-    Disjoint (X \ {a}) (Y \ {a}) := by tauto_set
+example (hAB : A ∩ B = {a}) : Disjoint (A \ {a}) (B \ {a}) := by tauto_set
 
 -- union_subset_union_iff
-example {A B X : Set α} (hAX : Disjoint A X) (hBX : Disjoint B X) :
-    A ∪ X ⊆ B ∪ X ↔ A ⊆ B := by
+example (hAC : Disjoint A C) (hBC : Disjoint B C) :
+    A ∪ C ⊆ B ∪ C ↔ A ⊆ B := by
   constructor <;> (intro; tauto_set)
 
 -- symmDiff_eq_alt
-example (X Y : Set α) : symmDiff X Y = (X ∪ Y) \ (X ∩ Y) := by tauto_set
+example : symmDiff A B = (A ∪ B) \ (A ∩ B) := by tauto_set
 
 -- symmDiff_disjoint_inter
-example (X Y : Set α) : Disjoint (symmDiff X Y) (X ∩ Y) := by tauto_set
+example : Disjoint (symmDiff A B) (A ∩ B) := by tauto_set
 
 -- symmDiff_empty_eq
-example (X : Set α) : symmDiff X ∅ = X := by tauto_set
+example : symmDiff A ∅ = A := by tauto_set
 
 -- empty_symmDiff_eq
-example (X : Set α) : symmDiff ∅ X = X := by tauto_set
+example : symmDiff ∅ A = A := by tauto_set
 
 -- symmDiff_subset_ground_right
-example {X Y E : Set α} (hE : symmDiff X Y ⊆ E) (hX : X ⊆ E) : Y ⊆ E := by tauto_set
+example (hC : symmDiff A B ⊆ C) (hA : A ⊆ C) : B ⊆ C := by tauto_set
 
 -- symmDiff_subset_ground_left
-example {X Y E : Set α} (hE : symmDiff X Y ⊆ E) (hX : Y ⊆ E) : X ⊆ E := by tauto_set
+example (hC : symmDiff A B ⊆ C) (hB : B ⊆ C) : A ⊆ C := by tauto_set

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2025 Lenny Taelman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lenny Taelman
+-/
+
+import Mathlib.Tactic.TautoSet
+
+variable (α : Type) (A B C D E : Set α)
+
+
+example (h : B ∪ C ⊆ A ∪ A) : B ⊆ A := by tauto_set
+example (h: B ∩ B ∩ C ⊇ A) : A ⊆ B := by tauto_set
+example (h1 : A ⊆ B ∪ C) (h2 : C ⊆ D): A ⊆ B ∪ D := by tauto_set
+
+example (h : A = Aᶜ) : B = ∅ := by tauto_set
+example (h : A = Aᶜ) : B = C := by tauto_set
+
+example (h : A ⊆ Aᶜ \ B) : A = ∅ := by tauto_set
+example (h1 : A ⊆ B \ C) : A ⊆ B := by tauto_set
+
+example (h : Set.univ ⊆ ((A ∪ B) ∩ C) ∩ ((Aᶜ ∩ Bᶜ) ∪ Cᶜ)) : D \ B ⊆ E ∩ Aᶜ := by tauto_set
+
+example (h : A ∩ B ⊆ C) (h2 : C ∩ D ⊆ E) : A ∩ B ∩ D ⊆ E := by tauto_set
+example (h : E = Aᶜᶜ ∩ Cᶜᶜᶜ ∩ D) : D ∩ (B ∪ Cᶜ) ∩ A = E ∪ (A ∩ Dᶜᶜ ∩ B)ᶜᶜ := by tauto_set
+example (h : E ⊇ Aᶜᶜ ∩ Cᶜᶜᶜ ∩ D) : D ∩ (B ∪ Cᶜ) ∩ A ⊆  E ∪ (A ∩ Dᶜᶜ ∩ B)ᶜᶜ := by tauto_set
+
+example (h1 : A = B) : A = B := by tauto_set
+example (h1 : A = B) (h2 : B ⊆ C): A ⊆ C := by tauto_set
+
+example (h1 : A ∩ B = Set.univ) : A = Set.univ := by tauto_set
+example (h1 : A ∪ B = ∅) : A = ∅ := by tauto_set
+
+example (h1 : Aᶜ ⊆ ∅) : A = Set.univ := by tauto_set
+example (h1: Set.univ ⊆ Aᶜ) : A = ∅ := by tauto_set
+
+example : A ∩ ∅ = ∅ := by tauto_set
+example : A ∪ Set.univ = Set.univ := by tauto_set
+
+example : ∅ ⊆ A := by tauto_set
+example : A ⊆ Set.univ := by tauto_set
+
+example (h1 : A ⊆ B) (h2: B ⊆ A) : A = B := by tauto_set
+
+example : A ∪ (B ∩ C) = (A ∪ B) ∩ (A ∪ C) := by tauto_set
+example : A ∩ (B ∪ C) = (A ∩ B) ∪ (A ∩ C) := by tauto_set
+example : A ∩ (B ∪ C) ⊆ (A ∩ B) ∪ (A ∩ C) := by tauto_set
+
+example : A ⊆ (A ∪ B) ∪ C := by tauto_set
+
+example : A ∩ B ⊆ A := by tauto_set
+example : A ⊆ A ∪ B := by tauto_set
+
+example (h1 : B ⊆ A) (h2 : Set.univ ⊆ B): Set.univ = A := by tauto_set
+
+example (h1 : A ⊆ B) (h2 : C ⊆ D) : C \ B ⊆ D \ A := by tauto_set
+
+example (h1 : Disjoint A B) (h2 : C ⊆ A) : Disjoint C (B \ D) := by tauto_set
+
+example : Aᶜᶜᶜ = Aᶜ := by tauto_set
+example : Aᶜᶜ = A := by tauto_set
+
+example (hAB : A ⊆ B) (hBC : B ⊆ C) : A ⊆ C := by tauto_set
+
+example : (Aᶜ ∩ B ∩ Cᶜᶜ)ᶜᶜᶜᶜᶜ = Cᶜ ∪ Bᶜ ∪ ∅ ∪ A ∪ ∅ := by tauto_set
+
+example : D ∩ (B ∪ Cᶜ) ∩ A = (Aᶜᶜ ∩ Cᶜᶜᶜ ∩ D) ∪ (A ∩ Dᶜᶜ ∩ B)ᶜᶜ := by tauto_set
+
+example (h1 : A ⊆ B) (h2 : B ⊆ C) (h3 : C ⊆ D) (h4 : D = E) (h5 : E ⊆ A) :
+  (Aᶜ ∩ B ∪ (C ∩ Bᶜ)ᶜ ∩ (Eᶜ ∪ A))ᶜ ∩ (B ∪ Eᶜᶜ)ᶜ =
+  (Dᶜ ∩ C ∪ (B ∩ Aᶜ)ᶜ ∩ (Eᶜ ∪ E))ᶜ ∩ (D ∪ Cᶜᶜ)ᶜ := by tauto_set
+
+
+
+/-
+  Examples from the Matroid Decomposition Theorem Verification,
+  see https://github.com/Ivan-Sergeyev/seymour, and in particular
+  https://github.com/Ivan-Sergeyev/seymour/blob/d8fcfa23336efe50b09fa0939e8a4ec3a5601ae9/Seymour/ForMathlib/SetTheory.lean
+-/
+
+-- setminus_inter_union_eq_union
+example  {X Y : Set α} : X \ (X ∩ Y) ∪ Y = X ∪ Y := by tauto_set
+
+-- sub_parts_eq
+example {A E₁ E₂ : Set α} (hA : A ⊆ E₁ ∪ E₂) : (A ∩ E₁) ∪ (A ∩ E₂) = A := by tauto_set
+
+-- elem_notin_set_minus_singleton
+example (a : α) (X : Set α) : a ∉ X \ {a} := by tauto_set
+
+-- sub_union_diff_sub_union
+example {A B C : Set α} (hA : A ⊆ B \ C) : A ⊆ B := by tauto_set
+
+-- singleton_inter_subset_left
+example {X Y : Set α} {a : α} (ha : X ∩ Y = {a}) : {a} ⊆ X := by tauto_set
+
+-- singleton_inter_subset_right
+example {X Y : Set α} {a : α} (ha : X ∩ Y = {a}) : {a} ⊆ Y := by tauto_set
+
+-- diff_subset_parent
+example {X₁ X₂ E : Set α} (hX₁E : X₁ ⊆ E) : X₁ \ X₂ ⊆ E := by tauto_set
+
+-- inter_subset_parent_left
+example {X₁ X₂ E : Set α} (hX₁E : X₁ ⊆ E) : X₁ ∩ X₂ ⊆ E := by tauto_set
+
+-- inter_subset_parent_right
+example {X₁ X₂ E : Set α} (hX₂E : X₂ ⊆ E) : X₁ ∩ X₂ ⊆ E := by tauto_set
+
+-- inter_subset_union
+example {X₁ X₂ : Set α} : X₁ ∩ X₂ ⊆ X₁ ∪ X₂ := by tauto_set
+
+-- subset_diff_empty_eq
+example {A B : Set α} (hAB : A ⊆ B) (hBA : B \ A = ∅) : A = B := by tauto_set
+
+-- Disjoint.ni_of_in
+example {X Y : Set α} {a : α} (hXY : Disjoint X Y) (ha : a ∈ X) :
+    a ∉ Y := by tauto_set
+
+-- disjoint_of_singleton_inter_left_wo
+example {X Y : Set α} {a : α} (hXY : X ∩ Y = {a}) :
+    Disjoint (X \ {a}) Y := by tauto_set
+
+-- disjoint_of_singleton_inter_right_wo
+example {X Y : Set α} {a : α} (hXY : X ∩ Y = {a}) :
+    Disjoint X (Y \ {a}) := by tauto_set
+
+-- disjoint_of_singleton_inter_both_wo
+example {X Y : Set α} {a : α} (hXY : X ∩ Y = {a}) :
+    Disjoint (X \ {a}) (Y \ {a}) := by tauto_set
+
+-- union_subset_union_iff
+example {A B X : Set α} (hAX : Disjoint A X) (hBX : Disjoint B X) :
+    A ∪ X ⊆ B ∪ X ↔ A ⊆ B := by
+  constructor
+  · intro h; tauto_set
+  · intro h; tauto_set
+
+-- symmDiff_eq_alt
+example (X Y : Set α) : symmDiff X Y = (X ∪ Y) \ (X ∩ Y) := by tauto_set
+
+-- symmDiff_disjoint_inter
+example (X Y : Set α) : Disjoint (symmDiff X Y) (X ∩ Y) := by tauto_set
+
+-- symmDiff_empty_eq
+example (X : Set α) : symmDiff X ∅ = X := by tauto_set
+
+-- empty_symmDiff_eq
+example (X : Set α) : symmDiff ∅ X = X := by tauto_set
+
+-- symmDiff_subset_ground_right
+example {X Y E : Set α} (hE : symmDiff X Y ⊆ E) (hX : X ⊆ E) : Y ⊆ E := by tauto_set
+
+-- symmDiff_subset_ground_left
+example {X Y E : Set α} (hE : symmDiff X Y ⊆ E) (hX : Y ⊆ E) : X ⊆ E := by tauto_set

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -40,7 +40,7 @@ example : A ∪ Set.univ = Set.univ := by tauto_set
 example : ∅ ⊆ A := by tauto_set
 example : A ⊆ Set.univ := by tauto_set
 
-example (h1 : A ⊆ B) (h2: B ⊆ A) : A = B := by tauto_set
+example (hAB : A ⊆ B) (hBA: B ⊆ A) : A = B := by tauto_set
 
 example : A ∪ (B ∩ C) = (A ∪ B) ∩ (A ∪ C) := by tauto_set
 example : A ∩ (B ∪ C) = (A ∩ B) ∪ (A ∩ C) := by tauto_set
@@ -51,7 +51,7 @@ example : A ⊆ (A ∪ B) ∪ C := by tauto_set
 example : A ∩ B ⊆ A := by tauto_set
 example : A ⊆ A ∪ B := by tauto_set
 
-example (h1 : B ⊆ A) (h2 : Set.univ ⊆ B): Set.univ = A := by tauto_set
+example (hBA : B ⊆ A) (hB : Set.univ ⊆ B): Set.univ = A := by tauto_set
 
 example (hAB : A ⊆ B) (hCD : C ⊆ D) : C \ B ⊆ D \ A := by tauto_set
 

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -31,8 +31,8 @@ example (h1 : A = B) (h2 : B ⊆ C): A ⊆ C := by tauto_set
 example (h1 : A ∩ B = Set.univ) : A = Set.univ := by tauto_set
 example (h1 : A ∪ B = ∅) : A = ∅ := by tauto_set
 
-example (h1 : Aᶜ ⊆ ∅) : A = Set.univ := by tauto_set
-example (h1: Set.univ ⊆ Aᶜ) : A = ∅ := by tauto_set
+example (h: Aᶜ ⊆ ∅) : A = Set.univ := by tauto_set
+example (h: Set.univ ⊆ Aᶜ) : A = ∅ := by tauto_set
 
 example : A ∩ ∅ = ∅ := by tauto_set
 example : A ∪ Set.univ = Set.univ := by tauto_set

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -66,7 +66,7 @@ example : (Aᶜ ∩ B ∩ Cᶜᶜ)ᶜᶜᶜᶜᶜ = Cᶜ ∪ Bᶜ ∪ ∅ ∪ A 
 
 example : D ∩ (B ∪ Cᶜ) ∩ A = (Aᶜᶜ ∩ Cᶜᶜᶜ ∩ D) ∪ (A ∩ Dᶜᶜ ∩ B)ᶜᶜ := by tauto_set
 
-example (h1 : A ⊆ B) (h2 : B ⊆ C) (h3 : C ⊆ D) (h4 : D = E) (h5 : E ⊆ A) :
+example (hAB : A ⊆ B) (hBC : B ⊆ C) (hCD : C ⊆ D) (hDE : D = E) (hEA : E ⊆ A) :
   (Aᶜ ∩ B ∪ (C ∩ Bᶜ)ᶜ ∩ (Eᶜ ∪ A))ᶜ ∩ (B ∪ Eᶜᶜ)ᶜ =
   (Dᶜ ∩ C ∪ (B ∩ Aᶜ)ᶜ ∩ (Eᶜ ∪ E))ᶜ ∩ (D ∪ Cᶜᶜ)ᶜ := by tauto_set
 

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -11,7 +11,7 @@ variable (α : Type) (A B C D E : Set α)
 
 example (h : B ∪ C ⊆ A ∪ A) : B ⊆ A := by tauto_set
 example (h: B ∩ B ∩ C ⊇ A) : A ⊆ B := by tauto_set
-example (h1 : A ⊆ B ∪ C) (h2 : C ⊆ D): A ⊆ B ∪ D := by tauto_set
+example (hABC : A ⊆ B ∪ C) (hCD : C ⊆ D): A ⊆ B ∪ D := by tauto_set
 
 example (h : A = Aᶜ) : B = ∅ := by tauto_set
 example (h : A = Aᶜ) : B = C := by tauto_set

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -10,7 +10,7 @@ variable {α : Type} {A B C D E : Set α}
 
 
 example (h : B ∪ C ⊆ A ∪ A) : B ⊆ A := by tauto_set
-example (h: B ∩ B ∩ C ⊇ A) : A ⊆ B := by tauto_set
+example (h : B ∩ B ∩ C ⊇ A) : A ⊆ B := by tauto_set
 example (hABC : A ⊆ B ∪ C) (hCD : C ⊆ D): A ⊆ B ∪ D := by tauto_set
 
 example (h : A = Aᶜ) : B = ∅ := by tauto_set

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -79,7 +79,7 @@ example (hAB : A ⊆ B) (hBC : B ⊆ C) (hCD : C ⊆ D) (hDE : D = E) (hEA : E �
 -/
 
 -- setminus_inter_union_eq_union
-example  {X Y : Set α} : X \ (X ∩ Y) ∪ Y = X ∪ Y := by tauto_set
+example {X Y : Set α} : X \ (X ∩ Y) ∪ Y = X ∪ Y := by tauto_set
 
 -- sub_parts_eq
 example {A E₁ E₂ : Set α} (hA : A ⊆ E₁ ∪ E₂) : (A ∩ E₁) ∪ (A ∩ E₂) = A := by tauto_set

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -53,7 +53,7 @@ example : A ⊆ A ∪ B := by tauto_set
 
 example (h1 : B ⊆ A) (h2 : Set.univ ⊆ B): Set.univ = A := by tauto_set
 
-example (h1 : A ⊆ B) (h2 : C ⊆ D) : C \ B ⊆ D \ A := by tauto_set
+example (hAB : A ⊆ B) (hCD : C ⊆ D) : C \ B ⊆ D \ A := by tauto_set
 
 example (hAB : Disjoint A B) (hCA : C ⊆ A) : Disjoint C (B \ D) := by tauto_set
 

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -131,7 +131,7 @@ example {X Y : Set α} {a : α} (hXY : X ∩ Y = {a}) :
 example {A B X : Set α} (hAX : Disjoint A X) (hBX : Disjoint B X) :
     A ∪ X ⊆ B ∪ X ↔ A ⊆ B := by
   constructor
-  · intro h; tauto_set
+  · intro; tauto_set
   · intro h; tauto_set
 
 -- symmDiff_eq_alt

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -67,8 +67,8 @@ example : (Aᶜ ∩ B ∩ Cᶜᶜ)ᶜᶜᶜᶜᶜ = Cᶜ ∪ Bᶜ ∪ ∅ ∪ A 
 example : D ∩ (B ∪ Cᶜ) ∩ A = (Aᶜᶜ ∩ Cᶜᶜᶜ ∩ D) ∪ (A ∩ Dᶜᶜ ∩ B)ᶜᶜ := by tauto_set
 
 example (hAB : A ⊆ B) (hBC : B ⊆ C) (hCD : C ⊆ D) (hDE : D = E) (hEA : E ⊆ A) :
-  (Aᶜ ∩ B ∪ (C ∩ Bᶜ)ᶜ ∩ (Eᶜ ∪ A))ᶜ ∩ (B ∪ Eᶜᶜ)ᶜ =
-  (Dᶜ ∩ C ∪ (B ∩ Aᶜ)ᶜ ∩ (Eᶜ ∪ E))ᶜ ∩ (D ∪ Cᶜᶜ)ᶜ := by tauto_set
+    (Aᶜ ∩ B ∪ (C ∩ Bᶜ)ᶜ ∩ (Eᶜ ∪ A))ᶜ ∩ (B ∪ Eᶜᶜ)ᶜ =
+    (Dᶜ ∩ C ∪ (B ∩ Aᶜ)ᶜ ∩ (Eᶜ ∪ E))ᶜ ∩ (D ∪ Cᶜᶜ)ᶜ := by tauto_set
 
 
 

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -130,7 +130,7 @@ example {X Y : Set α} {a : α} (hXY : X ∩ Y = {a}) :
 -- union_subset_union_iff
 example {A B X : Set α} (hAX : Disjoint A X) (hBX : Disjoint B X) :
     A ∪ X ⊆ B ∪ X ↔ A ⊆ B := by
-  constructor
+  constructor <;>
   · intro; tauto_set
   · intro h; tauto_set
 

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -6,7 +6,7 @@ Authors: Lenny Taelman
 
 import Mathlib.Tactic.TautoSet
 
-variable (α : Type) (A B C D E : Set α)
+variable {α : Type} {A B C D E : Set α}
 
 
 example (h : B ∪ C ⊆ A ∪ A) : B ⊆ A := by tauto_set

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -55,7 +55,7 @@ example (h1 : B ⊆ A) (h2 : Set.univ ⊆ B): Set.univ = A := by tauto_set
 
 example (h1 : A ⊆ B) (h2 : C ⊆ D) : C \ B ⊆ D \ A := by tauto_set
 
-example (h1 : Disjoint A B) (h2 : C ⊆ A) : Disjoint C (B \ D) := by tauto_set
+example (hAB : Disjoint A B) (hCA : C ⊆ A) : Disjoint C (B \ D) := by tauto_set
 
 example : Aᶜᶜᶜ = Aᶜ := by tauto_set
 example : Aᶜᶜ = A := by tauto_set

--- a/MathlibTest/TautoSet.lean
+++ b/MathlibTest/TautoSet.lean
@@ -130,9 +130,7 @@ example {X Y : Set α} {a : α} (hXY : X ∩ Y = {a}) :
 -- union_subset_union_iff
 example {A B X : Set α} (hAX : Disjoint A X) (hBX : Disjoint B X) :
     A ∪ X ⊆ B ∪ X ↔ A ⊆ B := by
-  constructor <;>
-  · intro; tauto_set
-  · intro h; tauto_set
+  constructor <;> (intro; tauto_set)
 
 -- symmDiff_eq_alt
 example (X Y : Set α) : symmDiff X Y = (X ∪ Y) \ (X ∩ Y) := by tauto_set

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -213,6 +213,7 @@
   "Mathlib.Tactic.Widget.CommDiag": ["Mathlib.CategoryTheory.Category.Basic"],
   "Mathlib.Tactic.Use": ["Batteries.Logic"],
   "Mathlib.Tactic.TermCongr": ["Mathlib.Logic.Basic"],
+  "Mathlib.Tactic.TautoSet": ["Mathlib.Data.Set.SymmDiff"],
   "Mathlib.Tactic.Tauto": ["Mathlib.Logic.Basic"],
   "Mathlib.Tactic.TFAE": ["Mathlib.Data.List.TFAE", "Mathlib.Tactic.Have"],
   "Mathlib.Tactic.Subsingleton": ["Mathlib.Logic.Basic", "Std.Logic"],


### PR DESCRIPTION
Implement a tactic that proves tautologies involving hypotheses and goals of the form `X ⊆ Y` or `X = Y`, where `X`, `Y` are expressions built using `∪`, `∩`, `\`, and `ᶜ` from finitely many variables of type `Set α`.  It also unfolds `Disjoint` and `symmDiff`.

Discussed in the zulip thread https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Trivialities.20about.20sets

The file MathlibTest/TautoSet.lean contains many usage examples, including a list of lemma's from the Matroid Decomposition Theorem Verification project, which can now be golfed to a single tactic invocation.
