### PR TITLE
[Merged by Bors] - feat (CategoryTheory): constructing chosen finite products for the preorder category of a meet-semilattice with a top element

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1939,6 +1939,7 @@ import Mathlib.CategoryTheory.Limits.MorphismProperty
 import Mathlib.CategoryTheory.Limits.Opposites
 import Mathlib.CategoryTheory.Limits.Over
 import Mathlib.CategoryTheory.Limits.Pi
+import Mathlib.CategoryTheory.Limits.Preorder
 import Mathlib.CategoryTheory.Limits.Preserves.Basic
 import Mathlib.CategoryTheory.Limits.Preserves.Filtered
 import Mathlib.CategoryTheory.Limits.Preserves.Finite

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1731,6 +1731,7 @@ import Mathlib.CategoryTheory.Category.ULift
 import Mathlib.CategoryTheory.ChosenFiniteProducts
 import Mathlib.CategoryTheory.ChosenFiniteProducts.Cat
 import Mathlib.CategoryTheory.ChosenFiniteProducts.FunctorCategory
+import Mathlib.CategoryTheory.ChosenFiniteProducts.InfSemilattice
 import Mathlib.CategoryTheory.Closed.Cartesian
 import Mathlib.CategoryTheory.Closed.Enrichment
 import Mathlib.CategoryTheory.Closed.Functor

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
@@ -34,6 +34,8 @@ is provided by the instance `monoidalOfChosenFiniteProducts`. -/
 noncomputable scoped instance monoidalCategory : MonoidalCategory C := by
   infer_instance
 
+/-- The symmetric monoidal structure on the preorder category of a
+meet-semilattice with a greatest element. -/
 noncomputable scoped instance symmetricCategory : SymmetricCategory C := by
   infer_instance
 

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2025 Sina Hazratpour. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sina Hazratpour
+-/
+
+import Mathlib.CategoryTheory.ChosenFiniteProducts
+
+/-!
+# Lattices have chosen finite products
+
+The preorder category of a meet-semilattice `C` with a top element has chosen finite products.
+
+-/
+
+namespace CategoryTheory
+
+open Category Limits MonoidalCategory
+
+universe u
+
+variable (C : Type u) [SemilatticeInf C] [OrderTop C]
+
+namespace SemilatticeInf
+
+abbrev chosenTerminal : C := ⊤
+
+/-- The chosen terminal object in `C` is terminal. -/
+def chosenTerminalIsTerminal : IsTerminal (chosenTerminal C) where
+  lift s := homOfLE (le_top)
+
+section
+
+variable {C}
+
+variable (X Y : C)
+
+def chosenProd : C := X ⊓ Y
+
+namespace chosenProd
+
+/-- The first projection `chosenProd X Y ⟶ X`. -/
+def fst : chosenProd X Y ⟶ X := homOfLE (inf_le_left)
+
+/-- The second projection `chosenProd X Y ⟶ Y`. -/
+def snd : chosenProd X Y ⟶ Y := homOfLE (inf_le_right)
+
+/-- `chosenProd X Y` is a binary product of `X` and `Y`. -/
+def isLimit : IsLimit (BinaryFan.mk (fst X Y) (snd X Y)) where
+  lift s := homOfLE <| le_inf (leOfHom <| s.π.app <|
+  ⟨WalkingPair.left⟩) (leOfHom <| s.π.app <| ⟨WalkingPair.right⟩)
+
+end chosenProd
+
+end
+
+noncomputable instance : ChosenFiniteProducts C where
+  terminal := ⟨_, chosenTerminalIsTerminal C⟩
+  product X Y := ⟨_, chosenProd.isLimit X Y⟩
+
+/-- A monoidal structure on a lattice is provided by the instance
+`monoidalOfChosenFiniteProducts`. -/
+noncomputable instance : MonoidalCategory C := by
+  infer_instance
+
+noncomputable instance : SymmetricCategory C := by
+  infer_instance
+
+namespace Monoidal
+
+open MonoidalCategory ChosenFiniteProducts
+
+lemma tensorObj {C : Type u} [Lattice C] [OrderTop C] {X Y : C} : X ⊗ Y = X ⊓ Y := rfl
+
+lemma tensorUnit {C : Type u} [Lattice C] [OrderTop C] :
+    𝟙_ C = SemilatticeInf.chosenTerminal C := rfl
+
+end Monoidal
+
+end SemilatticeInf
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
@@ -12,6 +12,9 @@ import Mathlib.CategoryTheory.Limits.Preorder
 
 The preorder category of a meet-semilattice `C` with a greatest element has chosen finite products.
 
+A symmetric monoidal structure on the preorder category is automatically provided by the
+instances `monoidalOfChosenFiniteProducts` and `ChosenFiniteProducts.instSymmetricCategory`.
+
 -/
 
 namespace CategoryTheory
