### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/ExteriorPower): add iMulti_family definition for product of a family of vectors

### DIFF
--- a/Mathlib/LinearAlgebra/ExteriorPower/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/Basic.lean
@@ -246,8 +246,7 @@ lemma map_comp_ιMulti_family {I : Type*} [LinearOrder I] (v : I → M) (f : M �
 lemma map_apply_ιMulti_family {I : Type*} [LinearOrder I] (v : I → M) (f : M →ₗ[R] N)
   (s : {s : Finset I // s.card = n}) :
     (map n f) (ιMulti_family R n v s) = ιMulti_family R n (f ∘ v) s := by
-  unfold ιMulti_family
-  simp only [map, alternatingMapLinearEquiv_apply_ιMulti]
+  simp only [ιMulti_family, map, alternatingMapLinearEquiv_apply_ιMulti]
   rfl
 
 @[simp]

--- a/Mathlib/LinearAlgebra/ExteriorPower/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/Basic.lean
@@ -54,6 +54,17 @@ def ιMulti : M [⋀^Fin n]→ₗ[R] (⋀[R]^n M) :=
 
 @[simp] lemma ιMulti_apply_coe (a : Fin n → M) : ιMulti R n a = ExteriorAlgebra.ιMulti R n a := rfl
 
+/-- Given a linearly ordered family `v` of vectors of `M` and a natural number `n`, produce the
+family of `n`fold exterior products of elements of `v`, seen as members of the
+`n`th exterior power. -/
+noncomputable def ιMulti_family {I : Type*} [LinearOrder I] (v : I → M) :
+    {s : Finset I // Finset.card s = n} → ⋀[R]^n M :=
+  fun ⟨s, hs⟩ => ιMulti R n (fun i => v (Finset.orderIsoOfFin s hs i))
+
+@[simp] lemma ιMulti_family_apply_coe {I : Type*} [LinearOrder I] (v : I → M)
+  (s : {s : Finset I // Finset.card s = n}) :
+    ιMulti_family R n v s = ExteriorAlgebra.ιMulti_family R n v s := rfl
+
 variable (M)
 /-- The image of `ExteriorAlgebra.ιMulti R n` spans the `n`th exterior power. Variant of
 `ExteriorAlgebra.ιMulti_span_fixedDegree`, useful in rewrites. -/
@@ -222,6 +233,22 @@ theorem map_comp_ιMulti (f : M →ₗ[R] N) :
 theorem map_apply_ιMulti (f : M →ₗ[R] N) (m : Fin n → M) :
     map n f (ιMulti R n m) = ιMulti R n (f ∘ m) := by
   simp only [map, alternatingMapLinearEquiv_apply_ιMulti, AlternatingMap.compLinearMap_apply]
+  rfl
+
+@[simp]
+lemma map_comp_ιMulti_family {I : Type*} [LinearOrder I] (v : I → M) (f : M →ₗ[R] N) :
+    (map n f) ∘ (ιMulti_family R n v) = ιMulti_family R n (f ∘ v) := by
+  ext ⟨s, hs⟩
+  unfold ιMulti_family
+  simp only [Function.comp_apply, map_apply_ιMulti]
+  rfl
+
+@[simp]
+lemma map_apply_ιMulti_family {I : Type*} [LinearOrder I] (v : I → M) (f : M →ₗ[R] N)
+  (s : {s : Finset I // s.card = n}) :
+    (map n f) (ιMulti_family R n v s) = ιMulti_family R n (f ∘ v) s := by
+  unfold ιMulti_family
+  simp only [map, alternatingMapLinearEquiv_apply_ιMulti]
   rfl
 
 @[simp]

--- a/Mathlib/LinearAlgebra/ExteriorPower/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/Basic.lean
@@ -57,9 +57,9 @@ def ιMulti : M [⋀^Fin n]→ₗ[R] (⋀[R]^n M) :=
 /-- Given a linearly ordered family `v` of vectors of `M` and a natural number `n`, produce the
 family of `n`fold exterior products of elements of `v`, seen as members of the
 `n`th exterior power. -/
-noncomputable def ιMulti_family {I : Type*} [LinearOrder I] (v : I → M) :
-    {s : Finset I // Finset.card s = n} → ⋀[R]^n M :=
-  fun ⟨s, hs⟩ => ιMulti R n (fun i => v (Finset.orderIsoOfFin s hs i))
+noncomputable def ιMulti_family {I : Type*} [LinearOrder I] (v : I → M)
+    (s : {s : Finset I // Finset.card s = n}) : ⋀[R]^n M :=
+  ιMulti R n fun i ↦ v <| Finset.orderIsoOfFin s.val s.property i
 
 @[simp] lemma ιMulti_family_apply_coe {I : Type*} [LinearOrder I] (v : I → M)
   (s : {s : Finset I // Finset.card s = n}) :

--- a/Mathlib/LinearAlgebra/ExteriorPower/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/Basic.lean
@@ -239,8 +239,7 @@ theorem map_apply_ιMulti (f : M →ₗ[R] N) (m : Fin n → M) :
 lemma map_comp_ιMulti_family {I : Type*} [LinearOrder I] (v : I → M) (f : M →ₗ[R] N) :
     (map n f) ∘ (ιMulti_family R n v) = ιMulti_family R n (f ∘ v) := by
   ext ⟨s, hs⟩
-  unfold ιMulti_family
-  simp only [Function.comp_apply, map_apply_ιMulti]
+  simp only [ιMulti_family, Function.comp_apply, map_apply_ιMulti]
   rfl
 
 @[simp]


### PR DESCRIPTION
This splits the definition of `ιMulti_family` from PR #10654 along with a few basic lemmas that do not rely on other parts of the PR. The `ιMulti_family` definition allows taking the product of a subset of a family of vectors, which is useful when the number of vectors is different from the degree of the exterior power. In particular, this is useful for working with a collection of basis or spanning vectors.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
