### PR TITLE
[Merged by Bors] - feat: replace statement that specific functions are C^ω by the fact that they are C^n for all n

### DIFF
--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -1002,14 +1002,14 @@ Warning: if you think you need this lemma, it is likely that you can simplify yo
 reformulating the lemma that you're applying next using the tips in
 Note [continuity lemma statement]
 -/
-theorem contDiff_prodAssoc : ContDiff 𝕜 ω <| Equiv.prodAssoc E F G :=
+theorem contDiff_prodAssoc {n : WithTop ℕ∞} : ContDiff 𝕜 n <| Equiv.prodAssoc E F G :=
   (LinearIsometryEquiv.prodAssoc 𝕜 E F G).contDiff
 
 /-- The natural equivalence `E × (F × G) ≃ (E × F) × G` is smooth.
 
 Warning: see remarks attached to `contDiff_prodAssoc`
 -/
-theorem contDiff_prodAssoc_symm : ContDiff 𝕜 ω <| (Equiv.prodAssoc E F G).symm :=
+theorem contDiff_prodAssoc_symm {n : WithTop ℕ∞} : ContDiff 𝕜 n <| (Equiv.prodAssoc E F G).symm :=
   (LinearIsometryEquiv.prodAssoc 𝕜 E F G).symm.contDiff
 
 /-! ### Bundled derivatives are smooth -/

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Manifold.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Manifold.lean
@@ -26,7 +26,8 @@ instance : IsManifold 𝓘(ℂ) ω ℍ :=
   UpperHalfPlane.isOpenEmbedding_coe.isManifold_singleton
 
 /-- The inclusion map `ℍ → ℂ` is an analytic map of manifolds. -/
-theorem contMDiff_coe : ContMDiff 𝓘(ℂ) 𝓘(ℂ) ω ((↑) : ℍ → ℂ) := fun _ => contMDiffAt_extChartAt
+theorem contMDiff_coe {n : WithTop ℕ∞} : ContMDiff 𝓘(ℂ) 𝓘(ℂ) n ((↑) : ℍ → ℂ) :=
+  fun _ => contMDiffAt_extChartAt
 
 @[deprecated (since := "2024-11-20")] alias smooth_coe := contMDiff_coe
 
@@ -34,8 +35,8 @@ theorem contMDiff_coe : ContMDiff 𝓘(ℂ) 𝓘(ℂ) ω ((↑) : ℍ → ℂ) :
 theorem mdifferentiable_coe : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) ((↑) : ℍ → ℂ) :=
   contMDiff_coe.mdifferentiable le_top
 
-lemma contMDiffAt_ofComplex {z : ℂ} (hz : 0 < z.im) :
-    ContMDiffAt 𝓘(ℂ) 𝓘(ℂ) ω ofComplex z := by
+lemma contMDiffAt_ofComplex {n : WithTop ℕ∞} {z : ℂ} (hz : 0 < z.im) :
+    ContMDiffAt 𝓘(ℂ) 𝓘(ℂ) n ofComplex z := by
   rw [contMDiffAt_iff]
   constructor
   · -- continuity at z

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -94,8 +94,8 @@ theorem stereoToFun_apply (x : E) :
     stereoToFun v x = (2 / ((1 : ℝ) - innerSL ℝ v x)) • orthogonalProjection (ℝ ∙ v)ᗮ x :=
   rfl
 
-theorem contDiffOn_stereoToFun :
-    ContDiffOn ℝ ω (stereoToFun v) {x : E | innerSL _ v x ≠ (1 : ℝ)} := by
+theorem contDiffOn_stereoToFun {n : WithTop ℕ∞} :
+    ContDiffOn ℝ n (stereoToFun v) {x : E | innerSL _ v x ≠ (1 : ℝ)} := by
   refine ContDiffOn.smul ?_ (orthogonalProjection (ℝ ∙ v)ᗮ).contDiff.contDiffOn
   refine contDiff_const.contDiffOn.div ?_ ?_
   · exact (contDiff_const.sub (innerSL ℝ v).contDiff).contDiffOn
@@ -104,7 +104,7 @@ theorem contDiffOn_stereoToFun :
 
 theorem continuousOn_stereoToFun :
     ContinuousOn (stereoToFun v) {x : E | innerSL _ v x ≠ (1 : ℝ)} :=
