### PR TITLE
[Merged by Bors] - feat(Algebra/Category): concrete category refactor for `Grp`

### DIFF
--- a/Mathlib/Algebra/Category/Grp/AB.lean
+++ b/Mathlib/Algebra/Category/Grp/AB.lean
@@ -31,16 +31,20 @@ noncomputable instance :
     simp only [ShortComplex.ab_exact_iff_ker_le_range] at hS ⊢
     intro x (hx : _ = _)
     dsimp at hx
-    rcases Concrete.colimit_exists_rep S.X₂ x with ⟨j, y, rfl⟩
-    rw [← CategoryTheory.comp_apply, colimMap_eq, colimit.ι_map, CategoryTheory.comp_apply,
-      ← map_zero (by exact colimit.ι S.X₃ j : (S.X₃).obj j →+ ↑(colimit S.X₃))] at hx
+    -- The type ascription around `rfl` works around a `HasForget`/`ConcreteCategory` mismatch,
+    -- and should be removed when `Concrete.colimit_exists_rep` takes `ConcreteCategory`.
+    rcases Concrete.colimit_exists_rep S.X₂ x with ⟨j, y, (rfl : (colimit.ι S.X₂ j) y = _)⟩
+    rw [← ConcreteCategory.comp_apply, colimMap_eq, colimit.ι_map, ConcreteCategory.comp_apply,
+      ← map_zero (colimit.ι S.X₃ j).hom] at hx
+    -- The type ascription around `hk` works around a `HasForget`/`ConcreteCategory` mismatch,
+    -- and should be removed when `Concrete.colimit_exists_rep` takes `ConcreteCategory`.
     rcases Concrete.colimit_exists_of_rep_eq.{u, u, u} S.X₃ _ _ hx
-      with ⟨k, e₁, e₂, hk : _ = S.X₃.map e₂ 0⟩
-    rw [map_zero, ← CategoryTheory.comp_apply, ← NatTrans.naturality, CategoryTheory.comp_apply]
+      with ⟨k, e₁, e₂, hk : (S.X₃.map e₁) _ = S.X₃.map e₂ 0⟩
+    rw [map_zero, ← ConcreteCategory.comp_apply, ← NatTrans.naturality, ConcreteCategory.comp_apply]
       at hk
     rcases hS k hk with ⟨t, ht⟩
     use colimit.ι S.X₁ k t
-    erw [← CategoryTheory.comp_apply, colimit.ι_map, CategoryTheory.comp_apply, ht]
+    erw [← ConcreteCategory.comp_apply, colimit.ι_map, ConcreteCategory.comp_apply, ht]
     exact colimit.w_apply S.X₂ e₁ y)
 
 noncomputable instance :
@@ -66,13 +70,13 @@ instance : HasExactLimitsOfShape (Discrete J) (AddCommGrp.{u}) := by
       let iY : limit Y ≅ AddCommGrp.of ((i : J) → Y.obj ⟨i⟩) := (Pi.isoLimit Y).symm ≪≫
           (limit.isLimit _).conePointUniqueUpToIso (AddCommGrp.HasLimit.productLimitCone _).isLimit
       have : Pi.map (fun i ↦ f.app ⟨i⟩) = iX.inv ≫ lim.map f ≫ iY.hom := by
-        simp only [AddCommGrp.coe_of, Functor.comp_obj, Discrete.functor_obj_eq_as, Discrete.mk_as,
-          Pi.isoLimit, IsLimit.conePointUniqueUpToIso, limit.cone,
-          AddCommGrp.HasLimit.productLimitCone, Iso.trans_inv, Functor.mapIso_inv,
-          IsLimit.uniqueUpToIso_inv, Cones.forget_map, IsLimit.liftConeMorphism_hom,
-          limit.isLimit_lift, Iso.symm_inv, Functor.mapIso_hom, IsLimit.uniqueUpToIso_hom, lim_obj,
-          lim_map, Iso.trans_hom, Iso.symm_hom, AddCommGrp.HasLimit.lift, Functor.const_obj_obj,
-          Category.assoc, limit.lift_map_assoc, Pi.cone_pt, iX, iY]
+        simp only [Functor.comp_obj, Discrete.functor_obj_eq_as, Discrete.mk_as, Pi.isoLimit,
+          IsLimit.conePointUniqueUpToIso, limit.cone, AddCommGrp.HasLimit.productLimitCone,
+          Iso.trans_inv, Functor.mapIso_inv, IsLimit.uniqueUpToIso_inv, Cones.forget_map,
+          IsLimit.liftConeMorphism_hom, limit.isLimit_lift, Iso.symm_inv, Functor.mapIso_hom,
+          IsLimit.uniqueUpToIso_hom, lim_obj, lim_map, Iso.trans_hom, Iso.symm_hom,
+          AddCommGrp.HasLimit.lift, Functor.const_obj_obj, Category.assoc, limit.lift_map_assoc,
+          Pi.cone_pt, iX, iY]
         ext g j
         change _ = (_ ≫ limit.π (Discrete.functor fun j ↦ Y.obj { as := j }) ⟨j⟩) _
         simp only [Discrete.functor_obj_eq_as, Functor.comp_obj, Discrete.mk_as, productIsProduct',

--- a/Mathlib/Algebra/Category/Grp/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/Grp/Adjunctions.lean
@@ -111,12 +111,6 @@ namespace Grp
 def free : Type u ⥤ Grp where
   obj α := of (FreeGroup α)
   map f := ofHom (FreeGroup.map f)
-  map_id := by
-    -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-    intros; ext; erw [← FreeGroup.map.unique] <;> intros <;> rfl
-  map_comp := by
-    -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-    intros; ext; erw [← FreeGroup.map.unique] <;> intros <;> rfl
 
 /-- The free-forgetful adjunction for groups.
 -/

--- a/Mathlib/Algebra/Category/Grp/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/Grp/Adjunctions.lean
@@ -69,7 +69,7 @@ def adj : free ⊣ forget AddCommGrp.{u} :=
       homEquiv_naturality_left_symm := by
         intros
         ext
-        simp only [Equiv.symm_symm]
+        simp
         apply FreeAbelianGroup.lift_comp }
 
 instance : free.{u}.IsLeftAdjoint :=
@@ -117,15 +117,13 @@ def free : Type u ⥤ Grp where
 def adj : free ⊣ forget Grp.{u} :=
   Adjunction.mkOfHomEquiv
     { homEquiv := fun _ _ => ConcreteCategory.homEquiv.trans FreeGroup.lift.symm
-      -- Porting note (https://github.com/leanprover-community/mathlib4/pull/11041): used to be just `by intros; ext1; rfl`.
       homEquiv_naturality_left_symm := by
         intros
-        ext
-        simp only [Equiv.symm_symm]
-        apply Eq.symm
-        apply FreeGroup.lift.unique
+        ext : 1
+        -- Porting note (https://github.com/leanprover-community/mathlib4/pull/11041): `ext` doesn't apply this theorem anymore
+        apply FreeGroup.ext_hom
         intros
-        apply FreeGroup.lift.of }
+        rfl }
 
 instance : (forget Grp.{u}).IsRightAdjoint  :=
   ⟨_, ⟨adj⟩⟩
@@ -211,12 +209,8 @@ def CommGrp.forget₂CommMonAdj : forget₂ CommGrp CommMonCat ⊣ CommMonCat.un
         invFun := fun f => (Units.coeHom Y).comp f.hom
         left_inv := fun _ => MonoidHom.ext fun _ => rfl
         right_inv := fun _ => CommGrp.ext fun _ => Units.ext rfl }
-    unit :=
-      { app := fun X => ofHom { (@toUnits X _).toMonoidHom with }
-        naturality := fun _ _ _ => CommGrp.ext fun _ => Units.ext rfl }
-    counit :=
-      { app := fun X => Units.coeHom X
-        naturality := by intros; exact MonoidHom.ext fun x => rfl } }
+    unit := { app := fun X => ofHom { (@toUnits X _).toMonoidHom with } }
+    counit := { app := fun X => Units.coeHom X } }
 
 instance : CommMonCat.units.{u}.IsRightAdjoint :=
   ⟨_, ⟨CommGrp.forget₂CommMonAdj⟩⟩

--- a/Mathlib/Algebra/Category/Grp/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/Grp/Adjunctions.lean
@@ -45,9 +45,9 @@ free abelian group with generators `x : X`.
 -/
 def free : Type u ⥤ AddCommGrp where
   obj α := of (FreeAbelianGroup α)
-  map := FreeAbelianGroup.map
-  map_id _ := AddMonoidHom.ext FreeAbelianGroup.map_id_apply
-  map_comp _ _ := AddMonoidHom.ext FreeAbelianGroup.map_comp_apply
+  map f := ofHom (FreeAbelianGroup.map f)
+  map_id _ := AddCommGrp.ext FreeAbelianGroup.map_id_apply
+  map_comp _ _ := AddCommGrp.ext FreeAbelianGroup.map_comp_apply
 
 @[simp]
 theorem free_obj_coe {α : Type u} : (free.obj α : Type u) = FreeAbelianGroup α :=
@@ -64,7 +64,7 @@ theorem free_map_coe {α β : Type u} {f : α → β} (x : FreeAbelianGroup α) 
 -/
 def adj : free ⊣ forget AddCommGrp.{u} :=
   Adjunction.mkOfHomEquiv
