### PR TITLE
[Merged by Bors] - chore(100,1000.yaml): name the authors field 'authors'

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -8,24 +8,24 @@
 1:
   title  : The Irrationality of the Square Root of 2
   decl   : irrational_sqrt_two
-  author : mathlib
+  authors: mathlib
 2:
   title  : Fundamental Theorem of Algebra
   decl   : Complex.exists_root
-  author : Chris Hughes
+  authors: Chris Hughes
 3:
   title  : The Denumerability of the Rational Numbers
   decl   : Rat.instDenumerable
-  author : Chris Hughes
+  authors: Chris Hughes
 4:
   title  : Pythagorean Theorem
   decl   : EuclideanGeometry.dist_sq_eq_dist_sq_add_dist_sq_iff_angle_eq_pi_div_two
-  author : Joseph Myers
+  authors: Joseph Myers
 5:
   title  : Prime Number Theorem
 6:
   title  : Gödel’s Incompleteness Theorem
-  author : Shogo Saito
+  authors: Shogo Saito
   links  :
     First incompleteness theorem: https://github.com/FormalizedFormalLogic/Incompleteness/blob/master/Incompleteness/Arith/First.lean
     Second incompleteness theorem: https://github.com/FormalizedFormalLogic/Incompleteness/blob/master/Incompleteness/Arith/Second.lean
@@ -35,21 +35,21 @@
   decls  :
     - legendreSym.quadratic_reciprocity
     - jacobiSym.quadratic_reciprocity
-  author : Chris Hughes (first) and Michael Stoll (second)
+  authors: Chris Hughes (first) and Michael Stoll (second)
 8:
   title  : The Impossibility of Trisecting the Angle and Doubling the Cube
 9:
   title  : The Area of a Circle
   decl   : Theorems100.area_disc
-  author : James Arthur and Benjamin Davidson and Andrew Souther
+  authors: James Arthur and Benjamin Davidson and Andrew Souther
 10:
   title  : Euler’s Generalization of Fermat’s Little Theorem
   decl   : Nat.ModEq.pow_totient
-  author : Chris Hughes
+  authors: Chris Hughes
 11:
   title  : The Infinitude of Primes
   decl   : Nat.exists_infinite_primes
-  author : Jeremy Avigad
+  authors: Jeremy Avigad
 12:
   title  : The Independence of the Parallel Postulate
 13:
@@ -57,46 +57,46 @@
 14:
   title  : Euler’s Summation of 1 + (1/2)^2 + (1/3)^2 + ….
   decl   : hasSum_zeta_two
-  author : Marc Masdeu and David Loeffler
+  authors: Marc Masdeu and David Loeffler
 15:
   title  : Fundamental Theorem of Integral Calculus
   decls  :
     - intervalIntegral.integral_hasStrictDerivAt_of_tendsto_ae_right
     - intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le
-  author : Yury G. Kudryashov (first) and Benjamin Davidson (second)
+  authors: Yury G. Kudryashov (first) and Benjamin Davidson (second)
 16:
   title  : Insolvability of General Higher Degree Equations (Abel-Ruffini Theorem)
-  author : Thomas Browning
+  authors: Thomas Browning
   decl   : AbelRuffini.exists_not_solvable_by_rad
 17:
   title  : De Moivre’s Formula
   decl   : Complex.cos_add_sin_mul_I_pow
-  author : Abhimanyu Pallavi Sudhir
+  authors: Abhimanyu Pallavi Sudhir
 18:
   title  : Liouville’s Theorem and the Construction of Transcendental Numbers
-  author : Jujian Zhang
+  authors: Jujian Zhang
   decl   :  Liouville.transcendental
 19:
   title  : Four Squares Theorem
   decl   : Nat.sum_four_squares
-  author : Chris Hughes
+  authors: Chris Hughes
 20:
   title  : All Primes (1 mod 4) Equal the Sum of Two Squares
   decl   : Nat.Prime.sq_add_sq
-  author : Chris Hughes
+  authors: Chris Hughes
 21:
   title  : Green’s Theorem
 22:
   title  : The Non-Denumerability of the Continuum
   decl   : Cardinal.not_countable_real
-  author : Floris van Doorn
+  authors: Floris van Doorn
 23:
   title  : Formula for Pythagorean Triples
   decl   : PythagoreanTriple.classification
-  author : Paul van Wamelen
+  authors: Paul van Wamelen
 24:
   title  : The Independence of the Continuum Hypothesis
-  author : Jesse Michael Han and Floris van Doorn
+  authors: Jesse Michael Han and Floris van Doorn
   links  :
     result: https://github.com/flypitch/flypitch/blob/master/src/summary.lean
     website: https://flypitch.github.io/
@@ -104,26 +104,26 @@
 25:
   title  : Schroeder-Bernstein Theorem
   decl   : Function.Embedding.schroeder_bernstein
-  author : Mario Carneiro
+  authors: Mario Carneiro
 26:
   title  : Leibniz’s Series for Pi
   decl   : Real.tendsto_sum_pi_div_four
-  author : Benjamin Davidson
+  authors: Benjamin Davidson
 27:
   title  : Sum of the Angles of a Triangle
   decl   : EuclideanGeometry.angle_add_angle_add_angle_eq_pi
-  author : Joseph Myers
+  authors: Joseph Myers
 28:
   title  : Pascal’s Hexagon Theorem
 29:
   title  : Feuerbach’s Theorem
 30:
   title  : The Ballot Problem
-  author : Bhavik Mehta and Kexing Ying
+  authors: Bhavik Mehta and Kexing Ying
   decl   : Ballot.ballot_problem
 31:
   title  : Ramsey’s Theorem
-  author : Bhavik Mehta
+  authors: Bhavik Mehta
   links  :
     result: https://github.com/b-mehta/combinatorics/blob/extras/src/inf_ramsey.lean
 32:
@@ -135,156 +135,156 @@
 34:
   title  : Divergence of the Harmonic Series
   decl   : Real.tendsto_sum_range_one_div_nat_succ_atTop
-  author : Anatole Dedecker and Yury Kudryashov
+  authors: Anatole Dedecker and Yury Kudryashov
 35:
   title  : Taylor’s Theorem
   decls  :
     - taylor_mean_remainder_lagrange
     - taylor_mean_remainder_cauchy
