### PR TITLE
[Merged by Bors] - feat(RingTheory/Artinian): integral non-zero-divisors are units over artinian rings

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4443,6 +4443,7 @@ import Mathlib.RingTheory.AlgebraicIndependent.Defs
 import Mathlib.RingTheory.AlgebraicIndependent.RankAndCardinality
 import Mathlib.RingTheory.AlgebraicIndependent.TranscendenceBasis
 import Mathlib.RingTheory.AlgebraicIndependent.Transcendental
+import Mathlib.RingTheory.Artinian.Algebra
 import Mathlib.RingTheory.Artinian.Instances
 import Mathlib.RingTheory.Artinian.Module
 import Mathlib.RingTheory.Artinian.Ring

--- a/Mathlib/RingTheory/Artinian/Algebra.lean
+++ b/Mathlib/RingTheory/Artinian/Algebra.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2025 Michal Staromiejski. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michal Staromiejski
+-/
+import Mathlib.RingTheory.Artinian.Ring
+import Mathlib.RingTheory.IntegralClosure.Algebra.Defs
+import Mathlib.RingTheory.IntegralClosure.IsIntegral.Basic
+
+/-!
+# Algebras over artinian rings
+
+In this file we collect results about algebras over artinian rings.
+-/
+
+namespace IsArtinianRing
+
+variable {R A : Type*}
+variable [CommRing R] [IsArtinianRing R] [CommRing A] [Algebra R A]
+
+open nonZeroDivisors
+
+/-- In an `R`-algebra over an artinian ring `R`, if an element is integral and
+is not a zero divisor, then it is a unit. -/
+theorem isUnit_of_isIntegral_of_nonZeroDivisor {a : A}
+    (hi : IsIntegral R a) (ha : a ∈ A⁰) : IsUnit a :=
+  let B := Algebra.adjoin R {a}
+  let b : B := ⟨a, Algebra.self_mem_adjoin_singleton R a⟩
+  haveI : Module.Finite R B := Algebra.finite_adjoin_simple_of_isIntegral hi
+  haveI : IsArtinianRing B := isArtinian_of_tower R inferInstance
+  have hinj : Function.Injective (B.subtype) := Subtype.val_injective
+  have hb : b ∈ B⁰ := comap_nonZeroDivisor_le_of_injective hinj ha
+  (isUnit_of_mem_nonZeroDivisors hb).map B.subtype
+
+/-- Integral element of an algebra over artinian ring `R` is either a zero divisor or a unit. -/
+theorem isUnit_iff_nonZeroDivisor_of_isIntegral {a : A}
+    (hi : IsIntegral R a) : IsUnit a ↔ a ∈ A⁰ :=
+  ⟨IsUnit.mem_nonZeroDivisors, isUnit_of_isIntegral_of_nonZeroDivisor hi⟩
+
+/-- In an `R`-algebra over an artinian ring `R`, if an element is integral and
+is not a zero divisor, then it is a unit. -/
+theorem isUnit_of_nonZeroDivisor_of_isIntegral' [Algebra.IsIntegral R A] {a : A}
+    (ha : a ∈ A⁰) : IsUnit a :=
+  isUnit_of_isIntegral_of_nonZeroDivisor (R := R) (Algebra.IsIntegral.isIntegral a) ha
+
+/-- Integral element of an algebra over artinian ring `R` is either a zero divisor or a unit. -/
+theorem isUnit_iff_nonZeroDivisor_of_isIntegral' [Algebra.IsIntegral R A] {a : A} :
+    IsUnit a ↔ a ∈ A⁰ :=
+  isUnit_iff_nonZeroDivisor_of_isIntegral (R := R) (Algebra.IsIntegral.isIntegral a)
+
+theorem isUnit_submonoid_eq_of_isIntegral [Algebra.IsIntegral R A] : IsUnit.submonoid A = A⁰ := by
+  ext; simpa [IsUnit.mem_submonoid_iff] using isUnit_iff_nonZeroDivisor_of_isIntegral' (R := R)
+
+end IsArtinianRing

--- a/Mathlib/RingTheory/Artinian/Ring.lean
+++ b/Mathlib/RingTheory/Artinian/Ring.lean
@@ -5,7 +5,6 @@ Authors: Chris Hughes, Junyan Xu, Jujian Zhang
 -/
 import Mathlib.Algebra.Field.Equiv
 import Mathlib.RingTheory.Artinian.Module
