### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology): notation X ^[n] for cosimplicial objects

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -483,7 +483,7 @@ instance : Category (CosimplicialObject C) := by
 
 namespace CosimplicialObject
 
-/-- `X _[n]` denotes the `n`th-term of the cosimplicial object X -/
+/-- `X ^[n]` denotes the `n`th-term of the cosimplicial object X -/
 scoped[Simplicial]
   notation3:1000 X " ^[" n "]" =>
     (X : CategoryTheory.CosimplicialObject _).obj (SimplexCategory.mk n)

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -14,11 +14,14 @@ import Mathlib.CategoryTheory.Opposites
 # Simplicial objects in a category.
 
 A simplicial object in a category `C` is a `C`-valued presheaf on `SimplexCategory`.
-(Similarly a cosimplicial object is functor `SimplexCategory ⥤ C`.)
+(Similarly, a cosimplicial object is a functor `SimplexCategory ⥤ C`.)
 
-Use the notation `X _[n]` in the `Simplicial` locale to obtain the `n`-th term of a
-(co)simplicial object `X`, where `n` is a natural number.
+## Notation
 
+The following notations can be enabled via `open Simplicial`.
+
+- `X _[n]` denotes the `n`-th term of a simplicial object `X`, where `n : ℕ`.
+- `X ^[n]` denotes the `n`-th term of a cosimplicial object `X`, where `n : ℕ`.
 -/
 
 open Opposite
@@ -482,7 +485,7 @@ namespace CosimplicialObject
 
 /-- `X _[n]` denotes the `n`th-term of the cosimplicial object X -/
 scoped[Simplicial]
-  notation3:1000 X " _[" n "]" =>
+  notation3:1000 X " ^[" n "]" =>
     (X : CategoryTheory.CosimplicialObject _).obj (SimplexCategory.mk n)
 
 instance {J : Type v} [SmallCategory J] [HasLimitsOfShape J C] :
@@ -514,15 +517,15 @@ variable (X : CosimplicialObject C)
 open Simplicial
 
 /-- Coface maps for a cosimplicial object. -/
-def δ {n} (i : Fin (n + 2)) : X _[n] ⟶ X _[n + 1] :=
+def δ {n} (i : Fin (n + 2)) : X ^[n] ⟶ X ^[n + 1] :=
   X.map (SimplexCategory.δ i)
 
 /-- Codegeneracy maps for a cosimplicial object. -/
-def σ {n} (i : Fin (n + 1)) : X _[n + 1] ⟶ X _[n] :=
+def σ {n} (i : Fin (n + 1)) : X ^[n + 1] ⟶ X ^[n] :=
   X.map (SimplexCategory.σ i)
 
 /-- Isomorphisms from identities in ℕ. -/
-def eqToIso {n m : ℕ} (h : n = m) : X _[n] ≅ X _[m] :=
+def eqToIso {n m : ℕ} (h : n = m) : X ^[n] ≅ X ^[m] :=
   X.mapIso (CategoryTheory.eqToIso (by rw [h]))
 
 @[simp]
@@ -723,7 +726,7 @@ def point : Augmented C ⥤ C :=
 def toArrow : Augmented C ⥤ Arrow C where
   obj X :=
     { left := point.obj X
-      right := drop.obj X _[0]
+      right := (drop.obj X) ^[0]
       hom := X.hom.app _ }
   map η :=
     { left := point.map η


### PR DESCRIPTION
We change the notation for the `n`-th term of a cosimplicial object `X`, introducing the new notation `X ^[n]`. The previous notation `X _[n]` is also the notation used when `X` is a simplicial object. This change prevents any confusion between the two and is more in line with the established notation `Xⁿ` for cosimplicial objects (with simplicial objects denoted `Xₙ`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

There may be more changes to make to the notation for (co)simplicial objects if the notation for objects of the simplex category is changed. However, this change seems fairly independent and worth considering as a standalone PR.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
