### PR TITLE
[Merged by Bors] - feat(MeasureTheory): additive contents on rings of sets

### DIFF
--- a/Mathlib/Data/Nat/Lattice.lean
+++ b/Mathlib/Data/Nat/Lattice.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Floris van Doorn, Gabriel Ebner, Yury Kudryashov
 -/
+import Mathlib.Data.Set.Accumulate
 import Mathlib.Order.ConditionallyCompleteLattice.Finset
 import Mathlib.Order.Interval.Finset.Nat
 
@@ -234,5 +235,8 @@ theorem biInter_le_succ (u : ℕ → Set α) (n : ℕ) : ⋂ k ≤ n + 1, u k = 
 
 theorem biInter_le_succ' (u : ℕ → Set α) (n : ℕ) : ⋂ k ≤ n + 1, u k = u 0 ∩ ⋂ k ≤ n, u (k + 1) :=
   Nat.iInf_le_succ' u n
+
+theorem accumulate_succ (u : ℕ → Set α) (n : ℕ) :
+    Set.Accumulate u (n + 1) = Set.Accumulate u n ∪ u (n + 1) := Set.biUnion_le_succ u n
 
 end Set

--- a/Mathlib/Data/Nat/Lattice.lean
+++ b/Mathlib/Data/Nat/Lattice.lean
@@ -237,6 +237,6 @@ theorem biInter_le_succ' (u : ℕ → Set α) (n : ℕ) : ⋂ k ≤ n + 1, u k =
   Nat.iInf_le_succ' u n
 
 theorem accumulate_succ (u : ℕ → Set α) (n : ℕ) :
-    Set.Accumulate u (n + 1) = Set.Accumulate u n ∪ u (n + 1) := Set.biUnion_le_succ u n
+    Accumulate u (n + 1) = Accumulate u n ∪ u (n + 1) := biUnion_le_succ u n
 
 end Set

--- a/Mathlib/Data/Set/Accumulate.lean
+++ b/Mathlib/Data/Set/Accumulate.lean
@@ -52,4 +52,17 @@ theorem iUnion_accumulate [Preorder α] : ⋃ x, Accumulate s x = ⋃ x, s x := 
     exact ⟨x', hz⟩
   · exact iUnion_mono fun i => subset_accumulate
 
+@[simp]
+lemma accumulate_zero_nat (s : ℕ → Set β) : Set.Accumulate s 0 = s 0 := by
+  simp [accumulate_def]
+
+open Function in
+theorem disjoint_accumulate [Preorder α]
+    (hs : Pairwise (Disjoint on s)) {i j : α} (hij : i < j) :
+    Disjoint (Set.Accumulate s i) (s j) := by
+  apply disjoint_left.2 (fun x hx ↦ ?_)
+  simp only [Accumulate, mem_iUnion, exists_prop] at hx
+  rcases hx with ⟨k, hk, hx⟩
+  exact disjoint_left.1 (hs (hk.trans_lt hij).ne) hx
+
 end Set

--- a/Mathlib/Data/Set/Accumulate.lean
+++ b/Mathlib/Data/Set/Accumulate.lean
@@ -53,13 +53,12 @@ theorem iUnion_accumulate [Preorder α] : ⋃ x, Accumulate s x = ⋃ x, s x := 
   · exact iUnion_mono fun i => subset_accumulate
 
 @[simp]
-lemma accumulate_zero_nat (s : ℕ → Set β) : Set.Accumulate s 0 = s 0 := by
+lemma accumulate_zero_nat (s : ℕ → Set β) : Accumulate s 0 = s 0 := by
   simp [accumulate_def]
 
 open Function in
