### PR TITLE
[Merged by Bors] - feat: add theorem about the norm of cross products

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3162,6 +3162,7 @@ import Mathlib.Geometry.Euclidean.Angle.Sphere
 import Mathlib.Geometry.Euclidean.Angle.Unoriented.Affine
 import Mathlib.Geometry.Euclidean.Angle.Unoriented.Basic
 import Mathlib.Geometry.Euclidean.Angle.Unoriented.Conformal
+import Mathlib.Geometry.Euclidean.Angle.Unoriented.CrossProduct
 import Mathlib.Geometry.Euclidean.Angle.Unoriented.RightAngle
 import Mathlib.Geometry.Euclidean.Basic
 import Mathlib.Geometry.Euclidean.Circumcenter

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
@@ -3,11 +3,10 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers, Manuel Candales
 -/
+import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Analysis.InnerProductSpace.Subspace
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse
 import Mathlib.LinearAlgebra.CrossProduct
-import Mathlib.Analysis.InnerProductSpace.PiL2
-
 
 /-!
 # Angles between vectors
@@ -356,6 +355,5 @@ theorem crossProduct_norm_eq_norm_mul_norm_mul_sin (a b : EuclideanSpace ℝ (Fi
       ← h_norm_sq_eq_inner, dotProduct_comm b a, dotProduct_eq_inner]
   linear_combination (‖a‖ * ‖b‖) ^ 2 * (sin_sq_add_cos_sq (angle a b)).symm +
     congrArg (· ^ 2) (cos_angle_mul_norm_mul_norm a b)
-
 
 end InnerProductGeometry

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
@@ -339,42 +339,23 @@ for members of `Fin 3 → ℝ` instead of the sup norm-/
 noncomputable def l2Norm (v : EuclideanSpace ℝ (Fin 3)) : ℝ :=
   ‖v‖
 
--- The l2 norm of the cross of two real vectors equals the produce of their individual norms
--- times the sine of the angle between them.
+theorem sin_angle_nonneg : 0 ≤ sin (angle x y) :=
+  sin_nonneg_of_nonneg_of_le_pi (angle_nonneg x y) (angle_le_pi x y)
+
+/- The norm of the cross product of two real vectors equals the product of their individual norms
+  times the sine of the angle between them. -/
 theorem crossProduct_norm_eq_norm_mul_norm_mul_sin (a b : EuclideanSpace ℝ (Fin 3)) :
-  l2Norm (a ×₃ b) = ‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b) :=
-by
-  let lhs := l2Norm (a ×₃ b)
-  let rhs := ‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b)
-  have h_lhs_pos : lhs ≥ 0 := norm_nonneg _
-  have h_rhs_pos : rhs ≥ 0 := mul_nonneg
-    (mul_nonneg (norm_nonneg _) (norm_nonneg _))
-    (Real.sin_nonneg_of_mem_Icc
-      (by simp [InnerProductGeometry.angle_nonneg, InnerProductGeometry.angle_le_pi]))
-  suffices h_square_lhs_eq_square_rhs : lhs ^2 = rhs ^ 2 from by
-    {rw [sq_eq_sq_iff_eq_or_eq_neg] at h_square_lhs_eq_square_rhs
-     cases h_square_lhs_eq_square_rhs with
-     | inl h_eq => exact h_eq
-     | inr h_eq_neg =>
-       unfold lhs at h_lhs_pos ; unfold lhs rhs at h_eq_neg
-       rw [h_eq_neg] at h_lhs_pos
-       have h_rhs_eq_0 : rhs = 0 := by
-        unfold rhs
-        exact le_antisymm (neg_le_neg_iff.mp (by simp [h_lhs_pos])) h_rhs_pos
-       unfold rhs at h_rhs_eq_0
-       simp [h_rhs_eq_0, h_eq_neg]}
-  unfold lhs rhs
-  have h_norm_sq_eq_inner (v : EuclideanSpace ℝ (Fin 3)): (‖v‖ ^ 2 = v ⬝ᵥ v) :=
-    by rw [@norm_sq_eq_inner ℝ] ; exact rfl
-  rw [l2Norm, h_norm_sq_eq_inner (a ×₃ b), cross_dot_cross,
-      ←h_norm_sq_eq_inner, ←h_norm_sq_eq_inner, dotProduct_comm b a]
-  have inner_eq_dotProduct (a b : EuclideanSpace ℝ (Fin 3)) :
-    inner a b = a ⬝ᵥ b:= by exact rfl
-  repeat rw [←inner_eq_dotProduct]
-  rw [←(InnerProductGeometry.cos_angle_mul_norm_mul_norm a b)]
-  calc
-    _ = ‖a‖ ^ 2 * ‖b‖ ^ 2 * (1 - Real.cos (InnerProductGeometry.angle a b) ^ 2) := by ring
-    _ = _ := by rw [←Real.sin_sq] ; ring
+    l2Norm (a ×₃ b) = ‖a‖ * ‖b‖ * sin (angle a b) := by
+  have h_lhs_nonneg : 0 ≤ l2Norm (a ×₃ b) := norm_nonneg _
+  have h_rhs_nonneg : 0 ≤ ‖a‖ * ‖b‖ * Real.sin (angle a b) :=
+    mul_nonneg (mul_nonneg (norm_nonneg _) (norm_nonneg _)) (sin_angle_nonneg)
+  have h_norm_sq_eq_inner (v : EuclideanSpace ℝ (Fin 3)) : (‖v‖ ^ 2 = v ⬝ᵥ v) :=
+    norm_sq_eq_inner (𝕜 := ℝ) v
+  have dotProduct_eq_inner (v w : EuclideanSpace ℝ (Fin 3)) : v ⬝ᵥ w = inner v w := rfl
+  simp_rw [← sq_eq_sq₀ h_lhs_nonneg h_rhs_nonneg, l2Norm, h_norm_sq_eq_inner, cross_dot_cross,
+      ← h_norm_sq_eq_inner, dotProduct_comm b a, dotProduct_eq_inner]
+  linear_combination (‖a‖ * ‖b‖) ^ 2 * (sin_sq_add_cos_sq (angle a b)).symm +
+    congrArg (· ^ 2) (cos_angle_mul_norm_mul_norm a b)
 
 
 end InnerProductGeometry

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
@@ -336,23 +336,23 @@ theorem sin_eq_one_iff_angle_eq_pi_div_two : sin (angle x y) = 1 ↔ angle x y =
 
 open Matrix
 
