### PR TITLE
[Merged by Bors] - refactor(Topology/Category): clean up remaining uses of `HasForget`

### DIFF
--- a/Mathlib/Topology/Category/Born.lean
+++ b/Mathlib/Topology/Category/Born.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.CategoryTheory.ConcreteCategory.BundledHom
+import Mathlib.CategoryTheory.ConcreteCategory.Basic
 import Mathlib.Topology.Bornology.Hom
 
 /-!

--- a/Mathlib/Topology/Category/Born.lean
+++ b/Mathlib/Topology/Category/Born.lean
@@ -18,33 +18,31 @@ universe u
 open CategoryTheory
 
 /-- The category of bornologies. -/
-def Born :=
-  Bundled Bornology
+structure Born where
+  carrier : Type*
+  [str : Bornology carrier]
+
+attribute [instance] Born.str
 
 namespace Born
 
 instance : CoeSort Born Type* :=
-  Bundled.coeSort
-
-instance (X : Born) : Bornology X :=
-  X.str
+  ⟨carrier⟩
 
 /-- Construct a bundled `Born` from a `Bornology`. -/
-def of (α : Type*) [Bornology α] : Born :=
-  Bundled.of α
+abbrev of (α : Type*) [Bornology α] : Born where
+  carrier := α
 
 instance : Inhabited Born :=
   ⟨of PUnit⟩
 
-instance : BundledHom @LocallyBoundedMap where
-  id := @LocallyBoundedMap.id
-  comp := @LocallyBoundedMap.comp
-  hom_ext _ _ := DFunLike.coe_injective
+instance : LargeCategory.{u} Born where
+  Hom X Y := LocallyBoundedMap X Y
+  id X := LocallyBoundedMap.id X
+  comp f g := g.comp f
 
-instance : LargeCategory.{u} Born :=
-  BundledHom.category LocallyBoundedMap
-
-instance : HasForget Born :=
-  BundledHom.hasForget LocallyBoundedMap
+instance : ConcreteCategory Born (LocallyBoundedMap · ·) where
+  hom f := f
+  ofHom f := f
 
 end Born

--- a/Mathlib/Topology/Category/Born.lean
+++ b/Mathlib/Topology/Category/Born.lean
@@ -19,6 +19,7 @@ open CategoryTheory
 
 /-- The category of bornologies. -/
 structure Born where
+  /-- The underlying bornology. -/
   carrier : Type*
   [str : Bornology carrier]
 

--- a/Mathlib/Topology/Category/CompactlyGenerated.lean
+++ b/Mathlib/Topology/Category/CompactlyGenerated.lean
@@ -20,8 +20,6 @@ compact Hausdorff spaces `S` mapping continuously to `X`.
 * Every first-countable space is `u`-compactly generated for every universe `u`.
 -/
 
-attribute [local instance] CategoryTheory.HasForget.instFunLike
-
 universe u w
 
 open CategoryTheory Topology TopologicalSpace

--- a/Mathlib/Topology/Category/Compactum.lean
+++ b/Mathlib/Topology/Category/Compactum.lean
@@ -53,7 +53,7 @@ topological space which satisfies `CompactSpace` and `T2Space`.
 We also add wrappers around structures which already exist. Here are the main ones, all in the
 `Compactum` namespace:
 
-- `forget : Compactum ⥤ Type*` is the forgetful functor, which induces a `HasForget`
+- `forget : Compactum ⥤ Type*` is the forgetful functor, which induces a `ConcreteCategory`
   instance for `Compactum`.
 - `free : Type* ⥤ Compactum` is the left adjoint to `forget`, and the adjunction is in `adj`.
 - `str : Ultrafilter X → X` is the structure map for `X : Compactum`.
@@ -101,15 +101,17 @@ def free : Type* ⥤ Compactum :=
 def adj : free ⊣ forget :=
   Monad.adj _
 
