### PR TITLE
[Merged by Bors] - feat(Order/Partition/Basic): partitions of lattice elements

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3034,6 +3034,7 @@ import Mathlib.Data.Set.Operations
 import Mathlib.Data.Set.Opposite
 import Mathlib.Data.Set.Pairwise.Basic
 import Mathlib.Data.Set.Pairwise.Lattice
+import Mathlib.Data.Set.Partition
 import Mathlib.Data.Set.Pointwise.Iterate
 import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Data.Set.Pointwise.Support

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3034,7 +3034,6 @@ import Mathlib.Data.Set.Operations
 import Mathlib.Data.Set.Opposite
 import Mathlib.Data.Set.Pairwise.Basic
 import Mathlib.Data.Set.Pairwise.Lattice
-import Mathlib.Data.Set.Partition
 import Mathlib.Data.Set.Pointwise.Iterate
 import Mathlib.Data.Set.Pointwise.SMul
 import Mathlib.Data.Set.Pointwise.Support
@@ -4321,6 +4320,7 @@ import Mathlib.Order.OrderIsoNat
 import Mathlib.Order.PFilter
 import Mathlib.Order.Part
 import Mathlib.Order.PartialSups
+import Mathlib.Order.Partition.Basic
 import Mathlib.Order.Partition.Equipartition
 import Mathlib.Order.Partition.Finpartition
 import Mathlib.Order.PiLex

