### PR TITLE
[Merged by Bors] - chore(ConjAct): don't import fields

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -229,6 +229,7 @@ import Mathlib.Algebra.EuclideanDomain.Field
 import Mathlib.Algebra.EuclideanDomain.Int
 import Mathlib.Algebra.Exact
 import Mathlib.Algebra.Expr
+import Mathlib.Algebra.Field.Action.ConjAct
 import Mathlib.Algebra.Field.Basic
 import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Field.Equiv
@@ -374,6 +375,7 @@ import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.Group.ZeroOne
 import Mathlib.Algebra.GroupPower.IterateHom
 import Mathlib.Algebra.GroupWithZero.Action.Basic
+import Mathlib.Algebra.GroupWithZero.Action.ConjAct
 import Mathlib.Algebra.GroupWithZero.Action.Defs
 import Mathlib.Algebra.GroupWithZero.Action.End
 import Mathlib.Algebra.GroupWithZero.Action.Faithful
@@ -883,6 +885,7 @@ import Mathlib.Algebra.Regular.Basic
 import Mathlib.Algebra.Regular.Pow
 import Mathlib.Algebra.Regular.SMul
 import Mathlib.Algebra.Ring.Action.Basic
+import Mathlib.Algebra.Ring.Action.ConjAct
 import Mathlib.Algebra.Ring.Action.Field
 import Mathlib.Algebra.Ring.Action.Group
 import Mathlib.Algebra.Ring.Action.Invariant

--- a/Mathlib/Algebra/Field/Action/ConjAct.lean
+++ b/Mathlib/Algebra/Field/Action/ConjAct.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2022 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.GroupWithZero.Action.ConjAct
+
+/-!
+# Conjugation action on a field on itself
+-/
+
+namespace ConjAct
+
+variable {K : Type*} [DivisionRing K]
+
+instance distribMulAction₀ : DistribMulAction (ConjAct K) K :=
+  { ConjAct.mulAction₀ with
+    smul_zero := by simp [smul_def]
+    smul_add := by simp [smul_def, mul_add, add_mul] }
+
+end ConjAct

--- a/Mathlib/Algebra/GroupWithZero/Action/ConjAct.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/ConjAct.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2022 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.GroupTheory.GroupAction.ConjAct
+
+/-!
+# Conjugation action of a group with zero on itself
+-/
+
+assert_not_exists Ring
+
+variable {α G₀ : Type*}
+
+namespace ConjAct
+variable [GroupWithZero G₀]
+
+instance : GroupWithZero (ConjAct G₀) := ‹GroupWithZero G₀›
+
+@[simp] lemma ofConjAct_zero : ofConjAct 0 = (0 : G₀) := rfl
+@[simp] lemma toConjAct_zero : toConjAct (0 : G₀) = 0 := rfl
+
+instance mulAction₀ : MulAction (ConjAct G₀) G₀ where
+  one_smul := by simp [smul_def]
+  mul_smul := by simp [smul_def, mul_assoc]
+
+instance smulCommClass₀ [SMul α G₀] [SMulCommClass α G₀ G₀] [IsScalarTower α G₀ G₀] :
+    SMulCommClass α (ConjAct G₀) G₀ where
+  smul_comm a ug g := by rw [smul_def, smul_def, mul_smul_comm, smul_mul_assoc]
+
+instance smulCommClass₀' [SMul α G₀] [SMulCommClass G₀ α G₀] [IsScalarTower α G₀ G₀] :
+    SMulCommClass (ConjAct G₀) α G₀ :=
+  haveI := SMulCommClass.symm G₀ α G₀
+  .symm ..
+
+end ConjAct

--- a/Mathlib/Algebra/Ring/Action/ConjAct.lean
+++ b/Mathlib/Algebra/Ring/Action/ConjAct.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2022 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.Algebra.Ring.Action.Basic
+import Mathlib.GroupTheory.GroupAction.ConjAct
+
+/-!
+# Conjugation action of a ring on itself
+-/
+
+assert_not_exists Field
+
+namespace ConjAct
+variable {R : Type*} [Semiring R]
+
+instance unitsMulSemiringAction : MulSemiringAction (ConjAct Rˣ) R :=
+  { ConjAct.unitsMulDistribMulAction with
+    smul_zero := by simp [units_smul_def]
+    smul_add := by simp [units_smul_def, mul_add, add_mul] }
+
+end ConjAct

--- a/Mathlib/Analysis/Normed/Algebra/Exponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Exponential.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Anatole Dedecker. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker, Eric Wieser
 -/
+import Mathlib.Algebra.Ring.Action.ConjAct
 import Mathlib.Analysis.Analytic.ChangeOrigin
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.Data.Nat.Choose.Cast

