### PR TITLE
[Merged by Bors] - chore(Mathlib/RingTheory/MvPolynomial): rename MonomialOrder.lCoeff to MonomialOrder.leadingCoeff 

### DIFF
--- a/Mathlib/RingTheory/MvPolynomial/Groebner.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Groebner.lean
@@ -17,7 +17,7 @@ Let `R` be a commutative ring, `σ` a type of indeterminates and `m : MonomialOr
 a monomial ordering on `σ →₀ ℕ`.
 
 Consider a family of polynomials `b : ι → MvPolynomial σ R` with invertible leading coefficients
-(with respect to `m`) : we assume `hb : ∀ i, IsUnit (m.lCoeff (b i))`).
+(with respect to `m`) : we assume `hb : ∀ i, IsUnit (m.leadingCoeff (b i))`).
 
 * `MonomialOrder.div hb f` furnishes
   - a finitely supported family `g : ι →₀ MvPolynomial σ R`
@@ -33,7 +33,7 @@ The proof is done by induction, using two standard constructions
 * `MonomialOrder.subLTerm f` deletes the leading term of a polynomial `f`
 
 * `MonomialOrder.reduce hb f` subtracts from `f` the appropriate multiple of `b : MvPolynomial σ R`,
-provided `IsUnit (m.lCoeff b)`.
+provided `IsUnit (m.leadingCoeff b)`.
 
 * `MonomialOrder.div_set` is the variant of `MonomialOrder.div` for a set of polynomials.
 
@@ -41,7 +41,7 @@ provided `IsUnit (m.lCoeff b)`.
 
 ## TODO
 
-* Prove that under `Field F`, `IsUnit (m.lCoeff (b i))` is equivalent to `b i ≠ 0`.
+* Prove that under `Field F`, `IsUnit (m.leadingCoeff (b i))` is equivalent to `b i ≠ 0`.
 
 -/
 
@@ -56,7 +56,7 @@ variable {σ : Type*} {m : MonomialOrder σ} {R : Type*} [CommRing R]
 variable (m) in
 /-- Delete the leading term in a multivariate polynomial (for some monomial order) -/
 noncomputable def subLTerm (f : MvPolynomial σ R) : MvPolynomial σ R :=
-  f - monomial (m.degree f) (m.lCoeff f)
+  f - monomial (m.degree f) (m.leadingCoeff f)
 
 theorem degree_sub_LTerm_le (f : MvPolynomial σ R) :
     m.degree (m.subLTerm f) ≼[m] m.degree f := by
@@ -77,32 +77,33 @@ theorem degree_sub_LTerm_lt {f : MvPolynomial σ R} (hf : m.degree f ≠ 0) :
     exact hf hf'.symm
   rw [← coeff_degree_ne_zero_iff (m := m), hf'] at this
   apply this
-  simp [subLTerm, coeff_monomial, lCoeff]
+  simp [subLTerm, coeff_monomial, leadingCoeff]
 
 variable (m) in
 /-- Reduce a polynomial modulo a polynomial with unit leading term (for some monomial order) -/
-noncomputable def reduce {b : MvPolynomial σ R} (hb : IsUnit (m.lCoeff b)) (f : MvPolynomial σ R) :
+noncomputable
+def reduce {b : MvPolynomial σ R} (hb : IsUnit (m.leadingCoeff b)) (f : MvPolynomial σ R) :
     MvPolynomial σ R :=
- f - monomial (m.degree f - m.degree b) (hb.unit⁻¹ * m.lCoeff f) * b
+ f - monomial (m.degree f - m.degree b) (hb.unit⁻¹ * m.leadingCoeff f) * b
 
-theorem degree_reduce_lt {f b : MvPolynomial σ R} (hb : IsUnit (m.lCoeff b))
+theorem degree_reduce_lt {f b : MvPolynomial σ R} (hb : IsUnit (m.leadingCoeff b))
     (hbf : m.degree b ≤ m.degree f) (hf : m.degree f ≠ 0) :
     m.degree (m.reduce hb f) ≺[m] m.degree f := by
   have H : m.degree f =
-    m.degree ((monomial (m.degree f - m.degree b)) (hb.unit⁻¹ * m.lCoeff f)) +
+    m.degree ((monomial (m.degree f - m.degree b)) (hb.unit⁻¹ * m.leadingCoeff f)) +
       m.degree b := by
     classical
     rw [degree_monomial, if_neg]
     · ext d
       rw [tsub_add_cancel_of_le hbf]
-    · simp only [Units.mul_right_eq_zero, lCoeff_eq_zero_iff]
+    · simp only [Units.mul_right_eq_zero, leadingCoeff_eq_zero_iff]
       intro hf0
       apply hf
       simp [hf0]
   have H' : coeff (m.degree f) (m.reduce hb f) = 0 := by
     simp only [reduce, coeff_sub, sub_eq_zero]
     nth_rewrite 2 [H]
-    rw [coeff_mul_of_degree_add (m := m), lCoeff_monomial]
+    rw [coeff_mul_of_degree_add (m := m), leadingCoeff_monomial]
     rw [mul_comm, ← mul_assoc]
     simp only [IsUnit.mul_val_inv, one_mul]
     rfl
@@ -117,13 +118,13 @@ theorem degree_reduce_lt {f b : MvPolynomial σ R} (hb : IsUnit (m.lCoeff b))
   · intro K
     simp only [EmbeddingLike.apply_eq_iff_eq] at K
     nth_rewrite 1 [← K] at H'
-    change lCoeff m _ = 0 at H'
-    rw [lCoeff_eq_zero_iff] at H'
+    change leadingCoeff m _ = 0 at H'
+    rw [leadingCoeff_eq_zero_iff] at H'
     rw [H', degree_zero] at K
     exact hf K.symm
 
 theorem div {ι : Type*} {b : ι → MvPolynomial σ R}
-    (hb : ∀ i, IsUnit (m.lCoeff (b i))) (f : MvPolynomial σ R) :
+    (hb : ∀ i, IsUnit (m.leadingCoeff (b i))) (f : MvPolynomial σ R) :
     ∃ (g : ι →₀ (MvPolynomial σ R)) (r : MvPolynomial σ R),
       f = Finsupp.linearCombination _ b g + r ∧
         (∀ i, m.degree (b i * (g i)) ≼[m] m.degree f) ∧
@@ -162,7 +163,7 @@ theorem div {ι : Type*} {b : ι → MvPolynomial σ R}
       simpa [hf0'] using hf
     obtain ⟨g', r', H'⟩ := div hb (m.reduce (hb i) f)
     use g' +
-      Finsupp.single i (monomial (m.degree f - m.degree (b i)) ((hb i).unit⁻¹ * m.lCoeff f))
+      Finsupp.single i (monomial (m.degree f - m.degree (b i)) ((hb i).unit⁻¹ * m.leadingCoeff f))
     use r'
     constructor
     · rw [map_add, add_assoc, add_comm _ r', ← add_assoc, ← H'.1]
@@ -194,7 +195,7 @@ theorem div {ι : Type*} {b : ι → MvPolynomial σ R}
         (∀ i, m.degree ((b  i) * (g' i)) ≼[m] m.degree (m.subLTerm f)) ∧
         (∀ c ∈ r'.support, ∀ i, ¬ m.degree (b i) ≤ c) by
       obtain ⟨g', r', H'⟩ := this
-      use g', r' +  monomial (m.degree f) (m.lCoeff f)
+      use g', r' +  monomial (m.degree f) (m.leadingCoeff f)
       constructor
       · simp [← add_assoc, ← H'.1, subLTerm]
       constructor
@@ -225,7 +226,7 @@ decreasing_by
   simp
 
 theorem div_set {B : Set (MvPolynomial σ R)}
-    (hB : ∀ b ∈ B, IsUnit (m.lCoeff b)) (f : MvPolynomial σ R) :
+    (hB : ∀ b ∈ B, IsUnit (m.leadingCoeff b)) (f : MvPolynomial σ R) :
     ∃ (g : B →₀ (MvPolynomial σ R)) (r : MvPolynomial σ R),
       f = Finsupp.linearCombination _ (fun (b : B) ↦ (b : MvPolynomial σ R)) g + r ∧
         (∀ (b : B), m.degree ((b : MvPolynomial σ R) * (g b)) ≼[m] m.degree f) ∧

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -20,7 +20,7 @@ and a monomial order `m : MonomialOrder σ`.
 
 * `m.leadingCoeff_ne_zero_iff f` asserts that this coefficient is nonzero iff `f ≠ 0`.
 
-* in a field, `m.leadingCoeff_is_unit_iff f` asserts that this coefficient is a unit iff `f ≠ 0`.
+* in a field, `m.isUnit_leadingCoeff f` asserts that this coefficient is a unit iff `f ≠ 0`.
 
 * `m.degree_add_le` : the `m.degree` of `f + g` is smaller than or equal to the supremum
 of those of `f` and `g`
@@ -79,6 +79,8 @@ variable (m) in
 def leadingCoeff {R : Type*} [CommSemiring R] (f : MvPolynomial σ R) : R :=
   f.coeff (m.degree f)
 
+@[deprecated (since := "2025-01-31")] alias lCoeff := leadingCoeff
+
 @[simp]
 theorem degree_zero : m.degree (0 : MvPolynomial σ R) = 0 := by
   simp [degree]
@@ -86,6 +88,8 @@ theorem degree_zero : m.degree (0 : MvPolynomial σ R) = 0 := by
 @[simp]
 theorem leadingCoeff_zero : m.leadingCoeff (0 : MvPolynomial σ R) = 0 := by
   simp [degree, leadingCoeff]
+
+@[deprecated (since := "2025-01-31")] alias lCoeff_zero := leadingCoeff_zero
 
 theorem degree_monomial_le {d : σ →₀ ℕ} (c : R) :
     m.degree (monomial d c) ≼[m] d := by
@@ -104,6 +108,8 @@ theorem leadingCoeff_monomial {d : σ →₀ ℕ} (c : R) :
   classical
   simp only [leadingCoeff, degree_monomial]
   split_ifs with hc <;> simp [hc]
+
+@[deprecated (since := "2025-01-31")] alias lCoeff_monomial := leadingCoeff_monomial
 
 theorem degree_le_iff {f : MvPolynomial σ R} {d : σ →₀ ℕ} :
     m.degree f ≼[m] d ↔ ∀ c ∈ f.support, c ≼[m] d := by
@@ -142,10 +148,14 @@ theorem leadingCoeff_ne_zero_iff {f : MvPolynomial σ R} :
       exact hd
     exact Finset.sup_mem_of_nonempty hf
 
+@[deprecated (since := "2025-01-31")] alias lCoeff_ne_zero_iff := leadingCoeff_ne_zero_iff
+
 @[simp]
 theorem leadingCoeff_eq_zero_iff {f : MvPolynomial σ R} :
     leadingCoeff m f = 0 ↔ f = 0 := by
   simp only [← not_iff_not, leadingCoeff_ne_zero_iff]
+
+@[deprecated (since := "2025-01-31")] alias lCoeff_eq_zero_iff := leadingCoeff_eq_zero_iff
 
 theorem coeff_degree_ne_zero_iff {f : MvPolynomial σ R} :
     f.coeff (m.degree f) ≠ 0 ↔ f ≠ 0 :=
@@ -206,6 +216,8 @@ theorem degree_add_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] m.degr
 theorem leadingCoeff_add_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] m.degree f) :
     m.leadingCoeff (f + g) = m.leadingCoeff f := by
   simp only [leadingCoeff, m.degree_add_of_lt h, coeff_add, coeff_eq_zero_of_lt h, add_zero]
+
+@[deprecated (since := "2025-01-31")] alias lCoeff_add_of_lt := leadingCoeff_add_of_lt
 
 theorem degree_add_of_ne {f g : MvPolynomial σ R}
     (h : m.degree f ≠ m.degree g) :
@@ -287,6 +299,9 @@ theorem leadingCoeff_mul_of_isRegular_left {f g : MvPolynomial σ R}
     m.leadingCoeff (f * g) = m.leadingCoeff f * m.leadingCoeff g := by
   simp only [leadingCoeff, degree_mul_of_isRegular_left hf hg, coeff_mul_of_degree_add]
 
+@[deprecated (since := "2025-01-31")]
+alias lCoeff_mul_of_isRegular_left := leadingCoeff_mul_of_isRegular_left
+
 /-- Multiplicativity of leading coefficients -/
 theorem degree_mul_of_isRegular_right {f g : MvPolynomial σ R}
     (hf : f ≠ 0) (hg : IsRegular (m.leadingCoeff g)) :
@@ -298,6 +313,9 @@ theorem leadingCoeff_mul_of_isRegular_right {f g : MvPolynomial σ R}
     (hf : f ≠ 0) (hg : IsRegular (m.leadingCoeff g)) :
     m.leadingCoeff (f * g) = m.leadingCoeff f * m.leadingCoeff g := by
   simp only [leadingCoeff, degree_mul_of_isRegular_right hf hg, coeff_mul_of_degree_add]
+
+@[deprecated (since := "2025-01-31")]
+alias lCoeff_mul_of_isRegular_right := leadingCoeff_mul_of_isRegular_right
 
 /-- Degree of product -/
 theorem degree_mul [IsDomain R] {f g : MvPolynomial σ R} (hf : f ≠ 0) (hg : g ≠ 0) :
@@ -314,6 +332,8 @@ theorem leadingCoeff_mul [IsDomain R] {f g : MvPolynomial σ R}
     (hf : f ≠ 0) (hg : g ≠ 0) :
     m.leadingCoeff (f * g) = m.leadingCoeff f * m.leadingCoeff g := by
   rw [leadingCoeff, degree_mul hf hg, ← coeff_mul_of_degree_add]
+
+@[deprecated (since := "2025-01-31")] alias lCoeff_mul := leadingCoeff_mul
 
 theorem degree_smul_le {r : R} {f : MvPolynomial σ R} :
     m.degree (r • f) ≼[m] m.degree f := by
@@ -374,15 +394,19 @@ theorem leadingCoeff_sub_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] 
   apply leadingCoeff_add_of_lt
   simp only [degree_neg, h]
 
+@[deprecated (since := "2025-01-31")] alias lCoeff_sub_of_lt := leadingCoeff_sub_of_lt
+
 end Ring
 
 section Field
 
 variable {R : Type*} [Field R]
 
-theorem leadingCoeff_is_unit_iff {f : MvPolynomial σ R} :
+theorem isUnit_leadingCoeff {f : MvPolynomial σ R} :
     IsUnit (m.leadingCoeff f) ↔ f ≠ 0 := by
   simp only [isUnit_iff_ne_zero, ne_eq, leadingCoeff_eq_zero_iff]
+
+@[deprecated (since := "2025-01-31")] alias lCoeff_is_unit_iff := isUnit_leadingCoeff
 
 end Field
 

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -16,11 +16,11 @@ and a monomial order `m : MonomialOrder σ`.
 
 * `m.degree f` is the degree of `f` for the monomial ordering `m`
 
-* `m.lCoeff f` is the leading coefficient of `f` for the monomial ordering `m`
+* `m.leadingCoeff f` is the leading coefficient of `f` for the monomial ordering `m`
 
-* `m.lCoeff_ne_zero_iff f` asserts that this coefficient is nonzero iff `f ≠ 0`.
+* `m.leadingCoeff_ne_zero_iff f` asserts that this coefficient is nonzero iff `f ≠ 0`.
 
-* in a field, `m.lCoeff_is_unit_iff f` asserts that this coefficient is a unit iff `f ≠ 0`.
+* in a field, `m.leadingCoeff_is_unit_iff f` asserts that this coefficient is a unit iff `f ≠ 0`.
 
 * `m.degree_add_le` : the `m.degree` of `f + g` is smaller than or equal to the supremum
 of those of `f` and `g`
@@ -28,7 +28,7 @@ of those of `f` and `g`
 * `m.degree_add_of_lt h` : the `m.degree` of `f + g` is equal to that of `f`
 if the `m.degree` of `g` is strictly smaller than that `f`
 
-* `m.lCoeff_add_of_lt h`: then, the leading coefficient of `f + g` is that of `f` .
+* `m.leadingCoeff_add_of_lt h`: then, the leading coefficient of `f + g` is that of `f` .
 
 * `m.degree_add_of_ne h` : the `m.degree` of `f + g` is equal to that the supremum
 of those of `f` and `g` if they are distinct
@@ -39,7 +39,7 @@ of those of `f` and `g`
 * `m.degree_sub_of_lt h` : the `m.degree` of `f - g` is equal to that of `f`
 if the `m.degree` of `g` is strictly smaller than that `f`
 
-* `m.lCoeff_sub_of_lt h`: then, the leading coefficient of `f - g` is that of `f` .
+* `m.leadingCoeff_sub_of_lt h`: then, the leading coefficient of `f - g` is that of `f` .
 
 * `m.degree_mul_le`: the `m.degree` of `f * g` is smaller than or equal to the sum of those of
 `f` and `g`.
@@ -48,8 +48,8 @@ if the `m.degree` of `g` is strictly smaller than that `f`
 assert the  equality when the leading coefficient of `f` or `g` is regular,
 or when `R` is a domain and `f` and `g` are nonzero.
 
-* `m.lCoeff_mul_of_isRegular_left`, `m.lCoeff_mul_of_isRegular_right`  and `m.lCoeff_mul`
-say that `m.lCoeff (f * g) = m.lCoeff f * m.lCoeff g`
+* `m.leadingCoeff_mul_of_isRegular_left`, `m.leadingCoeff_mul_of_isRegular_right`
+  and `m.leadingCoeff_mul` say that `m.leadingCoeff (f * g) = m.leadingCoeff f * m.leadingCoeff g`
 
 ## Reference
 
@@ -76,7 +76,7 @@ def degree {R : Type*} [CommSemiring R] (f : MvPolynomial σ R) : σ →₀ ℕ 
 
 variable (m) in
 /-- the leading coefficient of a multivariate polynomial with respect to a monomial ordering -/
-def lCoeff {R : Type*} [CommSemiring R] (f : MvPolynomial σ R) : R :=
+def leadingCoeff {R : Type*} [CommSemiring R] (f : MvPolynomial σ R) : R :=
   f.coeff (m.degree f)
 
 @[simp]
@@ -84,8 +84,8 @@ theorem degree_zero : m.degree (0 : MvPolynomial σ R) = 0 := by
   simp [degree]
 
 @[simp]
-theorem lCoeff_zero : m.lCoeff (0 : MvPolynomial σ R) = 0 := by
-  simp [degree, lCoeff]
+theorem leadingCoeff_zero : m.leadingCoeff (0 : MvPolynomial σ R) = 0 := by
+  simp [degree, leadingCoeff]
 
 theorem degree_monomial_le {d : σ →₀ ℕ} (c : R) :
     m.degree (monomial d c) ≼[m] d := by
@@ -99,10 +99,10 @@ theorem degree_monomial {d : σ →₀ ℕ} (c : R) [Decidable (c = 0)] :
   split_ifs with hc <;> simp
 
 @[simp]
-theorem lCoeff_monomial {d : σ →₀ ℕ} (c : R) :
-    m.lCoeff (monomial d c) = c := by
+theorem leadingCoeff_monomial {d : σ →₀ ℕ} (c : R) :
+    m.leadingCoeff (monomial d c) = c := by
   classical
-  simp only [lCoeff, degree_monomial]
+  simp only [leadingCoeff, degree_monomial]
   split_ifs with hc <;> simp [hc]
 
 theorem degree_le_iff {f : MvPolynomial σ R} {d : σ →₀ ℕ} :
@@ -127,15 +127,15 @@ theorem coeff_eq_zero_of_lt {f : MvPolynomial σ R} {d : σ →₀ ℕ} (hd : m.
   rw [← not_le] at hd
   by_contra hf
   apply hd (m.le_degree (mem_support_iff.mpr hf))
-theorem lCoeff_ne_zero_iff {f : MvPolynomial σ R} :
-    m.lCoeff f ≠ 0 ↔ f ≠ 0 := by
+theorem leadingCoeff_ne_zero_iff {f : MvPolynomial σ R} :
+    m.leadingCoeff f ≠ 0 ↔ f ≠ 0 := by
   constructor
   · rw [not_imp_not]
     intro hf
-    rw [hf, lCoeff_zero]
+    rw [hf, leadingCoeff_zero]
   · intro hf
     rw [← support_nonempty] at hf
-    rw [lCoeff, ← mem_support_iff, degree]
+    rw [leadingCoeff, ← mem_support_iff, degree]
     suffices f.support.sup m.toSyn ∈ m.toSyn '' f.support by
       obtain ⟨d, hd, hd'⟩ := this
       rw [← hd', AddEquiv.symm_apply_apply]
@@ -143,18 +143,18 @@ theorem lCoeff_ne_zero_iff {f : MvPolynomial σ R} :
     exact Finset.sup_mem_of_nonempty hf
 
 @[simp]
-theorem lCoeff_eq_zero_iff {f : MvPolynomial σ R} :
-    lCoeff m f = 0 ↔ f = 0 := by
-  simp only [← not_iff_not, lCoeff_ne_zero_iff]
+theorem leadingCoeff_eq_zero_iff {f : MvPolynomial σ R} :
+    leadingCoeff m f = 0 ↔ f = 0 := by
+  simp only [← not_iff_not, leadingCoeff_ne_zero_iff]
 
 theorem coeff_degree_ne_zero_iff {f : MvPolynomial σ R} :
     f.coeff (m.degree f) ≠ 0 ↔ f ≠ 0 :=
-  m.lCoeff_ne_zero_iff
+  m.leadingCoeff_ne_zero_iff
 
 @[simp]
 theorem coeff_degree_eq_zero_iff {f : MvPolynomial σ R} :
     f.coeff (m.degree f) = 0 ↔ f = 0 :=
-  m.lCoeff_eq_zero_iff
+  m.leadingCoeff_eq_zero_iff
 
 theorem degree_eq_zero_iff_totalDegree_eq_zero {f : MvPolynomial σ R} :
     m.degree f = 0 ↔ f.totalDegree = 0 := by
@@ -195,16 +195,17 @@ theorem degree_add_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] m.degr
   · apply le_trans degree_add_le
     simp only [sup_le_iff, le_refl, true_and, le_of_lt h]
   · apply le_degree
-    rw [mem_support_iff, coeff_add, m.coeff_eq_zero_of_lt h, add_zero, ← lCoeff, lCoeff_ne_zero_iff]
+    rw [mem_support_iff, coeff_add, m.coeff_eq_zero_of_lt h, add_zero,
+      ← leadingCoeff, leadingCoeff_ne_zero_iff]
     intro hf
     rw [← not_le, hf] at h
     apply h
     simp only [degree_zero, map_zero]
     apply bot_le
 
-theorem lCoeff_add_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] m.degree f) :
-    m.lCoeff (f + g) = m.lCoeff f := by
-  simp only [lCoeff, m.degree_add_of_lt h, coeff_add, coeff_eq_zero_of_lt h, add_zero]
+theorem leadingCoeff_add_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] m.degree f) :
+    m.leadingCoeff (f + g) = m.leadingCoeff f := by
+  simp only [leadingCoeff, m.degree_add_of_lt h, coeff_add, coeff_eq_zero_of_lt h, add_zero]
 
 theorem degree_add_of_ne {f g : MvPolynomial σ R}
     (h : m.degree f ≠ m.degree g) :
@@ -240,7 +241,7 @@ theorem degree_mul_le {f g : MvPolynomial σ R} :
 
 /-- Multiplicativity of leading coefficients -/
 theorem coeff_mul_of_degree_add {f g : MvPolynomial σ R} :
-    (f * g).coeff (m.degree f + m.degree g) = m.lCoeff f * m.lCoeff g := by
+    (f * g).coeff (m.degree f + m.degree g) = m.leadingCoeff f * m.leadingCoeff g := by
   classical
   rw [coeff_mul]
   rw [Finset.sum_eq_single (m.degree f, m.degree g)]
@@ -270,38 +271,38 @@ theorem coeff_mul_of_degree_add {f g : MvPolynomial σ R} :
 
 /-- Multiplicativity of leading coefficients -/
 theorem degree_mul_of_isRegular_left {f g : MvPolynomial σ R}
-    (hf : IsRegular (m.lCoeff f)) (hg : g ≠ 0) :
+    (hf : IsRegular (m.leadingCoeff f)) (hg : g ≠ 0) :
     m.degree (f * g) = m.degree f + m.degree g := by
   apply m.toSyn.injective
   apply le_antisymm degree_mul_le
   apply le_degree
   rw [mem_support_iff, coeff_mul_of_degree_add]
   simp only [ne_eq, hf, IsRegular.left, IsLeftRegular.mul_left_eq_zero_iff,
-    lCoeff_eq_zero_iff]
+    leadingCoeff_eq_zero_iff]
   exact hg
 
 /-- Multiplicativity of leading coefficients -/
-theorem lCoeff_mul_of_isRegular_left {f g : MvPolynomial σ R}
-    (hf : IsRegular (m.lCoeff f)) (hg : g ≠ 0) :
-    m.lCoeff (f * g) = m.lCoeff f * m.lCoeff g := by
-  simp only [lCoeff, degree_mul_of_isRegular_left hf hg, coeff_mul_of_degree_add]
+theorem leadingCoeff_mul_of_isRegular_left {f g : MvPolynomial σ R}
+    (hf : IsRegular (m.leadingCoeff f)) (hg : g ≠ 0) :
+    m.leadingCoeff (f * g) = m.leadingCoeff f * m.leadingCoeff g := by
+  simp only [leadingCoeff, degree_mul_of_isRegular_left hf hg, coeff_mul_of_degree_add]
 
 /-- Multiplicativity of leading coefficients -/
 theorem degree_mul_of_isRegular_right {f g : MvPolynomial σ R}
-    (hf : f ≠ 0) (hg : IsRegular (m.lCoeff g)) :
+    (hf : f ≠ 0) (hg : IsRegular (m.leadingCoeff g)) :
     m.degree (f * g) = m.degree f + m.degree g := by
   rw [mul_comm, m.degree_mul_of_isRegular_left hg hf, add_comm]
 
 /-- Multiplicativity of leading coefficients -/
-theorem lCoeff_mul_of_isRegular_right {f g : MvPolynomial σ R}
-    (hf : f ≠ 0) (hg : IsRegular (m.lCoeff g)) :
-    m.lCoeff (f * g) = m.lCoeff f * m.lCoeff g := by
-  simp only [lCoeff, degree_mul_of_isRegular_right hf hg, coeff_mul_of_degree_add]
+theorem leadingCoeff_mul_of_isRegular_right {f g : MvPolynomial σ R}
+    (hf : f ≠ 0) (hg : IsRegular (m.leadingCoeff g)) :
+    m.leadingCoeff (f * g) = m.leadingCoeff f * m.leadingCoeff g := by
+  simp only [leadingCoeff, degree_mul_of_isRegular_right hf hg, coeff_mul_of_degree_add]
 
 /-- Degree of product -/
 theorem degree_mul [IsDomain R] {f g : MvPolynomial σ R} (hf : f ≠ 0) (hg : g ≠ 0) :
     m.degree (f * g) = m.degree f + m.degree g :=
-  degree_mul_of_isRegular_left (isRegular_of_ne_zero (lCoeff_ne_zero_iff.mpr hf)) hg
+  degree_mul_of_isRegular_left (isRegular_of_ne_zero (leadingCoeff_ne_zero_iff.mpr hf)) hg
 
 /-- Degree of of product -/
 theorem degree_mul_of_nonzero_mul [IsDomain R] {f g : MvPolynomial σ R} (hfg : f * g ≠ 0) :
@@ -309,10 +310,10 @@ theorem degree_mul_of_nonzero_mul [IsDomain R] {f g : MvPolynomial σ R} (hfg : 
   degree_mul (left_ne_zero_of_mul hfg) (right_ne_zero_of_mul hfg)
 
 /-- Multiplicativity of leading coefficients -/
-theorem lCoeff_mul [IsDomain R] {f g : MvPolynomial σ R}
+theorem leadingCoeff_mul [IsDomain R] {f g : MvPolynomial σ R}
     (hf : f ≠ 0) (hg : g ≠ 0) :
-    m.lCoeff (f * g) = m.lCoeff f * m.lCoeff g := by
-  rw [lCoeff, degree_mul hf hg, ← coeff_mul_of_degree_add]
+    m.leadingCoeff (f * g) = m.leadingCoeff f * m.leadingCoeff g := by
+  rw [leadingCoeff, degree_mul hf hg, ← coeff_mul_of_degree_add]
 
 theorem degree_smul_le {r : R} {f : MvPolynomial σ R} :
     m.degree (r • f) ≼[m] m.degree f := by
@@ -329,12 +330,12 @@ theorem degree_smul {r : R} (hr : IsRegular r) {f : MvPolynomial σ R} :
   apply le_degree
   simp only [mem_support_iff, smul_eq_C_mul]
   rw [← zero_add (degree m f), ← degree_C r, coeff_mul_of_degree_add]
-  simp [lCoeff, hr.left.mul_left_eq_zero_iff, hf]
+  simp [leadingCoeff, hr.left.mul_left_eq_zero_iff, hf]
 
 theorem eq_C_of_degree_eq_zero {f : MvPolynomial σ R} (hf : m.degree f = 0) :
-    f = C (m.lCoeff f) := by
+    f = C (m.leadingCoeff f) := by
   ext d
-  simp only [lCoeff, hf]
+  simp only [leadingCoeff, hf]
   classical
   by_cases hd : d = 0
   · simp [hd]
@@ -367,10 +368,10 @@ theorem degree_sub_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] m.degr
   apply degree_add_of_lt
   simp only [degree_neg, h]
 
-theorem lCoeff_sub_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] m.degree f) :
-    m.lCoeff (f - g) = m.lCoeff f := by
+theorem leadingCoeff_sub_of_lt {f g : MvPolynomial σ R} (h : m.degree g ≺[m] m.degree f) :
+    m.leadingCoeff (f - g) = m.leadingCoeff f := by
   rw [sub_eq_add_neg]
-  apply lCoeff_add_of_lt
+  apply leadingCoeff_add_of_lt
   simp only [degree_neg, h]
 
 end Ring
@@ -379,9 +380,9 @@ section Field
 
 variable {R : Type*} [Field R]
 
-theorem lCoeff_is_unit_iff {f : MvPolynomial σ R} :
-    IsUnit (m.lCoeff f) ↔ f ≠ 0 := by
-  simp only [isUnit_iff_ne_zero, ne_eq, lCoeff_eq_zero_iff]
+theorem leadingCoeff_is_unit_iff {f : MvPolynomial σ R} :
+    IsUnit (m.leadingCoeff f) ↔ f ≠ 0 := by
+  simp only [isUnit_iff_ne_zero, ne_eq, leadingCoeff_eq_zero_iff]
 
 end Field
 


### PR DESCRIPTION
For coherence with other names in mathlib, we rename `MonomialOrder.lCoeff` to `MonomialOrder.leadingCoeff`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
