### PR TITLE
[Merged by Bors] - feat(BigOperators): ite_prod_one / ite_sum_zero

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -483,12 +483,12 @@ theorem prod_dite_irrel (p : Prop) [Decidable p] (s : Finset α) (f : p → α �
 
 @[to_additive]
 theorem ite_prod_one (p : Prop) [Decidable p] (s : Finset α) (f : α → β) :
-    (if p then (∏ x in s, f x) else 1) = ∏ x in s, if p then f x else 1 := by
+    (if p then (∏ x ∈ s, f x) else 1) = ∏ x ∈ s, if p then f x else 1 := by
   simp only [prod_ite_irrel, prod_const_one]
 
 @[to_additive]
 theorem ite_one_prod (p : Prop) [Decidable p] (s : Finset α) (f : α → β) :
-    (if p then 1 else (∏ x in s, f x)) = ∏ x in s, if p then 1 else f x := by
+    (if p then 1 else (∏ x ∈ s, f x)) = ∏ x ∈ s, if p then 1 else f x := by
   simp only [prod_ite_irrel, prod_const_one]
 
 @[to_additive]

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -482,13 +482,12 @@ theorem prod_dite_irrel (p : Prop) [Decidable p] (s : Finset α) (f : p → α �
   split_ifs with h <;> rfl
 
 @[to_additive]
-theorem ite_prod_one {R ι : Type*} [CommMonoid R] {p : Prop} [Decidable p] (s : Finset ι)
-    (f : ι → R) :
+theorem ite_prod_one (p : Prop) [Decidable p] (s : Finset α) (f : α → β) :
     (if p then (∏ x in s, f x) else 1) = ∏ x in s, if p then f x else 1 := by
   simp only [prod_ite_irrel, prod_const_one]
 
 @[to_additive]
-theorem ite_one_prod {R ι : Type*} [CommMonoid R] {p : Prop} [Decidable p] (s : Finset ι)
+theorem ite_one_prod (p : Prop) [Decidable p] (s : Finset α) (f : α → β) :
     (f : ι → R) :
     (if p then 1 else (∏ x in s, f x)) = ∏ x in s, if p then 1 else f x := by
   simp only [prod_ite_irrel, prod_const_one]

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -482,6 +482,18 @@ theorem prod_dite_irrel (p : Prop) [Decidable p] (s : Finset α) (f : p → α �
   split_ifs with h <;> rfl
 
 @[to_additive]
+theorem ite_prod_one {R ι : Type*} [CommMonoid R] {p : Prop} [Decidable p] (s : Finset ι)
+    (f : ι → R) :
+    (if p then (∏ x in s, f x) else 1) = ∏ x in s, if p then f x else 1 := by
+  simp only [prod_ite_irrel, prod_const_one]
+
+@[to_additive]
+theorem ite_one_prod {R ι : Type*} [CommMonoid R] {p : Prop} [Decidable p] (s : Finset ι)
+    (f : ι → R) :
+    (if p then 1 else (∏ x in s, f x)) = ∏ x in s, if p then 1 else f x := by
+  simp only [prod_ite_irrel, prod_const_one]
+
+@[to_additive]
 theorem nonempty_of_prod_ne_one (h : ∏ x ∈ s, f x ≠ 1) : s.Nonempty :=
   s.eq_empty_or_nonempty.elim (fun H => False.elim <| h <| H.symm ▸ prod_empty) id
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -488,7 +488,6 @@ theorem ite_prod_one (p : Prop) [Decidable p] (s : Finset α) (f : α → β) :
 
 @[to_additive]
 theorem ite_one_prod (p : Prop) [Decidable p] (s : Finset α) (f : α → β) :
-    (f : ι → R) :
     (if p then 1 else (∏ x in s, f x)) = ∏ x in s, if p then 1 else f x := by
   simp only [prod_ite_irrel, prod_const_one]
 


### PR DESCRIPTION
These lemmas were useful for manipulating nested sums while working on the Selberg sieve. They can be used to push a condition from the outer sum into an inner sum. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
