### PR TITLE
[Merged by Bors] - feat(Topology/ContinuousMap/CompactlySupported): add `partialOrder`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5250,6 +5250,7 @@ import Mathlib.Topology.Algebra.Order.Field
 import Mathlib.Topology.Algebra.Order.Floor
 import Mathlib.Topology.Algebra.Order.Group
 import Mathlib.Topology.Algebra.Order.LiminfLimsup
+import Mathlib.Topology.Algebra.Order.Support
 import Mathlib.Topology.Algebra.Order.UpperLower
 import Mathlib.Topology.Algebra.Polynomial
 import Mathlib.Topology.Algebra.PontryaginDual

--- a/Mathlib/Topology/Algebra/Order/Support.lean
+++ b/Mathlib/Topology/Algebra/Order/Support.lean
@@ -25,10 +25,10 @@ variable {X M : Type*} [TopologicalSpace X] [One M]
 
 section SemilatticeSup
 
-variable [SemilatticeSup β]
+variable [SemilatticeSup M]
 
 @[to_additive]
-theorem HasCompactMulSupport.sup {f g : α → β} (hf : HasCompactMulSupport f)
+theorem HasCompactMulSupport.sup {f g : X → M} (hf : HasCompactMulSupport f)
     (hg : HasCompactMulSupport g) :  HasCompactMulSupport (f ⊔ g) := by
   apply IsCompact.of_isClosed_subset (IsCompact.union hf hg) (isClosed_mulTSupport _)
   rw [mulTSupport, mulTSupport, mulTSupport, ← closure_union]
@@ -39,10 +39,10 @@ end SemilatticeSup
 
 section SemilatticeInf
 
-variable [SemilatticeInf β]
+variable [SemilatticeInf M]
 
 @[to_additive]
-theorem HasCompactMulSupport.inf {f g : α → β} (hf : HasCompactMulSupport f)
+theorem HasCompactMulSupport.inf {f g : X → M} (hf : HasCompactMulSupport f)
     (hg : HasCompactMulSupport g) :  HasCompactMulSupport (f ⊓ g) := by
   apply IsCompact.of_isClosed_subset (IsCompact.union hf hg) (isClosed_mulTSupport _)
   rw [mulTSupport, mulTSupport, mulTSupport, ← closure_union]

--- a/Mathlib/Topology/Algebra/Order/Support.lean
+++ b/Mathlib/Topology/Algebra/Order/Support.lean
@@ -9,16 +9,10 @@ import Mathlib.Topology.Algebra.Support
 /-!
 # The topological support of sup and inf of functions
 
-In a topological space `α` and a space `β` with `Sup` structure, for `f g : α → β` with compact
+In a topological space `X` and a space `M` with `Sup` structure, for `f g : X → M` with compact
 support, we show that `f ⊔ g` has compact support. Similarly, in `β` with `Inf` structure, `f ⊓ g`
 has compact support if so do `f` and `g`.
 
-## Implementation Notes
-
-* We write all lemmas for multiplicative functions, and use `@[to_additive]` to get the more common
-  additive versions.
-* We do not put the definitions in the `Function` namespace, following many other topological
-  definitions that are in the root namespace (compare `Embedding` vs `Function.Embedding`).
 -/
 
 variable {X M : Type*} [TopologicalSpace X] [One M]

