### PR TITLE
feat(Topology/Algebra/TopologicallyNilpotent): define topologically nilpotent elements

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5229,6 +5229,7 @@ import Mathlib.Topology.Algebra.SeparationQuotient.Section
 import Mathlib.Topology.Algebra.Star
 import Mathlib.Topology.Algebra.StarSubalgebra
 import Mathlib.Topology.Algebra.Support
+import Mathlib.Topology.Algebra.TopologicallyNilpotent
 import Mathlib.Topology.Algebra.UniformConvergence
 import Mathlib.Topology.Algebra.UniformField
 import Mathlib.Topology.Algebra.UniformFilterBasis

--- a/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
+++ b/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández
 -/
 
+import Mathlib
+
 /-! # Topologically nilpotent elements
 
 Let `M` be a monoid with zero `M`, endowed with a topology.
@@ -17,7 +19,6 @@ monoids with zero endowed with a topology is topologically nilpotent.
 
 * `IsTopologicallyNilpotent.zero`: `0` is topologically nilpotent.
 -/
-
 
 open Filter
 

--- a/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
+++ b/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2024 Antoine Chambert-Loir, María Inés de Frutos-Fernández. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández
+-/
+import Mathlib.Topology.Algebra.LinearTopology
+import Mathlib.RingTheory.Ideal.Basic
+
+/-! # Topologicall nilpotent elements -/
+
+open Filter
+
+open scoped Topology
+
+/-- An element is topologically nilpotent if its powers converge to `0`. -/
+def IsTopologicallyNilpotent
+    {R : Type*} [Semiring R] [TopologicalSpace R] (a : R) : Prop :=
+  Tendsto (fun n : ℕ => a ^ n) atTop (𝓝 0)
+
+namespace IsTopologicallyNilpotent
+
+variable {R S : Type*} [TopologicalSpace R] [TopologicalSpace S]
+
+theorem map [Semiring R] [Semiring S]
+    {φ : R →+* S} (hφ : Continuous φ) {a : R} (ha : IsTopologicallyNilpotent a) :
+    IsTopologicallyNilpotent (φ a) := by
+  unfold IsTopologicallyNilpotent at ha ⊢
+  simp_rw [← map_pow]
+  exact (map_zero φ ▸  hφ.tendsto 0).comp ha
+
+theorem zero [Semiring R] :
+    IsTopologicallyNilpotent (0 : R) := tendsto_atTop_of_eventually_const (i₀ := 1)
+    (fun _ hi => by rw [zero_pow (Nat.ne_zero_iff_zero_lt.mpr hi)])
+
+variable [CommRing R] [IsLinearTopology R R]
+
+theorem mul_right {a : R} (ha : IsTopologicallyNilpotent a) (b : R) :
+    IsTopologicallyNilpotent (a * b) := by
+  intro v hv
+  rw [IsLinearTopology.hasBasis_ideal.mem_iff] at hv
+  rcases hv with ⟨I, I_mem_nhds, I_subset⟩
+  specialize ha I_mem_nhds
+  simp only [mem_map, mem_atTop_sets, ge_iff_le, Set.mem_preimage, SetLike.mem_coe] at ha ⊢
+  rcases ha with ⟨n, ha⟩
+  use n
+  intro m hm
+  rw [mul_pow]
+  exact  I_subset (I.mul_mem_right _ (ha m hm))
+
+ theorem mul_left (a : R) {b : R} (hb : IsTopologicallyNilpotent b) :
+    IsTopologicallyNilpotent (a * b) :=
+  mul_comm a b ▸ mul_right hb a
+
+theorem add {a b : R} (ha : IsTopologicallyNilpotent a) (hb : IsTopologicallyNilpotent b) :
+    IsTopologicallyNilpotent (a + b) := by
+  intro v hv
+  rw [IsLinearTopology.hasBasis_ideal.mem_iff] at hv
+  rcases hv with ⟨I, I_mem_nhds, I_subset⟩
+  specialize ha I_mem_nhds
+  specialize hb I_mem_nhds
+  simp only [mem_map, mem_atTop_sets, ge_iff_le, Set.mem_preimage, SetLike.mem_coe] at ha hb ⊢
+  rcases ha with ⟨na, ha⟩
+  rcases hb with ⟨nb, hb⟩
+  exact ⟨na + nb, fun m hm ↦
+    I_subset (I.add_pow_mem_of_pow_mem_of_le (ha na le_rfl) (hb nb le_rfl)
+      (le_trans hm (Nat.le_add_right _ _)))⟩
+
+end IsTopologicallyNilpotent

