### PR TITLE
[Merged by Bors] - feat(GroupTheory/IndexNormal): subgroups of small index are normal

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2552,6 +2552,7 @@ import Mathlib.Data.FinEnum
 import Mathlib.Data.FinEnum.Option
 import Mathlib.Data.Finite.Card
 import Mathlib.Data.Finite.Defs
+import Mathlib.Data.Finite.Perm
 import Mathlib.Data.Finite.Powerset
 import Mathlib.Data.Finite.Prod
 import Mathlib.Data.Finite.Set

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3332,6 +3332,7 @@ import Mathlib.GroupTheory.GroupAction.Support
 import Mathlib.GroupTheory.GroupExtension.Defs
 import Mathlib.GroupTheory.HNNExtension
 import Mathlib.GroupTheory.Index
+import Mathlib.GroupTheory.IndexNormal
 import Mathlib.GroupTheory.MonoidLocalization.Away
 import Mathlib.GroupTheory.MonoidLocalization.Basic
 import Mathlib.GroupTheory.MonoidLocalization.Cardinality

--- a/Mathlib/Data/Finite/Perm.lean
+++ b/Mathlib/Data/Finite/Perm.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2025 Antoine Chambert-Loir. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir
+-/
+
+import Mathlib.Data.Fintype.Perm
+import Mathlib.SetTheory.Cardinal.Finite
+
+/-! # Properties of `Equiv.Perm` on `Finite` types
+
+-/
+
+namespace Nat
+
+theorem card_perm {α : Type*} [Finite α] : Nat.card (Equiv.Perm α) = (Nat.card α)! := by
+  classical
+  have := Fintype.ofFinite α
+  rw [card_eq_fintype_card, card_eq_fintype_card, Fintype.card_perm]
+
+end Nat

--- a/Mathlib/Data/Nat/Prime/Factorial.lean
+++ b/Mathlib/Data/Nat/Prime/Factorial.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Data.Nat.Factorial.Basic
-import Mathlib.Data.Nat.Prime.Defs
 import Mathlib.Data.Nat.Prime.Basic
 /-!
 # Prime natural numbers and the factorial operator

--- a/Mathlib/Data/Nat/Prime/Factorial.lean
+++ b/Mathlib/Data/Nat/Prime/Factorial.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.Data.Nat.Prime.Defs
-
+import Mathlib.Data.Nat.Prime.Basic
 /-!
 # Prime natural numbers and the factorial operator
 
@@ -24,5 +24,14 @@ theorem Prime.dvd_factorial : ∀ {n p : ℕ} (_ : Prime p), p ∣ n ! ↔ p ≤
     exact
       ⟨fun h => h.elim (le_of_dvd (succ_pos _)) le_succ_of_le, fun h =>
         (_root_.lt_or_eq_of_le h).elim (Or.inr ∘ le_of_lt_succ) fun h => Or.inl <| by rw [h]⟩
