### PR TITLE
[Merged by Bors] - chore(Algebra/PUnitInstances): sort files according to topic

### DIFF
--- a/Counterexamples/CharPZeroNeCharZero.lean
+++ b/Counterexamples/CharPZeroNeCharZero.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa, Eric Wieser
 -/
 import Mathlib.Algebra.CharP.Lemmas
-import Mathlib.Algebra.PUnitInstances.Algebra
+import Mathlib.Algebra.Ring.PUnit
 
 /-! # `CharP R 0` and `CharZero R` need not coincide for semirings
 

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -262,6 +262,7 @@ import Mathlib.Algebra.GCDMonoid.Finset
 import Mathlib.Algebra.GCDMonoid.IntegrallyClosed
 import Mathlib.Algebra.GCDMonoid.Multiset
 import Mathlib.Algebra.GCDMonoid.Nat
+import Mathlib.Algebra.GCDMonoid.PUnit
 import Mathlib.Algebra.GeomSum
 import Mathlib.Algebra.GradedMonoid
 import Mathlib.Algebra.GradedMulAction
@@ -327,6 +328,7 @@ import Mathlib.Algebra.Group.NatPowAssoc
 import Mathlib.Algebra.Group.Operations
 import Mathlib.Algebra.Group.Opposite
 import Mathlib.Algebra.Group.PNatPowAssoc
+import Mathlib.Algebra.Group.PUnit
 import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.Pi.Units
@@ -600,6 +602,7 @@ import Mathlib.Algebra.Module.MinimalAxioms
 import Mathlib.Algebra.Module.NatInt
 import Mathlib.Algebra.Module.Opposite
 import Mathlib.Algebra.Module.PID
+import Mathlib.Algebra.Module.PUnit
 import Mathlib.Algebra.Module.Pi
 import Mathlib.Algebra.Module.PointwisePi
 import Mathlib.Algebra.Module.Presentation.Basic
@@ -801,6 +804,7 @@ import Mathlib.Algebra.Order.Nonneg.Floor
 import Mathlib.Algebra.Order.Nonneg.Lattice
 import Mathlib.Algebra.Order.Nonneg.Module
 import Mathlib.Algebra.Order.Nonneg.Ring
+import Mathlib.Algebra.Order.PUnit
 import Mathlib.Algebra.Order.PartialSups
 import Mathlib.Algebra.Order.Pi
 import Mathlib.Algebra.Order.Positive.Field
@@ -845,10 +849,6 @@ import Mathlib.Algebra.Order.ToIntervalMod
 import Mathlib.Algebra.Order.UpperLower
 import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Algebra.PEmptyInstances
-import Mathlib.Algebra.PUnitInstances.Algebra
-import Mathlib.Algebra.PUnitInstances.GCDMonoid
-import Mathlib.Algebra.PUnitInstances.Module
-import Mathlib.Algebra.PUnitInstances.Order
 import Mathlib.Algebra.Periodic
 import Mathlib.Algebra.Pointwise.Stabilizer
 import Mathlib.Algebra.Polynomial.AlgebraMap
@@ -953,6 +953,7 @@ import Mathlib.Algebra.Ring.Nat
 import Mathlib.Algebra.Ring.NegOnePow
 import Mathlib.Algebra.Ring.NonZeroDivisors
 import Mathlib.Algebra.Ring.Opposite
+import Mathlib.Algebra.Ring.PUnit
 import Mathlib.Algebra.Ring.Parity
 import Mathlib.Algebra.Ring.Pi
 import Mathlib.Algebra.Ring.Pointwise.Finset

--- a/Mathlib/Algebra/Category/GrpWithZero.lean
+++ b/Mathlib/Algebra/Category/GrpWithZero.lean
@@ -15,7 +15,7 @@ This file defines `GrpWithZero`, the category of groups with zero.
 
 universe u
 
