### PR TITLE
feat(ModelTheory/PartialEquiv): Define the mapping of a self-partialEquiv through an embedding

### DIFF
--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -833,6 +833,23 @@ theorem eq_of_eqOn_dense (hs : closure L s = ⊤) {f g : M →[L] N} (h : s.EqOn
 
 end Hom
 
+namespace Substructure
+
+theorem map_comap (S : L.Substructure N) (f : M →[L] N) :
+    ((S.comap) f).map f = S ⊓ f.range := by
+  rw [le_antisymm_iff]
+  constructor
+  · exact le_inf map_comap_le Hom.map_le_range
+  · intro x ⟨x_in_S, x_in_range⟩
+    rw [mem_map]
+    rw [SetLike.mem_coe, Hom.mem_range] at x_in_range
+    let ⟨y, hy⟩ := x_in_range
+    use y
+    rw [mem_comap, hy]
+    trivial
+
+end Substructure
+
 namespace Embedding
 
 /-- The restriction of a first-order embedding to a substructure `s ⊆ M` gives an embedding `s → N`.
@@ -956,6 +973,58 @@ theorem range_subtype (S : L.Substructure M) : S.subtype.toHom.range = S := by
 @[simp]
 lemma subtype_comp_inclusion {S T : L.Substructure M} (h : S ≤ T) :
     T.subtype.comp (inclusion h) = S.subtype := rfl
+
+/-- Equivalence between equal substructures. -/
+def equivOfEq {S T : L.Substructure M} (h : S = T) : S ≃[L] T := by
+  cases h
+  exact Equiv.refl _ _
+
+@[simp]
+theorem equivOfEq_refl (S : L.Substructure M) : (equivOfEq (Eq.refl S)) = Equiv.refl L S := rfl
+
+@[simp]
+theorem equivOfEq_symm {S T : L.Substructure M} (h : S = T) :
+    (equivOfEq h).symm = equivOfEq h.symm := by
+  cases h
+  rfl
+
+@[simp]
+theorem equivOfEq_comp {S T U : L.Substructure M} (h : S = T) (h' : T = U) :
+    (equivOfEq h').comp (equivOfEq h) = (equivOfEq (h.trans h')) := by
+  cases h
+  cases h'
+  rfl
+
+@[simp]
+theorem equivOfEq_apply {S T : L.Substructure M} (h : S = T) {m : M} (hm : m ∈ S) :
+    equivOfEq h ⟨m, hm⟩ = ⟨m, h ▸ hm⟩ := by
+  cases h
+  rfl
+
+@[simp]
+theorem subtype_comp_EquivOfEq {S T : L.Substructure M} (h : S = T) :
+    T.subtype.comp (equivOfEq h).toEmbedding = S.subtype := by
+  cases h
+  rfl
+
+@[simp]
+theorem substructureEquivMap_refl (S : L.Substructure M):
+    (Embedding.refl L M).substructureEquivMap S = equivOfEq (map_id S).symm := by
+  ext ⟨⟩
+  simp only [Embedding.refl_toHom, SetLike.coe_eq_coe, equivOfEq_apply]
+  rfl
+
+@[simp]
+theorem substructureEquivMap_comp_substructureEquivMap (f : M ↪[L] N) (g : N ↪[L] P)
+    (S : L.Substructure M) : (g.substructureEquivMap (S.map f.toHom)).comp
+    (f.substructureEquivMap S) = (equivOfEq (S.map_map ..).symm).comp
+    ((g.comp f).substructureEquivMap S) := by
+  apply Equiv.injective_toEmbedding
+  apply (subtype _).comp_injective
+  simp only [Equiv.comp_toEmbedding, ← Embedding.comp_assoc, Embedding.subtype_substructureEquivMap,
+    subtype_comp_EquivOfEq]
+  ext
+  rfl
 
 end Substructure
 


### PR DESCRIPTION
Define the mapping of a self-partialEquiv through an embedding and the notion of fully extendable partialEquiv.

---
This is some preparatory work for #18876 
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [ ] depends on: #21276 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
