### PR TITLE
[Merged by Bors] - feat(Order/Nucleus): nuclei form a complete lattice

### DIFF
--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -113,25 +113,28 @@ instance : BoundedOrder (Nucleus X) where
 
 variable {s : Set (Nucleus X)}
 
-def sInf_fun_idempotent : ∀ (x : X), sInf {x_1 | ∃ j ∈ s, j (sInf {x_2 | ∃ j ∈ s, j x = x_2}) = x_1}
-    ≤ sInf {x_1 | ∃ j ∈ s, j x = x_1} := by
+def sInf_fun (s : Set (Nucleus X)) (x : X) := sInf {j x | j ∈ s}
+
+def sInf_fun_increasing : ∀ (x : X), x ≤ sInf_fun s x := by
+  simp [sInf_fun, le_apply]
+
+def sInf_fun_idempotent : ∀ (x : X), sInf_fun s (sInf_fun s x) ≤ sInf_fun s x := by
   intro x
-  simp only [le_sInf_iff, Set.mem_setOf_eq, sInf_le_iff, lowerBounds, forall_exists_index, and_imp,
-    forall_apply_eq_imp_iff₂]
+  simp only [sInf_fun, le_sInf_iff, Set.mem_setOf_eq, forall_exists_index, and_imp,
+    forall_apply_eq_imp_iff₂, sInf_le_iff, lowerBounds]
   intro a ha b h
   rw [← idempotent]
   apply le_trans (h a ha)
   refine OrderHomClass.GCongr.mono a ?_
   simp_all [sInf_le_iff, lowerBounds]
 
-def sInf_preserves_inf :  ∀ (a b : X), sInf {x | ∃ j ∈ s, j a ⊓ j b = x} =
-    sInf {x | ∃ j ∈ s, j a = x} ⊓ sInf {x | ∃ j ∈ s, j b = x} := by
+def sInf_preserves_inf : ∀ (x y : X), sInf_fun s (x ⊓ y) = sInf_fun s x ⊓ sInf_fun s y := by
+  simp only [sInf_fun, InfHomClass.map_inf]
   intro x y
   apply le_antisymm
   · simp_all only [le_inf_iff, le_sInf_iff, Set.mem_setOf_eq, sInf_le_iff, lowerBounds,
     forall_exists_index, and_imp, forall_apply_eq_imp_iff₂, implies_true, and_self]
-  · simp only [le_sInf_iff, Set.mem_setOf_eq, forall_exists_index, and_imp,
-    forall_apply_eq_imp_iff₂, le_inf_iff]
+  · simp [le_sInf_iff]
     intro a ha
     apply And.intro
     · apply inf_le_of_left_le
@@ -140,11 +143,6 @@ def sInf_preserves_inf :  ∀ (a b : X), sInf {x | ∃ j ∈ s, j a ⊓ j b = x}
       simp_all [sInf_le_iff, lowerBounds]
 
 instance : InfSet (Nucleus X) where
-  sInf s := {
-    toFun x := sInf {j x | j ∈ s}
-    le_apply' x := (by simp [le_apply])
-    idempotent' := sInf_fun_idempotent
-    map_inf'  := (by simp; exact sInf_preserves_inf)
-  }
+  sInf s := ⟨⟨sInf_fun s, sInf_preserves_inf⟩, sInf_fun_idempotent, sInf_fun_increasing⟩
 
 end Nucleus

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -131,8 +131,12 @@ instance : InfSet (Nucleus X) where
 
 theorem sInf_apply (s : Set (Nucleus X)) (x : X) : sInf s x = ⨅ j ∈ s, j x := rfl
 
