### PR TITLE
[Merged by Bors] - doc: fixed notation error in customizing category composition

### DIFF
--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -23,7 +23,7 @@ Introduces notations in the `CategoryTheory` scope
 
 Users may like to add `g ⊚ f` for composition in the standard convention, using
 ```lean
-local notation g ` ⊚ `:80 f:80 := category.comp f g    -- type as \oo
+local notation:80 g " ⊚ " f:80 => CategoryTheory.CategoryStruct.comp f g    -- type as \oo
 ```
 
 ## Porting note


### PR DESCRIPTION
Fixed the notation error on defining customised composition following conventions, which is incorrectly ported from Lean 3.

---

tagging @kim-em (this is the exact duplicate of the previously closed PR #20878 but now on a different branch directly in mathlib4)



[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
