### PR TITLE
[Merged by Bors] - feat: more `symm_bijective`s

### DIFF
--- a/Mathlib/Algebra/Group/Action/Equidecomp.lean
+++ b/Mathlib/Algebra/Group/Action/Equidecomp.lean
@@ -204,6 +204,10 @@ theorem right_inv {f : Equidecomp X G} {x : X} (h : x ∈ f.target) :
 @[simp]
 theorem symm_symm (f : Equidecomp X G) : f.symm.symm = f := rfl
 
+theorem symm_involutive : Function.Involutive (symm : Equidecomp X G → _) := symm_symm
+
+theorem symm_bijective : Function.Bijective (symm : Equidecomp X G → _) := symm_involutive.bijective
+
 @[simp]
 theorem refl_symm : (refl X G).symm = refl X G := rfl
 

--- a/Mathlib/Algebra/Order/Hom/Ring.lean
+++ b/Mathlib/Algebra/Order/Hom/Ring.lean
@@ -391,6 +391,9 @@ def Simps.symm_apply (e : α ≃+*o β) : β → α :=
 @[simp]
 theorem symm_symm (e : α ≃+*o β) : e.symm.symm = e := rfl
 
+theorem symm_bijective : Bijective (OrderRingIso.symm : (α ≃+*o β) → β ≃+*o α) :=
+  Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
+
 /-- Composition of `OrderRingIso`s as an `OrderRingIso`. -/
 @[trans]
 protected def trans (f : α ≃+*o β) (g : β ≃+*o γ) : α ≃+*o γ :=
@@ -420,9 +423,6 @@ theorem self_trans_symm (e : α ≃+*o β) : e.trans e.symm = OrderRingIso.refl 
 @[simp]
 theorem symm_trans_self (e : α ≃+*o β) : e.symm.trans e = OrderRingIso.refl β :=
   ext e.right_inv
-
-theorem symm_bijective : Bijective (OrderRingIso.symm : (α ≃+*o β) → β ≃+*o α) :=
-  Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
 
 end LE
 

--- a/Mathlib/Analysis/Normed/Affine/Isometry.lean
+++ b/Mathlib/Analysis/Normed/Affine/Isometry.lean
@@ -450,6 +450,9 @@ theorem symm_apply_apply (x : P) : e.symm (e x) = x :=
 @[simp]
 theorem symm_symm : e.symm.symm = e := rfl
 
+theorem symm_bijective : Bijective (OrderRingIso.symm : P₂ ≃ᵃⁱ[𝕜] P → _) :=
+  Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
+
 @[simp]
 theorem toAffineEquiv_symm : e.toAffineEquiv.symm = e.symm.toAffineEquiv :=
   rfl

--- a/Mathlib/Analysis/Normed/Affine/Isometry.lean
+++ b/Mathlib/Analysis/Normed/Affine/Isometry.lean
@@ -450,7 +450,7 @@ theorem symm_apply_apply (x : P) : e.symm (e x) = x :=
 @[simp]
 theorem symm_symm : e.symm.symm = e := rfl
 
-theorem symm_bijective : Bijective (OrderRingIso.symm : P₂ ≃ᵃⁱ[𝕜] P → _) :=
+theorem symm_bijective : Bijective (AffineIsometryEquiv.symm : (P₂ ≃ᵃⁱ[𝕜] P) → _) :=
   Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
 
 @[simp]

--- a/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
+++ b/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
@@ -645,6 +645,9 @@ theorem map_eq_zero_iff {x : E} : e x = 0 ↔ x = 0 :=
 @[simp]
 theorem symm_symm : e.symm.symm = e := rfl
 
+theorem symm_bijective : Function.Bijective (symm : (E₂ ≃ₛₗᵢ[σ₂₁] E) → _) :=
+  Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
+
 @[simp]
 theorem toLinearEquiv_symm : e.toLinearEquiv.symm = e.symm.toLinearEquiv :=
   rfl

