### PR TITLE
[Merged by Bors] - chore: deprecate unused material about `List.mapIdx`

### DIFF
--- a/Mathlib/Data/List/Indexes.lean
+++ b/Mathlib/Data/List/Indexes.lean
@@ -9,6 +9,14 @@ import Mathlib.Data.List.Basic
 # Lemmas about List.*Idx functions.
 
 Some specification lemmas for `List.mapIdx`, `List.mapIdxM`, `List.foldlIdx` and `List.foldrIdx`.
+
+As of 2025-01-29, these are not used anywhere in Mathlib. Moreover, with
+`List.enum` and `List.enumFrom` being replaced by `List.zipIdx`
+in Lean's `nightly-2025-01-29` release, they now use deprecated functions and theorems.
+Rather than updating this unused material, we are deprecating it.
+Anyone wanting to restore this material is welcome to do so, but will need to update uses of
+`List.enum` and `List.enumFrom` to use `List.zipIdx` instead.
+However, note that this material will later be implemented in the Lean standard library.
 -/
 
 assert_not_exists MonoidWithZero
@@ -34,7 +42,7 @@ theorem mapIdx_append_one : ∀ {f : ℕ → α → β} {l : List α} {e : α},
     mapIdx f (l ++ [e]) = mapIdx f l ++ [f l.length e] :=
   mapIdx_concat
 
-@[local simp]
+@[deprecated "Deprecated without replacement." (since := "2025-01-29"), local simp]
 theorem map_enumFrom_eq_zipWith : ∀ (l : List α) (n : ℕ) (f : ℕ → α → β),
     map (uncurry f) (enumFrom n l) = zipWith (fun i ↦ f (i + n)) (range (length l)) l := by
   intro l
