### PR TITLE
[Merged by Bors] - chore(SetTheory/Game/Impartial): miscellaneous cleanup

### DIFF
--- a/Mathlib/SetTheory/Game/Impartial.lean
+++ b/Mathlib/SetTheory/Game/Impartial.lean
@@ -24,25 +24,28 @@ open scoped PGame
 
 namespace PGame
 
-/-- The definition for an impartial game, defined using Conway induction. -/
-def ImpartialAux (G : PGame) : Prop :=
+private def ImpartialAux (G : PGame) : Prop :=
   (G ≈ -G) ∧ (∀ i, ImpartialAux (G.moveLeft i)) ∧ ∀ j, ImpartialAux (G.moveRight j)
 termination_by G
 
-theorem impartialAux_def {G : PGame} : G.ImpartialAux ↔
-    (G ≈ -G) ∧ (∀ i, ImpartialAux (G.moveLeft i)) ∧ ∀ j, ImpartialAux (G.moveRight j) := by
-  rw [ImpartialAux]
+/-- An impartial game is one that's equivalent to its negative, such that each left and right move
+is also impartial.
 
-/-- A typeclass on impartial games. -/
+Note that this is a slightly more general definition than the one that's usually in the literature,
+as we don't require `G ≡ -G`. Despite this, the Sprague-Grundy theorem still holds: see
+`SetTheory.PGame.equiv_nim_grundyValue`.
+
+In such a game, both players have the same payoffs at any given moment. -/
 class Impartial (G : PGame) : Prop where
   out : ImpartialAux G
 
-theorem impartial_iff_aux {G : PGame} : G.Impartial ↔ G.ImpartialAux :=
+private theorem impartial_iff_aux {G : PGame} : G.Impartial ↔ G.ImpartialAux :=
   ⟨fun h => h.1, fun h => ⟨h⟩⟩
 
 theorem impartial_def {G : PGame} :
-    G.Impartial ↔ (G ≈ -G) ∧ (∀ i, Impartial (G.moveLeft i)) ∧ ∀ j, Impartial (G.moveRight j) := by
-  simpa only [impartial_iff_aux] using impartialAux_def
+    G.Impartial ↔ G ≈ -G ∧ (∀ i, Impartial (G.moveLeft i)) ∧ ∀ j, Impartial (G.moveRight j) := by
+  simp_rw [impartial_iff_aux]
+  rw [ImpartialAux]
 
 namespace Impartial
 
