### PR TITLE
feat(Cache): enable partial cache in downstream projects

### DIFF
--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -74,7 +74,9 @@ def getFileImports (content : String) (fileName : String := "") :
   let sp := (← read).srcSearchPath
   let res ← Lean.parseImports' content fileName
   res.imports
-    |>.filter (isPartOfMathlibCache ·.module)
+    -- Lean core files can never be modified and therefore we do not need to process these
+    -- moreover, it seems that `Lean.findLean` fails on these.
+    |>.filter (! isInLeanCore ·.module)
     |>.mapM fun imp => do
       let impSourceFile ← Lean.findLean sp imp.module
       pure (imp.module, impSourceFile)
@@ -147,11 +149,20 @@ partial def getHash (mod : Name) (sourceFile : FilePath) (visited : Std.HashSet 
     let rootHash := (← get).rootHash
     let pathHash := hash filePath.components -- TODO: change to `hash mod`
     let fileHash := hash <| rootHash :: pathHash :: hashFileContents content :: importHashes.toList
-    modifyGet fun stt =>
-      (some fileHash, { stt with
-        hashMap := stt.hashMap.insert mod fileHash
-        cache   := stt.cache.insert   mod (some fileHash)
-        depsMap := stt.depsMap.insert mod (fileImports.map (·.1)) })
+    if isPartOfMathlibCache mod then
+      -- mathlib/upstream: add hash to `hashMap`
+      modifyGet fun stt =>
+        (some fileHash, { stt with
+          depsMap := stt.depsMap.insert mod (fileImports.map (·.1))
+          cache   := stt.cache.insert   mod (some fileHash)
+          hashMap := stt.hashMap.insert mod fileHash })
+    else
+      -- downstream: add `none` to `cache` and do not add hash to `hashMap`
+      modifyGet fun stt =>
+        (none, { stt with
+          depsMap := stt.depsMap.insert mod (fileImports.map (·.1))
+          cache   := stt.cache.insert   mod none
+          hashMap := stt.hashMap })
 
 /-- Files to start hashing from. -/
 def roots : CacheM <| Array <| Name × FilePath := do
@@ -159,9 +170,9 @@ def roots : CacheM <| Array <| Name × FilePath := do
   return #[(`Mathlib, (mathlibDepPath / "Mathlib.lean"))]
 
 /-- Main API to retrieve the hashes of the Lean files -/
-def getHashMemo (extraRoots : Std.HashMap Name FilePath) : CacheM HashMemo :=
+def getHashMemo (roots : Std.HashMap Name FilePath) : CacheM HashMemo := do
   -- TODO: `Std.HashMap.mapM` seems not to exist yet, so we go via `.toArray`.
-  return (← StateT.run ((extraRoots.insertMany (← roots)).toArray.mapM fun
-    ⟨key, val⟩ => getHash key val) { rootHash := ← getRootHash }).2
+  return (← StateT.run (roots.toArray.mapM fun ⟨key, val⟩ => getHash key val)
+    {rootHash := ← getRootHash}).2
 
 end Cache.Hashing

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -22,6 +22,15 @@ def LIBDIR : FilePath :=
 def IRDIR : FilePath :=
   ".lake" / "build" / "ir"
 
+/--
+TODO: is there a better test to see if a module is part of Lean core?
+-/
+def isInLeanCore (mod : Name) := #[
+  `Init,
+  `Lean,
+  `Std,
+  `Lake ].contains mod.getRoot
+
 /-- Determine if the package `mod` is part of the mathlib cache.
 
 TODO: write a better predicate. -/

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -104,17 +104,16 @@ def main (args : List String) : IO Unit := do
     let mod := `Mathlib
     let sp := (← read).srcSearchPath
     let sourceFile ← Lean.findLean sp mod
-    roots := roots.insert mod sourceFile
+    roots := Std.HashMap.emptyWithCapacity.insert mod sourceFile
 
   let hashMemo ← getHashMemo roots
-  let hashMap := hashMemo.hashMap
+
   let goodCurl ← pure !curlArgs.contains (args.headD "") <||> validateCurl
   if leanTarArgs.contains (args.headD "") then validateLeanTar
-  let get (args : List String) (force := false) (decompress := true) := do
-    let hashMap ← if args.isEmpty then pure hashMap else hashMemo.filterByRootModules roots.keys
-    getFiles repo? hashMap force force goodCurl decompress
+  let get (force := false) (decompress := true) := do
+    getFiles repo? hashMemo.hashMap force force goodCurl decompress
   let pack (overwrite verbose unpackedOnly := false) := do
-    packCache hashMap overwrite verbose unpackedOnly (← getGitCommitHash)
+    packCache hashMemo.hashMap overwrite verbose unpackedOnly (← getGitCommitHash)
   let put (overwrite unpackedOnly := false) := do
     let repo := repo?.getD MATHLIBREPO
     putFiles repo (← pack overwrite (verbose := true) unpackedOnly) overwrite (← getToken)
@@ -131,17 +130,17 @@ def main (args : List String) : IO Unit := do
       putFilesAbsolute repo fileSet (tempConfigFilePath := stagingDir / "curl.config") (overwrite := false) (← getToken)
 
   match args with
-  | "get"  :: args => get args
-  | "get!" :: args => get args (force := true)
-  | "get-" :: args => get args (decompress := false)
+  | "get"  :: _ => get
+  | "get!" :: _ => get (force := true)
+  | "get-" :: _ => get (decompress := false)
   | ["pack"] => discard <| pack
   | ["pack!"] => discard <| pack (overwrite := true)
-  | ["unpack"] => unpackCache hashMap false
-  | ["unpack!"] => unpackCache hashMap true
+  | ["unpack"] => unpackCache hashMemo.hashMap false
+  | ["unpack!"] => unpackCache hashMemo.hashMap true
   | ["unstage"] => unstage
   | ["unstage!"] => unstage (overwrite := true)
   | ["clean"] =>
-    cleanCache <| hashMap.fold (fun acc _ hash => acc.insert <| CACHEDIR / hash.asLTar) .empty
+    cleanCache <| hashMemo.hashMap.fold (fun acc _ hash => acc.insert <| CACHEDIR / hash.asLTar) .empty
   | ["clean!"] => cleanCache
   -- We allow arguments for `put*` so they can be added to the `roots`.
   | "put" :: _ => put
@@ -155,10 +154,10 @@ def main (args : List String) : IO Unit := do
     putStaged stagingDir?.get!
   | ["commit"] =>
     if !(← isGitStatusClean) then IO.println "Please commit your changes first" return else
-    commit hashMap false (← getToken)
+    commit hashMemo.hashMap false (← getToken)
   | ["commit!"] =>
     if !(← isGitStatusClean) then IO.println "Please commit your changes first" return else
-    commit hashMap true (← getToken)
+    commit hashMemo.hashMap true (← getToken)
   | ["collect"] => IO.println "TODO"
-  | "lookup" :: _ => lookup hashMap roots.keys
+  | "lookup" :: _ => lookup hashMemo.hashMap roots.keys
   | _ => println help


### PR DESCRIPTION
Add features to `cache` and cleanup code:

* enable partial cache retrieval in downstream projects: `lake exe cache get MyProject.Basic` downloads only the relevant cache to build `MyProject/Basic.lean`

---

- [x] depends on: #21834

### Notes:
- replaces: #21195
- should address: #8767
- should address: #20568

### Completed:

- [x] depends on: #21632
- [x] ~~depends on: #21663~~
- [x] depends on: #21666
- [x] depends on: #21701
- [x] depends on: #21703
- [x] depends on: #21704
- [x] depends on: #21705
- [x] depends on: #21707
- [x] depends on: #21711
- [x] depends on: #21750
- [x] depends on: #21815
- [x] depends on: #21816
- [x] depends on: #21817
- [x] depends on: #21818
- [x] depends on: #21822
- [x] depends on: #21830
- #21848

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