-import Mathlib.RingTheory.IntegralClosure.IsIntegral.Basic
 import Mathlib.RingTheory.Localization.Defs
 import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
 import Mathlib.RingTheory.Nakayama
@@ -109,23 +108,6 @@ theorem isUnit_iff_mem_nonZeroDivisors {a : R} : IsUnit a ↔ a ∈ R⁰ :=
 
 theorem isUnit_submonoid_eq : IsUnit.submonoid R = R⁰ := by
   ext; simp [IsUnit.mem_submonoid_iff, isUnit_iff_mem_nonZeroDivisors]
-
-/-- In an `R`-algebra over an artinian ring `R`, if an element is integral and
-is not a zero divisor, then it is a unit. -/
-theorem _root_.IsIntegral.isUnit_of_nonzerodivisor {A} [CommRing A] [Algebra R A] {a : A}
-    (hi : IsIntegral R a) (ha : a ∈ A⁰) : IsUnit a :=
-  let B := Algebra.adjoin R {a}
-  let b : B := ⟨a, Algebra.self_mem_adjoin_singleton R a⟩
-  haveI : Module.Finite R B := Algebra.finite_adjoin_simple_of_isIntegral hi
-  haveI : IsArtinianRing B := isArtinian_of_tower R inferInstance
-  have hinj : Function.Injective (B.subtype) := Subtype.val_injective
-  have hb : b ∈ B⁰ := comap_nonZeroDivisor_le_of_injective hinj ha
-  (isUnit_of_mem_nonZeroDivisors hb).map B.subtype
-
-/-- Integral element of an algebra over artinian ring `R` is either a zero divisor or a unit. -/
-theorem _root_.IsIntegral.isUnit_iff_nonzerodivisor {A} [CommRing A] [Algebra R A] {a : A}
-    (hi : IsIntegral R a) : IsUnit a ↔ a ∈ A⁰ :=
-  ⟨IsUnit.mem_nonZeroDivisors, IsIntegral.isUnit_of_nonzerodivisor hi⟩
 
 end IsUnit
 

--- a/Mathlib/RingTheory/Artinian/Ring.lean
+++ b/Mathlib/RingTheory/Artinian/Ring.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes, Junyan Xu, Jujian Zhang
 -/
 import Mathlib.Algebra.Field.Equiv
 import Mathlib.RingTheory.Artinian.Module
+import Mathlib.RingTheory.IntegralClosure.IsIntegral.Basic
 import Mathlib.RingTheory.Localization.Defs
 import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
 import Mathlib.RingTheory.Nakayama
@@ -108,6 +109,23 @@ theorem isUnit_iff_mem_nonZeroDivisors {a : R} : IsUnit a ↔ a ∈ R⁰ :=
 
 theorem isUnit_submonoid_eq : IsUnit.submonoid R = R⁰ := by
   ext; simp [IsUnit.mem_submonoid_iff, isUnit_iff_mem_nonZeroDivisors]
+
+/-- In an `R`-algebra over an artinian ring `R`, if an element is integral and
+is not a zero divisor, then it is a unit. -/
+theorem _root_.IsIntegral.isUnit_of_nonzerodivisor {A} [CommRing A] [Algebra R A] {a : A}
+    (hi : IsIntegral R a) (ha : a ∈ A⁰) : IsUnit a :=
+  let B := Algebra.adjoin R {a}
+  let b : B := ⟨a, Algebra.self_mem_adjoin_singleton R a⟩
+  haveI : Module.Finite R B := Algebra.finite_adjoin_simple_of_isIntegral hi
+  haveI : IsArtinianRing B := isArtinian_of_tower R inferInstance
+  have hinj : Function.Injective (B.subtype) := Subtype.val_injective
+  have hb : b ∈ B⁰ := comap_nonZeroDivisor_le_of_injective hinj ha
+  (isUnit_of_mem_nonZeroDivisors hb).map B.subtype
+
+/-- Integral element of an algebra over artinian ring `R` is either a zero divisor or a unit. -/
+theorem _root_.IsIntegral.isUnit_iff_nonzerodivisor {A} [CommRing A] [Algebra R A] {a : A}
+    (hi : IsIntegral R a) : IsUnit a ↔ a ∈ A⁰ :=
+  ⟨IsUnit.mem_nonZeroDivisors, IsIntegral.isUnit_of_nonzerodivisor hi⟩
 
 end IsUnit
 


### PR DESCRIPTION
In an algebra over an artinian ring, integral elements are either units or zero divisors.
As units are never zero divisors, the fact follows from implication that integral non-zero-divisors are units.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
