### PR TITLE
[Merged by Bors] - chore(Tactic/Abel): cleanup abel docs and use `tactic_alt` attribute

### DIFF
--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -44,6 +44,15 @@ For example:
 example [AddCommMonoid α] (a b : α) : a + (b + a) = a + a + b := by abel
 example [AddCommGroup α] (a : α) : (3 : ℤ) • a = a + (2 : ℤ) • a := by abel
 ```
+
+## Future work
+
+* In mathlib 3, `abel` accepted addtional optional arguments:
+  ```
+  syntax "abel" (&" raw" <|> &" term")? (location)? : tactic
+  ```
+  It is undecided whether these features should be restored eventually.
+
 -/
 syntax (name := abel) "abel" "!"? : tactic
 

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -23,6 +23,30 @@ open Lean Elab Meta Tactic Qq
 initialize registerTraceClass `abel
 initialize registerTraceClass `abel.detail
 
+/--
+Tactic for evaluating equations in the language of
+*additive*, commutative monoids and groups.
+
+`abel` and its variants work as both tactics and conv tactics.
+
+* `abel1` fails if the target is not an equality that is provable by the axioms of
+  commutative monoids/groups.
+* `abel_nf` rewrites all group expressions into a normal form.
+  * In tactic mode, `abel_nf at h` can be used to rewrite in a hypothesis.
+  * `abel_nf (config := cfg)` allows for additional configuration:
+    * `red`: the reducibility setting (overridden by `!`)
+    * `recursive`: if true, `abel_nf` will also recurse into atoms
+* `abel!`, `abel1!`, `abel_nf!` will use a more aggressive reducibility setting to identify atoms.
+
+For example:
+
+```
+example [AddCommMonoid α] (a b : α) : a + (b + a) = a + a + b := by abel
+example [AddCommGroup α] (a : α) : (3 : ℤ) • a = a + (2 : ℤ) • a := by abel
+```
+-/
+syntax (name := abel) "abel" "!"? : tactic
+
 /-- The `Context` for a call to `abel`.
 
 Stores a few options for this call, and caches some common subexpressions
@@ -364,21 +388,10 @@ partial def eval (e : Expr) : M (NormalExpr × Expr) := do
       evalAtom e
   | _ => evalAtom e
 
-/-- Tactic for solving equations in the language of
-*additive*, commutative monoids and groups.
-This version of `abel` fails if the target is not an equality
-that is provable by the axioms of commutative monoids/groups.
-
-`abel1!` will use a more aggressive reducibility setting to identify atoms.
-This can prove goals that `abel` cannot, but is more expensive.
--/
-syntax (name := abel1) "abel1" "!"? : tactic
-
 open Lean Elab Meta Tactic
 
-/-- The `abel1` tactic, which solves equations in the language of commutative additive groups
-(or monoids). -/
-elab_rules : tactic | `(tactic| abel1 $[!%$tk]?) => withMainContext do
+@[tactic_alt abel]
+elab (name := abel1) "abel1" tk:"!"? : tactic => withMainContext do
   let tm := if tk.isSome then .default else .reducible
   let some (_, e₁, e₂) := (← whnfR <| ← getMainTarget).eq?
     | throwError "abel1 requires an equality goal"
@@ -394,7 +407,8 @@ elab_rules : tactic | `(tactic| abel1 $[!%$tk]?) => withMainContext do
     trace[abel] "verified that the simplified forms are identical"
     mkEqTrans p₁ (← mkEqSymm p₂)
 
-@[inherit_doc abel1] macro (name := abel1!) "abel1!" : tactic => `(tactic| abel1 !)
+@[tactic_alt abel]
+macro (name := abel1!) "abel1!" : tactic => `(tactic| abel1 !)
 
 theorem term_eq {α : Type*} [AddCommMonoid α] (n : ℕ) (x a : α) : term n x a = n • x + a := rfl
 /-- A type synonym used by `abel` to represent `n • x + a` in an additive commutative group. -/
@@ -495,21 +509,7 @@ def abelNFLocalDecl (s : IO.Ref AtomM.State) (cfg : AbelNF.Config) (fvarId : FVa
   | none => replaceMainGoal []
   | some (_, newGoal) => replaceMainGoal [newGoal]
 
-/-- Unsupported legacy syntax from mathlib3, which allowed passing additional terms to `abel`. -/
-syntax (name := abel_term) "abel" (&" raw" <|> &" term")? (location)? : tactic
-/-- Unsupported legacy syntax from mathlib3, which allowed passing additional terms to `abel!`. -/
-syntax (name := abel!_term) "abel!" (&" raw" <|> &" term")? (location)? : tactic
-
-/--
-Simplification tactic for expressions in the language of abelian groups,
-which rewrites all group expressions into a normal form.
-* `abel_nf!` will use a more aggressive reducibility setting to identify atoms.
-* `abel_nf (config := cfg)` allows for additional configuration:
-  * `red`: the reducibility setting (overridden by `!`)
-  * `recursive`: if true, `abel_nf` will also recurse into atoms
-* `abel_nf` works as both a tactic and a conv tactic.
-  In tactic mode, `abel_nf at h` can be used to rewrite in a hypothesis.
--/
+@[tactic_alt abel]
 elab (name := abelNF) "abel_nf" tk:"!"? cfg:optConfig loc:(location)? : tactic => do
   let mut cfg ← elabAbelNFConfig cfg
   if tk.isSome then cfg := { cfg with red := .default }
@@ -518,10 +518,11 @@ elab (name := abelNF) "abel_nf" tk:"!"? cfg:optConfig loc:(location)? : tactic =
   withLocation loc (abelNFLocalDecl s cfg) (abelNFTarget s cfg)
     fun _ ↦ throwError "abel_nf made no progress"
 
-@[inherit_doc abelNF] macro "abel_nf!" cfg:optConfig loc:(location)? : tactic =>
+@[tactic_alt abel]
+macro "abel_nf!" cfg:optConfig loc:(location)? : tactic =>
   `(tactic| abel_nf ! $cfg:optConfig $(loc)?)
 
