### PR TITLE
[Merged by Bors] - chore: rename AnalyticAt.order_neq_top_iff

### DIFF
--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -218,15 +218,18 @@ lemma order_eq_nat_iff (hf : AnalyticAt 𝕜 f z₀) (n : ℕ) : hf.order = ↑n
     refine ⟨fun hn ↦ (WithTop.coe_inj.mp hn : h.choose = n) ▸ h.choose_spec, fun h' ↦ ?_⟩
     rw [unique_eventuallyEq_pow_smul_nonzero h.choose_spec h']
 
-/- An analytic function `f` has finite order at a point `z₀` iff it locally looks
+/-- An analytic function `f` has finite order at a point `z₀` iff it locally looks
   like `(z - z₀) ^ order • g`, where `g` is analytic and does not vanish at
   `z₀`. -/
-lemma order_neq_top_iff (hf : AnalyticAt 𝕜 f z₀) :
+lemma order_ne_top_iff (hf : AnalyticAt 𝕜 f z₀) :
     hf.order ≠ ⊤ ↔ ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0
       ∧ f =ᶠ[𝓝 z₀] fun z ↦ (z - z₀) ^ (hf.order.toNat) • g z := by
   simp only [← ENat.coe_toNat_eq_self, Eq.comm, EventuallyEq, ← hf.order_eq_nat_iff]
 
-/- An analytic function has order zero at a point iff it does not vanish there. -/
+@[deprecated (since := "2025-02-03")]
+alias order_neq_top_iff := order_ne_top_iff
+
+/-- An analytic function has order zero at a point iff it does not vanish there. -/
 lemma order_eq_zero_iff (hf : AnalyticAt 𝕜 f z₀) :
     hf.order = 0 ↔ f z₀ ≠ 0 := by
   rw [← ENat.coe_zero, order_eq_nat_iff hf 0]
@@ -235,7 +238,7 @@ lemma order_eq_zero_iff (hf : AnalyticAt 𝕜 f z₀) :
     simpa [hg.self_of_nhds]
   · exact fun hz ↦ ⟨f, hf, hz, by simp⟩
 
-/- An analytic function vanishes at a point if its order is nonzero when converted to ℕ. -/
+/-- An analytic function vanishes at a point if its order is nonzero when converted to ℕ. -/
 lemma apply_eq_zero_of_order_toNat_ne_zero (hf : AnalyticAt 𝕜 f z₀) :
     hf.order.toNat ≠ 0 → f z₀ = 0 := by
   simp [hf.order_eq_zero_iff]
@@ -258,8 +261,8 @@ theorem order_mul {f g : 𝕜 → 𝕜} (hf : AnalyticAt 𝕜 f z₀) (hg : Anal
   by_cases h₂g : hg.order = ⊤
   · simp [mul_comm f g, hg.order_mul_of_order_eq_top hf h₂g, h₂g]
   -- Non-trivial case: both functions do not vanish around z₀
-  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf.order_neq_top_iff.1 h₂f
-  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := hg.order_neq_top_iff.1 h₂g
+  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := hf.order_ne_top_iff.1 h₂f
+  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := hg.order_ne_top_iff.1 h₂g
   rw [← ENat.coe_toNat h₂f, ← ENat.coe_toNat h₂g, ← ENat.coe_add, (hf.mul hg).order_eq_nat_iff]
   use g₁ * g₂, by exact h₁g₁.mul h₁g₂
   constructor


### PR DESCRIPTION
Per the naming convention, the symbol `≠` should be transcribed as "ne", not "neq".

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
