### PR TITLE
[Merged by Bors] - feat(FieldTheory): `F⟮a⟯ = F⟮a ^ q ^ n⟯` in `ExpChar q` for separable `a`

### DIFF
--- a/Mathlib/FieldTheory/PurelyInseparable.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable.lean
@@ -793,16 +793,14 @@ theorem adjoin_simple_eq_adjoin_pow_expChar_pow_of_isSeparable' [Algebra.IsSepar
 /-- If `F` is a field of exponential characteristic `q`, `a : E` is separable over `F`, then
 `F⟮a⟯ = F⟮a ^ q⟯`. -/
 theorem adjoin_simple_eq_adjoin_pow_expChar_of_isSeparable {a : E} (ha : IsSeparable F a)
-    (q : ℕ) [ExpChar F q] : F⟮a⟯ = F⟮a ^ q⟯ := by
-  haveI := (isSeparable_adjoin_simple_iff_isSeparable F E).mpr ha
-  simpa using adjoin_eq_adjoin_pow_expChar_of_isSeparable F E {a} q
+    (q : ℕ) [ExpChar F q] : F⟮a⟯ = F⟮a ^ q⟯ :=
+  pow_one q ▸ adjoin_simple_eq_adjoin_pow_expChar_pow_of_isSeparable F E ha q 1
 
 /-- If `E / F` is a separable field extension of exponential characteristic `q`, then
 `F⟮a⟯ = F⟮a ^ q⟯` for any `a : E`. -/
 theorem adjoin_simple_eq_adjoin_pow_expChar_of_isSeparable' [Algebra.IsSeparable F E] (a : E)
-    (q : ℕ) [ExpChar F q] : F⟮a⟯ = F⟮a ^ q⟯ := by
-  haveI := Algebra.isSeparable_tower_bot_of_isSeparable F F⟮a⟯ E
-  simpa using adjoin_eq_adjoin_pow_expChar_of_isSeparable' F E {a} q
+    (q : ℕ) [ExpChar F q] : F⟮a⟯ = F⟮a ^ q⟯ :=
+  pow_one q ▸ adjoin_simple_eq_adjoin_pow_expChar_pow_of_isSeparable' F E a q 1
 
 end IntermediateField
 

--- a/Mathlib/FieldTheory/PurelyInseparable.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable.lean
@@ -774,6 +774,36 @@ theorem adjoin_eq_adjoin_pow_expChar_of_isSeparable' [Algebra.IsSeparable F E] (
     (q : ℕ) [ExpChar F q] : adjoin F S = adjoin F ((· ^ q) '' S) :=
   pow_one q ▸ adjoin_eq_adjoin_pow_expChar_pow_of_isSeparable' F E S q 1
 
+-- Special cases for simple adjoin
+
+/-- If `F` is a field of exponential characteristic `q`, `a : E` is separable over `F`, then
+`F⟮a⟯ = F⟮a ^ q ^ n⟯` for any natural number `n`. -/
+theorem adjoin_simple_eq_adjoin_pow_expChar_pow_of_isSeparable {a : E} (ha : IsSeparable F a)
+    (q : ℕ) [ExpChar F q] (n : ℕ) : F⟮a⟯ = F⟮a ^ q ^ n⟯ := by
+  haveI := (isSeparable_adjoin_simple_iff_isSeparable F E).mpr ha
+  simpa using adjoin_eq_adjoin_pow_expChar_pow_of_isSeparable F E {a} q n
+
+/-- If `E / F` is a separable field extension of exponential characteristic `q`, then
+`F⟮a⟯ = F⟮a ^ q ^ n⟯` for any subset `a : E` and any natural number `n`. -/
+theorem adjoin_simple_eq_adjoin_pow_expChar_pow_of_isSeparable' [Algebra.IsSeparable F E] (a : E)
+    (q : ℕ) [ExpChar F q] (n : ℕ) : F⟮a⟯ = F⟮a ^ q ^ n⟯ := by
+  haveI := Algebra.isSeparable_tower_bot_of_isSeparable F F⟮a⟯ E
+  simpa using adjoin_eq_adjoin_pow_expChar_pow_of_isSeparable F E {a} q n
+
+/-- If `F` is a field of exponential characteristic `q`, `a : E` is separable over `F`, then
+`F⟮a⟯ = F⟮a ^ q⟯`. -/
+theorem adjoin_simple_eq_adjoin_pow_expChar_of_isSeparable {a : E} (ha : IsSeparable F a)
+    (q : ℕ) [ExpChar F q] : F⟮a⟯ = F⟮a ^ q⟯ := by
+  haveI := (isSeparable_adjoin_simple_iff_isSeparable F E).mpr ha
+  simpa using adjoin_eq_adjoin_pow_expChar_of_isSeparable F E {a} q
+
+/-- If `E / F` is a separable field extension of exponential characteristic `q`, then
+`F⟮a⟯ = F⟮a ^ q⟯` for any `a : E`. -/
+theorem adjoin_simple_eq_adjoin_pow_expChar_of_isSeparable' [Algebra.IsSeparable F E] (a : E)
+    (q : ℕ) [ExpChar F q] : F⟮a⟯ = F⟮a ^ q⟯ := by
+  haveI := Algebra.isSeparable_tower_bot_of_isSeparable F F⟮a⟯ E
+  simpa using adjoin_eq_adjoin_pow_expChar_of_isSeparable' F E {a} q
+
 end IntermediateField
 
 section


### PR DESCRIPTION
Add special cases of existing results for simple adjoin.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
