### PR TITLE
feat(SetTheory/Game/Birthday): use `proof_wanted` to state open problem

### DIFF
--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -266,8 +266,8 @@ theorem birthday_sub_le (x y : Game) : (x - y).birthday ≤ x.birthday ♯ y.bir
   apply (birthday_add_le x _).trans_eq
   rw [birthday_neg]
 
-/- The bound `(x * y).birthday ≤ x.birthday ⨳ y.birthday` is currently an open problem. See
-  https://mathoverflow.net/a/476829/147705. -/
+/-- This bound is currently an open problem. See https://mathoverflow.net/a/476829/147705. -/
+proof_wanted birthday_mul_le (x y : PGame) : birthday ⟦x * y⟧ ≤ birthday ⟦x⟧ ⨳ birthday ⟦y⟧
 
 /-- Games with bounded birthday are a small set. -/
 theorem small_setOf_birthday_lt (o : Ordinal) : Small.{u} {x : Game.{u} // birthday x < o} := by


### PR DESCRIPTION
See discussion on [Zulip](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Documenting.20open.20problems).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