-theorem iInf_apply {ι : Type*} (s : ι → (Nucleus X)) (x : X) :
-    iInf s x = ⨅ j ∈ Set.range s, j x := by simp [iInf, sInf_apply]
+theorem iInf_apply {ι : Type*} (f : ι → (Nucleus X)) (x : X) :
+    iInf f x = ⨅ j, f j x := by
+  simp only [iInf, sInf_apply]
+  apply le_antisymm
+  all_goals simp_all [sInf_le_iff, lowerBounds]
+  exact fun a b a_1 a_2 a_3 ↦ le_of_le_of_eq (a_1 a_2) (congrFun (congrArg DFunLike.coe a_3) x)
 
 instance : CompleteSemilatticeInf (Nucleus X) where
   sInf_le := (by simp_all [LE.le, sInf_apply, iInf_le_iff])

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -111,9 +111,11 @@ instance : BoundedOrder (Nucleus X) where
   bot_le _ _ := le_apply
   le_top _ _ := by simp
 
-variable {s : Set (Nucleus X)}
 
+/-- The function of the Nucleus corresponding to the infimum of `s` -/
 def sInf_fun (s : Set (Nucleus X)) (x : X) := sInf {j x | j ∈ s}
+
+variable {s : Set (Nucleus X)}
 
 lemma sInf_fun_idempotent (x : X) : sInf_fun s (sInf_fun s x) ≤ sInf_fun s x := by
   simp only [sInf_fun, le_sInf_iff, Set.mem_setOf_eq, forall_exists_index, and_imp,

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -114,21 +114,21 @@ instance : BoundedOrder (Nucleus X) where
 instance : InfSet (Nucleus X) where
   sInf s :=
   { toFun x := ⨅ j ∈ s, j x,
-    map_inf' x y:= (by
+    map_inf' x y := by
       simp only [InfHomClass.map_inf]
       apply le_antisymm
       · simp_all only [le_inf_iff, le_iInf_iff, iInf_le_iff, implies_true, and_self]
       · simp only [le_iInf_iff, le_inf_iff]
         refine fun _ _ ↦ ⟨inf_le_of_left_le ?_, inf_le_of_right_le ?_⟩
-        all_goals simp_all [iInf_le_iff])
-    idempotent' x := (by
+        all_goals simp_all [iInf_le_iff]
+    idempotent' x := by
       simp only [le_iInf_iff, iInf_le_iff]
       intro a ha b h
       rw [← idempotent]
       apply le_trans (h a ha)
       gcongr
-      simp_all [iInf_le_iff])
-    le_apply' x := (by simp [le_apply])}
+      simp_all [iInf_le_iff]
+    le_apply' x := by simp [le_apply]}
 
 theorem sInf_apply (s : Set (Nucleus X)) (x : X) : sInf s x = ⨅ j ∈ s, j x := rfl
 

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -119,12 +119,8 @@ instance : InfSet (Nucleus X) where
       apply le_antisymm
       · simp_all only [le_inf_iff, le_iInf_iff, iInf_le_iff, implies_true, and_self]
       · simp only [le_iInf_iff, le_inf_iff]
-        intro a ha
-        constructor
-        · apply inf_le_of_left_le
-          simp_all [iInf_le_iff, lowerBounds]
-        · apply inf_le_of_right_le
-          simp_all [iInf_le_iff, lowerBounds])
+        refine fun _ _ ↦ ⟨inf_le_of_left_le ?_, inf_le_of_right_le ?_⟩
+        all_goals simp_all [iInf_le_iff])
     idempotent' x := (by
       simp only [le_iInf_iff, iInf_le_iff]
       intro a ha b h

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -132,6 +132,9 @@ instance : InfSet (Nucleus X) where
 
 theorem sInf_apply (s : Set (Nucleus X)) (x : X) : sInf s x = ⨅ j ∈ s, j x := rfl
 
+theorem iInf_apply {ι : Type*} (s : ι → (Nucleus X)) (x : X) :
+    iInf s x = ⨅ j ∈ Set.range s, j x := by simp [iInf, sInf_apply]
+
 instance : CompleteSemilatticeInf (Nucleus X) where
   sInf_le := (by simp_all [LE.le, sInf_apply, iInf_le_iff])
   le_sInf := (by simp_all [LE.le, sInf_apply])

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -146,4 +146,6 @@ instance : CompleteSemilatticeInf (Nucleus X) where
   sInf_le := (by simp_all [sInf, LE.le, sInf_fun, sInf_le_iff,lowerBounds])
   le_sInf := (by simp_all [sInf, sInf_fun, LE.le])
 