+
+theorem coprime_factorial_iff {m n : ℕ} (hm : m ≠ 1) :
+    m.Coprime n ! ↔ n < m.minFac := by
+  rw [← not_le, iff_not_comm, Nat.Prime.not_coprime_iff_dvd]
+  constructor
+  · intro h
+    exact ⟨m.minFac, minFac_prime hm, minFac_dvd m, Nat.dvd_factorial (minFac_pos m) h⟩
+  · rintro ⟨p, hp, hdvd, hdvd'⟩
+    exact le_trans (minFac_le_of_dvd hp.two_le hdvd) (hp.dvd_factorial.mp hdvd')
 
 end Nat

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -11,9 +11,6 @@ import Mathlib.GroupTheory.Finiteness
 import Mathlib.GroupTheory.GroupAction.Quotient
 import Mathlib.GroupTheory.QuotientGroup.Basic
 
-import Mathlib.Data.Nat.Prime.Factorial
-import Mathlib.Data.Fintype.Perm
-
 /-!
 # Index of a Subgroup
 

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -11,6 +11,9 @@ import Mathlib.GroupTheory.Finiteness
 import Mathlib.GroupTheory.GroupAction.Quotient
 import Mathlib.GroupTheory.QuotientGroup.Basic
 
+import Mathlib.Data.Nat.Prime.Factorial
+import Mathlib.Data.Fintype.Perm
+
 /-!
 # Index of a Subgroup
 

--- a/Mathlib/GroupTheory/IndexNormal.lean
+++ b/Mathlib/GroupTheory/IndexNormal.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2025 Antoine Chambert-Loir. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir
+-/
+import Mathlib.GroupTheory.Index
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Nat.Prime.Factorial
+
+/-! # Subgroups of small index are normal
+
+* `Subgroup.normal_of_index_eq_smallest_prime_factor`: in a finite group `G`,
+a subgroup of index equal to the smallest prime factor of `Nat.card G` is normal.
+
+* `Subgroup.normal_of_index_two`: in a group `G`, a subgroup of index 2 is normal
+(This does not require `G` to be finite.)
+
+-/
+
+variable {G : Type*} [Group G] {H : Subgroup G} {p : ℕ}
+
+namespace Subgroup
+
+open MulAction MonoidHom Nat
+
+private theorem dvd_prime {r p : ℕ} (hp : p.Prime) (h : r ∣ p !)
+    (hr : ∀ {l : ℕ} (_ : l.Prime) (_ : l ∣ r), p ≤ l) : r ∣ p := by
+  rw [← Coprime.dvd_mul_right (n := (p-1)!) _]
+  · rw [mul_factorial_pred hp.pos]; exact h
+  · rw [coprime_iff_gcd_eq_one]
+    by_contra h
+    obtain ⟨l, hl, hl'⟩ := exists_prime_and_dvd h
+    rw [dvd_gcd_iff, hl.dvd_factorial] at hl'
+    apply (lt_iff_not_ge p.pred p).mp (Nat.pred_lt hp.ne_zero)
+    rw [pred_eq_sub_one, ge_iff_le]
+    exact le_trans (hr hl hl'.left) hl'.right
+
+/-- A subgroup of a finite group whose index is the smallest prime factor is normal -/
+theorem normal_of_index_eq_smallest_prime_factor [Finite G]
+    (hp : p.Prime) (hHp : H.index = p) (hp' : ∀ {l : ℕ} (_ : l.Prime) (_: l ∣ Nat.card G), p ≤ l) :
+    H.Normal := by
+  set f := toPermHom G (G ⧸ H) with hf
+  convert MonoidHom.normal_ker f
+  suffices H.normalCore.relindex H = 1 by
+    rw [← normalCore_eq_ker]
+    rw [relindex_eq_one] at this
+    exact le_antisymm this (normalCore_le H)
+  have index_ne_zero : H.index ≠ 0 := hHp ▸ Nat.Prime.ne_zero hp
+  apply mul_left_injective₀ index_ne_zero
+  dsimp only
+  rw [relindex_mul_index H.normalCore_le, one_mul, normalCore_eq_ker, hHp, ← hf]
+  apply Or.resolve_left (hp.eq_one_or_self_of_dvd f.ker.index _)
+  · -- f.ker.index ≠ 1
+    intro hf_one
+    apply hp.ne_one
+    rw [← hHp, index_eq_one, eq_top_iff]
+    apply le_trans _ H.normalCore_le
+    rw [← eq_top_iff, ← index_eq_one, normalCore_eq_ker, hf_one]
+  · --  f.ker.index ∣ p,
+    apply dvd_prime hp
+    · -- f.ker.index ∣ p.factorial : Lagrange on range
+      classical
+      haveI _ : Fintype f.range := Fintype.ofFinite ↥f.range
+      haveI _ : Fintype (G ⧸ H) := fintypeOfIndexNeZero index_ne_zero
+      rw [index_ker f, ← hHp]
+      simp only [index, card_eq_fintype_card, ← Fintype.card_perm]
+      simp only [← card_eq_fintype_card]
+      exact f.range.card_subgroup_dvd_card
+    · -- Condition on prime factors of f.ker.index : hypothesis on G
+      intro l hl hl'
+      exact hp' hl (dvd_trans hl' f.ker.index_dvd_card)
+
+/-- A subgroup of index 2 is normal (does not require finiteness of G) -/
+theorem normal_of_index_eq_two (hH : H.index = 2) :
+    H.Normal := by
+  classical
+  set f := MulAction.toPermHom G (G ⧸ H) with hf
+  convert MonoidHom.normal_ker f
+  suffices H.normalCore.relindex H = 1 by
+    rw [← Subgroup.normalCore_eq_ker]
+    rw [Subgroup.relindex_eq_one] at this
+    exact le_antisymm this (normalCore_le H)
+  have index_ne_zero : H.index ≠ 0 := by rw [hH]; exact two_ne_zero
+  apply mul_left_injective₀ index_ne_zero; dsimp only
+  rw [relindex_mul_index H.normalCore_le, one_mul, normalCore_eq_ker, hH]
+  have _ : Fintype (G ⧸ H) := by apply fintypeOfIndexNeZero index_ne_zero
+  apply Nat.eq_of_lt_succ_of_not_lt
+  · rw [index_ker f, card_eq_fintype_card, Nat.lt_succ_iff]
+    apply le_of_dvd two_pos
+    rw [← card_eq_fintype_card]
+    apply dvd_trans f.range.card_subgroup_dvd_card
+    rw [card_eq_fintype_card, Fintype.card_perm, ← card_eq_fintype_card]
+    unfold index at hH ; rw [hH]; norm_num
+  · -- ¬(f.ker.index < 2)
+    intro h
+    apply not_le.mpr Nat.one_lt_two
+    rw [Nat.lt_succ_iff] at h
+    apply le_trans _ h
+    rw [← hH, ← H.normalCore_eq_ker]
+    apply Nat.le_of_dvd _ (index_dvd_of_le H.normalCore_le)
+    rw [zero_lt_iff, H.normalCore_eq_ker, index_ker f, card_eq_fintype_card]
+    exact Fintype.card_ne_zero
+
+end Subgroup

--- a/Mathlib/GroupTheory/IndexNormal.lean
+++ b/Mathlib/GroupTheory/IndexNormal.lean
@@ -77,6 +77,12 @@ theorem normal_of_index_eq_smallest_prime_factor [Finite G]
       intro l hl hl'
       exact hp' hl (dvd_trans hl' f.ker.index_dvd_card)
 
+/-- A subgroup of index 1 is normal (does not require finiteness of G) -/ 
+theorem normal_of_index_eq_one (hH : H.index = 1) : H.Normal := by 
+  rw [index_eq_one] at hH 
+  rw [hH] 
+  infer_instance
+
 /-- A subgroup of index 2 is normal (does not require finiteness of G) -/
 theorem normal_of_index_eq_two (hH : H.index = 2) :
     H.Normal := by

--- a/Mathlib/GroupTheory/IndexNormal.lean
+++ b/Mathlib/GroupTheory/IndexNormal.lean
@@ -3,9 +3,9 @@ Copyright (c) 2025 Antoine Chambert-Loir. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir
 -/
-import Mathlib.GroupTheory.Index
-import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Perm
 import Mathlib.Data.Nat.Prime.Factorial
+import Mathlib.GroupTheory.Index
 
 /-! # Subgroups of small index are normal
 

--- a/Mathlib/GroupTheory/IndexNormal.lean
+++ b/Mathlib/GroupTheory/IndexNormal.lean
@@ -42,10 +42,10 @@ theorem normal_of_index_eq_one (hH : H.index = 1) : H.Normal := by
 theorem normal_of_index_eq_two (hH : H.index = 2) : H.Normal where
   conj_mem x hxH g := by simp_rw [mul_mem_iff_of_index_two hH, hxH, iff_true, inv_mem_iff]
 
-/-- A subgroup of a finite group whose index is the smallest prime factor is normal
+/-- A subgroup of a finite group whose index is the smallest prime factor is normal.
 
 Note : if `G` is infinite, then `Nat.card G = 0` and `(Nat.card G).minFac = 2` -/
-theorem normal_of_index_eq_smallest_prime_factor (hHp : H.index = (Nat.card G).minFac) :
+theorem normal_of_index_eq_minFac_card (hHp : H.index = (Nat.card G).minFac) :
     H.Normal := by
   by_cases hG0 : Nat.card G = 0
   · rw [hG0, minFac_zero] at hHp
@@ -66,6 +66,5 @@ theorem normal_of_index_eq_smallest_prime_factor (hHp : H.index = (Nat.card G).m
     rw [normalCore_eq_ker, index_ker, index_eq_card, ← Nat.card_perm]
     exact card_subgroup_dvd_card (toPermHom G (G ⧸ H)).range
   exact dvd_antisymm (dvd_prime hp h hp') (index_dvd_of_le H.normalCore_le)
-
 
 end Subgroup

--- a/Mathlib/GroupTheory/IndexNormal.lean
+++ b/Mathlib/GroupTheory/IndexNormal.lean
@@ -34,15 +34,11 @@ open MulAction MonoidHom Nat
 
 private theorem dvd_prime {r p : ℕ} (hp : p.Prime) (h : r ∣ p !)
     (hr : ∀ {l : ℕ} (_ : l.Prime) (_ : l ∣ r), p ≤ l) : r ∣ p := by
-  rw [← Coprime.dvd_mul_right (n := (p-1)!) _]
-  · rw [mul_factorial_pred hp.pos]; exact h
-  · rw [coprime_iff_gcd_eq_one]
-    by_contra h
-    obtain ⟨l, hl, hl'⟩ := exists_prime_and_dvd h
-    rw [dvd_gcd_iff, hl.dvd_factorial] at hl'
-    apply (lt_iff_not_ge p.pred p).mp (Nat.pred_lt hp.ne_zero)
-    rw [pred_eq_sub_one, ge_iff_le]
-    exact le_trans (hr hl hl'.left) hl'.right
+  rwa [← Coprime.dvd_mul_right, mul_factorial_pred hp.pos]
+  contrapose! hr
+  obtain ⟨l, hl, hl'⟩ := exists_prime_and_dvd hr
+  rw [dvd_gcd_iff, hl.dvd_factorial, Nat.le_sub_one_iff_lt hp.pos] at hl'
+  exact ⟨l, hl, hl'⟩
 
 /-- A subgroup of index 1 is normal (does not require finiteness of G) -/
 theorem normal_of_index_eq_one (hH : H.index = 1) : H.Normal := by

--- a/Mathlib/GroupTheory/IndexNormal.lean
+++ b/Mathlib/GroupTheory/IndexNormal.lean
@@ -74,7 +74,7 @@ theorem normal_of_index_eq_smallest_prime_factor [Finite G]
 theorem normal_of_index_eq_two (hH : H.index = 2) :
     H.Normal := by
   classical
-  set f := MulAction.toPermHom G (G ⧸ H) with hf
+  set f := MulAction.toPermHom G (G ⧸ H)
   convert MonoidHom.normal_ker f
   suffices H.normalCore.relindex H = 1 by
     rw [← Subgroup.normalCore_eq_ker]

--- a/Mathlib/GroupTheory/IndexNormal.lean
+++ b/Mathlib/GroupTheory/IndexNormal.lean
@@ -17,6 +17,15 @@ a subgroup of index equal to the smallest prime factor of `Nat.card G` is normal
 
 -/
 
+namespace Nat
+
+theorem card_perm {α : Type*} [Finite α] : Nat.card (Equiv.Perm α) = (Nat.card α)! := by
+  classical
+  have := Fintype.ofFinite α
+  rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, Fintype.card_perm]
+
+end Nat
+
 variable {G : Type*} [Group G] {H : Subgroup G} {p : ℕ}
 
 namespace Subgroup
@@ -35,52 +44,10 @@ private theorem dvd_prime {r p : ℕ} (hp : p.Prime) (h : r ∣ p !)
     rw [pred_eq_sub_one, ge_iff_le]
     exact le_trans (hr hl hl'.left) hl'.right
 
-/-- A subgroup of a finite group whose index is the smallest prime factor is normal -/
-theorem normal_of_index_eq_smallest_prime_factor [Finite G]
-    (hHp : H.index = (Nat.card G).minFac) :
-    H.Normal := by
-  by_cases hG : Nat.card G = 1
-  · rw [hG, minFac_one, index_eq_one] at hHp
-    rw [hHp]
-    infer_instance
-  have hp : (Nat.card G).minFac.Prime := minFac_prime hG
-  have hp' {l : ℕ} (h1 : l.Prime) (h2 : l ∣ Nat.card G) : (Nat.card G).minFac ≤ l :=
-    minFac_le_of_dvd h1.two_le h2
-  set f := toPermHom G (G ⧸ H) with hf
-  convert MonoidHom.normal_ker f
-  suffices H.normalCore.relindex H = 1 by
-    rw [← normalCore_eq_ker]
-    rw [relindex_eq_one] at this
-    exact le_antisymm this (normalCore_le H)
-  have index_ne_zero : H.index ≠ 0 := hHp ▸ Nat.Prime.ne_zero hp
-  apply mul_left_injective₀ index_ne_zero
-  dsimp only
-  rw [relindex_mul_index H.normalCore_le, one_mul, normalCore_eq_ker, hHp, ← hf]
-  apply Or.resolve_left (hp.eq_one_or_self_of_dvd f.ker.index _)
-  · -- f.ker.index ≠ 1
-    intro hf_one
-    apply hp.ne_one
-    rw [← hHp, index_eq_one, eq_top_iff]
-    apply le_trans _ H.normalCore_le
-    rw [← eq_top_iff, ← index_eq_one, normalCore_eq_ker, hf_one]
-  · --  f.ker.index ∣ p,
-    apply dvd_prime hp
-    · -- f.ker.index ∣ p.factorial : Lagrange on range
-      classical
-      haveI _ : Fintype f.range := Fintype.ofFinite ↥f.range
-      haveI _ : Fintype (G ⧸ H) := fintypeOfIndexNeZero index_ne_zero
-      rw [index_ker f, ← hHp]
-      simp only [index, card_eq_fintype_card, ← Fintype.card_perm]
-      simp only [← card_eq_fintype_card]
-      exact f.range.card_subgroup_dvd_card
-    · -- Condition on prime factors of f.ker.index : hypothesis on G
-      intro l hl hl'
-      exact hp' hl (dvd_trans hl' f.ker.index_dvd_card)
-
-/-- A subgroup of index 1 is normal (does not require finiteness of G) -/ 
-theorem normal_of_index_eq_one (hH : H.index = 1) : H.Normal := by 
-  rw [index_eq_one] at hH 
-  rw [hH] 
+/-- A subgroup of index 1 is normal (does not require finiteness of G) -/
+theorem normal_of_index_eq_one (hH : H.index = 1) : H.Normal := by
+  rw [index_eq_one] at hH
+  rw [hH]
   infer_instance
 
 /-- A subgroup of index 2 is normal (does not require finiteness of G) -/
@@ -95,5 +62,31 @@ theorem normal_of_index_eq_two (hH : H.index = 2) :
   rw [← ha1, ← H.inv_mem_iff] at hc
   rw [← H.inv_mem_iff, ← ha2, ← H.inv_mem_iff, ← ha1] at hb
   simpa [mul_assoc] using H.mul_mem (H.inv_mem hc) (H.mul_mem hb hc)
+
+/-- A subgroup of a finite group whose index is the smallest prime factor is normal
+
+Note : if `G` is infinite, then `Nat.card G = 0` and `(Nat.card G).minFac = 2` -/
+theorem normal_of_index_eq_smallest_prime_factor (hHp : H.index = (Nat.card G).minFac) :
+    H.Normal := by
+  by_cases hG0 : Nat.card G = 0
+  · rw [hG0, minFac_zero] at hHp
+    exact normal_of_index_eq_two hHp
+  by_cases hG1 : Nat.card G = 1
+  · rw [hG1, minFac_one] at hHp
+    exact normal_of_index_eq_one hHp
+  suffices H.normalCore.relindex H = 1 by
+    convert H.normalCore_normal
+    exact le_antisymm (relindex_eq_one.mp this) (normalCore_le H)
+  have : Finite G := finite_of_card_ne_zero hG0
+  have index_ne_zero : H.index ≠ 0 := index_ne_zero_of_finite
+  rw [← mul_left_inj' index_ne_zero, one_mul, relindex_mul_index H.normalCore_le]
+  have hp : Nat.Prime H.index := hHp ▸ minFac_prime hG1
+  have hp' {l : ℕ} (h1 : l.Prime) (h2 : l ∣ H.normalCore.index) : H.index ≤ l :=
+    hHp ▸ minFac_le_of_dvd h1.two_le (h2.trans H.normalCore.index_dvd_card)
+  have h : H.normalCore.index ∣ H.index ! := by
+    rw [normalCore_eq_ker, index_ker, index_eq_card, ← Nat.card_perm]
+    exact card_subgroup_dvd_card (toPermHom G (G ⧸ H)).range
+  exact dvd_antisymm (dvd_prime hp h hp') (index_dvd_of_le H.normalCore_le)
+
 
 end Subgroup

--- a/Mathlib/GroupTheory/IndexNormal.lean
+++ b/Mathlib/GroupTheory/IndexNormal.lean
@@ -6,6 +6,7 @@ Authors: Antoine Chambert-Loir
 import Mathlib.Data.Fintype.Perm
 import Mathlib.Data.Nat.Prime.Factorial
 import Mathlib.GroupTheory.Index
+import Mathlib.GroupTheory.Perm.Finite
 
 /-! # Subgroups of small index are normal
 
@@ -16,15 +17,6 @@ a subgroup of index equal to the smallest prime factor of `Nat.card G` is normal
 (This does not require `G` to be finite.)
 
 -/
-
-namespace Nat
-
-theorem card_perm {α : Type*} [Finite α] : Nat.card (Equiv.Perm α) = (Nat.card α)! := by
-  classical
-  have := Fintype.ofFinite α
-  rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, Fintype.card_perm]
-
-end Nat
 
 variable {G : Type*} [Group G] {H : Subgroup G} {p : ℕ}
 

--- a/Mathlib/GroupTheory/IndexNormal.lean
+++ b/Mathlib/GroupTheory/IndexNormal.lean
@@ -39,17 +39,8 @@ theorem normal_of_index_eq_one (hH : H.index = 1) : H.Normal := by
   infer_instance
 
 /-- A subgroup of index 2 is normal (does not require finiteness of G) -/
-theorem normal_of_index_eq_two (hH : H.index = 2) :
-    H.Normal := by
-  obtain ⟨a, ha⟩ := index_eq_two_iff.mp hH
-  have ha1 : ∀ b, b * a ∈ H ↔ ¬ b ∈ H := by simpa only [xor_iff_iff_not] using ha
-  have ha2 : ∀ b, ¬ b * a ∈ H ↔ b ∈ H := by simpa only [xor_iff_not_iff'] using ha
-  refine ⟨fun b hb c ↦ ?_⟩
-  by_cases hc : c ∈ H
-  · exact H.mul_mem (H.mul_mem hc hb) (H.inv_mem hc)
-  rw [← ha1, ← H.inv_mem_iff] at hc
-  rw [← H.inv_mem_iff, ← ha2, ← H.inv_mem_iff, ← ha1] at hb
-  simpa [mul_assoc] using H.mul_mem (H.inv_mem hc) (H.mul_mem hb hc)
+theorem normal_of_index_eq_two (hH : H.index = 2) : H.Normal where
+  conj_mem x hxH g := by simp_rw [mul_mem_iff_of_index_two hH, hxH, iff_true, inv_mem_iff]
 
 /-- A subgroup of a finite group whose index is the smallest prime factor is normal
 

--- a/Mathlib/GroupTheory/Perm/Finite.lean
+++ b/Mathlib/GroupTheory/Perm/Finite.lean
@@ -3,12 +3,12 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+import Mathlib.Data.Finite.Sum
 import Mathlib.Data.Finset.Fin
 import Mathlib.Data.Int.Order.Units
 import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.GroupTheory.Perm.Support
 import Mathlib.Logic.Equiv.Fintype
-import Mathlib.Data.Finite.Sum
 
 /-!
 # Permutations on `Fintype`s

--- a/Mathlib/GroupTheory/Perm/Finite.lean
+++ b/Mathlib/GroupTheory/Perm/Finite.lean
@@ -252,11 +252,4 @@ end Fintype
 
 end Equiv.Perm
 
-namespace Nat
 
-theorem card_perm {α : Type*} [Finite α] : Nat.card (Equiv.Perm α) = (Nat.card α)! := by
-  classical
-  have := Fintype.ofFinite α
-  rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, Fintype.card_perm]
-
-end Nat

--- a/Mathlib/GroupTheory/Perm/Finite.lean
+++ b/Mathlib/GroupTheory/Perm/Finite.lean
@@ -251,3 +251,12 @@ theorem support_pow_coprime {σ : Perm α} {n : ℕ} (h : Nat.Coprime n (orderOf
 end Fintype
 
 end Equiv.Perm
+
+namespace Nat
+
+theorem card_perm {α : Type*} [Finite α] : Nat.card (Equiv.Perm α) = (Nat.card α)! := by
+  classical
+  have := Fintype.ofFinite α
+  rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, Fintype.card_perm]
+
+end Nat

--- a/Mathlib/GroupTheory/Perm/Finite.lean
+++ b/Mathlib/GroupTheory/Perm/Finite.lean
@@ -251,5 +251,3 @@ theorem support_pow_coprime {σ : Perm α} {n : ℕ} (h : Nat.Coprime n (orderOf
 end Fintype
 
 end Equiv.Perm
-
-


### PR DESCRIPTION
* `Subgroup.normal_of_index_eq_smallest_prime_factor`: in a finite group `G`,
a subgroup of index equal to the smallest prime factor of `Nat.card G` is normal.

* `Subgroup.normal_of_index_two`: in a group `G`, a subgroup of index 2 is normal
(This does not require `G` to be finite.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