-theorem disjoint_accumulate [Preorder α]
-    (hs : Pairwise (Disjoint on s)) {i j : α} (hij : i < j) :
-    Disjoint (Set.Accumulate s i) (s j) := by
+theorem disjoint_accumulate [Preorder α] (hs : Pairwise (Disjoint on s)) {i j : α} (hij : i < j) :
+    Disjoint (Accumulate s i) (s j) := by
   apply disjoint_left.2 (fun x hx ↦ ?_)
   simp only [Accumulate, mem_iUnion, exists_prop] at hx
   rcases hx with ⟨k, hk, hx⟩

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -5,7 +5,10 @@ Authors: Rémy Degenne, Peter Pfaffelhuber
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Data.ENNReal.Basic
+import Mathlib.MeasureTheory.OuterMeasure.Induced
 import Mathlib.MeasureTheory.SetSemiring
+import Mathlib.Topology.Algebra.InfiniteSum.Defs
+import Mathlib.Topology.Algebra.InfiniteSum.ENNReal
 
 /-!
 # Additive Contents
@@ -39,6 +42,37 @@ If `C` is a set ring (`MeasureTheory.IsSetRing C`), we have, for `s, t ∈ C`,
 * `MeasureTheory.addContent_le_diff`: `m s - m t ≤ m (s \ t)`
 
 -/
+
+@[simp]
+lemma accumulate_zero_nat {α : Type*}
+  (s : ℕ → Set α) : Set.Accumulate s 0 = s 0 := by simp [Set.accumulate_def]
+
+open Function in
+theorem Set.disjoint_accumulate {α : Type*} {s : ℕ → Set α}
+    (hs : Pairwise (Disjoint on s)) {i j : ℕ}
+    (hij : i < j) : Disjoint (Set.Accumulate s i) (s j) := by
+  rw [Set.accumulate_def]
+  induction i with
+  | zero => simp only [Nat.zero_eq, nonpos_iff_eq_zero, iUnion_iUnion_eq_left]; exact hs hij.ne
+  | succ i hi =>
+    rw [Set.biUnion_le_succ s i]
+    exact Disjoint.union_left (hi ((Nat.lt_succ_self i).trans hij)) (hs hij.ne)
+
+open scoped ENNReal in
+open Filter Topology in
+theorem ENNReal.tendsto_atTop_zero_const_sub_iff (f : ℕ → ℝ≥0∞) (a : ℝ≥0∞) (ha : a ≠ ∞)
+    (hfa : ∀ n, f n ≤ a) :
+    Tendsto (fun n ↦ a - f n) atTop (𝓝 0) ↔ Tendsto (fun n ↦ f n) atTop (𝓝 a) := by
+  rw [ENNReal.tendsto_atTop_zero, ENNReal.tendsto_atTop ha]
+  refine ⟨fun h ε hε ↦ ?_, fun h ε hε ↦ ?_⟩ <;> obtain ⟨N, hN⟩ := h ε hε
+  · refine ⟨N, fun n hn ↦ ⟨?_, (hfa n).trans (le_add_right le_rfl)⟩⟩
+    specialize hN n hn
+    rw [tsub_le_iff_right] at hN ⊢
+    rwa [add_comm]
+  · refine ⟨N, fun n hn ↦ ?_⟩
+    have hN_left := (hN n hn).1
+    rw [tsub_le_iff_right] at hN_left ⊢
+    rwa [add_comm]
 
 open Set Finset
 
