### PR TITLE
[Merged by Bors] - feat(CI): remove `:closed-pr:` reaction, if PR is reopened

### DIFF
--- a/.github/workflows/zulip_emoji_closed_pr.yaml
+++ b/.github/workflows/zulip_emoji_closed_pr.yaml
@@ -4,8 +4,8 @@ name: Add "closed-pr" emoji in Zulip
 # triggers the action when
 on:
   pull_request:
-    # the pull request is closed
-    types: [closed]
+    # the pull request is closed or reopened, to add or remove the emoji
+    types: [closed, reopened]
 
 jobs:
   add_closed_pr_emoji:
@@ -24,29 +24,38 @@ jobs:
           printf 'issue number: "%s"\npull request number: "%s"\n' "${{ github.event.issue.number }}" "${{ github.event.pull_request.number }}"
 
       - name: Set up Python
-        if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') }}
+        if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') ||
+                github.event_name == 'reopened' }}
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
       - name: Install dependencies
-        if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') }}
+        if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') ||
+                github.event_name == 'reopened' }}
         run: |
           python -m pip install --upgrade pip
           pip install zulip
 
       - name: checkout zulip_emoji_merge_delegate script
-        if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') }}
+        if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') ||
+                github.event_name == 'reopened' }}
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             scripts/zulip_emoji_merge_delegate.py
 
       - name: Run Zulip Emoji Merge Delegate Script
-        if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') }}
+        if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') ||
+                github.event_name == 'reopened' }}
         env:
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
           ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
           ZULIP_SITE: https://leanprover.zulipchat.com
         run: |
-          python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "closed" "${{ github.event.issue.number }}${{ github.event.pull_request.number }}"
+          # ${{ github.event.action }} is either "closed" or "reopened"
+          # however, it only matters that it is either "closed" or
+          # something different from "closed"
+          # the effect is to add the "closed-pr" emoji to the message, if it is "closed"
+          # and to remove it otherwise
+          python scripts/zulip_emoji_merge_delegate.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ github.event.action }}" "${{ github.event.issue.number }}${{ github.event.pull_request.number }}"


### PR DESCRIPTION
This PR follow up on #20902: the action is now also triggered by `reopened` PRs and the bot removes the `:closed-pr:` Zulip reaction in this case.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
