### PR TITLE
[Merged by Bors] - feat(Algebra): `Pi.single_induction`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Pi.lean
+++ b/Mathlib/Algebra/BigOperators/Pi.lean
@@ -181,3 +181,21 @@ def Pi.monoidHomMulEquiv {ι : Type*} [Fintype ι] [DecidableEq ι] (M : ι → 
       MonoidHom.mul_apply, mul_apply]
 
 end MulEquiv
+
+-- manually additivized to fix variable names
+@[elab_as_elim]
+lemma Pi.single_induction {ι M : Type*} [Finite ι] [DecidableEq ι] [AddCommMonoid M]
+    (p : (ι → M) → Prop) (f : ι → M) (zero : p 0) (add : ∀ f g, p f → p g → p (f + g))
+    (single : ∀ i m, p (Pi.single i m)) : p f := by
+  cases nonempty_fintype ι
+  rw [← Finset.univ_sum_single f]
+  exact Finset.sum_induction _ _ add zero (by simp [single])
+
+set_option linter.existingAttributeWarning false in
+@[elab_as_elim, to_additive existing]
+lemma Pi.mulSingle_induction {ι M : Type*} [Finite ι] [DecidableEq ι] [CommMonoid M]
+    (p : (ι → M) → Prop) (f : ι → M) (one : p 1) (mul : ∀ f g, p f → p g → p (f * g))
+    (mulSingle : ∀ i m, p (Pi.mulSingle i m)) : p f := by
+  cases nonempty_fintype ι
+  rw [← Finset.univ_prod_mulSingle f]
+  exact Finset.prod_induction _ _ mul one (by simp [mulSingle])

--- a/Mathlib/Algebra/BigOperators/Pi.lean
+++ b/Mathlib/Algebra/BigOperators/Pi.lean
@@ -182,19 +182,19 @@ def Pi.monoidHomMulEquiv {ι : Type*} [Fintype ι] [DecidableEq ι] (M : ι → 
 
 end MulEquiv
 
+variable [Finite ι] [DecidableEq ι] {M : Type*}
+
 -- manually additivized to fix variable names
-@[elab_as_elim]
-lemma Pi.single_induction {ι M : Type*} [Finite ι] [DecidableEq ι] [AddCommMonoid M]
-    (p : (ι → M) → Prop) (f : ι → M) (zero : p 0) (add : ∀ f g, p f → p g → p (f + g))
+lemma Pi.single_induction [AddCommMonoid M] (p : (ι → M) → Prop) (f : ι → M)
+    (zero : p 0) (add : ∀ f g, p f → p g → p (f + g))
     (single : ∀ i m, p (Pi.single i m)) : p f := by
   cases nonempty_fintype ι
   rw [← Finset.univ_sum_single f]
   exact Finset.sum_induction _ _ add zero (by simp [single])
 
-set_option linter.existingAttributeWarning false in
-@[elab_as_elim, to_additive existing]
-lemma Pi.mulSingle_induction {ι M : Type*} [Finite ι] [DecidableEq ι] [CommMonoid M]
-    (p : (ι → M) → Prop) (f : ι → M) (one : p 1) (mul : ∀ f g, p f → p g → p (f * g))
+@[to_additive (attr := elab_as_elim) existing]
+lemma Pi.mulSingle_induction [CommMonoid M] (p : (ι → M) → Prop) (f : ι → M)
+    (one : p 1) (mul : ∀ f g, p f → p g → p (f * g))
     (mulSingle : ∀ i m, p (Pi.mulSingle i m)) : p f := by
   cases nonempty_fintype ι
   rw [← Finset.univ_prod_mulSingle f]

--- a/Mathlib/Algebra/BigOperators/Pi.lean
+++ b/Mathlib/Algebra/BigOperators/Pi.lean
@@ -183,6 +183,7 @@ def Pi.monoidHomMulEquiv {ι : Type*} [Fintype ι] [DecidableEq ι] (M : ι → 
 end MulEquiv
 
 -- manually additivized to fix variable names
+-- See https://github.com/leanprover-community/mathlib4/issues/11462
 @[elab_as_elim]
 lemma Pi.single_induction {ι M : Type*} [Finite ι] [DecidableEq ι] [AddCommMonoid M]
     (p : (ι → M) → Prop) (f : ι → M) (zero : p 0) (add : ∀ f g, p f → p g → p (f + g))


### PR DESCRIPTION
From "Formalizing the Bruhat-Tits tree"
Co-authored-by: Judith Ludwig <ludwig@mathi.uni-heidelberg.de>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
