### PR TITLE
[Merged by Bors] - feat(Order/Chain): adapt linear order lemmas to chains

### DIFF
--- a/Mathlib/Order/Chain.lean
+++ b/Mathlib/Order/Chain.lean
@@ -129,6 +129,24 @@ theorem IsChain.exists3 (hchain : IsChain r s) [IsTrans α r] {a b c} (mem1 : a 
 
 end Total
 
+lemma IsChain.le_of_not_lt [Preorder α] (hs : IsChain (· ≤ ·) s)
+    {x y : α} (hx : x ∈ s) (hy : y ∈ s) (h : ¬ x < y) : y ≤ x := by
+  cases hs.total hx hy with
+  | inr h' => exact h'
+  | inl h' => simpa [lt_iff_le_not_le, h'] using h
+
+lemma IsChain.not_lt [Preorder α] (hs : IsChain (· ≤ ·) s)
+    {x y : α} (hx : x ∈ s) (hy : y ∈ s) : ¬ x < y ↔ y ≤ x :=
+  ⟨(hs.le_of_not_lt hx hy ·), fun h h' ↦ h'.not_le h⟩
+
+lemma IsChain.lt_of_not_le [Preorder α] (hs : IsChain (· ≤ ·) s)
+    {x y : α} (hx : x ∈ s) (hy : y ∈ s) (h : ¬ x ≤ y) : y < x :=
+  (hs.total hx hy).elim (h · |>.elim) (lt_of_le_not_le · h)
+
+lemma IsChain.not_le [Preorder α] (hs : IsChain (· ≤ ·) s)
+    {x y : α} (hx : x ∈ s) (hy : y ∈ s) : ¬ x ≤ y ↔ y < x :=
+  ⟨(hs.lt_of_not_le hx hy ·), fun h h' ↦ h'.not_lt h⟩
+
 theorem IsMaxChain.isChain (h : IsMaxChain r s) : IsChain r s :=
   h.1
 


### PR DESCRIPTION
Add a series of lemmas for chains in a preorder. Each of these are true in a linear order, but remain true under the weaker assumption that both elements are in a chain.

Used in the disproof of the Aharoni–Korman conjecture, https://github.com/leanprover-community/mathlib4/pull/20082.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