--- a/Mathlib/Data/Set/Partition.lean
+++ b/Mathlib/Data/Set/Partition.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2025 Peter Nelson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Peter Nelson
+-/
+import Mathlib.Data.SetLike.Basic
+import Mathlib.Order.SupIndep
+
+/-!
+# Partitions
+
+A `Partition` of an element `a` in a complete lattice is an independent family of nontrivial
+elements whose supremum is `a`.
+
+An important special case is where `s : Set α`, where a `Partition s` corresponds to a partition
+of the elements of `s` into a family of nonempty sets.
+This is equivalent to a transitive and symmetric binary relation `r : α → α → Prop`
+where `s` is the set of all `x` for which `r x x`.
+
+## Main definitions
+
+* For `[CompleteLattice α]` and `s : α`, a `Set.Partition s` is an independent collection of
+  nontrivial elements whose supremum is `s`.
+
+-/
+
+namespace Set
+
+variable {α : Type*} {s x y z : α}
+
+/-- A `Partition` of an element `s` of a `CompleteLattice` is a collection of
+independent nonempty parts whose supremum is `s`.  -/
+structure Partition [CompleteLattice α] (s : α) where
+  /-- The collection of parts-/
+  parts : Set α
+  /-- The parts are `sSupIndep`-/
+  indep : sSupIndep parts
+  /-- The bottom element is not a part-/
+  bot_not_mem : ⊥ ∉ parts
+  /-- The supremum of all parts is `s`-/
+  sSup_eq' : sSup parts = s
+
+namespace Partition
+
+section Basic
+
+variable [CompleteLattice α] {P : Partition s}
+
+instance {α : Type*} [CompleteLattice α] {s : α} : SetLike (Partition s) α where
+  coe := Partition.parts
+  coe_injective' p p' h := by cases p; cases p'; simpa using h
+
+@[simp] lemma mem_parts {x : α} : x ∈ P.parts ↔ x ∈ (P : Set α) := Iff.rfl
+
+@[ext] lemma ext {P Q : Partition s} (hP : ∀ x, x ∈ P ↔ x ∈ Q) : P = Q := by
+  cases P
+  cases Q
+  simp only [mk.injEq]
+  ext x
+  simpa using hP x
+
+lemma disjoint (hx : x ∈ P) (hy : y ∈ P) (hxy : x ≠ y) :
+    Disjoint x y :=
+  P.indep.pairwiseDisjoint hx hy hxy
+
+lemma pairwiseDisjoint : Set.PairwiseDisjoint (P : Set α) id :=
+  fun _ hx _ hy hxy ↦ P.disjoint hx hy hxy
+
+lemma ne_bot_of_mem (hx : x ∈ P) : x ≠ ⊥ :=
+  fun h ↦ P.bot_not_mem <| h ▸ hx
+
+lemma bot_lt_of_mem (hx : x ∈ P) : ⊥ < x :=
+  bot_lt_iff_ne_bot.2 <| P.ne_bot_of_mem hx
+
+@[simp]
+lemma iSup_eq (P : Partition s) : ⨆ x ∈ P, x = s := by
+  simp_rw [← P.sSup_eq', sSup_eq_iSup]
+  rfl
+
+@[simp]
+lemma sSup_eq (P : Partition s) : sSup P = s :=
+  P.sSup_eq'
+
+lemma le_of_mem (P : Partition s) (hx : x ∈ P) : x ≤ s :=
+  (le_sSup hx).trans_eq P.sSup_eq
+
+lemma parts_nonempty (P : Partition s) (hs : s ≠ ⊥) : (P : Set α).Nonempty :=
+  nonempty_iff_ne_empty.2 fun hP ↦ by simp [← P.sSup_eq, hP, sSup_empty] at hs
+
+@[simps] protected def copy {t : α} (P : Partition s) (hst : s = t) : Partition t where
+  parts := P.parts
+  indep := P.indep
+  bot_not_mem := P.bot_not_mem
+  sSup_eq' := hst ▸ P.sSup_eq'
+
+@[simp] lemma coe_copy_eq {t : α} {P : Partition s} (hst : s = t) :
+    (P.copy hst : Set α) = P := rfl
+
+@[simp] lemma mem_copy_iff {t x : α} {P : Partition s} (hst : s = t) :
+    x ∈ P.copy hst ↔ x ∈ P := Iff.rfl
+
+@[simps!] def partscopyEquiv {t : α} (P : Partition s) (hst : s = t) :
+    (P : Set α) ≃ (P.copy hst : Set α) := Equiv.Set.ofEq rfl
+
+end Basic
+
+end Partition
+
+end Set

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -28,7 +28,7 @@ variable {α : Type*} {s x y z : α}
 open Set
 
 /-- A `Partition` of an element `s` of a `CompleteLattice` is a collection of
-independent nonempty parts whose supremum is `s`.  -/
+independent nontrivial elements whose supremum is `s`.  -/
 structure Partition [CompleteLattice α] (s : α) where
   /-- The collection of parts-/
   parts : Set α
@@ -86,6 +86,7 @@ lemma le_of_mem (P : Partition s) (hx : x ∈ P) : x ≤ s :=
 lemma parts_nonempty (P : Partition s) (hs : s ≠ ⊥) : (P : Set α).Nonempty :=
   nonempty_iff_ne_empty.2 fun hP ↦ by simp [← P.sSup_eq, hP, sSup_empty] at hs
 
+/-- Convert a `Partition s` into a `Partition t` via an equality `s = t`. -/
 @[simps]
 protected def copy {t : α} (P : Partition s) (hst : s = t) : Partition t where
   parts := P.parts

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -23,10 +23,9 @@ where `s` is the set of all `x` for which `r x x`.
   nontrivial elements whose supremum is `s`.
 
 -/
-
-namespace Set
-
 variable {α : Type*} {s x y z : α}
+
+open Set
 
 /-- A `Partition` of an element `s` of a `CompleteLattice` is a collection of
 independent nonempty parts whose supremum is `s`.  -/
@@ -105,5 +104,3 @@ lemma parts_nonempty (P : Partition s) (hs : s ≠ ⊥) : (P : Set α).Nonempty 
 end Basic
 
 end Partition
-
-end Set

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -86,19 +86,23 @@ lemma le_of_mem (P : Partition s) (hx : x ∈ P) : x ≤ s :=
 lemma parts_nonempty (P : Partition s) (hs : s ≠ ⊥) : (P : Set α).Nonempty :=
   nonempty_iff_ne_empty.2 fun hP ↦ by simp [← P.sSup_eq, hP, sSup_empty] at hs
 
-@[simps] protected def copy {t : α} (P : Partition s) (hst : s = t) : Partition t where
+@[simps]
+protected def copy {t : α} (P : Partition s) (hst : s = t) : Partition t where
   parts := P.parts
   indep := P.indep
   bot_not_mem := P.bot_not_mem
   sSup_eq' := hst ▸ P.sSup_eq'
 
-@[simp] lemma coe_copy_eq {t : α} {P : Partition s} (hst : s = t) :
+@[simp]
+lemma coe_copy_eq {t : α} {P : Partition s} (hst : s = t) :
     (P.copy hst : Set α) = P := rfl
 
-@[simp] lemma mem_copy_iff {t x : α} {P : Partition s} (hst : s = t) :
+@[simp]
+lemma mem_copy_iff {t x : α} {P : Partition s} (hst : s = t) :
     x ∈ P.copy hst ↔ x ∈ P := Iff.rfl
 
-@[simps!] def partscopyEquiv {t : α} (P : Partition s) (hst : s = t) :
+@[simps!]
+def partscopyEquiv {t : α} (P : Partition s) (hst : s = t) :
     (P : Set α) ≃ (P.copy hst : Set α) := Equiv.Set.ofEq rfl
 
 end Basic

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -49,8 +49,6 @@ instance {α : Type*} [CompleteLattice α] {s : α} : SetLike (Partition s) α w
   coe := Partition.parts
   coe_injective' p p' h := by cases p; cases p'; simpa using h
 
-@[simp] lemma mem_parts {x : α} : x ∈ P.parts ↔ x ∈ (P : Set α) := Iff.rfl
-
 @[simp] lemma coe_parts : (P.parts : Set α) = P := rfl
 
 @[ext] lemma ext {P Q : Partition s} (hP : ∀ x, x ∈ P ↔ x ∈ Q) : P = Q :=
@@ -114,10 +112,6 @@ def removeBot (P : Set α) (indep : sSupIndep P) (sSup_eq : sSup P = s) : Partit
 @[simp]
 lemma coe_removeBot_eq (P : Set α) (indep) (sSup_eq : sSup P = s) :
     (removeBot P indep sSup_eq : Set α) = P \ {⊥} := rfl
-
-@[simp]
-lemma mem_removeBot_iff (P : Set α) (indep) (sSup_eq : sSup P = s) :
-    x ∈ (removeBot P indep sSup_eq : Set α) ↔ x ∈ P ∧ x ≠ ⊥ := Iff.rfl
 
 end Basic
 

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -22,6 +22,11 @@ where `s` is the set of all `x` for which `r x x`.
 * For `[CompleteLattice α]` and `s : α`, a `Set.Partition s` is an independent collection of
   nontrivial elements whose supremum is `s`.
 
+## TODO
+
+* Link this to `Finpartition`.
+* Give API lemmas for the specialization to the `Set` case.
+
 -/
 variable {α : Type*} {s x y z : α}
 
@@ -35,9 +40,9 @@ structure Partition [CompleteLattice α] (s : α) where
   /-- The parts are `sSupIndep`-/
   indep : sSupIndep parts
   /-- The bottom element is not a part-/
-  bot_not_mem : ⊥ ∉ parts
+  bot_not_mem' : ⊥ ∉ parts
   /-- The supremum of all parts is `s`-/
-  sSup_parts_eq : sSup parts = s
+  sSup_eq' : sSup parts = s
 
 namespace Partition
 
@@ -59,15 +64,15 @@ lemma disjoint (hx : x ∈ P) (hy : y ∈ P) (hxy : x ≠ y) :
   P.indep.pairwiseDisjoint hx hy hxy
 
 lemma pairwiseDisjoint : Set.PairwiseDisjoint (P : Set α) id :=
-  fun _ hx _ hy hxy ↦ P.disjoint hx hy hxy
+  P.indep.pairwiseDisjoint
 
 @[simp]
 lemma sSup_eq (P : Partition s) : sSup P = s :=
-  P.sSup_parts_eq
+  P.sSup_eq'
 
 @[simp]
 lemma iSup_eq (P : Partition s) : ⨆ x ∈ P, x = s := by
-  simp_rw [← P.sSup_parts_eq, sSup_eq_iSup]
+  simp_rw [← P.sSup_eq', sSup_eq_iSup]
   rfl
 
 lemma le_of_mem (P : Partition s) (hx : x ∈ P) : x ≤ s :=
@@ -75,6 +80,10 @@ lemma le_of_mem (P : Partition s) (hx : x ∈ P) : x ≤ s :=
 
 lemma parts_nonempty (P : Partition s) (hs : s ≠ ⊥) : (P : Set α).Nonempty :=
   nonempty_iff_ne_empty.2 fun hP ↦ by simp [← P.sSup_eq, hP, sSup_empty] at hs
+
+@[simp]
+lemma bot_not_mem (P : Partition s) : ⊥ ∉ P :=
+  P.bot_not_mem'
 
 lemma ne_bot_of_mem (hx : x ∈ P) : x ≠ ⊥ :=
   fun h ↦ P.bot_not_mem <| h ▸ hx
@@ -87,8 +96,8 @@ lemma bot_lt_of_mem (hx : x ∈ P) : ⊥ < x :=
 protected def copy {t : α} (P : Partition s) (hst : s = t) : Partition t where
   parts := P.parts
   indep := P.indep
-  bot_not_mem := P.bot_not_mem
-  sSup_parts_eq := hst ▸ P.sSup_eq
+  bot_not_mem' := P.bot_not_mem
+  sSup_eq' := hst ▸ P.sSup_eq
 
 @[simp]
 lemma coe_copy_eq {t : α} {P : Partition s} (hst : s = t) : (P.copy hst : Set α) = P := rfl
@@ -98,7 +107,7 @@ lemma mem_copy_iff {t x : α} {P : Partition s} (hst : s = t) : x ∈ P.copy hst
 
 /-- The natural equivalence between the subtype of parts and the subtype of parts of a copy. -/
 @[simps!]
-def partscopyEquiv {t : α} (P : Partition s) (hst : s = t) : ↥P ≃ ↥(P.copy hst) :=
+def partscopyEquiv {t : α} (P : Partition s) (hst : s = t) : ↥(P.copy hst) ≃ ↥P :=
   Equiv.Set.ofEq rfl
 
 /-- A constructor for `Partition s` that removes `⊥` from the set of parts. -/
@@ -106,8 +115,8 @@ def partscopyEquiv {t : α} (P : Partition s) (hst : s = t) : ↥P ≃ ↥(P.cop
 def removeBot (P : Set α) (indep : sSupIndep P) (sSup_eq : sSup P = s) : Partition s where
   parts := P \ {⊥}
   indep := indep.mono diff_subset
-  bot_not_mem := by simp
-  sSup_parts_eq := by simp [← sSup_eq]
+  bot_not_mem' := by simp
+  sSup_eq' := by simp [← sSup_eq]
 
 @[simp]
 lemma coe_removeBot_eq (P : Set α) (indep) (sSup_eq : sSup P = s) :

--- a/Mathlib/Order/Partition/Basic.lean
+++ b/Mathlib/Order/Partition/Basic.lean
@@ -64,9 +64,13 @@ initialize_simps_projections Partition (parts → coe, as_prefix coe)
 @[ext] lemma ext {P Q : Partition s} (hP : ∀ x, x ∈ P ↔ x ∈ Q) : P = Q :=
   SetLike.ext hP
 
+@[simp]
+lemma sSupIndep (P : Partition s) : sSupIndep (P : Set α) :=
+  P.sSupIndep'
+
 lemma disjoint (hx : x ∈ P) (hy : y ∈ P) (hxy : x ≠ y) :
     Disjoint x y :=
-  P.sSupIndep'.pairwiseDisjoint hx hy hxy
+  P.sSupIndep.pairwiseDisjoint hx hy hxy
 
 lemma pairwiseDisjoint : Set.PairwiseDisjoint (P : Set α) id :=
   P.sSupIndep'.pairwiseDisjoint
@@ -77,7 +81,7 @@ lemma sSup_eq (P : Partition s) : sSup P = s :=
 
 @[simp]
 lemma iSup_eq (P : Partition s) : ⨆ x ∈ P, x = s := by
-  simp_rw [← P.sSup_eq', sSup_eq_iSup]
+  simp_rw [← P.sSup_eq, sSup_eq_iSup]
   rfl
 
 lemma le_of_mem (P : Partition s) (hx : x ∈ P) : x ≤ s :=
@@ -90,10 +94,6 @@ lemma parts_nonempty (P : Partition s) (hs : s ≠ ⊥) : (P : Set α).Nonempty 
 lemma bot_not_mem (P : Partition s) : ⊥ ∉ P :=
   P.bot_not_mem'
 
-@[simp]
-lemma sSupIndep (P : Partition s) : sSupIndep (P : Set α) :=
-  P.sSupIndep'
-
 lemma ne_bot_of_mem (hx : x ∈ P) : x ≠ ⊥ :=
   fun h ↦ P.bot_not_mem <| h ▸ hx
 
@@ -103,13 +103,10 @@ lemma bot_lt_of_mem (hx : x ∈ P) : ⊥ < x :=
 /-- Convert a `Partition s` into a `Partition t` via an equality `s = t`. -/
 @[simps]
 protected def copy {t : α} (P : Partition s) (hst : s = t) : Partition t where
-  parts := P.parts
+  parts := P
   sSupIndep' := P.sSupIndep
   bot_not_mem' := P.bot_not_mem
   sSup_eq' := hst ▸ P.sSup_eq
-
-@[simp]
-lemma coe_copy_eq {t : α} {P : Partition s} (hst : s = t) : (P.copy hst : Set α) = P := rfl
 
 @[simp]
 lemma mem_copy_iff {t x : α} {P : Partition s} (hst : s = t) : x ∈ P.copy hst ↔ x ∈ P := Iff.rfl


### PR DESCRIPTION
This provides a version of `Finpartition` where the partition can have infinitely many parts. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