@@ -60,6 +68,7 @@ theorem map_enumFrom_eq_zipWith : ∀ (l : List α) (n : ℕ) (f : ℕ → α �
 
 @[deprecated (since := "2024-10-15")] alias mapIdx_eq_nil := mapIdx_eq_nil_iff
 
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem get_mapIdx (l : List α) (f : ℕ → α → β) (i : ℕ) (h : i < l.length)
     (h' : i < (l.mapIdx f).length := h.trans_le length_mapIdx.ge) :
     (l.mapIdx f).get ⟨i, h'⟩ = f i (l.get ⟨i, h⟩) := by
@@ -152,30 +161,41 @@ section FoldrIdx
 
 -- Porting note: Changed argument order of `foldrIdxSpec` to align better with `foldrIdx`.
 /-- Specification of `foldrIdx`. -/
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 def foldrIdxSpec (f : ℕ → α → β → β) (b : β) (as : List α) (start : ℕ) : β :=
   foldr (uncurry f) b <| enumFrom start as
 
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem foldrIdxSpec_cons (f : ℕ → α → β → β) (b a as start) :
     foldrIdxSpec f b (a :: as) start = f start a (foldrIdxSpec f b as (start + 1)) :=
   rfl
 
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem foldrIdx_eq_foldrIdxSpec (f : ℕ → α → β → β) (b as start) :
     foldrIdx f b as start = foldrIdxSpec f b as start := by
   induction as generalizing start
   · rfl
   · simp only [foldrIdx, foldrIdxSpec_cons, *]
 
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem foldrIdx_eq_foldr_enum (f : ℕ → α → β → β) (b : β) (as : List α) :
     foldrIdx f b as = foldr (uncurry f) b (enum as) := by
   simp only [foldrIdx, foldrIdxSpec, foldrIdx_eq_foldrIdxSpec, enum]
 
 end FoldrIdx
 
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem indexesValues_eq_filter_enum (p : α → Prop) [DecidablePred p] (as : List α) :
     indexesValues p as = filter (p ∘ Prod.snd) (enum as) := by
   simp (config := { unfoldPartialApp := true }) [indexesValues, foldrIdx_eq_foldr_enum, uncurry,
     filter_eq_foldr, cond_eq_if]
 
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem findIdxs_eq_map_indexesValues (p : α → Prop) [DecidablePred p] (as : List α) :
     findIdxs p as = map Prod.fst (indexesValues p as) := by
   simp (config := { unfoldPartialApp := true }) only [indexesValues_eq_filter_enum,
@@ -186,19 +206,26 @@ section FoldlIdx
 
 -- Porting note: Changed argument order of `foldlIdxSpec` to align better with `foldlIdx`.
 /-- Specification of `foldlIdx`. -/
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 def foldlIdxSpec (f : ℕ → α → β → α) (a : α) (bs : List β) (start : ℕ) : α :=
   foldl (fun a p ↦ f p.fst a p.snd) a <| enumFrom start bs
 
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem foldlIdxSpec_cons (f : ℕ → α → β → α) (a b bs start) :
     foldlIdxSpec f a (b :: bs) start = foldlIdxSpec f (f start a b) bs (start + 1) :=
   rfl
 
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem foldlIdx_eq_foldlIdxSpec (f : ℕ → α → β → α) (a bs start) :
     foldlIdx f a bs start = foldlIdxSpec f a bs start := by
   induction bs generalizing start a
   · rfl
   · simp [foldlIdxSpec, *]
 
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem foldlIdx_eq_foldl_enum (f : ℕ → α → β → α) (a : α) (bs : List β) :
     foldlIdx f a bs = foldl (fun a p ↦ f p.fst a p.snd) a (enum bs) := by
   simp only [foldlIdx, foldlIdxSpec, foldlIdx_eq_foldlIdxSpec, enum]
@@ -210,11 +237,15 @@ section FoldIdxM
 -- Porting note: `foldrM_eq_foldr` now depends on `[LawfulMonad m]`
 variable {m : Type u → Type v} [Monad m]
 
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem foldrIdxM_eq_foldrM_enum {β} (f : ℕ → α → β → m β) (b : β) (as : List α) [LawfulMonad m] :
     foldrIdxM f b as = foldrM (uncurry f) b (enum as) := by
   simp (config := { unfoldPartialApp := true }) only [foldrIdxM, foldrM_eq_foldr,
     foldrIdx_eq_foldr_enum, uncurry]
 
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem foldlIdxM_eq_foldlM_enum [LawfulMonad m] {β} (f : ℕ → β → α → m β) (b : β) (as : List α) :
     foldlIdxM f b as = List.foldlM (fun b p ↦ f p.fst b p.snd) b (enum as) := by
   rw [foldlIdxM, foldlM_eq_foldl, foldlIdx_eq_foldl_enum]
@@ -227,15 +258,20 @@ section MapIdxM
 variable {m : Type u → Type v} [Monad m]
 
 /-- Specification of `mapIdxMAux`. -/
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 def mapIdxMAuxSpec {β} (f : ℕ → α → m β) (start : ℕ) (as : List α) : m (List β) :=
   List.traverse (uncurry f) <| enumFrom start as
 
 -- Note: `traverse` the class method would require a less universe-polymorphic
 -- `m : Type u → Type u`.
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem mapIdxMAuxSpec_cons {β} (f : ℕ → α → m β) (start : ℕ) (a : α) (as : List α) :
     mapIdxMAuxSpec f start (a :: as) = cons <$> f start a <*> mapIdxMAuxSpec f (start + 1) as :=
   rfl
 
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem mapIdxMGo_eq_mapIdxMAuxSpec
     [LawfulMonad m] {β} (f : ℕ → α → m β) (arr : Array β) (as : List α) :
     mapIdxM.go f as arr = (arr.toList ++ ·) <$> mapIdxMAuxSpec f arr.size as := by
@@ -259,6 +295,8 @@ theorem mapIdxMGo_eq_mapIdxMAuxSpec
       simp only [Array.push_toList, append_assoc, singleton_append, Array.size_push,
         map_eq_pure_bind]
 
+set_option linter.deprecated false in
+@[deprecated "Deprecated without replacement." (since := "2025-01-29")]
 theorem mapIdxM_eq_mmap_enum [LawfulMonad m] {β} (f : ℕ → α → m β) (as : List α) :
     as.mapIdxM f = List.traverse (uncurry f) (enum as) := by
   simp only [mapIdxM, mapIdxMGo_eq_mapIdxMAuxSpec, Array.toList_toArray,


### PR DESCRIPTION
As of 2025-01-29, these specification lemmas for `List.mapIdx`, `List.mapIdxM`, `List.foldlIdx` and `List.foldrIdx` are not used anywhere in Mathlib. Moreover, with `List.enum` and `List.enumFrom` being replaced by `List.zipIdx` in Lean's `nightly-2025-01-29` release, they now use deprecated functions and theorems.

Rather than updating this unused material, we are deprecating it. Anyone wanting to restore this material is welcome to do so, but will need to update uses of `List.enum` and `List.enumFrom` to use `List.zipIdx` instead. However, note that this material will later be implemented in the Lean standard library.