### PR TITLE
[Merged by Bors] - chore: remove some adaptation notes about unused variable linter

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Hom.lean
+++ b/Mathlib/Algebra/GroupWithZero/Hom.lean
@@ -40,13 +40,6 @@ open Function
 namespace NeZero
 variable {F α β : Type*} [Zero α] [Zero β] [FunLike F α β] [ZeroHomClass F α β] {a : α}
 
-#adaptation_note
-/--
-We name `neZero` so it can be used as a named argument,
-but since https://github.com/leanprover/lean4/pull/5338, this is considered unused,
-so we need to disable the linter.
--/
-set_option linter.unusedVariables false in
 lemma of_map (f : F) [neZero : NeZero (f a)] : NeZero a :=
   ⟨fun h ↦ ne (f a) <| by rw [h]; exact ZeroHomClass.map_zero f⟩
 

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -234,7 +234,6 @@ theorem rootMultiplicity_mul {p q : R[X]} {x : R} (hpq : p * q ≠ 0) :
     multiplicity_mul (prime_X_sub_C x) (finiteMultiplicity_X_sub_C _ hpq)]
 
 open Multiset in
-set_option linter.unusedVariables false in
 theorem exists_multiset_roots [DecidableEq R] :
     ∀ {p : R[X]} (_ : p ≠ 0), ∃ s : Multiset R,
       (Multiset.card s : WithBot ℕ) ≤ degree p ∧ ∀ a, s.count a = rootMultiplicity a p
@@ -245,11 +244,6 @@ theorem exists_multiset_roots [DecidableEq R] :
       have hpd : 0 < degree p := degree_pos_of_root hp hx
       have hd0 : p /ₘ (X - C x) ≠ 0 := fun h => by
         rw [← mul_divByMonic_eq_iff_isRoot.2 hx, h, mul_zero] at hp; exact hp rfl
-      #adaptation_note
-      /--
-      Since https://github.com/leanprover/lean4/pull/5338, this is considered unused,
-      because it is only used in the decreasing_by clause.
-      -/
       have wf : degree (p /ₘ (X - C x)) < degree p :=
         degree_divByMonic_lt _ (monic_X_sub_C x) hp ((degree_X_sub_C x).symm ▸ by decide)
       let ⟨t, htd, htr⟩ := @exists_multiset_roots _ (p /ₘ (X - C x)) hd0

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Boundary.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Boundary.lean
@@ -41,13 +41,6 @@ def boundary (n : ℕ) : SSet.{u} where
 /-- The boundary `∂Δ[n]` of the `n`-th standard simplex -/
 scoped[Simplicial] notation3 "∂Δ[" n "]" => SSet.boundary n
 
