### PR TITLE
[Merged by Bors] - chore(Algebra.Quaternion): scope simp theorems with weak keys

### DIFF
--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -161,15 +161,15 @@ theorem coe_inj {x y : R} : (x : ℍ[R,c₁,c₂,c₃]) = y ↔ x = y :=
 -- Should adjust `simps` to name properly, i.e. as `zero_re` rather than `instZero_zero_re`.
 instance : Zero ℍ[R,c₁,c₂,c₃] := ⟨⟨0, 0, 0, 0⟩⟩
 
-@[simp] theorem zero_re : (0 : ℍ[R,c₁,c₂,c₃]).re = 0 := rfl
+@[scoped simp] theorem zero_re : (0 : ℍ[R,c₁,c₂,c₃]).re = 0 := rfl
 
-@[simp] theorem zero_imI : (0 : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
+@[scoped simp] theorem zero_imI : (0 : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
 
-@[simp] theorem zero_imJ : (0 : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
+@[scoped simp] theorem zero_imJ : (0 : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
 
-@[simp] theorem zero_imK : (0 : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
+@[scoped simp] theorem zero_imK : (0 : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
 
-@[simp] theorem zero_im : (0 : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
+@[scoped simp] theorem zero_im : (0 : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
 
 @[simp, norm_cast]
 theorem coe_zero : ((0 : R) : ℍ[R,c₁,c₂,c₃]) = 0 := rfl
@@ -182,15 +182,15 @@ variable [One R]
 -- Porting note: removed `simps`, added simp lemmas manually. Should adjust `simps` to name properly
 instance : One ℍ[R,c₁,c₂,c₃] := ⟨⟨1, 0, 0, 0⟩⟩
 
-@[simp] theorem one_re : (1 : ℍ[R,c₁,c₂,c₃]).re = 1 := rfl
+@[scoped simp] theorem one_re : (1 : ℍ[R,c₁,c₂,c₃]).re = 1 := rfl
 
-@[simp] theorem one_imI : (1 : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
+@[scoped simp] theorem one_imI : (1 : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
 
-@[simp] theorem one_imJ : (1 : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
+@[scoped simp] theorem one_imJ : (1 : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
 
-@[simp] theorem one_imK : (1 : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
+@[scoped simp] theorem one_imK : (1 : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
 
-@[simp] theorem one_im : (1 : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
+@[scoped simp] theorem one_im : (1 : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
 
 @[simp, norm_cast]
 theorem coe_one : ((1 : R) : ℍ[R,c₁,c₂,c₃]) = 1 := rfl
@@ -442,19 +442,19 @@ alias coe_nat_cast := coe_natCast
 theorem intCast_re (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).re = z :=
   rfl
 
-@[simp]
+@[scoped simp]
 theorem ofNat_re (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).re = ofNat(n) := rfl
 
-@[simp]
+@[scoped simp]
 theorem ofNat_imI (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
 
-@[simp]
+@[scoped simp]
 theorem ofNat_imJ (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
 
-@[simp]
+@[scoped simp]
 theorem ofNat_imK (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
 
-@[simp]
+@[scoped simp]
 theorem ofNat_im (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
 
 @[deprecated (since := "2024-04-17")]
@@ -857,28 +857,28 @@ theorem coe_imK : (x : ℍ[R]).imK = 0 := rfl
 @[simp, norm_cast]
 theorem coe_im : (x : ℍ[R]).im = 0 := rfl
 
-@[simp] theorem zero_re : (0 : ℍ[R]).re = 0 := rfl
+@[scoped simp] theorem zero_re : (0 : ℍ[R]).re = 0 := rfl
 
-@[simp] theorem zero_imI : (0 : ℍ[R]).imI = 0 := rfl
+@[scoped simp] theorem zero_imI : (0 : ℍ[R]).imI = 0 := rfl
 
-@[simp] theorem zero_imJ : (0 : ℍ[R]).imJ = 0 := rfl
+@[scoped simp] theorem zero_imJ : (0 : ℍ[R]).imJ = 0 := rfl
 
-@[simp] theorem zero_imK : (0 : ℍ[R]).imK = 0 := rfl
+@[scoped simp] theorem zero_imK : (0 : ℍ[R]).imK = 0 := rfl
 
-@[simp] theorem zero_im : (0 : ℍ[R]).im = 0 := rfl
+@[scoped simp] theorem zero_im : (0 : ℍ[R]).im = 0 := rfl
 
 @[simp, norm_cast]
 theorem coe_zero : ((0 : R) : ℍ[R]) = 0 := rfl
 
-@[simp] theorem one_re : (1 : ℍ[R]).re = 1 := rfl
+@[scoped simp] theorem one_re : (1 : ℍ[R]).re = 1 := rfl
 
-@[simp] theorem one_imI : (1 : ℍ[R]).imI = 0 := rfl
+@[scoped simp] theorem one_imI : (1 : ℍ[R]).imI = 0 := rfl
 
-@[simp] theorem one_imJ : (1 : ℍ[R]).imJ = 0 := rfl
+@[scoped simp] theorem one_imJ : (1 : ℍ[R]).imJ = 0 := rfl
 
-@[simp] theorem one_imK : (1 : ℍ[R]).imK = 0 := rfl
+@[scoped simp] theorem one_imK : (1 : ℍ[R]).imK = 0 := rfl
 
-@[simp] theorem one_im : (1 : ℍ[R]).im = 0 := rfl
+@[scoped simp] theorem one_im : (1 : ℍ[R]).im = 0 := rfl
 
 @[simp, norm_cast]
 theorem coe_one : ((1 : R) : ℍ[R]) = 1 := rfl


### PR DESCRIPTION
The discrimination keys of these do not reference `QuaternionAlgebra` so can apply broadly with `simp`. There is already essential notation scoped to this namespace so `open scoped QuaternionAlgebra` should not burden the user any more than it does currently. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
