### PR TITLE
[Merged by Bors] - chore(shake): shake reports an invalid config file

### DIFF
--- a/Shake/Main.lean
+++ b/Shake/Main.lean
@@ -457,7 +457,7 @@ def main (args : List String) : IO UInt32 := do
     pure (some (path.parent.get! / "scripts" / "noshake.json"))
   else pure none
 
-  -- Read the config file, `validCfgFile? = false` only if the config file is present and valid
+  -- Read the config file, `validCfgFile? = false` only if the config file is present and invalid
   let (cfg, validCfgFile?) ← if let some file := cfgFile then
     try
       pure (← IO.ofExcept (Json.parse (← IO.FS.readFile file) >>= fromJson? (α := ShakeCfg)), true)

--- a/Shake/Main.lean
+++ b/Shake/Main.lean
@@ -457,7 +457,8 @@ def main (args : List String) : IO UInt32 := do
     pure (some (path.parent.get! / "scripts" / "noshake.json"))
   else pure none
 
-  -- Read the config file, `validCfgFile? = false` only if the config file is present and invalid
+  -- Read the config file
+  -- Set `validCfgFile?` to `false` only if the config file is present and invalid
   let (cfg, validCfgFile?) ← if let some file := cfgFile then
     try
       pure (← IO.ofExcept (Json.parse (← IO.FS.readFile file) >>= fromJson? (α := ShakeCfg)), true)

--- a/Shake/Main.lean
+++ b/Shake/Main.lean
@@ -458,16 +458,16 @@ def main (args : List String) : IO UInt32 := do
   else pure none
 
   -- Read the config file
-  -- `validCfgFile?` is `false` if and only if the config file is present and invalid.
-  let (cfg, validCfgFile?) ← if let some file := cfgFile then
+  -- `isValidCfgFile` is `false` if and only if the config file is present and invalid.
+  let (cfg, isValidCfgFile) ← if let some file := cfgFile then
     try
       pure (← IO.ofExcept (Json.parse (← IO.FS.readFile file) >>= fromJson? (α := ShakeCfg)), true)
     catch e =>
-      -- The `cfgFile` is invalid, so we print the error and return `validCfgFile? = false`.
+      -- The `cfgFile` is invalid, so we print the error and return `isValidCfgFile = false`.
       println! "{e.toString}"
       pure ({}, false)
-  else pure ({}, true)
-  if ! validCfgFile? then
+    else pure ({}, true)
+  if !isValidCfgFile then
     IO.println s!"Invalid config file '{cfgFile.get!}'"
     IO.Process.exit 1
   else

--- a/Shake/Main.lean
+++ b/Shake/Main.lean
@@ -457,7 +457,7 @@ def main (args : List String) : IO UInt32 := do
     pure (some (path.parent.get! / "scripts" / "noshake.json"))
   else pure none
 
-  -- Read the config file, `validCfgFile? = false` only of the config file is present and invalid
+  -- Read the config file, `validCfgFile? = false` only if the config file is present and valid
   let (cfg, validCfgFile?) ← if let some file := cfgFile then
     try
       pure (← IO.ofExcept (Json.parse (← IO.FS.readFile file) >>= fromJson? (α := ShakeCfg)), true)

--- a/Shake/Main.lean
+++ b/Shake/Main.lean
@@ -458,12 +458,12 @@ def main (args : List String) : IO UInt32 := do
   else pure none
 
   -- Read the config file
-  -- Set `validCfgFile?` to `false` only if the config file is present and invalid
+  -- `validCfgFile?` is `false` if and only if the config file is present and invalid.
   let (cfg, validCfgFile?) ← if let some file := cfgFile then
     try
       pure (← IO.ofExcept (Json.parse (← IO.FS.readFile file) >>= fromJson? (α := ShakeCfg)), true)
     catch e =>
-      -- the `cfgFile` is invalid, so we print the error and return `validCfgFile? = false`
+      -- The `cfgFile` is invalid, so we print the error and return `validCfgFile? = false`.
       println! "{e.toString}"
       pure ({}, false)
   else pure ({}, true)


### PR DESCRIPTION
If the file `scripts/noshake.json` is invalid, `lake exe shake` may report various "fixes".  This PR makes it report that `scripts/noshake.json` is invalid.

[Reported on Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/bizarre.20lake.20shake.20errors)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
