### PR TITLE
[Merged by Bors] - feat: establish additivity of MeromorphicAt.order under multiplication of meromorphic functions

### DIFF
--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -235,27 +235,18 @@ lemma order_of_locallyZero_mul_meromorphic {f g : 𝕜 → 𝕜} {x : 𝕜}
 theorem order_mul {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     (hf.mul hg).order = hf.order + hg.order := by
   -- Trivial cases: one of the functions vanishes around z₀
-  by_cases h₂f : hf.order = ⊤
+  cases' h₂f : hf.order with m h₂f
   · simp [hf.order_of_locallyZero_mul_meromorphic hg, h₂f]
-  by_cases h₂g : hg.order = ⊤
+  cases' h₂g : hg.order with n h₂f
   · simp [mul_comm f g, hg.order_of_locallyZero_mul_meromorphic hf, h₂g]
   -- Non-trivial case: both functions do not vanish around z₀
-  have h₃f := (hf.order.coe_untop h₂f).symm
-  have h₃g := (hg.order.coe_untop h₂g).symm
-  rw [h₃f, h₃g, ← WithTop.coe_add, MeromorphicAt.order_eq_int_iff]
-  obtain ⟨F, h₁F, h₂F, h₃F⟩ := (hf.order_eq_int_iff (hf.order.untop h₂f)).1 h₃f
-  obtain ⟨G, h₁G, h₂G, h₃G⟩ := (hg.order_eq_int_iff (hg.order.untop h₂g)).1 h₃g
-  clear h₃f h₃g
-  use F * G, h₁F.mul h₁G, by simp; tauto
-  rw [eventually_nhdsWithin_iff, eventually_nhds_iff] at *
-  obtain ⟨s, h₁s, h₂s, h₃s⟩ := h₃F
-  obtain ⟨t, h₁t, h₂t, h₃t⟩ := h₃G
-  use s ∩ t
-  constructor
-  · intro y h₁y h₂y
-    simp [h₁s y h₁y.1 h₂y, h₁t y h₁y.2 h₂y, zpow_add' (by left; exact sub_ne_zero_of_ne h₂y)]
-    group
-  · exact ⟨IsOpen.inter h₂s h₂t, Set.mem_inter h₃s h₃t⟩
+  rw [← WithTop.coe_add, order_eq_int_iff]
+  obtain ⟨F, h₁F, h₂F, h₃F⟩ := (hf.order_eq_int_iff _).1 h₂f
+  obtain ⟨G, h₁G, h₂G, h₃G⟩ := (hg.order_eq_int_iff _).1 h₂g
+  use F * G, h₁F.mul h₁G, by simp [h₂F, h₂G]
+  filter_upwards [self_mem_nhdsWithin, h₃F, h₃G] with a ha hfa hga
+  simp only [Pi.mul_apply, hfa, hga, zpow_add₀ (sub_ne_zero.mpr ha), smul_eq_mul]
+  ring
 
 lemma iff_eventuallyEq_zpow_smul_analyticAt {f : 𝕜 → E} {x : 𝕜} : MeromorphicAt f x ↔
     ∃ (n : ℤ) (g : 𝕜 → E), AnalyticAt 𝕜 g x ∧ ∀ᶠ z in 𝓝[≠] x, f z = (z - x) ^ n • g z := by

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -223,29 +223,29 @@ lemma _root_.AnalyticAt.meromorphicAt_order {f : 𝕜 → E} {x : 𝕜} (hf : An
     rcases (hf.order_eq_nat_iff _).mp hn.symm with ⟨g, h1, h2, h3⟩
     exact ⟨g, h1, h2, h3.filter_mono nhdsWithin_le_nhds⟩
 
-/-- Helper lemma for `MeromorphicAt.order_mul` -/
-lemma order_of_locallyZero_mul_meromorphic {f g : 𝕜 → 𝕜} {x : 𝕜}
-    (hf : MeromorphicAt f x)  (hg : MeromorphicAt g x) (h'f : hf.order = ⊤) :
-    (hf.mul hg).order = ⊤ := by
-  rw [order_eq_top_iff] at *
-  filter_upwards [h'f] with z hz using by simp [hz]
-
-/-- The order is additive when multiplying meromorphic functions -/
-theorem order_mul {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
-    (hf.mul hg).order = hf.order + hg.order := by
+/-- The order is additive when multiplying scalar-valued and vector-valued meromorphic functions. -/
+theorem order_smul {f : 𝕜 → 𝕜} {g : 𝕜 → E} {x : 𝕜}
+    (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    (hf.smul hg).order = hf.order + hg.order := by
   -- Trivial cases: one of the functions vanishes around z₀
   cases' h₂f : hf.order with m h₂f
-  · simp [hf.order_of_locallyZero_mul_meromorphic hg, h₂f]
+  · simp only [top_add, order_eq_top_iff] at h₂f ⊢
+    filter_upwards [h₂f] with z hz using by simp [hz]
   cases' h₂g : hg.order with n h₂f
-  · simp [mul_comm f g, hg.order_of_locallyZero_mul_meromorphic hf, h₂g]
+  · simp only [add_top, order_eq_top_iff] at h₂g ⊢
+    filter_upwards [h₂g] with z hz using by simp [hz]
   -- Non-trivial case: both functions do not vanish around z₀
   rw [← WithTop.coe_add, order_eq_int_iff]
   obtain ⟨F, h₁F, h₂F, h₃F⟩ := (hf.order_eq_int_iff _).1 h₂f
   obtain ⟨G, h₁G, h₂G, h₃G⟩ := (hg.order_eq_int_iff _).1 h₂g
-  use F * G, h₁F.mul h₁G, by simp [h₂F, h₂G]
+  use F • G, h₁F.smul h₁G, by simp [h₂F, h₂G]
   filter_upwards [self_mem_nhdsWithin, h₃F, h₃G] with a ha hfa hga
-  simp only [Pi.mul_apply, hfa, hga, zpow_add₀ (sub_ne_zero.mpr ha), smul_eq_mul]
-  ring
+  simp [hfa, hga, smul_comm (F a), zpow_add₀ (sub_ne_zero.mpr ha), mul_smul]
+
+/-- The order is additive when multiplying meromorphic functions. -/
+theorem order_mul {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    (hf.mul hg).order = hf.order + hg.order :=
+  hf.order_smul hg
 
 lemma iff_eventuallyEq_zpow_smul_analyticAt {f : 𝕜 → E} {x : 𝕜} : MeromorphicAt f x ↔
     ∃ (n : ℤ) (g : 𝕜 → E), AnalyticAt 𝕜 g x ∧ ∀ᶠ z in 𝓝[≠] x, f z = (z - x) ^ n • g z := by

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -227,9 +227,8 @@ lemma _root_.AnalyticAt.meromorphicAt_order {f : 𝕜 → E} {x : 𝕜} (hf : An
 lemma order_of_locallyZero_mul_meromorphic {f g : 𝕜 → 𝕜} {x : 𝕜}
     (hf : MeromorphicAt f x)  (hg : MeromorphicAt g x) (h'f : hf.order = ⊤) :
     (hf.mul hg).order = ⊤ := by
-  rw [order_eq_top_iff, eventually_nhdsWithin_iff, eventually_nhds_iff] at *
-  obtain ⟨t, h₁t, h₂t⟩ := h'f
-  use t, fun y h₁y h₂y ↦ (by rw [Pi.mul_apply, h₁t y h₁y h₂y, zero_mul])
+  rw [order_eq_top_iff] at *
+  filter_upwards [h'f] with z hz using by simp [hz]
 
 /-- The order is additive when multiplying meromorphic functions -/
 theorem order_mul {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -223,6 +223,40 @@ lemma _root_.AnalyticAt.meromorphicAt_order {f : 𝕜 → E} {x : 𝕜} (hf : An
     rcases (hf.order_eq_nat_iff _).mp hn.symm with ⟨g, h1, h2, h3⟩
     exact ⟨g, h1, h2, h3.filter_mono nhdsWithin_le_nhds⟩
 
+/-- Helper lemma for `MeromorphicAt.order_mul` -/
+lemma order_of_locallyZero_mul_meromorphic {f g : 𝕜 → 𝕜} {x : 𝕜}
+    (hf : MeromorphicAt f x)  (hg : MeromorphicAt g x) (h'f : hf.order = ⊤) :
+    (hf.mul hg).order = ⊤ := by
+  rw [order_eq_top_iff, eventually_nhdsWithin_iff, eventually_nhds_iff] at *
+  obtain ⟨t, h₁t, h₂t⟩ := h'f
+  use t, fun y h₁y h₂y ↦ (by rw [Pi.mul_apply, h₁t y h₁y h₂y, zero_mul])
+
+/-- The order is additive when multiplying meromorphic functions -/
+theorem order_mul {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    (hf.mul hg).order = hf.order + hg.order := by
+  -- Trivial cases: one of the functions vanishes around z₀
+  by_cases h₂f : hf.order = ⊤
+  · simp [hf.order_of_locallyZero_mul_meromorphic hg, h₂f]
+  by_cases h₂g : hg.order = ⊤
+  · simp [mul_comm f g, hg.order_of_locallyZero_mul_meromorphic hf, h₂g]
+  -- Non-trivial case: both functions do not vanish around z₀
+  have h₃f := (hf.order.coe_untop h₂f).symm
+  have h₃g := (hg.order.coe_untop h₂g).symm
+  rw [h₃f, h₃g, ← WithTop.coe_add, MeromorphicAt.order_eq_int_iff]
+  obtain ⟨F, h₁F, h₂F, h₃F⟩ := (hf.order_eq_int_iff (hf.order.untop h₂f)).1 h₃f
+  obtain ⟨G, h₁G, h₂G, h₃G⟩ := (hg.order_eq_int_iff (hg.order.untop h₂g)).1 h₃g
+  clear h₃f h₃g
+  use F * G, h₁F.mul h₁G, by simp; tauto
+  rw [eventually_nhdsWithin_iff, eventually_nhds_iff] at *
+  obtain ⟨s, h₁s, h₂s, h₃s⟩ := h₃F
+  obtain ⟨t, h₁t, h₂t, h₃t⟩ := h₃G
+  use s ∩ t
+  constructor
+  · intro y h₁y h₂y
+    simp [h₁s y h₁y.1 h₂y, h₁t y h₁y.2 h₂y, zpow_add' (by left; exact sub_ne_zero_of_ne h₂y)]
+    group
+  · exact ⟨IsOpen.inter h₂s h₂t, Set.mem_inter h₃s h₃t⟩
+
 lemma iff_eventuallyEq_zpow_smul_analyticAt {f : 𝕜 → E} {x : 𝕜} : MeromorphicAt f x ↔
     ∃ (n : ℤ) (g : 𝕜 → E), AnalyticAt 𝕜 g x ∧ ∀ᶠ z in 𝓝[≠] x, f z = (z - x) ^ n • g z := by
   refine ⟨fun ⟨n, hn⟩ ↦ ⟨-n, _, ⟨hn, eventually_nhdsWithin_iff.mpr ?_⟩⟩, ?_⟩


### PR DESCRIPTION
These theorems are used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
