### PR TITLE
[Merged by Bors] - chore: survey of simp porting notes

### DIFF
--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -595,7 +595,7 @@ end OfLinearEquiv
 section OfRingEquiv
 
 /-- Promotes a linear `RingEquiv` to an `AlgEquiv`. -/
-@[simps apply symm_apply toEquiv] -- Porting note: don't want redundant `toEquiv_symm_apply` simps
+@[simps apply symm_apply toEquiv]
 def ofRingEquiv {f : A₁ ≃+* A₂} (hf : ∀ x, f (algebraMap R A₁ x) = algebraMap R A₂ x) :
     A₁ ≃ₐ[R] A₂ :=
   { f with
@@ -757,7 +757,7 @@ variable [Group G] [MulSemiringAction G A] [SMulCommClass G R A]
 
 This is a stronger version of `MulSemiringAction.toRingEquiv` and
 `DistribMulAction.toLinearEquiv`. -/
-@[simps! apply symm_apply toEquiv] -- Porting note: don't want redundant simps lemma `toEquiv_symm`
+@[simps! apply symm_apply toEquiv]
 def toAlgEquiv (g : G) : A ≃ₐ[R] A :=
   { MulSemiringAction.toRingEquiv _ _ g, MulSemiringAction.toAlgHom R A g with }
 

--- a/Mathlib/Algebra/Algebra/Hom.lean
+++ b/Mathlib/Algebra/Algebra/Hom.lean
@@ -127,8 +127,6 @@ def toAddMonoidHom' (f : A →ₐ[R] B) : A →+ B := (f : A →+* B)
 instance coeOutAddMonoidHom : CoeOut (A →ₐ[R] B) (A →+ B) :=
   ⟨AlgHom.toAddMonoidHom'⟩
 
--- Porting note: Lean 3: `@[simp, norm_cast] coe_mk`
---               Lean 4: `@[simp] coe_mk` & `@[norm_cast] coe_mks`
 @[simp]
 theorem coe_mk {f : A →+* B} (h) : ((⟨f, h⟩ : A →ₐ[R] B) : A → B) = f :=
   rfl

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -92,8 +92,7 @@ theorem one_eq_span_one_set : (1 : Submodule R A) = span R 1 :=
 
 @[simp]
 theorem one_le {P : Submodule R A} : (1 : Submodule R A) ≤ P ↔ (1 : A) ∈ P := by
-  -- Porting note: simpa no longer closes refl goals, so added `SetLike.mem_coe`
-  simp only [one_eq_span, span_le, Set.singleton_subset_iff, SetLike.mem_coe]
+  simp [one_eq_span]
 
 variable {M : Type*} [AddCommMonoid M] [Module R M] [Module A M] [IsScalarTower R A M]
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -468,8 +468,6 @@ def toSubalgebra (p : Submodule R A) (h_one : (1 : A) ∈ p)
 theorem mem_toSubalgebra {p : Submodule R A} {h_one h_mul} {x} :
     x ∈ p.toSubalgebra h_one h_mul ↔ x ∈ p := Iff.rfl
 
--- Porting note: changed statement to reflect new structures
--- @[simp] -- Porting note: as a result, it is no longer a great simp lemma
 theorem toSubalgebra_mk (s : Submodule R A) (h1 hmul) :
     s.toSubalgebra h1 hmul =
       Subalgebra.mk ⟨⟨⟨s, @hmul⟩, h1⟩, s.add_mem, s.zero_mem⟩

--- a/Mathlib/Algebra/Category/Grp/Preadditive.lean
+++ b/Mathlib/Algebra/Category/Grp/Preadditive.lean
@@ -23,16 +23,6 @@ instance (P Q : AddCommGrp) : AddCommGroup (P ⟶ Q) :=
 @[simp]
 lemma hom_add_apply {P Q : AddCommGrp} (f g : P ⟶ Q) (x : P) : (f + g) x = f x + g x := rfl
 
-section
-
--- Porting note: the simp attribute was locally deactivated here,
--- otherwise Lean would try to infer `Preadditive AddCommGrp`
--- in order to prove the axioms `add_comp` and `comp_add` in the
--- next instance declaration
-attribute [-simp] Preadditive.add_comp Preadditive.comp_add
-
 instance : Preadditive AddCommGrp where
-
-end
 
 end AddCommGrp

--- a/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
@@ -248,9 +248,6 @@ namespace Free
 
 section
 
--- Porting note: removed local reducible attribute for categoryFree, adjusted dsimp invocations
--- accordingly
-
 instance : Preadditive (Free R C) where
   homGroup _ _ := Finsupp.instAddCommGroup
   add_comp X Y Z f f' g := by

--- a/Mathlib/Algebra/Group/Subgroup/Finite.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Finite.lean
@@ -96,9 +96,8 @@ instance fintypeBot : Fintype (⊥ : Subgroup G) :=
     rintro ⟨x, ⟨hx⟩⟩
     exact Finset.mem_singleton_self _⟩
 
-@[to_additive] -- Porting note: removed `simp` because `simpNF` says it can prove it.
-theorem card_bot : Nat.card (⊥ : Subgroup G) = 1 :=
-  Nat.card_unique
+@[to_additive]
+theorem card_bot : Nat.card (⊥ : Subgroup G) = 1 := by simp
 
 @[to_additive]
 theorem card_top : Nat.card (⊤ : Subgroup G) = Nat.card G :=

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -98,9 +98,9 @@ section
 
 variable [Semiring k] [NonUnitalNonAssocSemiring R]
 
--- Porting note: `reducible` cannot be `local`, so we replace some definitions and theorems with
---               new ones which have new types.
-
+-- TODO: This definition is very leaky, and we later have frequent problems conflating the two
+-- versions of `single`. Perhaps someone wants to try making this a `def` rather than an `abbrev`?
+-- In Mathlib 3 this was locally reducible.
 abbrev single (a : G) (b : k) : MonoidAlgebra k G := Finsupp.single a b
 
 theorem single_zero (a : G) : (single a 0 : MonoidAlgebra k G) = 0 := Finsupp.single_zero a

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -807,9 +807,6 @@ protected noncomputable def opRingEquiv [Monoid G] :
       rw [MulOpposite.unop_mul (α := MonoidAlgebra k G), unop_op, unop_op, single_mul_single]
       simp }
 
--- @[simp] -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10618): simp can prove this.
--- More specifically, the LHS simplifies to `Finsupp.single`, which implies there's some
--- defeq abuse going on.
 theorem opRingEquiv_single [Monoid G] (r : k) (x : G) :
     MonoidAlgebra.opRingEquiv (op (single x r)) = single (op x) (op r) := by simp
 

--- a/Mathlib/Algebra/Order/Interval/Basic.lean
+++ b/Mathlib/Algebra/Order/Interval/Basic.lean
@@ -166,7 +166,7 @@ theorem bot_mul : ⊥ * t = ⊥ :=
 theorem mul_bot : s * ⊥ = ⊥ :=
   Option.map₂_none_right _ _
 
--- Porting note: simp can prove `add_bot`
+-- simp can already prove `add_bot`
 attribute [simp] mul_bot
 
 end Interval
