### PR TITLE
[Merged by Bors] - feat(Analysis/SpecialFunctions): generalise away from nat

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
@@ -24,32 +24,30 @@ open Filter Function Complex Real
 
 open scoped Interval Topology BigOperators Nat Classical Complex
 
-lemma Complex.summable_log_one_add_of_summable  {f : ℕ → ℂ} (hf : Summable f) :
-    Summable (fun n : ℕ => Complex.log (1 + f n)) := by
-  have hff := Summable.const_smul ((3 : ℝ) / 2) (summable_norm_iff.mpr hf)
-  have := Metric.tendsto_atTop.mp (Summable.tendsto_atTop_zero ((summable_norm_iff.mpr hf)))
-  apply Summable.of_norm_bounded_eventually_nat (fun n => 3/2 * Complex.abs (f n)) hff
-  simp only [smul_eq_mul, gt_iff_lt, ge_iff_le, dist_zero_right, Real.norm_eq_abs, Complex.abs_abs,
-    Complex.norm_eq_abs, eventually_atTop] at *
-  obtain ⟨n, hn⟩ := this (1/2) (one_half_pos)
-  exact Exists.intro n fun m hm ↦ norm_log_one_add_half_le_self (LT.lt.le (hn m hm))
+variable {ι : Type*}
 
-lemma Real.summable_log_one_add_of_summable  {f : ℕ → ℝ} (hf : Summable f) :
-     Summable (fun n : ℕ => log (1 + |f n|)) := by
+lemma Complex.summable_log_one_add_of_summable {f : ι → ℂ} (hf : Summable f) :
+    Summable (fun i : ι => Complex.log (1 + f i)) := by
+  apply (hf.norm.const_smul (3 / 2 : ℝ)).of_norm_bounded_eventually
+  filter_upwards [hf.norm.tendsto_cofinite_zero.eventually_le_const one_half_pos] with i hi
+  exact norm_log_one_add_half_le_self hi
+
+lemma Real.summable_log_one_add_of_summable {f : ι → ℝ} (hf : Summable f) :
+     Summable (fun i : ι => log (1 + |f i|)) := by
   have : Summable (fun n ↦ Complex.ofRealCLM (log (1 + |f n|))) := by
-    convert Complex.summable_log_one_add_of_summable  (Complex.ofRealCLM.summable hf.norm) with x
+    convert Complex.summable_log_one_add_of_summable (Complex.ofRealCLM.summable hf.norm) with x
     rw [ofRealCLM_apply, ofReal_log (by positivity)]
     simp only [ofReal_add, ofReal_one, norm_eq_abs, ofRealCLM_apply]
   convert Complex.reCLM.summable this
 
-lemma Complex.multipliable_one_add_of_summable (f : ℕ → ℂ) (hf : Summable f)
-    (hff : ∀ n : ℕ, 1 + f n ≠ 0) : Multipliable (fun n : ℕ => 1 + f n) := by
-  refine Complex.multipliable_of_summable_log  (fun n => 1 + f n) (by simpa) ?_
+lemma Complex.multipliable_one_add_of_summable (f : ι → ℂ) (hf : Summable f)
+    (hff : ∀ n : ι, 1 + f n ≠ 0) : Multipliable (fun n : ι => 1 + f n) := by
+  refine Complex.multipliable_of_summable_log (fun n => 1 + f n) (by simpa) ?_
   simpa only [forall_const] using Complex.summable_log_one_add_of_summable hf
 
-lemma Real.multipliable_one_add_of_summable (f : ℕ → ℝ) (hf : Summable f) :
-    Multipliable (fun n : ℕ => 1 + |f n|) := by
-  refine Real.multipliable_of_summable_log  (fun n => 1 + |f n|) (fun _ ↦ by positivity) ?_
+lemma Real.multipliable_one_add_of_summable (f : ι → ℝ) (hf : Summable f) :
+    Multipliable (fun n : ι => 1 + |f n|) := by
+  refine Real.multipliable_of_summable_log (fun n => 1 + |f n|) (fun _ ↦ by positivity) ?_
   simpa only [forall_const] using Real.summable_log_one_add_of_summable  hf
 
 lemma Complex.tendstoUniformlyOn_tsum_nat_log_one_add {α : Type*} {f : ℕ → α → ℂ} (K : Set α)


### PR DESCRIPTION
Generalise the first four lemmas in this file to have an arbitrary indexing type rather than nat.
Despite the diff looking strange, the only user-facing change here is that the lemmas are strictly more general.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
