### PR TITLE
[Merged by Bors] - fix: make `NNRatCast` computable for `NNReal` and `ENNReal`

### DIFF
--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -185,6 +185,12 @@ lemma coe_ne_coe : (p : ℝ≥0∞) ≠ q ↔ p ≠ q := coe_inj.not
 theorem range_coe' : range ofNNReal = Iio ∞ := WithTop.range_coe
 theorem range_coe : range ofNNReal = {∞}ᶜ := (isCompl_range_some_none ℝ≥0).symm.compl_eq.symm
 
+instance : NNRatCast ℝ≥0∞ where
+  nnratCast r := ofNNReal r
+
+@[norm_cast]
+theorem coe_nnratCast (q : ℚ≥0) : ↑(q : ℝ≥0) = (q : ℝ≥0∞) := rfl
+
 /-- `toNNReal x` returns `x` if it is real, otherwise 0. -/
 protected def toNNReal : ℝ≥0∞ → ℝ≥0 := WithTop.untop' 0
 

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -94,7 +94,7 @@ variable {α : Type*}
 /-- The extended nonnegative real numbers. This is usually denoted [0, ∞],
   and is relevant as the codomain of a measure. -/
 def ENNReal := WithTop ℝ≥0
-  deriving Zero, AddCommMonoidWithOne, SemilatticeSup, DistribLattice, Nontrivial
+  deriving Zero, Top, AddCommMonoidWithOne, SemilatticeSup, DistribLattice, Nontrivial
 
 @[inherit_doc]
 scoped[ENNReal] notation "ℝ≥0∞" => ENNReal
@@ -105,6 +105,7 @@ scoped[ENNReal] notation "∞" => (⊤ : ENNReal)
 namespace ENNReal
 
 instance : OrderBot ℝ≥0∞ := inferInstanceAs (OrderBot (WithTop ℝ≥0))
+instance : OrderTop ℝ≥0∞ := inferInstanceAs (OrderTop (WithTop ℝ≥0))
 instance : BoundedOrder ℝ≥0∞ := inferInstanceAs (BoundedOrder (WithTop ℝ≥0))
 instance : CharZero ℝ≥0∞ := inferInstanceAs (CharZero (WithTop ℝ≥0))
 instance : Min ℝ≥0∞ := SemilatticeInf.toMin
@@ -691,6 +692,12 @@ theorem image_ennreal_ofReal (h : s.OrdConnected) : (ENNReal.ofReal '' s).OrdCon
 end OrdConnected
 
 end Set
+
+/-- While not very useful, this instance uses the same representation as `Real.instRepr`. -/
+unsafe instance : Repr ℝ≥0∞ where
+  reprPrec
+  | (r : ℝ≥0), p => Repr.addAppParen f!"ENNReal.ofReal ({repr r.val})" p
+  | ∞, _ => "∞"
 
 namespace Mathlib.Meta.Positivity
 

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -71,7 +71,7 @@ instance : Max ℝ≥0 := SemilatticeSup.toMax
 instance : Sub ℝ≥0 := Nonneg.sub
 instance : OrderedSub ℝ≥0 := Nonneg.orderedSub
 
--- a computable copy of Nonneg.nnRatCast
+-- a computable copy of `Nonneg.instNNRatCast`
 instance : NNRatCast ℝ≥0 where nnratCast r := ⟨r, NNRat.cast_nonneg _⟩
 
 noncomputable instance : LinearOrderedSemifield ℝ≥0 :=

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -72,7 +72,7 @@ instance : Sub ℝ≥0 := Nonneg.sub
 instance : OrderedSub ℝ≥0 := Nonneg.orderedSub
 
 -- a computable copy of `Nonneg.instNNRatCast`
-instance : NNRatCast ℝ≥0 where nnratCast r := ⟨r, NNRat.cast_nonneg _⟩
+instance : NNRatCast ℝ≥0 where nnratCast r := ⟨r, r.cast_nonneg⟩
 
 noncomputable instance : LinearOrderedSemifield ℝ≥0 :=
   Nonneg.linearOrderedSemifield

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -980,6 +980,10 @@ theorem Real.exists_lt_of_strictMono [h : Nontrivial Γ₀ˣ] {f : Γ₀ →*₀
 
 end StrictMono
 
+/-- While not very useful, this instance uses the same representation as `Real.instRepr`. -/
+unsafe instance : Repr ℝ≥0 where
+  reprPrec r _ := f!"({repr r.val}).toNNReal"
+
 namespace Mathlib.Meta.Positivity
 
 open Lean Meta Qq Function

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -71,6 +71,9 @@ instance : Max ℝ≥0 := SemilatticeSup.toMax
 instance : Sub ℝ≥0 := Nonneg.sub
 instance : OrderedSub ℝ≥0 := Nonneg.orderedSub
 
+-- a computable copy of Nonneg.nnRatCast
+instance : NNRatCast ℝ≥0 where nnratCast r := ⟨r, NNRat.cast_nonneg _⟩
+
 noncomputable instance : LinearOrderedSemifield ℝ≥0 :=
   Nonneg.linearOrderedSemifield
 

--- a/Mathlib/Data/Real/Basic.lean
+++ b/Mathlib/Data/Real/Basic.lean
@@ -543,7 +543,8 @@ noncomputable instance decidableEq (a b : ℝ) : Decidable (a = b) := by infer_i
 The representative chosen is the one passed in the VM to `Quot.mk`, so two cauchy sequences
 converging to the same number may be printed differently.
 -/
-unsafe instance : Repr ℝ where reprPrec r _ := "Real.ofCauchy " ++ repr r.cauchy
+unsafe instance : Repr ℝ where
+  reprPrec r p := Repr.addAppParen ("Real.ofCauchy " ++ repr r.cauchy) p
 
 theorem le_mk_of_forall_le {f : CauSeq ℚ abs} : (∃ i, ∀ j ≥ i, x ≤ f j) → x ≤ mk f := by
   intro h


### PR DESCRIPTION
This lets us write `0.5 : NNReal` and `0.5 : ENNReal` without issue; previously the former was noncomputable, and there was no instance for the latter.

This also adds some mostly-useless `Repr` instances, which are useful for testing this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
