### PR TITLE
Add lemma List.zipwith_finset_sum

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -1593,6 +1593,50 @@ theorem sum_toFinset_count_eq_length [DecidableEq α] (l : List α) :
     ∑ a ∈ l.toFinset, l.count a = l.length := by
   simpa [List.map_const'] using (Finset.sum_list_map_count l fun _ => (1 : ℕ)).symm
 
+/-- The sum of the `zipWith` operation on two lists equals the sum of applying the operation
+    to corresponding elements of the two lists, indexed over the minimum of their lengths. -/
+lemma zipwith_finset_sum [Inhabited α] [Inhabited β] [AddCommMonoid γ]
+  {op : α → β → γ}
+  (l : List α) (m : List β) :
+  (List.zipWith op l m).sum =
+  ∑ x ∈ (Finset.range (Nat.min l.length m.length)), op (l[x]!) (m[x]!) := by
+  induction m generalizing l with
+  | nil =>
+      simp
+  | cons mhead mtail ih =>
+      cases l with
+      | nil =>
+          simp
+      | cons lhead ltail =>
+          simp only [List.zipWith, List.sum_cons]
+          rw [ih]
+          have h_min :
+            Nat.min (ltail.length + 1) (mtail.length + 1)
+            = Nat.succ (Nat.min ltail.length mtail.length) := Nat.succ_min_succ _ _
+          simp only [List.length_cons, h_min, Nat.succ_eq_add_one]
+          have h_zero : op lhead mhead = op (lhead :: ltail)[0]! (mhead :: mtail)[0]!:= by simp
+          have h_rest :
+            ∑ x in Finset.range (ltail.length.min mtail.length),
+            op (lhead :: ltail)[x + 1]! (mhead :: mtail)[x + 1]! =
+            ∑ x in Finset.range (ltail.length.min mtail.length),
+            op ltail[x]! mtail[x]! := by
+              apply Finset.sum_congr rfl
+              intros x hx
+              cases mtail.get? x with
+              | none => simp [List.length, Nat.lt_succ_iff] at hx; simp
+              | some qx =>
+                cases ltail.get? x with
+                | none => simp [List.length, Nat.lt_succ_iff] at hx; simp
+                | some fx => simp [Option.get!]
+          rw [h_zero, ←h_rest]
+          let n := ltail.length.min mtail.length
+          rw [Finset.sum_range_succ' (fun x => op (lhead :: ltail)[x]! (mhead :: mtail)[x]!) n]
+          exact
+            AddCommMagma.add_comm (op (lhead :: ltail)[0]! (mhead :: mtail)[0]!)
+              (∑ x ∈ Finset.range (ltail.length.min mtail.length),
+                op (lhead :: ltail)[x + 1]! (mhead :: mtail)[x + 1]!)
+
+
 end List
 
 namespace Multiset


### PR DESCRIPTION
### **Description:**  

This PR adds the lemma `List.zipwith_finset_sum` to `Mathlib.Algebra.BigOperators.Group.Finset.Basic`.  

#### **Statement:**  
The sum of the `zipWith` operation on two lists equals the sum of applying the operation to corresponding elements of the two lists, indexed over the minimum of their lengths.  

#### **Formal Statement:**  
```lean
lemma zipwith_finset_sum [Inhabited α] [Inhabited β] [AddCommMonoid γ]
  {op : α → β → γ}
  (l : List α) (m : List β) :
  (List.zipWith op l m).sum =
  ∑ x ∈ (Finset.range (Nat.min l.length m.length)), op (l[x]!) (m[x]!)
```

#### **Remarks:**
- This lemma provides a useful equivalence between `List.zipWith` and summation over a `Finset.range` indexed by `Nat.min l.length m.length`.
- It can be helpful in algebraic manipulations involving list-based summations.

#### **Dependencies:**  
No additional dependencies.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