-  contDiffOn_stereoToFun.continuousOn
+  (contDiffOn_stereoToFun (n := 0)).continuousOn
 
 variable (v)
 
@@ -389,7 +389,7 @@ instance EuclideanSpace.instIsManifoldSphere
         (-- Removed type ascription, and this helped for some reason with timeout issues?
             OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ)
             n (ne_zero_of_mem_unit_sphere v')).repr
-      have H₁ := U'.contDiff.comp_contDiffOn contDiffOn_stereoToFun
+      have H₁ := U'.contDiff.comp_contDiffOn (contDiffOn_stereoToFun (n := ω))
       -- Porting note: need to help with implicit variables again
       have H₂ := (contDiff_stereoInvFunAux (m := ω) (v := v.val)|>.comp
         (ℝ ∙ (v : E))ᗮ.subtypeL.contDiff).comp U.symm.contDiff

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -159,7 +159,7 @@ theorem hasFDerivAt_stereoInvFunAux_comp_coe (v : E) :
     hasFDerivAt_stereoInvFunAux v
   refine this.comp (0 : (ℝ ∙ v)ᗮ) (by apply ContinuousLinearMap.hasFDerivAt)
 
-theorem contDiff_stereoInvFunAux : ContDiff ℝ ω (stereoInvFunAux v) := by
+theorem contDiff_stereoInvFunAux {m : WithTop ℕ∞} : ContDiff ℝ m (stereoInvFunAux v) := by
   have h₀ : ContDiff ℝ ω fun w : E => ‖w‖ ^ 2 := contDiff_norm_sq ℝ
   have h₁ : ContDiff ℝ ω fun w : E => (‖w‖ ^ 2 + 4)⁻¹ := by
     refine (h₀.add contDiff_const).inv ?_
@@ -168,7 +168,7 @@ theorem contDiff_stereoInvFunAux : ContDiff ℝ ω (stereoInvFunAux v) := by
   have h₂ : ContDiff ℝ ω fun w => (4 : ℝ) • w + (‖w‖ ^ 2 - 4) • v := by
     refine (contDiff_const.smul contDiff_id).add ?_
     exact (h₀.sub contDiff_const).smul contDiff_const
-  exact h₁.smul h₂
+  exact (h₁.smul h₂).of_le le_top
 
 /-- Stereographic projection, reverse direction.  This is a map from the orthogonal complement of a
 unit vector `v` in an inner product space `E` to the unit sphere in `E`. -/
@@ -195,7 +195,8 @@ theorem stereoInvFun_ne_north_pole (hv : ‖v‖ = 1) (w : (ℝ ∙ v)ᗮ) :
   · simpa using stereoInvFunAux_mem hv w.2
 
 theorem continuous_stereoInvFun (hv : ‖v‖ = 1) : Continuous (stereoInvFun hv) :=
-  continuous_induced_rng.2 (contDiff_stereoInvFunAux.continuous.comp continuous_subtype_val)
+  continuous_induced_rng.2
+    ((contDiff_stereoInvFunAux (m := 0)).continuous.comp continuous_subtype_val)
 
 open scoped InnerProductSpace in
 attribute [-simp] AddSubgroupClass.coe_norm Submodule.coe_norm in
@@ -390,7 +391,7 @@ instance EuclideanSpace.instIsManifoldSphere
             n (ne_zero_of_mem_unit_sphere v')).repr
       have H₁ := U'.contDiff.comp_contDiffOn contDiffOn_stereoToFun
       -- Porting note: need to help with implicit variables again
-      have H₂ := (contDiff_stereoInvFunAux (v := v.val)|>.comp
+      have H₂ := (contDiff_stereoInvFunAux (m := ω) (v := v.val)|>.comp
         (ℝ ∙ (v : E))ᗮ.subtypeL.contDiff).comp U.symm.contDiff
       convert H₁.comp_inter (H₂.contDiffOn : ContDiffOn ℝ ω _ Set.univ) using 1
       -- -- squeezed from `ext, simp [sphere_ext_iff, stereographic'_symm_apply, real_inner_comm]`
@@ -408,8 +409,8 @@ instance (n : ℕ) : IsManifold (𝓡 n) ω (sphere (0 :  EuclideanSpace ℝ (Fi
   EuclideanSpace.instIsManifoldSphere
 
 /-- The inclusion map (i.e., `coe`) from the sphere in `E` to `E` is analytic. -/
-theorem contMDiff_coe_sphere {n : ℕ} [Fact (finrank ℝ E = n + 1)] :
-    ContMDiff (𝓡 n) 𝓘(ℝ, E) ω ((↑) : sphere (0 : E) 1 → E) := by
+theorem contMDiff_coe_sphere {m : WithTop ℕ∞} {n : ℕ} [Fact (finrank ℝ E = n + 1)] :
+    ContMDiff (𝓡 n) 𝓘(ℝ, E) m ((↑) : sphere (0 : E) 1 → E) := by
   -- Porting note: trouble with filling these implicit variables in the instance
   have := EuclideanSpace.instIsManifoldSphere (E := E) (n := n)
   rw [contMDiff_iff]
@@ -454,18 +455,18 @@ theorem ContMDiff.codRestrict_sphere {n : ℕ} [Fact (finrank ℝ E = n + 1)] {f
   simp [not_iff_not, Subtype.ext_iff, hfxv, real_inner_comm]
 
 /-- The antipodal map is analytic. -/
-theorem contMDiff_neg_sphere {n : ℕ} [Fact (finrank ℝ E = n + 1)] :
-    ContMDiff (𝓡 n) (𝓡 n) ω fun x : sphere (0 : E) 1 => -x := by
+theorem contMDiff_neg_sphere {m : WithTop ℕ∞} {n : ℕ} [Fact (finrank ℝ E = n + 1)] :
+    ContMDiff (𝓡 n) (𝓡 n) m fun x : sphere (0 : E) 1 => -x := by
   -- this doesn't elaborate well in term mode
   apply ContMDiff.codRestrict_sphere
   apply contDiff_neg.contMDiff.comp _
   exact contMDiff_coe_sphere
 
 private lemma stereographic'_neg {n : ℕ} [Fact (finrank ℝ E = n + 1)] (v : sphere (0 : E) 1) :
-  stereographic' n (-v) v = 0 := by
-    dsimp [stereographic']
-    simp only [EmbeddingLike.map_eq_zero_iff]
-    apply stereographic_neg_apply
+    stereographic' n (-v) v = 0 := by
+  dsimp [stereographic']
+  simp only [EmbeddingLike.map_eq_zero_iff]
+  apply stereographic_neg_apply
 
 /-- Consider the differential of the inclusion of the sphere in `E` at the point `v` as a continuous
 linear map from `TangentSpace (𝓡 n) v` to `E`.  The range of this map is the orthogonal complement
@@ -571,7 +572,7 @@ instance : LieGroup (𝓡 1) ω Circle where
     exact Complex.conjCLE.contDiff.contMDiff.comp contMDiff_coe_sphere
 
 /-- The map `fun t ↦ exp (t * I)` from `ℝ` to the unit circle in `ℂ` is analytic. -/
-theorem contMDiff_circleExp : ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) ω Circle.exp :=
+theorem contMDiff_circleExp {m : WithTop ℕ∞} : ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) m Circle.exp :=
   (contDiff_exp.comp (contDiff_id.smul contDiff_const)).contMDiff.codRestrict_sphere _
 
 @[deprecated (since := "2024-07-25")] alias contMDiff_expMapCircle := contMDiff_circleExp

--- a/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
@@ -265,7 +265,7 @@ variable [FiberBundle F E] [VectorBundle 𝕜 F E]
 variable (n IB) in
 /-- When `B` is a manifold with respect to a model `IB` and `E` is a
 topological vector bundle over `B` with fibers isomorphic to `F`,
-then `ContMDiffVectorBundle F E IB` registers that the bundle is `C^n`, in the sense of having
+then `ContMDiffVectorBundle n F E IB` registers that the bundle is `C^n`, in the sense of having
 `C^n` transition functions. This is a mixin, not carrying any new data. -/
 class ContMDiffVectorBundle : Prop where
   protected contMDiffOn_coordChangeL :


### PR DESCRIPTION
This is equivalent mathematically, but in applications the latter form is often more convenient. For instance, when proving that the composition is C^n, it's better to have right away the fact that the function is C^n.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
