### PR TITLE
[Merged by Bors] - feat(Data/Nat/Choose) : An upper bound on the binomial coefficient

### DIFF
--- a/Mathlib/Data/Nat/Choose/Bounds.lean
+++ b/Mathlib/Data/Nat/Choose/Bounds.lean
@@ -50,7 +50,7 @@ theorem pow_le_choose (r n : ℕ) : ((n + 1 - r : ℕ) ^ r : α) / r ! ≤ n.cho
     exact n.pow_sub_le_descFactorial r
   exact mod_cast r.factorial_pos
 
-theorem choose_succ_le_two_pow {n k : ℕ} : (n + 1).choose k ≤ 2 ^ n := by
+theorem choose_succ_le_two_pow (n k : ℕ) : (n + 1).choose k ≤ 2 ^ n := by
   by_cases lt : n + 1 < k
   · simp [choose_eq_zero_of_lt lt]
   · cases' n with n
@@ -62,8 +62,8 @@ theorem choose_succ_le_two_pow {n k : ℕ} : (n + 1).choose k ≤ 2 ^ n := by
           (n + 2).choose (k + 1) =
             (n + 1).choose k +
             (n + 1).choose (k + 1)           := choose_succ_succ' _ _
-          _ ≤ 2 ^ n + (n + 1).choose (k + 1) := Nat.add_le_add_right choose_succ_le_two_pow _
-          _ ≤ 2 ^ n + 2 ^ n                  := Nat.add_le_add_left choose_succ_le_two_pow _
+          _ ≤ 2 ^ n + (n + 1).choose (k + 1) := Nat.add_le_add_right (choose_succ_le_two_pow _ _) _
+          _ ≤ 2 ^ n + 2 ^ n                  := Nat.add_le_add_left (choose_succ_le_two_pow _ _) _
           _ = 2 ^ (n + 1)                    := Eq.symm (two_pow_succ n)
 
 end Nat

--- a/Mathlib/Data/Nat/Choose/Bounds.lean
+++ b/Mathlib/Data/Nat/Choose/Bounds.lean
@@ -58,12 +58,8 @@ theorem choose_succ_le_two_pow (n k : ℕ) : (n + 1).choose k ≤ 2 ^ n := by
     · cases' k with k
       · rw [choose_zero_right]
         exact Nat.one_le_two_pow
-      · calc
-          (n + 2).choose (k + 1) =
-            (n + 1).choose k +
-            (n + 1).choose (k + 1)           := choose_succ_succ' _ _
-          _ ≤ 2 ^ n + (n + 1).choose (k + 1) := Nat.add_le_add_right (choose_succ_le_two_pow _ _) _
-          _ ≤ 2 ^ n + 2 ^ n                  := Nat.add_le_add_left (choose_succ_le_two_pow _ _) _
-          _ = 2 ^ (n + 1)                    := Eq.symm (two_pow_succ n)
+      · rw [choose_succ_succ', two_pow_succ]
+        exact Nat.add_le_add (choose_succ_le_two_pow n k) (choose_succ_le_two_pow n (k + 1))
+
 
 end Nat

--- a/Mathlib/Data/Nat/Choose/Bounds.lean
+++ b/Mathlib/Data/Nat/Choose/Bounds.lean
@@ -50,17 +50,18 @@ theorem pow_le_choose (r n : ℕ) : ((n + 1 - r : ℕ) ^ r : α) / r ! ≤ n.cho
     exact n.pow_sub_le_descFactorial r
   exact mod_cast r.factorial_pos
 
-theorem choose_succ_le_two_pow {n k : ℕ} : (n + 1).choose k <= 2 ^ n := by
+theorem choose_succ_le_two_pow {n k : ℕ} : (n + 1).choose k ≤ 2 ^ n := by
   by_cases lt : n + 1 < k
   · simp [choose_eq_zero_of_lt lt]
   · cases' n with n
     · cases k <;> simp_all
     · cases' k with k
-      · exact Nat.one_le_two_pow
+      · rw [choose_zero_right]
+        exact Nat.one_le_two_pow
       · calc
           (n + 2).choose (k + 1) =
             (n + 1).choose k +
-            (n + 1).choose (k + 1)           := by simp [choose_succ_succ']
+            (n + 1).choose (k + 1)           := choose_succ_succ' _ _
           _ ≤ 2 ^ n + (n + 1).choose (k + 1) := Nat.add_le_add_right choose_succ_le_two_pow _
           _ ≤ 2 ^ n + 2 ^ n                  := Nat.add_le_add_left choose_succ_le_two_pow _
           _ = 2 ^ (n + 1)                    := Eq.symm (two_pow_succ n)

--- a/Mathlib/Data/Nat/Choose/Bounds.lean
+++ b/Mathlib/Data/Nat/Choose/Bounds.lean
@@ -50,4 +50,19 @@ theorem pow_le_choose (r n : ℕ) : ((n + 1 - r : ℕ) ^ r : α) / r ! ≤ n.cho
     exact n.pow_sub_le_descFactorial r
   exact mod_cast r.factorial_pos
 
+theorem choose_succ_le_two_pow {n k : ℕ} : (n + 1).choose k <= 2 ^ n := by
+  by_cases lt : n + 1 < k
+  · simp [choose_eq_zero_of_lt lt]
+  · cases' n with n
+    · cases k <;> simp_all
+    · cases' k with k
+      · exact Nat.one_le_two_pow
+      · calc
+          (n + 2).choose (k + 1) =
+            (n + 1).choose k +
+            (n + 1).choose (k + 1)           := by simp [choose_succ_succ']
+          _ ≤ 2 ^ n + (n + 1).choose (k + 1) := Nat.add_le_add_right choose_succ_le_two_pow _
+          _ ≤ 2 ^ n + 2 ^ n                  := Nat.add_le_add_left choose_succ_le_two_pow _
+          _ = 2 ^ (n + 1)                    := Eq.symm (two_pow_succ n)
+
 end Nat

--- a/Mathlib/Data/Nat/Choose/Bounds.lean
+++ b/Mathlib/Data/Nat/Choose/Bounds.lean
@@ -61,5 +61,4 @@ theorem choose_succ_le_two_pow (n k : ℕ) : (n + 1).choose k ≤ 2 ^ n := by
       · rw [choose_succ_succ', two_pow_succ]
         exact Nat.add_le_add (choose_succ_le_two_pow n k) (choose_succ_le_two_pow n (k + 1))
 
-
 end Nat

--- a/Mathlib/Data/Nat/Choose/Bounds.lean
+++ b/Mathlib/Data/Nat/Choose/Bounds.lean
@@ -61,4 +61,9 @@ theorem choose_succ_le_two_pow (n k : ℕ) : (n + 1).choose k ≤ 2 ^ n := by
       · rw [choose_succ_succ', two_pow_succ]
         exact Nat.add_le_add (choose_succ_le_two_pow n k) (choose_succ_le_two_pow n (k + 1))
 
+theorem choose_le_two_pow (n k : ℕ) (p : 0 < n) : n.choose k < 2 ^ n := by
+  refine lt_of_le_of_lt ?_ (Nat.two_pow_pred_lt_two_pow p)
+  rw [← Nat.sub_add_cancel p]
+  exact choose_succ_le_two_pow (n - 1) k
+
 end Nat


### PR DESCRIPTION
Add a theorem bounding `(n+1).choose k` from above by `2^n`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
