### PR TITLE
[Merged by Bors] - feat(Set/Finite): a set is finite if its image and fibers are finite

### DIFF
--- a/Mathlib/Data/Set/Finite/Lattice.lean
+++ b/Mathlib/Data/Set/Finite/Lattice.lean
@@ -199,6 +199,16 @@ theorem union_finset_finite_of_range_finite (f : α → Finset β) (h : (range f
 
 end SetFiniteConstructors
 
+/--
+If the image of `s` under `f` is finite, and each fiber of `f` has a finite intersection
+with `s`, then `s` is itself finite.
+
+It is useful to give `f` explicitly here so this can be used with `apply`.
+-/
+lemma Finite.of_finite_fibers (f : α → β) {s : Set α} (himage : (f '' s).Finite)
+    (hfibers : ∀ x ∈ f '' s, (s ∩ f ⁻¹' {x}).Finite) : s.Finite :=
+  (himage.biUnion hfibers).subset fun x ↦ by aesop
+
 /-! ### Properties -/
 
 theorem finite_subset_iUnion {s : Set α} (hs : s.Finite) {ι} {t : ι → Set α} (h : s ⊆ ⋃ i, t i) :


### PR DESCRIPTION
A useful lemma from the disproof of the Aharoni–Korman conjecture, #20082.

Note this does not seem to follow from any of the existing preimage finiteness lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
