### PR TITLE
[Merged by Bors] - feat(Topology/ContinuousMap/CompactlySupported): left-composition with a continuous map

### DIFF
--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -152,7 +152,7 @@ lemma coe_compLeft {g : C(β, γ)} (f : C_c(α, β)) (hg : g 0 = 0) : f.compLeft
   rw [if_pos hg]
   simp
 
-lemma compLeft_apply {g : C(β, γ)} (f : C_c(α, β)) (hg : g 0 = 0) (a : α) :
+lemma compLeft_apply {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) (a : α) :
     f.compLeft g a = g (f a) := by
   rw [coe_compLeft f hg]
   simp

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -141,6 +141,11 @@ noncomputable def compLeft {γ : Type*} [TopologicalSpace γ] [Zero γ] (g : C(�
       simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_zero]
       exact HasCompactSupport.zero
 
+lemma toContinuousMap_compLeft (hg : g 0 = 0) : (f.compLeft g).toContinuousMap = g.comp f := if_pos hg
+
+lemma coe_compLeft (hg : g 0 = 0) : f.compLeft g = g ∘ f := sorry
+
+lemma compLeft_apply (hg : g 0 = 0) (a : α) : f.compLeft g a = g (f a) := sorry
 end Basics
 
 /-! ### Algebraic structure

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -144,7 +144,7 @@ lemma toContinuousMap_compLeft {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) 
 lemma coe_compLeft {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) : f.compLeft g = g ∘ f := by
   simp [compLeft, if_pos hg]
 
-lemma compLeft_apply {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) (a : α) : 
+lemma compLeft_apply {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) (a : α) :
     f.compLeft g a = g (f a) := by simp [coe_compLeft hg f]
 
 end Basics

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -126,6 +126,7 @@ def ContinuousMap.liftCompactlySupported [CompactSpace α] : C(α, β) ≃ C_c(�
 
 /-- Composition of a continuous function `f` with compact support with another continuous function
 `g` from the left yields another continuous function `g ∘ f` with compact support. -/
+@[simps]
 def comp_left {γ : Type*} [TopologicalSpace γ] [Zero γ] {g : C(β, γ)} (f : C_c(α, β))
     (hg : g 0 = 0) : C_c(α, γ) where
   toContinuousMap := g.comp f

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -46,7 +46,7 @@ scoped[CompactlySupported] notation (priority := 2000)
 @[inherit_doc]
 scoped[CompactlySupported] notation α " →C_c " β => CompactlySupportedContinuousMap α β
 
-open CompactlySupported
+open CompactlySupported Classical
 
 section
 
@@ -126,11 +126,17 @@ def ContinuousMap.liftCompactlySupported [CompactSpace α] : C(α, β) ≃ C_c(�
 
 /-- Composition of a continuous function `f` with compact support with another continuous function
 `g` from the left yields another continuous function `g ∘ f` with compact support. -/
-@[simps]
-def comp_left {γ : Type*} [TopologicalSpace γ] [Zero γ] {g : C(β, γ)} (f : C_c(α, β))
-    (hg : g 0 = 0) : C_c(α, γ) where
-  toContinuousMap := g.comp f
-  hasCompactSupport' := f.hasCompactSupport'.comp_left hg
+noncomputable def comp_left {γ : Type*} [TopologicalSpace γ] [Zero γ] {g : C(β, γ)}
+    (f : C_c(α, β)) : C_c(α, γ) where
+  toContinuousMap := if g 0 = 0 then g.comp f else 0
+  hasCompactSupport' := by
+    by_cases hg : g 0 = 0
+    · rw [if_pos hg]
+      simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_comp, ContinuousMap.coe_coe]
+      exact HasCompactSupport.comp_left f.hasCompactSupport' hg
+    · rw [if_neg hg]
+      simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_zero]
+      exact HasCompactSupport.zero
 
 end Basics
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -125,6 +125,7 @@ def ContinuousMap.liftCompactlySupported [CompactSpace α] : C(α, β) ≃ C_c(�
   right_inv _ := rfl
 
 variable {γ : Type*} [TopologicalSpace γ] [Zero γ]
+
 /-- Composition of a continuous function `f` with compact support with another continuous function
 `g` sending `0` to `0` from the left yields another continuous function `g ∘ f` with compact
 support.

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -125,7 +125,9 @@ def ContinuousMap.liftCompactlySupported [CompactSpace α] : C(α, β) ≃ C_c(�
   right_inv _ := rfl
 
 /-- Composition of a continuous function `f` with compact support with another continuous function
-`g` from the left yields another continuous function `g ∘ f` with compact support. -/
+`g` sending `0` to `0` from the left yields another continuous function `g ∘ f` with compact support.
+
+ If `g` doesn't send `0` to `0`, `f.compLeft g` defaults to `0`. -/
 noncomputable def compLeft {γ : Type*} [TopologicalSpace γ] [Zero γ] (g : C(β, γ))
     (f : C_c(α, β)) : C_c(α, γ) where
   toContinuousMap := if g 0 = 0 then g.comp f else 0

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -146,7 +146,7 @@ noncomputable def compLeft (g : C(β, γ)) (f : C_c(α, β)) : C_c(α, γ) where
 lemma toContinuousMap_compLeft {g : C(β, γ)} (f : C_c(α, β)) (hg : g 0 = 0) :
     (f.compLeft g).toContinuousMap = g.comp f := if_pos hg
 
-lemma coe_compLeft {g : C(β, γ)} (f : C_c(α, β)) (hg : g 0 = 0) : f.compLeft g = g ∘ f := by
+lemma coe_compLeft {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) : f.compLeft g = g ∘ f := by
   rw [compLeft]
   simp only [coe_mk]
   rw [if_pos hg]

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -130,7 +130,7 @@ def ContinuousMap.liftCompactlySupported [CompactSpace α] : C(α, β) ≃ C_c(�
  If `g` doesn't send `0` to `0`, `f.compLeft g` defaults to `0`. -/
 noncomputable def compLeft {γ : Type*} [TopologicalSpace γ] [Zero γ] (g : C(β, γ))
     (f : C_c(α, β)) : C_c(α, γ) where
-  toContinuousMap := if g 0 = 0 then g.comp f else 0
+  toContinuousMap := by classical exact if g 0 = 0 then g.comp f else 0
   hasCompactSupport' := by
     classical
     split hg

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -143,7 +143,7 @@ noncomputable def compLeft (g : C(β, γ)) (f : C_c(α, β)) : C_c(α, γ) where
       simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_zero]
       exact HasCompactSupport.zero
 
-lemma toContinuousMap_compLeft {g : C(β, γ)} (f : C_c(α, β)) (hg : g 0 = 0) :
+lemma toContinuousMap_compLeft {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) :
     (f.compLeft g).toContinuousMap = g.comp f := if_pos hg
 
 lemma coe_compLeft {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) : f.compLeft g = g ∘ f := by

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -135,12 +135,10 @@ noncomputable def compLeft (g : C(β, γ)) (f : C_c(α, β)) : C_c(α, γ) where
   toContinuousMap := by classical exact if g 0 = 0 then g.comp f else 0
   hasCompactSupport' := by
     classical
-    by_cases hg : g 0 = 0
-    · rw [if_pos hg]
-      simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_comp, ContinuousMap.coe_coe]
+    split_ifs with hg
+    · simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_comp, ContinuousMap.coe_coe]
       exact HasCompactSupport.comp_left f.hasCompactSupport' hg
-    · rw [if_neg hg]
-      simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_zero]
+    · simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_zero]
       exact HasCompactSupport.zero
 
 lemma toContinuousMap_compLeft {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) :
