### PR TITLE
[Merged by Bors] - refactor(Analysis/Normed): `ConcreteCategory` refactor for `SemiNormedGrp`

### DIFF
--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
@@ -6,8 +6,7 @@ Authors: Johan Commelin, Riccardo Brasca
 import Mathlib.Analysis.Normed.Group.Constructions
 import Mathlib.Analysis.Normed.Group.Hom
 import Mathlib.CategoryTheory.Limits.Shapes.ZeroMorphisms
-import Mathlib.CategoryTheory.ConcreteCategory.BundledHom
-import Mathlib.CategoryTheory.Elementwise
+import Mathlib.CategoryTheory.ConcreteCategory.Basic
 
 /-!
 # The category of seminormed groups

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
@@ -24,60 +24,115 @@ universe u
 open CategoryTheory
 
 /-- The category of seminormed abelian groups and bounded group homomorphisms. -/
-def SemiNormedGrp : Type (u + 1) :=
-  Bundled SeminormedAddCommGroup
+structure SemiNormedGrp : Type (u + 1) where
+  /-- The underlying seminormed abelian group. -/
+  carrier : Type u
+  [str : SeminormedAddCommGroup carrier]
+
+attribute [instance] SemiNormedGrp.str
 
 namespace SemiNormedGrp
 
-instance bundledHom : BundledHom @NormedAddGroupHom where
-  toFun := @NormedAddGroupHom.toFun
-  id := @NormedAddGroupHom.id
-  comp := @NormedAddGroupHom.comp
-
-deriving instance LargeCategory for SemiNormedGrp
-
--- Porting note: deriving fails for HasForget, adding instance manually.
--- See https://github.com/leanprover-community/mathlib4/issues/5020
--- deriving instance LargeCategory, HasForget for SemiRingCat
-instance : HasForget SemiNormedGrp := by
-  dsimp [SemiNormedGrp]
-  infer_instance
-
 instance : CoeSort SemiNormedGrp Type* where
-  coe X := X.α
+  coe X := X.carrier
 
 /-- Construct a bundled `SemiNormedGrp` from the underlying type and typeclass. -/
-def of (M : Type u) [SeminormedAddCommGroup M] : SemiNormedGrp :=
-  Bundled.of M
+abbrev of (M : Type u) [SeminormedAddCommGroup M] : SemiNormedGrp where
+  carrier := M
 
-instance (M : SemiNormedGrp) : SeminormedAddCommGroup M :=
-  M.str
+/-- The type of morphisms in `SemiNormedGrp` -/
+@[ext]
+structure Hom (M N : SemiNormedGrp.{u}) where
+  /-- The underlying `NormedAddGroupHom`. -/
+  hom' : NormedAddGroupHom M N
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/10754): added instance
-instance funLike {V W : SemiNormedGrp} : FunLike (V ⟶ W) V W where
-  coe := (forget SemiNormedGrp).map
-  coe_injective' f g h := by cases f; cases g; congr
+instance : LargeCategory.{u} SemiNormedGrp where
+  Hom X Y := Hom X Y
+  id X := ⟨NormedAddGroupHom.id X⟩
+  comp f g := ⟨g.hom'.comp f.hom'⟩
 
