### PR TITLE
[Merged by Bors] - feat(Order/Atoms): atoms, coatoms in SetLike

### DIFF
--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -200,19 +200,14 @@ theorem isCoatom_iff [OrderTop A] {K : A} :
 
 theorem covBy_iff {K L : A} :
     K ⋖ L ↔ K < L ∧ ∀ H g, K ≤ H → H ≤ L → g ∉ K → g ∈ H → H = L := by
-  apply and_congr_right
-  intro _
-  apply forall_congr'
-  intro H
+  refine and_congr_right fun _ ↦ forall_congr' fun H ↦ ?_
   rw [lt_iff_le_not_le, SetLike.not_le_iff_exists, lt_iff_le_not_le, not_and, not_not,
     and_comm (a := _ ≤ _), and_imp, exists_imp]
-  apply forall_congr'
-  intro b
+  refine forall_congr' fun b ↦ ?_
   simp only [← and_imp]
   rw [and_comm, and_comm (b:= _ ∈ _), and_assoc]
-  apply imp_congr_right
-  intro h
-  simp only [le_antisymm_iff, h.2.1, true_and]
+  refine imp_congr_right fun ⟨_, _, h⟩ ↦ ?_
+  simp only [le_antisymm_iff, h, true_and]
 
 /-- Dual variant of `SetLike.covBy_iff` -/
 theorem covBy_iff' {K L : A} :

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -212,20 +212,14 @@ theorem covBy_iff {K L : A} :
 /-- Dual variant of `SetLike.covBy_iff` -/
 theorem covBy_iff' {K L : A} :
     K ⋖ L ↔ K < L ∧ ∀ H g, K ≤ H → H ≤ L → g ∉ H → g ∈ L → H = K := by
