### PR TITLE
[Merged by Bors] - chore(AlgebraicGeometry): more API for local at source

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -622,7 +622,8 @@ end HasAffineProperty
 
 end targetAffineLocally
 
-open MorphismProperty in
+open MorphismProperty
+
 lemma hasOfPostcompProperty_isOpenImmersion_of_morphismRestrict (P : MorphismProperty Scheme)
     [P.RespectsIso] (H : ∀ {X Y : Scheme.{u}} (f : X ⟶ Y) (U : Y.Opens), P f → P (f ∣_ U)) :
     P.HasOfPostcompProperty @IsOpenImmersion where
@@ -635,9 +636,7 @@ lemma hasOfPostcompProperty_isOpenImmersion_of_morphismRestrict (P : MorphismPro
     exact H _ _ hfg
 
 instance (P : MorphismProperty Scheme) [P.RespectsIso] [P.IsStableUnderBaseChange] :
-    P.HasOfPostcompProperty @IsOpenImmersion := by
-  apply hasOfPostcompProperty_isOpenImmersion_of_morphismRestrict
-  introv hf
-  exact P.of_isPullback (isPullback_morphismRestrict f U).flip hf
+    P.HasOfPostcompProperty @IsOpenImmersion :=
+  HasOfPostcompProperty.of_le P (.monomorphisms Scheme) (fun _ _ f _ ↦ inferInstanceAs (Mono f))
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -622,4 +622,22 @@ end HasAffineProperty
 
 end targetAffineLocally
 
+open MorphismProperty in
+lemma hasOfPostcompProperty_isOpenImmersion_of_morphismRestrict (P : MorphismProperty Scheme)
+    [P.RespectsIso] (H : ∀ {X Y : Scheme.{u}} (f : X ⟶ Y) (U : Y.Opens), P f → P (f ∣_ U)) :
+    P.HasOfPostcompProperty @IsOpenImmersion where
+  of_postcomp {X Y Z} f g hg hfg := by
+    have : (f ≫ g) ⁻¹ᵁ g.opensRange = ⊤ := by simp
+    have : f = X.topIso.inv ≫ (X.isoOfEq this).inv ≫ (f ≫ g) ∣_ g.opensRange ≫
+        (IsOpenImmersion.isoOfRangeEq g.opensRange.ι g (by simp)).hom := by
+      simp [← cancel_mono g]
+    simp_rw [this, cancel_left_of_respectsIso (P := P), cancel_right_of_respectsIso (P := P)]
+    exact H _ _ hfg
+
+instance (P : MorphismProperty Scheme) [P.RespectsIso] [P.IsStableUnderBaseChange] :
+    P.HasOfPostcompProperty @IsOpenImmersion := by
+  apply hasOfPostcompProperty_isOpenImmersion_of_morphismRestrict
+  introv hf
+  exact P.of_isPullback (isPullback_morphismRestrict f U).flip hf
+
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -635,7 +635,7 @@ lemma hasOfPostcompProperty_isOpenImmersion_of_morphismRestrict (P : MorphismPro
     simp_rw [this, cancel_left_of_respectsIso (P := P), cancel_right_of_respectsIso (P := P)]
     exact H _ _ hfg
 
-instance (P : MorphismProperty Scheme) [P.RespectsIso] [P.IsStableUnderBaseChange] :
+instance (P : MorphismProperty Scheme) [P.IsStableUnderBaseChange] :
     P.HasOfPostcompProperty @IsOpenImmersion :=
   HasOfPostcompProperty.of_le P (.monomorphisms Scheme) (fun _ _ f _ ↦ inferInstanceAs (Mono f))
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
@@ -151,6 +151,27 @@ instance (P) [IsLocalAtTarget P] : IsLocalAtTarget P.diagonal :=
   letI := HasAffineProperty.of_isLocalAtTarget P
   inferInstance
 
+open MorphismProperty in
+instance (P : MorphismProperty Scheme)
+    [P.HasOfPostcompProperty @IsOpenImmersion] [P.RespectsRight @IsOpenImmersion]
+    [IsLocalAtSource P] : IsLocalAtSource P.diagonal := by
+  let g {X Y : Scheme} (f : X ⟶ Y) (U : X.Opens) :
+      pullback (U.ι ≫ f) (U.ι ≫ f) ⟶ pullback f f :=
+    pullback.map (U.ι ≫ f) (U.ι ≫ f) f f U.ι U.ι (𝟙 Y) (by simp) (by simp)
+  have heq {X Y : Scheme} (f : X ⟶ Y) (U : X.Opens) :
+      U.ι ≫ pullback.diagonal f = pullback.diagonal (U.ι ≫ f) ≫ g f U := by
+    apply pullback.hom_ext <;> simp [g]
+  refine IsLocalAtSource.mk' (fun {X Y} f U hf ↦ ?_) (fun {X Y} f {ι} U hU hf ↦ ?_)
+  · show P _
+    apply P.of_postcomp (W' := @IsOpenImmersion) (pullback.diagonal (U.ι ≫ f)) (g f U) inferInstance
+    rw [← heq]
+    apply IsLocalAtSource.comp
+    exact hf
+  · show P _
+    refine IsLocalAtSource.of_iSup_eq_top U hU fun i ↦ ?_
+    rw [heq]
+    exact RespectsRight.postcomp (P := P) (Q := @IsOpenImmersion) (g _ _) inferInstance _ (hf i)
+
 end Diagonal
 
 section Universally

--- a/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
@@ -155,21 +155,17 @@ open MorphismProperty in
 instance (P : MorphismProperty Scheme)
     [P.HasOfPostcompProperty @IsOpenImmersion] [P.RespectsRight @IsOpenImmersion]
     [IsLocalAtSource P] : IsLocalAtSource P.diagonal := by
-  let g {X Y : Scheme} (f : X ⟶ Y) (U : X.Opens) :
-      pullback (U.ι ≫ f) (U.ι ≫ f) ⟶ pullback f f :=
+  let g {X Y : Scheme} (f : X ⟶ Y) (U : X.Opens) :=
     pullback.map (U.ι ≫ f) (U.ι ≫ f) f f U.ι U.ι (𝟙 Y) (by simp) (by simp)
-  have heq {X Y : Scheme} (f : X ⟶ Y) (U : X.Opens) :
-      U.ι ≫ pullback.diagonal f = pullback.diagonal (U.ι ≫ f) ≫ g f U := by
-    apply pullback.hom_ext <;> simp [g]
   refine IsLocalAtSource.mk' (fun {X Y} f U hf ↦ ?_) (fun {X Y} f {ι} U hU hf ↦ ?_)
   · show P _
     apply P.of_postcomp (W' := @IsOpenImmersion) (pullback.diagonal (U.ι ≫ f)) (g f U) inferInstance
-    rw [← heq]
+    rw [← pullback.comp_diagonal]
     apply IsLocalAtSource.comp
     exact hf
   · show P _
     refine IsLocalAtSource.of_iSup_eq_top U hU fun i ↦ ?_
-    rw [heq]
+    rw [pullback.comp_diagonal]
     exact RespectsRight.postcomp (P := P) (Q := @IsOpenImmersion) (g _ _) inferInstance _ (hf i)
 
 end Diagonal

--- a/Mathlib/AlgebraicGeometry/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
@@ -147,6 +147,11 @@ lemma map_mem_image_iff {X Y : Scheme} (f : X ⟶ Y) [IsOpenImmersion f]
     {U : X.Opens} {x : X} : f.base x ∈ f ''ᵁ U ↔ x ∈ U :=
   f.isOpenEmbedding.injective.mem_set_image
 
+@[simp]
+lemma preimage_opensRange {X Y : Scheme.{u}} (f : X.Hom Y) [IsOpenImmersion f] :
+    f ⁻¹ᵁ f.opensRange = ⊤ := by
+  simp [Scheme.Hom.opensRange]
+
 /-- The isomorphism `Γ(Y, f(U)) ≅ Γ(X, U)` induced by an open immersion `f : X ⟶ Y`. -/
 def appIso (U) : Γ(Y, f ''ᵁ U) ≅ Γ(X, U) :=
   (asIso <| LocallyRingedSpace.IsOpenImmersion.invApp f.toLRSHom U).symm

--- a/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
@@ -282,6 +282,11 @@ theorem pullback.diagonal_comp (f : X ⟶ Y) (g : Y ⟶ Z) [HasPullback f f] [Ha
     diagonal (f ≫ g) = diagonal f ≫ (pullbackDiagonalMapIdIso f f g).inv ≫ pullback.snd _ _ := by
   ext <;> simp
 
+lemma pullback.comp_diagonal (f : X ⟶ Y) (g : Y ⟶ Z) [HasPullback f f] [HasPullback g g] :
+    f ≫ pullback.diagonal g = pullback.diagonal (f ≫ g) ≫
+      pullback.map (f ≫ g) (f ≫ g) g g f f (𝟙 Z) (by simp) (by simp) := by
+  apply pullback.hom_ext <;> simp
+
 theorem pullback_map_diagonal_isPullback :
     IsPullback (pullback.fst _ _ ≫ f)
       (pullback.map f g (f ≫ i) (g ≫ i) _ _ i (Category.id_comp _).symm (Category.id_comp _).symm)

--- a/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
@@ -281,6 +281,7 @@ theorem pullback.diagonal_comp (f : X ⟶ Y) (g : Y ⟶ Z) :
     diagonal (f ≫ g) = diagonal f ≫ (pullbackDiagonalMapIdIso f f g).inv ≫ pullback.snd _ _ := by
   ext <;> simp
 
+@[reassoc]
 lemma pullback.comp_diagonal (f : X ⟶ Y) (g : Y ⟶ Z) :
     f ≫ pullback.diagonal g = pullback.diagonal (f ≫ g) ≫
       pullback.map (f ≫ g) (f ≫ g) g g f f (𝟙 Z) (by simp) (by simp) := by

--- a/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
@@ -277,15 +277,14 @@ theorem pullbackDiagonalMapIdIso_inv_snd_snd :
   rw [Iso.inv_comp_eq]
   simp
 
-theorem pullback.diagonal_comp (f : X ⟶ Y) (g : Y ⟶ Z) [HasPullback f f] [HasPullback g g]
-    [HasPullback (f ≫ g) (f ≫ g)] :
+theorem pullback.diagonal_comp (f : X ⟶ Y) (g : Y ⟶ Z) :
     diagonal (f ≫ g) = diagonal f ≫ (pullbackDiagonalMapIdIso f f g).inv ≫ pullback.snd _ _ := by
   ext <;> simp
 
-lemma pullback.comp_diagonal (f : X ⟶ Y) (g : Y ⟶ Z) [HasPullback f f] [HasPullback g g] :
+lemma pullback.comp_diagonal (f : X ⟶ Y) (g : Y ⟶ Z) :
     f ≫ pullback.diagonal g = pullback.diagonal (f ≫ g) ≫
       pullback.map (f ≫ g) (f ≫ g) g g f f (𝟙 Z) (by simp) (by simp) := by
-  apply pullback.hom_ext <;> simp
+  ext <;> simp
 
 theorem pullback_map_diagonal_isPullback :
     IsPullback (pullback.fst _ _ ≫ f)

--- a/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
@@ -235,6 +235,14 @@ lemma precomp_iff [W.RespectsLeft W'] [W.HasOfPrecompProperty W']
     W (f ≫ g) ↔ W g :=
   ⟨W.of_precomp f g hf, fun hg ↦ RespectsLeft.precomp _ hf _ hg⟩
 
+lemma HasOfPostcompProperty.of_le (Q : MorphismProperty C) [W.HasOfPostcompProperty Q]
+    (hle : W' ≤ Q) : W.HasOfPostcompProperty W' where
+  of_postcomp f g hg hfg := W.of_postcomp (W' := Q) f g (hle _ hg) hfg
+
+lemma HasOfPrecompProperty.of_le (Q : MorphismProperty C) [W.HasOfPrecompProperty Q]
+    (hle : W' ≤ Q) : W.HasOfPrecompProperty W' where
+  of_precomp f g hg hfg := W.of_precomp (W' := Q) f g (hle _ hg) hfg
+
 end
 
 instance : (isomorphisms C).HasTwoOutOfThreeProperty where

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -211,6 +211,14 @@ theorem pullback_map [HasPullbacks C]
   exacts [baseChange_map _ (Over.homMk _ e₂.symm : Over.mk g ⟶ Over.mk g') h₂,
     baseChange_map _ (Over.homMk _ e₁.symm : Over.mk f ⟶ Over.mk f') h₁]
 
+instance IsStableUnderBaseChange.hasOfPostcompProperty_monomorphisms
+    [P.IsStableUnderBaseChange] : P.HasOfPostcompProperty (MorphismProperty.monomorphisms C) where
+  of_postcomp {X Y Z} f g (hg : Mono g) hcomp := by
+    have : f = (asIso (pullback.fst (f ≫ g) g)).inv ≫ pullback.snd (f ≫ g) g := by
+      simp [Iso.eq_inv_comp, ← cancel_mono g, pullback.condition]
+    rw [this, cancel_left_of_respectsIso (P := P)]
+    exact P.pullback_snd _ _ hcomp
+
 @[deprecated (since := "2024-11-06")] alias IsStableUnderBaseChange.pullback_map := pullback_map
 
 lemma of_isPushout [P.IsStableUnderCobaseChange]
@@ -275,6 +283,14 @@ theorem pushout_inr [IsStableUnderCobaseChange P]
   of_isPushout (IsPushout.of_hasPushout f g).flip H
 
 @[deprecated (since := "2024-11-06")] alias IsStableUnderBaseChange.inr := pushout_inr
+
+instance IsStableUnderCobaseChange.hasOfPrecompProperty_epimorphisms
+    [P.IsStableUnderCobaseChange] : P.HasOfPrecompProperty (MorphismProperty.epimorphisms C) where
+  of_precomp {X Y Z} f g (hf : Epi f) hcomp := by
+    have : g = pushout.inr (f ≫ g) f ≫ (asIso (pushout.inl (f ≫ g) f)).inv := by
+      rw [asIso_inv, IsIso.eq_comp_inv, ← cancel_epi f, ← pushout.condition, assoc]
+    rw [this, cancel_right_of_respectsIso (P := P)]
+    exact P.pushout_inr _ _ hcomp
 
 instance IsStableUnderCobaseChange.op [IsStableUnderCobaseChange P] :
     IsStableUnderBaseChange P.op where


### PR DESCRIPTION
In particular `P.diagonal` is local at the source if `P` is and `P` is sufficiently compatible with open immersions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
