### PR TITLE
[Merged by Bors] - feat: Function.const as a PartialEquiv

### DIFF
--- a/Mathlib/Logic/Equiv/PartialEquiv.lean
+++ b/Mathlib/Logic/Equiv/PartialEquiv.lean
@@ -561,17 +561,17 @@ theorem ofSet_symm (s : Set α) : (PartialEquiv.ofSet s).symm = PartialEquiv.ofS
   rfl
 
 /-- `Function.const` as a `PartialEquiv`.
-  It consists of two constant maps in opposite directions. -/
+It consists of two constant maps in opposite directions. -/
 @[simps]
 def single (a : α) (b : β) : PartialEquiv α β where
   toFun := Function.const α b
   invFun := Function.const β a
   source := {a}
   target := {b}
-  map_source' := fun _ _ ↦ by rfl
-  map_target' := fun _ _ ↦ by rfl
-  left_inv' := fun a' ha'  ↦ by rw [eq_of_mem_singleton ha']; rfl
-  right_inv' := fun b' hb' ↦ by rw [eq_of_mem_singleton hb']; rfl
+  map_source' _ _ := rfl
+  map_target' _ _ := rfl
+  left_inv' a' ha' := by rw [eq_of_mem_singleton ha', const_apply]
+  right_inv' b' hb' := by rw [eq_of_mem_singleton hb', const_apply]
 
 /-- Composing two partial equivs if the target of the first coincides with the source of the
 second. -/

--- a/Mathlib/Logic/Equiv/PartialEquiv.lean
+++ b/Mathlib/Logic/Equiv/PartialEquiv.lean
@@ -560,6 +560,19 @@ theorem ofSet_coe (s : Set α) : (PartialEquiv.ofSet s : α → α) = id :=
 theorem ofSet_symm (s : Set α) : (PartialEquiv.ofSet s).symm = PartialEquiv.ofSet s :=
   rfl
 
+/-- `Function.const` as a `PartialEquiv`.
+  It consists of two constant maps in opposite directions. -/
+@[simps]
+def single {X Y : Type*} (x : X) (y : Y) : PartialEquiv X Y where
+  toFun := Function.const X y
+  invFun := Function.const Y x
+  source := {x}
+  target := {y}
+  map_source' := fun _ _ ↦ by rfl
+  map_target' := fun _ _ ↦ by rfl
+  left_inv' := fun x' x'mem  ↦ by rw [Set.eq_of_mem_singleton x'mem]; rfl
+  right_inv' := fun y' y'mem ↦ by rw [Set.eq_of_mem_singleton y'mem]; rfl
+
 /-- Composing two partial equivs if the target of the first coincides with the source of the
 second. -/
 @[simps]

--- a/Mathlib/Logic/Equiv/PartialEquiv.lean
+++ b/Mathlib/Logic/Equiv/PartialEquiv.lean
@@ -563,15 +563,15 @@ theorem ofSet_symm (s : Set α) : (PartialEquiv.ofSet s).symm = PartialEquiv.ofS
 /-- `Function.const` as a `PartialEquiv`.
   It consists of two constant maps in opposite directions. -/
 @[simps]
-def single {X Y : Type*} (x : X) (y : Y) : PartialEquiv X Y where
-  toFun := Function.const X y
-  invFun := Function.const Y x
-  source := {x}
-  target := {y}
+def single (a : α) (b : β) : PartialEquiv α β where
+  toFun := Function.const α b
+  invFun := Function.const β a
+  source := {a}
+  target := {b}
   map_source' := fun _ _ ↦ by rfl
   map_target' := fun _ _ ↦ by rfl
-  left_inv' := fun x' x'mem  ↦ by rw [Set.eq_of_mem_singleton x'mem]; rfl
-  right_inv' := fun y' y'mem ↦ by rw [Set.eq_of_mem_singleton y'mem]; rfl
+  left_inv' := fun a' ha'  ↦ by rw [eq_of_mem_singleton ha']; rfl
+  right_inv' := fun b' hb' ↦ by rw [eq_of_mem_singleton hb']; rfl
 
 /-- Composing two partial equivs if the target of the first coincides with the source of the
 second. -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
