### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): prove finite results for induced subgraphs of `G.support`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -410,6 +410,9 @@ instance neighborSet.memDecidable (v : V) [DecidableRel G.Adj] :
     DecidablePred (· ∈ G.neighborSet v) :=
   inferInstanceAs <| DecidablePred (Adj G v)
 
+lemma neighborSet_subset_support (v : V) : G.neighborSet v ⊆ G.support :=
+  fun _ hadj ↦ ⟨v, hadj.symm⟩
+
 section EdgeSet
 
 variable {G₁ G₂ : SimpleGraph V}

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -452,19 +452,19 @@ instance : DecidablePred (· ∈ G.support) := by
 theorem card_edgeFinset_induce_of_support_subset (h : G.support ⊆ s) :
     #(G.induce s).edgeFinset = #G.edgeFinset := by
   apply card_bij (fun e _ ↦ e.map (↑))
-  · apply Sym2.ind
-    intro _ _
+  · intro e
+    induction e
     simp
-  · apply Sym2.ind
-    intro _ _ _
-    apply Sym2.ind
-    simp [Subtype.ext_iff]
-  · apply Sym2.ind
-    intro v₁ v₂ hadj
+  · intro e₁ _ e₂ _
+    induction e₁
+    induction e₂
+    simp [Subtype.ext_iff_val]
+  · intro e hadj
+    induction' e with v w
     rw [mem_edgeFinset, mem_edgeSet] at hadj
-    have hv₁ : v₁ ∈ G.support := G.mem_support.mpr ⟨v₂, hadj⟩
-    have hv₂ : v₂ ∈ G.support := G.mem_support.mpr ⟨v₁, hadj.symm⟩
-    use s(⟨v₁, h hv₁⟩, ⟨v₂, h hv₂⟩)
+    have hv : v ∈ G.support := G.mem_support.mpr ⟨w, hadj⟩
+    have hw : w ∈ G.support := G.mem_support.mpr ⟨v, hadj.symm⟩
+    use s(⟨v, h hv⟩, ⟨w, h hw⟩)
     simp [hadj]
 
 theorem card_edgeFinset_induce_support :

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -451,7 +451,7 @@ instance : DecidablePred (· ∈ G.support) := by
 `s` has the same number of edges as `G`. -/
 theorem card_edgeFinset_induce_of_support_subset (h : G.support ⊆ s) :
     #(G.induce s).edgeFinset = #G.edgeFinset := by
-  apply Finset.card_bij (fun e _ ↦ e.map (↑))
+  apply card_bij (fun e _ ↦ e.map (↑))
   · apply Sym2.ind
     intro _ _
     simp
@@ -476,7 +476,7 @@ in the induced subgraph of `s` are the same as in `G`. -/
 theorem degree_induce_of_support_subset (h : G.support ⊆ s) (v : s) :
     (G.induce s).degree v = G.degree v := by
   simp_rw [←card_neighborFinset_eq_degree]
-  apply Finset.card_bij (fun v _ ↦ ↑v) (by simp) (by simp)
+  apply card_bij (fun v _ ↦ ↑v) (by simp) (by simp)
   intro w hadj
   rw [mem_neighborFinset] at hadj
   have hw : w ∈ G.support := G.mem_support.mpr ⟨v, hadj.symm⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -504,6 +504,7 @@ theorem degree_induce_of_support_subset (h : G.support ⊆ s) (v : s) :
     (G.induce s).degree v = G.degree v :=
   degree_induce_of_neighborSet_subset <| (G.neighborSet_subset_support v).trans h
 
+@[simp]
 theorem degree_induce_support (v : G.support) :
     (G.induce G.support).degree v = G.degree v :=
   degree_induce_of_support_subset subset_rfl v

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -437,11 +437,19 @@ end Finite
 
 section Support
 
-variable [DecidableEq V] {s : Set V} [DecidablePred (· ∈ s)]
-  [Fintype V] {G : SimpleGraph V} [DecidableRel G.Adj]
+variable {s : Set V} [DecidablePred (· ∈ s)] [Fintype V] {G : SimpleGraph V} [DecidableRel G.Adj]
+
+lemma edgeFinset_subset_sym2_of_support_subset (h : G.support ⊆ s) :
+    G.edgeFinset ⊆ s.toFinset.sym2 := by
+  simp_rw [subset_iff, Sym2.forall,
+    mem_edgeFinset, mem_edgeSet, mk_mem_sym2_iff, Set.mem_toFinset]
+  intro _ _ hadj
+  exact ⟨h ⟨_, hadj⟩, h ⟨_, hadj.symm⟩⟩
 
 instance : DecidablePred (· ∈ G.support) :=
   inferInstanceAs <| DecidablePred (· ∈ { v | ∃ w, G.Adj v w })
