### PR TITLE
[Merged by Bors] - chore(AlgebraicTopology): fix the definition of Kan complexes

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialSet/KanComplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/KanComplex.lean
@@ -16,22 +16,20 @@ we show that every Kan complex is a quasicategory.
 ## TODO
 
 - Show that the singular simplicial set of a topological space is a Kan complex.
-- Generalize the definition to higher universes.
-  Since `Λ[n, i]` is an object of `SSet.{0}`,
-  the current definition of a Kan complex `S`
-  requires `S : SSet.{0}`.
 
 -/
+
+universe u
 
 namespace SSet
 
 open CategoryTheory Simplicial
 
 /-- A simplicial set `S` is a *Kan complex* if it satisfies the following horn-filling condition:
-for every `n : ℕ` and `0 ≤ i ≤ n`,
+for every nonzero `n : ℕ` and `0 ≤ i ≤ n`,
 every map of simplicial sets `σ₀ : Λ[n, i] → S` can be extended to a map `σ : Δ[n] → S`. -/
-class KanComplex (S : SSet) : Prop where
-  hornFilling : ∀ ⦃n : ℕ⦄ ⦃i : Fin (n+1)⦄ (σ₀ : Λ[n, i] ⟶ S),
-    ∃ σ : Δ[n] ⟶ S, σ₀ = hornInclusion n i ≫ σ
+class KanComplex (S : SSet.{u}) : Prop where
+  hornFilling : ∀ ⦃n : ℕ⦄ ⦃i : Fin (n + 2)⦄ (σ₀ : Λ[n + 1, i] ⟶ S),
+    ∃ σ : Δ[n + 1] ⟶ S, σ₀ = hornInclusion (n + 1) i ≫ σ
 
 end SSet


### PR DESCRIPTION
The definition of Kan complexes is fixed by taking into account Remark 2.3 at https://ncatlab.org/nlab/show/horn

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
