### PR TITLE
[Merged by Bors] - perf(Algebra.Quaternion): reorder instances in spread

### DIFF
--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -1318,18 +1318,14 @@ alias rat_cast_imK := ratCast_imK
 alias coe_rat_cast := coe_ratCast
 
 instance instDivisionRing : DivisionRing ℍ[R] where
-  __ := Quaternion.instGroupWithZero
   __ := Quaternion.instRing
+  __ := Quaternion.instGroupWithZero
   nnqsmul := (· • ·)
   qsmul := (· • ·)
-  nnratCast_def _ := by simp only [← coe_nnratCast, NNRat.cast_def, coe_div, coe_natCast]
-  ratCast_def _ := by simp only [← coe_ratCast, Rat.cast_def, coe_div, coe_intCast, coe_natCast]
-  nnqsmul_def _ _ := by
-    simp only [← coe_nnratCast, coe_mul_eq_smul]
-    ext <;> exact NNRat.smul_def ..
-  qsmul_def _ _ := by
-    simp only [← coe_ratCast, coe_mul_eq_smul]
-    ext <;> exact Rat.smul_def ..
+  nnratCast_def _ := by rw [← coe_nnratCast, NNRat.cast_def, coe_div, coe_natCast, coe_natCast]
+  ratCast_def _ := by rw [← coe_ratCast, Rat.cast_def, coe_div, coe_intCast, coe_natCast]
+  nnqsmul_def _ _ := by rw [← coe_nnratCast, coe_mul_eq_smul]; ext <;> exact NNRat.smul_def ..
+  qsmul_def _ _ := by rw [← coe_ratCast, coe_mul_eq_smul]; ext <;> exact Rat.smul_def ..
 
 theorem normSq_inv : normSq a⁻¹ = (normSq a)⁻¹ :=
   map_inv₀ normSq _

--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -1268,8 +1268,7 @@ instance instInv : Inv ℍ[R] :=
   ⟨fun a => (normSq a)⁻¹ • star a⟩
 
 instance instGroupWithZero : GroupWithZero ℍ[R] :=
-  { Quaternion.instNontrivial,
-    (by infer_instance : MonoidWithZero ℍ[R]) with
+  { Quaternion.instNontrivial with
     inv := Inv.inv
     inv_zero := by rw [instInv_inv, star_zero, smul_zero]
     mul_inv_cancel := fun a ha => by
@@ -1323,10 +1322,14 @@ instance instDivisionRing : DivisionRing ℍ[R] where
   __ := Quaternion.instRing
   nnqsmul := (· • ·)
   qsmul := (· • ·)
-  nnratCast_def q := by rw [← coe_nnratCast, NNRat.cast_def, coe_div, coe_natCast, coe_natCast]
-  ratCast_def q := by rw [← coe_ratCast, Rat.cast_def, coe_div, coe_intCast, coe_natCast]
-  nnqsmul_def q x := by rw [← coe_nnratCast, coe_mul_eq_smul]; ext <;> exact NNRat.smul_def _ _
-  qsmul_def q x := by rw [← coe_ratCast, coe_mul_eq_smul]; ext <;> exact Rat.smul_def _ _
+  nnratCast_def _ := by simp only [← coe_nnratCast, NNRat.cast_def, coe_div, coe_natCast]
+  ratCast_def _ := by simp only [← coe_ratCast, Rat.cast_def, coe_div, coe_intCast, coe_natCast]
+  nnqsmul_def _ _ := by
+    simp only [← coe_nnratCast, coe_mul_eq_smul]
+    ext <;> exact NNRat.smul_def ..
+  qsmul_def _ _ := by
+    simp only [← coe_ratCast, coe_mul_eq_smul]
+    ext <;> exact Rat.smul_def ..
 
 theorem normSq_inv : normSq a⁻¹ = (normSq a)⁻¹ :=
   map_inv₀ normSq _


### PR DESCRIPTION
As @JovanGerb reminded me, we still have some places where supplied instance ordering can result in an unnecessarily unfolded term. `Quaternion.instDivisionRing` is one such. 

Co-authored-by: Jovan Gerbscheid <jovan.gerbscheid@gmail.com> 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