+
+variable [DecidableEq V]
 
 theorem map_edgeFinset_induce :
     (G.induce s).edgeFinset.map (Embedding.subtype s).sym2Map
@@ -458,14 +466,6 @@ theorem map_edgeFinset_induce :
   · intro ⟨hadj, hv, hw⟩
     use ⟨v, hv⟩, ⟨w, hw⟩, hadj
     tauto
-
-omit [DecidableEq V] in
-lemma edgeFinset_subset_sym2_of_support_subset (h : G.support ⊆ s) :
-    G.edgeFinset ⊆ s.toFinset.sym2 := by
-  simp_rw [subset_iff, Sym2.forall,
-    mem_edgeFinset, mem_edgeSet, mk_mem_sym2_iff, Set.mem_toFinset]
-  intro _ _ hadj
-  exact ⟨h ⟨_, hadj⟩, h ⟨_, hadj.symm⟩⟩
 
 theorem map_edgeFinset_induce_of_support_subset (h : G.support ⊆ s) :
     (G.induce s).edgeFinset.map (Embedding.subtype s).sym2Map = G.edgeFinset := by

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -481,20 +481,28 @@ theorem card_edgeFinset_induce_support :
     #(G.induce G.support).edgeFinset = #G.edgeFinset :=
   card_edgeFinset_induce_of_support_subset subset_rfl
 
+theorem map_neighborFinset_induce (v : s) :
+    ((G.induce s).neighborFinset v).map (Embedding.subtype s)
+      = G.neighborFinset v ∩ s.toFinset := by
+  ext; simp [Set.mem_def]
+
+theorem map_neighborFinset_induce_of_neighborSet_subset {v : s} (h : G.neighborSet v ⊆ s) :
+    ((G.induce s).neighborFinset v).map (Embedding.subtype s) = G.neighborFinset v := by
+  rwa [← Set.toFinset_subset_toFinset, ← neighborFinset_def, ← inter_eq_left,
+    ← map_neighborFinset_induce v] at h
+
 /-- If the neighbor set of a vertex `v` is a subset of `s`, then the degree of the vertex in the
 induced subgraph of `s` is the same as in `G`. -/
 theorem degree_induce_of_neighborSet_subset {v : s} (h : G.neighborSet v ⊆ s) :
     (G.induce s).degree v = G.degree v := by
-  apply card_nbij (fun v ↦ ↑v) (by simp) (Set.injOn_of_injective Subtype.val_injective)
-  intro _ hadj
-  rw [neighborFinset_def, Set.coe_toFinset] at hadj
-  simp [show G.Adj v _ from hadj, h hadj]
+  simp_rw [← card_neighborFinset_eq_degree,
+    ← map_neighborFinset_induce_of_neighborSet_subset h, card_map]
 
 /-- If the support of the simple graph `G` is a subset of the set `s`, then the degree of vertices
 in the induced subgraph of `s` are the same as in `G`. -/
 theorem degree_induce_of_support_subset (h : G.support ⊆ s) (v : s) :
     (G.induce s).degree v = G.degree v :=
-  degree_induce_of_neighborSet_subset (fun _ hadj ↦ h ⟨v, hadj.symm⟩)
+  degree_induce_of_neighborSet_subset <| (G.neighborSet_subset_support v).trans h
 
 theorem degree_induce_support (v : G.support) :
     (G.induce G.support).degree v = G.degree v :=

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -443,9 +443,8 @@ lemma card_support_le [Fintype V] [Fintype G.support] :
 
 variable {s : Set V} [DecidablePred (· ∈ s)] [Fintype V] {G : SimpleGraph V} [DecidableRel G.Adj]
 
-instance : DecidablePred (· ∈ G.support) := by
-  unfold support Rel.dom
-  infer_instance
+instance : DecidablePred (· ∈ G.support) :=
+  inferInstanceAs <| DecidablePred (· ∈ { v | ∃ w, G.Adj v w })
 
 /-- If the support of the simple graph `G` is a subset of the set `s`, then the induced subgraph of
 `s` has the same number of edges as `G`. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -471,6 +471,15 @@ theorem card_edgeFinset_induce_support :
     #(G.induce G.support).edgeFinset = #G.edgeFinset :=
   card_edgeFinset_induce_of_support_subset subset_rfl
 