-/-- Returns the l2 norm of a vector. This function is necessary to make sure the l2 norm is taken
-for members of `Fin 3 → ℝ` instead of the sup norm-/
-noncomputable def l2Norm (v : EuclideanSpace ℝ (Fin 3)) : ℝ :=
-  ‖v‖
-
 /- The norm of the cross product of two real vectors equals the product of their individual norms
   times the sine of the angle between them. -/
-theorem crossProduct_norm_eq_norm_mul_norm_mul_sin (a b : EuclideanSpace ℝ (Fin 3)) :
-    l2Norm (a ×₃ b) = ‖a‖ * ‖b‖ * sin (angle a b) := by
-  have h_lhs_nonneg : 0 ≤ l2Norm (a ×₃ b) := norm_nonneg _
+theorem norm_withLpEquiv_crossProduct (a b : EuclideanSpace ℝ (Fin 3)) :
+    ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm (WithLp.equiv _ _ a ×₃ WithLp.equiv _ _ b)‖ =
+    ‖a‖ * ‖b‖ * sin (angle a b) := by
+  have h_lhs_nonneg :
+    0 ≤ ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm (WithLp.equiv _ _ a ×₃ WithLp.equiv _ _ b)‖ :=
+    norm_nonneg _
   have h_rhs_nonneg : 0 ≤ ‖a‖ * ‖b‖ * Real.sin (angle a b) :=
     mul_nonneg (mul_nonneg (norm_nonneg _) (norm_nonneg _)) (sin_angle_nonneg)
   have h_norm_sq_eq_inner (v : EuclideanSpace ℝ (Fin 3)) : (‖v‖ ^ 2 = v ⬝ᵥ v) :=
     norm_sq_eq_inner (𝕜 := ℝ) v
+  have h_with_lp_equiv_cross: (WithLp.equiv 2 (Fin 3 → ℝ)).symm
+    (((WithLp.equiv 2 (Fin 3 → ℝ)) a) ×₃ ((WithLp.equiv 2 (Fin 3 → ℝ)) b)) = a ×₃ b := rfl
   have dotProduct_eq_inner (v w : EuclideanSpace ℝ (Fin 3)) : v ⬝ᵥ w = inner v w := rfl
