### PR TITLE
[Merged by Bors] - feat: Descriptive.tree basic API

### DIFF
--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -225,11 +225,15 @@ abbrev instSubtype {X S} [SetLike S X] {p : S → Prop} : SetLike {s // p s} X w
   coe_injective' := SetLike.coe_injective.comp Subtype.val_injective
 
 section
+
 attribute [local instance] instSubtypeSet instSubtype
+
 @[simp] lemma mem_mk_set {X} {p : Set X → Prop} {U : Set X} {h : p U} {x : X} :
   x ∈ Subtype.mk U h ↔ x ∈ U := Iff.rfl
+
 @[simp] lemma mem_mk {X S} [SetLike S X] {p : S → Prop} {U : S} {h : p U} {x : X} :
   x ∈ Subtype.mk U h ↔ x ∈ U := Iff.rfl
+
 end
 
 end SetLike

--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -224,4 +224,12 @@ abbrev instSubtype {X S} [SetLike S X] {p : S → Prop} : SetLike {s // p s} X w
   coe := (↑)
   coe_injective' := SetLike.coe_injective.comp Subtype.val_injective
 
+section
+attribute [local instance] instSubtypeSet instSubtype
+@[simp] lemma mem_mk_set {X} {p : Set X → Prop} {U : Set X} {h : p U} {x : X} :
+  x ∈ Subtype.mk U h ↔ x ∈ U := Iff.rfl
+@[simp] lemma mem_mk {X S} [SetLike S X] {p : S → Prop} {U : S} {h : p U} {x : X} :
+  x ∈ Subtype.mk U h ↔ x ∈ U := Iff.rfl
+end
+
 end SetLike

--- a/Mathlib/Order/CompleteLattice/SetLike.lean
+++ b/Mathlib/Order/CompleteLattice/SetLike.lean
@@ -51,6 +51,7 @@ lemma mem_subtype : x ∈ L.subtype T ↔ x ∈ T := Iff.rfl
 @[simp] lemma mem_iSup : x ∈ ⨆ i : I, f i ↔ ∃ i : I, x ∈ f i := by simp [← mem_subtype]
 @[simp] lemma not_mem_bot : ¬ x ∈ (⊥ : L) := by simp [← mem_subtype]
 
-@[simp] lemma mem_mk (U : Set X) (h : U ∈ L) : x ∈ (⟨U, h⟩ : L) ↔ x ∈ U := Iff.rfl
+@[deprecated SetLike.mem_mk_set (since := "2025-01-29")]
+lemma mem_mk (U : Set X) (h : U ∈ L) : x ∈ (⟨U, h⟩ : L) ↔ x ∈ U := by simp
 
 end CompleteSublattice

--- a/Mathlib/Order/CompleteLattice/SetLike.lean
+++ b/Mathlib/Order/CompleteLattice/SetLike.lean
@@ -27,7 +27,9 @@ lemma mem_subtype : x ∈ L.subtype T ↔ x ∈ T := Iff.rfl
 @[simp] lemma setLike_mem_sup : x ∈ S ⊔ T ↔ x ∈ S ∨ x ∈ T := by simp [← mem_subtype]
 
 @[simp] lemma setLike_mem_coe : x ∈ T.val ↔ x ∈ T := Iff.rfl
-@[simp] lemma setLike_mem_mk (U : Set X) (h : U ∈ L) : x ∈ (⟨U, h⟩ : L) ↔ x ∈ U := Iff.rfl
+
+@[deprecated SetLike.mem_mk_set (since := "2025-01-29")]
+lemma setLike_mem_mk (U : Set X) (h : U ∈ L) : x ∈ (⟨U, h⟩ : L) ↔ x ∈ U := by simp
 
 end Sublattice
 

--- a/Mathlib/SetTheory/Descriptive/Tree.lean
+++ b/Mathlib/SetTheory/Descriptive/Tree.lean
@@ -62,7 +62,7 @@ lemma take_mem {n : ℕ} (x : T) : x.val.take n ∈ T :=
 @[simp] lemma take_eq_take {x : T} {m n : ℕ} :
   take m x = take n x ↔ m ⊓ x.val.length = n ⊓ x.val.length := by simp [Subtype.ext_iff]
 
-/-! ### `subAt`
+-- ### `subAt`
 
 variable (T) (x y : List A)
 /-- The residual tree obtained by regarding the node x as new root -/
@@ -81,7 +81,7 @@ def subAt : tree A := ⟨(x ++ ·)⁻¹' T, fun _ _ _ ↦ mem_of_append (by rwa 
 @[simps] def drop (n : ℕ) (x : T) : subAt T (Tree.take n x).val :=
   ⟨x.val.drop n, by simp⟩
 
-/-! ### `pullSub`
+-- ### `pullSub`
 
 /-- Adjoint of `subAt`, given by pasting x before the root of T. Explicitly,
   elements are prefixes of x or x with an element of T appended -/

--- a/Mathlib/SetTheory/Descriptive/Tree.lean
+++ b/Mathlib/SetTheory/Descriptive/Tree.lean
@@ -77,6 +77,7 @@ def subAt : tree A := ⟨(x ++ ·)⁻¹' T, fun _ _ _ ↦ mem_of_append (by rwa 
 @[gcongr] lemma subAt_mono (h : S ≤ T) : subAt S x ≤ subAt T x :=
   Set.preimage_mono h
 
+/-! ### `drop`
 
 /-- A variant of `List.drop` that takes values in `subAt` -/
 @[simps] def drop (n : ℕ) (x : T) : subAt T (Tree.take n x).val :=

--- a/Mathlib/SetTheory/Descriptive/Tree.lean
+++ b/Mathlib/SetTheory/Descriptive/Tree.lean
@@ -53,7 +53,6 @@ lemma singleton_mem (T : tree A) {a : A} {x : List A} (h : a :: x ∈ T) : [a] �
 lemma take_mem {n : ℕ} (x : T) : x.val.take n ∈ T :=
   mem_of_prefix (x.val.take_prefix n) x.prop
 
-
 /-- A variant of `List.take` internally to a tree -/
 @[simps] def take (n : ℕ) (x : T) : T := ⟨x.val.take n, take_mem x⟩
 
@@ -63,6 +62,7 @@ lemma take_mem {n : ℕ} (x : T) : x.val.take n ∈ T :=
 @[simp] lemma take_eq_take {x : T} {m n : ℕ} :
   take m x = take n x ↔ m ⊓ x.val.length = n ⊓ x.val.length := by simp [Subtype.ext_iff]
 
+/-! ### `subAt`
 
 variable (T) (x y : List A)
 /-- The residual tree obtained by regarding the node x as new root -/
@@ -77,11 +77,11 @@ def subAt : tree A := ⟨(x ++ ·)⁻¹' T, fun _ _ _ ↦ mem_of_append (by rwa 
 @[gcongr] lemma subAt_mono (h : S ≤ T) : subAt S x ≤ subAt T x :=
   Set.preimage_mono h
 
-/-! ### `drop`
-
 /-- A variant of `List.drop` that takes values in `subAt` -/
 @[simps] def drop (n : ℕ) (x : T) : subAt T (Tree.take n x).val :=
   ⟨x.val.drop n, by simp⟩
+
+/-! ### `pullSub`
 
 /-- Adjoint of `subAt`, given by pasting x before the root of T. Explicitly,
   elements are prefixes of x or x with an element of T appended -/

--- a/Mathlib/SetTheory/Descriptive/Tree.lean
+++ b/Mathlib/SetTheory/Descriptive/Tree.lean
@@ -68,6 +68,7 @@ def subAt : tree A := ⟨(x ++ ·)⁻¹' T, fun _ _ _ ↦ mem_of_append (by rwa 
 @[gcongr] lemma subAt_mono {S T : tree A} (h : S ≤ T) : subAt S x ≤ subAt T x :=
   Set.preimage_mono h
 
+/-- A variant of `List.drop` that takes values in `subAt` -/
 @[simps] def drop {T : tree A} (n : ℕ) (x : T) : subAt T (Tree.take n x).val :=
   ⟨x.val.drop n, by simp⟩
 

--- a/Mathlib/SetTheory/Descriptive/Tree.lean
+++ b/Mathlib/SetTheory/Descriptive/Tree.lean
@@ -27,20 +27,95 @@ def tree (A : Type*) : CompleteSublattice (Set (List A)) :=
     (by rintro S hS x a ⟨t, ht, hx⟩; use t, ht, hS ht hx)
     (by rintro S hS x a h T hT; exact hS hT <| h T hT)
 
-instance (A : Type*) : SetLike (tree A) (List A) := SetLike.instSubtypeSet
+@[simps!] instance (A : Type*) : SetLike (tree A) (List A) := SetLike.instSubtypeSet
 
+namespace Tree
 variable {A : Type*} {T : tree A}
 
 lemma mem_of_append {x y : List A} (h : x ++ y ∈ T) : x ∈ T := by
   induction' y with y ys ih generalizing x
   · simpa using h
   · exact T.prop (ih (by simpa))
-
 lemma mem_of_prefix {x y : List A} (h' : x <+: y) (h : y ∈ T) : x ∈ T := by
   obtain ⟨_, rfl⟩ := h'; exact mem_of_append h
+instance : Trans (List.IsPrefix) (fun x (T : tree A) ↦ x ∈ T) (fun x T ↦ x ∈ T) where
+  trans := mem_of_prefix
+lemma singleton_mem (T : tree A) {a : A} {x : List A} (h : a :: x ∈ T) : [a] ∈ T :=
+  mem_of_prefix ⟨x, rfl⟩ h
 
 @[simp] lemma tree_eq_bot : T = ⊥ ↔ [] ∉ T where
   mp := by rintro rfl; simp
   mpr h := by ext x; simpa using fun h' ↦ h <| mem_of_prefix x.nil_prefix h'
 
-end Descriptive
+lemma take_mem {T : tree A} {n : ℕ} (x : T) : x.val.take n ∈ T :=
+  mem_of_prefix (x.val.take_prefix n) x.prop
+
+/-- A variant of `List.take` internally to a tree -/
+@[simps] def take {T : tree A} (n : ℕ) (x : T) : T := ⟨x.val.take n, take_mem x⟩
+
+@[simp] lemma take_take {T : tree A} (m n : ℕ) (x : T) :
+  take m (take n x) = take (m ⊓ n) x := by simp [Subtype.ext_iff, List.take_take]
+@[simp] lemma take_eq_take {x : T} {m n : ℕ} :
+  take m x = take n x ↔ m ⊓ x.val.length = n ⊓ x.val.length := by simp [Subtype.ext_iff]
+
+variable (T) (x y : List A)
+/-- The residual tree obtained by regarding the node x as new root -/
+def subAt : tree A := ⟨(x ++ ·)⁻¹' T, fun _ _ _ ↦ mem_of_append (by rwa [List.append_assoc])⟩
+@[simp] lemma mem_subAt : y ∈ subAt T x ↔ x ++ y ∈ T := Iff.rfl
+
+@[simp] lemma subAt_nil : subAt T [] = T := rfl
+@[simp] lemma subAt_append : subAt (subAt T x) y = subAt T (x ++ y) := by ext; simp
+@[gcongr] lemma subAt_mono {S T : tree A} (h : S ≤ T) : subAt S x ≤ subAt T x :=
+  Set.preimage_mono h
+
+@[simps] def drop {T : tree A} (n : ℕ) (x : T) : subAt T (Tree.take n x).val :=
+  ⟨x.val.drop n, by simp⟩
+
+/-- Adjoint of `subAt` -/
+def pullSub : tree A where
+  val := { y | y.take x.length <+: x ∧ y.drop x.length ∈ T }
+  property := fun y a ⟨h1, h2⟩ ↦
+    ⟨((y.prefix_append [a]).take x.length).trans h1,
+    mem_of_prefix ((y.prefix_append [a]).drop x.length) h2⟩
+
+variable {T x y}
+lemma mem_pullSub_short (hl : y.length ≤ x.length) :
+  y ∈ pullSub T x ↔ y <+: x ∧ [] ∈ T := by
+  simp [pullSub, List.take_of_length_le hl, List.drop_eq_nil_iff.mpr hl]
+lemma mem_pullSub_long (hl : x.length ≤ y.length) :
+  y ∈ pullSub T x ↔ ∃ z ∈ T, y = x ++ z where
+  mp := by
+    intro ⟨h1, h2⟩; use y.drop x.length, h2
+    nth_rw 1 [← List.take_append_drop x.length y]
+    simpa [- List.take_append_drop, List.prefix_iff_eq_take, hl] using h1
+  mpr := by simp +contextual [pullSub]
+@[simp] lemma mem_pullSub_append : x ++ y ∈ pullSub T x ↔ y ∈ T := by simp [mem_pullSub_long]
+@[simp] lemma mem_pullSub_self : x ∈ pullSub T x ↔ [] ∈ T := by
+  simpa using mem_pullSub_append (y := [])
+
+variable (T x y)
+lemma pullSub_subAt : pullSub (subAt T x) x ≤ T := by
+  intro y (h : y ∈ pullSub _ x); rcases le_total y.length x.length with h' | h'
+  · rw [mem_pullSub_short h'] at h; exact mem_of_prefix h.1 (by simpa using h.2)
+  · rw [mem_pullSub_long h'] at h; obtain ⟨_, h, rfl⟩ := h; exact h
+@[simp] lemma subAt_pullSub : subAt (pullSub T x) x = T := by
+  ext y; simp
+@[gcongr] lemma pullSub_mono {S T : tree A} (h : S ≤ T) x : pullSub S x ≤ pullSub T x :=
+  fun _ ⟨h1, h2⟩ ↦ ⟨h1, h h2⟩
+lemma pullSub_adjunction (S T : tree A) (x : List A) : pullSub S x ≤ T ↔ S ≤ subAt T x where
+  mp _ := by rw [← subAt_pullSub S x]; gcongr
+  mpr _ := le_trans (by gcongr) (pullSub_subAt T x)
+
+@[simp] lemma pullSub_nil : pullSub T [] = T := by simp [pullSub]
+@[simp] lemma pullSub_append : pullSub (pullSub T y) x = pullSub T (x ++ y) := by
+  ext z; rcases le_total x.length z.length with hl | hl
+  · by_cases hp : x <+: z
+    · obtain ⟨z, rfl⟩ := hp
+      simp [pullSub, List.take_add]
+    · constructor <;> intro ⟨h, _⟩ <;>
+        [skip; replace h := by simpa [List.take_take] using h.take x.length] <;>
+        cases hp <| List.prefix_iff_eq_take.mpr (h.eq_of_length (by simpa)).symm
+  · rw [mem_pullSub_short hl, mem_pullSub_short (by simp), mem_pullSub_short (by simp; omega)]
+    simpa using fun _ ↦ (z.isPrefix_append_of_length hl).symm
+
+end Descriptive.Tree


### PR DESCRIPTION
add API on Descriptive.tree, in particular operations for switching between subtrees

---
The changes in other files are done to replace a lemma added in the previous PR by its proper general form. Taken from https://github.com/sven-manthe/A-formalization-of-Borel-determinacy-in-Lean
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