-  author : Moritz Doll
+  authors: Moritz Doll
 36:
   title  : Brouwer Fixed Point Theorem
-  author : Brendan Seamas Murphy
+  authors: Brendan Seamas Murphy
   links  :
     result: https://github.com/Shamrock-Frost/BrouwerFixedPoint/blob/master/src/brouwer_fixed_point.lean
 37:
   title  : The Solution of a Cubic
-  author : Jeoff Lee
+  authors: Jeoff Lee
   decl   : Theorems100.cubic_eq_zero_iff
 38:
   title  : Arithmetic Mean/Geometric Mean
   decl   : Real.geom_mean_le_arith_mean_weighted
-  author : Yury G. Kudryashov
+  authors: Yury G. Kudryashov
 39:
   title  : Solutions to Pell’s Equation
   decls  :
     - Pell.eq_pell
     - Pell.exists_of_not_isSquare
-  author : Mario Carneiro (first), Michael Stoll (second)
+  authors: Mario Carneiro (first), Michael Stoll (second)
   note   : "In `pell.eq_pell`, `d` is defined to be `a*a - 1` for an arbitrary `a > 1`."
 40:
   title  : Minkowski’s Fundamental Theorem
   decl   : MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure
-  author : Alex J. Best and Yaël Dillies
+  authors: Alex J. Best and Yaël Dillies
 41:
   title  : Puiseux’s Theorem
 42:
   title  : Sum of the Reciprocals of the Triangular Numbers
-  author : Jalex Stark and Yury Kudryashov
+  authors: Jalex Stark and Yury Kudryashov
   decl   : Theorems100.inverse_triangle_sum
 43:
   title  : The Isoperimetric Theorem
 44:
   title  : The Binomial Theorem
   decl   : add_pow
-  author : Chris Hughes
+  authors: Chris Hughes
 45:
   title  : The Partition Theorem
-  author : Bhavik Mehta and Aaron Anderson
+  authors: Bhavik Mehta and Aaron Anderson
   decl   : Theorems100.partition_theorem
 46:
   title  : The Solution of the General Quartic Equation
   decl   : Theorems100.quartic_eq_zero_iff
-  author : Thomas Zhu
+  authors: Thomas Zhu
 47:
   title  : The Central Limit Theorem
 48:
   title  : Dirichlet’s Theorem
   decl   : Nat.setOf_prime_and_eq_mod_infinite
-  author : David Loeffler, Michael Stoll
+  authors: David Loeffler, Michael Stoll
 49:
   title  : The Cayley-Hamilton Theorem
   decl   : Matrix.aeval_self_charpoly
-  author : Kim Morrison
+  authors: Kim Morrison
 50:
   title  : The Number of Platonic Solids
 51:
   title  : Wilson’s Lemma
   decl   : ZMod.wilsons_lemma
-  author : Chris Hughes
+  authors: Chris Hughes
 52:
   title  : The Number of Subsets of a Set
   decl   : Finset.card_powerset
-  author : mathlib
+  authors: mathlib
 53:
   title  : Pi is Transcendental
 54:
   title  : Königsberg Bridges Problem
   decl   : Konigsberg.not_isEulerian
-  author : Kyle Miller
+  authors: Kyle Miller
 55:
   title  : Product of Segments of Chords
   decl   : EuclideanGeometry.mul_dist_eq_mul_dist_of_cospherical_of_angle_eq_pi
-  author : Manuel Candales
+  authors: Manuel Candales
 56:
   title  : The Hermite-Lindemann Transcendence Theorem
 57:
   title  : Heron’s Formula
   decl   : Theorems100.heron
-  author : Matt Kempster
+  authors: Matt Kempster
 58:
   title  : Formula for the Number of Combinations
   decls  :
     - Finset.card_powersetCard
     - Finset.mem_powersetCard
-  author : mathlib <!--Jeremy Avigad in lean 2-->
+  authors: mathlib <!--Jeremy Avigad in lean 2-->
 59:
   title  : The Laws of Large Numbers
   decl   : ProbabilityTheory.strong_law_ae
-  author : Sébastien Gouëzel
+  authors: Sébastien Gouëzel
 60:
   title  : Bezout’s Theorem
   decl   : Nat.gcd_eq_gcd_ab
-  author : mathlib
+  authors: mathlib
 61:
   title  : Theorem of Ceva
 62:
   title  : Fair Games Theorem
   decl   : MeasureTheory.submartingale_iff_expected_stoppedValue_mono
-  author : Kexing Ying
+  authors: Kexing Ying
 63:
   title  : Cantor’s Theorem
   decl: Function.cantor_surjective
-  author : Johannes Hölzl and Mario Carneiro
+  authors: Johannes Hölzl and Mario Carneiro
 64:
   title  : L’Hopital’s Rule
   decl   : deriv.lhopital_zero_nhds
-  author : Anatole Dedecker
+  authors: Anatole Dedecker
 65:
   title  : Isosceles Triangle Theorem
   decl   : EuclideanGeometry.angle_eq_angle_of_dist_eq
-  author : Joseph Myers
+  authors: Joseph Myers
 66:
   title  : Sum of a Geometric Series
   decls  :
     - geom_sum_Ico
     - NNReal.hasSum_geometric
-  author : Sander R. Dahmen (finite) and Johannes Hölzl (infinite)
+  authors: Sander R. Dahmen (finite) and Johannes Hölzl (infinite)
 67:
   title  : e is Transcendental
-  author : Jujian Zhang
+  authors: Jujian Zhang
   links  :
     result: https://github.com/jjaassoonn/transcendental/blob/master/src/e_transcendental.lean
     website: https://jjaassoonn.github.io/transcendental/
 68:
   title  : Sum of an arithmetic series
   decl   : Finset.sum_range_id
-  author : Johannes Hölzl
+  authors: Johannes Hölzl
 69:
   title  : Greatest Common Divisor Algorithm
   decls  :
     - EuclideanDomain.gcd
     - EuclideanDomain.gcd_dvd
     - EuclideanDomain.dvd_gcd
-  author : mathlib
+  authors: mathlib
 70:
   title  : The Perfect Number Theorem
   decl   : Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect
