### PR TITLE
WIP: generalise lemmas to ENorm

### DIFF
--- a/Mathlib/Analysis/NormedSpace/IndicatorFunction.lean
+++ b/Mathlib/Analysis/NormedSpace/IndicatorFunction.lean
@@ -7,9 +7,9 @@ import Mathlib.Algebra.Order.Group.Indicator
 import Mathlib.Analysis.Normed.Group.Basic
 
 /-!
-# Indicator function and norm
+# Indicator function and (e)norm
 
-This file contains a few simple lemmas about `Set.indicator` and `norm`.
+This file contains a few simple lemmas about `Set.indicator`, `norm` and `enorm`.
 
 ## Tags
 indicator, norm
@@ -36,9 +36,21 @@ theorem norm_indicator_le_of_subset (h : s ⊆ t) (f : α → E) (a : α) :
   simp only [norm_indicator_eq_indicator_norm]
   exact indicator_le_indicator_of_subset ‹_› (fun _ => norm_nonneg _) _
 
+theorem enorm_indicator_le_of_subset (h : s ⊆ t) (f : α → E) (a : α) :
+    ‖indicator s f a‖ₑ ≤ ‖indicator t f a‖ₑ := by
+  simp only [enorm_indicator_eq_indicator_enorm]
+  apply indicator_le_indicator_of_subset ‹_› (zero_le _)
+
 theorem indicator_norm_le_norm_self : indicator s (fun a => ‖f a‖) a ≤ ‖f a‖ :=
   indicator_le_self' (fun _ _ => norm_nonneg _) a
+
+theorem indicator_enorm_le_enorm_self : indicator s (fun a => ‖f a‖ₑ) a ≤ ‖f a‖ₑ :=
+  indicator_le_self' (fun _ _ ↦ zero_le _) a
 
 theorem norm_indicator_le_norm_self : ‖indicator s f a‖ ≤ ‖f a‖ := by
   rw [norm_indicator_eq_indicator_norm]
   apply indicator_norm_le_norm_self
+
+theorem enorm_indicator_le_enorm_self : ‖indicator s f a‖ₑ ≤ ‖f a‖ₑ := by
+  rw [enorm_indicator_eq_indicator_enorm]
+  apply indicator_enorm_le_enorm_self

