### PR TITLE
[Merged by Bors] - feat: add `Valued.tendsto_zero_pow_of_le_neg_one`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6132,6 +6132,7 @@ import Mathlib.Topology.Algebra.Valued.NormedValued
 import Mathlib.Topology.Algebra.Valued.ValuationTopology
 import Mathlib.Topology.Algebra.Valued.ValuedField
 import Mathlib.Topology.Algebra.Valued.WithVal
+import Mathlib.Topology.Algebra.Valued.WithZeroMulInt
 import Mathlib.Topology.Algebra.WithZeroTopology
 import Mathlib.Topology.ApproximateUnit
 import Mathlib.Topology.Baire.BaireMeasurable

--- a/Mathlib/Topology/Algebra/Valued/WithZeroMulInt.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithZeroMulInt.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2025 Salvatore Mercuri. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Salvatore Mercuri
+-/
+import Mathlib.Topology.Algebra.Valued.ValuationTopology
+
+/-!
+# Topological results for integer-valued rings
+
+This file contains topological results for valuation rings taking values in the
+multiplicative integers with zero adjoined. These are useful for cases where there
+is a `Valued R ℤₘ₀` instance but no canonical base with which to embed this into
+`NNReal`.
+-/
+
+open Filter WithZero Set
+open scoped Topology
+
+namespace Valued
+variable {R : Type*} [Ring R] [Valued R ℤᵐ⁰] {x : R}
+
+/-- In a `ℤᵐ⁰`-valued ring, powers of `x` tend to zero if `v x ≤ exp (-1)`. -/
+lemma tendsto_zero_pow_of_le_exp_neg_one (hx : v x ≤ exp (-1)) :
+    Tendsto (fun n : ℕ ↦ x ^ n) atTop (𝓝 0) := by
+  simp only [(hasBasis_nhds_zero _ _).tendsto_right_iff, mem_setOf_eq, map_pow, eventually_atTop,
+    forall_const, logEquiv.forall_congr_left, logEquiv_symm, coe_expEquiv_apply]
+  obtain hvx | hvx := eq_or_ne (v x) 0
+  · exact fun _ ↦ ⟨1, fun n hn ↦ by rw [hvx, zero_pow (by omega)]; exact exp_pos⟩
+  refine fun γ ↦ ⟨(1 - γ).toNat, fun b hb ↦ lt_exp_of_log_lt ?_⟩
+  calc
+        (v x ^ b).log
+    _ = b * (v x).log := by simp [log_pow]
+    _ ≤ b * (-1) := by gcongr; simpa [log_le_iff_le_exp hvx]
+    _ < γ := by omega
+
+lemma exists_pow_lt_of_le_exp_neg_one (hx : v x ≤ exp (-1)) (γ : ℤᵐ⁰ˣ) : ∃ n, v x ^ n < γ := by
+  let ⟨n, hn⟩ := eventually_atTop.1 <| (hasBasis_nhds_zero _ _ |>.tendsto_right_iff).1
+    (tendsto_zero_pow_of_le_exp_neg_one hx) γ trivial
+  exact ⟨n, by simpa using hn n le_rfl⟩
+
+end Valued


### PR DESCRIPTION
If `K` is a valued ring taking values in the multiplicative integers wth a zero adjoined, then `Valued.tendsto_zero_pow_of_le_neg_one` is the result that `x ^ n` tends to zero in this ring if `v x` is at most `-1` valued. 

---
- [x] depends on: #21160
- [x] depends on: #22055
- [x] depends on: #24977
- [x] depends on: #26761

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
