### PR TITLE
[Merged by Bors] - feat: add pi versions of `HasBasis.prod_same_index` and `HasBasis.prod_self`

### DIFF
--- a/Mathlib/Order/Filter/Pi.lean
+++ b/Mathlib/Order/Filter/Pi.lean
@@ -99,6 +99,28 @@ theorem hasBasis_pi {ι' : ι → Type*} {s : ∀ i, ι' i → Set (α i)} {p : 
       fun If : Set ι × ∀ i, ι' i => If.1.pi fun i => s i <| If.2 i := by
   simpa [Set.pi_def] using hasBasis_iInf' fun i => (h i).comap (eval i : (∀ j, α j) → α i)
 
+theorem hasBasis_pi_same_index {κ : Type*} {p : κ → Prop} {s : Π i : ι, κ → Set (α i)}
+    (h : ∀ i : ι, (f i).HasBasis p (s i))
+    (h_dir : ∀ I : Set ι, ∀ k : ι → κ, I.Finite → (∀ i ∈ I, p (k i)) →
+      ∃ k₀, p k₀ ∧ ∀ i ∈ I, s i k₀ ⊆ s i (k i)) :
+    (pi f).HasBasis (fun Ik : Set ι × κ ↦ Ik.1.Finite ∧ p Ik.2)
+      (fun Ik ↦ Ik.1.pi (fun i ↦ s i Ik.2)) := by
+  refine hasBasis_pi h |>.to_hasBasis ?_ ?_
+  · rintro ⟨I, k⟩ ⟨hI, hk⟩
+    rcases h_dir I k hI hk with ⟨k₀, hk₀, hk₀'⟩
+    exact ⟨⟨I, k₀⟩, ⟨hI, hk₀⟩, Set.pi_mono hk₀'⟩
+  · rintro ⟨I, k⟩ ⟨hI, hk⟩
+    exact ⟨⟨I, fun _ ↦ k⟩, ⟨hI, fun _ _ ↦ hk⟩, subset_rfl⟩
+
+theorem HasBasis.pi_self {α : Type*} {κ : Type*} {f : Filter α} {p : κ → Prop} {s : κ → Set α}
+    (h : f.HasBasis p s) :
+    (pi fun _ ↦ f).HasBasis (fun Ik : Set ι × κ ↦ Ik.1.Finite ∧ p Ik.2)
+      (fun Ik ↦ Ik.1.pi (fun _ ↦ s Ik.2)) := by
+  refine hasBasis_pi_same_index (fun _ ↦ h) (fun I k hI hk ↦ ?_)
+  rcases h.mem_iff.mp (biInter_mem hI |>.mpr fun i hi ↦ h.mem_of_mem (hk i hi))
+    with ⟨k₀, hk₀, hk₀'⟩
+  exact ⟨k₀, hk₀, fun i hi ↦ hk₀'.trans (biInter_subset_of_mem hi)⟩
+
 theorem le_pi_principal (s : (i : ι) → Set (α i)) :
     𝓟 (univ.pi s) ≤ pi fun i ↦ 𝓟 (s i) :=
   le_pi.2 fun i ↦ tendsto_principal_principal.2 fun _f hf ↦ hf i trivial


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
