### PR TITLE
[Merged by Bors] - chore: remove references to `_root_.Embedding`

### DIFF
--- a/Mathlib/Topology/Algebra/StarSubalgebra.lean
+++ b/Mathlib/Topology/Algebra/StarSubalgebra.lean
@@ -33,7 +33,7 @@ variable [TopologicalSpace A] [Semiring A] [Algebra R A] [StarRing A] [StarModul
 instance [TopologicalSemiring A] (s : StarSubalgebra R A) : TopologicalSemiring s :=
   s.toSubalgebra.topologicalSemiring
 
-/-- The `StarSubalgebra.inclusion` of a star subalgebra is an `Embedding`. -/
+/-- The `StarSubalgebra.inclusion` of a star subalgebra is an embedding. -/
 lemma isEmbedding_inclusion {S₁ S₂ : StarSubalgebra R A} (h : S₁ ≤ S₂) :
     IsEmbedding (inclusion h) where
   eq_induced := Eq.symm induced_compose

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -20,13 +20,6 @@ Furthermore, we say that `f` has compact support if the topological support of `
 
 * `mulTSupport` & `tsupport`
 * `HasCompactMulSupport` & `HasCompactSupport`
-
-## Implementation Notes
-
-* We write all lemmas for multiplicative functions, and use `@[to_additive]` to get the more common
-  additive versions.
-* We do not put the definitions in the `Function` namespace, following many other topological
-  definitions that are in the root namespace (compare `Embedding` vs `Function.Embedding`).
 -/
 
 

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -20,6 +20,12 @@ Furthermore, we say that `f` has compact support if the topological support of `
 
 * `mulTSupport` & `tsupport`
 * `HasCompactMulSupport` & `HasCompactSupport`
+
+## TODO
+
+The definitions have been put in the root namespace following many other topological definitions,
+like `Embedding`. Since then, `Embedding` was renamed to `Topology.IsEmbedding`, so it might be
+worth reconsidering namespacing the definitions here.
 -/
 
 

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -906,8 +906,8 @@ theorem Topology.IsInducing.isCompact_iff {f : X → Y} (hf : IsInducing f) :
 
 @[deprecated (since := "2024-10-28")] alias Inducing.isCompact_iff := IsInducing.isCompact_iff
 
-/-- If `f : X → Y` is an `Embedding`, the image `f '' s` of a set `s` is compact
-  if and only if `s` is compact. -/
+/-- If `f : X → Y` is an embedding, the image `f '' s` of a set `s` is compact
+if and only if `s` is compact. -/
 theorem Topology.IsEmbedding.isCompact_iff {f : X → Y} (hf : IsEmbedding f) :
     IsCompact s ↔ IsCompact (f '' s) := hf.isInducing.isCompact_iff
 

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -610,8 +610,8 @@ theorem Topology.IsInducing.isLindelof_iff {f : X → Y} (hf : IsInducing f) :
 
 @[deprecated (since := "2024-10-28")] alias Inducing.isLindelof_iff := IsInducing.isLindelof_iff
 
-/-- If `f : X → Y` is an `Embedding`, the image `f '' s` of a set `s` is Lindelöf
-  if and only if `s` is Lindelöf. -/
+/-- If `f : X → Y` is an embedding, the image `f '' s` of a set `s` is Lindelöf
+if and only if `s` is Lindelöf. -/
 theorem Topology.IsEmbedding.isLindelof_iff {f : X → Y} (hf : IsEmbedding f) :
     IsLindelof s ↔ IsLindelof (f '' s) := hf.isInducing.isLindelof_iff
 

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -121,8 +121,8 @@ lemma Topology.IsInducing.isSigmaCompact_iff {f : X → Y} {s : Set X}
 @[deprecated (since := "2024-10-28")]
 alias Inducing.isSigmaCompact_iff := IsInducing.isSigmaCompact_iff
 
-/-- If `f : X → Y` is an `Embedding`, the image `f '' s` of a set `s` is σ-compact
-  if and only `s` is σ-compact. -/
+/-- If `f : X → Y` is an embedding, the image `f '' s` of a set `s` is σ-compact
+if and only `s` is σ-compact. -/
 lemma Topology.IsEmbedding.isSigmaCompact_iff {f : X → Y} {s : Set X}
     (hf : IsEmbedding f) : IsSigmaCompact s ↔ IsSigmaCompact (f '' s) :=
   hf.isInducing.isSigmaCompact_iff

--- a/Mathlib/Topology/Defs/Induced.lean
+++ b/Mathlib/Topology/Defs/Induced.lean
@@ -25,7 +25,7 @@ as well as topology inducing maps, topological embeddings, and quotient maps.
 * `IsInducing`: a map `f : X → Y` is called *inducing*,
   if the topology on the domain is equal to the induced topology.
 
-* `Embedding`: a map `f : X → Y` is an *embedding*,
+* `IsEmbedding`: a map `f : X → Y` is an *embedding*,
   if it is a topology inducing map and it is injective.
 
 * `IsOpenEmbedding`: a map `f : X → Y` is an *open embedding*,


### PR DESCRIPTION
This was renamed to `Topology.IsEmbedding` in #15993 and #18133 and those docstrings should have been fixed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
