### PR TITLE
perf(RingTheory/JacobiZariski): another test

### DIFF
--- a/Mathlib/Algebra/Module/Presentation/Differentials.lean
+++ b/Mathlib/Algebra/Module/Presentation/Differentials.lean
@@ -70,6 +70,7 @@ lemma comm₂₃' : pres.toExtension.toKaehler.comp pres.cotangentSpaceBasis.rep
     Finsupp.linearCombination_single, one_smul, one_smul,
     Generators.cotangentSpaceBasis_apply]
   simp [Generators.toExtension]
+  sorry
 
 /-- The canonical map `(pres.rels →₀ S) →ₗ[S] pres.toExtension.Cotangent`. -/
 noncomputable def hom₁ : (pres.rels →₀ S) →ₗ[S] pres.toExtension.Cotangent :=

--- a/Mathlib/RingTheory/Etale/Kaehler.lean
+++ b/Mathlib/RingTheory/Etale/Kaehler.lean
@@ -92,6 +92,7 @@ def tensorCotangentSpace
   haveI : IsScalarTower P.Ring Q.Ring T :=
     .of_algebraMap_eq fun r ↦ (f.algebraMap_toRingHom r).symm
   haveI : FormallyEtale P.Ring Q.Ring := ‹_›
+  haveI : IsScalarTower S T Q.CotangentSpace := sorry
   { __ := (CotangentSpace.map f).liftBaseChange T
     invFun := LinearMap.liftBaseChange T (by
       refine LinearMap.liftBaseChange _ ?_ ∘ₗ
@@ -103,27 +104,29 @@ def tensorCotangentSpace
         LinearMap.id (R := T) x
       congr 1
       ext : 4
-      refine Derivation.liftKaehlerDifferential_unique
-        (R := R) (S := P.Ring) (M := T ⊗[S] P.CotangentSpace) _ _ ?_
-      ext a
-      have : (tensorKaehlerEquivOfFormallyEtale R P.Ring Q.Ring).symm
-          ((D R Q.Ring) (f.toRingHom a)) = 1 ⊗ₜ D _ _ a :=
-        tensorKaehlerEquivOfFormallyEtale_symm_D_algebraMap R P.Ring Q.Ring a
-      simp [this]
+      sorry
+      --refine Derivation.liftKaehlerDifferential_unique
+      --  (R := R) (S := P.Ring) (M := T ⊗[S] P.CotangentSpace) _ _ ?_
+      --ext a
+      --have : (tensorKaehlerEquivOfFormallyEtale R P.Ring Q.Ring).symm
+      --    ((D R Q.Ring) (f.toRingHom a)) = 1 ⊗ₜ D _ _ a :=
+      --  tensorKaehlerEquivOfFormallyEtale_symm_D_algebraMap R P.Ring Q.Ring a
+      --simp [this]
     right_inv x := by
       show (LinearMap.liftBaseChange _ _ ∘ₗ LinearMap.liftBaseChange _ _) x =
         LinearMap.id (R := T) x
       congr 1
       ext a
       dsimp
-      obtain ⟨x, hx⟩ := (tensorKaehlerEquivOfFormallyEtale R P.Ring _).surjective (D R Q.Ring a)
+      sorry
+      /- obtain ⟨x, hx⟩ := (tensorKaehlerEquivOfFormallyEtale R P.Ring _).surjective (D R Q.Ring a)
       simp only [one_smul, ← hx, LinearEquiv.symm_apply_apply]
       show (((CotangentSpace.map f).liftBaseChange T).restrictScalars Q.Ring ∘ₗ
         LinearMap.liftBaseChange _ _) x = ((TensorProduct.mk _ _ _ 1) ∘ₗ
           (tensorKaehlerEquivOfFormallyEtale R P.Ring Q.Ring).toLinearMap) x
       congr 1
       ext a
-      simp; rfl }
+      simp; rfl -/ }
 
 /-- (Implementation)
 If `J ≃ Q ⊗ₚ I` (e.g. when `T = Q ⊗ₚ S` and `P → Q` is flat), then `T ⊗ₛ I/I² ≃ J/J²`.
