### PR TITLE
feat(CategoryTheory/Topos): basic definitions and results in topos theory

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2276,6 +2276,10 @@ import Mathlib.CategoryTheory.Subterminal
 import Mathlib.CategoryTheory.Sums.Associator
 import Mathlib.CategoryTheory.Sums.Basic
 import Mathlib.CategoryTheory.Thin
+import Mathlib.CategoryTheory.Topos.Basic
+import Mathlib.CategoryTheory.Topos.Classifier
+import Mathlib.CategoryTheory.Topos.Exponentials
+import Mathlib.CategoryTheory.Topos.Power
 import Mathlib.CategoryTheory.Triangulated.Adjunction
 import Mathlib.CategoryTheory.Triangulated.Basic
 import Mathlib.CategoryTheory.Triangulated.Functor

--- a/Mathlib/CategoryTheory/Topos/Basic.lean
+++ b/Mathlib/CategoryTheory/Topos/Basic.lean
@@ -3,8 +3,9 @@ Copyright (c) 2024 Charlie Conneen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Charlie Conneen
 -/
-import Mathlib.CategoryTheory.Closed.Cartesian
+import Mathlib.CategoryTheory.ChosenFiniteProducts
 import Mathlib.CategoryTheory.Topos.Power
+
 
 /-!
 # Topoi

--- a/Mathlib/CategoryTheory/Topos/Basic.lean
+++ b/Mathlib/CategoryTheory/Topos/Basic.lean
@@ -30,7 +30,7 @@ In this file, a "predicate" refers to any morphism into `Ω C`.
 
 ## Notation
 
-* If `φ` is a predicate `X ⟶ Ω C`, `⌈φ⌉` is shorthand for `Name φ`, 
+* If `φ` is a predicate `X ⟶ Ω C`, `⌈φ⌉` is shorthand for `Name φ`,
   which is the global element `⊤_ C ⟶ Pow X` associated to `φ`.
 
 ## References
@@ -60,7 +60,7 @@ class Topos where
   /-- A topos has power objects. -/
   [has_power_objects : HasPowers C]
 
-attribute [instance] Topos.has_terminal Topos.has_pullbacks 
+attribute [instance] Topos.has_terminal Topos.has_pullbacks
                      Topos.subobject_classifier Topos.has_power_objects
 
 variable [Topos C] {C}
@@ -96,17 +96,17 @@ def Predicate.eq (B : C) : B ⨯ B ⟶ Ω C := ClassifierOf (diag B)
 /-- The lift `X ⟶ B ⨯ B` of a morphism with itself, when composed
 with `predicate.eq B`, is true.
 -/
-lemma Predicate.lift_eq {X B : C} (b : X ⟶ B) : 
+lemma Predicate.lift_eq {X B : C} (b : X ⟶ B) :
     prod.lift b b ≫ Predicate.eq B = Predicate.true_ X := by
   dsimp only [eq, true_]
   rw [←prod.comp_diag b, assoc, (ClassifierComm (diag B)), ←assoc, terminal.comp_from]
 
-/-- Two maps in a topos are equal if their lift composed with 
+/-- Two maps in a topos are equal if their lift composed with
 the equality predicate on `B ⨯ B` is true.
 In other words, this combined with `Predicate.lift_eq` states that
 `Predicate.eq` is able to distinguish whether two morphisms are equal.
 -/
