### PR TITLE
[Merged by Bors] - feat(RingTheory/LaurentSeries): add algebraEquiv

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
@@ -403,6 +403,9 @@ def adicCompletion :=
 instance : Field (v.adicCompletion K) := inferInstanceAs <|
   Field (@UniformSpace.Completion K v.adicValued.toUniformSpace)
 
+instance : Algebra K (v.adicCompletion K) :=
+  RingHom.toAlgebra (@UniformSpace.Completion.coeRingHom K _ v.adicValued.toUniformSpace _ _)
+
 instance : Inhabited (v.adicCompletion K) :=
   ⟨0⟩
 

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -14,6 +14,8 @@ import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.Topology.UniformSpace.Cauchy
 import Mathlib.Algebra.Group.Int.TypeTags
 
+import Mathlib.RingTheory.AdicCompletion.Algebra
+
 /-!
 # Laurent Series
 
@@ -1071,6 +1073,16 @@ theorem coe_X_compare :
   rw [PowerSeries.coe_X, ← RatFunc.coe_X, ← LaurentSeries_coe, ← compare_coe]
   rfl
 
+instance : Algebra K (RatFuncAdicCompl K) :=
+  RingHom.toAlgebra ((LaurentSeriesRingEquiv K).toRingHom.comp HahnSeries.C)
+
+theorem algebraMap_apply (a : K) : algebraMap K K⸨X⸩ a = HahnSeries.C a := by
+  simp [RingHom.algebraMap_toAlgebra]
+
+def LaurentSeriesAlgEquiv : K⸨X⸩ ≃ₐ[K] RatFuncAdicCompl K :=
+  AlgEquiv.ofRingEquiv (f := LaurentSeriesRingEquiv K)
+    (fun a ↦ by simp [RingHom.algebraMap_toAlgebra])
+
 open Filter WithZero
 
 open scoped WithZeroTopology Topology Multiplicative
@@ -1179,6 +1191,16 @@ theorem powerSeries_ext_subring :
 abbrev powerSeriesRingEquiv : K⟦X⟧ ≃+* (idealX K).adicCompletionIntegers (RatFunc K) :=
   ((powerSeriesEquivSubring K).trans (LaurentSeriesRingEquiv K).subringMap).trans
     <| RingEquiv.subringCongr (powerSeries_ext_subring K)
+
+example : Algebra K ((idealX K).adicCompletionIntegers (RatFunc K)) := by
+  unfold adicCompletionIntegers
+  apply RingHom.toAlgebra
+  apply RingHom.codRestrict
+
+/-- The algebra isomorphism between `K⟦X⟧` and the unit ball inside the `X`-adic completion of
+`RatFunc K`. -/
+abbrev powerSeriesRingAlgEquiv : K⟦X⟧ ≃ₐ[K] (idealX K).adicCompletionIntegers (RatFunc K) :=
+  sorry
 
 end PowerSeries
 

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -1058,6 +1058,11 @@ abbrev LaurentSeriesRingEquiv : K⸨X⸩ ≃+* RatFuncAdicCompl K :=
   (ratfuncAdicComplRingEquiv K).symm
 
 @[simp]
+lemma LaurentSeriesRingEquiv_def (f : K⟦X⟧) :
+    (LaurentSeriesRingEquiv K) f = (LaurentSeriesPkg K).compare ratfuncAdicComplPkg (f : K⸨X⸩) :=
+  rfl
+
+@[simp]
 theorem ratfuncAdicComplRingEquiv_apply (x : RatFuncAdicCompl K) :
     ratfuncAdicComplRingEquiv K x = ratfuncAdicComplPkg.compare (LaurentSeriesPkg K) x := rfl
 
@@ -1160,10 +1165,9 @@ lemma powerSeriesEquivSubring_coe_apply (f : K⟦X⟧) :
 completion of `RatFunc K`. -/
 theorem mem_integers_of_powerSeries (F : K⟦X⟧) :
     (LaurentSeriesRingEquiv K) F ∈ (idealX K).adicCompletionIntegers (RatFunc K) := by
-  have : (LaurentSeriesRingEquiv K) F =
-    (LaurentSeriesPkg K).compare ratfuncAdicComplPkg (F : K⸨X⸩) := rfl
   simp only [Subring.mem_map, exists_prop, ValuationSubring.mem_toSubring,
-    mem_adicCompletionIntegers, this,  valuation_compare, val_le_one_iff_eq_coe]
+    mem_adicCompletionIntegers, LaurentSeriesRingEquiv_def,
+    valuation_compare, val_le_one_iff_eq_coe]
   exact ⟨F, rfl⟩
 
 /- Conversely, all elements in the unit ball inside the completion of `RatFunc K` come from a power
@@ -1203,16 +1207,14 @@ lemma powerSeriesRingEquiv_coe_apply (f : K⟦X⟧) :
 lemma LaurentSeriesRingEquiv_mem_valuationSubring (f : K⟦X⟧) :
     LaurentSeriesRingEquiv K f ∈ Valued.v.valuationSubring := by
   simp only [Valuation.mem_valuationSubring_iff]