+/-- If the neighbor set of a vertex `v` is a subset of `s`, then the degree of the vertex in the
+induced subgraph of `s` is the same as in `G`. -/
+theorem degree_induce_of_neighborSet_subset {v : s} (h : G.neighborSet v ⊆ s) :
+    (G.induce s).degree v = G.degree v := by
+  apply card_nbij (fun v ↦ ↑v) (by simp) (Set.injOn_of_injective Subtype.val_injective)
+  intro _ hadj
+  rw [neighborFinset_def, Set.coe_toFinset] at hadj
+  simp [show G.Adj v _ from hadj, h hadj]
+
 /-- If the support of the simple graph `G` is a subset of the set `s`, then the degree of vertices
 in the induced subgraph of `s` are the same as in `G`. -/
 theorem degree_induce_of_support_subset (h : G.support ⊆ s) (v : s) :

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -482,12 +482,12 @@ theorem card_edgeFinset_induce_support :
   card_edgeFinset_induce_of_support_subset subset_rfl
 
 theorem map_neighborFinset_induce (v : s) :
-    ((G.induce s).neighborFinset v).map (Embedding.subtype s)
+    ((G.induce s).neighborFinset v).map (.subtype s)
       = G.neighborFinset v ∩ s.toFinset := by
   ext; simp [Set.mem_def]
 
 theorem map_neighborFinset_induce_of_neighborSet_subset {v : s} (h : G.neighborSet v ⊆ s) :
-    ((G.induce s).neighborFinset v).map (Embedding.subtype s) = G.neighborFinset v := by
+    ((G.induce s).neighborFinset v).map (.subtype s) = G.neighborFinset v := by
   rwa [← Set.toFinset_subset_toFinset, ← neighborFinset_def, ← inter_eq_left,
     ← map_neighborFinset_induce v] at h
 

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -451,20 +451,12 @@ instance : DecidablePred (· ∈ G.support) := by
 `s` has the same number of edges as `G`. -/
 theorem card_edgeFinset_induce_of_support_subset (h : G.support ⊆ s) :
     #(G.induce s).edgeFinset = #G.edgeFinset := by
-  apply card_bij (fun e _ ↦ e.map (↑))
-  · intro e
-    induction e
-    simp
-  · intro e₁ _ e₂ _
-    induction e₁
-    induction e₂
+  apply card_nbij (fun e ↦ e.map (↑)) (by rintro ⟨_, _⟩; simp)
+  · rintro ⟨_, _⟩ _ ⟨_, _⟩ _
     simp [Subtype.ext_iff_val]
-  · intro e hadj
-    induction' e with v w
-    rw [mem_edgeFinset, mem_edgeSet] at hadj
-    have hv : v ∈ G.support := G.mem_support.mpr ⟨w, hadj⟩
-    have hw : w ∈ G.support := G.mem_support.mpr ⟨v, hadj.symm⟩
-    use s(⟨v, h hv⟩, ⟨w, h hw⟩)
+  · rintro ⟨v, w⟩ hadj
+    rw [Set.coe_toFinset, mem_edgeSet] at hadj
+    use s(⟨v, h ⟨w, hadj⟩⟩, ⟨w, h ⟨v, hadj.symm⟩⟩)
     simp [hadj]
 
 theorem card_edgeFinset_induce_support :
@@ -483,14 +475,8 @@ theorem degree_induce_of_neighborSet_subset {v : s} (h : G.neighborSet v ⊆ s) 
 /-- If the support of the simple graph `G` is a subset of the set `s`, then the degree of vertices
 in the induced subgraph of `s` are the same as in `G`. -/
 theorem degree_induce_of_support_subset (h : G.support ⊆ s) (v : s) :
-    (G.induce s).degree v = G.degree v := by
-  simp_rw [←card_neighborFinset_eq_degree]
-  apply card_bij (fun v _ ↦ ↑v) (by simp) (by simp)
-  intro w hadj
-  rw [mem_neighborFinset] at hadj
-  have hw : w ∈ G.support := G.mem_support.mpr ⟨v, hadj.symm⟩
-  use ⟨w, h hw⟩
-  simp [hadj]
+    (G.induce s).degree v = G.degree v :=
+  degree_induce_of_neighborSet_subset (fun _ hadj ↦ h ⟨v, hadj.symm⟩)
 
 theorem degree_induce_support (v : G.support) :
     (G.induce G.support).degree v = G.degree v :=


### PR DESCRIPTION
Prove the edges and degrees in the induced subgraphs of `G.support` are equal to the edges and degrees in the original simple graph.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