@@ -242,21 +245,22 @@ def tensorH1Cotangent [alg : Algebra P.Ring Q.Ring] (halg : algebraMap P.Ring Q.
   · intro x
     have : Function.Exact (h1Cotangentι.baseChange T) (P.cotangentComplex.baseChange T) :=
       Module.Flat.lTensor_exact T (LinearMap.exact_subtype_ker_map _)
-    obtain ⟨a, ha⟩ := (this ((Extension.tensorCotangent f halg H₂).symm x.1)).mp (by
-      apply (Extension.tensorCotangentSpace f H₁).injective
-      rw [map_zero, ← x.2]
-      have : (CotangentSpace.map f).liftBaseChange T ∘ₗ P.cotangentComplex.baseChange T =
-          Q.cotangentComplex ∘ₗ (Cotangent.map f).liftBaseChange T := by
-        ext x; obtain ⟨x, rfl⟩ := Cotangent.mk_surjective x; dsimp
-        simp only [CotangentSpace.map_tmul,
-          map_one, Hom.toAlgHom_apply, one_smul, cotangentComplex_mk]
-      exact (DFunLike.congr_fun this _).trans (DFunLike.congr_arg Q.cotangentComplex
-        ((tensorCotangent f halg H₂).apply_symm_apply x.1)))
-    refine ⟨a, Subtype.ext (.trans ?_ ((LinearEquiv.eq_symm_apply _).mp ha))⟩
-    show (h1Cotangentι ∘ₗ (H1Cotangent.map f).liftBaseChange T) _ =
-      ((Cotangent.map f).liftBaseChange T ∘ₗ h1Cotangentι.baseChange T) _
-    congr 1
-    ext; simp
+    sorry
+    --obtain ⟨a, ha⟩ := (this ((Extension.tensorCotangent f halg H₂).symm x.1)).mp (by
+    --  apply (Extension.tensorCotangentSpace f H₁).injective
+    --  rw [map_zero, ← x.2]
+    --  have : (CotangentSpace.map f).liftBaseChange T ∘ₗ P.cotangentComplex.baseChange T =
+    --      Q.cotangentComplex ∘ₗ (Cotangent.map f).liftBaseChange T := by
+    --    ext x; obtain ⟨x, rfl⟩ := Cotangent.mk_surjective x; dsimp
+    --    simp only [CotangentSpace.map_tmul,
+    --      map_one, Hom.toAlgHom_apply, one_smul, cotangentComplex_mk]
+    --  exact (DFunLike.congr_fun this _).trans (DFunLike.congr_arg Q.cotangentComplex
+    --    ((tensorCotangent f halg H₂).apply_symm_apply x.1)))
+    --refine ⟨a, Subtype.ext (.trans ?_ ((LinearEquiv.eq_symm_apply _).mp ha))⟩
+    --show (h1Cotangentι ∘ₗ (H1Cotangent.map f).liftBaseChange T) _ =
+    --  ((Cotangent.map f).liftBaseChange T ∘ₗ h1Cotangentι.baseChange T) _
+    --congr 1
+    --ext; simp
 
 end Extension
 

--- a/Mathlib/RingTheory/Kaehler/CotangentComplex.lean
+++ b/Mathlib/RingTheory/Kaehler/CotangentComplex.lean
@@ -51,7 +51,27 @@ variable (P : Extension.{w} R S)
 The cotangent space on `P = R[X]`.
 This is isomorphic to `Sⁿ` with `n` being the number of variables of `P`.
 -/
-abbrev CotangentSpace : Type _ := S ⊗[P.Ring] Ω[P.Ring⁄R]
+def CotangentSpace : Type _ := S ⊗[P.Ring] Ω[P.Ring⁄R]
+
+noncomputable
+instance : AddCommGroup P.CotangentSpace := fast_instance%
+  inferInstanceAs <| AddCommGroup (S ⊗[P.Ring] Ω[P.Ring⁄R])
+
+noncomputable
+instance : Module S P.CotangentSpace := fast_instance%
+  inferInstanceAs <| Module S (S ⊗[P.Ring] Ω[P.Ring⁄R])
+
+noncomputable
+instance {S' : Type*} [CommSemiring S'] [Algebra S' S] [Algebra S' P.Ring]
+    [IsScalarTower S' P.Ring S] : Module S' P.CotangentSpace := fast_instance%
+  inferInstanceAs <| Module S' (S ⊗[P.Ring] Ω[P.Ring⁄R])
+
+noncomputable
+instance : Module P.Ring P.CotangentSpace := fast_instance%
+  inferInstanceAs <| Module P.Ring (S ⊗[P.Ring] Ω[P.Ring⁄R])
+
+instance : IsScalarTower P.Ring S P.CotangentSpace :=
+  inferInstanceAs <| IsScalarTower P.Ring S (S ⊗[P.Ring] Ω[P.Ring⁄R])
 
 /-- The cotangent complex given by a presentation `R[X] → S` (i.e. a closed embedding `S ↪ Aⁿ`). -/
 noncomputable
@@ -86,6 +106,9 @@ variable [IsScalarTower R R' R''] [IsScalarTower S S' S'']
 
 namespace CotangentSpace
 
+noncomputable instance : Module S P'.CotangentSpace := fast_instance%
+  inferInstanceAs <| Module S (S' ⊗[P'.Ring] Ω[P'.Ring⁄R'])
+
 /--
 This is the map on the cotangent space associated to a map of presentation.
 The matrix associated to this map is the Jacobian matrix. See `CotangentSpace.repr_map`.
@@ -95,6 +118,8 @@ def map (f : Hom P P') : P.CotangentSpace →ₗ[S] P'.CotangentSpace := by
   letI := ((algebraMap S S').comp (algebraMap P.Ring S)).toAlgebra
   haveI : IsScalarTower P.Ring S S' := IsScalarTower.of_algebraMap_eq' rfl
   letI := f.toAlgHom.toAlgebra
+  haveI : IsScalarTower P.Ring S P'.CotangentSpace :=
+    inferInstanceAs <| IsScalarTower _ _ (_ ⊗[_] _)
   haveI : IsScalarTower P.Ring P'.Ring S' :=
     IsScalarTower.of_algebraMap_eq (fun x ↦ (f.algebraMap_toRingHom x).symm)
   apply LinearMap.liftBaseChange
@@ -103,14 +128,18 @@ def map (f : Hom P P') : P.CotangentSpace →ₗ[S] P'.CotangentSpace := by
 @[simp]
 lemma map_tmul (f : Hom P P') (x y) :
     CotangentSpace.map f (x ⊗ₜ .D _ _ y) = (algebraMap _ _ x) ⊗ₜ .D _ _ (f.toAlgHom y) := by
-  simp only [CotangentSpace.map, AlgHom.toRingHom_eq_coe, LinearMap.liftBaseChange_tmul,
-    LinearMap.coe_comp, LinearMap.coe_restrictScalars, Function.comp_apply, map_D, mk_apply]
-  rw [smul_tmul', ← Algebra.algebraMap_eq_smul_one]
-  rfl
+  sorry
+  --simp only [CotangentSpace.map, AlgHom.toRingHom_eq_coe, LinearMap.liftBaseChange_tmul,
+  --  LinearMap.coe_comp, LinearMap.coe_restrictScalars, Function.comp_apply, map_D, mk_apply]
+  --rw [smul_tmul', ← Algebra.algebraMap_eq_smul_one]
+  --rfl
 
 @[simp]
 lemma map_id :
-    CotangentSpace.map (.id P) = LinearMap.id := by ext; simp
+    CotangentSpace.map (.id P) = LinearMap.id := by sorry--ext; simp
+
+instance : LinearMap.CompatibleSMul P'.CotangentSpace P''.CotangentSpace S S' :=
+  inferInstanceAs <| LinearMap.CompatibleSMul (_ ⊗[_] _) (_ ⊗[_] _) S S'
 
 lemma map_comp (f : Hom P P') (g : Hom P' P'') :
     CotangentSpace.map (g.comp f) =
@@ -141,6 +170,9 @@ lemma map_cotangentComplex (f : Hom P P') (x) :
     CotangentSpace.map f (P.cotangentComplex x) = P'.cotangentComplex (.map f x) := by
   obtain ⟨x, rfl⟩ := Cotangent.mk_surjective x
   rw [cotangentComplex_mk, map_tmul, map_one, Cotangent.map_mk, cotangentComplex_mk]
+
+instance : LinearMap.CompatibleSMul P'.Cotangent P''.CotangentSpace S S' :=
+  inferInstanceAs <| LinearMap.CompatibleSMul _ (_ ⊗[_] _) S S'
 
 lemma map_comp_cotangentComplex (f : Hom P P') :
     CotangentSpace.map f ∘ₗ P.cotangentComplex =
@@ -220,15 +252,17 @@ variable [IsScalarTower R S S']
 
 lemma Hom.sub_one_tmul (f g : Hom P P') (x) :
     f.sub g (1 ⊗ₜ .D _ _ x) = Cotangent.mk (f.subToKer g x) := by
-  simp only [sub, LinearMap.liftBaseChange_tmul, Derivation.liftKaehlerDifferential_comp_D,
-    Derivation.mk_coe, LinearMap.coe_comp, LinearMap.coe_restrictScalars, Function.comp_apply,
-    one_smul]
+  sorry
+  --simp only [sub, LinearMap.liftBaseChange_tmul, Derivation.liftKaehlerDifferential_comp_D,
+  --  Derivation.mk_coe, LinearMap.coe_comp, LinearMap.coe_restrictScalars, Function.comp_apply,
+  --  one_smul]
 
 @[simp]
 lemma Hom.sub_tmul (f g : Hom P P') (r x) :
     f.sub g (r ⊗ₜ .D _ _ x) = r • Cotangent.mk (f.subToKer g x) := by
-  simp only [sub, LinearMap.liftBaseChange_tmul, Derivation.liftKaehlerDifferential_comp_D,
-    Derivation.mk_coe, LinearMap.coe_comp, LinearMap.coe_restrictScalars, Function.comp_apply]
+  sorry
+  --simp only [sub, LinearMap.liftBaseChange_tmul, Derivation.liftKaehlerDifferential_comp_D,
+  --  Derivation.mk_coe, LinearMap.coe_comp, LinearMap.coe_restrictScalars, Function.comp_apply]
 
 lemma CotangentSpace.map_sub_map (f g : Hom P P') :
     CotangentSpace.map f - CotangentSpace.map g =
@@ -247,10 +281,11 @@ lemma CotangentSpace.map_sub_map (f g : Hom P P') :
     | add => simp only [map_add, tmul_add, LinearMap.coe_comp, LinearMap.coe_restrictScalars,
       Function.comp_apply, *]
     | tmul =>
-      simp only [Derivation.tensorProductTo_tmul, tmul_smul, smul_tmul', LinearMap.sub_apply,
-        map_tmul, Hom.toAlgHom_apply, LinearMap.coe_comp, LinearMap.coe_restrictScalars,
-        Function.comp_apply, Hom.sub_tmul, LinearMap.map_smul_of_tower, cotangentComplex_mk,
-        Hom.subToKer_apply_coe, map_sub, ← algebraMap_eq_smul_one, tmul_sub, smul_sub]
+      sorry
+      --simp only [Derivation.tensorProductTo_tmul, tmul_smul, smul_tmul', LinearMap.sub_apply,
+      --  map_tmul, Hom.toAlgHom_apply, LinearMap.coe_comp, LinearMap.coe_restrictScalars,
+      --  Function.comp_apply, Hom.sub_tmul, LinearMap.map_smul_of_tower, cotangentComplex_mk,
+      --  Hom.subToKer_apply_coe, map_sub, ← algebraMap_eq_smul_one, tmul_sub, smul_sub]
 
 lemma Cotangent.map_sub_map (f g : Hom P P') :
     map f - map g = (f.sub g) ∘ₗ P.cotangentComplex := by
@@ -384,8 +419,9 @@ lemma cotangentSpaceBasis_repr_tmul (r x i) :
     P.cotangentSpaceBasis.repr (r ⊗ₜ[P.Ring] KaehlerDifferential.D R P.Ring x : _) i =
       r * aeval P.val (pderiv i x) := by
   classical
-  simp only [cotangentSpaceBasis, Basis.baseChange_repr_tmul, mvPolynomialBasis_repr_apply,
-    Algebra.smul_def, mul_comm r, algebraMap_apply, toExtension]
+  sorry
+  --simp only [cotangentSpaceBasis, Basis.baseChange_repr_tmul, mvPolynomialBasis_repr_apply,
+  --  Algebra.smul_def, mul_comm r, algebraMap_apply, toExtension]
 
 lemma cotangentSpaceBasis_repr_one_tmul (x i) :
     P.cotangentSpaceBasis.repr (1 ⊗ₜ .D _ _ x) i = aeval P.val (pderiv i x) := by
@@ -393,7 +429,8 @@ lemma cotangentSpaceBasis_repr_one_tmul (x i) :
 
 lemma cotangentSpaceBasis_apply (i) :
     P.cotangentSpaceBasis i = ((1 : S) ⊗ₜ[P.Ring] D R P.Ring (.X i) :) := by
-  simp [cotangentSpaceBasis, toExtension]
+  sorry
+  --simp [cotangentSpaceBasis, toExtension]
 
 instance (P : Generators R S) : Module.Free S P.toExtension.CotangentSpace :=
   .of_basis P.cotangentSpaceBasis
@@ -441,11 +478,12 @@ end Generators
 open KaehlerDifferential in
 attribute [local instance] Module.finitePresentation_of_projective in
 instance [Algebra.FinitePresentation R S] : Module.FinitePresentation S (Ω[S⁄R]) := by
-  let P := Algebra.Presentation.ofFinitePresentation R S
-  have : Algebra.FiniteType R P.toExtension.Ring := .mvPolynomial _ _
-  refine Module.finitePresentation_of_surjective _ P.toExtension.toKaehler_surjective ?_
-  rw [LinearMap.exact_iff.mp P.toExtension.exact_cotangentComplex_toKaehler, ← Submodule.map_top]
-  exact (Extension.Cotangent.finite P.ideal_fg_of_isFinite).1.map P.toExtension.cotangentComplex
+  sorry
+  --let P := Algebra.Presentation.ofFinitePresentation R S
+  --have : Algebra.FiniteType R P.toExtension.Ring := .mvPolynomial _ _
+  --refine Module.finitePresentation_of_surjective _ P.toExtension.toKaehler_surjective ?_
+  --rw [LinearMap.exact_iff.mp P.toExtension.exact_cotangentComplex_toKaehler, ← Submodule.map_top]
+  --exact (Extension.Cotangent.finite P.ideal_fg_of_isFinite).1.map P.toExtension.cotangentComplex
 
 variable {P : Generators R S}
 
@@ -511,12 +549,13 @@ instance [FinitePresentation R S] [Module.Projective S (Ω[S⁄R])] :
     .of_surjective P.equivH1Cotangent.toLinearMap P.equivH1Cotangent.surjective
   rw [Module.finite_def, Submodule.fg_top, ← LinearMap.ker_rangeRestrict]
   have := Extension.Cotangent.finite P.ideal_fg_of_isFinite
-  have : Module.FinitePresentation S (LinearMap.range P.toExtension.cotangentComplex) := by
-    rw [← LinearMap.exact_iff.mp P.toExtension.exact_cotangentComplex_toKaehler]
-    exact Module.finitePresentation_of_projective_of_exact
-      _ _ (Subtype.val_injective) P.toExtension.toKaehler_surjective
-      (LinearMap.exact_subtype_ker_map _)
-  exact Module.FinitePresentation.fg_ker (N := LinearMap.range P.toExtension.cotangentComplex)
-    _ P.toExtension.cotangentComplex.surjective_rangeRestrict
+  sorry
+  --have : Module.FinitePresentation S (LinearMap.range P.toExtension.cotangentComplex) := by
+  --  rw [← LinearMap.exact_iff.mp P.toExtension.exact_cotangentComplex_toKaehler]
+  --  exact Module.finitePresentation_of_projective_of_exact
+  --    _ _ (Subtype.val_injective) P.toExtension.toKaehler_surjective
+  --    (LinearMap.exact_subtype_ker_map _)
+  --exact Module.FinitePresentation.fg_ker (N := LinearMap.range P.toExtension.cotangentComplex)
+  --  _ P.toExtension.cotangentComplex.surjective_rangeRestrict
 
 end Algebra

--- a/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
+++ b/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
@@ -168,6 +168,10 @@ section instanceProblem
 attribute [local instance 999999] Zero.toOfNat0 SemilinearMapClass.distribMulActionSemiHomClass
   SemilinearEquivClass.instSemilinearMapClass TensorProduct.addZeroClass AddZeroClass.toZero
 
+instance : IsScalarTower S T (Q.comp P).toExtension.CotangentSpace := by
+  unfold Extension.CotangentSpace
+  infer_instance
+
 lemma CotangentSpace.compEquiv_symm_inr :
     (compEquiv Q P).symm.toLinearMap ∘ₗ
       LinearMap.inr T Q.toExtension.CotangentSpace (T ⊗[S] P.toExtension.CotangentSpace) =
@@ -376,26 +380,28 @@ def δ :
 
 lemma exact_δ_map :
     Function.Exact (δ Q P) (mapBaseChange R S T) := by
-  apply SnakeLemma.exact_δ_left (π₂ := (Q.comp P).toExtension.toKaehler)
-    (hπ₂ := (Q.comp P).toExtension.exact_cotangentComplex_toKaehler)
-  · apply (P.cotangentSpaceBasis.baseChange T).ext
-    intro i
-    simp only [Basis.baseChange_apply, LinearMap.coe_comp, Function.comp_apply,
-      LinearMap.baseChange_tmul, toKaehler_cotangentSpaceBasis, mapBaseChange_tmul, map_D,
-      one_smul, comp_vars, LinearMap.liftBaseChange_tmul]
-    rw [cotangentSpaceBasis_apply]
-    conv_rhs => enter [2]; tactic => exact Extension.CotangentSpace.map_tmul ..
-    simp only [map_one, mapBaseChange_tmul, map_D, one_smul]
-    simp [Extension.Hom.toAlgHom]
-  · exact LinearMap.lTensor_surjective T P.toExtension.toKaehler_surjective
+  sorry
+  --apply SnakeLemma.exact_δ_left (π₂ := (Q.comp P).toExtension.toKaehler)
+  --  (hπ₂ := (Q.comp P).toExtension.exact_cotangentComplex_toKaehler)
+  --· apply (P.cotangentSpaceBasis.baseChange T).ext
+  --  intro i
+  --  simp only [Basis.baseChange_apply, LinearMap.coe_comp, Function.comp_apply,
+  --    LinearMap.baseChange_tmul, toKaehler_cotangentSpaceBasis, mapBaseChange_tmul, map_D,
+  --    one_smul, comp_vars, LinearMap.liftBaseChange_tmul]
+  --  rw [cotangentSpaceBasis_apply]
+  --  conv_rhs => enter [2]; tactic => exact Extension.CotangentSpace.map_tmul ..
+  --  simp only [map_one, mapBaseChange_tmul, map_D, one_smul]
+  --  simp [Extension.Hom.toAlgHom]
+  --· exact LinearMap.lTensor_surjective T P.toExtension.toKaehler_surjective
 
 lemma δ_eq (x : Q.toExtension.H1Cotangent) (y)
     (hy : Extension.Cotangent.map (ofComp Q P).toExtensionHom y = x.1) (z)
     (hz : (Extension.CotangentSpace.map (toComp Q P).toExtensionHom).liftBaseChange T z =
       (Q.comp P).toExtension.cotangentComplex y) :
     δ Q P x = P.toExtension.toKaehler.baseChange T z := by
-  apply SnakeLemma.δ_eq
-  exacts [hy, hz]
+  sorry
+  --apply SnakeLemma.δ_eq
+  --exacts [hy, hz]
 
 lemma δ_eq_δAux (x : Q.ker) (hx) :
     δ Q P ⟨.mk x, hx⟩ = δAux R Q x.1 := by
@@ -428,11 +434,12 @@ lemma δ_eq_δ (Q : Generators.{u₁} S T) (P : Generators.{u₂} R S)
 
 lemma exact_map_δ :
     Function.Exact (Extension.H1Cotangent.map (Q.ofComp P).toExtensionHom) (δ Q P) := by
-  apply SnakeLemma.exact_δ_right
-    (ι₂ := (Q.comp P).toExtension.h1Cotangentι)
-    (hι₂ := LinearMap.exact_subtype_ker_map _)
-  · ext x; rfl
-  · exact Subtype.val_injective
+  sorry
+  --apply SnakeLemma.exact_δ_right
+  --  (ι₂ := (Q.comp P).toExtension.h1Cotangentι)
+  --  (hι₂ := LinearMap.exact_subtype_ker_map _)
+  --· ext x; rfl
+  --· exact Subtype.val_injective
 
 lemma δ_map
     (Q : Generators.{u₁} S T) (P : Generators.{u₂} R S)

--- a/Mathlib/RingTheory/Smooth/Kaehler.lean
+++ b/Mathlib/RingTheory/Smooth/Kaehler.lean
@@ -485,10 +485,11 @@ lemma CotangentSpace.map_toInfinitesimal_bijective (P : Extension.{u} R S) :
   letI : Algebra P.Ring P.infinitesimal.Ring := inferInstanceAs (Algebra P.Ring (P.Ring ⧸ _))
   have : IsScalarTower P.Ring P.infinitesimal.Ring S := .of_algebraMap_eq' rfl
   apply LinearMap.restrictScalars_injective P.Ring
-  ext x a
-  dsimp
-  simp only [map_tmul, id.map_eq_id, RingHom.id_apply, Hom.toAlgHom_apply]
-  exact (tensorKaehlerQuotKerSqEquiv_symm_tmul_D _ _).symm
+  sorry
+  --ext x a
+  --dsimp
+  --simp only [map_tmul, id.map_eq_id, RingHom.id_apply, Hom.toAlgHom_apply]
+  --exact (tensorKaehlerQuotKerSqEquiv_symm_tmul_D _ _).symm
 
 lemma Cotangent.map_toInfinitesimal_bijective (P : Extension.{u} R S) :
     Function.Bijective (Cotangent.map P.toInfinitesimal) := by

--- a/Mathlib/RingTheory/Smooth/Local.lean
+++ b/Mathlib/RingTheory/Smooth/Local.lean
@@ -33,5 +33,6 @@ theorem Algebra.FormallySmooth.iff_injective_lTensor_residueField {R S} [CommRin
     have : Module.Finite P.Ring P.ker := ⟨(Submodule.fg_top _).mpr h'⟩
     .of_surjective _ Extension.Cotangent.mk_surjective
   have : Module.Finite S P.Cotangent := Module.Finite.of_restrictScalars_finite P.Ring _ _
-  rw [← IsLocalRing.split_injective_iff_lTensor_residueField_injective,
-    P.formallySmooth_iff_split_injection]
+  sorry
+  --rw [← IsLocalRing.split_injective_iff_lTensor_residueField_injective,
+  --  P.formallySmooth_iff_split_injection]


### PR DESCRIPTION
Make `CotangentSpace` a `def`. I sorried out all breaking proofs, only fixing statements and data. So this should be a lower estimate on the build time.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
