### PR TITLE
[Merged by Bors] - refactor(Topology/Constructible): use `QuasiSeparatedSpace`

### DIFF
--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -589,6 +589,12 @@ lemma range_comap_algebraMap_localization_compl_eq_range_comap_quotientMk
   rw [range_comap_of_surjective _ _ surj, localization_away_comap_range _ (C c)]
   simp [Polynomial.ker_mapRingHom, Ideal.map_span]
 
+lemma isRetrocompact_iff {U : Set (PrimeSpectrum R)} (hU : IsOpen U) :
+    IsRetrocompact U ↔ IsCompact U := by
+  refine isTopologicalBasis_basic_opens.isRetrocompact_iff_isCompact ?_ hU
+  simpa [← TopologicalSpace.Opens.coe_inf, ← basicOpen_mul, -basicOpen_eq_zeroLocus_compl]
+    using fun _ _ ↦ isCompact_basicOpen _
+
 end BasicOpen
 
 section DiscreteTopology

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -589,12 +589,6 @@ lemma range_comap_algebraMap_localization_compl_eq_range_comap_quotientMk
   rw [range_comap_of_surjective _ _ surj, localization_away_comap_range _ (C c)]
   simp [Polynomial.ker_mapRingHom, Ideal.map_span]
 
-lemma isRetrocompact_iff {U : Set (PrimeSpectrum R)} (hU : IsOpen U) :
-    IsRetrocompact U ↔ IsCompact U := by
-  refine isTopologicalBasis_basic_opens.isRetrocompact_iff_isCompact ?_ hU
-  simpa [← TopologicalSpace.Opens.coe_inf, ← basicOpen_mul, -basicOpen_eq_zeroLocus_compl]
-    using fun _ _ ↦ isCompact_basicOpen _
-
 end BasicOpen
 
 section DiscreteTopology

--- a/Mathlib/Topology/Constructible.lean
+++ b/Mathlib/Topology/Constructible.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Order.BooleanSubalgebra
+import Mathlib.Topology.QuasiSeparated
 import Mathlib.Topology.Spectral.Hom
 
 /-!
