### PR TITLE
[Merged by Bors] - feat: submodule of mv polynomials whose coeffs lie in a fixed submodule

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -857,44 +857,6 @@ theorem constantCoeff_comp_algebraMap :
 
 end ConstantCoeff
 
-section coeffsIn
-variable {R S σ : Type*} [CommSemiring R] [CommSemiring S]
-
-section Module
-variable [Module R S] {M N : Submodule R S} {x : MvPolynomial σ S}
-
-variable (σ M)
-/-- The `R`-submodule of multivariate polynomials whose coefficients lie in a `R`-submodule `M`. -/
-@[simps]
-def coeffsIn : Submodule R (MvPolynomial σ S) where
-  carrier := {p | ∀ i, p.coeff i ∈ M}
-  add_mem' := by simp+contextual [add_mem]
-  zero_mem' := by simp
-  smul_mem' := by simp+contextual [Submodule.smul_mem]
-
-@[simp] lemma mem_coeffsIn : x ∈ coeffsIn σ M ↔ ∀ i, x.coeff i ∈ M := .rfl
-
-end Module
-
-section Algebra
-variable [Algebra R S] {M N : Submodule R S} {x : MvPolynomial σ S} {n : ℕ}
-
-lemma le_coeffsIn_mul : coeffsIn σ M * coeffsIn σ N ≤ coeffsIn σ (M * N) := by
-  classical
-  rw [Submodule.mul_le]
-  intros x hx y hy k
-  rw [MvPolynomial.coeff_mul]
-  exact sum_mem fun c hc ↦ Submodule.mul_mem_mul (hx _) (hy _)
-
-lemma coeffsIn_pow_le : coeffsIn σ M ^ n ≤ coeffsIn σ (M ^ n) := by
-  classical
-  induction' n with n IH
-  · simpa [MvPolynomial.coeff_one, apply_ite] using ⟨1, map_one _⟩
-  · exact (Submodule.mul_le_mul_left IH).trans le_coeffsIn_mul
-
-end Algebra
-end coeffsIn
-
 section AsSum
 
 @[simp]
