### PR TITLE
[Merged by Bors] - feat(Order/WellFoundedSet): add convenience constructors for IsWF and IsPWO for WellFoundedLT types

### DIFF
--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -208,6 +208,9 @@ theorem isWF_univ_iff : IsWF (univ : Set α) ↔ WellFounded ((· < ·) : α →
 
 theorem IsWF.mono (h : IsWF t) (st : s ⊆ t) : IsWF s := h.subset st
 
+lemma IsWF.of_wellFoundedLT [WellFoundedLT α] : IsWF s :=
+  (isWF_univ_iff.2 wellFounded_lt).mono (subset_univ _)
+
 end LT
 
 section Preorder
@@ -505,6 +508,12 @@ protected theorem IsWF.isPWO (hs : s.IsWF) : s.IsPWO := by
 /-- In a linear order, the predicates `Set.IsWF` and `Set.IsPWO` are equivalent. -/
 theorem isWF_iff_isPWO : s.IsWF ↔ s.IsPWO :=
   ⟨IsWF.isPWO, IsPWO.isWF⟩
+
+/--
+If `α` is a linear order with well-founded `<`, then the universe is a partially well-ordered set.
+Note this does not hold without the linearity assumption.
+-/
+lemma IsPWO.of_linearOrder [WellFoundedLT α] : s.IsPWO := IsWF.of_wellFoundedLT.isPWO
 
 end LinearOrder
 

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -510,7 +510,7 @@ theorem isWF_iff_isPWO : s.IsWF ↔ s.IsPWO :=
   ⟨IsWF.isPWO, IsPWO.isWF⟩
 
 /--
-If `α` is a linear order with well-founded `<`, then the universe is a partially well-ordered set.
+If `α` is a linear order with well-founded `<`, then any set in it is a partially well-ordered set.
 Note this does not hold without the linearity assumption.
 -/
 lemma IsPWO.of_linearOrder [WellFoundedLT α] : s.IsPWO := IsWF.of_wellFoundedLT.isPWO


### PR DESCRIPTION
A useful lemma from the disproof of the Aharoni–Korman conjecture, https://github.com/leanprover-community/mathlib4/pull/20082.

While these are easy to inline, they are hard to discover for an end user, since `WellFoundedLT` is never mentioned in this file. As such, this change improves discoverability, especially with `exact?`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