@@ -28,16 +31,6 @@ namespace SemilatticeInf
 noncomputable scoped instance chosenFiniteProducts : ChosenFiniteProducts C where
   terminal := ⟨_, Preorder.isTerminalTop C⟩
   product X Y := ⟨_,  Preorder.isLimitBinaryFan X Y⟩
-
-/-- A monoidal structure on the preorder category of a meet-semilattice with a greatest element
-is provided by the instance `monoidalOfChosenFiniteProducts`. -/
-noncomputable scoped instance monoidalCategory : MonoidalCategory C := by
-  infer_instance
-
-/-- The symmetric monoidal structure on the preorder category of a
-meet-semilattice with a greatest element. -/
-noncomputable scoped instance symmetricCategory : SymmetricCategory C := by
-  infer_instance
 
 namespace Monoidal
 

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
@@ -9,7 +9,7 @@ import Mathlib.CategoryTheory.ChosenFiniteProducts
 /-!
 # Lattices have chosen finite products
 
-The preorder category of a meet-semilattice `C` with a top element has chosen finite products.
+The preorder category of a meet-semilattice `C` with a greatest element has chosen finite products.
 
 -/
 
@@ -23,9 +23,10 @@ variable (C : Type u) [SemilatticeInf C] [OrderTop C]
 
 namespace SemilatticeInf
 
+/-- The chosen terminal object in the preorder category of `C`. -/
 abbrev chosenTerminal : C := ⊤
 
-/-- The chosen terminal object in `C` is terminal. -/
+/-- The chosen terminal object in the preoder category of `C` is terminal. -/
 def chosenTerminalIsTerminal : IsTerminal (chosenTerminal C) where
   lift s := homOfLE (le_top)
 
@@ -35,6 +36,7 @@ variable {C}
 
 variable (X Y : C)
 
+/-- The chosen binary product in the preorder category of `C`. -/
 def chosenProd : C := X ⊓ Y
 
 namespace chosenProd
@@ -54,12 +56,13 @@ end chosenProd
 
 end
 
+/-- Chosen finite products for the preorder category of a meet-semilattice with a greatest element-/
 noncomputable instance : ChosenFiniteProducts C where
   terminal := ⟨_, chosenTerminalIsTerminal C⟩
   product X Y := ⟨_, chosenProd.isLimit X Y⟩
 
-/-- A monoidal structure on a lattice is provided by the instance
-`monoidalOfChosenFiniteProducts`. -/
+/-- A monoidal structure on the preorder category of a meet-semilattice with a greatest element
+is provided by the instance `monoidalOfChosenFiniteProducts`. -/
 noncomputable instance : MonoidalCategory C := by
   infer_instance
 

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
@@ -57,7 +57,7 @@ end chosenProd
 end
 
 /-- Chosen finite products for the preorder category of a meet-semilattice with a greatest element-/
-noncomputable scoped instance : ChosenFiniteProducts C where
+noncomputable scoped instance chosenFiniteProducts : ChosenFiniteProducts C where
   terminal := ⟨_, chosenTerminalIsTerminal C⟩
   product X Y := ⟨_, chosenProd.isLimit X Y⟩
 

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
@@ -57,7 +57,7 @@ end chosenProd
 end
 
 /-- Chosen finite products for the preorder category of a meet-semilattice with a greatest element-/
-noncomputable instance : ChosenFiniteProducts C where
+noncomputable scoped instance : ChosenFiniteProducts C where
   terminal := ⟨_, chosenTerminalIsTerminal C⟩
   product X Y := ⟨_, chosenProd.isLimit X Y⟩
 

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
@@ -5,9 +5,10 @@ Authors: Sina Hazratpour
 -/
 
 import Mathlib.CategoryTheory.ChosenFiniteProducts
+import Mathlib.CategoryTheory.Limits.Preorder
 
 /-!
-# Lattices have chosen finite products
+# Chosen finite products for the preorder category of a meet-semilattice with a greatest element
 
 The preorder category of a meet-semilattice `C` with a greatest element has chosen finite products.
 
@@ -23,50 +24,17 @@ variable (C : Type u) [SemilatticeInf C] [OrderTop C]
 
 namespace SemilatticeInf
 