-  author : Aaron Anderson
+  authors: Aaron Anderson
 71:
   title  : Order of a Subgroup
   decl   : Subgroup.card_subgroup_dvd_card
-  author : mathlib
+  authors: mathlib
 72:
   title  : Sylow’s Theorem
   decls  :
@@ -292,42 +292,42 @@
     - Sylow.isPretransitive_of_finite
     - Sylow.card_dvd_index
     - card_sylow_modEq_one
-  author : Chris Hughes
+  authors: Chris Hughes
 73:
   title  : Ascending or Descending Sequences (Erdős–Szekeres Theorem)
   decl   : Theorems100.erdos_szekeres
-  author : Bhavik Mehta
+  authors: Bhavik Mehta
 74:
   title  : The Principle of Mathematical Induction
   decl   : Nat
   note   : Automatically generated when defining the natural numbers
-  author : Leonardo de Moura
+  authors: Leonardo de Moura
 75:
   title  : The Mean Value Theorem
   decl   : exists_deriv_eq_slope
-  author : Yury G. Kudryashov
+  authors: Yury G. Kudryashov
 76:
   title  : Fourier Series
   decls  :
     - fourierCoeff
     - hasSum_fourier_series_L2
-  author : Heather Macbeth
+  authors: Heather Macbeth
 77:
   title  : Sum of kth powers
   decls  :
     - sum_range_pow
     - sum_Ico_pow
-  author : Moritz Firsching and Fabian Kruse and Ashvni Narayanan
+  authors: Moritz Firsching and Fabian Kruse and Ashvni Narayanan
 78:
   title  : The Cauchy-Schwarz Inequality
   decls  :
     - inner_mul_inner_self_le
     - norm_inner_le_norm
-  author : Zhouhang Zhou
+  authors: Zhouhang Zhou
 79:
   title  : The Intermediate Value Theorem
   decl   : intermediate_value_Icc
-  author : Rob Lewis and Chris Hughes
+  authors: Rob Lewis and Chris Hughes
 80:
   title  : The Fundamental Theorem of Arithmetic
   decls  :
@@ -336,33 +336,33 @@
     - EuclideanDomain.to_principal_ideal_domain
     - UniqueFactorizationMonoid
     - UniqueFactorizationMonoid.factors_unique
-  author : Chris Hughes
+  authors: Chris Hughes
   note   : "it also has a generalized version, by showing that every Euclidean domain is a unique factorization domain, and showing that the integers form a Euclidean domain."
 81:
   title  : Divergence of the Prime Reciprocal Series
   decls  :
     - Theorems100.Real.tendsto_sum_one_div_prime_atTop
     - not_summable_one_div_on_primes
-  author : Manuel Candales (archive), Michael Stoll (mathlib)
+  authors: Manuel Candales (archive), Michael Stoll (mathlib)
 82:
   title  : Dissection of Cubes (J.E. Littlewood’s ‘elegant’ proof)
   decl   : Theorems100.«82».cannot_cube_a_cube
-  author : Floris van Doorn
+  authors: Floris van Doorn
 83:
   title  : The Friendship Theorem
   decl   : Theorems100.friendship_theorem
-  author : Aaron Anderson and Jalex Stark and Kyle Miller
+  authors: Aaron Anderson and Jalex Stark and Kyle Miller
 84:
   title  : Morley’s Theorem
 85:
   title  : Divisibility by 3 Rule
-  author : Kim Morrison
+  authors: Kim Morrison
   decls  :
     - Nat.three_dvd_iff
 86:
   title  : Lebesgue Measure and Integration
   decl   : MeasureTheory.lintegral
-  author : Johannes Hölzl
+  authors: Johannes Hölzl
 87:
   title  : Desargues’s Theorem
 88:
@@ -370,22 +370,22 @@
   decls  :
     - card_derangements_eq_numDerangements
     - numDerangements_sum
-  author : Henry Swanson
+  authors: Henry Swanson
 89:
   title  : The Factor and Remainder Theorems
   decls  :
     - Polynomial.dvd_iff_isRoot
     - Polynomial.mod_X_sub_C_eq_C_eval
-  author : Chris Hughes
+  authors: Chris Hughes
 90:
   title  : Stirling’s Formula
   decls  :
     - Stirling.tendsto_stirlingSeq_sqrt_pi
-  author : Moritz Firsching and Fabian Kruse and Nikolas Kuhn and Heather Macbeth
+  authors: Moritz Firsching and Fabian Kruse and Nikolas Kuhn and Heather Macbeth
 91:
   title  : The Triangle Inequality
   decl   : norm_add_le
-  author : Zhouhang Zhou
+  authors: Zhouhang Zhou
 92:
   title  : Pick’s Theorem
 93:
@@ -393,15 +393,15 @@
   decls  :
     - Theorems100.birthday
     - Theorems100.birthday_measure
-  author : Eric Rodriguez
+  authors: Eric Rodriguez
 94:
   title  : The Law of Cosines
   decl   : EuclideanGeometry.dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle
-  author : Joseph Myers
+  authors: Joseph Myers
 95:
   title  : Ptolemy’s Theorem
   decl   : EuclideanGeometry.mul_dist_add_mul_dist_eq_mul_dist_of_cospherical
-  author : Manuel Candales
+  authors: Manuel Candales
 96:
   title  : Principle of Inclusion/Exclusion
   decls  :
@@ -411,24 +411,24 @@
     - Finset.inclusion_exclusion_card_inf_compl
   links  :
     github : https://github.com/NeilStrickland/lean_lib/blob/f88d162da2f990b87c4d34f5f46bbca2bbc5948e/src/combinatorics/matching.lean#L304
-  author : Neil Strickland (outside mathlib), Yaël Dillies (in mathlib)
+  authors: Neil Strickland (outside mathlib), Yaël Dillies (in mathlib)
 97:
   title  : Cramer’s Rule
   decl   : Matrix.mulVec_cramer
-  author : Anne Baanen
+  authors: Anne Baanen
 98:
   title  : Bertrand’s Postulate
   decl   : Nat.bertrand
