### PR TITLE
[Merged by Bors] - feat: add `WithZero.units_val_eq_coe_unitsWithZeroEquiv` 

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johan Commelin
 -/
 import Mathlib.Algebra.Group.WithOne.Defs
-import Mathlib.Algebra.Group.TypeTags.Basic
 import Mathlib.Algebra.GroupWithZero.Hom
 import Mathlib.Algebra.GroupWithZero.Units.Basic
 import Mathlib.Data.Nat.Cast.Defs

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johan Commelin
 -/
 import Mathlib.Algebra.Group.WithOne.Defs
+import Mathlib.Algebra.Group.TypeTags.Basic
 import Mathlib.Algebra.GroupWithZero.Hom
 import Mathlib.Algebra.GroupWithZero.Units.Basic
 import Mathlib.Data.Nat.Cast.Defs
@@ -265,6 +266,10 @@ def unitsWithZeroEquiv : (WithZero α)ˣ ≃* α where
   left_inv _ := Units.ext <| by simp only [coe_unzero, Units.mk0_val]
   right_inv _ := rfl
   map_mul' _ _ := coe_inj.mp <| by simp only [Units.val_mul, coe_unzero, coe_mul]
+
+theorem units_val_eq_coe_unitsWithZeroEquiv (γ : (WithZero α)ˣ) :
+    γ.val = ↑(unitsWithZeroEquiv γ) := by
+  simp only [WithZero.unitsWithZeroEquiv, MulEquiv.coe_mk, Equiv.coe_fn_mk, WithZero.coe_unzero]
 
 /-- Any group with zero is isomorphic to adjoining `0` to the units of itself. -/
 def withZeroUnitsEquiv {G : Type*} [GroupWithZero G]

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -266,8 +266,8 @@ def unitsWithZeroEquiv : (WithZero α)ˣ ≃* α where
   right_inv _ := rfl
   map_mul' _ _ := coe_inj.mp <| by simp only [Units.val_mul, coe_unzero, coe_mul]
 
-theorem units_val_eq_coe_unitsWithZeroEquiv (γ : (WithZero α)ˣ) :
-    γ.val = ↑(unitsWithZeroEquiv γ) := by
+theorem coe_unitsWithZeroEquiv_eq_units_val (γ : (WithZero α)ˣ) :
+    ↑(unitsWithZeroEquiv γ) = γ.val := by
   simp only [WithZero.unitsWithZeroEquiv, MulEquiv.coe_mk, Equiv.coe_fn_mk, WithZero.coe_unzero]
 
 /-- Any group with zero is isomorphic to adjoining `0` to the units of itself. -/


### PR DESCRIPTION
Taking `Units.val` of a unit in `WithZero α` corresponds to coercing `unitsWithZeroEquiv` from `α` to `WithZero α`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