-/-- The chosen terminal object in the preorder category of `C`. -/
-abbrev chosenTerminal : C := ⊤
-
-/-- The chosen terminal object in the preoder category of `C` is terminal. -/
-def chosenTerminalIsTerminal : IsTerminal (chosenTerminal C) where
-  lift s := homOfLE (le_top)
-
-section
-
-variable {C}
-
-variable (X Y : C)
-
-/-- The chosen binary product in the preorder category of `C`. -/
-def chosenProd : C := X ⊓ Y
-
-namespace chosenProd
-
-/-- The first projection `chosenProd X Y ⟶ X`. -/
-def fst : chosenProd X Y ⟶ X := homOfLE (inf_le_left)
-
-/-- The second projection `chosenProd X Y ⟶ Y`. -/
-def snd : chosenProd X Y ⟶ Y := homOfLE (inf_le_right)
-
-/-- `chosenProd X Y` is a binary product of `X` and `Y`. -/
-def isLimit : IsLimit (BinaryFan.mk (fst X Y) (snd X Y)) where
-  lift s := homOfLE <| le_inf (leOfHom <| s.π.app <|
-  ⟨WalkingPair.left⟩) (leOfHom <| s.π.app <| ⟨WalkingPair.right⟩)
-
-end chosenProd
-
-end
-
 /-- Chosen finite products for the preorder category of a meet-semilattice with a greatest element-/
 noncomputable scoped instance chosenFiniteProducts : ChosenFiniteProducts C where
-  terminal := ⟨_, chosenTerminalIsTerminal C⟩
-  product X Y := ⟨_, chosenProd.isLimit X Y⟩
+  terminal := ⟨_, Preorder.isTerminalTop C⟩
+  product X Y := ⟨_,  Preorder.isLimitBinaryFan X Y⟩
 
 /-- A monoidal structure on the preorder category of a meet-semilattice with a greatest element
 is provided by the instance `monoidalOfChosenFiniteProducts`. -/
-noncomputable instance : MonoidalCategory C := by
+noncomputable scoped instance monoidalCategory : MonoidalCategory C := by
   infer_instance
 
-noncomputable instance : SymmetricCategory C := by
+noncomputable scoped instance symmetricCategory : SymmetricCategory C := by
   infer_instance
 
 namespace Monoidal
@@ -76,7 +44,7 @@ open MonoidalCategory ChosenFiniteProducts
 lemma tensorObj {C : Type u} [Lattice C] [OrderTop C] {X Y : C} : X ⊗ Y = X ⊓ Y := rfl
 
 lemma tensorUnit {C : Type u} [Lattice C] [OrderTop C] :
-    𝟙_ C = SemilatticeInf.chosenTerminal C := rfl
+    𝟙_ C = ⊤ := rfl
 
 end Monoidal
 

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
@@ -43,9 +43,9 @@ namespace Monoidal
 
 open MonoidalCategory ChosenFiniteProducts
 
-lemma tensorObj {C : Type u} [Lattice C] [OrderTop C] {X Y : C} : X ⊗ Y = X ⊓ Y := rfl
+lemma tensorObj {C : Type u} [SemilatticeInf C] [OrderTop C] {X Y : C} : X ⊗ Y = X ⊓ Y := rfl
 
