### PR TITLE
[Merged by Bors] - feat(Algebra/MvPolynomial): add `comp` versions of rename lemmas

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Rename.lean
+++ b/Mathlib/Algebra/MvPolynomial/Rename.lean
@@ -88,6 +88,9 @@ lemma rename_comp_rename (f : σ → τ) (g : τ → α) :
 theorem rename_id : rename id = AlgHom.id R (MvPolynomial σ R) :=
   AlgHom.ext fun p ↦ eval₂_eta p
 
+lemma rename_id_apply (p : MvPolynomial σ R) : rename id p = p := by
+  simp
+
 theorem rename_monomial (f : σ → τ) (d : σ →₀ ℕ) (r : R) :
     rename f (monomial d r) = monomial (d.mapDomain f) r := by
   rw [rename, aeval_monomial, monomial_eq (s := Finsupp.mapDomain f d),
@@ -144,8 +147,8 @@ def renameEquiv (f : σ ≃ τ) : MvPolynomial σ R ≃ₐ[R] MvPolynomial τ R 
   { rename f with
     toFun := rename f
     invFun := rename f.symm
-    left_inv := fun p => by simp [rename_rename, f.symm_comp_self]
-    right_inv := fun p => by simp [rename_rename, f.self_comp_symm] }
+    left_inv := fun p => by rw [rename_rename, f.symm_comp_self, rename_id_apply]
+    right_inv := fun p => by rw [rename_rename, f.self_comp_symm, rename_id_apply] }
 
 @[simp]
 theorem renameEquiv_refl : renameEquiv R (Equiv.refl σ) = AlgEquiv.refl :=

--- a/Mathlib/Algebra/MvPolynomial/Rename.lean
+++ b/Mathlib/Algebra/MvPolynomial/Rename.lean
@@ -64,6 +64,11 @@ theorem map_rename (f : R →+* S) (g : σ → τ) (p : MvPolynomial σ R) :
     (fun p q hp hq => by simp only [hp, hq, map_add]) fun p n hp => by
     simp only [hp, rename_X, map_X, map_mul]
 
+lemma map_comp_rename (f : R →+* S) (g : σ → τ) :
+    (map f).comp (rename g).toRingHom = (rename g).toRingHom.comp (map f) := by
+  apply RingHom.ext
+  simp [map_rename]
+
 @[simp]
 theorem rename_rename (f : σ → τ) (g : τ → α) (p : MvPolynomial σ R) :
     rename g (rename f p) = rename (g ∘ f) p :=
@@ -76,9 +81,15 @@ theorem rename_rename (f : σ → τ) (g : τ → α) (p : MvPolynomial σ R) :
     refine eval₂Hom_congr ?_ rfl rfl
     ext1; simp only [comp_apply, RingHom.coe_comp, eval₂Hom_C]
 
+lemma rename_comp_rename (f : σ → τ) (g : τ → α) :
+    (rename (R := R) g).comp (rename f) = rename (g ∘ f) := by
+  ext
+  simp
+
 @[simp]
-theorem rename_id (p : MvPolynomial σ R) : rename id p = p :=
-  eval₂_eta p
+theorem rename_id : rename id = AlgHom.id R (MvPolynomial σ R) := by
+  ext
+  simp
 
 theorem rename_monomial (f : σ → τ) (d : σ →₀ ℕ) (r : R) :
     rename f (monomial d r) = monomial (d.mapDomain f) r := by
@@ -136,12 +147,12 @@ def renameEquiv (f : σ ≃ τ) : MvPolynomial σ R ≃ₐ[R] MvPolynomial τ R 
   { rename f with
     toFun := rename f
     invFun := rename f.symm
-    left_inv := fun p => by rw [rename_rename, f.symm_comp_self, rename_id]
-    right_inv := fun p => by rw [rename_rename, f.self_comp_symm, rename_id] }
+    left_inv := fun p => by simp [rename_rename, f.symm_comp_self]
+    right_inv := fun p => by simp [rename_rename, f.self_comp_symm] }
 
 @[simp]
 theorem renameEquiv_refl : renameEquiv R (Equiv.refl σ) = AlgEquiv.refl :=
-  AlgEquiv.ext rename_id
+  AlgEquiv.ext (by simp)
 
 @[simp]
 theorem renameEquiv_symm (f : σ ≃ τ) : (renameEquiv R f).symm = renameEquiv R f.symm :=
@@ -171,6 +182,11 @@ theorem eval₂Hom_rename : eval₂Hom f g (rename k p) = eval₂Hom f (g ∘ k)
 
 theorem aeval_rename [Algebra R S] : aeval g (rename k p) = aeval (g ∘ k) p :=
   eval₂Hom_rename _ _ _ _
