### PR TITLE
[Merged by Bors] - doc: turn links to Stacks into `stacks` attributes

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Basic.lean
@@ -242,11 +242,9 @@ attribute [local instance] OfCoimageImageComparisonIsIso.isNormalEpiCategory
 
 /-- A preadditive category with kernels, cokernels, and finite products,
 in which the coimage-image comparison morphism is always an isomorphism,
-is an abelian category.
-
-The Stacks project uses this characterisation at the definition of an abelian category.
-See <https://stacks.math.columbia.edu/tag/0109>.
--/
+is an abelian category. -/
+@[stacks 0109
+"The Stacks project uses this characterisation at the definition of an abelian category."]
 def ofCoimageImageComparisonIsIso : Abelian C where
 
 end CategoryTheory.Abelian

--- a/Mathlib/CategoryTheory/Abelian/Images.lean
+++ b/Mathlib/CategoryTheory/Abelian/Images.lean
@@ -85,10 +85,8 @@ end Coimage
 In any abelian category this is an isomorphism.
 
 Conversely, any additive category with kernels and cokernels and
-in which this is always an isomorphism, is abelian.
-
-See <https://stacks.math.columbia.edu/tag/0107>
--/
+in which this is always an isomorphism, is abelian. -/
+@[stacks 0107]
 def coimageImageComparison : Abelian.coimage f ⟶ Abelian.image f :=
   cokernel.desc (kernel.ι f) (kernel.lift (cokernel.π f) f (by simp)) (by ext; simp)
 

--- a/Mathlib/CategoryTheory/Abelian/Transfer.lean
+++ b/Mathlib/CategoryTheory/Abelian/Transfer.lean
@@ -154,10 +154,8 @@ open AbelianOfAdjunction
 we have `F : C ⥤ D` `G : D ⥤ C` (both preserving zero morphisms),
 `G` is left exact (that is, preserves finite limits),
 and further we have `adj : G ⊣ F` and `i : F ⋙ G ≅ 𝟭 C`,
-then `C` is also abelian.
-
-See <https://stacks.math.columbia.edu/tag/03A3>
--/
+then `C` is also abelian. -/
+@[stacks 03A3]
 def abelianOfAdjunction {C : Type u₁} [Category.{v₁} C] [Preadditive C] [HasFiniteProducts C]
     {D : Type u₂} [Category.{v₂} D] [Abelian D] (F : C ⥤ D) [Functor.PreservesZeroMorphisms F]
     (G : D ⥤ C) [Functor.PreservesZeroMorphisms G] [PreservesFiniteLimits G] (i : F ⋙ G ≅ 𝟭 C)

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -97,10 +97,8 @@ There is also a constructor `Adjunction.mkOfHomEquiv` which constructs an adjunc
 hom set equivalence.
 
 To construct adjoints to a given functor, there are constructors `leftAdjointOfEquiv` and
-`adjunctionOfEquivLeft` (as well as their duals).
-
-See <https://stacks.math.columbia.edu/tag/0037>.
--/
+`adjunctionOfEquivLeft` (as well as their duals). -/
+@[stacks 0037]
 structure Adjunction (F : C ⥤ D) (G : D ⥤ C) where
   /-- The unit of an adjunction -/
   unit : 𝟭 C ⟶ F.comp G
@@ -508,11 +506,8 @@ section
 variable {E : Type u₃} [ℰ : Category.{v₃} E] {H : D ⥤ E} {I : E ⥤ D}
   (adj₁ : F ⊣ G) (adj₂ : H ⊣ I)
 
-/-- Composition of adjunctions.
-
-See <https://stacks.math.columbia.edu/tag/0DV0>.
--/
-@[simps! (config := .lemmasOnly) unit counit]
+/-- Composition of adjunctions. -/
+@[simps! (config := .lemmasOnly) unit counit, stacks 0DV0]
 def comp : F ⋙ H ⊣ I ⋙ G :=
   mk' {
     homEquiv := fun _ _ ↦ Equiv.trans (adj₂.homEquiv _ _) (adj₁.homEquiv _ _)

--- a/Mathlib/CategoryTheory/Adjunction/Limits.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Limits.lean
@@ -79,10 +79,8 @@ def functorialityAdjunction : Cocones.functoriality K F ⊣ functorialityRightAd
   counit := functorialityCounit adj K
 
 include adj in