@@ -173,6 +207,120 @@ lemma le_addContent_diff (m : AddContent C) (hC : IsSetRing C) (hs : s ∈ C) (h
   rw [tsub_eq_zero_of_le
     (addContent_mono hC.isSetSemiring (hC.inter_mem hs ht) ht inter_subset_right), add_zero]
 
+lemma addContent_diff_of_ne_top (m : AddContent C) (hC : IsSetRing C)
+    (hm_ne_top : ∀ s ∈ C, m s ≠ ∞)
+    {s t : Set α} (hs : s ∈ C) (ht : t ∈ C) (hts : t ⊆ s) :
+    m (s \ t) = m s - m t := by
+  have h_union : m (t ∪ s \ t) = m t + m (s \ t) :=
+    addContent_union hC ht (hC.diff_mem hs ht) disjoint_sdiff_self_right
+  simp_rw [Set.union_diff_self, Set.union_eq_right.mpr hts] at h_union
+  rw [h_union, ENNReal.add_sub_cancel_left (hm_ne_top _ ht)]
+
+lemma addContent_accumulate (m : AddContent C) (hC : IsSetRing C)
+    {s : ℕ → Set α} (hs_disj : Pairwise (Function.onFun Disjoint s)) (hsC : ∀ i, s i ∈ C) (n : ℕ) :
+      m (Set.Accumulate s n) = ∑ i in Finset.range (n + 1), m (s i) := by
+  induction n with
+  | zero => simp
+  | succ n hn =>
+    rw [Finset.sum_range_succ, ← hn, Set.accumulate_succ, addContent_union hC _ (hsC _)]
+    · exact Set.disjoint_accumulate hs_disj (Nat.lt_succ_self n)
+    · exact hC.accumulate_mem hsC n
+
 end IsSetRing
+
+open scoped ENNReal
+
+open scoped Topology
+open Filter
+
+variable {α : Type*} {C : Set (Set α)}
+
+/-- In a ring of sets, continuity of an additive content at `∅` implies σ-additivity.
+This is not true in general in semirings, or without the hypothesis that `m` is finite. See the
+examples 7 and 8 in Halmos' book Measure Theory (1974), page 40. -/
+theorem addContent_iUnion_eq_sum_of_tendsto_zero (hC : IsSetRing C) (m : AddContent C)
+    (hm_ne_top : ∀ s ∈ C, m s ≠ ∞)
+    (hm_tendsto : ∀ ⦃s : ℕ → Set α⦄ (_ : ∀ n, s n ∈ C),
+      Antitone s → (⋂ n, s n) = ∅ → Tendsto (fun n ↦ m (s n)) atTop (𝓝 0))
+    ⦃f : ℕ → Set α⦄ (hf : ∀ i, f i ∈ C) (hUf : (⋃ i, f i) ∈ C)
+    (h_disj : Pairwise (Function.onFun Disjoint f)) :
+    m (⋃ i, f i) = ∑' i, m (f i) := by
+  -- We use the continuity of `m` at `∅` on the sequence `n ↦ (⋃ i, f i) \ (set.accumulate f n)`
+  let s : ℕ → Set α := fun n ↦ (⋃ i, f i) \ Set.Accumulate f n
+  have hCs n : s n ∈ C := hC.diff_mem hUf (hC.accumulate_mem hf n)
+  have h_tendsto : Tendsto (fun n ↦ m (s n)) atTop (𝓝 0) := by
+    refine hm_tendsto hCs ?_ ?_
+    · intro i j hij x hxj
+      rw [Set.mem_diff] at hxj ⊢
+      exact ⟨hxj.1, fun hxi ↦ hxj.2 (Set.monotone_accumulate hij hxi)⟩
+    · simp_rw [s, Set.diff_eq]
+      rw [Set.iInter_inter_distrib, Set.iInter_const, ← Set.compl_iUnion, Set.iUnion_accumulate]
+      exact Set.inter_compl_self _
+  have hmsn n : m (s n) = m (⋃ i, f i) - ∑ i in Finset.range (n + 1), m (f i) := by
+    rw [addContent_diff_of_ne_top m hC hm_ne_top hUf (hC.accumulate_mem hf n)
+      (Set.accumulate_subset_iUnion _), addContent_accumulate m hC h_disj hf n]
+  simp_rw [hmsn] at h_tendsto
+  refine tendsto_nhds_unique ?_ (ENNReal.tendsto_nat_tsum fun i ↦ m (f i))
+  refine (Filter.tendsto_add_atTop_iff_nat 1).mp ?_
+  rwa [ENNReal.tendsto_atTop_zero_const_sub_iff _ _ (hm_ne_top _ hUf) (fun n ↦ ?_)] at h_tendsto
+  rw [← addContent_accumulate m hC h_disj hf]
+  exact addContent_mono hC.isSetSemiring (hC.accumulate_mem hf n) hUf
+    (Set.accumulate_subset_iUnion _)
+
+theorem sUnion_eq_sum_of_union_eq_add (hC_empty : ∅ ∈ C)
+    (hC_union : ∀ {s t : Set α}, s ∈ C → t ∈ C → s ∪ t ∈ C)
+    (m : Set α → ℝ≥0∞) (m_empty : m ∅ = 0)
+    (m_add : ∀ {s t : Set α} (_ : s ∈ C) (_ : t ∈ C), Disjoint s t → m (s ∪ t) = m s + m t)
+    (I : Finset (Set α)) (h_ss : ↑I ⊆ C) (h_dis : Set.PairwiseDisjoint (I : Set (Set α)) id)
+    (h_mem : ⋃₀ ↑I ∈ C) :
+    m (⋃₀ I) = ∑ u in I, m u := by
+  classical
+  induction I using Finset.induction with
+  | empty => simp only [Finset.coe_empty, Set.sUnion_empty, Finset.sum_empty, m_empty]
+  | @insert s I hsI h =>
+    rw [Finset.coe_insert] at *
+    rw [Set.insert_subset_iff] at h_ss
+    rw [Set.pairwiseDisjoint_insert_of_not_mem] at h_dis
+    swap; · exact hsI
+    have h_sUnion_mem : ⋃₀ ↑I ∈ C := by
+      have (J : Finset (Set α)) : ↑J ⊆ C → ⋃₀ ↑J ∈ C := by
+        induction J using Finset.induction with
+        | empty => simp [hC_empty]
+        | @insert s I _ h =>
+          intro h_insert
+          simp only [Finset.coe_insert, Set.sUnion_insert, Set.insert_subset_iff] at h_insert ⊢
+          exact hC_union h_insert.1 (h h_insert.2)
+      exact this I h_ss.2
+    rw [Set.sUnion_insert, m_add h_ss.1 h_sUnion_mem (Set.disjoint_sUnion_right.mpr h_dis.2),
+      Finset.sum_insert hsI, h h_ss.2 h_dis.1]
+    rwa [Set.sUnion_insert] at h_mem
+
+theorem sUnion_eq_sum_of_union_eq_add' (hC_empty : ∅ ∈ C)
+    (hC_union : ∀ {s t : Set α}, s ∈ C → t ∈ C → s ∪ t ∈ C)
+    {m : ∀ s : Set α, s ∈ C → ℝ≥0∞} (m_empty : m ∅ hC_empty = 0)
+    (m_add : ∀ {s t : Set α} (hs : s ∈ C) (ht : t ∈ C),
+      Disjoint s t → m (s ∪ t) (hC_union hs ht) = m s hs + m t ht)
+    (I : Finset (Set α)) (h_ss : ↑I ⊆ C) (h_dis : Set.PairwiseDisjoint (I : Set (Set α)) id)
+    (h_mem : ⋃₀ ↑I ∈ C) :
+    m (⋃₀ I) h_mem = ∑ u : I, m u (h_ss u.property) := by
+  have h : extend m (⋃₀ ↑I) = ∑ u ∈ I, extend m u :=
+    sUnion_eq_sum_of_union_eq_add hC_empty (fun hs ht ↦ hC_union hs ht) (extend m)
+      (extend_empty hC_empty m_empty) ?_ I h_ss h_dis h_mem
+  · rw [extend_eq m h_mem] at h
+    refine h.trans ?_
+    simp_rw [← extend_eq m, Finset.univ_eq_attach]
+    exact (Finset.sum_attach _ _).symm
+  · simp_rw [← extend_eq m] at m_add
+    exact m_add
+
+lemma IsSetRing.sUnion_eq_sum_of_union_eq_add (hC : IsSetRing C)
+    {m : ∀ s : Set α, s ∈ C → ℝ≥0∞} (m_empty : m ∅ hC.empty_mem = 0)
+    (m_add : ∀ {s t : Set α} (hs : s ∈ C) (ht : t ∈ C),
+      Disjoint s t → m (s ∪ t) (hC.union_mem hs ht) = m s hs + m t ht)
+    (I : Finset (Set α)) (h_ss : ↑I ⊆ C) (h_dis : Set.PairwiseDisjoint (I : Set (Set α)) id)
+    (h_mem : ⋃₀ ↑I ∈ C) :
+    m (⋃₀ I) h_mem = ∑ u : I, m u (h_ss u.property) :=
+  sUnion_eq_sum_of_union_eq_add' hC.empty_mem (fun hs ht ↦ hC.union_mem hs ht) m_empty m_add I
+    h_ss h_dis h_mem
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -161,9 +161,10 @@ lemma addContent_biUnion_le {ι : Type*} (hC : IsSetRing C) {s : ι → Set α}
     {S : Finset ι} (hs : ∀ n ∈ S, s n ∈ C) :
     m (⋃ i ∈ S, s i) ≤ ∑ i ∈ S, m (s i) := by
   classical
-  induction' S using Finset.induction with i S hiS h hs
-  · simp
-  · rw [Finset.sum_insert hiS]
+  induction S using Finset.induction with
+  | empty => simp
+  | @insert i S hiS h =>
+    rw [Finset.sum_insert hiS]
     simp_rw [← Finset.mem_coe, Finset.coe_insert, Set.biUnion_insert]
     simp only [Finset.mem_insert, forall_eq_or_imp] at hs
     refine (addContent_union_le hC hs.1 (hC.biUnion_mem S hs.2)).trans ?_
@@ -187,7 +188,7 @@ lemma addContent_diff_of_ne_top (m : AddContent C) (hC : IsSetRing C)
   rw [h_union, ENNReal.add_sub_cancel_left (hm_ne_top _ ht)]
 
 lemma addContent_accumulate (m : AddContent C) (hC : IsSetRing C)
-    {s : ℕ → Set α} (hs_disj : Pairwise (Function.onFun Disjoint s)) (hsC : ∀ i, s i ∈ C) (n : ℕ) :
+    {s : ℕ → Set α} (hs_disj : Pairwise (Disjoint on s)) (hsC : ∀ i, s i ∈ C) (n : ℕ) :
       m (Set.Accumulate s n) = ∑ i in Finset.range (n + 1), m (s i) := by
   induction n with
   | zero => simp

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -43,9 +43,9 @@ If `C` is a set ring (`MeasureTheory.IsSetRing C`), we have, for `s, t ∈ C`,
 
 -/
 
-open Set Finset
+open Set Finset Function Filter
 
-open scoped ENNReal
+open scoped ENNReal Topology
 
 namespace MeasureTheory
 
@@ -220,15 +220,6 @@ def IsSetRing.addContent_of_union (m : Set α → ℝ≥0∞) (hC : IsSetRing C)
         Finset.sum_insert hsI, h h_ss.2 h_dis.1]
       rwa [Set.sUnion_insert] at h_mem
 