--- Basic instances
-instance : HasForget Compactum where forget := forget
-
--- Porting note: changed from forget to X.A
 instance : CoeSort Compactum Type* :=
   ⟨fun X => X.A⟩
 
-instance {X Y : Compactum} : CoeFun (X ⟶ Y) fun _ => X → Y :=
-  ⟨fun f => f.f⟩
+instance {X Y : Compactum} : FunLike (X ⟶ Y) X Y where
+  coe f := f.f
+  coe_injective' _ _ h := (Monad.forget_faithful β).map_injective h
+
+-- Basic instances
+instance : ConcreteCategory Compactum (· ⟶ ·) where
+  hom f := f
+  ofHom f := f
 
 instance : HasLimits Compactum :=
   hasLimits_of_hasLimits_createsLimits forget

--- a/Mathlib/Topology/Category/LightProfinite/Extend.lean
+++ b/Mathlib/Topology/Category/LightProfinite/Extend.lean
@@ -28,7 +28,7 @@ universe u
 
 open CategoryTheory Limits FintypeCat Functor
 
-attribute [local instance] FintypeCat.discreteTopology HasForget.instFunLike
+attribute [local instance] FintypeCat.discreteTopology
 
 namespace LightProfinite
 

--- a/Mathlib/Topology/Category/Profinite/Basic.lean
+++ b/Mathlib/Topology/Category/Profinite/Basic.lean
@@ -37,10 +37,6 @@ profinite
 
 -/
 
--- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] CategoryTheory.HasForget.instFunLike
-
-
 universe v u
 
 open CategoryTheory Topology CompHausLike

--- a/Mathlib/Topology/Category/TopCommRingCat.lean
+++ b/Mathlib/Topology/Category/TopCommRingCat.lean
@@ -46,35 +46,23 @@ instance : Category TopCommRingCat.{u} where
       -- TODO automate
       cases f
       cases g
-      dsimp; apply Continuous.comp <;> assumption⟩
+      continuity⟩
 
