### PR TITLE
[Merged by Bors] - chore: move ProofWidgets to v0.0.51

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -10,7 +10,7 @@ open Lake DSL
 require "leanprover-community" / "batteries" @ git "main"
 require "leanprover-community" / "Qq" @ git "master"
 require "leanprover-community" / "aesop" @ git "master"
-require "leanprover-community" / "proofwidgets" @ git "main"
+require "leanprover-community" / "proofwidgets" @ git "v0.0.51" -- ProofWidgets should always be pinned to a specific version
 require "leanprover-community" / "importGraph" @ git "main"
 require "leanprover-community" / "LeanSearchClient" @ git "main"
 require "leanprover-community" / "plausible" @ git "main"


### PR DESCRIPTION
If ProofWidgets is not pinned to a release tag, we will probably get `npm` errors when its `main` branch moves on.