### PR TITLE
[Merged by Bors] - chore(Computability/RegularExpressions): golf

### DIFF
--- a/Mathlib/Computability/RegularExpressions.lean
+++ b/Mathlib/Computability/RegularExpressions.lean
@@ -202,23 +202,19 @@ theorem one_rmatch_iff (x : List α) : rmatch 1 x ↔ x = [] := by
 theorem char_rmatch_iff (a : α) (x : List α) : rmatch (char a) x ↔ x = [a] := by
   cases' x with _ x
   · exact of_decide_eq_true rfl
-  cases' x with head tail
-  · rw [rmatch, deriv]
-    split_ifs
-    · tauto
-    · simp [List.singleton_inj]; tauto
-  · rw [rmatch, rmatch, deriv]
-    split_ifs with h
-    · simp only [deriv_one, zero_rmatch, cons.injEq, and_false, reduceCtorEq]
-    · simp only [deriv_zero, zero_rmatch, cons.injEq, and_false, reduceCtorEq]
+  · cases' x with head tail
+    · rw [rmatch, deriv, List.singleton_inj]
+      split <;> tauto
+    · rw [rmatch, rmatch, deriv, cons.injEq]
+      split
+      · simp_rw [deriv_one, zero_rmatch, reduceCtorEq, and_false]
+      · simp_rw [deriv_zero, zero_rmatch, reduceCtorEq, and_false]
 
 theorem add_rmatch_iff (P Q : RegularExpression α) (x : List α) :
     (P + Q).rmatch x ↔ P.rmatch x ∨ Q.rmatch x := by
-  induction x generalizing P Q with
-  | nil => simp only [rmatch, matchEpsilon, Bool.or_eq_true_iff]
-  | cons _ _ ih =>
-    repeat rw [rmatch]
-    rw [deriv_add]
+  induction' x with _ _ ih generalizing P Q
+  · simp only [rmatch, matchEpsilon, Bool.or_eq_true_iff]
+  · rw [rmatch, deriv_add]
     exact ih _ _
 
 theorem mul_rmatch_iff (P Q : RegularExpression α) (x : List α) :
@@ -232,8 +228,7 @@ theorem mul_rmatch_iff (P Q : RegularExpression α) (x : List α) :
       rwa [Bool.and_eq_true_iff] at h
     · rintro ⟨t, u, h₁, h₂⟩
       cases' List.append_eq_nil_iff.1 h₁.symm with ht hu
-      subst ht
-      subst hu
+      subst ht hu
       repeat rw [rmatch] at h₂
       simp [h₂]
   · rw [rmatch]; simp only [deriv]


### PR DESCRIPTION
I'm not a great golfer, but I noticed some style inconsistencies - it might be the age of the file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
