### PR TITLE
[Merged by Bors] - feat(Algebra/Category): concrete category refactor for `MonCat`

### DIFF
--- a/Mathlib/Algebra/Category/Grp/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/Grp/Adjunctions.lean
@@ -31,7 +31,6 @@ category of abelian groups.
   abelian groups to groups.
 -/
 
-
 noncomputable section
 
 universe u
@@ -169,7 +168,7 @@ end Abelianization
 end Grp
 
 /-- The functor taking a monoid to its subgroup of units. -/
-@[simps]
+@[simps!]
 def MonCat.units : MonCat.{u} ⥤ Grp.{u} where
   obj R := Grp.of Rˣ
   map f := Grp.ofHom <| Units.map f.hom
@@ -184,7 +183,7 @@ def Grp.forget₂MonAdj : forget₂ Grp MonCat ⊣ MonCat.units.{u} := Adjunctio
       left_inv _ := MonCat.ext fun _ => rfl
       right_inv _ := Grp.ext fun _ => Units.ext rfl }
   unit :=
-    { app X := ofHom { (@toUnits X _).toMonoidHom with }
+    { app X := ofHom (@toUnits X _)
       naturality _ _ _ := Grp.ext fun _ => Units.ext rfl }
   counit :=
     { app X := MonCat.ofHom (Units.coeHom X)
@@ -194,7 +193,7 @@ instance : MonCat.units.{u}.IsRightAdjoint :=
   ⟨_, ⟨Grp.forget₂MonAdj⟩⟩
 
 /-- The functor taking a monoid to its subgroup of units. -/
-@[simps]
+@[simps!]
 def CommMonCat.units : CommMonCat.{u} ⥤ CommGrp.{u} where
   obj R := CommGrp.of Rˣ
   map f := CommGrp.ofHom <| Units.map f.hom
@@ -210,7 +209,15 @@ def CommGrp.forget₂CommMonAdj : forget₂ CommGrp CommMonCat ⊣ CommMonCat.un
         left_inv _ := CommMonCat.ext fun _ => rfl
         right_inv _ := CommGrp.ext fun _ => Units.ext rfl }
     unit.app X := ofHom toUnits.toMonoidHom
-    counit.app X := CommMonCat.ofHom (Units.coeHom X) }
+    -- `aesop` can find the following proof but it takes `0.5`s.
+    unit.naturality _ _ _ := CommGrp.ext fun _ => Units.ext rfl
+    counit.app X := CommMonCat.ofHom (Units.coeHom X)
+    -- `aesop` can find the following proof but it takes `0.5`s.
+    counit.naturality _ _ _ := CommMonCat.ext fun _ => rfl
+    -- `aesop` can find the following proof but it takes `0.2`s.
+    homEquiv_unit := by intros; rfl
+    -- `aesop` can find the following proof but it takes `0.2`s.
+    homEquiv_counit := by intros; rfl }
 
 instance : CommMonCat.units.{u}.IsRightAdjoint :=
   ⟨_, ⟨CommGrp.forget₂CommMonAdj⟩⟩

--- a/Mathlib/Algebra/Category/Grp/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/Grp/Adjunctions.lean
@@ -172,23 +172,23 @@ end Grp
 @[simps]
 def MonCat.units : MonCat.{u} ⥤ Grp.{u} where
   obj R := Grp.of Rˣ
-  map f := Grp.ofHom <| Units.map f
+  map f := Grp.ofHom <| Units.map f.hom
   map_id _ := Grp.ext fun _ => Units.ext rfl
   map_comp _ _ := Grp.ext fun _ => Units.ext rfl
 
 /-- The forgetful-units adjunction between `Grp` and `MonCat`. -/
 def Grp.forget₂MonAdj : forget₂ Grp MonCat ⊣ MonCat.units.{u} := Adjunction.mk' {
-  homEquiv := fun _ Y ↦
-    { toFun := fun f => ofHom (MonoidHom.toHomUnits f)
-      invFun := fun f => (Units.coeHom Y).comp f.hom
-      left_inv := fun _ => MonoidHom.ext fun _ => rfl
-      right_inv := fun _ => Grp.ext fun _ => Units.ext rfl }
+  homEquiv _ Y :=
+    { toFun f := ofHom (MonoidHom.toHomUnits f.hom)
+      invFun f := MonCat.ofHom ((Units.coeHom Y).comp f.hom)
+      left_inv _ := MonCat.ext fun _ => rfl
+      right_inv _ := Grp.ext fun _ => Units.ext rfl }
   unit :=
-    { app := fun X => ofHom { (@toUnits X _).toMonoidHom with }
-      naturality := fun _ _ _ => Grp.ext fun _ => Units.ext rfl }
+    { app X := ofHom { (@toUnits X _).toMonoidHom with }
+      naturality _ _ _ := Grp.ext fun _ => Units.ext rfl }
   counit :=
-    { app := fun X => Units.coeHom X
-      naturality := by intros; exact MonoidHom.ext fun x => rfl } }
+    { app X := MonCat.ofHom (Units.coeHom X)
+      naturality _ _ _ := MonCat.ext fun _ => rfl } }
 
 instance : MonCat.units.{u}.IsRightAdjoint :=
   ⟨_, ⟨Grp.forget₂MonAdj⟩⟩
@@ -197,7 +197,7 @@ instance : MonCat.units.{u}.IsRightAdjoint :=
 @[simps]
 def CommMonCat.units : CommMonCat.{u} ⥤ CommGrp.{u} where
   obj R := CommGrp.of Rˣ
-  map f := CommGrp.ofHom <| Units.map f
+  map f := CommGrp.ofHom <| Units.map f.hom
   map_id _ := CommGrp.ext fun _ => Units.ext rfl
   map_comp _ _ := CommGrp.ext fun _ => Units.ext rfl
 
@@ -205,12 +205,12 @@ def CommMonCat.units : CommMonCat.{u} ⥤ CommGrp.{u} where
 def CommGrp.forget₂CommMonAdj : forget₂ CommGrp CommMonCat ⊣ CommMonCat.units.{u} :=
   Adjunction.mk' {
     homEquiv := fun _ Y ↦
-      { toFun := fun f => ofHom (MonoidHom.toHomUnits f)
-        invFun := fun f => (Units.coeHom Y).comp f.hom
-        left_inv := fun _ => MonoidHom.ext fun _ => rfl
-        right_inv := fun _ => CommGrp.ext fun _ => Units.ext rfl }
-    unit := { app := fun X => ofHom { (@toUnits X _).toMonoidHom with } }
-    counit := { app := fun X => Units.coeHom X } }
+      { toFun f := ofHom (MonoidHom.toHomUnits f.hom)
+        invFun f := CommMonCat.ofHom ((Units.coeHom Y).comp f.hom)
+        left_inv _ := CommMonCat.ext fun _ => rfl
+        right_inv _ := CommGrp.ext fun _ => Units.ext rfl }
+    unit.app X := ofHom toUnits.toMonoidHom
+    counit.app X := CommMonCat.ofHom (Units.coeHom X) }
 
 instance : CommMonCat.units.{u}.IsRightAdjoint :=
   ⟨_, ⟨CommGrp.forget₂CommMonAdj⟩⟩

--- a/Mathlib/Algebra/Category/Grp/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/Grp/FilteredColimits.lean
@@ -108,16 +108,17 @@ noncomputable def colimit : Grp.{max v u} :=
 @[to_additive "The cocone over the proposed colimit additive group."]
 noncomputable def colimitCocone : Cocone F where
   pt := colimit.{v, u} F
-  ι.app J := Grp.ofHom ((MonCat.FilteredColimits.colimitCocone (F ⋙ forget₂ Grp MonCat)).ι.app J)
+  ι.app J := Grp.ofHom ((MonCat.FilteredColimits.colimitCocone
+    (F ⋙ forget₂ Grp MonCat)).ι.app J).hom
   ι.naturality _ _ f := (forget₂ _ MonCat).map_injective
     ((MonCat.FilteredColimits.colimitCocone _).ι.naturality f)
 
 /-- The proposed colimit cocone is a colimit in `Grp`. -/
 @[to_additive "The proposed colimit cocone is a colimit in `AddGroup`."]
 def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
-  desc t := Grp.ofHom <|
-    MonCat.FilteredColimits.colimitDesc.{v, u} (F ⋙ forget₂ Grp MonCat.{max v u})
-      ((forget₂ Grp MonCat).mapCocone t)
+  desc t := Grp.ofHom
+    (MonCat.FilteredColimits.colimitDesc.{v, u} (F ⋙ forget₂ Grp MonCat.{max v u})
+      ((forget₂ Grp MonCat).mapCocone t)).hom
   fac t j :=
     ConcreteCategory.coe_ext <|
       (Types.TypeMax.colimitCoconeIsColimit.{v, u} (F ⋙ forget Grp)).fac

--- a/Mathlib/Algebra/Category/Grp/Limits.lean
+++ b/Mathlib/Algebra/Category/Grp/Limits.lean
@@ -95,7 +95,7 @@ noncomputable instance Forget₂.createsLimit :
           { pt := Grp.of (Types.Small.limitCone (F ⋙ forget Grp)).pt
             π :=
               { app j := ofHom <| MonCat.limitπMonoidHom (F ⋙ forget₂ Grp MonCat) j
-                naturality i j h:= hom_ext <|
+                naturality i j h:= hom_ext <| congr_arg MonCat.Hom.hom <|
                   (MonCat.HasLimits.limitCone
                         (F ⋙ forget₂ Grp MonCat.{u})).π.naturality h } }
         validLift := by apply IsLimit.uniqueUpToIso (MonCat.HasLimits.limitConeIsLimit.{v, u} _) t
@@ -263,7 +263,8 @@ noncomputable instance Forget₂.createsLimit :
             π :=
               { app j := ofHom <| MonCat.limitπMonoidHom
                   (F ⋙ forget₂ CommGrp Grp.{u} ⋙ forget₂ Grp MonCat.{u}) j
-                naturality i j h := hom_ext <| (MonCat.HasLimits.limitCone _).π.naturality h } }
+                naturality i j h := hom_ext <| congr_arg MonCat.Hom.hom <|
+                  (MonCat.HasLimits.limitCone _).π.naturality h } }
         validLift := by apply IsLimit.uniqueUpToIso (Grp.limitConeIsLimit _) hc
         makesLimit :=
           IsLimit.ofFaithful (forget₂ _ Grp.{u} ⋙ forget₂ _ MonCat.{u})

--- a/Mathlib/Algebra/Category/GrpWithZero.lean
+++ b/Mathlib/Algebra/Category/GrpWithZero.lean
@@ -6,6 +6,7 @@ Authors: Yaël Dillies
 import Mathlib.Algebra.Category.MonCat.Basic
 import Mathlib.Algebra.GroupWithZero.WithZero
 import Mathlib.CategoryTheory.Category.Bipointed
+import Mathlib.CategoryTheory.ConcreteCategory.Bundled
 
 /-!
 # The category of groups with zero

--- a/Mathlib/Algebra/Category/GrpWithZero.lean
+++ b/Mathlib/Algebra/Category/GrpWithZero.lean
@@ -72,8 +72,8 @@ instance hasForgetToBipointed : HasForget₂ GrpWithZero Bipointed where
 
 instance hasForgetToMon : HasForget₂ GrpWithZero MonCat where
   forget₂ :=
-      { obj := fun X => ⟨ X , _ ⟩
-        map := fun f => f.toMonoidHom }
+      { obj := fun X => MonCat.of X
+        map := fun f => MonCat.ofHom f.toMonoidHom }
 
 /-- Constructs an isomorphism of groups with zero from a group isomorphism between them. -/
 @[simps]