-  simp_rw [← sq_eq_sq₀ h_lhs_nonneg h_rhs_nonneg, l2Norm, h_norm_sq_eq_inner, cross_dot_cross,
-      ← h_norm_sq_eq_inner, dotProduct_comm b a, dotProduct_eq_inner]
+  simp_rw [← sq_eq_sq₀ h_lhs_nonneg h_rhs_nonneg, h_norm_sq_eq_inner, h_with_lp_equiv_cross,
+  cross_dot_cross, ← h_norm_sq_eq_inner, dotProduct_comm b a, dotProduct_eq_inner]
   linear_combination (‖a‖ * ‖b‖) ^ 2 * (sin_sq_add_cos_sq (angle a b)).symm +
     congrArg (· ^ 2) (cos_angle_mul_norm_mul_norm a b)
 

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
@@ -89,7 +89,7 @@ theorem angle_le_pi (x y : V) : angle x y ≤ π :=
   Real.arccos_le_pi _
 
 /-- The sine of the angle between two vectors is nonnegative. -/
-theorem sin_angle_nonneg : 0 ≤ sin (angle x y) :=
+theorem sin_angle_nonneg (x y : V) : 0 ≤ sin (angle x y) :=
   sin_nonneg_of_nonneg_of_le_pi (angle_nonneg x y) (angle_le_pi x y)
 
 /-- The angle between a vector and the negation of another vector. -/

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
@@ -9,7 +9,6 @@ import Mathlib.LinearAlgebra.CrossProduct
 import Mathlib.Analysis.InnerProductSpace.PiL2
 
 
-
 /-!
 # Angles between vectors
 
@@ -91,6 +90,10 @@ theorem angle_nonneg (x y : V) : 0 ≤ angle x y :=
 /-- The angle between two vectors is at most π. -/
 theorem angle_le_pi (x y : V) : angle x y ≤ π :=
   Real.arccos_le_pi _
+
+/-- The sine of the angle between two vectors is nonnegative. -/
+theorem sin_angle_nonneg : 0 ≤ sin (angle x y) :=
+  sin_nonneg_of_nonneg_of_le_pi (angle_nonneg x y) (angle_le_pi x y)
 
 /-- The angle between a vector and the negation of another vector. -/
 theorem angle_neg_right (x y : V) : angle x (-y) = π - angle x y := by
@@ -338,9 +341,6 @@ open Matrix
 for members of `Fin 3 → ℝ` instead of the sup norm-/
 noncomputable def l2Norm (v : EuclideanSpace ℝ (Fin 3)) : ℝ :=
   ‖v‖
-
-theorem sin_angle_nonneg : 0 ≤ sin (angle x y) :=
-  sin_nonneg_of_nonneg_of_le_pi (angle_nonneg x y) (angle_le_pi x y)
 
 /- The norm of the cross product of two real vectors equals the product of their individual norms
   times the sine of the angle between them. -/

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
@@ -3,10 +3,8 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers, Manuel Candales
 -/
-import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Analysis.InnerProductSpace.Subspace
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse
-import Mathlib.LinearAlgebra.CrossProduct
 
 /-!
 # Angles between vectors
@@ -333,27 +331,5 @@ theorem sin_eq_one_iff_angle_eq_pi_div_two : sin (angle x y) = 1 ↔ angle x y =
   refine ⟨fun h => ?_, fun h => by rw [h, sin_pi_div_two]⟩
   rw [← cos_eq_zero_iff_angle_eq_pi_div_two, ← abs_eq_zero, abs_cos_eq_sqrt_one_sub_sin_sq, h]
   simp
