### PR TITLE
[Merged by Bors] - feat(ModularForms/QExpansion): define q-expansions

### DIFF
--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Exp.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Exp.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.Complex.Periodic
 import Mathlib.Analysis.Complex.UpperHalfPlane.Basic
 
 /-!
@@ -13,11 +14,28 @@ This file contains lemmas about the exponential function on the upper half plane
 q-expansions of modular forms.
 -/
 
-open Real Complex UpperHalfPlane
+open Real Complex UpperHalfPlane Function
 
-theorem UpperHalfPlane.abs_exp_two_pi_I_lt_one (z : ℍ) :
-    ‖(Complex.exp (2 * π * Complex.I * z))‖ < 1 := by
-  simp only [coe_I, Complex.norm_eq_abs, Complex.abs_exp, mul_re, re_ofNat, ofReal_re, im_ofNat,
-    ofReal_im, mul_zero, sub_zero, Complex.I_re, mul_im, zero_mul, add_zero, Complex.I_im, mul_one,
-    sub_self, coe_re, coe_im, zero_sub, exp_lt_one_iff, Left.neg_neg_iff]
+local notation "𝕢" => Periodic.qParam
+
+theorem Function.Periodic.im_invQParam_pos_of_abs_lt_one
+    {h : ℝ} (hh : 0 < h) {q : ℂ} (hq : q.abs < 1) (hq_ne : q ≠ 0) :
+    0 < im (Periodic.invQParam h q) :=
+  im_invQParam .. ▸ mul_pos_of_neg_of_neg
+    (div_neg_of_neg_of_pos (neg_lt_zero.mpr hh) Real.two_pi_pos)
+    ((Real.log_neg_iff (abs.pos hq_ne)).mpr hq)
+
+lemma Function.Periodic.abs_qParam_le_of_one_half_le_im {ξ : ℂ} (hξ : 1 / 2 ≤ ξ.im) :
+    ‖𝕢 1 ξ‖ ≤ rexp (-π) := by
+  rwa [Periodic.qParam, ofReal_one, div_one, Complex.norm_eq_abs, Complex.abs_exp, Real.exp_le_exp,
+    mul_right_comm, mul_I_re, neg_le_neg_iff, ← ofReal_ofNat, ← ofReal_mul, im_ofReal_mul,
+    mul_comm _ π, mul_assoc, le_mul_iff_one_le_right Real.pi_pos, ← div_le_iff₀' two_pos]
+
+theorem UpperHalfPlane.abs_qParam_lt_one (n : ℕ) [NeZero n] (τ : ℍ) : (𝕢 n τ).abs < 1 := by
+  rw [Periodic.abs_qParam, Real.exp_lt_one_iff, neg_mul, coe_im, neg_mul, neg_div, neg_lt_zero,
+    div_pos_iff_of_pos_right (mod_cast Nat.pos_of_ne_zero <| NeZero.ne _)]
   positivity
+
+theorem UpperHalfPlane.abs_exp_two_pi_I_lt_one (τ : ℍ) :
+    ‖(Complex.exp (2 * π * Complex.I * τ))‖ < 1 := by
+  simpa [Function.Periodic.abs_qParam, Complex.abs_exp] using τ.abs_qParam_lt_one 1

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -3,8 +3,8 @@ Copyright (c) 2024 David Loeffler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Loeffler
 -/
-import Mathlib.Analysis.Complex.Periodic
 import Mathlib.Analysis.Complex.TaylorSeries
+import Mathlib.Analysis.Complex.UpperHalfPlane.Exp
 import Mathlib.NumberTheory.ModularForms.Basic
 import Mathlib.NumberTheory.ModularForms.Identities
 import Mathlib.RingTheory.PowerSeries.Basic
@@ -32,24 +32,6 @@ variable {k : ℤ} {F : Type*} [FunLike F ℍ ℂ] {Γ : Subgroup SL(2, ℤ)} (n
 
 local notation "I∞" => comap Complex.im atTop
 local notation "𝕢" => Periodic.qParam
-
-theorem Function.Periodic.im_invQParam_pos_of_abs_lt_one
-    {h : ℝ} (hh : 0 < h) {q : ℂ} (hq : q.abs < 1) (hq_ne : q ≠ 0) :
-    0 < im (Periodic.invQParam h q) :=
-  im_invQParam .. ▸ mul_pos_of_neg_of_neg
-    (div_neg_of_neg_of_pos (neg_lt_zero.mpr hh) Real.two_pi_pos)
-    ((Real.log_neg_iff (abs.pos hq_ne)).mpr hq)
-
-lemma Function.Periodic.abs_qParam_le_of_one_half_le_im {ξ : ℂ} (hξ : 1 / 2 ≤ ξ.im) :
-    ‖𝕢 1 ξ‖ ≤ rexp (-π) := by
-  rwa [Periodic.qParam, ofReal_one, div_one, norm_eq_abs, abs_exp, Real.exp_le_exp,
-    mul_right_comm, mul_I_re, neg_le_neg_iff, ← ofReal_ofNat, ← ofReal_mul, im_ofReal_mul,
-    mul_comm _ π, mul_assoc, le_mul_iff_one_le_right Real.pi_pos, ← div_le_iff₀' two_pos]
-
-theorem UpperHalfPlane.abs_qParam_lt_one (n : ℕ) [NeZero n] (τ : ℍ) : (𝕢 n τ).abs < 1 := by
-  rw [Periodic.abs_qParam, Real.exp_lt_one_iff, neg_mul, coe_im, neg_mul, neg_div, neg_lt_zero,
-    div_pos_iff_of_pos_right (mod_cast Nat.pos_of_ne_zero <| NeZero.ne _)]
-  positivity
 
 namespace SlashInvariantFormClass
 
@@ -146,7 +128,7 @@ lemma qExpansion_formalMultilinearSeries_apply_norm (m : ℕ) :
   simp
 
 lemma qExpansion_formalMultilinearSeries_radius [NeZero n] [ModularFormClass F Γ(n) k] :
-    1 ≤ (qExpansion_formalMultilinearSeries n f).radius := by
+    1 ≤ (qExpansionFormalMultilinearSeries n f).radius := by
   refine le_of_forall_ge_of_dense fun r hr ↦ ?_
   lift r to NNReal using hr.ne_top
   apply FormalMultilinearSeries.le_radius_of_summable
@@ -157,7 +139,7 @@ lemma qExpansion_formalMultilinearSeries_radius [NeZero n] [ModularFormClass F �
 
 /-- The `q`-expansion of `f` is an `FPowerSeries` representing `cuspFunction n f`. -/
 lemma hasFPowerSeries_cuspFunction [NeZero n] [ModularFormClass F Γ(n) k] :
-    HasFPowerSeriesOnBall (cuspFunction n f) (qExpansion_formalMultilinearSeries n f) 0 1 := by
+    HasFPowerSeriesOnBall (cuspFunction n f) (qExpansionFormalMultilinearSeries n f) 0 1 := by
   refine ⟨qExpansion_formalMultilinearSeries_radius n f, zero_lt_one, fun hy ↦ ?_⟩
   rw [EMetric.mem_ball, edist_zero_right, ENNReal.coe_lt_one_iff, ← NNReal.coe_lt_one,
     coe_nnnorm, norm_eq_abs] at hy

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -117,17 +117,19 @@ lemma hasSum_qExpansion [NeZero n] [ModularFormClass F Γ(n) k] (τ : ℍ) :
   simpa only [eq_cuspFunction n f] using
     hasSum_qExpansion_of_abs_lt n f (τ.abs_qParam_lt_one n)
 
-/-- The `q`-expansion of a level `n` modular form, bundled as a `FormalMultilinearSeries`. -/
+/-- The `q`-expansion of a level `n` modular form, bundled as a `FormalMultilinearSeries`. 
+TODO: Maybe get rid of this and instead define a general API for converting `PowerSeries` to
+`FormalMultlinearSeries`. -/
 def qExpansionFormalMultilinearSeries : FormalMultilinearSeries ℂ ℂ ℂ :=
   fun m ↦ (qExpansion n f).coeff ℂ m • ContinuousMultilinearMap.mkPiAlgebraFin ℂ m _
 
-lemma qExpansion_formalMultilinearSeries_apply_norm (m : ℕ) :
+lemma qExpansionFormalMultilinearSeries_apply_norm (m : ℕ) :
     ‖qExpansionFormalMultilinearSeries n f m‖ = ‖(qExpansion n f).coeff ℂ m‖ := by
   rw [qExpansionFormalMultilinearSeries,
     ← (ContinuousMultilinearMap.piFieldEquiv ℂ (Fin m) ℂ).symm.norm_map]
   simp
 
-lemma qExpansion_formalMultilinearSeries_radius [NeZero n] [ModularFormClass F Γ(n) k] :
+lemma qExpansionFormalMultilinearSeries_radius [NeZero n] [ModularFormClass F Γ(n) k] :
     1 ≤ (qExpansionFormalMultilinearSeries n f).radius := by
   refine le_of_forall_ge_of_dense fun r hr ↦ ?_
   lift r to NNReal using hr.ne_top

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -117,7 +117,7 @@ lemma hasSum_qExpansion [NeZero n] [ModularFormClass F Γ(n) k] (τ : ℍ) :
   simpa only [eq_cuspFunction n f] using
     hasSum_qExpansion_of_abs_lt n f (τ.abs_qParam_lt_one n)
 
-/-- The `q`-expansion of a level `n` modular form, bundled as a `FormalMultilinearSeries`. 
+/-- The `q`-expansion of a level `n` modular form, bundled as a `FormalMultilinearSeries`.
 TODO: Maybe get rid of this and instead define a general API for converting `PowerSeries` to
 `FormalMultlinearSeries`. -/
 def qExpansionFormalMultilinearSeries : FormalMultilinearSeries ℂ ℂ ℂ :=
@@ -134,7 +134,7 @@ lemma qExpansionFormalMultilinearSeries_radius [NeZero n] [ModularFormClass F Γ
   refine le_of_forall_ge_of_dense fun r hr ↦ ?_
   lift r to NNReal using hr.ne_top
   apply FormalMultilinearSeries.le_radius_of_summable
-  simp only [qExpansion_formalMultilinearSeries_apply_norm]
+  simp only [qExpansionFormalMultilinearSeries_apply_norm]
   rw [← r.abs_eq]
   simp_rw [pow_abs, ← Complex.abs_ofReal, ofReal_pow, ← Complex.norm_eq_abs, ← norm_mul]
   exact (hasSum_qExpansion_of_abs_lt n f (q := r) (by simpa using hr)).summable.norm
@@ -142,7 +142,7 @@ lemma qExpansionFormalMultilinearSeries_radius [NeZero n] [ModularFormClass F Γ
 /-- The `q`-expansion of `f` is an `FPowerSeries` representing `cuspFunction n f`. -/
 lemma hasFPowerSeries_cuspFunction [NeZero n] [ModularFormClass F Γ(n) k] :
     HasFPowerSeriesOnBall (cuspFunction n f) (qExpansionFormalMultilinearSeries n f) 0 1 := by
-  refine ⟨qExpansion_formalMultilinearSeries_radius n f, zero_lt_one, fun hy ↦ ?_⟩
+  refine ⟨qExpansionFormalMultilinearSeries_radius n f, zero_lt_one, fun hy ↦ ?_⟩
   rw [EMetric.mem_ball, edist_zero_right, ENNReal.coe_lt_one_iff, ← NNReal.coe_lt_one,
     coe_nnnorm, norm_eq_abs] at hy
   simpa [qExpansionFormalMultilinearSeries] using hasSum_qExpansion_of_abs_lt n f hy

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -19,9 +19,22 @@ application, we show that cusp forms decay exponentially to 0 as `im τ → ∞`
 We also define the `q`-expansion of a modular form, either as a power series or as a
 `FormalMultlinearSeries`, and show that it converges to `f` on the upper half plane.
 
+## Main definitions and results
+
+* `SlashInvariantFormClass.cuspFunction`: for a level `n` slash-invariant form, this is the function
+  `F` such that `f τ = F (exp (2 * π * I * τ / n))`, extended by a choice of limit at `0`.
+* `ModularFormClass.differentiableAt_cuspFunction`: when `f` is a modular form, its `cuspFunction`
+  is differentiable on the open unit disc (including at `0`).
+* `ModularFormClass.qExpansion`: the `q`-expansion of a modular form (defined as the Taylor series
+  of its `cuspFunction`), bundled as a `PowerSeries`.
+* `ModularFormClass.hasSum_qExpansion`: the `q`-expansion evaluated at `𝕢 n τ` sums to `f τ`, for
+  `τ` in the upper half plane.
+
 ## TO DO:
 
 * generalise to handle arbitrary finite-index subgroups (not just `Γ(n)` for some `n`)
+* define the `q`-expansion map on modular form spaces as a linear map (or even a ring hom from
+  the graded ring of all modular forms?)
 -/
 
 open ModularForm Complex Filter UpperHalfPlane Function

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -136,12 +136,12 @@ lemma hasSum_qExpansion [NeZero n] [ModularFormClass F Γ(n) k] (τ : ℍ) :
     hasSum_qExpansion_of_abs_lt n f (τ.abs_qParam_lt_one n)
 
 /-- The `q`-expansion of a level `n` modular form, bundled as a `FormalMultilinearSeries`. -/
-def qExpansion_formalMultilinearSeries : FormalMultilinearSeries ℂ ℂ ℂ :=
+def qExpansionFormalMultilinearSeries : FormalMultilinearSeries ℂ ℂ ℂ :=
   fun m ↦ (qExpansion n f).coeff ℂ m • ContinuousMultilinearMap.mkPiAlgebraFin ℂ m _
 
 lemma qExpansion_formalMultilinearSeries_apply_norm (m : ℕ) :
-    ‖qExpansion_formalMultilinearSeries n f m‖ = ‖(qExpansion n f).coeff ℂ m‖ := by
-  rw [qExpansion_formalMultilinearSeries,
+    ‖qExpansionFormalMultilinearSeries n f m‖ = ‖(qExpansion n f).coeff ℂ m‖ := by
+  rw [qExpansionFormalMultilinearSeries,
     ← (ContinuousMultilinearMap.piFieldEquiv ℂ (Fin m) ℂ).symm.norm_map]
   simp
 
@@ -161,7 +161,7 @@ lemma hasFPowerSeries_cuspFunction [NeZero n] [ModularFormClass F Γ(n) k] :
   refine ⟨qExpansion_formalMultilinearSeries_radius n f, zero_lt_one, fun hy ↦ ?_⟩
   rw [EMetric.mem_ball, edist_zero_right, ENNReal.coe_lt_one_iff, ← NNReal.coe_lt_one,
     coe_nnnorm, norm_eq_abs] at hy
-  simpa [qExpansion_formalMultilinearSeries] using hasSum_qExpansion_of_abs_lt n f hy
+  simpa [qExpansionFormalMultilinearSeries] using hasSum_qExpansion_of_abs_lt n f hy
 
 end ModularFormClass
 

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -111,6 +111,7 @@ lemma analyticAt_cuspFunction_zero [NeZero n] [ModularFormClass F Γ(n) k] :
     (fun q hq ↦ (differentiableAt_cuspFunction _ _ hq).differentiableWithinAt)
     (by simpa only [ball_zero_eq] using Metric.ball_mem_nhds (0 : ℂ) zero_lt_one)
 
+/-- The `q`-expansion of a level `n` modular form, bundled as a `PowerSeries`. -/
 def qExpansion : PowerSeries ℂ :=
   .mk fun m ↦ (↑m.factorial)⁻¹ * iteratedDeriv m (cuspFunction n f) 0
 
@@ -134,6 +135,7 @@ lemma hasSum_qExpansion [NeZero n] [ModularFormClass F Γ(n) k] (τ : ℍ) :
   simpa only [eq_cuspFunction n f] using
     hasSum_qExpansion_of_abs_lt n f (τ.abs_qParam_lt_one n)
 
+/-- The `q`-expansion of a level `n` modular form, bundled as a `FormalMultilinearSeries`. -/
 def qExpansion_formalMultilinearSeries : FormalMultilinearSeries ℂ ℂ ℂ :=
   fun m ↦ (qExpansion n f).coeff ℂ m • ContinuousMultilinearMap.mkPiAlgebraFin ℂ m _
 
@@ -143,8 +145,7 @@ lemma qExpansion_formalMultilinearSeries_apply_norm (m : ℕ) :
     ← (ContinuousMultilinearMap.piFieldEquiv ℂ (Fin m) ℂ).symm.norm_map]
   simp
 
-lemma qExpansion_formalMultilinearSeries_radius
-    [NeZero n] [ModularFormClass F Γ(n) k] :
+lemma qExpansion_formalMultilinearSeries_radius [NeZero n] [ModularFormClass F Γ(n) k] :
     1 ≤ (qExpansion_formalMultilinearSeries n f).radius := by
   refine le_of_forall_ge_of_dense fun r hr ↦ ?_
   lift r to NNReal using hr.ne_top
@@ -154,6 +155,7 @@ lemma qExpansion_formalMultilinearSeries_radius
   simp_rw [pow_abs, ← Complex.abs_ofReal, ofReal_pow, ← Complex.norm_eq_abs, ← norm_mul]
   exact (hasSum_qExpansion_of_abs_lt n f (q := r) (by simpa using hr)).summable.norm
 
+/-- The `q`-expansion of `f` is an `FPowerSeries` representing `cuspFunction n f`. -/
 lemma hasFPowerSeries_cuspFunction [NeZero n] [ModularFormClass F Γ(n) k] :
     HasFPowerSeriesOnBall (cuspFunction n f) (qExpansion_formalMultilinearSeries n f) 0 1 := by
   refine ⟨qExpansion_formalMultilinearSeries_radius n f, zero_lt_one, fun hy ↦ ?_⟩

--- a/Mathlib/NumberTheory/ModularForms/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/QExpansion.lean
@@ -16,10 +16,12 @@ We show that a modular form of level `Γ(n)` can be written as `τ ↦ F (𝕢 n
 analytic on the open unit disc, and `𝕢 n` is the parameter `τ ↦ exp (2 * I * π * τ / n)`. As an
 application, we show that cusp forms decay exponentially to 0 as `im τ → ∞`.
 
+We also define the `q`-expansion of a modular form, either as a power series or as a
+`FormalMultlinearSeries`, and show that it converges to `f` on the upper half plane.
+
 ## TO DO:
 
 * generalise to handle arbitrary finite-index subgroups (not just `Γ(n)` for some `n`)
-* define the `q`-expansion as a formal power series
 -/
 
 open ModularForm Complex Filter UpperHalfPlane Function
@@ -117,9 +119,12 @@ lemma hasSum_qExpansion [NeZero n] [ModularFormClass F Γ(n) k] (τ : ℍ) :
   simpa only [eq_cuspFunction n f] using
     hasSum_qExpansion_of_abs_lt n f (τ.abs_qParam_lt_one n)
 
-/-- The `q`-expansion of a level `n` modular form, bundled as a `FormalMultilinearSeries`.
+/--
+The `q`-expansion of a level `n` modular form, bundled as a `FormalMultilinearSeries`.
+
 TODO: Maybe get rid of this and instead define a general API for converting `PowerSeries` to
-`FormalMultlinearSeries`. -/
+`FormalMultlinearSeries`.
+-/
 def qExpansionFormalMultilinearSeries : FormalMultilinearSeries ℂ ℂ ℂ :=
   fun m ↦ (qExpansion n f).coeff ℂ m • ContinuousMultilinearMap.mkPiAlgebraFin ℂ m _
 


### PR DESCRIPTION
We define the q-expansion of a modular form (either as a power series or as a `FormalMultlinearSeries`), show it has radius of convergence at least 1, and show that it converges to the original form on the open unit ball.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
