### PR TITLE
[Merged by Bors] - feat: define the Cartan matrix of a root pairing relative to a base

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3615,6 +3615,7 @@ import Mathlib.LinearAlgebra.Reflection
 import Mathlib.LinearAlgebra.RootSystem.Base
 import Mathlib.LinearAlgebra.RootSystem.BaseChange
 import Mathlib.LinearAlgebra.RootSystem.Basic
+import Mathlib.LinearAlgebra.RootSystem.CartanMatrix
 import Mathlib.LinearAlgebra.RootSystem.Defs
 import Mathlib.LinearAlgebra.RootSystem.Finite.CanonicalBilinear
 import Mathlib.LinearAlgebra.RootSystem.Finite.Nondegenerate

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -410,7 +410,7 @@ alias rootSystem_toLin_apply := rootSystem_toPerfectPairing_apply
 @[simp] lemma rootSystem_coroot_apply (α) : (rootSystem H).coroot α = coroot α := rfl
 
 instance : (rootSystem H).IsCrystallographic where
-  exists_int α β :=
+  pairing_mem_range_algebraMap α β :=
     ⟨chainBotCoeff β.1 α.1 - chainTopCoeff β.1 α.1, by simp [apply_coroot_eq_cast β.1 α.1]⟩
 
 theorem isReduced_rootSystem : (rootSystem H).IsReduced := by

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -410,7 +410,7 @@ alias rootSystem_toLin_apply := rootSystem_toPerfectPairing_apply
 @[simp] lemma rootSystem_coroot_apply (α) : (rootSystem H).coroot α = coroot α := rfl
 
 instance : (rootSystem H).IsCrystallographic where
-  pairing_mem_range_algebraMap α β :=
+  exists_value α β :=
     ⟨chainBotCoeff β.1 α.1 - chainTopCoeff β.1 α.1, by simp [apply_coroot_eq_cast β.1 α.1]⟩
 
 theorem isReduced_rootSystem : (rootSystem H).IsReduced := by

--- a/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
@@ -115,7 +115,7 @@ end SubfieldValued
 /-- Restriction of scalars for a crystallographic root pairing. -/
 abbrev restrictScalars [P.IsCrystallographic] :
     RootSystem ι K (span K (range P.root)) (span K (range P.coroot)) :=
-  P.restrictScalars' K (IsValuedIn.trans P K ℤ).pairing_mem_range_algebraMap
+  P.restrictScalars' K (IsValuedIn.trans P K ℤ).exists_value
 
 /-- Restriction of scalars to `ℚ` for a crystallographic root pairing in characteristic zero. -/
 abbrev restrictScalarsRat [CharZero L] [P.IsCrystallographic] :=

--- a/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
@@ -115,7 +115,7 @@ end SubfieldValued
 /-- Restriction of scalars for a crystallographic root pairing. -/
 abbrev restrictScalars [P.IsCrystallographic] :
     RootSystem ι K (span K (range P.root)) (span K (range P.coroot)) :=
-  P.restrictScalars' K <| IsCrystallographic.mem_range_algebraMap P K
+  P.restrictScalars' K (IsValuedIn.trans P K ℤ).pairing_mem_range_algebraMap
 
 /-- Restriction of scalars to `ℚ` for a crystallographic root pairing in characteristic zero. -/
 abbrev restrictScalarsRat [CharZero L] [P.IsCrystallographic] :=

--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2025 Oliver Nash. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oliver Nash
+-/
+import Mathlib.LinearAlgebra.RootSystem.Base
+
+/-!
+# Cartan matrices for root systems
+
+This file contains definitions and basic results about Cartan matrices of root pairings / systems.
+
+## Main definitions:
+ * `RootPairing.cartanMatrix`: the Cartan matrix of a crystallographic root pairing, with respect to
+   a base `b`.
+
+-/
+
+noncomputable section
+
+open Function Set
+
+variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+
+namespace RootPairing.Base
+
+variable (S : Type*) [CommRing S] [Algebra S R]
+  {P : RootPairing ι R M N} [P.IsValuedIn S] (b : P.Base)
+
+/-- The Cartan matrix of a root pairing, taking values in `S`, with respect to a base `b`.
+
+See also `RootPairing.Base.cartanMatrix`. -/
+def cartanMatrixIn :
+    Matrix b.support b.support S :=
+  fun i j ↦ P.pairingIn S i j
+
+/-- The Cartan matrix of a crystallographic root pairing, with respect to a base `b`. -/
+abbrev cartanMatrix [P.IsCrystallographic] :
+    Matrix b.support b.support ℤ :=
+  b.cartanMatrixIn ℤ
+
+lemma cartanMatrixIn_def (i j : b.support) :
+    b.cartanMatrixIn S i j = P.pairingIn S i j :=
+  rfl
+
+variable [Nontrivial R] [NoZeroSMulDivisors S R]
+
+@[simp]
+lemma cartanMatrixIn_apply_same (i : b.support) :
+    b.cartanMatrixIn S i i = 2 :=
+  NoZeroSMulDivisors.algebraMap_injective S R <| by simp [cartanMatrixIn_def, map_ofNat]
+
+end RootPairing.Base

