### PR TITLE
[Merged by Bors] - chore(AlgebraicTopology/AlternatingFaceMapComplex): remove shouting in docstring

### DIFF
--- a/Mathlib/AlgebraicTopology/AlternatingFaceMapComplex.lean
+++ b/Mathlib/AlgebraicTopology/AlternatingFaceMapComplex.lean
@@ -62,7 +62,7 @@ sum of the face maps -/
 def objD (n : ℕ) : X _[n + 1] ⟶ X _[n] :=
   ∑ i : Fin (n + 2), (-1 : ℤ) ^ (i : ℕ) • X.δ i
 
-/-
+/-!
 ## The chain complex relation `d ≫ d`
 -/
 

--- a/Mathlib/AlgebraicTopology/AlternatingFaceMapComplex.lean
+++ b/Mathlib/AlgebraicTopology/AlternatingFaceMapComplex.lean
@@ -62,8 +62,10 @@ sum of the face maps -/
 def objD (n : ℕ) : X _[n + 1] ⟶ X _[n] :=
   ∑ i : Fin (n + 2), (-1 : ℤ) ^ (i : ℕ) • X.δ i
 
-/-- ## The chain complex relation `d ≫ d`
+/-
+## The chain complex relation `d ≫ d`
 -/
+
 theorem d_squared (n : ℕ) : objD X (n + 1) ≫ objD X n = 0 := by
   -- we start by expanding d ≫ d as a double sum
   dsimp


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Currently the docstring for `d_squared` is very loud!

![shout2](https://github.com/user-attachments/assets/d9b1af7a-6442-4ed1-a7ef-287b045021ac)

