### PR TITLE
[Merged by Bors] - refactor(Order/Category): `ConcreteCategory` instance for `\omegaCPO`

### DIFF
--- a/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
@@ -19,7 +19,7 @@ an `OmegaCompletePartialOrder`.
 ## Main definitions
 
  * `ωCPO`
-   * an instance of `Category` and `HasForget`
+   * an instance of `Category` and `ConcreteCategory`
 
  -/
 
@@ -30,39 +30,38 @@ universe u v
 
 
 /-- The category of types with an omega complete partial order. -/
-def ωCPO : Type (u + 1) :=
-  Bundled OmegaCompletePartialOrder
+structure ωCPO : Type (u + 1) where
+  /-- The underlying type. -/
+  carrier : Type u
+  [str : OmegaCompletePartialOrder carrier]
+
+attribute [instance] ωCPO.str
 
 namespace ωCPO
 
 open OmegaCompletePartialOrder
 
-instance : BundledHom @ContinuousHom where
-  toFun := @ContinuousHom.Simps.apply
-  id := @ContinuousHom.id
-  comp := @ContinuousHom.comp
-  hom_ext := @ContinuousHom.coe_inj
-
--- Porting note: `deriving instance HasForget` didn't work.
-deriving instance LargeCategory for ωCPO
-instance : HasForget ωCPO := by unfold ωCPO; infer_instance
-
 instance : CoeSort ωCPO Type* :=
-  Bundled.coeSort
+  ⟨carrier⟩
 
 /-- Construct a bundled ωCPO from the underlying type and typeclass. -/
-def of (α : Type*) [OmegaCompletePartialOrder α] : ωCPO :=
-  Bundled.of α
+abbrev of (α : Type*) [OmegaCompletePartialOrder α] : ωCPO where
+  carrier := α
 
-@[simp]
 theorem coe_of (α : Type*) [OmegaCompletePartialOrder α] : ↥(of α) = α :=
   rfl
 
+instance : LargeCategory.{u} ωCPO where
+  Hom X Y := ContinuousHom X Y
+  id X := ContinuousHom.id
+  comp f g := g.comp f
+
+instance : ConcreteCategory ωCPO (ContinuousHom · ·) where
+  hom f := f
+  ofHom f := f
+
 instance : Inhabited ωCPO :=
   ⟨of PUnit⟩
-
-instance (α : ωCPO) : OmegaCompletePartialOrder α :=
-  α.str
 
 section
 
@@ -77,12 +76,11 @@ def product {J : Type v} (f : J → ωCPO.{v}) : Fan f :=
 /-- The pi-type is a limit cone for the product. -/
 def isProduct (J : Type v) (f : J → ωCPO) : IsLimit (product f) where
   lift s :=
-    -- Porting note: Original proof didn't have `.toFun`
-    ⟨⟨fun t j => (s.π.app ⟨j⟩).toFun t, fun _ _ h j => (s.π.app ⟨j⟩).monotone h⟩,
+    ⟨⟨fun t j => (s.π.app ⟨j⟩) t, fun _ _ h j => (s.π.app ⟨j⟩).monotone h⟩,
       fun x => funext fun j => (s.π.app ⟨j⟩).continuous x⟩
   uniq s m w := by
     ext t; funext j -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): Originally `ext t j`
-    change m.toFun t j = (s.π.app ⟨j⟩).toFun t
+    change m t j = (s.π.app ⟨j⟩) t
     rw [← w ⟨j⟩]
     rfl
   fac _ _ := rfl
@@ -109,16 +107,14 @@ def equalizerι {α β : Type*} [OmegaCompletePartialOrder α] [OmegaCompletePar
   .mk (OrderHom.Subtype.val _) fun _ => rfl
 
 /-- A construction of the equalizer fork. -/
--- Porting note: Changed `{ a // f a = g a }` to `{ a // f.toFun a = g.toFun a }`
 def equalizer {X Y : ωCPO.{v}} (f g : X ⟶ Y) : Fork f g :=
-  Fork.ofι (P := ωCPO.of { a // f.toFun a = g.toFun a }) (equalizerι f g)
+  Fork.ofι (P := ωCPO.of { a // f a = g a }) (equalizerι f g)
     (ContinuousHom.ext _ _ fun x => x.2)
 
 /-- The equalizer fork is a limit. -/
 def isEqualizer {X Y : ωCPO.{v}} (f g : X ⟶ Y) : IsLimit (equalizer f g) :=
   Fork.IsLimit.mk' _ fun s =>
-    -- Porting note: Changed `s.ι x` to `s.ι.toFun x`
-    ⟨{  toFun := fun x => ⟨s.ι.toFun x, by apply ContinuousHom.congr_fun s.condition⟩
+    ⟨{  toFun := fun x => ⟨s.ι x, by apply ContinuousHom.congr_fun s.condition⟩
         monotone' := fun _ _ h => s.ι.monotone h
         map_ωSup' := fun x => Subtype.ext (s.ι.continuous x)
       }, by ext; rfl, fun hm => by

--- a/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
@@ -7,7 +7,7 @@ import Mathlib.Order.OmegaCompletePartialOrder
 import Mathlib.CategoryTheory.Limits.Shapes.Products
 import Mathlib.CategoryTheory.Limits.Shapes.Equalizers
 import Mathlib.CategoryTheory.Limits.Constructions.LimitsOfProductsAndEqualizers
-import Mathlib.CategoryTheory.ConcreteCategory.BundledHom
+import Mathlib.CategoryTheory.ConcreteCategory.Basic
 
 /-!
 # Category of types with an omega complete partial order


### PR DESCRIPTION
This should be the final PR replacing `HasForget` with `ConcreteCategory`, in this case for `\omegaCPO`.

---

- [ ] depends on: #21409 
- [ ] depends on: #21410 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
