### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Matching): Interactions between `spanningCoe`, `IsAlternating` and `IsCycles`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -403,15 +403,6 @@ lemma induce_sUnion_connected_of_pairwise_not_disjoint {S : Set (Set V)} (Sn : S
   refine ⟨s ∪ t, Set.union_subset (Set.subset_sUnion_of_mem sS) (Set.subset_sUnion_of_mem tS),
           Or.inl vs, Or.inr wt, induce_union_connected (Sc sS) (Sc tS) (Snd sS tS) _ _⟩
 
-lemma ConnectedComponent.induce_supp_spanningCoe_adj_iff {v w : V} (c : G.ConnectedComponent) :
-  (G.induce c.supp).spanningCoe.Adj v w ↔ v ∈ c.supp ∧ G.Adj v w := by
-  by_cases h : v ∈ c.supp
-  · refine ⟨by aesop, ?_⟩
-    intro h'
-    have : w ∈ c.supp := by rwa [c.mem_supp_iff_of_adj h'.2] at h
-    aesop
-  · aesop
-
 lemma extend_finset_to_connected (Gpc : G.Preconnected) {t : Finset V} (tn : t.Nonempty) :
     ∃ (t' : Finset V), t ⊆ t' ∧ (G.induce (t' : Set V)).Connected := by
   classical

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -403,6 +403,15 @@ lemma induce_sUnion_connected_of_pairwise_not_disjoint {S : Set (Set V)} (Sn : S
   refine ⟨s ∪ t, Set.union_subset (Set.subset_sUnion_of_mem sS) (Set.subset_sUnion_of_mem tS),
           Or.inl vs, Or.inr wt, induce_union_connected (Sc sS) (Sc tS) (Snd sS tS) _ _⟩
 
+lemma ConnectedComponent.induce_supp_spanningCoe_adj_iff {v w : V} (c : G.ConnectedComponent) :
+  (G.induce c.supp).spanningCoe.Adj v w ↔ v ∈ c.supp ∧ G.Adj v w := by
+  by_cases h : v ∈ c.supp
+  · refine ⟨by aesop, ?_⟩
+    intro h'
+    have : w ∈ c.supp := by rwa [c.mem_supp_iff_of_adj h'.2] at h
+    aesop
+  · aesop
+
 lemma extend_finset_to_connected (Gpc : G.Preconnected) {t : Finset V} (tn : t.Nonempty) :
     ∃ (t' : Finset V), t ⊆ t' ∧ (G.induce (t' : Set V)).Connected := by
   classical

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -243,7 +243,7 @@ lemma IsPerfectMatching.induce_connectedComponent_isMatching (h : M.IsPerfectMat
   simpa [h.2.verts_eq_univ] using h.1.induce_connectedComponent c
 
 @[simp]
-lemma IsPerfectMatching.toSubgraph_spanningCoe_iff (h : M.spanningCoe ≤ G') :
+lemma IsPerfectMatching.toSubgraph_iff (h : M.spanningCoe ≤ G') :
     (G'.toSubgraph M.spanningCoe h).IsPerfectMatching ↔ M.IsPerfectMatching := by
   simp only [isPerfectMatching_iff, toSubgraph_adj, spanningCoe_adj]
 
@@ -339,7 +339,7 @@ lemma IsCycles.other_adj_of_adj (h : G.IsCycles) (hadj : G.Adj v w) :
   obtain ⟨w', hww'⟩ := (G.neighborSet v).exists_ne_of_one_lt_ncard (by omega) w
   exact ⟨w', ⟨hww'.2.symm, hww'.1⟩⟩
 
-lemma IsCycles.spanningCoe_induce_supp (c : G.ConnectedComponent) (h : G.IsCycles) :
+lemma IsCycles.induce_supp (c : G.ConnectedComponent) (h : G.IsCycles) :
     (G.induce c.supp).spanningCoe.IsCycles := by
   intro v ⟨w, hw⟩
   rw [mem_neighborSet, c.adj_spanningCoe_induce_supp] at hw
@@ -350,7 +350,7 @@ lemma IsCycles.spanningCoe_induce_supp (c : G.ConnectedComponent) (h : G.IsCycle
 
 open scoped symmDiff
 
-lemma Subgraph.IsPerfectMatching.symmDiff_spanningCoe_IsCycles
+lemma Subgraph.IsPerfectMatching.symmDiff_IsCycles
     {M : Subgraph G} {M' : Subgraph G'} (hM : M.IsPerfectMatching)
     (hM' : M'.IsPerfectMatching) : (M.spanningCoe ∆ M'.spanningCoe).IsCycles := by
   intro v
@@ -380,7 +380,7 @@ def IsAlternating (G G' : SimpleGraph V) :=
 lemma IsAlternating.mono {G'' : SimpleGraph V} (halt : G.IsAlternating G') (h : G'' ≤ G) :
     G''.IsAlternating G' := fun _ _ _ hww' hvw hvw' ↦ halt hww' (h hvw) (h hvw')
 
-lemma IsPerfectMatching.symmDiff_spanningCoe_of_isAlternating (hM : M.IsPerfectMatching)
+lemma IsPerfectMatching.symmDiff_of_isAlternating (hM : M.IsPerfectMatching)
     (hG' : G'.IsAlternating M.spanningCoe) (hG'cyc : G'.IsCycles) :
     (⊤ : Subgraph (M.spanningCoe ∆ G')).IsPerfectMatching := by
   rw [Subgraph.isPerfectMatching_iff]
@@ -406,7 +406,7 @@ lemma IsPerfectMatching.symmDiff_spanningCoe_of_isAlternating (hM : M.IsPerfectM
     · have ⟨w', hw'⟩ := hG'cyc.other_adj_of_adj hr.1
       simp_all [show M.Adj v y ↔ ¬M.Adj v w' from by simpa using hG' hw'.1 hr.1 hw'.2]
 
-lemma IsPerfectMatching.symmDiff_spanningCoe_IsPerfectMatching_IsAlternating_left {M' : Subgraph G'}
+lemma IsPerfectMatching.isAlternating_symmDiff_left {M' : Subgraph G'}
     (hM : M.IsPerfectMatching) (hM' : M'.IsPerfectMatching) :
     (M.spanningCoe ∆ M'.spanningCoe).IsAlternating M.spanningCoe := by
   intro v w w' hww' hvw hvw'
@@ -418,6 +418,6 @@ lemma IsPerfectMatching.symmDiff_spanningCoe_IsPerfectMatching_IsAlternating_lef
 lemma IsPerfectMatching.isAlternating_symmDiff_right
     {M' : Subgraph G'} (hM : M.IsPerfectMatching) (hM' : M'.IsPerfectMatching) :
     (M.spanningCoe ∆ M'.spanningCoe).IsAlternating M'.spanningCoe := by
-  simpa [symmDiff_comm] using symmDiff_spanningCoe_IsPerfectMatching_IsAlternating_left hM' hM
+  simpa [symmDiff_comm] using isAlternating_symmDiff_left hM' hM
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -413,7 +413,7 @@ lemma IsPerfectMatching.symmDiff_spanningCoe_IsPerfectMatching_IsAlternating_lef
   intro v w w' hww' hvw hvw'
   obtain ⟨v1, ⟨hm1, hv1⟩⟩ := hM.1 (hM.2 v)
   obtain ⟨v2, ⟨hm2, hv2⟩⟩ := hM'.1 (hM'.2 v)
-  simp only [ne_eq, symmDiff_def, sup_adj, sdiff_adj, Subgraph.spanningCoe_adj] at *
+  simp only [symmDiff_def] at *
   aesop
 
 lemma IsPerfectMatching.symmDiff_spanningCoe_IsPerfectMatching_IsAlternating_right

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -5,7 +5,6 @@ Authors: Alena Gusakov, Arthur Paulino, Kyle Miller, Pim Otte
 -/
 import Mathlib.Combinatorics.SimpleGraph.DegreeSum
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting
-import Mathlib.Combinatorics.SimpleGraph.Connectivity.Subgraph
 import Mathlib.Data.Fintype.Order
 import Mathlib.Data.Set.Functor
 

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -342,11 +342,11 @@ lemma IsCycles.other_adj_of_adj (h : G.IsCycles) (hadj : G.Adj v w) :
 lemma IsCycles.spanningCoe_induce_supp (c : G.ConnectedComponent) (h : G.IsCycles) :
     (G.induce c.supp).spanningCoe.IsCycles := by
   intro v ⟨w, hw⟩
-  rw [mem_neighborSet, c.induce_supp_spanningCoe_adj_iff] at hw
+  rw [mem_neighborSet, c.adj_spanningCoe_induce_supp] at hw
   rw [← h ⟨w, hw.2⟩]
   congr
   ext w'
-  simp only [mem_neighborSet, c.induce_supp_spanningCoe_adj_iff, hw, true_and]
+  simp only [mem_neighborSet, c.adj_spanningCoe_induce_supp, hw, true_and]
 
 open scoped symmDiff
 
@@ -382,7 +382,7 @@ lemma IsAlternating.mono {G'' : SimpleGraph V} (halt : G.IsAlternating G') (h : 
 
 lemma IsPerfectMatching.symmDiff_spanningCoe_of_isAlternating (hM : M.IsPerfectMatching)
     (hG' : G'.IsAlternating M.spanningCoe) (hG'cyc : G'.IsCycles) :
-    ((M.spanningCoe ∆ G').toSubgraph rfl).IsPerfectMatching := by
+    (⊤ : Subgraph (M.spanningCoe ∆ G')).IsPerfectMatching := by
   rw [Subgraph.isPerfectMatching_iff]
   intro v
   simp only [toSubgraph_adj, symmDiff_def, sup_adj, sdiff_adj, Subgraph.spanningCoe_adj]
@@ -391,21 +391,20 @@ lemma IsPerfectMatching.symmDiff_spanningCoe_of_isAlternating (hM : M.IsPerfectM
   · obtain ⟨w', hw'⟩ := hG'cyc.other_adj_of_adj h
     have hmadj :  M.Adj v w ↔ ¬M.Adj v w' := by simpa using hG' hw'.1 h hw'.2
     use w'
-    simp only [hmadj.mp hw.1, hw'.2, not_true_eq_false, and_self, not_false_eq_true, or_true,
-      true_and]
+    simp only [Subgraph.top_adj, sup_adj, sdiff_adj, Subgraph.spanningCoe_adj, hmadj.mp hw.1, hw'.2,
+      not_true_eq_false, and_self, not_false_eq_true, or_true, true_and]
     rintro y (hl | hr)
     · aesop
     · obtain ⟨w'', hw''⟩ := hG'cyc.other_adj_of_adj hr.1
       by_contra! hc
-      simp_all only [show M.Adj v y ↔ ¬M.Adj v w' from by simpa using hG' hc hr.1 hw'.2,
-        not_false_eq_true, ne_eq, iff_true, not_true_eq_false, and_false]
+      simp_all [show M.Adj v y ↔ ¬M.Adj v w' from by simpa using hG' hc hr.1 hw'.2]
   · use w
-    simp only [hw.1, h, not_false_eq_true, and_self, not_true_eq_false, or_false, true_and]
+    simp only [Subgraph.top_adj, sup_adj, sdiff_adj, Subgraph.spanningCoe_adj, hw.1, h,
+      not_false_eq_true, and_self, not_true_eq_false, or_false, true_and]
     rintro y (hl | hr)
     · exact hw.2 _ hl.1
     · have ⟨w', hw'⟩ := hG'cyc.other_adj_of_adj hr.1
-      simp_all only [show M.Adj v y ↔ ¬M.Adj v w' from by simpa using hG' hw'.1 hr.1 hw'.2, not_not,
-        ne_eq, and_false]
+      simp_all [show M.Adj v y ↔ ¬M.Adj v w' from by simpa using hG' hw'.1 hr.1 hw'.2]
 
 lemma IsPerfectMatching.symmDiff_spanningCoe_IsPerfectMatching_IsAlternating_left {M' : Subgraph G'}
     (hM : M.IsPerfectMatching) (hM' : M'.IsPerfectMatching) :

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -382,7 +382,7 @@ lemma IsAlternating.mono {G'' : SimpleGraph V} (halt : G.IsAlternating G') (h : 
 
 lemma IsPerfectMatching.symmDiff_spanningCoe_of_isAlternating (hM : M.IsPerfectMatching)
     (hG' : G'.IsAlternating M.spanningCoe) (hG'cyc : G'.IsCycles) :
-    (SimpleGraph.toSubgraph (M.spanningCoe ∆ G') (by rfl)).IsPerfectMatching := by
+    ((M.spanningCoe ∆ G').toSubgraph rfl).IsPerfectMatching := by
   rw [Subgraph.isPerfectMatching_iff]
   intro v
   simp only [toSubgraph_adj, symmDiff_def, sup_adj, sdiff_adj, Subgraph.spanningCoe_adj]
@@ -411,12 +411,12 @@ lemma IsPerfectMatching.symmDiff_spanningCoe_IsPerfectMatching_IsAlternating_lef
     (hM : M.IsPerfectMatching) (hM' : M'.IsPerfectMatching) :
     (M.spanningCoe ∆ M'.spanningCoe).IsAlternating M.spanningCoe := by
   intro v w w' hww' hvw hvw'
-  obtain ⟨v1, ⟨hm1, hv1⟩⟩ := hM.1 (hM.2 v)
-  obtain ⟨v2, ⟨hm2, hv2⟩⟩ := hM'.1 (hM'.2 v)
+  obtain ⟨v1, hm1, hv1⟩ := hM.1 (hM.2 v)
+  obtain ⟨v2, hm2, hv2⟩ := hM'.1 (hM'.2 v)
   simp only [symmDiff_def] at *
   aesop
 
-lemma IsPerfectMatching.symmDiff_spanningCoe_IsPerfectMatching_IsAlternating_right
+lemma IsPerfectMatching.isAlternating_symmDiff_right
     {M' : Subgraph G'} (hM : M.IsPerfectMatching) (hM' : M'.IsPerfectMatching) :
     (M.spanningCoe ∆ M'.spanningCoe).IsAlternating M'.spanningCoe := by
   simpa [symmDiff_comm] using symmDiff_spanningCoe_IsPerfectMatching_IsAlternating_left hM' hM

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -5,6 +5,7 @@ Authors: Alena Gusakov, Arthur Paulino, Kyle Miller, Pim Otte
 -/
 import Mathlib.Combinatorics.SimpleGraph.DegreeSum
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting
+import Mathlib.Combinatorics.SimpleGraph.Connectivity.Subgraph
 import Mathlib.Data.Fintype.Order
 import Mathlib.Data.Set.Functor
 
@@ -339,14 +340,14 @@ lemma IsCycles.other_adj_of_adj (h : G.IsCycles) (hadj : G.Adj v w) :
   obtain ⟨w', hww'⟩ := (G.neighborSet v).exists_ne_of_one_lt_ncard (by omega) w
   exact ⟨w', ⟨hww'.2.symm, hww'.1⟩⟩
 
-lemma induce_component_IsCycles (c : G.ConnectedComponent) (h : G.IsCycles)
-  : (G.induce c.supp).spanningCoe.IsCycles := by
+lemma IsCycles.spanningCoe_induce_supp (c : G.ConnectedComponent) (h : G.IsCycles) :
+    (G.induce c.supp).spanningCoe.IsCycles := by
   intro v ⟨w, hw⟩
   rw [mem_neighborSet, c.induce_supp_spanningCoe_adj_iff] at hw
   rw [← h ⟨w, hw.2⟩]
   congr
   ext w'
-  simp only [mem_neighborSet, induce_component_spanningCoe_Adj, hw, true_and]
+  simp only [mem_neighborSet, c.induce_supp_spanningCoe_adj_iff, hw, true_and]
 
 open scoped symmDiff
 

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -350,7 +350,7 @@ lemma IsCycles.induce_supp (c : G.ConnectedComponent) (h : G.IsCycles) :
 
 open scoped symmDiff
 
-lemma Subgraph.IsPerfectMatching.symmDiff_IsCycles
+lemma Subgraph.IsPerfectMatching.symmDiff_isCycles
     {M : Subgraph G} {M' : Subgraph G'} (hM : M.IsPerfectMatching)
     (hM' : M'.IsPerfectMatching) : (M.spanningCoe ∆ M'.spanningCoe).IsCycles := by
   intro v

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -1079,6 +1079,14 @@ lemma mem_supp_iff_of_adj {v w : V} (c : G.ConnectedComponent) (hadj : G.Adj v w
   · exact hadj.symm
   · exact hadj
 
+lemma induce_supp_spanningCoe_adj_iff {v w : V} (c : G.ConnectedComponent) :
+  (G.induce c.supp).spanningCoe.Adj v w ↔ v ∈ c.supp ∧ G.Adj v w := by
+  by_cases h : v ∈ c.supp
+  · refine ⟨by aesop, ?_⟩
+    intro h'
+    have : w ∈ c.supp := by rwa [c.mem_supp_iff_of_adj h'.2] at h
+    aesop
+  · aesop
 
 theorem connectedComponentMk_mem {v : V} : v ∈ G.connectedComponentMk v :=
   rfl

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -1072,6 +1072,14 @@ theorem mem_supp_iff (C : G.ConnectedComponent) (v : V) :
     v ∈ C.supp ↔ G.connectedComponentMk v = C :=
   Iff.rfl
 
+lemma mem_supp_iff_of_adj {v w : V} (c : G.ConnectedComponent) (hadj : G.Adj v w) :
+    v ∈ c.supp ↔ w ∈ c.supp := by
+  simp only [ConnectedComponent.mem_supp_iff] at *
+  constructor <;> intro h <;> simp only [← h] <;> apply connectedComponentMk_eq_of_adj
+  · exact hadj.symm
+  · exact hadj
+
+
 theorem connectedComponentMk_mem {v : V} : v ∈ G.connectedComponentMk v :=
   rfl
 

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -1079,7 +1079,7 @@ lemma mem_supp_iff_of_adj {v w : V} (c : G.ConnectedComponent) (hadj : G.Adj v w
   · exact hadj.symm
   · exact hadj
 
-lemma induce_supp_spanningCoe_adj_iff {v w : V} (c : G.ConnectedComponent) :
+lemma adj_spanningCoe_induce_supp {v w : V} (c : G.ConnectedComponent) :
   (G.induce c.supp).spanningCoe.Adj v w ↔ v ∈ c.supp ∧ G.Adj v w := by
   by_cases h : v ∈ c.supp
   · refine ⟨by aesop, ?_⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -1084,7 +1084,7 @@ lemma adj_spanningCoe_induce_supp {v w : V} (c : G.ConnectedComponent) :
   by_cases h : v ∈ c.supp
   · refine ⟨by aesop, ?_⟩
     intro h'
-    have : w ∈ c.supp := by rwa [c.mem_supp_iff_of_adj h'.2] at h
+    have : w ∈ c.supp := by rwa [c.mem_supp_congr_adj h'.2] at h
     aesop
   · aesop
 

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -1072,7 +1072,7 @@ theorem mem_supp_iff (C : G.ConnectedComponent) (v : V) :
     v ∈ C.supp ↔ G.connectedComponentMk v = C :=
   Iff.rfl
 
-lemma mem_supp_iff_of_adj {v w : V} (c : G.ConnectedComponent) (hadj : G.Adj v w) :
+lemma mem_supp_congr_adj {v w : V} (c : G.ConnectedComponent) (hadj : G.Adj v w) :
     v ∈ c.supp ↔ w ∈ c.supp := by
   simp only [ConnectedComponent.mem_supp_iff] at *
   constructor <;> intro h <;> simp only [← h] <;> apply connectedComponentMk_eq_of_adj
@@ -1080,7 +1080,7 @@ lemma mem_supp_iff_of_adj {v w : V} (c : G.ConnectedComponent) (hadj : G.Adj v w
   · exact hadj
 
 lemma adj_spanningCoe_induce_supp {v w : V} (c : G.ConnectedComponent) :
-  (G.induce c.supp).spanningCoe.Adj v w ↔ v ∈ c.supp ∧ G.Adj v w := by
+    (G.induce c.supp).spanningCoe.Adj v w ↔ v ∈ c.supp ∧ G.Adj v w := by
   by_cases h : v ∈ c.supp
   · refine ⟨by aesop, ?_⟩
     intro h'


### PR DESCRIPTION
Add basic results in preparation for Tutte's theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Tutte's theorem](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Tutte's.20theorem)
[Example usage in Tutte proof](https://github.com/pimotte/TutteLean/blob/84e794d61050982d25ea61b1c1e8a4996cfcf561/TutteLean/Part2.lean#L910)