### PR TITLE
[Merged by Bors] - chore(Algebra/Group/Submonoid/Operations): move instances to new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5655,15 +5655,3 @@ import Mathlib.Util.TermReduce
 import Mathlib.Util.TransImports
 import Mathlib.Util.WhatsNew
 import Mathlib.Util.WithWeakNamespace
-import Mathlib.scratch.Profile
-import Mathlib.scratch.scratch1
-import Mathlib.scratch.scratch2
-import Mathlib.scratch.scratch3
-import Mathlib.scratch.scratch37
-import Mathlib.scratch.scratch4
-import Mathlib.scratch.scratch5
-import Mathlib.scratch.scratch6
-import Mathlib.scratch.scratch7
-import Mathlib.scratch.scratch8
-import Mathlib.scratch.scratch9
-import Mathlib.scratch.spectral

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4404,7 +4404,6 @@ import Mathlib.RepresentationTheory.GroupCohomology.Basic
 import Mathlib.RepresentationTheory.GroupCohomology.Hilbert90
 import Mathlib.RepresentationTheory.GroupCohomology.LowDegree
 import Mathlib.RepresentationTheory.GroupCohomology.Resolution
-import Mathlib.RepresentationTheory.GroupCohomology.scratch
 import Mathlib.RepresentationTheory.Invariants
 import Mathlib.RepresentationTheory.Maschke
 import Mathlib.RepresentationTheory.Rep

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -354,6 +354,7 @@ import Mathlib.Algebra.Group.Submonoid.Defs
 import Mathlib.Algebra.Group.Submonoid.DistribMulAction
 import Mathlib.Algebra.Group.Submonoid.Finsupp
 import Mathlib.Algebra.Group.Submonoid.Membership
+import Mathlib.Algebra.Group.Submonoid.MulAction
 import Mathlib.Algebra.Group.Submonoid.MulOpposite
 import Mathlib.Algebra.Group.Submonoid.Operations
 import Mathlib.Algebra.Group.Submonoid.Pointwise
@@ -4403,6 +4404,7 @@ import Mathlib.RepresentationTheory.GroupCohomology.Basic
 import Mathlib.RepresentationTheory.GroupCohomology.Hilbert90
 import Mathlib.RepresentationTheory.GroupCohomology.LowDegree
 import Mathlib.RepresentationTheory.GroupCohomology.Resolution
+import Mathlib.RepresentationTheory.GroupCohomology.scratch
 import Mathlib.RepresentationTheory.Invariants
 import Mathlib.RepresentationTheory.Maschke
 import Mathlib.RepresentationTheory.Rep
@@ -5654,3 +5656,15 @@ import Mathlib.Util.TermReduce
 import Mathlib.Util.TransImports
 import Mathlib.Util.WhatsNew
 import Mathlib.Util.WithWeakNamespace
+import Mathlib.scratch.Profile
+import Mathlib.scratch.scratch1
+import Mathlib.scratch.scratch2
+import Mathlib.scratch.scratch3
+import Mathlib.scratch.scratch37
+import Mathlib.scratch.scratch4
+import Mathlib.scratch.scratch5
+import Mathlib.scratch.scratch6
+import Mathlib.scratch.scratch7
+import Mathlib.scratch.scratch8
+import Mathlib.scratch.scratch9
+import Mathlib.scratch.spectral

--- a/Mathlib/Algebra/Group/Submonoid/MulAction.lean
+++ b/Mathlib/Algebra/Group/Submonoid/MulAction.lean
@@ -6,8 +6,6 @@ Authors: Eric Wieser
 import Mathlib.Algebra.Group.Submonoid.Defs
 import Mathlib.Algebra.Group.Action.Defs
 
-section Actions
-
 /-! ### Actions by `Submonoid`s
 
 These instances transfer the action by an element `m : M` of a monoid `M` written as `m • a` onto