+instance : CompleteLattice (Nucleus X) := completeLatticeOfCompleteSemilatticeInf (Nucleus X)
+
 end Nucleus

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -113,28 +113,25 @@ instance : BoundedOrder (Nucleus X) where
 
 variable {s : Set (Nucleus X)}
 
-def sInf_fun (s : Set (Nucleus X)) (x : X) := sInf {j x | j ∈ s}
-
-def sInf_fun_increasing : ∀ (x : X), x ≤ sInf_fun s x := by
-  simp [sInf_fun, le_apply]
-
-def sInf_fun_idempotent : ∀ (x : X), sInf_fun s (sInf_fun s x) ≤ sInf_fun s x := by
+def sInf_fun_idempotent : ∀ (x : X), sInf {x_1 | ∃ j ∈ s, j (sInf {x_2 | ∃ j ∈ s, j x = x_2}) = x_1}
+    ≤ sInf {x_1 | ∃ j ∈ s, j x = x_1} := by
   intro x
-  simp only [sInf_fun, le_sInf_iff, Set.mem_setOf_eq, forall_exists_index, and_imp,
-    forall_apply_eq_imp_iff₂, sInf_le_iff, lowerBounds]
+  simp only [le_sInf_iff, Set.mem_setOf_eq, sInf_le_iff, lowerBounds, forall_exists_index, and_imp,
+    forall_apply_eq_imp_iff₂]
   intro a ha b h
   rw [← idempotent]
   apply le_trans (h a ha)
   refine OrderHomClass.GCongr.mono a ?_
   simp_all [sInf_le_iff, lowerBounds]
 
-def sInf_preserves_inf : ∀ (x y : X), sInf_fun s (x ⊓ y) = sInf_fun s x ⊓ sInf_fun s y := by
-  simp only [sInf_fun, InfHomClass.map_inf]
+def sInf_preserves_inf :  ∀ (a b : X), sInf {x | ∃ j ∈ s, j a ⊓ j b = x} =
+    sInf {x | ∃ j ∈ s, j a = x} ⊓ sInf {x | ∃ j ∈ s, j b = x} := by
   intro x y
   apply le_antisymm
   · simp_all only [le_inf_iff, le_sInf_iff, Set.mem_setOf_eq, sInf_le_iff, lowerBounds,
     forall_exists_index, and_imp, forall_apply_eq_imp_iff₂, implies_true, and_self]
-  · simp [le_sInf_iff]
+  · simp only [le_sInf_iff, Set.mem_setOf_eq, forall_exists_index, and_imp,
+    forall_apply_eq_imp_iff₂, le_inf_iff]
     intro a ha
     apply And.intro
     · apply inf_le_of_left_le
@@ -143,6 +140,11 @@ def sInf_preserves_inf : ∀ (x y : X), sInf_fun s (x ⊓ y) = sInf_fun s x ⊓ 
       simp_all [sInf_le_iff, lowerBounds]
 
 instance : InfSet (Nucleus X) where
-  sInf s := ⟨⟨sInf_fun s, sInf_preserves_inf⟩, sInf_fun_idempotent, sInf_fun_increasing⟩
+  sInf s := {
+    toFun x := sInf {j x | j ∈ s}
+    le_apply' x := (by simp [le_apply])
+    idempotent' := sInf_fun_idempotent
+    map_inf'  := (by simp; exact sInf_preserves_inf)
+  }
 
 end Nucleus

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -111,42 +111,34 @@ instance : BoundedOrder (Nucleus X) where
   bot_le _ _ := le_apply
   le_top _ _ := by simp
 
