### PR TITLE
[Merged by Bors] - feat: add lemmas for working with orders of analytic functions

### DIFF
--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -231,12 +231,12 @@ lemma order_eq_zero_iff (hf : AnalyticAt 𝕜 f z₀) :
     hf.order = 0 ↔ f z₀ ≠ 0 := by
   rw [(by rfl : (0 : ENat) = (0 : Nat)), order_eq_nat_iff hf 0]
   constructor
-  · intro ⟨g, _, _, hg⟩; simpa [Eventually.self_of_nhds hg]
-  · intro hz; use f; exact ⟨hf, hz, by simp⟩
+  · intro ⟨g, _, _, hg⟩; simpa [hg.self_of_nhds]
+  · exact fun hz ↦ ⟨f, hf, hz, by simp⟩
 
 /- An analytic function vanishes at a point if its order vanishes when converted to ℕ. -/
-lemma zero_if_order_toNat_eq_zero (hf : AnalyticAt 𝕜 f z₀) :
-    hf.order.toNat ≠ 0 → f z₀ = 0 := by simp [hf.order_eq_zero_iff]; tauto
+lemma zero_if_order_toNat_eq_zero (hf : AnalyticAt 𝕜 f z₀) : hf.order.toNat ≠ 0 → f z₀ = 0 := by
+  simp [hf.order_eq_zero_iff]; tauto
 
 end AnalyticAt
 

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -223,8 +223,7 @@ lemma order_eq_nat_iff (hf : AnalyticAt 𝕜 f z₀) (n : ℕ) : hf.order = ↑n
 lemma order_neq_top_iff (hf : AnalyticAt 𝕜 f z₀) :
     hf.order ≠ ⊤ ↔ ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0
       ∧ f =ᶠ[𝓝 z₀] fun z ↦ (z - z₀) ^ (hf.order.toNat) • g z := by
