### PR TITLE
feat: establish additivity of AnalyticAt.order under multiplication/powers of analytic functions

### DIFF
--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -274,9 +274,11 @@ theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : Anal
 /-- The order multiplies by `n` when taking an analytic function to its `n`th power. -/
 theorem order_pow {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
     (hf.pow n).order = n * hf.order := by
-  induction' n with n hn
-  · simp [AnalyticAt.order_eq_zero_iff]
-  · simp [add_mul, pow_add, (hf.pow n).order_mul hf, hn]
+  induction n
+  case zero =>
+    simp [AnalyticAt.order_eq_zero_iff]
+  case succ n hn =>
+    simp [add_mul, pow_add, (hf.pow n).order_mul hf, hn]
 
 end AnalyticAt
 

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -241,7 +241,7 @@ lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
   tauto
 
 /- Helper lemma for `AnalyticAt.order_mul` -/
-lemma order_eq_top_of_order_eq_top_mul_analytic {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
+lemma order_mul_of_order_eq_top {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
     (hg : AnalyticAt 𝕜 g z₀) (h'f : hf.order = ⊤) :
     (hf.mul hg).order = ⊤ := by
   rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff] at *

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -253,10 +253,10 @@ theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : Anal
     (hf.mul hg).order = hf.order + hg.order := by
   -- Trivial cases: one of the functions vanishes around z₀
   by_cases h₂f : hf.order = ⊤
-  · simp [hf.order_eq_top_of_order_eq_top_mul_analytic hg h₂f, h₂f]
+  · simp [hf.order_mul_of_order_eq_top hg h₂f, h₂f]
   by_cases h₂g : hg.order = ⊤
   · have : (fun x ↦ f x * g x) = (fun x ↦ g x * f x) := by simp_rw [mul_comm]
-    simp [this, hg.order_eq_top_of_order_eq_top_mul_analytic hf h₂g, h₂g]
+    simp [this, hg.order_mul_of_order_eq_top hf h₂g, h₂g]
 
   -- Non-trivial case: both functions do not vanish around z₀
   obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf.order_neq_top_iff.1 h₂f

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -240,40 +240,38 @@ lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
   simp [hf.order_eq_zero_iff]
   tauto
 
-/-- Helper lemma for `AnalyticAt.order_mul` -/
-lemma order_of_locallyZero_mul_analytic {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
+/- Helper lemma for `AnalyticAt.order_mul` -/
+lemma order_eq_top_of_order_eq_top_mul_analytic {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
   (hg : AnalyticAt 𝕜 g z₀) (h'f : hf.order = ⊤) :
     (hf.mul hg).order = ⊤ := by
   rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff] at *
   obtain ⟨t, h₁t, h₂t, h₃t⟩ := h'f
   exact ⟨t, fun y hy ↦ (by rw [h₁t y hy]; ring), h₂t, h₃t⟩
 
-/-- The order is additive when multiplying analytic functions -/
+/-- The order is additive when multiplying analytic functions. -/
 theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
     (hf.mul hg).order = hf.order + hg.order := by
   -- Trivial cases: one of the functions vanishes around z₀
   by_cases h₂f : hf.order = ⊤
-  · simp [hf.order_of_locallyZero_mul_analytic hg h₂f, h₂f]
+  · simp [hf.order_eq_top_of_order_eq_top_mul_analytic hg h₂f, h₂f]
   by_cases h₂g : hg.order = ⊤
   · have : (fun x ↦ f x * g x) = (fun x ↦ g x * f x) := by simp_rw [mul_comm]
-    simp [this, hg.order_of_locallyZero_mul_analytic hf h₂g, h₂g]
+    simp [this, hg.order_eq_top_of_order_eq_top_mul_analytic hf h₂g, h₂g]
 
   -- Non-trivial case: both functions do not vanish around z₀
   obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf.order_neq_top_iff.1 h₂f
   obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := hg.order_neq_top_iff.1 h₂g
   rw [← ENat.coe_toNat h₂f, ← ENat.coe_toNat h₂g, ← ENat.coe_add, (hf.mul hg).order_eq_nat_iff]
-  use g₁ * g₂
+  use g₁ * g₂, by exact h₁g₁.mul h₁g₂
   constructor
-  · exact h₁g₁.mul h₁g₂
-  · constructor
-    · simp
-      tauto
-    · obtain ⟨t, h₁t, h₂t, h₃t⟩ := eventually_nhds_iff.1 h₃g₁
-      obtain ⟨s, h₁s, h₂s, h₃s⟩ := eventually_nhds_iff.1 h₃g₂
-      exact eventually_nhds_iff.2
-        ⟨t ∩ s, fun y hy ↦ (by rw [h₁t y hy.1, h₁s y hy.2]; simp; ring), h₂t.inter h₂s, h₃t, h₃s⟩
+  · simp
+    tauto
+  · obtain ⟨t, h₁t, h₂t, h₃t⟩ := eventually_nhds_iff.1 h₃g₁
+    obtain ⟨s, h₁s, h₂s, h₃s⟩ := eventually_nhds_iff.1 h₃g₂
+    exact eventually_nhds_iff.2
+      ⟨t ∩ s, fun y hy ↦ (by rw [h₁t y hy.1, h₁s y hy.2]; simp; ring), h₂t.inter h₂s, h₃t, h₃s⟩
 
-/-- The order multiplies by `n` when taking an analytic function to its `n`th power -/
+/-- The order multiplies by `n` when taking an analytic function to its `n`th power. -/
 theorem order_pow {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
     (hf.pow n).order = n * hf.order := by
   induction' n with n hn

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -240,6 +240,46 @@ lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
   simp [hf.order_eq_zero_iff]
   tauto
 
+/-- Helper lemma for `AnalyticAt.order_mul` -/
+lemma order_of_locallyZero_mul_analytic {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
+  (hg : AnalyticAt 𝕜 g z₀) (h'f : hf.order = ⊤) :
+    (hf.mul hg).order = ⊤ := by
+  rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff] at *
+  obtain ⟨t, h₁t, h₂t, h₃t⟩ := h'f
+  exact ⟨t, fun y hy ↦ (by rw [h₁t y hy]; ring), h₂t, h₃t⟩
+
+/-- The order is additive when multiplying analytic functions -/
+theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+    (hf.mul hg).order = hf.order + hg.order := by
+  -- Trivial cases: one of the functions vanishes around z₀
+  by_cases h₂f : hf.order = ⊤
+  · simp [hf.order_of_locallyZero_mul_analytic hg h₂f, h₂f]
+  by_cases h₂g : hg.order = ⊤
+  · have : (fun x ↦ f x * g x) = (fun x ↦ g x * f x) := by simp_rw [mul_comm]
+    simp [this, hg.order_of_locallyZero_mul_analytic hf h₂g, h₂g]
+
+  -- Non-trivial case: both functions do not vanish around z₀
+  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf.order_neq_top_iff.1 h₂f
+  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := hg.order_neq_top_iff.1 h₂g
+  rw [← ENat.coe_toNat h₂f, ← ENat.coe_toNat h₂g, ← ENat.coe_add, (hf.mul hg).order_eq_nat_iff]
+  use g₁ * g₂
+  constructor
+  · exact h₁g₁.mul h₁g₂
+  · constructor
+    · simp
+      tauto
+    · obtain ⟨t, h₁t, h₂t, h₃t⟩ := eventually_nhds_iff.1 h₃g₁
+      obtain ⟨s, h₁s, h₂s, h₃s⟩ := eventually_nhds_iff.1 h₃g₂
+      exact eventually_nhds_iff.2
+        ⟨t ∩ s, fun y hy ↦ (by rw [h₁t y hy.1, h₁s y hy.2]; simp; ring), h₂t.inter h₂s, h₃t, h₃s⟩
+
+/-- The order multiplies by `n` when taking an analytic function to its `n`th power -/
+theorem order_pow {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
+    (hf.pow n).order = n * hf.order := by
+  induction' n with n hn
+  · simp [AnalyticAt.order_eq_zero_iff]
+  · simp [add_mul, pow_add, (hf.pow n).order_mul hf, hn]
+
 end AnalyticAt
 
 namespace AnalyticOnNhd

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -242,7 +242,7 @@ lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
 
 /- Helper lemma for `AnalyticAt.order_mul` -/
 lemma order_eq_top_of_order_eq_top_mul_analytic {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
-  (hg : AnalyticAt 𝕜 g z₀) (h'f : hf.order = ⊤) :
+    (hg : AnalyticAt 𝕜 g z₀) (h'f : hf.order = ⊤) :
     (hf.mul hg).order = ⊤ := by
   rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff] at *
   obtain ⟨t, h₁t, h₂t, h₃t⟩ := h'f


### PR DESCRIPTION
These theorems are used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