--- a/Mathlib/Topology/Algebra/Order/Support.lean
+++ b/Mathlib/Topology/Algebra/Order/Support.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2025 Yoh Tanimoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yoh Tanimoto
+-/
+import Mathlib.Algebra.Order.Group.Indicator
+import Mathlib.Topology.Algebra.Support
+
+/-!
+# The topological support of sup and inf of functions
+
+In a topological space `α` and a space `β` with `Sup` structure, for `f g : α → β` with compact
+support, we show that `f ⊔ g` has compact support. Similarly, in `β` with `Inf` structure, `f ⊓ g`
+has compact support if so do `f` and `g`.
+
+## Implementation Notes
+
+* We write all lemmas for multiplicative functions, and use `@[to_additive]` to get the more common
+  additive versions.
+* We do not put the definitions in the `Function` namespace, following many other topological
+  definitions that are in the root namespace (compare `Embedding` vs `Function.Embedding`).
+-/
+
+variable {α β : Type*} [TopologicalSpace α] [One β]
+
+section SemilatticeSup
+
+variable [SemilatticeSup β]
+
+@[to_additive]
+theorem HasCompactMulSupport.sup {f g : α → β} (hf : HasCompactMulSupport f)
+    (hg : HasCompactMulSupport g) :  HasCompactMulSupport (f ⊔ g) := by
+  apply IsCompact.of_isClosed_subset (IsCompact.union hf hg) (isClosed_mulTSupport _)
+  rw [mulTSupport, mulTSupport, mulTSupport, ← closure_union]
+  apply closure_mono
+  exact Function.mulSupport_sup f g
+
+end SemilatticeSup
+
+section SemilatticeInf
+
+variable [SemilatticeInf β]
+
+@[to_additive]
+theorem HasCompactMulSupport.inf {f g : α → β} (hf : HasCompactMulSupport f)
+    (hg : HasCompactMulSupport g) :  HasCompactMulSupport (f ⊓ g) := by
+  apply IsCompact.of_isClosed_subset (IsCompact.union hf hg) (isClosed_mulTSupport _)
+  rw [mulTSupport, mulTSupport, mulTSupport, ← closure_union]
+  apply closure_mono
+  exact Function.mulSupport_inf f g
+
+end SemilatticeInf

--- a/Mathlib/Topology/Algebra/Order/Support.lean
+++ b/Mathlib/Topology/Algebra/Order/Support.lean
@@ -21,7 +21,7 @@ has compact support if so do `f` and `g`.
   definitions that are in the root namespace (compare `Embedding` vs `Function.Embedding`).
 -/
 
-variable {α β : Type*} [TopologicalSpace α] [One β]
+variable {X M : Type*} [TopologicalSpace X] [One M]
 
 section SemilatticeSup
 

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -5,8 +5,10 @@ Authors: Floris van Doorn, Patrick Massot
 -/
 import Mathlib.Algebra.GroupWithZero.Indicator
 import Mathlib.Algebra.Order.Group.Unbundled.Abs
+import Mathlib.Algebra.Order.Group.Indicator
 import Mathlib.Algebra.Module.Basic
 import Mathlib.Topology.Separation.Hausdorff
+import Mathlib.Topology.Order.Lattice
 
 /-!
 # The topological support of a function
