### PR TITLE
[Merged by Bors] - feat(Data/Matroid/Constructions): Instances for basic matroids

### DIFF
--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -263,6 +263,12 @@ instance finiteRk_of_finite (M : Matroid α) [M.Finite] : FiniteRk M :=
   /-- The empty set isn't a base -/
   empty_not_base : ¬M.Base ∅
 
+instance rkPos_nonempty {M : Matroid α} [M.RkPos] : M.Nonempty := by
+  obtain ⟨B, hB⟩ := M.exists_base
+  obtain rfl | ⟨e, heB⟩ := B.eq_empty_or_nonempty
+  · exact False.elim <| RkPos.empty_not_base hB
+  exact ⟨e, M.subset_ground B hB heB ⟩
+
 @[deprecated (since := "2025-01-20")] alias rkPos_iff_empty_not_base := rkPos_iff
 
 section exchange

--- a/Mathlib/Data/Matroid/Constructions.lean
+++ b/Mathlib/Data/Matroid/Constructions.lean
@@ -128,6 +128,9 @@ theorem eq_loopyOn_or_rkPos (M : Matroid α) : M = loopyOn M.E ∨ RkPos M := by
 theorem not_rkPos_iff : ¬RkPos M ↔ M = loopyOn M.E := by
   rw [rkPos_iff, not_iff_comm, empty_base_iff]
 
+instance loopyOn_finiteRk : FiniteRk (loopyOn E) :=
+  ⟨∅, by simp⟩
+
 end LoopyOn
 
 section FreeOn
@@ -182,6 +185,13 @@ theorem restrict_eq_freeOn_iff : M ↾ I = freeOn I ↔ M.Indep I := by
 
 theorem Indep.restrict_eq_freeOn (hI : M.Indep I) : M ↾ I = freeOn I := by
   rwa [restrict_eq_freeOn_iff]
+
+instance freeOn_finitary : Finitary (freeOn E) := by
+  simp only [finitary_iff, freeOn_indep_iff]
+  exact fun I h e heI ↦ by simpa using h {e} (by simpa)
+
+lemma freeOn_rkPos (hE : E.Nonempty) : RkPos (freeOn E) := by
+  simp [rkPos_iff, hE.ne_empty.symm]
 
 end FreeOn
 
@@ -242,6 +252,20 @@ theorem uniqueBaseOn_restrict' (I E R : Set α) :
 theorem uniqueBaseOn_restrict (h : I ⊆ E) (R : Set α) :
     (uniqueBaseOn I E) ↾ R = uniqueBaseOn (I ∩ R) R := by
   rw [uniqueBaseOn_restrict', inter_right_comm, inter_eq_self_of_subset_left h]
+
+lemma uniqueBaseOn_finiteRk (hI : I.Finite) : FiniteRk (uniqueBaseOn I E) := by
+  rw [← uniqueBaseOn_inter_ground_eq]
+  refine ⟨I ∩ E, ?_⟩
+  rw [uniqueBaseOn_base_iff inter_subset_right, and_iff_right rfl]
+  exact hI.subset inter_subset_left
+
+instance uniqueBaseOn_finitary : Finitary (uniqueBaseOn I E) := by
+  refine ⟨fun K hK ↦ ?_⟩
+  simp only [uniqueBaseOn_indep_iff'] at hK ⊢
+  exact fun e heK ↦ singleton_subset_iff.1 <| hK _ (by simpa) (by simp)
+
+lemma uniqueBaseOn_rkPos (hIE : I ⊆ E) (hI : I.Nonempty) : RkPos (uniqueBaseOn I E) where
+  empty_not_base := by simpa [uniqueBaseOn_base_iff hIE] using Ne.symm <| hI.ne_empty
 
 end uniqueBaseOn
 


### PR DESCRIPTION
We add some instances for the matroids in `Data/Matroid/Constructions`, and also a `RkPos -> Nonempty` instance in `Matroid.Basic`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