-end IsSetRing
-
-open scoped ENNReal
-
-open scoped Topology
-open Filter
-
-variable {α : Type*} {C : Set (Set α)}
-
 /-- In a ring of sets, continuity of an additive content at `∅` implies σ-additivity.
 This is not true in general in semirings, or without the hypothesis that `m` is finite. See the
 examples 7 and 8 in Halmos' book Measure Theory (1974), page 40. -/
@@ -237,7 +228,7 @@ theorem addContent_iUnion_eq_sum_of_tendsto_zero (hC : IsSetRing C) (m : AddCont
     (hm_tendsto : ∀ ⦃s : ℕ → Set α⦄ (_ : ∀ n, s n ∈ C),
       Antitone s → (⋂ n, s n) = ∅ → Tendsto (fun n ↦ m (s n)) atTop (𝓝 0))
     ⦃f : ℕ → Set α⦄ (hf : ∀ i, f i ∈ C) (hUf : (⋃ i, f i) ∈ C)
-    (h_disj : Pairwise (Function.onFun Disjoint f)) :
+    (h_disj : Pairwise (Disjoint on f)) :
     m (⋃ i, f i) = ∑' i, m (f i) := by
   -- We use the continuity of `m` at `∅` on the sequence `n ↦ (⋃ i, f i) \ (set.accumulate f n)`
   let s : ℕ → Set α := fun n ↦ (⋃ i, f i) \ Set.Accumulate f n
@@ -256,9 +247,11 @@ theorem addContent_iUnion_eq_sum_of_tendsto_zero (hC : IsSetRing C) (m : AddCont
   simp_rw [hmsn] at h_tendsto
   refine tendsto_nhds_unique ?_ (ENNReal.tendsto_nat_tsum fun i ↦ m (f i))
   refine (Filter.tendsto_add_atTop_iff_nat 1).mp ?_
-  rwa [ENNReal.tendsto_atTop_zero_const_sub_iff _ _ (hm_ne_top _ hUf) (fun n ↦ ?_)] at h_tendsto
+  rwa [ENNReal.tendsto_const_sub_nhds_zero_iff (hm_ne_top _ hUf) (fun n ↦ ?_)] at h_tendsto
   rw [← addContent_accumulate m hC h_disj hf]
   exact addContent_mono hC.isSetSemiring (hC.accumulate_mem hf n) hUf
     (Set.accumulate_subset_iUnion _)
+
+end IsSetRing
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -3,12 +3,9 @@ Copyright (c) 2024 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne, Peter Pfaffelhuber
 -/
-import Mathlib.Algebra.BigOperators.Group.Finset.Basic
-import Mathlib.Data.ENNReal.Basic
-import Mathlib.MeasureTheory.OuterMeasure.Induced
 import Mathlib.MeasureTheory.SetSemiring
 import Mathlib.Topology.Algebra.InfiniteSum.Defs
-import Mathlib.Topology.Algebra.InfiniteSum.ENNReal
+import Mathlib.Topology.Instances.ENNReal.Lemmas
 
 /-!
 # Additive Contents
@@ -40,6 +37,10 @@ If `C` is a set ring (`MeasureTheory.IsSetRing C`), we have, for `s, t ∈ C`,
 
 * `MeasureTheory.addContent_union_le`: `m (s ∪ t) ≤ m s + m t`
 * `MeasureTheory.addContent_le_diff`: `m s - m t ≤ m (s \ t)`
+* `IsSetRing.addContent_of_union`: a function on a ring of sets which is additive on pairs of
+disjoint sets defines an additive content
+* `addContent_iUnion_eq_sum_of_tendsto_zero`: if an additive content is continuous at `∅`, then
+its value on a countable disjoint union is the sum of the values
 
 -/
 

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -40,9 +40,6 @@ A ring of sets is a set of sets containing `∅`, stable by union, set differenc
 
 -/
 
-theorem Set.accumulate_succ {α : Type*} (s : ℕ → Set α) (n : ℕ) :
-    Set.Accumulate s (n + 1) = Set.Accumulate s n ∪ s (n + 1) := Set.biUnion_le_succ s n
-
 open Finset Set
 
 namespace MeasureTheory

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -305,9 +305,10 @@ lemma biUnion_mem {ι : Type*} (hC : IsSetRing C) {s : ι → Set α}
     (S : Finset ι) (hs : ∀ n ∈ S, s n ∈ C) :
     ⋃ i ∈ S, s i ∈ C := by
   classical
-  induction' S using Finset.induction with i S _ h hs
-  · simp [hC.empty_mem]
-  · simp_rw [← Finset.mem_coe, Finset.coe_insert, Set.biUnion_insert]
+  induction S using Finset.induction with
+  | empty => simp [hC.empty_mem]
+  | @insert i S _ h =>
+    simp_rw [← Finset.mem_coe, Finset.coe_insert, Set.biUnion_insert]
     refine hC.union_mem (hs i (mem_insert_self i S)) ?_
     exact h (fun n hnS ↦ hs n (mem_insert_of_mem hnS))
 
@@ -345,26 +346,21 @@ lemma disjointed_mem {ι : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
 
 theorem iUnion_le_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ n, s n ∈ C) (n : ℕ) :
     (⋃ i ≤ n, s i) ∈ C := by
-  induction' n with n hn
-  · simp only [Nat.le_zero_eq, iUnion_iUnion_eq_left]
-    exact hs 0
-  rw [Set.biUnion_le_succ]
-  exact hC.union_mem hn (hs _)
+  induction n with
+  | zero => simp [hs 0]
+  | succ n hn => rw [biUnion_le_succ]; exact hC.union_mem hn (hs _)
 
 theorem iInter_le_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ n, s n ∈ C) (n : ℕ) :
     (⋂ i ≤ n, s i) ∈ C := by
-  induction' n with n hn
-  · simp only [Nat.le_zero_eq, iInter_iInter_eq_left]
-    exact hs 0
-  rw [Set.biInter_le_succ]
-  exact hC.inter_mem hn (hs _)
+  induction n with
+  | zero => simp [hs 0]
+  | succ n hn => rw [biInter_le_succ]; exact hC.inter_mem hn (hs _)
 
 theorem accumulate_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ i, s i ∈ C) (n : ℕ) :