@@ -296,10 +297,13 @@ variable [CompactSpace X] {P : ∀ s : Set X, IsConstructible s → Prop} {B : S
 lemma _root_.IsRetrocompact.isCompact (hs : IsRetrocompact s) : IsCompact s := by
   simpa using hs CompactSpace.isCompact_univ
 
+variable [QuasiSeparatedSpace X]
+
 /-- Variant of `TopologicalSpace.IsTopologicalBasis.isRetrocompact_iff_isCompact` for a
 non-indexed topological basis. -/
+@[stacks 0069 "Iff form of (2). Note that Stacks doesn't define quasi-separated spaces."]
 lemma _root_.TopologicalSpace.IsTopologicalBasis.isRetrocompact_iff_isCompact'
-    (basis : IsTopologicalBasis B) (compact_inter : ∀ U ∈ B, ∀ V ∈ B, IsCompact (U ∩ V))
+    (basis : IsTopologicalBasis B) (isCompact_basis : ∀ U ∈ B, IsCompact U)
     (hU : IsOpen U) : IsRetrocompact U ↔ IsCompact U := by
   refine ⟨IsRetrocompact.isCompact, fun hU' {V} hV' hV ↦ ?_⟩
   obtain ⟨s, rfl⟩ := eq_sUnion_finset_of_isTopologicalBasis_of_isCompact_open _ basis _ hU' hU
@@ -308,43 +312,44 @@ lemma _root_.TopologicalSpace.IsTopologicalBasis.isRetrocompact_iff_isCompact'
   refine ((s.finite_toSet.image _).prod (t.finite_toSet.image _)).isCompact_biUnion ?_
   simp only [mem_prod, mem_image, Finset.mem_coe, Subtype.exists, exists_and_right, exists_eq_right,
     and_imp, forall_exists_index, Prod.forall]
-  exact fun u v hu _ hv _ ↦ compact_inter _ hu _ hv
+  exact fun u v hu _ hv _ ↦ (isCompact_basis _ hu).inter_of_isOpen (isCompact_basis _ hv)
+    (basis.isOpen hu) (basis.isOpen hv)
 
+@[stacks 0069 "Iff form of (2). Note that Stacks doesn't define quasi-separated spaces."]
 lemma _root_.TopologicalSpace.IsTopologicalBasis.isRetrocompact_iff_isCompact
-    (basis : IsTopologicalBasis (range b)) (compact_inter : ∀ i j, IsCompact (b i ∩ b j))
+    (basis : IsTopologicalBasis (range b)) (isCompact_basis : ∀ i, IsCompact (b i))
     (hU : IsOpen U) : IsRetrocompact U ↔ IsCompact U :=
-  basis.isRetrocompact_iff_isCompact' (by simpa using compact_inter) hU
+  basis.isRetrocompact_iff_isCompact' (by simpa using isCompact_basis) hU
 
 /-- Variant of `TopologicalSpace.IsTopologicalBasis.isRetrocompact` for a non-indexed topological
 basis. -/
 lemma _root_.TopologicalSpace.IsTopologicalBasis.isRetrocompact' (basis : IsTopologicalBasis B)
-    (compact_inter : ∀ U ∈ B, ∀ V ∈ B, IsCompact (U ∩ V)) (hU : U ∈ B) : IsRetrocompact U :=
-  (basis.isRetrocompact_iff_isCompact' compact_inter <| basis.isOpen hU).2 <| by
-    simpa using compact_inter _ hU _ hU
+    (isCompact_basis : ∀ U ∈ B, IsCompact U) (hU : U ∈ B) : IsRetrocompact U :=
+  (basis.isRetrocompact_iff_isCompact' isCompact_basis <| basis.isOpen hU).2 <| isCompact_basis _ hU
 
 lemma _root_.TopologicalSpace.IsTopologicalBasis.isRetrocompact
-    (basis : IsTopologicalBasis (range b)) (compact_inter : ∀ i j, IsCompact (b i ∩ b j)) (i : ι) :
+    (basis : IsTopologicalBasis (range b)) (isCompact_basis : ∀ i, IsCompact (b i)) (i : ι) :
     IsRetrocompact (b i) :=
-  (basis.isRetrocompact_iff_isCompact compact_inter <| basis.isOpen <| mem_range_self _).2 <| by
-    simpa using compact_inter i i
+  (basis.isRetrocompact_iff_isCompact isCompact_basis <| basis.isOpen <| mem_range_self _).2 <|
+    isCompact_basis _
 
 /-- Variant of `TopologicalSpace.IsTopologicalBasis.isConstructible` for a non-indexed topological
 basis. -/
 lemma _root_.TopologicalSpace.IsTopologicalBasis.isConstructible' (basis : IsTopologicalBasis B)
-    (compact_inter : ∀ U ∈ B, ∀ V ∈ B, IsCompact (U ∩ V)) (hU : U ∈ B) : IsConstructible U :=
-  (basis.isRetrocompact' compact_inter hU).isConstructible <| basis.isOpen hU
+    (isCompact_basis : ∀ U ∈ B, IsCompact U) (hU : U ∈ B) : IsConstructible U :=
+  (basis.isRetrocompact' isCompact_basis hU).isConstructible <| basis.isOpen hU
 
 lemma _root_.TopologicalSpace.IsTopologicalBasis.isConstructible
-    (basis : IsTopologicalBasis (range b)) (compact_inter : ∀ i j, IsCompact (b i ∩ b j)) (i : ι) :
+    (basis : IsTopologicalBasis (range b)) (isCompact_basis : ∀ i, IsCompact (b i)) (i : ι) :
     IsConstructible (b i) :=
-  (basis.isRetrocompact compact_inter _).isConstructible <| basis.isOpen <| mem_range_self _
+  (basis.isRetrocompact isCompact_basis _).isConstructible <| basis.isOpen <| mem_range_self _
 
 @[elab_as_elim]
 lemma IsConstructible.induction_of_isTopologicalBasis {ι : Type*} [Nonempty ι] (b : ι → Set X)
-    (basis : IsTopologicalBasis (range b)) (compact_inter : ∀ i j, IsCompact (b i ∩ b j))
+    (basis : IsTopologicalBasis (range b)) (isCompact_basis : ∀ i, IsCompact (b i))
     (sdiff : ∀ i s (hs : Set.Finite s), P (b i \ ⋃ j ∈ s, b j)
-      ((basis.isConstructible compact_inter _).sdiff <| .biUnion hs fun _ _ ↦
-        basis.isConstructible compact_inter _))
+      ((basis.isConstructible isCompact_basis _).sdiff <| .biUnion hs fun _ _ ↦
+        basis.isConstructible isCompact_basis _))
     (union : ∀ s hs t ht, P s hs → P t ht → P (s ∪ t) (hs.union ht))
     (s : Set X) (hs : IsConstructible s) : P s hs := by
   induction s, hs using BooleanSubalgebra.closure_sdiff_sup_induction with
@@ -354,8 +359,7 @@ lemma IsConstructible.induction_of_isTopologicalBasis {ι : Type*} [Nonempty ι]
   | bot_mem => exact ⟨isOpen_empty, .empty⟩
   | top_mem => exact ⟨isOpen_univ, .univ⟩
   | sdiff U hU V hV =>
-    have := isCompact_open_iff_eq_finite_iUnion_of_isTopologicalBasis _ basis
-        fun i ↦ by simpa using compact_inter i i
+    have := isCompact_open_iff_eq_finite_iUnion_of_isTopologicalBasis _ basis isCompact_basis
     obtain ⟨s, hs, rfl⟩ := (this _).1 ⟨hU.2.isCompact, hU.1⟩
     obtain ⟨t, ht, rfl⟩ := (this _).1 ⟨hV.2.isCompact, hV.1⟩
     simp_rw [iUnion_diff]
@@ -364,11 +368,11 @@ lemma IsConstructible.induction_of_isTopologicalBasis {ι : Type*} [Nonempty ι]
     | @insert i s hi hs ih =>
       simp_rw [biUnion_insert]
       exact union _ _ _
-        (.biUnion hs fun i _ ↦ (basis.isConstructible compact_inter _).sdiff <|
-          .biUnion ht fun j _ ↦ basis.isConstructible compact_inter _)
+        (.biUnion hs fun i _ ↦ (basis.isConstructible isCompact_basis _).sdiff <|
+          .biUnion ht fun j _ ↦ basis.isConstructible isCompact_basis _)
         (sdiff _ _ ht)
         (ih ⟨isOpen_biUnion fun  _ _ ↦ basis.isOpen ⟨_, rfl⟩, .biUnion hs
-          fun i _ ↦ basis.isRetrocompact compact_inter _⟩)
+          fun i _ ↦ basis.isRetrocompact isCompact_basis _⟩)
   | sup s _ t _ hs' ht' => exact union _ _ _ _ hs' ht'
 
 end CompactSpace

--- a/Mathlib/Topology/QuasiSeparated.lean
+++ b/Mathlib/Topology/QuasiSeparated.lean
@@ -111,14 +111,21 @@ instance (priority := 100) NoetherianSpace.to_quasiSeparatedSpace [NoetherianSpa
     QuasiSeparatedSpace α :=
   ⟨fun _ _ _ _ _ _ => NoetherianSpace.isCompact _⟩
 
-theorem IsQuasiSeparated.of_quasiSeparatedSpace (s : Set α) [QuasiSeparatedSpace α] :
-    IsQuasiSeparated s :=
+section QuasiSeparatedSpace
+variable [QuasiSeparatedSpace α] {U V : Set α}
+
+lemma IsQuasiSeparated.of_quasiSeparatedSpace (s : Set α) : IsQuasiSeparated s :=
   isQuasiSeparated_univ.of_subset (Set.subset_univ _)
 
-theorem QuasiSeparatedSpace.of_isOpenEmbedding (h : IsOpenEmbedding f) [QuasiSeparatedSpace β] :
-    QuasiSeparatedSpace α :=
-  isQuasiSeparated_univ_iff.mp
-    (h.isQuasiSeparated_iff.mpr <| IsQuasiSeparated.of_quasiSeparatedSpace _)
+lemma QuasiSeparatedSpace.of_isOpenEmbedding {f : β → α} (h : IsOpenEmbedding f) :
+    QuasiSeparatedSpace β :=
+  isQuasiSeparated_univ_iff.mp (h.isQuasiSeparated_iff.mpr <| .of_quasiSeparatedSpace _)
 
 @[deprecated (since := "2024-10-18")]
 alias QuasiSeparatedSpace.of_openEmbedding := QuasiSeparatedSpace.of_isOpenEmbedding
+
+lemma IsCompact.inter_of_isOpen (hUcomp : IsCompact U) (hVcomp : IsCompact V) (hUopen : IsOpen U)
+    (hVopen : IsOpen V) : IsCompact (U ∩ V) :=
+  QuasiSeparatedSpace.inter_isCompact _ _ hUopen hUcomp hVopen hVcomp
+
+end QuasiSeparatedSpace

--- a/Mathlib/Topology/QuasiSeparated.lean
+++ b/Mathlib/Topology/QuasiSeparated.lean
@@ -25,8 +25,7 @@ of compact open subsets are still compact.
   a quasi-separated space, then so is `α`.
 -/
 
-
-open TopologicalSpace Topology
+open Set TopologicalSpace Topology
 
 variable {α β : Type*} [TopologicalSpace α] [TopologicalSpace β] {f : α → β}
 
@@ -110,6 +109,17 @@ instance (priority := 100) T2Space.to_quasiSeparatedSpace [T2Space α] : QuasiSe
 instance (priority := 100) NoetherianSpace.to_quasiSeparatedSpace [NoetherianSpace α] :
     QuasiSeparatedSpace α :=
   ⟨fun _ _ _ _ _ _ => NoetherianSpace.isCompact _⟩
+
+lemma QuasiSeparatedSpace.of_isTopologicalBasis {ι : Type*} {b : ι → Set α}
+    (basis : IsTopologicalBasis (range b)) (isCompact_inter : ∀ i j, IsCompact (b i ∩ b j)) :
+    QuasiSeparatedSpace α where
+  inter_isCompact U V hUopen hUcomp hVopen hVcomp := by
+    have aux := isCompact_open_iff_eq_finite_iUnion_of_isTopologicalBasis b basis fun i ↦ by
+      simpa using isCompact_inter i i
+    obtain ⟨s, hs, rfl⟩ := (aux _).1 ⟨hUcomp, hUopen⟩
+    obtain ⟨t, ht, rfl⟩ := (aux _).1 ⟨hVcomp, hVopen⟩
+    rw [iUnion₂_inter_iUnion₂]
+    exact hs.isCompact_biUnion fun i hi ↦ ht.isCompact_biUnion fun j hj ↦ isCompact_inter ..
 
 section QuasiSeparatedSpace
 variable [QuasiSeparatedSpace α] {U V : Set α}


### PR DESCRIPTION
A few lemmas took assumptions of the form`IsTopologicalBasis (range b)` +  `∀ i j, IsCompact (b i ∩ b j)`. But this is equivalent to the more natural set of assumptions `IsTopologicalBasis (range b)` + `∀ i, IsCompact (b i)` + `QuasiSeparatedSpace X`.

Also link to [Stacks 0069](https://stacks.math.columbia.edu/tag/0069).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
