### PR TITLE
[Merged by Bors] - feat: submodule of multivariate polynomials of bounded degrees

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -545,17 +545,15 @@ variable (s t) in
 lemma degreesLE_add : degreesLE R σ (s + t) = degreesLE R σ s * degreesLE R σ t := by
   classical
   rw [le_antisymm_iff, Submodule.mul_le]
-  refine ⟨fun x hx ↦ ?_, fun x hx y hy ↦ degrees_mul_le.trans (add_le_add hx hy)⟩
-  rw [x.as_sum]
-  refine sum_mem fun i hi ↦ ?_
+  refine ⟨fun x hx ↦ x.as_sum ▸ sum_mem fun i hi ↦ ?_,
+    fun x hx y hy ↦ degrees_mul_le.trans (add_le_add hx hy)⟩
   replace hi : i.toMultiset ≤ s + t := (Finset.le_sup hi).trans hx
   let a := (i.toMultiset - t).toFinsupp
   let b := (i.toMultiset ⊓ t).toFinsupp
   have : a + b = i := Multiset.toFinsupp.symm.injective (by simp [a, b, Multiset.sub_add_inter])
   have ha : a.toMultiset ≤ s := by simpa [a, add_comm (a := t)] using hi
   have hb : b.toMultiset ≤ t := by simp [b, Multiset.inter_le_right]
-  have : monomial i (x.coeff i) = monomial a (x.coeff i) * monomial b 1 := by simp [this]
-  rw [this]
+  rw [show monomial i (x.coeff i) = monomial a (x.coeff i) * monomial b 1 by simp [this]]
   exact Submodule.mul_mem_mul ((degrees_monomial _ _).trans ha) ((degrees_monomial _ _).trans hb)
 
 @[simp] lemma degreesLE_zero : degreesLE R σ 0 = 1 := by

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -524,6 +524,53 @@ theorem totalDegree_rename_le (f : σ → τ) (p : MvPolynomial σ R) :
 
 end TotalDegree
 
+section degreesLE
+variable {s t : Multiset σ}
+
+variable (R σ s) in
+/-- The submodule of multivariate polynomials of degrees bounded by a monomial `s`. -/
+def degreesLE : Submodule R (MvPolynomial σ R) where
+  carrier := {p | p.degrees ≤ s}
+  add_mem' {a b} ha hb := by classical exact degrees_add_le.trans (sup_le ha hb)
+  zero_mem' := by simp
+  smul_mem' c {x} hx := by
+    dsimp
+    rw [Algebra.smul_def]
+    refine degrees_mul_le.trans ?_
+    simpa [degrees_C] using hx
+
+@[simp] lemma mem_degreesLE : p ∈ degreesLE R σ s ↔ p.degrees ≤ s := Iff.rfl
+
+variable (s t) in
+lemma degreesLE_add : degreesLE R σ (s + t) = degreesLE R σ s * degreesLE R σ t := by
+  classical
+  rw [le_antisymm_iff, Submodule.mul_le]
+  refine ⟨fun x hx ↦ ?_, fun x hx y hy ↦ degrees_mul_le.trans (add_le_add hx hy)⟩
+  rw [x.as_sum]
+  refine sum_mem fun i hi ↦ ?_
+  replace hi : i.toMultiset ≤ s + t := (Finset.le_sup hi).trans hx
+  let a := (i.toMultiset - t).toFinsupp
+  let b := (i.toMultiset ⊓ t).toFinsupp
+  have : a + b = i := Multiset.toFinsupp.symm.injective (by simp [a, b, Multiset.sub_add_inter])
+  have ha : a.toMultiset ≤ s := by simpa [a, add_comm (a := t)] using hi
+  have hb : b.toMultiset ≤ t := by simp [b, Multiset.inter_le_right]
+  have : monomial i (x.coeff i) = monomial a (x.coeff i) * monomial b 1 := by simp [this]
+  rw [this]
+  exact Submodule.mul_mem_mul ((degrees_monomial _ _).trans ha) ((degrees_monomial _ _).trans hb)
+
+@[simp] lemma degreesLE_zero : degreesLE R σ 0 = 1 := by
+  refine le_antisymm (fun x hx ↦ ?_) (by simp)
+  simp only [mem_degreesLE, nonpos_iff_eq_zero] at hx
+  have := (totalDegree_eq_zero_iff_eq_C (p := x)).mp
+    (Nat.eq_zero_of_le_zero (x.totalDegree_le_degrees_card.trans (by simp [hx])))
+  exact ⟨x.coeff 0, by simp [Algebra.smul_def, ← this]⟩
+
+variable (s) in
+lemma degreesLE_nsmul : ∀ n, degreesLE R σ (n • s) = degreesLE R σ s ^ n
+  | 0 => by simp
+  | k + 1 => by simp only [pow_succ, degreesLE_nsmul, degreesLE_add, add_smul, one_smul]
+
+end degreesLE
 end CommSemiring
 
 end MvPolynomial


### PR DESCRIPTION
From GrowthInGroups (LeanCamCombi)

Co-authored-by: Andrew Yang


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
