### PR TITLE
[Merged by Bors] - feat: generalise `TopologicalGroup.isInducing_if_nhds_one` to `MonoidHomClass`

### DIFF
--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -811,12 +811,16 @@ theorem continuous_of_continuousAt_one₂ {H M : Type*} [CommMonoid M] [Topologi
     (((hl x).comp tendsto_snd).mul hf)).mono_right (le_of_eq ?_)
   simp only [map_one, mul_one, MonoidHom.one_apply]
 
+variable {H : Type*} [Group H] [TopologicalSpace H] [TopologicalGroup H] {F : Type*}
+    [FunLike F G H] {f : MonoidHomClass F G H}
+
 @[to_additive]
 lemma TopologicalGroup.isInducing_iff_nhds_one
-    {H : Type*} [Group H] [TopologicalSpace H] [TopologicalGroup H] {f : G →* H} :
+    {H : Type*} [Group H] [TopologicalSpace H] [TopologicalGroup H] {F : Type*}
+    [FunLike F G H] [MonoidHomClass F G H] {f : F} :
     Topology.IsInducing f ↔ 𝓝 (1 : G) = (𝓝 (1 : H)).comap f := by
   rw [Topology.isInducing_iff_nhds]
-  refine ⟨(f.map_one ▸ · 1), fun hf x ↦ ?_⟩
+  refine ⟨(map_one f ▸ · 1), fun hf x ↦ ?_⟩
   rw [← nhds_translation_mul_inv, ← nhds_translation_mul_inv (f x), Filter.comap_comap, hf,
     Filter.comap_comap]
   congr 1

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -811,9 +811,6 @@ theorem continuous_of_continuousAt_one₂ {H M : Type*} [CommMonoid M] [Topologi
     (((hl x).comp tendsto_snd).mul hf)).mono_right (le_of_eq ?_)
   simp only [map_one, mul_one, MonoidHom.one_apply]
 
-variable {H : Type*} [Group H] [TopologicalSpace H] [TopologicalGroup H] {F : Type*}
-    [FunLike F G H] {f : MonoidHomClass F G H}
-
 @[to_additive]
 lemma TopologicalGroup.isInducing_iff_nhds_one
     {H : Type*} [Group H] [TopologicalSpace H] [TopologicalGroup H] {F : Type*}

--- a/Mathlib/Topology/Algebra/Ring/Basic.lean
+++ b/Mathlib/Topology/Algebra/Ring/Basic.lean
@@ -254,6 +254,12 @@ theorem TopologicalRing.of_nhds_zero
   have := TopologicalAddGroup.of_comm_of_nhds_zero hadd hneg hleft
   TopologicalRing.of_addGroup_of_nhds_zero hmul hmul_left hmul_right
 
+theorem TopologicalRing.isInducing_iff_nhds_zero {G H : Type*} [Ring G] [TopologicalSpace G]
+    [Ring H] [TopologicalRing G] [TopologicalSpace H] [TopologicalRing H] (f : G →+* H) :
+    IsInducing f ↔ nhds 0 = Filter.comap f (nhds 0) := by
+  rw [← AddMonoidHom.coe_coe, ← RingHom.toAddMonoidHom_eq_coe]
+  exact TopologicalAddGroup.isInducing_iff_nhds_zero
+
 end
 
 variable [TopologicalSpace α]

--- a/Mathlib/Topology/Algebra/Ring/Basic.lean
+++ b/Mathlib/Topology/Algebra/Ring/Basic.lean
@@ -254,12 +254,6 @@ theorem TopologicalRing.of_nhds_zero
   have := TopologicalAddGroup.of_comm_of_nhds_zero hadd hneg hleft
   TopologicalRing.of_addGroup_of_nhds_zero hmul hmul_left hmul_right
 
-theorem TopologicalRing.isInducing_iff_nhds_zero {G H : Type*} [Ring G] [TopologicalSpace G]
-    [Ring H] [TopologicalRing G] [TopologicalSpace H] [TopologicalRing H] (f : G →+* H) :
-    IsInducing f ↔ nhds 0 = Filter.comap f (nhds 0) := by
-  rw [← AddMonoidHom.coe_coe, ← RingHom.toAddMonoidHom_eq_coe]
-  exact TopologicalAddGroup.isInducing_iff_nhds_zero
-
 end
 
 variable [TopologicalSpace α]


### PR DESCRIPTION
This allows direct application of `TopologicalAddGroup.isInducing_iff_nhds_zero` to `TopologicalRing` and ring homs. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
