### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology): rename standardSimplex to stdSimplex

### DIFF
--- a/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
+++ b/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
@@ -176,10 +176,10 @@ def shift {n : ℕ} {Δ : SimplexCategory}
           substs hj₁ hj₂
           simpa only [shiftFun_succ] using f.toOrderHom.monotone (Fin.succ_le_succ_iff.mp hi) }
 
-open SSet.standardSimplex in
+open SSet.stdSimplex in
 /-- The obvious extra degeneracy on the standard simplex. -/
 protected noncomputable def extraDegeneracy (Δ : SimplexCategory) :
-    SimplicialObject.Augmented.ExtraDegeneracy (standardSimplex.obj Δ) where
+    SimplicialObject.Augmented.ExtraDegeneracy (stdSimplex.obj Δ) where
   s' _ := objMk (OrderHom.const _ 0)
   s  _ f := (objEquiv _ _).symm
     (shift (objEquiv _ _ f))
@@ -198,7 +198,7 @@ protected noncomputable def extraDegeneracy (Δ : SimplexCategory) :
     apply (objEquiv _ _).injective
     apply SimplexCategory.Hom.ext
     ext i : 2
-    dsimp [SimplicialObject.δ, SimplexCategory.δ, SSet.standardSimplex,
+    dsimp [SimplicialObject.δ, SimplexCategory.δ, SSet.stdSimplex,
       objEquiv, Equiv.ulift, uliftFunctor]
     simp only [shiftFun_succ]
   s_comp_δ n i := by
@@ -206,7 +206,7 @@ protected noncomputable def extraDegeneracy (Δ : SimplexCategory) :
     apply (objEquiv _ _).injective
     apply SimplexCategory.Hom.ext
     ext j : 2
-    dsimp [SimplicialObject.δ, SimplexCategory.δ, SSet.standardSimplex,
+    dsimp [SimplicialObject.δ, SimplexCategory.δ, SSet.stdSimplex,
       objEquiv, Equiv.ulift, uliftFunctor]
     by_cases h : j = 0
     · subst h
@@ -219,7 +219,7 @@ protected noncomputable def extraDegeneracy (Δ : SimplexCategory) :
     apply (objEquiv _ _).injective
     apply SimplexCategory.Hom.ext
     ext j : 2
-    dsimp [SimplicialObject.σ, SimplexCategory.σ, SSet.standardSimplex,
+    dsimp [SimplicialObject.σ, SimplexCategory.σ, SSet.stdSimplex,
       objEquiv, Equiv.ulift, uliftFunctor]
     by_cases h : j = 0
     · subst h
@@ -227,8 +227,8 @@ protected noncomputable def extraDegeneracy (Δ : SimplexCategory) :
     · obtain ⟨_, rfl⟩ := Fin.eq_succ_of_ne_zero h
       simp only [Fin.succ_predAbove_succ, shiftFun_succ, Function.comp_apply]
 
-instance nonempty_extraDegeneracy_standardSimplex (Δ : SimplexCategory) :
-    Nonempty (SimplicialObject.Augmented.ExtraDegeneracy (standardSimplex.obj Δ)) :=
+instance nonempty_extraDegeneracy_stdSimplex (Δ : SimplexCategory) :
+    Nonempty (SimplicialObject.Augmented.ExtraDegeneracy (stdSimplex.obj Δ)) :=
   ⟨StandardSimplex.extraDegeneracy Δ⟩
 
 end StandardSimplex

--- a/Mathlib/AlgebraicTopology/Quasicategory/StrictSegal.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/StrictSegal.lean
@@ -39,18 +39,18 @@ instance quasicategory {X : SSet.{u}} [StrictSegal X] : Quasicategory X := by
   · rw [← spine_arrow, spine_δ_arrow_lt _ hlt]
     dsimp only [Path.map, spine_arrow, Fin.coe_eq_castSucc]
     apply congr_arg
-    simp only [horn, horn.spineId, standardSimplex, uliftFunctor, Functor.comp_obj,
+    simp only [horn, horn.spineId, stdSimplex, uliftFunctor, Functor.comp_obj,
       yoneda_obj_obj, whiskering_obj_obj_map, uliftFunctor_map, yoneda_obj_map,
-      standardSimplex.objEquiv, Equiv.ulift, Equiv.coe_fn_symm_mk,
+      stdSimplex.objEquiv, Equiv.ulift, Equiv.coe_fn_symm_mk,
       Quiver.Hom.unop_op, horn.face_coe, Subtype.mk.injEq]
     rw [mkOfSucc_δ_lt hlt]
     rfl
   · rw [← spine_arrow, spine_δ_arrow_gt _ hgt]
     dsimp only [Path.map, spine_arrow, Fin.coe_eq_castSucc]
     apply congr_arg
-    simp only [horn, horn.spineId, standardSimplex, uliftFunctor, Functor.comp_obj,
+    simp only [horn, horn.spineId, stdSimplex, uliftFunctor, Functor.comp_obj,
       yoneda_obj_obj, whiskering_obj_obj_map, uliftFunctor_map, yoneda_obj_map,
-      standardSimplex.objEquiv, Equiv.ulift, Equiv.coe_fn_symm_mk,
+      stdSimplex.objEquiv, Equiv.ulift, Equiv.coe_fn_symm_mk,
       Quiver.Hom.unop_op, horn.face_coe, Subtype.mk.injEq]
     rw [mkOfSucc_δ_gt hgt]
     rfl
@@ -74,7 +74,7 @@ instance quasicategory {X : SSet.{u}} [StrictSegal X] : Quasicategory X := by
       dsimp [spine_arrow, Path.interval, Path.map]
       rw [← types_comp_apply (σ₀.app _) (X.map _), ← σ₀.naturality]
       apply congr_arg
-      simp only [horn, standardSimplex, uliftFunctor, Functor.comp_obj,
+      simp only [horn, stdSimplex, uliftFunctor, Functor.comp_obj,
         whiskering_obj_obj_obj, yoneda_obj_obj, uliftFunctor_obj, ne_eq,
         whiskering_obj_obj_map, uliftFunctor_map, yoneda_obj_map, len_mk,
         Nat.reduceAdd, Quiver.Hom.unop_op]
@@ -85,7 +85,7 @@ instance quasicategory {X : SSet.{u}} [StrictSegal X] : Quasicategory X := by
     simp only [spineToDiagonal, diagonal, spineToSimplex_spine]
     rw [← types_comp_apply (σ₀.app _) (X.map _), ← σ₀.naturality, types_comp_apply]
     apply congr_arg
-    simp only [horn, standardSimplex, uliftFunctor, Functor.comp_obj,
+    simp only [horn, stdSimplex, uliftFunctor, Functor.comp_obj,
       whiskering_obj_obj_obj, yoneda_obj_obj, uliftFunctor_obj,
       uliftFunctor_map, whiskering_obj_obj_map, yoneda_obj_map, horn.face_coe,
       len_mk, Nat.reduceAdd, Quiver.Hom.unop_op, Subtype.mk.injEq, ULift.up_inj]
@@ -94,7 +94,7 @@ instance quasicategory {X : SSet.{u}} [StrictSegal X] : Quasicategory X := by
     | zero => contradiction
     | succ _ =>
       fin_cases z <;>
-      · simp only [standardSimplex.objEquiv, uliftFunctor_map, yoneda_obj_map,
+      · simp only [stdSimplex.objEquiv, uliftFunctor_map, yoneda_obj_map,
           Quiver.Hom.unop_op, Equiv.ulift_symm_down]
         rw [mkOfSucc_δ_eq heq]
         rfl

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
@@ -71,43 +71,43 @@ def uliftFunctor : SSet.{u} ⥤ SSet.{max u v} :=
 
 /-- The `n`-th standard simplex `Δ[n]` associated with a nonempty finite linear order `n`
 is the Yoneda embedding of `n`. -/
-def standardSimplex : SimplexCategory ⥤ SSet.{u} :=
+def stdSimplex : SimplexCategory ⥤ SSet.{u} :=
   yoneda ⋙ uliftFunctor
 
-@[inherit_doc SSet.standardSimplex]
-scoped[Simplicial] notation3 "Δ[" n "]" => SSet.standardSimplex.obj (SimplexCategory.mk n)
+@[inherit_doc SSet.stdSimplex]
+scoped[Simplicial] notation3 "Δ[" n "]" => SSet.stdSimplex.obj (SimplexCategory.mk n)
 
 instance : Inhabited SSet :=
   ⟨Δ[0]⟩
 
-namespace standardSimplex
+namespace stdSimplex
 
 open Finset Opposite SimplexCategory
 
 @[simp]
 lemma map_id (n : SimplexCategory) :
-    (SSet.standardSimplex.map (SimplexCategory.Hom.mk OrderHom.id : n ⟶ n)) = 𝟙 _ :=
+    (SSet.stdSimplex.map (SimplexCategory.Hom.mk OrderHom.id : n ⟶ n)) = 𝟙 _ :=
   CategoryTheory.Functor.map_id _ _
 
 /-- Simplices of the standard simplex identify to morphisms in `SimplexCategory`. -/
 def objEquiv (n : SimplexCategory) (m : SimplexCategoryᵒᵖ) :
-    (standardSimplex.{u}.obj n).obj m ≃ (m.unop ⟶ n) :=
+    (stdSimplex.{u}.obj n).obj m ≃ (m.unop ⟶ n) :=
   Equiv.ulift.{u, 0}
 
 /-- Constructor for simplices of the standard simplex which takes a `OrderHom` as an input. -/
 abbrev objMk {n : SimplexCategory} {m : SimplexCategoryᵒᵖ}
     (f : Fin (len m.unop + 1) →o Fin (n.len + 1)) :
-    (standardSimplex.{u}.obj n).obj m :=
+    (stdSimplex.{u}.obj n).obj m :=
   (objEquiv _ _).symm (Hom.mk f)
 
 lemma map_apply {m₁ m₂ : SimplexCategoryᵒᵖ} (f : m₁ ⟶ m₂) {n : SimplexCategory}
-    (x : (standardSimplex.{u}.obj n).obj m₁) :
-    (standardSimplex.{u}.obj n).map f x = (objEquiv _ _).symm (f.unop ≫ (objEquiv _ _) x) := by
+    (x : (stdSimplex.{u}.obj n).obj m₁) :
+    (stdSimplex.{u}.obj n).map f x = (objEquiv _ _).symm (f.unop ≫ (objEquiv _ _) x) := by
   rfl
 
-/-- The canonical bijection `(standardSimplex.obj n ⟶ X) ≃ X.obj (op n)`. -/
+/-- The canonical bijection `(stdSimplex.obj n ⟶ X) ≃ X.obj (op n)`. -/
 def _root_.SSet.yonedaEquiv (X : SSet.{u}) (n : SimplexCategory) :
-    (standardSimplex.obj n ⟶ X) ≃ X.obj (op n) :=
+    (stdSimplex.obj n ⟶ X) ≃ X.obj (op n) :=
   yonedaCompUliftFunctorEquiv X n
 
 /-- The unique non-degenerate `n`-simplex in `Δ[n]`. -/
@@ -149,7 +149,7 @@ lemma coe_triangle_down_toOrderHom {n : ℕ} (a b c : Fin (n+1)) (hab : a ≤ b)
     ↑(triangle a b c hab hbc).down.toOrderHom = ![a, b, c] :=
   rfl
 
-end standardSimplex
+end stdSimplex
 
 section
 
@@ -161,7 +161,7 @@ def asOrderHom {n} {m} (α : Δ[n].obj m) : OrderHom (Fin (m.unop.len + 1)) (Fin
 end
 
 /-- The boundary `∂Δ[n]` of the `n`-th standard simplex consists of
-all `m`-simplices of `standardSimplex n` that are not surjective
+all `m`-simplices of `stdSimplex n` that are not surjective
 (when viewed as monotone function `m → n`). -/
 def boundary (n : ℕ) : SSet.{u} where
   obj m := { α : Δ[n].obj m // ¬Function.Surjective (asOrderHom α) }
@@ -219,7 +219,7 @@ open SimplexCategory Finset Opposite
 /-- The (degenerate) subsimplex of `Λ[n+2, i]` concentrated in vertex `k`. -/
 @[simps]
 def const (n : ℕ) (i k : Fin (n+3)) (m : SimplexCategoryᵒᵖ) : Λ[n+2, i].obj m := by
-  refine ⟨standardSimplex.const _ k _, ?_⟩
+  refine ⟨stdSimplex.const _ k _, ?_⟩
   suffices ¬ Finset.univ ⊆ {i, k} by
     simpa [← Set.univ_subset_iff, Set.subset_def, asOrderHom, not_or, Fin.forall_fin_one,
       subset_iff, mem_univ, @eq_comm _ _ k]
@@ -233,7 +233,7 @@ def const (n : ℕ) (i k : Fin (n+3)) (m : SimplexCategoryᵒᵖ) : Λ[n+2, i].o
 This edge only exists if `{i, a, b}` has cardinality less than `n`. -/
 @[simps]
 def edge (n : ℕ) (i a b : Fin (n+1)) (hab : a ≤ b) (H : #{i, a, b} ≤ n) : Λ[n, i] _[1] := by
-  refine ⟨standardSimplex.edge n a b hab, ?range⟩
+  refine ⟨stdSimplex.edge n a b hab, ?range⟩
   case range =>
     suffices ∃ x, ¬i = x ∧ ¬a = x ∧ ¬b = x by
       simpa only [unop_op, len_mk, Nat.reduceAdd, asOrderHom, yoneda_obj_obj, Set.union_singleton,
@@ -277,7 +277,7 @@ which is the type of horn that occurs in the horn-filling condition of quasicate
 def primitiveTriangle {n : ℕ} (i : Fin (n+4))
     (h₀ : 0 < i) (hₙ : i < Fin.last (n+3))
     (k : ℕ) (h : k < n+2) : Λ[n+3, i] _[2] := by
-  refine ⟨standardSimplex.triangle
+  refine ⟨stdSimplex.triangle
     (n := n+3) ⟨k, by omega⟩ ⟨k+1, by omega⟩ ⟨k+2, by omega⟩ ?_ ?_, ?_⟩
   · simp only [Fin.mk_le_mk, le_add_iff_nonneg_right, zero_le]
   · simp only [Fin.mk_le_mk, add_le_add_iff_left, one_le_two]
@@ -285,8 +285,8 @@ def primitiveTriangle {n : ℕ} (i : Fin (n+4))
     OrderHom.const_coe_coe, Set.union_singleton, ne_eq, ← Set.univ_subset_iff, Set.subset_def,
     Set.mem_univ, Set.mem_insert_iff, Set.mem_range, Function.const_apply, exists_const,
     forall_true_left, not_forall, not_or, unop_op, not_exists,
-    standardSimplex.triangle, OrderHom.coe_mk, @eq_comm _ _ i,
-    standardSimplex.objMk, standardSimplex.objEquiv, Equiv.ulift]
+    stdSimplex.triangle, OrderHom.coe_mk, @eq_comm _ _ i,
+    stdSimplex.objMk, stdSimplex.objEquiv, Equiv.ulift]
   dsimp
   by_cases hk0 : k = 0
   · subst hk0
@@ -302,9 +302,9 @@ def primitiveTriangle {n : ℕ} (i : Fin (n+4))
 /-- The `j`th subface of the `i`-th horn. -/
 @[simps]
 def face {n : ℕ} (i j : Fin (n+2)) (h : j ≠ i) : Λ[n+1, i] _[n] :=
-  ⟨(standardSimplex.objEquiv _ _).symm (SimplexCategory.δ j), by
+  ⟨(stdSimplex.objEquiv _ _).symm (SimplexCategory.δ j), by
     simpa [← Set.univ_subset_iff, Set.subset_def, asOrderHom, SimplexCategory.δ, not_or,
-      standardSimplex.objEquiv, asOrderHom, Equiv.ulift]⟩
+      stdSimplex.objEquiv, asOrderHom, Equiv.ulift]⟩
 
 /-- Two morphisms from a horn are equal if they are equal on all suitable faces. -/
 protected
@@ -313,14 +313,14 @@ lemma hom_ext {n : ℕ} {i : Fin (n+2)} {S : SSet} (σ₁ σ₂ : Λ[n+1, i] ⟶
     σ₁ = σ₂ := by
   apply NatTrans.ext; apply funext; apply Opposite.rec; apply SimplexCategory.rec
   intro m; ext f
-  obtain ⟨f', hf⟩ := (standardSimplex.objEquiv _ _).symm.surjective f.1
+  obtain ⟨f', hf⟩ := (stdSimplex.objEquiv _ _).symm.surjective f.1
   obtain ⟨j, hji, hfj⟩ : ∃ j, ¬j = i ∧ ∀ k, f'.toOrderHom k ≠ j := by
     obtain ⟨f, hf'⟩ := f
     subst hf
     simpa [← Set.univ_subset_iff, Set.subset_def, asOrderHom, not_or] using hf'
   have H : f = (Λ[n+1, i].map (factor_δ f' j).op) (face i j hji) := by
     apply Subtype.ext
-    apply (standardSimplex.objEquiv _ _).injective
+    apply (stdSimplex.objEquiv _ _).injective
     rw [← hf]
     exact (factor_δ_spec f' j hfj).symm
   have H₁ := congrFun (σ₁.naturality (factor_δ f' j).op) (face i j hji)
@@ -337,8 +337,8 @@ open Simplicial
 /-- The simplicial circle. -/
 noncomputable def S1 : SSet :=
   Limits.colimit <|
-    Limits.parallelPair (standardSimplex.map <| SimplexCategory.δ 0 : Δ[0] ⟶ Δ[1])
-      (standardSimplex.map <| SimplexCategory.δ 1)
+    Limits.parallelPair (stdSimplex.map <| SimplexCategory.δ 0 : Δ[0] ⟶ Δ[1])
+      (stdSimplex.map <| SimplexCategory.δ 1)
 
 end Examples
 
@@ -455,13 +455,13 @@ namespace Augmented
 /-- The functor which sends `[n]` to the simplicial set `Δ[n]` equipped by
 the obvious augmentation towards the terminal object of the category of sets. -/
 @[simps]
-noncomputable def standardSimplex : SimplexCategory ⥤ SSet.Augmented.{u} where
+noncomputable def stdSimplex : SimplexCategory ⥤ SSet.Augmented.{u} where
   obj Δ :=
-    { left := SSet.standardSimplex.obj Δ
+    { left := SSet.stdSimplex.obj Δ
       right := terminal _
       hom := { app := fun _ => terminal.from _ } }
   map θ :=
-    { left := SSet.standardSimplex.map θ
+    { left := SSet.stdSimplex.map θ
       right := terminal.from _ }
 
 end Augmented

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
@@ -74,6 +74,8 @@ is the Yoneda embedding of `n`. -/
 def stdSimplex : SimplexCategory ⥤ SSet.{u} :=
   yoneda ⋙ uliftFunctor
 
+@[deprecated (since := "2025-01-23")] alias standardSimplex := stdSimplex
+
 @[inherit_doc SSet.stdSimplex]
 scoped[Simplicial] notation3 "Δ[" n "]" => SSet.stdSimplex.obj (SimplexCategory.mk n)
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
@@ -110,8 +110,8 @@ lemma map_interval {X Y : SSet.{u}} {n : ℕ} (f : X.Path n) (σ : X ⟶ Y)
     (f.map σ).interval j l hjl = (f.interval j l hjl).map σ := rfl
 
 /-- The spine of the unique non-degenerate `n`-simplex in `Δ[n]`.-/
-def standardSimplex.spineId (n : ℕ) : Path Δ[n] n :=
-  spine Δ[n] n (standardSimplex.id n)
+def stdSimplex.spineId (n : ℕ) : Path Δ[n] n :=
+  spine Δ[n] n (stdSimplex.id n)
 
 /-- Any inner horn contains the spine of the unique non-degenerate `n`-simplex
 in `Δ[n]`.-/
@@ -119,27 +119,27 @@ in `Δ[n]`.-/
 def horn.spineId {n : ℕ} (i : Fin (n + 3))
     (h₀ : 0 < i) (hₙ : i < Fin.last (n + 2)) :
     Path Λ[n + 2, i] (n + 2) where
-  vertex j := ⟨standardSimplex.spineId _ |>.vertex j, (horn.const n i j _).property⟩
-  arrow j := ⟨standardSimplex.spineId _ |>.arrow j, by
+  vertex j := ⟨stdSimplex.spineId _ |>.vertex j, (horn.const n i j _).property⟩
+  arrow j := ⟨stdSimplex.spineId _ |>.arrow j, by
     let edge := horn.primitiveEdge h₀ hₙ j
-    have ha : (standardSimplex.spineId _).arrow j = edge.val := by
-      dsimp only [edge, standardSimplex.spineId, standardSimplex.id, spine_arrow,
-        mkOfSucc, horn.primitiveEdge, horn.edge, standardSimplex.edge,
-        standardSimplex.map_apply]
+    have ha : (stdSimplex.spineId _).arrow j = edge.val := by
+      dsimp only [edge, stdSimplex.spineId, stdSimplex.id, spine_arrow,
+        mkOfSucc, horn.primitiveEdge, horn.edge, stdSimplex.edge,
+        stdSimplex.map_apply]
       aesop
     rw [ha]
     exact edge.property⟩
   arrow_src := by
     simp only [horn, SimplicialObject.δ, Subtype.mk.injEq]
-    exact standardSimplex.spineId _ |>.arrow_src
+    exact stdSimplex.spineId _ |>.arrow_src
   arrow_tgt := by
     simp only [horn, SimplicialObject.δ, Subtype.mk.injEq]
-    exact standardSimplex.spineId _ |>.arrow_tgt
+    exact stdSimplex.spineId _ |>.arrow_tgt
 
 @[simp]
 lemma horn.spineId_map_hornInclusion {n : ℕ} (i : Fin (n + 3))
     (h₀ : 0 < i) (hₙ : i < Fin.last (n + 2)) :
     Path.map (horn.spineId i h₀ hₙ) (hornInclusion (n + 2) i) =
-      standardSimplex.spineId (n + 2) := rfl
+      stdSimplex.spineId (n + 2) := rfl
 
 end SSet


### PR DESCRIPTION
Moves:
- SSet.standardSimplex -> SSet.stdSimplex
- SSet.standardSimplex.* -> SSet.stdSimplex.*

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I expect this will require some discussion, but here is my pitch:

This saves five letters, and `std` is a "standard" abbreviation, even within the Lean community (see, e.g., `Std.Data.HashMap.Basic`).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
