### PR TITLE
[Merged by Bors] - feat: `notation3`-defined pretty printers now make tokens that are clickable in documentation

### DIFF
--- a/Mathlib/Util/Notation3.lean
+++ b/Mathlib/Util/Notation3.lean
@@ -443,6 +443,24 @@ def getPrettyPrintOpt (opt? : Option (TSyntax ``prettyPrintOpt)) : Bool :=
     true
 
 /--
+If `pp.tagAppFns` is true and the head of the current expression is a constant,
+then delaborates the head and uses it for the ref.
+This causes tokens inside the syntax to refer to this constant.
+A consequence is that docgen will linkify the tokens.
+-/
+def withHeadRefIfTagAppFns (d : Delab) : Delab := do
+  let tagAppFns ← getPPOption getPPTagAppFns
+  if tagAppFns && (← getExpr).getAppFn.consumeMData.isConst then
+    -- Delaborate the head to register term info and get a syntax we can use for the ref.
+    -- The syntax `f` itself is thrown away.
+    let f ← withNaryFn delab
+    let stx ← withRef f d
+    -- Annotate to ensure that the full syntax still refers to the whole expression.
+    annotateTermInfo stx
+  else
+    d
+
+/--
 `notation3` declares notation using Lean-3-style syntax.
 
 Examples:
@@ -584,7 +602,7 @@ elab (name := notation3) doc:(docComment)? attrs?:(Parser.Term.attributes)? attr
       let delabName := name ++ `delab
       let matcher ← ms.foldrM (fun m t => `($(m.2) >=> $t)) (← `(pure))
       trace[notation3] "matcher:{indentD matcher}"
-      let mut result ← `(`($pat))
+      let mut result ← `(withHeadRefIfTagAppFns `($pat))
       for (name, id) in boundIdents.toArray do
         match boundType.getD name .normal with
         | .normal => result ← `(MatchState.delabVar s $(quote name) (some e) >>= fun $id => $result)

--- a/Mathlib/Util/Notation3.lean
+++ b/Mathlib/Util/Notation3.lean
@@ -453,7 +453,7 @@ def withHeadRefIfTagAppFns (d : Delab) : Delab := do
   if tagAppFns && (← getExpr).getAppFn.consumeMData.isConst then
     -- Delaborate the head to register term info and get a syntax we can use for the ref.
     -- The syntax `f` itself is thrown away.
-    let f ← withNaryFn delab
+    let f ← withNaryFn <| withOptionAtCurrPos `pp.tagAppFns true delab
     let stx ← withRef f d
     -- Annotate to ensure that the full syntax still refers to the whole expression.
     annotateTermInfo stx


### PR DESCRIPTION
Modifies the `notation3` delaborator generator so that when `pp.tagAppFns` is true, and when the expression being delaborated is the application of a constant, all the tokens of the notation are annotated with that constant. The consequence is that in docgen documentation, the tokens will be links to that constant.

This heuristic might give unexpected results. For example, in
```lean
notation3 "Nat≥0" => { x : Nat // 0 ≤ x }
```
the documentation will have appearances of `Nat≥0` link to `Subtype`.

In complicated notations this heuristic may have mixed results. For example, it's possible to use `notation3` to define notations that have different head constants in different expansions, and so the tokens can link to different constants in different appearances. There are no such cases of this in mathlib however.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Filter.2EEventually.20.28.60.E2.88.80.E1.B6.A0.60.29.20notation.20is.20not.20clickable.20in.20docs/near/494590979)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
