### PR TITLE
chore(Logic/Basic): deprecate proof equalities

### DIFF
--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -388,24 +388,24 @@ theorem eq_equivalence {α : Sort*} : Equivalence (@Eq α) :=
 -- These were migrated to Batteries but the `@[simp]` attributes were (mysteriously?) removed.
 attribute [simp] eq_mp_eq_cast eq_mpr_eq_cast
 
--- @[simp] -- FIXME simp ignores proof rewrites
+@[deprecated "proof rewrites do nothing in Lean" (since := "2025-01-19")]
 theorem congr_refl_left {α β : Sort*} (f : α → β) {a b : α} (h : a = b) :
     congr (Eq.refl f) h = congr_arg f h := rfl
 
--- @[simp] -- FIXME simp ignores proof rewrites
+@[deprecated "proof rewrites do nothing in Lean" (since := "2025-01-19")]
 theorem congr_refl_right {α β : Sort*} {f g : α → β} (h : f = g) (a : α) :
     congr h (Eq.refl a) = congr_fun h a := rfl
 
--- @[simp] -- FIXME simp ignores proof rewrites
+@[deprecated "proof rewrites do nothing in Lean" (since := "2025-01-19")]
 theorem congr_arg_refl {α β : Sort*} (f : α → β) (a : α) :
     congr_arg f (Eq.refl a) = Eq.refl (f a) :=
   rfl
 
--- @[simp] -- FIXME simp ignores proof rewrites
+@[deprecated "proof rewrites do nothing in Lean" (since := "2025-01-19")]
 theorem congr_fun_rfl {α β : Sort*} (f : α → β) (a : α) : congr_fun (Eq.refl f) a = Eq.refl (f a) :=
   rfl
 
--- @[simp] -- FIXME simp ignores proof rewrites
+@[deprecated "proof rewrites do nothing in Lean" (since := "2025-01-19")]
 theorem congr_fun_congr_arg {α β γ : Sort*} (f : α → β → γ) {a a' : α} (p : a = a') (b : β) :
     congr_fun (congr_arg f p) b = congr_arg (fun a ↦ f a b) p := rfl
 


### PR DESCRIPTION
In Lean, `p : Prop` and `x y : p` imply `x = y` definitionally, so any proof of this sort is useless.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Proof.20equalities)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
