### PR TITLE
[Merged by Bors] - chore(Data/Nat/Choose/Sum): refined the statement of `Finset.sum_antidiagonal_choose_add`.

### DIFF
--- a/Mathlib/Data/Nat/Choose/Sum.lean
+++ b/Mathlib/Data/Nat/Choose/Sum.lean
@@ -230,9 +230,9 @@ theorem sum_antidiagonal_choose_succ_mul (f : ℕ → ℕ → R) (n : ℕ) :
   simpa only [nsmul_eq_mul] using sum_antidiagonal_choose_succ_nsmul f n
 
 theorem sum_antidiagonal_choose_add (d n : ℕ) :
-    (∑ ij ∈ antidiagonal n, (d + ij.2).choose d) = (d + n).choose d + (d + n).choose (d + 1) := by
+    (∑ ij ∈ antidiagonal n, (d + ij.2).choose d) = (d + n + 1).choose (d + 1) := by
   induction n with
   | zero => simp
-  | succ n hn => simpa [Nat.sum_antidiagonal_succ] using hn
+  | succ n hn => rw [Nat.sum_antidiagonal_succ, hn, Nat.choose_succ_succ (d + (n + 1)), ← add_assoc]
 
 end Finset

--- a/Mathlib/RingTheory/PowerSeries/WellKnown.lean
+++ b/Mathlib/RingTheory/PowerSeries/WellKnown.lean
@@ -93,8 +93,7 @@ theorem mk_one_pow_eq_mk_choose_add :
       rw [pow_add, hd, pow_one, mul_comm, coeff_mul]
       simp_rw [coeff_mk, Pi.one_apply, one_mul]
       norm_cast
-      rw [Finset.sum_antidiagonal_choose_add, ← Nat.choose_succ_succ, Nat.succ_eq_add_one,
-        add_right_comm]
+      rw [Finset.sum_antidiagonal_choose_add, add_right_comm]
 
 /--
 Given a natural number `d : ℕ` and a commutative ring `S`, `PowerSeries.invOneSubPow S d` is the


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


In this pull request, we have refined the statement of the theorem `Nat.sum_antidiagonal_choose_add`. The original statement looked like:
```
theorem sum_antidiagonal_choose_add (d n : ℕ) :
    (∑ ij ∈ antidiagonal n, (d + ij.2).choose d) =
    (d + n).choose d + (d + n).choose (succ d) := ...
```
We change it to:
```
theorem sum_antidiagonal_choose_add (d n : ℕ) :
    (∑ ij ∈ antidiagonal n, (d + ij.2).choose d) =
    (d + n + 1).choose (d + 1) := ...
```
which looks much nicer.