### PR TITLE
[Merged by Bors] - feat(Factorial): k! divides the product of any k successive integers

### DIFF
--- a/Mathlib/Data/Nat/Factorial/BigOperators.lean
+++ b/Mathlib/Data/Nat/Factorial/BigOperators.lean
@@ -55,11 +55,11 @@ lemma factorial_coe_dvd_prod (k : ℕ) (n : ℤ) : (k ! : ℤ) ∣ ∏ i ∈ ran
   by_cases hn : n < 0
   · by_cases hnk : 0 < n + k
     · have : ∏ i ∈ range k, (n + ↑i) = 0 := prod_eq_zero_iff.mpr <| by
-        have ⟨negn, _⟩ : ∃ (negn : ℕ), -n = ↑negn := Int.eq_ofNat_of_zero_le <| by linarith
-        exact ⟨negn, by rw [mem_range]; omega⟩
+        use n.natAbs
+        simp [abs_of_nonpos, hn.le, ← Int.ofNat_lt, hnk, neg_lt_iff_pos_add, add_comm]
       rw [this]
       exact (k ! : ℤ).dvd_zero
-    · have prod_eq : ∏ x ∈ range k, |n + ↑x| =  ∏ x ∈ range k, -(n + ↑x) := by
+    · have prod_eq : ∏ x ∈ range k, |n + ↑x| = ∏ x ∈ range k, -(n + ↑x) := by
         refine prod_congr rfl fun _ hx ↦ ?_
         rw [mem_range] at hx
         rw [abs_of_neg]

--- a/Mathlib/Data/Nat/Factorial/BigOperators.lean
+++ b/Mathlib/Data/Nat/Factorial/BigOperators.lean
@@ -42,15 +42,14 @@ theorem descFactorial_eq_prod_range (n : ℕ) : ∀ k, n.descFactorial k = ∏ i
   | 0 => rfl
   | k + 1 => by rw [descFactorial, prod_range_succ, mul_comm, descFactorial_eq_prod_range n k]
 
-/-- `k!` divides the product of any `k` successive integers. -/
+/-- `k!` divides the product of any `k` consecutive integers. -/
 lemma factorial_coe_dvd_prod (k : ℕ) (n : ℤ) : (k ! : ℤ) ∣ ∏ i ∈ range k, (n + i) := by
   rw [Int.dvd_iff_emod_eq_zero, Finset.prod_int_mod]
   simp_rw [← Int.emod_add_emod n]
-  rw [← Finset.prod_int_mod, ← Int.dvd_iff_emod_eq_zero]
   have hn : 0 ≤ n % k ! := Int.emod_nonneg n <| Int.natCast_ne_zero.mpr k.factorial_ne_zero
   obtain ⟨x, hx⟩ := Int.eq_ofNat_of_zero_le hn
   have hdivk := x.factorial_dvd_ascFactorial k
   zify [x.ascFactorial_eq_prod_range k] at hdivk
-  rwa [hx]
+  rwa [← Finset.prod_int_mod, ← Int.dvd_iff_emod_eq_zero, hx]
 
 end Nat