@@ -369,6 +371,36 @@ protected theorem HasCompactSupport.abs {f : α → β} (hf : HasCompactSupport 
   hf.comp_left (g := abs) abs_zero
 
 end OrderedAddGroup
+
+section SemiLatticeSup
+
+variable [TopologicalSpace α] [SemilatticeSup β] [Zero β]
+
+variable {f g : α → β}
+
+theorem HasCompactSupport.sup (hf : HasCompactSupport f) (hg : HasCompactSupport g) :
+    HasCompactSupport (f ⊔ g) := by
+  apply IsCompact.of_isClosed_subset (IsCompact.union hf hg) (isClosed_tsupport _)
+  rw [tsupport, tsupport, tsupport, ← closure_union]
+  apply closure_mono
+  exact Function.support_sup f g
+
+end SemiLatticeSup
+
+section SemiLatticeSup
+
+variable [TopologicalSpace α] [SemilatticeInf β] [Zero β]
+
+variable {f g : α → β}
+
+theorem HasCompactSupport.inf (hf : HasCompactSupport f) (hg : HasCompactSupport g) :
+    HasCompactSupport (f ⊓ g) := by
+  apply IsCompact.of_isClosed_subset (IsCompact.union hf hg) (isClosed_tsupport _)
+  rw [tsupport, tsupport, tsupport, ← closure_union]
+  apply closure_mono
+  exact Function.support_inf f g
+
+end SemiLatticeSup
 
 end CompactSupport2
 

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -5,10 +5,8 @@ Authors: Floris van Doorn, Patrick Massot
 -/
 import Mathlib.Algebra.GroupWithZero.Indicator
 import Mathlib.Algebra.Order.Group.Unbundled.Abs
-import Mathlib.Algebra.Order.Group.Indicator
 import Mathlib.Algebra.Module.Basic
 import Mathlib.Topology.Separation.Hausdorff
-import Mathlib.Topology.Order.Lattice
 
 /-!
 # The topological support of a function
@@ -371,36 +369,6 @@ protected theorem HasCompactSupport.abs {f : α → β} (hf : HasCompactSupport 
   hf.comp_left (g := abs) abs_zero
 
 end OrderedAddGroup
-
-section SemiLatticeSup
-
-variable [TopologicalSpace α] [SemilatticeSup β] [Zero β]
-
-variable {f g : α → β}
-
-theorem HasCompactSupport.sup (hf : HasCompactSupport f) (hg : HasCompactSupport g) :
-    HasCompactSupport (f ⊔ g) := by
-  apply IsCompact.of_isClosed_subset (IsCompact.union hf hg) (isClosed_tsupport _)
-  rw [tsupport, tsupport, tsupport, ← closure_union]
-  apply closure_mono
-  exact Function.support_sup f g
-
-end SemiLatticeSup
-
-section SemiLatticeSup
-
-variable [TopologicalSpace α] [SemilatticeInf β] [Zero β]
-
-variable {f g : α → β}
-
-theorem HasCompactSupport.inf (hf : HasCompactSupport f) (hg : HasCompactSupport g) :
-    HasCompactSupport (f ⊓ g) := by
-  apply IsCompact.of_isClosed_subset (IsCompact.union hf hg) (isClosed_tsupport _)
-  rw [tsupport, tsupport, tsupport, ← closure_union]
-  apply closure_mono
-  exact Function.support_inf f g
-
-end SemiLatticeSup
 
 end CompactSupport2
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -3,8 +3,7 @@ Copyright (c) 2024 Yoh Tanimoto. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yoh Tanimoto
 -/
-import Mathlib.Topology.Algebra.Support
-import Mathlib.Topology.ContinuousMap.CocompactMap
+import Mathlib.Algebra.Order.Group.Indicator
 import Mathlib.Topology.ContinuousMap.ZeroAtInfty
 
 /-!
@@ -417,7 +416,16 @@ end PartialOrder
 
 section SemilatticeSup
 
-variable [SemilatticeSup β] [TopologicalSpace β] [ContinuousSup β] [Zero β]
+variable [SemilatticeSup β] [Zero β]
+
+theorem HasCompactSupport.sup {f g : α → β} (hf : HasCompactSupport f) (hg : HasCompactSupport g) :
+    HasCompactSupport (f ⊔ g) := by
+  apply IsCompact.of_isClosed_subset (IsCompact.union hf hg) (isClosed_tsupport _)
+  rw [tsupport, tsupport, tsupport, ← closure_union]
+  apply closure_mono
+  exact Function.support_sup f g
+
+variable [TopologicalSpace β] [ContinuousSup β]
 
 instance sup : Max C_c(α, β) where max f g :=
   { toFun := fun a ↦ f a ⊔ g a
@@ -442,7 +450,16 @@ end SemilatticeSup
 
 section SemilatticeInf
 
-variable [SemilatticeInf β] [TopologicalSpace β] [ContinuousInf β] [Zero β]
+variable [SemilatticeInf β] [Zero β]
+
+theorem HasCompactSupport.inf {f g : α → β} (hf : HasCompactSupport f) (hg : HasCompactSupport g) :
+    HasCompactSupport (f ⊓ g) := by
+  apply IsCompact.of_isClosed_subset (IsCompact.union hf hg) (isClosed_tsupport _)
+  rw [tsupport, tsupport, tsupport, ← closure_union]
+  apply closure_mono
+  exact Function.support_inf f g
+
+variable [TopologicalSpace β] [ContinuousInf β]
 
 instance inf : Min C_c(α, β) where min f g :=
   { toFun := fun a ↦ f a ⊓ g a
@@ -621,3 +638,5 @@ lemma nnrealPart_apply (f : C_c(α, ℝ)) (x : α) :
 end CompactlySupportedContinuousMap
 
 end NonnegativePart
+
+#min_imports

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -428,8 +428,8 @@ theorem HasCompactSupport.sup {f g : α → β} (hf : HasCompactSupport f) (hg :
 variable [TopologicalSpace β] [ContinuousSup β]
 
 instance sup : Max C_c(α, β) where max f g :=
-  { toFun := fun a ↦ f a ⊔ g a
-    hasCompactSupport' := HasCompactSupport.sup f.hasCompactSupport g.hasCompactSupport}
+  { toFun := f ⊔ g
+    hasCompactSupport' := f.hasCompactSupport.sup g.hasCompactSupport }
 
 @[simp, norm_cast] lemma coe_sup (f g : C_c(α, β)) : ⇑(f ⊔ g) = ⇑f ⊔ g := rfl
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -399,6 +399,25 @@ instance : StarRing C_c(α, β) :=
 
 end StarRing
 
+section PartialOrder
+
+/-! ### The partial order in `C_c`
+When `β` is equipped with a partial order, `C_c(α, β)` is given the pointwise partial order.
+-/
+
+variable {β : Type*} [TopologicalSpace β] [Zero β]
+
+instance partialOrder [PartialOrder β] : PartialOrder C_c(α, β) :=
+  PartialOrder.lift (fun f => f.toFun) (fun f g _ => by aesop)
+
+theorem le_def [PartialOrder β] {f g : C_c(α, β)} : f ≤ g ↔ ∀ a, f a ≤ g a :=
+  Pi.le_def
+
+theorem lt_def [PartialOrder β] {f g : C_c(α, β)} : f < g ↔ (∀ a, f a ≤ g a) ∧ ∃ a, f a < g a :=
+  Pi.lt_def
+
+end PartialOrder
+
 /-! ### `C_c` as a functor
 
 For each `β` with sufficient structure, there is a contravariant functor `C_c(-, β)` from the

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -429,7 +429,8 @@ variable [TopologicalSpace β] [ContinuousSup β]
 
 instance sup : Max C_c(α, β) where max f g :=
   { toFun := f ⊔ g
-    hasCompactSupport' := f.hasCompactSupport.sup g.hasCompactSupport }
+    continuous_toFun := Continuous.sup f.continuous g.continuous
+    hasCompactSupport' := HasCompactSupport.sup f.hasCompactSupport g.hasCompactSupport }
 
 @[simp, norm_cast] lemma coe_sup (f g : C_c(α, β)) : ⇑(f ⊔ g) = ⇑f ⊔ g := rfl
 
@@ -438,13 +439,13 @@ instance sup : Max C_c(α, β) where max f g :=
 instance semilatticeSup : SemilatticeSup C_c(α, β) :=
   DFunLike.coe_injective.semilatticeSup _ coe_sup
 
-lemma sup'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) (a : α) :
+lemma finsetSup'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) (a : α) :
     s.sup' H f a = s.sup' H fun i ↦ f i a :=
   Finset.comp_sup'_eq_sup'_comp H (fun g : C_c(α, β) ↦ g a) fun _ _ ↦ rfl
 
 @[simp, norm_cast]
 lemma coe_sup' {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) :
-    ⇑(s.sup' H f) = s.sup' H fun i ↦ ⇑(f i) := by ext; simp [sup'_apply]
+    ⇑(s.sup' H f) = s.sup' H fun i ↦ ⇑(f i) := by ext; simp [finsetSup'_apply]
 
 end SemilatticeSup
 
@@ -463,7 +464,8 @@ variable [TopologicalSpace β] [ContinuousInf β]
 
 instance inf : Min C_c(α, β) where min f g :=
   { toFun := f ⊓ g
-    hasCompactSupport' := f.hasCompactSupport.inf g.hasCompactSupport }
+    continuous_toFun := Continuous.inf f.continuous g.continuous
+    hasCompactSupport' := HasCompactSupport.inf f.hasCompactSupport g.hasCompactSupport }
 
 @[simp, norm_cast] lemma coe_inf (f g : C_c(α, β)) : ⇑(f ⊓ g) = ⇑f ⊓ g := rfl
 
@@ -478,7 +480,7 @@ lemma finsetInf'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι →
 
 @[simp, norm_cast]
 lemma coe_inf' {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) :
-    ⇑(s.inf' H f) = s.inf' H fun i ↦ ⇑(f i) := by ext; simp [inf'_apply]
+    ⇑(s.inf' H f) = s.inf' H fun i ↦ ⇑(f i) := by ext; simp [finsetInf'_apply]
 
 end SemilatticeInf
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -408,7 +408,7 @@ When `β` is equipped with a partial order, `C_c(α, β)` is given the pointwise
 variable {β : Type*} [TopologicalSpace β] [Zero β]
 
 instance partialOrder [PartialOrder β] : PartialOrder C_c(α, β) :=
-  PartialOrder.lift (fun f => f.toFun) (fun f g _ => by aesop)
+  PartialOrder.lift (⇑) DFunLike.coe_injective
 
 theorem le_def [PartialOrder β] {f g : C_c(α, β)} : f ≤ g ↔ ∀ a, f a ≤ g a :=
   Pi.le_def

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -3,8 +3,8 @@ Copyright (c) 2024 Yoh Tanimoto. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yoh Tanimoto
 -/
-import Mathlib.Algebra.Order.Group.Indicator
 import Mathlib.Topology.ContinuousMap.ZeroAtInfty
+import Mathlib.Topology.Algebra.Order.Support
 
 /-!
 # Compactly supported continuous functions
@@ -416,21 +416,12 @@ end PartialOrder
 
 section SemilatticeSup
 
-variable [SemilatticeSup β] [Zero β]
-
-theorem HasCompactSupport.sup {f g : α → β} (hf : HasCompactSupport f) (hg : HasCompactSupport g) :
-    HasCompactSupport (f ⊔ g) := by
-  apply IsCompact.of_isClosed_subset (IsCompact.union hf hg) (isClosed_tsupport _)
-  rw [tsupport, tsupport, tsupport, ← closure_union]
-  apply closure_mono
-  exact Function.support_sup f g
-
-variable [TopologicalSpace β] [ContinuousSup β]
+variable [SemilatticeSup β] [Zero β] [TopologicalSpace β] [ContinuousSup β]
 
 instance instSup : Max C_c(α, β) where max f g :=
   { toFun := f ⊔ g
     continuous_toFun := Continuous.sup f.continuous g.continuous
-    hasCompactSupport' := HasCompactSupport.sup f.hasCompactSupport g.hasCompactSupport }
+    hasCompactSupport' := f.hasCompactSupport.sup g.hasCompactSupport }
 
 @[simp, norm_cast] lemma coe_sup (f g : C_c(α, β)) : ⇑(f ⊔ g) = ⇑f ⊔ g := rfl
 
@@ -451,21 +442,12 @@ end SemilatticeSup
 
 section SemilatticeInf
 
-variable [SemilatticeInf β] [Zero β]
-
-theorem HasCompactSupport.inf {f g : α → β} (hf : HasCompactSupport f) (hg : HasCompactSupport g) :
-    HasCompactSupport (f ⊓ g) := by
-  apply IsCompact.of_isClosed_subset (IsCompact.union hf hg) (isClosed_tsupport _)
-  rw [tsupport, tsupport, tsupport, ← closure_union]
-  apply closure_mono
-  exact Function.support_inf f g
-
-variable [TopologicalSpace β] [ContinuousInf β]
+variable [SemilatticeInf β] [Zero β] [TopologicalSpace β] [ContinuousInf β]
 
 instance instInf : Min C_c(α, β) where min f g :=
   { toFun := f ⊓ g
     continuous_toFun := Continuous.inf f.continuous g.continuous
-    hasCompactSupport' := HasCompactSupport.inf f.hasCompactSupport g.hasCompactSupport }
+    hasCompactSupport' := f.hasCompactSupport.inf g.hasCompactSupport }
 
 @[simp, norm_cast] lemma coe_inf (f g : C_c(α, β)) : ⇑(f ⊓ g) = ⇑f ⊓ g := rfl
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -427,7 +427,7 @@ theorem HasCompactSupport.sup {f g : α → β} (hf : HasCompactSupport f) (hg :
 
 variable [TopologicalSpace β] [ContinuousSup β]
 
-instance sup : Max C_c(α, β) where max f g :=
+instance instSup : Max C_c(α, β) where max f g :=
   { toFun := f ⊔ g
     continuous_toFun := Continuous.sup f.continuous g.continuous
     hasCompactSupport' := HasCompactSupport.sup f.hasCompactSupport g.hasCompactSupport }

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -444,7 +444,7 @@ lemma finsetSup'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι →
   Finset.comp_sup'_eq_sup'_comp H (fun g : C_c(α, β) ↦ g a) fun _ _ ↦ rfl
 
 @[simp, norm_cast]
-lemma coe_sup' {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) :
+lemma coe_finsetSup' {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) :
     ⇑(s.sup' H f) = s.sup' H fun i ↦ ⇑(f i) := by ext; simp [finsetSup'_apply]
 
 end SemilatticeSup

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -638,5 +638,3 @@ lemma nnrealPart_apply (f : C_c(α, ℝ)) (x : α) :
 end CompactlySupportedContinuousMap
 
 end NonnegativePart
-
-#min_imports

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -486,7 +486,7 @@ section Lattice
 
 instance [Lattice β] [TopologicalSpace β] [TopologicalLattice β] [Zero β] :
     Lattice C_c(α, β) :=
-  DFunLike.coe_injective.lattice _ (fun _ _ ↦ rfl) fun _ _ ↦ rfl
+  DFunLike.coe_injective.lattice _ coe_sup coe_inf
 
 -- TODO transfer this lattice structure to `BoundedContinuousFunction`
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -462,7 +462,7 @@ theorem HasCompactSupport.inf {f g : α → β} (hf : HasCompactSupport f) (hg :
 
 variable [TopologicalSpace β] [ContinuousInf β]
 
-instance inf : Min C_c(α, β) where min f g :=
+instance instInf : Min C_c(α, β) where min f g :=
   { toFun := f ⊓ g
     continuous_toFun := Continuous.inf f.continuous g.continuous
     hasCompactSupport' := HasCompactSupport.inf f.hasCompactSupport g.hasCompactSupport }

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -462,9 +462,8 @@ theorem HasCompactSupport.inf {f g : α → β} (hf : HasCompactSupport f) (hg :
 variable [TopologicalSpace β] [ContinuousInf β]
 
 instance inf : Min C_c(α, β) where min f g :=
-  { toFun := fun a ↦ f a ⊓ g a
-    hasCompactSupport' := HasCompactSupport.inf f.hasCompactSupport g.hasCompactSupport}
-
+  { toFun := f ⊓ g
+    hasCompactSupport' := f.hasCompactSupport.inf g.hasCompactSupport }
 
 @[simp, norm_cast] lemma coe_inf (f g : C_c(α, β)) : ⇑(f ⊓ g) = ⇑f ⊓ g := rfl
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -470,7 +470,7 @@ instance inf : Min C_c(α, β) where min f g :=
 @[simp] lemma inf_apply (f g : C_c(α, β)) (a : α) : (f ⊓ g) a = f a ⊓ g a := rfl
 
 instance semilatticeInf : SemilatticeInf C_c(α, β) :=
-  DFunLike.coe_injective.semilatticeInf _ fun _ _ ↦ rfl
+  DFunLike.coe_injective.semilatticeInf _ coe_inf
 
 lemma inf'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) (a : α) :
     s.inf' H f a = s.inf' H fun i ↦ f i a :=

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -472,7 +472,7 @@ instance inf : Min C_c(α, β) where min f g :=
 instance semilatticeInf : SemilatticeInf C_c(α, β) :=
   DFunLike.coe_injective.semilatticeInf _ coe_inf
 
-lemma inf'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) (a : α) :
+lemma finsetInf'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) (a : α) :
     s.inf' H f a = s.inf' H fun i ↦ f i a :=
   Finset.comp_inf'_eq_inf'_comp H (fun g : C_c(α, β) ↦ g a) fun _ _ ↦ rfl
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -3,8 +3,8 @@ Copyright (c) 2024 Yoh Tanimoto. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yoh Tanimoto
 -/
-import Mathlib.Topology.ContinuousMap.ZeroAtInfty
 import Mathlib.Topology.Algebra.Order.Support
+import Mathlib.Topology.ContinuousMap.ZeroAtInfty
 
 /-!
 # Compactly supported continuous functions

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -407,16 +407,74 @@ When `β` is equipped with a partial order, `C_c(α, β)` is given the pointwise
 
 variable {β : Type*} [TopologicalSpace β] [Zero β] [PartialOrder β]
 
-instance partialOrder [PartialOrder β] : PartialOrder C_c(α, β) :=
-  PartialOrder.lift (⇑) DFunLike.coe_injective
+instance partialOrder : PartialOrder C_c(α, β) := PartialOrder.lift (⇑) DFunLike.coe_injective
 
-theorem le_def [PartialOrder β] {f g : C_c(α, β)} : f ≤ g ↔ ∀ a, f a ≤ g a :=
-  Pi.le_def
+theorem le_def {f g : C_c(α, β)} : f ≤ g ↔ ∀ a, f a ≤ g a := Pi.le_def
 
-theorem lt_def [PartialOrder β] {f g : C_c(α, β)} : f < g ↔ (∀ a, f a ≤ g a) ∧ ∃ a, f a < g a :=
-  Pi.lt_def
+theorem lt_def {f g : C_c(α, β)} : f < g ↔ (∀ a, f a ≤ g a) ∧ ∃ a, f a < g a := Pi.lt_def
 
 end PartialOrder
+
+section SemilatticeSup
+
+variable [SemilatticeSup β] [TopologicalSpace β] [ContinuousSup β] [Zero β]
+
+instance sup : Max C_c(α, β) where max f g :=
+  { toFun := fun a ↦ f a ⊔ g a
+    hasCompactSupport' := HasCompactSupport.sup f.hasCompactSupport g.hasCompactSupport}
+
+@[simp, norm_cast] lemma coe_sup (f g : C_c(α, β)) : ⇑(f ⊔ g) = ⇑f ⊔ g := rfl
+
+@[simp] lemma sup_apply (f g : C_c(α, β)) (a : α) : (f ⊔ g) a = f a ⊔ g a := rfl
+
+instance semilatticeSup : SemilatticeSup C_c(α, β) :=
+  DFunLike.coe_injective.semilatticeSup _ fun _ _ ↦ rfl
+
+lemma sup'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) (a : α) :
+    s.sup' H f a = s.sup' H fun i ↦ f i a :=
+  Finset.comp_sup'_eq_sup'_comp H (fun g : C_c(α, β) ↦ g a) fun _ _ ↦ rfl
+
+@[simp, norm_cast]
+lemma coe_sup' {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) :
+    ⇑(s.sup' H f) = s.sup' H fun i ↦ ⇑(f i) := by ext; simp [sup'_apply]
+
+end SemilatticeSup
+
+section SemilatticeInf
+
+variable [SemilatticeInf β] [TopologicalSpace β] [ContinuousInf β] [Zero β]
+
+instance inf : Min C_c(α, β) where min f g :=
+  { toFun := fun a ↦ f a ⊓ g a
+    hasCompactSupport' := HasCompactSupport.inf f.hasCompactSupport g.hasCompactSupport}
+
+
+@[simp, norm_cast] lemma coe_inf (f g : C_c(α, β)) : ⇑(f ⊓ g) = ⇑f ⊓ g := rfl
+
+@[simp] lemma inf_apply (f g : C_c(α, β)) (a : α) : (f ⊓ g) a = f a ⊓ g a := rfl
+
+instance semilatticeInf : SemilatticeInf C_c(α, β) :=
+  DFunLike.coe_injective.semilatticeInf _ fun _ _ ↦ rfl
+
+lemma inf'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) (a : α) :
+    s.inf' H f a = s.inf' H fun i ↦ f i a :=
+  Finset.comp_inf'_eq_inf'_comp H (fun g : C_c(α, β) ↦ g a) fun _ _ ↦ rfl
+
+@[simp, norm_cast]
+lemma coe_inf' {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) :
+    ⇑(s.inf' H f) = s.inf' H fun i ↦ ⇑(f i) := by ext; simp [inf'_apply]
+
+end SemilatticeInf
+
+section Lattice
+
+instance [Lattice β] [TopologicalSpace β] [TopologicalLattice β] [Zero β] :
+    Lattice C_c(α, β) :=
+  DFunLike.coe_injective.lattice _ (fun _ _ ↦ rfl) fun _ _ ↦ rfl
+
+-- TODO transfer this lattice structure to `BoundedContinuousFunction`
+
+end Lattice
 
 /-! ### `C_c` as a functor
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -405,7 +405,7 @@ section PartialOrder
 When `β` is equipped with a partial order, `C_c(α, β)` is given the pointwise partial order.
 -/
 
-variable {β : Type*} [TopologicalSpace β] [Zero β]
+variable {β : Type*} [TopologicalSpace β] [Zero β] [PartialOrder β]
 
 instance partialOrder [PartialOrder β] : PartialOrder C_c(α, β) :=
   PartialOrder.lift (⇑) DFunLike.coe_injective

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -479,7 +479,7 @@ lemma finsetInf'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι →
   Finset.comp_inf'_eq_inf'_comp H (fun g : C_c(α, β) ↦ g a) fun _ _ ↦ rfl
 
 @[simp, norm_cast]
-lemma coe_inf' {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) :
+lemma coe_finsetInf' {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) :
     ⇑(s.inf' H f) = s.inf' H fun i ↦ ⇑(f i) := by ext; simp [finsetInf'_apply]
 
 end SemilatticeInf

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -436,7 +436,7 @@ instance sup : Max C_c(α, β) where max f g :=
 @[simp] lemma sup_apply (f g : C_c(α, β)) (a : α) : (f ⊔ g) a = f a ⊔ g a := rfl
 
 instance semilatticeSup : SemilatticeSup C_c(α, β) :=
-  DFunLike.coe_injective.semilatticeSup _ fun _ _ ↦ rfl
+  DFunLike.coe_injective.semilatticeSup _ coe_sup
 
 lemma sup'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C_c(α, β)) (a : α) :
     s.sup' H f a = s.sup' H fun i ↦ f i a :=


### PR DESCRIPTION
Add `instance : PartialOrder C_c(α, β)` using pointwise `PartialOrder β`, following [ContinuousMap.partialOrder](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/ContinuousMap/Ordered.html#ContinuousMap.partialOrder)

---

Split from #20040