-lemma Predicate.eq_of_lift_eq {X B : C} {b b' : X ⟶ B} 
+lemma Predicate.eq_of_lift_eq {X B : C} {b b' : X ⟶ B}
   (comm' : prod.lift b b' ≫ Predicate.eq B = Predicate.true_ X) :
     b = b' := by
   dsimp only [eq, true_] at comm'
@@ -120,7 +120,7 @@ lemma Predicate.eq_of_lift_eq {X B : C} {b b' : X ⟶ B}
   exact t₁.symm.trans t₂
 
 /-- The "singleton" map `B ⟶ Pow B`.
-In Set, this map sends `b ∈ B` to the 
+In Set, this map sends `b ∈ B` to the
 singleton set containing just `b`.
 -/
 def singleton (B : C) : B ⟶ Pow B := (Predicate.eq B)^
@@ -130,13 +130,13 @@ instance singletonMono (B : C) : Mono (singleton B) where
   right_cancellation := by
     intro X b b' h
     rw [singleton] at h
-    have h₁ : prod.map (𝟙 _) (b ≫ (Predicate.eq B)^) ≫ in_ B 
+    have h₁ : prod.map (𝟙 _) (b ≫ (Predicate.eq B)^) ≫ in_ B
     = prod.map (𝟙 _) (b' ≫ (Predicate.eq B)^) ≫ in_ B :=
       congrFun (congrArg CategoryStruct.comp (congrArg (prod.map (𝟙 B)) h)) (in_ B)
     rw [prod.map_id_comp, assoc, Pow_powerizes, prod.map_id_comp, assoc, Pow_powerizes] at h₁
-    have comm : (b ≫ terminal.from _) ≫ t C 
+    have comm : (b ≫ terminal.from _) ≫ t C
     = prod.lift b (𝟙 _) ≫ prod.map (𝟙 _) b ≫ Predicate.eq _ := by
-      rw [terminal.comp_from, ←assoc, prod.lift_map, comp_id, 
+      rw [terminal.comp_from, ←assoc, prod.lift_map, comp_id,
           id_comp, Predicate.lift_eq, Predicate.true_]
     rw [terminal.comp_from, h₁, ←assoc, prod.lift_map, id_comp, comp_id] at comm
     exact Predicate.eq_of_lift_eq comm.symm
@@ -160,15 +160,15 @@ to the corresponding predicate on `B`.
 def Predicate.fromName {B} (φ' : ⊤_ C ⟶ Pow B) : B ⟶ Ω C :=
   (prod.lift (𝟙 B) (terminal.from B)) ≫ φ'^
 
-/-- The condition from the definition of `Name` 
-as the `P_transpose` of a morphism. 
+/-- The condition from the definition of `Name`
+as the `P_transpose` of a morphism.
 -/
 lemma Predicate.NameDef {B} (φ : B ⟶ Ω C) : (prod.map (𝟙 _) ⌈φ⌉) ≫ (in_ B) = (prod.fst) ≫ φ :=
   Pow_powerizes _ _
 
 /-- The equivalence between morphisms `B ⟶ Ω C` and morphisms `⊤_ C ⟶ Pow B`,
 which comes from the more general equivalence between morphisms `B ⨯ A ⟶ Ω C`
-and morphisms `A ⟶ Pow B`. 
+and morphisms `A ⟶ Pow B`.
 -/
 def Predicate.NameEquiv (B : C) : (B ⟶ Ω C) ≃ (⊤_ C ⟶ Pow B) where
   toFun := Name

--- a/Mathlib/CategoryTheory/Topos/Basic.lean
+++ b/Mathlib/CategoryTheory/Topos/Basic.lean
@@ -1,0 +1,188 @@
+/-
+Copyright (c) 2024 Charlie Conneen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Charlie Conneen
+-/
+import Mathlib.CategoryTheory.Closed.Cartesian
+import Mathlib.CategoryTheory.Topos.Power
+
+/-!
+# Topoi
+
+We follow Mac Lane and Moerdijk in defining a topos as a category
+with a terminal object, pullbacks, a subobject classifier, and
+power objects.
+
+In this file, a "predicate" refers to any morphism into `Ω C`.
+
+## Main definitions
+
+* `CategoryTheory.Topos C` is a typeclass asserting that `C` is a topos.
+
+* The namespace `CategoryTheory.Topos.Predicate` provides an API for various
+  useful predicates, such as `Predicate.eq` as the equality predicate
+  `B ⨯ B ⟶ Ω C`, and `Predicate.isSingleton` which is the classifier of the
+  singleton map `singleton B : B ⟶ Pow B`.
+
+## Main results
+
+* `singleton B : B ⟶ Pow B` is a monomorphism. This is `singletonMono`.
+
+## Notation
+
+* If `φ` is a predicate `X ⟶ Ω C`, `⌈φ⌉` is shorthand for `Name φ`, 
+  which is the global element `⊤_ C ⟶ Pow X` associated to `φ`.
+
+## References
+
+* [S. MacLane and I. Moerdijk, *Sheaves in Geometry and Logic*][MLM92]
+
+-/
+
+namespace CategoryTheory
+
+open Category Limits Classifier Power
+
+universe u v
+
+variable (C : Type u) [Category.{v} C]
+
+/-- A category is a topos if it has a terminal object,
+all pullbacks, a subobject classifier, and power objects.
+-/
+class Topos where
+  /-- A topos has a terminal object. -/
+  [has_terminal : HasTerminal C]
+  /-- A topos has pullbacks. -/
+  [has_pullbacks : HasPullbacks C]
+  /-- A topos has a subobject classifier. -/
+  [subobject_classifier : HasClassifier C]
+  /-- A topos has power objects. -/
+  [has_power_objects : HasPowers C]
+
+attribute [instance] Topos.has_terminal Topos.has_pullbacks 
+                     Topos.subobject_classifier Topos.has_power_objects
+
+variable [Topos C] {C}
+
+namespace Topos
+
+/-- A topos has (chosen) finite products. -/
+noncomputable instance chosenFiniteProducts : ChosenFiniteProducts C :=
+  ChosenFiniteProducts.ofFiniteProducts C
+/-- A topos has binary products. -/
+instance hasBinaryProducts : HasBinaryProducts C :=
+  hasBinaryProducts_of_hasTerminal_and_pullbacks C
+/-- A topos has finite products. -/
+instance hasFiniteProducts : HasFiniteProducts C :=
+  hasFiniteProducts_of_has_binary_and_terminal
+/-- A topos has equalizers, since it has pullbacks and
+binary products.
+-/
+instance hasEqualizers : HasEqualizers C :=
+  hasEqualizers_of_hasPullbacks_and_binary_products
+
+
+noncomputable section
+
+/-- The predicate on `B` which corresponds to the subobject `𝟙 B: B ⟶ B`. -/
+def Predicate.true_ (B : C) : B ⟶ Ω C := terminal.from B ≫ (t C)
+
+/--
+  The equality predicate on `B ⨯ B`.
+-/
+def Predicate.eq (B : C) : B ⨯ B ⟶ Ω C := ClassifierOf (diag B)
+
+/-- The lift `X ⟶ B ⨯ B` of a morphism with itself, when composed
+with `predicate.eq B`, is true.
+-/
+lemma Predicate.lift_eq {X B : C} (b : X ⟶ B) : 
+    prod.lift b b ≫ Predicate.eq B = Predicate.true_ X := by
+  dsimp only [eq, true_]
+  rw [←prod.comp_diag b, assoc, (ClassifierComm (diag B)), ←assoc, terminal.comp_from]
+
+/-- Two maps in a topos are equal if their lift composed with 
+the equality predicate on `B ⨯ B` is true.
+In other words, this combined with `Predicate.lift_eq` states that
+`Predicate.eq` is able to distinguish whether two morphisms are equal.
+-/
+lemma Predicate.eq_of_lift_eq {X B : C} {b b' : X ⟶ B} 
+  (comm' : prod.lift b b' ≫ Predicate.eq B = Predicate.true_ X) :
+    b = b' := by
+  dsimp only [eq, true_] at comm'
+  let cone_lift := ClassifierCone_into (comm' := comm')
+  have t : cone_lift ≫ diag _ = prod.lift b b' := ClassifierCone_into_comm (comm' := comm')
+  rw [prod.comp_diag] at t
+  have t₁ := congrArg (fun k ↦ k ≫ prod.fst) t
+  have t₂ := congrArg (fun k ↦ k ≫ prod.snd) t
+  simp at t₁
+  simp at t₂
+  exact t₁.symm.trans t₂
+
+/-- The "singleton" map `B ⟶ Pow B`.
+In Set, this map sends `b ∈ B` to the 
+singleton set containing just `b`.
+-/
+def singleton (B : C) : B ⟶ Pow B := (Predicate.eq B)^
+
+/-- `singleton B : B ⟶ Pow B` is a monomorphism. -/
+instance singletonMono (B : C) : Mono (singleton B) where
+  right_cancellation := by
+    intro X b b' h
+    rw [singleton] at h
+    have h₁ : prod.map (𝟙 _) (b ≫ (Predicate.eq B)^) ≫ in_ B 
+    = prod.map (𝟙 _) (b' ≫ (Predicate.eq B)^) ≫ in_ B :=
+      congrFun (congrArg CategoryStruct.comp (congrArg (prod.map (𝟙 B)) h)) (in_ B)
+    rw [prod.map_id_comp, assoc, Pow_powerizes, prod.map_id_comp, assoc, Pow_powerizes] at h₁
+    have comm : (b ≫ terminal.from _) ≫ t C 
+    = prod.lift b (𝟙 _) ≫ prod.map (𝟙 _) b ≫ Predicate.eq _ := by
+      rw [terminal.comp_from, ←assoc, prod.lift_map, comp_id, 
+          id_comp, Predicate.lift_eq, Predicate.true_]
+    rw [terminal.comp_from, h₁, ←assoc, prod.lift_map, id_comp, comp_id] at comm
+    exact Predicate.eq_of_lift_eq comm.symm
+
+/-- The predicate on `Pow B` which picks out the subobject of "singletons".
+-/
+def Predicate.isSingleton (B : C) : Pow B ⟶ Ω C := χ_ (singleton B)
+
+/-- The name ⌈φ⌉ : ⊤_ C ⟶ Pow B of a predicate `φ : B ⟶ Ω C`.
+This is the global element of `Pow B` associated to a predicate
+on `B`.
+-/
+def Name {B} (φ : B ⟶ Ω C) : ⊤_ C ⟶ Pow B := (((prod.fst) ≫ φ))^
+
+/-- Notation for `Name`. Consistent with Mac Lane and Moerdijk's notation. -/
+notation "⌈" φ "⌉" => Name φ
+
+/-- The inverse of `Name`, sending a global element of `Pow B`
+to the corresponding predicate on `B`.
+-/
+def Predicate.fromName {B} (φ' : ⊤_ C ⟶ Pow B) : B ⟶ Ω C :=
+  (prod.lift (𝟙 B) (terminal.from B)) ≫ φ'^
+
+/-- The condition from the definition of `Name` 
+as the `P_transpose` of a morphism. 
+-/
+lemma Predicate.NameDef {B} (φ : B ⟶ Ω C) : (prod.map (𝟙 _) ⌈φ⌉) ≫ (in_ B) = (prod.fst) ≫ φ :=
+  Pow_powerizes _ _
+
+/-- The equivalence between morphisms `B ⟶ Ω C` and morphisms `⊤_ C ⟶ Pow B`,
+which comes from the more general equivalence between morphisms `B ⨯ A ⟶ Ω C`
+and morphisms `A ⟶ Pow B`. 
+-/
+def Predicate.NameEquiv (B : C) : (B ⟶ Ω C) ≃ (⊤_ C ⟶ Pow B) where
+  toFun := Name
+  invFun := fromName
+  left_inv := by
+    intro φ
+    dsimp [Name, fromName]
+    rw [P_transpose_left_inv, ←assoc, prod.lift_fst, id_comp]
+  right_inv := by
+    intro φ'
+    dsimp only [Name, fromName]
+    have h := (Limits.prod.rightUnitor B).hom_inv_id
+    dsimp at h
+    rw [←assoc, h, id_comp, P_transpose_right_inv]
+
+end
+end CategoryTheory.Topos

--- a/Mathlib/CategoryTheory/Topos/Classifier.lean
+++ b/Mathlib/CategoryTheory/Topos/Classifier.lean
@@ -117,7 +117,7 @@ terminal.from U              χ_ m
 ```
 is a pullback square.
 -/
-def ClassifierPb : IsPullback m (terminal.from U) (χ_ m) (t C) :=
+lemma ClassifierPb : IsPullback m (terminal.from U) (χ_ m) (t C) :=
   ((Classifier_IsClassifier C).char m).default.prop
 
 /-- The diagram
@@ -136,7 +136,7 @@ lemma ClassifierComm : m ≫ (χ_ m) = terminal.from _ ≫ t C := (ClassifierPb 
 /-- `ClassifierOf m` is the only map for which the associated square
 is a pullback square. 
 -/
-def unique (χ : X ⟶ Ω C) (hχ : IsPullback m (terminal.from _) χ (t C)) : χ = χ_ m := by
+lemma unique (χ : X ⟶ Ω C) (hχ : IsPullback m (terminal.from _) χ (t C)) : χ = χ_ m := by
   have h := ((Classifier_IsClassifier C).char m).uniq (Subtype.mk χ hχ)
   apply_fun (fun x => x.val) at h
   assumption
@@ -178,10 +178,9 @@ then `ClassifierCone_into` is the lift of `g` to `U`;
 the following is a proof that it is indeed a lift, i.e.
 that lift composed with `m` is `g`.
 -/
-def ClassifierCone_into_comm {Z : C} (g : Z ⟶ X) (comm' : g ≫ χ_ m = (terminal.from Z ≫ t C)) :
+lemma ClassifierCone_into_comm {Z : C} (g : Z ⟶ X) (comm' : g ≫ χ_ m = (terminal.from Z ≫ t C)) :
     ClassifierCone_into (comm' := comm') ≫ m = g :=
   IsPullback.lift_fst (ClassifierPb m) _ _ comm'
-
 
 variable [HasClassifier C]
 
@@ -208,7 +207,7 @@ noncomputable instance Mono_is_RegularMono {A B : C} (m : A ⟶ B) [Mono m] : Re
 /-- A category with a subobject classifier satisfies the condition
 that a map which is both monic and epic is an isomorphism. 
 -/
-def balanced {A B : C} (f : A ⟶ B) [ef : Epi f] [Mono f] : IsIso f :=
+lemma balanced {A B : C} (f : A ⟶ B) [ef : Epi f] [Mono f] : IsIso f :=
   @isIso_limit_cone_parallelPair_of_epi _ _ _ _ _ _ _ (Mono_is_RegularMono f).isLimit ef
 
 /-- `C` is a balanced category.  -/
@@ -221,16 +220,15 @@ instance : Balanced Cᵒᵖ := balanced_opposite
 /-- If the source of a faithful functor has a subobject classifier, the functor reflects
   isomorphisms. This holds for any balanced category.
 -/
-def reflectsIsomorphisms (D : Type u₀) [Category.{v₀} D] (F : C ⥤ D) [Functor.Faithful F] :
+theorem reflectsIsomorphisms (D : Type u₀) [Category.{v₀} D] (F : C ⥤ D) [Functor.Faithful F] :
     Functor.ReflectsIsomorphisms F :=
   reflectsIsomorphisms_of_reflectsMonomorphisms_of_reflectsEpimorphisms F
 
 /-- If the source of a faithful functor is the opposite category of one with a subobject classifier,
   the same holds -- the functor reflects isomorphisms.
 -/
-def reflectsIsomorphismsOp (D : Type u₀) [Category.{v₀} D] (F : Cᵒᵖ ⥤ D) [Functor.Faithful F] :
+theorem reflectsIsomorphismsOp (D : Type u₀) [Category.{v₀} D] (F : Cᵒᵖ ⥤ D) [Functor.Faithful F] :
     Functor.ReflectsIsomorphisms F :=
   reflectsIsomorphisms_of_reflectsMonomorphisms_of_reflectsEpimorphisms F
-
 
 end CategoryTheory.Classifier

--- a/Mathlib/CategoryTheory/Topos/Classifier.lean
+++ b/Mathlib/CategoryTheory/Topos/Classifier.lean
@@ -1,0 +1,236 @@
+/-
+Copyright (c) 2024 Charlie Conneen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Charlie Conneen
+-/
+
+import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq
+import Mathlib.CategoryTheory.Limits.Shapes.RegularMono
+import Mathlib.Tactic.ApplyFun
+
+/-!
+
+# Subobject Classifier
+
+We define what it means for a morphism in a category to be a subobject
+classifier as `CategoryTheory.Classifier.IsClassifier`.
+
+## Main definitions
+
+Let `C` refer to a category with a terminal object.
+
+* `CategoryTheory.Classifier.IsClassifier` describes what it means for a
+  pair of an object `Ω : C` and a morphism `t : ⊤_ C ⟶ Ω` to be a subobject
+  classifier for `C`.
+
+* `CategoryTheory.Classifier.HasClassifier C` is the data of `C` having a
+  subobject classifier.
+
+## Main results
+
+* It is a theorem that the truth morphism `⊤_ C ⟶ Ω C` is a (split, and
+  therefore regular) monomorphism.
+
+* `Classifier.balanced` shows that any category with a subobject classifier
+  is balanced. This follows from the fact that every monomorphism is the
+  pullback of a regular monomorphism (the truth morphism).
+
+## Notation
+
+* if `m` is a monomorphism, `χ_ m` denotes characteristic map of `m`,
+  which is the corresponding map to the subobject classifier.
+
+## References
+
+* [S. MacLane and I. Moerdijk, *Sheaves in Geometry and Logic*][MLM92]
+
+-/
+
+
+universe u v u₀ v₀
+
+open CategoryTheory Category Limits Functor
+
+variable {C : Type u} [Category.{v} C] [HasTerminal C]
+
+namespace CategoryTheory.Classifier
+
+/-- A morphism `t : ⊤_ C ⟶ Ω` from the terminal object of a category `C`
+is a subobject classifier if, for every monomorphism `m : U ⟶ X` in `C`,
+there is a unique map `χ : X ⟶ Ω` such that the following square is a pullback square:
+```
+      U ---------m----------> X
+      |                       |
+terminal.from U               χ
+      |                       |
+      v                       v
+    ⊤_ C --------t----------> Ω
+```
+-/
+class IsClassifier {Ω : C} (t : ⊤_ C ⟶ Ω) where
+  /-- For any monomorphism `U ⟶ X`, there is exactly one map `X ⟶ Ω`
+  making the appropriate square a pullback square. -/
+  char {U X : C} (m : U ⟶ X) [Mono m] : Unique { χ : X ⟶ Ω // IsPullback m (terminal.from (U : C)) χ t }
+
+variable (C)
+
+/-- A category C has a subobject classifier if there is some object `Ω` such that
+a morphism `t : ⊤_ C ⟶ Ω` is a subobject classifier (`CategoryTheory.Classifier.IsClassifier`). -/
+class HasClassifier where
+  /-- the target of a subobject classifier -/
+  Ω : C
+  /-- a subobject classifier -/
+  t : ⊤_ C ⟶ Ω
+  /-- the pair `Ω` and `t` form a subobject classifier -/
+  is_classifier : IsClassifier t
+
+variable [HasClassifier C]
+
+/-- shorthand for `HasClassifier.Ω` -/
+abbrev Ω : C := HasClassifier.Ω
+
+/-- shorthand for `HasClassifier.t` -/
+abbrev t : ⊤_ C ⟶ Ω C := HasClassifier.t
+
+/-- helper definition for destructuring `IsClassifier` -/
+def Classifier_IsClassifier : IsClassifier (t C) :=
+  HasClassifier.is_classifier
+
+variable {C}
+variable {U X : C} (χ : X ⟶ Ω C) (m : U ⟶ X) [Mono m]
+
+/-- returns the characteristic morphism of the subobject `(m : U ⟶ X) [Mono m]` -/
+def ClassifierOf : X ⟶ Ω C :=
+  ((Classifier_IsClassifier C).char m).default
+
+/-- shorthand for the characteristic morphism, `ClassifierOf m` -/
+abbrev χ_ := ClassifierOf m
+
+/-- The diagram
+```
+      U ---------m----------> X
+      |                       |
+terminal.from U              χ_ m
+      |                       |
+      v                       v
+    ⊤_ C -------t C---------> Ω
+```
+is a pullback square.
+-/
+def ClassifierPb : IsPullback m (terminal.from U) (χ_ m) (t C) :=
+  ((Classifier_IsClassifier C).char m).default.prop
+
+/-- The diagram
+```
+      U ---------m----------> X
+      |                       |
+terminal.from U              χ_ m
+      |                       |
+      v                       v
+    ⊤_ C -------t C---------> Ω
+```
+commutes.
+-/
+lemma ClassifierComm : m ≫ (χ_ m) = terminal.from _ ≫ t C := (ClassifierPb m).w
+
+/-- `ClassifierOf m` is the only map for which the associated square
+is a pullback square. 
+-/
+def unique (χ : X ⟶ Ω C) (hχ : IsPullback m (terminal.from _) χ (t C)) : χ = χ_ m := by
+  have h := ((Classifier_IsClassifier C).char m).uniq (Subtype.mk χ hχ)
+  apply_fun (fun x => x.val) at h
+  assumption
+
+/-- The underlying `PullbackCone` from the pullback diagram. -/
+noncomputable def ClassifierCone : PullbackCone (χ_ m) (t C) :=
+  PullbackCone.mk m (terminal.from _) (ClassifierComm m)
+
+/-- The underlying `IsLimit` from `ClassifierPb`. -/
+noncomputable def ClassifierPullback :
+    IsLimit (PullbackCone.mk m (terminal.from _) (ClassifierComm m)) :=
+  (ClassifierPb m).isLimit'.some
+
+/-- If a map `g : Z ⟶ X and the following diagram commutes:
+```
+      Z ---------g----------> X
+      |                       |
+terminal.from U              χ_ m
+      |                       |
+      v                       v
+    ⊤_ C -------t C---------> Ω
+```
+then this is shorthand for the lift of `g` to `U`.
+-/
+noncomputable def ClassifierCone_into {Z : C} (g : Z ⟶ X) (comm' : g ≫ (χ_ m) = (terminal.from Z ≫ t C)) :
+    Z ⟶ U :=
+  IsPullback.lift (ClassifierPb m) _ _ comm'
+
+/-- If a map `g : Z ⟶ X and the following diagram commutes:
+```
+      Z ---------g----------> X
+      |                       |
+terminal.from U              χ_ m
+      |                       |
+      v                       v
+    ⊤_ C -------t C---------> Ω
+```
+then `ClassifierCone_into` is the lift of `g` to `U`;
+the following is a proof that it is indeed a lift, i.e.
+that lift composed with `m` is `g`.
+-/
+def ClassifierCone_into_comm {Z : C} (g : Z ⟶ X) (comm' : g ≫ χ_ m = (terminal.from Z ≫ t C)) :
+    ClassifierCone_into (comm' := comm') ≫ m = g :=
+  IsPullback.lift_fst (ClassifierPb m) _ _ comm'
+
+
+variable [HasClassifier C]
+
+/-- `t C` is a regular monomorphism (because it is split). -/
+noncomputable instance truth_is_RegularMono : RegularMono (t C) :=
+  RegularMono.ofIsSplitMono (t C)
+
+/-- The following diagram
+```
+      U ---------m----------> X
+      |                       |
+terminal.from U              χ_ m
+      |                       |
+      v                       v
+    ⊤_ C -------t C---------> Ω
+```
+being a pullback for any monic `m` means that every monomorphism
+in `C` is the pullback of a regular monomorphism; since regularity
+is stable under base change, every monomorphism is regular.
+-/
+noncomputable instance Mono_is_RegularMono {A B : C} (m : A ⟶ B) [Mono m] : RegularMono m :=
+  regularOfIsPullbackFstOfRegular (ClassifierPb m).w (ClassifierPb m).isLimit
+
+/-- A category with a subobject classifier satisfies the condition
+that a map which is both monic and epic is an isomorphism. 
+-/
+def balanced {A B : C} (f : A ⟶ B) [ef : Epi f] [Mono f] : IsIso f :=
+  @isIso_limit_cone_parallelPair_of_epi _ _ _ _ _ _ _ (Mono_is_RegularMono f).isLimit ef
+
+/-- `C` is a balanced category.  -/
+instance : Balanced C where
+  isIso_of_mono_of_epi := fun f => balanced f
+
+/-- Since `C` is balanced, so is `Cᵒᵖ`. -/
+instance : Balanced Cᵒᵖ := balanced_opposite
+
+/-- If the source of a faithful functor has a subobject classifier, the functor reflects
+  isomorphisms. This holds for any balanced category.
+-/
+def reflectsIsomorphisms (D : Type u₀) [Category.{v₀} D] (F : C ⥤ D) [Functor.Faithful F] :
+    Functor.ReflectsIsomorphisms F :=
+  reflectsIsomorphisms_of_reflectsMonomorphisms_of_reflectsEpimorphisms F
+
+/-- If the source of a faithful functor is the opposite category of one with a subobject classifier,
+  the same holds -- the functor reflects isomorphisms.
+-/
+def reflectsIsomorphismsOp (D : Type u₀) [Category.{v₀} D] (F : Cᵒᵖ ⥤ D) [Functor.Faithful F] :
+    Functor.ReflectsIsomorphisms F :=
+  reflectsIsomorphisms_of_reflectsMonomorphisms_of_reflectsEpimorphisms F
+
+
+end CategoryTheory.Classifier

--- a/Mathlib/CategoryTheory/Topos/Classifier.lean
+++ b/Mathlib/CategoryTheory/Topos/Classifier.lean
@@ -134,7 +134,7 @@ commutes.
 lemma ClassifierComm : m ≫ (χ_ m) = terminal.from _ ≫ t C := (ClassifierPb m).w
 
 /-- `ClassifierOf m` is the only map for which the associated square
-is a pullback square. 
+is a pullback square.
 -/
 lemma unique (χ : X ⟶ Ω C) (hχ : IsPullback m (terminal.from _) χ (t C)) : χ = χ_ m := by
   have h := ((Classifier_IsClassifier C).char m).uniq (Subtype.mk χ hχ)
@@ -184,7 +184,7 @@ lemma ClassifierCone_into_comm {Z : C} (g : Z ⟶ X) (comm' : g ≫ χ_ m = (ter
 
 end CategoryTheory.Classifier
 
--- note: linter error caused an issue with `[HasClassifier C]`, 
+-- note: linter error caused an issue with `[HasClassifier C]`,
 -- requiring namespace split.
 
 namespace CategoryTheory.Classifier
@@ -213,9 +213,9 @@ noncomputable instance Mono_is_RegularMono {A B : C} (m : A ⟶ B) [Mono m] : Re
 
 
 /-- A category with a subobject classifier satisfies the condition
-that a map which is both monic and epic is an isomorphism. 
+that a map which is both monic and epic is an isomorphism.
 -/
-lemma balanced {A B : C} (f : A ⟶ B) [ef : Epi f] [Mono f] : IsIso f := 
+lemma balanced {A B : C} (f : A ⟶ B) [ef : Epi f] [Mono f] : IsIso f :=
   isIso_of_epi_of_strongMono f
 
 /-- `C` is a balanced category.  -/

--- a/Mathlib/CategoryTheory/Topos/Classifier.lean
+++ b/Mathlib/CategoryTheory/Topos/Classifier.lean
@@ -70,7 +70,8 @@ terminal.from U               χ
 class IsClassifier {Ω : C} (t : ⊤_ C ⟶ Ω) where
   /-- For any monomorphism `U ⟶ X`, there is exactly one map `X ⟶ Ω`
   making the appropriate square a pullback square. -/
-  char {U X : C} (m : U ⟶ X) [Mono m] : Unique { χ : X ⟶ Ω // IsPullback m (terminal.from (U : C)) χ t }
+  char {U X : C} (m : U ⟶ X) [Mono m] :
+    Unique { χ : X ⟶ Ω // IsPullback m (terminal.from (U : C)) χ t }
 
 variable (C)
 
@@ -161,7 +162,8 @@ terminal.from U              χ_ m
 ```
 then this is shorthand for the lift of `g` to `U`.
 -/
-noncomputable def ClassifierCone_into {Z : C} (g : Z ⟶ X) (comm' : g ≫ (χ_ m) = (terminal.from Z ≫ t C)) :
+noncomputable def ClassifierCone_into {Z : C} (g : Z ⟶ X)
+(comm' : g ≫ (χ_ m) = (terminal.from Z ≫ t C)) :
     Z ⟶ U :=
   IsPullback.lift (ClassifierPb m) _ _ comm'
 

--- a/Mathlib/CategoryTheory/Topos/Classifier.lean
+++ b/Mathlib/CategoryTheory/Topos/Classifier.lean
@@ -182,7 +182,14 @@ lemma ClassifierCone_into_comm {Z : C} (g : Z ⟶ X) (comm' : g ≫ χ_ m = (ter
     ClassifierCone_into (comm' := comm') ≫ m = g :=
   IsPullback.lift_fst (ClassifierPb m) _ _ comm'
 
-variable [HasClassifier C]
+end CategoryTheory.Classifier
+
+-- note: linter error caused an issue with `[HasClassifier C]`, 
+-- requiring namespace split.
+
+namespace CategoryTheory.Classifier
+
+variable (C) [HasClassifier C]
 
 /-- `t C` is a regular monomorphism (because it is split). -/
 noncomputable instance truth_is_RegularMono : RegularMono (t C) :=
@@ -204,15 +211,16 @@ is stable under base change, every monomorphism is regular.
 noncomputable instance Mono_is_RegularMono {A B : C} (m : A ⟶ B) [Mono m] : RegularMono m :=
   regularOfIsPullbackFstOfRegular (ClassifierPb m).w (ClassifierPb m).isLimit
 
+
 /-- A category with a subobject classifier satisfies the condition
 that a map which is both monic and epic is an isomorphism. 
 -/
-lemma balanced {A B : C} (f : A ⟶ B) [ef : Epi f] [Mono f] : IsIso f :=
-  @isIso_limit_cone_parallelPair_of_epi _ _ _ _ _ _ _ (Mono_is_RegularMono f).isLimit ef
+lemma balanced {A B : C} (f : A ⟶ B) [ef : Epi f] [Mono f] : IsIso f := 
+  isIso_of_epi_of_strongMono f
 
 /-- `C` is a balanced category.  -/
 instance : Balanced C where
-  isIso_of_mono_of_epi := fun f => balanced f
+  isIso_of_mono_of_epi := fun f => balanced _ f
 
 /-- Since `C` is balanced, so is `Cᵒᵖ`. -/
 instance : Balanced Cᵒᵖ := balanced_opposite

--- a/Mathlib/CategoryTheory/Topos/Exponentials.lean
+++ b/Mathlib/CategoryTheory/Topos/Exponentials.lean
@@ -1,0 +1,470 @@
+/-
+Copyright (c) 2024 Charlie Conneen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Charlie Conneen
+-/
+import Mathlib.CategoryTheory.Monoidal.OfHasFiniteProducts
+import Mathlib.CategoryTheory.Topos.Basic
+
+
+open CategoryTheory Category Limits Classifier Power Topos
+
+universe u v
+
+variable {C : Type u} [Category.{v} C] [Topos C]
+
+/-!
+# Exponential Objects
+
+Proves that a topos has exponential objects (internal homs).
+Consequently, every topos is Cartesian closed.
+
+## Main definitions
+
+* `Hom A B` is the exponential object, and `eval A B` is the associated
+  "evaluation map" `A ⨯ Hom A B ⟶ B`.
+
+* `IsExponentialObject` says what it means to be an exponential object.
+
+## Main results
+
+* `ToposHasExponentials` shows that a topos has exponential objects.
+  This is done by showing `IsExponentialObject (eval A B)`.
+
+* `ExpAdjEquiv` exhibits `(A ⨯ X ⟶ B) ≃ (X ⟶ Hom A B)` for any `A B X : C`
+  in a topos `C`.
+
+## References
+
+* [S. MacLane and I. Moerdijk, *Sheaves in Geometry and Logic*][MLM92]
+
+-/
+
+
+namespace CategoryTheory.Topos
+
+noncomputable section
+
+/-- The exponential object B^A. -/
+def Hom (A B : C) : C :=
+  pullback
+    ((((prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^ ≫ Predicate.isSingleton B)^)
+    ⌈Predicate.true_ A⌉
+
+/-- The map which sends `A ⟶ B` to its graph as a subobject of `B ⨯ A`. -/
+def Hom_toGraph (A B : C) : Hom A B ⟶ Pow (B ⨯ A) := pullback.fst _ _
+
+/-- The map sending a morphism to its graph is a monomorphism, so that
+the graphs of morphisms `A ⟶ B` may be regarded as subobjects of `B ⨯ A`.
+-/
+instance Hom_toGraph_Mono {A B : C} : Mono (Hom_toGraph A B) := pullback.fst_of_mono
+
+/-- Convenience lemma used in `Hom_comm`. -/
+lemma ExpConeSnd_Terminal (A B : C) : 
+    pullback.snd _ _ = terminal.from (Hom A B) := Unique.eq_default _
+
+/-- Convenience lemma used in `EvalDef_comm`. -/
+lemma Hom_comm (A B : C) : 
+    Hom_toGraph A B ≫ ((((prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^ ≫ Predicate.isSingleton B)^)
+    = terminal.from (Hom A B) ≫ ⌈Predicate.true_ A⌉ := by
+  rw [←ExpConeSnd_Terminal]; exact pullback.condition
+
+/-- This lemma states that the following diagram commutes:
+```
+    A ⨯ Hom A B ---------terminal.from _----------> ⊤_ C
+      |                                               |
+      |                                               |
+(𝟙 A) ⨯ Hom_toGraph A B                              t C
+      |                                               |
+      |                                               |
+      v                                               v
+    A ⨯ Pow (B ⨯ A)  -----------u-------------------> Ω
+```
+where `u` intuitively is the predicate:
+(a,S) ↦ "there is exactly one b in B such that (b,a) in S".
+This is used to define the map `eval A B : A ⨯ Hom A B ⟶ B`
+as a `pullback.lift` where the object `B` serves as the pullback.
+-/
+lemma evalDef_comm (A B : C) :
+  (prod.map (𝟙 A) (Hom_toGraph A B) 
+  ≫ ((prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^) ≫ Predicate.isSingleton B
+  = Predicate.true_ (A ⨯ Hom A B) := by
+    let id_m : A ⨯ Hom A B ⟶ A ⨯ Pow (B ⨯ A) := prod.map (𝟙 _) (Hom_toGraph A B)
+    let v := (((prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^)
+    let σ_B := Predicate.isSingleton B
+    let u := ((v ≫ Predicate.isSingleton B)^)
+    let id_u := prod.map (𝟙 A) u
+    have comm_middle : v ≫ σ_B = id_u ≫ (in_ A) := (Pow_powerizes A (v ≫ σ_B)).symm
+    have comm_left : 
+    id_m ≫ id_u 
+    =  prod.map (𝟙 _) (terminal.from _) ≫ prod.map (𝟙 _) ⌈Predicate.true_ A⌉ := by
+      rw [prod.map_map, prod.map_map]
+      ext; simp
+      rw [prod.map_snd, prod.map_snd, Hom_comm]
+    have h_terminal : 
+    (prod.map (𝟙 A) (terminal.from (Hom A B)) ≫ prod.fst) ≫ terminal.from A = terminal.from _ :=
+      Unique.eq_default _
+    rw [assoc, comm_middle, ←assoc, comm_left, assoc, Predicate.NameDef]
+    dsimp [Predicate.true_]
+    rw [←assoc, ←assoc, h_terminal]
+
+/-- The evaluation map eval : A ⨯ B^A ⟶ B. -/
+def eval (A B : C) : A ⨯ (Hom A B) ⟶ B :=
+  ClassifierCone_into (comm' := evalDef_comm A B)
+
+/-- This states the commutativity of the square relating 
+`eval A B` to `singleton B` and `Hom_toGraph A B`, which
+arises from its definition.
+-/
+lemma evalCondition (A B : C) : 
+    eval A B ≫ singleton B 
+    = prod.map (𝟙 _) (Hom_toGraph A B) ≫ ((prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^ :=
+  ClassifierCone_into_comm _ _ _
+
+/-- A map `f_exp : X ⟶ HomAB` exponentiates `f : A ⨯ X ⟶ B` with respect to
+an "evaluation map" `e : A ⨯ HomAB ⟶ B` if the following diagram commutes:
+```
+
+        A ⨯ X ---f----> B
+          |             ^
+          |            /
+          |           /
+    (𝟙 A) ⨯ f_exp    /
+          |         /
+          |        e
+          |       /
+          |      /
+          |     /
+          |    /
+          v   /
+        A ⨯ HomAB
+```
+-/
+abbrev Exponentiates {A B X HomAB : C}  (e : A ⨯ HomAB ⟶ B) (f : A ⨯ X ⟶ B) (f_exp : X ⟶ HomAB) :=
+  (prod.map (𝟙 _) f_exp) ≫ e = f
+
+/-- An object `HomAB` and a map `e : A ⨯ HomAB ⟶ B` form an exponential object for `A B : C`
+if, for any map `f : A ⨯ X ⟶ B`, there is a unique map `f_exp : A ⟶ PB` such that
+the following diagram commutes:
+```
+
+        A ⨯ X ---f----> B
+          |             ^
+          |            /
+          |           /
+    (𝟙 A) ⨯ f_exp    /
+          |         /
+          |        e
+          |       /
+          |      /
+          |     /
+          |    /
+          v   /
+        A ⨯ HomAB
+```
+-/
+class IsExponentialObject {A B HomAB : C} (e : A ⨯ HomAB ⟶ B) where
+  /-- The map that sends morphisms `A ⨯ X ⟶ B` to morphisms `X ⟶ Hom A B`. -/
+  exp : ∀ {X} (_ : A ⨯ X ⟶ B), X ⟶ HomAB
+  /-- `exp f` satisfies commutativity of the above diagram. -/
+  exponentiates : ∀ {X} (f : A ⨯ X ⟶ B), Exponentiates e f (exp f)
+  /-- `exp f` is the only map that satisfies the above commutativity condition. -/
+  unique' : ∀ {X} {f : A ⨯ X ⟶ B} {exp' : X ⟶ HomAB}, Exponentiates e f exp' → exp f = exp'
+
+/-- What it means for a pair `A B : C` to have an exponential object.
+See `IsExponentialObject`.
+-/
+class HasExponentialObject (A B : C) where
+  /-- The "internal hom" object. -/
+  HomAB : C
+  /-- The evaluation map. -/
+  e : A ⨯ HomAB ⟶ B
+  /-- `HomAB` and `e` form an exponential object for `A B : C`. -/
+  is_exp : IsExponentialObject e
+
+variable (C)
+
+/-- A category has exponential objects if each pair of objects therein has an exponential object. -/
+class HasExponentialObjects where
+  has_exponential_object (A B : C) : HasExponentialObject A B
+
+variable {C}
+
+attribute [instance] HasExponentialObjects.has_exponential_object
+
+variable {A B X : C} (f : A ⨯ X ⟶ B)
+
+/-- Useful definition in the context of the construction of `eval A B`.
+This is the composition of `Hom_map f` with `Hom_toGraph A B`, as exhibited
+in `Hom_mapCondition` below.
+-/
+abbrev h_map : X ⟶ Pow (B ⨯ A) := 
+  ((prod.associator _ _ _).hom ≫ prod.map (𝟙 _) f ≫ Predicate.eq _)^
+
+/-- Helper lemma which shows that the appropriate square commutes 
+in the definition of `Hom_map`.
+-/
+lemma HomMapSquareComm :
+    h_map f ≫ (((prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A))^ ≫ Predicate.isSingleton B)^ =
+    terminal.from X ≫ ⌈Predicate.true_ A⌉ := by
+  -- consider (1⨯f) ≫ (eq B) : B ⨯ A ⨯ X ⟶ Ω C.
+  let id_f'eq : B ⨯ A ⨯ X ⟶ Ω C := prod.map (𝟙 _) f ≫ Predicate.eq _
+  -- h is the map that, in `Set`, takes an element of X to the graph of the corresponding function.
+  -- We want to lift this to a map X ⟶ Exp A B.
+  -- The idea is to show that this map actually "maps elements of X to graphs of functions", which,
+  -- in an arbitrary topos, is the same as checking commutativity of the obvious square.
+  let h : X ⟶ Pow (B ⨯ A) := (((prod.associator _ _ _).hom ≫ id_f'eq)^)
+  -- h is by definition a P-transpose
+  have h_condition : (prod.associator _ _ _).hom ≫ id_f'eq = (prod.map (prod.map (𝟙 _) (𝟙 _)) h) ≫ in_ _ := by
+    rw [prod.map_id_id]
+    symm
+    apply Pow_powerizes
+  -- moving the associator to the rhs of `h_condition`.
+  have h_condition₂ : id_f'eq = (prod.associator _ _ _).inv ≫ (prod.map (prod.map (𝟙 _) (𝟙 _)) h) ≫ in_ _ := by
+    rw [←h_condition, ←assoc, (prod.associator _ _ _).inv_hom_id, id_comp]
+  -- this is the map v: A ⨯ P(B⨯A) ⟶ P(B) which was used in the definition of `Exp A B`.
+  let v : A ⨯ Pow (B ⨯ A) ⟶ Pow B := (((prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^)
+  -- v is by definition a P-transpose
+  have v_condition : (prod.associator _ _ _).inv ≫ in_ (B ⨯ A) = prod.map (𝟙 _) v ≫ in_ _ := (Pow_powerizes _ _).symm
+  have lhs : (prod.map (𝟙 A) h ≫ v ≫ Predicate.isSingleton B)^ = h ≫ (v ≫ Predicate.isSingleton B)^ := by
+    apply Pow_unique
+    rw [prod.map_id_comp, assoc _ _ (in_ A), Pow_powerizes, ←assoc]
+  rw [←lhs]
+  -- Claim that f ≫ {•}_B = (1⨯h) ≫ v.
+  -- This is obtained by showing that both maps are the P-transpose of (1⨯f) ≫ (eq B).
+  -- There might be a slightly faster way to do this.
+  have transpose₁ : id_f'eq^ = f ≫ singleton _ := by
+    apply Pow_unique
+    dsimp only [Topos.singleton]
+    rw [prod.map_id_comp, assoc, (Pow_powerizes B (Predicate.eq B))]
+  have shuffle_h_around : (prod.associator B A X).inv ≫ (prod.map (prod.map (𝟙 _) (𝟙 _)) h) = prod.map (𝟙 _) (prod.map (𝟙 _) h) ≫ (prod.associator _ _ _).inv := by simp
+  have transpose₂ : id_f'eq^ = (prod.map (𝟙 _) h) ≫ v := by
+    apply Pow_unique
+    rw [h_condition₂, ←assoc, shuffle_h_around, prod.map_id_comp, assoc _ _ (in_ B), ←v_condition, assoc]
+  have eqn₁ : f ≫ singleton _ = (prod.map (𝟙 _) h) ≫ v := transpose₁.symm.trans transpose₂
+  -- now compose by the `isSingleton B` predicate.
+  have eqn₂ : f ≫ singleton _ ≫ Predicate.isSingleton _ = (prod.map (𝟙 _) h) ≫ v ≫ Predicate.isSingleton _ := by
+    rw [←assoc, ←assoc, eqn₁]
+  rw [←eqn₂]
+  -- from here, the argument is mostly definition unpacking.
+  apply Pow_unique
+  dsimp only [Name, Predicate.true_, Predicate.isSingleton]
+  have f_terminal : f ≫ terminal.from B = terminal.from _ := Unique.eq_default _
+  have rightUnitor_terminal : (Limits.prod.rightUnitor A).hom ≫ terminal.from A 
+  = terminal.from _ := 
+    Unique.eq_default _
+  have A_X_terminal : prod.map (𝟙 A) (terminal.from X) ≫ terminal.from (A ⨯ ⊤_ C) 
+  = terminal.from _ := 
+    Unique.eq_default _
+  have obv : terminal.from (A ⨯ ⊤_ C) ≫ t C 
+  = prod.map (𝟙 A) (P_transpose (terminal.from (A ⨯ ⊤_ C) ≫ t C)) ≫ in_ A := 
+    (Pow_powerizes _ _).symm
+  have map_def : (Limits.prod.rightUnitor A).hom = prod.fst := rfl
+  rw [ClassifierComm (singleton _), ←assoc, ←map_def, rightUnitor_terminal, ←assoc,
+  f_terminal, prod.map_id_comp, assoc, ←obv, ←assoc, A_X_terminal]
+
+/-- Given a map `f : A ⨯ X ⟶ B`, `Hom_map f` 
+is the associated map `X ⟶ Hom A B`. 
+-/
+def Hom_map : X ⟶ Hom A B :=
+  pullback.lift (h_map f) (terminal.from X) (HomMapSquareComm f)
+
+/-- composing `Hom_map f` with the map sending a morphism to its graph
+is the map `h_map f` defined above.
+-/
+@[simp]
+lemma Hom_mapCondition : Hom_map f ≫ (Hom_toGraph A B) = h_map f :=
+  pullback.lift_fst _ _ _
+
+/-- `Hom_map f` satisfies the condition that
+the following diagram commutes:
+```
+        A ⨯ X ---f----> B
+          |             ^
+          |            /
+          |           /
+    (𝟙 A) ⨯ Hom_map  /
+          |         /
+          |     eval A B
+          |       /
+          |      /
+          |     /
+          |    /
+          v   /
+        A ⨯ (Hom A B)
+```
+-/
+theorem Hom_Exponentiates : Exponentiates (eval A B) f (Hom_map f) := by
+  dsimp only [Exponentiates]
+  rw [←cancel_mono (singleton B), assoc, evalCondition, ←assoc,
+    prod.map_map, id_comp, Hom_mapCondition]
+  have h : P_transpose_inv (f ≫ singleton B) 
+  = P_transpose_inv (prod.map (𝟙 A) (h_map f) ≫ P_transpose ((prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A))) := by
+    rw [P_transpose_inv, P_transpose_inv, prod.map_id_comp, assoc, singleton,
+      Pow_powerizes, prod.map_id_comp, assoc, Pow_powerizes, ←assoc]
+    have h' : (prod.map (𝟙 B) (prod.map (𝟙 A) (h_map f)) ≫ (prod.associator B A (Power.Pow (B ⨯ A))).inv)
+      = (prod.associator B A X).inv ≫ (prod.map (𝟙 _) (h_map f)) := by simp
+    rw [h', assoc, h_map, Pow_powerizes, ←assoc, Iso.inv_hom_id, id_comp]
+  have h₀ := congrArg (fun k => P_transpose k) h
+  have t₁ : ((f ≫ singleton B)^)^ = f ≫ singleton B := (transposeEquiv _ _).right_inv _
+  have t₂ : (((prod.map (𝟙 A) (h_map f) ≫ ((prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A))^))^)^
+    = (prod.map (𝟙 A) (h_map f) ≫ ((prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A))^) :=
+      P_transpose_right_inv _
+  simp only [t₁, t₂] at h₀
+  exact h₀.symm
+
+/-- Proof of the uniqueness of `Hom_map f` as a map
+`X ⟶ Hom A B` satisfying commutativity of the associated
+diagram. See `Hom_Exponentiates`.
+-/
+theorem Hom_Unique {exp' : X ⟶ Hom A B} (h : Exponentiates (eval A B) f exp') : 
+    Hom_map f = exp' := by
+  dsimp only [Exponentiates] at h
+  have h_singleton := congrArg (fun k ↦ k ≫ singleton B) h
+  simp only at h_singleton
+  let v : A ⨯ Pow (B ⨯ A) ⟶ Pow B := (((prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^)
+  -- want to rewrite (1⨯g) ≫ eval A B ≫ singleton B = (1⨯(g≫m)) ≫ v
+  have rhs : eval A B ≫ singleton B = prod.map (𝟙 _) (Hom_toGraph A B) ≫ v := by
+    apply PullbackCone.IsLimit.lift_fst
+  rw [assoc, rhs, ←assoc, ←prod.map_id_comp] at h_singleton
+  let id_f'eq : B ⨯ A ⨯ X ⟶ Ω C := prod.map (𝟙 _) f ≫ Predicate.eq _
+  have h₁ : id_f'eq^ = f ≫ singleton B := by
+    apply Pow_unique
+    dsimp only [id_f'eq, singleton]
+    rw [prod.map_id_comp, assoc, Pow_powerizes _ (Predicate.eq B)]
+  have h₂ : (prod.map (𝟙 _) (prod.map (𝟙 _) (exp' ≫ Hom_toGraph A B)) 
+      ≫ (prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^
+      = prod.map (𝟙 _) (exp' ≫ Hom_toGraph A B) ≫ v := by
+    apply Pow_unique
+    rw [prod.map_id_comp, assoc, Pow_powerizes]
+  have h₃ := Pow_powerizes _ ((prod.map (𝟙 B) (prod.map (𝟙 A) (exp' ≫ Hom_toGraph A B)) 
+      ≫ (prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A)))
+  rw [h₂, h_singleton, ←h₁, Pow_powerizes _ id_f'eq, ←assoc] at h₃
+  have h' := Hom_Exponentiates f
+  dsimp only [Exponentiates] at h'
+  have h'_singleton := congrArg (fun k ↦ k ≫ singleton B) h'
+  simp only at h'_singleton
+  rw [assoc, rhs, ←assoc, ←prod.map_id_comp] at h'_singleton
+  have h₂' : (prod.map (𝟙 _) (prod.map (𝟙 _) (Hom_map f ≫ Hom_toGraph A B)) 
+      ≫ (prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^
+      = prod.map (𝟙 _) (Hom_map f ≫ Hom_toGraph A B) ≫ v := by
+    apply Pow_unique
+    rw [prod.map_id_comp, assoc, Pow_powerizes]
+  have h₃' := Pow_powerizes _ ((prod.map (𝟙 B) (prod.map (𝟙 A) (Hom_map f ≫ Hom_toGraph A B)) 
+    ≫ (prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A)))
+  rw [h₂', h'_singleton, ←h₁, Pow_powerizes _ id_f'eq, ←assoc] at h₃'
+
+  have hx := h₃'.symm.trans h₃
+  have c₀ : prod.map (𝟙 B) (prod.map (𝟙 A) (exp' ≫ Hom_toGraph A B)) ≫ (prod.associator _ _ _).inv
+    = (prod.associator _ _ _).inv ≫ (prod.map (𝟙 _) (exp' ≫ Hom_toGraph A B)) := by simp
+  have c₁ : prod.map (𝟙 B) (prod.map (𝟙 A) (Hom_map f ≫ Hom_toGraph A B)) 
+      ≫ (prod.associator _ _ _).inv
+      = (prod.associator _ _ _).inv ≫ (prod.map (𝟙 _) (Hom_map f ≫ Hom_toGraph A B)) := by simp
+  rw [c₀, c₁] at hx
+  have hy := congrArg (fun k ↦ (prod.associator B A X).hom ≫ k) hx
+  simp only at hy
+  rw [←assoc, ←assoc, Iso.hom_inv_id, id_comp, ←assoc, ←assoc, Iso.hom_inv_id, id_comp] at hy
+  have hz := congrArg (fun k ↦ P_transpose k) hy
+  simp only at hz
+  rw [P_transpose_right_inv, P_transpose_right_inv] at hz
+  rw [cancel_mono] at hz
+  assumption
+
+/-- `eval A B` is an exponential object for the pair `A B : C` -/
+instance Hom_isExponential : IsExponentialObject (eval A B) where
+  exp := Hom_map
+  exponentiates := Hom_Exponentiates
+  unique' := by apply Hom_Unique
+
+/-- A topos `C` has an exponential object for every pair of objects `A B : C` -/
+instance ExponentialObject_inst (A B : C) : HasExponentialObject A B where
+  HomAB := Hom A B
+  e := eval A B
+  is_exp := Hom_isExponential
+
+/-- A topos has all exponential objects. -/
+instance ToposHasExponentials : HasExponentialObjects C where
+  has_exponential_object := ExponentialObject_inst
+
+variable (X Y Z W)
+
+/-- Internal composition in a topos, defined in terms of `Hom_map` -/
+def InternalComposition : (Hom X Y) ⨯ (Hom Y Z) ⟶ Hom X Z :=
+  Hom_map ((prod.associator X (Hom X Y) (Hom Y Z)).inv ≫ (prod.map (eval X Y) (𝟙 _)) ≫ eval Y Z)
+
+variable {X Y Z W}
+
+/-- The global element of `Hom X Y` associated to a morphism `X ⟶ Y`. -/
+def FnName (f : X ⟶ Y) : ⊤_ C ⟶ Hom X Y :=
+  Hom_map (prod.fst ≫ f)
+
+/-- The inverse to `Hom_map`, which sends a morphism `X ⟶ Hom Y Z`
+to its "un-curried" version `Y ⨯ X ⟶ Z`.
+-/
+abbrev Hom_map_inv (f : X ⟶ Hom Y Z) := prod.map (𝟙 _) f ≫ eval _ _
+
+/-- The equivalence between arrows `A ⨯ X ⟶ B` and arrows `X ⟶ Hom A B`. -/
+def ExpAdjEquiv (A B X : C) : (A ⨯ X ⟶ B) ≃ (X ⟶ Hom A B) where
+  toFun := Hom_map
+  invFun := Hom_map_inv
+  left_inv := fun f => Hom_Exponentiates f
+  right_inv := by
+    intro g
+    apply Hom_Unique; rfl
+
+variable (X Y)
+
+/-- The map `Hom A X ⟶ Hom A Y` associated to a map `X ⟶ Y`.
+This is how `ExpFunctor` acts on morphisms.
+-/
+def ExpHom {X Y : C} (A : C) (f : X ⟶ Y) : Hom A X ⟶ Hom A Y := Hom_map (eval A _ ≫ f)
+
+/-- The covariant functor `C ⥤ C` associated to an object `A : C` 
+sending an object `B` to the "internal hom" `Hom A B`.
+-/
+def ExpFunctor (A : C) : C ⥤ C where
+  obj := fun B ↦ Hom A B
+  map := fun {X Y} f ↦ ExpHom A f
+  map_id := by
+    intro X
+    dsimp only [ExpHom]
+    rw [comp_id]
+    apply Hom_Unique
+    dsimp only [Exponentiates]
+    rw [prod.map_id_id, id_comp]
+  map_comp := by
+    intro X Y Z f g
+    change ExpHom A (f ≫ g) = ExpHom A f ≫ ExpHom A g
+    dsimp only [ExpHom]
+    apply Hom_Unique
+    dsimp only [Exponentiates]
+    rw [prod.map_id_comp, assoc, Hom_Exponentiates, ←assoc, Hom_Exponentiates, assoc]
+
+/-- A topos is a monoidal category with monoidal structure coming from binary products. -/
+instance ToposMonoidal : MonoidalCategory C := monoidalOfHasFiniteProducts C
+
+/-- The adjunction between the product and the "internal hom" `Hom A B`. -/
+def TensorHomAdjunction (A : C) : MonoidalCategory.tensorLeft A ⊣ ExpFunctor A := by
+  apply Adjunction.mkOfHomEquiv
+  fapply Adjunction.CoreHomEquiv.mk
+
+  · intro X B
+    exact ExpAdjEquiv A B X
+
+  · intro X X' Y f g
+    change prod.map (𝟙 _) (f ≫ g) ≫ eval _ _ = (prod.map (𝟙 _) f) ≫ prod.map (𝟙 _) g ≫ eval _ _
+    rw [←assoc, prod.map_map, id_comp]
+
+  · intro X Y Y' f g
+    change Hom_map (f ≫ g) = Hom_map f ≫ ExpHom A g
+    apply Hom_Unique
+    dsimp only [Exponentiates, ExpHom]
+    rw [prod.map_id_comp, assoc, Hom_Exponentiates, ←assoc, Hom_Exponentiates]
+
+-- note: wholly unsure why `C` is already CC.
+-- the following produces no errors, but #lint gets mad about it.
+-- /-- A topos is cartesian closed. -/
+-- instance CartesianClosed : CartesianClosed C := by assumption
+
+end
+end CategoryTheory.Topos

--- a/Mathlib/CategoryTheory/Topos/Exponentials.lean
+++ b/Mathlib/CategoryTheory/Topos/Exponentials.lean
@@ -60,11 +60,11 @@ the graphs of morphisms `A ⟶ B` may be regarded as subobjects of `B ⨯ A`.
 instance Hom_toGraph_Mono {A B : C} : Mono (Hom_toGraph A B) := pullback.fst_of_mono
 
 /-- Convenience lemma used in `Hom_comm`. -/
-lemma ExpConeSnd_Terminal (A B : C) : 
+lemma ExpConeSnd_Terminal (A B : C) :
     pullback.snd _ _ = terminal.from (Hom A B) := Unique.eq_default _
 
 /-- Convenience lemma used in `EvalDef_comm`. -/
-lemma Hom_comm (A B : C) : 
+lemma Hom_comm (A B : C) :
     Hom_toGraph A B ≫ ((((prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^ ≫ Predicate.isSingleton B)^)
     = terminal.from (Hom A B) ≫ ⌈Predicate.true_ A⌉ := by
   rw [←ExpConeSnd_Terminal]; exact pullback.condition
@@ -86,7 +86,7 @@ This is used to define the map `eval A B : A ⨯ Hom A B ⟶ B`
 as a `pullback.lift` where the object `B` serves as the pullback.
 -/
 lemma evalDef_comm (A B : C) :
-  (prod.map (𝟙 A) (Hom_toGraph A B) 
+  (prod.map (𝟙 A) (Hom_toGraph A B)
   ≫ ((prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^) ≫ Predicate.isSingleton B
   = Predicate.true_ (A ⨯ Hom A B) := by
     let id_m : A ⨯ Hom A B ⟶ A ⨯ Pow (B ⨯ A) := prod.map (𝟙 _) (Hom_toGraph A B)
@@ -95,13 +95,13 @@ lemma evalDef_comm (A B : C) :
     let u := ((v ≫ Predicate.isSingleton B)^)
     let id_u := prod.map (𝟙 A) u
     have comm_middle : v ≫ σ_B = id_u ≫ (in_ A) := (Pow_powerizes A (v ≫ σ_B)).symm
-    have comm_left : 
-    id_m ≫ id_u 
+    have comm_left :
+    id_m ≫ id_u
     =  prod.map (𝟙 _) (terminal.from _) ≫ prod.map (𝟙 _) ⌈Predicate.true_ A⌉ := by
       rw [prod.map_map, prod.map_map]
       ext; simp
       rw [prod.map_snd, prod.map_snd, Hom_comm]
-    have h_terminal : 
+    have h_terminal :
     (prod.map (𝟙 A) (terminal.from (Hom A B)) ≫ prod.fst) ≫ terminal.from A = terminal.from _ :=
       Unique.eq_default _
     rw [assoc, comm_middle, ←assoc, comm_left, assoc, Predicate.NameDef]
@@ -112,12 +112,12 @@ lemma evalDef_comm (A B : C) :
 def eval (A B : C) : A ⨯ (Hom A B) ⟶ B :=
   ClassifierCone_into (comm' := evalDef_comm A B)
 
-/-- This states the commutativity of the square relating 
+/-- This states the commutativity of the square relating
 `eval A B` to `singleton B` and `Hom_toGraph A B`, which
 arises from its definition.
 -/
-lemma evalCondition (A B : C) : 
-    eval A B ≫ singleton B 
+lemma evalCondition (A B : C) :
+    eval A B ≫ singleton B
     = prod.map (𝟙 _) (Hom_toGraph A B) ≫ ((prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^ :=
   ClassifierCone_into_comm _ _ _
 
@@ -198,10 +198,10 @@ variable {A B X : C} (f : A ⨯ X ⟶ B)
 This is the composition of `Hom_map f` with `Hom_toGraph A B`, as exhibited
 in `Hom_mapCondition` below.
 -/
-abbrev h_map : X ⟶ Pow (B ⨯ A) := 
+abbrev h_map : X ⟶ Pow (B ⨯ A) :=
   ((prod.associator _ _ _).hom ≫ prod.map (𝟙 _) f ≫ Predicate.eq _)^
 
-/-- Helper lemma which shows that the appropriate square commutes 
+/-- Helper lemma which shows that the appropriate square commutes
 in the definition of `Hom_map`.
 -/
 lemma HomMapSquareComm :
@@ -250,21 +250,21 @@ lemma HomMapSquareComm :
   apply Pow_unique
   dsimp only [Name, Predicate.true_, Predicate.isSingleton]
   have f_terminal : f ≫ terminal.from B = terminal.from _ := Unique.eq_default _
-  have rightUnitor_terminal : (Limits.prod.rightUnitor A).hom ≫ terminal.from A 
-  = terminal.from _ := 
+  have rightUnitor_terminal : (Limits.prod.rightUnitor A).hom ≫ terminal.from A
+  = terminal.from _ :=
     Unique.eq_default _
-  have A_X_terminal : prod.map (𝟙 A) (terminal.from X) ≫ terminal.from (A ⨯ ⊤_ C) 
-  = terminal.from _ := 
+  have A_X_terminal : prod.map (𝟙 A) (terminal.from X) ≫ terminal.from (A ⨯ ⊤_ C)
+  = terminal.from _ :=
     Unique.eq_default _
-  have obv : terminal.from (A ⨯ ⊤_ C) ≫ t C 
-  = prod.map (𝟙 A) (P_transpose (terminal.from (A ⨯ ⊤_ C) ≫ t C)) ≫ in_ A := 
+  have obv : terminal.from (A ⨯ ⊤_ C) ≫ t C
+  = prod.map (𝟙 A) (P_transpose (terminal.from (A ⨯ ⊤_ C) ≫ t C)) ≫ in_ A :=
     (Pow_powerizes _ _).symm
   have map_def : (Limits.prod.rightUnitor A).hom = prod.fst := rfl
   rw [ClassifierComm (singleton _), ←assoc, ←map_def, rightUnitor_terminal, ←assoc,
   f_terminal, prod.map_id_comp, assoc, ←obv, ←assoc, A_X_terminal]
 
-/-- Given a map `f : A ⨯ X ⟶ B`, `Hom_map f` 
-is the associated map `X ⟶ Hom A B`. 
+/-- Given a map `f : A ⨯ X ⟶ B`, `Hom_map f`
+is the associated map `X ⟶ Hom A B`.
 -/
 def Hom_map : X ⟶ Hom A B :=
   pullback.lift (h_map f) (terminal.from X) (HomMapSquareComm f)
@@ -298,7 +298,7 @@ theorem Hom_Exponentiates : Exponentiates (eval A B) f (Hom_map f) := by
   dsimp only [Exponentiates]
   rw [←cancel_mono (singleton B), assoc, evalCondition, ←assoc,
     prod.map_map, id_comp, Hom_mapCondition]
-  have h : P_transpose_inv (f ≫ singleton B) 
+  have h : P_transpose_inv (f ≫ singleton B)
   = P_transpose_inv (prod.map (𝟙 A) (h_map f) ≫ P_transpose ((prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A))) := by
     rw [P_transpose_inv, P_transpose_inv, prod.map_id_comp, assoc, singleton,
       Pow_powerizes, prod.map_id_comp, assoc, Pow_powerizes, ←assoc]
@@ -317,7 +317,7 @@ theorem Hom_Exponentiates : Exponentiates (eval A B) f (Hom_map f) := by
 `X ⟶ Hom A B` satisfying commutativity of the associated
 diagram. See `Hom_Exponentiates`.
 -/
-theorem Hom_Unique {exp' : X ⟶ Hom A B} (h : Exponentiates (eval A B) f exp') : 
+theorem Hom_Unique {exp' : X ⟶ Hom A B} (h : Exponentiates (eval A B) f exp') :
     Hom_map f = exp' := by
   dsimp only [Exponentiates] at h
   have h_singleton := congrArg (fun k ↦ k ≫ singleton B) h
@@ -332,12 +332,12 @@ theorem Hom_Unique {exp' : X ⟶ Hom A B} (h : Exponentiates (eval A B) f exp') 
     apply Pow_unique
     dsimp only [id_f'eq, singleton]
     rw [prod.map_id_comp, assoc, Pow_powerizes _ (Predicate.eq B)]
-  have h₂ : (prod.map (𝟙 _) (prod.map (𝟙 _) (exp' ≫ Hom_toGraph A B)) 
+  have h₂ : (prod.map (𝟙 _) (prod.map (𝟙 _) (exp' ≫ Hom_toGraph A B))
       ≫ (prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^
       = prod.map (𝟙 _) (exp' ≫ Hom_toGraph A B) ≫ v := by
     apply Pow_unique
     rw [prod.map_id_comp, assoc, Pow_powerizes]
-  have h₃ := Pow_powerizes _ ((prod.map (𝟙 B) (prod.map (𝟙 A) (exp' ≫ Hom_toGraph A B)) 
+  have h₃ := Pow_powerizes _ ((prod.map (𝟙 B) (prod.map (𝟙 A) (exp' ≫ Hom_toGraph A B))
       ≫ (prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A)))
   rw [h₂, h_singleton, ←h₁, Pow_powerizes _ id_f'eq, ←assoc] at h₃
   have h' := Hom_Exponentiates f
@@ -345,19 +345,19 @@ theorem Hom_Unique {exp' : X ⟶ Hom A B} (h : Exponentiates (eval A B) f exp') 
   have h'_singleton := congrArg (fun k ↦ k ≫ singleton B) h'
   simp only at h'_singleton
   rw [assoc, rhs, ←assoc, ←prod.map_id_comp] at h'_singleton
-  have h₂' : (prod.map (𝟙 _) (prod.map (𝟙 _) (Hom_map f ≫ Hom_toGraph A B)) 
+  have h₂' : (prod.map (𝟙 _) (prod.map (𝟙 _) (Hom_map f ≫ Hom_toGraph A B))
       ≫ (prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^
       = prod.map (𝟙 _) (Hom_map f ≫ Hom_toGraph A B) ≫ v := by
     apply Pow_unique
     rw [prod.map_id_comp, assoc, Pow_powerizes]
-  have h₃' := Pow_powerizes _ ((prod.map (𝟙 B) (prod.map (𝟙 A) (Hom_map f ≫ Hom_toGraph A B)) 
+  have h₃' := Pow_powerizes _ ((prod.map (𝟙 B) (prod.map (𝟙 A) (Hom_map f ≫ Hom_toGraph A B))
     ≫ (prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A)))
   rw [h₂', h'_singleton, ←h₁, Pow_powerizes _ id_f'eq, ←assoc] at h₃'
 
   have hx := h₃'.symm.trans h₃
   have c₀ : prod.map (𝟙 B) (prod.map (𝟙 A) (exp' ≫ Hom_toGraph A B)) ≫ (prod.associator _ _ _).inv
     = (prod.associator _ _ _).inv ≫ (prod.map (𝟙 _) (exp' ≫ Hom_toGraph A B)) := by simp
-  have c₁ : prod.map (𝟙 B) (prod.map (𝟙 A) (Hom_map f ≫ Hom_toGraph A B)) 
+  have c₁ : prod.map (𝟙 B) (prod.map (𝟙 A) (Hom_map f ≫ Hom_toGraph A B))
       ≫ (prod.associator _ _ _).inv
       = (prod.associator _ _ _).inv ≫ (prod.map (𝟙 _) (Hom_map f ≫ Hom_toGraph A B)) := by simp
   rw [c₀, c₁] at hx
@@ -419,7 +419,7 @@ This is how `ExpFunctor` acts on morphisms.
 -/
 def ExpHom {X Y : C} (A : C) (f : X ⟶ Y) : Hom A X ⟶ Hom A Y := Hom_map (eval A _ ≫ f)
 
-/-- The covariant functor `C ⥤ C` associated to an object `A : C` 
+/-- The covariant functor `C ⥤ C` associated to an object `A : C`
 sending an object `B` to the "internal hom" `Hom A B`.
 -/
 def ExpFunctor (A : C) : C ⥤ C where

--- a/Mathlib/CategoryTheory/Topos/Exponentials.lean
+++ b/Mathlib/CategoryTheory/Topos/Exponentials.lean
@@ -6,13 +6,6 @@ Authors: Charlie Conneen
 import Mathlib.CategoryTheory.Monoidal.OfHasFiniteProducts
 import Mathlib.CategoryTheory.Topos.Basic
 
-
-open CategoryTheory Category Limits Classifier Power Topos
-
-universe u v
-
-variable {C : Type u} [Category.{v} C] [Topos C]
-
 /-!
 # Exponential Objects
 
@@ -40,6 +33,11 @@ Consequently, every topos is Cartesian closed.
 
 -/
 
+open CategoryTheory Category Limits Classifier Power Topos
+
+universe u v
+
+variable {C : Type u} [Category.{v} C] [Topos C]
 
 namespace CategoryTheory.Topos
 
@@ -78,7 +76,7 @@ lemma Hom_comm (A B : C) :
       |                                               |
       |                                               |
       v                                               v
-    A ⨯ Pow (B ⨯ A)  -----------u-------------------> Ω
+    A ⨯ Pow (B ⨯ A) ------------u-------------------> Ω
 ```
 where `u` intuitively is the predicate:
 (a,S) ↦ "there is exactly one b in B such that (b,a) in S".
@@ -201,11 +199,13 @@ in `Hom_mapCondition` below.
 abbrev h_map : X ⟶ Pow (B ⨯ A) :=
   ((prod.associator _ _ _).hom ≫ prod.map (𝟙 _) f ≫ Predicate.eq _)^
 
+
 /-- Helper lemma which shows that the appropriate square commutes
 in the definition of `Hom_map`.
 -/
 lemma HomMapSquareComm :
-    h_map f ≫ (((prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A))^ ≫ Predicate.isSingleton B)^ =
+    h_map f ≫ (((prod.associator B A (Power.Pow (B ⨯ A))).inv
+    ≫ in_ (B ⨯ A))^ ≫ Predicate.isSingleton B)^ =
     terminal.from X ≫ ⌈Predicate.true_ A⌉ := by
   -- consider (1⨯f) ≫ (eq B) : B ⨯ A ⨯ X ⟶ Ω C.
   let id_f'eq : B ⨯ A ⨯ X ⟶ Ω C := prod.map (𝟙 _) f ≫ Predicate.eq _
@@ -215,18 +215,22 @@ lemma HomMapSquareComm :
   -- in an arbitrary topos, is the same as checking commutativity of the obvious square.
   let h : X ⟶ Pow (B ⨯ A) := (((prod.associator _ _ _).hom ≫ id_f'eq)^)
   -- h is by definition a P-transpose
-  have h_condition : (prod.associator _ _ _).hom ≫ id_f'eq = (prod.map (prod.map (𝟙 _) (𝟙 _)) h) ≫ in_ _ := by
+  have h_condition : (prod.associator _ _ _).hom ≫ id_f'eq
+  = (prod.map (prod.map (𝟙 _) (𝟙 _)) h) ≫ in_ _ := by
     rw [prod.map_id_id]
     symm
     apply Pow_powerizes
   -- moving the associator to the rhs of `h_condition`.
-  have h_condition₂ : id_f'eq = (prod.associator _ _ _).inv ≫ (prod.map (prod.map (𝟙 _) (𝟙 _)) h) ≫ in_ _ := by
+  have h_condition₂ : id_f'eq
+  = (prod.associator _ _ _).inv ≫ (prod.map (prod.map (𝟙 _) (𝟙 _)) h) ≫ in_ _ := by
     rw [←h_condition, ←assoc, (prod.associator _ _ _).inv_hom_id, id_comp]
   -- this is the map v: A ⨯ P(B⨯A) ⟶ P(B) which was used in the definition of `Exp A B`.
   let v : A ⨯ Pow (B ⨯ A) ⟶ Pow B := (((prod.associator _ _ _).inv ≫ in_ (B ⨯ A))^)
   -- v is by definition a P-transpose
-  have v_condition : (prod.associator _ _ _).inv ≫ in_ (B ⨯ A) = prod.map (𝟙 _) v ≫ in_ _ := (Pow_powerizes _ _).symm
-  have lhs : (prod.map (𝟙 A) h ≫ v ≫ Predicate.isSingleton B)^ = h ≫ (v ≫ Predicate.isSingleton B)^ := by
+  have v_condition : (prod.associator _ _ _).inv ≫ in_ (B ⨯ A)
+  = prod.map (𝟙 _) v ≫ in_ _ := (Pow_powerizes _ _).symm
+  have lhs : (prod.map (𝟙 A) h ≫ v ≫ Predicate.isSingleton B)^
+  = h ≫ (v ≫ Predicate.isSingleton B)^ := by
     apply Pow_unique
     rw [prod.map_id_comp, assoc _ _ (in_ A), Pow_powerizes, ←assoc]
   rw [←lhs]
@@ -237,13 +241,16 @@ lemma HomMapSquareComm :
     apply Pow_unique
     dsimp only [Topos.singleton]
     rw [prod.map_id_comp, assoc, (Pow_powerizes B (Predicate.eq B))]
-  have shuffle_h_around : (prod.associator B A X).inv ≫ (prod.map (prod.map (𝟙 _) (𝟙 _)) h) = prod.map (𝟙 _) (prod.map (𝟙 _) h) ≫ (prod.associator _ _ _).inv := by simp
+  have shuffle_h_around : (prod.associator B A X).inv ≫ (prod.map (prod.map (𝟙 _) (𝟙 _)) h)
+  = prod.map (𝟙 _) (prod.map (𝟙 _) h) ≫ (prod.associator _ _ _).inv := by simp
   have transpose₂ : id_f'eq^ = (prod.map (𝟙 _) h) ≫ v := by
     apply Pow_unique
-    rw [h_condition₂, ←assoc, shuffle_h_around, prod.map_id_comp, assoc _ _ (in_ B), ←v_condition, assoc]
+    rw [h_condition₂, ←assoc, shuffle_h_around, prod.map_id_comp, assoc _ _ (in_ B),
+    ←v_condition, assoc]
   have eqn₁ : f ≫ singleton _ = (prod.map (𝟙 _) h) ≫ v := transpose₁.symm.trans transpose₂
   -- now compose by the `isSingleton B` predicate.
-  have eqn₂ : f ≫ singleton _ ≫ Predicate.isSingleton _ = (prod.map (𝟙 _) h) ≫ v ≫ Predicate.isSingleton _ := by
+  have eqn₂ : f ≫ singleton _ ≫ Predicate.isSingleton _
+  = (prod.map (𝟙 _) h) ≫ v ≫ Predicate.isSingleton _ := by
     rw [←assoc, ←assoc, eqn₁]
   rw [←eqn₂]
   -- from here, the argument is mostly definition unpacking.
@@ -299,15 +306,18 @@ theorem Hom_Exponentiates : Exponentiates (eval A B) f (Hom_map f) := by
   rw [←cancel_mono (singleton B), assoc, evalCondition, ←assoc,
     prod.map_map, id_comp, Hom_mapCondition]
   have h : P_transpose_inv (f ≫ singleton B)
-  = P_transpose_inv (prod.map (𝟙 A) (h_map f) ≫ P_transpose ((prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A))) := by
+      = P_transpose_inv (prod.map (𝟙 A) (h_map f)
+      ≫ P_transpose ((prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A))) := by
     rw [P_transpose_inv, P_transpose_inv, prod.map_id_comp, assoc, singleton,
       Pow_powerizes, prod.map_id_comp, assoc, Pow_powerizes, ←assoc]
-    have h' : (prod.map (𝟙 B) (prod.map (𝟙 A) (h_map f)) ≫ (prod.associator B A (Power.Pow (B ⨯ A))).inv)
+    have h' : (prod.map (𝟙 B) (prod.map (𝟙 A) (h_map f))
+        ≫ (prod.associator B A (Power.Pow (B ⨯ A))).inv)
       = (prod.associator B A X).inv ≫ (prod.map (𝟙 _) (h_map f)) := by simp
     rw [h', assoc, h_map, Pow_powerizes, ←assoc, Iso.inv_hom_id, id_comp]
   have h₀ := congrArg (fun k => P_transpose k) h
   have t₁ : ((f ≫ singleton B)^)^ = f ≫ singleton B := (transposeEquiv _ _).right_inv _
-  have t₂ : (((prod.map (𝟙 A) (h_map f) ≫ ((prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A))^))^)^
+  have t₂ : (((prod.map (𝟙 A) (h_map f)
+      ≫ ((prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A))^))^)^
     = (prod.map (𝟙 A) (h_map f) ≫ ((prod.associator B A (Power.Pow (B ⨯ A))).inv ≫ in_ (B ⨯ A))^) :=
       P_transpose_right_inv _
   simp only [t₁, t₂] at h₀

--- a/Mathlib/CategoryTheory/Topos/Power.lean
+++ b/Mathlib/CategoryTheory/Topos/Power.lean
@@ -131,7 +131,8 @@ lemma Pow_powerizes (B) {A} (f : B ⨯ A ⟶ Ω C) : prod.map (𝟙 _) (f^) ≫ 
 /-- `P_transpose` is the only map which satisfies the commutativity
 of the diagram from `IsPower`.
 -/
-lemma Pow_unique (B) {A} {f : B ⨯ A ⟶ Ω C} {hat' : A ⟶ Pow B} (hat'_powerizes : prod.map (𝟙 _) hat' ≫ in_ B = f ) :
+lemma Pow_unique (B) {A} {f : B ⨯ A ⟶ Ω C} {hat' : A ⟶ Pow B}
+(hat'_powerizes : prod.map (𝟙 _) hat' ≫ in_ B = f ) :
     f^ = hat' := by
   have h := ((Pow_is_power B).hat f).uniq ⟨hat', hat'_powerizes⟩
   apply_fun (fun x => x.val) at h
@@ -324,7 +325,8 @@ def PowSelfAdj : PowFunctorOp C ⊣ PowFunctor C := by
     rw [prod.map_id_comp _ (P_transpose _), assoc _ _ (in_ X'), Pow_powerizes, ←assoc _ _ (in_ X),
       prod.map_map, id_comp, comp_id, ←comp_id f, ←id_comp (P_transpose _), ←prod.map_map,
       assoc, Pow_powerizes]
-    have h : prod.map f (𝟙 Y) ≫ (prod.braiding X Y).hom = (prod.braiding _ _).hom ≫ prod.map (𝟙 _) f := by simp
+    have h : prod.map f (𝟙 Y) ≫ (prod.braiding X Y).hom
+    = (prod.braiding _ _).hom ≫ prod.map (𝟙 _) f := by simp
     rw [←assoc (prod.map f (𝟙 _)), h]
     simp
 
@@ -340,7 +342,8 @@ def PowSelfAdj : PowFunctorOp C ⊣ PowFunctor C := by
     apply Pow_unique
     rw [prod.map_id_comp (P_transpose _), assoc, Pow_powerizes, ←assoc _ _ (in_ Y),
       prod.map_map, id_comp, comp_id, ←comp_id g]
-    have h : prod.map g (𝟙 X) ≫ (prod.braiding X Y).inv = (prod.braiding _ _).inv ≫ prod.map (𝟙 _) g := by simp
+    have h : prod.map g (𝟙 X) ≫ (prod.braiding X Y).inv
+    = (prod.braiding _ _).inv ≫ prod.map (𝟙 _) g := by simp
     rw [←id_comp (P_transpose _), ←prod.map_map, assoc, Pow_powerizes, ←assoc (prod.map g _), h]
     simp only [prod.braiding_inv, prod.lift_map_assoc, comp_id, prod.lift_map, assoc]
 

--- a/Mathlib/CategoryTheory/Topos/Power.lean
+++ b/Mathlib/CategoryTheory/Topos/Power.lean
@@ -1,0 +1,349 @@
+/-
+Copyright (c) 2024 Charlie Conneen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Charlie Conneen
+-/
+import Mathlib.CategoryTheory.Limits.Constructions.FiniteProductsOfBinaryProducts
+import Mathlib.CategoryTheory.Limits.Constructions.Equalizers
+import Mathlib.CategoryTheory.Topos.Classifier
+
+/-!
+# Power Objects
+
+Defines power objects for a category C with a subobject classifier and pullbacks.
+
+## Main definitions
+
+
+## Main results
+
+
+## Notation
+
+* if `f : B ⨯ A ⟶ Ω C` is a morphism in a category with power objects, then 
+  `f^` denotes the corresponding morphism `A ⟶ Pow B`.
+* If `g : A ⟶ Pow B` is a morphism in a category with power objects, then
+  `g^` denotes the corresponding morphism `B ⨯ A ⟶ Ω C`.
+* To "curry" maps in the other coordinate, put the caret `^` before the function argument
+  instead of after.
+
+## References
+
+
+-/
+
+
+
+
+open CategoryTheory Category Limits Classifier
+
+
+universe u v
+variable {C : Type u} [Category.{v} C] [HasTerminal C] [HasClassifier C] [HasPullbacks C]
+
+namespace CategoryTheory.Power
+
+
+/-- Having a subobject classifier implies having terminal objects.
+    Combined with having pullbacks, this shows that C has binary products.
+-/
+instance hasBinaryProducts : HasBinaryProducts C := hasBinaryProducts_of_hasTerminal_and_pullbacks C
+
+/-- A category with a terminal object and binary products 
+has all finite products.
+-/
+instance hasFiniteProducts : HasFiniteProducts C := hasFiniteProducts_of_has_binary_and_terminal
+
+/-- A category with binary products and pullbacks has equalizers. -/
+instance hasEqualizers : HasEqualizers C := hasEqualizers_of_hasPullbacks_and_binary_products
+
+/-- An object `PB` and a map `in_B : B ⨯ PB ⟶ Ω C` form a power object for `B : C`
+if, for any map `f : B ⨯ A ⟶ Ω C`, there is a unique map `f' : A ⟶ PB` such that
+the following diagram commutes:
+```
+
+        B ⨯ A ---f---> Ω C
+          |             ^
+          |            /
+          |           /
+    (𝟙 B) ⨯ f'       /
+          |         /
+          |       in_B
+          |       /
+          |      /
+          |     /
+          |    /
+          v   /
+        B ⨯ PB
+```
+-/
+class IsPower {B PB : C} (in_B : B ⨯ PB ⟶ Ω C) where
+  /-- For each `f`, there is exactly one 
+  morphism `A ⟶ PB` making the above diagram commute.
+  -/
+  hat {A : C} (f : B ⨯ A ⟶ Ω C) : Unique { f' : A ⟶ PB // (prod.map (𝟙 _) f') ≫ in_B = f }
+
+/-- What it means for an object B to have a power object. -/
+class HasPower (B : C) where
+  /-- The power object. -/
+  Pow : C
+  /-- The membership predicate. -/
+  in_ : B ⨯ Pow ⟶ Ω C
+  /-- The pair `Pow` and `in_` form a power object for `B`. -/
+  is_power : IsPower in_
+
+variable (C)
+
+/-- A category has power objects if each of its objects
+has a power object.
+-/
+class HasPowers where
+  /-- Each `B : C` has a power object. -/
+  has_power_object (B : C) : HasPower B
+
+variable {C}
+
+attribute [instance] HasPowers.has_power_object
+
+variable [HasPowers C]
+
+
+/-- Notation for the power object of an object. -/
+abbrev Pow (B : C) : C := (HasPowers.has_power_object B).Pow
+
+/-- Notation for the predicate "b ∈ S" as a map `B ⨯ P(B) ⟶ Ω`. -/
+abbrev in_ (B : C) : B ⨯ (Pow B) ⟶ Ω C := (HasPowers.has_power_object B).in_
+
+instance Pow_is_power (B : C) : IsPower (in_ B) := (HasPowers.has_power_object B).is_power
+
+/-- The map Hom(B⨯A,Ω) → Hom(A,P(B)). 
+This is currying the left argument.
+-/
+def P_transpose {B A} (f : B ⨯ A ⟶ Ω C) : A ⟶ Pow B := ((Pow_is_power B).hat f).default
+
+/-- Shorthand for currying the left argument. -/
+notation f "^" => P_transpose f
+
+/-- `P_transpose` satisfies the commutativity of the diagram from `IsPower`. -/
+lemma Pow_powerizes (B) {A} (f : B ⨯ A ⟶ Ω C) : prod.map (𝟙 _) (f^) ≫ in_ B = f :=
+  (((Pow_is_power B).hat f).default).prop
+
+/-- `P_transpose` is the only map which satisfies the commutativity
+of the diagram from `IsPower`.
+-/
+lemma Pow_unique (B) {A} {f : B ⨯ A ⟶ Ω C} {hat' : A ⟶ Pow B} (hat'_powerizes : prod.map (𝟙 _) hat' ≫ in_ B = f ) :
+    f^ = hat' := by
+  have h := ((Pow_is_power B).hat f).uniq ⟨hat', hat'_powerizes⟩
+  apply_fun (fun x => x.val) at h
+  symm
+  assumption
+
+noncomputable section
+
+/-- Un-currying on the left. -/
+abbrev P_transpose_inv {B A} (f : A ⟶ Pow B) : B ⨯ A ⟶ Ω C := (prod.map (𝟙 _) f) ≫ in_ B
+
+/-- Shorthand for un-currying on the left. -/
+notation f "^" => P_transpose_inv f
+
+/-- Equivalence between Hom(B⨯A,Ω) and Hom(A,P(B)). -/
+def transposeEquiv (A B : C) : (B ⨯ A ⟶ Ω C) ≃ (A ⟶ Pow B) where
+  toFun := P_transpose
+  invFun := P_transpose_inv
+  left_inv := fun f => Pow_powerizes _ _
+  right_inv := by
+    intro g
+    apply Pow_unique
+    rfl
+
+/-- `P_transpose_inv` is a left inverse of
+`P_transpose`.
+-/
+@[simp]
+lemma P_transpose_left_inv {B A} (f : B ⨯ A ⟶ Ω C) : (f^)^ = f :=
+  (transposeEquiv _ _).left_inv _
+
+/-- `P_transpose_inv` is a right inverse of
+`P_transpose`.
+-/
+@[simp]
+lemma P_transpose_right_inv {B A : C} (f : A ⟶ Pow B) : (f^)^ = f :=
+  (transposeEquiv _ _).right_inv _
+
+/-- The map Hom(B⨯A,Ω) → Hom(B,P(A)).
+This is currying the right argument.
+-/
+def P_transpose_symm {B A} (f : B ⨯ A ⟶ Ω C) : B ⟶ Pow A :=
+  P_transpose ((prod.braiding A B).hom ≫ f)
+
+/-- Shorthand for currying the right argument. -/
+notation "^" f => P_transpose_symm f
+
+/-- Un-currying on the right. -/
+abbrev P_transpose_symm_inv {B A} (f : B ⟶ Pow A) : B ⨯ A ⟶ Ω C :=
+  (prod.braiding A B).inv ≫ (P_transpose_inv f)
+
+/-- Shorthand for un-currying on the right. -/
+notation "^" f => P_transpose_symm_inv f
+
+/-- Equivalence between Hom(B⨯A,Ω) and Hom(B,P(A)). -/
+def transposeEquivSymm (A B : C) : (B ⨯ A ⟶ Ω C) ≃ (B ⟶ Pow A) where
+  toFun := P_transpose_symm
+  invFun := P_transpose_symm_inv
+  left_inv := by
+    intro f
+    dsimp only [P_transpose_symm, P_transpose_inv, P_transpose_symm_inv]
+    rw [Pow_powerizes, ←assoc, Iso.inv_hom_id, id_comp]
+  right_inv := by
+    intro g
+    apply Pow_unique
+    rw [←assoc, Iso.hom_inv_id, id_comp]
+
+/-- `P_transpose_symm_inv` is the left inverse
+of `P_transpose_symm`.
+-/
+@[simp]
+lemma P_transpose_symm_left_inv {B A} (f : B ⨯ A ⟶ Ω C) :
+    (^(^f)) = f :=
+  (transposeEquivSymm _ _).left_inv _
+
+/-- `P_transpose_symm_inv` is the right inverse
+of `P_transpose_symm`.
+-/
+@[simp]
+lemma P_transpose_symm_right_inv {B A : C} (f : B ⟶ Pow A) : 
+    (^(^f)) = f :=
+  (transposeEquivSymm _ _).right_inv _
+
+/-- Equivalence between Hom(A,P(B)) and Hom(B, P(A)).
+This is just the composition of `transposeEquiv` and `transposeEquivSymm`.
+-/
+def transpose_transpose_Equiv (A B : C) : (B ⟶ Pow A) ≃ (A ⟶ Pow B) :=
+  -- (transposeEquivSymm A B).symm.trans (transposeEquiv A B)
+  Equiv.trans (transposeEquivSymm A B).symm (transposeEquiv A B)
+
+
+/--
+  The power object functor's action on arrows.
+  Sends `h : A ⟶ B` to the P-transpose of the map `h⨯1 ≫ ∈_B : A ⨯ Pow B ⟶ B ⨯ Pow B ⟶ Ω`.
+-/
+def Pow_map {B A : C} (h : A ⟶ B) : Pow B ⟶ Pow A :=
+  P_transpose ((prod.map h (𝟙 (Pow B))) ≫ (in_ B))
+
+/-- The following diagram commutes:
+```
+    A ⨯ Pow B ----(𝟙 A) ⨯ Pow_map h----> A ⨯ Pow A
+      |                                    |
+      |                                    |
+    h ⨯ (𝟙 (Pow B))                      in_ A
+      |                                    |
+      v                                    v
+    B ⨯ Pow B ----------in_ B-----------> Ω C
+```
+-/
+lemma Pow_map_Powerizes {A B : C} (h : A ⟶ B) :
+    (prod.map (𝟙 A) (Pow_map h)) ≫ in_ A = (prod.map h (𝟙 (Pow B))) ≫ (in_ B) := by
+  dsimp [Pow_map]
+  apply Pow_powerizes
+
+/-- `Pow_map` sends the identity on an object `X` to the identity on `Pow X`. -/
+@[simp]
+lemma Pow_map_id {B : C} : Pow_map (𝟙 B) = 𝟙 (Pow B) := by
+  apply Pow_unique; rfl
+
+
+variable (C)
+
+/--
+  The power object functor.
+  Sends objects `B` to their power objects `Pow B`.
+  Sends arrows `h : A ⟶ B` to the P-transpose of the map `h⨯1 ≫ ∈_B : A ⨯ Pow B ⟶ B ⨯ Pow B ⟶ Ω`,
+  which is the "preimage" morphism `P(h) : Pow B ⟶ Pow A`.
+-/
+def PowFunctor : Cᵒᵖ ⥤ C where
+  obj := fun ⟨B⟩ ↦ Pow B
+  map := fun ⟨h⟩ ↦ Pow_map h
+  map_id := by
+    intro _
+    apply Pow_unique
+    rfl
+  map_comp := by
+    intro ⟨X⟩ ⟨Y⟩ ⟨Z⟩ ⟨f⟩ ⟨g⟩
+    apply Pow_unique
+    dsimp [Pow_map]
+    symm
+    calc
+      prod.map (g ≫ f)  (𝟙 (Pow X)) ≫ in_ X
+        = (prod.map g (𝟙 (Pow X))) ≫ (prod.map f  (𝟙 (Pow X))) ≫ in_ X  := by 
+        rw [←assoc, ←prod.map_comp_id]
+      _ = (prod.map g (𝟙 (Pow X))) ≫ (prod.map (𝟙 Y) (Pow_map f)) ≫ in_ Y := by
+        rw [Pow_map_Powerizes]
+      _ = (prod.map (𝟙 Z) (Pow_map f)) ≫ (prod.map g (𝟙 (Pow Y))) ≫ in_ Y := by
+        repeat rw [prod.map_map_assoc, comp_id, id_comp]
+      _ = (prod.map (𝟙 Z) (Pow_map f)) ≫ (prod.map (𝟙 Z) (Pow_map g)) ≫ in_ Z := by
+        rw [Pow_map_Powerizes]
+      _ = prod.map (𝟙 Z) (Pow_map f ≫ Pow_map g ) ≫ in_ Z  := by
+        rw [←assoc, prod.map_id_comp]
+
+/-- The power object functor, treated as a functor `C ⥤ Cᵒᵖ`. -/
+def PowFunctorOp : C ⥤ Cᵒᵖ where
+  obj := fun B ↦ ⟨Pow B⟩
+  map := fun h ↦ ⟨Pow_map h⟩
+  map_id := by
+    intro _
+    apply congrArg Opposite.op
+    apply (PowFunctor C).map_id
+  map_comp := by
+    intros
+    apply congrArg Opposite.op
+    apply (PowFunctor C).map_comp
+
+/-- exhibiting that the pow functor is adjoint to itself on the right. -/
+def PowSelfAdj : PowFunctorOp C ⊣ PowFunctor C := by
+  apply Adjunction.mkOfHomEquiv
+  fapply Adjunction.CoreHomEquiv.mk
+
+  -- homEquiv step
+  · exact fun X ⟨Y⟩ => {
+      toFun := fun ⟨f⟩ => (transpose_transpose_Equiv X Y).toFun f
+      invFun := fun g => ⟨(transpose_transpose_Equiv X Y).invFun g⟩
+      left_inv := fun ⟨f⟩ => by simp
+      right_inv := fun g => by simp
+    }
+
+  -- homEquiv_naturality_left_symm step
+  · intro X' X ⟨Y⟩ f g
+    simp
+    congr
+    show (transpose_transpose_Equiv X' Y).symm (f ≫ g) =
+      (transpose_transpose_Equiv X Y).symm g ≫ Pow_map f
+    dsimp only [transpose_transpose_Equiv, transposeEquivSymm, transposeEquiv]
+    simp
+    dsimp only [P_transpose_symm, P_transpose_inv, Pow_map]
+    apply Pow_unique
+    rw [prod.map_id_comp _ (P_transpose _), assoc _ _ (in_ X'), Pow_powerizes, ←assoc _ _ (in_ X), 
+      prod.map_map, id_comp, comp_id, ←comp_id f, ←id_comp (P_transpose _), ←prod.map_map,
+      assoc, Pow_powerizes]
+    have h : prod.map f (𝟙 Y) ≫ (prod.braiding X Y).hom = (prod.braiding _ _).hom ≫ prod.map (𝟙 _) f := by simp
+    rw [←assoc (prod.map f (𝟙 _)), h]
+    simp
+
+  -- homEquiv_naturality_right step
+  · intro X ⟨Y⟩ ⟨Y'⟩ ⟨f⟩ ⟨g⟩
+    dsimp only [transpose_transpose_Equiv, transposeEquiv, transposeEquivSymm]
+    simp only [prod.lift_map_assoc, comp_id, Equiv.toFun_as_coe, Equiv.trans_apply,
+      Equiv.coe_fn_symm_mk, Equiv.coe_fn_mk, Equiv.invFun_as_coe, Equiv.symm_trans_apply,
+      Equiv.symm_symm]
+    show P_transpose ((prod.braiding X Y').inv ≫ prod.map (𝟙 X) (g ≫ f) ≫ in_ X) =
+      P_transpose ((prod.braiding X Y).inv ≫ prod.map (𝟙 X) f ≫ in_ X) ≫ Pow_map g
+    dsimp only [P_transpose_inv, Pow_map]
+    apply Pow_unique
+    rw [prod.map_id_comp (P_transpose _), assoc, Pow_powerizes, ←assoc _ _ (in_ Y),
+      prod.map_map, id_comp, comp_id, ←comp_id g]
+    have h : prod.map g (𝟙 X) ≫ (prod.braiding X Y).inv = (prod.braiding _ _).inv ≫ prod.map (𝟙 _) g := by simp
+    rw [←id_comp (P_transpose _), ←prod.map_map, assoc, Pow_powerizes, ←assoc (prod.map g _), h]
+    simp only [prod.braiding_inv, prod.lift_map_assoc, comp_id, prod.lift_map, assoc]
+
+
+end
+end CategoryTheory.Power

--- a/Mathlib/CategoryTheory/Topos/Power.lean
+++ b/Mathlib/CategoryTheory/Topos/Power.lean
@@ -20,7 +20,7 @@ Defines power objects for a category C with a subobject classifier and pullbacks
 
 ## Notation
 
-* if `f : B ⨯ A ⟶ Ω C` is a morphism in a category with power objects, then 
+* if `f : B ⨯ A ⟶ Ω C` is a morphism in a category with power objects, then
   `f^` denotes the corresponding morphism `A ⟶ Pow B`.
 * If `g : A ⟶ Pow B` is a morphism in a category with power objects, then
   `g^` denotes the corresponding morphism `B ⨯ A ⟶ Ω C`.
@@ -49,7 +49,7 @@ namespace CategoryTheory.Power
 -/
 instance hasBinaryProducts : HasBinaryProducts C := hasBinaryProducts_of_hasTerminal_and_pullbacks C
 
-/-- A category with a terminal object and binary products 
+/-- A category with a terminal object and binary products
 has all finite products.
 -/
 instance hasFiniteProducts : HasFiniteProducts C := hasFiniteProducts_of_has_binary_and_terminal
@@ -78,7 +78,7 @@ the following diagram commutes:
 ```
 -/
 class IsPower {B PB : C} (in_B : B ⨯ PB ⟶ Ω C) where
-  /-- For each `f`, there is exactly one 
+  /-- For each `f`, there is exactly one
   morphism `A ⟶ PB` making the above diagram commute.
   -/
   hat {A : C} (f : B ⨯ A ⟶ Ω C) : Unique { f' : A ⟶ PB // (prod.map (𝟙 _) f') ≫ in_B = f }
@@ -116,7 +116,7 @@ abbrev in_ (B : C) : B ⨯ (Pow B) ⟶ Ω C := (HasPowers.has_power_object B).in
 
 instance Pow_is_power (B : C) : IsPower (in_ B) := (HasPowers.has_power_object B).is_power
 
-/-- The map Hom(B⨯A,Ω) → Hom(A,P(B)). 
+/-- The map Hom(B⨯A,Ω) → Hom(A,P(B)).
 This is currying the left argument.
 -/
 def P_transpose {B A} (f : B ⨯ A ⟶ Ω C) : A ⟶ Pow B := ((Pow_is_power B).hat f).default
@@ -211,7 +211,7 @@ lemma P_transpose_symm_left_inv {B A} (f : B ⨯ A ⟶ Ω C) :
 of `P_transpose_symm`.
 -/
 @[simp]
-lemma P_transpose_symm_right_inv {B A : C} (f : B ⟶ Pow A) : 
+lemma P_transpose_symm_right_inv {B A : C} (f : B ⟶ Pow A) :
     (^(^f)) = f :=
   (transposeEquivSymm _ _).right_inv _
 
@@ -274,7 +274,7 @@ def PowFunctor : Cᵒᵖ ⥤ C where
     symm
     calc
       prod.map (g ≫ f)  (𝟙 (Pow X)) ≫ in_ X
-        = (prod.map g (𝟙 (Pow X))) ≫ (prod.map f  (𝟙 (Pow X))) ≫ in_ X  := by 
+        = (prod.map g (𝟙 (Pow X))) ≫ (prod.map f  (𝟙 (Pow X))) ≫ in_ X  := by
         rw [←assoc, ←prod.map_comp_id]
       _ = (prod.map g (𝟙 (Pow X))) ≫ (prod.map (𝟙 Y) (Pow_map f)) ≫ in_ Y := by
         rw [Pow_map_Powerizes]
@@ -321,7 +321,7 @@ def PowSelfAdj : PowFunctorOp C ⊣ PowFunctor C := by
     simp
     dsimp only [P_transpose_symm, P_transpose_inv, Pow_map]
     apply Pow_unique
-    rw [prod.map_id_comp _ (P_transpose _), assoc _ _ (in_ X'), Pow_powerizes, ←assoc _ _ (in_ X), 
+    rw [prod.map_id_comp _ (P_transpose _), assoc _ _ (in_ X'), Pow_powerizes, ←assoc _ _ (in_ X),
       prod.map_map, id_comp, comp_id, ←comp_id f, ←id_comp (P_transpose _), ←prod.map_map,
       assoc, Pow_powerizes]
     have h : prod.map f (𝟙 Y) ≫ (prod.braiding X Y).hom = (prod.braiding _ _).hom ≫ prod.map (𝟙 _) f := by simp


### PR DESCRIPTION
This code contains basic definitions and results in topos theory, including the definition of a subobject classifier, power objects, and topoi. It is proved that every topos has exponential objects, i.e. "internal homs". The mathematical content follows chapter IV sections 1-2 of Mac Lane and Moerdijk's text "Sheaves in Geometry and Logic". 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #21281

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
