### PR TITLE
[Merged by Bors] - chore(Data/Set/Pointwise/SMul): move content to earlier files

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -288,6 +288,7 @@ import Mathlib.Algebra.Group.Action.Hom
 import Mathlib.Algebra.Group.Action.Opposite
 import Mathlib.Algebra.Group.Action.Option
 import Mathlib.Algebra.Group.Action.Pi
+import Mathlib.Algebra.Group.Action.Pointwise.Set
 import Mathlib.Algebra.Group.Action.Pretransitive
 import Mathlib.Algebra.Group.Action.Prod
 import Mathlib.Algebra.Group.Action.Sigma
@@ -413,6 +414,7 @@ import Mathlib.Algebra.GroupWithZero.Action.End
 import Mathlib.Algebra.GroupWithZero.Action.Faithful
 import Mathlib.Algebra.GroupWithZero.Action.Opposite
 import Mathlib.Algebra.GroupWithZero.Action.Pi
+import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set
 import Mathlib.Algebra.GroupWithZero.Action.Prod
 import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.GroupWithZero.Associated
@@ -943,6 +945,7 @@ import Mathlib.Algebra.Ring.Action.End
 import Mathlib.Algebra.Ring.Action.Field
 import Mathlib.Algebra.Ring.Action.Group
 import Mathlib.Algebra.Ring.Action.Invariant
+import Mathlib.Algebra.Ring.Action.Pointwise.Set
 import Mathlib.Algebra.Ring.Action.Subobjects
 import Mathlib.Algebra.Ring.AddAut
 import Mathlib.Algebra.Ring.Associated
@@ -3188,7 +3191,6 @@ import Mathlib.Data.Set.Opposite
 import Mathlib.Data.Set.Pairwise.Basic
 import Mathlib.Data.Set.Pairwise.Lattice
 import Mathlib.Data.Set.Pointwise.Iterate
-import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Data.Set.Pointwise.Support
 import Mathlib.Data.Set.Prod
 import Mathlib.Data.Set.SMulAntidiagonal

--- a/Mathlib/Algebra/Group/Action/Pointwise/Set.lean
+++ b/Mathlib/Algebra/Group/Action/Pointwise/Set.lean
@@ -1,17 +1,17 @@
 /-
 Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johan Commelin, Floris van Doorn
+Authors: Johan Commelin, Floris van Doorn, Yaël Dillies
 -/
+import Mathlib.Algebra.Group.Action.Basic
+import Mathlib.Algebra.Group.Action.Opposite
 import Mathlib.Algebra.Group.Pointwise.Set.Basic
-import Mathlib.Algebra.GroupWithZero.Action.Basic
-import Mathlib.Algebra.GroupWithZero.Action.Units
-import Mathlib.Algebra.Module.Defs
-import Mathlib.Algebra.NoZeroSMulDivisors.Defs
+import Mathlib.Algebra.Group.Action.Prod
+import Mathlib.Algebra.Group.Units.Equiv
 import Mathlib.Data.Set.Pairwise.Basic
 
 /-!
-# Pointwise action on sets
+# Pointwise actions on sets
 
 This file proves that several kinds of actions of a type `α` on another type `β` transfer to actions
 of `α`/`Set α` on `Set β`.
