### PR TITLE
[Merged by Bors] - chore(Data/Matroid/IndepAxioms): improved docstring for `IndepMatroid`

### DIFF
--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -96,7 +96,7 @@ section IndepMatroid
 /-- A matroid as defined by a ground set and an independence predicate.
 This definition is an implementation detail whose purpose is to organize the multiple
 different versions of the independence axioms;
-as a rule, the term `IndepMatroid` should never appear in type signatures outside this file.
+as a rule, the type `IndepMatroid` should never appear in type signatures outside this file.
 
 The intended pattern for defining a `Matroid α` from a known independence predicate
 `MyIndep : Set α → Prop` and ground set `E : Set α` is to write

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -105,7 +105,8 @@ The intended pattern for defining a `Matroid α` from a known independence predi
 def myMatroid : Matroid α := IndepMatroid.matroid <| IndepMatroid.ofFoo E MyIndep _ _ … _
 ```
 
-where `IndepMatroid.ofFoo` is one of the several available constructors for `IndepMatroid`,
+where `IndepMatroid.ofFoo` is either `IndepMatroid.mk`,
+or one of the several other available constructors for `IndepMatroid`,
 and the `_` represent the proofs that this constructor requires.
 
 After such a definition is made, the facts that `myMatroid.Indep = myIndep` and `myMatroid.E = E`

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -102,20 +102,16 @@ which is then converted into a matroid via `IndepMatroid.matroid`.
 
 To define a `Matroid α` from a known independence predicate
 `MyIndep : Set α → Prop` and ground set `E : Set α`, one can either write
-
 ```
 def myMatroid (…) : Matroid α :=
   IndepMatroid.matroid <| IndepMatroid.ofFoo E MyIndep _ _ … _
 ```
-
 or, slightly more indirectly,
-
 ```
 private def myIndepMatroid (…) : IndepMatroid α := IndepMatroid.ofFoo E MyIndep _ _ … _
 
 def myMatroid (…) : Matroid α := (myIndepMatroid …).matroid
 ```
-
 In both cases, `IndepMatroid.ofFoo` is either `IndepMatroid.mk`,
 or one of the several other available constructors for `IndepMatroid`,
 and the `_` represent the proofs that this constructor requires.

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -110,7 +110,7 @@ or one of the several other available constructors for `IndepMatroid`,
 and the `_` represent the proofs that this constructor requires.
 
 After such a definition is made, the facts that `myMatroid.Indep = myIndep` and `myMatroid.E = E`
-are true by either `rfl` or `simp`.
+are true by either `rfl` or `simp [myMatroid]`.
 -/
 structure IndepMatroid (α : Type*) where
   /-- The ground set -/

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -93,10 +93,24 @@ variable {α : Type*}
 
 section IndepMatroid
 
-/-- A matroid as defined by the independence axioms. This is the same thing as a `Matroid`,
-  and so does not need its own API; it exists to make it easier to construct a matroid from its
-  independent sets. The constructed `IndepMatroid` can then be converted into a matroid
-  with `IndepMatroid.matroid`. -/
+/-- A matroid as defined by a ground set and an independence predicate.
+This definition is an implementation detail whose purpose is to organize the multiple
+different versions of the independence axioms;
+as a rule, the term `IndepMatroid` should never appear in type signatures outside this file.
+
+The intended pattern for defining a `Matroid α` from a known independence predicate
+`MyIndep : Set α → Prop` and ground set `E : Set α` is to write
+
+```
+def MyMatroid : Matroid α := IndepMatroid.matroid <| IndepMatroid.ofFoo E MyIndep _ _ … _
+```
+
+where `IndepMatroid.ofFoo` is one of the several available constructors for `IndepMatroid`,
+and the `_` represent the proofs that this constructor requires.
+
+After such a definition is made, the facts that `myMatroid.Indep = myIndep` and `myMatroid.E = E`
+are true by either `rfl` or `simp`.
+-/
 structure IndepMatroid (α : Type*) where
   /-- The ground set -/
   (E : Set α)

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -96,16 +96,27 @@ section IndepMatroid
 /-- A matroid as defined by a ground set and an independence predicate.
 This definition is an implementation detail whose purpose is to organize the multiple
 different versions of the independence axioms;
-as a rule, the type `IndepMatroid` should never appear in type signatures outside this file.
+usually, terms of type `IndepMatroid` should either be directly piped into `IndepMatroid.matroid`,
+or should be constructed as a private definition
+which is then converted into a matroid via `IndepMatroid.matroid`.
 
-The intended pattern for defining a `Matroid α` from a known independence predicate
-`MyIndep : Set α → Prop` and ground set `E : Set α` is to write
+To define a `Matroid α` from a known independence predicate
+`MyIndep : Set α → Prop` and ground set `E : Set α`, one can either write
 
 ```
-def myMatroid : Matroid α := IndepMatroid.matroid <| IndepMatroid.ofFoo E MyIndep _ _ … _
+def myMatroid (…) : Matroid α :=
+  IndepMatroid.matroid <| IndepMatroid.ofFoo E MyIndep _ _ … _
 ```
 
-where `IndepMatroid.ofFoo` is either `IndepMatroid.mk`,
+or, slightly more indirectly,
+
+```
+private def myIndepMatroid (…) : IndepMatroid α := IndepMatroid.ofFoo E MyIndep _ _ … _
+
+def myMatroid (…) : Matroid α := (myIndepMatroid …).matroid
+```
+
+In both cases, `IndepMatroid.ofFoo` is either `IndepMatroid.mk`,
 or one of the several other available constructors for `IndepMatroid`,
 and the `_` represent the proofs that this constructor requires.
 

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -110,7 +110,7 @@ or one of the several other available constructors for `IndepMatroid`,
 and the `_` represent the proofs that this constructor requires.
 
 After such a definition is made, the facts that `myMatroid.Indep = myIndep` and `myMatroid.E = E`
-are true by either `rfl` or `simp [myMatroid]`.
+are true by either `rfl` or `simp [myMatroid]`, and can be made directly into @[simp] lemmas.
 -/
 structure IndepMatroid (α : Type*) where
   /-- The ground set -/

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -102,7 +102,7 @@ The intended pattern for defining a `Matroid α` from a known independence predi
 `MyIndep : Set α → Prop` and ground set `E : Set α` is to write
 
 ```
-def MyMatroid : Matroid α := IndepMatroid.matroid <| IndepMatroid.ofFoo E MyIndep _ _ … _
+def myMatroid : Matroid α := IndepMatroid.matroid <| IndepMatroid.ofFoo E MyIndep _ _ … _
 ```
 
 where `IndepMatroid.ofFoo` is one of the several available constructors for `IndepMatroid`,


### PR DESCRIPTION
This PR changes the docstring of `IndepMatroid` to more explicitly lay out the intended design pattern for using `IndepMatroid` to define a matroid. 

This felt like it might be helpful, because two people who spoke to me after using the definition were experiencing difficulties due to going against the pattern, so it wasn't so obvious what to do from the existing docstring. 

@alreadydone @madvorak 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
