### PR TITLE
feat(Data/Set): representing the equivalence classes of a Quot

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3014,6 +3014,7 @@ import Mathlib.Data.Set.Pointwise.Iterate
 import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Data.Set.Pointwise.Support
 import Mathlib.Data.Set.Prod
+import Mathlib.Data.Set.Quot
 import Mathlib.Data.Set.SMulAntidiagonal
 import Mathlib.Data.Set.Semiring
 import Mathlib.Data.Set.Sigma

--- a/Mathlib/Data/Set/Quot.lean
+++ b/Mathlib/Data/Set/Quot.lean
@@ -45,8 +45,8 @@ lemma out_image_represents (C : Set (Quot r)) : (Quot.out '' C).Represents C whe
     rw [← hyc, c'.out_eq]
   exact {c} h := by
     ext v
-    simp only [mem_inter_iff, mem_image, mem_empty_iff_false, iff_false,
-      not_and, forall_exists_index, and_imp]
+    simp only [mem_inter_iff, mem_image, mem_empty_iff_false, iff_false, not_and,
+      forall_exists_index, and_imp]
     intro c' hc' hv hvc
     rw [← hvc, ← hv, c'.out_eq] at h
     exact h hc'
@@ -67,12 +67,11 @@ lemma disjoint_represents (hrep : s.Represents C) (h : c ∉ C) : Disjoint s c :
 
 lemma ncard_sdiff_represents_of_mem [Fintype α] (hrep : s.Represents C) (h : c ∈ C) :
     ((c : Set α) \ s).ncard = (c : Set α).ncard - 1 := by
-  simp [← ncard_inter_add_ncard_diff_eq_ncard c s (toFinite _),
-    inter_comm, ncard_represents_inter hrep h]
+  simp [← ncard_inter_add_ncard_diff_eq_ncard c s (toFinite _), inter_comm,
+    ncard_represents_inter hrep h]
 
 lemma ncard_sdiff_represents_of_not_mem [Fintype α] (hrep : s.Represents C) (h : c ∉ C) :
     ((c : Set α) \ s).ncard = (c : Set α).ncard := by
-  simp [← ncard_inter_add_ncard_diff_eq_ncard c s (toFinite _),
-    inter_comm, hrep.exact h]
+  simp [← ncard_inter_add_ncard_diff_eq_ncard c s (toFinite _), inter_comm, hrep.exact h]
 
 end Set

--- a/Mathlib/Data/Set/Quot.lean
+++ b/Mathlib/Data/Set/Quot.lean
@@ -48,13 +48,13 @@ variable {C : Set (Quot r)} {s : Set α} {c : Quot r}
 lemma unique_rep (hrep : s.Represents C) (h : c ∈ C) : ∃! x, x ∈ s ∩ c := by
   obtain ⟨x, ⟨hx, rfl⟩⟩ := hrep.2.2 h
   use x
-  simp only [mem_inter_iff, hx, SetLike.mem_coe, Quot.mem_toSet, and_self, and_imp, true_and]
+  simp only [mem_inter_iff, hx, SetLike.mem_coe, Quot.mem_coe, and_self, and_imp, true_and]
   exact fun y hy hyx ↦ hrep.2.1 hy hx hyx
 
 lemma exact (hrep : s.Represents C) (h : c ∉ C) : Disjoint s c := by
   rw [disjoint_left]
   intro a ha hc
-  simp only [SetLike.mem_coe, Quot.mem_toSet] at hc
+  simp only [SetLike.mem_coe, Quot.mem_coe] at hc
   subst hc
   exact h (hrep.1 ha)
 

--- a/Mathlib/Data/Set/Quot.lean
+++ b/Mathlib/Data/Set/Quot.lean
@@ -18,14 +18,11 @@ import Mathlib.Data.Set.Card
 
 variable {α : Type*} {r : α → α → Prop}
 
-/-- Convert an equivalence class to a `Set`. -/
-def Quot.toSet (c : Quot r) : Set α := {x | Quot.mk r x = c}
-
 /-- A quotient element can be interpreted as the set of elements in the same equivalence class. -/
 instance : SetLike (Quot r) α where
-  coe := Quot.toSet
+  coe (c : Quot r) := {x | Quot.mk r x = c}
   coe_injective' x y h := by
-    simp only [Quot.toSet] at h
+    dsimp at h
     simpa using show x.out ∈ {v | Quot.mk r v = y} by
       rw [← h]
       exact x.out_eq

--- a/Mathlib/Data/Set/Quot.lean
+++ b/Mathlib/Data/Set/Quot.lean
@@ -21,6 +21,7 @@ variable {α : Type*} {r : α → α → Prop}
 /-- Convert an equivalence class to a `Set`. -/
 def Quot.toSet (c : Quot r) : Set α := {x | Quot.mk r x = c}
 
+/-- A quotient element can be interpreted as the set of elements in the same equivalence class. -/
 instance : SetLike (Quot r) α where
   coe := Quot.toSet
   coe_injective' x y h := by
@@ -29,7 +30,7 @@ instance : SetLike (Quot r) α where
       rw [← h]
       exact x.out_eq
 
-@[simp] lemma Quot.mem_toSet {x : α} {c : Quot r} : x ∈ c ↔ Quot.mk r x = c := Iff.rfl
+@[simp] lemma Quot.mem_coe {x : α} {c : Quot r} : x ∈ c ↔ Quot.mk r x = c := Iff.rfl
 
 @[ext] theorem Quot.ext (c d : Quot r) (h : ∀ x, x ∈ c ↔ x ∈ d) : c = d := SetLike.ext h
 

--- a/Mathlib/Data/Set/Quot.lean
+++ b/Mathlib/Data/Set/Quot.lean
@@ -53,7 +53,7 @@ lemma out_image_represents (C : Set (Quot r)) : (Quot.out '' C).Represents C whe
 
 variable {C : Set (Quot r)} {s : Set α} {c : Quot r}
 
-lemma ncard_represents_inter (hrep : s.Represents C)(h : c ∈ C) : (s ∩ c).ncard = 1 := by
+lemma ncard_represents_inter (hrep : s.Represents C) (h : c ∈ C) : (s ∩ c).ncard = 1 := by
   rw [ncard_eq_one]
   obtain ⟨a, ha⟩ := hrep.unique_rep h
   aesop

--- a/Mathlib/Data/Set/Quot.lean
+++ b/Mathlib/Data/Set/Quot.lean
@@ -36,8 +36,7 @@ structure Represents (s : Set α) (C : Set (Quot r)) where
   unique_rep {c : Quot r} (h : c ∈ C) : ∃! v, v ∈ s ∩ c
   exact {c : Quot r} (h : c ∉ C) : s ∩ c = ∅
 
-lemma out_image_represents (C : Set (Quot r)) :
-    (Quot.out '' C).Represents C where
+lemma out_image_represents (C : Set (Quot r)) : (Quot.out '' C).Represents C where
   unique_rep {c} h := by
     use c.out
     simp only [Set.mem_inter_iff, and_imp]
@@ -52,14 +51,14 @@ lemma out_image_represents (C : Set (Quot r)) :
     rw [← hvc, ← hv, c'.out_eq] at h
     exact h hc'
 
-lemma ncard_represents_inter {C : Set (Quot r)} {s : Set α}
-    {c : (Quot r)} (hrep : s.Represents C) (h : c ∈ C) : (s ∩ c).ncard = 1 := by
+lemma ncard_represents_inter {C : Set (Quot r)} {s : Set α} {c : (Quot r)} (hrep : s.Represents C)
+    (h : c ∈ C) : (s ∩ c).ncard = 1 := by
   rw [Set.ncard_eq_one]
   obtain ⟨a, ha⟩ := hrep.unique_rep h
   aesop
 
-lemma disjoint_represents {C : Set (Quot r)} {s : Set α}
-    {c : Quot r} (hrep : s.Represents C) (h : c ∉ C) : Disjoint s c := by
+lemma disjoint_represents {C : Set (Quot r)} {s : Set α} {c : Quot r} (hrep : s.Represents C)
+    (h : c ∉ C) : Disjoint s c := by
   rw [Set.disjoint_right]
   intro v hv hvr
   have := hrep.exact h
@@ -71,14 +70,12 @@ lemma disjoint_of_represents {c : Quot r} {s : Set α} {p : Quot r → Prop}
   apply disjoint_represents hrep
   simpa
 
-lemma ncard_sdiff_represents_of_mem [Fintype α] {c : Quot r}
-    {s : Set α} {C : Set (Quot r)}
+lemma ncard_sdiff_represents_of_mem [Fintype α] {c : Quot r} {s : Set α} {C : Set (Quot r)}
     (hrep : s.Represents C) (h : c ∈ C) : ((c : Set α) \ s).ncard = (c : Set α).ncard - 1 := by
   simp [← Set.ncard_inter_add_ncard_diff_eq_ncard c s (Set.toFinite _),
     Set.inter_comm, ncard_represents_inter hrep h]
 
-lemma ncard_sdiff_represents_of_not_mem [Fintype α] {c : Quot r}
-    {s : Set α} {C : Set (Quot r)}
+lemma ncard_sdiff_represents_of_not_mem [Fintype α] {c : Quot r} {s : Set α} {C : Set (Quot r)}
     (hrep : s.Represents C) (h : c ∉ C) : ((c : Set α) \ s).ncard = (c : Set α).ncard := by
   simp [← Set.ncard_inter_add_ncard_diff_eq_ncard c s (Set.toFinite _),
     Set.inter_comm, hrep.exact h]

--- a/Mathlib/Data/Set/Quot.lean
+++ b/Mathlib/Data/Set/Quot.lean
@@ -19,9 +19,9 @@ import Mathlib.Data.Set.Card
 variable {α : Type*} {r : α → α → Prop}
 
 /-- Convert an equivalence class to a `Set`. -/
-def Quot.toSet (c : Quot r) : Set V := {v | Quot.mk r v = c}
+def Quot.toSet (c : Quot r) : Set α := {v | Quot.mk r v = c}
 
-instance : SetLike (Quot r) V where
+instance : SetLike (Quot r) α where
   coe := Quot.toSet
   coe_injective' x y h := by
     simp only [Quot.toSet] at h
@@ -32,11 +32,11 @@ instance : SetLike (Quot r) V where
 namespace Set
 
 /-- A set represents a set of quotients if it contains exactly one element from each quotient. -/
-structure Represents (s : Set V) (C : Set (Quot r)) where
+structure Represents (s : Set α) (C : Set (Quot r)) where
   unique_rep {c : Quot r} (h : c ∈ C) : ∃! v, v ∈ s ∩ c
   exact {c : Quot r} (h : c ∉ C) : s ∩ c = ∅
 
-lemma represents_of_image_exists_rep_choose (C : Set (Quot r)) :
+lemma out_image_represents (C : Set (Quot r)) :
     (Quot.out '' C).Represents C where
   unique_rep {c} h := by
     use c.out
@@ -52,13 +52,13 @@ lemma represents_of_image_exists_rep_choose (C : Set (Quot r)) :
     rw [← hvc, ← hv, c'.out_eq] at h
     exact h hc'
 
-lemma ncard_represents_inter {C : Set (Quot r)} {s : Set V}
+lemma ncard_represents_inter {C : Set (Quot r)} {s : Set α}
     {c : (Quot r)} (hrep : s.Represents C) (h : c ∈ C) : (s ∩ c).ncard = 1 := by
   rw [Set.ncard_eq_one]
   obtain ⟨a, ha⟩ := hrep.unique_rep h
   aesop
 
-lemma disjoint_represents {C : Set (Quot r)} {s : Set V}
+lemma disjoint_represents {C : Set (Quot r)} {s : Set α}
     {c : Quot r} (hrep : s.Represents C) (h : c ∉ C) : Disjoint s c := by
   rw [Set.disjoint_right]
   intro v hv hvr
@@ -66,20 +66,20 @@ lemma disjoint_represents {C : Set (Quot r)} {s : Set V}
   rw [Set.eq_empty_iff_forall_not_mem] at this
   simp_all
 
-lemma disjoint_of_represents {c : Quot r} {s : Set V} {p : Quot r → Prop}
+lemma disjoint_of_represents {c : Quot r} {s : Set α} {p : Quot r → Prop}
     (hrep : s.Represents {c | p c}) (h : ¬ p c) : Disjoint s c := by
   apply disjoint_represents hrep
   simpa
 
-lemma ncard_sdiff_represents_of_mem [Fintype V] {c : Quot r}
-    {s : Set V} {C : Set (Quot r)}
-    (hrep : s.Represents C) (h : c ∈ C) : ((c : Set V) \ s).ncard = (c : Set V).ncard - 1 := by
+lemma ncard_sdiff_represents_of_mem [Fintype α] {c : Quot r}
+    {s : Set α} {C : Set (Quot r)}
+    (hrep : s.Represents C) (h : c ∈ C) : ((c : Set α) \ s).ncard = (c : Set α).ncard - 1 := by
   simp [← Set.ncard_inter_add_ncard_diff_eq_ncard c s (Set.toFinite _),
     Set.inter_comm, ncard_represents_inter hrep h]
 
-lemma ncard_sdiff_represents_of_not_mem [Fintype V] {c : Quot r}
-    {s : Set V} {C : Set (Quot r)}
-    (hrep : s.Represents C) (h : c ∉ C) : ((c : Set V) \ s).ncard = (c : Set V).ncard := by
+lemma ncard_sdiff_represents_of_not_mem [Fintype α] {c : Quot r}
+    {s : Set α} {C : Set (Quot r)}
+    (hrep : s.Represents C) (h : c ∉ C) : ((c : Set α) \ s).ncard = (c : Set α).ncard := by
   simp [← Set.ncard_inter_add_ncard_diff_eq_ncard c s (Set.toFinite _),
     Set.inter_comm, hrep.exact h]
 

--- a/Mathlib/Data/Set/Quot.lean
+++ b/Mathlib/Data/Set/Quot.lean
@@ -29,54 +29,52 @@ instance : SetLike (Quot r) α where
       rw [← h]
       exact x.out_eq
 
-@[simp] lemma Quot.mem_toSet {x : α} {c : Quot r} : x ∈ c.toSet ↔ Quot.mk r x = c := Iff.rfl
+@[simp] lemma Quot.mem_toSet {x : α} {c : Quot r} : x ∈ c ↔ Quot.mk r x = c := Iff.rfl
 
 @[ext] theorem Quot.ext (c d : Quot r) (h : ∀ x, x ∈ c ↔ x ∈ d) : c = d := SetLike.ext h
 
 namespace Set
 
 /-- A set represents a set of quotients if it contains exactly one element from each quotient. -/
-structure Represents (s : Set α) (C : Set (Quot r)) where
-  unique_rep {c : Quot r} (h : c ∈ C) : ∃! v, v ∈ s ∩ c
-  exact {c : Quot r} (h : c ∉ C) : s ∩ c = ∅
+def Represents (s : Set α) (C : Set (Quot r)) := Set.BijOn (Quot.mk r) s C
 
-lemma out_image_represents (C : Set (Quot r)) : (Quot.out '' C).Represents C where
-  unique_rep {c} h := by
-    use c.out
-    simp only [mem_inter_iff, and_imp]
-    refine ⟨⟨by aesop, Quot.out_eq _⟩, fun y hy hyc ↦ ?_⟩
-    obtain ⟨c', ⟨_, rfl⟩⟩ := hy
-    rw [← hyc, c'.out_eq]
-  exact {c} h := by
-    ext v
-    simp only [mem_inter_iff, mem_image, mem_empty_iff_false, iff_false,
-      not_and, forall_exists_index, and_imp]
-    intro c' hc' hv hvc
-    rw [← hvc, ← hv, c'.out_eq] at h
-    exact h hc'
+lemma out_image_represents (C : Set (Quot r)) : (Quot.out '' C).Represents C :=
+  Set.BijOn.mk (by rintro c ⟨x, ⟨hx, rfl⟩⟩; simp_all) (by
+    rintro x ⟨c, ⟨hc, rfl⟩⟩ y ⟨d, ⟨hd, rfl⟩⟩ hxy
+    aesop) (fun _ _ ↦ by simpa)
+
+namespace Represents
 
 variable {C : Set (Quot r)} {s : Set α} {c : Quot r}
 
-lemma ncard_represents_inter (hrep : s.Represents C)(h : c ∈ C) : (s ∩ c).ncard = 1 := by
+lemma unique_rep (hrep : s.Represents C) (h : c ∈ C) : ∃! x, x ∈ s ∩ c := by
+  obtain ⟨x, ⟨hx, rfl⟩⟩ := hrep.2.2 h
+  use x
+  simp only [mem_inter_iff, hx, SetLike.mem_coe, Quot.mem_toSet, and_self, and_imp, true_and]
+  exact fun y hy hyx ↦ hrep.2.1 hy hx hyx
+
+lemma exact (hrep : s.Represents C) (h : c ∉ C) : Disjoint s c := by
+  rw [disjoint_left]
+  intro a ha hc
+  simp only [SetLike.mem_coe, Quot.mem_toSet] at hc
+  subst hc
+  exact h (hrep.1 ha)
+
+lemma ncard_inter (hrep : s.Represents C) (h : c ∈ C) : (s ∩ c).ncard = 1 := by
   rw [ncard_eq_one]
   obtain ⟨a, ha⟩ := hrep.unique_rep h
   aesop
 
-lemma disjoint_represents (hrep : s.Represents C) (h : c ∉ C) : Disjoint s c := by
-  rw [disjoint_right]
-  intro v hv hvr
-  have := hrep.exact h
-  rw [eq_empty_iff_forall_not_mem] at this
-  simp_all
-
-lemma ncard_sdiff_represents_of_mem [Fintype α] (hrep : s.Represents C) (h : c ∈ C) :
+lemma ncard_sdiff_of_mem [Fintype α] (hrep : s.Represents C) (h : c ∈ C) :
     ((c : Set α) \ s).ncard = (c : Set α).ncard - 1 := by
   simp [← ncard_inter_add_ncard_diff_eq_ncard c s (toFinite _),
-    inter_comm, ncard_represents_inter hrep h]
+    inter_comm, ncard_inter hrep h]
 
-lemma ncard_sdiff_represents_of_not_mem [Fintype α] (hrep : s.Represents C) (h : c ∉ C) :
+lemma ncard_sdiff_of_not_mem [Fintype α] (hrep : s.Represents C) (h : c ∉ C) :
     ((c : Set α) \ s).ncard = (c : Set α).ncard := by
   simp [← ncard_inter_add_ncard_diff_eq_ncard c s (toFinite _),
-    inter_comm, hrep.exact h]
+    inter_comm, disjoint_iff_inter_eq_empty.mp (hrep.exact h)]
+
+end Represents
 
 end Set

--- a/Mathlib/Data/Set/Quot.lean
+++ b/Mathlib/Data/Set/Quot.lean
@@ -51,27 +51,27 @@ lemma out_image_represents (C : Set (Quot r)) : (Quot.out '' C).Represents C whe
     rw [← hvc, ← hv, c'.out_eq] at h
     exact h hc'
 
-lemma ncard_represents_inter {C : Set (Quot r)} {s : Set α} {c : (Quot r)} (hrep : s.Represents C)
-    (h : c ∈ C) : (s ∩ c).ncard = 1 := by
+variable {C : Set (Quot r)} {s : Set α} {c : Quot r}
+
+lemma ncard_represents_inter (hrep : s.Represents C)(h : c ∈ C) : (s ∩ c).ncard = 1 := by
   rw [ncard_eq_one]
   obtain ⟨a, ha⟩ := hrep.unique_rep h
   aesop
 
-lemma disjoint_represents {C : Set (Quot r)} {s : Set α} {c : Quot r} (hrep : s.Represents C)
-    (h : c ∉ C) : Disjoint s c := by
+lemma disjoint_represents (hrep : s.Represents C) (h : c ∉ C) : Disjoint s c := by
   rw [disjoint_right]
   intro v hv hvr
   have := hrep.exact h
   rw [eq_empty_iff_forall_not_mem] at this
   simp_all
 
-lemma ncard_sdiff_represents_of_mem [Fintype α] {c : Quot r} {s : Set α} {C : Set (Quot r)}
-    (hrep : s.Represents C) (h : c ∈ C) : ((c : Set α) \ s).ncard = (c : Set α).ncard - 1 := by
+lemma ncard_sdiff_represents_of_mem [Fintype α] (hrep : s.Represents C) (h : c ∈ C) :
+    ((c : Set α) \ s).ncard = (c : Set α).ncard - 1 := by
   simp [← ncard_inter_add_ncard_diff_eq_ncard c s (toFinite _),
     inter_comm, ncard_represents_inter hrep h]
 
-lemma ncard_sdiff_represents_of_not_mem [Fintype α] {c : Quot r} {s : Set α} {C : Set (Quot r)}
-    (hrep : s.Represents C) (h : c ∉ C) : ((c : Set α) \ s).ncard = (c : Set α).ncard := by
+lemma ncard_sdiff_represents_of_not_mem [Fintype α] (hrep : s.Represents C) (h : c ∉ C) :
+    ((c : Set α) \ s).ncard = (c : Set α).ncard := by
   simp [← ncard_inter_add_ncard_diff_eq_ncard c s (toFinite _),
     inter_comm, hrep.exact h]
 

--- a/Mathlib/Data/Set/Quot.lean
+++ b/Mathlib/Data/Set/Quot.lean
@@ -39,13 +39,13 @@ structure Represents (s : Set α) (C : Set (Quot r)) where
 lemma out_image_represents (C : Set (Quot r)) : (Quot.out '' C).Represents C where
   unique_rep {c} h := by
     use c.out
-    simp only [Set.mem_inter_iff, and_imp]
+    simp only [mem_inter_iff, and_imp]
     refine ⟨⟨by aesop, Quot.out_eq _⟩, fun y hy hyc ↦ ?_⟩
     obtain ⟨c', ⟨_, rfl⟩⟩ := hy
     rw [← hyc, c'.out_eq]
   exact {c} h := by
     ext v
-    simp only [Set.mem_inter_iff, Set.mem_image, Set.mem_empty_iff_false, iff_false,
+    simp only [mem_inter_iff, mem_image, mem_empty_iff_false, iff_false,
       not_and, forall_exists_index, and_imp]
     intro c' hc' hv hvc
     rw [← hvc, ← hv, c'.out_eq] at h
@@ -53,31 +53,26 @@ lemma out_image_represents (C : Set (Quot r)) : (Quot.out '' C).Represents C whe
 
 lemma ncard_represents_inter {C : Set (Quot r)} {s : Set α} {c : (Quot r)} (hrep : s.Represents C)
     (h : c ∈ C) : (s ∩ c).ncard = 1 := by
-  rw [Set.ncard_eq_one]
+  rw [ncard_eq_one]
   obtain ⟨a, ha⟩ := hrep.unique_rep h
   aesop
 
 lemma disjoint_represents {C : Set (Quot r)} {s : Set α} {c : Quot r} (hrep : s.Represents C)
     (h : c ∉ C) : Disjoint s c := by
-  rw [Set.disjoint_right]
+  rw [disjoint_right]
   intro v hv hvr
   have := hrep.exact h
-  rw [Set.eq_empty_iff_forall_not_mem] at this
+  rw [eq_empty_iff_forall_not_mem] at this
   simp_all
-
-lemma disjoint_of_represents {c : Quot r} {s : Set α} {p : Quot r → Prop}
-    (hrep : s.Represents {c | p c}) (h : ¬ p c) : Disjoint s c := by
-  apply disjoint_represents hrep
-  simpa
 
 lemma ncard_sdiff_represents_of_mem [Fintype α] {c : Quot r} {s : Set α} {C : Set (Quot r)}
     (hrep : s.Represents C) (h : c ∈ C) : ((c : Set α) \ s).ncard = (c : Set α).ncard - 1 := by
-  simp [← Set.ncard_inter_add_ncard_diff_eq_ncard c s (Set.toFinite _),
-    Set.inter_comm, ncard_represents_inter hrep h]
+  simp [← ncard_inter_add_ncard_diff_eq_ncard c s (toFinite _),
+    inter_comm, ncard_represents_inter hrep h]
 
 lemma ncard_sdiff_represents_of_not_mem [Fintype α] {c : Quot r} {s : Set α} {C : Set (Quot r)}
     (hrep : s.Represents C) (h : c ∉ C) : ((c : Set α) \ s).ncard = (c : Set α).ncard := by
-  simp [← Set.ncard_inter_add_ncard_diff_eq_ncard c s (Set.toFinite _),
-    Set.inter_comm, hrep.exact h]
+  simp [← ncard_inter_add_ncard_diff_eq_ncard c s (toFinite _),
+    inter_comm, hrep.exact h]
 
 end Set

--- a/Mathlib/Data/Set/Quot.lean
+++ b/Mathlib/Data/Set/Quot.lean
@@ -19,7 +19,7 @@ import Mathlib.Data.Set.Card
 variable {α : Type*} {r : α → α → Prop}
 
 /-- Convert an equivalence class to a `Set`. -/
-def Quot.toSet (c : Quot r) : Set α := {v | Quot.mk r v = c}
+def Quot.toSet (c : Quot r) : Set α := {x | Quot.mk r x = c}
 
 instance : SetLike (Quot r) α where
   coe := Quot.toSet
@@ -28,6 +28,10 @@ instance : SetLike (Quot r) α where
     simpa using show x.out ∈ {v | Quot.mk r v = y} by
       rw [← h]
       exact x.out_eq
+
+@[simp] lemma Quot.mem_toSet {x : α} {c : Quot r} : x ∈ c.toSet ↔ Quot.mk r x = c := Iff.rfl
+
+@[ext] theorem Quot.ext (c d : Quot r) (h : ∀ x, x ∈ c ↔ x ∈ d) : c = d := SetLike.ext h
 
 namespace Set
 

--- a/Mathlib/Data/Set/Quot.lean
+++ b/Mathlib/Data/Set/Quot.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2025 Pim Otte. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pim Otte
+-/
+
+import Mathlib.Data.Set.Card
+
+/-!
+# Quotients as Sets
+
+## Main definitions
+
+* `Quot.toSet` interprets an equivalence class as a set.
+* `Set.Represents` says that a set represents a set of quotients if it contains exactly one element
+  from each quotient.
+-/
+
+universe u
+
+variable {V : Type u} {r : V → V → Prop}
+
+/-- Convert an equivalence class to a Set -/
+def Quot.toSet (c : Quot r) : Set V := {v | Quot.mk r v = c}
+
+instance : SetLike (Quot r) V where
+  coe := Quot.toSet
+  coe_injective' := by
+    intro x y h
+    simp only [Quot.toSet] at h
+    simpa using show x.out ∈ {v | Quot.mk r v = y} from by
+      rw [← h]
+      exact Quot.out_eq x
+
+namespace Set
+
+/-- A set represents a set of quotients if it contains exactly one element from each quotient. -/
+structure Represents (s : Set V) (C : Set (Quot r)) where
+  unique_rep {c : Quot r} (h : c ∈ C) : ∃! v, v ∈ s ∩ c
+  exact {c : Quot r} (h : c ∉ C) : s ∩ c = ∅
+
+lemma represents_of_image_exists_rep_choose (C : Set (Quot r)) :
+    ((fun c ↦ c.out) '' C).Represents C where
+  unique_rep {c} h := by
+    use c.out
+    simp only [Set.mem_inter_iff, and_imp]
+    refine ⟨⟨by aesop, Quot.out_eq _⟩, ?_⟩
+    intro y hy hyc
+    obtain ⟨c', ⟨_, rfl⟩⟩ := hy
+    rw [← hyc, show Quot.mk r (Quot.out c') = c'
+      from Quot.out_eq c']
+  exact {c} {h} := by
+    ext v
+    simp only [Set.mem_inter_iff, Set.mem_image, Set.mem_empty_iff_false, iff_false,
+      not_and, forall_exists_index, and_imp]
+    intro c' hc' hv hvc
+    have : c = c' := by
+      rw [← hvc, ← hv]
+      exact (Quot.exists_rep c').choose_spec
+    exact h (this ▸ hc')
+
+lemma ncard_represents_inter {C : Set (Quot r)} {s : Set V}
+    {c : (Quot r)} (hrep : s.Represents C) (h : c ∈ C) : (s ∩ c).ncard = 1 := by
+  rw [Set.ncard_eq_one]
+  obtain ⟨a, ha⟩ := hrep.unique_rep h
+  aesop
+
+lemma disjoint_represents {C : Set (Quot r)} {s : Set V}
+    {c : (Quot r)} (hrep : s.Represents C) (h : c ∉ C) : Disjoint s c := by
+  rw [Set.disjoint_right]
+  intro v hv hvr
+  have := hrep.exact h
+  rw [Set.eq_empty_iff_forall_not_mem] at this
+  simp_all
+
+lemma disjoint_of_represents {c : Quot r}
+    {s : Set V} {p : (Quot r) → Prop}
+    (hrep : s.Represents {c | p c})
+    (h : ¬ p c) : Disjoint s c := by
+  apply disjoint_represents hrep
+  simp_all only [Set.mem_setOf_eq, not_false_eq_true]
+
+lemma ncard_sdiff_represents_of_mem [Fintype V] {c : Quot r}
+    {s : Set V} {C : Set (Quot r)}
+    (hrep : s.Represents C) (h : c ∈ C) : ((c : Set V) \ s).ncard = (c : Set V).ncard - 1 := by
+  simp [← Set.ncard_inter_add_ncard_diff_eq_ncard c s (Set.toFinite _),
+    Set.inter_comm, ncard_represents_inter hrep h]
+
+lemma ncard_sdiff_represents_of_not_mem [Fintype V] {c : Quot r}
+    {s : Set V} {C : Set (Quot r)}
+    (hrep : s.Represents C) (h : c ∉ C) : ((c : Set V) \ s).ncard = (c : Set V).ncard := by
+  simp [← Set.ncard_inter_add_ncard_diff_eq_ncard c s (Set.toFinite _),
+    Set.inter_comm, hrep.exact h]
+
+end Set


### PR DESCRIPTION
Adds the SetLike instance for Quot along with the notion of `Represents`, which says that a Set represents a set of equivalence classes if it contains exactly one element of each class.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This is the more generic version of #20024