-  have : (LaurentSeriesRingEquiv K) f =
-    (LaurentSeriesPkg K).compare ratfuncAdicComplPkg (f : K⸨X⸩) := rfl
-  rw [this, valuation_compare, val_le_one_iff_eq_coe]
+  rw [LaurentSeriesRingEquiv_def, valuation_compare, val_le_one_iff_eq_coe]
   use f
 
 lemma algebraMap_C_mem_adicCompletionIntegers (x : K) :
     ((LaurentSeriesRingEquiv K).toRingHom.comp HahnSeries.C) x ∈
       adicCompletionIntegers (RatFunc K) (idealX K) := by
   have : HahnSeries.C x = ofPowerSeries ℤ K (PowerSeries.C K x) := by
-    simp only [C_apply, ofPowerSeries_C]
+    simp [C_apply, ofPowerSeries_C]
   simp only [RingHom.comp_apply, RingEquiv.toRingHom_eq_coe, RingHom.coe_coe, this]
   apply LaurentSeriesRingEquiv_mem_valuationSubring
 
@@ -1230,9 +1232,9 @@ instance : IsScalarTower K ((idealX K).adicCompletionIntegers (RatFunc K))
 def powerSeriesAlgEquiv : K⟦X⟧ ≃ₐ[K] (idealX K).adicCompletionIntegers (RatFunc K) := by
   apply AlgEquiv.ofRingEquiv (f := powerSeriesRingEquiv K)
   intro a
-  simp only [PowerSeries.algebraMap_eq, RingHom.algebraMap_toAlgebra]
-  rw [← Subtype.coe_inj, powerSeriesRingEquiv_coe_apply]
-  rw [RingHom.codRestrict_apply _ _ (algebraMap_C_mem_adicCompletionIntegers K)]
+  rw [PowerSeries.algebraMap_eq, RingHom.algebraMap_toAlgebra, ← Subtype.coe_inj,
+    powerSeriesRingEquiv_coe_apply,
+    RingHom.codRestrict_apply _ _ (algebraMap_C_mem_adicCompletionIntegers K)]
   simp
 
 end PowerSeries

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -5,6 +5,7 @@ Authors: Aaron Anderson, María Inés de Frutos-Fernández, Filippo A. E. Nuccio
 -/
 import Mathlib.Data.Int.Interval
 import Mathlib.FieldTheory.RatFunc.AsPolynomial
+import Mathlib.RingTheory.AdicCompletion.Algebra
 import Mathlib.RingTheory.Binomial
 import Mathlib.RingTheory.HahnSeries.PowerSeries
 import Mathlib.RingTheory.HahnSeries.Summable
@@ -14,7 +15,6 @@ import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.Topology.UniformSpace.Cauchy
 import Mathlib.Algebra.Group.Int.TypeTags
 
-import Mathlib.RingTheory.AdicCompletion.Algebra
 
 /-!
 # Laurent Series
@@ -62,8 +62,8 @@ such that the `X`-adic valuation `v` satisfies `v (f - Q) < γ`.
 `LaurentSeries.exists_powerSeries_of_memIntegers` show that an element in the completion of
 `RatFunc K` is in the unit ball if and only if it comes from a power series through the isomorphism
 `LaurentSeriesRingEquiv`.
-* `LaurentSeries.powerSeriesRingEquiv` is the ring isomorphism between `K⟦X⟧` and the unit ball
-inside the `X`-adic completion of `RatFunc K`.
+* `LaurentSeries.powerSeriesAlgEquiv` is the `K`-algebra isomorphism between `K⟦X⟧`
+and the unit ball inside the `X`-adic completion of `RatFunc K`.
 
 ## Implementation details
 
@@ -77,18 +77,13 @@ that it is complete and contains `RatFunc K` as a dense subspace. The isomorphis
 equivalence, expressing the mathematical idea that the completion "is unique". It is
 `LaurentSeries.comparePkg`.
 * For applications to `K⟦X⟧` it is actually more handy to use the *inverse* of the above
-equivalence: `LaurentSeries.LaurentSeriesRingEquiv` is the *topological, ring equivalence*
-`K⸨X⸩ ≃+* RatFuncAdicCompl K`.
+equivalence: `LaurentSeries.LaurentSeriesAlgEquiv` is the *topological, algebra equivalence*
+`K⸨X⸩ ≃ₐ[K] RatFuncAdicCompl K`.
 * In order to compare `K⟦X⟧` with the valuation subring in the `X`-adic completion of
 `RatFunc K` we consider its alias `LaurentSeries.powerSeries_as_subring` as a subring of `K⸨X⸩`,
 that is itself clearly isomorphic (via the inverse of `LaurentSeries.powerSeriesEquivSubring`)
 to `K⟦X⟧`.
 
-## To Do
-* The `AdicCompletion` construction is currently done for ideals in rings and does not take into
-account the relation with algebra structures on the ring, hence it does not yield a `K`-algebra
-structure on the `X`-adic completion of `K⸨X⸩`. Once this will be available, we should update
-`LaurentSeries.LaurentSeriesRingEquiv` to an algebra equivalence.
 -/
 universe u
 