-  author : Bolton Bailey and Patrick Stevens
+  authors: Bolton Bailey and Patrick Stevens
 99:
   title  : Buffon Needle Problem
   links  :
   decls  :
     - BuffonsNeedle.buffon_short
     - BuffonsNeedle.buffon_long
-  author : Enrico Z. Borba
+  authors: Enrico Z. Borba
 100:
   title  : Descartes Rule of Signs
   links  :
     github : https://github.com/Timeroot/lean-descartes-signs/
-  author : Alex Meiburg
+  authors: Alex Meiburg

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -402,7 +402,7 @@ Q420714:
 Q422187:
   title: Myhill–Nerode theorem
   decl: Language.isRegular_iff_finite_range_leftQuotient
-  author: Chris Wong
+  authors: Chris Wong
   date: 2024-03-24
 
 Q425432:

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -17,7 +17,7 @@
 Q11518:
   title: Pythagorean theorem
   decl: EuclideanGeometry.dist_sq_eq_dist_sq_add_dist_sq_iff_angle_eq_pi_div_two
-  author: Joseph Myers
+  authors: Joseph Myers
 
 Q12524:
   title: Schwenk's theorem
@@ -25,14 +25,14 @@ Q12524:
 Q26708:
   title: Binomial theorem
   decl: add_pow
-  author: Chris Hughes
+  authors: Chris Hughes
 
 Q32182:
   title: Balinski's theorem
 
 Q33481:
   title: Arrow's impossibility theorem
-  author: Benjamin Davidson, Andrew Souther
+  authors: Benjamin Davidson, Andrew Souther
   date: 2021
   url: https://github.com/asouther4/lean-social-choice/blob/master/src/arrows_theorem.lean
 
@@ -56,7 +56,7 @@ Q132469:
 Q137164:
   title: Besicovitch covering theorem
   decl: Besicovitch.exists_disjoint_closedBall_covering_ae
-  author: Sébastien Gouëzel
+  authors: Sébastien Gouëzel
   date: 2021
 
 Q154210:
@@ -75,7 +75,7 @@ Q174955:
 Q179208:
   title: Cayley's theorem
   decl: Equiv.Perm.subgroupOfMulAction
-  author: Eric Wieser
+  authors: Eric Wieser
   date: 2021
 
 Q179467:
@@ -97,7 +97,7 @@ Q180345:
 Q182505:
   title: Bayes' theorem
   decl: ProbabilityTheory.cond_eq_inv_mul_cond_mul
-  author: Rishikesh Vaishnav
+  authors: Rishikesh Vaishnav
   date: 2022
 
 Q184410:
@@ -106,7 +106,7 @@ Q184410:
 Q188295:
   title: Fermat's little theorem
   decl: ZMod.pow_card_sub_one_eq_one
-  author: Aaron Anderson
+  authors: Aaron Anderson
   date: 2020
 
 Q188745:
@@ -118,7 +118,7 @@ Q189136:
   decls:
     - exists_deriv_eq_slope
     - exists_ratio_deriv_eq_ratio_slope
-  author: Yury G. Kudryashov
+  authors: Yury G. Kudryashov
   date: 2019
 
 Q190026:
@@ -134,25 +134,25 @@ Q190391:
 Q190556:
   title: De Moivre's theorem
   decl: Complex.cos_add_sin_mul_I_pow
-  author: Abhimanyu Pallavi Sudhir
+  authors: Abhimanyu Pallavi Sudhir
   date: 2019
 
 Q191693:
   title: Lebesgue's decomposition theorem
   decl: MeasureTheory.Measure.haveLebesgueDecomposition_of_sigmaFinite
-  author: Kexing Ying
+  authors: Kexing Ying
   date: 2021
 
 Q192760:
   title: Fundamental theorem of algebra
   decl: Complex.isAlgClosed
-  author: Chris Hughes
+  authors: Chris Hughes
   date: 2019
 
 Q193286:
   title: Rolle's theorem
   decl: exists_deriv_eq_zero
-  author: Yury G. Kudryashov
+  authors: Yury G. Kudryashov
   date: 2019
 
 Q193878:
@@ -174,7 +174,7 @@ Q195133:
 
 Q200787:
   title: Gödel's incompleteness theorem
-  author: Shogo Saito
+  authors: Shogo Saito
   # TODO: how to display this data nicely? want two URLs, right?
   # results:
   #   - First: https://github.com/FormalizedFormalLogic/Incompleteness/blob/master/Incompleteness/Arith/First.lean
@@ -184,7 +184,7 @@ Q200787:
 Q203565:
   title: Solutions of a general cubic equation
   decl: Theorems100.cubic_eq_zero_iff
-  author: Jeoff Lee
+  authors: Jeoff Lee
   date: 2022
 
 Q204884:
@@ -202,7 +202,7 @@ Q207244:
 Q208416:
   title: Independence of the continuum hypothesis
   url: https://github.com/flypitch/flypitch/blob/d72904c17fbb874f01ffe168667ba12663a7b853/src/summary.lean#L90
-  author: Floris van Doorn and Jesse Michael Han
+  authors: Floris van Doorn and Jesse Michael Han
   date: 2019-09-17
 
 Q208756:
@@ -240,7 +240,7 @@ Q242045:
 Q245098:
   title: Intermediate value theorem
   decl: intermediate_value_Icc
-  author: Rob Lewis and Chris Hughes
+  authors: Rob Lewis and Chris Hughes
 
 Q245098X:
   title: Bolzano's theorem
@@ -267,7 +267,7 @@ Q256303:
 Q257387:
   title: Vitali theorem
   # i.e. existence of the Vitali set
-  author: Ching-Tsun Chou
+  authors: Ching-Tsun Chou
   url: https://github.com/ctchou/my_lean/blob/main/MyLean/NonMeasurable.lean
   comment: "mathlib4 pull request at https://github.com/leanprover-community/mathlib4/pull/20722"
 
@@ -295,7 +295,7 @@ Q273037:
 Q276082:
   title: Wilson's theorem
   decl: ZMod.wilsons_lemma
-  author: Chris Hughes
+  authors: Chris Hughes
 
 Q280116:
   title: Odd number theorem
@@ -331,7 +331,7 @@ Q318767:
   decls:
     - Complex.tendsto_tsum_powerSeries_nhdsWithin_stolzCone
     - Real.tendsto_tsum_powerSeries_nhdsWithin_lt
