### PR TITLE
[Merged by Bors] - feat(Analysis/RCLike/Basic): PosMulReflectLE

### DIFF
--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -809,15 +809,15 @@ protected lemma inv_pos : 0 < z⁻¹ ↔ 0 < z := by
   rw [← inv_inv z]
   exact RCLike.inv_pos_of_pos h
 
-theorem inv_nonneg_of_nonneg {x : 𝕜} (h : 0 ≤ x) : 0 ≤ x⁻¹ := by
-  by_cases h0 : x = 0
-  · subst x
+theorem inv_nonneg_of_nonneg (h : 0 ≤ z) : 0 ≤ z⁻¹ := by
+  by_cases h0 : z = 0
+  · subst z
     simp only [_root_.inv_zero, le_refl]
   · exact (RCLike.inv_pos.mpr (lt_of_le_of_ne h (Ne.symm h0))).le
 
 @[simp]
-theorem inv_nonneg {x : 𝕜} : 0 ≤ x⁻¹ ↔ 0 ≤ x :=
-  ⟨by simpa only [inv_inv] using inv_nonneg_of_nonneg (x := x⁻¹), inv_nonneg_of_nonneg⟩
+theorem inv_nonneg : 0 ≤ z⁻¹ ↔ 0 ≤ z :=
+  ⟨by simpa only [inv_inv] using inv_nonneg_of_nonneg (x := z⁻¹), inv_nonneg_of_nonneg⟩
 
 /-- With `z ≤ w` iff `w - z` is real and nonnegative, `ℝ` and `ℂ` are star ordered rings.
 (That is, a star ring in which the nonnegative elements are those of the form `star z * z`.)

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -809,16 +809,6 @@ protected lemma inv_pos : 0 < z⁻¹ ↔ 0 < z := by
   rw [← inv_inv z]
   exact RCLike.inv_pos_of_pos h
 
-theorem inv_nonneg_of_nonneg (h : 0 ≤ z) : 0 ≤ z⁻¹ := by
-  by_cases h0 : z = 0
-  · subst z
-    simp only [_root_.inv_zero, le_refl]
-  · exact (RCLike.inv_pos.mpr (lt_of_le_of_ne h (Ne.symm h0))).le
-
-@[simp]
-theorem inv_nonneg : 0 ≤ z⁻¹ ↔ 0 ≤ z :=
-  ⟨(by simpa only [inv_inv] using inv_nonneg_of_nonneg ·), inv_nonneg_of_nonneg⟩
-
 /-- With `z ≤ w` iff `w - z` is real and nonnegative, `ℝ` and `ℂ` are star ordered rings.
 (That is, a star ring in which the nonnegative elements are those of the form `star z * z`.)
 
@@ -888,6 +878,19 @@ theorem ofReal_mul_pos_iff (x : ℝ) (z : K) :
 theorem ofReal_mul_neg_iff (x : ℝ) (z : K) :
     x * z < 0 ↔ (x < 0 ∧ 0 < z) ∨ (0 < x ∧ z < 0) := by
   simpa only [mul_neg, neg_pos, neg_neg_iff_pos] using ofReal_mul_pos_iff x (-z)