@@ -1079,6 +1074,7 @@ theorem algebraMap_apply (a : K) : algebraMap K K⸨X⸩ a = HahnSeries.C a := b
 instance : Algebra K (RatFuncAdicCompl K) :=
   RingHom.toAlgebra ((LaurentSeriesRingEquiv K).toRingHom.comp HahnSeries.C)
 
+/-- The algebra equivalence between `K⸨X⸩` and the `X`-adic completion of `RatFunc X` -/
 def LaurentSeriesAlgEquiv : K⸨X⸩ ≃ₐ[K] RatFuncAdicCompl K :=
   AlgEquiv.ofRingEquiv (f := LaurentSeriesRingEquiv K)
     (fun a ↦ by simp [RingHom.algebraMap_toAlgebra])
@@ -1232,7 +1228,7 @@ instance : IsScalarTower K ((idealX K).adicCompletionIntegers (RatFunc K))
 
 /-- The algebra isomorphism between `K⟦X⟧` and the unit ball inside the `X`-adic completion of
 `RatFunc K`. -/
-abbrev powerSeriesAlgEquiv : K⟦X⟧ ≃ₐ[K] (idealX K).adicCompletionIntegers (RatFunc K) := by
+def powerSeriesAlgEquiv : K⟦X⟧ ≃ₐ[K] (idealX K).adicCompletionIntegers (RatFunc K) := by
   apply AlgEquiv.ofRingEquiv (f := powerSeriesRingEquiv K)
   intro a
   simp only [PowerSeries.algebraMap_eq, RingHom.algebraMap_toAlgebra]

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -5,7 +5,6 @@ Authors: Aaron Anderson, María Inés de Frutos-Fernández, Filippo A. E. Nuccio
 -/
 import Mathlib.Data.Int.Interval
 import Mathlib.FieldTheory.RatFunc.AsPolynomial
-import Mathlib.RingTheory.AdicCompletion.Algebra
 import Mathlib.RingTheory.Binomial
 import Mathlib.RingTheory.HahnSeries.PowerSeries
 import Mathlib.RingTheory.HahnSeries.Summable

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -1192,14 +1192,36 @@ abbrev powerSeriesRingEquiv : K⟦X⟧ ≃+* (idealX K).adicCompletionIntegers (
   ((powerSeriesEquivSubring K).trans (LaurentSeriesRingEquiv K).subringMap).trans
     <| RingEquiv.subringCongr (powerSeries_ext_subring K)
 
-example : Algebra K ((idealX K).adicCompletionIntegers (RatFunc K)) := by
+instance : Algebra K ((idealX K).adicCompletionIntegers (RatFunc K)) := by
   unfold adicCompletionIntegers
   apply RingHom.toAlgebra
-  apply RingHom.codRestrict
+  apply ((LaurentSeriesRingEquiv K).toRingHom.comp HahnSeries.C).codRestrict
+  intro a
+  simp only [RingEquiv.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply,
+    C_apply]
+  simp only [Valuation.mem_valuationSubring_iff]
+  suffices (LaurentSeriesRingEquiv K) (single 0 a) =
+    (LaurentSeriesPkg K).compare ratfuncAdicComplPkg (single 0 a) by
+    rw [this, valuation_compare, val_le_one_iff_eq_coe]
+    use PowerSeries.C K a
+    simp
+  unfold LaurentSeriesRingEquiv
+  generalize single (0 : ℤ) a = f
+  suffices f = ratfuncAdicComplRingEquiv K
+    ((LaurentSeriesPkg K).compare ratfuncAdicComplPkg f) by
+    rw [this, ← RingEquiv.trans_apply]
+    rfl
+  suffices f = ((ratfuncAdicComplPkg.compare (LaurentSeriesPkg K)) ∘
+    ((LaurentSeriesPkg K).compare ratfuncAdicComplPkg)) f by
+      exact this
+  rw [AbstractCompletion.inverse_compare]
+  simp only [C_apply, id_eq]
 
 /-- The algebra isomorphism between `K⟦X⟧` and the unit ball inside the `X`-adic completion of
 `RatFunc K`. -/
-abbrev powerSeriesRingAlgEquiv : K⟦X⟧ ≃ₐ[K] (idealX K).adicCompletionIntegers (RatFunc K) :=
+abbrev powerSeriesAlgEquiv : K⟦X⟧ ≃ₐ[K] (idealX K).adicCompletionIntegers (RatFunc K) := by
+  apply AlgEquiv.ofRingEquiv (f := powerSeriesRingEquiv K)
+  intro a
   sorry
 
 end PowerSeries


### PR DESCRIPTION
Define an `Algebra K RatFuncAdicCompl K` instance on `RatFuncAdicCompl K` 
and promote the already defined ring equivalences to algebra equivalences `LaurentSeriesAlgEquiv : K⸨X⸩ ≃ₐ[K] RatFuncAdicCompl K` and `K⟦X⟧ ≃ₐ[K] (idealX K).adicCompletionIntegers (RatFunc K)`.



TODO : update docstring (on top of file)
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
