### PR TITLE
[Merged by Bors] - feat(Matrix): more lemmas for `PEquiv.toMatrix`

### DIFF
--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -49,6 +49,17 @@ theorem stdBasisMatrix_zero (i : m) (j : n) : stdBasisMatrix i j (0 : α) = 0 :=
   ext
   simp
 
+@[simp]
+lemma transpose_stdBasisMatrix (i : m) (j : n) (a : α) :
+    (stdBasisMatrix i j a)ᵀ = stdBasisMatrix j i a := by
+  aesop (add unsafe unfold stdBasisMatrix)
+
+@[simp]
+lemma map_stdBasisMatrix (i : m) (j : n) (a : α) {β : Type*} [Zero β]
+    {F : Type*} [FunLike F α β] [ZeroHomClass F α β] (f : F) :
+    (stdBasisMatrix i j a).map f = stdBasisMatrix i j (f a) := by
+  aesop (add unsafe unfold stdBasisMatrix)
+
 end Zero
 
 theorem stdBasisMatrix_add [AddZeroClass α] (i : m) (j : n) (a b : α) :

--- a/Mathlib/Data/Matrix/ConjTranspose.lean
+++ b/Mathlib/Data/Matrix/ConjTranspose.lean
@@ -11,6 +11,7 @@ import Mathlib.Algebra.Star.BigOperators
 import Mathlib.Algebra.Star.Module
 import Mathlib.Algebra.Star.Pi
 import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Data.Matrix.Basis
 import Mathlib.Data.Matrix.Mul
 
 /-!
@@ -39,6 +40,13 @@ def conjTranspose [Star α] (M : Matrix m n α) : Matrix n m α :=
 
 @[inherit_doc]
 scoped postfix:1024 "ᴴ" => Matrix.conjTranspose
+
+@[simp]
+lemma conjTranspose_stdBasisMatrix [DecidableEq n] [DecidableEq m] [AddMonoid α]
+    [StarAddMonoid α] (i : m) (j : n) (a : α) :
+    (stdBasisMatrix i j a)ᴴ = stdBasisMatrix j i (star a) := by
+  show (stdBasisMatrix i j a).transpose.map starAddEquiv = stdBasisMatrix j i (star a)
+  simp
 
 section Diagonal
 

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -789,14 +789,14 @@ theorem one_vecMul [Fintype m] (A : Matrix m n α) : 1 ᵥ* A = ∑ i, A i := by
 
 @[deprecated (since := "2025-01-26")] alias vec_one_mul := one_vecMul
 
-lemma ext_of_mulVec [DecidableEq n] [Fintype n] {M N : Matrix m n α}
+lemma ext_of_mulVec_single [DecidableEq n] [Fintype n] {M N : Matrix m n α}
     (h : ∀ i, M *ᵥ Pi.single i 1 = N *ᵥ Pi.single i 1) :
     M = N := by
   ext i j
   simp_rw [mulVec_single_one] at h
   exact congrFun (h j) i
 
-lemma ext_of_vecMul [DecidableEq m] [Fintype m] {M N : Matrix m n α}
+lemma ext_of_single_vecMul [DecidableEq m] [Fintype m] {M N : Matrix m n α}
     (h : ∀ i, Pi.single i 1 ᵥ* M = Pi.single i 1 ᵥ* N) :
     M = N := by
   ext i j

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -789,7 +789,21 @@ theorem one_vecMul [Fintype m] (A : Matrix m n α) : 1 ᵥ* A = ∑ i, A i := by
 
 @[deprecated (since := "2025-01-26")] alias vec_one_mul := one_vecMul
 