--- a/Mathlib/MeasureTheory/Function/L2Space.lean
+++ b/Mathlib/MeasureTheory/Function/L2Space.lean
@@ -20,9 +20,7 @@ is also an inner product space, with inner product defined as `inner f g = ∫ a
 * `integrable_inner` : for `f` and `g` in `Lp E 2 μ`, the pointwise inner product
  `fun x ↦ ⟪f x, g x⟫` is integrable.
 * `L2.innerProductSpace` : `Lp E 2 μ` is an inner product space.
-
 -/
-
 
 noncomputable section
 
@@ -160,7 +158,7 @@ private theorem norm_sq_eq_inner' (f : α →₂[μ] E) : ‖f‖ ^ 2 = RCLike.r
   · rw [← ENNReal.rpow_natCast, eLpNorm_eq_eLpNorm' two_ne_zero ENNReal.ofNat_ne_top, eLpNorm', ←
       ENNReal.rpow_mul, one_div, h_two]
     simp [enorm_eq_nnnorm]
-  · refine (lintegral_rpow_enorm_lt_top_of_eLpNorm'_lt_top zero_lt_two ?_).ne
+  · refine (lintegral_rpow_enorm_lt_top_of_eLpNorm'_lt_top zero_lt_two (ε := E) ?_).ne
     rw [← h_two, ← eLpNorm_eq_eLpNorm' two_ne_zero ENNReal.ofNat_ne_top]
     exact Lp.eLpNorm_lt_top f
 

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -499,7 +499,8 @@ theorem MonotoneOn.memℒp_top (hmono : MonotoneOn f s) {a b : X}
   apply Memℒp.mono A (aemeasurable_restrict_of_monotoneOn h's hmono).aestronglyMeasurable
   apply (ae_restrict_iff' h's).mpr
   apply ae_of_all _ fun y hy ↦ ?_
-  exact (hC _ (mem_image_of_mem f hy)).trans (le_abs_self _)
+  -- TODO: hC has the wrong type, and this causes an error
+  sorry -- was: exact (hC _ (mem_image_of_mem f hy)).trans (le_abs_self _)
 
 theorem MonotoneOn.memℒp_of_measure_ne_top (hmono : MonotoneOn f s) {a b : X}
     (ha : IsLeast s a) (hb : IsGreatest s b) (hs : μ s ≠ ∞) (h's : MeasurableSet s) :

--- a/Mathlib/MeasureTheory/Function/LpOrder.lean
+++ b/Mathlib/MeasureTheory/Function/LpOrder.lean
@@ -58,12 +58,12 @@ instance instOrderedAddCommGroup : OrderedAddCommGroup (Lp E p μ) :=
 
 theorem _root_.MeasureTheory.Memℒp.sup {f g : α → E} (hf : Memℒp f p μ) (hg : Memℒp g p μ) :
     Memℒp (f ⊔ g) p μ :=
-  Memℒp.mono' (hf.norm.add hg.norm) (hf.1.sup hg.1)
+  Memℒp.mono'' (hf.norm.add hg.norm) (hf.1.sup hg.1)
     (Filter.Eventually.of_forall fun x => norm_sup_le_add (f x) (g x))
 
 theorem _root_.MeasureTheory.Memℒp.inf {f g : α → E} (hf : Memℒp f p μ) (hg : Memℒp g p μ) :
     Memℒp (f ⊓ g) p μ :=
-  Memℒp.mono' (hf.norm.add hg.norm) (hf.1.inf hg.1)
+  Memℒp.mono'' (hf.norm.add hg.norm) (hf.1.inf hg.1)
     (Filter.Eventually.of_forall fun x => norm_inf_le_add (f x) (g x))
 
 theorem _root_.MeasureTheory.Memℒp.abs {f : α → E} (hf : Memℒp f p μ) : Memℒp |f| p μ :=
@@ -94,7 +94,7 @@ noncomputable instance instNormedLatticeAddCommGroup [Fact (1 ≤ p)] :
     solid := fun f g hfg => by
       rw [← coeFn_le] at hfg
       simp_rw [Lp.norm_def, ENNReal.toReal_le_toReal (Lp.eLpNorm_ne_top f) (Lp.eLpNorm_ne_top g)]
-      refine eLpNorm_mono_ae ?_
+      refine eLpNorm_mono_ae' ?_
       filter_upwards [hfg, Lp.coeFn_abs f, Lp.coeFn_abs g] with x hx hxf hxg
       rw [hxf, hxg] at hx
       exact HasSolidNorm.solid hx }

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -70,7 +70,7 @@ this quantity is finite -/
 def eLpNorm' {_ : MeasurableSpace α} (f : α → ε) (q : ℝ) (μ : Measure α) : ℝ≥0∞ :=
   (∫⁻ a, ‖f a‖ₑ ^ q ∂μ) ^ (1 / q)
 
-lemma eLpNorm'_eq_lintegral_enorm {_ : MeasurableSpace α} (f : α → F) (q : ℝ) (μ : Measure α) :
+lemma eLpNorm'_eq_lintegral_enorm {_ : MeasurableSpace α} (f : α → ε) (q : ℝ) (μ : Measure α) :
     eLpNorm' f q μ = (∫⁻ a, ‖f a‖ₑ ^ q ∂μ) ^ (1 / q) :=
   rfl
 
@@ -81,7 +81,7 @@ alias eLpNorm'_eq_lintegral_nnnorm := eLpNorm'_eq_lintegral_enorm
 def eLpNormEssSup {_ : MeasurableSpace α} (f : α → ε) (μ : Measure α) :=
   essSup (fun x => ‖f x‖ₑ) μ
 
-lemma eLpNormEssSup_eq_essSup_enorm {_ : MeasurableSpace α} (f : α → F) (μ : Measure α) :
+lemma eLpNormEssSup_eq_essSup_enorm {_ : MeasurableSpace α} (f : α → ε) (μ : Measure α) :
     eLpNormEssSup f μ = essSup (‖f ·‖ₑ) μ := rfl
 
 @[deprecated (since := "2025-01-17")]
@@ -93,25 +93,25 @@ def eLpNorm {_ : MeasurableSpace α}
     (f : α → ε) (p : ℝ≥0∞) (μ : Measure α := by volume_tac) : ℝ≥0∞ :=
   if p = 0 then 0 else if p = ∞ then eLpNormEssSup f μ else eLpNorm' f (ENNReal.toReal p) μ
 
-theorem eLpNorm_eq_eLpNorm' (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) {f : α → F} :
+theorem eLpNorm_eq_eLpNorm' (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) {f : α → ε} :
     eLpNorm f p μ = eLpNorm' f (ENNReal.toReal p) μ := by simp [eLpNorm, hp_ne_zero, hp_ne_top]
 
-lemma eLpNorm_nnreal_eq_eLpNorm' {f : α → F} {p : ℝ≥0} (hp : p ≠ 0) :
+lemma eLpNorm_nnreal_eq_eLpNorm' {f : α → ε} {p : ℝ≥0} (hp : p ≠ 0) :
     eLpNorm f p μ = eLpNorm' f p μ :=
   eLpNorm_eq_eLpNorm' (by exact_mod_cast hp) ENNReal.coe_ne_top
 
-theorem eLpNorm_eq_lintegral_rpow_enorm (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) {f : α → F} :
+theorem eLpNorm_eq_lintegral_rpow_enorm (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) {f : α → ε} :
     eLpNorm f p μ = (∫⁻ x, ‖f x‖ₑ ^ p.toReal ∂μ) ^ (1 / p.toReal) := by
   rw [eLpNorm_eq_eLpNorm' hp_ne_zero hp_ne_top, eLpNorm'_eq_lintegral_enorm]
 
 @[deprecated (since := "2025-01-17")]
 alias eLpNorm_eq_lintegral_rpow_nnnorm := eLpNorm_eq_lintegral_rpow_enorm
 
-lemma eLpNorm_nnreal_eq_lintegral {f : α → F} {p : ℝ≥0} (hp : p ≠ 0) :
+lemma eLpNorm_nnreal_eq_lintegral {f : α → ε} {p : ℝ≥0} (hp : p ≠ 0) :
     eLpNorm f p μ = (∫⁻ x, ‖f x‖ₑ ^ (p : ℝ) ∂μ) ^ (1 / (p : ℝ)) :=
   eLpNorm_nnreal_eq_eLpNorm' hp
 
-theorem eLpNorm_one_eq_lintegral_enorm {f : α → F} : eLpNorm f 1 μ = ∫⁻ x, ‖f x‖ₑ ∂μ := by
+theorem eLpNorm_one_eq_lintegral_enorm {f : α → ε} : eLpNorm f 1 μ = ∫⁻ x, ‖f x‖ₑ ∂μ := by
   simp_rw [eLpNorm_eq_lintegral_rpow_enorm one_ne_zero ENNReal.coe_ne_top, ENNReal.one_toReal,
     one_div_one, ENNReal.rpow_one]
 
@@ -119,7 +119,7 @@ theorem eLpNorm_one_eq_lintegral_enorm {f : α → F} : eLpNorm f 1 μ = ∫⁻ 
 alias eLpNorm_one_eq_lintegral_nnnorm := eLpNorm_one_eq_lintegral_enorm
 
 @[simp]
-theorem eLpNorm_exponent_top {f : α → F} : eLpNorm f ∞ μ = eLpNormEssSup f μ := by simp [eLpNorm]
+theorem eLpNorm_exponent_top {f : α → ε} : eLpNorm f ∞ μ = eLpNormEssSup f μ := by simp [eLpNorm]
 
 /-- The property that `f:α→E` is ae strongly measurable and `(∫ ‖f a‖^p ∂μ)^(1/p)` is finite
 if `p < ∞`, or `essSup f < ∞` if `p = ∞`. -/
@@ -127,11 +127,11 @@ def Memℒp {α} {_ : MeasurableSpace α} [TopologicalSpace ε] (f : α → ε) 
     (μ : Measure α := by volume_tac) : Prop :=
   AEStronglyMeasurable f μ ∧ eLpNorm f p μ < ∞
 
-theorem Memℒp.aestronglyMeasurable {f : α → E} {p : ℝ≥0∞} (h : Memℒp f p μ) :
+theorem Memℒp.aestronglyMeasurable [TopologicalSpace ε] {f : α → ε} {p : ℝ≥0∞} (h : Memℒp f p μ) :
     AEStronglyMeasurable f μ :=
   h.1
 
-theorem lintegral_rpow_enorm_eq_rpow_eLpNorm' {f : α → F} (hq0_lt : 0 < q) :
+theorem lintegral_rpow_enorm_eq_rpow_eLpNorm' {f : α → ε} (hq0_lt : 0 < q) :
     ∫⁻ a, ‖f a‖ₑ ^ q ∂μ = eLpNorm' f q μ ^ q := by
   rw [eLpNorm'_eq_lintegral_enorm, ← ENNReal.rpow_mul, one_div, inv_mul_cancel₀, ENNReal.rpow_one]
   exact hq0_lt.ne'
@@ -139,7 +139,7 @@ theorem lintegral_rpow_enorm_eq_rpow_eLpNorm' {f : α → F} (hq0_lt : 0 < q) :
 @[deprecated (since := "2025-01-17")]
 alias lintegral_rpow_nnnorm_eq_rpow_eLpNorm' := lintegral_rpow_enorm_eq_rpow_eLpNorm'
 
-lemma eLpNorm_nnreal_pow_eq_lintegral {f : α → F} {p : ℝ≥0} (hp : p ≠ 0) :
+lemma eLpNorm_nnreal_pow_eq_lintegral {f : α → ε} {p : ℝ≥0} (hp : p ≠ 0) :
     eLpNorm f p μ ^ (p : ℝ) = ∫⁻ x, ‖f x‖ₑ ^ (p : ℝ) ∂μ := by
   simp [eLpNorm_eq_eLpNorm' (by exact_mod_cast hp) ENNReal.coe_ne_top,
     lintegral_rpow_enorm_eq_rpow_eLpNorm' ((NNReal.coe_pos.trans pos_iff_ne_zero).mpr hp)]
@@ -148,13 +148,15 @@ end ℒpSpaceDefinition
 
 section Top
 
-theorem Memℒp.eLpNorm_lt_top {f : α → E} (hfp : Memℒp f p μ) : eLpNorm f p μ < ∞ :=
+theorem Memℒp.eLpNorm_lt_top [TopologicalSpace ε] {f : α → ε} (hfp : Memℒp f p μ) :
+    eLpNorm f p μ < ∞ :=
   hfp.2
 
-theorem Memℒp.eLpNorm_ne_top {f : α → E} (hfp : Memℒp f p μ) : eLpNorm f p μ ≠ ∞ :=
+theorem Memℒp.eLpNorm_ne_top [TopologicalSpace ε] {f : α → ε} (hfp : Memℒp f p μ) :
+    eLpNorm f p μ ≠ ∞ :=
   ne_of_lt hfp.2
 
-theorem lintegral_rpow_enorm_lt_top_of_eLpNorm'_lt_top {f : α → F} (hq0_lt : 0 < q)
+theorem lintegral_rpow_enorm_lt_top_of_eLpNorm'_lt_top {f : α → ε} (hq0_lt : 0 < q)
     (hfq : eLpNorm' f q μ < ∞) : ∫⁻ a, ‖f a‖ₑ ^ q ∂μ < ∞ := by
   rw [lintegral_rpow_enorm_eq_rpow_eLpNorm' hq0_lt]
   exact ENNReal.rpow_lt_top_of_nonneg (le_of_lt hq0_lt) (ne_of_lt hfq)
@@ -163,7 +165,7 @@ theorem lintegral_rpow_enorm_lt_top_of_eLpNorm'_lt_top {f : α → F} (hq0_lt : 
 alias lintegral_rpow_nnnorm_lt_top_of_eLpNorm'_lt_top' :=
   lintegral_rpow_enorm_lt_top_of_eLpNorm'_lt_top
 
-theorem lintegral_rpow_enorm_lt_top_of_eLpNorm_lt_top {f : α → F} (hp_ne_zero : p ≠ 0)
+theorem lintegral_rpow_enorm_lt_top_of_eLpNorm_lt_top {f : α → ε} (hp_ne_zero : p ≠ 0)
     (hp_ne_top : p ≠ ∞) (hfp : eLpNorm f p μ < ∞) : ∫⁻ a, ‖f a‖ₑ ^ p.toReal ∂μ < ∞ := by
   apply lintegral_rpow_enorm_lt_top_of_eLpNorm'_lt_top
   · exact ENNReal.toReal_pos hp_ne_zero hp_ne_top
@@ -173,7 +175,7 @@ theorem lintegral_rpow_enorm_lt_top_of_eLpNorm_lt_top {f : α → F} (hp_ne_zero
 alias lintegral_rpow_nnnorm_lt_top_of_eLpNorm_lt_top :=
   lintegral_rpow_enorm_lt_top_of_eLpNorm_lt_top
 
-theorem eLpNorm_lt_top_iff_lintegral_rpow_nnnorm_lt_top {f : α → F} (hp_ne_zero : p ≠ 0)
+theorem eLpNorm_lt_top_iff_lintegral_rpow_nnnorm_lt_top {f : α → ε} (hp_ne_zero : p ≠ 0)
     (hp_ne_top : p ≠ ∞) : eLpNorm f p μ < ∞ ↔ ∫⁻ a, (‖f a‖ₑ) ^ p.toReal ∂μ < ∞ :=
   ⟨lintegral_rpow_enorm_lt_top_of_eLpNorm_lt_top hp_ne_zero hp_ne_top, by
     intro h
@@ -187,14 +189,14 @@ end Top
 section Zero
 
 @[simp]
-theorem eLpNorm'_exponent_zero {f : α → F} : eLpNorm' f 0 μ = 1 := by
+theorem eLpNorm'_exponent_zero {f : α → ε} : eLpNorm' f 0 μ = 1 := by
   rw [eLpNorm', div_zero, ENNReal.rpow_zero]
 
 @[simp]
-theorem eLpNorm_exponent_zero {f : α → F} : eLpNorm f 0 μ = 0 := by simp [eLpNorm]
+theorem eLpNorm_exponent_zero {f : α → ε} : eLpNorm f 0 μ = 0 := by simp [eLpNorm]
 
 @[simp]
-theorem memℒp_zero_iff_aestronglyMeasurable {f : α → E} :
+theorem memℒp_zero_iff_aestronglyMeasurable [TopologicalSpace ε] {f : α → ε} :
     Memℒp f 0 μ ↔ AEStronglyMeasurable f μ := by simp [Memℒp, eLpNorm_exponent_zero]
 
 @[simp]
@@ -233,21 +235,21 @@ theorem eLpNorm_zero' : eLpNorm (fun _ : α => (0 : F)) p μ = 0 := by convert e
 
 variable [MeasurableSpace α]
 
-theorem eLpNorm'_measure_zero_of_pos {f : α → F} (hq_pos : 0 < q) :
+theorem eLpNorm'_measure_zero_of_pos {f : α → ε} (hq_pos : 0 < q) :
     eLpNorm' f q (0 : Measure α) = 0 := by simp [eLpNorm', hq_pos]
 
-theorem eLpNorm'_measure_zero_of_exponent_zero {f : α → F} : eLpNorm' f 0 (0 : Measure α) = 1 := by
+theorem eLpNorm'_measure_zero_of_exponent_zero {f : α → ε} : eLpNorm' f 0 (0 : Measure α) = 1 := by
   simp [eLpNorm']
 
-theorem eLpNorm'_measure_zero_of_neg {f : α → F} (hq_neg : q < 0) :
+theorem eLpNorm'_measure_zero_of_neg {f : α → ε} (hq_neg : q < 0) :
     eLpNorm' f q (0 : Measure α) = ∞ := by simp [eLpNorm', hq_neg]
 
 @[simp]
-theorem eLpNormEssSup_measure_zero {f : α → F} : eLpNormEssSup f (0 : Measure α) = 0 := by
+theorem eLpNormEssSup_measure_zero {f : α → ε} : eLpNormEssSup f (0 : Measure α) = 0 := by
   simp [eLpNormEssSup]
 
 @[simp]
-theorem eLpNorm_measure_zero {f : α → F} : eLpNorm f p (0 : Measure α) = 0 := by
+theorem eLpNorm_measure_zero {f : α → ε} : eLpNorm f p (0 : Measure α) = 0 := by
   by_cases h0 : p = 0
   · simp [h0]
   by_cases h_top : p = ∞
@@ -255,7 +257,8 @@ theorem eLpNorm_measure_zero {f : α → F} : eLpNorm f p (0 : Measure α) = 0 :
   rw [← Ne] at h0
   simp [eLpNorm_eq_eLpNorm' h0 h_top, eLpNorm', ENNReal.toReal_pos h0 h_top]
 
-@[simp] lemma memℒp_measure_zero {f : α → F} : Memℒp f p (0 : Measure α) := by simp [Memℒp]
+@[simp] lemma memℒp_measure_zero [TopologicalSpace ε] {f : α → ε} : Memℒp f p (0 : Measure α) := by
+  simp [Memℒp]
 
 end Zero
 
@@ -286,7 +289,7 @@ end Neg
 
 section Const
 
-theorem eLpNorm'_const (c : F) (hq_pos : 0 < q) :
+theorem eLpNorm'_const (c : ε) (hq_pos : 0 < q) :
     eLpNorm' (fun _ : α => c) q μ = ‖c‖ₑ * μ Set.univ ^ (1 / q) := by
   rw [eLpNorm'_eq_lintegral_enorm, lintegral_const,
     ENNReal.mul_rpow_of_nonneg _ _ (by simp [hq_pos.le] : 0 ≤ 1 / q)]
@@ -306,19 +309,19 @@ theorem eLpNorm'_const' [IsFiniteMeasure μ] (c : F) (hc_ne_zero : c ≠ 0) (hq_
   · rw [Ne, ENNReal.rpow_eq_top_iff, not_or, not_and_or, not_and_or]
     simp [hc_ne_zero]
 
-theorem eLpNormEssSup_const (c : F) (hμ : μ ≠ 0) : eLpNormEssSup (fun _ : α => c) μ = ‖c‖ₑ := by
+theorem eLpNormEssSup_const (c : ε) (hμ : μ ≠ 0) : eLpNormEssSup (fun _ : α => c) μ = ‖c‖ₑ := by
   rw [eLpNormEssSup_eq_essSup_enorm, essSup_const _ hμ]
 
-theorem eLpNorm'_const_of_isProbabilityMeasure (c : F) (hq_pos : 0 < q) [IsProbabilityMeasure μ] :
+theorem eLpNorm'_const_of_isProbabilityMeasure (c : ε) (hq_pos : 0 < q) [IsProbabilityMeasure μ] :
     eLpNorm' (fun _ : α => c) q μ = ‖c‖ₑ := by simp [eLpNorm'_const c hq_pos, measure_univ]
 
-theorem eLpNorm_const (c : F) (h0 : p ≠ 0) (hμ : μ ≠ 0) :
+theorem eLpNorm_const (c : ε) (h0 : p ≠ 0) (hμ : μ ≠ 0) :
     eLpNorm (fun _ : α => c) p μ = ‖c‖ₑ * μ Set.univ ^ (1 / ENNReal.toReal p) := by
   by_cases h_top : p = ∞
   · simp [h_top, eLpNormEssSup_const c hμ]
   simp [eLpNorm_eq_eLpNorm' h0 h_top, eLpNorm'_const, ENNReal.toReal_pos h0 h_top]
 
-theorem eLpNorm_const' (c : F) (h0 : p ≠ 0) (h_top : p ≠ ∞) :
+theorem eLpNorm_const' (c : ε) (h0 : p ≠ 0) (h_top : p ≠ ∞) :
     eLpNorm (fun _ : α => c) p μ = ‖c‖ₑ * μ Set.univ ^ (1 / ENNReal.toReal p) := by
   simp [eLpNorm_eq_eLpNorm' h0 h_top, eLpNorm'_const, ENNReal.toReal_pos h0 h_top]
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -40,8 +40,8 @@ open TopologicalSpace MeasureTheory Filter
 
 open scoped NNReal ENNReal Topology ComplexConjugate
 
-variable {α ε E F G : Type*} {m m0 : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ} {μ ν : Measure α}
-  [NormedAddCommGroup E] [NormedAddCommGroup F] [NormedAddCommGroup G] [ENorm ε]
+variable {α ε ε' E F G : Type*} {m m0 : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ} {μ ν : Measure α}
+  [NormedAddCommGroup E] [NormedAddCommGroup F] [NormedAddCommGroup G] [ENorm ε] [ENorm ε']
 
 namespace MeasureTheory
 
@@ -366,13 +366,19 @@ end Const
 
 variable {f : α → F}
 
-lemma eLpNorm'_mono_nnnorm_ae {f : α → F} {g : α → G} (hq : 0 ≤ q) (h : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ ‖g x‖₊) :
+lemma eLpNorm'_mono_enorm_ae {f : α → ε} {g : α → ε'} (hq : 0 ≤ q) (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm' f q μ ≤ eLpNorm' g q μ := by
   simp only [eLpNorm'_eq_lintegral_enorm]
   gcongr ?_ ^ (1/q)
   refine lintegral_mono_ae (h.mono fun x hx => ?_)
-  dsimp [enorm]
   gcongr
+
+lemma eLpNorm'_mono_nnnorm_ae {f : α → F} {g : α → G} (hq : 0 ≤ q) (h : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ ‖g x‖₊) :
+    eLpNorm' f q μ ≤ eLpNorm' g q μ := by
+  apply eLpNorm'_mono_enorm_ae hq
+  dsimp [enorm]
+  simp_rw [ENNReal.coe_le_coe]
+  exact h
 
 theorem eLpNorm'_mono_ae {f : α → F} {g : α → G} (hq : 0 ≤ q) (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ ‖g x‖) :
     eLpNorm' f q μ ≤ eLpNorm' g q μ :=

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -1128,12 +1128,33 @@ theorem eLpNorm'_le_nnreal_smul_eLpNorm'_of_ae_le_mul {f : α → F} {g : α →
   simp_rw [ENNReal.coe_le_coe, ← NNReal.mul_rpow, NNReal.rpow_le_rpow_iff hp]
   exact h
 
+theorem eLpNorm'_le_nnreal_smul_eLpNorm'_of_ae_le_mul_enormWIP {f : α → ε} {g : α → ε'} {c : ℝ≥0}
+    (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ c * ‖g x‖ₑ) {p : ℝ} (hp : 0 < p) :
+    eLpNorm' f p μ ≤ c • eLpNorm' g p μ := by
+  simp_rw [eLpNorm'_eq_lintegral_enorm]
+  rw [← ENNReal.rpow_le_rpow_iff hp, ENNReal.smul_def, smul_eq_mul,
+    ENNReal.mul_rpow_of_nonneg _ _ hp.le]
+  simp_rw [← ENNReal.rpow_mul, one_div, inv_mul_cancel₀ hp.ne.symm, ENNReal.rpow_one, --enorm,
+    ← ENNReal.coe_rpow_of_nonneg _ hp.le, ← lintegral_const_mul' _ _ ENNReal.coe_ne_top,
+  ]--← ENNReal.coe_mul]
+  apply lintegral_mono_ae
+  --simp_rw [/-ENNReal.coe_le_coe,-/ ← NNReal.mul_rpow, NNReal.rpow_le_rpow_iff hp]
+  -- TODO: apply this, or so rw [ENNReal.rpow_le_rpow_iff hp]
+  sorry --exact h
+
 theorem eLpNormEssSup_le_nnreal_smul_eLpNormEssSup_of_ae_le_mul {f : α → F} {g : α → G} {c : ℝ≥0}
     (h : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ c * ‖g x‖₊) : eLpNormEssSup f μ ≤ c • eLpNormEssSup g μ :=
   calc
     essSup (‖f ·‖ₑ) μ ≤ essSup (fun x => (↑(c * ‖g x‖₊) : ℝ≥0∞)) μ :=
       essSup_mono_ae <| h.mono fun _ hx => ENNReal.coe_le_coe.mpr hx
     _ = essSup (c * ‖g ·‖ₑ) μ := by simp_rw [ENNReal.coe_mul, enorm]
+    _ = c • essSup (‖g ·‖ₑ) μ := ENNReal.essSup_const_mul
+
+theorem eLpNormEssSup_le_nnreal_smul_eLpNormEssSup_of_ae_le_mul_enormWIP {f : α → ε} {g : α → ε'} {c : ℝ≥0}
+    (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ c * ‖g x‖ₑ) : eLpNormEssSup f μ ≤ c • eLpNormEssSup g μ :=
+  calc
+    essSup (‖f ·‖ₑ) μ ≤ essSup (fun x => (↑(c * ‖g x‖ₑ) : ℝ≥0∞)) μ :=
+      essSup_mono_ae <| h.mono fun _ hx => hx
     _ = c • essSup (‖g ·‖ₑ) μ := ENNReal.essSup_const_mul
 
 theorem eLpNorm_le_nnreal_smul_eLpNorm_of_ae_le_mul {f : α → F} {g : α → G} {c : ℝ≥0}
@@ -1145,6 +1166,16 @@ theorem eLpNorm_le_nnreal_smul_eLpNorm_of_ae_le_mul {f : α → F} {g : α → G
     exact eLpNormEssSup_le_nnreal_smul_eLpNormEssSup_of_ae_le_mul h
   simp_rw [eLpNorm_eq_eLpNorm' h0 h_top]
   exact eLpNorm'_le_nnreal_smul_eLpNorm'_of_ae_le_mul h (ENNReal.toReal_pos h0 h_top)
+
+theorem eLpNorm_le_nnreal_smul_eLpNorm_of_ae_le_mul_enormWIP {f : α → ε} {g : α → ε'} {c : ℝ≥0}
+    (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ c * ‖g x‖ₑ) (p : ℝ≥0∞) : eLpNorm f p μ ≤ c • eLpNorm g p μ := by
+  by_cases h0 : p = 0
+  · simp [h0]
+  by_cases h_top : p = ∞
+  · rw [h_top]
+    exact eLpNormEssSup_le_nnreal_smul_eLpNormEssSup_of_ae_le_mul_enormWIP h
+  simp_rw [eLpNorm_eq_eLpNorm' h0 h_top]
+  exact eLpNorm'_le_nnreal_smul_eLpNorm'_of_ae_le_mul_enormWIP h (ENNReal.toReal_pos h0 h_top)
 
 -- TODO: add the whole family of lemmas?
 private theorem le_mul_iff_eq_zero_of_nonneg_of_neg_of_nonneg {α} [LinearOrderedSemiring α]
@@ -1173,10 +1204,26 @@ theorem eLpNorm_le_mul_eLpNorm_of_ae_le_mul {f : α → F} {g : α → G} {c : �
   eLpNorm_le_nnreal_smul_eLpNorm_of_ae_le_mul
     (h.mono fun _x hx => hx.trans <| mul_le_mul_of_nonneg_right c.le_coe_toNNReal (norm_nonneg _)) _
 
+theorem eLpNorm_le_mul_eLpNorm_of_ae_le_mul_enormWIP {f : α → ε} {g : α → ε'} {c : ℝ≥0}
+    (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ c * ‖g x‖ₑ) (p : ℝ≥0∞) :
+    eLpNorm f p μ ≤ ENNReal.ofReal c * eLpNorm g p μ := by
+  sorry
+  -- refine eLpNorm_le_nnreal_smul_eLpNorm_of_ae_le_mul_enormWIP (f := f) (g := g) (c := c) ?_
+  -- apply (h.mono fun _x hx => hx.trans <| mul_le_mul_of_nonneg_right ?_ ?_)--(le_refl _) (norm_nonneg _)) _
+  -- sorry
+  -- sorry
+
 theorem Memℒp.of_nnnorm_le_mul {f : α → E} {g : α → F} {c : ℝ≥0} (hg : Memℒp g p μ)
     (hf : AEStronglyMeasurable f μ) (hfg : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ c * ‖g x‖₊) : Memℒp f p μ :=
   ⟨hf,
     (eLpNorm_le_nnreal_smul_eLpNorm_of_ae_le_mul hfg p).trans_lt <|
+      ENNReal.mul_lt_top ENNReal.coe_lt_top hg.eLpNorm_lt_top⟩
+
+theorem Memℒp.of_enorm_le_mul [TopologicalSpace ε] {f : α → ε} {g : α → ε} {c : ℝ≥0}
+    (hg : Memℒp g p μ) (hf : AEStronglyMeasurable f μ) (hfg : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ c * ‖g x‖ₑ) :
+    Memℒp f p μ :=
+  ⟨hf,
+    (eLpNorm_le_nnreal_smul_eLpNorm_of_ae_le_mul_enormWIP hfg p).trans_lt <|
       ENNReal.mul_lt_top ENNReal.coe_lt_top hg.eLpNorm_lt_top⟩
 
 theorem Memℒp.of_le_mul {f : α → E} {g : α → F} {c : ℝ} (hg : Memℒp g p μ)
@@ -1184,6 +1231,12 @@ theorem Memℒp.of_le_mul {f : α → E} {g : α → F} {c : ℝ} (hg : Memℒp 
   ⟨hf,
     (eLpNorm_le_mul_eLpNorm_of_ae_le_mul hfg p).trans_lt <|
       ENNReal.mul_lt_top ENNReal.ofReal_lt_top hg.eLpNorm_lt_top⟩
+
+theorem Memℒp.of_le_mul_enormWIP [TopologicalSpace ε] [TopologicalSpace ε'] {f : α → ε} {g : α → ε'}
+    {c : ℝ≥0} (hg : Memℒp g p μ)
+    (hf : AEStronglyMeasurable f μ) (hfg : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ c * ‖g x‖ₑ) : Memℒp f p μ :=
+  ⟨hf, (eLpNorm_le_mul_eLpNorm_of_ae_le_mul_enormWIP hfg p).trans_lt <|
+    ENNReal.mul_lt_top ENNReal.ofReal_lt_top hg.eLpNorm_lt_top⟩
 
 end Monotonicity
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -392,44 +392,52 @@ theorem eLpNorm'_congr_enorm_ae {f g : α → ε} (hfg : ∀ᵐ x ∂μ, ‖f x�
 @[deprecated (since := "2025-02-02")] alias eLpNorm'_congr_nnnorm_ae := eLpNorm'_congr_enorm_ae
 
 theorem eLpNorm'_congr_norm_ae {f g : α → F} (hfg : ∀ᵐ x ∂μ, ‖f x‖ = ‖g x‖) :
-    eLpNorm' f q μ = eLpNorm' g q μ :=
-  eLpNorm'_congr_enorm_ae <| hfg.mono fun _x hx => NNReal.eq hx
+    eLpNorm' f q μ = eLpNorm' g q μ := by
+  refine eLpNorm'_congr_enorm_ae <| hfg.mono fun _x hx => ?_; sorry -- was: NNReal.eq hx
 
-theorem eLpNorm'_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) : eLpNorm' f q μ = eLpNorm' g q μ :=
+theorem eLpNorm'_congr_ae {f g : α → ε} (hfg : f =ᵐ[μ] g) : eLpNorm' f q μ = eLpNorm' g q μ :=
   eLpNorm'_congr_enorm_ae (hfg.fun_comp _)
 
-theorem eLpNormEssSup_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) :
+theorem eLpNormEssSup_congr_ae {f g : α → ε} (hfg : f =ᵐ[μ] g) :
     eLpNormEssSup f μ = eLpNormEssSup g μ :=
-  essSup_congr_ae (hfg.fun_comp (((↑) : ℝ≥0 → ℝ≥0∞) ∘ nnnorm))
+  essSup_congr_ae (hfg.fun_comp _)
 
-theorem eLpNormEssSup_mono_nnnorm_ae {f g : α → F} (hfg : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ ‖g x‖₊) :
-    eLpNormEssSup f μ ≤ eLpNormEssSup g μ :=
-  essSup_mono_ae <| hfg.mono fun _x hx => ENNReal.coe_le_coe.mpr hx
+theorem eLpNormEssSup_mono_enorm_ae {f g : α → ε} (hfg : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
+    eLpNormEssSup f μ ≤ eLpNormEssSup g μ := by
+  refine essSup_mono_ae <| hfg.mono fun _x hx => ?_
+  sorry -- was: ENNReal.coe_le_coe.mpr hx
 
-theorem eLpNorm_mono_nnnorm_ae {f : α → F} {g : α → G} (h : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ ‖g x‖₊) :
+theorem eLpNorm_mono_enorm_ae {f : α → ε} {g : α → ε'} (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm f p μ ≤ eLpNorm g p μ := by
   simp only [eLpNorm]
   split_ifs
   · exact le_rfl
-  · exact essSup_mono_ae (h.mono fun x hx => ENNReal.coe_le_coe.mpr hx)
-  · exact eLpNorm'_mono_nnnorm_ae ENNReal.toReal_nonneg h
+  · refine essSup_mono_ae (h.mono fun x hx => ?_); sorry -- was: ENNReal.coe_le_coe.mpr hx)
+  · sorry --refine eLpNorm'_mono_enorm_ae ?_
+    -- sorry -- was: ENNReal.toReal_nonneg h
 
-theorem eLpNorm_mono_ae {f : α → F} {g : α → G} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ ‖g x‖) :
-    eLpNorm f p μ ≤ eLpNorm g p μ :=
-  eLpNorm_mono_nnnorm_ae h
+@[deprecated (since := "2025-02-02")]
+alias eLpNorm_mono_nnnorm_ae := eLpNorm_mono_enorm_ae
 
-theorem eLpNorm_mono_ae_real {f : α → F} {g : α → ℝ} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ g x) :
+theorem eLpNorm_mono_ae {f : α → ε} {g : α → ε'} (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
-  eLpNorm_mono_ae <| h.mono fun _x hx =>
+  eLpNorm_mono_enorm_ae h
+
+theorem eLpNorm_mono_ae_real {f : α → ε} {g : α → ℝ} (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ g x) :
+    eLpNorm f p μ ≤ eLpNorm g p μ :=
+  eLpNorm_mono_ae <| h.mono fun _x hx => -- XXX will need adjustments
     hx.trans ((le_abs_self _).trans (Real.norm_eq_abs _).symm.le)
 
-theorem eLpNorm_mono_nnnorm {f : α → F} {g : α → G} (h : ∀ x, ‖f x‖₊ ≤ ‖g x‖₊) :
+theorem eLpNorm_mono {f : α → ε} {g : α → ε'} (h : ∀ x, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
-  eLpNorm_mono_nnnorm_ae (Eventually.of_forall fun x => h x)
+  eLpNorm_mono_enorm_ae (Eventually.of_forall fun x => h x)
 
-theorem eLpNorm_mono {f : α → F} {g : α → G} (h : ∀ x, ‖f x‖ ≤ ‖g x‖) :
+@[deprecated (since := "2025-02-02")]
+alias eLpNorm_mono_nnnorm := eLpNorm_mono
+
+theorem eLpNorm_mono_norm {f : α → F} {g : α → G} (h : ∀ x, ‖f x‖ ≤ ‖g x‖) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
-  eLpNorm_mono_ae (Eventually.of_forall fun x => h x)
+  sorry -- was: eLpNorm_mono_ae (Eventually.of_forall fun x => h x)
 
 theorem eLpNorm_mono_real {f : α → F} {g : α → ℝ} (h : ∀ x, ‖f x‖ ≤ g x) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
@@ -468,7 +476,7 @@ theorem eLpNorm_le_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ x ∂μ, �
 
 theorem eLpNorm_congr_nnnorm_ae {f : α → F} {g : α → G} (hfg : ∀ᵐ x ∂μ, ‖f x‖₊ = ‖g x‖₊) :
     eLpNorm f p μ = eLpNorm g p μ :=
-  le_antisymm (eLpNorm_mono_nnnorm_ae <| EventuallyEq.le hfg)
+  le_antisymm (eLpNorm_mono_enorm_ae <| EventuallyEq.le hfg)
     (eLpNorm_mono_nnnorm_ae <| (EventuallyEq.symm hfg).le)
 
 theorem eLpNorm_congr_norm_ae {f : α → F} {g : α → G} (hfg : ∀ᵐ x ∂μ, ‖f x‖ = ‖g x‖) :

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -411,9 +411,6 @@ theorem eLpNormEssSup_mono_enorm_ae {f g : α → ε} (hfg : ∀ᵐ x ∂μ, ‖
 @[deprecated (since := "2025-02-02")]
 alias eLpNormEssSup_mono_nnnorm_ae := eLpNormEssSup_mono_enorm_ae
 
-@[deprecated (since := "2024-07-27")]
-alias snormEssSup_mono_nnnorm_ae := eLpNormEssSup_mono_nnnorm_ae
-
 theorem eLpNorm_mono_enorm_ae {f : α → ε} {g : α → ε'} (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm f p μ ≤ eLpNorm g p μ := by
   simp only [eLpNorm]
@@ -481,9 +478,6 @@ theorem eLpNormEssSup_lt_top_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ 
     eLpNormEssSup f μ < ∞ :=
   (eLpNormEssSup_le_of_ae_bound hfC).trans_lt ENNReal.ofReal_lt_top
 
-@[deprecated (since := "2024-07-27")]
-alias snormEssSup_lt_top_of_ae_bound := eLpNormEssSup_lt_top_of_ae_bound
-
 theorem eLpNorm_le_of_ae_enorm_bound {f : α → ε} {C : ℝ≥0} (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C) :
     eLpNorm f p μ ≤ C • μ Set.univ ^ p.toReal⁻¹ := by
   rcases eq_zero_or_neZero μ with rfl | hμ
@@ -497,17 +491,11 @@ theorem eLpNorm_le_of_ae_enorm_bound {f : α → ε} {C : ℝ≥0} (hfC : ∀ᵐ
 @[deprecated (since := "2025-02-22")]
 alias eLpNorm_le_of_ae_nnnorm_bound := eLpNorm_le_of_ae_enorm_bound
 
-@[deprecated (since := "2024-07-27")]
-alias snorm_le_of_ae_nnnorm_bound := eLpNorm_le_of_ae_nnnorm_bound
-
 -- FIXME: perhaps the statement makes no sense now: happy to change it
 theorem eLpNorm_le_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C.toNNReal) :
     eLpNorm f p μ ≤ μ Set.univ ^ p.toReal⁻¹ * ENNReal.ofReal C := by
   rw [← mul_comm]
   exact eLpNorm_le_of_ae_enorm_bound (hfC.mono fun x hx => hx)
-
-@[deprecated (since := "2024-07-27")]
-alias snorm_le_of_ae_bound := eLpNorm_le_of_ae_bound
 
 theorem eLpNorm_congr_enorm_ae {f : α → ε} {g : α → ε'} (hfg : ∀ᵐ x ∂μ, ‖f x‖ₑ = ‖g x‖ₑ) :
     eLpNorm f p μ = eLpNorm g p μ :=
@@ -519,7 +507,7 @@ alias eLpNorm_congr_nnnorm_ae := eLpNorm_congr_enorm_ae
 
 theorem eLpNorm_congr_norm_ae {f : α → F} {g : α → G} (hfg : ∀ᵐ x ∂μ, ‖f x‖ = ‖g x‖) :
     eLpNorm f p μ = eLpNorm g p μ :=
-  eLpNorm_congr_nnnorm_ae <| hfg.mono fun _x hx => NNReal.eq hx
+  eLpNorm_congr_enorm_ae <| hfg.mono fun _x hx => sorry -- TODO fix! was: NNReal.eq hx
 
 -- XXXMR: need a zero element in ε
 open scoped symmDiff in
@@ -536,9 +524,6 @@ theorem eLpNorm'_norm {f : α → F} :
 theorem eLpNorm'_enorm {f : α → ε} :
     eLpNorm' (fun a => ‖f a‖ₑ) q μ = eLpNorm' f q μ := by simp [eLpNorm'_eq_lintegral_enorm]
 
-@[deprecated (since := "2024-07-27")]
-alias snorm'_norm := eLpNorm'_norm
-
 @[simp]
 theorem eLpNorm_norm (f : α → F) : eLpNorm (fun x => ‖f x‖) p μ = eLpNorm f p μ :=
   eLpNorm_congr_norm_ae <| Eventually.of_forall fun _ => norm_norm _
@@ -547,9 +532,6 @@ theorem eLpNorm_norm (f : α → F) : eLpNorm (fun x => ‖f x‖) p μ = eLpNor
 theorem eLpNorm_enorm (f : α → ε) : eLpNorm (fun x => ‖f x‖ₑ) p μ = eLpNorm f p μ :=
   -- TODO: add a lemma enorm_enorm and use it here!
   eLpNorm_congr_enorm_ae <| Eventually.of_forall fun _ => rfl
-
-@[deprecated (since := "2024-07-27")]
-alias snorm_norm := eLpNorm_norm
 
 theorem eLpNorm'_enorm_rpow (f : α → ε) (p q : ℝ) (hq_pos : 0 < q) :
     eLpNorm' (fun x => ‖f x‖ₑ ^ q) p μ = eLpNorm' f (p * q) μ ^ q := by
@@ -569,9 +551,6 @@ theorem eLpNorm'_norm_rpow (f : α → F) (p q : ℝ) (hq_pos : 0 < q) :
     mul_assoc, inv_mul_cancel₀ hq_pos.ne.symm, mul_one, ← ofReal_norm_eq_enorm,
     Real.norm_eq_abs, abs_eq_self.mpr (Real.rpow_nonneg (norm_nonneg _) _), mul_comm p,
     ← ENNReal.ofReal_rpow_of_nonneg (norm_nonneg _) hq_pos.le, ENNReal.rpow_mul]
-
-@[deprecated (since := "2024-07-27")]
-alias snorm'_norm_rpow := eLpNorm'_norm_rpow
 
 theorem eLpNorm_enorm_rpow (f : α → ε) (hq_pos : 0 < q) :
     eLpNorm (fun x => ‖f x‖ₑ ^ q) p μ = eLpNorm f (p * ENNReal.ofReal q) μ ^ q := by
@@ -599,13 +578,8 @@ theorem eLpNorm_norm_rpow (f : α → F) (hq_pos : 0 < q) :
   -- missing: ‖f x‖ ^ q and ‖f x‖ₑ ^ q have the same eLpNorm
   sorry
 
-@[deprecated (since := "2024-07-27")]
-alias snorm_norm_rpow := eLpNorm_norm_rpow
-
 theorem eLpNorm_congr_ae {f g : α → ε} (hfg : f =ᵐ[μ] g) : eLpNorm f p μ = eLpNorm g p μ :=
   eLpNorm_congr_enorm_ae <| hfg.mono fun _x hx => hx ▸ rfl
-
-#exit
 
 theorem memℒp_congr_ae [TopologicalSpace ε] {f g : α → ε} (hfg : f =ᵐ[μ] g) :
     Memℒp f p μ ↔ Memℒp g p μ := by

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -199,6 +199,7 @@ theorem eLpNorm_exponent_zero {f : α → ε} : eLpNorm f 0 μ = 0 := by simp [e
 theorem memℒp_zero_iff_aestronglyMeasurable [TopologicalSpace ε] {f : α → ε} :
     Memℒp f 0 μ ↔ AEStronglyMeasurable f μ := by simp [Memℒp, eLpNorm_exponent_zero]
 
+-- XXXMR: needs ENormedSpace (or perhaps seminormed), well-behaved zero
 @[simp]
 theorem eLpNorm'_zero (hp0_lt : 0 < q) : eLpNorm' (0 : α → F) q μ = 0 := by
   simp [eLpNorm'_eq_lintegral_enorm, hp0_lt]
@@ -209,6 +210,7 @@ theorem eLpNorm'_zero' (hq0_ne : q ≠ 0) (hμ : μ ≠ 0) : eLpNorm' (0 : α �
   · exact eLpNorm'_zero (lt_of_le_of_ne hq0 hq0_ne.symm)
   · simp [eLpNorm'_eq_lintegral_enorm, ENNReal.rpow_eq_zero_iff, hμ, hq_neg]
 
+-- XXXMR: needs ENormedSpace (or perhaps seminormed), well-behaved zero
 @[simp]
 theorem eLpNormEssSup_zero : eLpNormEssSup (0 : α → F) μ = 0 := by
   simp [eLpNormEssSup, ← bot_eq_zero', essSup_const_bot]

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -390,6 +390,9 @@ theorem eLpNorm'_congr_enorm_ae {f g : α → ε} (hfg : ∀ᵐ x ∂μ, ‖f x�
 @[deprecated (since := "2025-02-02")] alias eLpNorm'_congr_nnnorm_ae := eLpNorm'_congr_enorm_ae
 
 -- TODO: does this exist already? Is there a better proof? Better name!
+-- make an iff!
+-- name. enorm_eq_enorm_iff_norm ?
+-- enorm_eq_iff_norm_eq
 theorem foo {F : Type*} {G : Type*} [NormedAddCommGroup F] [NormedAddCommGroup G]
     {x : F} {y : G} (h : ‖x‖ = ‖y‖) : ‖x‖ₑ = ‖y‖ₑ := by
   -- I can prove this first (this should also exist, if it doesn't already!)
@@ -413,12 +416,16 @@ theorem foo_leq {F : Type*} {G : Type*} [NormedAddCommGroup F] [NormedAddCommGro
 theorem foo_le {F : Type*} {G : Type*} [NormedAddCommGroup F] [NormedAddCommGroup G]
     {x : F} {y : G} (h : ‖x‖ < ‖y‖) : ‖x‖ₑ < ‖y‖ₑ := by
   -- I can prove this first (this should also exist, if it doesn't already!)
-  have : ‖x‖₊ < ‖y‖₊ := by
-    simp only [← coe_nnnorm] at h
-    sorry -- apply NNReal.coe_mono
-    -- exact h
-  simp only [enorm_eq_nnnorm]
-  gcongr
+  simp only [← ofReal_norm]
+  refine (ENNReal.ofReal_lt_ofReal_iff_of_nonneg ?_).mpr h
+  apply norm_nonneg _
+  -- -- enorm = ENNReal.ofReal norm is a new mathlib lemma, in NormedGr
+  -- have : ‖x‖₊ < ‖y‖₊ := by
+  --   simp only [← coe_nnnorm] at h
+  --   sorry -- apply NNReal.coe_mono
+  --   -- exact h
+  -- simp only [enorm_eq_nnnorm]
+  -- gcongr
 
 theorem eLpNorm'_congr_norm_ae {f g : α → F} (hfg : ∀ᵐ x ∂μ, ‖f x‖ = ‖g x‖) :
     eLpNorm' f q μ = eLpNorm' g q μ :=
@@ -456,7 +463,11 @@ theorem eLpNorm_mono_ae {f : α → ε} {g : α → ε'} (h : ∀ᵐ x ∂μ, �
 theorem eLpNorm_mono_ae' {f : α → F} {g : α → G} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ ‖g x‖) :
     eLpNorm f p μ ≤ eLpNorm g p μ := by
   apply eLpNorm_mono_enorm_ae --(foo h)
-  sorry -- TODO: want to use foo under a binder, with the same set; how to do that *nicely*?
+  convert h -- nicer. SIMP_RW!
+  constructor
+  · intro h
+    sorry -- other direction
+  apply fun h ↦ foo_leq h
 
 theorem eLpNorm_mono_ae_real {f : α → F} {g : α → ℝ} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ g x) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
@@ -502,22 +513,24 @@ theorem eLpNormEssSup_lt_top_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ 
     eLpNormEssSup f μ < ∞ :=
   (eLpNormEssSup_le_of_ae_bound hfC).trans_lt ENNReal.ofReal_lt_top
 
-theorem eLpNorm_le_of_ae_enorm_bound {f : α → ε} {C : ℝ≥0} (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C) :
+theorem eLpNorm_le_of_ae_enorm_bound {f : α → ε} {C : ℝ≥0∞} (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C) :
     eLpNorm f p μ ≤ C • μ Set.univ ^ p.toReal⁻¹ := by
   rcases eq_zero_or_neZero μ with rfl | hμ
   · simp
   by_cases hp : p = 0
   · simp [hp]
-  have : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖(C : ℝ)‖ₑ := hfC.mono fun x hx => hx.trans_eq C.enorm_eq.symm
+  have : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖C‖ₑ := hfC -- XXX inline, uses eborn_eq_self
   refine (eLpNorm_mono_ae this).trans_eq ?_
-  rw [eLpNorm_const _ hp (NeZero.ne μ), C.enorm_eq, one_div, ENNReal.smul_def, smul_eq_mul]
+  rw [eLpNorm_const _ hp (NeZero.ne μ), one_div, enorm_eq_self, smul_eq_mul]
 
 @[deprecated (since := "2025-02-22")]
 alias eLpNorm_le_of_ae_nnnorm_bound := eLpNorm_le_of_ae_enorm_bound
 
+-- perhaps keep old versions as well!
+
 -- FIXME: perhaps the statement makes no sense now: happy to change it
-theorem eLpNorm_le_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C.toNNReal) :
-    eLpNorm f p μ ≤ μ Set.univ ^ p.toReal⁻¹ * ENNReal.ofReal C := by
+theorem eLpNorm_le_of_ae_bound {f : α → F} {C : ℝ≥0∞} (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C) :
+    eLpNorm f p μ ≤ μ Set.univ ^ p.toReal⁻¹ * C := by
   rw [← mul_comm]
   exact eLpNorm_le_of_ae_enorm_bound (hfC.mono fun x hx => hx)
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -392,9 +392,40 @@ theorem eLpNorm'_congr_enorm_ae {f g : α → ε} (hfg : ∀ᵐ x ∂μ, ‖f x�
 
 @[deprecated (since := "2025-02-02")] alias eLpNorm'_congr_nnnorm_ae := eLpNorm'_congr_enorm_ae
 
+-- TODO: does this exist already? Is there a better proof? Better name!
+theorem foo {F : Type*} {G : Type*} [NormedAddCommGroup F] [NormedAddCommGroup G]
+    {x : F} {y : G} (h : ‖x‖ = ‖y‖) : ‖x‖ₑ = ‖y‖ₑ := by
+  -- I can prove this first (this should also exist, if it doesn't already!)
+  have : ‖x‖₊ = ‖y‖₊ := by
+    simp only [← coe_nnnorm] at h
+    apply NNReal.coe_injective
+    exact h
+  simp only [enorm_eq_nnnorm]
+  congr
+
+theorem foo_leq {F : Type*} {G : Type*} [NormedAddCommGroup F] [NormedAddCommGroup G]
+    {x : F} {y : G} (h : ‖x‖ ≤ ‖y‖) : ‖x‖ₑ ≤ ‖y‖ₑ := by
+  -- I can prove this first (this should also exist, if it doesn't already!)
+  have : ‖x‖₊ ≤ ‖y‖₊ := by
+    simp only [← coe_nnnorm] at h
+    apply NNReal.coe_mono
+    exact h
+  simp only [enorm_eq_nnnorm]
+  gcongr
+
+theorem foo_le {F : Type*} {G : Type*} [NormedAddCommGroup F] [NormedAddCommGroup G]
+    {x : F} {y : G} (h : ‖x‖ < ‖y‖) : ‖x‖ₑ < ‖y‖ₑ := by
+  -- I can prove this first (this should also exist, if it doesn't already!)
+  have : ‖x‖₊ < ‖y‖₊ := by
+    simp only [← coe_nnnorm] at h
+    sorry -- apply NNReal.coe_mono
+    -- exact h
+  simp only [enorm_eq_nnnorm]
+  gcongr
+
 theorem eLpNorm'_congr_norm_ae {f g : α → F} (hfg : ∀ᵐ x ∂μ, ‖f x‖ = ‖g x‖) :
-    eLpNorm' f q μ = eLpNorm' g q μ := by
-  refine eLpNorm'_congr_enorm_ae <| hfg.mono fun _x hx => ?_; sorry -- was: NNReal.eq hx
+    eLpNorm' f q μ = eLpNorm' g q μ :=
+  eLpNorm'_congr_enorm_ae <| hfg.mono fun _x hx ↦ foo hx
 
 theorem eLpNorm'_congr_ae {f g : α → ε} (hfg : f =ᵐ[μ] g) : eLpNorm' f q μ = eLpNorm' g q μ :=
   eLpNorm'_congr_enorm_ae (hfg.fun_comp _)
@@ -404,9 +435,8 @@ theorem eLpNormEssSup_congr_ae {f g : α → ε} (hfg : f =ᵐ[μ] g) :
   essSup_congr_ae (hfg.fun_comp _)
 
 theorem eLpNormEssSup_mono_enorm_ae {f g : α → ε} (hfg : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
-    eLpNormEssSup f μ ≤ eLpNormEssSup g μ := by
-  refine essSup_mono_ae <| hfg.mono fun _x hx => ?_
-  sorry -- was: ENNReal.coe_le_coe.mpr hx
+    eLpNormEssSup f μ ≤ eLpNormEssSup g μ :=
+  essSup_mono_ae <| hfg.mono fun _x hx => hx
 
 @[deprecated (since := "2025-02-02")]
 alias eLpNormEssSup_mono_nnnorm_ae := eLpNormEssSup_mono_enorm_ae
@@ -428,7 +458,8 @@ theorem eLpNorm_mono_ae {f : α → ε} {g : α → ε'} (h : ∀ᵐ x ∂μ, �
 
 theorem eLpNorm_mono_ae' {f : α → F} {g : α → G} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ ‖g x‖) :
     eLpNorm f p μ ≤ eLpNorm g p μ := by
-  apply eLpNorm_mono_enorm_ae
+  apply eLpNorm_mono_enorm_ae --(foo h)
+  -- TODO: how to use foo under a binder?
   sorry -- familiar sorry, equal norm => equal enorm
 
 theorem eLpNorm_mono_ae_real {f : α → F} {g : α → ℝ} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ g x) :
@@ -436,8 +467,9 @@ theorem eLpNorm_mono_ae_real {f : α → F} {g : α → ℝ} (h : ∀ᵐ x ∂μ
   refine eLpNorm_mono_ae <| h.mono fun _x hx => ?_
   have := hx.trans (le_abs_self _)
   rw [← Real.norm_eq_abs] at this
-  -- now, the same familiar sorry as above
-  sorry -- was: hx.trans ((le_abs_self _).trans (Real.norm_eq_abs _).symm.le)
+  apply foo_leq this
+  -- FIXME: golf this; original proof was
+  -- was: hx.trans ((le_abs_self _).trans (Real.norm_eq_abs _).symm.le)
 
 theorem eLpNorm_mono {f : α → ε} {g : α → ε'} (h : ∀ x, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
@@ -448,7 +480,7 @@ alias eLpNorm_mono_nnnorm := eLpNorm_mono
 
 theorem eLpNorm_mono_norm {f : α → ε} {g : α → ε'} (h : ∀ x, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
-  sorry -- was: eLpNorm_mono_ae (Eventually.of_forall fun x => h x)
+  eLpNorm_mono_ae (Eventually.of_forall fun x => h x)
 
 theorem eLpNorm_mono_real {f : α → F} {g : α → ℝ} (h : ∀ x, ‖f x‖ ≤ g x) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
@@ -507,7 +539,7 @@ alias eLpNorm_congr_nnnorm_ae := eLpNorm_congr_enorm_ae
 
 theorem eLpNorm_congr_norm_ae {f : α → F} {g : α → G} (hfg : ∀ᵐ x ∂μ, ‖f x‖ = ‖g x‖) :
     eLpNorm f p μ = eLpNorm g p μ :=
-  eLpNorm_congr_enorm_ae <| hfg.mono fun _x hx => sorry -- TODO fix! was: NNReal.eq hx
+  eLpNorm_congr_enorm_ae <| hfg.mono fun _x hx ↦ foo hx
 
 -- XXXMR: need a zero element in ε
 open scoped symmDiff in
@@ -597,10 +629,8 @@ theorem Memℒp.of_le [TopologicalSpace ε] [TopologicalSpace ε'] {f : α → �
 alias Memℒp.mono := Memℒp.of_le
 
 theorem Memℒp.mono' {f : α → E} {g : α → ℝ} (hg : Memℒp g p μ) (hf : AEStronglyMeasurable f μ)
-    (h : ∀ᵐ a ∂μ, ‖f a‖ ≤ g a) : Memℒp f p μ := by
-  refine hg.mono hf <| h.mono fun _x hx => ?_
-  have : ‖f _x‖ ≤ ‖g _x‖ := hx.trans (le_abs_self _)
-  sorry -- familiar sorry now
+    (h : ∀ᵐ a ∂μ, ‖f a‖ ≤ g a) : Memℒp f p μ :=
+  hg.mono hf <| h.mono fun _x hx ↦ foo_leq (hx.trans (le_abs_self _))
 
 theorem Memℒp.congr_norm [TopologicalSpace ε] [TopologicalSpace ε'] {f : α → ε} {g : α → ε'}
     (hf : Memℒp f p μ) (hg : AEStronglyMeasurable g μ)
@@ -762,7 +792,7 @@ lemma eLpNorm_indicator_const_le (c : G) (p : ℝ≥0∞) :
     eLpNorm (s.indicator fun _ => c) p μ ≤ eLpNorm (t.indicator fun _ => c) p μ := by
       refine eLpNorm_mono ?_
       intro x
-      sorry -- apply enorm_indicator_le_of_subset. TODO: wait until recompilation
+      sorry -- apply enorm_indicator_le_of_subset -- recompile, then should work!
       --eLpNorm_mono (norm_indicator_le_of_subset (subset_toMeasurable _ _) _)
     _ = ‖c‖ₑ * μ t ^ (1 / p.toReal) :=
       eLpNorm_indicator_const (measurableSet_toMeasurable ..) hp h'p

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -407,14 +407,20 @@ theorem eLpNormEssSup_mono_enorm_ae {f g : α → ε} (hfg : ∀ᵐ x ∂μ, ‖
   refine essSup_mono_ae <| hfg.mono fun _x hx => ?_
   sorry -- was: ENNReal.coe_le_coe.mpr hx
 
+@[deprecated (since := "2025-02-02")]
+alias eLpNormEssSup_mono_nnnorm_ae := eLpNormEssSup_mono_enorm_ae
+
+@[deprecated (since := "2024-07-27")]
+alias snormEssSup_mono_nnnorm_ae := eLpNormEssSup_mono_nnnorm_ae
+
 theorem eLpNorm_mono_enorm_ae {f : α → ε} {g : α → ε'} (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm f p μ ≤ eLpNorm g p μ := by
   simp only [eLpNorm]
   split_ifs
   · exact le_rfl
-  · refine essSup_mono_ae (h.mono fun x hx => ?_); sorry -- was: ENNReal.coe_le_coe.mpr hx)
-  · sorry --refine eLpNorm'_mono_enorm_ae ?_
-    -- sorry -- was: ENNReal.toReal_nonneg h
+  · exact essSup_mono_ae (h.mono fun x hx => hx)
+  · sorry -- type mismatch... refine eLpNorm'_mono_enorm_ae (f := f) (g := g) ?_
+    -- was: ENNReal.toReal_nonneg h
 
 @[deprecated (since := "2025-02-02")]
 alias eLpNorm_mono_nnnorm_ae := eLpNorm_mono_enorm_ae
@@ -423,19 +429,23 @@ theorem eLpNorm_mono_ae {f : α → ε} {g : α → ε'} (h : ∀ᵐ x ∂μ, �
     eLpNorm f p μ ≤ eLpNorm g p μ :=
   eLpNorm_mono_enorm_ae h
 
-theorem eLpNorm_mono_ae_real {f : α → ε} {g : α → ℝ} (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ g x) :
+theorem eLpNorm_mono_ae' {f : α → F} {g : α → G} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ ‖g x‖) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
-  eLpNorm_mono_ae <| h.mono fun _x hx => -- XXX will need adjustments
-    hx.trans ((le_abs_self _).trans (Real.norm_eq_abs _).symm.le)
+  sorry -- TODO! proof was eLpNorm_mono_enorm_ae h
+
+theorem eLpNorm_mono_ae_real {f : α → F} {g : α → ℝ} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ g x) :
+    eLpNorm f p μ ≤ eLpNorm g p μ := by
+  refine eLpNorm_mono_ae <| h.mono fun _x hx => ?_-- TODO: hypothesis doesn't apply directly!
+  sorry -- was: hx.trans ((le_abs_self _).trans (Real.norm_eq_abs _).symm.le)
 
 theorem eLpNorm_mono {f : α → ε} {g : α → ε'} (h : ∀ x, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
-  eLpNorm_mono_enorm_ae (Eventually.of_forall fun x => h x)
+  eLpNorm_mono_enorm_ae (Eventually.of_forall fun x ↦ h x)
 
 @[deprecated (since := "2025-02-02")]
 alias eLpNorm_mono_nnnorm := eLpNorm_mono
 
-theorem eLpNorm_mono_norm {f : α → F} {g : α → G} (h : ∀ x, ‖f x‖ ≤ ‖g x‖) :
+theorem eLpNorm_mono_norm {f : α → ε} {g : α → ε'} (h : ∀ x, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
   sorry -- was: eLpNorm_mono_ae (Eventually.of_forall fun x => h x)
 
@@ -443,17 +453,24 @@ theorem eLpNorm_mono_real {f : α → F} {g : α → ℝ} (h : ∀ x, ‖f x‖ 
     eLpNorm f p μ ≤ eLpNorm g p μ :=
   eLpNorm_mono_ae_real (Eventually.of_forall fun x => h x)
 
-theorem eLpNormEssSup_le_of_ae_nnnorm_bound {f : α → F} {C : ℝ≥0} (hfC : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ C) :
+theorem eLpNormEssSup_le_of_ae_enorm_bound {f : α → ε} {C : ℝ≥0} (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C) :
     eLpNormEssSup f μ ≤ C :=
-  essSup_le_of_ae_le (C : ℝ≥0∞) <| hfC.mono fun _x hx => ENNReal.coe_le_coe.mpr hx
+  essSup_le_of_ae_le (C : ℝ≥0∞) <| hfC.mono fun _x hx ↦ hx
+
+@[deprecated (since := "2025-02-02")]
+alias eLpNormEssSup_le_of_ae_nnnorm_bound := eLpNormEssSup_le_of_ae_enorm_bound
 
 theorem eLpNormEssSup_le_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) :
-    eLpNormEssSup f μ ≤ ENNReal.ofReal C :=
-  eLpNormEssSup_le_of_ae_nnnorm_bound <| hfC.mono fun _x hx => hx.trans C.le_coe_toNNReal
+    eLpNormEssSup f μ ≤ ENNReal.ofReal C := by
+  refine eLpNormEssSup_le_of_ae_enorm_bound <| hfC.mono fun _x hx => ?_
+  sorry -- was: hx.trans C.le_coe_toNNReal
 
-theorem eLpNormEssSup_lt_top_of_ae_nnnorm_bound {f : α → F} {C : ℝ≥0} (hfC : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ C) :
+theorem eLpNormEssSup_lt_top_of_ae_enorm_bound {f : α → ε} {C : ℝ≥0} (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C) :
     eLpNormEssSup f μ < ∞ :=
-  (eLpNormEssSup_le_of_ae_nnnorm_bound hfC).trans_lt ENNReal.coe_lt_top
+  (eLpNormEssSup_le_of_ae_enorm_bound hfC).trans_lt ENNReal.coe_lt_top
+
+@[deprecated (since := "2025-02-02")]
+alias eLpNormEssSup_lt_top_of_ae_nnnorm_bound := eLpNormEssSup_lt_top_of_ae_enorm_bound
 
 theorem eLpNormEssSup_lt_top_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) :
     eLpNormEssSup f μ < ∞ :=
@@ -466,6 +483,7 @@ theorem eLpNorm_le_of_ae_nnnorm_bound {f : α → F} {C : ℝ≥0} (hfC : ∀ᵐ
   by_cases hp : p = 0
   · simp [hp]
   have : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ ‖(C : ℝ)‖₊ := hfC.mono fun x hx => hx.trans_eq C.nnnorm_eq.symm
+  sorry /-
   refine (eLpNorm_mono_ae this).trans_eq ?_
   rw [eLpNorm_const _ hp (NeZero.ne μ), C.enorm_eq, one_div, ENNReal.smul_def, smul_eq_mul]
 
@@ -474,15 +492,22 @@ theorem eLpNorm_le_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ x ∂μ, �
   rw [← mul_comm]
   exact eLpNorm_le_of_ae_nnnorm_bound (hfC.mono fun x hx => hx.trans C.le_coe_toNNReal)
 
-theorem eLpNorm_congr_nnnorm_ae {f : α → F} {g : α → G} (hfg : ∀ᵐ x ∂μ, ‖f x‖₊ = ‖g x‖₊) :
+@[deprecated (since := "2024-07-27")]
+alias snorm_le_of_ae_bound := eLpNorm_le_of_ae_bound
+
+theorem eLpNorm_congr_enorm_ae {f : α → ε} {g : α → ε'} (hfg : ∀ᵐ x ∂μ, ‖f x‖ₑ = ‖g x‖ₑ) :
     eLpNorm f p μ = eLpNorm g p μ :=
   le_antisymm (eLpNorm_mono_enorm_ae <| EventuallyEq.le hfg)
-    (eLpNorm_mono_nnnorm_ae <| (EventuallyEq.symm hfg).le)
+    (eLpNorm_mono_enorm_ae <| (EventuallyEq.symm hfg).le)
+
+@[deprecated (since := "2025-02-02")]
+alias eLpNorm_congr_nnnorm_ae := eLpNorm_congr_enorm_ae
 
 theorem eLpNorm_congr_norm_ae {f : α → F} {g : α → G} (hfg : ∀ᵐ x ∂μ, ‖f x‖ = ‖g x‖) :
     eLpNorm f p μ = eLpNorm g p μ :=
   eLpNorm_congr_nnnorm_ae <| hfg.mono fun _x hx => NNReal.eq hx
 
+-- XXXMR: need a zero element in ε
 open scoped symmDiff in
 theorem eLpNorm_indicator_sub_indicator (s t : Set α) (f : α → E) :
     eLpNorm (s.indicator f - t.indicator f) p μ = eLpNorm ((s ∆ t).indicator f) p μ :=
@@ -494,8 +519,26 @@ theorem eLpNorm'_norm {f : α → F} :
     eLpNorm' (fun a => ‖f a‖) q μ = eLpNorm' f q μ := by simp [eLpNorm'_eq_lintegral_enorm]
 
 @[simp]
+theorem eLpNorm'_enorm {f : α → ε} :
+    eLpNorm' (fun a => ‖f a‖ₑ) q μ = eLpNorm' f q μ := by simp [eLpNorm'_eq_lintegral_enorm]
+
+@[deprecated (since := "2024-07-27")]
+alias snorm'_norm := eLpNorm'_norm
+
+@[simp]
 theorem eLpNorm_norm (f : α → F) : eLpNorm (fun x => ‖f x‖) p μ = eLpNorm f p μ :=
   eLpNorm_congr_norm_ae <| Eventually.of_forall fun _ => norm_norm _
+
+--@[simp]
+theorem eLpNorm_enorm (f : α → ε) : eLpNorm (fun x => ‖f x‖ₑ) p μ = eLpNorm f p μ := by
+  --apply eLpNorm_congr_norm_ae --<| Eventually.of_forall fun _ => norm_norm _
+  sorry -- WIP!
+
+@[deprecated (since := "2024-07-27")]
+alias snorm_norm := eLpNorm_norm
+
+theorem eLpNorm'_enorm_rpow (f : α → F) (p q : ℝ) (hq_pos : 0 < q) :
+    eLpNorm' (fun x => ‖f x‖ₑ ^ q) p μ = eLpNorm' f (p * q) μ ^ q := by sorry -- WIP!
 
 theorem eLpNorm'_norm_rpow (f : α → F) (p q : ℝ) (hq_pos : 0 < q) :
     eLpNorm' (fun x => ‖f x‖ ^ q) p μ = eLpNorm' f (p * q) μ ^ q := by

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -21,8 +21,8 @@ and is almost everywhere strongly measurable.
 
 ## Main definitions
 
-* `eLpNorm' f p μ` : `(∫ ‖f a‖^p ∂μ) ^ (1/p)` for `f : α → F` and `p : ℝ`, where `α` is a measurable
-  space and `F` is a normed group.
+* `eLpNorm' f p μ` : `(∫ ‖f a‖^p ∂μ) ^ (1/p)` for `f : α → ε` and `p : ℝ`, where `α` is a measurable
+  space and `ε` is an enormed space (e.g., a normed group).
 * `eLpNormEssSup f μ` : seminorm in `ℒ∞`, equal to the essential supremum `essSup ‖f‖ μ`.
 * `eLpNorm f p μ` : for `p : ℝ≥0∞`, seminorm in `ℒp`, equal to `0` for `p=0`, to `eLpNorm' f p μ`
   for `0 < p < ∞` and to `eLpNormEssSup f μ` for `p = ∞`.

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -354,6 +354,7 @@ theorem memℒp_const (c : E) [IsFiniteMeasure μ] : Memℒp (fun _ : α => c) p
   refine ENNReal.rpow_lt_top_of_nonneg ?_ (measure_ne_top μ Set.univ)
   simp
 