--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -32,7 +32,7 @@ variable (S : Type*) [CommRing S] [Algebra S R]
 See also `RootPairing.Base.cartanMatrix`. -/
 def cartanMatrixIn :
     Matrix b.support b.support S :=
-  fun i j ↦ P.pairingIn S i j
+  .of fun i j ↦ P.pairingIn S i j
 
 /-- The Cartan matrix of a crystallographic root pairing, with respect to a base `b`. -/
 abbrev cartanMatrix [P.IsCrystallographic] :

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -381,7 +381,7 @@ lemma pairing_reflection_perm_self_right (i j : ι) :
     root_coroot_eq_pairing]
 
 @[mk_iff]
-class IsValuedIn (S : Type*) [CommRing S] [Algebra S R] : Prop where
+class IsValuedIn (S : Type*) [CommSemiRing S] [Algebra S R] : Prop where
   exists_value : ∀ i j, ∃ s, algebraMap S R s = P.pairing i j
 
 protected alias exists_value := IsValuedIn.exists_value

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -380,8 +380,12 @@ lemma pairing_reflection_perm_self_right (i j : ι) :
     sub_add_cancel_left, ← toLin_toPerfectPairing, map_neg, toLin_toPerfectPairing,
     root_coroot_eq_pairing]
 
+/-- If `R` is an `S`-algebra, a root pairing over `R` is said to be valued in `S` if the pairing
+between a root and coroot always belongs to `S`.
+
+Of particular interest is the case `S = ℤ`. See `RootPairing.IsCrystallographic`. -/
 @[mk_iff]
-class IsValuedIn (S : Type*) [CommSemiring S] [Algebra S R] : Prop where
+class IsValuedIn (S : Type*) [CommRing S] [Algebra S R] : Prop where
   exists_value : ∀ i j, ∃ s, algebraMap S R s = P.pairing i j
 
 protected alias exists_value := IsValuedIn.exists_value

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -381,7 +381,7 @@ lemma pairing_reflection_perm_self_right (i j : ι) :
     root_coroot_eq_pairing]
 
 @[mk_iff]
-class IsValuedIn (S : Type*) [CommSemiRing S] [Algebra S R] : Prop where
+class IsValuedIn (S : Type*) [CommSemiring S] [Algebra S R] : Prop where
   exists_value : ∀ i j, ∃ s, algebraMap S R s = P.pairing i j
 
 protected alias exists_value := IsValuedIn.exists_value
@@ -582,7 +582,8 @@ Note that it is uniquely-defined only when the map `S → R` is injective, i.e.,
 def coxeterWeightIn (S : Type*) [CommRing S] [Algebra S R] [P.IsValuedIn S] (i j : ι) : S :=
   P.pairingIn S i j * P.pairingIn S j i
 
-@[simp] lemma algebraMap_coxeterWeightIn (S : Type*) [CommRing S] [Algebra S R] [P.IsValuedIn S] :
+@[simp] lemma algebraMap_coxeterWeightIn (S : Type*) [CommRing S] [Algebra S R] [P.IsValuedIn S]
+    (i j : ι) :
     algebraMap S R (P.coxeterWeightIn S i j) = P.coxeterWeight i j := by
   simp [coxeterWeightIn, coxeterWeight]
 

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -380,12 +380,11 @@ lemma pairing_reflection_perm_self_right (i j : ι) :
     sub_add_cancel_left, ← toLin_toPerfectPairing, map_neg, toLin_toPerfectPairing,
     root_coroot_eq_pairing]
 
-/-- If `R` is an `S`-algebra, a root pairing over `R` is said to be valued in `S` if the pairing
-between a root and coroot always belongs to `S`.
-
-Of particular interest is the case `S = ℤ`. See `RootPairing.IsCrystallographic`. -/
+@[mk_iff]
 class IsValuedIn (S : Type*) [CommRing S] [Algebra S R] : Prop where