--- a/Mathlib/Algebra/Category/MonCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/MonCat/Adjunctions.lean
@@ -61,8 +61,9 @@ def free : Type u ⥤ MonCat.{u} where
 /-- The free-forgetful adjunction for monoids. -/
 def adj : free ⊣ forget MonCat.{u} :=
   Adjunction.mkOfHomEquiv
-    { homEquiv := fun _ _ => ConcreteCategory.homEquiv.trans FreeMonoid.lift.symm
-      homEquiv_naturality_left_symm := fun _ _ => MonCat.hom_ext (FreeMonoid.hom_eq fun _ => rfl) }
+    -- The hint `(C := MonCat)` below speeds up the declaration by 10 times.
+    { homEquiv X Y := (ConcreteCategory.homEquiv (C := MonCat)).trans FreeMonoid.lift.symm
+      homEquiv_naturality_left_symm _ _ := MonCat.hom_ext (FreeMonoid.hom_eq fun _ => rfl) }
 
 instance : (forget MonCat.{u}).IsRightAdjoint :=
   ⟨_, ⟨adj⟩⟩

--- a/Mathlib/Algebra/Category/MonCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/MonCat/Adjunctions.lean
@@ -32,21 +32,21 @@ namespace MonCat
 @[to_additive (attr := simps) "The functor of adjoining a neutral element `zero` to a semigroup"]
 def adjoinOne : Semigrp.{u} ⥤ MonCat.{u} where
   obj S := MonCat.of (WithOne S)
-  map := WithOne.map
-  map_id _ := WithOne.map_id
-  map_comp := WithOne.map_comp
+  map f := ofHom (WithOne.map f)
+  map_id _ := MonCat.hom_ext WithOne.map_id
+  map_comp _ _ := MonCat.hom_ext (WithOne.map_comp _ _)
 
 @[to_additive]
 instance hasForgetToSemigroup : HasForget₂ MonCat Semigrp where
   forget₂ :=
     { obj := fun M => Semigrp.of M
-      map := MonoidHom.toMulHom }
+      map f := f.hom.toMulHom }
 
 /-- The `adjoinOne`-forgetful adjunction from `Semigrp` to `MonCat`. -/
 @[to_additive "The `adjoinZero`-forgetful adjunction from `AddSemigrp` to `AddMonCat`"]
 def adjoinOneAdj : adjoinOne ⊣ forget₂ MonCat.{u} Semigrp.{u} :=
   Adjunction.mkOfHomEquiv
