### PR TITLE
[Merged by Bors] - chore(CondExp): golf

### DIFF
--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -465,7 +465,7 @@ theorem tendsto_condExp_unique (fs gs : ℕ → α → E) (f g : α → E)
 variable [OrderedSMul ℝ E]
 
 lemma condExp_mono (hf : Integrable f μ) (hg : Integrable g μ) (hfg : f ≤ᵐ[μ] g) :
-    μ[f|m] ≤ᵐ[μ] μ[g|m] := by 
+    μ[f|m] ≤ᵐ[μ] μ[g|m] := by
   by_cases hm : m ≤ m₀
   swap; · simp_rw [condExp_of_not_le hm]; rfl
   by_cases hμm : SigmaFinite (μ.trim hm)

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -8,8 +8,8 @@ import Mathlib.MeasureTheory.Function.ConditionalExpectation.CondexpL1
 /-! # Conditional expectation
 
 We build the conditional expectation of an integrable function `f` with value in a Banach space
-with respect to a measure `μ` (defined on a measurable space structure `m0`) and a measurable space
-structure `m` with `hm : m ≤ m0` (a sub-sigma-algebra). This is an `m`-strongly measurable
+with respect to a measure `μ` (defined on a measurable space structure `m₀`) and a measurable space
+structure `m` with `hm : m ≤ m₀` (a sub-sigma-algebra). This is an `m`-strongly measurable
 function `μ[f|hm]` which is integrable and verifies `∫ x in s, μ[f|hm] x ∂μ = ∫ x in s, f x ∂μ`
 for all `m`-measurable sets `s`. It is unique as an element of `L¹`.
 
@@ -38,7 +38,7 @@ The conditional expectation and its properties
   with respect to `m`.
 * `integrable_condExp` : `condExp` is integrable.
 * `stronglyMeasurable_condExp` : `condExp` is `m`-strongly-measurable.
