### PR TITLE
[Merged by Bors] - chore(Algebra/PUnitInstances): generalise universes

### DIFF
--- a/Mathlib/Algebra/PUnitInstances/Algebra.lean
+++ b/Mathlib/Algebra/PUnitInstances/Algebra.lean
@@ -29,10 +29,10 @@ instance commGroup : CommGroup PUnit where
   mul_comm := by intros; rfl
 
 -- shortcut instances
-@[to_additive] instance : One PUnit where one := ()
-@[to_additive] instance : Mul PUnit where mul _ _ := ()
-@[to_additive] instance : Div PUnit where div _ _ := ()
-@[to_additive] instance : Inv PUnit where inv _ := ()
+@[to_additive] instance : One PUnit where one := unit
+@[to_additive] instance : Mul PUnit where mul _ _ := unit
+@[to_additive] instance : Div PUnit where div _ _ := unit
+@[to_additive] instance : Inv PUnit where inv _ := unit
 
 -- dsimp loops when applying this lemma to its LHS,
 -- probably https://github.com/leanprover/lean4/pull/2867


### PR DESCRIPTION
Generalise these shortcut instances to arbitrary universes rather than restricting them to `PUnit.{1}`. As a consequence, the following 8 lemmas are also universe generalised.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
