### PR TITLE
[Merged by Bors] - feat: Borel-measurable group homs from locally compact normed groups to real normed spaces are continuous

### DIFF
--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -651,3 +651,34 @@ abbrev NormedSpace.ofCore {𝕜 : Type*} {E : Type*} [NormedField 𝕜] [Seminor
   norm_smul_le r x := by rw [core.norm_smul r x]
 
 end Core
+
+variable {G H : Type*} [SeminormedAddCommGroup G] [SeminormedAddCommGroup H] [NormedSpace ℝ H]
+  {s : Set G}
+
+/-- A group homomorphism from a normed group to a real normed space,
+bounded on a neighborhood of `0`, must be continuous. -/
+lemma AddMonoidHom.continuous_of_isBounded_nhds_zero (f : G →+ H) (hs : s ∈ 𝓝 (0 : G))
+    (hbounded : IsBounded (f '' s)) : Continuous f := by
+  obtain ⟨δ, hδ, hUε⟩ := Metric.mem_nhds_iff.mp hs
+  obtain ⟨C, hC⟩ := (isBounded_iff_subset_ball 0).1 (hbounded.subset <| image_subset f hUε)
+  refine continuous_of_continuousAt_zero _ (continuousAt_iff.2 fun ε (hε : _ < _) => ?_)
+  simp only [dist_zero_right, _root_.map_zero, exists_prop]
+  simp only [subset_def, mem_image, mem_ball, dist_zero_right, forall_exists_index, and_imp,
+    forall_apply_eq_imp_iff₂] at hC
+  have hC₀ : 0 < C := (norm_nonneg _).trans_lt <| hC 0 (by simpa)
+  obtain ⟨n, hn⟩ := exists_nat_gt (C / ε)
+  have hnpos : 0 < (n : ℝ) := (div_pos hC₀ hε).trans hn
+  have hn₀ : n ≠ 0 := by rintro rfl; simp at hnpos
+  refine ⟨δ / n, div_pos hδ hnpos, fun {x} hxδ => ?_⟩
+  calc
+    ‖f x‖
+    _ = ‖(n : ℝ)⁻¹ • f (n • x)‖ := by simp [← Nat.cast_smul_eq_nsmul ℝ, hn₀]
+    _ ≤ ‖(n : ℝ)⁻¹‖ * ‖f (n • x)‖ := norm_smul_le ..
+    _ < ‖(n : ℝ)⁻¹‖ * C := by
+      gcongr
+      · simpa [pos_iff_ne_zero]
+      · refine hC _ <| norm_nsmul_le.trans_lt ?_
+        simpa only [norm_mul, Real.norm_natCast, lt_div_iff₀ hnpos, mul_comm] using hxδ
+    _ = (n : ℝ)⁻¹ * C := by simp
+    _ < (C / ε : ℝ)⁻¹ * C := by gcongr
+    _ = ε := by simp [hC₀.ne']

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -1154,11 +1154,14 @@ end
 open Bornology Metric Set
 open scoped Topology
 
-variable {G : Type*} [SeminormedAddCommGroup G] [TopologicalAddGroup G] {s : Set G}
+variable {G H : Type*} [SeminormedAddCommGroup G] [SeminormedAddCommGroup H] [NormedSpace K H]
+  {s : Set G}
 
-/-- A group hom from a normed group to `ℝ` or `ℂ`, bounded on a neighborhood of `0`, must be
-continuous. -/
-lemma AddMonoidHom.continuous_of_isBounded_nhds_zero (f : G →+ K) (hs : s ∈ 𝓝 (0 : G))
+variable (K) in
+include K in
+/-- A group homomorphism from a normed group to a `ℝ`- or `ℂ`-normed space,
+bounded on a neighborhood of `0`, must be continuous. -/
+lemma AddMonoidHom.continuous_of_isBounded_nhds_zero (f : G →+ H) (hs : s ∈ 𝓝 (0 : G))
     (hbounded : IsBounded (f '' s)) : Continuous f := by
   obtain ⟨δ, hδ, hUε⟩ := Metric.mem_nhds_iff.mp hs
   obtain ⟨C, hC⟩ := (isBounded_iff_subset_ball 0).1 (hbounded.subset <| image_subset f hUε)
@@ -1169,13 +1172,17 @@ lemma AddMonoidHom.continuous_of_isBounded_nhds_zero (f : G →+ K) (hs : s ∈ 
   have hC₀ : 0 < C := (norm_nonneg _).trans_lt <| hC 0 (by simpa)
   obtain ⟨n, hn⟩ := exists_nat_gt (C / ε)
   have hnpos : 0 < (n : ℝ) := (div_pos hC₀ hε).trans hn
+  have hn₀ : n ≠ 0 := by rintro rfl; simp at hnpos
   refine ⟨δ / n, div_pos hδ hnpos, fun {x} hxδ => ?_⟩
-  have h2 : f (n • x) = n • f x := map_nsmul f _ _
-  have hn' : (n : K) ≠ 0 := Nat.cast_ne_zero.2 (by rintro rfl; simp at hnpos)
-  simp_rw [nsmul_eq_mul, mul_comm (n : K), ← div_eq_iff hn'] at h2
-  replace hxδ : ‖n • x‖ < δ := by
-    refine norm_nsmul_le.trans_lt ?_
-    simpa only [norm_mul, Real.norm_natCast, lt_div_iff₀ hnpos, mul_comm] using hxδ
-  rw [← h2, norm_div, RCLike.norm_natCast, div_lt_iff₀' hnpos]
-  rw [div_lt_iff₀ hε] at hn
-  exact (hC _ hxδ).trans hn
+  calc
+    ‖f x‖
+    _ = ‖(n : K)⁻¹ • f (n • x)‖ := by simp [← Nat.cast_smul_eq_nsmul K, hn₀]
+    _ ≤ ‖(n : K)⁻¹‖ * ‖f (n • x)‖ := norm_smul_le ..
+    _ < ‖(n : K)⁻¹‖ * C := by
+      gcongr
+      · simpa [pos_iff_ne_zero]
+      · refine hC _ <| norm_nsmul_le.trans_lt ?_
+        simpa only [norm_mul, Real.norm_natCast, lt_div_iff₀ hnpos, mul_comm] using hxδ
+    _ = (n : ℝ)⁻¹ * C := by simp
+    _ < (C / ε : ℝ)⁻¹ * C := by gcongr
+    _ = ε := by simp [hC₀.ne']

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -1150,3 +1150,32 @@ noncomputable def IsRCLikeNormedField.rclike (𝕜 : Type*)
   exact p.copy_of_normedField hk hp
 
 end
+
+open Bornology Metric Set
+open scoped Topology
+
+variable {G : Type*} [SeminormedAddCommGroup G] [TopologicalAddGroup G] {s : Set G}
+
+/-- A group hom from a normed group to `ℝ` or `ℂ`, bounded on a neighborhood of `0`, must be
+continuous. -/
+lemma AddMonoidHom.continuous_of_isBounded_nhds_zero (f : G →+ K) (hs : s ∈ 𝓝 (0 : G))
+    (hbounded : IsBounded (f '' s)) : Continuous f := by
+  obtain ⟨δ, hδ, hUε⟩ := Metric.mem_nhds_iff.mp hs
+  obtain ⟨C, hC⟩ := (isBounded_iff_subset_ball 0).1 (hbounded.subset <| image_subset f hUε)
+  refine continuous_of_continuousAt_zero _ (continuousAt_iff.2 fun ε (hε : _ < _) => ?_)
+  simp only [dist_zero_right, _root_.map_zero, exists_prop]
+  simp only [subset_def, mem_image, mem_ball, dist_zero_right, forall_exists_index, and_imp,
+    forall_apply_eq_imp_iff₂] at hC
+  have hC₀ : 0 < C := (norm_nonneg _).trans_lt <| hC 0 (by simpa)
+  obtain ⟨n, hn⟩ := exists_nat_gt (C / ε)
+  have hnpos : 0 < (n : ℝ) := (div_pos hC₀ hε).trans hn
+  refine ⟨δ / n, div_pos hδ hnpos, fun {x} hxδ => ?_⟩
+  have h2 : f (n • x) = n • f x := map_nsmul f _ _
+  have hn' : (n : K) ≠ 0 := Nat.cast_ne_zero.2 (by rintro rfl; simp at hnpos)
+  simp_rw [nsmul_eq_mul, mul_comm (n : K), ← div_eq_iff hn'] at h2
+  replace hxδ : ‖n • x‖ < δ := by
+    refine norm_nsmul_le.trans_lt ?_
+    simpa only [norm_mul, Real.norm_natCast, lt_div_iff₀ hnpos, mul_comm] using hxδ
+  rw [← h2, norm_div, RCLike.norm_natCast, div_lt_iff₀' hnpos]
+  rw [div_lt_iff₀ hε] at hn
+  exact (hC _ hxδ).trans hn

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -1150,39 +1150,3 @@ noncomputable def IsRCLikeNormedField.rclike (𝕜 : Type*)
   exact p.copy_of_normedField hk hp
 
 end
-
-open Bornology Metric Set
-open scoped Topology
-
-variable {G H : Type*} [SeminormedAddCommGroup G] [SeminormedAddCommGroup H] [NormedSpace K H]
-  {s : Set G}
-
-variable (K) in
-include K in
-/-- A group homomorphism from a normed group to a `ℝ`- or `ℂ`-normed space,
-bounded on a neighborhood of `0`, must be continuous. -/
-lemma AddMonoidHom.continuous_of_isBounded_nhds_zero (f : G →+ H) (hs : s ∈ 𝓝 (0 : G))
-    (hbounded : IsBounded (f '' s)) : Continuous f := by
-  obtain ⟨δ, hδ, hUε⟩ := Metric.mem_nhds_iff.mp hs
-  obtain ⟨C, hC⟩ := (isBounded_iff_subset_ball 0).1 (hbounded.subset <| image_subset f hUε)
-  refine continuous_of_continuousAt_zero _ (continuousAt_iff.2 fun ε (hε : _ < _) => ?_)
-  simp only [dist_zero_right, _root_.map_zero, exists_prop]
-  simp only [subset_def, mem_image, mem_ball, dist_zero_right, forall_exists_index, and_imp,
-    forall_apply_eq_imp_iff₂] at hC
-  have hC₀ : 0 < C := (norm_nonneg _).trans_lt <| hC 0 (by simpa)
-  obtain ⟨n, hn⟩ := exists_nat_gt (C / ε)
-  have hnpos : 0 < (n : ℝ) := (div_pos hC₀ hε).trans hn
-  have hn₀ : n ≠ 0 := by rintro rfl; simp at hnpos
-  refine ⟨δ / n, div_pos hδ hnpos, fun {x} hxδ => ?_⟩
-  calc
-    ‖f x‖
-    _ = ‖(n : K)⁻¹ • f (n • x)‖ := by simp [← Nat.cast_smul_eq_nsmul K, hn₀]
-    _ ≤ ‖(n : K)⁻¹‖ * ‖f (n • x)‖ := norm_smul_le ..
-    _ < ‖(n : K)⁻¹‖ * C := by
-      gcongr
-      · simpa [pos_iff_ne_zero]
-      · refine hC _ <| norm_nsmul_le.trans_lt ?_
-        simpa only [norm_mul, Real.norm_natCast, lt_div_iff₀ hnpos, mul_comm] using hxδ
-    _ = (n : ℝ)⁻¹ * C := by simp
-    _ < (C / ε : ℝ)⁻¹ * C := by gcongr
-    _ = ε := by simp [hC₀.ne']

--- a/Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean
@@ -46,7 +46,7 @@ variable {G H : Type*} [MeasurableSpace G] [Group G] [TopologicalSpace G]
   [TopologicalGroup G] [BorelSpace G] [LocallyCompactSpace G]
   [MeasurableSpace H] [SeminormedGroup H] [OpensMeasurableSpace H]
 
--- TODO: This could be streamlined by proving that inner regular always exist
+-- TODO: This could be streamlined by proving that inner regular measures always exist
 open Metric Bornology in
 @[to_additive]
 lemma _root_.MonoidHom.exists_nhds_isBounded (f : G →* H) (hf : Measurable f) (x : G) :
@@ -68,6 +68,12 @@ lemma _root_.MonoidHom.exists_nhds_isBounded (f : G →* H) (hf : Measurable f) 
   exact (this.div this).smul _
 
 end SeminormedGroup
+
+/-- A Borel-measurable group hom from a locally compact normed group to `ℝ` or `ℂ` is continuous. -/
+lemma AddMonoidHom.continuous_of_measurable {G K : Type*} [SeminormedAddCommGroup G]
+    [MeasurableSpace G] [BorelSpace G] [LocallyCompactSpace G] [RCLike K] (f : G →+ K)
+    (h : Measurable f) : Continuous f :=
+  let ⟨_s, hs, hbdd⟩ := f.exists_nhds_isBounded h 0; f.continuous_of_isBounded_nhds_zero hs hbdd
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
   [FiniteDimensional ℝ E] (μ : Measure E) [IsAddHaarMeasure μ] {F : Type*} [NormedAddCommGroup F]

--- a/Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean
@@ -74,7 +74,7 @@ continuous. -/
 lemma AddMonoidHom.continuous_of_measurable {G H : Type*}
     [SeminormedAddCommGroup G] [MeasurableSpace G] [BorelSpace G] [LocallyCompactSpace G]
     [SeminormedAddCommGroup H] [MeasurableSpace H] [OpensMeasurableSpace H] [NormedSpace ℝ H]
-    (f : G →+ K) (hf : Measurable f) : Continuous f :=
+    (f : G →+ H) (hf : Measurable f) : Continuous f :=
   let ⟨_s, hs, hbdd⟩ := f.exists_nhds_isBounded hf 0; f.continuous_of_isBounded_nhds_zero hs hbdd
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]

--- a/Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean
@@ -69,11 +69,13 @@ lemma _root_.MonoidHom.exists_nhds_isBounded (f : G →* H) (hf : Measurable f) 
 
 end SeminormedGroup
 
-/-- A Borel-measurable group hom from a locally compact normed group to `ℝ` or `ℂ` is continuous. -/
-lemma AddMonoidHom.continuous_of_measurable {G K : Type*} [SeminormedAddCommGroup G]
-    [MeasurableSpace G] [BorelSpace G] [LocallyCompactSpace G] [RCLike K] (f : G →+ K)
-    (h : Measurable f) : Continuous f :=
-  let ⟨_s, hs, hbdd⟩ := f.exists_nhds_isBounded h 0; f.continuous_of_isBounded_nhds_zero hs hbdd
+/-- A Borel-measurable group hom from a locally compact normed group to a real normed space is
+continuous. -/
+lemma AddMonoidHom.continuous_of_measurable {G H : Type*}
+    [SeminormedAddCommGroup G] [MeasurableSpace G] [BorelSpace G] [LocallyCompactSpace G]
+    [SeminormedAddCommGroup H] [MeasurableSpace H] [OpensMeasurableSpace H] [NormedSpace ℝ H]
+    (f : G →+ K) (hf : Measurable f) : Continuous f :=
+  let ⟨_s, hs, hbdd⟩ := f.exists_nhds_isBounded hf 0; f.continuous_of_isBounded_nhds_zero hs hbdd
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
   [FiniteDimensional ℝ E] (μ : Measure E) [IsAddHaarMeasure μ] {F : Type*} [NormedAddCommGroup F]


### PR DESCRIPTION
From LeanCamCombi

Co-authored-by: Mantas Baksys

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
