### PR TITLE
[Merged by Bors] - feat(SetTheory/Game/PGame): rewrite left moves of `-x` as right moves of `x` under binders

### DIFF
--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1363,6 +1363,26 @@ theorem moveRight_neg_symm {x : PGame} (i) :
 theorem moveRight_neg_symm' {x : PGame} (i) :
     x.moveRight i = -(-x).moveLeft (toLeftMovesNeg i) := by simp
 
+@[simp]
+theorem forall_leftMoves_neg {x : PGame} {p : (-x).LeftMoves → Prop} :
+    (∀ i : (-x).LeftMoves, p i) ↔ (∀ i : x.RightMoves, p (toLeftMovesNeg i)) :=
+  toLeftMovesNeg.forall_congr_right.symm
+
+@[simp]
+theorem exists_leftMoves_neg {x : PGame} {p : (-x).LeftMoves → Prop} :
+    (∃ i : (-x).LeftMoves, p i) ↔ (∃ i : x.RightMoves, p (toLeftMovesNeg i)) :=
+  toLeftMovesNeg.exists_congr_right.symm
+
+@[simp]
+theorem forall_rightMoves_neg {x : PGame} {p : (-x).RightMoves → Prop} :
+    (∀ i : (-x).RightMoves, p i) ↔ (∀ i : x.LeftMoves, p (toRightMovesNeg i)) :=
+  toRightMovesNeg.forall_congr_right.symm
+
+@[simp]
+theorem exists_rightMoves_neg {x : PGame} {p : (-x).RightMoves → Prop} :
+    (∃ i : (-x).RightMoves, p i) ↔ (∃ i : x.LeftMoves, p (toRightMovesNeg i)) :=
+  toRightMovesNeg.exists_congr_right.symm
+
 theorem leftMoves_neg_cases {x : PGame} (k) {P : (-x).LeftMoves → Prop}
     (h : ∀ i, P <| toLeftMovesNeg i) :
     P k := by


### PR DESCRIPTION
These lemmas strengthen our simp set considerably, and allow us to now prove various other theorems by `simp` on the negative game.

See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/116395-maths/topic/Poset.20games/near/496019881) for some discussion on this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
