### PR TITLE
[Merged by Bors] - style: replace `field x y := match x, y with` with `field`

### DIFF
--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -170,7 +170,7 @@ lemma coe_mul [Mul α] (a b : α) : (↑(a * b) : WithOne α) = a * b := rfl
 @[to_additive]
 instance monoid [Semigroup α] : Monoid (WithOne α) where
   __ := mulOneClass
-  mul_assoc a b c := match a, b, c with
+  mul_assoc
     | 1, b, c => by simp
     | (a : α), 1, c => by simp
     | (a : α), (b : α), 1 => by simp
@@ -178,7 +178,7 @@ instance monoid [Semigroup α] : Monoid (WithOne α) where
 
 @[to_additive]
 instance commMonoid [CommSemigroup α] : CommMonoid (WithOne α) where
-  mul_comm := fun a b => match a, b with
+  mul_comm
     | (a : α), (b : α) => congr_arg some (mul_comm a b)
     | (_ : α), 1 => rfl
     | 1, (_ : α) => rfl

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -142,7 +142,7 @@ section Pow
 variable [One α] [Pow α ℕ]
 
 instance pow : Pow (WithZero α) ℕ where
-  pow x n := match x, n with
+  pow
     | none, 0 => 1
     | none, _ + 1 => 0
     | some x, n => ↑(x ^ n)
@@ -155,12 +155,12 @@ instance monoidWithZero [Monoid α] : MonoidWithZero (WithZero α) where
   __ := mulZeroOneClass
   __ := semigroupWithZero
   npow n a := a ^ n
-  npow_zero a := match a with
-    | none => rfl
+  npow_zero
+    | 0 => rfl
     | some _ => congr_arg some (pow_zero _)
-  npow_succ n a := match a with
-    | none => by change 0 ^ (n + 1) = 0 ^ n * 0; simp only [mul_zero]; rfl
-    | some _ => congr_arg some <| pow_succ _ _
+  npow_succ
+    | n, 0 => by simp only [mul_zero]; rfl
+    | n, some _ => congr_arg some <| pow_succ _ _
 
 instance commMonoidWithZero [CommMonoid α] : CommMonoidWithZero (WithZero α) :=
   { WithZero.monoidWithZero, WithZero.commSemigroup with }
@@ -193,7 +193,7 @@ section ZPow
 variable [One α] [Pow α ℤ]
 
 instance : Pow (WithZero α) ℤ where
-  pow a n := match a, n with
+  pow
     | none, Int.ofNat 0 => 1
     | none, Int.ofNat (Nat.succ _) => 0
     | none, Int.negSucc _ => 0
@@ -205,20 +205,20 @@ end ZPow
 
 instance divInvMonoid [DivInvMonoid α] : DivInvMonoid (WithZero α) where
   __ := monoidWithZero
-  div_eq_mul_inv a b := match a, b with
+  div_eq_mul_inv
     | none, _ => rfl
     | some _, none => rfl
     | some a, some b => congr_arg some (div_eq_mul_inv a b)
   zpow n a := a ^ n
-  zpow_zero' a := match a with
+  zpow_zero'
     | none => rfl
     | some _ => congr_arg some (zpow_zero _)
