### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Action): `ConcreteCategory` instances for `Action`

### DIFF
--- a/Mathlib/CategoryTheory/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Action/Basic.lean
@@ -243,6 +243,30 @@ instance : (forget V G).Faithful where map_injective w := Hom.ext w
 instance [HasForget V] : HasForget (Action V G) where
   forget := forget V G ⋙ HasForget.forget
 
+/-- The type of `V`-morphisms that can be lifted back to morphisms in the category `Action`. -/
+abbrev HomSubtype {FV : V → V → Type*} {CV : V → Type*} [∀ X Y, FunLike (FV X Y) (CV X) (CV Y)]
+    [ConcreteCategory V FV] (M N : Action V G) :=
+  { f : FV M.V N.V // ∀ g : G,
+      f ∘ ConcreteCategory.hom (M.ρ.hom g) = ConcreteCategory.hom (N.ρ.hom g) ∘ f }
+
+instance {FV : V → V → Type*} {CV : V → Type*} [∀ X Y, FunLike (FV X Y) (CV X) (CV Y)]
+    [ConcreteCategory V FV] (M N : Action V G) :
+    FunLike (HomSubtype V G M N) (CV M.V) (CV N.V) where
+  coe f := f.1
+  coe_injective' _ _ h := Subtype.ext (DFunLike.coe_injective h)
+
+instance {FV : V → V → Type*} {CV : V → Type*} [∀ X Y, FunLike (FV X Y) (CV X) (CV Y)]
+    [ConcreteCategory V FV] : ConcreteCategory (Action V G) (HomSubtype V G) where
+  hom f := ⟨ConcreteCategory.hom (C := V) f.1, fun g => by
+    ext
+    simpa using CategoryTheory.congr_fun (f.2 g) _⟩
+  ofHom f := ⟨ConcreteCategory.ofHom (C := V) f, fun g => ConcreteCategory.ext_apply fun x => by
+    simpa [ConcreteCategory.hom_ofHom] using congr_fun (f.2 g) x⟩
+  hom_ofHom _ := by dsimp; ext; simp [ConcreteCategory.hom_ofHom]
+  ofHom_hom _ := by ext; simp [ConcreteCategory.ofHom_hom]
+  id_apply := ConcreteCategory.id_apply (C := V)
+  comp_apply _ _ := ConcreteCategory.comp_apply (C := V) _ _
+
 instance hasForgetToV [HasForget V] : HasForget₂ (Action V G) V where forget₂ := forget V G
 
 /-- The forgetful functor is intertwined by `functorCategoryEquivalence` with

--- a/Mathlib/CategoryTheory/Action/Continuous.lean
+++ b/Mathlib/CategoryTheory/Action/Continuous.lean
@@ -71,6 +71,11 @@ instance : Category (ContAction V G) :=
 instance : HasForget (ContAction V G) :=
   FullSubcategory.hasForget (IsContinuous (V := V) (G := G))
 
+instance {FV : V → V → Type*} {CV : V → Type*} [∀ X Y, FunLike (FV X Y) (CV X) (CV Y)]
+    [ConcreteCategory V FV] :
+    ConcreteCategory (ContAction V G) (fun X Y => Action.HomSubtype V G X.1 Y.1) :=
+  FullSubcategory.concreteCategory (IsContinuous (V := V) (G := G))
+
 instance : HasForget₂ (ContAction V G) (Action V G) :=
   FullSubcategory.hasForget₂ (IsContinuous (V := V) (G := G))
 
@@ -104,6 +109,11 @@ instance : Category (DiscreteContAction V G) :=
 
 instance : HasForget (DiscreteContAction V G) :=
   FullSubcategory.hasForget (IsDiscrete (V := V) (G := G))
+
+instance {FV : V → V → Type*} {CV : V → Type*} [∀ X Y, FunLike (FV X Y) (CV X) (CV Y)]
+    [ConcreteCategory V FV] :
+    ConcreteCategory (DiscreteContAction V G) (fun X Y => Action.HomSubtype V G X.1 Y.1) :=
+  FullSubcategory.concreteCategory (IsDiscrete (V := V) (G := G))
 
 instance : HasForget₂ (DiscreteContAction V G) (ContAction V G) :=
   FullSubcategory.hasForget₂ (IsDiscrete (V := V) (G := G))


### PR DESCRIPTION
Alongside the existing `HasForget` instances, allow deriving `ConcreteCategory (Action V G)` if `V` is a concrete category.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
