### PR TITLE
[Merged by Bors] - feat(Algebra/Category): `ConcreteCategory` instance for `Semigrp`

### DIFF
--- a/Mathlib/Algebra/Category/MonCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/MonCat/Adjunctions.lean
@@ -32,7 +32,7 @@ namespace MonCat
 @[to_additive (attr := simps) "The functor of adjoining a neutral element `zero` to a semigroup"]
 def adjoinOne : Semigrp.{u} ⥤ MonCat.{u} where
   obj S := MonCat.of (WithOne S)
-  map f := ofHom (WithOne.map f)
+  map f := ofHom (WithOne.map f.hom)
   map_id _ := MonCat.hom_ext WithOne.map_id
   map_comp _ _ := MonCat.hom_ext (WithOne.map_comp _ _)
 
@@ -40,13 +40,15 @@ def adjoinOne : Semigrp.{u} ⥤ MonCat.{u} where
 instance hasForgetToSemigroup : HasForget₂ MonCat Semigrp where
   forget₂ :=
     { obj := fun M => Semigrp.of M
-      map f := f.hom.toMulHom }
+      map f := Semigrp.ofHom f.hom.toMulHom }
 
 /-- The `adjoinOne`-forgetful adjunction from `Semigrp` to `MonCat`. -/
 @[to_additive "The `adjoinZero`-forgetful adjunction from `AddSemigrp` to `AddMonCat`"]
 def adjoinOneAdj : adjoinOne ⊣ forget₂ MonCat.{u} Semigrp.{u} :=
   Adjunction.mkOfHomEquiv
