### PR TITLE
[Merged by Bors] - chore: rename `IsMetricSeparated` to `Metric.AreSeparated`

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Hausdorff.lean
+++ b/Mathlib/MeasureTheory/Measure/Hausdorff.lean
@@ -130,7 +130,7 @@ measure has the Caratheodory property.
 /-- We say that an outer measure `μ` in an (e)metric space is *metric* if `μ (s ∪ t) = μ s + μ t`
 for any two metric separated sets `s`, `t`. -/
 def IsMetric (μ : OuterMeasure X) : Prop :=
-  ∀ s t : Set X, IsMetricSeparated s t → μ (s ∪ t) = μ s + μ t
+  ∀ s t : Set X, Metric.AreSeparated s t → μ (s ∪ t) = μ s + μ t
 
 namespace IsMetric
 
@@ -138,7 +138,7 @@ variable {μ : OuterMeasure X}
 
 /-- A metric outer measure is additive on a finite set of pairwise metric separated sets. -/
 theorem finset_iUnion_of_pairwise_separated (hm : IsMetric μ) {I : Finset ι} {s : ι → Set X}
-    (hI : ∀ i ∈ I, ∀ j ∈ I, i ≠ j → IsMetricSeparated (s i) (s j)) :
+    (hI : ∀ i ∈ I, ∀ j ∈ I, i ≠ j → Metric.AreSeparated (s i) (s j)) :
     μ (⋃ i ∈ I, s i) = ∑ i ∈ I, μ (s i) := by
   classical
   induction' I using Finset.induction_on with i I hiI ihI hI