+-- TODO: does this hold in ε, if c = ⊤?
 theorem memℒp_top_const (c : F) : Memℒp (fun _ : α => c) ∞ μ :=
   ⟨aestronglyMeasurable_const, by by_cases h : μ = 0 <;> simp [eLpNorm_const _, h]⟩
 
@@ -419,8 +420,7 @@ theorem eLpNorm_mono_enorm_ae {f : α → ε} {g : α → ε'} (h : ∀ᵐ x ∂
   split_ifs
   · exact le_rfl
   · exact essSup_mono_ae (h.mono fun x hx => hx)
-  · sorry -- type mismatch... refine eLpNorm'_mono_enorm_ae (f := f) (g := g) ?_
-    -- was: ENNReal.toReal_nonneg h
+  · exact eLpNorm'_mono_enorm_ae ENNReal.toReal_nonneg h
 
 @[deprecated (since := "2025-02-02")]
 alias eLpNorm_mono_nnnorm_ae := eLpNorm_mono_enorm_ae
@@ -430,12 +430,16 @@ theorem eLpNorm_mono_ae {f : α → ε} {g : α → ε'} (h : ∀ᵐ x ∂μ, �
   eLpNorm_mono_enorm_ae h
 
 theorem eLpNorm_mono_ae' {f : α → F} {g : α → G} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ ‖g x‖) :
-    eLpNorm f p μ ≤ eLpNorm g p μ :=
-  sorry -- TODO! proof was eLpNorm_mono_enorm_ae h
+    eLpNorm f p μ ≤ eLpNorm g p μ := by
+  apply eLpNorm_mono_enorm_ae
+  sorry -- familiar sorry, equal norm => equal enorm
 
 theorem eLpNorm_mono_ae_real {f : α → F} {g : α → ℝ} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ g x) :
     eLpNorm f p μ ≤ eLpNorm g p μ := by
-  refine eLpNorm_mono_ae <| h.mono fun _x hx => ?_-- TODO: hypothesis doesn't apply directly!
+  refine eLpNorm_mono_ae <| h.mono fun _x hx => ?_
+  have := hx.trans (le_abs_self _)
+  rw [← Real.norm_eq_abs] at this
+  -- now, the same familiar sorry as above
   sorry -- was: hx.trans ((le_abs_self _).trans (Real.norm_eq_abs _).symm.le)
 
 theorem eLpNorm_mono {f : α → ε} {g : α → ε'} (h : ∀ x, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
@@ -463,6 +467,7 @@ alias eLpNormEssSup_le_of_ae_nnnorm_bound := eLpNormEssSup_le_of_ae_enorm_bound
 theorem eLpNormEssSup_le_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) :
     eLpNormEssSup f μ ≤ ENNReal.ofReal C := by
   refine eLpNormEssSup_le_of_ae_enorm_bound <| hfC.mono fun _x hx => ?_
+  have := C.le_coe_toNNReal -- XXX: this is the lemma I need below!
   sorry -- was: hx.trans C.le_coe_toNNReal
 
 theorem eLpNormEssSup_lt_top_of_ae_enorm_bound {f : α → ε} {C : ℝ≥0} (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C) :
@@ -476,21 +481,30 @@ theorem eLpNormEssSup_lt_top_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ 
     eLpNormEssSup f μ < ∞ :=
   (eLpNormEssSup_le_of_ae_bound hfC).trans_lt ENNReal.ofReal_lt_top
 
-theorem eLpNorm_le_of_ae_nnnorm_bound {f : α → F} {C : ℝ≥0} (hfC : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ C) :
+@[deprecated (since := "2024-07-27")]
+alias snormEssSup_lt_top_of_ae_bound := eLpNormEssSup_lt_top_of_ae_bound
+
+theorem eLpNorm_le_of_ae_enorm_bound {f : α → ε} {C : ℝ≥0} (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C) :
     eLpNorm f p μ ≤ C • μ Set.univ ^ p.toReal⁻¹ := by
   rcases eq_zero_or_neZero μ with rfl | hμ
   · simp
   by_cases hp : p = 0
   · simp [hp]
-  have : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ ‖(C : ℝ)‖₊ := hfC.mono fun x hx => hx.trans_eq C.nnnorm_eq.symm
-  sorry /-
+  have : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖(C : ℝ)‖ₑ := hfC.mono fun x hx => hx.trans_eq C.enorm_eq.symm
   refine (eLpNorm_mono_ae this).trans_eq ?_
   rw [eLpNorm_const _ hp (NeZero.ne μ), C.enorm_eq, one_div, ENNReal.smul_def, smul_eq_mul]
 
-theorem eLpNorm_le_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) :
+@[deprecated (since := "2025-02-22")]
+alias eLpNorm_le_of_ae_nnnorm_bound := eLpNorm_le_of_ae_enorm_bound
+
+@[deprecated (since := "2024-07-27")]
+alias snorm_le_of_ae_nnnorm_bound := eLpNorm_le_of_ae_nnnorm_bound
+
+-- FIXME: perhaps the statement makes no sense now: happy to change it
+theorem eLpNorm_le_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C.toNNReal) :
     eLpNorm f p μ ≤ μ Set.univ ^ p.toReal⁻¹ * ENNReal.ofReal C := by
   rw [← mul_comm]
