### PR TITLE
[Merged by Bors] - chore(GroupExtension/Defs): define `Section` and redefine `Splitting`

### DIFF
--- a/Mathlib/GroupTheory/GroupExtension/Defs.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Defs.lean
@@ -177,7 +177,7 @@ theorem rightHom_section (g : G) : S.rightHom (σ g) = g := σ.rightInverse_righ
 
 @[to_additive (attr := simp)]
 theorem rightHom_comp_section : S.rightHom ∘ σ = id :=
-  Function.RightInverse.comp_eq_id σ.rightInverse_rightHom
+  σ.rightInverse_rightHom.comp_eq_id
 
 end Section
 

--- a/Mathlib/GroupTheory/GroupExtension/Defs.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Defs.lean
@@ -38,6 +38,16 @@ For additive groups:
   of `G` by `N`
 - `SemidirectProduct.toGroupExtension φ`: the multiplicative group extension associated to the
   semidirect product coming from `φ : G →* MulAut N`, `1 → N → N ⋊[φ] G → G → 1`
+
+## TODO
+
+If `N` is abelian,
+
+- there is a bijection between `N`-conjugacy classes of
+  `(SemidirectProduct.toGroupExtension φ).Splitting` and `groupCohomology.H1`
+  (which will be available in `GroupTheory/GroupExtension/Abelian.lean` to be added in a later PR).
+- there is a bijection between equivalence classes of group extensions and `groupCohomology.H2`
+  (which is also stated as a TODO in `RepresentationTheory/GroupCohomology/LowDegree.lean`).
 -/
 
 variable (N E G : Type*)

--- a/Mathlib/GroupTheory/GroupExtension/Defs.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Defs.lean
@@ -248,9 +248,8 @@ theorem toGroupExtension_rightHom : (toGroupExtension φ).rightHom = SemidirectP
   rfl
 
 /-- A canonical splitting of the group extension associated to the semidirect product -/
-def inr_splitting : (toGroupExtension φ).Splitting := {
-  inr with
+def inr_splitting : (toGroupExtension φ).Splitting where
+  __ := inr
   rightInverse_rightHom := rightHom_inr
-}
 
 end SemidirectProduct

--- a/Mathlib/GroupTheory/GroupExtension/Defs.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Defs.lean
@@ -177,8 +177,7 @@ variable (σ : S.Section)
 theorem rightHom_section (g : G) : S.rightHom (σ g) = g := σ.rightInverse_rightHom g
 
 @[to_additive (attr := simp)]
-theorem rightHom_comp_section : S.rightHom ∘ σ = id :=
-  σ.rightInverse_rightHom.comp_eq_id
+theorem rightHom_comp_section : S.rightHom ∘ σ = id := σ.rightInverse_rightHom.comp_eq_id
 
 end Section
 

