### PR TITLE
[Merged by Bors] - fix: add missing `MonoidAlgebra.smul_single`

### DIFF
--- a/Counterexamples/ZeroDivisorsInAddMonoidAlgebras.lean
+++ b/Counterexamples/ZeroDivisorsInAddMonoidAlgebras.lean
@@ -235,7 +235,7 @@ example {α} [Ring α] [Nontrivial α] : ∃ f g : AddMonoidAlgebra α F, f ≠ 
 example {α} [Zero α] :
     2 • (Finsupp.single 0 1 : α →₀ F) = (Finsupp.single 0 1 : α →₀ F)
       ∧ (Finsupp.single 0 1 : α →₀ F) ≠ 0 :=
-  ⟨smul_single _ _ _, by simp [Ne, Finsupp.single_eq_zero, z01.ne]⟩
+  ⟨Finsupp.smul_single _ _ _, by simp [Ne, Finsupp.single_eq_zero, z01.ne]⟩
 
 end F
 

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -1480,6 +1480,7 @@ section Algebra
 @[simps]
 def singleZeroRingHom [Semiring k] [AddMonoid G] : k →+* k[G] :=
   { singleAddHom 0 with
+    toFun := single 0
     map_one' := rfl
     map_mul' := fun x y => by simp only [Finsupp.singleAddHom, single_mul_single, zero_add] }
 

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -381,6 +381,11 @@ def comapDistribMulActionSelf [Group G] [Semiring k] : DistribMulAction G (Monoi
 
 end DerivedInstances
 
+@[simp]
+theorem smul_single [Semiring k] [SMulZeroClass R k]  (a : G) (c : R) (b : k) :
+    c • single a b = single a (c • b) :=
+  Finsupp.smul_single _ _ _
+
 /-!
 #### Copies of `ext` lemmas and bundled `single`s from `Finsupp`
 
@@ -625,12 +630,9 @@ theorem liftNC_smul [MulOneClass G] {R : Type*} [Semiring R] (f : k →+* R) (g 
       (AddMonoidHom.mulLeft (f c)).comp (liftNC (↑f) g) from
     DFunLike.congr_fun this φ
   ext
-  -- Porting note: `reducible` cannot be `local` so the proof gets more complex.
-  unfold MonoidAlgebra
-  simp only [AddMonoidHom.coe_comp, Function.comp_apply, singleAddHom_apply, smulAddHom_apply,
-    smul_single, smul_eq_mul, AddMonoidHom.coe_mulLeft, Finsupp.singleAddHom_apply]
-  -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-  erw [liftNC_single, liftNC_single]; rw [AddMonoidHom.coe_coe, map_mul, mul_assoc]
+  simp_rw [AddMonoidHom.comp_apply, singleAddHom_apply, smulAddHom_apply,
+    AddMonoidHom.coe_mulLeft, smul_single, liftNC_single, smul_eq_mul, AddMonoidHom.coe_coe,
+    map_mul, mul_assoc]
 
 end MiscTheorems
 
@@ -684,7 +686,7 @@ theorem single_one_comm [CommSemiring k] [MulOneClass G] (r : k) (f : MonoidAlge
 /-- `Finsupp.single 1` as a `RingHom` -/
 @[simps]
 def singleOneRingHom [Semiring k] [MulOneClass G] : k →+* MonoidAlgebra k G :=
-  { Finsupp.singleAddHom 1 with
+  { singleAddHom 1 with
     map_one' := rfl
     map_mul' := fun x y => by simp }
 
@@ -1171,6 +1173,11 @@ because we've never discussed actions of additive groups. -/
 
 end DerivedInstances
 
+@[simp]
+theorem smul_single [Semiring k] [SMulZeroClass R k] (a : G) (c : R) (b : k) :
+    c • single a b = single a (c • b) :=
+  Finsupp.smul_single _ _ _
+
 /-!
 #### Copies of `ext` lemmas and bundled `single`s from `Finsupp`
 
@@ -1471,7 +1478,7 @@ section Algebra
 /-- `Finsupp.single 0` as a `RingHom` -/
 @[simps]
 def singleZeroRingHom [Semiring k] [AddMonoid G] : k →+* k[G] :=
-  { Finsupp.singleAddHom 0 with
+  { singleAddHom 0 with
     map_one' := rfl
     map_mul' := fun x y => by simp only [Finsupp.singleAddHom, single_mul_single, zero_add] }
 

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -687,6 +687,7 @@ theorem single_one_comm [CommSemiring k] [MulOneClass G] (r : k) (f : MonoidAlge
 @[simps]
 def singleOneRingHom [Semiring k] [MulOneClass G] : k →+* MonoidAlgebra k G :=
   { singleAddHom 1 with
+    toFun := single 1
     map_one' := rfl
     map_mul' := fun x y => by simp }
 

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -540,7 +540,6 @@ def of [MulOneClass G] : G →* MonoidAlgebra k G :=
 end
 
 /-- Copy of `Finsupp.smul_single'` that avoids the `MonoidAlgebra = Finsupp` defeq abuse. -/
-@[simp]
 theorem smul_single' (c : k) (a : G) (b : k) : c • single a b = single a (c * b) :=
   Finsupp.smul_single' c a b
 
@@ -631,8 +630,7 @@ theorem liftNC_smul [MulOneClass G] {R : Type*} [Semiring R] (f : k →+* R) (g 
     DFunLike.congr_fun this φ
   ext
   simp_rw [AddMonoidHom.comp_apply, singleAddHom_apply, smulAddHom_apply,
-    AddMonoidHom.coe_mulLeft, smul_single, liftNC_single, smul_eq_mul, AddMonoidHom.coe_coe,
-    map_mul, mul_assoc]
+    AddMonoidHom.coe_mulLeft, smul_single', liftNC_single, AddMonoidHom.coe_coe, map_mul, mul_assoc]
 
 end MiscTheorems
 
@@ -1341,7 +1339,6 @@ def singleHom [AddZeroClass G] : k × Multiplicative G →* k[G] where
   map_mul' _a _b := single_mul_single.symm
 
 /-- Copy of `Finsupp.smul_single'` that avoids the `AddMonoidAlgebra = Finsupp` defeq abuse. -/
-@[simp]
 theorem smul_single' (c : k) (a : G) (b : k) : c • single a b = single a (c * b) :=
   Finsupp.smul_single' c a b
 

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -382,7 +382,7 @@ def comapDistribMulActionSelf [Group G] [Semiring k] : DistribMulAction G (Monoi
 end DerivedInstances
 
 @[simp]
-theorem smul_single [Semiring k] [SMulZeroClass R k]  (a : G) (c : R) (b : k) :
+theorem smul_single [Semiring k] [SMulZeroClass R k] (a : G) (c : R) (b : k) :
     c • single a b = single a (c • b) :=
   Finsupp.smul_single _ _ _
 

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -430,7 +430,7 @@ theorem monomial_pow (n : ℕ) (r : R) (k : ℕ) : monomial n r ^ k = monomial (
 
 theorem smul_monomial {S} [SMulZeroClass S R] (a : S) (n : ℕ) (b : R) :
     a • monomial n b = monomial n (a • b) :=
-  toFinsupp_injective <| by simp; rw [smul_single]
+  toFinsupp_injective <| AddMonoidAlgebra.smul_single _ _ _
 
 theorem monomial_injective (n : ℕ) : Function.Injective (monomial n : R → R[X]) :=
   (toFinsuppIso R).symm.injective.comp (single_injective n)


### PR DESCRIPTION
This eliminates some `erw`s.

Also fixes bad generated simp lemmas about `singleOneRingHom` and `singleZeroRingHom`, which previously included unwanted `toFun` terms.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
