### PR TITLE
[Merged by Bors] - refactor: split `RingTheory/{Prime,Maximal}Spectrum` into `RingTheory/Spectrum/{Prime,Maximal}/{Defs,Basic}`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4573,7 +4573,6 @@ import Mathlib.RingTheory.Localization.NormTrace
 import Mathlib.RingTheory.Localization.NumDen
 import Mathlib.RingTheory.Localization.Submodule
 import Mathlib.RingTheory.MatrixAlgebra
-import Mathlib.RingTheory.MaximalSpectrum
 import Mathlib.RingTheory.Multiplicity
 import Mathlib.RingTheory.MvPolynomial
 import Mathlib.RingTheory.MvPolynomial.Basic
@@ -4664,7 +4663,6 @@ import Mathlib.RingTheory.PowerSeries.Trunc
 import Mathlib.RingTheory.PowerSeries.WellKnown
 import Mathlib.RingTheory.Presentation
 import Mathlib.RingTheory.Prime
-import Mathlib.RingTheory.PrimeSpectrum
 import Mathlib.RingTheory.PrincipalIdealDomain
 import Mathlib.RingTheory.PrincipalIdealDomainOfPrime
 import Mathlib.RingTheory.QuotSMulTop
@@ -4701,6 +4699,10 @@ import Mathlib.RingTheory.Smooth.Kaehler
 import Mathlib.RingTheory.Smooth.Local
 import Mathlib.RingTheory.Smooth.Pi
 import Mathlib.RingTheory.Smooth.StandardSmooth
+import Mathlib.RingTheory.Spectrum.Maximal.Basic
+import Mathlib.RingTheory.Spectrum.Maximal.Defs
+import Mathlib.RingTheory.Spectrum.Prime.Basic
+import Mathlib.RingTheory.Spectrum.Prime.Defs
 import Mathlib.RingTheory.Support
 import Mathlib.RingTheory.SurjectiveOnStalks
 import Mathlib.RingTheory.TensorProduct.Basic

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -10,7 +10,7 @@ import Mathlib.RingTheory.KrullDimension.Basic
 import Mathlib.RingTheory.LocalRing.ResidueField.Defs
 import Mathlib.RingTheory.LocalRing.RingHom.Basic
 import Mathlib.RingTheory.Localization.Away.Basic
-import Mathlib.RingTheory.MaximalSpectrum
+import Mathlib.RingTheory.Spectrum.Maximal.Basic
 import Mathlib.Tactic.StacksAttribute
 import Mathlib.Topology.KrullDimension
 import Mathlib.Topology.Sober

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Maximal.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Maximal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Kurniadi Angdinata
 -/
 import Mathlib.AlgebraicGeometry.PrimeSpectrum.Basic
-import Mathlib.RingTheory.MaximalSpectrum
+import Mathlib.RingTheory.Spectrum.Maximal.Basic
 
 /-!
 # Maximal spectrum of a commutative ring

--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -5,7 +5,7 @@ Authors: Kenji Nakagawa, Anne Baanen, Filippo A. E. Nuccio
 -/
 import Mathlib.Algebra.Algebra.Subalgebra.Pointwise
 import Mathlib.Algebra.Polynomial.FieldDivision
-import Mathlib.RingTheory.MaximalSpectrum
+import Mathlib.RingTheory.Spectrum.Maximal.Basic
 import Mathlib.RingTheory.ChainOfDivisors
 import Mathlib.RingTheory.DedekindDomain.Basic
 import Mathlib.RingTheory.FractionalIdeal.Operations

--- a/Mathlib/RingTheory/KrullDimension/Basic.lean
+++ b/Mathlib/RingTheory/KrullDimension/Basic.lean
@@ -5,7 +5,7 @@ Authors: Fangming Li, Jujian Zhang
 -/
 import Mathlib.Algebra.MvPolynomial.CommRing
 import Mathlib.Algebra.Polynomial.Basic
-import Mathlib.RingTheory.PrimeSpectrum
+import Mathlib.RingTheory.Spectrum.Prime.Basic
 import Mathlib.Order.KrullDimension
 
 /-!

--- a/Mathlib/RingTheory/Nullstellensatz.lean
+++ b/Mathlib/RingTheory/Nullstellensatz.lean
@@ -6,7 +6,7 @@ Authors: Devon Tuma
 import Mathlib.RingTheory.Jacobson.Ring
 import Mathlib.FieldTheory.IsAlgClosed.Basic
 import Mathlib.RingTheory.MvPolynomial
