### PR TITLE
[Merged by Bors] - feat: `ext` lemmas for `stdBasisMatrix`

### DIFF
--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -15,7 +15,7 @@ at position `(i, j)`, and zeroes elsewhere.
 assert_not_exists Matrix.trace
 
 variable {l m n : Type*}
-variable {R α : Type*}
+variable {R α β : Type*}
 
 namespace Matrix
 
@@ -133,11 +133,10 @@ def stdBasisMatrixAddMonoidHom [AddCommMonoid α] (i : m) (j : n) : α →+ Matr
 
 variable (R)
 /-- `Matrix.stdBasisMatrix` as a bundled linear map. -/
-@[simps]
+@[simps!]
 def stdBasisMatrixLinearMap [Semiring R] [AddCommMonoid α] [Module R α] (i : m) (j : n) :
     α →ₗ[R] Matrix m n α where
-  toFun := stdBasisMatrix i j
-  map_add' _ _ := stdBasisMatrix_add _ _ _ _
+  __ := stdBasisMatrixAddMonoidHom i j
   map_smul' _ _:= smul_stdBasisMatrix _ _ _ _ |>.symm
 
 section ext
@@ -163,7 +162,8 @@ theorem ext_addMonoidHom
 See note [partially-applied ext lemmas]. -/
 @[local ext]
 theorem ext_linearMap
-    [Finite m] [Finite n][Semiring R] [AddCommMonoid α] [AddCommMonoid β] [Module R α] [Module R β] ⦃f g : Matrix m n α →ₗ[R] β⦄
+    [Finite m] [Finite n][Semiring R] [AddCommMonoid α] [AddCommMonoid β] [Module R α] [Module R β]
+    ⦃f g : Matrix m n α →ₗ[R] β⦄
     (h : ∀ i j, f ∘ₗ stdBasisMatrixLinearMap R i j = g ∘ₗ stdBasisMatrixLinearMap R i j) :
     f = g :=
   LinearMap.toAddMonoidHom_injective <| ext_addMonoidHom fun i j =>

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -124,6 +124,53 @@ protected theorem induction_on
       simpa using h_std_basis default default 0)
     h_add h_std_basis
 
+/-- `Matrix.stdBasisMatrix` as a bundled additive map. -/
+@[simps]
+def stdBasisMatrixAddMonoidHom [AddCommMonoid α] (i : m) (j : n) : α →+ Matrix m n α where
+  toFun := stdBasisMatrix i j
+  map_zero' := stdBasisMatrix_zero _ _
+  map_add' _ _ := stdBasisMatrix_add _ _ _ _
+
+variable (R)
+/-- `Matrix.stdBasisMatrix` as a bundled linear map. -/
+@[simps]
+def stdBasisMatrixLinearMap [Semiring R] [AddCommMonoid α] [Module R α] (i : m) (j : n) :
+    α →ₗ[R] Matrix m n α where
+  toFun := stdBasisMatrix i j
+  map_add' _ _ := stdBasisMatrix_add _ _ _ _
+  map_smul' _ _:= smul_stdBasisMatrix _ _ _ _ |>.symm
+
+section ext
+
+/-- Additive maps from finite matrices are equal if they agree on the standard basis.
+
+See note [partially-applied ext lemmas]. -/
+@[local ext]
+theorem ext_addMonoidHom
+    [Finite m] [Finite n] [AddCommMonoid α] [AddCommMonoid β] ⦃f g : Matrix m n α →+ β⦄
+    (h : ∀ i j, f.comp (stdBasisMatrixAddMonoidHom i j) = g.comp (stdBasisMatrixAddMonoidHom i j)) :
+    f = g := by
+  cases nonempty_fintype m
+  cases nonempty_fintype n
+  ext x
+  rw [matrix_eq_sum_stdBasisMatrix x]
+  simp_rw [map_sum]
+  congr! 2
+  exact DFunLike.congr_fun (h _ _) _
+
+/-- Linear maps from finite matrices are equal if they agree on the standard basis.
+
+See note [partially-applied ext lemmas]. -/
+@[local ext]
+theorem ext_linearMap
+    [Finite m] [Finite n][Semiring R] [AddCommMonoid α] [AddCommMonoid β] [Module R α] [Module R β] ⦃f g : Matrix m n α →ₗ[R] β⦄
+    (h : ∀ i j, f ∘ₗ stdBasisMatrixLinearMap R i j = g ∘ₗ stdBasisMatrixLinearMap R i j) :
+    f = g :=
+  LinearMap.toAddMonoidHom_injective <| ext_addMonoidHom fun i j =>
+    congrArg LinearMap.toAddMonoidHom <| h i j
+
+end ext
+
 namespace StdBasisMatrix
 
 section


### PR DESCRIPTION
Additive and linear maps from matrices agree if they agree on `stdBasisMatrix`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Motivated by #21148