-variable [Fintype m] [Fintype n] [DecidableEq m]
+variable [Fintype m] [DecidableEq m]
+
+lemma ext_of_mulVec {M N : Matrix n m α} (h : ∀ i, M *ᵥ Pi.single i 1 = N *ᵥ Pi.single i 1) :
+    M = N := by
+  ext i j
+  simp_rw [mulVec_single_one] at h
+  exact congrFun (h j) i
+
+lemma ext_of_vecMul {M N : Matrix m n α} (h : ∀ i, Pi.single i 1 ᵥ* M = Pi.single i 1 ᵥ* N) :
+    M = N := by
+  ext i j
+  simp_rw [single_one_vecMul] at h
+  exact congrFun (h i) j
+
+variable [Fintype n]
 
 @[simp]
 theorem one_mulVec (v : m → α) : 1 *ᵥ v = v := by

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -789,21 +789,21 @@ theorem one_vecMul [Fintype m] (A : Matrix m n α) : 1 ᵥ* A = ∑ i, A i := by
 
 @[deprecated (since := "2025-01-26")] alias vec_one_mul := one_vecMul
 
-variable [Fintype m] [DecidableEq m]
-
-lemma ext_of_mulVec {M N : Matrix n m α} (h : ∀ i, M *ᵥ Pi.single i 1 = N *ᵥ Pi.single i 1) :
+lemma ext_of_mulVec [DecidableEq n] [Fintype n] {M N : Matrix m n α}
+    (h : ∀ i, M *ᵥ Pi.single i 1 = N *ᵥ Pi.single i 1) :
     M = N := by
   ext i j
   simp_rw [mulVec_single_one] at h
   exact congrFun (h j) i
 
-lemma ext_of_vecMul {M N : Matrix m n α} (h : ∀ i, Pi.single i 1 ᵥ* M = Pi.single i 1 ᵥ* N) :
+lemma ext_of_vecMul [DecidableEq m] [Fintype m] {M N : Matrix m n α}
+    (h : ∀ i, Pi.single i 1 ᵥ* M = Pi.single i 1 ᵥ* N) :
     M = N := by
   ext i j
   simp_rw [single_one_vecMul] at h
   exact congrFun (h i) j
 
-variable [Fintype n]
+variable [Fintype m] [Fintype n] [DecidableEq m]
 
 @[simp]
 theorem one_mulVec (v : m → α) : 1 *ᵥ v = v := by

--- a/Mathlib/Data/Matrix/PEquiv.lean
+++ b/Mathlib/Data/Matrix/PEquiv.lean
@@ -103,16 +103,16 @@ theorem transpose_toMatrix_toPEquiv_apply
   simp [toMatrix_apply, Pi.single_apply, eq_comm, ← Equiv.apply_eq_iff_eq_symm_apply]
 
 theorem toMatrix_toPEquiv_mul [Fintype m] [DecidableEq m]
-    [Semiring α] (f : n ≃ m) (M : Matrix m n α) :
+    [Semiring α] (f : l ≃ m) (M : Matrix m n α) :
     f.toPEquiv.toMatrix * M = M.submatrix f id := by
   ext i j
   rw [toMatrix_mul_apply, Equiv.toPEquiv_apply, submatrix_apply, id]
 
 @[deprecated (since := "2025-01-27")] alias toPEquiv_mul_matrix := toMatrix_toPEquiv_mul
 
-theorem mul_toMatrix_toPEquiv [Fintype n] [DecidableEq m]
-    [Semiring α] (f : n ≃ m) (M : Matrix m n α) :
-    M * f.toPEquiv.toMatrix = M.submatrix id f.symm :=
+theorem mul_toMatrix_toPEquiv [Fintype m] [DecidableEq n]
+    [Semiring α] (M : Matrix l m α) (f : m ≃ n):
+    (M * f.toPEquiv.toMatrix) = M.submatrix id f.symm :=
   Matrix.ext fun i j => by
     rw [PEquiv.mul_toMatrix_apply, ← Equiv.toPEquiv_symm, Equiv.toPEquiv_apply,
       Matrix.submatrix_apply, id]

--- a/Mathlib/Data/Matrix/PEquiv.lean
+++ b/Mathlib/Data/Matrix/PEquiv.lean
@@ -102,32 +102,35 @@ theorem transpose_toMatrix_toPEquiv_apply
   ext
   simp [toMatrix_apply, Pi.single_apply, eq_comm, ← Equiv.apply_eq_iff_eq_symm_apply]
 
