### PR TITLE
chore(Order/WellFoundedSet): get rid of nonrec

### DIFF
--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -589,8 +589,8 @@ section Preorder
 variable [Preorder α] {s t : Set α} {a : α}
 
 /-- `Set.IsWF.min` returns a minimal element of a nonempty well-founded set. -/
-noncomputable def IsWF.min (hs : IsWF s) (hn : s.Nonempty) : α :=
-  WellFounded.min hs univ (nonempty_iff_univ_nonempty.1 hn.to_subtype)
+noncomputable nonrec def IsWF.min (hs : IsWF s) (hn : s.Nonempty) : α :=
+  (WellFounded.min hs univ (nonempty_iff_univ_nonempty.1 hn.to_subtype)).1
 
 theorem IsWF.min_mem (hs : IsWF s) (hn : s.Nonempty) : hs.min hn ∈ s :=
   (WellFounded.min hs univ (nonempty_iff_univ_nonempty.1 hn.to_subtype)).2

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -596,7 +596,7 @@ theorem IsWF.min_mem (hs : IsWF s) (hn : s.Nonempty) : hs.min hn ∈ s :=
   (WellFounded.min hs univ (nonempty_iff_univ_nonempty.1 hn.to_subtype)).2
 
 theorem IsWF.not_lt_min (hs : IsWF s) (hn : s.Nonempty) (ha : a ∈ s) : ¬a < hs.min hn :=
-  WellFounded.not_lt_min hs univ (nonempty_iff_univ_nonempty.1 hn.to_subtype) (@mem_univ s ⟨a, ha⟩)
+  WellFounded.not_lt_min hs univ (nonempty_iff_univ_nonempty.1 hn.to_subtype) (mem_univ ⟨a, ha⟩)
 
 theorem IsWF.min_of_subset_not_lt_min {hs : s.IsWF} {hsn : s.Nonempty} {ht : t.IsWF}
     {htn : t.Nonempty} (hst : s ⊆ t) : ¬hs.min hsn < ht.min htn :=

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -217,7 +217,8 @@ section Preorder
 
 variable [Preorder α] {s t : Set α} {a : α}
 
-protected nonrec theorem IsWF.union (hs : IsWF s) (ht : IsWF t) : IsWF (s ∪ t) := hs.union ht
+protected theorem IsWF.union (hs : IsWF s) (ht : IsWF t) : IsWF (s ∪ t) :=
+  WellFoundedOn.union hs ht
 
 @[simp] theorem isWF_union : IsWF (s ∪ t) ↔ IsWF s ∧ IsWF t := wellFoundedOn_union
 
@@ -393,11 +394,12 @@ variable [Preorder α] [Preorder β] {s t : Set α}
 def IsPWO (s : Set α) : Prop :=
   PartiallyWellOrderedOn s (· ≤ ·)
 
-nonrec theorem IsPWO.mono (ht : t.IsPWO) : s ⊆ t → s.IsPWO := ht.mono
+theorem IsPWO.mono (ht : t.IsPWO) : s ⊆ t → s.IsPWO :=
+  PartiallyWellOrderedOn.mono ht
 
-nonrec theorem IsPWO.exists_monotone_subseq (h : s.IsPWO) (f : ℕ → α) (hf : ∀ n, f n ∈ s) :
+theorem IsPWO.exists_monotone_subseq (h : s.IsPWO) (f : ℕ → α) (hf : ∀ n, f n ∈ s) :
     ∃ g : ℕ ↪o ℕ, Monotone (f ∘ g) :=
-  h.exists_monotone_subseq f hf
+  PartiallyWellOrderedOn.exists_monotone_subseq h f hf
 
 theorem isPWO_iff_exists_monotone_subseq :
     s.IsPWO ↔ ∀ f : ℕ → α, (∀ n, f n ∈ s) → ∃ g : ℕ ↪o ℕ, Monotone (f ∘ g) :=
@@ -406,8 +408,8 @@ theorem isPWO_iff_exists_monotone_subseq :
 protected theorem IsPWO.isWF (h : s.IsPWO) : s.IsWF := by
   simpa only [← lt_iff_le_not_le] using h.wellFoundedOn
 
-nonrec theorem IsPWO.prod {t : Set β} (hs : s.IsPWO) (ht : t.IsPWO) : IsPWO (s ×ˢ t) :=
-  hs.prod ht
+theorem IsPWO.prod {t : Set β} (hs : s.IsPWO) (ht : t.IsPWO) : IsPWO (s ×ˢ t) :=
+  PartiallyWellOrderedOn.prod hs ht
 
 theorem IsPWO.image_of_monotoneOn (hs : s.IsPWO) {f : α → β} (hf : MonotoneOn f s) :
     IsPWO (f '' s) :=
@@ -416,8 +418,8 @@ theorem IsPWO.image_of_monotoneOn (hs : s.IsPWO) {f : α → β} (hf : MonotoneO
 theorem IsPWO.image_of_monotone (hs : s.IsPWO) {f : α → β} (hf : Monotone f) : IsPWO (f '' s) :=
   hs.image_of_monotone_on (hf.monotoneOn _)
 
-protected nonrec theorem IsPWO.union (hs : IsPWO s) (ht : IsPWO t) : IsPWO (s ∪ t) :=
-  hs.union ht
+protected theorem IsPWO.union (hs : IsPWO s) (ht : IsPWO t) : IsPWO (s ∪ t) :=
+  PartiallyWellOrderedOn.union hs ht
 
 @[simp]
 theorem isPWO_union : IsPWO (s ∪ t) ↔ IsPWO s ∧ IsPWO t :=
@@ -587,14 +589,14 @@ section Preorder
 variable [Preorder α] {s t : Set α} {a : α}
 
 /-- `Set.IsWF.min` returns a minimal element of a nonempty well-founded set. -/
-noncomputable nonrec def IsWF.min (hs : IsWF s) (hn : s.Nonempty) : α :=
-  hs.min univ (nonempty_iff_univ_nonempty.1 hn.to_subtype)
+noncomputable def IsWF.min (hs : IsWF s) (hn : s.Nonempty) : α :=
+  WellFounded.min hs univ (nonempty_iff_univ_nonempty.1 hn.to_subtype)
 
 theorem IsWF.min_mem (hs : IsWF s) (hn : s.Nonempty) : hs.min hn ∈ s :=
   (WellFounded.min hs univ (nonempty_iff_univ_nonempty.1 hn.to_subtype)).2
 
-nonrec theorem IsWF.not_lt_min (hs : IsWF s) (hn : s.Nonempty) (ha : a ∈ s) : ¬a < hs.min hn :=
-  hs.not_lt_min univ (nonempty_iff_univ_nonempty.1 hn.to_subtype) (mem_univ (⟨a, ha⟩ : s))
+theorem IsWF.not_lt_min (hs : IsWF s) (hn : s.Nonempty) (ha : a ∈ s) : ¬a < hs.min hn :=
+  WellFounded.not_lt_min hs univ (nonempty_iff_univ_nonempty.1 hn.to_subtype) (@mem_univ s ⟨a, ha⟩)
 
 theorem IsWF.min_of_subset_not_lt_min {hs : s.IsWF} {hsn : s.Nonempty} {ht : t.IsWF}
     {htn : t.Nonempty} (hst : s ⊆ t) : ¬hs.min hsn < ht.min htn :=


### PR DESCRIPTION
My own impression is that this constitutes code smell, but if this isn't the case then feel free to close this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
