### PR TITLE
[Merged by Bors] - feat(Data/LinearIndependent): iff versions of smul action on independent sets

### DIFF
--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -398,6 +398,13 @@ theorem LinearIndependent.group_smul {G : Type*} [hG : Group G] [DistribMulActio
   · simp_rw [hgs i hi]
   · simpa only [smul_assoc, smul_comm] using hsum
 
+@[simp] theorem LinearIndependent.group_smul_iff {G : Type*} [hG : Group G] [DistribMulAction G R]
+    [DistribMulAction G M] [IsScalarTower G R M] [SMulCommClass G R M] {v : ι → M} {w : ι → G} :
+    LinearIndependent R (w • v) ↔ LinearIndependent R v := by
+  refine ⟨fun h ↦ ?_, fun h ↦ h.group_smul w⟩
+  convert h.group_smul (fun i ↦ (w i)⁻¹)
+  simp [funext_iff]
+
 -- This lemma cannot be proved with `LinearIndependent.group_smul` since the action of
 -- `Rˣ` on `R` is not commutative.
 theorem LinearIndependent.units_smul {v : ι → M} (hv : LinearIndependent R v) (w : ι → Rˣ) :
@@ -408,6 +415,12 @@ theorem LinearIndependent.units_smul {v : ι → M} (hv : LinearIndependent R v)
   refine hv s (fun i ↦ g₁ i • w i) (fun i ↦ g₂ i • w i) (fun i hi ↦ ?_) ?_ i
   · simp_rw [hgs i hi]
   · simpa only [smul_eq_mul, mul_smul, Pi.smul_apply'] using hsum
+
+@[simp] theorem LinearIndependent.units_smul_iff {v : ι → M} {w : ι → Rˣ} :
+    LinearIndependent R (w • v) ↔ LinearIndependent R v := by
+  refine ⟨fun h ↦ ?_, fun h ↦ h.units_smul w⟩
+  convert h.units_smul (fun i ↦ (w i)⁻¹)
+  simp [funext_iff]
 
 theorem linearIndependent_image {ι} {s : Set ι} {f : ι → M} (hf : Set.InjOn f s) :
     (LinearIndependent R fun x : s ↦ f x) ↔ LinearIndependent R fun x : f '' s => (x : M) :=

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -398,8 +398,9 @@ theorem LinearIndependent.group_smul {G : Type*} [hG : Group G] [DistribMulActio
   · simp_rw [hgs i hi]
   · simpa only [smul_assoc, smul_comm] using hsum
 
-@[simp] theorem LinearIndependent.group_smul_iff {G : Type*} [hG : Group G] [DistribMulAction G R]
-    [DistribMulAction G M] [IsScalarTower G R M] [SMulCommClass G R M] {v : ι → M} {w : ι → G} :
+@[simp]
+theorem LinearIndependent.group_smul_iff {G : Type*} [hG : Group G] [DistribMulAction G R]
+    [DistribMulAction G M] [IsScalarTower G R M] [SMulCommClass G R M] (v : ι → M) (w : ι → G) :
     LinearIndependent R (w • v) ↔ LinearIndependent R v := by
   refine ⟨fun h ↦ ?_, fun h ↦ h.group_smul w⟩
   convert h.group_smul (fun i ↦ (w i)⁻¹)
@@ -416,7 +417,8 @@ theorem LinearIndependent.units_smul {v : ι → M} (hv : LinearIndependent R v)
   · simp_rw [hgs i hi]
   · simpa only [smul_eq_mul, mul_smul, Pi.smul_apply'] using hsum
 
-@[simp] theorem LinearIndependent.units_smul_iff {v : ι → M} {w : ι → Rˣ} :
+@[simp]
+theorem LinearIndependent.units_smul_iff (v : ι → M) (w : ι → Rˣ) :
     LinearIndependent R (w • v) ↔ LinearIndependent R v := by
   refine ⟨fun h ↦ ?_, fun h ↦ h.units_smul w⟩
   convert h.units_smul (fun i ↦ (w i)⁻¹)


### PR DESCRIPTION
We add iff versions of `LinearIndependent.group_smul` and `LinearIndependent.units_smul`, which can be simp. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
