### PR TITLE
[Merged by Bors] - feat: notation for variance according to a measure

### DIFF
--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -56,6 +56,11 @@ to `evariance`. -/
 def variance {Ω : Type*} {_ : MeasurableSpace Ω} (X : Ω → ℝ) (μ : Measure Ω) : ℝ :=
   (evariance X μ).toReal
 
+scoped notation "eVar[" X " ; " μ "]" => ProbabilityTheory.evariance X μ
+scoped notation "eVar[" X "]" => eVar[X ; MeasureTheory.MeasureSpace.volume]
+scoped notation "Var[" X " ; " μ "]" => ProbabilityTheory.variance X μ
+scoped notation "Var[" X "]" => Var[X ; MeasureTheory.MeasureSpace.volume]
+
 variable {Ω : Type*} {m : MeasurableSpace Ω} {X : Ω → ℝ} {μ : Measure Ω}
 
 theorem _root_.MeasureTheory.Memℒp.evariance_lt_top [IsFiniteMeasure μ] (hX : Memℒp X 2 μ) :
@@ -151,7 +156,9 @@ theorem evariance_mul (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) :
   rw [mul_comm]
   simp_rw [← smul_eq_mul, ← integral_smul_const, smul_eq_mul, mul_comm]
 
-scoped notation "eVar[" X "]" => ProbabilityTheory.evariance X MeasureTheory.MeasureSpace.volume
+lemma variance_eq_integral (hX : AEMeasurable (fun ω ↦ (‖X ω - ∫ ω', X ω' ∂μ‖₊ : ℝ≥0∞) ^ 2) μ) :
+    Var[X ; μ] = ∫ ω, (X ω - μ[X]) ^ 2 ∂μ := by
+  simp [variance, evariance, ← integral_toReal hX (by simp [← ENNReal.coe_pow])]
 
 @[simp]
 theorem variance_zero (μ : Measure Ω) : variance 0 μ = 0 := by
@@ -174,8 +181,6 @@ theorem variance_smul' {A : Type*} [CommSemiring A] [Algebra A ℝ] (c : A) (X :
   convert variance_smul (algebraMap A ℝ c) X μ using 1
   · congr; simp only [algebraMap_smul]
   · simp only [Algebra.smul_def, map_pow]
-
-scoped notation "Var[" X "]" => ProbabilityTheory.variance X MeasureTheory.MeasureSpace.volume
 
 theorem variance_def' [IsProbabilityMeasure μ] {X : Ω → ℝ} (hX : Memℒp X 2 μ) :
     variance X μ = μ[X ^ 2] - μ[X] ^ 2 := by

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -56,9 +56,25 @@ to `evariance`. -/
 def variance {Ω : Type*} {_ : MeasurableSpace Ω} (X : Ω → ℝ) (μ : Measure Ω) : ℝ :=
   (evariance X μ).toReal
 
+/-- The `ℝ≥0∞`-valued variance of the real-valued random variable `X` according to the measure `μ`.
+
+This is defined as the Lebesgue integral of `(X - 𝔼[X])^2`. -/
 scoped notation "eVar[" X " ; " μ "]" => ProbabilityTheory.evariance X μ
+
+/-- The `ℝ≥0∞`-valued variance of the real-valued random variable `X` according to the volume
+measure.
+
+This is defined as the Lebesgue integral of `(X - 𝔼[X])^2`. -/
 scoped notation "eVar[" X "]" => eVar[X ; MeasureTheory.MeasureSpace.volume]
+
+/-- The `ℝ`-valued variance of the real-valued random variable `X` according to the measure `μ`.
+
+It is set to `0` if `X` has infinite variance. -/
 scoped notation "Var[" X " ; " μ "]" => ProbabilityTheory.variance X μ
+
+/-- The `ℝ`-valued variance of the real-valued random variable `X` according to the volume measure.
+
+It is set to `0` if `X` has infinite variance. -/
 scoped notation "Var[" X "]" => Var[X ; MeasureTheory.MeasureSpace.volume]
 
 variable {Ω : Type*} {m : MeasurableSpace Ω} {X : Ω → ℝ} {μ : Measure Ω}

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -172,10 +172,6 @@ theorem evariance_mul (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) :
   rw [mul_comm]
   simp_rw [← smul_eq_mul, ← integral_smul_const, smul_eq_mul, mul_comm]
 
-lemma variance_eq_integral (hX : AEMeasurable (fun ω ↦ (‖X ω - ∫ ω', X ω' ∂μ‖₊ : ℝ≥0∞) ^ 2) μ) :
-    Var[X ; μ] = ∫ ω, (X ω - μ[X]) ^ 2 ∂μ := by
-  simp [variance, evariance, ← integral_toReal hX (by simp [← ENNReal.coe_pow])]
-
 @[simp]
 theorem variance_zero (μ : Measure Ω) : variance 0 μ = 0 := by
   simp only [variance, evariance_zero, ENNReal.zero_toReal]


### PR DESCRIPTION
The convention of using `X ; μ` to denote that `X` is sampled with measure `μ` comes from PFR.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/116395-maths/topic/.60MeasureSpace.60.20vs.20.60Measure.60.20in.20.60ProbabilityTheory.2F.60/near/476702131)

From my PhD (LeanCamCombi)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