-  exact eLpNorm_le_of_ae_nnnorm_bound (hfC.mono fun x hx => hx.trans C.le_coe_toNNReal)
+  exact eLpNorm_le_of_ae_enorm_bound (hfC.mono fun x hx => hx)
 
 @[deprecated (since := "2024-07-27")]
 alias snorm_le_of_ae_bound := eLpNorm_le_of_ae_bound
@@ -529,16 +543,25 @@ alias snorm'_norm := eLpNorm'_norm
 theorem eLpNorm_norm (f : α → F) : eLpNorm (fun x => ‖f x‖) p μ = eLpNorm f p μ :=
   eLpNorm_congr_norm_ae <| Eventually.of_forall fun _ => norm_norm _
 
---@[simp]
-theorem eLpNorm_enorm (f : α → ε) : eLpNorm (fun x => ‖f x‖ₑ) p μ = eLpNorm f p μ := by
-  --apply eLpNorm_congr_norm_ae --<| Eventually.of_forall fun _ => norm_norm _
-  sorry -- WIP!
+@[simp]
+theorem eLpNorm_enorm (f : α → ε) : eLpNorm (fun x => ‖f x‖ₑ) p μ = eLpNorm f p μ :=
+  -- TODO: add a lemma enorm_enorm and use it here!
+  eLpNorm_congr_enorm_ae <| Eventually.of_forall fun _ => rfl
 
 @[deprecated (since := "2024-07-27")]
 alias snorm_norm := eLpNorm_norm
 
-theorem eLpNorm'_enorm_rpow (f : α → F) (p q : ℝ) (hq_pos : 0 < q) :
-    eLpNorm' (fun x => ‖f x‖ₑ ^ q) p μ = eLpNorm' f (p * q) μ ^ q := by sorry -- WIP!
+theorem eLpNorm'_enorm_rpow (f : α → ε) (p q : ℝ) (hq_pos : 0 < q) :
+    eLpNorm' (fun x => ‖f x‖ₑ ^ q) p μ = eLpNorm' f (p * q) μ ^ q := by
+  --simp_rw [show ‖‖f a‖ₑ ^ q‖ₑ = ‖f a ^ q‖ₑ by rfl]
+  simp_rw [eLpNorm', ← ENNReal.rpow_mul, ← one_div_mul_one_div, one_div,
+    mul_assoc, inv_mul_cancel₀ hq_pos.ne.symm, mul_one]
+  -- XXX: need the enorm_enorm lemma now!
+  --show ‖‖f _‖ₑ ^ q‖ₑ = ‖f _ ^ q‖ₑ by rfl,
+  --← ofReal_norm_eq_enorm,
+  --  Real.norm_eq_abs, abs_eq_self.mpr (Real.rpow_nonneg (norm_nonneg _) _), mul_comm p,
+  --  ← ENNReal.ofReal_rpow_of_nonneg (norm_nonneg _) hq_pos.le, ENNReal.rpow_mul]
+  sorry
 
 theorem eLpNorm'_norm_rpow (f : α → F) (p q : ℝ) (hq_pos : 0 < q) :
     eLpNorm' (fun x => ‖f x‖ ^ q) p μ = eLpNorm' f (p * q) μ ^ q := by
@@ -547,19 +570,16 @@ theorem eLpNorm'_norm_rpow (f : α → F) (p q : ℝ) (hq_pos : 0 < q) :
     Real.norm_eq_abs, abs_eq_self.mpr (Real.rpow_nonneg (norm_nonneg _) _), mul_comm p,
     ← ENNReal.ofReal_rpow_of_nonneg (norm_nonneg _) hq_pos.le, ENNReal.rpow_mul]
 
-theorem eLpNorm_norm_rpow (f : α → F) (hq_pos : 0 < q) :
-    eLpNorm (fun x => ‖f x‖ ^ q) p μ = eLpNorm f (p * ENNReal.ofReal q) μ ^ q := by
+@[deprecated (since := "2024-07-27")]
+alias snorm'_norm_rpow := eLpNorm'_norm_rpow
+
+theorem eLpNorm_enorm_rpow (f : α → ε) (hq_pos : 0 < q) :
+    eLpNorm (fun x => ‖f x‖ₑ ^ q) p μ = eLpNorm f (p * ENNReal.ofReal q) μ ^ q := by
   by_cases h0 : p = 0
   · simp [h0, ENNReal.zero_rpow_of_pos hq_pos]
   by_cases hp_top : p = ∞
   · simp only [hp_top, eLpNorm_exponent_top, ENNReal.top_mul', hq_pos.not_le,
       ENNReal.ofReal_eq_zero, if_false, eLpNorm_exponent_top, eLpNormEssSup_eq_essSup_enorm]
-    have h_rpow : essSup (‖‖f ·‖ ^ q‖ₑ) μ = essSup (‖f ·‖ₑ ^ q) μ := by
-      congr
-      ext1 x
-      conv_rhs => rw [← enorm_norm]
-      rw [← Real.enorm_rpow_of_nonneg (norm_nonneg _) hq_pos.le]
-    rw [h_rpow]
     have h_rpow_mono := ENNReal.strictMono_rpow_of_pos hq_pos
     have h_rpow_surj := (ENNReal.rpow_left_bijective hq_pos.ne.symm).2
     let iso := h_rpow_mono.orderIsoOfSurjective _ h_rpow_surj
@@ -570,44 +590,67 @@ theorem eLpNorm_norm_rpow (f : α → F) (hq_pos : 0 < q) :
     rwa [Ne, ENNReal.ofReal_eq_zero, not_le]
   swap; · exact ENNReal.mul_ne_top hp_top ENNReal.ofReal_ne_top
   rw [ENNReal.toReal_mul, ENNReal.toReal_ofReal hq_pos.le]
-  exact eLpNorm'_norm_rpow f p.toReal q hq_pos
+  exact eLpNorm'_enorm_rpow f p.toReal q hq_pos
 
-theorem eLpNorm_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) : eLpNorm f p μ = eLpNorm g p μ :=
-  eLpNorm_congr_norm_ae <| hfg.mono fun _x hx => hx ▸ rfl
+-- TODO: is this lemma still useful? if so, fix the proof below!
+theorem eLpNorm_norm_rpow (f : α → F) (hq_pos : 0 < q) :
+    eLpNorm (fun x => ‖f x‖ ^ q) p μ = eLpNorm f (p * ENNReal.ofReal q) μ ^ q := by
+  rw [← eLpNorm_enorm_rpow f hq_pos]
+  -- missing: ‖f x‖ ^ q and ‖f x‖ₑ ^ q have the same eLpNorm
+  sorry
 
-theorem memℒp_congr_ae {f g : α → E} (hfg : f =ᵐ[μ] g) : Memℒp f p μ ↔ Memℒp g p μ := by
+@[deprecated (since := "2024-07-27")]
+alias snorm_norm_rpow := eLpNorm_norm_rpow
+
+theorem eLpNorm_congr_ae {f g : α → ε} (hfg : f =ᵐ[μ] g) : eLpNorm f p μ = eLpNorm g p μ :=
+  eLpNorm_congr_enorm_ae <| hfg.mono fun _x hx => hx ▸ rfl
+
+#exit
+
+theorem memℒp_congr_ae [TopologicalSpace ε] {f g : α → ε} (hfg : f =ᵐ[μ] g) :
+    Memℒp f p μ ↔ Memℒp g p μ := by
   simp only [Memℒp, eLpNorm_congr_ae hfg, aestronglyMeasurable_congr hfg]
 
-theorem Memℒp.ae_eq {f g : α → E} (hfg : f =ᵐ[μ] g) (hf_Lp : Memℒp f p μ) : Memℒp g p μ :=
+theorem Memℒp.ae_eq [TopologicalSpace ε] {f g : α → ε} (hfg : f =ᵐ[μ] g) (hf_Lp : Memℒp f p μ) :
+    Memℒp g p μ :=
   (memℒp_congr_ae hfg).1 hf_Lp
 
-theorem Memℒp.of_le {f : α → E} {g : α → F} (hg : Memℒp g p μ) (hf : AEStronglyMeasurable f μ)
-    (hfg : ∀ᵐ x ∂μ, ‖f x‖ ≤ ‖g x‖) : Memℒp f p μ :=
+theorem Memℒp.of_le [TopologicalSpace ε] [TopologicalSpace ε'] {f : α → ε} {g : α → ε'}
+    (hg : Memℒp g p μ) (hf : AEStronglyMeasurable f μ)
+    (hfg : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖g x‖ₑ) : Memℒp f p μ :=
   ⟨hf, (eLpNorm_mono_ae hfg).trans_lt hg.eLpNorm_lt_top⟩
 
 alias Memℒp.mono := Memℒp.of_le
 
 theorem Memℒp.mono' {f : α → E} {g : α → ℝ} (hg : Memℒp g p μ) (hf : AEStronglyMeasurable f μ)
-    (h : ∀ᵐ a ∂μ, ‖f a‖ ≤ g a) : Memℒp f p μ :=
-  hg.mono hf <| h.mono fun _x hx => le_trans hx (le_abs_self _)
+    (h : ∀ᵐ a ∂μ, ‖f a‖ ≤ g a) : Memℒp f p μ := by
+  refine hg.mono hf <| h.mono fun _x hx => ?_
+  have : ‖f _x‖ ≤ ‖g _x‖ := hx.trans (le_abs_self _)
+  sorry -- familiar sorry now
 
-theorem Memℒp.congr_norm {f : α → E} {g : α → F} (hf : Memℒp f p μ) (hg : AEStronglyMeasurable g μ)
-    (h : ∀ᵐ a ∂μ, ‖f a‖ = ‖g a‖) : Memℒp g p μ :=
+theorem Memℒp.congr_norm [TopologicalSpace ε] [TopologicalSpace ε'] {f : α → ε} {g : α → ε'}
+    (hf : Memℒp f p μ) (hg : AEStronglyMeasurable g μ)
+    (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) : Memℒp g p μ :=
   hf.mono hg <| EventuallyEq.le <| EventuallyEq.symm h
 
-theorem memℒp_congr_norm {f : α → E} {g : α → F} (hf : AEStronglyMeasurable f μ)
-    (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ = ‖g a‖) : Memℒp f p μ ↔ Memℒp g p μ :=
+theorem memℒp_congr_norm [TopologicalSpace ε] [TopologicalSpace ε'] {f : α → ε} {g : α → ε'}
+    (hf : AEStronglyMeasurable f μ)
+    (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) : Memℒp f p μ ↔ Memℒp g p μ :=
   ⟨fun h2f => h2f.congr_norm hg h, fun h2g => h2g.congr_norm hf <| EventuallyEq.symm h⟩
 
