### PR TITLE
[Merged by Bors] - feat(Analysis/SpecialFunctions): prove asymptotic results for binomial coefficents and factorial variants

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1534,6 +1534,7 @@ import Mathlib.Analysis.Seminorm
 import Mathlib.Analysis.SpecialFunctions.Arsinh
 import Mathlib.Analysis.SpecialFunctions.Bernstein
 import Mathlib.Analysis.SpecialFunctions.BinaryEntropy
+import Mathlib.Analysis.SpecialFunctions.Choose
 import Mathlib.Analysis.SpecialFunctions.CompareExp
 import Mathlib.Analysis.SpecialFunctions.Complex.Analytic
 import Mathlib.Analysis.SpecialFunctions.Complex.Arctan

--- a/Mathlib/Analysis/SpecialFunctions/Choose.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Choose.lean
@@ -3,7 +3,8 @@ Copyright (c) 2025 Mitchell Horner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mitchell Horner
 -/
-import Mathlib.Analysis.Calculus.Deriv.Pow
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Analysis.Asymptotics.AsymptoticEquivalent
 
 /-!
 # Binomial coefficents and factorial variants

--- a/Mathlib/Analysis/SpecialFunctions/Choose.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Choose.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2025 Mitchell Horner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mitchell Horner
+-/
+import Mathlib.Analysis.Calculus.Deriv.Pow
+
+/-!
+# Binomial coefficents and factorial variants
+
+This file proves asymptotic theorems for binomial coefficents and factorial variants.
+
+## Main definitions
+
+* `isEquivalent_descFactorial` is the proof that `n.descFactorial k ~ n^k` as `n → ∞`.
+
+* `isEquivalent_choose` is the proof that `n.choose k ~ n^k / k!` as `n → ∞`.
+
+* `isTheta_choose` is the proof that `n.choose k = Θ(n^k)` as `n → ∞`.
+-/
+
+
+open Asymptotics Topology
+
+/-- `n.descFactorial k` is asymptotically equivalent to `n^k`. -/
+lemma isEquivalent_descFactorial (k : ℕ) :
+    (fun (n : ℕ) ↦ (n.descFactorial k : ℝ))
+      ~[Filter.atTop] (fun (n : ℕ) ↦ (n^k : ℝ)) := by
+  induction k with
+  | zero => simpa using IsEquivalent.refl
+  | succ k h =>
+    simp_rw [Nat.descFactorial_succ, Nat.cast_mul, pow_succ']
+    apply IsEquivalent.mul _ h
+    have hz : ∀ᶠ (x : ℕ) in Filter.atTop, (x : ℝ) ≠ 0 := by
+      rw [Filter.eventually_atTop]
+      use 1; intro n hn
+      exact ne_of_gt (mod_cast hn)
+    rw [isEquivalent_iff_tendsto_one hz, ←Filter.tendsto_add_atTop_iff_nat k]
+    simpa using tendsto_natCast_div_add_atTop (k : ℝ)
+
+/-- `n.choose k` is asymptotically equivalent to `n^k / k!`. -/
+theorem isEquivalent_choose (k : ℕ) :
+    (fun (n : ℕ) ↦ (n.choose k : ℝ))
+      ~[Filter.atTop] (fun (n : ℕ) ↦ (n^k / k.factorial : ℝ)) := by
+  conv_lhs =>
+    intro n
+    rw [Nat.choose_eq_descFactorial_div_factorial,
+      Nat.cast_div (n.factorial_dvd_descFactorial k) (mod_cast k.factorial_ne_zero)]
+  exact (isEquivalent_descFactorial k).div (IsEquivalent.refl)
+
+/-- `n.choose k` is big-theta `n^k`. -/
+theorem isTheta_choose (k : ℕ) :
+    (fun (n : ℕ) ↦ (n.choose k : ℝ))
+      =Θ[Filter.atTop] (fun (n : ℕ) ↦ (n^k : ℝ)) := by
+  apply (isEquivalent_choose k).trans_isTheta
+  conv_lhs =>
+    intro n
+    rw [div_eq_mul_inv, mul_comm]
+  apply IsTheta.const_mul_left _ isTheta_rfl
+  exact inv_ne_zero (mod_cast k.factorial_ne_zero)

--- a/Mathlib/Analysis/SpecialFunctions/Choose.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Choose.lean
@@ -36,7 +36,7 @@ lemma isEquivalent_descFactorial (k : ℕ) :
       rw [Filter.eventually_atTop]
       use 1; intro n hn
       exact ne_of_gt (mod_cast hn)
-    rw [isEquivalent_iff_tendsto_one hz, ←Filter.tendsto_add_atTop_iff_nat k]
+    rw [isEquivalent_iff_tendsto_one hz, ← Filter.tendsto_add_atTop_iff_nat k]
     simpa using tendsto_natCast_div_add_atTop (k : ℝ)
 
 /-- `n.choose k` is asymptotically equivalent to `n^k / k!`. -/
@@ -47,7 +47,7 @@ theorem isEquivalent_choose (k : ℕ) :
     intro n
     rw [Nat.choose_eq_descFactorial_div_factorial,
       Nat.cast_div (n.factorial_dvd_descFactorial k) (mod_cast k.factorial_ne_zero)]
-  exact (isEquivalent_descFactorial k).div (IsEquivalent.refl)
+  exact (isEquivalent_descFactorial k).div IsEquivalent.refl
 
 /-- `n.choose k` is big-theta `n^k`. -/
 theorem isTheta_choose (k : ℕ) :

--- a/Mathlib/Analysis/SpecialFunctions/Choose.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Choose.lean
@@ -30,11 +30,9 @@ lemma isEquivalent_descFactorial (k : ℕ) :
   | zero => simpa using IsEquivalent.refl
   | succ k h =>
     simp_rw [descFactorial_succ, cast_mul, _root_.pow_succ']
-    apply IsEquivalent.mul _ h
-    have hz : ∀ᶠ (x : ℕ) in atTop, (x : ℝ) ≠ 0 := by
-      rw [eventually_atTop]
-      use 1; intro n hn
-      exact ne_of_gt (mod_cast hn)
+    refine IsEquivalent.mul ?_ h
+    have hz : ∀ᶠ (x : ℕ) in atTop, (x : ℝ) ≠ 0 :=
+      eventually_atTop.mpr ⟨1, fun n hn ↦ ne_of_gt (mod_cast hn)⟩
     rw [isEquivalent_iff_tendsto_one hz, ← tendsto_add_atTop_iff_nat k]
     simpa using tendsto_natCast_div_add_atTop (k : ℝ)
 
@@ -51,8 +49,5 @@ theorem isEquivalent_choose (k : ℕ) :
 theorem isTheta_choose (k : ℕ) :
     (fun (n : ℕ) ↦ (n.choose k : ℝ)) =Θ[atTop] (fun (n : ℕ) ↦ (n^k : ℝ)) := by
   apply (isEquivalent_choose k).trans_isTheta
-  conv_lhs =>
-    intro n
-    rw [div_eq_mul_inv, mul_comm]
-  apply IsTheta.const_mul_left _ isTheta_rfl
-  exact inv_ne_zero (mod_cast k.factorial_ne_zero)
+  simp_rw [div_eq_mul_inv, mul_comm _ (_⁻¹)]
+  exact isTheta_rfl.const_mul_left <| inv_ne_zero (mod_cast k.factorial_ne_zero)

--- a/Mathlib/Analysis/SpecialFunctions/Choose.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Choose.lean
@@ -11,7 +11,7 @@ import Mathlib.Analysis.Asymptotics.AsymptoticEquivalent
 
 This file proves asymptotic theorems for binomial coefficents and factorial variants.
 
-## Main definitions
+## Main statements
 
 * `isEquivalent_descFactorial` is the proof that `n.descFactorial k ~ n^k` as `n → ∞`.
 

--- a/Mathlib/Analysis/SpecialFunctions/Choose.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Choose.lean
@@ -21,38 +21,35 @@ This file proves asymptotic theorems for binomial coefficents and factorial vari
 -/
 
 
-open Asymptotics Topology
+open Asymptotics Filter Nat Topology
 
 /-- `n.descFactorial k` is asymptotically equivalent to `n^k`. -/
 lemma isEquivalent_descFactorial (k : ℕ) :
-    (fun (n : ℕ) ↦ (n.descFactorial k : ℝ))
-      ~[Filter.atTop] (fun (n : ℕ) ↦ (n^k : ℝ)) := by
+    (fun (n : ℕ) ↦ (n.descFactorial k : ℝ)) ~[atTop] (fun (n : ℕ) ↦ (n^k : ℝ)) := by
   induction k with
   | zero => simpa using IsEquivalent.refl
   | succ k h =>
-    simp_rw [Nat.descFactorial_succ, Nat.cast_mul, pow_succ']
+    simp_rw [descFactorial_succ, cast_mul, _root_.pow_succ']
     apply IsEquivalent.mul _ h
-    have hz : ∀ᶠ (x : ℕ) in Filter.atTop, (x : ℝ) ≠ 0 := by
-      rw [Filter.eventually_atTop]
+    have hz : ∀ᶠ (x : ℕ) in atTop, (x : ℝ) ≠ 0 := by
+      rw [eventually_atTop]
       use 1; intro n hn
       exact ne_of_gt (mod_cast hn)
-    rw [isEquivalent_iff_tendsto_one hz, ← Filter.tendsto_add_atTop_iff_nat k]
+    rw [isEquivalent_iff_tendsto_one hz, ← tendsto_add_atTop_iff_nat k]
     simpa using tendsto_natCast_div_add_atTop (k : ℝ)
 
 /-- `n.choose k` is asymptotically equivalent to `n^k / k!`. -/
 theorem isEquivalent_choose (k : ℕ) :
-    (fun (n : ℕ) ↦ (n.choose k : ℝ))
-      ~[Filter.atTop] (fun (n : ℕ) ↦ (n^k / k.factorial : ℝ)) := by
+    (fun (n : ℕ) ↦ (n.choose k : ℝ)) ~[atTop] (fun (n : ℕ) ↦ (n^k / k.factorial : ℝ)) := by
   conv_lhs =>
     intro n
-    rw [Nat.choose_eq_descFactorial_div_factorial,
-      Nat.cast_div (n.factorial_dvd_descFactorial k) (mod_cast k.factorial_ne_zero)]
+    rw [choose_eq_descFactorial_div_factorial,
+      cast_div (n.factorial_dvd_descFactorial k) (mod_cast k.factorial_ne_zero)]
   exact (isEquivalent_descFactorial k).div IsEquivalent.refl
 
 /-- `n.choose k` is big-theta `n^k`. -/
 theorem isTheta_choose (k : ℕ) :
-    (fun (n : ℕ) ↦ (n.choose k : ℝ))
-      =Θ[Filter.atTop] (fun (n : ℕ) ↦ (n^k : ℝ)) := by
+    (fun (n : ℕ) ↦ (n.choose k : ℝ)) =Θ[atTop] (fun (n : ℕ) ↦ (n^k : ℝ)) := by
   apply (isEquivalent_choose k).trans_isTheta
   conv_lhs =>
     intro n

--- a/Mathlib/Analysis/SpecialFunctions/Choose.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Choose.lean
@@ -14,9 +14,7 @@ This file proves asymptotic theorems for binomial coefficents and factorial vari
 ## Main statements
 
 * `isEquivalent_descFactorial` is the proof that `n.descFactorial k ~ n^k` as `n → ∞`.
-
 * `isEquivalent_choose` is the proof that `n.choose k ~ n^k / k!` as `n → ∞`.
-
 * `isTheta_choose` is the proof that `n.choose k = Θ(n^k)` as `n → ∞`.
 -/
 


### PR DESCRIPTION
Prove `n.choose k ~ n^k / k!` and `n.choose k = Θ(n^k)` as `n → ∞`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This is needed for a proof of the Erdős-Stone-Simonovits theorem for simple graphs.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