-    { homEquiv := fun _ _ => WithOne.lift.symm
+    { homEquiv := fun _ _ => ConcreteCategory.homEquiv.trans WithOne.lift.symm
       homEquiv_naturality_left_symm := by
         intro S T M f g
         ext x
@@ -60,15 +60,15 @@ def adjoinOneAdj : adjoinOne ⊣ forget₂ MonCat.{u} Semigrp.{u} :=
 /-- The free functor `Type u ⥤ MonCat` sending a type `X` to the free monoid on `X`. -/
 def free : Type u ⥤ MonCat.{u} where
   obj α := MonCat.of (FreeMonoid α)
-  map := FreeMonoid.map
-  map_id _ := FreeMonoid.hom_eq (fun _ => rfl)
-  map_comp _ _ := FreeMonoid.hom_eq (fun _ => rfl)
+  map f := ofHom (FreeMonoid.map f)
+  map_id _ := MonCat.hom_ext (FreeMonoid.hom_eq fun _ => rfl)
+  map_comp _ _ := MonCat.hom_ext (FreeMonoid.hom_eq fun _ => rfl)
 
 /-- The free-forgetful adjunction for monoids. -/
 def adj : free ⊣ forget MonCat.{u} :=
   Adjunction.mkOfHomEquiv
-    { homEquiv := fun _ _ => FreeMonoid.lift.symm
-      homEquiv_naturality_left_symm := fun _ _ => FreeMonoid.hom_eq (fun _ => rfl) }
+    { homEquiv := fun _ _ => ConcreteCategory.homEquiv.trans FreeMonoid.lift.symm
+      homEquiv_naturality_left_symm := fun _ _ => MonCat.hom_ext (FreeMonoid.hom_eq fun _ => rfl) }
 
 instance : (forget MonCat.{u}).IsRightAdjoint :=
   ⟨_, ⟨adj⟩⟩

--- a/Mathlib/Algebra/Category/MonCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/MonCat/Adjunctions.lean
@@ -48,14 +48,8 @@ def adjoinOneAdj : adjoinOne ⊣ forget₂ MonCat.{u} Semigrp.{u} :=
   Adjunction.mkOfHomEquiv
     { homEquiv := fun _ _ => ConcreteCategory.homEquiv.trans WithOne.lift.symm
       homEquiv_naturality_left_symm := by
-        intro S T M f g
-        ext x
-        simp only [Equiv.symm_symm, adjoinOne_map, coe_comp]
-        simp_rw [WithOne.map]
-        cases x
-        · rfl
-        · simp
-          rfl }
+        intros
+        ext ⟨_|_⟩ <;> simp <;> rfl }
 
 /-- The free functor `Type u ⥤ MonCat` sending a type `X` to the free monoid on `X`. -/
 def free : Type u ⥤ MonCat.{u} where

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -24,59 +24,89 @@ universe u v
 
 open CategoryTheory
 
-/-- The category of monoids and monoid morphisms. -/
-@[to_additive AddMonCat]
-def MonCat : Type (u + 1) :=
-  Bundled Monoid
+/-- The category of additive groups and group morphisms. -/
+structure AddMonCat : Type (u + 1) where
+  /-- The underlying type. -/
+  (carrier : Type u)
+  [str : AddMonoid carrier]
 
-/-- The category of additive monoids and monoid morphisms. -/
-add_decl_doc AddMonCat
+/-- The category of groups and group morphisms. -/
+@[to_additive AddMonCat]
+structure MonCat : Type (u + 1) where
+  /-- The underlying type. -/
+  (carrier : Type u)
+  [str : Monoid carrier]
+
+attribute [instance] AddMonCat.str MonCat.str
+attribute [to_additive existing] MonCat.carrier MonCat.str
+
+initialize_simps_projections AddMonCat (carrier → coe, -str)
+initialize_simps_projections MonCat (carrier → coe, -str)
 
 namespace MonCat
 
-/-- `MonoidHom` doesn't actually assume associativity. This alias is needed to make the category
-theory machinery work. -/
 @[to_additive]
-abbrev AssocMonoidHom (M N : Type*) [Monoid M] [Monoid N] :=
-  MonoidHom M N
+instance : CoeSort MonCat (Type u) :=
+  ⟨MonCat.carrier⟩
 
-/-- `AddMonoidHom` doesn't actually assume associativity. This alias is needed to make
-the category theory machinery work. -/
-add_decl_doc AddMonCat.AssocAddMonoidHom
+attribute [coe] AddMonCat.carrier MonCat.carrier
 
-@[to_additive]
-instance bundledHom : BundledHom AssocMonoidHom where
-  toFun {_ _} _ _ f := ⇑f
-  id _ := MonoidHom.id _
-  comp _ _ _ := MonoidHom.comp
+/-- Construct a bundled `MonCat` from the underlying type and typeclass. -/
+@[to_additive "Construct a bundled `AddMonCat` from the underlying type and typeclass."]
+abbrev of (M : Type u) [Monoid M] : MonCat := ⟨M⟩
 
-deriving instance LargeCategory for MonCat
-attribute [to_additive instAddMonCatLargeCategory] instMonCatLargeCategory
+end MonCat
 
--- Porting note: https://github.com/leanprover-community/mathlib4/issues/5020
-@[to_additive]
-instance hasForget : HasForget MonCat :=
-  BundledHom.hasForget _
+/-- The type of morphisms in `AddMonCat R`. -/
+@[ext]
+structure AddMonCat.Hom (A B : AddMonCat.{u}) where
+  private mk ::
+  /-- The underlying monoid homomorphism. -/
+  hom' : A →+ B
 
-@[to_additive]
-instance : CoeSort MonCat Type* where
-  coe X := X.α
+/-- The type of morphisms in `MonCat R`. -/
+@[to_additive, ext]
+structure MonCat.Hom (A B : MonCat.{u}) where
+  private mk ::
+  /-- The underlying monoid homomorphism. -/
+  hom' : A →* B
 
-@[to_additive]
-instance (X : MonCat) : Monoid X := X.str
+attribute [to_additive existing AddMonCat.Hom.mk] MonCat.Hom.mk
 
--- Porting note (https://github.com/leanprover-community/mathlib4/pull/10670): this instance was not necessary in mathlib
-@[to_additive]
-instance {X Y : MonCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
-  coe (f : X →* Y) := f
+namespace MonCat
 
 @[to_additive]
-instance instFunLike (X Y : MonCat) : FunLike (X ⟶ Y) X Y :=
-  inferInstanceAs <| FunLike (X →* Y) X Y
+instance : Category MonCat.{u} where
+  Hom X Y := Hom X Y
+  id X := ⟨MonoidHom.id X⟩
+  comp f g := ⟨g.hom'.comp f.hom'⟩
 
 @[to_additive]
-instance instMonoidHomClass (X Y : MonCat) : MonoidHomClass (X ⟶ Y) X Y :=
-  inferInstanceAs <| MonoidHomClass (X →* Y) X Y
+instance : ConcreteCategory MonCat (· →* ·) where
+  hom := Hom.hom'
+  ofHom := Hom.mk
+
+/-- Turn a morphism in `MonCat` back into a `MonoidHom`. -/
+@[to_additive "Turn a morphism in `AddMonCat` back into an `AddMonoidHom`."]
+abbrev Hom.hom {X Y : MonCat.{u}} (f : Hom X Y) :=
+  ConcreteCategory.hom (C := MonCat) f
+
+/-- Typecheck a `MonoidHom` as a morphism in `MonCat`. -/
+@[to_additive "Typecheck an `AddMonoidHom` as a morphism in `AddMonCat`. "]
+abbrev ofHom {X Y : Type u} [Monoid X] [Monoid Y] (f : X →* Y) : of X ⟶ of Y :=
+  ConcreteCategory.ofHom (C := MonCat) f
+
+variable {R} in
+/-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
+def Hom.Simps.hom (X Y : MonCat.{u}) (f : Hom X Y) :=
+  f.hom
+
+initialize_simps_projections Hom (hom' → hom)
+initialize_simps_projections AddMonCat.Hom (hom' → hom)
+
+/-!
+The results below duplicate the `ConcreteCategory` simp lemmas, but we can keep them for `dsimp`.
+-/
 
 @[to_additive (attr := simp)]
 lemma coe_id {X : MonCat} : (𝟙 X : X → X) = id := rfl
@@ -84,26 +114,69 @@ lemma coe_id {X : MonCat} : (𝟙 X : X → X) = id := rfl
 @[to_additive (attr := simp)]
 lemma coe_comp {X Y Z : MonCat} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g : X → Z) = g ∘ f := rfl
 
-@[to_additive (attr := simp)] lemma forget_map {X Y : MonCat} (f : X ⟶ Y) :
+@[to_additive (attr := simp)]
+lemma forget_map {X Y : MonCat} (f : X ⟶ Y) :
     (forget MonCat).map f = f := rfl
 
 @[to_additive (attr := ext)]
 lemma ext {X Y : MonCat} {f g : X ⟶ Y} (w : ∀ x : X, f x = g x) : f = g :=
-  MonoidHom.ext w
+  ConcreteCategory.hom_ext _ _ w
 
-/-- Construct a bundled `MonCat` from the underlying type and typeclass. -/
 @[to_additive]
-def of (M : Type u) [Monoid M] : MonCat :=
-  Bundled.of M
+-- This is not `simp` to avoid rewriting in types of terms.
+theorem coe_of (M : Type u) [Monoid M] : (MonCat.of M : Type u) = M := rfl
 
-/-- Construct a bundled `AddMonCat` from the underlying type and typeclass. -/
-add_decl_doc AddMonCat.of
+@[to_additive (attr := simp)]
+lemma hom_id {M : MonCat} : (𝟙 M : M ⟶ M).hom = MonoidHom.id M := rfl
 
--- Porting note: removed `@[simp]` here, as it makes it harder to tell when to apply
--- bundled or unbundled lemmas.
--- (This change seems dangerous!)
+/- Provided for rewriting. -/
 @[to_additive]
-theorem coe_of (R : Type u) [Monoid R] : (MonCat.of R : Type u) = R := rfl
+lemma id_apply (M : MonCat) (x : M) :
+    (𝟙 M : M ⟶ M) x = x := by simp
+
+@[to_additive (attr := simp)]
+lemma hom_comp {M N T : MonCat} (f : M ⟶ N) (g : N ⟶ T) :
+    (f ≫ g).hom = g.hom.comp f.hom := rfl
+
+/- Provided for rewriting. -/
+@[to_additive]
+lemma comp_apply {M N T : MonCat} (f : M ⟶ N) (g : N ⟶ T) (x : M) :
+    (f ≫ g) x = g (f x) := by simp
+
+@[to_additive (attr := ext)]
+lemma hom_ext {M N : MonCat} {f g : M ⟶ N} (hf : f.hom = g.hom) : f = g :=
+  Hom.ext hf
+
+@[to_additive (attr := simp)]
+lemma hom_ofHom {M N : Type u} [Monoid M] [Monoid N] (f : M →* N) :
+  (ofHom f).hom = f := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_hom {M N : MonCat} (f : M ⟶ N) :
+    ofHom (Hom.hom f) = f := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_id {M : Type u} [Monoid M] : ofHom (MonoidHom.id M) = 𝟙 (of M) := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_comp {M N P : Type u} [Monoid M] [Monoid N] [Monoid P]
+    (f : M →* N) (g : N →* P) :
+    ofHom (g.comp f) = ofHom f ≫ ofHom g :=
+  rfl
+
+@[to_additive]
+lemma ofHom_apply {X Y : Type u} [Monoid X] [Monoid Y] (f : X →* Y) (x : X) :
+    (ofHom f) x = f x := rfl
+
+@[to_additive (attr := simp)]
+lemma inv_hom_apply {M N : MonCat} (e : M ≅ N) (x : M) : e.inv (e.hom x) = x := by
+  rw [← comp_apply]
+  simp
+
+@[to_additive (attr := simp)]
+lemma hom_inv_apply {M N : MonCat} (e : M ≅ N) (s : N) : e.hom (e.inv s) = s := by
+  rw [← comp_apply]
+  simp
 
 @[to_additive]
 instance : Inhabited MonCat :=
@@ -111,25 +184,15 @@ instance : Inhabited MonCat :=
   ⟨@of PUnit (@DivInvMonoid.toMonoid _ (@Group.toDivInvMonoid _
     (@CommGroup.toGroup _ PUnit.commGroup)))⟩
 
-/-- Typecheck a `MonoidHom` as a morphism in `MonCat`. -/
-@[to_additive]
-def ofHom {X Y : Type u} [Monoid X] [Monoid Y] (f : X →* Y) : of X ⟶ of Y := f
-
-/-- Typecheck an `AddMonoidHom` as a morphism in `AddMonCat`. -/
-add_decl_doc AddMonCat.ofHom
-
-@[to_additive (attr := simp)]
-lemma ofHom_apply {X Y : Type u} [Monoid X] [Monoid Y] (f : X →* Y) (x : X) :
-    (ofHom f) x = f x := rfl
-
----- Porting note: added to ease the port of `CategoryTheory.Action.Basic`
 @[to_additive]
 instance (X Y : MonCat.{u}) : One (X ⟶ Y) := ⟨ofHom 1⟩
 
 @[to_additive (attr := simp)]
-lemma oneHom_apply (X Y : MonCat.{u}) (x : X) : (1 : X ⟶ Y) x = 1 := rfl
+lemma hom_one (X Y : MonCat.{u}) : (1 : X ⟶ Y).hom = 1 := rfl
 
----- Porting note: added to ease the port of `CategoryTheory.Action.Basic`
+@[to_additive]
+lemma oneHom_apply (X Y : MonCat.{u}) (x : X) : (1 : X ⟶ Y).hom x = 1 := rfl
+
 @[to_additive (attr := simp)]
 lemma one_of {A : Type*} [Monoid A] : (1 : MonCat.of A) = (1 : A) := rfl
 
@@ -137,58 +200,101 @@ lemma one_of {A : Type*} [Monoid A] : (1 : MonCat.of A) = (1 : A) := rfl
 lemma mul_of {A : Type*} [Monoid A] (a b : A) :
     @HMul.hMul (MonCat.of A) (MonCat.of A) (MonCat.of A) _ a b = a * b := rfl
 
-@[to_additive]
-instance {G : Type*} [Group G] : Group (MonCat.of G) := by assumption
-
 /-- Universe lift functor for monoids. -/
 @[to_additive (attr := simps)
   "Universe lift functor for additive monoids."]
 def uliftFunctor : MonCat.{v} ⥤ MonCat.{max v u} where
   obj X := MonCat.of (ULift.{u, v} X)
   map {_ _} f := MonCat.ofHom <|
-    MulEquiv.ulift.symm.toMonoidHom.comp <| f.comp MulEquiv.ulift.toMonoidHom
+    MulEquiv.ulift.symm.toMonoidHom.comp <| f.hom.comp MulEquiv.ulift.toMonoidHom
   map_id X := by rfl
   map_comp {X Y Z} f g := by rfl
 
 end MonCat
 
-/-- The category of commutative monoids and monoid morphisms. -/
-@[to_additive AddCommMonCat]
-def CommMonCat : Type (u + 1) :=
-  Bundled CommMonoid
+/-- The category of additive groups and group morphisms. -/
+structure AddCommMonCat : Type (u + 1) where
+  /-- The underlying type. -/
+  (carrier : Type u)
+  [str : AddCommMonoid carrier]
 
-/-- The category of additive commutative monoids and monoid morphisms. -/
-add_decl_doc AddCommMonCat
+/-- The category of groups and group morphisms. -/
+@[to_additive AddCommMonCat]
+structure CommMonCat : Type (u + 1) where
+  /-- The underlying type. -/
+  (carrier : Type u)
+  [str : CommMonoid carrier]
+
+attribute [instance] AddCommMonCat.str CommMonCat.str
+attribute [to_additive existing] CommMonCat.carrier CommMonCat.str
+
+initialize_simps_projections AddCommMonCat (carrier → coe, -str)
+initialize_simps_projections CommMonCat (carrier → coe, -str)
 
 namespace CommMonCat
 
 @[to_additive]
-instance : BundledHom.ParentProjection @CommMonoid.toMonoid := ⟨⟩
+instance : CoeSort CommMonCat (Type u) :=
+  ⟨CommMonCat.carrier⟩
 
-deriving instance LargeCategory for CommMonCat
-attribute [to_additive instAddCommMonCatLargeCategory] instCommMonCatLargeCategory
+attribute [coe] AddCommMonCat.carrier CommMonCat.carrier
 
--- Porting note: https://github.com/leanprover-community/mathlib4/issues/5020
+/-- Construct a bundled `CommMonCat` from the underlying type and typeclass. -/
+@[to_additive "Construct a bundled `AddCommMonCat` from the underlying type and typeclass."]
+abbrev of (M : Type u) [CommMonoid M] : CommMonCat := ⟨M⟩
+
+end CommMonCat
+
+/-- The type of morphisms in `AddCommMonCat R`. -/
+@[ext]
+structure AddCommMonCat.Hom (A B : AddCommMonCat.{u}) where
+  private mk ::
+  /-- The underlying monoid homomorphism. -/
+  hom' : A →+ B
+
+/-- The type of morphisms in `CommMonCat R`. -/
+@[to_additive, ext]
+structure CommMonCat.Hom (A B : CommMonCat.{u}) where
+  private mk ::
+  /-- The underlying monoid homomorphism. -/
+  hom' : A →* B
+
+attribute [to_additive existing AddCommMonCat.Hom.mk] CommMonCat.Hom.mk
+
+namespace CommMonCat
+
 @[to_additive]
-instance hasForget : HasForget CommMonCat := by
-  dsimp only [CommMonCat]
-  infer_instance
+instance : Category CommMonCat.{u} where
+  Hom X Y := Hom X Y
+  id X := ⟨MonoidHom.id X⟩
+  comp f g := ⟨g.hom'.comp f.hom'⟩
 
 @[to_additive]
-instance : CoeSort CommMonCat Type* where
-  coe X := X.α
+instance : ConcreteCategory CommMonCat (· →* ·) where
+  hom := Hom.hom'
+  ofHom := Hom.mk
 
-@[to_additive]
-instance (X : CommMonCat) : CommMonoid X := X.str
+/-- Turn a morphism in `CommMonCat` back into a `MonoidHom`. -/
+@[to_additive "Turn a morphism in `AddCommMonCat` back into an `AddMonoidHom`."]
+abbrev Hom.hom {X Y : CommMonCat.{u}} (f : Hom X Y) :=
+  ConcreteCategory.hom (C := CommMonCat) f
 
--- Porting note (https://github.com/leanprover-community/mathlib4/pull/10670): this instance was not necessary in mathlib
-@[to_additive]
-instance {X Y : CommMonCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
-  coe (f : X →* Y) := f
+/-- Typecheck a `MonoidHom` as a morphism in `CommMonCat`. -/
+@[to_additive "Typecheck an `AddMonoidHom` as a morphism in `AddCommMonCat`. "]
+abbrev ofHom {X Y : Type u} [CommMonoid X] [CommMonoid Y] (f : X →* Y) : of X ⟶ of Y :=
+  ConcreteCategory.ofHom (C := CommMonCat) f
 
-@[to_additive]
-instance instFunLike (X Y : CommMonCat) : FunLike (X ⟶ Y) X Y :=
-  show FunLike (X →* Y) X Y by infer_instance
+/-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
+@[to_additive "Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas."]
+def Hom.Simps.hom (X Y : CommMonCat.{u}) (f : Hom X Y) :=
+  f.hom
+
+initialize_simps_projections Hom (hom' → hom)
+initialize_simps_projections AddCommMonCat.Hom (hom' → hom)
+
+/-!
+The results below duplicate the `ConcreteCategory` simp lemmas, but we can keep them for `dsimp`.
+-/
 
 @[to_additive (attr := simp)]
 lemma coe_id {X : CommMonCat} : (𝟙 X : X → X) = id := rfl
@@ -203,46 +309,88 @@ lemma forget_map {X Y : CommMonCat} (f : X ⟶ Y) :
 
 @[to_additive (attr := ext)]
 lemma ext {X Y : CommMonCat} {f g : X ⟶ Y} (w : ∀ x : X, f x = g x) : f = g :=
-  MonoidHom.ext w
+  ConcreteCategory.hom_ext _ _ w
 
-/-- Construct a bundled `CommMonCat` from the underlying type and typeclass. -/
+@[to_additive (attr := simp)]
+lemma hom_id {M : CommMonCat} : (𝟙 M : M ⟶ M).hom = MonoidHom.id M := rfl
+
+/- Provided for rewriting. -/
 @[to_additive]
-def of (M : Type u) [CommMonoid M] : CommMonCat :=
-  Bundled.of M
+lemma id_apply (M : CommMonCat) (x : M) :
+    (𝟙 M : M ⟶ M) x = x := by simp
 
-/-- Construct a bundled `AddCommMonCat` from the underlying type and typeclass. -/
-add_decl_doc AddCommMonCat.of
+@[to_additive (attr := simp)]
+lemma hom_comp {M N T : CommMonCat} (f : M ⟶ N) (g : N ⟶ T) :
+    (f ≫ g).hom = g.hom.comp f.hom := rfl
+
+/- Provided for rewriting. -/
+@[to_additive]
+lemma comp_apply {M N T : CommMonCat} (f : M ⟶ N) (g : N ⟶ T) (x : M) :
+    (f ≫ g) x = g (f x) := by simp
+
+@[to_additive (attr := ext)]
+lemma hom_ext {M N : CommMonCat} {f g : M ⟶ N} (hf : f.hom = g.hom) : f = g :=
+  Hom.ext hf
+
+@[to_additive (attr := simp)]
+lemma hom_ofHom {M N : Type u} [CommMonoid M] [CommMonoid N] (f : M →* N) :
+  (ofHom f).hom = f := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_hom {M N : CommMonCat} (f : M ⟶ N) :
+    ofHom (Hom.hom f) = f := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_id {M : Type u} [CommMonoid M] : ofHom (MonoidHom.id M) = 𝟙 (of M) := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_comp {M N P : Type u} [CommMonoid M] [CommMonoid N] [CommMonoid P]
+    (f : M →* N) (g : N →* P) :
+    ofHom (g.comp f) = ofHom f ≫ ofHom g :=
+  rfl
+
+@[to_additive]
+lemma ofHom_apply {X Y : Type u} [CommMonoid X] [CommMonoid Y] (f : X →* Y) (x : X) :
+    (ofHom f) x = f x := rfl
+
+@[to_additive (attr := simp)]
+lemma inv_hom_apply {M N : CommMonCat} (e : M ≅ N) (x : M) : e.inv (e.hom x) = x := by
+  rw [← comp_apply]
+  simp
+
+@[to_additive (attr := simp)]
+lemma hom_inv_apply {M N : CommMonCat} (e : M ≅ N) (s : N) : e.hom (e.inv s) = s := by
+  rw [← comp_apply]
+  simp
 
 @[to_additive]
 instance : Inhabited CommMonCat :=
   -- The default instance for `CommMonoid PUnit` is derived via `CommRing` which breaks to_additive
   ⟨@of PUnit (@CommGroup.toCommMonoid _ PUnit.commGroup)⟩
 
--- Porting note: removed `@[simp]` here, as it makes it harder to tell when to apply
--- bundled or unbundled lemmas.
--- (This change seems dangerous!)
 @[to_additive]
 theorem coe_of (R : Type u) [CommMonoid R] : (CommMonCat.of R : Type u) = R :=
   rfl
 
 @[to_additive hasForgetToAddMonCat]
-instance hasForgetToMonCat : HasForget₂ CommMonCat MonCat :=
-  BundledHom.forget₂ _ _
+instance hasForgetToMonCat : HasForget₂ CommMonCat MonCat where
+  forget₂ :=
+    { obj R := MonCat.of R
+      map f := MonCat.ofHom f.hom }
+
+@[to_additive (attr := simp)] lemma coe_forget₂_obj (X : CommMonCat) :
+    ((forget₂ CommMonCat MonCat).obj X : Type _) = X := rfl
+
+@[to_additive (attr := simp)] lemma hom_forget₂_map {X Y : CommMonCat}
+    (f : X ⟶ Y) :
+    ((forget₂ CommMonCat MonCat).map f).hom = f.hom := rfl
+
+@[to_additive (attr := simp)] lemma forget₂_map_ofHom {X Y : Type u} [CommMonoid X] [CommMonoid Y]
+    (f : X →* Y) :
+    (forget₂ CommMonCat MonCat).map (ofHom f) = MonCat.ofHom f := rfl
 
 @[to_additive]
 instance : Coe CommMonCat.{u} MonCat.{u} where coe := (forget₂ CommMonCat MonCat).obj
-
--- Porting note: this was added to make automation work (it already exists for MonCat)
-/-- Typecheck a `MonoidHom` as a morphism in `CommMonCat`. -/
-@[to_additive]
-def ofHom {X Y : Type u} [CommMonoid X] [CommMonoid Y] (f : X →* Y) : of X ⟶ of Y := f
-
-/-- Typecheck an `AddMonoidHom` as a morphism in `AddCommMonCat`. -/
-add_decl_doc AddCommMonCat.ofHom
-
-@[to_additive (attr := simp)]
-lemma ofHom_apply {X Y : Type u} [CommMonoid X] [CommMonoid Y] (f : X →* Y) (x : X) :
-    (ofHom f) x = f x := rfl
 
 /-- Universe lift functor for commutative monoids. -/
 @[to_additive (attr := simps)
@@ -250,7 +398,7 @@ lemma ofHom_apply {X Y : Type u} [CommMonoid X] [CommMonoid Y] (f : X →* Y) (x
 def uliftFunctor : CommMonCat.{v} ⥤ CommMonCat.{max v u} where
   obj X := CommMonCat.of (ULift.{u, v} X)
   map {_ _} f := CommMonCat.ofHom <|
-    MulEquiv.ulift.symm.toMonoidHom.comp <| f.comp MulEquiv.ulift.toMonoidHom
+    MulEquiv.ulift.symm.toMonoidHom.comp <| f.hom.comp MulEquiv.ulift.toMonoidHom
   map_id X := by rfl
   map_comp {X Y Z} f g := by rfl
 
@@ -293,12 +441,12 @@ namespace CategoryTheory.Iso
 @[to_additive addMonCatIsoToAddEquiv
       "Build an `AddEquiv` from an isomorphism in the category\n`AddMonCat`."]
 def monCatIsoToMulEquiv {X Y : MonCat} (i : X ≅ Y) : X ≃* Y :=
-  MonoidHom.toMulEquiv i.hom i.inv i.hom_inv_id i.inv_hom_id
+  MonoidHom.toMulEquiv i.hom.hom i.inv.hom (by ext; simp) (by ext; simp)
 
 /-- Build a `MulEquiv` from an isomorphism in the category `CommMonCat`. -/
 @[to_additive "Build an `AddEquiv` from an isomorphism in the category\n`AddCommMonCat`."]
 def commMonCatIsoToMulEquiv {X Y : CommMonCat} (i : X ≅ Y) : X ≃* Y :=
-  MonoidHom.toMulEquiv i.hom i.inv i.hom_inv_id i.inv_hom_id
+  MonoidHom.toMulEquiv i.hom.hom i.inv.hom (by ext; simp) (by ext; simp)
 
 end CategoryTheory.Iso
 
@@ -330,18 +478,14 @@ add_decl_doc addEquivIsoAddCommMonCatIso
 instance MonCat.forget_reflects_isos : (forget MonCat.{u}).ReflectsIsomorphisms where
   reflects {X Y} f _ := by
     let i := asIso ((forget MonCat).map f)
-    -- Again a problem that exists already creeps into other things https://github.com/leanprover/lean4/pull/2644
-    -- this used to be `by aesop`; see next declaration
-    let e : X ≃* Y := MulEquiv.mk i.toEquiv (MonoidHom.map_mul (show MonoidHom X Y from f))
+    let e : X ≃* Y := { f.hom, i.toEquiv with }
     exact e.toMonCatIso.isIso_hom
 
 @[to_additive]
 instance CommMonCat.forget_reflects_isos : (forget CommMonCat.{u}).ReflectsIsomorphisms where
   reflects {X Y} f _ := by
     let i := asIso ((forget CommMonCat).map f)
-    let e : X ≃* Y := MulEquiv.mk i.toEquiv
-      -- Porting FIXME: this would ideally be `by aesop`, as in `MonCat.forget_reflects_isos`
-      (MonoidHom.map_mul (show MonoidHom X Y from f))
+    let e : X ≃* Y := { f.hom, i.toEquiv with }
     exact e.toCommMonCatIso.isIso_hom
 
 -- Porting note: this was added in order to ensure that `forget₂ CommMonCat MonCat`
@@ -349,7 +493,7 @@ instance CommMonCat.forget_reflects_isos : (forget CommMonCat.{u}).ReflectsIsomo
 -- we could have used `CategoryTheory.HasForget.ReflectsIso` alternatively
 @[to_additive]
 instance CommMonCat.forget₂_full : (forget₂ CommMonCat MonCat).Full where
-  map_surjective f := ⟨f, rfl⟩
+  map_surjective f := ⟨ofHom f.hom, rfl⟩
 
 example : (forget₂ CommMonCat MonCat).ReflectsIsomorphisms := inferInstance
 
@@ -357,16 +501,26 @@ example : (forget₂ CommMonCat MonCat).ReflectsIsomorphisms := inferInstance
 `@[simp]` lemmas for `MonoidHom.comp` and categorical identities.
 -/
 
-@[to_additive (attr := simp)] theorem MonoidHom.comp_id_monCat
-    {G : MonCat.{u}} {H : Type u} [Monoid H] (f : G →* H) : f.comp (𝟙 G) = f :=
-  Category.id_comp (MonCat.ofHom f)
-@[to_additive (attr := simp)] theorem MonoidHom.id_monCat_comp
-    {G : Type u} [Monoid G] {H : MonCat.{u}} (f : G →* H) : MonoidHom.comp (𝟙 H) f = f :=
-  Category.comp_id (MonCat.ofHom f)
+@[to_additive (attr := deprecated
+  "Proven by `simp only [MonCat.hom_id, comp_id]`"
+  (since := "2025-01-28"))]
+theorem MonoidHom.comp_id_monCat {G : MonCat.{u}} {H : Type u} [Monoid H] (f : G →* H) :
+    f.comp (MonCat.Hom.hom (𝟙 G)) = f := by simp
+@[to_additive (attr := deprecated
+  "Proven by `simp only [MonCat.hom_id, id_comp]`"
+  (since := "2025-01-28"))]
+theorem MonoidHom.id_monCat_comp {G : Type u} [Monoid G] {H : MonCat.{u}} (f : G →* H) :
+    MonoidHom.comp (MonCat.Hom.hom (𝟙 H)) f = f := by simp
 
-@[to_additive (attr := simp)] theorem MonoidHom.comp_id_commMonCat
-    {G : CommMonCat.{u}} {H : Type u} [CommMonoid H] (f : G →* H) : f.comp (𝟙 G) = f :=
-  Category.id_comp (CommMonCat.ofHom f)
-@[to_additive (attr := simp)] theorem MonoidHom.id_commMonCat_comp
-    {G : Type u} [CommMonoid G] {H : CommMonCat.{u}} (f : G →* H) : MonoidHom.comp (𝟙 H) f = f :=
-  Category.comp_id (CommMonCat.ofHom f)
+@[to_additive (attr := deprecated
+  "Proven by `simp only [CommMonCat.hom_id, comp_id]`"
+  (since := "2025-01-28"))]
+theorem MonoidHom.comp_id_commMonCat {G : CommMonCat.{u}} {H : Type u} [CommMonoid H] (f : G →* H) :
+    f.comp (CommMonCat.Hom.hom (𝟙 G)) = f := by
+  simp
+@[to_additive (attr := deprecated
+  "Proven by `simp only [CommMonCat.hom_id, id_comp]`"
+  (since := "2025-01-28"))]
+theorem MonoidHom.id_commMonCat_comp {G : Type u} [CommMonoid G] {H : CommMonCat.{u}} (f : G →* H) :
+    MonoidHom.comp (CommMonCat.Hom.hom (𝟙 H)) f = f := by
+  simp

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -5,7 +5,7 @@ Authors: Kim Morrison
 -/
 import Mathlib.Algebra.PUnitInstances.Algebra
 import Mathlib.Algebra.Group.ULift
-import Mathlib.CategoryTheory.ConcreteCategory.BundledHom
+import Mathlib.CategoryTheory.ConcreteCategory.Basic
 import Mathlib.CategoryTheory.Functor.ReflectsIso
 import Mathlib.Algebra.Ring.Action.Group
 

--- a/Mathlib/Algebra/Category/MonCat/Colimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Colimits.lean
@@ -141,17 +141,18 @@ theorem quot_mul (x y : Prequotient F) : Quot.mk Setoid.r (mul x y) =
 
 /-- The bundled monoid giving the colimit of a diagram. -/
 def colimit : MonCat :=
-  ⟨ColimitType F, by infer_instance⟩
+  of (ColimitType F)
 
 /-- The function from a given monoid in the diagram to the colimit monoid. -/
 def coconeFun (j : J) (x : F.obj j) : ColimitType F :=
   Quot.mk _ (Prequotient.of j x)
 
 /-- The monoid homomorphism from a given monoid in the diagram to the colimit monoid. -/
-def coconeMorphism (j : J) : F.obj j ⟶ colimit F where
-  toFun := coconeFun F j
-  map_one' := Quot.sound (Relation.one _)
-  map_mul' _ _ := Quot.sound (Relation.mul _ _ _)
+def coconeMorphism (j : J) : F.obj j ⟶ colimit F :=
+  ofHom
+  { toFun := coconeFun F j
+    map_one' := Quot.sound (Relation.one _)
+    map_mul' _ _ := Quot.sound (Relation.mul _ _ _) }
 
 @[simp]
 theorem cocone_naturality {j j' : J} (f : j ⟶ j') :
@@ -188,8 +189,8 @@ def descFun (s : Cocone F) : ColimitType F → s.pt := by
     | symm x y _ h => exact h.symm
     | trans x y z _ _ h₁ h₂ => exact h₁.trans h₂
     | map j j' f x => exact s.w_apply f x
-    | mul j x y => exact map_mul (s.ι.app j) x y
-    | one j => exact map_one (s.ι.app j)
+    | mul j x y => exact map_mul (s.ι.app j).hom x y
+    | one j => exact map_one (s.ι.app j).hom
     | mul_1 x x' y _ h => exact congr_arg (· * _) h
     | mul_2 x y y' _ h => exact congr_arg (_ * ·) h
     | mul_assoc x y z => exact mul_assoc _ _ _
@@ -197,15 +198,16 @@ def descFun (s : Cocone F) : ColimitType F → s.pt := by
     | mul_one x => exact mul_one _
 
 /-- The monoid homomorphism from the colimit monoid to the cone point of any other cocone. -/
-def descMorphism (s : Cocone F) : colimit F ⟶ s.pt where
-  toFun := descFun F s
-  map_one' := rfl
-  map_mul' x y := by
-    induction x using Quot.inductionOn
-    induction y using Quot.inductionOn
-    dsimp [descFun]
-    rw [← quot_mul]
-    simp only [descFunLift]
+def descMorphism (s : Cocone F) : colimit F ⟶ s.pt :=
+  ofHom
+  { toFun := descFun F s
+    map_one' := rfl
+    map_mul' x y := by
+      induction x using Quot.inductionOn
+      induction y using Quot.inductionOn
+      dsimp [descFun]
+      rw [← quot_mul]
+      simp only [descFunLift] }
 
 /-- Evidence that the proposed colimit is the colimit. -/
 def colimitIsColimit : IsColimit (colimitCocone F) where

--- a/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
@@ -233,18 +233,19 @@ noncomputable def colimit : MonCat.{max v u} :=
 @[to_additive
       "The additive monoid homomorphism from a given additive monoid in the diagram to the
       colimit additive monoid."]
-def coconeMorphism (j : J) : F.obj j ⟶ colimit F where
-  toFun := (Types.TypeMax.colimitCocone.{v, max v u, v} (F ⋙ forget MonCat)).ι.app j
-  map_one' := (colimit_one_eq F j).symm
-  map_mul' x y := by
-    convert (colimit_mul_mk_eq F ⟨j, x⟩ ⟨j, y⟩ j (𝟙 j) (𝟙 j)).symm
-    rw [F.map_id]
-    rfl
+def coconeMorphism (j : J) : F.obj j ⟶ colimit F :=
+  ofHom
+  { toFun := (Types.TypeMax.colimitCocone.{v, max v u, v} (F ⋙ forget MonCat)).ι.app j
+    map_one' := (colimit_one_eq F j).symm
+    map_mul' x y := by
+      convert (colimit_mul_mk_eq F ⟨j, x⟩ ⟨j, y⟩ j (𝟙 j) (𝟙 j)).symm
+      rw [F.map_id]
+      rfl }
 
 @[to_additive (attr := simp)]
 theorem cocone_naturality {j j' : J} (f : j ⟶ j') :
     F.map f ≫ coconeMorphism.{v, u} F j' = coconeMorphism F j :=
-  MonoidHom.ext fun x =>
+  MonCat.ext fun x =>
     congr_fun ((Types.TypeMax.colimitCocone (F ⋙ forget MonCat)).ι.naturality f) x
 
 /-- The cocone over the proposed colimit monoid. -/
@@ -262,38 +263,39 @@ The only thing left to see is that it is a monoid homomorphism.
       to the cocone point. As a function, this is simply given by the induced map of the
       corresponding cocone in `Type`. The only thing left to see is that it is an additive monoid
       homomorphism."]
-def colimitDesc (t : Cocone F) : colimit.{v, u} F ⟶ t.pt where
-  toFun := (Types.TypeMax.colimitCoconeIsColimit.{v, max v u, v} (F ⋙ forget MonCat)).desc
-    ((forget MonCat).mapCocone t)
-  map_one' := by
-    rw [colimit_one_eq F IsFiltered.nonempty.some]
-    exact MonoidHom.map_one _
-  map_mul' x y := by
-    refine Quot.induction_on₂ x y ?_
-    clear x y
-    intro x y
-    obtain ⟨i, x⟩ := x
-    obtain ⟨j, y⟩ := y
-    rw [colimit_mul_mk_eq F ⟨i, x⟩ ⟨j, y⟩ (max' i j) (IsFiltered.leftToMax i j)
-      (IsFiltered.rightToMax i j)]
-    dsimp [Types.TypeMax.colimitCoconeIsColimit]
-    -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-    erw [MonoidHom.map_mul]
-    -- Porting note: `rw` can't see through coercion is actually forgetful functor,
-    -- so can't rewrite `t.w_apply`
-    congr 1 <;>
-    exact t.w_apply _ _
+def colimitDesc (t : Cocone F) : colimit.{v, u} F ⟶ t.pt :=
+  ofHom
+  { toFun := (Types.TypeMax.colimitCoconeIsColimit.{v, max v u, v} (F ⋙ forget MonCat)).desc
+      ((forget MonCat).mapCocone t)
+    map_one' := by
+      rw [colimit_one_eq F IsFiltered.nonempty.some]
+      exact MonoidHom.map_one _
+    map_mul' x y := by
+      refine Quot.induction_on₂ x y ?_
+      clear x y
+      intro x y
+      obtain ⟨i, x⟩ := x
+      obtain ⟨j, y⟩ := y
+      rw [colimit_mul_mk_eq F ⟨i, x⟩ ⟨j, y⟩ (max' i j) (IsFiltered.leftToMax i j)
+        (IsFiltered.rightToMax i j)]
+      dsimp [Types.TypeMax.colimitCoconeIsColimit]
+      -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
+      erw [MonoidHom.map_mul]
+      -- Porting note: `rw` can't see through coercion is actually forgetful functor,
+      -- so can't rewrite `t.w_apply`
+      congr 1 <;>
+      exact t.w_apply _ _ }
 
 /-- The proposed colimit cocone is a colimit in `MonCat`. -/
 @[to_additive "The proposed colimit cocone is a colimit in `AddMonCat`."]
 def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
   desc := colimitDesc.{v, u} F
-  fac t j := MonoidHom.ext fun x => congr_fun ((Types.TypeMax.colimitCoconeIsColimit.{v, u}
+  fac t j := MonCat.ext fun x => congr_fun ((Types.TypeMax.colimitCoconeIsColimit.{v, u}
     (F ⋙ forget MonCat)).fac ((forget MonCat).mapCocone t) j) x
-  uniq t m h := MonoidHom.ext fun y => congr_fun
+  uniq t m h := MonCat.ext fun y => congr_fun
       ((Types.TypeMax.colimitCoconeIsColimit (F ⋙ forget MonCat)).uniq ((forget MonCat).mapCocone t)
         ((forget MonCat).map m)
-        fun j => funext fun x => DFunLike.congr_fun (i := MonCat.instFunLike _ _) (h j) x) y
+        fun j => funext fun x => ConcreteCategory.congr_hom (h j) x) y
 
 @[to_additive]
 instance forget_preservesFilteredColimits :
@@ -348,25 +350,28 @@ noncomputable def colimit : CommMonCat.{max v u} :=
 @[to_additive "The cocone over the proposed colimit additive commutative monoid."]
 noncomputable def colimitCocone : Cocone F where
   pt := colimit.{v, u} F
-  ι := { (MonCat.FilteredColimits.colimitCocone.{v, u}
-    (F ⋙ forget₂ CommMonCat MonCat.{max v u})).ι with }
+  ι.app j := ofHom ((MonCat.FilteredColimits.colimitCocone.{v, u}
+    (F ⋙ forget₂ CommMonCat MonCat.{max v u})).ι.app j).hom
+  ι.naturality _ _ f := hom_ext <| congr_arg (MonCat.Hom.hom)
+    ((MonCat.FilteredColimits.colimitCocone.{v, u}
+      (F ⋙ forget₂ CommMonCat MonCat.{max v u})).ι.naturality f)
 
 /-- The proposed colimit cocone is a colimit in `CommMonCat`. -/
 @[to_additive "The proposed colimit cocone is a colimit in `AddCommMonCat`."]
 def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
-  desc t :=
-    MonCat.FilteredColimits.colimitDesc.{v, u} (F ⋙ forget₂ CommMonCat MonCat.{max v u})
-      ((forget₂ CommMonCat MonCat.{max v u}).mapCocone t)
+  desc t := ofHom
+    (MonCat.FilteredColimits.colimitDesc.{v, u} (F ⋙ forget₂ CommMonCat MonCat.{max v u})
+      ((forget₂ CommMonCat MonCat.{max v u}).mapCocone t)).hom
   fac t j :=
-    DFunLike.coe_injective (i := CommMonCat.instFunLike _ _) <|
+    ConcreteCategory.coe_ext <|
       (Types.TypeMax.colimitCoconeIsColimit.{v, u} (F ⋙ forget CommMonCat.{max v u})).fac
         ((forget CommMonCat).mapCocone t) j
   uniq t m h :=
-    DFunLike.coe_injective (i := CommMonCat.instFunLike _ _) <|
+    ConcreteCategory.coe_ext <|
       (Types.TypeMax.colimitCoconeIsColimit.{v, u} (F ⋙ forget CommMonCat.{max v u})).uniq
         ((forget CommMonCat.{max v u}).mapCocone t)
         ((forget CommMonCat.{max v u}).map m) fun j => funext fun x =>
-          DFunLike.congr_fun (i := CommMonCat.instFunLike _ _) (h j) x
+          CategoryTheory.congr_fun (h j) x
 
 @[to_additive forget₂AddMonPreservesFilteredColimits]
 noncomputable instance forget₂Mon_preservesFilteredColimits :

--- a/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
@@ -101,7 +101,8 @@ theorem colimitMulAux_eq_of_rel_left {x x' y : Σ j, F.obj j}
     colimitMulAux.{v, u} F x y = colimitMulAux.{v, u} F x' y := by
   obtain ⟨j₁, x⟩ := x; obtain ⟨j₂, y⟩ := y; obtain ⟨j₃, x'⟩ := x'
   obtain ⟨l, f, g, hfg⟩ := hxx'
-  simp? at hfg says simp only [Functor.comp_obj, Functor.comp_map, forget_map] at hfg
+  simp? at hfg says
+    simp only [Functor.comp_obj, Functor.comp_map, ConcreteCategory.forget_map_eq_coe] at hfg
   obtain ⟨s, α, β, γ, h₁, h₂, h₃⟩ :=
     IsFiltered.tulip (IsFiltered.leftToMax j₁ j₂) (IsFiltered.rightToMax j₁ j₂)
       (IsFiltered.rightToMax j₃ j₂) (IsFiltered.leftToMax j₃ j₂) f g

--- a/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
@@ -57,23 +57,27 @@ end AddMonoidHom
 /-- The forgetful functor `MonCat.{u} ⥤ Type u` is corepresentable. -/
 def MonCat.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} (Multiplicative ℕ)))) ≅ forget MonCat.{u} :=
-  (NatIso.ofComponents (fun M => (MonoidHom.fromULiftMultiplicativeNatEquiv M.α).toIso))
+  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
+    (MonoidHom.fromULiftMultiplicativeNatEquiv M.carrier)).toIso))
 
 
 /-- The forgetful functor `CommMonCat.{u} ⥤ Type u` is corepresentable. -/
 def CommMonCat.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} (Multiplicative ℕ)))) ≅ forget CommMonCat.{u} :=
-  (NatIso.ofComponents (fun M => (MonoidHom.fromULiftMultiplicativeNatEquiv M.α).toIso))
+  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
+    (MonoidHom.fromULiftMultiplicativeNatEquiv M.carrier)).toIso))
 
 /-- The forgetful functor `AddMonCat.{u} ⥤ Type u` is corepresentable. -/
 def AddMonCat.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} ℕ))) ≅ forget AddMonCat.{u} :=