-instance : HasForget TopCommRingCat.{u} where
-  forget :=
-    { obj := fun R => R
-      map := fun f => f.val }
-  -- Porting note: Old proof was `forget_faithful := { }`
-  forget_faithful :=
-    { map_injective := fun {_ _ _ _} h => Subtype.ext <| RingHom.coe_inj h }
+instance (R S : TopCommRingCat.{u}) : FunLike { f : R →+* S // Continuous f } R S where
+  coe f := f.val
+  coe_injective' _ _ h := Subtype.ext (DFunLike.coe_injective h)
+
+instance : ConcreteCategory TopCommRingCat.{u} fun R S => { f : R →+* S // Continuous f } where
+  hom f := f
+  ofHom f := f
 
 /-- Construct a bundled `TopCommRingCat` from the underlying type and the appropriate typeclasses.
 -/
-def of (X : Type u) [CommRing X] [TopologicalSpace X] [TopologicalRing X] : TopCommRingCat :=
+abbrev of (X : Type u) [CommRing X] [TopologicalSpace X] [TopologicalRing X] : TopCommRingCat :=
   ⟨X⟩
 
-@[simp]
 theorem coe_of (X : Type u) [CommRing X] [TopologicalSpace X] [TopologicalRing X] :
     (of X : Type u) = X := rfl
-
-instance forgetTopologicalSpace (R : TopCommRingCat) :
-    TopologicalSpace ((forget TopCommRingCat).obj R) :=
-  R.isTopologicalSpace
-
-instance forgetCommRing (R : TopCommRingCat) : CommRing ((forget TopCommRingCat).obj R) :=
-  R.isCommRing
-
-instance forgetTopologicalRing (R : TopCommRingCat) :
-    TopologicalRing ((forget TopCommRingCat).obj R) :=
-  R.isTopologicalRing
 
 instance hasForgetToCommRingCat : HasForget₂ TopCommRingCat CommRingCat :=
   HasForget₂.mk' (fun R => CommRingCat.of R) (fun _ => rfl)

--- a/Mathlib/Topology/Category/UniformSpace.lean
+++ b/Mathlib/Topology/Category/UniformSpace.lean
@@ -25,54 +25,82 @@ open CategoryTheory
 
 
 /-- A (bundled) uniform space. -/
-def UniformSpaceCat : Type (u + 1) :=
-  Bundled UniformSpace
+structure UniformSpaceCat : Type (u + 1) where
+  carrier : Type u
+  [str : UniformSpace carrier]
+
+attribute [instance] UniformSpaceCat.str
 
 namespace UniformSpaceCat
 
-/-- The information required to build morphisms for `UniformSpace`. -/
-instance : UnbundledHom @UniformContinuous :=
-  ⟨@uniformContinuous_id, @UniformContinuous.comp⟩
-
-deriving instance LargeCategory for UniformSpaceCat
-
-instance : HasForget UniformSpaceCat :=
-  inferInstanceAs <| HasForget <| Bundled UniformSpace
-
 instance : CoeSort UniformSpaceCat Type* :=
-  Bundled.coeSort
-
-instance (x : UniformSpaceCat) : UniformSpace x :=
-  x.str
+  ⟨carrier⟩
 
 /-- Construct a bundled `UniformSpace` from the underlying type and the typeclass. -/
-def of (α : Type u) [UniformSpace α] : UniformSpaceCat :=
-  ⟨α, ‹_›⟩
+abbrev of (α : Type u) [UniformSpace α] : UniformSpaceCat where
+  carrier := α
+
+@[ext]
+structure Hom (X Y : UniformSpaceCat) where
+  hom' : { f : X → Y // UniformContinuous f }
+
+instance : LargeCategory.{u} UniformSpaceCat.{u} where
+  Hom := Hom
+  id X := ⟨id, uniformContinuous_id⟩
+  comp f g := ⟨⟨g.hom'.val ∘ f.hom'.val, g.hom'.property.comp f.hom'.property⟩⟩
+  id_comp := by intros; apply Hom.ext; simp
+  comp_id := by intros; apply Hom.ext; simp
+  assoc := by intros; apply Hom.ext; ext; simp
+
+instance instFunLike (X Y : UniformSpaceCat) :
+    FunLike { f : X → Y // UniformContinuous f } X Y where
+  coe := Subtype.val
+  coe_injective' _ _ h := Subtype.ext h
+
+instance : ConcreteCategory UniformSpaceCat ({ f : · → · // UniformContinuous f }) where
+  hom f := f.hom'
+  ofHom f := ⟨f⟩
+
+abbrev Hom.hom {X Y : UniformSpaceCat} (f : Hom X Y) :=
+  ConcreteCategory.hom (C := UniformSpaceCat) f
+
+abbrev ofHom {X Y : Type u} [UniformSpace X] [UniformSpace Y]
+    (f : { f : X → Y // UniformContinuous f }) : of X ⟶ of Y :=
+  ConcreteCategory.ofHom f
 
 instance : Inhabited UniformSpaceCat :=
   ⟨UniformSpaceCat.of Empty⟩
 
-@[simp]
 theorem coe_of (X : Type u) [UniformSpace X] : (of X : Type u) = X :=
   rfl
 
-instance (X Y : UniformSpaceCat) : CoeFun (X ⟶ Y) fun _ => X → Y :=
-  ⟨(forget UniformSpaceCat).map⟩
-
 @[simp]
-theorem coe_comp {X Y Z : UniformSpaceCat} (f : X ⟶ Y) (g : Y ⟶ Z) : (f ≫ g : X → Z) = g ∘ f :=
+theorem hom_comp {X Y Z : UniformSpaceCat} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    (f ≫ g).hom = ⟨g ∘ f, g.hom.prop.comp f.hom.prop⟩ :=
   rfl
 
 @[simp]
+theorem hom_id (X : UniformSpaceCat) : (𝟙 X : X ⟶ X).hom = ⟨id, uniformContinuous_id⟩ :=
+  rfl
+
+@[simp]
+theorem hom_ofHom {X Y : Type u} [UniformSpace X] [UniformSpace Y]
+    (f : { f : X → Y // UniformContinuous f }) : (ofHom f).hom = f :=
+  rfl
+
+theorem coe_comp {X Y Z : UniformSpaceCat} (f : X ⟶ Y) (g : Y ⟶ Z) : (f ≫ g : X → Z) = g ∘ f :=
+  rfl
+
 theorem coe_id (X : UniformSpaceCat) : (𝟙 X : X → X) = id :=
   rfl
 
 theorem coe_mk {X Y : UniformSpaceCat} (f : X → Y) (hf : UniformContinuous f) :
-    ((⟨f, hf⟩ : X ⟶ Y) : X → Y) = f :=
+    (⟨f, hf⟩ : X ⟶ Y).hom = f :=
   rfl
 
-theorem hom_ext {X Y : UniformSpaceCat} {f g : X ⟶ Y} : (f : X → Y) = g → f = g :=
-  Subtype.eq
+@[ext]
+theorem hom_ext {X Y : UniformSpaceCat} {f g : X ⟶ Y} (h : (f : X → Y) = g) : f = g :=
+  Hom.ext (Subtype.ext h)
 
 /-- The forgetful functor from uniform spaces to topological spaces. -/
 instance hasForgetToTop : HasForget₂ UniformSpaceCat.{u} TopCat.{u} where
@@ -80,7 +108,7 @@ instance hasForgetToTop : HasForget₂ UniformSpaceCat.{u} TopCat.{u} where
     { obj := fun X => TopCat.of X
       map := fun f => TopCat.ofHom
         { toFun := f
-          continuous_toFun := f.property.continuous } }
+          continuous_toFun := f.hom.property.continuous } }
 
 end UniformSpaceCat
 
@@ -103,10 +131,10 @@ attribute [instance] isUniformSpace isCompleteSpace isT0
 def toUniformSpace (X : CpltSepUniformSpace) : UniformSpaceCat :=
   UniformSpaceCat.of X
 
-instance completeSpace (X : CpltSepUniformSpace) : CompleteSpace (toUniformSpace X).α :=
+instance completeSpace (X : CpltSepUniformSpace) : CompleteSpace (toUniformSpace X).carrier :=
   CpltSepUniformSpace.isCompleteSpace X
 
-instance t0Space (X : CpltSepUniformSpace) : T0Space (toUniformSpace X).α :=
+instance t0Space (X : CpltSepUniformSpace) : T0Space (toUniformSpace X).carrier :=
   CpltSepUniformSpace.isT0 X
 
 /-- Construct a bundled `UniformSpace` from the underlying type and the appropriate typeclasses. -/
@@ -125,12 +153,33 @@ instance : Inhabited CpltSepUniformSpace :=
 instance category : LargeCategory CpltSepUniformSpace :=
   InducedCategory.category toUniformSpace
 
+instance instFunLike (X Y : CpltSepUniformSpace) :
+    FunLike { f : X → Y // UniformContinuous f } X Y where
+  coe := Subtype.val
+  coe_injective' _ _ h := Subtype.ext h
+
 /-- The concrete category instance on `CpltSepUniformSpace`. -/
-instance hasForget : HasForget CpltSepUniformSpace :=
-  InducedCategory.hasForget toUniformSpace
+instance concreteCategory : ConcreteCategory CpltSepUniformSpace
+    ({ f : · → · // UniformContinuous f }) :=
+  InducedCategory.concreteCategory toUniformSpace
 
 instance hasForgetToUniformSpace : HasForget₂ CpltSepUniformSpace UniformSpaceCat :=
   InducedCategory.hasForget₂ toUniformSpace
+
+@[simp]
+theorem hom_comp {X Y Z : CpltSepUniformSpace} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    ConcreteCategory.hom (f ≫ g) = ⟨g ∘ f, g.hom.prop.comp f.hom.prop⟩ :=
+  rfl
+
+@[simp]
+theorem hom_id (X : CpltSepUniformSpace) :
+    ConcreteCategory.hom (𝟙 X : X ⟶ X) = ⟨id, uniformContinuous_id⟩ :=
+  rfl
+
+@[simp]
+theorem hom_ofHom {X Y : Type u} [UniformSpace X] [UniformSpace Y]
+    (f : { f : X → Y // UniformContinuous f }) : (UniformSpaceCat.ofHom f).hom = f :=
+  rfl
 
 end CpltSepUniformSpace
 
@@ -141,17 +190,18 @@ open UniformSpace
 open CpltSepUniformSpace
 
 /-- The functor turning uniform spaces into complete separated uniform spaces. -/
+@[simps map]
 noncomputable def completionFunctor : UniformSpaceCat ⥤ CpltSepUniformSpace where
   obj X := CpltSepUniformSpace.of (Completion X)
-  map f := ⟨Completion.map f.1, Completion.uniformContinuous_map⟩
-  map_id _ := Subtype.eq Completion.map_id
-  map_comp f g := Subtype.eq (Completion.map_comp g.property f.property).symm
+  map f := ofHom ⟨Completion.map f.1, Completion.uniformContinuous_map⟩
+  map_id _ := hom_ext Completion.map_id
+  map_comp f g := hom_ext (Completion.map_comp g.hom.property f.hom.property).symm
 
 /-- The inclusion of a uniform space into its completion. -/
 def completionHom (X : UniformSpaceCat) :
     X ⟶ (forget₂ CpltSepUniformSpace UniformSpaceCat).obj (completionFunctor.obj X) where
-  val := ((↑) : X → Completion X)
-  property := Completion.uniformContinuous_coe X
+  hom'.val := ((↑) : X → Completion X)
+  hom'.property := Completion.uniformContinuous_coe X
 
 @[simp]
 theorem completionHom_val (X : UniformSpaceCat) (x) : (completionHom X) x = (x : Completion X) :=
@@ -161,15 +211,9 @@ theorem completionHom_val (X : UniformSpaceCat) (x) : (completionHom X) x = (x :
 noncomputable def extensionHom {X : UniformSpaceCat} {Y : CpltSepUniformSpace}
     (f : X ⟶ (forget₂ CpltSepUniformSpace UniformSpaceCat).obj Y) :
     completionFunctor.obj X ⟶ Y where
-  val := Completion.extension f
-  property := Completion.uniformContinuous_extension
+  hom'.val := Completion.extension f
+  hom'.property := Completion.uniformContinuous_extension
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/10754): added this instance to make things compile
-instance (X : UniformSpaceCat) : UniformSpace ((forget _).obj X) :=
-  show UniformSpace X from inferInstance
-
--- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] CategoryTheory.HasForget.instFunLike in
 @[simp]
 theorem extensionHom_val {X : UniformSpaceCat} {Y : CpltSepUniformSpace}
     (f : X ⟶ (forget₂ _ _).obj Y) (x) : (extensionHom f) x = Completion.extension f x :=
@@ -179,9 +223,8 @@ theorem extensionHom_val {X : UniformSpaceCat} {Y : CpltSepUniformSpace}
 theorem extension_comp_coe {X : UniformSpaceCat} {Y : CpltSepUniformSpace}
     (f : toUniformSpace (CpltSepUniformSpace.of (Completion X)) ⟶ toUniformSpace Y) :
     extensionHom (completionHom X ≫ f) = f := by
-  apply Subtype.eq
-  funext x
-  exact congr_fun (Completion.extension_comp_coe f.property) x
+  ext x
+  exact congr_fun (Completion.extension_comp_coe f.hom.property) x
 
 /-- The completion functor is left adjoint to the forgetful functor. -/
 noncomputable def adj : completionFunctor ⊣ forget₂ CpltSepUniformSpace UniformSpaceCat :=
@@ -191,16 +234,14 @@ noncomputable def adj : completionFunctor ⊣ forget₂ CpltSepUniformSpace Unif
           invFun := fun f => extensionHom f
           left_inv := fun f => by dsimp; rw [extension_comp_coe]
           right_inv := fun f => by
-            apply Subtype.eq; funext x; cases f
+            ext x
+            rcases f with ⟨⟨_, _⟩⟩
             exact @Completion.extension_coe _ _ _ _ _ (CpltSepUniformSpace.t0Space _)
               ‹_› _ }
       homEquiv_naturality_left_symm := fun {X' X Y} f g => by
-        apply hom_ext; funext x; dsimp
-        erw [coe_comp]
-        -- Porting note: used to be `erw [← Completion.extension_map]`
-        have := (Completion.extension_map (γ := Y) (f := g) g.2 f.2)
-        simp only [forget_map_eq_coe] at this ⊢
-        erw [this]
+        ext x
+        dsimp [-Function.comp_apply]
+        erw [Completion.extension_map (γ := Y) g.hom.2 f.hom.2]
         rfl }
 
 noncomputable instance : Reflective (forget₂ CpltSepUniformSpace UniformSpaceCat) where

--- a/Mathlib/Topology/Category/UniformSpace.lean
+++ b/Mathlib/Topology/Category/UniformSpace.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Reid Barton, Patrick Massot, Kim Morrison
 -/
 import Mathlib.CategoryTheory.Adjunction.Reflective
-import Mathlib.CategoryTheory.ConcreteCategory.UnbundledHom
 import Mathlib.CategoryTheory.Monad.Limits
 import Mathlib.Topology.Category.TopCat.Basic
 import Mathlib.Topology.UniformSpace.Completion

--- a/Mathlib/Topology/Category/UniformSpace.lean
+++ b/Mathlib/Topology/Category/UniformSpace.lean
@@ -23,8 +23,9 @@ universe u
 open CategoryTheory
 
 
-/-- A (bundled) uniform space. -/
+/-- An object in the category of uniform spaces. -/
 structure UniformSpaceCat : Type (u + 1) where
+  /-- The underlying uniform space. -/
   carrier : Type u
   [str : UniformSpace carrier]
 
@@ -39,8 +40,10 @@ instance : CoeSort UniformSpaceCat Type* :=
 abbrev of (α : Type u) [UniformSpace α] : UniformSpaceCat where
   carrier := α
 
+/-- A bundled uniform continuous map. -/
 @[ext]
 structure Hom (X Y : UniformSpaceCat) where
+  /-- The underlying `UniformContinuous` function. -/
   hom' : { f : X → Y // UniformContinuous f }
 
 instance : LargeCategory.{u} UniformSpaceCat.{u} where
@@ -60,9 +63,11 @@ instance : ConcreteCategory UniformSpaceCat ({ f : · → · // UniformContinuou
   hom f := f.hom'
   ofHom f := ⟨f⟩
 
+/-- Turn a morphism in `UniformSpaceCat` back into a function which is `UniformContinuous`. -/
 abbrev Hom.hom {X Y : UniformSpaceCat} (f : Hom X Y) :=
   ConcreteCategory.hom (C := UniformSpaceCat) f
 
+/-- Typecheck a function which is `UniformContinuous` as a morphism in `UniformSpaceCat`. -/
 abbrev ofHom {X Y : Type u} [UniformSpace X] [UniformSpace Y]
     (f : { f : X → Y // UniformContinuous f }) : of X ⟶ of Y :=
   ConcreteCategory.ofHom f


### PR DESCRIPTION
This PR upgrades the remaining usage of `HasForget` in the folder `Mathlib/Topology/Category`, upgrading to `ConcreteCategory`.

I made a `Hom` structure for `UniformSpaceCat` but not for the other concrete categories, since it was the only category to actually need some disambiguating between categorical homs and uniformly continuous maps.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
