### PR TITLE
[Merged by Bors] - refactor: restate lemmas about `∑' _, c` using `ENat.card`/`Set.encard`

### DIFF
--- a/Mathlib/Data/Real/ENatENNReal.lean
+++ b/Mathlib/Data/Real/ENatENNReal.lean
@@ -59,6 +59,9 @@ theorem toENNReal_inj : (m : ℝ≥0∞) = (n : ℝ≥0∞) ↔ m = n :=
 
 @[deprecated (since := "2024-12-29")] alias toENNReal_coe_eq_iff := toENNReal_inj
 
+@[simp, norm_cast] lemma toENNReal_eq_top : (n : ℝ≥0∞) = ∞ ↔ n = ⊤ := by simp [← toENNReal_inj]
+@[norm_cast] lemma toENNReal_ne_top : (n : ℝ≥0∞) ≠ ∞ ↔ n ≠ ⊤ := by simp
+
 @[simp, norm_cast]
 theorem toENNReal_le : (m : ℝ≥0∞) ≤ n ↔ m ≤ n :=
   toENNRealOrderEmbedding.le_iff_le
@@ -68,7 +71,7 @@ theorem toENNReal_lt : (m : ℝ≥0∞) < n ↔ m < n :=
   toENNRealOrderEmbedding.lt_iff_lt
 
 @[simp, norm_cast]
-lemma toENNReal_lt_top : (n : ℝ≥0∞) < ∞ ↔ n < ⊤ := by simpa using toENNReal_lt (n := ⊤)
+lemma toENNReal_lt_top : (n : ℝ≥0∞) < ∞ ↔ n < ⊤ := by simp [← toENNReal_lt]
 
 @[mono]
 theorem toENNReal_mono : Monotone ((↑) : ℕ∞ → ℝ≥0∞) :=

--- a/Mathlib/Data/Real/ENatENNReal.lean
+++ b/Mathlib/Data/Real/ENatENNReal.lean
@@ -67,6 +67,9 @@ theorem toENNReal_le : (m : ℝ≥0∞) ≤ n ↔ m ≤ n :=
 theorem toENNReal_lt : (m : ℝ≥0∞) < n ↔ m < n :=
   toENNRealOrderEmbedding.lt_iff_lt
 
+@[simp, norm_cast]
+lemma toENNReal_lt_top : (n : ℝ≥0∞) < ∞ ↔ n < ⊤ := by simpa using toENNReal_lt (n := ⊤)
+
 @[mono]
 theorem toENNReal_mono : Monotone ((↑) : ℕ∞ → ℝ≥0∞) :=
   toENNRealOrderEmbedding.monotone

--- a/Mathlib/MeasureTheory/Function/EssSup.lean
+++ b/Mathlib/MeasureTheory/Function/EssSup.lean
@@ -96,11 +96,11 @@ variable [MeasurableSingletonClass α]
 
 @[simp] lemma essSup_uniformOn_eq_ciSup [Finite α] (hf : BddAbove (Set.range f)) :
     essSup f (uniformOn univ) = ⨆ a, f a :=
-  essSup_eq_ciSup (by simp [uniformOn, cond_apply, Set.finite_univ]) hf
+  essSup_eq_ciSup (by simpa [uniformOn, cond_apply]) hf
 
 @[simp] lemma essInf_cond_count_eq_ciInf [Finite α] (hf : BddBelow (Set.range f)) :
     essInf f (uniformOn univ) = ⨅ a, f a :=
-  essInf_eq_ciInf (by simp [uniformOn, cond_apply, Set.finite_univ]) hf
+  essInf_eq_ciInf (by simpa [uniformOn, cond_apply]) hf
 
 end ConditionallyCompleteLattice
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -1524,8 +1524,8 @@ theorem lintegral_count [MeasurableSingletonClass α] (f : α → ℝ≥0∞) :
   exact funext fun a => lintegral_dirac a f
 
 @[deprecated ENNReal.tsum_const (since := "2025-02-06")]
