### PR TITLE
[Merged by Bors] - fix(Linter/OldObtain): typos

### DIFF
--- a/Mathlib/Tactic/Linter/OldObtain.lean
+++ b/Mathlib/Tactic/Linter/OldObtain.lean
@@ -10,9 +10,9 @@ import Lean.Elab.Command
 import Mathlib.Tactic.Linter.Header
 
 /-!
-# The `oldObtain` linter, against stream-of-conciousness `obtain`
+# The `oldObtain` linter, against stream-of-consciousness `obtain`
 
-The `oldObtain` linter flags any occurrences of "stream-of-conciousness" `obtain`,
+The `oldObtain` linter flags any occurrences of "stream-of-consciousness" `obtain`,
 i.e. uses of the `obtain` tactic which do not immediately provide a proof.
 
 ## Example
@@ -64,7 +64,7 @@ def isObtainWithoutProof : Syntax → Bool
 @[deprecated isObtainWithoutProof (since := "2024-12-07")]
 def is_obtain_without_proof := @isObtainWithoutProof
 
-/-- The `oldObtain` linter emits a warning upon uses of the "stream-of-conciousness" variants
+/-- The `oldObtain` linter emits a warning upon uses of the "stream-of-consciousness" variants
 of the `obtain` tactic, i.e. with the proof postponed. -/
 register_option linter.oldObtain : Bool := {
   defValue := false
@@ -78,7 +78,7 @@ def oldObtainLinter : Linter where run := withSetOptionIn fun stx => do
     if (← MonadState.get).messages.hasErrors then
       return
     if let some head := stx.find? isObtainWithoutProof then
-      Linter.logLint linter.oldObtain head m!"Please remove stream-of-conciousness `obtain` syntax"
+      Linter.logLint linter.oldObtain head m!"Please remove stream-of-consciousness `obtain` syntax"
 
 initialize addLinter oldObtainLinter
 

--- a/MathlibTest/oldObtain.lean
+++ b/MathlibTest/oldObtain.lean
@@ -20,7 +20,7 @@ theorem foo : True := by
 -- These cases are linted against.
 
 /--
-warning: Please remove stream-of-conciousness `obtain` syntax
+warning: Please remove stream-of-consciousness `obtain` syntax
 note: this linter can be disabled with `set_option linter.oldObtain false`
 -/
 #guard_msgs in
@@ -30,7 +30,7 @@ theorem foo' : True := by
   trivial
 
 /--
-warning: Please remove stream-of-conciousness `obtain` syntax
+warning: Please remove stream-of-consciousness `obtain` syntax
 note: this linter can be disabled with `set_option linter.oldObtain false`
 -/
 #guard_msgs in


### PR DESCRIPTION
typos I noticed while reading.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
