### PR TITLE
chore(RingTheory/Generators): use unification hints for variables and relations

### DIFF
--- a/Mathlib/Algebra/Module/Presentation/Differentials.lean
+++ b/Mathlib/Algebra/Module/Presentation/Differentials.lean
@@ -103,13 +103,14 @@ lemma surjective_hom₁ : Function.Surjective (hom₁ pres) := by
   simp only [LinearMap.mem_range]
   refine ⟨Finsupp.single r 1, ?_⟩
   simp only [LinearMap.coe_mk, AddHom.coe_mk, hom₁_single, φ]
-  rfl
 
 lemma comm₁₂_single (r : pres.rels) :
     pres.toExtension.cotangentComplex (hom₁ pres (Finsupp.single r 1)) =
       pres.cotangentSpaceBasis.repr.symm ((differentialsRelations pres).relation r) := by
   simp only [hom₁, Finsupp.linearCombination_single, one_smul, differentialsRelations,
     Basis.repr_symm_apply, Extension.cotangentComplex_mk]
+  -- this is needed after #21050
+  rw [Extension.cotangentComplex_mk]
   exact pres.cotangentSpaceBasis.repr.injective (by ext; simp)
 
 lemma comm₁₂ : pres.toExtension.cotangentComplex.comp (hom₁ pres) =