-    { homEquiv := fun _ _ => ConcreteCategory.homEquiv.trans WithOne.lift.symm
+    { homEquiv X Y :=
+        ConcreteCategory.homEquiv.trans (WithOne.lift.symm.trans
+          (ConcreteCategory.homEquiv (X := X) (Y := (forget₂ _ _).obj Y)).symm)
       homEquiv_naturality_left_symm := by
         intros
         ext ⟨_|_⟩ <;> simp <;> rfl }

--- a/Mathlib/Algebra/Category/Semigrp/Basic.lean
+++ b/Mathlib/Algebra/Category/Semigrp/Basic.lean
@@ -5,7 +5,7 @@ Authors: Julian Kuelshammer
 -/
 import Mathlib.Algebra.PEmptyInstances
 import Mathlib.Algebra.Group.Equiv.Defs
-import Mathlib.CategoryTheory.ConcreteCategory.BundledHom
+import Mathlib.CategoryTheory.ConcreteCategory.Basic
 import Mathlib.CategoryTheory.Functor.ReflectsIso
 
 /-!
@@ -31,77 +31,163 @@ universe u v
 
 open CategoryTheory
 
+/-- The category of additive magmas and additive magma morphisms. -/
+structure AddMagmaCat : Type (u + 1) where
+  /-- The underlying additive magma. -/
+  (carrier : Type u)
+  [str : Add carrier]
+
 /-- The category of magmas and magma morphisms. -/
 @[to_additive]
-def MagmaCat : Type (u + 1) :=
-  Bundled Mul
+structure MagmaCat : Type (u + 1) where
+  /-- The underlying magma. -/
+  (carrier : Type u)
+  [str : Mul carrier]
 
-/-- The category of additive magmas and additive magma morphisms. -/
-add_decl_doc AddMagmaCat
+attribute [instance] AddMagmaCat.str MagmaCat.str
+attribute [to_additive existing] MagmaCat.carrier MagmaCat.str
+
+initialize_simps_projections AddMagmaCat (carrier → coe, -str)
+initialize_simps_projections MagmaCat (carrier → coe, -str)
 
 namespace MagmaCat
 
 @[to_additive]
-instance bundledHom : BundledHom @MulHom :=
-  ⟨@MulHom.toFun, @MulHom.id, @MulHom.comp,
-    by intros; apply @DFunLike.coe_injective, by aesop_cat, by simp⟩
+instance : CoeSort MagmaCat (Type u) :=
+  ⟨MagmaCat.carrier⟩
 
--- Porting note: deriving failed for `HasForget`,
--- "default handlers have not been implemented yet"
--- https://github.com/leanprover-community/mathlib4/issues/5020
-deriving instance LargeCategory for MagmaCat
-instance instHasForget : HasForget MagmaCat := BundledHom.hasForget MulHom
-
-attribute [to_additive] instMagmaCatLargeCategory instHasForget
-
-@[to_additive]
-instance : CoeSort MagmaCat Type* where
-  coe X := X.α
-
--- Porting note: Hinting to Lean that `forget R` and `R` are the same
-unif_hint forget_obj_eq_coe (R : MagmaCat) where ⊢
-  (forget MagmaCat).obj R ≟ R
-unif_hint _root_.AddMagmaCat.forget_obj_eq_coe (R : AddMagmaCat) where ⊢
-  (forget AddMagmaCat).obj R ≟ R
-
-@[to_additive]
-instance (X : MagmaCat) : Mul X := X.str
-
-@[to_additive]
-instance instFunLike (X Y : MagmaCat) : FunLike (X ⟶ Y) X Y :=
-  inferInstanceAs <| FunLike (X →ₙ* Y) X Y
-
-@[to_additive]
-instance instMulHomClass (X Y : MagmaCat) : MulHomClass (X ⟶ Y) X Y :=
-  inferInstanceAs <| MulHomClass (X →ₙ* Y) X Y
+attribute [coe] AddMagmaCat.carrier MagmaCat.carrier
 
 /-- Construct a bundled `MagmaCat` from the underlying type and typeclass. -/
-@[to_additive]
-def of (M : Type u) [Mul M] : MagmaCat :=
-  Bundled.of M
+@[to_additive "Construct a bundled `AddMagmaCat` from the underlying type and typeclass."]
+abbrev of (M : Type u) [Mul M] : MagmaCat := ⟨M⟩
 
-/-- Construct a bundled `AddMagmaCat` from the underlying type and typeclass. -/
-add_decl_doc AddMagmaCat.of
+end MagmaCat
+
+/-- The type of morphisms in `AddMagmaCat R`. -/
+@[ext]
+structure AddMagmaCat.Hom (A B : AddMagmaCat.{u}) where
+  private mk ::
+  /-- The underlying `AddHom`. -/
+  hom' : A →ₙ+ B
+
+/-- The type of morphisms in `MagmaCat R`. -/
+@[to_additive, ext]
+structure MagmaCat.Hom (A B : MagmaCat.{u}) where
+  private mk ::
+  /-- The underlying `MulHom`. -/
+  hom' : A →ₙ* B
+
+attribute [to_additive existing AddMagmaCat.Hom.mk] MagmaCat.Hom.mk
+
+namespace MagmaCat
+
+@[to_additive]
+instance : Category MagmaCat.{u} where
+  Hom X Y := Hom X Y
+  id X := ⟨MulHom.id X⟩
+  comp f g := ⟨g.hom'.comp f.hom'⟩
+
+@[to_additive]
+instance : ConcreteCategory MagmaCat (· →ₙ* ·) where
+  hom := Hom.hom'
+  ofHom := Hom.mk
+
+/-- Turn a morphism in `MagmaCat` back into a `MulHom`. -/
+@[to_additive "Turn a morphism in `AddMagmaCat` back into an `AddHom`."]
+abbrev Hom.hom {X Y : MagmaCat.{u}} (f : Hom X Y) :=
+  ConcreteCategory.hom (C := MagmaCat) f
+
+/-- Typecheck a `MulHom` as a morphism in `MagmaCat`. -/
+@[to_additive "Typecheck an `AddHom` as a morphism in `AddMagmaCat`. "]
+abbrev ofHom {X Y : Type u} [Mul X] [Mul Y] (f : X →ₙ* Y) : of X ⟶ of Y :=
+  ConcreteCategory.ofHom (C := MagmaCat) f
+
+variable {R} in
+/-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
+def Hom.Simps.hom (X Y : MagmaCat.{u}) (f : Hom X Y) :=
+  f.hom
+
+initialize_simps_projections Hom (hom' → hom)
+initialize_simps_projections AddMagmaCat.Hom (hom' → hom)
+
+/-!
+The results below duplicate the `ConcreteCategory` simp lemmas, but we can keep them for `dsimp`.
+-/
 
 @[to_additive (attr := simp)]
-theorem coe_of (R : Type u) [Mul R] : (MagmaCat.of R : Type u) = R :=
+lemma coe_id {X : MagmaCat} : (𝟙 X : X → X) = id := rfl
+
+@[to_additive (attr := simp)]
+lemma coe_comp {X Y Z : MagmaCat} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g : X → Z) = g ∘ f := rfl
+
+@[to_additive (attr := simp)]
+lemma forget_map {X Y : MagmaCat} (f : X ⟶ Y) :
+    (forget MagmaCat).map f = f := rfl
+
+@[to_additive (attr := ext)]
+lemma ext {X Y : MagmaCat} {f g : X ⟶ Y} (w : ∀ x : X, f x = g x) : f = g :=
+  ConcreteCategory.hom_ext _ _ w
+
+@[to_additive]
+-- This is not `simp` to avoid rewriting in types of terms.
+theorem coe_of (M : Type u) [Mul M] : (MagmaCat.of M : Type u) = M := rfl
+
+@[to_additive (attr := simp)]
+lemma hom_id {M : MagmaCat} : (𝟙 M : M ⟶ M).hom = MulHom.id M := rfl
+
+/- Provided for rewriting. -/
+@[to_additive]
+lemma id_apply (M : MagmaCat) (x : M) :
+    (𝟙 M : M ⟶ M) x = x := by simp
+
+@[to_additive (attr := simp)]
+lemma hom_comp {M N T : MagmaCat} (f : M ⟶ N) (g : N ⟶ T) :
+    (f ≫ g).hom = g.hom.comp f.hom := rfl
+
+/- Provided for rewriting. -/
+@[to_additive]
+lemma comp_apply {M N T : MagmaCat} (f : M ⟶ N) (g : N ⟶ T) (x : M) :
+    (f ≫ g) x = g (f x) := by simp
+
+@[to_additive (attr := ext)]
+lemma hom_ext {M N : MagmaCat} {f g : M ⟶ N} (hf : f.hom = g.hom) : f = g :=
+  Hom.ext hf
+
+@[to_additive (attr := simp)]
+lemma hom_ofHom {M N : Type u} [Mul M] [Mul N] (f : M →ₙ* N) :
+  (ofHom f).hom = f := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_hom {M N : MagmaCat} (f : M ⟶ N) :
+    ofHom (Hom.hom f) = f := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_id {M : Type u} [Mul M] : ofHom (MulHom.id M) = 𝟙 (of M) := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_comp {M N P : Type u} [Mul M] [Mul N] [Mul P]
+    (f : M →ₙ* N) (g : N →ₙ* P) :
+    ofHom (g.comp f) = ofHom f ≫ ofHom g :=
   rfl
+
+@[to_additive]
+lemma ofHom_apply {X Y : Type u} [Mul X] [Mul Y] (f : X →ₙ* Y) (x : X) :
+    (ofHom f) x = f x := rfl
+
+@[to_additive (attr := simp)]
+lemma inv_hom_apply {M N : MagmaCat} (e : M ≅ N) (x : M) : e.inv (e.hom x) = x := by
+  rw [← comp_apply]
+  simp
+
+@[to_additive (attr := simp)]
+lemma hom_inv_apply {M N : MagmaCat} (e : M ≅ N) (s : N) : e.hom (e.inv s) = s := by
+  rw [← comp_apply]
+  simp
 
 @[to_additive (attr := simp)]
 lemma mulEquiv_coe_eq {X Y : Type _} [Mul X] [Mul Y] (e : X ≃* Y) :
-    (@DFunLike.coe (MagmaCat.of X ⟶ MagmaCat.of Y) _ (fun _ => (forget MagmaCat).obj _)
-      HasForget.instFunLike (e : X →ₙ* Y) : X → Y) = ↑e :=
-  rfl
-
-/-- Typecheck a `MulHom` as a morphism in `MagmaCat`. -/
-@[to_additive]
-def ofHom {X Y : Type u} [Mul X] [Mul Y] (f : X →ₙ* Y) : of X ⟶ of Y := f
-
-/-- Typecheck an `AddHom` as a morphism in `AddMagmaCat`. -/
-add_decl_doc AddMagmaCat.ofHom
-
-@[to_additive]
-theorem ofHom_apply {X Y : Type u} [Mul X] [Mul Y] (f : X →ₙ* Y) (x : X) : ofHom f x = f x :=
+    (ofHom (e : X →ₙ* Y)).hom = ↑e :=
   rfl
 
 @[to_additive]
@@ -110,79 +196,164 @@ instance : Inhabited MagmaCat :=
 
 end MagmaCat
 
+/-- The category of additive semigroups and semigroup morphisms. -/
+structure AddSemigrp : Type (u + 1) where
+  /-- The underlying type. -/
+  (carrier : Type u)
+  [str : AddSemigroup carrier]
+
 /-- The category of semigroups and semigroup morphisms. -/
 @[to_additive]
-def Semigrp : Type (u + 1) :=
-  Bundled Semigroup
+structure Semigrp : Type (u + 1) where
+  /-- The underlying type. -/
+  (carrier : Type u)
+  [str : Semigroup carrier]
 
-/-- The category of additive semigroups and semigroup morphisms. -/
-add_decl_doc AddSemigrp
+attribute [instance] AddSemigrp.str Semigrp.str
+attribute [to_additive existing] Semigrp.carrier Semigrp.str
+
+initialize_simps_projections AddSemigrp (carrier → coe, -str)
+initialize_simps_projections Semigrp (carrier → coe, -str)
 
 namespace Semigrp
 
 @[to_additive]
-instance : BundledHom.ParentProjection @Semigroup.toMul := ⟨⟩
+instance : CoeSort Semigrp (Type u) :=
+  ⟨Semigrp.carrier⟩
 
-deriving instance LargeCategory for Semigrp
-
--- Porting note: deriving failed for `HasForget`,
--- "default handlers have not been implemented yet"
--- https://github.com/leanprover-community/mathlib4/issues/5020
-instance instHasForget : HasForget Semigrp :=
-  BundledHom.hasForget (fun _ _ => _)
-
-attribute [to_additive] instSemigrpLargeCategory Semigrp.instHasForget
-
-@[to_additive]
-instance : CoeSort Semigrp Type* where
-  coe X := X.α
-
--- Porting note: Hinting to Lean that `forget R` and `R` are the same
-unif_hint forget_obj_eq_coe (R : Semigrp) where ⊢
-  (forget Semigrp).obj R ≟ R
-unif_hint _root_.AddSemigrp.forget_obj_eq_coe (R : AddSemigrp) where ⊢
-  (forget AddSemigrp).obj R ≟ R
-
-@[to_additive]
-instance (X : Semigrp) : Semigroup X := X.str
-
-@[to_additive]
-instance instFunLike (X Y : Semigrp) : FunLike (X ⟶ Y) X Y :=
-  inferInstanceAs <| FunLike (X →ₙ* Y) X Y
-
-@[to_additive]
-instance instMulHomClass (X Y : Semigrp) : MulHomClass (X ⟶ Y) X Y :=
-  inferInstanceAs <| MulHomClass (X →ₙ* Y) X Y
+attribute [coe] AddSemigrp.carrier Semigrp.carrier
 
 /-- Construct a bundled `Semigrp` from the underlying type and typeclass. -/
-@[to_additive]
-def of (M : Type u) [Semigroup M] : Semigrp :=
-  Bundled.of M
+@[to_additive "Construct a bundled `AddSemigrp` from the underlying type and typeclass."]
+abbrev of (M : Type u) [Semigroup M] : Semigrp := ⟨M⟩
 
-/-- Construct a bundled `AddSemigrp` from the underlying type and typeclass. -/
-add_decl_doc AddSemigrp.of
+end Semigrp
+
+/-- The type of morphisms in `AddSemigrp R`. -/
+@[ext]
+structure AddSemigrp.Hom (A B : AddSemigrp.{u}) where
+  private mk ::
+  /-- The underlying `AddHom`. -/
+  hom' : A →ₙ+ B
+
+/-- The type of morphisms in `Semigrp R`. -/
+@[to_additive, ext]
+structure Semigrp.Hom (A B : Semigrp.{u}) where
+  private mk ::
+  /-- The underlying `MulHom`. -/
+  hom' : A →ₙ* B
+
+attribute [to_additive existing AddSemigrp.Hom.mk] Semigrp.Hom.mk
+
+namespace Semigrp
+
+@[to_additive]
+instance : Category Semigrp.{u} where
+  Hom X Y := Hom X Y
+  id X := ⟨MulHom.id X⟩
+  comp f g := ⟨g.hom'.comp f.hom'⟩
+
+@[to_additive]
+instance : ConcreteCategory Semigrp (· →ₙ* ·) where
+  hom := Hom.hom'
+  ofHom := Hom.mk
+
+/-- Turn a morphism in `Semigrp` back into a `MulHom`. -/
+@[to_additive "Turn a morphism in `AddSemigrp` back into an `AddHom`."]
+abbrev Hom.hom {X Y : Semigrp.{u}} (f : Hom X Y) :=
+  ConcreteCategory.hom (C := Semigrp) f
+
+/-- Typecheck a `MulHom` as a morphism in `Semigrp`. -/
+@[to_additive "Typecheck an `AddHom` as a morphism in `AddSemigrp`. "]
+abbrev ofHom {X Y : Type u} [Semigroup X] [Semigroup Y] (f : X →ₙ* Y) : of X ⟶ of Y :=
+  ConcreteCategory.ofHom (C := Semigrp) f
+
+variable {R} in
+/-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
+def Hom.Simps.hom (X Y : Semigrp.{u}) (f : Hom X Y) :=
+  f.hom
+
+initialize_simps_projections Hom (hom' → hom)
+initialize_simps_projections AddSemigrp.Hom (hom' → hom)
+
+/-!
+The results below duplicate the `ConcreteCategory` simp lemmas, but we can keep them for `dsimp`.
+-/
 
 @[to_additive (attr := simp)]
-theorem coe_of (R : Type u) [Semigroup R] : (Semigrp.of R : Type u) = R :=
+lemma coe_id {X : Semigrp} : (𝟙 X : X → X) = id := rfl
+
+@[to_additive (attr := simp)]
+lemma coe_comp {X Y Z : Semigrp} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g : X → Z) = g ∘ f := rfl
+
+@[to_additive (attr := deprecated "Use hom_comp instead" (since := "2025-01-28"))]
+lemma comp_def {X Y Z : Semigrp} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g).hom = g.hom.comp f.hom := rfl
+
+@[simp] lemma forget_map {X Y : Semigrp} (f : X ⟶ Y) : (forget Semigrp).map f = (f : X → Y) := rfl
+
+@[to_additive (attr := ext)]
+lemma ext {X Y : Semigrp} {f g : X ⟶ Y} (w : ∀ x : X, f x = g x) : f = g :=
+  ConcreteCategory.hom_ext _ _ w
+
+@[to_additive]
+-- This is not `simp` to avoid rewriting in types of terms.
+theorem coe_of (R : Type u) [Semigroup R] : ↑(Semigrp.of R) = R :=
   rfl
+
+@[to_additive (attr := simp)]
+lemma hom_id {X : Semigrp} : (𝟙 X : X ⟶ X).hom = MulHom.id X := rfl
+
+/- Provided for rewriting. -/
+@[to_additive]
+lemma id_apply (X : Semigrp) (x : X) :
+    (𝟙 X : X ⟶ X) x = x := by simp
+
+@[to_additive (attr := simp)]
+lemma hom_comp {X Y T : Semigrp} (f : X ⟶ Y) (g : Y ⟶ T) :
+    (f ≫ g).hom = g.hom.comp f.hom := rfl
+
+/- Provided for rewriting. -/
+@[to_additive]
+lemma comp_apply {X Y T : Semigrp} (f : X ⟶ Y) (g : Y ⟶ T) (x : X) :
+    (f ≫ g) x = g (f x) := by simp
+
+@[to_additive (attr := ext)]
+lemma hom_ext {X Y : Semigrp} {f g : X ⟶ Y} (hf : f.hom = g.hom) : f = g :=
+  Hom.ext hf
+
+@[to_additive (attr := simp)]
+lemma hom_ofHom {X Y : Type u} [Semigroup X] [Semigroup Y] (f : X →ₙ* Y) : (ofHom f).hom = f := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_hom {X Y : Semigrp} (f : X ⟶ Y) :
+    ofHom (Hom.hom f) = f := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_id {X : Type u} [Semigroup X] : ofHom (MulHom.id X) = 𝟙 (of X) := rfl
+
+@[to_additive (attr := simp)]
+lemma ofHom_comp {X Y Z : Type u} [Semigroup X] [Semigroup Y] [Semigroup Z]
+    (f : X →ₙ* Y) (g : Y →ₙ* Z) :
+    ofHom (g.comp f) = ofHom f ≫ ofHom g :=
+  rfl
+
+@[to_additive]
+lemma ofHom_apply {X Y : Type u} [Semigroup X] [Semigroup Y] (f : X →ₙ* Y) (x : X) :
+    (ofHom f) x = f x := rfl
+
+@[to_additive (attr := simp)]
+lemma inv_hom_apply {X Y : Semigrp} (e : X ≅ Y) (x : X) : e.inv (e.hom x) = x := by
+  rw [← comp_apply]
+  simp
+
+@[to_additive (attr := simp)]
+lemma hom_inv_apply {X Y : Semigrp} (e : X ≅ Y) (s : Y) : e.hom (e.inv s) = s := by
+  rw [← comp_apply]
+  simp
 
 @[to_additive (attr := simp)]
 lemma mulEquiv_coe_eq {X Y : Type _} [Semigroup X] [Semigroup Y] (e : X ≃* Y) :
-    (@DFunLike.coe (Semigrp.of X ⟶ Semigrp.of Y) _ (fun _ => (forget Semigrp).obj _)
-      HasForget.instFunLike (e : X →ₙ* Y) : X → Y) = ↑e :=
-  rfl
-
-/-- Typecheck a `MulHom` as a morphism in `Semigrp`. -/
-@[to_additive]
-def ofHom {X Y : Type u} [Semigroup X] [Semigroup Y] (f : X →ₙ* Y) : of X ⟶ of Y :=
-  f
-
-/-- Typecheck an `AddHom` as a morphism in `AddSemigrp`. -/
-add_decl_doc AddSemigrp.ofHom
-
-@[to_additive]
-theorem ofHom_apply {X Y : Type u} [Semigroup X] [Semigroup Y] (f : X →ₙ* Y) (x : X) :
-    ofHom f x = f x :=
+    (ofHom (e : X →ₙ* Y)).hom = ↑e :=
   rfl
 
 @[to_additive]
@@ -190,8 +361,10 @@ instance : Inhabited Semigrp :=
   ⟨Semigrp.of PEmpty⟩
 
 @[to_additive]
-instance hasForgetToMagmaCat : HasForget₂ Semigrp MagmaCat :=
-  BundledHom.forget₂ _ _
+instance hasForgetToMagmaCat : HasForget₂ Semigrp MagmaCat where
+  forget₂ :=
+    { obj R := MagmaCat.of R
+      map f := MagmaCat.ofHom f.hom }
 
 end Semigrp
 
@@ -205,12 +378,8 @@ variable [Mul X] [Mul Y]
 @[to_additive (attr := simps)
       "Build an isomorphism in the category `AddMagmaCat` from an `AddEquiv` between `Add`s."]
 def MulEquiv.toMagmaCatIso (e : X ≃* Y) : MagmaCat.of X ≅ MagmaCat.of Y where
-  hom := e.toMulHom
-  inv := e.symm.toMulHom
-  hom_inv_id := by
-    ext
-    simp_rw [CategoryTheory.comp_apply, toMulHom_eq_coe, MagmaCat.mulEquiv_coe_eq, symm_apply_apply,
-      CategoryTheory.id_apply]
+  hom := MagmaCat.ofHom e.toMulHom
+  inv := MagmaCat.ofHom e.symm.toMulHom
 
 end
 
@@ -223,8 +392,8 @@ variable [Semigroup X] [Semigroup Y]
   "Build an isomorphism in the category
   `AddSemigroup` from an `AddEquiv` between `AddSemigroup`s."]
 def MulEquiv.toSemigrpIso (e : X ≃* Y) : Semigrp.of X ≅ Semigrp.of Y where
-  hom := e.toMulHom
-  inv := e.symm.toMulHom
+  hom := Semigrp.ofHom e.toMulHom
+  inv := Semigrp.ofHom e.symm.toMulHom
 
 end
 
@@ -234,13 +403,13 @@ namespace CategoryTheory.Iso
 @[to_additive
       "Build an `AddEquiv` from an isomorphism in the category `AddMagmaCat`."]
 def magmaCatIsoToMulEquiv {X Y : MagmaCat} (i : X ≅ Y) : X ≃* Y :=
-  MulHom.toMulEquiv i.hom i.inv i.hom_inv_id i.inv_hom_id
+  MulHom.toMulEquiv i.hom.hom i.inv.hom (by ext; simp) (by ext; simp)
 
 /-- Build a `MulEquiv` from an isomorphism in the category `Semigroup`. -/
 @[to_additive
   "Build an `AddEquiv` from an isomorphism in the category `AddSemigroup`."]
 def semigrpIsoToMulEquiv {X Y : Semigrp} (i : X ≅ Y) : X ≃* Y :=
-  MulHom.toMulEquiv i.hom i.inv i.hom_inv_id i.inv_hom_id
+  MulHom.toMulEquiv i.hom.hom i.inv.hom (by ext; simp) (by ext; simp)
 
 end CategoryTheory.Iso
 
@@ -268,14 +437,14 @@ def mulEquivIsoSemigrpIso {X Y : Type u} [Semigroup X] [Semigroup Y] :
 instance MagmaCat.forgetReflectsIsos : (forget MagmaCat.{u}).ReflectsIsomorphisms where
   reflects {X Y} f _ := by
     let i := asIso ((forget MagmaCat).map f)
-    let e : X ≃* Y := { f, i.toEquiv with }
+    let e : X ≃* Y := { f.hom, i.toEquiv with }
     exact e.toMagmaCatIso.isIso_hom
 
 @[to_additive]
 instance Semigrp.forgetReflectsIsos : (forget Semigrp.{u}).ReflectsIsomorphisms where
   reflects {X Y} f _ := by
     let i := asIso ((forget Semigrp).map f)
-    let e : X ≃* Y := { f, i.toEquiv with }
+    let e : X ≃* Y := { f.hom, i.toEquiv with }
     exact e.toSemigrpIso.isIso_hom
 
 -- Porting note: this was added in order to ensure that `forget₂ CommMonCat MonCat`
@@ -283,7 +452,7 @@ instance Semigrp.forgetReflectsIsos : (forget Semigrp.{u}).ReflectsIsomorphisms 
 -- we could have used `CategoryTheory.HasForget.ReflectsIso` alternatively
 @[to_additive]
 instance Semigrp.forget₂_full : (forget₂ Semigrp MagmaCat).Full where
-  map_surjective f := ⟨f, rfl⟩
+  map_surjective f := ⟨ofHom f.hom, rfl⟩
 
 /-!
 Once we've shown that the forgetful functors to type reflect isomorphisms,

--- a/MathlibTest/CategoryTheory/ConcreteCategory/Semigrp.lean
+++ b/MathlibTest/CategoryTheory/ConcreteCategory/Semigrp.lean
@@ -1,0 +1,47 @@
+import Mathlib.Algebra.Category.Semigrp.Basic
+
+universe v u
+
+open CategoryTheory Semigrp
+
+set_option maxHeartbeats 10000
+set_option synthInstance.maxHeartbeats 2000
+
+/- We test if all the coercions and `map_mul` lemmas trigger correctly. -/
+
+example (X : Type u) [Semigroup X] : ⇑(𝟙 (of X)) = id := by simp
+
+example {X Y : Type u} [Semigroup X] [Semigroup Y] (f : X →ₙ* Y) :
+    ⇑(ofHom f) = ⇑f := by simp
+
+example {X Y : Type u} [Semigroup X] [Semigroup Y] (f : X →ₙ* Y)
+    (x : X) : (ofHom f) x = f x := by simp
+
+example {X Y Z : Semigrp} (f : X ⟶ Y) (g : Y ⟶ Z) : ⇑(f ≫ g) = ⇑g ∘ ⇑f := by simp
+
+example {X Y Z : Type u} [Semigroup X] [Semigroup Y] [Semigroup Z]
+    (f : X →ₙ* Y) (g : Y →ₙ* Z) :
+    ⇑(ofHom f ≫ ofHom g) = g ∘ f := by simp
+
+example {X Y : Type u} [Semigroup X] [Semigroup Y] {Z : Semigrp}
+    (f : X →ₙ* Y) (g : of Y ⟶ Z) :
+    ⇑(ofHom f ≫ g) = g ∘ f := by simp
+
+example {X Y : Semigrp} {Z : Type u} [Semigroup Z] (f : X ⟶ Y) (g : Y ⟶ of Z) :
+    ⇑(f ≫ g) = g ∘ f := by simp
+
+example {Y Z : Semigrp} {X : Type u} [Semigroup X] (f : of X ⟶ Y) (g : Y ⟶ Z) :
+    ⇑(f ≫ g) = g ∘ f := by simp
+
+example {X Y Z : Semigrp} (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) : (f ≫ g) x = g (f x) := by simp
+
+example {X Y : Semigrp} (e : X ≅ Y) (x : X) : e.inv (e.hom x) = x := by simp
+
+example {X Y : Semigrp} (e : X ≅ Y) (y : Y) : e.hom (e.inv y) = y := by simp
+
+example (X : Semigrp) : ⇑(𝟙 X) = id := by simp
+
+example {X : Type*} [Semigroup X] : ⇑(MulHom.id X) = id := by simp
+
+example {M N : Semigrp} (f : M ⟶ N) (x y : M) : f (x * y) = f x * f y := by
+  simp


### PR DESCRIPTION
Very straightforward, essentially copypasting the design of `MonCat` back onto `MagmaCat` and `Semigrp`. We can probably do without this amount of `dsimp` lemmas, they should all be pretty easy to prove from generic `ConcreteCategory` results, but it doesn't hurt to have them in any case.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
