### PR TITLE
[Merged by Bors] - feat(SimpleGraph/Clique): graphs without one cliques

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -367,12 +367,12 @@ protected theorem CliqueFree.replaceVertex [DecidableEq α] (h : G.CliqueFree n)
     conv at hφ => enter [a, b]; rw [G.adj_replaceVertex_iff_of_ne _ (mt a) (mt b)]
     exact hφ
 
-lemma cliqueFree_one :  G.CliqueFree 1 ↔ IsEmpty α:=by
+@[simp]
+lemma cliqueFree_one : G.CliqueFree 1 ↔ IsEmpty α :=by
   constructor
-  · simp only [CliqueFree, isNClique_one, not_exists, forall_eq_apply_imp_iff] at h
-    exact { false := h }
-  · sorry
-
+  · simp only [CliqueFree, isNClique_one, not_exists, forall_eq_apply_imp_iff]
+    exact fun a => { false := a }
+  · intro h t hf; simp_all
 
 @[simp]
 theorem cliqueFree_two : G.CliqueFree 2 ↔ G = ⊥ := by

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -368,11 +368,8 @@ protected theorem CliqueFree.replaceVertex [DecidableEq α] (h : G.CliqueFree n)
     exact hφ
 
 @[simp]
-lemma cliqueFree_one : G.CliqueFree 1 ↔ IsEmpty α :=by
-  constructor
-  · simp only [CliqueFree, isNClique_one, not_exists, forall_eq_apply_imp_iff]
-    exact fun a => { false := a }
-  · intro h t hf; simp_all
+lemma cliqueFree_one : G.CliqueFree 1 ↔ IsEmpty α := by
+  simp [CliqueFree, isEmpty_iff]
 
 @[simp]
 theorem cliqueFree_two : G.CliqueFree 2 ↔ G = ⊥ := by

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -367,6 +367,13 @@ protected theorem CliqueFree.replaceVertex [DecidableEq α] (h : G.CliqueFree n)
     conv at hφ => enter [a, b]; rw [G.adj_replaceVertex_iff_of_ne _ (mt a) (mt b)]
     exact hφ
 
+lemma cliqueFree_one :  G.CliqueFree 1 ↔ IsEmpty α:=by
+  constructor
+  · simp only [CliqueFree, isNClique_one, not_exists, forall_eq_apply_imp_iff] at h
+    exact { false := h }
+  · sorry
+
+
 @[simp]
 theorem cliqueFree_two : G.CliqueFree 2 ↔ G = ⊥ := by
   classical

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -451,8 +451,4 @@ theorem cliqueFree_of_chromaticNumber_lt {n : ℕ} (hc : G.chromaticNumber < n) 
   rw [← hne] at hc
   simpa using hc
 
-theorem colorable_of_cliqueFree_one {n : ℕ} (h : G.CliqueFree 1) : G.Colorable n :=by
-  simp only [cliqueFree_one] at h
-  exact colorable_of_isEmpty G n
-
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -451,4 +451,8 @@ theorem cliqueFree_of_chromaticNumber_lt {n : ℕ} (hc : G.chromaticNumber < n) 
   rw [← hne] at hc
   simpa using hc
 
+theorem colorable_of_cliqueFree_one {n : ℕ} (h : G.CliqueFree 1) : G.Colorable n :=by
+  simp only [cliqueFree_one] at h
+  exact colorable_of_isEmpty G n
+
 end SimpleGraph


### PR DESCRIPTION
A simple graph is cliqueFree one iff it has no vertices.

Co-authored-by: Lian Tattersall <lian.tattersall.20@alumni.ucl.ac.uk>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