-theorem _root_.ENNReal.tsum_const_eq [MeasurableSingletonClass α] (c : ℝ≥0∞) :
-    ∑' _ : α, c = c * Measure.count (univ : Set α) := by simp [mul_comm]
+lemma _root_.ENNReal.tsum_const_eq (c : ℝ≥0∞) : ∑' _ : α, c = c * count (univ : Set α) := by
+  simp [mul_comm]
 
 /-- Markov's inequality for the counting measure with hypothesis using `tsum` in `ℝ≥0∞`. -/
 theorem _root_.ENNReal.count_const_le_le_of_tsum_le [MeasurableSingletonClass α] {a : α → ℝ≥0∞}

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -1523,8 +1523,9 @@ theorem lintegral_count [MeasurableSingletonClass α] (f : α → ℝ≥0∞) :
   congr
   exact funext fun a => lintegral_dirac a f
 
+@[deprecated ENNReal.tsum_const (since := "2025-02-06")]
 theorem _root_.ENNReal.tsum_const_eq [MeasurableSingletonClass α] (c : ℝ≥0∞) :
-    ∑' _ : α, c = c * Measure.count (univ : Set α) := by rw [← lintegral_count, lintegral_const]
+    ∑' _ : α, c = c * Measure.count (univ : Set α) := by simp [mul_comm]
 
 /-- Markov's inequality for the counting measure with hypothesis using `tsum` in `ℝ≥0∞`. -/
 theorem _root_.ENNReal.count_const_le_le_of_tsum_le [MeasurableSingletonClass α] {a : α → ℝ≥0∞}

--- a/Mathlib/MeasureTheory/Measure/Count.lean
+++ b/Mathlib/MeasureTheory/Measure/Count.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.MeasureTheory.Measure.Dirac
+import Mathlib.Topology.Algebra.InfiniteSum.ENNReal
 
 /-!
 # Counting measure
@@ -34,18 +35,15 @@ theorem le_count_apply : ∑' _ : s, (1 : ℝ≥0∞) ≤ count s :=
     _ ≤ ∑' i, dirac i s := ENNReal.tsum_le_tsum fun _ => le_dirac_apply
     _ ≤ count s := le_sum_apply _ _
 
