### PR TITLE
[Merged by Bors] - chore (RingTheory/HahnSeries): fix names that use coeff

### DIFF
--- a/Mathlib/Algebra/Vertex/HVertexOperator.lean
+++ b/Mathlib/Algebra/Vertex/HVertexOperator.lean
@@ -62,7 +62,7 @@ def coeff (A : HVertexOperator Γ R V W) (n : Γ) : V →ₗ[R] W where
   toFun v := ((of R).symm (A v)).coeff n
   map_add' _ _ := by simp
   map_smul' _ _ := by
-    simp only [map_smul, RingHom.id_apply, of_symm_smul, HahnSeries.smul_coeff]
+    simp only [map_smul, RingHom.id_apply, of_symm_smul, HahnSeries.coeff_smul]
 
 @[deprecated (since := "2024-06-18")] alias _root_.VertexAlg.coeff := coeff
 
@@ -93,14 +93,18 @@ def of_coeff (f : Γ → V →ₗ[R] W)
 @[deprecated (since := "2024-06-18")] alias _root_.VertexAlg.HetVertexOperator.of_coeff := of_coeff
 
 @[simp]
-theorem add_coeff (A B : HVertexOperator Γ R V W) : (A + B).coeff = A.coeff + B.coeff := by
+theorem coeff_add (A B : HVertexOperator Γ R V W) : (A + B).coeff = A.coeff + B.coeff := by
   ext
   simp
 
+@[deprecated (since := "2025-01-31")] alias add_coeff := coeff_add
+
 @[simp]
-theorem smul_coeff (A : HVertexOperator Γ R V W) (r : R) : (r • A).coeff = r • (A.coeff) := by
+theorem coeff_smul (A : HVertexOperator Γ R V W) (r : R) : (r • A).coeff = r • (A.coeff) := by
   ext
   simp
+
+@[deprecated (since := "2025-01-31")] alias smul_coeff := coeff_smul
 
 end Coeff
 
@@ -123,21 +127,21 @@ def compHahnSeries (u : U) : HahnSeries Γ' (HahnSeries Γ W) where
     intro g' hg' hAB
     apply hg'
     simp_rw [hAB]
-    simp_all only [map_zero, HahnSeries.zero_coeff, not_true_eq_false]
+    simp_all only [map_zero, HahnSeries.coeff_zero, not_true_eq_false]
 
 @[simp]
 theorem compHahnSeries_add (u v : U) :
     compHahnSeries A B (u + v) = compHahnSeries A B u + compHahnSeries A B v := by
   ext
