### PR TITLE
[Merged by Bors] - chore(Order/WellFoundedSet): flip `isWF_iff_isPWO`

### DIFF
--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -505,9 +505,13 @@ protected theorem IsWF.isPWO (hs : s.IsWF) : s.IsPWO := by
   simp only [forall_mem_range, not_lt] at hm
   exact ⟨m, m + 1, by omega, hm _⟩
 
-/-- In a linear order, the predicates `Set.IsWF` and `Set.IsPWO` are equivalent. -/
+/-- In a linear order, the predicates `Set.IsPWO` and `Set.IsWF` are equivalent. -/
+theorem isPWO_iff_isWF : s.IsPWO ↔ s.IsWF :=
+  ⟨IsPWO.isWF, IsWF.isPWO⟩
+
+@[deprecated isPWO_iff_isWF (since := "2025-01-21")]
 theorem isWF_iff_isPWO : s.IsWF ↔ s.IsPWO :=
-  ⟨IsWF.isPWO, IsPWO.isWF⟩
+  isPWO_iff_isWF.symm
 
 /--
 If `α` is a linear order with well-founded `<`, then any set in it is a partially well-ordered set.

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -672,6 +672,9 @@ theorem BddBelow.wellFoundedOn_lt : BddBelow s → s.WellFoundedOn (· < ·) := 
 theorem BddAbove.wellFoundedOn_gt : BddAbove s → s.WellFoundedOn (· > ·) :=
   fun h => h.dual.wellFoundedOn_lt
 
+theorem BddBelow.isWF : BddBelow s → IsWF s :=
+  BddBelow.wellFoundedOn_lt
+
 end LocallyFiniteOrder
 
 namespace Set.PartiallyWellOrderedOn

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -478,7 +478,7 @@ variable [LocallyFiniteOrder Γ]
 
 theorem suppBddBelow_supp_PWO (f : Γ → R) (hf : BddBelow (Function.support f)) :
     (Function.support f).IsPWO :=
-  IsPWO.of_linearOrder
+  hf.isWF.isPWO
 
 /-- Construct a Hahn series from any function whose support is bounded below. -/
 @[simps]

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -478,7 +478,7 @@ variable [LocallyFiniteOrder Γ]
 
 theorem suppBddBelow_supp_PWO (f : Γ → R) (hf : BddBelow (Function.support f)) :
     (Function.support f).IsPWO :=
-  IsPWO.of_linearOrder
+  Set.IsPWO.of_linearOrder
 
 /-- Construct a Hahn series from any function whose support is bounded below. -/
 @[simps]

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -476,10 +476,9 @@ theorem BddBelow_zero [Nonempty Γ] : BddBelow (Function.support (0 : Γ → R))
 
 variable [LocallyFiniteOrder Γ]
 
-theorem suppBddBelow_supp_PWO (f : Γ → R)
-    (hf : BddBelow (Function.support f)) :
+theorem suppBddBelow_supp_PWO (f : Γ → R) (hf : BddBelow (Function.support f)) :
     (Function.support f).IsPWO :=
-  Set.isWF_iff_isPWO.mp hf.wellFoundedOn_lt
+  IsPWO.of_linearOrder
 
 /-- Construct a Hahn series from any function whose support is bounded below. -/
 @[simps]


### PR DESCRIPTION
Iff lemmas are generally of the form `complicated thing ↔ simpler thing`, and being a PWO is more complicated than being a well-founded set (in the sense that PWOs are well-founded sets with extra conditions).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
