### PR TITLE
[Merged by Bors] - fix(Zulip closed pr): use emoji code for newer version of `:closed-pr:`

### DIFF
--- a/scripts/zulip_emoji_merge_delegate.py
+++ b/scripts/zulip_emoji_merge_delegate.py
@@ -72,6 +72,7 @@ for message in messages:
         print(f"matched: '{message}'")
 
         # removing previous emoji reactions
+        # if the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well
         print("Removing previous reactions, if present.")
         if has_peace_sign:
             print('Removing peace_sign')
@@ -108,7 +109,7 @@ for message in messages:
             result = client.remove_reaction({
                 "message_id": message['id'],
                 "emoji_name": "closed-pr",
-                "emoji_code": "61282",
+                "emoji_code": "61293",  # 61282 was the earlier version of the emoji
                 "reaction_type": "realm_emoji",
             })
             print(f"result: '{result}'")


### PR DESCRIPTION
When the emoji changed, its `emoji_code` also changed.  This PR uses the current code.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
