### PR TITLE
[Merged by Bors] - doc: fix several typos

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -8,8 +8,9 @@ import Mathlib.Analysis.SpecialFunctions.Log.Basic
 /-!
 # The Positive Part of the Logarithm
 
-This file defines the function `Real.posLog = r ↦ max 0 (log r)`, introduces the notation `log⁺,
-For a finite length-`n` sequence `f i` of reals, it establishes the following standard estimates.
+This file defines the function `Real.posLog = r ↦ max 0 (log r)` and introduces the notation
+`log⁺`. For a finite length-`n` sequence `f i` of reals, it establishes the following standard
+estimates.
 
 - `theorem posLog_prod : log⁺ (∏ i, f i) ≤ ∑ i, log⁺ (f i)`
 
@@ -25,7 +26,7 @@ namespace Real
 /-- Definition: the positive part of the logarithm. -/
 noncomputable def posLog : ℝ → ℝ := fun r ↦ max 0 (log r)
 
-/-- Notation `log⁺` for the real part of the logarithm. -/
+/-- Notation `log⁺` for the positive part of the logarithm. -/
 scoped notation "log⁺" => posLog
 
 /-- Definition of the positive part of the logarithm, formulated as a theorem. -/
@@ -63,7 +64,7 @@ theorem posLog_eq_zero_iff (x : ℝ) : log⁺ x = 0 ↔ |x| ≤ 1 := by
   rw [← posLog_abs, ← log_nonpos_iff (abs_nonneg x)]
   simp [posLog]
 
-/-- The function `log⁺` equals `log` outside of in the interval (-1,1). -/
+/-- The function `log⁺` equals `log` outside of the interval (-1,1). -/
 theorem posLog_eq_log {x : ℝ} (hx : 1 ≤ |x|) : log⁺ x = log x := by
   simp only [posLog, sup_eq_right]
   rw [← log_abs]
@@ -75,7 +76,7 @@ theorem log_of_nat_eq_posLog {n : ℕ} : log⁺ n = log n := by
   · simp [hn, posLog]
   · simp [posLog_eq_log, Nat.one_le_iff_ne_zero.2 hn]
 
-/-- The function `log⁺` is monotone in the positive axis. -/
+/-- The function `log⁺` is monotone on the positive axis. -/
 theorem monotoneOn_posLog : MonotoneOn log⁺ (Set.Ici 0) := by
   intro x hx y hy hxy
   simp only [posLog, le_sup_iff, sup_le_iff, le_refl, true_and]


### PR DESCRIPTION
Fix several typos in the documentation that I myself introduced yesterday :-( I apologize for causing this extra work.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