-open CategoryTheory Order
+open CategoryTheory
 
 /-- The category of groups with zero. -/
 structure GrpWithZero where

--- a/Mathlib/Algebra/Category/GrpWithZero.lean
+++ b/Mathlib/Algebra/Category/GrpWithZero.lean
@@ -13,6 +13,8 @@ import Mathlib.CategoryTheory.Category.Bipointed
 This file defines `GrpWithZero`, the category of groups with zero.
 -/
 
+assert_not_exists Ring
+
 universe u
 
 open CategoryTheory

--- a/Mathlib/Algebra/Category/ModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Basic.lean
@@ -5,7 +5,7 @@ Authors: Robert A. Spencer, Markus Himmel
 -/
 import Mathlib.Algebra.Category.Grp.Preadditive
 import Mathlib.Algebra.Module.Equiv.Basic
-import Mathlib.Algebra.PUnitInstances.Module
+import Mathlib.Algebra.Module.PUnit
 import Mathlib.CategoryTheory.Conj
 import Mathlib.CategoryTheory.Linear.Basic
 import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -3,11 +3,10 @@ Copyright (c) 2018 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
-import Mathlib.Algebra.PUnitInstances.Algebra
+import Mathlib.Algebra.Group.PUnit
 import Mathlib.Algebra.Group.ULift
 import Mathlib.CategoryTheory.ConcreteCategory.Basic
 import Mathlib.CategoryTheory.Functor.ReflectsIso
-import Mathlib.Algebra.Ring.Action.Group
 
 /-!
 # Category instances for `Monoid`, `AddMonoid`, `CommMonoid`, and `AddCommMmonoid`.

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Group.PUnit
+import Mathlib.Algebra.Group.TypeTags.Hom
 import Mathlib.Algebra.Group.ULift
 import Mathlib.CategoryTheory.ConcreteCategory.Basic
 import Mathlib.CategoryTheory.Functor.ReflectsIso
@@ -18,6 +19,8 @@ We introduce the bundled categories:
 * `AddCommMonCat`
 along with the relevant forgetful functors between them.
 -/
+
+assert_not_exists MonoidWithZero
 
 universe u v
 