-  unfold EventuallyEq; rw [← hf.order_eq_nat_iff]
-  exact ⟨fun h₁f ↦ (ENat.coe_toNat h₁f).symm, fun h₁f ↦ ENat.coe_toNat_eq_self.mp h₁f.symm ⟩
+  simp only [← ENat.coe_toNat_eq_self, Eq.comm, EventuallyEq, ← hf.order_eq_nat_iff]
 
 /- An analytic function has order zero at a point iff it does not vanish there. -/
 lemma order_eq_zero_iff (hf : AnalyticAt 𝕜 f z₀) :

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -217,7 +217,7 @@ lemma order_eq_nat_iff (hf : AnalyticAt 𝕜 f z₀) (n : ℕ) : hf.order = ↑n
     refine ⟨fun hn ↦ (WithTop.coe_inj.mp hn : h.choose = n) ▸ h.choose_spec, fun h' ↦ ?_⟩
     rw [unique_eventuallyEq_pow_smul_nonzero h.choose_spec h']
 
-/- An analytic function `f` has finite order at a point `z₀` iff locally looks
+/- An analytic function `f` has finite order at a point `z₀` iff it locally looks
   like `(z - z₀) ^ order • g`, where `g` is analytic and does not vanish at
   `z₀`. -/
 lemma order_neq_top_iff (hf : AnalyticAt 𝕜 f z₀) :

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -217,6 +217,27 @@ lemma order_eq_nat_iff (hf : AnalyticAt 𝕜 f z₀) (n : ℕ) : hf.order = ↑n
     refine ⟨fun hn ↦ (WithTop.coe_inj.mp hn : h.choose = n) ▸ h.choose_spec, fun h' ↦ ?_⟩
     rw [unique_eventuallyEq_pow_smul_nonzero h.choose_spec h']
 
+/- An analytic function `f` has finite order at a point `z₀` iff locally looks
+  like `(z - z₀) ^ order • g`, where `g` is analytic and does not vanish at
+  `z₀`. -/
+lemma order_neq_top_iff (hf : AnalyticAt 𝕜 f z₀) :
+    hf.order ≠ ⊤ ↔ ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0
+      ∧ f =ᶠ[𝓝 z₀] fun z ↦ (z - z₀) ^ (hf.order.toNat) • g z := by
+  erw [← hf.order_eq_nat_iff]
+  exact ⟨fun h₁f ↦ (ENat.coe_toNat h₁f).symm, fun h₁f ↦ ENat.coe_toNat_eq_self.mp h₁f.symm ⟩
+
+/- An analytic function has order zero at a point iff it does not vanish there. -/
+lemma order_eq_zero_iff (hf : AnalyticAt 𝕜 f z₀) :
+    hf.order = 0 ↔ f z₀ ≠ 0 := by
+  rw [(by rfl : (0 : ENat) = (0 : Nat)), order_eq_nat_iff hf 0]
+  constructor
+  · intro ⟨g, _, _, hg⟩; simpa [Eventually.self_of_nhds hg]
+  · intro hz; use f; exact ⟨hf, hz, by simp⟩
+
+/- An analytic function vanishes at a point if its order vanishes when converted to ℕ. -/
+lemma zero_if_order_toNat_eq_zero (hf : AnalyticAt 𝕜 f z₀) :
+    hf.order.toNat ≠ 0 → f z₀ = 0 := by simp [hf.order_eq_zero_iff]; tauto
+
 end AnalyticAt
 
 namespace AnalyticOnNhd

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -235,7 +235,8 @@ lemma order_eq_zero_iff (hf : AnalyticAt 𝕜 f z₀) :
   · exact fun hz ↦ ⟨f, hf, hz, by simp⟩
 
 /- An analytic function vanishes at a point if its order is nonzero when converted to ℕ. -/
-lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) : hf.order.toNat ≠ 0 → f z₀ = 0 := by
+lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
+    hf.order.toNat ≠ 0 → f z₀ = 0 := by
   simp [hf.order_eq_zero_iff]
   tauto
 

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -223,7 +223,7 @@ lemma order_eq_nat_iff (hf : AnalyticAt 𝕜 f z₀) (n : ℕ) : hf.order = ↑n
 lemma order_neq_top_iff (hf : AnalyticAt 𝕜 f z₀) :
     hf.order ≠ ⊤ ↔ ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0
       ∧ f =ᶠ[𝓝 z₀] fun z ↦ (z - z₀) ^ (hf.order.toNat) • g z := by
-  erw [← hf.order_eq_nat_iff]
+  unfold EventuallyEq; rw [← hf.order_eq_nat_iff]
   exact ⟨fun h₁f ↦ (ENat.coe_toNat h₁f).symm, fun h₁f ↦ ENat.coe_toNat_eq_self.mp h₁f.symm ⟩
 
 /- An analytic function has order zero at a point iff it does not vanish there. -/

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -229,7 +229,7 @@ lemma order_neq_top_iff (hf : AnalyticAt 𝕜 f z₀) :
 /- An analytic function has order zero at a point iff it does not vanish there. -/
 lemma order_eq_zero_iff (hf : AnalyticAt 𝕜 f z₀) :
     hf.order = 0 ↔ f z₀ ≠ 0 := by
-  rw [(by rfl : (0 : ENat) = (0 : Nat)), order_eq_nat_iff hf 0]
+  rw [← ENat.coe_zero, order_eq_nat_iff hf 0]
   constructor
   · intro ⟨g, _, _, hg⟩; simpa [hg.self_of_nhds]
   · exact fun hz ↦ ⟨f, hf, hz, by simp⟩

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -234,8 +234,8 @@ lemma order_eq_zero_iff (hf : AnalyticAt 𝕜 f z₀) :
     simpa [hg.self_of_nhds]
   · exact fun hz ↦ ⟨f, hf, hz, by simp⟩
 
-/- An analytic function vanishes at a point if its order vanishes when converted to ℕ. -/
-lemma zero_if_order_toNat_eq_zero (hf : AnalyticAt 𝕜 f z₀) : hf.order.toNat ≠ 0 → f z₀ = 0 := by
+/- An analytic function vanishes at a point if its order is nonzero when converted to ℕ. -/
+lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) : hf.order.toNat ≠ 0 → f z₀ = 0 := by
   simp [hf.order_eq_zero_iff]
   tauto
 

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -230,12 +230,14 @@ lemma order_eq_zero_iff (hf : AnalyticAt 𝕜 f z₀) :
     hf.order = 0 ↔ f z₀ ≠ 0 := by
   rw [← ENat.coe_zero, order_eq_nat_iff hf 0]
   constructor
-  · intro ⟨g, _, _, hg⟩; simpa [hg.self_of_nhds]
+  · intro ⟨g, _, _, hg⟩
+    simpa [hg.self_of_nhds]
   · exact fun hz ↦ ⟨f, hf, hz, by simp⟩
 
 /- An analytic function vanishes at a point if its order vanishes when converted to ℕ. -/
 lemma zero_if_order_toNat_eq_zero (hf : AnalyticAt 𝕜 f z₀) : hf.order.toNat ≠ 0 → f z₀ = 0 := by
-  simp [hf.order_eq_zero_iff]; tauto
+  simp [hf.order_eq_zero_iff]
+  tauto
 
 end AnalyticAt
 


### PR DESCRIPTION
Add three simple lemmas to the AnalyticAt namespace, to simplify working with orders of analytic functions.

These lemmas are used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
