### PR TITLE
[Merged by Bors] - chore(MeasureTheory/Function): remove unneeded rw in condexp_restrict_ae_eq_restrict

### DIFF
--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Indicator.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Indicator.lean
@@ -119,7 +119,6 @@ theorem condexp_restrict_ae_eq_restrict (hm : m ≤ m0) [SigmaFinite (μ.trim hm
       Set.indicator_indicator]
     suffices h_int_restrict : Integrable (t.indicator ((μ.restrict s)[f|m])) (μ.restrict s) by
       rw [integrable_indicator_iff (hm _ hs_m), IntegrableOn]
-      rw [integrable_indicator_iff (hm _ ht), IntegrableOn] at h_int_restrict ⊢
       exact h_int_restrict
     exact integrable_condexp.indicator (hm _ ht)
   · intro t ht _


### PR DESCRIPTION
Removes an unnecessary rewrite.

Found by [`tryAtEachStep`](https://github.com/dwrensha/tryAtEachStep).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
