### PR TITLE
[Merged by Bors] - feat: state `PEquiv.equiv_toPEquiv_toMatrix` in terms of `submatrix`

### DIFF
--- a/Mathlib/Data/Matrix/PEquiv.lean
+++ b/Mathlib/Data/Matrix/PEquiv.lean
@@ -152,8 +152,8 @@ theorem single_mul_single_right [Fintype n] [Fintype k] [DecidableEq n] [Decidab
   rw [← Matrix.mul_assoc, single_mul_single]
 
 /-- We can also define permutation matrices by permuting the rows of the identity matrix. -/
-theorem equiv_toPEquiv_toMatrix [DecidableEq n] [Zero α] [One α] (σ : Equiv n n) (i j : n) :
-    σ.toPEquiv.toMatrix i j = (1 : Matrix n n α) (σ i) j :=
-  if_congr Option.some_inj rfl rfl
+theorem equiv_toPEquiv_toMatrix [DecidableEq n] [Zero α] [One α] (σ : Equiv n n) :
+    σ.toPEquiv.toMatrix = (1 : Matrix n n α).submatrix σ id :=
+  Matrix.ext fun _ _ => if_congr Option.some_inj rfl rfl
 
 end PEquiv


### PR DESCRIPTION
This matches the prose more closely, and also means lemmas about `submatrix` can be used.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