-
-open Matrix
-
-/- The norm of the cross product of two real vectors equals the product of their individual norms
-  times the sine of the angle between them. -/
-theorem norm_withLpEquiv_crossProduct (a b : EuclideanSpace ℝ (Fin 3)) :
-    ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm (WithLp.equiv _ _ a ×₃ WithLp.equiv _ _ b)‖ =
-    ‖a‖ * ‖b‖ * sin (angle a b) := by
-  have h_lhs_nonneg :
-    0 ≤ ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm (WithLp.equiv _ _ a ×₃ WithLp.equiv _ _ b)‖ :=
-    norm_nonneg _
-  have h_rhs_nonneg : 0 ≤ ‖a‖ * ‖b‖ * Real.sin (angle a b) :=
-    mul_nonneg (mul_nonneg (norm_nonneg _) (norm_nonneg _)) (sin_angle_nonneg)
-  have h_norm_sq_eq_inner (v : EuclideanSpace ℝ (Fin 3)) : (‖v‖ ^ 2 = v ⬝ᵥ v) :=
-    norm_sq_eq_inner (𝕜 := ℝ) v
-  have h_with_lp_equiv_cross: (WithLp.equiv 2 (Fin 3 → ℝ)).symm
-    (((WithLp.equiv 2 (Fin 3 → ℝ)) a) ×₃ ((WithLp.equiv 2 (Fin 3 → ℝ)) b)) = a ×₃ b := rfl
-  have dotProduct_eq_inner (v w : EuclideanSpace ℝ (Fin 3)) : v ⬝ᵥ w = inner v w := rfl
-  simp_rw [← sq_eq_sq₀ h_lhs_nonneg h_rhs_nonneg, h_norm_sq_eq_inner, h_with_lp_equiv_cross,
-  cross_dot_cross, ← h_norm_sq_eq_inner, dotProduct_comm b a, dotProduct_eq_inner]
-  linear_combination (‖a‖ * ‖b‖) ^ 2 * (sin_sq_add_cos_sq (angle a b)).symm +
-    congrArg (· ^ 2) (cos_angle_mul_norm_mul_norm a b)
 
 end InnerProductGeometry

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2020 Vedant Gupta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vedant Gupta, Thomas Browning, Eric Wieser
+-/
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Geometry.Euclidean.Angle.Unoriented.Basic
+import Mathlib.LinearAlgebra.CrossProduct
+
+/-!
+# Norm of cross-products
+
+This file proves `InnerProductGeometry.norm_withLpEquiv_crossProduct`, relating the norm of the
+cross-product of two real vectors with their individual norms.
+
+## Main definitions
+
+* `InnerProductGeometry.angle` is the undirected angle between two vectors.
+-/
+
+
+assert_not_exists HasFDerivAt ConformalAt
+
+noncomputable section
+
+open Real
+
+open Matrix
+
+namespace InnerProductGeometry
+
+/- The norm of the cross product of two real vectors equals the product of their individual norms
+  times the sine of the angle between them. -/
+theorem norm_withLpEquiv_crossProduct (a b : EuclideanSpace ℝ (Fin 3)) :
+    ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm (WithLp.equiv _ _ a ×₃ WithLp.equiv _ _ b)‖ =
+    ‖a‖ * ‖b‖ * sin (angle a b) := by
+  have := @sin_angle_nonneg _ _ _ a b
+  refine sq_eq_sq₀ (by positivity) (by positivity) |>.mp ?_
+  trans ‖a‖^2 * ‖b‖^2 - inner a b ^ 2
+  · simp_rw [norm_sq_eq_inner (𝕜 := ℝ), EuclideanSpace.inner_eq_star_dotProduct, star_trivial,
+      RCLike.re_to_real, Equiv.apply_symm_apply, cross_dot_cross,
+      dotProduct_comm (WithLp.equiv _ _ b) (WithLp.equiv _ _ a), sq]
+  · linear_combination (‖a‖ * ‖b‖) ^ 2 * (sin_sq_add_cos_sq (angle a b)).symm +
+      congrArg (· ^ 2) (cos_angle_mul_norm_mul_norm a b)
+
+end InnerProductGeometry

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
@@ -12,10 +12,6 @@ import Mathlib.LinearAlgebra.CrossProduct
 
 This file proves `InnerProductGeometry.norm_withLpEquiv_crossProduct`, relating the norm of the
 cross-product of two real vectors with their individual norms.
-
-## Main definitions
-
-* `InnerProductGeometry.angle` is the undirected angle between two vectors.
 -/
 
 

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
@@ -39,8 +39,8 @@ theorem norm_withLpEquiv_crossProduct (a b : EuclideanSpace ℝ (Fin 3)) :
   · linear_combination (‖a‖ * ‖b‖) ^ 2 * (sin_sq_add_cos_sq (angle a b)).symm +
       congrArg (· ^ 2) (cos_angle_mul_norm_mul_norm a b)
 