+
+lemma instPosMulReflectLE : PosMulReflectLE K := by
+  constructor
+  intro a b c (h : _ * _ ≤ _ * _)
+  obtain ⟨a',ha1,ha2⟩ := pos_iff_exists_ofReal.mp a.2
+  rw [← sub_nonneg]
+  rw [← ha2, ← sub_nonneg, ← mul_sub, le_iff_lt_or_eq] at h
+  rcases h with h|h
+  · rw [ofReal_mul_pos_iff] at h
+    classical exact le_of_lt <| h.by_cases (False.elim <| not_lt_of_gt ·.1 ha1) (·.2)
+  · exact le_of_eq ((mul_eq_zero_iff_left <| ofReal_ne_zero.mpr ha1.ne').mp (h.symm)).symm
+
+scoped[ComplexOrder] attribute [instance] RCLike.instPosMulReflectLE
 
 end Order
 

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -817,7 +817,7 @@ theorem inv_nonneg_of_nonneg (h : 0 ≤ z) : 0 ≤ z⁻¹ := by
 
 @[simp]
 theorem inv_nonneg : 0 ≤ z⁻¹ ↔ 0 ≤ z :=
-  ⟨by simpa only [inv_inv] using inv_nonneg_of_nonneg (x := z⁻¹), inv_nonneg_of_nonneg⟩
+  ⟨(by simpa only [inv_inv] using inv_nonneg_of_nonneg ·), inv_nonneg_of_nonneg⟩
 
 /-- With `z ≤ w` iff `w - z` is real and nonnegative, `ℝ` and `ℂ` are star ordered rings.
 (That is, a star ring in which the nonnegative elements are those of the form `star z * z`.)

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -809,6 +809,16 @@ protected lemma inv_pos : 0 < z⁻¹ ↔ 0 < z := by
   rw [← inv_inv z]
   exact RCLike.inv_pos_of_pos h
 
+theorem inv_nonneg_of_nonneg {x : 𝕜} (h : 0 ≤ x) : 0 ≤ x⁻¹ := by
+  by_cases h0 : x = 0
+  · subst x
+    simp only [_root_.inv_zero, le_refl]
+  · exact (RCLike.inv_pos.mpr (lt_of_le_of_ne h (Ne.symm h0))).le
+
+@[simp]
+theorem inv_nonneg {x : 𝕜} : 0 ≤ x⁻¹ ↔ 0 ≤ x :=
+  ⟨by simpa only [inv_inv] using inv_nonneg_of_nonneg (x := x⁻¹), inv_nonneg_of_nonneg⟩
+
 /-- With `z ≤ w` iff `w - z` is real and nonnegative, `ℝ` and `ℂ` are star ordered rings.
 (That is, a star ring in which the nonnegative elements are those of the form `star z * z`.)
 

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -882,13 +882,13 @@ theorem ofReal_mul_neg_iff (x : ℝ) (z : K) :
 lemma instPosMulReflectLE : PosMulReflectLE K := by
   constructor
   intro a b c (h : _ * _ ≤ _ * _)
-  obtain ⟨a',ha1,ha2⟩ := pos_iff_exists_ofReal.mp a.2
+  obtain ⟨a', ha1, ha2⟩ := pos_iff_exists_ofReal.mp a.2
   rw [← sub_nonneg]
   rw [← ha2, ← sub_nonneg, ← mul_sub, le_iff_lt_or_eq] at h
-  rcases h with h|h
+  rcases h with h | h
   · rw [ofReal_mul_pos_iff] at h
-    classical exact le_of_lt <| h.by_cases (False.elim <| not_lt_of_gt ·.1 ha1) (·.2)
-  · exact le_of_eq ((mul_eq_zero_iff_left <| ofReal_ne_zero.mpr ha1.ne').mp (h.symm)).symm
+    exact le_of_lt <| h.rec (False.elim <| not_lt_of_gt ·.1 ha1) (·.2)
+  · exact ((mul_eq_zero_iff_left <| ofReal_ne_zero.mpr ha1.ne').mp h.symm).ge
 
 scoped[ComplexOrder] attribute [instance] RCLike.instPosMulReflectLE
 


### PR DESCRIPTION
Adds
```
@[simp]
theorem RCLike.inv_nonneg {x : 𝕜} : 0 ≤ x⁻¹ ↔ 0 ≤ x
```
to match [inv_nonneg](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Order/GroupWithZero/Unbundled.html#inv_nonneg) and [Rat.inv_nonneg](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Field/Rat.html#Rat.inv_nonneg).

Upstreamed from [QuantumInfo](https://github.com/Timeroot/Lean-QuantumInfo)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
