### PR TITLE
[Merged by Bors] - feat: the category of ind-objects satisfies the AB5 axiom

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1654,7 +1654,9 @@ import Mathlib.CategoryTheory.Abelian.Ext
 import Mathlib.CategoryTheory.Abelian.FunctorCategory
 import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Basic
 import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.FunctorCategory
+import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Indization
 import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Sheaf
+import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Types
 import Mathlib.CategoryTheory.Abelian.GrothendieckCategory
 import Mathlib.CategoryTheory.Abelian.Images
 import Mathlib.CategoryTheory.Abelian.Injective

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Indization.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Indization.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2025 Markus Himmel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Himmel
+-/
+import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.FunctorCategory
+import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Types
+import Mathlib.CategoryTheory.Limits.Indization.Category
+
+/-!
+# AB axioms in the category of ind-objects
+
+We show that `Ind C` satisfies Grothendieck's axiom AB5 if `C` has finite limits.
+-/
+
+universe v u
+
+namespace CategoryTheory.Limits
+
+variable {C : Type u} [Category.{v} C]
+
+instance {J : Type v} [SmallCategory J] [IsFiltered J] [HasFiniteLimits C] :
+    HasExactColimitsOfShape J (Ind C) :=
+  HasExactColimitsOfShape.domain_of_functor J (Ind.inclusion C)
+
+instance [HasFiniteLimits C] : AB5 (Ind C) where
+  ofShape _ _ _ := inferInstance
+
+end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Types.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Types.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2025 Markus Himmel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Himmel
+-/
+import Mathlib.CategoryTheory.Limits.FilteredColimitCommutesFiniteLimit
+import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Basic
+
+/-!
+# The category of types satisfies Grothendieck's AB5 axiom
+
+This is of course just the well-known fact that filtered colimits commute with finite limits in
+the category of types.
+-/
+
+universe v
+
+namespace CategoryTheory.Limits
+
+instance : AB5 (Type v) where
+  ofShape _ _ _ := ⟨inferInstance⟩
+
+end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Indization/Category.lean
+++ b/Mathlib/CategoryTheory/Limits/Indization/Category.lean
@@ -3,12 +3,9 @@ Copyright (c) 2024 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
-import Mathlib.CategoryTheory.Functor.Flat
 import Mathlib.CategoryTheory.Limits.Constructions.Filtered
-import Mathlib.CategoryTheory.Limits.FullSubcategory
+import Mathlib.CategoryTheory.Limits.Indization.Equalizers
 import Mathlib.CategoryTheory.Limits.Indization.LocallySmall
-import Mathlib.CategoryTheory.Limits.Indization.ParallelPair
-import Mathlib.CategoryTheory.Limits.Indization.FilteredColimits
 import Mathlib.CategoryTheory.Limits.Indization.Products
 
 /-!
@@ -17,24 +14,32 @@ import Mathlib.CategoryTheory.Limits.Indization.Products
 We define the `v`-category of Ind-objects of a category `C`, called `Ind C`, as well as the functors
 `Ind.yoneda : C ⥤ Ind C` and `Ind.inclusion C : Ind C ⥤ Cᵒᵖ ⥤ Type v`.
 
-For a small filtered category `I`, we also define `Ind.lim I : (I ⥤ C) ⥤ Ind C`.
+For a small filtered category `I`, we also define `Ind.lim I : (I ⥤ C) ⥤ Ind C` and show that
+it preserves finite limits and finite colimits.
 
 This file will mainly collect results about ind-objects (stated in terms of `IsIndObject`) and
 reinterpret them in terms of `Ind C`.
 
