### PR TITLE
[Merged by Bors] - chore(Data/Matroid/Rank/Cardinal): docstring typo 

### DIFF
--- a/Mathlib/Data/Matroid/Rank/Cardinal.lean
+++ b/Mathlib/Data/Matroid/Rank/Cardinal.lean
@@ -178,7 +178,7 @@ section Invariant
 
 /-- A class stating that cardinality-valued rank is well-defined
 (i.e. all bases are equicardinal) for a matroid `M` and its minors.
-Notably, this holds for `Finitary` matroids; see `Matroid.invarCardinalRank_of_finitary`.  -/
+Notably, this holds for `Finitary` matroids; see `Matroid.invariantCardinalRank_of_finitary`.  -/
 @[mk_iff]
 class InvariantCardinalRank (M : Matroid α) : Prop where
   forall_card_basis_diff :


### PR DESCRIPTION
Fixes a wrong lemma reference in a docstring. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