-theorem memℒp_top_of_bound {f : α → E} (hf : AEStronglyMeasurable f μ) (C : ℝ)
-    (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) : Memℒp f ∞ μ :=
+theorem memℒp_top_of_bound [TopologicalSpace ε] {f : α → ε}
+    (hf : AEStronglyMeasurable f μ) (C : ℝ)
+    (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C.toNNReal) : Memℒp f ∞ μ :=
   ⟨hf, by
     rw [eLpNorm_exponent_top]
-    exact eLpNormEssSup_lt_top_of_ae_bound hfC⟩
+    exact eLpNormEssSup_lt_top_of_ae_enorm_bound hfC⟩
 
-theorem Memℒp.of_bound [IsFiniteMeasure μ] {f : α → E} (hf : AEStronglyMeasurable f μ) (C : ℝ)
-    (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) : Memℒp f p μ :=
-  (memℒp_const C).of_le hf (hfC.mono fun _x hx => le_trans hx (le_abs_self _))
+theorem Memℒp.of_bound [TopologicalSpace ε] [IsFiniteMeasure μ] {f : α → ε}
+    (hf : AEStronglyMeasurable f μ) (C : ℝ)
+    (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C.toNNReal) : Memℒp f p μ := by
+  refine (memℒp_const C).of_le hf (hfC.mono fun _x hx => ?_)
+  apply hx.trans ?_
+  sorry -- left: C.toNNReal ≤ ‖C‖ₑ
 
 theorem memℒp_of_bounded [IsFiniteMeasure μ]
     {a b : ℝ} {f : α → ℝ} (h : ∀ᵐ x ∂μ, f x ∈ Set.Icc a b)
