### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/TensorProduct): upgrade `TensorProduct.prodRight`

### DIFF
--- a/Mathlib/Algebra/Module/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Module/Equiv/Defs.lean
@@ -310,6 +310,10 @@ variable {e₁₂} {e₂₃}
 theorem coe_toAddEquiv : e.toAddEquiv = e :=
   rfl
 
+@[simp]
+lemma coe_addEquiv_apply (x : M) : (e : M ≃+ M₂) x = e x := by
+  rfl
+
 /-- The two paths coercion can take to an `AddMonoidHom` are equivalent -/
 theorem toAddMonoidHom_commutes : e.toLinearMap.toAddMonoidHom = e.toAddEquiv.toAddMonoidHom :=
   rfl

--- a/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
@@ -41,33 +41,38 @@ def prodRight : M₁ ⊗[R] (M₂ × M₃) ≃ₗ[S] ((M₁ ⊗[R] M₂) × (M�
     (TensorProduct.AlgebraTensorModule.lift <|
       LinearMap.prodMapLinear R M₂ M₃ (M₁ ⊗[R] M₂) (M₁ ⊗[R] M₃) S
         ∘ₗ LinearMap.prod (AlgebraTensorModule.mk R S M₁ M₂) (AlgebraTensorModule.mk R S M₁ M₃))
-    
     (LinearMap.coprod
-     (AlgebraTensorModule.lTensor _ _ <| LinearMap.inl _ _ _) 
+     (AlgebraTensorModule.lTensor _ _ <| LinearMap.inl _ _ _)
      (AlgebraTensorModule.lTensor _ _ <| LinearMap.inr _ _ _))
     (by ext <;> simp)
     (by ext <;> simp)
 
-@[simp] theorem prodRight_tmul (m₁ : M₁) (m₂ : M₂) (m₃ : M₃) :
-    prodRight R S M₁ M₂ M₃ (m₁ ⊗ₜ (m₂, m₃)) = (m₁ ⊗ₜ m₂, m₁ ⊗ₜ m₃) :=
+@[simp] theorem prodRight_tmul (m₁ : M₁) (m : M₂ × M₃) :
+    prodRight R S M₁ M₂ M₃ (m₁ ⊗ₜ m) = (m₁ ⊗ₜ m.1, m₁ ⊗ₜ m.2) :=
   rfl
 
 @[simp] theorem prodRight_symm_tmul (m₁ : M₁) (m₂ : M₂) (m₃ : M₃) :
     (prodRight R S M₁ M₂ M₃).symm (m₁ ⊗ₜ m₂, m₁ ⊗ₜ m₃) = (m₁ ⊗ₜ (m₂, m₃)) :=
   (LinearEquiv.symm_apply_eq _).mpr rfl
 
+variable [Module S M₂] [IsScalarTower R S M₂]
+
 /-- Tensor products distribute over a product on the left . -/
-def prodLeft : (M₁ × M₂) ⊗[R] M₃ ≃ₗ[R] ((M₁ ⊗[R] M₃) × (M₂ ⊗[R] M₃)) :=
-  TensorProduct.comm _ _ _
-    ≪≫ₗ TensorProduct.prodRight R R _ _ _
-    ≪≫ₗ (TensorProduct.comm R _ _).prod (TensorProduct.comm R _ _)
+def prodLeft : (M₁ × M₂) ⊗[R] M₃ ≃ₗ[S] ((M₁ ⊗[R] M₃) × (M₂ ⊗[R] M₃)) :=
+  AddEquiv.toLinearEquiv (TensorProduct.comm _ _ _ ≪≫ₗ
+      TensorProduct.prodRight R R _ _ _ ≪≫ₗ
+      (TensorProduct.comm R _ _).prod (TensorProduct.comm R _ _)).toAddEquiv <| fun c x ↦ by
+    induction x
+    · simp
+    · simp [TensorProduct.smul_tmul']
+    · simp_all
 
 @[simp] theorem prodLeft_tmul (m₁ : M₁) (m₂ : M₂) (m₃ : M₃) :
-    prodLeft R M₁ M₂ M₃ ((m₁, m₂) ⊗ₜ m₃) = (m₁ ⊗ₜ m₃, m₂ ⊗ₜ m₃) :=
+    prodLeft R S M₁ M₂ M₃ ((m₁, m₂) ⊗ₜ m₃) = (m₁ ⊗ₜ m₃, m₂ ⊗ₜ m₃) :=
   rfl
 
 @[simp] theorem prodLeft_symm_tmul (m₁ : M₁) (m₂ : M₂) (m₃ : M₃) :
-    (prodLeft R M₁ M₂ M₃).symm (m₁ ⊗ₜ m₃, m₂ ⊗ₜ m₃) = ((m₁, m₂) ⊗ₜ m₃) :=
+    (prodLeft R S M₁ M₂ M₃).symm (m₁ ⊗ₜ m₃, m₂ ⊗ₜ m₃) = ((m₁, m₂) ⊗ₜ m₃) :=
   (LinearEquiv.symm_apply_eq _).mpr rfl
 
 end TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.LinearAlgebra.TensorProduct.Basic
 import Mathlib.LinearAlgebra.Prod
+import Mathlib.LinearAlgebra.TensorProduct.Tower
 
 /-!
 # Tensor products of products
@@ -22,42 +22,44 @@ See `Mathlib.LinearAlgebra.TensorProduct.Pi` for arbitrary products.
 
 -/
 
-universe uR uM₁ uM₂ uM₃
-variable (R : Type uR) (M₁ : Type uM₁) (M₂ : Type uM₂) (M₃ : Type uM₃)
+universe uR uS uM₁ uM₂ uM₃
+variable (R : Type uR) (S : Type uS) (M₁ : Type uM₁) (M₂ : Type uM₂) (M₃ : Type uM₃)
 
 suppress_compilation
 
 namespace TensorProduct
 
-variable [CommSemiring R] [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
-variable [Module R M₁] [Module R M₂] [Module R M₃]
+variable [CommSemiring R] [CommSemiring S] [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
+variable [Algebra R S]
+variable [Module R M₁] [Module S M₁] [IsScalarTower R S M₁] [Module R M₂] [Module R M₃]
 
 attribute [ext] TensorProduct.ext
 
 /-- Tensor products distribute over a product on the right. -/
-def prodRight : M₁ ⊗[R] (M₂ × M₃) ≃ₗ[R] ((M₁ ⊗[R] M₂) × (M₁ ⊗[R] M₃)) :=
+def prodRight : M₁ ⊗[R] (M₂ × M₃) ≃ₗ[S] ((M₁ ⊗[R] M₂) × (M₁ ⊗[R] M₃)) :=
   LinearEquiv.ofLinear
-    (lift <|
-      LinearMap.prodMapLinear R M₂ M₃ (M₁ ⊗[R] M₂) (M₁ ⊗[R] M₃) R
-        ∘ₗ LinearMap.prod (mk _ _ _) (mk _ _ _))
+    (TensorProduct.AlgebraTensorModule.lift <|
+      LinearMap.prodMapLinear R M₂ M₃ (M₁ ⊗[R] M₂) (M₁ ⊗[R] M₃) S
+        ∘ₗ LinearMap.prod (AlgebraTensorModule.mk R S M₁ M₂) (AlgebraTensorModule.mk R S M₁ M₃))
+    
     (LinearMap.coprod
-      (LinearMap.lTensor _ <| LinearMap.inl _ _ _)
-      (LinearMap.lTensor _ <| LinearMap.inr _ _ _))
+     (AlgebraTensorModule.lTensor _ _ <| LinearMap.inl _ _ _) 
+     (AlgebraTensorModule.lTensor _ _ <| LinearMap.inr _ _ _))
     (by ext <;> simp)
     (by ext <;> simp)
 
 @[simp] theorem prodRight_tmul (m₁ : M₁) (m₂ : M₂) (m₃ : M₃) :
-    prodRight R M₁ M₂ M₃ (m₁ ⊗ₜ (m₂, m₃)) = (m₁ ⊗ₜ m₂, m₁ ⊗ₜ m₃) :=
+    prodRight R S M₁ M₂ M₃ (m₁ ⊗ₜ (m₂, m₃)) = (m₁ ⊗ₜ m₂, m₁ ⊗ₜ m₃) :=
   rfl
 
 @[simp] theorem prodRight_symm_tmul (m₁ : M₁) (m₂ : M₂) (m₃ : M₃) :
-    (prodRight R M₁ M₂ M₃).symm (m₁ ⊗ₜ m₂, m₁ ⊗ₜ m₃) = (m₁ ⊗ₜ (m₂, m₃)) :=
+    (prodRight R S M₁ M₂ M₃).symm (m₁ ⊗ₜ m₂, m₁ ⊗ₜ m₃) = (m₁ ⊗ₜ (m₂, m₃)) :=
   (LinearEquiv.symm_apply_eq _).mpr rfl
 
 /-- Tensor products distribute over a product on the left . -/
 def prodLeft : (M₁ × M₂) ⊗[R] M₃ ≃ₗ[R] ((M₁ ⊗[R] M₃) × (M₂ ⊗[R] M₃)) :=
   TensorProduct.comm _ _ _
-    ≪≫ₗ TensorProduct.prodRight R _ _ _
+    ≪≫ₗ TensorProduct.prodRight R R _ _ _
     ≪≫ₗ (TensorProduct.comm R _ _).prod (TensorProduct.comm R _ _)
 
 @[simp] theorem prodLeft_tmul (m₁ : M₁) (m₂ : M₂) (m₃ : M₃) :

--- a/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
@@ -60,11 +60,8 @@ variable [Module S M₂] [IsScalarTower R S M₂]
 def prodLeft : (M₁ × M₂) ⊗[R] M₃ ≃ₗ[S] (M₁ ⊗[R] M₃) × (M₂ ⊗[R] M₃) :=
   AddEquiv.toLinearEquiv (TensorProduct.comm _ _ _ ≪≫ₗ
       TensorProduct.prodRight R R _ _ _ ≪≫ₗ
-      (TensorProduct.comm R _ _).prod (TensorProduct.comm R _ _)).toAddEquiv <| fun c x ↦ by
-    induction x
-    · simp
-    · simp [TensorProduct.smul_tmul']
-    · simp_all
+      (TensorProduct.comm R _ _).prod (TensorProduct.comm R _ _)).toAddEquiv
+    fun c x ↦ x.induction_on (by simp) (by simp [TensorProduct.smul_tmul']) (by simp_all)
 
 @[simp] theorem prodLeft_tmul (m₁ : M₁) (m₂ : M₂) (m₃ : M₃) :
     prodLeft R S M₁ M₂ M₃ ((m₁, m₂) ⊗ₜ m₃) = (m₁ ⊗ₜ m₃, m₂ ⊗ₜ m₃) :=

--- a/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
@@ -57,7 +57,7 @@ def prodRight : M₁ ⊗[R] (M₂ × M₃) ≃ₗ[S] ((M₁ ⊗[R] M₂) × (M�
 variable [Module S M₂] [IsScalarTower R S M₂]
 
 /-- Tensor products distribute over a product on the left . -/
-def prodLeft : (M₁ × M₂) ⊗[R] M₃ ≃ₗ[S] ((M₁ ⊗[R] M₃) × (M₂ ⊗[R] M₃)) :=
+def prodLeft : (M₁ × M₂) ⊗[R] M₃ ≃ₗ[S] (M₁ ⊗[R] M₃) × (M₂ ⊗[R] M₃) :=
   AddEquiv.toLinearEquiv (TensorProduct.comm _ _ _ ≪≫ₗ
       TensorProduct.prodRight R R _ _ _ ≪≫ₗ
       (TensorProduct.comm R _ _).prod (TensorProduct.comm R _ _)).toAddEquiv <| fun c x ↦ by

--- a/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
@@ -22,14 +22,13 @@ See `Mathlib.LinearAlgebra.TensorProduct.Pi` for arbitrary products.
 
 -/
 
-universe uR uS uM₁ uM₂ uM₃
-variable (R : Type uR) (S : Type uS) (M₁ : Type uM₁) (M₂ : Type uM₂) (M₃ : Type uM₃)
+variable (R S M₁ M₂ M₃ : Type*)
 
 suppress_compilation
 
 namespace TensorProduct
 
-variable [CommSemiring R] [CommSemiring S] [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
+variable [CommSemiring R] [Semiring S] [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
 variable [Algebra R S]
 variable [Module R M₁] [Module S M₁] [IsScalarTower R S M₁] [Module R M₂] [Module R M₃]
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
@@ -39,11 +39,11 @@ attribute [ext] TensorProduct.ext
 def prodRight : M₁ ⊗[R] (M₂ × M₃) ≃ₗ[S] ((M₁ ⊗[R] M₂) × (M₁ ⊗[R] M₃)) :=
   LinearEquiv.ofLinear
     (TensorProduct.AlgebraTensorModule.lift <|
-      LinearMap.prodMapLinear R M₂ M₃ (M₁ ⊗[R] M₂) (M₁ ⊗[R] M₃) S
-        ∘ₗ LinearMap.prod (AlgebraTensorModule.mk R S M₁ M₂) (AlgebraTensorModule.mk R S M₁ M₃))
+      LinearMap.prodMapLinear R M₂ M₃ (M₁ ⊗[R] M₂) (M₁ ⊗[R] M₃) S ∘ₗ
+        LinearMap.prod (AlgebraTensorModule.mk R S M₁ M₂) (AlgebraTensorModule.mk R S M₁ M₃))
     (LinearMap.coprod
-     (AlgebraTensorModule.lTensor _ _ <| LinearMap.inl _ _ _)
-     (AlgebraTensorModule.lTensor _ _ <| LinearMap.inr _ _ _))
+      (AlgebraTensorModule.lTensor _ _ <| LinearMap.inl _ _ _)
+      (AlgebraTensorModule.lTensor _ _ <| LinearMap.inr _ _ _))
     (by ext <;> simp)
     (by ext <;> simp)
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
@@ -35,7 +35,7 @@ variable [Module R M₁] [Module S M₁] [IsScalarTower R S M₁] [Module R M₂
 attribute [ext] TensorProduct.ext
 
 /-- Tensor products distribute over a product on the right. -/
-def prodRight : M₁ ⊗[R] (M₂ × M₃) ≃ₗ[S] ((M₁ ⊗[R] M₂) × (M₁ ⊗[R] M₃)) :=
+def prodRight : M₁ ⊗[R] (M₂ × M₃) ≃ₗ[S] (M₁ ⊗[R] M₂) × (M₁ ⊗[R] M₃) :=
   LinearEquiv.ofLinear
     (TensorProduct.AlgebraTensorModule.lift <|
       LinearMap.prodMapLinear R M₂ M₃ (M₁ ⊗[R] M₂) (M₁ ⊗[R] M₃) S ∘ₗ


### PR DESCRIPTION
... to a linear map over an `R`-algebra `S`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
