### PR TITLE
[Merged by Bors] - chore(Algebra/Group/Action): group similar lemmas

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -276,6 +276,7 @@ import Mathlib.Algebra.Group.Action.Defs
 import Mathlib.Algebra.Group.Action.End
 import Mathlib.Algebra.Group.Action.Equidecomp
 import Mathlib.Algebra.Group.Action.Faithful
+import Mathlib.Algebra.Group.Action.Hom
 import Mathlib.Algebra.Group.Action.Opposite
 import Mathlib.Algebra.Group.Action.Option
 import Mathlib.Algebra.Group.Action.Pi

--- a/Mathlib/Algebra/AddConstMap/Basic.lean
+++ b/Mathlib/Algebra/AddConstMap/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
+import Mathlib.Algebra.Group.Action.End
 import Mathlib.Algebra.Group.Action.Pi
 import Mathlib.Algebra.GroupPower.IterateHom
 import Mathlib.Algebra.Module.NatInt

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -583,8 +583,8 @@ protected def counit' : coextendScalars f ⋙ restrictScalars f ⟶ 𝟭 (Module
         dsimp
         rw [CoextendScalars.smul_apply, one_mul, ← LinearMap.map_smul]
         congr
-        change f r = (f r) • (1 : S)
-        rw [smul_eq_mul (a := f r) (a' := 1), mul_one] }
+        change f r = f r • (1 : S)
+        rw [smul_eq_mul (f r) 1, mul_one] }
 
 end RestrictionCoextensionAdj
 

--- a/Mathlib/Algebra/GradedMonoid.lean
+++ b/Mathlib/Algebra/GradedMonoid.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.BigOperators.Group.List.Lemmas
-import Mathlib.Algebra.Group.Action.End
+import Mathlib.Algebra.Group.Action.Hom
 import Mathlib.Algebra.Group.Submonoid.Defs
 import Mathlib.Data.List.FinRange
 import Mathlib.Data.SetLike.Basic

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -53,8 +53,23 @@ variable {M N G H α β γ δ : Type*}
 @[to_additive "See also `AddMonoid.toAddAction`"]
 instance (priority := 910) Mul.toSMul (α : Type*) [Mul α] : SMul α α := ⟨(· * ·)⟩
 
+/-- Like `Mul.toSMul`, but multiplies on the right.
+
+See also `Monoid.toOppositeMulAction` and `MonoidWithZero.toOppositeMulActionWithZero`. -/
+@[to_additive "Like `Add.toVAdd`, but adds on the right.
+
+  See also `AddMonoid.toOppositeAddAction`."]
+instance (priority := 910) Mul.toSMulMulOpposite (α : Type*) [Mul α] : SMul αᵐᵒᵖ α where
+  smul a b := b * a.unop
+
 @[to_additive (attr := simp)]
-lemma smul_eq_mul (α : Type*) [Mul α] {a a' : α} : a • a' = a * a' := rfl
+lemma smul_eq_mul {α : Type*} [Mul α] (a b : α) : a • b = a * b := rfl
+
+@[to_additive]
+lemma op_smul_eq_mul {α : Type*} [Mul α] (a b : α) : MulOpposite.op a • b = b * a := rfl
+
+@[to_additive (attr := simp)]
+lemma MulOpposite.smul_eq_mul_unop [Mul α] (a : αᵐᵒᵖ) (b : α) : a • b = b * a.unop := rfl
 
 /-- Type class for additive monoid actions. -/
 class AddAction (G : Type*) (P : Type*) [AddMonoid G] extends VAdd G P where

--- a/Mathlib/Algebra/Group/Action/End.lean
+++ b/Mathlib/Algebra/Group/Action/End.lean
@@ -3,8 +3,9 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Action.Defs
-import Mathlib.Algebra.Group.Hom.Defs
+import Mathlib.Algebra.Group.Action.Faithful
+import Mathlib.Algebra.Group.Action.Hom
+import Mathlib.Algebra.Group.TypeTags.Hom
 import Mathlib.Logic.Embedding.Basic
 
 /-!
@@ -34,10 +35,8 @@ open Function (Injective Surjective)
 
 variable {M N α : Type*}
 
-section
-variable [Monoid M] [MulAction M α]
-
 namespace MulAction
+variable [Monoid M] [MulAction M α]
 
 variable (M α) in
 /-- Embedding of `α` into functions `M → α` induced by a multiplicative action of `M` on `α`. -/
@@ -51,77 +50,7 @@ lemma toFun_apply (x : M) (y : α) : MulAction.toFun M α y x = x • y := rfl
 
 end MulAction
 
-/-- Push forward the action of `R` on `M` along a compatible surjective map `f : R →* S`.
-
-See also `Function.Surjective.distribMulActionLeft` and `Function.Surjective.moduleLeft`.
--/
-@[to_additive
-"Push forward the action of `R` on `M` along a compatible surjective map `f : R →+ S`."]
-abbrev Function.Surjective.mulActionLeft {R S M : Type*} [Monoid R] [MulAction R M] [Monoid S]
-    [SMul S M] (f : R →* S) (hf : Surjective f) (hsmul : ∀ (c) (x : M), f c • x = c • x) :
-    MulAction S M where
-  smul := (· • ·)
-  one_smul b := by rw [← f.map_one, hsmul, one_smul]
-  mul_smul := hf.forall₂.mpr fun a b x ↦ by simp only [← f.map_mul, hsmul, mul_smul]
-
-namespace MulAction
-
-variable (α)
-
-/-- A multiplicative action of `M` on `α` and a monoid homomorphism `N → M` induce
-a multiplicative action of `N` on `α`.
-
-See note [reducible non-instances]. -/
-@[to_additive]
-abbrev compHom [Monoid N] (g : N →* M) : MulAction N α where
-  smul := SMul.comp.smul g
-  one_smul _ := by simpa [(· • ·)] using MulAction.one_smul ..
-  mul_smul _ _ _ := by simpa [(· • ·)] using MulAction.mul_smul ..
-
-/-- An additive action of `M` on `α` and an additive monoid homomorphism `N → M` induce
-an additive action of `N` on `α`.
-
-See note [reducible non-instances]. -/
-add_decl_doc AddAction.compHom
-
-@[to_additive]
-lemma compHom_smul_def
-    {E F G : Type*} [Monoid E] [Monoid F] [MulAction F G] (f : E →* F) (a : E) (x : G) :
-    letI : MulAction E G := MulAction.compHom _ f
-    a • x = (f a) • x := rfl
-
-end MulAction
-end
-
-section CompatibleScalar
-
-/-- If the multiplicative action of `M` on `N` is compatible with multiplication on `N`, then
-`fun x ↦ x • 1` is a monoid homomorphism from `M` to `N`. -/
-@[to_additive (attr := simps)
-"If the additive action of `M` on `N` is compatible with addition on `N`, then
-`fun x ↦ x +ᵥ 0` is an additive monoid homomorphism from `M` to `N`."]
-def MonoidHom.smulOneHom {M N} [Monoid M] [MulOneClass N] [MulAction M N] [IsScalarTower M N N] :
-    M →* N where
-  toFun x := x • (1 : N)
-  map_one' := one_smul _ _
-  map_mul' x y := by rw [smul_one_mul, smul_smul]
-
-/-- A monoid homomorphism between two monoids M and N can be equivalently specified by a
-multiplicative action of M on N that is compatible with the multiplication on N. -/
-@[to_additive
-"A monoid homomorphism between two additive monoids M and N can be equivalently
-specified by an additive action of M on N that is compatible with the addition on N."]
-def monoidHomEquivMulActionIsScalarTower (M N) [Monoid M] [Monoid N] :
-    (M →* N) ≃ {_inst : MulAction M N // IsScalarTower M N N} where
-  toFun f := ⟨MulAction.compHom N f, SMul.comp.isScalarTower _⟩
-  invFun := fun ⟨_, _⟩ ↦ MonoidHom.smulOneHom
-  left_inv f := MonoidHom.ext fun m ↦ mul_one (f m)
-  right_inv := fun ⟨_, _⟩ ↦ Subtype.ext <| MulAction.ext <| funext₂ <| smul_one_smul N
-
-end CompatibleScalar
-
-variable (α)
-
+variable (α) in
 /-- The monoid of endomorphisms.
 
 Note that this is generalized by `CategoryTheory.End` to categories other than `Type u`. -/
@@ -137,8 +66,6 @@ instance : Monoid (Function.End α) where
   npow_succ _ _ := Function.iterate_succ _ _
 
 instance : Inhabited (Function.End α) := ⟨1⟩
-
-variable {α}
 
 /-- The tautological action by `Function.End α` on `α`.
 
@@ -159,6 +86,9 @@ instance Function.End.applyMulAction : MulAction (Function.End α) α where
   one_smul _ := rfl
   mul_smul _ _ _ := rfl
 
+/-- The tautological additive action by `Additive (Function.End α)` on `α`. -/
+instance Function.End.applyAddAction : AddAction (Additive (Function.End α)) α := inferInstance
+
 @[simp] lemma Function.End.smul_def (f : Function.End α) (a : α) : f • a = f a := rfl
 
 --TODO - This statement should be somethting like `toFun (f * g) = toFun f ∘ toFun g`
@@ -166,6 +96,10 @@ lemma Function.End.mul_def (f g : Function.End α) : (f * g) = f ∘ g := rfl
 
 --TODO - This statement should be somethting like `toFun 1 = id`
 lemma Function.End.one_def : (1 : Function.End α) = id := rfl
+
+/-- `Function.End.applyMulAction` is faithful. -/
+instance Function.End.apply_FaithfulSMul : FaithfulSMul (Function.End α) α where
+  eq_of_smul_eq_smul := funext
 
 /-- The monoid hom representing a monoid action.
 
@@ -175,8 +109,19 @@ def MulAction.toEndHom [Monoid M] [MulAction M α] : M →* Function.End α wher
   map_one' := funext (one_smul M)
   map_mul' x y := funext (mul_smul x y)
 
+/-- The additive monoid hom representing an additive monoid action.
+
+When `M` is a group, see `AddAction.toPermHom`. -/
+def AddAction.toEndHom [AddMonoid M] [AddAction M α] : M →+ Additive (Function.End α) :=
+  MonoidHom.toAdditive'' MulAction.toEndHom
+
 /-- The monoid action induced by a monoid hom to `Function.End α`
 
 See note [reducible non-instances]. -/
-abbrev MulAction.ofEndHom [Monoid M] (f : M →* Function.End α) : MulAction M α :=
-  MulAction.compHom α f
+abbrev MulAction.ofEndHom [Monoid M] (f : M →* Function.End α) : MulAction M α := .compHom α f
+
+/-- The additive action induced by a hom to `Additive (Function.End α)`
+
+See note [reducible non-instances]. -/
+abbrev AddAction.ofEndHom [AddMonoid M] (f : M →+ Additive (Function.End α)) : AddAction M α :=
+  .compHom α f

--- a/Mathlib/Algebra/Group/Action/Faithful.lean
+++ b/Mathlib/Algebra/Group/Action/Faithful.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Action.End
+import Mathlib.Algebra.Group.Action.Defs
 
 /-!
 # Faithful group actions
@@ -56,6 +56,7 @@ lemma smul_left_injective' [SMul M α] [FaithfulSMul M α] : Injective ((· • 
 instance RightCancelMonoid.faithfulSMul [RightCancelMonoid α] : FaithfulSMul α α :=
   ⟨fun h ↦ mul_right_cancel (h 1)⟩
 
-/-- `Function.End.applyMulAction` is faithful. -/
-instance Function.End.apply_FaithfulSMul : FaithfulSMul (Function.End α) α :=
-  ⟨fun {_ _} ↦ funext⟩
+/-- `Monoid.toOppositeMulAction` is faithful on cancellative monoids. -/
+@[to_additive " `AddMonoid.toOppositeAddAction` is faithful on additive cancellative monoids. "]
+instance LefttCancelMonoid.to_faithfulSMul_mulOpposite [LeftCancelMonoid α] : FaithfulSMul αᵐᵒᵖ α :=
+  ⟨fun h ↦ MulOpposite.unop_injective <| mul_left_cancel (h 1)⟩

--- a/Mathlib/Algebra/Group/Action/Hom.lean
+++ b/Mathlib/Algebra/Group/Action/Hom.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2018 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes, Yury Kudryashov
+-/
+import Mathlib.Algebra.Group.Action.Pretransitive
+import Mathlib.Algebra.Group.Hom.Defs
+
+/-!
+# Homomorphisms and group actions
+-/
+
+assert_not_exists MonoidWithZero
+
+open Function (Injective Surjective)
+
+variable {M N α : Type*}
+
+section
+variable [Monoid M] [MulAction M α]
+
+/-- Push forward the action of `R` on `M` along a compatible surjective map `f : R →* S`.
+
+See also `Function.Surjective.distribMulActionLeft` and `Function.Surjective.moduleLeft`.
+-/
+@[to_additive
+"Push forward the action of `R` on `M` along a compatible surjective map `f : R →+ S`."]
+abbrev Function.Surjective.mulActionLeft {R S M : Type*} [Monoid R] [MulAction R M] [Monoid S]
+    [SMul S M] (f : R →* S) (hf : Surjective f) (hsmul : ∀ (c) (x : M), f c • x = c • x) :
+    MulAction S M where
+  smul := (· • ·)
+  one_smul b := by rw [← f.map_one, hsmul, one_smul]
+  mul_smul := hf.forall₂.mpr fun a b x ↦ by simp only [← f.map_mul, hsmul, mul_smul]
+
+namespace MulAction
+
+variable (α)
+
+/-- A multiplicative action of `M` on `α` and a monoid homomorphism `N → M` induce
+a multiplicative action of `N` on `α`.
+
+See note [reducible non-instances]. -/
+@[to_additive]
+abbrev compHom [Monoid N] (g : N →* M) : MulAction N α where
+  smul := SMul.comp.smul g
+  one_smul _ := by simpa [(· • ·)] using MulAction.one_smul ..
+  mul_smul _ _ _ := by simpa [(· • ·)] using MulAction.mul_smul ..
+
+/-- An additive action of `M` on `α` and an additive monoid homomorphism `N → M` induce
+an additive action of `N` on `α`.
+
+See note [reducible non-instances]. -/
+add_decl_doc AddAction.compHom
+
+@[to_additive]
+lemma compHom_smul_def
+    {E F G : Type*} [Monoid E] [Monoid F] [MulAction F G] (f : E →* F) (a : E) (x : G) :
+    letI : MulAction E G := MulAction.compHom _ f
+    a • x = (f a) • x := rfl
+
+/-- If an action is transitive, then composing this action with a surjective homomorphism gives
+again a transitive action. -/
+@[to_additive]
+lemma isPretransitive_compHom {E F G : Type*} [Monoid E] [Monoid F] [MulAction F G]
+    [IsPretransitive F G] {f : E →* F} (hf : Surjective f) :
+    letI : MulAction E G := MulAction.compHom _ f
+    IsPretransitive E G := by
+  let _ : MulAction E G := MulAction.compHom _ f
+  refine ⟨fun x y ↦ ?_⟩
+  obtain ⟨m, rfl⟩ : ∃ m : F, m • x = y := exists_smul_eq F x y
+  obtain ⟨e, rfl⟩ : ∃ e, f e = m := hf m
+  exact ⟨e, rfl⟩
+
+@[to_additive]
+lemma IsPretransitive.of_compHom {M N α : Type*} [Monoid M] [Monoid N] [MulAction N α]
+    (f : M →* N) [h : letI := compHom α f; IsPretransitive M α] : IsPretransitive N α :=
+  letI := compHom α f; h.of_smul_eq f rfl
+
+end MulAction
+end
+
+section CompatibleScalar
+
+/-- If the multiplicative action of `M` on `N` is compatible with multiplication on `N`, then
+`fun x ↦ x • 1` is a monoid homomorphism from `M` to `N`. -/
+@[to_additive (attr := simps)
+"If the additive action of `M` on `N` is compatible with addition on `N`, then
+`fun x ↦ x +ᵥ 0` is an additive monoid homomorphism from `M` to `N`."]
+def MonoidHom.smulOneHom {M N} [Monoid M] [MulOneClass N] [MulAction M N] [IsScalarTower M N N] :
+    M →* N where
+  toFun x := x • (1 : N)
+  map_one' := one_smul _ _
+  map_mul' x y := by rw [smul_one_mul, smul_smul]
+
+/-- A monoid homomorphism between two monoids M and N can be equivalently specified by a
+multiplicative action of M on N that is compatible with the multiplication on N. -/
+@[to_additive
+"A monoid homomorphism between two additive monoids M and N can be equivalently
+specified by an additive action of M on N that is compatible with the addition on N."]
+def monoidHomEquivMulActionIsScalarTower (M N) [Monoid M] [Monoid N] :
+    (M →* N) ≃ {_inst : MulAction M N // IsScalarTower M N N} where
+  toFun f := ⟨MulAction.compHom N f, SMul.comp.isScalarTower _⟩
+  invFun := fun ⟨_, _⟩ ↦ MonoidHom.smulOneHom
+  left_inv f := MonoidHom.ext fun m ↦ mul_one (f m)
+  right_inv := fun ⟨_, _⟩ ↦ Subtype.ext <| MulAction.ext <| funext₂ <| smul_one_smul N
+
+end CompatibleScalar

--- a/Mathlib/Algebra/Group/Action/Opposite.lean
+++ b/Mathlib/Algebra/Group/Action/Opposite.lean
@@ -137,27 +137,9 @@ lemma op_smul_mul (b : β) (a₁ a₂ : α) : b <• (a₁ * a₂) = b <• a₁
 
 end
 
-/-! ### Actions _by_ the opposite type (right actions)
-
-In `Mul.toSMul` in another file, we define the left action `a₁ • a₂ = a₁ * a₂`. For the
-multiplicative opposite, we define `MulOpposite.op a₁ • a₂ = a₂ * a₁`, with the multiplication
-reversed.
--/
+/-! ### Actions _by_ the opposite type (right actions) -/
 
 open MulOpposite
-
-/-- Like `Mul.toSMul`, but multiplies on the right.
-
-See also `Monoid.toOppositeMulAction` and `MonoidWithZero.toOppositeMulActionWithZero`. -/
-@[to_additive "Like `Add.toVAdd`, but adds on the right.
-
-  See also `AddMonoid.toOppositeAddAction`."]
-instance Mul.toHasOppositeSMul [Mul α] : SMul αᵐᵒᵖ α where smul c x := x * c.unop
-
-@[to_additive] lemma op_smul_eq_mul [Mul α] {a a' : α} : op a • a' = a' * a := rfl
-
-@[to_additive (attr := simp)]
-lemma MulOpposite.smul_eq_mul_unop [Mul α] {a : αᵐᵒᵖ} {a' : α} : a • a' = a' * a.unop := rfl
 
 /-- The right regular action of a group on itself is transitive. -/
 @[to_additive "The right regular action of an additive group on itself is transitive."]

--- a/Mathlib/Algebra/Group/Action/Pi.lean
+++ b/Mathlib/Algebra/Group/Action/Pi.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 -/
 import Mathlib.Algebra.Group.Action.Faithful
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Data.Set.Function
 
 /-!

--- a/Mathlib/Algebra/Group/Action/Pretransitive.lean
+++ b/Mathlib/Algebra/Group/Action/Pretransitive.lean
@@ -75,30 +75,10 @@ end MulAction
 
 namespace MulAction
 
-variable (α)
-
-/-- If an action is transitive, then composing this action with a surjective homomorphism gives
-again a transitive action. -/
-@[to_additive]
-lemma isPretransitive_compHom {E F G : Type*} [Monoid E] [Monoid F] [MulAction F G]
-    [IsPretransitive F G] {f : E →* F} (hf : Surjective f) :
-    letI : MulAction E G := MulAction.compHom _ f
-    IsPretransitive E G := by
-  let _ : MulAction E G := MulAction.compHom _ f
-  refine ⟨fun x y ↦ ?_⟩
-  obtain ⟨m, rfl⟩ : ∃ m : F, m • x = y := exists_smul_eq F x y
-  obtain ⟨e, rfl⟩ : ∃ e, f e = m := hf m
-  exact ⟨e, rfl⟩
-
 @[to_additive]
 lemma IsPretransitive.of_smul_eq {M N α : Type*} [SMul M α] [SMul N α] [IsPretransitive M α]
     (f : M → N) (hf : ∀ {c : M} {x : α}, f c • x = c • x) : IsPretransitive N α where
   exists_smul_eq x y := (exists_smul_eq x y).elim fun m h ↦ ⟨f m, hf.trans h⟩
-
-@[to_additive]
-lemma IsPretransitive.of_compHom {M N α : Type*} [Monoid M] [Monoid N] [MulAction N α]
-    (f : M →* N) [h : letI := compHom α f; IsPretransitive M α] : IsPretransitive N α :=
-  letI := compHom α f; h.of_smul_eq f rfl
 
 end MulAction
 

--- a/Mathlib/Algebra/Group/Action/Prod.lean
+++ b/Mathlib/Algebra/Group/Action/Prod.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot, Eric Wieser
 -/
 import Mathlib.Algebra.Group.Action.Faithful
+import Mathlib.Algebra.Group.Action.Hom
 import Mathlib.Algebra.Group.Prod
 
 /-!

--- a/Mathlib/Algebra/Group/Action/Sigma.lean
+++ b/Mathlib/Algebra/Group/Action/Sigma.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Group.Action.Faithful
+import Mathlib.Data.Sigma.Basic
 
 /-!
 # Sigma instances for additive and multiplicative actions

--- a/Mathlib/Algebra/Group/Action/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Action/TypeTags.lean
@@ -3,8 +3,9 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Action.End
-import Mathlib.Algebra.Group.TypeTags.Hom
+import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.TypeTags.Basic
+import Mathlib.Tactic.MinImports
 
 /-!
 # Additive and Multiplicative for group actions
@@ -14,7 +15,7 @@ import Mathlib.Algebra.Group.TypeTags.Hom
 group action
 -/
 
-assert_not_exists MonoidWithZero
+assert_not_exists MonoidWithZero MonoidHom
 
 open Function (Injective Surjective)
 
@@ -55,18 +56,3 @@ instance Multiplicative.smulCommClass [VAdd α γ] [VAdd β γ] [VAddCommClass �
   ⟨@vadd_comm α β _ _ _ _⟩
 
 end
-
-/-- The tautological additive action by `Additive (Function.End α)` on `α`. -/
-instance AddAction.functionEnd : AddAction (Additive (Function.End α)) α := inferInstance
-
-/-- The additive monoid hom representing an additive monoid action.
-
-When `M` is a group, see `AddAction.toPermHom`. -/
-def AddAction.toEndHom [AddMonoid M] [AddAction M α] : M →+ Additive (Function.End α) :=
-  MonoidHom.toAdditive'' MulAction.toEndHom
-
-/-- The additive action induced by a hom to `Additive (Function.End α)`
-
-See note [reducible non-instances]. -/
-abbrev AddAction.ofEndHom [AddMonoid M] (f : M →+ Additive (Function.End α)) : AddAction M α :=
-  AddAction.compHom α f

--- a/Mathlib/Algebra/GroupWithZero/Action/End.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/End.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Action.End
+import Mathlib.Algebra.Group.Action.Hom
 import Mathlib.Algebra.Group.Equiv.Defs
 import Mathlib.Algebra.GroupWithZero.Action.Defs
 import Mathlib.Algebra.GroupWithZero.Action.Units

--- a/Mathlib/Algebra/GroupWithZero/Pointwise/Finset.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pointwise/Finset.lean
@@ -190,7 +190,7 @@ open scoped RightActions
       MulOpposite.op_inv, inv_eq_zero, MulOpposite.op_eq_zero_iff, inv_inv,
       MulOpposite.smul_eq_mul_unop, MulOpposite.unop_op, mul_inv_rev, ha]
 
-@[simp] lemma inv_op_smul_finset_distrib₀ (a : α) (s : Finset α) : (s <• a)⁻¹ = a⁻¹ • s⁻¹ := by
+lemma inv_op_smul_finset_distrib₀ (a : α) (s : Finset α) : (s <• a)⁻¹ = a⁻¹ • s⁻¹ := by
   obtain rfl | ha := eq_or_ne a 0
   · obtain rfl | hs := s.eq_empty_or_nonempty <;> simp [*]
   -- was `simp` and very slow (https://github.com/leanprover-community/mathlib4/issues/19751)

--- a/Mathlib/Algebra/Module/Defs.lean
+++ b/Mathlib/Algebra/Module/Defs.lean
@@ -3,7 +3,6 @@ Copyright (c) 2015 Nathaniel Thomas. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
 -/
-import Mathlib.Algebra.Group.Action.End
 import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.GroupWithZero.Action.Defs
 import Mathlib.Algebra.Ring.Defs

--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -235,8 +235,8 @@ instance {A : Type*} [Semiring A] [Algebra R A] {S : Submonoid R} :
           on_goal 1 => rw [e₁, e₂]
           on_goal 2 => rw [eq_comm]
           all_goals
-            rw [smul_smul, mul_mul_mul_comm, ← smul_eq_mul, ← smul_eq_mul A, smul_smul_smul_comm,
-              mul_smul, mul_smul])
+            rw [smul_smul, mul_mul_mul_comm, ← smul_eq_mul, ← smul_eq_mul (α := A),
+              smul_smul_smul_comm, mul_smul, mul_smul])
     one := mk 1 (1 : S)
     one_mul := by
       rintro ⟨a, s⟩

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -532,7 +532,7 @@ lemma image_basicOpen_eq_basicOpen (a : A) (i : ℕ) :
     (PrimeSpectrum.basicOpen (R := A⁰_ f) <|
       HomogeneousLocalization.mk
         ⟨m * i, ⟨decompose 𝒜 a i ^ m,
-          (smul_eq_mul ℕ) ▸ SetLike.pow_mem_graded _ (Submodule.coe_mem _)⟩,
+          smul_eq_mul m i ▸ SetLike.pow_mem_graded _ (Submodule.coe_mem _)⟩,
           ⟨f^i, by rw [mul_comm]; exact SetLike.pow_mem_graded _ f_deg⟩, ⟨i, rfl⟩⟩).1 :=
   Set.preimage_injective.mpr (toSpec_surjective 𝒜 f_deg hm) <|
     Set.preimage_image_eq _ (toSpec_injective 𝒜 f_deg hm) ▸ by

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -576,8 +576,7 @@ variable {σ : R →* S}
 @[ext]
 theorem ext_ring {f g : R →ₑ+[σ] N'} (h : f 1 = g 1) : f = g := by
   ext x
-  rw [← mul_one x, ← smul_eq_mul R, f.map_smulₑ, g.map_smulₑ, h]
-
+  rw [← mul_one x, ← smul_eq_mul, f.map_smulₑ, g.map_smulₑ, h]
 
 end Semiring
 

--- a/Mathlib/GroupTheory/Perm/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
+import Mathlib.Algebra.Group.Action.End
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Group.Units.Equiv
 import Mathlib.Algebra.GroupPower.IterateHom

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
@@ -353,7 +353,7 @@ open DualNumber TrivSqZeroExt
 variable {R : Type*} [CommRing R]
 
 theorem ι_mul_ι (r₁ r₂) : ι (0 : QuadraticForm R R) r₁ * ι (0 : QuadraticForm R R) r₂ = 0 := by
-  rw [← mul_one r₁, ← mul_one r₂, ← smul_eq_mul R, ← smul_eq_mul R, LinearMap.map_smul,
+  rw [← mul_one r₁, ← mul_one r₂, ← smul_eq_mul r₁, ← smul_eq_mul r₂, LinearMap.map_smul,
     LinearMap.map_smul, smul_mul_smul_comm, ι_sq_scalar, QuadraticMap.zero_apply, RingHom.map_zero,
     smul_zero]
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -613,7 +613,7 @@ def linMulLin (f g : M →ₗ[R] A) : QuadraticMap R M A where
   toFun := f * g
   toFun_smul a x := by
     rw [Pi.mul_apply, Pi.mul_apply, LinearMap.map_smulₛₗ, RingHom.id_apply, LinearMap.map_smulₛₗ,
-      RingHom.id_apply, smul_mul_assoc, mul_smul_comm, ← smul_assoc, (smul_eq_mul R)]
+      RingHom.id_apply, smul_mul_assoc, mul_smul_comm, ← smul_assoc, smul_eq_mul]
   exists_companion' :=
     ⟨(LinearMap.mul R A).compl₁₂ f g + (LinearMap.mul R A).flip.compl₁₂ g f, fun x y => by
       simp only [Pi.mul_apply, map_add, left_distrib, right_distrib, LinearMap.add_apply,

--- a/Mathlib/LinearAlgebra/TensorProduct/Quotient.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Quotient.lean
@@ -176,7 +176,7 @@ lemma quotTensorEquivQuotSMul_mk_tmul (I : Ideal R) (r : R) (x : M) :
   (quotTensorEquivQuotSMul M I).eq_symm_apply.mp <|
     Eq.trans (congrArg (· ⊗ₜ[R] x) <|
         Eq.trans (congrArg (Ideal.Quotient.mk I)
-                    (Eq.trans (smul_eq_mul R) (mul_one r))).symm <|
+                    (Eq.trans (smul_eq_mul ..) (mul_one r))).symm <|
           Submodule.Quotient.mk_smul I r 1) <|
       smul_tmul r _ x
 

--- a/Mathlib/MeasureTheory/Integral/Asymptotics.lean
+++ b/Mathlib/MeasureTheory/Integral/Asymptotics.lean
@@ -88,7 +88,7 @@ theorem IsBigO.set_integral_isBigO
   obtain ⟨t, htl, ht⟩ := hC.exists_mem
   obtain ⟨u, hu, v, hv, huv⟩ := Filter.mem_prod_iff.mp htl
   refine isBigO_iff.mpr ⟨C * (μ s).toReal, eventually_iff_exists_mem.mpr ⟨v, hv, fun x hx ↦ ?_⟩⟩
-  rw [mul_assoc, ← smul_eq_mul (a' := ‖g x‖), ← MeasureTheory.Measure.restrict_apply_univ,
+  rw [mul_assoc, ← smul_eq_mul _ ‖g x‖, ← MeasureTheory.Measure.restrict_apply_univ,
     ← integral_const, mul_comm, ← smul_eq_mul, ← integral_smul_const]
   haveI : IsFiniteMeasure (μ.restrict s) := ⟨by rw [Measure.restrict_apply_univ s]; exact hμ⟩
   refine (norm_integral_le_integral_norm _).trans <|

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -455,7 +455,7 @@ theorem integral_indicator_const [CompleteSpace E] (e : E) ⦃s : Set X⦄ (s_me
 @[simp]
 theorem integral_indicator_one ⦃s : Set X⦄ (hs : MeasurableSet s) :
     ∫ x, s.indicator 1 x ∂μ = (μ s).toReal :=
-  (integral_indicator_const 1 hs).trans ((smul_eq_mul _).trans (mul_one _))
+  (integral_indicator_const 1 hs).trans ((smul_eq_mul ..).trans (mul_one _))
 
 theorem setIntegral_indicatorConstLp [CompleteSpace E]
     {p : ℝ≥0∞} (hs : MeasurableSet s) (ht : MeasurableSet t) (hμt : μ t ≠ ∞) (e : E) :

--- a/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
@@ -101,7 +101,7 @@ theorem unique_topology_of_t2 {t : TopologicalSpace 𝕜} (h₁ : @IsTopological
       -- `ξ₀ ∈ 𝓑 ⊆ {ξ₀}ᶜ`, which is a contradiction.
       by_contra! h
       suffices (ξ₀ * ξ⁻¹) • ξ ∈ balancedCore 𝕜 {ξ₀}ᶜ by
-        rw [smul_eq_mul 𝕜, mul_assoc, inv_mul_cancel₀ hξ0, mul_one] at this
+        rw [smul_eq_mul, mul_assoc, inv_mul_cancel₀ hξ0, mul_one] at this
         exact not_mem_compl_iff.mpr (mem_singleton ξ₀) ((balancedCore_subset _) this)
       -- For that, we use that `𝓑` is balanced : since `‖ξ₀‖ < ε < ‖ξ‖`, we have `‖ξ₀ / ξ‖ ≤ 1`,
       -- hence `ξ₀ = (ξ₀ / ξ) • ξ ∈ 𝓑` because `ξ ∈ 𝓑`.


### PR DESCRIPTION
Swap imports and move lemmas between pairs of files to avoid scattering families of lemmas. Make the concrete action by `Function.End` depend on generic properties `FaithfulSMul`/`IsPretransitive` rather than the other way around.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
