### PR TITLE
feat(ModelTheory/FinitelyGenerated): countably many homomorphisms between finitely generated structures and countable structures

### DIFF
--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -585,6 +585,9 @@ def toEmbedding : (M ≃[L] N) → M ↪[L] N :=
 def toHom : (M ≃[L] N) → M →[L] N :=
   HomClass.toHom
 
+theorem injective_toHom : Function.Injective (toHom : (M ≃[L] N) → M →[L] N) :=
+  fun _ _ h ↦ DFunLike.coe_injective (congr_arg (⇑) h)
+
 @[simp]
 theorem toEmbedding_toHom (f : M ≃[L] N) : f.toEmbedding.toHom = f.toHom :=
   rfl

--- a/Mathlib/ModelTheory/FinitelyGenerated.lean
+++ b/Mathlib/ModelTheory/FinitelyGenerated.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Aaron Anderson
+Authors: Aaron Anderson, Gabin Kolly
 -/
 import Mathlib.Data.Set.Finite.Lemmas
 import Mathlib.ModelTheory.Substructures
@@ -63,6 +63,8 @@ theorem fg_bot : (⊥ : L.Substructure M).FG :=
   ⟨∅, by rw [Finset.coe_empty, closure_empty]⟩
 
 instance instInhabited_fg : Inhabited { S : L.Substructure M // S.FG } := ⟨⊥, fg_bot⟩
+
+instance instInhabited_finiteEquiv : Inhabited { S : L.Substructure M // S.FG } := ⟨⊥, fg_bot⟩
 
 theorem fg_closure {s : Set M} (hs : s.Finite) : FG (closure L s) :=
   ⟨hs.toFinset, by rw [hs.coe_toFinset]⟩
@@ -247,6 +249,31 @@ theorem FG.finite [L.IsRelational] (h : FG L M) : Finite M :=
 
 theorem fg_iff_finite [L.IsRelational] : FG L M ↔ Finite M :=
   ⟨FG.finite, fun _ => FG.of_finite⟩
+
+theorem FG.countable_Hom_to_countable (N : Type*) [L.Structure N] [Countable N] (h : FG L M) :
+    Countable (M →[L] N) := by
+  let ⟨S, finite_S, closure_S⟩ := fg_iff.1 h
+  let g : (M →[L] N) → (S → N) :=
+    fun f ↦ f ∘ (↑)
+  have g_inj : Function.Injective g := by
+    intro f f' h
+    apply Hom.eq_of_eqOn_dense closure_S
+    intro x x_in_S
+    exact congr_fun h ⟨x, x_in_S⟩
+  have : Finite ↑S := (S.finite_coe_iff).2 finite_S
+  exact Function.Embedding.countable ⟨g, g_inj⟩
+
+instance FG.instCountable_Hom_to_countable (N : Type*) [L.Structure N] [Countable N] [h : FG L M] :
+    Countable (M →[L] N) :=
+  FG.countable_Hom_to_countable N h
+
+theorem FG.countable_Embedding_to_countable (N : Type*) [L.Structure N] [Countable N] (_ : FG L M) :
+    Countable (M ↪[L] N) :=
+  Function.Embedding.countable ⟨Embedding.toHom, Embedding.toHom_injective⟩
+
+instance Fg.instCountable_Embedding_to_countable (N : Type*) [L.Structure N]
+    [Countable N] [h : FG L M] : Countable (M ↪[L] N) :=
+  FG.countable_Embedding_to_countable N h
 
 theorem cg_def : CG L M ↔ (⊤ : L.Substructure M).CG :=
   ⟨fun h => h.1, fun h => ⟨h⟩⟩

--- a/Mathlib/ModelTheory/FinitelyGenerated.lean
+++ b/Mathlib/ModelTheory/FinitelyGenerated.lean
@@ -250,7 +250,7 @@ theorem FG.finite [L.IsRelational] (h : FG L M) : Finite M :=
 theorem fg_iff_finite [L.IsRelational] : FG L M ↔ Finite M :=
   ⟨FG.finite, fun _ => FG.of_finite⟩
 
-theorem FG.countable_Hom_to_countable (N : Type*) [L.Structure N] [Countable N] (h : FG L M) :
+theorem FG.countable_hom_to_countable (N : Type*) [L.Structure N] [Countable N] (h : FG L M) :
     Countable (M →[L] N) := by
   let ⟨S, finite_S, closure_S⟩ := fg_iff.1 h
   let g : (M →[L] N) → (S → N) :=

--- a/Mathlib/ModelTheory/FinitelyGenerated.lean
+++ b/Mathlib/ModelTheory/FinitelyGenerated.lean
@@ -237,7 +237,7 @@ theorem FG.countable_embedding (N : Type*) [L.Structure N] [Countable N] (_ : FG
     Countable (M ↪[L] N) :=
   Function.Embedding.countable ⟨Embedding.toHom, Embedding.toHom_injective⟩
 
-instance Fg.instCountable_embedding (N : Type*) [L.Structure N]
+instance FG.instCountable_embedding (N : Type*) [L.Structure N]
     [Countable N] [h : FG L M] : Countable (M ↪[L] N) :=
   FG.countable_embedding N h
 
@@ -271,9 +271,17 @@ theorem FG.countable_Embedding_to_countable (N : Type*) [L.Structure N] [Countab
     Countable (M ↪[L] N) :=
   Function.Embedding.countable ⟨Embedding.toHom, Embedding.toHom_injective⟩
 
-instance Fg.instCountable_Embedding_to_countable (N : Type*) [L.Structure N]
+instance FG.instCountable_Embedding_to_countable (N : Type*) [L.Structure N]
     [Countable N] [h : FG L M] : Countable (M ↪[L] N) :=
   FG.countable_Embedding_to_countable N h
+
+theorem FG.countable_Equiv_to_countable (N : Type*) [L.Structure N] [Countable N] (h : FG L M) :
+    Countable (M ≃[L] N) :=
+  Function.Embedding.countable ⟨Equiv.toHom, Equiv.injective_toHom⟩
+
+instance FG.instCountable_Equiv_to_countable (N : Type*) [L.Structure N] [Countable N]
+    [h : FG L M] : Countable (M ≃[L] N) :=
+  FG.countable_Equiv_to_countable N h
 
 theorem cg_def : CG L M ↔ (⊤ : L.Substructure M).CG :=
   ⟨fun h => h.1, fun h => ⟨h⟩⟩

--- a/Mathlib/ModelTheory/FinitelyGenerated.lean
+++ b/Mathlib/ModelTheory/FinitelyGenerated.lean
@@ -250,7 +250,7 @@ theorem FG.finite [L.IsRelational] (h : FG L M) : Finite M :=
 theorem fg_iff_finite [L.IsRelational] : FG L M ↔ Finite M :=
   ⟨FG.finite, fun _ => FG.of_finite⟩
 
-theorem FG.countable_hom_to_countable (N : Type*) [L.Structure N] [Countable N] (h : FG L M) :
+instance FG.instCountable_Hom_to_countable (N : Type*) [L.Structure N] [Countable N] [h : FG L M] :
     Countable (M →[L] N) := by
   let ⟨S, finite_S, closure_S⟩ := fg_iff.1 h
   let g : (M →[L] N) → (S → N) :=
@@ -263,25 +263,13 @@ theorem FG.countable_hom_to_countable (N : Type*) [L.Structure N] [Countable N] 
   have : Finite ↑S := (S.finite_coe_iff).2 finite_S
   exact Function.Embedding.countable ⟨g, g_inj⟩
 
-instance FG.instCountable_Hom_to_countable (N : Type*) [L.Structure N] [Countable N] [h : FG L M] :
-    Countable (M →[L] N) :=
-  FG.countable_Hom_to_countable N h
-
-theorem FG.countable_Embedding_to_countable (N : Type*) [L.Structure N] [Countable N] (_ : FG L M) :
-    Countable (M ↪[L] N) :=
-  Function.Embedding.countable ⟨Embedding.toHom, Embedding.toHom_injective⟩
-
 instance FG.instCountable_Embedding_to_countable (N : Type*) [L.Structure N]
     [Countable N] [h : FG L M] : Countable (M ↪[L] N) :=
-  FG.countable_Embedding_to_countable N h
+ Function.Embedding.countable ⟨Embedding.toHom, Embedding.toHom_injective⟩
 
-theorem FG.countable_Equiv_to_countable (N : Type*) [L.Structure N] [Countable N] (h : FG L M) :
+instance FG.instCountable_Equiv_to_countable (N : Type*) [L.Structure N] [Countable N] [FG L M] :
     Countable (M ≃[L] N) :=
   Function.Embedding.countable ⟨Equiv.toHom, Equiv.injective_toHom⟩
-
-instance FG.instCountable_Equiv_to_countable (N : Type*) [L.Structure N] [Countable N]
-    [h : FG L M] : Countable (M ≃[L] N) :=
-  FG.countable_Equiv_to_countable N h
 
 theorem cg_def : CG L M ↔ (⊤ : L.Substructure M).CG :=
   ⟨fun h => h.1, fun h => ⟨h⟩⟩

--- a/Mathlib/ModelTheory/FinitelyGenerated.lean
+++ b/Mathlib/ModelTheory/FinitelyGenerated.lean
@@ -250,7 +250,7 @@ theorem FG.finite [L.IsRelational] (h : FG L M) : Finite M :=
 theorem fg_iff_finite [L.IsRelational] : FG L M ↔ Finite M :=
   ⟨FG.finite, fun _ => FG.of_finite⟩
 
-instance FG.instCountable_Hom_to_countable (N : Type*) [L.Structure N] [Countable N] [h : FG L M] :
+instance FG.instCountable_hom_to_countable (N : Type*) [L.Structure N] [Countable N] [h : FG L M] :
     Countable (M →[L] N) := by
   let ⟨S, finite_S, closure_S⟩ := fg_iff.1 h
   let g : (M →[L] N) → (S → N) :=
@@ -263,11 +263,11 @@ instance FG.instCountable_Hom_to_countable (N : Type*) [L.Structure N] [Countabl
   have : Finite ↑S := (S.finite_coe_iff).2 finite_S
   exact Function.Embedding.countable ⟨g, g_inj⟩
 
-instance FG.instCountable_Embedding_to_countable (N : Type*) [L.Structure N]
+instance FG.instCountable_embedding_to_countable (N : Type*) [L.Structure N]
     [Countable N] [h : FG L M] : Countable (M ↪[L] N) :=
  Function.Embedding.countable ⟨Embedding.toHom, Embedding.toHom_injective⟩
 
-instance FG.instCountable_Equiv_to_countable (N : Type*) [L.Structure N] [Countable N] [FG L M] :
+instance FG.instCountable_equiv_to_countable (N : Type*) [L.Structure N] [Countable N] [FG L M] :
     Countable (M ≃[L] N) :=
   Function.Embedding.countable ⟨Equiv.toHom, Equiv.injective_toHom⟩
 

--- a/Mathlib/ModelTheory/FinitelyGenerated.lean
+++ b/Mathlib/ModelTheory/FinitelyGenerated.lean
@@ -237,8 +237,8 @@ theorem FG.countable_embedding (N : Type*) [L.Structure N] [Countable N] (_ : FG
     Countable (M ↪[L] N) :=
   Function.Embedding.countable ⟨Embedding.toHom, Embedding.toHom_injective⟩
 
-instance FG.instCountable_embedding (N : Type*) [L.Structure N]
-    [Countable N] [h : FG L M] : Countable (M ↪[L] N) :=
+instance FG.instCountable_embedding (N : Type*) [L.Structure N] [Countable N] [h : FG L M] :
+    Countable (M ↪[L] N) :=
   FG.countable_embedding N h
 
 theorem FG.of_finite [Finite M] : FG L M := by


### PR DESCRIPTION
Add instances of countability for the types of first-order homomorphisms, embeddings and equivalences between a finitely generated structure and a countable structure.

---
This is some preparatory work for #18876 
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
