### PR TITLE
[Merged by Bors] - chore: remove non-emptiness hypotheses in the disjoint union of manifolds

### DIFF
--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -851,7 +851,7 @@ theorem piChartedSpace_chartAt {ι : Type*} [Finite ι] (H : ι → Type*)
 section sum
 
 variable [TopologicalSpace H] [TopologicalSpace M] [TopologicalSpace M']
-    [cm : ChartedSpace H M] [cm' : ChartedSpace H M'] [Nonempty H] [Nonempty M] [Nonempty M']
+    [cm : ChartedSpace H M] [cm' : ChartedSpace H M'] [Inhabited M] [Inhabited M']
 
 /-- The disjoint union of two charted spaces on `H` is a charted space over `H`. -/
 instance ChartedSpace.sum : ChartedSpace H (M ⊕ M') where

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -851,7 +851,7 @@ theorem piChartedSpace_chartAt {ι : Type*} [Finite ι] (H : ι → Type*)
 section sum
 
 variable [TopologicalSpace H] [TopologicalSpace M] [TopologicalSpace M']
-    [cm : ChartedSpace H M] [cm' : ChartedSpace H M'] [Inhabited M] [Inhabited M']
+    [cm : ChartedSpace H M] [cm' : ChartedSpace H M'] [Nonempty H]
 
 /-- The disjoint union of two charted spaces on `H` is a charted space over `H`. -/
 instance ChartedSpace.sum : ChartedSpace H (M ⊕ M') where

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -259,12 +259,11 @@ end prod
 section disjointUnion
 
 variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M'] {n : WithTop ℕ∞}
-  [hM : IsManifold I n M] [hM' : IsManifold I n M']
-  [Nonempty M] [Nonempty M'] [Nonempty H]
+  [hM : IsManifold I n M] [hM' : IsManifold I n M'] [Nonempty H]
   {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H' : Type*} [TopologicalSpace H']
   {J : Type*} {J : ModelWithCorners 𝕜 E' H'}
   {N N' : Type*} [TopologicalSpace N] [TopologicalSpace N'] [ChartedSpace H' N] [ChartedSpace H' N']
-  [IsManifold J n N] [IsManifold J n N'] [Nonempty N] [Nonempty N'] [Nonempty H']
+  [IsManifold J n N] [IsManifold J n N'] [Nonempty H']
 
 open Topology
 

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -181,6 +181,15 @@ lemma Boundaryless.iff_boundary_eq_empty : I.boundary M = ∅ ↔ BoundarylessMa
   rw [h]
   trivial
 
+/-- `M` is boundaryless iff its boundary is empty. -/
+lemma Boundaryless.iff_boundary_eq_empty : I.boundary M = ∅ ↔ BoundarylessManifold I M := by
+  refine ⟨fun h ↦ { isInteriorPoint' := ?_ }, fun a ↦ boundary_eq_empty I⟩
+  intro x
+  show x ∈ I.interior M
+  rw [← compl_interior, compl_empty_iff] at h
+  rw [h]
+  trivial
+
 /-- Manifolds with empty boundary are boundaryless. -/
 lemma Boundaryless.of_boundary_eq_empty (h : I.boundary M = ∅) : BoundarylessManifold I M :=
   (Boundaryless.iff_boundary_eq_empty (I := I)).mp h

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -181,15 +181,6 @@ lemma Boundaryless.iff_boundary_eq_empty : I.boundary M = ∅ ↔ BoundarylessMa
   rw [h]
   trivial
 
-/-- `M` is boundaryless iff its boundary is empty. -/
-lemma Boundaryless.iff_boundary_eq_empty : I.boundary M = ∅ ↔ BoundarylessManifold I M := by
-  refine ⟨fun h ↦ { isInteriorPoint' := ?_ }, fun a ↦ boundary_eq_empty I⟩
-  intro x
-  show x ∈ I.interior M
-  rw [← compl_interior, compl_empty_iff] at h
-  rw [h]
-  trivial
-
 /-- Manifolds with empty boundary are boundaryless. -/
 lemma Boundaryless.of_boundary_eq_empty (h : I.boundary M = ∅) : BoundarylessManifold I M :=
   (Boundaryless.iff_boundary_eq_empty (I := I)).mp h

--- a/Mathlib/Geometry/Manifold/IsManifold.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold.lean
@@ -829,7 +829,7 @@ variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M']
 
 /-- The disjoint union of two `C^n` manifolds modelled on `(E, H)`
 is a `C^n` manifold modeled on `(E, H)`. -/
-instance disjointUnion [Inhabited M] [Inhabited M'] : IsManifold I n (M ⊕ M') where
+instance disjointUnion [Nonempty H] : IsManifold I n (M ⊕ M') where
   compatible {e} e' he he' := by
     obtain (⟨f, hf, hef⟩ | ⟨f, hf, hef⟩) := ChartedSpace.mem_atlas_sum he
     · obtain (⟨f', hf', he'f'⟩ | ⟨f', hf', he'f'⟩) := ChartedSpace.mem_atlas_sum he'

--- a/Mathlib/Geometry/Manifold/IsManifold.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold.lean
@@ -829,7 +829,7 @@ variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M']
 
 /-- The disjoint union of two `C^n` manifolds modelled on `(E, H)`
 is a `C^n` manifold modeled on `(E, H)`. -/
-instance disjointUnion [Nonempty M] [Nonempty M'] [Nonempty H] : IsManifold I n (M ⊕ M') where
+instance disjointUnion [Inhabited M] [Inhabited M'] : IsManifold I n (M ⊕ M') where
   compatible {e} e' he he' := by
     obtain (⟨f, hf, hef⟩ | ⟨f, hf, hef⟩) := ChartedSpace.mem_atlas_sum he
     · obtain (⟨f', hf', he'f'⟩ | ⟨f', hf', he'f'⟩) := ChartedSpace.mem_atlas_sum he'

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1328,6 +1328,11 @@ end subtypeRestr
 variable {X X' Z : Type*} [TopologicalSpace X] [TopologicalSpace X'] [TopologicalSpace Z]
     [hX : Inhabited X] {f : X → X'}
 
+-- better: defs lift_openEmbedding_empty (does the empty homeo already exist?)
+-- and lift_openEmbedding_inhabited (the current def);
+-- then have the real definition switch on these!
+-- need to decide which simp lemmas to keep...
+
 /-- Extend a partial homeomorphism `e : X → Z` to `X' → Z`, using an open embedding `ι : X → X'`.
 On `ι(X)`, the extension is specified by `e`; its value elsewhere is arbitrary (and uninteresting).
 -/

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1326,20 +1326,14 @@ theorem subtypeRestr_symm_eqOn_of_le {U V : Opens X} (hU : Nonempty U) (hV : Non
 end subtypeRestr
 
 variable {X X' Z : Type*} [TopologicalSpace X] [TopologicalSpace X'] [TopologicalSpace Z]
-    [hX : Inhabited X] {f : X → X'}
-
--- better: defs lift_openEmbedding_empty (does the empty homeo already exist?)
--- and lift_openEmbedding_inhabited (the current def);
--- then have the real definition switch on these!
--- need to decide which simp lemmas to keep...
+    {f : X → X'} [Nonempty Z]
 
 /-- Extend a partial homeomorphism `e : X → Z` to `X' → Z`, using an open embedding `ι : X → X'`.
 On `ι(X)`, the extension is specified by `e`; its value elsewhere is arbitrary (and uninteresting).
 -/
-noncomputable def lift_openEmbedding
-    (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
+noncomputable def lift_openEmbedding (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
     PartialHomeomorph X' Z where
-  toFun := extend f e (fun _ ↦ e hX.default)
+  toFun := extend f e (fun _ ↦ (Classical.arbitrary Z))
   invFun := f ∘ e.invFun
   source := f '' e.source
   target := e.target
@@ -1357,7 +1351,9 @@ noncomputable def lift_openEmbedding
   open_source := hf.isOpenMap _ e.open_source
   open_target := e.open_target
   continuousOn_toFun := by
-    set F := (extend f e (fun _ ↦ e hX.default)) with F_eq
+    by_cases hX : Nonempty X; swap
+    · intro x hx; simp_all
+    set F := (extend f e (fun _ ↦ (Classical.arbitrary Z))) with F_eq
     have heq : EqOn F (e ∘ (hf.toPartialHomeomorph).symm) (f '' e.source) := by
       intro x ⟨x₀, hx₀, hxx₀⟩
       rw [← hxx₀, F_eq, hf.injective.extend_apply e, comp_apply, hf.toPartialHomeomorph_left_inv]
@@ -1372,11 +1368,13 @@ noncomputable def lift_openEmbedding
   continuousOn_invFun := hf.continuous.comp_continuousOn e.continuousOn_invFun
 
 @[simp]
-lemma lift_openEmbedding_toFun (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
-    (e.lift_openEmbedding hf) = extend f e (fun _ ↦ e hX.default) := rfl
+lemma lift_openEmbedding_toFun [Nonempty X]
+    (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
+    (e.lift_openEmbedding hf) = extend f e (fun _ ↦ (Classical.arbitrary Z)) := rfl
 
 lemma lift_openEmbedding_apply (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) {x : X} :
     (lift_openEmbedding e hf) (f x) = e x := by
+  have : Nonempty X := Nonempty.intro x
   simp_rw [e.lift_openEmbedding_toFun]
   apply hf.injective.extend_apply
 
@@ -1401,13 +1399,14 @@ lemma lift_openEmbedding_symm_target (e : PartialHomeomorph X Z) (hf : IsOpenEmb
     (e.lift_openEmbedding hf).symm.target = f '' e.source := by
   rw [PartialHomeomorph.symm_target, e.lift_openEmbedding_source]
 
-lemma lift_openEmbedding_trans_apply
+lemma lift_openEmbedding_trans_apply [Nonempty X]
     (e e' : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) (z : Z) :
     (e.lift_openEmbedding hf).symm.trans (e'.lift_openEmbedding hf) z = (e.symm.trans e') z := by
   simp [hf.injective.extend_apply e']
 
 @[simp]
-lemma lift_openEmbedding_trans (e e' : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
+lemma lift_openEmbedding_trans [Nonempty X]
+    (e e' : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
     (e.lift_openEmbedding hf).symm.trans (e'.lift_openEmbedding hf) = e.symm.trans e' := by
   ext x
   · exact e.lift_openEmbedding_trans_apply e' hf x

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1410,14 +1410,12 @@ lemma lift_openEmbedding_trans
     (e.lift_openEmbedding hf).symm.trans (e'.lift_openEmbedding hf) = e.symm.trans e' := by
   ext z
   · by_cases h': Nonempty X; swap
-    · exfalso
-      have := not_nonempty_iff.mp h'
-      exact IsEmpty.false (e.symm z)
+    · have := not_nonempty_iff.mp h'
+      exact (IsEmpty.false (e.symm z)).elim
     exact e.lift_openEmbedding_trans_apply e' hf z
   · by_cases h': Nonempty X; swap
-    · exfalso
-      have := not_nonempty_iff.mp h'
-      exact IsEmpty.false (e.symm z)
+    · have := not_nonempty_iff.mp h'
+      exact (IsEmpty.false (e.symm z)).elim
     simp [hf.injective.extend_apply e]
   · simp_rw [PartialHomeomorph.trans_source, e.lift_openEmbedding_symm_source, e.symm_source,
       e.lift_openEmbedding_symm, e'.lift_openEmbedding_source]

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1326,7 +1326,7 @@ theorem subtypeRestr_symm_eqOn_of_le {U V : Opens X} (hU : Nonempty U) (hV : Non
 end subtypeRestr
 
 variable {X X' Z : Type*} [TopologicalSpace X] [TopologicalSpace X'] [TopologicalSpace Z]
-    [Nonempty X] [Nonempty Z] {f : X → X'}
+    [Nonempty X] {f : X → X'}
 
 /-- Extend a partial homeomorphism `e : X → Z` to `X' → Z`, using an open embedding `ι : X → X'`.
 On `ι(X)`, the extension is specified by `e`; its value elsewhere is arbitrary (and uninteresting).
@@ -1334,7 +1334,9 @@ On `ι(X)`, the extension is specified by `e`; its value elsewhere is arbitrary 
 noncomputable def lift_openEmbedding
     (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
     PartialHomeomorph X' Z where
-  toFun := extend f e (Classical.arbitrary (α := X' → Z))
+  toFun := by
+    inhabit X; --letI foo e
+    exact extend f e (fun _ ↦ e inhabited_h.default)--(Classical.arbitrary (α := X' → Z))
   invFun := f ∘ e.invFun
   source := f '' e.source
   target := e.target
@@ -1352,7 +1354,8 @@ noncomputable def lift_openEmbedding
   open_source := hf.isOpenMap _ e.open_source
   open_target := e.open_target
   continuousOn_toFun := by
-    set F := (extend f (↑e) (Classical.arbitrary (X' → Z))) with F_eq
+    inhabit X
+    set F := (extend f (↑e) (fun _ ↦ e inhabited_h.default)) with F_eq
     have heq : EqOn F (e ∘ (hf.toPartialHomeomorph).symm) (f '' e.source) := by
       intro x ⟨x₀, hx₀, hxx₀⟩
       rw [← hxx₀, F_eq, hf.injective.extend_apply e, comp_apply, hf.toPartialHomeomorph_left_inv]
@@ -1363,7 +1366,8 @@ noncomputable def lift_openEmbedding
       have : ContinuousOn (hf.toPartialHomeomorph).symm (f '' univ) := by
         apply (hf.toPartialHomeomorph).continuousOn_invFun
       apply this.mono; gcongr; exact fun ⦃a⦄ a ↦ trivial
-    apply ContinuousOn.congr this heq
+    dsimp
+    apply ContinuousOn.congr --this heq
   continuousOn_invFun := hf.continuous.comp_continuousOn e.continuousOn_invFun
 
 @[simp]

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1326,7 +1326,7 @@ theorem subtypeRestr_symm_eqOn_of_le {U V : Opens X} (hU : Nonempty U) (hV : Non
 end subtypeRestr
 
 variable {X X' Z : Type*} [TopologicalSpace X] [TopologicalSpace X'] [TopologicalSpace Z]
-    {f : X → X'} [Nonempty Z]
+  [Nonempty Z] {f : X → X'}
 
 /-- Extend a partial homeomorphism `e : X → Z` to `X' → Z`, using an open embedding `ι : X → X'`.
 On `ι(X)`, the extension is specified by `e`; its value elsewhere is arbitrary (and uninteresting).
@@ -1351,7 +1351,7 @@ noncomputable def lift_openEmbedding (e : PartialHomeomorph X Z) (hf : IsOpenEmb
   open_source := hf.isOpenMap _ e.open_source
   open_target := e.open_target
   continuousOn_toFun := by
-    by_cases hX : Nonempty X; swap
+    by_cases Nonempty X; swap
     · intro x hx; simp_all
     set F := (extend f e (fun _ ↦ (Classical.arbitrary Z))) with F_eq
     have heq : EqOn F (e ∘ (hf.toPartialHomeomorph).symm) (f '' e.source) := by
@@ -1361,10 +1361,10 @@ noncomputable def lift_openEmbedding (e : PartialHomeomorph X Z) (hf : IsOpenEmb
       apply e.continuousOn_toFun.comp; swap
       · intro x' ⟨x, hx, hx'x⟩
         rw [← hx'x, hf.toPartialHomeomorph_left_inv]; exact hx
-      have : ContinuousOn (hf.toPartialHomeomorph).symm (f '' univ) := by
-        apply (hf.toPartialHomeomorph).continuousOn_invFun
+      have : ContinuousOn (hf.toPartialHomeomorph).symm (f '' univ) :=
+        (hf.toPartialHomeomorph).continuousOn_invFun
       apply this.mono; gcongr; exact fun ⦃a⦄ a ↦ trivial
-    apply ContinuousOn.congr this heq
+    exact ContinuousOn.congr this heq
   continuousOn_invFun := hf.continuous.comp_continuousOn e.continuousOn_invFun
 
 @[simp]
@@ -1374,7 +1374,7 @@ lemma lift_openEmbedding_toFun [Nonempty X]
 
 lemma lift_openEmbedding_apply (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) {x : X} :
     (lift_openEmbedding e hf) (f x) = e x := by
-  have : Nonempty X := Nonempty.intro x
+  have := Nonempty.intro x
   simp_rw [e.lift_openEmbedding_toFun]
   apply hf.injective.extend_apply
 

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1368,8 +1368,7 @@ noncomputable def lift_openEmbedding (e : PartialHomeomorph X Z) (hf : IsOpenEmb
   continuousOn_invFun := hf.continuous.comp_continuousOn e.continuousOn_invFun
 
 @[simp]
-lemma lift_openEmbedding_toFun
-    (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
+lemma lift_openEmbedding_toFun (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
     (e.lift_openEmbedding hf) = extend f e (fun _ ↦ (Classical.arbitrary Z)) := rfl
 
 lemma lift_openEmbedding_apply (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) {x : X} :
@@ -1404,8 +1403,7 @@ lemma lift_openEmbedding_trans_apply
   simp [hf.injective.extend_apply e']
 
 @[simp]
-lemma lift_openEmbedding_trans
-    (e e' : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
+lemma lift_openEmbedding_trans (e e' : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
     (e.lift_openEmbedding hf).symm.trans (e'.lift_openEmbedding hf) = e.symm.trans e' := by
   ext z
   · exact e.lift_openEmbedding_trans_apply e' hf z

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1368,7 +1368,7 @@ noncomputable def lift_openEmbedding (e : PartialHomeomorph X Z) (hf : IsOpenEmb
   continuousOn_invFun := hf.continuous.comp_continuousOn e.continuousOn_invFun
 
 @[simp]
-lemma lift_openEmbedding_toFun [Nonempty X]
+lemma lift_openEmbedding_toFun
     (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
     (e.lift_openEmbedding hf) = extend f e (fun _ ↦ (Classical.arbitrary Z)) := rfl
 
@@ -1399,18 +1399,26 @@ lemma lift_openEmbedding_symm_target (e : PartialHomeomorph X Z) (hf : IsOpenEmb
     (e.lift_openEmbedding hf).symm.target = f '' e.source := by
   rw [PartialHomeomorph.symm_target, e.lift_openEmbedding_source]
 
-lemma lift_openEmbedding_trans_apply [Nonempty X]
+lemma lift_openEmbedding_trans_apply
     (e e' : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) (z : Z) :
     (e.lift_openEmbedding hf).symm.trans (e'.lift_openEmbedding hf) z = (e.symm.trans e') z := by
   simp [hf.injective.extend_apply e']
 
 @[simp]
-lemma lift_openEmbedding_trans [Nonempty X]
+lemma lift_openEmbedding_trans
     (e e' : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
     (e.lift_openEmbedding hf).symm.trans (e'.lift_openEmbedding hf) = e.symm.trans e' := by
-  ext x
-  · exact e.lift_openEmbedding_trans_apply e' hf x
-  · simp [hf.injective.extend_apply e]
+  ext z
+  · by_cases h': Nonempty X; swap
+    · exfalso
+      have := not_nonempty_iff.mp h'
+      exact IsEmpty.false (e.symm z)
+    exact e.lift_openEmbedding_trans_apply e' hf z
+  · by_cases h': Nonempty X; swap
+    · exfalso
+      have := not_nonempty_iff.mp h'
+      exact IsEmpty.false (e.symm z)
+    simp [hf.injective.extend_apply e]
   · simp_rw [PartialHomeomorph.trans_source, e.lift_openEmbedding_symm_source, e.symm_source,
       e.lift_openEmbedding_symm, e'.lift_openEmbedding_source]
     refine ⟨fun ⟨hx, ⟨y, hy, hxy⟩⟩ ↦ ⟨hx, ?_⟩, fun ⟨hx, hx'⟩ ↦ ⟨hx, mem_image_of_mem f hx'⟩⟩

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1408,14 +1408,8 @@ lemma lift_openEmbedding_trans
     (e e' : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
     (e.lift_openEmbedding hf).symm.trans (e'.lift_openEmbedding hf) = e.symm.trans e' := by
   ext z
-  · by_cases h': Nonempty X; swap
-    · have := not_nonempty_iff.mp h'
-      exact (IsEmpty.false (e.symm z)).elim
-    exact e.lift_openEmbedding_trans_apply e' hf z
-  · by_cases h': Nonempty X; swap
-    · have := not_nonempty_iff.mp h'
-      exact (IsEmpty.false (e.symm z)).elim
-    simp [hf.injective.extend_apply e]
+  · exact e.lift_openEmbedding_trans_apply e' hf z
+  · simp [hf.injective.extend_apply e]
   · simp_rw [PartialHomeomorph.trans_source, e.lift_openEmbedding_symm_source, e.symm_source,
       e.lift_openEmbedding_symm, e'.lift_openEmbedding_source]
     refine ⟨fun ⟨hx, ⟨y, hy, hxy⟩⟩ ↦ ⟨hx, ?_⟩, fun ⟨hx, hx'⟩ ↦ ⟨hx, mem_image_of_mem f hx'⟩⟩

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1326,7 +1326,7 @@ theorem subtypeRestr_symm_eqOn_of_le {U V : Opens X} (hU : Nonempty U) (hV : Non
 end subtypeRestr
 
 variable {X X' Z : Type*} [TopologicalSpace X] [TopologicalSpace X'] [TopologicalSpace Z]
-    [Nonempty X] {f : X → X'}
+    [hX : Inhabited X] {f : X → X'}
 
 /-- Extend a partial homeomorphism `e : X → Z` to `X' → Z`, using an open embedding `ι : X → X'`.
 On `ι(X)`, the extension is specified by `e`; its value elsewhere is arbitrary (and uninteresting).
@@ -1334,9 +1334,7 @@ On `ι(X)`, the extension is specified by `e`; its value elsewhere is arbitrary 
 noncomputable def lift_openEmbedding
     (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
     PartialHomeomorph X' Z where
-  toFun := by
-    inhabit X; --letI foo e
-    exact extend f e (fun _ ↦ e inhabited_h.default)--(Classical.arbitrary (α := X' → Z))
+  toFun := extend f e (fun _ ↦ e hX.default)
   invFun := f ∘ e.invFun
   source := f '' e.source
   target := e.target
@@ -1354,8 +1352,7 @@ noncomputable def lift_openEmbedding
   open_source := hf.isOpenMap _ e.open_source
   open_target := e.open_target
   continuousOn_toFun := by
-    inhabit X
-    set F := (extend f (↑e) (fun _ ↦ e inhabited_h.default)) with F_eq
+    set F := (extend f e (fun _ ↦ e hX.default)) with F_eq
     have heq : EqOn F (e ∘ (hf.toPartialHomeomorph).symm) (f '' e.source) := by
       intro x ⟨x₀, hx₀, hxx₀⟩
       rw [← hxx₀, F_eq, hf.injective.extend_apply e, comp_apply, hf.toPartialHomeomorph_left_inv]
@@ -1366,13 +1363,12 @@ noncomputable def lift_openEmbedding
       have : ContinuousOn (hf.toPartialHomeomorph).symm (f '' univ) := by
         apply (hf.toPartialHomeomorph).continuousOn_invFun
       apply this.mono; gcongr; exact fun ⦃a⦄ a ↦ trivial
-    dsimp
-    apply ContinuousOn.congr --this heq
+    apply ContinuousOn.congr this heq
   continuousOn_invFun := hf.continuous.comp_continuousOn e.continuousOn_invFun
 
 @[simp]
 lemma lift_openEmbedding_toFun (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) :
-    (e.lift_openEmbedding hf) = extend f e (Classical.arbitrary (α := (X' → Z))) := rfl
+    (e.lift_openEmbedding hf) = extend f e (fun _ ↦ e hX.default) := rfl
 
 lemma lift_openEmbedding_apply (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) {x : X} :
     (lift_openEmbedding e hf) (f x) = e x := by

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -1374,7 +1374,6 @@ lemma lift_openEmbedding_toFun
 
 lemma lift_openEmbedding_apply (e : PartialHomeomorph X Z) (hf : IsOpenEmbedding f) {x : X} :
     (lift_openEmbedding e hf) (f x) = e x := by
-  have := Nonempty.intro x
   simp_rw [e.lift_openEmbedding_toFun]
   apply hf.injective.extend_apply
 


### PR DESCRIPTION
The previous code assumed both manifolds were non-empty: this is in fact not necessary.
(When doing bordism theory, such unions are meaningful: a cobordism between a manifold M and "the empty set" is supposed to have boundary M union the empty set, so we need to speak about this.)

Besides, the code only gets marginally longer, so this change might be worth it independently.

From my bordism theory project.

---

- [ ] depends on: #15893 because I stacked the branches this way

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
