### PR TITLE
[Merged by Bors] - feat(RingTheory/Artinian): rewrite results using spectra types instead of sets

### DIFF
--- a/Mathlib/RingTheory/Artinian/Instances.lean
+++ b/Mathlib/RingTheory/Artinian/Instances.lean
@@ -19,7 +19,7 @@ namespace IsArtinianRing
 
 variable (R : Type*) [CommRing R] [IsArtinianRing R] [IsReduced R]
 
-attribute [local instance] subtype_isMaximal_finite fieldOfSubtypeIsMaximal
+attribute [local instance] fieldOfSubtypeIsMaximal
 
 instance : DecompositionMonoid R := MulEquiv.decompositionMonoid (equivPi R)
 

--- a/Mathlib/RingTheory/Artinian/Module.lean
+++ b/Mathlib/RingTheory/Artinian/Module.lean
@@ -454,7 +454,7 @@ section CommSemiring
 variable (R : Type*) [CommSemiring R] [IsArtinianRing R]
 
 @[stacks 00J7]
-lemma maximal_ideals_finite : {I : Ideal R | I.IsMaximal}.Finite := by
+lemma setOf_isMaximal_finite : {I : Ideal R | I.IsMaximal}.Finite := by
   set Spec := {I : Ideal R | I.IsMaximal}
   obtain ⟨_, ⟨s, rfl⟩, H⟩ := IsArtinian.set_has_minimal
     (range (Finset.inf · Subtype.val : Finset Spec → Ideal R)) ⟨⊤, ∅, by simp⟩
@@ -465,7 +465,7 @@ lemma maximal_ideals_finite : {I : Ideal R | I.IsMaximal}.Finite := by
   rwa [← Subtype.ext <| q.2.eq_of_le p.2.ne_top hq2]
 
 instance : Finite (MaximalSpectrum R) :=