@@ -642,6 +685,7 @@ theorem Memℒp.mono_measure [TopologicalSpace ε] {f : α → ε} (hμν : ν �
     Memℒp f p ν :=
   ⟨hf.1.mono_measure hμν, (eLpNorm_mono_measure f hμν).trans_lt hf.2⟩
 
+-- TODO: can this also be generalised?
 section Indicator
 variable {c : ε} {hf : AEStronglyMeasurable f μ} {s : Set α}
 
@@ -677,8 +721,7 @@ lemma eLpNorm_restrict_le (f : α → F) (p : ℝ≥0∞) (μ : Measure α) (s :
 
 lemma eLpNorm_indicator_le (f : α → E) : eLpNorm (s.indicator f) p μ ≤ eLpNorm f p μ := by
   refine eLpNorm_mono_ae <| .of_forall fun x ↦ ?_
-  suffices ‖s.indicator f x‖₊ ≤ ‖f x‖₊ by exact NNReal.coe_mono this
-  rw [nnnorm_indicator_eq_indicator_nnnorm]
+  rw [enorm_indicator_eq_indicator_enorm]
   exact s.indicator_le_self _ x
 
 lemma eLpNormEssSup_indicator_le (s : Set α) (f : α → G) :
@@ -742,8 +785,11 @@ lemma eLpNorm_indicator_const_le (c : G) (p : ℝ≥0∞) :
     exact eLpNormEssSup_indicator_const_le _ _
   let t := toMeasurable μ s
   calc
-    eLpNorm (s.indicator fun _ => c) p μ ≤ eLpNorm (t.indicator fun _ => c) p μ :=
-      eLpNorm_mono (norm_indicator_le_of_subset (subset_toMeasurable _ _) _)
+    eLpNorm (s.indicator fun _ => c) p μ ≤ eLpNorm (t.indicator fun _ => c) p μ := by
+      refine eLpNorm_mono ?_
+      intro x
+      sorry -- apply enorm_indicator_le_of_subset. TODO: wait until recompilation
+      --eLpNorm_mono (norm_indicator_le_of_subset (subset_toMeasurable _ _) _)
     _ = ‖c‖ₑ * μ t ^ (1 / p.toReal) :=
       eLpNorm_indicator_const (measurableSet_toMeasurable ..) hp h'p
     _ = ‖c‖ₑ * μ s ^ (1 / p.toReal) := by rw [measure_toMeasurable]
@@ -967,10 +1013,14 @@ theorem ae_le_eLpNormEssSup {f : α → ε} : ∀ᵐ y ∂μ, ‖f y‖ₑ ≤ e
   ae_le_essSup
 
 lemma eLpNormEssSup_lt_top_iff_isBoundedUnder :
-    eLpNormEssSup f μ < ⊤ ↔ IsBoundedUnder (· ≤ ·) (ae μ) fun x ↦ ‖f x‖₊ where
+    eLpNormEssSup f μ < ⊤ ↔ IsBoundedUnder (· ≤ ·) (ae μ) fun x ↦ ‖f x‖ₑ where
   mp h := ⟨(eLpNormEssSup f μ).toNNReal, by
-    simp_rw [← ENNReal.coe_le_coe, ENNReal.coe_toNNReal h.ne]; exact ae_le_eLpNormEssSup⟩
-  mpr := by rintro ⟨C, hC⟩; exact eLpNormEssSup_lt_top_of_ae_nnnorm_bound (C := C) hC
+    sorry⟩
+    -- was: simp_rw [← ENNReal.coe_le_coe, ENNReal.coe_toNNReal h.ne]; exact ae_le_eLpNormEssSup
+  mpr := by
+    rintro ⟨C, hC⟩
+    apply eLpNormEssSup_lt_top_of_ae_enorm_bound --(C := C.toNNReal) hC
+    repeat sorry -- TODO: fix this proof!
 
 theorem meas_eLpNormEssSup_lt {f : α → ε} : μ { y | eLpNormEssSup f μ < ‖f y‖ₑ } = 0 :=
   meas_essSup_lt
@@ -988,8 +1038,11 @@ lemma eLpNorm_lt_top_of_finite [Finite α] [IsFiniteMeasure μ] : eLpNorm f p μ
   exact Finite.exists_le _
 
 @[simp] lemma Memℒp.of_discrete [DiscreteMeasurableSpace α] [Finite α] [IsFiniteMeasure μ] :
-    Memℒp f p μ :=
-  let ⟨C, hC⟩ := Finite.exists_le (‖f ·‖₊); .of_bound .of_finite C <| .of_forall hC
+    Memℒp f p μ := by
+  let ⟨C, hC⟩ := Finite.exists_le (‖f ·‖ₑ);
+  apply Memℒp.of_bound
+  -- TODO: complete this, was: --.of_finite C <| .of_forall hC
+  repeat sorry
 
 @[simp] lemma eLpNorm_of_isEmpty [IsEmpty α] (f : α → E) (p : ℝ≥0∞) : eLpNorm f p μ = 0 := by
   simp [Subsingleton.elim f 0]
@@ -1306,8 +1359,9 @@ theorem _root_.Continuous.memℒp_top_of_hasCompactSupport
     {f : X → E} (hf : Continuous f) (h'f : HasCompactSupport f) (μ : Measure X) : Memℒp f ⊤ μ := by
   borelize E
   rcases hf.bounded_above_of_compact_support h'f with ⟨C, hC⟩
-  apply memℒp_top_of_bound ?_ C (Filter.Eventually.of_forall hC)
-  exact (hf.stronglyMeasurable_of_hasCompactSupport h'f).aestronglyMeasurable
+  sorry -- TODO: bounded_above_of_compact_support produces something with ‖f‖ ≤ C...
+  -- apply memℒp_top_of_bound ?_ C (Filter.Eventually.of_forall hC)
+  -- exact (hf.stronglyMeasurable_of_hasCompactSupport h'f).aestronglyMeasurable
 
 section UnifTight
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -389,47 +389,48 @@ theorem eLpNorm'_congr_enorm_ae {f g : α → ε} (hfg : ∀ᵐ x ∂μ, ‖f x�
 
 @[deprecated (since := "2025-02-02")] alias eLpNorm'_congr_nnnorm_ae := eLpNorm'_congr_enorm_ae
 
+-- nnnorm versions of this also hold; I'm omitting them since ‖‖ₑ seems to be more useful
+
 -- TODO: does this exist already? Is there a better proof? Better name!
 -- make an iff!
--- name. enorm_eq_enorm_iff_norm ?
--- enorm_eq_iff_norm_eq
-theorem foo {F : Type*} {G : Type*} [NormedAddCommGroup F] [NormedAddCommGroup G]
-    {x : F} {y : G} (h : ‖x‖ = ‖y‖) : ‖x‖ₑ = ‖y‖ₑ := by
-  -- I can prove this first (this should also exist, if it doesn't already!)
-  have : ‖x‖₊ = ‖y‖₊ := by
-    simp only [← coe_nnnorm] at h
-    apply NNReal.coe_injective
-    exact h
-  simp only [enorm_eq_nnnorm]
-  congr
+-- Is `enorm_eq_enorm_iff_norm` a better name?
+theorem enorm_eq_iff_norm_eq {F : Type*} {G : Type*} [NormedAddCommGroup F] [NormedAddCommGroup G]
+    {x : F} {y : G} :
 
-theorem foo_leq {F : Type*} {G : Type*} [NormedAddCommGroup F] [NormedAddCommGroup G]
-    {x : F} {y : G} (h : ‖x‖ ≤ ‖y‖) : ‖x‖ₑ ≤ ‖y‖ₑ := by
-  -- I can prove this first (this should also exist, if it doesn't already!)
-  have : ‖x‖₊ ≤ ‖y‖₊ := by
-    simp only [← coe_nnnorm] at h
-    apply NNReal.coe_mono
-    exact h
-  simp only [enorm_eq_nnnorm]
-  gcongr
 
-theorem foo_le {F : Type*} {G : Type*} [NormedAddCommGroup F] [NormedAddCommGroup G]
-    {x : F} {y : G} (h : ‖x‖ < ‖y‖) : ‖x‖ₑ < ‖y‖ₑ := by
-  -- I can prove this first (this should also exist, if it doesn't already!)
+
+    ‖x‖ = ‖y‖ ↔ ‖x‖ₑ = ‖y‖ₑ := by
   simp only [← ofReal_norm]
-  refine (ENNReal.ofReal_lt_ofReal_iff_of_nonneg ?_).mpr h
-  apply norm_nonneg _
-  -- -- enorm = ENNReal.ofReal norm is a new mathlib lemma, in NormedGr
-  -- have : ‖x‖₊ < ‖y‖₊ := by
+  constructor
+  · intro h
+    congr
+  · intro h
+    refine (Real.toNNReal_eq_toNNReal_iff (by positivity) (by positivity)).mp (ENNReal.coe_inj.mp h)
+
+    exact ENNReal.coe_inj.mp h
+  -- -- I can prove this first (this should also exist, if it doesn't already!)
+  -- have : ‖x‖₊ = ‖y‖₊ := by
   --   simp only [← coe_nnnorm] at h
-  --   sorry -- apply NNReal.coe_mono
-  --   -- exact h
+  --   apply NNReal.coe_injective
+  --   exact h
   -- simp only [enorm_eq_nnnorm]
-  -- gcongr
+  -- congr
+
+theorem enorm_leq_iff_norm_leq {F : Type*} {G : Type*} [NormedAddCommGroup F] [NormedAddCommGroup G]
+    {x : F} {y : G} (h : ‖x‖ ≤ ‖y‖) : ‖x‖ₑ ≤ ‖y‖ₑ := by
+  simp only [← ofReal_norm]
+  exact ENNReal.ofReal_le_ofReal h
+
+theorem enorm_le_iff_norm_le {F : Type*} {G : Type*} [NormedAddCommGroup F] [NormedAddCommGroup G]
+    {x : F} {y : G} (h : ‖x‖ < ‖y‖) : ‖x‖ₑ < ‖y‖ₑ := by
+  simp only [← ofReal_norm]
+  exact (ENNReal.ofReal_lt_ofReal_iff_of_nonneg (norm_nonneg _)).mpr h
+
+#exit
 
 theorem eLpNorm'_congr_norm_ae {f g : α → F} (hfg : ∀ᵐ x ∂μ, ‖f x‖ = ‖g x‖) :
     eLpNorm' f q μ = eLpNorm' g q μ :=
-  eLpNorm'_congr_enorm_ae <| hfg.mono fun _x hx ↦ foo hx
+  eLpNorm'_congr_enorm_ae <| hfg.mono fun _x hx ↦ enorm_eq_iff_norm_eq hx
 
 theorem eLpNorm'_congr_ae {f g : α → ε} (hfg : f =ᵐ[μ] g) : eLpNorm' f q μ = eLpNorm' g q μ :=
   eLpNorm'_congr_enorm_ae (hfg.fun_comp _)
@@ -462,16 +463,17 @@ theorem eLpNorm_mono_ae {f : α → ε} {g : α → ε'} (h : ∀ᵐ x ∂μ, �
 
 theorem eLpNorm_mono_ae' {f : α → F} {g : α → G} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ ‖g x‖) :
     eLpNorm f p μ ≤ eLpNorm g p μ := by
-  apply eLpNorm_mono_enorm_ae --(foo h)
+  apply eLpNorm_mono_enorm_ae --(enorm_eq_iff_norm_eq_leq h)
+  --simp_rw [enorm_leq_iff_norm_leq] at h
   convert h -- nicer. SIMP_RW!
   constructor
   · intro h
     sorry -- other direction
-  apply fun h ↦ foo_leq h
+  apply fun h ↦ enorm_leq_iff_norm_leq h
 
 theorem eLpNorm_mono_ae_real {f : α → F} {g : α → ℝ} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ g x) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
-  eLpNorm_mono_ae <| h.mono fun _x hx ↦ foo_leq ((Real.norm_eq_abs _) ▸ hx.trans (le_abs_self _))
+  eLpNorm_mono_ae <| h.mono fun _x hx ↦ enorm_leq_iff_norm_leq ((Real.norm_eq_abs _) ▸ hx.trans (le_abs_self _))
 
 theorem eLpNorm_mono {f : α → ε} {g : α → ε'} (h : ∀ x, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
@@ -544,7 +546,7 @@ alias eLpNorm_congr_nnnorm_ae := eLpNorm_congr_enorm_ae
 
 theorem eLpNorm_congr_norm_ae {f : α → F} {g : α → G} (hfg : ∀ᵐ x ∂μ, ‖f x‖ = ‖g x‖) :
     eLpNorm f p μ = eLpNorm g p μ :=
-  eLpNorm_congr_enorm_ae <| hfg.mono fun _x hx ↦ foo hx
+  eLpNorm_congr_enorm_ae <| hfg.mono fun _x hx ↦ enorm_eq_iff_norm_eq hx
 
 -- XXXMR: need a zero element in ε
 open scoped symmDiff in
@@ -642,7 +644,7 @@ theorem Memℒp.mono' [TopologicalSpace ε] {f : α → ε} {g : α → ℝ≥0}
 
 theorem Memℒp.mono'' {f : α → E} {g : α → ℝ} (hg : Memℒp g p μ) (hf : AEStronglyMeasurable f μ)
     (h : ∀ᵐ a ∂μ, ‖f a‖ ≤ g a) : Memℒp f p μ :=
-  hg.mono hf <| h.mono fun _x hx ↦ foo_leq (hx.trans (le_abs_self _))
+  hg.mono hf <| h.mono fun _x hx ↦ enorm_leq_iff_norm_leq (hx.trans (le_abs_self _))
 
 theorem Memℒp.congr_norm [TopologicalSpace ε] [TopologicalSpace ε'] {f : α → ε} {g : α → ε'}
     (hf : Memℒp f p μ) (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) :

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -555,20 +555,20 @@ theorem memℒp_of_bounded [IsFiniteMeasure μ]
   (memℒp_const (max |a| |b|)).mono' hX (by filter_upwards [ha, hb] with x using abs_le_max_abs_abs)
 
 @[gcongr, mono]
-theorem eLpNorm'_mono_measure (f : α → F) (hμν : ν ≤ μ) (hq : 0 ≤ q) :
+theorem eLpNorm'_mono_measure (f : α → ε) (hμν : ν ≤ μ) (hq : 0 ≤ q) :
     eLpNorm' f q ν ≤ eLpNorm' f q μ := by
   simp_rw [eLpNorm']
   gcongr
   exact lintegral_mono' hμν le_rfl
 
 @[gcongr, mono]
-theorem eLpNormEssSup_mono_measure (f : α → F) (hμν : ν ≪ μ) :
+theorem eLpNormEssSup_mono_measure (f : α → ε) (hμν : ν ≪ μ) :
     eLpNormEssSup f ν ≤ eLpNormEssSup f μ := by
   simp_rw [eLpNormEssSup]
   exact essSup_mono_measure hμν
 
 @[gcongr, mono]
-theorem eLpNorm_mono_measure (f : α → F) (hμν : ν ≤ μ) : eLpNorm f p ν ≤ eLpNorm f p μ := by
+theorem eLpNorm_mono_measure (f : α → ε) (hμν : ν ≤ μ) : eLpNorm f p ν ≤ eLpNorm f p μ := by
   by_cases hp0 : p = 0
   · simp [hp0]
   by_cases hp_top : p = ∞
@@ -576,11 +576,12 @@ theorem eLpNorm_mono_measure (f : α → F) (hμν : ν ≤ μ) : eLpNorm f p ν
   simp_rw [eLpNorm_eq_eLpNorm' hp0 hp_top]
   exact eLpNorm'_mono_measure f hμν ENNReal.toReal_nonneg
 
-theorem Memℒp.mono_measure {f : α → E} (hμν : ν ≤ μ) (hf : Memℒp f p μ) : Memℒp f p ν :=
+theorem Memℒp.mono_measure [TopologicalSpace ε] {f : α → ε} (hμν : ν ≤ μ) (hf : Memℒp f p μ) :
+    Memℒp f p ν :=
   ⟨hf.1.mono_measure hμν, (eLpNorm_mono_measure f hμν).trans_lt hf.2⟩
 
 section Indicator
-variable {c : F} {hf : AEStronglyMeasurable f μ} {s : Set α}
+variable {c : ε} {hf : AEStronglyMeasurable f μ} {s : Set α}
 
 lemma eLpNorm_indicator_eq_eLpNorm_restrict (hs : MeasurableSet s) :
     eLpNorm (s.indicator f) p μ = eLpNorm f p (μ.restrict s) := by
@@ -640,6 +641,9 @@ lemma eLpNormEssSup_indicator_const_eq (s : Set α) (c : G) (hμs : μ s ≠ 0) 
   refine hμs (measure_mono_null (fun x hx_mem => ?_) h')
   rw [Set.mem_setOf_eq, Set.indicator_of_mem hx_mem, enorm_eq_nnnorm]
 
+-- The following lemmas require [Zero F].
+variable {c : F}
+
 lemma eLpNorm_indicator_const₀ (hs : NullMeasurableSet s μ) (hp : p ≠ 0) (hp_top : p ≠ ∞) :
     eLpNorm (s.indicator fun _ => c) p μ = ‖c‖ₑ * μ s ^ (1 / p.toReal) :=
   have hp_pos : 0 < p.toReal := ENNReal.toReal_pos hp hp_top
@@ -697,14 +701,14 @@ lemma memℒp_indicator_const (p : ℝ≥0∞) (hs : MeasurableSet s) (c : E) (h
   · have := Fact.mk hμ.lt_top
     apply memℒp_const
 
-lemma eLpNormEssSup_piecewise (f g : α → E) [DecidablePred (· ∈ s)] (hs : MeasurableSet s) :
+lemma eLpNormEssSup_piecewise (f g : α → ε) [DecidablePred (· ∈ s)] (hs : MeasurableSet s) :
     eLpNormEssSup (Set.piecewise s f g) μ
       = max (eLpNormEssSup f (μ.restrict s)) (eLpNormEssSup g (μ.restrict sᶜ)) := by
   simp only [eLpNormEssSup, ← ENNReal.essSup_piecewise hs]
   congr with x
   by_cases hx : x ∈ s <;> simp [hx]
 
-lemma eLpNorm_top_piecewise (f g : α → E) [DecidablePred (· ∈ s)] (hs : MeasurableSet s) :
+lemma eLpNorm_top_piecewise (f g : α → ε) [DecidablePred (· ∈ s)] (hs : MeasurableSet s) :
     eLpNorm (Set.piecewise s f g) ∞ μ
       = max (eLpNorm f ∞ (μ.restrict s)) (eLpNorm g ∞ (μ.restrict sᶜ)) :=
   eLpNormEssSup_piecewise f g hs
@@ -750,10 +754,11 @@ theorem eLpNorm_restrict_eq_of_support_subset {s : Set α} {f : α → F} (hsf :
     have : ¬(p.toReal ≤ 0) := by simpa only [not_le] using ENNReal.toReal_pos hp0 hp_top
     simpa [this] using hsf
 
-theorem Memℒp.restrict (s : Set α) {f : α → E} (hf : Memℒp f p μ) : Memℒp f p (μ.restrict s) :=
+theorem Memℒp.restrict [TopologicalSpace ε] (s : Set α) {f : α → ε} (hf : Memℒp f p μ) :
+    Memℒp f p (μ.restrict s) :=
   hf.mono_measure Measure.restrict_le_self
 
-theorem eLpNorm'_smul_measure {p : ℝ} (hp : 0 ≤ p) {f : α → F} (c : ℝ≥0∞) :
+theorem eLpNorm'_smul_measure {p : ℝ} (hp : 0 ≤ p) {f : α → ε} (c : ℝ≥0∞) :
     eLpNorm' f p (c • μ) = c ^ (1 / p) * eLpNorm' f p μ := by
   rw [eLpNorm', lintegral_smul_measure, ENNReal.mul_rpow_of_nonneg, eLpNorm']
   simp [hp]
@@ -771,7 +776,7 @@ end SMul
 
 /-- Use `eLpNorm_smul_measure_of_ne_top` instead. -/
 private theorem eLpNorm_smul_measure_of_ne_zero_of_ne_top {p : ℝ≥0∞} (hp_ne_zero : p ≠ 0)
-    (hp_ne_top : p ≠ ∞) {f : α → F} (c : ℝ≥0∞) :
+    (hp_ne_top : p ≠ ∞) {f : α → ε} (c : ℝ≥0∞) :
     eLpNorm f p (c • μ) = c ^ (1 / p).toReal • eLpNorm f p μ := by
   simp_rw [eLpNorm_eq_eLpNorm' hp_ne_zero hp_ne_top]
   rw [eLpNorm'_smul_measure ENNReal.toReal_nonneg]
@@ -877,7 +882,7 @@ theorem eLpNorm'_eq_zero_iff (hq0_lt : 0 < q) {f : α → E} (hf : AEStronglyMea
     eLpNorm' f q μ = 0 ↔ f =ᵐ[μ] 0 :=
   ⟨ae_eq_zero_of_eLpNorm'_eq_zero (le_of_lt hq0_lt) hf, eLpNorm'_eq_zero_of_ae_zero hq0_lt⟩
 
-theorem coe_nnnorm_ae_le_eLpNormEssSup {_ : MeasurableSpace α} (f : α → F) (μ : Measure α) :
+theorem coe_nnnorm_ae_le_eLpNormEssSup {_ : MeasurableSpace α} (f : α → ε) (μ : Measure α) :
     ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ eLpNormEssSup f μ :=
   ENNReal.ae_le_essSup fun x => ‖f x‖ₑ
 
@@ -896,7 +901,7 @@ theorem eLpNorm_eq_zero_of_ae_zero {f : α → E} (hf : f =ᵐ[μ] 0) : eLpNorm 
   rw [← eLpNorm_zero (p := p) (μ := μ) (α := α) (F := E)]
   exact eLpNorm_congr_ae hf
 
-theorem ae_le_eLpNormEssSup {f : α → F} : ∀ᵐ y ∂μ, ‖f y‖ₑ ≤ eLpNormEssSup f μ :=
+theorem ae_le_eLpNormEssSup {f : α → ε} : ∀ᵐ y ∂μ, ‖f y‖ₑ ≤ eLpNormEssSup f μ :=
   ae_le_essSup
 
 lemma eLpNormEssSup_lt_top_iff_isBoundedUnder :
@@ -905,7 +910,7 @@ lemma eLpNormEssSup_lt_top_iff_isBoundedUnder :
     simp_rw [← ENNReal.coe_le_coe, ENNReal.coe_toNNReal h.ne]; exact ae_le_eLpNormEssSup⟩
   mpr := by rintro ⟨C, hC⟩; exact eLpNormEssSup_lt_top_of_ae_nnnorm_bound (C := C) hC
 
-theorem meas_eLpNormEssSup_lt {f : α → F} : μ { y | eLpNormEssSup f μ < ‖f y‖ₑ } = 0 :=
+theorem meas_eLpNormEssSup_lt {f : α → ε} : μ { y | eLpNormEssSup f μ < ‖f y‖ₑ } = 0 :=
   meas_essSup_lt
 
 lemma eLpNorm_lt_top_of_finite [Finite α] [IsFiniteMeasure μ] : eLpNorm f p μ < ∞ := by
@@ -1101,7 +1106,6 @@ end BoundedSMul
 ### Bounded actions by normed division rings
 The inequalities in the previous section are now tight.
 -/
-
 
 section NormedSpace
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -343,14 +343,16 @@ theorem eLpNorm_const_lt_top_iff {p : ℝ≥0∞} {c : F} (hp_ne_zero : p ≠ 0)
   simpa [hμ, hc, hμ_top, hμ_top.lt_top] using
     ENNReal.rpow_lt_top_of_nonneg (inv_nonneg.mpr hp.le) hμ_top
 
-theorem memℒp_const (c : E) [IsFiniteMeasure μ] : Memℒp (fun _ : α => c) p μ := by
+theorem memℒp_const [TopologicalSpace ε] (c : ε) [IsFiniteMeasure μ] :
+    Memℒp (fun _ : α => c) p μ := by
   refine ⟨aestronglyMeasurable_const, ?_⟩
   by_cases h0 : p = 0
   · simp [h0]
   by_cases hμ : μ = 0
   · simp [hμ]
   rw [eLpNorm_const c h0 hμ]
-  refine ENNReal.mul_lt_top ENNReal.coe_lt_top ?_
+  refine ENNReal.mul_lt_top ?_ ?_
+  · sorry -- was: ENNReal.coe_lt_top
   refine ENNReal.rpow_lt_top_of_nonneg ?_ (measure_ne_top μ Set.univ)
   simp
 
@@ -374,12 +376,7 @@ lemma eLpNorm'_mono_enorm_ae {f : α → ε} {g : α → ε'} (hq : 0 ≤ q) (h 
   refine lintegral_mono_ae (h.mono fun x hx => ?_)
   gcongr
 
-lemma eLpNorm'_mono_nnnorm_ae {f : α → F} {g : α → G} (hq : 0 ≤ q) (h : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ ‖g x‖₊) :
-    eLpNorm' f q μ ≤ eLpNorm' g q μ := by
-  apply eLpNorm'_mono_enorm_ae hq
-  dsimp [enorm]
-  simp_rw [ENNReal.coe_le_coe]
-  exact h
+@[deprecated (since := "2025-02-03")] alias eLpNorm'_mono_nnnorm_ae := eLpNorm'_mono_enorm_ae
 
 theorem eLpNorm'_mono_ae {f : α → ε} {g : α → ε'} (hq : 0 ≤ q) (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm' f q μ ≤ eLpNorm' g q μ :=
@@ -459,17 +456,11 @@ theorem eLpNorm_mono_ae {f : α → ε} {g : α → ε'} (h : ∀ᵐ x ∂μ, �
 theorem eLpNorm_mono_ae' {f : α → F} {g : α → G} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ ‖g x‖) :
     eLpNorm f p μ ≤ eLpNorm g p μ := by
   apply eLpNorm_mono_enorm_ae --(foo h)
-  -- TODO: how to use foo under a binder?
-  sorry -- familiar sorry, equal norm => equal enorm
+  sorry -- TODO: want to use foo under a binder, with the same set; how to do that *nicely*?
 
 theorem eLpNorm_mono_ae_real {f : α → F} {g : α → ℝ} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ g x) :
-    eLpNorm f p μ ≤ eLpNorm g p μ := by
-  refine eLpNorm_mono_ae <| h.mono fun _x hx => ?_
-  have := hx.trans (le_abs_self _)
-  rw [← Real.norm_eq_abs] at this
-  apply foo_leq this
-  -- FIXME: golf this; original proof was
-  -- was: hx.trans ((le_abs_self _).trans (Real.norm_eq_abs _).symm.le)
+    eLpNorm f p μ ≤ eLpNorm g p μ :=
+  eLpNorm_mono_ae <| h.mono fun _x hx ↦ foo_leq ((Real.norm_eq_abs _) ▸ hx.trans (le_abs_self _))
 
 theorem eLpNorm_mono {f : α → ε} {g : α → ε'} (h : ∀ x, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm f p μ ≤ eLpNorm g p μ :=
@@ -506,6 +497,7 @@ theorem eLpNormEssSup_lt_top_of_ae_enorm_bound {f : α → ε} {C : ℝ≥0} (hf
 @[deprecated (since := "2025-02-02")]
 alias eLpNormEssSup_lt_top_of_ae_nnnorm_bound := eLpNormEssSup_lt_top_of_ae_enorm_bound
 
+-- TODO: generalise this?
 theorem eLpNormEssSup_lt_top_of_ae_bound {f : α → F} {C : ℝ} (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) :
     eLpNormEssSup f μ < ∞ :=
   (eLpNormEssSup_le_of_ae_bound hfC).trans_lt ENNReal.ofReal_lt_top
@@ -628,23 +620,29 @@ theorem Memℒp.of_le [TopologicalSpace ε] [TopologicalSpace ε'] {f : α → �
 
 alias Memℒp.mono := Memℒp.of_le
 
-theorem Memℒp.mono' {f : α → E} {g : α → ℝ} (hg : Memℒp g p μ) (hf : AEStronglyMeasurable f μ)
+-- Is this version useful? The old version is now mono''.
+theorem Memℒp.mono' [TopologicalSpace ε] {f : α → ε} {g : α → ℝ≥0}
+    (hg : Memℒp g p μ) (hf : AEStronglyMeasurable f μ)
+    (h : ∀ᵐ a ∂μ, ‖f a‖ₑ ≤ g a) : Memℒp f p μ :=
+  hg.mono hf <| h.mono fun _x hx ↦ hx.trans <|
+    by simp only [coe_le_enorm, NNReal.nnnorm_eq_self, le_refl]
+
+theorem Memℒp.mono'' {f : α → E} {g : α → ℝ} (hg : Memℒp g p μ) (hf : AEStronglyMeasurable f μ)
     (h : ∀ᵐ a ∂μ, ‖f a‖ ≤ g a) : Memℒp f p μ :=
   hg.mono hf <| h.mono fun _x hx ↦ foo_leq (hx.trans (le_abs_self _))
 
 theorem Memℒp.congr_norm [TopologicalSpace ε] [TopologicalSpace ε'] {f : α → ε} {g : α → ε'}
-    (hf : Memℒp f p μ) (hg : AEStronglyMeasurable g μ)
-    (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) : Memℒp g p μ :=
+    (hf : Memℒp f p μ) (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) :
+    Memℒp g p μ :=
   hf.mono hg <| EventuallyEq.le <| EventuallyEq.symm h
 
 theorem memℒp_congr_norm [TopologicalSpace ε] [TopologicalSpace ε'] {f : α → ε} {g : α → ε'}
-    (hf : AEStronglyMeasurable f μ)
-    (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) : Memℒp f p μ ↔ Memℒp g p μ :=
+    (hf : AEStronglyMeasurable f μ) (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ a ∂μ, ‖f a‖ₑ = ‖g a‖ₑ) :
+    Memℒp f p μ ↔ Memℒp g p μ :=
   ⟨fun h2f => h2f.congr_norm hg h, fun h2g => h2g.congr_norm hf <| EventuallyEq.symm h⟩
 
 theorem memℒp_top_of_bound [TopologicalSpace ε] {f : α → ε}
-    (hf : AEStronglyMeasurable f μ) (C : ℝ)
-    (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C.toNNReal) : Memℒp f ∞ μ :=
+    (hf : AEStronglyMeasurable f μ) (C : ℝ) (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C.toNNReal) : Memℒp f ∞ μ :=
   ⟨hf, by
     rw [eLpNorm_exponent_top]
     exact eLpNormEssSup_lt_top_of_ae_enorm_bound hfC⟩
@@ -654,14 +652,15 @@ theorem Memℒp.of_bound [TopologicalSpace ε] [IsFiniteMeasure μ] {f : α → 
     (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C.toNNReal) : Memℒp f p μ := by
   refine (memℒp_const C).of_le hf (hfC.mono fun _x hx => ?_)
   apply hx.trans ?_
-  sorry -- left: C.toNNReal ≤ ‖C‖ₑ
+  simp only [coe_le_enorm]
+  sorry -- left: C.toNNReal ≤ ‖C‖₊... is this the right goal to have?
 
 theorem memℒp_of_bounded [IsFiniteMeasure μ]
     {a b : ℝ} {f : α → ℝ} (h : ∀ᵐ x ∂μ, f x ∈ Set.Icc a b)
     (hX : AEStronglyMeasurable f μ) (p : ENNReal) : Memℒp f p μ :=
   have ha : ∀ᵐ x ∂μ, a ≤ f x := h.mono fun ω h => h.1
   have hb : ∀ᵐ x ∂μ, f x ≤ b := h.mono fun ω h => h.2
-  (memℒp_const (max |a| |b|)).mono' hX (by filter_upwards [ha, hb] with x using abs_le_max_abs_abs)
+  (memℒp_const (max |a| |b|)).mono'' hX (by filter_upwards [ha, hb] with x using abs_le_max_abs_abs)
 
 @[gcongr, mono]
 theorem eLpNorm'_mono_measure (f : α → ε) (hμν : ν ≤ μ) (hq : 0 ≤ q) :
@@ -719,7 +718,7 @@ lemma eLpNormEssSup_indicator_eq_eLpNormEssSup_restrict (hs : MeasurableSet s) :
     eLpNormEssSup (s.indicator f) μ = eLpNormEssSup f (μ.restrict s) := by
   simp_rw [← eLpNorm_exponent_top, eLpNorm_indicator_eq_eLpNorm_restrict hs]
 
-lemma eLpNorm_restrict_le (f : α → F) (p : ℝ≥0∞) (μ : Measure α) (s : Set α) :
+lemma eLpNorm_restrict_le (f : α → ε) (p : ℝ≥0∞) (μ : Measure α) (s : Set α) :
     eLpNorm f p (μ.restrict s) ≤ eLpNorm f p μ :=
   eLpNorm_mono_measure f Measure.restrict_le_self
 
@@ -789,11 +788,8 @@ lemma eLpNorm_indicator_const_le (c : G) (p : ℝ≥0∞) :
     exact eLpNormEssSup_indicator_const_le _ _
   let t := toMeasurable μ s
   calc
-    eLpNorm (s.indicator fun _ => c) p μ ≤ eLpNorm (t.indicator fun _ => c) p μ := by
-      refine eLpNorm_mono ?_
-      intro x
-      sorry -- apply enorm_indicator_le_of_subset -- recompile, then should work!
-      --eLpNorm_mono (norm_indicator_le_of_subset (subset_toMeasurable _ _) _)
+    eLpNorm (s.indicator fun _ => c) p μ ≤ eLpNorm (t.indicator fun _ => c) p μ :=
+      eLpNorm_mono fun x ↦ (enorm_indicator_le_of_subset (subset_toMeasurable _ _)) _ _
     _ = ‖c‖ₑ * μ t ^ (1 / p.toReal) :=
       eLpNorm_indicator_const (measurableSet_toMeasurable ..) hp h'p
     _ = ‖c‖ₑ * μ s ^ (1 / p.toReal) := by rw [measure_toMeasurable]

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -767,7 +767,7 @@ section SMul
 variable {R : Type*} [Zero R] [SMulWithZero R ℝ≥0∞] [IsScalarTower R ℝ≥0∞ ℝ≥0∞]
   [NoZeroSMulDivisors R ℝ≥0∞] {c : R}
 
-@[simp] lemma eLpNormEssSup_smul_measure (hc : c ≠ 0) (f : α → F) :
+@[simp] lemma eLpNormEssSup_smul_measure (hc : c ≠ 0) (f : α → ε) :
     eLpNormEssSup f (c • μ) = eLpNormEssSup f μ := by
   simp_rw [eLpNormEssSup]
   exact essSup_smul_measure hc _
@@ -785,7 +785,7 @@ private theorem eLpNorm_smul_measure_of_ne_zero_of_ne_top {p : ℝ≥0∞} (hp_n
   rw [ENNReal.toReal_inv]
 
 /-- See `eLpNorm_smul_measure_of_ne_zero'` for a version with scalar multiplication by `ℝ≥0`. -/
-theorem eLpNorm_smul_measure_of_ne_zero {c : ℝ≥0∞} (hc : c ≠ 0) (f : α → F) (p : ℝ≥0∞)
+theorem eLpNorm_smul_measure_of_ne_zero {c : ℝ≥0∞} (hc : c ≠ 0) (f : α → ε) (p : ℝ≥0∞)
     (μ : Measure α) : eLpNorm f p (c • μ) = c ^ (1 / p).toReal • eLpNorm f p μ := by
   by_cases hp0 : p = 0
   · simp [hp0]
@@ -794,24 +794,24 @@ theorem eLpNorm_smul_measure_of_ne_zero {c : ℝ≥0∞} (hc : c ≠ 0) (f : α 
   exact eLpNorm_smul_measure_of_ne_zero_of_ne_top hp0 hp_top c
 
 /-- See `eLpNorm_smul_measure_of_ne_zero` for a version with scalar multiplication by `ℝ≥0∞`. -/
-lemma eLpNorm_smul_measure_of_ne_zero' {c : ℝ≥0} (hc : c ≠ 0) (f : α → F) (p : ℝ≥0∞)
+lemma eLpNorm_smul_measure_of_ne_zero' {c : ℝ≥0} (hc : c ≠ 0) (f : α → ε) (p : ℝ≥0∞)
     (μ : Measure α) : eLpNorm f p (c • μ) = c ^ p.toReal⁻¹ • eLpNorm f p μ :=
   (eLpNorm_smul_measure_of_ne_zero (ENNReal.coe_ne_zero.2 hc) ..).trans (by simp; norm_cast)
 
 /-- See `eLpNorm_smul_measure_of_ne_top'` for a version with scalar multiplication by `ℝ≥0`. -/
-theorem eLpNorm_smul_measure_of_ne_top {p : ℝ≥0∞} (hp_ne_top : p ≠ ∞) (f : α → F) (c : ℝ≥0∞) :
+theorem eLpNorm_smul_measure_of_ne_top {p : ℝ≥0∞} (hp_ne_top : p ≠ ∞) (f : α → ε) (c : ℝ≥0∞) :
     eLpNorm f p (c • μ) = c ^ (1 / p).toReal • eLpNorm f p μ := by
   by_cases hp0 : p = 0
   · simp [hp0]
   · exact eLpNorm_smul_measure_of_ne_zero_of_ne_top hp0 hp_ne_top c
 
 /-- See `eLpNorm_smul_measure_of_ne_top'` for a version with scalar multiplication by `ℝ≥0∞`. -/
-lemma eLpNorm_smul_measure_of_ne_top' (hp : p ≠ ∞) (c : ℝ≥0) (f : α → F) :
+lemma eLpNorm_smul_measure_of_ne_top' (hp : p ≠ ∞) (c : ℝ≥0) (f : α → ε) :
     eLpNorm f p (c • μ) = c ^ p.toReal⁻¹ • eLpNorm f p μ := by
   have : 0 ≤ p.toReal⁻¹ := by positivity
   refine (eLpNorm_smul_measure_of_ne_top hp ..).trans ?_
   simp [ENNReal.smul_def, ENNReal.coe_rpow_of_nonneg, this]
-theorem eLpNorm_one_smul_measure {f : α → F} (c : ℝ≥0∞) :
+theorem eLpNorm_one_smul_measure {f : α → ε} (c : ℝ≥0∞) :
     eLpNorm f 1 (c • μ) = c * eLpNorm f 1 μ := by
   rw [@eLpNorm_smul_measure_of_ne_top _ _ _ μ _ 1 (@ENNReal.coe_ne_top 1) f c]
   simp
@@ -830,7 +830,7 @@ theorem Memℒp.smul_measure {f : α → E} {c : ℝ≥0∞} (hf : Memℒp f p �
     Memℒp f p (c • μ) :=
   hf.of_measure_le_smul c hc le_rfl
 
-theorem eLpNorm_one_add_measure (f : α → F) (μ ν : Measure α) :
+theorem eLpNorm_one_add_measure (f : α → ε) (μ ν : Measure α) :
     eLpNorm f 1 (μ + ν) = eLpNorm f 1 μ + eLpNorm f 1 ν := by
   simp_rw [eLpNorm_one_eq_lintegral_enorm]
   rw [lintegral_add_measure _ μ ν]
@@ -973,11 +973,11 @@ theorem Memℒp.comp_measurePreserving {ν : MeasureTheory.Measure β} (hg : Mem
     (hf : MeasurePreserving f μ ν) : Memℒp (g ∘ f) p μ :=
   .comp_of_map (hf.map_eq.symm ▸ hg) hf.aemeasurable
 
-theorem _root_.MeasurableEmbedding.eLpNormEssSup_map_measure {g : β → F}
+theorem _root_.MeasurableEmbedding.eLpNormEssSup_map_measure {g : β → ε}
     (hf : MeasurableEmbedding f) : eLpNormEssSup g (Measure.map f μ) = eLpNormEssSup (g ∘ f) μ :=
   hf.essSup_map_measure
 
-theorem _root_.MeasurableEmbedding.eLpNorm_map_measure {g : β → F} (hf : MeasurableEmbedding f) :
+theorem _root_.MeasurableEmbedding.eLpNorm_map_measure {g : β → ε} (hf : MeasurableEmbedding f) :
     eLpNorm g p (Measure.map f μ) = eLpNorm (g ∘ f) p μ := by
   by_cases hp_zero : p = 0
   · simp only [hp_zero, eLpNorm_exponent_zero]

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -202,7 +202,8 @@ theorem memℒp_zero_iff_aestronglyMeasurable [TopologicalSpace ε] {f : α → 
 -- XXXMR: needs ENormedSpace (or perhaps seminormed), well-behaved zero
 @[simp]
 theorem eLpNorm'_zero (hp0_lt : 0 < q) : eLpNorm' (0 : α → F) q μ = 0 := by
-  simp [eLpNorm'_eq_lintegral_enorm, hp0_lt]
+  simp only [eLpNorm'_eq_lintegral_enorm, Pi.zero_apply, enorm_zero, hp0_lt,
+    ENNReal.zero_rpow_of_pos, lintegral_const, zero_mul, one_div, inv_pos]
 
 @[simp]
 theorem eLpNorm'_zero' (hq0_ne : q ≠ 0) (hμ : μ ≠ 0) : eLpNorm' (0 : α → F) q μ = 0 := by
@@ -353,7 +354,7 @@ theorem memℒp_const (c : E) [IsFiniteMeasure μ] : Memℒp (fun _ : α => c) p
   refine ENNReal.rpow_lt_top_of_nonneg ?_ (measure_ne_top μ Set.univ)
   simp
 
-theorem memℒp_top_const (c : E) : Memℒp (fun _ : α => c) ∞ μ :=
+theorem memℒp_top_const (c : F) : Memℒp (fun _ : α => c) ∞ μ :=
   ⟨aestronglyMeasurable_const, by by_cases h : μ = 0 <;> simp [eLpNorm_const _, h]⟩
 
 theorem memℒp_const_iff {p : ℝ≥0∞} {c : E} (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) :

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -380,21 +380,23 @@ lemma eLpNorm'_mono_nnnorm_ae {f : α → F} {g : α → G} (hq : 0 ≤ q) (h : 
   simp_rw [ENNReal.coe_le_coe]
   exact h
 
-theorem eLpNorm'_mono_ae {f : α → F} {g : α → G} (hq : 0 ≤ q) (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ ‖g x‖) :
+theorem eLpNorm'_mono_ae {f : α → ε} {g : α → ε'} (hq : 0 ≤ q) (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ ‖g x‖ₑ) :
     eLpNorm' f q μ ≤ eLpNorm' g q μ :=
-  eLpNorm'_mono_nnnorm_ae hq h
+  eLpNorm'_mono_enorm_ae hq h
 
-theorem eLpNorm'_congr_nnnorm_ae {f g : α → F} (hfg : ∀ᵐ x ∂μ, ‖f x‖₊ = ‖g x‖₊) :
+theorem eLpNorm'_congr_enorm_ae {f g : α → ε} (hfg : ∀ᵐ x ∂μ, ‖f x‖ₑ = ‖g x‖ₑ) :
     eLpNorm' f q μ = eLpNorm' g q μ := by
   have : (‖f ·‖ₑ ^ q) =ᵐ[μ] (‖g ·‖ₑ ^ q) := hfg.mono fun x hx ↦ by simp [enorm, hx]
   simp only [eLpNorm'_eq_lintegral_enorm, lintegral_congr_ae this]
 
+@[deprecated (since := "2025-02-02")] alias eLpNorm'_congr_nnnorm_ae := eLpNorm'_congr_enorm_ae
+
 theorem eLpNorm'_congr_norm_ae {f g : α → F} (hfg : ∀ᵐ x ∂μ, ‖f x‖ = ‖g x‖) :
     eLpNorm' f q μ = eLpNorm' g q μ :=
-  eLpNorm'_congr_nnnorm_ae <| hfg.mono fun _x hx => NNReal.eq hx
+  eLpNorm'_congr_enorm_ae <| hfg.mono fun _x hx => NNReal.eq hx
 
 theorem eLpNorm'_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) : eLpNorm' f q μ = eLpNorm' g q μ :=
-  eLpNorm'_congr_nnnorm_ae (hfg.fun_comp _)
+  eLpNorm'_congr_enorm_ae (hfg.fun_comp _)
 
 theorem eLpNormEssSup_congr_ae {f g : α → F} (hfg : f =ᵐ[μ] g) :
     eLpNormEssSup f μ = eLpNormEssSup g μ :=

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/ChebyshevMarkov.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/ChebyshevMarkov.lean
@@ -15,40 +15,45 @@ open scoped NNReal ENNReal
 
 namespace MeasureTheory
 
-variable {α E : Type*} {m0 : MeasurableSpace α} [NormedAddCommGroup E]
-  {p : ℝ≥0∞} (μ : Measure α) {f : α → E}
+variable {α E ε : Type*} {m0 : MeasurableSpace α} [NormedAddCommGroup E]
+  [ENorm ε] [TopologicalSpace ε]
+  {p : ℝ≥0∞} (μ : Measure α) {f : α → ε}
 
-theorem pow_mul_meas_ge_le_eLpNorm (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞)
-    (hf : AEStronglyMeasurable f μ) (ε : ℝ≥0∞) :
-    (ε * μ { x | ε ≤ (‖f x‖₊ : ℝ≥0∞) ^ p.toReal }) ^ (1 / p.toReal) ≤ eLpNorm f p μ := by
+theorem pow_mul_meas_ge_le_eLpNorm {f : α → ε} (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞)
+    (hf : AEStronglyMeasurable f μ) (ε' : ℝ≥0∞) :
+    (ε' * μ { x | ε' ≤ (‖f x‖ₑ : ℝ≥0∞) ^ p.toReal }) ^ (1 / p.toReal) ≤ eLpNorm f p μ := by
   rw [eLpNorm_eq_lintegral_rpow_enorm hp_ne_zero hp_ne_top]
   gcongr
-  exact mul_meas_ge_le_lintegral₀ (hf.enorm.pow_const _) ε
+  refine mul_meas_ge_le_lintegral₀ ?_ ε'
+  sorry -- TODO! was:(hf.enorm.pow_const _)
 
 theorem mul_meas_ge_le_pow_eLpNorm (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞)
     (hf : AEStronglyMeasurable f μ) (ε : ℝ≥0∞) :
-    ε * μ { x | ε ≤ (‖f x‖₊ : ℝ≥0∞) ^ p.toReal } ≤ eLpNorm f p μ ^ p.toReal := by
+    ε * μ { x | ε ≤ (‖f x‖ₑ : ℝ≥0∞) ^ p.toReal } ≤ eLpNorm f p μ ^ p.toReal := by
   have : 1 / p.toReal * p.toReal = 1 := by
     refine one_div_mul_cancel ?_
     rw [Ne, ENNReal.toReal_eq_zero_iff]
     exact not_or_intro hp_ne_zero hp_ne_top
-  rw [← ENNReal.rpow_one (ε * μ { x | ε ≤ (‖f x‖₊ : ℝ≥0∞) ^ p.toReal }), ← this, ENNReal.rpow_mul]
+  rw [← ENNReal.rpow_one (ε * μ { x | ε ≤ (‖f x‖ₑ : ℝ≥0∞) ^ p.toReal }), ← this, ENNReal.rpow_mul]
   gcongr
   exact pow_mul_meas_ge_le_eLpNorm μ hp_ne_zero hp_ne_top hf ε
 
 /-- A version of Chebyshev-Markov's inequality using Lp-norms. -/
 theorem mul_meas_ge_le_pow_eLpNorm' (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞)
     (hf : AEStronglyMeasurable f μ) (ε : ℝ≥0∞) :
-    ε ^ p.toReal * μ { x | ε ≤ ‖f x‖₊ } ≤ eLpNorm f p μ ^ p.toReal := by
+    ε ^ p.toReal * μ { x | ε ≤ ‖f x‖ₑ } ≤ eLpNorm f p μ ^ p.toReal := by
   convert mul_meas_ge_le_pow_eLpNorm μ hp_ne_zero hp_ne_top hf (ε ^ p.toReal) using 4
   ext x
   rw [ENNReal.rpow_le_rpow_iff (ENNReal.toReal_pos hp_ne_zero hp_ne_top)]
 
-theorem meas_ge_le_mul_pow_eLpNorm (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞)
+theorem meas_ge_le_mul_pow_eLpNorm {f : α → ε} (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞)
     (hf : AEStronglyMeasurable f μ) {ε : ℝ≥0∞} (hε : ε ≠ 0) :
-    μ { x | ε ≤ ‖f x‖₊ } ≤ ε⁻¹ ^ p.toReal * eLpNorm f p μ ^ p.toReal := by
+    μ { x | ε ≤ ‖f x‖ₑ } ≤ ε⁻¹ ^ p.toReal * eLpNorm f p μ ^ p.toReal := by
   by_cases h : ε = ∞
-  · simp [h]
+  · -- simp_rw [h, top_le_iff, enorm_ne_top, Set.setOf_false, measure_empty, ENNReal.inv_top]
+    sorry -- this proof fails for f mapping into ε; `enorm_ne_top` needs generalisation!
+    -- simp only [h, top_le_iff, enorm_ne_top, Set.setOf_false, measure_empty, ENNReal.inv_top,
+    -- zero_le] -- this fails for f to ε
   have hεpow : ε ^ p.toReal ≠ 0 := (ENNReal.rpow_pos (pos_iff_ne_zero.2 hε) h).ne.symm
   have hεpow' : ε ^ p.toReal ≠ ∞ := ENNReal.rpow_ne_top_of_nonneg ENNReal.toReal_nonneg h
   rw [ENNReal.inv_rpow, ← ENNReal.mul_le_mul_left hεpow hεpow', ← mul_assoc,
@@ -57,7 +62,7 @@ theorem meas_ge_le_mul_pow_eLpNorm (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞
 
 theorem Memℒp.meas_ge_lt_top' {μ : Measure α} (hℒp : Memℒp f p μ) (hp_ne_zero : p ≠ 0)
     (hp_ne_top : p ≠ ∞) {ε : ℝ≥0∞} (hε : ε ≠ 0) :
-    μ { x | ε ≤ ‖f x‖₊ } < ∞ := by
+    μ { x | ε ≤ ‖f x‖ₑ } < ∞ := by
   apply (meas_ge_le_mul_pow_eLpNorm μ hp_ne_zero hp_ne_top hℒp.aestronglyMeasurable hε).trans_lt
     (ENNReal.mul_lt_top ?_ ?_)
   · simp [hε, lt_top_iff_ne_top]
@@ -65,8 +70,7 @@ theorem Memℒp.meas_ge_lt_top' {μ : Measure α} (hℒp : Memℒp f p μ) (hp_n
 
 theorem Memℒp.meas_ge_lt_top {μ : Measure α} (hℒp : Memℒp f p μ) (hp_ne_zero : p ≠ 0)
     (hp_ne_top : p ≠ ∞) {ε : ℝ≥0} (hε : ε ≠ 0) :
-    μ { x | ε ≤ ‖f x‖₊ } < ∞ := by
-  simp_rw [← ENNReal.coe_le_coe]
+    μ { x | ε ≤ ‖f x‖ₑ } < ∞ := by
   apply hℒp.meas_ge_lt_top' hp_ne_zero hp_ne_top (by simp [hε])
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/CompareExp.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/CompareExp.lean
@@ -20,7 +20,8 @@ namespace MeasureTheory
 
 section SameSpace
 
-variable {α E : Type*} {m : MeasurableSpace α} [NormedAddCommGroup E] {μ : Measure α} {f : α → E}
+variable {α E ε : Type*} {m : MeasurableSpace α} [NormedAddCommGroup E]
+  [ENorm ε] [TopologicalSpace ε] {μ : Measure α} {f : α → ε}
 
 theorem eLpNorm'_le_eLpNorm'_mul_rpow_measure_univ {p q : ℝ} (hp0_lt : 0 < p) (hpq : p ≤ q)
     (hf : AEStronglyMeasurable f μ) :
@@ -37,12 +38,14 @@ theorem eLpNorm'_le_eLpNorm'_mul_rpow_measure_univ {p q : ℝ} (hp0_lt : 0 < p) 
   let r := p * q / (q - p)
   have hpqr : 1 / p = 1 / q + 1 / r := by field_simp [r, hp0_lt.ne', hq0_lt.ne']
   calc
-    (∫⁻ a : α, (↑‖f a‖₊ * g a) ^ p ∂μ) ^ (1 / p) ≤
-        (∫⁻ a : α, ↑‖f a‖₊ ^ q ∂μ) ^ (1 / q) * (∫⁻ a : α, g a ^ r ∂μ) ^ (1 / r) :=
-      ENNReal.lintegral_Lp_mul_le_Lq_mul_Lr hp0_lt hpq hpqr μ hf.enorm aemeasurable_const
-    _ = (∫⁻ a : α, ↑‖f a‖₊ ^ q ∂μ) ^ (1 / q) * μ Set.univ ^ (1 / p - 1 / q) := by
+    (∫⁻ a : α, (↑‖f a‖ₑ * g a) ^ p ∂μ) ^ (1 / p) ≤
+        (∫⁻ a : α, ↑‖f a‖ₑ ^ q ∂μ) ^ (1 / q) * (∫⁻ a : α, g a ^ r ∂μ) ^ (1 / r) := by
+      refine ENNReal.lintegral_Lp_mul_le_Lq_mul_Lr hp0_lt hpq hpqr μ ?_ aemeasurable_const
+      sorry -- apply hf.enorm would solve this, but needs to be generalised!
+    _ = (∫⁻ a : α, ↑‖f a‖ₑ ^ q ∂μ) ^ (1 / q) * μ Set.univ ^ (1 / p - 1 / q) := by
       rw [hpqr]; simp [r, g]
 
+omit [TopologicalSpace ε] in
 theorem eLpNorm'_le_eLpNormEssSup_mul_rpow_measure_univ {q : ℝ} (hq_pos : 0 < q) :
     eLpNorm' f q μ ≤ eLpNormEssSup f μ * μ Set.univ ^ (1 / q) := by
   have h_le : (∫⁻ a : α, ‖f a‖ₑ ^ q ∂μ) ≤ ∫⁻ _ : α, eLpNormEssSup f μ ^ q ∂μ := by
@@ -87,6 +90,7 @@ theorem eLpNorm'_le_eLpNorm'_of_exponent_le {p q : ℝ} (hp0_lt : 0 < p)
   have h_le_μ := eLpNorm'_le_eLpNorm'_mul_rpow_measure_univ hp0_lt hpq hf
   rwa [measure_univ, ENNReal.one_rpow, mul_one] at h_le_μ
 
+omit [TopologicalSpace ε] in
 theorem eLpNorm'_le_eLpNormEssSup {q : ℝ} (hq_pos : 0 < q) [IsProbabilityMeasure μ] :
     eLpNorm' f q μ ≤ eLpNormEssSup f μ :=
   (eLpNorm'_le_eLpNormEssSup_mul_rpow_measure_univ hq_pos).trans_eq (by simp [measure_univ])
@@ -110,7 +114,7 @@ theorem eLpNorm'_lt_top_of_eLpNorm'_lt_top_of_exponent_le {p q : ℝ} [IsFiniteM
       refine Or.inl ⟨hfq_lt_top, ENNReal.rpow_lt_top_of_nonneg ?_ (measure_ne_top μ Set.univ)⟩
       rwa [le_sub_comm, sub_zero, one_div, one_div, inv_le_inv₀ hq_pos hp_pos]
 
-theorem Memℒp.mono_exponent {p q : ℝ≥0∞} [IsFiniteMeasure μ] {f : α → E} (hfq : Memℒp f q μ)
+theorem Memℒp.mono_exponent {p q : ℝ≥0∞} [IsFiniteMeasure μ] (hfq : Memℒp f q μ)
     (hpq : p ≤ q) : Memℒp f p μ := by
   cases' hfq with hfq_m hfq_lt_top
   by_cases hp0 : p = 0
@@ -158,6 +162,8 @@ alias Memℒp.memℒp_of_exponent_le_of_measure_support_ne_top :=
   Memℒp.mono_exponent_of_measure_support_ne_top
 
 end SameSpace
+
+-- TODO: try generalising from here onwards: needs stronger classes
 
 section Bilinear
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/TriangleInequality.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/TriangleInequality.lean
@@ -18,7 +18,8 @@ open scoped ENNReal Topology
 
 namespace MeasureTheory
 
-variable {α E : Type*} {m : MeasurableSpace α} [NormedAddCommGroup E]
+variable {α E ε : Type*}
+  {m : MeasurableSpace α} [NormedAddCommGroup E] [ENorm ε] [TopologicalSpace ε]
   {p : ℝ≥0∞} {q : ℝ} {μ : Measure α} {f g : α → E}
 
 theorem eLpNorm'_add_le (hf : AEStronglyMeasurable f μ) (hg : AEStronglyMeasurable g μ)
@@ -40,13 +41,13 @@ theorem eLpNorm'_add_le_of_le_one (hf : AEStronglyMeasurable f μ) (hq0 : 0 ≤ 
     _ ≤ (2 : ℝ≥0∞) ^ (1 / q - 1) * (eLpNorm' f q μ + eLpNorm' g q μ) :=
       ENNReal.lintegral_Lp_add_le_of_le_one hf.enorm hq0 hq1
 
-theorem eLpNormEssSup_add_le {f g : α → E} :
+theorem eLpNormEssSup_add_le :
     eLpNormEssSup (f + g) μ ≤ eLpNormEssSup f μ + eLpNormEssSup g μ := by
   refine le_trans (essSup_mono_ae (Eventually.of_forall fun x => ?_)) (ENNReal.essSup_add_le _ _)
   simp_rw [Pi.add_apply, enorm_eq_nnnorm, ← ENNReal.coe_add, ENNReal.coe_le_coe]
   exact nnnorm_add_le _ _
 
-theorem eLpNorm_add_le {f g : α → E} (hf : AEStronglyMeasurable f μ) (hg : AEStronglyMeasurable g μ)
+theorem eLpNorm_add_le (hf : AEStronglyMeasurable f μ) (hg : AEStronglyMeasurable g μ)
     (hp1 : 1 ≤ p) : eLpNorm (f + g) p μ ≤ eLpNorm f p μ + eLpNorm g p μ := by
   by_cases hp0 : p = 0
   · simp [hp0]
@@ -122,11 +123,11 @@ theorem eLpNorm_sub_le' (hf : AEStronglyMeasurable f μ) (hg : AEStronglyMeasura
     (p : ℝ≥0∞) : eLpNorm (f - g) p μ ≤ LpAddConst p * (eLpNorm f p μ + eLpNorm g p μ) := by
   simpa only [sub_eq_add_neg, eLpNorm_neg] using eLpNorm_add_le' hf hg.neg p
 
-theorem eLpNorm_sub_le {f g : α → E} (hf : AEStronglyMeasurable f μ) (hg : AEStronglyMeasurable g μ)
+theorem eLpNorm_sub_le (hf : AEStronglyMeasurable f μ) (hg : AEStronglyMeasurable g μ)
     (hp : 1 ≤ p) : eLpNorm (f - g) p μ ≤ eLpNorm f p μ + eLpNorm g p μ := by
   simpa [LpAddConst_of_one_le hp] using eLpNorm_sub_le' hf hg p
 
-theorem eLpNorm_add_lt_top {f g : α → E} (hf : Memℒp f p μ) (hg : Memℒp g p μ) :
+theorem eLpNorm_add_lt_top (hf : Memℒp f p μ) (hg : Memℒp g p μ) :
     eLpNorm (f + g) p μ < ∞ :=
   calc
     eLpNorm (f + g) p μ ≤ LpAddConst p * (eLpNorm f p μ + eLpNorm g p μ) :=
@@ -149,10 +150,10 @@ theorem eLpNorm_sum_le {ι} {f : ι → α → E} {s : Finset ι}
     (fun f => AEStronglyMeasurable f μ) eLpNorm_zero (fun _f _g hf hg => eLpNorm_add_le hf hg hp1)
     (fun _f _g hf hg => hf.add hg) _ hfs
 
-theorem Memℒp.add {f g : α → E} (hf : Memℒp f p μ) (hg : Memℒp g p μ) : Memℒp (f + g) p μ :=
+theorem Memℒp.add (hf : Memℒp f p μ) (hg : Memℒp g p μ) : Memℒp (f + g) p μ :=
   ⟨AEStronglyMeasurable.add hf.1 hg.1, eLpNorm_add_lt_top hf hg⟩
 
-theorem Memℒp.sub {f g : α → E} (hf : Memℒp f p μ) (hg : Memℒp g p μ) : Memℒp (f - g) p μ := by
+theorem Memℒp.sub (hf : Memℒp f p μ) (hg : Memℒp g p μ) : Memℒp (f - g) p μ := by
   rw [sub_eq_add_neg]
   exact hf.add hg.neg
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Trim.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Trim.lean
@@ -17,17 +17,18 @@ namespace MeasureTheory
 open Filter
 open scoped ENNReal
 
-variable {α E : Type*} {m m0 : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ} {μ : Measure α}
-  [NormedAddCommGroup E]
+variable {α ε : Type*} [ENorm ε] [TopologicalSpace ε]
+  {m m0 : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ} {μ : Measure α}
 
-theorem eLpNorm'_trim (hm : m ≤ m0) {f : α → E} (hf : StronglyMeasurable[m] f) :
+theorem eLpNorm'_trim (hm : m ≤ m0) {f : α → ε} (hf : StronglyMeasurable[m] f) :
     eLpNorm' f q (μ.trim hm) = eLpNorm' f q μ := by
   simp_rw [eLpNorm']
   congr 1
   refine lintegral_trim hm ?_
-  refine @Measurable.pow_const _ _ _ _ _ _ _ m _ (@Measurable.coe_nnreal_ennreal _ m _ ?_) q
-  apply @StronglyMeasurable.measurable
-  exact @StronglyMeasurable.nnnorm α m _ _ _ hf
+  sorry -- TODO: was the following... need to check if this holds!
+  -- refine @Measurable.pow_const _ _ _ _ _ _ _ m _ (@Measurable.coe_nnreal_ennreal _ m _ ?_) q
+  -- apply @StronglyMeasurable.measurable
+  -- exact @StronglyMeasurable.nnnorm α m _ _ _ hf
 
 theorem limsup_trim (hm : m ≤ m0) {f : α → ℝ≥0∞} (hf : Measurable[m] f) :
     limsup f (ae (μ.trim hm)) = limsup f (ae μ) := by
@@ -46,11 +47,12 @@ theorem essSup_trim (hm : m ≤ m0) {f : α → ℝ≥0∞} (hf : Measurable[m] 
   simp_rw [essSup]
   exact limsup_trim hm hf
 
-theorem eLpNormEssSup_trim (hm : m ≤ m0) {f : α → E} (hf : StronglyMeasurable[m] f) :
+-- TODO: does StronglyMeasurable.enorm hold for ENorms?
+theorem eLpNormEssSup_trim (hm : m ≤ m0) {f : α → ε} (hf : StronglyMeasurable[m] f) :
     eLpNormEssSup f (μ.trim hm) = eLpNormEssSup f μ :=
-  essSup_trim _ (@StronglyMeasurable.enorm _ m _ _ _ hf)
+  essSup_trim _ sorry --(@StronglyMeasurable.enorm _ m _ _ _ hf)
 
-theorem eLpNorm_trim (hm : m ≤ m0) {f : α → E} (hf : StronglyMeasurable[m] f) :
+theorem eLpNorm_trim (hm : m ≤ m0) {f : α → ε} (hf : StronglyMeasurable[m] f) :
     eLpNorm f p (μ.trim hm) = eLpNorm f p μ := by
   by_cases h0 : p = 0
   · simp [h0]
@@ -58,12 +60,12 @@ theorem eLpNorm_trim (hm : m ≤ m0) {f : α → E} (hf : StronglyMeasurable[m] 
   · simpa only [h_top, eLpNorm_exponent_top] using eLpNormEssSup_trim hm hf
   simpa only [eLpNorm_eq_eLpNorm' h0 h_top] using eLpNorm'_trim hm hf
 
-theorem eLpNorm_trim_ae (hm : m ≤ m0) {f : α → E} (hf : AEStronglyMeasurable[m] f (μ.trim hm)) :
+theorem eLpNorm_trim_ae (hm : m ≤ m0) {f : α → ε} (hf : AEStronglyMeasurable[m] f (μ.trim hm)) :
     eLpNorm f p (μ.trim hm) = eLpNorm f p μ := by
   rw [eLpNorm_congr_ae hf.ae_eq_mk, eLpNorm_congr_ae (ae_eq_of_ae_eq_trim hf.ae_eq_mk)]
   exact eLpNorm_trim hm hf.stronglyMeasurable_mk
 
-theorem memℒp_of_memℒp_trim (hm : m ≤ m0) {f : α → E} (hf : Memℒp f p (μ.trim hm)) : Memℒp f p μ :=
+theorem memℒp_of_memℒp_trim (hm : m ≤ m0) {f : α → ε} (hf : Memℒp f p (μ.trim hm)) : Memℒp f p μ :=
   ⟨aestronglyMeasurable_of_aestronglyMeasurable_trim hm hf.1,
     (le_of_eq (eLpNorm_trim_ae hm hf.1).symm).trans_lt hf.2⟩
 

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -70,8 +70,8 @@ noncomputable section
 open TopologicalSpace MeasureTheory Filter
 open scoped NNReal ENNReal Topology MeasureTheory Uniformity symmDiff
 
-variable {α E F G : Type*} {m m0 : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ} {μ ν : Measure α}
-  [NormedAddCommGroup E] [NormedAddCommGroup F] [NormedAddCommGroup G]
+variable {α E F G ε : Type*} {m m0 : MeasurableSpace α} {p : ℝ≥0∞} {q : ℝ} {μ ν : Measure α}
+  [NormedAddCommGroup E] [NormedAddCommGroup F] [NormedAddCommGroup G] [ENorm ε]
 
 namespace MeasureTheory
 
@@ -83,13 +83,13 @@ The space of equivalence classes of measurable functions for which `eLpNorm f p 
 
 
 @[simp]
-theorem eLpNorm_aeeqFun {α E : Type*} [MeasurableSpace α] {μ : Measure α} [NormedAddCommGroup E]
-    {p : ℝ≥0∞} {f : α → E} (hf : AEStronglyMeasurable f μ) :
+theorem eLpNorm_aeeqFun {α : Type*} [MeasurableSpace α] {μ : Measure α}
+    [TopologicalSpace ε] {p : ℝ≥0∞} {f : α → ε} (hf : AEStronglyMeasurable f μ) :
     eLpNorm (AEEqFun.mk f hf) p μ = eLpNorm f p μ :=
   eLpNorm_congr_ae (AEEqFun.coeFn_mk _ _)
 
-theorem Memℒp.eLpNorm_mk_lt_top {α E : Type*} [MeasurableSpace α] {μ : Measure α}
-    [NormedAddCommGroup E] {p : ℝ≥0∞} {f : α → E} (hfp : Memℒp f p μ) :
+theorem Memℒp.eLpNorm_mk_lt_top {α : Type*} [MeasurableSpace α] {μ : Measure α}
+    [TopologicalSpace ε] {p : ℝ≥0∞} {f : α → ε} (hfp : Memℒp f p μ) :
     eLpNorm (AEEqFun.mk f hfp.1) p μ < ∞ := by simp [hfp.2]
 
 /-- Lp space -/
@@ -342,11 +342,17 @@ theorem norm_le_mul_norm_of_ae_le_mul {c : ℝ} {f : Lp E p μ} {g : Lp F p μ}
 theorem norm_le_norm_of_ae_le {f : Lp E p μ} {g : Lp F p μ} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ ‖g x‖) :
     ‖f‖ ≤ ‖g‖ := by
   rw [norm_def, norm_def]
-  exact ENNReal.toReal_mono (eLpNorm_ne_top _) (eLpNorm_mono_ae h)
+  refine ENNReal.toReal_mono (eLpNorm_ne_top _) (eLpNorm_mono_ae ?_)
+  sorry -- apply foo_leq under binders
 
 theorem mem_Lp_of_nnnorm_ae_le_mul {c : ℝ≥0} {f : α →ₘ[μ] E} {g : Lp F p μ}
     (h : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ c * ‖g x‖₊) : f ∈ Lp E p μ :=
   mem_Lp_iff_memℒp.2 <| Memℒp.of_nnnorm_le_mul (Lp.memℒp g) f.aestronglyMeasurable h
+
+theorem mem_Lp_of_enorm_ae_le_mul2 {c : ℝ≥0} {f : α →ₘ[μ] E} {g : Lp F p μ}
+    (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ c * ‖g x‖ₑ) : f ∈ Lp E p μ := by
+  refine mem_Lp_iff_memℒp.2 ?_
+  sorry -- refine Memℒp.of_enorm_le_mul (f := f) (Lp.memℒp g) f.aestronglyMeasurable h
 
 theorem mem_Lp_of_ae_le_mul {c : ℝ} {f : α →ₘ[μ] E} {g : Lp F p μ}
     (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ c * ‖g x‖) : f ∈ Lp E p μ :=
@@ -354,7 +360,7 @@ theorem mem_Lp_of_ae_le_mul {c : ℝ} {f : α →ₘ[μ] E} {g : Lp F p μ}
 
 theorem mem_Lp_of_nnnorm_ae_le {f : α →ₘ[μ] E} {g : Lp F p μ} (h : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ ‖g x‖₊) :
     f ∈ Lp E p μ :=
-  mem_Lp_iff_memℒp.2 <| Memℒp.of_le (Lp.memℒp g) f.aestronglyMeasurable h
+  mem_Lp_iff_memℒp.2 <| sorry -- was: Memℒp.of_le (Lp.memℒp g) f.aestronglyMeasurable h
 
 theorem mem_Lp_of_ae_le {f : α →ₘ[μ] E} {g : Lp F p μ} (h : ∀ᵐ x ∂μ, ‖f x‖ ≤ ‖g x‖) :
     f ∈ Lp E p μ :=
@@ -362,28 +368,44 @@ theorem mem_Lp_of_ae_le {f : α →ₘ[μ] E} {g : Lp F p μ} (h : ∀ᵐ x ∂�
 
 theorem mem_Lp_of_ae_nnnorm_bound [IsFiniteMeasure μ] {f : α →ₘ[μ] E} (C : ℝ≥0)
     (hfC : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ C) : f ∈ Lp E p μ :=
+  sorry -- mem_Lp_iff_memℒp.2 <| Memℒp.of_bound f.aestronglyMeasurable _ hfC
+
+theorem mem_Lp_of_ae_enorm_bound [IsFiniteMeasure μ] {f : α →ₘ[μ] E} (C : ℝ)
+    (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C.toNNReal) : f ∈ Lp E p μ :=
   mem_Lp_iff_memℒp.2 <| Memℒp.of_bound f.aestronglyMeasurable _ hfC
 
-theorem mem_Lp_of_ae_bound [IsFiniteMeasure μ] {f : α →ₘ[μ] E} (C : ℝ) (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) :
+theorem mem_Lp_of_ae_bound [IsFiniteMeasure μ] {f : α →ₘ[μ] E} (C : ℝ) (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C.toNNReal) :
     f ∈ Lp E p μ :=
   mem_Lp_iff_memℒp.2 <| Memℒp.of_bound f.aestronglyMeasurable _ hfC
 
-theorem nnnorm_le_of_ae_bound [IsFiniteMeasure μ] {f : Lp E p μ} {C : ℝ≥0}
-    (hfC : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ C) : ‖f‖₊ ≤ measureUnivNNReal μ ^ p.toReal⁻¹ * C := by
+-- theorem nnnorm_le_of_ae_bound [IsFiniteMeasure μ] {f : Lp E p μ} {C : ℝ≥0}
+--     (hfC : ∀ᵐ x ∂μ, ‖f x‖₊ ≤ C) : ‖f‖₊ ≤ measureUnivNNReal μ ^ p.toReal⁻¹ * C := by
+--   by_cases hμ : μ = 0
+--   · by_cases hp : p.toReal⁻¹ = 0
+--     · simp [hp, hμ, nnnorm_def]
+--     · simp [hμ, nnnorm_def, Real.zero_rpow hp]
+--   rw [← ENNReal.coe_le_coe, nnnorm_def, ENNReal.coe_toNNReal (eLpNorm_ne_top _)]
+--   refine (eLpNorm_le_of_ae_enorm_bound hfC).trans_eq ?_
+--   rw [← coe_measureUnivNNReal μ, ← ENNReal.coe_rpow_of_ne_zero (measureUnivNNReal_pos hμ).ne',
+--     ENNReal.coe_mul, mul_comm, ENNReal.smul_def, smul_eq_mul]
+
+theorem enorm_le_of_ae_bound [IsFiniteMeasure μ] {f : Lp E p μ} {C : ℝ≥0}
+    (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C) : ‖f‖ₑ ≤ measureUnivNNReal μ ^ p.toReal⁻¹ * C := by
   by_cases hμ : μ = 0
   · by_cases hp : p.toReal⁻¹ = 0
     · simp [hp, hμ, nnnorm_def]
     · simp [hμ, nnnorm_def, Real.zero_rpow hp]
-  rw [← ENNReal.coe_le_coe, nnnorm_def, ENNReal.coe_toNNReal (eLpNorm_ne_top _)]
-  refine (eLpNorm_le_of_ae_nnnorm_bound hfC).trans_eq ?_
+  rw [enorm_def]
+  refine (eLpNorm_le_of_ae_enorm_bound hfC).trans_eq ?_
   rw [← coe_measureUnivNNReal μ, ← ENNReal.coe_rpow_of_ne_zero (measureUnivNNReal_pos hμ).ne',
-    ENNReal.coe_mul, mul_comm, ENNReal.smul_def, smul_eq_mul]
+    mul_comm, ENNReal.smul_def, smul_eq_mul]
 
 theorem norm_le_of_ae_bound [IsFiniteMeasure μ] {f : Lp E p μ} {C : ℝ} (hC : 0 ≤ C)
     (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) : ‖f‖ ≤ measureUnivNNReal μ ^ p.toReal⁻¹ * C := by
   lift C to ℝ≥0 using hC
-  have := nnnorm_le_of_ae_bound hfC
-  rwa [← NNReal.coe_le_coe, NNReal.coe_mul, NNReal.coe_rpow] at this
+  sorry -- previous proof was:
+  -- have := nnnorm_le_of_ae_bound hfC
+  -- rwa [← NNReal.coe_le_coe, NNReal.coe_mul, NNReal.coe_rpow] at this
 
 instance instNormedAddCommGroup [hp : Fact (1 ≤ p)] : NormedAddCommGroup (Lp E p μ) :=
   { AddGroupNorm.toNormedAddCommGroup
@@ -517,7 +539,8 @@ variable {X : Type*} [TopologicalSpace X] [MeasurableSpace X]
 
 /-- A bounded measurable function with compact support is in L^p. -/
 theorem _root_.HasCompactSupport.memℒp_of_bound {f : X → E} (hf : HasCompactSupport f)
-    (h2f : AEStronglyMeasurable f μ) (C : ℝ) (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) : Memℒp f p μ := by
+    (h2f : AEStronglyMeasurable f μ) (C : ℝ) (hfC : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ C.toNNReal) :
+    Memℒp f p μ := by
   have := memℒp_top_of_bound h2f C hfC
   exact this.mono_exponent_of_measure_support_ne_top
     (fun x ↦ image_eq_zero_of_nmem_tsupport) (hf.measure_lt_top.ne) le_top
@@ -1503,20 +1526,29 @@ variable [IsFiniteMeasure μ]
 
 /-- A bounded continuous function on a finite-measure space is in `Lp`. -/
 theorem mem_Lp (f : α →ᵇ E) : f.toContinuousMap.toAEEqFun μ ∈ Lp E p μ := by
-  refine Lp.mem_Lp_of_ae_bound ‖f‖ ?_
+  refine Lp.mem_Lp_of_ae_bound ‖f‖ₑ.toNNReal ?_
   filter_upwards [f.toContinuousMap.coeFn_toAEEqFun μ] with x _
-  convert f.norm_coe_le_norm x using 2
+  sorry -- need enorm version: convert f.norm_coe_le_norm x using 2
 
 /-- The `Lp`-norm of a bounded continuous function is at most a constant (depending on the measure
 of the whole space) times its sup-norm. -/
 theorem Lp_nnnorm_le (f : α →ᵇ E) :
     ‖(⟨f.toContinuousMap.toAEEqFun μ, mem_Lp f⟩ : Lp E p μ)‖₊ ≤
       measureUnivNNReal μ ^ p.toReal⁻¹ * ‖f‖₊ := by
-  apply Lp.nnnorm_le_of_ae_bound
+  sorry /- apply Lp.nnnorm_le_of_ae_bound
   refine (f.toContinuousMap.coeFn_toAEEqFun μ).mono ?_
   intro x hx
   rw [← NNReal.coe_le_coe, coe_nnnorm, coe_nnnorm]
-  convert f.norm_coe_le_norm x using 2
+  convert f.norm_coe_le_norm x using 2 -/
+
+theorem Lp_enorm_le (f : α →ᵇ E) :
+    ‖(⟨f.toContinuousMap.toAEEqFun μ, mem_Lp f⟩ : Lp E p μ)‖ₑ ≤
+      measureUnivNNReal μ ^ p.toReal⁻¹ * ‖f‖ₑ := by
+  apply Lp.enorm_le_of_ae_bound
+  refine (f.toContinuousMap.coeFn_toAEEqFun μ).mono ?_
+  intro x hx
+  sorry -- was: rw [coe_enorm, coe_nnnorm] and something!
+  --convert f.norm_coe_le_norm x using 2
 
 /-- The `Lp`-norm of a bounded continuous function is at most a constant (depending on the measure
 of the whole space) times its sup-norm. -/

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
@@ -261,7 +261,8 @@ theorem memℒp_zero (f : α →ₛ E) (μ : Measure α) : Memℒp f 0 μ :=
 
 theorem memℒp_top (f : α →ₛ E) (μ : Measure α) : Memℒp f ∞ μ :=
   let ⟨C, hfC⟩ := f.exists_forall_norm_le
-  memℒp_top_of_bound f.aestronglyMeasurable C <| Eventually.of_forall hfC
+  -- hfC has the wrong type
+  sorry -- was: memℒp_top_of_bound f.aestronglyMeasurable C <| Eventually.of_forall hfC
 
 protected theorem eLpNorm'_eq {p : ℝ} (f : α →ₛ F) (μ : Measure α) :
     eLpNorm' f p μ = (∑ y ∈ f.range, ‖y‖ₑ ^ p * μ (f ⁻¹' {y})) ^ (1 / p) := by
@@ -339,7 +340,8 @@ theorem integrable_pair {f : α →ₛ E} {g : α →ₛ F} :
 theorem memℒp_of_isFiniteMeasure (f : α →ₛ E) (p : ℝ≥0∞) (μ : Measure α) [IsFiniteMeasure μ] :
     Memℒp f p μ :=
   let ⟨C, hfC⟩ := f.exists_forall_norm_le
-  Memℒp.of_bound f.aestronglyMeasurable C <| Eventually.of_forall hfC
+  -- hfC has the wrong type!
+  sorry -- Memℒp.of_bound f.aestronglyMeasurable C <| Eventually.of_forall hfC
 
 @[fun_prop]
 theorem integrable_of_isFiniteMeasure [IsFiniteMeasure μ] (f : α →ₛ E) : Integrable f μ :=

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
@@ -145,7 +145,7 @@ theorem memℒp_approxOn [BorelSpace E] {f : β → E} {μ : Measure β} (fmeas 
   calc
     eLpNorm (fun x => approxOn f fmeas s y₀ h₀ n x - y₀) p μ ≤
         eLpNorm (fun x => ‖f x - y₀‖ + ‖f x - y₀‖) p μ :=
-      eLpNorm_mono_ae this
+      eLpNorm_mono_ae' this
     _ < ⊤ := eLpNorm_add_lt_top hf' hf'
 
 theorem tendsto_approxOn_range_Lp_eLpNorm [BorelSpace E] {f : β → E} (hp_ne_top : p ≠ ∞)

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -308,8 +308,8 @@ theorem Memℒp.eLpNorm_indicator_norm_ge_pos_le (hf : Memℒp f p μ) (hmeas : 
   obtain ⟨M, hM⟩ := hf.eLpNorm_indicator_norm_ge_le hmeas hε
   refine
     ⟨max M 1, lt_of_lt_of_le zero_lt_one (le_max_right _ _), le_trans (eLpNorm_mono fun x => ?_) hM⟩
-  rw [norm_indicator_eq_indicator_norm, norm_indicator_eq_indicator_norm]
-  refine Set.indicator_le_indicator_of_subset (fun x hx => ?_) (fun x => norm_nonneg (f x)) x
+  simp only [enorm_indicator_eq_indicator_enorm]
+  refine Set.indicator_le_indicator_of_subset (fun x hx => ?_) (fun _ => zero_le _) x
   rw [Set.mem_setOf_eq] at hx -- removing the `rw` breaks the proof!
   exact (max_le_iff.1 hx).1
 
@@ -334,6 +334,7 @@ theorem eLpNorm_indicator_le_of_bound {f : α → β} (hp_top : p ≠ ∞) {ε :
   have haebdd : ∀ᵐ x ∂μ.restrict s, ‖f x‖ ≤ M := by
     filter_upwards
     exact fun x => (hf x).le
+  sorry /- full proof was:
   refine le_trans (eLpNorm_le_of_ae_bound haebdd) ?_
   rw [Measure.restrict_apply MeasurableSet.univ, Set.univ_inter,
     ← ENNReal.le_div_iff_mul_le (Or.inl _) (Or.inl ENNReal.ofReal_ne_top)]
@@ -341,7 +342,7 @@ theorem eLpNorm_indicator_le_of_bound {f : α → β} (hp_top : p ≠ ∞) {ε :
     refine le_trans hμ ?_
     rw [← ENNReal.ofReal_rpow_of_pos (div_pos hε hM),
       ENNReal.rpow_le_rpow_iff (ENNReal.toReal_pos hp hp_top), ENNReal.ofReal_div_of_pos hM]
-  · simpa only [ENNReal.ofReal_eq_zero, not_le, Ne]
+  · simpa only [ENNReal.ofReal_eq_zero, not_le, Ne] -/
 
 section
 
@@ -474,7 +475,7 @@ theorem eLpNorm_sub_le_of_dist_bdd (μ : Measure α)
         Real.norm_eq_abs, abs_of_nonneg hc]
       exact hf x hx
     · simp [Set.indicator_of_not_mem hx]
-  refine le_trans (eLpNorm_mono this) ?_
+  refine le_trans (eLpNorm_mono (fun x ↦ foo_leq (this x))) ?_
   rw [eLpNorm_indicator_const hs hp hp']
   refine mul_le_mul_right' (le_of_eq ?_) _
   rw [← ofReal_norm_eq_enorm, Real.norm_eq_abs, abs_of_nonneg hc]

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -697,9 +697,9 @@ theorem unifIntegrable_of (hp : 1 ≤ p) (hp' : p ≠ ∞) {f : ι → α → β
     · rw [Set.indicator_of_not_mem hfx, Set.indicator_of_not_mem]
       rwa [Set.mem_setOf, hx] at hfx
   refine ⟨max C 1, lt_max_of_lt_right one_pos, fun i => le_trans (eLpNorm_mono fun x => ?_) (hCg i)⟩
-  rw [norm_indicator_eq_indicator_norm, norm_indicator_eq_indicator_norm]
+  simp only [enorm_indicator_eq_indicator_enorm]
   exact Set.indicator_le_indicator_of_subset
-    (fun x hx => Set.mem_setOf_eq ▸ le_trans (le_max_left _ _) hx) (fun _ => norm_nonneg _) _
+    (fun x hx => Set.mem_setOf_eq ▸ le_trans (le_max_left _ _) hx) (fun _ => zero_le _) _
 
 end UnifIntegrable
 

--- a/Mathlib/Probability/Independence/Integrable.lean
+++ b/Mathlib/Probability/Independence/Integrable.lean
@@ -30,16 +30,16 @@ lemma Memℒp.isProbabilityMeasure_of_indepFun
     (f : Ω → E) (g : Ω → F) {p : ℝ≥0∞} (hp : p ≠ 0) (hp' : p ≠ ∞)
     (hℒp : Memℒp f p μ) (h'f : ¬ (∀ᵐ ω ∂μ, f ω = 0)) (hindep : IndepFun f g μ) :
     IsProbabilityMeasure μ := by
-  obtain ⟨c, c_pos, hc⟩ : ∃ (c : ℝ≥0), 0 < c ∧ 0 < μ {ω | c ≤ ‖f ω‖₊} := by
+  obtain ⟨c, c_pos, hc⟩ : ∃ (c : ℝ≥0), 0 < c ∧ 0 < μ {ω | c ≤ ‖f ω‖ₑ} := by
     contrapose! h'f
     have A (c : ℝ≥0) (hc : 0 < c) : ∀ᵐ ω ∂μ, ‖f ω‖₊ < c := by simpa [ae_iff] using h'f c hc
     obtain ⟨u, -, u_pos, u_lim⟩ : ∃ u, StrictAnti u ∧ (∀ (n : ℕ), 0 < u n)
       ∧ Tendsto u atTop (𝓝 0) := exists_seq_strictAnti_tendsto (0 : ℝ≥0)
     filter_upwards [ae_all_iff.2 (fun n ↦ A (u n) (u_pos n))] with ω hω
     simpa using ge_of_tendsto' u_lim (fun i ↦ (hω i).le)
-  have h'c : μ {ω | c ≤ ‖f ω‖₊} < ∞ := hℒp.meas_ge_lt_top hp hp' c_pos.ne'
-  have := hindep.measure_inter_preimage_eq_mul {x | c ≤ ‖x‖₊} Set.univ
-    (isClosed_le continuous_const continuous_nnnorm).measurableSet MeasurableSet.univ
+  have h'c : μ {ω | c ≤ ‖f ω‖ₑ} < ∞ := hℒp.meas_ge_lt_top hp hp' c_pos.ne'
+  have := hindep.measure_inter_preimage_eq_mul {x | c ≤ ‖x‖ₑ} Set.univ
+    (isClosed_le continuous_const continuous_enorm).measurableSet MeasurableSet.univ
   simp only [Set.preimage_setOf_eq, Set.preimage_univ, Set.inter_univ] at this
   exact ⟨(ENNReal.mul_eq_left hc.ne' h'c.ne).1 this.symm⟩
 


### PR DESCRIPTION
This work is part of (and a necessary pre-requisite for) the Carleson project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