-    Set.Accumulate s n ∈ C := by
-  induction' n with n hn
-  · simp only [Accumulate, Nat.le_zero_eq, iUnion_iUnion_eq_left, hs 0]
-  · rw [Set.accumulate_succ]
-    exact hC.union_mem hn (hs _)
+    Accumulate s n ∈ C := by
+  induction n with
+  | zero => simp [hs 0]
+  | succ n hn => rw [accumulate_succ]; exact hC.union_mem hn (hs _)
 
 end IsSetRing
 

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -3,6 +3,8 @@ Copyright (c) 2023 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne, Peter Pfaffelhuber
 -/
+import Mathlib.Data.Nat.Lattice
+import Mathlib.Data.Set.Accumulate
 import Mathlib.Data.Set.Pairwise.Lattice
 import Mathlib.MeasureTheory.PiSystem
 
@@ -37,6 +39,9 @@ A ring of sets is a set of sets containing `∅`, stable by union, set differenc
   by the definition `IsSetSemiring.diffFinset₀` (see above).
 
 -/
+
+theorem Set.accumulate_succ {α : Type*} (s : ℕ → Set α) (n : ℕ) :
+    Set.Accumulate s (n + 1) = Set.Accumulate s n ∪ s (n + 1) := Set.biUnion_le_succ s n
 
 open Finset Set
 
