### PR TITLE
[Merged by Bors] - feat(List/InsertIdx): add lemmas

### DIFF
--- a/Mathlib/Data/List/InsertIdx.lean
+++ b/Mathlib/Data/List/InsertIdx.lean
@@ -19,13 +19,71 @@ open Nat hiding one_pos
 
 namespace List
 
-universe u
+universe u v
 
-variable {α : Type u}
+variable {α : Type u} {β : Type v}
 
 section InsertIdx
 
 variable {a : α}
+
+@[simp]
+theorem sublist_insertIdx (l : List α) (n : ℕ) (a : α) : l <+ (l.insertIdx n a) := by
+  simpa only [eraseIdx_insertIdx] using eraseIdx_sublist (l.insertIdx n a) n
+
+@[simp]
+theorem subset_insertIdx (l : List α) (n : ℕ) (a : α) : l ⊆ l.insertIdx n a :=
+  (sublist_insertIdx ..).subset
+
+/-- Erasing `n`th element of a list, then inserting `a` at the same place
+is the same as setting `n`th element to `a`.
+
+We assume that `n ≠ length l`, because otherwise LHS equals `l ++ [a]` while RHS equals `l`. -/
+@[simp]
+theorem insertIdx_eraseIdx {l : List α} {n : ℕ} (hn : n ≠ length l) (a : α) :
+    insertIdx n a (l.eraseIdx n) = l.set n a := by
+  induction n generalizing l <;> cases l <;> simp_all
+
+theorem insertIdx_eraseIdx_getElem {l : List α} {n : ℕ} (hn : n < length l) :
+    insertIdx n l[n] (l.eraseIdx n) = l := by
+  simp [hn.ne]
+
+theorem eq_or_mem_of_mem_insertIdx {l : List α} {n : ℕ} {a b : α} (h : a ∈ insertIdx n b l) :
+    a = b ∨ a ∈ l := by
+  cases Nat.lt_or_ge (length l) n with
+  | inl hn =>
+    rw [insertIdx_of_length_lt _ _ _ hn] at h
+    exact .inr h
+  | inr hn =>
+    rwa [mem_insertIdx hn] at h
+
+theorem insertIdx_subset_cons (n : ℕ) (a : α) (l : List α) : insertIdx n a l ⊆ a :: l := by
+  intro b hb
+  simpa using eq_or_mem_of_mem_insertIdx hb
+
+theorem insertIdx_pmap {p : α → Prop} (f : ∀ a, p a → β) {l : List α} {a : α} {n : ℕ}
+    (hl : ∀ x ∈ l, p x) (ha : p a) :
+    (l.pmap f hl).insertIdx n (f a ha) = (insertIdx n a l).pmap f
+      (fun _ h ↦ (eq_or_mem_of_mem_insertIdx h).elim (fun heq ↦ heq ▸ ha) (hl _)) := by
+  induction n generalizing l with
+  | zero => cases l <;> simp
+  | succ n ihn => cases l <;> simp_all
+
+theorem map_insertIdx (f : α → β) (l : List α) (n : ℕ) (a : α) :
+    (insertIdx n a l).map f = insertIdx n (f a) (l.map f) := by
+  simpa only [pmap_eq_map] using (insertIdx_pmap (fun a _ ↦ f a) (fun _ _ ↦ trivial) trivial).symm
+
+theorem eraseIdx_pmap {p : α → Prop} (f : ∀ a, p a → β) {l : List α} (hl : ∀ a ∈ l, p a) (n : ℕ) :
+    (pmap f l hl).eraseIdx n = (l.eraseIdx n).pmap f fun a ha ↦ hl a (eraseIdx_subset _ _ ha) :=
+  match l, hl, n with
+  | [], _, _ => rfl
+  | a :: _, _, 0 => rfl
+  | a :: as, h, n + 1 => by rw [forall_mem_cons] at h; simp [eraseIdx_pmap f h.2 n]
+
+/-- Erasing an index commutes with `List.map`. -/
+theorem eraseIdx_map (f : α → β) (l : List α) (n : ℕ) :
+    (map f l).eraseIdx n = (l.eraseIdx n).map f := by
+  simpa only [pmap_eq_map] using eraseIdx_pmap (fun a _ ↦ f a) (fun _ _ ↦ trivial) n
 
 theorem get_insertIdx_of_lt (l : List α) (x : α) (n k : ℕ) (hn : k < n) (hk : k < l.length)
     (hk' : k < (insertIdx n x l).length := hk.trans_le (length_le_length_insertIdx _ _ _)) :

--- a/Mathlib/Data/List/Perm/Basic.lean
+++ b/Mathlib/Data/List/Perm/Basic.lean
@@ -83,6 +83,21 @@ protected theorem Perm.insertIdx {l₁ l₂ : List α} (h : l₁ ~ l₂) (n : �
     insertIdx n a l₁ ~ insertIdx n a l₂ :=
   perm_insertIdx_iff.mpr h
 
+theorem perm_eraseIdx_of_getElem?_eq {l₁ l₂ : List α} {m n : ℕ} (h : l₁[m]? = l₂[n]?) :
+    eraseIdx l₁ m ~ eraseIdx l₂ n ↔ l₁ ~ l₂ := by
+  cases Nat.lt_or_ge m l₁.length with
+  | inl hm =>
+    rw [getElem?_eq_getElem hm, eq_comm, getElem?_eq_some_iff] at h
+    cases h with
+    | intro hn hnm =>
+      rw [← perm_cons l₁[m], rel_congr_left (getElem_cons_eraseIdx_perm ..), ← hnm,
+        rel_congr_right (getElem_cons_eraseIdx_perm ..)]
+  | inr hm =>
+    rw [getElem?_eq_none hm, eq_comm, getElem?_eq_none_iff] at h
+    rw [eraseIdx_of_length_le h, eraseIdx_of_length_le hm]
+
+alias ⟨_, Perm.eraseIdx_of_getElem?_eq⟩ := perm_eraseIdx_of_getElem?_eq
+
 section Rel
 
 open Relator

--- a/Mathlib/Data/List/Perm/Basic.lean
+++ b/Mathlib/Data/List/Perm/Basic.lean
@@ -7,6 +7,7 @@ import Batteries.Data.List.Perm
 import Mathlib.Logic.Relation
 import Mathlib.Order.RelClasses
 import Mathlib.Data.List.Forall2
+import Mathlib.Data.List.InsertIdx
 
 /-!
 # List Permutations
@@ -41,6 +42,17 @@ theorem Perm.subset_congr_left {l₁ l₂ l₃ : List α} (h : l₁ ~ l₂) : l�
 
 theorem Perm.subset_congr_right {l₁ l₂ l₃ : List α} (h : l₁ ~ l₂) : l₃ ⊆ l₁ ↔ l₃ ⊆ l₂ :=
   ⟨fun h' => h'.trans h.subset, fun h' => h'.trans h.symm.subset⟩
+
+theorem set_perm_cons_eraseIdx {n : ℕ} (h : n < l.length) (a : α) :
+    l.set n a ~ a :: l.eraseIdx n := by
+  rw [← insertIdx_eraseIdx h.ne]
+  apply perm_insertIdx
+  rw [length_eraseIdx_of_lt h]
+  exact Nat.le_sub_one_of_lt h
+
+theorem getElem_cons_eraseIdx_perm {n : ℕ} (h : n < l.length) :
+    l[n] :: l.eraseIdx n ~ l := by
+  simpa [h] using (set_perm_cons_eraseIdx h l[n]).symm
 
 section Rel
 


### PR DESCRIPTION
Also drop a duplicate `Trans` instance for `List.Perm`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
