### PR TITLE
[Merged by Bors] - chore(Analysis/InnerProductSpace): split off continuity, convexity of inner product

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1404,6 +1404,8 @@ import Mathlib.Analysis.InnerProductSpace.Basic
 import Mathlib.Analysis.InnerProductSpace.Calculus
 import Mathlib.Analysis.InnerProductSpace.Completion
 import Mathlib.Analysis.InnerProductSpace.ConformalLinearMap
+import Mathlib.Analysis.InnerProductSpace.Continuous
+import Mathlib.Analysis.InnerProductSpace.Convex
 import Mathlib.Analysis.InnerProductSpace.Defs
 import Mathlib.Analysis.InnerProductSpace.Dual
 import Mathlib.Analysis.InnerProductSpace.EuclideanDist

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Analysis.Complex.CauchyIntegral
+import Mathlib.Analysis.InnerProductSpace.Convex
 import Mathlib.Analysis.NormedSpace.Extr
 import Mathlib.Data.Complex.FiniteDimensional
 import Mathlib.Topology.Order.ExtrClosure

--- a/Mathlib/Analysis/Complex/Arg.lean
+++ b/Mathlib/Analysis/Complex/Arg.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Eric Rodriguez. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Rodriguez
 -/
-import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.InnerProductSpace.Convex
 import Mathlib.Analysis.SpecialFunctions.Complex.Arg
 
 /-!

--- a/Mathlib/Analysis/Convex/Measure.lean
+++ b/Mathlib/Analysis/Convex/Measure.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
+import Mathlib.Analysis.Convex.Normed
 import Mathlib.Analysis.Convex.Topology
 import Mathlib.Analysis.Normed.Affine.AddTorsorBases
 import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar

--- a/Mathlib/Analysis/Convex/Strong.lean
+++ b/Mathlib/Analysis/Convex/Strong.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Yaël Dillies, Chenyi Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chenyi Li, Ziyu Wang, Yaël Dillies
 -/
+import Mathlib.Analysis.Convex.Function
 import Mathlib.Analysis.InnerProductSpace.Basic
 
 /-!

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou, Sébastien Gouëzel, Frédéric Dupuis
 -/
 
+import Mathlib.Algebra.EuclideanDomain.Field
 import Mathlib.Analysis.Complex.Basic
-import Mathlib.Analysis.Convex.Uniform
 import Mathlib.Analysis.InnerProductSpace.Defs
-import Mathlib.Analysis.Normed.Operator.BoundedLinearMaps
+import Mathlib.GroupTheory.MonoidLocalization.Basic
 
 /-!
 # Properties of inner product spaces
@@ -20,8 +20,6 @@ This file proves many basic properties of inner product spaces (real or complex)
 - `norm_inner_eq_norm_iff`: the equality criteion in the Cauchy-Schwartz inequality (also in many
   variants).
 - `inner_eq_sum_norm_sq_div_four`: the polarization identity.
-- We show that the inner product is continuous, `continuous_inner`, and bundle it as the
-  continuous sesquilinear map `innerSL` (see also `innerₛₗ` for the non-continuous version).
 
 ## Tags
 
@@ -488,19 +486,6 @@ theorem inner_eq_sum_norm_sq_div_four (x y : E) :
   push_cast
   simp only [sq, ← mul_div_right_comm, ← add_div]
 