-instance toAddMonoidHomClass {V W : SemiNormedGrp} : AddMonoidHomClass (V ⟶ W) V W where
-  map_add f := f.map_add'
-  map_zero f := (AddMonoidHom.mk' f.toFun f.map_add').map_zero
+instance : ConcreteCategory SemiNormedGrp (NormedAddGroupHom · ·) where
+  hom f := f.hom'
+  ofHom f := ⟨f⟩
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/10688): added to ease automation
+/-- Turn a morphism in `SemiNormedGrp` back into a `NormedAddGroupHom`. -/
+abbrev Hom.hom {M N : SemiNormedGrp.{u}} (f : Hom M N) :=
+  ConcreteCategory.hom (C := SemiNormedGrp) f
+
+/-- Typecheck a `NormedAddGroupHom` as a morphism in `SemiNormedGrp`. -/
+abbrev ofHom {M N : Type u} [SeminormedAddCommGroup M] [SeminormedAddCommGroup N]
+    (f : NormedAddGroupHom M N) : of M ⟶ of N :=
+  ConcreteCategory.ofHom (C := SemiNormedGrp) f
+
+/-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
+def Hom.Simps.hom (M N : SemiNormedGrp.{u}) (f : Hom M N) :=
+  f.hom
+
+initialize_simps_projections Hom (hom' → hom)
+
+/-!
+The results below duplicate the `ConcreteCategory` simp lemmas, but we can keep them for `dsimp`.
+-/
 @[ext]
 lemma ext {M N : SemiNormedGrp} {f₁ f₂ : M ⟶ N} (h : ∀ (x : M), f₁ x = f₂ x) : f₁ = f₂ :=
-  DFunLike.ext _ _ h
+  ConcreteCategory.ext_apply h
 
 @[simp]
+lemma hom_id {M : SemiNormedGrp} : (𝟙 M : M ⟶ M).hom = NormedAddGroupHom.id M := rfl
+
+/- Provided for rewriting. -/
+lemma id_apply (M : SemiNormedGrp) (r : M) :
+    (𝟙 M : M ⟶ M) r = r := by simp
+
+@[simp]
+lemma hom_comp {M N O : SemiNormedGrp} (f : M ⟶ N) (g : N ⟶ O) :
+    (f ≫ g).hom = g.hom.comp f.hom := rfl
+
+/- Provided for rewriting. -/
+lemma comp_apply {M N O : SemiNormedGrp} (f : M ⟶ N) (g : N ⟶ O) (r : M) :
+    (f ≫ g) r = g (f r) := by simp
+
+@[ext]
+lemma hom_ext {M N : SemiNormedGrp} {f g : M ⟶ N} (hf : f.hom = g.hom) : f = g :=
+  Hom.ext hf
+
+@[simp]
+lemma hom_ofHom {M N : Type u} [SeminormedAddCommGroup M] [SeminormedAddCommGroup N]
+    (f : NormedAddGroupHom M N) : (ofHom f).hom = f := rfl
+
+@[simp]
+lemma ofHom_hom {M N : SemiNormedGrp} (f : M ⟶ N) :
+    ofHom (Hom.hom f) = f := rfl
+
+@[simp]
+lemma ofHom_id {M : Type u} [SeminormedAddCommGroup M] :
+    ofHom (NormedAddGroupHom.id M) = 𝟙 (of M) := rfl
+
+@[simp]
+lemma ofHom_comp {M N O : Type u} [SeminormedAddCommGroup M] [SeminormedAddCommGroup N]
+    [SeminormedAddCommGroup O] (f : NormedAddGroupHom M N) (g : NormedAddGroupHom N O) :
+    ofHom (g.comp f) = ofHom f ≫ ofHom g :=
+  rfl
+
+lemma ofHom_apply {M N : Type u} [SeminormedAddCommGroup M] [SeminormedAddCommGroup N]
+    (f : NormedAddGroupHom M N) (r : M) : ofHom f r = f r := rfl
+
+@[simp]
+lemma inv_hom_apply {M N : SemiNormedGrp} (e : M ≅ N) (r : M) : e.inv (e.hom r) = r := by
+  rw [← comp_apply]
+  simp
+
+@[simp]
+lemma hom_inv_apply {M N : SemiNormedGrp} (e : M ≅ N) (s : N) : e.hom (e.inv s) = s := by
+  rw [← comp_apply]
+  simp
+
 theorem coe_of (V : Type u) [SeminormedAddCommGroup V] : (SemiNormedGrp.of V : Type u) = V :=
   rfl
 
--- Porting note: marked with high priority to short circuit simplifier's path
-@[simp (high)]
 theorem coe_id (V : SemiNormedGrp) : (𝟙 V : V → V) = id :=
   rfl
 
--- Porting note: marked with high priority to short circuit simplifier's path
-@[simp (high)]
 theorem coe_comp {M N K : SemiNormedGrp} (f : M ⟶ N) (g : N ⟶ K) :
     (f ≫ g : M → K) = g ∘ f :=
   rfl
@@ -89,10 +144,13 @@ instance ofUnique (V : Type u) [SeminormedAddCommGroup V] [i : Unique V] :
     Unique (SemiNormedGrp.of V) :=
   i
 
-instance {M N : SemiNormedGrp} : Zero (M ⟶ N) :=
-  NormedAddGroupHom.zero
+instance {M N : SemiNormedGrp} : Zero (M ⟶ N) where
+  zero := ofHom 0
 
 @[simp]
+theorem hom_zero {V W : SemiNormedGrp} : (0 : V ⟶ W).hom = 0 :=
+  rfl
+
 theorem zero_apply {V W : SemiNormedGrp} (x : V) : (0 : V ⟶ W) x = 0 :=
   rfl
 
@@ -106,101 +164,205 @@ theorem isZero_of_subsingleton (V : SemiNormedGrp) [Subsingleton V] : Limits.IsZ
 instance hasZeroObject : Limits.HasZeroObject SemiNormedGrp.{u} :=
   ⟨⟨of PUnit, isZero_of_subsingleton _⟩⟩
 
-theorem iso_isometry_of_normNoninc {V W : SemiNormedGrp} (i : V ≅ W) (h1 : i.hom.NormNoninc)
-    (h2 : i.inv.NormNoninc) : Isometry i.hom := by
+theorem iso_isometry_of_normNoninc {V W : SemiNormedGrp} (i : V ≅ W) (h1 : i.hom.hom.NormNoninc)
+    (h2 : i.inv.hom.NormNoninc) : Isometry i.hom := by
   apply AddMonoidHomClass.isometry_of_norm
   intro v
   apply le_antisymm (h1 v)
   calc
-    ‖v‖ = ‖i.inv (i.hom v)‖ := by rw [Iso.hom_inv_id_apply]
+    ‖v‖ = ‖i.inv (i.hom v)‖ := by rw [← comp_apply, Iso.hom_inv_id, id_apply]
     _ ≤ ‖i.hom v‖ := h2 _
+
+instance Hom.add {M N : SemiNormedGrp} : Add (M ⟶ N) where
+  add f g := ofHom (f.hom + g.hom)
+
+@[simp]
+theorem hom_add {V W : SemiNormedGrp} (f g : V ⟶ W) : (f + g).hom = f.hom + g.hom :=
+  rfl
+
+instance Hom.neg {M N : SemiNormedGrp} : Neg (M ⟶ N) where
+  neg f := ofHom (- f.hom)
+
+@[simp]
+theorem hom_neg {V W : SemiNormedGrp} (f : V ⟶ W) : (-f).hom = - f.hom :=
+  rfl
+
+instance Hom.sub {M N : SemiNormedGrp} : Sub (M ⟶ N) where
+  sub f g := ofHom (f.hom - g.hom)
+
+@[simp]
+theorem hom_sub {V W : SemiNormedGrp} (f g : V ⟶ W) : (f - g).hom = f.hom - g.hom :=
+  rfl
+
+instance Hom.nsmul {M N : SemiNormedGrp} : SMul ℕ (M ⟶ N) where
+  smul n f := ofHom (n • f.hom)
+
+@[simp]
+theorem hom_nsum {V W : SemiNormedGrp} (n : ℕ) (f : V ⟶ W) : (n • f).hom = n • f.hom :=
+  rfl
+
+instance Hom.zsmul {M N : SemiNormedGrp} : SMul ℤ (M ⟶ N) where
+  smul n f := ofHom (n • f.hom)
+
+@[simp]
+theorem hom_zsum {V W : SemiNormedGrp} (n : ℤ) (f : V ⟶ W) : (n • f).hom = n • f.hom :=
+  rfl
+
+instance Hom.addCommGroup {V W : SemiNormedGrp} : AddCommGroup (V ⟶ W) :=
+  Function.Injective.addCommGroup _ ConcreteCategory.hom_injective rfl (fun _ _ => rfl)
+    (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
 
 end SemiNormedGrp
 
 /-- `SemiNormedGrp₁` is a type synonym for `SemiNormedGrp`,
 which we shall equip with the category structure consisting only of the norm non-increasing maps.
 -/
-def SemiNormedGrp₁ : Type (u + 1) :=
-  Bundled SeminormedAddCommGroup
+structure SemiNormedGrp₁ : Type (u + 1) where
+  /-- The underlying seminormed abelian group. -/
+  carrier : Type u
+  [str : SeminormedAddCommGroup carrier]
+
+attribute [instance] SemiNormedGrp₁.str
 
 namespace SemiNormedGrp₁
 
 instance : CoeSort SemiNormedGrp₁ Type* where
-  coe X := X.α
+  coe X := X.carrier
+
+/-- Construct a bundled `SemiNormedGrp₁` from the underlying type and typeclass. -/
+abbrev of (M : Type u) [SeminormedAddCommGroup M] : SemiNormedGrp₁ where
+  carrier := M
+
+/-- The type of morphisms in `SemiNormedGrp₁` -/
+@[ext]
+structure Hom (M N : SemiNormedGrp₁.{u}) where
+  /-- The underlying `NormedAddGroupHom`. -/
+  hom' : NormedAddGroupHom M N
+  normNoninc : hom'.NormNoninc
 
 instance : LargeCategory.{u} SemiNormedGrp₁ where
-  Hom X Y := { f : NormedAddGroupHom X Y // f.NormNoninc }
+  Hom := Hom
   id X := ⟨NormedAddGroupHom.id X, NormedAddGroupHom.NormNoninc.id⟩
   comp {_ _ _} f g := ⟨g.1.comp f.1, g.2.comp f.2⟩
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/10754): added instance
-instance instFunLike (X Y : SemiNormedGrp₁) : FunLike (X ⟶ Y) X Y where
+instance instFunLike (X Y : SemiNormedGrp₁) :
+    FunLike { f : NormedAddGroupHom X Y // f.NormNoninc } X Y where
   coe f := f.1.toFun
   coe_injective' _ _ h := Subtype.val_inj.mp (NormedAddGroupHom.coe_injective h)
 
+instance : ConcreteCategory SemiNormedGrp₁
+    fun X Y => { f : NormedAddGroupHom X Y // f.NormNoninc } where
+  hom f := ⟨f.1, f.2⟩
+  ofHom f := ⟨f.1, f.2⟩
+
+instance (X Y : SemiNormedGrp₁) :
+    AddMonoidHomClass { f : NormedAddGroupHom X Y // f.NormNoninc } X Y where
+  map_add f := map_add f.1
+  map_zero f := map_zero f.1
+
+/-- Turn a morphism in `SemiNormedGrp₁` back into a norm-nonincreasing `NormedAddGroupHom`. -/
+abbrev Hom.hom {M N : SemiNormedGrp₁.{u}} (f : Hom M N) :=
+  ConcreteCategory.hom (C := SemiNormedGrp₁) f
+
+/-- Promote a `NormedAddGroupHom` to a morphism in `SemiNormedGrp₁`. -/
+abbrev mkHom {M N : Type u} [SeminormedAddCommGroup M] [SeminormedAddCommGroup N]
+    (f : NormedAddGroupHom M N) (i : f.NormNoninc) :
+    SemiNormedGrp₁.of M ⟶ SemiNormedGrp₁.of N :=
+  ConcreteCategory.ofHom ⟨f, i⟩
+
+/-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
+def Hom.Simps.hom (M N : SemiNormedGrp₁.{u}) (f : Hom M N) : NormedAddGroupHom M N :=
+  f.hom
+
+initialize_simps_projections Hom (hom' → hom)
+
+instance (X Y : SemiNormedGrp₁) : CoeFun (X ⟶ Y) (fun _ => X → Y) where
+  coe f := f.hom.1
+
+theorem mkHom_apply {M N : Type u} [SeminormedAddCommGroup M] [SeminormedAddCommGroup N]
+    (f : NormedAddGroupHom M N) (i : f.NormNoninc) (x) :
+    mkHom f i x = f x :=
+  rfl
+
+/-!
+The results below duplicate the `ConcreteCategory` simp lemmas, but we can keep them for `dsimp`.
+-/
 @[ext]
-theorem hom_ext {M N : SemiNormedGrp₁} (f g : M ⟶ N) (w : (f : M → N) = (g : M → N)) :
-    f = g :=
-  Subtype.eq (NormedAddGroupHom.ext (congr_fun w))
+lemma ext {M N : SemiNormedGrp₁} {f₁ f₂ : M ⟶ N} (h : ∀ (x : M), f₁ x = f₂ x) : f₁ = f₂ :=
+  ConcreteCategory.ext_apply h
 
-instance : HasForget.{u} SemiNormedGrp₁ where
-  forget :=
-    { obj := fun X => X
-      map := fun f => f }
-  forget_faithful := { }
+@[simp]
+lemma hom_id {M : SemiNormedGrp₁} : (𝟙 M : M ⟶ M).hom = NormedAddGroupHom.id M := rfl
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/10754): added instance
-instance toAddMonoidHomClass {V W : SemiNormedGrp₁} : AddMonoidHomClass (V ⟶ W) V W where
-  map_add f := f.1.map_add'
-  map_zero f := (AddMonoidHom.mk' f.1 f.1.map_add').map_zero
+/- Provided for rewriting. -/
+lemma id_apply (M : SemiNormedGrp₁) (r : M) :
+    (𝟙 M : M ⟶ M) r = r := by simp
 
-/-- Construct a bundled `SemiNormedGrp₁` from the underlying type and typeclass. -/
-def of (M : Type u) [SeminormedAddCommGroup M] : SemiNormedGrp₁ :=
-  Bundled.of M
+@[simp]
+lemma hom_comp {M N O : SemiNormedGrp₁} (f : M ⟶ N) (g : N ⟶ O) :
+    (f ≫ g).hom.1 = g.hom.1.comp f.hom.1 := rfl
+
+/- Provided for rewriting. -/
+lemma comp_apply {M N O : SemiNormedGrp₁} (f : M ⟶ N) (g : N ⟶ O) (r : M) :
+    (f ≫ g) r = g (f r) := by simp
+
+@[ext]
+lemma hom_ext {M N : SemiNormedGrp₁} {f g : M ⟶ N} (hf : f.hom = g.hom) : f = g :=
+  Hom.ext (congr_arg Subtype.val hf)
+
+@[simp]
+lemma hom_mkHom {M N : Type u} [SeminormedAddCommGroup M] [SeminormedAddCommGroup N]
+    (f : NormedAddGroupHom M N) (hf : f.NormNoninc) : (mkHom f hf).hom = f := rfl
+
+@[simp]
+lemma mkHom_hom {M N : SemiNormedGrp₁} (f : M ⟶ N) :
+    mkHom (Hom.hom f) f.normNoninc = f := rfl
+
+@[simp]
+lemma mkHom_id {M : Type u} [SeminormedAddCommGroup M] :
+    mkHom (NormedAddGroupHom.id M) NormedAddGroupHom.NormNoninc.id = 𝟙 (of M) := rfl
+
+@[simp]
+lemma mkHom_comp {M N O : Type u} [SeminormedAddCommGroup M] [SeminormedAddCommGroup N]
+    [SeminormedAddCommGroup O] (f : NormedAddGroupHom M N) (g : NormedAddGroupHom N O)
+    (hf : f.NormNoninc) (hg : g.NormNoninc) :
+    mkHom (g.comp f) (hg.comp hf) = mkHom f hf ≫ mkHom g hg :=
+  rfl
+
+@[simp]
+lemma inv_hom_apply {M N : SemiNormedGrp₁} (e : M ≅ N) (r : M) : e.inv (e.hom r) = r := by
+  rw [← comp_apply]
+  simp
+
+@[simp]
+lemma hom_inv_apply {M N : SemiNormedGrp₁} (e : M ≅ N) (s : N) : e.hom (e.inv s) = s := by
+  rw [← comp_apply]
+  simp
 
 instance (M : SemiNormedGrp₁) : SeminormedAddCommGroup M :=
   M.str
 
-/-- Promote a morphism in `SemiNormedGrp` to a morphism in `SemiNormedGrp₁`. -/
-def mkHom {M N : SemiNormedGrp} (f : M ⟶ N) (i : f.NormNoninc) :
-    SemiNormedGrp₁.of M ⟶ SemiNormedGrp₁.of N :=
-  ⟨f, i⟩
-
--- @[simp] -- Porting note: simpNF linter claims LHS simplifies with `SemiNormedGrp₁.coe_of`
-theorem mkHom_apply {M N : SemiNormedGrp} (f : M ⟶ N) (i : f.NormNoninc) (x) :
-    mkHom f i x = f x :=
-  rfl
-
 /-- Promote an isomorphism in `SemiNormedGrp` to an isomorphism in `SemiNormedGrp₁`. -/
 @[simps]
-def mkIso {M N : SemiNormedGrp} (f : M ≅ N) (i : f.hom.NormNoninc) (i' : f.inv.NormNoninc) :
+def mkIso {M N : SemiNormedGrp} (f : M ≅ N) (i : f.hom.hom.NormNoninc) (i' : f.inv.hom.NormNoninc) :
     SemiNormedGrp₁.of M ≅ SemiNormedGrp₁.of N where
-  hom := mkHom f.hom i
-  inv := mkHom f.inv i'
-  hom_inv_id := by apply Subtype.eq; exact f.hom_inv_id
-  inv_hom_id := by apply Subtype.eq; exact f.inv_hom_id
+  hom := mkHom f.hom.hom i
+  inv := mkHom f.inv.hom i'
 
 instance : HasForget₂ SemiNormedGrp₁ SemiNormedGrp where
   forget₂ :=
-    { obj := fun X => X
-      map := fun f => f.1 }
+    { obj := fun X => SemiNormedGrp.of X
+      map := fun f => SemiNormedGrp.ofHom f.1 }
 
-@[simp]
 theorem coe_of (V : Type u) [SeminormedAddCommGroup V] : (SemiNormedGrp₁.of V : Type u) = V :=
   rfl
 
--- Porting note: marked with high priority to short circuit simplifier's path
-@[simp (high)]
 theorem coe_id (V : SemiNormedGrp₁) : ⇑(𝟙 V) = id :=
   rfl
 
--- Porting note: marked with high priority to short circuit simplifier's path
-@[simp (high)]
 theorem coe_comp {M N K : SemiNormedGrp₁} (f : M ⟶ N) (g : N ⟶ K) :
     (f ≫ g : M → K) = g ∘ f :=
   rfl
-
--- Porting note: deleted `coe_comp'`, as we no longer have the relevant coercion.
 
 instance : Inhabited SemiNormedGrp₁ :=
   ⟨of PUnit⟩
@@ -209,7 +371,6 @@ instance ofUnique (V : Type u) [SeminormedAddCommGroup V] [i : Unique V] :
     Unique (SemiNormedGrp₁.of V) :=
   i
 
--- Porting note: extracted from `Limits.HasZeroMorphisms` instance below.
 instance (X Y : SemiNormedGrp₁) : Zero (X ⟶ Y) where
   zero := ⟨0, NormedAddGroupHom.NormNoninc.zero⟩
 
@@ -233,8 +394,7 @@ theorem iso_isometry {V W : SemiNormedGrp₁} (i : V ≅ W) : Isometry i.hom := 
   intro v
   apply le_antisymm (i.hom.2 v)
   calc
-    -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-    ‖v‖ = ‖i.inv (i.hom v)‖ := by erw [Iso.hom_inv_id_apply]
+    ‖v‖ = ‖i.inv (i.hom v)‖ := by rw [← comp_apply, Iso.hom_inv_id, id_apply]
     _ ≤ ‖i.hom v‖ := i.inv.2 _
 
 end SemiNormedGrp₁

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
@@ -324,8 +324,8 @@ lemma mkHom_id {M : Type u} [SeminormedAddCommGroup M] :
 @[simp]
 lemma mkHom_comp {M N O : Type u} [SeminormedAddCommGroup M] [SeminormedAddCommGroup N]
     [SeminormedAddCommGroup O] (f : NormedAddGroupHom M N) (g : NormedAddGroupHom N O)
-    (hf : f.NormNoninc) (hg : g.NormNoninc) :
-    mkHom (g.comp f) (hg.comp hf) = mkHom f hf ≫ mkHom g hg :=
+    (hf : f.NormNoninc) (hg : g.NormNoninc) (hgf : (g.comp f).NormNoninc) :
+    mkHom (g.comp f) hgf = mkHom f hf ≫ mkHom g hg :=
   rfl
 
 @[simp]

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp/Completion.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp/Completion.lean
@@ -43,26 +43,27 @@ namespace SemiNormedGrp
 @[simps]
 def completion : SemiNormedGrp.{u} ⥤ SemiNormedGrp.{u} where
   obj V := SemiNormedGrp.of (Completion V)
-  map f := f.completion
-  map_id _ := completion_id
-  map_comp f g := (completion_comp f g).symm
+  map f := SemiNormedGrp.ofHom f.hom.completion
+  map_id _ := SemiNormedGrp.hom_ext completion_id
+  map_comp f g := SemiNormedGrp.hom_ext (completion_comp f.hom g.hom).symm
 
 instance completion_completeSpace {V : SemiNormedGrp} : CompleteSpace (completion.obj V) :=
   Completion.completeSpace _
 
 /-- The canonical morphism from a seminormed group `V` to its completion. -/
-def completion.incl {V : SemiNormedGrp} : V ⟶ completion.obj V where
-  toFun v := (v : Completion V)
-  map_add' := Completion.coe_add
-  bound' := ⟨1, fun v => by simp⟩
+def completion.incl {V : SemiNormedGrp} : V ⟶ completion.obj V :=
+  ofHom
+  { toFun v := (v : Completion V)
+    map_add' := Completion.coe_add
+    bound' := ⟨1, fun v => by simp⟩ }
 
 theorem completion.norm_incl_eq {V : SemiNormedGrp} {v : V} : ‖completion.incl v‖ = ‖v‖ :=
   UniformSpace.Completion.norm_coe _
 
-theorem completion.map_normNoninc {V W : SemiNormedGrp} {f : V ⟶ W} (hf : f.NormNoninc) :
-    (completion.map f).NormNoninc :=
+theorem completion.map_normNoninc {V W : SemiNormedGrp} {f : V ⟶ W} (hf : f.hom.NormNoninc) :
+    (completion.map f).hom.NormNoninc :=
   NormedAddGroupHom.NormNoninc.normNoninc_iff_norm_le_one.2 <|
-    (NormedAddGroupHom.norm_completion f).le.trans <|
+    (NormedAddGroupHom.norm_completion f.hom).le.trans <|
       NormedAddGroupHom.NormNoninc.normNoninc_iff_norm_le_one.1 hf
 
 variable (V W : SemiNormedGrp)
@@ -72,45 +73,27 @@ from the completion of `V` to the completion of `W`.
 The difference from the definition obtained from the functoriality of completion is in that the
 map sending a morphism `f` to the associated morphism of completions is itself additive. -/
 def completion.mapHom (V W : SemiNormedGrp.{u}) :
-    -- Porting note: cannot see instances through concrete cats
-    have (V W : SemiNormedGrp.{u}) : AddGroup (V ⟶ W) :=
-      inferInstanceAs <| AddGroup <| NormedAddGroupHom V W
-    (V ⟶ W) →+ (completion.obj V ⟶ completion.obj W) :=
-  @AddMonoidHom.mk' _ _ (_) (_) completion.map fun f g => f.completion_add g
+   (V ⟶ W) →+ (completion.obj V ⟶ completion.obj W) :=
+  @AddMonoidHom.mk' _ _ (_) (_) completion.map fun f g =>
+    SemiNormedGrp.hom_ext (f.hom.completion_add g.hom)
 
--- @[simp] -- Porting note: removed simp since LHS simplifies and is not used
 theorem completion.map_zero (V W : SemiNormedGrp) : completion.map (0 : V ⟶ W) = 0 :=
-  -- Porting note: cannot see instances through concrete cats
-  @AddMonoidHom.map_zero _ _ (_) (_) (completion.mapHom V W)
+  (completion.mapHom V W).map_zero
 
 instance : Preadditive SemiNormedGrp.{u} where
-  homGroup P Q := inferInstanceAs <| AddCommGroup <| NormedAddGroupHom P Q
-  add_comp _ Q _ f f' g := by
-    ext x
-    -- Porting note: failing simps probably due to instance synthesis issues with concrete
-    -- cats; see the gymnastics below for what used to be
-    -- simp only [add_apply, comp_apply. map_add]
-    rw [NormedAddGroupHom.add_apply, CategoryTheory.comp_apply, CategoryTheory.comp_apply,
-      CategoryTheory.comp_apply, @NormedAddGroupHom.add_apply _ _ (_) (_)]
-    convert map_add g (f x) (f' x)
-  comp_add _ _ _ _ _ _ := by
-    ext
-    -- Porting note: failing simps probably due to instance synthesis issues with concrete
-    -- cats; see the gymnastics below for what used to be
-    rw [NormedAddGroupHom.add_apply, CategoryTheory.comp_apply, CategoryTheory.comp_apply,
-      CategoryTheory.comp_apply, @NormedAddGroupHom.add_apply _ _ (_) (_)]
 
 instance : Functor.Additive completion where
-  map_add := NormedAddGroupHom.completion_add _ _
+  map_add := SemiNormedGrp.hom_ext <| NormedAddGroupHom.completion_add _ _
 
 /-- Given a normed group hom `f : V → W` with `W` complete, this provides a lift of `f` to
 the completion of `V`. The lemmas `lift_unique` and `lift_comp_incl` provide the api for the
 universal property of the completion. -/
 def completion.lift {V W : SemiNormedGrp} [CompleteSpace W] [T0Space W] (f : V ⟶ W) :
-    completion.obj V ⟶ W where
-  toFun := f.extension
-  map_add' := f.extension.toAddMonoidHom.map_add'
-  bound' := f.extension.bound'
+    completion.obj V ⟶ W :=
+  ofHom
+  { toFun := f.hom.extension
+    map_add' := f.hom.extension.toAddMonoidHom.map_add'
+    bound' := f.hom.extension.bound' }
 
 theorem completion.lift_comp_incl {V W : SemiNormedGrp} [CompleteSpace W] [T0Space W]
     (f : V ⟶ W) : completion.incl ≫ completion.lift f = f :=
@@ -118,7 +101,7 @@ theorem completion.lift_comp_incl {V W : SemiNormedGrp} [CompleteSpace W] [T0Spa
 
 theorem completion.lift_unique {V W : SemiNormedGrp} [CompleteSpace W] [T0Space W]
     (f : V ⟶ W) (g : completion.obj V ⟶ W) : completion.incl ≫ g = f → g = completion.lift f :=
-  fun h => (NormedAddGroupHom.extension_unique _ fun v =>
-    ((NormedAddGroupHom.ext_iff.1 h) v).symm).symm
+  fun h => SemiNormedGrp.hom_ext (NormedAddGroupHom.extension_unique _ fun v =>
+    ((SemiNormedGrp.ext_iff.1 h) v).symm).symm
 
 end SemiNormedGrp

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp/Kernels.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp/Kernels.lean
@@ -35,20 +35,18 @@ noncomputable section
 /-- Auxiliary definition for `HasCokernels SemiNormedGrp₁`. -/
 def cokernelCocone {X Y : SemiNormedGrp₁.{u}} (f : X ⟶ Y) : Cofork f 0 :=
   Cofork.ofπ
-    (@SemiNormedGrp₁.mkHom _ (SemiNormedGrp.of (Y ⧸ NormedAddGroupHom.range f.1))
-      f.1.range.normedMk (NormedAddGroupHom.isQuotientQuotient _).norm_le)
+    (@SemiNormedGrp₁.mkHom _ (Y ⧸ NormedAddGroupHom.range f.1) _ _
+      f.hom.1.range.normedMk (NormedAddGroupHom.isQuotientQuotient _).norm_le)
     (by
       ext x
       -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5026): was
-      -- simp only [comp_apply, Limits.zero_comp, NormedAddGroupHom.zero_apply,
-      --   SemiNormedGrp₁.mkHom_apply, SemiNormedGrp₁.zero_apply,
-      --   ← NormedAddGroupHom.mem_ker, f.1.range.ker_normedMk, f.1.mem_range]
-      -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-      erw [Limits.zero_comp, CategoryTheory.comp_apply, SemiNormedGrp₁.mkHom_apply,
-        SemiNormedGrp₁.zero_apply, ← NormedAddGroupHom.mem_ker, f.1.range.ker_normedMk,
-        f.1.mem_range]
-      use x
-      rfl)
+      -- simp only [ConcreteCategory.comp_apply, Limits.zero_comp, NormedAddGroupHom.zero_apply,
+      -- SemiNormedGrp₁.mkHom_apply, SemiNormedGrp₁.zero_apply,
+      -- ← NormedAddGroupHom.mem_ker, f.1.range.ker_normedMk, f.1.mem_range]
+      rw [Limits.zero_comp, comp_apply, SemiNormedGrp₁.mkHom_apply,
+        SemiNormedGrp₁.zero_apply, ← NormedAddGroupHom.mem_ker, f.hom.1.range.ker_normedMk,
+        f.hom.1.mem_range]
+      use x)
 
 /-- Auxiliary definition for `HasCokernels SemiNormedGrp₁`. -/
 def cokernelLift {X Y : SemiNormedGrp₁.{u}} (f : X ⟶ Y) (s : CokernelCofork f) :
@@ -59,8 +57,6 @@ def cokernelLift {X Y : SemiNormedGrp₁.{u}} (f : X ⟶ Y) (s : CokernelCofork 
     rintro _ ⟨b, rfl⟩
     change (f ≫ s.π) b = 0
     simp
-    -- This used to be the end of the proof before https://github.com/leanprover/lean4/pull/2644
-    erw [zero_apply]
   -- The lift has norm at most one:
   exact NormedAddGroupHom.lift_normNoninc _ _ _ s.π.2
 
@@ -75,12 +71,11 @@ instance : HasCokernels SemiNormedGrp₁.{u} where
               apply NormedAddGroupHom.lift_mk f.1.range
               rintro _ ⟨b, rfl⟩
               change (f ≫ s.π) b = 0
-              simp
-              -- This used to be the end of the proof before https://github.com/leanprover/lean4/pull/2644
-              erw [zero_apply])
+              simp)
             fun _ _ w =>
-            Subtype.eq
-              (NormedAddGroupHom.lift_unique f.1.range _ _ _ (congr_arg Subtype.val w :)) }
+            SemiNormedGrp₁.hom_ext <| Subtype.eq
+              (NormedAddGroupHom.lift_unique f.1.range _ _ _
+                (congr_arg Subtype.val (congr_arg Hom.hom w))) }
 
 -- Sanity check
 example : HasCokernels SemiNormedGrp₁ := by infer_instance
@@ -93,24 +88,18 @@ namespace SemiNormedGrp
 
 section EqualizersAndKernels
 
--- Porting note: these weren't needed in Lean 3
-instance {V W : SemiNormedGrp.{u}} : Sub (V ⟶ W) :=
-  (inferInstance : Sub (NormedAddGroupHom V W))
-noncomputable instance {V W : SemiNormedGrp.{u}} : Norm (V ⟶ W) :=
-  (inferInstance : Norm (NormedAddGroupHom V W))
-noncomputable instance {V W : SemiNormedGrp.{u}} : NNNorm (V ⟶ W) :=
-  (inferInstance : NNNorm (NormedAddGroupHom V W))
+noncomputable instance {V W : SemiNormedGrp.{u}} : Norm (V ⟶ W) where
+  norm f := norm f.hom
+noncomputable instance {V W : SemiNormedGrp.{u}} : NNNorm (V ⟶ W) where
+  nnnorm f := nnnorm f.hom
+
 /-- The equalizer cone for a parallel pair of morphisms of seminormed groups. -/
 def fork {V W : SemiNormedGrp.{u}} (f g : V ⟶ W) : Fork f g :=
-  @Fork.ofι _ _ _ _ _ _ (of (f - g : NormedAddGroupHom V W).ker)
-    (NormedAddGroupHom.incl (f - g).ker) <| by
-    -- Porting note: not needed in mathlib3
-    change NormedAddGroupHom V W at f g
+  @Fork.ofι _ _ _ _ _ _ (of (f - g).hom.ker)
+    (ofHom (NormedAddGroupHom.incl (f - g).hom.ker)) <| by
     ext v
-    have : v.1 ∈ (f - g).ker := v.2
-    simpa only [NormedAddGroupHom.incl_apply, Pi.zero_apply, coe_comp, NormedAddGroupHom.coe_zero,
-      NormedAddGroupHom.mem_ker, NormedAddGroupHom.coe_sub, Pi.sub_apply,
-      sub_eq_zero] using this
+    have : v.1 ∈ (f - g).hom.ker := v.2
+    simpa [-SetLike.coe_mem, NormedAddGroupHom.mem_ker, sub_eq_zero] using this
 
 instance hasLimit_parallelPair {V W : SemiNormedGrp.{u}} (f g : V ⟶ W) :
     HasLimit (parallelPair f g) where
@@ -118,12 +107,15 @@ instance hasLimit_parallelPair {V W : SemiNormedGrp.{u}} (f g : V ⟶ W) :
     Nonempty.intro
       { cone := fork f g
         isLimit :=
+          have this := fun (c : Fork f g) =>
+            show NormedAddGroupHom.compHom (f - g).hom c.ι.hom = 0 by
+              rw [hom_sub, AddMonoidHom.map_sub, AddMonoidHom.sub_apply, sub_eq_zero]
+              exact congr_arg Hom.hom c.condition
           Fork.IsLimit.mk _
-            (fun c =>
-              NormedAddGroupHom.ker.lift (Fork.ι c) _ <|
-                show NormedAddGroupHom.compHom (f - g) c.ι = 0 by
-                  rw [AddMonoidHom.map_sub, AddMonoidHom.sub_apply, sub_eq_zero]; exact c.condition)
-            (fun _ => NormedAddGroupHom.ker.incl_comp_lift _ _ _) fun c g h => by
+            (fun c => ofHom <|
+              NormedAddGroupHom.ker.lift (Fork.ι c).hom _ <| this c)
+            (fun _ => SemiNormedGrp.hom_ext <| NormedAddGroupHom.ker.incl_comp_lift _ _ (this _))
+            fun c g h => by
         -- Porting note: the `simp_rw` was `rw [← h]` but motive is not type correct in mathlib4
               ext x; dsimp; simp_rw [← h]; rfl}
 
@@ -140,25 +132,19 @@ section Cokernel
 /-- Auxiliary definition for `HasCokernels SemiNormedGrp`. -/
 noncomputable
 def cokernelCocone {X Y : SemiNormedGrp.{u}} (f : X ⟶ Y) : Cofork f 0 :=
-  @Cofork.ofπ _ _ _ _ _ _ (SemiNormedGrp.of (Y ⧸ NormedAddGroupHom.range f)) f.range.normedMk
-    (by
-      ext a
-      simp only [coe_comp, Function.comp_apply, Limits.zero_comp, zero_apply]
-      -- Porting note: simp doesn't seem to be firing in the below line
-      rw [← NormedAddGroupHom.mem_ker, f.range.ker_normedMk, f.mem_range]
-      simp only [exists_apply_eq_apply])
+  Cofork.ofπ (P := SemiNormedGrp.of (Y ⧸ NormedAddGroupHom.range f.hom))
+    (ofHom f.hom.range.normedMk)
+    (by aesop)
 
 /-- Auxiliary definition for `HasCokernels SemiNormedGrp`. -/
 noncomputable
 def cokernelLift {X Y : SemiNormedGrp.{u}} (f : X ⟶ Y) (s : CokernelCofork f) :
     (cokernelCocone f).pt ⟶ s.pt :=
-  NormedAddGroupHom.lift _ s.π
+  ofHom <| NormedAddGroupHom.lift _ s.π.hom
     (by
       rintro _ ⟨b, rfl⟩
       change (f ≫ s.π) b = 0
-      simp
-      -- This used to be the end of the proof before https://github.com/leanprover/lean4/pull/2644
-      erw [zero_apply])
+      simp)
 
 /-- Auxiliary definition for `HasCokernels SemiNormedGrp`. -/
 noncomputable
@@ -167,13 +153,12 @@ def isColimitCokernelCocone {X Y : SemiNormedGrp.{u}} (f : X ⟶ Y) :
   isColimitAux _ (cokernelLift f)
     (fun s => by
       ext
-      apply NormedAddGroupHom.lift_mk f.range
+      apply NormedAddGroupHom.lift_mk f.hom.range
       rintro _ ⟨b, rfl⟩
       change (f ≫ s.π) b = 0
-      simp
-      -- This used to be the end of the proof before https://github.com/leanprover/lean4/pull/2644
-      erw [zero_apply])
-    fun _ _ w => NormedAddGroupHom.lift_unique f.range _ _ _ w
+      simp)
+    fun _ _ w => SemiNormedGrp.hom_ext <| NormedAddGroupHom.lift_unique f.hom.range _ _ _ <|
+      congr_arg Hom.hom w
 
 instance : HasCokernels SemiNormedGrp.{u} where
   has_colimit f :=
@@ -206,14 +191,11 @@ theorem explicitCokernelπ_surjective {X Y : SemiNormedGrp.{u}} {f : X ⟶ Y} :
     Function.Surjective (explicitCokernelπ f) :=
   Quot.mk_surjective
 
-@[simp, reassoc]
+@[reassoc (attr := simp)]
 theorem comp_explicitCokernelπ {X Y : SemiNormedGrp.{u}} (f : X ⟶ Y) :
     f ≫ explicitCokernelπ f = 0 := by
   convert (cokernelCocone f).w WalkingParallelPairHom.left
   simp
-
--- Porting note: wasn't necessary in Lean 3. Is this a bug?
-attribute [simp] comp_explicitCokernelπ_assoc
 
 @[simp]
 theorem explicitCokernelπ_apply_dom_eq_zero {X Y : SemiNormedGrp.{u}} {f : X ⟶ Y} (x : X) :
@@ -270,17 +252,14 @@ instance explicitCokernelπ.epi {X Y : SemiNormedGrp.{u}} {f : X ⟶ Y} :
   constructor
   intro Z g h H
   ext x
-  -- Porting note: no longer needed
-  -- obtain ⟨x, hx⟩ := explicitCokernelπ_surjective (explicitCokernelπ f x)
-  -- change (explicitCokernelπ f ≫ g) _ = _
   rw [H]
 
 theorem isQuotient_explicitCokernelπ {X Y : SemiNormedGrp.{u}} (f : X ⟶ Y) :
-    NormedAddGroupHom.IsQuotient (explicitCokernelπ f) :=
+    NormedAddGroupHom.IsQuotient (explicitCokernelπ f).hom :=
   NormedAddGroupHom.isQuotientQuotient _
 
 theorem normNoninc_explicitCokernelπ {X Y : SemiNormedGrp.{u}} (f : X ⟶ Y) :
-    (explicitCokernelπ f).NormNoninc :=
+    (explicitCokernelπ f).hom.NormNoninc :=
   (isQuotient_explicitCokernelπ f).norm_le
 
 open scoped NNReal
@@ -290,7 +269,7 @@ theorem explicitCokernelDesc_norm_le_of_norm_le {X Y Z : SemiNormedGrp.{u}} {f :
   NormedAddGroupHom.lift_norm_le _ _ _ h
 
 theorem explicitCokernelDesc_normNoninc {X Y Z : SemiNormedGrp.{u}} {f : X ⟶ Y} {g : Y ⟶ Z}
-    {cond : f ≫ g = 0} (hg : g.NormNoninc) : (explicitCokernelDesc cond).NormNoninc := by
+    {cond : f ≫ g = 0} (hg : g.hom.NormNoninc) : (explicitCokernelDesc cond).hom.NormNoninc := by
   refine NormedAddGroupHom.NormNoninc.normNoninc_iff_norm_le_one.2 ?_
   rw [← NNReal.coe_one]
   exact


### PR DESCRIPTION
This PR adds a `Hom` structure and `ConcreteCategory` instance for `SemiNormedGrp` and `SemiNormedGrp_1`.

Zulip thread: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Concrete.20category.20class.20redesign

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
