### PR TITLE
[Merged by Bors] - feat: regularity of the pullback of a vector field on a manifold

### DIFF
--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -1094,6 +1094,19 @@ theorem hasFDerivAt_zero_of_eventually_const (c : F) (hf : f =ᶠ[𝓝 x] fun _ 
 
 end Const
 
+theorem differentiableWithinAt_of_isInvertible_fderivWithin
+    (hf : (fderivWithin 𝕜 f s x).IsInvertible) : DifferentiableWithinAt 𝕜 f s x := by
+  contrapose hf
+  rw [fderivWithin_zero_of_not_differentiableWithinAt hf]
+  contrapose! hf
+  rcases isInvertible_zero_iff.1 hf with ⟨hE, hF⟩
+  exact (hasFDerivAt_of_subsingleton _ _).differentiableAt.differentiableWithinAt
+
+theorem differentiableAt_of_isInvertible_fderiv
+    (hf : (fderiv 𝕜 f x).IsInvertible) : DifferentiableAt 𝕜 f x := by
+  simp only [← differentiableWithinAt_univ, ← fderivWithin_univ] at hf ⊢
+  exact differentiableWithinAt_of_isInvertible_fderivWithin hf
+
 section MeanValue
 
 /-- Converse to the mean value inequality: if `f` is differentiable at `x₀` and `C`-lipschitz

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -738,6 +738,17 @@ theorem ChartedSpace.t1Space [T1Space H] : T1Space M := by
       exact (chartAt H x).injOn.ne (ChartedSpace.mem_chart_source x) hy hxy
   · exact ⟨(chartAt H x).source, (chartAt H x).open_source, ChartedSpace.mem_chart_source x, hy⟩
 
+/-- A charted space over a discrete space is discrete. -/
+theorem ChartedSpace.discreteTopology [DiscreteTopology H] : DiscreteTopology M := by
+  apply singletons_open_iff_discrete.1 (fun x ↦ ?_)
+  have : IsOpen ((chartAt H x).source ∩ (chartAt H x) ⁻¹' {chartAt H x x}) :=
+    isOpen_inter_preimage _ (isOpen_discrete _)
+  convert this
+  refine Subset.antisymm (by simp) ?_
+  simp only [subset_singleton_iff, mem_inter_iff, mem_preimage, mem_singleton_iff, and_imp]
+  intro y hy h'y
+  exact (chartAt H x).injOn hy (ChartedSpace.mem_chart_source x) h'y
+
 end
 
 library_note "Manifold type tags" /-- For technical reasons we introduce two type tags:

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -747,7 +747,7 @@ theorem ChartedSpace.discreteTopology [DiscreteTopology H] : DiscreteTopology M 
   refine Subset.antisymm (by simp) ?_
   simp only [subset_singleton_iff, mem_inter_iff, mem_preimage, mem_singleton_iff, and_imp]
   intro y hy h'y
-  exact (chartAt H x).injOn hy (ChartedSpace.mem_chart_source x) h'y
+  exact (chartAt H x).injOn hy (mem_chart_source _ x) h'y
 
 end
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -583,12 +583,26 @@ protected theorem UniqueMDiffOn.eq (U : UniqueMDiffOn I s) (hx : x ∈ s)
 We mimic the API for functions between vector spaces
 -/
 
+@[simp, mfld_simps]
+theorem mfderivWithin_univ : mfderivWithin I I' f univ = mfderiv I I' f := by
+  ext x : 1
+  simp only [mfderivWithin, mfderiv, mfld_simps]
+  rw [mdifferentiableWithinAt_univ]
+
 theorem mfderivWithin_zero_of_not_mdifferentiableWithinAt
     (h : ¬MDifferentiableWithinAt I I' f s x) : mfderivWithin I I' f s x = 0 := by
   simp only [mfderivWithin, h, if_neg, not_false_iff]
 
 theorem mfderiv_zero_of_not_mdifferentiableAt (h : ¬MDifferentiableAt I I' f x) :
     mfderiv I I' f x = 0 := by simp only [mfderiv, h, if_neg, not_false_iff]
+
+theorem mdifferentiable_of_subsingleton [Subsingleton E] : MDifferentiable I I' f := by
+  intro x
+  have : Subsingleton H := I.injective.subsingleton
+  have : DiscreteTopology M := discreteTopology H M
+  have : ContinuousAt f x := continuous_of_discreteTopology.continuousAt
+  simp only [mdifferentiableAt_iff, this, true_and]
+  exact (hasFDerivAt_of_subsingleton _ _).differentiableAt.differentiableWithinAt
 
 theorem mdifferentiableWithinAt_of_isInvertible_mfderivWithin
     (hf : (mfderivWithin I I' f s x).IsInvertible) : MDifferentiableWithinAt I I' f s x := by
@@ -597,12 +611,12 @@ theorem mdifferentiableWithinAt_of_isInvertible_mfderivWithin
   contrapose! hf
   rcases ContinuousLinearMap.isInvertible_zero_iff.1 hf with ⟨hE, hF⟩
   have : Subsingleton E := hE
-  have : Subsingleton H := I.injective.subsingleton
-  have : DiscreteTopology H := by infer_instance
-  have : DiscreteTopology M := sorry
-  have : ContinuousWithinAt f s x := continuous_of_discreteTopology.continuousWithinAt
-  simp [mdifferentiableWithinAt_iff', this]
-  exact (hasFDerivAt_of_subsingleton _ _).differentiableAt.differentiableWithinAt
+  exact mdifferentiable_of_subsingleton.mdifferentiableAt.mdifferentiableWithinAt
+
+theorem mdifferentiableAt_of_isInvertible_mfderiv
+    (hf : (mfderiv I I' f x).IsInvertible) : MDifferentiableAt I I' f x := by
+  simp only [← mdifferentiableWithinAt_univ, ← mfderivWithin_univ] at hf ⊢
+  exact mdifferentiableWithinAt_of_isInvertible_mfderivWithin hf
 
 theorem HasMFDerivWithinAt.mono (h : HasMFDerivWithinAt I I' f t x f') (hst : s ⊆ t) :
     HasMFDerivWithinAt I I' f s x f' :=
@@ -729,12 +743,6 @@ theorem mfderivWithin_subset (st : s ⊆ t) (hs : UniqueMDiffWithinAt I s x)
     (h : MDifferentiableWithinAt I I' f t x) :
     mfderivWithin I I' f s x = mfderivWithin I I' f t x :=
   ((MDifferentiableWithinAt.hasMFDerivWithinAt h).mono st).mfderivWithin hs
-
-@[simp, mfld_simps]
-theorem mfderivWithin_univ : mfderivWithin I I' f univ = mfderiv I I' f := by
-  ext x : 1
-  simp only [mfderivWithin, mfderiv, mfld_simps]
-  rw [mdifferentiableWithinAt_univ]
 
 theorem mfderivWithin_inter (ht : t ∈ 𝓝 x) :
     mfderivWithin I I' f (s ∩ t) x = mfderivWithin I I' f s x := by

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -590,6 +590,20 @@ theorem mfderivWithin_zero_of_not_mdifferentiableWithinAt
 theorem mfderiv_zero_of_not_mdifferentiableAt (h : ¬MDifferentiableAt I I' f x) :
     mfderiv I I' f x = 0 := by simp only [mfderiv, h, if_neg, not_false_iff]
 
+theorem mdifferentiableWithinAt_of_isInvertible_mfderivWithin
+    (hf : (mfderivWithin I I' f s x).IsInvertible) : MDifferentiableWithinAt I I' f s x := by
+  contrapose hf
+  rw [mfderivWithin_zero_of_not_mdifferentiableWithinAt hf]
+  contrapose! hf
+  rcases ContinuousLinearMap.isInvertible_zero_iff.1 hf with ⟨hE, hF⟩
+  have : Subsingleton E := hE
+  have : Subsingleton H := I.injective.subsingleton
+  have : DiscreteTopology H := by infer_instance
+  have : DiscreteTopology M := sorry
+  have : ContinuousWithinAt f s x := continuous_of_discreteTopology.continuousWithinAt
+  simp [mdifferentiableWithinAt_iff', this]
+  exact (hasFDerivAt_of_subsingleton _ _).differentiableAt.differentiableWithinAt
+
 theorem HasMFDerivWithinAt.mono (h : HasMFDerivWithinAt I I' f t x f') (hst : s ⊆ t) :
     HasMFDerivWithinAt I I' f s x f' :=
   ⟨ContinuousWithinAt.mono h.1 hst,

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -600,8 +600,7 @@ theorem mdifferentiable_of_subsingleton [Subsingleton E] : MDifferentiable I I' 
   intro x
   have : Subsingleton H := I.injective.subsingleton
   have : DiscreteTopology M := discreteTopology H M
-  have : ContinuousAt f x := continuous_of_discreteTopology.continuousAt
-  simp only [mdifferentiableAt_iff, this, true_and]
+  simp only [mdifferentiableAt_iff, continuous_of_discreteTopology.continuousAt, true_and]
   exact (hasFDerivAt_of_subsingleton _ _).differentiableAt.differentiableWithinAt
 
 theorem mdifferentiableWithinAt_of_isInvertible_mfderivWithin

--- a/Mathlib/Geometry/Manifold/VectorField.lean
+++ b/Mathlib/Geometry/Manifold/VectorField.lean
@@ -184,6 +184,32 @@ lemma mpullback_eq_pullback {f : E → E'} {V : E' → E'} :
   ext x
   simp [mpullback]
 
+lemma mpullbackWithin_comp_of_left
+    {g : M' → M''} {f : M → M'} {V : Π (x : M''), TangentSpace I'' x} {s : Set M} {t : Set M'}
+    {x₀ : M} (hf : MDifferentiableWithinAt I I' f s x₀) (h : Set.MapsTo f s t)
+    (hu : UniqueMDiffWithinAt I s x₀) (hg' : (mfderivWithin I' I'' g t (f x₀)).IsInvertible) :
+    mpullbackWithin I I'' (g ∘ f) V s x₀ =
+      mpullbackWithin I I' f (mpullbackWithin I' I'' g V t) s x₀ := by
+  simp only [mpullbackWithin, comp_apply]
+  have hg : MDifferentiableWithinAt I' I'' g t (f x₀) :=
+    mdifferentiableWithinAt_of_isInvertible_mfderivWithin hg'
+  rw [mfderivWithin_comp _ hg hf h hu, IsInvertible.inverse_comp_apply_of_left]
+  · rfl
+  · exact hg'
+
+lemma mpullbackWithin_comp_of_right
+    {g : M' → M''} {f : M → M'} {V : Π (x : M''), TangentSpace I'' x} {s : Set M} {t : Set M'}
+    {x₀ : M} (hg : MDifferentiableWithinAt I' I'' g t (f x₀)) (h : Set.MapsTo f s t)
+    (hu : UniqueMDiffWithinAt I s x₀) (hf' : (mfderivWithin I I' f s x₀).IsInvertible) :
+    mpullbackWithin I I'' (g ∘ f) V s x₀ =
+      mpullbackWithin I I' f (mpullbackWithin I' I'' g V t) s x₀ := by
+  simp only [mpullbackWithin, comp_apply]
+  have hf : MDifferentiableWithinAt I I' f s x₀ :=
+    mdifferentiableWithinAt_of_isInvertible_mfderivWithin hf'
+  rw [mfderivWithin_comp _ hg hf h hu, IsInvertible.inverse_comp_apply_of_right hf']
+  rfl
+
+
 /-! ### Regularity of pullback of vector fields
 
 In this paragraph, we assume that the model space is complete, to ensure that the set of invertible
@@ -353,7 +379,7 @@ protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_inter
     (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) :
     ContMDiffWithinAt I I.tangent m
       (fun (y : M) ↦ (mpullbackWithin I I' f V s y : TangentBundle I M)) (s ∩ f ⁻¹' t) x₀ := by
-  /- We want to apply the general theorem `ContMDiffWithinAt.clm_apply_of_inCoordinates`, stating
+  /- We want to apply the theorem `ContMDiffWithinAt.clm_apply_of_inCoordinates`, stating
   that applying linear maps to vector fields gives a smooth result when the linear map and the
   vector field are smooth. This theorem is general, we will apply it to
   `b₁ = f`, `b₂ = id`, `v = V ∘ f`, `ϕ = fun x ↦ (mfderivWithin I I' f s x).inverse`-/
@@ -631,31 +657,6 @@ lemma eventuallyEq_mpullback_mpullbackWithin_extChartAt (V : Π (x : M), Tangent
   simp only [ContinuousLinearMap.inverse_id, ContinuousLinearMap.coe_id', id_eq]
 
 end ContMDiff
-
-lemma mpullbackWithin_comp_of_left
-    {g : M' → M''} {f : M → M'} {V : Π (x : M''), TangentSpace I'' x} {s : Set M} {t : Set M'}
-    {x₀ : M} (hf : MDifferentiableWithinAt I I' f s x₀) (h : Set.MapsTo f s t)
-    (hu : UniqueMDiffWithinAt I s x₀) (hg' : (mfderivWithin I' I'' g t (f x₀)).IsInvertible) :
-    mpullbackWithin I I'' (g ∘ f) V s x₀ =
-      mpullbackWithin I I' f (mpullbackWithin I' I'' g V t) s x₀ := by
-  simp only [mpullbackWithin, comp_apply]
-  have hg : MDifferentiableWithinAt I' I'' g t (f x₀) :=
-    mdifferentiableWithinAt_of_isInvertible_mfderivWithin hg'
-  rw [mfderivWithin_comp _ hg hf h hu, IsInvertible.inverse_comp_apply_of_left]
-  · rfl
-  · exact hg'
-
-lemma mpullbackWithin_comp_of_right
-    {g : M' → M''} {f : M → M'} {V : Π (x : M''), TangentSpace I'' x} {s : Set M} {t : Set M'}
-    {x₀ : M} (hg : MDifferentiableWithinAt I' I'' g t (f x₀)) (h : Set.MapsTo f s t)
-    (hu : UniqueMDiffWithinAt I s x₀) (hf' : (mfderivWithin I I' f s x₀).IsInvertible) :
-    mpullbackWithin I I'' (g ∘ f) V s x₀ =
-      mpullbackWithin I I' f (mpullbackWithin I' I'' g V t) s x₀ := by
-  simp only [mpullbackWithin, comp_apply]
-  have hf : MDifferentiableWithinAt I I' f s x₀ :=
-    mdifferentiableWithinAt_of_isInvertible_mfderivWithin hf'
-  rw [mfderivWithin_comp _ hg hf h hu, IsInvertible.inverse_comp_apply_of_right hf']
-  rfl
 
 end Pullback
 

--- a/Mathlib/Geometry/Manifold/VectorField.lean
+++ b/Mathlib/Geometry/Manifold/VectorField.lean
@@ -336,6 +336,325 @@ protected lemma _root_.MDifferentiable.mpullback_vectorField
 
 end MDifferentiability
 
+
+section ContMDiff
+
+variable [IsManifold I n M] [IsManifold I' n M'] [CompleteSpace E]
+-- the next assumptions will usually follow from the previous ones, but they are needed for
+-- the statements to make sense, so we add them here.
+[IsManifold I 1 M] [IsManifold I' 1 M']
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version within a set at a point. -/
+protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_inter
+    (hV : ContMDiffWithinAt I' I'.tangent m
+      (fun (y : M') ↦ (V y : TangentBundle I' M')) t (f x₀))
+    (hf : ContMDiffWithinAt I I' n f s x₀) (hf' : (mfderivWithin I I' f s x₀).IsInvertible)
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) :
+    ContMDiffWithinAt I I.tangent m
+      (fun (y : M) ↦ (mpullbackWithin I I' f V s y : TangentBundle I M)) (s ∩ f ⁻¹' t) x₀ := by
+  /- We want to apply the general theorem `ContMDiffWithinAt.clm_apply_of_inCoordinates`, stating
+  that applying linear maps to vector fields gives a smooth result when the linear map and the
+  vector field are smooth. This theorem is general, we will apply it to
+  `b₁ = f`, `b₂ = id`, `v = V ∘ f`, `ϕ = fun x ↦ (mfderivWithin I I' f s x).inverse`-/
+  let b₁ := f
+  let b₂ : M → M := id
+  let v : Π (x : M), TangentSpace I' (f x) := V ∘ f
+  let ϕ : Π (x : M), TangentSpace I' (f x) →L[𝕜] TangentSpace I x :=
+    fun x ↦ (mfderivWithin I I' f s x).inverse
+  have hv : ContMDiffWithinAt I I'.tangent m
+      (fun x ↦ (v x : TangentBundle I' M')) (s ∩ f ⁻¹' t) x₀ := by
+    apply hV.comp x₀ ((hf.of_le (le_trans (le_self_add) hmn)).mono inter_subset_left)
+    exact MapsTo.mono_left (mapsTo_preimage _ _) inter_subset_right
+  /- The only nontrivial fact, from which the conclusion follows, is
+  that `ϕ` depends smoothly on `x`. -/
+  suffices hϕ : ContMDiffWithinAt I 𝓘(𝕜, E' →L[𝕜] E) m
+      (fun (x : M) ↦ ContinuousLinearMap.inCoordinates
+        E' (TangentSpace I' (M := M')) E (TangentSpace I (M := M))
+        (b₁ x₀) (b₁ x) (b₂ x₀) (b₂ x) (ϕ x)) s x₀ from
+    ContMDiffWithinAt.clm_apply_of_inCoordinates (hϕ.mono inter_subset_left) hv contMDiffWithinAt_id
+  /- To prove that `ϕ` depends smoothly on `x`, we use that the derivative depends smoothly on `x`
+  (this is `ContMDiffWithinAt.mfderivWithin_const`), and that taking the inverse is a smooth
+  operation at an invertible map. -/
+  -- the derivative in coordinates depends smoothly on the point
+  have : ContMDiffWithinAt I 𝓘(𝕜, E →L[𝕜] E') m
+      (fun (x : M) ↦ ContinuousLinearMap.inCoordinates
+        E (TangentSpace I (M := M)) E' (TangentSpace I' (M := M'))
+        x₀ x (f x₀) (f x) (mfderivWithin I I' f s x)) s x₀ :=
+    hf.mfderivWithin_const hmn hx₀ hs
+  -- therefore, its inverse in coordinates also depends smoothly on the point
+  have : ContMDiffWithinAt I 𝓘(𝕜, E' →L[𝕜] E) m
+      (ContinuousLinearMap.inverse ∘ (fun (x : M) ↦ ContinuousLinearMap.inCoordinates
+        E (TangentSpace I (M := M)) E' (TangentSpace I' (M := M'))
+        x₀ x (f x₀) (f x) (mfderivWithin I I' f s x))) s x₀ := by
+    apply ContMDiffAt.comp_contMDiffWithinAt _ _ this
+    apply ContDiffAt.contMDiffAt
+    apply IsInvertible.contDiffAt_map_inverse
+    rw [inCoordinates_eq (FiberBundle.mem_baseSet_trivializationAt' x₀)
+      (FiberBundle.mem_baseSet_trivializationAt' (f x₀))]
+    exact isInvertible_equiv.comp (hf'.comp isInvertible_equiv)
+  -- the inverse in coordinates coincides with the in-coordinate version of the inverse,
+  -- therefore the previous point gives the conclusion
+  apply this.congr_of_eventuallyEq_of_mem _ hx₀
+  have A : (trivializationAt E (TangentSpace I) x₀).baseSet ∈ 𝓝[s] x₀ := by
+    apply nhdsWithin_le_nhds
+    apply (trivializationAt _ _ _).open_baseSet.mem_nhds
+    exact FiberBundle.mem_baseSet_trivializationAt' _
+  have B : f ⁻¹' (trivializationAt E' (TangentSpace I') (f x₀)).baseSet ∈ 𝓝[s] x₀ := by
+    apply hf.continuousWithinAt.preimage_mem_nhdsWithin
+    apply (trivializationAt _ _ _).open_baseSet.mem_nhds
+    exact FiberBundle.mem_baseSet_trivializationAt' _
+  filter_upwards [A, B] with x hx h'x
+  simp only [Function.comp_apply]
+  rw [inCoordinates_eq hx h'x, inCoordinates_eq h'x (by exact hx)]
+  simp only [inverse_equiv_comp, inverse_comp_equiv, ContinuousLinearEquiv.symm_symm, ϕ]
+  rfl
+
+lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_inter_of_eq
+    (hV : ContMDiffWithinAt I' I'.tangent m
+      (fun (y : M') ↦ (V y : TangentBundle I' M')) t y₀)
+    (hf : ContMDiffWithinAt I I' n f s x₀) (hf' : (mfderivWithin I I' f s x₀).IsInvertible)
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (h : f x₀ = y₀) :
+    ContMDiffWithinAt I I.tangent m
+      (fun (y : M) ↦ (mpullbackWithin I I' f V s y : TangentBundle I M)) (s ∩ f⁻¹' t) x₀ := by
+  subst h
+  exact ContMDiffWithinAt.mpullbackWithin_vectorField_inter hV hf hf' hx₀ hs hmn
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version within a set at a point. -/
+protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem
+    (hV : ContMDiffWithinAt I' I'.tangent m
+      (fun (y : M') ↦ (V y : TangentBundle I' M')) t (f x₀))
+    (hf : ContMDiffWithinAt I I' n f s x₀) (hf' : (mfderivWithin I I' f s x₀).IsInvertible)
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (hst : f ⁻¹' t ∈ 𝓝[s] x₀) :
+    ContMDiffWithinAt I I.tangent m
+      (fun (y : M) ↦ (mpullbackWithin I I' f V s y : TangentBundle I M)) s x₀ := by
+  apply (ContMDiffWithinAt.mpullbackWithin_vectorField_inter
+    hV hf hf' hx₀ hs hmn).mono_of_mem_nhdsWithin
+  exact Filter.inter_mem self_mem_nhdsWithin hst
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version within a set at a point. -/
+protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem_of_eq
+    (hV : ContMDiffWithinAt I' I'.tangent m
+      (fun (y : M') ↦ (V y : TangentBundle I' M')) t y₀)
+    (hf : ContMDiffWithinAt I I' n f s x₀) (hf' : (mfderivWithin I I' f s x₀).IsInvertible)
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (hst : f ⁻¹' t ∈ 𝓝[s] x₀)
+    (hy₀ : f x₀ = y₀) :
+    ContMDiffWithinAt I I.tangent m
+      (fun (y : M) ↦ (mpullbackWithin I I' f V s y : TangentBundle I M)) s x₀ := by
+  subst hy₀
+  exact ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem hV hf hf' hx₀ hs hmn hst
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version within a set at a point. -/
+protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField
+    (hV : ContMDiffWithinAt I' I'.tangent m
+      (fun (y : M') ↦ (V y : TangentBundle I' M')) t (f x₀))
+    (hf : ContMDiffWithinAt I I' n f s x₀) (hf' : (mfderivWithin I I' f s x₀).IsInvertible)
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (hst : MapsTo f s t) :
+    ContMDiffWithinAt I I.tangent m
+      (fun (y : M) ↦ (mpullbackWithin I I' f V s y : TangentBundle I M)) s x₀ :=
+  ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem hV hf hf' hx₀ hs hmn
+    hst.preimage_mem_nhdsWithin
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version within a set at a point. -/
+protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_eq
+    (hV : ContMDiffWithinAt I' I'.tangent m
+      (fun (y : M') ↦ (V y : TangentBundle I' M')) t y₀)
+    (hf : ContMDiffWithinAt I I' n f s x₀) (hf' : (mfderivWithin I I' f s x₀).IsInvertible)
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (hst : MapsTo f s t) (h : f x₀ = y₀) :
+    ContMDiffWithinAt I I.tangent m
+      (fun (y : M) ↦ (mpullbackWithin I I' f V s y : TangentBundle I M)) s x₀ := by
+  subst h
+  exact ContMDiffWithinAt.mpullbackWithin_vectorField hV hf hf' hx₀ hs hmn hst
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version within a set at a point, with a set used for the pullback possibly larger. -/
+protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField' {u : Set M}
+    (hV : ContMDiffWithinAt I' I'.tangent m
+      (fun (y : M') ↦ (V y : TangentBundle I' M')) t (f x₀))
+    (hf : ContMDiffWithinAt I I' n f u x₀) (hf' : (mfderivWithin I I' f u x₀).IsInvertible)
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n)
+    (hst : f ⁻¹' t ∈ 𝓝[s] x₀) (hu : s ⊆ u) :
+    ContMDiffWithinAt I I.tangent m
+      (fun (y : M) ↦ (mpullbackWithin I I' f V u y : TangentBundle I M)) s x₀ := by
+  have hn : (1 : ℕ) ≤ n := le_trans le_add_self hmn
+  have hh : (mfderivWithin I I' f s x₀).IsInvertible := by
+    convert hf' using 1
+    exact (hf.mdifferentiableWithinAt hn).mfderivWithin_mono (hs _ hx₀) hu
+  apply (hV.mpullbackWithin_vectorField_of_mem (hf.mono hu) hh hx₀ hs hmn
+    hst).congr_of_eventuallyEq_of_mem _ hx₀
+  have Y := (contMDiffWithinAt_iff_contMDiffWithinAt_nhdsWithin (by simp)).1 (hf.of_le hn)
+  simp_rw [insert_eq_of_mem (hu hx₀)] at Y
+  filter_upwards [self_mem_nhdsWithin, nhdsWithin_mono _ hu Y] with y hy h'y
+  simp only [mpullbackWithin, Bundle.TotalSpace.mk_inj]
+  rw [MDifferentiableWithinAt.mfderivWithin_mono (h'y.mdifferentiableWithinAt le_rfl) (hs _ hy) hu]
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version within a set at a point, with a set used for the pullback possibly larger. -/
+protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_eq' {u : Set M}
+    (hV : ContMDiffWithinAt I' I'.tangent m
+      (fun (y : M') ↦ (V y : TangentBundle I' M')) t y₀)
+    (hf : ContMDiffWithinAt I I' n f u x₀) (hf' : (mfderivWithin I I' f u x₀).IsInvertible)
+    (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (hst : f ⁻¹' t ∈ 𝓝[s] x₀)
+    (hu : s ⊆ u) (hy₀ : f x₀ = y₀) :
+    ContMDiffWithinAt I I.tangent m
+      (fun (y : M) ↦ (mpullbackWithin I I' f V u y : TangentBundle I M)) s x₀ := by
+  subst hy₀
+  exact ContMDiffWithinAt.mpullbackWithin_vectorField' hV hf hf' hx₀ hs hmn hst hu
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version on a set. -/
+protected lemma _root_.ContMDiffOn.mpullbackWithin_vectorField_inter
+    (hV : ContMDiffOn I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) t)
+    (hf : ContMDiffOn I I' n f s) (hf' : ∀ x ∈ s ∩ f ⁻¹' t, (mfderivWithin I I' f s x).IsInvertible)
+    (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) :
+    ContMDiffOn I I.tangent m
+      (fun (y : M) ↦ (mpullbackWithin I I' f V s y : TangentBundle I M)) (s ∩ f ⁻¹' t) :=
+  fun _ hx₀ ↦ ContMDiffWithinAt.mpullbackWithin_vectorField_inter
+    (hV _ hx₀.2) (hf _ hx₀.1) (hf' _ hx₀) hx₀.1 hs hmn
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version within a set at a point, but with full pullback. -/
+protected lemma _root_.ContMDiffWithinAt.mpullback_vectorField_preimage
+    (hV : ContMDiffWithinAt I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) t (f x₀))
+    (hf : ContMDiffAt I I' n f x₀) (hf' : (mfderiv I I' f x₀).IsInvertible) (hmn : m + 1 ≤ n) :
+    ContMDiffWithinAt I I.tangent m
+      (fun (y : M) ↦ (mpullback I I' f V y : TangentBundle I M)) (f ⁻¹' t) x₀ := by
+  simp only [← contMDiffWithinAt_univ, ← mfderivWithin_univ, ← mpullbackWithin_univ] at hV hf hf' ⊢
+  simpa using hV.mpullbackWithin_vectorField_inter hf hf' (mem_univ _) uniqueMDiffOn_univ hmn
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version within a set at a point, but with full pullback. -/
+protected lemma _root_.ContMDiffWithinAt.mpullback_vectorField_preimage_of_eq
+    (hV : ContMDiffWithinAt I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) t y₀)
+    (hf : ContMDiffAt I I' n f x₀) (hf' : (mfderiv I I' f x₀).IsInvertible) (hmn : m + 1 ≤ n)
+    (hy₀ : y₀ = f x₀) :
+    ContMDiffWithinAt I I.tangent m
+      (fun (y : M) ↦ (mpullback I I' f V y : TangentBundle I M)) (f ⁻¹' t) x₀ := by
+  subst hy₀
+  exact ContMDiffWithinAt.mpullback_vectorField_preimage hV hf hf' hmn
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version within a set at a point, but with full pullback. -/
+protected lemma _root_.ContMDiffWithinAt.mpullback_vectorField_of_mem_nhdsWithin
+    (hV : ContMDiffWithinAt I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) t (f x₀))
+    (hf : ContMDiffAt I I' n f x₀) (hf' : (mfderiv I I' f x₀).IsInvertible) (hmn : m + 1 ≤ n)
+    (hst : f ⁻¹' t ∈ 𝓝[s] x₀) :
+    ContMDiffWithinAt I I.tangent m
+      (fun (y : M) ↦ (mpullback I I' f V y : TangentBundle I M)) s x₀ :=
+  (ContMDiffWithinAt.mpullback_vectorField_preimage hV hf hf' hmn).mono_of_mem_nhdsWithin hst
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version within a set at a point, but with full pullback. -/
+protected lemma _root_.ContMDiffWithinAt.mpullback_vectorField_of_mem_nhdsWithin_of_eq
+    (hV : ContMDiffWithinAt I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) t y₀)
+    (hf : ContMDiffAt I I' n f x₀) (hf' : (mfderiv I I' f x₀).IsInvertible) (hmn : m + 1 ≤ n)
+    (hst : f ⁻¹' t ∈ 𝓝[s] x₀) (hy₀ : y₀ = f x₀) :
+    ContMDiffWithinAt I I.tangent m
+      (fun (y : M) ↦ (mpullback I I' f V y : TangentBundle I M)) s x₀ := by
+  subst hy₀
+  exact ContMDiffWithinAt.mpullback_vectorField_of_mem_nhdsWithin hV hf hf' hmn hst
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version on a set, but with full pullback -/
+protected lemma _root_.ContMDiffOn.mpullback_vectorField_preimage
+    (hV : ContMDiffOn I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) t)
+    (hf : ContMDiff I I' n f) (hf' : ∀ x ∈ f ⁻¹' t, (mfderiv I I' f x).IsInvertible)
+    (hmn : m + 1 ≤ n) :
+    ContMDiffOn I I.tangent m
+      (fun (y : M) ↦ (mpullback I I' f V y : TangentBundle I M)) (f ⁻¹' t) :=
+  fun x₀ hx₀ ↦ ContMDiffWithinAt.mpullback_vectorField_preimage (hV _ hx₀) (hf x₀) (hf' _ hx₀) hmn
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+Version at a point. -/
+protected lemma _root_.ContMDiffAt.mpullback_vectorField_preimage
+    (hV : ContMDiffAt I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) (f x₀))
+    (hf : ContMDiffAt I I' n f x₀) (hf' : (mfderiv I I' f x₀).IsInvertible) (hmn : m + 1 ≤ n) :
+    ContMDiffAt I I.tangent m
+      (fun (y : M) ↦ (mpullback I I' f V y : TangentBundle I M)) x₀ := by
+  simp only [← contMDiffWithinAt_univ] at hV hf hf' ⊢
+  simpa using ContMDiffWithinAt.mpullback_vectorField_preimage hV hf hf' hmn
+
+/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`. -/
+protected lemma _root_.ContMDiff.mpullback_vectorField
+    (hV : ContMDiff I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')))
+    (hf : ContMDiff I I' n f) (hf' : ∀ x, (mfderiv I I' f x).IsInvertible) (hmn : m + 1 ≤ n) :
+    ContMDiff I I.tangent m (fun (y : M) ↦ (mpullback I I' f V y : TangentBundle I M)) :=
+  fun x ↦ ContMDiffAt.mpullback_vectorField_preimage (hV (f x)) (hf x) (hf' x) hmn
+
+lemma contMDiffWithinAt_mpullbackWithin_extChartAt_symm
+    {V : Π (x : M), TangentSpace I x}
+    (hV : ContMDiffWithinAt I I.tangent m (fun x ↦ (V x : TangentBundle I M)) s x)
+    (hs : UniqueMDiffOn I s) (hx : x ∈ s) (hmn : m + 1 ≤ n) :
+    ContMDiffWithinAt 𝓘(𝕜, E) 𝓘(𝕜, E).tangent m
+      (fun y ↦ (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (range I) y :
+        TangentBundle 𝓘(𝕜, E) E))
+      ((extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' s) (extChartAt I x x) :=
+  ContMDiffWithinAt.mpullbackWithin_vectorField_of_eq' hV
+    (contMDiffWithinAt_extChartAt_symm_range (n := n) _ (mem_extChartAt_target x))
+    (isInvertible_mfderivWithin_extChartAt_symm (mem_extChartAt_target x))
+    (by simp [hx]) (UniqueMDiffOn.uniqueMDiffOn_target_inter hs x) hmn
+    ((mapsTo_preimage _ _).mono_left inter_subset_right).preimage_mem_nhdsWithin
+    (Subset.trans inter_subset_left (extChartAt_target_subset_range x)) (extChartAt_to_inv x)
+
+lemma eventually_contMDiffWithinAt_mpullbackWithin_extChartAt_symm
+    {V : Π (x : M), TangentSpace I x}
+    (hV : ContMDiffWithinAt I I.tangent m (fun x ↦ (V x : TangentBundle I M)) s x)
+    (hs : UniqueMDiffOn I s) (hx : x ∈ s) (hmn : m + 1 ≤ n) (hm : m ≠ ∞) :
+    ∀ᶠ y in 𝓝[s] x, ContMDiffWithinAt 𝓘(𝕜, E) 𝓘(𝕜, E).tangent m
+    (fun z ↦ (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (range I) z :
+      TangentBundle 𝓘(𝕜, E) E))
+    ((extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' s) (extChartAt I x y) := by
+  have T := nhdsWithin_mono _ (subset_insert _ _)
+    ((contMDiffWithinAt_iff_contMDiffWithinAt_nhdsWithin hm).1
+      (contMDiffWithinAt_mpullbackWithin_extChartAt_symm hV hs hx hmn))
+  have A := (continuousAt_extChartAt (I := I) x).continuousWithinAt.preimage_mem_nhdsWithin'' T rfl
+  apply (nhdsWithin_le_iff.2 _) A
+  filter_upwards [self_mem_nhdsWithin, nhdsWithin_le_nhds (extChartAt_source_mem_nhds (I := I) x)]
+    with y hy h'y
+  simp only [mfld_simps] at hy h'y
+  simp [hy, h'y]
+
+omit [CompleteSpace E] in
+lemma eventuallyEq_mpullback_mpullbackWithin_extChartAt (V : Π (x : M), TangentSpace I x) :
+    V =ᶠ[𝓝[s] x] mpullback I 𝓘(𝕜, E) (extChartAt I x)
+      (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (range I)) := by
+  apply nhdsWithin_le_nhds
+  filter_upwards [extChartAt_source_mem_nhds (I := I) x] with y hy
+  have A : (extChartAt I x).symm (extChartAt I x y) = y := (extChartAt I x).left_inv hy
+  rw [mpullback_apply, mpullbackWithin_apply,
+    ← (isInvertible_mfderiv_extChartAt hy).inverse_comp_apply_of_right,
+    mfderivWithin_extChartAt_symm_comp_mfderiv_extChartAt' hy, A]
+  simp only [ContinuousLinearMap.inverse_id, ContinuousLinearMap.coe_id', id_eq]
+
+end ContMDiff
+
+lemma mpullbackWithin_comp_of_left
+    {g : M' → M''} {f : M → M'} {V : Π (x : M''), TangentSpace I'' x}
+    {s : Set M} {t : Set M'} {x₀ : M} (hg : MDifferentiableWithinAt I' I'' g t (f x₀))
+    (hf : MDifferentiableWithinAt I I' f s x₀) (h : Set.MapsTo f s t)
+    (hu : UniqueMDiffWithinAt I s x₀) (hg' : (mfderivWithin I' I'' g t (f x₀)).IsInvertible) :
+    mpullbackWithin I I'' (g ∘ f) V s x₀ =
+      mpullbackWithin I I' f (mpullbackWithin I' I'' g V t) s x₀ := by
+  simp only [mpullbackWithin, comp_apply]
+  rw [mfderivWithin_comp _ hg hf h hu, IsInvertible.inverse_comp_apply_of_left]
+  · rfl
+  · exact hg'
+
+lemma mpullbackWithin_comp_of_right
+    {g : M' → M''} {f : M → M'} {V : Π (x : M''), TangentSpace I'' x}
+    {s : Set M} {t : Set M'} {x₀ : M} (hg : MDifferentiableWithinAt I' I'' g t (f x₀))
+    (hf : MDifferentiableWithinAt I I' f s x₀) (h : Set.MapsTo f s t)
+    (hu : UniqueMDiffWithinAt I s x₀) (hf' : (mfderivWithin I I' f s x₀).IsInvertible) :
+    mpullbackWithin I I'' (g ∘ f) V s x₀ =
+      mpullbackWithin I I' f (mpullbackWithin I' I'' g V t) s x₀ := by
+  simp only [mpullbackWithin, comp_apply]
+  rw [mfderivWithin_comp _ hg hf h hu, IsInvertible.inverse_comp_apply_of_right hf']
+  rfl
+
 end Pullback
 
 end VectorField

--- a/Mathlib/Geometry/Manifold/VectorField.lean
+++ b/Mathlib/Geometry/Manifold/VectorField.lean
@@ -633,25 +633,27 @@ lemma eventuallyEq_mpullback_mpullbackWithin_extChartAt (V : Π (x : M), Tangent
 end ContMDiff
 
 lemma mpullbackWithin_comp_of_left
-    {g : M' → M''} {f : M → M'} {V : Π (x : M''), TangentSpace I'' x}
-    {s : Set M} {t : Set M'} {x₀ : M} (hg : MDifferentiableWithinAt I' I'' g t (f x₀))
-    (hf : MDifferentiableWithinAt I I' f s x₀) (h : Set.MapsTo f s t)
+    {g : M' → M''} {f : M → M'} {V : Π (x : M''), TangentSpace I'' x} {s : Set M} {t : Set M'}
+    {x₀ : M} (hf : MDifferentiableWithinAt I I' f s x₀) (h : Set.MapsTo f s t)
     (hu : UniqueMDiffWithinAt I s x₀) (hg' : (mfderivWithin I' I'' g t (f x₀)).IsInvertible) :
     mpullbackWithin I I'' (g ∘ f) V s x₀ =
       mpullbackWithin I I' f (mpullbackWithin I' I'' g V t) s x₀ := by
   simp only [mpullbackWithin, comp_apply]
+  have hg : MDifferentiableWithinAt I' I'' g t (f x₀) :=
+    mdifferentiableWithinAt_of_isInvertible_mfderivWithin hg'
   rw [mfderivWithin_comp _ hg hf h hu, IsInvertible.inverse_comp_apply_of_left]
   · rfl
   · exact hg'
 
 lemma mpullbackWithin_comp_of_right
-    {g : M' → M''} {f : M → M'} {V : Π (x : M''), TangentSpace I'' x}
-    {s : Set M} {t : Set M'} {x₀ : M} (hg : MDifferentiableWithinAt I' I'' g t (f x₀))
-    (hf : MDifferentiableWithinAt I I' f s x₀) (h : Set.MapsTo f s t)
+    {g : M' → M''} {f : M → M'} {V : Π (x : M''), TangentSpace I'' x} {s : Set M} {t : Set M'}
+    {x₀ : M} (hg : MDifferentiableWithinAt I' I'' g t (f x₀)) (h : Set.MapsTo f s t)
     (hu : UniqueMDiffWithinAt I s x₀) (hf' : (mfderivWithin I I' f s x₀).IsInvertible) :
     mpullbackWithin I I'' (g ∘ f) V s x₀ =
       mpullbackWithin I I' f (mpullbackWithin I' I'' g V t) s x₀ := by
   simp only [mpullbackWithin, comp_apply]
+  have hf : MDifferentiableWithinAt I I' f s x₀ :=
+    mdifferentiableWithinAt_of_isInvertible_mfderivWithin hf'
   rw [mfderivWithin_comp _ hg hf h hu, IsInvertible.inverse_comp_apply_of_right hf']
   rfl
 

--- a/Mathlib/Geometry/Manifold/VectorField.lean
+++ b/Mathlib/Geometry/Manifold/VectorField.lean
@@ -366,11 +366,12 @@ end MDifferentiability
 section ContMDiff
 
 variable [IsManifold I n M] [IsManifold I' n M'] [CompleteSpace E]
--- the next assumptions will usually follow from the previous ones, but they are needed for
--- the statements to make sense, so we add them here.
-[IsManifold I 1 M] [IsManifold I' 1 M']
+  -- If `1 < n` then `IsManifold.of_le` shows the following assumptions are redundant.
+  -- We include them since they are necessary to make the statement.
+  [IsManifold I 1 M] [IsManifold I' 1 M']
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+`m + 1 ≤ n` is `C^m`.
 Version within a set at a point. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_inter
     (hV : ContMDiffWithinAt I' I'.tangent m

--- a/Mathlib/Geometry/Manifold/VectorField.lean
+++ b/Mathlib/Geometry/Manifold/VectorField.lean
@@ -447,7 +447,8 @@ lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_inter_of_eq
   subst h
   exact ContMDiffWithinAt.mpullbackWithin_vectorField_inter hV hf hf' hx₀ hs hmn
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem
     (hV : ContMDiffWithinAt I' I'.tangent m
@@ -460,7 +461,8 @@ protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem
     hV hf hf' hx₀ hs hmn).mono_of_mem_nhdsWithin
   exact Filter.inter_mem self_mem_nhdsWithin hst
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem_of_eq
     (hV : ContMDiffWithinAt I' I'.tangent m
@@ -473,7 +475,8 @@ protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem_of_e
   subst hy₀
   exact ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem hV hf hf' hx₀ hs hmn hst
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField
     (hV : ContMDiffWithinAt I' I'.tangent m
@@ -485,7 +488,8 @@ protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField
   ContMDiffWithinAt.mpullbackWithin_vectorField_of_mem hV hf hf' hx₀ hs hmn
     hst.preimage_mem_nhdsWithin
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_eq
     (hV : ContMDiffWithinAt I' I'.tangent m
@@ -497,7 +501,8 @@ protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_eq
   subst h
   exact ContMDiffWithinAt.mpullbackWithin_vectorField hV hf hf' hx₀ hs hmn hst
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point, with a set used for the pullback possibly larger. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField' {u : Set M}
     (hV : ContMDiffWithinAt I' I'.tangent m
@@ -519,7 +524,8 @@ protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField' {u : Set M
   simp only [mpullbackWithin, Bundle.TotalSpace.mk_inj]
   rw [MDifferentiableWithinAt.mfderivWithin_mono (h'y.mdifferentiableWithinAt le_rfl) (hs _ hy) hu]
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point, with a set used for the pullback possibly larger. -/
 protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_eq' {u : Set M}
     (hV : ContMDiffWithinAt I' I'.tangent m
@@ -532,7 +538,8 @@ protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_of_eq' {u :
   subst hy₀
   exact ContMDiffWithinAt.mpullbackWithin_vectorField' hV hf hf' hx₀ hs hmn hst hu
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version on a set. -/
 protected lemma _root_.ContMDiffOn.mpullbackWithin_vectorField_inter
     (hV : ContMDiffOn I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) t)
@@ -543,7 +550,8 @@ protected lemma _root_.ContMDiffOn.mpullbackWithin_vectorField_inter
   fun _ hx₀ ↦ ContMDiffWithinAt.mpullbackWithin_vectorField_inter
     (hV _ hx₀.2) (hf _ hx₀.1) (hf' _ hx₀) hx₀.1 hs hmn
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point, but with full pullback. -/
 protected lemma _root_.ContMDiffWithinAt.mpullback_vectorField_preimage
     (hV : ContMDiffWithinAt I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) t (f x₀))
@@ -553,7 +561,8 @@ protected lemma _root_.ContMDiffWithinAt.mpullback_vectorField_preimage
   simp only [← contMDiffWithinAt_univ, ← mfderivWithin_univ, ← mpullbackWithin_univ] at hV hf hf' ⊢
   simpa using hV.mpullbackWithin_vectorField_inter hf hf' (mem_univ _) uniqueMDiffOn_univ hmn
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point, but with full pullback. -/
 protected lemma _root_.ContMDiffWithinAt.mpullback_vectorField_preimage_of_eq
     (hV : ContMDiffWithinAt I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) t y₀)
@@ -564,7 +573,8 @@ protected lemma _root_.ContMDiffWithinAt.mpullback_vectorField_preimage_of_eq
   subst hy₀
   exact ContMDiffWithinAt.mpullback_vectorField_preimage hV hf hf' hmn
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point, but with full pullback. -/
 protected lemma _root_.ContMDiffWithinAt.mpullback_vectorField_of_mem_nhdsWithin
     (hV : ContMDiffWithinAt I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) t (f x₀))
@@ -574,7 +584,8 @@ protected lemma _root_.ContMDiffWithinAt.mpullback_vectorField_of_mem_nhdsWithin
       (fun (y : M) ↦ (mpullback I I' f V y : TangentBundle I M)) s x₀ :=
   (ContMDiffWithinAt.mpullback_vectorField_preimage hV hf hf' hmn).mono_of_mem_nhdsWithin hst
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version within a set at a point, but with full pullback. -/
 protected lemma _root_.ContMDiffWithinAt.mpullback_vectorField_of_mem_nhdsWithin_of_eq
     (hV : ContMDiffWithinAt I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) t y₀)
@@ -585,7 +596,8 @@ protected lemma _root_.ContMDiffWithinAt.mpullback_vectorField_of_mem_nhdsWithin
   subst hy₀
   exact ContMDiffWithinAt.mpullback_vectorField_of_mem_nhdsWithin hV hf hf' hmn hst
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version on a set, but with full pullback -/
 protected lemma _root_.ContMDiffOn.mpullback_vectorField_preimage
     (hV : ContMDiffOn I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) t)
@@ -595,7 +607,8 @@ protected lemma _root_.ContMDiffOn.mpullback_vectorField_preimage
       (fun (y : M) ↦ (mpullback I I' f V y : TangentBundle I M)) (f ⁻¹' t) :=
   fun x₀ hx₀ ↦ ContMDiffWithinAt.mpullback_vectorField_preimage (hV _ hx₀) (hf x₀) (hf' _ hx₀) hmn
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`.
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`.
 Version at a point. -/
 protected lemma _root_.ContMDiffAt.mpullback_vectorField_preimage
     (hV : ContMDiffAt I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')) (f x₀))
@@ -605,7 +618,8 @@ protected lemma _root_.ContMDiffAt.mpullback_vectorField_preimage
   simp only [← contMDiffWithinAt_univ] at hV hf hf' ⊢
   simpa using ContMDiffWithinAt.mpullback_vectorField_preimage hV hf hf' hmn
 
-/-- The pullback of a `C^m` vector field by a `C^n` function with `m + 1 ≤ n` is `C^m`. -/
+/-- The pullback of a `C^m` vector field by a `C^n` function with invertible derivative and
+with `m + 1 ≤ n` is `C^m`. -/
 protected lemma _root_.ContMDiff.mpullback_vectorField
     (hV : ContMDiff I' I'.tangent m (fun (y : M') ↦ (V y : TangentBundle I' M')))
     (hf : ContMDiff I I' n f) (hf' : ∀ x, (mfderiv I I' f x).IsInvertible) (hmn : m + 1 ≤ n) :

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -896,14 +896,32 @@ theorem inverse_equiv (e : M ≃L[R] M₂) : inverse (e : M →L[R] M₂) = e.sy
 
 @[deprecated (since := "2024-10-29")] alias inverse_non_equiv := inverse_of_not_isInvertible
 
+theorem isInvertible_zero_iff :
+    IsInvertible (0 : M →L[R] M₂) ↔ Subsingleton M ∧ Subsingleton M₂ := by
+  refine ⟨fun h ↦ ?_, ?_⟩
+  · rcases h with ⟨e, he⟩
+    have A : Subsingleton M := by
+      refine ⟨fun x y ↦ e.injective ?_⟩
+      change (e : M →L[R] M₂) x = (e : M →L[R] M₂) y
+      simp [he]
+    exact ⟨A, e.toEquiv.symm.subsingleton⟩
+  · rintro ⟨hM, hM₂⟩
+    let e : M ≃L[R] M₂ :=
+    { toFun := 0
+      invFun := 0
+      left_inv := fun x ↦ Subsingleton.elim _ _
+      right_inv := fun x ↦ Subsingleton.elim _ _
+      map_add' := fun x y ↦ Subsingleton.elim _ _
+      map_smul' := fun x y ↦ Subsingleton.elim _ _ }
+    refine ⟨e, ?_⟩
+    ext x
+    exact Subsingleton.elim _ _
+
 @[simp] theorem inverse_zero : inverse (0 : M →L[R] M₂) = 0 := by
   by_cases h : IsInvertible (0 : M →L[R] M₂)
-  · rcases h with ⟨e', he'⟩
-    simp only [← he', inverse_equiv]
-    ext v
-    apply e'.injective
-    rw [← ContinuousLinearEquiv.coe_coe, he']
-    rfl
+  · rcases isInvertible_zero_iff.1 h with ⟨hM, hM₂⟩
+    ext x
+    exact Subsingleton.elim _ _
   · exact inverse_of_not_isInvertible h
 
 lemma IsInvertible.comp {g : M₂ →L[R] M₃} {f : M →L[R] M₂}

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -898,21 +898,19 @@ theorem inverse_equiv (e : M ≃L[R] M₂) : inverse (e : M →L[R] M₂) = e.sy
 
 theorem isInvertible_zero_iff :
     IsInvertible (0 : M →L[R] M₂) ↔ Subsingleton M ∧ Subsingleton M₂ := by
-  refine ⟨fun h ↦ ?_, ?_⟩
-  · rcases h with ⟨e, he⟩
-    have A : Subsingleton M := by
+  refine ⟨fun ⟨e, he⟩ ↦ ?_, ?_⟩
+  · have A : Subsingleton M := by
       refine ⟨fun x y ↦ e.injective ?_⟩
-      change (e : M →L[R] M₂) x = (e : M →L[R] M₂) y
-      simp [he]
+      simp [he, ← ContinuousLinearEquiv.coe_coe]
     exact ⟨A, e.toEquiv.symm.subsingleton⟩
   · rintro ⟨hM, hM₂⟩
     let e : M ≃L[R] M₂ :=
     { toFun := 0
       invFun := 0
-      left_inv := fun x ↦ Subsingleton.elim _ _
-      right_inv := fun x ↦ Subsingleton.elim _ _
-      map_add' := fun x y ↦ Subsingleton.elim _ _
-      map_smul' := fun x y ↦ Subsingleton.elim _ _ }
+      left_inv x := Subsingleton.elim _ _
+      right_inv x := Subsingleton.elim _ _
+      map_add' x y := Subsingleton.elim _ _
+      map_smul' c x := Subsingleton.elim _ _ }
     refine ⟨e, ?_⟩
     ext x
     exact Subsingleton.elim _ _

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -896,6 +896,7 @@ theorem inverse_equiv (e : M ≃L[R] M₂) : inverse (e : M →L[R] M₂) = e.sy
 
 @[deprecated (since := "2024-10-29")] alias inverse_non_equiv := inverse_of_not_isInvertible
 
+@[simp]
 theorem isInvertible_zero_iff :
     IsInvertible (0 : M →L[R] M₂) ↔ Subsingleton M ∧ Subsingleton M₂ := by
   refine ⟨fun ⟨e, he⟩ ↦ ?_, ?_⟩


### PR DESCRIPTION
We show that the pullback of a `C^m` vector field on a manifold under a `C^{m+1}` map with invertible derivative is `C^m`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
