### PR TITLE
[Merged by Bors] - feat(RingTheory/Artinian): an artinian local reduced ring is a field

### DIFF
--- a/Mathlib/RingTheory/Artinian/Ring.lean
+++ b/Mathlib/RingTheory/Artinian/Ring.lean
@@ -88,8 +88,8 @@ theorem isNilpotent_jacobson_bot : IsNilpotent (Ideal.jacobson (⊥ : Ideal R)) 
 variable (R) in
 /-- Commutative artinian reduced local ring is a field. -/
 theorem isField_of_isReduced_of_isLocalRing [IsReduced R] [IsLocalRing R] : IsField R :=
-  let e : R ≃+* _ := (IsArtinianRing.equivPi R).trans (RingEquiv.piUnique _)
-  MulEquiv.isField _ (Ideal.Quotient.field _).toIsField e.toMulEquiv
+  (IsArtinianRing.equivPi R).trans (RingEquiv.piUnique _) |>.toMulEquiv.isField
+    _ (Ideal.Quotient.field _).toIsField
 
 section Localization
 

--- a/Mathlib/RingTheory/Artinian/Ring.lean
+++ b/Mathlib/RingTheory/Artinian/Ring.lean
@@ -91,9 +91,6 @@ theorem isField_of_isReduced_of_isLocalRing [IsReduced R] [IsLocalRing R] : IsFi
   let e : R ≃+* _ := (IsArtinianRing.equivPi R).trans (RingEquiv.piUnique _)
   MulEquiv.isField _ (Ideal.Quotient.field _).toIsField e.toMulEquiv
 
-noncomputable instance [IsReduced R] [IsLocalRing R] : Field R :=
-    (isField_of_isReduced_of_isLocalRing R).toField
-
 section Localization
 
 variable (S : Submonoid R) (L : Type*) [CommSemiring L] [Algebra R L] [IsLocalization S L]

--- a/Mathlib/RingTheory/Artinian/Ring.lean
+++ b/Mathlib/RingTheory/Artinian/Ring.lean
@@ -3,8 +3,10 @@ Copyright (c) 2021 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Junyan Xu, Jujian Zhang
 -/
+import Mathlib.Algebra.Field.Equiv
 import Mathlib.RingTheory.Artinian.Module
 import Mathlib.RingTheory.Localization.Defs
+import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
 import Mathlib.RingTheory.Nakayama
 
 /-!
@@ -82,6 +84,15 @@ theorem isNilpotent_jacobson_bot : IsNilpotent (Ideal.jacobson (⊥ : Ideal R)) 
   refine hxJ (mem_annihilator.2 fun y hy => (mem_bot R).1 ?_)
   refine this (mul_mem_mul (mem_span_singleton_self x) ?_)
   rwa [← hn (n + 1) (Nat.le_succ _)]
+
+variable (R) in
+/-- Commutative artinian reduced local ring is a field. -/
+theorem isField_of_isReduced_of_isLocalRing [IsReduced R] [IsLocalRing R] : IsField R :=
+  let e : R ≃+* _ := (IsArtinianRing.equivPi R).trans (RingEquiv.piUnique _)
+  MulEquiv.isField _ (Ideal.Quotient.field _).toIsField e.toMulEquiv
+
+noncomputable instance [IsReduced R] [IsLocalRing R] : Field R :=
+    (isField_of_isReduced_of_isLocalRing R).toField
 
 section Localization
 


### PR DESCRIPTION
Prove that an artinian local reduced ring is a field.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