-
-/-- The function of the Nucleus corresponding to the infimum of `s` -/
-def sInf_fun (s : Set (Nucleus X)) (x : X) := sInf {j x | j ∈ s}
-
-variable {s : Set (Nucleus X)}
-
-lemma sInf_fun_idempotent (x : X) : sInf_fun s (sInf_fun s x) ≤ sInf_fun s x := by
-  simp only [sInf_fun, le_sInf_iff, Set.mem_setOf_eq, forall_exists_index, and_imp,
-    forall_apply_eq_imp_iff₂, sInf_le_iff, lowerBounds]
-  intro a ha b h
-  rw [← idempotent]
-  apply le_trans (h a ha)
-  gcongr
-  simp_all [sInf_le_iff, lowerBounds]
-
-lemma sInf_fun_map_inf (x y : X): sInf_fun s (x ⊓ y) = sInf_fun s x ⊓ sInf_fun s y := by
-  simp only [sInf_fun, InfHomClass.map_inf]
-  apply le_antisymm
-  · -- squeezed because of performance
-    simp_all only [le_inf_iff, le_sInf_iff, Set.mem_setOf_eq, sInf_le_iff, lowerBounds,
-    forall_exists_index, and_imp, forall_apply_eq_imp_iff₂, implies_true, and_self]
-  · simp only [le_sInf_iff, Set.mem_setOf_eq, forall_exists_index, and_imp,
-    forall_apply_eq_imp_iff₂, le_inf_iff]
-    intro a ha
-    constructor
-    · apply inf_le_of_left_le
-      simp_all [sInf_le_iff, lowerBounds]
-    · apply inf_le_of_right_le
-      simp_all [sInf_le_iff, lowerBounds]
-
 instance : InfSet (Nucleus X) where
-  sInf s := ⟨⟨sInf_fun s, sInf_fun_map_inf⟩, sInf_fun_idempotent, (by simp[sInf_fun,le_apply])⟩
+  sInf s :=
+  { toFun x := ⨅ j ∈ s, j x,
+    map_inf' x y:= (by
+      simp only [InfHomClass.map_inf]
+      apply le_antisymm
+      · simp_all only [le_inf_iff, le_iInf_iff, iInf_le_iff, implies_true, and_self]
+      · simp only [le_iInf_iff, le_inf_iff]
+        intro a ha
+        constructor
+        · apply inf_le_of_left_le
+          simp_all [iInf_le_iff, lowerBounds]
+        · apply inf_le_of_right_le
+          simp_all [iInf_le_iff, lowerBounds])
+    idempotent' x := (by
+      simp only [le_iInf_iff, iInf_le_iff]
+      intro a ha b h
+      rw [← idempotent]
+      apply le_trans (h a ha)
+      gcongr
+      simp_all [iInf_le_iff])
+    le_apply' x := (by simp [le_apply])}
+
+theorem sInf_apply (s : Set (Nucleus X)) (x : X) : sInf s x = ⨅ j ∈ s, j x := rfl
 
 instance : CompleteSemilatticeInf (Nucleus X) where
-  sInf_le := (by simp_all [sInf, LE.le, sInf_fun, sInf_le_iff,lowerBounds])
-  le_sInf := (by simp_all [sInf, sInf_fun, LE.le])
+  sInf_le := (by simp_all [LE.le, sInf_apply, iInf_le_iff])
+  le_sInf := (by simp_all [LE.le, sInf_apply])
 
 instance : CompleteLattice (Nucleus X) := completeLatticeOfCompleteSemilatticeInf (Nucleus X)
 

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -113,14 +113,13 @@ instance : BoundedOrder (Nucleus X) where
 
 instance : InfSet (Nucleus X) where
   sInf s :=
