### PR TITLE
[Merged by Bors] - feat: do not allocate heap cells for Erased

### DIFF
--- a/Mathlib/Data/Erased.lean
+++ b/Mathlib/Data/Erased.lean
@@ -21,7 +21,7 @@ universe u
   and proofs. This can be used to track data without storing it
   literally. -/
 def Erased (α : Sort u) : Sort max 1 u :=
-  Σ's : α → Prop, ∃ a, (fun b => a = b) = s
+  { s : α → Prop // ∃ a, (a = ·) = s }
 
 namespace Erased
 


### PR DESCRIPTION
The memory representation of `Erased` used to be a heap cell, because `Erased` is defined in terms of `PSigma`.  If we define `Erased` as a subtype of a predicate instead, then the compiler will erase values of type `Erased`.

Unfortunately, this does not work for ghost fields in structures (yet).  The structure will still contain a field for the ghost value, but at least it will be the scalar zero now.  But I suspect it would be fairly small diff to fix this in core.

```lean
structure Demo where
  a : Erased Nat
  b : Erased Nat

set_option trace.compiler.ir.result true in
def foo : Demo where a := .mk 42; b := .mk 8
```

Before:
```
[result]
def foo._closed_1 : obj :=
  let x_1 : obj := ctor_0[PSigma.mk] ◾ ◾;
  inc x_1;
  let x_2 : obj := ctor_0[Demo.mk] x_1 x_1;
  ret x_2
def foo : obj :=
  let x_1 : obj := foo._closed_1;
  ret x_1
```

After:
```
[result]
def foo : obj :=
  let x_1 : obj := ctor_0[Demo.mk] ◾ ◾;
  ret x_1
```

@digama0 This is what I was suggesting earlier this week.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
