### PR TITLE
[Merged by Bors] - style: correct `MaximalSpectrum.IsMaximal` for style conformance.

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -974,7 +974,7 @@ theorem associates_irreducible : Irreducible <| Associates.mk v.asIdeal :=
 def equivMaximalSpectrum (hR : ¬IsField R) : HeightOneSpectrum R ≃ MaximalSpectrum R where
   toFun v := ⟨v.asIdeal, v.isPrime.isMaximal v.ne_bot⟩
   invFun v :=
-    ⟨v.asIdeal, v.IsMaximal.isPrime, Ring.ne_bot_of_isMaximal_of_not_isField v.IsMaximal hR⟩
+    ⟨v.asIdeal, v.isMaximal.isPrime, Ring.ne_bot_of_isMaximal_of_not_isField v.isMaximal hR⟩
   left_inv := fun ⟨_, _, _⟩ => rfl
   right_inv := fun ⟨_, _⟩ => rfl
 

--- a/Mathlib/RingTheory/Spectrum/Maximal/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Maximal/Basic.lean
@@ -29,7 +29,7 @@ instance [Nontrivial R] : Nonempty <| MaximalSpectrum R :=
 
 /-- The natural inclusion from the maximal spectrum to the prime spectrum. -/
 def toPrimeSpectrum (x : MaximalSpectrum R) : PrimeSpectrum R :=
-  ⟨x.asIdeal, x.IsMaximal.isPrime⟩
+  ⟨x.asIdeal, x.isMaximal.isPrime⟩
 
 theorem toPrimeSpectrum_injective : (@toPrimeSpectrum R _).Injective := fun ⟨_, _⟩ ⟨_, _⟩ h => by
   simpa only [MaximalSpectrum.mk.injEq] using PrimeSpectrum.ext_iff.mp h

--- a/Mathlib/RingTheory/Spectrum/Maximal/Defs.lean
+++ b/Mathlib/RingTheory/Spectrum/Maximal/Defs.lean
@@ -22,6 +22,8 @@ maximal ideals of `R`. -/
 @[ext]
 structure MaximalSpectrum (R : Type*) [CommSemiring R] where
   asIdeal : Ideal R
-  IsMaximal : asIdeal.IsMaximal
+  isMaximal : asIdeal.IsMaximal
+
+@[deprecated (since := "2025-01-16")] alias MaximalSpectrum.IsMaximal := MaximalSpectrum.isMaximal
 
 attribute [instance] MaximalSpectrum.IsMaximal

--- a/Mathlib/RingTheory/Spectrum/Maximal/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Maximal/Topology.lean
@@ -32,7 +32,7 @@ theorem toPrimeSpectrum_range :
     Set.range (@toPrimeSpectrum R _) = { x | IsClosed ({x} : Set <| PrimeSpectrum R) } := by
   simp only [isClosed_singleton_iff_isMaximal]
   ext ⟨x, _⟩
-  exact ⟨fun ⟨y, hy⟩ => hy ▸ y.IsMaximal, fun hx => ⟨⟨x, hx⟩, rfl⟩⟩
+  exact ⟨fun ⟨y, hy⟩ => hy ▸ y.isMaximal, fun hx => ⟨⟨x, hx⟩, rfl⟩⟩
 
 /-- The Zariski topology on the maximal spectrum of a commutative ring is defined as the subspace
 topology induced by the natural inclusion into the prime spectrum. -/
@@ -41,7 +41,7 @@ instance zariskiTopology : TopologicalSpace <| MaximalSpectrum R :=
 
 instance : T1Space <| MaximalSpectrum R :=
   ⟨fun x => isClosed_induced_iff.mpr
-    ⟨{toPrimeSpectrum x}, (isClosed_singleton_iff_isMaximal _).mpr x.IsMaximal, by
+    ⟨{toPrimeSpectrum x}, (isClosed_singleton_iff_isMaximal _).mpr x.isMaximal, by
       simpa only [← image_singleton] using preimage_image_eq {x} toPrimeSpectrum_injective⟩⟩
 
 theorem toPrimeSpectrum_continuous : Continuous <| @toPrimeSpectrum R _ :=


### PR DESCRIPTION
Rename `MaximalSpectrum.IsMaximal` to `MaximalSpectrum.isMaximal` and add deprecation note.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
