### PR TITLE
refactor: split the `group` tactic into `group` and `group_exp`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5043,6 +5043,7 @@ import Mathlib.Tactic.GCongr.ForwardAttr
 import Mathlib.Tactic.Generalize
 import Mathlib.Tactic.GeneralizeProofs
 import Mathlib.Tactic.Group
+import Mathlib.Tactic.GroupExp
 import Mathlib.Tactic.GuardGoalNums
 import Mathlib.Tactic.GuardHypNums
 import Mathlib.Tactic.Have

--- a/Mathlib/Data/Int/Defs.lean
+++ b/Mathlib/Data/Int/Defs.lean
@@ -46,8 +46,9 @@ protected lemma le_iff_lt_or_eq : a ≤ b ↔ a < b ∨ a = b := by rw [Int.le_i
 
 end Order
 
-@[simp] protected alias add_neg_cancel := Int.add_right_neg
-@[simp] protected alias neg_add_cancel := Int.add_left_neg
+-- We want to use these lemmas earlier than the lemmas simp can prove them with
+@[simp, nolint simpNF] protected alias add_neg_cancel := Int.add_right_neg
+@[simp, nolint simpNF] protected alias neg_add_cancel := Int.add_left_neg
 
 -- TODO: Tag in Lean
 attribute [simp] natAbs_pos

--- a/Mathlib/Data/Int/Defs.lean
+++ b/Mathlib/Data/Int/Defs.lean
@@ -46,6 +46,9 @@ protected lemma le_iff_lt_or_eq : a ≤ b ↔ a < b ∨ a = b := by rw [Int.le_i
 
 end Order
 
+@[simp] protected alias add_neg_cancel := Int.add_right_neg
+@[simp] protected alias neg_add_cancel := Int.add_left_neg
+
 -- TODO: Tag in Lean
 attribute [simp] natAbs_pos
 

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.ZMod.Aut
 import Mathlib.Data.ZMod.QuotientGroup
 import Mathlib.GroupTheory.SpecificGroups.Dihedral
 import Mathlib.GroupTheory.Subgroup.Simple
+import Mathlib.Tactic.GroupExp
 
 /-!
 # Cyclic groups
@@ -559,7 +560,7 @@ theorem commutative_of_cyclic_center_quotient [IsCyclic G'] (f : G →* G') (hf 
     _ = y ^ m * (y ^ n * (y ^ (-m) * a)) * (y ^ (-n) * b) := by rw [mem_center_iff.1 ha]
     _ = y ^ m * y ^ n * y ^ (-m) * (a * (y ^ (-n) * b)) := by simp [mul_assoc]
     _ = y ^ m * y ^ n * y ^ (-m) * (y ^ (-n) * b * a) := by rw [mem_center_iff.1 hb]
-    _ = b * a := by group
+    _ = b * a := by group_exp
 
 /-- A group is commutative if the quotient by the center is cyclic. -/
 @[to_additive

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Kim Morrison, Ainsley Pahljina
 -/
 import Mathlib.RingTheory.Fintype
 import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
 import Mathlib.Tactic.Zify
 
 /-!

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -108,6 +108,7 @@ import Mathlib.Tactic.GCongr.ForwardAttr
 import Mathlib.Tactic.Generalize
 import Mathlib.Tactic.GeneralizeProofs
 import Mathlib.Tactic.Group
+import Mathlib.Tactic.GroupExp
 import Mathlib.Tactic.GuardGoalNums
 import Mathlib.Tactic.GuardHypNums
 import Mathlib.Tactic.Have

--- a/Mathlib/Tactic/GroupExp.lean
+++ b/Mathlib/Tactic/GroupExp.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2020. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Browning, Patrick Massot
+-/
+import Mathlib.Tactic.Group
+import Mathlib.Tactic.Ring
+
+/-!
+# `group_exp` tactic
+
+Normalizes expressions in the language of groups. The basic idea is to use the simplifier
+to put everything into a product of group powers (`zpow` which takes a group element and an
+integer), then simplify the exponents using the `ring` tactic. The process needs to be repeated
+since `ring` can normalize an exponent to zero, leading to a factor that can be removed
+before collecting exponents again. The simplifier step also uses some extra lemmas to avoid
+some `ring` invocations.
+
+## Tags
+
+group theory
+-/
+
+namespace Mathlib.Tactic.Group
+open Lean Meta Parser.Tactic Elab.Tactic
+
+/-- Tactic for normalizing expressions in multiplicative groups, without assuming
+commutativity, using only the group axioms without any information about which group
+is manipulated.
+
+(For additive commutative groups, use the `abel` tactic instead.)
+
+Example:
+```lean
+example {G : Type} [Group G] (a b c d : G) (h : c = (a*b^2)*((b*b)⁻¹*a⁻¹)*d) : a*c*d⁻¹ = a := by
+  group at h -- normalizes `h` which becomes `h : c = d`
+  rw [h]     -- the goal is now `a*d*d⁻¹ = a`
+  group      -- which then normalized and closed
+```
+-/
+syntax (name := group_exp) "group_exp" (location)? : tactic
+
+macro_rules
+| `(tactic| group $[$loc]?) =>
+  `(tactic| repeat (fail_if_no_progress (group $[$loc]? <;> ring_nf $[$loc]?)))
+
+end Mathlib.Tactic.Group

--- a/Mathlib/Tactic/GroupExp.lean
+++ b/Mathlib/Tactic/GroupExp.lean
@@ -41,7 +41,7 @@ example {G : Type} [Group G] (a b c d : G) (h : c = (a*b^2)*((b*b)⁻¹*a⁻¹)*
 syntax (name := group_exp) "group_exp" (location)? : tactic
 
 macro_rules
-| `(tactic| group $[$loc]?) =>
+| `(tactic| group_exp $[$loc]?) =>
   `(tactic| repeat (fail_if_no_progress (group $[$loc]? <;> ring_nf $[$loc]?)))
 
 end Mathlib.Tactic.Group

--- a/MathlibTest/Group.lean
+++ b/MathlibTest/Group.lean
@@ -13,37 +13,13 @@ example (a b c : G) : c⁻¹*(b*c⁻¹)*c*(a*b)*(b⁻¹*a⁻¹*b⁻¹)*c = 1 := 
 -- https://en.wikipedia.org/wiki/Three_subgroups_lemma#Proof_and_the_Hall%E2%80%93Witt_identity
 example (g h k : G) : g*⁅⁅g⁻¹,h⁆,k⁆*g⁻¹*k*⁅⁅k⁻¹,g⁆,h⁆*k⁻¹*h*⁅⁅h⁻¹,k⁆,g⁆*h⁻¹ = 1 := by group
 
-example (a : G) : a^2*a = a^3 := by group
-
 example (n m : ℕ) (a : G) : a^n*a^m = a^(n+m) := by group
 
-example (a b c : G) : c*(a*b^2)*((b*b)⁻¹*a⁻¹)*c = c*c := by group
-
 example (n : ℕ) (a : G) : a^n*(a⁻¹)^n = 1 := by group
-
-example (a : G) : a^2*a⁻¹*a⁻¹ = 1 := by group
-
-example (n m : ℕ) (a : G) : a^n*a^m = a^(m+n) := by group
 
 example (n : ℕ) (a : G) : a^(n-n) = 1 := by group
 
 example (n : ℤ) (a : G) : a^(n-n) = 1 := by group
-
-example (n : ℤ) (a : G) (h : a^(n*(n+1)-n-n^2) = a) : a = 1 := by
-  group at h
-  exact h.symm
-
-example (a b c d : G) (h : c = (a*b^2)*((b*b)⁻¹*a⁻¹)*d) : a*c*d⁻¹ = a := by
-  group at h
-  rw [h]
-  group
-
--- The next example can be expanded to require an arbitrarily high number of alternations
--- between simp and ring
-
-example (n m : ℤ) (a b : G) : a^(m-n)*b^(m-n)*b^(n-m)*a^(n-m) = 1 := by group
-
-example (n : ℤ) (a b : G) : a^n*b^n*a^n*a^n*a^(-n)*a^(-n)*b^(-n)*a^(-n) = 1 := by group
 
 -- Test that group deals with `1⁻¹` properly
 

--- a/MathlibTest/GroupExp.lean
+++ b/MathlibTest/GroupExp.lean
@@ -1,25 +1,27 @@
 import Mathlib.Tactic.GroupExp
 
-example (a : G) : a^2*a = a^3 := by group
+variable {G : Type} [Group G]
 
-example (a b c : G) : c*(a*b^2)*((b*b)⁻¹*a⁻¹)*c = c*c := by group
+example (a : G) : a^2*a = a^3 := by group_exp
 
-example (a : G) : a^2*a⁻¹*a⁻¹ = 1 := by group
+example (a b c : G) : c*(a*b^2)*((b*b)⁻¹*a⁻¹)*c = c*c := by group_exp
 
-example (n m : ℕ) (a : G) : a^n*a^m = a^(m+n) := by group
+example (a : G) : a^2*a⁻¹*a⁻¹ = 1 := by group_exp
+
+example (n m : ℕ) (a : G) : a^n*a^m = a^(m+n) := by group_exp
 
 example (n : ℤ) (a : G) (h : a^(n*(n+1)-n-n^2) = a) : a = 1 := by
-  group at h
+  group_exp at h
   exact h.symm
 
 example (a b c d : G) (h : c = (a*b^2)*((b*b)⁻¹*a⁻¹)*d) : a*c*d⁻¹ = a := by
-  group at h
+  group_exp at h
   rw [h]
-  group
+  group_exp
 
 -- The next example can be expanded to require an arbitrarily high number of alternations
 -- between simp and ring
 
-example (n m : ℤ) (a b : G) : a^(m-n)*b^(m-n)*b^(n-m)*a^(n-m) = 1 := by group
+example (n m : ℤ) (a b : G) : a^(m-n)*b^(m-n)*b^(n-m)*a^(n-m) = 1 := by group_exp
 
-example (n : ℤ) (a b : G) : a^n*b^n*a^n*a^n*a^(-n)*a^(-n)*b^(-n)*a^(-n) = 1 := by group
+example (n : ℤ) (a b : G) : a^n*b^n*a^n*a^n*a^(-n)*a^(-n)*b^(-n)*a^(-n) = 1 := by group_exp

--- a/MathlibTest/GroupExp.lean
+++ b/MathlibTest/GroupExp.lean
@@ -1,0 +1,25 @@
+import Mathlib.Tactic.GroupExp
+
+example (a : G) : a^2*a = a^3 := by group
+
+example (a b c : G) : c*(a*b^2)*((b*b)⁻¹*a⁻¹)*c = c*c := by group
+
+example (a : G) : a^2*a⁻¹*a⁻¹ = 1 := by group
+
+example (n m : ℕ) (a : G) : a^n*a^m = a^(m+n) := by group
+
+example (n : ℤ) (a : G) (h : a^(n*(n+1)-n-n^2) = a) : a = 1 := by
+  group at h
+  exact h.symm
+
+example (a b c d : G) (h : c = (a*b^2)*((b*b)⁻¹*a⁻¹)*d) : a*c*d⁻¹ = a := by
+  group at h
+  rw [h]
+  group
+
+-- The next example can be expanded to require an arbitrarily high number of alternations
+-- between simp and ring
+
+example (n m : ℤ) (a b : G) : a^(m-n)*b^(m-n)*b^(n-m)*a^(n-m) = 1 := by group
+
+example (n : ℤ) (a b : G) : a^n*b^n*a^n*a^n*a^(-n)*a^(-n)*b^(-n)*a^(-n) = 1 := by group

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -105,6 +105,7 @@
   "Mathlib.Tactic.Generalize",
   "Mathlib.Tactic.GeneralizeProofs",
   "Mathlib.Tactic.Group",
+  "Mathlib.Tactic.GroupExp",
   "Mathlib.Tactic.GuardHypNums",
   "Mathlib.Tactic.HaveI",
   "Mathlib.Tactic.Hint",


### PR DESCRIPTION
This is motivated by the fact that `group` is used in files that shouldn't know about `Field`, which is used internally in `ring`, and is generally a large import (120 files!).

Closes #21324.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
