### PR TITLE
[Merged by Bors] - feat(RingTheory/LocalRing): add instance `Unique (MaximalSpectrum R)` for a local ring `R`

### DIFF
--- a/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
+++ b/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
@@ -49,9 +49,9 @@ theorem eq_maximalIdeal {I : Ideal R} (hI : I.IsMaximal) : I = maximalIdeal R :=
   ExistsUnique.unique (maximal_ideal_unique R) hI <| maximalIdeal.isMaximal R
 
 /-- The maximal spectrum of a local ring is a singleton. -/
-instance : Unique (MaximalSpectrum R) :=
-  { default := ⟨maximalIdeal R, maximalIdeal.isMaximal R⟩
-    uniq := fun I ↦ MaximalSpectrum.ext_iff.mpr <| eq_maximalIdeal I.isMaximal }
+instance : Unique (MaximalSpectrum R) where
+  default := ⟨maximalIdeal R, maximalIdeal.isMaximal R⟩
+  uniq := fun I ↦ MaximalSpectrum.ext_iff.mpr <| eq_maximalIdeal I.isMaximal
 
 theorem le_maximalIdeal {J : Ideal R} (hJ : J ≠ ⊤) : J ≤ maximalIdeal R := by
   rcases Ideal.exists_le_maximal J hJ with ⟨M, hM1, hM2⟩

--- a/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
+++ b/Mathlib/RingTheory/LocalRing/MaximalIdeal/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.RingTheory.Jacobson.Ideal
 import Mathlib.RingTheory.LocalRing.MaximalIdeal.Defs
 import Mathlib.RingTheory.Localization.Basic
 import Mathlib.RingTheory.Nilpotent.Lemmas
+import Mathlib.RingTheory.Spectrum.Maximal.Defs
 
 /-!
 
@@ -46,6 +47,11 @@ variable {R}
 
 theorem eq_maximalIdeal {I : Ideal R} (hI : I.IsMaximal) : I = maximalIdeal R :=
   ExistsUnique.unique (maximal_ideal_unique R) hI <| maximalIdeal.isMaximal R
+
+/-- The maximal spectrum of a local ring is a singleton. -/
+instance : Unique (MaximalSpectrum R) :=
+  { default := ⟨maximalIdeal R, maximalIdeal.isMaximal R⟩
+    uniq := fun I ↦ MaximalSpectrum.ext_iff.mpr <| eq_maximalIdeal I.isMaximal }
 
 theorem le_maximalIdeal {J : Ideal R} (hJ : J ≠ ⊤) : J ≤ maximalIdeal R := by
   rcases Ideal.exists_le_maximal J hJ with ⟨M, hM1, hM2⟩


### PR DESCRIPTION
Introduce the instance `Unique (MaximalSpectrum R)` for a local ring `R`.

I need this for simpler proofs, for example that a local reduced artinian ring is a field (using `RingEquiv.piUnique` introduced in #20794). I think it's generally useful.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
