### PR TITLE
[Merged by Bors] - refactor(MeasureTheory): `ConcreteCategory` instance for `MeasCat`

### DIFF
--- a/Mathlib/MeasureTheory/Category/MeasCat.lean
+++ b/Mathlib/MeasureTheory/Category/MeasCat.lean
@@ -37,41 +37,40 @@ universe u v
 
 
 /-- The category of measurable spaces and measurable functions. -/
-def MeasCat : Type (u + 1) :=
-  Bundled MeasurableSpace
+structure MeasCat : Type (u + 1) where
+  /-- The underlying measurable space. -/
+  carrier : Type u
+  [str : MeasurableSpace carrier]
+
+attribute [instance] MeasCat.str
 
 namespace MeasCat
 
 instance : CoeSort MeasCat Type* :=
-  Bundled.coeSort
-
-instance (X : MeasCat) : MeasurableSpace X :=
-  X.str
+  ⟨carrier⟩
 
 /-- Construct a bundled `MeasCat` from the underlying type and the typeclass. -/
-def of (α : Type u) [ms : MeasurableSpace α] : MeasCat :=
-  ⟨α, ms⟩
+abbrev of (α : Type u) [ms : MeasurableSpace α] : MeasCat where
+  carrier := α
 
-@[simp]
 theorem coe_of (X : Type u) [MeasurableSpace X] : (of X : Type u) = X :=
   rfl
 
-instance unbundledHom : UnbundledHom @Measurable :=
-  ⟨@measurable_id, @Measurable.comp⟩
+instance : LargeCategory MeasCat where
+  Hom X Y := { f : X → Y // Measurable f }
+  id X := ⟨id, measurable_id⟩
+  comp f g := ⟨g.1 ∘ f.1, g.2.comp f.2⟩
 
-deriving instance LargeCategory for MeasCat
+instance (X Y : MeasCat) : FunLike ({ f : X → Y // Measurable f }) X Y where
+  coe f := f
+  coe_injective' _ _ := Subtype.ext
 
--- Porting note: `deriving instance HasForget for MeasCat` didn't work. Define it manually.
--- see https://github.com/leanprover-community/mathlib4/issues/5020
-instance : HasForget MeasCat := by
-  unfold MeasCat
-  infer_instance
+instance : ConcreteCategory MeasCat ({ f : · → · // Measurable f }) where
+  hom f := f
+  ofHom f := f
 
 instance : Inhabited MeasCat :=
   ⟨MeasCat.of Empty⟩
-
--- This was a global instance prior to https://github.com/leanprover-community/mathlib4/pull/13170. We may experiment with removing it.
-attribute [local instance] HasForget.instFunLike
 
 /-- `Measure X` is the measurable space of measures over the measurable space `X`. It is the
 weakest measurable space, s.t. `fun μ ↦ μ s` is measurable for all measurable sets `s` in `X`. An
@@ -83,9 +82,9 @@ In probability theory, the `MeasCat`-morphisms `X → Prob X` are (sub-)Markov k
 the restriction of `Measure` to (sub-)probability space.)
 -/
 def Measure : MeasCat ⥤ MeasCat where
-  obj X := ⟨@MeasureTheory.Measure X.1 X.2, inferInstance⟩
+  obj X := of (@MeasureTheory.Measure X.1 X.2)
   map f := ⟨Measure.map (⇑f), Measure.measurable_map f.1 f.2⟩
-  map_id := fun ⟨α, I⟩ => Subtype.eq <| funext fun μ => @Measure.map_id α I μ
+  map_id X := Subtype.eq <| funext fun μ => @Measure.map_id X.carrier X.str μ
   map_comp := fun ⟨_, hf⟩ ⟨_, hg⟩ => Subtype.eq <| funext fun _ => (Measure.map_map hg hf).symm
 
 /-- The Giry monad, i.e. the monadic structure associated with `Measure`. -/

--- a/Mathlib/MeasureTheory/Category/MeasCat.lean
+++ b/Mathlib/MeasureTheory/Category/MeasCat.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.MeasureTheory.Measure.GiryMonad
-import Mathlib.CategoryTheory.ConcreteCategory.UnbundledHom
 import Mathlib.CategoryTheory.Monad.Algebra
 import Mathlib.Topology.Category.TopCat.Basic
 


### PR DESCRIPTION
Upgrade the `HasForget` instance on `MeasCat` to a `ConcreteCategory`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