--- a/Mathlib/GroupTheory/GroupExtension/Defs.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Defs.lean
@@ -32,20 +32,12 @@ For additive groups:
       ↘︎ E' ↗︎️
 ```
 
-- `(Add?)GroupExtension.Splitting S`: structure for splittings of a group extension `S` of `G` by
-  `N` as section homomorphisms `G → E`
+- `(Add?)GroupExtension.Section S`: structure for right inverses to `rightHom` of a group extension
+  `S` of `G` by `N`
+- `(Add?)GroupExtension.Splitting S`: structure for section homomorphisms of a group extension `S`
+  of `G` by `N`
 - `SemidirectProduct.toGroupExtension φ`: the multiplicative group extension associated to the
   semidirect product coming from `φ : G →* MulAut N`, `1 → N → N ⋊[φ] G → G → 1`
-
-## TODO
-
-If `N` is abelian,
-
-- there is a bijection between `N`-conjugacy classes of
-  `(SemidirectProduct.toGroupExtension φ).Splitting` and `groupCohomology.H1`
-  (which will be available in `GroupTheory/GroupExtension/Abelian.lean` to be added in a later PR).
-- there is a bijection between equivalence classes of group extensions and `groupCohomology.H2`
-  (which is also stated as a TODO in `RepresentationTheory/GroupCohomology/LowDegree.lean`).
 -/
 
 variable (N E G : Type*)
@@ -84,20 +76,23 @@ namespace AddGroupExtension
 variable [AddGroup N] [AddGroup E] [AddGroup G] (S : AddGroupExtension N E G)
 
 /-- `AddGroupExtension`s are equivalent iff there is a homomorphism making a commuting diagram. -/
-structure Equiv {E' : Type*} [AddGroup E'] (S' : AddGroupExtension N E' G) where
-  /-- The homomorphism -/
-  toAddMonoidHom : E →+ E'
+structure Equiv {E' : Type*} [AddGroup E'] (S' : AddGroupExtension N E' G) extends E →+ E' where
   /-- The left-hand side of the diagram commutes. -/
   inl_comm : toAddMonoidHom.comp S.inl = S'.inl
   /-- The right-hand side of the diagram commutes. -/
   rightHom_comm : S'.rightHom.comp toAddMonoidHom = S.rightHom
 
+/-- `Section` of an additive group extension is a right inverse to `S.rightHom`. -/
+structure Section where
+  /-- The underlying function -/
+  toFun : G → E
+  /-- `Section` is a right inverse to `S.rightHom` -/
+  rightInverse_rightHom : Function.RightInverse toFun S.rightHom
+
 /-- `Splitting` of an additive group extension is a section homomorphism. -/
-structure Splitting where
-  /-- A section homomorphism -/
-  sectionHom : G →+ E
-  /-- The section is a left inverse of the projection map. -/
-  rightHom_comp_sectionHom : S.rightHom.comp sectionHom = AddMonoidHom.id G
+structure Splitting extends G →+ E, S.Section
+
+attribute [nolint docBlame] Splitting.toSection
 
 end AddGroupExtension
 
@@ -135,30 +130,58 @@ noncomputable def conjAct : E →* MulAut N where
 /-- The inclusion and a conjugation commute. -/
 theorem inl_conjAct_comm {e : E} {n : N} : S.inl (S.conjAct e n) = e * S.inl n * e⁻¹ := by
   simp only [conjAct, MonoidHom.coe_mk, OneHom.coe_mk, MulEquiv.trans_apply,
-    MonoidHom.apply_ofInjective_symm]
-  rfl
+    MonoidHom.apply_ofInjective_symm, MulAut.conjNormal_apply, MonoidHom.ofInjective_apply]
 
 /-- `GroupExtension`s are equivalent iff there is a homomorphism making a commuting diagram. -/
 @[to_additive]
-structure Equiv {E' : Type*} [Group E'] (S' : GroupExtension N E' G) where
-  /-- The homomorphism -/
-  toMonoidHom : E →* E'
+structure Equiv {E' : Type*} [Group E'] (S' : GroupExtension N E' G) extends E →* E' where
   /-- The left-hand side of the diagram commutes. -/
   inl_comm : toMonoidHom.comp S.inl = S'.inl
   /-- The right-hand side of the diagram commutes. -/
   rightHom_comm : S'.rightHom.comp toMonoidHom = S.rightHom
 
+/-- `Section` of a group extension is a right inverse to `S.rightHom`. -/
+@[to_additive]
+structure Section where
+  /-- The underlying function -/
+  toFun : G → E
+  /-- `Section` is a right inverse to `S.rightHom` -/
+  rightInverse_rightHom : Function.RightInverse toFun S.rightHom
+
+namespace Section
+
+@[to_additive]
+instance : FunLike S.Section G E where
+  coe := toFun
+  coe_injective' := fun ⟨_, _⟩ ⟨_, _⟩ _ ↦ by congr
+
+variable {S}
+
+@[to_additive (attr := simp)]
+theorem coe_mk (σ : G → E) (hσ : Function.RightInverse σ S.rightHom) : (mk σ hσ : G → E) = σ := rfl
+
+variable (σ : S.Section)
+
+@[to_additive (attr := simp)]
+theorem rightHom_section (g : G) : S.rightHom (σ g) = g := σ.rightInverse_rightHom g
+
+@[to_additive (attr := simp)]
+theorem rightHom_comp_section : S.rightHom ∘ σ = id :=
+  Function.RightInverse.comp_eq_id σ.rightInverse_rightHom
+
+end Section
+
 /-- `Splitting` of a group extension is a section homomorphism. -/
 @[to_additive]
-structure Splitting where
-  /-- A section homomorphism -/
-  sectionHom : G →* E
-  /-- The section is a left inverse of the projection map. -/
-  rightHom_comp_sectionHom : S.rightHom.comp sectionHom = MonoidHom.id G
+structure Splitting extends G →* E, S.Section
+
+attribute [nolint docBlame] Splitting.toSection
+
+namespace Splitting
 
 @[to_additive]
 instance : FunLike S.Splitting G E where
-  coe s := s.sectionHom
+  coe s := s.toFun
   coe_injective' := by
     intro ⟨_, _⟩ ⟨_, _⟩ h
     congr
@@ -166,16 +189,36 @@ instance : FunLike S.Splitting G E where
 
 @[to_additive]
 instance : MonoidHomClass S.Splitting G E where
-  map_mul s := s.sectionHom.map_mul'
-  map_one s := s.sectionHom.map_one'
+  map_mul s := s.map_mul'
+  map_one s := s.map_one'
+
+variable {S}
+
+@[to_additive (attr := simp)]
+theorem coe_mk (s : G →* E) (hs : Function.RightInverse s S.rightHom) : (mk s hs : G → E) = s := rfl
+
+@[to_additive (attr := simp)]
+theorem coe_monoidHom_mk (s : G →* E) (hs : Function.RightInverse s S.rightHom) :
+    (mk s hs : G →* E) = s := rfl
+
+variable (s : S.Splitting)
+
+@[to_additive (attr := simp)]
+theorem rightHom_splitting (g : G) : S.rightHom (s g) = g := s.rightInverse_rightHom g
+
+@[to_additive (attr := simp)]
+theorem rightHom_comp_splitting : S.rightHom.comp s = MonoidHom.id G := by
+  ext g
+  simp only [MonoidHom.comp_apply, MonoidHom.id_apply, MonoidHom.coe_coe, rightHom_splitting]
+
+end Splitting
 
 /-- A splitting of an extension `S` is `N`-conjugate to another iff there exists `n : N` such that
 the section homomorphism is a conjugate of the other section homomorphism by `S.inl n`. -/
 @[to_additive
       "A splitting of an extension `S` is `N`-conjugate to another iff there exists `n : N` such
       that the section homomorphism is a conjugate of the other section homomorphism by `S.inl n`."]
-def IsConj (S : GroupExtension N E G) (s s' : S.Splitting) : Prop :=
-  ∃ n : N, s.sectionHom = fun g ↦ S.inl n * s'.sectionHom g * (S.inl n)⁻¹
+def IsConj (s s' : S.Splitting) : Prop := ∃ n : N, s = fun g ↦ S.inl n * s' g * (S.inl n)⁻¹
 
 end GroupExtension
 
@@ -195,8 +238,9 @@ theorem toGroupExtension_rightHom : (toGroupExtension φ).rightHom = SemidirectP
   rfl
 
 /-- A canonical splitting of the group extension associated to the semidirect product -/
-def inr_splitting : (toGroupExtension φ).Splitting where
-  sectionHom := inr
-  rightHom_comp_sectionHom := rightHom_comp_inr
+def inr_splitting : (toGroupExtension φ).Splitting := {
+  inr with
+  rightInverse_rightHom := rightHom_inr
+}
 
 end SemidirectProduct

--- a/Mathlib/GroupTheory/GroupExtension/Defs.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Defs.lean
@@ -102,7 +102,8 @@ structure Section where
 /-- `Splitting` of an additive group extension is a section homomorphism. -/
 structure Splitting extends G →+ E, S.Section
 
-attribute [nolint docBlame] Splitting.toSection
+/-- A splitting of an additive group extension as a (set-theoretic) section. -/
+add_decl_doc Splitting.toSection
 
 end AddGroupExtension
 
@@ -185,7 +186,8 @@ end Section
 @[to_additive]
 structure Splitting extends G →* E, S.Section
 
-attribute [nolint docBlame] Splitting.toSection
+/-- A splitting of a group extension as a (set-theoretic) section. -/
+add_decl_doc Splitting.toSection
 
 namespace Splitting
 


### PR DESCRIPTION
This PR:
- defines `structure (Add)?GroupExtension.Section` as a right inverse to `rightHom`
- redefines `structure (Add)?GroupExtension.Splitting` using `Section`
- rewrites the definition of `structure (Add)?GroupExtension.Equiv` with `extends`

As the first part of #19582, this PR contains only the changes to the `Defs` file.

Moves:
- GroupExtension.Splitting.sectionHom -> GroupExtension.Splitting.toMonoidHom
- GroupExtension.Splitting.rightHom_comp_sectionHom -> GroupExtension.Splitting.rightInverse_rightHom

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