-import Mathlib.RingTheory.PrimeSpectrum
+import Mathlib.RingTheory.Spectrum.Prime.Basic
 
 /-!
 # Nullstellensatz

--- a/Mathlib/RingTheory/Spectrum/Maximal/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Maximal/Basic.lean
@@ -4,18 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Kurniadi Angdinata
 -/
 import Mathlib.RingTheory.Localization.AsSubring
-import Mathlib.RingTheory.PrimeSpectrum
+import Mathlib.RingTheory.Spectrum.Maximal.Defs
+import Mathlib.RingTheory.Spectrum.Prime.Basic
 
 /-!
-# Maximal spectrum of a commutative ring
+# Maximal spectrum of a commutative (semi)ring
 
-The maximal spectrum of a commutative ring is the type of all maximal ideals.
-It is naturally a subset of the prime spectrum endowed with the subspace topology.
-
-## Main definitions
-
-* `MaximalSpectrum R`: The maximal spectrum of a commutative ring `R`,
-  i.e., the set of all maximal ideals of `R`.
+Basic properties the maximal spectrum of a ring.
 
 ## Implementation notes
 
@@ -23,24 +18,15 @@ The Zariski topology on the maximal spectrum is defined as the subspace topology
 natural inclusion into the prime spectrum to avoid API duplication for zero loci.
 -/
 
-
 noncomputable section
 
 open scoped Classical
 
 variable (R S P : Type*) [CommSemiring R] [CommSemiring S] [CommSemiring P]
 
-/-- The maximal spectrum of a commutative ring `R` is the type of all maximal ideals of `R`. -/
-@[ext]
-structure MaximalSpectrum where
-  asIdeal : Ideal R
-  IsMaximal : asIdeal.IsMaximal
-
-attribute [instance] MaximalSpectrum.IsMaximal
+namespace MaximalSpectrum
 
 variable {R}
-
-namespace MaximalSpectrum
 
 instance [Nontrivial R] : Nonempty <| MaximalSpectrum R :=
   let ⟨I, hI⟩ := Ideal.exists_maximal R
@@ -93,8 +79,6 @@ theorem iInf_localization_eq_bot : ⨅ v : PrimeSpectrum R,
 end PrimeSpectrum
 
 namespace MaximalSpectrum
-
-variable (R)
 
 /-- The product of localizations at all maximal ideals of a commutative semiring. -/
 abbrev PiLocalization : Type _ := Π I : MaximalSpectrum R, Localization.AtPrime I.1
@@ -187,8 +171,6 @@ theorem finite_of_toPiLocalization_surjective
 end MaximalSpectrum
 
 namespace PrimeSpectrum
-
-variable (R)
 
 /-- The product of localizations at all prime ideals of a commutative semiring. -/
 abbrev PiLocalization : Type _ := Π p : PrimeSpectrum R, Localization p.asIdeal.primeCompl

--- a/Mathlib/RingTheory/Spectrum/Maximal/Defs.lean
+++ b/Mathlib/RingTheory/Spectrum/Maximal/Defs.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2022 David Kurniadi Angdinata. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David Kurniadi Angdinata
+-/
+import Mathlib.RingTheory.Ideal.Maximal
+
+/-!
+# Maximal spectrum of a commutative (semi)ring
+
+The maximal spectrum of a commutative (semi)ring is the type of all maximal ideals.
+It is naturally a subset of the prime spectrum endowed with the subspace topology.
+
+## Main definitions
+
+* `MaximalSpectrum R`: The maximal spectrum of a commutative (semi)ring `R`,
+  i.e., the set of all maximal ideals of `R`.
+-/
+
+/-- The maximal spectrum of a commutative (semi)ring `R` is the type of all
+maximal ideals of `R`. -/
+@[ext]
+structure MaximalSpectrum (R : Type*) [CommSemiring R] where
+  asIdeal : Ideal R
+  IsMaximal : asIdeal.IsMaximal
+
+attribute [instance] MaximalSpectrum.IsMaximal

--- a/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
@@ -8,11 +8,10 @@ import Mathlib.RingTheory.Ideal.Prod
 import Mathlib.RingTheory.Localization.Ideal
 import Mathlib.RingTheory.Nilpotent.Lemmas
 import Mathlib.RingTheory.Noetherian.Basic