--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -112,7 +112,21 @@ def ofSurjective {vars} (val : vars → S) (h : Function.Surjective (aeval (R :=
   σ' x := (h x).choose
   aeval_val_σ' x := (h x).choose_spec
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+library_note "type fields of generators and presentations"/--
+When working with generators and presentations, we rely on the MvPolynomial API, but since the
+type of variables is bundled in `Generators R S`, many lemmas don't apply with rw or simp, because
+they can't see through the definition of vars in constructions such as `Generators.comp` and
+`Generators.localizationAway`.
+
+A possible approach is to make all of these constructions abbrevs, but this causes simp to also
+unfold val which is not always desirable. More generally, it is then harder to predict how instance
+search and simp behave. This approached was tried, but caused too many regressions.
+
+Instead we use unification hints, to allow Lean to see through the `vars` (and `rels`) fields
+at reducible transparency.
+-/
+
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint ofSurjective_vars_eq {vars} (val : vars → S)
     (h : Function.Surjective (aeval (R := R) val)) where
   ⊢ (ofSurjective val h).vars ≟ vars
@@ -124,7 +138,7 @@ noncomputable def ofSurjectiveAlgebraMap (h : Function.Surjective (algebraMap R 
     use C (h s).choose
     simp [(h s).choose_spec]
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint ofSurjectiveAlgebraMap_vars_eq (h : Function.Surjective (algebraMap R S)) where
   ⊢ (ofSurjectiveAlgebraMap.{w} h).vars ≟ PEmpty.{w+1}
 
@@ -133,7 +147,7 @@ noncomputable def id : Generators.{w} R R := ofSurjectiveAlgebraMap <| by
   rw [id.map_eq_id]
   exact RingHomSurjective.is_surjective
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint id_vars_eq where
   ⊢ (id (R := R)).vars ≟ PEmpty.{w+1}
 
@@ -143,7 +157,7 @@ def ofAlgHom {I} (f : MvPolynomial I R →ₐ[R] S) (h : Function.Surjective f) 
     Generators R S :=
   ofSurjective (f ∘ X) (by rwa [show aeval (f ∘ X) = f by ext; simp])
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint ofAlgHom_vars {I} (f : MvPolynomial I R →ₐ[R] S) (h : Function.Surjective f) where
   ⊢ (ofAlgHom f h).vars ≟ PEmpty.{w+1}
 
@@ -154,7 +168,7 @@ def ofSet {s : Set S} (hs : Algebra.adjoin R s = ⊤) : Generators R S := by
   rwa [← AlgHom.range_eq_top, ← Algebra.adjoin_range_eq_range_aeval,
     Subtype.range_coe_subtype, Set.setOf_mem_eq]
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint ofSet_vars {s : Set S} (hs : Algebra.adjoin R s = ⊤) where
   ⊢ (ofSet hs).vars ≟ s
 
@@ -168,7 +182,7 @@ def self : Generators R S where
   σ' := X
   aeval_val_σ' := aeval_X _
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint self_vars_eq where ⊢ (self R S).vars ≟ S
 
 /-- The extension `R[X₁,...,Xₙ] → S` given a family of generators. -/
@@ -202,7 +216,7 @@ def localizationAway : Generators R S where
     rw [mul_one, one_mul, IsLocalization.mk'_pow]
     simp
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint localizationAway_vars_eq_unit where
   ⊢ (localizationAway r (S := S)).vars ≟ Unit
 
@@ -230,7 +244,7 @@ def comp (Q : Generators S T) (P : Generators R S) : Generators R T where
       aeval_monomial, map_one, Finsupp.prod_mapDomain_index_inj Sum.inl_injective, Sum.elim_inl,
       one_mul, single_eq_monomial]
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint comp_vars_eq_sum (Q : Generators S T) (P : Generators R S) where
   ⊢ (Q.comp P).vars ≟ Q.vars ⊕ P.vars
 
@@ -255,7 +269,7 @@ def extendScalars (P : Generators R T) : Generators S T where
   σ' x := map (algebraMap R S) (P.σ x)
   aeval_val_σ' s := by simp [@aeval_def S, ← IsScalarTower.algebraMap_eq, ← @aeval_def R]
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint extendsScalars_vars (P : Generators R T) where
   ⊢ (P.extendScalars S).vars ≟ P.vars
 
@@ -289,7 +303,7 @@ def baseChange {T} [CommRing T] [Algebra R T] (P : Generators R S) :
     use (a + b)
     rw [map_add, ha, hb]
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint baseChange_vars_eq (P : Generators R S) where
   ⊢ (P.baseChange (T := T)).vars ≟ P.vars
 

--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -112,6 +112,7 @@ def ofSurjective {vars} (val : vars → S) (h : Function.Surjective (aeval (R :=
   σ' x := (h x).choose
   aeval_val_σ' x := (h x).choose_spec
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint ofSurjective_vars_eq {vars} (val : vars → S)
     (h : Function.Surjective (aeval (R := R) val)) where
   ⊢ (ofSurjective val h).vars ≟ vars
@@ -123,6 +124,7 @@ noncomputable def ofSurjectiveAlgebraMap (h : Function.Surjective (algebraMap R 
     use C (h s).choose
     simp [(h s).choose_spec]
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint ofSurjectiveAlgebraMap_vars_eq (h : Function.Surjective (algebraMap R S)) where
   ⊢ (ofSurjectiveAlgebraMap.{w} h).vars ≟ PEmpty.{w+1}
 
@@ -131,6 +133,7 @@ noncomputable def id : Generators.{w} R R := ofSurjectiveAlgebraMap <| by
   rw [id.map_eq_id]
   exact RingHomSurjective.is_surjective
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint id_vars_eq where
   ⊢ (id (R := R)).vars ≟ PEmpty.{w+1}
 
@@ -140,6 +143,7 @@ def ofAlgHom {I} (f : MvPolynomial I R →ₐ[R] S) (h : Function.Surjective f) 
     Generators R S :=
   ofSurjective (f ∘ X) (by rwa [show aeval (f ∘ X) = f by ext; simp])
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint ofAlgHom_vars {I} (f : MvPolynomial I R →ₐ[R] S) (h : Function.Surjective f) where
   ⊢ (ofAlgHom f h).vars ≟ PEmpty.{w+1}
 
@@ -150,6 +154,7 @@ def ofSet {s : Set S} (hs : Algebra.adjoin R s = ⊤) : Generators R S := by
   rwa [← AlgHom.range_eq_top, ← Algebra.adjoin_range_eq_range_aeval,
     Subtype.range_coe_subtype, Set.setOf_mem_eq]
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint ofSet_vars {s : Set S} (hs : Algebra.adjoin R s = ⊤) where
   ⊢ (ofSet hs).vars ≟ s
 
@@ -163,6 +168,7 @@ def self : Generators R S where
   σ' := X
   aeval_val_σ' := aeval_X _
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint self_vars_eq where ⊢ (self R S).vars ≟ S
 
 /-- The extension `R[X₁,...,Xₙ] → S` given a family of generators. -/
@@ -196,9 +202,11 @@ def localizationAway : Generators R S where
     rw [mul_one, one_mul, IsLocalization.mk'_pow]
     simp
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint localizationAway_vars_eq_unit where
   ⊢ (localizationAway r (S := S)).vars ≟ Unit
 
+-- test that the `vars` field is reducibly def-eq to `Unit`
 example : (localizationAway (S := S) r).vars = Unit := by
   with_reducible rfl
 
@@ -222,9 +230,11 @@ def comp (Q : Generators S T) (P : Generators R S) : Generators R T where
       aeval_monomial, map_one, Finsupp.prod_mapDomain_index_inj Sum.inl_injective, Sum.elim_inl,
       one_mul, single_eq_monomial]
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint comp_vars_eq_sum (Q : Generators S T) (P : Generators R S) where
   ⊢ (Q.comp P).vars ≟ Q.vars ⊕ P.vars
 
+-- test that the `vars` field of the composition is now reducibly def-eq to the sum
 example (Q : Generators S T) (P : Generators R S) :
     (Q.comp P).vars = (Q.vars ⊕ P.vars) := by
   with_reducible rfl
@@ -240,6 +250,7 @@ def extendScalars (P : Generators R T) : Generators S T where
   σ' x := map (algebraMap R S) (P.σ x)
   aeval_val_σ' s := by simp [@aeval_def S, ← IsScalarTower.algebraMap_eq, ← @aeval_def R]
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint extendsScalars_vars (P : Generators R T) where
   ⊢ (P.extendScalars S).vars ≟ P.vars
 
@@ -273,6 +284,7 @@ def baseChange {T} [CommRing T] [Algebra R T] (P : Generators R S) :
     use (a + b)
     rw [map_add, ha, hb]
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint baseChange_vars_eq (P : Generators R S) where
   ⊢ (P.baseChange (T := T)).vars ≟ P.vars
 

--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -216,7 +216,7 @@ variable {T} [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
 
 /-- Given two families of generators `S[X] → T` and `R[Y] → S`,
 we may construct the family of generators `R[X, Y] → T`. -/
-@[simps val, simps (config := .lemmasOnly) vars σ]
+@[simps (config := .lemmasOnly) vars σ]
 noncomputable
 def comp (Q : Generators S T) (P : Generators R S) : Generators R T where
   vars := Q.vars ⊕ P.vars
@@ -238,6 +238,11 @@ unif_hint comp_vars_eq_sum (Q : Generators S T) (P : Generators R S) where
 example (Q : Generators S T) (P : Generators R S) :
     (Q.comp P).vars = (Q.vars ⊕ P.vars) := by
   with_reducible rfl
+
+@[simp]
+lemma comp_val (Q : Generators S T) (P : Generators R S) :
+    (Q.comp P).val = Sum.elim Q.val (algebraMap S T ∘ P.val) :=
+  rfl
 
 variable (S) in
 /-- If `R → S → T` is a tower of algebras, a family of generators `R[X] → T`

--- a/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
+++ b/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
@@ -139,7 +139,8 @@ lemma Cotangent.exact :
       Subtype.exists, exists_and_right, exists_eq_right,
       toExtension_Ring, toExtension_commRing, toExtension_algebra₂]
     refine ⟨?_, Submodule.subset_span ⟨Extension.Cotangent.mk ⟨w, hw⟩, ?_⟩⟩
-    · simp [ker_eq_ker_aeval_val, RingHom.mem_ker, aeval_val_eq_zero hw]
+    · simp only [ker_eq_ker_aeval_val, RingHom.mem_ker, Hom.algebraMap_toAlgHom,
+        aeval_val_eq_zero hw, map_zero]
     · rw [map_mk]
       rfl
 

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -143,11 +143,11 @@ noncomputable def ofBijectiveAlgebraMap (h : Function.Bijective (algebraMap R S)
     rw [aeval_injective_iff_of_isEmpty]
     exact h.injective
 
-/-- Let lean see through the `rels` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint ofBijectiveAlgebraMap_rels_eq (h : Function.Bijective (algebraMap R S)) where
   ⊢ (ofBijectiveAlgebraMap.{t, w} h).rels ≟ PEmpty
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint ofBijectiveAlgebraMap_toGenerators (h : Function.Bijective (algebraMap R S)) where
   ⊢ (ofBijectiveAlgebraMap.{t, w} h).vars ≟ PEmpty
 
@@ -205,11 +205,11 @@ noncomputable def localizationAway : Presentation R S where
     simp only [Generators.localizationAway_vars, Set.range_const]
     apply span_range_relation_eq_ker_localizationAway r
 
-/-- Let lean see through the `rels` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint localizationAway_rels_eq where
   ⊢ (localizationAway S r).rels ≟ Unit
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint localizationAway_vars_eq where
   ⊢ (localizationAway S r).vars ≟ Unit
 
@@ -281,11 +281,11 @@ def baseChange : Presentation T (T ⊗[R] S) where
   relation i := MvPolynomial.map (algebraMap R T) (P.relation i)
   span_range_relation_eq_ker := P.span_range_relation_eq_ker_baseChange T
 
-/-- Let lean see through the `rels` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint baseChange_rels_eq where
   ⊢ (P.baseChange T).rels ≟ P.rels
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint baseChange_vars_eq where
   ⊢ (P.baseChange T).vars ≟ P.vars
 
@@ -434,11 +434,11 @@ noncomputable def comp : Presentation R T where
     (fun rp ↦ MvPolynomial.rename Sum.inr <| P.relation rp)
   span_range_relation_eq_ker := Q.span_range_relation_eq_ker_comp P
 
-/-- Let lean see through the `rels` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint comp_rels_eq where
   ⊢ (Q.comp P).rels ≟ Q.rels ⊕ P.rels
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint comp_vars_eq where
   ⊢ (Q.comp P).vars ≟ Q.vars ⊕ P.vars
 

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -443,6 +443,11 @@ unif_hint comp_vars_eq where
   ⊢ (Q.comp P).vars ≟ Q.vars ⊕ P.vars
 
 @[simp]
+lemma comp_val :
+    (Q.comp P).val = (Q.toGenerators.comp P.toGenerators).val :=
+  rfl
+
+@[simp]
 lemma comp_relation_inr (r : P.rels) :
     (Q.comp P).relation (Sum.inr r) = rename Sum.inr (P.relation r) :=
   rfl

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -143,9 +143,11 @@ noncomputable def ofBijectiveAlgebraMap (h : Function.Bijective (algebraMap R S)
     rw [aeval_injective_iff_of_isEmpty]
     exact h.injective
 
+/-- Let lean see through the `rels` field to enable the `MvPolynomial` API. -/
 unif_hint ofBijectiveAlgebraMap_rels_eq (h : Function.Bijective (algebraMap R S)) where
   ⊢ (ofBijectiveAlgebraMap.{t, w} h).rels ≟ PEmpty
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint ofBijectiveAlgebraMap_toGenerators (h : Function.Bijective (algebraMap R S)) where
   ⊢ (ofBijectiveAlgebraMap.{t, w} h).vars ≟ PEmpty
 
@@ -203,9 +205,11 @@ noncomputable def localizationAway : Presentation R S where
     simp only [Generators.localizationAway_vars, Set.range_const]
     apply span_range_relation_eq_ker_localizationAway r
 
+/-- Let lean see through the `rels` field to enable the `MvPolynomial` API. -/
 unif_hint localizationAway_rels_eq where
   ⊢ (localizationAway S r).rels ≟ Unit
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint localizationAway_vars_eq where
   ⊢ (localizationAway S r).vars ≟ Unit
 
@@ -277,9 +281,11 @@ def baseChange : Presentation T (T ⊗[R] S) where
   relation i := MvPolynomial.map (algebraMap R T) (P.relation i)
   span_range_relation_eq_ker := P.span_range_relation_eq_ker_baseChange T
 
+/-- Let lean see through the `rels` field to enable the `MvPolynomial` API. -/
 unif_hint baseChange_rels_eq where
   ⊢ (P.baseChange T).rels ≟ P.rels
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint baseChange_vars_eq where
   ⊢ (P.baseChange T).vars ≟ P.vars
 
@@ -428,9 +434,11 @@ noncomputable def comp : Presentation R T where
     (fun rp ↦ MvPolynomial.rename Sum.inr <| P.relation rp)
   span_range_relation_eq_ker := Q.span_range_relation_eq_ker_comp P
 
+/-- Let lean see through the `rels` field to enable the `MvPolynomial` API. -/
 unif_hint comp_rels_eq where
   ⊢ (Q.comp P).rels ≟ Q.rels ⊕ P.rels
 
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
 unif_hint comp_vars_eq where
   ⊢ (Q.comp P).vars ≟ Q.vars ⊕ P.vars
 

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -254,6 +254,19 @@ noncomputable def comp : PreSubmersivePresentation R T where
     ((Sum.inr_injective).comp (P.map_inj)) <| by simp
   relations_finite := inferInstanceAs <| Finite (Q.rels ⊕ P.rels)
 
+/-- Let lean see through the `rels` field to enable the `MvPolynomial` API. -/
+unif_hint comp_rels_eq where
+  ⊢ (Q.comp P).rels ≟ Q.rels ⊕ P.rels
+
+/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+unif_hint comp_vars_eq where
+  ⊢ (Q.comp P).vars ≟ Q.vars ⊕ P.vars
+
+@[simp]
+lemma comp_val : (Q.comp P).val = (Q.toPresentation.comp P.toPresentation).val := rfl
+
+lemma comp_rel : (Q.comp P).val = (Q.toPresentation.comp P.toPresentation).val := rfl
+
 /-- The dimension of the composition of two finite submersive presentations is
 the sum of the dimensions. -/
 lemma dimension_comp_eq_dimension_add_dimension [Q.IsFinite] [P.IsFinite] :
@@ -342,15 +355,13 @@ private lemma jacobiMatrix_comp_₂₂_det :
   simp only [Matrix.toBlocks₂₂, AlgHom.mapMatrix_apply, Matrix.map_apply, Matrix.of_apply,
     RingHom.mapMatrix_apply, Generators.algebraMap_apply, map_aeval, coe_eval₂Hom]
   rw [jacobiMatrix_comp_inr_inr, ← IsScalarTower.algebraMap_eq]
-  simp only [aeval, AlgHom.coe_mk, coe_eval₂Hom]
   generalize P.jacobiMatrix i j = p
   induction' p using MvPolynomial.induction_on with a p q hp hq p i hp
-  · simp only [algHom_C, algebraMap_eq, eval₂_C]
-    erw [MvPolynomial.eval₂_C]
-  · simp [hp, hq]
-  · simp only [map_mul, rename_X, eval₂_mul, hp, eval₂_X]
-    erw [Generators.comp_val]
-    simp
+  · simp
+  · simp only [map_add, hp, hq, eval₂_add]
+  · simp only [comp_val, Presentation.comp_val, Generators.comp_val, map_mul, rename_X,
+      aeval_rename, aeval_X, Sum.elim_inr, Function.comp_apply, eval₂_mul, eval₂_X]
+    simp [aeval, Function.comp_def]
 
 end P
 

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -254,11 +254,11 @@ noncomputable def comp : PreSubmersivePresentation R T where
     ((Sum.inr_injective).comp (P.map_inj)) <| by simp
   relations_finite := inferInstanceAs <| Finite (Q.rels ⊕ P.rels)
 
-/-- Let lean see through the `rels` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint comp_rels_eq where
   ⊢ (Q.comp P).rels ≟ Q.rels ⊕ P.rels
 
-/-- Let lean see through the `vars` field to enable the `MvPolynomial` API. -/
+/-- See library note [type fields of generators and presentations]. -/
 unif_hint comp_vars_eq where
   ⊢ (Q.comp P).vars ≟ Q.vars ⊕ P.vars
 

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -400,7 +400,6 @@ lemma baseChange_jacobian : (P.baseChange T).jacobian = 1 ⊗ₜ P.jacobian := b
     simp only [baseChange, jacobiMatrix_apply, Presentation.baseChange_relation,
       RingHom.mapMatrix_apply, Matrix.map_apply]
     erw [MvPolynomial.pderiv_map]
-    rfl
   rw [h]
   erw [← RingHom.map_det, aeval_map_algebraMap]
   rw [P.algebraMap_apply]


### PR DESCRIPTION
When working with generators and presentations, we rely on the `MvPolynomial` API, but since the type of variables is bundled in `Generators R S`, many lemmas don't apply with `rw` or `simp`, because they can't see through the definition of `vars` in constructions such as `Generators.comp` and `Generators.localizationAway`.

A possible approach is to make all of these constructions `abbrev`s, but this causes `simp` to also unfold `val` which is not always desirable. More generally, it is then harder to predict how instance search and `simp` behave. This approach is tried in #21050, but causes many regressions.

This approach is less invasive, as it uses `unif_hint` to unify the `vars` (and `rels`) fields of constructions with the correct type.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
