### PR TITLE
[Merged by Bors] - chore(InfiniteSum/NatInt): put `Multipliable.tendsto_prod_tprod_nat` in the right namespace

### DIFF
--- a/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
@@ -51,6 +51,12 @@ theorem Multipliable.tendsto_prod_tprod_nat {f : ℕ → M} (h : Multipliable f)
     Tendsto (fun n ↦ ∏ i ∈ range n, f i) atTop (𝓝 (∏' i, f i)) :=
   HasProd.tendsto_prod_nat h.hasProd
 
+@[deprecated "use Multipliable.tendsto_prod_tprod_nat" (since := "2025-02-02")]
+alias HasProd.Multipliable.tendsto_prod_tprod_nat := Multipliable.tendsto_prod_tprod_nat
+
+@[deprecated "use Summable.tendsto_sum_tsum_nat" (since := "2025-02-02")]
+alias HasSum.Multipliable.tendsto_sum_tsum_nat := Summable.tendsto_sum_tsum_nat
+
 namespace HasProd
 
 section ContinuousMul

--- a/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
@@ -49,7 +49,7 @@ to `∏' i, f i`. -/
 to `∑' i, f i`."]
 theorem Multipliable.tendsto_prod_tprod_nat {f : ℕ → M} (h : Multipliable f) :
     Tendsto (fun n ↦ ∏ i ∈ range n, f i) atTop (𝓝 (∏' i, f i)) :=
-  HasProd.tendsto_prod_nat h.hasProd
+  h.hasProd.tendsto_prod_nat
 
 @[deprecated "use Multipliable.tendsto_prod_tprod_nat" (since := "2025-02-02")]
 alias HasProd.Multipliable.tendsto_prod_tprod_nat := Multipliable.tendsto_prod_tprod_nat

--- a/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
@@ -35,13 +35,11 @@ section Nat
 
 section Monoid
 
-namespace HasProd
-
 /-- If `f : ℕ → M` has product `m`, then the partial products `∏ i ∈ range n, f i` converge
 to `m`. -/
 @[to_additive "If `f : ℕ → M` has sum `m`, then the partial sums `∑ i ∈ range n, f i` converge
 to `m`."]
-theorem tendsto_prod_nat {f : ℕ → M} (h : HasProd f m) :
+theorem HasProd.tendsto_prod_nat {f : ℕ → M} (h : HasProd f m) :
     Tendsto (fun n ↦ ∏ i ∈ range n, f i) atTop (𝓝 m) :=
   h.comp tendsto_finset_range
 
@@ -51,7 +49,9 @@ to `∏' i, f i`. -/
 to `∑' i, f i`."]
 theorem Multipliable.tendsto_prod_tprod_nat {f : ℕ → M} (h : Multipliable f) :
     Tendsto (fun n ↦ ∏ i ∈ range n, f i) atTop (𝓝 (∏' i, f i)) :=
-  tendsto_prod_nat h.hasProd
+  HasProd.tendsto_prod_nat h.hasProd
+
+namespace HasProd
 
 section ContinuousMul
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
@@ -51,7 +51,7 @@ theorem Multipliable.tendsto_prod_tprod_nat {f : ℕ → M} (h : Multipliable f)
     Tendsto (fun n ↦ ∏ i ∈ range n, f i) atTop (𝓝 (∏' i, f i)) :=
   h.hasProd.tendsto_prod_nat
 
-@[deprecated "use Multipliable.tendsto_prod_tprod_nat" (since := "2025-02-02")]
+@[deprecated (since := "2025-02-02")]
 alias HasProd.Multipliable.tendsto_prod_tprod_nat := Multipliable.tendsto_prod_tprod_nat
 
 @[deprecated "use Summable.tendsto_sum_tsum_nat" (since := "2025-02-02")]

--- a/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/NatInt.lean
@@ -54,7 +54,7 @@ theorem Multipliable.tendsto_prod_tprod_nat {f : ℕ → M} (h : Multipliable f)
 @[deprecated (since := "2025-02-02")]
 alias HasProd.Multipliable.tendsto_prod_tprod_nat := Multipliable.tendsto_prod_tprod_nat
 
-@[deprecated "use Summable.tendsto_sum_tsum_nat" (since := "2025-02-02")]
+@[deprecated (since := "2025-02-02")]
 alias HasSum.Multipliable.tendsto_sum_tsum_nat := Summable.tendsto_sum_tsum_nat
 
 namespace HasProd


### PR DESCRIPTION
Before, it was:
```
HasProd.Multipliable.tendsto_prod_tprod_nat
```
which made the additive version
```
HasSum.Multipliable.tendsto_sum_tsum_nat
```

By lifting into the root namespace, Multipliable properly additivizes


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
