### PR TITLE
[Merged by Bors] - chore: replace `right_deriv` by `rightDeriv` in lemma names

### DIFF
--- a/Mathlib/Analysis/Convex/Deriv.lean
+++ b/Mathlib/Analysis/Convex/Deriv.lean
@@ -395,10 +395,13 @@ lemma le_slope_of_hasDerivWithinAt_Ioi (hfc : ConvexOn ℝ S f)
   exact hfc.1.ordConnected.out hx hy ⟨ht'.le, ht.le⟩
 
 /-- Reformulation of `ConvexOn.le_slope_of_hasDerivWithinAt_Ioi` using `derivWithin`. -/
-lemma right_deriv_le_slope (hfc : ConvexOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
+lemma rightDeriv_le_slope (hfc : ConvexOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
     (hfd : DifferentiableWithinAt ℝ f (Ioi x) x) :
     derivWithin f (Ioi x) x ≤ slope f x y :=
   le_slope_of_hasDerivWithinAt_Ioi hfc hx hy hxy hfd.hasDerivWithinAt
+
+@[deprecated (since := "2025-01-26")]
+alias right_deriv_le_slope := rightDeriv_le_slope
 
 /-- If `f : ℝ → ℝ` is convex on `S` and differentiable within `S` at `x`, then the slope of any
 secant line with left endpoint at `x` is bounded below by the derivative of `f` within `S` at `x`.
@@ -449,10 +452,13 @@ lemma slope_le_of_hasDerivWithinAt_Iio (hfc : ConvexOn ℝ S f)
   exact hfc.1.ordConnected.out hx hy ⟨ht.le, ht'.le⟩
 
 /-- Reformulation of `ConvexOn.slope_le_of_hasDerivWithinAt_Iio` using `derivWithin`. -/
-lemma slope_le_left_deriv (hfc : ConvexOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
+lemma slope_le_leftDeriv (hfc : ConvexOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
     (hfd : DifferentiableWithinAt ℝ f (Iio y) y) :
     slope f x y ≤ derivWithin f (Iio y) y :=
   hfc.slope_le_of_hasDerivWithinAt_Iio hx hy hxy hfd.hasDerivWithinAt
+
+@[deprecated (since := "2025-01-26")]
+alias slope_le_left_deriv := slope_le_leftDeriv
 
 /-- If `f : ℝ → ℝ` is convex on `S` and differentiable within `S` at `y`, then the slope of any
 secant line with right endpoint at `y` is bounded above by the derivative of `f` within `S` at `y`.
@@ -531,10 +537,13 @@ lemma lt_slope_of_hasDerivWithinAt_Ioi (hfc : StrictConvexOn ℝ S f)
   simp only [← slope_def_field] at this
   exact (hfc.convexOn.le_slope_of_hasDerivWithinAt_Ioi hx hu hxu hf').trans_lt this
 
-lemma right_deriv_lt_slope (hfc : StrictConvexOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
+lemma rightDeriv_lt_slope (hfc : StrictConvexOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
     (hfd : DifferentiableWithinAt ℝ f (Ioi x) x) :
     derivWithin f (Ioi x) x < slope f x y :=
   hfc.lt_slope_of_hasDerivWithinAt_Ioi hx hy hxy hfd.hasDerivWithinAt
+
+@[deprecated (since := "2025-01-26")]
+alias right_deriv_lt_slope := rightDeriv_lt_slope
 
 /-- If `f : ℝ → ℝ` is strictly convex on `S` and differentiable within `S` at `x ∈ S`, then the
 slope of any secant line with left endpoint at `x` is strictly greater than the derivative of `f`
@@ -583,10 +592,13 @@ lemma slope_lt_of_hasDerivWithinAt_Iio (hfc : StrictConvexOn ℝ S f)
   simp_rw [← slope_def_field, slope_comm _ y] at this
   exact this.trans_le <| hfc.convexOn.slope_le_of_hasDerivWithinAt_Iio hu hy huy hf'
 
-lemma slope_lt_left_deriv (hfc : StrictConvexOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
+lemma slope_lt_leftDeriv (hfc : StrictConvexOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
     (hfd : DifferentiableWithinAt ℝ f (Iio y) y)  :
     slope f x y < derivWithin f (Iio y) y :=
   hfc.slope_lt_of_hasDerivWithinAt_Iio hx hy hxy hfd.hasDerivWithinAt
+
+@[deprecated (since := "2025-01-26")]
+alias slope_lt_left_deriv := slope_lt_leftDeriv
 
 /-- If `f : ℝ → ℝ` is strictly convex on `S` and differentiable within `S` at `y ∈ S`, then the
 slope of any secant line with right endpoint at `y` is strictly less than the derivative of `f`
@@ -657,10 +669,13 @@ lemma slope_le_of_hasDerivWithinAt_Ioi (hfc : ConcaveOn ℝ S f)
   simpa only [Pi.neg_def, slope_neg, neg_neg] using
     neg_le_neg (hfc.neg.le_slope_of_hasDerivWithinAt_Ioi hx hy hxy hf'.neg)
 
-lemma slope_le_right_deriv (hfc : ConcaveOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
+lemma slope_le_rightDeriv (hfc : ConcaveOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
     (hfd : DifferentiableWithinAt ℝ f (Ioi x) x) :
     slope f x y ≤ derivWithin f (Ioi x) x :=
   hfc.slope_le_of_hasDerivWithinAt_Ioi hx hy hxy hfd.hasDerivWithinAt
+
+@[deprecated (since := "2025-01-26")]
+alias slope_le_right_deriv := slope_le_rightDeriv
 
 lemma slope_le_of_hasDerivWithinAt (hfc : ConcaveOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
     (hfd : HasDerivWithinAt f f' S x) :
@@ -696,10 +711,13 @@ lemma le_slope_of_hasDerivWithinAt_Iio (hfc : ConcaveOn ℝ S f)
   simpa only [neg_neg, Pi.neg_def, slope_neg] using
     neg_le_neg (hfc.neg.slope_le_of_hasDerivWithinAt_Iio hx hy hxy hf'.neg)
 
-lemma left_deriv_le_slope (hfc : ConcaveOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
+lemma leftDeriv_le_slope (hfc : ConcaveOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
     (hfd : DifferentiableWithinAt ℝ f (Iio y) y) :
     derivWithin f (Iio y) y ≤ slope f x y :=
   hfc.le_slope_of_hasDerivWithinAt_Iio hx hy hxy hfd.hasDerivWithinAt
+
+@[deprecated (since := "2025-01-26")]
+alias left_deriv_le_slope := leftDeriv_le_slope
 
 lemma le_slope_of_hasDerivWithinAt (hfc : ConcaveOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
     (hf' : HasDerivWithinAt f f' S y) :
@@ -757,10 +775,13 @@ lemma slope_lt_of_hasDerivWithinAt_Ioi (hfc : StrictConcaveOn ℝ S f)
   simpa only [Pi.neg_def, slope_neg, neg_neg] using
     neg_lt_neg (hfc.neg.lt_slope_of_hasDerivWithinAt_Ioi hx hy hxy hf'.neg)
 
-lemma slope_lt_right_deriv (hfc : StrictConcaveOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
+lemma slope_lt_rightDeriv (hfc : StrictConcaveOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
     (hfd : DifferentiableWithinAt ℝ f (Ioi x) x) :
     slope f x y < derivWithin f (Ioi x) x :=
   hfc.slope_lt_of_hasDerivWithinAt_Ioi hx hy hxy hfd.hasDerivWithinAt
+
+@[deprecated (since := "2025-01-26")]
+alias slope_lt_right_deriv := slope_lt_rightDeriv
 
 lemma slope_lt_of_hasDerivWithinAt (hfc : StrictConcaveOn ℝ S f)
     (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y) (hfd : HasDerivWithinAt f f' S x) :
@@ -797,10 +818,13 @@ lemma lt_slope_of_hasDerivWithinAt_Iio (hfc : StrictConcaveOn ℝ S f)
   simpa only [Pi.neg_def, slope_neg, neg_neg] using
     neg_lt_neg (hfc.neg.slope_lt_of_hasDerivWithinAt_Iio hx hy hxy hf'.neg)
 
-lemma left_deriv_lt_slope (hfc : StrictConcaveOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
+lemma leftDeriv_lt_slope (hfc : StrictConcaveOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
     (hfd : DifferentiableWithinAt ℝ f (Iio y) y) :
     derivWithin f (Iio y) y < slope f x y :=
   hfc.lt_slope_of_hasDerivWithinAt_Iio hx hy hxy hfd.hasDerivWithinAt
+
+@[deprecated (since := "2025-01-26")]
+alias left_deriv_lt_slope := leftDeriv_lt_slope
 
 lemma lt_slope_of_hasDerivWithinAt (hfc : StrictConcaveOn ℝ S f)
     (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y) (hf' : HasDerivWithinAt f f' S y) :


### PR DESCRIPTION
And similarly for `left_deriv`.

There is no `leftDeriv` or `rightDeriv` definition (they refer to a `derivWithin` in an interval) but they have a similar role in lemma names so should be written in the same way as definitions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