-    { homEquiv := fun _ _ => FreeAbelianGroup.lift.symm
+    { homEquiv := fun _ _ => ConcreteCategory.homEquiv.trans FreeAbelianGroup.lift.symm
       -- Porting note (https://github.com/leanprover-community/mathlib4/pull/11041): used to be just `by intros; ext; rfl`.
       homEquiv_naturality_left_symm := by
         intros
@@ -110,23 +110,23 @@ namespace Grp
 -/
 def free : Type u ⥤ Grp where
   obj α := of (FreeGroup α)
-  map := FreeGroup.map
+  map f := ofHom (FreeGroup.map f)
   map_id := by
     -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-    intros; ext1; erw [← FreeGroup.map.unique] <;> intros <;> rfl
+    intros; ext; erw [← FreeGroup.map.unique] <;> intros <;> rfl
   map_comp := by
     -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-    intros; ext1; erw [← FreeGroup.map.unique] <;> intros <;> rfl
+    intros; ext; erw [← FreeGroup.map.unique] <;> intros <;> rfl
 
 /-- The free-forgetful adjunction for groups.
 -/
 def adj : free ⊣ forget Grp.{u} :=
   Adjunction.mkOfHomEquiv
-    { homEquiv := fun _ _ => FreeGroup.lift.symm
+    { homEquiv := fun _ _ => ConcreteCategory.homEquiv.trans FreeGroup.lift.symm
       -- Porting note (https://github.com/leanprover-community/mathlib4/pull/11041): used to be just `by intros; ext1; rfl`.
       homEquiv_naturality_left_symm := by
         intros
-        ext1
+        ext
         simp only [Equiv.symm_symm]
         apply Eq.symm
         apply FreeGroup.lift.unique
@@ -142,22 +142,30 @@ section Abelianization
  -/
 def abelianize : Grp.{u} ⥤ CommGrp.{u} where
   obj G := CommGrp.of (Abelianization G)
-  map f := Abelianization.lift (Abelianization.of.comp f)
+  map f := CommGrp.ofHom (Abelianization.lift (Abelianization.of.comp f.hom))
   map_id := by
-    intros; simp only [coe_id]
-    apply (Equiv.apply_eq_iff_eq_symm_apply Abelianization.lift).mpr; rfl
+    intros
+    simp only [coe_id]
+    ext : 1
+    apply (Equiv.apply_eq_iff_eq_symm_apply Abelianization.lift).mpr
+    rfl
   map_comp := by
-    intros; simp only [coe_comp]
-    apply (Equiv.apply_eq_iff_eq_symm_apply Abelianization.lift).mpr; rfl
+    intros
+    simp only [coe_comp]
+    ext : 1
+    apply (Equiv.apply_eq_iff_eq_symm_apply Abelianization.lift).mpr
+    rfl
 
 /-- The abelianization-forgetful adjuction from `Group` to `CommGroup`. -/
 def abelianizeAdj : abelianize ⊣ forget₂ CommGrp.{u} Grp.{u} :=
   Adjunction.mkOfHomEquiv
-    { homEquiv := fun _ _ => Abelianization.lift.symm
+    { homEquiv := fun _ _ => ((ConcreteCategory.homEquiv (C := CommGrp)).trans
+        Abelianization.lift.symm).trans
+        (ConcreteCategory.homEquiv (C := Grp)).symm
       -- Porting note (https://github.com/leanprover-community/mathlib4/pull/11041): used to be just `by intros; ext1; rfl`.
       homEquiv_naturality_left_symm := by
         intros
-        ext1
+        ext
         simp only [Equiv.symm_symm]
         apply Eq.symm
         apply Abelianization.lift.unique
@@ -173,19 +181,19 @@ end Grp
 def MonCat.units : MonCat.{u} ⥤ Grp.{u} where
   obj R := Grp.of Rˣ
   map f := Grp.ofHom <| Units.map f
-  map_id _ := MonoidHom.ext fun _ => Units.ext rfl
-  map_comp _ _ := MonoidHom.ext fun _ => Units.ext rfl
+  map_id _ := Grp.ext fun _ => Units.ext rfl
+  map_comp _ _ := Grp.ext fun _ => Units.ext rfl
 
 /-- The forgetful-units adjunction between `Grp` and `MonCat`. -/
 def Grp.forget₂MonAdj : forget₂ Grp MonCat ⊣ MonCat.units.{u} := Adjunction.mk' {
   homEquiv := fun _ Y ↦
-    { toFun := fun f => MonoidHom.toHomUnits f
-      invFun := fun f => (Units.coeHom Y).comp f
+    { toFun := fun f => ofHom (MonoidHom.toHomUnits f)
+      invFun := fun f => (Units.coeHom Y).comp f.hom
       left_inv := fun _ => MonoidHom.ext fun _ => rfl
-      right_inv := fun _ => MonoidHom.ext fun _ => Units.ext rfl }
+      right_inv := fun _ => Grp.ext fun _ => Units.ext rfl }
   unit :=
-    { app := fun X => { (@toUnits X _).toMonoidHom with }
-      naturality := fun _ _ _ => MonoidHom.ext fun _ => Units.ext rfl }
+    { app := fun X => ofHom { (@toUnits X _).toMonoidHom with }
+      naturality := fun _ _ _ => Grp.ext fun _ => Units.ext rfl }
   counit :=
     { app := fun X => Units.coeHom X
       naturality := by intros; exact MonoidHom.ext fun x => rfl } }
@@ -198,20 +206,20 @@ instance : MonCat.units.{u}.IsRightAdjoint :=
 def CommMonCat.units : CommMonCat.{u} ⥤ CommGrp.{u} where
   obj R := CommGrp.of Rˣ
   map f := CommGrp.ofHom <| Units.map f
-  map_id _ := MonoidHom.ext fun _ => Units.ext rfl
-  map_comp _ _ := MonoidHom.ext fun _ => Units.ext rfl
+  map_id _ := CommGrp.ext fun _ => Units.ext rfl
+  map_comp _ _ := CommGrp.ext fun _ => Units.ext rfl
 
 /-- The forgetful-units adjunction between `CommGrp` and `CommMonCat`. -/
 def CommGrp.forget₂CommMonAdj : forget₂ CommGrp CommMonCat ⊣ CommMonCat.units.{u} :=
   Adjunction.mk' {
     homEquiv := fun _ Y ↦
-      { toFun := fun f => MonoidHom.toHomUnits f
-        invFun := fun f => (Units.coeHom Y).comp f
+      { toFun := fun f => ofHom (MonoidHom.toHomUnits f)
+        invFun := fun f => (Units.coeHom Y).comp f.hom
         left_inv := fun _ => MonoidHom.ext fun _ => rfl
-        right_inv := fun _ => MonoidHom.ext fun _ => Units.ext rfl }
+        right_inv := fun _ => CommGrp.ext fun _ => Units.ext rfl }
     unit :=
-      { app := fun X => { (@toUnits X _).toMonoidHom with }
-        naturality := fun _ _ _ => MonoidHom.ext fun _ => Units.ext rfl }
+      { app := fun X => ofHom { (@toUnits X _).toMonoidHom with }
+        naturality := fun _ _ _ => CommGrp.ext fun _ => Units.ext rfl }
     counit :=
       { app := fun X => Units.coeHom X
         naturality := by intros; exact MonoidHom.ext fun x => rfl } }

--- a/Mathlib/Algebra/Category/Grp/Basic.lean
+++ b/Mathlib/Algebra/Category/Grp/Basic.lean
@@ -24,43 +24,96 @@ universe u v
 
 open CategoryTheory
 
+/-- The category of additive groups and group morphisms. -/
+structure AddGrp : Type (u + 1) where
+  (carrier : Type u)
+  [str : AddGroup carrier]
+
 /-- The category of groups and group morphisms. -/
 @[to_additive]
-def Grp : Type (u + 1) :=
-  Bundled Group
+structure Grp : Type (u + 1) where
+  (carrier : Type u)
+  [str : Group carrier]
 
-/-- The category of additive groups and group morphisms -/
-add_decl_doc AddGrp
+attribute [instance] AddGrp.str Grp.str
+attribute [to_additive existing] Grp.carrier Grp.str
+
+initialize_simps_projections AddGrp (carrier → coe, -str)
+initialize_simps_projections Grp (carrier → coe, -str)
 
 namespace Grp
 
 @[to_additive]
-instance : BundledHom.ParentProjection
-  (fun {α : Type*} (h : Group α) => h.toDivInvMonoid.toMonoid) := ⟨⟩
+instance : CoeSort Grp (Type u) :=
+  ⟨Grp.carrier⟩
 
-deriving instance LargeCategory for Grp
-attribute [to_additive] instGrpLargeCategory
+attribute [coe] AddGrp.carrier Grp.carrier
+
+/-- Construct a bundled `Grp` from the underlying type and typeclass. -/
+@[to_additive]
+abbrev of (M : Type u) [Group M] : Grp := ⟨M⟩
+
+/-- Construct a bundled `AddGrp` from the underlying type and typeclass. -/
+add_decl_doc AddGrp.of
+
+end Grp
+
+/-- The type of morphisms in `AddGrp R`. -/
+@[ext]
+structure AddGrp.Hom (A B : AddGrp.{u}) where
+  private mk ::
+  /-- The underlying monoid homomorphism. -/
+  hom' : A →+ B
+
+/-- The type of morphisms in `Grp R`. -/
+@[to_additive, ext]
+structure Grp.Hom (A B : Grp.{u}) where
+  private mk ::
+  /-- The underlying monoid homomorphism. -/
+  hom' : A →* B
+
+attribute [to_additive existing AddGrp.Hom.mk] Grp.Hom.mk
+
+namespace Grp
 
 @[to_additive]
-instance hasForget : HasForget Grp := by
-  dsimp only [Grp]
-  infer_instance
+instance : Category Grp.{u} where
+  Hom X Y := Hom X Y
+  id X := ⟨MonoidHom.id X⟩
+  comp f g := ⟨g.hom'.comp f.hom'⟩
 
 @[to_additive]
-instance : CoeSort Grp Type* where
-  coe X := X.α
+instance : ConcreteCategory Grp (· →* ·) where
+  hom := Hom.hom'
+  ofHom := Hom.mk
 
+/-- Turn a morphism in `Grp` back into a `MonoidHom`. -/
 @[to_additive]
-instance (X : Grp) : Group X := X.str
+abbrev Hom.hom {X Y : Grp.{u}} (f : Hom X Y) :=
+  ConcreteCategory.hom (C := Grp) f
 
--- Porting note (https://github.com/leanprover-community/mathlib4/pull/10670): this instance was not necessary in mathlib
-@[to_additive]
-instance {X Y : Grp} : CoeFun (X ⟶ Y) fun _ => X → Y where
-  coe (f : X →* Y) := f
+/-- Turn a morphism in `AddGrp` back into an `AddMonoidHom`. -/
+add_decl_doc AddGrp.Hom.hom
 
+/-- Typecheck a `MonoidHom` as a morphism in `Grp`. -/
 @[to_additive]
-instance instFunLike (X Y : Grp) : FunLike (X ⟶ Y) X Y :=
-  show FunLike (X →* Y) X Y from inferInstance
+abbrev ofHom {X Y : Type u} [Group X] [Group Y] (f : X →* Y) : of X ⟶ of Y :=
+  ConcreteCategory.ofHom (C := Grp) f
+
+/-- Typecheck an `AddMonoidHom` as a morphism in `AddGrp`. -/
+add_decl_doc AddGrp.ofHom
+
+variable {R} in
+/-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
+def Hom.Simps.hom (X Y : Grp.{u}) (f : Hom X Y) :=
+  f.hom
+
+initialize_simps_projections Hom (hom' → hom)
+initialize_simps_projections AddGrp.Hom (hom' → hom)
+
+/-!
+The results below duplicate the `ConcreteCategory` simp lemmas, but we can keep them for `dsimp`.
+-/
 
 @[to_additive (attr := simp)]
 lemma coe_id {X : Grp} : (𝟙 X : X → X) = id := rfl
@@ -68,68 +121,99 @@ lemma coe_id {X : Grp} : (𝟙 X : X → X) = id := rfl
 @[to_additive (attr := simp)]
 lemma coe_comp {X Y Z : Grp} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g : X → Z) = g ∘ f := rfl
 
-@[to_additive]
-lemma comp_def {X Y Z : Grp} {f : X ⟶ Y} {g : Y ⟶ Z} : f ≫ g = g.comp f := rfl
+@[to_additive (attr := deprecated "Use hom_comp instead" (since := "2025-01-28"))]
+lemma comp_def {X Y Z : Grp} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g).hom = g.hom.comp f.hom := rfl
 
 @[simp] lemma forget_map {X Y : Grp} (f : X ⟶ Y) : (forget Grp).map f = (f : X → Y) := rfl
 
 @[to_additive (attr := ext)]
 lemma ext {X Y : Grp} {f g : X ⟶ Y} (w : ∀ x : X, f x = g x) : f = g :=
-  MonoidHom.ext w
+  ConcreteCategory.hom_ext _ _ w
 
-/-- Construct a bundled `Group` from the underlying type and typeclass. -/
 @[to_additive]
-def of (X : Type u) [Group X] : Grp :=
-  Bundled.of X
-
-/-- Construct a bundled `AddGroup` from the underlying type and typeclass. -/
-add_decl_doc AddGrp.of
-
-@[to_additive (attr := simp)]
+-- This is not `simp` to avoid rewriting in types of terms.
 theorem coe_of (R : Type u) [Group R] : ↑(Grp.of R) = R :=
   rfl
 
 @[to_additive (attr := simp)]
-theorem coe_comp' {G H K : Type _} [Group G] [Group H] [Group K] (f : G →* H) (g : H →* K) :
-    @DFunLike.coe (G →* K) G (fun _ ↦ K) MonoidHom.instFunLike (CategoryStruct.comp
-      (X := Grp.of G) (Y := Grp.of H) (Z := Grp.of K) f g) = g ∘ f :=
-  rfl
+lemma hom_id {X : Grp} : (𝟙 X : X ⟶ X).hom = MonoidHom.id X := rfl
+
+/- Provided for rewriting. -/
+@[to_additive]
+lemma id_apply (X : Grp) (x : X) :
+    (𝟙 X : X ⟶ X) x = x := by simp
 
 @[to_additive (attr := simp)]
-theorem coe_id' {G : Type _} [Group G] :
-    @DFunLike.coe (G →* G) G (fun _ ↦ G) MonoidHom.instFunLike
-      (CategoryStruct.id (X := Grp.of G)) = id :=
+lemma hom_comp {X Y T : Grp} (f : X ⟶ Y) (g : Y ⟶ T) :
+    (f ≫ g).hom = g.hom.comp f.hom := rfl
+
+/- Provided for rewriting. -/
+@[to_additive]
+lemma comp_apply {X Y T : Grp} (f : X ⟶ Y) (g : Y ⟶ T) (x : X) :
+    (f ≫ g) x = g (f x) := by simp
+
+@[to_additive (attr := ext)]
+lemma hom_ext {X Y : Grp} {f g : X ⟶ Y} (hf : f.hom = g.hom) : f = g :=
+  Hom.ext hf
+
+@[to_additive (attr := simp)]
+lemma hom_ofHom {R S : Type u} [Group R] [Group S] (f : R →* S) : (ofHom f).hom = f := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_hom {X Y : Grp} (f : X ⟶ Y) :
+    ofHom (Hom.hom f) = f := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_id {X : Type u} [Group X] : ofHom (MonoidHom.id X) = 𝟙 (of X) := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_comp {X Y Z : Type u} [Group X] [Group Y] [Group Z]
+    (f : X →* Y) (g : Y →* Z) :
+    ofHom (g.comp f) = ofHom f ≫ ofHom g :=
   rfl
+
+@[to_additive]
+lemma ofHom_apply {X Y : Type u} [Group X] [Group Y] (f : X →* Y) (x : X) :
+    (ofHom f) x = f x := rfl
+
+@[to_additive (attr := simp)]
+lemma inv_hom_apply {X Y : Grp} (e : X ≅ Y) (x : X) : e.inv (e.hom x) = x := by
+  rw [← comp_apply]
+  simp
+
+@[to_additive (attr := simp)]
+lemma hom_inv_apply {X Y : Grp} (e : X ≅ Y) (s : Y) : e.hom (e.inv s) = s := by
+  rw [← comp_apply]
+  simp
+
+@[to_additive (attr := deprecated "use `coe_comp` instead" (since := "2025-01-28"))]
+alias coe_comp' := coe_comp
+
+@[to_additive (attr := deprecated "use `coe_id` instead" (since := "2025-01-28"))]
+alias coe_id' := coe_id
 
 @[to_additive]
 instance : Inhabited Grp :=
   ⟨Grp.of PUnit⟩
 
 @[to_additive hasForgetToAddMonCat]
-instance hasForgetToMonCat : HasForget₂ Grp MonCat :=
-  BundledHom.forget₂ _ _
+instance hasForgetToMonCat : HasForget₂ Grp MonCat where
+  forget₂.obj X := MonCat.of X
+  forget₂.map f := MonCat.ofHom f.hom
+
+@[to_additive (attr := simp)] lemma forget₂_map_ofHom {X Y : Type u} [Group X] [Group Y]
+    (f : X →* Y) :
+    (forget₂ Grp MonCat).map (ofHom f) = MonCat.ofHom f := rfl
 
 @[to_additive]
 instance : Coe Grp.{u} MonCat.{u} where coe := (forget₂ Grp MonCat).obj
 
 @[to_additive]
-instance (G H : Grp) : One (G ⟶ H) := (inferInstance : One (MonoidHom G H))
+instance (G H : Grp) : One (G ⟶ H) where
+  one := ofHom 1
 
 @[to_additive (attr := simp)]
 theorem one_apply (G H : Grp) (g : G) : ((1 : G ⟶ H) : G → H) g = 1 :=
-  rfl
-
-/-- Typecheck a `MonoidHom` as a morphism in `Grp`. -/
-@[to_additive]
-def ofHom {X Y : Type u} [Group X] [Group Y] (f : X →* Y) : of X ⟶ of Y :=
-  f
-
-/-- Typecheck an `AddMonoidHom` as a morphism in `AddGroup`. -/
-add_decl_doc AddGrp.ofHom
-
-@[to_additive]
-theorem ofHom_apply {X Y : Type _} [Group X] [Group Y] (f : X →* Y) (x : X) :
-    (ofHom f) x = f x :=
   rfl
 
 @[to_additive]
@@ -137,7 +221,7 @@ lemma ofHom_injective {X Y : Type u} [Group X] [Group Y] :
     Function.Injective (fun (f : X →* Y) ↦ ofHom f) := by
   intro _ _ h
   ext
-  apply DFunLike.congr_fun h
+  apply ConcreteCategory.congr_hom h
 
 @[to_additive]
 instance ofUnique (G : Type*) [Group G] [i : Unique G] : Unique (Grp.of G) := i
@@ -147,24 +231,33 @@ instance ofUnique (G : Type*) [Group G] [i : Unique G] : Unique (Grp.of G) := i
 example {R S : Grp} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 := by simp [h]
 
 /-- Universe lift functor for groups. -/
-@[to_additive (attr := simps)
+@[to_additive (attr := simps obj map)
   "Universe lift functor for additive groups."]
 def uliftFunctor : Grp.{v} ⥤ Grp.{max v u} where
   obj X := Grp.of (ULift.{u, v} X)
   map {_ _} f := Grp.ofHom <|
-    MulEquiv.ulift.symm.toMonoidHom.comp <| f.comp MulEquiv.ulift.toMonoidHom
+    MulEquiv.ulift.symm.toMonoidHom.comp <| f.hom.comp MulEquiv.ulift.toMonoidHom
   map_id X := by rfl
   map_comp {X Y Z} f g := by rfl
 
 end Grp
 
-/-- The category of commutative groups and group morphisms. -/
-@[to_additive]
-def CommGrp : Type (u + 1) :=
-  Bundled CommGroup
+/-- The category of additive groups and group morphisms. -/
+structure AddCommGrp : Type (u + 1) where
+  (carrier : Type u)
+  [str : AddCommGroup carrier]
 
-/-- The category of additive commutative groups and group morphisms. -/
-add_decl_doc AddCommGrp
+/-- The category of groups and group morphisms. -/
+@[to_additive]
+structure CommGrp : Type (u + 1) where
+  (carrier : Type u)
+  [str : CommGroup carrier]
+
+attribute [instance] AddCommGrp.str CommGrp.str
+attribute [to_additive existing] CommGrp.carrier CommGrp.str
+
+initialize_simps_projections AddCommGrp (carrier → coe, -str)
+initialize_simps_projections CommGrp (carrier → coe, -str)
 
 /-- `Ab` is an abbreviation for `AddCommGroup`, for the sake of mathematicians' sanity. -/
 abbrev Ab := AddCommGrp
@@ -172,31 +265,76 @@ abbrev Ab := AddCommGrp
 namespace CommGrp
 
 @[to_additive]
-instance : BundledHom.ParentProjection @CommGroup.toGroup := ⟨⟩
+instance : CoeSort CommGrp (Type u) :=
+  ⟨CommGrp.carrier⟩
 
-deriving instance LargeCategory for CommGrp
-attribute [to_additive] instCommGrpLargeCategory
+attribute [coe] AddCommGrp.carrier CommGrp.carrier
+
+/-- Construct a bundled `CommGrp` from the underlying type and typeclass. -/
+@[to_additive]
+abbrev of (M : Type u) [CommGroup M] : CommGrp := ⟨M⟩
+
+/-- Construct a bundled `AddCommGrp` from the underlying type and typeclass. -/
+add_decl_doc AddCommGrp.of
+
+end CommGrp
+
+/-- The type of morphisms in `AddCommGrp R`. -/
+@[ext]
+structure AddCommGrp.Hom (A B : AddCommGrp.{u}) where
+  private mk ::
+  /-- The underlying monoid homomorphism. -/
+  hom' : A →+ B
+
+/-- The type of morphisms in `CommGrp R`. -/
+@[to_additive, ext]
+structure CommGrp.Hom (A B : CommGrp.{u}) where
+  private mk ::
+  /-- The underlying monoid homomorphism. -/
+  hom' : A →* B
+
+attribute [to_additive existing AddCommGrp.Hom.mk] CommGrp.Hom.mk
+
+namespace CommGrp
 
 @[to_additive]
-instance hasForget : HasForget CommGrp := by
-  dsimp only [CommGrp]
-  infer_instance
+instance : Category CommGrp.{u} where
+  Hom X Y := Hom X Y
+  id X := ⟨MonoidHom.id X⟩
+  comp f g := ⟨g.hom'.comp f.hom'⟩
 
 @[to_additive]
-instance : CoeSort CommGrp Type* where
-  coe X := X.α
+instance : ConcreteCategory CommGrp (· →* ·) where
+  hom := Hom.hom'
+  ofHom := Hom.mk
 
+/-- Turn a morphism in `CommGrp` back into a `MonoidHom`. -/
 @[to_additive]
-instance commGroupInstance (X : CommGrp) : CommGroup X := X.str
+abbrev Hom.hom {X Y : CommGrp.{u}} (f : Hom X Y) :=
+  ConcreteCategory.hom (C := CommGrp) f
 
--- Porting note (https://github.com/leanprover-community/mathlib4/pull/10670): this instance was not necessary in mathlib
-@[to_additive]
-instance {X Y : CommGrp} : CoeFun (X ⟶ Y) fun _ => X → Y where
-  coe (f : X →* Y) := f
+/-- Turn a morphism in `AddCommGrp` back into an `AddMonoidHom`. -/
+add_decl_doc AddCommGrp.Hom.hom
 
+/-- Typecheck a `MonoidHom` as a morphism in `CommGrp`. -/
 @[to_additive]
-instance instFunLike (X Y : CommGrp) : FunLike (X ⟶ Y) X Y :=
-  show FunLike (X →* Y) X Y from inferInstance
+abbrev ofHom {X Y : Type u} [CommGroup X] [CommGroup Y] (f : X →* Y) : of X ⟶ of Y :=
+  ConcreteCategory.ofHom (C := CommGrp) f
+
+/-- Typecheck an `AddMonoidHom` as a morphism in `AddCommGrp`. -/
+add_decl_doc AddCommGrp.ofHom
+
+/-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
+@[to_additive]
+def Hom.Simps.hom (X Y : CommGrp.{u}) (f : Hom X Y) :=
+  f.hom
+
+initialize_simps_projections Hom (hom' → hom)
+initialize_simps_projections AddCommGrp.Hom (hom' → hom)
+
+/-!
+The results below duplicate the `ConcreteCategory` simp lemmas, but we can keep them for `dsimp`.
+-/
 
 @[to_additive (attr := simp)]
 lemma coe_id {X : CommGrp} : (𝟙 X : X → X) = id := rfl
@@ -204,8 +342,8 @@ lemma coe_id {X : CommGrp} : (𝟙 X : X → X) = id := rfl
 @[to_additive (attr := simp)]
 lemma coe_comp {X Y Z : CommGrp} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g : X → Z) = g ∘ f := rfl
 
-@[to_additive]
-lemma comp_def {X Y Z : CommGrp} {f : X ⟶ Y} {g : Y ⟶ Z} : f ≫ g = g.comp f := rfl
+@[to_additive (attr := deprecated "Use hom_comp instead" (since := "2025-01-28"))]
+lemma comp_def {X Y Z : CommGrp} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g).hom = g.hom.comp f.hom := rfl
 
 @[to_additive (attr := simp)]
 lemma forget_map {X Y : CommGrp} (f : X ⟶ Y) :
@@ -214,73 +352,109 @@ lemma forget_map {X Y : CommGrp} (f : X ⟶ Y) :
 
 @[to_additive (attr := ext)]
 lemma ext {X Y : CommGrp} {f g : X ⟶ Y} (w : ∀ x : X, f x = g x) : f = g :=
-  MonoidHom.ext w
-
-/-- Construct a bundled `CommGroup` from the underlying type and typeclass. -/
-@[to_additive]
-def of (G : Type u) [CommGroup G] : CommGrp :=
-  Bundled.of G
-
-/-- Construct a bundled `AddCommGroup` from the underlying type and typeclass. -/
-add_decl_doc AddCommGrp.of
+  ConcreteCategory.hom_ext _ _ w
 
 @[to_additive]
 instance : Inhabited CommGrp :=
   ⟨CommGrp.of PUnit⟩
 
-@[to_additive (attr := simp)]
-theorem coe_of (R : Type u) [CommGroup R] : (CommGrp.of R : Type u) = R :=
+@[to_additive]
+-- This is not `simp` to avoid rewriting in types of terms.
+theorem coe_of (R : Type u) [CommGroup R] : ↑(CommGrp.of R) = R :=
   rfl
 
 @[to_additive (attr := simp)]
-theorem coe_comp' {G H K : Type _} [CommGroup G] [CommGroup H] [CommGroup K]
-    (f : G →* H) (g : H →* K) :
-    @DFunLike.coe (G →* K) G (fun _ ↦ K) MonoidHom.instFunLike (CategoryStruct.comp
-      (X := CommGrp.of G) (Y := CommGrp.of H) (Z := CommGrp.of K) f g) = g ∘ f :=
-  rfl
+lemma hom_id {X : CommGrp} : (𝟙 X : X ⟶ X).hom = MonoidHom.id X := rfl
+
+/- Provided for rewriting. -/
+@[to_additive]
+lemma id_apply (X : CommGrp) (x : X) :
+    (𝟙 X : X ⟶ X) x = x := by simp
 
 @[to_additive (attr := simp)]
-theorem coe_id' {G : Type _} [CommGroup G] :
-    @DFunLike.coe (G →* G) G (fun _ ↦ G) MonoidHom.instFunLike
-      (CategoryStruct.id (X := CommGrp.of G)) = id :=
+lemma hom_comp {X Y T : CommGrp} (f : X ⟶ Y) (g : Y ⟶ T) :
+    (f ≫ g).hom = g.hom.comp f.hom := rfl
+
+/- Provided for rewriting. -/
+@[to_additive]
+lemma comp_apply {X Y T : CommGrp} (f : X ⟶ Y) (g : Y ⟶ T) (x : X) :
+    (f ≫ g) x = g (f x) := by simp
+
+@[to_additive (attr := ext)]
+lemma hom_ext {X Y : CommGrp} {f g : X ⟶ Y} (hf : f.hom = g.hom) : f = g :=
+  Hom.ext hf
+
+@[to_additive (attr := simp)]
+lemma hom_ofHom {X Y : Type u} [CommGroup X] [CommGroup Y] (f : X →* Y) :
+  (ofHom f).hom = f := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_hom {X Y : CommGrp} (f : X ⟶ Y) :
+    ofHom (Hom.hom f) = f := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_id {X : Type u} [CommGroup X] : ofHom (MonoidHom.id X) = 𝟙 (of X) := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_comp {X Y Z : Type u} [CommGroup X] [CommGroup Y] [CommGroup Z]
+    (f : X →* Y) (g : Y →* Z) :
+    ofHom (g.comp f) = ofHom f ≫ ofHom g :=
   rfl
+
+@[to_additive]
+lemma ofHom_apply {X Y : Type u} [CommGroup X] [CommGroup Y] (f : X →* Y) (x : X) :
+    (ofHom f) x = f x := rfl
+
+@[to_additive (attr := simp)]
+lemma inv_hom_apply {X Y : CommGrp} (e : X ≅ Y) (x : X) : e.inv (e.hom x) = x := by
+  rw [← comp_apply]
+  simp
+
+@[to_additive (attr := simp)]
+lemma hom_inv_apply {X Y : CommGrp} (e : X ≅ Y) (s : Y) : e.hom (e.inv s) = s := by
+  rw [← comp_apply]
+  simp
+
+@[to_additive (attr := deprecated "use `coe_comp` instead" (since := "2025-01-28"))]
+alias coe_comp' := coe_comp
+
+@[to_additive (attr := deprecated "use `coe_id` instead" (since := "2025-01-28"))]
+alias coe_id' := coe_id
 
 @[to_additive]
 instance ofUnique (G : Type*) [CommGroup G] [i : Unique G] : Unique (CommGrp.of G) :=
   i
 
 @[to_additive]
-instance hasForgetToGroup : HasForget₂ CommGrp Grp :=
-  BundledHom.forget₂ _ _
+instance hasForgetToGroup : HasForget₂ CommGrp Grp where
+  forget₂.obj X := Grp.of X
+  forget₂.map f := Grp.ofHom f.hom
+
+@[to_additive (attr := simp)] lemma forget₂_grp_map_ofHom {X Y : Type u} [CommGroup X] [CommGroup Y]
+    (f : X →* Y) :
+    (forget₂ CommGrp Grp).map (ofHom f) = Grp.ofHom f := rfl
 
 @[to_additive]
 instance : Coe CommGrp.{u} Grp.{u} where coe := (forget₂ CommGrp Grp).obj
 
 @[to_additive hasForgetToAddCommMonCat]
-instance hasForgetToCommMonCat : HasForget₂ CommGrp CommMonCat :=
-  InducedCategory.hasForget₂ fun G : CommGrp => CommMonCat.of G
+instance hasForgetToCommMonCat : HasForget₂ CommGrp CommMonCat where
+  forget₂.obj X := CommMonCat.of X
+  forget₂.map f := CommMonCat.ofHom f.hom
+
+@[to_additive (attr := simp)] lemma forget₂_commMonCat_map_ofHom {X Y : Type u}
+    [CommGroup X] [CommGroup Y] (f : X →* Y) :
+    (forget₂ CommGrp CommMonCat).map (ofHom f) = CommMonCat.ofHom f := rfl
 
 @[to_additive]
 instance : Coe CommGrp.{u} CommMonCat.{u} where coe := (forget₂ CommGrp CommMonCat).obj
 
 @[to_additive]
-instance (G H : CommGrp) : One (G ⟶ H) := (inferInstance : One (MonoidHom G H))
+instance (G H : CommGrp) : One (G ⟶ H) where
+  one := ofHom 1
 
 @[to_additive (attr := simp)]
 theorem one_apply (G H : CommGrp) (g : G) : ((1 : G ⟶ H) : G → H) g = 1 :=
-  rfl
-
-/-- Typecheck a `MonoidHom` as a morphism in `CommGroup`. -/
-@[to_additive]
-def ofHom {X Y : Type u} [CommGroup X] [CommGroup Y] (f : X →* Y) : of X ⟶ of Y :=
-  f
-
-/-- Typecheck an `AddMonoidHom` as a morphism in `AddCommGroup`. -/
-add_decl_doc AddCommGrp.ofHom
-
-@[to_additive (attr := simp)]
-theorem ofHom_apply {X Y : Type _} [CommGroup X] [CommGroup Y] (f : X →* Y) (x : X) :
-    @DFunLike.coe (X →* Y) X (fun _ ↦ Y) _ (ofHom f) x = f x :=
   rfl
 
 @[to_additive]
@@ -288,19 +462,19 @@ lemma ofHom_injective {X Y : Type u} [CommGroup X] [CommGroup Y] :
     Function.Injective (fun (f : X →* Y) ↦ ofHom f) := by
   intro _ _ h
   ext
-  apply DFunLike.congr_fun h
+  apply ConcreteCategory.congr_hom h
 
 -- We verify that simp lemmas apply when coercing morphisms to functions.
 @[to_additive]
 example {R S : CommGrp} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 := by simp [h]
 
 /-- Universe lift functor for commutative groups. -/
-@[to_additive (attr := simps)
+@[to_additive (attr := simps obj map)
   "Universe lift functor for additive commutative groups."]
 def uliftFunctor : CommGrp.{v} ⥤ CommGrp.{max v u} where
   obj X := CommGrp.of (ULift.{u, v} X)
   map {_ _} f := CommGrp.ofHom <|
-    MulEquiv.ulift.symm.toMonoidHom.comp <| f.comp MulEquiv.ulift.toMonoidHom
+    MulEquiv.ulift.symm.toMonoidHom.comp <| f.hom.comp MulEquiv.ulift.toMonoidHom
   map_id X := by rfl
   map_comp {X Y Z} f g := by rfl
 
@@ -313,21 +487,17 @@ namespace AddCommGrp
 -- TODO generalize this, requiring a `ULiftInstances.lean` file
 /-- Any element of an abelian group gives a unique morphism from `ℤ` sending
 `1` to that element. -/
+@[simps!]
 def asHom {G : AddCommGrp.{0}} (g : G) : AddCommGrp.of ℤ ⟶ G :=
-  zmultiplesHom G g
-
-@[simp]
-theorem asHom_apply {G : AddCommGrp.{0}} (g : G) (i : ℤ) :
-    @DFunLike.coe (ℤ →+ ↑G) ℤ (fun _ ↦ ↑G) _ (asHom g) i = i • g :=
-  rfl
+  ofHom (zmultiplesHom G g)
 
 theorem asHom_injective {G : AddCommGrp.{0}} : Function.Injective (@asHom G) := fun h k w => by
-  convert congr_arg (fun k : AddCommGrp.of ℤ ⟶ G => (k : ℤ → G) (1 : ℤ)) w <;> simp
+  simpa using CategoryTheory.congr_fun w 1
 
 @[ext]
 theorem int_hom_ext {G : AddCommGrp.{0}} (f g : AddCommGrp.of ℤ ⟶ G)
     (w : f (1 : ℤ) = g (1 : ℤ)) : f = g :=
-  @AddMonoidHom.ext_int G _ f g w
+  hom_ext (AddMonoidHom.ext_int w)
 
 -- TODO: this argument should be generalised to the situation where
 -- the forgetful functor is representable.
@@ -342,8 +512,8 @@ end AddCommGrp
 /-- Build an isomorphism in the category `Grp` from a `MulEquiv` between `Group`s. -/
 @[to_additive (attr := simps)]
 def MulEquiv.toGrpIso {X Y : Grp} (e : X ≃* Y) : X ≅ Y where
-  hom := e.toMonoidHom
-  inv := e.symm.toMonoidHom
+  hom := Grp.ofHom e.toMonoidHom
+  inv := Grp.ofHom e.symm.toMonoidHom
 
 /-- Build an isomorphism in the category `AddGroup` from an `AddEquiv` between `AddGroup`s. -/
 add_decl_doc AddEquiv.toAddGrpIso
@@ -352,8 +522,8 @@ add_decl_doc AddEquiv.toAddGrpIso
 between `CommGroup`s. -/
 @[to_additive (attr := simps)]
 def MulEquiv.toCommGrpIso {X Y : CommGrp} (e : X ≃* Y) : X ≅ Y where
-  hom := e.toMonoidHom
-  inv := e.symm.toMonoidHom
+  hom := CommGrp.ofHom e.toMonoidHom
+  inv := CommGrp.ofHom e.symm.toMonoidHom
 
 /-- Build an isomorphism in the category `AddCommGrp` from an `AddEquiv`
 between `AddCommGroup`s. -/
@@ -364,7 +534,7 @@ namespace CategoryTheory.Iso
 /-- Build a `MulEquiv` from an isomorphism in the category `Grp`. -/
 @[to_additive (attr := simp)]
 def groupIsoToMulEquiv {X Y : Grp} (i : X ≅ Y) : X ≃* Y :=
-  MonoidHom.toMulEquiv i.hom i.inv i.hom_inv_id i.inv_hom_id
+  MonoidHom.toMulEquiv i.hom.hom i.inv.hom (by ext; simp) (by ext; simp)
 
 /-- Build an `addEquiv` from an isomorphism in the category `AddGroup` -/
 add_decl_doc addGroupIsoToAddEquiv
@@ -372,7 +542,7 @@ add_decl_doc addGroupIsoToAddEquiv
 /-- Build a `MulEquiv` from an isomorphism in the category `CommGroup`. -/
 @[to_additive (attr := simps!)]
 def commGroupIsoToMulEquiv {X Y : CommGrp} (i : X ≅ Y) : X ≃* Y :=
-  MonoidHom.toMulEquiv i.hom i.inv i.hom_inv_id i.inv_hom_id
+  MonoidHom.toMulEquiv i.hom.hom i.inv.hom (by ext; simp) (by ext; simp)
 
 /-- Build an `AddEquiv` from an isomorphism in the category `AddCommGroup`. -/
 add_decl_doc addCommGroupIsoToAddEquiv
@@ -406,11 +576,11 @@ namespace CategoryTheory.Aut
 /-- The (bundled) group of automorphisms of a type is isomorphic to the (bundled) group
 of permutations. -/
 def isoPerm {α : Type u} : Grp.of (Aut α) ≅ Grp.of (Equiv.Perm α) where
-  hom :=
+  hom := Grp.ofHom
     { toFun := fun g => g.toEquiv
       map_one' := by aesop
       map_mul' := by aesop }
-  inv :=
+  inv := Grp.ofHom
     { toFun := fun g => g.toIso
       map_one' := by aesop
       map_mul' := by aesop }
@@ -457,19 +627,29 @@ abbrev CommGrpMax.{u1, u2} := CommGrp.{max u1 u2}
 abbrev AddCommGrpMax.{u1, u2} := AddCommGrp.{max u1 u2}
 
 /-!
-`@[simp]` lemmas for `MonoidHom.comp` and categorical identities.
+Deprecated lemmas for `MonoidHom.comp` and categorical identities.
 -/
 
-@[to_additive (attr := simp)] theorem MonoidHom.comp_id_grp
-    {G : Grp.{u}} {H : Type u} [Group H] (f : G →* H) : f.comp (𝟙 G) = f :=
-  Category.id_comp (Grp.ofHom f)
-@[to_additive (attr := simp)] theorem MonoidHom.id_grp_comp
-    {G : Type u} [Group G] {H : Grp.{u}} (f : G →* H) : MonoidHom.comp (𝟙 H) f = f :=
-  Category.comp_id (Grp.ofHom f)
+@[to_additive (attr := deprecated
+  "Proven by `simp only [Grp.hom_id, comp_id]`"
+  (since := "2025-01-28"))]
+theorem MonoidHom.comp_id_grp {G : Grp.{u}} {H : Type u} [Monoid H] (f : G →* H) :
+    f.comp (Grp.Hom.hom (𝟙 G)) = f := by simp
+@[to_additive (attr := deprecated
+  "Proven by `simp only [Grp.hom_id, id_comp]`"
+  (since := "2025-01-28"))]
+theorem MonoidHom.id_grp_comp {G : Type u} [Monoid G] {H : Grp.{u}} (f : G →* H) :
+    MonoidHom.comp (Grp.Hom.hom (𝟙 H)) f = f := by simp
 
-@[to_additive (attr := simp)] theorem MonoidHom.comp_id_commGrp
-    {G : CommGrp.{u}} {H : Type u} [CommGroup H] (f : G →* H) : f.comp (𝟙 G) = f :=
-  Category.id_comp (CommGrp.ofHom f)
-@[to_additive (attr := simp)] theorem MonoidHom.id_commGrp_comp
-    {G : Type u} [CommGroup G] {H : CommGrp.{u}} (f : G →* H) : MonoidHom.comp (𝟙 H) f = f :=
-  Category.comp_id (CommGrp.ofHom f)
+@[to_additive (attr := deprecated
+  "Proven by `simp only [CommGrp.hom_id, comp_id]`"
+  (since := "2025-01-28"))]
+theorem MonoidHom.comp_id_commGrp {G : CommGrp.{u}} {H : Type u} [Monoid H] (f : G →* H) :
+    f.comp (CommGrp.Hom.hom (𝟙 G)) = f := by
+  simp
+@[to_additive (attr := deprecated
+  "Proven by `simp only [CommGrp.hom_id, id_comp]`"
+  (since := "2025-01-28"))]
+theorem MonoidHom.id_commGrp_comp {G : Type u} [Monoid G] {H : CommGrp.{u}} (f : G →* H) :
+    MonoidHom.comp (CommGrp.Hom.hom (𝟙 H)) f = f := by
+  simp

--- a/Mathlib/Algebra/Category/Grp/Basic.lean
+++ b/Mathlib/Algebra/Category/Grp/Basic.lean
@@ -26,12 +26,14 @@ open CategoryTheory
 
 /-- The category of additive groups and group morphisms. -/
 structure AddGrp : Type (u + 1) where
+  /-- The underlying type. -/
   (carrier : Type u)
   [str : AddGroup carrier]
 
 /-- The category of groups and group morphisms. -/
 @[to_additive]
 structure Grp : Type (u + 1) where
+  /-- The underlying type. -/
   (carrier : Type u)
   [str : Group carrier]
 
@@ -50,11 +52,8 @@ instance : CoeSort Grp (Type u) :=
 attribute [coe] AddGrp.carrier Grp.carrier
 
 /-- Construct a bundled `Grp` from the underlying type and typeclass. -/
-@[to_additive]
+@[to_additive "Construct a bundled `AddGrp` from the underlying type and typeclass."]
 abbrev of (M : Type u) [Group M] : Grp := ⟨M⟩
-
-/-- Construct a bundled `AddGrp` from the underlying type and typeclass. -/
-add_decl_doc AddGrp.of
 
 end Grp
 
@@ -88,20 +87,14 @@ instance : ConcreteCategory Grp (· →* ·) where
   ofHom := Hom.mk
 
 /-- Turn a morphism in `Grp` back into a `MonoidHom`. -/
-@[to_additive]
+@[to_additive "Turn a morphism in `AddGrp` back into an `AddMonoidHom`."]
 abbrev Hom.hom {X Y : Grp.{u}} (f : Hom X Y) :=
   ConcreteCategory.hom (C := Grp) f
 
-/-- Turn a morphism in `AddGrp` back into an `AddMonoidHom`. -/
-add_decl_doc AddGrp.Hom.hom
-
 /-- Typecheck a `MonoidHom` as a morphism in `Grp`. -/
-@[to_additive]
+@[to_additive "Typecheck an `AddMonoidHom` as a morphism in `AddGrp`. "]
 abbrev ofHom {X Y : Type u} [Group X] [Group Y] (f : X →* Y) : of X ⟶ of Y :=
   ConcreteCategory.ofHom (C := Grp) f
-
-/-- Typecheck an `AddMonoidHom` as a morphism in `AddGrp`. -/
-add_decl_doc AddGrp.ofHom
 
 variable {R} in
 /-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
@@ -244,12 +237,14 @@ end Grp
 
 /-- The category of additive groups and group morphisms. -/
 structure AddCommGrp : Type (u + 1) where
+  /-- The underlying type. -/
   (carrier : Type u)
   [str : AddCommGroup carrier]
 
 /-- The category of groups and group morphisms. -/
 @[to_additive]
 structure CommGrp : Type (u + 1) where
+  /-- The underlying type. -/
   (carrier : Type u)
   [str : CommGroup carrier]
 
@@ -271,11 +266,8 @@ instance : CoeSort CommGrp (Type u) :=
 attribute [coe] AddCommGrp.carrier CommGrp.carrier
 
 /-- Construct a bundled `CommGrp` from the underlying type and typeclass. -/
-@[to_additive]
+@[to_additive "Construct a bundled `AddCommGrp` from the underlying type and typeclass."]
 abbrev of (M : Type u) [CommGroup M] : CommGrp := ⟨M⟩
-
-/-- Construct a bundled `AddCommGrp` from the underlying type and typeclass. -/
-add_decl_doc AddCommGrp.of
 
 end CommGrp
 
@@ -309,23 +301,17 @@ instance : ConcreteCategory CommGrp (· →* ·) where
   ofHom := Hom.mk
 
 /-- Turn a morphism in `CommGrp` back into a `MonoidHom`. -/
-@[to_additive]
+@[to_additive "Turn a morphism in `AddCommGrp` back into an `AddMonoidHom`."]
 abbrev Hom.hom {X Y : CommGrp.{u}} (f : Hom X Y) :=
   ConcreteCategory.hom (C := CommGrp) f
 
-/-- Turn a morphism in `AddCommGrp` back into an `AddMonoidHom`. -/
-add_decl_doc AddCommGrp.Hom.hom
-
 /-- Typecheck a `MonoidHom` as a morphism in `CommGrp`. -/
-@[to_additive]
+@[to_additive "Typecheck an `AddMonoidHom` as a morphism in `AddCommGrp`. "]
 abbrev ofHom {X Y : Type u} [CommGroup X] [CommGroup Y] (f : X →* Y) : of X ⟶ of Y :=
   ConcreteCategory.ofHom (C := CommGrp) f
 
-/-- Typecheck an `AddMonoidHom` as a morphism in `AddCommGrp`. -/
-add_decl_doc AddCommGrp.ofHom
-
 /-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
-@[to_additive]
+@[to_additive "Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas."]
 def Hom.Simps.hom (X Y : CommGrp.{u}) (f : Hom X Y) :=
   f.hom
 

--- a/Mathlib/Algebra/Category/Grp/Biproducts.lean
+++ b/Mathlib/Algebra/Category/Grp/Biproducts.lean
@@ -41,10 +41,11 @@ def binaryProductLimitCone (G H : AddCommGrp.{u}) : Limits.LimitCone (pair G H) 
       π :=
         { app := fun j =>
             Discrete.casesOn j fun j =>
-              WalkingPair.casesOn j (AddMonoidHom.fst G H) (AddMonoidHom.snd G H)
+              WalkingPair.casesOn j (ofHom (AddMonoidHom.fst G H)) (ofHom (AddMonoidHom.snd G H))
           naturality := by rintro ⟨⟨⟩⟩ ⟨⟨⟩⟩ ⟨⟨⟨⟩⟩⟩ <;> rfl } }
   isLimit :=
-    { lift := fun s => AddMonoidHom.prod (s.π.app ⟨WalkingPair.left⟩) (s.π.app ⟨WalkingPair.right⟩)
+    { lift := fun s => ofHom <|
+        AddMonoidHom.prod (s.π.app ⟨WalkingPair.left⟩).hom (s.π.app ⟨WalkingPair.right⟩).hom
       fac := by rintro s (⟨⟩ | ⟨⟩) <;> rfl
       uniq := fun s m w => by
         simp_rw [← w ⟨WalkingPair.left⟩, ← w ⟨WalkingPair.right⟩]
@@ -52,12 +53,12 @@ def binaryProductLimitCone (G H : AddCommGrp.{u}) : Limits.LimitCone (pair G H) 
 
 @[simp]
 theorem binaryProductLimitCone_cone_π_app_left (G H : AddCommGrp.{u}) :
-    (binaryProductLimitCone G H).cone.π.app ⟨WalkingPair.left⟩ = AddMonoidHom.fst G H :=
+    (binaryProductLimitCone G H).cone.π.app ⟨WalkingPair.left⟩ = ofHom (AddMonoidHom.fst G H) :=
   rfl
 
 @[simp]
 theorem binaryProductLimitCone_cone_π_app_right (G H : AddCommGrp.{u}) :
-    (binaryProductLimitCone G H).cone.π.app ⟨WalkingPair.right⟩ = AddMonoidHom.snd G H :=
+    (binaryProductLimitCone G H).cone.π.app ⟨WalkingPair.right⟩ = ofHom (AddMonoidHom.snd G H) :=
   rfl
 
 /-- We verify that the biproduct in `AddCommGrp` is isomorphic to
@@ -69,12 +70,12 @@ noncomputable def biprodIsoProd (G H : AddCommGrp.{u}) :
 
 @[simp, elementwise]
 theorem biprodIsoProd_inv_comp_fst (G H : AddCommGrp.{u}) :
-    (biprodIsoProd G H).inv ≫ biprod.fst = AddMonoidHom.fst G H :=
+    (biprodIsoProd G H).inv ≫ biprod.fst = ofHom (AddMonoidHom.fst G H) :=
   IsLimit.conePointUniqueUpToIso_inv_comp _ _ (Discrete.mk WalkingPair.left)
 
 @[simp, elementwise]
 theorem biprodIsoProd_inv_comp_snd (G H : AddCommGrp.{u}) :
-    (biprodIsoProd G H).inv ≫ biprod.snd = AddMonoidHom.snd G H :=
+    (biprodIsoProd G H).inv ≫ biprod.snd = ofHom (AddMonoidHom.snd G H) :=
   IsLimit.conePointUniqueUpToIso_inv_comp _ _ (Discrete.mk WalkingPair.right)
 
 namespace HasLimit
@@ -84,19 +85,16 @@ variable {J : Type w} (f : J → AddCommGrp.{max w u})
 /-- The map from an arbitrary cone over an indexed family of abelian groups
 to the cartesian product of those groups.
 -/
--- This was marked `@[simps]` until we made `AddCommGrp.coe_of` a simp lemma,
--- after which the simp normal form linter complains.
--- The generated simp lemmas were not used in Mathlib.
--- Possible solution: higher priority function coercions that remove the `of`?
--- @[simps]
-def lift (s : Fan f) : s.pt ⟶ AddCommGrp.of (∀ j, f j) where
-  toFun x j := s.π.app ⟨j⟩ x
-  map_zero' := by
-    simp only [Functor.const_obj_obj, map_zero]
-    rfl
-  map_add' x y := by
-    simp only [Functor.const_obj_obj, map_add]
-    rfl
+@[simps!]
+def lift (s : Fan f) : s.pt ⟶ AddCommGrp.of (∀ j, f j) :=
+  ofHom
+  { toFun x j := s.π.app ⟨j⟩ x
+    map_zero' := by
+      simp only [Functor.const_obj_obj, map_zero]
+      rfl
+    map_add' x y := by
+      simp only [Functor.const_obj_obj, map_add]
+      rfl }
 
 /-- Construct limit data for a product in `AddCommGrp`, using
 `AddCommGrp.of (∀ j, F.obj j)`.
@@ -105,14 +103,13 @@ def lift (s : Fan f) : s.pt ⟶ AddCommGrp.of (∀ j, f j) where
 def productLimitCone : Limits.LimitCone (Discrete.functor f) where
   cone :=
     { pt := AddCommGrp.of (∀ j, f j)
-      π := Discrete.natTrans fun j => Pi.evalAddMonoidHom (fun j => f j) j.as }
+      π := Discrete.natTrans fun j => ofHom <| Pi.evalAddMonoidHom (fun j => f j) j.as }
   isLimit :=
     { lift := lift.{_, u} f
       fac := fun _ _ => rfl
       uniq := fun s m w => by
-        ext x
-        funext j
-        exact congr_arg (fun g : s.pt ⟶ f j => (g : s.pt → f j) x) (w ⟨j⟩) }
+        ext x j
+        exact CategoryTheory.congr_fun (w ⟨j⟩) x }
 
 end HasLimit
 
@@ -129,7 +126,7 @@ noncomputable def biproductIsoPi (f : J → AddCommGrp.{u}) :
 
 @[simp, elementwise]
 theorem biproductIsoPi_inv_comp_π (f : J → AddCommGrp.{u}) (j : J) :
-    (biproductIsoPi f).inv ≫ biproduct.π f j = Pi.evalAddMonoidHom (fun j => f j) j :=
+    (biproductIsoPi f).inv ≫ biproduct.π f j = ofHom (Pi.evalAddMonoidHom (fun j => f j) j) :=
   IsLimit.conePointUniqueUpToIso_inv_comp _ _ (Discrete.mk j)
 
 end AddCommGrp

--- a/Mathlib/Algebra/Category/Grp/Colimits.lean
+++ b/Mathlib/Algebra/Category/Grp/Colimits.lean
@@ -67,7 +67,7 @@ variable (c : Cocone F)
 /-- (implementation detail) Part of the universal property of the colimit cocone, but without
     assuming that `Quot F` lives in the correct universe. -/
 def Quot.desc [DecidableEq J] : Quot.{w} F →+ c.pt := by
-  refine QuotientAddGroup.lift _ (DFinsupp.sumAddHom c.ι.app) ?_
+  refine QuotientAddGroup.lift _ (DFinsupp.sumAddHom fun x => (c.ι.app x).hom) ?_
   dsimp
   rw [AddSubgroup.closure_le]
   intro _ ⟨_, _, _, _, eq⟩
@@ -140,7 +140,7 @@ lemma quotUliftToQuot_ι [DecidableEq J] (j : J) (x : (F ⋙ uliftFunctor.{u'}).
   dsimp [quotUliftToQuot, Quot.ι]
   conv_lhs => erw [AddMonoidHom.comp_apply (QuotientAddGroup.mk' (Relations (F ⋙ uliftFunctor)))
     (DFinsupp.singleAddHom _ j), QuotientAddGroup.lift_mk']
-  simp only [Functor.comp_obj, uliftFunctor_obj, coe_of, DFinsupp.singleAddHom_apply,
+  simp only [Functor.comp_obj, uliftFunctor_obj, DFinsupp.singleAddHom_apply,
     DFinsupp.sumAddHom_single, AddMonoidHom.coe_comp, AddMonoidHom.coe_coe, Function.comp_apply]
   rfl
 
@@ -170,8 +170,8 @@ lemma Quot.desc_quotQuotUliftAddEquiv [DecidableEq J] (c : Cocone F) :
     AddEquiv.ulift.symm.toAddMonoidHom.comp (Quot.desc F c) := by
   refine Quot.addMonoidHom_ext _ (fun j a ↦ ?_)
   dsimp
-  simp only [quotToQuotUlift_ι, Functor.comp_obj, uliftFunctor_obj, coe_of, ι_desc,
-    Functor.const_obj_obj]
+  simp only [quotToQuotUlift_ι, Functor.comp_obj, uliftFunctor_obj, ι_desc,
+    Functor.const_obj_obj, AddMonoidHom.coe_comp, AddMonoidHom.coe_coe, Function.comp_apply, ι_desc]
   erw [Quot.ι_desc]
   rfl
 
@@ -181,10 +181,10 @@ induces a cocone on `F` as long as the universes work out.
 @[simps]
 def toCocone [DecidableEq J] {A : Type w} [AddCommGroup A] (f : Quot F →+ A) : Cocone F where
   pt := AddCommGrp.of A
-  ι := { app := fun j => f.comp (Quot.ι F j) }
+  ι.app j := ofHom <| f.comp (Quot.ι F j)
 
 lemma Quot.desc_toCocone_desc [DecidableEq J] {A : Type w} [AddCommGroup A] (f : Quot F →+ A)
-    (hc : IsColimit c) : (hc.desc (toCocone F f)).comp (Quot.desc F c) = f := by
+    (hc : IsColimit c) : (hc.desc (toCocone F f)).hom.comp (Quot.desc F c) = f := by
   refine Quot.addMonoidHom_ext F (fun j x ↦ ?_)
   rw [AddMonoidHom.comp_apply, ι_desc]
   change (c.ι.app j ≫ hc.desc (toCocone F f)) _ = _
@@ -215,14 +215,14 @@ noncomputable def isColimit_of_bijective_desc [DecidableEq J]
     obtain ⟨x, rfl⟩ := h.2 x
     dsimp
     rw [← AddEquiv.ofBijective_apply _ h, AddEquiv.symm_apply_apply]
-    suffices eq : m.comp (AddEquiv.ofBijective (Quot.desc F c) h) = Quot.desc F s by
+    suffices eq : m.hom.comp (AddEquiv.ofBijective (Quot.desc F c) h) = Quot.desc F s by
       rw [← eq]; rfl
     exact Quot.addMonoidHom_ext F (by simp [← hm])
 
 /-- (internal implementation) The colimit cocone of a functor `F`, implemented as a quotient of
 `DFinsupp (fun j ↦ F.obj j)`, under the assumption that said quotient is small.
 -/
-@[simps]
+@[simps pt ι_app]
 noncomputable def colimitCocone [DecidableEq J] [Small.{w} (Quot.{w} F)] : Cocone F where
   pt := AddCommGrp.of (Shrink (Quot F))
   ι :=
@@ -231,8 +231,6 @@ noncomputable def colimitCocone [DecidableEq J] [Small.{w} (Quot.{w} F)] : Cocon
       naturality _ _ _ := by
         ext
         dsimp
-        simp only [Category.comp_id, ofHom_apply, AddMonoidHom.coe_comp, AddMonoidHom.coe_coe,
-          Function.comp_apply]
         change Shrink.addEquiv.symm _ = _
         rw [Quot.map_ι] }
 
@@ -240,7 +238,7 @@ noncomputable def colimitCocone [DecidableEq J] [Small.{w} (Quot.{w} F)] : Cocon
 theorem Quot.desc_colimitCocone [DecidableEq J] (F : J ⥤ AddCommGrp.{w}) [Small.{w} (Quot F)] :
     Quot.desc F (colimitCocone F) = (Shrink.addEquiv (α := Quot F)).symm.toAddMonoidHom := by
   refine Quot.addMonoidHom_ext F (fun j x ↦ ?_)
-  simp only [colimitCocone_pt, coe_of, AddEquiv.toAddMonoidHom_eq_coe, AddMonoidHom.coe_coe]
+  simp only [colimitCocone_pt, AddEquiv.toAddMonoidHom_eq_coe, AddMonoidHom.coe_coe]
   erw [Quot.ι_desc]
   simp
 
@@ -288,16 +286,17 @@ open QuotientAddGroup
 agrees with the usual group-theoretical quotient.
 -/
 noncomputable def cokernelIsoQuotient {G H : AddCommGrp.{u}} (f : G ⟶ H) :
-    cokernel f ≅ AddCommGrp.of (H ⧸ AddMonoidHom.range f) where
-  hom := cokernel.desc f (mk' _) <| by
+    cokernel f ≅ AddCommGrp.of (H ⧸ AddMonoidHom.range f.hom) where
+  hom := cokernel.desc f (ofHom (mk' _)) <| by
         ext x
+        dsimp only [hom_comp, hom_ofHom]
         apply Quotient.sound
         apply leftRel_apply.mpr
         fconstructor
         · exact -x
         · simp only [add_zero, AddMonoidHom.map_neg]
-  inv :=
-    QuotientAddGroup.lift _ (cokernel.π f) <| by
+  inv := ofHom <|
+    QuotientAddGroup.lift _ (cokernel.π f).hom <| by
       rintro _ ⟨x, rfl⟩
       exact cokernel.condition_apply f x
   hom_inv_id := by
@@ -306,6 +305,8 @@ noncomputable def cokernelIsoQuotient {G H : AddCommGrp.{u}} (f : G ⟶ H) :
     rfl
   inv_hom_id := by
     ext x
-    exact QuotientAddGroup.induction_on x <| cokernel.π_desc_apply f _ _
+    dsimp only [hom_comp, hom_ofHom, hom_zero, AddMonoidHom.coe_comp, coe_mk',
+      Function.comp_apply, AddMonoidHom.zero_apply, id_eq, lift_mk, hom_id, AddMonoidHom.coe_id]
+    exact QuotientAddGroup.induction_on (α := H) x <| cokernel.π_desc_apply f _ _
 
 end AddCommGrp

--- a/Mathlib/Algebra/Category/Grp/EnoughInjectives.lean
+++ b/Mathlib/Algebra/Category/Grp/EnoughInjectives.lean
@@ -33,7 +33,7 @@ instance enoughInjectives : EnoughInjectives AddCommGrp.{u} where
   presentation A_ := Nonempty.intro
     { J := of <| (CharacterModule A_) → ULift.{u} (AddCircle (1 : ℚ))
       injective := injective_of_divisible _
-      f := ⟨⟨fun a i ↦ ULift.up (i a), by aesop⟩, by aesop⟩
+      f := ofHom ⟨⟨fun a i ↦ ULift.up (i a), by aesop⟩, by aesop⟩
       mono := (AddCommGrp.mono_iff_injective _).mpr <| (injective_iff_map_eq_zero _).mpr
         fun _ h0 ↦ eq_zero_of_character_apply (congr_arg ULift.down <| congr_fun h0 ·) }
 

--- a/Mathlib/Algebra/Category/Grp/EpiMono.lean
+++ b/Mathlib/Algebra/Category/Grp/EpiMono.lean
@@ -67,28 +67,28 @@ namespace Grp
 
 -- Porting note: already have Group G but Lean can't use that
 @[to_additive]
-instance (G : Grp) : Group G.α :=
+instance (G : Grp) : Group G.carrier :=
   G.str
 
 variable {A B : Grp.{u}} (f : A ⟶ B)
 
 @[to_additive]
-theorem ker_eq_bot_of_mono [Mono f] : f.ker = ⊥ :=
-  MonoidHom.ker_eq_bot_of_cancel fun u _ =>
-    (@cancel_mono _ _ _ _ _ f _ (show Grp.of f.ker ⟶ A from u) _).1
+theorem ker_eq_bot_of_mono [Mono f] : f.hom.ker = ⊥ :=
+  MonoidHom.ker_eq_bot_of_cancel fun u v h => ConcreteCategory.ext_iff.mp <|
+    (@cancel_mono _ _ _ _ _ f _ (ofHom u) (ofHom v)).1 <| ConcreteCategory.ext h
 
 @[to_additive]
-theorem mono_iff_ker_eq_bot : Mono f ↔ f.ker = ⊥ :=
+theorem mono_iff_ker_eq_bot : Mono f ↔ f.hom.ker = ⊥ :=
   ⟨fun _ => ker_eq_bot_of_mono f, fun h =>
-    ConcreteCategory.mono_of_injective _ <| (MonoidHom.ker_eq_bot_iff f).1 h⟩
+    ConcreteCategory.mono_of_injective _ <| (MonoidHom.ker_eq_bot_iff f.hom).1 h⟩
 
 @[to_additive]
 theorem mono_iff_injective : Mono f ↔ Function.Injective f :=
-  Iff.trans (mono_iff_ker_eq_bot f) <| MonoidHom.ker_eq_bot_iff f
+  Iff.trans (mono_iff_ker_eq_bot f) <| MonoidHom.ker_eq_bot_iff f.hom
 
 namespace SurjectiveOfEpiAuxs
 
-local notation3 "X" => Set.range (· • (f.range : Set B) : B → Set B)
+local notation3 "X" => Set.range (· • (f.hom.range : Set B) : B → Set B)
 
 /-- Define `X'` to be the set of all left cosets with an extra point at "infinity".
 -/
@@ -128,53 +128,49 @@ theorem one_smul (x : X') : (1 : B) • x = x :=
     simp only [one_leftCoset, Subtype.ext_iff_val]
   | ∞ => rfl
 
-theorem fromCoset_eq_of_mem_range {b : B} (hb : b ∈ f.range) :
-    fromCoset ⟨b • ↑f.range, b, rfl⟩ = fromCoset ⟨f.range, 1, one_leftCoset _⟩ := by
+theorem fromCoset_eq_of_mem_range {b : B} (hb : b ∈ f.hom.range) :
+    fromCoset ⟨b • ↑f.hom.range, b, rfl⟩ = fromCoset ⟨f.hom.range, 1, one_leftCoset _⟩ := by
   congr
-  let b : B.α := b
-  change b • (f.range : Set B) = f.range
-  nth_rw 2 [show (f.range : Set B.α) = (1 : B) • f.range from (one_leftCoset _).symm]
+  nth_rw 2 [show (f.hom.range : Set B) = (1 : B) • f.hom.range from (one_leftCoset _).symm]
   rw [leftCoset_eq_iff, mul_one]
   exact Subgroup.inv_mem _ hb
 
 example (G : Type) [Group G] (S : Subgroup G) : Set G := S
 
-theorem fromCoset_ne_of_nin_range {b : B} (hb : b ∉ f.range) :
-    fromCoset ⟨b • ↑f.range, b, rfl⟩ ≠ fromCoset ⟨f.range, 1, one_leftCoset _⟩ := by
+theorem fromCoset_ne_of_nin_range {b : B} (hb : b ∉ f.hom.range) :
+    fromCoset ⟨b • ↑f.hom.range, b, rfl⟩ ≠ fromCoset ⟨f.hom.range, 1, one_leftCoset _⟩ := by
   intro r
   simp only [fromCoset.injEq, Subtype.mk.injEq] at r
-  -- Porting note: annoying dance between types CoeSort.coe B, B.α, and B
-  let b' : B.α := b
-  change b' • (f.range : Set B) = f.range at r
-  nth_rw 2 [show (f.range : Set B.α) = (1 : B) • f.range from (one_leftCoset _).symm] at r
+  nth_rw 2 [show (f.hom.range : Set B) = (1 : B) • f.hom.range from (one_leftCoset _).symm] at r
   rw [leftCoset_eq_iff, mul_one] at r
   exact hb (inv_inv b ▸ Subgroup.inv_mem _ r)
 
 instance : DecidableEq X' :=
   Classical.decEq _
 
-/-- Let `τ` be the permutation on `X'` exchanging `f.range` and the point at infinity.
+/-- Let `τ` be the permutation on `X'` exchanging `f.hom.range` and the point at infinity.
 -/
 noncomputable def tau : SX' :=
-  Equiv.swap (fromCoset ⟨↑f.range, ⟨1, one_leftCoset _⟩⟩) ∞
+  Equiv.swap (fromCoset ⟨↑f.hom.range, ⟨1, one_leftCoset _⟩⟩) ∞
 
 local notation "τ" => tau f
 
-theorem τ_apply_infinity : τ ∞ = fromCoset ⟨f.range, 1, one_leftCoset _⟩ :=
+theorem τ_apply_infinity : τ ∞ = fromCoset ⟨f.hom.range, 1, one_leftCoset _⟩ :=
   Equiv.swap_apply_right _ _
 
-theorem τ_apply_fromCoset : τ (fromCoset ⟨f.range, 1, one_leftCoset _⟩) = ∞ :=
+theorem τ_apply_fromCoset : τ (fromCoset ⟨f.hom.range, 1, one_leftCoset _⟩) = ∞ :=
   Equiv.swap_apply_left _ _
 
-theorem τ_apply_fromCoset' (x : B) (hx : x ∈ f.range) :
-    τ (fromCoset ⟨x • ↑f.range, ⟨x, rfl⟩⟩) = ∞ :=
+theorem τ_apply_fromCoset' (x : B) (hx : x ∈ f.hom.range) :
+    τ (fromCoset ⟨x • ↑f.hom.range, ⟨x, rfl⟩⟩) = ∞ :=
   (fromCoset_eq_of_mem_range _ hx).symm ▸ τ_apply_fromCoset _
 
-theorem τ_symm_apply_fromCoset : Equiv.symm τ (fromCoset ⟨f.range, 1, one_leftCoset _⟩) = ∞ := by
+theorem τ_symm_apply_fromCoset :
+    Equiv.symm τ (fromCoset ⟨f.hom.range, 1, one_leftCoset _⟩) = ∞ := by
   rw [tau, Equiv.symm_swap, Equiv.swap_apply_left]
 
 theorem τ_symm_apply_infinity :
-    Equiv.symm τ ∞ = fromCoset ⟨f.range, 1, one_leftCoset _⟩ := by
+    Equiv.symm τ ∞ = fromCoset ⟨f.hom.range, 1, one_leftCoset _⟩ := by
   rw [tau, Equiv.symm_swap, Equiv.swap_apply_right]
 
 /-- Let `g : B ⟶ S(X')` be defined as such that, for any `β : B`, `g(β)` is the function sending
@@ -215,9 +211,10 @@ local notation "h" => h f
 
 /-!
 The strategy is the following: assuming `epi f`
-* prove that `f.range = {x | h x = g x}`;
+* prove that `f.hom.range = {x | h x = g x}`;
 * thus `f ≫ h = f ≫ g` so that `h = g`;
-* but if `f` is not surjective, then some `x ∉ f.range`, then `h x ≠ g x` at the coset `f.range`.
+* but if `f` is not surjective, then some `x ∉ f.hom.range`, then `h x ≠ g x` at the coset
+`f.hom.range`.
 -/
 
 
@@ -227,70 +224,71 @@ theorem g_apply_fromCoset (x : B) (y : X) :
 
 theorem g_apply_infinity (x : B) : (g x) ∞ = ∞ := rfl
 
-theorem h_apply_infinity (x : B) (hx : x ∈ f.range) : (h x) ∞ = ∞ := by
+theorem h_apply_infinity (x : B) (hx : x ∈ f.hom.range) : (h x) ∞ = ∞ := by
   change ((τ).symm.trans (g x)).trans τ _ = _
   simp only [MonoidHom.coe_mk, Equiv.toFun_as_coe, Equiv.coe_trans, Function.comp_apply]
   rw [τ_symm_apply_infinity, g_apply_fromCoset]
   simpa only using τ_apply_fromCoset' f x hx
 
 theorem h_apply_fromCoset (x : B) :
-    (h x) (fromCoset ⟨f.range, 1, one_leftCoset _⟩) =
-      fromCoset ⟨f.range, 1, one_leftCoset _⟩ := by
+    (h x) (fromCoset ⟨f.hom.range, 1, one_leftCoset _⟩) =
+      fromCoset ⟨f.hom.range, 1, one_leftCoset _⟩ := by
     change ((τ).symm.trans (g x)).trans τ _ = _
     simp [-MonoidHom.coe_range, τ_symm_apply_fromCoset, g_apply_infinity, τ_apply_infinity]
 
-theorem h_apply_fromCoset' (x : B) (b : B) (hb : b ∈ f.range) :
-    h x (fromCoset ⟨b • f.range, b, rfl⟩) = fromCoset ⟨b • ↑f.range, b, rfl⟩ :=
+theorem h_apply_fromCoset' (x : B) (b : B) (hb : b ∈ f.hom.range) :
+    h x (fromCoset ⟨b • f.hom.range, b, rfl⟩) = fromCoset ⟨b • ↑f.hom.range, b, rfl⟩ :=
   (fromCoset_eq_of_mem_range _ hb).symm ▸ h_apply_fromCoset f x
 
-theorem h_apply_fromCoset_nin_range (x : B) (hx : x ∈ f.range) (b : B) (hb : b ∉ f.range) :
-    h x (fromCoset ⟨b • f.range, b, rfl⟩) = fromCoset ⟨(x * b) • ↑f.range, x * b, rfl⟩ := by
+theorem h_apply_fromCoset_nin_range (x : B) (hx : x ∈ f.hom.range) (b : B) (hb : b ∉ f.hom.range) :
+    h x (fromCoset ⟨b • f.hom.range, b, rfl⟩) = fromCoset ⟨(x * b) • ↑f.hom.range, x * b, rfl⟩ := by
   change ((τ).symm.trans (g x)).trans τ _ = _
   simp only [tau, MonoidHom.coe_mk, Equiv.toFun_as_coe, Equiv.coe_trans, Function.comp_apply]
   rw [Equiv.symm_swap,
-    @Equiv.swap_apply_of_ne_of_ne X' _ (fromCoset ⟨f.range, 1, one_leftCoset _⟩) ∞
-      (fromCoset ⟨b • ↑f.range, b, rfl⟩) (fromCoset_ne_of_nin_range _ hb) (by simp)]
+    @Equiv.swap_apply_of_ne_of_ne X' _ (fromCoset ⟨f.hom.range, 1, one_leftCoset _⟩) ∞
+      (fromCoset ⟨b • ↑f.hom.range, b, rfl⟩) (fromCoset_ne_of_nin_range _ hb) (by simp)]
   simp only [g_apply_fromCoset, leftCoset_assoc]
   refine Equiv.swap_apply_of_ne_of_ne (fromCoset_ne_of_nin_range _ fun r => hb ?_) (by simp)
   convert Subgroup.mul_mem _ (Subgroup.inv_mem _ hx) r
   rw [← mul_assoc, inv_mul_cancel, one_mul]
 
-theorem agree : f.range = { x | h x = g x } := by
+theorem agree : f.hom.range = { x | h x = g x } := by
   refine Set.ext fun b => ⟨?_, fun hb : h b = g b => by_contradiction fun r => ?_⟩
   · rintro ⟨a, rfl⟩
     change h (f a) = g (f a)
     ext ⟨⟨_, ⟨y, rfl⟩⟩⟩
     · rw [g_apply_fromCoset]
-      by_cases m : y ∈ f.range
+      by_cases m : y ∈ f.hom.range
       · rw [h_apply_fromCoset' _ _ _ m, fromCoset_eq_of_mem_range _ m]
         change fromCoset _ = fromCoset ⟨f a • (y • _), _⟩
         simp only [← fromCoset_eq_of_mem_range _ (Subgroup.mul_mem _ ⟨a, rfl⟩ m), smul_smul]
       · rw [h_apply_fromCoset_nin_range f (f a) ⟨_, rfl⟩ _ m]
         simp only [leftCoset_assoc]
     · rw [g_apply_infinity, h_apply_infinity f (f a) ⟨_, rfl⟩]
-  · have eq1 : (h b) (fromCoset ⟨f.range, 1, one_leftCoset _⟩) =
-        fromCoset ⟨f.range, 1, one_leftCoset _⟩ := by
+  · have eq1 : (h b) (fromCoset ⟨f.hom.range, 1, one_leftCoset _⟩) =
+        fromCoset ⟨f.hom.range, 1, one_leftCoset _⟩ := by
       change ((τ).symm.trans (g b)).trans τ _ = _
       dsimp [tau]
       simp [g_apply_infinity f]
     have eq2 :
-      g b (fromCoset ⟨f.range, 1, one_leftCoset _⟩) = fromCoset ⟨b • ↑f.range, b, rfl⟩ := rfl
+        g b (fromCoset ⟨f.hom.range, 1, one_leftCoset _⟩) = fromCoset ⟨b • ↑f.hom.range, b, rfl⟩ :=
+      rfl
     exact (fromCoset_ne_of_nin_range _ r).symm (by rw [← eq1, ← eq2, DFunLike.congr_fun hb])
 
-theorem comp_eq : (f ≫ show B ⟶ Grp.of SX' from g) = f ≫ show B ⟶ Grp.of SX' from h := by
+theorem comp_eq : (f ≫ ofHom g) = f ≫ ofHom h := by
   ext a
-  change g (f a) = h (f a)
+  simp only [hom_comp, hom_ofHom, MonoidHom.coe_comp, Function.comp_apply]
   have : f a ∈ { b | h b = g b } := by
     rw [← agree]
     use a
   rw [this]
 
-theorem g_ne_h (x : B) (hx : x ∉ f.range) : g ≠ h := by
+theorem g_ne_h (x : B) (hx : x ∉ f.hom.range) : g ≠ h := by
   intro r
   replace r :=
-    DFunLike.congr_fun (DFunLike.congr_fun r x) (fromCoset ⟨f.range, ⟨1, one_leftCoset _⟩⟩)
+    DFunLike.congr_fun (DFunLike.congr_fun r x) (fromCoset ⟨f.hom.range, ⟨1, one_leftCoset _⟩⟩)
   change _ = ((τ).symm.trans (g x)).trans τ _ at r
-  rw [g_apply_fromCoset, MonoidHom.coe_mk] at r
+  rw [g_apply_fromCoset] at r
   simp only [MonoidHom.coe_range, Subtype.coe_mk, Equiv.symm_swap, Equiv.toFun_as_coe,
     Equiv.coe_trans, Function.comp_apply] at r
   erw [Equiv.swap_apply_left, g_apply_infinity, Equiv.swap_apply_right] at r
@@ -305,13 +303,13 @@ theorem surjective_of_epi [Epi f] : Function.Surjective f := by
   rcases r with ⟨b, hb⟩
   exact
     SurjectiveOfEpiAuxs.g_ne_h f b (fun ⟨c, hc⟩ => hb _ hc)
-      ((cancel_epi f).1 (SurjectiveOfEpiAuxs.comp_eq f))
+      (congr_arg Grp.Hom.hom ((cancel_epi f).1 (SurjectiveOfEpiAuxs.comp_eq f)))
 
 theorem epi_iff_surjective : Epi f ↔ Function.Surjective f :=
   ⟨fun _ => surjective_of_epi f, ConcreteCategory.epi_of_surjective f⟩
 
-theorem epi_iff_range_eq_top : Epi f ↔ f.range = ⊤ :=
-  Iff.trans (epi_iff_surjective _) (Subgroup.eq_top_iff' f.range).symm
+theorem epi_iff_range_eq_top : Epi f ↔ f.hom.range = ⊤ :=
+  Iff.trans (epi_iff_surjective _) (Subgroup.eq_top_iff' f.hom.range).symm
 
 end Grp
 
@@ -327,8 +325,8 @@ theorem epi_iff_surjective : Epi f ↔ Function.Surjective f := by
     apply groupAddGroupEquivalence.inverse.map_epi
   rwa [Grp.epi_iff_surjective] at i1
 
-theorem epi_iff_range_eq_top : Epi f ↔ f.range = ⊤ :=
-  Iff.trans (epi_iff_surjective _) (AddSubgroup.eq_top_iff' f.range).symm
+theorem epi_iff_range_eq_top : Epi f ↔ f.hom.range = ⊤ :=
+  Iff.trans (epi_iff_surjective _) (AddSubgroup.eq_top_iff' f.hom.range).symm
 
 end AddGrp
 
@@ -353,37 +351,33 @@ namespace CommGrp
 variable {A B : CommGrp.{u}} (f : A ⟶ B)
 
 -- Porting note: again to help with non-transparency
-private instance (A : CommGrp) : CommGroup A.α := A.str
-private instance (A : CommGrp) : Group A.α := A.str.toGroup
+private instance (A : CommGrp) : CommGroup A.carrier := A.str
+private instance (A : CommGrp) : Group A.carrier := A.str.toGroup
 
 @[to_additive]
-theorem ker_eq_bot_of_mono [Mono f] : f.ker = ⊥ :=
-  MonoidHom.ker_eq_bot_of_cancel fun u _ =>
-    (@cancel_mono _ _ _ _ _ f _ (show CommGrp.of f.ker ⟶ A from u) _).1
+theorem ker_eq_bot_of_mono [Mono f] : f.hom.ker = ⊥ :=
+  MonoidHom.ker_eq_bot_of_cancel fun u v h => ConcreteCategory.ext_iff.mp <|
+    (@cancel_mono _ _ _ _ _ f _ (ofHom u) (ofHom v)).1 <| ConcreteCategory.ext h
 
 @[to_additive]
-theorem mono_iff_ker_eq_bot : Mono f ↔ f.ker = ⊥ :=
+theorem mono_iff_ker_eq_bot : Mono f ↔ f.hom.ker = ⊥ :=
   ⟨fun _ => ker_eq_bot_of_mono f, fun h =>
-    ConcreteCategory.mono_of_injective _ <| (MonoidHom.ker_eq_bot_iff f).1 h⟩
+    ConcreteCategory.mono_of_injective _ <| (MonoidHom.ker_eq_bot_iff f.hom).1 h⟩
 
 @[to_additive]
 theorem mono_iff_injective : Mono f ↔ Function.Injective f :=
-  Iff.trans (mono_iff_ker_eq_bot f) <| MonoidHom.ker_eq_bot_iff f
+  Iff.trans (mono_iff_ker_eq_bot f) <| MonoidHom.ker_eq_bot_iff f.hom
 
 @[to_additive]
-theorem range_eq_top_of_epi [Epi f] : f.range = ⊤ :=
-  MonoidHom.range_eq_top_of_cancel fun u v h =>
-    (@cancel_epi _ _ _ _ _ f _ (show B ⟶ ⟨B ⧸ MonoidHom.range f, inferInstance⟩ from u) v).1 h
-
--- Porting note: again lack of transparency
-@[to_additive]
-instance (G : CommGrp) : CommGroup <| (forget CommGrp).obj G :=
-  G.str
+theorem range_eq_top_of_epi [Epi f] : f.hom.range = ⊤ :=
+  MonoidHom.range_eq_top_of_cancel fun u v h => ConcreteCategory.ext_iff.mp <|
+    (@cancel_epi _ _ _ _ _ f _ (ofHom u) (ofHom v)).1 (ConcreteCategory.ext h)
 
 @[to_additive]
-theorem epi_iff_range_eq_top : Epi f ↔ f.range = ⊤ :=
+theorem epi_iff_range_eq_top : Epi f ↔ f.hom.range = ⊤ :=
   ⟨fun _ => range_eq_top_of_epi _, fun hf =>
-    ConcreteCategory.epi_of_surjective _ <| MonoidHom.range_eq_top.mp hf⟩
+    ConcreteCategory.epi_of_surjective _ <| show Function.Surjective f.hom from
+      MonoidHom.range_eq_top.mp hf⟩
 
 @[to_additive]
 theorem epi_iff_surjective : Epi f ↔ Function.Surjective f := by

--- a/Mathlib/Algebra/Category/Grp/EquivalenceGroupAddGroup.lean
+++ b/Mathlib/Algebra/Category/Grp/EquivalenceGroupAddGroup.lean
@@ -25,7 +25,7 @@ namespace Grp
 @[simps]
 def toAddGrp : Grp ⥤ AddGrp where
   obj X := AddGrp.of (Additive X)
-  map {_} {_} := MonoidHom.toAdditive
+  map {_} {_} f := AddGrp.ofHom f.hom.toAdditive
 
 end Grp
 
@@ -36,7 +36,7 @@ namespace CommGrp
 @[simps]
 def toAddCommGrp : CommGrp ⥤ AddCommGrp where
   obj X := AddCommGrp.of (Additive X)
-  map {_} {_} := MonoidHom.toAdditive
+  map {_} {_} f := AddCommGrp.ofHom f.hom.toAdditive
 
 end CommGrp
 
@@ -47,7 +47,7 @@ namespace AddGrp
 @[simps]
 def toGrp : AddGrp ⥤ Grp where
   obj X := Grp.of (Multiplicative X)
-  map {_} {_} := AddMonoidHom.toMultiplicative
+  map {_} {_} f := Grp.ofHom f.hom.toMultiplicative
 
 end AddGrp
 
@@ -58,7 +58,7 @@ namespace AddCommGrp
 @[simps]
 def toCommGrp : AddCommGrp ⥤ CommGrp where
   obj X := CommGrp.of (Multiplicative X)
-  map {_} {_} := AddMonoidHom.toMultiplicative
+  map {_} {_} f := CommGrp.ofHom f.hom.toMultiplicative
 
 end AddCommGrp
 

--- a/Mathlib/Algebra/Category/Grp/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/Grp/FilteredColimits.lean
@@ -108,23 +108,25 @@ noncomputable def colimit : Grp.{max v u} :=
 @[to_additive "The cocone over the proposed colimit additive group."]
 noncomputable def colimitCocone : Cocone F where
   pt := colimit.{v, u} F
-  ι := { (MonCat.FilteredColimits.colimitCocone (F ⋙ forget₂ Grp MonCat.{max v u})).ι with }
+  ι.app J := Grp.ofHom ((MonCat.FilteredColimits.colimitCocone (F ⋙ forget₂ Grp MonCat)).ι.app J)
+  ι.naturality _ _ f := (forget₂ _ MonCat).map_injective
+    ((MonCat.FilteredColimits.colimitCocone _).ι.naturality f)
 
 /-- The proposed colimit cocone is a colimit in `Grp`. -/
 @[to_additive "The proposed colimit cocone is a colimit in `AddGroup`."]
 def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
-  desc t :=
+  desc t := Grp.ofHom <|
     MonCat.FilteredColimits.colimitDesc.{v, u} (F ⋙ forget₂ Grp MonCat.{max v u})
       ((forget₂ Grp MonCat).mapCocone t)
   fac t j :=
-    DFunLike.coe_injective <|
+    ConcreteCategory.coe_ext <|
       (Types.TypeMax.colimitCoconeIsColimit.{v, u} (F ⋙ forget Grp)).fac
       ((forget Grp).mapCocone t) j
   uniq t _ h :=
-    DFunLike.coe_injective' <|
+    ConcreteCategory.coe_ext <|
       (Types.TypeMax.colimitCoconeIsColimit.{v, u} (F ⋙ forget Grp)).uniq
       ((forget Grp).mapCocone t) _
-        fun j => funext fun x => DFunLike.congr_fun (h j) x
+        fun j => funext fun x => ConcreteCategory.congr_hom (h j) x
 
 @[to_additive forget₂AddMon_preservesFilteredColimits]
 noncomputable instance forget₂Mon_preservesFilteredColimits :
@@ -175,25 +177,26 @@ noncomputable def colimit : CommGrp :=
 @[to_additive "The cocone over the proposed colimit additive commutative group."]
 noncomputable def colimitCocone : Cocone F where
   pt := colimit.{v, u} F
-  ι :=
-    { (Grp.FilteredColimits.colimitCocone
-          (F ⋙ forget₂ CommGrp Grp.{max v u})).ι with }
+  ι.app J := CommGrp.ofHom
+    ((Grp.FilteredColimits.colimitCocone (F ⋙ forget₂ CommGrp Grp)).ι.app J).hom
+  ι.naturality _ _ f := (forget₂ _ Grp).map_injective
+    ((Grp.FilteredColimits.colimitCocone _).ι.naturality f)
 
 /-- The proposed colimit cocone is a colimit in `CommGrp`. -/
 @[to_additive "The proposed colimit cocone is a colimit in `AddCommGroup`."]
 def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
-  desc t :=
-    (Grp.FilteredColimits.colimitCoconeIsColimit.{v, u}
+  desc t := CommGrp.ofHom
+    ((Grp.FilteredColimits.colimitCoconeIsColimit.{v, u}
           (F ⋙ forget₂ CommGrp Grp.{max v u})).desc
-      ((forget₂ CommGrp Grp.{max v u}).mapCocone t)
+      ((forget₂ CommGrp Grp.{max v u}).mapCocone t)).hom
   fac t j :=
-    DFunLike.coe_injective <|
+    ConcreteCategory.coe_ext <|
       (Types.TypeMax.colimitCoconeIsColimit.{v, u} (F ⋙ forget CommGrp)).fac
         ((forget CommGrp).mapCocone t) j
   uniq t _ h :=
-    DFunLike.coe_injective <|
+    ConcreteCategory.coe_ext <|
       (Types.TypeMax.colimitCoconeIsColimit.{v, u} (F ⋙ forget CommGrp)).uniq
-        ((forget CommGrp).mapCocone t) _ fun j => funext fun x => DFunLike.congr_fun (h j) x
+        ((forget CommGrp).mapCocone t) _ fun j => funext fun x => ConcreteCategory.congr_hom (h j) x
 
 @[to_additive]
 noncomputable instance forget₂Group_preservesFilteredColimits :

--- a/Mathlib/Algebra/Category/Grp/FiniteGrp.lean
+++ b/Mathlib/Algebra/Category/Grp/FiniteGrp.lean
@@ -44,21 +44,13 @@ instance : CoeSort FiniteGrp.{u} (Type u) where
 instance : Category FiniteGrp := InducedCategory.category FiniteGrp.toGrp
 
 @[to_additive]
-instance : HasForget FiniteGrp := InducedCategory.hasForget FiniteGrp.toGrp
+instance : ConcreteCategory FiniteGrp (· →* ·) := InducedCategory.concreteCategory FiniteGrp.toGrp
 
 @[to_additive]
 instance (G : FiniteGrp) : Group G := inferInstanceAs <| Group G.toGrp
 
 @[to_additive]
 instance (G : FiniteGrp) : Finite G := G.isFinite
-
-@[to_additive]
-instance (G H : FiniteGrp) : FunLike (G ⟶ H) G H :=
-  inferInstanceAs <| FunLike (G →* H) G H
-
-@[to_additive]
-instance (G H : FiniteGrp) : MonoidHomClass (G ⟶ H) G H :=
-  inferInstanceAs <| MonoidHomClass (G →* H) G H
 
 /-- Construct a term of `FiniteGrp` from a type endowed with the structure of a finite group. -/
 @[to_additive "Construct a term of `FiniteAddGrp` from a type endowed with the structure of a

--- a/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
@@ -56,22 +56,26 @@ end AddMonoidHom
 /-- The forget functor `Grp.{u} ⥤ Type u` is corepresentable. -/
 def Grp.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} (Multiplicative ℤ)))) ≅ forget Grp.{u} :=
-  (NatIso.ofComponents (fun M => (MonoidHom.fromULiftMultiplicativeIntEquiv M.α).toIso))
+  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
+    (MonoidHom.fromULiftMultiplicativeIntEquiv M.carrier)).toIso))
 
 /-- The forget functor `CommGrp.{u} ⥤ Type u` is corepresentable. -/
 def CommGrp.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} (Multiplicative ℤ)))) ≅ forget CommGrp.{u} :=
-  (NatIso.ofComponents (fun M => (MonoidHom.fromULiftMultiplicativeIntEquiv M.α).toIso))
+  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
+    (MonoidHom.fromULiftMultiplicativeIntEquiv M.carrier)).toIso))
 
 /-- The forget functor `AddGrp.{u} ⥤ Type u` is corepresentable. -/
 def AddGrp.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} ℤ))) ≅ forget AddGrp.{u} :=
-  (NatIso.ofComponents (fun M => (AddMonoidHom.fromULiftIntEquiv M.α).toIso))
+  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
+    (AddMonoidHom.fromULiftIntEquiv M.carrier)).toIso))
 
 /-- The forget functor `AddCommGrp.{u} ⥤ Type u` is corepresentable. -/
 def AddCommGrp.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} ℤ))) ≅ forget AddCommGrp.{u} :=
-  (NatIso.ofComponents (fun M => (AddMonoidHom.fromULiftIntEquiv M.α).toIso))
+  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
+    (AddMonoidHom.fromULiftIntEquiv M.carrier)).toIso))
 
 instance Grp.forget_isCorepresentable :
     (forget Grp.{u}).IsCorepresentable :=

