### PR TITLE
feat(Order/GaloisConnection): Galois insertion is order-reflecting

### DIFF
--- a/Mathlib/Order/GaloisConnection.lean
+++ b/Mathlib/Order/GaloisConnection.lean
@@ -470,6 +470,11 @@ theorem leftInverse_l_u [Preorder α] [PartialOrder β] (gi : GaloisInsertion l 
     LeftInverse l u :=
   gi.l_u_eq
 
+theorem le_of_u_le_u [Preorder α] [PartialOrder β] (gi : GaloisInsertion l u)
+    {a b : β} (h : u a ≤ u b) : a ≤ b := by
+  rw [← gi.gc.le_iff_le, gi.l_u_eq] at h
+  exact h
+
 theorem l_top [Preorder α] [PartialOrder β] [OrderTop α] [OrderTop β]
     (gi : GaloisInsertion l u) : l ⊤ = ⊤ :=
   top_unique <| (gi.le_l_u _).trans <| gi.gc.monotone_l le_top
@@ -689,6 +694,11 @@ theorem u_l_eq [PartialOrder α] [Preorder β] (gi : GaloisCoinsertion l u) (a :
 theorem u_l_leftInverse [PartialOrder α] [Preorder β] (gi : GaloisCoinsertion l u) :
     LeftInverse u l :=
   gi.u_l_eq
+
+theorem le_of_l_le_l [PartialOrder α] [Preorder β] (gi : GaloisCoinsertion l u)
+    {a b : α} (h : l a ≤ l b) : a ≤ b := by
+  rw [gi.gc.le_iff_le, gi.u_l_eq] at h
+  exact h
 
 theorem u_bot [PartialOrder α] [Preorder β] [OrderBot α] [OrderBot β] (gi : GaloisCoinsertion l u) :
     u ⊥ = ⊥ :=

--- a/Mathlib/Order/GaloisConnection.lean
+++ b/Mathlib/Order/GaloisConnection.lean
@@ -475,6 +475,9 @@ theorem le_of_u_le_u [Preorder α] [PartialOrder β] (gi : GaloisInsertion l u)
   rw [← gi.gc.le_iff_le, gi.l_u_eq] at h
   exact h
 
+@[simp] theorem u_le_u_iff_le [Preorder α] [PartialOrder β] (gi : GaloisInsertion l u) {a b : β} :
+    u a ≤ u b ↔ a ≤ b := ⟨(gi.le_of_u_le_u ·), (gi.gc.monotone_u ·)⟩
+
 theorem l_top [Preorder α] [PartialOrder β] [OrderTop α] [OrderTop β]
     (gi : GaloisInsertion l u) : l ⊤ = ⊤ :=
   top_unique <| (gi.le_l_u _).trans <| gi.gc.monotone_l le_top
@@ -699,6 +702,9 @@ theorem le_of_l_le_l [PartialOrder α] [Preorder β] (gi : GaloisCoinsertion l u
     {a b : α} (h : l a ≤ l b) : a ≤ b := by
   rw [gi.gc.le_iff_le, gi.u_l_eq] at h
   exact h
+
+@[simp] theorem l_le_l_iff_le [PartialOrder α] [Preorder β] (gi : GaloisCoinsertion l u) {a b : α} :
+    l a ≤ l b ↔ a ≤ b := ⟨(gi.le_of_l_le_l ·), (gi.gc.monotone_l ·)⟩
 
 theorem u_bot [PartialOrder α] [Preorder β] [OrderBot α] [OrderBot β] (gi : GaloisCoinsertion l u) :
     u ⊥ = ⊥ :=


### PR DESCRIPTION
* Add lemmas stating that the injective side of a Galois (co)insertion is order-reflecting
* Add simp lemmas for the iff version (order-preserving + order-reflecting)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
