### PR TITLE
[Merged by Bors] - feat(RingTheory/IntegralClosure): prove `Module.Finite R (adjoin R S)` for finite set `S` of integral elements

### DIFF
--- a/Mathlib/RingTheory/IntegralClosure/IsIntegral/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegral/Basic.lean
@@ -201,6 +201,14 @@ theorem fg_adjoin_of_finite {s : Set A} (hfs : s.Finite) (his : ∀ x ∈ s, IsI
           (his a <| Set.mem_insert a s).fg_adjoin_singleton)
     his
 
+theorem Algebra.finite_adjoin_of_finite_of_isIntegral {s : Set A} (hf : s.Finite)
+    (hi : ∀ x ∈ s, IsIntegral R x) : Module.Finite R (adjoin R s) :=
+  Module.Finite.iff_fg.mpr <| fg_adjoin_of_finite hf hi
+
+theorem Algebra.finite_adjoin_simple_of_isIntegral {x : A} (hi : IsIntegral R x) :
+    Module.Finite R (adjoin R {x}) :=
+  Module.Finite.iff_fg.mpr hi.fg_adjoin_singleton
+
 theorem isNoetherian_adjoin_finset [IsNoetherianRing R] (s : Finset A)
     (hs : ∀ x ∈ s, IsIntegral R x) : IsNoetherian R (Algebra.adjoin R (s : Set A)) :=
   isNoetherian_of_fg_of_noetherian _ (fg_adjoin_of_finite s.finite_toSet hs)

--- a/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
@@ -132,8 +132,19 @@ theorem le_integralClosure_iff_isIntegral {S : Subalgebra R A} :
       Algebra.isIntegral_def.symm
 
 theorem Algebra.IsIntegral.adjoin {S : Set A} (hS : ∀ x ∈ S, IsIntegral R x) :
-    Algebra.IsIntegral R (Algebra.adjoin R S) :=
+    Algebra.IsIntegral R (adjoin R S) :=
   le_integralClosure_iff_isIntegral.mp <| adjoin_le hS
+
+theorem Algebra.finite_adjoin_of_isIntegral {S : Set A} (hf : S.Finite)
+    (hi : ∀ x ∈ S, IsIntegral R x) : Module.Finite R (adjoin R S) :=
+  haveI : Algebra.IsIntegral R (adjoin R S) := IsIntegral.adjoin hi
+  haveI : Algebra.FiniteType R (adjoin R S) :=
+    ⟨(Subalgebra.fg_top _).mpr <| by simpa using Subalgebra.fg_adjoin_finset hf.toFinset⟩
+  Algebra.IsIntegral.finite
+
+theorem Algebra.finite_adjoin_simple_of_isIntegral {x : A} (hi : IsIntegral R x) :
+    Module.Finite R (adjoin R {x}) :=
+  ⟨(Submodule.fg_top _).mpr hi.fg_adjoin_singleton⟩
 
 theorem integralClosure_eq_top_iff : integralClosure R A = ⊤ ↔ Algebra.IsIntegral R A := by
   rw [← top_le_iff, le_integralClosure_iff_isIntegral,

--- a/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
@@ -135,17 +135,6 @@ theorem Algebra.IsIntegral.adjoin {S : Set A} (hS : ∀ x ∈ S, IsIntegral R x)
     Algebra.IsIntegral R (adjoin R S) :=
   le_integralClosure_iff_isIntegral.mp <| adjoin_le hS
 
-theorem Algebra.finite_adjoin_of_isIntegral {S : Set A} (hf : S.Finite)
-    (hi : ∀ x ∈ S, IsIntegral R x) : Module.Finite R (adjoin R S) :=
-  haveI : Algebra.IsIntegral R (adjoin R S) := IsIntegral.adjoin hi
-  haveI : Algebra.FiniteType R (adjoin R S) :=
-    ⟨(Subalgebra.fg_top _).mpr <| by simpa using Subalgebra.fg_adjoin_finset hf.toFinset⟩
-  Algebra.IsIntegral.finite
-
-theorem Algebra.finite_adjoin_simple_of_isIntegral {x : A} (hi : IsIntegral R x) :
-    Module.Finite R (adjoin R {x}) :=
-  ⟨(Submodule.fg_top _).mpr hi.fg_adjoin_singleton⟩
-
 theorem integralClosure_eq_top_iff : integralClosure R A = ⊤ ↔ Algebra.IsIntegral R A := by
   rw [← top_le_iff, le_integralClosure_iff_isIntegral,
       (Subalgebra.topEquiv (R := R) (A := A)).isIntegral_iff] -- explicit arguments for speedup


### PR DESCRIPTION
Prove that `Algebra.adjoin R S` has finite rank over `R` when `S` is finite with elements that are all integral over `R`.
Special case for singleton included.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