-  author: Jeremy Tan
+  authors: Jeremy Tan
 
 Q321237:
   title: Green's theorem
@@ -414,7 +414,7 @@ Q428134:
 Q459547:
   title: Ptolemy's theorem
   decl: EuclideanGeometry.mul_dist_add_mul_dist_eq_mul_dist_of_cospherical
-  author: Manuel Candales
+  authors: Manuel Candales
 
 Q467205:
   title: Fundamental theorems of welfare economics
@@ -431,25 +431,25 @@ Q468391:
 Q470877:
   title: Stirling's theorem
   decl: Stirling.tendsto_stirlingSeq_sqrt_pi
-  author: Moritz Firsching and Fabian Kruse and Nikolas Kuhn and Heather Macbeth
+  authors: Moritz Firsching and Fabian Kruse and Nikolas Kuhn and Heather Macbeth
 
 Q472883:
   title: Quadratic reciprocity theorem
   decls:
     - legendreSym.quadratic_reciprocity
     - jacobiSym.quadratic_reciprocity
-  author: Chris Hughes (first) and Michael Stoll (second)
+  authors: Chris Hughes (first) and Michael Stoll (second)
 
 Q474881:
   title: Cantor's theorem
   # a.k.a. Cantor's diagonal argument
   decl: Function.cantor_surjective
-  author: Johannes Hölzl and Mario Carneiro
+  authors: Johannes Hölzl and Mario Carneiro
 
 Q476776:
   title: Solutions of a general quartic equation
   decl: Theorems100.quartic_eq_zero_iff
-  author: Thomas Zhu
+  authors: Thomas Zhu
 
 Q487132:
   title: Infinite monkey theorem
@@ -510,7 +510,7 @@ Q544369:
 Q550402:
   title: Dirichlet's theorem on arithmetic progressions
   decl: Nat.setOf_prime_and_eq_mod_infinite
-  author: David Loeffler, Michael Stoll
+  authors: David Loeffler, Michael Stoll
 
 Q552367:
   title: Berge's theorem
@@ -564,7 +564,7 @@ Q608294:
 Q609612:
   title: Knaster–Tarski theorem
   decl: fixedPoints.completeLattice
-  author: Kenny Lau
+  authors: Kenny Lau
   date: 2018
 
 Q612021:
@@ -591,7 +591,7 @@ Q632546X:
 Q632546:
   title: Bertrand's postulate
   decl: Nat.bertrand
-  author: Bolton Bailey and Patrick Stevens
+  authors: Bolton Bailey and Patrick Stevens
 
 Q637418:
   title: Napoleon's theorem
@@ -599,7 +599,7 @@ Q637418:
 Q642620:
   title: Krein–Milman theorem
   decl: closure_convexHull_extremePoints
-  author: Yaël Dillies
+  authors: Yaël Dillies
   date: 2022
 
 Q643513:
@@ -639,7 +639,7 @@ Q656645:
 Q656772:
   title: Cayley–Hamilton theorem
   decl: Matrix.aeval_self_charpoly
-  author: Kim Morrison
+  authors: Kim Morrison
 
 Q657469:
   title: Lefschetz fixed-point theorem
@@ -649,7 +649,7 @@ Q657469X:
 
 Q657482:
   title: Abel–Ruffini theorem
-  author: Thomas Browning
+  authors: Thomas Browning
   decl: AbelRuffini.exists_not_solvable_by_rad
 
 Q657903:
@@ -668,7 +668,7 @@ Q670235:
     - EuclideanDomain.to_principal_ideal_domain
     - UniqueFactorizationMonoid
     - UniqueFactorizationMonoid.factors_unique
-  author: Chris Hughes
+  authors: Chris Hughes
   comment: "it also has a generalized version, by showing that every Euclidean domain is a unique factorization domain, and showing that the integers form a Euclidean domain."
 
 Q671663:
@@ -692,13 +692,13 @@ Q693083:
 Q716171:
   title: Erdős–Ginzburg–Ziv theorem
   decl: ZMod.erdos_ginzburg_ziv
-  author: Yaël Dillies
+  authors: Yaël Dillies
   date: 2023
 
 Q718875:
   title: Erdős–Ko–Rado theorem
   decl: Finset.erdos_ko_rado
-  author: Bhavik Mehta, Yaël Dillies
+  authors: Bhavik Mehta, Yaël Dillies
   date: 2020
 
 Q719966:
@@ -707,7 +707,7 @@ Q719966:
 Q720469:
   title: Chevalley–Warning theorem
   decl: char_dvd_card_solutions_of_sum_lt
-  author: Johan Commelin
+  authors: Johan Commelin
   date: 2019
 
 Q721695:
@@ -747,7 +747,7 @@ Q744440:
 
 Q748233:
   title: Sylvester–Gallai theorem
-  author: Bhavik Mehta
+  authors: Bhavik Mehta
   url: https://github.com/YaelDillies/LeanCamCombi/blob/6a6a670f324b2af82ae17f21f9d51ac0bc859f6f/LeanCamCombi/SylvesterChvatal.lean#L610
   date: 2022
 
@@ -757,7 +757,7 @@ Q751120:
 Q752375:
   title: Extreme value theorem
   decl: IsCompact.exists_isMinOn
-  author: Sébastien Gouëzel
+  authors: Sébastien Gouëzel
   date: 2018
 
 Q755986:
@@ -769,13 +769,13 @@ Q755991:
 Q756946:
   title: Lagrange's four-square theorem
   decl: Nat.sum_four_squares
-  author: Chris Hughes
+  authors: Chris Hughes
   date: 2019
 
 Q764287:
   title: Van der Waerden's theorem
   decl: Combinatorics.exists_mono_homothetic_copy
-  author: David Wärn
+  authors: David Wärn
   # TODO: this is only some version; should this entry be modified accordingly?
 
 Q765987:
@@ -831,7 +831,7 @@ Q830513:
 Q834025:
   title: Cauchy integral theorem
   decl: Complex.circleIntegral_div_sub_of_differentiable_on_off_countable
-  author: Yury Kudryashov
+  authors: Yury Kudryashov
   date: 2021
 
 Q834211:
@@ -839,7 +839,7 @@ Q834211:
 
 Q837506:
   title: Theorem on friends and strangers
-  author: Bhavik Mehta
+  authors: Bhavik Mehta
   url: https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Small.20Ramsey.20numbers/near/490303695
   comment: "will enter mathlib in 2024"
 
@@ -853,7 +853,7 @@ Q841893:
 Q842953:
   title: Lebesgue's density theorem
   decl: Besicovitch.ae_tendsto_measure_inter_div
-  author: Oliver Nash
+  authors: Oliver Nash
   date: 2022
 
 Q844612:
@@ -892,7 +892,7 @@ Q853067:
   decls:
     - Pell.eq_pell
     - Pell.exists_of_not_isSquare
-  author: Mario Carneiro (first), Michael Stoll (second)
+  authors: Mario Carneiro (first), Michael Stoll (second)
   comment: "In `pell.eq_pell`, `d` is defined to be `a*a - 1` for an arbitrary `a > 1`."
 
 Q856032:
@@ -969,14 +969,14 @@ Q913849:
 Q914517:
   title: Fermat's theorem on sums of two squares
   decl: Nat.Prime.sq_add_sq
-  author: Chris Hughes
+  authors: Chris Hughes
 
 Q915474:
   title: Robin's theorem
 
 Q918099:
   title: Ramsey's theorem
-  author: Bhavik Mehta
+  authors: Bhavik Mehta
   url: https://github.com/b-mehta/combinatorics/blob/extras/src/inf_ramsey.lean
 
 Q922012:
@@ -1013,7 +1013,7 @@ Q931404:
 Q939927:
   title: Stone–Weierstrass theorem
   decl: ContinuousMap.subalgebra_topologicalClosure_eq_top_of_separatesPoints
-  author: Scott Morrison and Heather Macbeth
+  authors: Scott Morrison and Heather Macbeth
   date: 2021-05-01
 
 Q942046:
@@ -1030,7 +1030,7 @@ Q944297:
 
 Q948664:
   title: Kneser's addition theorem
-  author: Mantas Bakšys, Yaël Dillies
+  authors: Mantas Bakšys, Yaël Dillies
   url: https://github.com/YaelDillies/LeanCamCombi/blob/master/LeanCamCombi/Kneser/Kneser.lean
   date: 2022
 
@@ -1065,7 +1065,7 @@ Q976033:
 Q976607:
   title: Erdős–Szekeres theorem
   decl: Theorems100.erdos_szekeres
-  author: Bhavik Mehta
+  authors: Bhavik Mehta
 
 Q977912:
   title: Stolper&ndash;Samuelson theorem
@@ -1091,12 +1091,12 @@ Q1008566:
 Q1032886:
   title: Hales–Jewett theorem
   decl: Combinatorics.Line.exists_mono_in_high_dimension
-  author: David Wärn
+  authors: David Wärn
 
 Q1033910:
   title: Cantor–Bernstein–Schroeder theorem
   decl: Function.Embedding.schroeder_bernstein
-  author: Mario Carneiro
+  authors: Mario Carneiro
 
 Q1037559:
   title: Pólya enumeration theorem
@@ -1111,7 +1111,7 @@ Q1046232:
 Q1047749:
   title: Turán's theorem
   decl: SimpleGraph.isTuranMaximal_iff_nonempty_iso_turanGraph
-  author: Jeremy Tan
+  authors: Jeremy Tan
 
 Q1048589:
   title: Hohenberg–Kohn theorems
@@ -1130,7 +1130,7 @@ Q1050203:
 Q1050932:
   title: Hartogs's theorem
   url: https://github.com/girving/ray/blob/main/Ray/Hartogs/Hartogs.lean
-  author: Geoffrey Irving
+  authors: Geoffrey Irving
 
 Q1051404:
   title: Cesàro's theorem
@@ -1220,7 +1220,7 @@ Q1077741:
 
 Q1082910:
   title: Euler's partition theorem
-  author: Bhavik Mehta and Aaron Anderson
+  authors: Bhavik Mehta and Aaron Anderson
   decl: Theorems100.partition_theorem
 
 Q1095330:
@@ -1231,7 +1231,7 @@ Q1095330:
 Q1097021:
   title: Minkowski's theorem
   decl: MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure
-  author: Alex J. Best and Yaël Dillies
+  authors: Alex J. Best and Yaël Dillies
   date: 2021
 
 Q1103054:
@@ -1282,7 +1282,7 @@ Q1137206:
   decls:
     - taylor_mean_remainder_lagrange
     - taylor_mean_remainder_cauchy
-  author: Moritz Doll
+  authors: Moritz Doll
 
 Q1139041:
   title: Cauchy's theorem
@@ -1309,7 +1309,7 @@ Q1143540:
 
 Q1144897:
   title: Brouwer fixed-point theorem
-  author: Brendan Seamas Murphy
+  authors: Brendan Seamas Murphy
   url: https://github.com/Shamrock-Frost/BrouwerFixedPoint/blob/master/src/brouwer_fixed_point.lean
   comment: "in Lean 3"
 
@@ -1391,7 +1391,7 @@ Q1191319:
 Q1191709:
   title: Egorov's theorem
   decl: MeasureTheory.tendstoUniformlyOn_of_ae_tendsto
-  author: Kexing Ying
+  authors: Kexing Ying
 
 Q1191862:
   title: Rouché's theorem
@@ -1418,7 +1418,7 @@ Q1217677:
   decls:
     - intervalIntegral.integral_hasStrictDerivAt_of_tendsto_ae_right
     - intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le
-  author: Yury G. Kudryashov (first) and Benjamin Davidson (second)
+  authors: Yury G. Kudryashov (first) and Benjamin Davidson (second)
 
 Q1227061:
   title: Khinchin's theorem
@@ -1435,7 +1435,7 @@ Q1242398:
 Q1243340:
   title: Birkhoff–Von Neumann theorem
   decl: doublyStochastic_eq_convexHull_permMatrix
-  author: Bhavik Mehta
+  authors: Bhavik Mehta
   date: 2024
 
 Q1249069:
@@ -1544,7 +1544,7 @@ Q1425529:
 Q1426292:
   title: Banach–Steinhaus theorem
   decl: banach_steinhaus
-  author: Jireh Loreaux
+  authors: Jireh Loreaux
   date: 2021
 
 Q1434158:
@@ -1581,7 +1581,7 @@ Q1505529:
 Q1506253:
   title: Euclid's theorem
   decl: Nat.exists_infinite_primes
-  author: Jeremy Avigad
+  authors: Jeremy Avigad
 
 Q1529941:
   title: Peter–Weyl theorem
@@ -1595,7 +1595,7 @@ Q1535225:
 Q1542114:
   title: Bézout's theorem
   decl: Nat.gcd_eq_gcd_ab
-  author: mathlib
+  authors: mathlib
 
 Q1543149:
   title: Sokhatsky–Weierstrass theorem
@@ -1615,7 +1615,7 @@ Q1564541:
 Q1566341:
   title: Hindman's theorem
   decl: Hindman.FP_partition_regular
-  author: David Wärn
+  authors: David Wärn
 
 Q1566372:
   title: Haag's theorem
@@ -1626,7 +1626,7 @@ Q1568612:
 Q1568811:
   title: Hahn decomposition theorem
   decl: MeasureTheory.SignedMeasure.exists_isCompl_positive_negative
-  author: Kexing Ying
+  authors: Kexing Ying
   date: 2021
 
 Q1572474:
@@ -1659,7 +1659,7 @@ Q1632301:
 
 Q1632433:
   title: Helly's theorem
-  author: Vasily Nesterov
+  authors: Vasily Nesterov
   decl: Convex.helly_theorem
   date: 2023
 
@@ -1678,7 +1678,7 @@ Q1683356:
 Q1687147:
   title: Sprague–Grundy theorem
   decl: SetTheory.PGame.equiv_nim_grundyValue
-  author: Fox Thomson
+  authors: Fox Thomson
   date: 2020
 
 Q1694565:
@@ -1822,7 +1822,7 @@ Q2022775:
 Q2027347:
   title: Optional stopping theorem
   decl: MeasureTheory.submartingale_iff_expected_stoppedValue_mono
-  author: Kexing Ying, Rémy Degenne
+  authors: Kexing Ying, Rémy Degenne
   date: 2022
 
 Q2028341:
@@ -1918,13 +1918,13 @@ Q2226774:
 Q2226786:
   title: Sperner's theorem
   decl: IsAntichain.sperner
-  author: Bhavik Mehta, Alena Gusakov, Yaël Dillies
+  authors: Bhavik Mehta, Alena Gusakov, Yaël Dillies
   date: 2022
 
 Q2226800:
   title: Schur–Zassenhaus theorem
   decl: Subgroup.exists_left_complement'_of_coprime
-  author: Thomas Browning
+  authors: Thomas Browning
   date: 2021
 
 Q2226803:
@@ -1936,7 +1936,7 @@ Q2226807:
 Q2226855:
   title: Sharkovskii's theorem
   # TODO: Find the code
-  author: Bhavik Mehta
+  authors: Bhavik Mehta
   date: 2022
 
 Q2226868:
@@ -1947,7 +1947,7 @@ Q2226962:
 
 Q2253746:
   title: Bertrand's ballot theorem
-  author: Bhavik Mehta and Kexing Ying
+  authors: Bhavik Mehta and Kexing Ying
   decl: Ballot.ballot_problem
 
 Q2266397:
@@ -1965,7 +1965,7 @@ Q2270905:
 Q2275191:
   title: Lebesgue differentiation theorem
   decl: VitaliFamily.ae_tendsto_lintegral_div
-  author: Sébastien Gouëzel
+  authors: Sébastien Gouëzel
   date: 2021
 
 Q2277040:
@@ -2120,7 +2120,7 @@ Q2916568:
 Q2919401:
   title: Ostrowski's theorem
   decl: Rat.AbsoluteValue.equiv_real_or_padic
-  author: David Kurniadi Angdinata, Fabrizio Barroero, Laura Capuano, Nirvana Coppola, María Inés de Frutos-Fernández, Sam van Gool, Silvain Rideau-Kikuchi, Amos Turchet, Francesco Veneziano
+  authors: David Kurniadi Angdinata, Fabrizio Barroero, Laura Capuano, Nirvana Coppola, María Inés de Frutos-Fernández, Sam van Gool, Silvain Rideau-Kikuchi, Amos Turchet, Francesco Veneziano
   date: 2024
 
 Q2981012:
@@ -2168,7 +2168,7 @@ Q3229335:
 Q3229352:
   title: Vitali covering theorem
   decl: Vitali.exists_disjoint_covering_ae
-  author: Sébastien Gouëzel
+  authors: Sébastien Gouëzel
   date: 2021
 
 Q3345678:
@@ -2206,7 +2206,7 @@ Q3526993:
 
 Q3526996:
   title: Kolmogorov extension theorem
-  author: Rémy Degenne, Peter Pfaffelhuber
+  authors: Rémy Degenne, Peter Pfaffelhuber
   date: 2023
   url: https://github.com/RemyDegenne/kolmogorov_extension4
 
@@ -2279,7 +2279,7 @@ Q3527100:
 Q3527102:
   title: Kruskal–Katona theorem
   decl: Finset.kruskal_katona
-  author: Bhavik Mehta, Yaël Dillies
+  authors: Bhavik Mehta, Yaël Dillies
   date: 2020
 
 Q3527110:
@@ -2339,7 +2339,7 @@ Q3527214:
 Q3527215:
   title: Hilbert projection theorem
   decl: exists_norm_eq_iInf_of_complete_convex
-  author: Zhouhang Zhou
+  authors: Zhouhang Zhou
   date: 2019
 
 Q3527217:
@@ -2372,13 +2372,13 @@ Q3527247:
 Q3527250:
   title: Hadamard three-lines theorem
   decl: Complex.HadamardThreeLines.norm_le_interpStrip_of_mem_verticalClosedStrip
-  author: Xavier Généreux
+  authors: Xavier Généreux
   date: 2023
 
 Q3527263:
   title: Kleene fixed-point theorem
   decl: fixedPoints.lfp_eq_sSup_iterate