-  apply and_congr_right
-  intro _
-  apply forall_congr'
-  intro H
-  rw [imp_not_comm]
-  rw [lt_iff_le_not_le, SetLike.not_le_iff_exists, lt_iff_le_not_le, not_and, not_not,
+  refine and_congr_right fun _ ↦ forall_congr' fun H ↦ ?_
+  rw [imp_not_comm, lt_iff_le_not_le, SetLike.not_le_iff_exists, lt_iff_le_not_le, not_and, not_not,
     and_comm (a := _ ≤ _), and_imp, exists_imp]
-  apply forall_congr'
-  intro b
+  refine forall_congr' fun b ↦ ?_
   simp only [← and_imp]
   rw [and_comm (b := K ≤ _), and_comm, and_comm (b:= _ ∈ _), and_assoc]
-  apply imp_congr_right
-  intro h
-  simp only [le_antisymm_iff, h.1, and_true]
+  refine imp_congr_right fun ⟨h, _⟩ ↦ ?_
+  simp only [le_antisymm_iff, h, and_true]
 
 end SetLike
 

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
 import Mathlib.Data.Set.Lattice
+import Mathlib.Data.SetLike.Basic
 import Mathlib.Order.ModularLattice
 import Mathlib.Order.SuccPred.Basic
 import Mathlib.Order.WellFounded
@@ -182,6 +183,56 @@ theorem covBy_top_iff : a ⋖ ⊤ ↔ IsCoatom a :=
   toDual_covBy_toDual_iff.symm.trans bot_covBy_iff
 
 alias ⟨CovBy.isCoatom, IsCoatom.covBy_top⟩ := covBy_top_iff
+
+namespace SetLike
+
+variable {A B : Type*} [SetLike A B]
+
+theorem isAtom_iff [OrderBot A] {K : A} :
+    IsAtom K ↔ K ≠ ⊥ ∧ ∀ H g, H ≤ K → g ∉ H → g ∈ K → H = ⊥ := by
+  simp_rw [IsAtom, lt_iff_le_not_le, SetLike.not_le_iff_exists,
+    and_comm (a := _ ≤ _), and_imp, exists_imp, ← and_imp, and_comm]
+
+theorem isCoatom_iff [OrderTop A] {K : A} :
+    IsCoatom K ↔ K ≠ ⊤ ∧ ∀ H g, K ≤ H → g ∉ K → g ∈ H → H = ⊤ := by
+  simp_rw [IsCoatom, lt_iff_le_not_le, SetLike.not_le_iff_exists,
+    and_comm (a := _ ≤ _), and_imp, exists_imp, ← and_imp, and_comm]
+
+theorem covBy_iff {K L : A} :
+    K ⋖ L ↔ K < L ∧ ∀ H g, K ≤ H → H ≤ L → g ∉ K → g ∈ H → H = L := by
+  apply and_congr_right
+  intro _
+  apply forall_congr'
+  intro H
+  rw [lt_iff_le_not_le, SetLike.not_le_iff_exists, lt_iff_le_not_le, not_and, not_not,
+    and_comm (a := _ ≤ _), and_imp, exists_imp]
+  apply forall_congr'
+  intro b
+  simp only [← and_imp]
+  rw [and_comm, and_comm (b:= _ ∈ _), and_assoc]
+  apply imp_congr_right
+  intro h
+  simp only [le_antisymm_iff, h.2.1, true_and]
+
+/-- Dual variant of `SetLike.covBy_iff` -/
+theorem covBy_iff' {K L : A} :
+    K ⋖ L ↔ K < L ∧ ∀ H g, K ≤ H → H ≤ L → g ∉ H → g ∈ L → H = K := by
+  apply and_congr_right
+  intro _
+  apply forall_congr'
+  intro H
+  rw [imp_not_comm]
+  rw [lt_iff_le_not_le, SetLike.not_le_iff_exists, lt_iff_le_not_le, not_and, not_not,
+    and_comm (a := _ ≤ _), and_imp, exists_imp]
+  apply forall_congr'
+  intro b
+  simp only [← and_imp]
+  rw [and_comm (b := K ≤ _), and_comm, and_comm (b:= _ ∈ _), and_assoc]
+  apply imp_congr_right
+  intro h
+  simp only [le_antisymm_iff, h.1, and_true]
+
+end SetLike
 
 end PartialOrder
 

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -206,7 +206,7 @@ theorem covBy_iff {K L : A} :
   refine forall_congr' fun b ↦ ?_
   simp only [← and_imp]
   rw [and_comm, and_comm (b:= _ ∈ _), and_assoc]
-  refine imp_congr_right fun ⟨_, _, h⟩ ↦ ?_
+  refine imp_congr_right fun ⟨_, h, _⟩ ↦ ?_
   simp only [le_antisymm_iff, h, true_and]
 
 /-- Dual variant of `SetLike.covBy_iff` -/

--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -51,16 +51,8 @@ theorem IsMaximal.ne_top {I : Ideal α} (h : I.IsMaximal) : I ≠ ⊤ :=
   (isMaximal_def.1 h).1
 
 theorem isMaximal_iff {I : Ideal α} :
-    I.IsMaximal ↔ (1 : α) ∉ I ∧ ∀ (J : Ideal α) (x), I ≤ J → x ∉ I → x ∈ J → (1 : α) ∈ J :=
-  isMaximal_def.trans <|
-    and_congr I.ne_top_iff_one <|
-      forall_congr' fun J => by
-        rw [lt_iff_le_not_le]
-        exact
-          ⟨fun H x h hx₁ hx₂ => J.eq_top_iff_one.1 <| H ⟨h, not_subset.2 ⟨_, hx₂, hx₁⟩⟩,
-            fun H ⟨h₁, h₂⟩ =>
-            let ⟨x, xJ, xI⟩ := not_subset.1 h₂
-            J.eq_top_iff_one.2 <| H x h₁ xI xJ⟩
+    I.IsMaximal ↔ (1 : α) ∉ I ∧ ∀ (J : Ideal α) (x), I ≤ J → x ∉ I → x ∈ J → (1 : α) ∈ J := by
+  simp_rw [isMaximal_def, SetLike.isCoatom_iff, Ideal.ne_top_iff_one, ← Ideal.eq_top_iff_one]
 
 theorem IsMaximal.eq_of_le {I J : Ideal α} (hI : I.IsMaximal) (hJ : J ≠ ⊤) (IJ : I ≤ J) : I = J :=
   eq_iff_le_not_lt.2 ⟨IJ, fun h => hJ (hI.1.2 _ h)⟩


### PR DESCRIPTION
Add `SetLike.isAtom_iff`, `SetLike.isCoatom_iff`, `SetLike.covBy_iff` and `SetLike.covBy_iff'` that translate
the properties of being an atom, a coatom, or covby in a `SetLike` type.

Use it to golf the proof if `Ideal.isMaximal_iff`.

`SetLike.isCoatom_iff` was written by @alreadydone .

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
