### PR TITLE
[Merged by Bors] - chore(Analysis/Normed/Ring/WithAbs): make equiv a ring equiv

### DIFF
--- a/Mathlib/Analysis/Normed/Ring/WithAbs.lean
+++ b/Mathlib/Analysis/Normed/Ring/WithAbs.lean
@@ -30,7 +30,7 @@ open Topology
 
 noncomputable section
 
-variable {R S K : Type*} [Semiring R] [OrderedSemiring S] [Field K]
+variable {R R' S K : Type*} [Semiring R] [Ring R'] [OrderedSemiring S] [Field K]
 
 /-- Type synonym for a semiring which depends on an absolute value. This is a function that takes
 an absolute value on a semiring and returns the semiring. We use this to assign and infer instances
@@ -40,10 +40,7 @@ def WithAbs : AbsoluteValue R S → Type _ := fun _ => R
 
 namespace WithAbs
 
-variable (v : AbsoluteValue R ℝ)
-
-/-- Canonical equivalence between `WithAbs v` and `R`. -/
-def equiv : WithAbs v ≃ R := Equiv.refl (WithAbs v)
+variable (v : AbsoluteValue R ℝ) (v' : AbsoluteValue R' ℝ)
 
 instance instNonTrivial [Nontrivial R] : Nontrivial (WithAbs v) := inferInstanceAs (Nontrivial R)
 
@@ -51,56 +48,60 @@ instance instUnique [Unique R] : Unique (WithAbs v) := inferInstanceAs (Unique R
 
 instance instSemiring : Semiring (WithAbs v) := inferInstanceAs (Semiring R)
 
-instance instRing [Ring R] : Ring (WithAbs v) := inferInstanceAs (Ring R)
+instance instRing : Ring (WithAbs v') := inferInstanceAs (Ring R')
 
 instance instInhabited : Inhabited (WithAbs v) := ⟨0⟩
 
-instance normedRing {R : Type*} [Ring R] (v : AbsoluteValue R ℝ) : NormedRing (WithAbs v) :=
-  v.toNormedRing
+/-- Canonical equivalence between `WithAbs v` and `R`. -/
+def equiv : WithAbs v ≃+* R := RingEquiv.refl _
+
+instance normedRing : NormedRing (WithAbs v') :=
+  v'.toNormedRing
 
 instance normedField (v : AbsoluteValue K ℝ) : NormedField (WithAbs v) :=
   v.toNormedField
 
 /-! `WithAbs.equiv` preserves the ring structure. -/
+variable (x y : WithAbs v) (r s : R) (x' y' : WithAbs v') (r' s' : R')
 
-variable (x y : WithAbs v) (r s : R)
-@[simp]
-theorem equiv_zero : WithAbs.equiv v 0 = 0 := rfl
+@[deprecated "Use map_zero" (since := "2025-01-13"), simp]
+theorem equiv_zero : equiv v 0 = 0 := rfl
 
-@[simp]
-theorem equiv_symm_zero : (WithAbs.equiv v).symm 0 = 0 := rfl
+@[deprecated "Use map_zero" (since := "2025-01-13"), simp]
+theorem equiv_symm_zero : (equiv v).symm 0 = 0 := rfl
 
-@[simp]
-theorem equiv_add : WithAbs.equiv v (x + y) = WithAbs.equiv v x + WithAbs.equiv v y := rfl
+@[deprecated "Use map_add" (since := "2025-01-13"), simp]
+theorem equiv_add : equiv v (x + y) = equiv v x + equiv v y := rfl
 
-@[simp]
+@[deprecated "Use map_add" (since := "2025-01-13"), simp]
 theorem equiv_symm_add :
-    (WithAbs.equiv v).symm (r + s) = (WithAbs.equiv v).symm r + (WithAbs.equiv v).symm s :=
+    (equiv v).symm (r + s) = (equiv v).symm r + (equiv v).symm s :=
   rfl
 
-@[simp]
-theorem equiv_sub [Ring R] : WithAbs.equiv v (x - y) = WithAbs.equiv v x - WithAbs.equiv v y := rfl
+@[deprecated "Use map_sub" (since := "2025-01-13"), simp]
+theorem equiv_sub : equiv v' (x' - y') = equiv v' x' - equiv v' y' := rfl
 
-@[simp]
-theorem equiv_symm_sub [Ring R] :
-    (WithAbs.equiv v).symm (r - s) = (WithAbs.equiv v).symm r - (WithAbs.equiv v).symm s :=
+@[deprecated "Use map_sub" (since := "2025-01-13"), simp]
+theorem equiv_symm_sub :
+    (equiv v').symm (r' - s') = (equiv v').symm r' - (equiv v').symm s' :=
   rfl
 
-@[simp]
-theorem equiv_neg [Ring R] : WithAbs.equiv v (-x) = - WithAbs.equiv v x := rfl
+@[deprecated "Use map_neg" (since := "2025-01-13"), simp]
+theorem equiv_neg : equiv v' (-x') = - equiv v' x' := rfl
 
