### PR TITLE
[Merged by Bors] - feat(Data/Matroid/Basic): matroid congruence definitions

### DIFF
--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -777,7 +777,7 @@ to supplied arguments that are provably equal to those of `M`. -/
 to supplied arguments that are provably equal to those of `M`. -/
 @[simps!] def copyBase (M : Matroid α) (E : Set α) (Base : Set α → Prop)
     (hE : E = M.E) (h : ∀ B, Base B ↔ M.Base B) : Matroid α :=
-  M.copyBaseIndep E Base M.Indep hE h (fun _ ↦ Iff.rfl)
+  M.copy E Base M.Indep hE h (fun _ ↦ Iff.rfl)
 
 end copy
 

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -744,49 +744,11 @@ theorem existsMaximalSubsetProperty_indep (M : Matroid α) :
 
 end dep_indep
 
-section congr
-
-/-- create a copy of `M : Matroid α` with an independence predicate and ground set defeq
-to supplied arguments that are provably equal to those of `M`. -/
-@[simps] def congrIndep (M : Matroid α) (E : Set α) (Indep : Set α → Prop)
-    (hE : E = M.E) (h : ∀ I, Indep I ↔ M.Indep I) : Matroid α where
-  E := E
-  Base := M.Base
-  Indep := Indep
-  indep_iff' _ := by simp_rw [h, M.indep_iff]
-  exists_base := M.exists_base
-  base_exchange := M.base_exchange
-  maximality := by
-    simp_rw [hE, show Indep = M.Indep from funext (by simp [h])]
-    exact M.maximality
-  subset_ground := by
-    simp_rw [hE]
-    exact M.subset_ground
-
-/-- create a copy of `M : Matroid α` with a base predicate and ground set defeq
-to supplied arguments that are provably equal to those of `M`. -/
-@[simps] def congrBase (M : Matroid α) (E : Set α) (Base : Set α → Prop)
-    (hE : E = M.E) (h : ∀ B, Base B ↔ M.Base B) : Matroid α where
-  E := E
-  Base := Base
-  Indep := M.Indep
-  indep_iff' _ := by simp_rw [h, M.indep_iff]
-  exists_base := by
-    simp_rw [h]
-    exact M.exists_base
-  base_exchange := by
-    simp_rw [show Base = M.Base from funext (by simp [h])]
-    exact M.base_exchange
-  maximality := by
-    simp_rw [hE]
-    exact M.maximality
-  subset_ground := by
-    simp_rw [hE, h]
-    exact M.subset_ground
+section copy
 
 /-- create a copy of `M : Matroid α` with independence and base predicates and ground set defeq
 to supplied arguments that are provably equal to those of `M`. -/
-@[simps] def congrBaseIndep (M : Matroid α) (E : Set α) (Base Indep : Set α → Prop)
+@[simps] def copyBaseIndep (M : Matroid α) (E : Set α) (Base Indep : Set α → Prop)
     (hE : E = M.E) (hB : ∀ B, Base B ↔ M.Base B) (hI : ∀ I, Indep I ↔ M.Indep I) : Matroid α where
   E := E
   Base := Base
@@ -805,7 +767,19 @@ to supplied arguments that are provably equal to those of `M`. -/
     simp_rw [hE, hB]
     exact M.subset_ground
 
-end congr
+/-- create a copy of `M : Matroid α` with an independence predicate and ground set defeq
+to supplied arguments that are provably equal to those of `M`. -/
+@[simps!] def copyIndep (M : Matroid α) (E : Set α) (Indep : Set α → Prop)
+    (hE : E = M.E) (h : ∀ I, Indep I ↔ M.Indep I) : Matroid α :=
+  M.copyBaseIndep E M.Base Indep hE (fun _ ↦ Iff.rfl) h
+
+/-- create a copy of `M : Matroid α` with a base predicate and ground set defeq
+to supplied arguments that are provably equal to those of `M`. -/
+@[simps!] def copyBase (M : Matroid α) (E : Set α) (Base : Set α → Prop)
+    (hE : E = M.E) (h : ∀ B, Base B ↔ M.Base B) : Matroid α :=
+  M.copyBaseIndep E Base M.Indep hE h (fun _ ↦ Iff.rfl)
+
+end copy
 
 section Basis
 

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -748,7 +748,7 @@ section copy
 
 /-- create a copy of `M : Matroid α` with independence and base predicates and ground set defeq
 to supplied arguments that are provably equal to those of `M`. -/