-Adopting the theorem numbering of [Kashiwara2006], we show that
-* `Ind C` has filtered colimits (6.1.8),
-* `Ind C ⥤ Cᵒᵖ ⥤ Type v` creates filtered colimits (6.1.8),
-* `C ⥤ Ind C` preserves finite colimits (6.1.6),
+Adopting the theorem numbering of [Kashiwara2006], we show the following properties:
+
+Limits:
+* If `C` has products indexed by `α`, then `Ind C` has products indexed by `α`, and the functor
+  `Ind C ⥤ Cᵒᵖ ⥤ Type v` creates such products (6.1.17),
+* if `C` has equalizers, then `Ind C` has equalizers, and the functor `Ind C ⥤ Cᵒᵖ ⥤ Type v`
+  creates them (6.1.17)
+* if `C` has small limits (resp. finite limits), then `Ind C` has small limits (resp. finite limits)
+  and the functor `Ind C ⥤ Cᵒᵖ ⥤ Type v` creates them (6.1.17),
+* the functor `C ⥤ Ind C` preserves small limits (6.1.17).
+
+Colimits:
+* `Ind C` has filtered colimits (6.1.8), and the functor `Ind C ⥤ Cᵒᵖ ⥤ Type v` preserves filtered
+  colimits,
 * if `C` has coproducts indexed by a finite type `α`, then `Ind C` has coproducts indexed by `α`
   (6.1.18(ii)),
 * if `C` has finite coproducts, then `Ind C` has small coproducts (6.1.18(ii)),
-* if `C` has products indexed by `α`, then `Ind C` has products indexed by `α`, and the functor
-  `Ind C ⥤ Cᵒᵖ ⥤ Type v` creates such products (6.1.17)
-* the functor `C ⥤ Ind C` preserves small limits,
-* if `C` has coequalizers, then `Ind C` has coequalizers (6.1.18(i)).
-
-More limit-colimit properties will follow.
+* if `C` has coequalizers, then `Ind C` has coequalizers (6.1.18(i)),
+* if `C` has finite colimits, then `Ind C` has small colimits (6.1.18(iii)).
+* `C ⥤ Ind C` preserves finite colimits (6.1.6),
 
 Note that:
 * the functor `Ind C ⥤ Cᵒᵖ ⥤ Type v` does not preserve any kind of colimit in general except for
@@ -126,6 +131,34 @@ noncomputable instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
 instance {J : Type v} [HasLimitsOfShape (Discrete J) C] :
     HasLimitsOfShape (Discrete J) (Ind C) :=
   hasLimitsOfShape_of_hasLimitsOfShape_createsLimitsOfShape (Ind.inclusion C)
+
+noncomputable instance [HasLimitsOfShape WalkingParallelPair C] :
+    CreatesLimitsOfShape WalkingParallelPair (Ind.inclusion C) :=
+  letI _ : CreatesLimitsOfShape WalkingParallelPair
+      (fullSubcategoryInclusion (IsIndObject (C := C))) :=
+    createsLimitsOfShapeFullSubcategoryInclusion
+      (closedUnderLimitsOfShape_walkingParallelPair_isIndObject)
+  inferInstanceAs <|
+    CreatesLimitsOfShape WalkingParallelPair
+      ((Ind.equivalence C).functor ⋙ fullSubcategoryInclusion _)
+
+instance [HasLimitsOfShape WalkingParallelPair C] :
+    HasLimitsOfShape WalkingParallelPair (Ind C) :=
+  hasLimitsOfShape_of_hasLimitsOfShape_createsLimitsOfShape (Ind.inclusion C)
+
+noncomputable instance [HasFiniteLimits C] : CreatesFiniteLimits (Ind.inclusion C) :=
+  letI _ : CreatesFiniteProducts (Ind.inclusion C) :=
+    { creates _ _ := createsLimitsOfShapeOfEquiv (Discrete.equivalence Equiv.ulift) _  }
+  createsFiniteLimitsOfCreatesEqualizersAndFiniteProducts (Ind.inclusion C)
+
+instance [HasFiniteLimits C] : HasFiniteLimits (Ind C) :=
+  hasFiniteLimits_of_hasLimitsLimits_of_createsFiniteLimits (Ind.inclusion C)
+
+noncomputable instance [HasLimits C] : CreatesLimitsOfSize.{v, v} (Ind.inclusion C) :=
+  createsLimitsOfSizeOfCreatesEqualizersAndProducts.{v, v} (Ind.inclusion C)
+
+instance [HasLimits C] : HasLimits (Ind C) :=
+  hasLimits_of_hasLimits_createsLimits (Ind.inclusion C)
 
 instance : PreservesLimits (Ind.yoneda (C := C)) :=
   letI _ : PreservesLimitsOfSize.{v, v} (Ind.yoneda ⋙ Ind.inclusion C) :=