-/-- The L2 norm of the cross product of two real vectors (of type `Fin 3 → R`)
-equals the product of their individual L2 norms times the sine of the angle between them. -/
+/-- The L2 norm of the cross product of two real vectors (of type `Fin 3 → R`) equals the product
+of their individual L2 norms times the sine of the angle between them. -/
 theorem norm_withLpEquiv_symm_crossProduct (a b : Fin 3 → ℝ) :
     ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm (a ×₃ b)‖ =
     ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm a‖ * ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm b‖ *

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
@@ -14,8 +14,6 @@ This file proves `InnerProductGeometry.norm_withLpEquiv_crossProduct`, relating 
 cross-product of two real vectors with their individual norms.
 -/
 
-noncomputable section
-
 open Real
 open Matrix
 

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
@@ -14,13 +14,9 @@ This file proves `InnerProductGeometry.norm_withLpEquiv_crossProduct`, relating 
 cross-product of two real vectors with their individual norms.
 -/
 
-
-assert_not_exists HasFDerivAt ConformalAt
-
 noncomputable section
 
 open Real
-
 open Matrix
 
 namespace InnerProductGeometry

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
@@ -30,7 +30,7 @@ namespace InnerProductGeometry
 theorem norm_withLpEquiv_crossProduct (a b : EuclideanSpace ℝ (Fin 3)) :
     ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm (WithLp.equiv _ _ a ×₃ WithLp.equiv _ _ b)‖ =
     ‖a‖ * ‖b‖ * sin (angle a b) := by
-  have := @sin_angle_nonneg _ _ _ a b
+  have := sin_angle_nonneg a b
   refine sq_eq_sq₀ (by positivity) (by positivity) |>.mp ?_
   trans ‖a‖^2 * ‖b‖^2 - inner a b ^ 2
   · simp_rw [norm_sq_eq_inner (𝕜 := ℝ), EuclideanSpace.inner_eq_star_dotProduct, star_trivial,
@@ -38,5 +38,13 @@ theorem norm_withLpEquiv_crossProduct (a b : EuclideanSpace ℝ (Fin 3)) :
       dotProduct_comm (WithLp.equiv _ _ b) (WithLp.equiv _ _ a), sq]
   · linear_combination (‖a‖ * ‖b‖) ^ 2 * (sin_sq_add_cos_sq (angle a b)).symm +
       congrArg (· ^ 2) (cos_angle_mul_norm_mul_norm a b)
+
+/- Same theorem as above but taking in vectors of type `Fin 3 → ℝ`. -/
+theorem norm_withLpEquiv_symm_crossProduct (a b : Fin 3 → ℝ) :
+    ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm (a ×₃ b)‖ =
+    ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm a‖ * ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm b‖ *
+      sin (angle ((WithLp.equiv 2 (Fin 3 → ℝ)).symm a) ((WithLp.equiv 2 (Fin 3 → ℝ)).symm b)) := by
+  rw [← norm_withLpEquiv_crossProduct ((WithLp.equiv _ _).symm a) ((WithLp.equiv _ _).symm b)]
+  simp
 
 end InnerProductGeometry

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/CrossProduct.lean
@@ -25,8 +25,8 @@ open Matrix
 
 namespace InnerProductGeometry
 
-/- The norm of the cross product of two real vectors equals the product of their individual norms
-  times the sine of the angle between them. -/
+/-- The L2 norm of the cross product of two real vectors (of type `EuclideanSpace ℝ (Fin 3)`)
+equals the product of their individual norms times the sine of the angle between them. -/
 theorem norm_withLpEquiv_crossProduct (a b : EuclideanSpace ℝ (Fin 3)) :
     ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm (WithLp.equiv _ _ a ×₃ WithLp.equiv _ _ b)‖ =
     ‖a‖ * ‖b‖ * sin (angle a b) := by
@@ -39,7 +39,8 @@ theorem norm_withLpEquiv_crossProduct (a b : EuclideanSpace ℝ (Fin 3)) :
   · linear_combination (‖a‖ * ‖b‖) ^ 2 * (sin_sq_add_cos_sq (angle a b)).symm +
       congrArg (· ^ 2) (cos_angle_mul_norm_mul_norm a b)
 
