### PR TITLE
[Merged by Bors] - fix(CI): use `Elab.async=false` for late importers workflow

### DIFF
--- a/.github/workflows/latest_import.yml
+++ b/.github/workflows/latest_import.yml
@@ -50,9 +50,9 @@ jobs:
       run: |
         # shellcheck complains if there are two backticks inside single quotes :(
         # set `linter.minImports option` to true in `lakefile`
-        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨\`linter.minImports, true⟩,\n=}' lakefile.lean
+        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨`linter.minImports, true⟩,\n=}' lakefile.lean
         # set `Elab.async` to false in `lakefile`
-        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨\`Elab.async, false⟩,\n=}' lakefile.lean
+        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨`Elab.async, false⟩,\n=}' lakefile.lean
 
         # import the `minImports` linter in `Mathlib.Init`
         sed -i -z 's=^=import Mathlib.Tactic.Linter.MinImports\n=' Mathlib/Init.lean

--- a/.github/workflows/latest_import.yml
+++ b/.github/workflows/latest_import.yml
@@ -48,8 +48,8 @@ jobs:
 
     - name: add minImports linter option
       run: |
-        # set `linter.minImports option` to true and `Leab.async` to false in `lakefile`
-        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨`linter.minImports, true⟩,\n  ⟨`Elab.async, false⟩,\n=}' lakefile.lean
+        # set `linter.minImports option` to true and `Elab.async` to false in `lakefile`
+        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨\`linter.minImports, true⟩,\n  ⟨\`Elab.async, false⟩,\n=}' lakefile.lean
 
         # import the `minImports` linter in `Mathlib.Init`
         sed -i -z 's=^=import Mathlib.Tactic.Linter.MinImports\n=' Mathlib/Init.lean

--- a/.github/workflows/latest_import.yml
+++ b/.github/workflows/latest_import.yml
@@ -48,11 +48,10 @@ jobs:
 
     - name: add minImports linter option
       run: |
-        # shellcheck complains if there are two backticks inside single quotes :(
-        # set `linter.minImports option` to true in `lakefile`
-        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨`linter.minImports, true⟩,\n=}' lakefile.lean
-        # set `Elab.async` to false in `lakefile`
-        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨`Elab.async, false⟩,\n=}' lakefile.lean
+        # we disable checking for backticks inside single quotes with the next line
+        # shellcheck disable=SC2016
+        # set `linter.minImports option` to true and `Elab.async` to false in `lakefile`
+        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨`linter.minImports, true⟩,\n  ⟨`Elab.async, false⟩,\n=}' lakefile.lean
 
         # import the `minImports` linter in `Mathlib.Init`
         sed -i -z 's=^=import Mathlib.Tactic.Linter.MinImports\n=' Mathlib/Init.lean

--- a/.github/workflows/latest_import.yml
+++ b/.github/workflows/latest_import.yml
@@ -48,8 +48,8 @@ jobs:
 
     - name: add minImports linter option
       run: |
-        # set `linter.minImports option` to true in `lakefile`
-        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨`linter.minImports, true⟩,\n=}' lakefile.lean
+        # set `linter.minImports option` to true and `Leab.async` to false in `lakefile`
+        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨`linter.minImports, true⟩,\n  ⟨`Elab.async, false⟩,\n=}' lakefile.lean
 
         # import the `minImports` linter in `Mathlib.Init`
         sed -i -z 's=^=import Mathlib.Tactic.Linter.MinImports\n=' Mathlib/Init.lean

--- a/.github/workflows/latest_import.yml
+++ b/.github/workflows/latest_import.yml
@@ -48,8 +48,11 @@ jobs:
 
     - name: add minImports linter option
       run: |
-        # set `linter.minImports option` to true and `Elab.async` to false in `lakefile`
-        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨\`linter.minImports, true⟩,\n  ⟨\`Elab.async, false⟩,\n=}' lakefile.lean
+        # shellcheck complains if there are two backticks inside single quotes :(
+        # set `linter.minImports option` to true in `lakefile`
+        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨\`linter.minImports, true⟩,\n=}' lakefile.lean
+        # set `Elab.async` to false in `lakefile`
+        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨\`Elab.async, false⟩,\n=}' lakefile.lean
 
         # import the `minImports` linter in `Mathlib.Init`
         sed -i -z 's=^=import Mathlib.Tactic.Linter.MinImports\n=' Mathlib/Init.lean


### PR DESCRIPTION
Spotted in [this Zulip message](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Late.20importers.20report/near/496179935).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
