### PR TITLE
[Merged by Bors] - feat(CategoryTheory): the equivalence of categories induced by a bijection

### DIFF
--- a/Mathlib/CategoryTheory/EqToHom.lean
+++ b/Mathlib/CategoryTheory/EqToHom.lean
@@ -338,4 +338,26 @@ theorem dcongr_arg {ι : Type*} {F G : ι → C} (α : ∀ i, F i ⟶ G i) {i j 
   subst h
   simp
 
+/-- If `T ≃ D` is a bijection and `D` is a category, then
+`InducedCategory D e` is equivalent to `D`. -/
+@[simps]
+def Equivalence.induced {T : Type*} (e : T ≃ D) :
+    InducedCategory D e ≌ D where
+  functor := inducedFunctor e
+  inverse :=
+    { obj := e.symm
+      map {X Y} f := show e (e.symm X) ⟶ e (e.symm Y) from
+        eqToHom (e.apply_symm_apply X) ≫ f ≫
+          eqToHom (e.apply_symm_apply Y).symm
+      map_comp {X Y Z} f g := by
+        dsimp
+        erw [Category.assoc, Category.assoc, Category.assoc]
+        rw [eqToHom_trans_assoc, eqToHom_refl, Category.id_comp] }
+  unitIso := NatIso.ofComponents (fun _ ↦ eqToIso (by simp)) (fun {X Y} f ↦ by
+    dsimp
+    erw [eqToHom_trans_assoc _ (by simp), eqToHom_refl, Category.id_comp]
+    rfl )
+  counitIso := NatIso.ofComponents (fun _ ↦ eqToIso (by simp))
+  functor_unitIso_comp X := eqToHom_trans (by simp) (by simp)
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/EssentiallySmall.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Mathlib.CategoryTheory.Category.ULift
+import Mathlib.CategoryTheory.EqToHom
 import Mathlib.CategoryTheory.Skeletal
 import Mathlib.Logic.UnivLE
 import Mathlib.Logic.Small.Basic
@@ -189,7 +190,7 @@ noncomputable instance [Small.{w} C] : Category.{v} (Shrink.{w} C) :=
 
 /-- The categorical equivalence between `C` and `Shrink C`, when `C` is small. -/
 noncomputable def equivalence [Small.{w} C] : C ≌ Shrink.{w} C :=
-  (inducedFunctor (equivShrink C).symm).asEquivalence.symm
+  (Equivalence.induced _).symm
 
 end Shrink
 


### PR DESCRIPTION
When `f : T → D` is a map and `D` is a category, then `InducedCategory D f` is a category with objects `T` with a fully faithful functor to `D`. In this PR, we show that in the case of a bijection `T ≃ D`, the induced category is equivalent to `D`.

The code would be nicer (see #19945) if the type of morphisms in the induced category was defined as a 1-field structure. This would be a very welcomed refactor.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