-theorem toMatrix_toPEquiv_mul [Fintype m] [DecidableEq m] [Semiring α] (f : m ≃ m)
-    (M : Matrix m n α) : f.toPEquiv.toMatrix * M = M.submatrix f id := by
+theorem toMatrix_toPEquiv_mul [Fintype m] [DecidableEq m]
+    [Semiring α] (f : n ≃ m) (M : Matrix m n α) :
+    f.toPEquiv.toMatrix * M = M.submatrix f id := by
   ext i j
   rw [toMatrix_mul_apply, Equiv.toPEquiv_apply, submatrix_apply, id]
 
 @[deprecated (since := "2025-01-27")] alias toPEquiv_mul_matrix := toMatrix_toPEquiv_mul
 
-theorem mul_toMatrix_toPEquiv {m n α : Type*} [Fintype n] [DecidableEq n] [Semiring α] (f : n ≃ n)
-    (M : Matrix m n α) : M * f.toPEquiv.toMatrix = M.submatrix id f.symm :=
+theorem mul_toMatrix_toPEquiv [Fintype n] [DecidableEq m]
+    [Semiring α] (f : n ≃ m) (M : Matrix m n α) :
+    M * f.toPEquiv.toMatrix = M.submatrix id f.symm :=
   Matrix.ext fun i j => by
     rw [PEquiv.mul_toMatrix_apply, ← Equiv.toPEquiv_symm, Equiv.toPEquiv_apply,
       Matrix.submatrix_apply, id]
 
 @[deprecated (since := "2025-01-27")] alias mul_toPEquiv_toMatrix := mul_toMatrix_toPEquiv
 
-lemma toMatrix_toPEquiv_mulVec_single [DecidableEq n] [DecidableEq m] [Fintype n]
-    [NonAssocSemiring α] (σ : m ≃ n) (i : n) (x : α) :
-    σ.toPEquiv.toMatrix *ᵥ Pi.single i x = Pi.single (σ.symm i) x := by
+lemma toMatrix_toPEquiv_mulVec [DecidableEq n] [Fintype n]
+    [NonAssocSemiring α] (σ : m ≃ n) (a : n → α) :
+    σ.toPEquiv.toMatrix *ᵥ a = a ∘ σ := by
   ext j
-  simp [Pi.single_apply, Equiv.apply_eq_iff_eq_symm_apply σ]
+  simp [toMatrix, mulVec, dotProduct]
 
-lemma single_vecMul_toMatrix_toPEquiv [DecidableEq n] [DecidableEq m] [Fintype m]
-    [NonAssocSemiring α] (σ : m ≃ n) (i : m) (x : α) :
-    Pi.single i x ᵥ* σ.toPEquiv.toMatrix = Pi.single (σ i) x := by
+lemma vecMul_toMatrix_toPEquiv [DecidableEq n] [Fintype m]
+    [NonAssocSemiring α] (σ : m ≃ n) (a : m → α) :
+    a ᵥ* σ.toPEquiv.toMatrix = a ∘ σ.symm := by
+  classical
   ext j
-  simp [Pi.single_apply]
+  simp [toMatrix, σ.apply_eq_iff_eq_symm_apply, vecMul, dotProduct]
 
 theorem toMatrix_trans [Fintype m] [DecidableEq m] [DecidableEq n] [Semiring α] (f : l ≃. m)
     (g : m ≃. n) : ((f.trans g).toMatrix : Matrix l n α) = f.toMatrix * g.toMatrix := by