--- See note [lower instance priority]
-instance (priority := 100) InnerProductSpace.toUniformConvexSpace : UniformConvexSpace F :=
-  ⟨fun ε hε => by
-    refine
-      ⟨2 - √(4 - ε ^ 2), sub_pos_of_lt <| (sqrt_lt' zero_lt_two).2 ?_, fun x hx y hy hxy => ?_⟩
-    · norm_num
-      exact pow_pos hε _
-    rw [sub_sub_cancel]
-    refine le_sqrt_of_sq_le ?_
-    rw [sq, eq_sub_iff_add_eq.2 (parallelogram_law_with_norm ℝ x y), ← sq ‖x - y‖, hx, hy]
-    ring_nf
-    gcongr⟩
-
 /-- Polarization identity: The real inner product, in terms of the norm. -/
 theorem real_inner_eq_norm_add_mul_self_sub_norm_mul_self_sub_norm_mul_self_div_two (x y : F) :
     ⟪x, y⟫_ℝ = (‖x + y‖ * ‖x + y‖ - ‖x‖ * ‖x‖ - ‖y‖ * ‖y‖) / 2 :=
@@ -591,27 +576,6 @@ theorem real_inner_smul_self_left (x : F) (r : ℝ) : ⟪r • x, x⟫_ℝ = r *
 /-- The inner product of a vector with a multiple of itself. -/
 theorem real_inner_smul_self_right (x : F) (r : ℝ) : ⟪x, r • x⟫_ℝ = r * (‖x‖ * ‖x‖) := by
   rw [inner_smul_right, ← real_inner_self_eq_norm_mul_norm]
-
-/-- When an inner product space `E` over `𝕜` is considered as a real normed space, its inner
-product satisfies `IsBoundedBilinearMap`.
-
-In order to state these results, we need a `NormedSpace ℝ E` instance. We will later establish
-such an instance by restriction-of-scalars, `InnerProductSpace.rclikeToReal 𝕜 E`, but this
-instance may be not definitionally equal to some other “natural” instance. So, we assume
-`[NormedSpace ℝ E]`.
--/
-theorem _root_.isBoundedBilinearMap_inner [NormedSpace ℝ E] [IsScalarTower ℝ 𝕜 E] :
-    IsBoundedBilinearMap ℝ fun p : E × E => ⟪p.1, p.2⟫ :=
-  { add_left := inner_add_left
-    smul_left := fun r x y => by
-      simp only [← algebraMap_smul 𝕜 r x, algebraMap_eq_ofReal, inner_smul_real_left]
-    add_right := inner_add_right
-    smul_right := fun r x y => by
-      simp only [← algebraMap_smul 𝕜 r y, algebraMap_eq_ofReal, inner_smul_real_right]
-    bound :=
-      ⟨1, zero_lt_one, fun x y => by
-        rw [one_mul]
-        exact norm_inner_le_norm x y⟩ }
 
 /-- The inner product of two weighted sums, where the weights in each
 sum add to 0, in terms of the norms of pairwise differences. -/
@@ -925,43 +889,3 @@ noncomputable instance RCLike.toInnerProductSpaceReal : InnerProductSpace ℝ �
 example : (innerProductSpace : InnerProductSpace ℝ ℝ) = RCLike.toInnerProductSpaceReal := rfl
 example :
   (instInnerProductSpaceRealComplex : InnerProductSpace ℝ ℂ) = RCLike.toInnerProductSpaceReal := rfl
-
-section Continuous
-
-variable [SeminormedAddCommGroup E] [InnerProductSpace 𝕜 E]
-
-local notation "⟪" x ", " y "⟫" => @inner 𝕜 _ _ x y
-
-/-!
-### Continuity of the inner product
--/
-
-theorem continuous_inner : Continuous fun p : E × E => ⟪p.1, p.2⟫ :=
-  letI : InnerProductSpace ℝ E := InnerProductSpace.rclikeToReal 𝕜 E
-  letI : IsScalarTower ℝ 𝕜 E := RestrictScalars.isScalarTower _ _ _
-  isBoundedBilinearMap_inner.continuous
-
-variable {α : Type*}
-
-theorem Filter.Tendsto.inner {f g : α → E} {l : Filter α} {x y : E} (hf : Tendsto f l (𝓝 x))
-    (hg : Tendsto g l (𝓝 y)) : Tendsto (fun t => ⟪f t, g t⟫) l (𝓝 ⟪x, y⟫) :=
-  (continuous_inner.tendsto _).comp (hf.prod_mk_nhds hg)
-
-variable [TopologicalSpace α] {f g : α → E} {x : α} {s : Set α}
-
-theorem ContinuousWithinAt.inner (hf : ContinuousWithinAt f s x) (hg : ContinuousWithinAt g s x) :
-    ContinuousWithinAt (fun t => ⟪f t, g t⟫) s x :=
-  Filter.Tendsto.inner hf hg
-
-theorem ContinuousAt.inner (hf : ContinuousAt f x) (hg : ContinuousAt g x) :
-    ContinuousAt (fun t => ⟪f t, g t⟫) x :=
-  Filter.Tendsto.inner hf hg
-
-theorem ContinuousOn.inner (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
-    ContinuousOn (fun t => ⟪f t, g t⟫) s := fun x hx => (hf x hx).inner (hg x hx)
-
-@[continuity]
-theorem Continuous.inner (hf : Continuous f) (hg : Continuous g) : Continuous fun t => ⟪f t, g t⟫ :=
-  continuous_iff_continuousAt.2 fun _x => hf.continuousAt.inner hg.continuousAt
-
-end Continuous

--- a/Mathlib/Analysis/InnerProductSpace/Continuous.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Continuous.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2019 Zhouhang Zhou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhouhang Zhou, Sébastien Gouëzel, Frédéric Dupuis
+-/
+
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.Normed.Operator.BoundedLinearMaps
+
+/-!
+# Continuity of inner product
+
+We show that the inner product is continuous, `continuous_inner`.
+
+## Tags
+
+inner product space, Hilbert space, norm
+
+-/
+
+noncomputable section
+
+open RCLike Real Filter Topology ComplexConjugate Finsupp
+open LinearMap renaming BilinForm → BilinForm
+
+variable {𝕜 E F : Type*} [RCLike 𝕜]
+
+
+section Continuous
+
+variable [SeminormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+local notation "⟪" x ", " y "⟫" => @inner 𝕜 _ _ x y
+
+/-!
+### Continuity of the inner product
+-/
+
+/-- When an inner product space `E` over `𝕜` is considered as a real normed space, its inner
+product satisfies `IsBoundedBilinearMap`.
+
+In order to state these results, we need a `NormedSpace ℝ E` instance. We will later establish
+such an instance by restriction-of-scalars, `InnerProductSpace.rclikeToReal 𝕜 E`, but this
+instance may be not definitionally equal to some other “natural” instance. So, we assume
+`[NormedSpace ℝ E]`.
+-/
+theorem _root_.isBoundedBilinearMap_inner [NormedSpace ℝ E] [IsScalarTower ℝ 𝕜 E] :
+    IsBoundedBilinearMap ℝ fun p : E × E => ⟪p.1, p.2⟫ :=
+  { add_left := inner_add_left
+    smul_left := fun r x y => by
+      simp only [← algebraMap_smul 𝕜 r x, algebraMap_eq_ofReal, inner_smul_real_left]
+    add_right := inner_add_right
+    smul_right := fun r x y => by
+      simp only [← algebraMap_smul 𝕜 r y, algebraMap_eq_ofReal, inner_smul_real_right]
+    bound :=
+      ⟨1, zero_lt_one, fun x y => by
+        rw [one_mul]
+        exact norm_inner_le_norm x y⟩ }
+
+theorem continuous_inner : Continuous fun p : E × E => ⟪p.1, p.2⟫ :=
+  letI : InnerProductSpace ℝ E := InnerProductSpace.rclikeToReal 𝕜 E
+  letI : IsScalarTower ℝ 𝕜 E := RestrictScalars.isScalarTower _ _ _
+  isBoundedBilinearMap_inner.continuous
+
+variable {α : Type*}
+
+theorem Filter.Tendsto.inner {f g : α → E} {l : Filter α} {x y : E} (hf : Tendsto f l (𝓝 x))
+    (hg : Tendsto g l (𝓝 y)) : Tendsto (fun t => ⟪f t, g t⟫) l (𝓝 ⟪x, y⟫) :=
+  (continuous_inner.tendsto _).comp (hf.prod_mk_nhds hg)
+
+variable [TopologicalSpace α] {f g : α → E} {x : α} {s : Set α}
+
+theorem ContinuousWithinAt.inner (hf : ContinuousWithinAt f s x) (hg : ContinuousWithinAt g s x) :
+    ContinuousWithinAt (fun t => ⟪f t, g t⟫) s x :=
+  Filter.Tendsto.inner hf hg
+
+theorem ContinuousAt.inner (hf : ContinuousAt f x) (hg : ContinuousAt g x) :
+    ContinuousAt (fun t => ⟪f t, g t⟫) x :=
+  Filter.Tendsto.inner hf hg
+
+theorem ContinuousOn.inner (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
+    ContinuousOn (fun t => ⟪f t, g t⟫) s := fun x hx => (hf x hx).inner (hg x hx)
+
+@[continuity]
+theorem Continuous.inner (hf : Continuous f) (hg : Continuous g) : Continuous fun t => ⟪f t, g t⟫ :=
+  continuous_iff_continuousAt.2 fun _x => hf.continuousAt.inner hg.continuousAt
+
+end Continuous
+

--- a/Mathlib/Analysis/InnerProductSpace/Convex.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Convex.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2019 Zhouhang Zhou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhouhang Zhou, Sébastien Gouëzel, Frédéric Dupuis
+-/
+
+import Mathlib.Analysis.Convex.Uniform
+import Mathlib.Analysis.InnerProductSpace.Basic
+
+/-!
+# Properties of inner product spaces
+
+## Main results
+
+- `InnerProductSpace.toUniformConvexSpace`: an inner product space is a uniformly convex space.
+
+## Tags
+
+inner product space, Hilbert space, norm
+
+-/
+
+
+noncomputable section
+
+open RCLike Real Filter Topology ComplexConjugate Finsupp
+open LinearMap (BilinForm)
+
+variable {𝕜 E F : Type*} [RCLike 𝕜] [SeminormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+  [SeminormedAddCommGroup F] [InnerProductSpace ℝ F]
+
+-- See note [lower instance priority]
+instance (priority := 100) InnerProductSpace.toUniformConvexSpace : UniformConvexSpace F :=
+  ⟨fun ε hε => by
+    refine
+      ⟨2 - √(4 - ε ^ 2), sub_pos_of_lt <| (sqrt_lt' zero_lt_two).2 ?_, fun x hx y hy hxy => ?_⟩
+    · norm_num
+      exact pow_pos hε _
+    rw [sub_sub_cancel]
+    refine le_sqrt_of_sq_le ?_
+    rw [sq, eq_sub_iff_add_eq.2 (parallelogram_law_with_norm ℝ x y), ← sq ‖x - y‖, hx, hy]
+    ring_nf
+    gcongr⟩
+

--- a/Mathlib/Analysis/InnerProductSpace/Convex.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Convex.lean
@@ -8,7 +8,7 @@ import Mathlib.Analysis.Convex.Uniform
 import Mathlib.Analysis.InnerProductSpace.Basic
 
 /-!
-# Properties of inner product spaces
+# Convexity properties of inner product spaces
 
 ## Main results
 

--- a/Mathlib/Analysis/InnerProductSpace/LinearMap.lean
+++ b/Mathlib/Analysis/InnerProductSpace/LinearMap.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou, Sébastien Gouëzel, Frédéric Dupuis
 -/
 
-import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.InnerProductSpace.Continuous
 
 /-!
 # Linear maps on inner product spaces

--- a/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
+++ b/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Heather Macbeth
 -/
 import Mathlib.Topology.Algebra.Algebra
-import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.InnerProductSpace.Convex
 import Mathlib.Algebra.Module.LinearMap.Rat
 import Mathlib.Tactic.Module
 

--- a/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
@@ -5,6 +5,8 @@ Authors: Zhouhang Zhou, Sébastien Gouëzel, Frédéric Dupuis
 -/
 
 import Mathlib.Analysis.InnerProductSpace.LinearMap
+import Mathlib.LinearAlgebra.FiniteDimensional
+import Mathlib.RingTheory.LocalRing.Basic
 
 /-!
 # Orthonormal sets

--- a/Mathlib/Analysis/Quaternion.lean
+++ b/Mathlib/Analysis/Quaternion.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Eric Wieser
 -/
 import Mathlib.Algebra.Quaternion
-import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.InnerProductSpace.Continuous
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Topology.Algebra.Algebra
 

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/PosPart.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/PosPart.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
 
-import Mathlib.Topology.ContinuousMap.StarOrdered
-import Mathlib.Analysis.InnerProductSpace.Basic
-import Mathlib.Topology.ContinuousMap.StoneWeierstrass
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Unique
+import Mathlib.Analysis.InnerProductSpace.Continuous
+import Mathlib.Topology.ContinuousMap.StarOrdered
+import Mathlib.Topology.ContinuousMap.StoneWeierstrass
 
 /-! # The positive (and negative) parts of a selfadjoint element in a C⋆-algebra
 

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/PosPart.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/PosPart.lean
@@ -5,7 +5,6 @@ Authors: Jireh Loreaux
 -/
 
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Unique
-import Mathlib.Analysis.InnerProductSpace.Continuous
 import Mathlib.Topology.ContinuousMap.StarOrdered
 import Mathlib.Topology.ContinuousMap.StoneWeierstrass
 

--- a/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Yaël Dillies, Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
+import Mathlib.Analysis.InnerProductSpace.Convex
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Combinatorics.Additive.AP.Three.Defs
 import Mathlib.Combinatorics.Pigeonhole

--- a/Mathlib/Geometry/Euclidean/Inversion/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Inversion/Basic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Analysis.Normed.Group.AddTorsor
 import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.Normed.Group.AddTorsor
 import Mathlib.Tactic.AdaptationNote
 
 /-!

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 -/
 import Mathlib.Analysis.Convex.StrictConvexBetween
+import Mathlib.Analysis.InnerProductSpace.Convex
 import Mathlib.Geometry.Euclidean.Basic
 
 /-!

--- a/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
-import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.InnerProductSpace.Continuous
 import Mathlib.Analysis.Normed.Module.Dual
 import Mathlib.MeasureTheory.Function.AEEqOfLIntegral
 import Mathlib.MeasureTheory.Function.StronglyMeasurable.Lp

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.InnerProductSpace.Continuous
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Complex
 
 /-!

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Inner.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Inner.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne, Sébastien Gouëzel
 -/
+import Mathlib.Analysis.InnerProductSpace.Continuous
 import Mathlib.MeasureTheory.Function.StronglyMeasurable.AEStronglyMeasurable
-import Mathlib.Analysis.InnerProductSpace.Basic
 
 /-!
 # Inner products of strongly measurable functions are strongly measurable.


### PR DESCRIPTION
Looking at [the longest pole](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/The.20long.20pole.20in.20mathlib/near/498144514) I saw that `InnerProductSpace.Basic` imports quite a lot that isn't used in downstream files such as `Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances`. By splitting off two little files I managed to clean up the import hierarchy a bit.

This PR adds two new files:
* `InnerProductSpace/Continuous.lean`: shows that the inner product is continuous.
* `InnerProductSpace/Convex.lean`: shows that inner product spaces are uniformly convex spaces.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
