### PR TITLE
[Merged by Bors] - doc(Algebra/Category/Ring/Basic): Fix some docstrings

### DIFF
--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -166,7 +166,7 @@ instance forgetReflectIsos : (forget SemiRingCat).ReflectsIsomorphisms where
 
 end SemiRingCat
 
-/-- The category of semirings. -/
+/-- The category of rings. -/
 structure RingCat where
   private mk ::
   /-- The underlying type. -/
@@ -314,7 +314,7 @@ instance forgetReflectIsos : (forget RingCat).ReflectsIsomorphisms where
 
 end RingCat
 
-/-- The category of semirings. -/
+/-- The category of commutative semirings. -/
 structure CommSemiRingCat where
   private mk ::
   /-- The underlying type. -/
@@ -461,7 +461,7 @@ instance forgetReflectIsos : (forget CommSemiRingCat).ReflectsIsomorphisms where
 
 end CommSemiRingCat
 
-/-- The category of semirings. -/
+/-- The category of commutative rings. -/
 structure CommRingCat where
   private mk ::
   /-- The underlying type. -/


### PR DESCRIPTION
Fix a few docstrings for `RingCat`, `CommSemiRingCat`, and `CommRingCat` that were incorrectly copied from `SemiRingCat`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
