### PR TITLE
[Merged by Bors] - chore: deprecate list_reverse_induction

### DIFF
--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -6,7 +6,6 @@ Authors: Fox Thomson, Chris Wong
 import Mathlib.Computability.Language
 import Mathlib.Data.Countable.Small
 import Mathlib.Data.Fintype.Card
-import Mathlib.Data.List.Indexes
 import Mathlib.Tactic.NormNum
 
 /-!

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -185,9 +185,9 @@ theorem comap_id : M.comap id = M := rfl
 @[simp]
 theorem evalFrom_comap (f : α' → α) (s : σ) (x : List α') :
     (M.comap f).evalFrom s x = M.evalFrom s (x.map f) := by
-  induction x using List.list_reverse_induction with
-  | base => simp
-  | ind x a ih => simp [ih]
+  induction x using List.reverseRecOn with
+  | nil => simp
+  | append_singleton x a ih => simp [ih]
 
 @[simp]
 theorem eval_comap (f : α' → α) (x : List α') : (M.comap f).eval x = M.eval (x.map f) := by
@@ -226,9 +226,9 @@ theorem symm_reindex (g : σ ≃ σ') : (reindex (α := α) g).symm = reindex g.
 @[simp]
 theorem evalFrom_reindex (g : σ ≃ σ') (s : σ') (x : List α) :
     (reindex g M).evalFrom s x = g (M.evalFrom (g.symm s) x) := by
-  induction x using List.list_reverse_induction with
-  | base => simp
-  | ind x a ih => simp [ih]
+  induction x using List.reverseRecOn with
+  | nil => simp
+  | append_singleton x a ih => simp [ih]
 
 @[simp]
 theorem eval_reindex (g : σ ≃ σ') (x : List α) : (reindex g M).eval x = g (M.eval x) := by

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -85,9 +85,9 @@ theorem accepts_toDFA : L.toDFA.accepts = L := by
   ext x
   rw [DFA.mem_accepts]
   suffices L.toDFA.eval x = L.leftQuotient x by simp [this]
-  induction x using List.list_reverse_induction with
-  | base => simp
-  | ind x a ih => simp [ih, leftQuotient_append]
+  induction x using List.reverseRecOn with
+  | nil => simp
+  | append_singleton x a ih => simp [ih, leftQuotient_append]
 
 theorem IsRegular.of_finite_range_leftQuotient (h : Set.Finite (Set.range L.leftQuotient)) :
     L.IsRegular :=

--- a/Mathlib/Data/List/Indexes.lean
+++ b/Mathlib/Data/List/Indexes.lean
@@ -23,17 +23,10 @@ variable {α : Type u} {β : Type v}
 
 section MapIdx
 
+@[deprecated reverseRecOn (since := "2025-01-28")]
 theorem list_reverse_induction (p : List α → Prop) (base : p [])
-    (ind : ∀ (l : List α) (e : α), p l → p (l ++ [e])) : (∀ (l : List α), p l) := by
-  let q := fun l ↦ p (reverse l)
-  have pq : ∀ l, p (reverse l) → q l := by simp only [q, reverse_reverse]; intro; exact id
-  have qp : ∀ l, q (reverse l) → p l := by simp only [q, reverse_reverse]; intro; exact id
-  intro l
-  apply qp
-  generalize (reverse l) = l
-  induction' l with head tail ih
-  · apply pq; simp only [reverse_nil, base]
-  · apply pq; simp only [reverse_cons]; apply ind; apply qp; rw [reverse_reverse]; exact ih
+    (ind : ∀ (l : List α) (e : α), p l → p (l ++ [e])) : (∀ (l : List α), p l) :=
+  fun l => l.reverseRecOn base ind
 
 @[deprecated (since := "2024-10-15")] alias mapIdxGo_length := mapIdx_go_length
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
