### PR TITLE
[Merged by Bors] - feat: let `notation3` pretty print "overapplied" notations

### DIFF
--- a/Mathlib/Util/Notation3.lean
+++ b/Mathlib/Util/Notation3.lean
@@ -217,6 +217,24 @@ def setupLCtx (lctx : LocalContext) (boundNames : Array Name) :
     boundFVars := boundFVars.insert fvarId name
   return (lctx, boundFVars)
 
+/--
+Represents a key to use when registering the `delab` attribute for a delaborator.
+We use this to handle overapplication.
+-/
+inductive DelabKey where
+  /-- The key `app.const` or `app` with a specific arity. -/
+  | app (const : Option Name) (arity : Nat)
+  | other (key : Name)
+  deriving Repr
+
+/--
+Turns the `DelabKey` into a key that the `delab` attribute accepts.
+-/
+def DelabKey.key : DelabKey → Name
+  | .app none     _ => `app
+  | .app (some n) _ => `app ++ n
+  | .other key      => key
+
 /-- Given an expression, generate a matcher for it.
 The `boundFVars` hash map records which state variables certain fvars correspond to.
 The `localFVars` hash map records which local variable the matcher should use for an exact
@@ -228,11 +246,11 @@ If it succeeds generating a matcher, returns
 2. a `Term` that represents a `Matcher` for the given expression `e`. -/
 partial def exprToMatcher (boundFVars : Std.HashMap FVarId Name)
     (localFVars : Std.HashMap FVarId Term) (e : Expr) :
-    OptionT TermElabM (List Name × Term) := do
+    OptionT TermElabM (List DelabKey × Term) := do
   match e with
   | .mvar .. => return ([], ← `(pure))
-  | .const n _ => return ([`app ++ n], ← ``(matchExpr (Expr.isConstOf · $(quote n))))
-  | .sort .. => return ([`sort], ← ``(matchExpr Expr.isSort))
+  | .const n _ => return ([.app n 0], ← ``(matchExpr (Expr.isConstOf · $(quote n))))
+  | .sort .. => return ([.other `sort], ← ``(matchExpr Expr.isSort))
   | .fvar fvarId =>
     if let some n := boundFVars[fvarId]? then
       -- This fvar is a pattern variable.
@@ -245,14 +263,19 @@ partial def exprToMatcher (boundFVars : Std.HashMap FVarId Name)
       if n.hasMacroScopes then
         -- Match by just the type; this is likely an unnamed instance for example
         let (_, m) ← exprToMatcher boundFVars localFVars (← instantiateMVars (← inferType e))
-        return ([`fvar], ← ``(matchTypeOf $m))
+        return ([.other `fvar], ← ``(matchTypeOf $m))
       else
         -- This is an fvar from a `variable`. Match by name and type.
         let (_, m) ← exprToMatcher boundFVars localFVars (← instantiateMVars (← inferType e))
-        return ([`fvar], ← ``(matchFVar $(quote n) $m))
+        return ([.other `fvar], ← ``(matchFVar $(quote n) $m))
   | .app .. =>
     e.withApp fun f args => do
-      let (keys, matchF) ← exprToMatcher boundFVars localFVars f
+      let (keys, matchF) ←
+        if let .const n _ := f then
+          pure ([.app n args.size], ← ``(matchExpr (Expr.isConstOf · $(quote n))))
+        else
+          let (_, matchF) ← exprToMatcher boundFVars localFVars f
+          pure ([.app none args.size], matchF)
       let mut fty ← inferType f
       let mut matcher := matchF
       for arg in args do
@@ -268,8 +291,8 @@ partial def exprToMatcher (boundFVars : Std.HashMap FVarId Name)
         else
           let (_, matchArg) ← exprToMatcher boundFVars localFVars arg
           matcher ← ``(matchApp $matcher $matchArg)