+import Mathlib.RingTheory.Spectrum.Prime.Defs
 
 /-!
-# Prime spectrum of a commutative (semi)ring as a type
-
-The prime spectrum of a commutative (semi)ring is the type of all prime ideals.
+# Prime spectrum of a commutative (semi)ring
 
 For the Zariski topology, see `AlgebraicGeometry.PrimeSpectrum.Basic`.
 
@@ -21,8 +20,6 @@ which is constructed in `AlgebraicGeometry.StructureSheaf`.)
 
 ## Main definitions
 
-* `PrimeSpectrum R`: The prime spectrum of a commutative (semi)ring `R`,
-  i.e., the set of all prime ideals of `R`.
 * `zeroLocus s`: The zero locus of a subset `s` of `R`
   is the subset of `PrimeSpectrum R` consisting of all prime ideals that contain `s`.
 * `vanishingIdeal t`: The vanishing ideal of a subset `t` of `PrimeSpectrum R`
@@ -51,20 +48,6 @@ open scoped Classical Pointwise
 universe u v
 
 variable (R : Type u) (S : Type v)
-
-/-- The prime spectrum of a commutative (semi)ring `R` is the type of all prime ideals of `R`.
-
-It is naturally endowed with a topology (the Zariski topology),
-and a sheaf of commutative rings (see `AlgebraicGeometry.StructureSheaf`).
-It is a fundamental building block in algebraic geometry. -/
-@[ext]
-structure PrimeSpectrum [CommSemiring R] where
-  asIdeal : Ideal R
-  isPrime : asIdeal.IsPrime
-
-@[deprecated (since := "2024-06-22")] alias PrimeSpectrum.IsPrime := PrimeSpectrum.isPrime
-
-attribute [instance] PrimeSpectrum.isPrime
 
 namespace PrimeSpectrum
 

--- a/Mathlib/RingTheory/Spectrum/Prime/Defs.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Defs.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2020 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin, Filippo A. E. Nuccio, Andrew Yang
+-/
+import Mathlib.RingTheory.Ideal.Prime
+
+/-!
+# Prime spectrum of a commutative (semi)ring as a type
+
+The prime spectrum of a commutative (semi)ring is the type of all prime ideals.
+
+For the Zariski topology, see `AlgebraicGeometry.PrimeSpectrum.Basic`.
+
+(It is also naturally endowed with a sheaf of rings,
+which is constructed in `AlgebraicGeometry.StructureSheaf`.)
+
+## Main definitions
+
+* `PrimeSpectrum R`: The prime spectrum of a commutative (semi)ring `R`,
+  i.e., the set of all prime ideals of `R`.
+-/
+
+/-- The prime spectrum of a commutative (semi)ring `R` is the type of all prime ideals of `R`.
+
+It is naturally endowed with a topology (the Zariski topology),
+and a sheaf of commutative rings (see `AlgebraicGeometry.StructureSheaf`).
+It is a fundamental building block in algebraic geometry. -/
+@[ext]
+structure PrimeSpectrum (R : Type*) [CommSemiring R] where
+  asIdeal : Ideal R
+  isPrime : asIdeal.IsPrime
+
+@[deprecated (since := "2024-06-22")] alias PrimeSpectrum.IsPrime := PrimeSpectrum.isPrime
+
+attribute [instance] PrimeSpectrum.isPrime

--- a/Mathlib/RingTheory/Support.lean
+++ b/Mathlib/RingTheory/Support.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.RingTheory.PrimeSpectrum
+import Mathlib.RingTheory.Spectrum.Prime.Basic
 import Mathlib.RingTheory.Localization.AtPrime
 import Mathlib.Algebra.Exact
 import Mathlib.Algebra.Module.LocalizedModule.Basic

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -7,7 +7,7 @@ import Mathlib.RingTheory.Valuation.ValuationRing
 import Mathlib.RingTheory.Localization.AsSubring
 import Mathlib.Algebra.Ring.Subring.Pointwise
 import Mathlib.Algebra.Ring.Action.Field
-import Mathlib.RingTheory.PrimeSpectrum
+import Mathlib.RingTheory.Spectrum.Prime.Basic
 import Mathlib.RingTheory.LocalRing.ResidueField.Basic
 
 /-!


### PR DESCRIPTION
Split off definitions of maximal and prime spectrum of a ring to be able to use it in other modules without pulling unnecessary imports.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
