### PR TITLE
[Merged by Bors] - feat: inj/cancel from mono

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -343,17 +343,15 @@ lemma min_mul [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a b c : α) :
   haveI := mulRightMono_of_mulRightStrictMono α
   Left.min_le_max_of_mul_le_mul h
 
-@[to_additive] lemma Left.mul_left_cancel_of_mulLeftStrictMono [MulLeftStrictMono α]
-    (h : a * b = a * c) : b = c := by
-  contrapose! h
-  obtain lt|lt := h.lt_or_lt
-  exacts [(mul_lt_mul_left' lt _).ne, (mul_lt_mul_left' lt _).ne']
+/-- Not an instance, to avoid loops with `IsLeftCancelMul.mulLeftStrictMono_of_mulLeftMono`. -/
+@[to_additive]
+theorem MulLeftStrictMono.toIsLeftCancelMul [MulLeftStrictMono α] : IsLeftCancelMul α where
+  mul_left_cancel _ _ _ h := StrictMono.injective (fun _ _ h => mul_lt_mul_left' h _) h
 
-@[to_additive] lemma Right.mul_right_cancel_of_mulRightStrictMono [MulRightStrictMono α]
-    (h : b * a = c * a) : b = c := by
-  contrapose! h
-  obtain lt|lt := h.lt_or_lt
-  exacts [(mul_lt_mul_right' lt _).ne, (mul_lt_mul_right' lt _).ne']
+/-- Not an instance, to avoid loops with `IsRightCancelMul.mulRightStrictMono_of_mulRightMono`. -/
+@[to_additive]
+theorem MulRightStrictMono.toIsRightCancelMul [MulRightStrictMono α] : IsRightCancelMul α where
+  mul_right_cancel _ _ _ h := StrictMono.injective (fun _ _ h => mul_lt_mul_right' h _) h
 
 end LinearOrder
 

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -283,6 +283,18 @@ theorem mul_right_cancel'' [MulRightReflectLE α] {a b c : α}
   haveI := mulRightMono_of_mulRightStrictMono α
   rw [le_antisymm_iff, eq_true (mul_le_mul' hac hbd), true_and, mul_le_mul_iff_of_ge hac hbd]
 
+@[to_additive] lemma mul_left_inj'' [MulRightStrictMono α] {a b c : α} {h : c ≤ b} :
+    c * a  = b * a ↔ c = b := by
+  refine ⟨fun h' => ?_, fun h => h ▸ rfl⟩
+  contrapose h'
+  exact mul_lt_mul_right' (h.lt_of_ne h') a |>.ne
+
+@[to_additive] lemma mul_right_inj'' [MulLeftStrictMono α] {a b c : α} {h : c ≤ b} :
+    a * c = a * b ↔ c = b := by
+  refine ⟨fun h' => ?_, fun h => h ▸ rfl⟩
+  contrapose h'
+  exact mul_lt_mul_left' (h.lt_of_ne h') a |>.ne
+
 end PartialOrder
 
 section LinearOrder
@@ -324,6 +336,18 @@ lemma min_mul [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a b c : α) :
     (h : a * b ≤ c * d) : min a b ≤ max c d :=
   haveI := mulRightMono_of_mulRightStrictMono α
   Left.min_le_max_of_mul_le_mul h
+
+@[to_additive] lemma Left.mul_left_cancel_of_mulLeftStrictMono [MulLeftStrictMono α]
+    (h : a * b = a * c) : b = c := by
+  contrapose! h
+  obtain lt|lt := h.lt_or_lt
+  exacts [(mul_lt_mul_left' lt _).ne, (mul_lt_mul_left' lt _).ne']
+
+@[to_additive] lemma Right.mul_right_cancel_of_mulRightStrictMono [MulRightStrictMono α]
+    (h : b * a = c * a) : b = c := by
+  contrapose! h
+  obtain lt|lt := h.lt_or_lt
+  exacts [(mul_lt_mul_right' lt _).ne, (mul_lt_mul_right' lt _).ne']
 
 end LinearOrder
 

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -283,17 +283,23 @@ theorem mul_right_cancel'' [MulRightReflectLE α] {a b c : α}
   haveI := mulRightMono_of_mulRightStrictMono α
   rw [le_antisymm_iff, eq_true (mul_le_mul' hac hbd), true_and, mul_le_mul_iff_of_ge hac hbd]
 
-@[to_additive] lemma mul_left_inj'' [MulRightStrictMono α] {a b c : α} {h : c ≤ b} :
+@[to_additive]
+lemma mul_left_inj_of_comparable [MulRightStrictMono α] {a b c : α} {h : b ≤ c ∨ c ≤ b} :
     c * a  = b * a ↔ c = b := by
-  refine ⟨fun h' => ?_, fun h => h ▸ rfl⟩
+  refine ⟨fun h' => ?_, (· ▸ rfl)⟩
   contrapose h'
-  exact mul_lt_mul_right' (h.lt_of_ne h') a |>.ne
+  obtain h|h := h
+  · exact mul_lt_mul_right' (h.lt_of_ne' h') a |>.ne'
+  · exact mul_lt_mul_right' (h.lt_of_ne h') a |>.ne
 
-@[to_additive] lemma mul_right_inj'' [MulLeftStrictMono α] {a b c : α} {h : c ≤ b} :
+@[to_additive]
+lemma mul_right_inj_of_comparable [MulLeftStrictMono α] {a b c : α} {h : b ≤ c ∨ c ≤ b} :
     a * c = a * b ↔ c = b := by
   refine ⟨fun h' => ?_, fun h => h ▸ rfl⟩
   contrapose h'
-  exact mul_lt_mul_left' (h.lt_of_ne h') a |>.ne
+  obtain h|h := h
+  · exact mul_lt_mul_left' (h.lt_of_ne' h') a |>.ne'
+  · exact mul_lt_mul_left' (h.lt_of_ne h') a |>.ne
 
 end PartialOrder
 

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -144,12 +144,20 @@ section Preorder
 variable [Preorder α]
 
 @[to_additive]
-lemma mul_left_mono [CovariantClass α α (· * ·) (· ≤ ·)] {a : α} : Monotone (a * ·) :=
+lemma mul_left_mono [MulLeftMono α] {a : α} : Monotone (a * ·) :=
   fun _ _ h ↦ mul_le_mul_left' h _
 
 @[to_additive]
-lemma mul_right_mono [CovariantClass α α (swap (· * ·)) (· ≤ ·)] {a : α} : Monotone (· * a) :=
+lemma mul_right_mono [MulRightMono α] {a : α} : Monotone (· * a) :=
   fun _ _ h ↦ mul_le_mul_right' h _
+
+@[to_additive]
+lemma mul_left_strictMono [MulLeftStrictMono α] {a : α} : StrictMono (a * ·) :=
+  fun _ _ h ↦ mul_lt_mul_left' h _
+
+@[to_additive]
+lemma mul_right_strictMono [MulRightStrictMono α] {a : α} : StrictMono (· * a) :=
+  fun _ _ h ↦ mul_lt_mul_right' h _
 
 @[to_additive (attr := gcongr)]
 theorem mul_lt_mul_of_lt_of_lt [MulLeftStrictMono α]
@@ -346,12 +354,12 @@ lemma min_mul [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a b c : α) :
 /-- Not an instance, to avoid loops with `IsLeftCancelMul.mulLeftStrictMono_of_mulLeftMono`. -/
 @[to_additive]
 theorem MulLeftStrictMono.toIsLeftCancelMul [MulLeftStrictMono α] : IsLeftCancelMul α where
-  mul_left_cancel _ _ _ h := StrictMono.injective (fun _ _ h => mul_lt_mul_left' h _) h
+  mul_left_cancel _ _ _ h := mul_left_strictMono.injective h
 
 /-- Not an instance, to avoid loops with `IsRightCancelMul.mulRightStrictMono_of_mulRightMono`. -/
 @[to_additive]
 theorem MulRightStrictMono.toIsRightCancelMul [MulRightStrictMono α] : IsRightCancelMul α where
-  mul_right_cancel _ _ _ h := StrictMono.injective (fun _ _ h => mul_lt_mul_right' h _) h
+  mul_right_cancel _ _ _ h := mul_right_strictMono.injective h
 
 end LinearOrder
 

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -293,19 +293,19 @@ theorem mul_right_cancel'' [MulRightReflectLE α] {a b c : α}
 
 @[to_additive]
 lemma mul_left_inj_of_comparable [MulRightStrictMono α] {a b c : α} {h : b ≤ c ∨ c ≤ b} :
-    c * a  = b * a ↔ c = b := by
+    c * a = b * a ↔ c = b := by
   refine ⟨fun h' => ?_, (· ▸ rfl)⟩
   contrapose h'
-  obtain h|h := h
+  obtain h | h := h
   · exact mul_lt_mul_right' (h.lt_of_ne' h') a |>.ne'
   · exact mul_lt_mul_right' (h.lt_of_ne h') a |>.ne
 
 @[to_additive]
 lemma mul_right_inj_of_comparable [MulLeftStrictMono α] {a b c : α} {h : b ≤ c ∨ c ≤ b} :
     a * c = a * b ↔ c = b := by
-  refine ⟨fun h' => ?_, fun h => h ▸ rfl⟩
+  refine ⟨fun h' => ?_, (· ▸ rfl)⟩
   contrapose h'
-  obtain h|h := h
+  obtain h | h := h
   · exact mul_lt_mul_left' (h.lt_of_ne' h') a |>.ne'
   · exact mul_lt_mul_left' (h.lt_of_ne h') a |>.ne
 

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -292,7 +292,7 @@ theorem mul_right_cancel'' [MulRightReflectLE α] {a b c : α}
   rw [le_antisymm_iff, eq_true (mul_le_mul' hac hbd), true_and, mul_le_mul_iff_of_ge hac hbd]
 
 @[to_additive]
-lemma mul_left_inj_of_comparable [MulRightStrictMono α] {a b c : α} {h : b ≤ c ∨ c ≤ b} :
+lemma mul_left_inj_of_comparable [MulRightStrictMono α] {a b c : α} (h : b ≤ c ∨ c ≤ b) :
     c * a = b * a ↔ c = b := by
   refine ⟨fun h' => ?_, (· ▸ rfl)⟩
   contrapose h'
@@ -301,7 +301,7 @@ lemma mul_left_inj_of_comparable [MulRightStrictMono α] {a b c : α} {h : b ≤
   · exact mul_lt_mul_right' (h.lt_of_ne h') a |>.ne
 
 @[to_additive]
-lemma mul_right_inj_of_comparable [MulLeftStrictMono α] {a b c : α} {h : b ≤ c ∨ c ≤ b} :
+lemma mul_right_inj_of_comparable [MulLeftStrictMono α] {a b c : α} (h : b ≤ c ∨ c ≤ b) :
     a * c = a * b ↔ c = b := by
   refine ⟨fun h' => ?_, (· ▸ rfl)⟩
   contrapose h'


### PR DESCRIPTION
Prove injectivity/cancellability of mul/add assuming some monotonicity.

These results were rescued from #6627.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
