### PR TITLE
[Merged by Bors] - feat(`InformationTheory/Hamming`): Add AddGroup instances

### DIFF
--- a/Mathlib/InformationTheory/Hamming.lean
+++ b/Mathlib/InformationTheory/Hamming.lean
@@ -244,6 +244,8 @@ instance [Zero α] [∀ i, Zero (β i)] [∀ i, SMulWithZero α (β i)] : SMulWi
 instance [∀ i, AddMonoid (β i)] : AddMonoid (Hamming β) :=
   Pi.addMonoid
 
+instance [∀ i, AddGroup (β i)] : AddGroup (Hamming β) := Pi.addGroup
+
 instance [∀ i, AddCommMonoid (β i)] : AddCommMonoid (Hamming β) :=
   Pi.addCommMonoid
 
@@ -396,15 +398,15 @@ instance [∀ i, Zero (β i)] : Norm (Hamming β) :=
 theorem norm_eq_hammingNorm [∀ i, Zero (β i)] (x : Hamming β) : ‖x‖ = hammingNorm (ofHamming x) :=
   rfl
 
--- Porting note: merged `SeminormedAddCommGroup` and `NormedAddCommGroup` instances
+instance [∀ i, AddGroup (β i)] : NormedAddGroup (Hamming β) where
+  dist_eq := by push_cast; exact mod_cast hammingDist_eq_hammingNorm
 
 instance [∀ i, AddCommGroup (β i)] : NormedAddCommGroup (Hamming β) where
   dist_eq := by push_cast; exact mod_cast hammingDist_eq_hammingNorm
 
 @[simp, push_cast]
-theorem nnnorm_eq_hammingNorm [∀ i, AddCommGroup (β i)] (x : Hamming β) :
-    ‖x‖₊ = hammingNorm (ofHamming x) :=
-  rfl
+theorem nnnorm_eq_hammingNorm [∀ i, AddGroup (β i)] (x : Hamming β) :
+    ‖x‖₊ = hammingNorm (ofHamming x) := rfl
 
 end
 


### PR DESCRIPTION
Add missing AddGroup and NormedAddGroup instances to Hamming.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
