### PR TITLE
[Merged by Bors] - feat(Algebra/Algebra/Prod): simple theorems about `fst`, `snd` and `prod`

### DIFF
--- a/Mathlib/Algebra/Algebra/Prod.lean
+++ b/Mathlib/Algebra/Algebra/Prod.lean
@@ -61,7 +61,15 @@ def fst : A × B →ₐ[R] A :=
 def snd : A × B →ₐ[R] B :=
   { RingHom.snd A B with commutes' := fun _r => rfl }
 
-variable {R A B}
+variable {A B}
+
+@[simp]
+theorem fst_apply (a) : fst R A B a = a.1 := rfl
+
+@[simp]
+theorem snd_apply (a) : snd R A B a = a.2 := rfl
+
+variable {R}
 
 /-- The `Pi.prod` of two morphisms is a morphism. -/
 @[simps!]
@@ -81,8 +89,11 @@ theorem fst_prod (f : A →ₐ[R] B) (g : A →ₐ[R] C) : (fst R B C).comp (pro
 theorem snd_prod (f : A →ₐ[R] B) (g : A →ₐ[R] C) : (snd R B C).comp (prod f g) = g := by ext; rfl
 
 @[simp]
-theorem prod_fst_snd : prod (fst R A B) (snd R A B) = 1 :=
-  DFunLike.coe_injective Pi.prod_fst_snd
+theorem prod_fst_snd : prod (fst R A B) (snd R A B) = AlgHom.id R _ := rfl
+
+theorem prod_comp {C' : Type*} [Semiring C'] [Algebra R C']
+    (f : A →ₐ[R] B) (g : B →ₐ[R] C) (g' : B →ₐ[R] C') :
+    (g.prod g').comp f = (g.comp f).prod (g'.comp f) := rfl
 
 /-- Taking the product of two maps with the same domain is equivalent to taking the product of
 their codomains. -/


### PR DESCRIPTION
Very basic theorems about `AlgHom.fst`, `AlgHom.snd` and `AlgHom.prod`.
Counterparts for `LinearMap` already exist.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
