### PR TITLE
[Merged by Bors] - feat(CategoryTheory): (co)limits of constant functors

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Connected.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Bhavik Mehta
+Authors: Bhavik Mehta, Joël Riou
 -/
 import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
 import Mathlib.CategoryTheory.Limits.Shapes.Equalizers
@@ -14,9 +14,11 @@ import Mathlib.CategoryTheory.Limits.Preserves.Basic
 
 A connected limit is a limit whose shape is a connected category.
 
-We give examples of connected categories, and prove that the functor given
-by `(X × -)` preserves any connected limit. That is, any limit of shape `J`
-where `J` is a connected category is preserved by the functor `(X × -)`.
+We show that constant functors from a connected category have a limit
+and a colimit, give examples of connected categories, and prove
+that the functor given by `(X × -)` preserves any connected limit.
+That is, any limit of shape `J` where `J` is a connected category is
+preserved by the functor `(X × -)`.
 -/
 
 
@@ -27,6 +29,52 @@ universe v₁ v₂ u₁ u₂
 open CategoryTheory CategoryTheory.Category CategoryTheory.Limits
 
 namespace CategoryTheory
+
+section Const
+
+namespace Limits
+
+variable (J : Type u₁) [Category.{v₁} J] {C : Type u₂} [Category.{v₂} C] (X : C)
+
+/-- The obvious cone of a constant functor. -/
+@[simps]
+def constCone : Cone ((Functor.const J).obj X) where
+  pt := X
+  π := 𝟙 _
+
+/-- The obvious cocone of a constant functor. -/
+@[simps]
+def constCocone : Cocone ((Functor.const J).obj X) where
+  pt := X
+  ι := 𝟙 _
+
+variable [IsConnected J]
+
+/-- When `J` is a connected category, the limit of a
+constant functor `J ⥤ C` with value `X : C` identifies to `X`. -/
+def isLimitConstCone : IsLimit (constCone J X) where
+  lift s := s.π.app (Classical.arbitrary _)
+  fac s j := by
+    dsimp
+    rw [comp_id]
+    exact constant_of_preserves_morphisms _
+      (fun _ _ f ↦ by simpa using s.w f) _ _
+  uniq s m hm := by simpa using hm (Classical.arbitrary _)
+
+/-- When `J` is a connected category, the colimit of a
+constant functor `J ⥤ C` with value `X : C` identifies to `X`. -/
+def isColimitConstCocone : IsColimit (constCocone J X) where
+  desc s := s.ι.app (Classical.arbitrary _)
+  fac s j := by
+    dsimp
+    rw [id_comp]
+    exact constant_of_preserves_morphisms _
+      (fun _ _ f ↦ by simpa using (s.w f).symm) _ _
+  uniq s m hm := by simpa using hm (Classical.arbitrary _)
+
+end Limits
+
+end Const
 
 section Examples
 

--- a/Mathlib/CategoryTheory/Limits/Constructions/EventuallyConstant.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/EventuallyConstant.lean
@@ -25,8 +25,6 @@ namespace CategoryTheory
 
 open Category Limits
 
-section
-
 variable {J C : Type*} [Category J] [Category C] (F : J ⥤ C)
 
 namespace Functor
@@ -315,7 +313,5 @@ noncomputable def constConeIsColimit [IsCofiltered J] :
   simp [← h₁, h₂])
 
 end Limits
-
-end
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/Constructions/EventuallyConstant.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/EventuallyConstant.lean
@@ -5,7 +5,6 @@ Authors: Joël Riou
 -/
 import Mathlib.CategoryTheory.Filtered.Basic
 import Mathlib.CategoryTheory.Limits.HasLimits
-import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 
 /-!
 # Limits of eventually constant functors
