### PR TITLE
[Merged by Bors] - feat: the prime spectrum is quasi-separated

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -150,13 +150,8 @@ theorem quasiSeparatedSpace_of_quasiSeparated {X Y : Scheme} (f : X ⟶ Y)
   rw [← terminalIsTerminal.hom_ext (f ≫ terminal.from Y) (terminal.from X)]
   infer_instance
 
-instance quasiSeparatedSpace_of_isAffine (X : Scheme) [IsAffine X] : QuasiSeparatedSpace X := by
-  -- TODO: This silly `simpa` would be unnecessary if we had indexed topological bases
-  refine .of_isTopologicalBasis
-    (by simpa [Opens.IsBasis, ← Set.range_comp] using isBasis_basicOpen X) fun i j ↦ ?_
-  change IsCompact (X.basicOpen i ⊓ X.basicOpen j).1
-  rw [← Scheme.basicOpen_mul]
-  exact ((isAffineOpen_top _).basicOpen _).isCompact
+instance quasiSeparatedSpace_of_isAffine (X : Scheme) [IsAffine X] : QuasiSeparatedSpace X :=
+  (quasiSeparatedSpace_congr X.isoSpec.hom.homeomorph).2 PrimeSpectrum.instQuasiSeparatedSpace
 
 theorem IsAffineOpen.isQuasiSeparated {X : Scheme} {U : X.Opens} (hU : IsAffineOpen U) :
     IsQuasiSeparated (U : Set X) := by

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -150,19 +150,11 @@ theorem quasiSeparatedSpace_of_quasiSeparated {X Y : Scheme} (f : X ⟶ Y)
   rw [← terminalIsTerminal.hom_ext (f ≫ terminal.from Y) (terminal.from X)]
   infer_instance
 
-instance quasiSeparatedSpace_of_isAffine (X : Scheme) [IsAffine X] :
-    QuasiSeparatedSpace X := by
-  constructor
-  intro U V hU hU' hV hV'
-  obtain ⟨s, hs, e⟩ := (isCompactOpen_iff_eq_basicOpen_union _).mp ⟨hU', hU⟩
-  obtain ⟨s', hs', e'⟩ := (isCompactOpen_iff_eq_basicOpen_union _).mp ⟨hV', hV⟩
-  rw [e, e', Set.iUnion₂_inter]
-  simp_rw [Set.inter_iUnion₂]
-  apply hs.isCompact_biUnion
-  intro i _
-  apply hs'.isCompact_biUnion
-  intro i' _
-  change IsCompact (X.basicOpen i ⊓ X.basicOpen i').1
+instance quasiSeparatedSpace_of_isAffine (X : Scheme) [IsAffine X] : QuasiSeparatedSpace X := by
+  -- TODO: This silly `simpa` would be unnecessary if we had indexed topological bases
+  refine .of_isTopologicalBasis
+    (by simpa [Opens.IsBasis, ← Set.range_comp] using isBasis_basicOpen X) fun i j ↦ ?_
+  change IsCompact (X.basicOpen i ⊓ X.basicOpen j).1
   rw [← Scheme.basicOpen_mul]
   exact ((isAffineOpen_top _).basicOpen _).isCompact
 

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -14,7 +14,9 @@ import Mathlib.RingTheory.Localization.Away.Basic
 import Mathlib.RingTheory.Localization.Ideal
 import Mathlib.RingTheory.Spectrum.Maximal.Localization
 import Mathlib.Tactic.StacksAttribute
+import Mathlib.Topology.Constructible
 import Mathlib.Topology.KrullDimension
+import Mathlib.Topology.QuasiSeparated
 import Mathlib.Topology.Sober
 
 /-!
@@ -588,6 +590,16 @@ lemma range_comap_algebraMap_localization_compl_eq_range_comap_quotientMk
     Polynomial.map_surjective _ Ideal.Quotient.mk_surjective
   rw [range_comap_of_surjective _ _ surj, localization_away_comap_range _ (C c)]
   simp [Polynomial.ker_mapRingHom, Ideal.map_span]
+
+instance : QuasiSeparatedSpace (PrimeSpectrum R) :=
+  .of_isTopologicalBasis isTopologicalBasis_basic_opens fun i j ↦ by
+    simpa [← TopologicalSpace.Opens.coe_inf, ← basicOpen_mul, -basicOpen_eq_zeroLocus_compl]
+      using isCompact_basicOpen _
+
+-- TODO: Abstract out this lemma to spectral spaces
+lemma isRetrocompact_iff {U : Set (PrimeSpectrum R)} (hU : IsOpen U) :
+    IsRetrocompact U ↔ IsCompact U :=
+  isTopologicalBasis_basic_opens.isRetrocompact_iff_isCompact isCompact_basicOpen hU
 
 end BasicOpen
 

--- a/Mathlib/Topology/QuasiSeparated.lean
+++ b/Mathlib/Topology/QuasiSeparated.lean
@@ -139,3 +139,7 @@ lemma IsCompact.inter_of_isOpen (hUcomp : IsCompact U) (hVcomp : IsCompact V) (h
   QuasiSeparatedSpace.inter_isCompact _ _ hUopen hUcomp hVopen hVcomp
 
 end QuasiSeparatedSpace
+
+lemma quasiSeparatedSpace_congr (e : α ≃ₜ β) : QuasiSeparatedSpace α ↔ QuasiSeparatedSpace β where
+  mp _ := .of_isOpenEmbedding e.symm.isOpenEmbedding
+  mpr _ := .of_isOpenEmbedding e.isOpenEmbedding


### PR DESCRIPTION
Also golf the `QuasiSeparatedSpace` instance for affine schemes (the common proof was abstracted out in #21325) and prove that open sets are retrocompact iff they are compact (this should eventually become a lemma about spectral spaces).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
