### PR TITLE
[Merged by Bors] - chore: address some porting notes about coercions of equivs

### DIFF
--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -141,7 +141,9 @@ theorem coe_fun_injective : @Function.Injective (A₁ ≃ₐ[R] A₂) (A₁ → 
 instance hasCoeToRingEquiv : CoeOut (A₁ ≃ₐ[R] A₂) (A₁ ≃+* A₂) :=
   ⟨AlgEquiv.toRingEquiv⟩
 
--- Porting note: `toFun_eq_coe` no longer needed in Lean4
+@[simp]
+theorem coe_toEquiv : ((e : A₁ ≃ A₂) : A₁ → A₂) = e :=
+  rfl
 
 @[simp]
 theorem toRingEquiv_eq_coe : e.toRingEquiv = e :=
@@ -161,7 +163,6 @@ theorem coe_ringEquiv' : (e.toRingEquiv : A₁ → A₂) = e :=
 theorem coe_ringEquiv_injective : Function.Injective ((↑) : (A₁ ≃ₐ[R] A₂) → A₁ ≃+* A₂) :=
   fun _ _ h => ext <| RingEquiv.congr_fun h
 
--- Porting note: Added [coe] attribute
 /-- Interpret an algebra equivalence as an algebra homomorphism.
 
 This definition is included for symmetry with the other `to*Hom` projections.
@@ -285,7 +286,7 @@ theorem coe_coe_symm_apply_coe_apply {F : Type*} [EquivLike F A₁ A₂] [AlgEqu
     (f : A₁ ≃ₐ[R] A₂).symm (f x) = x :=
   EquivLike.left_inv f x
 
--- Porting note: `simp` normal form of `invFun_eq_symm`
+/-- `simp` normal form of `invFun_eq_symm` -/
 @[simp]
 theorem symm_toEquiv_eq_symm {e : A₁ ≃ₐ[R] A₂} : (e : A₁ ≃ A₂).symm = e.symm :=
   rfl
@@ -359,12 +360,10 @@ end symm
 
 section simps
 
--- Porting note: the default simps projection was `e.toEquiv.toFun`, it should be `FunLike.coe`
 /-- See Note [custom simps projection] -/
 def Simps.apply (e : A₁ ≃ₐ[R] A₂) : A₁ → A₂ :=
   e
 
--- Porting note: the default simps projection was `e.toEquiv`, it should be `EquivLike.toEquiv`
 /-- See Note [custom simps projection] -/
 def Simps.toEquiv (e : A₁ ≃ₐ[R] A₂) : A₁ ≃ A₂ :=
   e

--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -214,19 +214,19 @@ theorem mk_coe (e : M ≃* N) (e' h₁ h₂ h₃) : (⟨⟨e, e', h₁, h₂⟩,
 theorem toEquiv_eq_coe (f : M ≃* N) : f.toEquiv = f :=
   rfl
 
--- Porting note: added, to simplify `f.toMulHom` back to the coercion via `MulHomClass.toMulHom`.
+/-- The `simp`-normal form to turn something into a `MulHom` is via `MulHomClass.toMulHom`. -/
 @[to_additive (attr := simp)]
 theorem toMulHom_eq_coe (f : M ≃* N) : f.toMulHom = ↑f :=
   rfl
 
--- Porting note: `to_fun_eq_coe` no longer needed in Lean4
+@[to_additive]
+theorem toFun_eq_coe (f : M ≃* N) : f.toFun = f := rfl
 
+/-- `simp`-normal form of `toFun_eq_coe`. -/
 @[to_additive (attr := simp)]
 theorem coe_toEquiv (f : M ≃* N) : ⇑(f : M ≃ N) = f := rfl
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: `MulHom.coe_mk` simplifies `↑f.toMulHom` to `f.toMulHom.toFun`,
--- not `f.toEquiv.toFun`; use higher priority as a workaround
-@[to_additive (attr := simp 1100)]
+@[to_additive (attr := simp)]
 theorem coe_toMulHom {f : M ≃* N} : (f.toMulHom : M → N) = f := rfl
 
 /-- Makes a multiplicative isomorphism from a bijection which preserves multiplication. -/
@@ -300,10 +300,10 @@ lemma symm_map_mul {M N : Type*} [Mul M] [Mul N] (h : M ≃* N) (x y : N) :
 def symm {M N : Type*} [Mul M] [Mul N] (h : M ≃* N) : N ≃* M :=
   ⟨h.toEquiv.symm, h.symm_map_mul⟩
 
-@[to_additive] -- Porting note: no longer a `simp`, see below
+@[to_additive]
 theorem invFun_eq_symm {f : M ≃* N} : f.invFun = f.symm := rfl
--- Porting note: to_additive translated the name incorrectly in mathlib 3.
 
+/-- `simp`-normal form of `invFun_eq_symm`. -/
 @[to_additive (attr := simp)]
 theorem coe_toEquiv_symm (f : M ≃* N) : ((f : M ≃ N).symm : N → M) = f.symm := rfl
 
@@ -312,8 +312,6 @@ theorem equivLike_inv_eq_symm (f : M ≃* N) : EquivLike.inv f = f.symm := rfl
 
 @[to_additive (attr := simp)]
 theorem toEquiv_symm (f : M ≃* N) : (f.symm : N ≃ M) = (f : M ≃ N).symm := rfl
-
--- Porting note: `toEquiv_mk` no longer needed in Lean4
 
 @[to_additive (attr := simp)]
 theorem symm_symm (f : M ≃* N) : f.symm.symm = f := rfl

--- a/Mathlib/LinearAlgebra/Finsupp/SumProd.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/SumProd.lean
@@ -42,10 +42,7 @@ def sumFinsuppLEquivProdFinsupp {α β : Type*} : (α ⊕ β →₀ M) ≃ₗ[R]
     map_smul' := by
       intros
       ext <;>
-        -- Porting note: `add_equiv.to_fun_eq_coe` →
-        --               `Equiv.toFun_as_coe` & `AddEquiv.toEquiv_eq_coe` & `AddEquiv.coe_toEquiv`
-        simp only [Equiv.toFun_as_coe, AddEquiv.toEquiv_eq_coe, AddEquiv.coe_toEquiv, Prod.smul_fst,
-          Prod.smul_snd, smul_apply,
+        simp only [AddEquiv.toFun_eq_coe, Prod.smul_fst, Prod.smul_snd, smul_apply,
           snd_sumFinsuppAddEquivProdFinsupp, fst_sumFinsuppAddEquivProdFinsupp,
           RingHom.id_apply] }
 

--- a/Mathlib/Topology/Hom/Open.lean
+++ b/Mathlib/Topology/Hom/Open.lean
@@ -73,7 +73,8 @@ instance : ContinuousOpenMapClass (α →CO β) α β where
 theorem toFun_eq_coe {f : α →CO β} : f.toFun = (f : α → β) :=
   rfl
 
-@[simp] -- Porting note: new, simpNF of `toFun_eq_coe`
+@[simp]
+/-- `simp`-normal form of `toFun_eq_coe`. -/
 theorem coe_toContinuousMap (f : α →CO β) : (f.toContinuousMap : α → β) = f := rfl
 
 @[ext]

--- a/Mathlib/Topology/Hom/Open.lean
+++ b/Mathlib/Topology/Hom/Open.lean
@@ -73,8 +73,8 @@ instance : ContinuousOpenMapClass (α →CO β) α β where
 theorem toFun_eq_coe {f : α →CO β} : f.toFun = (f : α → β) :=
   rfl
 
-@[simp]
 /-- `simp`-normal form of `toFun_eq_coe`. -/
+@[simp]
 theorem coe_toContinuousMap (f : α →CO β) : (f.toContinuousMap : α → β) = f := rfl
 
 @[ext]


### PR DESCRIPTION
I came across a few porting notes about removing `toFun_eq_coe`. We in fact do want to have this lemma for rewriting, but not as a `@[simp]` lemma. So readd the missing `toFun_eq_coe` lemmas, and turn some porting notes into doc comments.

In those files, also clean up some other porting notes about coercions: it looks like there were some workarounds that are now unnecessary.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
