### PR TITLE
[Merged by Bors] - chore(Geometry): use numeric subscripts for indices

### DIFF
--- a/Archive/Wiedijk100Theorems/HeronsFormula.lean
+++ b/Archive/Wiedijk100Theorems/HeronsFormula.lean
@@ -12,10 +12,6 @@ This file proves Theorem 57 from the [100 Theorems List](https://www.cs.ru.nl/~f
 also known as Heron's formula, which gives the area of a triangle based only on its three sides'
 lengths.
 
-## TODO
-
-Change variable names here: https://leanprover-community.github.io/100.html#57
-
 ## References
 
 * https://en.wikipedia.org/wiki/Herons_formula

--- a/Archive/Wiedijk100Theorems/HeronsFormula.lean
+++ b/Archive/Wiedijk100Theorems/HeronsFormula.lean
@@ -12,6 +12,10 @@ This file proves Theorem 57 from the [100 Theorems List](https://www.cs.ru.nl/~f
 also known as Heron's formula, which gives the area of a triangle based only on its three sides'
 lengths.
 
+## TODO
+
+Change variable names here: https://leanprover-community.github.io/100.html#57
+
 ## References
 
 * https://en.wikipedia.org/wiki/Herons_formula
@@ -35,18 +39,18 @@ variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V
   We show this by equating this formula to `a * b * sin γ`, where `γ` is the angle opposite
   the side `c`.
  -/
-theorem heron {p1 p2 p3 : P} (h1 : p1 ≠ p2) (h2 : p3 ≠ p2) :
-    let a := dist p1 p2
-    let b := dist p3 p2
-    let c := dist p1 p3
+theorem heron {p₁ p₂ p₃ : P} (h1 : p₁ ≠ p₂) (h2 : p₃ ≠ p₂) :
+    let a := dist p₁ p₂
+    let b := dist p₃ p₂
+    let c := dist p₁ p₃
     let s := (a + b + c) / 2
-    1 / 2 * a * b * sin (∠ p1 p2 p3) = √ (s * (s - a) * (s - b) * (s - c)) := by
+    1 / 2 * a * b * sin (∠ p₁ p₂ p₃) = √ (s * (s - a) * (s - b) * (s - c)) := by
   intro a b c s
-  let γ := ∠ p1 p2 p3
+  let γ := ∠ p₁ p₂ p₃
   obtain := (dist_pos.mpr h1).ne', (dist_pos.mpr h2).ne'
   have cos_rule : cos γ = (a * a + b * b - c * c) / (2 * a * b) := by
     field_simp [a, b, c, γ, mul_comm,
-      dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle p1 p2 p3]
+      dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle p₁ p₂ p₃]
   let numerator := (2 * a * b) ^ 2 - (a * a + b * b - c * c) ^ 2
   let denominator := (2 * a * b) ^ 2
   have split_to_frac : ↑1 - cos γ ^ 2 = numerator / denominator := by

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/Affine.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/Affine.lean
@@ -35,12 +35,12 @@ open InnerProductGeometry
 variable {V P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
   [NormedAddTorsor V P] {p p₀ : P}
 
-/-- The undirected angle at `p2` between the line segments to `p1` and
-`p3`. If either of those points equals `p2`, this is π/2. Use
-`open scoped EuclideanGeometry` to access the `∠ p1 p2 p3`
+/-- The undirected angle at `p₂` between the line segments to `p₁` and
+`p₃`. If either of those points equals `p₂`, this is π/2. Use
+`open scoped EuclideanGeometry` to access the `∠ p₁ p₂ p₃`
 notation. -/
-nonrec def angle (p1 p2 p3 : P) : ℝ :=
-  angle (p1 -ᵥ p2 : V) (p3 -ᵥ p2)
+nonrec def angle (p₁ p₂ p₃ : P) : ℝ :=
+  angle (p₁ -ᵥ p₂ : V) (p₃ -ᵥ p₂)
 
 @[inherit_doc] scoped notation "∠" => EuclideanGeometry.angle
 
@@ -113,15 +113,15 @@ theorem angle_neg (v₁ v₂ v₃ : V) : ∠ (-v₁) (-v₂) (-v₃) = ∠ v₁ 
 
 /-- The angle at a point does not depend on the order of the other two
 points. -/
-nonrec theorem angle_comm (p1 p2 p3 : P) : ∠ p1 p2 p3 = ∠ p3 p2 p1 :=
+nonrec theorem angle_comm (p₁ p₂ p₃ : P) : ∠ p₁ p₂ p₃ = ∠ p₃ p₂ p₁ :=
   angle_comm _ _
 
 /-- The angle at a point is nonnegative. -/
-nonrec theorem angle_nonneg (p1 p2 p3 : P) : 0 ≤ ∠ p1 p2 p3 :=
+nonrec theorem angle_nonneg (p₁ p₂ p₃ : P) : 0 ≤ ∠ p₁ p₂ p₃ :=
   angle_nonneg _ _
 
 /-- The angle at a point is at most π. -/
-nonrec theorem angle_le_pi (p1 p2 p3 : P) : ∠ p1 p2 p3 ≤ π :=
+nonrec theorem angle_le_pi (p₁ p₂ p₃ : P) : ∠ p₁ p₂ p₃ ≤ π :=
   angle_le_pi _ _
 
 /-- The angle ∠AAB at a point is always `π / 2`. -/
@@ -138,111 +138,111 @@ theorem angle_self_of_ne (h : p ≠ p₀) : ∠ p p₀ p = 0 := angle_self <| vs
 
 
 /-- If the angle ∠ABC at a point is π, the angle ∠BAC is 0. -/
-theorem angle_eq_zero_of_angle_eq_pi_left {p1 p2 p3 : P} (h : ∠ p1 p2 p3 = π) : ∠ p2 p1 p3 = 0 := by
+theorem angle_eq_zero_of_angle_eq_pi_left {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = π) : ∠ p₂ p₁ p₃ = 0 := by
   unfold angle at h
   rw [angle_eq_pi_iff] at h
-  rcases h with ⟨hp1p2, ⟨r, ⟨hr, hpr⟩⟩⟩
+  rcases h with ⟨hp₁p₂, ⟨r, ⟨hr, hpr⟩⟩⟩
   unfold angle
   rw [angle_eq_zero_iff]
-  rw [← neg_vsub_eq_vsub_rev, neg_ne_zero] at hp1p2
-  use hp1p2, -r + 1, add_pos (neg_pos_of_neg hr) zero_lt_one
-  rw [add_smul, ← neg_vsub_eq_vsub_rev p1 p2, smul_neg]
+  rw [← neg_vsub_eq_vsub_rev, neg_ne_zero] at hp₁p₂
+  use hp₁p₂, -r + 1, add_pos (neg_pos_of_neg hr) zero_lt_one
+  rw [add_smul, ← neg_vsub_eq_vsub_rev p₁ p₂, smul_neg]
   simp [← hpr]
 
 /-- If the angle ∠ABC at a point is π, the angle ∠BCA is 0. -/
-theorem angle_eq_zero_of_angle_eq_pi_right {p1 p2 p3 : P} (h : ∠ p1 p2 p3 = π) :
-    ∠ p2 p3 p1 = 0 := by
+theorem angle_eq_zero_of_angle_eq_pi_right {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = π) :
+    ∠ p₂ p₃ p₁ = 0 := by
   rw [angle_comm] at h
   exact angle_eq_zero_of_angle_eq_pi_left h
 
 /-- If ∠BCD = π, then ∠ABC = ∠ABD. -/
-theorem angle_eq_angle_of_angle_eq_pi (p1 : P) {p2 p3 p4 : P} (h : ∠ p2 p3 p4 = π) :
-    ∠ p1 p2 p3 = ∠ p1 p2 p4 := by
+theorem angle_eq_angle_of_angle_eq_pi (p₁ : P) {p₂ p₃ p₄ : P} (h : ∠ p₂ p₃ p₄ = π) :
+    ∠ p₁ p₂ p₃ = ∠ p₁ p₂ p₄ := by
   unfold angle at *
   rcases angle_eq_pi_iff.1 h with ⟨_, ⟨r, ⟨hr, hpr⟩⟩⟩
   rw [eq_comm]
-  convert angle_smul_right_of_pos (p1 -ᵥ p2) (p3 -ᵥ p2) (add_pos (neg_pos_of_neg hr) zero_lt_one)
-  rw [add_smul, ← neg_vsub_eq_vsub_rev p2 p3, smul_neg, neg_smul, ← hpr]
+  convert angle_smul_right_of_pos (p₁ -ᵥ p₂) (p₃ -ᵥ p₂) (add_pos (neg_pos_of_neg hr) zero_lt_one)
+  rw [add_smul, ← neg_vsub_eq_vsub_rev p₂ p₃, smul_neg, neg_smul, ← hpr]
   simp
 
 /-- If ∠BCD = π, then ∠ACB + ∠ACD = π. -/
-nonrec theorem angle_add_angle_eq_pi_of_angle_eq_pi (p1 : P) {p2 p3 p4 : P} (h : ∠ p2 p3 p4 = π) :
-    ∠ p1 p3 p2 + ∠ p1 p3 p4 = π := by
+nonrec theorem angle_add_angle_eq_pi_of_angle_eq_pi (p₁ : P) {p₂ p₃ p₄ : P} (h : ∠ p₂ p₃ p₄ = π) :
+    ∠ p₁ p₃ p₂ + ∠ p₁ p₃ p₄ = π := by
   unfold angle at h
-  rw [angle_comm p1 p3 p2, angle_comm p1 p3 p4]
+  rw [angle_comm p₁ p₃ p₂, angle_comm p₁ p₃ p₄]
   unfold angle
   exact angle_add_angle_eq_pi_of_angle_eq_pi _ h
 
 /-- **Vertical Angles Theorem**: angles opposite each other, formed by two intersecting straight
 lines, are equal. -/
-theorem angle_eq_angle_of_angle_eq_pi_of_angle_eq_pi {p1 p2 p3 p4 p5 : P} (hapc : ∠ p1 p5 p3 = π)
-    (hbpd : ∠ p2 p5 p4 = π) : ∠ p1 p5 p2 = ∠ p3 p5 p4 := by
-  linarith [angle_add_angle_eq_pi_of_angle_eq_pi p1 hbpd, angle_comm p4 p5 p1,
-    angle_add_angle_eq_pi_of_angle_eq_pi p4 hapc, angle_comm p4 p5 p3]
+theorem angle_eq_angle_of_angle_eq_pi_of_angle_eq_pi {p₁ p₂ p₃ p₄ p₅ : P} (hapc : ∠ p₁ p₅ p₃ = π)
+    (hbpd : ∠ p₂ p₅ p₄ = π) : ∠ p₁ p₅ p₂ = ∠ p₃ p₅ p₄ := by
+  linarith [angle_add_angle_eq_pi_of_angle_eq_pi p₁ hbpd, angle_comm p₄ p₅ p₁,
+    angle_add_angle_eq_pi_of_angle_eq_pi p₄ hapc, angle_comm p₄ p₅ p₃]
 
 /-- If ∠ABC = π then dist A B ≠ 0. -/
-theorem left_dist_ne_zero_of_angle_eq_pi {p1 p2 p3 : P} (h : ∠ p1 p2 p3 = π) : dist p1 p2 ≠ 0 := by
+theorem left_dist_ne_zero_of_angle_eq_pi {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = π) : dist p₁ p₂ ≠ 0 := by
   by_contra heq
   rw [dist_eq_zero] at heq
   rw [heq, angle_self_left] at h
   exact Real.pi_ne_zero (by linarith)
 
 /-- If ∠ABC = π then dist C B ≠ 0. -/
-theorem right_dist_ne_zero_of_angle_eq_pi {p1 p2 p3 : P} (h : ∠ p1 p2 p3 = π) : dist p3 p2 ≠ 0 :=
+theorem right_dist_ne_zero_of_angle_eq_pi {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = π) : dist p₃ p₂ ≠ 0 :=
   left_dist_ne_zero_of_angle_eq_pi <| (angle_comm _ _ _).trans h
 
 /-- If ∠ABC = π, then (dist A C) = (dist A B) + (dist B C). -/
-theorem dist_eq_add_dist_of_angle_eq_pi {p1 p2 p3 : P} (h : ∠ p1 p2 p3 = π) :
-    dist p1 p3 = dist p1 p2 + dist p3 p2 := by
+theorem dist_eq_add_dist_of_angle_eq_pi {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = π) :
+    dist p₁ p₃ = dist p₁ p₂ + dist p₃ p₂ := by
   rw [dist_eq_norm_vsub V, dist_eq_norm_vsub V, dist_eq_norm_vsub V, ← vsub_sub_vsub_cancel_right]
   exact norm_sub_eq_add_norm_of_angle_eq_pi h
 
 /-- If A ≠ B and C ≠ B then ∠ABC = π if and only if (dist A C) = (dist A B) + (dist B C). -/
-theorem dist_eq_add_dist_iff_angle_eq_pi {p1 p2 p3 : P} (hp1p2 : p1 ≠ p2) (hp3p2 : p3 ≠ p2) :
-    dist p1 p3 = dist p1 p2 + dist p3 p2 ↔ ∠ p1 p2 p3 = π := by
+theorem dist_eq_add_dist_iff_angle_eq_pi {p₁ p₂ p₃ : P} (hp₁p₂ : p₁ ≠ p₂) (hp₃p₂ : p₃ ≠ p₂) :
+    dist p₁ p₃ = dist p₁ p₂ + dist p₃ p₂ ↔ ∠ p₁ p₂ p₃ = π := by
   rw [dist_eq_norm_vsub V, dist_eq_norm_vsub V, dist_eq_norm_vsub V, ← vsub_sub_vsub_cancel_right]
   exact
-    norm_sub_eq_add_norm_iff_angle_eq_pi (fun he => hp1p2 (vsub_eq_zero_iff_eq.1 he)) fun he =>
-      hp3p2 (vsub_eq_zero_iff_eq.1 he)
+    norm_sub_eq_add_norm_iff_angle_eq_pi (fun he => hp₁p₂ (vsub_eq_zero_iff_eq.1 he)) fun he =>
+      hp₃p₂ (vsub_eq_zero_iff_eq.1 he)
 
 /-- If ∠ABC = 0, then (dist A C) = abs ((dist A B) - (dist B C)). -/
-theorem dist_eq_abs_sub_dist_of_angle_eq_zero {p1 p2 p3 : P} (h : ∠ p1 p2 p3 = 0) :
-    dist p1 p3 = |dist p1 p2 - dist p3 p2| := by
+theorem dist_eq_abs_sub_dist_of_angle_eq_zero {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = 0) :
+    dist p₁ p₃ = |dist p₁ p₂ - dist p₃ p₂| := by
   rw [dist_eq_norm_vsub V, dist_eq_norm_vsub V, dist_eq_norm_vsub V, ← vsub_sub_vsub_cancel_right]
   exact norm_sub_eq_abs_sub_norm_of_angle_eq_zero h
 
 /-- If A ≠ B and C ≠ B then ∠ABC = 0 if and only if (dist A C) = abs ((dist A B) - (dist B C)). -/
-theorem dist_eq_abs_sub_dist_iff_angle_eq_zero {p1 p2 p3 : P} (hp1p2 : p1 ≠ p2) (hp3p2 : p3 ≠ p2) :
-    dist p1 p3 = |dist p1 p2 - dist p3 p2| ↔ ∠ p1 p2 p3 = 0 := by
+theorem dist_eq_abs_sub_dist_iff_angle_eq_zero {p₁ p₂ p₃ : P} (hp₁p₂ : p₁ ≠ p₂) (hp₃p₂ : p₃ ≠ p₂) :
+    dist p₁ p₃ = |dist p₁ p₂ - dist p₃ p₂| ↔ ∠ p₁ p₂ p₃ = 0 := by
   rw [dist_eq_norm_vsub V, dist_eq_norm_vsub V, dist_eq_norm_vsub V, ← vsub_sub_vsub_cancel_right]
   exact
-    norm_sub_eq_abs_sub_norm_iff_angle_eq_zero (fun he => hp1p2 (vsub_eq_zero_iff_eq.1 he))
-      fun he => hp3p2 (vsub_eq_zero_iff_eq.1 he)
+    norm_sub_eq_abs_sub_norm_iff_angle_eq_zero (fun he => hp₁p₂ (vsub_eq_zero_iff_eq.1 he))
+      fun he => hp₃p₂ (vsub_eq_zero_iff_eq.1 he)
 
 /-- If M is the midpoint of the segment AB, then ∠AMB = π. -/
-theorem angle_midpoint_eq_pi (p1 p2 : P) (hp1p2 : p1 ≠ p2) : ∠ p1 (midpoint ℝ p1 p2) p2 = π := by
+theorem angle_midpoint_eq_pi (p₁ p₂ : P) (hp₁p₂ : p₁ ≠ p₂) : ∠ p₁ (midpoint ℝ p₁ p₂) p₂ = π := by
   simp only [angle, left_vsub_midpoint, invOf_eq_inv, right_vsub_midpoint, inv_pos, zero_lt_two,
     angle_smul_right_of_pos, angle_smul_left_of_pos]
-  rw [← neg_vsub_eq_vsub_rev p1 p2]
+  rw [← neg_vsub_eq_vsub_rev p₁ p₂]
   apply angle_self_neg_of_nonzero
   simpa only [ne_eq, vsub_eq_zero_iff_eq]
 
 /-- If M is the midpoint of the segment AB and C is the same distance from A as it is from B
 then ∠CMA = π / 2. -/
-theorem angle_left_midpoint_eq_pi_div_two_of_dist_eq {p1 p2 p3 : P} (h : dist p3 p1 = dist p3 p2) :
-    ∠ p3 (midpoint ℝ p1 p2) p1 = π / 2 := by
-  let m : P := midpoint ℝ p1 p2
-  have h1 : p3 -ᵥ p1 = p3 -ᵥ m - (p1 -ᵥ m) := (vsub_sub_vsub_cancel_right p3 p1 m).symm
-  have h2 : p3 -ᵥ p2 = p3 -ᵥ m + (p1 -ᵥ m) := by
+theorem angle_left_midpoint_eq_pi_div_two_of_dist_eq {p₁ p₂ p₃ : P} (h : dist p₃ p₁ = dist p₃ p₂) :
+    ∠ p₃ (midpoint ℝ p₁ p₂) p₁ = π / 2 := by
+  let m : P := midpoint ℝ p₁ p₂
+  have h1 : p₃ -ᵥ p₁ = p₃ -ᵥ m - (p₁ -ᵥ m) := (vsub_sub_vsub_cancel_right p₃ p₁ m).symm
+  have h2 : p₃ -ᵥ p₂ = p₃ -ᵥ m + (p₁ -ᵥ m) := by
     rw [left_vsub_midpoint, ← midpoint_vsub_right, vsub_add_vsub_cancel]
-  rw [dist_eq_norm_vsub V p3 p1, dist_eq_norm_vsub V p3 p2, h1, h2] at h
-  exact (norm_add_eq_norm_sub_iff_angle_eq_pi_div_two (p3 -ᵥ m) (p1 -ᵥ m)).mp h.symm
+  rw [dist_eq_norm_vsub V p₃ p₁, dist_eq_norm_vsub V p₃ p₂, h1, h2] at h
+  exact (norm_add_eq_norm_sub_iff_angle_eq_pi_div_two (p₃ -ᵥ m) (p₁ -ᵥ m)).mp h.symm
 
 /-- If M is the midpoint of the segment AB and C is the same distance from A as it is from B
 then ∠CMB = π / 2. -/
-theorem angle_right_midpoint_eq_pi_div_two_of_dist_eq {p1 p2 p3 : P} (h : dist p3 p1 = dist p3 p2) :
-    ∠ p3 (midpoint ℝ p1 p2) p2 = π / 2 := by
-  rw [midpoint_comm p1 p2, angle_left_midpoint_eq_pi_div_two_of_dist_eq h.symm]
+theorem angle_right_midpoint_eq_pi_div_two_of_dist_eq {p₁ p₂ p₃ : P} (h : dist p₃ p₁ = dist p₃ p₂) :
+    ∠ p₃ (midpoint ℝ p₁ p₂) p₂ = π / 2 := by
+  rw [midpoint_comm p₁ p₂, angle_left_midpoint_eq_pi_div_two_of_dist_eq h.symm]
 
 /-- If the second of three points is strictly between the other two, the angle at that point
 is π. -/

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/RightAngle.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/RightAngle.lean
@@ -18,6 +18,10 @@ Results in this file are generally given in a form with only those non-degenerac
 needed for the particular result, rather than requiring affine independence of the points of a
 triangle unnecessarily.
 
+## TODO
+
+Change variable names here: https://leanprover-community.github.io/100.html#4
+
 ## References
 
 * https://en.wikipedia.org/wiki/Pythagorean_theorem
@@ -321,12 +325,12 @@ variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V
   [NormedAddTorsor V P]
 
 /-- **Pythagorean theorem**, if-and-only-if angle-at-point form. -/
-theorem dist_sq_eq_dist_sq_add_dist_sq_iff_angle_eq_pi_div_two (p1 p2 p3 : P) :
-    dist p1 p3 * dist p1 p3 = dist p1 p2 * dist p1 p2 + dist p3 p2 * dist p3 p2 ↔
-      ∠ p1 p2 p3 = π / 2 := by
-  erw [dist_comm p3 p2, dist_eq_norm_vsub V p1 p3, dist_eq_norm_vsub V p1 p2,
-    dist_eq_norm_vsub V p2 p3, ← norm_sub_sq_eq_norm_sq_add_norm_sq_iff_angle_eq_pi_div_two,
-    vsub_sub_vsub_cancel_right p1, ← neg_vsub_eq_vsub_rev p2 p3, norm_neg]
+theorem dist_sq_eq_dist_sq_add_dist_sq_iff_angle_eq_pi_div_two (p₁ p₂ p₃ : P) :
+    dist p₁ p₃ * dist p₁ p₃ = dist p₁ p₂ * dist p₁ p₂ + dist p₃ p₂ * dist p₃ p₂ ↔
+      ∠ p₁ p₂ p₃ = π / 2 := by
+  erw [dist_comm p₃ p₂, dist_eq_norm_vsub V p₁ p₃, dist_eq_norm_vsub V p₁ p₂,
+    dist_eq_norm_vsub V p₂ p₃, ← norm_sub_sq_eq_norm_sq_add_norm_sq_iff_angle_eq_pi_div_two,
+    vsub_sub_vsub_cancel_right p₁, ← neg_vsub_eq_vsub_rev p₂ p₃, norm_neg]
 
 /-- An angle in a right-angled triangle expressed using `arccos`. -/
 theorem angle_eq_arccos_of_angle_eq_pi_div_two {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = π / 2) :

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/RightAngle.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/RightAngle.lean
@@ -18,10 +18,6 @@ Results in this file are generally given in a form with only those non-degenerac
 needed for the particular result, rather than requiring affine independence of the points of a
 triangle unnecessarily.
 
-## TODO
-
-Change variable names here: https://leanprover-community.github.io/100.html#4
-
 ## References
 
 * https://en.wikipedia.org/wiki/Pythagorean_theorem

--- a/Mathlib/Geometry/Euclidean/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Basic.lean
@@ -63,9 +63,9 @@ variable [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
 variable [NormedAddTorsor V P]
 
 /-- The midpoint of the segment AB is the same distance from A as it is from B. -/
-theorem dist_left_midpoint_eq_dist_right_midpoint (p1 p2 : P) :
-    dist p1 (midpoint ℝ p1 p2) = dist p2 (midpoint ℝ p1 p2) := by
-  rw [dist_left_midpoint (𝕜 := ℝ) p1 p2, dist_right_midpoint (𝕜 := ℝ) p1 p2]
+theorem dist_left_midpoint_eq_dist_right_midpoint (p₁ p₂ : P) :
+    dist p₁ (midpoint ℝ p₁ p₂) = dist p₂ (midpoint ℝ p₁ p₂) := by
+  rw [dist_left_midpoint (𝕜 := ℝ) p₁ p₂, dist_right_midpoint (𝕜 := ℝ) p₁ p₂]
 
 /-- The inner product of two vectors given with `weightedVSub`, in
 terms of the pairwise distances. -/
@@ -322,16 +322,16 @@ theorem orthogonalProjection_mem_orthogonal (s : AffineSubspace ℝ P) [Nonempty
 `orthogonalProjection` produces a result in the direction of the
 given subspace. -/
 theorem orthogonalProjection_vsub_mem_direction {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p1 : P} (p2 : P) (hp1 : p1 ∈ s) :
-    ↑(orthogonalProjection s p2 -ᵥ ⟨p1, hp1⟩ : s.direction) ∈ s.direction :=
-  (orthogonalProjection s p2 -ᵥ ⟨p1, hp1⟩ : s.direction).2
+    [HasOrthogonalProjection s.direction] {p₁ : P} (p₂ : P) (hp₁ : p₁ ∈ s) :
+    ↑(orthogonalProjection s p₂ -ᵥ ⟨p₁, hp₁⟩ : s.direction) ∈ s.direction :=
+  (orthogonalProjection s p₂ -ᵥ ⟨p₁, hp₁⟩ : s.direction).2
 
 /-- Subtracting the `orthogonalProjection` from a point in the given
 subspace produces a result in the direction of the given subspace. -/
 theorem vsub_orthogonalProjection_mem_direction {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p1 : P} (p2 : P) (hp1 : p1 ∈ s) :
-    ↑((⟨p1, hp1⟩ : s) -ᵥ orthogonalProjection s p2 : s.direction) ∈ s.direction :=
-  ((⟨p1, hp1⟩ : s) -ᵥ orthogonalProjection s p2 : s.direction).2
+    [HasOrthogonalProjection s.direction] {p₁ : P} (p₂ : P) (hp₁ : p₁ ∈ s) :
+    ↑((⟨p₁, hp₁⟩ : s) -ᵥ orthogonalProjection s p₂ : s.direction) ∈ s.direction :=
+  ((⟨p₁, hp₁⟩ : s) -ᵥ orthogonalProjection s p₂ : s.direction).2
 
 /-- A point equals its orthogonal projection if and only if it lies in
 the subspace. -/
@@ -421,47 +421,47 @@ orthogonal projection, produces the original point if the vector is a
 multiple of the result of subtracting a point's orthogonal projection
 from that point. -/
 theorem orthogonalProjection_vadd_smul_vsub_orthogonalProjection {s : AffineSubspace ℝ P}
-    [Nonempty s] [HasOrthogonalProjection s.direction] {p1 : P} (p2 : P) (r : ℝ) (hp : p1 ∈ s) :
-    orthogonalProjection s (r • (p2 -ᵥ orthogonalProjection s p2 : V) +ᵥ p1) = ⟨p1, hp⟩ :=
+    [Nonempty s] [HasOrthogonalProjection s.direction] {p₁ : P} (p₂ : P) (r : ℝ) (hp : p₁ ∈ s) :
+    orthogonalProjection s (r • (p₂ -ᵥ orthogonalProjection s p₂ : V) +ᵥ p₁) = ⟨p₁, hp⟩ :=
   orthogonalProjection_vadd_eq_self hp
     (Submodule.smul_mem _ _ (vsub_orthogonalProjection_mem_direction_orthogonal s _))
 
-/-- The square of the distance from a point in `s` to `p2` equals the
+/-- The square of the distance from a point in `s` to `p₂` equals the
 sum of the squares of the distances of the two points to the
 `orthogonalProjection`. -/
 theorem dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq
-    {s : AffineSubspace ℝ P} [Nonempty s] [HasOrthogonalProjection s.direction] {p1 : P} (p2 : P)
-    (hp1 : p1 ∈ s) :
-    dist p1 p2 * dist p1 p2 =
-      dist p1 (orthogonalProjection s p2) * dist p1 (orthogonalProjection s p2) +
-        dist p2 (orthogonalProjection s p2) * dist p2 (orthogonalProjection s p2) := by
-  rw [dist_comm p2 _, dist_eq_norm_vsub V p1 _, dist_eq_norm_vsub V p1 _, dist_eq_norm_vsub V _ p2,
-    ← vsub_add_vsub_cancel p1 (orthogonalProjection s p2) p2,
+    {s : AffineSubspace ℝ P} [Nonempty s] [HasOrthogonalProjection s.direction] {p₁ : P} (p₂ : P)
+    (hp₁ : p₁ ∈ s) :
+    dist p₁ p₂ * dist p₁ p₂ =
+      dist p₁ (orthogonalProjection s p₂) * dist p₁ (orthogonalProjection s p₂) +
+        dist p₂ (orthogonalProjection s p₂) * dist p₂ (orthogonalProjection s p₂) := by
+  rw [dist_comm p₂ _, dist_eq_norm_vsub V p₁ _, dist_eq_norm_vsub V p₁ _, dist_eq_norm_vsub V _ p₂,
+    ← vsub_add_vsub_cancel p₁ (orthogonalProjection s p₂) p₂,
     norm_add_sq_eq_norm_sq_add_norm_sq_iff_real_inner_eq_zero]
-  exact Submodule.inner_right_of_mem_orthogonal (vsub_orthogonalProjection_mem_direction p2 hp1)
-    (orthogonalProjection_vsub_mem_direction_orthogonal s p2)
+  exact Submodule.inner_right_of_mem_orthogonal (vsub_orthogonalProjection_mem_direction p₂ hp₁)
+    (orthogonalProjection_vsub_mem_direction_orthogonal s p₂)
 
 /-- The square of the distance between two points constructed by
 adding multiples of the same orthogonal vector to points in the same
 subspace. -/
-theorem dist_sq_smul_orthogonal_vadd_smul_orthogonal_vadd {s : AffineSubspace ℝ P} {p1 p2 : P}
-    (hp1 : p1 ∈ s) (hp2 : p2 ∈ s) (r1 r2 : ℝ) {v : V} (hv : v ∈ s.directionᗮ) :
-    dist (r1 • v +ᵥ p1) (r2 • v +ᵥ p2) * dist (r1 • v +ᵥ p1) (r2 • v +ᵥ p2) =
-      dist p1 p2 * dist p1 p2 + (r1 - r2) * (r1 - r2) * (‖v‖ * ‖v‖) :=
+theorem dist_sq_smul_orthogonal_vadd_smul_orthogonal_vadd {s : AffineSubspace ℝ P} {p₁ p₂ : P}
+    (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) (r₁ r₂ : ℝ) {v : V} (hv : v ∈ s.directionᗮ) :
+    dist (r₁ • v +ᵥ p₁) (r₂ • v +ᵥ p₂) * dist (r₁ • v +ᵥ p₁) (r₂ • v +ᵥ p₂) =
+      dist p₁ p₂ * dist p₁ p₂ + (r₁ - r₂) * (r₁ - r₂) * (‖v‖ * ‖v‖) :=
   calc
-    dist (r1 • v +ᵥ p1) (r2 • v +ᵥ p2) * dist (r1 • v +ᵥ p1) (r2 • v +ᵥ p2) =
-        ‖p1 -ᵥ p2 + (r1 - r2) • v‖ * ‖p1 -ᵥ p2 + (r1 - r2) • v‖ := by
-      rw [dist_eq_norm_vsub V (r1 • v +ᵥ p1), vsub_vadd_eq_vsub_sub, vadd_vsub_assoc, sub_smul,
+    dist (r₁ • v +ᵥ p₁) (r₂ • v +ᵥ p₂) * dist (r₁ • v +ᵥ p₁) (r₂ • v +ᵥ p₂) =
+        ‖p₁ -ᵥ p₂ + (r₁ - r₂) • v‖ * ‖p₁ -ᵥ p₂ + (r₁ - r₂) • v‖ := by
+      rw [dist_eq_norm_vsub V (r₁ • v +ᵥ p₁), vsub_vadd_eq_vsub_sub, vadd_vsub_assoc, sub_smul,
         add_comm, add_sub_assoc]
-    _ = ‖p1 -ᵥ p2‖ * ‖p1 -ᵥ p2‖ + ‖(r1 - r2) • v‖ * ‖(r1 - r2) • v‖ :=
+    _ = ‖p₁ -ᵥ p₂‖ * ‖p₁ -ᵥ p₂‖ + ‖(r₁ - r₂) • v‖ * ‖(r₁ - r₂) • v‖ :=
       (norm_add_sq_eq_norm_sq_add_norm_sq_real
-        (Submodule.inner_right_of_mem_orthogonal (vsub_mem_direction hp1 hp2)
+        (Submodule.inner_right_of_mem_orthogonal (vsub_mem_direction hp₁ hp₂)
           (Submodule.smul_mem _ _ hv)))
-    _ = ‖(p1 -ᵥ p2 : V)‖ * ‖(p1 -ᵥ p2 : V)‖ + |r1 - r2| * |r1 - r2| * ‖v‖ * ‖v‖ := by
+    _ = ‖(p₁ -ᵥ p₂ : V)‖ * ‖(p₁ -ᵥ p₂ : V)‖ + |r₁ - r₂| * |r₁ - r₂| * ‖v‖ * ‖v‖ := by
       rw [norm_smul, Real.norm_eq_abs]
       ring
-    _ = dist p1 p2 * dist p1 p2 + (r1 - r2) * (r1 - r2) * (‖v‖ * ‖v‖) := by
-      rw [dist_eq_norm_vsub V p1, abs_mul_abs_self, mul_assoc]
+    _ = dist p₁ p₂ * dist p₁ p₂ + (r₁ - r₂) * (r₁ - r₂) * (‖v‖ * ‖v‖) := by
+      rw [dist_eq_norm_vsub V p₁, abs_mul_abs_self, mul_assoc]
 
 /-- Reflection in an affine subspace, which is expected to be nonempty
 and complete. The word "reflection" is sometimes understood to mean

--- a/Mathlib/Geometry/Euclidean/Circumcenter.lean
+++ b/Mathlib/Geometry/Euclidean/Circumcenter.lean
@@ -41,26 +41,26 @@ open AffineSubspace
 /-- `p` is equidistant from two points in `s` if and only if its
 `orthogonalProjection` is. -/
 theorem dist_eq_iff_dist_orthogonalProjection_eq {s : AffineSubspace ℝ P} [Nonempty s]
-    [HasOrthogonalProjection s.direction] {p1 p2 : P} (p3 : P) (hp1 : p1 ∈ s) (hp2 : p2 ∈ s) :
-    dist p1 p3 = dist p2 p3 ↔
-      dist p1 (orthogonalProjection s p3) = dist p2 (orthogonalProjection s p3) := by
+    [HasOrthogonalProjection s.direction] {p₁ p₂ : P} (p₃ : P) (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) :
+    dist p₁ p₃ = dist p₂ p₃ ↔
+      dist p₁ (orthogonalProjection s p₃) = dist p₂ (orthogonalProjection s p₃) := by
   rw [← mul_self_inj_of_nonneg dist_nonneg dist_nonneg, ←
     mul_self_inj_of_nonneg dist_nonneg dist_nonneg,
-    dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq p3 hp1,
-    dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq p3 hp2]
+    dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq p₃ hp₁,
+    dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq p₃ hp₂]
   simp
 
 /-- `p` is equidistant from a set of points in `s` if and only if its
 `orthogonalProjection` is. -/
 theorem dist_set_eq_iff_dist_orthogonalProjection_eq {s : AffineSubspace ℝ P} [Nonempty s]
     [HasOrthogonalProjection s.direction] {ps : Set P} (hps : ps ⊆ s) (p : P) :
-    (Set.Pairwise ps fun p1 p2 => dist p1 p = dist p2 p) ↔
-      Set.Pairwise ps fun p1 p2 =>
-        dist p1 (orthogonalProjection s p) = dist p2 (orthogonalProjection s p) :=
-  ⟨fun h _ hp1 _ hp2 hne =>
-    (dist_eq_iff_dist_orthogonalProjection_eq p (hps hp1) (hps hp2)).1 (h hp1 hp2 hne),
-    fun h _ hp1 _ hp2 hne =>
-    (dist_eq_iff_dist_orthogonalProjection_eq p (hps hp1) (hps hp2)).2 (h hp1 hp2 hne)⟩
+    (Set.Pairwise ps fun p₁ p₂ => dist p₁ p = dist p₂ p) ↔
+      Set.Pairwise ps fun p₁ p₂ =>
+        dist p₁ (orthogonalProjection s p) = dist p₂ (orthogonalProjection s p) :=
+  ⟨fun h _ hp₁ _ hp₂ hne =>
+    (dist_eq_iff_dist_orthogonalProjection_eq p (hps hp₁) (hps hp₂)).1 (h hp₁ hp₂ hne),
+    fun h _ hp₁ _ hp₂ hne =>
+    (dist_eq_iff_dist_orthogonalProjection_eq p (hps hp₁) (hps hp₂)).2 (h hp₁ hp₂ hne)⟩
 
 /-- There exists `r` such that `p` has distance `r` from all the
 points of a set of points in `s` if and only if there exists (possibly
@@ -68,7 +68,7 @@ different) `r` such that its `orthogonalProjection` has that distance
 from all the points in that set. -/
 theorem exists_dist_eq_iff_exists_dist_orthogonalProjection_eq {s : AffineSubspace ℝ P} [Nonempty s]
     [HasOrthogonalProjection s.direction] {ps : Set P} (hps : ps ⊆ s) (p : P) :
-    (∃ r, ∀ p1 ∈ ps, dist p1 p = r) ↔ ∃ r, ∀ p1 ∈ ps, dist p1 ↑(orthogonalProjection s p) = r := by
+    (∃ r, ∀ p₁ ∈ ps, dist p₁ p = r) ↔ ∃ r, ∀ p₁ ∈ ps, dist p₁ ↑(orthogonalProjection s p) = r := by
   have h := dist_set_eq_iff_dist_orthogonalProjection_eq hps p
   simp_rw [Set.pairwise_eq_iff_exists_eq] at h
   exact h
@@ -106,11 +106,11 @@ theorem existsUnique_dist_eq_of_insert {s : AffineSubspace ℝ P}
         Submodule.smul_mem _ _
           (vsub_mem_vectorSpan ℝ (Set.mem_insert _ _)
             (Set.mem_insert_of_mem _ (orthogonalProjection_mem _)))
-    · intro p1 hp1
+    · intro p₁ hp₁
       rw [Sphere.mem_coe, mem_sphere, ← mul_self_inj_of_nonneg dist_nonneg (Real.sqrt_nonneg _),
         Real.mul_self_sqrt (add_nonneg (mul_self_nonneg _) (mul_self_nonneg _))]
-      cases' hp1 with hp1 hp1
-      · rw [hp1]
+      cases' hp₁ with hp₁ hp₁
+      · rw [hp₁]
         rw [hpo,
           dist_sq_smul_orthogonal_vadd_smul_orthogonal_vadd (orthogonalProjection_mem p) hcc _ _
             (vsub_orthogonalProjection_mem_direction_orthogonal s p),
@@ -120,9 +120,9 @@ theorem existsUnique_dist_eq_of_insert {s : AffineSubspace ℝ P}
         simp (disch := field_simp_discharge) only [div_div, sub_div', one_mul, mul_div_assoc',
           div_mul_eq_mul_div, add_div', eq_div_iff, div_eq_iff, ycc₂]
         ring
-      · rw [dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq _ (hps hp1),
+      · rw [dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq _ (hps hp₁),
           orthogonalProjection_vadd_smul_vsub_orthogonalProjection _ _ hcc, Subtype.coe_mk,
-          dist_of_mem_subset_mk_sphere hp1 hcr, dist_eq_norm_vsub V cc₂ cc, vadd_vsub, norm_smul, ←
+          dist_of_mem_subset_mk_sphere hp₁ hcr, dist_eq_norm_vsub V cc₂ cc, vadd_vsub, norm_smul, ←
           dist_eq_norm_vsub V, Real.norm_eq_abs, abs_div, abs_of_nonneg dist_nonneg,
           div_mul_cancel₀ _ hy0, abs_mul_abs_self]
   · rintro ⟨cc₃, cr₃⟩ ⟨hcc₃, hcr₃⟩
@@ -130,8 +130,8 @@ theorem existsUnique_dist_eq_of_insert {s : AffineSubspace ℝ P}
     obtain ⟨t₃, cc₃', hcc₃', hcc₃''⟩ :
       ∃ r : ℝ, ∃ p0 ∈ s, cc₃ = r • (p -ᵥ ↑((orthogonalProjection s) p)) +ᵥ p0 := by
       rwa [mem_affineSpan_insert_iff (orthogonalProjection_mem p)] at hcc₃
-    have hcr₃' : ∃ r, ∀ p1 ∈ ps, dist p1 cc₃ = r :=
-      ⟨cr₃, fun p1 hp1 => dist_of_mem_subset_mk_sphere (Set.mem_insert_of_mem _ hp1) hcr₃⟩
+    have hcr₃' : ∃ r, ∀ p₁ ∈ ps, dist p₁ cc₃ = r :=
+      ⟨cr₃, fun p₁ hp₁ => dist_of_mem_subset_mk_sphere (Set.mem_insert_of_mem _ hp₁) hcr₃⟩
     rw [exists_dist_eq_iff_exists_dist_orthogonalProjection_eq hps cc₃, hcc₃'',
       orthogonalProjection_vadd_smul_vsub_orthogonalProjection _ _ hcc₃'] at hcr₃'
     cases' hcr₃' with cr₃' hcr₃'
@@ -395,8 +395,8 @@ orthogonal projection, produces the original point if the vector is a
 multiple of the result of subtracting a point's orthogonal projection
 from that point. -/
 theorem orthogonalProjection_vadd_smul_vsub_orthogonalProjection {n : ℕ} (s : Simplex ℝ P n)
-    {p1 : P} (p2 : P) (r : ℝ) (hp : p1 ∈ affineSpan ℝ (Set.range s.points)) :
-    s.orthogonalProjectionSpan (r • (p2 -ᵥ s.orthogonalProjectionSpan p2 : V) +ᵥ p1) = ⟨p1, hp⟩ :=
+    {p₁ : P} (p₂ : P) (r : ℝ) (hp : p₁ ∈ affineSpan ℝ (Set.range s.points)) :
+    s.orthogonalProjectionSpan (r • (p₂ -ᵥ s.orthogonalProjectionSpan p₂ : V) +ᵥ p₁) = ⟨p₁, hp⟩ :=
   EuclideanGeometry.orthogonalProjection_vadd_smul_vsub_orthogonalProjection _ _ _
 
 theorem coe_orthogonalProjection_vadd_smul_vsub_orthogonalProjection {n : ℕ} {r₁ : ℝ}
@@ -405,16 +405,16 @@ theorem coe_orthogonalProjection_vadd_smul_vsub_orthogonalProjection {n : ℕ} {
   congrArg ((↑) : _ → P) (orthogonalProjection_vadd_smul_vsub_orthogonalProjection _ _ _ hp₁o)
 
 theorem dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq {n : ℕ}
-    (s : Simplex ℝ P n) {p1 : P} (p2 : P) (hp1 : p1 ∈ affineSpan ℝ (Set.range s.points)) :
-    dist p1 p2 * dist p1 p2 =
-      dist p1 (s.orthogonalProjectionSpan p2) * dist p1 (s.orthogonalProjectionSpan p2) +
-        dist p2 (s.orthogonalProjectionSpan p2) * dist p2 (s.orthogonalProjectionSpan p2) := by
-  rw [PseudoMetricSpace.dist_comm p2 _, dist_eq_norm_vsub V p1 _, dist_eq_norm_vsub V p1 _,
-    dist_eq_norm_vsub V _ p2, ← vsub_add_vsub_cancel p1 (s.orthogonalProjectionSpan p2) p2,
+    (s : Simplex ℝ P n) {p₁ : P} (p₂ : P) (hp₁ : p₁ ∈ affineSpan ℝ (Set.range s.points)) :
+    dist p₁ p₂ * dist p₁ p₂ =
+      dist p₁ (s.orthogonalProjectionSpan p₂) * dist p₁ (s.orthogonalProjectionSpan p₂) +
+        dist p₂ (s.orthogonalProjectionSpan p₂) * dist p₂ (s.orthogonalProjectionSpan p₂) := by
+  rw [PseudoMetricSpace.dist_comm p₂ _, dist_eq_norm_vsub V p₁ _, dist_eq_norm_vsub V p₁ _,
+    dist_eq_norm_vsub V _ p₂, ← vsub_add_vsub_cancel p₁ (s.orthogonalProjectionSpan p₂) p₂,
     norm_add_sq_eq_norm_sq_add_norm_sq_iff_real_inner_eq_zero]
   exact
-    Submodule.inner_right_of_mem_orthogonal (vsub_orthogonalProjection_mem_direction p2 hp1)
-      (orthogonalProjection_vsub_mem_direction_orthogonal _ p2)
+    Submodule.inner_right_of_mem_orthogonal (vsub_orthogonalProjection_mem_direction p₂ hp₁)
+      (orthogonalProjection_vsub_mem_direction_orthogonal _ p₂)
 
 theorem dist_circumcenter_sq_eq_sq_sub_circumradius {n : ℕ} {r : ℝ} (s : Simplex ℝ P n) {p₁ : P}
     (h₁ : ∀ i : Fin (n + 1), dist (s.points i) p₁ = r)

--- a/Mathlib/Geometry/Euclidean/Triangle.lean
+++ b/Mathlib/Geometry/Euclidean/Triangle.lean
@@ -25,10 +25,6 @@ non-degeneracy conditions needed for the particular result, rather
 than requiring affine independence of the points of a triangle
 unnecessarily.
 
-## TODO
-
-Change variable names here: https://leanprover-community.github.io/100.html#27
-
 ## References
 
 * https://en.wikipedia.org/wiki/Law_of_cosines

--- a/Mathlib/Geometry/Euclidean/Triangle.lean
+++ b/Mathlib/Geometry/Euclidean/Triangle.lean
@@ -25,6 +25,10 @@ non-degeneracy conditions needed for the particular result, rather
 than requiring affine independence of the points of a triangle
 unnecessarily.
 
+## TODO
+
+Change variable names here: https://leanprover-community.github.io/100.html#27
+
 ## References
 
 * https://en.wikipedia.org/wiki/Law_of_cosines
@@ -250,53 +254,53 @@ variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V
   [NormedAddTorsor V P]
 
 /-- **Law of cosines** (cosine rule), angle-at-point form. -/
-theorem dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle (p1 p2 p3 : P) :
-    dist p1 p3 * dist p1 p3 = dist p1 p2 * dist p1 p2 + dist p3 p2 * dist p3 p2 -
-      2 * dist p1 p2 * dist p3 p2 * Real.cos (∠ p1 p2 p3) := by
-  rw [dist_eq_norm_vsub V p1 p3, dist_eq_norm_vsub V p1 p2, dist_eq_norm_vsub V p3 p2]
+theorem dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle (p₁ p₂ p₃ : P) :
+    dist p₁ p₃ * dist p₁ p₃ = dist p₁ p₂ * dist p₁ p₂ + dist p₃ p₂ * dist p₃ p₂ -
+      2 * dist p₁ p₂ * dist p₃ p₂ * Real.cos (∠ p₁ p₂ p₃) := by
+  rw [dist_eq_norm_vsub V p₁ p₃, dist_eq_norm_vsub V p₁ p₂, dist_eq_norm_vsub V p₃ p₂]
   unfold angle
   convert norm_sub_sq_eq_norm_sq_add_norm_sq_sub_two_mul_norm_mul_norm_mul_cos_angle
-    (p1 -ᵥ p2 : V) (p3 -ᵥ p2 : V)
-  · exact (vsub_sub_vsub_cancel_right p1 p3 p2).symm
-  · exact (vsub_sub_vsub_cancel_right p1 p3 p2).symm
+    (p₁ -ᵥ p₂ : V) (p₃ -ᵥ p₂ : V)
+  · exact (vsub_sub_vsub_cancel_right p₁ p₃ p₂).symm
+  · exact (vsub_sub_vsub_cancel_right p₁ p₃ p₂).symm
 
 alias law_cos := dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle
 
 /-- **Isosceles Triangle Theorem**: Pons asinorum, angle-at-point form. -/
-theorem angle_eq_angle_of_dist_eq {p1 p2 p3 : P} (h : dist p1 p2 = dist p1 p3) :
-    ∠ p1 p2 p3 = ∠ p1 p3 p2 := by
-  rw [dist_eq_norm_vsub V p1 p2, dist_eq_norm_vsub V p1 p3] at h
+theorem angle_eq_angle_of_dist_eq {p₁ p₂ p₃ : P} (h : dist p₁ p₂ = dist p₁ p₃) :
+    ∠ p₁ p₂ p₃ = ∠ p₁ p₃ p₂ := by
+  rw [dist_eq_norm_vsub V p₁ p₂, dist_eq_norm_vsub V p₁ p₃] at h
   unfold angle
   convert angle_sub_eq_angle_sub_rev_of_norm_eq h
-  · exact (vsub_sub_vsub_cancel_left p3 p2 p1).symm
-  · exact (vsub_sub_vsub_cancel_left p2 p3 p1).symm
+  · exact (vsub_sub_vsub_cancel_left p₃ p₂ p₁).symm
+  · exact (vsub_sub_vsub_cancel_left p₂ p₃ p₁).symm
 
 /-- Converse of pons asinorum, angle-at-point form. -/
-theorem dist_eq_of_angle_eq_angle_of_angle_ne_pi {p1 p2 p3 : P} (h : ∠ p1 p2 p3 = ∠ p1 p3 p2)
-    (hpi : ∠ p2 p1 p3 ≠ π) : dist p1 p2 = dist p1 p3 := by
+theorem dist_eq_of_angle_eq_angle_of_angle_ne_pi {p₁ p₂ p₃ : P} (h : ∠ p₁ p₂ p₃ = ∠ p₁ p₃ p₂)
+    (hpi : ∠ p₂ p₁ p₃ ≠ π) : dist p₁ p₂ = dist p₁ p₃ := by
   unfold angle at h hpi
-  rw [dist_eq_norm_vsub V p1 p2, dist_eq_norm_vsub V p1 p3]
+  rw [dist_eq_norm_vsub V p₁ p₂, dist_eq_norm_vsub V p₁ p₃]
   rw [← angle_neg_neg, neg_vsub_eq_vsub_rev, neg_vsub_eq_vsub_rev] at hpi
-  rw [← vsub_sub_vsub_cancel_left p3 p2 p1, ← vsub_sub_vsub_cancel_left p2 p3 p1] at h
+  rw [← vsub_sub_vsub_cancel_left p₃ p₂ p₁, ← vsub_sub_vsub_cancel_left p₂ p₃ p₁] at h
   exact norm_eq_of_angle_sub_eq_angle_sub_rev_of_angle_ne_pi h hpi
 
 /-- The **sum of the angles of a triangle** (possibly degenerate, where the
 given vertex is distinct from the others), angle-at-point. -/
-theorem angle_add_angle_add_angle_eq_pi {p1 p2 p3 : P} (h2 : p2 ≠ p1) (h3 : p3 ≠ p1) :
-    ∠ p1 p2 p3 + ∠ p2 p3 p1 + ∠ p3 p1 p2 = π := by
-  rw [add_assoc, add_comm, add_comm (∠ p2 p3 p1), angle_comm p2 p3 p1]
+theorem angle_add_angle_add_angle_eq_pi {p₁ p₂ p₃ : P} (h2 : p₂ ≠ p₁) (h3 : p₃ ≠ p₁) :
+    ∠ p₁ p₂ p₃ + ∠ p₂ p₃ p₁ + ∠ p₃ p₁ p₂ = π := by
+  rw [add_assoc, add_comm, add_comm (∠ p₂ p₃ p₁), angle_comm p₂ p₃ p₁]
   unfold angle
-  rw [← angle_neg_neg (p1 -ᵥ p3), ← angle_neg_neg (p1 -ᵥ p2), neg_vsub_eq_vsub_rev,
+  rw [← angle_neg_neg (p₁ -ᵥ p₃), ← angle_neg_neg (p₁ -ᵥ p₂), neg_vsub_eq_vsub_rev,
     neg_vsub_eq_vsub_rev, neg_vsub_eq_vsub_rev, neg_vsub_eq_vsub_rev, ←
-    vsub_sub_vsub_cancel_right p3 p2 p1, ← vsub_sub_vsub_cancel_right p2 p3 p1]
+    vsub_sub_vsub_cancel_right p₃ p₂ p₁, ← vsub_sub_vsub_cancel_right p₂ p₃ p₁]
   exact angle_add_angle_sub_add_angle_sub_eq_pi (fun he => h3 (vsub_eq_zero_iff_eq.1 he)) fun he =>
     h2 (vsub_eq_zero_iff_eq.1 he)
 
 /-- The **sum of the angles of a triangle** (possibly degenerate, where the triangle is a line),
 oriented angles at point. -/
 theorem oangle_add_oangle_add_oangle_eq_pi [Module.Oriented ℝ V (Fin 2)]
-    [Fact (Module.finrank ℝ V = 2)] {p1 p2 p3 : P} (h21 : p2 ≠ p1) (h32 : p3 ≠ p2)
-    (h13 : p1 ≠ p3) : ∡ p1 p2 p3 + ∡ p2 p3 p1 + ∡ p3 p1 p2 = π := by
+    [Fact (Module.finrank ℝ V = 2)] {p₁ p₂ p₃ : P} (h21 : p₂ ≠ p₁) (h32 : p₃ ≠ p₂)
+    (h13 : p₁ ≠ p₃) : ∡ p₁ p₂ p₃ + ∡ p₂ p₃ p₁ + ∡ p₃ p₁ p₂ = π := by
   simpa only [neg_vsub_eq_vsub_rev] using
     positiveOrientation.oangle_add_cyc3_neg_left (vsub_ne_zero.mpr h21) (vsub_ne_zero.mpr h32)
       (vsub_ne_zero.mpr h13)

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean
@@ -86,9 +86,9 @@ theorem vsub_set_subset_vectorSpan (s : Set P) : s -ᵥ s ⊆ ↑(vectorSpan k s
   Submodule.subset_span
 
 /-- Each pairwise difference is in the `vectorSpan`. -/
-theorem vsub_mem_vectorSpan {s : Set P} {p1 p2 : P} (hp1 : p1 ∈ s) (hp2 : p2 ∈ s) :
-    p1 -ᵥ p2 ∈ vectorSpan k s :=
-  vsub_set_subset_vectorSpan k s (vsub_mem_vsub hp1 hp2)
+theorem vsub_mem_vectorSpan {s : Set P} {p₁ p₂ : P} (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) :
+    p₁ -ᵥ p₂ ∈ vectorSpan k s :=
+  vsub_set_subset_vectorSpan k s (vsub_mem_vsub hp₁ hp₂)
 
 @[simp] lemma vectorSpan_vadd (s : Set P) (v : V) : vectorSpan k (v +ᵥ s) = vectorSpan k s := by
   simp [vectorSpan]
@@ -96,7 +96,7 @@ theorem vsub_mem_vectorSpan {s : Set P} {p1 p2 : P} (hp1 : p1 ∈ s) (hp2 : p2 �
 /-- The points in the affine span of a (possibly empty) set of points. Use `affineSpan` instead to
 get an `AffineSubspace k P`. -/
 def spanPoints (s : Set P) : Set P :=
-  { p | ∃ p1 ∈ s, ∃ v ∈ vectorSpan k s, p = v +ᵥ p1 }
+  { p | ∃ p₁ ∈ s, ∃ v ∈ vectorSpan k s, p = v +ᵥ p₁ }
 
 /-- A point in a set is in its affine span. -/
 theorem mem_spanPoints (p : P) (s : Set P) : p ∈ s → p ∈ spanPoints k s
@@ -119,19 +119,19 @@ theorem spanPoints_nonempty (s : Set P) : (spanPoints k s).Nonempty ↔ s.Nonemp
 affine span. -/
 theorem vadd_mem_spanPoints_of_mem_spanPoints_of_mem_vectorSpan {s : Set P} {p : P} {v : V}
     (hp : p ∈ spanPoints k s) (hv : v ∈ vectorSpan k s) : v +ᵥ p ∈ spanPoints k s := by
-  rcases hp with ⟨p2, ⟨hp2, ⟨v2, ⟨hv2, hv2p⟩⟩⟩⟩
-  rw [hv2p, vadd_vadd]
-  exact ⟨p2, hp2, v + v2, (vectorSpan k s).add_mem hv hv2, rfl⟩
+  rcases hp with ⟨p₂, ⟨hp₂, ⟨v₂, ⟨hv₂, hv₂p⟩⟩⟩⟩
+  rw [hv₂p, vadd_vadd]
+  exact ⟨p₂, hp₂, v + v₂, (vectorSpan k s).add_mem hv hv₂, rfl⟩
 
 /-- Subtracting two points in the affine span produces a vector in the spanning submodule. -/
-theorem vsub_mem_vectorSpan_of_mem_spanPoints_of_mem_spanPoints {s : Set P} {p1 p2 : P}
-    (hp1 : p1 ∈ spanPoints k s) (hp2 : p2 ∈ spanPoints k s) : p1 -ᵥ p2 ∈ vectorSpan k s := by
-  rcases hp1 with ⟨p1a, ⟨hp1a, ⟨v1, ⟨hv1, hv1p⟩⟩⟩⟩
-  rcases hp2 with ⟨p2a, ⟨hp2a, ⟨v2, ⟨hv2, hv2p⟩⟩⟩⟩
-  rw [hv1p, hv2p, vsub_vadd_eq_vsub_sub (v1 +ᵥ p1a), vadd_vsub_assoc, add_comm, add_sub_assoc]
-  have hv1v2 : v1 - v2 ∈ vectorSpan k s := (vectorSpan k s).sub_mem hv1 hv2
-  refine (vectorSpan k s).add_mem ?_ hv1v2
-  exact vsub_mem_vectorSpan k hp1a hp2a
+theorem vsub_mem_vectorSpan_of_mem_spanPoints_of_mem_spanPoints {s : Set P} {p₁ p₂ : P}
+    (hp₁ : p₁ ∈ spanPoints k s) (hp₂ : p₂ ∈ spanPoints k s) : p₁ -ᵥ p₂ ∈ vectorSpan k s := by
+  rcases hp₁ with ⟨p₁a, ⟨hp₁a, ⟨v₁, ⟨hv₁, hv₁p⟩⟩⟩⟩
+  rcases hp₂ with ⟨p₂a, ⟨hp₂a, ⟨v₂, ⟨hv₂, hv₂p⟩⟩⟩⟩
+  rw [hv₁p, hv₂p, vsub_vadd_eq_vsub_sub (v₁ +ᵥ p₁a), vadd_vsub_assoc, add_comm, add_sub_assoc]
+  have hv₁v₂ : v₁ - v₂ ∈ vectorSpan k s := (vectorSpan k s).sub_mem hv₁ hv₂
+  refine (vectorSpan k s).add_mem ?_ hv₁v₂
+  exact vsub_mem_vectorSpan k hp₁a hp₂a
 
 end
 
@@ -142,8 +142,8 @@ structure AffineSubspace (k : Type*) {V : Type*} (P : Type*) [Ring k] [AddCommGr
   /-- The affine subspace seen as a subset. -/
   carrier : Set P
   smul_vsub_vadd_mem :
-    ∀ (c : k) {p1 p2 p3 : P},
-      p1 ∈ carrier → p2 ∈ carrier → p3 ∈ carrier → c • (p1 -ᵥ p2 : V) +ᵥ p3 ∈ carrier
+    ∀ (c : k) {p₁ p₂ p₃ : P},
+      p₁ ∈ carrier → p₂ ∈ carrier → p₃ ∈ carrier → c • (p₁ -ᵥ p₂ : V) +ᵥ p₃ ∈ carrier
 
 namespace Submodule
 
@@ -194,16 +194,16 @@ def directionOfNonempty {s : AffineSubspace k P} (h : (s : Set P).Nonempty) : Su
     cases' h with p hp
     exact vsub_self p ▸ vsub_mem_vsub hp hp
   add_mem' := by
-    rintro _ _ ⟨p1, hp1, p2, hp2, rfl⟩ ⟨p3, hp3, p4, hp4, rfl⟩
+    rintro _ _ ⟨p₁, hp₁, p₂, hp₂, rfl⟩ ⟨p₃, hp₃, p₄, hp₄, rfl⟩
     rw [← vadd_vsub_assoc]
-    refine vsub_mem_vsub ?_ hp4
-    convert s.smul_vsub_vadd_mem 1 hp1 hp2 hp3
+    refine vsub_mem_vsub ?_ hp₄
+    convert s.smul_vsub_vadd_mem 1 hp₁ hp₂ hp₃
     rw [one_smul]
   smul_mem' := by
-    rintro c _ ⟨p1, hp1, p2, hp2, rfl⟩
-    rw [← vadd_vsub (c • (p1 -ᵥ p2)) p2]
-    refine vsub_mem_vsub ?_ hp2
-    exact s.smul_vsub_vadd_mem c hp1 hp2 hp2
+    rintro c _ ⟨p₁, hp₁, p₂, hp₂, rfl⟩
+    rw [← vadd_vsub (c • (p₁ -ᵥ p₂)) p₂]
+    refine vsub_mem_vsub ?_ hp₂
+    exact s.smul_vsub_vadd_mem c hp₁ hp₂ hp₂
 
 /-- `direction_of_nonempty` gives the same submodule as `direction`. -/
 theorem directionOfNonempty_eq_direction {s : AffineSubspace k P} (h : (s : Set P).Nonempty) :
@@ -221,7 +221,7 @@ theorem coe_direction_eq_vsub_set {s : AffineSubspace k P} (h : (s : Set P).None
 /-- A vector is in the direction of a nonempty affine subspace if and only if it is the subtraction
 of two vectors in the subspace. -/
 theorem mem_direction_iff_eq_vsub {s : AffineSubspace k P} (h : (s : Set P).Nonempty) (v : V) :
-    v ∈ s.direction ↔ ∃ p1 ∈ s, ∃ p2 ∈ s, v = p1 -ᵥ p2 := by
+    v ∈ s.direction ↔ ∃ p₁ ∈ s, ∃ p₂ ∈ s, v = p₁ -ᵥ p₂ := by
   rw [← SetLike.mem_coe, coe_direction_eq_vsub_set h, Set.mem_vsub]
   simp only [SetLike.mem_coe, eq_comm]
 
@@ -230,15 +230,15 @@ subspace. -/
 theorem vadd_mem_of_mem_direction {s : AffineSubspace k P} {v : V} (hv : v ∈ s.direction) {p : P}
     (hp : p ∈ s) : v +ᵥ p ∈ s := by
   rw [mem_direction_iff_eq_vsub ⟨p, hp⟩] at hv
-  rcases hv with ⟨p1, hp1, p2, hp2, hv⟩
+  rcases hv with ⟨p₁, hp₁, p₂, hp₂, hv⟩
   rw [hv]
-  convert s.smul_vsub_vadd_mem 1 hp1 hp2 hp
+  convert s.smul_vsub_vadd_mem 1 hp₁ hp₂ hp
   rw [one_smul]
 
 /-- Subtracting two points in the subspace produces a vector in the direction. -/
-theorem vsub_mem_direction {s : AffineSubspace k P} {p1 p2 : P} (hp1 : p1 ∈ s) (hp2 : p2 ∈ s) :
-    p1 -ᵥ p2 ∈ s.direction :=
-  vsub_mem_vectorSpan k hp1 hp2
+theorem vsub_mem_direction {s : AffineSubspace k P} {p₁ p₂ : P} (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) :
+    p₁ -ᵥ p₂ ∈ s.direction :=
+  vsub_mem_vectorSpan k hp₁ hp₂
 
 /-- Adding a vector to a point in a subspace produces a point in the subspace if and only if the
 vector is in the direction. -/
@@ -260,11 +260,11 @@ theorem coe_direction_eq_vsub_set_right {s : AffineSubspace k P} {p : P} (hp : p
     (s.direction : Set V) = (· -ᵥ p) '' s := by
   rw [coe_direction_eq_vsub_set ⟨p, hp⟩]
   refine le_antisymm ?_ ?_
-  · rintro v ⟨p1, hp1, p2, hp2, rfl⟩
-    exact ⟨(p1 -ᵥ p2) +ᵥ p,
-      vadd_mem_of_mem_direction (vsub_mem_direction hp1 hp2) hp, vadd_vsub _ _⟩
-  · rintro v ⟨p2, hp2, rfl⟩
-    exact ⟨p2, hp2, p, hp, rfl⟩
+  · rintro v ⟨p₁, hp₁, p₂, hp₂, rfl⟩
+    exact ⟨(p₁ -ᵥ p₂) +ᵥ p,
+      vadd_mem_of_mem_direction (vsub_mem_direction hp₁ hp₂) hp, vadd_vsub _ _⟩
+  · rintro v ⟨p₂, hp₂, rfl⟩
+    exact ⟨p₂, hp₂, p, hp, rfl⟩
 
 /-- Given a point in an affine subspace, the set of vectors in its direction equals the set of
 vectors subtracting that point on the left. -/
@@ -281,28 +281,28 @@ theorem coe_direction_eq_vsub_set_left {s : AffineSubspace k P} {p : P} (hp : p 
 /-- Given a point in an affine subspace, a vector is in its direction if and only if it results from
 subtracting that point on the right. -/
 theorem mem_direction_iff_eq_vsub_right {s : AffineSubspace k P} {p : P} (hp : p ∈ s) (v : V) :
-    v ∈ s.direction ↔ ∃ p2 ∈ s, v = p2 -ᵥ p := by
+    v ∈ s.direction ↔ ∃ p₂ ∈ s, v = p₂ -ᵥ p := by
   rw [← SetLike.mem_coe, coe_direction_eq_vsub_set_right hp]
-  exact ⟨fun ⟨p2, hp2, hv⟩ => ⟨p2, hp2, hv.symm⟩, fun ⟨p2, hp2, hv⟩ => ⟨p2, hp2, hv.symm⟩⟩
+  exact ⟨fun ⟨p₂, hp₂, hv⟩ => ⟨p₂, hp₂, hv.symm⟩, fun ⟨p₂, hp₂, hv⟩ => ⟨p₂, hp₂, hv.symm⟩⟩
 
 /-- Given a point in an affine subspace, a vector is in its direction if and only if it results from
 subtracting that point on the left. -/
 theorem mem_direction_iff_eq_vsub_left {s : AffineSubspace k P} {p : P} (hp : p ∈ s) (v : V) :
-    v ∈ s.direction ↔ ∃ p2 ∈ s, v = p -ᵥ p2 := by
+    v ∈ s.direction ↔ ∃ p₂ ∈ s, v = p -ᵥ p₂ := by
   rw [← SetLike.mem_coe, coe_direction_eq_vsub_set_left hp]
-  exact ⟨fun ⟨p2, hp2, hv⟩ => ⟨p2, hp2, hv.symm⟩, fun ⟨p2, hp2, hv⟩ => ⟨p2, hp2, hv.symm⟩⟩
+  exact ⟨fun ⟨p₂, hp₂, hv⟩ => ⟨p₂, hp₂, hv.symm⟩, fun ⟨p₂, hp₂, hv⟩ => ⟨p₂, hp₂, hv.symm⟩⟩
 
 /-- Given a point in an affine subspace, a result of subtracting that point on the right is in the
 direction if and only if the other point is in the subspace. -/
-theorem vsub_right_mem_direction_iff_mem {s : AffineSubspace k P} {p : P} (hp : p ∈ s) (p2 : P) :
-    p2 -ᵥ p ∈ s.direction ↔ p2 ∈ s := by
+theorem vsub_right_mem_direction_iff_mem {s : AffineSubspace k P} {p : P} (hp : p ∈ s) (p₂ : P) :
+    p₂ -ᵥ p ∈ s.direction ↔ p₂ ∈ s := by
   rw [mem_direction_iff_eq_vsub_right hp]
   simp
 
 /-- Given a point in an affine subspace, a result of subtracting that point on the left is in the
 direction if and only if the other point is in the subspace. -/
-theorem vsub_left_mem_direction_iff_mem {s : AffineSubspace k P} {p : P} (hp : p ∈ s) (p2 : P) :
-    p -ᵥ p2 ∈ s.direction ↔ p2 ∈ s := by
+theorem vsub_left_mem_direction_iff_mem {s : AffineSubspace k P} {p : P} (hp : p ∈ s) (p₂ : P) :
+    p -ᵥ p₂ ∈ s.direction ↔ p₂ ∈ s := by
   rw [mem_direction_iff_eq_vsub_left hp]
   simp
 
@@ -318,8 +318,8 @@ protected theorem ext_iff (s₁ s₂ : AffineSubspace k P) : s₁ = s₂ ↔ (s�
   SetLike.ext'_iff
 
 /-- Two affine subspaces with the same direction and nonempty intersection are equal. -/
-theorem ext_of_direction_eq {s1 s2 : AffineSubspace k P} (hd : s1.direction = s2.direction)
-    (hn : ((s1 : Set P) ∩ s2).Nonempty) : s1 = s2 := by
+theorem ext_of_direction_eq {s₁ s₂ : AffineSubspace k P} (hd : s₁.direction = s₂.direction)
+    (hn : ((s₁ : Set P) ∩ s₂).Nonempty) : s₁ = s₂ := by
   ext p
   have hq1 := Set.mem_of_mem_inter_left hn.some_mem
   have hq2 := Set.mem_of_mem_inter_right hn.some_mem
@@ -393,12 +393,12 @@ theorem eq_iff_direction_eq_of_mem {s₁ s₂ : AffineSubspace k P} {p : P} (h�
 /-- Construct an affine subspace from a point and a direction. -/
 def mk' (p : P) (direction : Submodule k V) : AffineSubspace k P where
   carrier := { q | ∃ v ∈ direction, q = v +ᵥ p }
-  smul_vsub_vadd_mem c p1 p2 p3 hp1 hp2 hp3 := by
-    rcases hp1 with ⟨v1, hv1, hp1⟩
-    rcases hp2 with ⟨v2, hv2, hp2⟩
-    rcases hp3 with ⟨v3, hv3, hp3⟩
-    use c • (v1 - v2) + v3, direction.add_mem (direction.smul_mem c (direction.sub_mem hv1 hv2)) hv3
-    simp [hp1, hp2, hp3, vadd_vadd]
+  smul_vsub_vadd_mem c p₁ p₂ p₃ hp₁ hp₂ hp₃ := by
+    rcases hp₁ with ⟨v₁, hv₁, hp₁⟩
+    rcases hp₂ with ⟨v₂, hv₂, hp₂⟩
+    rcases hp₃ with ⟨v₃, hv₃, hp₃⟩
+    use c • (v₁ - v₂) + v₃, direction.add_mem (direction.smul_mem c (direction.sub_mem hv₁ hv₂)) hv₃
+    simp [hp₁, hp₂, hp₃, vadd_vadd]
 
 /-- An affine subspace constructed from a point and a direction contains that point. -/
 theorem self_mem_mk' (p : P) (direction : Submodule k V) : p ∈ mk' p direction :=
@@ -421,9 +421,9 @@ theorem direction_mk' (p : P) (direction : Submodule k V) :
   ext v
   rw [mem_direction_iff_eq_vsub (mk'_nonempty _ _)]
   constructor
-  · rintro ⟨p1, ⟨v1, hv1, hp1⟩, p2, ⟨v2, hv2, hp2⟩, hv⟩
-    rw [hv, hp1, hp2, vadd_vsub_vadd_cancel_right]
-    exact direction.sub_mem hv1 hv2
+  · rintro ⟨p₁, ⟨v₁, hv₁, hp₁⟩, p₂, ⟨v₂, hv₂, hp₂⟩, hv⟩
+    rw [hv, hp₁, hp₂, vadd_vsub_vadd_cancel_right]
+    exact direction.sub_mem hv₁ hv₂
   · exact fun hv => ⟨v +ᵥ p, vadd_mem_mk' _ hv, p, self_mem_mk' _ _, (vadd_vsub _ _).symm⟩
 
 /-- A point lies in an affine subspace constructed from another point and a direction if and only
@@ -443,13 +443,13 @@ theorem mk'_eq {s : AffineSubspace k P} {p : P} (hp : p ∈ s) : mk' p s.directi
   ext_of_direction_eq (direction_mk' p s.direction) ⟨p, Set.mem_inter (self_mem_mk' _ _) hp⟩
 
 /-- If an affine subspace contains a set of points, it contains the `spanPoints` of that set. -/
-theorem spanPoints_subset_coe_of_subset_coe {s : Set P} {s1 : AffineSubspace k P} (h : s ⊆ s1) :
-    spanPoints k s ⊆ s1 := by
-  rintro p ⟨p1, hp1, v, hv, hp⟩
+theorem spanPoints_subset_coe_of_subset_coe {s : Set P} {s₁ : AffineSubspace k P} (h : s ⊆ s₁) :
+    spanPoints k s ⊆ s₁ := by
+  rintro p ⟨p₁, hp₁, v, hv, hp⟩
   rw [hp]
-  have hp1s1 : p1 ∈ (s1 : Set P) := Set.mem_of_mem_of_subset hp1 h
-  refine vadd_mem_of_mem_direction ?_ hp1s1
-  have hs : vectorSpan k s ≤ s1.direction := vectorSpan_mono k h
+  have hp₁s₁ : p₁ ∈ (s₁ : Set P) := Set.mem_of_mem_of_subset hp₁ h
+  refine vadd_mem_of_mem_direction ?_ hp₁s₁
+  have hs : vectorSpan k s ≤ s₁.direction := vectorSpan_mono k h
   rw [SetLike.le_def] at hs
   rw [← SetLike.mem_coe]
   exact Set.mem_of_mem_of_subset hv hs
@@ -486,10 +486,10 @@ variable (k : Type*) {V : Type*} {P : Type*} [Ring k] [AddCommGroup V] [Module k
 (Actually defined here in terms of spans in modules.) -/
 def affineSpan (s : Set P) : AffineSubspace k P where
   carrier := spanPoints k s
-  smul_vsub_vadd_mem c _ _ _ hp1 hp2 hp3 :=
-    vadd_mem_spanPoints_of_mem_spanPoints_of_mem_vectorSpan k hp3
+  smul_vsub_vadd_mem c _ _ _ hp₁ hp₂ hp₃ :=
+    vadd_mem_spanPoints_of_mem_spanPoints_of_mem_vectorSpan k hp₃
       ((vectorSpan k s).smul_mem c
-        (vsub_mem_vectorSpan_of_mem_spanPoints_of_mem_spanPoints k hp1 hp2))
+        (vsub_mem_vectorSpan_of_mem_spanPoints_of_mem_spanPoints k hp₁ hp₂))
 
 /-- The affine span, converted to a set, is `spanPoints`. -/
 @[simp]
@@ -504,11 +504,11 @@ theorem subset_affineSpan (s : Set P) : s ⊆ affineSpan k s :=
 theorem direction_affineSpan (s : Set P) : (affineSpan k s).direction = vectorSpan k s := by
   apply le_antisymm
   · refine Submodule.span_le.2 ?_
-    rintro v ⟨p1, ⟨p2, hp2, v1, hv1, hp1⟩, p3, ⟨p4, hp4, v2, hv2, hp3⟩, rfl⟩
+    rintro v ⟨p₁, ⟨p₂, hp₂, v₁, hv₁, hp₁⟩, p₃, ⟨p₄, hp₄, v₂, hv₂, hp₃⟩, rfl⟩
     simp only [SetLike.mem_coe]
-    rw [hp1, hp3, vsub_vadd_eq_vsub_sub, vadd_vsub_assoc]
+    rw [hp₁, hp₃, vsub_vadd_eq_vsub_sub, vadd_vsub_assoc]
     exact
-      (vectorSpan k s).sub_mem ((vectorSpan k s).add_mem hv1 (vsub_mem_vectorSpan k hp2 hp4)) hv2
+      (vectorSpan k s).sub_mem ((vectorSpan k s).add_mem hv₁ (vsub_mem_vectorSpan k hp₂ hp₄)) hv₂
   · exact vectorSpan_mono k (subset_spanPoints k s)
 
 /-- A point in a set is in its affine span. -/
@@ -532,22 +532,22 @@ instance : CompleteLattice (AffineSubspace k P) :=
   {
     PartialOrder.lift ((↑) : AffineSubspace k P → Set P)
       coe_injective with
-    sup := fun s1 s2 => affineSpan k (s1 ∪ s2)
+    sup := fun s₁ s₂ => affineSpan k (s₁ ∪ s₂)
     le_sup_left := fun _ _ =>
       Set.Subset.trans Set.subset_union_left (subset_spanPoints k _)
     le_sup_right := fun _ _ =>
       Set.Subset.trans Set.subset_union_right (subset_spanPoints k _)
-    sup_le := fun _ _ _ hs1 hs2 => spanPoints_subset_coe_of_subset_coe (Set.union_subset hs1 hs2)
-    inf := fun s1 s2 =>
-      mk (s1 ∩ s2) fun c _ _ _ hp1 hp2 hp3 =>
-        ⟨s1.smul_vsub_vadd_mem c hp1.1 hp2.1 hp3.1, s2.smul_vsub_vadd_mem c hp1.2 hp2.2 hp3.2⟩
+    sup_le := fun _ _ _ hs₁ hs₂ => spanPoints_subset_coe_of_subset_coe (Set.union_subset hs₁ hs₂)
+    inf := fun s₁ s₂ =>
+      mk (s₁ ∩ s₂) fun c _ _ _ hp₁ hp₂ hp₃ =>
+        ⟨s₁.smul_vsub_vadd_mem c hp₁.1 hp₂.1 hp₃.1, s₂.smul_vsub_vadd_mem c hp₁.2 hp₂.2 hp₃.2⟩
     inf_le_left := fun _ _ => Set.inter_subset_left
     inf_le_right := fun _ _ => Set.inter_subset_right
-    le_sInf := fun S s1 hs1 => by
+    le_sInf := fun S s₁ hs₁ => by
       -- Porting note: surely there is an easier way?
-      refine Set.subset_sInter (t := (s1 : Set P)) ?_
+      refine Set.subset_sInter (t := (s₁ : Set P)) ?_
       rintro t ⟨s, _hs, rfl⟩
-      exact Set.subset_iInter (hs1 s)
+      exact Set.subset_iInter (hs₁ s)
     top :=
       { carrier := Set.univ
         smul_vsub_vadd_mem := fun _ _ _ _ _ _ _ => Set.mem_univ _ }
@@ -558,10 +558,10 @@ instance : CompleteLattice (AffineSubspace k P) :=
     bot_le := fun _ _ => False.elim
     sSup := fun s => affineSpan k (⋃ s' ∈ s, (s' : Set P))
     sInf := fun s =>
-      mk (⋂ s' ∈ s, (s' : Set P)) fun c p1 p2 p3 hp1 hp2 hp3 =>
-        Set.mem_iInter₂.2 fun s2 hs2 => by
+      mk (⋂ s' ∈ s, (s' : Set P)) fun c p₁ p₂ p₃ hp₁ hp₂ hp₃ =>
+        Set.mem_iInter₂.2 fun s₂ hs₂ => by
           rw [Set.mem_iInter₂] at *
-          exact s2.smul_vsub_vadd_mem c (hp1 s2 hs2) (hp2 s2 hs2) (hp3 s2 hs2)
+          exact s₂.smul_vsub_vadd_mem c (hp₁ s₂ hs₂) (hp₂ s₂ hs₂) (hp₃ s₂ hs₂)
     le_sSup := fun _ _ h => Set.Subset.trans (Set.subset_biUnion_of_mem h) (subset_spanPoints k _)
     sSup_le := fun _ _ h => spanPoints_subset_coe_of_subset_coe (Set.iUnion₂_subset h)
     sInf_le := fun _ _ => Set.biInter_subset_of_mem
@@ -571,31 +571,31 @@ instance : Inhabited (AffineSubspace k P) :=
   ⟨⊤⟩
 
 /-- The `≤` order on subspaces is the same as that on the corresponding sets. -/
-theorem le_def (s1 s2 : AffineSubspace k P) : s1 ≤ s2 ↔ (s1 : Set P) ⊆ s2 :=
+theorem le_def (s₁ s₂ : AffineSubspace k P) : s₁ ≤ s₂ ↔ (s₁ : Set P) ⊆ s₂ :=
   Iff.rfl
 
 /-- One subspace is less than or equal to another if and only if all its points are in the second
 subspace. -/
-theorem le_def' (s1 s2 : AffineSubspace k P) : s1 ≤ s2 ↔ ∀ p ∈ s1, p ∈ s2 :=
+theorem le_def' (s₁ s₂ : AffineSubspace k P) : s₁ ≤ s₂ ↔ ∀ p ∈ s₁, p ∈ s₂ :=
   Iff.rfl
 
 /-- The `<` order on subspaces is the same as that on the corresponding sets. -/
-theorem lt_def (s1 s2 : AffineSubspace k P) : s1 < s2 ↔ (s1 : Set P) ⊂ s2 :=
+theorem lt_def (s₁ s₂ : AffineSubspace k P) : s₁ < s₂ ↔ (s₁ : Set P) ⊂ s₂ :=
   Iff.rfl
 
 /-- One subspace is not less than or equal to another if and only if it has a point not in the
 second subspace. -/
-theorem not_le_iff_exists (s1 s2 : AffineSubspace k P) : ¬s1 ≤ s2 ↔ ∃ p ∈ s1, p ∉ s2 :=
+theorem not_le_iff_exists (s₁ s₂ : AffineSubspace k P) : ¬s₁ ≤ s₂ ↔ ∃ p ∈ s₁, p ∉ s₂ :=
   Set.not_subset
 
 /-- If a subspace is less than another, there is a point only in the second. -/
-theorem exists_of_lt {s1 s2 : AffineSubspace k P} (h : s1 < s2) : ∃ p ∈ s2, p ∉ s1 :=
+theorem exists_of_lt {s₁ s₂ : AffineSubspace k P} (h : s₁ < s₂) : ∃ p ∈ s₂, p ∉ s₁ :=
   Set.exists_of_ssubset h
 
 /-- A subspace is less than another if and only if it is less than or equal to the second subspace
 and there is a point only in the second. -/
-theorem lt_iff_le_and_exists (s1 s2 : AffineSubspace k P) :
-    s1 < s2 ↔ s1 ≤ s2 ∧ ∃ p ∈ s2, p ∉ s1 := by
+theorem lt_iff_le_and_exists (s₁ s₂ : AffineSubspace k P) :
+    s₁ < s₂ ↔ s₁ ≤ s₂ ∧ ∃ p ∈ s₂, p ∉ s₁ := by
   rw [lt_iff_le_not_le, not_le_iff_exists]
 
 /-- If an affine subspace is nonempty and contained in another with the same direction, they are
@@ -618,8 +618,8 @@ variable (P)
 /-- The Galois insertion formed by `affineSpan` and coercion back to a set. -/
 protected def gi : GaloisInsertion (affineSpan k) ((↑) : AffineSubspace k P → Set P) where
   choice s _ := affineSpan k s
-  gc s1 _s2 :=
-    ⟨fun h => Set.Subset.trans (subset_spanPoints k s1) h, spanPoints_subset_coe_of_subset_coe⟩
+  gc s₁ _s₂ :=
+    ⟨fun h => Set.Subset.trans (subset_spanPoints k s₁) h, spanPoints_subset_coe_of_subset_coe⟩
   le_l_u _ := subset_spanPoints k _
   choice_eq _ _ := rfl
 
@@ -814,17 +814,17 @@ theorem direction_eq_top_iff_of_nonempty {s : AffineSubspace k P} (h : (s : Set 
 /-- The inf of two affine subspaces, coerced to a set, is the intersection of the two sets of
 points. -/
 @[simp]
-theorem inf_coe (s1 s2 : AffineSubspace k P) : (s1 ⊓ s2 : Set P) = (s1 : Set P) ∩ s2 :=
+theorem inf_coe (s₁ s₂ : AffineSubspace k P) : (s₁ ⊓ s₂ : Set P) = (s₁ : Set P) ∩ s₂ :=
   rfl
 
 /-- A point is in the inf of two affine subspaces if and only if it is in both of them. -/
-theorem mem_inf_iff (p : P) (s1 s2 : AffineSubspace k P) : p ∈ s1 ⊓ s2 ↔ p ∈ s1 ∧ p ∈ s2 :=
+theorem mem_inf_iff (p : P) (s₁ s₂ : AffineSubspace k P) : p ∈ s₁ ⊓ s₂ ↔ p ∈ s₁ ∧ p ∈ s₂ :=
   Iff.rfl
 
 /-- The direction of the inf of two affine subspaces is less than or equal to the inf of their
 directions. -/
-theorem direction_inf (s1 s2 : AffineSubspace k P) :
-    (s1 ⊓ s2).direction ≤ s1.direction ⊓ s2.direction := by
+theorem direction_inf (s₁ s₂ : AffineSubspace k P) :
+    (s₁ ⊓ s₂).direction ≤ s₁.direction ⊓ s₂.direction := by
   simp only [direction_eq_vectorSpan, vectorSpan_def]
   exact
     le_inf (sInf_le_sInf fun p hp => trans (vsub_self_mono inter_subset_left) hp)
@@ -846,58 +846,58 @@ theorem direction_inf_of_mem_inf {s₁ s₂ : AffineSubspace k P} {p : P} (h : p
 
 /-- If one affine subspace is less than or equal to another, the same applies to their
 directions. -/
-theorem direction_le {s1 s2 : AffineSubspace k P} (h : s1 ≤ s2) : s1.direction ≤ s2.direction := by
+theorem direction_le {s₁ s₂ : AffineSubspace k P} (h : s₁ ≤ s₂) : s₁.direction ≤ s₂.direction := by
   simp only [direction_eq_vectorSpan, vectorSpan_def]
   exact vectorSpan_mono k h
 
 /-- If one nonempty affine subspace is less than another, the same applies to their directions -/
-theorem direction_lt_of_nonempty {s1 s2 : AffineSubspace k P} (h : s1 < s2)
-    (hn : (s1 : Set P).Nonempty) : s1.direction < s2.direction := by
+theorem direction_lt_of_nonempty {s₁ s₂ : AffineSubspace k P} (h : s₁ < s₂)
+    (hn : (s₁ : Set P).Nonempty) : s₁.direction < s₂.direction := by
   cases' hn with p hp
   rw [lt_iff_le_and_exists] at h
-  rcases h with ⟨hle, p2, hp2, hp2s1⟩
+  rcases h with ⟨hle, p₂, hp₂, hp₂s₁⟩
   rw [SetLike.lt_iff_le_and_exists]
-  use direction_le hle, p2 -ᵥ p, vsub_mem_direction hp2 (hle hp)
+  use direction_le hle, p₂ -ᵥ p, vsub_mem_direction hp₂ (hle hp)
   intro hm
-  rw [vsub_right_mem_direction_iff_mem hp p2] at hm
-  exact hp2s1 hm
+  rw [vsub_right_mem_direction_iff_mem hp p₂] at hm
+  exact hp₂s₁ hm
 
 /-- The sup of the directions of two affine subspaces is less than or equal to the direction of
 their sup. -/
-theorem sup_direction_le (s1 s2 : AffineSubspace k P) :
-    s1.direction ⊔ s2.direction ≤ (s1 ⊔ s2).direction := by
+theorem sup_direction_le (s₁ s₂ : AffineSubspace k P) :
+    s₁.direction ⊔ s₂.direction ≤ (s₁ ⊔ s₂).direction := by
   simp only [direction_eq_vectorSpan, vectorSpan_def]
   exact
     sup_le
-      (sInf_le_sInf fun p hp => Set.Subset.trans (vsub_self_mono (le_sup_left : s1 ≤ s1 ⊔ s2)) hp)
-      (sInf_le_sInf fun p hp => Set.Subset.trans (vsub_self_mono (le_sup_right : s2 ≤ s1 ⊔ s2)) hp)
+      (sInf_le_sInf fun p hp => Set.Subset.trans (vsub_self_mono (le_sup_left : s₁ ≤ s₁ ⊔ s₂)) hp)
+      (sInf_le_sInf fun p hp => Set.Subset.trans (vsub_self_mono (le_sup_right : s₂ ≤ s₁ ⊔ s₂)) hp)
 
 /-- The sup of the directions of two nonempty affine subspaces with empty intersection is less than
 the direction of their sup. -/
-theorem sup_direction_lt_of_nonempty_of_inter_empty {s1 s2 : AffineSubspace k P}
-    (h1 : (s1 : Set P).Nonempty) (h2 : (s2 : Set P).Nonempty) (he : (s1 ∩ s2 : Set P) = ∅) :
-    s1.direction ⊔ s2.direction < (s1 ⊔ s2).direction := by
-  cases' h1 with p1 hp1
-  cases' h2 with p2 hp2
+theorem sup_direction_lt_of_nonempty_of_inter_empty {s₁ s₂ : AffineSubspace k P}
+    (h1 : (s₁ : Set P).Nonempty) (h2 : (s₂ : Set P).Nonempty) (he : (s₁ ∩ s₂ : Set P) = ∅) :
+    s₁.direction ⊔ s₂.direction < (s₁ ⊔ s₂).direction := by
+  cases' h1 with p₁ hp₁
+  cases' h2 with p₂ hp₂
   rw [SetLike.lt_iff_le_and_exists]
-  use sup_direction_le s1 s2, p2 -ᵥ p1,
-    vsub_mem_direction ((le_sup_right : s2 ≤ s1 ⊔ s2) hp2) ((le_sup_left : s1 ≤ s1 ⊔ s2) hp1)
+  use sup_direction_le s₁ s₂, p₂ -ᵥ p₁,
+    vsub_mem_direction ((le_sup_right : s₂ ≤ s₁ ⊔ s₂) hp₂) ((le_sup_left : s₁ ≤ s₁ ⊔ s₂) hp₁)
   intro h
   rw [Submodule.mem_sup] at h
-  rcases h with ⟨v1, hv1, v2, hv2, hv1v2⟩
-  rw [← sub_eq_zero, sub_eq_add_neg, neg_vsub_eq_vsub_rev, add_comm v1, add_assoc, ←
-    vadd_vsub_assoc, ← neg_neg v2, add_comm, ← sub_eq_add_neg, ← vsub_vadd_eq_vsub_sub,
-    vsub_eq_zero_iff_eq] at hv1v2
+  rcases h with ⟨v₁, hv₁, v₂, hv₂, hv₁v₂⟩
+  rw [← sub_eq_zero, sub_eq_add_neg, neg_vsub_eq_vsub_rev, add_comm v₁, add_assoc, ←
+    vadd_vsub_assoc, ← neg_neg v₂, add_comm, ← sub_eq_add_neg, ← vsub_vadd_eq_vsub_sub,
+    vsub_eq_zero_iff_eq] at hv₁v₂
   refine Set.Nonempty.ne_empty ?_ he
-  use v1 +ᵥ p1, vadd_mem_of_mem_direction hv1 hp1
-  rw [hv1v2]
-  exact vadd_mem_of_mem_direction (Submodule.neg_mem _ hv2) hp2
+  use v₁ +ᵥ p₁, vadd_mem_of_mem_direction hv₁ hp₁
+  rw [hv₁v₂]
+  exact vadd_mem_of_mem_direction (Submodule.neg_mem _ hv₂) hp₂
 
 /-- If the directions of two nonempty affine subspaces span the whole module, they have nonempty
 intersection. -/
-theorem inter_nonempty_of_nonempty_of_sup_direction_eq_top {s1 s2 : AffineSubspace k P}
-    (h1 : (s1 : Set P).Nonempty) (h2 : (s2 : Set P).Nonempty)
-    (hd : s1.direction ⊔ s2.direction = ⊤) : ((s1 : Set P) ∩ s2).Nonempty := by
+theorem inter_nonempty_of_nonempty_of_sup_direction_eq_top {s₁ s₂ : AffineSubspace k P}
+    (h1 : (s₁ : Set P).Nonempty) (h2 : (s₂ : Set P).Nonempty)
+    (hd : s₁.direction ⊔ s₂.direction = ⊤) : ((s₁ : Set P) ∩ s₂).Nonempty := by
   by_contra h
   rw [Set.not_nonempty_iff_eq_empty] at h
   have hlt := sup_direction_lt_of_nonempty_of_inter_empty h1 h2 h
@@ -906,16 +906,16 @@ theorem inter_nonempty_of_nonempty_of_sup_direction_eq_top {s1 s2 : AffineSubspa
 
 /-- If the directions of two nonempty affine subspaces are complements of each other, they intersect
 in exactly one point. -/
-theorem inter_eq_singleton_of_nonempty_of_isCompl {s1 s2 : AffineSubspace k P}
-    (h1 : (s1 : Set P).Nonempty) (h2 : (s2 : Set P).Nonempty)
-    (hd : IsCompl s1.direction s2.direction) : ∃ p, (s1 : Set P) ∩ s2 = {p} := by
+theorem inter_eq_singleton_of_nonempty_of_isCompl {s₁ s₂ : AffineSubspace k P}
+    (h1 : (s₁ : Set P).Nonempty) (h2 : (s₂ : Set P).Nonempty)
+    (hd : IsCompl s₁.direction s₂.direction) : ∃ p, (s₁ : Set P) ∩ s₂ = {p} := by
   cases' inter_nonempty_of_nonempty_of_sup_direction_eq_top h1 h2 hd.sup_eq_top with p hp
   use p
   ext q
   rw [Set.mem_singleton_iff]
   constructor
   · rintro ⟨hq1, hq2⟩
-    have hqp : q -ᵥ p ∈ s1.direction ⊓ s2.direction :=
+    have hqp : q -ᵥ p ∈ s₁.direction ⊓ s₂.direction :=
       ⟨vsub_mem_direction hq1 hp.1, vsub_mem_direction hq2 hp.2⟩
     rwa [hd.inf_eq_bot, Submodule.mem_bot, vsub_eq_zero_iff_eq] at hqp
   · exact fun h => h.symm ▸ hp
@@ -924,8 +924,8 @@ theorem inter_eq_singleton_of_nonempty_of_isCompl {s1 s2 : AffineSubspace k P}
 @[simp]
 theorem affineSpan_coe (s : AffineSubspace k P) : affineSpan k (s : Set P) = s := by
   refine le_antisymm ?_ (subset_spanPoints _ _)
-  rintro p ⟨p1, hp1, v, hv, rfl⟩
-  exact vadd_mem_of_mem_direction hv hp1
+  rintro p ⟨p₁, hp₁, v, hv, rfl⟩
+  exact vadd_mem_of_mem_direction hv hp₁
 
 end AffineSubspace
 
@@ -944,12 +944,12 @@ theorem vectorSpan_eq_span_vsub_set_left {s : Set P} {p : P} (hp : p ∈ s) :
   rw [vectorSpan_def]
   refine le_antisymm ?_ (Submodule.span_mono ?_)
   · rw [Submodule.span_le]
-    rintro v ⟨p1, hp1, p2, hp2, hv⟩
-    simp_rw [← vsub_sub_vsub_cancel_left p1 p2 p] at hv
+    rintro v ⟨p₁, hp₁, p₂, hp₂, hv⟩
+    simp_rw [← vsub_sub_vsub_cancel_left p₁ p₂ p] at hv
     rw [← hv, SetLike.mem_coe, Submodule.mem_span]
-    exact fun m hm => Submodule.sub_mem _ (hm ⟨p2, hp2, rfl⟩) (hm ⟨p1, hp1, rfl⟩)
-  · rintro v ⟨p2, hp2, hv⟩
-    exact ⟨p, hp, p2, hp2, hv⟩
+    exact fun m hm => Submodule.sub_mem _ (hm ⟨p₂, hp₂, rfl⟩) (hm ⟨p₁, hp₁, rfl⟩)
+  · rintro v ⟨p₂, hp₂, hv⟩
+    exact ⟨p, hp, p₂, hp₂, hv⟩
 
 /-- The `vectorSpan` is the span of the pairwise subtractions with a given point on the right. -/
 theorem vectorSpan_eq_span_vsub_set_right {s : Set P} {p : P} (hp : p ∈ s) :
@@ -957,12 +957,12 @@ theorem vectorSpan_eq_span_vsub_set_right {s : Set P} {p : P} (hp : p ∈ s) :
   rw [vectorSpan_def]
   refine le_antisymm ?_ (Submodule.span_mono ?_)
   · rw [Submodule.span_le]
-    rintro v ⟨p1, hp1, p2, hp2, hv⟩
-    simp_rw [← vsub_sub_vsub_cancel_right p1 p2 p] at hv
+    rintro v ⟨p₁, hp₁, p₂, hp₂, hv⟩
+    simp_rw [← vsub_sub_vsub_cancel_right p₁ p₂ p] at hv
     rw [← hv, SetLike.mem_coe, Submodule.mem_span]
-    exact fun m hm => Submodule.sub_mem _ (hm ⟨p1, hp1, rfl⟩) (hm ⟨p2, hp2, rfl⟩)
-  · rintro v ⟨p2, hp2, hv⟩
-    exact ⟨p2, hp2, p, hp, hv⟩
+    exact fun m hm => Submodule.sub_mem _ (hm ⟨p₁, hp₁, rfl⟩) (hm ⟨p₂, hp₂, rfl⟩)
+  · rintro v ⟨p₂, hp₂, hv⟩
+    exact ⟨p₂, hp₂, p, hp, hv⟩
 
 /-- The `vectorSpan` is the span of the pairwise subtractions with a given point on the left,
 excluding the subtraction of that point from itself. -/
@@ -1315,64 +1315,64 @@ variable {k : Type*} {V : Type*} {P : Type*} [Ring k] [AddCommGroup V] [Module k
 
 /-- The direction of the sup of two nonempty affine subspaces is the sup of the two directions and
 of any one difference between points in the two subspaces. -/
-theorem direction_sup {s1 s2 : AffineSubspace k P} {p1 p2 : P} (hp1 : p1 ∈ s1) (hp2 : p2 ∈ s2) :
-    (s1 ⊔ s2).direction = s1.direction ⊔ s2.direction ⊔ k ∙ p2 -ᵥ p1 := by
+theorem direction_sup {s₁ s₂ : AffineSubspace k P} {p₁ p₂ : P} (hp₁ : p₁ ∈ s₁) (hp₂ : p₂ ∈ s₂) :
+    (s₁ ⊔ s₂).direction = s₁.direction ⊔ s₂.direction ⊔ k ∙ p₂ -ᵥ p₁ := by
   refine le_antisymm ?_ ?_
-  · change (affineSpan k ((s1 : Set P) ∪ s2)).direction ≤ _
-    rw [← mem_coe] at hp1
-    rw [direction_affineSpan, vectorSpan_eq_span_vsub_set_right k (Set.mem_union_left _ hp1),
+  · change (affineSpan k ((s₁ : Set P) ∪ s₂)).direction ≤ _
+    rw [← mem_coe] at hp₁
+    rw [direction_affineSpan, vectorSpan_eq_span_vsub_set_right k (Set.mem_union_left _ hp₁),
       Submodule.span_le]
-    rintro v ⟨p3, hp3, rfl⟩
-    cases' hp3 with hp3 hp3
+    rintro v ⟨p₃, hp₃, rfl⟩
+    cases' hp₃ with hp₃ hp₃
     · rw [sup_assoc, sup_comm, SetLike.mem_coe, Submodule.mem_sup]
-      use 0, Submodule.zero_mem _, p3 -ᵥ p1, vsub_mem_direction hp3 hp1
+      use 0, Submodule.zero_mem _, p₃ -ᵥ p₁, vsub_mem_direction hp₃ hp₁
       rw [zero_add]
     · rw [sup_assoc, SetLike.mem_coe, Submodule.mem_sup]
-      use 0, Submodule.zero_mem _, p3 -ᵥ p1
+      use 0, Submodule.zero_mem _, p₃ -ᵥ p₁
       rw [and_comm, zero_add]
       use rfl
-      rw [← vsub_add_vsub_cancel p3 p2 p1, Submodule.mem_sup]
-      use p3 -ᵥ p2, vsub_mem_direction hp3 hp2, p2 -ᵥ p1, Submodule.mem_span_singleton_self _
+      rw [← vsub_add_vsub_cancel p₃ p₂ p₁, Submodule.mem_sup]
+      use p₃ -ᵥ p₂, vsub_mem_direction hp₃ hp₂, p₂ -ᵥ p₁, Submodule.mem_span_singleton_self _
   · refine sup_le (sup_direction_le _ _) ?_
     rw [direction_eq_vectorSpan, vectorSpan_def]
     exact
       sInf_le_sInf fun p hp =>
         Set.Subset.trans
           (Set.singleton_subset_iff.2
-            (vsub_mem_vsub (mem_spanPoints k p2 _ (Set.mem_union_right _ hp2))
-              (mem_spanPoints k p1 _ (Set.mem_union_left _ hp1))))
+            (vsub_mem_vsub (mem_spanPoints k p₂ _ (Set.mem_union_right _ hp₂))
+              (mem_spanPoints k p₁ _ (Set.mem_union_left _ hp₁))))
           hp
 
 /-- The direction of the span of the result of adding a point to a nonempty affine subspace is the
 sup of the direction of that subspace and of any one difference between that point and a point in
 the subspace. -/
-theorem direction_affineSpan_insert {s : AffineSubspace k P} {p1 p2 : P} (hp1 : p1 ∈ s) :
-    (affineSpan k (insert p2 (s : Set P))).direction =
-    Submodule.span k {p2 -ᵥ p1} ⊔ s.direction := by
-  rw [sup_comm, ← Set.union_singleton, ← coe_affineSpan_singleton k V p2]
-  change (s ⊔ affineSpan k {p2}).direction = _
-  rw [direction_sup hp1 (mem_affineSpan k (Set.mem_singleton _)), direction_affineSpan]
+theorem direction_affineSpan_insert {s : AffineSubspace k P} {p₁ p₂ : P} (hp₁ : p₁ ∈ s) :
+    (affineSpan k (insert p₂ (s : Set P))).direction =
+    Submodule.span k {p₂ -ᵥ p₁} ⊔ s.direction := by
+  rw [sup_comm, ← Set.union_singleton, ← coe_affineSpan_singleton k V p₂]
+  change (s ⊔ affineSpan k {p₂}).direction = _
+  rw [direction_sup hp₁ (mem_affineSpan k (Set.mem_singleton _)), direction_affineSpan]
   simp
 
-/-- Given a point `p1` in an affine subspace `s`, and a point `p2`, a point `p` is in the span of
-`s` with `p2` added if and only if it is a multiple of `p2 -ᵥ p1` added to a point in `s`. -/
-theorem mem_affineSpan_insert_iff {s : AffineSubspace k P} {p1 : P} (hp1 : p1 ∈ s) (p2 p : P) :
-    p ∈ affineSpan k (insert p2 (s : Set P)) ↔
-      ∃ r : k, ∃ p0 ∈ s, p = r • (p2 -ᵥ p1 : V) +ᵥ p0 := by
-  rw [← mem_coe] at hp1
-  rw [← vsub_right_mem_direction_iff_mem (mem_affineSpan k (Set.mem_insert_of_mem _ hp1)),
-    direction_affineSpan_insert hp1, Submodule.mem_sup]
+/-- Given a point `p₁` in an affine subspace `s`, and a point `p₂`, a point `p` is in the span of
+`s` with `p₂` added if and only if it is a multiple of `p₂ -ᵥ p₁` added to a point in `s`. -/
+theorem mem_affineSpan_insert_iff {s : AffineSubspace k P} {p₁ : P} (hp₁ : p₁ ∈ s) (p₂ p : P) :
+    p ∈ affineSpan k (insert p₂ (s : Set P)) ↔
+      ∃ r : k, ∃ p0 ∈ s, p = r • (p₂ -ᵥ p₁ : V) +ᵥ p0 := by
+  rw [← mem_coe] at hp₁
+  rw [← vsub_right_mem_direction_iff_mem (mem_affineSpan k (Set.mem_insert_of_mem _ hp₁)),
+    direction_affineSpan_insert hp₁, Submodule.mem_sup]
   constructor
-  · rintro ⟨v1, hv1, v2, hv2, hp⟩
-    rw [Submodule.mem_span_singleton] at hv1
-    rcases hv1 with ⟨r, rfl⟩
-    use r, v2 +ᵥ p1, vadd_mem_of_mem_direction hv2 hp1
+  · rintro ⟨v₁, hv₁, v₂, hv₂, hp⟩
+    rw [Submodule.mem_span_singleton] at hv₁
+    rcases hv₁ with ⟨r, rfl⟩
+    use r, v₂ +ᵥ p₁, vadd_mem_of_mem_direction hv₂ hp₁
     symm at hp
     rw [← sub_eq_zero, ← vsub_vadd_eq_vsub_sub, vsub_eq_zero_iff_eq] at hp
     rw [hp, vadd_vadd]
-  · rintro ⟨r, p3, hp3, rfl⟩
-    use r • (p2 -ᵥ p1), Submodule.mem_span_singleton.2 ⟨r, rfl⟩, p3 -ᵥ p1,
-      vsub_mem_direction hp3 hp1
+  · rintro ⟨r, p₃, hp₃, rfl⟩
+    use r • (p₂ -ᵥ p₁), Submodule.mem_span_singleton.2 ⟨r, rfl⟩, p₃ -ᵥ p₁,
+      vsub_mem_direction hp₃ hp₁
     rw [vadd_vsub_assoc]
 
 end AffineSubspace


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
