### PR TITLE
[Merged by Bors] - fix(Mathlib/Tactic): `minImports` now correctly handles namespaced declarations

### DIFF
--- a/Mathlib/Tactic/MinImports.lean
+++ b/Mathlib/Tactic/MinImports.lean
@@ -133,6 +133,40 @@ def previousInstName : Name → Name
     .str init newTail
   | nm => nm
 
+/--
+`getDeclName cmd id` takes a `Syntax` input `cmd` and returns the `Name` of the declaration defined
+by `cmd`.
+-/
+def getDeclName (cmd : Syntax) : CommandElabM Name := do
+  let ns ← getCurrNamespace
+  let id1 ← getId cmd
+  let id2 := mkIdentFrom id1 (previousInstName id1.getId)
+  let modifiers : TSyntax ``Parser.Command.declModifiers := ⟨cmd[0]⟩
+  let modifiers ← elabModifiers modifiers
+  liftCoreM do (
+    -- Try applying the algorithm in `Lean.mkDeclName` to attach a namespace to the name.
+    -- Unfortunately calling `Lean.mkDeclName` directly won't work: it will complain that there is
+    -- already a declaration with this name.
+    (do
+      let shortName := id1.getId
+      let view := extractMacroScopes shortName
+      let name := view.name
+      let isRootName := (`_root_).isPrefixOf name
+      let mut fullName := if isRootName then
+        { view with name := name.replacePrefix `_root_ Name.anonymous }.review
+      else
+        ns ++ shortName
+      -- Apply name visibility rules: private names get mangled.
+      match modifiers.visibility with
+      | .private => return mkPrivateName (← getEnv) fullName
+      | _ => return fullName) <|>
+    -- try the visible name or the current "nameless" `instance` name
+    realizeGlobalConstNoOverload id1 <|>
+    -- otherwise, guess what the previous "nameless" `instance` name was
+    realizeGlobalConstNoOverload id2 <|>
+    -- failing everything, use the current namespace followed by the visible name
+    return ns ++ id1.getId)
+
 /--`getAllDependencies cmd id` takes a `Syntax` input `cmd` and returns the `NameSet` of all the
 declaration names that are implied by
 * the `SyntaxNodeKinds`,
@@ -149,16 +183,7 @@ you can use `Lean.NameSet.transitivelyUsedConstants` to get those.
 def getAllDependencies (cmd id : Syntax) :
     CommandElabM NameSet := do
   let env ← getEnv
-  let id1 ← getId cmd
-  let ns ← getCurrNamespace
-  let id2 := mkIdentFrom id1 (previousInstName id1.getId)
-  let nm ← liftCoreM do (
-    -- try the visible name or the current "nameless" `instance` name
-    realizeGlobalConstNoOverload id1 <|>
-    -- otherwise, guess what the previous "nameless" `instance` name was
-    realizeGlobalConstNoOverload id2 <|>
-    -- failing everything, use the current namespace followed by the visible name
-    return ns ++ id1.getId)
+  let nm ← getDeclName cmd
   -- We collect the implied declaration names, the `SyntaxNodeKinds` and the attributes.
   return getVisited env nm
               |>.append (getVisited env id.getId)

--- a/MathlibTest/MinImports.lean
+++ b/MathlibTest/MinImports.lean
@@ -74,6 +74,33 @@ import Mathlib.Data.Nat.Notation
 #min_imports in
 lemma hi (n : ℕ) : n = n := by extract_goal; rfl
 
+section Variables
+
+/-- info: import Mathlib.Data.Nat.Notation -/
+#guard_msgs in
+#min_imports in
+def confusableName : (1 : ℕ) = 1 := rfl
+
+variable {R : Type*} [Semiring R]
+
+-- Don't get confused by unused variables.
+variable {K : Type*} [Field K]
+
+namespace Namespace
+
+-- The dependency on `Semiring` is only found in the `variable` declaration.
+-- We find it by looking up the declaration by name and checking the term,
+-- which used to get confused if running in a namespace.
+
+/-- info: import Mathlib.Algebra.Ring.Defs -/
+#guard_msgs in
+#min_imports in
+protected def confusableName : (1 : R) = 1 := rfl
+
+end Namespace
+
+end Variables
+
 section Linter.MinImports
 
 set_option linter.minImports.increases false


### PR DESCRIPTION
The `minImports` linter/tactic is passed a piece of syntax and needs to figure out the dependencies of the declaration. Apart from looking at the syntax itself, it also looks at the elaborated term. This goes via determining the `Name` associated to that piece of syntax. The previous algorithm would get confused if there's a name `_root_.foo` and we're looking at `namespace Foo; def foo`. By replicating the logic of the builtin `Lean.Elab.mkDeclName` (that function unfortunately mixes name parsing/mangling and environment updating, so we can't call into it directly).

Apart from the extra test case, I have made sure that `MeasureTheory.Measure.le_add_left` now reports a sensible set of minimal imports. I have not added it as a test case since it is so far in the import hierarchy.

This PR also updates `upstreamableDecl` to use the same syntax -> name resolution.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