-@[simps] def copyBaseIndep (M : Matroid α) (E : Set α) (Base Indep : Set α → Prop)
+@[simps] def copy (M : Matroid α) (E : Set α) (Base Indep : Set α → Prop)
     (hE : E = M.E) (hB : ∀ B, Base B ↔ M.Base B) (hI : ∀ I, Indep I ↔ M.Indep I) : Matroid α where
   E := E
   Base := Base

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -771,7 +771,7 @@ to supplied arguments that are provably equal to those of `M`. -/
 to supplied arguments that are provably equal to those of `M`. -/
 @[simps!] def copyIndep (M : Matroid α) (E : Set α) (Indep : Set α → Prop)
     (hE : E = M.E) (h : ∀ I, Indep I ↔ M.Indep I) : Matroid α :=
-  M.copyBaseIndep E M.Base Indep hE (fun _ ↦ Iff.rfl) h
+  M.copy E M.Base Indep hE (fun _ ↦ Iff.rfl) h
 
 /-- create a copy of `M : Matroid α` with a base predicate and ground set defeq
 to supplied arguments that are provably equal to those of `M`. -/

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -734,6 +734,69 @@ theorem existsMaximalSubsetProperty_indep (M : Matroid α) :
 
 end dep_indep
 
+section congr
+
+/-- create a copy of `M : Matroid α` with an independence predicate and ground set defeq
+to supplied arguments that are provably equal to those of `M`. -/
+@[simps] def congrIndep (M : Matroid α) (E : Set α) (Indep : Set α → Prop)
+    (hE : E = M.E) (h : ∀ I, Indep I ↔ M.Indep I) : Matroid α where
+  E := E
+  Base := M.Base
+  Indep := Indep
+  indep_iff' _ := by simp_rw [h, M.indep_iff]
+  exists_base := M.exists_base
+  base_exchange := M.base_exchange
+  maximality := by
+    simp_rw [hE, show Indep = M.Indep from funext (by simp [h])]
+    exact M.maximality
+  subset_ground := by
+    simp_rw [hE]
+    exact M.subset_ground
+
+/-- create a copy of `M : Matroid α` with a base predicate and ground set defeq
+to supplied arguments that are provably equal to those of `M`. -/
+@[simps] def congrBase (M : Matroid α) (E : Set α) (Base : Set α → Prop)
+    (hE : E = M.E) (h : ∀ B, Base B ↔ M.Base B) : Matroid α where
+  E := E
+  Base := Base
+  Indep := M.Indep
+  indep_iff' _ := by simp_rw [h, M.indep_iff]
+  exists_base := by
+    simp_rw [h]
+    exact M.exists_base
+  base_exchange := by
+    simp_rw [show Base = M.Base from funext (by simp [h])]
+    exact M.base_exchange
+  maximality := by
+    simp_rw [hE]
+    exact M.maximality
+  subset_ground := by
+    simp_rw [hE, h]
+    exact M.subset_ground
+
+/-- create a copy of `M : Matroid α` with independence and base predicates and ground set defeq
+to supplied arguments that are provably equal to those of `M`. -/
+@[simps] def congrBaseIndep (M : Matroid α) (E : Set α) (Base Indep : Set α → Prop)
+    (hE : E = M.E) (hB : ∀ B, Base B ↔ M.Base B) (hI : ∀ I, Indep I ↔ M.Indep I) : Matroid α where
+  E := E
+  Base := Base
+  Indep := Indep
+  indep_iff' _ := by simp_rw [hI, hB, M.indep_iff]
+  exists_base := by
+    simp_rw [hB]
+    exact M.exists_base
+  base_exchange := by
+    simp_rw [show Base = M.Base from funext (by simp [hB])]
+    exact M.base_exchange
+  maximality := by
+    simp_rw [hE, show Indep = M.Indep from funext (by simp [hI])]
+    exact M.maximality
+  subset_ground := by
+    simp_rw [hE, hB]
+    exact M.subset_ground
+
+end congr
+
 section Basis
 
 /-- A Basis for a set `X ⊆ M.E` is a maximal independent subset of `X`


### PR DESCRIPTION
Added three definitions that produce copies of matroids with superior definitional properties, in response to [this comment](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Transcendence.20degree.3F/near/494675777) on zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