@@ -340,6 +345,29 @@ lemma disjointed_mem {ι : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
     (hC : IsSetRing C) {s : ι → Set α} (hs : ∀ j, s j ∈ C) (i : ι) :
     disjointed s i ∈ C :=
   disjointedRec (fun _ j ht ↦ hC.diff_mem ht <| hs j) (hs i)
+
+theorem iUnion_le_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ n, s n ∈ C) (n : ℕ) :
+    (⋃ i ≤ n, s i) ∈ C := by
+  induction' n with n hn
+  · simp only [Nat.le_zero_eq, iUnion_iUnion_eq_left]
+    exact hs 0
+  rw [Set.biUnion_le_succ]
+  exact hC.union_mem hn (hs _)
+
+theorem iInter_le_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ n, s n ∈ C) (n : ℕ) :
+    (⋂ i ≤ n, s i) ∈ C := by
+  induction' n with n hn
+  · simp only [Nat.le_zero_eq, iInter_iInter_eq_left]
+    exact hs 0
+  rw [Set.biInter_le_succ]
+  exact hC.inter_mem hn (hs _)
+
+theorem accumulate_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ i, s i ∈ C) (n : ℕ) :
+    Set.Accumulate s n ∈ C := by
+  induction' n with n hn
+  · simp only [Accumulate, Nat.le_zero_eq, iUnion_iUnion_eq_left, hs 0]
+  · rw [Set.accumulate_succ]
+    exact hC.union_mem hn (hs _)
 
 end IsSetRing
 

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -237,12 +237,11 @@ protected theorem tendsto_nhds_zero {f : Filter α} {u : α → ℝ≥0∞} :
     Tendsto u f (𝓝 0) ↔ ∀ ε > 0, ∀ᶠ x in f, u x ≤ ε :=
   nhds_zero_basis_Iic.tendsto_right_iff
 
