### PR TITLE
[Merged by Bors] - doc(docs/1000.yaml): remove incorrect description

### DIFF
--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1738,12 +1738,9 @@ Q1765521:
 
 Q1766814:
   title: Smn theorem
-  decls:
-    - Nat.Partrec.Code.smn
-    - Nat.Partrec'.part_iff
+  decl: Nat.Partrec.Code.smn
   authors: Mario Carneiro
   date: 2018
-  comment: "This theorem is trivial when using Mathlib's computability definition, but this definition is equivalent to the usual one, as shown in `Nat.Partrec'.part_iff`."
 
 Q1785610:
   title: Poncelet's closure theorem


### PR DESCRIPTION
In my previous PR, I added incorrect description to Smn theorem.
`Nat.Partrec'` is different from the definition of usual partial recursive functions, because it does't allow recursion on partial recursive functions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
