### PR TITLE
[Merged by Bors] - fix(Zulip reaction): add emoji_code and realm_emoji for `:closed-pr:`

### DIFF
--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -107,7 +107,9 @@ for message in messages:
             print('Removing closed-pr')
             result = client.remove_reaction({
                 "message_id": message['id'],
-                "emoji_name": "closed-pr"
+                "emoji_name": "closed-pr",
+                "emoji_code": "61282",
+                "reaction_type": "realm_emoji",
             })
             print(f"result: '{result}'")
 


### PR DESCRIPTION
I forgot that for custom emoji, the Zulip API to remove reactions requires also the code and realm_emoji, possibly not both, but certainly at least one!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
