### PR TITLE
[Merged by Bors] - chore(Cache): Add support for $MATHLIB_CACHE_DIR

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -44,17 +44,20 @@ def IRDIR : FilePath :=
 
 /-- Target directory for caching -/
 initialize CACHEDIR : FilePath ← do
-  match ← IO.getEnv "XDG_CACHE_HOME" with
-  | some path => return path / "mathlib"
+  match ← IO.getEnv "MATHLIB_CACHE_DIR" with
+  | some path => return path
   | none =>
-    let home ← if System.Platform.isWindows then
-      let drive ← IO.getEnv "HOMEDRIVE"
-      let path ← IO.getEnv "HOMEPATH"
-      pure <| return (← drive) ++ (← path)
-    else IO.getEnv "HOME"
-    match home with
-    | some path => return path / ".cache" / "mathlib"
-    | none => pure ⟨".cache"⟩
+    match ← IO.getEnv "XDG_CACHE_HOME" with
+    | some path => return path / "mathlib"
+    | none =>
+      let home ← if System.Platform.isWindows then
+        let drive ← IO.getEnv "HOMEDRIVE"
+        let path ← IO.getEnv "HOMEPATH"
+        pure <| return (← drive) ++ (← path)
+      else IO.getEnv "HOME"
+      match home with
+      | some path => return path / ".cache" / "mathlib"
+      | none => pure ⟨".cache"⟩
 
 /-- Target file path for `curl` configurations -/
 def CURLCFG :=


### PR DESCRIPTION
This allows someone to explicitly put just Mathlib's own cache in some specific location without needing to entirely affect any program using XDG_CACHE_HOME.

When unset we fallback to the same logic as before.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