-  (NatIso.ofComponents (fun M => (AddMonoidHom.fromULiftNatEquiv M.α).toIso))
+  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
+    (AddMonoidHom.fromULiftNatEquiv M.carrier)).toIso))
 
 /-- The forgetful functor `AddCommMonCat.{u} ⥤ Type u` is corepresentable. -/
 def AddCommMonCat.coyonedaObjIsoForget :
     coyoneda.obj (op (of (ULift.{u} ℕ))) ≅ forget AddCommMonCat.{u} :=
-  (NatIso.ofComponents (fun M => (AddMonoidHom.fromULiftNatEquiv M.α).toIso))
+  (NatIso.ofComponents (fun M => (ConcreteCategory.homEquiv.trans
+    (AddMonoidHom.fromULiftNatEquiv M.carrier)).toIso))
 
 instance MonCat.forget_isCorepresentable :
     (forget MonCat.{u}).IsCorepresentable :=

--- a/Mathlib/Algebra/Category/MonCat/Limits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Limits.lean
@@ -87,9 +87,9 @@ namespace HasLimits
 noncomputable def limitCone : Cone F :=
   { pt := MonCat.of (Types.Small.limitCone (F ⋙ forget _)).pt
     π :=
-    { app := limitπMonoidHom F
-      naturality := fun _ _ f =>
-        DFunLike.coe_injective ((Types.Small.limitCone (F ⋙ forget _)).π.naturality f) } }
+    { app j := ofHom (limitπMonoidHom F j)
+      naturality := fun _ _ f => MonCat.ext fun x =>
+        CategoryTheory.congr_hom ((Types.Small.limitCone (F ⋙ forget _)).π.naturality f) x } }
 
 /-- Witness that the limit cone in `MonCat` is a limit cone.
 (Internal use only; use the limits API.)