@@ -236,6 +269,9 @@ instance [HasColimitsOfShape WalkingParallelPair C] :
     (F.obj WalkingParallelPair.one).2 (Ind.inclusion _ |>.map <| F.map WalkingParallelPairHom.left)
     (Ind.inclusion _ |>.map <| F.map WalkingParallelPairHom.right)
   exact hasColimitOfIso (diagramIsoParallelPair _ ≪≫ P.parallelPairIsoParallelPairCompIndYoneda)
+
+instance [HasFiniteColimits C] : HasColimits (Ind C) :=
+  has_colimits_of_hasCoequalizers_and_coproducts
 
 /-- A way to understand morphisms in `Ind C`: every morphism is induced by a natural transformation
 of diagrams. -/

--- a/Mathlib/CategoryTheory/Limits/Preserves/Creates/Finite.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Creates/Finite.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
 import Mathlib.CategoryTheory.Limits.Creates
+import Mathlib.CategoryTheory.Limits.Shapes.FiniteLimits
+import Mathlib.CategoryTheory.Limits.Preserves.Finite
 import Mathlib.CategoryTheory.FinCategory.AsType
 
 /-!
@@ -69,6 +71,14 @@ instance compCreatesFiniteLimits (F : C ⥤ D) (G : D ⥤ E) [CreatesFiniteLimit
 def createsFiniteLimitsOfNatIso {F G : C ⥤ D} {h : F ≅ G} [CreatesFiniteLimits F] :
     CreatesFiniteLimits G where
   createsFiniteLimits _ _ _ := createsLimitsOfShapeOfNatIso h
+
+theorem hasFiniteLimits_of_hasLimitsLimits_of_createsFiniteLimits (F : C ⥤ D) [HasFiniteLimits D]
+    [CreatesFiniteLimits F] : HasFiniteLimits C where
+  out _ _ _ := hasLimitsOfShape_of_hasLimitsOfShape_createsLimitsOfShape F
+
+instance (priority := 100) preservesFiniteLimits_of_createsFiniteLimits_and_hasFiniteLimits
+    (F : C ⥤ D) [CreatesFiniteLimits F] [HasFiniteLimits D] : PreservesFiniteLimits F where
+  preservesFiniteLimits _ _ _ := inferInstance
 
 end
 
@@ -149,6 +159,14 @@ instance compCreatesFiniteColimits (F : C ⥤ D) (G : D ⥤ E) [CreatesFiniteCol
 def createsFiniteColimitsOfNatIso {F G : C ⥤ D} {h : F ≅ G} [CreatesFiniteColimits F] :
     CreatesFiniteColimits G where
   createsFiniteColimits _ _ _ := createsColimitsOfShapeOfNatIso h
+
+theorem hasFiniteColimits_of_hasColimits_of_createsFiniteColimits (F : C ⥤ D) [HasFiniteColimits D]
+    [CreatesFiniteColimits F] : HasFiniteColimits C where
+  out _ _ _ := hasColimitsOfShape_of_hasColimitsOfShape_createsColimitsOfShape F
+
+instance (priority := 100) preservesFiniteColimits_of_createsFiniteColimits_and_hasFiniteColimits
+    (F : C ⥤ D) [CreatesFiniteColimits F] [HasFiniteColimits D] : PreservesFiniteColimits F where
+  preservesFiniteColimits _ _ _ := inferInstance
 
 end
 


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