--- a/Mathlib/Algebra/Category/Grp/Images.lean
+++ b/Mathlib/Algebra/Category/Grp/Images.lean
@@ -34,18 +34,18 @@ section
 -- implementation details of `IsImage` for `AddCommGrp`; use the API, not these
 /-- the image of a morphism in `AddCommGrp` is just the bundling of `AddMonoidHom.range f` -/
 def image : AddCommGrp :=
-  AddCommGrp.of (AddMonoidHom.range f)
+  AddCommGrp.of (AddMonoidHom.range f.hom)
 
 /-- the inclusion of `image f` into the target -/
 def image.ι : image f ⟶ H :=
-  f.range.subtype
+  ofHom f.hom.range.subtype
 
 instance : Mono (image.ι f) :=
   ConcreteCategory.mono_of_injective (image.ι f) Subtype.val_injective
 
 /-- the corestriction map to the image -/
 def factorThruImage : G ⟶ image f :=
-  f.rangeRestrict
+  ofHom f.hom.rangeRestrict
 
 theorem image.fac : factorThruImage f ≫ image.ι f = f := by
   ext
@@ -56,25 +56,26 @@ attribute [local simp] image.fac
 variable {f}
 
 /-- the universal property for the image factorisation -/
-noncomputable def image.lift (F' : MonoFactorisation f) : image f ⟶ F'.I where
-  toFun := (fun x => F'.e (Classical.indefiniteDescription _ x.2).1 : image f → F'.I)
-  map_zero' := by
-    haveI := F'.m_mono
-    apply injective_of_mono F'.m
-    change (F'.e ≫ F'.m) _ = _
-    rw [F'.fac, AddMonoidHom.map_zero]
-    exact (Classical.indefiniteDescription (fun y => f y = 0) _).2
-  map_add' := by
-    intro x y
-    haveI := F'.m_mono
-    apply injective_of_mono F'.m
-    rw [AddMonoidHom.map_add]
-    change (F'.e ≫ F'.m) _ = (F'.e ≫ F'.m) _ + (F'.e ≫ F'.m) _
-    rw [F'.fac]
-    rw [(Classical.indefiniteDescription (fun z => f z = _) _).2]
-    rw [(Classical.indefiniteDescription (fun z => f z = _) _).2]
-    rw [(Classical.indefiniteDescription (fun z => f z = _) _).2]
-    rfl
+noncomputable def image.lift (F' : MonoFactorisation f) : image f ⟶ F'.I :=
+  ofHom
+  { toFun := (fun x => F'.e (Classical.indefiniteDescription _ x.2).1 : image f → F'.I)
+    map_zero' := by
+      haveI := F'.m_mono
+      apply injective_of_mono F'.m
+      change (F'.e ≫ F'.m) _ = _
+      rw [F'.fac, AddMonoidHom.map_zero]
+      exact (Classical.indefiniteDescription (fun y => f y = 0) _).2
+    map_add' := by
+      intro x y
+      haveI := F'.m_mono
+      apply injective_of_mono F'.m
+      rw [AddMonoidHom.map_add]
+      change (F'.e ≫ F'.m) _ = (F'.e ≫ F'.m) _ + (F'.e ≫ F'.m) _
+      rw [F'.fac]
+      rw [(Classical.indefiniteDescription (fun z => f z = _) _).2]
+      rw [(Classical.indefiniteDescription (fun z => f z = _) _).2]
+      rw [(Classical.indefiniteDescription (fun z => f z = _) _).2]
+      rfl }
 
 theorem image.lift_fac (F' : MonoFactorisation f) : image.lift F' ≫ F'.m = image.ι f := by
   ext x
@@ -100,7 +101,7 @@ noncomputable def isImage : IsImage (monoFactorisation f) where
 agrees with the usual group-theoretical range.
 -/
 noncomputable def imageIsoRange {G H : AddCommGrp.{0}} (f : G ⟶ H) :
-    Limits.image f ≅ AddCommGrp.of f.range :=
+    Limits.image f ≅ AddCommGrp.of f.hom.range :=
   IsImage.isoExt (Image.isImage f) (isImage f)
 
 end AddCommGrp

--- a/Mathlib/Algebra/Category/Grp/Injective.lean
+++ b/Mathlib/Algebra/Category/Grp/Injective.lean
@@ -58,11 +58,11 @@ theorem Module.Baer.of_divisible [DivisibleBy A ℤ] : Module.Baer ℤ A := fun 
 namespace AddCommGrp
 
 theorem injective_as_module_iff : Injective (ModuleCat.of ℤ A) ↔
-    Injective (⟨A,inferInstance⟩ : AddCommGrp) :=
+    Injective (C := AddCommGrp) (AddCommGrp.of A) :=
   ((forget₂ (ModuleCat ℤ) AddCommGrp).asEquivalence.map_injective_iff (ModuleCat.of ℤ A)).symm
 
 instance injective_of_divisible [DivisibleBy A ℤ] :
-    Injective (⟨A,inferInstance⟩ : AddCommGrp) :=
+    Injective (C := AddCommGrp) (AddCommGrp.of A) :=
   (injective_as_module_iff A).mp <|
     Module.injective_object_of_injective_module (inj := (Module.Baer.of_divisible A).injective)
 

--- a/Mathlib/Algebra/Category/Grp/Kernels.lean
+++ b/Mathlib/Algebra/Category/Grp/Kernels.lean
@@ -21,25 +21,27 @@ variable {G H : AddCommGrp.{u}} (f : G ⟶ H)
 
 /-- The kernel cone induced by the concrete kernel. -/
 def kernelCone : KernelFork f :=
-  KernelFork.ofι (Z := of f.ker) f.ker.subtype <| ext fun x => x.casesOn fun _ hx => hx
+  KernelFork.ofι (Z := of f.hom.ker) (ofHom f.hom.ker.subtype) <| ext fun x =>
+    x.casesOn fun _ hx => hx
 
 /-- The kernel of a group homomorphism is a kernel in the categorical sense. -/
 def kernelIsLimit : IsLimit <| kernelCone f :=
   Fork.IsLimit.mk _
-    (fun s => (by exact Fork.ι s : _ →+ G).codRestrict _ fun c => mem_ker.mpr <|
-      by exact DFunLike.congr_fun s.condition c)
+    (fun s => ofHom <| s.ι.hom.codRestrict _ fun c => mem_ker.mpr <|
+      ConcreteCategory.congr_hom s.condition c)
     (fun _ => by rfl)
-    (fun _ _ h => ext fun x => Subtype.ext_iff_val.mpr <| by exact DFunLike.congr_fun h x)
+    (fun _ _ h => ext fun x => Subtype.ext_iff_val.mpr <| ConcreteCategory.congr_hom h x)
 
 /-- The cokernel cocone induced by the projection onto the quotient. -/
 def cokernelCocone : CokernelCofork f :=
-  CokernelCofork.ofπ (Z := of <| H ⧸ f.range) (mk' f.range) <| ext fun x =>
+  CokernelCofork.ofπ (Z := of <| H ⧸ f.hom.range) (ofHom (mk' f.hom.range)) <| ext fun x =>
     (eq_zero_iff _).mpr ⟨x, rfl⟩
 
 /-- The projection onto the quotient is a cokernel in the categorical sense. -/
 def cokernelIsColimit : IsColimit <| cokernelCocone f :=
   Cofork.IsColimit.mk _
-    (fun s => lift _ _ <| (range_le_ker_iff _ _).mpr <| CokernelCofork.condition s)
+    (fun s => ofHom <| lift _ _ <| (range_le_ker_iff _ _).mpr <|
+      congr_arg Hom.hom (CokernelCofork.condition s))
     (fun _ => rfl)
     (fun _ _ h => have : Epi (cokernelCocone f).π := (epi_iff_surjective _).mpr <| mk'_surjective _
       (cancel_epi (cokernelCocone f).π).mp <| by simpa only [parallelPair_obj_one] using h)

--- a/Mathlib/Algebra/Category/Grp/LargeColimits.lean
+++ b/Mathlib/Algebra/Category/Grp/LargeColimits.lean
@@ -40,8 +40,9 @@ lemma isColimit_iff_bijective_desc [DecidableEq J] :
     apply ofHom_injective
     refine hc.hom_ext (fun j ↦ ?_)
     ext x
-    rw [CategoryTheory.comp_apply, CategoryTheory.comp_apply, ← Quot.ι_desc _ c j x]
-    exact ULift.down_injective (DFunLike.congr_fun eq (Quot.ι F j x))
+    rw [ConcreteCategory.comp_apply, ConcreteCategory.comp_apply, ← Quot.ι_desc _ c j x]
+    simp only [hom_ofHom, AddMonoidHom.postcompEquiv_apply, AddMonoidHom.comp_apply]
+    exact DFunLike.congr_fun eq (Quot.ι F j x)
   · set c' : Cocone F :=
       { pt := AddCommGrp.of (ULift (AddCircle (1 : ℚ)))
         ι :=
@@ -49,11 +50,9 @@ lemma isColimit_iff_bijective_desc [DecidableEq J] :
                        (Quot.ι F j))
             naturality {j j'} u := by
               ext
-              change ofHom ((AddEquiv.ulift.symm.toAddMonoidHom.comp χ).comp _) (F.map u _) = _
               dsimp
-              rw [Quot.map_ι F (f := u)]
-              rfl } }
-    use AddEquiv.ulift.toAddMonoidHom.comp (hc.desc c')
+              rw [Quot.map_ι F (f := u)] } }
+    use AddEquiv.ulift.toAddMonoidHom.comp (hc.desc c').hom
     refine Quot.addMonoidHom_ext _ (fun j x ↦ ?_)
     dsimp
     rw [Quot.ι_desc]

--- a/Mathlib/Algebra/Category/Grp/Limits.lean
+++ b/Mathlib/Algebra/Category/Grp/Limits.lean
@@ -46,7 +46,7 @@ def sectionsSubgroup : Subgroup (∀ j, F.obj j) :=
     inv_mem' := fun {a} ah j j' f => by
       simp only [Functor.comp_map, Pi.inv_apply, MonoidHom.map_inv, inv_inj]
       dsimp [Functor.sections] at ah ⊢
-      rw [(F.map f).map_inv (a j), ah f] }
+      rw [(F.map f).hom.map_inv (a j), ah f] }
 
 @[to_additive]
 instance sectionsGroup : Group (F ⋙ forget Grp.{u}).sections :=
@@ -95,10 +95,10 @@ noncomputable instance Forget₂.createsLimit :
       { liftedCone :=
           { pt := Grp.of (Types.Small.limitCone (F ⋙ forget Grp)).pt
             π :=
-              { app := MonCat.limitπMonoidHom (F ⋙ forget₂ Grp MonCat)
-                naturality :=
+              { app j := ofHom <| MonCat.limitπMonoidHom (F ⋙ forget₂ Grp MonCat) j
+                naturality i j h:= hom_ext <|
                   (MonCat.HasLimits.limitCone
-                        (F ⋙ forget₂ Grp MonCat.{u})).π.naturality } }
+                        (F ⋙ forget₂ Grp MonCat.{u})).π.naturality h } }
         validLift := by apply IsLimit.uniqueUpToIso (MonCat.HasLimits.limitConeIsLimit.{v, u} _) t
         makesLimit :=
          IsLimit.ofFaithful (forget₂ Grp MonCat.{u}) (MonCat.HasLimits.limitConeIsLimit _)
@@ -262,9 +262,9 @@ noncomputable instance Forget₂.createsLimit :
       { liftedCone :=
           { pt := CommGrp.of (Types.Small.limitCone.{v, u} (F ⋙ forget CommGrp)).pt
             π :=
-              { app := MonCat.limitπMonoidHom
-                  (F ⋙ forget₂ CommGrp Grp.{u} ⋙ forget₂ Grp MonCat.{u})
-                naturality := (MonCat.HasLimits.limitCone _).π.naturality } }
+              { app j := ofHom <| MonCat.limitπMonoidHom
+                  (F ⋙ forget₂ CommGrp Grp.{u} ⋙ forget₂ Grp MonCat.{u}) j
+                naturality i j h := hom_ext <| (MonCat.HasLimits.limitCone _).π.naturality h } }
         validLift := by apply IsLimit.uniqueUpToIso (Grp.limitConeIsLimit _) hc
         makesLimit :=
           IsLimit.ofFaithful (forget₂ _ Grp.{u} ⋙ forget₂ _ MonCat.{u})
@@ -452,40 +452,36 @@ namespace AddCommGrp
 agrees with the usual group-theoretical kernel.
 -/
 def kernelIsoKer {G H : AddCommGrp.{u}} (f : G ⟶ H) :
-    kernel f ≅ AddCommGrp.of f.ker where
-  hom :=
-    { toFun := fun g => ⟨kernel.ι f g, DFunLike.congr_fun (kernel.condition f) g⟩
+    kernel f ≅ AddCommGrp.of f.hom.ker where
+  hom := ofHom
+    { toFun := fun g => ⟨kernel.ι f g, ConcreteCategory.congr_hom (kernel.condition f) g⟩
       map_zero' := by
         refine Subtype.ext ?_
         simp [(AddSubgroup.coe_zero _).symm]
       map_add' := fun g g' => by
         refine Subtype.ext ?_
-        change _ = _ + _
-        dsimp
         simp }
-  inv := kernel.lift f (AddSubgroup.subtype f.ker) <| by ext x; exact x.2
+  inv := kernel.lift f (ofHom (AddSubgroup.subtype f.hom.ker)) <| by ext x; exact x.2
   hom_inv_id := by
     -- Porting note (https://github.com/leanprover-community/mathlib4/pull/11041): it would be nice to do the next two steps by a single `ext`,
     -- but this will require thinking carefully about the relative priorities of `@[ext]` lemmas.
     refine equalizer.hom_ext ?_
     ext x
-    dsimp
-    apply DFunLike.congr_fun (kernel.lift_ι f _ _)
+    apply ConcreteCategory.congr_hom (kernel.lift_ι f _ _)
   inv_hom_id := by
     apply AddCommGrp.ext
     simp only [AddMonoidHom.coe_mk, coe_id, coe_comp]
     rintro ⟨x, mem⟩
     refine Subtype.ext ?_
-    simp only [ZeroHom.coe_mk, Function.comp_apply, id_eq]
-    apply DFunLike.congr_fun (kernel.lift_ι f _ _)
+    apply ConcreteCategory.congr_hom (kernel.lift_ι f _ _)
 
 @[simp]
 theorem kernelIsoKer_hom_comp_subtype {G H : AddCommGrp.{u}} (f : G ⟶ H) :
-    (kernelIsoKer f).hom ≫ AddSubgroup.subtype f.ker = kernel.ι f := by ext; rfl
+    (kernelIsoKer f).hom ≫ ofHom (AddSubgroup.subtype f.hom.ker) = kernel.ι f := by ext; rfl
 
 @[simp]
 theorem kernelIsoKer_inv_comp_ι {G H : AddCommGrp.{u}} (f : G ⟶ H) :
-    (kernelIsoKer f).inv ≫ kernel.ι f = AddSubgroup.subtype f.ker := by
+    (kernelIsoKer f).inv ≫ kernel.ι f = ofHom (AddSubgroup.subtype f.hom.ker) := by
   ext
   simp [kernelIsoKer]
 
@@ -493,7 +489,8 @@ theorem kernelIsoKer_inv_comp_ι {G H : AddCommGrp.{u}} (f : G ⟶ H) :
 agrees with the `AddSubgroup.subtype` map.
 -/
 def kernelIsoKerOver {G H : AddCommGrp.{u}} (f : G ⟶ H) :
-    Over.mk (kernel.ι f) ≅ @Over.mk _ _ G (AddCommGrp.of f.ker) (AddSubgroup.subtype f.ker) :=
+    Over.mk (kernel.ι f) ≅ @Over.mk _ _ G (AddCommGrp.of f.hom.ker)
+      (ofHom (AddSubgroup.subtype f.hom.ker)) :=
   Over.isoMk (kernelIsoKer f)
 
 end AddCommGrp

--- a/Mathlib/Algebra/Category/Grp/Limits.lean
+++ b/Mathlib/Algebra/Category/Grp/Limits.lean
@@ -19,7 +19,6 @@ the underlying types are just the limits in the category of types.
 
 -/
 
-
 open CategoryTheory CategoryTheory.Limits
 
 universe v u w
@@ -457,7 +456,7 @@ def kernelIsoKer {G H : AddCommGrp.{u}} (f : G ⟶ H) :
     { toFun := fun g => ⟨kernel.ι f g, ConcreteCategory.congr_hom (kernel.condition f) g⟩
       map_zero' := by
         refine Subtype.ext ?_
-        simp [(AddSubgroup.coe_zero _).symm]
+        simp only [Functor.comp_obj, map_zero, ZeroMemClass.coe_zero]
       map_add' := fun g g' => by
         refine Subtype.ext ?_
         simp }
@@ -466,11 +465,10 @@ def kernelIsoKer {G H : AddCommGrp.{u}} (f : G ⟶ H) :
     -- Porting note (https://github.com/leanprover-community/mathlib4/pull/11041): it would be nice to do the next two steps by a single `ext`,
     -- but this will require thinking carefully about the relative priorities of `@[ext]` lemmas.
     refine equalizer.hom_ext ?_
-    ext x
-    apply ConcreteCategory.congr_hom (kernel.lift_ι f _ _)
+    ext
+    simp
   inv_hom_id := by
     apply AddCommGrp.ext
-    simp only [AddMonoidHom.coe_mk, coe_id, coe_comp]
     rintro ⟨x, mem⟩
     refine Subtype.ext ?_
     apply ConcreteCategory.congr_hom (kernel.lift_ι f _ _)

--- a/Mathlib/Algebra/Category/Grp/Preadditive.lean
+++ b/Mathlib/Algebra/Category/Grp/Preadditive.lean
@@ -16,13 +16,50 @@ universe u
 
 namespace AddCommGrp
 
-instance (P Q : AddCommGrp) : AddCommGroup (P ⟶ Q) :=
-  (inferInstance : AddCommGroup (AddMonoidHom P Q))
+variable {M N : AddCommGrp.{u}}
 
--- Porting note (https://github.com/leanprover-community/mathlib4/pull/10688): this lemma was not necessary in mathlib
-@[simp]
+instance : Add (M ⟶ N) where
+  add f g := ofHom (f.hom + g.hom)
+
+@[simp] lemma hom_add (f g : M ⟶ N) : (f + g).hom = f.hom + g.hom := rfl
+
 lemma hom_add_apply {P Q : AddCommGrp} (f g : P ⟶ Q) (x : P) : (f + g) x = f x + g x := rfl
 
+instance : Zero (M ⟶ N) where
+  zero := ofHom 0
+
+@[simp] lemma hom_zero : (0 : M ⟶ N).hom = 0 := rfl
+
+instance : SMul ℕ (M ⟶ N) where
+  smul n f := ofHom (n • f.hom)
+
+@[simp] lemma hom_nsmul (n : ℕ) (f : M ⟶ N) : (n • f).hom = n • f.hom := rfl
+
+instance : Neg (M ⟶ N) where
+  neg f := ofHom (-f.hom)
+
+@[simp] lemma hom_neg (f : M ⟶ N) : (-f).hom = -f.hom := rfl
+
+instance : Sub (M ⟶ N) where
+  sub f g := ofHom (f.hom - g.hom)
+
+@[simp] lemma hom_sub (f g : M ⟶ N) : (f - g).hom = f.hom - g.hom := rfl
+
+instance : SMul ℤ (M ⟶ N) where
+  smul n f := ofHom (n • f.hom)
+
+@[simp] lemma hom_zsmul (n : ℕ) (f : M ⟶ N) : (n • f).hom = n • f.hom := rfl
+
+instance (P Q : AddCommGrp) : AddCommGroup (P ⟶ Q) :=
+  Function.Injective.addCommGroup (Hom.hom) ConcreteCategory.hom_injective
+    rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
+
 instance : Preadditive AddCommGrp where
+
+/-- `AddCommGrp.Hom.hom` bundled as an additive equivalence. -/
+@[simps!]
+def homAddEquiv : (M ⟶ N) ≃+ (M →+ N) :=
+  { ConcreteCategory.homEquiv (C := AddCommGrp) with
+    map_add' _ _ := rfl }
 
 end AddCommGrp

--- a/Mathlib/Algebra/Category/Grp/Ulift.lean
+++ b/Mathlib/Algebra/Category/Grp/Ulift.lean
@@ -79,7 +79,7 @@ namespace Grp
   "The universe lift functor for additive groups is fully faithful."]
 def uliftFunctorFullyFaithful : uliftFunctor.{u, v}.FullyFaithful where
   preimage f := Grp.ofHom (MulEquiv.ulift.toMonoidHom.comp
-    (f.comp MulEquiv.ulift.symm.toMonoidHom))
+    (f.hom.comp MulEquiv.ulift.symm.toMonoidHom))
   map_preimage _ := rfl
   preimage_map _ := rfl
 
@@ -131,8 +131,8 @@ namespace CommGrp
 @[to_additive
   "The universe lift functor for commutative additive groups is fully faithful."]
 def uliftFunctorFullyFaithful : uliftFunctor.{u, v}.FullyFaithful where
-  preimage f := Grp.ofHom (MulEquiv.ulift.toMonoidHom.comp
-    (f.comp MulEquiv.ulift.symm.toMonoidHom))
+  preimage f := CommGrp.ofHom (MulEquiv.ulift.toMonoidHom.comp
+    (f.hom.comp MulEquiv.ulift.symm.toMonoidHom))
   map_preimage _ := rfl
   preimage_map _ := rfl
 

--- a/Mathlib/Algebra/Category/Grp/ZModuleEquivalence.lean
+++ b/Mathlib/Algebra/Category/Grp/ZModuleEquivalence.lean
@@ -32,9 +32,9 @@ instance forget₂_addCommGroup_full : (forget₂ (ModuleCat ℤ) AddCommGrp.{u}
     f := ⟨@ModuleCat.ofHom _ _ _ _ _ A.isModule _ B.isModule <|
             @LinearMap.mk _ _ _ _ _ _ _ _ _ A.isModule B.isModule
             { toFun := f,
-              map_add' := AddMonoidHom.map_add (show A.carrier →+ B.carrier from f) }
+              map_add' := AddMonoidHom.map_add f.hom }
             (fun n x => by
-              convert AddMonoidHom.map_zsmul (show A.carrier →+ B.carrier from f) x n <;>
+              convert AddMonoidHom.map_zsmul f.hom x n <;>
                 ext <;> apply int_smul_eq_zsmul), rfl⟩
 
 /-- The forgetful functor from `ℤ` modules to `AddCommGrp` is essentially surjective. -/

--- a/Mathlib/Algebra/Category/ModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Basic.lean
@@ -247,7 +247,7 @@ theorem forget₂_obj_moduleCat_of (X : Type v) [AddCommGroup X] [Module R X] :
 
 @[simp]
 theorem forget₂_map (X Y : ModuleCat R) (f : X ⟶ Y) :
-    (forget₂ (ModuleCat R) AddCommGrp).map f = f.hom.toAddMonoidHom :=
+    (forget₂ (ModuleCat R) AddCommGrp).map f = AddCommGrp.ofHom f.hom :=
   rfl
 
 instance : Inhabited (ModuleCat R) :=
@@ -473,14 +473,14 @@ variable (M N : ModuleCat.{v} R)
 /-- The scalar multiplication on an object of `ModuleCat R` considered as
 a morphism of rings from `R` to the endomorphisms of the underlying abelian group. -/
 def smul : R →+* End ((forget₂ (ModuleCat R) AddCommGrp).obj M) where
-  toFun r :=
+  toFun r := AddCommGrp.ofHom
     { toFun := fun (m : M) => r • m
       map_zero' := by dsimp; rw [smul_zero]
       map_add' := fun x y => by dsimp; rw [smul_add] }
-  map_one' := AddMonoidHom.ext (fun x => by dsimp; rw [one_smul])
-  map_zero' := AddMonoidHom.ext (fun x => by dsimp; rw [zero_smul]; rfl)
-  map_mul' r s := AddMonoidHom.ext (fun (x : M) => (smul_smul r s x).symm)
-  map_add' r s := AddMonoidHom.ext (fun (x : M) => add_smul r s x)
+  map_one' := AddCommGrp.ext (fun x => by simp)
+  map_zero' := AddCommGrp.ext (fun x => by simp)
+  map_mul' r s := AddCommGrp.ext (fun (x : M) => (smul_smul r s x).symm)
+  map_add' r s := AddCommGrp.ext (fun (x : M) => add_smul r s x)
 
 lemma smul_naturality {M N : ModuleCat.{v} R} (f : M ⟶ N) (r : R) :
     (forget₂ (ModuleCat R) AddCommGrp).map f ≫ N.smul r =
@@ -555,7 +555,7 @@ with the scalar multiplication. -/
 @[simps]
 def homMk : M ⟶ N where
   hom'.toFun := φ
-  hom'.map_add' _ _ := φ.map_add _ _
+  hom'.map_add' _ _ := φ.hom.map_add _ _
   hom'.map_smul' r x := (congr_hom (hφ r) x).symm
 
 lemma forget₂_map_homMk :

--- a/Mathlib/Algebra/Category/ModuleCat/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/FilteredColimits.lean
@@ -133,8 +133,8 @@ def colimit : ModuleCatMax.{v, u, u} R :=
 /-- The linear map from a given `R`-module in the diagram to the colimit module. -/
 def coconeMorphism (j : J) : F.obj j ⟶ colimit F :=
   ofHom
-    { (AddCommGrp.FilteredColimits.colimitCocone
-      (F ⋙ forget₂ (ModuleCat R) AddCommGrp.{max v u})).ι.app j with
+    { ((AddCommGrp.FilteredColimits.colimitCocone
+      (F ⋙ forget₂ (ModuleCat R) AddCommGrp.{max v u})).ι.app j).hom with
     map_smul' := fun r x => by erw [colimit_smul_mk_eq F r ⟨j, x⟩]; rfl }
 
 /-- The cocone over the proposed colimit module. -/
@@ -152,9 +152,9 @@ it is a linear map, i.e. preserves scalar multiplication.
 -/
 def colimitDesc (t : Cocone F) : colimit F ⟶ t.pt :=
   ofHom
-    { (AddCommGrp.FilteredColimits.colimitCoconeIsColimit
+    { ((AddCommGrp.FilteredColimits.colimitCoconeIsColimit
           (F ⋙ forget₂ (ModuleCatMax.{v, u} R) AddCommGrp.{max v u})).desc
-      ((forget₂ (ModuleCat R) AddCommGrp.{max v u}).mapCocone t) with
+      ((forget₂ (ModuleCat R) AddCommGrp.{max v u}).mapCocone t)).hom with
     map_smul' := fun r x => by
       refine Quot.inductionOn x ?_; clear x; intro x; obtain ⟨j, x⟩ := x
       erw [colimit_smul_mk_eq]

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
@@ -115,7 +115,7 @@ def isoMk (app : ∀ (X : Cᵒᵖ), M₁.obj X ≅ M₂.obj X)
 /-- The underlying presheaf of abelian groups of a presheaf of modules. -/
 def presheaf : Cᵒᵖ ⥤ Ab where
   obj X := (forget₂ _ _).obj (M.obj X)
-  map f := AddMonoidHom.mk' (M.map f) (by simp)
+  map f := AddCommGrp.ofHom <| AddMonoidHom.mk' (M.map f) (by simp)
 
 @[simp]
 lemma presheaf_obj_coe (X : Cᵒᵖ) :
@@ -123,7 +123,7 @@ lemma presheaf_obj_coe (X : Cᵒᵖ) :
 
 @[simp]
 lemma presheaf_map_apply_coe {X Y : Cᵒᵖ} (f : X ⟶ Y) (x : M.obj X) :
-    DFunLike.coe (α := M.obj X) (β := fun _ ↦ M.obj Y) (M.presheaf.map f) x = M.map f x := rfl
+    DFunLike.coe (α := M.obj X) (β := fun _ ↦ M.obj Y) (M.presheaf.map f).hom x = M.map f x := rfl
 
 instance (M : PresheafOfModules R) (X : Cᵒᵖ) :
     Module (R.obj X) (M.presheaf.obj X) :=
@@ -134,7 +134,7 @@ variable (R) in
 def toPresheaf : PresheafOfModules.{v} R ⥤ Cᵒᵖ ⥤ Ab where
   obj M := M.presheaf
   map f :=
-    { app := fun X ↦ AddMonoidHom.mk' (Hom.app f X) (by simp)
+    { app := fun X ↦ AddCommGrp.ofHom <| AddMonoidHom.mk' (Hom.app f X) (by simp)
       naturality := fun X Y g ↦ by ext x; exact naturality_apply f g x }
 
 @[simp]
@@ -144,7 +144,7 @@ lemma toPresheaf_obj_coe (X : Cᵒᵖ) :
 @[simp]
 lemma toPresheaf_map_app_apply (f : M₁ ⟶ M₂) (X : Cᵒᵖ) (x : M₁.obj X) :
     DFunLike.coe (α := M₁.obj X) (β := fun _ ↦ M₂.obj X)
-      (((toPresheaf R).map f).app X) x = f.app X x := rfl
+      (((toPresheaf R).map f).app X).hom x = f.app X x := rfl
 
 instance : (toPresheaf R).Faithful where
   map_injective {_ _ f g} h := by

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
@@ -82,7 +82,8 @@ lemma isCompatible_map_smul_aux {Y Z : C} (f : Y ⟶ X) (g : Z ⟶ Y)
   · rw [hr₀', R.map_comp, RingCat.comp_apply, ← hr₀, ← RingCat.comp_apply, NatTrans.naturality,
       RingCat.comp_apply]
   · rw [hm₀', A.map_comp, AddCommGrp.coe_comp, Function.comp_apply, ← hm₀]
-    erw [NatTrans.naturality_apply]
+    erw [NatTrans.naturality_apply φ]
+    rfl -- `ConcreteCategory`/`HasForget` mismatch workaround
 
 variable (hr₀ : (r₀.map (whiskerRight α (forget _))).IsAmalgamation r)
   (hm₀ : (m₀.map (whiskerRight φ (forget _))).IsAmalgamation m)
@@ -106,13 +107,14 @@ lemma isCompatible_map_smul : ((r₀.smul m₀).map (whiskerRight φ (forget _))
       RingCat.comp_apply]
   have hb₀ : (φ.app (Opposite.op Z)) b₀ = (A.map (f₁.op ≫ g₁.op)) m := by
     dsimp [b₀]
-    erw [NatTrans.naturality_apply, hb₁, Functor.map_comp, CategoryTheory.comp_apply]
+    erw [NatTrans.naturality_apply φ, hb₁, Functor.map_comp, ConcreteCategory.comp_apply]
+    rfl -- `ConcreteCategory`/`HasForget` mismatch workaround
   have ha₀' : (α.app (Opposite.op Z)) a₀ = (R.map (f₂.op ≫ g₂.op)) r := by
     rw [ha₀, ← op_comp, fac, op_comp]
   have hb₀' : (φ.app (Opposite.op Z)) b₀ = (A.map (f₂.op ≫ g₂.op)) m := by
     rw [hb₀, ← op_comp, fac, op_comp]
   dsimp
-  erw [← NatTrans.naturality_apply, ← NatTrans.naturality_apply]
+  erw [← NatTrans.naturality_apply φ, ← NatTrans.naturality_apply φ]
   exact (isCompatible_map_smul_aux α φ hA r m f₁ g₁ a₁ a₀ b₁ b₀ ha₁ ha₀ hb₁ hb₀).trans
     (isCompatible_map_smul_aux α φ hA r m f₂ g₂ a₂ a₀ b₂ b₀ ha₂ ha₀' hb₂ hb₀').symm
 
@@ -166,7 +168,7 @@ def SMulCandidate.mk' (S : Sieve X.unop) (hS : S ∈ J X.unop)
     · rw [← RingCat.comp_apply, NatTrans.naturality, RingCat.comp_apply, ha₀]
       apply (hr₀ _ hg).symm.trans
       simp [RingCat.forget_map]
-    · erw [NatTrans.naturality_apply, hb₀]
+    · erw [NatTrans.naturality_apply φ, hb₀]
       apply (hm₀ _ hg).symm.trans
       dsimp
       rw [Functor.map_comp]
@@ -203,6 +205,7 @@ instance : Subsingleton (SMulCandidate α φ r m) where
       all_goals apply Presheaf.imageSieve_mem
     apply A.isSeparated _ _ hS
     intro Y f ⟨⟨r₀, hr₀⟩, ⟨m₀, hm₀⟩⟩
+    show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
     rw [h₁ f.op r₀ hr₀ m₀ hm₀, h₂ f.op r₀ hr₀ m₀ hm₀]
 
 noncomputable instance : Unique (SMulCandidate α φ r m) :=
@@ -222,18 +225,22 @@ lemma map_smul_eq {Y : Cᵒᵖ} (f : X ⟶ Y) (r₀ : R₀.obj Y) (hr₀ : α.ap
 protected lemma one_smul : smul α φ 1 m = m := by
   apply A.isSeparated _ _ (Presheaf.imageSieve_mem J φ m)
   rintro Y f ⟨m₀, hm₀⟩
+  show A.val.map f.op _ = _ -- `ConcreteCategory`/`HasForget` mismatch workaround
   rw [← hm₀, map_smul_eq α φ 1 m f.op 1 (by simp) m₀ hm₀, one_smul]
+  rfl -- `ConcreteCategory`/`HasForget` mismatch workaround
 
 protected lemma zero_smul : smul α φ 0 m = 0 := by
   apply A.isSeparated _ _ (Presheaf.imageSieve_mem J φ m)
   rintro Y f ⟨m₀, hm₀⟩
+  show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
   rw [map_smul_eq α φ 0 m f.op 0 (by simp) m₀ hm₀, zero_smul, map_zero,
-    (A.val.map f.op).map_zero]
+    (A.val.map f.op).hom.map_zero]
 
 protected lemma smul_zero : smul α φ r 0 = 0 := by
   apply A.isSeparated _ _ (Presheaf.imageSieve_mem J α r)
   rintro Y f ⟨r₀, hr₀⟩
-  rw [(A.val.map f.op).map_zero, map_smul_eq α φ r 0 f.op r₀ hr₀ 0 (by simp),
+  show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
+  rw [(A.val.map f.op).hom.map_zero, map_smul_eq α φ r 0 f.op r₀ hr₀ 0 (by simp),
     smul_zero, map_zero]
 
 protected lemma smul_add : smul α φ r (m + m') = smul α φ r m + smul α φ r m' := by
@@ -242,11 +249,13 @@ protected lemma smul_add : smul α φ r (m + m') = smul α φ r m + smul α φ r
     refine J.intersection_covering (J.intersection_covering ?_ ?_) ?_
     all_goals apply Presheaf.imageSieve_mem
   apply A.isSeparated _ _ hS
-  rintro Y f ⟨⟨⟨r₀, hr₀⟩, ⟨m₀ : M₀.obj _, hm₀⟩⟩, ⟨m₀' : M₀.obj _, hm₀'⟩⟩
-  rw [(A.val.map f.op).map_add, map_smul_eq α φ r m f.op r₀ hr₀ m₀ hm₀,
+  rintro Y f ⟨⟨⟨r₀, hr₀⟩, ⟨m₀ : M₀.obj _, hm₀ : (φ.app _) _ = _⟩⟩,
+    ⟨m₀' : M₀.obj _, hm₀' : (φ.app _) _ = _⟩⟩
+  show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
+  rw [(A.val.map f.op).hom.map_add, map_smul_eq α φ r m f.op r₀ hr₀ m₀ hm₀,
     map_smul_eq α φ r m' f.op r₀ hr₀ m₀' hm₀',
     map_smul_eq α φ r (m + m') f.op r₀ hr₀ (m₀ + m₀')
-      (by rw [map_add, map_add, hm₀, hm₀']),
+      (by rw [map_add, map_add, hm₀, hm₀']; rfl),
     smul_add, map_add]
 
 protected lemma add_smul : smul α φ (r + r') m = smul α φ r m + smul α φ r' m := by
@@ -257,7 +266,8 @@ protected lemma add_smul : smul α φ (r + r') m = smul α φ r m + smul α φ r
   apply A.isSeparated _ _ hS
   rintro Y f ⟨⟨⟨r₀ : R₀.obj _, (hr₀ : (α.app (Opposite.op Y)) r₀ = (R.val.map f.op) r)⟩,
     ⟨r₀' : R₀.obj _, (hr₀' : (α.app (Opposite.op Y)) r₀' = (R.val.map f.op) r')⟩⟩, ⟨m₀, hm₀⟩⟩
-  rw [(A.val.map f.op).map_add, map_smul_eq α φ r m f.op r₀ hr₀ m₀ hm₀,
+  show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
+  rw [(A.val.map f.op).hom.map_add, map_smul_eq α φ r m f.op r₀ hr₀ m₀ hm₀,
     map_smul_eq α φ r' m f.op r₀' hr₀' m₀ hm₀,
     map_smul_eq α φ (r + r') m f.op (r₀ + r₀') (by rw [map_add, map_add, hr₀, hr₀'])
       m₀ hm₀, add_smul, map_add]
@@ -271,6 +281,7 @@ protected lemma mul_smul : smul α φ (r * r') m = smul α φ r (smul α φ r' m
   rintro Y f ⟨⟨⟨r₀ : R₀.obj _, (hr₀ : (α.app (Opposite.op Y)) r₀ = (R.val.map f.op) r)⟩,
     ⟨r₀' : R₀.obj _, (hr₀' : (α.app (Opposite.op Y)) r₀' = (R.val.map f.op) r')⟩⟩,
     ⟨m₀ : M₀.obj _, hm₀⟩⟩
+  show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
   rw [map_smul_eq α φ (r * r') m f.op (r₀ * r₀')
     (by rw [map_mul, map_mul, hr₀, hr₀']) m₀ hm₀, mul_smul,
     map_smul_eq α φ r (smul α φ r' m) f.op r₀ hr₀ (r₀' • m₀)
@@ -297,10 +308,12 @@ lemma map_smul :
     all_goals apply Presheaf.imageSieve_mem
   apply A.isSeparated _ _ hS
   rintro Y f ⟨⟨r₀,
-    (hr₀ : (α.app (Opposite.op Y)).hom r₀ = (R.val.map f.op).hom ((R.val.map π).hom r))⟩, ⟨m₀, hm₀⟩⟩
-  rw [← CategoryTheory.comp_apply, ← Functor.map_comp,
+    (hr₀ : (α.app (Opposite.op Y)).hom r₀ = (R.val.map f.op).hom ((R.val.map π).hom r))⟩,
+    ⟨m₀, (hm₀ : (φ.app _) _ = _)⟩⟩
+  show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
+  rw [← ConcreteCategory.comp_apply, ← Functor.map_comp,
     map_smul_eq α φ r m (π ≫ f.op) r₀ (by rw [hr₀, Functor.map_comp, RingCat.comp_apply]) m₀
-      (by rw [hm₀, Functor.map_comp, CategoryTheory.comp_apply]),
+      (by rw [hm₀, Functor.map_comp, ConcreteCategory.comp_apply]; rfl),
     map_smul_eq α φ (R.val.map π r) (A.val.map π m) f.op r₀ hr₀ m₀ hm₀]
 
 end Sheafify

--- a/Mathlib/Algebra/Category/ModuleCat/Tannaka.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Tannaka.lean
@@ -42,13 +42,13 @@ def ringEquivEndForget₂ (R : Type u) [Ring R] :
     intros
     apply NatTrans.ext
     ext
-    simp only [AdditiveFunctor.of_fst, ModuleCat.forget₂_obj, AddCommGrp.coe_of,
-      AddCommGrp.ofHom_apply, DistribMulAction.toAddMonoidHom_apply, add_smul]
+    simp only [AdditiveFunctor.of_fst, ModuleCat.forget₂_obj, AddCommGrp.ofHom_apply,
+      DistribMulAction.toAddMonoidHom_apply, add_smul, AddCommGrp.hom_ofHom]
     rfl
   map_mul' := by
     intros
     apply NatTrans.ext
     ext
-    simp only [AdditiveFunctor.of_fst, ModuleCat.forget₂_obj, AddCommGrp.coe_of,
-      AddCommGrp.ofHom_apply, DistribMulAction.toAddMonoidHom_apply, mul_smul]
+    simp only [AdditiveFunctor.of_fst, ModuleCat.forget₂_obj, AddCommGrp.ofHom_apply,
+      DistribMulAction.toAddMonoidHom_apply, mul_smul, AddCommGrp.hom_ofHom]
     rfl

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -316,7 +316,7 @@ instance hasForgetToSemiRingCat : HasForget₂ RingCat SemiRingCat where
 instance hasForgetToAddCommGrp : HasForget₂ RingCat AddCommGrp where
   forget₂ :=
     { obj := fun R ↦ AddCommGrp.of R
-      map := fun f ↦ f.hom.toAddMonoidHom }
+      map := fun f ↦ AddCommGrp.ofHom f.hom.toAddMonoidHom }
 
 /-- Ring equivalence are isomorphisms in category of semirings -/
 @[simps]

--- a/Mathlib/Algebra/Category/Semigrp/Basic.lean
+++ b/Mathlib/Algebra/Category/Semigrp/Basic.lean
@@ -209,7 +209,8 @@ def MulEquiv.toMagmaCatIso (e : X ≃* Y) : MagmaCat.of X ≅ MagmaCat.of Y wher
   inv := e.symm.toMulHom
   hom_inv_id := by
     ext
-    simp_rw [comp_apply, toMulHom_eq_coe, MagmaCat.mulEquiv_coe_eq, symm_apply_apply, id_apply]
+    simp_rw [CategoryTheory.comp_apply, toMulHom_eq_coe, MagmaCat.mulEquiv_coe_eq, symm_apply_apply,
+      CategoryTheory.id_apply]
 
 end
 

--- a/Mathlib/Algebra/Homology/ConcreteCategory.lean
+++ b/Mathlib/Algebra/Homology/ConcreteCategory.lean
@@ -75,20 +75,30 @@ lemma δ_apply (x₃ : (forget₂ C Ab).obj (S.X₃.X i))
         (forget₂ C Ab).map (S.X₁.homologyπ j) (S.X₁.cyclesMk x₁ k hk (by
           have := hS.mono_f
           apply (Preadditive.mono_iff_injective (S.f.f k)).1 inferInstance
-          rw [← forget₂_comp_apply, ← HomologicalComplex.Hom.comm, forget₂_comp_apply, hx₁,
-            ← forget₂_comp_apply, HomologicalComplex.d_comp_d, Functor.map_zero, map_zero,
-            AddMonoidHom.zero_apply])) := by
+          -- Since `C` is only a `HasForget`, not a `ConcreteCategory` (for now),
+          -- we need to rewrite everything to `HasForget`.
+          have : ∀ {X Y : Ab} (f : X ⟶ Y), (f : X → Y) =
+            @DFunLike.coe _ _ _ (HasForget.toFunLike _ _ _) f := by intros; ext; rfl
+          rw [this, this, ← forget₂_comp_apply, ← HomologicalComplex.Hom.comm, forget₂_comp_apply,
+            ← this, ← this, hx₁, this, this,
+            ← forget₂_comp_apply, HomologicalComplex.d_comp_d, Functor.map_zero, ← this, ← this,
+            map_zero]; rfl)) := by
+  -- Since `C` is only a `HasForget`, not a `ConcreteCategory` (for now),
+  -- we need to rewrite everything to `HasForget`.
+  have : ∀ {X Y : Ab} (f : X ⟶ Y), (f : X → Y) =
+  @DFunLike.coe _ _ _ (HasForget.toFunLike _ _ _) f := by intros; ext; rfl
   refine hS.δ_apply' i j hij _ ((forget₂ C Ab).map (S.X₂.pOpcycles i) x₂) _ ?_ ?_
-  · rw [← forget₂_comp_apply, ← forget₂_comp_apply,
+  · rw [this, this, ← forget₂_comp_apply, this, this, ← forget₂_comp_apply,
       HomologicalComplex.p_opcyclesMap, Functor.map_comp, CategoryTheory.comp_apply,
-      HomologicalComplex.homology_π_ι, forget₂_comp_apply, hx₂, HomologicalComplex.i_cyclesMk]
+      HomologicalComplex.homology_π_ι, forget₂_comp_apply, ← this, ← this, hx₂, ← this,
+      HomologicalComplex.i_cyclesMk]
   · apply (Preadditive.mono_iff_injective (S.X₂.iCycles j)).1 inferInstance
     conv_lhs =>
-      rw [← forget₂_comp_apply, HomologicalComplex.cyclesMap_i, forget₂_comp_apply,
-        HomologicalComplex.i_cyclesMk, hx₁]
+      rw [this, this, ← forget₂_comp_apply, HomologicalComplex.cyclesMap_i, forget₂_comp_apply,
+        ← this ((forget₂ C Ab).map (S.X₁.iCycles j)), HomologicalComplex.i_cyclesMk, ← this, hx₁]
     conv_rhs =>
-      rw [← forget₂_comp_apply, ← forget₂_comp_apply,
-        HomologicalComplex.pOpcycles_opcyclesToCycles_assoc, HomologicalComplex.toCycles_i]
+      rw [this, this, ← forget₂_comp_apply, this, ← forget₂_comp_apply,
+        HomologicalComplex.pOpcycles_opcyclesToCycles_assoc, HomologicalComplex.toCycles_i, ← this]
 
 end ShortExact
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExactSequences.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExactSequences.lean
@@ -59,10 +59,9 @@ lemma covariant_sequence_exact₂' (n : ℕ) :
     (ShortComplex.mk (AddCommGrp.ofHom ((mk₀ S.f).postcomp X (add_zero n)))
       (AddCommGrp.ofHom ((mk₀ S.g).postcomp X (add_zero n))) (by
         ext x
-        dsimp [AddCommGrp.ofHom]
+        dsimp
         simp only [comp_assoc_of_third_deg_zero, mk₀_comp_mk₀, ShortComplex.zero, mk₀_zero,
-          comp_zero]
-        rfl)).Exact := by
+          comp_zero])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveCoyoneda.obj (op ((singleFunctor C 0).obj X))).homologySequence_exact₂ _
     (hS.singleTriangle_distinguished) n
@@ -80,10 +79,9 @@ lemma covariant_sequence_exact₃' :
     (ShortComplex.mk (AddCommGrp.ofHom ((mk₀ S.g).postcomp X (add_zero n₀)))
       (AddCommGrp.ofHom (hS.extClass.postcomp X h)) (by
         ext x
-        dsimp [AddCommGrp.ofHom]
+        dsimp
         simp only [comp_assoc_of_second_deg_zero, ShortComplex.ShortExact.comp_extClass,
-          comp_zero]
-        rfl)).Exact := by
+          comp_zero])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveCoyoneda.obj (op ((singleFunctor C 0).obj X))).homologySequence_exact₃ _
     (hS.singleTriangle_distinguished) n₀ n₁ (by omega)
@@ -100,9 +98,9 @@ lemma covariant_sequence_exact₁' :
       (AddCommGrp.ofHom (hS.extClass.postcomp X h))
       (AddCommGrp.ofHom ((mk₀ S.f).postcomp X (add_zero n₁))) (by
         ext x
-        dsimp [AddCommGrp.ofHom]
-        simp only [comp_assoc_of_third_deg_zero, ShortComplex.ShortExact.extClass_comp, comp_zero]
-        rfl)).Exact := by
+        dsimp
+        simp only [comp_assoc_of_third_deg_zero, ShortComplex.ShortExact.extClass_comp,
+          comp_zero])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveCoyoneda.obj (op ((singleFunctor C 0).obj X))).homologySequence_exact₁ _
     (hS.singleTriangle_distinguished) n₀ n₁ (by omega)
@@ -185,9 +183,8 @@ lemma contravariant_sequence_exact₂' (n : ℕ) :
     (ShortComplex.mk (AddCommGrp.ofHom ((mk₀ S.g).precomp Y (zero_add n)))
       (AddCommGrp.ofHom ((mk₀ S.f).precomp Y (zero_add n))) (by
         ext
-        dsimp [AddCommGrp.ofHom]
-        simp only [mk₀_comp_mk₀_assoc, ShortComplex.zero, mk₀_zero, zero_comp]
-        rfl)).Exact := by
+        dsimp
+        simp only [mk₀_comp_mk₀_assoc, ShortComplex.zero, mk₀_zero, zero_comp])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveYoneda.obj ((singleFunctor C 0).obj Y)).homologySequence_exact₂ _
     (op_distinguished _ hS.singleTriangle_distinguished) n
@@ -205,9 +202,8 @@ lemma contravariant_sequence_exact₁' :
     (ShortComplex.mk (AddCommGrp.ofHom (((mk₀ S.f).precomp Y (zero_add n₀))))
       (AddCommGrp.ofHom (hS.extClass.precomp Y h)) (by
         ext
-        dsimp [AddCommGrp.ofHom]
-        simp only [ShortComplex.ShortExact.extClass_comp_assoc]
-        rfl)).Exact := by
+        dsimp
+        simp only [ShortComplex.ShortExact.extClass_comp_assoc])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveYoneda.obj ((singleFunctor C 0).obj Y)).homologySequence_exact₃ _
     (op_distinguished _ hS.singleTriangle_distinguished) n₀ n₁ (by omega)
@@ -222,9 +218,8 @@ lemma contravariant_sequence_exact₃' :
     (ShortComplex.mk (AddCommGrp.ofHom (hS.extClass.precomp Y h))
       (AddCommGrp.ofHom (((mk₀ S.g).precomp Y (zero_add n₁)))) (by
         ext
-        dsimp [AddCommGrp.ofHom]
-        simp only [ShortComplex.ShortExact.comp_extClass_assoc]
-        rfl)).Exact := by
+        dsimp
+        simp only [ShortComplex.ShortExact.comp_extClass_assoc])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveYoneda.obj ((singleFunctor C 0).obj Y)).homologySequence_exact₁ _
     (op_distinguished _ hS.singleTriangle_distinguished) n₀ n₁ (by omega)

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -563,18 +563,12 @@ open HomComplex
 
 /-- The cochain complex of homomorphisms between two cochain complexes `F` and `G`.
 In degree `n : ℤ`, it consists of the abelian group `HomComplex.Cochain F G n`. -/
--- We also constructed the `d_apply` lemma using `@[simps]`
--- until we made `AddCommGrp.coe_of` a simp lemma,
--- after which the simp normal form linter complains.
--- It was not used a simp lemma in Mathlib.
--- Possible solution: higher priority function coercions that remove the `of`?
--- @[simp]
-@[simps! X]
+@[simps! X d_hom_apply]
 def HomComplex : CochainComplex AddCommGrp ℤ where
   X i := AddCommGrp.of (Cochain F G i)
   d i j := AddCommGrp.ofHom (δ_hom ℤ F G i j)
-  shape _ _ hij := by ext; apply δ_shape _ _ hij
-  d_comp_d' _ _ _ _ _  := by ext; apply δ_δ
+  shape _ _ hij := by ext; simp [δ_shape _ _ hij]
+  d_comp_d' _ _ _ _ _  := by ext; simp [δ_δ]
 
 namespace HomComplex
 

--- a/Mathlib/Algebra/Homology/ImageToKernel.lean
+++ b/Mathlib/Algebra/Homology/ImageToKernel.lean
@@ -61,7 +61,7 @@ lemma imageToKernel_arrow_apply [HasForget V] (w : f ≫ g = 0)
     (x : (forget V).obj (Subobject.underlying.obj (imageSubobject f))) :
     (kernelSubobject g).arrow (imageToKernel f g w x) =
       (imageSubobject f).arrow x := by
-  rw [← comp_apply, imageToKernel_arrow]
+  rw [← CategoryTheory.comp_apply, imageToKernel_arrow]
 
 -- This is less useful as a `simp` lemma than it initially appears,
 -- as it "loses" the information the morphism factors through the image.

--- a/Mathlib/Algebra/Homology/ShortComplex/Ab.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Ab.lean
@@ -37,22 +37,22 @@ variable (S : ShortComplex Ab.{u})
 
 @[simp]
 lemma ab_zero_apply (x : S.X₁) : S.g (S.f x) = 0 := by
-  rw [← CategoryTheory.comp_apply, S.zero]
+  rw [← ConcreteCategory.comp_apply, S.zero]
   rfl
 
 /-- The canonical additive morphism `S.X₁ →+ AddMonoidHom.ker S.g` induced by `S.f`. -/
 @[simps!]
-def abToCycles : S.X₁ →+ AddMonoidHom.ker S.g :=
+def abToCycles : S.X₁ →+ AddMonoidHom.ker S.g.hom :=
     AddMonoidHom.mk' (fun x => ⟨S.f x, S.ab_zero_apply x⟩) (by aesop)
 
 /-- The explicit left homology data of a short complex of abelian group that is
 given by a kernel and a quotient given by the `AddMonoidHom` API. -/
 @[simps]
 def abLeftHomologyData : S.LeftHomologyData where
-  K := AddCommGrp.of (AddMonoidHom.ker S.g)
-  H := AddCommGrp.of ((AddMonoidHom.ker S.g) ⧸ AddMonoidHom.range S.abToCycles)
-  i := (AddMonoidHom.ker S.g).subtype
-  π := QuotientAddGroup.mk' _
+  K := AddCommGrp.of (AddMonoidHom.ker S.g.hom)
+  H := AddCommGrp.of ((AddMonoidHom.ker S.g.hom) ⧸ AddMonoidHom.range S.abToCycles)
+  i := AddCommGrp.ofHom <| (AddMonoidHom.ker S.g.hom).subtype
+  π := AddCommGrp.ofHom <| QuotientAddGroup.mk' _
   wi := by
     ext ⟨_, hx⟩
     exact hx
@@ -65,12 +65,12 @@ def abLeftHomologyData : S.LeftHomologyData where
   hπ := AddCommGrp.cokernelIsColimit (AddCommGrp.ofHom S.abToCycles)
 
 @[simp]
-lemma abLeftHomologyData_f' : S.abLeftHomologyData.f' = S.abToCycles := rfl
+lemma abLeftHomologyData_f' : S.abLeftHomologyData.f' = AddCommGrp.ofHom S.abToCycles := rfl
 
 /-- Given a short complex `S` of abelian groups, this is the isomorphism between
 the abstract `S.cycles` of the homology API and the more concrete description as
 `AddMonoidHom.ker S.g`. -/
-noncomputable def abCyclesIso : S.cycles ≅ AddCommGrp.of (AddMonoidHom.ker S.g) :=
+noncomputable def abCyclesIso : S.cycles ≅ AddCommGrp.of (AddMonoidHom.ker S.g.hom) :=
   S.abLeftHomologyData.cyclesIso
 
 -- This was a simp lemma until we made `AddCommGrp.coe_of` a simp lemma,
@@ -78,10 +78,10 @@ noncomputable def abCyclesIso : S.cycles ≅ AddCommGrp.of (AddMonoidHom.ker S.g
 -- It was not used a simp lemma in Mathlib.
 -- Possible solution: higher priority function coercions that remove the `of`?
 -- @[simp]
-lemma abCyclesIso_inv_apply_iCycles (x : AddMonoidHom.ker S.g) :
+lemma abCyclesIso_inv_apply_iCycles (x : AddMonoidHom.ker S.g.hom) :
     S.iCycles (S.abCyclesIso.inv x) = x := by
   dsimp only [abCyclesIso]
-  rw [← CategoryTheory.comp_apply, S.abLeftHomologyData.cyclesIso_inv_comp_iCycles]
+  rw [← ConcreteCategory.comp_apply, S.abLeftHomologyData.cyclesIso_inv_comp_iCycles]
   rfl
 
 /-- Given a short complex `S` of abelian groups, this is the isomorphism between
@@ -89,7 +89,7 @@ the abstract `S.homology` of the homology API and the more explicit
 quotient of `AddMonoidHom.ker S.g` by the image of
 `S.abToCycles : S.X₁ →+ AddMonoidHom.ker S.g`. -/
 noncomputable def abHomologyIso : S.homology ≅
-    AddCommGrp.of ((AddMonoidHom.ker S.g) ⧸ AddMonoidHom.range S.abToCycles) :=
+    AddCommGrp.of ((AddMonoidHom.ker S.g.hom) ⧸ AddMonoidHom.range S.abToCycles) :=
   S.abLeftHomologyData.homologyIso
 
 lemma exact_iff_surjective_abToCycles :
@@ -121,15 +121,15 @@ lemma ab_exact_iff_function_exact :
     simp only [ab_zero_apply]
   · tauto
 
-lemma ab_exact_iff_ker_le_range : S.Exact ↔ S.g.ker ≤ S.f.range := S.ab_exact_iff
+lemma ab_exact_iff_ker_le_range : S.Exact ↔ S.g.hom.ker ≤ S.f.hom.range := S.ab_exact_iff
 
-lemma ab_exact_iff_range_eq_ker : S.Exact ↔ S.f.range = S.g.ker := by
+lemma ab_exact_iff_range_eq_ker : S.Exact ↔ S.f.hom.range = S.g.hom.ker := by
   rw [ab_exact_iff_ker_le_range]
   constructor
   · intro h
     refine le_antisymm ?_ h
     rintro _ ⟨x₁, rfl⟩
-    rw [AddMonoidHom.mem_ker, ← CategoryTheory.comp_apply, S.zero]
+    rw [AddMonoidHom.mem_ker, ← ConcreteCategory.comp_apply, S.zero]
     rfl
   · intro h
     rw [h]

--- a/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
@@ -32,7 +32,7 @@ lemma ShortComplex.zero_apply
     [Limits.HasZeroMorphisms C] [(forget₂ C Ab).PreservesZeroMorphisms]
     (S : ShortComplex C) (x : (forget₂ C Ab).obj S.X₁) :
     ((forget₂ C Ab).map S.g) (((forget₂ C Ab).map S.f) x) = 0 := by
-  rw [← CategoryTheory.comp_apply, ← Functor.map_comp, S.zero, Functor.map_zero]
+  rw [← ConcreteCategory.comp_apply, ← Functor.map_comp, S.zero, Functor.map_zero]
   rfl
 
 section preadditive
@@ -112,8 +112,8 @@ lemma i_cyclesMk [S.HasHomology] (x₂ : (forget₂ C Ab).obj S.X₂)
     (hx₂ : ((forget₂ C Ab).map S.g) x₂ = 0) :
     (forget₂ C Ab).map S.iCycles (S.cyclesMk x₂ hx₂) = x₂ := by
   dsimp [cyclesMk]
-  erw [← CategoryTheory.comp_apply, S.mapCyclesIso_hom_iCycles (forget₂ C Ab),
-    ← CategoryTheory.comp_apply, abCyclesIso_inv_apply_iCycles ]
+  erw [← ConcreteCategory.comp_apply, S.mapCyclesIso_hom_iCycles (forget₂ C Ab),
+    ← ConcreteCategory.comp_apply, abCyclesIso_inv_apply_iCycles]
 
 end ShortComplex
 

--- a/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
+++ b/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
@@ -81,7 +81,7 @@ def toTop : SimplexCategory ⥤ TopCat where
     apply toTopObj.ext
     funext i
     dsimp
-    simp only [comp_apply, TopCat.coe_of_of, ContinuousMap.coe_mk, coe_toTopMap]
+    simp only [CategoryTheory.comp_apply, TopCat.coe_of_of, ContinuousMap.coe_mk, coe_toTopMap]
     rw [← Finset.sum_biUnion]
     · apply Finset.sum_congr
       · exact Finset.ext (fun j => ⟨fun hj => by simpa using hj, fun hj => by simpa using hj⟩)

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp/Kernels.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp/Kernels.lean
@@ -44,7 +44,7 @@ def cokernelCocone {X Y : SemiNormedGrp₁.{u}} (f : X ⟶ Y) : Cofork f 0 :=
       --   SemiNormedGrp₁.mkHom_apply, SemiNormedGrp₁.zero_apply,
       --   ← NormedAddGroupHom.mem_ker, f.1.range.ker_normedMk, f.1.mem_range]
       -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-      erw [Limits.zero_comp, comp_apply, SemiNormedGrp₁.mkHom_apply,
+      erw [Limits.zero_comp, CategoryTheory.comp_apply, SemiNormedGrp₁.mkHom_apply,
         SemiNormedGrp₁.zero_apply, ← NormedAddGroupHom.mem_ker, f.1.range.ker_normedMk,
         f.1.mem_range]
       use x
@@ -143,16 +143,10 @@ def cokernelCocone {X Y : SemiNormedGrp.{u}} (f : X ⟶ Y) : Cofork f 0 :=
   @Cofork.ofπ _ _ _ _ _ _ (SemiNormedGrp.of (Y ⧸ NormedAddGroupHom.range f)) f.range.normedMk
     (by
       ext a
-      simp only [comp_apply, Limits.zero_comp]
-      -- Porting note: `simp` not firing on the below
-      rw [NormedAddGroupHom.zero_apply]
-      -- Porting note: Lean 3 didn't need this instance
-      letI : SeminormedAddCommGroup ((forget SemiNormedGrp).obj Y) :=
-        (inferInstance : SeminormedAddCommGroup Y)
-      -- Porting note: again simp doesn't seem to be firing in the below line
+      simp only [coe_comp, Function.comp_apply, Limits.zero_comp, zero_apply]
+      -- Porting note: simp doesn't seem to be firing in the below line
       rw [← NormedAddGroupHom.mem_ker, f.range.ker_normedMk, f.mem_range]
-    -- This used to be `simp only [exists_apply_eq_apply]` before https://github.com/leanprover/lean4/pull/2644
-      convert exists_apply_eq_apply f a)
+      simp only [exists_apply_eq_apply])
 
 /-- Auxiliary definition for `HasCokernels SemiNormedGrp`. -/
 noncomputable

--- a/Mathlib/CategoryTheory/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Action/Basic.lean
@@ -46,20 +46,21 @@ variable {V}
 theorem ρ_one {G : MonCat.{u}} (A : Action V G) : A.ρ 1 = 𝟙 A.V := by rw [MonoidHom.map_one]; rfl
 
 /-- When a group acts, we can lift the action to the group of automorphisms. -/
-@[simps]
-def ρAut {G : Grp.{u}} (A : Action V (MonCat.of G)) : G ⟶ Grp.of (Aut A.V) where
-  toFun g :=
-    { hom := A.ρ g
-      inv := A.ρ (g⁻¹ : G)
-      hom_inv_id := (A.ρ.map_mul (g⁻¹ : G) g).symm.trans (by rw [inv_mul_cancel, ρ_one])
-      inv_hom_id := (A.ρ.map_mul g (g⁻¹ : G)).symm.trans (by rw [mul_inv_cancel, ρ_one]) }
-  map_one' := Aut.ext A.ρ.map_one
-  map_mul' x y := Aut.ext (A.ρ.map_mul x y)
+@[simps!]
+def ρAut {G : Grp.{u}} (A : Action V (MonCat.of G)) : G ⟶ Grp.of (Aut A.V) :=
+  Grp.ofHom
+  { toFun g :=
+      { hom := A.ρ g
+        inv := A.ρ (g⁻¹ : G)
+        hom_inv_id := (A.ρ.map_mul (g⁻¹ : G) g).symm.trans (by rw [inv_mul_cancel, ρ_one])
+        inv_hom_id := (A.ρ.map_mul g (g⁻¹ : G)).symm.trans (by rw [mul_inv_cancel, ρ_one]) }
+    map_one' := Aut.ext A.ρ.map_one
+    map_mul' x y := Aut.ext (A.ρ.map_mul x y) }
 
 -- These lemmas have always been bad (https://github.com/leanprover-community/mathlib4/issues/7657),
 -- but https://github.com/leanprover/lean4/pull/2644 made `simp` start noticing
 -- It would be worth fixing these, as `ρAut_apply_inv` is used in `erw` later.
-attribute [nolint simpNF] Action.ρAut_apply_inv Action.ρAut_apply_hom
+attribute [nolint simpNF] Action.ρAut_hom_apply_inv Action.ρAut_hom_apply_hom
 
 variable (G : MonCat.{u})
 

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -185,7 +185,7 @@ instance forget₂_faithful (C : Type u) (D : Type u') [Category.{v} C] [HasForg
 
 instance InducedCategory.hasForget {C : Type u} {D : Type u'}
     [Category.{v'} D] [HasForget.{w} D] (f : C → D) :
-      HasForget (InducedCategory D f) where
+    HasForget (InducedCategory D f) where
   forget := inducedFunctor f ⋙ forget D
 
 instance InducedCategory.hasForget₂ {C : Type u} {D : Type u'} [Category.{v} D]
@@ -425,6 +425,30 @@ abbrev Types.instConcreteCategory : ConcreteCategory (Type u) (fun X Y => X ⟶ 
   ofHom f := f
 
 end
+
+open ConcreteCategory
+
+instance InducedCategory.concreteCategory {C : Type u} {D : Type u'} [Category.{v'} D]
+    {FD : D → D → Type*} {CD : D → Type w} [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)]
+    [ConcreteCategory.{w} D FD] (f : C → D) :
+    ConcreteCategory (InducedCategory D f) (fun X Y => FD (f X) (f Y)) where
+  hom := hom (C := D)
+  ofHom := ofHom (C := D)
+  hom_ofHom := hom_ofHom (C := D)
+  ofHom_hom := ofHom_hom (C := D)
+  comp_apply := ConcreteCategory.comp_apply (C := D)
+  id_apply := ConcreteCategory.id_apply (C := D)
+
+instance FullSubcategory.concreteCategory {C : Type u} [Category.{v} C]
+    {FC : C → C → Type*} {CC : C → Type w} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+    [ConcreteCategory.{w} C FC]
+    (Z : C → Prop) : ConcreteCategory (FullSubcategory Z) (fun X Y => FC X.1 Y.1) where
+  hom := hom (C := C)
+  ofHom := ofHom (C := C)
+  hom_ofHom := hom_ofHom (C := C)
+  ofHom_hom := ofHom_hom (C := C)
+  comp_apply := ConcreteCategory.comp_apply (C := C)
+  id_apply := ConcreteCategory.id_apply (C := C)
 
 end ConcreteCategory
 

--- a/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
+++ b/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
@@ -210,13 +210,7 @@ as an object of `C`. -/
 @[simps]
 noncomputable def autGaloisSystem : PointedGaloisObject F ⥤ Grp.{u₂} where
   obj := fun A ↦ Grp.of <| Aut (A : C)
-  map := fun {A B} f ↦ (autMapHom f : Aut (A : C) →* Aut (B : C))
-  map_id := fun A ↦ by
-    ext (σ : Aut A.obj)
-    simp
-  map_comp {A B C} f g := by
-    ext (σ : Aut A.obj)
-    simp
+  map := fun {A B} f ↦ Grp.ofHom (autMapHom f)
 
 /-- The limit of `autGaloisSystem`. -/
 noncomputable def AutGalois : Type (max u₁ u₂) :=

--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -241,7 +241,7 @@ theorem widePullback_ext' {B : C} {ι : Type w} [Nonempty ι] {X : ι → C}
     (h : ∀ j, π f j x = π f j y) : x = y := by
   apply Concrete.widePullback_ext _ _ _ _ h
   inhabit ι
-  simp only [← π_arrow f default, comp_apply, h]
+  simp only [← π_arrow f default, CategoryTheory.comp_apply, h]
 
 end WidePullback
 
@@ -255,7 +255,8 @@ theorem multiequalizer_ext {I : MulticospanIndex.{w, w'} C} [HasMultiequalizer I
   apply Concrete.limit_ext
   rintro (a | b)
   · apply h
-  · rw [← limit.w I.multicospan (WalkingMulticospan.Hom.fst b), comp_apply, comp_apply]
+  · rw [← limit.w I.multicospan (WalkingMulticospan.Hom.fst b), CategoryTheory.comp_apply,
+      CategoryTheory.comp_apply]
     simp [h]
 
 /-- An auxiliary equivalence to be used in `multiequalizerEquiv` below. -/
@@ -334,7 +335,7 @@ theorem widePushout_exists_rep' {B : C} {α : Type _} [Nonempty α] {X : α → 
   rcases Concrete.widePushout_exists_rep f x with (⟨y, rfl⟩ | ⟨i, y, rfl⟩)
   · inhabit α
     use default, f _ y
-    simp only [← arrow_ι _ default, comp_apply]
+    simp only [← arrow_ι _ default, CategoryTheory.comp_apply]
   · use i, y
 
 end WidePushout

--- a/Mathlib/CategoryTheory/Preadditive/Yoneda/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Yoneda/Basic.lean
@@ -52,13 +52,11 @@ structure, see `preadditiveYonedaObj`.
 def preadditiveYoneda : C ⥤ Cᵒᵖ ⥤ AddCommGrp.{v} where
   obj Y := preadditiveYonedaObj Y ⋙ forget₂ _ _
   map f :=
-    { app := fun _ =>
+    { app := fun _ => AddCommGrp.ofHom
         { toFun := fun g => g ≫ f
           map_zero' := Limits.zero_comp
           map_add' := fun _ _ => add_comp _ _ _ _ _ _ }
       naturality := fun _ _ _ => AddCommGrp.ext fun _ => Category.assoc _ _ _ }
-  map_id _ := by ext; dsimp; simp
-  map_comp f g := by ext; dsimp; simp
 
 /-- The Yoneda embedding for preadditive categories sends an object `X` to the copresheaf sending an
 object `Y` to the `End X`-module of morphisms `X ⟶ Y`.
@@ -79,14 +77,12 @@ structure, see `preadditiveCoyonedaObj`.
 def preadditiveCoyoneda : Cᵒᵖ ⥤ C ⥤ AddCommGrp.{v} where
   obj X := preadditiveCoyonedaObj X ⋙ forget₂ _ _
   map f :=
-    { app := fun _ =>
+    { app := fun _ => AddCommGrp.ofHom
         { toFun := fun g => f.unop ≫ g
           map_zero' := Limits.comp_zero
           map_add' := fun _ _ => comp_add _ _ _ _ _ _ }
       naturality := fun _ _ _ =>
         AddCommGrp.ext fun _ => Eq.symm <| Category.assoc _ _ _ }
-  map_id _ := by ext; dsimp; simp
-  map_comp f g := by ext; dsimp; simp
 
 instance additive_yonedaObj (X : C) : Functor.Additive (preadditiveYonedaObj X) where
 

--- a/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
@@ -96,7 +96,7 @@ theorem pullback_refine {Y X : C} {P : Cᵒᵖ ⥤ D} {S T : J.Cover X} (h : S �
 def mk {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : P.obj (op X)) : Meq P S :=
   ⟨fun I => P.map I.f.op x, fun I => by
     dsimp
-    simp only [← comp_apply, ← P.map_comp, ← op_comp, I.r.w]⟩
+    simp only [← CategoryTheory.comp_apply, ← P.map_comp, ← op_comp, I.r.w]⟩
 
 theorem mk_apply {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : P.obj (op X)) (I : S.Arrow) :
     mk S x I = P.map I.f.op x :=
@@ -152,7 +152,7 @@ theorem res_mk_eq_mk_pullback {Y X : C} {P : Cᵒᵖ ⥤ D} {S : J.Cover X} (x :
   ext i
   simp only [Functor.op_obj, unop_op, pullback_obj, diagram_obj, Functor.comp_obj,
     diagramPullback_app, Meq.equiv_apply, Meq.pullback_apply]
-  rw [← comp_apply, Multiequalizer.lift_ι]
+  rw [← CategoryTheory.comp_apply, Multiequalizer.lift_ι]
   erw [Meq.equiv_symm_eq_apply]
   cases i; rfl
 
@@ -162,13 +162,13 @@ theorem toPlus_mk {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : P.obj (op X))
   let e : S ⟶ ⊤ := homOfLE (OrderTop.le_top _)
   rw [← colimit.w _ e.op]
   delta Cover.toMultiequalizer
-  rw [comp_apply]
-  erw [comp_apply]
+  rw [CategoryTheory.comp_apply]
+  erw [CategoryTheory.comp_apply]
   apply congr_arg
   dsimp [diagram]
   apply Concrete.multiequalizer_ext
   intro i
-  simp only [← comp_apply, Category.assoc, Multiequalizer.lift_ι, Category.comp_id,
+  simp only [← CategoryTheory.comp_apply, Category.assoc, Multiequalizer.lift_ι, Category.comp_id,
     Meq.equiv_symm_eq_apply]
   rfl
 
@@ -177,17 +177,17 @@ theorem toPlus_apply {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : Meq P S) (
   dsimp only [toPlus, plusObj]
   delta Cover.toMultiequalizer
   dsimp [mk]
-  erw [← comp_apply]
-  rw [ι_colimMap_assoc, colimit.ι_pre, comp_apply, comp_apply]
+  erw [← CategoryTheory.comp_apply]
+  rw [ι_colimMap_assoc, colimit.ι_pre, CategoryTheory.comp_apply, CategoryTheory.comp_apply]
   dsimp only [Functor.op]
   let e : (J.pullback I.f).obj (unop (op S)) ⟶ ⊤ := homOfLE (OrderTop.le_top _)
   rw [← colimit.w _ e.op]
-  erw [comp_apply]
+  erw [CategoryTheory.comp_apply]
   apply congr_arg
   apply Concrete.multiequalizer_ext
   intro i
   dsimp
-  erw [← comp_apply, ← comp_apply, ← comp_apply]
+  erw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply]
   rw [Multiequalizer.lift_ι, Multiequalizer.lift_ι, Multiequalizer.lift_ι]
   erw [Meq.equiv_symm_eq_apply]
   simpa using (x.condition (Cover.Relation.mk' (I.precompRelation i.f))).symm
@@ -196,11 +196,11 @@ theorem toPlus_eq_mk {X : C} {P : Cᵒᵖ ⥤ D} (x : P.obj (op X)) :
     (J.toPlus P).app _ x = mk (Meq.mk ⊤ x) := by
   dsimp [mk, toPlus]
   delta Cover.toMultiequalizer
-  simp only [comp_apply]
+  simp only [CategoryTheory.comp_apply]
   apply congr_arg
   apply (Meq.equiv P ⊤).injective
   ext i
-  rw [Meq.equiv_apply, Equiv.apply_symm_apply, ← comp_apply, Multiequalizer.lift_ι]
+  rw [Meq.equiv_apply, Equiv.apply_symm_apply, ← CategoryTheory.comp_apply, Multiequalizer.lift_ι]
   rfl
 
 variable [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)]
@@ -224,7 +224,7 @@ theorem eq_mk_iff_exists {X : C} {P : Cᵒᵖ ⥤ D} {S T : J.Cover X} (x : Meq 
     convert hh
     all_goals
       dsimp [diagram]
-      erw [← comp_apply, Multiequalizer.lift_ι, Meq.equiv_symm_eq_apply]
+      erw [← CategoryTheory.comp_apply, Multiequalizer.lift_ι, Meq.equiv_symm_eq_apply]
       cases I; rfl
   · rintro ⟨S, h1, h2, e⟩
     apply Concrete.colimit_rep_eq_of_exists
@@ -235,7 +235,7 @@ theorem eq_mk_iff_exists {X : C} {P : Cᵒᵖ ⥤ D} {S T : J.Cover X} (x : Meq 
     convert e
     all_goals
       dsimp
-      erw [← comp_apply, Multiequalizer.lift_ι]
+      erw [← CategoryTheory.comp_apply, Multiequalizer.lift_ι]
       erw [Meq.equiv_symm_eq_apply]
       cases i; rfl
 
@@ -314,11 +314,12 @@ def meqOfSep (P : Cᵒᵖ ⥤ D)
   property := by
     intro II
     apply inj_of_sep P hsep
-    rw [← comp_apply, ← comp_apply, (J.toPlus P).naturality, (J.toPlus P).naturality, comp_apply,
-      comp_apply]
+    rw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply, (J.toPlus P).naturality,
+      (J.toPlus P).naturality, CategoryTheory.comp_apply, CategoryTheory.comp_apply]
     erw [toPlus_apply (T II.fst.fromMiddle) (t II.fst.fromMiddle) II.fst.toMiddle,
-      toPlus_apply (T II.snd.fromMiddle) (t II.snd.fromMiddle) II.snd.toMiddle, ← ht, ← ht, ←
-      comp_apply, ← comp_apply, ← (J.plusObj P).map_comp, ← (J.plusObj P).map_comp]
+      toPlus_apply (T II.snd.fromMiddle) (t II.snd.fromMiddle) II.snd.toMiddle, ← ht, ← ht,
+      ← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply, ← (J.plusObj P).map_comp,
+      ← (J.plusObj P).map_comp]
     rw [← op_comp, ← op_comp]
     exact s.condition
       (Cover.Relation.mk { hf := II.fst.from_middle_condition }
@@ -396,7 +397,7 @@ theorem isSheaf_of_sep (P : Cᵒᵖ ⥤ D)
     intro I
     apply_fun Meq.equiv _ _ at h
     apply_fun fun e => e I at h
-    convert h <;> erw [Meq.equiv_apply, ← comp_apply, Multiequalizer.lift_ι] <;> rfl
+    convert h <;> erw [Meq.equiv_apply, ← CategoryTheory.comp_apply, Multiequalizer.lift_ι] <;> rfl
   · rintro (x : (multiequalizer (S.index _) : D))
     obtain ⟨t, ht⟩ := exists_of_sep P hsep X S (Meq.equiv _ _ x)
     use t
@@ -404,7 +405,7 @@ theorem isSheaf_of_sep (P : Cᵒᵖ ⥤ D)
     rw [← ht]
     ext i
     dsimp
-    erw [← comp_apply]
+    erw [← CategoryTheory.comp_apply]
     rw [Multiequalizer.lift_ι]
     rfl
 

--- a/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
@@ -47,7 +47,7 @@ def imageSieve {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : G.obj (op U)) : 
   downward_closed := by
     rintro V W i ⟨t, ht⟩ j
     refine ⟨F.map j.op t, ?_⟩
-    rw [op_comp, G.map_comp, comp_apply, ← ht, elementwise_of% f.naturality]
+    rw [op_comp, G.map_comp, CategoryTheory.comp_apply, ← ht, elementwise_of% f.naturality]
 
 theorem imageSieve_eq_sieveOfSection {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : G.obj (op U)) :
     imageSieve f s = (Subpresheaf.range (whiskerRight f (forget A))).sieveOfSection s :=
@@ -129,8 +129,8 @@ instance isLocallySurjective_comp {F₁ F₂ F₃ : Cᵒᵖ ⥤ A} (f₁ : F₁ 
         imageSieve (f₁ ≫ f₂) s := by
       rintro V i ⟨W, i, j, H, ⟨t', ht'⟩, rfl⟩
       refine ⟨t', ?_⟩
-      rw [op_comp, F₃.map_comp, NatTrans.comp_app, comp_apply, comp_apply, ht',
-        elementwise_of% f₂.naturality, H.choose_spec]
+      rw [op_comp, F₃.map_comp, NatTrans.comp_app, CategoryTheory.comp_apply,
+        CategoryTheory.comp_apply, ht', elementwise_of% f₂.naturality, H.choose_spec]
     apply J.superset_covering this
     apply J.bind_covering
     · apply imageSieve_mem
@@ -192,8 +192,8 @@ lemma isLocallyInjective_of_isLocallyInjective_of_isLocallySurjective
       apply J.superset_covering (Sieve.le_pullback_bind _ _ _ hf)
       apply equalizerSieve_mem J (f₁ ≫ f₂)
       dsimp
-      rw [comp_apply, comp_apply, app_localPreimage, app_localPreimage,
-        NatTrans.naturality_apply, NatTrans.naturality_apply, h]
+      rw [CategoryTheory.comp_apply, CategoryTheory.comp_apply, app_localPreimage,
+        app_localPreimage, NatTrans.naturality_apply, NatTrans.naturality_apply, h]
 
 lemma isLocallyInjective_of_isLocallyInjective_of_isLocallySurjective_fac
     {F₁ F₂ F₃ : Cᵒᵖ ⥤ A} {f₁ : F₁ ⟶ F₂} {f₂ : F₂ ⟶ F₃} (f₃ : F₁ ⟶ F₃) (fac : f₁ ≫ f₂ = f₃)
@@ -218,7 +218,7 @@ lemma isLocallySurjective_of_isLocallySurjective_of_isLocallyInjective
       apply J.superset_covering (Sieve.le_pullback_bind _ _ _ hf)
       apply equalizerSieve_mem J f₂
       rw [NatTrans.naturality_apply, ← app_localPreimage (f₁ ≫ f₂) _ _ hf,
-        NatTrans.comp_app, comp_apply]
+        NatTrans.comp_app, CategoryTheory.comp_apply]
 
 lemma isLocallySurjective_of_isLocallySurjective_of_isLocallyInjective_fac
     {F₁ F₂ F₃ : Cᵒᵖ ⥤ A} {f₁ : F₁ ⟶ F₂} {f₂ : F₂ ⟶ F₃} (f₃ : F₁ ⟶ F₃) (fac : f₁ ≫ f₂ = f₃)

--- a/Mathlib/FieldTheory/Galois/Profinite.lean
+++ b/Mathlib/FieldTheory/Galois/Profinite.lean
@@ -52,7 +52,7 @@ namespace finGaloisGroupMap
 @[simp]
 lemma map_id (L : (FiniteGaloisIntermediateField k K)ᵒᵖ) :
     (finGaloisGroupMap (𝟙 L)) = 𝟙 L.unop.finGaloisGroup :=
-  AlgEquiv.restrictNormalHom_id _ _
+  ConcreteCategory.ext (AlgEquiv.restrictNormalHom_id _ _)
 
 @[simp]
 lemma map_comp {L₁ L₂ L₃ : (FiniteGaloisIntermediateField k K)ᵒᵖ} (f : L₁ ⟶ L₂) (g : L₂ ⟶ L₃) :
@@ -68,6 +68,7 @@ lemma map_comp {L₁ L₂ L₃ : (FiniteGaloisIntermediateField k K)ᵒᵖ} (f :
   haveI : IsScalarTower k L₃ L₁ := IsScalarTower.of_algebraMap_eq' rfl
   haveI : IsScalarTower k L₃ L₂ := IsScalarTower.of_algebraMap_eq' rfl
   haveI : IsScalarTower L₃ L₂ L₁ := IsScalarTower.of_algebraMap_eq' rfl
+  ext : 1
   apply IsScalarTower.AlgEquiv.restrictNormalHom_comp k L₃ L₂ L₁
 
 end finGaloisGroupMap

--- a/Mathlib/Order/Category/NonemptyFinLinOrd.lean
+++ b/Mathlib/Order/Category/NonemptyFinLinOrd.lean
@@ -170,7 +170,7 @@ theorem epi_iff_surjective {A B : NonemptyFinLinOrd.{u}} (f : A ⟶ B) :
       congr
       rw [← cancel_epi f]
       ext a
-      simp only [coe_of, comp_apply]
+      simp only [CategoryTheory.comp_apply]
       change ite _ _ _ = ite _ _ _
       split_ifs with h₁ h₂ h₂
       any_goals rfl

--- a/Mathlib/RepresentationTheory/Invariants.lean
+++ b/Mathlib/RepresentationTheory/Invariants.lean
@@ -123,8 +123,8 @@ theorem mem_invariants_iff_comm {X Y : Rep k G} (f : X.V →ₗ[k] Y.V) (g : G) 
   dsimp
   rw [← LinearMap.comp_assoc, ← ModuleCat.hom_ofHom (Y.ρ g), ← ModuleCat.hom_ofHom f,
       ← ModuleCat.hom_comp, ← ModuleCat.hom_ofHom (X.ρ g⁻¹), ← ModuleCat.hom_comp,
-      Rep.ofHom_ρ, ← ρAut_apply_inv X g, Rep.ofHom_ρ, ← ρAut_apply_hom Y g, ← ModuleCat.hom_ext_iff,
-      Iso.inv_comp_eq, ρAut_apply_hom, ← ModuleCat.hom_ofHom (X.ρ g),
+      Rep.ofHom_ρ, ← ρAut_hom_apply_inv X g, Rep.ofHom_ρ, ← ρAut_hom_apply_hom Y g,
+      ← ModuleCat.hom_ext_iff, Iso.inv_comp_eq, ρAut_hom_apply_hom, ← ModuleCat.hom_ofHom (X.ρ g),
       ← ModuleCat.hom_comp, ← ModuleCat.hom_ext_iff]
   exact comm
 

--- a/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Basic.lean
+++ b/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Basic.lean
@@ -162,13 +162,13 @@ def ofFiniteGrp (G : FiniteGrp) : ProfiniteGrp :=
 instance : HasForget₂ FiniteGrp ProfiniteGrp where
   forget₂ :=
   { obj := ofFiniteGrp
-    map := fun f => ⟨f, by continuity⟩ }
+    map := fun f => ⟨f.hom, by continuity⟩ }
 
 @[to_additive]
 instance : HasForget₂ ProfiniteGrp Grp where
   forget₂ := {
     obj := fun P => ⟨P, P.group⟩
-    map := fun f => f.toMonoidHom
+    map := fun f => Grp.ofHom f.toMonoidHom
   }
 
 /-- A closed subgroup of a profinite group is profinite. -/

--- a/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Basic.lean
+++ b/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Basic.lean
@@ -166,10 +166,8 @@ instance : HasForget₂ FiniteGrp ProfiniteGrp where
 
 @[to_additive]
 instance : HasForget₂ ProfiniteGrp Grp where
-  forget₂ := {
-    obj := fun P => ⟨P, P.group⟩
-    map := fun f => Grp.ofHom f.toMonoidHom
-  }
+  forget₂.obj P := Grp.of P
+  forget₂.map f := Grp.ofHom f.toMonoidHom
 
 /-- A closed subgroup of a profinite group is profinite. -/
 def ofClosedSubgroup {G : ProfiniteGrp} (H : ClosedSubgroup G)  : ProfiniteGrp :=

--- a/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Limits.lean
+++ b/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Limits.lean
@@ -43,9 +43,9 @@ instance (P : ProfiniteGrp) : SmallCategory (OpenNormalSubgroup P) :=
 where `P : ProfiniteGrp`. -/
 def toFiniteQuotientFunctor (P : ProfiniteGrp) : OpenNormalSubgroup P ⥤ FiniteGrp := {
     obj := fun H => FiniteGrp.of (P ⧸ H.toSubgroup)
-    map := fun fHK => QuotientGroup.map _ _ (.id _) (leOfHom fHK)
-    map_id _ := QuotientGroup.map_id _
-    map_comp f g := (QuotientGroup.map_comp_map
+    map := fun fHK => FiniteGrp.ofHom (QuotientGroup.map _ _ (.id _) (leOfHom fHK))
+    map_id _ := ConcreteCategory.ext <| QuotientGroup.map_id _
+    map_comp f g := ConcreteCategory.ext <| (QuotientGroup.map_comp_map
       _ _ _ (.id _) (.id _) (leOfHom f) (leOfHom g)).symm }
 
 /--The `MonoidHom` from a profinite group `P` to  the projective limit of its quotients by

--- a/Mathlib/Topology/Category/CompHaus/Basic.lean
+++ b/Mathlib/Topology/Category/CompHaus/Basic.lean
@@ -168,7 +168,7 @@ def limitCone {J : Type v} [SmallCategory J] (F : J ⥤ CompHaus.{max v u}) : Li
       naturality := by
         intro _ _ f
         ext ⟨x, hx⟩
-        simp only [comp_apply, Functor.const_obj_map, id_apply]
+        simp only [CategoryTheory.comp_apply, Functor.const_obj_map, CategoryTheory.id_apply]
         exact (hx f).symm } }
 
 /-- The limit cone `CompHaus.limitCone F` is indeed a limit cone. -/

--- a/Mathlib/Topology/Category/Profinite/Basic.lean
+++ b/Mathlib/Topology/Category/Profinite/Basic.lean
@@ -240,8 +240,8 @@ theorem epi_iff_surjective {X Y : Profinite.{u}} (f : X ⟶ Y) : Epi f ↔ Funct
         apply ULift.ext
         dsimp [g, LocallyConstant.ofIsClopen]
         -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-        erw [comp_apply, ContinuousMap.coe_mk, comp_apply, ContinuousMap.coe_mk,
-          Function.comp_apply, if_neg]
+        erw [CategoryTheory.comp_apply, ContinuousMap.coe_mk, CategoryTheory.comp_apply,
+          ContinuousMap.coe_mk, Function.comp_apply, if_neg]
         refine mt (fun α => hVU α) ?_
         simp only [U, C, Set.mem_range_self, not_true, not_false_iff, Set.mem_compl_iff]
       apply_fun fun e => (e y).down at H

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -217,9 +217,9 @@ theorem range_prod_map {W X Y Z : TopCat.{u}} (f : W ⟶ Y) (g : X ⟶ Z) :
   · rintro ⟨y, rfl⟩
     simp_rw [Set.mem_inter_iff, Set.mem_preimage, Set.mem_range]
     -- sizable changes in this proof after https://github.com/leanprover-community/mathlib4/pull/13170
-    rw [← comp_apply, ← comp_apply]
+    rw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply]
     simp_rw [Limits.prod.map_fst,
-      Limits.prod.map_snd, comp_apply]
+      Limits.prod.map_snd, CategoryTheory.comp_apply]
     exact ⟨exists_apply_eq_apply _ _, exists_apply_eq_apply _ _⟩
   · rintro ⟨⟨x₁, hx₁⟩, ⟨x₂, hx₂⟩⟩
     use (prodIsoProd W X).inv (x₁, x₂)
@@ -227,12 +227,12 @@ theorem range_prod_map {W X Y Z : TopCat.{u}} (f : W ⟶ Y) (g : X ⟶ Z) :
     apply Concrete.limit_ext
     rintro ⟨⟨⟩⟩
     · change limit.π (pair Y Z) _ ((prod.map f g) _) = _
-      erw [← comp_apply, Limits.prod.map_fst]
+      erw [← CategoryTheory.comp_apply, Limits.prod.map_fst]
       change (_ ≫ _ ≫ f) _ = _
       rw [TopCat.prodIsoProd_inv_fst_assoc,TopCat.comp_app]
       exact hx₁
     · change limit.π (pair Y Z) _ ((prod.map f g) _) = _
-      erw [← comp_apply, Limits.prod.map_snd]
+      erw [← CategoryTheory.comp_apply, Limits.prod.map_snd]
       change (_ ≫ _ ≫ g) _ = _
       rw [TopCat.prodIsoProd_inv_snd_assoc,TopCat.comp_app]
       exact hx₂

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -48,7 +48,7 @@ def pullbackCone (f : X ⟶ Z) (g : Y ⟶ Z) : PullbackCone f g :=
       -- Next 2 lines were
       -- `rw [comp_apply, ContinuousMap.coe_mk, comp_apply, ContinuousMap.coe_mk]`
       -- `exact h` before https://github.com/leanprover/lean4/pull/2644
-      rw [comp_apply, comp_apply]
+      rw [CategoryTheory.comp_apply, CategoryTheory.comp_apply]
       congr!)
 
 /-- The constructed cone is a limit. -/
@@ -69,12 +69,12 @@ def pullbackConeIsLimit (f : X ⟶ Z) (g : Y ⟶ Z) : IsLimit (pullbackCone f g)
       · delta pullbackCone
         ext a
         -- This used to be `rw`, but we need `rw; rfl` after https://github.com/leanprover/lean4/pull/2644
-        rw [comp_apply, ContinuousMap.coe_mk]
+        rw [CategoryTheory.comp_apply, ContinuousMap.coe_mk]
         rfl
       · delta pullbackCone
         ext a
         -- This used to be `rw`, but we need `rw; rfl` after https://github.com/leanprover/lean4/pull/2644
-        rw [comp_apply, ContinuousMap.coe_mk]
+        rw [CategoryTheory.comp_apply, ContinuousMap.coe_mk]
         rfl
       · intro m h₁ h₂
         -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): used to be `ext x`.
@@ -150,7 +150,7 @@ theorem range_pullback_to_prod {X Y Z : TopCat} (f : X ⟶ Z) (g : Y ⟶ Z) :
     change (forget TopCat).map _ _ = _ -- new `change` after https://github.com/leanprover-community/mathlib4/pull/13170
     apply Concrete.limit_ext
     rintro ⟨⟨⟩⟩ <;>
-    erw [← comp_apply, ← comp_apply, limit.lift_π] <;> -- now `erw` after https://github.com/leanprover-community/mathlib4/pull/13170
+    erw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply, limit.lift_π] <;> -- now `erw` after https://github.com/leanprover-community/mathlib4/pull/13170
     -- This used to be `simp` before https://github.com/leanprover/lean4/pull/2644
     aesop_cat
 
@@ -202,29 +202,30 @@ theorem range_pullback_map {W X Y Z S T : TopCat} (f₁ : W ⟶ S) (f₂ : X ⟶
   constructor
   · rintro ⟨y, rfl⟩
     simp only [Set.mem_inter_iff, Set.mem_preimage, Set.mem_range]
-    rw [← comp_apply, ← comp_apply]
-    simp only [limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app, comp_apply]
+    rw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply]
+    simp only [limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app, CategoryTheory.comp_apply]
     exact ⟨exists_apply_eq_apply _ _, exists_apply_eq_apply _ _⟩
   rintro ⟨⟨x₁, hx₁⟩, ⟨x₂, hx₂⟩⟩
   have : f₁ x₁ = f₂ x₂ := by
     apply (TopCat.mono_iff_injective _).mp H₃
-    rw [← comp_apply, eq₁, ← comp_apply, eq₂,
-      comp_apply, comp_apply, hx₁, hx₂, ← comp_apply, pullback.condition]
+    rw [← CategoryTheory.comp_apply, eq₁, ← CategoryTheory.comp_apply, eq₂,
+      CategoryTheory.comp_apply, CategoryTheory.comp_apply, hx₁, hx₂, ← CategoryTheory.comp_apply,
+      pullback.condition]
     rfl -- `rfl` was not needed before https://github.com/leanprover-community/mathlib4/pull/13170
   use (pullbackIsoProdSubtype f₁ f₂).inv ⟨⟨x₁, x₂⟩, this⟩
   change (forget TopCat).map _ _ = _
   apply Concrete.limit_ext
   rintro (_ | _ | _) <;>
-  erw [← comp_apply, ← comp_apply] -- now `erw` after https://github.com/leanprover-community/mathlib4/pull/13170
+  erw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply] -- now `erw` after https://github.com/leanprover-community/mathlib4/pull/13170
   · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_π_app_one]
-    simp only [cospan_one, pullbackIsoProdSubtype_inv_fst_assoc, comp_apply]
+    simp only [cospan_one, pullbackIsoProdSubtype_inv_fst_assoc, CategoryTheory.comp_apply]
     rw [pullbackFst_apply, hx₁, ← limit.w _ WalkingCospan.Hom.inl, cospan_map_inl,
-        comp_apply (g := g₁)]
+        CategoryTheory.comp_apply (g := g₁)]
   · simp only [cospan_left, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
-      pullbackIsoProdSubtype_inv_fst_assoc, comp_apply]
+      pullbackIsoProdSubtype_inv_fst_assoc, CategoryTheory.comp_apply]
     erw [hx₁] -- now `erw` after https://github.com/leanprover-community/mathlib4/pull/13170
   · simp only [cospan_right, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
-      pullbackIsoProdSubtype_inv_snd_assoc, comp_apply]
+      pullbackIsoProdSubtype_inv_snd_assoc, CategoryTheory.comp_apply]
     erw [hx₂] -- now `erw` after https://github.com/leanprover-community/mathlib4/pull/13170
 
 theorem pullback_fst_range {X Y S : TopCat} (f : X ⟶ S) (g : Y ⟶ S) :

--- a/Mathlib/Topology/Gluing.lean
+++ b/Mathlib/Topology/Gluing.lean
@@ -196,8 +196,9 @@ theorem ι_eq_iff_rel (i j : D.J) (x : D.U i) (y : D.U j) :
       (ConcreteCategory.bijective_of_isIso (sigmaIsoSigma.{u, u} _).inv).2 x
     unfold InvImage MultispanIndex.fstSigmaMap MultispanIndex.sndSigmaMap
     simp only [forget_map_eq_coe]
-    erw [TopCat.comp_app, sigmaIsoSigma_inv_apply, ← comp_apply, ← comp_apply,
-      colimit.ι_desc_assoc, ← comp_apply, ← comp_apply, colimit.ι_desc_assoc]
+    erw [TopCat.comp_app, sigmaIsoSigma_inv_apply, ← CategoryTheory.comp_apply,
+      ← CategoryTheory.comp_apply, colimit.ι_desc_assoc, ← CategoryTheory.comp_apply,
+      ← CategoryTheory.comp_apply, colimit.ι_desc_assoc]
       -- previous line now `erw` after https://github.com/leanprover-community/mathlib4/pull/13170
     erw [sigmaIsoSigma_hom_ι_apply, sigmaIsoSigma_hom_ι_apply]
     exact Or.inr ⟨y, ⟨rfl, rfl⟩⟩

--- a/Mathlib/Topology/Sheaves/LocallySurjective.lean
+++ b/Mathlib/Topology/Sheaves/LocallySurjective.lean
@@ -109,7 +109,7 @@ theorem locally_surjective_iff_surjective_on_stalks (T : ℱ ⟶ 𝒢) :
     obtain ⟨W, hxW, hWV, hWU, h_eq⟩ := key_W
     refine ⟨W, hWU, ⟨ℱ.map hWV.op s, ?_⟩, hxW⟩
     convert h_eq using 1
-    simp only [← comp_apply, T.naturality]
+    simp only [← CategoryTheory.comp_apply, T.naturality]
 
 end SurjectiveOnStalks
 

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -130,14 +130,14 @@ theorem restrict_restrict {X : TopCat} {C : Type*} [Category C] [HasForget C]
     {F : X.Presheaf C} {U V W : Opens X} (e₁ : U ≤ V) (e₂ : V ≤ W) (x : F.obj (op W)) :
     x |_ V |_ U = x |_ U := by
   delta restrictOpen restrict
-  rw [← comp_apply, ← Functor.map_comp]
+  rw [← CategoryTheory.comp_apply, ← Functor.map_comp]
   rfl
 
 theorem map_restrict {X : TopCat} {C : Type*} [Category C] [HasForget C]
     {F G : X.Presheaf C} (e : F ⟶ G) {U V : Opens X} (h : U ≤ V) (x : F.obj (op V)) :
     e.app _ (x |_ U) = e.app _ x |_ U := by
   delta restrictOpen restrict
-  rw [← comp_apply, NatTrans.naturality, comp_apply]
+  rw [← CategoryTheory.comp_apply, NatTrans.naturality, CategoryTheory.comp_apply]
 
 open CategoryTheory.Limits
 

--- a/Mathlib/Topology/Sheaves/SheafCondition/UniqueGluing.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/UniqueGluing.lean
@@ -181,12 +181,12 @@ theorem existsUnique_gluing' (V : Opens X) (iUV : ∀ i : ι, U i ⟶ V) (hcover
   obtain ⟨gl, gl_spec, gl_uniq⟩ := F.existsUnique_gluing U sf h
   refine ⟨F.1.map (eqToHom V_eq_supr_U).op gl, ?_, ?_⟩
   · intro i
-    rw [← comp_apply, ← F.1.map_comp]
+    rw [← CategoryTheory.comp_apply, ← F.1.map_comp]
     exact gl_spec i
   · intro gl' gl'_spec
     convert congr_arg _ (gl_uniq (F.1.map (eqToHom V_eq_supr_U.symm).op gl') fun i => _) <;>
-      rw [← comp_apply, ← F.1.map_comp]
-    · rw [eqToHom_op, eqToHom_op, eqToHom_trans, eqToHom_refl, F.1.map_id, id_apply]
+      rw [← CategoryTheory.comp_apply, ← F.1.map_comp]
+    · rw [eqToHom_op, eqToHom_op, eqToHom_trans, eqToHom_refl, F.1.map_id, CategoryTheory.id_apply]
     · convert gl'_spec i
 
 @[ext]
@@ -195,7 +195,7 @@ theorem eq_of_locally_eq (s t : F.1.obj (op (iSup U)))
   let sf : ∀ i : ι, F.1.obj (op (U i)) := fun i => F.1.map (Opens.leSupr U i).op s
   have sf_compatible : IsCompatible _ U sf := by
     intro i j
-    simp_rw [sf, ← comp_apply, ← F.1.map_comp]
+    simp_rw [sf, ← CategoryTheory.comp_apply, ← F.1.map_comp]
     rfl
   obtain ⟨gl, -, gl_uniq⟩ := F.existsUnique_gluing U sf sf_compatible
   trans gl
@@ -215,11 +215,11 @@ theorem eq_of_locally_eq' (V : Opens X) (iUV : ∀ i : ι, U i ⟶ V) (hcover : 
   have V_eq_supr_U : V = iSup U := le_antisymm hcover (iSup_le fun i => (iUV i).le)
   suffices F.1.map (eqToHom V_eq_supr_U.symm).op s = F.1.map (eqToHom V_eq_supr_U.symm).op t by
     convert congr_arg (F.1.map (eqToHom V_eq_supr_U).op) this <;>
-    rw [← comp_apply, ← F.1.map_comp, eqToHom_op, eqToHom_op, eqToHom_trans, eqToHom_refl,
-      F.1.map_id, id_apply]
+    rw [← CategoryTheory.comp_apply, ← F.1.map_comp, eqToHom_op, eqToHom_op, eqToHom_trans,
+      eqToHom_refl, F.1.map_id, CategoryTheory.id_apply]
   apply eq_of_locally_eq
   intro i
-  rw [← comp_apply, ← comp_apply, ← F.1.map_comp]
+  rw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply, ← F.1.map_comp]
   convert h i
 
 theorem eq_of_locally_eq₂ {U₁ U₂ V : Opens X} (i₁ : U₁ ⟶ V) (i₂ : U₂ ⟶ V) (hcover : V ≤ U₁ ⊔ U₂)

--- a/Mathlib/Topology/Sheaves/Stalks.lean
+++ b/Mathlib/Topology/Sheaves/Stalks.lean
@@ -113,12 +113,14 @@ lemma map_germ_eq_Γgerm (F : X.Presheaf C) {U : Opens X} {i : U ⟶ ⊤} (x : X
 attribute [local instance] HasForget.instFunLike in
 theorem germ_res_apply (F : X.Presheaf C)
     {U V : Opens X} (i : U ⟶ V) (x : X) (hx : x ∈ U) [HasForget C] (s) :
-  F.germ U x hx (F.map i.op s) = F.germ V x (i.le hx) s := by rw [← comp_apply, germ_res]
+    F.germ U x hx (F.map i.op s) = F.germ V x (i.le hx) s := by
+  rw [← CategoryTheory.comp_apply, germ_res]
 
 attribute [local instance] HasForget.instFunLike in
 theorem germ_res_apply' (F : X.Presheaf C)
     {U V : Opens X} (i : op V ⟶ op U) (x : X) (hx : x ∈ U) [HasForget C] (s) :
-  F.germ U x hx (F.map i s) = F.germ V x (i.unop.le hx) s := by rw [← comp_apply, germ_res']
+    F.germ U x hx (F.map i s) = F.germ V x (i.unop.le hx) s := by
+  rw [← CategoryTheory.comp_apply, germ_res']
 
 attribute [local instance] HasForget.instFunLike in
 lemma Γgerm_res_apply (F : X.Presheaf C)
@@ -143,8 +145,8 @@ attribute [local instance] HasForget.instFunLike in
 theorem stalkFunctor_map_germ_apply [HasForget C]
     {F G : X.Presheaf C} (U : Opens X) (x : X) (hx : x ∈ U) (f : F ⟶ G) (s) :
     (stalkFunctor C x).map f (F.germ U x hx s) = G.germ U x hx (f.app (op U) s) := by
-  rw [← comp_apply, ← stalkFunctor_map_germ]
-  exact (comp_apply _ _ _).symm
+  rw [← CategoryTheory.comp_apply, ← stalkFunctor_map_germ]
+  exact (CategoryTheory.comp_apply _ _ _).symm
 
 -- a variant of `stalkFunctor_map_germ_apply` that makes simpNF happy.
 attribute [local instance] HasForget.instFunLike in
@@ -403,7 +405,8 @@ theorem germ_ext (F : X.Presheaf C) {U V : Opens X} {x : X} {hxU : x ∈ U} {hxV
     (W : Opens X) (hxW : x ∈ W) (iWU : W ⟶ U) (iWV : W ⟶ V) {sU : F.obj (op U)} {sV : F.obj (op V)}
     (ih : F.map iWU.op sU = F.map iWV.op sV) :
       F.germ _ x hxU sU = F.germ _ x hxV sV := by
-  rw [← F.germ_res iWU x hxW, ← F.germ_res iWV x hxW, comp_apply, comp_apply, ih]
+  rw [← F.germ_res iWU x hxW, ← F.germ_res iWV x hxW, CategoryTheory.comp_apply,
+    CategoryTheory.comp_apply, ih]
 
 variable [PreservesFilteredColimits (forget C)]
 
@@ -436,7 +439,8 @@ theorem stalkFunctor_map_injective_of_app_injective {F G : Presheaf C X} (f : F 
   rcases germ_exist F x t with ⟨U₂, hxU₂, t, rfl⟩
   rw [stalkFunctor_map_germ_apply, stalkFunctor_map_germ_apply] at hst
   obtain ⟨W, hxW, iWU₁, iWU₂, heq⟩ := G.germ_eq x hxU₁ hxU₂ _ _ hst
-  rw [← comp_apply, ← comp_apply, ← f.naturality, ← f.naturality, comp_apply, comp_apply] at heq
+  rw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply, ← f.naturality, ← f.naturality,
+    CategoryTheory.comp_apply, CategoryTheory.comp_apply] at heq
   replace heq := h W heq
   convert congr_arg (F.germ _ x hxW) heq using 1
   exacts [(F.germ_res_apply iWU₁ x hxW s).symm, (F.germ_res_apply iWU₂ x hxW t).symm]
@@ -533,7 +537,7 @@ theorem app_surjective_of_injective_of_locally_surjective {F G : Sheaf C X} (f :
     · use s
       apply G.eq_of_locally_eq' V U iVU V_cover
       intro x
-      rw [← comp_apply, ← f.1.naturality, comp_apply, s_spec, heq]
+      rw [← CategoryTheory.comp_apply, ← f.1.naturality, CategoryTheory.comp_apply, s_spec, heq]
   intro x y
   -- What's left to show here is that the sections `sf` are compatible, i.e. they agree on
   -- the intersections `V x ⊓ V y`. We prove this by showing that all germs are equal.
@@ -543,7 +547,8 @@ theorem app_surjective_of_injective_of_locally_surjective {F G : Sheaf C X} (f :
   apply hinj z ((iVU x).le ((inf_le_left : V x ⊓ V y ≤ V x) hz))
   dsimp only
   rw [stalkFunctor_map_germ_apply, stalkFunctor_map_germ_apply]
-  simp_rw [← comp_apply, f.1.naturality, comp_apply, heq, ← comp_apply, ← G.1.map_comp]
+  simp_rw [← CategoryTheory.comp_apply, f.1.naturality, CategoryTheory.comp_apply, heq,
+    ← CategoryTheory.comp_apply, ← G.1.map_comp]
   rfl
 
 theorem app_surjective_of_stalkFunctor_map_bijective {F G : Sheaf C X} (f : F ⟶ G) (U : Opens X)
@@ -562,7 +567,7 @@ theorem app_surjective_of_stalkFunctor_map_bijective {F G : Sheaf C X} (f : F �
   obtain ⟨V₂, hxV₂, iV₂V₁, iV₂U, heq⟩ := G.presheaf.germ_eq x hxV₁ hx _ _ hs₁
   -- The restriction of `s₁` to that neighborhood is our desired local preimage.
   use V₂, hxV₂, iV₂U, F.1.map iV₂V₁.op s₁
-  rw [← comp_apply, f.1.naturality, comp_apply, heq]
+  rw [← CategoryTheory.comp_apply, f.1.naturality, CategoryTheory.comp_apply, heq]
 
 theorem app_bijective_of_stalkFunctor_map_bijective {F G : Sheaf C X} (f : F ⟶ G) (U : Opens X)
     (h : ∀ x ∈ U, Function.Bijective ((stalkFunctor C x).map f.1)) :

--- a/MathlibTest/CategoryTheory/ConcreteCategory/Grp.lean
+++ b/MathlibTest/CategoryTheory/ConcreteCategory/Grp.lean
@@ -1,0 +1,50 @@
+import Mathlib.Algebra.Category.Grp.Basic
+
+universe v u
+
+open CategoryTheory Grp
+
+set_option maxHeartbeats 10000
+set_option synthInstance.maxHeartbeats 2000
+
+/- We test if all the coercions and `map_add` lemmas trigger correctly. -/
+
+example (X : Type u) [Group X] : ⇑(𝟙 (of X)) = id := by simp
+
+example {X Y : Type u} [Group X] [Group Y] (f : X →* Y) :
+    ⇑(ofHom f) = ⇑f := by simp
+
+example {X Y : Type u} [Group X] [Group Y] (f : X →* Y)
+    (x : X) : (ofHom f) x = f x := by simp
+
+example {X Y Z : Grp} (f : X ⟶ Y) (g : Y ⟶ Z) : ⇑(f ≫ g) = ⇑g ∘ ⇑f := by simp
+
+example {X Y Z : Type u} [Group X] [Group Y] [Group Z]
+    (f : X →* Y) (g : Y →* Z) :
+    ⇑(ofHom f ≫ ofHom g) = g ∘ f := by simp
+
+example {X Y : Type u} [Group X] [Group Y] {Z : Grp}
+    (f : X →* Y) (g : of Y ⟶ Z) :
+    ⇑(ofHom f ≫ g) = g ∘ f := by simp
+
+example {X Y : Grp} {Z : Type u} [Group Z] (f : X ⟶ Y) (g : Y ⟶ of Z) :
+    ⇑(f ≫ g) = g ∘ f := by simp
+
+example {Y Z : Grp} {X : Type u} [Group X] (f : of X ⟶ Y) (g : Y ⟶ Z) :
+    ⇑(f ≫ g) = g ∘ f := by simp
+
+example {X Y Z : Grp} (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) : (f ≫ g) x = g (f x) := by simp
+
+example {X Y : Grp} (e : X ≅ Y) (x : X) : e.inv (e.hom x) = x := by simp
+
+example {X Y : Grp} (e : X ≅ Y) (y : Y) : e.hom (e.inv y) = y := by simp
+
+example (X : Grp) : ⇑(𝟙 X) = id := by simp
+
+example {X : Type*} [Group X] : ⇑(MonoidHom.id X) = id := by simp
+
+example {M N : Grp} (f : M ⟶ N) (x y : M) : f (x * y) = f x * f y := by
+  simp
+
+example {M N : Grp} (f : M ⟶ N) : f 1 = 1 := by
+  simp


### PR DESCRIPTION
This is a step towards a concrete category redesign, as outlined in this Zulip post: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Concrete.20category.20class.20redesign/near/493903980

This PR updates the concrete category definitions of `Grp`, `AddGrp`, `CommGrp` and `AddCommGrp` to match the standard set by `AlgebraCat`, `ModuleCat` and `RingCat`:
* Package objects and homs into structures.
* Replace `HasForget` with `ConcreteCategory`.
* Set up a good `@[simp]` set.
* Ensure constructors and projections are reducible. See `MathlibTest/CategoryTheory/ConcreteCategory/Grp.lean` for the specification of all the new functionality.

In particular, we can drop `coe_of` from the `@[simp]` set, which means we can re-enable some `@[simps]` attributes downstream. (I did the ones I came across, but we'd need to go through the library more carefully to get them all.)

Overall I think we get a good cleanup, even if there are a handful of places where we have to fight more against the `HasForget`/`ConcreteCategory` non-reducible defeq. Those should go away as `HasForget` is obsoleted further.

I have not tried to look for code that can be cleaned up now, only at what broke. I want to get started on cleanup when the other concrete category instances are in.


---

- [ ] depends on: #21189

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