-/- Same theorem as above but taking in vectors of type `Fin 3 → ℝ`. -/
+/-- The L2 norm of the cross product of two real vectors (of type `Fin 3 → R`)
+equals the product of their individual L2 norms times the sine of the angle between them. -/
 theorem norm_withLpEquiv_symm_crossProduct (a b : Fin 3 → ℝ) :
     ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm (a ×₃ b)‖ =
     ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm a‖ * ‖(WithLp.equiv 2 (Fin 3 → ℝ)).symm b‖ *

--- a/Mathlib/LinearAlgebra/CrossProduct.lean
+++ b/Mathlib/LinearAlgebra/CrossProduct.lean
@@ -7,6 +7,8 @@ import Mathlib.Data.Matrix.Notation
 import Mathlib.LinearAlgebra.BilinearMap
 import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.Algebra.Lie.Basic
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Geometry.Euclidean.Angle.Unoriented.Basic
 
 /-!
 # Cross products
@@ -163,3 +165,109 @@ lemma crossProduct_ne_zero_iff_linearIndependent {F : Type*} [Field F] {v w : Fi
   simp only [smul_eq_mul, mul_comm (w 0), mul_comm (w 1), mul_comm (w 2), h1] at h20 h21 h22
   rw [hv', cons_eq_zero_iff, cons_eq_zero_iff, cons_eq_zero_iff, zero_empty] at hv
   exact hv ⟨(h20 trivial).2, (h21 trivial).2, (h22 trivial).2, rfl⟩
+
+
+#eval @norm (ℝ) !₂[1, 2, 3]
+
+#check ((!₂[1, 2, 3]) : (Fin 3 → ℕ)) 1
+#check norm_sq_eq_inner
+#check neg_le_neg_iff
+#check Eq.trans
+#check @norm (EuclideanSpace ℝ (Fin 3)) (PiLp.instNorm 2 fun x ↦ ℝ) ![1, 2, 3]
+#check @norm (Fin 3 → ℝ) NormedRing.toNorm ((crossProduct a) b)
+
+-- instance : Coe (EuclideanSpace R (Fin 3)) (Fin 3 → R) where
+--   coe x := ![x 0, x 1, x 2]
+#check le_antisymm
+
+/-- The L2 norm of a vector in ℝ³, using Mathlib's PiLp norm instance -/
+-- noncomputable def l2Norm (v : Fin 3 → ℝ) : ℝ :=
+--   (∑ i, (v i) ^ 2) ^ ((1:ℝ) / (2:ℝ))
+
+noncomputable def l2Norm (v : EuclideanSpace ℝ (Fin 3)) : ℝ :=
+  ‖v‖
+
+#check EuclideanSpace ℝ (Fin 3)
+#check InnerProductGeometry.cos_angle_mul_norm_mul_norm
+
+#check  (!₂[1, 2, 3])
+#check inner
+#print dotProduct
+#check InnerProductGeometry.angle
+
+-- TODO: generalize from natural numbers to all R
+theorem crossProduct_norm_eq_norm_mul_norm_mul_sin (a b : EuclideanSpace ℝ (Fin 3)) :
+  l2Norm (a ×₃ b) = ‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b) :=
+by
+  let lhs := l2Norm (a ×₃ b)
+  let rhs := ‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b)
+  have h_lhs_pos : lhs ≥ 0 := norm_nonneg _
+  have h_rhs_pos : rhs ≥ 0 := mul_nonneg
+    (mul_nonneg (norm_nonneg _) (norm_nonneg _))
+    (Real.sin_nonneg_of_mem_Icc
+      (by simp [InnerProductGeometry.angle_nonneg, InnerProductGeometry.angle_le_pi]))
+  suffices h_square_lhs_eq_square_rhs : lhs ^2 = rhs ^ 2 from by
+    {rw [sq_eq_sq_iff_eq_or_eq_neg] at h_square_lhs_eq_square_rhs
+     cases h_square_lhs_eq_square_rhs with
+     | inl h_eq => exact h_eq
+     | inr h_eq_neg =>
+       unfold lhs at h_lhs_pos ; unfold lhs rhs at h_eq_neg
+       rw [h_eq_neg] at h_lhs_pos
+       have h_rhs_eq_0 : rhs = 0 := le_antisymm (neg_le_neg_iff.mp (by simp [h_lhs_pos])) h_rhs_pos
+       unfold rhs at h_rhs_eq_0
+       simp [h_rhs_eq_0, h_eq_neg]}
+  unfold lhs rhs
+  have h_norm_sq_eq_inner (v : EuclideanSpace ℝ (Fin 3)): (‖v‖ ^ 2 = v ⬝ᵥ v) :=
+    by rw [@norm_sq_eq_inner ℝ] ; exact rfl
+  -- Now I want to replace the things with dot products
+  rw [l2Norm, h_norm_sq_eq_inner (a ×₃ b), cross_dot_cross]
+  rw [←h_norm_sq_eq_inner, ←h_norm_sq_eq_inner]
+  rw [dotProduct_comm b a]
+  have sanity_check (a b : EuclideanSpace ℝ (Fin 3)) :
+    inner a b = ∑ i : Fin 3, a i * b i:= by exact rfl
+  repeat rw [dotProduct] ; repeat rw [←sanity_check]
+  rw [←(InnerProductGeometry.cos_angle_mul_norm_mul_norm a b)]
+  calc
+    _ = ‖a‖ ^ 2 * ‖b‖ ^ 2 * (1 - Real.cos (InnerProductGeometry.angle a b) ^ 2) := by ring
+    _ = _ := by rw [←Real.sin_sq] ; ring
+
+
+
+
+
+
+
+  -- sorry
+
+
+#check neg_nonneg.mp
+-- have htest : ‖a ×₃ b‖ ^ 2 = (‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b)) ^ 2
+--     → ‖a ×₃ b‖ = ‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b) := by
+--   apply Real.sq_eq_sq_iff_eq_or_eq_neg
+--   -- Need to show both terms are non-negative
+--   · exact norm_nonneg _
+--   · exact mul_nonneg (mul_nonneg (norm_nonneg _) (norm_nonneg _)) (Real.sin_nonneg_of_mem_Icc _)
+
+
+-- theorem crossProuduct_norm_eq_norm_mul_norm_mul_sin (a b : EuclideanSpace ℝ (Fin 3)) :
+--   ‖a ×₃ b‖ = ‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b) :=
+-- by
+--   have h0 : (‖a‖ ^ 2 = a ⬝ᵥ a) := by rw [@norm_sq_eq_inner ℝ] ; exact rfl
+--   have h1 : ‖a ×₃ b‖ ≥ 0 := norm_nonneg (a ×₃ b)
+--   have h2 : ‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b) ≥ 0 :=
+--     by exact mul_nonneg
+--         (mul_nonneg (norm_nonneg _) (norm_nonneg _))
+--         (Real.sin_nonneg_of_mem_Icc
+--           (by simp [InnerProductGeometry.angle_nonneg, InnerProductGeometry.angle_le_pi]))
+--   have htt (a : ℝ): a ≤ 0 ∧ a ≥ 0 → a = 0 := by apply?
+--   have htest : ‖a ×₃ b‖ ^ 2 = (‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b)) ^ 2
+--     → ‖a ×₃ b‖ = ‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b) := by
+--     intro h
+--     rw [sq_eq_sq_iff_eq_or_eq_neg] at h
+--     cases h with
+--     | inl hl => exact hl
+--     | inr hr =>
+--       rw [hr] at h1
+--       have hstep : ‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b) = 0 :=
+--         le_antisymm (neg_le_neg_iff.mp (by simp [h1])) h2
+--       simp [hstep, hr]

