### PR TITLE
[Merged by Bors] - chore(CategoryTheory): rename `ConcreteCategory` to `HasForget`

### DIFF
--- a/Mathlib/Algebra/Category/AlgebraCat/Basic.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Basic.lean
@@ -127,7 +127,7 @@ lemma hom_inv_apply {A B : AlgebraCat.{v} R} (e : A ≅ B) (x : B) : e.hom (e.in
 instance : Inhabited (AlgebraCat R) :=
   ⟨of R R⟩
 
-instance : ConcreteCategory.{v} (AlgebraCat.{v} R) where
+instance : HasForget.{v} (AlgebraCat.{v} R) where
   forget :=
     { obj := fun R => R
       map := fun f => f.hom }

--- a/Mathlib/Algebra/Category/BialgebraCat/Basic.lean
+++ b/Mathlib/Algebra/Category/BialgebraCat/Basic.lean
@@ -95,7 +95,7 @@ abbrev ofHom {X Y : Type v} [Ring X] [Ring Y]
     Hom.toBialgHom (𝟙 M) = BialgHom.id _ _ :=
   rfl
 
-instance concreteCategory : ConcreteCategory.{v} (BialgebraCat.{v} R) where
+instance hasForget : HasForget.{v} (BialgebraCat.{v} R) where
   forget :=
     { obj := fun M => M
       map := fun f => f.toBialgHom }

--- a/Mathlib/Algebra/Category/BoolRing.lean
+++ b/Mathlib/Algebra/Category/BoolRing.lean
@@ -71,7 +71,7 @@ lemma hom_ext {R S : BoolRing} {f g : R ⟶ S} (hf : f.hom = g.hom) : f = g :=
 abbrev ofHom {R S : Type u} [BooleanRing R] [BooleanRing S] (f : R →+* S) : of R ⟶ of S :=
   ⟨f⟩
 
-instance : ConcreteCategory BoolRing where
+instance : HasForget BoolRing where
   forget :=
     { obj := fun R ↦ R
       map := fun f ↦ f.hom }

--- a/Mathlib/Algebra/Category/CoalgebraCat/Basic.lean
+++ b/Mathlib/Algebra/Category/CoalgebraCat/Basic.lean
@@ -96,7 +96,7 @@ abbrev ofHom {X Y : Type v} [AddCommGroup X] [Module R X] [AddCommGroup Y] [Modu
     Hom.toCoalgHom (𝟙 M) = CoalgHom.id _ _ :=
   rfl
 
-instance concreteCategory : ConcreteCategory.{v} (CoalgebraCat.{v} R) where
+instance hasForget : HasForget.{v} (CoalgebraCat.{v} R) where
   forget :=
     { obj := fun M => M
       map := fun f => f.toCoalgHom }

--- a/Mathlib/Algebra/Category/FGModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/FGModuleCat/Basic.lean
@@ -46,7 +46,7 @@ def FGModuleCat :=
   FullSubcategory fun V : ModuleCat.{u} R => Module.Finite R V
 -- Porting note: still no derive handler via `dsimp`.
 -- see https://github.com/leanprover-community/mathlib4/issues/5020
--- deriving LargeCategory, ConcreteCategory,Preadditive
+-- deriving LargeCategory, HasForget,Preadditive
 
 variable {R}
 
@@ -72,7 +72,7 @@ instance : LargeCategory (FGModuleCat R) := by
   dsimp [FGModuleCat]
   infer_instance
 
-instance : ConcreteCategory (FGModuleCat R) := by
+instance : HasForget (FGModuleCat R) := by
   dsimp [FGModuleCat]
   infer_instance
 

--- a/Mathlib/Algebra/Category/Grp/Basic.lean
+++ b/Mathlib/Algebra/Category/Grp/Basic.lean
@@ -42,7 +42,7 @@ deriving instance LargeCategory for Grp
 attribute [to_additive] instGrpLargeCategory
 
 @[to_additive]
-instance concreteCategory : ConcreteCategory Grp := by
+instance hasForget : HasForget Grp := by
   dsimp only [Grp]
   infer_instance
 
@@ -171,7 +171,7 @@ deriving instance LargeCategory for CommGrp
 attribute [to_additive] instCommGrpLargeCategory
 
 @[to_additive]
-instance concreteCategory : ConcreteCategory CommGrp := by
+instance hasForget : HasForget CommGrp := by
   dsimp only [CommGrp]
   infer_instance
 

--- a/Mathlib/Algebra/Category/Grp/FiniteGrp.lean
+++ b/Mathlib/Algebra/Category/Grp/FiniteGrp.lean
@@ -44,7 +44,7 @@ instance : CoeSort FiniteGrp.{u} (Type u) where
 instance : Category FiniteGrp := InducedCategory.category FiniteGrp.toGrp
 
 @[to_additive]
-instance : ConcreteCategory FiniteGrp := InducedCategory.concreteCategory FiniteGrp.toGrp
+instance : HasForget FiniteGrp := InducedCategory.hasForget FiniteGrp.toGrp
 
 @[to_additive]
 instance (G : FiniteGrp) : Group G := inferInstanceAs <| Group G.toGrp

--- a/Mathlib/Algebra/Category/GrpWithZero.lean
+++ b/Mathlib/Algebra/Category/GrpWithZero.lean
@@ -56,7 +56,7 @@ lemma coe_id {X : GrpWithZero} : (𝟙 X : X → X) = id := rfl
 
 lemma coe_comp {X Y Z : GrpWithZero} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g : X → Z) = g ∘ f := rfl
 
-instance groupWithZeroConcreteCategory : ConcreteCategory GrpWithZero where
+instance groupWithZeroHasForget : HasForget GrpWithZero where
   forget :=
   { obj := fun G => G
     map := fun f => f.toFun }

--- a/Mathlib/Algebra/Category/HopfAlgebraCat/Basic.lean
+++ b/Mathlib/Algebra/Category/HopfAlgebraCat/Basic.lean
@@ -94,7 +94,7 @@ abbrev ofHom {X Y : Type v} [Ring X] [Ring Y]
     Hom.toBialgHom (𝟙 M) = BialgHom.id _ _ :=
   rfl
 
-instance concreteCategory : ConcreteCategory.{v} (HopfAlgebraCat.{v} R) where
+instance hasForget : HasForget.{v} (HopfAlgebraCat.{v} R) where
   forget :=
     { obj := fun M => M
       map := fun f => f.toBialgHom }

--- a/Mathlib/Algebra/Category/ModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Basic.lean
@@ -188,7 +188,7 @@ end
 instance : Inhabited (ModuleCat R) :=
   ⟨of R R⟩
 
-instance moduleConcreteCategory : ConcreteCategory.{v} (ModuleCat.{v} R) where
+instance moduleHasForget : HasForget.{v} (ModuleCat.{v} R) where
   forget :=
     { obj := fun R => R
       map := fun f => f.hom }

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
@@ -32,7 +32,7 @@ namespace CategoryTheory
 
 namespace Presieve.FamilyOfElements
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 section smul
 

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/ChangeOfRings.lean
@@ -53,7 +53,7 @@ noncomputable def restrictHomEquivOfIsLocallySurjective
   toFun f := (restrictScalars α).map f
   invFun g := homMk ((toPresheaf R).map g) (fun X r' m ↦ by
     apply hM₂.isSeparated _ _ (Presheaf.imageSieve_mem J α r')
-    -- Type-ascript `hr` so it uses `RingCat.Hom.hom` instead of `ConcreteCategory.instFunLike`
+    -- Type-ascript `hr` so it uses `RingCat.Hom.hom` instead of `HasForget.instFunLike`
     rintro Y p ⟨r : R.obj _, (hr : α.app (Opposite.op Y) r = R'.map p.op r')⟩
     have hg : ∀ (z : M₁.obj X), g.app _ (M₁.map p.op z) = M₂.map p.op (g.app X z) :=
       fun z ↦ congr_fun ((forget _).congr_map (g.naturality p.op)) z

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -3,9 +3,9 @@ Copyright (c) 2018 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
-import Mathlib.CategoryTheory.ConcreteCategory.BundledHom
 import Mathlib.Algebra.PUnitInstances.Algebra
 import Mathlib.Algebra.Group.ULift
+import Mathlib.CategoryTheory.ConcreteCategory.BundledHom
 import Mathlib.CategoryTheory.Functor.ReflectsIso
 import Mathlib.Algebra.Ring.Action.Group
 
@@ -55,8 +55,8 @@ attribute [to_additive instAddMonCatLargeCategory] instMonCatLargeCategory
 
 -- Porting note: https://github.com/leanprover-community/mathlib4/issues/5020
 @[to_additive]
-instance concreteCategory : ConcreteCategory MonCat :=
-  BundledHom.concreteCategory _
+instance hasForget : HasForget MonCat :=
+  BundledHom.hasForget _
 
 @[to_additive]
 instance : CoeSort MonCat Type* where
@@ -170,7 +170,7 @@ attribute [to_additive instAddCommMonCatLargeCategory] instCommMonCatLargeCatego
 
 -- Porting note: https://github.com/leanprover-community/mathlib4/issues/5020
 @[to_additive]
-instance concreteCategory : ConcreteCategory CommMonCat := by
+instance hasForget : HasForget CommMonCat := by
   dsimp only [CommMonCat]
   infer_instance
 
@@ -346,7 +346,7 @@ instance CommMonCat.forget_reflects_isos : (forget CommMonCat.{u}).ReflectsIsomo
 
 -- Porting note: this was added in order to ensure that `forget₂ CommMonCat MonCat`
 -- automatically reflects isomorphisms
--- we could have used `CategoryTheory.ConcreteCategory.ReflectsIso` alternatively
+-- we could have used `CategoryTheory.HasForget.ReflectsIso` alternatively
 @[to_additive]
 instance CommMonCat.forget₂_full : (forget₂ CommMonCat MonCat).Full where
   map_surjective f := ⟨f, rfl⟩

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -120,7 +120,7 @@ lemma hom_inv_apply {R S : SemiRingCat} (e : R ≅ S) (s : S) : e.hom (e.inv s) 
 instance : Inhabited SemiRingCat :=
   ⟨of PUnit⟩
 
-instance : ConcreteCategory.{u} SemiRingCat where
+instance : HasForget.{u} SemiRingCat where
   forget :=
     { obj := fun R => R
       map := fun f => f.hom }
@@ -264,7 +264,7 @@ lemma hom_inv_apply {R S : RingCat} (e : R ≅ S) (s : S) : e.hom (e.inv s) = s 
 instance : Inhabited RingCat :=
   ⟨of PUnit⟩
 
-instance : ConcreteCategory.{u} RingCat where
+instance : HasForget.{u} RingCat where
   forget :=
     { obj := fun R => R
       map := fun f => f.hom }
@@ -413,7 +413,7 @@ lemma hom_inv_apply {R S : CommSemiRingCat} (e : R ≅ S) (s : S) : e.hom (e.inv
 instance : Inhabited CommSemiRingCat :=
   ⟨of PUnit⟩
 
-instance : ConcreteCategory.{u} CommSemiRingCat where
+instance : HasForget.{u} CommSemiRingCat where
   forget :=
     { obj := fun R => R
       map := fun f => f.hom }
@@ -560,7 +560,7 @@ lemma hom_inv_apply {R S : CommRingCat} (e : R ≅ S) (s : S) : e.hom (e.inv s) 
 instance : Inhabited CommRingCat :=
   ⟨of PUnit⟩
 
-instance : ConcreteCategory.{u} CommRingCat where
+instance : HasForget.{u} CommRingCat where
   forget :=
     { obj := fun R => R
       map := fun f => f.hom }
@@ -669,10 +669,10 @@ abbrev CommRingCatMax.{u1, u2} := CommRingCat.{max u1 u2}
 
 lemma RingCat.forget_map_apply {R S : RingCat} (f : R ⟶ S)
     (x : (CategoryTheory.forget RingCat).obj R) :
-    @DFunLike.coe _ _ _ ConcreteCategory.instFunLike f x = f x :=
+    @DFunLike.coe _ _ _ HasForget.instFunLike f x = f x :=
   rfl
 
 lemma CommRingCat.forget_map_apply {R S : CommRingCat} (f : R ⟶ S)
     (x : (CategoryTheory.forget CommRingCat).obj R) :
-    @DFunLike.coe _ _ _ ConcreteCategory.instFunLike f x = f x :=
+    @DFunLike.coe _ _ _ HasForget.instFunLike f x = f x :=
   rfl

--- a/Mathlib/Algebra/Category/Semigrp/Basic.lean
+++ b/Mathlib/Algebra/Category/Semigrp/Basic.lean
@@ -46,13 +46,13 @@ instance bundledHom : BundledHom @MulHom :=
   ⟨@MulHom.toFun, @MulHom.id, @MulHom.comp,
     by intros; apply @DFunLike.coe_injective, by aesop_cat, by simp⟩
 
--- Porting note: deriving failed for `ConcreteCategory`,
+-- Porting note: deriving failed for `HasForget`,
 -- "default handlers have not been implemented yet"
 -- https://github.com/leanprover-community/mathlib4/issues/5020
 deriving instance LargeCategory for MagmaCat
-instance instConcreteCategory : ConcreteCategory MagmaCat := BundledHom.concreteCategory MulHom
+instance instHasForget : HasForget MagmaCat := BundledHom.hasForget MulHom
 
-attribute [to_additive] instMagmaCatLargeCategory instConcreteCategory
+attribute [to_additive] instMagmaCatLargeCategory instHasForget
 
 @[to_additive]
 instance : CoeSort MagmaCat Type* where
@@ -90,7 +90,7 @@ theorem coe_of (R : Type u) [Mul R] : (MagmaCat.of R : Type u) = R :=
 @[to_additive (attr := simp)]
 lemma mulEquiv_coe_eq {X Y : Type _} [Mul X] [Mul Y] (e : X ≃* Y) :
     (@DFunLike.coe (MagmaCat.of X ⟶ MagmaCat.of Y) _ (fun _ => (forget MagmaCat).obj _)
-      ConcreteCategory.instFunLike (e : X →ₙ* Y) : X → Y) = ↑e :=
+      HasForget.instFunLike (e : X →ₙ* Y) : X → Y) = ↑e :=
   rfl
 
 /-- Typecheck a `MulHom` as a morphism in `MagmaCat`. -/
@@ -125,13 +125,13 @@ instance : BundledHom.ParentProjection @Semigroup.toMul := ⟨⟩
 
 deriving instance LargeCategory for Semigrp
 
--- Porting note: deriving failed for `ConcreteCategory`,
+-- Porting note: deriving failed for `HasForget`,
 -- "default handlers have not been implemented yet"
 -- https://github.com/leanprover-community/mathlib4/issues/5020
-instance instConcreteCategory : ConcreteCategory Semigrp :=
-  BundledHom.concreteCategory (fun _ _ => _)
+instance instHasForget : HasForget Semigrp :=
+  BundledHom.hasForget (fun _ _ => _)
 
-attribute [to_additive] instSemigrpLargeCategory Semigrp.instConcreteCategory
+attribute [to_additive] instSemigrpLargeCategory Semigrp.instHasForget
 
 @[to_additive]
 instance : CoeSort Semigrp Type* where
@@ -169,7 +169,7 @@ theorem coe_of (R : Type u) [Semigroup R] : (Semigrp.of R : Type u) = R :=
 @[to_additive (attr := simp)]
 lemma mulEquiv_coe_eq {X Y : Type _} [Semigroup X] [Semigroup Y] (e : X ≃* Y) :
     (@DFunLike.coe (Semigrp.of X ⟶ Semigrp.of Y) _ (fun _ => (forget Semigrp).obj _)
-      ConcreteCategory.instFunLike (e : X →ₙ* Y) : X → Y) = ↑e :=
+      HasForget.instFunLike (e : X →ₙ* Y) : X → Y) = ↑e :=
   rfl
 
 /-- Typecheck a `MulHom` as a morphism in `Semigrp`. -/
@@ -279,7 +279,7 @@ instance Semigrp.forgetReflectsIsos : (forget Semigrp.{u}).ReflectsIsomorphisms 
 
 -- Porting note: this was added in order to ensure that `forget₂ CommMonCat MonCat`
 -- automatically reflects isomorphisms
--- we could have used `CategoryTheory.ConcreteCategory.ReflectsIso` alternatively
+-- we could have used `CategoryTheory.HasForget.ReflectsIso` alternatively
 @[to_additive]
 instance Semigrp.forget₂_full : (forget₂ Semigrp MagmaCat).Full where
   map_surjective f := ⟨f, rfl⟩

--- a/Mathlib/Algebra/Homology/ConcreteCategory.lean
+++ b/Mathlib/Algebra/Homology/ConcreteCategory.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.Homology.ShortComplex.ConcreteCategory
 # Homology of complexes in concrete categories
 
 The homology of short complexes in concrete categories was studied in
-`Mathlib.Algebra.Homology.ShortComplex.ConcreteCategory`. In this file,
+`Mathlib.Algebra.Homology.ShortComplex.HasForget`. In this file,
 we introduce specific definitions and lemmas for the homology
 of homological complexes in concrete categories. In particular,
 we give a computation of the connecting homomorphism of
@@ -22,7 +22,7 @@ open CategoryTheory
 
 universe v u
 
-variable {C : Type u} [Category.{v} C] [ConcreteCategory.{v} C] [HasForget₂ C Ab.{v}]
+variable {C : Type u} [Category.{v} C] [HasForget.{v} C] [HasForget₂ C Ab.{v}]
   [Abelian C] [(forget₂ C Ab).Additive] [(forget₂ C Ab).PreservesHomology]
   {ι : Type*} {c : ComplexShape ι}
 

--- a/Mathlib/Algebra/Homology/ImageToKernel.lean
+++ b/Mathlib/Algebra/Homology/ImageToKernel.lean
@@ -47,7 +47,7 @@ theorem subobject_ofLE_as_imageToKernel (w : f ≫ g = 0) (h) :
     Subobject.ofLE (imageSubobject f) (kernelSubobject g) h = imageToKernel f g w :=
   rfl
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 -- Porting note: removed elementwise attribute which does not seem to be helpful here
 -- a more suitable lemma is added below
@@ -57,7 +57,7 @@ theorem imageToKernel_arrow (w : f ≫ g = 0) :
   simp [imageToKernel]
 
 @[simp]
-lemma imageToKernel_arrow_apply [ConcreteCategory V] (w : f ≫ g = 0)
+lemma imageToKernel_arrow_apply [HasForget V] (w : f ≫ g = 0)
     (x : (forget V).obj (Subobject.underlying.obj (imageSubobject f))) :
     (kernelSubobject g).arrow (imageToKernel f g w x) =
       (imageSubobject f).arrow x := by

--- a/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
@@ -25,7 +25,7 @@ open Limits
 
 section
 
-variable {C : Type u} [Category.{v} C] [ConcreteCategory.{w} C] [HasForget₂ C Ab]
+variable {C : Type u} [Category.{v} C] [HasForget.{w} C] [HasForget₂ C Ab]
 
 @[simp]
 lemma ShortComplex.zero_apply
@@ -81,7 +81,7 @@ lemma exact_iff_exact_map_forget₂ [S.HasHomology] :
     S.Exact ↔ (S.map (forget₂ C Ab)).Exact :=
   (S.exact_map_iff_of_faithful (forget₂ C Ab)).symm
 
-lemma exact_iff_of_concreteCategory [S.HasHomology] :
+lemma exact_iff_of_hasForget [S.HasHomology] :
     S.Exact ↔ ∀ (x₂ : (forget₂ C Ab).obj S.X₂) (_ : ((forget₂ C Ab).map S.g) x₂ = 0),
       ∃ (x₁ : (forget₂ C Ab).obj S.X₁), ((forget₂ C Ab).map S.f) x₁ = x₂ := by
   rw [S.exact_iff_exact_map_forget₂, ab_exact_iff]
@@ -123,10 +123,10 @@ end
 
 section abelian
 
-variable {C : Type u} [Category.{v} C] [ConcreteCategory.{v} C] [HasForget₂ C Ab]
+variable {C : Type u} [Category.{v} C] [HasForget.{v} C] [HasForget₂ C Ab]
   [Abelian C] [(forget₂ C Ab).Additive] [(forget₂ C Ab).PreservesHomology]
 
-attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] HasForget.instFunLike HasForget.hasCoeToSort
 
 namespace ShortComplex
 

--- a/Mathlib/Algebra/Homology/ShortComplex/ModuleCat.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ModuleCat.lean
@@ -43,7 +43,7 @@ lemma moduleCat_zero_apply (x : S.X₁) : S.g (S.f x) = 0 :=
 
 lemma moduleCat_exact_iff :
     S.Exact ↔ ∀ (x₂ : S.X₂) (_ : S.g x₂ = 0), ∃ (x₁ : S.X₁), S.f x₁ = x₂ :=
-  S.exact_iff_of_concreteCategory
+  S.exact_iff_of_hasForget
 
 lemma moduleCat_exact_iff_ker_sub_range :
     S.Exact ↔ LinearMap.ker S.g.hom ≤ LinearMap.range S.f.hom := by

--- a/Mathlib/AlgebraicGeometry/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
@@ -180,7 +180,7 @@ theorem appIso_inv_app (U) :
   (PresheafedSpace.IsOpenImmersion.invApp_app _ _).trans (by rw [eqToHom_op])
 
 /--
-`elementwise` generates the `ConcreteCategory.instFunLike` lemma, we want `CommRingCat.Hom.hom`.
+`elementwise` generates the `HasForget.instFunLike` lemma, we want `CommRingCat.Hom.hom`.
 -/
 theorem appIso_inv_app_apply' (U) (x) :
     f.app (f ''ᵁ U) ((f.appIso U).inv x) = X.presheaf.map (eqToHom (preimage_image_eq f U)).op x :=

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean
@@ -309,7 +309,7 @@ def homogeneousLocalizationToStalk (x : ProjectiveSpectrum.top 𝒜) (y : at x) 
         ProjectiveSpectrum.basicOpen 𝒜 g.den.1 ⊓ ProjectiveSpectrum.basicOpen 𝒜 c)
       ⟨⟨mem_basicOpen_den _ x f, mem_basicOpen_den _ x g⟩, hc⟩
       (homOfLE inf_le_left ≫ homOfLE inf_le_left) (homOfLE inf_le_left ≫ homOfLE inf_le_right)
