### PR TITLE
[Merged by Bors] - feat: Sylow's first theorem for elementary `p`-groups

### DIFF
--- a/Mathlib/Algebra/Module/ZMod.lean
+++ b/Mathlib/Algebra/Module/ZMod.lean
@@ -120,10 +120,10 @@ namespace ZModModule
 variable {p : ℕ} {G : Type*} [AddCommGroup G]
 
 /-- In an elementary abelian `p`-group, every finite subgroup `H` contains a further subgroup of
-cardinality between `k` and `pk`, if `k ≤ |H|`. -/
-lemma exists_submodule_subset_card_le (hp : p.Prime) [Module (ZMod p) G] {k : ℕ}
-    (H : Submodule (ZMod p) G) (hk : k ≤ Nat.card H) (h'k : k ≠ 0) :
-    ∃ (H' : Submodule (ZMod p) G), Nat.card H' ≤ k ∧ k < p * Nat.card H' ∧ H' ≤ H := by
+cardinality between `k` and `p * k`, if `k ≤ |H|`. -/
+lemma exists_submodule_subset_card_le (hp : p.Prime) [Module (ZMod p) G]
+    (H : Submodule (ZMod p) G) {k : ℕ} (hk : k ≤ Nat.card H) (h'k : k ≠ 0) :
+    ∃ H' : Submodule (ZMod p) G, Nat.card H' ≤ k ∧ k < p * Nat.card H' ∧ H' ≤ H := by
   obtain ⟨H'm, H'mHm, H'mk, kH'm⟩ := Sylow.exists_subgroup_le_card_le
     (H := AddSubgroup.toSubgroup ((AddSubgroup.toZModSubmodule _).symm H)) hp
       isPGroup_multiplicative hk h'k

--- a/Mathlib/Algebra/Module/ZMod.lean
+++ b/Mathlib/Algebra/Module/ZMod.lean
@@ -5,6 +5,7 @@ Authors: Lawrence Wu
 -/
 import Mathlib.Algebra.Module.Submodule.Lattice
 import Mathlib.Data.ZMod.Basic
+import Mathlib.GroupTheory.Sylow
 
 /-!
 # The `ZMod n`-module structure on Abelian groups whose elements have order dividing `n`
@@ -114,3 +115,18 @@ theorem _root_.Submodule.toAddSubgroup_toZModSubmodule (S : Submodule (ZMod n) M
   rfl
 
 end AddSubgroup
+
+namespace ZModModule
+variable {p : ℕ} {G : Type*} [AddCommGroup G]
+
+/-- In an elementary abelian `p`-group, every finite subgroup `H` contains a further subgroup of
+cardinality between `k` and `pk`, if `k ≤ |H|`. -/
+lemma exists_submodule_subset_card_le (hp : p.Prime) [Module (ZMod p) G] {k : ℕ}
+    (H : Submodule (ZMod p) G) (hk : k ≤ Nat.card H) (h'k : k ≠ 0) :
+    ∃ (H' : Submodule (ZMod p) G), Nat.card H' ≤ k ∧ k < p * Nat.card H' ∧ H' ≤ H := by
+  obtain ⟨H'm, H'mHm, H'mk, kH'm⟩ := Sylow.exists_subgroup_le_card_le
+    (H := AddSubgroup.toSubgroup ((AddSubgroup.toZModSubmodule _).symm H)) hp
+      isPGroup_multiplicative hk h'k
+  exact ⟨AddSubgroup.toZModSubmodule _ (AddSubgroup.toSubgroup.symm H'm), H'mk, kH'm, H'mHm⟩
+
+end ZModModule


### PR DESCRIPTION
From PFR


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
Any suggestion for where to put this result?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
