### PR TITLE
[Merged by Bors] - chore(SupIndep): speedup the `Decidable` instance

### DIFF
--- a/Mathlib/Order/SupIndep.lean
+++ b/Mathlib/Order/SupIndep.lean
@@ -63,6 +63,17 @@ theorem supIndep_iff_disjoint_erase [DecidableEq ι] :
   ⟨fun hs _ hi => hs (erase_subset _ _) hi (not_mem_erase _ _), fun hs _ ht i hi hit =>
     (hs i hi).mono_right (sup_mono fun _ hj => mem_erase.2 ⟨ne_of_mem_of_not_mem hj hit, ht hj⟩)⟩
 
+/-- If both the index type and the lattice have decidable equality,
+then the `SupIndep` predicate is decidable.
+
+TODO: speedup the definition and drop the `[DecidableEq ι]` assumption
+by iterating over the pairs `(a, t)` such that `s = Finset.cons a t _`
+using something like `List.eraseIdx`
+or by generating both `f i` and `(s.erase i).sup f` in one loop over `s`.
+Yet another possible optimization is to precompute partial suprema of `f`
+over the inits and tails of the list representing `s`,
+store them in 2 `Array`s,
+then compute each `sup` in 1 operation. -/
 instance [DecidableEq ι] [DecidableEq α] : Decidable (SupIndep s f) :=
   have : ∀ i, Decidable (Disjoint (f i) ((s.erase i).sup f)) := fun _ ↦
     decidable_of_iff _ disjoint_iff.symm

--- a/Mathlib/Order/SupIndep.lean
+++ b/Mathlib/Order/SupIndep.lean
@@ -5,7 +5,6 @@ Authors: Aaron Anderson, Kevin Buzzard, Yaël Dillies, Eric Wieser
 -/
 import Mathlib.Data.Finset.Sigma
 import Mathlib.Data.Finset.Pairwise
-import Mathlib.Data.Finset.Powerset
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.CompleteLatticeIntervals
 
@@ -58,13 +57,16 @@ def SupIndep (s : Finset ι) (f : ι → α) : Prop :=
 
 variable {s t : Finset ι} {f : ι → α} {i : ι}
 
-instance [DecidableEq ι] [DecidableEq α] : Decidable (SupIndep s f) := by
-  refine @Finset.decidableForallOfDecidableSubsets _ _ _ (?_)
-  rintro t -
-  refine @Finset.decidableDforallFinset _ _ _ (?_)
-  rintro i -
-  have : Decidable (Disjoint (f i) (sup t f)) := decidable_of_iff' (_ = ⊥) disjoint_iff
-  infer_instance
+/-- The RHS looks like the definition of `iSupIndep`. -/
+theorem supIndep_iff_disjoint_erase [DecidableEq ι] :
+    s.SupIndep f ↔ ∀ i ∈ s, Disjoint (f i) ((s.erase i).sup f) :=
+  ⟨fun hs _ hi => hs (erase_subset _ _) hi (not_mem_erase _ _), fun hs _ ht i hi hit =>
+    (hs i hi).mono_right (sup_mono fun _ hj => mem_erase.2 ⟨ne_of_mem_of_not_mem hj hit, ht hj⟩)⟩
+
+instance [DecidableEq ι] [DecidableEq α] : Decidable (SupIndep s f) :=
+  have : ∀ i, Decidable (Disjoint (f i) ((s.erase i).sup f)) := fun _ ↦
+    decidable_of_iff _ disjoint_iff.symm
+  decidable_of_iff _ supIndep_iff_disjoint_erase.symm
 
 theorem SupIndep.subset (ht : t.SupIndep f) (h : s ⊆ t) : s.SupIndep f := fun _ hu _ hi =>
   ht (hu.trans h) (h hi)
@@ -87,12 +89,6 @@ theorem SupIndep.le_sup_iff (hs : s.SupIndep f) (hts : t ⊆ s) (hi : i ∈ s) (
   refine ⟨fun h => ?_, le_sup⟩
   by_contra hit
   exact hf i (disjoint_self.1 <| (hs hts hi hit).mono_right h)
-
-/-- The RHS looks like the definition of `iSupIndep`. -/
-theorem supIndep_iff_disjoint_erase [DecidableEq ι] :
-    s.SupIndep f ↔ ∀ i ∈ s, Disjoint (f i) ((s.erase i).sup f) :=
-  ⟨fun hs _ hi => hs (erase_subset _ _) hi (not_mem_erase _ _), fun hs _ ht i hi hit =>
-    (hs i hi).mono_right (sup_mono fun _ hj => mem_erase.2 ⟨ne_of_mem_of_not_mem hj hit, ht hj⟩)⟩
 
 theorem supIndep_antimono_fun {g : ι → α} (h : ∀ x ∈ s, f x ≤ g x) (h : s.SupIndep g) :
     s.SupIndep f := by


### PR DESCRIPTION
The new instance runs in polynomial time
instead of exponential.

---
It's possible to iterate over all representations of `s` as `cons a t _`
without `DecidableEq ι` (and it's faster),
but this would require new constructions.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