--- a/Mathlib/Data/Nat/Factorial/BigOperators.lean
+++ b/Mathlib/Data/Nat/Factorial/BigOperators.lean
@@ -52,25 +52,13 @@ private lemma factorial_coe_dvd_prod_of_nonneg (k : ℕ) (n : ℤ) (hn : 0 ≤ n
 
 /-- `k!` divides the product of any `k` successive integers. -/
 lemma factorial_coe_dvd_prod (k : ℕ) (n : ℤ) : (k ! : ℤ) ∣ ∏ i ∈ range k, (n + i) := by
-  by_cases hn : n < 0
-  · by_cases hnk : 0 < n + k
-    · have : ∏ i ∈ range k, (n + ↑i) = 0 := prod_eq_zero_iff.mpr <| by
-        use n.natAbs
-        simp [abs_of_nonpos, hn.le, ← Int.ofNat_lt, hnk, neg_lt_iff_pos_add, add_comm]
-      rw [this]
-      exact (k ! : ℤ).dvd_zero
-    · have prod_eq : ∏ x ∈ range k, |n + ↑x| = ∏ x ∈ range k, -(n + ↑x) := by
-        refine prod_congr rfl fun _ hx ↦ ?_
-        rw [mem_range] at hx
-        rw [abs_of_neg]
-        linarith
-      rw [← dvd_abs, abs_prod, prod_eq, ← prod_range_reflect]
-      simp_rw [neg_add_rev, add_comm]
-      rw [show ∏ j ∈ range k, (-n + -↑(k - 1 - j)) = ∏ j ∈ range k, (-n + -↑(k - 1) + j) from ?_]
-      · exact factorial_coe_dvd_prod_of_nonneg k (-n + -↑(k - 1)) (by omega)
-      · refine prod_congr rfl fun _ ↦ ?_
-        rw [mem_range]
-        omega
-  · exact factorial_coe_dvd_prod_of_nonneg k n <| not_lt.mp hn
+  rw [Int.dvd_iff_emod_eq_zero, Finset.prod_int_mod]
+  simp_rw [← Int.emod_add_emod n]
+  rw [← Finset.prod_int_mod, ← Int.dvd_iff_emod_eq_zero]
+  have hn : 0 ≤ n % k ! := Int.emod_nonneg n <| Int.natCast_ne_zero.mpr k.factorial_ne_zero
+  obtain ⟨x, hx⟩ := Int.eq_ofNat_of_zero_le hn
+  have hdivk := x.factorial_dvd_ascFactorial k
+  zify [x.ascFactorial_eq_prod_range k] at hdivk
+  rwa [hx]
 
 end Nat

--- a/Mathlib/Data/Nat/Factorial/BigOperators.lean
+++ b/Mathlib/Data/Nat/Factorial/BigOperators.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller, Pim Otte
 -/
 import Mathlib.Data.Nat.Factorial.Basic
-import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Algebra.Order.BigOperators.Ring.Finset
+import Mathlib.Tactic.Zify
 
 /-!
 # Factorial with big operators
@@ -41,14 +41,6 @@ theorem ascFactorial_eq_prod_range (n : ℕ) : ∀ k, n.ascFactorial k = ∏ i �
 theorem descFactorial_eq_prod_range (n : ℕ) : ∀ k, n.descFactorial k = ∏ i ∈ range k, (n - i)
   | 0 => rfl
   | k + 1 => by rw [descFactorial, prod_range_succ, mul_comm, descFactorial_eq_prod_range n k]
-
-/-- `k!` divides the product of any `k` successive non-negative integers. -/
-private lemma factorial_coe_dvd_prod_of_nonneg (k : ℕ) (n : ℤ) (hn : 0 ≤ n) :
-    (k ! : ℤ) ∣ ∏ i ∈ range k, (n + i) := by
-  obtain ⟨x, hx⟩ := Int.eq_ofNat_of_zero_le hn
-  have hdivk := x.factorial_dvd_ascFactorial k
-  zify [x.ascFactorial_eq_prod_range k] at hdivk
-  rwa [hx]
 
 /-- `k!` divides the product of any `k` successive integers. -/
 lemma factorial_coe_dvd_prod (k : ℕ) (n : ℤ) : (k ! : ℤ) ∣ ∏ i ∈ range k, (n + i) := by

--- a/Mathlib/Data/Nat/Factorial/BigOperators.lean
+++ b/Mathlib/Data/Nat/Factorial/BigOperators.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller, Pim Otte
 -/
 import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Algebra.Order.BigOperators.Ring.Finset
 
 /-!
@@ -40,5 +41,36 @@ theorem ascFactorial_eq_prod_range (n : ℕ) : ∀ k, n.ascFactorial k = ∏ i �
 theorem descFactorial_eq_prod_range (n : ℕ) : ∀ k, n.descFactorial k = ∏ i ∈ range k, (n - i)
   | 0 => rfl
   | k + 1 => by rw [descFactorial, prod_range_succ, mul_comm, descFactorial_eq_prod_range n k]
+
+/-- `k!` divides the product of any `k` successive non-negative integers. -/
+private lemma factorial_coe_dvd_prod_of_nonneg (k : ℕ) (n : ℤ) (hn : 0 ≤ n) :
+    (k ! : ℤ) ∣ ∏ i ∈ range k, (n + i) := by
+  obtain ⟨x, hx⟩ := Int.eq_ofNat_of_zero_le hn
+  have hdivk := x.factorial_dvd_ascFactorial k
+  zify [x.ascFactorial_eq_prod_range k] at hdivk
+  rwa [hx]
+
+/-- `k!` divides the product of any `k` successive integers. -/
+lemma factorial_coe_dvd_prod (k : ℕ) (n : ℤ) : (k ! : ℤ) ∣ ∏ i ∈ range k, (n + i) := by
+  by_cases hn : n < 0
+  · by_cases hnk : 0 < n + k
+    · have : ∏ i ∈ range k, (n + ↑i) = 0 := prod_eq_zero_iff.mpr <| by
+        have ⟨negn, _⟩ : ∃ (negn : ℕ), -n = ↑negn := Int.eq_ofNat_of_zero_le <| by linarith
+        exact ⟨negn, by rw [mem_range]; omega⟩
+      rw [this]
+      exact (k ! : ℤ).dvd_zero
+    · have prod_eq : ∏ x ∈ range k, |n + ↑x| =  ∏ x ∈ range k, -(n + ↑x) := by
+        refine prod_congr rfl fun _ hx ↦ ?_
+        rw [mem_range] at hx
+        rw [abs_of_neg]
+        linarith
+      rw [← dvd_abs, abs_prod, prod_eq, ← prod_range_reflect]
+      simp_rw [neg_add_rev, add_comm]
+      rw [show ∏ j ∈ range k, (-n + -↑(k - 1 - j)) = ∏ j ∈ range k, (-n + -↑(k - 1) + j) from ?_]
+      · exact factorial_coe_dvd_prod_of_nonneg k (-n + -↑(k - 1)) (by omega)
+      · refine prod_congr rfl fun _ ↦ ?_
+        rw [mem_range]
+        omega
+  · exact factorial_coe_dvd_prod_of_nonneg k n <| not_lt.mp hn
 
 end Nat


### PR DESCRIPTION
Co-authored-by: Aaron Hill <aa1ronham@gmail.com>
Co-authored-by: Matej Penciak <matej.penciak@gmail.com>
Co-authored-by: Austin Letson <waustinletson@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