-* `setIntegral_condExp (hf : Integrable f μ) (hs : MeasurableSet[m] s)` : if `m ≤ m0` (the
+* `setIntegral_condExp (hf : Integrable f μ) (hs : MeasurableSet[m] s)` : if `m ≤ m₀` (the
   σ-algebra over which the measure is defined), then the conditional expectation verifies
   `∫ x in s, condExp m μ f x ∂μ = ∫ x in s, f x ∂μ` for any `m`-measurable set `s`.
 
@@ -52,8 +52,8 @@ Uniqueness of the conditional expectation
 
 ## Notations
 
-For a measure `μ` defined on a measurable space structure `m0`, another measurable space structure
-`m` with `hm : m ≤ m0` (a sub-σ-algebra) and a function `f`, we define the notation
+For a measure `μ` defined on a measurable space structure `m₀`, another measurable space structure
+`m` with `hm : m ≤ m₀` (a sub-σ-algebra) and a function `f`, we define the notation
 * `μ[f|m] = condExp m μ f`.
 
 ## Tags
@@ -62,35 +62,29 @@ conditional expectation, conditional expected value
 
 -/
 
-
 open TopologicalSpace MeasureTheory.Lp Filter
-
-open scoped ENNReal Topology MeasureTheory
+open scoped Classical ENNReal Topology MeasureTheory
 
 namespace MeasureTheory
-
-variable {α F F' 𝕜 : Type*} [RCLike 𝕜]
   -- 𝕜 for ℝ or ℂ
-  -- F' for integrals on a Lp submodule
-  [NormedAddCommGroup F']
-  [NormedSpace 𝕜 F'] [NormedSpace ℝ F'] [CompleteSpace F']
+  -- E for integrals on a Lp submodule
+variable {α β E 𝕜 : Type*} [RCLike 𝕜] {m m₀ : MeasurableSpace α} {μ : Measure α} {f g : α → E}
+  {s : Set α}
 
-open scoped Classical
+section NormedAddCommGroup
+variable [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
 
-variable {m m0 : MeasurableSpace α} {μ : Measure α} {f g : α → F'} {s : Set α}
-
+variable (m) in
 /-- Conditional expectation of a function. It is defined as 0 if any one of the following conditions
 is true:
-- `m` is not a sub-σ-algebra of `m0`,
+- `m` is not a sub-σ-algebra of `m₀`,
 - `μ` is not σ-finite with respect to `m`,
 - `f` is not integrable. -/
-noncomputable irreducible_def condExp (m : MeasurableSpace α) {m0 : MeasurableSpace α}
-    (μ : Measure α) (f : α → F') : α → F' :=
-  if hm : m ≤ m0 then
+noncomputable irreducible_def condExp (μ : Measure[m₀] α) (f : α → E) : α → E :=
+  if hm : m ≤ m₀ then
     if h : SigmaFinite (μ.trim hm) ∧ Integrable f μ then
       if StronglyMeasurable[m] f then f
-      else (@aestronglyMeasurable'_condExpL1 _ _ _ _ _ m m0 μ hm h.1 _).mk
-        (@condExpL1 _ _ _ _ _ _ _ hm μ h.1 f)
+      else have := h.1; aestronglyMeasurable'_condExpL1.mk (condExpL1 hm μ f)
     else 0
   else 0
 
@@ -99,16 +93,16 @@ noncomputable irreducible_def condExp (m : MeasurableSpace α) {m0 : MeasurableS
 -- We define notation `μ[f|m]` for the conditional expectation of `f` with respect to `m`.
 scoped notation μ "[" f "|" m "]" => MeasureTheory.condExp m μ f
 
-theorem condExp_of_not_le (hm_not : ¬m ≤ m0) : μ[f|m] = 0 := by rw [condExp, dif_neg hm_not]
+theorem condExp_of_not_le (hm_not : ¬m ≤ m₀) : μ[f|m] = 0 := by rw [condExp, dif_neg hm_not]
 
 @[deprecated (since := "2025-01-21")] alias condexp_of_not_le := condExp_of_not_le
 
-theorem condExp_of_not_sigmaFinite (hm : m ≤ m0) (hμm_not : ¬SigmaFinite (μ.trim hm)) :
+theorem condExp_of_not_sigmaFinite (hm : m ≤ m₀) (hμm_not : ¬SigmaFinite (μ.trim hm)) :
     μ[f|m] = 0 := by rw [condExp, dif_pos hm, dif_neg]; push_neg; exact fun h => absurd h hμm_not
 
 @[deprecated (since := "2025-01-21")] alias condexp_of_not_sigmaFinite := condExp_of_not_sigmaFinite
 
-theorem condExp_of_sigmaFinite (hm : m ≤ m0) [hμm : SigmaFinite (μ.trim hm)] :
+theorem condExp_of_sigmaFinite (hm : m ≤ m₀) [hμm : SigmaFinite (μ.trim hm)] :
     μ[f|m] =
       if Integrable f μ then
         if StronglyMeasurable[m] f then f
@@ -122,20 +116,19 @@ theorem condExp_of_sigmaFinite (hm : m ≤ m0) [hμm : SigmaFinite (μ.trim hm)]
 
 @[deprecated (since := "2025-01-21")] alias condexp_of_sigmaFinite := condExp_of_sigmaFinite
 
-theorem condExp_of_stronglyMeasurable (hm : m ≤ m0) [hμm : SigmaFinite (μ.trim hm)] {f : α → F'}
+theorem condExp_of_stronglyMeasurable (hm : m ≤ m₀) [hμm : SigmaFinite (μ.trim hm)] {f : α → E}
     (hf : StronglyMeasurable[m] f) (hfi : Integrable f μ) : μ[f|m] = f := by
   rw [condExp_of_sigmaFinite hm, if_pos hfi, if_pos hf]
 
 @[deprecated (since := "2025-01-21")]
 alias condexp_of_stronglyMeasurable := condExp_of_stronglyMeasurable
 
-theorem condExp_const (hm : m ≤ m0) (c : F') [IsFiniteMeasure μ] :
-    μ[fun _ : α => c|m] = fun _ => c :=
-  condExp_of_stronglyMeasurable hm (@stronglyMeasurable_const _ _ m _ _) (integrable_const c)
+theorem condExp_const (hm : m ≤ m₀) (c : E) [IsFiniteMeasure μ] : μ[fun _ : α ↦ c|m] = fun _ ↦ c :=
+  condExp_of_stronglyMeasurable hm stronglyMeasurable_const (integrable_const c)
 
 @[deprecated (since := "2025-01-21")] alias condexp_const := condExp_const
 
-theorem condExp_ae_eq_condExpL1 (hm : m ≤ m0) [hμm : SigmaFinite (μ.trim hm)] (f : α → F') :
+theorem condExp_ae_eq_condExpL1 (hm : m ≤ m₀) [hμm : SigmaFinite (μ.trim hm)] (f : α → E) :
     μ[f|m] =ᵐ[μ] condExpL1 hm μ f := by
   rw [condExp_of_sigmaFinite hm]
   by_cases hfi : Integrable f μ
@@ -151,41 +144,37 @@ theorem condExp_ae_eq_condExpL1 (hm : m ≤ m0) [hμm : SigmaFinite (μ.trim hm)
 
 @[deprecated (since := "2025-01-21")] alias condexp_ae_eq_condexpL1 := condExp_ae_eq_condExpL1
 
-theorem condExp_ae_eq_condExpL1CLM (hm : m ≤ m0) [SigmaFinite (μ.trim hm)] (hf : Integrable f μ) :
-    μ[f|m] =ᵐ[μ] condExpL1CLM F' hm μ (hf.toL1 f) := by
+theorem condExp_ae_eq_condExpL1CLM (hm : m ≤ m₀) [SigmaFinite (μ.trim hm)] (hf : Integrable f μ) :
+    μ[f|m] =ᵐ[μ] condExpL1CLM E hm μ (hf.toL1 f) := by
   refine (condExp_ae_eq_condExpL1 hm f).trans (Eventually.of_forall fun x => ?_)
   rw [condExpL1_eq hf]
 
 @[deprecated (since := "2025-01-21")] alias condexp_ae_eq_condexpL1CLM := condExp_ae_eq_condExpL1CLM
 
 theorem condExp_undef (hf : ¬Integrable f μ) : μ[f|m] = 0 := by
-  by_cases hm : m ≤ m0
+  by_cases hm : m ≤ m₀
   swap; · rw [condExp_of_not_le hm]
   by_cases hμm : SigmaFinite (μ.trim hm)
   swap; · rw [condExp_of_not_sigmaFinite hm hμm]
-  haveI : SigmaFinite (μ.trim hm) := hμm
   rw [condExp_of_sigmaFinite, if_neg hf]
 
 @[deprecated (since := "2025-01-21")] alias condexp_undef := condExp_undef
 
 @[simp]
-theorem condExp_zero : μ[(0 : α → F')|m] = 0 := by
-  by_cases hm : m ≤ m0
+theorem condExp_zero : μ[(0 : α → E)|m] = 0 := by
+  by_cases hm : m ≤ m₀
   swap; · rw [condExp_of_not_le hm]
   by_cases hμm : SigmaFinite (μ.trim hm)
   swap; · rw [condExp_of_not_sigmaFinite hm hμm]
-  haveI : SigmaFinite (μ.trim hm) := hμm
-  exact
-    condExp_of_stronglyMeasurable hm (@stronglyMeasurable_zero _ _ m _ _) (integrable_zero _ _ _)
+  exact condExp_of_stronglyMeasurable hm stronglyMeasurable_zero (integrable_zero _ _ _)
 
 @[deprecated (since := "2025-01-21")] alias condexp_zero := condExp_zero
 
 theorem stronglyMeasurable_condExp : StronglyMeasurable[m] (μ[f|m]) := by
-  by_cases hm : m ≤ m0
+  by_cases hm : m ≤ m₀
   swap; · rw [condExp_of_not_le hm]; exact stronglyMeasurable_zero
   by_cases hμm : SigmaFinite (μ.trim hm)
   swap; · rw [condExp_of_not_sigmaFinite hm hμm]; exact stronglyMeasurable_zero
-  haveI : SigmaFinite (μ.trim hm) := hμm
   rw [condExp_of_sigmaFinite hm]
   split_ifs with hfi hfm
   · exact hfm
@@ -195,18 +184,17 @@ theorem stronglyMeasurable_condExp : StronglyMeasurable[m] (μ[f|m]) := by
 @[deprecated (since := "2025-01-21")] alias stronglyMeasurable_condexp := stronglyMeasurable_condExp
 
 theorem condExp_congr_ae (h : f =ᵐ[μ] g) : μ[f|m] =ᵐ[μ] μ[g|m] := by
-  by_cases hm : m ≤ m0
+  by_cases hm : m ≤ m₀
   swap; · simp_rw [condExp_of_not_le hm]; rfl
   by_cases hμm : SigmaFinite (μ.trim hm)
   swap; · simp_rw [condExp_of_not_sigmaFinite hm hμm]; rfl
-  haveI : SigmaFinite (μ.trim hm) := hμm
   exact (condExp_ae_eq_condExpL1 hm f).trans
     (Filter.EventuallyEq.trans (by rw [condExpL1_congr_ae hm h])
       (condExp_ae_eq_condExpL1 hm g).symm)
 
 @[deprecated (since := "2025-01-21")] alias condexp_congr_ae := condExp_congr_ae
 
-theorem condExp_of_aestronglyMeasurable' (hm : m ≤ m0) [hμm : SigmaFinite (μ.trim hm)] {f : α → F'}
+theorem condExp_of_aestronglyMeasurable' (hm : m ≤ m₀) [hμm : SigmaFinite (μ.trim hm)] {f : α → E}
     (hf : AEStronglyMeasurable' m f μ) (hfi : Integrable f μ) : μ[f|m] =ᵐ[μ] f := by
   refine ((condExp_congr_ae hf.ae_eq_mk).trans ?_).trans hf.ae_eq_mk.symm
   rw [condExp_of_stronglyMeasurable hm hf.stronglyMeasurable_mk
@@ -217,18 +205,17 @@ alias condexp_of_aestronglyMeasurable' := condExp_of_aestronglyMeasurable'
 
 @[fun_prop]
 theorem integrable_condExp : Integrable (μ[f|m]) μ := by
-  by_cases hm : m ≤ m0
+  by_cases hm : m ≤ m₀
   swap; · rw [condExp_of_not_le hm]; exact integrable_zero _ _ _
   by_cases hμm : SigmaFinite (μ.trim hm)
   swap; · rw [condExp_of_not_sigmaFinite hm hμm]; exact integrable_zero _ _ _
-  haveI : SigmaFinite (μ.trim hm) := hμm
   exact (integrable_condExpL1 f).congr (condExp_ae_eq_condExpL1 hm f).symm
 
 @[deprecated (since := "2025-01-21")] alias integrable_condexp := integrable_condExp
 
 /-- The integral of the conditional expectation `μ[f|hm]` over an `m`-measurable set is equal to
 the integral of `f` on that set. -/
-theorem setIntegral_condExp (hm : m ≤ m0) [SigmaFinite (μ.trim hm)] (hf : Integrable f μ)
+theorem setIntegral_condExp (hm : m ≤ m₀) [SigmaFinite (μ.trim hm)] (hf : Integrable f μ)
     (hs : MeasurableSet[m] s) : ∫ x in s, (μ[f|m]) x ∂μ = ∫ x in s, f x ∂μ := by
   rw [setIntegral_congr_ae (hm s hs) ((condExp_ae_eq_condExpL1 hm f).mono fun x hx _ => hx)]
   exact setIntegral_condExpL1 hf hs
@@ -237,20 +224,20 @@ theorem setIntegral_condExp (hm : m ≤ m0) [SigmaFinite (μ.trim hm)] (hf : Int
 
 @[deprecated (since := "2024-04-17")] alias set_integral_condexp := setIntegral_condExp
 
-theorem integral_condExp (hm : m ≤ m0) [hμm : SigmaFinite (μ.trim hm)] :
+theorem integral_condExp (hm : m ≤ m₀) [hμm : SigmaFinite (μ.trim hm)] :
     ∫ x, (μ[f|m]) x ∂μ = ∫ x, f x ∂μ := by
   by_cases hf : Integrable f μ
   · suffices ∫ x in Set.univ, (μ[f|m]) x ∂μ = ∫ x in Set.univ, f x ∂μ by
       simp_rw [setIntegral_univ] at this; exact this
-    exact setIntegral_condExp hm hf (@MeasurableSet.univ _ m)
+    exact setIntegral_condExp hm hf .univ
   simp only [condExp_undef hf, Pi.zero_apply, integral_zero, integral_undef hf]
 
 @[deprecated (since := "2025-01-21")] alias integral_condexp := integral_condExp
 
-/-- Total probability law using `condExp` as conditional probability. -/
-theorem integral_condExp_indicator [mF : MeasurableSpace F] {Y : α → F} (hY : Measurable Y)
+/-- **Law of total probability** using `condExp` as conditional probability. -/
+theorem integral_condExp_indicator [mβ : MeasurableSpace β] {Y : α → β} (hY : Measurable Y)
     [SigmaFinite (μ.trim hY.comap_le)] {A : Set α} (hA : MeasurableSet A) :
-    ∫ x, (μ[(A.indicator fun _ ↦ (1 : ℝ)) | mF.comap Y]) x ∂μ = (μ A).toReal := by
+    ∫ x, (μ[(A.indicator fun _ ↦ (1 : ℝ)) | mβ.comap Y]) x ∂μ = (μ A).toReal := by
   rw [integral_condExp, integral_indicator hA, setIntegral_const, smul_eq_mul, mul_one]
 
 @[deprecated (since := "2025-01-21")] alias integral_condexp_indicator := integral_condExp_indicator
@@ -258,8 +245,8 @@ theorem integral_condExp_indicator [mF : MeasurableSpace F] {Y : α → F} (hY :
 /-- **Uniqueness of the conditional expectation**
 If a function is a.e. `m`-measurable, verifies an integrability condition and has same integral
 as `f` on all `m`-measurable sets, then it is a.e. equal to `μ[f|hm]`. -/
-theorem ae_eq_condExp_of_forall_setIntegral_eq (hm : m ≤ m0) [SigmaFinite (μ.trim hm)]
-    {f g : α → F'} (hf : Integrable f μ)
+theorem ae_eq_condExp_of_forall_setIntegral_eq (hm : m ≤ m₀) [SigmaFinite (μ.trim hm)]
+    {f g : α → E} (hf : Integrable f μ)
     (hg_int_finite : ∀ s, MeasurableSet[m] s → μ s < ∞ → IntegrableOn g s μ)
     (hg_eq : ∀ s : Set α, MeasurableSet[m] s → μ s < ∞ → ∫ x in s, g x ∂μ = ∫ x in s, f x ∂μ)
     (hgm : AEStronglyMeasurable' m g μ) : g =ᵐ[μ] μ[f|m] := by
@@ -277,51 +264,7 @@ alias ae_eq_condExp_of_forall_set_integral_eq := ae_eq_condExp_of_forall_setInte
 @[deprecated (since := "2025-01-21")]
 alias ae_eq_condexp_of_forall_set_integral_eq := ae_eq_condExp_of_forall_set_integral_eq
 
-section MemL2
-
-lemma Memℒp.condExpL2_ae_eq_condExp' {𝕜 : Type*} [RCLike 𝕜] [InnerProductSpace 𝕜 F']
-    (hm : m ≤ m0) (hf1 : Integrable f μ) (hf2 : Memℒp f 2 μ) [SigmaFinite (μ.trim hm)] :
-    condExpL2 F' 𝕜 hm hf2.toLp =ᵐ[μ] μ[f | m] := by
-  refine ae_eq_condExp_of_forall_setIntegral_eq hm hf1
-    (fun s hs htop ↦ integrableOn_condExpL2_of_measure_ne_top hm htop.ne _) (fun s hs htop ↦ ?_)
-    (aeStronglyMeasurable'_condExpL2 hm _)
-  rw [integral_condExpL2_eq hm (hf2.toLp _) hs htop.ne]
-  refine setIntegral_congr_ae (hm _ hs) ?_
-  filter_upwards [hf2.coeFn_toLp] with ω hω _ using hω
-
-lemma Memℒp.condExpL2_ae_eq_condExp {𝕜 : Type*} [RCLike 𝕜] [InnerProductSpace 𝕜 F']
-    (hm : m ≤ m0) (hf : Memℒp f 2 μ) [IsFiniteMeasure μ] :
-    condExpL2 F' 𝕜 hm hf.toLp =ᵐ[μ] μ[f | m] :=
-  hf.condExpL2_ae_eq_condExp' hm (memℒp_one_iff_integrable.1 <| hf.mono_exponent one_le_two)
-
--- TODO: Generalize via the conditional Jensen inequality
-lemma eLpNorm_condExp_le {𝕜 : Type*} [RCLike 𝕜] [InnerProductSpace 𝕜 F'] :
-    eLpNorm (μ[f | m]) 2 μ ≤ eLpNorm f 2 μ := by
-  by_cases hm : m ≤ m0; swap
-  · simp [condExp_of_not_le hm]
-  by_cases hfμ : SigmaFinite (μ.trim hm); swap
-  · rw [condExp_of_not_sigmaFinite hm hfμ]
-    simp
-  by_cases hfi : Integrable f μ; swap
-  · rw [condExp_undef hfi]
-    simp
-  obtain hf | hf := eq_or_ne (eLpNorm f 2 μ) ∞
-  · simp [hf]
-  replace hf : Memℒp f 2 μ := ⟨hfi.1, Ne.lt_top' fun a ↦ hf (id (Eq.symm a))⟩
-  rw [← eLpNorm_congr_ae (hf.condExpL2_ae_eq_condExp' (𝕜 := 𝕜) hm hfi)]
-  refine le_trans (eLpNorm_condExpL2_le hm _) ?_
-  rw [eLpNorm_congr_ae hf.coeFn_toLp]
-
-protected lemma Memℒp.condExp {𝕜 : Type*} [RCLike 𝕜] [InnerProductSpace 𝕜 F']
-    (hf : Memℒp f 2 μ) : Memℒp (μ[f | m]) 2 μ := by
-  by_cases hm : m ≤ m0
-  · exact ⟨(stronglyMeasurable_condExp.mono hm).aestronglyMeasurable,
-      eLpNorm_condExp_le (𝕜 := 𝕜).trans_lt hf.eLpNorm_lt_top⟩
-  · simp [condExp_of_not_le hm]
-
-end MemL2
-
-theorem condExp_bot' [hμ : NeZero μ] (f : α → F') :
+theorem condExp_bot' [hμ : NeZero μ] (f : α → E) :
     μ[f|⊥] = fun _ => (μ Set.univ).toReal⁻¹ • ∫ x, f x ∂μ := by
   by_cases hμ_finite : IsFiniteMeasure μ
   swap
@@ -341,7 +284,7 @@ theorem condExp_bot' [hμ : NeZero μ] (f : α → F') :
 
 @[deprecated (since := "2025-01-21")] alias condexp_bot' := condExp_bot'
 
-theorem condExp_bot_ae_eq (f : α → F') :
+theorem condExp_bot_ae_eq (f : α → E) :
     μ[f|⊥] =ᵐ[μ] fun _ => (μ Set.univ).toReal⁻¹ • ∫ x, f x ∂μ := by
   rcases eq_zero_or_neZero μ with rfl | hμ
   · rw [ae_zero]; exact eventually_bot
@@ -349,18 +292,17 @@ theorem condExp_bot_ae_eq (f : α → F') :
 
 @[deprecated (since := "2025-01-21")] alias condexp_bot_ae_eq := condExp_bot_ae_eq
 
-theorem condExp_bot [IsProbabilityMeasure μ] (f : α → F') : μ[f|⊥] = fun _ => ∫ x, f x ∂μ := by
+theorem condExp_bot [IsProbabilityMeasure μ] (f : α → E) : μ[f|⊥] = fun _ => ∫ x, f x ∂μ := by
   refine (condExp_bot' f).trans ?_; rw [measure_univ, ENNReal.one_toReal, inv_one, one_smul]
 
 @[deprecated (since := "2025-01-21")] alias condexp_bot := condExp_bot
 
-theorem condExp_add (hf : Integrable f μ) (hg : Integrable g μ) :
+theorem condExp_add (hf : Integrable f μ) (hg : Integrable g μ) (m : MeasurableSpace α) :
     μ[f + g|m] =ᵐ[μ] μ[f|m] + μ[g|m] := by
-  by_cases hm : m ≤ m0
+  by_cases hm : m ≤ m₀
   swap; · simp_rw [condExp_of_not_le hm]; simp
   by_cases hμm : SigmaFinite (μ.trim hm)
   swap; · simp_rw [condExp_of_not_sigmaFinite hm hμm]; simp
-  haveI : SigmaFinite (μ.trim hm) := hμm
   refine (condExp_ae_eq_condExpL1 hm _).trans ?_
   rw [condExpL1_add hf hg]
   exact (coeFn_add _ _).trans
@@ -368,101 +310,119 @@ theorem condExp_add (hf : Integrable f μ) (hg : Integrable g μ) :
 
 @[deprecated (since := "2025-01-21")] alias condexp_add := condExp_add
 
-theorem condExp_finset_sum {ι : Type*} {s : Finset ι} {f : ι → α → F'}
-    (hf : ∀ i ∈ s, Integrable (f i) μ) : μ[∑ i ∈ s, f i|m] =ᵐ[μ] ∑ i ∈ s, μ[f i|m] := by
+theorem condExp_finset_sum {ι : Type*} {s : Finset ι} {f : ι → α → E}
+    (hf : ∀ i ∈ s, Integrable (f i) μ) (m : MeasurableSpace α) :
+    μ[∑ i ∈ s, f i|m] =ᵐ[μ] ∑ i ∈ s, μ[f i|m] := by
   induction' s using Finset.induction_on with i s his heq hf
   · rw [Finset.sum_empty, Finset.sum_empty, condExp_zero]
   · rw [Finset.sum_insert his, Finset.sum_insert his]
-    exact (condExp_add (hf i <| Finset.mem_insert_self i s) <|
-      integrable_finset_sum' _ fun j hmem => hf j <| Finset.mem_insert_of_mem hmem).trans
-        ((EventuallyEq.refl _ _).add (heq fun j hmem => hf j <| Finset.mem_insert_of_mem hmem))
+    exact (condExp_add (hf i <| Finset.mem_insert_self i s)
+      (integrable_finset_sum' _ <| Finset.forall_of_forall_insert hf) _).trans
+        ((EventuallyEq.refl _ _).add <| heq <| Finset.forall_of_forall_insert hf)
 
 @[deprecated (since := "2025-01-21")] alias condexp_finset_sum := condExp_finset_sum
 
-theorem condExp_smul (c : 𝕜) (f : α → F') : μ[c • f|m] =ᵐ[μ] c • μ[f|m] := by
-  by_cases hm : m ≤ m0
+theorem condExp_smul [NormedSpace 𝕜 E] (c : 𝕜) (f : α → E) (m : MeasurableSpace α) :
+    μ[c • f|m] =ᵐ[μ] c • μ[f|m] := by
+  by_cases hm : m ≤ m₀
   swap; · simp_rw [condExp_of_not_le hm]; simp
   by_cases hμm : SigmaFinite (μ.trim hm)
   swap; · simp_rw [condExp_of_not_sigmaFinite hm hμm]; simp
-  haveI : SigmaFinite (μ.trim hm) := hμm
   refine (condExp_ae_eq_condExpL1 hm _).trans ?_
   rw [condExpL1_smul c f]
-  refine (@condExp_ae_eq_condExpL1 _ _ _ _ _ m _ _ hm _ f).mp ?_
+  refine (condExp_ae_eq_condExpL1 hm f).mp ?_
   refine (coeFn_smul c (condExpL1 hm μ f)).mono fun x hx1 hx2 => ?_
   simp only [hx1, hx2, Pi.smul_apply]
 
 @[deprecated (since := "2025-01-21")] alias condexp_smul := condExp_smul
 
-theorem condExp_neg (f : α → F') : μ[-f|m] =ᵐ[μ] -μ[f|m] := by
-  letI : Module ℝ (α → F') := @Pi.module α (fun _ => F') ℝ _ _ fun _ => inferInstance
+theorem condExp_neg (f : α → E) (m : MeasurableSpace α) : μ[-f|m] =ᵐ[μ] -μ[f|m] := by
   calc
     μ[-f|m] = μ[(-1 : ℝ) • f|m] := by rw [neg_one_smul ℝ f]
-    _ =ᵐ[μ] (-1 : ℝ) • μ[f|m] := condExp_smul (-1) f
+    _ =ᵐ[μ] (-1 : ℝ) • μ[f|m] := condExp_smul ..
     _ = -μ[f|m] := neg_one_smul ℝ (μ[f|m])
 
 @[deprecated (since := "2025-01-21")] alias condexp_neg := condExp_neg
 
-theorem condExp_sub (hf : Integrable f μ) (hg : Integrable g μ) :
+theorem condExp_sub (hf : Integrable f μ) (hg : Integrable g μ) (m : MeasurableSpace α) :
     μ[f - g|m] =ᵐ[μ] μ[f|m] - μ[g|m] := by
   simp_rw [sub_eq_add_neg]
-  exact (condExp_add hf hg.neg).trans (EventuallyEq.rfl.add (condExp_neg g))
+  exact (condExp_add hf hg.neg _).trans (EventuallyEq.rfl.add (condExp_neg ..))
 
 @[deprecated (since := "2025-01-21")] alias condexp_sub := condExp_sub
 
-theorem condExp_condExp_of_le {m₁ m₂ m0 : MeasurableSpace α} {μ : Measure α} (hm₁₂ : m₁ ≤ m₂)
-    (hm₂ : m₂ ≤ m0) [SigmaFinite (μ.trim hm₂)] : μ[μ[f|m₂]|m₁] =ᵐ[μ] μ[f|m₁] := by
+/-- **Tower property of the conditional expectation**.
+
+Taking the `m₂`-conditional expectation then the `m₁`-conditional expectation, where `m₁` is a
+smaller σ-algebra, is the same as taking the `m₁`-conditional expectation directly. -/
+theorem condExp_condExp_of_le {m₁ m₂ m₀ : MeasurableSpace α} {μ : Measure α} (hm₁₂ : m₁ ≤ m₂)
+    (hm₂ : m₂ ≤ m₀) [SigmaFinite (μ.trim hm₂)] : μ[μ[f|m₂]|m₁] =ᵐ[μ] μ[f|m₁] := by
   by_cases hμm₁ : SigmaFinite (μ.trim (hm₁₂.trans hm₂))
   swap; · simp_rw [condExp_of_not_sigmaFinite (hm₁₂.trans hm₂) hμm₁]; rfl
-  haveI : SigmaFinite (μ.trim (hm₁₂.trans hm₂)) := hμm₁
   by_cases hf : Integrable f μ
   swap; · simp_rw [condExp_undef hf, condExp_zero]; rfl
   refine ae_eq_of_forall_setIntegral_eq_of_sigmaFinite' (hm₁₂.trans hm₂)
-    (fun s _ _ => integrable_condExp.integrableOn)
-    (fun s _ _ => integrable_condExp.integrableOn) ?_
-    (StronglyMeasurable.aeStronglyMeasurable' stronglyMeasurable_condExp)
-    (StronglyMeasurable.aeStronglyMeasurable' stronglyMeasurable_condExp)
+    (fun s _ _ => integrable_condExp.integrableOn) (fun s _ _ => integrable_condExp.integrableOn) ?_
+    stronglyMeasurable_condExp.aeStronglyMeasurable'
+    stronglyMeasurable_condExp.aeStronglyMeasurable'
   intro s hs _
   rw [setIntegral_condExp (hm₁₂.trans hm₂) integrable_condExp hs]
   rw [setIntegral_condExp (hm₁₂.trans hm₂) hf hs, setIntegral_condExp hm₂ hf (hm₁₂ s hs)]
 
 @[deprecated (since := "2025-01-21")] alias condexp_condexp_of_le := condExp_condExp_of_le
 
-theorem condExp_mono {E} [NormedLatticeAddCommGroup E] [CompleteSpace E] [NormedSpace ℝ E]
-    [OrderedSMul ℝ E] {f g : α → E} (hf : Integrable f μ) (hg : Integrable g μ) (hfg : f ≤ᵐ[μ] g) :
-    μ[f|m] ≤ᵐ[μ] μ[g|m] := by
-  by_cases hm : m ≤ m0
-  swap; · simp_rw [condExp_of_not_le hm]; rfl
-  by_cases hμm : SigmaFinite (μ.trim hm)
-  swap; · simp_rw [condExp_of_not_sigmaFinite hm hμm]; rfl
-  haveI : SigmaFinite (μ.trim hm) := hμm
-  exact (condExp_ae_eq_condExpL1 hm _).trans_le
-    ((condExpL1_mono hf hg hfg).trans_eq (condExp_ae_eq_condExpL1 hm _).symm)
+section MemL2
+variable [InnerProductSpace 𝕜 E]
 
-@[deprecated (since := "2025-01-21")] alias condexp_mono := condExp_mono
+lemma Memℒp.condExpL2_ae_eq_condExp' (hm : m ≤ m₀) (hf1 : Integrable f μ) (hf2 : Memℒp f 2 μ)
+    [SigmaFinite (μ.trim hm)] : condExpL2 E 𝕜 hm hf2.toLp =ᵐ[μ] μ[f | m] := by
+  refine ae_eq_condExp_of_forall_setIntegral_eq hm hf1
+    (fun s hs htop ↦ integrableOn_condExpL2_of_measure_ne_top hm htop.ne _) (fun s hs htop ↦ ?_)
+    (aeStronglyMeasurable'_condExpL2 hm _)
+  rw [integral_condExpL2_eq hm (hf2.toLp _) hs htop.ne]
+  refine setIntegral_congr_ae (hm _ hs) ?_
+  filter_upwards [hf2.coeFn_toLp] with ω hω _ using hω
 
-theorem condExp_nonneg {E} [NormedLatticeAddCommGroup E] [CompleteSpace E] [NormedSpace ℝ E]
-    [OrderedSMul ℝ E] {f : α → E} (hf : 0 ≤ᵐ[μ] f) : 0 ≤ᵐ[μ] μ[f|m] := by
-  by_cases hfint : Integrable f μ
-  · rw [(condExp_zero.symm : (0 : α → E) = μ[0|m])]
-    exact condExp_mono (integrable_zero _ _ _) hfint hf
-  · rw [condExp_undef hfint]
+lemma Memℒp.condExpL2_ae_eq_condExp (hm : m ≤ m₀) (hf : Memℒp f 2 μ) [IsFiniteMeasure μ] :
+    condExpL2 E 𝕜 hm hf.toLp =ᵐ[μ] μ[f | m] :=
+  hf.condExpL2_ae_eq_condExp' hm (memℒp_one_iff_integrable.1 <| hf.mono_exponent one_le_two)
 
-@[deprecated (since := "2025-01-21")] alias condexp_nonneg := condExp_nonneg
+-- TODO: Generalize via the conditional Jensen inequality
+include 𝕜 in
+lemma eLpNorm_condExp_le : eLpNorm (μ[f | m]) 2 μ ≤ eLpNorm f 2 μ := by
+  by_cases hm : m ≤ m₀; swap
+  · simp [condExp_of_not_le hm]
+  by_cases hfμ : SigmaFinite (μ.trim hm); swap
+  · rw [condExp_of_not_sigmaFinite hm hfμ]
+    simp
+  by_cases hfi : Integrable f μ; swap
+  · rw [condExp_undef hfi]
+    simp
+  obtain hf | hf := eq_or_ne (eLpNorm f 2 μ) ∞
+  · simp [hf]
+  replace hf : Memℒp f 2 μ := ⟨hfi.1, Ne.lt_top' fun a ↦ hf (id (Eq.symm a))⟩
+  rw [← eLpNorm_congr_ae (hf.condExpL2_ae_eq_condExp' (𝕜 := 𝕜) hm hfi)]
+  refine le_trans (eLpNorm_condExpL2_le hm _) ?_
+  rw [eLpNorm_congr_ae hf.coeFn_toLp]
 
-theorem condExp_nonpos {E} [NormedLatticeAddCommGroup E] [CompleteSpace E] [NormedSpace ℝ E]
-    [OrderedSMul ℝ E] {f : α → E} (hf : f ≤ᵐ[μ] 0) : μ[f|m] ≤ᵐ[μ] 0 := by
-  by_cases hfint : Integrable f μ
-  · rw [(condExp_zero.symm : (0 : α → E) = μ[0|m])]
-    exact condExp_mono hfint (integrable_zero _ _ _) hf
-  · rw [condExp_undef hfint]
+include 𝕜 in
+protected lemma Memℒp.condExp (hf : Memℒp f 2 μ) : Memℒp (μ[f | m]) 2 μ := by
+  by_cases hm : m ≤ m₀
+  · exact ⟨(stronglyMeasurable_condExp.mono hm).aestronglyMeasurable,
+      eLpNorm_condExp_le (𝕜 := 𝕜).trans_lt hf.eLpNorm_lt_top⟩
+  · simp [condExp_of_not_le hm]
 
-@[deprecated (since := "2025-01-21")] alias condexp_nonpos := condExp_nonpos
+end MemL2
+end NormedAddCommGroup
+
+section NormedLatticeAddCommGroup
+variable [NormedLatticeAddCommGroup E] [CompleteSpace E] [NormedSpace ℝ E]
 
 /-- **Lebesgue dominated convergence theorem**: sufficient conditions under which almost
   everywhere convergence of a sequence of functions implies the convergence of their image by
   `condExpL1`. -/
-theorem tendsto_condExpL1_of_dominated_convergence (hm : m ≤ m0) [SigmaFinite (μ.trim hm)]
-    {fs : ℕ → α → F'} {f : α → F'} (bound_fs : α → ℝ)
+theorem tendsto_condExpL1_of_dominated_convergence (hm : m ≤ m₀) [SigmaFinite (μ.trim hm)]
+    {fs : ℕ → α → E} {f : α → E} (bound_fs : α → ℝ)
     (hfs_meas : ∀ n, AEStronglyMeasurable (fs n) μ) (h_int_bound_fs : Integrable bound_fs μ)
     (hfs_bound : ∀ n, ∀ᵐ x ∂μ, ‖fs n x‖ ≤ bound_fs x)
     (hfs : ∀ᵐ x ∂μ, Tendsto (fun n => fs n x) atTop (𝓝 (f x))) :
@@ -475,7 +435,7 @@ alias tendsto_condexpL1_of_dominated_convergence := tendsto_condExpL1_of_dominat
 /-- If two sequences of functions have a.e. equal conditional expectations at each step, converge
 and verify dominated convergence hypotheses, then the conditional expectations of their limits are
 a.e. equal. -/
-theorem tendsto_condExp_unique (fs gs : ℕ → α → F') (f g : α → F')
+theorem tendsto_condExp_unique (fs gs : ℕ → α → E) (f g : α → E)
     (hfs_int : ∀ n, Integrable (fs n) μ) (hgs_int : ∀ n, Integrable (gs n) μ)
     (hfs : ∀ᵐ x ∂μ, Tendsto (fun n => fs n x) atTop (𝓝 (f x)))
     (hgs : ∀ᵐ x ∂μ, Tendsto (fun n => gs n x) atTop (𝓝 (g x))) (bound_fs : α → ℝ)
@@ -483,9 +443,8 @@ theorem tendsto_condExp_unique (fs gs : ℕ → α → F') (f g : α → F')
     (h_int_bound_gs : Integrable bound_gs μ) (hfs_bound : ∀ n, ∀ᵐ x ∂μ, ‖fs n x‖ ≤ bound_fs x)
     (hgs_bound : ∀ n, ∀ᵐ x ∂μ, ‖gs n x‖ ≤ bound_gs x) (hfg : ∀ n, μ[fs n|m] =ᵐ[μ] μ[gs n|m]) :
     μ[f|m] =ᵐ[μ] μ[g|m] := by
-  by_cases hm : m ≤ m0; swap; · simp_rw [condExp_of_not_le hm]; rfl
+  by_cases hm : m ≤ m₀; swap; · simp_rw [condExp_of_not_le hm]; rfl
   by_cases hμm : SigmaFinite (μ.trim hm); swap; · simp_rw [condExp_of_not_sigmaFinite hm hμm]; rfl
-  haveI : SigmaFinite (μ.trim hm) := hμm
   refine (condExp_ae_eq_condExpL1 hm f).trans ((condExp_ae_eq_condExpL1 hm g).trans ?_).symm
   rw [← Lp.ext_iff]
   have hn_eq : ∀ n, condExpL1 hm μ (gs n) = condExpL1 hm μ (fs n) := by
@@ -503,4 +462,32 @@ theorem tendsto_condExp_unique (fs gs : ℕ → α → F') (f g : α → F')
 
 @[deprecated (since := "2025-01-21")] alias tendsto_condexp_unique := tendsto_condExp_unique
 
+variable [OrderedSMul ℝ E]
+
+lemma condExp_mono (hf : Integrable f μ) (hg : Integrable g μ) (hfg : f ≤ᵐ[μ] g) :
+    μ[f|m] ≤ᵐ[μ] μ[g|m] := by 
+  by_cases hm : m ≤ m₀
+  swap; · simp_rw [condExp_of_not_le hm]; rfl
+  by_cases hμm : SigmaFinite (μ.trim hm)
+  swap; · simp_rw [condExp_of_not_sigmaFinite hm hμm]; rfl
+  exact (condExp_ae_eq_condExpL1 hm _).trans_le
+    ((condExpL1_mono hf hg hfg).trans_eq (condExp_ae_eq_condExpL1 hm _).symm)
+
+lemma condExp_nonneg (hf : 0 ≤ᵐ[μ] f) : 0 ≤ᵐ[μ] μ[f|m] := by
+  by_cases hfint : Integrable f μ
+  · rw [(condExp_zero.symm : (0 : α → E) = μ[0|m])]
+    exact condExp_mono (integrable_zero _ _ _) hfint hf
+  · rw [condExp_undef hfint]
+
+lemma condExp_nonpos (hf : f ≤ᵐ[μ] 0) : μ[f|m] ≤ᵐ[μ] 0 := by
+  by_cases hfint : Integrable f μ
+  · rw [(condExp_zero.symm : (0 : α → E) = μ[0|m])]
+    exact condExp_mono hfint (integrable_zero _ _ _) hf
+  · rw [condExp_undef hfint]
+
+@[deprecated (since := "2025-01-21")] alias condexp_mono := condExp_mono
+@[deprecated (since := "2025-01-21")] alias condexp_nonneg := condExp_nonneg
+@[deprecated (since := "2025-01-21")] alias condexp_nonpos := condExp_nonpos
+
+end NormedLatticeAddCommGroup
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Indicator.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Indicator.lean
@@ -88,9 +88,8 @@ theorem condExp_indicator (hf_int : Integrable f μ) (hs : MeasurableSet[m] s) :
   calc
     s.indicator (μ[s.indicator f + sᶜ.indicator f|m]) =ᵐ[μ]
         s.indicator (μ[s.indicator f|m] + μ[sᶜ.indicator f|m]) := by
-      have : μ[s.indicator f + sᶜ.indicator f|m] =ᵐ[μ] μ[s.indicator f|m] + μ[sᶜ.indicator f|m] :=
-        condExp_add (hf_int.indicator (hm _ hs)) (hf_int.indicator (hm _ hs.compl))
-      filter_upwards [this] with x hx
+      filter_upwards [condExp_add (hf_int.indicator (hm _ hs)) (hf_int.indicator (hm _ hs.compl)) m]
+        with x hx
       classical rw [Set.indicator_apply, Set.indicator_apply, hx]
     _ = s.indicator (μ[s.indicator f|m]) + s.indicator (μ[sᶜ.indicator f|m]) :=
       (s.indicator_add' _ _)

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Real.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Real.lean
@@ -67,8 +67,7 @@ theorem eLpNorm_one_condExp_le_eLpNorm (f : α → ℝ) : eLpNorm (μ[f|m]) 1 μ
       refine eLpNorm_mono_ae ?_
       filter_upwards [condExp_mono hf hf.abs
         (ae_of_all μ (fun x => le_abs_self (f x) : ∀ x, f x ≤ |f x|)),
-        EventuallyLE.trans (condExp_neg f).symm.le
-          (condExp_mono hf.neg hf.abs
+        (condExp_neg ..).symm.le.trans (condExp_mono hf.neg hf.abs
           (ae_of_all μ (fun x => neg_le_abs (f x) : ∀ x, -f x ≤ |f x|)))] with x hx₁ hx₂
       exact abs_le_abs hx₁ hx₂
     _ = eLpNorm f 1 μ := by
@@ -256,14 +255,14 @@ theorem condExp_stronglyMeasurable_simpleFunc_mul (hm : m ≤ m0) (f : @SimpleFu
       @SimpleFunc.coe_const _ _ m, @SimpleFunc.coe_zero _ _ m, Set.piecewise_eq_indicator]
     rw [this, this]
     refine (condExp_indicator (hg.smul c) hs).trans ?_
-    filter_upwards [condExp_smul (m := m) (m0 := m0) c g] with x hx
+    filter_upwards [condExp_smul c g m] with x hx
     classical simp_rw [Set.indicator_apply, hx]
   · have h_add := @SimpleFunc.coe_add _ _ m _ g₁ g₂
     calc
       μ[⇑(g₁ + g₂) * g|m] =ᵐ[μ] μ[(⇑g₁ + ⇑g₂) * g|m] := by
         refine condExp_congr_ae (EventuallyEq.mul ?_ EventuallyEq.rfl); rw [h_add]
       _ =ᵐ[μ] μ[⇑g₁ * g|m] + μ[⇑g₂ * g|m] := by
-        rw [add_mul]; exact condExp_add (hg.simpleFunc_mul' hm _) (hg.simpleFunc_mul' hm _)
+        rw [add_mul]; exact condExp_add (hg.simpleFunc_mul' hm _) (hg.simpleFunc_mul' hm _) _
       _ =ᵐ[μ] ⇑g₁ * μ[g|m] + ⇑g₂ * μ[g|m] := EventuallyEq.add h_eq₁ h_eq₂
       _ =ᵐ[μ] ⇑(g₁ + g₂) * μ[g|m] := by rw [h_add, add_mul]
 

--- a/Mathlib/Probability/Martingale/Basic.lean
+++ b/Mathlib/Probability/Martingale/Basic.lean
@@ -98,7 +98,7 @@ protected theorem integrable (hf : Martingale f ℱ μ) (i : ι) : Integrable (f
 
 theorem setIntegral_eq [SigmaFiniteFiltration μ ℱ] (hf : Martingale f ℱ μ) {i j : ι} (hij : i ≤ j)
     {s : Set Ω} (hs : MeasurableSet[ℱ i] s) : ∫ ω in s, f i ω ∂μ = ∫ ω in s, f j ω ∂μ := by
-  rw [← @setIntegral_condExp _ _ _ _ _ (ℱ i) m0 _ _ _ (ℱ.le i) _ (hf.integrable j) hs]
+  rw [← setIntegral_condExp (ℱ.le i) (hf.integrable j) hs]
   refine setIntegral_congr_ae (ℱ.le i s hs) ?_
   filter_upwards [hf.2 i j hij] with _ heq _ using heq.symm
 
@@ -107,17 +107,18 @@ alias set_integral_eq := setIntegral_eq
 
 theorem add (hf : Martingale f ℱ μ) (hg : Martingale g ℱ μ) : Martingale (f + g) ℱ μ := by
   refine ⟨hf.adapted.add hg.adapted, fun i j hij => ?_⟩
-  exact (condExp_add (hf.integrable j) (hg.integrable j)).trans ((hf.2 i j hij).add (hg.2 i j hij))
+  exact (condExp_add (hf.integrable j) (hg.integrable j) _).trans
+    ((hf.2 i j hij).add (hg.2 i j hij))
 
 theorem neg (hf : Martingale f ℱ μ) : Martingale (-f) ℱ μ :=
-  ⟨hf.adapted.neg, fun i j hij => (condExp_neg (f j)).trans (hf.2 i j hij).neg⟩
+  ⟨hf.adapted.neg, fun i j hij => (condExp_neg ..).trans (hf.2 i j hij).neg⟩
 
 theorem sub (hf : Martingale f ℱ μ) (hg : Martingale g ℱ μ) : Martingale (f - g) ℱ μ := by
   rw [sub_eq_add_neg]; exact hf.add hg.neg
 
 theorem smul (c : ℝ) (hf : Martingale f ℱ μ) : Martingale (c • f) ℱ μ := by
   refine ⟨hf.adapted.smul c, fun i j hij => ?_⟩
-  refine (condExp_smul c (f j)).trans ((hf.2 i j hij).mono fun x hx => ?_)
+  refine (condExp_smul ..).trans ((hf.2 i j hij).mono fun x hx => ?_)
   simp only [Pi.smul_apply, hx]
 
 theorem supermartingale [Preorder E] (hf : Martingale f ℱ μ) : Supermartingale f ℱ μ :=
@@ -170,7 +171,7 @@ alias set_integral_le := setIntegral_le
 theorem add [Preorder E] [AddLeftMono E] (hf : Supermartingale f ℱ μ)
     (hg : Supermartingale g ℱ μ) : Supermartingale (f + g) ℱ μ := by
   refine ⟨hf.1.add hg.1, fun i j hij => ?_, fun i => (hf.2.2 i).add (hg.2.2 i)⟩
-  refine (condExp_add (hf.integrable j) (hg.integrable j)).le.trans ?_
+  refine (condExp_add (hf.integrable j) (hg.integrable j) _).le.trans ?_
   filter_upwards [hf.2.1 i j hij, hg.2.1 i j hij]
   intros
   refine add_le_add ?_ ?_ <;> assumption
@@ -182,7 +183,7 @@ theorem add_martingale [Preorder E] [AddLeftMono E]
 theorem neg [Preorder E] [AddLeftMono E] (hf : Supermartingale f ℱ μ) :
     Submartingale (-f) ℱ μ := by
   refine ⟨hf.1.neg, fun i j hij => ?_, fun i => (hf.2.2 i).neg⟩
-  refine EventuallyLE.trans ?_ (condExp_neg (f j)).symm.le
+  refine EventuallyLE.trans ?_ (condExp_neg ..).symm.le
   filter_upwards [hf.2.1 i j hij] with _ _
   simpa
 
@@ -209,7 +210,7 @@ theorem ae_le_condExp [LE E] (hf : Submartingale f ℱ μ) {i j : ι} (hij : i �
 theorem add [Preorder E] [AddLeftMono E] (hf : Submartingale f ℱ μ)
     (hg : Submartingale g ℱ μ) : Submartingale (f + g) ℱ μ := by
   refine ⟨hf.1.add hg.1, fun i j hij => ?_, fun i => (hf.2.2 i).add (hg.2.2 i)⟩
-  refine EventuallyLE.trans ?_ (condExp_add (hf.integrable j) (hg.integrable j)).symm.le
+  refine EventuallyLE.trans ?_ (condExp_add (hf.integrable j) (hg.integrable j) _).symm.le
   filter_upwards [hf.2.1 i j hij, hg.2.1 i j hij]
   intros
   refine add_le_add ?_ ?_ <;> assumption
@@ -220,7 +221,7 @@ theorem add_martingale [Preorder E] [AddLeftMono E] (hf : Submartingale f ℱ μ
 
 theorem neg [Preorder E] [AddLeftMono E] (hf : Submartingale f ℱ μ) :
     Supermartingale (-f) ℱ μ := by
-  refine ⟨hf.1.neg, fun i j hij => (condExp_neg (f j)).le.trans ?_, fun i => (hf.2.2 i).neg⟩
+  refine ⟨hf.1.neg, fun i j hij => (condExp_neg ..).le.trans ?_, fun i => (hf.2.2 i).neg⟩
   filter_upwards [hf.2.1 i j hij] with _ _
   simpa
 
@@ -286,7 +287,7 @@ theorem submartingale_of_condExp_sub_nonneg [IsFiniteMeasure μ] {f : ι → Ω 
     Submartingale f ℱ μ := by
   refine ⟨hadp, fun i j hij => ?_, hint⟩
   rw [← condExp_of_stronglyMeasurable (ℱ.le _) (hadp _) (hint _), ← eventually_sub_nonneg]
-  exact EventuallyLE.trans (hf i j hij) (condExp_sub (hint _) (hint _)).le
+  exact EventuallyLE.trans (hf i j hij) (condExp_sub (hint _) (hint _) _).le
 
 @[deprecated (since := "2025-01-21")]
 alias submartingale_of_condexp_sub_nonneg := submartingale_of_condExp_sub_nonneg
@@ -295,7 +296,7 @@ theorem Submartingale.condExp_sub_nonneg {f : ι → Ω → ℝ} (hf : Submartin
     (hij : i ≤ j) : 0 ≤ᵐ[μ] μ[f j - f i|ℱ i] := by
   by_cases h : SigmaFinite (μ.trim (ℱ.le i))
   swap; · rw [condExp_of_not_sigmaFinite (ℱ.le i) h]
-  refine EventuallyLE.trans ?_ (condExp_sub (hf.integrable _) (hf.integrable _)).symm.le
+  refine EventuallyLE.trans ?_ (condExp_sub (hf.integrable _) (hf.integrable _) _).symm.le
   rw [eventually_sub_nonneg,
     condExp_of_stronglyMeasurable (ℱ.le _) (hf.adapted _) (hf.integrable _)]
   exact hf.2.1 i j hij
@@ -332,10 +333,8 @@ variable {F : Type*} [NormedLatticeAddCommGroup F] [NormedSpace ℝ F] [Complete
 theorem smul_nonneg {f : ι → Ω → F} {c : ℝ} (hc : 0 ≤ c) (hf : Supermartingale f ℱ μ) :
     Supermartingale (c • f) ℱ μ := by
   refine ⟨hf.1.smul c, fun i j hij => ?_, fun i => (hf.2.2 i).smul c⟩
-  refine (condExp_smul c (f j)).le.trans ?_
-  filter_upwards [hf.2.1 i j hij] with _ hle
-  simp_rw [Pi.smul_apply]
-  exact smul_le_smul_of_nonneg_left hle hc
+  filter_upwards [condExp_smul c (f j) (ℱ i), hf.2.1 i j hij] with ω hω hle
+  simpa only [hω, Pi.smul_apply] using smul_le_smul_of_nonneg_left hle hc
 
 theorem smul_nonpos {f : ι → Ω → F} {c : ℝ} (hc : c ≤ 0) (hf : Supermartingale f ℱ μ) :
     Submartingale (c • f) ℱ μ := by
@@ -418,7 +417,7 @@ theorem supermartingale_nat [IsFiniteMeasure μ] {f : ℕ → Ω → ℝ} (hadp 
     Supermartingale f 𝒢 μ := by
   rw [← neg_neg f]
   refine (submartingale_nat hadp.neg (fun i => (hint i).neg) fun i =>
-    EventuallyLE.trans ?_ (condExp_neg _).symm.le).neg
+    EventuallyLE.trans ?_ (condExp_neg ..).symm.le).neg
   filter_upwards [hf i] with x hx using neg_le_neg hx
 
 theorem martingale_nat [IsFiniteMeasure μ] {f : ℕ → Ω → ℝ} (hadp : Adapted 𝒢 f)
@@ -431,7 +430,7 @@ theorem submartingale_of_condExp_sub_nonneg_nat [IsFiniteMeasure μ] {f : ℕ �
     (hf : ∀ i, 0 ≤ᵐ[μ] μ[f (i + 1) - f i|𝒢 i]) : Submartingale f 𝒢 μ := by
   refine submartingale_nat hadp hint fun i => ?_
   rw [← condExp_of_stronglyMeasurable (𝒢.le _) (hadp _) (hint _), ← eventually_sub_nonneg]
-  exact EventuallyLE.trans (hf i) (condExp_sub (hint _) (hint _)).le
+  exact EventuallyLE.trans (hf i) (condExp_sub (hint _) (hint _) _).le
 
 @[deprecated (since := "2025-01-21")]
 alias submartingale_of_condexp_sub_nonneg_nat := submartingale_of_condExp_sub_nonneg_nat
@@ -452,7 +451,7 @@ theorem martingale_of_condExp_sub_eq_zero_nat [IsFiniteMeasure μ] {f : ℕ → 
   refine martingale_iff.2 ⟨supermartingale_of_condExp_sub_nonneg_nat hadp hint fun i => ?_,
     submartingale_of_condExp_sub_nonneg_nat hadp hint fun i => (hf i).symm.le⟩
   rw [← neg_sub]
-  refine (EventuallyEq.trans ?_ (condExp_neg _).symm).le
+  refine (EventuallyEq.trans ?_ (condExp_neg ..).symm).le
   filter_upwards [hf i] with x hx
   simpa only [Pi.zero_apply, Pi.neg_apply, zero_eq_neg]
 

--- a/Mathlib/Probability/Martingale/Centering.lean
+++ b/Mathlib/Probability/Martingale/Centering.lean
@@ -85,12 +85,12 @@ theorem martingale_martingalePart (hf : Adapted ℱ f) (hf_int : ∀ n, Integrab
   have h_eq_sum : μ[martingalePart f ℱ μ j|ℱ i] =ᵐ[μ]
       f 0 + ∑ k ∈ Finset.range j, (μ[f (k + 1) - f k|ℱ i] - μ[μ[f (k + 1) - f k|ℱ k]|ℱ i]) := by
     rw [martingalePart_eq_sum]
-    refine (condExp_add (hf_int 0) (by fun_prop)).trans ?_
-    refine (EventuallyEq.rfl.add (condExp_finset_sum fun i _ => by fun_prop)).trans ?_
+    refine (condExp_add (hf_int 0) (by fun_prop) _).trans ?_
+    refine (EventuallyEq.rfl.add (condExp_finset_sum (fun i _ => by fun_prop) _)).trans ?_
     refine EventuallyEq.add ?_ ?_
     · rw [condExp_of_stronglyMeasurable (ℱ.le _) _ (hf_int 0)]
       · exact (hf 0).mono (ℱ.mono (zero_le i))
-    · exact eventuallyEq_sum fun k _ => condExp_sub (by fun_prop) integrable_condExp
+    · exact eventuallyEq_sum fun k _ => condExp_sub (by fun_prop) integrable_condExp _
   refine h_eq_sum.trans ?_
   have h_ge : ∀ k, i ≤ k → μ[f (k + 1) - f k|ℱ i] - μ[μ[f (k + 1) - f k|ℱ k]|ℱ i] =ᵐ[μ] 0 := by
     intro k hk

--- a/Mathlib/Probability/Martingale/Convergence.lean
+++ b/Mathlib/Probability/Martingale/Convergence.lean
@@ -335,7 +335,7 @@ theorem Martingale.eq_condExp_of_tendsto_eLpNorm {μ : Measure Ω} (hf : Marting
     tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds hgtends (fun m => zero_le _)
       fun m => eLpNorm_one_condExp_le_eLpNorm _
   have hev : ∀ m ≥ n, eLpNorm (μ[f m - g|ℱ n]) 1 μ = eLpNorm (f n - μ[g|ℱ n]) 1 μ := by
-    refine fun m hm => eLpNorm_congr_ae ((condExp_sub (hf.integrable m) hg).trans ?_)
+    refine fun m hm => eLpNorm_congr_ae ((condExp_sub (hf.integrable m) hg _).trans ?_)
     filter_upwards [hf.2 n m hm] with x hx
     simp only [hx, Pi.sub_apply]
   exact tendsto_nhds_unique (tendsto_atTop_of_eventually_const hev) ht


### PR DESCRIPTION
* Remove useless `@`
* Remove useless `haveI`/`letI`
* Make `m` explicit in `condExp_add`, `condExp_sub`, etc... for use inside `filter_upwards`. Currently, using one of those lemmas in `filter_upwards` results in metavariables.
* Reorder the file according to typeclass assumptions
* Rename the base σ-algebra to `m₀` and the normed space to `E`

From my PhD (LeanCamCombi)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
