### PR TITLE
[Merged by Bors] - feat(Order): relate chains to antichains

### DIFF
--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Set.Pairwise.Basic
 import Mathlib.Order.Bounds.Basic
 import Mathlib.Order.Directed
 import Mathlib.Order.Hom.Set
+import Mathlib.Order.Chain
 
 /-!
 # Antichains
@@ -171,6 +172,28 @@ theorem isAntichain_singleton (a : α) (r : α → α → Prop) : IsAntichain r 
 
 theorem Set.Subsingleton.isAntichain (hs : s.Subsingleton) (r : α → α → Prop) : IsAntichain r s :=
   hs.pairwise _
+
+/-- A set which is simultaneously a chain and antichain is subsingleton. -/
+lemma subsingleton_of_isChain_of_isAntichain (hs : IsChain r s) (ht : IsAntichain r s) :
+    s.Subsingleton := by
+  intro x hx y hy
+  by_contra! hne
+  cases hs hx hy hne with
+  | inl h => exact ht hx hy hne h
+  | inr h => exact ht hy hx hne.symm h
+
+lemma isChain_and_isAntichain_iff_subsingleton : IsChain r s ∧ IsAntichain r s ↔ s.Subsingleton :=
+  ⟨fun h ↦ subsingleton_of_isChain_of_isAntichain h.1 h.2, fun h ↦ ⟨h.isChain, h.isAntichain _⟩⟩
+
+/-- The intersection of a chain and an antichain is subsingleton.  -/
+lemma inter_subsingleton_of_isChain_of_isAntichain (hs : IsChain r s) (ht : IsAntichain r t) :
+    (s ∩ t).Subsingleton :=
+  subsingleton_of_isChain_of_isAntichain (hs.mono (by simp)) (ht.subset (by simp))
+
+/-- The intersection of an antichain and a chain is subsingleton.  -/
+lemma inter_subsingleton_of_isAntichain_of_isChain (hs : IsAntichain r s) (ht : IsChain r t) :
+    (s ∩ t).Subsingleton :=
+  subsingleton_of_isChain_of_isAntichain (ht.mono (by simp)) (hs.subset (by simp))
 
 section Preorder
 

--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -193,7 +193,7 @@ lemma inter_subsingleton_of_isChain_of_isAntichain (hs : IsChain r s) (ht : IsAn
 /-- The intersection of an antichain and a chain is subsingleton.  -/
 lemma inter_subsingleton_of_isAntichain_of_isChain (hs : IsAntichain r s) (ht : IsChain r t) :
     (s ∩ t).Subsingleton :=
-  subsingleton_of_isChain_of_isAntichain (ht.mono (by simp)) (hs.subset (by simp))
+  inter_comm _ _ ▸ inter_subsingleton_of_isChain_of_isAntichain ht hs
 
 section Preorder
 


### PR DESCRIPTION
A set which is a chain and an antichain is subsingleton. As a result, the intersection of a chain and antichain is subsingleton.

Useful from the disproof of the Aharoni–Korman conjecture, https://github.com/leanprover-community/mathlib4/pull/20082.

I believe the large import here is acceptable, as `IsChain` and `IsAntichain` need to be related to each other somewhere, but there is not much to say about both (as this PR shows). As such, making a third file specifically for these seems unnecessary, and putting these in `Order.Chain` results in a larger import change.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