-    -- Go from `ConcreteCategory.instFunLike` to `CommRingCat.Hom.hom`
+    -- Go from `HasForget.instFunLike` to `CommRingCat.Hom.hom`
     show (Proj.structureSheaf 𝒜).presheaf.map (homOfLE inf_le_left ≫ homOfLE inf_le_left).op
         (sectionInBasicOpen 𝒜 x f) =
       (Proj.structureSheaf 𝒜).presheaf.map (homOfLE inf_le_left ≫ homOfLE inf_le_right).op

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -532,7 +532,7 @@ def stalkIso (x : PrimeSpectrum.Top R) :
       exists_const _ _ s x hxU
     rw [← res_apply R U V iVU s ⟨x, hxV⟩, ← hs, const_apply, localizationToStalk_mk']
     refine (structureSheaf R).presheaf.germ_ext V hxV (homOfLE hg) iVU ?_
-    -- Replace the `ConcreteCategory.instFunLike` instance with `CommRingCat.hom`:
+    -- Replace the `HasForget.instFunLike` instance with `CommRingCat.hom`:
     show (structureSheaf R).presheaf.map (homOfLE hg).op _ =
       (structureSheaf R).presheaf.map iVU.op s
     rw [← hs, res_const']

--- a/Mathlib/AlgebraicTopology/SimplexCategory.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory.lean
@@ -747,7 +747,7 @@ end Truncated
 
 section Concrete
 
-instance : ConcreteCategory.{0} SimplexCategory where
+instance : HasForget.{0} SimplexCategory where
   forget :=
     { obj := fun i => Fin (i.len + 1)
       map := fun f => f.toOrderHom }

--- a/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
+++ b/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
@@ -22,10 +22,10 @@ namespace SimplexCategory
 
 open Simplicial NNReal CategoryTheory
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 -- Porting note: added, should be moved
-instance (x : SimplexCategory) : Fintype (ConcreteCategory.forget.obj x) :=
+instance (x : SimplexCategory) : Fintype (HasForget.forget.obj x) :=
   inferInstanceAs (Fintype (Fin _))
 
 /-- The topological simplex associated to `x : SimplexCategory`.

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
@@ -36,10 +36,10 @@ instance bundledHom : BundledHom @NormedAddGroupHom where
 
 deriving instance LargeCategory for SemiNormedGrp
 
--- Porting note: deriving fails for ConcreteCategory, adding instance manually.
+-- Porting note: deriving fails for HasForget, adding instance manually.
 -- See https://github.com/leanprover-community/mathlib4/issues/5020
--- deriving instance LargeCategory, ConcreteCategory for SemiRingCat
-instance : ConcreteCategory SemiNormedGrp := by
+-- deriving instance LargeCategory, HasForget for SemiRingCat
+instance : HasForget SemiNormedGrp := by
   dsimp [SemiNormedGrp]
   infer_instance
 
@@ -143,7 +143,7 @@ theorem hom_ext {M N : SemiNormedGrp₁} (f g : M ⟶ N) (w : (f : M → N) = (g
     f = g :=
   Subtype.eq (NormedAddGroupHom.ext (congr_fun w))
 
-instance : ConcreteCategory.{u} SemiNormedGrp₁ where
+instance : HasForget.{u} SemiNormedGrp₁ where
   forget :=
     { obj := fun X => X
       map := fun f => f }

--- a/Mathlib/CategoryTheory/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Action/Basic.lean
@@ -231,7 +231,7 @@ variable (V G)
 
 /-- (implementation) The forgetful functor from bundled actions to the underlying objects.
 
-Use the `CategoryTheory.forget` API provided by the `ConcreteCategory` instance below,
+Use the `CategoryTheory.forget` API provided by the `HasForget` instance below,
 rather than using this directly.
 -/
 @[simps]
@@ -241,10 +241,10 @@ def forget : Action V G ⥤ V where
 
 instance : (forget V G).Faithful where map_injective w := Hom.ext w
 
-instance [ConcreteCategory V] : ConcreteCategory (Action V G) where
-  forget := forget V G ⋙ ConcreteCategory.forget
+instance [HasForget V] : HasForget (Action V G) where
+  forget := forget V G ⋙ HasForget.forget
 
-instance hasForgetToV [ConcreteCategory V] : HasForget₂ (Action V G) V where forget₂ := forget V G
+instance hasForgetToV [HasForget V] : HasForget₂ (Action V G) V where forget₂ := forget V G
 
 /-- The forgetful functor is intertwined by `functorCategoryEquivalence` with
 evaluation at `PUnit.star`. -/

--- a/Mathlib/CategoryTheory/Action/Concrete.lean
+++ b/Mathlib/CategoryTheory/Action/Concrete.lean
@@ -167,7 +167,7 @@ end FintypeCat
 
 section ToMulAction
 
-variable {V : Type (u + 1)} [LargeCategory V] [ConcreteCategory V]
+variable {V : Type (u + 1)} [LargeCategory V] [HasForget V]
 
 instance instMulAction {G : MonCat.{u}} (X : Action V G) :
     MulAction G ((CategoryTheory.forget _).obj X) where

--- a/Mathlib/CategoryTheory/Action/Continuous.lean
+++ b/Mathlib/CategoryTheory/Action/Continuous.lean
@@ -28,7 +28,7 @@ universe u v
 
 open CategoryTheory Limits
 
-variable (V : Type (u + 1)) [LargeCategory V] [ConcreteCategory V] [HasForget₂ V TopCat]
+variable (V : Type (u + 1)) [LargeCategory V] [HasForget V] [HasForget₂ V TopCat]
 variable (G : MonCat.{u}) [TopologicalSpace G]
 
 namespace Action
@@ -68,8 +68,8 @@ namespace ContAction
 instance : Category (ContAction V G) :=
   FullSubcategory.category (IsContinuous (V := V) (G := G))
 
-instance : ConcreteCategory (ContAction V G) :=
-  FullSubcategory.concreteCategory (IsContinuous (V := V) (G := G))
+instance : HasForget (ContAction V G) :=
+  FullSubcategory.hasForget (IsContinuous (V := V) (G := G))
 
 instance : HasForget₂ (ContAction V G) (Action V G) :=
   FullSubcategory.hasForget₂ (IsContinuous (V := V) (G := G))
@@ -102,8 +102,8 @@ namespace DiscreteContAction
 instance : Category (DiscreteContAction V G) :=
   FullSubcategory.category (IsDiscrete (V := V) (G := G))
 
-instance : ConcreteCategory (DiscreteContAction V G) :=
-  FullSubcategory.concreteCategory (IsDiscrete (V := V) (G := G))
+instance : HasForget (DiscreteContAction V G) :=
+  FullSubcategory.hasForget (IsDiscrete (V := V) (G := G))
 
 instance : HasForget₂ (DiscreteContAction V G) (ContAction V G) :=
   FullSubcategory.hasForget₂ (IsDiscrete (V := V) (G := G))

--- a/Mathlib/CategoryTheory/Action/Limits.lean
+++ b/Mathlib/CategoryTheory/Action/Limits.lean
@@ -219,7 +219,7 @@ instance : HasZeroMorphisms (Action V G) where
 
 instance forget_preservesZeroMorphisms : Functor.PreservesZeroMorphisms (forget V G) where
 
-instance forget₂_preservesZeroMorphisms [ConcreteCategory V] :
+instance forget₂_preservesZeroMorphisms [HasForget V] :
     Functor.PreservesZeroMorphisms (forget₂ (Action V G) V) where
 
 instance functorCategoryEquivalence_preservesZeroMorphisms :
@@ -251,7 +251,7 @@ instance : Preadditive (Action V G) where
 
 instance forget_additive : Functor.Additive (forget V G) where
 
-instance forget₂_additive [ConcreteCategory V] : Functor.Additive (forget₂ (Action V G) V) where
+instance forget₂_additive [HasForget V] : Functor.Additive (forget₂ (Action V G) V) where
 
 instance functorCategoryEquivalence_additive :
     Functor.Additive (functorCategoryEquivalence V G).functor where
@@ -289,7 +289,7 @@ instance : Linear R (Action V G) where
 
 instance forget_linear : Functor.Linear R (forget V G) where
 
-instance forget₂_linear [ConcreteCategory V] : Functor.Linear R (forget₂ (Action V G) V) where
+instance forget₂_linear [HasForget V] : Functor.Linear R (forget₂ (Action V G) V) where
 
 instance functorCategoryEquivalence_linear :
     Functor.Linear R (functorCategoryEquivalence V G).functor where

--- a/Mathlib/CategoryTheory/Category/Bipointed.lean
+++ b/Mathlib/CategoryTheory/Category/Bipointed.lean
@@ -76,7 +76,7 @@ instance largeCategory : LargeCategory Bipointed where
   id := Hom.id
   comp := @Hom.comp
 
-instance concreteCategory : ConcreteCategory Bipointed where
+instance hasForget : HasForget Bipointed where
   forget :=
     { obj := Bipointed.X
       map := @Hom.toFun }

--- a/Mathlib/CategoryTheory/Category/Pointed.lean
+++ b/Mathlib/CategoryTheory/Category/Pointed.lean
@@ -82,7 +82,7 @@ instance largeCategory : LargeCategory Pointed where
 @[simp] lemma Hom.comp_toFun' {X Y Z : Pointed.{u}} (f : X ⟶ Y) (g : Y ⟶ Z) :
     (f ≫ g).toFun = g.toFun ∘ f.toFun := rfl
 
-instance concreteCategory : ConcreteCategory Pointed where
+instance hasForget : HasForget Pointed where
   forget :=
     { obj := Pointed.X
       map := @Hom.toFun }

--- a/Mathlib/CategoryTheory/Category/TwoP.lean
+++ b/Mathlib/CategoryTheory/Category/TwoP.lean
@@ -62,8 +62,8 @@ theorem coe_toBipointed (X : TwoP) : ↥X.toBipointed = ↥X :=
 noncomputable instance largeCategory : LargeCategory TwoP :=
   InducedCategory.category toBipointed
 
-noncomputable instance concreteCategory : ConcreteCategory TwoP :=
-  InducedCategory.concreteCategory toBipointed
+noncomputable instance hasForget : HasForget TwoP :=
+  InducedCategory.hasForget toBipointed
 
 noncomputable instance hasForgetToBipointed : HasForget₂ TwoP Bipointed :=
   InducedCategory.hasForget₂ toBipointed

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -9,7 +9,7 @@ import Mathlib.CategoryTheory.Types
 # Concrete categories
 
 A concrete category is a category `C` with a fixed faithful functor
-`forget : C ⥤ Type*`.  We define concrete categories using `class ConcreteCategory`.
+`forget : C ⥤ Type*`.  We define concrete categories using `class HasForget`.
 In particular, we impose no restrictions on the
 carrier type `C`, so `Type` is a concrete category with the identity
 forgetful functor.
@@ -27,6 +27,11 @@ Two classes helping construct concrete categories in the two most
 common cases are provided in the files `BundledHom` and
 `UnbundledHom`, see their documentation for details.
 
+## Implementation notes
+
+We are currently switching over from `HasForget` to a new class `ConcreteCategory`,
+see Zulip thread: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Concrete.20category.20class.20redesign
+
 ## References
 
 See [Ahrens and Lumsdaine, *Displayed Categories*][ahrens2017] for
@@ -42,27 +47,32 @@ namespace CategoryTheory
 
 /-- A concrete category is a category `C` with a fixed faithful functor `Forget : C ⥤ Type`.
 
-Note that `ConcreteCategory` potentially depends on three independent universe levels,
+Note that `HasForget` potentially depends on three independent universe levels,
 * the universe level `w` appearing in `Forget : C ⥤ Type w`
 * the universe level `v` of the morphisms (i.e. we have a `Category.{v} C`)
 * the universe level `u` of the objects (i.e `C : Type u`)
 They are specified that order, to avoid unnecessary universe annotations.
 -/
-class ConcreteCategory (C : Type u) [Category.{v} C] where
+class HasForget (C : Type u) [Category.{v} C] where
   /-- We have a functor to Type -/
   protected forget : C ⥤ Type w
   /-- That functor is faithful -/
   [forget_faithful : forget.Faithful]
 
-attribute [inline, reducible] ConcreteCategory.forget
-attribute [instance] ConcreteCategory.forget_faithful
+@[deprecated HasForget
+  "`ConcreteCategory` will be refactored, use `HasForget` in the meantime"
+  (since := "2025-01-17")]
+alias ConcreteCategory := HasForget
+
+attribute [inline, reducible] HasForget.forget
+attribute [instance] HasForget.forget_faithful
 
 /-- The forgetful functor from a concrete category to `Type u`. -/
-abbrev forget (C : Type u) [Category.{v} C] [ConcreteCategory.{w} C] : C ⥤ Type w :=
-  ConcreteCategory.forget
+abbrev forget (C : Type u) [Category.{v} C] [HasForget.{w} C] : C ⥤ Type w :=
+  HasForget.forget
 
 -- this is reducible because we want `forget (Type u)` to unfold to `𝟭 _`
-@[instance] abbrev ConcreteCategory.types : ConcreteCategory.{u, u, u+1} (Type u) where
+@[instance] abbrev HasForget.types : HasForget.{u, u, u+1} (Type u) where
   forget := 𝟭 _
 
 /-- Provide a coercion to `Type u` for a concrete category. This is not marked as an instance
@@ -70,24 +80,24 @@ as it could potentially apply to every type, and so is too expensive in typeclas
 
 You can use it on particular examples as:
 ```
-instance : HasCoeToSort X := ConcreteCategory.hasCoeToSort X
+instance : HasCoeToSort X := HasForget.hasCoeToSort X
 ```
 -/
-def ConcreteCategory.hasCoeToSort (C : Type u) [Category.{v} C] [ConcreteCategory.{w} C] :
+def HasForget.hasCoeToSort (C : Type u) [Category.{v} C] [HasForget.{w} C] :
     CoeSort C (Type w) where
   coe X := (forget C).obj X
 
 section
 
-attribute [local instance] ConcreteCategory.hasCoeToSort
+attribute [local instance] HasForget.hasCoeToSort
 
-variable {C : Type u} [Category.{v} C] [ConcreteCategory.{w} C]
+variable {C : Type u} [Category.{v} C] [HasForget.{w} C]
 
 /-- In any concrete category, `(forget C).map` is injective. -/
-abbrev ConcreteCategory.instFunLike {X Y : C} : FunLike (X ⟶ Y) X Y where
+abbrev HasForget.instFunLike {X Y : C} : FunLike (X ⟶ Y) X Y where
   coe f := (forget C).map f
   coe_injective' _ _ h := (forget C).map_injective h
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 /-- In any concrete category, we can test equality of morphisms by pointwise evaluations. -/
 @[ext low] -- Porting note: lowered priority
@@ -134,47 +144,47 @@ end
 /-- `HasForget₂ C D`, where `C` and `D` are both concrete categories, provides a functor
 `forget₂ C D : C ⥤ D` and a proof that `forget₂ ⋙ (forget D) = forget C`.
 -/
-class HasForget₂ (C : Type u) (D : Type u') [Category.{v} C] [ConcreteCategory.{w} C]
-  [Category.{v'} D] [ConcreteCategory.{w} D] where
+class HasForget₂ (C : Type u) (D : Type u') [Category.{v} C] [HasForget.{w} C]
+  [Category.{v'} D] [HasForget.{w} D] where
   /-- A functor from `C` to `D` -/
   forget₂ : C ⥤ D
-  /-- It covers the `ConcreteCategory.forget` for `C` and `D` -/
+  /-- It covers the `HasForget.forget` for `C` and `D` -/
   forget_comp : forget₂ ⋙ forget D = forget C := by aesop
 
 /-- The forgetful functor `C ⥤ D` between concrete categories for which we have an instance
 `HasForget₂ C`. -/
-abbrev forget₂ (C : Type u) (D : Type u') [Category.{v} C] [ConcreteCategory.{w} C]
-    [Category.{v'} D] [ConcreteCategory.{w} D] [HasForget₂ C D] : C ⥤ D :=
+abbrev forget₂ (C : Type u) (D : Type u') [Category.{v} C] [HasForget.{w} C]
+    [Category.{v'} D] [HasForget.{w} D] [HasForget₂ C D] : C ⥤ D :=
   HasForget₂.forget₂
 
-attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] HasForget.instFunLike HasForget.hasCoeToSort
 
-lemma forget₂_comp_apply {C : Type u} {D : Type u'} [Category.{v} C] [ConcreteCategory.{w} C]
-    [Category.{v'} D] [ConcreteCategory.{w} D] [HasForget₂ C D] {X Y Z : C}
+lemma forget₂_comp_apply {C : Type u} {D : Type u'} [Category.{v} C] [HasForget.{w} C]
+    [Category.{v'} D] [HasForget.{w} D] [HasForget₂ C D] {X Y Z : C}
     (f : X ⟶ Y) (g : Y ⟶ Z) (x : (forget₂ C D).obj X) :
     ((forget₂ C D).map (f ≫ g) x) =
       (forget₂ C D).map g ((forget₂ C D).map f x) := by
   rw [Functor.map_comp, comp_apply]
 
-instance forget₂_faithful (C : Type u) (D : Type u') [Category.{v} C] [ConcreteCategory.{w} C]
-    [Category.{v'} D] [ConcreteCategory.{w} D] [HasForget₂ C D] : (forget₂ C D).Faithful :=
+instance forget₂_faithful (C : Type u) (D : Type u') [Category.{v} C] [HasForget.{w} C]
+    [Category.{v'} D] [HasForget.{w} D] [HasForget₂ C D] : (forget₂ C D).Faithful :=
   HasForget₂.forget_comp.faithful_of_comp
 
-instance InducedCategory.concreteCategory {C : Type u} {D : Type u'}
-    [Category.{v'} D] [ConcreteCategory.{w} D] (f : C → D) :
-      ConcreteCategory (InducedCategory D f) where
+instance InducedCategory.hasForget {C : Type u} {D : Type u'}
+    [Category.{v'} D] [HasForget.{w} D] (f : C → D) :
+      HasForget (InducedCategory D f) where
   forget := inducedFunctor f ⋙ forget D
 
 instance InducedCategory.hasForget₂ {C : Type u} {D : Type u'} [Category.{v} D]
-    [ConcreteCategory.{w} D] (f : C → D) : HasForget₂ (InducedCategory D f) D where
+    [HasForget.{w} D] (f : C → D) : HasForget₂ (InducedCategory D f) D where
   forget₂ := inducedFunctor f
   forget_comp := rfl
 
-instance FullSubcategory.concreteCategory {C : Type u} [Category.{v} C] [ConcreteCategory.{w} C]
-    (Z : C → Prop) : ConcreteCategory (FullSubcategory Z) where
+instance FullSubcategory.hasForget {C : Type u} [Category.{v} C] [HasForget.{w} C]
+    (Z : C → Prop) : HasForget (FullSubcategory Z) where
   forget := fullSubcategoryInclusion Z ⋙ forget C
 
-instance FullSubcategory.hasForget₂ {C : Type u} [Category.{v} C] [ConcreteCategory.{w} C]
+instance FullSubcategory.hasForget₂ {C : Type u} [Category.{v} C] [HasForget.{w} C]
     (Z : C → Prop) : HasForget₂ (FullSubcategory Z) C where
   forget₂ := fullSubcategoryInclusion Z
   forget_comp := rfl
@@ -182,8 +192,8 @@ instance FullSubcategory.hasForget₂ {C : Type u} [Category.{v} C] [ConcreteCat
 /-- In order to construct a “partially forgetting” functor, we do not need to verify functor laws;
 it suffices to ensure that compositions agree with `forget₂ C D ⋙ forget D = forget C`.
 -/
-def HasForget₂.mk' {C : Type u} {D : Type u'} [Category.{v} C] [ConcreteCategory.{w} C]
-    [Category.{v'} D] [ConcreteCategory.{w} D]
+def HasForget₂.mk' {C : Type u} {D : Type u'} [Category.{v} C] [HasForget.{w} C]
+    [Category.{v'} D] [HasForget.{w} D]
     (obj : C → D) (h_obj : ∀ X, (forget D).obj (obj X) = (forget C).obj X)
     (map : ∀ {X Y}, (X ⟶ Y) → (obj X ⟶ obj Y))
     (h_map : ∀ {X Y} {f : X ⟶ Y}, HEq ((forget D).map (map f)) ((forget C).map f)) :
@@ -193,9 +203,9 @@ def HasForget₂.mk' {C : Type u} {D : Type u'} [Category.{v} C] [ConcreteCatego
 
 /-- Composition of `HasForget₂` instances. -/
 @[reducible]
-def HasForget₂.trans (C : Type u) [Category.{v} C] [ConcreteCategory.{w} C]
-    (D : Type u') [Category.{v'} D] [ConcreteCategory.{w} D]
-    (E : Type u'') [Category.{v''} E] [ConcreteCategory.{w} E]
+def HasForget₂.trans (C : Type u) [Category.{v} C] [HasForget.{w} C]
+    (D : Type u') [Category.{v'} D] [HasForget.{w} D]
+    (E : Type u'') [Category.{v''} E] [HasForget.{w} E]
     [HasForget₂ C D] [HasForget₂ D E] : HasForget₂ C E where
   forget₂ := CategoryTheory.forget₂ C D ⋙ CategoryTheory.forget₂ D E
   forget_comp := by
@@ -204,13 +214,13 @@ def HasForget₂.trans (C : Type u) [Category.{v} C] [ConcreteCategory.{w} C]
 
 /-- Every forgetful functor factors through the identity functor. This is not a global instance as
     it is prone to creating type class resolution loops. -/
-def hasForgetToType (C : Type u) [Category.{v} C] [ConcreteCategory.{w} C] :
+def hasForgetToType (C : Type u) [Category.{v} C] [HasForget.{w} C] :
     HasForget₂ C (Type w) where
   forget₂ := forget C
   forget_comp := Functor.comp_id _
 
 @[simp]
-lemma NatTrans.naturality_apply {C D : Type*} [Category C] [Category D] [ConcreteCategory D]
+lemma NatTrans.naturality_apply {C D : Type*} [Category C] [Category D] [HasForget D]
     {F G : C ⥤ D} (φ : F ⟶ G) {X Y : C} (f : X ⟶ Y) (x : F.obj X) :
     φ.app Y (F.map f x) = G.map f (φ.app X x) := by
   simpa only [Functor.map_comp] using congr_fun ((forget D).congr_map (φ.naturality f)) x

--- a/Mathlib/CategoryTheory/ConcreteCategory/Bundled.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Bundled.lean
@@ -12,9 +12,9 @@ import Batteries.Tactic.Lint.Misc
 `Bundled c` provides a uniform structure for bundling a type equipped with a type class.
 
 We provide `Category` instances for these in
-`Mathlib/CategoryTheory/ConcreteCategory/UnbundledHom.lean`
+`Mathlib/CategoryTheory/HasForget/UnbundledHom.lean`
 (for categories with unbundled homs, e.g. topological spaces)
-and in `Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean`
+and in `Mathlib/CategoryTheory/HasForget/BundledHom.lean`
 (for categories with bundled homs, e.g. monoids).
 -/
 

--- a/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
@@ -66,7 +66,7 @@ instance category : Category (Bundled c) where
   id_comp _ := by apply 𝒞.hom_ext; simp
 
 /-- A category given by `BundledHom` is a concrete category. -/
-instance concreteCategory : ConcreteCategory.{u} (Bundled c) where
+instance hasForget : HasForget.{u} (Bundled c) where
   forget :=
     { obj := fun X => X
       map := @fun X Y f => 𝒞.toFun X.str Y.str f
@@ -82,7 +82,7 @@ unif_hint (C : Bundled c) where
 
 variable {hom}
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 /-- A version of `HasForget₂.mk'` for categories defined using `@BundledHom`. -/
 def mkHasForget₂ {d : Type u → Type u} {hom_d : ∀ ⦃α β : Type u⦄ (_ : d α) (_ : d β), Type u}

--- a/Mathlib/CategoryTheory/ConcreteCategory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/EpiMono.lean
@@ -25,7 +25,7 @@ universe w v v' u u'
 
 namespace CategoryTheory
 
-variable {C : Type u} [Category.{v} C] [ConcreteCategory.{w} C]
+variable {C : Type u} [Category.{v} C] [HasForget.{w} C]
 
 open Limits MorphismProperty
 
@@ -33,14 +33,14 @@ namespace ConcreteCategory
 
 section
 
-attribute [local instance] ConcreteCategory.instFunLike in
+attribute [local instance] HasForget.instFunLike in
 /-- In any concrete category, injective morphisms are monomorphisms. -/
 theorem mono_of_injective {X Y : C} (f : X ⟶ Y) (i : Function.Injective f) :
     Mono f :=
   (forget C).mono_of_mono_map ((mono_iff_injective ((forget C).map f)).2 i)
 
 instance forget₂_preservesMonomorphisms (C : Type u) (D : Type u')
-    [Category.{v} C] [ConcreteCategory.{w} C] [Category.{v'} D] [ConcreteCategory.{w} D]
+    [Category.{v} C] [HasForget.{w} C] [Category.{v'} D] [HasForget.{w} D]
     [HasForget₂ C D] [(forget C).PreservesMonomorphisms] :
     (forget₂ C D).PreservesMonomorphisms :=
   have : (forget₂ C D ⋙ forget D).PreservesMonomorphisms := by
@@ -49,7 +49,7 @@ instance forget₂_preservesMonomorphisms (C : Type u) (D : Type u')
   Functor.preservesMonomorphisms_of_preserves_of_reflects _ (forget D)
 
 instance forget₂_preservesEpimorphisms (C : Type u) (D : Type u')
-    [Category.{v} C] [ConcreteCategory.{w} C] [Category.{v'} D] [ConcreteCategory.{w} D]
+    [Category.{v} C] [HasForget.{w} C] [Category.{v'} D] [HasForget.{w} D]
     [HasForget₂ C D] [(forget C).PreservesEpimorphisms] :
     (forget₂ C D).PreservesEpimorphisms :=
   have : (forget₂ C D ⋙ forget D).PreservesEpimorphisms := by
@@ -133,8 +133,8 @@ section
 
 open CategoryTheory.Limits
 
-attribute [local instance] ConcreteCategory.hasCoeToSort
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort
+attribute [local instance] HasForget.instFunLike
 
 theorem injective_of_mono_of_preservesPullback {X Y : C} (f : X ⟶ Y) [Mono f]
     [PreservesLimitsOfShape WalkingCospan (forget C)] : Function.Injective f :=

--- a/Mathlib/CategoryTheory/ConcreteCategory/ReflectsIso.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/ReflectsIso.lean
@@ -18,8 +18,8 @@ namespace CategoryTheory
 
 instance : (forget (Type u)).ReflectsIsomorphisms where reflects _ _ _ {i} := i
 
-variable (C : Type (u + 1)) [Category C] [ConcreteCategory.{u} C]
-variable (D : Type (u + 1)) [Category D] [ConcreteCategory.{u} D]
+variable (C : Type (u + 1)) [Category C] [HasForget.{u} C]
+variable (D : Type (u + 1)) [Category D] [HasForget.{u} D]
 
 -- This should not be an instance, as it causes a typeclass loop
 -- with `CategoryTheory.hasForgetToType`.

--- a/Mathlib/CategoryTheory/DifferentialObject.lean
+++ b/Mathlib/CategoryTheory/DifferentialObject.lean
@@ -208,10 +208,10 @@ end DifferentialObject
 namespace DifferentialObject
 
 variable (S : Type*) [AddMonoidWithOne S]
-variable (C : Type (u + 1)) [LargeCategory C] [ConcreteCategory C] [HasZeroMorphisms C]
+variable (C : Type (u + 1)) [LargeCategory C] [HasForget C] [HasZeroMorphisms C]
 variable [HasShift C S]
 
-instance concreteCategoryOfDifferentialObjects : ConcreteCategory (DifferentialObject S C) where
+instance hasForgetOfDifferentialObjects : HasForget (DifferentialObject S C) where
   forget := forget S C ⋙ CategoryTheory.forget C
 
 instance : HasForget₂ (DifferentialObject S C) C where

--- a/Mathlib/CategoryTheory/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/FintypeCat.lean
@@ -53,7 +53,7 @@ def incl : FintypeCat ⥤ Type* :=
 instance : incl.Full := InducedCategory.full _
 instance : incl.Faithful := InducedCategory.faithful _
 
-instance concreteCategoryFintype : ConcreteCategory FintypeCat :=
+instance hasForgetFintype : HasForget FintypeCat :=
   ⟨incl⟩
 
 /- Help typeclass inference infer fullness of forgetful functor. -/

--- a/Mathlib/CategoryTheory/Functor/Flat.lean
+++ b/Mathlib/CategoryTheory/Functor/Flat.lean
@@ -307,7 +307,7 @@ noncomputable def lanEvaluationIsoColim (F : C ⥤ D) (X : D)
         ι_colimMap, whiskerLeft_app]
       rfl)
 
-variable [ConcreteCategory.{u₁} E] [HasLimits E] [HasColimits E]
+variable [HasForget.{u₁} E] [HasLimits E] [HasColimits E]
 variable [ReflectsLimits (forget E)] [PreservesFilteredColimits (forget E)]
 variable [PreservesLimits (forget E)]
 

--- a/Mathlib/CategoryTheory/GradedObject.lean
+++ b/Mathlib/CategoryTheory/GradedObject.lean
@@ -283,10 +283,10 @@ namespace GradedObject
 noncomputable section
 
 variable (β : Type)
-variable (C : Type (u + 1)) [LargeCategory C] [ConcreteCategory C] [HasCoproducts.{0} C]
+variable (C : Type (u + 1)) [LargeCategory C] [HasForget C] [HasCoproducts.{0} C]
   [HasZeroMorphisms C]
 
-instance : ConcreteCategory (GradedObject β C) where forget := total β C ⋙ forget C
+instance : HasForget (GradedObject β C) where forget := total β C ⋙ forget C
 
 instance : HasForget₂ (GradedObject β C) C where forget₂ := total β C
 

--- a/Mathlib/CategoryTheory/Limits/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/ConcreteCategory/Basic.lean
@@ -19,20 +19,20 @@ open CategoryTheory
 
 namespace CategoryTheory.Limits.Concrete
 
-attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] HasForget.instFunLike HasForget.hasCoeToSort
 
 section Limits
 
 /-- If a functor `G : J ⥤ C` to a concrete category has a limit and that `forget C`
 is corepresentable, then `(G ⋙ forget C).sections` is small. -/
 lemma small_sections_of_hasLimit
-    {C : Type u} [Category.{v} C] [ConcreteCategory.{v} C]
+    {C : Type u} [Category.{v} C] [HasForget.{v} C]
     [(forget C).IsCorepresentable] {J : Type w} [Category.{t} J] (G : J ⥤ C) [HasLimit G] :
     Small.{v} (G ⋙ forget C).sections := by
   rw [← Types.hasLimit_iff_small_sections]
   infer_instance
 
-variable {C : Type u} [Category.{v} C] [ConcreteCategory.{max w v} C] {J : Type w} [Category.{t} J]
+variable {C : Type u} [Category.{v} C] [HasForget.{max w v} C] {J : Type w} [Category.{t} J]
   (F : J ⥤ C) [PreservesLimit F (forget C)]
 
 theorem to_product_injective_of_isLimit {D : Cone F} (hD : IsLimit D) :
@@ -64,7 +64,7 @@ section Surjective
 Given surjections `⋯ ⟶ Xₙ₊₁ ⟶ Xₙ ⟶ ⋯ ⟶ X₀` in a concrete category whose forgetful functor
 preserves sequential limits, the projection map `lim Xₙ ⟶ X₀` is surjective.
 -/
-lemma surjective_π_app_zero_of_surjective_map {C : Type u} [Category.{v} C] [ConcreteCategory.{v} C]
+lemma surjective_π_app_zero_of_surjective_map {C : Type u} [Category.{v} C] [HasForget.{v} C]
     [PreservesLimitsOfShape ℕᵒᵖ (forget C)] {F : ℕᵒᵖ ⥤ C} {c : Cone F}
     (hc : IsLimit c) (hF : ∀ n, Function.Surjective (F.map (homOfLE (Nat.le_succ n)).op)) :
     Function.Surjective (c.π.app ⟨0⟩) :=
@@ -78,7 +78,7 @@ section Colimits
 
 section
 
-variable {C : Type u} [Category.{v} C] [ConcreteCategory.{t} C] {J : Type w} [Category.{r} J]
+variable {C : Type u} [Category.{v} C] [HasForget.{t} C] {J : Type w} [Category.{r} J]
   (F : J ⥤ C)
 
 section
@@ -124,7 +124,7 @@ end
 
 section FilteredColimits
 
-variable {C : Type u} [Category.{v} C] [ConcreteCategory.{max t w} C] {J : Type w} [Category.{r} J]
+variable {C : Type u} [Category.{v} C] [HasForget.{max t w} C] {J : Type w} [Category.{r} J]
   (F : J ⥤ C) [PreservesColimit F (forget C)] [IsFiltered J]
 
 theorem isColimit_exists_of_rep_eq {D : Cocone F} {i j : J} (hD : IsColimit D)

--- a/Mathlib/CategoryTheory/Limits/ConcreteCategory/WithAlgebraicStructures.lean
+++ b/Mathlib/CategoryTheory/Limits/ConcreteCategory/WithAlgebraicStructures.lean
@@ -47,7 +47,7 @@ theorem colimit_rep_eq_zero
     ∃ (j' : J) (i : j ⟶ j'), (F.map i).hom x = 0 := by
   -- Break the abstraction barrier between homs and functions for `colimit_rep_eq_iff_exists`.
   have : ∀ (X Y : ModuleCat R) (f : X ⟶ Y),
-    DFunLike.coe f.hom = DFunLike.coe (self := ConcreteCategory.instFunLike) f := fun _ _ _ => rfl
+    DFunLike.coe f.hom = DFunLike.coe (self := HasForget.instFunLike) f := fun _ _ _ => rfl
   rw [show 0 = colimit.ι F j 0 by simp, this, colimit_rep_eq_iff_exists] at hx
   obtain ⟨j', i, y, g⟩ := hx
   exact ⟨j', i, g ▸ by simp [← this]⟩
@@ -68,7 +68,7 @@ lemma colimit_no_zero_smul_divisor
 
   -- Break the abstraction barrier between homs and functions for `Concrete.colimit_exists_rep`.
   have : ∀ (X Y : ModuleCat R) (f : X ⟶ Y),
-    DFunLike.coe f.hom = DFunLike.coe (self := ConcreteCategory.instFunLike) f := fun _ _ _ => rfl
+    DFunLike.coe f.hom = DFunLike.coe (self := HasForget.instFunLike) f := fun _ _ _ => rfl
   classical
   obtain ⟨j, x, rfl⟩ := Concrete.colimit_exists_rep F x
   rw [← this, ← map_smul (colimit.ι F j).hom] at hx

--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -347,7 +347,7 @@ noncomputable instance filtered_colim_preservesFiniteLimits_of_types :
   · exact Functor.mapIso _ (hc.uniqueUpToIso (limit.isLimit F))
   · exact asIso (colimitLimitToLimitColimitCone F)
 
-variable {C : Type u} [Category.{v} C] [ConcreteCategory.{v} C]
+variable {C : Type u} [Category.{v} C] [HasForget.{v} C]
 
 section
 

--- a/Mathlib/CategoryTheory/Limits/MonoCoprod.lean
+++ b/Mathlib/CategoryTheory/Limits/MonoCoprod.lean
@@ -239,7 +239,7 @@ end Preservation
 
 section Concrete
 
-instance [ConcreteCategory C] [PreservesColimitsOfShape (Discrete WalkingPair) (forget C)]
+instance [HasForget C] [PreservesColimitsOfShape (Discrete WalkingPair) (forget C)]
     [ReflectsMonomorphisms (forget C)] : MonoCoprod C :=
   monoCoprod_of_preservesCoprod_of_reflectsMono (forget C)
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -35,7 +35,7 @@ universe w w' v u t r
 
 namespace CategoryTheory.Limits.Concrete
 
-attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] HasForget.instFunLike HasForget.hasCoeToSort
 
 variable {C : Type u} [Category.{v} C]
 
@@ -43,7 +43,7 @@ section Products
 
 section ProductEquiv
 
-variable [ConcreteCategory.{max w v} C] {J : Type w} (F : J → C)
+variable [HasForget.{max w v} C] {J : Type w} (F : J → C)
   [HasProduct F] [PreservesLimit (Discrete.functor F) (forget C)]
 
 /-- The equivalence `(forget C).obj (∏ᶜ F) ≃ ∀ j, F j` if `F : J → C` is a family of objects
@@ -66,7 +66,7 @@ end ProductEquiv
 section ProductExt
 
 variable {J : Type w} (f : J → C) [HasProduct f] {D : Type t} [Category.{r} D]
-  [ConcreteCategory.{max w r} D] (F : C ⥤ D)
+  [HasForget.{max w r} D] (F : C ⥤ D)
   [PreservesLimit (Discrete.functor f) F]
   [HasProduct fun j => F.obj (f j)]
   [PreservesLimitsOfShape WalkingCospan (forget D)]
@@ -89,7 +89,7 @@ end Products
 
 section Terminal
 
-variable [ConcreteCategory.{w} C]
+variable [HasForget.{w} C]
 
 /-- If `forget C` preserves terminals and `X` is terminal, then `(forget C).obj X` is a
 singleton. -/
@@ -124,7 +124,7 @@ end Terminal
 
 section Initial
 
-variable [ConcreteCategory.{w} C]
+variable [HasForget.{w} C]
 
 /-- If `forget C` preserves initials and `X` is initial, then `(forget C).obj X` is empty. -/
 lemma empty_of_initial_of_preserves [PreservesColimit (Functor.empty.{0} C) (forget C)] (X : C)
@@ -149,7 +149,7 @@ end Initial
 
 section BinaryProducts
 
-variable [ConcreteCategory.{w} C] (X₁ X₂ : C) [HasBinaryProduct X₁ X₂]
+variable [HasForget.{w} C] (X₁ X₂ : C) [HasBinaryProduct X₁ X₂]
   [PreservesLimit (pair X₁ X₂) (forget C)]
 
 /-- The equivalence `(forget C).obj (X₁ ⨯ X₂) ≃ ((forget C).obj X₁) × ((forget C).obj X₂)`
@@ -183,7 +183,7 @@ end BinaryProducts
 
 section Pullbacks
 
-variable [ConcreteCategory.{v} C] {X₁ X₂ S : C} (f₁ : X₁ ⟶ S) (f₂ : X₂ ⟶ S)
+variable [HasForget.{v} C] {X₁ X₂ S : C} (f₁ : X₁ ⟶ S) (f₂ : X₂ ⟶ S)
     [HasPullback f₁ f₂] [PreservesLimit (cospan f₁ f₂) (forget C)]
 
 /-- In a concrete category `C`, given two morphisms `f₁ : X₁ ⟶ S` and `f₂ : X₂ ⟶ S`,
@@ -220,7 +220,7 @@ end Pullbacks
 
 section WidePullback
 
-variable [ConcreteCategory.{max w v} C]
+variable [HasForget.{max w v} C]
 
 open WidePullback
 
@@ -247,7 +247,7 @@ end WidePullback
 
 section Multiequalizer
 
-variable [ConcreteCategory.{max w w' v} C]
+variable [HasForget.{max w w' v} C]
 
 theorem multiequalizer_ext {I : MulticospanIndex.{w, w'} C} [HasMultiequalizer I]
     [PreservesLimit I.multicospan (forget C)] (x y : ↑(multiequalizer I))
@@ -315,7 +315,7 @@ open WidePushout
 
 open WidePushoutShape
 
-variable [ConcreteCategory.{v} C]
+variable [HasForget.{v} C]
 
 theorem widePushout_exists_rep {B : C} {α : Type _} {X : α → C} (f : ∀ j : α, B ⟶ X j)
     [HasWidePushout.{v} B X f] [PreservesColimit (wideSpan B X f) (forget C)]
@@ -340,7 +340,7 @@ theorem widePushout_exists_rep' {B : C} {α : Type _} [Nonempty α] {X : α → 
 end WidePushout
 
 -- We don't mark this as an `@[ext]` lemma as we don't always want to work elementwise.
-theorem cokernel_funext {C : Type*} [Category C] [HasZeroMorphisms C] [ConcreteCategory C]
+theorem cokernel_funext {C : Type*} [Category C] [HasZeroMorphisms C] [HasForget C]
     {M N K : C} {f : M ⟶ N} [HasCokernel f] {g h : cokernel f ⟶ K}
     (w : ∀ n : N, g (cokernel.π f n) = h (cokernel.π f n)) : g = h := by
   ext x

--- a/Mathlib/CategoryTheory/MorphismProperty/Concrete.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Concrete.lean
@@ -25,13 +25,13 @@ universe v u
 
 namespace CategoryTheory
 
-variable (C : Type u) [Category.{v} C] [ConcreteCategory C]
+variable (C : Type u) [Category.{v} C] [HasForget C]
 
 namespace MorphismProperty
 
 open Function
 
-attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] HasForget.instFunLike HasForget.hasCoeToSort
 
 /-- Injectiveness (in a concrete category) as a `MorphismProperty` -/
 protected def injective : MorphismProperty C := fun _ _ f => Injective f

--- a/Mathlib/CategoryTheory/Sites/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Sites/Adjunction.lean
@@ -28,7 +28,7 @@ variable {F : D ⥤ E} {G : E ⥤ D}
 
 /-- The forgetful functor from `Sheaf J D` to sheaves of types, for a concrete category `D`
 whose forgetful functor preserves the correct limits. -/
-abbrev sheafForget [ConcreteCategory D] [HasSheafCompose J (forget D)] :
+abbrev sheafForget [HasForget D] [HasSheafCompose J (forget D)] :
     Sheaf J D ⥤ Sheaf J (Type _) :=
   sheafCompose J (forget D)
 
@@ -96,7 +96,7 @@ instance [G.IsLeftAdjoint] : J.PreservesSheafification G :=
 
 section ForgetToType
 
-variable [HasWeakSheafify J D] [ConcreteCategory D] [HasSheafCompose J (forget D)]
+variable [HasWeakSheafify J D] [HasForget D] [HasSheafCompose J (forget D)]
 
 @[deprecated (since := "2024-11-26")] alias composeAndSheafifyFromTypes := composeAndSheafify
 

--- a/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
@@ -31,11 +31,11 @@ universe w
 
 open CategoryTheory Sheaf Limits Opposite
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 namespace CategoryTheory
 
-variable {C : Type*} (D : Type*) [Category C] [Category D] [ConcreteCategory.{w} D]
+variable {C : Type*} (D : Type*) [Category C] [Category D] [HasForget.{w} D]
 
 lemma regularTopology.isLocallySurjective_iff [Preregular C] {F G : Cᵒᵖ ⥤ D} (f : F ⟶ G) :
     Presheaf.IsLocallySurjective (regularTopology C) f ↔

--- a/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
@@ -120,7 +120,7 @@ theorem toSheafify_comp_sheafifyCompIso_inv :
 section
 
 -- We will sheafify `D`-valued presheaves in this section.
-variable [ConcreteCategory.{max v u} D] [PreservesLimits (forget D)]
+variable [HasForget.{max v u} D] [PreservesLimits (forget D)]
   [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)] [(forget D).ReflectsIsomorphisms]
 
 @[simp]

--- a/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
@@ -30,9 +30,9 @@ variable {D : Type w} [Category.{max v u} D]
 
 section
 
-variable [ConcreteCategory.{max v u} D]
+variable [HasForget.{max v u} D]
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/5171): removed @[nolint has_nonempty_instance]
 /-- A concrete version of the multiequalizer, to be used below. -/
@@ -44,9 +44,9 @@ end
 
 namespace Meq
 
-variable [ConcreteCategory.{max v u} D]
+variable [HasForget.{max v u} D]
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 instance {X} (P : Cᵒᵖ ⥤ D) (S : J.Cover X) :
     CoeFun (Meq P S) fun _ => ∀ I : S.Arrow, P.obj (op I.Y) :=
@@ -128,9 +128,9 @@ namespace GrothendieckTopology
 
 namespace Plus
 
-variable [ConcreteCategory.{max v u} D]
+variable [HasForget.{max v u} D]
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 variable [PreservesLimits (forget D)]
 variable [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
@@ -541,7 +541,7 @@ theorem sheafifyMap_sheafifyLift {P Q R : Cᵒᵖ ⥤ D} (η : P ⟶ Q) (γ : Q 
 end GrothendieckTopology
 
 variable (J)
-variable [ConcreteCategory.{max v u} D] [PreservesLimits (forget D)]
+variable [HasForget.{max v u} D] [PreservesLimits (forget D)]
   [∀ (P : Cᵒᵖ ⥤ D) (X : C) (S : J.Cover X), HasMultiequalizer (S.index P)]
   [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
   [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)] [(forget D).ReflectsIsomorphisms]

--- a/Mathlib/CategoryTheory/Sites/EpiMono.lean
+++ b/Mathlib/CategoryTheory/Sites/EpiMono.lean
@@ -26,7 +26,7 @@ namespace CategoryTheory
 open Category ConcreteCategory
 
 variable {C : Type u} [Category.{v} C] (J : GrothendieckTopology C)
-  (A : Type u') [Category.{v'} A] [ConcreteCategory.{w} A]
+  (A : Type u') [Category.{v'} A] [HasForget.{w} A]
   [HasFunctorialSurjectiveInjectiveFactorization A]
   [J.WEqualsLocallyBijective A]
 

--- a/Mathlib/CategoryTheory/Sites/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Sites/Equivalence.lean
@@ -269,7 +269,7 @@ lemma PreservesSheafification.transport
       K.W_whiskerLeft_iff (G := G) (J := J) (f := whiskerRight f F)] at this
 
 variable [Functor.IsContinuous.{v₃} G K J] [(G.sheafPushforwardContinuous A K J).EssSurj]
-variable [G.IsCocontinuous K J] [ConcreteCategory A]
+variable [G.IsCocontinuous K J] [HasForget A]
   [K.WEqualsLocallyBijective A]
 
 lemma WEqualsLocallyBijective.transport (hG : CoverPreserving K J G) :

--- a/Mathlib/CategoryTheory/Sites/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Sites/LeftExact.lean
@@ -112,7 +112,7 @@ instance preservesLimits_diagramFunctor (X : C) [HasLimits D] :
   apply preservesLimitsOfShape_diagramFunctor.{w, v, u}
 
 variable [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
-variable [ConcreteCategory.{max v u} D]
+variable [HasForget.{max v u} D]
 variable [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)]
 
 /-- An auxiliary definition to be used in the proof that `J.plusFunctor D` commutes
@@ -227,7 +227,7 @@ section
 variable {D : Type w} [Category.{max v u} D]
 variable [∀ (P : Cᵒᵖ ⥤ D) (X : C) (S : J.Cover X), HasMultiequalizer (S.index P)]
 variable [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
-variable [ConcreteCategory.{max v u} D]
+variable [HasForget.{max v u} D]
 variable [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)]
 variable [PreservesLimits (forget D)]
 variable [(forget D).ReflectsIsomorphisms]

--- a/Mathlib/CategoryTheory/Sites/LocallyBijective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallyBijective.lean
@@ -24,7 +24,7 @@ universe w' w v' v u' u
 namespace CategoryTheory
 
 variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
-  {A : Type u'} [Category.{v'} A] [ConcreteCategory.{w} A]
+  {A : Type u'} [Category.{v'} A] [HasForget.{w} A]
 
 namespace Sheaf
 
@@ -144,7 +144,7 @@ lemma WEqualsLocallyBijective.mk' [HasWeakSheafify J A] [(forget A).ReflectsIsom
       CategoryTheory.toSheafify_naturality, Presheaf.comp_isLocallyInjective_iff,
       Presheaf.comp_isLocallySurjective_iff]
 
-instance {D : Type w} [Category.{w'} D] [ConcreteCategory.{max u v} D]
+instance {D : Type w} [Category.{w'} D] [HasForget.{max u v} D]
     [HasWeakSheafify J D] [J.HasSheafCompose (forget D)]
     [J.PreservesSheafification (forget D)] [(forget D).ReflectsIsomorphisms] :
     J.WEqualsLocallyBijective D := by

--- a/Mathlib/CategoryTheory/Sites/LocallyInjective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallyInjective.lean
@@ -29,10 +29,10 @@ namespace CategoryTheory
 open Opposite Limits
 
 variable {C : Type u} [Category.{v} C]
-  {D : Type u'} [Category.{v'} D] [ConcreteCategory.{w} D]
+  {D : Type u'} [Category.{v'} D] [HasForget.{w} D]
   (J : GrothendieckTopology C)
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 namespace Presheaf
 
@@ -189,7 +189,7 @@ instance isLocallyInjective_toSheafify (P : Cᵒᵖ ⥤ Type max u v) :
   rw [GrothendieckTopology.plusMap_toPlus]
   infer_instance
 
-instance isLocallyInjective_toSheafify' [ConcreteCategory.{max u v} D]
+instance isLocallyInjective_toSheafify' [HasForget.{max u v} D]
     (P : Cᵒᵖ ⥤ D) [HasWeakSheafify J D] [J.HasSheafCompose (forget D)]
     [J.PreservesSheafification (forget D)] :
     IsLocallyInjective J (toSheafify J P) := by

--- a/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
@@ -33,9 +33,9 @@ namespace CategoryTheory
 
 variable {C : Type u} [Category.{v} C] (J : GrothendieckTopology C)
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
-variable {A : Type u'} [Category.{v'} A] [ConcreteCategory.{w'} A]
+variable {A : Type u'} [Category.{v'} A] [HasForget.{w'} A]
 
 namespace Presheaf
 
@@ -295,7 +295,7 @@ instance isLocallySurjective_toSheafify (P : Cᵒᵖ ⥤ Type max u v) :
   infer_instance
 
 instance isLocallySurjective_toSheafify' {D : Type*} [Category D]
-    [ConcreteCategory.{max u v} D]
+    [HasForget.{max u v} D]
     (P : Cᵒᵖ ⥤ D) [HasWeakSheafify J D] [J.HasSheafCompose (forget D)]
     [J.PreservesSheafification (forget D)] :
     IsLocallySurjective J (toSheafify J P) := by

--- a/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
@@ -24,7 +24,7 @@ namespace CategoryTheory
 
 namespace Presheaf
 
-variable [ConcreteCategory A]
+variable [HasForget A]
 
 lemma isLocallyInjective_whisker [H.IsCocontinuous J K] [IsLocallyInjective K f] :
     IsLocallyInjective J (whiskerLeft H.op f) where

--- a/Mathlib/CategoryTheory/Sites/PreservesSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesSheafification.lean
@@ -249,7 +249,7 @@ variable {D E : Type*} [Category.{max v u} D] [Category.{max v u} E] (F : D ⥤ 
   [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ E]
   [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ F]
   [∀ (X : C) (W : J.Cover X) (P : Cᵒᵖ ⥤ D), PreservesLimit (W.index P).multicospan F]
-  [ConcreteCategory D] [ConcreteCategory E]
+  [HasForget D] [HasForget E]
   [∀ X, PreservesColimitsOfShape (Cover J X)ᵒᵖ (forget D)]
   [∀ X, PreservesColimitsOfShape (Cover J X)ᵒᵖ (forget E)]
   [PreservesLimits (forget D)] [PreservesLimits (forget E)]
@@ -285,7 +285,7 @@ instance : PreservesSheafification J F := by
 end
 
 example {D : Type*} [Category.{max v u} D]
-  [ConcreteCategory.{max v u} D] [PreservesLimits (forget D)]
+  [HasForget.{max v u} D] [PreservesLimits (forget D)]
   [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
   [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)]
   [∀ (α β : Type max u v) (fst snd : β → α),

--- a/Mathlib/CategoryTheory/Sites/Pullback.lean
+++ b/Mathlib/CategoryTheory/Sites/Pullback.lean
@@ -105,7 +105,7 @@ variable {C : Type v₁} [SmallCategory C] {D : Type v₁} [SmallCategory D] (G 
   (J : GrothendieckTopology C) (K : GrothendieckTopology D)
 
 -- The favourable assumptions under which we have sheafification
-variable [ConcreteCategory.{v₁} A] [PreservesLimits (forget A)] [HasColimits A] [HasLimits A]
+variable [HasForget.{v₁} A] [PreservesLimits (forget A)] [HasColimits A] [HasLimits A]
   [PreservesFilteredColimits (forget A)] [(forget A).ReflectsIsomorphisms]
   [Functor.IsContinuous.{v₁} G J K]
 

--- a/Mathlib/CategoryTheory/Sites/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheaf.lean
@@ -75,10 +75,10 @@ https://stacks.math.columbia.edu/tag/00VR
 def IsSheaf (P : Cᵒᵖ ⥤ A) : Prop :=
   ∀ E : A, Presieve.IsSheaf J (P ⋙ coyoneda.obj (op E))
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike in
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike in
 /-- Condition that a presheaf with values in a concrete category is separated for
 a Grothendieck topology. -/
-def IsSeparated (P : Cᵒᵖ ⥤ A) [ConcreteCategory A] : Prop :=
+def IsSeparated (P : Cᵒᵖ ⥤ A) [HasForget A] : Prop :=
   ∀ (X : C) (S : Sieve X) (_ : S ∈ J X) (x y : P.obj (op X)),
     (∀ (Y : C) (f : Y ⟶ X) (_ : S f), P.map f.op x = P.map f.op y) → x = y
 

--- a/Mathlib/CategoryTheory/Sites/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Sites/Whiskering.lean
@@ -141,13 +141,13 @@ instance hasSheafCompose_of_preservesLimitsOfSize [PreservesLimitsOfSize.{v₁, 
 
 variable {J}
 
-lemma Sheaf.isSeparated [ConcreteCategory A] [J.HasSheafCompose (forget A)]
+lemma Sheaf.isSeparated [HasForget A] [J.HasSheafCompose (forget A)]
     (F : Sheaf J A) : Presheaf.IsSeparated J F.val := by
   rintro X S hS x y h
   exact (Presieve.isSeparated_of_isSheaf _ _ ((isSheaf_iff_isSheaf_of_type _ _).1
     ((sheafCompose J (forget A)).obj F).2) S hS).ext (fun _ _ hf => h _ _ hf)
 
-lemma Presheaf.IsSheaf.isSeparated {F : Cᵒᵖ ⥤ A} [ConcreteCategory A]
+lemma Presheaf.IsSheaf.isSeparated {F : Cᵒᵖ ⥤ A} [HasForget A]
     [J.HasSheafCompose (forget A)] (hF : Presheaf.IsSheaf J F) :
     Presheaf.IsSeparated J F :=
   Sheaf.isSeparated ⟨F, hF⟩

--- a/Mathlib/Condensed/Discrete/Characterization.lean
+++ b/Mathlib/Condensed/Discrete/Characterization.lean
@@ -33,7 +33,7 @@ universe u
 
 open CategoryTheory Limits Functor FintypeCat
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 namespace Condensed
 

--- a/Mathlib/Condensed/Discrete/Colimit.lean
+++ b/Mathlib/Condensed/Discrete/Colimit.lean
@@ -21,7 +21,7 @@ noncomputable section
 
 open CategoryTheory Functor Limits FintypeCat CompHausLike.LocallyConstant
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 namespace Condensed
 

--- a/Mathlib/Condensed/Discrete/LocallyConstant.lean
+++ b/Mathlib/Condensed/Discrete/LocallyConstant.lean
@@ -69,7 +69,7 @@ universe u w
 
 open CategoryTheory Limits LocallyConstant TopologicalSpace.Fiber Opposite Function Fiber
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 variable {P : TopCat.{u} → Prop}
 

--- a/Mathlib/Condensed/Discrete/Module.lean
+++ b/Mathlib/Condensed/Discrete/Module.lean
@@ -24,7 +24,7 @@ universe w u
 
 open CategoryTheory LocallyConstant CompHausLike Functor Category Functor Opposite
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 variable {P : TopCat.{u} → Prop}
 

--- a/Mathlib/Condensed/Epi.lean
+++ b/Mathlib/Condensed/Epi.lean
@@ -21,11 +21,11 @@ universe v u w u' v'
 
 open CategoryTheory Sheaf Opposite Limits Condensed ConcreteCategory
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 namespace Condensed
 
-variable (A : Type u') [Category.{v'} A] [ConcreteCategory.{v'} A]
+variable (A : Type u') [Category.{v'} A] [HasForget.{v'} A]
   [HasFunctorialSurjectiveInjectiveFactorization A]
 
 variable {X Y : Condensed.{u} A} (f : X ⟶ Y)

--- a/Mathlib/Condensed/Explicit.lean
+++ b/Mathlib/Condensed/Explicit.lean
@@ -54,7 +54,7 @@ forgetful functor preserves finite products.
 -/
 noncomputable def ofSheafForgetStonean
     [∀ X, HasLimitsOfShape (StructuredArrow X Stonean.toCompHaus.op) A]
-    [ConcreteCategory A] [ReflectsFiniteProducts (CategoryTheory.forget A)]
+    [HasForget A] [ReflectsFiniteProducts (CategoryTheory.forget A)]
     (F : Stonean.{u}ᵒᵖ ⥤ A) [PreservesFiniteProducts (F ⋙ CategoryTheory.forget A)] :
     Condensed A :=
   StoneanCompHaus.equivalence A |>.functor.obj {
@@ -84,7 +84,7 @@ forgetful functor preserves finite products and satisfies the equalizer conditio
 -/
 noncomputable def ofSheafForgetProfinite
     [∀ X, HasLimitsOfShape (StructuredArrow X profiniteToCompHaus.op) A]
-    [ConcreteCategory A] [ReflectsFiniteLimits (CategoryTheory.forget A)]
+    [HasForget A] [ReflectsFiniteLimits (CategoryTheory.forget A)]
     (F : Profinite.{u}ᵒᵖ ⥤ A) [PreservesFiniteProducts (F ⋙ CategoryTheory.forget A)]
     (hF : EqualizerCondition (F ⋙ CategoryTheory.forget A)) :
     Condensed A :=
@@ -112,7 +112,7 @@ The condensed object associated to a presheaf on `CompHaus` whose postcompositio
 forgetful functor preserves finite products and satisfies the equalizer condition.
 -/
 noncomputable def ofSheafForgetCompHaus
-    [ConcreteCategory A] [ReflectsFiniteLimits (CategoryTheory.forget A)]
+    [HasForget A] [ReflectsFiniteLimits (CategoryTheory.forget A)]
     (F : CompHaus.{u}ᵒᵖ ⥤ A) [PreservesFiniteProducts (F ⋙ CategoryTheory.forget A)]
     (hF : EqualizerCondition (F ⋙ CategoryTheory.forget A)) : Condensed A where
   val := F

--- a/Mathlib/Condensed/Light/Epi.lean
+++ b/Mathlib/Condensed/Light/Epi.lean
@@ -19,13 +19,13 @@ Further, we prove that the functor `lim : Discrete ℕ ⥤ LightCondMod R` prese
 
 universe v u w u' v'
 
-open CategoryTheory Sheaf Limits ConcreteCategory GrothendieckTopology
+open CategoryTheory Sheaf Limits HasForget GrothendieckTopology
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 namespace LightCondensed
 
-variable (A : Type u') [Category.{v'} A] [ConcreteCategory.{w} A]
+variable (A : Type u') [Category.{v'} A] [HasForget.{w} A]
   [PreservesFiniteProducts (CategoryTheory.forget A)]
 
 variable {X Y : LightCondensed.{u} A} (f : X ⟶ Y)

--- a/Mathlib/Condensed/Light/Explicit.lean
+++ b/Mathlib/Condensed/Light/Explicit.lean
@@ -50,7 +50,7 @@ the forgetful functor preserves finite products and satisfies the equalizer cond
 -/
 @[simps]
 noncomputable def ofSheafForgetLightProfinite
-    [ConcreteCategory A] [ReflectsFiniteLimits (CategoryTheory.forget A)]
+    [HasForget A] [ReflectsFiniteLimits (CategoryTheory.forget A)]
     (F : LightProfinite.{u}ᵒᵖ ⥤ A) [PreservesFiniteProducts (F ⋙ CategoryTheory.forget A)]
     (hF : EqualizerCondition (F ⋙ CategoryTheory.forget A)) : LightCondensed A where
   val := F

--- a/Mathlib/Condensed/Light/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/Light/TopCatAdjunction.lean
@@ -22,7 +22,7 @@ universe u
 
 open LightCondensed LightCondSet CategoryTheory LightProfinite
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 namespace LightCondSet
 

--- a/Mathlib/Condensed/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/TopCatAdjunction.lean
@@ -21,7 +21,7 @@ universe u
 
 open Condensed CondensedSet CategoryTheory CompHaus
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 variable (X : CondensedSet.{u})
 

--- a/Mathlib/Condensed/TopComparison.lean
+++ b/Mathlib/Condensed/TopComparison.lean
@@ -25,7 +25,7 @@ universe w w' v u
 
 open CategoryTheory Opposite Limits regularTopology ContinuousMap Topology
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 variable {C : Type u} [Category.{v} C] (G : C ⥤ TopCat.{w})
   (X : Type w') [TopologicalSpace X]

--- a/Mathlib/Geometry/RingedSpace/Basic.lean
+++ b/Mathlib/Geometry/RingedSpace/Basic.lean
@@ -95,7 +95,7 @@ theorem isUnit_res_of_isUnit_germ (U : Opens X) (f : X.presheaf.obj (op U)) (x :
 /-- Specialize `TopCat.Presheaf.germ_res_apply` to sheaves of rings.
 
 This is unfortunately needed because the results on presheaves are stated using the
-`ConcreteCategory.instFunLike` instance, which is not reducibly equal to the actual coercion of
+`HasForget.instFunLike` instance, which is not reducibly equal to the actual coercion of
 morphisms in `CommRingCat` to functions.
 -/
 lemma _root_.CommRingCat.germ_res_apply
@@ -107,7 +107,7 @@ lemma _root_.CommRingCat.germ_res_apply
 /-- Specialize `TopCat.Presheaf.germ_res_apply'` to sheaves of rings.
 
 This is unfortunately needed because the results on presheaves are stated using the
-`ConcreteCategory.instFunLike` instance, which is not reducibly equal to the actual coercion of
+`HasForget.instFunLike` instance, which is not reducibly equal to the actual coercion of
 morphisms in `CommRingCat` to functions.
 -/
 lemma _root_.CommRingCat.germ_res_apply'
@@ -149,13 +149,13 @@ theorem isUnit_of_isUnit_germ (U : Opens X) (f : X.presheaf.obj (op U))
       congr_arg (X.presheaf.germ (V y) z hzVy) (hg y), RingHom.map_one, RingHom.map_one]
   -- We claim that these local inverses glue together to a global inverse of `f`.
   obtain ⟨gl, gl_spec, -⟩ :
-    -- We need to rephrase the result from `ConcreteCategory` to `CommRingCat`.
+    -- We need to rephrase the result from `HasForget` to `CommRingCat`.
     ∃ gl : X.presheaf.obj (op U), (∀ i, ((sheaf X).val.map (iVU i).op) gl = g i) ∧ _ :=
     X.sheaf.existsUnique_gluing' V U iVU hcover g ic
   apply isUnit_of_mul_eq_one f gl
   apply X.sheaf.eq_of_locally_eq' V U iVU hcover
   intro i
-  -- We need to rephrase the goal from `ConcreteCategory` to `CommRingCat`.
+  -- We need to rephrase the goal from `HasForget` to `CommRingCat`.
   show ((sheaf X).val.map (iVU i).op).hom (f * gl) = ((sheaf X).val.map (iVU i).op) 1
   rw [RingHom.map_one, RingHom.map_mul, gl_spec]
   exact hg i

--- a/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
+++ b/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
@@ -718,7 +718,7 @@ end Pullback
 
 section OfStalkIso
 
-variable [HasLimits C] [HasColimits C] [ConcreteCategory C]
+variable [HasLimits C] [HasColimits C] [HasForget C]
 variable [(CategoryTheory.forget C).ReflectsIsomorphisms]
   [PreservesLimits (CategoryTheory.forget C)]
 

--- a/Mathlib/Geometry/RingedSpace/SheafedSpace.lean
+++ b/Mathlib/Geometry/RingedSpace/SheafedSpace.lean
@@ -209,14 +209,14 @@ instance [HasLimits C] : HasColimits.{v} (SheafedSpace C) :=
 noncomputable instance [HasLimits C] : PreservesColimits (forget.{_, _, v} C) :=
   Limits.comp_preservesColimits forgetToPresheafedSpace (PresheafedSpace.forget C)
 
-section ConcreteCategory
+section HasForget
 
-variable [ConcreteCategory.{v} C] [HasColimits C] [HasLimits C]
+variable [HasForget.{v} C] [HasColimits C] [HasLimits C]
 variable  [PreservesLimits (CategoryTheory.forget C)]
 variable [PreservesFilteredColimits (CategoryTheory.forget C)]
 variable [(CategoryTheory.forget C).ReflectsIsomorphisms]
 
-attribute [local instance] ConcreteCategory.instFunLike in
+attribute [local instance] HasForget.instFunLike in
 lemma hom_stalk_ext {X Y : SheafedSpace C} (f g : X ⟶ Y) (h : f.base = g.base)
     (h' : ∀ x, f.stalkMap x = (Y.presheaf.stalkCongr (h ▸ rfl)).hom ≫ g.stalkMap x) :
     f = g := by
@@ -241,7 +241,7 @@ lemma mono_of_base_injective_of_stalk_epi {X Y : SheafedSpace C} (f : X ⟶ Y)
     ← PresheafedSpace.stalkMap.comp ⟨g, gc⟩ f, ← PresheafedSpace.stalkMap.comp ⟨g, hc⟩ f]
   congr 1
 
-end ConcreteCategory
+end HasForget
 
 end SheafedSpace
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat.lean
@@ -80,7 +80,7 @@ abbrev ofHom {X : Type v} [AddCommGroup X] [Module R X]
     Hom.toIsometry (𝟙 M) = Isometry.id _ :=
   rfl
 
-instance concreteCategory : ConcreteCategory.{v} (QuadraticModuleCat.{v} R) where
+instance hasForget : HasForget.{v} (QuadraticModuleCat.{v} R) where
   forget :=
     { obj := fun M => M
       map := fun f => f.toIsometry }

--- a/Mathlib/MeasureTheory/Category/MeasCat.lean
+++ b/Mathlib/MeasureTheory/Category/MeasCat.lean
@@ -61,9 +61,9 @@ instance unbundledHom : UnbundledHom @Measurable :=
 
 deriving instance LargeCategory for MeasCat
 
--- Porting note: `deriving instance ConcreteCategory for MeasCat` didn't work. Define it manually.
+-- Porting note: `deriving instance HasForget for MeasCat` didn't work. Define it manually.
 -- see https://github.com/leanprover-community/mathlib4/issues/5020
-instance : ConcreteCategory MeasCat := by
+instance : HasForget MeasCat := by
   unfold MeasCat
   infer_instance
 
@@ -71,7 +71,7 @@ instance : Inhabited MeasCat :=
   ⟨MeasCat.of Empty⟩
 
 -- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 /-- `Measure X` is the measurable space of measures over the measurable space `X`. It is the
 weakest measurable space, s.t. `fun μ ↦ μ s` is measurable for all measurable sets `s` in `X`. An

--- a/Mathlib/Order/Category/BddDistLat.lean
+++ b/Mathlib/Order/Category/BddDistLat.lean
@@ -60,8 +60,8 @@ theorem coe_toBddLat (X : BddDistLat) : ↥X.toBddLat = ↥X :=
 instance : LargeCategory.{u} BddDistLat :=
   InducedCategory.category toBddLat
 
-instance : ConcreteCategory BddDistLat :=
-  InducedCategory.concreteCategory toBddLat
+instance : HasForget BddDistLat :=
+  InducedCategory.hasForget toBddLat
 
 instance hasForgetToDistLat : HasForget₂ BddDistLat DistLat where
   forget₂ :=

--- a/Mathlib/Order/Category/BddLat.lean
+++ b/Mathlib/Order/Category/BddLat.lean
@@ -62,7 +62,7 @@ instance : LargeCategory.{u} BddLat where
 instance instFunLike (X Y : BddLat) : FunLike (X ⟶ Y) X Y :=
   show FunLike (BoundedLatticeHom X Y) X Y from inferInstance
 
-instance : ConcreteCategory BddLat where
+instance : HasForget BddLat where
   forget :=
   { obj := (↑)
     map := DFunLike.coe }

--- a/Mathlib/Order/Category/BddOrd.lean
+++ b/Mathlib/Order/Category/BddOrd.lean
@@ -59,7 +59,7 @@ instance largeCategory : LargeCategory.{u} BddOrd where
 instance instFunLike (X Y : BddOrd) : FunLike (X ⟶ Y) X Y :=
   show FunLike (BoundedOrderHom X Y) X Y from inferInstance
 
-instance concreteCategory : ConcreteCategory BddOrd where
+instance hasForget : HasForget BddOrd where
   forget :=
     { obj := (↥)
       map := DFunLike.coe }

--- a/Mathlib/Order/Category/BoolAlg.lean
+++ b/Mathlib/Order/Category/BoolAlg.lean
@@ -53,8 +53,8 @@ theorem coe_toBddDistLat (X : BoolAlg) : ↥X.toBddDistLat = ↥X :=
 instance : LargeCategory.{u} BoolAlg :=
   InducedCategory.category toBddDistLat
 
-instance : ConcreteCategory BoolAlg :=
-  InducedCategory.concreteCategory toBddDistLat
+instance : HasForget BoolAlg :=
+  InducedCategory.hasForget toBddDistLat
 
 instance hasForgetToBddDistLat : HasForget₂ BoolAlg BddDistLat :=
   InducedCategory.hasForget₂ toBddDistLat

--- a/Mathlib/Order/Category/CompleteLat.lean
+++ b/Mathlib/Order/Category/CompleteLat.lean
@@ -48,7 +48,7 @@ instance : BundledHom @CompleteLatticeHom where
 
 deriving instance LargeCategory for CompleteLat
 
-instance : ConcreteCategory CompleteLat := by
+instance : HasForget CompleteLat := by
   dsimp [CompleteLat]; infer_instance
 
 instance hasForgetToBddLat : HasForget₂ CompleteLat BddLat where

--- a/Mathlib/Order/Category/DistLat.lean
+++ b/Mathlib/Order/Category/DistLat.lean
@@ -49,8 +49,8 @@ instance : BundledHom.ParentProjection @DistribLattice.toLattice :=
 
 deriving instance LargeCategory for DistLat
 
-instance : ConcreteCategory DistLat :=
-  BundledHom.concreteCategory _
+instance : HasForget DistLat :=
+  BundledHom.hasForget _
 
 instance hasForgetToLat : HasForget₂ DistLat Lat :=
   BundledHom.forget₂ _ _

--- a/Mathlib/Order/Category/FinBddDistLat.lean
+++ b/Mathlib/Order/Category/FinBddDistLat.lean
@@ -56,8 +56,8 @@ instance : Inhabited FinBddDistLat :=
 instance largeCategory : LargeCategory FinBddDistLat :=
   InducedCategory.category toBddDistLat
 
-instance concreteCategory : ConcreteCategory FinBddDistLat :=
-  InducedCategory.concreteCategory toBddDistLat
+instance hasForget : HasForget FinBddDistLat :=
+  InducedCategory.hasForget toBddDistLat
 
 instance hasForgetToBddDistLat : HasForget₂ FinBddDistLat BddDistLat :=
   InducedCategory.hasForget₂ FinBddDistLat.toBddDistLat

--- a/Mathlib/Order/Category/FinBoolAlg.lean
+++ b/Mathlib/Order/Category/FinBoolAlg.lean
@@ -66,8 +66,8 @@ instance : Inhabited FinBoolAlg :=
 instance largeCategory : LargeCategory FinBoolAlg :=
   InducedCategory.category FinBoolAlg.toBoolAlg
 
-instance concreteCategory : ConcreteCategory FinBoolAlg :=
-  InducedCategory.concreteCategory FinBoolAlg.toBoolAlg
+instance hasForget : HasForget FinBoolAlg :=
+  InducedCategory.hasForget FinBoolAlg.toBoolAlg
 
 instance instFunLike {X Y : FinBoolAlg} : FunLike (X ⟶ Y) X Y :=
   BoundedLatticeHom.instFunLike

--- a/Mathlib/Order/Category/FinPartOrd.lean
+++ b/Mathlib/Order/Category/FinPartOrd.lean
@@ -55,8 +55,8 @@ instance : Inhabited FinPartOrd :=
 instance largeCategory : LargeCategory FinPartOrd :=
   InducedCategory.category FinPartOrd.toPartOrd
 
-instance concreteCategory : ConcreteCategory FinPartOrd :=
-  InducedCategory.concreteCategory FinPartOrd.toPartOrd
+instance hasForget : HasForget FinPartOrd :=
+  InducedCategory.hasForget FinPartOrd.toPartOrd
 
 instance hasForgetToPartOrd : HasForget₂ FinPartOrd PartOrd :=
   InducedCategory.hasForget₂ FinPartOrd.toPartOrd

--- a/Mathlib/Order/Category/Frm.lean
+++ b/Mathlib/Order/Category/Frm.lean
@@ -56,11 +56,11 @@ instance bundledHom : BundledHom Hom where
   comp _ _ _ := FrameHom.comp
   hom_ext _ _ := DFunLike.coe_injective
 
--- Porting note: Originally `deriving instance LargeCategory, ConcreteCategory for Frm`
+-- Porting note: Originally `deriving instance LargeCategory, HasForget for Frm`
 -- see https://github.com/leanprover-community/mathlib4/issues/5020
 deriving instance LargeCategory, Category for Frm
 
-instance : ConcreteCategory Frm := by
+instance : HasForget Frm := by
   unfold Frm
   infer_instance
 

--- a/Mathlib/Order/Category/HeytAlg.lean
+++ b/Mathlib/Order/Category/HeytAlg.lean
@@ -50,7 +50,7 @@ deriving instance LargeCategory for HeytAlg
 
 -- Porting note: deriving failed.
 -- see https://github.com/leanprover-community/mathlib4/issues/5020
-instance : ConcreteCategory HeytAlg := by
+instance : HasForget HeytAlg := by
   dsimp [HeytAlg]
   infer_instance
 

--- a/Mathlib/Order/Category/Lat.lean
+++ b/Mathlib/Order/Category/Lat.lean
@@ -57,8 +57,8 @@ instance : BundledHom @LatticeHom where
 instance : LargeCategory.{u} Lat :=
   BundledHom.category LatticeHom
 
-instance : ConcreteCategory Lat :=
-  BundledHom.concreteCategory LatticeHom
+instance : HasForget Lat :=
+  BundledHom.hasForget LatticeHom
 
 instance hasForgetToPartOrd : HasForget₂ Lat PartOrd where
   forget₂ :=

--- a/Mathlib/Order/Category/LinOrd.lean
+++ b/Mathlib/Order/Category/LinOrd.lean
@@ -28,8 +28,8 @@ instance : BundledHom.ParentProjection @LinearOrder.toPartialOrder :=
 deriving instance LargeCategory for LinOrd
 
 -- Porting note: Probably see https://github.com/leanprover-community/mathlib4/issues/5020
-instance : ConcreteCategory LinOrd :=
-  BundledHom.concreteCategory _
+instance : HasForget LinOrd :=
+  BundledHom.hasForget _
 
 instance : CoeSort LinOrd Type* :=
   Bundled.coeSort

--- a/Mathlib/Order/Category/NonemptyFinLinOrd.lean
+++ b/Mathlib/Order/Category/NonemptyFinLinOrd.lean
@@ -59,8 +59,8 @@ instance : BundledHom.ParentProjection @NonemptyFiniteLinearOrder.toLinearOrder 
 deriving instance LargeCategory for NonemptyFinLinOrd
 
 -- Porting note: probably see https://github.com/leanprover-community/mathlib4/issues/5020
-instance : ConcreteCategory NonemptyFinLinOrd :=
-  BundledHom.concreteCategory _
+instance : HasForget NonemptyFinLinOrd :=
+  BundledHom.hasForget _
 
 instance : CoeSort NonemptyFinLinOrd Type* :=
   Bundled.coeSort

--- a/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
@@ -19,7 +19,7 @@ an `OmegaCompletePartialOrder`.
 ## Main definitions
 
  * `ωCPO`
-   * an instance of `Category` and `ConcreteCategory`
+   * an instance of `Category` and `HasForget`
 
  -/
 
@@ -43,9 +43,9 @@ instance : BundledHom @ContinuousHom where
   comp := @ContinuousHom.comp
   hom_ext := @ContinuousHom.coe_inj
 
--- Porting note: `deriving instance ConcreteCategory` didn't work.
+-- Porting note: `deriving instance HasForget` didn't work.
 deriving instance LargeCategory for ωCPO
-instance : ConcreteCategory ωCPO := by unfold ωCPO; infer_instance
+instance : HasForget ωCPO := by unfold ωCPO; infer_instance
 
 instance : CoeSort ωCPO Type* :=
   Bundled.coeSort

--- a/Mathlib/Order/Category/PartOrd.lean
+++ b/Mathlib/Order/Category/PartOrd.lean
@@ -30,8 +30,8 @@ instance : BundledHom.ParentProjection @PartialOrder.toPreorder :=
 deriving instance LargeCategory for PartOrd
 
 -- Porting note: probably see https://github.com/leanprover-community/mathlib4/issues/5020
-instance : ConcreteCategory PartOrd :=
-  BundledHom.concreteCategory _
+instance : HasForget PartOrd :=
+  BundledHom.hasForget _
 
 instance : CoeSort PartOrd Type* :=
   Bundled.coeSort

--- a/Mathlib/Order/Category/Preord.lean
+++ b/Mathlib/Order/Category/Preord.lean
@@ -35,8 +35,8 @@ instance : BundledHom @OrderHom where
 deriving instance LargeCategory for Preord
 
 -- Porting note: probably see https://github.com/leanprover-community/mathlib4/issues/5020
-instance : ConcreteCategory Preord :=
-  BundledHom.concreteCategory _
+instance : HasForget Preord :=
+  BundledHom.hasForget _
 
 instance : CoeSort Preord Type* :=
   Bundled.coeSort

--- a/Mathlib/Order/Category/Semilat.lean
+++ b/Mathlib/Order/Category/Semilat.lean
@@ -67,7 +67,7 @@ instance : LargeCategory.{u} SemilatSupCat where
 instance instFunLike (X Y : SemilatSupCat) : FunLike (X ⟶ Y) X Y :=
   show FunLike (SupBotHom X Y) X Y from inferInstance
 
-instance : ConcreteCategory SemilatSupCat where
+instance : HasForget SemilatSupCat where
   forget :=
     { obj := SemilatSupCat.X
       map := DFunLike.coe }
@@ -117,7 +117,7 @@ instance : LargeCategory.{u} SemilatInfCat where
 instance instFunLike (X Y : SemilatInfCat) : FunLike (X ⟶ Y) X Y :=
   show FunLike (InfTopHom X Y) X Y from inferInstance
 
-instance : ConcreteCategory SemilatInfCat where
+instance : HasForget SemilatInfCat where
   forget :=
     { obj := SemilatInfCat.X
       map := DFunLike.coe }

--- a/Mathlib/RepresentationTheory/FDRep.lean
+++ b/Mathlib/RepresentationTheory/FDRep.lean
@@ -57,14 +57,14 @@ variable {k G : Type u} [Field k] [Monoid G]
 
 -- Porting note: `@[derive]` didn't work for `FDRep`. Add the 4 instances here.
 instance : LargeCategory (FDRep k G) := inferInstance
-instance : ConcreteCategory (FDRep k G) := inferInstance
+instance : HasForget (FDRep k G) := inferInstance
 instance : Preadditive (FDRep k G) := inferInstance
 instance : HasFiniteLimits (FDRep k G) := inferInstance
 
 instance : Linear k (FDRep k G) := by infer_instance
 
 instance : CoeSort (FDRep k G) (Type u) :=
-  ConcreteCategory.hasCoeToSort _
+  HasForget.hasCoeToSort _
 
 instance (V : FDRep k G) : AddCommGroup V := by
   change AddCommGroup ((forget₂ (FDRep k G) (FGModuleCat k)).obj V).obj; infer_instance

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -48,7 +48,7 @@ section
 variable [Monoid G]
 
 instance : CoeSort (Rep k G) (Type u) :=
-  ConcreteCategory.hasCoeToSort _
+  HasForget.hasCoeToSort _
 
 instance (V : Rep k G) : AddCommGroup V := by
   change AddCommGroup ((forget₂ (Rep k G) (ModuleCat k)).obj V); infer_instance

--- a/Mathlib/Tactic/CategoryTheory/Elementwise.lean
+++ b/Mathlib/Tactic/CategoryTheory/Elementwise.lean
@@ -45,11 +45,11 @@ universe u
 theorem forall_congr_forget_Type (α : Type u) (p : α → Prop) :
     (∀ (x : (forget (Type u)).obj α), p x) ↔ ∀ (x : α), p x := Iff.rfl
 
-attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] HasForget.instFunLike HasForget.hasCoeToSort
 
 theorem forget_hom_Type (α β : Type u) (f : α ⟶ β) : DFunLike.coe f = f := rfl
 
-theorem hom_elementwise {C : Type*} [Category C] [ConcreteCategory C]
+theorem hom_elementwise {C : Type*} [Category C] [HasForget C]
     {X Y : C} {f g : X ⟶ Y} (h : f = g) (x : X) : f x = g x := by rw [h]
 
 end theorems
@@ -67,11 +67,11 @@ def elementwiseThms : List Name :=
 /--
 Given an equation `f = g` between morphisms `X ⟶ Y` in a category `C`
 (possibly after a `∀` binder), produce the equation `∀ (x : X), f x = g x` or
-`∀ [ConcreteCategory C] (x : X), f x = g x` as needed (after the `∀` binder), but
+`∀ [HasForget C] (x : X), f x = g x` as needed (after the `∀` binder), but
 with compositions fully right associated and identities removed.
 
 Returns the proof of the new theorem along with (optionally) a new level metavariable
-for the first universe parameter to `ConcreteCategory`.
+for the first universe parameter to `HasForget`.
 
 The `simpSides` option controls whether to simplify both sides of the equality, for simpNF
 purposes.
@@ -84,7 +84,7 @@ def elementwiseExpr (src : Name) (type pf : Expr) (simpSides := true) :
       -- First simplify using elementwise-specific lemmas
       let mut eqPf' ← simpType (simpOnlyNames elementwiseThms (config := { decide := false })) eqPf
       if (← inferType eqPf') == .const ``True [] then
-        throwError "elementwise lemma for {src} is trivial after applying ConcreteCategory \
+        throwError "elementwise lemma for {src} is trivial after applying HasForget \
           lemmas, which can be caused by how applications are unfolded. \
           Using elementwise is unnecessary."
       if simpSides then
@@ -115,16 +115,16 @@ where
       MetaM α := do
     let (C, instC) ← try extractCatInstance eqTy catch _ =>
       throwError "elementwise expects equality of morphisms in a category"
-    -- First try being optimistic that there is already a ConcreteCategory instance.
+    -- First try being optimistic that there is already a HasForget instance.
     if let some eqPf' ← observing? (mkAppM ``hom_elementwise #[eqPf]) then
       k eqPf' none
     else
       -- That failed, so we need to introduce the instance, which takes creating
-      -- a fresh universe level for `ConcreteCategory`'s forgetful functor.
+      -- a fresh universe level for `HasForget`'s forgetful functor.
       let .app (.const ``Category [v, u]) _ ← inferType instC
         | throwError "internal error in elementwise"
       let w ← mkFreshLevelMVar
-      let cty : Expr := mkApp2 (.const ``ConcreteCategory [w, v, u]) C instC
+      let cty : Expr := mkApp2 (.const ``HasForget [w, v, u]) C instC
       withLocalDecl `inst .instImplicit cty fun cfvar => do
         let eqPf' ← mkAppM ``hom_elementwise #[eqPf]
         k eqPf' (some (w, cfvar))
@@ -143,7 +143,7 @@ private partial def mkUnusedName (names : List Name) (baseName : Name) : Name :=
     loop 1
 
 /-- The `elementwise` attribute can be added to a lemma proving an equation of morphisms, and it
-creates a new lemma for a `ConcreteCategory` giving an equation with those morphisms applied
+creates a new lemma for a `HasForget` giving an equation with those morphisms applied
 to some value.
 
 Syntax examples:
@@ -165,16 +165,16 @@ produces
 ```lean
 lemma some_lemma_apply {C : Type*} [Category C]
     {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) (h : X ⟶ Z) (w : ...)
-    [ConcreteCategory C] (x : X) : g (f x) = h x := ...
+    [HasForget C] (x : X) : g (f x) = h x := ...
 ```
 
-Here `X` is being coerced to a type via `CategoryTheory.ConcreteCategory.hasCoeToSort` and
-`f`, `g`, and `h` are being coerced to functions via `CategoryTheory.ConcreteCategory.hasCoeToFun`.
+Here `X` is being coerced to a type via `CategoryTheory.HasForget.hasCoeToSort` and
+`f`, `g`, and `h` are being coerced to functions via `CategoryTheory.HasForget.hasCoeToFun`.
 Further, we simplify the type using `CategoryTheory.coe_id : ((𝟙 X) : X → X) x = x` and
 `CategoryTheory.coe_comp : (f ≫ g) x = g (f x)`,
 replacing morphism composition with function composition.
 
-The `[ConcreteCategory C]` argument will be omitted if it is possible to synthesize an instance.
+The `[HasForget C]` argument will be omitted if it is possible to synthesize an instance.
 
 The name of the produced lemma can be specified with `@[elementwise other_lemma_name]`.
 If `simp` is added first, the generated lemma will also have the `simp` attribute.
@@ -195,7 +195,7 @@ initialize registerBuiltinAttribute {
       let newLevels ← if let some level := level? then do
         let w := mkUnusedName levels `w
         unless ← isLevelDefEq level (mkLevelParam w) do
-          throwError "Could not create level parameter for ConcreteCategory instance"
+          throwError "Could not create level parameter for HasForget instance"
         pure <| w :: levels
       else
         pure levels
@@ -215,8 +215,8 @@ example (M N K : MonCat) (f : M ⟶ N) (g : N ⟶ K) (h : M ⟶ K) (w : f ≫ g 
 ```
 In this case, `elementwise_of% w` generates the lemma `∀ (x : M), f (g x) = h x`.
 
-Like the `@[elementwise]` attribute, `elementwise_of%` inserts a `ConcreteCategory`
-instance argument if it can't synthesize a relevant `ConcreteCategory` instance.
+Like the `@[elementwise]` attribute, `elementwise_of%` inserts a `HasForget`
+instance argument if it can't synthesize a relevant `HasForget` instance.
 (Technical note: The forgetful functor's universe variable is instantiated with a
 fresh level metavariable in this case.)
 

--- a/Mathlib/Tactic/Linter/GlobalAttributeIn.lean
+++ b/Mathlib/Tactic/Linter/GlobalAttributeIn.lean
@@ -21,11 +21,11 @@ hence, we lint against it.
 *Example*: before this was discovered, `Mathlib/Topology/Category/TopCat/Basic.lean`
 contained the following code:
 ```
-attribute [instance] ConcreteCategory.instFunLike in
+attribute [instance] HasForget.instFunLike in
 instance (X Y : TopCat.{u}) : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe f := f
 ```
-Despite the `in`, this makes `ConcreteCategory.instFunLike` a global instance.
+Despite the `in`, this makes `HasForget.instFunLike` a global instance.
 
 This seems to apply to all attributes. For example:
 ```lean

--- a/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Basic.lean
+++ b/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Basic.lean
@@ -96,7 +96,7 @@ instance (G H : ProfiniteGrp) : ContinuousMapClass (G ⟶ H) G H :=
   inferInstanceAs <| ContinuousMapClass (ContinuousMonoidHom G H) G H
 
 @[to_additive]
-instance : ConcreteCategory ProfiniteGrp where
+instance : HasForget ProfiniteGrp where
   forget :=
   { obj := fun G => G
     map := fun f => f }

--- a/Mathlib/Topology/Category/Born.lean
+++ b/Mathlib/Topology/Category/Born.lean
@@ -44,7 +44,7 @@ instance : BundledHom @LocallyBoundedMap where
 instance : LargeCategory.{u} Born :=
   BundledHom.category LocallyBoundedMap
 
-instance : ConcreteCategory Born :=
-  BundledHom.concreteCategory LocallyBoundedMap
+instance : HasForget Born :=
+  BundledHom.hasForget LocallyBoundedMap
 
 end Born

--- a/Mathlib/Topology/Category/CompHaus/Basic.lean
+++ b/Mathlib/Topology/Category/CompHaus/Basic.lean
@@ -35,7 +35,7 @@ The category `CompHaus` is defined using the structure `CompHausLike`. See the f
 universe v u
 
 -- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] CategoryTheory.ConcreteCategory.instFunLike
+attribute [local instance] CategoryTheory.HasForget.instFunLike
 
 open CategoryTheory CompHausLike
 

--- a/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
@@ -29,7 +29,7 @@ universe u
 
 open CategoryTheory Limits CompHausLike
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 namespace CompHaus
 

--- a/Mathlib/Topology/Category/CompHaus/Projective.lean
+++ b/Mathlib/Topology/Category/CompHaus/Projective.lean
@@ -34,7 +34,7 @@ open CategoryTheory Function
 
 namespace CompHaus
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 instance projective_ultrafilter (X : Type*) : Projective (of <| Ultrafilter X) where
   factors {Y Z} f g hg := by

--- a/Mathlib/Topology/Category/CompHausLike/Basic.lean
+++ b/Mathlib/Topology/Category/CompHausLike/Basic.lean
@@ -64,7 +64,7 @@ universe u
 
 open CategoryTheory
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 variable (P : TopCat.{u} → Prop)
 
@@ -89,8 +89,8 @@ instance : CoeSort (CompHausLike P) (Type u) :=
 instance category : Category (CompHausLike P) :=
   InducedCategory.category toTop
 
-instance concreteCategory : ConcreteCategory (CompHausLike P) :=
-  InducedCategory.concreteCategory _
+instance hasForget : HasForget (CompHausLike P) :=
+  InducedCategory.hasForget _
 
 instance hasForget₂ : HasForget₂ (CompHausLike P) TopCat :=
   InducedCategory.hasForget₂ _

--- a/Mathlib/Topology/Category/CompHausLike/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/CompHausLike/EffectiveEpi.lean
@@ -21,7 +21,7 @@ universe u
 
 open CategoryTheory Limits Topology
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 namespace CompHausLike
 

--- a/Mathlib/Topology/Category/CompHausLike/Limits.lean
+++ b/Mathlib/Topology/Category/CompHausLike/Limits.lean
@@ -40,7 +40,7 @@ namespace CompHausLike
 
 universe w u
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 section FiniteCoproducts
 

--- a/Mathlib/Topology/Category/CompactlyGenerated.lean
+++ b/Mathlib/Topology/Category/CompactlyGenerated.lean
@@ -20,7 +20,7 @@ compact Hausdorff spaces `S` mapping continuously to `X`.
 * Every first-countable space is `u`-compactly generated for every universe `u`.
 -/
 
-attribute [local instance] CategoryTheory.ConcreteCategory.instFunLike
+attribute [local instance] CategoryTheory.HasForget.instFunLike
 
 universe u w
 
@@ -47,8 +47,8 @@ attribute [instance] is_compactly_generated
 instance : Category.{w, w+1} CompactlyGenerated.{u, w} :=
   InducedCategory.category toTop
 
-instance : ConcreteCategory.{w} CompactlyGenerated.{u, w} :=
-  InducedCategory.concreteCategory _
+instance : HasForget.{w} CompactlyGenerated.{u, w} :=
+  InducedCategory.hasForget _
 
 variable (X : Type w) [TopologicalSpace X] [UCompactlyGeneratedSpace.{u} X]
 

--- a/Mathlib/Topology/Category/Compactum.lean
+++ b/Mathlib/Topology/Category/Compactum.lean
@@ -53,7 +53,7 @@ topological space which satisfies `CompactSpace` and `T2Space`.
 We also add wrappers around structures which already exist. Here are the main ones, all in the
 `Compactum` namespace:
 
-- `forget : Compactum ⥤ Type*` is the forgetful functor, which induces a `ConcreteCategory`
+- `forget : Compactum ⥤ Type*` is the forgetful functor, which induces a `HasForget`
   instance for `Compactum`.
 - `free : Type* ⥤ Compactum` is the left adjoint to `forget`, and the adjunction is in `adj`.
 - `str : Ultrafilter X → X` is the structure map for `X : Compactum`.
@@ -102,7 +102,7 @@ def adj : free ⊣ forget :=
   Monad.adj _
 
 -- Basic instances
-instance : ConcreteCategory Compactum where forget := forget
+instance : HasForget Compactum where forget := forget
 
 -- Porting note: changed from forget to X.A
 instance : CoeSort Compactum Type* :=

--- a/Mathlib/Topology/Category/DeltaGenerated.lean
+++ b/Mathlib/Topology/Category/DeltaGenerated.lean
@@ -41,8 +41,8 @@ attribute [instance] deltaGenerated
 instance : LargeCategory.{u} DeltaGenerated.{u} :=
   InducedCategory.category toTop
 
-instance : ConcreteCategory.{u} DeltaGenerated.{u} :=
-  InducedCategory.concreteCategory _
+instance : HasForget.{u} DeltaGenerated.{u} :=
+  InducedCategory.hasForget _
 
 /-- Constructor for objects of the category `DeltaGenerated` -/
 def of (X : Type u) [TopologicalSpace X] [DeltaGeneratedSpace X] : DeltaGenerated.{u} where

--- a/Mathlib/Topology/Category/FinTopCat.lean
+++ b/Mathlib/Topology/Category/FinTopCat.lean
@@ -38,8 +38,8 @@ attribute [instance] fintype
 instance : Category FinTopCat :=
   InducedCategory.category toTop
 
-instance : ConcreteCategory FinTopCat :=
-  InducedCategory.concreteCategory _
+instance : HasForget FinTopCat :=
+  InducedCategory.hasForget _
 
 instance (X : FinTopCat) : TopologicalSpace ((forget FinTopCat).obj X) :=
   inferInstanceAs <| TopologicalSpace X

--- a/Mathlib/Topology/Category/LightProfinite/AsLimit.lean
+++ b/Mathlib/Topology/Category/LightProfinite/AsLimit.lean
@@ -20,7 +20,7 @@ noncomputable section
 
 open CategoryTheory Limits CompHausLike
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 namespace LightProfinite
 

--- a/Mathlib/Topology/Category/LightProfinite/Basic.lean
+++ b/Mathlib/Topology/Category/LightProfinite/Basic.lean
@@ -36,7 +36,7 @@ universe v u
 Previously, this had accidentally been made a global instance,
 and we now turn it on locally when convenient.
 -/
-attribute [local instance] CategoryTheory.ConcreteCategory.instFunLike
+attribute [local instance] CategoryTheory.HasForget.instFunLike
 
 open CategoryTheory Limits Opposite FintypeCat Topology TopologicalSpace CompHausLike
 
@@ -261,7 +261,7 @@ def toProfinite (S : LightDiagram) : Profinite := S.cone.pt
 @[simps!]
 instance : Category LightDiagram := InducedCategory.category toProfinite
 
-instance concreteCategory : ConcreteCategory LightDiagram := InducedCategory.concreteCategory _
+instance hasForget : HasForget LightDiagram := InducedCategory.hasForget _
 
 end LightDiagram
 

--- a/Mathlib/Topology/Category/LightProfinite/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/LightProfinite/EffectiveEpi.lean
@@ -19,7 +19,7 @@ universe u
 
 open CategoryTheory Limits CompHausLike
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 namespace LightProfinite
 

--- a/Mathlib/Topology/Category/LightProfinite/Extend.lean
+++ b/Mathlib/Topology/Category/LightProfinite/Extend.lean
@@ -28,7 +28,7 @@ universe u
 
 open CategoryTheory Limits FintypeCat Functor
 
-attribute [local instance] FintypeCat.discreteTopology ConcreteCategory.instFunLike
+attribute [local instance] FintypeCat.discreteTopology HasForget.instFunLike
 
 namespace LightProfinite
 

--- a/Mathlib/Topology/Category/Profinite/Basic.lean
+++ b/Mathlib/Topology/Category/Profinite/Basic.lean
@@ -38,7 +38,7 @@ profinite
 -/
 
 -- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] CategoryTheory.ConcreteCategory.instFunLike
+attribute [local instance] CategoryTheory.HasForget.instFunLike
 
 
 universe v u

--- a/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
@@ -27,7 +27,7 @@ namespace Profinite
 open CategoryTheory Limits
 
 -- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 universe u v
 

--- a/Mathlib/Topology/Category/Profinite/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/Profinite/EffectiveEpi.lean
@@ -25,7 +25,7 @@ universe u
 
 open CategoryTheory Limits
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 namespace Profinite
 

--- a/Mathlib/Topology/Category/Profinite/Extend.lean
+++ b/Mathlib/Topology/Category/Profinite/Extend.lean
@@ -27,7 +27,7 @@ universe u w
 
 open CategoryTheory Limits FintypeCat Functor
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 namespace Profinite
 

--- a/Mathlib/Topology/Category/Profinite/Projective.lean
+++ b/Mathlib/Topology/Category/Profinite/Projective.lean
@@ -31,7 +31,7 @@ universe u v w
 open CategoryTheory Function
 
 -- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 namespace Profinite
 

--- a/Mathlib/Topology/Category/Sequential.lean
+++ b/Mathlib/Topology/Category/Sequential.lean
@@ -18,7 +18,7 @@ for defining categories of topological spaces, by giving it the induced category
 
 open CategoryTheory
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 universe u
 
@@ -42,8 +42,8 @@ attribute [instance] is_sequential
 instance : Category.{u, u+1} Sequential.{u} :=
   InducedCategory.category toTop
 
-instance : ConcreteCategory.{u} Sequential.{u} :=
-  InducedCategory.concreteCategory _
+instance : HasForget.{u} Sequential.{u} :=
+  InducedCategory.hasForget _
 
 variable (X : Type u) [TopologicalSpace X] [SequentialSpace X]
 

--- a/Mathlib/Topology/Category/Stonean/Basic.lean
+++ b/Mathlib/Topology/Category/Stonean/Basic.lean
@@ -43,7 +43,7 @@ open CategoryTheory
 open scoped Topology
 
 -- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 /-- `Stonean` is the category of extremally disconnected compact Hausdorff spaces. -/
 abbrev Stonean := CompHausLike (fun X ↦ ExtremallyDisconnected X)

--- a/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
@@ -24,7 +24,7 @@ universe u
 
 open CategoryTheory Limits CompHausLike
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 namespace Stonean
 

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -17,7 +17,7 @@ universe w u
 
 open CategoryTheory Limits CompHausLike Topology
 
-attribute [local instance] ConcreteCategory.instFunLike
+attribute [local instance] HasForget.instFunLike
 
 namespace Stonean
 

--- a/Mathlib/Topology/Category/TopCat/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Basic.lean
@@ -34,10 +34,10 @@ instance bundledHom : BundledHom @ContinuousMap where
 
 deriving instance LargeCategory for TopCat
 
--- Porting note: currently no derive handler for ConcreteCategory
+-- Porting note: currently no derive handler for HasForget
 -- see https://github.com/leanprover-community/mathlib4/issues/5020
-instance concreteCategory : ConcreteCategory TopCat :=
-  inferInstanceAs <| ConcreteCategory (Bundled TopologicalSpace)
+instance hasForget : HasForget TopCat :=
+  inferInstanceAs <| HasForget (Bundled TopologicalSpace)
 
 instance : CoeSort TopCat Type* where
   coe X := X.α
@@ -94,7 +94,7 @@ equal function coercion for a continuous map `C(X, Y)`.
 @[simp] theorem coe_of_of {X Y : Type u} [TopologicalSpace X] [TopologicalSpace Y]
     {f : C(X, Y)} {x} :
     @DFunLike.coe (TopCat.of X ⟶ TopCat.of Y) ((CategoryTheory.forget TopCat).obj (TopCat.of X))
-      (fun _ ↦ (CategoryTheory.forget TopCat).obj (TopCat.of Y)) ConcreteCategory.instFunLike
+      (fun _ ↦ (CategoryTheory.forget TopCat).obj (TopCat.of Y)) HasForget.instFunLike
       f x =
     @DFunLike.coe C(X, Y) X
       (fun _ ↦ Y) _

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -119,7 +119,7 @@ theorem pullbackIsoProdSubtype_hom_snd (f : X ⟶ Z) (g : Y ⟶ Z) :
 
 -- Porting note: why do I need to tell Lean to coerce pullback to a type
 theorem pullbackIsoProdSubtype_hom_apply {f : X ⟶ Z} {g : Y ⟶ Z}
-    (x : ConcreteCategory.forget.obj (pullback f g)) :
+    (x : HasForget.forget.obj (pullback f g)) :
     (pullbackIsoProdSubtype f g).hom x =
       ⟨⟨pullback.fst f g x, pullback.snd f g x⟩, by
         simpa using ConcreteCategory.congr_hom pullback.condition x⟩ := by

--- a/Mathlib/Topology/Category/TopCommRingCat.lean
+++ b/Mathlib/Topology/Category/TopCommRingCat.lean
@@ -48,7 +48,7 @@ instance : Category TopCommRingCat.{u} where
       cases g
       dsimp; apply Continuous.comp <;> assumption⟩
 
-instance : ConcreteCategory TopCommRingCat.{u} where
+instance : HasForget TopCommRingCat.{u} where
   forget :=
     { obj := fun R => R
       map := fun f => f.val }

--- a/Mathlib/Topology/Category/UniformSpace.lean
+++ b/Mathlib/Topology/Category/UniformSpace.lean
@@ -36,8 +36,8 @@ instance : UnbundledHom @UniformContinuous :=
 
 deriving instance LargeCategory for UniformSpaceCat
 
-instance : ConcreteCategory UniformSpaceCat :=
-  inferInstanceAs <| ConcreteCategory <| Bundled UniformSpace
+instance : HasForget UniformSpaceCat :=
+  inferInstanceAs <| HasForget <| Bundled UniformSpace
 
 instance : CoeSort UniformSpaceCat Type* :=
   Bundled.coeSort
@@ -126,8 +126,8 @@ instance category : LargeCategory CpltSepUniformSpace :=
   InducedCategory.category toUniformSpace
 
 /-- The concrete category instance on `CpltSepUniformSpace`. -/
-instance concreteCategory : ConcreteCategory CpltSepUniformSpace :=
-  InducedCategory.concreteCategory toUniformSpace
+instance hasForget : HasForget CpltSepUniformSpace :=
+  InducedCategory.hasForget toUniformSpace
 
 instance hasForgetToUniformSpace : HasForget₂ CpltSepUniformSpace UniformSpaceCat :=
   InducedCategory.hasForget₂ toUniformSpace
@@ -169,7 +169,7 @@ instance (X : UniformSpaceCat) : UniformSpace ((forget _).obj X) :=
   show UniformSpace X from inferInstance
 
 -- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] CategoryTheory.ConcreteCategory.instFunLike in
+attribute [local instance] CategoryTheory.HasForget.instFunLike in
 @[simp]
 theorem extensionHom_val {X : UniformSpaceCat} {Y : CpltSepUniformSpace}
     (f : X ⟶ (forget₂ _ _).obj Y) (x) : (extensionHom f) x = Completion.extension f x :=

--- a/Mathlib/Topology/Order/Category/AlexDisc.lean
+++ b/Mathlib/Topology/Order/Category/AlexDisc.lean
@@ -31,7 +31,7 @@ instance : BundledHom.ParentProjection @AlexandrovDiscreteSpace.toTopologicalSpa
 
 deriving instance LargeCategory for AlexDisc
 
-instance instConcreteCategory : ConcreteCategory AlexDisc := BundledHom.concreteCategory _
+instance instHasForget : HasForget AlexDisc := BundledHom.hasForget _
 instance instHasForgetToTop : HasForget₂ AlexDisc TopCat := BundledHom.forget₂ _ _
 instance forgetToTop_full : (forget₂ AlexDisc TopCat).Full := BundledHom.forget₂_full _ _
 instance forgetToTop_faithful : (forget₂ AlexDisc TopCat).Faithful where
@@ -46,7 +46,7 @@ def of (α : Type*) [TopologicalSpace α] [AlexandrovDiscrete α] : AlexDisc := 
   (forget₂ AlexDisc TopCat).obj (of α) = TopCat.of α := rfl
 
 -- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] CategoryTheory.ConcreteCategory.instFunLike
+attribute [local instance] CategoryTheory.HasForget.instFunLike
 
 /-- Constructs an equivalence between preorders from an order isomorphism between them. -/
 @[simps]

--- a/Mathlib/Topology/Order/Category/FrameAdjunction.lean
+++ b/Mathlib/Topology/Order/Category/FrameAdjunction.lean
@@ -77,7 +77,7 @@ lemma isOpen_iff (U : Set (PT L)) : IsOpen U ↔ ∃ u : L, {x | x u} = U := Iff
 end PT
 
 -- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] CategoryTheory.ConcreteCategory.instFunLike
+attribute [local instance] CategoryTheory.HasForget.instFunLike
 
 /-- The covariant functor `pt` from the category of locales to the category of
 topological spaces, which sends a locale `L` to the topological space `PT L` of homomorphisms

--- a/Mathlib/Topology/Sheaves/CommRingCat.lean
+++ b/Mathlib/Topology/Sheaves/CommRingCat.lean
@@ -90,9 +90,9 @@ section SubmonoidPresheaf
 
 open scoped nonZeroDivisors
 
-variable {X : TopCat.{w}} {C : Type u} [Category.{v} C] [ConcreteCategory C]
+variable {X : TopCat.{w}} {C : Type u} [Category.{v} C] [HasForget C]
 
-attribute [local instance 1000] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance 1000] HasForget.hasCoeToSort HasForget.instFunLike
 
 -- note: this was specialized to `CommRingCat` in #19757
 /-- A subpresheaf with a submonoid structure on each of the components. -/

--- a/Mathlib/Topology/Sheaves/Functors.lean
+++ b/Mathlib/Topology/Sheaves/Functors.lean
@@ -75,7 +75,7 @@ variable {C}
 @[simp] lemma pushforward_map (f : X ⟶ Y) {F F' : X.Sheaf C} (α : F ⟶ F') :
     ((pushforward C f).map α).1 = (Presheaf.pushforward C f).map α.1 := rfl
 
-variable (A : Type*) [Category.{w} A] [ConcreteCategory.{w} A] [HasColimits A] [HasLimits A]
+variable (A : Type*) [Category.{w} A] [HasForget.{w} A] [HasColimits A] [HasLimits A]
 variable [PreservesLimits (CategoryTheory.forget A)]
 variable [PreservesFilteredColimits (CategoryTheory.forget A)]
 variable [(CategoryTheory.forget A).ReflectsIsomorphisms]

--- a/Mathlib/Topology/Sheaves/LocallySurjective.lean
+++ b/Mathlib/Topology/Sheaves/LocallySurjective.lean
@@ -30,7 +30,7 @@ We prove that these are equivalent.
 universe v u
 
 
-attribute [local instance] CategoryTheory.ConcreteCategory.instFunLike
+attribute [local instance] CategoryTheory.HasForget.instFunLike
 
 noncomputable section
 
@@ -46,7 +46,7 @@ section LocallySurjective
 
 open scoped AlgebraicGeometry
 
-variable {C : Type u} [Category.{v} C] [ConcreteCategory.{v} C] {X : TopCat.{v}}
+variable {C : Type u} [Category.{v} C] [HasForget.{v} C] {X : TopCat.{v}}
 variable {ℱ 𝒢 : X.Presheaf C}
 
 /-- A map of presheaves `T : ℱ ⟶ 𝒢` is **locally surjective** if for any open set `U`,

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -62,8 +62,8 @@ lemma ext {X : TopCat} {P Q : Presheaf C X} {f g : P ⟶ Q}
   induction U with | _ U => ?_
   apply w
 
-attribute [local instance] CategoryTheory.ConcreteCategory.hasCoeToSort
-  CategoryTheory.ConcreteCategory.instFunLike
+attribute [local instance] CategoryTheory.HasForget.hasCoeToSort
+  CategoryTheory.HasForget.instFunLike
 
 /-- attribute `sheaf_restrict` to mark lemmas related to restricting sheaves -/
 macro "sheaf_restrict" : attr =>
@@ -103,7 +103,7 @@ example {X} [CompleteLattice X] (v : Nat → X) (w x y z : X) (e : v 0 = v 1) (_
 For `x : F.obj (op V)`, we provide the notation `x |_ₕ i` (`h` stands for `hom`) for `i : U ⟶ V`,
 and the notation `x |_ₗ U ⟪i⟫` (`l` stands for `le`) for `i : U ≤ V`.
 -/
-def restrict {X : TopCat} {C : Type*} [Category C] [ConcreteCategory C] {F : X.Presheaf C}
+def restrict {X : TopCat} {C : Type*} [Category C] [HasForget C] {F : X.Presheaf C}
     {V : Opens X} (x : F.obj (op V)) {U : Opens X} (h : U ⟶ V) : F.obj (op U) :=
   F.map h.op x
 
@@ -118,7 +118,7 @@ open AlgebraicGeometry
 /-- The restriction of a section along an inclusion of open sets.
 For `x : F.obj (op V)`, we provide the notation `x |_ U`, where the proof `U ≤ V` is inferred by
 the tactic `Top.presheaf.restrict_tac'` -/
-abbrev restrictOpen {X : TopCat} {C : Type*} [Category C] [ConcreteCategory C] {F : X.Presheaf C}
+abbrev restrictOpen {X : TopCat} {C : Type*} [Category C] [HasForget C] {F : X.Presheaf C}
     {V : Opens X} (x : F.obj (op V)) (U : Opens X)
     (e : U ≤ V := by restrict_tac) :
     F.obj (op U) :=
@@ -127,14 +127,14 @@ abbrev restrictOpen {X : TopCat} {C : Type*} [Category C] [ConcreteCategory C] {
 /-- restriction of a section to open subset -/
 scoped[AlgebraicGeometry] infixl:80 " |_ " => TopCat.Presheaf.restrictOpen
 
-theorem restrict_restrict {X : TopCat} {C : Type*} [Category C] [ConcreteCategory C]
+theorem restrict_restrict {X : TopCat} {C : Type*} [Category C] [HasForget C]
     {F : X.Presheaf C} {U V W : Opens X} (e₁ : U ≤ V) (e₂ : V ≤ W) (x : F.obj (op W)) :
     x |_ V |_ U = x |_ U := by
   delta restrictOpen restrict
   rw [← comp_apply, ← Functor.map_comp]
   rfl
 
-theorem map_restrict {X : TopCat} {C : Type*} [Category C] [ConcreteCategory C]
+theorem map_restrict {X : TopCat} {C : Type*} [Category C] [HasForget C]
     {F G : X.Presheaf C} (e : F ⟶ G) {U V : Opens X} (h : U ≤ V) (x : F.obj (op V)) :
     e.app _ (x |_ U) = e.app _ x |_ U := by
   delta restrictOpen restrict

--- a/Mathlib/Topology/Sheaves/SheafCondition/UniqueGluing.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/UniqueGluing.lean
@@ -40,7 +40,7 @@ open TopCat TopCat.Presheaf CategoryTheory CategoryTheory.Limits
 
 universe v u x
 
-variable {C : Type u} [Category.{v} C] [ConcreteCategory.{v} C]
+variable {C : Type u} [Category.{v} C] [HasForget.{v} C]
 
 namespace TopCat
 
@@ -48,7 +48,7 @@ namespace Presheaf
 
 section
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 variable {X : TopCat.{x}} (F : Presheaf C X) {ι : Type x} (U : ι → Opens X)
 
@@ -135,7 +135,7 @@ end TypeValued
 
 section
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 variable [HasLimits C] [(forget C).ReflectsIsomorphisms] [PreservesLimits (forget C)]
 variable {X : TopCat.{v}} (F : Presheaf C X)
@@ -159,10 +159,10 @@ open CategoryTheory
 
 section
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
-variable [HasLimits C] [(ConcreteCategory.forget (C := C)).ReflectsIsomorphisms]
-variable [PreservesLimits (ConcreteCategory.forget (C := C))]
+variable [HasLimits C] [(HasForget.forget (C := C)).ReflectsIsomorphisms]
+variable [PreservesLimits (HasForget.forget (C := C))]
 variable {X : TopCat.{v}} (F : Sheaf C X) {ι : Type v} (U : ι → Opens X)
 
 /-- A more convenient way of obtaining a unique gluing of sections for a sheaf.

--- a/Mathlib/Topology/Sheaves/Stalks.lean
+++ b/Mathlib/Topology/Sheaves/Stalks.lean
@@ -110,19 +110,19 @@ lemma map_germ_eq_Γgerm (F : X.Presheaf C) {U : Opens X} {i : U ⟶ ⊤} (x : X
     F.map i.op ≫ F.germ U x hx = F.Γgerm x :=
   germ_res F i x hx
 
-attribute [local instance] ConcreteCategory.instFunLike in
+attribute [local instance] HasForget.instFunLike in
 theorem germ_res_apply (F : X.Presheaf C)
-    {U V : Opens X} (i : U ⟶ V) (x : X) (hx : x ∈ U) [ConcreteCategory C] (s) :
+    {U V : Opens X} (i : U ⟶ V) (x : X) (hx : x ∈ U) [HasForget C] (s) :
   F.germ U x hx (F.map i.op s) = F.germ V x (i.le hx) s := by rw [← comp_apply, germ_res]
 
-attribute [local instance] ConcreteCategory.instFunLike in
+attribute [local instance] HasForget.instFunLike in
 theorem germ_res_apply' (F : X.Presheaf C)
-    {U V : Opens X} (i : op V ⟶ op U) (x : X) (hx : x ∈ U) [ConcreteCategory C] (s) :
+    {U V : Opens X} (i : op V ⟶ op U) (x : X) (hx : x ∈ U) [HasForget C] (s) :
   F.germ U x hx (F.map i s) = F.germ V x (i.unop.le hx) s := by rw [← comp_apply, germ_res']
 
-attribute [local instance] ConcreteCategory.instFunLike in
+attribute [local instance] HasForget.instFunLike in
 lemma Γgerm_res_apply (F : X.Presheaf C)
-    {U : Opens X} {i : U ⟶ ⊤} (x : X) (hx : x ∈ U) [ConcreteCategory C] (s) :
+    {U : Opens X} {i : U ⟶ ⊤} (x : X) (hx : x ∈ U) [HasForget C] (s) :
   F.germ U x hx (F.map i.op s) = F.Γgerm x s := F.germ_res_apply i x hx s
 
 /-- A morphism from the stalk of `F` at `x` to some object `Y` is completely determined by its
@@ -139,17 +139,17 @@ theorem stalkFunctor_map_germ {F G : X.Presheaf C} (U : Opens X) (x : X) (hx : x
     F.germ U x hx ≫ (stalkFunctor C x).map f = f.app (op U) ≫ G.germ U x hx :=
   colimit.ι_map (whiskerLeft (OpenNhds.inclusion x).op f) (op ⟨U, hx⟩)
 
-attribute [local instance] ConcreteCategory.instFunLike in
-theorem stalkFunctor_map_germ_apply [ConcreteCategory C]
+attribute [local instance] HasForget.instFunLike in
+theorem stalkFunctor_map_germ_apply [HasForget C]
     {F G : X.Presheaf C} (U : Opens X) (x : X) (hx : x ∈ U) (f : F ⟶ G) (s) :
     (stalkFunctor C x).map f (F.germ U x hx s) = G.germ U x hx (f.app (op U) s) := by
   rw [← comp_apply, ← stalkFunctor_map_germ]
   exact (comp_apply _ _ _).symm
 
 -- a variant of `stalkFunctor_map_germ_apply` that makes simpNF happy.
-attribute [local instance] ConcreteCategory.instFunLike in
+attribute [local instance] HasForget.instFunLike in
 @[simp]
-theorem stalkFunctor_map_germ_apply' [ConcreteCategory C]
+theorem stalkFunctor_map_germ_apply' [HasForget C]
     {F G : X.Presheaf C} (U : Opens X) (x : X) (hx : x ∈ U) (f : F ⟶ G) (s) :
     DFunLike.coe (F := F.stalk x ⟶ G.stalk x) ((stalkFunctor C x).map f) (F.germ U x hx s) =
       G.germ U x hx (f.app (op U) s) :=
@@ -393,9 +393,9 @@ end stalkSpecializes
 section Concrete
 
 variable {C}
-variable [ConcreteCategory.{v} C]
+variable [HasForget.{v} C]
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: @[ext] attribute only applies to structures or lemmas proving x = y
 -- @[ext]

--- a/MathlibTest/CategoryTheory/Elementwise.lean
+++ b/MathlibTest/CategoryTheory/Elementwise.lean
@@ -8,22 +8,22 @@ open CategoryTheory
 
 attribute [simp] Iso.hom_inv_id Iso.inv_hom_id IsIso.hom_inv_id IsIso.inv_hom_id
 
-attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] HasForget.instFunLike HasForget.hasCoeToSort
 
 @[elementwise]
-theorem ex1 [Category C] [ConcreteCategory C] (X : C) (f g h : X ⟶ X) (h' : g ≫ h = h ≫ g) :
+theorem ex1 [Category C] [HasForget C] (X : C) (f g h : X ⟶ X) (h' : g ≫ h = h ≫ g) :
     f ≫ g ≫ h = f ≫ h ≫ g := by rw [h']
 
--- If there is already a `ConcreteCategory` instance, do not add a new argument.
-example : ∀ C [Category C] [ConcreteCategory C] (X : C) (f g h : X ⟶ X) (_ : g ≫ h = h ≫ g)
+-- If there is already a `HasForget` instance, do not add a new argument.
+example : ∀ C [Category C] [HasForget C] (X : C) (f g h : X ⟶ X) (_ : g ≫ h = h ≫ g)
     (x : X), h (g (f x)) = g (h (f x)) := @ex1_apply
 
 @[elementwise]
 theorem ex2 [Category C] (X : C) (f g h : X ⟶ X) (h' : g ≫ h = h ≫ g) :
     f ≫ g ≫ h = f ≫ h ≫ g := by rw [h']
 
--- If there is not already a `ConcreteCategory` instance, insert a new argument.
-example : ∀ C [Category C] (X : C) (f g h : X ⟶ X) (_ : g ≫ h = h ≫ g) [ConcreteCategory C]
+-- If there is not already a `HasForget` instance, insert a new argument.
+example : ∀ C [Category C] (X : C) (f g h : X ⟶ X) (_ : g ≫ h = h ≫ g) [HasForget C]
     (x : X), h (g (f x)) = g (h (f x)) := @ex2_apply
 
 -- Need nosimp on the following `elementwise` since the lemma can be proved by simp anyway.
@@ -31,11 +31,11 @@ example : ∀ C [Category C] (X : C) (f g h : X ⟶ X) (_ : g ≫ h = h ≫ g) [
 theorem ex3 [Category C] {X Y : C} (f : X ≅ Y) : f.hom ≫ f.inv = 𝟙 X :=
   Iso.hom_inv_id _
 
-example : ∀ C [Category C] (X Y : C) (f : X ≅ Y) [ConcreteCategory C] (x : X),
+example : ∀ C [Category C] (X Y : C) (f : X ≅ Y) [HasForget C] (x : X),
     f.inv (f.hom x) = x := @ex3_apply
 
 -- Make sure there's no `id x` in there:
-example : ∀ C [Category C] (X Y : C) (f : X ≅ Y) [ConcreteCategory C] (x : X),
+example : ∀ C [Category C] (X Y : C) (f : X ≅ Y) [HasForget C] (x : X),
     f.inv (f.hom x) = x := by intros; simp only [ex3_apply]
 
 @[elementwise]
@@ -48,7 +48,7 @@ lemma foo' [Category C]
     {M N K : C} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = h) : f ≫ 𝟙 N ≫ g = h := by
   simp [w]
 
-lemma bar [Category C] [ConcreteCategory C]
+lemma bar [Category C] [HasForget C]
     {M N K : C} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = h) (x : M) : g (f x) = h x := by
   apply foo_apply w
 
@@ -61,23 +61,23 @@ example {M N K : Type} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = 
 example {M N K : Type} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = h) (x : M) :
   g (f x) = h x := (elementwise_of% w) x
 
-example [Category C] [ConcreteCategory C]
+example [Category C] [HasForget C]
     {M N K : C} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = h) (x : M) :
     g (f x) = h x := by
   have := elementwise_of% w
   guard_hyp this : ∀ (x : M), g (f x) = h x
   exact this x
 
--- `elementwise_of%` allows a level metavariable for its `ConcreteCategory` instance.
+-- `elementwise_of%` allows a level metavariable for its `HasForget` instance.
 -- Previously this example did not specify that the universe levels of `C` and `D` (inside `h`)
 -- were the same, and this constraint was added post-hoc by the proof term.
 -- After https://github.com/leanprover/lean4/pull/4493 this no longer works (happily!).
-example {C : Type u} [Category.{v} C] [ConcreteCategory.{w} C]
+example {C : Type u} [Category.{v} C] [HasForget.{w} C]
     (h : ∀ (D : Type u) [Category.{v} D] (X Y : D) (f : X ⟶ Y) (g : Y ⟶ X), f ≫ g = 𝟙 X)
     {M N : C} {f : M ⟶ N} {g : N ⟶ M} (x : M) : g (f x) = x := by
   have := elementwise_of% h
   guard_hyp this : ∀ D [Category D] (X Y : D) (f : X ⟶ Y) (g : Y ⟶ X)
-    [ConcreteCategory D] (x : X), g (f x) = x
+    [HasForget D] (x : X), g (f x) = x
   rw [this]
 
 section Mon
@@ -126,7 +126,7 @@ lemma gh (X : C) : g X = h X := rfl
 @[elementwise]
 theorem fh (X : C) : f X = h X := gh X
 
-variable (X : C) [ConcreteCategory C] (x : X)
+variable (X : C) [HasForget C] (x : X)
 
 -- Prior to https://github.com/leanprover-community/mathlib4/pull/13413 this would produce
 -- `fh_apply X x : (g X) x = (h X) x`.

--- a/MathlibTest/slow_simp.lean
+++ b/MathlibTest/slow_simp.lean
@@ -12,7 +12,7 @@ but took over 260,000 heartbeats with `import Mathlib`.
 After deleting some bad simp lemmas that were being tried everywhere
 (discovered using `set_option diagnostics true`):
 * Mathlib.MeasureTheory.coeFn_comp_toFiniteMeasure_eq_coeFn
-* LightProfinite.concreteCategory_forget_obj
+* LightProfinite.hasForget_forget_obj
 * CategoryTheory.sum_comp_inl
 * CategoryTheory.sum_comp_inr
 it is back down to 19,000 heartbeats even with `import Mathlib`.


### PR DESCRIPTION
This is the first step towards a concrete category redesign, as outlined in this Zulip post: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Concrete.20category.20class.20redesign/near/493903980

This commit was generated by find-and-replacing `ConcreteCategory` and `concreteCategory` with `HasForget` and `hasForget` respectively, making sure not to touch imports. I did not look too closely at the changes, since we should be going over everything during the redesign anyway.

`ConcreteCategory` is now temporarily an alias for `HasForget`, with a deprecation warning.

The `ConcreteCategory` namespace itself was not renamed, since we'll eventually be redoing those results for the new `ConcreteCategory` class.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
