### PR TITLE
[Merged by Bors] - feat(Computability/CFG): deq and repr on CFR

### DIFF
--- a/Mathlib/Computability/ContextFreeGrammar.lean
+++ b/Mathlib/Computability/ContextFreeGrammar.lean
@@ -29,6 +29,7 @@ structure ContextFreeRule (T : Type uT) (N : Type uN) where
   input : N
   /-- Output string a.k.a. right-hand side. -/
   output : List (Symbol T N)
+deriving DecidableEq, Repr
 
 /-- Context-free grammar that generates words over the alphabet `T` (a type of terminals). -/
 structure ContextFreeGrammar.{uN,uT} (T : Type uT) where

--- a/Mathlib/Computability/ContextFreeGrammar.lean
+++ b/Mathlib/Computability/ContextFreeGrammar.lean
@@ -85,10 +85,6 @@ theorem rewrites_iff :
       u = p ++ [Symbol.nonterminal r.input] ++ q ∧ v = p ++ r.output ++ q :=
   ⟨Rewrites.exists_parts, by rintro ⟨p, q, rfl, rfl⟩; apply rewrites_of_exists_parts⟩
 
-lemma nonterminal_rule_if_rewrite : r.Rewrites u v → .nonterminal r.input ∈ u := by
-  simp_rw [rewrites_iff, List.append_assoc]
-  exact fun _ ↦ List.mem_iff_append.mpr (by tauto)
-
 /-- Add extra prefix to context-free rewriting. -/
 lemma Rewrites.append_left (hvw : r.Rewrites u v) (p : List (Symbol T N)) :
     r.Rewrites (p ++ u) (p ++ v) := by
@@ -167,17 +163,9 @@ lemma Derives.eq_or_head {u w : List (Symbol T g.NT)} (huw : g.Derives u w) :
     u = w ∨ ∃ v : List (Symbol T g.NT), g.Produces u v ∧ g.Derives v w :=
   Relation.ReflTransGen.cases_head huw
 
-lemma Derives.iff_eq_or_head {u w : List (Symbol T g.NT)} :
-    g.Derives u w ↔ u = w ∨ ∃ v : List (Symbol T g.NT), g.Produces u v ∧ g.Derives v w :=
-  Relation.ReflTransGen.cases_head_iff
-
 lemma Derives.eq_or_tail {u w : List (Symbol T g.NT)} (huw : g.Derives u w) :
-    w = u ∨ ∃ v : List (Symbol T g.NT), g.Derives u v ∧ g.Produces v w :=
-  Relation.ReflTransGen.cases_tail huw
-
-lemma Derives.iff_eq_or_tail {u w : List (Symbol T g.NT)} :
-    g.Derives u w ↔ w = u ∨ ∃ v : List (Symbol T g.NT), g.Derives u v ∧ g.Produces v w :=
-  Relation.ReflTransGen.cases_tail_iff g.Produces u w
+    u = w ∨ ∃ v : List (Symbol T g.NT), g.Derives u v ∧ g.Produces v w :=
+  (Relation.ReflTransGen.cases_tail huw).casesOn (Or.inl ∘ Eq.symm) Or.inr
 
 /-- Add extra prefix to context-free producing. -/
 lemma Produces.append_left {v w : List (Symbol T g.NT)}
@@ -206,24 +194,6 @@ lemma Derives.append_right {v w : List (Symbol T g.NT)}
   induction hvw with
   | refl => rfl
   | tail _ last ih => exact ih.trans_produces <| last.append_right p
-
-lemma produces_empty (g : ContextFreeGrammar T) (u v : List (Symbol T g.NT)) (h : g.Produces u v) :
-    ∃ r ∈ g.rules, .nonterminal r.input ∈ u := by
-  obtain ⟨w, ⟨l, r⟩⟩ := h
-  exact ⟨w, ⟨l, ContextFreeRule.nonterminal_rule_if_rewrite r⟩⟩
-
-lemma derives_empty (g : ContextFreeGrammar T) (t : g.NT) (h : ∀ r ∈ g.rules, r.input ≠ t) :
-    ∀ s ≠ [.nonterminal t], ¬g.Derives [.nonterminal t] s := fun _ hs ↦ by
-  rw [Derives.iff_eq_or_head]
-  push_neg
-  refine ⟨hs.symm, fun _ hx ↦ ?_⟩
-  have hxr := produces_empty g _ _ hx
-  simp_rw [List.mem_singleton, Symbol.nonterminal.injEq] at hxr
-  tauto
-
-lemma noninitial_empty (g : ContextFreeGrammar T) (h : ∀ r ∈ g.rules, r.input ≠ g.initial) :
-    g.language = 0 :=
-  Language.ext fun _ ↦ ⟨(absurd · (derives_empty g _ h _ (by simp))), fun _ ↦ by contradiction⟩
 
 end ContextFreeGrammar
 

