### PR TITLE
[Merged by Bors] - chore: replace `open scoped Classical`with `open scoped Classical in` or `classical` in a tactic proof

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
@@ -32,7 +32,6 @@ lemma Complex.summable_log_one_add_of_summable {f : ι → ℂ} (hf : Summable f
   filter_upwards [hf.norm.tendsto_cofinite_zero.eventually_le_const one_half_pos] with i hi
   exact norm_log_one_add_half_le_self hi
 
-
 lemma Real.summable_log_one_add_of_summable {f : ι → ℝ} (hf : Summable f) :
      Summable (fun i : ι => log (1 + |f i|)) := by
   have : Summable (fun n ↦ Complex.ofRealCLM (log (1 + |f n|))) := by

--- a/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
@@ -22,7 +22,7 @@ products.
 
 open Filter Function Complex Real
 
-open scoped Interval Topology BigOperators Nat Classical Complex
+open scoped Interval Topology BigOperators Nat Complex
 
 variable {ι : Type*}
 
@@ -31,6 +31,7 @@ lemma Complex.summable_log_one_add_of_summable {f : ι → ℂ} (hf : Summable f
   apply (hf.norm.const_smul (3 / 2 : ℝ)).of_norm_bounded_eventually
   filter_upwards [hf.norm.tendsto_cofinite_zero.eventually_le_const one_half_pos] with i hi
   exact norm_log_one_add_half_le_self hi
+
 
 lemma Real.summable_log_one_add_of_summable {f : ι → ℝ} (hf : Summable f) :
      Summable (fun i : ι => log (1 + |f i|)) := by

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -54,7 +54,7 @@ noncomputable section
 
 open Function Set MeasureTheory.OuterMeasure Filter MeasurableSpace Encodable
 
-open scoped Classical Topology ENNReal
+open scoped Topology ENNReal
 
 universe u v
 
@@ -168,6 +168,7 @@ open List MeasurableEquiv
 
 variable [Encodable ι]
 
+open scoped Classical in
 /-- The product measure on an encodable finite type, defined by mapping `Measure.tprod` along the
   equivalence `MeasurableEquiv.piMeasurableEquivTProd`.
   The definition `MeasureTheory.Measure.pi` should be used instead of this one. -/
@@ -176,6 +177,7 @@ def pi' : Measure (∀ i, α i) :=
 
 theorem pi'_pi [∀ i, SigmaFinite (μ i)] (s : ∀ i, Set (α i)) :
     pi' μ (pi univ s) = ∏ i, μ i (s i) := by
+  classical
   rw [pi']
   rw [← MeasurableEquiv.piMeasurableEquivTProd_symm_apply, MeasurableEquiv.map_apply,
     MeasurableEquiv.piMeasurableEquivTProd_symm_apply, elim_preimage_pi, tprod_tprod _ μ, ←
@@ -342,6 +344,7 @@ theorem pi_empty_univ {α : Type*} [Fintype α] [IsEmpty α] {β : α → Type*}
 
 theorem pi_eval_preimage_null {i : ι} {s : Set (α i)} (hs : μ i s = 0) :
     Measure.pi μ (eval i ⁻¹' s) = 0 := by
+  classical
   -- WLOG, `s` is measurable
   rcases exists_measurable_superset_of_null hs with ⟨t, hst, _, hμt⟩
   suffices Measure.pi μ (eval i ⁻¹' t) = 0 from measure_mono_null (preimage_mono hst) this

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -69,7 +69,7 @@ conditional expectation, conditional expected value
 -/
 
 open TopologicalSpace MeasureTheory.Lp Filter
-open scoped Classical ENNReal Topology MeasureTheory
+open scoped ENNReal Topology MeasureTheory
 
 namespace MeasureTheory
   -- 𝕜 for ℝ or ℂ
@@ -80,6 +80,7 @@ variable {α β E 𝕜 : Type*} [RCLike 𝕜] {m m₀ : MeasurableSpace α} {μ 
 section NormedAddCommGroup
 variable [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
 
+open scoped Classical in
 variable (m) in
 /-- Conditional expectation of a function. It is defined as 0 if any one of the following conditions
 is true:
@@ -108,6 +109,7 @@ theorem condExp_of_not_sigmaFinite (hm : m ≤ m₀) (hμm_not : ¬SigmaFinite (
 
 @[deprecated (since := "2025-01-21")] alias condexp_of_not_sigmaFinite := condExp_of_not_sigmaFinite
 
+open scoped Classical in
 theorem condExp_of_sigmaFinite (hm : m ≤ m₀) [hμm : SigmaFinite (μ.trim hm)] :
     μ[f|m] =
       if Integrable f μ then
@@ -320,6 +322,7 @@ theorem condExp_add (hf : Integrable f μ) (hg : Integrable g μ) (m : Measurabl
 theorem condExp_finset_sum {ι : Type*} {s : Finset ι} {f : ι → α → E}
     (hf : ∀ i ∈ s, Integrable (f i) μ) (m : MeasurableSpace α) :
     μ[∑ i ∈ s, f i|m] =ᵐ[μ] ∑ i ∈ s, μ[f i|m] := by
+  classical
   induction' s using Finset.induction_on with i s his heq hf
   · rw [Finset.sum_empty, Finset.sum_empty, condExp_zero]
   · rw [Finset.sum_insert his, Finset.sum_insert his]

--- a/Mathlib/Order/DirectedInverseSystem.lean
+++ b/Mathlib/Order/DirectedInverseSystem.lean
@@ -144,15 +144,13 @@ theorem mk_injective (h : ∀ i j hij, Function.Injective (f i j hij)) (i) :
 
 section map₀
 
-open Classical (arbitrary)
-
 variable [Nonempty ι] (ih : ∀ i, F i)
 
 /-- "Nullary map" to construct an element in the direct limit. -/
-noncomputable def map₀ : DirectLimit F f := ⟦⟨arbitrary ι, ih _⟩⟧
+noncomputable def map₀ : DirectLimit F f := ⟦⟨Classical.arbitrary ι, ih _⟩⟧
 
 theorem map₀_def (compat : ∀ i j h, f i j h (ih i) = ih j) (i) : map₀ f ih = ⟦⟨i, ih i⟩⟧ :=
-  have ⟨j, hcj, hij⟩ := exists_ge_ge (arbitrary ι) i
+  have ⟨j, hcj, hij⟩ := exists_ge_ge (Classical.arbitrary ι) i
   Quotient.sound ⟨j, hcj, hij, (compat ..).trans (compat ..).symm⟩
 
 end map₀


### PR DESCRIPTION
reduces some technical debt by replacing `open scoped classical` with `open scoped classical in` or adding a `classical tactic` to a tactic proof.  Used explicit `Classical.arbitrary` in two spots in Mathlib/Order/DirectedInverseSystem.lean 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
