### PR TITLE
feat(Cache): enable partial cache in downstream projects

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -126,8 +126,9 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
       IO.FS.removeFile IO.CURLCFG
       if success + failed < done then
         IO.eprintln "Warning: some files were not found in the cache."
-        IO.eprintln "This usually means that your local checkout of mathlib4 has diverged from upstream."
-        IO.eprintln "If you push your commits to a branch of the mathlib4 repository, CI will build the oleans and they will be available later."
+        IO.eprintln "* If you have mathlib4 as a dependency, this is expected, but you can use `lake clean mathlib` if the cache is not applied."
+        IO.eprintln "* If you are on a clone of mathlib4, this usually means that your local checkout has diverged from upstream."
+        IO.eprintln "  If you push your commits to a branch of the mathlib4 repository, CI will build the oleans and they will be available later."
       pure failed
     else
       let r ← hashMap.foldM (init := []) fun acc _ hash => do


### PR DESCRIPTION
NOTE: completely replaced by #21238

Enable `lake exe cache get MyProject.lean` to get a partial mathlib cache.

Does not alter the functionality of `lake exe cache get` (no args) in downstream projects, nor `lake exe cache get Mathlib/Init.lean` for cached files.

Note: This is a bit hacky and will always report "Warning: some files were not found in the cache" for the files coming from the downstream project, but a proper implementation seems to require access to the loaded lake `Workspace` (not just the manifest), which seems not to be supported at the current time.

---

Moreover, this assumes the downstream project has a somewhat sane setup, which hopefully applies for a majority of projects. Concretely, `lake exe cache get MyProject/Basic.lean` assumes that there is a folder `./MyProject/`.

TODO: Test for projects `requiring` a third-party package!

## Use case:

I would like to use `lake exe cache get Game.lean` in NNG and others to automatically only fetch the relevant part of Mathlib.


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
