### PR TITLE
[Merged by Bors] - feat(CI): bench-after-CI

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -354,7 +354,7 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request DELETE \
-            --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -357,6 +357,7 @@ jobs:
             curl --request DELETE \
               --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/${label}" \
               --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+          done
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -339,14 +339,24 @@ jobs:
           # Only return if PR is still open
           filterOutClosed: true
 
+      - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
+        name: If `bench-after-CI` is present, add a `!bench` comment.
+        uses: GrantBirki/comment@v2
+        with:
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
+          issue-number: ${{ steps.PR.outputs.number }}
+          body: |
+            !bench
+
       - id: remove_labels
         name: Remove "awaiting-CI"
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the labels don't exist
         run: |
-          curl --request DELETE \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+          for label in awaiting-CI bench-after-CI; do
+            curl --request DELETE \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/${label}" \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -353,11 +353,9 @@ jobs:
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the labels don't exist
         run: |
-          for label in awaiting-CI bench-after-CI; do
-            curl --request DELETE \
-              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/${label}" \
-              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
-          done
+          curl --request DELETE \
+            --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/bench_summary_comment.yml
+++ b/.github/workflows/bench_summary_comment.yml
@@ -39,5 +39,5 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request DELETE \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/bench-after-CI \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/bench-after-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/bench_summary_comment.yml
+++ b/.github/workflows/bench_summary_comment.yml
@@ -39,5 +39,5 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request DELETE \
-            --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/bench-after-CI \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/bench-after-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/bench_summary_comment.yml
+++ b/.github/workflows/bench_summary_comment.yml
@@ -33,3 +33,11 @@ jobs:
         env:
           PR:  ${{ github.event.issue.number }}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Remove "bench-after-CI"
+        # we use curl rather than octokit/request-action so that the job won't fail
+        # (and send an annoying email) if the labels don't exist
+        run: |
+          curl --request DELETE \
+            --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/bench-after-CI \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -367,6 +367,7 @@ jobs:
             curl --request DELETE \
               --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/${label}" \
               --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+          done
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -363,11 +363,9 @@ jobs:
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the labels don't exist
         run: |
-          for label in awaiting-CI bench-after-CI; do
-            curl --request DELETE \
-              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/${label}" \
-              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
-          done
+          curl --request DELETE \
+            --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -364,7 +364,7 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request DELETE \
-            --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -349,14 +349,24 @@ jobs:
           # Only return if PR is still open
           filterOutClosed: true
 
+      - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
+        name: If `bench-after-CI` is present, add a `!bench` comment.
+        uses: GrantBirki/comment@v2
+        with:
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
+          issue-number: ${{ steps.PR.outputs.number }}
+          body: |
+            !bench
+
       - id: remove_labels
         name: Remove "awaiting-CI"
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the labels don't exist
         run: |
-          curl --request DELETE \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+          for label in awaiting-CI bench-after-CI; do
+            curl --request DELETE \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/${label}" \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,7 +371,7 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request DELETE \
-            --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -356,14 +356,24 @@ jobs:
           # Only return if PR is still open
           filterOutClosed: true
 
+      - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
+        name: If `bench-after-CI` is present, add a `!bench` comment.
+        uses: GrantBirki/comment@v2
+        with:
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
+          issue-number: ${{ steps.PR.outputs.number }}
+          body: |
+            !bench
+
       - id: remove_labels
         name: Remove "awaiting-CI"
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the labels don't exist
         run: |
-          curl --request DELETE \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+          for label in awaiting-CI bench-after-CI; do
+            curl --request DELETE \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/${label}" \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -374,6 +374,7 @@ jobs:
             curl --request DELETE \
               --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/${label}" \
               --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+          done
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,11 +370,9 @@ jobs:
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the labels don't exist
         run: |
-          for label in awaiting-CI bench-after-CI; do
-            curl --request DELETE \
-              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/${label}" \
-              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
-          done
+          curl --request DELETE \
+            --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -368,7 +368,7 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request DELETE \
-            --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -353,14 +353,24 @@ jobs:
           # Only return if PR is still open
           filterOutClosed: true
 
+      - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
+        name: If `bench-after-CI` is present, add a `!bench` comment.
+        uses: GrantBirki/comment@v2
+        with:
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
+          issue-number: ${{ steps.PR.outputs.number }}
+          body: |
+            !bench
+
       - id: remove_labels
         name: Remove "awaiting-CI"
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the labels don't exist
         run: |
-          curl --request DELETE \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+          for label in awaiting-CI bench-after-CI; do
+            curl --request DELETE \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/${label}" \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -371,6 +371,7 @@ jobs:
             curl --request DELETE \
               --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/${label}" \
               --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+          done
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -367,11 +367,9 @@ jobs:
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the labels don't exist
         run: |
-          for label in awaiting-CI bench-after-CI; do
-            curl --request DELETE \
-              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/${label}" \
-              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
-          done
+          curl --request DELETE \
+            --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 status = ["Build", "Lint style"]
 use_squash_merge = true
 timeout_sec = 28800
-block_labels = ["WIP", "blocked-by-other-PR", "merge-conflict", "awaiting-CI"]
+block_labels = ["WIP", "blocked-by-other-PR", "merge-conflict", "awaiting-CI", "bench-after-CI"]
 delete_merged_branches = true
 update_base_for_deletes = true
 cut_body_after = "---"


### PR DESCRIPTION
Adds a CI step that checks if the `bench-after-CI` label is present.  If so, it adds a comment `!bench` once CI passes, triggering a benchmarking run.

The management is as follow:
* the label `bench-after-CI` is applied manually while CI is running;
* once CI passes the lint phase, if the label is present, a bot comments `!bench`, starting the bench process;
* when the bench process terminates, it posts the report;
* this triggers the bench-summary bot to post the summary *and* to remove the label.

Meanwhile, the label `bench-after-CI` is in the list of labels that `bors` rejects.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60bench-after-CI.60.3F)

I added the label to this PR, ~~but I am not sure whether the workflow will act on it, since the code is not in `master`~~ and the automation worked.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