-  pairing_mem_range_algebraMap : ∀ i j, P.pairing i j ∈ range (algebraMap S R)
+  exists_value : ∀ i j, ∃ s, algebraMap S R s = P.pairing i j
+
+protected alias exists_value := IsValuedIn.exists_value
 
 /-- A root pairing is said to be crystallographic if the pairing between a root and coroot is
 always an integer. -/
@@ -394,21 +393,21 @@ abbrev IsCrystallographic := P.IsValuedIn ℤ
 section IsValuedIn
 
 instance : P.IsValuedIn R where
-  pairing_mem_range_algebraMap i j := by simp
+  exists_value i j := by simp
 
 variable (S : Type*) [CommRing S] [Algebra S R]
 
 variable {S} in
-lemma isValuedIn_iff :
-    P.IsValuedIn S ↔ ∀ i j, ∃ s, algebraMap S R s = P.pairing i j :=
-  ⟨fun ⟨h⟩ ↦ h, fun h ↦ ⟨h⟩⟩
+lemma isValuedIn_iff_mem_range :
+    P.IsValuedIn S ↔ ∀ i j, P.pairing i j ∈ range (algebraMap S R) := by
+  simp only [isValuedIn_iff, mem_range]
 
 instance : P.IsValuedIn R where
-  pairing_mem_range_algebraMap := by simp
+  exists_value := by simp
 
 instance [P.IsValuedIn S] : P.flip.IsValuedIn S := by
   rw [isValuedIn_iff, forall_comm]
-  exact IsValuedIn.pairing_mem_range_algebraMap
+  exact P.exists_value
 
 /-- A variant of `RootPairing.pairing` for root pairings which are valued in a smaller set of
 coefficients.
@@ -416,17 +415,17 @@ coefficients.
 Note that it is uniquely-defined only when the map `S → R` is injective, i.e., when we have
 `[NoZeroSMulDivisors S R]`. -/
 def pairingIn [P.IsValuedIn S] (i j : ι) : S :=
-  (P.isValuedIn_iff.mp inferInstance i j).choose
+  (P.exists_value i j).choose
 
 @[simp]
 lemma algebraMap_pairingIn [P.IsValuedIn S] (i j : ι) :
     algebraMap S R (P.pairingIn S i j) = P.pairing i j :=
-  (P.isValuedIn_iff.mp inferInstance i j).choose_spec
+  (P.exists_value i j).choose_spec
 
 lemma IsValuedIn.trans (T : Type*) [CommRing T] [Algebra T S] [Algebra T R] [IsScalarTower T S R]
     [P.IsValuedIn T] :
     P.IsValuedIn S where
-  pairing_mem_range_algebraMap i j := by
+  exists_value i j := by
     use algebraMap T S (P.pairingIn T i j)
     simp [← RingHom.comp_apply, ← IsScalarTower.algebraMap_eq T S R]
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -268,10 +268,11 @@ instance instIsRootPositiveRootForm : IsRootPositive P P.RootForm where
 lemma coxeterWeight_mem_set_of_isCrystallographic (i j : ι) [P.IsCrystallographic] :
     P.coxeterWeight i j ∈ ({0, 1, 2, 3, 4} : Set R) := by
   obtain ⟨n, hcn⟩ : ∃ n : ℕ, P.coxeterWeight i j = n := by