-theorem tendsto_atTop_zero_const_sub_iff {l : Filter α} {f : α → ℝ≥0∞} {a : ℝ≥0∞} (ha : a ≠ ∞)
+theorem tendsto_const_sub_nhds_zero_iff {l : Filter α} {f : α → ℝ≥0∞} {a : ℝ≥0∞} (ha : a ≠ ∞)
     (hfa : ∀ n, f n ≤ a) :
     Tendsto (fun n ↦ a - f n) l (𝓝 0) ↔ Tendsto (fun n ↦ f n) l (𝓝 a) := by
-  lift a to ℝ≥0 using ha
-  rw [ENNReal.tendsto_nhds_zero, ENNReal.tendsto_nhds]
-  refine ⟨fun h ε hε ↦ ?_, fun h ε hε ↦ ?_⟩ --<;> obtain ⟨N, hN⟩ := h ε hε
+  rw [ENNReal.tendsto_nhds_zero, ENNReal.tendsto_nhds ha]
+  refine ⟨fun h ε hε ↦ ?_, fun h ε hε ↦ ?_⟩
   · filter_upwards [h ε hε] with n hn
     refine ⟨?_, (hfa n).trans (le_add_right le_rfl)⟩
     rw [tsub_le_iff_right] at hn ⊢

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -237,6 +237,21 @@ protected theorem tendsto_nhds_zero {f : Filter α} {u : α → ℝ≥0∞} :
     Tendsto u f (𝓝 0) ↔ ∀ ε > 0, ∀ᶠ x in f, u x ≤ ε :=
   nhds_zero_basis_Iic.tendsto_right_iff
 
