### PR TITLE
[Merged by Bors] - feat: derivWithin lemmas

### DIFF
--- a/Mathlib/Analysis/Calculus/Deriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Basic.lean
@@ -658,6 +658,9 @@ theorem deriv_const' : (deriv fun _ : 𝕜 => c) = fun _ => 0 :=
 theorem derivWithin_const : derivWithin (fun _ => c) s = 0 := by
   ext; simp [derivWithin]
 
+@[simp]
+theorem derivWithin_zero : derivWithin (0 : 𝕜 → F) s = 0 := derivWithin_const _ _
+
 end Const
 
 section Continuous

--- a/Mathlib/Analysis/Calculus/Deriv/Mul.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Mul.lean
@@ -246,6 +246,17 @@ theorem derivWithin_mul_const (hc : DifferentiableWithinAt 𝕜 c s x) (d : 𝔸
   · exact (hc.hasDerivWithinAt.mul_const d).derivWithin hxs
   · simp [derivWithin_zero_of_isolated hxs]
 
+lemma derivWithin_mul_const_field (u : 𝕜') :
+    derivWithin (fun y => v y * u) s x = derivWithin v s x * u := by
+  by_cases hv : DifferentiableWithinAt 𝕜 v s x
+  · rw [derivWithin_mul_const hv u]
+  by_cases hu : u = 0
+  · simp [hu]
+  rw [derivWithin_zero_of_not_differentiableWithinAt hv, zero_mul,
+      derivWithin_zero_of_not_differentiableWithinAt]
+  have : v = fun x ↦ (v x * u) * u⁻¹ := by ext; simp [hu]
+  exact fun h_diff ↦ hv <| this ▸ h_diff.mul_const _
+
 theorem deriv_mul_const (hc : DifferentiableAt 𝕜 c x) (d : 𝔸) :
     deriv (fun y => c y * d) x = deriv c x * d :=
   (hc.hasDerivAt.mul_const d).deriv
@@ -283,6 +294,11 @@ theorem derivWithin_const_mul (c : 𝔸) (hd : DifferentiableWithinAt 𝕜 d s x
   rcases uniqueDiffWithinAt_or_nhdsWithin_eq_bot s x with hxs | hxs
   · exact (hd.hasDerivWithinAt.const_mul c).derivWithin hxs
   · simp [derivWithin_zero_of_isolated hxs]
+
+lemma derivWithin_const_mul_field (u : 𝕜') :
+    derivWithin (fun y => u * v y) s x = u * derivWithin v s x := by
+  simp_rw [mul_comm u]
+  exact derivWithin_mul_const_field u
 
 theorem deriv_const_mul (c : 𝔸) (hd : DifferentiableAt 𝕜 d x) :
     deriv (fun y => c * d y) x = c * deriv d x :=


### PR DESCRIPTION
New lemmas: `derivWithin_zero`, `derivWithin_mul_const_field`, `derivWithin_const_mul_field`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

The name `derivWithin_mul_const_field` matches `deriv_mul_const_field`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