-  zpow_succ' n a := match a with
-    | none => by change 0 ^ _ = 0 ^ _ * 0; simp only [mul_zero]; rfl
-    | some _ => congr_arg some (DivInvMonoid.zpow_succ' _ _)
-  zpow_neg' _ a := match a with
-    | none => rfl
-    | some _ => congr_arg some (DivInvMonoid.zpow_neg' _ _)
+  zpow_succ'
+    | n, none => by change 0 ^ _ = 0 ^ _ * 0; simp only [mul_zero]; rfl
+    | n, some _ => congr_arg some (DivInvMonoid.zpow_succ' _ _)
+  zpow_neg'
+    | n, none => rfl
+    | n, some _ => congr_arg some (DivInvMonoid.zpow_neg' _ _)
 
 instance divInvOneMonoid [DivInvOneMonoid α] : DivInvOneMonoid (WithZero α) where
   __ := divInvMonoid
@@ -230,16 +230,14 @@ instance involutiveInv [InvolutiveInv α] : InvolutiveInv (WithZero α) where
 instance divisionMonoid [DivisionMonoid α] : DivisionMonoid (WithZero α) where
   __ := divInvMonoid
   __ := involutiveInv
-  mul_inv_rev a b := match a, b with
+  mul_inv_rev
     | none, none => rfl
     | none, some _ => rfl
     | some _, none => rfl
     | some _, some _ => congr_arg some (mul_inv_rev _ _)
-  inv_eq_of_mul a b := match a, b with
-    | none, none => fun _ ↦ rfl
-    | none, some b => fun _ ↦ by contradiction
-    | some a, none => fun _ ↦ by contradiction
-    | some _, some _ => fun h ↦
+  inv_eq_of_mul
+    | none, none, _ => rfl
+    | some _, some _, h =>
       congr_arg some <| inv_eq_of_mul_eq_one_right <| Option.some_injective _ h
 
 instance divisionCommMonoid [DivisionCommMonoid α] : DivisionCommMonoid (WithZero α) where
@@ -260,7 +258,6 @@ instance groupWithZero : GroupWithZero (WithZero α) where
     norm_cast
     apply mul_inv_cancel
 
-
 /-- Any group is isomorphic to the units of itself adjoined with `0`. -/
 def unitsWithZeroEquiv : (WithZero α)ˣ ≃* α where
   toFun a := unzero a.ne_zero
@@ -277,9 +274,7 @@ def withZeroUnitsEquiv {G : Type*} [GroupWithZero G]
   invFun a := if h : a = 0 then 0 else (Units.mk0 a h : Gˣ)
   left_inv := (by induction · <;> simp)
   right_inv _ := by simp only; split <;> simp_all
-  map_mul' x y := by
-    induction x <;> induction y <;>
-    simp [← WithZero.coe_mul, ← Units.val_mul]
+  map_mul' := (by induction · <;> induction · <;> simp [← WithZero.coe_mul])
 
 /-- A version of `Equiv.optionCongr` for `WithZero`. -/
 noncomputable def _root_.MulEquiv.withZero [Group β] (e : α ≃* β) :
@@ -288,9 +283,7 @@ noncomputable def _root_.MulEquiv.withZero [Group β] (e : α ≃* β) :
   invFun := map' e.symm.toMonoidHom
   left_inv := (by induction · <;> simp)
   right_inv := (by induction · <;> simp)
-  map_mul' x y := by
-    induction x <;> induction y <;>
-    simp
+  map_mul' := (by induction · <;> induction · <;> simp)
 
 /-- The inverse of `MulEquiv.withZero`. -/
 protected noncomputable def _root_.MulEquiv.unzero [Group β] (e : WithZero α ≃* WithZero β) :
@@ -314,11 +307,6 @@ instance commGroupWithZero [CommGroup α] : CommGroupWithZero (WithZero α) :=
 instance addMonoidWithOne [AddMonoidWithOne α] : AddMonoidWithOne (WithZero α) where
   natCast n := if n = 0 then 0 else (n : α)
   natCast_zero := rfl
-  natCast_succ n := by
-    cases n with
-    | zero => show (((1 : ℕ) : α) : WithZero α) = 0 + 1; · rw [Nat.cast_one, coe_one, zero_add]
-    | succ n =>
-        show (((n + 2 : ℕ) : α) : WithZero α) = ((n + 1 : ℕ) : α) + 1
-        rw [Nat.cast_succ, coe_add, coe_one]
+  natCast_succ n := by cases n <;> simp
 
 end WithZero

--- a/Mathlib/Algebra/Module/Presentation/Cokernel.lean
+++ b/Mathlib/Algebra/Module/Presentation/Cokernel.lean
@@ -71,7 +71,7 @@ and one for each generator of `M₁`. -/
 def cokernelRelations : Relations A where
   G := pres₂.G
   R := Sum pres₂.R ι
-  relation x := match x with
+  relation
     | .inl r => pres₂.relation r
     | .inr i => data.lift i
 

--- a/Mathlib/Algebra/Module/Presentation/Tautological.lean
+++ b/Mathlib/Algebra/Module/Presentation/Tautological.lean
@@ -33,7 +33,7 @@ inductive tautological.R
 noncomputable def tautologicalRelations : Relations A where
   G := M
   R := tautological.R A M
-  relation r := match r with
+  relation
     | .add m₁ m₂ => Finsupp.single m₁ 1 + Finsupp.single m₂ 1 - Finsupp.single (m₁ + m₂) 1
     | .smul a m => a • Finsupp.single m 1 - Finsupp.single (a • m) 1
 

--- a/Mathlib/Algebra/Module/Presentation/Tensor.lean
+++ b/Mathlib/Algebra/Module/Presentation/Tensor.lean
@@ -32,7 +32,7 @@ noncomputable def tensor :
     Relations A where
   G := relations₁.G × relations₂.G
   R := Sum (relations₁.R × relations₂.G) (relations₁.G × relations₂.R)
-  relation r := match r with
+  relation
     | .inl ⟨r₁, g₂⟩ => Finsupp.embDomain (Function.Embedding.sectL relations₁.G g₂)
         (relations₁.relation r₁)
     | .inr ⟨g₁, r₂⟩ => Finsupp.embDomain (Function.Embedding.sectR g₁ relations₂.G)

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -24,15 +24,15 @@ variable [MulZeroClass α] {a b : WithTop α}
 
 instance instMulZeroClass : MulZeroClass (WithTop α) where
   zero := 0
-  mul a b := match a, b with
+  mul
     | (a : α), (b : α) => ↑(a * b)
     | (a : α), ⊤ => if a = 0 then 0 else ⊤
     | ⊤, (b : α) => if b = 0 then 0 else ⊤
     | ⊤, ⊤ => ⊤
-  mul_zero a := match a with
+  mul_zero
     | (a : α) => congr_arg some <| mul_zero _
     | ⊤ => if_pos rfl
-  zero_mul b := match b with
+  zero_mul
     | (b : α) => congr_arg some <| zero_mul _
     | ⊤ => if_pos rfl
 
@@ -93,10 +93,10 @@ end MulZeroClass
 /-- `Nontrivial α` is needed here as otherwise we have `1 * ⊤ = ⊤` but also `0 * ⊤ = 0`. -/
 instance instMulZeroOneClass [MulZeroOneClass α] [Nontrivial α] : MulZeroOneClass (WithTop α) where
   __ := instMulZeroClass
-  one_mul a := match a with
+  one_mul
     | ⊤ => mul_top (mt coe_eq_coe.1 one_ne_zero)
     | (a : α) => by rw [← coe_one, ← coe_mul, one_mul]
-  mul_one a := match a with
+  mul_one
     | ⊤ => top_mul (mt coe_eq_coe.1 one_ne_zero)
     | (a : α) => by rw [← coe_one, ← coe_mul, mul_one]
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -46,14 +46,14 @@ open WalkingPair
 /-- The equivalence swapping left and right.
 -/
 def WalkingPair.swap : WalkingPair ≃ WalkingPair where
-  toFun j := match j with
+  toFun
     | left => right
     | right => left
-  invFun j := match j with
+  invFun
     | left => right
     | right => left
-  left_inv j := by cases j; repeat rfl
-  right_inv j := by cases j; repeat rfl
+  left_inv j := by cases j <;> rfl
+  right_inv j := by cases j <;> rfl
 
 @[simp]
 theorem WalkingPair.swap_apply_left : WalkingPair.swap left = right :=
@@ -74,13 +74,13 @@ theorem WalkingPair.swap_symm_apply_ff : WalkingPair.swap.symm right = left :=
 /-- An equivalence from `WalkingPair` to `Bool`, sometimes useful when reindexing limits.
 -/
 def WalkingPair.equivBool : WalkingPair ≃ Bool where
-  toFun j := match j with
+  toFun
     | left => true
     | right => false
   -- to match equiv.sum_equiv_sigma_bool
   invFun b := Bool.recOn b right left
-  left_inv j := by cases j; repeat rfl
-  right_inv b := by cases b; repeat rfl
+  left_inv j := by cases j <;> rfl
+  right_inv b := by cases b <;> rfl
 
 @[simp]
 theorem WalkingPair.equivBool_apply_left : WalkingPair.equivBool left = true :=
@@ -136,7 +136,7 @@ attribute [local aesop safe tactic (rule_sets := [CategoryTheory])]
 /-- The natural transformation between two functors out of the
  walking pair, specified by its components. -/
 def mapPair : F ⟶ G where
-  app j := match j with
+  app
     | ⟨left⟩ => f
     | ⟨right⟩ => g
   naturality := fun ⟨X⟩ ⟨Y⟩ ⟨⟨u⟩⟩ => by aesop_cat

--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -160,7 +160,7 @@ variable {V' : Type*} [Quiver.{v' + 1} V']
 def lift [HasReverse V'] (φ : Prefunctor V V') :
     Prefunctor (Symmetrify V) V' where
   obj := φ.obj
-  map f := match f with
+  map
   | Sum.inl g => φ.map g
   | Sum.inr g => reverse (φ.map g)
 

--- a/Mathlib/Combinatorics/SimpleGraph/Sum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Sum.lean
@@ -29,11 +29,11 @@ namespace SimpleGraph
 /-- Disjoint sum of `G` and `H`. -/
 @[simps!]
 protected def sum (G : SimpleGraph α) (H : SimpleGraph β) : SimpleGraph (α ⊕ β) where
-  Adj u v := match u, v with
+  Adj
     | Sum.inl u, Sum.inl v => G.Adj u v
     | Sum.inr u, Sum.inr v => H.Adj u v
     | _, _ => false
-  symm u v := match u, v with
+  symm
     | Sum.inl u, Sum.inl v => G.adj_symm
     | Sum.inr u, Sum.inr v => H.adj_symm
     | Sum.inl _, Sum.inr _ | Sum.inr _, Sum.inl _ => id

--- a/Mathlib/Data/Sum/Lattice.lean
+++ b/Mathlib/Data/Sum/Lattice.lean
@@ -24,22 +24,22 @@ variable [SemilatticeSup α] [SemilatticeSup β]
 -- The linter significantly hinders readability here.
 set_option linter.unusedVariables false in
 instance instSemilatticeSup : SemilatticeSup (α ⊕ₗ β) where
-  sup x y := match x, y with
+  sup
     | inlₗ a₁, inlₗ a₂ => inl (a₁ ⊔ a₂)
     | inlₗ a₁, inrₗ b₂ => inr b₂
     | inrₗ b₁, inlₗ a₂ => inr b₁
     | inrₗ b₁, inrₗ b₂ => inr (b₁ ⊔ b₂)
-  le_sup_left x y := match x, y with
+  le_sup_left
     | inlₗ a₁, inlₗ a₂ => inl_le_inl_iff.2 le_sup_left
     | inlₗ a₁, inrₗ b₂ => inl_le_inr _ _
     | inrₗ b₁, inlₗ a₂ => le_rfl
     | inrₗ b₁, inrₗ b₂ => inr_le_inr_iff.2 le_sup_left
-  le_sup_right x y := match x, y with
+  le_sup_right
     | inlₗ a₁, inlₗ a₂ => inl_le_inl_iff.2 le_sup_right
     | inlₗ a₁, inrₗ b₂ => le_rfl
     | inrₗ b₁, inlₗ a₂ => inl_le_inr _ _
     | inrₗ b₁, inrₗ b₂ => inr_le_inr_iff.2 le_sup_right
-  sup_le x y z hxz hyz := match x, y, z, hxz, hyz with
+  sup_le
     | inlₗ a₁, inlₗ a₂, inlₗ a₃, Lex.inl h₁₃, Lex.inl h₂₃ => inl_le_inl_iff.2 <| sup_le h₁₃ h₂₃
     | inlₗ a₁, inlₗ a₂, inrₗ b₃, Lex.sep _ _, Lex.sep _ _ => Lex.sep _ _
     | inlₗ a₁, inrₗ b₂, inrₗ b₃, Lex.sep _ _, Lex.inr h₂₃ => inr_le_inr_iff.2 h₂₃
@@ -57,22 +57,22 @@ variable [SemilatticeInf α] [SemilatticeInf β]
 -- The linter significantly hinders readability here.
 set_option linter.unusedVariables false in
 instance instSemilatticeInf : SemilatticeInf (α ⊕ₗ β) where
-  inf x y := match x, y with
+  inf
     | inlₗ a₁, inlₗ a₂ => inl (a₁ ⊓ a₂)
     | inlₗ a₁, inrₗ b₂ => inl a₁
     | inrₗ b₁, inlₗ a₂ => inl a₂
     | inrₗ b₁, inrₗ b₂ => inr (b₁ ⊓ b₂)
-  inf_le_left x y := match x, y with
+  inf_le_left
     | inlₗ a₁, inlₗ a₂ => inl_le_inl_iff.2 inf_le_left
     | inlₗ a₁, inrₗ b₂ => le_rfl
     | inrₗ b₁, inlₗ a₂ => inl_le_inr _ _
     | inrₗ b₁, inrₗ b₂ => inr_le_inr_iff.2 inf_le_left
-  inf_le_right x y := match x, y with
+  inf_le_right
     | inlₗ a₁, inlₗ a₂ => inl_le_inl_iff.2 inf_le_right
     | inlₗ a₁, inrₗ b₂ => inl_le_inr _ _
     | inrₗ b₁, inlₗ a₂ => le_rfl
     | inrₗ b₁, inrₗ b₂ => inr_le_inr_iff.2 inf_le_right
-  le_inf x y z hzx hzy := match x, y, z, hzx, hzy with
+  le_inf
     | inlₗ a₁, inlₗ a₂, inlₗ a₃, Lex.inl h₁₃, Lex.inl h₂₃ => inl_le_inl_iff.2 <| le_inf h₁₃ h₂₃
     | inlₗ a₁, inlₗ a₂, inrₗ b₃, Lex.inl h₁₃, Lex.sep _ _ => inl_le_inl_iff.2 h₁₃
     | inlₗ a₁, inrₗ b₂, inlₗ a₃, Lex.sep _ _, Lex.inl h₂₃ => inl_le_inl_iff.2 h₂₃

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -103,12 +103,12 @@ theorem one_def : (1 : DihedralGroup n) = r 0 :=
   rfl
 
 private def fintypeHelper : (ZMod n) ⊕ (ZMod n) ≃ DihedralGroup n where
-  invFun i := match i with
-    | r j => Sum.inl j
-    | sr j => Sum.inr j
-  toFun i := match i with
-    | Sum.inl j => r j
-    | Sum.inr j => sr j
+  invFun
+    | r j => .inl j
+    | sr j => .inr j
+  toFun
+    | .inl j => r j
+    | .inr j => sr j
   left_inv := by rintro (x | x) <;> rfl
   right_inv := by rintro (x | x) <;> rfl
 

--- a/Mathlib/LinearAlgebra/ExteriorPower/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/Basic.lean
@@ -82,7 +82,7 @@ noncomputable def relations (ι : Type*) [DecidableEq ι] (M : Type*)
     Module.Relations R where
   G := ι → M
   R := Rels R ι M
-  relation r := match r with
+  relation
     | .add m i x y => Finsupp.single (update m i x) 1 +
         Finsupp.single (update m i y) 1 -
         Finsupp.single (update m i (x + y)) 1

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -286,12 +286,12 @@ theorem sumCongr_refl {α β} :
 /-- A subtype of a sum is equivalent to a sum of subtypes. -/
 def subtypeSum {α β} {p : α ⊕ β → Prop} :
     {c // p c} ≃ {a // p (Sum.inl a)} ⊕ {b // p (Sum.inr b)} where
-  toFun c := match h : c.1 with
-    | Sum.inl a => Sum.inl ⟨a, h ▸ c.2⟩
-    | Sum.inr b => Sum.inr ⟨b, h ▸ c.2⟩
-  invFun c := match c with
-    | Sum.inl a => ⟨Sum.inl a, a.2⟩
-    | Sum.inr b => ⟨Sum.inr b, b.2⟩
+  toFun
+    | ⟨.inl a, h⟩ => .inl ⟨a, h⟩
+    | ⟨.inr b, h⟩ => .inr ⟨b, h⟩
+  invFun
+    | .inl a => ⟨.inl a, a.2⟩
+    | .inr b => ⟨.inr b, b.2⟩
   left_inv := by rintro ⟨a | b, h⟩ <;> rfl
   right_inv := by rintro (a | b) <;> rfl
 

--- a/Mathlib/Order/Booleanisation.lean
+++ b/Mathlib/Order/Booleanisation.lean
@@ -51,7 +51,7 @@ algebra. -/
 
 /-- The complement operator on `Booleanisation α` sends `a` to `aᶜ` and `aᶜ` to `a`, for `a : α`. -/
 instance instCompl : HasCompl (Booleanisation α) where
-  compl x := match x with
+  compl
     | lift a => comp a
     | comp a => lift a
 
@@ -94,7 +94,7 @@ instance instLT : LT (Booleanisation α) where
 * `aᶜ ⊔ b` is `(a \ b)ᶜ`
 * `aᶜ ⊔ bᶜ` is `(a ⊓ b)ᶜ` -/
 instance instSup : Max (Booleanisation α) where
-  max x y := match x, y with
+  max
     | lift a, lift b => lift (a ⊔ b)
     | lift a, comp b => comp (b \ a)
     | comp a, lift b => comp (a \ b)
@@ -106,7 +106,7 @@ instance instSup : Max (Booleanisation α) where
 * `aᶜ ⊓ b` is `b \ a`
 * `aᶜ ⊓ bᶜ` is `(a ⊔ b)ᶜ` -/
 instance instInf : Min (Booleanisation α) where
-  min x y := match x, y with
+  min
     | lift a, lift b => lift (a ⊓ b)
     | lift a, comp b => lift (a \ b)
     | comp a, lift b => lift (b \ a)
@@ -126,7 +126,7 @@ instance instTop : Top (Booleanisation α) where
 * `aᶜ \ b` is `(a ⊔ b)ᶜ`
 * `aᶜ \ bᶜ` is `b \ a` -/
 instance instSDiff : SDiff (Booleanisation α) where
-  sdiff x y := match x, y with
+  sdiff
     | lift a, lift b => lift (a \ b)
     | lift a, comp b => lift (a ⊓ b)
     | comp a, lift b => comp (a ⊔ b)
@@ -162,22 +162,22 @@ instance instSDiff : SDiff (Booleanisation α) where
 
 instance instPreorder : Preorder (Booleanisation α) where
   lt := (· < ·)
-  lt_iff_le_not_le x y := match x, y with
+  lt_iff_le_not_le
     | lift a, lift b => by simp [lt_iff_le_not_le]
     | lift a, comp b => by simp
     | comp a, lift b => by simp
     | comp a, comp b => by simp [lt_iff_le_not_le]
-  le_refl x := match x with
+  le_refl
     | lift _ => LE.lift le_rfl
     | comp _ => LE.comp le_rfl
-  le_trans x y z hxy hyz := match x, y, z, hxy, hyz with
+  le_trans
     | lift _, lift _, lift _, LE.lift hab, LE.lift hbc => LE.lift <| hab.trans hbc
     | lift _, lift _, comp _, LE.lift hab, LE.sep hbc => LE.sep <| hbc.mono_left hab
     | lift _, comp _, comp _, LE.sep hab, LE.comp hcb => LE.sep <| hab.mono_right hcb
     | comp _, comp _, comp _, LE.comp hba, LE.comp hcb => LE.comp <| hcb.trans hba
 
 instance instPartialOrder : PartialOrder (Booleanisation α) where
-  le_antisymm x y hxy hyx := match x, y, hxy, hyx with
+  le_antisymm
     | lift a, lift b, LE.lift hab, LE.lift hba => by rw [hab.antisymm hba]
     | comp a, comp b, LE.comp hab, LE.comp hba => by rw [hab.antisymm hba]
 
@@ -185,17 +185,17 @@ instance instPartialOrder : PartialOrder (Booleanisation α) where
 set_option linter.unusedVariables false in
 instance instSemilatticeSup : SemilatticeSup (Booleanisation α) where
   sup x y := max x y
-  le_sup_left x y := match x, y with
+  le_sup_left
     | lift a, lift b => LE.lift le_sup_left
     | lift a, comp b => LE.sep disjoint_sdiff_self_right
     | comp a, lift b => LE.comp sdiff_le
     | comp a, comp b => LE.comp inf_le_left
-  le_sup_right x y := match x, y with
+  le_sup_right
     | lift a, lift b => LE.lift le_sup_right
     | lift a, comp b => LE.comp sdiff_le
     | comp a, lift b => LE.sep disjoint_sdiff_self_right
     | comp a, comp b => LE.comp inf_le_right
-  sup_le x y z hxz hyz := match x, y, z, hxz, hyz with
+  sup_le
     | lift a, lift b, lift c, LE.lift hac, LE.lift hbc => LE.lift <| sup_le hac hbc
     | lift a, lift b, comp c, LE.sep hac, LE.sep hbc => LE.sep <| hac.sup_left hbc
     | lift a, comp b, comp c, LE.sep hac, LE.comp hcb => LE.comp <| le_sdiff.2 ⟨hcb, hac.symm⟩
@@ -206,17 +206,17 @@ instance instSemilatticeSup : SemilatticeSup (Booleanisation α) where
 set_option linter.unusedVariables false in
 instance instSemilatticeInf : SemilatticeInf (Booleanisation α) where
   inf x y := min x y
-  inf_le_left x y := match x, y with
+  inf_le_left
     | lift a, lift b => LE.lift inf_le_left
     | lift a, comp b => LE.lift sdiff_le
     | comp a, lift b => LE.sep disjoint_sdiff_self_left
     | comp a, comp b => LE.comp le_sup_left
-  inf_le_right x y := match x, y with
+  inf_le_right
     | lift a, lift b => LE.lift inf_le_right
     | lift a, comp b => LE.sep disjoint_sdiff_self_left
     | comp a, lift b => LE.lift sdiff_le
     | comp a, comp b => LE.comp le_sup_right
-  le_inf x y z hxz hyz := match x, y, z, hxz, hyz with
+  le_inf
     | lift a, lift b, lift c, LE.lift hab, LE.lift hac => LE.lift <| le_inf hab hac
     | lift a, lift b, comp c, LE.lift hab, LE.sep hac => LE.lift <| le_sdiff.2 ⟨hab, hac⟩
     | lift a, comp b, lift c, LE.sep hab, LE.lift hac => LE.lift <| le_sdiff.2 ⟨hac, hab⟩
@@ -227,7 +227,7 @@ instance instDistribLattice : DistribLattice (Booleanisation α) where
   inf_le_left _ _ := inf_le_left
   inf_le_right _ _ := inf_le_right
   le_inf _ _ _ := le_inf
-  le_sup_inf x y z := match x, y, z with
+  le_sup_inf
     | lift _, lift _, lift _ => LE.lift le_sup_inf
     | lift a, lift b, comp c => LE.lift <| by simp [sup_left_comm, sup_comm, sup_assoc]
     | lift a, comp b, lift c => LE.lift <| by
@@ -241,23 +241,23 @@ instance instDistribLattice : DistribLattice (Booleanisation α) where
 -- The linter significantly hinders readability here.
 set_option linter.unusedVariables false in
 instance instBoundedOrder : BoundedOrder (Booleanisation α) where
-  le_top x := match x with
+  le_top
     | lift a => LE.sep disjoint_bot_right
     | comp a => LE.comp bot_le
-  bot_le x := match x with
+  bot_le
     | lift a => LE.lift bot_le
     | comp a => LE.sep disjoint_bot_left
 
 instance instBooleanAlgebra : BooleanAlgebra (Booleanisation α) where
   le_top _ := le_top
   bot_le _ := bot_le
-  inf_compl_le_bot x := match x with
+  inf_compl_le_bot
     | lift a => by simp
     | comp a => by simp
-  top_le_sup_compl x := match x with
+  top_le_sup_compl
     | lift a => by simp
     | comp a => by simp
-  sdiff_eq x y := match x, y with
+  sdiff_eq
     | lift a, lift b => by simp
     | lift a, comp b => by simp
     | comp a, lift b => by simp

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -134,7 +134,7 @@ def zip (c₀ : Chain α) (c₁ : Chain β) : Chain (α × β) :=
 
 /-- An example of a `Chain` constructed from an ordered pair. -/
 def pair (a b : α) (hab : a ≤ b) : Chain α where
-  toFun n := match n with
+  toFun
     | 0 => a
     | _ => b
   monotone' _ _ _ := by aesop

--- a/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
+++ b/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
@@ -256,10 +256,10 @@ private def secondRow : ComposableArrows (ModuleCat (AdicCompletion I R)) 4 :=
 include hf
 
 private lemma firstRow_exact : (firstRow I M f).Exact where
-  zero k _ := match k with
-    | 0 => ModuleCat.hom_ext (tens_exact I M f hf).linearMap_comp_eq_zero
-    | 1 => ModuleCat.hom_ext (LinearMap.zero_comp _)
-    | 2 => ModuleCat.hom_ext (LinearMap.zero_comp 0)
+  zero
+    | 0, _ => ModuleCat.hom_ext (tens_exact I M f hf).linearMap_comp_eq_zero
+    | 1, _ => ModuleCat.hom_ext (LinearMap.zero_comp _)
+    | 2, _ => ModuleCat.hom_ext (LinearMap.zero_comp 0)
   exact k _ := by
     rw [ShortComplex.moduleCat_exact_iff]
     match k with
@@ -268,10 +268,10 @@ private lemma firstRow_exact : (firstRow I M f).Exact where
     | 2 => intro _ _; exact ⟨0, rfl⟩
 
 private lemma secondRow_exact [Fintype ι] [IsNoetherianRing R] : (secondRow I M f).Exact where
-  zero k _ := match k with
-    | 0 => ModuleCat.hom_ext (adic_exact I M f hf).linearMap_comp_eq_zero
-    | 1 => ModuleCat.hom_ext (LinearMap.zero_comp (map I f))
-    | 2 => ModuleCat.hom_ext (LinearMap.zero_comp 0)
+  zero
+    | 0, _ => ModuleCat.hom_ext (adic_exact I M f hf).linearMap_comp_eq_zero
+    | 1, _ => ModuleCat.hom_ext (LinearMap.zero_comp (map I f))
+    | 2, _ => ModuleCat.hom_ext (LinearMap.zero_comp 0)
   exact k _ := by
     rw [ShortComplex.moduleCat_exact_iff]
     match k with


### PR DESCRIPTION
This is valid and shorter syntax.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