@@ -16,7 +14,6 @@ the action by an element `s : S` of a submonoid `S : Submonoid M` such that `s �
 These instances work particularly well in conjunction with `Monoid.toMulAction`, enabling
 `s • m` as an alias for `↑s * m`.
 -/
-
 
 namespace Submonoid
 
@@ -68,7 +65,4 @@ instance mulAction [MulAction M' α] (S : Submonoid M') : MulAction S α where
 
 example {S : Submonoid M'} : IsScalarTower S M' M' := by infer_instance
 
-
 end Submonoid
-
-end Actions

--- a/Mathlib/Algebra/Group/Submonoid/MulAction.lean
+++ b/Mathlib/Algebra/Group/Submonoid/MulAction.lean
@@ -6,7 +6,8 @@ Authors: Eric Wieser
 import Mathlib.Algebra.Group.Submonoid.Defs
 import Mathlib.Algebra.Group.Action.Defs
 
-/-! ### Actions by `Submonoid`s
+/-! 
+# Actions by `Submonoid`s
 
 These instances transfer the action by an element `m : M` of a monoid `M` written as `m • a` onto
 the action by an element `s : S` of a submonoid `S : Submonoid M` such that `s • a = (s : M) • a`.

--- a/Mathlib/Algebra/Group/Submonoid/MulAction.lean
+++ b/Mathlib/Algebra/Group/Submonoid/MulAction.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2021 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.Algebra.Group.Submonoid.Defs
+import Mathlib.Algebra.Group.Action.Defs
+
+section Actions
+
+/-! ### Actions by `Submonoid`s
+
+These instances transfer the action by an element `m : M` of a monoid `M` written as `m • a` onto
+the action by an element `s : S` of a submonoid `S : Submonoid M` such that `s • a = (s : M) • a`.
+
+These instances work particularly well in conjunction with `Monoid.toMulAction`, enabling
+`s • m` as an alias for `↑s * m`.
+-/
+
+
+namespace Submonoid
+
+variable {M' : Type*} {α β : Type*}
+
+section MulOneClass
+
+variable [MulOneClass M']
+
+@[to_additive]
+instance smul [SMul M' α] (S : Submonoid M') : SMul S α :=
+  SMul.comp _ S.subtype
+
+@[to_additive]
+instance smulCommClass_left [SMul M' β] [SMul α β] [SMulCommClass M' α β]
+    (S : Submonoid M') : SMulCommClass S α β :=
+  ⟨fun a _ _ => smul_comm (a : M') _ _⟩
+
+@[to_additive]
+instance smulCommClass_right [SMul α β] [SMul M' β] [SMulCommClass α M' β]
+    (S : Submonoid M') : SMulCommClass α S β :=
+  ⟨fun a s => smul_comm a (s : M')⟩
+
+/-- Note that this provides `IsScalarTower S M' M'` which is needed by `SMulMulAssoc`. -/
+instance isScalarTower [SMul α β] [SMul M' α] [SMul M' β] [IsScalarTower M' α β]
+      (S : Submonoid M') :
+    IsScalarTower S α β :=
+  ⟨fun a => smul_assoc (a : M')⟩
+
+section SMul
+variable [SMul M' α] {S : Submonoid M'}
+
+@[to_additive] lemma smul_def (g : S) (a : α) : g • a = (g : M') • a := rfl
+
+@[to_additive (attr := simp)]
+lemma mk_smul (g : M') (hg : g ∈ S) (a : α) : (⟨g, hg⟩ : S) • a = g • a := rfl
+
+end SMul
+end MulOneClass
+
+variable [Monoid M']
+
+/-- The action by a submonoid is the action by the underlying monoid. -/
+@[to_additive
+      "The additive action by an `AddSubmonoid` is the action by the underlying `AddMonoid`. "]
+instance mulAction [MulAction M' α] (S : Submonoid M') : MulAction S α where
+  one_smul := one_smul M'
+  mul_smul m₁ m₂ := mul_smul (m₁ : M') m₂
+
+example {S : Submonoid M'} : IsScalarTower S M' M' := by infer_instance
+
+
+end Submonoid
+
+end Actions

--- a/Mathlib/Algebra/Group/Submonoid/MulAction.lean
+++ b/Mathlib/Algebra/Group/Submonoid/MulAction.lean
@@ -6,7 +6,7 @@ Authors: Eric Wieser
 import Mathlib.Algebra.Group.Submonoid.Defs
 import Mathlib.Algebra.Group.Action.Defs
 
-/-! 
+/-!
 # Actions by `Submonoid`s
 
 These instances transfer the action by an element `m : M` of a monoid `M` written as `m • a` onto

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Group.Action.Faithful
 import Mathlib.Algebra.Group.Nat.Defs
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Group.Submonoid.Basic
+import Mathlib.Algebra.Group.Submonoid.MulAction
 import Mathlib.Algebra.Group.TypeTags.Basic
 
 /-!
@@ -973,74 +974,9 @@ theorem Submonoid.equivMapOfInjective_coe_mulEquiv (e : M ≃* N) :
   ext
   rfl
 
-section Actions
-
-/-! ### Actions by `Submonoid`s
-
-These instances transfer the action by an element `m : M` of a monoid `M` written as `m • a` onto
-the action by an element `s : S` of a submonoid `S : Submonoid M` such that `s • a = (s : M) • a`.
-
-These instances work particularly well in conjunction with `Monoid.toMulAction`, enabling
-`s • m` as an alias for `↑s * m`.
--/
-
-
-namespace Submonoid
-
-variable {M' : Type*} {α β : Type*}
-
-section MulOneClass
-
-variable [MulOneClass M']
-
-@[to_additive]
-instance smul [SMul M' α] (S : Submonoid M') : SMul S α :=
-  SMul.comp _ S.subtype
-
-@[to_additive]
-instance smulCommClass_left [SMul M' β] [SMul α β] [SMulCommClass M' α β]
-    (S : Submonoid M') : SMulCommClass S α β :=
-  ⟨fun a _ _ => smul_comm (a : M') _ _⟩
-
-@[to_additive]
-instance smulCommClass_right [SMul α β] [SMul M' β] [SMulCommClass α M' β]
-    (S : Submonoid M') : SMulCommClass α S β :=
-  ⟨fun a s => smul_comm a (s : M')⟩
-
-/-- Note that this provides `IsScalarTower S M' M'` which is needed by `SMulMulAssoc`. -/
-instance isScalarTower [SMul α β] [SMul M' α] [SMul M' β] [IsScalarTower M' α β]
-      (S : Submonoid M') :
-    IsScalarTower S α β :=
-  ⟨fun a => smul_assoc (a : M')⟩
-
-section SMul
-variable [SMul M' α] {S : Submonoid M'}
-
-@[to_additive] lemma smul_def (g : S) (a : α) : g • a = (g : M') • a := rfl
-
-@[to_additive (attr := simp)]
-lemma mk_smul (g : M') (hg : g ∈ S) (a : α) : (⟨g, hg⟩ : S) • a = g • a := rfl
-
-instance faithfulSMul [FaithfulSMul M' α] : FaithfulSMul S α :=
+instance faithfulSMul {M' α : Type*} [MulOneClass M'] [SMul M' α] {S : Submonoid M'}
+    [FaithfulSMul M' α] : FaithfulSMul S α :=
   ⟨fun h => Subtype.ext <| eq_of_smul_eq_smul h⟩
-
-end SMul
-end MulOneClass
-
-variable [Monoid M']
-
-/-- The action by a submonoid is the action by the underlying monoid. -/
-@[to_additive
-      "The additive action by an `AddSubmonoid` is the action by the underlying `AddMonoid`. "]
-instance mulAction [MulAction M' α] (S : Submonoid M') : MulAction S α :=
-  MulAction.compHom _ S.subtype
-
-example {S : Submonoid M'} : IsScalarTower S M' M' := by infer_instance
-
-
-end Submonoid
-
-end Actions
 
 section Units
 

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -974,7 +974,7 @@ theorem Submonoid.equivMapOfInjective_coe_mulEquiv (e : M ≃* N) :
   ext
   rfl
 
-instance faithfulSMul {M' α : Type*} [MulOneClass M'] [SMul M' α] {S : Submonoid M'}
+instance Submonoid.faithfulSMul {M' α : Type*} [MulOneClass M'] [SMul M' α] {S : Submonoid M'}
     [FaithfulSMul M' α] : FaithfulSMul S α :=
   ⟨fun h => Subtype.ext <| eq_of_smul_eq_smul h⟩
 

--- a/Mathlib/Algebra/Module/Submodule/Defs.lean
+++ b/Mathlib/Algebra/Module/Submodule/Defs.lean
@@ -5,6 +5,7 @@ Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.GroupTheory.GroupAction.SubMulAction
+import Mathlib.Algebra.Group.Submonoid.Basic
 
 /-!
 

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.MonoidAlgebra.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.WithTop
 import Mathlib.Data.Finset.Sort
 import Mathlib.Tactic.FastInstance
+import Mathlib.Algebra.Group.Submonoid.Operations
 
 /-!
 # Theory of univariate polynomials

--- a/Mathlib/GroupTheory/GroupAction/Defs.lean
+++ b/Mathlib/GroupTheory/GroupAction/Defs.lean
@@ -5,8 +5,8 @@ Authors: Chris Hughes
 -/
 import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Algebra.Group.Subgroup.Defs
-import Mathlib.Algebra.Group.Submonoid.Operations
 import Mathlib.Algebra.GroupWithZero.Action.Defs
+import Mathlib.Algebra.Group.Submonoid.MulAction
 
 /-!
 # Definition of `orbit`, `fixedPoints` and `stabilizer`

--- a/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
@@ -6,6 +6,7 @@ Authors: Amelia Livingston
 import Mathlib.Algebra.Group.Submonoid.Defs
 import Mathlib.GroupTheory.Congruence.Hom
 import Mathlib.GroupTheory.OreLocalization.Basic
+import Mathlib.Algebra.Group.Submonoid.Operations
 
 /-!
 # Localizations of commutative monoids

--- a/Mathlib/GroupTheory/OreLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/OreLocalization/Basic.lean
@@ -3,9 +3,10 @@ Copyright (c) 2022 Jakob von Raumer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jakob von Raumer, Kevin Klinge, Andrew Yang
 -/
-import Mathlib.Algebra.Group.Submonoid.Operations
 import Mathlib.GroupTheory.OreLocalization.OreSet
 import Mathlib.Tactic.Common
+import Mathlib.Algebra.Group.Submonoid.MulAction
+import Mathlib.Algebra.Group.Units.Defs
 
 /-!
 

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -9,6 +9,7 @@ import Mathlib.Topology.Algebra.MulAction
 import Mathlib.Algebra.BigOperators.Pi
 import Mathlib.Algebra.Group.ULift
 import Mathlib.Topology.ContinuousMap.Defs
+import Mathlib.Algebra.Group.Submonoid.Basic
 
 /-!
 # Theory of topological monoids


### PR DESCRIPTION
Move declarations such as `Submonoid.smul` and `Submonoid.mulAction`  into a new file, and shake some imports.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This PR moves definitions such as `Submonoid.smul` and `Submonoid.mulAction` from the 1000+ line long file `Mathlib/Algebra/Group/Submonoid/Operations.lean` to their own short file with far fewer imports. It then imports this new short file into `Mathlib/Algebra/Group/Submonoid/Operations.lean`. No declarations are changed (the declaration diff report is a false positive). This is preparation for #20983 and an attempt to make the diff of that PR readable.

Most of the declarations moved in this PR were originally made in this mathlib3 PR https://github.com/leanprover-community/mathlib3/pull/7665 so I've attributed the new file to Eric Wieser in 2021 as the author of that PR. The resulting move makes `lake exe shake` very excited, as `Mathlib/GroupTheory/GroupAction/Defs.lean` now only needs to import the new smaller file rather than all of `Mathlib/Algebra/Group/Submonoid/Operations.lean`, and `Mathlib/GroupTheory/OreLocalization/Basic.lean` also can get away without it. Then 4 other files need imports added to them to pick up the pieces. 
