### PR TITLE
[Merged by Bors] - feat(Order/WellFounded): a relation is well-founded iff there's no infinite decreasing sequence

### DIFF
--- a/Mathlib/Order/OrderIsoNat.lean
+++ b/Mathlib/Order/OrderIsoNat.lean
@@ -77,7 +77,9 @@ theorem not_acc_of_decreasing_seq (f : ((· > ·) : ℕ → ℕ → Prop) ↪r r
   rw [acc_iff_no_decreasing_seq, not_isEmpty_iff]
   exact ⟨⟨f, k, rfl⟩⟩
 
-/-- A relation is well-founded iff it doesn't have any infinite decreasing sequence. -/
+/-- A strict order relation is well-founded iff it doesn't have any infinite decreasing sequence.
+
+See `wellFounded_iff_no_descending_seq` for a version which works on any relation. -/
 theorem wellFounded_iff_no_descending_seq :
     WellFounded r ↔ IsEmpty (((· > ·) : ℕ → ℕ → Prop) ↪r r) := by
   constructor

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -81,7 +81,7 @@ theorem wellFounded_iff_has_min {r : α → α → Prop} :
 /-- A relation is well-founded iff it doesn't have any infinite decreasing sequence.
 
 See `RelEmbedding.wellFounded_iff_no_descending_seq` for a version on strict orders. -/
-theorem wellFounded_iff_no_descending_seq {r : α → α → Prop} :
+theorem wellFounded_iff_no_descending_seq :
     WellFounded r ↔ IsEmpty { f : ℕ → α // ∀ n, r (f (n + 1)) (f n) } := by
   rw [WellFounded.wellFounded_iff_has_min]
   refine ⟨fun hr ↦ ⟨fun ⟨f, hf⟩ ↦ ?_⟩, ?_⟩
@@ -93,6 +93,10 @@ theorem wellFounded_iff_no_descending_seq {r : α → α → Prop} :
     let f : ℕ → s := Nat.rec (Classical.indefiniteDescription _ hs) fun n IH ↦
       ⟨(hs' _ IH.2).choose, (hs' _ IH.2).choose_spec.1⟩
     exact ⟨⟨Subtype.val ∘ f, fun n ↦ (hs' _ (f n).2).choose_spec.2⟩⟩
+
+theorem not_rel_apply_succ [h : IsWellFounded α r] (f : ℕ → α) : ∃ n, ¬ r (f (n + 1)) (f n) := by
+  by_contra! hf
+  exact (wellFounded_iff_no_descending_seq.1 h.wf).elim ⟨f, hf⟩
 
 open Set
 

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -78,6 +78,22 @@ theorem wellFounded_iff_has_min {r : α → α → Prop} :
   by_contra hy'
   exact hm' y hy' hy
 
+/-- A relation is well-founded iff it doesn't have any infinite decreasing sequence.
+
+See `RelEmbedding.wellFounded_iff_no_descending_seq` for a version on strict orders. -/
+theorem wellFounded_iff_no_descending_seq {r : α → α → Prop} :
+    WellFounded r ↔ IsEmpty { f : ℕ → α // ∀ n, r (f (n + 1)) (f n) } := by
+  rw [WellFounded.wellFounded_iff_has_min]
+  refine ⟨fun hr ↦ ⟨fun ⟨f, hf⟩ ↦ ?_⟩, ?_⟩
+  · obtain ⟨_, ⟨n, rfl⟩, hn⟩ := hr _ (Set.range_nonempty f)
+    exact hn _ (Set.mem_range_self (n + 1)) (hf n)
+  · contrapose!
+    rw [not_isEmpty_iff]
+    rintro ⟨s, hs, hs'⟩
+    let f : ℕ → s := Nat.rec (Classical.indefiniteDescription _ hs) fun n IH ↦
+      ⟨(hs' _ IH.2).choose, (hs' _ IH.2).choose_spec.1⟩
+    exact ⟨⟨Subtype.val ∘ f, fun n ↦ (hs' _ (f n).2).choose_spec.2⟩⟩
+
 open Set
 
 /-- The supremum of a bounded, well-founded order -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Yes, this was somehow missing! Note that the existing `RelEmbedding.wellFounded_iff_no_descending_seq` assumes a strictly order relation, whereas this new version works on any relation whatsoever.

It might be possible to golf `RelEmbedding.wellFounded_iff_no_descending_seq` and the adjacent lemmas by using this new one, but I couldn't figure out an easy way to do so.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
