### PR TITLE
[Merged by Bors] - doc(Order/Hom/Lattice): warn against `toFun`

### DIFF
--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -49,37 +49,45 @@ structure SupHom (α β : Type*) [Max α] [Max β] where
   Instead use the coercion coming from the `FunLike` instance. -/
   toFun : α → β
   /-- A `SupHom` preserves suprema.
-  Do not use this directly. Use `SupHom.map_sup` instead. -/
+  Do not use this directly. Use `SupHomClass.map_sup` instead. -/
   map_sup' (a b : α) : toFun (a ⊔ b) = toFun a ⊔ toFun b
 
 /-- The type of `⊓`-preserving functions from `α` to `β`. -/
 structure InfHom (α β : Type*) [Min α] [Min β] where
-  /-- The underlying function of an `InfHom` -/
+  /-- The underlying function of an `InfHom`.
+  Do not use this Function directly.
+  Instead use the coercion coming from the `FunLike` instance. -/
   toFun : α → β
-  /-- An `InfHom` preserves infima. -/
+  /-- An `InfHom` preserves infima.
+  Do not use this directly. Use `InfHomClass.map_inf` instead. -/
   map_inf' (a b : α) : toFun (a ⊓ b) = toFun a ⊓ toFun b
 
 /-- The type of finitary supremum-preserving homomorphisms from `α` to `β`. -/
 structure SupBotHom (α β : Type*) [Max α] [Max β] [Bot α] [Bot β] extends SupHom α β where
-  /-- A `SupBotHom` preserves the bottom element. -/
+  /-- A `SupBotHom` preserves the bottom element.
+  Do not use this directly. Use `SupBotHomClass.map_bot` instead. -/
   map_bot' : toFun ⊥ = ⊥
 
 /-- The type of finitary infimum-preserving homomorphisms from `α` to `β`. -/
 structure InfTopHom (α β : Type*) [Min α] [Min β] [Top α] [Top β] extends InfHom α β where
-  /-- An `InfTopHom` preserves the top element. -/
+  /-- An `InfTopHom` preserves the top element.
+  Do not use this directly. Use `InfTopHomClass.map_top` instead. -/
   map_top' : toFun ⊤ = ⊤
 
 /-- The type of lattice homomorphisms from `α` to `β`. -/
 structure LatticeHom (α β : Type*) [Lattice α] [Lattice β] extends SupHom α β where
-  /-- A `LatticeHom` preserves infima. -/
+  /-- A `LatticeHom` preserves infima.
+  Do not use this directly. Use `LatticeHomClass.map_inf` instead. -/
   map_inf' (a b : α) : toFun (a ⊓ b) = toFun a ⊓ toFun b
 
 /-- The type of bounded lattice homomorphisms from `α` to `β`. -/
 structure BoundedLatticeHom (α β : Type*) [Lattice α] [Lattice β] [BoundedOrder α]
   [BoundedOrder β] extends LatticeHom α β where
-  /-- A `BoundedLatticeHom` preserves the top element. -/
+  /-- A `BoundedLatticeHom` preserves the top element.
+  Do not use this directly. Use `BoundedLatticeHomClass.map_top` instead. -/
   map_top' : toFun ⊤ = ⊤
-  /-- A `BoundedLatticeHom` preserves the bottom element. -/
+  /-- A `BoundedLatticeHom` preserves the bottom element.
+  Do not use this directly. Use `BoundedLatticeHomClass.map_bot` instead. -/
   map_bot' : toFun ⊥ = ⊥
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: remove this configuration and use the default configuration.
@@ -338,9 +346,6 @@ instance : FunLike (SupHom α β) α β where
 
 instance : SupHomClass (SupHom α β) α β where
   map_sup := SupHom.map_sup'
-
-lemma map_sup (f : SupHom α β) (a b : α) : f (a ⊔ b) = f a ⊔ f b := by
-  apply map_sup'
 
 @[simp] lemma toFun_eq_coe (f : SupHom α β) : f.toFun = f := rfl
 

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -44,9 +44,13 @@ variable {F ι α β γ δ : Type*}
 
 /-- The type of `⊔`-preserving functions from `α` to `β`. -/
 structure SupHom (α β : Type*) [Max α] [Max β] where
-  /-- The underlying function of a `SupHom` -/
+  /-- The underlying function of a `SupHom`.
+  Do not use this Function directly.
+  Instead use the coercion coming from the `FunLike` instance. -/
   toFun : α → β
-  /-- A `SupHom` preserves suprema. -/
+  /-- A `SupHom` preserves suprema.
+  Do not use this directly. Use `SupHom.map_sup` instead.
+  -/
   map_sup' (a b : α) : toFun (a ⊔ b) = toFun a ⊔ toFun b
 
 /-- The type of `⊓`-preserving functions from `α` to `β`. -/

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -49,8 +49,7 @@ structure SupHom (α β : Type*) [Max α] [Max β] where
   Instead use the coercion coming from the `FunLike` instance. -/
   toFun : α → β
   /-- A `SupHom` preserves suprema.
