### PR TITLE
[Merged by Bors] - fix: `rename_bvar` now handles mdata and mvars

### DIFF
--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -359,6 +359,7 @@ def renameBVar (e : Expr) (old new : Name) : Expr :=
     lam (if n == old then new else n) (ty.renameBVar old new) (bd.renameBVar old new) bi
   | forallE n ty bd bi =>
     forallE (if n == old then new else n) (ty.renameBVar old new) (bd.renameBVar old new) bi
+  | mdata d e' => mdata d (e'.renameBVar old new)
   | e => e
 
 open Lean.Meta in

--- a/Mathlib/Tactic/RenameBVar.lean
+++ b/Mathlib/Tactic/RenameBVar.lean
@@ -42,6 +42,7 @@ Note: name clashes are resolved automatically.
 -/
 elab "rename_bvar " old:ident " → " new:ident loc?:(location)? : tactic => do
   let mvarId ← getMainGoal
+  instantiateMVarDeclMVars mvarId
   match loc? with
   | none => renameBVarTarget mvarId old.getId new.getId
   | some loc =>

--- a/MathlibTest/renameBvar.lean
+++ b/MathlibTest/renameBvar.lean
@@ -1,4 +1,8 @@
 import Mathlib.Tactic.RenameBVar
+import Lean
+
+set_option linter.unusedVariables false
+axiom test_sorry {α : Sort _} : α
 
 /- This test is somewhat flaky since it depends on the pretty printer. -/
 /--
@@ -32,3 +36,27 @@ example (P : ℕ → ℕ → Prop) (h : ∀ n, ∃ m, P n m) : ∀ l, ∃ m, P l
   rename_bvar l → m
   trace_state
   exact h
+
+/--
+info: case intro
+a b c : Int
+h2 : b ∣ c
+k : Int
+hk : b = a * k
+⊢ ∃ k, c = a * k
+---
+info: case intro
+a b c : Int
+h2 : b ∣ c
+k : Int
+hk : b = a * k
+⊢ ∃ m, c = a * m
+-/
+#guard_msgs in
+example (a b c : Int) (h1 : a ∣ b) (h2 : b ∣ c) : a ∣ c := by
+  rcases h1 with ⟨k, hk⟩
+  show ∃ k, c = a * k
+  trace_state
+  rename_bvar k → m
+  trace_state
+  exact test_sorry


### PR DESCRIPTION
Reported by Patrick Massot [on Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/rename_bvar.20is.20broken/near/493593195)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