--- a/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
+++ b/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
@@ -12,23 +12,28 @@ open Filter
 
 open scoped Topology
 
-/-- An element is topologically nilpotent if its powers converge to `0`. -/
+/-- In a monoid with zero endowed with a topology,
+  an element is topologically nilpotent if its powers converge to `0`. -/
 def IsTopologicallyNilpotent
     {R : Type*} [MonoidWithZero R] [TopologicalSpace R] (a : R) : Prop :=
   Tendsto (fun n : ℕ => a ^ n) atTop (𝓝 0)
 
 namespace IsTopologicallyNilpotent
 
-variable {R S : Type*} [TopologicalSpace R] [TopologicalSpace S]
+variable {R S : Type*} [TopologicalSpace R] [MonoidWithZero R]
+  [MonoidWithZero S] [TopologicalSpace S]
 
-theorem map [MonoidWithZero R] [MonoidWithZero S]
-    {φ : R →*₀ S} (hφ : Continuous φ) {a : R} (ha : IsTopologicallyNilpotent a) :
+/-- The image of a topologically nilpotent element under a continuous morphism
+  is topologically nilpotent -/
+theorem map {F : Type*} [FunLike F R S] [MonoidWithZeroHomClass F R S]
+    {φ : F} (hφ : Continuous φ) {a : R} (ha : IsTopologicallyNilpotent a) :
     IsTopologicallyNilpotent (φ a) := by
   unfold IsTopologicallyNilpotent at ha ⊢
   simp_rw [← map_pow]
   exact (map_zero φ ▸  hφ.tendsto 0).comp ha
 
-theorem zero [MonoidWithZero R] :
+/-- `0` is topologically nilpotent -/
+theorem zero :
     IsTopologicallyNilpotent (0 : R) := tendsto_atTop_of_eventually_const (i₀ := 1)
     (fun _ hi => by rw [zero_pow (Nat.ne_zero_iff_zero_lt.mpr hi)])
 

--- a/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
+++ b/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
@@ -14,55 +14,22 @@ open scoped Topology
 
 /-- An element is topologically nilpotent if its powers converge to `0`. -/
 def IsTopologicallyNilpotent
-    {R : Type*} [Semiring R] [TopologicalSpace R] (a : R) : Prop :=
+    {R : Type*} [MonoidWithZero R] [TopologicalSpace R] (a : R) : Prop :=
   Tendsto (fun n : ℕ => a ^ n) atTop (𝓝 0)
 
 namespace IsTopologicallyNilpotent
 
 variable {R S : Type*} [TopologicalSpace R] [TopologicalSpace S]
 
-theorem map [Semiring R] [Semiring S]
-    {φ : R →+* S} (hφ : Continuous φ) {a : R} (ha : IsTopologicallyNilpotent a) :
+theorem map [MonoidWithZero R] [MonoidWithZero S]
+    {φ : R →*₀ S} (hφ : Continuous φ) {a : R} (ha : IsTopologicallyNilpotent a) :
     IsTopologicallyNilpotent (φ a) := by
   unfold IsTopologicallyNilpotent at ha ⊢
   simp_rw [← map_pow]
   exact (map_zero φ ▸  hφ.tendsto 0).comp ha
 
