### PR TITLE
[Merged by Bors] - chore(GroupTheory/SpecificGroups/Alternating.lean): follow last minute review of JX

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
@@ -108,6 +108,8 @@ theorem alternatingGroup.index_eq_two [Nontrivial α] :
 theorem alternatingGroup.index_eq_one [Subsingleton α] : (alternatingGroup α).index = 1 := by
   rw [Subgroup.index_eq_one]; apply Subsingleton.elim
 
+@[deprecated (since := "2025-02-01")] alias index.eq_one := alternatingGroup.index_eq_one
+
 theorem two_mul_card_alternatingGroup [Nontrivial α] :
     2 * card (alternatingGroup α) = card (Perm α) := by
   simp only [← Nat.card_eq_fintype_card, ← alternatingGroup.index_eq_two (α := α), index_mul_card]

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
@@ -108,8 +108,6 @@ theorem alternatingGroup.index_eq_two [Nontrivial α] :
 theorem alternatingGroup.index_eq_one [Subsingleton α] : (alternatingGroup α).index = 1 := by
   rw [Subgroup.index_eq_one]; apply Subsingleton.elim
 
-@[deprecated (since := "2025-02-01")] alias index.eq_one := alternatingGroup.index_eq_one
-
 theorem two_mul_card_alternatingGroup [Nontrivial α] :
     2 * card (alternatingGroup α) = card (Perm α) := by
   simp only [← Nat.card_eq_fintype_card, ← alternatingGroup.index_eq_two (α := α), index_mul_card]

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
@@ -105,7 +105,7 @@ theorem alternatingGroup.index_eq_two [Nontrivial α] :
   simp_rw [mem_top, Nat.card_eq_fintype_card]; rfl
 
 @[nontriviality]
-theorem index_eq_one [Subsingleton α] : (alternatingGroup α).index = 1 := by
+theorem alternatingGroup.index_eq_one [Subsingleton α] : (alternatingGroup α).index = 1 := by
   rw [Subgroup.index_eq_one]; apply Subsingleton.elim
 
 theorem two_mul_card_alternatingGroup [Nontrivial α] :
@@ -368,7 +368,7 @@ namespace Equiv.Perm
 
 open Subgroup Group
 
-/-- The alternating group is the only subgroup of index 2 of the permutation group -/
+/-- The alternating group is the only subgroup of index 2 of the permutation group. -/
 theorem eq_alternatingGroup_of_index_eq_two {G : Subgroup (Equiv.Perm α)} (hG : G.index = 2) :
     G = alternatingGroup α := by
   nontriviality α
@@ -384,7 +384,7 @@ theorem eq_alternatingGroup_of_index_eq_two {G : Subgroup (Equiv.Perm α)} (hG :
   rw [← (isConj_iff.mp <| isConj_swap hxy hab).choose_spec]
   exact (normal_of_index_eq_two hG).conj_mem _ habG _
 
-/-- A subgroup of the permutation group of index ≤ 2 contains the alternating group -/
+/-- A subgroup of the permutation group of index ≤ 2 contains the alternating group. -/
 theorem alternatingGroup_le_of_index_le_two
     {G : Subgroup (Equiv.Perm α)} (hG : G.index ≤ 2) :
     alternatingGroup α ≤ G := by
@@ -396,7 +396,7 @@ theorem alternatingGroup_le_of_index_le_two
 
 end Equiv.Perm
 
-/-- The alternating group is a characteristic subgroup of the permutation group -/
+/-- The alternating group is a characteristic subgroup of the permutation group. -/
 instance : (alternatingGroup α).Characteristic where
   fixed φ := by
     nontriviality α


### PR DESCRIPTION
This PR makes 3 modifications suggested by @alreadydone when he delegated the merge yesterday night.
suggestions that I hadn't detected in my email.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
