### PR TITLE
[Merged by Bors] - perf(Tactic/FieldSimp): exclude simp lemmas that don't apply for fields.

### DIFF
--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -86,6 +86,26 @@ partial def discharge (prop : Expr) : SimpM (Option Expr) :=
 @[inherit_doc discharge]
 elab "field_simp_discharge" : tactic => wrapSimpDischarger Mathlib.Tactic.FieldSimp.discharge
 
+/-- The list of lemma's that aren't used in `field_simp`.
+
+`one_div`, `mul_eq_zero` and `one_divp` are excluded because we don't want those rewrites.
+
+The remaining constants are excluded for efficiency. These are lemmas consisting of just
+`*`, `/` and `=` that are applicable in a typeclass that can't be a field. -/
+def fieldSimpExcluded : List Name := [
+  ``one_div, ``mul_eq_zero, ``one_divp,
+
+  ``div_self', ``div_div_cancel, ``div_div_cancel_left,
+  ``div_mul_cancel, ``div_mul_cancel_left, ``div_mul_cancel_right,
+  ``mul_div_cancel, ``mul_div_cancel_left, ``mul_div_cancel_right,
+  ``div_div_div_cancel_left, ``div_div_div_cancel_right,
+  ``div_mul_div_cancel, ``div_mul_div_cancel', ``div_mul_mul_cancel,
+  ``mul_div_div_cancel, ``mul_mul_div_cancel,
+
+  ``div_eq_self,
+  ``mul_left_eq_self, ``mul_right_eq_self, ``self_eq_mul_left, ``self_eq_mul_right,
+  ``div_left_inj, ``div_right_inj, ``mul_left_inj, ``mul_right_inj]
+
 /--
 The goal of `field_simp` is to reduce an expression in a field to an expression of the form `n / d`
 where neither `n` nor `d` contains any division symbol, just using the simplifier (with a carefully
@@ -169,9 +189,7 @@ elab_rules : tactic
     simpOnlyBuiltins.foldlM (·.addConst ·) ({} : SimpTheorems)
   else do
     let thms0 ← getSimpTheorems
-    let thms0 ← thms0.erase (.decl ``one_div)
-    let thms0 ← thms0.erase (.decl `mul_eq_zero)
-    thms0.erase (.decl ``one_divp)
+    fieldSimpExcluded.foldlM (init := thms0) fun thms0 name => thms0.erase (.decl name)
 
   let some ext ← getSimpExtension? `field_simps | throwError "field_simps not found"
   let thms ← ext.getTheorems


### PR DESCRIPTION
This PR excludes simp lemmas like `div_self'` from being used in the `field_simp` tactic. These lemmas have discrimination tree keys that commonly find a match when running `field_simp`, and if they do match then unification needs to fail, because the field is in fact not a `Group`/`CommGroup`/`LeftCancelMonoid`/`RightCancelMonoid`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
