### PR TITLE
chore(Data/List/ReduceOption): remove redundant `_iff` suffixes

### DIFF
--- a/Mathlib/Data/List/ReduceOption.lean
+++ b/Mathlib/Data/List/ReduceOption.lean
@@ -46,7 +46,7 @@ theorem reduceOption_replicate_none {n : ℕ} : (replicate n (@none α)).reduceO
   rw [filterMap_replicate_of_none]
   rfl
 
-theorem reduceOption_eq_nil_iff (l : List (Option α)) :
+theorem reduceOption_eq_nil {l : List (Option α)} :
     l.reduceOption = [] ↔ ∃ n, l = replicate n none := by
   dsimp [reduceOption]
   rw [filterMap_eq_nil_iff]
@@ -57,7 +57,7 @@ theorem reduceOption_eq_nil_iff (l : List (Option α)) :
     simp_rw [h, mem_replicate]
     tauto
 
-theorem reduceOption_eq_singleton_iff (l : List (Option α)) (a : α) :
+theorem reduceOption_eq_singleton {l : List (Option α)} {a : α} :
     l.reduceOption = [a] ↔ ∃ m n, l = replicate m none ++ some a :: replicate n none := by
   dsimp [reduceOption]
   constructor
@@ -92,7 +92,7 @@ theorem reduceOption_eq_concat_iff (l : List (Option α)) (l' : List α) (a : α
   · intro h
     rw [reduceOption_eq_append_iff] at h
     obtain ⟨l₁, _, h, hl₁, hl₂⟩ := h
-    rw [reduceOption_eq_singleton_iff] at hl₂
+    rw [reduceOption_eq_singleton] at hl₂
     obtain ⟨m, n, hl₂⟩ := hl₂
     use l₁ ++ replicate m none, replicate n none
     simp_rw [h, reduceOption_append, reduceOption_replicate_none, append_assoc, append_nil, hl₁,


### PR DESCRIPTION
These theorems are unambiguously iff, so the suffix is redundant. The arguments are also made implicit.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

@YaelDillies suggested removing redundant suffixes in #20645.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
