### PR TITLE
[Merged by Bors] - feat(CI): Zulip `:closed-pr:` emoji reaction

### DIFF
--- a/.github/workflows/zulip_emoji_closed_pr.yaml
+++ b/.github/workflows/zulip_emoji_closed_pr.yaml
@@ -21,7 +21,7 @@ jobs:
           # may be superfluous: GitHub may print the values of the environment variables by default
           printf '%s' "${TITLE}" | hexdump -cC
           printf 'PR title:"%s"\n' "${TITLE}"
-          printf 'issue number: %s\npull request number: %s\n' "${{ github.event.issue.number }}" "${{ github.event.pull_request.number }}"
+          printf 'issue number: "%s"\npull request number: "%s"\n' "${{ github.event.issue.number }}" "${{ github.event.pull_request.number }}"
 
       - name: Set up Python
         if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') }}

--- a/.github/workflows/zulip_emoji_closed_pr.yaml
+++ b/.github/workflows/zulip_emoji_closed_pr.yaml
@@ -1,0 +1,50 @@
+name: Add "closed-pr" emoji in Zulip
+
+# triggers the action when
+on:
+  pull_request:
+    # the pull request is closed
+    types: [closed]
+
+jobs:
+  add_closed_pr_emoji:
+    # we set the `TITLE` of the PR as a variable, this shields from possible code injection
+    env:
+      TITLE: ${{ github.event.pull_request.title }}
+
+    name: Add closed-pr emoji in Zulip
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debugging information
+        run: |
+          # may be superfluous: GitHub may print the values of the environment variables by default
+          printf '%s' "${TITLE}" | hexdump -cC
+          printf 'PR title:"%s"\n' "${TITLE}"
+          printf 'issue number: %s\npull request number: %s\n' "${{ github.event.issue.number }}" "${{ github.event.pull_request.number }}"
+
+      - name: Set up Python
+        if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install zulip
+
+      - uses: actions/checkout@v4
+        if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') }}
+        with:
+          sparse-checkout: |
+            scripts/zulip_emoji_merge_delegate.py
+
+      - name: Run Zulip Emoji Merge Delegate Script
+        if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') }}
+        env:
+          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+          ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
+          ZULIP_SITE: https://leanprover.zulipchat.com
+        run: |
+          python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "closed" "${{ github.event.issue.number }}${{ github.event.pull_request.number }}"

--- a/.github/workflows/zulip_emoji_closed_pr.yaml
+++ b/.github/workflows/zulip_emoji_closed_pr.yaml
@@ -1,4 +1,5 @@
 name: Add "closed-pr" emoji in Zulip
+# adds a reaction to Zulip messages that refer to a PR that was closed, but not merged
 
 # triggers the action when
 on:

--- a/.github/workflows/zulip_emoji_closed_pr.yaml
+++ b/.github/workflows/zulip_emoji_closed_pr.yaml
@@ -34,8 +34,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install zulip
 
-      - uses: actions/checkout@v4
+      - name: checkout zulip_emoji_merge_delegate script
         if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') }}
+        uses: actions/checkout@v4
         with:
           sparse-checkout: |
             scripts/zulip_emoji_merge_delegate.py

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -66,6 +66,7 @@ for message in messages:
     has_bors = any(reaction['emoji_name'] == 'bors' for reaction in reactions)
     has_merge = any(reaction['emoji_name'] == 'merge' for reaction in reactions)
     has_awaiting_author = any(reaction['emoji_name'] == 'writing' for reaction in reactions)
+    has_closed = any(reaction['emoji_name'] == 'closed-pr' for reaction in reactions)
     match = pr_pattern.search(content)
     if match:
         print(f"matched: '{message}'")
@@ -102,6 +103,13 @@ for message in messages:
                 "emoji_name": "writing"
             })
             print(f"result: '{result}'")
+        if has_closed:
+            print('Removing awaiting-author')
+            result = client.remove_reaction({
+                "message_id": message['id'],
+                "emoji_name": "closed-pr"
+            })
+            print(f"result: '{result}'")
 
 
         # applying appropriate emoji reaction
@@ -123,6 +131,12 @@ for message in messages:
             client.add_reaction({
                 "message_id": message['id'],
                 "emoji_name": "writing"
+            })
+        elif LABEL == 'closed':
+            print('adding closed-pr')
+            client.add_reaction({
+                "message_id": message['id'],
+                "emoji_name": "closed-pr"
             })
         elif LABEL == 'unlabeled':
             print('awaiting-author removed')

--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -104,7 +104,7 @@ for message in messages:
             })
             print(f"result: '{result}'")
         if has_closed:
-            print('Removing awaiting-author')
+            print('Removing closed-pr')
             result = client.remove_reaction({
                 "message_id": message['id'],
                 "emoji_name": "closed-pr"


### PR DESCRIPTION
Add a workflow that is triggered by closing a PR.  If the PR does title not start with `[Merged by Bors]`, then the script adds the `:closed-pr:` emoji reaction to messages on Zulip that link to the PR number.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