+theorem tendsto_atTop_zero_const_sub_iff {l : Filter α} {f : α → ℝ≥0∞} {a : ℝ≥0∞} (ha : a ≠ ∞)
+    (hfa : ∀ n, f n ≤ a) :
+    Tendsto (fun n ↦ a - f n) l (𝓝 0) ↔ Tendsto (fun n ↦ f n) l (𝓝 a) := by
+  lift a to ℝ≥0 using ha
+  rw [ENNReal.tendsto_nhds_zero, ENNReal.tendsto_nhds]
+  refine ⟨fun h ε hε ↦ ?_, fun h ε hε ↦ ?_⟩ --<;> obtain ⟨N, hN⟩ := h ε hε
+  · filter_upwards [h ε hε] with n hn
+    refine ⟨?_, (hfa n).trans (le_add_right le_rfl)⟩
+    rw [tsub_le_iff_right] at hn ⊢
+    rwa [add_comm]
+  · filter_upwards [h ε hε] with n hn
+    have hN_left := hn.1
+    rw [tsub_le_iff_right] at hN_left ⊢
+    rwa [add_comm]
+
 protected theorem tendsto_atTop [Nonempty β] [SemilatticeSup β] {f : β → ℝ≥0∞} {a : ℝ≥0∞}
     (ha : a ≠ ∞) : Tendsto f atTop (𝓝 a) ↔ ∀ ε > 0, ∃ N, ∀ n ≥ N, f n ∈ Icc (a - ε) (a + ε) :=
   .trans (atTop_basis.tendsto_iff (hasBasis_nhds_of_ne_top ha)) (by simp only [true_and]; rfl)


### PR DESCRIPTION
Two main results:
- a function on a ring of sets which is additive on pairs of disjoint sets defines an additive content
- if an additive content is continuous at `∅`, then its value on a countable disjoint union is the sum of the values

Co-authored-by: Peter Pfaffelhuber
Co-authored-by: Sébastien Gouëzel

Part of the formalization of Kolmogorov's extension theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