@@ -97,7 +97,7 @@ noncomputable def limitCone : Cone F :=
 @[to_additive "(Internal use only; use the limits API.)"]
 noncomputable def limitConeIsLimit : IsLimit (limitCone F) := by
   refine IsLimit.ofFaithful (forget MonCat) (Types.Small.limitConeIsLimit.{v,u} _)
-    (fun s => { toFun := _, map_one' := ?_, map_mul' := ?_ }) (fun s => rfl)
+    (fun s => ofHom { toFun := _, map_one' := ?_, map_mul' := ?_ }) (fun s => rfl)
   · simp only [Functor.mapCone_π_app, forget_map, map_one]
     rfl
   · intro x y
@@ -163,14 +163,18 @@ noncomputable instance forget_createsLimit :
   have : Small.{u} (Functor.sections (F ⋙ forget MonCat)) :=
     (Types.hasLimit_iff_small_sections _).mp (HasLimit.mk {cone := c, isLimit := t})
   refine LiftsToLimit.mk (LiftableCone.mk
-    {pt := MonCat.of (Types.Small.limitCone (F ⋙ forget MonCat)).pt, π := NatTrans.mk
-      (limitπMonoidHom F) (MonCat.HasLimits.limitCone F).π.naturality} (Cones.ext
+    { pt := MonCat.of (Types.Small.limitCone (F ⋙ forget MonCat)).pt,
+      π := NatTrans.mk
+        (fun j => ofHom (limitπMonoidHom F j))
+        (MonCat.HasLimits.limitCone F).π.naturality }
+    (Cones.ext
       ((Types.isLimitEquivSections t).trans (equivShrink _)).symm.toIso
       (fun _ ↦ funext (fun _ ↦ by simp; rfl)))) ?_
   refine IsLimit.ofFaithful (forget MonCat.{u}) (Types.Small.limitConeIsLimit.{v,u} _) ?_ ?_
   · intro _
-    refine {toFun := (Types.Small.limitConeIsLimit.{v,u} _).lift ((forget MonCat).mapCone _),
-                      map_one' := by simp; rfl, map_mul' := ?_ }
+    refine ofHom
+      { toFun := (Types.Small.limitConeIsLimit.{v,u} _).lift ((forget MonCat).mapCone _),
+        map_one' := by simp; rfl, map_mul' := ?_ }
     · intro x y
       simp only [Types.Small.limitConeIsLimit_lift, Functor.comp_obj, Functor.mapCone_pt,
           Functor.mapCone_π_app, forget_map, map_mul, mul_of]
@@ -240,10 +244,10 @@ noncomputable instance forget₂CreatesLimit : CreatesLimit F (forget₂ CommMon
     { liftedCone :=
         { pt := CommMonCat.of (Types.Small.limitCone (F ⋙ forget CommMonCat)).pt
           π :=
-            { app := MonCat.limitπMonoidHom (F ⋙ forget₂ CommMonCat.{u} MonCat.{u})
-              naturality :=
-                (MonCat.HasLimits.limitCone
-                      (F ⋙ forget₂ CommMonCat MonCat.{u})).π.naturality } }
+            { app j := ofHom (MonCat.limitπMonoidHom (F ⋙ forget₂ CommMonCat.{u} MonCat.{u}) j)
+              naturality _ _ j := ext <| fun x => congr_hom
+                ((MonCat.HasLimits.limitCone
+                  (F ⋙ forget₂ CommMonCat MonCat.{u})).π.naturality j) x } }
       validLift := by apply IsLimit.uniqueUpToIso (MonCat.HasLimits.limitConeIsLimit _) t
       makesLimit :=
         IsLimit.ofFaithful (forget₂ CommMonCat MonCat.{u})

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -153,12 +153,12 @@ instance {R : SemiRingCat} : Semiring ((forget SemiRingCat).obj R) :=
 instance hasForgetToMonCat : HasForget₂ SemiRingCat MonCat where
   forget₂ :=
     { obj := fun R ↦ MonCat.of R
-      map := fun f ↦ f.hom.toMonoidHom }
+      map := fun f ↦ MonCat.ofHom f.hom.toMonoidHom }
 
 instance hasForgetToAddCommMonCat : HasForget₂ SemiRingCat AddCommMonCat where
   forget₂ :=
     { obj := fun R ↦ AddCommMonCat.of R
-      map := fun f ↦ f.hom.toAddMonoidHom }
+      map := fun f ↦ AddCommMonCat.ofHom f.hom.toAddMonoidHom }
 
 /-- Ring equivalence are isomorphisms in category of semirings -/
 @[simps]