-theorem zero [Semiring R] :
+theorem zero [MonoidWithZero R] :
     IsTopologicallyNilpotent (0 : R) := tendsto_atTop_of_eventually_const (i₀ := 1)
     (fun _ hi => by rw [zero_pow (Nat.ne_zero_iff_zero_lt.mpr hi)])
-
-variable [CommRing R] [IsLinearTopology R R]
-
-theorem mul_right {a : R} (ha : IsTopologicallyNilpotent a) (b : R) :
-    IsTopologicallyNilpotent (a * b) := by
-  intro v hv
-  rw [IsLinearTopology.hasBasis_ideal.mem_iff] at hv
-  rcases hv with ⟨I, I_mem_nhds, I_subset⟩
-  specialize ha I_mem_nhds
-  simp only [mem_map, mem_atTop_sets, ge_iff_le, Set.mem_preimage, SetLike.mem_coe] at ha ⊢
-  rcases ha with ⟨n, ha⟩
-  use n
-  intro m hm
-  rw [mul_pow]
-  exact  I_subset (I.mul_mem_right _ (ha m hm))
-
- theorem mul_left (a : R) {b : R} (hb : IsTopologicallyNilpotent b) :
-    IsTopologicallyNilpotent (a * b) :=
-  mul_comm a b ▸ mul_right hb a
-
-theorem add {a b : R} (ha : IsTopologicallyNilpotent a) (hb : IsTopologicallyNilpotent b) :
-    IsTopologicallyNilpotent (a + b) := by
-  intro v hv
-  rw [IsLinearTopology.hasBasis_ideal.mem_iff] at hv
-  rcases hv with ⟨I, I_mem_nhds, I_subset⟩
-  specialize ha I_mem_nhds
-  specialize hb I_mem_nhds
-  simp only [mem_map, mem_atTop_sets, ge_iff_le, Set.mem_preimage, SetLike.mem_coe] at ha hb ⊢
-  rcases ha with ⟨na, ha⟩
-  rcases hb with ⟨nb, hb⟩
-  exact ⟨na + nb, fun m hm ↦
-    I_subset (I.add_pow_mem_of_pow_mem_of_le (ha na le_rfl) (hb nb le_rfl)
-      (le_trans hm (Nat.le_add_right _ _)))⟩
 
 end IsTopologicallyNilpotent

--- a/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
+++ b/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández
 -/
 
-import Mathlib
+import Mathlib.Topology.Algebra.LinearTopology
+import Mathlib.RingTheory.Ideal.Basic
 
 /-! # Topologically nilpotent elements
 

--- a/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
+++ b/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
@@ -3,10 +3,21 @@ Copyright (c) 2024 Antoine Chambert-Loir, María Inés de Frutos-Fernández. All
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández
 -/
-import Mathlib.Topology.Algebra.LinearTopology
-import Mathlib.RingTheory.Ideal.Basic
 
-/-! # Topologicall nilpotent elements -/
+/-! # Topologically nilpotent elements
+
+Let `M` be a monoid with zero `M`, endowed with a topology.
+
+* `IsTopologicallyNilpotent a` says that `a : M` is *topologically nilpotent*,
+ie, its powers converge to zero.
+
+* `IsTopologicallyNilpotent.map`:
+The image of a topologically nilpotent element under a continuous morphism of
+monoids with zero endowed with a topology is topologically nilpotent.
+
+* `IsTopologicallyNilpotent.zero`: `0` is topologically nilpotent.
+-/
+
 
 open Filter
 

--- a/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
+++ b/Mathlib/Topology/Algebra/TopologicallyNilpotent.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández
 -/
 
-import Mathlib.Topology.Algebra.LinearTopology
-import Mathlib.RingTheory.Ideal.Basic
+import Mathlib.Algebra.GroupWithZero.Hom
+import Mathlib.Topology.Basic
 
 /-! # Topologically nilpotent elements
 


### PR DESCRIPTION
An element of a monoid with zero is topologically nilpotent if its powers converge to zero.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