@@ -146,7 +146,7 @@ theorem finset_iUnion_of_pairwise_separated (hm : IsMetric μ) {I : Finset ι} {
   simp only [Finset.mem_insert] at hI
   rw [Finset.set_biUnion_insert, hm, ihI, Finset.sum_insert hiI]
   exacts [fun i hi j hj hij => hI i (Or.inr hi) j (Or.inr hj) hij,
-    IsMetricSeparated.finset_iUnion_right fun j hj =>
+    Metric.AreSeparated.finset_iUnion_right fun j hj =>
       hI i (Or.inl rfl) j (Or.inr hj) (ne_of_mem_of_not_mem hj hiI).symm]
 
 /-- Caratheodory theorem. If `m` is a metric outer measure, then every Borel measurable set `t` is
@@ -156,10 +156,10 @@ theorem borel_le_caratheodory (hm : IsMetric μ) : borel X ≤ μ.caratheodory :
   rw [borel_eq_generateFrom_isClosed]
   refine MeasurableSpace.generateFrom_le fun t ht => μ.isCaratheodory_iff_le.2 fun s => ?_
   set S : ℕ → Set X := fun n => {x ∈ s | (↑n)⁻¹ ≤ infEdist x t}
-  have Ssep (n) : IsMetricSeparated (S n) t :=
+  have Ssep (n) : Metric.AreSeparated (S n) t :=
     ⟨n⁻¹, ENNReal.inv_ne_zero.2 (ENNReal.natCast_ne_top _),
       fun x hx y hy ↦ hx.2.trans <| infEdist_le_edist_of_mem hy⟩
-  have Ssep' : ∀ n, IsMetricSeparated (S n) (s ∩ t) := fun n =>
+  have Ssep' : ∀ n, Metric.AreSeparated (S n) (s ∩ t) := fun n =>
     (Ssep n).mono Subset.rfl inter_subset_right
   have S_sub : ∀ n, S n ⊆ s \ t := fun n =>
     subset_inter inter_subset_left (Ssep n).subset_compl_right
@@ -204,7 +204,7 @@ theorem borel_le_caratheodory (hm : IsMetric μ) : borel X ≤ μ.caratheodory :
   intro n
   rw [← hm.finset_iUnion_of_pairwise_separated]
   · exact μ.mono (iUnion_subset fun i => iUnion_subset fun _ x hx => mem_iUnion.2 ⟨_, hx.1⟩)
-  suffices ∀ i j, i < j → IsMetricSeparated (S (2 * i + 1 + r)) (s \ S (2 * j + r)) from
+  suffices ∀ i j, i < j → Metric.AreSeparated (S (2 * i + 1 + r)) (s \ S (2 * j + r)) from
     fun i _ j _ hij => hij.lt_or_lt.elim
       (fun h => (this i j h).mono inter_subset_left fun x hx => by exact ⟨hx.1.1, hx.2⟩)
       fun h => (this j i h).symm.mono (fun x hx => by exact ⟨hx.1.1, hx.2⟩) inter_subset_left

--- a/Mathlib/Topology/MetricSpace/MetricSeparated.lean
+++ b/Mathlib/Topology/MetricSpace/MetricSeparated.lean
@@ -27,6 +27,8 @@ between `x ∈ s` and `y ∈ t` is bounded from below by a positive constant. -/
 def AreSeparated {X : Type*} [EMetricSpace X] (s t : Set X) :=
   ∃ r, r ≠ 0 ∧ ∀ x ∈ s, ∀ y ∈ t, r ≤ edist x y
 
+@[deprecated (since := "2025-01-21")] alias IsMetricSeparated := AreSeparated
+
 namespace AreSeparated
 
 variable {X : Type*} [EMetricSpace X] {s t : Set X}

--- a/Mathlib/Topology/MetricSpace/MetricSeparated.lean
+++ b/Mathlib/Topology/MetricSpace/MetricSeparated.lean
@@ -8,7 +8,7 @@ import Mathlib.Topology.EMetricSpace.Defs
 /-!
 # Metric separated pairs of sets
 
-In this file we define the predicate `IsMetricSeparated`. We say that two sets in an (extended)
+In this file we define the predicate `Metric.AreSeparated`. We say that two sets in an (extended)
 metric space are *metric separated* if the (extended) distance between `x ∈ s` and `y ∈ t` is
 bounded from below by a positive constant.
 
@@ -20,51 +20,52 @@ open EMetric Set
 
 noncomputable section
 
+namespace Metric
+
 /-- Two sets in an (extended) metric space are called *metric separated* if the (extended) distance
 between `x ∈ s` and `y ∈ t` is bounded from below by a positive constant. -/
-def IsMetricSeparated {X : Type*} [EMetricSpace X] (s t : Set X) :=
+def AreSeparated {X : Type*} [EMetricSpace X] (s t : Set X) :=
   ∃ r, r ≠ 0 ∧ ∀ x ∈ s, ∀ y ∈ t, r ≤ edist x y
 
-namespace IsMetricSeparated
+namespace AreSeparated
 
 variable {X : Type*} [EMetricSpace X] {s t : Set X}
 
 @[symm]
-theorem symm (h : IsMetricSeparated s t) : IsMetricSeparated t s :=
+theorem symm (h : AreSeparated s t) : AreSeparated t s :=
   let ⟨r, r0, hr⟩ := h
   ⟨r, r0, fun y hy x hx => edist_comm x y ▸ hr x hx y hy⟩
 
-theorem comm : IsMetricSeparated s t ↔ IsMetricSeparated t s :=
-  ⟨symm, symm⟩
+theorem comm : AreSeparated s t ↔ AreSeparated t s := ⟨symm, symm⟩
 
 @[simp]
-theorem empty_left (s : Set X) : IsMetricSeparated ∅ s :=
+theorem empty_left (s : Set X) : AreSeparated ∅ s :=
   ⟨1, one_ne_zero, fun _x => False.elim⟩
 
 @[simp]
-theorem empty_right (s : Set X) : IsMetricSeparated s ∅ :=
+theorem empty_right (s : Set X) : AreSeparated s ∅ :=
   (empty_left s).symm
 
-protected theorem disjoint (h : IsMetricSeparated s t) : Disjoint s t :=
+protected theorem disjoint (h : AreSeparated s t) : Disjoint s t :=
   let ⟨r, r0, hr⟩ := h
   Set.disjoint_left.mpr fun x hx1 hx2 => r0 <| by simpa using hr x hx1 x hx2
 
-theorem subset_compl_right (h : IsMetricSeparated s t) : s ⊆ tᶜ := fun _ hs ht =>
+theorem subset_compl_right (h : AreSeparated s t) : s ⊆ tᶜ := fun _ hs ht =>
   h.disjoint.le_bot ⟨hs, ht⟩
 
 @[mono]
 theorem mono {s' t'} (hs : s ⊆ s') (ht : t ⊆ t') :
-    IsMetricSeparated s' t' → IsMetricSeparated s t := fun ⟨r, r0, hr⟩ =>
+    AreSeparated s' t' → AreSeparated s t := fun ⟨r, r0, hr⟩ =>
   ⟨r, r0, fun x hx y hy => hr x (hs hx) y (ht hy)⟩
 
-theorem mono_left {s'} (h' : IsMetricSeparated s' t) (hs : s ⊆ s') : IsMetricSeparated s t :=
+theorem mono_left {s'} (h' : AreSeparated s' t) (hs : s ⊆ s') : AreSeparated s t :=
   h'.mono hs Subset.rfl
 
-theorem mono_right {t'} (h' : IsMetricSeparated s t') (ht : t ⊆ t') : IsMetricSeparated s t :=
+theorem mono_right {t'} (h' : AreSeparated s t') (ht : t ⊆ t') : AreSeparated s t :=
   h'.mono Subset.rfl ht
 
-theorem union_left {s'} (h : IsMetricSeparated s t) (h' : IsMetricSeparated s' t) :
-    IsMetricSeparated (s ∪ s') t := by
+theorem union_left {s'} (h : AreSeparated s t) (h' : AreSeparated s' t) :
+    AreSeparated (s ∪ s') t := by
   rcases h, h' with ⟨⟨r, r0, hr⟩, ⟨r', r0', hr'⟩⟩
   refine ⟨min r r', ?_, fun x hx y hy => hx.elim ?_ ?_⟩
   · rw [← pos_iff_ne_zero] at r0 r0' ⊢
@@ -74,42 +75,42 @@ theorem union_left {s'} (h : IsMetricSeparated s t) (h' : IsMetricSeparated s' t
 
 @[simp]
 theorem union_left_iff {s'} :
-    IsMetricSeparated (s ∪ s') t ↔ IsMetricSeparated s t ∧ IsMetricSeparated s' t :=
+    AreSeparated (s ∪ s') t ↔ AreSeparated s t ∧ AreSeparated s' t :=
   ⟨fun h => ⟨h.mono_left subset_union_left, h.mono_left subset_union_right⟩, fun h =>
     h.1.union_left h.2⟩
 
-theorem union_right {t'} (h : IsMetricSeparated s t) (h' : IsMetricSeparated s t') :
-    IsMetricSeparated s (t ∪ t') :=
+theorem union_right {t'} (h : AreSeparated s t) (h' : AreSeparated s t') :
+    AreSeparated s (t ∪ t') :=
   (h.symm.union_left h'.symm).symm
 
 @[simp]
 theorem union_right_iff {t'} :
-    IsMetricSeparated s (t ∪ t') ↔ IsMetricSeparated s t ∧ IsMetricSeparated s t' :=
+    AreSeparated s (t ∪ t') ↔ AreSeparated s t ∧ AreSeparated s t' :=
   comm.trans <| union_left_iff.trans <| and_congr comm comm
 
 theorem finite_iUnion_left_iff {ι : Type*} {I : Set ι} (hI : I.Finite) {s : ι → Set X}
-    {t : Set X} : IsMetricSeparated (⋃ i ∈ I, s i) t ↔ ∀ i ∈ I, IsMetricSeparated (s i) t := by
+    {t : Set X} : AreSeparated (⋃ i ∈ I, s i) t ↔ ∀ i ∈ I, AreSeparated (s i) t := by
   refine Finite.induction_on _ hI (by simp) @fun i I _ _ hI => ?_
   rw [biUnion_insert, forall_mem_insert, union_left_iff, hI]
 
 alias ⟨_, finite_iUnion_left⟩ := finite_iUnion_left_iff
 
 theorem finite_iUnion_right_iff {ι : Type*} {I : Set ι} (hI : I.Finite) {s : Set X}
-    {t : ι → Set X} : IsMetricSeparated s (⋃ i ∈ I, t i) ↔ ∀ i ∈ I, IsMetricSeparated s (t i) := by
+    {t : ι → Set X} : AreSeparated s (⋃ i ∈ I, t i) ↔ ∀ i ∈ I, AreSeparated s (t i) := by
   simpa only [@comm _ _ s] using finite_iUnion_left_iff hI
 
 @[simp]
 theorem finset_iUnion_left_iff {ι : Type*} {I : Finset ι} {s : ι → Set X} {t : Set X} :
-    IsMetricSeparated (⋃ i ∈ I, s i) t ↔ ∀ i ∈ I, IsMetricSeparated (s i) t :=
+    AreSeparated (⋃ i ∈ I, s i) t ↔ ∀ i ∈ I, AreSeparated (s i) t :=
   finite_iUnion_left_iff I.finite_toSet
 
 alias ⟨_, finset_iUnion_left⟩ := finset_iUnion_left_iff
 
 @[simp]
 theorem finset_iUnion_right_iff {ι : Type*} {I : Finset ι} {s : Set X} {t : ι → Set X} :
-    IsMetricSeparated s (⋃ i ∈ I, t i) ↔ ∀ i ∈ I, IsMetricSeparated s (t i) :=
+    AreSeparated s (⋃ i ∈ I, t i) ↔ ∀ i ∈ I, AreSeparated s (t i) :=
   finite_iUnion_right_iff I.finite_toSet
 
 alias ⟨_, finset_iUnion_right⟩ := finset_iUnion_right_iff
 
-end IsMetricSeparated
+end Metric.AreSeparated


### PR DESCRIPTION
I need the predicate of a single set to be metric-separated, but the current one which is about two sets is stealing the name.

From my PhD (LeanCamCombi)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