-@[inherit_doc abelNF] syntax (name := abelNFConv) "abel_nf" "!"? optConfig : conv
+@[inherit_doc abel] syntax (name := abelNFConv) "abel_nf" "!"? optConfig : conv
 
 /-- Elaborator for the `abel_nf` tactic. -/
 @[tactic abelNFConv] def elabAbelNFConv : Tactic := fun stx ↦ match stx with
@@ -531,24 +532,15 @@ elab (name := abelNF) "abel_nf" tk:"!"? cfg:optConfig loc:(location)? : tactic =
     Conv.applySimpResult (← abelNFCore (← IO.mkRef {}) cfg (← instantiateMVars (← Conv.getLhs)))
   | _ => Elab.throwUnsupportedSyntax
 
-@[inherit_doc abelNF] macro "abel_nf!" cfg:optConfig : conv => `(conv| abel_nf ! $cfg:optConfig)
+@[inherit_doc abel]
+macro "abel_nf!" cfg:optConfig : conv => `(conv| abel_nf ! $cfg:optConfig)
 
-/--
-Tactic for evaluating expressions in abelian groups.
+macro_rules
+  | `(tactic| abel !) => `(tactic| first | abel1! | try_this abel_nf!)
+  | `(tactic| abel) => `(tactic| first | abel1 | try_this abel_nf)
 
-* `abel!` will use a more aggressive reducibility setting to determine equality of atoms.
-* `abel1` fails if the target is not an equality.
-
-For example:
-```
-example [AddCommMonoid α] (a b : α) : a + (b + a) = a + a + b := by abel
-example [AddCommGroup α] (a : α) : (3 : ℤ) • a = a + (2 : ℤ) • a := by abel
-```
--/
-macro (name := abel) "abel" : tactic =>
-  `(tactic| first | abel1 | try_this abel_nf)
-@[inherit_doc abel] macro "abel!" : tactic =>
-  `(tactic| first | abel1! | try_this abel_nf!)
+@[tactic_alt abel]
+macro "abel!" : tactic => `(tactic| abel !)
 
 /--
 The tactic `abel` evaluates expressions in abelian groups.

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -522,10 +522,12 @@ elab (name := abelNF) "abel_nf" tk:"!"? cfg:optConfig loc:(location)? : tactic =
 macro "abel_nf!" cfg:optConfig loc:(location)? : tactic =>
   `(tactic| abel_nf ! $cfg:optConfig $(loc)?)
 
-@[inherit_doc abel] syntax (name := abelNFConv) "abel_nf" "!"? optConfig : conv
+@[inherit_doc abel]
+syntax (name := abelNFConv) "abel_nf" "!"? optConfig : conv
 
 /-- Elaborator for the `abel_nf` tactic. -/
-@[tactic abelNFConv] def elabAbelNFConv : Tactic := fun stx ↦ match stx with
+@[tactic abelNFConv]
+def elabAbelNFConv : Tactic := fun stx ↦ match stx with
   | `(conv| abel_nf $[!%$tk]? $cfg:optConfig) => withMainContext do
     let mut cfg ← elabAbelNFConfig cfg
     if tk.isSome then cfg := { cfg with red := .default }
@@ -542,14 +544,10 @@ macro_rules
 @[tactic_alt abel]
 macro "abel!" : tactic => `(tactic| abel !)
 
-/--
-The tactic `abel` evaluates expressions in abelian groups.
-This is the conv tactic version, which rewrites a target which is an abel equality to `True`.
-
-See also the `abel` tactic.
--/
+@[inherit_doc abel]
 macro (name := abelConv) "abel" : conv =>
   `(conv| first | discharge => abel1 | try_this abel_nf)
+
 @[inherit_doc abelConv] macro "abel!" : conv =>
   `(conv| first | discharge => abel1! | try_this abel_nf!)
 


### PR DESCRIPTION
Use `tactic_alt` attribute to group all variations of `abel` as a single tactic.

Moreover, add `abel !` (aliased by `abel!`) as valid syntax and remove old mathlib3 syntax for `abel`.

---

~~Are there any issues with removing the "unsupported mathlib3" syntax? Currently it looks like there was no `macro_rules`/`elab_rules` for that syntax anyways. But maybe `Mathport` used to use it in some way?~~ See conversiation with @digama0 below: I've added a note in the module docstring to keep the memory that Lean3 had this additional feature, in case anybody ever wants to reimplement it. But mathport is not useable anymore.

See https://leanprover-community.github.io/mathlib-manual/html-multi/Tactics/All-tactics/#abel-next for how Lean stores `abel` as a gazillion different tactics currently.


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