-    obtain ⟨z, hz⟩ := P.exists_int_eq_coxeterWeight i j
-    have hz₀ : 0 ≤ z := by simpa [hz] using P.coxeterWeight_non_neg P.RootForm i j
-    obtain ⟨n, rfl⟩ := Int.eq_ofNat_of_zero_le hz₀
-    exact ⟨n, by simp [hz]⟩
+    have : 0 ≤ P.coxeterWeightIn ℤ i j := by
+      simpa only [← Int.cast_nonneg (R := R), (show Int.cast = algebraMap ℤ R from rfl),
+        P.algebraMap_coxeterWeightIn] using P.coxeterWeight_non_neg P.RootForm i j
+    obtain ⟨n, hn⟩ := Int.eq_ofNat_of_zero_le this
+    exact ⟨n, by simp [← P.algebraMap_coxeterWeightIn i j ℤ, hn]⟩
   have : P.coxeterWeight i j ≤ 4 := P.coxeterWeight_le_four i j
   simp only [hcn, mem_insert_iff, mem_singleton_iff] at this ⊢
   norm_cast at this ⊢

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -269,8 +269,7 @@ lemma coxeterWeight_mem_set_of_isCrystallographic (i j : ι) [P.IsCrystallograph
     P.coxeterWeight i j ∈ ({0, 1, 2, 3, 4} : Set R) := by
   obtain ⟨n, hcn⟩ : ∃ n : ℕ, P.coxeterWeight i j = n := by
     have : 0 ≤ P.coxeterWeightIn ℤ i j := by
-      simpa only [← Int.cast_nonneg (R := R), (show Int.cast = algebraMap ℤ R from rfl),
-        P.algebraMap_coxeterWeightIn] using P.coxeterWeight_non_neg P.RootForm i j
+            simpa [← P.algebraMap_coxeterWeightIn _ _ ℤ] using P.coxeterWeight_non_neg P.RootForm i j
     obtain ⟨n, hn⟩ := Int.eq_ofNat_of_zero_le this
     exact ⟨n, by simp [← P.algebraMap_coxeterWeightIn i j ℤ, hn]⟩
   have : P.coxeterWeight i j ≤ 4 := P.coxeterWeight_le_four i j

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -269,9 +269,9 @@ lemma coxeterWeight_mem_set_of_isCrystallographic (i j : ι) [P.IsCrystallograph
     P.coxeterWeight i j ∈ ({0, 1, 2, 3, 4} : Set R) := by
   obtain ⟨n, hcn⟩ : ∃ n : ℕ, P.coxeterWeight i j = n := by
     have : 0 ≤ P.coxeterWeightIn ℤ i j := by
-            simpa [← P.algebraMap_coxeterWeightIn _ _ ℤ] using P.coxeterWeight_non_neg P.RootForm i j
+      simpa [← P.algebraMap_coxeterWeightIn ℤ] using P.coxeterWeight_non_neg P.RootForm i j
     obtain ⟨n, hn⟩ := Int.eq_ofNat_of_zero_le this
-    exact ⟨n, by simp [← P.algebraMap_coxeterWeightIn i j ℤ, hn]⟩
+    exact ⟨n, by simp [← P.algebraMap_coxeterWeightIn ℤ, hn]⟩
   have : P.coxeterWeight i j ≤ 4 := P.coxeterWeight_le_four i j
   simp only [hcn, mem_insert_iff, mem_singleton_iff] at this ⊢
   norm_cast at this ⊢

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -77,7 +77,7 @@ instance [P.IsAnisotropic] : P.flip.IsAnisotropic where
 /-- An auxiliary lemma en route to `RootPairing.instIsAnisotropicOfIsCrystallographic`. -/
 private lemma rootForm_root_ne_zero_aux [CharZero R] [P.IsCrystallographic] (i : ι) :
     P.RootForm (P.root i) (P.root i) ≠ 0 := by
-  choose z hz using IsValuedIn.pairing_mem_range_algebraMap (P := P) (S := ℤ) i
+  choose z hz using P.exists_value (S := ℤ) i
   simp_rw [algebraMap_int_eq, Int.coe_castRingHom] at hz
   simp only [rootForm_apply_apply, PerfectPairing.flip_apply_apply, root_coroot_eq_pairing, ← hz]
   suffices 0 < ∑ i, z i * z i by norm_cast; exact this.ne'

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -77,7 +77,8 @@ instance [P.IsAnisotropic] : P.flip.IsAnisotropic where
 /-- An auxiliary lemma en route to `RootPairing.instIsAnisotropicOfIsCrystallographic`. -/
 private lemma rootForm_root_ne_zero_aux [CharZero R] [P.IsCrystallographic] (i : ι) :
     P.RootForm (P.root i) (P.root i) ≠ 0 := by
-  choose z hz using P.exists_int i
+  choose z hz using IsValuedIn.pairing_mem_range_algebraMap (P := P) (S := ℤ) i
+  simp_rw [algebraMap_int_eq, Int.coe_castRingHom] at hz
   simp only [rootForm_apply_apply, PerfectPairing.flip_apply_apply, root_coroot_eq_pairing, ← hz]
   suffices 0 < ∑ i, z i * z i by norm_cast; exact this.ne'
   refine Finset.sum_pos' (fun i _ ↦ mul_self_nonneg (z i)) ⟨i, Finset.mem_univ i, ?_⟩


### PR DESCRIPTION
Also adding `RootPairing.IsValuedIn` (together with some API) since this enables us to define an integer-valued Cartan matrix for crystallographic pairings.

More importantly, `RootPairing.IsValuedIn` is also the missing piece to generalise (and unify) some results which currently require ordered scalars such as [RootPairing.coxeterWeight_mem_set_of_isCrystallographic](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.html#RootPairing.coxeterWeight_mem_set_of_isCrystallographic) but this work is left for a future PR (mostly to simplify review).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