@@ -97,20 +96,20 @@ lemma coneπApp_eq (j j' : J) (α : j' ⟶ i₀) (β : j' ⟶ j) :
 lemma coneπApp_eq_id : h.coneπApp i₀ = 𝟙 _ := by
   rw [h.coneπApp_eq i₀ i₀ (𝟙 _) (𝟙 _), h.isoMap_inv_hom_id]
 
-@[reassoc (attr := simp)]
-lemma coneπApp_naturality {j j' : J} (φ : j ⟶ j') :
-    h.coneπApp j ≫ F.map φ = h.coneπApp j' := by
-  let i := IsCofiltered.min i₀ j
-  let α : i ⟶ i₀ := IsCofiltered.minToLeft _ _
-  let β : i ⟶ j := IsCofiltered.minToRight _ _
-  rw [h.coneπApp_eq j _ α β, assoc, h.coneπApp_eq j' _ α (β ≫ φ), map_comp]
-
 /-- Given `h : F.IsEventuallyConstantTo i₀`, this is the (limit) cone for `F` whose
 point is `F.obj i₀`. -/
 @[simps]
 noncomputable def cone : Cone F where
   pt := F.obj i₀
-  π := { app := h.coneπApp }
+  π :=
+    { app := h.coneπApp
+      naturality := fun j j' φ ↦ by
+        dsimp
+        rw [id_comp]
+        let i := IsCofiltered.min i₀ j
+        let α : i ⟶ i₀ := IsCofiltered.minToLeft _ _
+        let β : i ⟶ j := IsCofiltered.minToRight _ _
+        rw [h.coneπApp_eq j _ α β, assoc, h.coneπApp_eq j' _ α (β ≫ φ), map_comp] }
 
 /-- When `h : F.IsEventuallyConstantTo i₀`, the limit of `F` exists and is `F.obj i₀`. -/
 def isLimitCone : IsLimit h.cone where
@@ -191,20 +190,20 @@ lemma coconeιApp_eq (j j' : J) (α : j ⟶ j') (β : i₀ ⟶ j') :
 lemma coconeιApp_eq_id : h.coconeιApp i₀ = 𝟙 _ := by
   rw [h.coconeιApp_eq i₀ i₀ (𝟙 _) (𝟙 _), h.isoMap_hom_inv_id]
 
-@[reassoc (attr := simp)]
-lemma coconeιApp_naturality {j j' : J} (φ : j ⟶ j') :
-    F.map φ ≫ h.coconeιApp j' = h.coconeιApp j := by
-  let i := IsFiltered.max i₀ j'
-  let α : i₀ ⟶ i := IsFiltered.leftToMax _ _
-  let β : j' ⟶ i := IsFiltered.rightToMax _ _
-  rw [h.coconeιApp_eq j' _ β α, h.coconeιApp_eq j _ (φ ≫ β) α, map_comp, assoc]
-
 /-- Given `h : F.IsEventuallyConstantFrom i₀`, this is the (limit) cocone for `F` whose
 point is `F.obj i₀`. -/
 @[simps]
 noncomputable def cocone : Cocone F where
   pt := F.obj i₀
-  ι := { app := h.coconeιApp }
+  ι :=
+    { app := h.coconeιApp
+      naturality := fun j j' φ ↦ by
+        dsimp
+        rw [comp_id]
+        let i := IsFiltered.max i₀ j'
+        let α : i₀ ⟶ i := IsFiltered.leftToMax _ _
+        let β : j' ⟶ i := IsFiltered.rightToMax _ _
+        rw [h.coconeιApp_eq j' _ β α, h.coconeιApp_eq j _ (φ ≫ β) α, map_comp, assoc] }
 
 /-- When `h : F.IsEventuallyConstantFrom i₀`, the colimit of `F` exists and is `F.obj i₀`. -/
 def isColimitCocone : IsColimit h.cocone where
@@ -239,17 +238,9 @@ exists `j : J`, such that for any `f : i ⟶ j`, the induced map `F.map f` is an
 class IsEventuallyConstant : Prop where
   exists_isEventuallyConstantTo : ∃ (j : J), F.IsEventuallyConstantTo j
 
-lemma exists_of_isEventuallyConstant [hF : IsEventuallyConstant F] :
-    ∃ (i : J), F.IsEventuallyConstantTo i :=
-  hF.exists_isEventuallyConstantTo
-
 instance [hF : IsEventuallyConstant F] [IsCofiltered J] : HasLimit F := by
   obtain ⟨j, h⟩ := hF.exists_isEventuallyConstantTo
   exact h.hasLimit
-
-instance (X : C) [IsCofiltered J] : IsEventuallyConstant ((Functor.const J).obj X) where
-  exists_isEventuallyConstantTo :=
-    ⟨Classical.choice IsCofiltered.nonempty, fun _ _ ↦ by dsimp; infer_instance⟩
 
 end IsCofiltered
 
@@ -260,58 +251,10 @@ exists `i : J`, such that for any `f : i ⟶ j`, the induced map `F.map f` is an
 class IsEventuallyConstant : Prop where
   exists_isEventuallyConstantFrom : ∃ (i : J), F.IsEventuallyConstantFrom i
 
-lemma exists_of_isEventuallyConstant [hF : IsEventuallyConstant F] :
-    ∃ (i : J), F.IsEventuallyConstantFrom i :=
-  hF.exists_isEventuallyConstantFrom
-
 instance [hF : IsEventuallyConstant F] [IsFiltered J] : HasColimit F := by
   obtain ⟨j, h⟩ := hF.exists_isEventuallyConstantFrom
   exact h.hasColimit
 
-instance (X : C) [IsFiltered J] : IsEventuallyConstant ((Functor.const J).obj X) where
-  exists_isEventuallyConstantFrom :=
-    ⟨Classical.choice IsFiltered.nonempty, fun _ _ ↦ by dsimp; infer_instance⟩
-
 end IsFiltered
-
-namespace Limits
-
-variable (J) (X : C)
-
-/-- The obvious cocone of a constant functor.  -/
-@[simps]
-def constCocone : Cocone ((Functor.const J).obj X) where
-  pt := X
-  ι := 𝟙 _
-
-/-- If `J` is a filtered category, the colimit of the constant functor `J ⥤ C`
-with value `X : C` is `X`. -/
-noncomputable def constCoconeIsColimit [IsFiltered J] :
-    IsColimit (constCocone J X) := Nonempty.some (by
-  obtain ⟨j, h⟩ := IsFiltered.exists_of_isEventuallyConstant ((Functor.const J).obj X)
-  refine ⟨IsColimit.ofIsoColimit h.isColimitCocone (Cocones.ext (Iso.refl _) (fun i ↦ ?_))⟩
-  have h₁ := h.coconeιApp_naturality (IsFiltered.leftToMax i j)
-  have h₂ := h.coconeιApp_naturality (IsFiltered.rightToMax i j)
-  simp only [Functor.const_obj_obj, Functor.const_obj_map, id_comp] at h₁ h₂
-  simp [← h₁, h₂])
-
-/-- The obvious cone of a constant functor.  -/
-@[simps]
-def constCone : Cone ((Functor.const J).obj X) where
-  pt := X
-  π := 𝟙 _
-
-/-- If `J` is a cofiltered category, the limit of the constant functor `J ⥤ C`
-with value `X : C` is `X`. -/
-noncomputable def constConeIsColimit [IsCofiltered J] :
-    IsLimit (constCone J X) := Nonempty.some (by
-  obtain ⟨j, h⟩ := IsCofiltered.exists_of_isEventuallyConstant ((Functor.const J).obj X)
-  refine ⟨IsLimit.ofIsoLimit h.isLimitCone (Cones.ext (Iso.refl _) (fun i ↦ ?_))⟩
-  have h₁ := h.coneπApp_naturality (IsCofiltered.minToLeft i j)
-  have h₂ := h.coneπApp_naturality (IsCofiltered.minToRight i j)
-  simp only [Functor.const_obj_obj, Functor.const_obj_map, comp_id] at h₁ h₂
-  simp [← h₁, h₂])
-
-end Limits
 
 end CategoryTheory


### PR DESCRIPTION
Constant functors from connected categories have a limit and a colimit.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
