### PR TITLE
[Merged by Bors] - feat(Data/Matrix/Mul): vecMul and mulVec are sums

### DIFF
--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -648,10 +648,8 @@ theorem vecMul_eq_sum [Fintype m] (v : m → α) (M : Matrix m n α) : v ᵥ* M 
 /-- The noncommutative version of `Matrix.mulVec_eq_sum`.  -/
 theorem mulVec_eq_sum' [Fintype n] (v : n → α) (M : Matrix m n α) :
     M *ᵥ v = ∑ i, MulOpposite.op (v i) • Mᵀ i := by
-  ext
-  simp only [Finset.sum_apply, Pi.smul_apply, transpose_apply, MulOpposite.smul_eq_mul_unop,
-    MulOpposite.unop_op]
-  rfl
+  ext i
+  simp [show (M *ᵥ v) i = ∑ x, M i x * v x from rfl]
 
 theorem mulVec_diagonal [Fintype m] [DecidableEq m] (v w : m → α) (x : m) :
     (diagonal v *ᵥ w) x = v x * w x :=

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -645,8 +645,7 @@ theorem mul_apply_eq_vecMul [Fintype n] (A : Matrix m n α) (B : Matrix n o α) 
 theorem vecMul_eq_sum [Fintype m] (v : m → α) (M : Matrix m n α) : v ᵥ* M = ∑ i, v i • M i :=
   (Finset.sum_fn ..).symm
 
-/-- The noncommutative version of `Matrix.mulVec_eq_sum`.  -/
-theorem mulVec_eq_sum' [Fintype n] (v : n → α) (M : Matrix m n α) :
+theorem mulVec_eq_sum [Fintype n] (v : n → α) (M : Matrix m n α) :
     M *ᵥ v = ∑ i, MulOpposite.op (v i) • Mᵀ i := by
   ext i
   simp [show (M *ᵥ v) i = ∑ x, M i x * v x from rfl]
@@ -887,10 +886,6 @@ theorem mulVec_transpose [Fintype m] (A : Matrix m n α) (x : m → α) : Aᵀ *
 theorem vecMul_transpose [Fintype n] (A : Matrix m n α) (x : n → α) : x ᵥ* Aᵀ = A *ᵥ x := by
   ext
   apply dotProduct_comm
-
-/-- The commutative version of `Matrix.mulVec_eq_sum'` -/
-theorem mulVec_eq_sum [Fintype n] (v : n → α) (M : Matrix m n α) : M *ᵥ v = ∑ i, v i • Mᵀ i := by
-  rw [← vecMul_transpose, vecMul_eq_sum]
 
 theorem mulVec_vecMul [Fintype n] [Fintype o] (A : Matrix m n α) (B : Matrix o n α) (x : o → α) :
     A *ᵥ (x ᵥ* B) = (A * Bᵀ) *ᵥ x := by rw [← mulVec_mulVec, mulVec_transpose]

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -646,9 +646,8 @@ theorem vecMul_eq_sum [Fintype m] (v : m → α) (M : Matrix m n α) : v ᵥ* M 
   (Finset.sum_fn ..).symm
 
 theorem mulVec_eq_sum [Fintype n] (v : n → α) (M : Matrix m n α) :
-    M *ᵥ v = ∑ i, MulOpposite.op (v i) • Mᵀ i := by
-  ext i
-  simp [show (M *ᵥ v) i = ∑ x, M i x * v x from rfl]
+    M *ᵥ v = ∑ i, MulOpposite.op (v i) • Mᵀ i :=
+  funext fun i ↦ by simp [show (M *ᵥ v) i = ∑ x, M i x * v x from rfl]
 
 theorem mulVec_diagonal [Fintype m] [DecidableEq m] (v w : m → α) (x : m) :
     (diagonal v *ᵥ w) x = v x * w x :=

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -883,7 +883,7 @@ theorem vecMul_transpose [Fintype n] (A : Matrix m n α) (x : n → α) : x ᵥ*
   apply dotProduct_comm
 
 theorem mulVec_eq_sum [Fintype n] (v : n → α) (M : Matrix m n α) : M *ᵥ v = ∑ i, v i • Mᵀ i := by