--- a/Mathlib/Algebra/Category/MonCat/Colimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Colimits.lean
@@ -46,6 +46,7 @@ Monoid.mk : {M : Type u} →
 ```
 -/
 
+assert_not_exists MonoidWithZero
 
 universe v u
 

--- a/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
@@ -16,6 +16,8 @@ and `MonCat`.
 
 -/
 
+assert_not_exists MonoidWithZero
+
 universe u
 
 open CategoryTheory Opposite

--- a/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sophie Morel
 -/
 import Mathlib.Algebra.Category.MonCat.Basic
+import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Group.Nat.Hom
 
 /-!

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison, Johannes Hölzl, Yury Kudryashov
 -/
 import Mathlib.Algebra.Category.Grp.Basic
-import Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso
 import Mathlib.Algebra.Ring.Equiv
+import Mathlib.Algebra.Ring.PUnit
+import Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso
 
 /-!
 # Category instances for `Semiring`, `Ring`, `CommSemiring`, and `CommRing`.

--- a/Mathlib/Algebra/GCDMonoid/PUnit.lean
+++ b/Mathlib/Algebra/GCDMonoid/PUnit.lean
@@ -4,13 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
 import Mathlib.Algebra.GCDMonoid.Basic
-import Mathlib.Algebra.PUnitInstances.Algebra
+import Mathlib.Algebra.Ring.PUnit
 
 /-!
-# Instances on PUnit
+# `PUnit` is a GCD monoid
 
-This file collects facts about algebraic structures on the one-element type, e.g. that it is a
-commutative ring.
+This file collects facts about algebraic structures on the one-element type, e.g. that it is has a
+GCD.
 -/
 
 namespace PUnit

--- a/Mathlib/Algebra/Group/PUnit.lean
+++ b/Mathlib/Algebra/Group/PUnit.lean
@@ -3,14 +3,17 @@ Copyright (c) 2019 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import Mathlib.Algebra.Ring.Basic
+import Mathlib.Algebra.Group.Defs
+import Mathlib.Tactic.MinImports
 
 /-!
-# Instances on PUnit
+# `PUnit` is a commutative group
 
 This file collects facts about algebraic structures on the one-element type, e.g. that it is a
 commutative ring.
 -/
+
+assert_not_exists MonoidWithZero
 
 namespace PUnit
 
@@ -22,11 +25,11 @@ instance commGroup : CommGroup PUnit where
   div _ _ := unit
   npow _ _ := unit
   zpow _ _ := unit
-  mul_assoc := by intros; rfl
-  one_mul := by intros; rfl
-  mul_one := by intros; rfl
-  inv_mul_cancel := by intros; rfl
-  mul_comm := by intros; rfl
+  mul_assoc _ _ _ := rfl
+  one_mul _ := rfl
+  mul_one _ := rfl
+  inv_mul_cancel _ := rfl
+  mul_comm _ _ := rfl
 
 -- shortcut instances
 @[to_additive] instance : One PUnit where one := unit
@@ -36,32 +39,12 @@ instance commGroup : CommGroup PUnit where
 
 -- dsimp loops when applying this lemma to its LHS,
 -- probably https://github.com/leanprover/lean4/pull/2867
-@[to_additive (attr := simp, nolint simpNF)]
-theorem one_eq : (1 : PUnit) = unit :=
-  rfl
+@[to_additive (attr := simp, nolint simpNF)] lemma one_eq : (1 : PUnit) = unit := rfl
 
 -- note simp can prove this when the Boolean ring structure is introduced
-@[to_additive]
-theorem mul_eq {x y : PUnit} : x * y = unit :=
-  rfl
+@[to_additive] lemma mul_eq (x y : PUnit) : x * y = unit := rfl
 
-@[to_additive (attr := simp)]
-theorem div_eq {x y : PUnit} : x / y = unit :=
-  rfl
-
-@[to_additive (attr := simp)]
-theorem inv_eq {x : PUnit} : x⁻¹ = unit :=
-  rfl
-
-instance commRing : CommRing PUnit where
-  __ := PUnit.commGroup
-  __ := PUnit.addCommGroup
-  left_distrib := by intros; rfl
-  right_distrib := by intros; rfl
-  zero_mul := by intros; rfl
-  mul_zero := by intros; rfl
-  natCast _ := unit
-
-instance cancelCommMonoidWithZero : CancelCommMonoidWithZero PUnit where
+@[to_additive (attr := simp)] lemma div_eq (x y : PUnit) : x / y = unit := rfl
+@[to_additive (attr := simp)] lemma inv_eq (x : PUnit) : x⁻¹ = unit := rfl
 
 end PUnit

--- a/Mathlib/Algebra/Module/PUnit.lean
+++ b/Mathlib/Algebra/Module/PUnit.lean
@@ -3,9 +3,9 @@ Copyright (c) 2019 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import Mathlib.Algebra.PUnitInstances.Algebra
 import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Ring.Action.Basic
+import Mathlib.Algebra.Ring.PUnit
 
 /-!
 # Instances on PUnit

--- a/Mathlib/Algebra/Module/Submodule/Lattice.lean
+++ b/Mathlib/Algebra/Module/Submodule/Lattice.lean
@@ -8,7 +8,7 @@ import Mathlib.Algebra.Group.Submonoid.Membership
 import Mathlib.Algebra.Group.Submonoid.BigOperators
 import Mathlib.Algebra.Module.Submodule.Defs
 import Mathlib.Algebra.Module.Equiv.Defs
-import Mathlib.Algebra.PUnitInstances.Module
+import Mathlib.Algebra.Module.PUnit
 import Mathlib.Data.Set.Subsingleton
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
 

--- a/Mathlib/Algebra/Order/PUnit.lean
+++ b/Mathlib/Algebra/Order/PUnit.lean
@@ -3,10 +3,8 @@ Copyright (c) 2019 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import Mathlib.Algebra.PUnitInstances.Algebra
+import Mathlib.Algebra.Group.PUnit
 import Mathlib.Algebra.Order.AddGroupWithTop
-import Mathlib.Order.Heyting.Basic
-
 /-!
 # Instances on PUnit
 
@@ -25,6 +23,7 @@ instance linearOrderedCancelAddCommMonoid : LinearOrderedCancelAddCommMonoid PUn
   add_le_add_left := by intros; rfl
 
 instance : LinearOrderedAddCommMonoidWithTop PUnit where
+  le_top _ := le_rfl
   top_add' _ := rfl
 
 end PUnit

--- a/Mathlib/Algebra/Ring/BooleanRing.lean
+++ b/Mathlib/Algebra/Ring/BooleanRing.lean
@@ -3,12 +3,12 @@ Copyright (c) 2021 Bryan Gin-ge Chen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bryan Gin-ge Chen, Yaël Dillies
 -/
-import Mathlib.Algebra.PUnitInstances.Algebra
+import Mathlib.Algebra.Group.Idempotent
+import Mathlib.Algebra.Ring.Equiv
+import Mathlib.Algebra.Ring.PUnit
+import Mathlib.Order.Hom.Lattice
 import Mathlib.Tactic.Abel
 import Mathlib.Tactic.Ring
-import Mathlib.Order.Hom.Lattice
-import Mathlib.Algebra.Ring.Equiv
-import Mathlib.Algebra.Group.Idempotent
 
 /-!
 # Boolean rings

--- a/Mathlib/Algebra/Ring/PUnit.lean
+++ b/Mathlib/Algebra/Ring/PUnit.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2019 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+-/
+import Mathlib.Algebra.Group.PUnit
+import Mathlib.Algebra.Ring.Defs
+
+/-!
+# `PUnit` is a commutative ring
+
+This file collects facts about algebraic structures on the one-element type, e.g. that it is a
+commutative ring.
+-/
+
+assert_not_exists Field
+
+namespace PUnit
+
+instance commRing : CommRing PUnit where
+  __ := PUnit.commGroup
+  __ := PUnit.addCommGroup
+  left_distrib := by intros; rfl
+  right_distrib := by intros; rfl
+  zero_mul := by intros; rfl
+  mul_zero := by intros; rfl
+  natCast _ := unit
+
+instance cancelCommMonoidWithZero : CancelCommMonoidWithZero PUnit where
+  mul_left_cancel_of_ne_zero := by simp
+
+end PUnit

--- a/Mathlib/Analysis/Normed/Group/Constructions.lean
+++ b/Mathlib/Analysis/Normed/Group/Constructions.lean
@@ -3,8 +3,8 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl, Yaël Dillies
 -/
+import Mathlib.Algebra.Group.PUnit
 import Mathlib.Algebra.Group.ULift
-import Mathlib.Algebra.PUnitInstances.Algebra
 import Mathlib.Analysis.Normed.Group.Basic
 
 /-!

--- a/Mathlib/CategoryTheory/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Action/Basic.lean
@@ -4,11 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Category.Grp.Basic
-import Mathlib.CategoryTheory.SingleObj
-import Mathlib.CategoryTheory.Limits.FunctorCategory.Basic
-import Mathlib.CategoryTheory.Limits.Preserves.Basic
+import Mathlib.Algebra.Ring.PUnit
 import Mathlib.CategoryTheory.Adjunction.Limits
 import Mathlib.CategoryTheory.Conj
+import Mathlib.CategoryTheory.Limits.FunctorCategory.Basic
+import Mathlib.CategoryTheory.Limits.Preserves.Basic
+import Mathlib.CategoryTheory.SingleObj
 
 /-!
 # `Action V G`, the category of actions of a monoid `G` inside some category `V`.

--- a/Mathlib/CategoryTheory/Category/Grpd.lean
+++ b/Mathlib/CategoryTheory/Category/Grpd.lean
@@ -22,6 +22,7 @@ Though `Grpd` is not a concrete category, we use `Bundled` to define
 its carrier type.
 -/
 
+assert_not_exists MonoidWithZero
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/SingleObj.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/SingleObj.lean
@@ -23,6 +23,8 @@ We characterise (co)limits of shape `SingleObj M`. Currently only in the categor
 
 -/
 
+assert_not_exists MonoidWithZero
+
 universe u v
 
 namespace CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Types/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Types/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Category.MonCat.Basic
+import Mathlib.Algebra.Ring.PUnit
 import Mathlib.CategoryTheory.Monoidal.CommMon_
 import Mathlib.CategoryTheory.Monoidal.Types.Basic
 

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Types/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Types/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Category.MonCat.Basic
-import Mathlib.Algebra.Ring.PUnit
 import Mathlib.CategoryTheory.Monoidal.CommMon_
 import Mathlib.CategoryTheory.Monoidal.Types.Basic
 
@@ -17,6 +16,7 @@ is equivalent to the category of "native" bundled monoids.
 Moreover, this equivalence is compatible with the forgetful functors to `Type`.
 -/
 
+assert_not_exists MonoidWithZero
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -3,11 +3,11 @@ Copyright (c) 2020 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
+import Mathlib.Algebra.Group.PUnit
 import Mathlib.CategoryTheory.Monoidal.Braided.Basic
-import Mathlib.CategoryTheory.Monoidal.Discrete
 import Mathlib.CategoryTheory.Monoidal.CoherenceLemmas
+import Mathlib.CategoryTheory.Monoidal.Discrete
 import Mathlib.CategoryTheory.Limits.Shapes.Terminal
-import Mathlib.Algebra.PUnitInstances.Algebra
 
 /-!
 # The category of monoids in a monoidal category.

--- a/Mathlib/CategoryTheory/SingleObj.lean
+++ b/Mathlib/CategoryTheory/SingleObj.lean
@@ -37,6 +37,7 @@ An element `x : M` can be reinterpreted as an element of `End (SingleObj.star M)
   `CategoryTheory.SingleObj`, so we give all names explicitly.
 -/
 
