### PR TITLE
[Merged by Bors] - feat(SimpleGraph/Operations): add edge_comm and lt_sup_edge

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Operations.lean
@@ -162,8 +162,8 @@ lemma edge_self_eq_bot : edge s s = ⊥ := by
 lemma sup_edge_self : G ⊔ edge s s = G := by
   rw [edge_self_eq_bot, sup_of_le_left bot_le]
 
-lemma lt_sup_edge (hne : s ≠ t) (hnadj : ¬G.Adj s t) : G < G ⊔ edge s t :=
-  left_lt_sup.2 fun h => hnadj <| h (by tauto)
+lemma lt_sup_edge (hne : s ≠ t) (hn : ¬G.Adj s t) : G < G ⊔ edge s t :=
+  left_lt_sup.2 fun h => hn <| h <| (edge_adj ..).mpr ⟨Or.inl ⟨rfl,rfl⟩, hne⟩
 
 variable {s t}
 

--- a/Mathlib/Combinatorics/SimpleGraph/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Operations.lean
@@ -162,7 +162,7 @@ lemma edge_self_eq_bot : edge s s = ⊥ := by
 lemma sup_edge_self : G ⊔ edge s s = G := by
   rw [edge_self_eq_bot, sup_of_le_left bot_le]
 
-lemma lt_sup_edge (hne : s ≠ t) (hn : ¬G.Adj s t) : G < G ⊔ edge s t :=
+lemma lt_sup_edge (hne : s ≠ t) (hn : ¬ G.Adj s t) : G < G ⊔ edge s t :=
   left_lt_sup.2 fun h => hn <| h <| (edge_adj ..).mpr ⟨Or.inl ⟨rfl,rfl⟩, hne⟩
 
 variable {s t}

--- a/Mathlib/Combinatorics/SimpleGraph/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Operations.lean
@@ -148,6 +148,9 @@ def edge : SimpleGraph V := fromEdgeSet {s(s, t)}
 lemma edge_adj (v w : V) : (edge s t).Adj v w ↔ (v = s ∧ w = t ∨ v = t ∧ w = s) ∧ v ≠ w := by
   rw [edge, fromEdgeSet_adj, Set.mem_singleton_iff, Sym2.eq_iff]
 
+lemma edge_comm : edge s t = edge t s := by
+  rw [edge, edge, Sym2.eq_swap]
+
 variable [DecidableEq V] in
 instance : DecidableRel (edge s t).Adj := fun _ _ ↦ by
   rw [edge_adj]; infer_instance
@@ -158,6 +161,9 @@ lemma edge_self_eq_bot : edge s s = ⊥ := by
 @[simp]
 lemma sup_edge_self : G ⊔ edge s s = G := by
   rw [edge_self_eq_bot, sup_of_le_left bot_le]
+
+lemma lt_sup_edge (hne : s ≠ t) (hnadj : ¬G.Adj s t) : G < G ⊔ edge s t :=
+  left_lt_sup.2 fun h => hnadj <| h (by tauto)
 
 variable {s t}
 

--- a/Mathlib/Combinatorics/SimpleGraph/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Operations.lean
@@ -163,7 +163,7 @@ lemma sup_edge_self : G ⊔ edge s s = G := by
   rw [edge_self_eq_bot, sup_of_le_left bot_le]
 
 lemma lt_sup_edge (hne : s ≠ t) (hn : ¬ G.Adj s t) : G < G ⊔ edge s t :=
-  left_lt_sup.2 fun h => hn <| h <| (edge_adj ..).mpr ⟨Or.inl ⟨rfl,rfl⟩, hne⟩
+  left_lt_sup.2 fun h ↦ hn <| h <| (edge_adj ..).mpr ⟨Or.inl ⟨rfl, rfl⟩, hne⟩
 
 variable {s t}
 


### PR DESCRIPTION

Co-authored-by: Lian Tattersall <lian.tattersall.20@alumni.ucl.ac.uk>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
