### PR TITLE
[Merged by Bors] - feat: mark AnalyticAt / MeromorphicAt for use with fun_prop

### DIFF
--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -442,6 +442,7 @@ variable (𝕜)
 
 /-- Given a function `f : E → F`, we say that `f` is analytic at `x` if it admits a convergent power
 series expansion around `x`. -/
+@[fun_prop]
 def AnalyticAt (f : E → F) (x : E) :=
   ∃ p : FormalMultilinearSeries 𝕜 E F, HasFPowerSeriesAt f p x
 
@@ -1343,6 +1344,7 @@ protected theorem AnalyticWithinAt.continuousWithinAt (hf : AnalyticWithinAt �
     ContinuousWithinAt f s x :=
   hf.continuousWithinAt_insert.mono (subset_insert x s)
 
+@[fun_prop]
 protected theorem AnalyticAt.continuousAt (hf : AnalyticAt 𝕜 f x) : ContinuousAt f x :=
   let ⟨_, hp⟩ := hf
   hp.continuousAt

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -870,8 +870,8 @@ theorem AnalyticAt.comp {g : F → G} {f : E → F} {x : E} (hg : AnalyticAt �
 analytic at `x`. -/
 @[fun_prop]
 theorem AnalyticAt.comp' {g : F → G} {f : E → F} {x : E} (hg : AnalyticAt 𝕜 g (f x))
-    (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (fun z ↦ g (f z)) x := by
-  apply hg.comp hf
+    (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (fun z ↦ g (f z)) x :=
+  hg.comp hf
 
 /-- Version of `AnalyticAt.comp` where point equality is a separate hypothesis. -/
 theorem AnalyticAt.comp_of_eq {g : F → G} {f : E → F} {y : F} {x : E} (hg : AnalyticAt 𝕜 g y)

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -880,7 +880,6 @@ theorem AnalyticAt.comp_of_eq {g : F → G} {f : E → F} {y : F} {x : E} (hg : 
   exact hg.comp hf
 
 /-- Version of `AnalyticAt.comp` where point equality is a separate hypothesis. -/
-@[fun_prop]
 theorem AnalyticAt.comp_of_eq' {g : F → G} {f : E → F} {y : F} {x : E} (hg : AnalyticAt 𝕜 g y)
     (hf : AnalyticAt 𝕜 f x) (hy : f x = y) : AnalyticAt 𝕜 (fun z ↦ g (f z)) x := by
   apply hg.comp_of_eq hf hy

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -860,16 +860,31 @@ alias AnalyticWithinOn.comp := AnalyticOn.comp
 
 /-- If two functions `g` and `f` are analytic respectively at `f x` and `x`, then `g ∘ f` is
 analytic at `x`. -/
+@[fun_prop]
 theorem AnalyticAt.comp {g : F → G} {f : E → F} {x : E} (hg : AnalyticAt 𝕜 g (f x))
     (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (g ∘ f) x := by
   rw [← analyticWithinAt_univ] at hg hf ⊢
   apply hg.comp hf (by simp)
 
+/-- If two functions `g` and `f` are analytic respectively at `f x` and `x`, then `g ∘ f` is
+analytic at `x`. -/
+@[fun_prop]
+theorem AnalyticAt.comp' {g : F → G} {f : E → F} {x : E} (hg : AnalyticAt 𝕜 g (f x))
+    (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (fun z ↦ g (f z)) x := by
+  apply hg.comp hf
+
 /-- Version of `AnalyticAt.comp` where point equality is a separate hypothesis. -/
+@[fun_prop]
 theorem AnalyticAt.comp_of_eq {g : F → G} {f : E → F} {y : F} {x : E} (hg : AnalyticAt 𝕜 g y)
     (hf : AnalyticAt 𝕜 f x) (hy : f x = y) : AnalyticAt 𝕜 (g ∘ f) x := by
   rw [← hy] at hg
   exact hg.comp hf
+
+/-- Version of `AnalyticAt.comp` where point equality is a separate hypothesis. -/
+@[fun_prop]
+theorem AnalyticAt.comp_of_eq' {g : F → G} {f : E → F} {y : F} {x : E} (hg : AnalyticAt 𝕜 g y)
+    (hf : AnalyticAt 𝕜 f x) (hy : f x = y) : AnalyticAt 𝕜 (fun z ↦ g (f z)) x := by
+  apply hg.comp_of_eq hf hy
 
 theorem AnalyticAt.comp_analyticWithinAt {g : F → G} {f : E → F} {x : E} {s : Set E}
     (hg : AnalyticAt 𝕜 g (f x)) (hf : AnalyticWithinAt 𝕜 f s x) :

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -874,7 +874,6 @@ theorem AnalyticAt.comp' {g : F → G} {f : E → F} {x : E} (hg : AnalyticAt �
   apply hg.comp hf
 
 /-- Version of `AnalyticAt.comp` where point equality is a separate hypothesis. -/
-@[fun_prop]
 theorem AnalyticAt.comp_of_eq {g : F → G} {f : E → F} {y : F} {x : E} (hg : AnalyticAt 𝕜 g y)
     (hf : AnalyticAt 𝕜 f x) (hy : f x = y) : AnalyticAt 𝕜 (g ∘ f) x := by
   rw [← hy] at hg

--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -46,6 +46,7 @@ theorem hasFPowerSeriesAt_const {c : F} {e : E} :
     HasFPowerSeriesAt (fun _ => c) (constFormalMultilinearSeries 𝕜 E c) e :=
   ⟨⊤, hasFPowerSeriesOnBall_const⟩
 
+@[fun_prop]
 theorem analyticAt_const {v : F} {x : E} : AnalyticAt 𝕜 (fun _ => v) x :=
   ⟨constFormalMultilinearSeries 𝕜 E v, hasFPowerSeriesAt_const⟩
 
@@ -100,10 +101,16 @@ theorem AnalyticWithinAt.add (hf : AnalyticWithinAt 𝕜 f s x) (hg : AnalyticWi
   let ⟨_, hqf⟩ := hg
   (hpf.add hqf).analyticWithinAt
 
+@[fun_prop]
 theorem AnalyticAt.add (hf : AnalyticAt 𝕜 f x) (hg : AnalyticAt 𝕜 g x) : AnalyticAt 𝕜 (f + g) x :=
   let ⟨_, hpf⟩ := hf
   let ⟨_, hqf⟩ := hg
   (hpf.add hqf).analyticAt
+
+@[fun_prop]
+theorem AnalyticAt.add' (hf : AnalyticAt 𝕜 f x) (hg : AnalyticAt 𝕜 g x) :
+    AnalyticAt 𝕜 (fun z ↦ f z + g z) x :=
+  hf.add hg
 
 theorem HasFPowerSeriesWithinOnBall.neg (hf : HasFPowerSeriesWithinOnBall f pf s x r) :
     HasFPowerSeriesWithinOnBall (-f) (-pf) s x r :=
@@ -134,9 +141,14 @@ theorem AnalyticWithinAt.neg (hf : AnalyticWithinAt 𝕜 f s x) : AnalyticWithin
   let ⟨_, hpf⟩ := hf
   hpf.neg.analyticWithinAt
 
+@[fun_prop]
 theorem AnalyticAt.neg (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (-f) x :=
   let ⟨_, hpf⟩ := hf
   hpf.neg.analyticAt
+
+@[fun_prop]
+theorem AnalyticAt.neg' (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (fun z ↦ -f z) x :=
+  hf.neg
 
 theorem HasFPowerSeriesWithinOnBall.sub (hf : HasFPowerSeriesWithinOnBall f pf s x r)
     (hg : HasFPowerSeriesWithinOnBall g pg s x r) :
@@ -160,9 +172,15 @@ theorem AnalyticWithinAt.sub (hf : AnalyticWithinAt 𝕜 f s x) (hg : AnalyticWi
     AnalyticWithinAt 𝕜 (f - g) s x := by
   simpa only [sub_eq_add_neg] using hf.add hg.neg
 
+@[fun_prop]
 theorem AnalyticAt.sub (hf : AnalyticAt 𝕜 f x) (hg : AnalyticAt 𝕜 g x) :
     AnalyticAt 𝕜 (f - g) x := by
   simpa only [sub_eq_add_neg] using hf.add hg.neg
+
+@[fun_prop]
+theorem AnalyticAt.sub' (hf : AnalyticAt 𝕜 f x) (hg : AnalyticAt 𝕜 g x) :
+    AnalyticAt 𝕜 (fun z ↦ f z - g z) x :=
+  hf.sub hg
 
 theorem HasFPowerSeriesWithinOnBall.const_smul (hf : HasFPowerSeriesWithinOnBall f pf s x r) :
     HasFPowerSeriesWithinOnBall (c • f) (c • pf) s x r where
@@ -191,9 +209,14 @@ theorem AnalyticWithinAt.const_smul (hf : AnalyticWithinAt 𝕜 f s x) :
   let ⟨_, hpf⟩ := hf
   hpf.const_smul.analyticWithinAt
 
+@[fun_prop]
 theorem AnalyticAt.const_smul (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (c • f) x :=
   let ⟨_, hpf⟩ := hf
   hpf.const_smul.analyticAt
+
+@[fun_prop]
+theorem AnalyticAt.const_smul' (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (fun z ↦ c • f z) x :=
+  hf.const_smul
 
 theorem AnalyticOn.add (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
     AnalyticOn 𝕜 (f + g) s :=
@@ -307,6 +330,7 @@ lemma AnalyticWithinAt.prod {e : E} {f : E → F} {g : E → G} {s : Set E}
   exact ⟨_, hf.prod hg⟩
 
 /-- The Cartesian product of analytic functions is analytic. -/
+@[fun_prop]
 lemma AnalyticAt.prod {e : E} {f : E → F} {g : E → G}
     (hf : AnalyticAt 𝕜 f e) (hg : AnalyticAt 𝕜 g e) :
     AnalyticAt 𝕜 (fun x ↦ (f x, g x)) e := by
@@ -590,11 +614,13 @@ pedantic to allow towers of field extensions.
 
 TODO: can we replace `𝕜'` with a "normed module" in such a way that `analyticAt_mul` is a special
 case of this? -/
+@[fun_prop]
 lemma analyticAt_smul [NormedSpace 𝕝 E] [IsScalarTower 𝕜 𝕝 E] (z : 𝕝 × E) :
     AnalyticAt 𝕜 (fun x : 𝕝 × E ↦ x.1 • x.2) z :=
   (ContinuousLinearMap.lsmul 𝕜 𝕝).analyticAt_bilinear z
 
 /-- Multiplication in a normed algebra over `𝕜` is analytic. -/
+@[fun_prop]
 lemma analyticAt_mul (z : A × A) : AnalyticAt 𝕜 (fun x : A × A ↦ x.1 * x.2) z :=
   (ContinuousLinearMap.mul 𝕜 A).analyticAt_bilinear z
 
@@ -606,10 +632,18 @@ lemma AnalyticWithinAt.smul [NormedSpace 𝕝 F] [IsScalarTower 𝕜 𝕝 F]
   (analyticAt_smul _).comp₂_analyticWithinAt hf hg
 
 /-- Scalar multiplication of one analytic function by another. -/
+@[fun_prop]
 lemma AnalyticAt.smul [NormedSpace 𝕝 F] [IsScalarTower 𝕜 𝕝 F] {f : E → 𝕝} {g : E → F} {z : E}
     (hf : AnalyticAt 𝕜 f z) (hg : AnalyticAt 𝕜 g z) :
-    AnalyticAt 𝕜 (fun x ↦ f x • g x) z :=
+    AnalyticAt 𝕜 (f • g) z :=
   (analyticAt_smul _).comp₂ hf hg
+
+/-- Scalar multiplication of one analytic function by another. -/
+@[fun_prop]
+lemma AnalyticAt.smul' [NormedSpace 𝕝 F] [IsScalarTower 𝕜 𝕝 F] {f : E → 𝕝} {g : E → F} {z : E}
+    (hf : AnalyticAt 𝕜 f z) (hg : AnalyticAt 𝕜 g z) :
+    AnalyticAt 𝕜 (fun x ↦ f x • g x) z :=
+  hf.smul hg
 
 /-- Scalar multiplication of one analytic function by another. -/
 lemma AnalyticOn.smul [NormedSpace 𝕝 F] [IsScalarTower 𝕜 𝕝 F]
@@ -634,9 +668,15 @@ lemma AnalyticWithinAt.mul {f g : E → A} {s : Set E} {z : E}
   (analyticAt_mul _).comp₂_analyticWithinAt hf hg
 
 /-- Multiplication of analytic functions (valued in a normed `𝕜`-algebra) is analytic. -/
+@[fun_prop]
 lemma AnalyticAt.mul {f g : E → A} {z : E} (hf : AnalyticAt 𝕜 f z) (hg : AnalyticAt 𝕜 g z) :
-    AnalyticAt 𝕜 (fun x ↦ f x * g x) z :=
+    AnalyticAt 𝕜 (f * g) z :=
   (analyticAt_mul _).comp₂ hf hg
+
+@[fun_prop]
+lemma AnalyticAt.mul' {f g : E → A} {z : E} (hf : AnalyticAt 𝕜 f z) (hg : AnalyticAt 𝕜 g z) :
+    AnalyticAt 𝕜 (fun x ↦ f x * g x) z :=
+  hf.mul hg
 
 /-- Multiplication of analytic functions (valued in a normed `𝕜`-algebra) is analytic. -/
 lemma AnalyticOn.mul {f g : E → A} {s : Set E}
@@ -665,6 +705,7 @@ lemma AnalyticWithinAt.pow {f : E → A} {z : E} {s : Set E} (hf : AnalyticWithi
     exact hm.mul hf
 
 /-- Powers of analytic functions (into a normed `𝕜`-algebra) are analytic. -/
+@[fun_prop]
 lemma AnalyticAt.pow {f : E → A} {z : E} (hf : AnalyticAt 𝕜 f z) (n : ℕ) :
     AnalyticAt 𝕜 (fun x ↦ f x ^ n) z := by
   rw [← analyticWithinAt_univ] at hf ⊢
@@ -791,6 +832,7 @@ lemma hasFPowerSeriesOnBall_inverse_one_sub
       List.ofFn_const, List.prod_replicate]
     exact (summable_geometric_of_norm_lt_one hy).hasSum
 
+@[fun_prop]
 lemma analyticAt_inverse_one_sub (𝕜 : Type*) [NontriviallyNormedField 𝕜]
     (A : Type*) [NormedRing A] [NormedAlgebra 𝕜 A] [HasSummableGeomSeries A] :
     AnalyticAt 𝕜 (fun x : A ↦ Ring.inverse (1 - x)) 0 :=
@@ -798,6 +840,7 @@ lemma analyticAt_inverse_one_sub (𝕜 : Type*) [NontriviallyNormedField 𝕜]
 
 /-- If `A` is a normed algebra over `𝕜` with summable geometric series, then inversion on `A` is
 analytic at any unit. -/
+@[fun_prop]
 lemma analyticAt_inverse {𝕜 : Type*} [NontriviallyNormedField 𝕜]
     {A : Type*} [NormedRing A] [NormedAlgebra 𝕜 A] [HasSummableGeomSeries A] (z : Aˣ) :
     AnalyticAt 𝕜 Ring.inverse (z : A) := by
@@ -837,12 +880,14 @@ lemma hasFPowerSeriesOnBall_inv_one_sub
   convert hasFPowerSeriesOnBall_inverse_one_sub 𝕜 𝕝
   exact Ring.inverse_eq_inv'.symm
 
+@[fun_prop]
 lemma analyticAt_inv_one_sub (𝕝 : Type*) [NontriviallyNormedField 𝕝] [NormedAlgebra 𝕜 𝕝] :
     AnalyticAt 𝕜 (fun x : 𝕝 ↦ (1 - x)⁻¹) 0 :=
   ⟨_, ⟨_, hasFPowerSeriesOnBall_inv_one_sub 𝕜 𝕝⟩⟩
 
 /-- If `𝕝` is a normed field extension of `𝕜`, then the inverse map `𝕝 → 𝕝` is `𝕜`-analytic
 away from 0. -/
+@[fun_prop]
 lemma analyticAt_inv {z : 𝕝} (hz : z ≠ 0) : AnalyticAt 𝕜 Inv.inv z := by
   convert analyticAt_inverse (𝕜 := 𝕜) (Units.mk0 _ hz)
   exact Ring.inverse_eq_inv'.symm
@@ -861,9 +906,15 @@ theorem AnalyticWithinAt.inv {f : E → 𝕝} {x : E} {s : Set E}
   (analyticAt_inv f0).comp_analyticWithinAt fa
 
 /-- `(f x)⁻¹` is analytic away from `f x = 0` -/
+@[fun_prop]
 theorem AnalyticAt.inv {f : E → 𝕝} {x : E} (fa : AnalyticAt 𝕜 f x) (f0 : f x ≠ 0) :
-    AnalyticAt 𝕜 (fun x ↦ (f x)⁻¹) x :=
+    AnalyticAt 𝕜 f⁻¹ x :=
   (analyticAt_inv f0).comp fa
+
+@[fun_prop]
+theorem AnalyticAt.inv' {f : E → 𝕝} {x : E} (fa : AnalyticAt 𝕜 f x) (f0 : f x ≠ 0) :
+    AnalyticAt 𝕜 (fun x ↦ (f x)⁻¹) x :=
+  fa.inv f0
 
 /-- `(f x)⁻¹` is analytic away from `f x = 0` -/
 theorem AnalyticOn.inv {f : E → 𝕝} {s : Set E}
@@ -887,10 +938,17 @@ theorem AnalyticWithinAt.div {f g : E → 𝕝} {s : Set E} {x : E}
   simp_rw [div_eq_mul_inv]; exact fa.mul (ga.inv g0)
 
 /-- `f x / g x` is analytic away from `g x = 0` -/
+@[fun_prop]
 theorem AnalyticAt.div {f g : E → 𝕝} {x : E}
     (fa : AnalyticAt 𝕜 f x) (ga : AnalyticAt 𝕜 g x) (g0 : g x ≠ 0) :
-    AnalyticAt 𝕜 (fun x ↦ f x / g x) x := by
+    AnalyticAt 𝕜 (f / g) x := by
   simp_rw [div_eq_mul_inv]; exact fa.mul (ga.inv g0)
+
+@[fun_prop]
+theorem AnalyticAt.div' {f g : E → 𝕝} {x : E}
+    (fa : AnalyticAt 𝕜 f x) (ga : AnalyticAt 𝕜 g x) (g0 : g x ≠ 0) :
+    AnalyticAt 𝕜 (fun x ↦ f x / g x) x :=
+  fa.div ga g0
 
 /-- `f x / g x` is analytic away from `g x = 0` -/
 theorem AnalyticOn.div {f g : E → 𝕝} {s : Set E}
@@ -924,6 +982,7 @@ theorem Finset.analyticWithinAt_sum {f : α → E → F} {c : E} {s : Set E}
     exact (h a (Or.inl rfl)).add (hB fun b m ↦ h b (Or.inr m))
 
 /-- Finite sums of analytic functions are analytic -/
+@[fun_prop]
 theorem Finset.analyticAt_sum {f : α → E → F} {c : E}
     (N : Finset α) (h : ∀ n ∈ N, AnalyticAt 𝕜 (f n) c) :
     AnalyticAt 𝕜 (fun z ↦ ∑ n ∈ N, f n z) c := by
@@ -958,6 +1017,7 @@ theorem Finset.analyticWithinAt_prod {A : Type*} [NormedCommRing A] [NormedAlgeb
     exact (h a (Or.inl rfl)).mul (hB fun b m ↦ h b (Or.inr m))
 
 /-- Finite products of analytic functions are analytic -/
+@[fun_prop]
 theorem Finset.analyticAt_prod {A : Type*} [NormedCommRing A] [NormedAlgebra 𝕜 A]
     {f : α → E → A} {c : E} (N : Finset α) (h : ∀ n ∈ N, AnalyticAt 𝕜 (f n) c) :
     AnalyticAt 𝕜 (fun z ↦ ∏ n ∈ N, f n z) c := by

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -274,9 +274,11 @@ theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : Anal
 /-- The order multiplies by `n` when taking an analytic function to its `n`th power. -/
 theorem order_pow {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
     (hf.pow n).order = n * hf.order := by
-  induction' n with n hn
-  · simp [AnalyticAt.order_eq_zero_iff]
-  · simp [add_mul, pow_add, (hf.pow n).order_mul hf, hn]
+  induction n
+  case zero =>
+    simp [AnalyticAt.order_eq_zero_iff]
+  case succ n hn =>
+    simp [add_mul, pow_add, (hf.pow n).order_mul hf, hn]
 
 end AnalyticAt
 

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -241,7 +241,7 @@ lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
   tauto
 
 /- Helper lemma for `AnalyticAt.order_mul` -/
-lemma order_eq_top_of_order_eq_top_mul_analytic {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
+lemma order_mul_of_order_eq_top {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
     (hg : AnalyticAt 𝕜 g z₀) (h'f : hf.order = ⊤) :
     (hf.mul hg).order = ⊤ := by
   rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff] at *

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -253,10 +253,10 @@ theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : Anal
     (hf.mul hg).order = hf.order + hg.order := by
   -- Trivial cases: one of the functions vanishes around z₀
   by_cases h₂f : hf.order = ⊤
-  · simp [hf.order_eq_top_of_order_eq_top_mul_analytic hg h₂f, h₂f]
+  · simp [hf.order_mul_of_order_eq_top hg h₂f, h₂f]
   by_cases h₂g : hg.order = ⊤
   · have : (fun x ↦ f x * g x) = (fun x ↦ g x * f x) := by simp_rw [mul_comm]
-    simp [this, hg.order_eq_top_of_order_eq_top_mul_analytic hf h₂g, h₂g]
+    simp [this, hg.order_mul_of_order_eq_top hf h₂g, h₂g]
 
   -- Non-trivial case: both functions do not vanish around z₀
   obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf.order_neq_top_iff.1 h₂f

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -240,40 +240,38 @@ lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
   simp [hf.order_eq_zero_iff]
   tauto
 
-/-- Helper lemma for `AnalyticAt.order_mul` -/
-lemma order_of_locallyZero_mul_analytic {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
+/- Helper lemma for `AnalyticAt.order_mul` -/
+lemma order_eq_top_of_order_eq_top_mul_analytic {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
   (hg : AnalyticAt 𝕜 g z₀) (h'f : hf.order = ⊤) :
     (hf.mul hg).order = ⊤ := by
   rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff] at *
   obtain ⟨t, h₁t, h₂t, h₃t⟩ := h'f
   exact ⟨t, fun y hy ↦ (by rw [h₁t y hy]; ring), h₂t, h₃t⟩
 
-/-- The order is additive when multiplying analytic functions -/
+/-- The order is additive when multiplying analytic functions. -/
 theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
     (hf.mul hg).order = hf.order + hg.order := by
   -- Trivial cases: one of the functions vanishes around z₀
   by_cases h₂f : hf.order = ⊤
-  · simp [hf.order_of_locallyZero_mul_analytic hg h₂f, h₂f]
+  · simp [hf.order_eq_top_of_order_eq_top_mul_analytic hg h₂f, h₂f]
   by_cases h₂g : hg.order = ⊤
   · have : (fun x ↦ f x * g x) = (fun x ↦ g x * f x) := by simp_rw [mul_comm]
-    simp [this, hg.order_of_locallyZero_mul_analytic hf h₂g, h₂g]
+    simp [this, hg.order_eq_top_of_order_eq_top_mul_analytic hf h₂g, h₂g]
 
   -- Non-trivial case: both functions do not vanish around z₀
   obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf.order_neq_top_iff.1 h₂f
   obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := hg.order_neq_top_iff.1 h₂g
   rw [← ENat.coe_toNat h₂f, ← ENat.coe_toNat h₂g, ← ENat.coe_add, (hf.mul hg).order_eq_nat_iff]
-  use g₁ * g₂
+  use g₁ * g₂, by exact h₁g₁.mul h₁g₂
   constructor
-  · exact h₁g₁.mul h₁g₂
-  · constructor
-    · simp
-      tauto
-    · obtain ⟨t, h₁t, h₂t, h₃t⟩ := eventually_nhds_iff.1 h₃g₁
-      obtain ⟨s, h₁s, h₂s, h₃s⟩ := eventually_nhds_iff.1 h₃g₂
-      exact eventually_nhds_iff.2
-        ⟨t ∩ s, fun y hy ↦ (by rw [h₁t y hy.1, h₁s y hy.2]; simp; ring), h₂t.inter h₂s, h₃t, h₃s⟩
+  · simp
+    tauto
+  · obtain ⟨t, h₁t, h₂t, h₃t⟩ := eventually_nhds_iff.1 h₃g₁
+    obtain ⟨s, h₁s, h₂s, h₃s⟩ := eventually_nhds_iff.1 h₃g₂
+    exact eventually_nhds_iff.2
+      ⟨t ∩ s, fun y hy ↦ (by rw [h₁t y hy.1, h₁s y hy.2]; simp; ring), h₂t.inter h₂s, h₃t, h₃s⟩
 
-/-- The order multiplies by `n` when taking an analytic function to its `n`th power -/
+/-- The order multiplies by `n` when taking an analytic function to its `n`th power. -/
 theorem order_pow {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
     (hf.pow n).order = n * hf.order := by
   induction' n with n hn

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -240,6 +240,46 @@ lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
   simp [hf.order_eq_zero_iff]
   tauto
 
+/-- Helper lemma for `AnalyticAt.order_mul` -/
+lemma order_of_locallyZero_mul_analytic {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
+  (hg : AnalyticAt 𝕜 g z₀) (h'f : hf.order = ⊤) :
+    (hf.mul hg).order = ⊤ := by
+  rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff] at *
+  obtain ⟨t, h₁t, h₂t, h₃t⟩ := h'f
+  exact ⟨t, fun y hy ↦ (by rw [h₁t y hy]; ring), h₂t, h₃t⟩
+
+/-- The order is additive when multiplying analytic functions -/
+theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
+    (hf.mul hg).order = hf.order + hg.order := by
+  -- Trivial cases: one of the functions vanishes around z₀
+  by_cases h₂f : hf.order = ⊤
+  · simp [hf.order_of_locallyZero_mul_analytic hg h₂f, h₂f]
+  by_cases h₂g : hg.order = ⊤
+  · have : (fun x ↦ f x * g x) = (fun x ↦ g x * f x) := by simp_rw [mul_comm]
+    simp [this, hg.order_of_locallyZero_mul_analytic hf h₂g, h₂g]
+
+  -- Non-trivial case: both functions do not vanish around z₀
+  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf.order_neq_top_iff.1 h₂f
+  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := hg.order_neq_top_iff.1 h₂g
+  rw [← ENat.coe_toNat h₂f, ← ENat.coe_toNat h₂g, ← ENat.coe_add, (hf.mul hg).order_eq_nat_iff]
+  use g₁ * g₂
+  constructor
+  · exact h₁g₁.mul h₁g₂
+  · constructor
+    · simp
+      tauto
+    · obtain ⟨t, h₁t, h₂t, h₃t⟩ := eventually_nhds_iff.1 h₃g₁
+      obtain ⟨s, h₁s, h₂s, h₃s⟩ := eventually_nhds_iff.1 h₃g₂
+      exact eventually_nhds_iff.2
+        ⟨t ∩ s, fun y hy ↦ (by rw [h₁t y hy.1, h₁s y hy.2]; simp; ring), h₂t.inter h₂s, h₃t, h₃s⟩
+
+/-- The order multiplies by `n` when taking an analytic function to its `n`th power -/
+theorem order_pow {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
+    (hf.pow n).order = n * hf.order := by
+  induction' n with n hn
+  · simp [AnalyticAt.order_eq_zero_iff]
+  · simp [add_mul, pow_add, (hf.pow n).order_mul hf, hn]
+
 end AnalyticAt
 
 namespace AnalyticOnNhd

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -242,7 +242,7 @@ lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
 
 /- Helper lemma for `AnalyticAt.order_mul` -/
 lemma order_eq_top_of_order_eq_top_mul_analytic {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀)
-  (hg : AnalyticAt 𝕜 g z₀) (h'f : hf.order = ⊤) :
+    (hg : AnalyticAt 𝕜 g z₀) (h'f : hf.order = ⊤) :
     (hf.mul hg).order = ⊤ := by
   rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff] at *
   obtain ⟨t, h₁t, h₂t, h₃t⟩ := h'f

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -246,7 +246,7 @@ lemma order_mul_of_order_eq_top {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z�
     (hf.mul hg).order = ⊤ := by
   rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff] at *
   obtain ⟨t, h₁t, h₂t, h₃t⟩ := h'f
-  exact ⟨t, fun y hy ↦ (by rw [h₁t y hy]; ring), h₂t, h₃t⟩
+  exact ⟨t, fun y hy ↦ (by simp [h₁t y hy]), h₂t, h₃t⟩
 
 /-- The order is additive when multiplying analytic functions. -/
 theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : AnalyticAt 𝕜 g z₀) :
@@ -255,8 +255,7 @@ theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : Anal
   by_cases h₂f : hf.order = ⊤
   · simp [hf.order_mul_of_order_eq_top hg h₂f, h₂f]
   by_cases h₂g : hg.order = ⊤
-  · have : (fun x ↦ f x * g x) = (fun x ↦ g x * f x) := by simp_rw [mul_comm]
-    simp [this, hg.order_mul_of_order_eq_top hf h₂g, h₂g]
+  · simp [mul_comm f g, hg.order_mul_of_order_eq_top hf h₂g, h₂g]
 
   -- Non-trivial case: both functions do not vanish around z₀
   obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf.order_neq_top_iff.1 h₂f
@@ -269,7 +268,7 @@ theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : Anal
   · obtain ⟨t, h₁t, h₂t, h₃t⟩ := eventually_nhds_iff.1 h₃g₁
     obtain ⟨s, h₁s, h₂s, h₃s⟩ := eventually_nhds_iff.1 h₃g₂
     exact eventually_nhds_iff.2
-      ⟨t ∩ s, fun y hy ↦ (by rw [h₁t y hy.1, h₁s y hy.2]; simp; ring), h₂t.inter h₂s, h₃t, h₃s⟩
+      ⟨t ∩ s, fun y hy ↦ (by simp [h₁t y hy.1, h₁s y hy.2]; ring), h₂t.inter h₂s, h₃t, h₃s⟩
 
 /-- The order multiplies by `n` when taking an analytic function to its `n`th power. -/
 theorem order_pow {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -271,7 +271,7 @@ theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : Anal
 
 /-- The order multiplies by `n` when taking an analytic function to its `n`th power. -/
 theorem order_pow {f : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) {n : ℕ} :
-    (hf.pow n).order = n * hf.order := by
+    (hf.pow n).order = n • hf.order := by
   induction n
   case zero =>
     simp [AnalyticAt.order_eq_zero_iff]

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -256,7 +256,6 @@ theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : Anal
   · simp [hf.order_mul_of_order_eq_top hg h₂f, h₂f]
   by_cases h₂g : hg.order = ⊤
   · simp [mul_comm f g, hg.order_mul_of_order_eq_top hf h₂g, h₂g]
-
   -- Non-trivial case: both functions do not vanish around z₀
   obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf.order_neq_top_iff.1 h₂f
   obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := hg.order_neq_top_iff.1 h₂g

--- a/Mathlib/Analysis/Analytic/Linear.lean
+++ b/Mathlib/Analysis/Analytic/Linear.lean
@@ -136,6 +136,7 @@ end ContinuousLinearMap
 
 variable {s : Set E} {z : E} {t : Set (E × F)} {p : E × F}
 
+@[fun_prop]
 lemma analyticAt_id : AnalyticAt 𝕜 (id : E → E) z :=
   (ContinuousLinearMap.id 𝕜 E).analyticAt z
 

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -26,9 +26,11 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 
 /-- Meromorphy of `f` at `x` (more precisely, on a punctured neighbourhood of `x`; the value at
 `x` itself is irrelevant). -/
+@[fun_prop]
 def MeromorphicAt (f : 𝕜 → E) (x : 𝕜) :=
   ∃ (n : ℕ), AnalyticAt 𝕜 (fun z ↦ (z - x) ^ n • f z) x
 
+@[fun_prop]
 lemma AnalyticAt.meromorphicAt {f : 𝕜 → E} {x : 𝕜} (hf : AnalyticAt 𝕜 f x) :
     MeromorphicAt f x :=
   ⟨0, by simpa only [pow_zero, one_smul]⟩
@@ -37,9 +39,11 @@ namespace MeromorphicAt
 
 lemma id (x : 𝕜) : MeromorphicAt id x := analyticAt_id.meromorphicAt
 
+@[fun_prop]
 lemma const (e : E) (x : 𝕜) : MeromorphicAt (fun _ ↦ e) x :=
   analyticAt_const.meromorphicAt
 
+@[fun_prop]
 lemma add {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     MeromorphicAt (f + g) x := by
   rcases hf with ⟨m, hf⟩
@@ -53,34 +57,62 @@ lemma add {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hg : Meromorph
   exact (((analyticAt_id.sub analyticAt_const).pow _).smul hf).add
    (((analyticAt_id.sub analyticAt_const).pow _).smul hg)
 
+@[fun_prop]
+lemma add' {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    MeromorphicAt (fun z ↦ f z + g z) x :=
+  hf.add hg
+
+@[fun_prop]
 lemma smul {f : 𝕜 → 𝕜} {g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     MeromorphicAt (f • g) x := by
   rcases hf with ⟨m, hf⟩
   rcases hg with ⟨n, hg⟩
   refine ⟨m + n, ?_⟩
-  convert hf.smul hg using 2 with z
+  convert hf.smul' hg using 2 with z
   rw [Pi.smul_apply', smul_eq_mul]
   module
 
+@[fun_prop]
+lemma smul' {f : 𝕜 → 𝕜} {g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    MeromorphicAt (fun z ↦ f z • g z) x :=
+  hf.smul hg
+
+@[fun_prop]
 lemma mul {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     MeromorphicAt (f * g) x :=
   hf.smul hg
 
+@[fun_prop]
+lemma mul' {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    MeromorphicAt (fun z ↦ f z * g z) x :=
+  hf.smul hg
+
+@[fun_prop]
 lemma neg {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicAt (-f) x := by
   convert (MeromorphicAt.const (-1 : 𝕜) x).smul hf using 1
   ext1 z
   simp only [Pi.neg_apply, Pi.smul_apply', neg_smul, one_smul]
+
+@[fun_prop]
+lemma neg' {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicAt (fun z ↦ -f z) x :=
+  hf.neg
 
 @[simp]
 lemma neg_iff {f : 𝕜 → E} {x : 𝕜} :
     MeromorphicAt (-f) x ↔ MeromorphicAt f x :=
   ⟨fun h ↦ by simpa only [neg_neg] using h.neg, MeromorphicAt.neg⟩
 
+@[fun_prop]
 lemma sub {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     MeromorphicAt (f - g) x := by
   convert hf.add hg.neg using 1
   ext1 z
   simp_rw [Pi.sub_apply, Pi.add_apply, Pi.neg_apply, sub_eq_add_neg]
+
+@[fun_prop]
+lemma sub' {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    MeromorphicAt (fun z ↦ f z - g z) x :=
+  hf.sub hg
 
 /-- With our definitions, `MeromorphicAt f x` depends only on the values of `f` on a punctured
 neighbourhood of `x` (not on `f x`) -/
@@ -89,13 +121,14 @@ lemma congr {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hfg : f =ᶠ
   rcases hf with ⟨m, hf⟩
   refine ⟨m + 1, ?_⟩
   have : AnalyticAt 𝕜 (fun z ↦ z - x) x := analyticAt_id.sub analyticAt_const
-  refine (this.smul hf).congr ?_
+  refine (this.smul' hf).congr ?_
   rw [eventuallyEq_nhdsWithin_iff] at hfg
   filter_upwards [hfg] with z hz
   rcases eq_or_ne z x with rfl | hn
   · simp
   · rw [hz (Set.mem_compl_singleton_iff.mp hn), pow_succ', mul_smul]
 
+@[fun_prop]
 lemma inv {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicAt f⁻¹ x := by
   rcases hf with ⟨m, hf⟩
   by_cases h_eq : (fun z ↦ (z - x) ^ m • f z) =ᶠ[𝓝 x] 0
@@ -110,7 +143,7 @@ lemma inv {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicA
     have : AnalyticAt 𝕜 (fun z ↦ (z - x) ^ (m + 1)) x :=
       (analyticAt_id.sub analyticAt_const).pow _
     -- use `m + 1` rather than `m` to damp out any silly issues with the value at `z = x`
-    refine ⟨n + 1, (this.smul <| hg_an.inv hg_ne).congr ?_⟩
+    refine ⟨n + 1, (this.smul' <| hg_an.inv hg_ne).congr ?_⟩
     filter_upwards [hg_eq, hg_an.continuousAt.eventually_ne hg_ne] with z hfg hg_ne'
     rcases eq_or_ne z x with rfl | hz_ne
     · simp only [sub_self, pow_succ, mul_zero, zero_smul]
@@ -123,24 +156,46 @@ lemma inv {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicA
       rw [pow_succ', mul_assoc, hfg]
       ring
 
+@[fun_prop]
+lemma inv' {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicAt (fun z ↦ f⁻¹ z) x :=
+  hf.inv
+
 @[simp]
 lemma inv_iff {f : 𝕜 → 𝕜} {x : 𝕜} :
     MeromorphicAt f⁻¹ x ↔ MeromorphicAt f x :=
   ⟨fun h ↦ by simpa only [inv_inv] using h.inv, MeromorphicAt.inv⟩
 
+@[fun_prop]
 lemma div {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     MeromorphicAt (f / g) x :=
   (div_eq_mul_inv f g).symm ▸ (hf.mul hg.inv)
 
+@[fun_prop]
+lemma div' {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    MeromorphicAt (fun z ↦ f z / g z) x :=
+  hf.div hg
+
+@[fun_prop]
 lemma pow {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (n : ℕ) : MeromorphicAt (f ^ n) x := by
   induction n with
   | zero => simpa only [pow_zero] using MeromorphicAt.const 1 x
   | succ m hm => simpa only [pow_succ] using hm.mul hf
 
+@[fun_prop]
+lemma pow' {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (n : ℕ) :
+    MeromorphicAt (fun z ↦ (f z) ^ n) x :=
+  hf.pow n
+
+@[fun_prop]
 lemma zpow {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (n : ℤ) : MeromorphicAt (f ^ n) x := by
   induction n with
   | ofNat m => simpa only [Int.ofNat_eq_coe, zpow_natCast] using hf.pow m
   | negSucc m => simpa only [zpow_negSucc, inv_iff] using hf.pow (m + 1)
+
+@[fun_prop]
+lemma zpow' {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (n : ℤ) :
+    MeromorphicAt (fun z ↦ (f z) ^ n) x :=
+  hf.zpow n
 
 theorem eventually_analyticAt [CompleteSpace E] {f : 𝕜 → E} {x : 𝕜}
     (h : MeromorphicAt f x) : ∀ᶠ y in 𝓝[≠] x, AnalyticAt 𝕜 f y := by

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -157,7 +157,7 @@ lemma inv {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicA
       ring
 
 @[fun_prop]
-lemma inv' {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicAt (fun z ↦ f⁻¹ z) x :=
+lemma inv' {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicAt (fun z ↦ (f z)⁻¹) x :=
   hf.inv
 
 @[simp]

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -395,7 +395,6 @@ theorem AnalyticOnNhd.iteratedFDeriv_of_isOpen (h : AnalyticOnNhd 𝕜 f s) (hs 
 
 /-- If a partial homeomorphism `f` is analytic at a point `a`, with invertible derivative, then
 its inverse is analytic at `f a`. -/
-@[fun_prop]
 theorem PartialHomeomorph.analyticAt_symm' (f : PartialHomeomorph E F) {a : E}
     {i : E ≃L[𝕜] F} (h0 : a ∈ f.source) (h : AnalyticAt 𝕜 f a) (h' : fderiv 𝕜 f a = i) :
     AnalyticAt 𝕜 f.symm (f a) := by
@@ -405,7 +404,6 @@ theorem PartialHomeomorph.analyticAt_symm' (f : PartialHomeomorph E F) {a : E}
 
 /-- If a partial homeomorphism `f` is analytic at a point `f.symm a`, with invertible derivative,
 then its inverse is analytic at `a`. -/
-@[fun_prop]
 theorem PartialHomeomorph.analyticAt_symm (f : PartialHomeomorph E F) {a : F}
     {i : E ≃L[𝕜] F} (h0 : a ∈ f.target) (h : AnalyticAt 𝕜 f (f.symm a))
     (h' : fderiv 𝕜 f (f.symm a) = i) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -118,6 +118,7 @@ theorem AnalyticWithinAt.differentiableWithinAt (h : AnalyticWithinAt 𝕜 f s x
   obtain ⟨p, hp⟩ := h
   exact hp.differentiableWithinAt
 
+@[fun_prop]
 theorem AnalyticAt.differentiableAt : AnalyticAt 𝕜 f x → DifferentiableAt 𝕜 f x
   | ⟨_, hp⟩ => hp.differentiableAt
 
@@ -234,6 +235,7 @@ protected theorem HasFPowerSeriesWithinOnBall.fderivWithin_of_mem [CompleteSpace
   exact this.symm
 
 /-- If a function is analytic on a set `s`, so is its Fréchet derivative. -/
+@[fun_prop]
 protected theorem AnalyticAt.fderiv [CompleteSpace F] (h : AnalyticAt 𝕜 f x) :
     AnalyticAt 𝕜 (fderiv 𝕜 f) x := by
   rcases h with ⟨p, r, hp⟩
@@ -393,6 +395,7 @@ theorem AnalyticOnNhd.iteratedFDeriv_of_isOpen (h : AnalyticOnNhd 𝕜 f s) (hs 
 
 /-- If a partial homeomorphism `f` is analytic at a point `a`, with invertible derivative, then
 its inverse is analytic at `f a`. -/
+@[fun_prop]
 theorem PartialHomeomorph.analyticAt_symm' (f : PartialHomeomorph E F) {a : E}
     {i : E ≃L[𝕜] F} (h0 : a ∈ f.source) (h : AnalyticAt 𝕜 f a) (h' : fderiv 𝕜 f a = i) :
     AnalyticAt 𝕜 f.symm (f a) := by
@@ -402,6 +405,7 @@ theorem PartialHomeomorph.analyticAt_symm' (f : PartialHomeomorph E F) {a : E}
 
 /-- If a partial homeomorphism `f` is analytic at a point `f.symm a`, with invertible derivative,
 then its inverse is analytic at `a`. -/
+@[fun_prop]
 theorem PartialHomeomorph.analyticAt_symm (f : PartialHomeomorph E F) {a : F}
     {i : E ≃L[𝕜] F} (h0 : a ∈ f.target) (h : AnalyticAt 𝕜 f (f.symm a))
     (h' : fderiv 𝕜 f (f.symm a) = i) :

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Analytic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Analytic.lean
@@ -21,6 +21,7 @@ variable {E : Type} [NormedAddCommGroup E] [NormedSpace ℂ E]
 variable {f g : E → ℂ} {z : ℂ} {x : E} {s : Set E}
 
 /-- `log` is analytic away from nonpositive reals -/
+@[fun_prop]
 theorem analyticAt_clog (m : z ∈ slitPlane) : AnalyticAt ℂ log z := by
   rw [analyticAt_iff_eventually_differentiableAt]
   filter_upwards [isOpen_slitPlane.eventually_mem m]
@@ -28,6 +29,7 @@ theorem analyticAt_clog (m : z ∈ slitPlane) : AnalyticAt ℂ log z := by
   exact differentiableAt_id.clog m
 
 /-- `log` is analytic away from nonpositive reals -/
+@[fun_prop]
 theorem AnalyticAt.clog (fa : AnalyticAt ℂ f x) (m : f x ∈ slitPlane) :
     AnalyticAt ℂ (fun z ↦ log (f z)) x :=
   (analyticAt_clog m).comp fa
@@ -56,6 +58,7 @@ theorem AnalyticWithinAt.cpow (fa : AnalyticWithinAt ℂ f s x) (ga : AnalyticWi
   exact ((fa.clog m).mul ga).cexp
 
 /-- `f z ^ g z` is analytic if `f z` is not a nonpositive real -/
+@[fun_prop]
 theorem AnalyticAt.cpow (fa : AnalyticAt ℂ f x) (ga : AnalyticAt ℂ g x)
     (m : f x ∈ slitPlane) : AnalyticAt ℂ (fun z ↦ f z ^ g z) x := by
   rw [← analyticWithinAt_univ] at fa ga ⊢

--- a/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
@@ -49,12 +49,12 @@ theorem analyticAt_cexp : AnalyticAt ℂ exp z :=
 
 /-- `exp ∘ f` is analytic -/
 @[fun_prop]
-theorem AnalyticAt.cexp (fa : AnalyticAt ℂ f x) : AnalyticAt ℂ (fun z ↦ exp (f z)) x :=
+theorem AnalyticAt.cexp (fa : AnalyticAt ℂ f x) : AnalyticAt ℂ (exp ∘ f) x :=
   analyticAt_cexp.comp fa
 
 /-- `exp ∘ f` is analytic -/
 @[fun_prop]
-theorem AnalyticAt.cexp' (fa : AnalyticAt ℂ f x) : AnalyticAt ℂ (exp ∘ f) x :=
+theorem AnalyticAt.cexp' (fa : AnalyticAt ℂ f x) : AnalyticAt ℂ (fun z ↦ exp (f z)) x :=
   fa.cexp
 
 theorem AnalyticWithinAt.cexp (fa : AnalyticWithinAt ℂ f s x) :

--- a/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
@@ -43,12 +43,19 @@ theorem analyticOnNhd_cexp : AnalyticOnNhd ℂ exp univ := by
 theorem analyticOn_cexp : AnalyticOn ℂ exp univ := analyticOnNhd_cexp.analyticOn
 
 /-- `exp` is analytic at any point -/
+@[fun_prop]
 theorem analyticAt_cexp : AnalyticAt ℂ exp z :=
   analyticOnNhd_cexp z (mem_univ _)
 
 /-- `exp ∘ f` is analytic -/
+@[fun_prop]
 theorem AnalyticAt.cexp (fa : AnalyticAt ℂ f x) : AnalyticAt ℂ (fun z ↦ exp (f z)) x :=
   analyticAt_cexp.comp fa
+
+/-- `exp ∘ f` is analytic -/
+@[fun_prop]
+theorem AnalyticAt.cexp' (fa : AnalyticAt ℂ f x) : AnalyticAt ℂ (exp ∘ f) x :=
+  fa.cexp
 
 theorem AnalyticWithinAt.cexp (fa : AnalyticWithinAt ℂ f s x) :
     AnalyticWithinAt ℂ (fun z ↦ exp (f z)) s x :=
@@ -204,12 +211,19 @@ theorem analyticOnNhd_rexp : AnalyticOnNhd ℝ exp univ := by
 theorem analyticOn_rexp : AnalyticOn ℝ exp univ := analyticOnNhd_rexp.analyticOn
 
 /-- `exp` is analytic at any point -/
+@[fun_prop]
 theorem analyticAt_rexp : AnalyticAt ℝ exp x :=
   analyticOnNhd_rexp x (mem_univ _)
 
 /-- `exp ∘ f` is analytic -/
-theorem AnalyticAt.rexp {x : E} (fa : AnalyticAt ℝ f x) : AnalyticAt ℝ (fun z ↦ exp (f z)) x :=
+@[fun_prop]
+theorem AnalyticAt.rexp {x : E} (fa : AnalyticAt ℝ f x) : AnalyticAt ℝ (exp ∘ f) x :=
   analyticAt_rexp.comp fa
+
+/-- `exp ∘ f` is analytic -/
+@[fun_prop]
+theorem AnalyticAt.rexp' {x : E} (fa : AnalyticAt ℝ f x) : AnalyticAt ℝ (fun z ↦ exp (f z)) x :=
+  fa.rexp
 
 theorem AnalyticWithinAt.rexp {x : E} (fa : AnalyticWithinAt ℝ f s x) :
     AnalyticWithinAt ℝ (fun z ↦ exp (f z)) s x :=


### PR DESCRIPTION
Mark theorems pertaining to `AnalyticAt` / `MeromorphicAt` for use with `fun_prop`. As discussed yesterday in the FLUG meeting with @TwoFX and others, I duplicated a several theorems because tactics such as `fun_prop` and `rw` cannot see that `f + g` and `fun x => f x + g x` are the same thing. I made the formulations a little more consistent, in that there is now always one theorem `AnalyticAt.add` that speaks about `f + g` and one version `AnalyticAt.add'` that speaks about `fun x => f x + g x`.

This new functionality is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