-theorem count_apply (hs : MeasurableSet s) : count s = ∑' _ : s, 1 := by
-  simp only [count, sum_apply, hs, dirac_apply', ← tsum_subtype s (1 : α → ℝ≥0∞), Pi.one_apply]
+theorem count_apply (hs : MeasurableSet s) : count s = s.encard := by
+  simp [count, hs, ← tsum_subtype, Set.encard]
 
-theorem count_empty : count (∅ : Set α) = 0 := by rw [count_apply MeasurableSet.empty, tsum_empty]
+@[deprecated measure_empty (since := "2025-02-06")]
+theorem count_empty : count (∅ : Set α) = 0 := measure_empty
 
 @[simp]
-theorem count_apply_finset' {s : Finset α} (s_mble : MeasurableSet (s : Set α)) :
-    count (↑s : Set α) = s.card :=
-  calc
-    count (↑s : Set α) = ∑' _ : (↑s : Set α), 1 := count_apply s_mble
-    _ = ∑ _ ∈ s, 1 := s.tsum_subtype 1
-    _ = s.card := by simp
+theorem count_apply_finset' {s : Finset α} (hs : MeasurableSet (s : Set α)) :
+    count (↑s : Set α) = s.card := by simp [count_apply hs]
 
 @[simp]
 theorem count_apply_finset [MeasurableSingletonClass α] (s : Finset α) :
@@ -102,7 +100,7 @@ theorem count_apply_lt_top [MeasurableSingletonClass α] : count s < ∞ ↔ s.F
 theorem count_eq_zero_iff : count s = 0 ↔ s = ∅ where
   mp h := eq_empty_of_forall_not_mem fun x hx ↦ by
     simpa [hx] using ((ENNReal.le_tsum x).trans <| le_sum_apply _ _).trans_eq h
-  mpr := by rintro rfl; exact count_empty
+  mpr := by rintro rfl; exact measure_empty
 
 lemma count_ne_zero_iff : count s ≠ 0 ↔ s.Nonempty :=
   count_eq_zero_iff.not.trans nonempty_iff_ne_empty.symm
@@ -145,10 +143,10 @@ theorem count_injective_image [MeasurableSingletonClass α] [MeasurableSingleton
 
 instance count.isFiniteMeasure [Finite α] :
     IsFiniteMeasure (Measure.count : Measure α) :=
-  ⟨by cases nonempty_fintype α; simp [Measure.count_apply, tsum_fintype]⟩
+  ⟨by cases nonempty_fintype α; simp [Measure.count_apply, finite_univ]⟩
 
-@[simp] lemma count_univ [Fintype α] : count (univ : Set α) = Fintype.card α := by
-  rw [count_apply .univ]; exact (tsum_univ 1).trans (by simp [tsum_fintype])
+@[simp]
+lemma count_univ : count (univ : Set α) = ENat.card α := by simp [count_apply .univ, encard_univ]
 
 end Measure
 

--- a/Mathlib/Probability/UniformOn.lean
+++ b/Mathlib/Probability/UniformOn.lean
@@ -89,11 +89,7 @@ alias finite_of_condCount_ne_zero := finite_of_uniformOn_ne_zero
 
 theorem uniformOn_univ [Fintype Ω] {s : Set Ω} :
     uniformOn Set.univ s = Measure.count s / Fintype.card Ω := by
-  rw [uniformOn, cond_apply MeasurableSet.univ, ← ENNReal.div_eq_inv_mul, Set.univ_inter]
-  congr
-  rw [← Finset.coe_univ, Measure.count_apply, Finset.univ.tsum_subtype' fun _ => (1 : ENNReal)]
-  · simp [Finset.card_univ]
-  · exact (@Finset.coe_univ Ω _).symm ▸ MeasurableSet.univ
+  simp [uniformOn, cond_apply, ← ENNReal.div_eq_inv_mul]
 
 @[deprecated (since := "2024-10-09")]
 alias condCount_univ := uniformOn_univ
@@ -115,7 +111,7 @@ theorem uniformOn_singleton (ω : Ω) (t : Set Ω) [Decidable (ω ∈ t)] :
     one_mul]
   split_ifs
   · rw [(by simpa : ({ω} : Set Ω) ∩ t = {ω}), Measure.count_singleton]
-  · rw [(by simpa : ({ω} : Set Ω) ∩ t = ∅), Measure.count_empty]
+  · simpa
 
 @[deprecated (since := "2024-10-09")]
 alias condCount_singleton := uniformOn_singleton

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -1673,6 +1673,8 @@ theorem infinite_iff {α : Type u} : Infinite α ↔ ℵ₀ ≤ #α := by
 lemma aleph0_le_mk_iff : ℵ₀ ≤ #α ↔ Infinite α := infinite_iff.symm
 lemma mk_lt_aleph0_iff : #α < ℵ₀ ↔ Finite α := by simp [← not_le, aleph0_le_mk_iff]
 
+@[simp] lemma mk_lt_aleph0 [Finite α] : #α < ℵ₀ := mk_lt_aleph0_iff.2 ‹_›
+
 @[simp]
 theorem aleph0_le_mk (α : Type u) [Infinite α] : ℵ₀ ≤ #α :=
   infinite_iff.1 ‹_›

--- a/Mathlib/SetTheory/Cardinal/ENat.lean
+++ b/Mathlib/SetTheory/Cardinal/ENat.lean
@@ -256,6 +256,10 @@ lemma toENat_nat (n : ℕ) : toENat n = n := map_natCast _ n
 
 @[simp] lemma toENat_eq_top {a : Cardinal} : toENat a = ⊤ ↔ ℵ₀ ≤ a := enat_gc.u_eq_top
 
+lemma toENat_ne_top {a : Cardinal} : toENat a ≠ ⊤ ↔ a < ℵ₀ := by simp
+
+@[simp] lemma toENat_lt_top {a : Cardinal} : toENat a < ⊤ ↔ a < ℵ₀ := by simp [lt_top_iff_ne_top]
+
 @[simp]
 theorem toENat_lift {a : Cardinal.{v}} : toENat (lift.{u} a) = toENat a := by
   cases le_total a ℵ₀ with

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -263,9 +263,11 @@ def card (α : Type*) : ℕ∞ :=
 theorem card_eq_coe_fintype_card [Fintype α] : card α = Fintype.card α := by
   simp [card]
 
-@[simp]
+@[simp high]
 theorem card_eq_top_of_infinite [Infinite α] : card α = ⊤ := by
   simp only [card, toENat_eq_top, aleph0_le_mk]
+
+@[simp] lemma card_eq_top : card α = ⊤ ↔ Infinite α := by simp [card, aleph0_le_mk_iff]
 
 @[simp] theorem card_lt_top_of_finite [Finite α] : card α < ⊤ := by simp [card]
 

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -265,7 +265,9 @@ theorem card_eq_coe_fintype_card [Fintype α] : card α = Fintype.card α := by
 
 @[simp]
 theorem card_eq_top_of_infinite [Infinite α] : card α = ⊤ := by
-  simp [card]
+  simp only [card, toENat_eq_top, aleph0_le_mk]
+
+@[simp] theorem card_lt_top_of_finite [Finite α] : card α < ⊤ := by simp [card]
 
 @[simp]
 theorem card_sum (α β : Type*) :

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -25,17 +25,25 @@ variable {α : Type*} (s : Set α)
 
 namespace ENNReal
 
-@[simp]
-lemma tsum_set_one_eq : ∑' (_ : s), (1 : ℝ≥0∞) = s.encard := by
+lemma tsum_set_one : ∑' _ : s, (1 : ℝ≥0∞) = s.encard := by
   obtain (hfin | hinf) := Set.finite_or_infinite s
   · lift s to Finset α using hfin
     simp [tsum_fintype]
   · have : Infinite s := infinite_coe_iff.mpr hinf
     rw [tsum_const_eq_top_of_ne_zero one_ne_zero, encard_eq_top hinf, ENat.toENNReal_top]
 
+lemma tsum_set_const (c : ℝ≥0∞) : ∑' _ : s, c = s.encard * c := by
+  simp [← tsum_set_one, ← ENNReal.tsum_mul_right]
+
+@[deprecated (since := "2025-02-06")] alias tsum_set_one_eq := tsum_set_one
+@[deprecated (since := "2025-02-06")] alias tsum_set_const_eq := tsum_set_const
+
 @[simp]
-lemma tsum_set_const_eq (c : ℝ≥0∞) : ∑' (_:s), (c : ℝ≥0∞) = s.encard * c := by
-  nth_rw 1 [← one_mul c]
-  rw [ENNReal.tsum_mul_right,tsum_set_one_eq]
+lemma tsum_one : ∑' _ : α, (1 : ℝ≥0∞) = ENat.card α := by
+  rw [← tsum_univ]; simpa [encard_univ] using tsum_set_one univ
+
+@[simp]
+lemma tsum_const (c : ℝ≥0∞) : ∑' _ : α, c = ENat.card α * c := by
+  rw [← tsum_univ]; simpa [encard_univ] using tsum_set_const univ c
 
 end ENNReal


### PR DESCRIPTION
Previously, someone trying to simplify away `∑' _, c` would stumble upon `ENNReal.tsum_const_eq`, turning the expression into `c * count univ`, and the only available rewrite from here would be `count_apply` turning the expression into `c * ∑' _, 1`!

Also remove `_eq` from the relevant lemma names.

From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
