### PR TITLE
[Merged by Bors] - refactor(CategoryTheory): `ConcreteCategory` instances for pointed types

### DIFF
--- a/Mathlib/CategoryTheory/Category/Bipointed.lean
+++ b/Mathlib/CategoryTheory/Category/Bipointed.lean
@@ -75,6 +75,7 @@ instance largeCategory : LargeCategory Bipointed where
   id := Hom.id
   comp := @Hom.comp
 
+/-- The subtype of functions corresponding to the morphisms in `Bipointed`. -/
 abbrev HomSubtype (X Y : Bipointed) :=
   { f : X → Y // f X.toProd.1 = Y.toProd.1 ∧ f X.toProd.2 = Y.toProd.2 }
 

--- a/Mathlib/CategoryTheory/Category/Bipointed.lean
+++ b/Mathlib/CategoryTheory/Category/Bipointed.lean
@@ -32,10 +32,9 @@ namespace Bipointed
 instance : CoeSort Bipointed Type* := ⟨Bipointed.X⟩
 
 /-- Turns a bipointing into a bipointed type. -/
-def of {X : Type*} (to_prod : X × X) : Bipointed :=
+abbrev of {X : Type*} (to_prod : X × X) : Bipointed :=
   ⟨X, to_prod⟩
 
-@[simp]
 theorem coe_of {X : Type*} (to_prod : X × X) : ↥(of to_prod) = X :=
   rfl
 
@@ -76,11 +75,16 @@ instance largeCategory : LargeCategory Bipointed where
   id := Hom.id
   comp := @Hom.comp
 
-instance hasForget : HasForget Bipointed where
-  forget :=
-    { obj := Bipointed.X
-      map := @Hom.toFun }
-  forget_faithful := ⟨@Hom.ext⟩
+abbrev HomSubtype (X Y : Bipointed) :=
+  { f : X → Y // f X.toProd.1 = Y.toProd.1 ∧ f X.toProd.2 = Y.toProd.2 }
+
+instance (X Y : Bipointed) : FunLike (HomSubtype X Y) X Y where
+  coe f := f
+  coe_injective' _ _ := Subtype.ext
+
+instance hasForget : ConcreteCategory Bipointed HomSubtype where
+  hom f := ⟨f.1, ⟨f.2, f.3⟩⟩
+  ofHom f := ⟨f.1, f.2.1, f.2.2⟩
 
 /-- Swaps the pointed elements of a bipointed type. `Prod.swap` as a functor. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Category/Pointed.lean
+++ b/Mathlib/CategoryTheory/Category/Pointed.lean
@@ -35,10 +35,9 @@ instance : CoeSort Pointed Type* :=
   ⟨Pointed.X⟩
 
 /-- Turns a point into a pointed type. -/
-def of {X : Type*} (point : X) : Pointed :=
+abbrev of {X : Type*} (point : X) : Pointed :=
   ⟨X, point⟩
 
-@[simp]
 theorem coe_of {X : Type*} (point : X) : ↥(of point) = X :=
   rfl
 
@@ -82,11 +81,13 @@ instance largeCategory : LargeCategory Pointed where
 @[simp] lemma Hom.comp_toFun' {X Y Z : Pointed.{u}} (f : X ⟶ Y) (g : Y ⟶ Z) :
     (f ≫ g).toFun = g.toFun ∘ f.toFun := rfl
 
-instance hasForget : HasForget Pointed where
-  forget :=
-    { obj := Pointed.X
-      map := @Hom.toFun }
-  forget_faithful := ⟨@Hom.ext⟩
+instance (X Y : Pointed) : FunLike { f : X → Y // f X.point = Y.point } X Y where
+  coe f := f
+  coe_injective' _ _ := Subtype.ext
+
+instance hasForget : ConcreteCategory Pointed fun X Y => { f : X → Y // f X.point = Y.point } where
+  hom f := ⟨f.1, f.2⟩
+  ofHom f := ⟨f.1, f.2⟩
 
 /-- Constructs an isomorphism between pointed types from an equivalence that preserves the point
 between them. -/

--- a/Mathlib/CategoryTheory/Category/TwoP.lean
+++ b/Mathlib/CategoryTheory/Category/TwoP.lean
@@ -38,10 +38,9 @@ instance : CoeSort TwoP Type* :=
   ⟨TwoP.X⟩
 
 /-- Turns a two-pointing into a two-pointed type. -/
-def of {X : Type*} (toTwoPointing : TwoPointing X) : TwoP :=
+abbrev of {X : Type*} (toTwoPointing : TwoPointing X) : TwoP :=
   ⟨X, toTwoPointing⟩
 
-@[simp]
 theorem coe_of {X : Type*} (toTwoPointing : TwoPointing X) : ↥(of toTwoPointing) = X :=
   rfl
 
@@ -62,8 +61,9 @@ theorem coe_toBipointed (X : TwoP) : ↥X.toBipointed = ↥X :=
 noncomputable instance largeCategory : LargeCategory TwoP :=
   InducedCategory.category toBipointed
 
-noncomputable instance hasForget : HasForget TwoP :=
-  InducedCategory.hasForget toBipointed
+noncomputable instance concreteCategory : ConcreteCategory TwoP
+    (fun X Y => Bipointed.HomSubtype X.toBipointed Y.toBipointed) :=
+  InducedCategory.concreteCategory toBipointed
 
 noncomputable instance hasForgetToBipointed : HasForget₂ TwoP Bipointed :=
   InducedCategory.hasForget₂ toBipointed


### PR DESCRIPTION
Upgrade the `HasForget` instances on `Pointed`, `Bipointed` and `TwoP` to `ConcreteCategory`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