@@ -247,7 +247,7 @@ theorem coe_pow_interval [OrderedCommMonoid α] (s : NonemptyInterval α) (n : �
     ↑(s ^ n) = (s : Interval α) ^ n :=
   map_pow (⟨⟨(↑), coe_one_interval⟩, coe_mul_interval⟩ : NonemptyInterval α →* Interval α) _ _
 
--- Porting note: simp can prove `coe_nsmul_interval`
+-- simp can already prove `coe_nsmul_interval`
 attribute [simp] coe_pow_interval
 
 end NonemptyInterval

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -240,7 +240,6 @@ theorem algHom_ext {f g : R[X] →ₐ[R] B} (hX : f X = g X) :
 theorem aeval_def (p : R[X]) : aeval x p = eval₂ (algebraMap R A) x p :=
   rfl
 
--- Porting note: removed `@[simp]` because `simp` can prove this
 theorem aeval_zero : aeval x (0 : R[X]) = 0 :=
   map_zero (aeval x)
 
@@ -256,19 +255,15 @@ theorem aeval_C (r : R) : aeval x (C r) = algebraMap R A r :=
 theorem aeval_monomial {n : ℕ} {r : R} : aeval x (monomial n r) = algebraMap _ _ r * x ^ n :=
   eval₂_monomial _ _
 
--- Porting note: removed `@[simp]` because `simp` can prove this
 theorem aeval_X_pow {n : ℕ} : aeval x ((X : R[X]) ^ n) = x ^ n :=
   eval₂_X_pow _ _
 
--- Porting note: removed `@[simp]` because `simp` can prove this
 theorem aeval_add : aeval x (p + q) = aeval x p + aeval x q :=
   map_add _ _ _
 
--- Porting note: removed `@[simp]` because `simp` can prove this
 theorem aeval_one : aeval x (1 : R[X]) = 1 :=
   map_one _
 
--- Porting note: removed `@[simp]` because `simp` can prove this
 theorem aeval_natCast (n : ℕ) : aeval x (n : R[X]) = n :=
   map_natCast _ _
 

--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -148,7 +148,8 @@ theorem coe_injective : Function.Injective (coe : R → ℍ[R,c₁,c₂]) := fun
 theorem coe_inj {x y : R} : (x : ℍ[R,c₁,c₂]) = y ↔ x = y :=
   coe_injective.eq_iff
 
--- Porting note: removed `simps`, added simp lemmas manually. Should adjust `simps` to name properly
+-- Porting note: removed `simps`, added simp lemmas manually.
+-- Should adjust `simps` to name properly, i.e. as `zero_re` rather than `instZero_zero_re`.
 instance : Zero ℍ[R,c₁,c₂] := ⟨⟨0, 0, 0, 0⟩⟩
 
 @[simp] theorem zero_re : (0 : ℍ[R,c₁,c₂]).re = 0 := rfl
@@ -1349,7 +1350,6 @@ variable (R : Type*) [One R] [Neg R]
 theorem mk_quaternion : #(ℍ[R]) = #R ^ 4 :=
   mk_quaternionAlgebra _ _
 
---@[simp] Porting note: LHS can be simplified to `#R^4`
 theorem mk_quaternion_of_infinite [Infinite R] : #(ℍ[R]) = #R :=
   mk_quaternionAlgebra_of_infinite _ _
 
@@ -1357,7 +1357,6 @@ theorem mk_quaternion_of_infinite [Infinite R] : #(ℍ[R]) = #R :=
 theorem mk_univ_quaternion : #(Set.univ : Set ℍ[R]) = #R ^ 4 :=
   mk_univ_quaternionAlgebra _ _
 
---@[simp] Porting note: LHS can be simplified to `#R^4`
 theorem mk_univ_quaternion_of_infinite [Infinite R] : #(Set.univ : Set ℍ[R]) = #R :=
   mk_univ_quaternionAlgebra_of_infinite _ _
 

--- a/Mathlib/Algebra/Star/Subalgebra.lean
+++ b/Mathlib/Algebra/Star/Subalgebra.lean
@@ -328,9 +328,8 @@ instance involutiveStar : InvolutiveStar (Subalgebra R A) where
 theorem mem_star_iff (S : Subalgebra R A) (x : A) : x ∈ star S ↔ star x ∈ S :=
   Iff.rfl
 
--- Porting note: removed `@[simp]` tag because `simp` can prove this
 theorem star_mem_star_iff (S : Subalgebra R A) (x : A) : star x ∈ star S ↔ x ∈ S := by
-  simp only [mem_star_iff, star_star]
+  simp
 
 @[simp]
 theorem coe_star (S : Subalgebra R A) : ((star S : Subalgebra R A) : Set A) = star (S : Set A) :=

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -216,7 +216,6 @@ theorem inner_neg_right (x y : E) : ⟪x, -y⟫ = -⟪x, y⟫ := by
 
 theorem inner_neg_neg (x y : E) : ⟪-x, -y⟫ = ⟪x, y⟫ := by simp
 
--- Porting note: removed `simp` because it can prove it using `inner_conj_symm`
 theorem inner_self_conj (x : E) : ⟪x, x⟫† = ⟪x, x⟫ := inner_conj_symm _ _
 
 theorem inner_sub_left (x y z : E) : ⟪x - y, z⟫ = ⟪x, z⟫ - ⟪y, z⟫ := by

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -728,13 +728,11 @@ end ProdLemmas
 
 noncomputable section CoprodLemmas
 
--- @[reassoc (attr := simp)]
-@[simp] -- Porting note: removing reassoc tag since result is not hygienic (two h's)
+@[simp]
 theorem coprod.desc_comp {V W X Y : C} [HasBinaryCoproduct X Y] (f : V ⟶ W) (g : X ⟶ V)
     (h : Y ⟶ V) : coprod.desc g h ≫ f = coprod.desc (g ≫ f) (h ≫ f) := by
   ext <;> simp
 
--- Porting note: hand generated reassoc here. Simp can prove it
 theorem coprod.desc_comp_assoc {C : Type u} [Category C] {V W X Y : C}
     [HasBinaryCoproduct X Y] (f : V ⟶ W) (g : X ⟶ V) (h : Y ⟶ V) {Z : C} (l : W ⟶ Z) :
     coprod.desc g h ≫ f ≫ l = coprod.desc (g ≫ f) (h ≫ f) ≫ l := by simp

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -728,14 +728,10 @@ end ProdLemmas
 
 noncomputable section CoprodLemmas
 
-@[simp]
+@[reassoc, simp]
 theorem coprod.desc_comp {V W X Y : C} [HasBinaryCoproduct X Y] (f : V ⟶ W) (g : X ⟶ V)
     (h : Y ⟶ V) : coprod.desc g h ≫ f = coprod.desc (g ≫ f) (h ≫ f) := by
   ext <;> simp
-
-theorem coprod.desc_comp_assoc {C : Type u} [Category C] {V W X Y : C}
-    [HasBinaryCoproduct X Y] (f : V ⟶ W) (g : X ⟶ V) (h : Y ⟶ V) {Z : C} (l : W ⟶ Z) :
-    coprod.desc g h ≫ f ≫ l = coprod.desc (g ≫ f) (h ≫ f) ≫ l := by simp
 
 theorem coprod.diag_comp {X Y : C} [HasBinaryCoproduct X X] (f : X ⟶ Y) :
     codiag X ≫ f = coprod.desc f f := by simp

--- a/Mathlib/CategoryTheory/Preadditive/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Basic.lean
@@ -65,12 +65,11 @@ attribute [inherit_doc Preadditive] Preadditive.homGroup Preadditive.add_comp Pr
 
 attribute [instance] Preadditive.homGroup
 
--- Porting note: simp can prove reassoc version
+-- simp can already prove reassoc version
 attribute [reassoc, simp] Preadditive.add_comp
 
 attribute [reassoc] Preadditive.comp_add
 
--- (the linter doesn't like `simp` on this lemma)
 attribute [simp] Preadditive.comp_add
 
 end CategoryTheory
@@ -124,22 +123,22 @@ def compHom : (P ⟶ Q) →+ (Q ⟶ R) →+ (P ⟶ R) :=
   AddMonoidHom.mk' (fun f => leftComp _ f) fun f₁ f₂ =>
     AddMonoidHom.ext fun g => (rightComp _ g).map_add f₁ f₂
 
--- Porting note: simp can prove the reassoc version
+-- simp can prove the reassoc version
 @[reassoc, simp]
 theorem sub_comp : (f - f') ≫ g = f ≫ g - f' ≫ g :=
   map_sub (rightComp P g) f f'
 
--- The redundant simp lemma linter says that simp can prove the reassoc version of this lemma.
+-- simp can prove the reassoc version
 @[reassoc, simp]
 theorem comp_sub : f ≫ (g - g') = f ≫ g - f ≫ g' :=
   map_sub (leftComp R f) g g'
 
--- Porting note: simp can prove the reassoc version
+-- simp can prove the reassoc version
 @[reassoc, simp]
 theorem neg_comp : (-f) ≫ g = -f ≫ g :=
   map_neg (rightComp P g) f
 
--- The redundant simp lemma linter says that simp can prove the reassoc version of this lemma.
+-- simp can prove the reassoc version
 @[reassoc, simp]
 theorem comp_neg : f ≫ (-g) = -f ≫ g :=
   map_neg (leftComp R f) g

--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -47,7 +47,6 @@ def exp' (z : ℂ) : CauSeq ℂ Complex.abs :=
   ⟨fun n => ∑ m ∈ range n, z ^ m / m.factorial, isCauSeq_exp z⟩
 
 /-- The complex exponential function, defined via its Taylor series -/
--- Porting note: removed `irreducible` attribute, so I can prove things
 @[pp_nodot]
 def exp (z : ℂ) : ℂ :=
   CauSeq.lim (exp' z)

--- a/Mathlib/Data/DFinsupp/BigOperators.lean
+++ b/Mathlib/Data/DFinsupp/BigOperators.lean
@@ -307,7 +307,7 @@ def liftAddHom [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] :
 -- This applies to roughly the remainder of the file.
 
 /-- The `DFinsupp` version of `Finsupp.liftAddHom_singleAddHom`,-/
-@[simp, nolint simpNF] -- Porting note: linter claims that simp can prove this, but it can not
+@[simp, nolint simpNF] -- simpNF correctly complains that the LHS simplifies already
 theorem liftAddHom_singleAddHom [∀ i, AddCommMonoid (β i)] :
     liftAddHom (β := β) (singleAddHom β) = AddMonoidHom.id (Π₀ i, β i) :=
   (liftAddHom (β := β)).toEquiv.apply_eq_iff_eq_symm_apply.2 rfl

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -65,18 +65,12 @@ theorem coe_inj {a b : ℕ} : (a : ℕ∞) = b ↔ a = b := WithTop.coe_inj
 instance : SuccAddOrder ℕ∞ where
   succ_eq_add_one x := by cases x <;> simp [SuccOrder.succ]
 
--- Porting note: `simp` and `norm_cast` can prove it
---@[simp, norm_cast]
 theorem coe_zero : ((0 : ℕ) : ℕ∞) = 0 :=
   rfl
 
--- Porting note: `simp` and `norm_cast` can prove it
---@[simp, norm_cast]
 theorem coe_one : ((1 : ℕ) : ℕ∞) = 1 :=
   rfl
 
--- Porting note: `simp` and `norm_cast` can prove it
---@[simp, norm_cast]
 theorem coe_add (m n : ℕ) : ↑(m + n) = (m + n : ℕ∞) :=
   rfl
 

--- a/Mathlib/Data/Finset/MulAntidiagonal.lean
+++ b/Mathlib/Data/Finset/MulAntidiagonal.lean
@@ -72,12 +72,10 @@ theorem mulAntidiagonal_mono_right (h : u ⊆ t) :
     mulAntidiagonal hs hu a ⊆ mulAntidiagonal hs ht a :=
   Set.Finite.toFinset_mono <| Set.mulAntidiagonal_mono_right h
 
--- Porting note: removed `(attr := simp)`. simp can prove this.
 @[to_additive]
 theorem swap_mem_mulAntidiagonal :
     x.swap ∈ Finset.mulAntidiagonal hs ht a ↔ x ∈ Finset.mulAntidiagonal ht hs a := by
-  simp only [mem_mulAntidiagonal, Prod.fst_swap, Prod.snd_swap, Set.swap_mem_mulAntidiagonal_aux,
-             Set.mem_mulAntidiagonal]
+  simp
 
 @[to_additive]
 theorem support_mulAntidiagonal_subset_mul : { a | (mulAntidiagonal hs ht a).Nonempty } ⊆ s * t :=

--- a/Mathlib/Data/Finset/Powerset.lean
+++ b/Mathlib/Data/Finset/Powerset.lean
@@ -39,13 +39,9 @@ theorem coe_powerset (s : Finset α) :
   ext
   simp
 
--- Porting note: remove @[simp], simp can prove it
-theorem empty_mem_powerset (s : Finset α) : ∅ ∈ powerset s :=
-  mem_powerset.2 (empty_subset _)
+theorem empty_mem_powerset (s : Finset α) : ∅ ∈ powerset s := by simp
 
--- Porting note: remove @[simp], simp can prove it
-theorem mem_powerset_self (s : Finset α) : s ∈ powerset s :=
-  mem_powerset.2 Subset.rfl
+theorem mem_powerset_self (s : Finset α) : s ∈ powerset s := by simp
 
 @[aesop safe apply (rule_sets := [finsetNonempty])]
 theorem powerset_nonempty (s : Finset α) : s.powerset.Nonempty :=

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1328,10 +1328,8 @@ theorem mapDomain_smul {_ : Monoid R} [AddCommMonoid M] [DistribMulAction R M] {
     (v : α →₀ M) : mapDomain f (b • v) = b • mapDomain f v :=
   mapDomain_mapRange _ _ _ _ (smul_add b)
 
--- Porting note: removed `simp` because `simpNF` can prove it.
 theorem smul_single' {_ : Semiring R} (c : R) (a : α) (b : R) :
-    c • Finsupp.single a b = Finsupp.single a (c * b) :=
-  smul_single _ _ _
+    c • Finsupp.single a b = Finsupp.single a (c * b) := by simp
 
 theorem smul_single_one [Semiring R] (a : α) (b : R) : b • single a (1 : R) = single a b := by
   rw [smul_single, smul_eq_mul, mul_one]

--- a/Mathlib/Data/Finsupp/Single.lean
+++ b/Mathlib/Data/Finsupp/Single.lean
@@ -403,9 +403,8 @@ theorem erase_of_not_mem_support {f : α →₀ M} {a} (haf : a ∉ f.support) :
   · rwa [hab, erase_same, eq_comm, ← not_mem_support_iff]
   · rw [erase_ne hab]
 
-@[simp, nolint simpNF] -- Porting note: simpNF linter claims simp can prove this, it can not
 theorem erase_zero (a : α) : erase a (0 : α →₀ M) = 0 := by
-  classical rw [← support_eq_empty, support_erase, support_zero, erase_empty]
+  simp
 
 theorem erase_eq_update_zero (f : α →₀ M) (a : α) : f.erase a = update f a 0 :=
   letI := Classical.decEq α

--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -72,9 +72,7 @@ def univ : Finset α :=
 theorem mem_univ (x : α) : x ∈ (univ : Finset α) :=
   Fintype.complete x
 
--- Porting note: removing @[simp], simp can prove it
-theorem mem_univ_val : ∀ x, x ∈ (univ : Finset α).1 :=
-  mem_univ
+theorem mem_univ_val : ∀ x, x ∈ (univ : Finset α).1 := by simp
 
 theorem eq_univ_iff_forall : s = univ ↔ ∀ x, x ∈ s := by simp [Finset.ext_iff]
 
@@ -733,9 +731,8 @@ theorem toFinset_setOf [Fintype α] (p : α → Prop) [DecidablePred p] [Fintype
   ext
   simp
 
---@[simp] Porting note: removing simp, simp can prove it
 theorem toFinset_ssubset_univ [Fintype α] {s : Set α} [Fintype s] :
-    s.toFinset ⊂ Finset.univ ↔ s ⊂ univ := by rw [← coe_ssubset, coe_toFinset, coe_univ]
+    s.toFinset ⊂ Finset.univ ↔ s ⊂ univ := by simp
 
 @[simp]
 theorem toFinset_image [DecidableEq β] (f : α → β) (s : Set α) [Fintype s] [Fintype (f '' s)] :
@@ -857,11 +854,9 @@ since that relies on a subsingleton elimination for `Unique`. -/
 instance Fintype.subtypeEq' (y : α) : Fintype { x // y = x } :=
   Fintype.subtype {y} (by simp [eq_comm])
 
--- Porting note: removing @[simp], simp can prove it
 theorem Fintype.univ_empty : @univ Empty _ = ∅ :=
   rfl
 
---@[simp] Porting note: removing simp, simp can prove it
 theorem Fintype.univ_pempty : @univ PEmpty _ = ∅ :=
   rfl
 
@@ -874,7 +869,6 @@ theorem Fintype.univ_unit : @univ Unit _ = {()} :=
 instance PUnit.fintype : Fintype PUnit :=
   Fintype.ofSubsingleton PUnit.unit
 
---@[simp] Porting note: removing simp, simp can prove it
 theorem Fintype.univ_punit : @univ PUnit _ = {PUnit.unit} :=
   rfl
 

--- a/Mathlib/Data/Int/Interval.lean
+++ b/Mathlib/Data/Int/Interval.lean
@@ -134,24 +134,20 @@ theorem Icc_eq_pair : Finset.Icc a (a + 1) = {a, a + 1} := by
   simp
   omega
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): removed `simp` attribute because `simpNF` says it can prove it
 theorem card_fintype_Icc : Fintype.card (Set.Icc a b) = (b + 1 - a).toNat := by
-  rw [← card_Icc, Fintype.card_ofFinset]
+  simp
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): removed `simp` attribute because `simpNF` says it can prove it
 theorem card_fintype_Ico : Fintype.card (Set.Ico a b) = (b - a).toNat := by
-  rw [← card_Ico, Fintype.card_ofFinset]
+  simp
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): removed `simp` attribute because `simpNF` says it can prove it
 theorem card_fintype_Ioc : Fintype.card (Set.Ioc a b) = (b - a).toNat := by
-  rw [← card_Ioc, Fintype.card_ofFinset]
+  simp
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): removed `simp` attribute because `simpNF` says it can prove it
 theorem card_fintype_Ioo : Fintype.card (Set.Ioo a b) = (b - a - 1).toNat := by
-  rw [← card_Ioo, Fintype.card_ofFinset]
+  simp
 
 theorem card_fintype_uIcc : Fintype.card (Set.uIcc a b) = (b - a).natAbs + 1 := by
-  rw [← card_uIcc, Fintype.card_ofFinset]
+  simp
 
 theorem card_fintype_Icc_of_le (h : a ≤ b + 1) : (Fintype.card (Set.Icc a b) : ℤ) = b + 1 - a := by
   rw [card_fintype_Icc, toNat_sub_of_le h]

--- a/Mathlib/Data/List/Rotate.lean
+++ b/Mathlib/Data/List/Rotate.lean
@@ -39,8 +39,7 @@ theorem rotate_nil (n : ℕ) : ([] : List α).rotate n = [] := by simp [rotate]
 @[simp]
 theorem rotate_zero (l : List α) : l.rotate 0 = l := by simp [rotate]
 
--- Porting note: removing simp, simp can prove it
-theorem rotate'_nil (n : ℕ) : ([] : List α).rotate' n = [] := by cases n <;> rfl
+theorem rotate'_nil (n : ℕ) : ([] : List α).rotate' n = [] := by simp
 
 @[simp]
 theorem rotate'_zero (l : List α) : l.rotate' 0 = l := by cases l <;> rfl
@@ -100,7 +99,7 @@ theorem rotate_eq_rotate' (l : List α) (n : ℕ) : l.rotate n = l.rotate' n :=
         rotate'_eq_drop_append_take (le_of_lt (Nat.mod_lt _ (Nat.pos_of_ne_zero h)))]
     simp [rotate]
 
-theorem rotate_cons_succ (l : List α) (a : α) (n : ℕ) :
+@[simp] theorem rotate_cons_succ (l : List α) (a : α) (n : ℕ) :
     (a :: l : List α).rotate (n + 1) = (l ++ [a]).rotate n := by
   rw [rotate_eq_rotate', rotate_eq_rotate', rotate'_cons_succ]
 
@@ -183,9 +182,6 @@ theorem zipWith_rotate_distrib {β γ : Type*} (f : α → β → γ) (l : List 
     take_zipWith, List.length_zipWith, h, min_self]
   rw [length_drop, length_drop, h]
 
-attribute [local simp] rotate_cons_succ
-
--- Porting note: removing @[simp], simp can prove it
 theorem zipWith_rotate_one {β : Type*} (f : α → α → β) (x y : α) (l : List α) :
     zipWith f (x :: y :: l) ((x :: y :: l).rotate 1) = f x y :: zipWith f (y :: l) (l ++ [x]) := by
   simp

--- a/Mathlib/Data/Multiset/FinsetOps.lean
+++ b/Mathlib/Data/Multiset/FinsetOps.lean
@@ -57,9 +57,7 @@ theorem mem_ndinsert {a b : α} {s : Multiset α} : a ∈ ndinsert b s ↔ a = b
 theorem le_ndinsert_self (a : α) (s : Multiset α) : s ≤ ndinsert a s :=
   Quot.inductionOn s fun _ => (sublist_insert _ _).subperm
 
--- Porting note: removing @[simp], simp can prove it
-theorem mem_ndinsert_self (a : α) (s : Multiset α) : a ∈ ndinsert a s :=
-  mem_ndinsert.2 (Or.inl rfl)
+theorem mem_ndinsert_self (a : α) (s : Multiset α) : a ∈ ndinsert a s := by simp
 
 theorem mem_ndinsert_of_mem {a b : α} {s : Multiset α} (h : a ∈ s) : a ∈ ndinsert b s :=
   mem_ndinsert.2 (Or.inr h)
@@ -130,7 +128,7 @@ def ndunion (s t : Multiset α) : Multiset α :=
 theorem coe_ndunion (l₁ l₂ : List α) : @ndunion α _ l₁ l₂ = (l₁ ∪ l₂ : List α) :=
   rfl
 
--- Porting note: removing @[simp], simp can prove it
+-- Porting note: removed @[simp], original porting note incorrectly claimed that simp can prove it
 theorem zero_ndunion (s : Multiset α) : ndunion 0 s = s :=
   Quot.inductionOn s fun _ => rfl
 

--- a/Mathlib/Data/Multiset/Pi.lean
+++ b/Mathlib/Data/Multiset/Pi.lean
@@ -57,7 +57,7 @@ theorem cons_swap {a a' : α} {b : δ a} {b' : δ a'} {m : Multiset α} {f : ∀
   on_goal 1 => rcases Decidable.eq_or_ne a'' a' with (rfl | h₂)
   all_goals simp [*, Pi.cons_same, Pi.cons_ne]
 
-@[simp, nolint simpNF] -- Porting note: false positive, this lemma can prove itself
+@[simp]
 theorem cons_eta {m : Multiset α} {a : α} (f : ∀ a' ∈ a ::ₘ m, δ a') :
     (cons m a (f _ (mem_cons_self _ _)) fun a' ha' => f a' (mem_cons_of_mem ha')) = f := by
   ext a' h'

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -102,7 +102,6 @@ lemma succ_injective : Injective Nat.succ := @succ.inj
 
 lemma succ_ne_succ : succ m ≠ succ n ↔ m ≠ n := succ_injective.ne_iff
 
--- Porting note: no longer a simp lemma, as simp can prove this
 lemma succ_succ_ne_one (n : ℕ) : n.succ.succ ≠ 1 := by simp
 
 lemma one_lt_succ_succ (n : ℕ) : 1 < n.succ.succ := succ_lt_succ <| succ_pos n

--- a/Mathlib/Data/PNat/Interval.lean
+++ b/Mathlib/Data/PNat/Interval.lean
@@ -71,7 +71,6 @@ theorem card_Ioo : #(Ioo a b) = b - a - 1 := by
 theorem card_uIcc : #(uIcc a b) = (b - a : ℤ).natAbs + 1 := by
   rw [← Nat.card_uIcc, ← map_subtype_embedding_uIcc, card_map]
 
-
 theorem card_fintype_Icc : Fintype.card (Set.Icc a b) = b + 1 - a := by
   rw [← card_Icc, Fintype.card_ofFinset]
 

--- a/Mathlib/Data/PNat/Interval.lean
+++ b/Mathlib/Data/PNat/Interval.lean
@@ -71,23 +71,19 @@ theorem card_Ioo : #(Ioo a b) = b - a - 1 := by
 theorem card_uIcc : #(uIcc a b) = (b - a : ℤ).natAbs + 1 := by
   rw [← Nat.card_uIcc, ← map_subtype_embedding_uIcc, card_map]
 
--- Porting note: `simpNF` says `simp` can prove this
+
 theorem card_fintype_Icc : Fintype.card (Set.Icc a b) = b + 1 - a := by
   rw [← card_Icc, Fintype.card_ofFinset]
 
--- Porting note: `simpNF` says `simp` can prove this
 theorem card_fintype_Ico : Fintype.card (Set.Ico a b) = b - a := by
   rw [← card_Ico, Fintype.card_ofFinset]
 
--- Porting note: `simpNF` says `simp` can prove this
 theorem card_fintype_Ioc : Fintype.card (Set.Ioc a b) = b - a := by
   rw [← card_Ioc, Fintype.card_ofFinset]
 
--- Porting note: `simpNF` says `simp` can prove this
 theorem card_fintype_Ioo : Fintype.card (Set.Ioo a b) = b - a - 1 := by
   rw [← card_Ioo, Fintype.card_ofFinset]
 
--- Porting note: `simpNF` says `simp` can prove this
 theorem card_fintype_uIcc : Fintype.card (Set.uIcc a b) = (b - a : ℤ).natAbs + 1 := by
   rw [← card_uIcc, Fintype.card_ofFinset]
 

--- a/Mathlib/Data/Seq/Seq.lean
+++ b/Mathlib/Data/Seq/Seq.lean
@@ -816,11 +816,11 @@ instance : LawfulFunctor Seq where
 theorem join_nil : join nil = (nil : Seq α) :=
   destruct_eq_nil rfl
 
---@[simp] -- Porting note: simp can prove: `join_cons` is more general
+-- Not a simp lemmas as `join_cons` is more general
 theorem join_cons_nil (a : α) (S) : join (cons (a, nil) S) = cons a (join S) :=
   destruct_eq_cons <| by simp [join]
 
---@[simp] -- Porting note: simp can prove: `join_cons` is more general
+-- Not a simp lemmas as `join_cons` is more general
 theorem join_cons_cons (a b : α) (s S) :
     join (cons (a, cons b s) S) = cons a (join (cons (b, s) S)) :=
   destruct_eq_cons <| by simp [join]

--- a/Mathlib/Geometry/Manifold/Algebra/LeftInvariantDerivation.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LeftInvariantDerivation.lean
@@ -90,20 +90,15 @@ theorem left_invariant' :
     𝒅ₕ (smoothLeftMul_one I g) (Derivation.evalAt (1 : G) ↑X) = Derivation.evalAt g ↑X :=
   left_invariant'' X g
 
--- Porting note: was `@[simp]` but `_root_.map_add` can prove it now
-protected theorem map_add : X (f + f') = X f + X f' := map_add X f f'
+protected theorem map_add : X (f + f') = X f + X f' := by simp
 
--- Porting note: was `@[simp]` but `_root_.map_zero` can prove it now
-protected theorem map_zero : X 0 = 0 := map_zero X
+protected theorem map_zero : X 0 = 0 := by simp
 
--- Porting note: was `@[simp]` but `_root_.map_neg` can prove it now
-protected theorem map_neg : X (-f) = -X f := map_neg X f
+protected theorem map_neg : X (-f) = -X f := by simp
 
--- Porting note: was `@[simp]` but `_root_.map_sub` can prove it now
-protected theorem map_sub : X (f - f') = X f - X f' := map_sub X f f'
+protected theorem map_sub : X (f - f') = X f - X f' := by simp
 
--- Porting note: was `@[simp]` but `_root_.map_smul` can prove it now
-protected theorem map_smul : X (r • f) = r • X f := map_smul X r f
+protected theorem map_smul : X (r • f) = r • X f := by simp
 
 @[simp]
 theorem leibniz : X (f * f') = f • X f' + f' • X f :=

--- a/Mathlib/GroupTheory/Congruence/Defs.lean
+++ b/Mathlib/GroupTheory/Congruence/Defs.lean
@@ -426,13 +426,11 @@ additive congruence relation in which they are contained."]
 theorem conGen_of_con (c : Con M) : conGen c = c :=
   le_antisymm (by rw [conGen_eq]; exact sInf_le fun _ _ => id) ConGen.Rel.of
 
--- Porting note: removing simp, simp can prove it
 /-- The map sending a binary relation to the smallest congruence relation in which it is
     contained is idempotent. -/
 @[to_additive addConGen_idem "The map sending a binary relation to the smallest additive
 congruence relation in which it is contained is idempotent."]
-theorem conGen_idem (r : M → M → Prop) : conGen (conGen r) = conGen r :=
-  conGen_of_con _
+theorem conGen_idem (r : M → M → Prop) : conGen (conGen r) = conGen r := by simp
 
 /-- The supremum of congruence relations `c, d` equals the smallest congruence relation containing
     the binary relation '`x` is related to `y` by `c` or `d`'. -/

--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -95,10 +95,9 @@ theorem Quotient.smul_coe [QuotientAction β H] (b : β) (a : α) :
 theorem Quotient.mk_smul_out [QuotientAction β H] (b : β) (q : α ⧸ H) :
     QuotientGroup.mk (b • q.out) = b • q := by rw [← Quotient.smul_mk, QuotientGroup.out_eq']
 
--- Porting note: removed simp attribute, simp can prove this
 @[to_additive]
-theorem Quotient.coe_smul_out [QuotientAction β H] (b : β) (q : α ⧸ H) : ↑(b • q.out) = b • q :=
-  Quotient.mk_smul_out H b q
+theorem Quotient.coe_smul_out [QuotientAction β H] (b : β) (q : α ⧸ H) : ↑(b • q.out) = b • q := by
+  simp
 
 theorem _root_.QuotientGroup.out_conj_pow_minimalPeriod_mem (a : α) (q : α ⧸ H) :
     q.out⁻¹ * a ^ Function.minimalPeriod (a • ·) q * q.out ∈ H := by
@@ -114,7 +113,6 @@ attribute [deprecated Quotient.mk_smul_out (since := "2024-10-19")] Quotient.mk_
 attribute [deprecated AddAction.Quotient.mk_vadd_out (since := "2024-10-19")]
 AddAction.Quotient.mk_vadd_out'
 
--- Porting note: removed simp attribute, simp can prove this
 @[to_additive]
 alias Quotient.coe_smul_out' := Quotient.coe_smul_out
 

--- a/Mathlib/LinearAlgebra/Dimension/Constructions.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Constructions.lean
@@ -153,10 +153,8 @@ theorem rank_finsupp' (ι : Type v) : Module.rank R (ι →₀ M) = #ι * Module
   simp [rank_finsupp]
 
 /-- The rank of `(ι →₀ R)` is `(#ι).lift`. -/
--- Porting note, this should not be `@[simp]`, as simp can prove it.
--- @[simp]
 theorem rank_finsupp_self (ι : Type w) : Module.rank R (ι →₀ R) = Cardinal.lift.{u} #ι := by
-  simp [rank_finsupp]
+  simp
 
 /-- If `R` and `ι` lie in the same universe, the rank of `(ι →₀ R)` is `# ι`. -/
 theorem rank_finsupp_self' {ι : Type u} : Module.rank R (ι →₀ R) = #ι := by simp

--- a/Mathlib/Logic/Denumerable.lean
+++ b/Mathlib/Logic/Denumerable.lean
@@ -148,7 +148,6 @@ end Sigma
 instance prod : Denumerable (α × β) :=
   ofEquiv _ (Equiv.sigmaEquivProd α β).symm
 
--- Porting note: removed @[simp] - simp can prove it
 theorem prod_ofNat_val (n : ℕ) :
     ofNat (α × β) n = (ofNat α (unpair n).1, ofNat β (unpair n).2) := by simp
 

--- a/Mathlib/Logic/Equiv/PartialEquiv.lean
+++ b/Mathlib/Logic/Equiv/PartialEquiv.lean
@@ -525,11 +525,9 @@ theorem refl_coe : (PartialEquiv.refl α : α → α) = id :=
 theorem refl_symm : (PartialEquiv.refl α).symm = PartialEquiv.refl α :=
   rfl
 
--- Porting note: removed `simp` because `simp` can prove this
 @[mfld_simps]
 theorem refl_restr_source (s : Set α) : ((PartialEquiv.refl α).restr s).source = s := by simp
 
--- Porting note: removed `simp` because `simp` can prove this
 @[mfld_simps]
 theorem refl_restr_target (s : Set α) : ((PartialEquiv.refl α).restr s).target = s := by
   change univ ∩ id ⁻¹' s = s

--- a/Mathlib/Order/BoundedOrder/Lattice.lean
+++ b/Mathlib/Order/BoundedOrder/Lattice.lean
@@ -34,11 +34,9 @@ section SemilatticeSupTop
 
 variable [SemilatticeSup α] [OrderTop α]
 
--- Porting note: Not simp because simp can prove it
 theorem top_sup_eq (a : α) : ⊤ ⊔ a = ⊤ :=
   sup_of_le_left le_top
 
--- Porting note: Not simp because simp can prove it
 theorem sup_top_eq (a : α) : a ⊔ ⊤ = ⊤ :=
   sup_of_le_right le_top
 
@@ -48,11 +46,9 @@ section SemilatticeSupBot
 
 variable [SemilatticeSup α] [OrderBot α] {a b : α}
 
--- Porting note: Not simp because simp can prove it
 theorem bot_sup_eq (a : α) : ⊥ ⊔ a = a :=
   sup_of_le_right bot_le
 
--- Porting note: Not simp because simp can prove it
 theorem sup_bot_eq (a : α) : a ⊔ ⊥ = a :=
   sup_of_le_left bot_le
 
@@ -65,10 +61,8 @@ section SemilatticeInfTop
 
 variable [SemilatticeInf α] [OrderTop α] {a b : α}
 
--- Porting note: Not simp because simp can prove it
 lemma top_inf_eq (a : α) : ⊤ ⊓ a = a := inf_of_le_right le_top
 
--- Porting note: Not simp because simp can prove it
 lemma inf_top_eq (a : α) : a ⊓ ⊤ = a := inf_of_le_left le_top
 
 @[simp]
@@ -81,10 +75,8 @@ section SemilatticeInfBot
 
 variable [SemilatticeInf α] [OrderBot α]
 
--- Porting note: Not simp because simp can prove it
 lemma bot_inf_eq (a : α) : ⊥ ⊓ a = ⊥ := inf_of_le_left bot_le
 
--- Porting note: Not simp because simp can prove it
 lemma inf_bot_eq (a : α) : a ⊓ ⊥ = ⊥ := inf_of_le_right bot_le
 
 end SemilatticeInfBot

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -153,10 +153,8 @@ def degreeLTEquiv (R) [Semiring R] (n : ℕ) : degreeLT R n ≃ₗ[R] Fin n → 
     · intro h
       exact (h (Finset.mem_univ _)).elim
 
--- Porting note: removed @[simp] as simp can prove this
 theorem degreeLTEquiv_eq_zero_iff_eq_zero {n : ℕ} {p : R[X]} (hp : p ∈ degreeLT R n) :
-    degreeLTEquiv _ _ ⟨p, hp⟩ = 0 ↔ p = 0 := by
-  rw [LinearEquiv.map_eq_zero_iff, Submodule.mk_eq_zero]
+    degreeLTEquiv _ _ ⟨p, hp⟩ = 0 ↔ p = 0 := by simp
 
 theorem eval_eq_sum_degreeLTEquiv {n : ℕ} {p : R[X]} (hp : p ∈ degreeLT R n) (x : R) :
     p.eval x = ∑ i, degreeLTEquiv _ _ ⟨p, hp⟩ i * x ^ (i : ℕ) := by
@@ -359,9 +357,8 @@ theorem coeff_restriction {p : R[X]} {n : ℕ} : ↑(coeff (restriction p) n) = 
     rfl
   · rfl
 
--- Porting note: removed @[simp] as simp can prove this
-theorem coeff_restriction' {p : R[X]} {n : ℕ} : (coeff (restriction p) n).1 = coeff p n :=
-  coeff_restriction
+theorem coeff_restriction' {p : R[X]} {n : ℕ} : (coeff (restriction p) n).1 = coeff p n := by
+  simp
 
 @[simp]
 theorem support_restriction (p : R[X]) : support (restriction p) = support p := by
@@ -429,9 +426,8 @@ theorem coeff_toSubring {n : ℕ} : ↑(coeff (toSubring p T hp) n) = coeff p n 
     rfl
   · rfl
 
--- Porting note: removed @[simp] as simp can prove this
-theorem coeff_toSubring' {n : ℕ} : (coeff (toSubring p T hp) n).1 = coeff p n :=
-  coeff_toSubring _ _ hp
+theorem coeff_toSubring' {n : ℕ} : (coeff (toSubring p T hp) n).1 = coeff p n := by
+  simp
 
 @[simp]
 theorem support_toSubring : support (toSubring p T hp) = support p := by

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -603,7 +603,6 @@ theorem lift_mul (a b : Cardinal.{u}) : lift.{v} (a * b) = lift.{v} a * lift.{v}
   inductionOn₂ a b fun _ _ =>
     mk_congr <| Equiv.ulift.trans (Equiv.prodCongr Equiv.ulift Equiv.ulift).symm
 
--- Porting note: Proof used to be simp, needed to remind simp that 1 + 1 = 2
 theorem lift_two : lift.{u, v} 2 = 2 := by simp [← one_add_one_eq_two]
 
 @[simp]

--- a/Mathlib/SetTheory/Game/Basic.lean
+++ b/Mathlib/SetTheory/Game/Basic.lean
@@ -912,8 +912,7 @@ def inv'Zero : inv' 0 ≡r 1 := by
   refine ⟨?_, ?_, fun i => ?_, IsEmpty.elim ?_⟩
   · apply Equiv.equivPUnit (InvTy _ _ _)
   · apply Equiv.equivPEmpty (InvTy _ _ _)
-  · -- Porting note: had to add `rfl`, because `simp` only uses the built-in `rfl`.
-    simp; rfl
+  · simp; rfl
   · dsimp
     infer_instance
 

--- a/Mathlib/SetTheory/Game/Basic.lean
+++ b/Mathlib/SetTheory/Game/Basic.lean
@@ -912,7 +912,10 @@ def inv'Zero : inv' 0 ≡r 1 := by
   refine ⟨?_, ?_, fun i => ?_, IsEmpty.elim ?_⟩
   · apply Equiv.equivPUnit (InvTy _ _ _)
   · apply Equiv.equivPEmpty (InvTy _ _ _)
-  · simp; rfl
+  · -- Porting note: we added `rfl` after the `simp`
+    -- (because `simp` now uses `rfl` only at reducible transparency)
+    -- Can we improve the simp set so it is not needed?
+    simp; rfl
   · dsimp
     infer_instance
 

--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -136,8 +136,6 @@ theorem birthday_add : ∀ x y : PGame.{u}, (x + y).birthday = x.birthday ♯ y.
     rw [birthday_def, nadd, lsub_sum, lsub_sum]
     simp only [mk_add_moveLeft_inl, mk_add_moveLeft_inr, mk_add_moveRight_inl, mk_add_moveRight_inr,
       moveLeft_mk, moveRight_mk]
-    -- Porting note: Originally `simp only [birthday_add]`, but this causes an error in
-    -- `termination_by`. Use a workaround.
     conv_lhs => left; left; right; intro a; rw [birthday_add (xL a) ⟨yl, yr, yL, yR⟩]
     conv_lhs => left; right; right; intro b; rw [birthday_add ⟨xl, xr, xL, xR⟩ (yL b)]
     conv_lhs => right; left; right; intro a; rw [birthday_add (xR a) ⟨yl, yr, yL, yR⟩]

--- a/Mathlib/SetTheory/Surreal/Dyadic.lean
+++ b/Mathlib/SetTheory/Surreal/Dyadic.lean
@@ -240,7 +240,6 @@ theorem dyadicMap_apply (m : ℤ) (p : Submonoid.powers (2 : ℤ)) :
       m * powHalf (Submonoid.log p) := by
   rw [← Localization.mk_eq_mk']; rfl
 
--- @[simp] -- Porting note: simp normal form is `dyadicMap_apply_pow'`
 theorem dyadicMap_apply_pow (m : ℤ) (n : ℕ) :
     dyadicMap (IsLocalization.mk' (Localization (Submonoid.powers 2)) m (Submonoid.pow 2 n)) =
       m • powHalf n := by

--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -67,7 +67,7 @@ theorem nat_lcm_helper (x y d m : ℕ) (hd : Nat.gcd x y = d)
     (d0 : Nat.beq d 0 = false)
     (dm : x * y = d * m) : Nat.lcm x y = m :=
   mul_right_injective₀ (Nat.ne_of_beq_eq_false d0) <| by
-    dsimp only -- Porting note: the `dsimp only` was not necessary in Lean3.
+    dsimp only
     rw [← dm, ← hd, Nat.gcd_mul_lcm]
 
 theorem int_gcd_helper {x y : ℤ} {x' y' d : ℕ}

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -269,7 +269,6 @@ theorem hasProd_prod {f : γ → β → α} {a : γ → α} {s : Finset γ} :
     (∀ i ∈ s, HasProd (f i) (a i)) → HasProd (fun b ↦ ∏ i ∈ s, f i b) (∏ i ∈ s, a i) := by
   classical
   exact Finset.induction_on s (by simp only [hasProd_one, prod_empty, forall_true_iff]) <| by
-    -- Porting note: with some help, `simp` used to be able to close the goal
     simp +contextual only [mem_insert, forall_eq_or_imp, not_false_iff,
       prod_insert, and_imp]
     exact fun x s _ IH hx h ↦ hx.mul (IH h)

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -799,13 +799,7 @@ linear equivalence `e` between `M` and `M₂ × f₁.ker` such that `(e x).2 = x
 def equivOfRightInverse (f₁ : M →L[R] M₂) (f₂ : M₂ →L[R] M) (h : Function.RightInverse f₂ f₁) :
     M ≃L[R] M₂ × ker f₁ :=
   equivOfInverse (f₁.prod (f₁.projKerOfRightInverse f₂ h)) (f₂.coprod (ker f₁).subtypeL)
-    (fun x => by simp) fun ⟨x, y⟩ => by
-      -- Porting note: `simp` timeouts.
-      rw [ContinuousLinearMap.coprod_apply,
-        Submodule.subtypeL_apply, _root_.map_add, ContinuousLinearMap.prod_apply, h x,
-        ContinuousLinearMap.projKerOfRightInverse_comp_inv,
-        ContinuousLinearMap.prod_apply, LinearMap.map_coe_ker,
-        ContinuousLinearMap.projKerOfRightInverse_apply_idem, Prod.mk_add_mk, add_zero, zero_add]
+    (fun x => by simp) fun ⟨x, y⟩ => by simp [h x]
 
 @[simp]
 theorem fst_equivOfRightInverse (f₁ : M →L[R] M₂) (f₂ : M₂ →L[R] M)

--- a/Mathlib/Topology/Category/TopCat/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Basic.lean
@@ -165,7 +165,6 @@ lemma isIso_of_bijective_of_isClosedMap {X Y : TopCat.{u}} (f : X ⟶ Y)
     (Equiv.ofBijective f hfbij) f.continuous hfcl
   inferInstanceAs <| IsIso (TopCat.isoOfHomeo e).hom
 
--- Porting note: simpNF requested partially simped version below
 theorem isOpenEmbedding_iff_comp_isIso {X Y Z : TopCat} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] :
     IsOpenEmbedding (f ≫ g) ↔ IsOpenEmbedding f :=
   (TopCat.homeoOfIso (asIso g)).isOpenEmbedding.of_comp_iff f

--- a/Mathlib/Topology/Category/UniformSpace.lean
+++ b/Mathlib/Topology/Category/UniformSpace.lean
@@ -67,8 +67,6 @@ theorem coe_comp {X Y Z : UniformSpaceCat} (f : X ⟶ Y) (g : Y ⟶ Z) : (f ≫ 
 theorem coe_id (X : UniformSpaceCat) : (𝟙 X : X → X) = id :=
   rfl
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): removed `simp` attribute
--- due to `LEFT-HAND SIDE HAS VARIABLE AS HEAD SYMBOL.`
 theorem coe_mk {X Y : UniformSpaceCat} (f : X → Y) (hf : UniformContinuous f) :
     ((⟨f, hf⟩ : X ⟶ Y) : X → Y) = f :=
   rfl

--- a/Mathlib/Topology/Compactification/OnePoint.lean
+++ b/Mathlib/Topology/Compactification/OnePoint.lean
@@ -122,7 +122,6 @@ protected def rec {C : OnePoint X → Sort*} (infty : C ∞) (coe : ∀ x : X, C
 theorem isCompl_range_coe_infty : IsCompl (range ((↑) : X → OnePoint X)) {∞} :=
   isCompl_range_some_none X
 
--- Porting note: moved @[simp] to a new lemma
 theorem range_coe_union_infty : range ((↑) : X → OnePoint X) ∪ {∞} = univ :=
   range_some_union_none X
 

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1643,9 +1643,7 @@ variable {ι κ : Type*} {σ : ι → Type*} {τ : κ → Type*} [∀ i, Topolog
 theorem continuous_sigmaMk {i : ι} : Continuous (@Sigma.mk ι σ i) :=
   continuous_iSup_rng continuous_coinduced_rng
 
--- Porting note: the proof was `by simp only [isOpen_iSup_iff, isOpen_coinduced]`
 theorem isOpen_sigma_iff {s : Set (Sigma σ)} : IsOpen s ↔ ∀ i, IsOpen (Sigma.mk i ⁻¹' s) := by
-  delta instTopologicalSpaceSigma
   rw [isOpen_iSup_iff]
   rfl
 

--- a/Mathlib/Topology/FiberBundle/Basic.lean
+++ b/Mathlib/Topology/FiberBundle/Basic.lean
@@ -285,7 +285,6 @@ theorem mem_trivializationAt_proj_source {x : TotalSpace F E} :
     x ∈ (trivializationAt F E x.proj).source :=
   (Trivialization.mem_source _).mpr <| mem_baseSet_trivializationAt F E x.proj
 
--- Porting note: removed `@[simp, mfld_simps]` because `simp` could already prove this
 theorem trivializationAt_proj_fst {x : TotalSpace F E} :
     ((trivializationAt F E x.proj) x).1 = x.proj :=
   Trivialization.coe_fst' _ <| mem_baseSet_trivializationAt F E x.proj

--- a/Mathlib/Topology/Gluing.lean
+++ b/Mathlib/Topology/Gluing.lean
@@ -235,10 +235,7 @@ theorem image_inter (i j : D.J) :
         -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10745): was `simp [eq₁]`
         -- See https://github.com/leanprover-community/mathlib4/issues/5026
         rw [TopCat.comp_app, CategoryTheory.IsIso.inv_hom_id_apply, eq₁]⟩
-    · -- Porting note: was
-      -- dsimp only at *; substs e₁ eq₁; exact ⟨y, by simp⟩
-      dsimp only at *
-      substs eq₁
+    · subst eq₁
       exact ⟨y, by simp [e₁]⟩
   · rintro ⟨x, hx⟩
     refine ⟨⟨D.f i j x, hx⟩, ⟨D.f j i (D.t _ _ x), ?_⟩⟩

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -113,12 +113,9 @@ theorem isOpen_iff_inter_of_iSup_eq_top (s : Set β) : IsOpen s ↔ ∀ i, IsOpe
 
 theorem isOpen_iff_coe_preimage_of_iSup_eq_top (s : Set β) :
     IsOpen s ↔ ∀ i, IsOpen ((↑) ⁻¹' s : Set (U i)) := by
-  -- Porting note: rewrote to avoid ´simp´ issues
-  rw [isOpen_iff_inter_of_iSup_eq_top hU s]
-  refine forall_congr' fun i => ?_
-  rw [(U _).2.isOpenEmbedding_subtypeVal.isOpen_iff_image_isOpen]
-  erw [Set.image_preimage_eq_inter_range]
-  rw [Subtype.range_coe, Opens.carrier_eq_coe]
+  simp [isOpen_iff_inter_of_iSup_eq_top hU s,
+    (U _).2.isOpenEmbedding_subtypeVal.isOpen_iff_image_isOpen,
+    Set.image_preimage_eq_inter_range]
 
 theorem isClosed_iff_coe_preimage_of_iSup_eq_top (s : Set β) :
     IsClosed s ↔ ∀ i, IsClosed ((↑) ⁻¹' s : Set (U i)) := by

--- a/Mathlib/Topology/MetricSpace/Dilation.lean
+++ b/Mathlib/Topology/MetricSpace/Dilation.lean
@@ -296,7 +296,6 @@ theorem coe_comp (g : β →ᵈ γ) (f : α →ᵈ β) : (g.comp f : α → γ) 
 theorem comp_apply (g : β →ᵈ γ) (f : α →ᵈ β) (x : α) : (g.comp f : α → γ) x = g (f x) :=
   rfl
 
--- Porting note: removed `simp` because it's difficult to auto prove `hne`
 /-- Ratio of the composition `g.comp f` of two dilations is the product of their ratios. We assume
 that there exist two points in `α` at extended distance neither `0` nor `∞` because otherwise
 `Dilation.ratio (g.comp f) = Dilation.ratio f = 1` while `Dilation.ratio g` can be any number. This

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -426,8 +426,7 @@ instance : MetricSpace GHSpace where
         In this coupling, the two spaces are at zero Hausdorff distance,
         i.e., they coincide. Therefore, the original spaces are isometric. -/
     rcases ghDist_eq_hausdorffDist x.Rep y.Rep with ⟨Φ, Ψ, Φisom, Ψisom, DΦΨ⟩
-    rw [← dist_ghDist] at DΦΨ
-    simp_rw [hxy] at DΦΨ -- Porting note: I have no idea why this needed `simp_rw` versus `rw`
+    rw [← dist_ghDist, hxy] at DΦΨ
     have : range Φ = range Ψ := by
       have hΦ : IsCompact (range Φ) := isCompact_range Φisom.continuous
       have hΨ : IsCompact (range Ψ) := isCompact_range Ψisom.continuous

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -217,7 +217,6 @@ protected theorem ext {s t : NonemptyCompacts α} (h : (s : Set α) = t) : s = t
 theorem coe_mk (s : Compacts α) (h) : (mk s h : Set α) = s :=
   rfl
 
--- Porting note: `@[simp]` moved to `coe_toCompacts`
 theorem carrier_eq_coe (s : NonemptyCompacts α) : s.carrier = s :=
   rfl
 
@@ -311,7 +310,6 @@ protected theorem ext {s t : PositiveCompacts α} (h : (s : Set α) = t) : s = t
 theorem coe_mk (s : Compacts α) (h) : (mk s h : Set α) = s :=
   rfl
 
--- Porting note: `@[simp]` moved to a new lemma
 theorem carrier_eq_coe (s : PositiveCompacts α) : s.carrier = s :=
   rfl
 

--- a/Mathlib/Topology/Sets/Opens.lean
+++ b/Mathlib/Topology/Sets/Opens.lean
@@ -91,7 +91,6 @@ theorem coe_mk {U : Set α} {hU : IsOpen U} : ↑(⟨U, hU⟩ : Opens α) = U :=
 @[simp]
 theorem mem_mk {x : α} {U : Set α} {h : IsOpen U} : x ∈ mk U h ↔ x ∈ U := Iff.rfl
 
--- Porting note: removed @[simp] because LHS simplifies to `∃ x, x ∈ U`
 protected theorem nonempty_coeSort {U : Opens α} : Nonempty U ↔ (U : Set α).Nonempty :=
   Set.nonempty_coe_sort
 
@@ -103,7 +102,6 @@ protected theorem nonempty_coe {U : Opens α} : (U : Set α).Nonempty ↔ ∃ x,
 theorem ext {U V : Opens α} (h : (U : Set α) = V) : U = V :=
   SetLike.coe_injective h
 
--- Porting note: removed @[simp], simp can prove it
 theorem coe_inj {U V : Opens α} : (U : Set α) = V ↔ U = V :=
   SetLike.ext'_iff.symm
 

--- a/Mathlib/Topology/Sheaves/LocalPredicate.lean
+++ b/Mathlib/Topology/Sheaves/LocalPredicate.lean
@@ -215,8 +215,6 @@ def stalkToFiber (P : LocalPredicate T) (x : X) : (subsheafToTypes P).presheaf.s
   · exact f.1 ⟨x, (unop U).2⟩
   · aesop
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11119): removed `simp` attribute,
--- due to left hand side is not in simple normal form.
 theorem stalkToFiber_germ (P : LocalPredicate T) (U : Opens X) (x : X) (hx : x ∈ U) (f) :
     stalkToFiber P x ((subsheafToTypes P).presheaf.germ U x hx f) = f.1 ⟨x, hx⟩ := by
   simp [Presheaf.germ, stalkToFiber]

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -127,8 +127,6 @@ abbrev restrictOpen {X : TopCat} {C : Type*} [Category C] [ConcreteCategory C] {
 /-- restriction of a section to open subset -/
 scoped[AlgebraicGeometry] infixl:80 " |_ " => TopCat.Presheaf.restrictOpen
 
--- Porting note: linter tells this lemma is no going to be picked up by the simplifier, hence
--- `@[simp]` is removed
 theorem restrict_restrict {X : TopCat} {C : Type*} [Category C] [ConcreteCategory C]
     {F : X.Presheaf C} {U V W : Opens X} (e₁ : U ≤ V) (e₂ : V ≤ W) (x : F.obj (op W)) :
     x |_ V |_ U = x |_ U := by
@@ -136,8 +134,6 @@ theorem restrict_restrict {X : TopCat} {C : Type*} [Category C] [ConcreteCategor
   rw [← comp_apply, ← Functor.map_comp]
   rfl
 
--- Porting note: linter tells this lemma is no going to be picked up by the simplifier, hence
--- `@[simp]` is removed
 theorem map_restrict {X : TopCat} {C : Type*} [Category C] [ConcreteCategory C]
     {F G : X.Presheaf C} (e : F ⟶ G) {U V : Opens X} (h : U ≤ V) (x : F.obj (op V)) :
     e.app _ (x |_ U) = e.app _ x |_ U := by

--- a/Mathlib/Topology/Sheaves/Skyscraper.lean
+++ b/Mathlib/Topology/Sheaves/Skyscraper.lean
@@ -143,7 +143,7 @@ noncomputable def skyscraperPresheafCoconeIsColimitOfSpecializes {y : X} (h : p�
     IsColimit (skyscraperPresheafCoconeOfSpecializes p₀ A h) where
   desc c := eqToHom (if_pos trivial).symm ≫ c.ι.app (op ⊤)
   fac c U := by
-    dsimp -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11227):added a `dsimp`
+    dsimp
     rw [← c.w (homOfLE <| (le_top : unop U ≤ _)).op]
     change _ ≫ _ ≫ dite _ _ _ ≫ _ = _
     rw [dif_pos]
@@ -151,7 +151,7 @@ noncomputable def skyscraperPresheafCoconeIsColimitOfSpecializes {y : X} (h : p�
         eqToHom_refl, Category.id_comp, unop_op, op_unop]
     · exact h.mem_open U.unop.1.2 U.unop.2
   uniq c f h := by
-    dsimp -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11227):added a `dsimp`
+    dsimp
     rw [← h, skyscraperPresheafCoconeOfSpecializes_ι_app, eqToHom_trans_assoc, eqToHom_refl,
       Category.id_comp]
 
@@ -195,7 +195,7 @@ noncomputable def skyscraperPresheafCoconeIsColimitOfNotSpecializes {y : X} (h :
       refine ((if_neg ?_).symm.ndrec terminalIsTerminal).hom_ext _ _
       exact fun h => h1.choose_spec h.1
     uniq := fun c f H => by
-      dsimp -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11227):added a `dsimp`
+      dsimp
       rw [← Category.id_comp f, ← H, ← Category.assoc]
       congr 1; apply terminalIsTerminal.hom_ext }
 

--- a/Mathlib/Topology/UniformSpace/Equiv.lean
+++ b/Mathlib/Topology/UniformSpace/Equiv.lean
@@ -130,7 +130,6 @@ protected theorem continuous_symm (h : α ≃ᵤ β) : Continuous h.symm :=
   h.uniformContinuous_symm.continuous
 
 /-- A uniform isomorphism as a homeomorphism. -/
--- @[simps] -- Porting note: removed, `simps?` produced no `simp` lemmas
 protected def toHomeomorph (e : α ≃ᵤ β) : α ≃ₜ β :=
   { e.toEquiv with
     continuous_toFun := e.continuous
@@ -372,7 +371,6 @@ def image (e : α ≃ᵤ β) (s : Set α) : s ≃ᵤ e '' s where
 end UniformEquiv
 
 /-- A uniform inducing equiv between uniform spaces is a uniform isomorphism. -/
--- @[simps] -- Porting note: removed, `simps?` produced no `simp` lemmas
 def Equiv.toUniformEquivOfIsUniformInducing [UniformSpace α] [UniformSpace β] (f : α ≃ β)
     (hf : IsUniformInducing f) : α ≃ᵤ β :=
   { f with

--- a/Mathlib/Topology/UniformSpace/OfCompactT2.lean
+++ b/Mathlib/Topology/UniformSpace/OfCompactT2.lean
@@ -79,8 +79,7 @@ def uniformSpaceOfCompactT2 [TopologicalSpace γ] [CompactSpace γ] [T2Space γ]
       · simp only [W, mem_union, mem_prod, and_self_iff]
         exact (_root_.em _).imp_left fun h => union_subset_union VU₁ VU₂ h
     -- So W ○ W ∈ F by definition of F
-    have : W ○ W ∈ F := @mem_lift' _ _ _ (fun s => s ○ s) _ W_in
-      -- Porting note: was `by simpa only using mem_lift' W_in`
+    have : W ○ W ∈ F := by simpa only using mem_lift' W_in
     -- And V₁ ×ˢ V₂ ∈ 𝓝 (x, y)
     have hV₁₂ : V₁ ×ˢ V₂ ∈ 𝓝 (x, y) := prod_mem_nhds V₁_in V₂_in
     -- But (x, y) is also a cluster point of F so (V₁ ×ˢ V₂) ∩ (W ○ W) ≠ ∅


### PR DESCRIPTION
I've removed many porting notes that had resulted from the `simpNF` linter.

I've left in place all porting notes about removing `@[simp]` but where the proof is `rfl` or `Iff.rfl`.