-  rw [← transpose_transpose M, mulVec_transpose, vecMul_eq_sum, transpose_transpose]
+  rw [← vecMul_transpose, vecMul_eq_sum]
 
 theorem mulVec_vecMul [Fintype n] [Fintype o] (A : Matrix m n α) (B : Matrix o n α) (x : o → α) :
     A *ᵥ (x ᵥ* B) = (A * Bᵀ) *ᵥ x := by rw [← mulVec_mulVec, mulVec_transpose]

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -645,6 +645,14 @@ theorem mul_apply_eq_vecMul [Fintype n] (A : Matrix m n α) (B : Matrix n o α) 
 theorem vecMul_eq_sum [Fintype m] (v : m → α) (M : Matrix m n α) : v ᵥ* M = ∑ i, v i • M i :=
   (Finset.sum_fn ..).symm
 
+/-- The noncommutative version of `Matrix.mulVec_eq_sum`.  -/
+theorem mulVec_eq_sum' [Fintype n] (v : n → α) (M : Matrix m n α) :
+    M *ᵥ v = ∑ i, MulOpposite.op (v i) • Mᵀ i := by
+  ext
+  simp only [Finset.sum_apply, Pi.smul_apply, transpose_apply, MulOpposite.smul_eq_mul_unop,
+    MulOpposite.unop_op]
+  rfl
+
 theorem mulVec_diagonal [Fintype m] [DecidableEq m] (v w : m → α) (x : m) :
     (diagonal v *ᵥ w) x = v x * w x :=
   diagonal_dotProduct v w x
@@ -882,6 +890,7 @@ theorem vecMul_transpose [Fintype n] (A : Matrix m n α) (x : n → α) : x ᵥ*
   ext
   apply dotProduct_comm
 
+/-- The commutative version of `Matrix.mulVec_eq_sum'` -/
 theorem mulVec_eq_sum [Fintype n] (v : n → α) (M : Matrix m n α) : M *ᵥ v = ∑ i, v i • Mᵀ i := by
   rw [← vecMul_transpose, vecMul_eq_sum]
 

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -642,6 +642,9 @@ theorem mul_apply_eq_vecMul [Fintype n] (A : Matrix m n α) (B : Matrix n o α) 
     (A * B) i = A i ᵥ* B :=
   rfl
 
+theorem vecMul_eq_sum [Fintype m] (v : m → α) (M : Matrix m n α) : v ᵥ* M = ∑ i, v i • M i :=
+  (Finset.sum_fn ..).symm
+
 theorem mulVec_diagonal [Fintype m] [DecidableEq m] (v w : m → α) (x : m) :
     (diagonal v *ᵥ w) x = v x * w x :=
   diagonal_dotProduct v w x
@@ -878,6 +881,9 @@ theorem mulVec_transpose [Fintype m] (A : Matrix m n α) (x : m → α) : Aᵀ *
 theorem vecMul_transpose [Fintype n] (A : Matrix m n α) (x : n → α) : x ᵥ* Aᵀ = A *ᵥ x := by
   ext
   apply dotProduct_comm
+
+theorem mulVec_eq_sum [Fintype n] (v : n → α) (M : Matrix m n α) : M *ᵥ v = ∑ i, v i • Mᵀ i := by
+  rw [← transpose_transpose M, mulVec_transpose, vecMul_eq_sum, transpose_transpose]
 
 theorem mulVec_vecMul [Fintype n] [Fintype o] (A : Matrix m n α) (B : Matrix o n α) (x : o → α) :
     A *ᵥ (x ᵥ* B) = (A * Bᵀ) *ᵥ x := by rw [← mulVec_mulVec, mulVec_transpose]

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -647,7 +647,7 @@ theorem vecMul_eq_sum [Fintype m] (v : m → α) (M : Matrix m n α) : v ᵥ* M 
 
 theorem mulVec_eq_sum [Fintype n] (v : n → α) (M : Matrix m n α) :
     M *ᵥ v = ∑ i, MulOpposite.op (v i) • Mᵀ i :=
-  funext fun i ↦ by simp [show (M *ᵥ v) i = ∑ x, M i x * v x from rfl]
+  (Finset.sum_fn ..).symm
 
 theorem mulVec_diagonal [Fintype m] [DecidableEq m] (v w : m → α) (x : m) :
     (diagonal v *ᵥ w) x = v x * w x :=


### PR DESCRIPTION
We add lemmas expressing `vecMul` and `mulVec` as summations. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