@@ -906,6 +868,104 @@ theorem as_sum (p : MvPolynomial σ R) : p = ∑ v ∈ p.support, monomial v (co
   (support_sum_monomial_coeff p).symm
 
 end AsSum
+
+section coeffsIn
+variable {R S σ : Type*} [CommSemiring R] [CommSemiring S]
+
+section Module
+variable [Module R S] {M N : Submodule R S} {p : MvPolynomial σ S} {s : σ} {i : σ →₀ ℕ} {x : S}
+  {n : ℕ}
+
+variable (σ M) in
+/-- The `R`-submodule of multivariate polynomials whose coefficients lie in a `R`-submodule `M`. -/
+@[simps]
+def coeffsIn : Submodule R (MvPolynomial σ S) where
+  carrier := {p | ∀ i, p.coeff i ∈ M}
+  add_mem' := by simp+contextual [add_mem]
+  zero_mem' := by simp
+  smul_mem' := by simp+contextual [Submodule.smul_mem]
+
+lemma mem_coeffsIn : p ∈ coeffsIn σ M ↔ ∀ i, p.coeff i ∈ M := .rfl
+
+@[simp]
+lemma monomial_mem_coeffsIn : monomial i x ∈ coeffsIn σ M ↔ x ∈ M := by
+  classical
+  simp only [mem_coeffsIn, coeff_monomial]
+  exact ⟨fun h ↦ by simpa using h i, fun hs j ↦ by split <;> simp [hs]⟩
+
+@[simp]
+lemma C_mem_coeffsIn : C x ∈ coeffsIn σ M ↔ x ∈ M := by simpa using monomial_mem_coeffsIn (i := 0)
+
+@[simp]
+lemma one_coeffsIn : 1 ∈ coeffsIn σ M ↔ 1 ∈ M := by simpa using C_mem_coeffsIn (x := (1 : S))
+
+@[simp]
+lemma mul_monomial_mem_coeffsIn : p * monomial i 1 ∈ coeffsIn σ M ↔ p ∈ coeffsIn σ M := by
+  classical
+  simp only [mem_coeffsIn, coeff_mul_monomial', Finsupp.mem_support_iff]
+  constructor
+  · rintro hp j
+    simpa using hp (j + i)
+  · rintro hp i
+    split <;> simp [hp]
+
+@[simp]
+lemma monomial_mul_mem_coeffsIn : monomial i 1 * p ∈ coeffsIn σ M ↔ p ∈ coeffsIn σ M := by
+  simp [mul_comm]
+
+@[simp]
+lemma mul_X_mem_coeffsIn : p * X s ∈ coeffsIn σ M ↔ p ∈ coeffsIn σ M := by
+  simpa [-mul_monomial_mem_coeffsIn] using mul_monomial_mem_coeffsIn (i := .single s 1)
+
+@[simp]
+lemma X_mul_mem_coeffsIn : X s * p ∈ coeffsIn σ M ↔ p ∈ coeffsIn σ M := by simp [mul_comm]
+
+variable (M) in
+lemma coeffsIn_eq_span_monomial : coeffsIn σ M = .span R {monomial i m | (m ∈ M) (i : σ →₀ ℕ)} := by
+  classical
+  refine le_antisymm ?_ <| Submodule.span_le.2 ?_
+  · rintro p hp
+    rw [p.as_sum]
+    exact sum_mem fun i hi ↦ Submodule.subset_span ⟨_, hp i, _, rfl⟩
+  · rintro _ ⟨m, hm, s, n, rfl⟩ i
+    simp [coeff_X_pow]
+    split <;> simp [hm]
+
+lemma coeffsIn_le {N : Submodule R (MvPolynomial σ S)} :
+    coeffsIn σ M ≤ N ↔ ∀ m ∈ M, ∀ i, monomial i m ∈ N := by
+  simp [coeffsIn_eq_span_monomial, Submodule.span_le, Set.subset_def,
+    forall_swap (α := MvPolynomial σ S)]
+
+end Module
+
+section Algebra
+variable [Algebra R S] {M : Submodule R S}
+
+lemma coeffsIn_mul (M N : Submodule R S) : coeffsIn σ (M * N) = coeffsIn σ M * coeffsIn σ N := by
+  classical
+  refine le_antisymm (coeffsIn_le.2 ?_) ?_
+  · intros r hr s
+    induction hr using Submodule.mul_induction_on' with
+    | mem_mul_mem m hm n hn =>
+      rw [← add_zero s, ← monomial_mul]
+      apply Submodule.mul_mem_mul <;> simpa
+    | add x _ y _ hx hy =>
+      simpa [map_add] using add_mem hx hy
+  · rw [Submodule.mul_le]
+    intros x hx y hy k
+    rw [MvPolynomial.coeff_mul]
+    exact sum_mem fun c hc ↦ Submodule.mul_mem_mul (hx _) (hy _)
+
+lemma coeffsIn_pow : ∀ {n}, n ≠ 0 → ∀ M : Submodule R S, coeffsIn σ (M ^ n) = coeffsIn σ M ^ n
+  | 1, _, M =>  by simp
+  | n + 2, _, M => by rw [pow_succ, coeffsIn_mul, coeffsIn_pow, ← pow_succ]; exact n.succ_ne_zero
+
+lemma le_coeffsIn_pow : ∀ {n}, coeffsIn σ M ^ n ≤ coeffsIn σ (M ^ n)
+  | 0 => by simpa using ⟨1, map_one _⟩
+  | n + 1 => (coeffsIn_pow n.succ_ne_zero _).ge
+
+end Algebra
+end coeffsIn
 
 end CommSemiring
 

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -957,7 +957,7 @@ lemma coeffsIn_mul (M N : Submodule R S) : coeffsIn σ (M * N) = coeffsIn σ M *
     exact sum_mem fun c hc ↦ Submodule.mul_mem_mul (hx _) (hy _)
 
 lemma coeffsIn_pow : ∀ {n}, n ≠ 0 → ∀ M : Submodule R S, coeffsIn σ (M ^ n) = coeffsIn σ M ^ n
-  | 1, _, M =>  by simp
+  | 1, _, M => by simp
   | n + 2, _, M => by rw [pow_succ, coeffsIn_mul, coeffsIn_pow, ← pow_succ]; exact n.succ_ne_zero
 
 lemma le_coeffsIn_pow : ∀ {n}, coeffsIn σ M ^ n ≤ coeffsIn σ (M ^ n)

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -857,6 +857,44 @@ theorem constantCoeff_comp_algebraMap :
 
 end ConstantCoeff
 
+section coeffsIn
+variable {R S σ : Type*} [CommSemiring R] [CommSemiring S]
+
+section Module
+variable [Module R S] {M N : Submodule R S} {x : MvPolynomial σ S}
+
+variable (σ M)
+/-- The `R`-submodule of multivariate polynomials whose coefficients lie in a `R`-submodule `M`. -/
+@[simps]
+def coeffsIn : Submodule R (MvPolynomial σ S) where
+  carrier := {p | ∀ i, p.coeff i ∈ M}
+  add_mem' := by simp+contextual [add_mem]
+  zero_mem' := by simp
+  smul_mem' := by simp+contextual [Submodule.smul_mem]
+
+@[simp] lemma mem_coeffsIn : x ∈ coeffsIn σ M ↔ ∀ i, x.coeff i ∈ M := .rfl
+
+end Module
+
+section Algebra
+variable [Algebra R S] {M N : Submodule R S} {x : MvPolynomial σ S} {n : ℕ}
+
+lemma le_coeffsIn_mul : coeffsIn σ M * coeffsIn σ N ≤ coeffsIn σ (M * N) := by
+  classical
+  rw [Submodule.mul_le]
+  intros x hx y hy k
+  rw [MvPolynomial.coeff_mul]
+  exact sum_mem fun c hc ↦ Submodule.mul_mem_mul (hx _) (hy _)
+
+lemma coeffsIn_pow_le : coeffsIn σ M ^ n ≤ coeffsIn σ (M ^ n) := by
+  classical
+  induction' n with n IH
+  · simpa [MvPolynomial.coeff_one, apply_ite] using ⟨1, map_one _⟩
+  · exact (Submodule.mul_le_mul_left IH).trans le_coeffsIn_mul
+
+end Algebra
+end coeffsIn
+
 section AsSum
 
 @[simp]


### PR DESCRIPTION
From GrowthInGroups (LeanCamCombi)

Co-authored-by: Andrew Yang


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
