### PR TITLE
[Merged by Bors] - feat: tautological action of `RelIso` on the ground type

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -749,6 +749,7 @@ import Mathlib.Algebra.Order.Floor.Div
 import Mathlib.Algebra.Order.Floor.Prime
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Group.Action
+import Mathlib.Algebra.Order.Group.Action.End
 import Mathlib.Algebra.Order.Group.Action.Synonym
 import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Group.Bounds

--- a/Mathlib/Algebra/Group/Action/End.lean
+++ b/Mathlib/Algebra/Group/Action/End.lean
@@ -45,6 +45,8 @@ This is generalized to bundled endomorphisms by:
 * `RingHom.applyMulSemiringAction`
 * `RingAut.applyMulSemiringAction`
 * `AlgEquiv.applyMulSemiringAction`
+* `RelHom.applyMulAction`
+* `RelEmbedding.applyMulAction`
 * `RelIso.applyMulAction`
 -/
 instance applyMulAction : MulAction (Function.End α) α where

--- a/Mathlib/Algebra/Group/Action/End.lean
+++ b/Mathlib/Algebra/Group/Action/End.lean
@@ -45,6 +45,7 @@ This is generalized to bundled endomorphisms by:
 * `RingHom.applyMulSemiringAction`
 * `RingAut.applyMulSemiringAction`
 * `AlgEquiv.applyMulSemiringAction`
+* `RelIso.applyMulAction`
 -/
 instance applyMulAction : MulAction (Function.End α) α where
   smul := (· <| ·)

--- a/Mathlib/Algebra/Order/Group/Action/End.lean
+++ b/Mathlib/Algebra/Order/Group/Action/End.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Group.Action.Faithful
-import Mathlib.Algebra.Group.Opposite
 import Mathlib.Algebra.Order.Group.End
 import Mathlib.Order.RelIso.Basic
 

--- a/Mathlib/Algebra/Order/Group/Action/End.lean
+++ b/Mathlib/Algebra/Order/Group/Action/End.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Action.Faithful
+import Mathlib.Algebra.Group.Opposite
+import Mathlib.Order.RelIso.Basic
+import Mathlib.Order.RelIso.Group
+
+/-!
+# Tautological action by relation automorphisms
+-/
+
+assert_not_exists MonoidWithZero
+
+namespace RelIso
+variable {α : Type*} {r : α → α → Prop}
+
+/-- The tautological action by `r ≃r r` on `α`. -/
+instance applyMulAction : MulAction (r ≃r r) α where
+  smul := (⇑)
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
+
+/-- The tautological action by `r ≃r r` on `α`. -/
+instance applyOpMulAction : MulAction (r ≃r r)ᵐᵒᵖ α where
+  smul e := e.unop.symm
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
+
+@[simp] lemma smul_def (f : r ≃r r) (a : α) : f • a = f a := rfl
+@[simp] lemma op_smul_def (f : (r ≃r r)ᵐᵒᵖ) (a : α) : f • a = f.unop.symm a := rfl
+
+instance apply_faithfulSMul : FaithfulSMul (r ≃r r) α where eq_of_smul_eq_smul h := RelIso.ext h
+
+instance apply_op_faithfulSMul : FaithfulSMul (r ≃r r)ᵐᵒᵖ α where
+  eq_of_smul_eq_smul h := MulOpposite.unop_injective <| symm_bijective.injective <| RelIso.ext h
+
+end RelIso

--- a/Mathlib/Algebra/Order/Group/Action/End.lean
+++ b/Mathlib/Algebra/Order/Group/Action/End.lean
@@ -5,14 +5,44 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Group.Action.Faithful
 import Mathlib.Algebra.Group.Opposite
+import Mathlib.Algebra.Order.Group.End
 import Mathlib.Order.RelIso.Basic
-import Mathlib.Order.RelIso.Group
 
 /-!
 # Tautological action by relation automorphisms
 -/
 
 assert_not_exists MonoidWithZero
+
+namespace RelHom
+variable {α : Type*} {r : α → α → Prop}
+
+/-- The tautological action by `r →r r` on `α`. -/
+instance applyMulAction : MulAction (r →r r) α where
+  smul := (⇑)
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
+
+@[simp] lemma smul_def (f : r →r r) (a : α) : f • a = f a := rfl
+
+instance apply_faithfulSMul : FaithfulSMul (r →r r) α where eq_of_smul_eq_smul h := RelHom.ext h
+
+end RelHom
+
+namespace RelEmbedding
+variable {α : Type*} {r : α → α → Prop}
+
+/-- The tautological action by `r ↪r r` on `α`. -/
+instance applyMulAction : MulAction (r ↪r r) α where
+  smul := (⇑)
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
+
+@[simp] lemma smul_def (f : r ↪r r) (a : α) : f • a = f a := rfl
+
+instance apply_faithfulSMul : FaithfulSMul (r ↪r r) α where eq_of_smul_eq_smul h := ext h
+
+end RelEmbedding
 
 namespace RelIso
 variable {α : Type*} {r : α → α → Prop}

--- a/Mathlib/Algebra/Order/Group/Action/End.lean
+++ b/Mathlib/Algebra/Order/Group/Action/End.lean
@@ -23,18 +23,8 @@ instance applyMulAction : MulAction (r ≃r r) α where
   one_smul _ := rfl
   mul_smul _ _ _ := rfl
 
-/-- The tautological action by `r ≃r r` on `α`. -/
-instance applyOpMulAction : MulAction (r ≃r r)ᵐᵒᵖ α where
-  smul e := e.unop.symm
-  one_smul _ := rfl
-  mul_smul _ _ _ := rfl
-
 @[simp] lemma smul_def (f : r ≃r r) (a : α) : f • a = f a := rfl
