### PR TITLE
[Merged by Bors] - refactor(LinearAlgebra/QuadraticForm/TensorProduct): baseChange_ext for Quadratic Maps

### DIFF
--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -169,8 +169,7 @@ theorem baseChange_ext ⦃Q₁ Q₂ : QuadraticMap A (A ⊗[R] M₂) N₁⦄
     dsimp [polar] at this
     calc
     Q₁ (x + y) = (Q₁ (x + y) - Q₁ x - Q₁ y) + Q₁ x + Q₁ y := by abel
-    _ = (Q₂ (x + y) - Q₂ x - Q₂ y) + Q₁ x + Q₁ y := by rw [this]
-    _ = (Q₂ (x + y) - Q₂ x - Q₂ y) + Q₂ x + Q₂ y := by rw [hx, hy]
+    _ = (Q₂ (x + y) - Q₂ x - Q₂ y) + Q₂ x + Q₂ y := by rw [this, hx, hy]
     _ = Q₂ (x + y) := by abel
 
 end CommRing

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -155,8 +155,7 @@ theorem baseChange_ext ⦃Q₁ Q₂ : QuadraticMap A (A ⊗[R] M₂) N₁⦄
     Q₁ = Q₂ := by
   replace h (a m) : Q₁ (a ⊗ₜ m) = Q₂ (a ⊗ₜ m) := by
     rw [← mul_one a, ← smul_eq_mul, ← smul_tmul', QuadraticMap.map_smul, QuadraticMap.map_smul, h]
-  apply QuadraticMap.ext
-  intro x
+  ext x
   induction x with
   | tmul => simp [h]
   | zero => simp
@@ -167,9 +166,6 @@ theorem baseChange_ext ⦃Q₁ Q₂ : QuadraticMap A (A ⊗[R] M₂) N₁⦄
       rw [← TensorProduct.tmul_add, h, h, h]
     replace := congr($this x y)
     dsimp [polar] at this
-    calc
-    Q₁ (x + y) = (Q₁ (x + y) - Q₁ x - Q₁ y) + Q₁ x + Q₁ y := by abel
-    _ = (Q₂ (x + y) - Q₂ x - Q₂ y) + Q₂ x + Q₂ y := by rw [this, hx, hy]
-    _ = Q₂ (x + y) := by abel
+    linear_combination (norm := module) this + hx + hy
 
 end CommRing

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -27,7 +27,7 @@ section CommRing
 variable [CommRing R] [CommRing A]
 variable [AddCommGroup M₁] [AddCommGroup M₂] [AddCommGroup N₁] [AddCommGroup N₂]
 variable [Algebra R A] [Module R M₁] [Module A M₁] [Module R N₁] [Module A N₁]
-variable [SMulCommClass R A M₁] [IsScalarTower R A M₁] [SMulCommClass R A N₁] [IsScalarTower R A N₁]
+variable [SMulCommClass R A M₁] [IsScalarTower R A M₁]  [IsScalarTower R A N₁]
 variable [Module R M₂] [Module R N₂]
 
 section InvertibleTwo
@@ -144,18 +144,19 @@ end QuadraticForm
 
 end InvertibleTwo
 
-/-- If two quadratic forms from `A ⊗[R] M₂` agree on elements of the form `1 ⊗ m`, they are equal.
+/-- If two quadratic maps from `A ⊗[R] M₂` agree on elements of the form `1 ⊗ m`, they are equal.
 
-In other words, if a base change exists for a quadratic form, it is unique.
+In other words, if a base change exists for a quadratic map, it is unique.
 
 Note that unlike `QuadraticForm.baseChange`, this does not need `Invertible (2 : R)`. -/
 @[ext]
-theorem baseChange_ext ⦃Q₁ Q₂ : QuadraticForm A (A ⊗[R] M₂)⦄
+theorem baseChange_ext ⦃Q₁ Q₂ : QuadraticMap A (A ⊗[R] M₂) N₁⦄
     (h : ∀ m, Q₁ (1 ⊗ₜ m) = Q₂ (1 ⊗ₜ m)) :
     Q₁ = Q₂ := by
   replace h (a m) : Q₁ (a ⊗ₜ m) = Q₂ (a ⊗ₜ m) := by
     rw [← mul_one a, ← smul_eq_mul, ← smul_tmul', QuadraticMap.map_smul, QuadraticMap.map_smul, h]
-  ext x
+  apply QuadraticMap.ext
+  intro x
   induction x with
   | tmul => simp [h]
   | zero => simp
@@ -166,6 +167,10 @@ theorem baseChange_ext ⦃Q₁ Q₂ : QuadraticForm A (A ⊗[R] M₂)⦄
       rw [← TensorProduct.tmul_add, h, h, h]
     replace := congr($this x y)
     dsimp [polar] at this
-    linear_combination this + hx + hy
+    calc
+    Q₁ (x + y) = (Q₁ (x + y) - Q₁ x - Q₁ y) + Q₁ x + Q₁ y := by abel
+    _ = (Q₂ (x + y) - Q₂ x - Q₂ y) + Q₁ x + Q₁ y := by rw [this]
+    _ = (Q₂ (x + y) - Q₂ x - Q₂ y) + Q₂ x + Q₂ y := by rw [hx, hy]
+    _ = Q₂ (x + y) := by abel
 
 end CommRing

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -27,7 +27,7 @@ section CommRing
 variable [CommRing R] [CommRing A]
 variable [AddCommGroup M₁] [AddCommGroup M₂] [AddCommGroup N₁] [AddCommGroup N₂]
 variable [Algebra R A] [Module R M₁] [Module A M₁] [Module R N₁] [Module A N₁]
-variable [SMulCommClass R A M₁] [IsScalarTower R A M₁]  [IsScalarTower R A N₁]
+variable [SMulCommClass R A M₁] [IsScalarTower R A M₁] [IsScalarTower R A N₁]
 variable [Module R M₂] [Module R N₂]
 
 section InvertibleTwo


### PR DESCRIPTION
`baseChange_ext` works just as well for quadratic maps as quadratic forms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
