### PR TITLE
feat(lint-style): enable running on downstream projects

### DIFF
--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -123,7 +123,7 @@ def lintStyleCli (args : Cli.Parsed) : IO UInt32 := do
   let mut allModuleNames := #[]
   for s in libraries do
     allModuleNames := allModuleNames.append
-      (← findImports <| (System.mkFilePath [s]).addExtension "lean")
+      (← findImports <| (System.FilePath.withExtension s "lean"))
   -- Note: since "Batteries" and "Std" are added explicitly to "Mathlib.lean", we remove them here
   -- manually.
   allModuleNames := eraseExplicitImports allModuleNames

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -138,16 +138,17 @@ def lintStyleCli (args : Cli.Parsed) : IO UInt32 := do
   -- If a nolints file is explicitly provided, it must exist.
   -- If the file is omitted, we try to find one in scripts/nolints-style.txt
   -- and otherwise proceed without any style exceptions.
-  if let some filename := args.positionalArg? "nolints-file" then
+  if let some filename := args.flag? "nolints-file" then
     if !(← System.FilePath.pathExists filename.value) then
       IO.eprintln s!"error: path {filename.value} does not exist"
       return 1
     styleExceptions := ← IO.FS.lines filename.value
   else
+
     if ← System.FilePath.pathExists ("scripts" / "nolints-style.txt") then
       styleExceptions := ← IO.FS.lines ("scripts" / "nolints-style.txt")
     else
-      IO.eprintln s!"warning: a file scripts/nolints-style.txt does not exist"
+      IO.eprintln s!"warning: a file 'scripts/nolints-style.txt' does not exist"
   let mut numberErrors ← lintModules styleExceptions allModuleNames style isMathlib fix
   -- If we are linting mathlib, also check the init imports and for undocumented scripts.
   if libraries.contains "Mathlib" then

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -101,7 +101,7 @@ def allScriptsDocumented : IO Bool := do
   let undocumented := fileNames.filter fun script ↦
     !readme.containsSubstr s!"`{script}`" && !dataFiles.contains script
   if undocumented.size > 0 then
-    IO.println s!"error: found {undocumented.size} undocumented script(s): \
+    IO.eprintln s!"error: found {undocumented.size} undocumented script(s): \
       please describe the script(s) in 'scripts/README.md'\n  \
       {String.intercalate "," undocumented.toList}"
   return undocumented.size == 0
@@ -114,7 +114,7 @@ def lintStyleCli (args : Cli.Parsed) : IO UInt32 := do
     | false => ErrorFormat.humanReadable
   let fix := args.hasFlag "fix"
   if (args.variableArgsAs? String).isNone then
-    IO.println "error: invalid input, library arguments must be strings"
+    IO.eprintln "error: invalid input, library arguments must be strings"
     return 1
   let libraries := match args.variableArgsAs! String with
   | #[] => #["Archive", "Counterexamples", "Mathlib"]

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -133,8 +133,10 @@ def lintStyleCli (args : Cli.Parsed) : IO UInt32 := do
   -- This script is re-run each time, hence is immune to such issues.
   let nolints ← IO.FS.lines ("scripts" / "nolints-style.txt")
   let mut numberErrors ← lintModules nolints allModuleNames style fix
-  if ← checkInitImports then numberErrors := numberErrors + 1
-  if !(← allScriptsDocumented) then numberErrors := numberErrors + 1
+  -- If we are linting mathlib, also check the init imports and for undocumented scripts.
+  if libraries.contains "Mathlib" then
+    if ← checkInitImports then numberErrors := numberErrors + 1
+    if !(← allScriptsDocumented) then numberErrors := numberErrors + 1
   -- If run with the `--fix` argument, return a zero exit code.
   -- Otherwise, make sure to return an exit code of at most 125,
   -- so this return value can be used further in shell scripts.

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -14,8 +14,10 @@ import Cli.Basic
 
 This file defines the `lint-style` executable which runs all text-based style linters.
 The linters themselves are defined in `Mathlib.Tactic.Linter.TextBased`.
+This script can be run run in Mathlib (and is used in its CI), but also in projects depending
+on it: to do the latter, pass it the libraries to lint.
 
-In addition, this checks that
+When linting mathlib, this script additionally checks that
 - `Mathlib.Init` is (transitively) imported in all of mathlib, and
 - every file in `scripts` is documented in its top-level README.
 -/

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -122,7 +122,8 @@ def lintStyleCli (args : Cli.Parsed) : IO UInt32 := do
   -- Read all module names to lint.
   let mut allModuleNames := #[]
   for s in libraries do
-    allModuleNames := allModuleNames.append (← findImports s!"{s}.lean")
+    allModuleNames := allModuleNames.append
+      (← findImports <| (System.mkFilePath [s]).addExtension "lean")
   -- Note: since "Batteries" and "Std" are added explicitly to "Mathlib.lean", we remove them here
   -- manually.
   allModuleNames := eraseExplicitImports allModuleNames


### PR DESCRIPTION
Enable lint-style to run on downstream projects, by making the following modifications:
- allow passing an explicit list of libraries to lint: if nothing is passed, it lints `Mathlib`, `Archive` and `Counterexamples` (as before); otherwise, it lints precisely the passed modules
- only check init imports, undocumented scripts and the errors from `lint-style.py` when linting Mathlib
- make the style exceptions file configurable and optional: using the `nolints-file` flag, the exceptions file can be configured. If the flag is omitted, we try to find a file at `scripts/nolints-style.txt` --- and otherwise proceed with no style exceptions.
This means mathlib can continue unchanged, and downstream projects can either add an explicit exceptions file, or proceed without any exceptions.

After this PR, one should be able to run lint-style on a downstream project by `lake exe lint-style ProjectName`.

Prompted by [this zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/lint-style.20for.20downstream.20libraries).

---

- [x] depends on: #24570
- [x] depends on: #24953

(I did not test the last part.)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
