### PR TITLE
[Merged by Bors] - chore: allow create-adaptation-pr.sh to continue when bump branch already exists

### DIFF
--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -137,7 +137,7 @@ git push
 echo
 echo "### [auto] create a new branch 'bump/nightly-$NIGHTLYDATE' and merge the latest changes from 'origin/nightly-testing'"
 
-git checkout -b "bump/nightly-$NIGHTLYDATE"
+git checkout -b "bump/nightly-$NIGHTLYDATE" || git checkout "bump/nightly-$NIGHTLYDATE"
 git merge --no-edit $NIGHTLYSHA || true # ignore error if there are conflicts
 
 # Check if there are merge conflicts


### PR DESCRIPTION
I found this useful when setting up the Batteries equivalent, so backporting to Mathlib.