### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology): fibrant and cofibrant objects

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1105,6 +1105,7 @@ import Mathlib.AlgebraicTopology.FundamentalGroupoid.Product
 import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
 import Mathlib.AlgebraicTopology.ModelCategory.Basic
 import Mathlib.AlgebraicTopology.ModelCategory.CategoryWithCofibrations
+import Mathlib.AlgebraicTopology.ModelCategory.IsCofibrant
 import Mathlib.AlgebraicTopology.MooreComplex
 import Mathlib.AlgebraicTopology.Quasicategory.Basic
 import Mathlib.AlgebraicTopology.Quasicategory.Nerve

--- a/Mathlib/AlgebraicTopology/ModelCategory/IsCofibrant.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/IsCofibrant.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.AlgebraicTopology.ModelCategory.CategoryWithCofibrations
+import Mathlib.CategoryTheory.Limits.Shapes.Terminal
+
+/-!
+# Fibrant and cofibrant objects in a model category
+
+Once a category `C` has been endowed with a `CategoryWithCofibrations C`
+instance, it is possible to define the property `IsCofibrant X` for
+any `X : C` as an abbreviation for `Cofibration (initial.to X : ⊥_ C ⟶ X)`.
+
+-/
+
+open CategoryTheory Limits
+
+namespace HomotopicalAlgebra
+
+variable {C : Type*} [Category C]
+
+section
+
+variable [CategoryWithCofibrations C] [HasInitial C]
+
+/-- An object `X` is cofibrant if `⊥_ C ⟶ X` is a cofibration. -/
+abbrev IsCofibrant (X : C) : Prop := Cofibration (initial.to X)
+
+lemma isCofibrant_iff (X : C) :
+    IsCofibrant X ↔ Cofibration (initial.to X) := Iff.rfl
+
+lemma isCofibrant_iff_of_isInitial [(cofibrations C).RespectsIso]
+    {A X : C} (i : A ⟶ X) (hA : IsInitial A) :
+    IsCofibrant X ↔ Cofibration i := by
+  simp only [isCofibrant_iff, cofibration_iff]
+  apply (cofibrations C).arrow_mk_iso_iff
+  exact Arrow.isoMk (IsInitial.uniqueUpToIso initialIsInitial hA) (Iso.refl _)
+
+end
+
+section
+
+variable [CategoryWithFibrations C] [HasTerminal C]
+
+/-- An object `X` is fibrant if `X ⟶ ⊤_ C` is a fibration. -/
+abbrev IsFibrant (X : C) : Prop := Fibration (terminal.from X)
+
+lemma isFibrant_iff (X : C) :
+    IsFibrant X ↔ Fibration (terminal.from X) := Iff.rfl
+
+lemma isFibrant_iff_of_isTerminal [(fibrations C).RespectsIso]
+    {X Y : C} (p : X ⟶ Y) (hY : IsTerminal Y) :
+    IsFibrant X ↔ Fibration p := by
+  simp only [isFibrant_iff, fibration_iff]
+  symm
+  apply (fibrations C).arrow_mk_iso_iff
+  exact Arrow.isoMk (Iso.refl _) (IsTerminal.uniqueUpToIso hY terminalIsTerminal)
+
+end
+
+end HomotopicalAlgebra

--- a/Mathlib/AlgebraicTopology/ModelCategory/IsCofibrant.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/IsCofibrant.lean
@@ -12,6 +12,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 Once a category `C` has been endowed with a `CategoryWithCofibrations C`
 instance, it is possible to define the property `IsCofibrant X` for
 any `X : C` as an abbreviation for `Cofibration (initial.to X : ⊥_ C ⟶ X)`.
+(Fibrant objects are defined similarly.)
 
 -/
 


### PR DESCRIPTION
Once a category `C` has been endowed with a `CategoryWithCofibrations C` instance, it is possible to define the property `IsCofibrant X` for any `X : C` as an abbreviation for `Cofibration (initial.to X : ⊥_ C ⟶ X)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
