### PR TITLE
[Merged by Bors] - chore: rename mem_nonZeroDivisor_of_injective and comap_nonZeroDivisor_le_of_injective

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -211,13 +211,19 @@ theorem nonZeroDivisors_le_comap_nonZeroDivisors_of_injective [NoZeroDivisors M'
 
 /-- If an element maps to a non-zero-divisor via injective homomorphism,
 then it is non-zero-divisor. -/
-theorem mem_nonZeroDivisor_of_injective [MonoidWithZeroHomClass F M M'] {f : F}
+theorem mem_nonZeroDivisors_of_injective [MonoidWithZeroHomClass F M M'] {f : F}
     (hf : Function.Injective f) {a : M} (ha : f a ∈ M'⁰) : a ∈ M⁰ :=
   fun x hx ↦ hf <| map_zero f ▸ ha (f x) (map_mul f x a ▸ map_zero f ▸ congrArg f hx)
 
-theorem comap_nonZeroDivisor_le_of_injective [MonoidWithZeroHomClass F M M'] {f : F}
+@[deprecated (since := "2025-02-03")]
+alias mem_nonZeroDivisor_of_injective := mem_nonZeroDivisors_of_injective
+
+theorem comap_nonZeroDivisors_le_of_injective [MonoidWithZeroHomClass F M M'] {f : F}
     (hf : Function.Injective f) : M'⁰.comap f ≤ M⁰ :=
-  fun _ ha ↦ mem_nonZeroDivisor_of_injective hf (Submonoid.mem_comap.mp ha)
+  fun _ ha ↦ mem_nonZeroDivisors_of_injective hf (Submonoid.mem_comap.mp ha)
+
+@[deprecated (since := "2025-02-03")]
+alias comap_nonZeroDivisor_le_of_injective := comap_nonZeroDivisors_le_of_injective
 
 end MonoidWithZero
 

--- a/Mathlib/RingTheory/Artinian/Algebra.lean
+++ b/Mathlib/RingTheory/Artinian/Algebra.lean
@@ -29,7 +29,7 @@ theorem isUnit_of_isIntegral_of_nonZeroDivisor {a : A}
   haveI : Module.Finite R B := Algebra.finite_adjoin_simple_of_isIntegral hi
   haveI : IsArtinianRing B := isArtinian_of_tower R inferInstance
   have hinj : Function.Injective (B.subtype) := Subtype.val_injective
-  have hb : b ∈ B⁰ := comap_nonZeroDivisor_le_of_injective hinj ha
+  have hb : b ∈ B⁰ := comap_nonZeroDivisors_le_of_injective hinj ha
   (isUnit_of_mem_nonZeroDivisors hb).map B.subtype
 
 /-- Integral element of an algebra over artinian ring `R` is either a zero divisor or a unit. -/

--- a/Mathlib/RingTheory/LocalRing/Subring.lean
+++ b/Mathlib/RingTheory/LocalRing/Subring.lean
@@ -26,7 +26,7 @@ theorem of_injective [IsLocalRing S] {f : R →+* S} (hf : Function.Injective f)
   haveI : Nontrivial R := f.domain_nontrivial
   refine .of_is_unit_or_is_unit_of_add_one fun {a b} hab ↦
     (IsLocalRing.isUnit_or_isUnit_of_add_one (map_add f .. ▸ map_one f ▸ congrArg f hab)).imp ?_ ?_
-  <;> exact h _ ∘ mem_nonZeroDivisor_of_injective hf ∘ IsUnit.mem_nonZeroDivisors
+  <;> exact h _ ∘ mem_nonZeroDivisors_of_injective hf ∘ IsUnit.mem_nonZeroDivisors
 
 /-- If in a sub(semi)ring `R` of a local (semi)ring `S` every element is either
 invertible or a zero divisor, then `R` is local. -/


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