@@ -154,7 +152,7 @@ lemma coe_compLeft {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) : f.compLeft
 
 lemma compLeft_apply {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) (a : α) :
     f.compLeft g a = g (f a) := by
-  rw [coe_compLeft f hg]
+  rw [coe_compLeft hg f]
   simp
 
 end Basics

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -124,16 +124,17 @@ def ContinuousMap.liftCompactlySupported [CompactSpace α] : C(α, β) ≃ C_c(�
   left_inv _ := rfl
   right_inv _ := rfl
 
+variable {γ : Type*} [TopologicalSpace γ] [Zero γ]
 /-- Composition of a continuous function `f` with compact support with another continuous function
-`g` sending `0` to `0` from the left yields another continuous function `g ∘ f` with compact support.
+`g` sending `0` to `0` from the left yields another continuous function `g ∘ f` with compact
+support.
 
  If `g` doesn't send `0` to `0`, `f.compLeft g` defaults to `0`. -/
-noncomputable def compLeft {γ : Type*} [TopologicalSpace γ] [Zero γ] (g : C(β, γ))
-    (f : C_c(α, β)) : C_c(α, γ) where
+noncomputable def compLeft (g : C(β, γ)) (f : C_c(α, β)) : C_c(α, γ) where
   toContinuousMap := by classical exact if g 0 = 0 then g.comp f else 0
   hasCompactSupport' := by
     classical
-    split hg
+    by_cases hg : g 0 = 0
     · rw [if_pos hg]
       simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_comp, ContinuousMap.coe_coe]
       exact HasCompactSupport.comp_left f.hasCompactSupport' hg