--- a/Mathlib/LinearAlgebra/CrossProduct.lean
+++ b/Mathlib/LinearAlgebra/CrossProduct.lean
@@ -7,8 +7,6 @@ import Mathlib.Data.Matrix.Notation
 import Mathlib.LinearAlgebra.BilinearMap
 import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.Algebra.Lie.Basic
-import Mathlib.Analysis.InnerProductSpace.PiL2
-import Mathlib.Geometry.Euclidean.Angle.Unoriented.Basic
 
 /-!
 # Cross products
@@ -165,46 +163,3 @@ lemma crossProduct_ne_zero_iff_linearIndependent {F : Type*} [Field F] {v w : Fi
   simp only [smul_eq_mul, mul_comm (w 0), mul_comm (w 1), mul_comm (w 2), h1] at h20 h21 h22
   rw [hv', cons_eq_zero_iff, cons_eq_zero_iff, cons_eq_zero_iff, zero_empty] at hv
   exact hv ⟨(h20 trivial).2, (h21 trivial).2, (h22 trivial).2, rfl⟩
-
-
-/-- Returns the l2 norm of a vector. This function is necessary to make sure the l2 norm is taken
-for members of `Fin 3 → ℝ` instead of the sup norm-/
-noncomputable def l2Norm (v : EuclideanSpace ℝ (Fin 3)) : ℝ :=
-  ‖v‖
-
--- The l2 norm of the cross of two real vectors equals the produce of their individual norms
--- times the sine of the angle between them.
-theorem crossProduct_norm_eq_norm_mul_norm_mul_sin (a b : EuclideanSpace ℝ (Fin 3)) :
-  l2Norm (a ×₃ b) = ‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b) :=
-by
-  let lhs := l2Norm (a ×₃ b)
-  let rhs := ‖a‖ * ‖b‖ * Real.sin (InnerProductGeometry.angle a b)
-  have h_lhs_pos : lhs ≥ 0 := norm_nonneg _
-  have h_rhs_pos : rhs ≥ 0 := mul_nonneg
-    (mul_nonneg (norm_nonneg _) (norm_nonneg _))
-    (Real.sin_nonneg_of_mem_Icc
-      (by simp [InnerProductGeometry.angle_nonneg, InnerProductGeometry.angle_le_pi]))
-  suffices h_square_lhs_eq_square_rhs : lhs ^2 = rhs ^ 2 from by
-    {rw [sq_eq_sq_iff_eq_or_eq_neg] at h_square_lhs_eq_square_rhs
-     cases h_square_lhs_eq_square_rhs with
-     | inl h_eq => exact h_eq
-     | inr h_eq_neg =>
-       unfold lhs at h_lhs_pos ; unfold lhs rhs at h_eq_neg
-       rw [h_eq_neg] at h_lhs_pos
-       have h_rhs_eq_0 : rhs = 0 := by
-        unfold rhs
-        exact le_antisymm (neg_le_neg_iff.mp (by simp [h_lhs_pos])) h_rhs_pos
-       unfold rhs at h_rhs_eq_0
-       simp [h_rhs_eq_0, h_eq_neg]}
-  unfold lhs rhs
-  have h_norm_sq_eq_inner (v : EuclideanSpace ℝ (Fin 3)): (‖v‖ ^ 2 = v ⬝ᵥ v) :=
-    by rw [@norm_sq_eq_inner ℝ] ; exact rfl
-  rw [l2Norm, h_norm_sq_eq_inner (a ×₃ b), cross_dot_cross,
-      ←h_norm_sq_eq_inner, ←h_norm_sq_eq_inner, dotProduct_comm b a]
-  have inner_eq_dotProduct (a b : EuclideanSpace ℝ (Fin 3)) :
-    inner a b = a ⬝ᵥ b:= by exact rfl
-  repeat rw [←inner_eq_dotProduct]
-  rw [←(InnerProductGeometry.cos_angle_mul_norm_mul_norm a b)]
-  calc
-    _ = ‖a‖ ^ 2 * ‖b‖ ^ 2 * (1 - Real.cos (InnerProductGeometry.angle a b) ^ 2) := by ring
-    _ = _ := by rw [←Real.sin_sq] ; ring

--- a/Mathlib/LinearAlgebra/CrossProduct.lean
+++ b/Mathlib/LinearAlgebra/CrossProduct.lean
@@ -167,8 +167,8 @@ lemma crossProduct_ne_zero_iff_linearIndependent {F : Type*} [Field F] {v w : Fi
   exact hv ⟨(h20 trivial).2, (h21 trivial).2, (h22 trivial).2, rfl⟩
 
 
--- this is necessary to make sure the l2 norm is taken for members of `Fin 3 → ℝ`
--- instead of the sup norm
+/-- Returns the l2 norm of a vector. This function is necessary to make sure the l2 norm is taken
+for members of `Fin 3 → ℝ` instead of the sup norm-/
 noncomputable def l2Norm (v : EuclideanSpace ℝ (Fin 3)) : ℝ :=
   ‖v‖
 


### PR DESCRIPTION
Add and prove the equality between the norm of a cross-product of two vectors and the product of the norms of the individual vectors and the sine of the angle between them. See `crossProduct_norm_eq_norm_mul_norm_mul_sin`.

---
 
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)