-  haveI : Finite {I : Ideal R // I.IsMaximal} := (maximal_ideals_finite R).to_subtype
+  haveI : Finite {I : Ideal R // I.IsMaximal} := (setOf_isMaximal_finite R).to_subtype
   .of_equiv _ (MaximalSpectrum.equivSubtype _).symm
 
 end CommSemiring
@@ -491,7 +491,7 @@ instance isMaximal_of_isPrime (p : Ideal R) [p.IsPrime] : p.IsMaximal :=
 lemma isPrime_iff_isMaximal (p : Ideal R) : p.IsPrime ↔ p.IsMaximal :=
   ⟨fun _ ↦ isMaximal_of_isPrime p, fun h ↦ h.isPrime⟩
 
-/-- The prime spectrum is in bijection with the set of prime ideals. -/
+/-- The prime spectrum is in bijection with the maximal spectrum. -/
 @[simps]
 def primeSpectrumEquivMaximalSpectrum : PrimeSpectrum R ≃ MaximalSpectrum R where
   toFun I := ⟨I.asIdeal, isPrime_iff_isMaximal I.asIdeal |>.mp I.isPrime⟩
@@ -499,11 +499,11 @@ def primeSpectrumEquivMaximalSpectrum : PrimeSpectrum R ≃ MaximalSpectrum R wh
   left_inv _ := rfl
   right_inv _ := rfl
 
-lemma primeSpectrum_equiv_maximalSpectrum_comp_asIdeal :
+lemma primeSpectrumEquivMaximalSpectrum_comp_asIdeal :
     MaximalSpectrum.asIdeal ∘ primeSpectrumEquivMaximalSpectrum =
       PrimeSpectrum.asIdeal (R := R) := rfl
 
-lemma primeSpectrum_equiv_maximalSpectrum_inv_comp_asIdeal :
+lemma primeSpectrumEquivMaximalSpectrum_symm_comp_asIdeal :
     PrimeSpectrum.asIdeal ∘ primeSpectrumEquivMaximalSpectrum.symm =
       MaximalSpectrum.asIdeal (R := R) := rfl
 
@@ -514,11 +514,11 @@ lemma primeSpectrum_asIdeal_range_eq :
 
 variable (R)
 
-lemma prime_ideals_finite : {I : Ideal R | I.IsPrime}.Finite := by
-  simpa only [isPrime_iff_isMaximal] using maximal_ideals_finite R
+lemma setOf_isPrime_finite : {I : Ideal R | I.IsPrime}.Finite := by
+  simpa only [isPrime_iff_isMaximal] using setOf_isMaximal_finite R
 
 instance : Finite (PrimeSpectrum R) :=
-  haveI : Finite {I : Ideal R // I.IsPrime} := (prime_ideals_finite R).to_subtype
+  haveI : Finite {I : Ideal R // I.IsPrime} := (setOf_isPrime_finite R).to_subtype
   .of_equiv _ (PrimeSpectrum.equivSubtype _).symm
 
 /-- A temporary field instance on the quotients by maximal ideals. -/

--- a/Mathlib/RingTheory/Artinian/Module.lean
+++ b/Mathlib/RingTheory/Artinian/Module.lean
@@ -464,11 +464,8 @@ lemma maximal_ideals_finite : {I : Ideal R | I.IsMaximal}.Finite := by
     inf_le_right.eq_of_not_lt (H (p ⊓ s.inf Subtype.val) ⟨insert p s, by simp⟩)
   rwa [← Subtype.ext <| q.2.eq_of_le p.2.ne_top hq2]
 
-lemma subtype_isMaximal_finite : Finite {I : Ideal R // I.IsMaximal} :=
-  (maximal_ideals_finite R).to_subtype
-
 instance : Finite (MaximalSpectrum R) :=
-  haveI := subtype_isMaximal_finite R
+  haveI : Finite {I : Ideal R // I.IsMaximal} := (maximal_ideals_finite R).to_subtype
   .of_equiv _ (MaximalSpectrum.equivSubtype _).symm
 
 end CommSemiring
@@ -520,11 +517,8 @@ variable (R)
 lemma prime_ideals_finite : {I : Ideal R | I.IsPrime}.Finite := by
   simpa only [isPrime_iff_isMaximal] using maximal_ideals_finite R
 
-lemma subtype_isPrime_finite : Finite {I : Ideal R // I.IsPrime} :=
-  (prime_ideals_finite R).to_subtype
-
 instance : Finite (PrimeSpectrum R) :=
-  haveI := subtype_isPrime_finite R
+  haveI : Finite {I : Ideal R // I.IsPrime} := (prime_ideals_finite R).to_subtype
   .of_equiv _ (PrimeSpectrum.equivSubtype _).symm
 
 /-- A temporary field instance on the quotients by maximal ideals. -/

--- a/Mathlib/RingTheory/Artinian/Module.lean
+++ b/Mathlib/RingTheory/Artinian/Module.lean
@@ -9,6 +9,8 @@ import Mathlib.RingTheory.Ideal.Prod
 import Mathlib.RingTheory.Ideal.Quotient.Operations
 import Mathlib.RingTheory.Nilpotent.Lemmas
 import Mathlib.RingTheory.Noetherian.Defs
+import Mathlib.RingTheory.Spectrum.Maximal.Basic
+import Mathlib.RingTheory.Spectrum.Prime.Basic
 
 /-!
 # Artinian rings and modules
@@ -462,8 +464,12 @@ lemma maximal_ideals_finite : {I : Ideal R | I.IsMaximal}.Finite := by
     inf_le_right.eq_of_not_lt (H (p ⊓ s.inf Subtype.val) ⟨insert p s, by simp⟩)
   rwa [← Subtype.ext <| q.2.eq_of_le p.2.ne_top hq2]
 
-lemma subtype_isMaximal_finite : Finite {I : Ideal R | I.IsMaximal} :=
+lemma subtype_isMaximal_finite : Finite {I : Ideal R // I.IsMaximal} :=
   (maximal_ideals_finite R).to_subtype
+
+instance : Finite (MaximalSpectrum R) :=
+  haveI := subtype_isMaximal_finite R
+  .of_equiv _ (MaximalSpectrum.equivSubtype _).symm
 
 end CommSemiring
 
@@ -488,30 +494,59 @@ instance isMaximal_of_isPrime (p : Ideal R) [p.IsPrime] : p.IsMaximal :=
 lemma isPrime_iff_isMaximal (p : Ideal R) : p.IsPrime ↔ p.IsMaximal :=
   ⟨fun _ ↦ isMaximal_of_isPrime p, fun h ↦ h.isPrime⟩
 
+/-- The prime spectrum is in bijection with the set of prime ideals. -/
+@[simps]
+def primeSpectrumEquivMaximalSpectrum : PrimeSpectrum R ≃ MaximalSpectrum R where
+  toFun I := ⟨I.asIdeal, isPrime_iff_isMaximal I.asIdeal |>.mp I.isPrime⟩
+  invFun I := ⟨I.asIdeal, isPrime_iff_isMaximal I.asIdeal |>.mpr I.isMaximal⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+lemma primeSpectrum_equiv_maximalSpectrum_comp_asIdeal :
+    MaximalSpectrum.asIdeal ∘ primeSpectrumEquivMaximalSpectrum =
+      PrimeSpectrum.asIdeal (R := R) := rfl
+
+lemma primeSpectrum_equiv_maximalSpectrum_inv_comp_asIdeal :
+    PrimeSpectrum.asIdeal ∘ primeSpectrumEquivMaximalSpectrum.symm =
+      MaximalSpectrum.asIdeal (R := R) := rfl
+
+lemma primeSpectrum_asIdeal_range_eq :
+    range PrimeSpectrum.asIdeal = (range <| MaximalSpectrum.asIdeal (R := R)) := by
+  simp only [PrimeSpectrum.range_asIdeal, MaximalSpectrum.range_asIdeal,
+    isPrime_iff_isMaximal]
+
 variable (R)
 
-lemma primeSpectrum_finite : {I : Ideal R | I.IsPrime}.Finite := by
+lemma prime_ideals_finite : {I : Ideal R | I.IsPrime}.Finite := by
   simpa only [isPrime_iff_isMaximal] using maximal_ideals_finite R
 
-attribute [local instance] subtype_isMaximal_finite
+lemma subtype_isPrime_finite : Finite {I : Ideal R // I.IsPrime} :=
+  (prime_ideals_finite R).to_subtype
+
+instance : Finite (PrimeSpectrum R) :=
+  haveI := subtype_isPrime_finite R
+  .of_equiv _ (PrimeSpectrum.equivSubtype _).symm
 
 /-- A temporary field instance on the quotients by maximal ideals. -/
 @[local instance] noncomputable def fieldOfSubtypeIsMaximal
-    (I : {I : Ideal R | I.IsMaximal}) : Field (R ⧸ I.1) :=
-  have := mem_setOf.mp I.2; Ideal.Quotient.field I.1
+    (I : MaximalSpectrum R) : Field (R ⧸ I.asIdeal) :=
+  Ideal.Quotient.field I.asIdeal
 
 /-- The quotient of a commutative artinian ring by its nilradical is isomorphic to
 a finite product of fields, namely the quotients by the maximal ideals. -/
 noncomputable def quotNilradicalEquivPi :
-    R ⧸ nilradical R ≃+* ∀ I : {I : Ideal R | I.IsMaximal}, R ⧸ I.1 :=
-  .trans (Ideal.quotEquivOfEq <| ext fun x ↦ by simp_rw [mem_nilradical,
-    nilpotent_iff_mem_prime, Submodule.mem_iInf, Subtype.forall, isPrime_iff_isMaximal, mem_setOf])
-  (Ideal.quotientInfRingEquivPiQuotient _ fun I J h ↦
-    Ideal.isCoprime_iff_sup_eq.mpr <| I.2.coprime_of_ne J.2 <| by rwa [Ne, Subtype.coe_inj])
+    R ⧸ nilradical R ≃+* ∀ I : MaximalSpectrum R, R ⧸ I.asIdeal :=
+  let f := MaximalSpectrum.asIdeal (R := R)
+  .trans
+    (Ideal.quotEquivOfEq <| ext fun x ↦ by
+      rw [PrimeSpectrum.nilradical_eq_iInf, iInf, primeSpectrum_asIdeal_range_eq]; rfl)
+    (Ideal.quotientInfRingEquivPiQuotient f <| fun I J h ↦
+      Ideal.isCoprime_iff_sup_eq.mpr <| I.2.coprime_of_ne J.2 <|
+      fun hIJ ↦ h <| MaximalSpectrum.ext hIJ)
 
 /-- A reduced commutative artinian ring is isomorphic to a finite product of fields,
 namely the quotients by the maximal ideals. -/
-noncomputable def equivPi [IsReduced R] : R ≃+* ∀ I : {I : Ideal R | I.IsMaximal}, R ⧸ I.1 :=
+noncomputable def equivPi [IsReduced R] : R ≃+* ∀ I : MaximalSpectrum R, R ⧸ I.asIdeal :=
   .trans (.symm <| .quotientBot R) <| .trans
     (Ideal.quotEquivOfEq (nilradical_eq_zero R).symm) (quotNilradicalEquivPi R)
 

--- a/Mathlib/RingTheory/Etale/Field.lean
+++ b/Mathlib/RingTheory/Etale/Field.lean
@@ -153,8 +153,7 @@ theorem iff_isSeparable [EssFiniteType K L] :
     FormallyEtale K L ↔ Algebra.IsSeparable K L :=
   ⟨fun _ ↦ FormallyUnramified.isSeparable K L, fun _ ↦ of_isSeparable K L⟩
 
-attribute [local instance]
-  IsArtinianRing.subtype_isMaximal_finite IsArtinianRing.fieldOfSubtypeIsMaximal in
+attribute [local instance] IsArtinianRing.fieldOfSubtypeIsMaximal in
 /--
 If `A` is an essentially of finite type algebra over a field `K`, then `A` is formally étale
 over `K` if and only if `A` is a finite product of separable field extensions.
@@ -170,8 +169,8 @@ theorem iff_exists_algEquiv_prod [EssFiniteType K A] :
     have := FormallyUnramified.finite_of_free K A
     have := FormallyUnramified.isReduced_of_field K A
     have : IsArtinianRing A := isArtinian_of_tower K inferInstance
-    letI : Fintype {I : Ideal A | I.IsMaximal} := (nonempty_fintype _).some
-    let v (i : {I : Ideal A | I.IsMaximal}) : A := (IsArtinianRing.equivPi A).symm (Pi.single i 1)
+    letI : Fintype (MaximalSpectrum A) := (nonempty_fintype _).some
+    let v (i : MaximalSpectrum A) : A := (IsArtinianRing.equivPi A).symm (Pi.single i 1)
     let e : A ≃ₐ[K] _ := { __ := IsArtinianRing.equivPi A, commutes' := fun r ↦ rfl }
     have := (FormallyEtale.iff_of_equiv e).mp inferInstance
     rw [FormallyEtale.pi_iff] at this
@@ -189,8 +188,6 @@ theorem iff_exists_algEquiv_prod [EssFiniteType K A] :
 
 end Algebra.FormallyEtale
 
-attribute [local instance]
-  IsArtinianRing.subtype_isMaximal_finite IsArtinianRing.fieldOfSubtypeIsMaximal in
 /--
 `A` is étale over a field `K` if and only if
 `A` is a finite product of finite separable field extensions.

--- a/Mathlib/RingTheory/Spectrum/Maximal/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Maximal/Basic.lean
@@ -18,6 +18,19 @@ variable (R S P : Type*) [CommSemiring R] [CommSemiring S] [CommSemiring P]
 
 namespace MaximalSpectrum
 
+/-- The prime spectrum is in bijection with the set of prime ideals. -/
+@[simps]
+def equivSubtype : MaximalSpectrum R ≃ {I : Ideal R // I.IsMaximal} where
+  toFun I := ⟨I.asIdeal, I.2⟩
+  invFun I := ⟨I, I.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+theorem range_asIdeal : Set.range MaximalSpectrum.asIdeal = {J : Ideal R | J.IsMaximal} :=
+  Set.ext fun J ↦
+    ⟨fun hJ ↦ let ⟨j, hj⟩ := Set.mem_range.mp hJ; Set.mem_setOf.mpr <| hj ▸ j.isMaximal,
+      fun hJ ↦ Set.mem_range.mpr ⟨⟨J, Set.mem_setOf.mp hJ⟩, rfl⟩⟩
+
 variable {R}
 
 instance [Nontrivial R] : Nonempty <| MaximalSpectrum R :=

--- a/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
@@ -203,8 +203,7 @@ theorem vanishingIdeal_zeroLocus_eq_radical (I : Ideal R) :
     rw [mem_vanishingIdeal, Ideal.radical_eq_sInf, Submodule.mem_sInf]
     exact ⟨fun h x hx => h ⟨x, hx.2⟩ hx.1, fun h x hx => h x.1 ⟨hx, x.2⟩⟩
 
-theorem nilradical_eq_iInf :
-    nilradical R = iInf asIdeal := by
+theorem nilradical_eq_iInf : nilradical R = iInf asIdeal := by
   apply range_asIdeal R ▸ nilradical_eq_sInf R
 
 @[simp]

--- a/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
@@ -73,6 +73,11 @@ def equivSubtype : PrimeSpectrum R ≃ {I : Ideal R // I.IsPrime} where
   left_inv _ := rfl
   right_inv _ := rfl
 
+theorem range_asIdeal : Set.range PrimeSpectrum.asIdeal = {J : Ideal R | J.IsPrime} :=
+  Set.ext fun J ↦
+    ⟨fun hJ ↦ let ⟨j, hj⟩ := Set.mem_range.mp hJ; Set.mem_setOf.mpr <| hj ▸ j.isPrime,
+      fun hJ ↦ Set.mem_range.mpr ⟨⟨J, Set.mem_setOf.mp hJ⟩, rfl⟩⟩
+
 /-- The map from the direct sum of prime spectra to the prime spectrum of a direct product. -/
 @[simp]
 def primeSpectrumProdOfSum : PrimeSpectrum R ⊕ PrimeSpectrum S → PrimeSpectrum (R × S)
@@ -197,6 +202,10 @@ theorem vanishingIdeal_zeroLocus_eq_radical (I : Ideal R) :
   Ideal.ext fun f => by
     rw [mem_vanishingIdeal, Ideal.radical_eq_sInf, Submodule.mem_sInf]
     exact ⟨fun h x hx => h ⟨x, hx.2⟩ hx.1, fun h x hx => h x.1 ⟨hx, x.2⟩⟩
+
+theorem nilradical_eq_iInf :
+    nilradical R = iInf asIdeal := by
+  apply range_asIdeal R ▸ nilradical_eq_sInf R
 
 @[simp]
 theorem zeroLocus_radical (I : Ideal R) : zeroLocus (I.radical : Set R) = zeroLocus I :=

--- a/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
@@ -43,10 +43,6 @@ section IsArtinianRing
 
 variable (R : Type u) [CommRing R] [IsArtinianRing R]
 
-instance : Finite (PrimeSpectrum R) :=
-  have : Finite {I : Ideal R // I.IsPrime} := IsArtinianRing.primeSpectrum_finite R
-  Finite.of_injective _ (equivSubtype R).injective
-
 instance : DiscreteTopology (PrimeSpectrum R) :=
   discreteTopology_iff_finite_and_isPrime_imp_isMaximal.mpr
     ⟨inferInstance, fun _ _ ↦ inferInstance⟩


### PR DESCRIPTION
Rewrite results about artinian rings using `MaximalSpectrum` and `PrimeSpectrum` instead of sets `{I | I.IsMaximal}` and `{I | I.IsPrime}`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
