### PR TITLE
feat: `casesm` tactic reuses hypothesis name if only one new hypothesis

### DIFF
--- a/Mathlib/Tactic/CasesM.lean
+++ b/Mathlib/Tactic/CasesM.lean
@@ -49,7 +49,9 @@ partial def casesMatching (matcher : Expr → MetaM Bool) (recursive := false) (
           for subgoal in subgoals do
             -- If only one new hypothesis is generated, rename it to the original name.
             let g ← if h : subgoal.fields.size = 1 then
-              subgoal.mvarId.rename subgoal.fields[0].fvarId! ldecl.userName
+              match subgoal.fields[0] with
+              | .fvar fvarId => subgoal.mvarId.rename fvarId ldecl.userName
+              | _ => pure subgoal.mvarId
             else
               pure subgoal.mvarId
             if recursive then

--- a/Mathlib/Tactic/CasesM.lean
+++ b/Mathlib/Tactic/CasesM.lean
@@ -48,12 +48,9 @@ partial def casesMatching (matcher : Expr → MetaM Bool) (recursive := false) (
               pure subgoals
           for subgoal in subgoals do
             -- If only one new hypothesis is generated, rename it to the original name.
-            let g ← if h : subgoal.fields.size = 1 then
-              match subgoal.fields[0] with
-              | .fvar fvarId => subgoal.mvarId.rename fvarId ldecl.userName
-              | _ => pure subgoal.mvarId
-            else
-              pure subgoal.mvarId
+            let g ← match subgoal.fields with
+            | #[.fvar fvarId] => subgoal.mvarId.rename fvarId ldecl.userName
+            | _ => pure subgoal.mvarId
             if recursive then
               acc ← go g acc
             else

--- a/Mathlib/Tactic/CasesM.lean
+++ b/Mathlib/Tactic/CasesM.lean
@@ -89,6 +89,7 @@ def matchPatterns (pats : Array AbstractMVarsResult) (e : Expr) : MetaM Bool := 
   if `type` matches one of the given patterns.
 * `casesm* p` is a more efficient and compact version of `· repeat casesm p`.
   It is more efficient because the pattern is compiled once.
+* `casesm! p` only applies `cases` if the number of resulting subgoals is <= 1.
 
 Example: The following tactic destructs all conjunctions and disjunctions in the current context.
 ```

--- a/MathlibTest/casesm.lean
+++ b/MathlibTest/casesm.lean
@@ -81,6 +81,36 @@ example : True ∧ True ∧ True := by
   · guard_target = True; constructorm True
   · guard_target = True ∧ True; constructorm* True, _∧_
 
+example (n : Nat) : True := by
+  fail_if_success casesm! Nat  -- two constructors, so `casesm!` doesn't fire
+  trivial
+
+example (h : Array Nat) : True := by
+  casesm! Array _
+  trivial
+
+example (h : Array Nat) : True := by
+  casesm Array _
+  -- user facing name is preserved:
+  guard_hyp h : List Nat
+  trivial
+
+example (n : Nat) (h : n = 0) : True := by
+  casesm Nat
+  · trivial
+  · -- user facing name is preserved:
+    guard_hyp h : n + 1 = 0
+    trivial
+
+example (h : P ∧ Q) : True := by
+  casesm _ ∧ _
+  -- user facing name is not used here, because there are multiple new hypotheses.
+  fail_if_success guard_hyp h : P
+  rename_i p q
+  guard_hyp p : P
+  guard_hyp q : Q
+  trivial
+
 section AuxDecl
 variable {p q r : Prop}
 variable (h : p ∧ q ∨ p ∧ r)


### PR DESCRIPTION
I would like to use `casesm` as a part of tactics like `array_to_list`, which will translate goals about `Array` to goals about `List`. For this to work well, I need `casesm` to preserve user-facing names when it makes sense to do so.

Also adds `casesm!` (analogous to `cases_type!`) which only performs case splits producing a single branch.