### PR TITLE
[Merged by Bors] - feat(CategoryTheory): small classes of morphisms

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2130,6 +2130,7 @@ import Mathlib.CategoryTheory.MorphismProperty.Composition
 import Mathlib.CategoryTheory.MorphismProperty.Concrete
 import Mathlib.CategoryTheory.MorphismProperty.Factorization
 import Mathlib.CategoryTheory.MorphismProperty.IsInvertedBy
+import Mathlib.CategoryTheory.MorphismProperty.IsSmall
 import Mathlib.CategoryTheory.MorphismProperty.LiftingProperty
 import Mathlib.CategoryTheory.MorphismProperty.Limits
 import Mathlib.CategoryTheory.MorphismProperty.OverAdjunction

--- a/Mathlib/CategoryTheory/MorphismProperty/IsSmall.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/IsSmall.lean
@@ -34,13 +34,10 @@ attribute [instance] IsSmall.small_toSet
 
 instance isSmall_ofHoms {ι : Type t} [Small.{w} ι] {A B : ι → C} (f : ∀ i, A i ⟶ B i) :
     IsSmall.{w} (ofHoms f) := by
-  let φ (i : Shrink.{w} ι) : (ofHoms f).toSet :=
-    ⟨Arrow.mk (f ((equivShrink _).symm i)), ⟨(equivShrink _).symm i⟩⟩
+  let φ (i : ι) : (ofHoms f).toSet := ⟨Arrow.mk (f i), ⟨i⟩⟩
   have hφ : Function.Surjective φ := by
     rintro ⟨⟨_, _, f⟩, ⟨i⟩⟩
-    refine ⟨equivShrink _ i, ?_⟩
-    simp only [Subtype.mk.injEq, φ]
-    fapply Arrow.ext <;> simp
+    exact ⟨i, rfl⟩
   exact ⟨small_of_surjective hφ⟩
 
 lemma isSmall_iff_eq_ofHoms :

--- a/Mathlib/CategoryTheory/MorphismProperty/IsSmall.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/IsSmall.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.MorphismProperty.Basic
+import Mathlib.Logic.Small.Basic
+
+/-!
+# Small classes of morphisms
+
+A class of morphisms `W : MorphismProperty C` is `w`-small
+if the corresponding set in `Set (Arrow C)` is.
+
+-/
+
+universe w t v u
+
+namespace CategoryTheory
+
+variable {C : Type u} [Category.{v} C]
+
+namespace MorphismProperty
+
+variable (W : MorphismProperty C)
+
+/-- A class of morphisms `W : MorphismProperty C` is `w`-small
+if the corresponding set in `Set (Arrow C)` is. -/
+@[pp_with_univ]
+class IsSmall : Prop where
+  small_toSet : Small.{w} W.toSet
+
+attribute [instance] IsSmall.small_toSet
+
+instance isSmall_ofHoms {ι : Type t} [Small.{w} ι] {A B : ι → C} (f : ∀ i, A i ⟶ B i) :
+    IsSmall.{w} (ofHoms f) := by
+  let φ (i : Shrink.{w} ι) : (ofHoms f).toSet :=
+    ⟨Arrow.mk (f ((equivShrink _).symm i)), ⟨(equivShrink _).symm i⟩⟩
+  have hφ : Function.Surjective φ := by
+    rintro ⟨⟨_, _, f⟩, ⟨i⟩⟩
+    refine ⟨equivShrink _ i, ?_⟩
+    simp only [Subtype.mk.injEq, φ]
+    fapply Arrow.ext <;> simp
+  exact ⟨small_of_surjective hφ⟩
+
+lemma isSmall_iff_eq_ofHoms :
+    IsSmall.{w} W ↔ ∃ (ι : Type w) (A B : ι → C) (f : ∀ i, A i ⟶ B i),
+      W = ofHoms f := by
+  constructor
+  · intro
+    refine ⟨Shrink.{w} W.toSet, _, _, fun i ↦ ((equivShrink _).symm i).1.hom, ?_⟩
+    ext A B f
+    rw [ofHoms_iff]
+    constructor
+    · intro hf
+      exact ⟨equivShrink _ ⟨f, hf⟩, by simp⟩
+    · rintro ⟨i, hi⟩
+      simp only [← W.arrow_mk_mem_toSet_iff, hi, Arrow.mk_eq, Subtype.coe_prop]
+  · rintro ⟨_, _, _, _, rfl⟩
+    infer_instance
+
+end MorphismProperty
+
+end CategoryTheory


### PR DESCRIPTION
This PR introduces a typeclass `IsSmall.{w} W` for `W : MorphismProperty C`. It means that the morphisms in `C` can be parametrized by a `w`-small type.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