@@ -115,7 +118,7 @@ theorem nonneg : ¬G < 0 := by
   exact (h.trans h').false
 
 /-- In an impartial game, either the first player always wins, or the second player always wins. -/
-theorem equiv_or_fuzzy_zero : (G ≈ 0) ∨ G ‖ 0 := by
+theorem equiv_or_fuzzy_zero : G ≈ 0 ∨ G ‖ 0 := by
   rcases lt_or_equiv_or_gt_or_fuzzy G 0 with (h | h | h | h)
   · exact ((nonneg G) h).elim
   · exact Or.inl h
@@ -123,11 +126,11 @@ theorem equiv_or_fuzzy_zero : (G ≈ 0) ∨ G ‖ 0 := by
   · exact Or.inr h
 
 @[simp]
-theorem not_equiv_zero_iff : ¬(G ≈ 0) ↔ G ‖ 0 :=
+theorem not_equiv_zero_iff : ¬ G ≈ 0 ↔ G ‖ 0 :=
   ⟨(equiv_or_fuzzy_zero G).resolve_left, Fuzzy.not_equiv⟩
 
 @[simp]
-theorem not_fuzzy_zero_iff : ¬G ‖ 0 ↔ (G ≈ 0) :=
+theorem not_fuzzy_zero_iff : ¬G ‖ 0 ↔ G ≈ 0 :=
   ⟨(equiv_or_fuzzy_zero G).resolve_right, Equiv.not_fuzzy⟩
 
 theorem add_self : G + G ≈ 0 :=
@@ -138,12 +141,12 @@ theorem mk'_add_self : (⟦G⟧ : Game) + ⟦G⟧ = 0 :=
   game_eq (add_self G)
 
 /-- This lemma doesn't require `H` to be impartial. -/
-theorem equiv_iff_add_equiv_zero (H : PGame) : (H ≈ G) ↔ (H + G ≈ 0) := by
+theorem equiv_iff_add_equiv_zero (H : PGame) : H ≈ G ↔ H + G ≈ 0 := by
   rw [equiv_iff_game_eq, ← add_right_cancel_iff (a := ⟦G⟧), mk'_add_self, ← quot_add,
     equiv_iff_game_eq, quot_zero]
 
 /-- This lemma doesn't require `H` to be impartial. -/
-theorem equiv_iff_add_equiv_zero' (H : PGame) : (G ≈ H) ↔ (G + H ≈ 0) := by
+theorem equiv_iff_add_equiv_zero' (H : PGame) : G ≈ H ↔ G + H ≈ 0 := by
   rw [equiv_iff_game_eq, ← add_left_cancel_iff, mk'_add_self, ← quot_add, equiv_iff_game_eq,
     Eq.comm, quot_zero]
 
@@ -165,14 +168,14 @@ theorem equiv_zero_iff_ge : (G ≈ 0) ↔ 0 ≤ G :=
 theorem fuzzy_zero_iff_gf : G ‖ 0 ↔ 0 ⧏ G :=
   ⟨And.right, fun h => ⟨lf_zero_iff.2 h, h⟩⟩
 
-theorem forall_leftMoves_fuzzy_iff_equiv_zero : (∀ i, G.moveLeft i ‖ 0) ↔ (G ≈ 0) := by
+theorem forall_leftMoves_fuzzy_iff_equiv_zero : (∀ i, G.moveLeft i ‖ 0) ↔ G ≈ 0 := by
   refine ⟨fun hb => ?_, fun hp i => ?_⟩
   · rw [equiv_zero_iff_le G, le_zero_lf]
     exact fun i => (hb i).1
   · rw [fuzzy_zero_iff_lf]
     exact hp.1.moveLeft_lf i
 
-theorem forall_rightMoves_fuzzy_iff_equiv_zero : (∀ j, G.moveRight j ‖ 0) ↔ (G ≈ 0) := by
+theorem forall_rightMoves_fuzzy_iff_equiv_zero : (∀ j, G.moveRight j ‖ 0) ↔ G ≈ 0 := by
   refine ⟨fun hb => ?_, fun hp i => ?_⟩
   · rw [equiv_zero_iff_ge G, zero_le_lf]
     exact fun i => (hb i).2

--- a/Mathlib/SetTheory/Game/Impartial.lean
+++ b/Mathlib/SetTheory/Game/Impartial.lean
@@ -130,7 +130,7 @@ theorem not_equiv_zero_iff : ¬ G ≈ 0 ↔ G ‖ 0 :=
   ⟨(equiv_or_fuzzy_zero G).resolve_left, Fuzzy.not_equiv⟩
 
 @[simp]
-theorem not_fuzzy_zero_iff : ¬G ‖ 0 ↔ G ≈ 0 :=
+theorem not_fuzzy_zero_iff : ¬ G ‖ 0 ↔ G ≈ 0 :=
   ⟨(equiv_or_fuzzy_zero G).resolve_right, Equiv.not_fuzzy⟩
 
 theorem add_self : G + G ≈ 0 :=

--- a/Mathlib/SetTheory/Game/Impartial.lean
+++ b/Mathlib/SetTheory/Game/Impartial.lean
@@ -35,7 +35,7 @@ Note that this is a slightly more general definition than the one that's usually
 as we don't require `G ≡ -G`. Despite this, the Sprague-Grundy theorem still holds: see
 `SetTheory.PGame.equiv_nim_grundyValue`.
 
-In such a game, both players have the same payoffs at any given moment. -/
+In such a game, both players have the same payoffs at any subposition. -/
 class Impartial (G : PGame) : Prop where
   out : ImpartialAux G
 

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -23,10 +23,9 @@ The pen-and-paper definition of nim defines the possible moves of `nim o` to be 
 However, this definition does not work for us because it would make the type of nim
 `Ordinal.{u} → SetTheory.PGame.{u + 1}`, which would make it impossible for us to state the
 Sprague-Grundy theorem, since that requires the type of `nim` to be
-`Ordinal.{u} → SetTheory.PGame.{u}`. For this reason, we
-instead use `o.toType` for the possible moves. You can use `to_left_moves_nim` and
-`to_right_moves_nim` to convert an ordinal less than `o` into a left or right move of `nim o`, and
-vice versa.
+`Ordinal.{u} → SetTheory.PGame.{u}`. For this reason, we instead use `o.toType` for the possible
+moves. We expose `toLeftMovesNim` and `toRightMovesNim` to conveniently convert an ordinal less than
+`o` into a left or right move of `nim o`, and vice versa.
 -/
 
 
@@ -50,20 +49,21 @@ noncomputable def nim (o : Ordinal.{u}) : PGame.{u} :=
 termination_by o
 decreasing_by all_goals exact ((enumIsoToType o).symm x).prop
 
+@[deprecated "you can use `rw [nim]` directly" (since := "2025-01-23")]
 theorem nim_def (o : Ordinal) : nim o =
     ⟨o.toType, o.toType,
       fun x => nim ((enumIsoToType o).symm x).val,
       fun x => nim ((enumIsoToType o).symm x).val⟩ := by
   rw [nim]
 
-theorem leftMoves_nim (o : Ordinal) : (nim o).LeftMoves = o.toType := by rw [nim_def]; rfl
-theorem rightMoves_nim (o : Ordinal) : (nim o).RightMoves = o.toType := by rw [nim_def]; rfl
+theorem leftMoves_nim (o : Ordinal) : (nim o).LeftMoves = o.toType := by rw [nim]; rfl
+theorem rightMoves_nim (o : Ordinal) : (nim o).RightMoves = o.toType := by rw [nim]; rfl
 
 theorem moveLeft_nim_hEq (o : Ordinal) :
-    HEq (nim o).moveLeft fun i : o.toType => nim ((enumIsoToType o).symm i) := by rw [nim_def]; rfl
+    HEq (nim o).moveLeft fun i : o.toType => nim ((enumIsoToType o).symm i) := by rw [nim]; rfl
 
 theorem moveRight_nim_hEq (o : Ordinal) :
-    HEq (nim o).moveRight fun i : o.toType => nim ((enumIsoToType o).symm i) := by rw [nim_def]; rfl
+    HEq (nim o).moveRight fun i : o.toType => nim ((enumIsoToType o).symm i) := by rw [nim]; rfl
 
 /-- Turns an ordinal less than `o` into a left move for `nim o` and vice versa. -/
 noncomputable def toLeftMovesNim {o : Ordinal} : Set.Iio o ≃ (nim o).LeftMoves :=
@@ -118,11 +118,11 @@ def rightMovesNimRecOn {o : Ordinal} {P : (nim o).RightMoves → Sort*} (i : (ni
   rw [← toRightMovesNim.apply_symm_apply i]; apply H
 
 instance isEmpty_nim_zero_leftMoves : IsEmpty (nim 0).LeftMoves := by
-  rw [nim_def]
+  rw [nim]
   exact isEmpty_toType_zero
 
 instance isEmpty_nim_zero_rightMoves : IsEmpty (nim 0).RightMoves := by
-  rw [nim_def]
+  rw [nim]
   exact isEmpty_toType_zero
 
 /-- `nim 0` has exactly the same moves as `0`. -/
@@ -164,7 +164,7 @@ theorem nim_one_moveRight (x) : (nim 1).moveRight x = nim 0 := by simp
 
 /-- `nim 1` has exactly the same moves as `star`. -/
 def nimOneRelabelling : nim 1 ≡r star := by
-  rw [nim_def]
+  rw [nim]
   refine ⟨?_, ?_, fun i => ?_, fun j => ?_⟩
   any_goals dsimp; apply Equiv.ofUnique
   all_goals simpa [enumIsoToType] using nimZeroRelabelling
@@ -175,7 +175,7 @@ theorem nim_one_equiv : nim 1 ≈ star :=
 @[simp]
 theorem nim_birthday (o : Ordinal) : (nim o).birthday = o := by
   induction' o using Ordinal.induction with o IH
-  rw [nim_def, birthday_def]
+  rw [nim, birthday_def]
   dsimp
   rw [max_eq_right le_rfl]
   convert lsub_typein o with i
@@ -184,7 +184,7 @@ theorem nim_birthday (o : Ordinal) : (nim o).birthday = o := by
 @[simp]
 theorem neg_nim (o : Ordinal) : -nim o = nim o := by
   induction' o using Ordinal.induction with o IH
-  rw [nim_def]; dsimp; congr <;> funext i <;> exact IH _ (Ordinal.typein_lt_self i)
+  rw [nim]; dsimp; congr <;> funext i <;> exact IH _ (Ordinal.typein_lt_self i)
 
 instance nim_impartial (o : Ordinal) : Impartial (nim o) := by
   induction' o using Ordinal.induction with o IH

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -186,7 +186,7 @@ theorem neg_nim (o : Ordinal) : -nim o = nim o := by
   induction' o using Ordinal.induction with o IH
   rw [nim]; dsimp; congr <;> funext i <;> exact IH _ (Ordinal.typein_lt_self i)
 
-instance nim_impartial (o : Ordinal) : Impartial (nim o) := by
+instance impartial_nim (o : Ordinal) : Impartial (nim o) := by
   induction' o using Ordinal.induction with o IH
   rw [impartial_def, neg_nim]
   refine ⟨equiv_rfl, fun i => ?_, fun i => ?_⟩ <;> simpa using IH _ (typein_lt_self _)


### PR DESCRIPTION
This PR does the following:

- Delete or private lemmas about `ImpartialAux`
- Deprecate `nim_def` (which has little reason to be part of the public API)
- Rename `nim_impartial` → `impartial_nim`
- Remove some redundant parentheses
- Improve docstrings

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
