### PR TITLE
[Merged by Bors] - chore(Combinatorics/SimpleGraph): Fix `hadj` naming

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Circulant.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Circulant.lean
@@ -137,15 +137,15 @@ private def cycleGraph_EulerianCircuit_cons (n : ℕ) :
     ∀ m : Fin (n + 3), (cycleGraph (n + 3)).Walk m 0
   | ⟨0, h⟩ => Walk.nil
   | ⟨m + 1, h⟩ =>
-    have hAdj : (cycleGraph (n + 3)).Adj ⟨m + 1, h⟩ ⟨m, Nat.lt_of_succ_lt h⟩ := by
+    have hadj : (cycleGraph (n + 3)).Adj ⟨m + 1, h⟩ ⟨m, Nat.lt_of_succ_lt h⟩ := by
       simp [cycleGraph_adj, Fin.ext_iff, Fin.sub_val_of_le]
-    Walk.cons hAdj (cycleGraph_EulerianCircuit_cons n ⟨m, Nat.lt_of_succ_lt h⟩)
+    Walk.cons hadj (cycleGraph_EulerianCircuit_cons n ⟨m, Nat.lt_of_succ_lt h⟩)
 
 /-- Eulerian trail of `cycleGraph (n + 3)` -/
 def cycleGraph_EulerianCircuit (n : ℕ) : (cycleGraph (n + 3)).Walk 0 0 :=
-  have hAdj : (cycleGraph (n + 3)).Adj 0 (Fin.last (n + 2)) := by
+  have hadj : (cycleGraph (n + 3)).Adj 0 (Fin.last (n + 2)) := by
     simp [cycleGraph_adj]
-  Walk.cons hAdj (cycleGraph_EulerianCircuit_cons n (Fin.last (n + 2)))
+  Walk.cons hadj (cycleGraph_EulerianCircuit_cons n (Fin.last (n + 2)))
 
 private theorem cycleGraph_EulerianCircuit_cons_length (n : ℕ) : ∀ m : Fin (n + 3),
     (cycleGraph_EulerianCircuit_cons n m).length = m.val

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -23,13 +23,13 @@ assert_not_exists Field
 
 namespace SimpleGraph
 
-theorem two_le_chromaticNumber_of_adj {α} {G : SimpleGraph α} {u v : α} (hAdj : G.Adj u v) :
+theorem two_le_chromaticNumber_of_adj {α} {G : SimpleGraph α} {u v : α} (hadj : G.Adj u v) :
     2 ≤ G.chromaticNumber := by
   refine le_of_not_lt ?_
   intro h
   have hc : G.Colorable 1 := chromaticNumber_le_iff_colorable.mp (Order.le_of_lt_add_one h)
   let c : G.Coloring (Fin 1) := hc.some
-  exact c.valid hAdj (Subsingleton.elim (c u) (c v))
+  exact c.valid hadj (Subsingleton.elim (c u) (c v))
 
 /-- Bicoloring of a path graph -/
 def pathGraph.bicoloring (n : ℕ) :
@@ -55,8 +55,8 @@ theorem chromaticNumber_pathGraph (n : ℕ) (h : 2 ≤ n) :
   have hc := (pathGraph.bicoloring n).colorable
   apply le_antisymm
   · exact hc.chromaticNumber_le
-  · have hAdj : (pathGraph n).Adj ⟨0, Nat.zero_lt_of_lt h⟩ ⟨1, h⟩ := by simp [pathGraph_adj]
-    exact two_le_chromaticNumber_of_adj hAdj
+  · have hadj : (pathGraph n).Adj ⟨0, Nat.zero_lt_of_lt h⟩ ⟨1, h⟩ := by simp [pathGraph_adj]
+    exact two_le_chromaticNumber_of_adj hadj
 
 theorem Coloring.even_length_iff_congr {α} {G : SimpleGraph α}
     (c : G.Coloring Bool) {u v : α} (p : G.Walk u v) :