-/-- A left adjoint preserves colimits.
-
-See <https://stacks.math.columbia.edu/tag/0038>.
--/
+/-- A left adjoint preserves colimits. -/
+@[stacks 0038]
 lemma leftAdjoint_preservesColimits : PreservesColimitsOfSize.{v, u} F where
   preservesColimitsOfShape :=
     { preservesColimit :=
@@ -203,10 +201,8 @@ def functorialityAdjunction' : functorialityLeftAdjoint adj K ⊣ Cones.functori
   counit := functorialityCounit' adj K
 
 include adj in
-/-- A right adjoint preserves limits.
-
-See <https://stacks.math.columbia.edu/tag/0038>.
--/
+/-- A right adjoint preserves limits. -/
+@[stacks 0038]
 lemma rightAdjoint_preservesLimits : PreservesLimitsOfSize.{v, u} G where
   preservesLimitsOfShape :=
     { preservesLimit :=

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -142,11 +142,8 @@ attribute [aesop safe (rule_sets := [CategoryTheory])] Subsingleton.elim
 
 /-- The typeclass `Category C` describes morphisms associated to objects of type `C`.
 The universe levels of the objects and morphisms are unconstrained, and will often need to be
-specified explicitly, as `Category.{v} C`. (See also `LargeCategory` and `SmallCategory`.)
-
-See <https://stacks.math.columbia.edu/tag/0014>.
--/
-@[pp_with_univ]
+specified explicitly, as `Category.{v} C`. (See also `LargeCategory` and `SmallCategory`.) -/
+@[pp_with_univ, stacks 0014]
 class Category (obj : Type u) extends CategoryStruct.{v} obj : Type max u (v + 1) where
   /-- Identity morphisms are left identities for composition. -/
   id_comp : ∀ {X Y : obj} (f : X ⟶ Y), 𝟙 X ≫ f = f := by aesop_cat
@@ -235,19 +232,15 @@ theorem dite_comp {P : Prop} [Decidable P]
     (if h : P then f h else f' h) ≫ g = if h : P then f h ≫ g else f' h ≫ g := by aesop
 
 /-- A morphism `f` is an epimorphism if it can be cancelled when precomposed:
-`f ≫ g = f ≫ h` implies `g = h`.
-
-See <https://stacks.math.columbia.edu/tag/003B>.
--/
+`f ≫ g = f ≫ h` implies `g = h`. -/
+@[stacks 003B]
 class Epi (f : X ⟶ Y) : Prop where
   /-- A morphism `f` is an epimorphism if it can be cancelled when precomposed. -/
   left_cancellation : ∀ {Z : C} (g h : Y ⟶ Z), f ≫ g = f ≫ h → g = h
 
 /-- A morphism `f` is a monomorphism if it can be cancelled when postcomposed:
-`g ≫ f = h ≫ f` implies `g = h`.
-
-See <https://stacks.math.columbia.edu/tag/003B>.
--/
+`g ≫ f = h ≫ f` implies `g = h`. -/
+@[stacks 003B]
 class Mono (f : X ⟶ Y) : Prop where
   /-- A morphism `f` is a monomorphism if it can be cancelled when postcomposed. -/
   right_cancellation : ∀ {Z : C} (g h : Z ⟶ X), g ≫ f = h ≫ f → g = h

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -39,10 +39,8 @@ The category structure coming from a preorder. There is a morphism `X ⟶ Y` if 
 
 Because we don't allow morphisms to live in `Prop`,
 we have to define `X ⟶ Y` as `ULift (PLift (X ≤ Y))`.
-See `CategoryTheory.homOfLE` and `CategoryTheory.leOfHom`.
-
-See <https://stacks.math.columbia.edu/tag/00D3>.
--/
+See `CategoryTheory.homOfLE` and `CategoryTheory.leOfHom`. -/
+@[stacks 00D3]
 instance (priority := 100) smallCategory (α : Type u) [Preorder α] : SmallCategory α where
   Hom U V := ULift (PLift (U ≤ V))
   id X := ⟨⟨le_refl X⟩⟩

--- a/Mathlib/CategoryTheory/Comma/Over.lean
+++ b/Mathlib/CategoryTheory/Comma/Over.lean
@@ -30,10 +30,8 @@ variable {T : Type u₁} [Category.{v₁} T]
 variable {D : Type u₂} [Category.{v₂} D]
 
 /-- The over category has as objects arrows in `T` with codomain `X` and as morphisms commutative
-triangles.
-
-See <https://stacks.math.columbia.edu/tag/001G>.
--/
+triangles. -/
+@[stacks 001G]
 def Over (X : T) :=
   CostructuredArrow (𝟭 T) X
 
@@ -118,10 +116,8 @@ section
 
 variable (X)
 
-/-- The forgetful functor mapping an arrow to its domain.
-
-See <https://stacks.math.columbia.edu/tag/001G>.
--/
+/-- The forgetful functor mapping an arrow to its domain. -/
+@[stacks 001G]
 def forget : Over X ⥤ T :=
   Comma.fst _ _
 
@@ -141,10 +137,8 @@ def forgetCocone (X : T) : Limits.Cocone (forget X) :=
   { pt := X
     ι := { app := Comma.hom } }
 
-/-- A morphism `f : X ⟶ Y` induces a functor `Over X ⥤ Over Y` in the obvious way.
-
-See <https://stacks.math.columbia.edu/tag/001G>.
--/
+/-- A morphism `f : X ⟶ Y` induces a functor `Over X ⥤ Over Y` in the obvious way. -/
+@[stacks 001G]
 def map {Y : T} (f : X ⟶ Y) : Over X ⥤ Over Y :=
   Comma.mapRight _ <| Discrete.natTrans fun _ => f
 

--- a/Mathlib/CategoryTheory/DiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/DiscreteCategory.lean
@@ -67,10 +67,8 @@ instance {α : Type u₁} [DecidableEq α] : DecidableEq (Discrete α) :=
 /-- The "Discrete" category on a type, whose morphisms are equalities.
 
 Because we do not allow morphisms in `Prop` (only in `Type`),
-somewhat annoyingly we have to define `X ⟶ Y` as `ULift (PLift (X = Y))`.
-
-See <https://stacks.math.columbia.edu/tag/001A>
--/
+somewhat annoyingly we have to define `X ⟶ Y` as `ULift (PLift (X = Y))`. -/
+@[stacks 001A]
 instance discreteCategory (α : Type u₁) : SmallCategory (Discrete α) where
   Hom X Y := ULift (PLift (X.as = Y.as))
   id _ := ULift.up (PLift.up rfl)

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -71,11 +71,8 @@ universe v₁ v₂ v₃ u₁ u₂ u₃
 
   The triangle equation is written as a family of equalities between morphisms, it is more
   complicated if we write it as an equality of natural transformations, because then we would have
-  to insert natural transformations like `F ⟶ F1`.
-
-See <https://stacks.math.columbia.edu/tag/001J>
--/
-@[ext]
+  to insert natural transformations like `F ⟶ F1`. -/
+@[ext, stacks 001J]
 structure Equivalence (C : Type u₁) (D : Type u₂) [Category.{v₁} C] [Category.{v₂} D] where mk' ::
   /-- A functor in one direction -/
   functor : C ⥤ D
@@ -425,10 +422,8 @@ theorem pow_neg_one (e : C ≌ C) : e ^ (-1 : ℤ) = e.symm :=
 -- Note: the better formulation of this would involve `HasShift`.
 end
 
-/-- The functor of an equivalence of categories is essentially surjective.
-
-See <https://stacks.math.columbia.edu/tag/02C3>.
--/
+/-- The functor of an equivalence of categories is essentially surjective. -/
+@[stacks 02C3]
 instance essSurj_functor (e : C ≌ E) : e.functor.EssSurj :=
   ⟨fun Y => ⟨e.inverse.obj Y, ⟨e.counitIso.app Y⟩⟩⟩
 
@@ -443,20 +438,16 @@ def fullyFaithfulFunctor (e : C ≌ E) : e.functor.FullyFaithful where
 def fullyFaithfulInverse (e : C ≌ E) : e.inverse.FullyFaithful where
   preimage {X Y} f := e.counitIso.inv.app X ≫ e.functor.map f ≫ e.counitIso.hom.app Y
 
-/-- The functor of an equivalence of categories is faithful.
-
-See <https://stacks.math.columbia.edu/tag/02C3>.
--/
+/-- The functor of an equivalence of categories is faithful. -/
+@[stacks 02C3]
 instance faithful_functor (e : C ≌ E) : e.functor.Faithful :=
   e.fullyFaithfulFunctor.faithful
 
 instance faithful_inverse (e : C ≌ E) : e.inverse.Faithful :=
   e.fullyFaithfulInverse.faithful
 
-/-- The functor of an equivalence of categories is full.
-
-See <https://stacks.math.columbia.edu/tag/02C3>.
--/
+/-- The functor of an equivalence of categories is full. -/
+@[stacks 02C3]
 instance full_functor (e : C ≌ E) : e.functor.Full :=
   e.fullyFaithfulFunctor.full
 
@@ -527,10 +518,8 @@ noncomputable def inv (F : C ⥤ D) [F.IsEquivalence] : D ⥤ C where
   map_id X := by apply F.map_injective; simp
   map_comp {X Y Z} f g := by apply F.map_injective; simp
 
-/-- Interpret a functor that is an equivalence as an equivalence.
-
-See <https://stacks.math.columbia.edu/tag/02C3>. -/
-@[simps functor]
+/-- Interpret a functor that is an equivalence as an equivalence. -/
+@[simps functor, stacks 02C3]
 noncomputable def asEquivalence (F : C ⥤ D) [F.IsEquivalence] : C ≌ D where
   functor := F
   inverse := F.inv

--- a/Mathlib/CategoryTheory/EssentialImage.lean
+++ b/Mathlib/CategoryTheory/EssentialImage.lean
@@ -109,10 +109,8 @@ def toEssImageCompEssentialImageInclusion (F : C ⥤ D) : F.toEssImage ⋙ F.ess
   FullSubcategory.lift_comp_inclusion _ _ _
 
 /-- A functor `F : C ⥤ D` is essentially surjective if every object of `D` is in the essential
-image of `F`. In other words, for every `Y : D`, there is some `X : C` with `F.obj X ≅ Y`.
-
-See <https://stacks.math.columbia.edu/tag/001C>.
--/
+image of `F`. In other words, for every `Y : D`, there is some `X : C` with `F.obj X ≅ Y`. -/
+@[stacks 001C]
 class EssSurj (F : C ⥤ D) : Prop where
   /-- All the objects of the target category are in the essential image. -/
   mem_essImage (Y : D) : Y ∈ F.essImage

--- a/Mathlib/CategoryTheory/FiberedCategory/Cartesian.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Cartesian.lean
@@ -65,9 +65,8 @@ a'        a --φ--> b
 v         v        v
 R' --g--> R --f--> S
 ```
-such that `φ'` lifts `g ≫ f`, there exists a lift `χ` of `g` such that `φ' = χ ≫ φ`.
-
-See <https://stacks.math.columbia.edu/tag/02XK>. -/
+such that `φ'` lifts `g ≫ f`, there exists a lift `χ` of `g` such that `φ' = χ ≫ φ`. -/
+@[stacks 02XK]
 class IsStronglyCartesian extends IsHomLift p f φ : Prop where
   universal_property' {a' : 𝒳} (g : p.obj a' ⟶ R) (φ' : a' ⟶ b) [IsHomLift p (g ≫ f) φ'] :
       ∃! χ : a' ⟶ a, IsHomLift p g χ ∧ χ ≫ φ = φ'

--- a/Mathlib/CategoryTheory/FiberedCategory/Cocartesian.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Cocartesian.lean
@@ -60,9 +60,8 @@ a --φ--> b        b'
 v        v        v
 R --f--> S --g--> S'
 ```
-such that `φ'` lifts `f ≫ g`, there exists a lift `χ` of `g` such that `φ' = χ ≫ φ`.
-
-See <https://stacks.math.columbia.edu/tag/02XK>. -/
+such that `φ'` lifts `f ≫ g`, there exists a lift `χ` of `g` such that `φ' = χ ≫ φ`. -/
+@[stacks 02XK]
 class IsStronglyCocartesian extends IsHomLift p f φ : Prop where
   universal_property' {b' : 𝒳} (g : S ⟶ p.obj b') (φ' : a ⟶ b') [IsHomLift p (f ≫ g) φ'] :
       ∃! χ : b ⟶ b', IsHomLift p g χ ∧ φ ≫ χ = φ'

--- a/Mathlib/CategoryTheory/Filtered/Basic.lean
+++ b/Mathlib/CategoryTheory/Filtered/Basic.lean
@@ -76,10 +76,8 @@ class IsFilteredOrEmpty : Prop where
 1. for every pair of objects there exists another object "to the right",
 2. for every pair of parallel morphisms there exists a morphism to the right so the compositions
    are equal, and
-3. there exists some object.
-
-See <https://stacks.math.columbia.edu/tag/002V>. (They also define a diagram being filtered.)
--/
+3. there exists some object. -/
+@[stacks 002V "They also define a diagram being filtered."]
 class IsFiltered extends IsFilteredOrEmpty C : Prop where
   /-- a filtered category must be non empty -/
   [nonempty : Nonempty C]
@@ -504,10 +502,8 @@ class IsCofilteredOrEmpty : Prop where
 1. for every pair of objects there exists another object "to the left",
 2. for every pair of parallel morphisms there exists a morphism to the left so the compositions
    are equal, and
-3. there exists some object.
-
-See <https://stacks.math.columbia.edu/tag/04AZ>.
--/
+3. there exists some object. -/
+@[stacks 04AZ]
 class IsCofiltered extends IsCofilteredOrEmpty C : Prop where
   /-- a cofiltered category must be non empty -/
   [nonempty : Nonempty C]

--- a/Mathlib/CategoryTheory/FullSubcategory.lean
+++ b/Mathlib/CategoryTheory/FullSubcategory.lean
@@ -99,11 +99,8 @@ variable (Z : C → Prop)
 /--
 A subtype-like structure for full subcategories. Morphisms just ignore the property. We don't use
 actual subtypes since the simp-normal form `↑X` of `X.val` does not work well for full
-subcategories.
-
-See <https://stacks.math.columbia.edu/tag/001D>. We do not define 'strictly full' subcategories.
--/
-@[ext]
+subcategories. -/
+@[ext, stacks 001D "We do not define 'strictly full' subcategories."]
 structure FullSubcategory where
   /-- The category of which this is a full subcategory -/
   obj : C

--- a/Mathlib/CategoryTheory/Functor/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/Basic.lean
@@ -30,10 +30,8 @@ section
 To apply a functor `F` to an object use `F.obj X`, and to a morphism use `F.map f`.
 
 The axiom `map_id` expresses preservation of identities, and
-`map_comp` expresses functoriality.
-
-See <https://stacks.math.columbia.edu/tag/001B>.
--/
+`map_comp` expresses functoriality. -/
+@[stacks 001B]
 structure Functor (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
     extends Prefunctor C D : Type max v₁ v₂ u₁ u₂ where
   /-- A functor preserves identity morphisms. -/

--- a/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
@@ -36,17 +36,13 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 
 namespace Functor
 
-/-- A functor `F : C ⥤ D` is full if for each `X Y : C`, `F.map` is surjective.
-
-See <https://stacks.math.columbia.edu/tag/001C>.
--/
+/-- A functor `F : C ⥤ D` is full if for each `X Y : C`, `F.map` is surjective. -/
+@[stacks 001C]
 class Full (F : C ⥤ D) : Prop where
   map_surjective {X Y : C} : Function.Surjective (F.map (X := X) (Y := Y))
 
-/-- A functor `F : C ⥤ D` is faithful if for each `X Y : C`, `F.map` is injective.
-
-See <https://stacks.math.columbia.edu/tag/001C>.
--/
+/-- A functor `F : C ⥤ D` is faithful if for each `X Y : C`, `F.map` is injective. -/
+@[stacks 001C]
 class Faithful (F : C ⥤ D) : Prop where
   /-- `F.map` is injective for each `X Y : C`. -/
   map_injective : ∀ {X Y : C}, Function.Injective (F.map : (X ⟶ Y) → (F.obj X ⟶ F.obj Y)) := by

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -67,10 +67,8 @@ NB. Some authors include the empty category as connected, we do not.
 We instead are interested in categories with exactly one 'connected
 component'.
 
-This allows us to show that the functor X ⨯ - preserves connected limits.
-
-See <https://stacks.math.columbia.edu/tag/002S>
--/
+This allows us to show that the functor X ⨯ - preserves connected limits. -/
+@[stacks 002S]
 class IsConnected (J : Type u₁) [Category.{v₁} J] extends IsPreconnected J : Prop where
   [is_nonempty : Nonempty J]
 

--- a/Mathlib/CategoryTheory/Iso.lean
+++ b/Mathlib/CategoryTheory/Iso.lean
@@ -42,10 +42,8 @@ open Category
 The inverse morphism is bundled.
 
 See also `CategoryTheory.Core` for the category with the same objects and isomorphisms playing
-the role of morphisms.
-
-See <https://stacks.math.columbia.edu/tag/0017>.
--/
+the role of morphisms. -/
+@[stacks 0017]
 structure Iso {C : Type u} [Category.{v} C] (X Y : C) where
   /-- The forward direction of an isomorphism. -/
   hom : X ⟶ Y

--- a/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
@@ -123,19 +123,15 @@ instance limitSubobjectProduct_mono [HasLimitsOfSize.{w, w} C] (F : J ⥤ C) :
     Mono (limitSubobjectProduct F) :=
   mono_comp _ _
 
-/-- Any category with products and equalizers has all limits.
-
-See <https://stacks.math.columbia.edu/tag/002N>.
--/
+/-- Any category with products and equalizers has all limits. -/
+@[stacks 002N]
 theorem has_limits_of_hasEqualizers_and_products [HasProducts.{w} C] [HasEqualizers C] :
     HasLimitsOfSize.{w, w} C :=
   { has_limits_of_shape :=
     fun _ _ => { has_limit := fun F => hasLimit_of_equalizer_and_product F } }
 
-/-- Any category with finite products and equalizers has all finite limits.
-
-See <https://stacks.math.columbia.edu/tag/002O>.
--/
+/-- Any category with finite products and equalizers has all finite limits. -/
+@[stacks 002O]
 theorem hasFiniteLimits_of_hasEqualizers_and_finite_products [HasFiniteProducts C]
     [HasEqualizers C] : HasFiniteLimits C where
   out _ := { has_limit := fun F => hasLimit_of_equalizer_and_product F }
@@ -343,19 +339,15 @@ instance colimitQuotientCoproduct_epi [HasColimitsOfSize.{w, w} C] (F : J ⥤ C)
     Epi (colimitQuotientCoproduct F) :=
   epi_comp _ _
 
-/-- Any category with coproducts and coequalizers has all colimits.
-
-See <https://stacks.math.columbia.edu/tag/002P>.
--/
+/-- Any category with coproducts and coequalizers has all colimits. -/
+@[stacks 002P]
 theorem has_colimits_of_hasCoequalizers_and_coproducts [HasCoproducts.{w} C] [HasCoequalizers C] :
     HasColimitsOfSize.{w, w} C where
   has_colimits_of_shape := fun _ _ =>
       { has_colimit := fun F => hasColimit_of_coequalizer_and_coproduct F }
 
-/-- Any category with finite coproducts and coequalizers has all finite colimits.
-
-See <https://stacks.math.columbia.edu/tag/002Q>.
--/
+/-- Any category with finite coproducts and coequalizers has all finite colimits. -/
+@[stacks 002Q]
 theorem hasFiniteColimits_of_hasCoequalizers_and_finite_coproducts [HasFiniteCoproducts C]
     [HasCoequalizers C] : HasFiniteColimits C where
   out _ := { has_colimit := fun F => hasColimit_of_coequalizer_and_coproduct F }

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -82,10 +82,8 @@ variable {D : Type u₂} [Category.{v₂} D]
 
 /--
 A functor `F : C ⥤ D` is final if for every `d : D`, the comma category of morphisms `d ⟶ F.obj c`
-is connected.
-
-See <https://stacks.math.columbia.edu/tag/04E6>
--/
+is connected. -/
+@[stacks 04E6]
 class Final (F : C ⥤ D) : Prop where
   out (d : D) : IsConnected (StructuredArrow d F)
 

--- a/Mathlib/CategoryTheory/Limits/IsLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/IsLimit.lean
@@ -46,10 +46,8 @@ variable {C : Type u₃} [Category.{v₃} C]
 variable {F : J ⥤ C}
 
 /-- A cone `t` on `F` is a limit cone if each cone on `F` admits a unique
-cone morphism to `t`.
-
-See <https://stacks.math.columbia.edu/tag/002E>.
-  -/
+cone morphism to `t`. -/
+@[stacks 002E]
 structure IsLimit (t : Cone F) where
   /-- There is a morphism from any cone point to `t.pt` -/
   lift : ∀ s : Cone F, s.pt ⟶ t.pt
@@ -495,10 +493,8 @@ end
 end IsLimit
 
 /-- A cocone `t` on `F` is a colimit cocone if each cocone on `F` admits a unique
-cocone morphism from `t`.
-
-See <https://stacks.math.columbia.edu/tag/002F>.
--/
+cocone morphism from `t`. -/
+@[stacks 002F]
 structure IsColimit (t : Cocone F) where
   /-- `t.pt` maps to all other cocone covertices -/
   desc : ∀ s : Cocone F, t.pt ⟶ s.pt

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -837,17 +837,13 @@ end CoprodLemmas
 
 variable (C)
 
-/-- `HasBinaryProducts` represents a choice of product for every pair of objects.
-
-See <https://stacks.math.columbia.edu/tag/001T>.
--/
+/-- `HasBinaryProducts` represents a choice of product for every pair of objects. -/
+@[stacks 001T]
 abbrev HasBinaryProducts :=
   HasLimitsOfShape (Discrete WalkingPair) C
 
-/-- `HasBinaryCoproducts` represents a choice of coproduct for every pair of objects.
-
-See <https://stacks.math.columbia.edu/tag/04AP>.
--/
+/-- `HasBinaryCoproducts` represents a choice of coproduct for every pair of objects. -/
+@[stacks 04AP]
 abbrev HasBinaryCoproducts :=
   HasColimitsOfShape (Discrete WalkingPair) C
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
@@ -502,10 +502,8 @@ end PushoutSymmetry
 
 variable (C)
 
-/-- `HasPullbacks` represents a choice of pullback for every pair of morphisms
-
-See <https://stacks.math.columbia.edu/tag/001W>
--/
+/-- `HasPullbacks` represents a choice of pullback for every pair of morphisms. -/
+@[stacks 001W]
 abbrev HasPullbacks :=
   HasLimitsOfShape WalkingCospan C
 

--- a/Mathlib/CategoryTheory/Limits/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Types.lean
@@ -192,10 +192,8 @@ instance hasLimitsOfShape [Small.{u} J] : HasLimitsOfShape J (Type u) where
 /--
 The category of types has all limits.
 
-More specifically, when `UnivLE.{v, u}`, the category `Type u` has all `v`-small limits.
-
-See <https://stacks.math.columbia.edu/tag/002U>.
--/
+More specifically, when `UnivLE.{v, u}`, the category `Type u` has all `v`-small limits. -/
+@[stacks 002U]
 instance (priority := 1300) hasLimitsOfSize [UnivLE.{v, u}] : HasLimitsOfSize.{w, v} (Type u) where
   has_limits_of_shape _ := { }
 
@@ -484,10 +482,8 @@ instance hasColimit [Small.{u} J] (F : J ⥤ Type u) : HasColimit F :=
 
 instance hasColimitsOfShape [Small.{u} J] : HasColimitsOfShape J (Type u) where
 
-/-- The category of types has all colimits.
-
-See <https://stacks.math.columbia.edu/tag/002U>.
--/
+/-- The category of types has all colimits. -/
+@[stacks 002U]
 instance (priority := 1300) hasColimitsOfSize [UnivLE.{v, u}] :
     HasColimitsOfSize.{w, v} (Type u) where
 

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
@@ -342,10 +342,8 @@ theorem braiding_inv_tensorUnit_right (X : C) : (β_ X (𝟙_ C)).inv = (λ_ X).
 end
 
 /--
-A symmetric monoidal category is a braided monoidal category for which the braiding is symmetric.
-
-See <https://stacks.math.columbia.edu/tag/0FFW>.
--/
+A symmetric monoidal category is a braided monoidal category for which the braiding is symmetric. -/
+@[stacks 0FFW]
 class SymmetricCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] extends
     BraidedCategory.{v} C where
   -- braiding symmetric:

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -149,10 +149,8 @@ In a monoidal category, we can take the tensor product of objects, `X ⊗ Y` and
 Tensor product does not need to be strictly associative on objects, but there is a
 specified associator, `α_ X Y Z : (X ⊗ Y) ⊗ Z ≅ X ⊗ (Y ⊗ Z)`. There is a tensor unit `𝟙_ C`,
 with specified left and right unitor isomorphisms `λ_ X : 𝟙_ C ⊗ X ≅ X` and `ρ_ X : X ⊗ 𝟙_ C ≅ X`.
-These associators and unitors satisfy the pentagon and triangle equations.
-
-See <https://stacks.math.columbia.edu/tag/0FFK>.
--/
+These associators and unitors satisfy the pentagon and triangle equations. -/
+@[stacks 0FFK]
 -- Porting note: The Mathport did not translate the temporary notation
 class MonoidalCategory (C : Type u) [𝒞 : Category.{v} C] extends MonoidalCategoryStruct C where
   tensorHom_def {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :

--- a/Mathlib/CategoryTheory/Noetherian.lean
+++ b/Mathlib/CategoryTheory/Noetherian.lean
@@ -30,10 +30,8 @@ open CategoryTheory.Limits
 variable {C : Type*} [Category C]
 
 /-- A noetherian object is an object
-which does not have infinite increasing sequences of subobjects.
-
-See https://stacks.math.columbia.edu/tag/0FCG
--/
+which does not have infinite increasing sequences of subobjects. -/
+@[stacks 0FCG]
 class NoetherianObject (X : C) : Prop where
   subobject_gt_wellFounded' : WellFounded ((· > ·) : Subobject X → Subobject X → Prop)
 
@@ -42,10 +40,8 @@ lemma NoetherianObject.subobject_gt_wellFounded (X : C) [NoetherianObject X] :
   NoetherianObject.subobject_gt_wellFounded'
 
 /-- An artinian object is an object
-which does not have infinite decreasing sequences of subobjects.
-
-See https://stacks.math.columbia.edu/tag/0FCF
--/
+which does not have infinite decreasing sequences of subobjects. -/
+@[stacks 0FCF]
 class ArtinianObject (X : C) : Prop where
   subobject_lt_wellFounded' : WellFounded ((· < ·) : Subobject X → Subobject X → Prop)
 

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -60,10 +60,8 @@ namespace CategoryTheory
 
 variable [Category.{v₁} C]
 
-/-- The opposite category.
-
-See <https://stacks.math.columbia.edu/tag/001M>.
--/
+/-- The opposite category. -/
+@[stacks 001M]
 instance Category.opposite : Category.{v₁} Cᵒᵖ where
   comp f g := (g.unop ≫ f.unop).op
   id X := (𝟙 (unop X)).op

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -35,11 +35,8 @@ section
 variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
 
 -- the generates simp lemmas like `id_fst` and `comp_snd`
-/-- `prod C D` gives the cartesian product of two categories.
-
-See <https://stacks.math.columbia.edu/tag/001K>.
--/
-@[simps (config := { notRecursive := [] }) Hom id_fst id_snd comp_fst comp_snd]
+/-- `prod C D` gives the cartesian product of two categories. -/
+@[simps (config := { notRecursive := [] }) Hom id_fst id_snd comp_fst comp_snd, stacks 001K]
 instance prod : Category.{max v₁ v₂} (C × D) where
   Hom X Y := (X.1 ⟶ Y.1) × (X.2 ⟶ Y.2)
   id X := ⟨𝟙 X.1, 𝟙 X.2⟩

--- a/Mathlib/CategoryTheory/SingleObj.lean
+++ b/Mathlib/CategoryTheory/SingleObj.lean
@@ -74,10 +74,8 @@ theorem comp_as_mul {x y z : SingleObj M} (f : x ⟶ y) (g : y ⟶ z) : f ≫ g 
 /-- If `M` is finite and in universe zero, then `SingleObj M` is a `FinCategory`. -/
 instance finCategoryOfFintype (M : Type) [Fintype M] [Monoid M] : FinCategory (SingleObj M) where
 
-/-- Groupoid structure on `SingleObj M`.
-
-See <https://stacks.math.columbia.edu/tag/0019>.
--/
+/-- Groupoid structure on `SingleObj M`. -/
+@[stacks 0019]
 instance groupoid : Groupoid (SingleObj G) where
   inv x := x⁻¹
   inv_comp := mul_inv_cancel
@@ -104,12 +102,8 @@ theorem toEnd_def (x : M) : toEnd M x = x :=
 variable (N : Type v) [Monoid N]
 
 /-- There is a 1-1 correspondence between monoid homomorphisms `M → N` and functors between the
-    corresponding single-object categories. It means that `SingleObj` is a fully faithful
-    functor.
-
-See <https://stacks.math.columbia.edu/tag/001F> --
-although we do not characterize when the functor is full or faithful.
--/
+corresponding single-object categories. It means that `SingleObj` is a fully faithful functor. -/
+@[stacks 001F "We do not characterize when the functor is full or faithful."]
 def mapHom : (M →* N) ≃ SingleObj M ⥤ SingleObj N where
   toFun f :=
     { obj := id

--- a/Mathlib/CategoryTheory/Sites/Canonical.lean
+++ b/Mathlib/CategoryTheory/Sites/Canonical.lean
@@ -188,10 +188,8 @@ theorem le_finestTopology (Ps : Set (Cᵒᵖ ⥤ Type v)) (J : GrothendieckTopol
   exact hJ P hP (S.pullback f) (J.pullback_stable f hS)
 
 /-- The `canonicalTopology` on a category is the finest (largest) topology for which every
-representable presheaf is a sheaf.
-
-See <https://stacks.math.columbia.edu/tag/00ZA>
--/
+representable presheaf is a sheaf. -/
+@[stacks 00ZA]
 def canonicalTopology (C : Type u) [Category.{v} C] : GrothendieckTopology C :=
   finestTopology (Set.range yoneda.obj)
 

--- a/Mathlib/CategoryTheory/Sites/EqualizerSheafCondition.lean
+++ b/Mathlib/CategoryTheory/Sites/EqualizerSheafCondition.lean
@@ -224,9 +224,8 @@ theorem compatible_iff (x : FirstObj P R) :
     rw [Types.limit_ext_iff'] at t
     simpa [firstMap, secondMap] using t ⟨⟨⟨Y, f, hf⟩, Z, g, hg⟩⟩
 
-/-- `P` is a sheaf for `R`, iff the fork given by `w` is an equalizer.
-See <https://stacks.math.columbia.edu/tag/00VM>.
--/
+/-- `P` is a sheaf for `R`, iff the fork given by `w` is an equalizer. -/
+@[stacks 00VM]
 theorem sheaf_condition : R.IsSheafFor P ↔ Nonempty (IsLimit (Fork.ofι _ (w P R))) := by
   rw [Types.type_equalizer_iff_unique,
     ← Equiv.forall_congr_right (firstObjEqFamily P R).toEquiv.symm]
@@ -322,10 +321,8 @@ theorem compatible_iff (x : FirstObj P X) : (Arrows.Compatible P π ((Types.prod
     apply_fun Pi.π (fun (ij : I × I) ↦ P.obj (op (pullback (π ij.1) (π ij.2)))) ⟨i, j⟩ at t
     simpa [firstMap, secondMap] using t
 
-/--
-`P` is a sheaf for `Presieve.ofArrows X π`, iff the fork given by `w` is an equalizer.
-See <https://stacks.math.columbia.edu/tag/00VM>.
--/
+/-- `P` is a sheaf for `Presieve.ofArrows X π`, iff the fork given by `w` is an equalizer. -/
+@[stacks 00VM]
 theorem sheaf_condition : (Presieve.ofArrows X π).IsSheafFor P ↔
     Nonempty (IsLimit (Fork.ofι (forkMap P X π) (w P X π))) := by
   rw [Types.type_equalizer_iff_unique, isSheafFor_arrows_iff]

--- a/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -66,9 +66,8 @@ three axioms:
 
 A sieve `S` on `X` is referred to as `J`-covering, (or just covering), if `S ∈ J X`.
 
-See <https://stacks.math.columbia.edu/tag/00Z4>, or [nlab], or [MM92][] Chapter III, Section 2,
-Definition 1.
--/
+See also [nlab] or [MM92] Chapter III, Section 2, Definition 1. -/
+@[stacks 00Z4]
 structure GrothendieckTopology where
   /-- A Grothendieck topology on `C` consists of a set of sieves for each object `X`,
     which satisfy some axioms. -/
@@ -132,9 +131,8 @@ theorem covering_of_eq_top : S = ⊤ → S ∈ J X := fun h => h.symm ▸ J.top_
 
 /-- If `S` is a subset of `R`, and `S` is covering, then `R` is covering as well.
 
-See <https://stacks.math.columbia.edu/tag/00Z5> (2), or discussion after [MM92] Chapter III,
-Section 2, Definition 1.
--/
+See also discussion after [MM92] Chapter III, Section 2, Definition 1. -/
+@[stacks 00Z5 "(2)"]
 theorem superset_covering (Hss : S ≤ R) (sjx : S ∈ J X) : R ∈ J X := by
   apply J.transitive sjx R fun Y f hf => _
   intros Y f hf
@@ -144,9 +142,8 @@ theorem superset_covering (Hss : S ≤ R) (sjx : S ∈ J X) : R ∈ J X := by
 
 /-- The intersection of two covering sieves is covering.
 
-See <https://stacks.math.columbia.edu/tag/00Z5> (1), or [MM92] Chapter III,
-Section 2, Definition 1 (iv).
--/
+See also [MM92] Chapter III, Section 2, Definition 1 (iv). -/
+@[stacks 00Z5 "(1)"]
 theorem intersection_covering (rj : R ∈ J X) (sj : S ∈ J X) : R ⊓ S ∈ J X := by
   apply J.transitive rj _ fun Y f Hf => _
   intros Y f hf
@@ -231,21 +228,21 @@ variable {C}
 theorem trivial_covering : S ∈ trivial C X ↔ S = ⊤ :=
   Set.mem_singleton_iff
 
-/-- See <https://stacks.math.columbia.edu/tag/00Z6> -/
+@[stacks 00Z6]
 instance instLEGrothendieckTopology : LE (GrothendieckTopology C) where
   le J₁ J₂ := (J₁ : ∀ X : C, Set (Sieve X)) ≤ (J₂ : ∀ X : C, Set (Sieve X))
 
 theorem le_def {J₁ J₂ : GrothendieckTopology C} : J₁ ≤ J₂ ↔ (J₁ : ∀ X : C, Set (Sieve X)) ≤ J₂ :=
   Iff.rfl
 
-/-- See <https://stacks.math.columbia.edu/tag/00Z6> -/
+@[stacks 00Z6]
 instance : PartialOrder (GrothendieckTopology C) :=
   { instLEGrothendieckTopology with
     le_refl := fun _ => le_def.mpr le_rfl
     le_trans := fun _ _ _ h₁₂ h₂₃ => le_def.mpr (le_trans h₁₂ h₂₃)
     le_antisymm := fun _ _ h₁₂ h₂₁ => GrothendieckTopology.ext (le_antisymm h₁₂ h₂₁) }
 
-/-- See <https://stacks.math.columbia.edu/tag/00Z7> -/
+@[stacks 00Z7]
 instance : InfSet (GrothendieckTopology C) where
   sInf T :=
     { sieves := sInf (sieves '' T)
@@ -265,7 +262,7 @@ lemma mem_sInf (s : Set (GrothendieckTopology C)) {X : C} (S : Sieve X) :
   show S ∈ sInf (sieves '' s) X ↔ _
   simp
 
-/-- See <https://stacks.math.columbia.edu/tag/00Z7> -/
+@[stacks 00Z7]
 theorem isGLB_sInf (s : Set (GrothendieckTopology C)) : IsGLB s (sInf s) := by
   refine @IsGLB.of_image _ _ _ _ sieves ?_ _ _ ?_
   · #adaptation_note

--- a/Mathlib/CategoryTheory/Sites/Pretopology.lean
+++ b/Mathlib/CategoryTheory/Sites/Pretopology.lean
@@ -101,8 +101,9 @@ instance : Inhabited (Pretopology C) :=
 /-- A pretopology `K` can be completed to a Grothendieck topology `J` by declaring a sieve to be
 `J`-covering if it contains a family in `K`.
 
-See <https://stacks.math.columbia.edu/tag/00ZC>, or [MM92] Chapter III, Section 2, Equation (2).
+See also [MM92] Chapter III, Section 2, Equation (2).
 -/
+@[stacks 00ZC]
 def toGrothendieck (K : Pretopology C) : GrothendieckTopology C where
   sieves X S := ∃ R ∈ K X, R ≤ (S : Presieve _)
   top_mem' _ := ⟨Presieve.singleton (𝟙 _), K.has_isos _, fun _ _ _ => ⟨⟩⟩
@@ -162,10 +163,8 @@ lemma mem_ofGrothendieck (t : GrothendieckTopology C) {X : C} (S : Presieve X) :
 
 /--
 The trivial pretopology, in which the coverings are exactly singleton isomorphisms. This topology is
-also known as the indiscrete, coarse, or chaotic topology.
-
-See <https://stacks.math.columbia.edu/tag/07GE>
--/
+also known as the indiscrete, coarse, or chaotic topology. -/
+@[stacks 07GE]
 def trivial : Pretopology C where
   coverings X S := ∃ (Y : _) (f : Y ⟶ X) (_ : IsIso f), S = Presieve.singleton f
   has_isos _ _ _ i := ⟨_, _, i, rfl⟩

--- a/Mathlib/CategoryTheory/Triangulated/Basic.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Basic.lean
@@ -95,8 +95,7 @@ In other words, we have a commutative diagram:
      f'     g'     h'
 ```
 -/
-@[stacks 0144]
-@[ext]
+@[ext, stacks 0144]
 structure TriangleMorphism (T₁ : Triangle C) (T₂ : Triangle C) where
   /-- the first morphism in a triangle morphism -/
   hom₁ : T₁.obj₁ ⟶ T₂.obj₁

--- a/Mathlib/CategoryTheory/Triangulated/Basic.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Basic.lean
@@ -34,9 +34,8 @@ We work in a category `C` equipped with a shift.
 variable (C : Type u) [Category.{v} C] [HasShift C ℤ]
 
 /-- A triangle in `C` is a sextuple `(X,Y,Z,f,g,h)` where `X,Y,Z` are objects of `C`,
-and `f : X ⟶ Y`, `g : Y ⟶ Z`, `h : Z ⟶ X⟦1⟧` are morphisms in `C`.
-See <https://stacks.math.columbia.edu/tag/0144>.
--/
+and `f : X ⟶ Y`, `g : Y ⟶ Z`, `h : Z ⟶ X⟦1⟧` are morphisms in `C`. -/
+@[stacks 0144]
 structure Triangle where mk' ::
   /-- the first object of a triangle -/
   obj₁ : C
@@ -95,8 +94,8 @@ In other words, we have a commutative diagram:
   X' ───> Y' ───> Z' ───> X'⟦1⟧
      f'     g'     h'
 ```
-See <https://stacks.math.columbia.edu/tag/0144>.
 -/
+@[stacks 0144]
 @[ext]
 structure TriangleMorphism (T₁ : Triangle C) (T₂ : Triangle C) where
   /-- the first morphism in a triangle morphism -/

--- a/Mathlib/CategoryTheory/Triangulated/Pretriangulated.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Pretriangulated.lean
@@ -56,9 +56,8 @@ relative to that shift is called pretriangulated if the following hold:
   ```
   where the left square commutes, and whose rows are distinguished triangles,
   there exists a morphism `c : Z ⟶ Z'` such that `(a,b,c)` is a triangle morphism.
-
-See <https://stacks.math.columbia.edu/tag/0145>
 -/
+@[stacks 0145]
 class Pretriangulated [∀ n : ℤ, Functor.Additive (shiftFunctor C n)] where
   /-- a class of triangle which are called `distinguished` -/
   distinguishedTriangles : Set (Triangle C)
@@ -115,10 +114,8 @@ theorem inv_rot_of_distTriang (T : Triangle C) (H : T ∈ distTriang C) :
       f       g       h
   X  ───> Y  ───> Z  ───> X⟦1⟧
 ```
-the composition `f ≫ g = 0`.
-See <https://stacks.math.columbia.edu/tag/0146>
--/
-@[reassoc]
+the composition `f ≫ g = 0`. -/
+@[reassoc, stacks 0146]
 theorem comp_distTriang_mor_zero₁₂ (T) (H : T ∈ (distTriang C)) : T.mor₁ ≫ T.mor₂ = 0 := by
   obtain ⟨c, hc⟩ :=
     complete_distinguished_triangle_morphism _ _ (contractible_distinguished T.obj₁) H (𝟙 T.obj₁)
@@ -130,10 +127,8 @@ theorem comp_distTriang_mor_zero₁₂ (T) (H : T ∈ (distTriang C)) : T.mor₁
       f       g       h
   X  ───> Y  ───> Z  ───> X⟦1⟧
 ```
-the composition `g ≫ h = 0`.
-See <https://stacks.math.columbia.edu/tag/0146>
--/
-@[reassoc]
+the composition `g ≫ h = 0`. -/
+@[reassoc, stacks 0146]
 theorem comp_distTriang_mor_zero₂₃ (T : Triangle C) (H : T ∈ distTriang C) :
     T.mor₂ ≫ T.mor₃ = 0 :=
   comp_distTriang_mor_zero₁₂ T.rotate (rot_of_distTriang T H)
@@ -143,10 +138,8 @@ theorem comp_distTriang_mor_zero₂₃ (T : Triangle C) (H : T ∈ distTriang C)
       f       g       h
   X  ───> Y  ───> Z  ───> X⟦1⟧
 ```
-the composition `h ≫ f⟦1⟧ = 0`.
-See <https://stacks.math.columbia.edu/tag/0146>
--/
-@[reassoc]
+the composition `h ≫ f⟦1⟧ = 0`. -/
+@[reassoc, stacks 0146]
 theorem comp_distTriang_mor_zero₃₁ (T : Triangle C) (H : T ∈ distTriang C) :
     T.mor₃ ≫ T.mor₁⟦1⟧' = 0 := by
   have H₂ := rot_of_distTriang T.rotate (rot_of_distTriang T H)

--- a/Mathlib/CategoryTheory/Triangulated/Triangulated.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Triangulated.lean
@@ -32,8 +32,8 @@ variable {C}
 
 -- Porting note: see https://github.com/leanprover/lean4/issues/2188
 set_option genInjectivity false in
-/-- An octahedron is a type of datum whose existence is asserted by
-the octahedron axiom (TR 4), see https://stacks.math.columbia.edu/tag/05QK -/
+/-- An octahedron is a type of datum whose existence is asserted by the octahedron axiom (TR 4). -/
+@[stacks 05QK]
 structure Octahedron
   {X₁ X₂ X₃ Z₁₂ Z₂₃ Z₁₃ : C}
   {u₁₂ : X₁ ⟶ X₂} {u₂₃ : X₂ ⟶ X₃} {u₁₃ : X₁ ⟶ X₃} (comm : u₁₂ ≫ u₂₃ = u₁₃)
@@ -160,7 +160,8 @@ end Triangulated
 open Triangulated
 
 /-- A triangulated category is a pretriangulated category which satisfies
-the octahedron axiom (TR 4), see https://stacks.math.columbia.edu/tag/05QK -/
+the octahedron axiom (TR 4). -/
+@[stacks 05QK]
 class IsTriangulated : Prop where
   /-- the octahedron axiom (TR 4) -/
   octahedron_axiom :

--- a/Mathlib/CategoryTheory/Types.lean
+++ b/Mathlib/CategoryTheory/Types.lean
@@ -224,10 +224,8 @@ def homOfElement {X : Type u} (x : X) : PUnit ⟶ X := fun _ => x
 theorem homOfElement_eq_iff {X : Type u} (x y : X) : homOfElement x = homOfElement y ↔ x = y :=
   ⟨fun H => congr_fun H PUnit.unit, by aesop⟩
 
-/-- A morphism in `Type` is a monomorphism if and only if it is injective.
-
-See <https://stacks.math.columbia.edu/tag/003C>.
--/
+/-- A morphism in `Type` is a monomorphism if and only if it is injective. -/
+@[stacks 003C]
 theorem mono_iff_injective {X Y : Type u} (f : X ⟶ Y) : Mono f ↔ Function.Injective f := by
   constructor
   · intro H x x' h
@@ -238,10 +236,8 @@ theorem mono_iff_injective {X Y : Type u} (f : X ⟶ Y) : Mono f ↔ Function.In
 theorem injective_of_mono {X Y : Type u} (f : X ⟶ Y) [hf : Mono f] : Function.Injective f :=
   (mono_iff_injective f).1 hf
 
-/-- A morphism in `Type` is an epimorphism if and only if it is surjective.
-
-See <https://stacks.math.columbia.edu/tag/003C>.
--/
+/-- A morphism in `Type` is an epimorphism if and only if it is surjective. -/
+@[stacks 003C]
 theorem epi_iff_surjective {X Y : Type u} (f : X ⟶ Y) : Epi f ↔ Function.Surjective f := by
   constructor
   · rintro ⟨H⟩

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -29,11 +29,8 @@ universe v v₁ v₂ u₁ u₂
 -- morphism levels before object levels. See note [CategoryTheory universes].
 variable {C : Type u₁} [Category.{v₁} C]
 
-/-- The Yoneda embedding, as a functor from `C` into presheaves on `C`.
-
-See <https://stacks.math.columbia.edu/tag/001O>.
--/
-@[simps]
+/-- The Yoneda embedding, as a functor from `C` into presheaves on `C`. -/
+@[simps, stacks 001O]
 def yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁ where
   obj X :=
     { obj := fun Y => unop Y ⟶ X
@@ -70,17 +67,13 @@ def fullyFaithful : (yoneda (C := C)).FullyFaithful where
 lemma fullyFaithful_preimage {X Y : C} (f : yoneda.obj X ⟶ yoneda.obj Y) :
     fullyFaithful.preimage f = f.app (op X) (𝟙 X) := rfl
 
-/-- The Yoneda embedding is full.
-
-See <https://stacks.math.columbia.edu/tag/001P>.
--/
+/-- The Yoneda embedding is full. -/
+@[stacks 001P]
 instance yoneda_full : (yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁).Full :=
   fullyFaithful.full
 
-/-- The Yoneda embedding is faithful.
-
-See <https://stacks.math.columbia.edu/tag/001P>.
--/
+/-- The Yoneda embedding is faithful. -/
+@[stacks 001P]
 instance yoneda_faithful : (yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁).Faithful :=
   fullyFaithful.faithful
 
@@ -254,10 +247,8 @@ def CorepresentableBy.toIso {F : C ⥤ Type v₁} {X : C} (e : F.Corepresentable
 
 /-- A functor `F : Cᵒᵖ ⥤ Type v` is representable if there is an object `Y` with a structure
 `F.RepresentableBy Y`, i.e. there is a natural bijection `(X ⟶ Y) ≃ F.obj (op X)`,
-which may also be rephrased as a natural isomorphism `yoneda.obj X ≅ F` when `Category.{v} C`.
-
-See <https://stacks.math.columbia.edu/tag/001Q>.
--/
+which may also be rephrased as a natural isomorphism `yoneda.obj X ≅ F` when `Category.{v} C`. -/
+@[stacks 001Q]
 class IsRepresentable (F : Cᵒᵖ ⥤ Type v) : Prop where
   has_representation : ∃ (Y : C), Nonempty (F.RepresentableBy Y)
 
@@ -277,9 +268,8 @@ instance {X : C} : IsRepresentable (yoneda.obj X) :=
   IsRepresentable.mk' (Iso.refl _)
 
 /-- A functor `F : C ⥤ Type v₁` is corepresentable if there is object `X` so `F ≅ coyoneda.obj X`.
-
-See <https://stacks.math.columbia.edu/tag/001Q>.
 -/
+@[stacks 001Q]
 class IsCorepresentable (F : C ⥤ Type v) : Prop where
   has_corepresentation : ∃ (X : C), Nonempty (F.CorepresentableBy X)
 
@@ -527,10 +517,8 @@ def yonedaCompUliftFunctorEquiv (F : Cᵒᵖ ⥤ Type max v₁ w) (X : C) :
 
 /-- The Yoneda lemma asserts that the Yoneda pairing
 `(X : Cᵒᵖ, F : Cᵒᵖ ⥤ Type) ↦ (yoneda.obj (unop X) ⟶ F)`
-is naturally isomorphic to the evaluation `(X, F) ↦ F.obj X`.
-
-See <https://stacks.math.columbia.edu/tag/001P>.
--/
+is naturally isomorphic to the evaluation `(X, F) ↦ F.obj X`. -/
+@[stacks 001P]
 def yonedaLemma : yonedaPairing C ≅ yonedaEvaluation C :=
   NatIso.ofComponents
     (fun _ ↦ Equiv.toIso (yonedaEquiv.trans Equiv.ulift.symm))
@@ -709,10 +697,8 @@ def coyonedaCompUliftFunctorEquiv (F : C ⥤ Type max v₁ w) (X : Cᵒᵖ) :
 
 /-- The Coyoneda lemma asserts that the Coyoneda pairing
 `(X : C, F : C ⥤ Type) ↦ (coyoneda.obj X ⟶ F)`
-is naturally isomorphic to the evaluation `(X, F) ↦ F.obj X`.
-
-See <https://stacks.math.columbia.edu/tag/001P>.
--/
+is naturally isomorphic to the evaluation `(X, F) ↦ F.obj X`. -/
+@[stacks 001P]
 def coyonedaLemma : coyonedaPairing C ≅ coyonedaEvaluation C :=
   NatIso.ofComponents
     (fun _ ↦ Equiv.toIso (coyonedaEquiv.trans Equiv.ulift.symm))

--- a/Mathlib/RingTheory/Etale/Basic.lean
+++ b/Mathlib/RingTheory/Etale/Basic.lean
@@ -38,10 +38,8 @@ variable (R : Type u) [CommRing R]
 variable (A : Type u) [CommRing A] [Algebra R A]
 
 /-- An `R` algebra `A` is formally étale if for every `R`-algebra, every square-zero ideal
-`I : Ideal B` and `f : A →ₐ[R] B ⧸ I`, there exists exactly one lift `A →ₐ[R] B`.
-
-See <https://stacks.math.columbia.edu/tag/00UQ> -/
-@[mk_iff]
+`I : Ideal B` and `f : A →ₐ[R] B ⧸ I`, there exists exactly one lift `A →ₐ[R] B`. -/
+@[mk_iff, stacks 00UQ]
 class FormallyEtale : Prop where
   comp_bijective :
     ∀ ⦃B : Type u⦄ [CommRing B],

--- a/Mathlib/RingTheory/Smooth/Basic.lean
+++ b/Mathlib/RingTheory/Smooth/Basic.lean
@@ -41,11 +41,8 @@ variable (R : Type u) [CommSemiring R]
 variable (A : Type u) [Semiring A] [Algebra R A]
 
 /-- An `R` algebra `A` is formally smooth if for every `R`-algebra, every square-zero ideal
-`I : Ideal B` and `f : A →ₐ[R] B ⧸ I`, there exists at least one lift `A →ₐ[R] B`.
-
-See <https://stacks.math.columbia.edu/tag/00TI>.
--/
-@[mk_iff]
+`I : Ideal B` and `f : A →ₐ[R] B ⧸ I`, there exists at least one lift `A →ₐ[R] B`. -/
+@[mk_iff, stacks 00TI]
 class FormallySmooth : Prop where
   comp_surjective :
     ∀ ⦃B : Type u⦄ [CommRing B],

--- a/Mathlib/RingTheory/Unramified/Basic.lean
+++ b/Mathlib/RingTheory/Unramified/Basic.lean
@@ -46,10 +46,8 @@ An `R`-algebra `A` is formally unramified if `Ω[A⁄R]` is trivial.
 
 This is equivalent to "for every `R`-algebra, every square-zero ideal
 `I : Ideal B` and `f : A →ₐ[R] B ⧸ I`, there exists at most one lift `A →ₐ[R] B`".
-See `Algebra.FormallyUnramified.iff_comp_injective`.
-
-See <https://stacks.math.columbia.edu/tag/00UM>. -/
-@[mk_iff]
+See `Algebra.FormallyUnramified.iff_comp_injective`. -/
+@[mk_iff, stacks 00UM]
 class FormallyUnramified : Prop where
   subsingleton_kaehlerDifferential : Subsingleton (Ω[A⁄R])
 

--- a/Mathlib/Topology/Category/Profinite/Basic.lean
+++ b/Mathlib/Topology/Category/Profinite/Basic.lean
@@ -96,9 +96,8 @@ section Profinite
 -- unhelpfully defines a function `CompHaus.{max u₁ u₂} → Profinite.{max u₁ u₂}`.
 /--
 (Implementation) The object part of the connected_components functor from compact Hausdorff spaces
-to Profinite spaces, given by quotienting a space by its connected components.
-See: https://stacks.math.columbia.edu/tag/0900
--/
+to Profinite spaces, given by quotienting a space by its connected components. -/
+@[stacks 0900]
 def CompHaus.toProfiniteObj (X : CompHaus.{u}) : Profinite.{u} where
   toTop := TopCat.of (ConnectedComponents X)
   is_compact := Quotient.compactSpace

--- a/Mathlib/Topology/Sheaves/Forget.lean
+++ b/Mathlib/Topology/Sheaves/Forget.lean
@@ -41,11 +41,8 @@ The important special case is when
 that preserves limits and reflects isomorphisms.
 Then to check the sheaf condition it suffices to check it on the underlying sheaf of types.
 
-Another useful example is the forgetful functor `TopCommRingCat ⥤ TopCat`.
-
-See <https://stacks.math.columbia.edu/tag/0073>.
-In fact we prove a stronger version with arbitrary target category.
--/
+Another useful example is the forgetful functor `TopCommRingCat ⥤ TopCat`. -/
+@[stacks 0073 "In fact we prove a stronger version with arbitrary target category."]
 theorem isSheaf_iff_isSheaf_comp' {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
     (G : C ⥤ D) [G.ReflectsIsomorphisms] [HasLimitsOfSize.{v, v} C] [PreservesLimitsOfSize.{v, v} G]
     {X : TopCat.{v}} (F : Presheaf C X) : Presheaf.IsSheaf F ↔ Presheaf.IsSheaf (F ⋙ G) :=


### PR DESCRIPTION
I did not touch the links that are in module docs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
