### PR TITLE
[Merged by Bors] - perf(CategoryTheory/Shift/Induced): remove `@[simp]` from `shiftFunctor_of_induced`

### DIFF
--- a/Mathlib/CategoryTheory/Shift/Induced.lean
+++ b/Mathlib/CategoryTheory/Shift/Induced.lean
@@ -154,7 +154,6 @@ noncomputable def induced : HasShift D A :=
 
 end HasShift
 
-@[simp]
 lemma shiftFunctor_of_induced (a : A) :
     letI := HasShift.induced F A s i
     shiftFunctor D a = s a := by


### PR DESCRIPTION
This PR removes the `simp` tag from `shiftFunctor_of_induced`. This lemma isn't used, and it has a very unfavourable discrimination tree key, meaning that it is tried every time the constant `shiftFunctor` appears.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