@@ -141,11 +142,20 @@ noncomputable def compLeft {γ : Type*} [TopologicalSpace γ] [Zero γ] (g : C(�
       simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_zero]
       exact HasCompactSupport.zero
 
-lemma toContinuousMap_compLeft (hg : g 0 = 0) : (f.compLeft g).toContinuousMap = g.comp f := if_pos hg
+lemma toContinuousMap_compLeft {g : C(β, γ)} (f : C_c(α, β)) (hg : g 0 = 0) :
+    (f.compLeft g).toContinuousMap = g.comp f := if_pos hg
 
-lemma coe_compLeft (hg : g 0 = 0) : f.compLeft g = g ∘ f := sorry
+lemma coe_compLeft {g : C(β, γ)} (f : C_c(α, β)) (hg : g 0 = 0) : f.compLeft g = g ∘ f := by
+  rw [compLeft]
+  simp only [coe_mk]
+  rw [if_pos hg]
+  simp
 
-lemma compLeft_apply (hg : g 0 = 0) (a : α) : f.compLeft g a = g (f a) := sorry
+lemma compLeft_apply {g : C(β, γ)} (f : C_c(α, β)) (hg : g 0 = 0) (a : α) :
+    f.compLeft g a = g (f a) := by
+  rw [coe_compLeft f hg]
+  simp
+
 end Basics
 
 /-! ### Algebraic structure

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -134,26 +134,18 @@ If `g` doesn't send `0` to `0`, `f.compLeft g` defaults to `0`. -/
 noncomputable def compLeft (g : C(β, γ)) (f : C_c(α, β)) : C_c(α, γ) where
   toContinuousMap := by classical exact if g 0 = 0 then g.comp f else 0
   hasCompactSupport' := by
-    classical
     split_ifs with hg
-    · simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_comp, ContinuousMap.coe_coe]
-      exact HasCompactSupport.comp_left f.hasCompactSupport' hg
-    · simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_zero]
-      exact HasCompactSupport.zero
+    · exact f.hasCompactSupport'.comp_left hg
+    · exact .zero
 
 lemma toContinuousMap_compLeft {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) :
     (f.compLeft g).toContinuousMap = g.comp f := if_pos hg
 
 lemma coe_compLeft {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) : f.compLeft g = g ∘ f := by
-  rw [compLeft]
-  simp only [coe_mk]
-  rw [if_pos hg]
-  simp
+  simp [compLeft, if_pos hg]
 
