### PR TITLE
[Merged by Bors] - fix(MathlibTest/TransImports): stop inspecting the `Lean` package

### DIFF
--- a/MathlibTest/TransImports.lean
+++ b/MathlibTest/TransImports.lean
@@ -3,8 +3,8 @@ import Mathlib.Util.TransImports
 /--
 info: 'MathlibTest.TransImports' has at most 1000 transitive imports
 
-3 starting with "Lean.Elab.I":
-[Lean.Elab.InfoTree, Lean.Elab.InfoTree.Main, Lean.Elab.InfoTree.Types]
+2 starting with "Mathlib.Tactic.Linter.H":
+[Mathlib.Tactic.Linter.HashCommandLinter, Mathlib.Tactic.Linter.Header]
 -/
 #guard_msgs in
-#trans_imports "Lean.Elab.I" at_most 1000
+#trans_imports "Mathlib.Tactic.Linter.H" at_most 1000


### PR DESCRIPTION
This makes it more robust to changes to lean internals.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/MathlibTest.2ETransImports)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