-@[simp] lemma op_smul_def (f : (r ≃r r)ᵐᵒᵖ) (a : α) : f • a = f.unop.symm a := rfl
 
 instance apply_faithfulSMul : FaithfulSMul (r ≃r r) α where eq_of_smul_eq_smul h := RelIso.ext h
-
-instance apply_op_faithfulSMul : FaithfulSMul (r ≃r r)ᵐᵒᵖ α where
-  eq_of_smul_eq_smul h := MulOpposite.unop_injective <| symm_bijective.injective <| RelIso.ext h
 
 end RelIso

--- a/Mathlib/Algebra/Order/Group/End.lean
+++ b/Mathlib/Algebra/Order/Group/End.lean
@@ -23,6 +23,9 @@ instance : Monoid (r →r r) where
   one_mul _ := rfl
   mul_one _ := rfl
 
+lemma one_def : (1 : r →r r) = .id r := rfl
+lemma mul_def (f g : r →r r) : (f * g) = f.comp g := rfl
+
 @[simp] lemma coe_one : ⇑(1 : r →r r) = id := rfl
 @[simp] lemma coe_mul (f g : r →r r) : ⇑(f * g) = f ∘ g := rfl
 
@@ -40,6 +43,9 @@ instance : Monoid (r ↪r r) where
   one_mul _ := rfl
   mul_one _ := rfl
 
+lemma one_def : (1 : r ↪r r) = .refl r := rfl
+lemma mul_def (f g : r ↪r r) : (f * g) = g.trans f := rfl
+
 @[simp] lemma coe_one : ⇑(1 : r ↪r r) = id := rfl
 @[simp] lemma coe_mul (f g : r ↪r r) : ⇑(f * g) = f ∘ g := rfl
 
@@ -51,24 +57,22 @@ end RelEmbedding
 namespace RelIso
 
 instance : Group (r ≃r r) where
-  one := RelIso.refl r
+  one := .refl r
   mul f₁ f₂ := f₂.trans f₁
-  inv := RelIso.symm
+  inv := .symm
   mul_assoc _ _ _ := rfl
   one_mul _ := ext fun _ => rfl
   mul_one _ := ext fun _ => rfl
   inv_mul_cancel f := ext f.symm_apply_apply
 
-@[simp]
-theorem coe_one : ((1 : r ≃r r) : α → α) = id :=
-  rfl
+lemma one_def : (1 : r ≃r r) = .refl r := rfl
+lemma mul_def (f g : r ≃r r) : (f * g) = g.trans f := rfl
 
-@[simp]
-theorem coe_mul (e₁ e₂ : r ≃r r) : ((e₁ * e₂) : α → α) = e₁ ∘ e₂ :=
-  rfl
+@[simp] lemma coe_one : ((1 : r ≃r r) : α → α) = id := rfl
+@[simp] lemma coe_mul (e₁ e₂ : r ≃r r) : ((e₁ * e₂) : α → α) = e₁ ∘ e₂ := rfl
 
-theorem mul_apply (e₁ e₂ : r ≃r r) (x : α) : (e₁ * e₂) x = e₁ (e₂ x) :=
-  rfl
+lemma one_apply (x : α) : (1 : r ≃r r) x = x := rfl
+lemma mul_apply (e₁ e₂ : r ≃r r) (x : α) : (e₁ * e₂) x = e₁ (e₂ x) := rfl
 
 @[simp]
 theorem inv_apply_self (e : r ≃r r) (x) : e⁻¹ (e x) = x :=

--- a/Mathlib/Algebra/Order/Group/End.lean
+++ b/Mathlib/Algebra/Order/Group/End.lean
@@ -14,6 +14,40 @@ assert_not_exists MulAction MonoidWithZero
 
 variable {α : Type*} {r : α → α → Prop}
 
+namespace RelHom
+
+instance : Monoid (r →r r) where
+  one := .id r
+  mul := .comp
+  mul_assoc _ _ _ := rfl
+  one_mul _ := rfl
+  mul_one _ := rfl
+
+@[simp] lemma coe_one : ⇑(1 : r →r r) = id := rfl
+@[simp] lemma coe_mul (f g : r →r r) : ⇑(f * g) = f ∘ g := rfl
+
+lemma one_apply (a : α) : (1 : r →r r) a = a := rfl
+lemma mul_apply (e₁ e₂ : r →r r) (x : α) : (e₁ * e₂) x = e₁ (e₂ x) := rfl
+
+end RelHom
+
+namespace RelEmbedding
+
+instance : Monoid (r ↪r r) where
+  one := .refl r
+  mul f g := g.trans f
+  mul_assoc _ _ _ := rfl
+  one_mul _ := rfl
+  mul_one _ := rfl
+
+@[simp] lemma coe_one : ⇑(1 : r ↪r r) = id := rfl
+@[simp] lemma coe_mul (f g : r ↪r r) : ⇑(f * g) = f ∘ g := rfl
+
+lemma one_apply (a : α) : (1 : r ↪r r) a = a := rfl
+lemma mul_apply (e₁ e₂ : r ↪r r) (x : α) : (e₁ * e₂) x = e₁ (e₂ x) := rfl
+
+end RelEmbedding
+
 namespace RelIso
 
 instance : Group (r ≃r r) where


### PR DESCRIPTION
This will be useful to make order isomorphisms act on flags.

Also add the monoid structure on `r →r r` and `r ↪r r` and the corresponding tautological actions.

From MiscYD

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