-  Do not use this directly. Use `SupHom.map_sup` instead.
-  -/
+  Do not use this directly. Use `SupHom.map_sup` instead. -/
   map_sup' (a b : α) : toFun (a ⊔ b) = toFun a ⊔ toFun b
 
 /-- The type of `⊓`-preserving functions from `α` to `β`. -/
@@ -339,6 +338,9 @@ instance : FunLike (SupHom α β) α β where
 
 instance : SupHomClass (SupHom α β) α β where
   map_sup := SupHom.map_sup'
+
+lemma map_sup (f : SupHom α β) (a b : α) : f (a ⊔ b) = f a ⊔ f b := by
+  apply map_sup'
 
 @[simp] lemma toFun_eq_coe (f : SupHom α β) : f.toFun = f := rfl
 

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -50,7 +50,8 @@ structure SupHom (α β : Type*) [Max α] [Max β] where
   instance. -/
   toFun : α → β
   /-- A `SupHom` preserves suprema.
-  Do not use this directly. Use `SupHomClass.map_sup` instead. -/
+
+  Do not use this directly. Use `map_sup` instead. -/
   map_sup' (a b : α) : toFun (a ⊔ b) = toFun a ⊔ toFun b
 
 /-- The type of `⊓`-preserving functions from `α` to `β`. -/

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -45,8 +45,9 @@ variable {F ι α β γ δ : Type*}
 /-- The type of `⊔`-preserving functions from `α` to `β`. -/
 structure SupHom (α β : Type*) [Max α] [Max β] where
   /-- The underlying function of a `SupHom`.
-  Do not use this Function directly.
-  Instead use the coercion coming from the `FunLike` instance. -/
+
+  Do not use this function directly. Instead use the coercion coming from the `FunLike`
+  instance. -/
   toFun : α → β
   /-- A `SupHom` preserves suprema.
   Do not use this directly. Use `SupHomClass.map_sup` instead. -/
@@ -55,39 +56,46 @@ structure SupHom (α β : Type*) [Max α] [Max β] where
 /-- The type of `⊓`-preserving functions from `α` to `β`. -/
 structure InfHom (α β : Type*) [Min α] [Min β] where
   /-- The underlying function of an `InfHom`.
-  Do not use this Function directly.
-  Instead use the coercion coming from the `FunLike` instance. -/
+
+  Do not use this function directly. Instead use the coercion coming from the `FunLike`
+  instance. -/
   toFun : α → β
   /-- An `InfHom` preserves infima.
-  Do not use this directly. Use `InfHomClass.map_inf` instead. -/
+
+  Do not use this directly. Use `map_inf` instead. -/
   map_inf' (a b : α) : toFun (a ⊓ b) = toFun a ⊓ toFun b
 
 /-- The type of finitary supremum-preserving homomorphisms from `α` to `β`. -/
 structure SupBotHom (α β : Type*) [Max α] [Max β] [Bot α] [Bot β] extends SupHom α β where
   /-- A `SupBotHom` preserves the bottom element.
-  Do not use this directly. Use `SupBotHomClass.map_bot` instead. -/
+
+  Do not use this directly. Use `map_bot` instead. -/
   map_bot' : toFun ⊥ = ⊥
 
 /-- The type of finitary infimum-preserving homomorphisms from `α` to `β`. -/
 structure InfTopHom (α β : Type*) [Min α] [Min β] [Top α] [Top β] extends InfHom α β where
   /-- An `InfTopHom` preserves the top element.
-  Do not use this directly. Use `InfTopHomClass.map_top` instead. -/
+
+  Do not use this directly. Use `map_top` instead. -/
   map_top' : toFun ⊤ = ⊤
 
 /-- The type of lattice homomorphisms from `α` to `β`. -/
 structure LatticeHom (α β : Type*) [Lattice α] [Lattice β] extends SupHom α β where
   /-- A `LatticeHom` preserves infima.
-  Do not use this directly. Use `LatticeHomClass.map_inf` instead. -/
+
+  Do not use this directly. Use `map_inf` instead. -/
   map_inf' (a b : α) : toFun (a ⊓ b) = toFun a ⊓ toFun b
 
 /-- The type of bounded lattice homomorphisms from `α` to `β`. -/
 structure BoundedLatticeHom (α β : Type*) [Lattice α] [Lattice β] [BoundedOrder α]
   [BoundedOrder β] extends LatticeHom α β where
   /-- A `BoundedLatticeHom` preserves the top element.
-  Do not use this directly. Use `BoundedLatticeHomClass.map_top` instead. -/
+
+  Do not use this directly. Use `map_top` instead. -/
   map_top' : toFun ⊤ = ⊤
   /-- A `BoundedLatticeHom` preserves the bottom element.
-  Do not use this directly. Use `BoundedLatticeHomClass.map_bot` instead. -/
+
+  Do not use this directly. Use `map_bot` instead. -/
   map_bot' : toFun ⊥ = ⊥
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: remove this configuration and use the default configuration.


### PR DESCRIPTION
---

This was discussed in #19440.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