-  author: Ira Fesefeldt
+  authors: Ira Fesefeldt
   date: 2024
 
 Q3527279:
@@ -2436,7 +2436,7 @@ Q3984052:
 Q3984053:
   title: Fourier inversion theorem
   decl: Continuous.fourier_inversion
-  author: Sébastien Gouëzel
+  authors: Sébastien Gouëzel
   date: 2024
 
 Q3984056:
@@ -2469,7 +2469,7 @@ Q4272645:
 Q4378868:
   title: Phragmén–Lindelöf theorem
   decl: PhragmenLindelof.horizontal_strip
-  author: Yury G. Kudryashov
+  authors: Yury G. Kudryashov
   date: 2022
 
 Q4378889:
@@ -2560,7 +2560,7 @@ Q4677985:
 Q4695203:
   title: Four functions theorem
   decl: four_functions_theorem
-  author: Yaël Dillies
+  authors: Yaël Dillies
   date: 2023
 
 Q4700718:
@@ -2632,7 +2632,7 @@ Q4827308:
 Q4830725:
   title: Ax–Grothendieck theorem
   decl: ax_grothendieck_zeroLocus
-  author: Chris Hughes
+  authors: Chris Hughes
   date: 2023
 
 Q4832965:
@@ -2848,7 +2848,7 @@ Q5166389:
 Q5171652:
   title: Corners theorem
   decl: corners_theorem_nat
-  author: Yaël Dillies, Bhavik Mehta
+  authors: Yaël Dillies, Bhavik Mehta
   date: 2022
 
 Q5172143:
@@ -3000,7 +3000,7 @@ Q5503689:
 Q5504427:
   title: Friendship theorem
   decl: Theorems100.friendship_theorem
-  author: Aaron Anderson and Jalex Stark and Kyle Miller
+  authors: Aaron Anderson and Jalex Stark and Kyle Miller
 
 Q5505098:
   title: Frobenius determinant theorem
@@ -3276,7 +3276,7 @@ Q6749789:
 
 Q6757284:
   title: Marcinkiewicz theorem
-  author: Jim Portegies
+  authors: Jim Portegies
   date: 2024-09-06
   url: https://github.com/fpvandoorn/carleson/blob/master/Carleson/RealInterpolation.lean
   # will become part of mathlib; update URL in this case!
@@ -3532,7 +3532,7 @@ Q7433034:
 Q7433182:
   title: Schwartz–Zippel theorem
   decl: MvPolynomial.schwartz_zippel_sup_sum
-  author: Bolton Bailey, Yaël Dillies
+  authors: Bolton Bailey, Yaël Dillies
   date: 2023
 
 Q7433295:
@@ -3693,7 +3693,7 @@ Q7857350:
 Q7888360:
   title: Structure theorem for finitely generated modules over a principal ideal domain
   decl: Module.equiv_free_prod_directSum
-  author: Pierre-Alexandre Bazin
+  authors: Pierre-Alexandre Bazin
   date: 2022
 
 Q7894110:
@@ -3759,7 +3759,7 @@ Q8066795:
 Q8074796:
   title: Zsigmondy's theorem
   # TODO: Find the code
-  author: Mantas Bakšys
+  authors: Mantas Bakšys
   date: 2022
 
 Q8081891:
@@ -3781,7 +3781,7 @@ Q10942247:
 Q11352023:
   title: Vitali convergence theorem
   decl: MeasureTheory.tendstoInMeasure_iff_tendsto_Lp
-  author: Igor Khavkine
+  authors: Igor Khavkine
   date: 2024
 
 Q11573495:
@@ -3820,7 +3820,7 @@ Q15895894:
 Q16251580:
   title: Matiyasevich's theorem
   decl: Pell.matiyasevic
-  author: Mario Carneiro
+  authors: Mario Carneiro
   date: 2017
 
 Q16680059:
@@ -3841,7 +3841,7 @@ Q17003552:
 Q17005116:
   title: Birkhoff's representation theorem
   decl: LatticeHom.birkhoffSet
-  author: Yaël Dillies
+  authors: Yaël Dillies
   date: 2022
 
 Q17008559:
@@ -3911,7 +3911,7 @@ Q18206266:
   title: Euclid–Euler theorem
   # a.k.a. perfect number theorem
   decl: Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect
-  author: Aaron Anderson
+  authors: Aaron Anderson
 
 Q18630480:
   title: Euler's quadrilateral theorem
@@ -3931,7 +3931,7 @@ Q20971632:
 Q22952648:
   title: Uncountability of the continuum
   decl: Cardinal.not_countable_real
-  author: Floris van Doorn
+  authors: Floris van Doorn
 
 Q25099402:
   title: Kolmogorov–Arnold representation theorem

--- a/scripts/yaml_check.py
+++ b/scripts/yaml_check.py
@@ -58,7 +58,7 @@ class HundredTheorem:
     # like |decl|, but a list of declarations (if one theorem is split into multiple declarations) (optional)
     decls: Optional[List[str]] = None
     # name(s) of the author(s) of this formalization (optional)
-    author: Optional[str] = None
+    authors: Optional[str] = None
     # Date of the formalization, in the form `YYYY`, `YYYY-MM` or `YYYY-MM-DD` (optional)
     date: Optional[str] = None
     links: Optional[Mapping[str, str]] = None
@@ -87,7 +87,7 @@ class ThousandPlusTheorem:
     # like |decl|, but a list of declarations (if one theorem is split into multiple declarations) (optional)
     decls: Optional[List[str]] = None
     # name(s) of the author(s) of this formalization (optional)
-    author: Optional[str] = None
+    authors: Optional[str] = None
     # Date of the formalization, in the form `YYYY`, `YYYY-MM` or `YYYY-MM-DD` (optional)
     date: Optional[str] = None
     # for external projects, an URL referring to the result


### PR DESCRIPTION
Currently, there is some annoying inconsistency
- the 1000 theorems project calls the field 'authors'
- the 1000.yaml file calls it 'author', deviating from this
- the 100.yaml file calls it 'author'.

Change them all to 'authors' for consistency.
Since formalisations are usually work of multiple people, this seems more appropriate, and matches the 1000+ theorem.

---

- [ ] depends on: #11311
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
