### PR TITLE
[Merged by Bors] - feat: in one dimension, a point is either isolated or a point of unique differentiability

### DIFF
--- a/Mathlib/Analysis/Calculus/TangentCone.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone.lean
@@ -6,6 +6,7 @@ Authors: Sébastien Gouëzel
 import Mathlib.Analysis.Convex.Topology
 import Mathlib.Analysis.Normed.Module.Basic
 import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Analysis.Seminorm
 
 /-!
 # Tangent cone
@@ -207,6 +208,125 @@ theorem mem_tangentCone_of_segment_subset {s : Set G} {x y : G} (h : segment ℝ
     y - x ∈ tangentConeAt ℝ s x :=
   mem_tangentCone_of_openSegment_subset ((openSegment_subset_segment ℝ x y).trans h)
 
+/-- The tangent cone at a non-isolated point contains `0`. -/
+theorem zero_mem_tangentCone {s : Set E} {x : E} (hx : (𝓝[s \ {x}] x).NeBot) :
+    0 ∈ tangentConeAt 𝕜 s x := by
+  obtain ⟨u, -, u_pos, u_lim⟩ :
+      ∃ u, StrictAnti u ∧ (∀ (n : ℕ), 0 < u n) ∧ Tendsto u atTop (𝓝 (0 : ℝ)) :=
+    exists_seq_strictAnti_tendsto (0 : ℝ)
+  have A n : ((s \ {x}) ∩ Metric.ball x (u n * u n)).Nonempty :=
+    NeBot.nonempty_of_mem hx (inter_mem_nhdsWithin _
+      (Metric.ball_mem_nhds _ (mul_pos (u_pos n) (u_pos n))))
+  choose v hv using A
+  let d := fun n ↦ v n - x
+  have M n : x + d n ∈ s \ {x} := by simpa [d] using (hv n).1
+  let ⟨r, hr⟩ := exists_one_lt_norm 𝕜
+  have W n := rescale_to_shell hr (u_pos n) (x := d n) (by simpa using (M n).2)
+  choose c c_ne c_le le_c hc using W
+  have c_lim : Tendsto (fun n ↦ ‖c n‖) atTop atTop := by
+    suffices Tendsto (fun n ↦ ‖c n‖⁻¹ ⁻¹ ) atTop atTop by simpa
+    apply tendsto_inv_nhdsGT_zero.comp
+    simp only [nhdsWithin, tendsto_inf, tendsto_principal, mem_Ioi, norm_pos_iff, ne_eq,
+      eventually_atTop, ge_iff_le]
+    have B (n : ℕ) : ‖c n‖⁻¹ ≤ ‖r‖ * u n := by
+      apply (hc n).trans
+      calc (u n)⁻¹ * ‖r‖ * ‖d n‖
+      _ ≤ (u n)⁻¹ * ‖r‖ * (u n * u n) := by
+        gcongr
+        · exact mul_nonneg (by simp [(u_pos n).le]) (norm_nonneg _)
+        · specialize hv n
+          simp only [mem_inter_iff, mem_diff, mem_singleton_iff, Metric.mem_ball, dist_eq_norm]
+            at hv
+          simpa using hv.2.le
+      _ = ((u n) ⁻¹ * u n ) * ‖r‖ * u n := by ring
+      _ = ‖r‖ * u n := by rw [inv_mul_cancel₀ (u_pos n).ne', one_mul]
+    refine ⟨?_, 0, fun n hn ↦ by simpa using c_ne n⟩
+    apply squeeze_zero (fun n ↦ by positivity) B
+    simpa using u_lim.const_mul _
+  refine ⟨c, d, Eventually.of_forall (fun n ↦ by simpa [d] using (hv n).1.1), c_lim, ?_⟩
+  rw [tendsto_zero_iff_norm_tendsto_zero]
+  exact squeeze_zero (fun n ↦ by positivity) (fun n ↦ (c_le n).le) u_lim
+
+/-- In a proper space, the tangent cone at a non-isolated point is nontrivial. -/
+theorem tangentCone_nonempty_of_properSpace [ProperSpace E]
+    {s : Set E} {x : E} (hx : (𝓝[s \ {x}] x).NeBot) :
+    (tangentConeAt 𝕜 s x ∩ {0}ᶜ).Nonempty := by
+  obtain ⟨u, -, u_pos, u_lim⟩ :
+      ∃ u, StrictAnti u ∧ (∀ (n : ℕ), 0 < u n) ∧ Tendsto u atTop (𝓝 (0 : ℝ)) :=
+    exists_seq_strictAnti_tendsto (0 : ℝ)
+  have A n : ((s \ {x}) ∩ Metric.ball x (u n)).Nonempty := by
+    apply NeBot.nonempty_of_mem hx (inter_mem_nhdsWithin _ (Metric.ball_mem_nhds _ (u_pos n)))
+  choose v hv using A
+  let d := fun n ↦ v n - x
+  have M n : x + d n ∈ s \ {x} := by simpa [d] using (hv n).1
+  let ⟨r, hr⟩ := exists_one_lt_norm 𝕜
+  have W n := rescale_to_shell hr zero_lt_one (x := d n) (by simpa using (M n).2)
+  choose c c_ne c_le le_c hc using W
+  have c_lim : Tendsto (fun n ↦ ‖c n‖) atTop atTop := by
+    suffices Tendsto (fun n ↦ ‖c n‖⁻¹ ⁻¹ ) atTop atTop by simpa
+    apply tendsto_inv_nhdsGT_zero.comp
+    simp only [nhdsWithin, tendsto_inf, tendsto_principal, mem_Ioi, norm_pos_iff, ne_eq,
+      eventually_atTop, ge_iff_le]
+    have B (n : ℕ) : ‖c n‖⁻¹ ≤ 1⁻¹ * ‖r‖ * u n := by
+      apply (hc n).trans
+      gcongr
+      specialize hv n
+      simp only [mem_inter_iff, mem_diff, mem_singleton_iff, Metric.mem_ball, dist_eq_norm] at hv
+      simpa using hv.2.le
+    refine ⟨?_, 0, fun n hn ↦ by simpa using c_ne n⟩
+    apply squeeze_zero (fun n ↦ by positivity) B
+    simpa using u_lim.const_mul _
+  obtain ⟨l, l_mem, φ, φ_strict, hφ⟩ :
+      ∃ l ∈ Metric.closedBall (0 : E) 1 \ Metric.ball (0 : E) (1 / ‖r‖),
+      ∃ (φ : ℕ → ℕ), StrictMono φ ∧ Tendsto ((fun n ↦ c n • d n) ∘ φ) atTop (𝓝 l) := by
+    apply IsCompact.tendsto_subseq _ (fun n ↦ ?_)
+    · exact (isCompact_closedBall 0 1).diff Metric.isOpen_ball
+    simp only [mem_diff, Metric.mem_closedBall, dist_zero_right, (c_le n).le,
+      Metric.mem_ball, not_lt, true_and, le_c n]
+  refine ⟨l, ?_, ?_⟩; swap
+  · simp only [mem_compl_iff, mem_singleton_iff]
+    contrapose! l_mem
+    simp only [one_div, l_mem, mem_diff, Metric.mem_closedBall, dist_self, zero_le_one,
+      Metric.mem_ball, inv_pos, norm_pos_iff, ne_eq, not_not, true_and]
+    contrapose! hr
+    simp [hr]
+  refine ⟨c ∘ φ, d ∘ φ, ?_, ?_, ?_⟩
+  · exact Eventually.of_forall (fun n ↦ by simpa [d] using (hv (φ n)).1.1)
+  · apply c_lim.comp φ_strict.tendsto_atTop
+  · exact hφ
+
+/-- The tangent cone at a non-isolated point in dimension 1 is the whole space -/
+theorem tangentCone_eq_univ {s : Set 𝕜} {x : 𝕜} (hx : (𝓝[s \ {x}] x).NeBot) :
+    tangentConeAt 𝕜 s x = univ := by
+  apply eq_univ_iff_forall.2 (fun y ↦ ?_)
+  rcases eq_or_ne y 0 with rfl | hy
+  · exact zero_mem_tangentCone hx
+  obtain ⟨u, -, u_pos, u_lim⟩ :
+      ∃ u, StrictAnti u ∧ (∀ (n : ℕ), 0 < u n) ∧ Tendsto u atTop (𝓝 (0 : ℝ)) :=
+    exists_seq_strictAnti_tendsto (0 : ℝ)
+  have A n : ((s \ {x}) ∩ Metric.ball x (u n)).Nonempty := by
+    apply NeBot.nonempty_of_mem hx (inter_mem_nhdsWithin _ (Metric.ball_mem_nhds _ (u_pos n)))
+  choose v hv using A
+  let d := fun n ↦ v n - x
+  have d_ne n : d n ≠ 0 := by
+    simp only [mem_inter_iff, mem_diff, mem_singleton_iff, Metric.mem_ball, d] at hv
+    simpa [d, sub_ne_zero] using (hv n).1.2
+  refine ⟨fun n ↦ y * (d n)⁻¹, d, ?_, ?_, ?_⟩
+  · exact Eventually.of_forall (fun n ↦ by simpa [d] using (hv n).1.1)
+  · simp only [norm_mul, norm_inv]
+    apply (tendsto_const_mul_atTop_of_pos (by simpa using hy)).2
+    apply tendsto_inv_nhdsGT_zero.comp
+    simp only [nhdsWithin, tendsto_inf, tendsto_principal, mem_Ioi, norm_pos_iff, ne_eq,
+      eventually_atTop, ge_iff_le]
+    have B (n : ℕ) : ‖d n‖ ≤ u n := by
+      specialize hv n
+      simp only [mem_inter_iff, mem_diff, mem_singleton_iff, Metric.mem_ball, dist_eq_norm] at hv
+      simpa using hv.2.le
+    refine ⟨?_, 0, fun n hn ↦ by simpa using d_ne n⟩
+    exact squeeze_zero (fun n ↦ by positivity) B u_lim
+  · convert tendsto_const_nhds (α := ℕ) (x := y) with n
+    simp only [smul_eq_mul, mul_assoc, inv_mul_cancel₀ (d_ne n), mul_one]
+
 end TangentCone
 
 section UniqueDiff
@@ -390,5 +510,16 @@ theorem uniqueDiffWithinAt_Ioi (a : ℝ) : UniqueDiffWithinAt ℝ (Ioi a) a :=
 
 theorem uniqueDiffWithinAt_Iio (a : ℝ) : UniqueDiffWithinAt ℝ (Iio a) a :=
   uniqueDiffWithinAt_convex (convex_Iio a) (by simp) (by simp)
+
+/-- In one dimension, every point is either a point of unique differentiability, or isolated. -/
+theorem uniqueDiffWithinAt_or_nhdsWithin_eq_bot (s : Set 𝕜) (x : 𝕜) :
+    UniqueDiffWithinAt 𝕜 s x ∨ 𝓝[s \ {x}] x = ⊥ := by
+  rcases eq_or_neBot (𝓝[s \ {x}] x) with h | h
+  · exact Or.inr h
+  refine Or.inl ⟨?_, ?_⟩
+  · simp [tangentCone_eq_univ h]
+  · simp only [mem_closure_iff_nhdsWithin_neBot]
+    apply neBot_of_le (hf := h)
+    exact nhdsWithin_mono _ diff_subset
 
 end UniqueDiff

--- a/Mathlib/Analysis/Calculus/TangentCone.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone.lean
@@ -5,8 +5,8 @@ Authors: Sébastien Gouëzel
 -/
 import Mathlib.Analysis.Convex.Topology
 import Mathlib.Analysis.Normed.Module.Basic
-import Mathlib.Analysis.SpecificLimits.Basic
 import Mathlib.Analysis.Seminorm
+import Mathlib.Analysis.SpecificLimits.Basic
 
 /-!
 # Tangent cone

--- a/Mathlib/Analysis/Calculus/TangentCone.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone.lean
@@ -211,6 +211,9 @@ theorem mem_tangentCone_of_segment_subset {s : Set G} {x y : G} (h : segment ℝ
 /-- The tangent cone at a non-isolated point contains `0`. -/
 theorem zero_mem_tangentCone {s : Set E} {x : E} (hx : (𝓝[s \ {x}] x).NeBot) :
     0 ∈ tangentConeAt 𝕜 s x := by
+  /- Take a sequence `d n` tending to `0` such that `x + d n ∈ s`. Taking `c n` of the order
+  of `1 / (d n) ^ (1/2)`, then `c n` tends to infinity, but `c n • d n` tends to `0`. By definition,
+  this shows that `0` belongs to the tangent cone. -/
   obtain ⟨u, -, u_pos, u_lim⟩ :
       ∃ u, StrictAnti u ∧ (∀ (n : ℕ), 0 < u n) ∧ Tendsto u atTop (𝓝 (0 : ℝ)) :=
     exists_seq_strictAnti_tendsto (0 : ℝ)
@@ -228,9 +231,9 @@ theorem zero_mem_tangentCone {s : Set E} {x : E} (hx : (𝓝[s \ {x}] x).NeBot) 
     apply tendsto_inv_nhdsGT_zero.comp
     simp only [nhdsWithin, tendsto_inf, tendsto_principal, mem_Ioi, norm_pos_iff, ne_eq,
       eventually_atTop, ge_iff_le]
-    have B (n : ℕ) : ‖c n‖⁻¹ ≤ ‖r‖ * u n := by
-      apply (hc n).trans
-      calc (u n)⁻¹ * ‖r‖ * ‖d n‖
+    have B (n : ℕ) : ‖c n‖⁻¹ ≤ ‖r‖ * u n := calc
+      ‖c n‖⁻¹
+      _ ≤ (u n)⁻¹ * ‖r‖ * ‖d n‖ := hc n
       _ ≤ (u n)⁻¹ * ‖r‖ * (u n * u n) := by
         gcongr
         · exact mul_nonneg (by simp [(u_pos n).le]) (norm_nonneg _)
@@ -250,6 +253,10 @@ theorem zero_mem_tangentCone {s : Set E} {x : E} (hx : (𝓝[s \ {x}] x).NeBot) 
 theorem tangentCone_nonempty_of_properSpace [ProperSpace E]
     {s : Set E} {x : E} (hx : (𝓝[s \ {x}] x).NeBot) :
     (tangentConeAt 𝕜 s x ∩ {0}ᶜ).Nonempty := by
+  /- Take a sequence `d n` tending to `0` such that `x + d n ∈ s`. Taking `c n` of the order
+  of `1 / d n`. Then `c n • d n` belongs to a fixed annulus. By compactness, one can extract
+  a subsequence converging to a limit `l`. Then `l` is nonzero, and by definition it belongs to
+  the tangent cone. -/
   obtain ⟨u, -, u_pos, u_lim⟩ :
       ∃ u, StrictAnti u ∧ (∀ (n : ℕ), 0 < u n) ∧ Tendsto u atTop (𝓝 (0 : ℝ)) :=
     exists_seq_strictAnti_tendsto (0 : ℝ)
@@ -289,17 +296,21 @@ theorem tangentCone_nonempty_of_properSpace [ProperSpace E]
       Metric.mem_ball, inv_pos, norm_pos_iff, ne_eq, not_not, true_and]
     contrapose! hr
     simp [hr]
-  refine ⟨c ∘ φ, d ∘ φ, ?_, ?_, ?_⟩
+  refine ⟨c ∘ φ, d ∘ φ, ?_, ?_, hφ⟩
   · exact Eventually.of_forall (fun n ↦ by simpa [d] using (hv (φ n)).1.1)
-  · apply c_lim.comp φ_strict.tendsto_atTop
-  · exact hφ
+  · exact c_lim.comp φ_strict.tendsto_atTop
 
-/-- The tangent cone at a non-isolated point in dimension 1 is the whole space -/
+/-- The tangent cone at a non-isolated point in dimension 1 is the whole space. -/
 theorem tangentCone_eq_univ {s : Set 𝕜} {x : 𝕜} (hx : (𝓝[s \ {x}] x).NeBot) :
     tangentConeAt 𝕜 s x = univ := by
   apply eq_univ_iff_forall.2 (fun y ↦ ?_)
+  -- first deal with the case of `0`, which has to be handled separately.
   rcases eq_or_ne y 0 with rfl | hy
   · exact zero_mem_tangentCone hx
+  /- Assume now `y` is a fixed nonzero scalar. Take a sequence `d n` tending to `0` such
+  that `x + d n ∈ s`. Let `c n = y / d n`. Then `‖c n‖` tends to infinity, and `c n • d n`
+  converges to `y` (as it is equal to `y`). By definition, this shows that `y` belongs to the
+  tangent cone. -/
   obtain ⟨u, -, u_pos, u_lim⟩ :
       ∃ u, StrictAnti u ∧ (∀ (n : ℕ), 0 < u n) ∧ Tendsto u atTop (𝓝 (0 : ℝ)) :=
     exists_seq_strictAnti_tendsto (0 : ℝ)
@@ -324,7 +335,7 @@ theorem tangentCone_eq_univ {s : Set 𝕜} {x : 𝕜} (hx : (𝓝[s \ {x}] x).Ne
     refine ⟨?_, 0, fun n hn ↦ by simpa using d_ne n⟩
     exact squeeze_zero (fun n ↦ by positivity) B u_lim
   · convert tendsto_const_nhds (α := ℕ) (x := y) with n
-    simp only [smul_eq_mul, mul_assoc, inv_mul_cancel₀ (d_ne n), mul_one]
+    simp [mul_assoc, inv_mul_cancel₀ (d_ne n)]
 
 end TangentCone
 

--- a/Mathlib/Analysis/Calculus/TangentCone.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone.lean
@@ -224,7 +224,7 @@ theorem zero_mem_tangentCone {s : Set E} {x : E} (hx : (𝓝[s \ {x}] x).NeBot) 
   have W n := rescale_to_shell hr (u_pos n) (x := d n) (by simpa using (M n).2)
   choose c c_ne c_le le_c hc using W
   have c_lim : Tendsto (fun n ↦ ‖c n‖) atTop atTop := by
-    suffices Tendsto (fun n ↦ ‖c n‖⁻¹ ⁻¹ ) atTop atTop by simpa
+    suffices Tendsto (fun n ↦ ‖c n‖⁻¹ ⁻¹) atTop atTop by simpa
     apply tendsto_inv_nhdsGT_zero.comp
     simp only [nhdsWithin, tendsto_inf, tendsto_principal, mem_Ioi, norm_pos_iff, ne_eq,
       eventually_atTop, ge_iff_le]
@@ -238,8 +238,7 @@ theorem zero_mem_tangentCone {s : Set E} {x : E} (hx : (𝓝[s \ {x}] x).NeBot) 
           simp only [mem_inter_iff, mem_diff, mem_singleton_iff, Metric.mem_ball, dist_eq_norm]
             at hv
           simpa using hv.2.le
-      _ = ((u n) ⁻¹ * u n ) * ‖r‖ * u n := by ring
-      _ = ‖r‖ * u n := by rw [inv_mul_cancel₀ (u_pos n).ne', one_mul]
+      _ = ‖r‖ * u n := by field_simp [(u_pos n).ne']; ring
     refine ⟨?_, 0, fun n hn ↦ by simpa using c_ne n⟩
     apply squeeze_zero (fun n ↦ by positivity) B
     simpa using u_lim.const_mul _

--- a/Mathlib/Analysis/Calculus/TangentCone.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone.lean
@@ -218,7 +218,7 @@ theorem zero_mem_tangentCone {s : Set E} {x : E} (hx : (𝓝[s \ {x}] x).NeBot) 
     NeBot.nonempty_of_mem hx (inter_mem_nhdsWithin _
       (Metric.ball_mem_nhds _ (mul_pos (u_pos n) (u_pos n))))
   choose v hv using A
-  let d := fun n ↦ v n - x
+  let d n := v n - x
   have M n : x + d n ∈ s \ {x} := by simpa [d] using (hv n).1
   let ⟨r, hr⟩ := exists_one_lt_norm 𝕜
   have W n := rescale_to_shell hr (u_pos n) (x := d n) (by simpa using (M n).2)


### PR DESCRIPTION
A point in a subset of a field is either a point of unique differentials, or isolated. In both cases, there is a definite value for the derivative of a map (its unique derivative in the former case, zero in the latter case). This means there is no choice involved, contrary to what happens in higher dimension. This remark means we can remove many `UniqueDiffWithinAt` assumptions in one-dimensional settings.

This PR proves the new lemma that a point is either isolated or a point of unique differentiability. The application to cleanup the library will be in a further PR (#20816)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
