### PR TITLE
[Merged by Bors] - doc(Order/WellFounded): minor docstring improvements

### DIFF
--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -11,7 +11,7 @@ import Mathlib.Order.Bounds.Defs
 
 A relation is well-founded if it can be used for induction: for each `x`, `(∀ y, r y x → P y) → P x`
 implies `P x`. Well-founded relations can be used for induction and recursion, including
-construction of fixed points in the space of dependent functions `Π x : α , β x`.
+construction of fixed points in the space of dependent functions `Π x : α, β x`.
 
 The predicate `WellFounded` is defined in the core library. In this file we prove some extra lemmas
 and provide a few new definitions: `WellFounded.min`, `WellFounded.sup`, and `WellFounded.succ`,
@@ -55,7 +55,7 @@ theorem has_min {α} {r : α → α → Prop} (H : WellFounded r) (s : Set α) :
 
 If you're working with a nonempty linear order, consider defining a
 `ConditionallyCompleteLinearOrderBot` instance via
-`WellFounded.conditionallyCompleteLinearOrderWithBot` and using `Inf` instead. -/
+`WellFoundedLT.conditionallyCompleteLinearOrderBot` and using `Inf` instead. -/
 noncomputable def min {r : α → α → Prop} (H : WellFounded r) (s : Set α) (h : s.Nonempty) : α :=
   Classical.choose (H.has_min s h)
 
@@ -101,14 +101,14 @@ protected noncomputable def succ {r : α → α → Prop} (wf : WellFounded r) (
   if h : ∃ y, r x y then wf.min { y | r x y } h else x
 
 set_option linter.deprecated false in
-@[deprecated "No deprecation message was provided." (since := "2024-10-25")]
+@[deprecated "`WellFounded.succ` is deprecated" (since := "2024-10-25")]
 protected theorem lt_succ {r : α → α → Prop} (wf : WellFounded r) {x : α} (h : ∃ y, r x y) :
     r x (wf.succ x) := by
   rw [WellFounded.succ, dif_pos h]
   apply min_mem
 
 set_option linter.deprecated false in
-@[deprecated "No deprecation message was provided." (since := "2024-10-25")]
+@[deprecated "`WellFounded.succ` is deprecated" (since := "2024-10-25")]
 protected theorem lt_succ_iff {r : α → α → Prop} [wo : IsWellOrder α r] {x : α} (h : ∃ y, r x y)
     (y : α) : r y (wo.wf.succ x) ↔ r y x ∨ y = x := by
   constructor


### PR DESCRIPTION
We fix two typos and add two missing deprecation messages.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