-      return (if keys.isEmpty then [`app] else keys, matcher)
-  | .lit (.natVal n) => return ([`lit], ← ``(natLitMatcher $(quote n)))
+      return (keys, matcher)
+  | .lit (.natVal n) => return ([.other `lit], ← ``(natLitMatcher $(quote n)))
   | .forallE n t b bi =>
     let (_, matchDom) ← exprToMatcher boundFVars localFVars t
     withLocalDecl n bi t fun arg => withFreshMacroScope do
@@ -277,7 +300,7 @@ partial def exprToMatcher (boundFVars : Std.HashMap FVarId Name)
       let body := b.instantiate1 arg
       let localFVars' := localFVars.insert arg.fvarId! n'
       let (_, matchBody) ← exprToMatcher boundFVars localFVars' body
-      return ([`forallE], ← ``(matchForall $matchDom (fun $n' => $matchBody)))
+      return ([.other `forallE], ← ``(matchForall $matchDom (fun $n' => $matchBody)))
   | .lam n t b bi =>
     let (_, matchDom) ← exprToMatcher boundFVars localFVars t
     withLocalDecl n bi t fun arg => withFreshMacroScope do
@@ -285,7 +308,7 @@ partial def exprToMatcher (boundFVars : Std.HashMap FVarId Name)
       let body := b.instantiate1 arg
       let localFVars' := localFVars.insert arg.fvarId! n'
       let (_, matchBody) ← exprToMatcher boundFVars localFVars' body
-      return ([`lam], ← ``(matchLambda $matchDom (fun $n' => $matchBody)))
+      return ([.other `lam], ← ``(matchLambda $matchDom (fun $n' => $matchBody)))
   | _ =>
     trace[notation3] "can't generate matcher for {e}"
     failure
@@ -297,7 +320,7 @@ Fails in the `OptionT` sense if it comes across something it's unable to handle.
 Also returns constant names that could serve as a key for a delaborator.
 For example, if it's for a function `f`, then `app.f`. -/
 partial def mkExprMatcher (stx : Term) (boundNames : Array Name) :
-    OptionT TermElabM (List Name × Term) := do
+    OptionT TermElabM (List DelabKey × Term) := do
   let (lctx, boundFVars) ← setupLCtx (← getLCtx) boundNames
   withLCtx lctx (← getLocalInstances) do
     let patt ←
@@ -360,7 +383,7 @@ Fails in the `OptionT` sense if a matcher couldn't be constructed.
 Also returns a delaborator key like in `mkExprMatcher`.
 Reminder: `$lit:ident : (scoped $scopedId:ident => $scopedTerm:Term)` -/
 partial def mkScopedMatcher (lit scopeId : Name) (scopedTerm : Term) (boundNames : Array Name) :
-    OptionT TermElabM (List Name × Term) := do
+    OptionT TermElabM (List DelabKey × Term) := do
   -- Build the matcher for `scopedTerm` with `scopeId` as an additional variable
   let (keys, smatcher) ← mkExprMatcher scopedTerm (boundNames.push scopeId)
   return (keys, ← ``(matchScoped $(quote lit) $(quote scopeId) $smatcher))
@@ -389,7 +412,7 @@ partial def matchFoldl (lit x y : Name) (smatcher : Matcher) (sinit : Matcher) :
 /-- Create a `Term` that represents a matcher for `foldl` notation.
 Reminder: `( lit ","* => foldl (x y => scopedTerm) init)` -/
 partial def mkFoldlMatcher (lit x y : Name) (scopedTerm init : Term) (boundNames : Array Name) :
-    OptionT TermElabM (List Name × Term) := do
+    OptionT TermElabM (List DelabKey × Term) := do
   -- Build the `scopedTerm` matcher with `x` and `y` as additional variables
   let boundNames' := boundNames |>.push x |>.push y
   let (keys, smatcher) ← mkExprMatcher scopedTerm boundNames'
@@ -399,7 +422,7 @@ partial def mkFoldlMatcher (lit x y : Name) (scopedTerm init : Term) (boundNames
 /-- Create a `Term` that represents a matcher for `foldr` notation.
 Reminder: `( lit ","* => foldr (x y => scopedTerm) init)` -/
 partial def mkFoldrMatcher (lit x y : Name) (scopedTerm init : Term) (boundNames : Array Name) :
-    OptionT TermElabM (List Name × Term) := do
+    OptionT TermElabM (List DelabKey × Term) := do
   -- Build the `scopedTerm` matcher with `x` and `y` as additional variables
   let boundNames' := boundNames |>.push x |>.push y
   let (keys, smatcher) ← mkExprMatcher scopedTerm boundNames'
@@ -599,7 +622,6 @@ elab (name := notation3) doc:(docComment)? attrs?:(Parser.Term.attributes)? attr
       liftTermElabM matchersM?
     if let some ms := matchers? then
       trace[notation3] "Matcher creation succeeded; assembling delaborator"
-      let delabName := name ++ `delab
       let matcher ← ms.foldrM (fun m t => `($(m.2) >=> $t)) (← `(pure))
       trace[notation3] "matcher:{indentD matcher}"
       let mut result ← `(withHeadRefIfTagAppFns `($pat))
@@ -612,16 +634,22 @@ elab (name := notation3) doc:(docComment)? attrs?:(Parser.Term.attributes)? attr
           `(let $id := MatchState.getFoldArray s $(quote name); $result)
       if hasBindersItem then
         result ← `(`(extBinders| $$(MatchState.getBinders s)*) >>= fun binders => $result)
-      elabCommand <| ← `(command|
-        /-- Pretty printer defined by `notation3` command. -/
-        def $(Lean.mkIdent delabName) : Delab := whenPPOption getPPNotation <|
-          getExpr >>= fun e => $matcher MatchState.empty >>= fun s => $result)
-      trace[notation3] "Defined delaborator {currNamespace ++ delabName}"
-      let delabKeys := ms.foldr (·.1 ++ ·) []
-      trace[notation3] "Adding `delab` attribute for keys {delabKeys}"
+      let delabKeys : List DelabKey := ms.foldr (·.1 ++ ·) []
       for key in delabKeys do
-        elabCommand <|
-          ← `(command| attribute [$attrKind delab $(mkIdent key)] $(Lean.mkIdent delabName))
+        trace[notation3] "Creating delaborator for key {repr key}"
+        let delabName := name ++ Name.mkSimple s!"delab_{key.key}"
+        let bodyCore ← `(getExpr >>= fun e => $matcher MatchState.empty >>= fun s => $result)
+        let body ←
+          match key with
+          | .app _ arity => ``(withOverApp $(quote arity) $bodyCore)
+          | _            => pure bodyCore
+        elabCommand <| ← `(
+          /-- Pretty printer defined by `notation3` command. -/
+          def $(Lean.mkIdent delabName) : Delab :=
+            whenPPOption getPPNotation <| whenNotPPOption getPPExplicit <| $body
+          -- Avoid scope issues by adding attribute afterwards.
+          attribute [$attrKind delab $(mkIdent key.key)] $(Lean.mkIdent delabName))
+        trace[notation3] "Defined delaborator {currNamespace ++ delabName}"
     else
       logWarning s!"\
         Was not able to generate a pretty printer for this notation. \

--- a/MathlibTest/notation3.lean
+++ b/MathlibTest/notation3.lean
@@ -89,9 +89,7 @@ notation3 "∃' " (...) ", " r:(scoped p => Exists p) => r
 
 def func (x : α) : α := x
 notation3 "func! " (...) ", " r:(scoped p => func p) => r
--- Make sure it handles additional arguments. Should not consume `(· * 2)`.
--- Note: right now this causes the notation to not pretty print at all.
-/-- info: func (fun x ↦ x) fun x ↦ x * 2 : ℕ → ℕ -/
+/-- info: (func! (x : ℕ → ℕ), x) fun x ↦ x * 2 : ℕ → ℕ -/
 #guard_msgs in #check (func! (x : Nat → Nat), x) (· * 2)
 
 structure MyUnit where
@@ -236,8 +234,8 @@ info: [notation3] syntax declaration has name Test.termδNat
 (matchExpr✝ (Expr.isConstOf✝ · `Nat)))
           pure✝ >=>
         pure✝
-[notation3] Defined delaborator Test.termδNat.delab
-[notation3] Adding `delab` attribute for keys [app.Inhabited.default]
+[notation3] Creating delaborator for key Mathlib.Notation3.DelabKey.app (some `Inhabited.default) 2
+[notation3] Defined delaborator Test.termδNat.«delab_app.Inhabited.default»
 -/
 #guard_msgs in
 set_option trace.notation3 true in


### PR DESCRIPTION
This PR makes `notation3`s delaborators be able to handle "overapplied" functions — these are notations that expand to functions that might then be applied to arguments. The fundamental issue is that we need to know the arity of a function to be able to keep track of how many arguments are supposed to be matched for the notation and how many are supposed to be put toward normal app delaboration. With some changes to core in the last year, we now have a `withOverApp` combinator we can take advantage of. To make use of it, the `notation3` delaborator generator has been modified to compute arities while creating matchers.

The effect is that we now observe
```lean
import Mathlib.Algebra.BigOperators.Finprod

variable (ι R : Type) (f : ι → R) [DecidableEq ι] [CommRing R]

example : (∑ᶠ (i : ι), Pi.single i (f i)) = f := by
  -- ⊢ ∑ᶠ (i : ι), Pi.single i (f i) = f
  ext j
  -- ⊢ (∑ᶠ (i : ι), Pi.single i (f i)) j = f j
  sorry
  ```
where before this PR the state after `ext j` was `⊢ finsum (fun i => Pi.single i (f i)) j = f j`.

Implementation note: matchers can be associated to multiple delaboration keys. Previously we would define a single delaborator and then give it multiple `delab` attributes per key. This is very rare to have more than one key. For simplicity, we now define a separate delaborator per key, since each can have its own arity processing.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