-lemma compLeft_apply {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) (a : α) :
-    f.compLeft g a = g (f a) := by
-  rw [coe_compLeft hg f]
-  simp
+lemma compLeft_apply {g : C(β, γ)} (hg : g 0 = 0) (f : C_c(α, β)) (a : α) : 
+    f.compLeft g a = g (f a) := by simp [coe_compLeft hg f]
 
 end Basics
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -130,7 +130,8 @@ noncomputable def comp_left {γ : Type*} [TopologicalSpace γ] [Zero γ] {g : C(
     (f : C_c(α, β)) : C_c(α, γ) where
   toContinuousMap := if g 0 = 0 then g.comp f else 0
   hasCompactSupport' := by
-    by_cases hg : g 0 = 0
+    classical
+    split hg
     · rw [if_pos hg]
       simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_comp, ContinuousMap.coe_coe]
       exact HasCompactSupport.comp_left f.hasCompactSupport' hg

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -124,6 +124,15 @@ def ContinuousMap.liftCompactlySupported [CompactSpace α] : C(α, β) ≃ C_c(�
   left_inv _ := rfl
   right_inv _ := rfl
 
+/-- Composition of a continuous function `f` with compact support with another continuous function
+`g` from the left yields another continuous function `g ∘ f` with compact support. -/
+def comp_left {γ : Type*} [TopologicalSpace γ] [Zero γ] {g : C(β, γ)} (f : C_c(α, β))
+    (hg : g 0 = 0) : C_c(α, γ) where
+  toContinuousMap := g.comp f
+  hasCompactSupport' := by
+    simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_comp, ContinuousMap.coe_coe]
+    exact HasCompactSupport.comp_left f.hasCompactSupport' hg
+
 end Basics
 
 /-! ### Algebraic structure

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -130,7 +130,7 @@ variable {γ : Type*} [TopologicalSpace γ] [Zero γ]
 `g` sending `0` to `0` from the left yields another continuous function `g ∘ f` with compact
 support.
 
- If `g` doesn't send `0` to `0`, `f.compLeft g` defaults to `0`. -/
+If `g` doesn't send `0` to `0`, `f.compLeft g` defaults to `0`. -/
 noncomputable def compLeft (g : C(β, γ)) (f : C_c(α, β)) : C_c(α, γ) where
   toContinuousMap := by classical exact if g 0 = 0 then g.comp f else 0
   hasCompactSupport' := by

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -46,7 +46,7 @@ scoped[CompactlySupported] notation (priority := 2000)
 @[inherit_doc]
 scoped[CompactlySupported] notation α " →C_c " β => CompactlySupportedContinuousMap α β
 
-open CompactlySupported Classical
+open CompactlySupported
 
 section
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -130,9 +130,7 @@ def ContinuousMap.liftCompactlySupported [CompactSpace α] : C(α, β) ≃ C_c(�
 def comp_left {γ : Type*} [TopologicalSpace γ] [Zero γ] {g : C(β, γ)} (f : C_c(α, β))
     (hg : g 0 = 0) : C_c(α, γ) where
   toContinuousMap := g.comp f
-  hasCompactSupport' := by
-    simp only [ContinuousMap.toFun_eq_coe, ContinuousMap.coe_comp, ContinuousMap.coe_coe]
-    exact HasCompactSupport.comp_left f.hasCompactSupport' hg
+  hasCompactSupport' := f.hasCompactSupport'.comp_left hg
 
 end Basics
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -126,7 +126,7 @@ def ContinuousMap.liftCompactlySupported [CompactSpace α] : C(α, β) ≃ C_c(�
 
 /-- Composition of a continuous function `f` with compact support with another continuous function
 `g` from the left yields another continuous function `g ∘ f` with compact support. -/
-noncomputable def comp_left {γ : Type*} [TopologicalSpace γ] [Zero γ] {g : C(β, γ)}
+noncomputable def compLeft {γ : Type*} [TopologicalSpace γ] [Zero γ] (g : C(β, γ))
     (f : C_c(α, β)) : C_c(α, γ) where
   toContinuousMap := if g 0 = 0 then g.comp f else 0
   hasCompactSupport' := by


### PR DESCRIPTION
Add `compLeft` which gives `g ∘ f : C_c(α, γ)` from `g : C(β, γ)`, `f : C_c(α, β))`.

---

Split from #20257