### PR TITLE
[Merged by Bors] - feat(CategoryTheory): `ConcreteCategory` instance for `DifferentialObject`

### DIFF
--- a/Mathlib/CategoryTheory/DifferentialObject.lean
+++ b/Mathlib/CategoryTheory/DifferentialObject.lean
@@ -75,7 +75,6 @@ instance categoryOfDifferentialObjects : Category (DifferentialObject S C) where
   id := Hom.id
   comp f g := Hom.comp f g
 
--- Porting note: added
 @[ext]
 theorem ext {A B : DifferentialObject S C} {f g : A ⟶ B} (w : f.f = g.f := by aesop_cat) : f = g :=
   Hom.ext w
@@ -206,6 +205,8 @@ end DifferentialObject
 
 namespace DifferentialObject
 
+section HasForget
+
 variable (S : Type*) [AddMonoidWithOne S]
 variable (C : Type (u + 1)) [LargeCategory C] [HasForget C] [HasZeroMorphisms C]
 variable [HasShift C S]
@@ -215,6 +216,37 @@ instance hasForgetOfDifferentialObjects : HasForget (DifferentialObject S C) whe
 
 instance : HasForget₂ (DifferentialObject S C) C where
   forget₂ := forget S C
+
+end HasForget
+
+section ConcreteCategory
+
+variable (S : Type*) [AddMonoidWithOne S]
+variable (C : Type (u + 1)) [LargeCategory C] [HasZeroMorphisms C]
+variable {FC : C → C → Type*} {CC : C → Type*} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+variable [ConcreteCategory C FC] [HasShift C S]
+
+/--
+The type of `C`-morphisms that can be lifted back to morphisms in the category `DifferentialObject`.
+-/
+abbrev HomSubtype (X Y : DifferentialObject S C) :=
+  { f : FC X.obj Y.obj // X.d ≫ (ConcreteCategory.ofHom f)⟦1⟧' = (ConcreteCategory.ofHom f) ≫ Y.d }
+
+instance (X Y : DifferentialObject S C) :
+    FunLike (HomSubtype S C X Y) (CC X.obj) (CC Y.obj) where
+  coe f := f.1
+  coe_injective' _ _ h := Subtype.ext (DFunLike.coe_injective h)
+
+instance concreteCategoryOfDifferentialObjects :
+    ConcreteCategory (DifferentialObject S C) (HomSubtype S C) where
+  hom f := ⟨ConcreteCategory.hom (C := C) f.1, by simp [ConcreteCategory.ofHom_hom]⟩
+  ofHom f := ⟨ConcreteCategory.ofHom (C := C) f, by simpa [ConcreteCategory.hom_ofHom] using f.2⟩
+  hom_ofHom _ := by dsimp; ext; simp [ConcreteCategory.hom_ofHom]
+  ofHom_hom _ := by ext; simp [ConcreteCategory.ofHom_hom]
+  id_apply := ConcreteCategory.id_apply (C := C)
+  comp_apply _ _ := ConcreteCategory.comp_apply (C := C) _ _
+
+end ConcreteCategory
 
 end DifferentialObject
 


### PR DESCRIPTION
Closely following the procedure of #21462 to promote the `HasForget` instance into a `ConcreteCategory` instance.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
