### PR TITLE
[Merged by Bors] - chore(RingTheory/Extension): Simplify algebra instance by using def.

### DIFF
--- a/Mathlib/RingTheory/Extension.lean
+++ b/Mathlib/RingTheory/Extension.lean
@@ -62,11 +62,7 @@ attribute [simp] algebraMap_σ
 -- We want to make sure `R₀` acts compatibly on `R` and `S` to avoid unsensical instances
 @[nolint unusedArguments]
 noncomputable instance {R₀} [CommRing R₀] [Algebra R₀ R] [Algebra R₀ S] [IsScalarTower R₀ R S] :
-    Algebra R₀ P.Ring where
-  __ := Module.compHom P.Ring (algebraMap R₀ R)
-  __ := (algebraMap R P.Ring).comp (algebraMap R₀ R)
-  smul_def' _ _ := smul_def _ _
-  commutes' _ _ := commutes _ _
+    Algebra R₀ P.Ring := Algebra.compHom P.Ring (algebraMap R₀ R)
 
 instance {R₀} [CommRing R₀] [Algebra R₀ R] [Algebra R₀ S] [IsScalarTower R₀ R S] :
     IsScalarTower R₀ R P.Ring := IsScalarTower.of_algebraMap_eq' rfl


### PR DESCRIPTION
As suggested in the conversation around #20518 , the algebra instance has been subsumed by a definition, and this PR makes the replacement.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