@@ -472,7 +472,7 @@ instance hasForgetToSemiRingCat : HasForget₂ CommSemiRingCat SemiRingCat where
 instance hasForgetToCommMonCat : HasForget₂ CommSemiRingCat CommMonCat where
   forget₂ :=
     { obj := fun R ↦ CommMonCat.of R
-      map := fun f ↦ f.hom.toMonoidHom }
+      map := fun f ↦ CommMonCat.ofHom f.hom.toMonoidHom }
 
 /-- Ring equivalence are isomorphisms in category of semirings -/
 @[simps]

--- a/Mathlib/Algebra/Category/Ring/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/Ring/FilteredColimits.lean
@@ -112,22 +112,22 @@ def colimitCocone : Cocone F where
   pt := colimit.{v, u} F
   ι :=
     { app := fun j => ofHom
-        { (MonCat.FilteredColimits.colimitCocone
-            (F ⋙ forget₂ SemiRingCatMax.{v, u} MonCat)).ι.app j,
-            (AddCommMonCat.FilteredColimits.colimitCocone
-              (F ⋙ forget₂ SemiRingCatMax.{v, u} AddCommMonCat)).ι.app j with }
+        { ((MonCat.FilteredColimits.colimitCocone
+            (F ⋙ forget₂ SemiRingCatMax.{v, u} MonCat)).ι.app j).hom,
+            ((AddCommMonCat.FilteredColimits.colimitCocone
+              (F ⋙ forget₂ SemiRingCatMax.{v, u} AddCommMonCat)).ι.app j).hom with }
       naturality := fun {_ _} f => hom_ext <|
         RingHom.coe_inj ((Types.TypeMax.colimitCocone (F ⋙ forget SemiRingCat)).ι.naturality f) }
 
 /-- The proposed colimit cocone is a colimit in `SemiRingCat`. -/
 def colimitCoconeIsColimit : IsColimit <| colimitCocone.{v, u} F where
   desc t := ofHom
