### PR TITLE
[Merged by Bors] - chore: address some porting notes in Mathlib/Computability

### DIFF
--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -83,7 +83,6 @@ theorem ack_two (n : ℕ) : ack 2 n = 2 * n + 3 := by
   · simp
   · simpa [mul_succ]
 
--- Porting note: re-written to get rid of ack_three_aux
 @[simp]
 theorem ack_three (n : ℕ) : ack 3 n = 2 ^ (n + 3) - 3 := by
   induction' n with n IH

--- a/Mathlib/Computability/Encoding.lean
+++ b/Mathlib/Computability/Encoding.lean
@@ -74,11 +74,12 @@ def sectionΓ'Bool : Γ' → Bool
   | Γ'.bit b => b
   | _ => Inhabited.default
 
-theorem leftInverse_section_inclusion : Function.LeftInverse sectionΓ'Bool inclusionBoolΓ' :=
-  fun x => Bool.casesOn x rfl rfl
+@[simp]
+theorem sectionΓ'Bool_inclusionBoolΓ' {b} : sectionΓ'Bool (inclusionBoolΓ' b) = b := by
+  cases b <;> rfl
 
 theorem inclusionBoolΓ'_injective : Function.Injective inclusionBoolΓ' :=
-  Function.HasLeftInverse.injective (Exists.intro sectionΓ'Bool leftInverse_section_inclusion)
+  Function.HasLeftInverse.injective ⟨_, (fun _ => sectionΓ'Bool_inclusionBoolΓ')⟩
 
 /-- An encoding function of the positive binary numbers in bool. -/
 def encodePosNum : PosNum → List Bool
@@ -111,7 +112,7 @@ theorem encodePosNum_nonempty (n : PosNum) : encodePosNum n ≠ [] :=
   PosNum.casesOn n (List.cons_ne_nil _ _) (fun _m => List.cons_ne_nil _ _) fun _m =>
     List.cons_ne_nil _ _
 
-theorem decode_encodePosNum : ∀ n, decodePosNum (encodePosNum n) = n := by
+@[simp] theorem decode_encodePosNum : ∀ n, decodePosNum (encodePosNum n) = n := by
   intro n
   induction' n with m hm m hm <;> unfold encodePosNum decodePosNum
   · rfl
@@ -119,7 +120,7 @@ theorem decode_encodePosNum : ∀ n, decodePosNum (encodePosNum n) = n := by
     exact if_neg (encodePosNum_nonempty m)
   · exact congr_arg PosNum.bit0 hm
 
-theorem decode_encodeNum : ∀ n, decodeNum (encodeNum n) = n := by
+@[simp] theorem decode_encodeNum : ∀ n, decodeNum (encodeNum n) = n := by
   intro n
   cases' n with n <;> unfold encodeNum decodeNum
   · rfl
@@ -127,7 +128,7 @@ theorem decode_encodeNum : ∀ n, decodeNum (encodeNum n) = n := by
   rw [PosNum.cast_to_num]
   exact if_neg (encodePosNum_nonempty n)
 
-theorem decode_encodeNat : ∀ n, decodeNat (encodeNat n) = n := by
+@[simp] theorem decode_encodeNat : ∀ n, decodeNat (encodeNat n) = n := by
   intro n
   conv_rhs => rw [← Num.to_of_nat n]
   exact congr_arg ((↑) : Num → ℕ) (decode_encodeNum n)
@@ -148,11 +149,7 @@ def encodingNatΓ' : Encoding ℕ where
   Γ := Γ'
   encode x := List.map inclusionBoolΓ' (encodeNat x)
   decode x := some (decodeNat (List.map sectionΓ'Bool x))
-  decode_encode x :=
-    congr_arg _ <| by
-      -- Porting note: `rw` can't unify `g ∘ f` with `fun x => g (f x)`, used `LeftInverse.id`
-      -- instead.
-      rw [List.map_map, leftInverse_section_inclusion.id, List.map_id, decode_encodeNat]
+  decode_encode x := congr_arg _ <| by simp [Function.comp_def]
 
 /-- A binary fin_encoding of ℕ in Γ'. -/
 def finEncodingNatΓ' : FinEncoding ℕ :=
@@ -167,7 +164,7 @@ def unaryEncodeNat : Nat → List Bool
 def unaryDecodeNat : List Bool → Nat :=
   List.length
 
-theorem unary_decode_encode_nat : ∀ n, unaryDecodeNat (unaryEncodeNat n) = n := fun n =>
+@[simp] theorem unary_decode_encode_nat : ∀ n, unaryDecodeNat (unaryEncodeNat n) = n := fun n =>
   Nat.rec rfl (fun (_m : ℕ) hm => (congr_arg Nat.succ hm.symm).symm) n
 
 /-- A unary fin_encoding of ℕ. -/
@@ -186,7 +183,7 @@ def decodeBool : List Bool → Bool
   | b :: _ => b
   | _ => Inhabited.default
 
-theorem decode_encodeBool (b : Bool) : decodeBool (encodeBool b) = b := rfl
+@[simp] theorem decode_encodeBool (b : Bool) : decodeBool (encodeBool b) = b := rfl
 
 /-- A fin_encoding of bool in bool. -/
 def finEncodingBoolBool : FinEncoding Bool where

--- a/Mathlib/Computability/Encoding.lean
+++ b/Mathlib/Computability/Encoding.lean
@@ -78,6 +78,10 @@ def sectionΓ'Bool : Γ' → Bool
 theorem sectionΓ'Bool_inclusionBoolΓ' {b} : sectionΓ'Bool (inclusionBoolΓ' b) = b := by
   cases b <;> rfl
 
+@[deprecated sectionΓ'Bool_inclusionBoolΓ' (since := "2025-01-21")]
+theorem leftInverse_section_inclusion : Function.LeftInverse sectionΓ'Bool inclusionBoolΓ' :=
+  fun x => Bool.casesOn x rfl rfl
+
 theorem inclusionBoolΓ'_injective : Function.Injective inclusionBoolΓ' :=
   Function.HasLeftInverse.injective ⟨_, (fun _ => sectionΓ'Bool_inclusionBoolΓ')⟩
 

--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -41,9 +41,6 @@ instance instCompleteAtomicBooleanAlgebra : CompleteAtomicBooleanAlgebra (Langua
 
 variable {l m : Language α} {a b x : List α}
 
--- Porting note: `reducible` attribute cannot be local.
--- attribute [local reducible] Language
-
 /-- Zero language has no elements. -/
 instance : Zero (Language α) :=
   ⟨(∅ : Set _)⟩
@@ -82,8 +79,6 @@ instance : KStar (Language α) := ⟨fun l ↦ {x | ∃ L : List (List α), x = 
 lemma kstar_def (l : Language α) : l∗ = {x | ∃ L : List (List α), x = L.flatten ∧ ∀ y ∈ L, y ∈ l} :=
   rfl
 
--- Porting note: `reducible` attribute cannot be local,
---               so this new theorem is required in place of `Set.ext`.
 @[ext]
 theorem ext {l m : Language α} (h : ∀ (x : List α), x ∈ l ↔ x ∈ m) : l = m :=
   Set.ext h
@@ -162,9 +157,7 @@ lemma mem_kstar_iff_exists_nonempty {x : List α} :
   · rintro ⟨S, rfl, h⟩
     refine ⟨S.filter fun l ↦ !List.isEmpty l,
       by simp [List.flatten_filter_not_isEmpty], fun y hy ↦ ?_⟩
-    -- Porting note: The previous code was:
-    -- rw [mem_filter, empty_iff_eq_nil] at hy
-    rw [mem_filter, Bool.not_eq_true', ← Bool.bool_iff_false, List.isEmpty_iff] at hy
+    simp only [mem_filter, Bool.not_eq_eq_eq_not, Bool.not_true, isEmpty_eq_false] at hy
     exact ⟨h y hy.1, hy.2⟩
   · rintro ⟨S, hx, h⟩
     exact ⟨S, hx, fun y hy ↦ (h y hy).1⟩

--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -157,7 +157,7 @@ lemma mem_kstar_iff_exists_nonempty {x : List α} :
   · rintro ⟨S, rfl, h⟩
     refine ⟨S.filter fun l ↦ !List.isEmpty l,
       by simp [List.flatten_filter_not_isEmpty], fun y hy ↦ ?_⟩
-    simp only [mem_filter, Bool.not_eq_eq_eq_not, Bool.not_true, isEmpty_eq_false] at hy
+    simp only [mem_filter, Bool.not_eq_eq_eq_not, Bool.not_true, isEmpty_eq_false, ne_eq] at hy
     exact ⟨h y hy.1, hy.2⟩
   · rintro ⟨S, hx, h⟩
     exact ⟨S, hx, fun y hy ↦ (h y hy).1⟩

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -387,7 +387,7 @@ protected theorem bind {f : α →. β} {g : α → β →. σ} (hf : Partrec f)
 
 theorem map {f : α →. β} {g : α → β → σ} (hf : Partrec f) (hg : Computable₂ g) :
     Partrec fun a => (f a).map (g a) := by
-  simpa [bind_some_eq_map] using @Partrec.bind _ _ _ _ _ _ _ (fun a => Part.some ∘ (g a)) hf hg
+  simpa [bind_some_eq_map] using Partrec.bind (g := fun a x => some (g a x)) hf hg
 
 theorem to₂ {f : α × β →. σ} (hf : Partrec f) : Partrec₂ fun a b => f (a, b) :=
   hf.of_eq fun ⟨_, _⟩ => rfl
@@ -656,11 +656,7 @@ variable [Primcodable α] [Primcodable β] [Primcodable γ] [Primcodable σ]
 open Computable
 
 theorem option_some_iff {f : α →. σ} : (Partrec fun a => (f a).map Option.some) ↔ Partrec f :=
-  ⟨fun h => (Nat.Partrec.ppred.comp h).of_eq fun n => by
-      -- Porting note: needed to help with applying bind_some_eq_map because `Function.comp` got
-      -- less reducible.
-      simp [Part.bind_assoc, ← Function.comp_apply (f := Part.some) (g := encode), bind_some_eq_map,
-        -Function.comp_apply],
+  ⟨fun h => (Nat.Partrec.ppred.comp h).of_eq fun n => by simp [Part.bind_assoc, bind_some_eq_map],
     fun hf => hf.map (option_some.comp snd).to₂⟩
 
 theorem option_casesOn_right {o : α → Option β} {f : α → σ} {g : α → β →. σ} (ho : Computable o)

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -206,8 +206,6 @@ theorem encode_lt_rfind' (cf) : encode cf < encode (rfind' cf) := by
 
 end Nat.Partrec.Code
 
--- Porting note: Opening `Primrec` inside `namespace Nat.Partrec.Code` causes it to resolve
--- to `Nat.Partrec`. Needs `open _root_.Partrec` support
 section
 open Primrec
 namespace Nat.Partrec.Code
@@ -557,7 +555,6 @@ theorem exists_code {f : ℕ →. ℕ} : Nat.Partrec f ↔ ∃ c : Code, eval c 
     | prec cf cg pf pg => exact pf.prec pg
     | rfind' cf pf => exact pf.rfind'
 
--- Porting note: `>>`s in `evaln` are now `>>=` because `>>`s are not elaborated well in Lean4.
 /-- A modified evaluation for the code which returns an `Option ℕ` instead of a `Part ℕ`. To avoid
 undecidability, `evaln` takes a parameter `k` and fails if it encounters a number ≥ k in the course
 of its execution. Other than this, the semantics are the same as in `Nat.Partrec.Code.eval`.

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -32,26 +32,6 @@ open Denumerable Encodable Function
 
 namespace Nat
 
--- Porting note: elim is no longer required because lean 4 is better
--- at inferring motive types (I think this is the reason)
--- and worst case, we can always explicitly write (motive := fun _ => C)
--- without having to then add all the other underscores
-
--- /-- The non-dependent recursor on naturals. -/
--- def elim {C : Sort*} : C → (ℕ → C → C) → ℕ → C :=
---   @Nat.rec fun _ => C
--- example {C : Sort*} (base : C) (succ : ℕ → C → C) (a : ℕ) :
---   a.elim base succ = a.rec base succ := rfl
-
--- Porting note: cases is no longer required because lean 4 is better
--- at inferring motive types (I think this is the reason)
-
--- /-- Cases on whether the input is 0 or a successor. -/
--- def cases {C : Sort*} (a : C) (f : ℕ → C) : ℕ → C :=
---   Nat.elim a fun n _ => f n
--- example {C : Sort*} (a : C) (f : ℕ → C) (n : ℕ) :
---   n.cases a f = n.casesOn a f := rfl
-
 /-- Calls the given function on a pair of entries `n`, encoded via the pairing function. -/
 @[simp, reducible]
 def unpaired {α} (f : ℕ → ℕ → α) (n : ℕ) : α :=
@@ -611,10 +591,6 @@ theorem _root_.PrimrecPred.or {p q : α → Prop} [DecidablePred p] [DecidablePr
     (hp : PrimrecPred p) (hq : PrimrecPred q) : PrimrecPred fun a => p a ∨ q a :=
   (Primrec.or.comp hp hq).of_eq fun n => by simp
 
--- Porting note: It is unclear whether we want to boolean versions
--- of these lemmas, just the prop versions, or both
--- The boolean versions are often actually easier to use
--- but did not exist in Lean 3
 protected theorem beq [DecidableEq α] : Primrec₂ (@BEq.beq α _) :=
   have : PrimrecRel fun a b : ℕ => a = b :=
     (PrimrecPred.and nat_le nat_le.swap).of_eq fun a => by simp [le_antisymm_iff]
@@ -1107,9 +1083,6 @@ instance vector {n} : Primcodable (List.Vector α n) :=
 instance finArrow {n} : Primcodable (Fin n → α) :=
   ofEquiv _ (Equiv.vectorEquivFin _ _).symm
 
--- Porting note: Equiv.arrayEquivFin is not ported yet
--- instance array {n} : Primcodable (Array' n α) :=
---   ofEquiv _ (Equiv.arrayEquivFin _ _)
 
 section ULower
 

--- a/Mathlib/Computability/RegularExpressions.lean
+++ b/Mathlib/Computability/RegularExpressions.lean
@@ -91,7 +91,7 @@ theorem plus_def (P Q : RegularExpression α) : plus P Q = P + Q :=
 theorem comp_def (P Q : RegularExpression α) : comp P Q = P * Q :=
   rfl
 
--- This was renamed to `matches'` during the port of Lean 4 as `matches` is a reserved work.
+-- This was renamed to `matches'` during the port of Lean 4 as `matches` is a reserved word.
 #adaptation_note /-- around nightly-2024-02-25,
   we need to write `comp x y` in the pattern `comp P Q`, instead of `x * y`. -/
 /-- `matches' P` provides a language which contains all strings that `P` matches -/

--- a/Mathlib/Computability/RegularExpressions.lean
+++ b/Mathlib/Computability/RegularExpressions.lean
@@ -30,6 +30,9 @@ universe u
 
 variable {α β γ : Type*}
 
+-- Disable generation of unneeded lemmas which the simpNF linter would complain about.
+set_option genSizeOfSpec false in
+set_option genInjectivity false in
 /-- This is the definition of regular expressions. The names used here is to mirror the definition
 of a Kleene algebra (https://en.wikipedia.org/wiki/Kleene_algebra).
 * `0` (`zero`) matches nothing
@@ -46,15 +49,6 @@ inductive RegularExpression (α : Type u) : Type u
   | plus : RegularExpression α → RegularExpression α → RegularExpression α
   | comp : RegularExpression α → RegularExpression α → RegularExpression α
   | star : RegularExpression α → RegularExpression α
-
-
--- Porting note: `simpNF` gets grumpy about how the `foo_def`s below can simplify these..
-attribute [nolint simpNF] RegularExpression.zero.sizeOf_spec
-attribute [nolint simpNF] RegularExpression.epsilon.sizeOf_spec
-attribute [nolint simpNF] RegularExpression.plus.sizeOf_spec
-attribute [nolint simpNF] RegularExpression.plus.injEq
-attribute [nolint simpNF] RegularExpression.comp.injEq
-attribute [nolint simpNF] RegularExpression.comp.sizeOf_spec
 
 namespace RegularExpression
 
@@ -79,7 +73,7 @@ instance : Pow (RegularExpression α) ℕ :=
   ⟨fun n r => npowRec r n⟩
 
 -- Porting note: declaration in an imported module
---attribute [match_pattern] Mul.mul
+-- attribute [match_pattern] Mul.mul
 
 @[simp]
 theorem zero_def : (zero : RegularExpression α) = 0 :=
@@ -97,7 +91,7 @@ theorem plus_def (P Q : RegularExpression α) : plus P Q = P + Q :=
 theorem comp_def (P Q : RegularExpression α) : comp P Q = P * Q :=
   rfl
 
--- Porting note: `matches` is reserved, moved to `matches'`
+-- This was renamed to `matches'` during the port of Lean 4 as `matches` is a reserved work.
 #adaptation_note /-- around nightly-2024-02-25,
   we need to write `comp x y` in the pattern `comp P Q`, instead of `x * y`. -/
 /-- `matches' P` provides a language which contains all strings that `P` matches -/
@@ -401,13 +395,8 @@ theorem matches'_map (f : α → β) :
   | char a => by
     rw [eq_comm]
     exact image_singleton
-  -- Porting note: the following close with last `rw` but not with `simp`?
-  | R + S => by simp only [matches'_map, map, matches'_add]; rw [map_add]
+  | R + S => by simp only [matches'_map, map, matches'_add, map_add]
   | comp R S => by simp [matches'_map]
-  | star R => by
-    simp_rw [map, matches', matches'_map]
-    rw [Language.kstar_eq_iSup_pow, Language.kstar_eq_iSup_pow]
-    simp_rw [← map_pow]
-    exact image_iUnion.symm
+  | star R => by simp [matches'_map]
 
 end RegularExpression

--- a/Mathlib/Computability/TMComputable.lean
+++ b/Mathlib/Computability/TMComputable.lean
@@ -82,7 +82,6 @@ instance inhabitedσ : Inhabited tm.σ :=
 def Stmt : Type :=
   Turing.TM2.Stmt tm.Γ tm.Λ tm.σ
 
--- Porting note: The `deriving Inhabited` handler couldn't derive this.
 instance inhabitedStmt : Inhabited (Stmt tm) :=
   inferInstanceAs (Inhabited (Turing.TM2.Stmt tm.Γ tm.Λ tm.σ))
 
@@ -135,8 +134,7 @@ structure EvalsToInTime {σ : Type*} (f : σ → Option σ) (a : σ) (b : Option
   steps_le_m : steps ≤ m
 
 /-- Reflexivity of `EvalsTo` in 0 steps. -/
--- @[refl] -- Porting note: `@[refl]` attribute only applies to lemmas proving `x ∼ x` in Lean4.
-def EvalsTo.refl {σ : Type*} (f : σ → Option σ) (a : σ) : EvalsTo f a a :=
+def EvalsTo.refl {σ : Type*} (f : σ → Option σ) (a : σ) : EvalsTo f a (some a) :=
   ⟨0, rfl⟩
 
 /-- Transitivity of `EvalsTo` in the sum of the numbers of steps. -/
@@ -146,8 +144,7 @@ def EvalsTo.trans {σ : Type*} (f : σ → Option σ) (a : σ) (b : σ) (c : Opt
   ⟨h₂.steps + h₁.steps, by rw [Function.iterate_add_apply, h₁.evals_in_steps, h₂.evals_in_steps]⟩
 
 /-- Reflexivity of `EvalsToInTime` in 0 steps. -/
--- @[refl] -- Porting note: `@[refl]` attribute only applies to lemmas proving `x ∼ x` in Lean4.
-def EvalsToInTime.refl {σ : Type*} (f : σ → Option σ) (a : σ) : EvalsToInTime f a a 0 :=
+def EvalsToInTime.refl {σ : Type*} (f : σ → Option σ) (a : σ) : EvalsToInTime f a (some a) 0 :=
   ⟨EvalsTo.refl f a, le_refl 0⟩
 
 /-- Transitivity of `EvalsToInTime` in the sum of the numbers of steps. -/

--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -122,10 +122,6 @@ def Code.eval : Code → List ℕ →. List ℕ
 
 namespace Code
 
-/- Porting note: The equation lemma of `eval` is too strong; it simplifies terms like the LHS of
-`pred_eval`. Even `eqns` can't fix this. We removed `simp` attr from `eval` and prepare new simp
-lemmas for `eval`. -/
-
 @[simp]
 theorem zero'_eval : zero'.eval = fun v => pure (0 :: v) := by simp [eval]
 

--- a/Mathlib/Computability/Tape.lean
+++ b/Mathlib/Computability/Tape.lean
@@ -584,9 +584,7 @@ theorem Tape.map_write {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (f : PointedMap �
     ∀ T : Tape Γ, (T.write b).map f = (T.map f).write (f b) := by
   rintro ⟨⟩; rfl
 
--- Porting note: `simpNF` complains about LHS does not simplify when using the simp lemma on
---               itself, but it does indeed.
-@[simp, nolint simpNF]
+@[simp]
 theorem Tape.write_move_right_n {Γ} [Inhabited Γ] (f : Γ → Γ) (L R : ListBlank Γ) (n : ℕ) :
     ((Tape.move Dir.right)^[n] (Tape.mk' L R)).write (f (R.nth n)) =
       (Tape.move Dir.right)^[n] (Tape.mk' L (R.modifyNth f n)) := by

--- a/Mathlib/Computability/TuringMachine.lean
+++ b/Mathlib/Computability/TuringMachine.lean
@@ -147,8 +147,7 @@ def evalInduction {σ} {f : σ → Option σ} {b : σ} {C : σ → Sort*} {a : �
 
 theorem mem_eval {σ} {f : σ → Option σ} {a b} : b ∈ eval f a ↔ Reaches f a b ∧ f b = none := by
   refine ⟨fun h ↦ ?_, fun ⟨h₁, h₂⟩ ↦ ?_⟩
-  · -- Porting note: Explicitly specify `c`.
-    refine @evalInduction _ _ _ (fun a ↦ Reaches f a b ∧ f b = none) _ h fun a h IH ↦ ?_
+  · refine evalInduction h fun a h IH ↦ ?_
     cases' e : f a with a'
     · rw [Part.mem_unique h
           (PFun.mem_fix_iff.2 <| Or.inl <| Part.mem_some_iff.2 <| by rw [e]; rfl)]

--- a/Mathlib/Data/Part.lean
+++ b/Mathlib/Data/Part.lean
@@ -436,7 +436,7 @@ theorem bind_some (a : α) (f : α → Part β) : (some a).bind f = f a :=
 theorem bind_of_mem {o : Part α} {a : α} (h : a ∈ o) (f : α → Part β) : o.bind f = f a := by
   rw [eq_some_iff.2 h, bind_some]
 
-theorem bind_some_eq_map (f : α → β) (x : Part α) : x.bind (some ∘ f) = map f x :=
+theorem bind_some_eq_map (f : α → β) (x : Part α) : x.bind (fun y => some (f y)) = map f x :=
   ext <| by simp [eq_comm]
 
 theorem bind_toOption (f : α → Part β) (o : Part α) [Decidable o.Dom] [∀ a, Decidable (f a).Dom]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
