### PR TITLE
[Merged by Bors] - feat: drop ordering assumption in `RootPairing.coxeterWeight_mem_set_of_isCrystallographic`

### DIFF
--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -430,6 +430,11 @@ noncomputable def restrictScalarsRange :
   simp [restrictScalarsRange]
 
 @[simp]
+lemma eq_restrictScalarsRange_iff (m : M') (n : N') (p : P') :
+    p = restrictScalarsRange i j k hk B hB m n ↔ k p = B (i m) (j n) := by
+  rw [← restrictScalarsRange_apply i j k hk B hB m n, hk.eq_iff]
+
+@[simp]
 lemma restrictScalarsRange_apply_eq_zero_iff (m : M') (n : N') :
     restrictScalarsRange i j k hk B hB m n = 0 ↔ B (i m) (j n) = 0 := by
   rw [← hk.eq_iff, restrictScalarsRange_apply, map_zero]

--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -43,7 +43,7 @@ lemma cartanMatrixIn_def (i j : b.support) :
     b.cartanMatrixIn S i j = P.pairingIn S i j :=
   rfl
 
-variable [Nontrivial R] [NoZeroSMulDivisors S R]
+variable [FaithfulSMul S R]
 
 @[simp]
 lemma cartanMatrixIn_apply_same (i : b.support) :

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -301,7 +301,7 @@ lemma coxeterWeightIn_mem_set_of_isCrystallographic :
   have : Fintype ι := Fintype.ofFinite ι
   obtain ⟨n, hcn⟩ : ∃ n : ℕ, P.coxeterWeightIn ℤ i j = n := by
     have : 0 ≤ P.coxeterWeightIn ℤ i j := by
-      simpa only [P.algebraMap_coxeterWeightIn] using P.coxeterWeight_non_neg (P.posRootForm ℤ) i j
+      simpa only [P.algebraMap_coxeterWeightIn] using P.coxeterWeight_nonneg (P.posRootForm ℤ) i j
     obtain ⟨n, hn⟩ := Int.eq_ofNat_of_zero_le this
     exact ⟨n, by simp [← P.algebraMap_coxeterWeightIn ℤ, hn]⟩
   have : P.coxeterWeightIn ℤ i j ≤ 4 := P.coxeterWeightIn_le_four ℤ i j

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -19,16 +19,20 @@ Another application is to the faithfulness of the Weyl group action on roots, an
 Weyl group.
 
 ## Main definitions:
- * `Polarization`: A distinguished linear map from the weight space to the coweight space.
- * `RootForm` : The bilinear form on weight space corresponding to `Polarization`.
+ * `RootPairing.Polarization`: A distinguished linear map from the weight space to the coweight
+   space.
+ * `RootPairing.RootForm` : The bilinear form on weight space corresponding to `Polarization`.
 
 ## Main results:
- * `polarization_self_sum_of_squares` : The inner product of any weight vector is a sum of squares.
- * `rootForm_reflection_reflection_apply` : `RootForm` is invariant with respect
+ * `RootPairing.rootForm_self_sum_of_squares` : The inner product of any
+   weight vector is a sum of squares.
+ * `RootPairing.rootForm_reflection_reflection_apply` : `RootForm` is invariant with respect
    to reflections.
- * `rootForm_self_smul_coroot`: The inner product of a root with itself times the
-   corresponding coroot is equal to two times Polarization applied to the root.
- * `rootForm_self_non_neg`: `RootForm` is positive semidefinite.
+ * `RootPairing.rootForm_self_smul_coroot`: The inner product of a root with itself
+   times the corresponding coroot is equal to two times Polarization applied to the root.
+ * `RootPairing.exists_ge_zero_eq_rootForm`: `RootForm` is positive semidefinite.
+ * `RootPairing.coxeterWeight_mem_set_of_isCrystallographic`: the Coxeter weights belongs to the
+   set `{0, 1, 2, 3, 4}`.
 
 ## References:
  * [N. Bourbaki, *Lie groups and Lie algebras. Chapters 4--6*][bourbaki1968]
@@ -37,8 +41,6 @@ Weyl group.
 ## TODO (possibly in other files)
  * Weyl-invariance
  * Faithfulness of Weyl group action, and finiteness of Weyl group, for finite root systems.
- * Relation to Coxeter weight.  In particular, positivity constraints for finite root pairings mean
-  we restrict to weights between 0 and 4.
 -/
 
 open Set Function
@@ -51,10 +53,12 @@ variable {ι R M N : Type*}
 
 namespace RootPairing
 
-section CommRing
-
-variable [Fintype ι] [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+variable [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
   (P : RootPairing ι R M N)
+
+section Fintype
+
+variable [Fintype ι]
 
 instance : Module.Finite R P.rootSpan := Finite.span_of_finite R <| finite_range P.root
 
@@ -166,6 +170,16 @@ lemma rootForm_self_smul_coroot (i : ι) :
   rw [Finset.sum_smul, add_neg_eq_zero.mpr rfl]
   exact sub_eq_zero_of_eq rfl
 
+lemma corootForm_self_smul_root (i : ι) :
+    (P.CorootForm (P.coroot i) (P.coroot i)) • P.root i = 2 • P.CoPolarization (P.coroot i) :=
+  rootForm_self_smul_coroot (P.flip) i
+
+lemma four_nsmul_coPolarization_compl_polarization_apply_root (i : ι) :
+    (4 • P.CoPolarization ∘ₗ P.Polarization) (P.root i) =
+    (P.RootForm (P.root i) (P.root i) * P.CorootForm (P.coroot i) (P.coroot i)) • P.root i := by
+  rw [LinearMap.smul_apply, LinearMap.comp_apply, show 4 = 2 * 2 from rfl, mul_smul, ← map_nsmul,
+    ← rootForm_self_smul_coroot, map_smul, smul_comm, ← corootForm_self_smul_root, smul_smul]
+
 lemma four_smul_rootForm_sq_eq_coxeterWeight_smul (i j : ι) :
     4 • (P.RootForm (P.root i) (P.root j)) ^ 2 = P.coxeterWeight i j •
       (P.RootForm (P.root i) (P.root i) * P.RootForm (P.root j) (P.root j)) := by
@@ -182,10 +196,6 @@ lemma four_smul_rootForm_sq_eq_coxeterWeight_smul (i j : ι) :
     smul_mul_assoc 2, ← mul_smul_comm, hji, ← rootForm_self_smul_coroot, map_smul, ← pairing,
     map_smul, ← pairing, smul_eq_mul, smul_eq_mul, smul_eq_mul, coxeterWeight]
   ring
-
-lemma corootForm_self_smul_root (i : ι) :
-    (P.CorootForm (P.coroot i) (P.coroot i)) • P.root i = 2 • P.CoPolarization (P.coroot i) :=
-  rootForm_self_smul_coroot (P.flip) i
 
 lemma rootForm_self_sum_of_squares (x : M) :
     IsSumSq (P.RootForm x x) :=
@@ -226,57 +236,86 @@ lemma prod_rootForm_smul_coroot_mem_range_domRestrict (i : ι) :
   use ⟨(c • 2 • P.root i), by aesop⟩
   simp
 
-end CommRing
+end Fintype
 
-section LinearOrderedCommRing
+section IsValuedInOrdered
 
-variable [Fintype ι] [LinearOrderedCommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N]
-  [Module R N] (P : RootPairing ι R M N)
+variable (S : Type*) [LinearOrderedCommRing S] [Algebra S R] [FaithfulSMul S R]
+  [Module S M] [IsScalarTower S R M] [P.IsValuedIn S]
 
-theorem rootForm_self_non_neg (x : M) : 0 ≤ P.RootForm x x :=
-  IsSumSq.nonneg (P.rootForm_self_sum_of_squares x)
+/-- The bilinear form of a finite root pairing taking values in a linearly-ordered ring, as a
+root-positive form. -/
+def posRootForm [Fintype ι] : P.RootPositiveForm S where
+  form := P.RootForm
+  symm := P.rootForm_symmetric
+  isOrthogonal_reflection := P.rootForm_reflection_reflection_apply
+  exists_eq i j := ⟨∑ k, P.pairingIn S i k * P.pairingIn S j k, by simp [rootForm_apply_apply]⟩
+  exists_pos_eq i := by
+    refine ⟨∑ k, P.pairingIn S i k ^ 2, ?_, by simp [sq, rootForm_apply_apply]⟩
+    exact Finset.sum_pos' (fun j _ ↦ sq_nonneg _) ⟨i, by simp⟩
 
-lemma rootForm_self_eq_zero_iff {x : M} :
-    P.RootForm x x = 0 ↔ x ∈ LinearMap.ker P.RootForm :=
-  P.RootForm.apply_apply_same_eq_zero_iff P.rootForm_self_non_neg P.rootForm_symmetric
-
-lemma rootForm_root_self_pos (i : ι) :
-    0 < P.RootForm (P.root i) (P.root i) := by
-  simp only [rootForm_apply_apply]
-  exact Finset.sum_pos' (fun j _ ↦ mul_self_nonneg _) ⟨i, by simp⟩
+theorem exists_ge_zero_eq_rootForm [Fintype ι] (x : M) (hx : x ∈ span S (range P.root)) :
+    ∃ s ≥ 0, algebraMap S R s = P.RootForm x x := by
+  refine ⟨(P.posRootForm S).posForm ⟨x, hx⟩ ⟨x, hx⟩, IsSumSq.nonneg ?_, by simp [posRootForm]⟩
+  choose s hs using P.coroot'_apply_apply_mem_of_mem_span S hx
+  suffices (P.posRootForm S).posForm ⟨x, hx⟩ ⟨x, hx⟩ = ∑ i, s i * s i from
+    this ▸ IsSumSq.sum_mul_self Finset.univ s
+  apply FaithfulSMul.algebraMap_injective S R
+  simp only [posRootForm, RootPositiveForm.algebraMap_posForm, map_sum, map_mul]
+  simp [← Algebra.linearMap_apply, hs, rootForm_apply_apply]
 
 /-- SGA3 XXI Prop. 2.3.1 -/
-lemma coxeterWeight_le_four (i j : ι) : P.coxeterWeight i j ≤ 4 := by
-  set li := P.RootForm (P.root i) (P.root i)
-  set lj := P.RootForm (P.root j) (P.root j)
-  set lij := P.RootForm (P.root i) (P.root j)
-  have hi := P.rootForm_root_self_pos i
-  have hj := P.rootForm_root_self_pos j
+lemma coxeterWeightIn_le_four [Finite ι] (i j : ι) :
+    P.coxeterWeightIn S i j ≤ 4 := by
+  have : Fintype ι := Fintype.ofFinite ι
+  let ri : span S (range P.root) := ⟨P.root i, Submodule.subset_span (mem_range_self _)⟩
+  let rj : span S (range P.root) := ⟨P.root j, Submodule.subset_span (mem_range_self _)⟩
+  set li := (P.posRootForm S).posForm ri ri
+  set lj := (P.posRootForm S).posForm rj rj
+  set lij := (P.posRootForm S).posForm ri rj
+  obtain ⟨si, hsi, hsi'⟩ := (P.posRootForm S).exists_pos_eq i
+  obtain ⟨sj, hsj, hsj'⟩ := (P.posRootForm S).exists_pos_eq j
+  replace hsi' : si = li := FaithfulSMul.algebraMap_injective S R <| by simpa [li] using hsi'
+  replace hsj' : sj = lj := FaithfulSMul.algebraMap_injective S R <| by simpa [lj] using hsj'
+  rw [hsi'] at hsi
+  rw [hsj'] at hsj
   have cs : 4 * lij ^ 2 ≤ 4 * (li * lj) := by
     rw [mul_le_mul_left four_pos]
-    exact LinearMap.BilinForm.apply_sq_le_of_symm P.RootForm P.rootForm_self_non_neg
-      P.rootForm_symmetric (P.root i) (P.root j)
-  have key : 4 • lij ^ 2 = _ • (li * lj) := P.four_smul_rootForm_sq_eq_coxeterWeight_smul i j
+    refine (P.posRootForm S).posForm.apply_sq_le_of_symm ?_ (P.posRootForm S).isSymm_posForm ri rj
+    intro x
+    obtain ⟨s, hs, hs'⟩ := P.exists_ge_zero_eq_rootForm S x x.property
+    change _ = (P.posRootForm S).form x x at hs'
+    rw [(P.posRootForm S).algebraMap_apply_eq_form_iff] at hs'
+    rwa [← hs']
+  have key : 4 • lij ^ 2 = P.coxeterWeightIn S i j • (li * lj) := by
+    apply FaithfulSMul.algebraMap_injective S R
+    simpa [map_ofNat, lij, posRootForm, ri, rj, li, lj] using
+       P.four_smul_rootForm_sq_eq_coxeterWeight_smul i j
   simp only [nsmul_eq_mul, smul_eq_mul, Nat.cast_ofNat] at key
   rwa [key, mul_le_mul_right (by positivity)] at cs
 
-instance instIsRootPositiveRootForm : IsRootPositive P P.RootForm where
-  zero_lt_apply_root i := P.rootForm_root_self_pos i
-  symm := P.rootForm_symmetric
-  apply_reflection_eq := P.rootForm_reflection_reflection_apply
+variable [Finite ι] [P.IsCrystallographic] [CharZero R] (i j : ι)
 
-lemma coxeterWeight_mem_set_of_isCrystallographic (i j : ι) [P.IsCrystallographic] :
-    P.coxeterWeight i j ∈ ({0, 1, 2, 3, 4} : Set R) := by
-  obtain ⟨n, hcn⟩ : ∃ n : ℕ, P.coxeterWeight i j = n := by
+lemma coxeterWeightIn_mem_set_of_isCrystallographic :
+    P.coxeterWeightIn ℤ i j ∈ ({0, 1, 2, 3, 4} : Set ℤ) := by
+  have : Fintype ι := Fintype.ofFinite ι
+  obtain ⟨n, hcn⟩ : ∃ n : ℕ, P.coxeterWeightIn ℤ i j = n := by
     have : 0 ≤ P.coxeterWeightIn ℤ i j := by
-      simpa [← P.algebraMap_coxeterWeightIn ℤ] using P.coxeterWeight_non_neg P.RootForm i j
+      simpa only [P.algebraMap_coxeterWeightIn] using P.coxeterWeight_non_neg (P.posRootForm ℤ) i j
     obtain ⟨n, hn⟩ := Int.eq_ofNat_of_zero_le this
     exact ⟨n, by simp [← P.algebraMap_coxeterWeightIn ℤ, hn]⟩
-  have : P.coxeterWeight i j ≤ 4 := P.coxeterWeight_le_four i j
+  have : P.coxeterWeightIn ℤ i j ≤ 4 := P.coxeterWeightIn_le_four ℤ i j
   simp only [hcn, mem_insert_iff, mem_singleton_iff] at this ⊢
   norm_cast at this ⊢
   omega
 
-end LinearOrderedCommRing
+lemma coxeterWeight_mem_set_of_isCrystallographic :
+    P.coxeterWeight i j ∈ ({0, 1, 2, 3, 4} : Set R) := by
+  have := (FaithfulSMul.algebraMap_injective ℤ R).mem_set_image.mpr <|
+    P.coxeterWeightIn_mem_set_of_isCrystallographic i j
+  rw [algebraMap_coxeterWeightIn] at this
+  simpa [eq_comm] using this
+
+end IsValuedInOrdered
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -42,8 +42,7 @@ Weyl group.
 ## Todo
  * Weyl-invariance of `RootForm` and `CorootForm`
  * Faithfulness of Weyl group perm action, and finiteness of Weyl group, over ordered rings.
- * Relation to Coxeter weight.  In particular, positivity constraints for finite root pairings mean
-  we restrict to weights between 0 and 4.
+ * Relation to Coxeter weight.
 -/
 
 noncomputable section
@@ -74,24 +73,15 @@ instance [P.IsAnisotropic] : P.flip.IsAnisotropic where
   rootForm_root_ne_zero := IsAnisotropic.corootForm_coroot_ne_zero
   corootForm_coroot_ne_zero := IsAnisotropic.rootForm_root_ne_zero
 
-/-- An auxiliary lemma en route to `RootPairing.instIsAnisotropicOfIsCrystallographic`. -/
-private lemma rootForm_root_ne_zero_aux [CharZero R] [P.IsCrystallographic] (i : ι) :
-    P.RootForm (P.root i) (P.root i) ≠ 0 := by
-  choose z hz using P.exists_value (S := ℤ) i
-  simp_rw [algebraMap_int_eq, Int.coe_castRingHom] at hz
-  simp only [rootForm_apply_apply, PerfectPairing.flip_apply_apply, root_coroot_eq_pairing, ← hz]
-  suffices 0 < ∑ i, z i * z i by norm_cast; exact this.ne'
-  refine Finset.sum_pos' (fun i _ ↦ mul_self_nonneg (z i)) ⟨i, Finset.mem_univ i, ?_⟩
-  have hzi : z i = 2 := by
-    specialize hz i
-    rw [pairing_same] at hz
-    norm_cast at hz
-  simp [hzi]
+lemma isAnisotropic_of_isValuedIn (S : Type*)
+    [LinearOrderedCommRing S] [Algebra S R] [FaithfulSMul S R] [P.IsValuedIn S] :
+    IsAnisotropic P where
+  rootForm_root_ne_zero i := (P.posRootForm S).form_apply_root_ne_zero i
+  corootForm_coroot_ne_zero i := (P.flip.posRootForm S).form_apply_root_ne_zero i
 
 instance instIsAnisotropicOfIsCrystallographic [CharZero R] [P.IsCrystallographic] :
-    IsAnisotropic P where
-  rootForm_root_ne_zero := P.rootForm_root_ne_zero_aux
-  corootForm_coroot_ne_zero := P.flip.rootForm_root_ne_zero_aux
+    IsAnisotropic P :=
+  P.isAnisotropic_of_isValuedIn ℤ
 
 end CommRing
 
@@ -224,15 +214,22 @@ section LinearOrderedCommRing
 
 variable [LinearOrderedCommRing R] [Module R M] [Module R N] (P : RootPairing ι R M N)
 
-instance instIsAnisotropicOfLinearOrderedCommRing : IsAnisotropic P where
-  rootForm_root_ne_zero i := (P.rootForm_root_self_pos i).ne'
-  corootForm_coroot_ne_zero i := (P.flip.rootForm_root_self_pos i).ne'
+instance instIsAnisotropicOfLinearOrderedCommRing : IsAnisotropic P :=
+  P.isAnisotropic_of_isValuedIn R
+
+lemma zero_le_rootForm (x : M) :
+    0 ≤ P.RootForm x x :=
+  (P.rootForm_self_sum_of_squares x).nonneg
 
 /-- See also `RootPairing.rootForm_restrict_nondegenerate_of_isAnisotropic`. -/
 lemma rootForm_restrict_nondegenerate_of_ordered :
     LinearMap.Nondegenerate (P.RootForm.restrict P.rootSpan) :=
-  (P.RootForm.nondegenerate_restrict_iff_disjoint_ker (rootForm_self_non_neg P)
+  (P.RootForm.nondegenerate_restrict_iff_disjoint_ker P.zero_le_rootForm
     P.rootForm_symmetric).mpr P.disjoint_rootSpan_ker_rootForm
+
+lemma rootForm_self_eq_zero_iff {x : M} :
+    P.RootForm x x = 0 ↔ x ∈ LinearMap.ker P.RootForm :=
+  P.RootForm.apply_apply_same_eq_zero_iff P.zero_le_rootForm P.rootForm_symmetric
 
 lemma eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero {x : M}
     (hx : x ∈ P.rootSpan) (hx' : P.RootForm x x = 0) :
@@ -242,7 +239,7 @@ lemma eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero {x : M}
 
 lemma rootForm_pos_of_ne_zero {x : M} (hx : x ∈ P.rootSpan) (h : x ≠ 0) :
     0 < P.RootForm x x := by
-  apply (P.rootForm_self_non_neg x).lt_of_ne
+  apply (P.zero_le_rootForm x).lt_of_ne
   contrapose! h
   exact P.eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero hx h.symm
 

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -25,7 +25,7 @@ positive semi-definite on weight space and positive-definite on the span of root
  * `RootPairing.zero_lt_pairingIn_iff`: sign relations between `RootPairing.pairingIn` and a
    root-positive form.
  * `RootPairing.pairing_zero_iff`: symmetric vanishing condition for `RootPairing.pairing`
- * `RootPairing.coxeterWeight_non_neg`: All pairs of roots have non-negative Coxeter weight.
+ * `RootPairing.coxeterWeight_nonneg`: All pairs of roots have non-negative Coxeter weight.
  * `RootPairing.coxeterWeight_zero_iff_isOrthogonal` : A Coxeter weight vanishes iff the roots are
    orthogonal.
 
@@ -145,7 +145,7 @@ lemma zero_lt_pairingIn_iff :
   rw [← B.zero_lt_apply_root_root_iff, ← B.isSymm_posForm.eq, RingHom.id_apply,
     B.zero_lt_apply_root_root_iff]
 
-lemma coxeterWeight_non_neg : 0 ≤ P.coxeterWeightIn S i j := by
+lemma coxeterWeight_nonneg : 0 ≤ P.coxeterWeightIn S i j := by
   dsimp [coxeterWeightIn]
   rcases lt_or_le 0 (P.pairingIn S i j) with h | h
   · exact le_of_lt <| mul_pos h ((zero_lt_pairingIn_iff B i j).mp h)

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -9,7 +9,7 @@ import Mathlib.LinearAlgebra.RootSystem.Defs
 # Root-positive bilinear forms on root pairings
 
 This file contains basic results on Weyl-invariant inner products for root systems and root data.
-We introduce a Prop-valued mixin class for a root pairing and bilinear form, specifying
+Given a root pairing we define a structure which contains a bilinear form together with axioms for
 reflection-invariance, symmetry, and strict positivity on all roots.  We show that root-positive
 forms display the same sign behavior as the canonical pairing between roots and coroots.
 
@@ -17,16 +17,17 @@ Root-positive forms show up naturally as the invariant forms for symmetrizable K
 algebras.  In the finite case, the canonical polarization yields a root-positive form that is
 positive semi-definite on weight space and positive-definite on the span of roots.
 
-## Main definitions:
+## Main definitions / results:
 
- * `IsRootPositive`: A prop-valued mixin class for root pairings with bilinear forms, specifying
-  the form is symmetric, reflection-invariant, and all roots have strictly positive norm.
-
-## Main results:
-
-* `pairing_pos_iff` and `pairing_zero_iff` : sign relations between `P.pairing` and the form `B`.
-* `coxeter_weight_non_neg` : All pairs of roots have non-negative Coxeter weight.
-* `orthogonal_of_coxeter_weight_zero` : If Coxeter weight vanishes, then the roots are orthogonal.
+ * `RootPairing.RootPositiveForm`: Given a root pairing this is a structure which contains a
+   bilinear form together with axioms for reflection-invariance, symmetry, and strict positivity on
+   all roots.
+ * `RootPairing.zero_lt_pairingIn_iff`: sign relations between `RootPairing.pairingIn` and a
+   root-positive form.
+ * `RootPairing.pairing_zero_iff`: symmetric vanishing condition for `RootPairing.pairing`
+ * `RootPairing.coxeterWeight_non_neg`: All pairs of roots have non-negative Coxeter weight.
+ * `RootPairing.coxeterWeight_zero_iff_isOrthogonal` : A Coxeter weight vanishes iff the roots are
+   orthogonal.
 
 ## TODO
 
@@ -36,62 +37,140 @@ positive semi-definite on weight space and positive-definite on the span of root
 
 noncomputable section
 
-variable {ι R M N : Type*}
+open Function Set Submodule
+
+variable {ι R S M N : Type*} [LinearOrderedCommRing S] [CommRing R] [Algebra S R]
+  [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
 
 namespace RootPairing
 
-variable [LinearOrderedCommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
-
-/-- A Prop-valued class for a bilinear form to be compatible with a root pairing. -/
-class IsRootPositive (P : RootPairing ι R M N) (B : M →ₗ[R] M →ₗ[R] R) : Prop where
-  zero_lt_apply_root : ∀ i, 0 < B (P.root i) (P.root i)
-  symm : ∀ x y, B x y = B y x
-  apply_reflection_eq : ∀ i x y, B (P.reflection i x) (P.reflection i y) = B x y
-
-variable {P : RootPairing ι R M N} (B : M →ₗ[R] M →ₗ[R] R) [IsRootPositive P B] (i j : ι)
-include B
-
-lemma two_mul_apply_root_root :
+lemma two_mul_apply_root_root_of_isOrthogonal (P : RootPairing ι R M N)
+    (B : LinearMap.BilinForm R M) (i j : ι) (h : B.IsOrthogonal (P.reflection j)) :
     2 * B (P.root i) (P.root j) = P.pairing i j * B (P.root j) (P.root j) := by
   rw [two_mul, ← eq_sub_iff_add_eq]
-  nth_rw 1 [← IsRootPositive.apply_reflection_eq (P := P) (B := B) j (P.root i) (P.root j)]
+  nth_rw 1 [← h]
   rw [reflection_apply, reflection_apply_self, root_coroot'_eq_pairing, LinearMap.map_sub₂,
     LinearMap.map_smul₂, smul_eq_mul, LinearMap.map_neg, LinearMap.map_neg, mul_neg, neg_sub_neg]
 
+variable (S) in
+/-- Given a root pairing, this is an invariant symmetric bilinear form satisfying a positivity
+condition. -/
+structure RootPositiveForm (P : RootPairing ι R M N) [P.IsValuedIn S] where
+  /-- The bilinear form bundled inside a `RootPositiveForm`. -/
+  form : LinearMap.BilinForm R M
+  symm : form.IsSymm
+  isOrthogonal_reflection (i : ι) : form.IsOrthogonal (P.reflection i)
+  exists_eq (i j : ι) : ∃ s, algebraMap S R s = form (P.root i) (P.root j)
+  exists_pos_eq (i : ι) : ∃ s > 0, algebraMap S R s = form (P.root i) (P.root i)
+
+variable {P : RootPairing ι R M N} [P.IsValuedIn S] (B : P.RootPositiveForm S) (i j : ι)
+
+lemma RootPositiveForm.two_mul_apply_root_root :
+    2 * B.form (P.root i) (P.root j) = P.pairing i j * B.form (P.root j) (P.root j) :=
+  P.two_mul_apply_root_root_of_isOrthogonal B.form i j (B.isOrthogonal_reflection j)
+
+variable [FaithfulSMul S R]
+
+lemma RootPositiveForm.form_apply_root_ne_zero (i : ι) :
+    B.form (P.root i) (P.root i) ≠ 0 := by
+  obtain ⟨s, hs, hs'⟩ := B.exists_pos_eq i
+  simpa [← hs'] using hs.ne'
+
+variable [Module S M] [IsScalarTower S R M]
+
+namespace RootPositiveForm
+
+/-- Given a root-positive form associated to a root pairing with coefficients in `R` but taking
+values in `S`, this is the associated `S`-bilinear form on the `S`-span of the roots. -/
+def posForm :
+    LinearMap.BilinForm S (span S (range P.root)) :=
+  LinearMap.restrictScalarsRange (span S (range P.root)).subtype (span S (range P.root)).subtype
+  (Algebra.linearMap S R) (FaithfulSMul.algebraMap_injective S R) B.form
+  (fun ⟨x, hx⟩ ⟨y, hy⟩ ↦ by
+    apply LinearMap.BilinMap.apply_apply_mem_of_mem_span
+      (s := range P.root) (t := range P.root)
+      (B := (LinearMap.restrictScalarsₗ S R _ _ _).comp (B.form.restrictScalars S))
+    · rintro - ⟨i, rfl⟩ - ⟨j, rfl⟩
+      simpa using B.exists_eq i j
+    · simpa
+    · simpa)
+
+@[simp] lemma algebraMap_posForm {x y : span S (range P.root)} :
+    algebraMap S R (B.posForm x y) = B.form x y := by
+  change Algebra.linearMap S R _ = _
+  simp [posForm]
+
+lemma algebraMap_apply_eq_form_iff {x y : span S (range P.root)} {s : S} :
+    algebraMap S R s = B.form x y ↔ s = B.posForm x y := by
+  simp [RootPositiveForm.posForm]
+
+lemma zero_lt_posForm_iff {x y : span S (range P.root)} :
+    0 < B.posForm x y ↔ ∃ s > 0, algebraMap S R s = B.form x y := by
+  refine ⟨fun h ↦ ⟨B.posForm x y, h, by simp⟩, fun ⟨s, h, h'⟩ ↦ ?_⟩
+  rw [← B.algebraMap_posForm] at h'
+  rwa [← FaithfulSMul.algebraMap_injective S R h']
+
+lemma zero_lt_posForm_apply_root (i : ι)
+    (hi : P.root i ∈ span S (range P.root) := subset_span (mem_range_self i)) :
+    0 < B.posForm ⟨P.root i, hi⟩ ⟨P.root i, hi⟩ := by
+  simpa only [zero_lt_posForm_iff] using B.exists_pos_eq i
+
+lemma isSymm_posForm :
+    B.posForm.IsSymm := by
+  intro x y
+  apply FaithfulSMul.algebraMap_injective S R
+  simpa using B.symm.eq x y
+
 @[simp]
-lemma zero_lt_apply_root_root_iff : 0 < B (P.root i) (P.root j) ↔ 0 < P.pairing i j := by
-  refine ⟨fun h ↦ (mul_pos_iff_of_pos_right
-    (IsRootPositive.zero_lt_apply_root (P := P) (B := B) j)).mp ?_,
-      fun h ↦ (mul_pos_iff_of_pos_left zero_lt_two).mp ?_⟩
-  · rw [← two_mul_apply_root_root]
-    exact mul_pos zero_lt_two h
-  · rw [two_mul_apply_root_root]
-    exact mul_pos h (IsRootPositive.zero_lt_apply_root (P := P) (B := B) j)
+lemma zero_lt_apply_root_root_iff
+    (hi : P.root i ∈ span S (range P.root) := subset_span (mem_range_self i))
+    (hj : P.root j ∈ span S (range P.root) := subset_span (mem_range_self j)) :
+    0 < B.posForm ⟨P.root i, hi⟩ ⟨P.root j, hj⟩ ↔ 0 < P.pairingIn S i j := by
+  let ri : span S (range P.root) := ⟨P.root i, hi⟩
+  let rj : span S (range P.root) := ⟨P.root j, hj⟩
+  have : 2 * B.posForm ri rj = P.pairingIn S i j * B.posForm rj rj := by
+    apply FaithfulSMul.algebraMap_injective S R
+    simpa [map_ofNat] using two_mul_apply_root_root B i j
+  calc  0 < B.posForm ri rj
+      ↔ 0 < 2 * B.posForm ri rj := by rw [mul_pos_iff_of_pos_left zero_lt_two]
+    _ ↔ 0 < P.pairingIn S i j * B.posForm rj rj := by rw [this]
+    _ ↔ 0 < P.pairingIn S i j := by rw [mul_pos_iff_of_pos_right (B.zero_lt_posForm_apply_root j)]
 
-lemma zero_lt_pairing_iff : 0 < P.pairing i j ↔ 0 < P.pairing j i := by
-  rw [← zero_lt_apply_root_root_iff B, IsRootPositive.symm P, zero_lt_apply_root_root_iff]
+end RootPositiveForm
 
-lemma coxeterWeight_non_neg : 0 ≤ P.coxeterWeight i j := by
-  dsimp [coxeterWeight]
-  by_cases h : 0 < P.pairing i j
-  · exact le_of_lt <| mul_pos h ((zero_lt_pairing_iff B i j).mp h)
-  · have hn : ¬ 0 < P.pairing j i := fun hc ↦ h ((zero_lt_pairing_iff B i j).mpr hc)
-    simp_all only [not_lt, ge_iff_le]
+include B
+
+lemma zero_lt_pairingIn_iff :
+    0 < P.pairingIn S i j ↔ 0 < P.pairingIn S j i := by
+  rw [← B.zero_lt_apply_root_root_iff, ← B.isSymm_posForm.eq, RingHom.id_apply,
+    B.zero_lt_apply_root_root_iff]
+
+lemma coxeterWeight_non_neg : 0 ≤ P.coxeterWeightIn S i j := by
+  dsimp [coxeterWeightIn]
+  rcases lt_or_le 0 (P.pairingIn S i j) with h | h
+  · exact le_of_lt <| mul_pos h ((zero_lt_pairingIn_iff B i j).mp h)
+  · have hn : P.pairingIn S j i ≤ 0 := by rwa [← not_lt, ← zero_lt_pairingIn_iff B i j, not_lt]
     exact mul_nonneg_of_nonpos_of_nonpos h hn
 
+variable [NoZeroDivisors R]
+
+omit [Module S M] [IsScalarTower S R M]
+
 @[simp]
-lemma apply_root_root_zero_iff : B (P.root i) (P.root j) = 0 ↔ P.pairing i j = 0 := by
-  refine ⟨fun hB => ?_, fun hP => ?_⟩
-  · have h2 : 2 * (B (P.root i)) (P.root j) = 0 := mul_eq_zero_of_right 2 hB
-    rw [two_mul_apply_root_root] at h2
-    exact eq_zero_of_ne_zero_of_mul_right_eq_zero (IsRootPositive.zero_lt_apply_root j).ne' h2
-  · have h2 : 2 * B (P.root i) (P.root j) = 0 := by rw [two_mul_apply_root_root, hP, zero_mul]
-    exact (mul_eq_zero.mp h2).resolve_left two_ne_zero
+lemma apply_root_root_zero_iff :
+    B.form (P.root i) (P.root j) = 0 ↔ P.pairing i j = 0 := by
+  have _i := Algebra.charZero_of_charZero S R
+  calc B.form (P.root i) (P.root j) = 0
+      ↔ 2 * B.form (P.root i) (P.root j) = 0 := by simp
+    _ ↔ P.pairing i j * B.form (P.root j) (P.root j) = 0 := by rw [B.two_mul_apply_root_root i j]
+    _ ↔ P.pairing i j = 0 := by simp [B.form_apply_root_ne_zero j]
 
-lemma pairing_zero_iff : P.pairing i j = 0 ↔ P.pairing j i = 0 := by
-  rw [← apply_root_root_zero_iff B, IsRootPositive.symm P, apply_root_root_zero_iff B]
+lemma pairing_zero_iff :
+    P.pairing i j = 0 ↔ P.pairing j i = 0 := by
+  rw [← apply_root_root_zero_iff B, ← B.symm.eq, RingHom.id_apply, apply_root_root_zero_iff]
 
-lemma coxeterWeight_zero_iff_isOrthogonal : P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
+lemma coxeterWeight_zero_iff_isOrthogonal :
+    P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
   rw [coxeterWeight, mul_eq_zero]
   refine ⟨fun h => ?_, fun h => Or.inl h.1⟩
   rcases h with h | h


### PR DESCRIPTION
Some of the required changes also allow us to unify (and generalise) the `RootPairing.IsAnisotropic` instances.

The means of obtaining these generalisations is to work with a root pairing with coefficients in `R` taking values in an ordered subring `S` (in the sense of `RootPairing.IsValuedIn`). This allows us to avoid assuming `R` is ordered, and includes the important case of a crystallographic pairing in characteristic zero.

The cost of this is that various definitions and lemmas need to be generalised to allow room for the subring `S` (implemented using an injective `algebra S R` structure). In particular the definition `RootPairing.IsRootPositive` becomes `RootPairing.RootPositiveForm` and has its API substantially reworked.

An alternative approach  to the headline result (taken in the informal literature) is to invoke `RootPairing.restrictScalarsRat` but this only works with field coefficients and does not provide the same unifications.

We also repair some doc strings (which did not have fully-qualified names, or had names which had drifted from the code).

---

- [x] depends on: #21287 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