-lemma tensorUnit {C : Type u} [Lattice C] [OrderTop C] :
+lemma tensorUnit {C : Type u} [SemilatticeInf C] [OrderTop C] :
     𝟙_ C = ⊤ := rfl
 
 end Monoidal

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts/InfSemilattice.lean
@@ -19,7 +19,7 @@ instances `monoidalOfChosenFiniteProducts` and `ChosenFiniteProducts.instSymmetr
 
 namespace CategoryTheory
 
-open Category Limits MonoidalCategory
+open Category MonoidalCategory
 
 universe u
 
@@ -32,16 +32,10 @@ noncomputable scoped instance chosenFiniteProducts : ChosenFiniteProducts C wher
   terminal := ⟨_, Preorder.isTerminalTop C⟩
   product X Y := ⟨_,  Preorder.isLimitBinaryFan X Y⟩
 
-namespace Monoidal
-
-open MonoidalCategory ChosenFiniteProducts
-
 lemma tensorObj {C : Type u} [SemilatticeInf C] [OrderTop C] {X Y : C} : X ⊗ Y = X ⊓ Y := rfl
 
 lemma tensorUnit {C : Type u} [SemilatticeInf C] [OrderTop C] :
     𝟙_ C = ⊤ := rfl
-
-end Monoidal
 
 end SemilatticeInf
 

--- a/Mathlib/CategoryTheory/Limits/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preorder.lean
@@ -61,9 +61,7 @@ end SemilatticeInf
 
 section SemilatticeSup
 
-variable {C}
-
-variable [SemilatticeSup C]
+variable {C} [SemilatticeSup C]
 
 /-- The supremum of two elements in a preordered type is a binary coproduct
 in the category associated to this preorder. -/

--- a/Mathlib/CategoryTheory/Limits/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preorder.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2025 Sina Hazratpour. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sina Hazratpour
+-/
+
+import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
+
+/-!
+# (Co)limits in a preoder category
+
+We provide basic results about the limits and colimits in the associated category of
+a preordered type.
+
+-/
+
+universe u
+
+open CategoryTheory Limits
+
+namespace Preorder
+
+variable (C : Type u)
+
+section OrderBot
+
+variable [Preorder C] [OrderBot C]
+
+/-- The least element in a preordered type is initial in the category
+associated to this preorder. -/
+def isInitialBot : IsInitial (⊥ : C) := IsInitial.ofUnique _
+
+instance : HasInitial C := hasInitial_of_unique ⊥
+
+end OrderBot
+
+section OrderTop
+
+variable [Preorder C] [OrderTop C]
+
+/-- The greatest element of a preordered type is terminal in the category
+associated to this preorder. -/
+def isTerminalTop : IsTerminal (⊤ : C) := IsTerminal.ofUnique _
+
+instance : HasTerminal C := hasTerminal_of_unique ⊤
+
+end OrderTop
+
+section SemilatticeInf
+
+variable {C}
+
+variable [SemilatticeInf C]
+
+/-- The infimum of two elements in a preordered type is a binary product in
+the category associated to this preorder. -/
+def isLimitBinaryFan (X Y : C) :
+    IsLimit (BinaryFan.mk (P := X ⊓ Y) (homOfLE inf_le_left) (homOfLE inf_le_right)) :=
+  BinaryFan.isLimitMk (fun s ↦ homOfLE (le_inf (leOfHom s.fst) (leOfHom s.snd)))
+    (by intros; rfl) (by intros; rfl) (by intros; rfl)
+
+end SemilatticeInf
+
+section SemilatticeSup
+
+variable {C}
+
+variable [SemilatticeSup C]
+
+/-- The supremum of two elements in a preordered type is a binary coproduct
+in the category associated to this preorder. -/
+def isColimitBinaryCofan (X Y : C) :
+    IsColimit (BinaryCofan.mk (P := X ⊔ Y) (homOfLE le_sup_left) (homOfLE le_sup_right)) :=
+  BinaryCofan.isColimitMk (fun s ↦ homOfLE (sup_le (leOfHom s.inl) (leOfHom s.inr)))
+    (by intros; rfl) (by intros; rfl) (by intros; rfl)
+
+end SemilatticeSup
+
+end Preorder

--- a/Mathlib/CategoryTheory/Limits/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preorder.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Sina Hazratpour. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sina Hazratpour
+Authors: Sina Hazratpour, Joël Riou
 -/
 
 import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts

--- a/Mathlib/CategoryTheory/Limits/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preorder.lean
@@ -9,7 +9,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
 /-!
 # (Co)limits in a preoder category
 
-We provide basic results about the limits and colimits in the associated category of
+We provide basic results about the nullary and binary (co)products in the associated category of
 a preordered type.
 
 -/

--- a/Mathlib/CategoryTheory/Limits/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preorder.lean
@@ -48,9 +48,7 @@ end OrderTop
 
 section SemilatticeInf
 
-variable {C}
-
-variable [SemilatticeInf C]
+variable {C} [SemilatticeInf C]
 
 /-- The infimum of two elements in a preordered type is a binary product in
 the category associated to this preorder. -/

--- a/Mathlib/CategoryTheory/Limits/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preorder.lean
@@ -7,7 +7,7 @@ Authors: Sina Hazratpour, Joël Riou
 import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
 
 /-!
-# (Co)limits in a preoder category
+# (Co)limits in a preorder category
 
 We provide basic results about the nullary and binary (co)products in the associated category of
 a preordered type.

--- a/Mathlib/CategoryTheory/Limits/Shapes/Preorder/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Preorder/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-import Mathlib.CategoryTheory.Limits.Shapes.Terminal
+import Mathlib.CategoryTheory.Limits.Preorder
 
 /-!
 # Limits and colimits indexed by preorders
@@ -27,12 +27,6 @@ section OrderBot
 
 variable [OrderBot J]
 
-/-- The least element in a preordered type is initial in the category
-associated to this preorder. -/
-def isInitialBot : IsInitial (⊥ : J) := IsInitial.ofUnique _
-
-instance : HasInitial J := hasInitial_of_unique ⊥
-
 instance : HasLimitsOfShape J C := ⟨fun _ ↦ by infer_instance⟩
 
 end OrderBot
@@ -40,12 +34,6 @@ end OrderBot
 section OrderTop
 
 variable [OrderTop J]
-
-/-- The greatest element of a preordered type is terminal in the category
-associated to this preorder. -/
-def isTerminalBot : IsTerminal (⊤ : J) := IsTerminal.ofUnique _
-
-instance : HasTerminal J := hasTerminal_of_unique ⊤
 
 instance : HasColimitsOfShape J C := ⟨fun _ ↦ by infer_instance⟩
 


### PR DESCRIPTION
The preorder category of a meet-semilattice `C` with a top element has chosen finite products. 

Motivation: I plan to use the induced monoidal structure to show that the preorder category of a distributive lattice is distributive. See this PR on Monoidal and cartesian distributive categories: #20182 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
