### PR TITLE
[Merged by Bors] - feat(DiscreteValuationRing): addVal_eq_zero_iff

### DIFF
--- a/Mathlib/Algebra/Group/Commute/Units.lean
+++ b/Mathlib/Algebra/Group/Commute/Units.lean
@@ -97,6 +97,11 @@ def Units.ofPow (u : Mˣ) (x : M) {n : ℕ} (hn : n ≠ 0) (hu : x ^ n = u) : M�
 @[to_additive]
 lemma isUnit_pow_succ_iff : IsUnit (a ^ (n + 1)) ↔ IsUnit a := isUnit_pow_iff n.succ_ne_zero
 
+lemma isUnit_pow_iff_of_not_isUnit (hx : ¬ IsUnit a) {n : ℕ} :
+    IsUnit (a ^ n) ↔ n = 0 := by
+  rcases n with (_|n) <;>
+  simp [hx]
+
 /-- If `a ^ n = 1`, `n ≠ 0`, then `a` is a unit. -/
 @[to_additive (attr := simps!) "If `n • x = 0`, `n ≠ 0`, then `x` is an additive unit."]
 def Units.ofPowEqOne (a : M) (n : ℕ) (ha : a ^ n = 1) (hn : n ≠ 0) : Mˣ := Units.ofPow 1 a hn ha

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -452,7 +452,7 @@ theorem addVal_add {a b : R} : min (addVal R a) (addVal R b) ≤ addVal R (a + b
   (addVal R).map_add _ _
 
 @[simp]
-lemma addVal_val_unit (u : Rˣ) :
+lemma addVal_eq_zero_of_unit (u : Rˣ) :
     addVal R u = 0 := by
   obtain ⟨ϖ, hϖ⟩ := exists_irreducible R
   rw [addVal_def (u : R) u hϖ 0] <;>

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -451,6 +451,21 @@ theorem addVal_le_iff_dvd {a b : R} : addVal R a ≤ addVal R b ↔ a ∣ b := b
 theorem addVal_add {a b : R} : min (addVal R a) (addVal R b) ≤ addVal R (a + b) :=
   (addVal R).map_add _ _
 
+@[simp]
+lemma addVal_val_unit (u : Rˣ) :
+    addVal R u = 0 := by
+  obtain ⟨ϖ, hϖ⟩ := exists_irreducible R
+  rw [addVal_def (u : R) u hϖ 0] <;>
+  simp
+
+lemma addVal_eq_zero_iff {x : R} :
+    addVal R x = 0 ↔ IsUnit x := by
+  rcases eq_or_ne x 0 with rfl|hx
+  · simp
+  obtain ⟨ϖ, hϖ⟩ := exists_irreducible R
+  obtain ⟨n, u, rfl⟩ := eq_unit_mul_pow_irreducible hx hϖ
+  simp [hϖ.unit_pow_iff, hϖ]
+
 end
 
 instance (R : Type*) [CommRing R] [IsDomain R] [IsDiscreteValuationRing R] :

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -464,7 +464,7 @@ lemma addVal_eq_zero_iff {x : R} :
   · simp
   obtain ⟨ϖ, hϖ⟩ := exists_irreducible R
   obtain ⟨n, u, rfl⟩ := eq_unit_mul_pow_irreducible hx hϖ
-  simp [hϖ.unit_pow_iff, hϖ]
+  simp [isUnit_pow_iff_of_not_isUnit hϖ.not_unit, hϖ]
 
 end
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Defs.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Defs.lean
@@ -197,3 +197,8 @@ theorem irreducible_of_factor {a : α} : ∀ x : α, x ∈ factors a → Irreduc
   (prime_of_factor x h).irreducible
 
 end UniqueFactorizationMonoid
+
+lemma Irreducible.unit_pow_iff {M : Type*} [Monoid M] {x : M} (hx : Irreducible x) {n : ℕ} :
+    IsUnit (x ^ n) ↔ n = 0 := by
+  rcases n with (_|n) <;>
+  simp [hx.not_unit]

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Defs.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Defs.lean
@@ -197,8 +197,3 @@ theorem irreducible_of_factor {a : α} : ∀ x : α, x ∈ factors a → Irreduc
   (prime_of_factor x h).irreducible
 
 end UniqueFactorizationMonoid
-
-lemma Irreducible.unit_pow_iff {M : Type*} [Monoid M] {x : M} (hx : Irreducible x) {n : ℕ} :
-    IsUnit (x ^ n) ↔ n = 0 := by
-  rcases n with (_|n) <;>
-  simp [hx.not_unit]


### PR DESCRIPTION
with helpers `addVal_val_unit` and `Irreducible.unit_pow_iff`

Unclear where to place `Irreducible.unit_pow_iff`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