+
+lemma aeval_comp_rename [Algebra R S] :
+    (aeval (R := R) g).comp (rename k) = MvPolynomial.aeval (g ∘ k) := by
+  ext
+  simp
 
 theorem rename_eval₂ (g : τ → MvPolynomial σ R) :
     rename k (p.eval₂ C (g ∘ k)) = (rename k p).eval₂ C (rename k ∘ g) := by

--- a/Mathlib/Algebra/MvPolynomial/Rename.lean
+++ b/Mathlib/Algebra/MvPolynomial/Rename.lean
@@ -65,9 +65,8 @@ theorem map_rename (f : R →+* S) (g : σ → τ) (p : MvPolynomial σ R) :
     simp only [hp, rename_X, map_X, map_mul]
 
 lemma map_comp_rename (f : R →+* S) (g : σ → τ) :
-    (map f).comp (rename g).toRingHom = (rename g).toRingHom.comp (map f) := by
-  apply RingHom.ext
-  simp [map_rename]
+    (map f).comp (rename g).toRingHom = (rename g).toRingHom.comp (map f) :=
+  RingHom.ext fun p ↦ map_rename f g p
 
 @[simp]
 theorem rename_rename (f : σ → τ) (g : τ → α) (p : MvPolynomial σ R) :
@@ -82,14 +81,12 @@ theorem rename_rename (f : σ → τ) (g : τ → α) (p : MvPolynomial σ R) :
     ext1; simp only [comp_apply, RingHom.coe_comp, eval₂Hom_C]
 
 lemma rename_comp_rename (f : σ → τ) (g : τ → α) :
-    (rename (R := R) g).comp (rename f) = rename (g ∘ f) := by
-  ext
-  simp
+    (rename (R := R) g).comp (rename f) = rename (g ∘ f) :=
+  AlgHom.ext fun p ↦ rename_rename f g p
 
 @[simp]
-theorem rename_id : rename id = AlgHom.id R (MvPolynomial σ R) := by
-  ext
-  simp
+theorem rename_id : rename id = AlgHom.id R (MvPolynomial σ R) :=
+  AlgHom.ext fun p ↦ eval₂_eta p
 
 theorem rename_monomial (f : σ → τ) (d : σ →₀ ℕ) (r : R) :
     rename f (monomial d r) = monomial (d.mapDomain f) r := by
@@ -184,9 +181,8 @@ theorem aeval_rename [Algebra R S] : aeval g (rename k p) = aeval (g ∘ k) p :=
   eval₂Hom_rename _ _ _ _
 
 lemma aeval_comp_rename [Algebra R S] :
-    (aeval (R := R) g).comp (rename k) = MvPolynomial.aeval (g ∘ k) := by
-  ext
-  simp
+    (aeval (R := R) g).comp (rename k) = MvPolynomial.aeval (g ∘ k) :=
+  AlgHom.ext fun p ↦ aeval_rename k g p
 
 theorem rename_eval₂ (g : τ → MvPolynomial σ R) :
     rename k (p.eval₂ C (g ∘ k)) = (rename k p).eval₂ C (rename k ∘ g) := by

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric/Defs.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric/Defs.lean
@@ -136,8 +136,8 @@ theorem map (hφ : IsSymmetric φ) (f : R →+* S) : IsSymmetric (map f φ) := f
 
 protected theorem rename (hφ : φ.IsSymmetric) (e : σ ≃ τ) : (rename e φ).IsSymmetric := fun _ => by
   apply rename_injective _ e.symm.injective
-  simp_rw [rename_rename, ← Equiv.coe_trans, Equiv.self_trans_symm, Equiv.coe_refl, rename_id]
-  rw [AlgHom.coe_id, id_eq, hφ]
+  simp_rw [rename_rename, ← Equiv.coe_trans, Equiv.self_trans_symm, Equiv.coe_refl, rename_id_apply]
+  rw [hφ]
 
 @[simp]
 theorem _root_.MvPolynomial.isSymmetric_rename {e : σ ≃ τ} :

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric/Defs.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric/Defs.lean
@@ -137,7 +137,7 @@ theorem map (hφ : IsSymmetric φ) (f : R →+* S) : IsSymmetric (map f φ) := f
 protected theorem rename (hφ : φ.IsSymmetric) (e : σ ≃ τ) : (rename e φ).IsSymmetric := fun _ => by
   apply rename_injective _ e.symm.injective
   simp_rw [rename_rename, ← Equiv.coe_trans, Equiv.self_trans_symm, Equiv.coe_refl, rename_id]
-  rw [hφ]
+  rw [AlgHom.coe_id, id_eq, hφ]
 
 @[simp]
 theorem _root_.MvPolynomial.isSymmetric_rename {e : σ ≃ τ} :


### PR DESCRIPTION
Also unapply `MvPolynomial.rename_id`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
