### PR TITLE
[Merged by Bors] - chore: remove --loc flag from unused_in_pole.sh

### DIFF
--- a/scripts/unused_in_pole.sh
+++ b/scripts/unused_in_pole.sh
@@ -11,4 +11,4 @@
 # Default to Mathlib if no argument is provided
 target=${1:-Mathlib}
 
-lake exe pole --loc --to $target | tail -n +3 | cut -f2 -d '|' | awk '{$1=$1; print}' | grep -v "Lean\." | grep -v "Init\." | grep -v "Tactic\." | grep -v "^Mathlib$" | grep -v "^Mathlib.Init$" | xargs lake exe unused
+lake exe pole --to $target | tail -n +3 | cut -f2 -d '|' | awk '{$1=$1; print}' | grep -v "Lean\." | grep -v "Init\." | grep -v "Tactic\." | grep -v "^Mathlib$" | grep -v "^Mathlib.Init$" | xargs lake exe unused


### PR DESCRIPTION
When developing `unused_in_pole.sh`, the Speed Center was broken, so I used the `--loc` flag to compute the longest pole according to lines of code rather than instruction counts. Let's remove it again, as I think instructions are more useful, and that's what we usually do when looking at the longest pole.