-#adaptation_note
-/--
-The new unused variable linter in
-https://github.com/leanprover/lean4/pull/5338
-flags `{ α : Δ[n].obj m // _ }`.
--/
-set_option linter.unusedVariables false in
 /-- The inclusion of the boundary of the `n`-th standard simplex into that standard simplex. -/
 def boundaryInclusion (n : ℕ) : ∂Δ[n] ⟶ Δ[n] where app m (α : { α : Δ[n].obj m // _ }) := α
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Horn.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Horn.lean
@@ -35,13 +35,6 @@ def horn (n : ℕ) (i : Fin (n + 1)) : SSet where
 /-- The `i`-th horn `Λ[n, i]` of the standard `n`-simplex -/
 scoped[Simplicial] notation3 "Λ[" n ", " i "]" => SSet.horn (n : ℕ) i
 
-#adaptation_note
-/--
-The new unused variable linter in
-https://github.com/leanprover/lean4/pull/5338
-flags `{ α : Δ[n].obj m // _ }`.
--/
-set_option linter.unusedVariables false in
 /-- The inclusion of the `i`-th horn of the `n`-th standard simplex into that standard simplex. -/
 def hornInclusion (n : ℕ) (i : Fin (n + 1)) : Λ[n, i] ⟶ Δ[n] where
   app m (α : { α : Δ[n].obj m // _ }) := α

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -1103,14 +1103,6 @@ theorem isRat_rpow_neg {a b : ℝ} {nb : ℕ}
     IsRat (a ^ b) num den := by
   rwa [pb.out, Real.rpow_intCast]
 
-#adaptation_note
-/--
-Since https://github.com/leanprover/lean4/pull/5338,
-the unused variable linter can not see usages of variables in
-`haveI' : ⋯ =Q ⋯ := ⟨⟩` clauses, so generates many false positives.
--/
-set_option linter.unusedVariables false
-
 /-- Evaluates expressions of the form `a ^ b` when `a` and `b` are both reals. -/
 @[norm_num (_ : ℝ) ^ (_ : ℝ)]
 def evalRPow : NormNumExt where eval {u α} e := do

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
@@ -122,13 +122,6 @@ variable [HasReflexiveCoequalizers A]
 noncomputable def constructLeftAdjointObj (Y : B) : A :=
   coequalizer (F'.map (U.map (adj₁.counit.app Y))) (otherMap _ _ adj₁ adj₂ Y)
 
-#adaptation_note
-/--
-The new unused variable linter in
-https://github.com/leanprover/lean4/pull/5338
-flags `{ z : F.obj (U.obj X) ⟶ R.obj Y // _ }`.
--/
-set_option linter.unusedVariables false in
 /-- The homset equivalence which helps show that `R` is a right adjoint. -/
 @[simps!]
 noncomputable def constructLeftAdjointEquiv [∀ X : B, RegularEpi (adj₁.counit.app X)] (Y : A)

--- a/Mathlib/CategoryTheory/Monad/Monadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Monadicity.lean
@@ -79,13 +79,6 @@ def comparisonLeftAdjointObj (A : adj.toMonad.Algebra)
     [HasCoequalizer (F.map A.a) (adj.counit.app _)] : D :=
   coequalizer (F.map A.a) (adj.counit.app _)
 
-#adaptation_note
-/--
-The new unused variable linter in
-https://github.com/leanprover/lean4/pull/5338
-flags `{ f : F.obj A.A ⟶ B // _ }`.
--/
-set_option linter.unusedVariables false in
 /--
 We have a bijection of homsets which will be used to construct the left adjoint to the comparison
 functor.

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -24,14 +24,6 @@ assert_not_exists OrderTop
 
 namespace Nat
 
-#adaptation_note
-/--
-After https://github.com/leanprover/lean4/pull/5338 we just unused argument warnings,
-but these are used in the decreasing by blocks.
-If instead we inline the `have` blocks, the unusedHavesSuffices linter triggers.
--/
-set_option linter.unusedVariables false
-
 /-! ### Floor logarithm -/
 
 

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -25,14 +25,6 @@ See other files in this directory for many more plugins.
 
 universe u
 
-#adaptation_note
-/--
-Since https://github.com/leanprover/lean4/pull/5338,
-the unused variable linter can not see usages of variables in
-`haveI' : ⋯ =Q ⋯ := ⟨⟩` clauses, so generates many false positives.
--/
-set_option linter.unusedVariables false
-
 namespace Mathlib
 open Lean
 open Meta

--- a/Mathlib/Tactic/NormNum/DivMod.lean
+++ b/Mathlib/Tactic/NormNum/DivMod.lean
@@ -13,14 +13,6 @@ This file adds support for the `%`, `/`, and `∣` (divisibility) operators on `
 to the `norm_num` tactic.
 -/
 
-#adaptation_note
-/--
-Since https://github.com/leanprover/lean4/pull/5338,
-the unused variable linter can not see usages of variables in
-`haveI' : ⋯ =Q ⋯ := ⟨⟩` clauses, so generates many false positives.
--/
-set_option linter.unusedVariables false
-
 namespace Mathlib
 open Lean
 open Meta

--- a/Mathlib/Tactic/NormNum/Eq.lean
+++ b/Mathlib/Tactic/NormNum/Eq.lean
@@ -11,14 +11,6 @@ import Mathlib.Tactic.NormNum.Inv
 
 variable {α : Type*}
 
-#adaptation_note
-/--
-Since https://github.com/leanprover/lean4/pull/5338,
-the unused variable linter can not see usages of variables in
-`haveI' : ⋯ =Q ⋯ := ⟨⟩` clauses, so generates many false positives.
--/
-set_option linter.unusedVariables false
-
 open Lean Meta Qq
 
 namespace Mathlib.Meta.NormNum

--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -16,14 +16,6 @@ Note that `Nat.coprime` is reducible and defined in terms of `Nat.gcd`, so the `
 also indirectly provides a `Nat.coprime` extension.
 -/
 
-#adaptation_note
-/--
-Since https://github.com/leanprover/lean4/pull/5338,
-the unused variable linter can not see usages of variables in
-`haveI' : ⋯ =Q ⋯ := ⟨⟩` clauses, so generates many false positives.
--/
-set_option linter.unusedVariables false
-
 namespace Tactic
 
 namespace NormNum

--- a/Mathlib/Tactic/NormNum/Ineq.lean
+++ b/Mathlib/Tactic/NormNum/Ineq.lean
@@ -13,14 +13,6 @@ import Mathlib.Algebra.Order.Ring.Cast
 # `norm_num` extensions for inequalities.
 -/
 
-#adaptation_note
-/--
-Since https://github.com/leanprover/lean4/pull/5338,
-the unused variable linter can not see usages of variables in
-`haveI' : ⋯ =Q ⋯ := ⟨⟩` clauses, so generates many false positives.
--/
-set_option linter.unusedVariables false
-
 open Lean Meta Qq
 
 namespace Mathlib.Meta.NormNum

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -13,14 +13,6 @@ import Mathlib.Algebra.Field.Basic
 
 variable {u : Lean.Level}
 
-#adaptation_note
-/--
-Since https://github.com/leanprover/lean4/pull/5338,
-the unused variable linter can not see usages of variables in
-`haveI' : ⋯ =Q ⋯ := ⟨⟩` clauses, so generates many false positives.
--/
-set_option linter.unusedVariables false
-
 namespace Mathlib.Meta.NormNum
 
 open Lean.Meta Qq

--- a/Mathlib/Tactic/NormNum/LegendreSymbol.lean
+++ b/Mathlib/Tactic/NormNum/LegendreSymbol.lean
@@ -356,14 +356,6 @@ namespace NormNum
 
 open Lean Elab Tactic Qq Mathlib.Meta.NormNum
 
-#adaptation_note
-/--
-Since https://github.com/leanprover/lean4/pull/5338,
-the unused variable linter can not see usages of variables in
-`haveI' : ⋯ =Q ⋯ := ⟨⟩` clauses, so generates many false positives.
--/
-set_option linter.unusedVariables false
-
 /-- This is the `norm_num` plug-in that evaluates Jacobi symbols. -/
 @[norm_num jacobiSym _ _]
 def evalJacobiSym : NormNumExt where eval {u α} e := do

--- a/Mathlib/Tactic/NormNum/Pow.lean
+++ b/Mathlib/Tactic/NormNum/Pow.lean
@@ -10,14 +10,6 @@ import Mathlib.Tactic.NormNum.Basic
 ## `norm_num` plugin for `^`.
 -/
 
-#adaptation_note
-/--
-Since https://github.com/leanprover/lean4/pull/5338,
-the unused variable linter can not see usages of variables in
-`haveI' : ⋯ =Q ⋯ := ⟨⟩` clauses, so generates many false positives.
--/
-set_option linter.unusedVariables false
-
 namespace Mathlib
 open Lean
 open Meta

--- a/Mathlib/Topology/SeparatedMap.lean
+++ b/Mathlib/Topology/SeparatedMap.lean
@@ -183,25 +183,11 @@ section eqLocus
 variable {f : X → Y} {g₁ g₂ : A → X} (h₁ : Continuous g₁) (h₂ : Continuous g₂)
 include h₁ h₂
 
-#adaptation_note
-/--
-After https://github.com/leanprover/lean4/pull/5338,
-the unused variable linter flags `g` here,
-but it is used in a type ascription to direct `fun_prop`.
--/
-set_option linter.unusedVariables false in
 theorem IsSeparatedMap.isClosed_eqLocus (sep : IsSeparatedMap f) (he : f ∘ g₁ = f ∘ g₂) :
     IsClosed {a | g₁ a = g₂ a} :=
   let g : A → f.Pullback f := fun a ↦ ⟨⟨g₁ a, g₂ a⟩, congr_fun he a⟩
   (isSeparatedMap_iff_isClosed_diagonal.mp sep).preimage (by fun_prop : Continuous g)
 
-#adaptation_note
-/--
-After https://github.com/leanprover/lean4/pull/5338,
-the unused variable linter flags `g` here,
-but it is used in a type ascription to direct `fun_prop`.
--/
-set_option linter.unusedVariables false in
 theorem IsLocallyInjective.isOpen_eqLocus (inj : IsLocallyInjective f) (he : f ∘ g₁ = f ∘ g₂) :
     IsOpen {a | g₁ a = g₂ a} :=
   let g : A → f.Pullback f := fun a ↦ ⟨⟨g₁ a, g₂ a⟩, congr_fun he a⟩


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
