### PR TITLE
[Merged by Bors] - feat(CategoryTheory): define unbundled `ConcreteCategory` class 

### DIFF
--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp/Kernels.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp/Kernels.lean
@@ -145,7 +145,7 @@ def cokernelCocone {X Y : SemiNormedGrp.{u}} (f : X ⟶ Y) : Cofork f 0 :=
       ext a
       simp only [comp_apply, Limits.zero_comp]
       -- Porting note: `simp` not firing on the below
-      rw [comp_apply, NormedAddGroupHom.zero_apply]
+      rw [NormedAddGroupHom.zero_apply]
       -- Porting note: Lean 3 didn't need this instance
       letI : SeminormedAddCommGroup ((forget SemiNormedGrp).obj Y) :=
         (inferInstance : SeminormedAddCommGroup Y)

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -396,7 +396,7 @@ example [inst : HasForget C] :
 Note that the `ConcreteCategory` and `HasForget` instances here differ from `forget_map_eq_coe`.
 -/
 theorem forget_eq_ConcreteCategory_hom [HasForget C] {X Y : C} (f : X ⟶ Y) :
-  (forget C).map f = @ConcreteCategory.hom _ _ _ _ _ (HasForget.toConcreteCategory C) _ _ f := rfl
+    (forget C).map f = @ConcreteCategory.hom _ _ _ _ _ (HasForget.toConcreteCategory C) _ _ f := rfl
 
 /-- A `FunLike` instance on plain functions, in order to instantiate a `ConcreteCategory` structure
 on the category of types.

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -330,10 +330,12 @@ instance toHasForget : HasForget C where
 
 end ConcreteCategory
 
-theorem forget_obj (X : C) : (forget C).obj X = ToType X := rfl
+theorem forget_obj (X : C) : (forget C).obj X = ToType X := by
+  with_reducible_and_instances rfl
 
 @[simp]
-theorem ConcreteCategory.forget_map_eq_coe {X Y : C} (f : X ⟶ Y) : (forget C).map f = f := rfl
+theorem ConcreteCategory.forget_map_eq_coe {X Y : C} (f : X ⟶ Y) : (forget C).map f = f := by
+  with_reducible_and_instances rfl
 
 /-- Analogue of `congr_fun h x`,
 when `h : f = g` is an equality between morphisms in a concrete category.
@@ -396,7 +398,8 @@ example [inst : HasForget C] :
 Note that the `ConcreteCategory` and `HasForget` instances here differ from `forget_map_eq_coe`.
 -/
 theorem forget_eq_ConcreteCategory_hom [HasForget C] {X Y : C} (f : X ⟶ Y) :
-    (forget C).map f = @ConcreteCategory.hom _ _ _ _ _ (HasForget.toConcreteCategory C) _ _ f := rfl
+    (forget C).map f = @ConcreteCategory.hom _ _ _ _ _ (HasForget.toConcreteCategory C) _ _ f := by
+  with_reducible_and_instances rfl
 
 /-- A `FunLike` instance on plain functions, in order to instantiate a `ConcreteCategory` structure
 on the category of types.

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -274,12 +274,14 @@ variable [ConcreteCategory C FC]
 
 This is an `abbrev` so that instances on `X` (e.g. `Ring`) do not need to be redeclared.
 -/
+@[nolint unusedArguments] -- Need the instance to trigger unification that finds `CC`.
 abbrev ToType [ConcreteCategory C FC] := CC
 
 /-- `ToHom X Y` is the type of (bundled) functions between objects `X Y : C`.
 
 This is an `abbrev` so that instances (e.g. `RingHomClass`) do not need to be redeclared.
 -/
+@[nolint unusedArguments] -- Need the instance to trigger unification that finds `FC`.
 abbrev ToHom [ConcreteCategory C FC] := FC
 
 namespace ConcreteCategory

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -371,7 +371,6 @@ abbrev HasForget.toFunLike [HasForget C] (X Y : C) :
   coe := (forget C).map
   coe_injective' _ _ h := Functor.Faithful.map_injective h
 
-attribute [local instance] HasForget.toFunLike
 /-- Build a concrete category out of `HasForget`.
 
 The intended usecase is to prove theorems referencing only `(forget C)`
@@ -386,8 +385,6 @@ abbrev HasForget.toConcreteCategory [HasForget C] :
   ofHom f := f
   id_apply := congr_fun ((forget C).map_id _)
   comp_apply _ _ := congr_fun ((forget C).map_comp _ _)
-
-attribute [local instance] HasForget.toConcreteCategory
 
 /-- Check that the new `ConcreteCategory` has the same forgetful functor as we started with. -/
 example [inst : HasForget C] :


### PR DESCRIPTION
This is a step towards a concrete category redesign, as outlined in this Zulip post: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Concrete.20category.20class.20redesign/near/493903980

This PR defines a new class `ConcreteCategory` that unbundles the coercion of morphisms to functions and objects to types, in order to allow `ConcreteCategory` to coexist alongisde existing coercions to functions/sorts. No instances are included yet, since those can be declared in parallel. See e.g. `CommRingCat` on the `redesign-ConcreteCategory` branch for examples of what a concrete category instance will end up looking like.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #20809 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