--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -1,15 +1,12 @@
 /-
-Copyright (c) 2021 . All rights reserved.
+Copyright (c) 2021 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import Mathlib.Algebra.Field.Defs
-import Mathlib.Algebra.GroupWithZero.Action.Basic
-import Mathlib.Algebra.Ring.Action.Basic
+import Mathlib.Algebra.Group.Subgroup.ZPowers.Basic
 import Mathlib.Data.Fintype.Card
 import Mathlib.GroupTheory.GroupAction.Defs
 import Mathlib.GroupTheory.Subgroup.Centralizer
-import Mathlib.Algebra.Group.Subgroup.ZPowers.Basic
 
 /-!
 # Conjugation action of a group on itself
@@ -35,8 +32,11 @@ is that some theorems about the group actions will not apply when since this
 
 -/
 
+-- TODO
+-- assert_not_exists GroupWithZero
+assert_not_exists Ring
 
-variable (α M G G₀ R K : Type*)
+variable (α M G : Type*)
 
 /-- A type alias for a group `G`. `ConjAct G` acts on `G` by conjugation -/
 def ConjAct : Type _ :=
@@ -46,13 +46,11 @@ namespace ConjAct
 
 open MulAction Subgroup
 
-variable {M G G₀ R K}
+variable {M G}
 
 instance [Group G] : Group (ConjAct G) := ‹Group G›
 
 instance [DivInvMonoid G] : DivInvMonoid (ConjAct G) := ‹DivInvMonoid G›
-
-instance [GroupWithZero G] : GroupWithZero (ConjAct G) := ‹GroupWithZero G›
 
 instance [Fintype G] : Fintype (ConjAct G) := ‹Fintype G›
 
@@ -167,56 +165,7 @@ instance unitsSMulCommClass' [SMul α M] [SMulCommClass M α M] [IsScalarTower �
 
 end Monoid
 
-section Semiring
-
-variable [Semiring R]
-
-instance unitsMulSemiringAction : MulSemiringAction (ConjAct Rˣ) R :=
-  { ConjAct.unitsMulDistribMulAction with
-    smul_zero := by simp [units_smul_def]
-    smul_add := by simp [units_smul_def, mul_add, add_mul] }
-
-end Semiring
-
 end Units
-
-section GroupWithZero
-
-variable [GroupWithZero G₀]
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): removed `simp` attribute because `simpNF` says it can prove it
-theorem ofConjAct_zero : ofConjAct (0 : ConjAct G₀) = 0 :=
-  rfl
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): removed `simp` attribute because `simpNF` says it can prove it
-theorem toConjAct_zero : toConjAct (0 : G₀) = 0 :=
-  rfl
-
-instance mulAction₀ : MulAction (ConjAct G₀) G₀ where
-  one_smul := by simp [smul_def]
-  mul_smul := by simp [smul_def, mul_assoc]
-
-instance smulCommClass₀ [SMul α G₀] [SMulCommClass α G₀ G₀] [IsScalarTower α G₀ G₀] :
-    SMulCommClass α (ConjAct G₀) G₀ where
-  smul_comm a ug g := by rw [smul_def, smul_def, mul_smul_comm, smul_mul_assoc]
-
-instance smulCommClass₀' [SMul α G₀] [SMulCommClass G₀ α G₀] [IsScalarTower α G₀ G₀] :
-    SMulCommClass (ConjAct G₀) α G₀ :=
-  haveI := SMulCommClass.symm G₀ α G₀
-  SMulCommClass.symm _ _ _
-
-end GroupWithZero
-
-section DivisionRing
-
-variable [DivisionRing K]
-
-instance distribMulAction₀ : DistribMulAction (ConjAct K) K :=
-  { ConjAct.mulAction₀ with
-    smul_zero := by simp [smul_def]
-    smul_add := by simp [smul_def, mul_add, add_mul] }
-
-end DivisionRing
 
 variable [Group G]
 

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/SpinGroup.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/SpinGroup.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Jiale Miao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jiale Miao, Utensil Song, Eric Wieser
 -/
+import Mathlib.Algebra.Ring.Action.ConjAct
 import Mathlib.GroupTheory.GroupAction.ConjAct
 import Mathlib.Algebra.Star.Unitary
 import Mathlib.LinearAlgebra.CliffordAlgebra.Star


### PR DESCRIPTION
`ConjAct` is imported in basic algebra files about groups, and therefore should not import `MonoidWithZero`. The latter is currently quite deeply embedded within the import graph, so we start by removing `Field`.

The copyright headers come from https://github.com/leanprover-community/mathlib3/pull/8627 and https://github.com/leanprover-community/mathlib3/pull/13439.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
