### PR TITLE
[Merged by Bors] - feat(Tactic/Linter): options to in/exclude definitions and private decls

### DIFF
--- a/Mathlib/Tactic/Linter/UpstreamableDecl.lean
+++ b/Mathlib/Tactic/Linter/UpstreamableDecl.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa, Anne Baanen
 -/
 import ImportGraph.Imports
-import Mathlib.Lean.Expr.Basic
 import Mathlib.Tactic.MinImports
 
 /-! # The `upstreamableDecl` linter

--- a/Mathlib/Tactic/Linter/UpstreamableDecl.lean
+++ b/Mathlib/Tactic/Linter/UpstreamableDecl.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa, Anne Baanen
 -/
 import ImportGraph.Imports
+import Mathlib.Lean.Expr.Basic
 import Mathlib.Tactic.MinImports
 
 /-! # The `upstreamableDecl` linter
@@ -56,15 +57,34 @@ namespace Mathlib.Linter
 The `upstreamableDecl` linter detects declarations that could be moved to a file higher up in the
 import hierarchy. If this is the case, it emits a warning.
 
+By default, this linter will not fire on definitions, nor private declarations:
+see options `linter.upstreamableDecl.defs` and `linter.upstreamableDecl.private`.
+
 This is intended to assist with splitting files.
+-/
+register_option linter.upstreamableDecl : Bool := {
+  defValue := false
+  descr := "enable the upstreamableDecl linter"
+}
+
+/--
+If set to `true`, the `upstreamableDecl` linter will add warnings on definitions.
 
 The linter does not place a warning on any declaration depending on a definition in the current file
 (while it does place a warning on the definition itself), since we often create a new file for a
 definition on purpose.
 -/
-register_option linter.upstreamableDecl : Bool := {
+register_option linter.upstreamableDecl.defs : Bool := {
   defValue := false
-  descr := "enable the upstreamableDecl linter"
+  descr := "upstreamableDecl warns on definitions"
+}
+
+/--
+If set to `true`, the `upstreamableDecl` linter will add warnings on private declarations.
+-/
+register_option linter.upstreamableDecl.private : Bool := {
+  defValue := false
+  descr := "upstreamableDecl warns on private declarations"
 }
 
 namespace DoubleImports
@@ -75,10 +95,21 @@ def upstreamableDeclLinter : Linter where run := withSetOptionIn fun stx ↦ do
       return
     if (← get).messages.hasErrors then
       return
+    let skipDef := !Linter.getLinterValue linter.upstreamableDecl.defs (← getOptions)
+    let skipPrivate := !Linter.getLinterValue linter.upstreamableDecl.private (← getOptions)
     if stx == (← `(command| set_option $(mkIdent `linter.upstreamableDecl) true)) then return
     let env ← getEnv
     let id ← getId stx
     if id != .missing then
+      -- Skip defs and private decls by default.
+      let names ← resolveGlobalConst id
+      if (skipDef && names.any fun name =>
+         if let some constInfo := env.find? name
+         then !(constInfo.isTheorem || constInfo.isCtor)
+         else true) ||
+         (skipPrivate && names.any isPrivateName) then
+        return
+
       let minImports := getIrredundantImports env (← getAllImports stx id)
       match minImports with
       | ⟨(RBNode.node _ .leaf upstream _ .leaf), _⟩ => do

--- a/MathlibTest/MinImports.lean
+++ b/MathlibTest/MinImports.lean
@@ -152,6 +152,10 @@ note: this linter can be disabled with `set_option linter.upstreamableDecl false
 #guard_msgs in
 theorem propose_to_move_this_theorem : (0 : ℕ) = 0 := rfl
 
+-- By default, the linter does not warn on definitions.
+def dont_propose_to_move_this_def : ℕ := 0
+
+set_option linter.upstreamableDecl.defs true in
 /--
 warning: Consider moving this declaration to the module Mathlib.Data.Nat.Notation.
 note: this linter can be disabled with `set_option linter.upstreamableDecl false`
@@ -165,12 +169,48 @@ theorem theorem_with_local_def : propose_to_move_this_def = 0 := rfl
 
 -- This definition depends on definitions in two different files, so should not be moved.
 #guard_msgs in
-def def_with_multiple_dependencies :=
+theorem theorem_with_multiple_dependencies : True :=
   let _ := Mathlib.Meta.FunProp.funPropAttr
   let _ := Mathlib.Meta.NormNum.evalNatDvd
-  false
+  trivial
 
-/-! Structures and inductives should be treated just like definitions. -/
+-- Private declarations shouldn't get a warning by default.
+private theorem private_theorem : (0 : ℕ) = 0 := rfl
+
+-- But we can enable the option.
+set_option linter.upstreamableDecl.private true in
+/--
+warning: Consider moving this declaration to the module Mathlib.Data.Nat.Notation.
+note: this linter can be disabled with `set_option linter.upstreamableDecl false`
+-/
+#guard_msgs in
+private theorem propose_to_move_this_private_theorem : (0 : ℕ) = 0 := rfl
+
+-- Private declarations shouldn't get a warning by default, even if definitions get a warning.
+set_option linter.upstreamableDecl.defs true in
+private def private_def : ℕ := 0
+
+-- But if we enable both options, they should.
+set_option linter.upstreamableDecl.defs true in
+set_option linter.upstreamableDecl.private true in
+/--
+warning: Consider moving this declaration to the module Mathlib.Data.Nat.Notation.
+note: this linter can be disabled with `set_option linter.upstreamableDecl false`
+-/
+#guard_msgs in
+private def propose_to_move_this_private_def : ℕ := 0
+
+/-! Structures and inductives should be treated just like definitions:
+no warnings by default, unless we enable the option. -/
+
+structure DontProposeToMoveThisStructure where
+  foo : ℕ
+
+inductive DontProposeToMoveThisInductive where
+| foo : ℕ → DontProposeToMoveThisInductive
+| bar : ℕ → DontProposeToMoveThisInductive → DontProposeToMoveThisInductive
+
+set_option linter.upstreamableDecl.defs true
 
 /--
 


### PR DESCRIPTION
Zulip thread: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/late.20imports

Two new options:
* `linter.upstreamableDecl.defs` (default: `false`): warn if a definition can be upstreamed
* `linter.upstreamableDecl.private` (default: `false`): warn if a private declaration can be upstreamed


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
