### PR TITLE
feat: `HasCompactMulSupport` lemmas in `ProperSpace`s

### DIFF
--- a/Mathlib/Topology/MetricSpace/Bounded.lean
+++ b/Mathlib/Topology/MetricSpace/Bounded.lean
@@ -325,6 +325,37 @@ theorem isBounded_of_bddAbove_of_bddBelow {s : Set α} (h₁ : BddAbove s) (h₂
 
 end CompactIccSpace
 
+section ProperSpace
+
+variable [ProperSpace α]
+
+namespace HasCompactMulSupport
+
+open Function Bornology
+
+variable [One β]
+variable {f : α → β}
+
+@[to_additive]
+theorem of_mulSupport_subset_closedBall (hf : mulSupport f ⊆ closedBall x r) :
+    HasCompactMulSupport f :=
+  HasCompactMulSupport.of_mulSupport_subset_isCompact (isCompact_closedBall ..) hf
+
+@[to_additive]
+theorem of_mulSupport_subset_ball (hf : mulSupport f ⊆ ball x r) :
+    HasCompactMulSupport f :=
+ of_mulSupport_subset_closedBall <| Trans.trans hf ball_subset_closedBall
+
+@[to_additive]
+theorem of_mulSupport_subset_isBounded {s : Set α}
+    (hs : IsBounded s) (hf : mulSupport f ⊆ s) :
+    HasCompactMulSupport f :=
+  IsCompact.closure_of_subset hs.isCompact_closure <| Trans.trans hf subset_closure
+
+end HasCompactMulSupport
+
+end ProperSpace
+
 end Bounded
 
 section Diam


### PR DESCRIPTION
Some lemmas for showing that a function on a proper space has compact support.

---

These have common potential use cases in analysis formalizations, e.g. [here](https://github.com/fpvandoorn/carleson/pull/192).


Note: I struggled a bit finding the right home for these, `#find_home` gave `Mathlib.Topology.MetricSpace.ProperSpace`, but that didn't work due to cyclic imports. `Mathlib.Algebra.Support` doesn't work for the same reason. 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