--- a/Mathlib/Data/Matrix/PEquiv.lean
+++ b/Mathlib/Data/Matrix/PEquiv.lean
@@ -178,4 +178,34 @@ theorem toMatrix_toPEquiv_eq [DecidableEq n] [Zero α] [One α] (σ : Equiv.Perm
 
 @[deprecated (since := "2025-01-27")] alias equiv_toPEquiv_toMatrix := toMatrix_toPEquiv_eq
 
+@[simp]
+lemma map_toMatrix {β : Type*} [DecidableEq n] [NonAssocSemiring α] [NonAssocSemiring β]
+    (f : α →+* β) (σ : m ≃. n) : σ.toMatrix.map f = σ.toMatrix := by
+  ext i j
+  simp
+
 end PEquiv
+
+namespace Equiv
+
+open Matrix
+
+variable {α m n : Type*} [DecidableEq m] [DecidableEq n]
+
+lemma toMatrix_toPEquiv_mulVec_single [Fintype n] [NonAssocSemiring α] (σ : m ≃ n) (i : n) (x : α) :
+    σ.toPEquiv.toMatrix *ᵥ Pi.single i x = Pi.single (σ.symm i) x := by
+  ext j
+  simp [Pi.single_apply, Equiv.apply_eq_iff_eq_symm_apply σ]
+
+lemma single_vecMul_toMatrix_toPEquiv [Fintype m] [NonAssocSemiring α] (σ : m ≃ n) (i : m) (x : α) :
+    Pi.single i x ᵥ* σ.toPEquiv.toMatrix = Pi.single (σ i) x := by
+  ext j
+  simp [Pi.single_apply]
+
+@[simp]
+lemma toMatrix_toPEquiv_mul_toMatrix_toPEquiv_symm [Fintype m] [Semiring α] (σ : m ≃ m) :
+    σ.toPEquiv.toMatrix (α := α) * σ.symm.toPEquiv.toMatrix = 1 := by
+  rw [← PEquiv.toMatrix_trans, ← Equiv.toPEquiv_trans, Equiv.self_trans_symm, Equiv.toPEquiv_refl,
+    PEquiv.toMatrix_refl]
+
+end Equiv

--- a/Mathlib/Data/Matrix/PEquiv.lean
+++ b/Mathlib/Data/Matrix/PEquiv.lean
@@ -40,7 +40,7 @@ open Matrix
 universe u v
 
 variable {k l m n : Type*}
-variable {α : Type v}
+variable {α β : Type*}
 
 open Matrix
 
@@ -117,6 +117,18 @@ theorem mul_toMatrix_toPEquiv {m n α : Type*} [Fintype n] [DecidableEq n] [Semi
 
 @[deprecated (since := "2025-01-27")] alias mul_toPEquiv_toMatrix := mul_toMatrix_toPEquiv
 
+lemma toMatrix_toPEquiv_mulVec_single [DecidableEq n] [DecidableEq m] [Fintype n]
+    [NonAssocSemiring α] (σ : m ≃ n) (i : n) (x : α) :
+    σ.toPEquiv.toMatrix *ᵥ Pi.single i x = Pi.single (σ.symm i) x := by
+  ext j
+  simp [Pi.single_apply, Equiv.apply_eq_iff_eq_symm_apply σ]
+
+lemma single_vecMul_toMatrix_toPEquiv [DecidableEq n] [DecidableEq m] [Fintype m]
+    [NonAssocSemiring α] (σ : m ≃ n) (i : m) (x : α) :
+    Pi.single i x ᵥ* σ.toPEquiv.toMatrix = Pi.single (σ i) x := by
+  ext j
+  simp [Pi.single_apply]
+
 theorem toMatrix_trans [Fintype m] [DecidableEq m] [DecidableEq n] [Semiring α] (f : l ≃. m)
     (g : m ≃. n) : ((f.trans g).toMatrix : Matrix l n α) = f.toMatrix * g.toMatrix := by
   ext i j
@@ -179,27 +191,9 @@ theorem toMatrix_toPEquiv_eq [DecidableEq n] [Zero α] [One α] (σ : Equiv.Perm
 @[deprecated (since := "2025-01-27")] alias equiv_toPEquiv_toMatrix := toMatrix_toPEquiv_eq
 
 @[simp]
-lemma map_toMatrix {β : Type*} [DecidableEq n] [NonAssocSemiring α] [NonAssocSemiring β]
+lemma map_toMatrix [DecidableEq n] [NonAssocSemiring α] [NonAssocSemiring β]
     (f : α →+* β) (σ : m ≃. n) : σ.toMatrix.map f = σ.toMatrix := by
   ext i j
   simp
 
 end PEquiv
-
-namespace Equiv
-
-open Matrix
-
-variable {α m n : Type*} [DecidableEq m] [DecidableEq n]
-
-lemma toMatrix_toPEquiv_mulVec_single [Fintype n] [NonAssocSemiring α] (σ : m ≃ n) (i : n) (x : α) :
-    σ.toPEquiv.toMatrix *ᵥ Pi.single i x = Pi.single (σ.symm i) x := by
-  ext j
-  simp [Pi.single_apply, Equiv.apply_eq_iff_eq_symm_apply σ]
-
-lemma single_vecMul_toMatrix_toPEquiv [Fintype m] [NonAssocSemiring α] (σ : m ≃ n) (i : m) (x : α) :
-    Pi.single i x ᵥ* σ.toPEquiv.toMatrix = Pi.single (σ i) x := by
-  ext j
-  simp [Pi.single_apply]
-
-end Equiv

--- a/Mathlib/Data/Matrix/PEquiv.lean
+++ b/Mathlib/Data/Matrix/PEquiv.lean
@@ -111,7 +111,7 @@ theorem toMatrix_toPEquiv_mul [Fintype m] [DecidableEq m]
 @[deprecated (since := "2025-01-27")] alias toPEquiv_mul_matrix := toMatrix_toPEquiv_mul
 
 theorem mul_toMatrix_toPEquiv [Fintype m] [DecidableEq n]
-    [Semiring α] (M : Matrix l m α) (f : m ≃ n):
+    [Semiring α] (M : Matrix l m α) (f : m ≃ n) :
     (M * f.toPEquiv.toMatrix) = M.submatrix id f.symm :=
   Matrix.ext fun i j => by
     rw [PEquiv.mul_toMatrix_apply, ← Equiv.toPEquiv_symm, Equiv.toPEquiv_apply,

--- a/Mathlib/Data/Matrix/PEquiv.lean
+++ b/Mathlib/Data/Matrix/PEquiv.lean
@@ -202,10 +202,4 @@ lemma single_vecMul_toMatrix_toPEquiv [Fintype m] [NonAssocSemiring α] (σ : m 
   ext j
   simp [Pi.single_apply]
 
-@[simp]
-lemma toMatrix_toPEquiv_mul_toMatrix_toPEquiv_symm [Fintype m] [Semiring α] (σ : m ≃ m) :
-    σ.toPEquiv.toMatrix (α := α) * σ.symm.toPEquiv.toMatrix = 1 := by
-  rw [← PEquiv.toMatrix_trans, ← Equiv.toPEquiv_trans, Equiv.self_trans_symm, Equiv.toPEquiv_refl,
-    PEquiv.toMatrix_refl]
-
 end Equiv

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -130,6 +130,7 @@ end CoeLemmas
 variable {S T : Type*} [CommRing S] [CommRing T]
 
 /-- A ring homomorphism ``f : R →+* S`` induces a homomorphism ``GLₙ(f) : GLₙ(R) →* GLₙ(S)``. -/
+@[simps! apply_val]
 def map (f : R →+* S) : GL n R →* GL n S := Units.map <| (RingHom.mapMatrix f).toMonoidHom
 
 @[simp]


### PR DESCRIPTION
Also

- add `Matrix.transpose_stdBasisMatrix` and `conjTranspose` version
- add `Matrix.ext_ofMulVec`
- tag `Matrix.GeneralLinearGroup.map` with `@[simps]`

From "Formalizing the Bruhat-Tits tree"
Co-authored by: Judith Ludwig <ludwig@mathi.uni-heidelberg.de>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