-    { (MonCat.FilteredColimits.colimitCoconeIsColimit.{v, u}
+    { ((MonCat.FilteredColimits.colimitCoconeIsColimit.{v, u}
             (F ⋙ forget₂ SemiRingCatMax.{v, u} MonCat)).desc
-        ((forget₂ SemiRingCatMax.{v, u} MonCat).mapCocone t),
-      (AddCommMonCat.FilteredColimits.colimitCoconeIsColimit.{v, u}
+        ((forget₂ SemiRingCatMax.{v, u} MonCat).mapCocone t)).hom,
+      ((AddCommMonCat.FilteredColimits.colimitCoconeIsColimit.{v, u}
             (F ⋙ forget₂ SemiRingCatMax.{v, u} AddCommMonCat)).desc
-        ((forget₂ SemiRingCatMax.{v, u} AddCommMonCat).mapCocone t) with }
+        ((forget₂ SemiRingCatMax.{v, u} AddCommMonCat).mapCocone t)).hom with }
   fac t j := hom_ext <|
     RingHom.coe_inj <|
       (Types.TypeMax.colimitCoconeIsColimit.{v, u} (F ⋙ forget SemiRingCatMax.{v, u})).fac

--- a/Mathlib/CategoryTheory/Abelian/Pseudoelements.lean
+++ b/Mathlib/CategoryTheory/Abelian/Pseudoelements.lean
@@ -389,7 +389,7 @@ theorem sub_of_eq_image {P Q : C} (f : P ⟶ Q) (x y : P) :
   Quotient.inductionOn₂ x y fun a a' h =>
     match Quotient.exact h with
     | ⟨R, p, q, ep, _, comm⟩ =>
-      let a'' : R ⟶ P := ↑(p ≫ a.hom) - ↑(q ≫ a'.hom)
+      let a'' : R ⟶ P := (p ≫ a.hom : R ⟶ P) - (q ≫ a'.hom : R ⟶ P)
       ⟨a'',
         ⟨show ⟦(a'' ≫ f : Over Q)⟧ = ⟦↑(0 : Q ⟶ Q)⟧ by
             dsimp at comm

--- a/Mathlib/CategoryTheory/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Action/Basic.lean
@@ -42,8 +42,7 @@ namespace Action
 
 variable {V}
 
-@[simp]
-theorem ρ_one {G : MonCat.{u}} (A : Action V G) : A.ρ 1 = 𝟙 A.V := by rw [MonoidHom.map_one]; rfl
+theorem ρ_one {G : MonCat.{u}} (A : Action V G) : A.ρ 1 = 𝟙 A.V := by simp
 
 /-- When a group acts, we can lift the action to the group of automorphisms. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Action/Concrete.lean
+++ b/Mathlib/CategoryTheory/Action/Concrete.lean
@@ -24,7 +24,7 @@ namespace Action
 /-- Bundles a type `H` with a multiplicative action of `G` as an `Action`. -/
 def ofMulAction (G H : Type u) [Monoid G] [MulAction G H] : Action (Type u) (MonCat.of G) where
   V := H
-  ρ := @MulAction.toEndHom _ _ _ (by assumption)
+  ρ := MonCat.ofHom <| @MulAction.toEndHom _ _ _ (by assumption)
 
 @[simp]
 theorem ofMulAction_apply {G H : Type u} [Monoid G] [MulAction G H] (g : G) (x : H) :
@@ -80,7 +80,7 @@ instance (G : Type*) (X : Type*) [Monoid G] [MulAction G X] [Fintype X] :
 def ofMulAction (G : Type u) (H : FintypeCat.{u}) [Monoid G] [MulAction G H] :
     Action FintypeCat (MonCat.of G) where
   V := H
-  ρ := @MulAction.toEndHom _ _ _ (by assumption)
+  ρ := MonCat.ofHom <| @MulAction.toEndHom _ _ _ (by assumption)
 
 @[simp]
 theorem ofMulAction_apply {G : Type u} {H : FintypeCat.{u}} [Monoid G] [MulAction G H]
@@ -174,12 +174,11 @@ instance instMulAction {G : MonCat.{u}} (X : Action V G) :
   smul g x := ((CategoryTheory.forget _).map (X.ρ g)) x
   one_smul x := by
     show ((CategoryTheory.forget _).map (X.ρ 1)) x = x
-    simp only [Action.ρ_one, FunctorToTypes.map_id_apply]
+    simp
   mul_smul g h x := by
     show (CategoryTheory.forget V).map (X.ρ (g * h)) x =
       ((CategoryTheory.forget V).map (X.ρ h) ≫ (CategoryTheory.forget V).map (X.ρ g)) x
-    rw [← Functor.map_comp, map_mul]
-    rfl
+    simp
 
 /- Specialize `instMulAction` to assist typeclass inference. -/
 instance {G : MonCat.{u}} (X : Action FintypeCat G) : MulAction G X.V := Action.instMulAction X

--- a/Mathlib/CategoryTheory/Action/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Action/Monoidal.lean
@@ -223,8 +223,8 @@ noncomputable def leftRegularTensorIso (G : Type u) [Group G] (X : Action (Type 
       comm := fun (g : G) => by
         funext ⟨(x₁ : G), (x₂ : X.V)⟩
         refine Prod.ext rfl ?_
-        -- This used to be `rw`, but we need `erw` after the concrete `MonCat` refactor.
-        erw [tensor_ρ, tensor_ρ]
+        dsimp [leftRegular] -- Unfold `leftRegular` so `rw` can see through `(leftRegular V).V = V`
+        rw [tensor_ρ, tensor_ρ]
         dsimp
         -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
         erw [leftRegular_ρ_hom_apply]

--- a/Mathlib/CategoryTheory/Action/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Action/Monoidal.lean
@@ -47,7 +47,10 @@ theorem tensorUnit_ρ' {g : G} :
 
 @[simp]
 theorem tensorUnit_ρ {g : G} :
-    ConcreteCategory.hom (Y := (MonCat.of (End (𝟙_ V)))) (𝟙_ (Action V G)).ρ g = 𝟙 (𝟙_ V) :=
+    -- Have to hint `F` here, otherwise `simp` doesn't reduce `↑(MonCat.of (End _))` to `End _`.
+    DFunLike.coe (F := _ →* End _)
+      -- Have to hint `Y` here for `simpNF` reasons.
+      (ConcreteCategory.hom (Y := MonCat.of (End (𝟙_ V))) (𝟙_ (Action V G)).ρ) g = 𝟙 (𝟙_ V) :=
   rfl
 
 /- Adding this solves `simpNF` linter report at `tensor_ρ` -/
@@ -58,14 +61,17 @@ theorem tensor_ρ' {X Y : Action V G} {g : G} :
 
 @[simp]
 theorem tensor_ρ {X Y : Action V G} {g : G} :
-    ConcreteCategory.hom (Y := MonCat.of (End (X.V ⊗ Y.V))) (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
+    -- Have to hint `F` here, otherwise `simp` doesn't reduce `↑(MonCat.of (End _))` to `End _`.
+    DFunLike.coe (F := _ →* End _)
+      -- Have to hint `Y` here for `simpNF` reasons.
+      (ConcreteCategory.hom (Y := MonCat.of (End (tensorObj X.V Y.V))) (X ⊗ Y).ρ) g =
+    X.ρ g ⊗ Y.ρ g :=
   rfl
 
 /-- Given an object `X` isomorphic to the tensor unit of `V`, `X` equipped with the trivial action
 is isomorphic to the tensor unit of `Action V G`. -/
 def tensorUnitIso {X : V} (f : 𝟙_ V ≅ X) : 𝟙_ (Action V G) ≅ Action.mk X 1 :=
-  -- `aesop` failed here because `simp` doesn't pick up `tensorUnit_ρ`...
-  Action.mkIso f (comm := by intros; simp [(tensorUnit_ρ)])
+  Action.mkIso f
 
 variable (V G)
 
@@ -92,7 +98,7 @@ variable [BraidedCategory V]
 
 instance : BraidedCategory (Action V G) :=
   braidedCategoryOfFaithful (Action.forget V G) (fun X Y => mkIso (β_ _ _)
-    (fun g => by simp [FunctorCategoryEquivalence.inverse, (tensor_ρ)])) (by simp)
+    (fun g => by simp [FunctorCategoryEquivalence.inverse])) (by simp)
 
 /-- When `V` is braided the forgetful functor `Action V G` to `V` is braided. -/
 instance : (Action.forget V G).Braided where
@@ -264,7 +270,7 @@ instance [F.LaxMonoidal] : (F.mapAction G).LaxMonoidal where
     { hom := ε F
       comm := fun g => by
         dsimp [FunctorCategoryEquivalence.inverse, Functor.mapAction]
-        rw [tensorUnit_ρ, Category.id_comp, tensorUnit_ρ, F.map_id, Category.comp_id] }
+        rw [Category.id_comp, F.map_id, Category.comp_id] }
   μ' X Y :=
     { hom := μ F X.V Y.V
       comm := fun g => μ_natural F (X.ρ g) (Y.ρ g) }
@@ -288,7 +294,7 @@ instance [F.OplaxMonoidal] : (F.mapAction G).OplaxMonoidal where
     { hom := η F
       comm := fun g => by
         dsimp [FunctorCategoryEquivalence.inverse, Functor.mapAction]
-        rw [tensorUnit_ρ, map_id, Category.id_comp, tensorUnit_ρ, Category.comp_id] }
+        rw [map_id, Category.id_comp, Category.comp_id] }
   δ' X Y :=
     { hom := δ F X.V Y.V
       comm := fun g => (δ_natural F (X.ρ g) (Y.ρ g)).symm }

--- a/Mathlib/CategoryTheory/Galois/Examples.lean
+++ b/Mathlib/CategoryTheory/Galois/Examples.lean
@@ -51,9 +51,9 @@ noncomputable def Action.imageComplement {X Y : Action FintypeCat (MonCat.of G)}
       calc (X.ρ g⁻¹ ≫ f.hom) x
           = (Y.ρ g⁻¹ * Y.ρ g) y.val := by rw [f.comm, FintypeCat.comp_apply, h]; rfl
         _ = y.val := by rw [← map_mul, inv_mul_cancel, Action.ρ_one, FintypeCat.id_apply]
-    map_one' := by simp only [Action.ρ_one]; rfl
-    map_mul' := fun g h ↦ FintypeCat.hom_ext _ _ <| fun y ↦ Subtype.ext <| by
-      exact congrFun (MonoidHom.map_mul Y.ρ g h) y.val
+    map_one' := by simp only [map_one, End.one_def, FintypeCat.id_apply, Subtype.coe_eta]; rfl
+    map_mul' := fun g h ↦ FintypeCat.hom_ext _ _ <| fun y ↦ Subtype.ext <|
+      congrFun (MonoidHom.map_mul Y.ρ.hom g h) y.val
   }
 
 /-- The inclusion from the complement of the image of `f : X ⟶ Y` into `Y`. -/

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Types.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Types.lean
@@ -34,7 +34,7 @@ instance monMonoid (A : Mon_ (Type u)) : Monoid A.X where
 -/
 noncomputable def functor : Mon_ (Type u) ⥤ MonCat.{u} where
   obj A := MonCat.of A.X
-  map f :=
+  map f := MonCat.ofHom
     { toFun := f.hom
       map_one' := congr_fun f.one_hom PUnit.unit
       map_mul' := fun x y => congr_fun f.mul_hom (x, y) }
@@ -70,11 +70,11 @@ noncomputable def monTypeEquivalenceMon : Mon_ (Type u) ≌ MonCat.{u} where
   counitIso :=
     NatIso.ofComponents
       (fun A =>
-        { hom :=
+        { hom := MonCat.ofHom
             { toFun := id
               map_one' := rfl
               map_mul' := fun _ _ => rfl }
-          inv :=
+          inv := MonCat.ofHom
             { toFun := id
               map_one' := rfl
               map_mul' := fun _ _ => rfl } })
@@ -100,7 +100,7 @@ instance commMonCommMonoid (A : CommMon_ (Type u)) : CommMonoid A.X :=
 -/
 noncomputable def functor : CommMon_ (Type u) ⥤ CommMonCat.{u} where
   obj A := CommMonCat.of A.X
-  map f := MonTypeEquivalenceMon.functor.map f
+  map f := CommMonCat.ofHom (MonTypeEquivalenceMon.functor.map f).hom
 
 /-- Converting a bundled commutative monoid to a commutative monoid object in `Type`.
 -/
@@ -131,11 +131,11 @@ noncomputable def commMonTypeEquivalenceCommMon : CommMon_ (Type u) ≌ CommMonC
   counitIso :=
     NatIso.ofComponents
       (fun A =>
-        { hom :=
+        { hom := CommMonCat.ofHom
             { toFun := id
               map_one' := rfl
               map_mul' := fun _ _ => rfl }
-          inv :=
+          inv := CommMonCat.ofHom
             { toFun := id
               map_one' := rfl
               map_mul' := fun _ _ => rfl } })

--- a/Mathlib/CategoryTheory/SingleObj.lean
+++ b/Mathlib/CategoryTheory/SingleObj.lean
@@ -234,12 +234,14 @@ open CategoryTheory
 /-- The fully faithful functor from `MonCat` to `Cat`. -/
 def toCat : MonCat ⥤ Cat where
   obj x := Cat.of (SingleObj x)
-  map {x y} f := SingleObj.mapHom x y f
+  map {x y} f := SingleObj.mapHom x y f.hom
 
 instance toCat_full : toCat.Full where
-  map_surjective := (SingleObj.mapHom _ _).surjective
+  map_surjective y :=
+    let ⟨x, h⟩ := (SingleObj.mapHom _ _).surjective y
+    ⟨ofHom x, h⟩
 
 instance toCat_faithful : toCat.Faithful where
-  map_injective h := by rwa [toCat, (SingleObj.mapHom _ _).apply_eq_iff_eq] at h
+  map_injective h := MonCat.hom_ext <| by rwa [toCat, (SingleObj.mapHom _ _).apply_eq_iff_eq] at h
 
 end MonCat

--- a/Mathlib/RepresentationTheory/FDRep.lean
+++ b/Mathlib/RepresentationTheory/FDRep.lean
@@ -82,16 +82,17 @@ instance (V W : FDRep k G) : FiniteDimensional k (V ⟶ W) :=
 
 /-- The monoid homomorphism corresponding to the action of `G` onto `V : FDRep k G`. -/
 def ρ (V : FDRep k G) : G →* V →ₗ[k] V :=
-  (ModuleCat.endRingEquiv _).toMonoidHom.comp (Action.ρ V)
+  (ModuleCat.endRingEquiv _).toMonoidHom.comp (Action.ρ V).hom
 
 @[simp]
 lemma endRingEquiv_symm_comp_ρ (V : FDRep k G) :
-    (MonoidHomClass.toMonoidHom (ModuleCat.endRingEquiv V.V.obj).symm).comp (ρ V) = Action.ρ V :=
+    (MonoidHomClass.toMonoidHom (ModuleCat.endRingEquiv V.V.obj).symm).comp (ρ V) =
+      (Action.ρ V).hom :=
   rfl
 
 @[simp]
 lemma endRingEquiv_comp_ρ (V : FDRep k G) :
-    (MonoidHomClass.toMonoidHom (ModuleCat.endRingEquiv V.V.obj)).comp (Action.ρ V) = ρ V := rfl
+    (MonoidHomClass.toMonoidHom (ModuleCat.endRingEquiv V.V.obj)).comp (Action.ρ V).hom = ρ V := rfl
 
 @[simp]
 lemma hom_action_ρ (V : FDRep k G) (g : G) : (Action.ρ V g).hom = ρ V g := rfl
@@ -112,7 +113,8 @@ theorem Iso.conj_ρ {V W : FDRep k G} (i : V ≅ W) (g : G) :
 @[simps ρ]
 def of {V : Type u} [AddCommGroup V] [Module k V] [FiniteDimensional k V]
     (ρ : Representation k G V) : FDRep k G :=
-  ⟨FGModuleCat.of k V, ρ ≫ MonCat.ofHom (ModuleCat.endRingEquiv _).symm.toMonoidHom⟩
+  ⟨FGModuleCat.of k V, MonCat.ofHom ρ ≫ MonCat.ofHom
+    (ModuleCat.endRingEquiv (ModuleCat.of k V)).symm.toMonoidHom⟩
 
 instance : HasForget₂ (FDRep k G) (Rep k G) where
   forget₂ := (forget₂ (FGModuleCat k) (ModuleCat k)).mapAction (MonCat.of G)

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -205,8 +205,9 @@ theorem diagonalSucc_inv_single_left (g : G) (f : Gⁿ →₀ k) (r : k) :
   refine f.induction ?_ ?_
   · simp only [TensorProduct.tmul_zero, map_zero]
   · intro a b x _ _ hx
+    -- `simp` doesn't pick up on `diagonalSucc_inv_single_single` unless it has parentheses.
     simp only [lift_apply, smul_single', mul_one, TensorProduct.tmul_add, map_add,
-      diagonalSucc_inv_single_single, hx, Finsupp.sum_single_index, mul_comm b,
+      (diagonalSucc_inv_single_single), hx, Finsupp.sum_single_index, mul_comm b,
       zero_mul, single_zero]
 
 theorem diagonalSucc_inv_single_right (g : G →₀ k) (f : Gⁿ) (r : k) :
@@ -215,7 +216,8 @@ theorem diagonalSucc_inv_single_right (g : G →₀ k) (f : Gⁿ) (r : k) :
   refine g.induction ?_ ?_
   · simp only [TensorProduct.zero_tmul, map_zero]
   · intro a b x _ _ hx
-    simp only [lift_apply, smul_single', map_add, hx, diagonalSucc_inv_single_single,
+    -- `simp` doesn't pick up on `diagonalSucc_inv_single_single` unless it has parentheses.
+    simp only [lift_apply, smul_single', map_add, hx, (diagonalSucc_inv_single_single),
       TensorProduct.add_tmul, Finsupp.sum_single_index, zero_mul, single_zero]
 
 end Rep

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -61,7 +61,7 @@ instance (V : Rep k G) : Module k V := by
 -/
 def ρ (V : Rep k G) : Representation k G V :=
 -- Porting note: was `V.ρ`
-  (ModuleCat.endRingEquiv V.V).toMonoidHom.comp (Action.ρ V)
+  (ModuleCat.endRingEquiv V.V).toMonoidHom.comp (Action.ρ V).hom
 
 /-- Lift an unbundled representation to `Rep`. -/
 def of {V : Type u} [AddCommGroup V] [Module k V] (ρ : G →* V →ₗ[k] V) : Rep k G :=
@@ -77,7 +77,7 @@ theorem of_ρ {V : Type u} [AddCommGroup V] [Module k V] (ρ : G →* V →ₗ[k
   rfl
 
 theorem Action_ρ_eq_ρ {A : Rep k G} :
-    Action.ρ A = (ModuleCat.endRingEquiv _).symm.toMonoidHom.comp A.ρ :=
+    Action.ρ A = MonCat.ofHom ((ModuleCat.endRingEquiv _).symm.toMonoidHom.comp A.ρ) :=
   rfl
 
 @[simp]

--- a/MathlibTest/CategoryTheory/ConcreteCategory/MonCat.lean
+++ b/MathlibTest/CategoryTheory/ConcreteCategory/MonCat.lean
@@ -1,0 +1,50 @@
+import Mathlib.Algebra.Category.MonCat.Basic
+
+universe v u
+
+open CategoryTheory MonCat
+
+set_option maxHeartbeats 10000
+set_option synthInstance.maxHeartbeats 2000
+
+/- We test if all the coercions and `map_mul` lemmas trigger correctly. -/
+
+example (X : Type u) [Monoid X] : ⇑(𝟙 (of X)) = id := by simp
+
+example {X Y : Type u} [Monoid X] [Monoid Y] (f : X →* Y) :
+    ⇑(ofHom f) = ⇑f := by simp
+
+example {X Y : Type u} [Monoid X] [Monoid Y] (f : X →* Y)
+    (x : X) : (ofHom f) x = f x := by simp
+
+example {X Y Z : MonCat} (f : X ⟶ Y) (g : Y ⟶ Z) : ⇑(f ≫ g) = ⇑g ∘ ⇑f := by simp
+
+example {X Y Z : Type u} [Monoid X] [Monoid Y] [Monoid Z]
+    (f : X →* Y) (g : Y →* Z) :
+    ⇑(ofHom f ≫ ofHom g) = g ∘ f := by simp
+
+example {X Y : Type u} [Monoid X] [Monoid Y] {Z : MonCat}
+    (f : X →* Y) (g : of Y ⟶ Z) :
+    ⇑(ofHom f ≫ g) = g ∘ f := by simp
+
+example {X Y : MonCat} {Z : Type u} [Monoid Z] (f : X ⟶ Y) (g : Y ⟶ of Z) :
+    ⇑(f ≫ g) = g ∘ f := by simp
+
+example {Y Z : MonCat} {X : Type u} [Monoid X] (f : of X ⟶ Y) (g : Y ⟶ Z) :
+    ⇑(f ≫ g) = g ∘ f := by simp
+
+example {X Y Z : MonCat} (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) : (f ≫ g) x = g (f x) := by simp
+
+example {X Y : MonCat} (e : X ≅ Y) (x : X) : e.inv (e.hom x) = x := by simp
+
+example {X Y : MonCat} (e : X ≅ Y) (y : Y) : e.hom (e.inv y) = y := by simp
+
+example (X : MonCat) : ⇑(𝟙 X) = id := by simp
+
+example {X : Type*} [Monoid X] : ⇑(MonoidHom.id X) = id := by simp
+
+example {M N : MonCat} (f : M ⟶ N) (x y : M) : f (x * y) = f x * f y := by
+  simp
+
+example {M N : MonCat} (f : M ⟶ N) : f 1 = 1 := by
+  simp

--- a/MathlibTest/MonCat.lean
+++ b/MathlibTest/MonCat.lean
@@ -3,7 +3,7 @@ import Mathlib.Algebra.Category.MonCat.Basic
 -- We verify that the coercions of morphisms to functions work correctly:
 example {R S : MonCat} (f : R ⟶ S) : ↑R → ↑S := f
 
--- Porting note: it's essential that simp lemmas for `→*` apply to morphisms.
+-- It's essential that simp lemmas for `→*` apply to morphisms.
 example {R S : MonCat} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 := by simp [h]
 
 example {R S : CommMonCat} (f : R ⟶ S) : ↑R → ↑S := f
@@ -12,7 +12,7 @@ example {R S : CommMonCat} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 := by sim
 
 -- We verify that when constructing a morphism in `CommMonCat`,
 -- when we construct the `toFun` field, the types are presented as `↑R`.
-example (R : CommMonCat.{u}) : R ⟶ R :=
+example (R : CommMonCat.{u}) : R ⟶ R := CommMonCat.ofHom
   { toFun := fun x => by
       match_target (R : Type u)
       guard_hyp x : (R : Type u)


### PR DESCRIPTION
This is a step towards a concrete category redesign, as outlined in this Zulip post: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Concrete.20category.20class.20redesign/near/493903980

This PR updates the concrete category definitions of (Add)(Comm)MonCat to match the standard set by AlgebraCat, ModuleCat and RingCat:

* Package objects and homs into structures.
* Replace HasForget with ConcreteCategory.
* Set up a good @[simp] set.
* Ensure constructors and projections are reducible. See MathlibTest/CategoryTheory/ConcreteCategory/MonCat.lean for the specification of all the new functionality.

Currently there are still a couple issues around actions and tensor products, where `simp [the_lemma]` doesn't work even though `simp [(the_lemma)]` does. Not sure why this is happening, the discrimination tree keys look perfectly normal and `trace.Meta.Tactic.simp` doesn't say anything useful.

I have not tried to look for code that can be cleaned up now, only at what broke. I want to get started on cleanup when the other concrete category instances are in.

---

- [ ] depends on: #21192 
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