+assert_not_exists MonoidWithZero
 
 universe u v w
 

--- a/Mathlib/GroupTheory/Coprod/Basic.lean
+++ b/Mathlib/GroupTheory/Coprod/Basic.lean
@@ -3,9 +3,9 @@ Copyright (c) 2023 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
+import Mathlib.Algebra.Group.PUnit
 import Mathlib.Algebra.Group.Subgroup.Ker
 import Mathlib.Algebra.Group.Submonoid.Membership
-import Mathlib.Algebra.PUnitInstances.Algebra
 import Mathlib.GroupTheory.Congruence.Basic
 
 /-!
@@ -116,6 +116,8 @@ There are several reasons to build an API from scratch.
 
 group, monoid, coproduct, free product
 -/
+
+assert_not_exists Ring
 
 open FreeMonoid Function List Set
 

--- a/Mathlib/GroupTheory/Coprod/Basic.lean
+++ b/Mathlib/GroupTheory/Coprod/Basic.lean
@@ -117,7 +117,7 @@ There are several reasons to build an API from scratch.
 group, monoid, coproduct, free product
 -/
 
-assert_not_exists Ring
+assert_not_exists MonoidWithZero
 
 open FreeMonoid Function List Set
 


### PR DESCRIPTION
Being about `PUnit` isn't really a topic. Let's follow the existing convention that `Foo` instances about `Bar` are in `Algebra.Foo.Bar`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
