### PR TITLE
feat: compare elements of well-orders in different types

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4251,6 +4251,7 @@ import Mathlib.Order.KonigLemma
 import Mathlib.Order.KrullDimension
 import Mathlib.Order.Lattice
 import Mathlib.Order.LatticeIntervals
+import Mathlib.Order.LiftEq
 import Mathlib.Order.LiminfLimsup
 import Mathlib.Order.Max
 import Mathlib.Order.MinMax

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -97,8 +97,10 @@ instance [IsTrichotomous α r] [IsTrichotomous β s] : IsTrichotomous (α ⊕ β
     | inr _, inl _ => Or.inr (Or.inr <| Lex.sep _ _)
     | inr a, inr b => (trichotomous_of s a b).imp3 Lex.inr (congr_arg _) Lex.inr⟩
 
-instance [IsWellOrder α r] [IsWellOrder β s] :
-    IsWellOrder (α ⊕ β) (Sum.Lex r s) where wf := Sum.lex_wf IsWellFounded.wf IsWellFounded.wf
+instance [IsWellFounded α r] [IsWellFounded β s] : IsWellFounded (α ⊕ β) (Sum.Lex r s) where
+  wf := Sum.lex_wf IsWellFounded.wf IsWellFounded.wf
+
+instance [IsWellOrder α r] [IsWellOrder β s] : IsWellOrder (α ⊕ β) (Sum.Lex r s) where
 
 end Lex
 
@@ -376,6 +378,9 @@ instance linearOrder [LinearOrder α] [LinearOrder β] : LinearOrder (α ⊕ₗ 
     le_total := total_of (Lex (· ≤ ·) (· ≤ ·)),
     decidableLE := instDecidableRelSumLex,
     decidableEq := instDecidableEqSum }
+
+instance wellFoundedLT [LT α] [LT β] [WellFoundedLT α] [WellFoundedLT β] : WellFoundedLT (α ⊕ₗ β) :=
+  inferInstanceAs (IsWellFounded _ (Sum.Lex _ _))
 
 /-- The lexicographical bottom of a sum is the bottom of the left component. -/
 instance orderBot [LE α] [OrderBot α] [LE β] :
@@ -658,8 +663,6 @@ def orderIsoPUnitSumLex : WithBot α ≃o PUnit ⊕ₗ α :=
       exact not_coe_le_bot _
     · simp only [elim_inl, lex_inr_inr, coe_le_coe]
   ⟩
-
-
 
 @[simp]
 theorem orderIsoPUnitSumLex_bot : @orderIsoPUnitSumLex α _ ⊥ = toLex (inl PUnit.unit) :=

--- a/Mathlib/Order/LiftEq.lean
+++ b/Mathlib/Order/LiftEq.lean
@@ -121,6 +121,12 @@ instance : IsWellOrder α (· <ᵤ ·) := by
 @[refl] theorem liftLE.refl (x : α) : x ≤ᵤ x := by simp
 theorem liftLT_irrefl (x : α) : ¬ x <ᵤ x := by simp
 
+theorem liftLE_of_liftEQ (h : x =ᵤ y) : x ≤ᵤ y := h.le
+theorem liftLE_of_liftLT (h : x <ᵤ y) : x ≤ᵤ y := h.le
+
+alias liftEQ.liftLE := liftLE_of_liftEQ
+alias liftLT.liftLE := liftLE_of_liftLT
+
 theorem liftEQ.comm : x =ᵤ y ↔ y =ᵤ x := by
   rw [← liftEQ_iff (γ := α ⊕ₗ β) (RelEmbedding.sumLexInr _ _).collapse (InitialSeg.leAdd _ _),
     eq_comm, liftEQ_iff]
@@ -135,11 +141,6 @@ theorem not_liftLE : ¬ x ≤ᵤ y ↔ y <ᵤ x := by
 @[simp]
 theorem not_liftLT : ¬ x <ᵤ y ↔ y ≤ᵤ x := by
   rw [← not_liftLE, not_not]
-
-theorem liftLE_of_liftLT (h : x <ᵤ y) : x ≤ᵤ y :=
-  h.le
-
-alias liftLT.liftLE := liftLE_of_liftLT
 
 theorem liftLE_total (x : α) (y : β) : x ≤ᵤ y ∨ y ≤ᵤ x := by
   rw [← liftLE_iff (γ := α ⊕ₗ β) (InitialSeg.leAdd _ _) (RelEmbedding.sumLexInr _ _).collapse,

--- a/Mathlib/Order/LiftEq.lean
+++ b/Mathlib/Order/LiftEq.lean
@@ -29,8 +29,9 @@ Replace instances of `Cardinal.lift x = Cardinal.lift y` or `Ordinal.lift x = Or
 
 universe u v w
 
-variable {α : Type u} {β : Type v} {γ : Type w} [LinearOrder α] [LinearOrder β] [LinearOrder γ]
-  [WellFoundedLT α] [WellFoundedLT β] [WellFoundedLT γ]
+variable {α : Type u} {β : Type v} {γ δ : Type*}
+  [LinearOrder α] [LinearOrder β] [LinearOrder γ] [LinearOrder δ]
+  [WellFoundedLT α] [WellFoundedLT β] [WellFoundedLT γ] [WellFoundedLT δ]
   {x : α} {y : β} {z : γ}
 
 /-- We write `x =ᵤ y` when the order types of `x` and `y` are equal.
@@ -62,7 +63,7 @@ def liftLT (x : α) (y : β) : Prop :=
 @[inherit_doc] infix:50 " <ᵤ " => liftLT
 
 omit [WellFoundedLT α] [WellFoundedLT β] in
-theorem InitialSeg.cmp_congr {δ : Type*} [LinearOrder δ] [WellFoundedLT δ]
+theorem InitialSeg.cmp_congr
     (f₁ : α ≤i γ) (g₁ : β ≤i γ) (f₂ : α ≤i δ) (g₂ : β ≤i δ) (x : α) (y : β) :
     cmp (f₁ x) (g₁ y) = cmp (f₂ x) (g₂ y) := by
   obtain h | h := @InitialSeg.total γ δ (· < ·) (· < ·) _ _
@@ -123,6 +124,7 @@ theorem liftLT_irrefl (x : α) : ¬ x <ᵤ x := by simp
 
 theorem liftLE_of_liftEQ (h : x =ᵤ y) : x ≤ᵤ y := h.le
 theorem liftLE_of_liftLT (h : x <ᵤ y) : x ≤ᵤ y := h.le
+theorem liftLE_iff_liftLT_or_liftEQ : x ≤ᵤ y ↔ x <ᵤ y ∨ x =ᵤ y := le_iff_lt_or_eq
 
 alias liftEQ.liftLE := liftLE_of_liftEQ
 alias liftLT.liftLE := liftLE_of_liftLT
@@ -142,14 +144,21 @@ theorem not_liftLE : ¬ x ≤ᵤ y ↔ y <ᵤ x := by
 theorem not_liftLT : ¬ x <ᵤ y ↔ y ≤ᵤ x := by
   rw [← not_liftLE, not_not]
 
+theorem liftLE_antisymm_iff : x =ᵤ y ↔ x ≤ᵤ y ∧ y ≤ᵤ x := by
+  rw [← liftLE_iff (γ := α ⊕ₗ β) (RelEmbedding.sumLexInr _ _).collapse (InitialSeg.leAdd _ _)]
+  exact le_antisymm_iff
+
+theorem liftLE_antisymm (h₁ : x ≤ᵤ y) (h₂ : y ≤ᵤ x) : x =ᵤ y :=
+  liftLE_antisymm_iff.2 ⟨h₁, h₂⟩
+
+alias liftLE.antisymm := liftLE_antisymm
+
 theorem liftLE_total (x : α) (y : β) : x ≤ᵤ y ∨ y ≤ᵤ x := by
-  rw [← liftLE_iff (γ := α ⊕ₗ β) (InitialSeg.leAdd _ _) (RelEmbedding.sumLexInr _ _).collapse,
-    ← liftLE_iff (γ := α ⊕ₗ β) (RelEmbedding.sumLexInr _ _).collapse (InitialSeg.leAdd _ _)]
+  rw [← liftLE_iff (γ := α ⊕ₗ β) (RelEmbedding.sumLexInr _ _).collapse (InitialSeg.leAdd _ _)]
   exact le_total ..
 
 theorem liftLT_trichotomy (x : α) (y : β) : x <ᵤ y ∨ x =ᵤ y ∨ y <ᵤ x := by
-  rw [← liftLT_iff (γ := α ⊕ₗ β) (InitialSeg.leAdd _ _) (RelEmbedding.sumLexInr _ _).collapse,
-    ← liftEQ_iff (γ := α ⊕ₗ β) (InitialSeg.leAdd _ _) (RelEmbedding.sumLexInr _ _).collapse,
+  rw [← liftEQ_iff (γ := α ⊕ₗ β) (InitialSeg.leAdd _ _) (RelEmbedding.sumLexInr _ _).collapse,
     ← liftLT_iff (γ := α ⊕ₗ β) (RelEmbedding.sumLexInr _ _).collapse (InitialSeg.leAdd _ _)]
   exact lt_trichotomy ..
 
@@ -186,12 +195,64 @@ theorem liftLT_of_liftLE_of_liftLT (h₁ : x ≤ᵤ y) (h₂ : y <ᵤ z) : x <�
 theorem liftLT_trans (h₁ : x <ᵤ y) (h₂ : y <ᵤ z) : x <ᵤ z :=
   liftLT_of_liftLE_of_liftLT h₁.liftLE h₂
 
+theorem liftEQ_trans (h₁ : x =ᵤ y) (h₂ : y =ᵤ z) : x =ᵤ z :=
+  (liftLE_trans h₁.liftLE h₂.liftLE).antisymm (liftLE_trans h₂.symm.liftLE h₁.symm.liftLE)
+
+theorem liftLE_of_liftLE_of_liftEQ (h₁ : x ≤ᵤ y) (h₂ : y =ᵤ z) : x ≤ᵤ z :=
+  liftLE_trans h₁ h₂.liftLE
+
+theorem liftLE_of_liftEQ_of_liftLE (h₁ : x =ᵤ y) (h₂ : y ≤ᵤ z) : x ≤ᵤ z :=
+  liftLE_trans h₁.liftLE h₂
+
+theorem liftLT_of_liftLT_of_liftEQ (h₁ : x <ᵤ y) (h₂ : y =ᵤ z) : x <ᵤ z :=
+  liftLT_of_liftLT_of_liftLE h₁ h₂.liftLE
+
+theorem liftLT_of_liftEQ_of_liftLT (h₁ : x =ᵤ y) (h₂ : y <ᵤ z) : x <ᵤ z :=
+  liftLT_of_liftLE_of_liftLT h₁.liftLE h₂
+
 alias liftLE.trans := liftLE_trans
 alias liftLT.trans_liftLE := liftLT_of_liftLT_of_liftLE
 alias liftLE.trans_liftLT := liftLT_of_liftLE_of_liftLT
 alias liftLT.trans := liftLT_trans
+alias liftEQ.trans := liftEQ_trans
+alias liftEQ.trans_liftLE := liftLE_of_liftEQ_of_liftLE
+alias liftLE.trans_liftEQ := liftLE_of_liftLE_of_liftEQ
+alias liftEQ.trans_liftLT := liftLT_of_liftEQ_of_liftLT
+alias liftLT.trans_liftEQ := liftLT_of_liftLT_of_liftEQ
 
 instance : @Trans α β γ (· ≤ᵤ ·) (· ≤ᵤ ·) (· ≤ᵤ ·) where trans := liftLE_trans
 instance : @Trans α β γ (· <ᵤ ·) (· ≤ᵤ ·) (· <ᵤ ·) where trans := liftLT_of_liftLT_of_liftLE
 instance : @Trans α β γ (· ≤ᵤ ·) (· <ᵤ ·) (· <ᵤ ·) where trans := liftLT_of_liftLE_of_liftLT
 instance : @Trans α β γ (· <ᵤ ·) (· <ᵤ ·) (· <ᵤ ·) where trans := liftLT_trans
+instance : @Trans α β γ (· =ᵤ ·) (· =ᵤ ·) (· =ᵤ ·) where trans := liftEQ_trans
+instance : @Trans α β γ (· ≤ᵤ ·) (· =ᵤ ·) (· ≤ᵤ ·) where trans := liftLE_of_liftLE_of_liftEQ
+instance : @Trans α β γ (· =ᵤ ·) (· ≤ᵤ ·) (· ≤ᵤ ·) where trans := liftLE_of_liftEQ_of_liftLE
+instance : @Trans α β γ (· <ᵤ ·) (· =ᵤ ·) (· <ᵤ ·) where trans := liftLT_of_liftLT_of_liftEQ
+instance : @Trans α β γ (· =ᵤ ·) (· <ᵤ ·) (· <ᵤ ·) where trans := liftLT_of_liftEQ_of_liftLT
+
+namespace InitialSeg
+
+theorem apply_liftEQ (f : α ≤i β) (x : α) : f x =ᵤ x :=
+  liftEQ.intro (.refl _) f rfl
+
+variable {f : α ≤i γ} {g : β ≤i δ}
+
+@[simp]
+theorem apply_liftLE_iff : f x ≤ᵤ y ↔ x ≤ᵤ y :=
+  ⟨(apply_liftEQ f x).symm.trans_liftLE, (apply_liftEQ f x).trans_liftLE⟩
+
+@[simp]
+theorem liftLE_apply_iff : y ≤ᵤ f x ↔ y ≤ᵤ x :=
+  ⟨fun h ↦ h.trans_liftEQ (apply_liftEQ f x), fun h ↦ h.trans_liftEQ (apply_liftEQ f x).symm⟩
+
+theorem apply_liftLE_apply_iff : f x ≤ᵤ g y ↔ x ≤ᵤ y := by simp
+
+@[simp] theorem apply_liftEQ_iff : f x =ᵤ y ↔ x =ᵤ y := by simp [liftLE_antisymm_iff]
+@[simp] theorem liftEQ_apply_iff {f : α ≤i γ} : y =ᵤ f x ↔ y =ᵤ x := by simp [liftLE_antisymm_iff]
+theorem apply_liftEQ_apply_iff : f x =ᵤ g y ↔ x =ᵤ y := by simp
+
+@[simp] theorem apply_liftLT_iff : f x <ᵤ y ↔ x <ᵤ y := by simp [← not_liftLE]
+@[simp] theorem liftLT_apply_iff {f : α ≤i γ} : y <ᵤ f x ↔ y <ᵤ x := by simp [← not_liftLE]
+theorem apply_liftLT_apply_iff : f x <ᵤ g y ↔ x <ᵤ y := by simp
+
+end InitialSeg

--- a/Mathlib/Order/LiftEq.lean
+++ b/Mathlib/Order/LiftEq.lean
@@ -20,6 +20,11 @@ The intended usage for this file is to easily compare ordinals or cardinals in d
 * `liftEQ`: two elements have the same order type
 * `liftLE`: an element has an order type less or equal to another
 * `liftLT`: an element has an order type less than another
+
+## TODO
+
+Replace instances of `Cardinal.lift x = Cardinal.lift y` or `Ordinal.lift x = Ordinal.lift y` by
+`x =ᵤ y`, and likewise for the other order relations.
 -/
 
 universe u v w

--- a/Mathlib/Order/LiftEq.lean
+++ b/Mathlib/Order/LiftEq.lean
@@ -120,17 +120,23 @@ theorem liftEQ.comm : x =ᵤ y ↔ y =ᵤ x := by
 theorem liftLT_irrefl (x : α) : ¬ x <ᵤ x := by
   simp
 
--- All of these instances are trivial consequences of `liftEQ_iff_eq`, `liftLE_iff_le`,
--- and `liftLT_iff_lt`.
-instance : IsRefl α (· =ᵤ ·) where refl := liftEQ.refl
-instance : IsRefl α (· ≤ᵤ ·) where refl := liftLE.refl
-instance : IsSymm α (· =ᵤ ·) where symm _ _ := liftEQ.symm
-instance : IsIrrefl α (· <ᵤ ·) where irrefl := liftLT_irrefl
-instance : IsTrans α (· =ᵤ ·) where trans := by simp
-instance : IsTrans α (· ≤ᵤ ·) where trans _ _ _ := by simpa using le_trans
-instance : IsTrans α (· <ᵤ ·) where trans _ _ _ := by simpa using lt_trans
-instance : IsTotal α (· ≤ᵤ ·) where total := by simpa using le_total
-instance : IsTrichotomous α (· <ᵤ ·) where trichotomous := by simpa using lt_trichotomy
+instance : IsEquiv α (· =ᵤ ·) := by
+  have : IsEquiv α (· = ·) := inferInstance
+  convert this
+  ext
+  simp
+
+instance : IsLinearOrder α (· ≤ᵤ ·) := by
+  have : IsLinearOrder α (· ≤ ·) := inferInstance
+  convert this
+  ext
+  simp
+
+instance : IsWellOrder α (· <ᵤ ·) := by
+  have : IsWellOrder α (· < ·) := inferInstance
+  convert this
+  ext
+  simp
 
 @[simp]
 theorem not_liftLE : ¬ x ≤ᵤ y ↔ y <ᵤ x := by

--- a/Mathlib/Order/LiftEq.lean
+++ b/Mathlib/Order/LiftEq.lean
@@ -248,11 +248,11 @@ theorem liftLE_apply_iff : y ≤ᵤ f x ↔ y ≤ᵤ x :=
 theorem apply_liftLE_apply_iff : f x ≤ᵤ g y ↔ x ≤ᵤ y := by simp
 
 @[simp] theorem apply_liftEQ_iff : f x =ᵤ y ↔ x =ᵤ y := by simp [liftLE_antisymm_iff]
-@[simp] theorem liftEQ_apply_iff {f : α ≤i γ} : y =ᵤ f x ↔ y =ᵤ x := by simp [liftLE_antisymm_iff]
+@[simp] theorem liftEQ_apply_iff : y =ᵤ f x ↔ y =ᵤ x := by simp [liftLE_antisymm_iff]
 theorem apply_liftEQ_apply_iff : f x =ᵤ g y ↔ x =ᵤ y := by simp
 
 @[simp] theorem apply_liftLT_iff : f x <ᵤ y ↔ x <ᵤ y := by simp [← not_liftLE]
-@[simp] theorem liftLT_apply_iff {f : α ≤i γ} : y <ᵤ f x ↔ y <ᵤ x := by simp [← not_liftLE]
+@[simp] theorem liftLT_apply_iff : y <ᵤ f x ↔ y <ᵤ x := by simp [← not_liftLE]
 theorem apply_liftLT_apply_iff : f x <ᵤ g y ↔ x <ᵤ y := by simp
 
 end InitialSeg

--- a/Mathlib/Order/LiftEq.lean
+++ b/Mathlib/Order/LiftEq.lean
@@ -103,40 +103,24 @@ theorem liftLT_iff_lt {y : α} : x <ᵤ y ↔ x < y :=
 alias ⟨_, LE.le.liftLE⟩ := liftLE_iff_le
 alias ⟨_, LT.lt.liftLT⟩ := liftLT_iff_lt
 
-@[refl]
-theorem liftEQ.refl (x : α) : x =ᵤ x :=
-  liftEQ_iff_eq.2 rfl
+instance : IsEquiv α (· =ᵤ ·) := by
+  convert inferInstanceAs (IsEquiv α (· = ·)); ext; simp
 
-@[refl]
-theorem liftLE.refl (x : α) : x ≤ᵤ x :=
-  le_rfl.liftLE
+instance : IsLinearOrder α (· ≤ᵤ ·) := by
+  convert inferInstanceAs (IsLinearOrder α (· ≤ ·)); ext; simp
+
+instance : IsWellOrder α (· <ᵤ ·) := by
+  convert inferInstanceAs (IsWellOrder α (· < ·)); ext; simp
+
+@[refl] theorem liftEQ.refl (x : α) : x =ᵤ x := by simp
+@[refl] theorem liftLE.refl (x : α) : x ≤ᵤ x := by simp
+theorem liftLT_irrefl (x : α) : ¬ x <ᵤ x := by simp
 
 theorem liftEQ.comm : x =ᵤ y ↔ y =ᵤ x := by
   rw [← liftEQ_iff (γ := α ⊕ₗ β) (RelEmbedding.sumLexInr _ _).collapse (InitialSeg.leAdd _ _),
     eq_comm, liftEQ_iff]
 
 @[symm] alias ⟨liftEQ.symm, _⟩ := liftEQ.comm
-
-theorem liftLT_irrefl (x : α) : ¬ x <ᵤ x := by
-  simp
-
-instance : IsEquiv α (· =ᵤ ·) := by
-  have : IsEquiv α (· = ·) := inferInstance
-  convert this
-  ext
-  simp
-
-instance : IsLinearOrder α (· ≤ᵤ ·) := by
-  have : IsLinearOrder α (· ≤ ·) := inferInstance
-  convert this
-  ext
-  simp
-
-instance : IsWellOrder α (· <ᵤ ·) := by
-  have : IsWellOrder α (· < ·) := inferInstance
-  convert this
-  ext
-  simp
 
 @[simp]
 theorem not_liftLE : ¬ x ≤ᵤ y ↔ y <ᵤ x := by
@@ -200,3 +184,8 @@ alias liftLE.trans := liftLE_trans
 alias liftLT.trans_liftLE := liftLT_of_liftLT_of_liftLE
 alias liftLE.trans_liftLT := liftLT_of_liftLE_of_liftLT
 alias liftLT.trans := liftLT_trans
+
+instance : @Trans α β γ (· ≤ᵤ ·) (· ≤ᵤ ·) (· ≤ᵤ ·) where trans := liftLE_trans
+instance : @Trans α β γ (· <ᵤ ·) (· ≤ᵤ ·) (· <ᵤ ·) where trans := liftLT_of_liftLT_of_liftLE
+instance : @Trans α β γ (· ≤ᵤ ·) (· <ᵤ ·) (· <ᵤ ·) where trans := liftLT_of_liftLE_of_liftLT
+instance : @Trans α β γ (· <ᵤ ·) (· <ᵤ ·) (· <ᵤ ·) where trans := liftLT_trans

--- a/Mathlib/Order/LiftEq.lean
+++ b/Mathlib/Order/LiftEq.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2025 Violeta Hernández Palacios. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Violeta Hernández Palacios
+-/
+import Mathlib.Order.InitialSeg
+
+/-!
+# Relating elements of distinct well-orders
+
+Let `α` and `β` be well-ordered sets. There always exists some well-order `γ` such that `α` and `β`
+are both initial segments of it. This then allows us to compare elements of `α` and `β` as if they
+belonged to the same well-order. Importantly, these relationships are independent of our choice of
+`γ`.
+
+The intended usage for this file is to easily compare ordinals or cardinals in different universes.
+
+## Main declarations
+
+* `liftEQ`: two elements have the same order type
+* `liftLE`: an element has an order type less or equal to another
+* `liftLT`: an element has an order type less than another
+-/
+
+universe u v w
+
+variable {α : Type u} {β : Type v} {γ : Type w} [LinearOrder α] [LinearOrder β] [LinearOrder γ]
+  [WellFoundedLT α] [WellFoundedLT β] [WellFoundedLT γ]
+  {x : α} {y : β}
+
+/-- We write `x =ᵤ y` when the order types of `x` and `y` are equal.
+
+Note that `x` and `y` may come from distinct well-orders, or even well-orders in different
+universes. -/
+def liftEQ (x : α) (y : β) : Prop :=
+  toLex ((InitialSeg.leAdd (· < ·) (· < ·)) x) =
+    toLex ((RelEmbedding.sumLexInr (· < ·) (· < ·)).collapse y)
+
+/-- We write `x ≤ᵤ y` when the order type of `x` is less or equal to the order type of `y`.
+
+Note that `x` and `y` may come from distinct well-orders, or even well-orders in different
+universes. -/
+def liftLE (x : α) (y : β) : Prop :=
+  toLex ((InitialSeg.leAdd (· < ·) (· < ·)) x) ≤
+    toLex ((RelEmbedding.sumLexInr (· < ·) (· < ·)).collapse y)
+
+/-- We write `x <ᵤ y` when the order type of `x` is less to the order type of `y`.
+
+Note that `x` and `y` may come from distinct well-orders, or even well-orders in different
+universes. -/
+def liftLT (x : α) (y : β) : Prop :=
+  toLex ((InitialSeg.leAdd (· < ·) (· < ·)) x) <
+    toLex ((RelEmbedding.sumLexInr (· < ·) (· < ·)).collapse y)
+
+@[inherit_doc] infix:50 " =ᵤ " => liftEQ
+@[inherit_doc] infix:50 " ≤ᵤ " => liftLE
+@[inherit_doc] infix:50 " <ᵤ " => liftLT
+
+omit [WellFoundedLT α] [WellFoundedLT β] in
+theorem InitialSeg.cmp_congr {δ : Type*} [LinearOrder δ] [WellFoundedLT δ]
+    (f₁ : α ≤i γ) (g₁ : β ≤i γ) (f₂ : α ≤i δ) (g₂ : β ≤i δ) (x : α) (y : β) :
+    cmp (f₁ x) (g₁ y) = cmp (f₂ x) (g₂ y) := by
+  obtain h | h := @InitialSeg.total γ δ (· < ·) (· < ·) _ _
+  · rw [← h.strictMono.cmp_map_eq, ← InitialSeg.trans_apply, ← InitialSeg.trans_apply,
+      ← f₂.eq, ← g₂.eq]
+  · rw [← h.strictMono.cmp_map_eq, ← InitialSeg.trans_apply, ← InitialSeg.trans_apply,
+      (f₂.trans h).eq, (g₂.trans h).eq]
+
+/-- For any initial segment embeddings `f` and `g` into the same type,
+`x =ᵤ y` is equivalent to `f x = g y`. -/
+theorem liftEQ_iff (f : α ≤i γ) (g : β ≤i γ) {x : α} {y : β} : f x = g y ↔ x =ᵤ y :=
+  eq_iff_eq_of_cmp_eq_cmp <| InitialSeg.cmp_congr (δ := α ⊕ₗ β)
+    f g (InitialSeg.leAdd _ _) (RelEmbedding.sumLexInr _ _).collapse x y
+
+/-- For any initial segment embeddings `f` and `g` into the same type,
+`x ≤ᵤ y` is equivalent to `f x ≤ g y`. -/
+theorem liftLE_iff (f : α ≤i γ) (g : β ≤i γ) {x : α} {y : β} : f x ≤ g y ↔ x ≤ᵤ y :=
+  le_iff_le_of_cmp_eq_cmp <| InitialSeg.cmp_congr (δ := α ⊕ₗ β)
+    f g (InitialSeg.leAdd _ _) (RelEmbedding.sumLexInr _ _).collapse x y
+
+/-- For any initial segment embeddings `f` and `g` into the same type,
+`x <ᵤ y` is equivalent to `f x < g y`. -/
+theorem liftLT_iff (f : α ≤i γ) (g : β ≤i γ) {x : α} {y : β} : f x < g y ↔ x <ᵤ y :=
+  lt_iff_lt_of_cmp_eq_cmp <| InitialSeg.cmp_congr (δ := α ⊕ₗ β)
+    f g (InitialSeg.leAdd _ _) (RelEmbedding.sumLexInr _ _).collapse x y
+
+alias ⟨liftEQ.intro, _⟩ := liftEQ_iff
+alias ⟨liftLE.intro, _⟩ := liftLE_iff
+alias ⟨liftLT.intro, _⟩ := liftLT_iff
+
+@[refl, simp]
+theorem liftEQ_refl (x : α) : x =ᵤ x :=
+  liftEQ.intro (InitialSeg.refl _) (InitialSeg.refl _) rfl
+
+@[refl, simp]
+theorem liftLE_refl (x : α) : x ≤ᵤ x :=
+  liftLE.intro (InitialSeg.refl _) (InitialSeg.refl _) le_rfl
+
+instance : IsRefl α (· =ᵤ ·) where refl := liftEQ_refl
+instance : IsRefl α (· ≤ᵤ ·) where refl := liftLE_refl
+
+@[simp]
+theorem not_liftLE : ¬ x ≤ᵤ y ↔ y <ᵤ x := by
+  rw [← liftLE_iff (γ := α ⊕ₗ β) (InitialSeg.leAdd _ _) (RelEmbedding.sumLexInr _ _).collapse,
+    not_le, liftLT_iff]
+
+@[simp]
+theorem not_liftLT : ¬ x <ᵤ y ↔ y ≤ᵤ x := by
+  rw [← not_liftLE, not_not]
+
+theorem liftLT_irrefl (x : α) : ¬ x <ᵤ x := by
+  simp
+
+instance : IsIrrefl α (· <ᵤ ·) where irrefl := liftLT_irrefl


### PR DESCRIPTION
We define the predicates `liftEQ`, `liftLE`, and `liftLT`, which compare elements from distinct well-orders by first embedding them as an initial segment of a common type.

The intended purpose is to use these predicates to compare ordinals/cardinals in different universes. For instance, `liftEQ x y` is equivalent to `lift.{v} x = lift.{u} y`, but is easier to work with since the universes are now implicit.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I believe these are useful predicates which can alleviate a lot of the universe hell that arises with `Cardinal.lift` and `Ordinal.lift`. The major issue with them is that there's not one but two ways to lift `x : Cardinal.{u}` to `Cardinal.{max u v}`: either `lift.{v} x` or `lift.{max u v} x`. Worse, `simp` can't see universes, and so isn't able to simplify one into the other. This makes it so that otherwise simple manipulations with ordinals/cardinals from different universes turn into complex `rw` chains with `lift_umax`, requiring explicit universes throughout.

The goal of these new predicates is that, instead of writing `lift.{v} x = lift.{u} y` (or any of the other equivalent ways of expressing this), we can simply write `x =ᵤ y`, and likewise for other order relations.

See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Universe-heterogeneous.20ordinal.20and.20cardinal.20relations).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
