### PR TITLE
[Merged by Bors] - feat(Data/Finset/Card): add `InjOn` and `SurjOn` versions of finset cardinality lemmas

### DIFF
--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -431,38 +431,39 @@ lemma le_card_of_inj_on_range (f : ℕ → α) (hf : ∀ i < n, f i ∈ s)
     n = #(range n) := (card_range n).symm
     _ ≤ #s := card_le_card_of_injOn f (by simpa only [mem_range]) (by simpa)
 
+lemma surjOn_of_injOn_of_card_le (f : α → β) (hf : Set.MapsTo f s t) (hinj : Set.InjOn f s)
+    (hst : #t ≤ #s) : Set.SurjOn f s t := by
+  classical
+  suffices s.image f = t by simp [← this, Set.SurjOn]
+  have : s.image f ⊆ t := by aesop (add simp Finset.subset_iff)
+  exact eq_of_subset_of_card_le this (hst.trans_eq (card_image_of_injOn hinj).symm)
+
 lemma surj_on_of_inj_on_of_card_le (f : ∀ a ∈ s, β) (hf : ∀ a ha, f a ha ∈ t)
     (hinj : ∀ a₁ a₂ ha₁ ha₂, f a₁ ha₁ = f a₂ ha₂ → a₁ = a₂) (hst : #t ≤ #s) :
     ∀ b ∈ t, ∃ a ha, b = f a ha := by
+  let f' : s → β := fun a ↦ f a a.2
+  have hinj' : Set.InjOn f' s.attach := fun x hx y hy hxy ↦ Subtype.ext (hinj _ _ x.2 y.2 hxy)
+  have hmapsto' : Set.MapsTo f' s.attach t := fun x hx ↦ hf _ _
+  intro b hb
+  obtain ⟨a, ha, rfl⟩ := surjOn_of_injOn_of_card_le _ hmapsto' hinj' (by rwa [card_attach]) hb
+  exact ⟨a, a.2, rfl⟩
+
+lemma injOn_of_surjOn_of_card_le (f : α → β) (hf : Set.MapsTo f s t) (hsurj : Set.SurjOn f s t)
+    (hst : #s ≤ #t) : Set.InjOn f s := by
   classical
-  have h : #(s.attach.image fun a : s ↦ f a a.2) = #s := by
-    rw [← @card_attach _ s, card_image_of_injective]
-    intro ⟨_, _⟩ ⟨_, _⟩ h
-    exact Subtype.eq <| hinj _ _ _ _ h
-  obtain rfl : image (fun a : { a // a ∈ s } => f a a.prop) s.attach = t :=
-    eq_of_subset_of_card_le (image_subset_iff.2 <| by simpa) (by simp [hst, h])
-  simp only [mem_image, mem_attach, true_and, Subtype.exists, forall_exists_index]
-  exact fun b a ha hb ↦ ⟨a, ha, hb.symm⟩
+  have : s.image f = t := Finset.coe_injective <| by simp [hsurj.image_eq_of_mapsTo hf]
+  have : #(s.image f) = #t := by rw [this]
+  have : #(s.image f) ≤ #s := card_image_le
+  rw [← card_image_iff]
+  omega
 
 theorem inj_on_of_surj_on_of_card_le (f : ∀ a ∈ s, β) (hf : ∀ a ha, f a ha ∈ t)
     (hsurj : ∀ b ∈ t, ∃ a ha, f a ha = b) (hst : #s ≤ #t) ⦃a₁⦄ (ha₁ : a₁ ∈ s) ⦃a₂⦄
-    (ha₂ : a₂ ∈ s) (ha₁a₂ : f a₁ ha₁ = f a₂ ha₂) : a₁ = a₂ :=
-  haveI : Inhabited { x // x ∈ s } := ⟨⟨a₁, ha₁⟩⟩
-  let f' : { x // x ∈ s } → { x // x ∈ t } := fun x => ⟨f x.1 x.2, hf x.1 x.2⟩
-  let g : { x // x ∈ t } → { x // x ∈ s } :=
-    @surjInv _ _ f' fun x =>
-      let ⟨y, hy₁, hy₂⟩ := hsurj x.1 x.2
-      ⟨⟨y, hy₁⟩, Subtype.eq hy₂⟩
-  have hg : Injective g := injective_surjInv _
-  have hsg : Surjective g := fun x =>
-    let ⟨y, hy⟩ :=
-      surj_on_of_inj_on_of_card_le (fun (x : { x // x ∈ t }) (_ : x ∈ t.attach) => g x)
-        (fun x _ => show g x ∈ s.attach from mem_attach _ _) (fun _ _ _ _ hxy => hg hxy) (by simpa)
-        x (mem_attach _ _)
-    ⟨y, hy.snd.symm⟩
-  have hif : Injective f' :=
-    (leftInverse_of_surjective_of_rightInverse hsg (rightInverse_surjInv _)).injective
-  Subtype.ext_iff_val.1 (@hif ⟨a₁, ha₁⟩ ⟨a₂, ha₂⟩ (Subtype.eq ha₁a₂))
+    (ha₂ : a₂ ∈ s) (ha₁a₂ : f a₁ ha₁ = f a₂ ha₂) : a₁ = a₂ := by
+  let f' : s → β := fun a ↦ f a a.2
+  have hsurj' : Set.SurjOn f' s.attach t := fun x hx ↦ by simpa [f'] using hsurj x hx
+  have hinj' := injOn_of_surjOn_of_card_le f' (fun x hx ↦ hf _ _) hsurj' (by simpa)
+  exact congrArg Subtype.val (@hinj' ⟨a₁, ha₁⟩ (by simp) ⟨a₂, ha₂⟩ (by simp) ha₁a₂)
 
 end bij
 


### PR DESCRIPTION
These lemmas are useful for dot notation, and help the interface between Set predicates and Finset cardinality.

In this PR we:
- Add two new lemmas for non-dependent functions, spelled with Set predicates
- Use them to golf the dependent versions and improve readability

Useful from the disproof of the Aharoni–Korman conjecture, https://github.com/leanprover-community/mathlib4/pull/20082.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
