### PR TITLE
[Merged by Bors] - feat: `log (x / x) = 0`

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
@@ -176,8 +176,10 @@ theorem arg_eq_arg_iff {x y : ℂ} (hx : x ≠ 0) (hy : y ≠ 0) :
   rw [← ofReal_div, arg_real_mul]
   exact div_pos (abs.pos hy) (abs.pos hx)
 
-@[simp]
-theorem arg_one : arg 1 = 0 := by simp [arg, zero_le_one]
+@[simp] lemma arg_one : arg 1 = 0 := by simp [arg, zero_le_one]
+
+@[simp] lemma arg_div_self (x : ℂ) : arg (x / x) = 0 := by
+  obtain rfl | hx := eq_or_ne x 0 <;> simp [*]
 
 @[simp]
 theorem arg_neg_one : arg (-1) = π := by simp [arg, le_refl, not_le.2 (zero_lt_one' ℝ)]

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
@@ -178,6 +178,7 @@ theorem arg_eq_arg_iff {x y : ℂ} (hx : x ≠ 0) (hy : y ≠ 0) :
 
 @[simp] lemma arg_one : arg 1 = 0 := by simp [arg, zero_le_one]
 
+/-- This holds true for all `x : ℂ` because of the junk values `0 / 0 = 0` and `arg 0 = 0`. -/
 @[simp] lemma arg_div_self (x : ℂ) : arg (x / x) = 0 := by
   obtain rfl | hx := eq_or_ne x 0 <;> simp [*]
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -93,6 +93,8 @@ theorem log_zero : log 0 = 0 := by simp [log]
 @[simp]
 theorem log_one : log 1 = 0 := by simp [log]
 
+@[simp] lemma log_div_self (x : ℂ) : log (x / x) = 0 := by simp [log]
+
 theorem log_neg_one : log (-1) = π * I := by simp [log]
 
 theorem log_I : log I = π / 2 * I := by simp [log]

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -93,6 +93,7 @@ theorem log_zero : log 0 = 0 := by simp [log]
 @[simp]
 theorem log_one : log 1 = 0 := by simp [log]
 
+/-- This holds true for all `x : ℂ` because of the junk values `0 / 0 = 0` and `log 0 = 0`. -/
 @[simp] lemma log_div_self (x : ℂ) : log (x / x) = 0 := by simp [log]
 
 theorem log_neg_one : log (-1) = π * I := by simp [log]

--- a/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -86,6 +86,9 @@ theorem log_zero : log 0 = 0 :=
 theorem log_one : log 1 = 0 :=
   exp_injective <| by rw [exp_log zero_lt_one, exp_zero]
 
+@[simp] lemma log_div_self (x : ℝ) : log (x / x) = 0 := by
+  obtain rfl | hx := eq_or_ne x 0 <;> simp [*]
+
 @[simp]
 theorem log_abs (x : ℝ) : log |x| = log x := by
   by_cases h : x = 0

--- a/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -86,6 +86,7 @@ theorem log_zero : log 0 = 0 :=
 theorem log_one : log 1 = 0 :=
   exp_injective <| by rw [exp_log zero_lt_one, exp_zero]
 
+/-- This holds true for all `x : \` because of the junk values `0 / 0 = 0` and `arg 0 = 0`. -/
 @[simp] lemma log_div_self (x : ℝ) : log (x / x) = 0 := by
   obtain rfl | hx := eq_or_ne x 0 <;> simp [*]
 


### PR DESCRIPTION
From PFR

Co-authored-by: Sébastien Gouëzel <sebastien.gouezel@univ-rennes1.fr>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