--- a/Mathlib/Computability/ContextFreeGrammar.lean
+++ b/Mathlib/Computability/ContextFreeGrammar.lean
@@ -85,6 +85,10 @@ theorem rewrites_iff :
       u = p ++ [Symbol.nonterminal r.input] ++ q ∧ v = p ++ r.output ++ q :=
   ⟨Rewrites.exists_parts, by rintro ⟨p, q, rfl, rfl⟩; apply rewrites_of_exists_parts⟩
 
+lemma nonterminal_rule_if_rewrite : r.Rewrites u v → .nonterminal r.input ∈ u := by
+  simp_rw [rewrites_iff, List.append_assoc]
+  exact fun _ ↦ List.mem_iff_append.mpr (by tauto)
+
 /-- Add extra prefix to context-free rewriting. -/
 lemma Rewrites.append_left (hvw : r.Rewrites u v) (p : List (Symbol T N)) :
     r.Rewrites (p ++ u) (p ++ v) := by
@@ -163,9 +167,17 @@ lemma Derives.eq_or_head {u w : List (Symbol T g.NT)} (huw : g.Derives u w) :
     u = w ∨ ∃ v : List (Symbol T g.NT), g.Produces u v ∧ g.Derives v w :=
   Relation.ReflTransGen.cases_head huw
 
+lemma Derives.iff_eq_or_head {u w : List (Symbol T g.NT)} :
+    g.Derives u w ↔ u = w ∨ ∃ v : List (Symbol T g.NT), g.Produces u v ∧ g.Derives v w :=
+  Relation.ReflTransGen.cases_head_iff
+
 lemma Derives.eq_or_tail {u w : List (Symbol T g.NT)} (huw : g.Derives u w) :
-    u = w ∨ ∃ v : List (Symbol T g.NT), g.Derives u v ∧ g.Produces v w :=
-  (Relation.ReflTransGen.cases_tail huw).casesOn (Or.inl ∘ Eq.symm) Or.inr
+    w = u ∨ ∃ v : List (Symbol T g.NT), g.Derives u v ∧ g.Produces v w :=
+  Relation.ReflTransGen.cases_tail huw
+
+lemma Derives.iff_eq_or_tail {u w : List (Symbol T g.NT)} :
+    g.Derives u w ↔ w = u ∨ ∃ v : List (Symbol T g.NT), g.Derives u v ∧ g.Produces v w :=
+  Relation.ReflTransGen.cases_tail_iff g.Produces u w
 
 /-- Add extra prefix to context-free producing. -/
 lemma Produces.append_left {v w : List (Symbol T g.NT)}
@@ -194,6 +206,24 @@ lemma Derives.append_right {v w : List (Symbol T g.NT)}
   induction hvw with
   | refl => rfl
   | tail _ last ih => exact ih.trans_produces <| last.append_right p
+
+lemma produces_empty (g : ContextFreeGrammar T) (u v : List (Symbol T g.NT)) (h : g.Produces u v) :
+    ∃ r ∈ g.rules, .nonterminal r.input ∈ u := by
+  obtain ⟨w, ⟨l, r⟩⟩ := h
+  exact ⟨w, ⟨l, ContextFreeRule.nonterminal_rule_if_rewrite r⟩⟩
+
+lemma derives_empty (g : ContextFreeGrammar T) (t : g.NT) (h : ∀ r ∈ g.rules, r.input ≠ t) :
+    ∀ s ≠ [.nonterminal t], ¬g.Derives [.nonterminal t] s := fun _ hs ↦ by
+  rw [Derives.iff_eq_or_head]
+  push_neg
+  refine ⟨hs.symm, fun _ hx ↦ ?_⟩
+  have hxr := produces_empty g _ _ hx
+  simp_rw [List.mem_singleton, Symbol.nonterminal.injEq] at hxr
+  tauto
+
+lemma noninitial_empty (g : ContextFreeGrammar T) (h : ∀ r ∈ g.rules, r.input ≠ g.initial) :
+    g.language = 0 :=
+  Language.ext fun _ ↦ ⟨(absurd · (derives_empty g _ h _ (by simp))), fun _ ↦ by contradiction⟩
 
 end ContextFreeGrammar
 


### PR DESCRIPTION
Repr can be dropped, but DecidableEq is quite useful for further proofs on CFGs.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