-  simp only [compHahnSeries_coeff, map_add, coeff_apply, HahnSeries.add_coeff', Pi.add_apply]
-  rw [← HahnSeries.add_coeff]
+  simp only [compHahnSeries_coeff, map_add, coeff_apply, HahnSeries.coeff_add', Pi.add_apply]
+  rw [← HahnSeries.coeff_add]
 
 @[simp]
 theorem compHahnSeries_smul (r : R) (u : U) :
     compHahnSeries A B (r • u) = r • compHahnSeries A B u := by
   ext
-  simp only [compHahnSeries_coeff, LinearMapClass.map_smul, coeff_apply, HahnSeries.smul_coeff]
-  rw [← HahnSeries.smul_coeff]
+  simp only [compHahnSeries_coeff, LinearMapClass.map_smul, coeff_apply, HahnSeries.coeff_smul]
+  rw [← HahnSeries.coeff_smul]
 
 /-- The composite of two heterogeneous vertex operators, as a heterogeneous vertex operator. -/
 @[simps]
@@ -147,17 +151,19 @@ def comp : HVertexOperator (Γ' ×ₗ Γ) R U W where
     intro u v
     ext g
     simp only [HahnSeries.ofIterate, compHahnSeries_add, Equiv.symm_apply_apply,
-      HahnModule.of_symm_add, HahnSeries.add_coeff', Pi.add_apply]
+      HahnModule.of_symm_add, HahnSeries.coeff_add', Pi.add_apply]
   map_smul' := by
     intro r x
     ext g
-    simp only [HahnSeries.ofIterate, compHahnSeries_smul, HahnSeries.smul_coeff,
+    simp only [HahnSeries.ofIterate, compHahnSeries_smul, HahnSeries.coeff_smul,
       compHahnSeries_coeff, coeff_apply, Equiv.symm_apply_apply, RingHom.id_apply, of_symm_smul]
 
 @[simp]
-theorem comp_coeff (g : Γ' ×ₗ Γ) :
+theorem coeff_comp (g : Γ' ×ₗ Γ) :
     (comp A B).coeff g = A.coeff (ofLex g).2 ∘ₗ B.coeff (ofLex g).1 := by
   rfl
+
+@[deprecated (since := "2025-01-31")] alias comp_coeff := coeff_comp
 
 end Products
 

--- a/Mathlib/Algebra/Vertex/VertexOperator.lean
+++ b/Mathlib/Algebra/Vertex/VertexOperator.lean
@@ -58,11 +58,11 @@ theorem coeff_eq_ncoeff (A : VertexOperator R V)
 
 @[simp]
 theorem ncoeff_add (A B : VertexOperator R V) (n : ℤ) : (A + B) [[n]] = A [[n]] + B [[n]] := by
-  rw [ncoeff, ncoeff, ncoeff, add_coeff, Pi.add_apply]
+  rw [ncoeff, ncoeff, ncoeff, coeff_add, Pi.add_apply]
 
 @[simp]
 theorem ncoeff_smul (A : VertexOperator R V) (r : R) (n : ℤ) : (r • A) [[n]] = r • A [[n]] := by
-  rw [ncoeff, ncoeff, smul_coeff, Pi.smul_apply]
+  rw [ncoeff, ncoeff, coeff_smul, Pi.smul_apply]
 
 theorem ncoeff_eq_zero_of_lt_order (A : VertexOperator R V) (n : ℤ) (x : V)
     (h : -n - 1 < HahnSeries.order ((HahnModule.of R).symm (A x))) : (A [[n]]) x = 0 := by

--- a/Mathlib/RingTheory/HahnSeries/Addition.lean
+++ b/Mathlib/RingTheory/HahnSeries/Addition.lean
@@ -59,17 +59,23 @@ instance : AddMonoid (HahnSeries Γ R) where
     apply add_zero
 
 @[simp]
-theorem add_coeff' {x y : HahnSeries Γ R} : (x + y).coeff = x.coeff + y.coeff :=
+theorem coeff_add' {x y : HahnSeries Γ R} : (x + y).coeff = x.coeff + y.coeff :=
   rfl
 
-theorem add_coeff {x y : HahnSeries Γ R} {a : Γ} : (x + y).coeff a = x.coeff a + y.coeff a :=
+@[deprecated (since := "2025-01-31")] alias add_coeff' := coeff_add'
+
+theorem coeff_add {x y : HahnSeries Γ R} {a : Γ} : (x + y).coeff a = x.coeff a + y.coeff a :=
   rfl
+
+@[deprecated (since := "2025-01-31")] alias add_coeff := coeff_add
 
 @[simp]
-theorem nsmul_coeff {x : HahnSeries Γ R} {n : ℕ} : (n • x).coeff = n • x.coeff := by
+theorem coeff_nsmul {x : HahnSeries Γ R} {n : ℕ} : (n • x).coeff = n • x.coeff := by
   induction n with
   | zero => simp
   | succ n ih => simp [add_nsmul, ih]
+
+@[deprecated (since := "2025-01-31")] alias nsmul_coeff := coeff_nsmul
 
 @[simp]
 protected lemma map_add [AddMonoid S] (f : R →+ S) {x y : HahnSeries Γ R} :
@@ -110,9 +116,9 @@ lemma addOppositeEquiv_orderTop (x : HahnSeries Γ (Rᵃᵒᵖ)) :
   classical
   simp only [orderTop, AddOpposite.unop_op, mk_eq_zero, EmbeddingLike.map_eq_zero_iff,
     addOppositeEquiv_support, ne_eq]
-  simp only [addOppositeEquiv_apply, AddOpposite.unop_op, mk_eq_zero, zero_coeff]
+  simp only [addOppositeEquiv_apply, AddOpposite.unop_op, mk_eq_zero, coeff_zero]
   simp_rw [HahnSeries.ext_iff, funext_iff]
-  simp only [Pi.zero_apply, AddOpposite.unop_eq_zero_iff, zero_coeff]
+  simp only [Pi.zero_apply, AddOpposite.unop_eq_zero_iff, coeff_zero]
 
 @[simp]
 lemma addOppositeEquiv_symm_orderTop (x : (HahnSeries Γ R)ᵃᵒᵖ) :
@@ -125,9 +131,9 @@ lemma addOppositeEquiv_leadingCoeff (x : HahnSeries Γ (Rᵃᵒᵖ)) :
   classical
   simp only [leadingCoeff, AddOpposite.unop_op, mk_eq_zero, EmbeddingLike.map_eq_zero_iff,
     addOppositeEquiv_support, ne_eq]
-  simp only [addOppositeEquiv_apply, AddOpposite.unop_op, mk_eq_zero, zero_coeff]
+  simp only [addOppositeEquiv_apply, AddOpposite.unop_op, mk_eq_zero, coeff_zero]
   simp_rw [HahnSeries.ext_iff, funext_iff]
-  simp only [Pi.zero_apply, AddOpposite.unop_eq_zero_iff, zero_coeff]
+  simp only [Pi.zero_apply, AddOpposite.unop_eq_zero_iff, coeff_zero]
   split <;> rfl
 
 @[simp]
@@ -138,7 +144,7 @@ lemma addOppositeEquiv_symm_leadingCoeff (x : (HahnSeries Γ R)ᵃᵒᵖ) :
 
 theorem support_add_subset {x y : HahnSeries Γ R} : support (x + y) ⊆ support x ∪ support y :=
   fun a ha => by
-  rw [mem_support, add_coeff] at ha
+  rw [mem_support, coeff_add] at ha
   rw [Set.mem_union, mem_support, mem_support]
   contrapose! ha
   rw [ha.1, ha.2, add_zero]
@@ -172,7 +178,7 @@ theorem orderTop_add_eq_left {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
   have hx : x ≠ 0 := ne_zero_iff_orderTop.mpr hxy.ne_top
   let g : Γ := Set.IsWF.min x.isWF_support (support_nonempty_iff.2 hx)
   have hcxyne : (x + y).coeff g ≠ 0 := by
-    rw [add_coeff, coeff_eq_zero_of_lt_orderTop (lt_of_eq_of_lt (orderTop_of_ne hx).symm hxy),
+    rw [coeff_add, coeff_eq_zero_of_lt_orderTop (lt_of_eq_of_lt (orderTop_of_ne hx).symm hxy),
       add_zero]
     exact coeff_orderTop_ne (orderTop_of_ne hx)
   have hxyx : (x + y).orderTop ≤ x.orderTop := by
@@ -194,7 +200,7 @@ theorem leadingCoeff_add_eq_left {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
   · rw [h, orderTop_zero] at ho
     rw [h, orderTop_eq_top_iff.mp ho.symm]
   · rw [orderTop_of_ne h, orderTop_of_ne hx, WithTop.coe_eq_coe] at ho
-    rw [leadingCoeff_of_ne h, leadingCoeff_of_ne hx, ho, add_coeff,
+    rw [leadingCoeff_of_ne h, leadingCoeff_of_ne hx, ho, coeff_add,
       coeff_eq_zero_of_lt_orderTop (lt_of_eq_of_lt (orderTop_of_ne hx).symm hxy), add_zero]
 
 theorem leadingCoeff_add_eq_right {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
@@ -215,8 +221,8 @@ def single.addMonoidHom (a : Γ) : R →+ HahnSeries Γ R :=
 @[simps]
 def coeff.addMonoidHom (g : Γ) : HahnSeries Γ R →+ R where
   toFun f := f.coeff g
-  map_zero' := zero_coeff
-  map_add' _ _ := add_coeff
+  map_zero' := coeff_zero
+  map_add' _ _ := coeff_add
 
 section Domain
 
@@ -249,7 +255,7 @@ open BigOperators
 @[simp]
 theorem coeff_sum {s : Finset α} {x : α → HahnSeries Γ R} (g : Γ) :
     (∑ i ∈ s, x i).coeff g = ∑ i ∈ s, (x i).coeff g :=
-  cons_induction rfl (fun i s his hsum => by rw [sum_cons, sum_cons, add_coeff, hsum]) s
+  cons_induction rfl (fun i s his hsum => by rw [sum_cons, sum_cons, coeff_add, hsum]) s
 
 end AddCommMonoid
 
@@ -272,11 +278,15 @@ instance : AddGroup (HahnSeries Γ R) :=
       apply neg_add_cancel }
 
 @[simp]
-theorem neg_coeff' {x : HahnSeries Γ R} : (-x).coeff = -x.coeff :=
+theorem coeff_neg' {x : HahnSeries Γ R} : (-x).coeff = -x.coeff :=
   rfl
 
-theorem neg_coeff {x : HahnSeries Γ R} {a : Γ} : (-x).coeff a = -x.coeff a :=
+@[deprecated (since := "2025-01-31")] alias neg_coeff' := coeff_neg'
+
+theorem coeff_neg {x : HahnSeries Γ R} {a : Γ} : (-x).coeff a = -x.coeff a :=
   rfl
+
+@[deprecated (since := "2025-01-31")] alias neg_coeff := coeff_neg
 
 @[simp]
 theorem support_neg {x : HahnSeries Γ R} : (-x).support = x.support := by
@@ -299,12 +309,16 @@ theorem order_neg [Zero Γ] {f : HahnSeries Γ R} : (-f).order = f.order := by
   simp only [order, support_neg, neg_eq_zero]
 
 @[simp]
-theorem sub_coeff' {x y : HahnSeries Γ R} : (x - y).coeff = x.coeff - y.coeff := by
+theorem coeff_sub' {x y : HahnSeries Γ R} : (x - y).coeff = x.coeff - y.coeff := by
   ext
   simp [sub_eq_add_neg]
 
-theorem sub_coeff {x y : HahnSeries Γ R} {a : Γ} : (x - y).coeff a = x.coeff a - y.coeff a := by
+@[deprecated (since := "2025-01-31")] alias sub_coeff' := coeff_sub'
+
+theorem coeff_sub {x y : HahnSeries Γ R} {a : Γ} : (x - y).coeff a = x.coeff a - y.coeff a := by
   simp
+
+@[deprecated (since := "2025-01-31")] alias sub_coeff := coeff_sub
 
 @[simp]
 protected lemma map_sub [AddGroup S] (f : R →+ S) {x y : HahnSeries Γ R} :
@@ -346,15 +360,17 @@ instance : SMul R (HahnSeries Γ V) :=
       isPWO_support' := x.isPWO_support.mono (Function.support_const_smul_subset r x.coeff) }⟩
 
 @[simp]
-theorem smul_coeff {r : R} {x : HahnSeries Γ V} {a : Γ} : (r • x).coeff a = r • x.coeff a :=
+theorem coeff_smul {r : R} {x : HahnSeries Γ V} {a : Γ} : (r • x).coeff a = r • x.coeff a :=
   rfl
+
+@[deprecated (since := "2025-01-31")] alias smul_coeff := coeff_smul
 
 instance : SMulZeroClass R (HahnSeries Γ V) :=
   { inferInstanceAs (SMul R (HahnSeries Γ V)) with
     smul_zero := by
       intro
       ext
-      simp only [smul_coeff, zero_coeff, smul_zero]}
+      simp only [coeff_smul, coeff_zero, smul_zero]}
 
 theorem orderTop_smul_not_lt (r : R) (x : HahnSeries Γ V) : ¬ (r • x).orderTop < x.orderTop := by
   by_cases hrx : r • x = 0

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -89,15 +89,17 @@ instance [Subsingleton R] : Subsingleton (HahnSeries Γ R) :=
   ⟨fun _ _ => HahnSeries.ext (by subsingleton)⟩
 
 @[simp]
-theorem zero_coeff {a : Γ} : (0 : HahnSeries Γ R).coeff a = 0 :=
+theorem coeff_zero {a : Γ} : (0 : HahnSeries Γ R).coeff a = 0 :=
   rfl
+
+@[deprecated (since := "2025-01-31")] alias zero_coeff := coeff_zero
 
 @[simp]
 theorem coeff_fun_eq_zero_iff {x : HahnSeries Γ R} : x.coeff = 0 ↔ x = 0 :=
   coeff_injective.eq_iff' rfl
 
 theorem ne_zero_of_coeff_ne_zero {x : HahnSeries Γ R} {g : Γ} (h : x.coeff g ≠ 0) : x ≠ 0 :=
-  mt (fun x0 => (x0.symm ▸ zero_coeff : x.coeff g = 0)) h
+  mt (fun x0 => (x0.symm ▸ coeff_zero : x.coeff g = 0)) h
 
 @[simp]
 theorem support_zero : support (0 : HahnSeries Γ R) = ∅ :=
@@ -174,16 +176,22 @@ def single (a : Γ) : ZeroHom R (HahnSeries Γ R) where
 variable {a b : Γ} {r : R}
 
 @[simp]
-theorem single_coeff_same (a : Γ) (r : R) : (single a r).coeff a = r := by
+theorem coeff_single_same (a : Γ) (r : R) : (single a r).coeff a = r := by
   classical exact Pi.single_eq_same (f := fun _ => R) a r
 
+@[deprecated (since := "2025-01-31")] alias single_coeff_same := coeff_single_same
+
 @[simp]
-theorem single_coeff_of_ne (h : b ≠ a) : (single a r).coeff b = 0 := by
+theorem coeff_single_of_ne (h : b ≠ a) : (single a r).coeff b = 0 := by
   classical exact Pi.single_eq_of_ne (f := fun _ => R) h r
 
+@[deprecated (since := "2025-01-31")] alias single_coeff_of_ne := coeff_single_of_ne
+
 open Classical in
-theorem single_coeff : (single a r).coeff b = if b = a then r else 0 := by
+theorem coeff_single : (single a r).coeff b = if b = a then r else 0 := by
   split_ifs with h <;> simp [h]
+
+@[deprecated (since := "2025-01-31")] alias single_coeff := coeff_single
 
 @[simp]
 theorem support_single_of_ne (h : r ≠ 0) : support (single a r) = {a} := by
@@ -199,7 +207,7 @@ theorem single_eq_zero : single a (0 : R) = 0 :=
   (single a).map_zero
 
 theorem single_injective (a : Γ) : Function.Injective (single a : R → HahnSeries Γ R) :=
-  fun r s rs => by rw [← single_coeff_same a r, ← single_coeff_same a s, rs]
+  fun r s rs => by rw [← coeff_single_same a r, ← coeff_single_same a s, rs]
 
 theorem single_ne_zero (h : r ≠ 0) : single a r ≠ 0 := fun con =>
   h (single_injective a (con.trans single_eq_zero.symm))
@@ -218,7 +226,7 @@ instance [Nonempty Γ] [Nontrivial R] : Nontrivial (HahnSeries Γ R) :=
     obtain ⟨r, s, rs⟩ := exists_pair_ne R
     inhabit Γ
     refine ⟨single default r, single default s, fun con => rs ?_⟩
-    rw [← single_coeff_same (default : Γ) r, con, single_coeff_same]⟩
+    rw [← coeff_single_same (default : Γ) r, con, coeff_single_same]⟩
 
 section Order
 
@@ -290,7 +298,7 @@ theorem lt_orderTop_single {g g' : Γ} (hgg' : g < g') : g < (single g' r).order
 theorem coeff_eq_zero_of_lt_orderTop {x : HahnSeries Γ R} {i : Γ} (hi : i < x.orderTop) :
     x.coeff i = 0 := by
   rcases eq_or_ne x 0 with (rfl | hx)
-  · exact zero_coeff
+  · exact coeff_zero
   contrapose! hi
   rw [← mem_support] at hi
   rw [orderTop_of_ne hx, WithTop.coe_lt_coe]
@@ -381,7 +389,7 @@ theorem zero_le_orderTop_iff {x : HahnSeries Γ R} : 0 ≤ x.orderTop ↔ 0 ≤ 
 
 theorem leadingCoeff_eq {x : HahnSeries Γ R} : x.leadingCoeff = x.coeff x.order := by
   by_cases h : x = 0
-  · rw [h, leadingCoeff_zero, zero_coeff]
+  · rw [h, leadingCoeff_zero, coeff_zero]
   · rw [leadingCoeff_of_ne h, order_of_ne h]
 
 end Order
@@ -443,7 +451,7 @@ theorem embDomain_single {f : Γ ↪o Γ'} {g : Γ} {r : R} :
   ext g'
   by_cases h : g' = f g
   · simp [h]
-  rw [embDomain_notin_image_support, single_coeff_of_ne h]
+  rw [embDomain_notin_image_support, coeff_single_of_ne h]
   by_cases hr : r = 0
   · simp [hr]
   rwa [support_single_of_ne hr, Set.image_singleton, Set.mem_singleton_iff]

--- a/Mathlib/RingTheory/HahnSeries/HEval.lean
+++ b/Mathlib/RingTheory/HahnSeries/HEval.lean
@@ -63,7 +63,7 @@ theorem support_powerSeriesFamily_subset (hx : 0 < x.orderTop) (a b : PowerSerie
     ((powerSeriesFamily hx (a * b)).coeff g).support ⊆
     (((powerSeriesFamily hx a).mul (powerSeriesFamily hx b)).coeff g).support.image
       fun i => i.1 + i.2 := by
-  simp only [coeff_support, smulFamily_toFun, HahnSeries.smul_coeff, Set.Finite.toFinset_subset,
+  simp only [coeff_support, smulFamily_toFun, HahnSeries.coeff_smul, Set.Finite.toFinset_subset,
     coe_image, support_subset_iff, Set.mem_image, Prod.exists]
   intro n hn
   simp_rw [PowerSeries.coeff_mul, sum_smul, mul_smul] at hn
@@ -72,7 +72,7 @@ theorem support_powerSeriesFamily_subset (hx : 0 < x.orderTop) (a b : PowerSerie
   use he.choose.1, he.choose.2
   refine ⟨?_, he.choose_spec.1⟩
   simp only [mul_toFun, smulFamily_toFun, powers_toFun, Algebra.mul_smul_comm,
-    Algebra.smul_mul_assoc, HahnSeries.smul_coeff, Set.Finite.coe_toFinset, ne_eq, Prod.mk.eta,
+    Algebra.smul_mul_assoc, HahnSeries.coeff_smul, Set.Finite.coe_toFinset, ne_eq, Prod.mk.eta,
     Function.mem_support]
   rw [← pow_add, smul_comm, he.choose_spec.1]
   exact he.choose_spec.2
@@ -82,7 +82,7 @@ theorem hsum_powerSeriesFamily_mul (hx : 0 < x.orderTop) (a b : PowerSeries R) :
     ((powerSeriesFamily hx a).mul (powerSeriesFamily hx b)).hsum := by
   ext g
   simp only [powerSeriesFamily_apply, PowerSeries.coeff_mul, Finset.sum_smul, ← Finset.sum_product,
-    hsum_coeff_eq_sum, mul_toFun]
+    coeff_hsum_eq_sum, mul_toFun]
   rw [sum_subset (support_powerSeriesFamily_subset hx a b g)]
   · rw [← coeff_sum, sum_sigma', coeff_sum]
     refine (Finset.sum_of_injOn (fun x => ⟨x.1 + x.2, x⟩) (fun _ _ _ _ => by simp_all) ?_ ?_

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -49,9 +49,11 @@ instance [Zero R] [One R] : One (HahnSeries Γ R) :=
 
 open Classical in
 @[simp]
-theorem one_coeff [Zero R] [One R] {a : Γ} :
+theorem coeff_one [Zero R] [One R] {a : Γ} :
     (1 : HahnSeries Γ R).coeff a = if a = 0 then 1 else 0 :=
-  single_coeff
+  coeff_single
+
+@[deprecated (since := "2025-01-31")] alias one_coeff := coeff_one
 
 @[simp]
 theorem single_zero_one [Zero R] [One R] : single (0 : Γ) (1 : R) = 1 :=
@@ -149,11 +151,13 @@ instance instSMul [Zero R] : SMul (HahnSeries Γ R) (HahnModule Γ' R V) where
           simp [not_nonempty_iff_eq_empty.1 ha]
         isPWO_support_vaddAntidiagonal.mono h }
 
-theorem smul_coeff [Zero R] (x : HahnSeries Γ R) (y : HahnModule Γ' R V) (a : Γ') :
+theorem coeff_smul [Zero R] (x : HahnSeries Γ R) (y : HahnModule Γ' R V) (a : Γ') :
     ((of R).symm <| x • y).coeff a =
       ∑ ij ∈ VAddAntidiagonal x.isPWO_support ((of R).symm y).isPWO_support a,
         x.coeff ij.fst • ((of R).symm y).coeff ij.snd :=
   rfl
+
+@[deprecated (since := "2025-01-31")] alias smul_coeff := coeff_smul
 
 end SMul
 
@@ -177,32 +181,36 @@ instance instSMulZeroClass [SMulZeroClass R V] :
     SMulZeroClass (HahnSeries Γ R) (HahnModule Γ' R V) where
   smul_zero x := by
     ext
-    simp [smul_coeff]
+    simp [coeff_smul]
 
-theorem smul_coeff_right [SMulZeroClass R V] {x : HahnSeries Γ R} {y : HahnModule Γ' R V} {a : Γ'}
+theorem coeff_smul_right [SMulZeroClass R V] {x : HahnSeries Γ R} {y : HahnModule Γ' R V} {a : Γ'}
     {s : Set Γ'} (hs : s.IsPWO) (hys : ((of R).symm y).support ⊆ s) :
     ((of R).symm <| x • y).coeff a =
       ∑ ij ∈ VAddAntidiagonal x.isPWO_support hs a,
         x.coeff ij.fst • ((of R).symm y).coeff ij.snd := by
   classical
-  rw [smul_coeff]
+  rw [coeff_smul]
   apply sum_subset_zero_on_sdiff (vaddAntidiagonal_mono_right hys) _ fun _ _ => rfl
   intro b hb
   simp only [not_and, mem_sdiff, mem_vaddAntidiagonal, HahnSeries.mem_support, not_imp_not] at hb
   rw [hb.2 hb.1.1 hb.1.2.2, smul_zero]
 
-theorem smul_coeff_left [SMulWithZero R V] {x : HahnSeries Γ R}
+@[deprecated (since := "2025-01-31")] alias smul_coeff_right := coeff_smul_right
+
+theorem coeff_smul_left [SMulWithZero R V] {x : HahnSeries Γ R}
     {y : HahnModule Γ' R V} {a : Γ'} {s : Set Γ}
     (hs : s.IsPWO) (hxs : x.support ⊆ s) :
     ((of R).symm <| x • y).coeff a =
       ∑ ij ∈ VAddAntidiagonal hs ((of R).symm y).isPWO_support a,
         x.coeff ij.fst • ((of R).symm y).coeff ij.snd := by
   classical
-  rw [smul_coeff]
+  rw [coeff_smul]
   apply sum_subset_zero_on_sdiff (vaddAntidiagonal_mono_left hxs) _ fun _ _ => rfl
   intro b hb
   simp only [not_and', mem_sdiff, mem_vaddAntidiagonal, HahnSeries.mem_support, not_ne_iff] at hb
   rw [hb.2 ⟨hb.1.2.1, hb.1.2.2⟩, zero_smul]
+
+@[deprecated (since := "2025-01-31")] alias smul_coeff_left := coeff_smul_left
 
 end SMulZeroClass
 
@@ -214,14 +222,14 @@ theorem smul_add [Zero R] [DistribSMul R V] (x : HahnSeries Γ R) (y z : HahnMod
     x • (y + z) = x • y + x • z := by
   ext k
   have hwf := ((of R).symm y).isPWO_support.union ((of R).symm z).isPWO_support
-  rw [smul_coeff_right hwf, of_symm_add]
-  · simp_all only [HahnSeries.add_coeff', Pi.add_apply, smul_add, of_symm_add]
-    rw [smul_coeff_right hwf Set.subset_union_right,
-      smul_coeff_right hwf Set.subset_union_left]
+  rw [coeff_smul_right hwf, of_symm_add]
+  · simp_all only [HahnSeries.coeff_add', Pi.add_apply, smul_add, of_symm_add]
+    rw [coeff_smul_right hwf Set.subset_union_right,
+      coeff_smul_right hwf Set.subset_union_left]
     simp_all [sum_add_distrib]
   · intro b
     simp_all only [Set.isPWO_union, HahnSeries.isPWO_support, and_self, of_symm_add,
-      HahnSeries.add_coeff', Pi.add_apply, ne_eq, Set.mem_union, HahnSeries.mem_support]
+      HahnSeries.coeff_add', Pi.add_apply, ne_eq, Set.mem_union, HahnSeries.mem_support]
     contrapose!
     intro h
     rw [h.1, h.2, add_zero]
@@ -235,25 +243,25 @@ theorem add_smul [AddCommMonoid R] [SMulWithZero R V] {x y : HahnSeries Γ R}
     (x + y) • z = x • z + y • z := by
   ext a
   have hwf := x.isPWO_support.union y.isPWO_support
-  rw [smul_coeff_left hwf, HahnSeries.add_coeff', of_symm_add]
-  · simp_all only [Pi.add_apply, HahnSeries.add_coeff']
-    rw [smul_coeff_left hwf Set.subset_union_right,
-      smul_coeff_left hwf Set.subset_union_left]
-    simp only [HahnSeries.add_coeff, h, sum_add_distrib]
+  rw [coeff_smul_left hwf, HahnSeries.coeff_add', of_symm_add]
+  · simp_all only [Pi.add_apply, HahnSeries.coeff_add']
+    rw [coeff_smul_left hwf Set.subset_union_right,
+      coeff_smul_left hwf Set.subset_union_left]
+    simp only [HahnSeries.coeff_add, h, sum_add_distrib]
   · intro b
     simp_all only [Set.isPWO_union, HahnSeries.isPWO_support, and_self, HahnSeries.mem_support,
-      HahnSeries.add_coeff, ne_eq, Set.mem_union, Set.mem_setOf_eq, mem_support]
+      HahnSeries.coeff_add, ne_eq, Set.mem_union, Set.mem_setOf_eq, mem_support]
     contrapose!
     intro h
     rw [h.1, h.2, add_zero]
 
-theorem single_smul_coeff_add [MulZeroClass R] [SMulWithZero R V] {r : R} {x : HahnModule Γ' R V}
+theorem coeff_single_smul_vadd [MulZeroClass R] [SMulWithZero R V] {r : R} {x : HahnModule Γ' R V}
     {a : Γ'} {b : Γ} :
     ((of R).symm (HahnSeries.single b r • x)).coeff (b +ᵥ a) = r • ((of R).symm x).coeff a := by
   by_cases hr : r = 0
-  · simp_all only [map_zero, zero_smul, smul_coeff, HahnSeries.support_zero, HahnSeries.zero_coeff,
+  · simp_all only [map_zero, zero_smul, coeff_smul, HahnSeries.support_zero, HahnSeries.coeff_zero,
     sum_const_zero]
-  simp only [hr, smul_coeff, smul_coeff, HahnSeries.support_single_of_ne, ne_eq, not_false_iff,
+  simp only [hr, coeff_smul, coeff_smul, HahnSeries.support_single_of_ne, ne_eq, not_false_iff,
     smul_eq_mul]
   by_cases hx : ((of R).symm x).coeff a = 0
   · simp only [hx, smul_zero]
@@ -277,13 +285,17 @@ theorem single_smul_coeff_add [MulZeroClass R] [SMulWithZero R V] {r : R} {x : H
       exact ⟨rfl, by exact hx, rfl⟩
   · simp
 
-theorem single_zero_smul_coeff {Γ} [OrderedAddCommMonoid Γ] [AddAction Γ Γ']
+@[deprecated (since := "2025-01-31")] alias single_smul_coeff_add := coeff_single_smul_vadd
+
+theorem coeff_single_zero_smul {Γ} [OrderedAddCommMonoid Γ] [AddAction Γ Γ']
     [IsOrderedCancelVAdd Γ Γ'] [MulZeroClass R] [SMulWithZero R V] {r : R}
     {x : HahnModule Γ' R V} {a : Γ'} :
     ((of R).symm ((HahnSeries.single 0 r : HahnSeries Γ R) • x)).coeff a =
     r • ((of R).symm x).coeff a := by
   nth_rw 1 [← zero_vadd Γ a]
-  exact single_smul_coeff_add
+  exact coeff_single_smul_vadd
+
+@[deprecated (since := "2025-01-31")] alias single_zero_smul_coeff := coeff_single_zero_smul
 
 @[simp]
 theorem single_zero_smul_eq_smul (Γ) [OrderedAddCommMonoid Γ] [AddAction Γ Γ']
@@ -291,20 +303,20 @@ theorem single_zero_smul_eq_smul (Γ) [OrderedAddCommMonoid Γ] [AddAction Γ Γ
     {x : HahnModule Γ' R V} :
     (HahnSeries.single (0 : Γ) r) • x = r • x := by
   ext
-  exact single_zero_smul_coeff
+  exact coeff_single_zero_smul
 
 @[simp]
 theorem zero_smul' [Zero R] [SMulWithZero R V] {x : HahnModule Γ' R V} :
     (0 : HahnSeries Γ R) • x = 0 := by
   ext
-  simp [smul_coeff]
+  simp [coeff_smul]
 
 @[simp]
 theorem one_smul' {Γ} [OrderedAddCommMonoid Γ] [AddAction Γ Γ'] [IsOrderedCancelVAdd Γ Γ']
     [MonoidWithZero R] [MulActionWithZero R V] {x : HahnModule Γ' R V} :
     (1 : HahnSeries Γ R) • x = x := by
   ext g
-  exact single_zero_smul_coeff.trans (one_smul R (x.coeff g))
+  exact coeff_single_zero_smul.trans (one_smul R (x.coeff g))
 
 theorem support_smul_subset_vadd_support' [MulZeroClass R] [SMulWithZero R V] {x : HahnSeries Γ R}
     {y : HahnModule Γ' R V} :
@@ -315,7 +327,7 @@ theorem support_smul_subset_vadd_support' [MulZeroClass R] [SMulWithZero R V] {x
   intro x hx
   contrapose! hx
   simp only [Set.mem_setOf_eq, not_nonempty_iff_eq_empty] at hx
-  simp [hx, smul_coeff]
+  simp [hx, coeff_smul]
 
 theorem support_smul_subset_vadd_support [MulZeroClass R] [SMulWithZero R V] {x : HahnSeries Γ R}
     {y : HahnModule Γ' R V} :
@@ -326,15 +338,17 @@ theorem support_smul_subset_vadd_support [MulZeroClass R] [SMulWithZero R V] {x 
   rw [h]
   exact support_smul_subset_vadd_support'
 
-theorem smul_coeff_order_add_order {Γ} [LinearOrderedCancelAddCommMonoid Γ] [Zero R]
+theorem coeff_smul_order_add_order {Γ} [LinearOrderedCancelAddCommMonoid Γ] [Zero R]
     [SMulWithZero R V] (x : HahnSeries Γ R) (y : HahnModule Γ R V) :
     ((of R).symm (x • y)).coeff (x.order + ((of R).symm y).order) =
     x.leadingCoeff • ((of R).symm y).leadingCoeff := by
-  by_cases hx : x = (0 : HahnSeries Γ R); · simp [HahnSeries.zero_coeff, hx]
-  by_cases hy : (of R).symm y = 0; · simp [hy, smul_coeff]
-  rw [HahnSeries.order_of_ne hx, HahnSeries.order_of_ne hy, smul_coeff,
+  by_cases hx : x = (0 : HahnSeries Γ R); · simp [HahnSeries.coeff_zero, hx]
+  by_cases hy : (of R).symm y = 0; · simp [hy, coeff_smul]
+  rw [HahnSeries.order_of_ne hx, HahnSeries.order_of_ne hy, coeff_smul,
     HahnSeries.leadingCoeff_of_ne hx, HahnSeries.leadingCoeff_of_ne hy]
   erw [Finset.vaddAntidiagonal_min_vadd_min, Finset.sum_singleton]
+
+@[deprecated (since := "2025-01-31")] alias smul_coeff_order_add_order := coeff_smul_order_add_order
 
 end DistribSMul
 
@@ -350,15 +364,17 @@ instance [NonUnitalNonAssocSemiring R] : Mul (HahnSeries Γ R) where
 theorem of_symm_smul_of_eq_mul [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} :
     (HahnModule.of R).symm (x • HahnModule.of R y) = x * y := rfl
 
-theorem mul_coeff [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {a : Γ} :
+theorem coeff_mul [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {a : Γ} :
     (x * y).coeff a =
       ∑ ij ∈ addAntidiagonal x.isPWO_support y.isPWO_support a, x.coeff ij.fst * y.coeff ij.snd :=
   rfl
 
+@[deprecated (since := "2025-01-31")] alias mul_coeff := coeff_mul
+
 protected lemma map_mul [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring S] (f : R →ₙ+* S)
     {x y : HahnSeries Γ R} : (x * y).map f = (x.map f : HahnSeries Γ S) * (y.map f) := by
   ext
-  simp only [map_coeff, mul_coeff, ZeroHom.coe_coe, map_sum, map_mul]
+  simp only [map_coeff, coeff_mul, ZeroHom.coe_coe, map_sum, map_mul]
   refine Eq.symm (sum_subset (fun gh hgh => ?_) (fun gh hgh hz => ?_))
   · simp_all only [mem_addAntidiagonal, mem_support, map_coeff, ZeroHom.coe_coe, ne_eq, and_true]
     exact ⟨fun h => hgh.1 (map_zero f ▸ congrArg f h), fun h => hgh.2.1 (map_zero f ▸ congrArg f h)⟩
@@ -368,17 +384,21 @@ protected lemma map_mul [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring
     · exact mul_eq_zero_of_left h (f (y.coeff gh.2))
     · exact mul_eq_zero_of_right (f (x.coeff gh.1)) (hz h)
 
-theorem mul_coeff_left' [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {a : Γ} {s : Set Γ}
+theorem coeff_mul_left' [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {a : Γ} {s : Set Γ}
     (hs : s.IsPWO) (hxs : x.support ⊆ s) :
     (x * y).coeff a =
       ∑ ij ∈ addAntidiagonal hs y.isPWO_support a, x.coeff ij.fst * y.coeff ij.snd :=
-  HahnModule.smul_coeff_left hs hxs
+  HahnModule.coeff_smul_left hs hxs
 
-theorem mul_coeff_right' [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {a : Γ} {s : Set Γ}
+@[deprecated (since := "2025-01-31")] alias mul_coeff_left' := coeff_mul_left'
+
+theorem coeff_mul_right' [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {a : Γ} {s : Set Γ}
     (hs : s.IsPWO) (hys : y.support ⊆ s) :
     (x * y).coeff a =
       ∑ ij ∈ addAntidiagonal x.isPWO_support hs a, x.coeff ij.fst * y.coeff ij.snd :=
-  HahnModule.smul_coeff_right hs hys
+  HahnModule.coeff_smul_right hs hys
+
+@[deprecated (since := "2025-01-31")] alias mul_coeff_right' := coeff_mul_right'
 
 instance [NonUnitalNonAssocSemiring R] : Distrib (HahnSeries Γ R) :=
   { inferInstanceAs (Mul (HahnSeries Γ R)),
@@ -392,16 +412,18 @@ instance [NonUnitalNonAssocSemiring R] : Distrib (HahnSeries Γ R) :=
       simp only [smul_eq_mul]
       exact add_mul }
 
-theorem single_mul_coeff_add [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ}
+theorem coeff_single_mul_add [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ}
     {b : Γ} : (single b r * x).coeff (a + b) = r * x.coeff a := by
   rw [← of_symm_smul_of_eq_mul, add_comm, ← vadd_eq_add]
-  exact HahnModule.single_smul_coeff_add
+  exact HahnModule.coeff_single_smul_vadd
 
-theorem mul_single_coeff_add [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ}
+@[deprecated (since := "2025-01-31")] alias single_mul_coeff_add := coeff_single_mul_add
+
+theorem coeff_mul_single_add [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ}
     {b : Γ} : (x * single b r).coeff (a + b) = x.coeff a * r := by
   by_cases hr : r = 0
-  · simp [hr, mul_coeff]
-  simp only [hr, smul_coeff, mul_coeff, support_single_of_ne, Ne, not_false_iff, smul_eq_mul]
+  · simp [hr, coeff_mul]
+  simp only [hr, coeff_smul, coeff_mul, support_single_of_ne, Ne, not_false_iff, smul_eq_mul]
   by_cases hx : x.coeff a = 0
   · simp only [hx, zero_mul]
     rw [sum_congr _ fun _ _ => rfl, sum_empty]
@@ -423,37 +445,45 @@ theorem mul_single_coeff_add [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeri
       simp [hx]
   · simp
 
-@[simp]
-theorem mul_single_zero_coeff [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ} :
-    (x * single 0 r).coeff a = x.coeff a * r := by rw [← add_zero a, mul_single_coeff_add, add_zero]
+@[deprecated (since := "2025-01-31")] alias mul_single_coeff_add := coeff_mul_single_add
 
-theorem single_zero_mul_coeff [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ} :
+@[simp]
+theorem coeff_mul_single_zero [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ} :
+    (x * single 0 r).coeff a = x.coeff a * r := by rw [← add_zero a, coeff_mul_single_add, add_zero]
+
+@[deprecated (since := "2025-01-31")] alias mul_single_zero_coeff := coeff_mul_single_zero
+
+theorem coeff_single_zero_mul [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ} :
     ((single 0 r : HahnSeries Γ R) * x).coeff a = r * x.coeff a := by
-  rw [← add_zero a, single_mul_coeff_add, add_zero]
+  rw [← add_zero a, coeff_single_mul_add, add_zero]
+
+@[deprecated (since := "2025-01-31")] alias single_zero_mul_coeff := coeff_single_zero_mul
 
 @[simp]
 theorem single_zero_mul_eq_smul [Semiring R] {r : R} {x : HahnSeries Γ R} :
     single 0 r * x = r • x := by
   ext
-  exact single_zero_mul_coeff
+  exact coeff_single_zero_mul
 
 theorem support_mul_subset_add_support [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} :
     support (x * y) ⊆ support x + support y := by
   rw [← of_symm_smul_of_eq_mul, ← vadd_eq_add]
   exact HahnModule.support_smul_subset_vadd_support
 
-theorem mul_coeff_order_add_order {Γ} [LinearOrderedCancelAddCommMonoid Γ]
+theorem coeff_mul_order_add_order {Γ} [LinearOrderedCancelAddCommMonoid Γ]
     [NonUnitalNonAssocSemiring R] (x y : HahnSeries Γ R) :
     (x * y).coeff (x.order + y.order) = x.leadingCoeff * y.leadingCoeff := by
   simp only [← of_symm_smul_of_eq_mul]
-  exact HahnModule.smul_coeff_order_add_order x y
+  exact HahnModule.coeff_smul_order_add_order x y
+
+@[deprecated (since := "2025-01-31")] alias mul_coeff_order_add_order := coeff_mul_order_add_order
 
 private theorem mul_assoc' [NonUnitalSemiring R] (x y z : HahnSeries Γ R) :
     x * y * z = x * (y * z) := by
   ext b
-  rw [mul_coeff_left' (x.isPWO_support.add y.isPWO_support) support_mul_subset_add_support,
-    mul_coeff_right' (y.isPWO_support.add z.isPWO_support) support_mul_subset_add_support]
-  simp only [mul_coeff, add_coeff, sum_mul, mul_sum, sum_sigma']
+  rw [coeff_mul_left' (x.isPWO_support.add y.isPWO_support) support_mul_subset_add_support,
+    coeff_mul_right' (y.isPWO_support.add z.isPWO_support) support_mul_subset_add_support]
+  simp only [coeff_mul, coeff_add, sum_mul, mul_sum, sum_sigma']
   apply Finset.sum_nbij' (fun ⟨⟨_i, j⟩, ⟨k, l⟩⟩ ↦ ⟨(k, l + j), (l, j)⟩)
     (fun ⟨⟨i, _j⟩, ⟨k, l⟩⟩ ↦ ⟨(i + k, l), (i, k)⟩) <;>
     aesop (add safe Set.add_mem_add) (add simp [add_assoc, mul_assoc])
@@ -463,10 +493,10 @@ instance [NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring (HahnSeries �
     inferInstanceAs (Distrib (HahnSeries Γ R)) with
     zero_mul := fun _ => by
       ext
-      simp [mul_coeff]
+      simp [coeff_mul]
     mul_zero := fun _ => by
       ext
-      simp [mul_coeff] }
+      simp [coeff_mul] }
 
 instance [NonUnitalSemiring R] : NonUnitalSemiring (HahnSeries Γ R) :=
   { inferInstanceAs (NonUnitalNonAssocSemiring (HahnSeries Γ R)) with
@@ -477,10 +507,10 @@ instance [NonAssocSemiring R] : NonAssocSemiring (HahnSeries Γ R) :=
     inferInstanceAs (NonUnitalNonAssocSemiring (HahnSeries Γ R)) with
     one_mul := fun x => by
       ext
-      exact single_zero_mul_coeff.trans (one_mul _)
+      exact coeff_single_zero_mul.trans (one_mul _)
     mul_one := fun x => by
       ext
-      exact mul_single_zero_coeff.trans (mul_one _) }
+      exact coeff_mul_single_zero.trans (mul_one _) }
 
 instance [Semiring R] : Semiring (HahnSeries Γ R) :=
   { inferInstanceAs (NonAssocSemiring (HahnSeries Γ R)),
@@ -490,7 +520,7 @@ instance [NonUnitalCommSemiring R] : NonUnitalCommSemiring (HahnSeries Γ R) whe
   __ : NonUnitalSemiring (HahnSeries Γ R) := inferInstance
   mul_comm x y := by
     ext
-    simp_rw [mul_coeff, mul_comm]
+    simp_rw [coeff_mul, mul_comm]
     exact Finset.sum_equiv (Equiv.prodComm _ _) (fun _ ↦ swap_mem_addAntidiagonal.symm) <| by simp
 
 instance [CommSemiring R] : CommSemiring (HahnSeries Γ R) :=
@@ -530,10 +560,10 @@ variable [PartialOrder Γ'] [AddAction Γ Γ'] [IsOrderedCancelVAdd Γ Γ'] [Add
 private theorem mul_smul' [Semiring R] [Module R V] (x y : HahnSeries Γ R)
     (z : HahnModule Γ' R V) : (x * y) • z = x • (y • z) := by
   ext b
-  rw [smul_coeff_left (x.isPWO_support.add y.isPWO_support)
-    HahnSeries.support_mul_subset_add_support, smul_coeff_right
+  rw [coeff_smul_left (x.isPWO_support.add y.isPWO_support)
+    HahnSeries.support_mul_subset_add_support, coeff_smul_right
     (y.isPWO_support.vadd ((of R).symm z).isPWO_support) support_smul_subset_vadd_support]
-  simp only [HahnSeries.mul_coeff, smul_coeff, HahnSeries.add_coeff, sum_smul, smul_sum, sum_sigma']
+  simp only [HahnSeries.coeff_mul, coeff_smul, HahnSeries.coeff_add, sum_smul, smul_sum, sum_sigma']
   apply Finset.sum_nbij' (fun ⟨⟨_i, j⟩, ⟨k, l⟩⟩ ↦ ⟨(k, l +ᵥ j), (l, j)⟩)
     (fun ⟨⟨i, _j⟩, ⟨k, l⟩⟩ ↦ ⟨(i + k, l), (i, k)⟩) <;>
     aesop (add safe [Set.vadd_mem_vadd, Set.add_mem_add]) (add simp [add_vadd, mul_smul])
@@ -557,7 +587,7 @@ instance instNoZeroSMulDivisors {Γ} [LinearOrderedCancelAddCommMonoid Γ] [Zero
     simp only [ne_eq]
     rw [HahnModule.ext_iff, funext_iff, not_forall]
     refine ⟨x.order + ((of R).symm y).order, ?_⟩
-    rw [smul_coeff_order_add_order x y, of_symm_zero, HahnSeries.zero_coeff, smul_eq_zero, not_or]
+    rw [coeff_smul_order_add_order x y, of_symm_zero, HahnSeries.coeff_zero, smul_eq_zero, not_or]
     constructor
     · exact HahnSeries.leadingCoeff_ne_iff.mpr hxy.1
     · exact HahnSeries.leadingCoeff_ne_iff.mpr hxy.2
@@ -594,7 +624,7 @@ theorem order_mul {Γ} [LinearOrderedCancelAddCommMonoid Γ] [NonUnitalNonAssocS
     (x * y).order = x.order + y.order := by
   apply le_antisymm
   · apply order_le_of_coeff_ne_zero
-    rw [mul_coeff_order_add_order x y]
+    rw [coeff_mul_order_add_order x y]
     exact mul_ne_zero (leadingCoeff_ne_iff.mpr hx) (leadingCoeff_ne_iff.mpr hy)
   · rw [order_of_ne hx, order_of_ne hy, order_of_ne (mul_ne_zero hx hy), ← Set.IsWF.min_add]
     exact Set.IsWF.min_le_min_of_subset support_mul_subset_add_support
@@ -617,9 +647,9 @@ theorem single_mul_single {a b : Γ} {r s : R} :
     single a r * single b s = single (a + b) (r * s) := by
   ext x
   by_cases h : x = a + b
-  · rw [h, mul_single_coeff_add]
+  · rw [h, coeff_mul_single_add]
     simp
-  · rw [single_coeff_of_ne h, mul_coeff, sum_eq_zero]
+  · rw [coeff_single_of_ne h, coeff_mul, sum_eq_zero]
     simp_rw [mem_addAntidiagonal]
     rintro ⟨y, z⟩ ⟨hy, hz, rfl⟩
     rw [eq_of_mem_support_single hy, eq_of_mem_support_single hz] at h
@@ -634,7 +664,7 @@ variable [Semiring R]
 @[simp]
 theorem single_pow (a : Γ) (n : ℕ) (r : R) : single a r ^ n = single (n • a) (r ^ n) := by
   induction' n with n IH
-  · ext; simp only [pow_zero, one_coeff, zero_smul, single_coeff]
+  · ext; simp only [pow_zero, coeff_one, zero_smul, coeff_single]
   · rw [pow_succ, pow_succ, IH, single_mul_single, succ_nsmul]
 
 end Semiring
@@ -669,7 +699,7 @@ theorem C_injective : Function.Injective (C : R → HahnSeries Γ R) := by
   intro r s rs
   rw [HahnSeries.ext_iff, funext_iff] at rs
   have h := rs 0
-  rwa [C_apply, single_coeff_same, C_apply, single_coeff_same] at h
+  rwa [C_apply, coeff_single_same, C_apply, coeff_single_same] at h
 
 theorem C_ne_zero {r : R} (h : r ≠ 0) : (C r : HahnSeries Γ R) ≠ 0 := by
   contrapose! h
@@ -702,7 +732,7 @@ theorem embDomain_mul [NonUnitalNonAssocSemiring R] (f : Γ ↪o Γ')
   ext g
   by_cases hg : g ∈ Set.range f
   · obtain ⟨g, rfl⟩ := hg
-    simp only [mul_coeff, embDomain_coeff]
+    simp only [coeff_mul, embDomain_coeff]
     trans
       ∑ ij in
         (addAntidiagonal x.isPWO_support y.isPWO_support g).map
@@ -762,8 +792,8 @@ instance : Algebra R (HahnSeries Γ A) where
     simp
   commutes' r x := by
     ext
-    simp only [smul_coeff, single_zero_mul_eq_smul, RingHom.coe_comp, RingHom.toFun_eq_coe, C_apply,
-      Function.comp_apply, algebraMap_smul, mul_single_zero_coeff]
+    simp only [coeff_smul, single_zero_mul_eq_smul, RingHom.coe_comp, RingHom.toFun_eq_coe, C_apply,
+      Function.comp_apply, algebraMap_smul, coeff_mul_single_zero]
     rw [← Algebra.commutes, Algebra.smul_def]
 
 theorem C_eq_algebraMap : C = algebraMap R (HahnSeries Γ R) :=
@@ -781,7 +811,7 @@ instance [Nontrivial Γ] [Nontrivial R] : Nontrivial (Subalgebra R (HahnSeries �
       intro x
       rw [HahnSeries.ext_iff, funext_iff, not_forall]
       refine ⟨a, ?_⟩
-      rw [single_coeff_same, algebraMap_apply, C_apply, single_coeff_of_ne ha]
+      rw [coeff_single_same, algebraMap_apply, C_apply, coeff_single_of_ne ha]
       exact zero_ne_one⟩⟩
 
 section Domain

--- a/Mathlib/RingTheory/HahnSeries/PowerSeries.lean
+++ b/Mathlib/RingTheory/HahnSeries/PowerSeries.lean
@@ -61,7 +61,7 @@ def toPowerSeries : HahnSeries ℕ R ≃+* PowerSeries R where
     simp
   map_mul' f g := by
     ext n
-    simp only [PowerSeries.coeff_mul, PowerSeries.coeff_mk, mul_coeff, isPWO_support]
+    simp only [PowerSeries.coeff_mul, PowerSeries.coeff_mk, coeff_mul, isPWO_support]
     classical
     refine (sum_filter_ne_zero _).symm.trans <| (sum_congr ?_ fun _ _ ↦ rfl).trans <|
       sum_filter_ne_zero _
@@ -110,7 +110,7 @@ theorem ofPowerSeries_apply_coeff (x : PowerSeries R) (n : ℕ) :
 theorem ofPowerSeries_C (r : R) : ofPowerSeries Γ R (PowerSeries.C R r) = HahnSeries.C r := by
   ext n
   simp only [ofPowerSeries_apply, C, RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk, ne_eq,
-    single_coeff]
+    coeff_single]
   split_ifs with hn
   · subst hn
     convert embDomain_coeff (a := 0) <;> simp
@@ -123,7 +123,7 @@ theorem ofPowerSeries_C (r : R) : ofPowerSeries Γ R (PowerSeries.C R r) = HahnS
 @[simp]
 theorem ofPowerSeries_X : ofPowerSeries Γ R PowerSeries.X = single 1 1 := by
   ext n
-  simp only [single_coeff, ofPowerSeries_apply, RingHom.coe_mk]
+  simp only [coeff_single, ofPowerSeries_apply, RingHom.coe_mk]
   split_ifs with hn
   · rw [hn]
     convert embDomain_coeff (a := 1) <;> simp
@@ -161,7 +161,7 @@ def toMvPowerSeries {σ : Type*} [Finite σ] : HahnSeries (σ →₀ ℕ) R ≃+
     simp only [MvPowerSeries.coeff_mul]
     classical
       change (f * g).coeff n = _
-      simp_rw [mul_coeff]
+      simp_rw [coeff_mul]
       refine (sum_filter_ne_zero _).symm.trans <| (sum_congr ?_ fun _ _ ↦ rfl).trans <|
         sum_filter_ne_zero _
       ext m

--- a/Mathlib/RingTheory/HahnSeries/Summable.lean
+++ b/Mathlib/RingTheory/HahnSeries/Summable.lean
@@ -158,12 +158,14 @@ def hsum (s : SummableFamily Γ R α) : HahnSeries Γ R where
       rw [finsum_congr h, finsum_zero]
 
 @[simp]
-theorem hsum_coeff {s : SummableFamily Γ R α} {g : Γ} : s.hsum.coeff g = ∑ᶠ i, (s i).coeff g :=
+theorem coeff_hsum {s : SummableFamily Γ R α} {g : Γ} : s.hsum.coeff g = ∑ᶠ i, (s i).coeff g :=
   rfl
+
+@[deprecated (since := "2025-01-31")] alias hsum_coeff := coeff_hsum
 
 theorem support_hsum_subset {s : SummableFamily Γ R α} : s.hsum.support ⊆ ⋃ a : α, (s a).support :=
   fun g hg => by
-  rw [mem_support, hsum_coeff, finsum_eq_sum _ (s.finite_co_support _)] at hg
+  rw [mem_support, coeff_hsum, finsum_eq_sum _ (s.finite_co_support _)] at hg
   obtain ⟨a, _, h2⟩ := exists_ne_zero_of_sum_ne_zero hg
   rw [Set.mem_iUnion]
   exact ⟨a, h2⟩
@@ -171,17 +173,22 @@ theorem support_hsum_subset {s : SummableFamily Γ R α} : s.hsum.support ⊆ �
 @[simp]
 theorem hsum_add {s t : SummableFamily Γ R α} : (s + t).hsum = s.hsum + t.hsum := by
   ext g
-  simp only [hsum_coeff, add_coeff, add_apply]
+  simp only [coeff_hsum, coeff_add, add_apply]
   exact finsum_add_distrib (s.finite_co_support _) (t.finite_co_support _)
 
-theorem hsum_coeff_eq_sum_of_subset {s : SummableFamily Γ R α} {g : Γ} {t : Finset α}
+theorem coeff_hsum_eq_sum_of_subset {s : SummableFamily Γ R α} {g : Γ} {t : Finset α}
     (h : { a | (s a).coeff g ≠ 0 } ⊆ t) : s.hsum.coeff g = ∑ i ∈ t, (s i).coeff g := by
-  simp only [hsum_coeff, finsum_eq_sum _ (s.finite_co_support _)]
+  simp only [coeff_hsum, finsum_eq_sum _ (s.finite_co_support _)]
   exact sum_subset (Set.Finite.toFinset_subset.mpr h) (by simp)
 
-theorem hsum_coeff_eq_sum {s : SummableFamily Γ R α} {g : Γ} :
+@[deprecated (since := "2025-01-31")] alias hsum_coeff_eq_sum_of_subset :=
+  coeff_hsum_eq_sum_of_subset
+
+theorem coeff_hsum_eq_sum {s : SummableFamily Γ R α} {g : Γ} :
     s.hsum.coeff g = ∑ i ∈ (s.coeff g).support, (s i).coeff g := by
-  simp only [hsum_coeff, finsum_eq_sum _ (s.finite_co_support _), coeff_support]
+  simp only [coeff_hsum, finsum_eq_sum _ (s.finite_co_support _), coeff_support]
+
+@[deprecated (since := "2025-01-31")] alias hsum_coeff_eq_sum := coeff_hsum_eq_sum
 
 /-- The summable family made of a single Hahn series. -/
 @[simps]
@@ -194,7 +201,7 @@ def single (x : HahnSeries Γ R) : SummableFamily Γ R Unit where
 @[simp]
 theorem hsum_single (x : HahnSeries Γ R) : (single x).hsum = x := by
   ext g
-  simp only [hsum_coeff, single_toFun, finsum_unique]
+  simp only [coeff_hsum, single_toFun, finsum_unique]
 
 /-- A summable family induced by an equivalence of the parametrizing type. -/
 @[simps]
@@ -210,7 +217,7 @@ def Equiv (e : α ≃ β) (s : SummableFamily Γ R α) : SummableFamily Γ R β 
 @[simp]
 theorem hsum_equiv (e : α ≃ β) (s : SummableFamily Γ R α) : (Equiv e s).hsum = s.hsum := by
   ext g
-  simp only [hsum_coeff, Equiv_toFun]
+  simp only [coeff_hsum, Equiv_toFun]
   exact finsum_eq_of_bijective e.symm (Equiv.bijective e.symm) fun x => rfl
 
 /-- The summable family given by multiplying every series in a summable family by a scalar. -/
@@ -220,12 +227,12 @@ def smulFamily [AddCommMonoid V] [SMulWithZero R V] (f : α → R) (s : Summable
   toFun a := (f a) • s a
   isPWO_iUnion_support' := by
     refine Set.IsPWO.mono s.isPWO_iUnion_support fun g hg => ?_
-    simp_all only [Set.mem_iUnion, mem_support, smul_coeff, ne_eq]
+    simp_all only [Set.mem_iUnion, mem_support, coeff_smul, ne_eq]
     obtain ⟨i, hi⟩ := hg
     exact Exists.intro i <| right_ne_zero_of_smul hi
   finite_co_support' g := by
     refine Set.Finite.subset (s.finite_co_support g) fun i hi => ?_
-    simp_all only [smul_coeff, ne_eq, Set.mem_setOf_eq, Function.mem_support]
+    simp_all only [coeff_smul, ne_eq, Set.mem_setOf_eq, Function.mem_support]
     exact right_ne_zero_of_smul hi
 
 theorem hsum_smulFamily [AddCommMonoid V] [SMulWithZero R V] (f : α → R)
@@ -246,7 +253,7 @@ instance : Neg (SummableFamily Γ R α) :=
         simp_rw [support_neg]
         exact s.isPWO_iUnion_support
       finite_co_support' := fun g => by
-        simp only [neg_coeff', Pi.neg_apply, Ne, neg_eq_zero]
+        simp only [coeff_neg', Pi.neg_apply, Ne, neg_eq_zero]
         exact s.finite_co_support g }⟩
 
 instance : AddCommGroup (SummableFamily Γ R α) :=
@@ -285,7 +292,7 @@ instance [Zero R] [SMulWithZero R V] : SMul R (SummableFamily Γ' V β) :=
         intro g
         refine (t.finite_co_support g).subset ?_
         intro i hi
-        simp only [Pi.smul_apply, smul_coeff, ne_eq, Set.mem_setOf_eq] at hi
+        simp only [Pi.smul_apply, coeff_smul, ne_eq, Set.mem_setOf_eq] at hi
         simp only [Function.mem_support, ne_eq]
         exact right_ne_zero_of_smul hi } ⟩
 
@@ -322,7 +329,7 @@ theorem isPWO_iUnion_support_prod_smul {s : α → HahnSeries Γ R} {t : β → 
       (hs := (s ab.1).isPWO_support) (ht := (t ab.2).isPWO_support))
     contrapose! hx
     simp only [Set.mem_setOf_eq, not_nonempty_iff_eq_empty] at hx
-    rw [mem_support, not_not, HahnModule.smul_coeff, hx, sum_empty]
+    rw [mem_support, not_not, HahnModule.coeff_smul, hx, sum_empty]
   refine Set.Subset.trans (Set.iUnion_mono fun a => (hsupp a)) ?_
   simp_all only [Set.iUnion_subset_iff, Prod.forall]
   exact fun a b => Set.vadd_subset_vadd (Set.subset_iUnion_of_subset a fun x y ↦ y)
@@ -335,7 +342,7 @@ theorem finite_co_support_prod_smul (s : SummableFamily Γ R α)
   apply ((VAddAntidiagonal s.isPWO_iUnion_support t.isPWO_iUnion_support g).finite_toSet.biUnion'
     (fun gh _ => smul_support_finite s t gh)).subset _
   exact fun ab hab => by
-    simp only [smul_coeff, ne_eq, Set.mem_setOf_eq] at hab
+    simp only [coeff_smul, ne_eq, Set.mem_setOf_eq] at hab
     obtain ⟨ij, hij⟩ := Finset.exists_ne_zero_of_sum_ne_zero hab
     simp only [mem_coe, mem_vaddAntidiagonal, Set.mem_iUnion, mem_support, ne_eq,
       Function.mem_support, exists_prop, Prod.exists]
@@ -365,12 +372,12 @@ theorem sum_vAddAntidiagonal_eq (s : SummableFamily Γ R α) (t : SummableFamily
     · exact smul_eq_zero_of_left hs ((t a.2).coeff gh.2)
     · simp_all
 
-theorem smul_coeff {R} {V} [Semiring R] [AddCommMonoid V] [Module R V]
+theorem coeff_smul {R} {V} [Semiring R] [AddCommMonoid V] [Module R V]
     (s : SummableFamily Γ R α) (t : SummableFamily Γ' V β) (g : Γ') :
     (smul s t).hsum.coeff g = ∑ gh ∈ VAddAntidiagonal s.isPWO_iUnion_support
       t.isPWO_iUnion_support g, (s.hsum.coeff gh.1) • (t.hsum.coeff gh.2) := by
-  rw [hsum_coeff]
-  simp only [hsum_coeff_eq_sum, smul_toFun, HahnModule.smul_coeff, Equiv.symm_apply_apply]
+  rw [coeff_hsum]
+  simp only [coeff_hsum_eq_sum, smul_toFun, HahnModule.coeff_smul, Equiv.symm_apply_apply]
   simp_rw [sum_vAddAntidiagonal_eq, Finset.smul_sum, Finset.sum_smul]
   rw [← sum_finsum_comm _ _ <| fun gh _ => smul_support_finite s t gh]
   refine sum_congr rfl fun gh _ => ?_
@@ -382,18 +389,18 @@ theorem smul_coeff {R} {V} [Semiring R] [AddCommMonoid V] [Module R V]
     Set.mem_setOf_eq, Prod.forall, coeff_support, mem_product]
   exact hsupp ab.1 ab.2 hab
 
-@[deprecated (since := "2024-11-17")] alias family_smul_coeff := smul_coeff
+@[deprecated (since := "2024-11-17")] alias family_smul_coeff := coeff_smul
 
 theorem smul_hsum {R} {V} [Semiring R] [AddCommMonoid V] [Module R V]
     (s : SummableFamily Γ R α) (t : SummableFamily Γ' V β) :
     (smul s t).hsum = (of R).symm (s.hsum • (of R) (t.hsum)) := by
   ext g
-  rw [smul_coeff s t g, HahnModule.smul_coeff, Equiv.symm_apply_apply]
+  rw [coeff_smul s t g, HahnModule.coeff_smul, Equiv.symm_apply_apply]
   refine Eq.symm (sum_of_injOn (fun a ↦ a) (fun _ _ _ _ h ↦ h) (fun _ hgh => ?_)
     (fun gh _ hgh => ?_) fun _ _ => by simp)
   · simp_all only [mem_coe, mem_vaddAntidiagonal, mem_support, ne_eq, Set.mem_iUnion, and_true]
     constructor
-    · rw [hsum_coeff_eq_sum] at hgh
+    · rw [coeff_hsum_eq_sum] at hgh
       have h' := Finset.exists_ne_zero_of_sum_ne_zero hgh.1
       simpa using h'
     · by_contra hi
@@ -478,11 +485,13 @@ theorem mul_eq_smul {β : Type*} (s : SummableFamily Γ R α) (t : SummableFamil
     mul s t = smul s t :=
   rfl
 
-theorem mul_coeff {β : Type*} (s : SummableFamily Γ R α) (t : SummableFamily Γ R β) (g : Γ) :
+theorem coeff_hsum_mul {β : Type*} (s : SummableFamily Γ R α) (t : SummableFamily Γ R β) (g : Γ) :
     (mul s t).hsum.coeff g = ∑ gh ∈ addAntidiagonal s.isPWO_iUnion_support
       t.isPWO_iUnion_support g, (s.hsum.coeff gh.1) * (t.hsum.coeff gh.2) := by
   simp_rw [← smul_eq_mul, mul_eq_smul]
-  exact smul_coeff s t g
+  exact coeff_smul s t g
+
+@[deprecated (since := "2025-01-31")] alias mul_coeff := coeff_hsum_mul
 
 theorem hsum_mul {β : Type*} (s : SummableFamily Γ R α) (t : SummableFamily Γ R β) :
     (mul s t).hsum = s.hsum * t.hsum := by
@@ -519,7 +528,7 @@ theorem coe_ofFinsupp {f : α →₀ HahnSeries Γ R} : ⇑(SummableFamily.ofFin
 @[simp]
 theorem hsum_ofFinsupp {f : α →₀ HahnSeries Γ R} : (ofFinsupp f).hsum = f.sum fun _ => id := by
   ext g
-  simp only [hsum_coeff, coe_ofFinsupp, Finsupp.sum, Ne]
+  simp only [coeff_hsum, coe_ofFinsupp, Finsupp.sum, Ne]
   simp_rw [← coeff.addMonoidHom_apply, id]
   rw [map_sum, finsum_eq_sum_of_support_subset]
   intro x h
@@ -551,7 +560,7 @@ def embDomain (s : SummableFamily Γ R α) (f : α ↪ β) : SummableFamily Γ R
         by_cases hb : b ∈ Set.range f
         · simp only [Ne, Set.mem_setOf_eq, dif_pos hb] at h
           exact ⟨Classical.choose hb, h, Classical.choose_spec hb⟩
-        · simp only [Ne, Set.mem_setOf_eq, dif_neg hb, zero_coeff, not_true_eq_false] at h)
+        · simp only [Ne, Set.mem_setOf_eq, dif_neg hb, coeff_zero, not_true_eq_false] at h)
 
 variable (s : SummableFamily Γ R α) (f : α ↪ β) {a : α} {b : β}
 
@@ -573,7 +582,7 @@ theorem embDomain_notin_range (h : b ∉ Set.range f) : s.embDomain f b = 0 := b
 theorem hsum_embDomain : (s.embDomain f).hsum = s.hsum := by
   classical
   ext g
-  simp only [hsum_coeff, embDomain_apply, apply_dite HahnSeries.coeff, dite_apply, zero_coeff]
+  simp only [coeff_hsum, embDomain_apply, apply_dite HahnSeries.coeff, dite_apply, coeff_zero]
   exact finsum_emb_domain f fun a => (s a).coeff g
 
 end EmbDomain
@@ -583,7 +592,7 @@ section powers
 theorem support_pow_subset_closure [OrderedCancelAddCommMonoid Γ] [Semiring R] (x : HahnSeries Γ R)
     (n : ℕ) : support (x ^ n) ⊆ AddSubmonoid.closure (support x) := by
   induction' n with n ih <;> intro g hn
-  · simp only [pow_zero, mem_support, one_coeff, ne_eq, ite_eq_right_iff, Classical.not_imp] at hn
+  · simp only [pow_zero, mem_support, coeff_one, ne_eq, ite_eq_right_iff, Classical.not_imp] at hn
     simp only [hn, SetLike.mem_coe]
     exact AddSubmonoid.zero_mem _
   · obtain ⟨i, hi, j, hj, rfl⟩ := support_mul_subset_add_support hn
@@ -601,7 +610,7 @@ theorem co_support_zero [OrderedCancelAddCommMonoid Γ] [Semiring R] (g : Γ) :
   simp only [Set.subset_singleton_iff, Set.mem_setOf_eq]
   intro n hn
   by_contra h'
-  simp_all only [ne_eq, not_false_eq_true, zero_pow, zero_coeff, not_true_eq_false]
+  simp_all only [ne_eq, not_false_eq_true, zero_pow, coeff_zero, not_true_eq_false]
 
 variable [LinearOrderedCancelAddCommMonoid Γ] [CommRing R]
 
@@ -685,9 +694,9 @@ theorem unit_aux (x : HahnSeries Γ R) {r : R} (hr : r * x.leadingCoeff = 1) :
       (fun _ => by simp_all only [zero_mul, zero_ne_one]), ← @WithTop.coe_add,
       WithTop.coe_nonneg, neg_add_cancel]
   · apply coeff_orderTop_ne h.symm
-    simp only [C_apply, single_mul_single, zero_add, mul_one, sub_coeff', Pi.sub_apply, one_coeff,
+    simp only [C_apply, single_mul_single, zero_add, mul_one, coeff_sub', Pi.sub_apply, coeff_one,
       ↓reduceIte]
-    have hrc := mul_coeff_order_add_order ((single (-x.order)) r) x
+    have hrc := coeff_mul_order_add_order ((single (-x.order)) r) x
     rw [order_single hrz, leadingCoeff_of_single, neg_add_cancel, hr] at hrc
     rw [hrc, sub_self]
 
@@ -696,8 +705,8 @@ theorem isUnit_iff {x : HahnSeries Γ R} : IsUnit x ↔ IsUnit (x.leadingCoeff) 
   · rintro ⟨⟨u, i, ui, iu⟩, rfl⟩
     refine
       isUnit_of_mul_eq_one (u.leadingCoeff) (i.leadingCoeff)
-        ((mul_coeff_order_add_order u i).symm.trans ?_)
-    rw [ui, one_coeff, if_pos]
+        ((coeff_mul_order_add_order u i).symm.trans ?_)
+    rw [ui, coeff_one, if_pos]
     rw [← order_mul (left_ne_zero_of_mul_eq_one ui) (right_ne_zero_of_mul_eq_one ui), ui, order_one]
   · rintro ⟨⟨u, i, ui, iu⟩, h⟩
     rw [Units.val_mk] at h

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -121,10 +121,10 @@ def hasseDeriv (R : Type*) {V : Type*} [AddCommGroup V] [Semiring R] [Module R V
     (fun _ h_lt ↦ by rw [coeff_eq_zero_of_lt_order <| lt_sub_iff_add_lt.mp h_lt, smul_zero]))
   map_add' f g := by
     ext
-    simp only [ofSuppBddBelow, add_coeff', Pi.add_apply, smul_add]
+    simp only [ofSuppBddBelow, coeff_add', Pi.add_apply, smul_add]
   map_smul' r f := by
     ext
-    simp only [ofSuppBddBelow, smul_coeff, RingHom.id_apply, smul_comm r]
+    simp only [ofSuppBddBelow, HahnSeries.coeff_smul, RingHom.id_apply, smul_comm r]
 
 variable [Semiring R] {V : Type*} [AddCommGroup V] [Module R V]
 
@@ -154,7 +154,7 @@ theorem hasseDeriv_single (k : ℕ) (n : ℤ) (x : V) :
 theorem hasseDeriv_comp_coeff (k l : ℕ) (f : LaurentSeries V) (n : ℤ) :
     (hasseDeriv R k (hasseDeriv R l f)).coeff n =
       ((Nat.choose (k + l) k) • hasseDeriv R (k + l) f).coeff n := by
-  rw [nsmul_coeff]
+  rw [coeff_nsmul]
   simp only [hasseDeriv_coeff, Pi.smul_apply, Nat.cast_add]
   rw [smul_smul, mul_comm, ← Ring.choose_add_smul_choose (n + k), add_assoc, Nat.choose_symm_add,
     smul_assoc]
@@ -186,7 +186,7 @@ theorem derivative_iterate (k : ℕ) (f : LaurentSeries V) :
 @[simp]
 theorem derivative_iterate_coeff (k : ℕ) (f : LaurentSeries V) (n : ℤ) :
     ((derivative R)^[k] f).coeff n = (descPochhammer ℤ k).smeval (n + k) • f.coeff (n + k) := by
-  rw [derivative_iterate, nsmul_coeff, Pi.smul_apply, hasseDeriv_coeff,
+  rw [derivative_iterate, coeff_nsmul, Pi.smul_apply, hasseDeriv_coeff,
     Ring.descPochhammer_eq_factorial_smul_choose, smul_assoc]
 
 end HasseDeriv
@@ -240,7 +240,7 @@ theorem powerSeriesPart_eq_zero (x : R⸨X⸩) : x.powerSeriesPart = 0 ↔ x = 0
 theorem single_order_mul_powerSeriesPart (x : R⸨X⸩) :
     (single x.order 1 : R⸨X⸩) * x.powerSeriesPart = x := by
   ext n
-  rw [← sub_add_cancel n x.order, single_mul_coeff_add, sub_add_cancel, one_mul]
+  rw [← sub_add_cancel n x.order, coeff_single_mul_add, sub_add_cancel, one_mul]
   by_cases h : x.order ≤ n
   · rw [Int.eq_natAbs_of_zero_le (sub_nonneg_of_le h), coeff_coe_powerSeries,
       powerSeriesPart_coeff, ← Int.eq_natAbs_of_zero_le (sub_nonneg_of_le h),
@@ -698,7 +698,7 @@ theorem eq_coeff_of_valuation_sub_lt {d n : ℤ} {f g : K⸨X⸩}
   · exact fun _ => by rw [triv]
   · intro hn
     apply eq_of_sub_eq_zero
-    rw [← HahnSeries.sub_coeff]
+    rw [← HahnSeries.coeff_sub]
     apply coeff_zero_of_lt_valuation K H hn
 
 /- Every Laurent series of valuation less than `(1 : ℤₘ₀)` comes from a power series. -/
@@ -877,7 +877,7 @@ theorem Cauchy.eventually_mem_nhds {ℱ : Filter K⸨X⸩} (hℱ : Cauchy ℱ)
   intro _ hf
   apply lt_of_le_of_lt (valuation_le_iff_coeff_lt_eq_zero K |>.mpr _) hD
   intro n hn
-  rw [HahnSeries.sub_coeff, sub_eq_zero, hf n hn |>.symm]; rfl
+  rw [HahnSeries.coeff_sub, sub_eq_zero, hf n hn |>.symm]; rfl
 
 /- Laurent Series with coefficients in a field are complete w.r.t. the `X`-adic valuation -/
 instance instLaurentSeriesComplete : CompleteSpace K⸨X⸩ :=


### PR DESCRIPTION
Basic pattern: `(n • x).coeff = n • x.coeff` was named `nsmul_coeff` but it should be `coeff_nsmul`.

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
