### PR TITLE
feat(Algebra): transfer algebra structure via a ring homomorphism

### DIFF
--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -195,6 +195,10 @@ theorem RingHom.algebraMap_toAlgebra {R S} [CommSemiring R] [CommSemiring S] (i 
     @algebraMap R S _ _ i.toAlgebra = i :=
   rfl
 
+/-- Transfer `R`-algebra structure via a ring homomorphism. -/
+def Algebra.of_algebra_of_ringHom (R) {A B} [CommSemiring R] [Semiring A] [CommSemiring B]
+    [Algebra R A] (f : A →+* B) : Algebra R B := f.comp (algebraMap R A) |>.toAlgebra
+
 namespace Algebra
 
 variable {R : Type u} {S : Type v} {A : Type w} {B : Type*}


### PR DESCRIPTION
For `Algebra R A` and `f : A →+* B`, produce `Algebra R B` with `algebraMap R B = f.comp (algebraMap R A)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