@@ -88,14 +88,14 @@ theorem Walk.three_le_chromaticNumber_of_odd_loop {α} {G : SimpleGraph α} {u :
 /-- Bicoloring of a cycle graph of even size -/
 def cycleGraph.bicoloring_of_even (n : ℕ) (h : Even n) : Coloring (cycleGraph n) Bool :=
   Coloring.mk (fun u ↦ u.val % 2 = 0) <| by
-    intro u v hAdj
+    intro u v hadj
     match n with
     | 0 => exact u.elim0
     | 1 => simp at h
     | n + 2 =>
       simp only [ne_eq, decide_eq_decide]
-      simp only [cycleGraph_adj] at hAdj
-      cases hAdj with
+      simp only [cycleGraph_adj] at hadj
+      cases hadj with
       | inl huv | inr huv =>
         rw [← add_eq_of_eq_sub' huv.symm, ← Fin.even_iff_mod_of_even h,
           ← Fin.even_iff_mod_of_even h, Fin.even_add_one_iff_odd]
@@ -107,22 +107,22 @@ theorem chromaticNumber_cycleGraph_of_even (n : ℕ) (h : 2 ≤ n) (hEven : Even
   have hc := (cycleGraph.bicoloring_of_even n hEven).colorable
   apply le_antisymm
   · apply hc.chromaticNumber_le
-  · have hAdj : (cycleGraph n).Adj ⟨0, Nat.zero_lt_of_lt h⟩ ⟨1, h⟩ := by
+  · have hadj : (cycleGraph n).Adj ⟨0, Nat.zero_lt_of_lt h⟩ ⟨1, h⟩ := by
       simp [cycleGraph_adj', Fin.sub_val_of_le]
-    exact two_le_chromaticNumber_of_adj hAdj
+    exact two_le_chromaticNumber_of_adj hadj
 
 /-- Tricoloring of a cycle graph -/
 def cycleGraph.tricoloring (n : ℕ) (h : 2 ≤ n) : Coloring (cycleGraph n)
   (Fin 3) := Coloring.mk (fun u ↦ if u.val = n - 1 then 2 else ⟨u.val % 2, by fin_omega⟩) <| by
-    intro u v hAdj
+    intro u v hadj
     match n with
     | 0 => exact u.elim0
     | 1 => simp at h
     | n + 2 =>
       simp only
-      simp [cycleGraph_adj] at hAdj
+      simp [cycleGraph_adj] at hadj
       split_ifs with hu hv
-      · simp [Fin.eq_mk_iff_val_eq.mpr hu, Fin.eq_mk_iff_val_eq.mpr hv] at hAdj
+      · simp [Fin.eq_mk_iff_val_eq.mpr hu, Fin.eq_mk_iff_val_eq.mpr hv] at hadj
       · refine (Fin.ne_of_lt (Fin.mk_lt_of_lt_val (?_))).symm
         exact v.val.mod_lt Nat.zero_lt_two
       · refine (Fin.ne_of_lt (Fin.mk_lt_of_lt_val ?_))
@@ -130,7 +130,7 @@ def cycleGraph.tricoloring (n : ℕ) (h : 2 ≤ n) : Coloring (cycleGraph n)
       · simp [Fin.ext_iff]
         have hu' : u.val + (1 : Fin (n + 2)) < n + 2 := by fin_omega
         have hv' : v.val + (1 : Fin (n + 2)) < n + 2 := by fin_omega
-        cases hAdj with
+        cases hadj with
         | inl huv | inr huv =>
           rw [← add_eq_of_eq_sub' huv.symm]
           simp only [Fin.val_add_eq_of_add_lt hv', Fin.val_add_eq_of_add_lt hu', Fin.val_one]


### PR DESCRIPTION
---
In some of my pull requests I used `hAdj`, but in other places `hadj` is used, so here I'm fixing my names

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