@@ -22,25 +22,37 @@ of `α`/`Set α` on `Set β`.
   default. Note that we do not mark them as reducible (as argued by note [reducible non-instances])
   since we expect the locale to be open whenever the instances are actually used (and making the
   instances reducible changes the behavior of `simp`.
-
 -/
 
+assert_not_exists MonoidWithZero OrderedAddCommMonoid
+
 open Function MulOpposite
+open scoped Pointwise
 
 variable {F α β γ : Type*}
 
 namespace Set
 
-open Pointwise
-
 /-! ### Translation/scaling of sets -/
 
+@[to_additive]
+lemma smul_set_prod {M α : Type*} [SMul M α] [SMul M β] (c : M) (s : Set α) (t : Set β) :
+    c • (s ×ˢ t) = (c • s) ×ˢ (c • t) :=
+  prodMap_image_prod (c • ·) (c • ·) s t
 
-section SMul
+@[to_additive]
+lemma smul_set_pi {G ι : Type*} {α : ι → Type*} [Group G] [∀ i, MulAction G (α i)]
+    (c : G) (I : Set ι) (s : ∀ i, Set (α i)) : c • I.pi s = I.pi fun i ↦ c • s i :=
+  smul_set_pi_of_surjective c I s fun _ _ ↦ (MulAction.bijective c).surjective
+
+@[to_additive]
+lemma smul_set_pi_of_isUnit {M ι : Type*} {α : ι → Type*} [Monoid M] [∀ i, MulAction M (α i)]
+    {c : M} (hc : IsUnit c) (I : Set ι) (s : ∀ i, Set (α i)) : c • I.pi s = I.pi (c • s ·) := by
+  lift c to Mˣ using hc
+  exact smul_set_pi c I s
 
 section Mul
-
-variable [Mul α] {s t u : Set α} {a : α}
+variable {ι : Sort*} {κ : ι → Sort*} [Mul α] {s s₁ s₂ t t₁ t₂ u : Set α} {a b : α}
 
 @[to_additive] lemma smul_set_subset_mul : a ∈ s → a • t ⊆ s * t := image_subset_image2_right
 
@@ -71,12 +83,42 @@ open scoped RightActions
 @[to_additive] lemma mul_pair (s : Set α) (a b : α) : s * {a, b} = s <• a ∪ s <• b := by
   rw [insert_eq, mul_union, mul_singleton, mul_singleton]; rfl
 
+@[to_additive] lemma range_mul {ι : Sort*} (a : α) (f : ι → α) :
+    range (fun i ↦ a * f i) = a • range f := range_smul a f
+
 end Mul
 
-variable {s s₁ s₂ : Set α} {t t₁ t₂ : Set β} {a : α} {b : β}
+@[to_additive]
+lemma image_smul_distrib [MulOneClass α] [MulOneClass β] [FunLike F α β] [MonoidHomClass F α β]
+    (f : F) (a : α) (s : Set α) :
+    f '' (a • s) = f a • f '' s :=
+  image_comm <| map_mul _ _
 
-@[to_additive] lemma range_mul [Mul α] {ι : Sort*} (a : α) (f : ι → α) :
-    range (fun i ↦ a * f i) = a • range f := range_smul a f
+open scoped RightActions in
+@[to_additive]
+lemma image_op_smul_distrib [MulOneClass α] [MulOneClass β] [FunLike F α β] [MonoidHomClass F α β]
+    (f : F) (a : α) (s : Set α) : f '' (s <• a) = f '' s <• f a := image_comm fun _ ↦ map_mul ..
+
+section Semigroup
+variable [Semigroup α]
+
+@[to_additive]
+lemma op_smul_set_mul_eq_mul_smul_set (a : α) (s : Set α) (t : Set α) :
+    op a • s * t = s * a • t :=
+  op_smul_set_smul_eq_smul_smul_set _ _ _ fun _ _ _ => mul_assoc _ _ _
+
+end Semigroup
+
+section IsLeftCancelMul
+
+variable [Mul α] [IsLeftCancelMul α] {s t : Set α}
+
+@[to_additive]
+theorem pairwiseDisjoint_smul_iff :
+    s.PairwiseDisjoint (· • t) ↔ (s ×ˢ t).InjOn fun p ↦ p.1 * p.2 :=
+  pairwiseDisjoint_image_right_iff fun _ _ ↦ mul_right_injective _
+
+end IsLeftCancelMul
 
 @[to_additive]
 instance smulCommClass_set [SMul α γ] [SMul β γ] [SMulCommClass α β γ] :
@@ -122,8 +164,8 @@ instance isCentralScalar [SMul α β] [SMul αᵐᵒᵖ β] [IsCentralScalar α 
 /-- A multiplicative action of a monoid `α` on a type `β` gives a multiplicative action of `Set α`
 on `Set β`. -/
 @[to_additive
-      "An additive action of an additive monoid `α` on a type `β` gives an additive action of
-      `Set α` on `Set β`"]
+"An additive action of an additive monoid `α` on a type `β` gives an additive action of `Set α`
+on `Set β`"]
 protected def mulAction [Monoid α] [MulAction α β] : MulAction (Set α) (Set β) where
   mul_smul _ _ _ := image2_assoc mul_smul
   one_smul s := image2_singleton_left.trans <| by simp_rw [one_smul, image_id']
@@ -136,189 +178,6 @@ protected def mulActionSet [Monoid α] [MulAction α β] : MulAction α (Set β)
   one_smul _ := by simp only [← image_smul, one_smul, image_id']
 
 scoped[Pointwise] attribute [instance] Set.mulActionSet Set.addActionSet Set.mulAction Set.addAction
-
-/-- If scalar multiplication by elements of `α` sends `(0 : β)` to zero,
-then the same is true for `(0 : Set β)`. -/
-protected def smulZeroClassSet [Zero β] [SMulZeroClass α β] :
-    SMulZeroClass α (Set β) where
-  smul_zero _ := image_singleton.trans <| by rw [smul_zero, singleton_zero]
-
-scoped[Pointwise] attribute [instance] Set.smulZeroClassSet
-
-/-- If the scalar multiplication `(· • ·) : α → β → β` is distributive,
-then so is `(· • ·) : α → Set β → Set β`. -/
-protected def distribSMulSet [AddZeroClass β] [DistribSMul α β] :
-    DistribSMul α (Set β) where
-  smul_add _ _ _ := image_image2_distrib <| smul_add _
-
-scoped[Pointwise] attribute [instance] Set.distribSMulSet
-
-/-- A distributive multiplicative action of a monoid on an additive monoid `β` gives a distributive
-multiplicative action on `Set β`. -/
-protected def distribMulActionSet [Monoid α] [AddMonoid β] [DistribMulAction α β] :
-    DistribMulAction α (Set β) where
-  smul_add := smul_add
-  smul_zero := smul_zero
-
-/-- A multiplicative action of a monoid on a monoid `β` gives a multiplicative action on `Set β`. -/
-protected def mulDistribMulActionSet [Monoid α] [Monoid β] [MulDistribMulAction α β] :
-    MulDistribMulAction α (Set β) where
-  smul_mul _ _ _ := image_image2_distrib <| smul_mul' _
-  smul_one _ := image_singleton.trans <| by rw [smul_one, singleton_one]
-
-scoped[Pointwise] attribute [instance] Set.distribMulActionSet Set.mulDistribMulActionSet
-
-instance [Zero α] [Zero β] [SMul α β] [NoZeroSMulDivisors α β] :
-    NoZeroSMulDivisors (Set α) (Set β) :=
-  ⟨fun {s t} h ↦ by
-    by_contra! H
-    have hst : (s • t).Nonempty := h.symm.subst zero_nonempty
-    rw [Ne, ← hst.of_smul_left.subset_zero_iff, Ne,
-      ← hst.of_smul_right.subset_zero_iff] at H
-    simp only [not_subset, mem_zero] at H
-    obtain ⟨⟨a, hs, ha⟩, b, ht, hb⟩ := H
-    exact (eq_zero_or_eq_zero_of_smul_eq_zero <| h.subset <| smul_mem_smul hs ht).elim ha hb⟩
-
-instance noZeroSMulDivisors_set [Zero α] [Zero β] [SMul α β] [NoZeroSMulDivisors α β] :
-    NoZeroSMulDivisors α (Set β) :=
-  ⟨fun {a s} h ↦ by
-    by_contra! H
-    have hst : (a • s).Nonempty := h.symm.subst zero_nonempty
-    rw [Ne, Ne, ← hst.of_image.subset_zero_iff, not_subset] at H
-    obtain ⟨ha, b, ht, hb⟩ := H
-    exact (eq_zero_or_eq_zero_of_smul_eq_zero <| h.subset <| smul_mem_smul_set ht).elim ha hb⟩
-
-instance [Zero α] [Mul α] [NoZeroDivisors α] : NoZeroDivisors (Set α) :=
-  ⟨fun h ↦ eq_zero_or_eq_zero_of_smul_eq_zero h⟩
-
-end SMul
-
-open Pointwise
-
-@[to_additive]
-theorem image_smul_distrib [MulOneClass α] [MulOneClass β] [FunLike F α β] [MonoidHomClass F α β]
-    (f : F) (a : α) (s : Set α) :
-    f '' (a • s) = f a • f '' s :=
-  image_comm <| map_mul _ _
-
-open scoped RightActions in
-@[to_additive]
-lemma image_op_smul_distrib [MulOneClass α] [MulOneClass β] [FunLike F α β] [MonoidHomClass F α β]
-    (f : F) (a : α) (s : Set α) : f '' (s <• a) = f '' s <• f a := image_comm fun _ ↦ map_mul _ _ _
-
-@[to_additive]
-theorem smul_set_prod {M : Type*} [SMul M α] [SMul M β] (c : M) (s : Set α) (t : Set β) :
-    c • (s ×ˢ t) = (c • s) ×ˢ (c • t) :=
-  prodMap_image_prod (c • ·) (c • ·) s t
-
-@[to_additive]
-theorem smul_set_pi {G ι : Type*} {α : ι → Type*} [Group G] [∀ i, MulAction G (α i)]
-    (c : G) (I : Set ι) (s : ∀ i, Set (α i)) : c • I.pi s = I.pi fun i ↦ c • s i :=
-  smul_set_pi_of_surjective c I s fun _ _ ↦ (MulAction.bijective c).surjective
-
-@[to_additive]
-theorem smul_set_pi_of_isUnit {M ι : Type*} {α : ι → Type*} [Monoid M] [∀ i, MulAction M (α i)]
-    {c : M} (hc : IsUnit c) (I : Set ι) (s : ∀ i, Set (α i)) : c • I.pi s = I.pi (c • s ·) := by
-  lift c to Mˣ using hc
-  exact smul_set_pi c I s
-
-theorem smul_set_pi₀ {M ι : Type*} {α : ι → Type*} [GroupWithZero M] [∀ i, MulAction M (α i)]
-    {c : M} (hc : c ≠ 0) (I : Set ι) (s : ∀ i, Set (α i)) : c • I.pi s = I.pi (c • s ·) :=
-  smul_set_pi_of_isUnit (.mk0 _ hc) I s
-
-section SMul
-
-variable [SMul αᵐᵒᵖ β] [SMul β γ] [SMul α γ]
-
--- TODO: replace hypothesis and conclusion with a typeclass
-@[to_additive]
-theorem op_smul_set_smul_eq_smul_smul_set (a : α) (s : Set β) (t : Set γ)
-    (h : ∀ (a : α) (b : β) (c : γ), (op a • b) • c = b • a • c) : (op a • s) • t = s • a • t := by
-  ext
-  simp [mem_smul, mem_smul_set, h]
-
-end SMul
-
-section SMulZeroClass
-
-variable [Zero β] [SMulZeroClass α β] {s : Set α} {t : Set β} {a : α}
-
-theorem smul_zero_subset (s : Set α) : s • (0 : Set β) ⊆ 0 := by simp [subset_def, mem_smul]
-
-theorem Nonempty.smul_zero (hs : s.Nonempty) : s • (0 : Set β) = 0 :=
-  s.smul_zero_subset.antisymm <| by simpa [mem_smul] using hs
-
-theorem zero_mem_smul_set (h : (0 : β) ∈ t) : (0 : β) ∈ a • t := ⟨0, h, smul_zero _⟩
-
-variable [Zero α] [NoZeroSMulDivisors α β]
-
-theorem zero_mem_smul_set_iff (ha : a ≠ 0) : (0 : β) ∈ a • t ↔ (0 : β) ∈ t := by
-  refine ⟨?_, zero_mem_smul_set⟩
-  rintro ⟨b, hb, h⟩
-  rwa [(eq_zero_or_eq_zero_of_smul_eq_zero h).resolve_left ha] at hb
-
-end SMulZeroClass
-
-section SMulWithZero
-
-variable [Zero α] [Zero β] [SMulWithZero α β] {s : Set α} {t : Set β}
-
-/-!
-Note that we have neither `SMulWithZero α (Set β)` nor `SMulWithZero (Set α) (Set β)`
-because `0 * ∅ ≠ 0`.
--/
-
-theorem zero_smul_subset (t : Set β) : (0 : Set α) • t ⊆ 0 := by simp [subset_def, mem_smul]
-
-theorem Nonempty.zero_smul (ht : t.Nonempty) : (0 : Set α) • t = 0 :=
-  t.zero_smul_subset.antisymm <| by simpa [mem_smul] using ht
-
-/-- A nonempty set is scaled by zero to the singleton set containing 0. -/
-@[simp] theorem zero_smul_set {s : Set β} (h : s.Nonempty) : (0 : α) • s = (0 : Set β) := by
-  simp only [← image_smul, image_eta, zero_smul, h.image_const, singleton_zero]
-
-theorem zero_smul_set_subset (s : Set β) : (0 : α) • s ⊆ 0 :=
-  image_subset_iff.2 fun x _ ↦ zero_smul α x
-
-theorem subsingleton_zero_smul_set (s : Set β) : ((0 : α) • s).Subsingleton :=
-  subsingleton_singleton.anti <| zero_smul_set_subset s
-
-variable [NoZeroSMulDivisors α β] {a : α}
-
-theorem zero_mem_smul_iff :
-    (0 : β) ∈ s • t ↔ (0 : α) ∈ s ∧ t.Nonempty ∨ (0 : β) ∈ t ∧ s.Nonempty := by
-  constructor
-  · rintro ⟨a, ha, b, hb, h⟩
-    obtain rfl | rfl := eq_zero_or_eq_zero_of_smul_eq_zero h
-    · exact Or.inl ⟨ha, b, hb⟩
-    · exact Or.inr ⟨hb, a, ha⟩
-  · rintro (⟨hs, b, hb⟩ | ⟨ht, a, ha⟩)
-    · exact ⟨0, hs, b, hb, zero_smul _ _⟩
-    · exact ⟨a, ha, 0, ht, smul_zero _⟩
-
-end SMulWithZero
-
-section Semigroup
-
-variable [Semigroup α]
-
-@[to_additive]
-theorem op_smul_set_mul_eq_mul_smul_set (a : α) (s : Set α) (t : Set α) :
-    op a • s * t = s * a • t :=
-  op_smul_set_smul_eq_smul_smul_set _ _ _ fun _ _ _ => mul_assoc _ _ _
-
-end Semigroup
-
-section IsLeftCancelMul
-
-variable [Mul α] [IsLeftCancelMul α] {s t : Set α}
-
-@[to_additive]
-theorem pairwiseDisjoint_smul_iff :
-    s.PairwiseDisjoint (· • t) ↔ (s ×ˢ t).InjOn fun p ↦ p.1 * p.2 :=
-  pairwiseDisjoint_image_right_iff fun _ _ ↦ mul_right_injective _
-
-end IsLeftCancelMul
 
 section Group
 
@@ -520,116 +379,4 @@ variable [CommGroup α]
     singleton_div_singleton]
 
 end CommGroup
-
-section GroupWithZero
-
-variable [GroupWithZero α] [MulAction α β] {s t : Set β} {a : α}
-
-@[simp]
-theorem smul_mem_smul_set_iff₀ (ha : a ≠ 0) (A : Set β) (x : β) : a • x ∈ a • A ↔ x ∈ A :=
-  show Units.mk0 a ha • _ ∈ _ ↔ _ from smul_mem_smul_set_iff
-
-theorem mem_smul_set_iff_inv_smul_mem₀ (ha : a ≠ 0) (A : Set β) (x : β) : x ∈ a • A ↔ a⁻¹ • x ∈ A :=
-  show _ ∈ Units.mk0 a ha • _ ↔ _ from mem_smul_set_iff_inv_smul_mem
-
-theorem mem_inv_smul_set_iff₀ (ha : a ≠ 0) (A : Set β) (x : β) : x ∈ a⁻¹ • A ↔ a • x ∈ A :=
-  show _ ∈ (Units.mk0 a ha)⁻¹ • _ ↔ _ from mem_inv_smul_set_iff
-
-theorem preimage_smul₀ (ha : a ≠ 0) (t : Set β) : (fun x ↦ a • x) ⁻¹' t = a⁻¹ • t :=
-  preimage_smul (Units.mk0 a ha) t
-
-theorem preimage_smul_inv₀ (ha : a ≠ 0) (t : Set β) : (fun x ↦ a⁻¹ • x) ⁻¹' t = a • t :=
-  preimage_smul (Units.mk0 a ha)⁻¹ t
-
-@[simp]
-theorem smul_set_subset_smul_set_iff₀ (ha : a ≠ 0) {A B : Set β} : a • A ⊆ a • B ↔ A ⊆ B :=
-  show Units.mk0 a ha • _ ⊆ _ ↔ _ from smul_set_subset_smul_set_iff
-
-@[deprecated (since := "2024-12-28")]
-alias set_smul_subset_set_smul_iff₀ := smul_set_subset_smul_set_iff₀
-
-theorem smul_set_subset_iff₀ (ha : a ≠ 0) {A B : Set β} : a • A ⊆ B ↔ A ⊆ a⁻¹ • B :=
-  show Units.mk0 a ha • _ ⊆ _ ↔ _ from smul_set_subset_iff_subset_inv_smul_set
-
-@[deprecated (since := "2024-12-28")] alias set_smul_subset_iff₀ := smul_set_subset_iff₀
-
-theorem subset_smul_set_iff₀ (ha : a ≠ 0) {A B : Set β} : A ⊆ a • B ↔ a⁻¹ • A ⊆ B :=
-  show _ ⊆ Units.mk0 a ha • _ ↔ _ from subset_smul_set_iff
-
-@[deprecated (since := "2024-12-28")] alias subset_set_smul_iff₀ := subset_smul_set_iff₀
-
-theorem smul_set_inter₀ (ha : a ≠ 0) : a • (s ∩ t) = a • s ∩ a • t :=
-  show Units.mk0 a ha • _ = _ from smul_set_inter
-
-theorem smul_set_sdiff₀ (ha : a ≠ 0) : a • (s \ t) = a • s \ a • t :=
-  image_diff (MulAction.injective₀ ha) _ _
-
-open scoped symmDiff in
-theorem smul_set_symmDiff₀ (ha : a ≠ 0) : a • s ∆ t = (a • s) ∆ (a • t) :=
-  image_symmDiff (MulAction.injective₀ ha) _ _
-
-theorem smul_set_univ₀ (ha : a ≠ 0) : a • (univ : Set β) = univ :=
-  image_univ_of_surjective <| MulAction.surjective₀ ha
-
-theorem smul_univ₀ {s : Set α} (hs : ¬s ⊆ 0) : s • (univ : Set β) = univ :=
-  let ⟨a, ha, ha₀⟩ := not_subset.1 hs
-  eq_univ_of_forall fun b ↦ ⟨a, ha, a⁻¹ • b, trivial, smul_inv_smul₀ ha₀ _⟩
-
-theorem smul_univ₀' {s : Set α} (hs : s.Nontrivial) : s • (univ : Set β) = univ :=
-  smul_univ₀ hs.not_subset_singleton
-
-@[simp] protected lemma inv_zero : (0 : Set α)⁻¹ = 0 := by ext; simp
-
-@[simp] lemma inv_smul_set_distrib₀ (a : α) (s : Set α) : (a • s)⁻¹ = op a⁻¹ • s⁻¹ := by
-  obtain rfl | ha := eq_or_ne a 0
-  · obtain rfl | hs := s.eq_empty_or_nonempty <;> simp [*]
-  · ext; simp [mem_smul_set_iff_inv_smul_mem₀, *]
-
-@[simp] lemma inv_op_smul_set_distrib₀ (a : α) (s : Set α) : (op a • s)⁻¹ = a⁻¹ • s⁻¹ := by
-  obtain rfl | ha := eq_or_ne a 0
-  · obtain rfl | hs := s.eq_empty_or_nonempty <;> simp [*]
-  · ext; simp [mem_smul_set_iff_inv_smul_mem₀, *]
-
-end GroupWithZero
-
-section Monoid
-
-variable [Monoid α] [AddGroup β] [DistribMulAction α β] (a : α) (s : Set α) (t : Set β)
-
-@[simp]
-theorem smul_set_neg : a • -t = -(a • t) := by
-  simp_rw [← image_smul, ← image_neg_eq_neg, image_image, smul_neg]
-
-@[simp]
-protected theorem smul_neg : s • -t = -(s • t) := by
-  simp_rw [← image_neg_eq_neg]
-  exact image_image2_right_comm smul_neg
-
-end Monoid
-
-section Semiring
-
-variable [Semiring α] [AddCommMonoid β] [Module α β]
-
-theorem add_smul_subset (a b : α) (s : Set β) : (a + b) • s ⊆ a • s + b • s := by
-  rintro _ ⟨x, hx, rfl⟩
-  simpa only [add_smul] using add_mem_add (smul_mem_smul_set hx) (smul_mem_smul_set hx)
-
-end Semiring
-
-section Ring
-
-variable [Ring α] [AddCommGroup β] [Module α β] (a : α) (s : Set α) (t : Set β)
-
-@[simp]
-theorem neg_smul_set : -a • t = -(a • t) := by
-  simp_rw [← image_smul, ← image_neg_eq_neg, image_image, neg_smul]
-
-@[simp]
-protected theorem neg_smul : -s • t = -(s • t) := by
-  simp_rw [← image_neg_eq_neg]
-  exact image2_image_left_comm neg_smul
-
-end Ring
-
 end Set

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -3,15 +3,15 @@ Copyright (c) 2020 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Yaël Dillies
 -/
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.Group.Action.Pi
+import Mathlib.Algebra.Group.Action.Pointwise.Set
 import Mathlib.Algebra.Group.Pointwise.Set.Finite
 import Mathlib.Algebra.Group.Pointwise.Set.ListOfFn
 import Mathlib.Data.Finset.Density
 import Mathlib.Data.Finset.Max
 import Mathlib.Data.Finset.NAry
-import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Data.Finset.Preimage
-import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 
 /-!
 # Pointwise operations of finsets

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Floris van Doorn, Yaël Dillies
 -/
+import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 import Mathlib.Data.Set.Lattice

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -3,12 +3,10 @@ Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Floris van Doorn, Yaël Dillies
 -/
-import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Group.Prod
-import Mathlib.Algebra.Group.Units.Hom
-import Mathlib.Algebra.Opposites
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 import Mathlib.Data.Set.Lattice
+import Mathlib.Tactic.MinImports
 
 /-!
 # Pointwise operations of sets
@@ -54,7 +52,7 @@ set multiplication, set addition, pointwise addition, pointwise multiplication,
 pointwise subtraction
 -/
 
-assert_not_exists MonoidWithZero OrderedAddCommMonoid
+assert_not_exists MulAction MonoidWithZero OrderedAddCommMonoid
 
 library_note "pointwise nat action"/--
 Pointwise monoids (`Set`, `Finset`, `Filter`) have derived pointwise actions of the form
@@ -982,13 +980,20 @@ lemma vsub_iInter₂_subset (s : Set β) (t : ∀ i, κ i → Set β) :
 
 end VSub
 
-open Pointwise
-
 @[to_additive]
 lemma image_smul_comm [SMul α β] [SMul α γ] (f : β → γ) (a : α) (s : Set β) :
     (∀ b, f (a • b) = a • f b) → f '' (a • s) = a • f '' s := image_comm
 
-open Pointwise
+section SMul
+variable [SMul αᵐᵒᵖ β] [SMul β γ] [SMul α γ]
+
+-- TODO: replace hypothesis and conclusion with a typeclass
+@[to_additive]
+lemma op_smul_set_smul_eq_smul_smul_set (a : α) (s : Set β) (t : Set γ)
+    (h : ∀ (a : α) (b : β) (c : γ), (op a • b) • c = b • a • c) : (op a • s) • t = s • a • t := by
+  ext; simp [mem_smul, mem_smul_set, h]
+
+end SMul
 
 /-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `Set`. See
 note [pointwise nat action]. -/

--- a/Mathlib/Algebra/Group/Submonoid/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Pointwise.lean
@@ -5,9 +5,10 @@ Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Group.Hom.End
 import Mathlib.Algebra.Group.Submonoid.Membership
+import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set
+import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Order.BigOperators.Group.List
 import Mathlib.Data.Nat.Cast.Basic
-import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Order.WellFoundedSet
 
 /-! # Pointwise instances on `Submonoid`s and `AddSubmonoid`s

--- a/Mathlib/Algebra/Group/Translate.lean
+++ b/Mathlib/Algebra/Group/Translate.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.BigOperators.Pi
+import Mathlib.Algebra.Group.Action.Pointwise.Set
 import Mathlib.Algebra.Group.Pi.Basic
-import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 
 /-!

--- a/Mathlib/Algebra/GroupWithZero/Action/Pointwise/Set.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Pointwise/Set.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Action.Pointwise.Set
+import Mathlib.Algebra.GroupWithZero.Action.Basic
+import Mathlib.Algebra.GroupWithZero.Action.Units
+import Mathlib.Algebra.GroupWithZero.Pointwise.Set.Basic
+import Mathlib.Algebra.NoZeroSMulDivisors.Defs
+
+/-!
+# Pointwise operations of sets in a group with zero
+
+This file proves properties of pointwise operations of sets in a group with zero.
+
+## Tags
+
+set multiplication, set addition, pointwise addition, pointwise multiplication,
+pointwise subtraction
+-/
+
+assert_not_exists OrderedAddCommMonoid Ring
+
+open Function
+open scoped Pointwise
+
+variable {α β : Type*}
+
+namespace Set
+
+lemma smul_set_pi₀ {M ι : Type*} {α : ι → Type*} [GroupWithZero M] [∀ i, MulAction M (α i)]
+    {c : M} (hc : c ≠ 0) (I : Set ι) (s : ∀ i, Set (α i)) : c • I.pi s = I.pi (c • s ·) :=
+  smul_set_pi_of_isUnit (.mk0 _ hc) I s
+
+section SMulZeroClass
+variable [Zero β] [SMulZeroClass α β] {s : Set α} {t : Set β} {a : α}
+
+/-- If scalar multiplication by elements of `α` sends `(0 : β)` to zero,
+then the same is true for `(0 : Set β)`. -/
+protected def smulZeroClassSet [Zero β] [SMulZeroClass α β] : SMulZeroClass α (Set β) where
+  smul_zero _ := image_singleton.trans <| by rw [smul_zero, singleton_zero]
+
+scoped[Pointwise] attribute [instance] Set.smulZeroClassSet
+
+lemma smul_zero_subset (s : Set α) : s • (0 : Set β) ⊆ 0 := by simp [subset_def, mem_smul]
+
+lemma Nonempty.smul_zero (hs : s.Nonempty) : s • (0 : Set β) = 0 :=
+  s.smul_zero_subset.antisymm <| by simpa [mem_smul] using hs
+
+lemma zero_mem_smul_set (h : (0 : β) ∈ t) : (0 : β) ∈ a • t := ⟨0, h, smul_zero _⟩
+
+variable [Zero α] [NoZeroSMulDivisors α β]
+
+lemma zero_mem_smul_set_iff (ha : a ≠ 0) : (0 : β) ∈ a • t ↔ (0 : β) ∈ t := by
+  refine ⟨?_, zero_mem_smul_set⟩
+  rintro ⟨b, hb, h⟩
+  rwa [(eq_zero_or_eq_zero_of_smul_eq_zero h).resolve_left ha] at hb
+
+end SMulZeroClass
+section SMulWithZero
+
+variable [Zero α] [Zero β] [SMulWithZero α β] {s : Set α} {t : Set β}
+
+/-!
+Note that we have neither `SMulWithZero α (Set β)` nor `SMulWithZero (Set α) (Set β)`
+because `0 * ∅ ≠ 0`.
+-/
+
+lemma zero_smul_subset (t : Set β) : (0 : Set α) • t ⊆ 0 := by simp [subset_def, mem_smul]
+
+lemma Nonempty.zero_smul (ht : t.Nonempty) : (0 : Set α) • t = 0 :=
+  t.zero_smul_subset.antisymm <| by simpa [mem_smul] using ht
+
+/-- A nonempty set is scaled by zero to the singleton set containing 0. -/
+@[simp] lemma zero_smul_set {s : Set β} (h : s.Nonempty) : (0 : α) • s = (0 : Set β) := by
+  simp only [← image_smul, image_eta, zero_smul, h.image_const, singleton_zero]
+
+lemma zero_smul_set_subset (s : Set β) : (0 : α) • s ⊆ 0 :=
+  image_subset_iff.2 fun x _ ↦ zero_smul α x
+
+lemma subsingleton_zero_smul_set (s : Set β) : ((0 : α) • s).Subsingleton :=
+  subsingleton_singleton.anti <| zero_smul_set_subset s
+
+variable [NoZeroSMulDivisors α β] {a : α}
+
+lemma zero_mem_smul_iff : 0 ∈ s • t ↔ 0 ∈ s ∧ t.Nonempty ∨ 0 ∈ t ∧ s.Nonempty where
+  mp := by
+    rintro ⟨a, ha, b, hb, h⟩
+    obtain rfl | rfl := eq_zero_or_eq_zero_of_smul_eq_zero h
+    · exact Or.inl ⟨ha, b, hb⟩
+    · exact Or.inr ⟨hb, a, ha⟩
+  mpr := by
+    rintro (⟨hs, b, hb⟩ | ⟨ht, a, ha⟩)
+    · exact ⟨0, hs, b, hb, zero_smul _ _⟩
+    · exact ⟨a, ha, 0, ht, smul_zero _⟩
+
+end SMulWithZero
+
+/-- If the scalar multiplication `(· • ·) : α → β → β` is distributive,
+then so is `(· • ·) : α → Set β → Set β`. -/
+protected def distribSMulSet [AddZeroClass β] [DistribSMul α β] : DistribSMul α (Set β) where
+  smul_add _ _ _ := image_image2_distrib <| smul_add _
+
+scoped[Pointwise] attribute [instance] Set.distribSMulSet
+
+/-- A distributive multiplicative action of a monoid on an additive monoid `β` gives a distributive
+multiplicative action on `Set β`. -/
+protected def distribMulActionSet [Monoid α] [AddMonoid β] [DistribMulAction α β] :
+    DistribMulAction α (Set β) where
+  smul_add := smul_add
+  smul_zero := smul_zero
+
+/-- A multiplicative action of a monoid on a monoid `β` gives a multiplicative action on `Set β`. -/
+protected def mulDistribMulActionSet [Monoid α] [Monoid β] [MulDistribMulAction α β] :
+    MulDistribMulAction α (Set β) where
+  smul_mul _ _ _ := image_image2_distrib <| smul_mul' _
+  smul_one _ := image_singleton.trans <| by rw [smul_one, singleton_one]
+
+scoped[Pointwise] attribute [instance] Set.distribMulActionSet Set.mulDistribMulActionSet
+
+instance instNoZeroSMulDivisors [Zero α] [Zero β] [SMul α β] [NoZeroSMulDivisors α β] :
+    NoZeroSMulDivisors (Set α) (Set β) where
+  eq_zero_or_eq_zero_of_smul_eq_zero {s t} h := by
+    by_contra! H
+    have hst : (s • t).Nonempty := h.symm.subst zero_nonempty
+    rw [Ne, ← hst.of_smul_left.subset_zero_iff, Ne,
+      ← hst.of_smul_right.subset_zero_iff] at H
+    simp only [not_subset, mem_zero] at H
+    obtain ⟨⟨a, hs, ha⟩, b, ht, hb⟩ := H
+    exact (eq_zero_or_eq_zero_of_smul_eq_zero <| h.subset <| smul_mem_smul hs ht).elim ha hb
+
+instance noZeroSMulDivisors_set [Zero α] [Zero β] [SMul α β] [NoZeroSMulDivisors α β] :
+    NoZeroSMulDivisors α (Set β) where
+  eq_zero_or_eq_zero_of_smul_eq_zero {a s} h := by
+    by_contra! H
+    have hst : (a • s).Nonempty := h.symm.subst zero_nonempty
+    rw [Ne, Ne, ← hst.of_image.subset_zero_iff, not_subset] at H
+    obtain ⟨ha, b, ht, hb⟩ := H
+    exact (eq_zero_or_eq_zero_of_smul_eq_zero <| h.subset <| smul_mem_smul_set ht).elim ha hb
+
+instance [Zero α] [Mul α] [NoZeroDivisors α] : NoZeroDivisors (Set α) where
+  eq_zero_or_eq_zero_of_mul_eq_zero h := eq_zero_or_eq_zero_of_smul_eq_zero h
+
+section GroupWithZero
+variable [GroupWithZero α] [MulAction α β] {s t : Set β} {a : α}
+
+@[simp]
+lemma smul_mem_smul_set_iff₀ (ha : a ≠ 0) (A : Set β) (x : β) : a • x ∈ a • A ↔ x ∈ A :=
+  show Units.mk0 a ha • _ ∈ _ ↔ _ from smul_mem_smul_set_iff
+
+lemma mem_smul_set_iff_inv_smul_mem₀ (ha : a ≠ 0) (A : Set β) (x : β) : x ∈ a • A ↔ a⁻¹ • x ∈ A :=
+  show _ ∈ Units.mk0 a ha • _ ↔ _ from mem_smul_set_iff_inv_smul_mem
+
+lemma mem_inv_smul_set_iff₀ (ha : a ≠ 0) (A : Set β) (x : β) : x ∈ a⁻¹ • A ↔ a • x ∈ A :=
+  show _ ∈ (Units.mk0 a ha)⁻¹ • _ ↔ _ from mem_inv_smul_set_iff
+
+lemma preimage_smul₀ (ha : a ≠ 0) (t : Set β) : (fun x ↦ a • x) ⁻¹' t = a⁻¹ • t :=
+  preimage_smul (Units.mk0 a ha) t
+
+lemma preimage_smul_inv₀ (ha : a ≠ 0) (t : Set β) : (fun x ↦ a⁻¹ • x) ⁻¹' t = a • t :=
+  preimage_smul (Units.mk0 a ha)⁻¹ t
+
+@[simp]
+lemma smul_set_subset_smul_set_iff₀ (ha : a ≠ 0) {A B : Set β} : a • A ⊆ a • B ↔ A ⊆ B :=
+  show Units.mk0 a ha • _ ⊆ _ ↔ _ from smul_set_subset_smul_set_iff
+
+@[deprecated (since := "2024-12-28")]
+alias set_smul_subset_set_smul_iff₀ := smul_set_subset_smul_set_iff₀
+
+lemma smul_set_subset_iff₀ (ha : a ≠ 0) {A B : Set β} : a • A ⊆ B ↔ A ⊆ a⁻¹ • B :=
+  show Units.mk0 a ha • _ ⊆ _ ↔ _ from smul_set_subset_iff_subset_inv_smul_set
+
+@[deprecated (since := "2024-12-28")] alias set_smul_subset_iff₀ := smul_set_subset_iff₀
+
+lemma subset_smul_set_iff₀ (ha : a ≠ 0) {A B : Set β} : A ⊆ a • B ↔ a⁻¹ • A ⊆ B :=
+  show _ ⊆ Units.mk0 a ha • _ ↔ _ from subset_smul_set_iff
+
+@[deprecated (since := "2024-12-28")] alias subset_set_smul_iff₀ := subset_smul_set_iff₀
+
+lemma smul_set_inter₀ (ha : a ≠ 0) : a • (s ∩ t) = a • s ∩ a • t :=
+  show Units.mk0 a ha • _ = _ from smul_set_inter
+
+lemma smul_set_sdiff₀ (ha : a ≠ 0) : a • (s \ t) = a • s \ a • t :=
+  image_diff (MulAction.injective₀ ha) _ _
+
+open scoped symmDiff in
+lemma smul_set_symmDiff₀ (ha : a ≠ 0) : a • s ∆ t = (a • s) ∆ (a • t) :=
+  image_symmDiff (MulAction.injective₀ ha) _ _
+
+lemma smul_set_univ₀ (ha : a ≠ 0) : a • (univ : Set β) = univ :=
+  image_univ_of_surjective <| MulAction.surjective₀ ha
+
+lemma smul_univ₀ {s : Set α} (hs : ¬s ⊆ 0) : s • (univ : Set β) = univ :=
+  let ⟨a, ha, ha₀⟩ := not_subset.1 hs
+  eq_univ_of_forall fun b ↦ ⟨a, ha, a⁻¹ • b, trivial, smul_inv_smul₀ ha₀ _⟩
+
+lemma smul_univ₀' {s : Set α} (hs : s.Nontrivial) : s • (univ : Set β) = univ :=
+  smul_univ₀ hs.not_subset_singleton
+
+open scoped RightActions in
+@[simp] lemma inv_smul_set_distrib₀ (a : α) (s : Set α) : (a • s)⁻¹ = s⁻¹ <• a⁻¹ := by
+  obtain rfl | ha := eq_or_ne a 0
+  · obtain rfl | hs := s.eq_empty_or_nonempty <;> simp [*]
+  · ext; simp [mem_smul_set_iff_inv_smul_mem₀, *]
+
+open scoped RightActions in
+@[simp] lemma inv_op_smul_set_distrib₀ (a : α) (s : Set α) : (s <• a)⁻¹ = a⁻¹ • s⁻¹ := by
+  obtain rfl | ha := eq_or_ne a 0
+  · obtain rfl | hs := s.eq_empty_or_nonempty <;> simp [*]
+  · ext; simp [mem_smul_set_iff_inv_smul_mem₀, *]
+
+end GroupWithZero
+end Set

--- a/Mathlib/Algebra/GroupWithZero/Pointwise/Finset.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pointwise/Finset.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
+import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set
 
 /-!
 # Pointwise operations of finsets in a group with zero

--- a/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Basic.lean
@@ -17,7 +17,7 @@ set multiplication, set addition, pointwise addition, pointwise multiplication,
 pointwise subtraction
 -/
 
-assert_not_exists OrderedAddCommMonoid Ring
+assert_not_exists MulAction OrderedAddCommMonoid Ring
 
 open Function
 open scoped Pointwise
@@ -53,6 +53,8 @@ lemma Nonempty.div_zero (hs : s.Nonempty) : s / 0 = 0 :=
 
 lemma Nonempty.zero_div (hs : s.Nonempty) : 0 / s = 0 :=
   s.zero_div_subset.antisymm <| by simpa [mem_div] using hs
+
+@[simp] protected lemma inv_zero : (0 : Set α)⁻¹ = 0 := by ext; simp
 
 end GroupWithZero
 end Set

--- a/Mathlib/Algebra/Module/PointwisePi.lean
+++ b/Mathlib/Algebra/Module/PointwisePi.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex J. Best
 -/
 import Mathlib.Algebra.Group.Action.Pi
-import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.Algebra.Group.Action.Pointwise.Set
+import Mathlib.Algebra.GroupWithZero.Units.Basic
 
 /-!
 # Pointwise actions on sets in Pi types

--- a/Mathlib/Algebra/Order/UpperLower.lean
+++ b/Mathlib/Algebra/Order/UpperLower.lean
@@ -3,9 +3,9 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import Mathlib.Algebra.Group.Action.Pointwise.Set
 import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Algebra.Order.Group.OrderIso
-import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Order.UpperLower.Basic
 /-!
 # Algebraic operations on upper/lower sets

--- a/Mathlib/Algebra/Ring/Action/Pointwise/Set.lean
+++ b/Mathlib/Algebra/Ring/Action/Pointwise/Set.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Pointwise.Set.Basic
+import Mathlib.Algebra.Module.Defs
+
+/-!
+# Pointwise operations of sets in a ring
+
+This file proves properties of pointwise operations of sets in a ring.
+
+## Tags
+
+set multiplication, set addition, pointwise addition, pointwise multiplication,
+pointwise subtraction
+-/
+
+assert_not_exists OrderedAddCommMonoid Field
+
+open Function
+open scoped Pointwise
+
+variable {α β : Type*}
+
+namespace Set
+
+section Monoid
+variable [Monoid α] [AddGroup β] [DistribMulAction α β] (a : α) (s : Set α) (t : Set β)
+
+@[simp]
+lemma smul_set_neg : a • -t = -(a • t) := by
+  simp_rw [← image_smul, ← image_neg_eq_neg, image_image, smul_neg]
+
+@[simp]
+protected lemma smul_neg : s • -t = -(s • t) := by
+  simp_rw [← image_neg_eq_neg]
+  exact image_image2_right_comm smul_neg
+
+end Monoid
+
+section Semiring
+variable [Semiring α] [AddCommMonoid β] [Module α β]
+
+lemma add_smul_subset (a b : α) (s : Set β) : (a + b) • s ⊆ a • s + b • s := by
+  rintro _ ⟨x, hx, rfl⟩
+  simpa only [add_smul] using add_mem_add (smul_mem_smul_set hx) (smul_mem_smul_set hx)
+
+end Semiring
+
+section Ring
+variable [Ring α] [AddCommGroup β] [Module α β] (a : α) (s : Set α) (t : Set β)
+
+@[simp]
+lemma neg_smul_set : -a • t = -(a • t) := by
+  simp_rw [← image_smul, ← image_neg_eq_neg, image_image, neg_smul]
+
+@[simp]
+protected lemma neg_smul : -s • t = -(s • t) := by
+  simp_rw [← image_neg_eq_neg]
+  exact image2_image_left_comm neg_smul
+
+end Ring
+end Set

--- a/Mathlib/Algebra/Ring/Pointwise/Finset.lean
+++ b/Mathlib/Algebra/Ring/Pointwise/Finset.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 import Mathlib.Algebra.Ring.Pointwise.Set
+import Mathlib.Algebra.Module.Defs
 
 /-!
 # Pointwise operations of sets in a ring

--- a/Mathlib/Algebra/Ring/Pointwise/Set.lean
+++ b/Mathlib/Algebra/Ring/Pointwise/Set.lean
@@ -17,7 +17,7 @@ set multiplication, set addition, pointwise addition, pointwise multiplication,
 pointwise subtraction
 -/
 
-assert_not_exists OrderedAddCommMonoid
+assert_not_exists MulAction OrderedAddCommMonoid Field
 
 open Function
 open scoped Pointwise

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -6,6 +6,7 @@ Authors: Alexander Bentkamp, Yury Kudryashov, Yaël Dillies
 import Mathlib.Algebra.Order.BigOperators.Ring.Finset
 import Mathlib.Algebra.Order.Module.OrderedSMul
 import Mathlib.Algebra.Order.Module.Synonym
+import Mathlib.Algebra.Ring.Action.Pointwise.Set
 import Mathlib.Analysis.Convex.Star
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.NoncommRing

--- a/Mathlib/Analysis/Convex/Star.lean
+++ b/Mathlib/Analysis/Convex/Star.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set
 import Mathlib.Algebra.Module.LinearMap.Prod
 import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.Algebra.Order.Group.Instances

--- a/Mathlib/Data/Real/Pointwise.lean
+++ b/Mathlib/Data/Real/Pointwise.lean
@@ -3,10 +3,10 @@ Copyright (c) 2021 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Eric Wieser
 -/
+import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set
 import Mathlib.Algebra.Order.Module.OrderedSMul
 import Mathlib.Algebra.Order.Module.Pointwise
 import Mathlib.Data.Real.Archimedean
-import Mathlib.Data.Set.Pointwise.SMul
 
 /-!
 # Pointwise operations on sets of reals

--- a/Mathlib/Data/Set/Pointwise/Iterate.lean
+++ b/Mathlib/Data/Set/Pointwise/Iterate.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Oliver Nash. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
-import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.Algebra.Group.Action.Pointwise.Set
 import Mathlib.Dynamics.FixedPoints.Basic
 
 /-!

--- a/Mathlib/Data/Set/Pointwise/Support.lean
+++ b/Mathlib/Data/Set/Pointwise/Support.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 import Mathlib.Algebra.Group.Support
-import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set
 
 /-!
 # Support of a function composed with a scalar action

--- a/Mathlib/GroupTheory/CoprodI.lean
+++ b/Mathlib/GroupTheory/CoprodI.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Wärn, Joachim Breitner
 -/
 import Mathlib.Algebra.Group.Action.End
+import Mathlib.Algebra.Group.Action.Pointwise.Set
 import Mathlib.Algebra.Group.Submonoid.Membership
-import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.GroupTheory.Congruence.Basic
 import Mathlib.GroupTheory.FreeGroup.IsFreeGroup
 import Mathlib.SetTheory.Cardinal.Basic

--- a/Mathlib/GroupTheory/Coset/Basic.lean
+++ b/Mathlib/GroupTheory/Coset/Basic.lean
@@ -3,10 +3,10 @@ Copyright (c) 2018 Mitchell Rowett. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mitchell Rowett, Kim Morrison
 -/
+import Mathlib.Algebra.Group.Action.Pointwise.Set
 import Mathlib.Algebra.Group.Subgroup.Basic
 import Mathlib.Algebra.Quotient
 import Mathlib.Data.Fintype.Card
-import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Data.Setoid.Basic
 import Mathlib.GroupTheory.Coset.Defs
 

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -3,10 +3,14 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+import Mathlib.Algebra.Group.Action.End
+import Mathlib.Algebra.Group.Action.Pointwise.Set
+import Mathlib.Algebra.Group.Action.Prod
 import Mathlib.Algebra.Group.Subgroup.Map
+import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 import Mathlib.Data.Finite.Sigma
 import Mathlib.Data.Set.Finite.Range
-import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Data.Setoid.Basic
 import Mathlib.GroupTheory.GroupAction.Defs
 

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -3,8 +3,8 @@ Copyright (c) 2024 Emilie Burgun. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Emilie Burgun
 -/
+import Mathlib.Algebra.Group.Action.Pointwise.Set
 import Mathlib.Algebra.Group.Commute.Basic
-import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Dynamics.PeriodicPts.Defs
 import Mathlib.GroupTheory.GroupAction.Defs
 

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -4,12 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov, Frédéric Dupuis,
   Heather Macbeth
 -/
+import Mathlib.Algebra.Group.Action.Pointwise.Set
 import Mathlib.Algebra.Module.Prod
 import Mathlib.Algebra.Module.Submodule.EqLocus
 import Mathlib.Algebra.Module.Submodule.Equiv
 import Mathlib.Algebra.Module.Submodule.RestrictScalars
 import Mathlib.Algebra.NoZeroSMulDivisors.Basic
-import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.LinearAlgebra.Span.Defs
 import Mathlib.Order.CompactlyGenerated.Basic
 import Mathlib.Order.OmegaCompletePartialOrder

--- a/Mathlib/Order/Filter/Pointwise.lean
+++ b/Mathlib/Order/Filter/Pointwise.lean
@@ -3,9 +3,11 @@ Copyright (c) 2019 Zhouhang Zhou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou, Yaël Dillies
 -/
+import Mathlib.Algebra.Group.Action.Pointwise.Set
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Group.OrderIso
-import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.Algebra.Ring.Defs
+import Mathlib.Algebra.SMulWithZero
 import Mathlib.Order.Filter.AtTopBot.Map
 import Mathlib.Order.Filter.Finite
 import Mathlib.Order.Filter.NAry

--- a/Mathlib/RingTheory/Ideal/Colon.lean
+++ b/Mathlib/RingTheory/Ideal/Colon.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
+import Mathlib.Algebra.Ring.Action.Pointwise.Set
 import Mathlib.LinearAlgebra.Quotient.Defs
 import Mathlib.RingTheory.Ideal.Maps
 

--- a/Mathlib/Topology/Algebra/ConstMulAction.lean
+++ b/Mathlib/Topology/Algebra/ConstMulAction.lean
@@ -3,9 +3,9 @@ Copyright (c) 2021 Alex Kontorovich, Heather Macbeth. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex Kontorovich, Heather Macbeth
 -/
+import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set
 import Mathlib.Algebra.Module.ULift
 import Mathlib.Algebra.Order.Group.Synonym
-import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.GroupTheory.GroupAction.Defs
 import Mathlib.Topology.Algebra.Constructions
 import Mathlib.Topology.Algebra.Support

--- a/Mathlib/Topology/Algebra/Ring/Basic.lean
+++ b/Mathlib/Topology/Algebra/Ring/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl
 -/
 import Mathlib.Algebra.Order.AbsoluteValue.Basic
+import Mathlib.Algebra.Ring.Opposite
 import Mathlib.Algebra.Ring.Prod
 import Mathlib.Algebra.Ring.Subring.Basic
 import Mathlib.Topology.Algebra.Group.Basic

--- a/Mathlib/Topology/Bornology/Absorbs.lean
+++ b/Mathlib/Topology/Bornology/Absorbs.lean
@@ -3,7 +3,8 @@ Copyright (c) 2020 Jean Lo, Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jean Lo, Yury Kudryashov
 -/
-import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set
+import Mathlib.Algebra.Ring.Action.Pointwise.Set
 import Mathlib.Topology.Bornology.Basic
 
 /-!

--- a/Mathlib/Topology/MetricSpace/IsometricSMul.lean
+++ b/Mathlib/Topology/MetricSpace/IsometricSMul.lean
@@ -3,7 +3,8 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.Algebra.GroupWithZero.Pointwise.Set.Basic
+import Mathlib.Algebra.Ring.Pointwise.Set
 import Mathlib.Topology.MetricSpace.Isometry
 import Mathlib.Topology.MetricSpace.Lipschitz
 


### PR DESCRIPTION
Move the content of `Data.Set.Pointwise.SMul` into three new files:
* `Algebra.Group.Action.Pointwise.Set` for lemmas about monoids/groups
* `Algebra.GroupWithZero.Action.Pointwise.Set` for lemmas about groups with zero. See https://github.com/leanprover-community/mathlib3/pull/11486 for the copyright header.
* `Algebra.Ring.Action.Pointwise.Set` for lemmas about rings. See https://github.com/leanprover-community/mathlib3/pull/11486 for the copyright header.
* Actually, there is a handful of lemmas that can simply be moved to existing earlier files.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [x] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #22323

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
