### PR TITLE
[Merged by Bors] - feat: principle of isolated zeros for meromorphic functions

### DIFF
--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -345,6 +345,51 @@ theorem eq_of_frequently_eq [ConnectedSpace 𝕜] (hf : AnalyticOnNhd 𝕜 f uni
 @[deprecated (since := "2024-09-26")]
 alias _root_.AnalyticOn.eq_of_frequently_eq := eq_of_frequently_eq
 
+
+/-- The set where an analytic function has infinite order is clopen in its domain of analyticity. -/
+theorem isClopen_setOf_order_eq_top [CompleteSpace E] (h₁f : AnalyticOnNhd 𝕜 f U) :
+    IsClopen { u : U | (h₁f u.1 u.2).order = ⊤ } := by
+  constructor
+  · rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
+    intro z hz
+    rcases (h₁f z.1 z.2).eventually_eq_zero_or_eventually_ne_zero with h | h
+    · -- Case: f is locally zero in a punctured neighborhood of z
+      rw [← (h₁f z.1 z.2).order_eq_top_iff] at h
+      tauto
+    · -- Case: f is locally nonzero in a punctured neighborhood of z
+      obtain ⟨t', h₁t', h₂t', h₃t'⟩ := eventually_nhds_iff.1 ((eventually_nhdsWithin_iff.1 h).and
+        (h₁f z.1 z.2).eventually_analyticAt)
+      use Subtype.val ⁻¹' t'
+      constructor
+      · intro w hw
+        simp only [mem_compl_iff, mem_setOf_eq]
+        by_cases h₁w : w = z
+        · rwa [h₁w]
+        · rw [(h₁t' w hw).2.order_eq_zero_iff.2 ((h₁t' w hw).1 (Subtype.coe_ne_coe.mpr h₁w))]
+          exact ENat.zero_ne_top
+      · exact ⟨isOpen_induced h₂t', h₃t'⟩
+  · apply isOpen_iff_forall_mem_open.mpr
+    intro z hz
+    conv =>
+      arg 1; intro; left; right; arg 1; intro
+      rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff]
+    simp only [Set.mem_setOf_eq] at hz
+    rw [AnalyticAt.order_eq_top_iff, eventually_nhds_iff] at hz
+    obtain ⟨t', h₁t', h₂t', h₃t'⟩ := hz
+    use Subtype.val ⁻¹' t'
+    simp only [Set.mem_compl_iff, Set.mem_singleton_iff, isOpen_induced h₂t', Set.mem_preimage,
+      h₃t', and_self, and_true]
+    intro w hw
+    simp only [mem_setOf_eq]
+    -- Trivial case: w = z
+    by_cases h₁w : w = z
+    · rw [h₁w]
+      tauto
+    -- Nontrivial case: w ≠ z
+    use t' \ {z.1}, fun y h₁y ↦ h₁t' y h₁y.1, h₂t'.sdiff isClosed_singleton
+    apply (Set.mem_diff w).1
+    exact ⟨hw, Set.mem_singleton_iff.not.1 (Subtype.coe_ne_coe.2 h₁w)⟩
+
 section Mul
 /-!
 ### Vanishing of products of analytic functions

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -347,7 +347,7 @@ alias _root_.AnalyticOn.eq_of_frequently_eq := eq_of_frequently_eq
 
 
 /-- The set where an analytic function has infinite order is clopen in its domain of analyticity. -/
-theorem isClopen_setOf_order_eq_top [CompleteSpace E] (h₁f : AnalyticOnNhd 𝕜 f U) :
+theorem isClopen_setOf_order_eq_top (h₁f : AnalyticOnNhd 𝕜 f U) :
     IsClopen { u : U | (h₁f u.1 u.2).order = ⊤ } := by
   constructor
   · rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
@@ -357,15 +357,14 @@ theorem isClopen_setOf_order_eq_top [CompleteSpace E] (h₁f : AnalyticOnNhd �
       rw [← (h₁f z.1 z.2).order_eq_top_iff] at h
       tauto
     · -- Case: f is locally nonzero in a punctured neighborhood of z
-      obtain ⟨t', h₁t', h₂t', h₃t'⟩ := eventually_nhds_iff.1 ((eventually_nhdsWithin_iff.1 h).and
-        (h₁f z.1 z.2).eventually_analyticAt)
+      obtain ⟨t', h₁t', h₂t', h₃t'⟩ := eventually_nhds_iff.1 (eventually_nhdsWithin_iff.1 h)
       use Subtype.val ⁻¹' t'
       constructor
       · intro w hw
         simp only [mem_compl_iff, mem_setOf_eq]
         by_cases h₁w : w = z
         · rwa [h₁w]
-        · rw [(h₁t' w hw).2.order_eq_zero_iff.2 ((h₁t' w hw).1 (Subtype.coe_ne_coe.mpr h₁w))]
+        · rw [(h₁f _ w.2).order_eq_zero_iff.2 ((h₁t' w hw) (Subtype.coe_ne_coe.mpr h₁w))]
           exact ENat.zero_ne_top
       · exact ⟨isOpen_induced h₂t', h₃t'⟩
   · apply isOpen_iff_forall_mem_open.mpr

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -345,7 +345,6 @@ theorem eq_of_frequently_eq [ConnectedSpace 𝕜] (hf : AnalyticOnNhd 𝕜 f uni
 @[deprecated (since := "2024-09-26")]
 alias _root_.AnalyticOn.eq_of_frequently_eq := eq_of_frequently_eq
 
-
 /-- The set where an analytic function has infinite order is clopen in its domain of analyticity. -/
 theorem isClopen_setOf_order_eq_top (h₁f : AnalyticOnNhd 𝕜 f U) :
     IsClopen { u : U | (h₁f u.1 u.2).order = ⊤ } := by

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -344,7 +344,7 @@ theorem isClopen_setOf_order_eq_top {U : Set 𝕜} [CompleteSpace E] (h₁f : Me
       use Subtype.val ⁻¹' t'
       constructor
       · intro w hw
-        simp
+        simp only [Set.mem_compl_iff, Set.mem_setOf_eq]
         by_cases h₁w : w = z
         · rwa [h₁w]
         · have h₂f := (h₁t' w hw) (Subtype.coe_ne_coe.mpr h₁w)
@@ -362,7 +362,7 @@ theorem isClopen_setOf_order_eq_top {U : Set 𝕜} [CompleteSpace E] (h₁f : Me
     simp only [Set.mem_compl_iff, Set.mem_singleton_iff, isOpen_induced h₂t', Set.mem_preimage,
       h₃t', and_self, and_true]
     intro w hw
-    simp
+    simp only [Set.mem_setOf_eq]
     -- Trivial case: w = z
     by_cases h₁w : w = z
     · rw [h₁w]

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -397,11 +397,11 @@ theorem exists_order_ne_top_iff_forall {U : Set 𝕜} [CompleteSpace E]
 
 /-- On a preconnected set, a meromorphic function has finite order at one point if it has finite
 order at another point. -/
-theorem order_ne_top_of_isPreconnected {U : Set 𝕜} [CompleteSpace E] {x y : U}
-    (hf : MeromorphicOn f U) (hU : IsPreconnected U) (hx : (hf x x.2).order ≠ ⊤) :
-    (hf y y.2).order ≠ ⊤ :=
-  (hf.exists_order_ne_top_iff_all_order_ne_top ⟨Set.nonempty_of_mem (Subtype.coe_prop x), hU⟩).1
-    (by use x) y
+theorem order_ne_top_of_isPreconnected {U : Set 𝕜} [CompleteSpace E] {x y : 𝕜}
+    (hf : MeromorphicOn f U) (hU : IsPreconnected U) (h₁x : x ∈ U) (hy : y ∈ U)
+    (h₂x : (hf x h₁x).order ≠ ⊤) :
+    (hf y hy).order ≠ ⊤ :=
+  (hf.exists_order_ne_top_iff_forall ⟨Set.nonempty_of_mem h₁x, hU⟩).1 (by use ⟨x, h₁x⟩) ⟨y, hy⟩
 
 section arithmetic
 

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -355,7 +355,8 @@ theorem clopen_of_order_eq_top {U : Set 𝕜} [CompleteSpace E] (h₁f : Meromor
     simp_rw [MeromorphicAt.order_eq_top_iff, eventually_nhdsWithin_iff, eventually_nhds_iff] at *
     obtain ⟨t', h₁t', h₂t', h₃t'⟩ := hz
     use Subtype.val ⁻¹' t'
-    simp [isOpen_induced h₂t', h₃t']
+    simp only [Set.mem_compl_iff, Set.mem_singleton_iff, isOpen_induced h₂t', Set.mem_preimage,
+      h₃t', and_self, and_true]
     intro w hw
     simp
     -- Trivial case: w = z
@@ -363,13 +364,11 @@ theorem clopen_of_order_eq_top {U : Set 𝕜} [CompleteSpace E] (h₁f : Meromor
     · rw [h₁w]
       tauto
     -- Nontrivial case: w ≠ z
-    use t' \ {z.1}
+    use t' \ {z.1}, fun y h₁y _ ↦ h₁t' y (Set.mem_of_mem_diff h₁y) (Set.mem_of_mem_inter_right h₁y)
     constructor
-    · exact fun y h₁y _ ↦ h₁t' y (Set.mem_of_mem_diff h₁y) (Set.mem_of_mem_inter_right h₁y)
-    · constructor
-      · exact h₂t'.sdiff isClosed_singleton
-      · apply (Set.mem_diff w).1
-        exact ⟨hw, Set.mem_singleton_iff.not.1 (Subtype.coe_ne_coe.2 h₁w)⟩
+    · exact h₂t'.sdiff isClosed_singleton
+    · apply (Set.mem_diff w).1
+      exact ⟨hw, Set.mem_singleton_iff.not.1 (Subtype.coe_ne_coe.2 h₁w)⟩
 
 section arithmetic
 

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -329,7 +329,7 @@ lemma const (e : E) {U : Set 𝕜} : MeromorphicOn (fun _ ↦ e) U :=
 
 /-- The set where a meromorphic function has infinite order is clopen in its domain of meromorphy.
 -/
-theorem isClopen_setOf_order_eq_top {U : Set 𝕜} [CompleteSpace E] (hf : MeromorphicOn f U) :
+theorem isClopen_setOf_order_eq_top {U : Set 𝕜} (hf : MeromorphicOn f U) :
     IsClopen { u : U | (hf u.1 u.2).order = ⊤ } := by
   constructor
   · rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
@@ -339,16 +339,18 @@ theorem isClopen_setOf_order_eq_top {U : Set 𝕜} [CompleteSpace E] (hf : Merom
       rw [← (hf z.1 z.2).order_eq_top_iff] at h
       tauto
     · -- Case: f is locally nonzero in a punctured neighborhood of z
-      obtain ⟨t', h₁t', h₂t', h₃t'⟩ := eventually_nhds_iff.1 (eventually_nhdsWithin_iff.1
-        (h.and (hf z.1 z.2).eventually_analyticAt))
+      obtain ⟨t', h₁t', h₂t', h₃t'⟩ := eventually_nhds_iff.1 (eventually_nhdsWithin_iff.1 h)
       use Subtype.val ⁻¹' t'
       constructor
       · intro w hw
         simp only [Set.mem_compl_iff, Set.mem_setOf_eq]
         by_cases h₁w : w = z
         · rwa [h₁w]
-        · have h₂f := (h₁t' w hw) (Subtype.coe_ne_coe.mpr h₁w)
-          simp [h₂f.2.meromorphicAt_order, h₂f.2.order_eq_zero_iff.2 h₂f.1]
+        · rw [MeromorphicAt.order_eq_top_iff, not_eventually]
+          apply Filter.Eventually.frequently
+          rw [eventually_nhdsWithin_iff, eventually_nhds_iff]
+          use t' \ {z.1}, fun y h₁y h₂y ↦ h₁t' y h₁y.1 h₁y.2, h₂t'.sdiff isClosed_singleton, hw,
+            Set.mem_singleton_iff.not.2 (Subtype.coe_ne_coe.mpr h₁w)
       · exact ⟨isOpen_induced h₂t', h₃t'⟩
   · apply isOpen_iff_forall_mem_open.mpr
     intro z hz
@@ -376,8 +378,7 @@ theorem isClopen_setOf_order_eq_top {U : Set 𝕜} [CompleteSpace E] (hf : Merom
 
 /-- On a connected set, there exists a point where a meromorphic function `f` has finite order iff
 `f` has finite order at every point. -/
-theorem exists_order_ne_top_iff_forall {U : Set 𝕜} [CompleteSpace E]
-    (hf : MeromorphicOn f U) (hU : IsConnected U) :
+theorem exists_order_ne_top_iff_forall {U : Set 𝕜} (hf : MeromorphicOn f U) (hU : IsConnected U) :
     (∃ u : U, (hf u u.2).order ≠ ⊤) ↔ (∀ u : U, (hf u u.2).order ≠ ⊤) := by
   constructor
   · intro h₂f
@@ -397,9 +398,8 @@ theorem exists_order_ne_top_iff_forall {U : Set 𝕜} [CompleteSpace E]
 
 /-- On a preconnected set, a meromorphic function has finite order at one point if it has finite
 order at another point. -/
-theorem order_ne_top_of_isPreconnected {U : Set 𝕜} [CompleteSpace E] {x y : 𝕜}
-    (hf : MeromorphicOn f U) (hU : IsPreconnected U) (h₁x : x ∈ U) (hy : y ∈ U)
-    (h₂x : (hf x h₁x).order ≠ ⊤) :
+theorem order_ne_top_of_isPreconnected {U : Set 𝕜} {x y : 𝕜} (hf : MeromorphicOn f U)
+    (hU : IsPreconnected U) (h₁x : x ∈ U) (hy : y ∈ U) (h₂x : (hf x h₁x).order ≠ ⊤) :
     (hf y hy).order ≠ ⊤ :=
   (hf.exists_order_ne_top_iff_forall ⟨Set.nonempty_of_mem h₁x, hU⟩).1 (by use ⟨x, h₁x⟩) ⟨y, hy⟩
 

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -397,7 +397,7 @@ theorem exists_order_ne_top_iff_forall {U : Set 𝕜} [CompleteSpace E]
 
 /-- On a preconnected set, a meromorphic function has finite order at one point if it has finite
 order at another point. -/
-theorem order_ne_top_of_order_ne_top {U : Set 𝕜} [CompleteSpace E] {x y : U}
+theorem order_ne_top_of_isPreconnected {U : Set 𝕜} [CompleteSpace E] {x y : U}
     (hf : MeromorphicOn f U) (hU : IsPreconnected U) (hx : (hf x x.2).order ≠ ⊤) :
     (hf y y.2).order ≠ ⊤ :=
   (hf.exists_order_ne_top_iff_all_order_ne_top ⟨Set.nonempty_of_mem (Subtype.coe_prop x), hU⟩).1

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -329,18 +329,18 @@ lemma const (e : E) {U : Set 𝕜} : MeromorphicOn (fun _ ↦ e) U :=
 
 /-- The set where a meromorphic function has infinite order is clopen in its domain of meromorphy.
 -/
-theorem isClopen_setOf_order_eq_top {U : Set 𝕜} [CompleteSpace E] (h₁f : MeromorphicOn f U) :
-    IsClopen { u : U | (h₁f u.1 u.2).order = ⊤ } := by
+theorem isClopen_setOf_order_eq_top {U : Set 𝕜} [CompleteSpace E] (hf : MeromorphicOn f U) :
+    IsClopen { u : U | (hf u.1 u.2).order = ⊤ } := by
   constructor
   · rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
     intro z hz
-    rcases (h₁f z.1 z.2).eventually_eq_zero_or_eventually_ne_zero with h | h
+    rcases (hf z.1 z.2).eventually_eq_zero_or_eventually_ne_zero with h | h
     · -- Case: f is locally zero in a punctured neighborhood of z
-      rw [← (h₁f z.1 z.2).order_eq_top_iff] at h
+      rw [← (hf z.1 z.2).order_eq_top_iff] at h
       tauto
     · -- Case: f is locally nonzero in a punctured neighborhood of z
       obtain ⟨t', h₁t', h₂t', h₃t'⟩ := eventually_nhds_iff.1 (eventually_nhdsWithin_iff.1
-        (h.and (h₁f z.1 z.2).eventually_analyticAt))
+        (h.and (hf z.1 z.2).eventually_analyticAt))
       use Subtype.val ⁻¹' t'
       constructor
       · intro w hw
@@ -373,6 +373,35 @@ theorem isClopen_setOf_order_eq_top {U : Set 𝕜} [CompleteSpace E] (h₁f : Me
     · exact h₂t'.sdiff isClosed_singleton
     · apply (Set.mem_diff w).1
       exact ⟨hw, Set.mem_singleton_iff.not.1 (Subtype.coe_ne_coe.2 h₁w)⟩
+
+/-- On a connected set, there exists a point where a meromorphic function `f` has finite order iff
+`f` has finite order at every point. -/
+theorem exists_order_ne_top_iff_all_order_ne_top {U : Set 𝕜} [CompleteSpace E]
+    (hf : MeromorphicOn f U) (hU : IsConnected U) :
+    (∃ u : U, (hf u u.2).order ≠ ⊤) ↔ (∀ u : U, (hf u u.2).order ≠ ⊤) := by
+  constructor
+  · intro h₂f
+    have := isPreconnected_iff_preconnectedSpace.1 hU.isPreconnected
+    rcases isClopen_iff.1 hf.isClopen_setOf_order_eq_top with h | h
+    · intro u
+      have : u ∉ (∅ : Set U) := by exact fun a => a
+      rw [← h] at this
+      tauto
+    · obtain ⟨u, hU⟩ := h₂f
+      have : u ∈ Set.univ := by trivial
+      rw [← h] at this
+      tauto
+  · intro h₂f
+    obtain ⟨v, hv⟩ := hU.nonempty
+    use ⟨v, hv⟩, h₂f ⟨v, hv⟩
+
+/-- On a preconnected set, a meromorphic function has finite order at one point if it has finite
+order at another point. -/
+theorem order_ne_top_of_order_ne_top {U : Set 𝕜} [CompleteSpace E] {x y : U}
+    (hf : MeromorphicOn f U) (hU : IsPreconnected U) (hx : (hf x x.2).order ≠ ⊤) :
+    (hf y y.2).order ≠ ⊤ :=
+  (hf.exists_order_ne_top_iff_all_order_ne_top ⟨Set.nonempty_of_mem (Subtype.coe_prop x), hU⟩).1
+    (by use x) y
 
 section arithmetic
 

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -329,7 +329,7 @@ lemma const (e : E) {U : Set 𝕜} : MeromorphicOn (fun _ ↦ e) U :=
 
 /-- The set where a meromorphic function has infinite order is clopen in its domain of meromorphy.
 -/
-theorem clopen_of_order_eq_top {U : Set 𝕜} [CompleteSpace E] (h₁f : MeromorphicOn f U) :
+theorem isClopen_setOf_order_eq_top {U : Set 𝕜} [CompleteSpace E] (h₁f : MeromorphicOn f U) :
     IsClopen { u : U | (h₁f u.1 u.2).order = ⊤ } := by
   constructor
   · rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -376,7 +376,7 @@ theorem isClopen_setOf_order_eq_top {U : Set 𝕜} [CompleteSpace E] (hf : Merom
 
 /-- On a connected set, there exists a point where a meromorphic function `f` has finite order iff
 `f` has finite order at every point. -/
-theorem exists_order_ne_top_iff_all_order_ne_top {U : Set 𝕜} [CompleteSpace E]
+theorem exists_order_ne_top_iff_forall {U : Set 𝕜} [CompleteSpace E]
     (hf : MeromorphicOn f U) (hU : IsConnected U) :
     (∃ u : U, (hf u u.2).order ≠ ⊤) ↔ (∀ u : U, (hf u u.2).order ≠ ⊤) := by
   constructor

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -42,27 +42,15 @@ theorem MeromorphicAt.eventually_eq_zero_or_eventually_ne_zero {f : 𝕜 → E} 
     (hf : MeromorphicAt f z₀) :
     (∀ᶠ z in 𝓝[≠] z₀, f z = 0) ∨ (∀ᶠ z in 𝓝[≠] z₀, f z ≠ 0) := by
   obtain ⟨n, h⟩ := hf
-  repeat rw [eventually_nhdsWithin_iff, eventually_nhds_iff]
   rcases h.eventually_eq_zero_or_eventually_ne_zero with h₁ | h₂
-  · obtain ⟨N, h₁N, h₂N, h₃N⟩ := eventually_nhds_iff.1 h₁
-    left
-    use N
-    simp [h₂N, h₃N]
-    intro y h₁y h₂y
-    have A := h₁N y h₁y
-    simp at A
-    rcases A with h₃ | h₄
-    · have C := sub_eq_zero.1 h₃.1
-      tauto
+  · left
+    filter_upwards [nhdsWithin_le_nhds h₁, self_mem_nhdsWithin] with y h₁y h₂y
+    rcases (smul_eq_zero.1 h₁y) with h₃ | h₄
+    · exact False.elim (h₂y (sub_eq_zero.1 (pow_eq_zero_iff'.1 h₃).1))
     · assumption
-  · obtain ⟨N, h₁N, h₂N, h₃N⟩ := eventually_nhds_iff.1 (eventually_nhdsWithin_iff.1 h₂)
-    right
-    use N
-    simp [h₂N, h₃N]
-    intro y h₁y h₂y
-    by_contra h
-    have A := h₁N y h₁y h₂y
-    simp [h] at A
+  · right
+    filter_upwards [h₂, self_mem_nhdsWithin] with y h₁y h₂y
+    exact (smul_ne_zero_iff.1 h₁y).2
 
 namespace MeromorphicAt
 

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -352,7 +352,11 @@ theorem clopen_of_order_eq_top {U : Set 𝕜} [CompleteSpace E] (h₁f : Meromor
       · exact ⟨isOpen_induced h₂t', h₃t'⟩
   · apply isOpen_iff_forall_mem_open.mpr
     intro z hz
-    simp_rw [MeromorphicAt.order_eq_top_iff, eventually_nhdsWithin_iff, eventually_nhds_iff] at *
+    conv =>
+      arg 1; intro; left; right; arg 1; intro
+      rw [MeromorphicAt.order_eq_top_iff, eventually_nhdsWithin_iff, eventually_nhds_iff]
+    simp only [Set.mem_setOf_eq] at hz
+    rw [MeromorphicAt.order_eq_top_iff, eventually_nhdsWithin_iff, eventually_nhds_iff] at hz
     obtain ⟨t', h₁t', h₂t', h₃t'⟩ := hz
     use Subtype.val ⁻¹' t'
     simp only [Set.mem_compl_iff, Set.mem_singleton_iff, isOpen_induced h₂t', Set.mem_preimage,


### PR DESCRIPTION
Establish a principle of isolated zeros and show that the set where a meromorphic function has infinite order is clopen in the domain of meromorphy.

These theorems are used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