-@[simp]
-theorem equiv_symm_neg [Ring R] : (WithAbs.equiv v).symm (-r) = - (WithAbs.equiv v).symm r := rfl
+@[deprecated "Use map_nneg" (since := "2025-01-13"), simp]
+theorem equiv_symm_neg : (equiv v').symm (-r') = - (equiv v').symm r' := rfl
 
-@[simp]
-theorem equiv_mul : WithAbs.equiv v (x * y) = WithAbs.equiv v x * WithAbs.equiv v y := rfl
+@[deprecated "Use map_mul" (since := "2025-01-13"), simp]
+theorem equiv_mul : equiv v (x * y) = equiv v x * equiv v y := rfl
 
-@[simp]
+@[deprecated "Use map_mul" (since := "2025-01-13"), simp]
 theorem equiv_symm_mul :
-    (WithAbs.equiv v).symm (x * y) = (WithAbs.equiv v).symm x * (WithAbs.equiv v).symm y :=
+    (equiv v).symm (x * y) = (equiv v).symm x * (equiv v).symm y :=
   rfl
 
 /-- `WithAbs.equiv` as a ring equivalence. -/
+@[deprecated equiv (since := "2025-01-13")]
 def ringEquiv : WithAbs v ≃+* R := RingEquiv.refl _
 
 /-! The completion of a field at an absolute value. -/

--- a/Mathlib/Analysis/Normed/Ring/WithAbs.lean
+++ b/Mathlib/Analysis/Normed/Ring/WithAbs.lean
@@ -30,6 +30,8 @@ open Topology
 
 noncomputable section
 
+section definition
+
 variable {R R' S K : Type*} [Semiring R] [Ring R'] [OrderedSemiring S] [Field K]
 
 /-- Type synonym for a semiring which depends on an absolute value. This is a function that takes
@@ -134,6 +136,8 @@ theorem isUniformInducing_of_comp (h : ∀ x, ‖f x‖ = v x) : IsUniformInduci
   isUniformInducing_iff_uniformSpace.2 <| uniformSpace_comap_eq_of_comp h
 
 end WithAbs
+
+end definition
 
 namespace AbsoluteValue
 

--- a/Mathlib/Analysis/Normed/Ring/WithAbs.lean
+++ b/Mathlib/Analysis/Normed/Ring/WithAbs.lean
@@ -54,7 +54,7 @@ instance instRing : Ring (WithAbs v') := inferInstanceAs (Ring R')
 
 instance instInhabited : Inhabited (WithAbs v) := ⟨0⟩
 
-/-- Canonical equivalence between `WithAbs v` and `R`. -/
+/-- The canonical (semiring) equivalence between `WithAbs v` and `R`. -/
 def equiv : WithAbs v ≃+* R := RingEquiv.refl _
 
 instance normedRing : NormedRing (WithAbs v') :=
@@ -91,7 +91,7 @@ theorem equiv_symm_sub :
 @[deprecated "Use map_neg" (since := "2025-01-13"), simp]
 theorem equiv_neg : equiv v' (-x') = - equiv v' x' := rfl
 
-@[deprecated "Use map_nneg" (since := "2025-01-13"), simp]
+@[deprecated "Use map_neg" (since := "2025-01-13"), simp]
 theorem equiv_symm_neg : (equiv v').symm (-r') = - (equiv v').symm r' := rfl
 
 @[deprecated "Use map_mul" (since := "2025-01-13"), simp]

--- a/Mathlib/NumberTheory/NumberField/Completion.lean
+++ b/Mathlib/NumberTheory/NumberField/Completion.lean
@@ -83,7 +83,7 @@ instance : Algebra K v.Completion :=
 lemma WithAbs.ratCast_equiv (v : InfinitePlace ℚ) (x : WithAbs v.1) :
     Rat.cast (WithAbs.equiv _ x) = (x : v.Completion) :=
   (eq_ratCast (UniformSpace.Completion.coeRingHom.comp
-    (WithAbs.ringEquiv v.1).symm.toRingHom) x).symm
+    (WithAbs.equiv v.1).symm.toRingHom) x).symm
 
 lemma Rat.norm_infinitePlace_completion (v : InfinitePlace ℚ) (x : ℚ) :
     ‖(x : v.Completion)‖ = |x| := by


### PR DESCRIPTION
Making `WithAbs.equiv` a ring equivalence (like `WithAbs.ringEquiv`) should make a lot of the API lemmas obsolete.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
