### PR TITLE
feat: lint against the tactic.skipAssignedInstances option in mathlib

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -118,7 +118,6 @@ macro_rules | `(!$p:subscript[$e:term,*]) => do
   let n := e.getElems.size
   `((WithLp.equiv $p <| ∀ _ : Fin $(quote n), _).symm ![$e,*])
 
-set_option trace.debug true in
 /-- Unexpander for the `!₂[x, y, ...]` notation. -/
 @[app_delab DFunLike.coe]
 def EuclideanSpace.delabVecNotation : Delab :=

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -80,7 +80,7 @@ The latter option was only added for backwards compatibility, and new uses shoul
 **How to fix this?** Remove these options: usually, they are not necessary for production code.
 (Some tests will intentionally use one of these options; in this case, simply allow the linter.)
 -/
-def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
+def setOptionLinter : Linter where run stx := do
     unless Linter.getLinterValue linter.style.setOption (← getOptions) do
       return
     if (← MonadState.get).messages.hasErrors then

--- a/Mathlib/Topology/Separation/Regular.lean
+++ b/Mathlib/Topology/Separation/Regular.lean
@@ -448,7 +448,6 @@ instance (priority := 100) NormalSpace.of_compactSpace_r1Space [CompactSpace X] 
     NormalSpace X where
   normal _s _t hs ht := .of_isCompact_isCompact_isClosed hs.isCompact ht.isCompact ht
 
-set_option pp.universes true in
 /-- A regular topological space with a Lindelöf topology is a normal space. A consequence of e.g.
 Corollaries 20.8 and 20.10 of [Willard's *General Topology*][zbMATH02107988] (without the
 assumption of Hausdorff). -/

--- a/MathlibTest/LintStyle.lean
+++ b/MathlibTest/LintStyle.lean
@@ -67,6 +67,31 @@ set_option debug.moduleNameAtTimeout false
 -- The lint does not fire on arbitrary options.
 set_option autoImplicit false
 
+-- A top-level `set_option ... in` is also linted against, also with several options.
+
+/--
+warning: Setting options starting with 'debug', 'pp', 'profiler', 'trace' is only intended for development and not for final code. If you intend to submit this contribution to the Mathlib project, please remove 'set_option profiler.threshold'.
+note: this linter can be disabled with `set_option linter.style.setOption false`
+-/
+#guard_msgs in
+set_option profiler.threshold 50 in
+lemma topLevelIn : True := trivial
+
+-- TODO: only the first warning is shown, FIX THIS!
+/--
+warning: The 'tactic.skipAssignedInstances' option was only added for backwards compatibility with existing code: please do not add new uses of it.
+note: this linter can be disabled with `set_option linter.style.setOption false`
+-/
+#guard_msgs in
+set_option tactic.skipAssignedInstances true in
+set_option profiler.threshold 5 in
+lemma topLevelIn' : True := trivial
+
+#guard_msgs in
+set_option autoImplicit true in
+set_option profiler.threshold 5 in
+lemma topLevelIn'' : True := trivial
+
 -- We also cover set_option tactics.
 
 /--
@@ -114,6 +139,8 @@ lemma tactic4 : True := by
   trivial
 
 -- This option is not affected, hence does not throw an error.
+set_option autoImplicit false
+
 set_option autoImplicit true in
 lemma foo' : True := trivial
 
@@ -125,7 +152,6 @@ note: this linter can be disabled with `set_option linter.style.setOption false`
 -/
 #guard_msgs in
 set_option tactic.skipAssignedInstances true
-lemma skipAssInst : True := trivial
 
 -- Currently, we also warn about setting the linter to `false`.
 /--
@@ -134,9 +160,12 @@ note: this linter can be disabled with `set_option linter.style.setOption false`
 -/
 #guard_msgs in
 set_option tactic.skipAssignedInstances false
-lemma skipAssInst' : True := trivial
 
--- TODO: this should warn!
+/--
+warning: The 'tactic.skipAssignedInstances' option was only added for backwards compatibility with existing code: please do not add new uses of it.
+note: this linter can be disabled with `set_option linter.style.setOption false`
+-/
+#guard_msgs in
 set_option tactic.skipAssignedInstances true in
 lemma skipAssInst'' : True := trivial
 

--- a/MathlibTest/LintStyle.lean
+++ b/MathlibTest/LintStyle.lean
@@ -117,7 +117,28 @@ lemma tactic4 : True := by
 set_option autoImplicit true in
 lemma foo' : True := trivial
 
--- TODO: add terms for the term form
+-- TODO: add tests for the term form
+
+/--
+warning: The 'tactic.skipAssignedInstances' option was only added for backwards compatibility with existing code: please do not add new uses of it.
+note: this linter can be disabled with `set_option linter.style.setOption false`
+-/
+#guard_msgs in
+set_option tactic.skipAssignedInstances true
+lemma skipAssInst : True := trivial
+
+-- Currently, we also warn about setting the linter to `false`.
+/--
+warning: The 'tactic.skipAssignedInstances' option was only added for backwards compatibility with existing code: please do not add new uses of it.
+note: this linter can be disabled with `set_option linter.style.setOption false`
+-/
+#guard_msgs in
+set_option tactic.skipAssignedInstances false
+lemma skipAssInst' : True := trivial
+
+-- TODO: this should warn!
+set_option tactic.skipAssignedInstances true in
+lemma skipAssInst'' : True := trivial
 
 end setOption
 

--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -76,7 +76,6 @@ tdc () {
 titlesPathsAndRegexes=(
   "porting notes"                  "*"      "Porting note"
   "backwards compatibility flags"  "*"      "set_option.*backward"
-  "skipAssignedInstances flags"    "*"      "set_option tactic.skipAssignedInstances"
   "adaptation notes"               "*"      "adaptation_note"
   "disabled simpNF lints"          "*"      "nolint simpNF"
   "erw"                            "*"      "erw \["


### PR DESCRIPTION
This means we can remove the corresponding technical debt entry. We also correct some outdated details in the Linter/Style.lean docstring.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
