### PR TITLE
[Merged by Bors] - doc(RingTheory/LaurentSeries): correct docstring

### DIFF
--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -79,7 +79,8 @@ equivalence: `LaurentSeries.LaurentSeriesRingEquiv` is the *topological, ring eq
 `K⸨X⸩ ≃+* RatFuncAdicCompl K`.
 * In order to compare `K⟦X⟧` with the valuation subring in the `X`-adic completion of
 `RatFunc K` we consider its alias `LaurentSeries.powerSeries_as_subring` as a subring of `K⸨X⸩`,
-that is itself clearly isomorphic (via the inverse of `LaurentSeries.powerSeriesEquivSubring`) to `K⟦X⟧`.
+that is itself clearly isomorphic (via the inverse of `LaurentSeries.powerSeriesEquivSubring`) 
+to `K⟦X⟧`.
 
 ## To Do
 * The `AdicCompletion` construction is currently done for ideals in rings and does not take into

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -24,7 +24,7 @@ type with a zero. They are denoted `R⸨X⸩`.
 
 * Defines `LaurentSeries` as an abbreviation for `HahnSeries ℤ`.
 * Defines `hasseDeriv` of a Laurent series with coefficients in a module over a ring.
-* Provides a coercion `from power series `R⟦X⟧` into `R⸨X⸩` given by `HahnSeries.ofPowerSeries`.
+* Provides a coercion from power series `R⟦X⟧` into `R⸨X⸩` given by `HahnSeries.ofPowerSeries`.
 * Defines `LaurentSeries.powerSeriesPart`
 * Defines the localization map `LaurentSeries.of_powerSeries_localization` which evaluates to
   `HahnSeries.ofPowerSeries`.
@@ -79,7 +79,7 @@ equivalence: `LaurentSeries.LaurentSeriesRingEquiv` is the *topological, ring eq
 `K⸨X⸩ ≃+* RatFuncAdicCompl K`.
 * In order to compare `K⟦X⟧` with the valuation subring in the `X`-adic completion of
 `RatFunc K` we consider its alias `LaurentSeries.powerSeries_as_subring` as a subring of `K⸨X⸩`,
-that is itself clearly isomorphic (via `LaurentSeries.powerSeriesEquivSubring.symm`) to `K⟦X⟧`.
+that is itself clearly isomorphic (via `LaurentSeries.powerSeriesEquivSubring`) to `K⟦X⟧`.
 
 ## To Do
 * The `AdicCompletion` construction is currently done for ideals in rings and does not take into

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -79,7 +79,7 @@ equivalence: `LaurentSeries.LaurentSeriesRingEquiv` is the *topological, ring eq
 `K⸨X⸩ ≃+* RatFuncAdicCompl K`.
 * In order to compare `K⟦X⟧` with the valuation subring in the `X`-adic completion of
 `RatFunc K` we consider its alias `LaurentSeries.powerSeries_as_subring` as a subring of `K⸨X⸩`,
-that is itself clearly isomorphic (via the inverse of `LaurentSeries.powerSeriesEquivSubring`) 
+that is itself clearly isomorphic (via the inverse of `LaurentSeries.powerSeriesEquivSubring`)
 to `K⟦X⟧`.
 
 ## To Do

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -79,7 +79,7 @@ equivalence: `LaurentSeries.LaurentSeriesRingEquiv` is the *topological, ring eq
 `K⸨X⸩ ≃+* RatFuncAdicCompl K`.
 * In order to compare `K⟦X⟧` with the valuation subring in the `X`-adic completion of
 `RatFunc K` we consider its alias `LaurentSeries.powerSeries_as_subring` as a subring of `K⸨X⸩`,
-that is itself clearly isomorphic (via `LaurentSeries.powerSeriesEquivSubring`) to `K⟦X⟧`.
+that is itself clearly isomorphic (via the inverse of `LaurentSeries.powerSeriesEquivSubring`) to `K⟦X⟧`.
 
 ## To Do
 * The `AdicCompletion` construction is currently done for ideals in rings and does not take into


### PR DESCRIPTION
Remove a superfluous backtick and remove `.symm` in a lemma of the docstring so that it can be made clickable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