-  { toFun x := ⨅ j ∈ s, j x,
+  { toFun x := ⨅ f ∈ s, f x,
     map_inf' x y := by
-      simp only [InfHomClass.map_inf]
-      apply le_antisymm
-      · simp_all only [le_inf_iff, le_iInf_iff, iInf_le_iff, implies_true, and_self]
-      · simp only [le_iInf_iff, le_inf_iff]
-        refine fun _ _ ↦ ⟨inf_le_of_left_le ?_, inf_le_of_right_le ?_⟩
-        all_goals simp_all [iInf_le_iff]
+      simp only [InfHomClass.map_inf, le_antisymm_iff, le_inf_iff, le_iInf_iff]
+      refine ⟨⟨?_, ?_⟩, ?_⟩ <;> rintro f hf
+      · exact iInf₂_le_of_le f hf inf_le_left
+      · exact iInf₂_le_of_le f hf inf_le_right
+      · exact ⟨inf_le_of_left_le <| iInf₂_le f hf, inf_le_of_right_le <| iInf₂_le f hf⟩
     idempotent' x := by
       simp only [le_iInf_iff, iInf_le_iff]
       intro a ha b h

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -115,35 +115,33 @@ variable {s : Set (Nucleus X)}
 
 def sInf_fun (s : Set (Nucleus X)) (x : X) := sInf {j x | j ∈ s}
 
-def sInf_fun_increasing : ∀ (x : X), x ≤ sInf_fun s x := by
-  simp [sInf_fun, le_apply]
-
-def sInf_fun_idempotent : ∀ (x : X), sInf_fun s (sInf_fun s x) ≤ sInf_fun s x := by
-  intro x
+lemma sInf_fun_idempotent (x : X) : sInf_fun s (sInf_fun s x) ≤ sInf_fun s x := by
   simp only [sInf_fun, le_sInf_iff, Set.mem_setOf_eq, forall_exists_index, and_imp,
     forall_apply_eq_imp_iff₂, sInf_le_iff, lowerBounds]
   intro a ha b h
   rw [← idempotent]
   apply le_trans (h a ha)
-  refine OrderHomClass.GCongr.mono a ?_
+  gcongr
   simp_all [sInf_le_iff, lowerBounds]
 
-def sInf_preserves_inf : ∀ (x y : X), sInf_fun s (x ⊓ y) = sInf_fun s x ⊓ sInf_fun s y := by
+lemma sInf_fun_map_inf : ∀ (x y : X), sInf_fun s (x ⊓ y) = sInf_fun s x ⊓ sInf_fun s y := by
   simp only [sInf_fun, InfHomClass.map_inf]
   intro x y
   apply le_antisymm
-  · simp_all only [le_inf_iff, le_sInf_iff, Set.mem_setOf_eq, sInf_le_iff, lowerBounds,
+  · -- squeezed because of performance
+    simp_all only [le_inf_iff, le_sInf_iff, Set.mem_setOf_eq, sInf_le_iff, lowerBounds,
     forall_exists_index, and_imp, forall_apply_eq_imp_iff₂, implies_true, and_self]
-  · simp [le_sInf_iff]
+  · simp only [le_sInf_iff, Set.mem_setOf_eq, forall_exists_index, and_imp,
+    forall_apply_eq_imp_iff₂, le_inf_iff]
     intro a ha
-    apply And.intro
+    constructor
     · apply inf_le_of_left_le
       simp_all [sInf_le_iff, lowerBounds]
     · apply inf_le_of_right_le
       simp_all [sInf_le_iff, lowerBounds]
 
 instance : InfSet (Nucleus X) where
-  sInf s := ⟨⟨sInf_fun s, sInf_preserves_inf⟩, sInf_fun_idempotent, sInf_fun_increasing⟩
+  sInf s := ⟨⟨sInf_fun s, sInf_fun_map_inf⟩, sInf_fun_idempotent, (by simp[sInf_fun,le_apply])⟩
 
 instance : CompleteSemilatticeInf (Nucleus X) where
   sInf_le := (by simp_all [sInf, LE.le, sInf_fun, sInf_le_iff,lowerBounds])

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -111,4 +111,38 @@ instance : BoundedOrder (Nucleus X) where
   bot_le _ _ := le_apply
   le_top _ _ := by simp
 
+variable {s : Set (Nucleus X)}
+
+def sInf_fun (s : Set (Nucleus X)) (x : X) := sInf {j x | j ∈ s}
+
+def sInf_fun_increasing : ∀ (x : X), x ≤ sInf_fun s x := by
+  simp [sInf_fun, le_apply]
+
+def sInf_fun_idempotent : ∀ (x : X), sInf_fun s (sInf_fun s x) ≤ sInf_fun s x := by
+  intro x
+  simp only [sInf_fun, le_sInf_iff, Set.mem_setOf_eq, forall_exists_index, and_imp,
+    forall_apply_eq_imp_iff₂, sInf_le_iff, lowerBounds]
+  intro a ha b h
+  rw [← idempotent]
+  apply le_trans (h a ha)
+  refine OrderHomClass.GCongr.mono a ?_
+  simp_all [sInf_le_iff, lowerBounds]
+
+def sInf_preserves_inf : ∀ (x y : X), sInf_fun s (x ⊓ y) = sInf_fun s x ⊓ sInf_fun s y := by
+  simp only [sInf_fun, InfHomClass.map_inf]
+  intro x y
+  apply le_antisymm
+  · simp_all only [le_inf_iff, le_sInf_iff, Set.mem_setOf_eq, sInf_le_iff, lowerBounds,
+    forall_exists_index, and_imp, forall_apply_eq_imp_iff₂, implies_true, and_self]
+  · simp [le_sInf_iff]
+    intro a ha
+    apply And.intro
+    · apply inf_le_of_left_le
+      simp_all [sInf_le_iff, lowerBounds]
+    · apply inf_le_of_right_le
+      simp_all [sInf_le_iff, lowerBounds]
+
+instance : InfSet (Nucleus X) where
+  sInf s := ⟨⟨sInf_fun s, sInf_preserves_inf⟩, sInf_fun_idempotent, sInf_fun_increasing⟩
+
 end Nucleus

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -145,4 +145,8 @@ def sInf_preserves_inf : ∀ (x y : X), sInf_fun s (x ⊓ y) = sInf_fun s x ⊓ 
 instance : InfSet (Nucleus X) where
   sInf s := ⟨⟨sInf_fun s, sInf_preserves_inf⟩, sInf_fun_idempotent, sInf_fun_increasing⟩
 
+instance : CompleteSemilatticeInf (Nucleus X) where
+  sInf_le := (by simp_all [sInf, LE.le, sInf_fun, sInf_le_iff,lowerBounds])
+  le_sInf := (by simp_all [sInf, sInf_fun, LE.le])
+
 end Nucleus

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -124,9 +124,8 @@ lemma sInf_fun_idempotent (x : X) : sInf_fun s (sInf_fun s x) ≤ sInf_fun s x :
   gcongr
   simp_all [sInf_le_iff, lowerBounds]
 
-lemma sInf_fun_map_inf : ∀ (x y : X), sInf_fun s (x ⊓ y) = sInf_fun s x ⊓ sInf_fun s y := by
+lemma sInf_fun_map_inf (x y : X): sInf_fun s (x ⊓ y) = sInf_fun s x ⊓ sInf_fun s y := by
   simp only [sInf_fun, InfHomClass.map_inf]
-  intro x y
   apply le_antisymm
   · -- squeezed because of performance
     simp_all only [le_inf_iff, le_sInf_iff, Set.mem_setOf_eq, sInf_le_iff, lowerBounds,

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -129,9 +129,9 @@ instance : InfSet (Nucleus X) where
       simp_all [iInf_le_iff]
     le_apply' x := by simp [le_apply]}
 
-theorem sInf_apply (s : Set (Nucleus X)) (x : X) : sInf s x = ⨅ j ∈ s, j x := rfl
+@[simp] theorem sInf_apply (s : Set (Nucleus X)) (x : X) : sInf s x = ⨅ j ∈ s, j x := rfl
 
-theorem iInf_apply {ι : Type*} (f : ι → (Nucleus X)) (x : X) :
+@[simp] theorem iInf_apply {ι : Type*} (f : ι → (Nucleus X)) (x : X) :
     iInf f x = ⨅ j, f j x := by
   simp only [iInf, sInf_apply]
   apply le_antisymm
@@ -139,8 +139,8 @@ theorem iInf_apply {ι : Type*} (f : ι → (Nucleus X)) (x : X) :
   exact fun a b a_1 a_2 a_3 ↦ le_of_le_of_eq (a_1 a_2) (congrFun (congrArg DFunLike.coe a_3) x)
 
 instance : CompleteSemilatticeInf (Nucleus X) where
-  sInf_le := (by simp_all [LE.le, sInf_apply, iInf_le_iff])
-  le_sInf := (by simp_all [LE.le, sInf_apply])
+  sInf_le := by simp_all [← coe_le_coe, Pi.le_def, iInf_le_iff]
+  le_sInf := by simp_all [← coe_le_coe, Pi.le_def]
 
 instance : CompleteLattice (Nucleus X) := completeLatticeOfCompleteSemilatticeInf (Nucleus X)
 

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -42,7 +42,7 @@ class NucleusClass (F X : Type*) [SemilatticeInf X] [FunLike F X X] extends InfH
     Prop where
   /-- A nucleus is idempotent. -/
   idempotent (x : X) (f : F) : f (f x) ≤ f x
-  /-- A nucleus is increasing. -/
+  /-- A nucleus is inflationary. -/
   le_apply (x : X) (f : F) : x ≤ f x
 
 namespace Nucleus
@@ -71,6 +71,8 @@ lemma idempotent : n (n x) = n x :=
 
 lemma le_apply : x ≤ n x :=
   n.toClosureOperator.le_closure x
+
+lemma monotone : Monotone n := n.toClosureOperator.monotone
 
 lemma map_inf : n (x ⊓ y) = n x ⊓ n y :=
   InfHomClass.map_inf n x y
@@ -120,27 +122,17 @@ instance : InfSet (Nucleus X) where
       · exact iInf₂_le_of_le f hf inf_le_left
       · exact iInf₂_le_of_le f hf inf_le_right
       · exact ⟨inf_le_of_left_le <| iInf₂_le f hf, inf_le_of_right_le <| iInf₂_le f hf⟩
-    idempotent' x := by
-      simp only [le_iInf_iff, iInf_le_iff]
-      intro a ha b h
-      rw [← idempotent]
-      apply le_trans (h a ha)
-      gcongr
-      simp_all [iInf_le_iff]
-    le_apply' x := by simp [le_apply]}
+    idempotent' x := iInf₂_mono fun f hf ↦ (f.monotone <| iInf₂_le f hf).trans_eq f.idempotent
+    le_apply' x := by simp [le_apply] }
 
 @[simp] theorem sInf_apply (s : Set (Nucleus X)) (x : X) : sInf s x = ⨅ j ∈ s, j x := rfl
 
-@[simp] theorem iInf_apply {ι : Type*} (f : ι → (Nucleus X)) (x : X) :
-    iInf f x = ⨅ j, f j x := by
-  simp only [iInf, sInf_apply]
-  apply le_antisymm
-  all_goals simp_all [sInf_le_iff, lowerBounds]
-  exact fun a b a_1 a_2 a_3 ↦ le_of_le_of_eq (a_1 a_2) (congrFun (congrArg DFunLike.coe a_3) x)
+@[simp] theorem iInf_apply {ι : Type*} (f : ι → (Nucleus X)) (x : X) : iInf f x = ⨅ j, f j x := by
+  rw [iInf, sInf_apply, iInf_range]
 
 instance : CompleteSemilatticeInf (Nucleus X) where
-  sInf_le := by simp_all [← coe_le_coe, Pi.le_def, iInf_le_iff]
-  le_sInf := by simp_all [← coe_le_coe, Pi.le_def]
+  sInf_le := by simp +contextual [← coe_le_coe, Pi.le_def, iInf_le_iff]
+  le_sInf := by simp +contextual [← coe_le_coe, Pi.le_def]
 
 instance : CompleteLattice (Nucleus X) := completeLatticeOfCompleteSemilatticeInf (Nucleus X)
 


### PR DESCRIPTION
Arbitrary meets of nuclei can be defined pointwise. Joins are harder to describe explicitely, so `completeLatticeOfCompleteSemilatticeInf` is used to create the `CompleteLattice` instance.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