--- a/Mathlib/CategoryTheory/Iso.lean
+++ b/Mathlib/CategoryTheory/Iso.lean
@@ -100,9 +100,12 @@ theorem symm_mk {X Y : C} (hom : X ⟶ Y) (inv : Y ⟶ X) (hom_inv_id) (inv_hom_
 @[simp]
 theorem symm_symm_eq {X Y : C} (α : X ≅ Y) : α.symm.symm = α := rfl
 
+theorem symm_bijective {X Y : C} : Function.Bijective (symm : (X ≅ Y) → _) :=
+  Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm_eq, symm_symm_eq⟩
+
 @[simp]
 theorem symm_eq_iff {X Y : C} {α β : X ≅ Y} : α.symm = β.symm ↔ α = β :=
-  ⟨fun h => symm_symm_eq α ▸ symm_symm_eq β ▸ congr_arg symm h, congr_arg symm⟩
+  symm_bijective.injective.eq_iff
 
 theorem nonempty_iso_symm (X Y : C) : Nonempty (X ≅ Y) ↔ Nonempty (Y ≅ X) :=
   ⟨fun h => ⟨h.some.symm⟩, fun h => ⟨h.some.symm⟩⟩

--- a/Mathlib/LinearAlgebra/AffineSpace/ContinuousAffineEquiv.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/ContinuousAffineEquiv.lean
@@ -173,6 +173,9 @@ theorem apply_eq_iff_eq (e : P₁ ≃ᵃL[k] P₂) {p₁ p₂ : P₁} : e p₁ =
 @[simp]
 theorem symm_symm (e : P₁ ≃ᵃL[k] P₂) : e.symm.symm = e := rfl
 
+theorem symm_bijective : Function.Bijective (symm : (P₁ ≃ᵃL[k] P₂) → _) :=
+  Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
+
 theorem symm_symm_apply (e : P₁ ≃ᵃL[k] P₂) (x : P₁) : e.symm.symm x = e x :=
   rfl
 

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -555,6 +555,9 @@ theorem symm_symm (f : M ≃[L] N) :
     f.symm.symm = f :=
   rfl
 
+theorem symm_bijective : Function.Bijective (symm : (M ≃[L] N) → _) :=
+  Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
+
 @[simp]
 theorem apply_symm_apply (f : M ≃[L] N) (a : N) : f (f.symm a) = a :=
   f.toEquiv.apply_symm_apply a

--- a/Mathlib/ModelTheory/PartialEquiv.lean
+++ b/Mathlib/ModelTheory/PartialEquiv.lean
@@ -75,6 +75,9 @@ def symm (f : M ≃ₚ[L] N) : N ≃ₚ[L] M where
 theorem symm_symm (f : M ≃ₚ[L] N) : f.symm.symm = f :=
   rfl
 
+theorem symm_bijective : Function.Bijective (symm : (M ≃ₚ[L] N) → _) :=
+  Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
+
 @[simp]
 theorem symm_apply (f : M ≃ₚ[L] N) (x : f.cod) : f.symm.toEquiv x = f.toEquiv.symm x :=
   rfl

--- a/Mathlib/Topology/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Algebra/Equiv.lean
@@ -256,8 +256,7 @@ theorem self_comp_symm (e : A ≃A[R] B) : (e : A → B) ∘ e.symm = id :=
 @[simp]
 theorem symm_symm (e : A ≃A[R] B) : e.symm.symm = e := rfl
 
-@[to_additive]
-theorem symm_bijective : Function.Bijective (symm : A ≃A[R] B → _) :=
+theorem symm_bijective : Function.Bijective (symm : (A ≃A[R] B) → _) :=
   Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
 
 @[simp]

--- a/Mathlib/Topology/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Algebra/Equiv.lean
@@ -256,6 +256,10 @@ theorem self_comp_symm (e : A ≃A[R] B) : (e : A → B) ∘ e.symm = id :=
 @[simp]
 theorem symm_symm (e : A ≃A[R] B) : e.symm.symm = e := rfl
 
+@[to_additive]
+theorem symm_bijective : Function.Bijective (symm : A ≃A[R] B → _) :=
+  Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
+
 @[simp]
 theorem refl_symm : (refl R A).symm = refl R A := rfl
 

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -632,6 +632,10 @@ theorem equivLike_inv_eq_symm (f : M ≃ₜ* N) : EquivLike.inv f = f.symm := rf
 @[to_additive (attr := simp)]
 theorem symm_symm (f : M ≃ₜ* N) : f.symm.symm = f := rfl
 
+@[to_additive]
+theorem symm_bijective : Function.Bijective (symm : M ≃ₜ* N → _) :=
+  Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
+
 /-- `e.symm` is a right inverse of `e`, written as `e (e.symm y) = y`. -/
 @[to_additive (attr := simp) "`e.symm` is a right inverse of `e`, written as `e (e.symm y) = y`."]
 theorem apply_symm_apply (e : M ≃ₜ* N) (y : N) : e (e.symm y) = y :=

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -431,7 +431,7 @@ theorem self_comp_symm (e : M₁ ≃SL[σ₁₂] M₂) : (e : M₁ → M₂) ∘
 @[simp]
 theorem symm_symm (e : M₁ ≃SL[σ₁₂] M₂) : e.symm.symm = e := rfl
 
-theorem symm_bijective : Function.Bijective (symm : M₁ ≃SL[σ₁₂] M₂ → _) :=
+theorem symm_bijective : Function.Bijective (ContinuousLinearEquiv.symm : (M₁ ≃SL[σ₁₂] M₂) → _) :=
   Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
 
 @[simp]

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -431,6 +431,9 @@ theorem self_comp_symm (e : M₁ ≃SL[σ₁₂] M₂) : (e : M₁ → M₂) ∘
 @[simp]
 theorem symm_symm (e : M₁ ≃SL[σ₁₂] M₂) : e.symm.symm = e := rfl
 
+theorem symm_bijective : Function.Bijective (symm : M₁ ≃SL[σ₁₂] M₂ → _) :=
+  Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
+
 @[simp]
 theorem refl_symm : (ContinuousLinearEquiv.refl R₁ M₁).symm = ContinuousLinearEquiv.refl R₁ M₁ :=
   rfl


### PR DESCRIPTION
This extends an established pattern.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
