### PR TITLE
[Merged by Bors] - chore(Analysis/Normed/Group): split file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1499,6 +1499,7 @@ import Mathlib.Analysis.Normed.Group.SemiNormedGrp.Completion
 import Mathlib.Analysis.Normed.Group.SemiNormedGrp.Kernels
 import Mathlib.Analysis.Normed.Group.Seminorm
 import Mathlib.Analysis.Normed.Group.SeparationQuotient
+import Mathlib.Analysis.Normed.Group.Subgroup
 import Mathlib.Analysis.Normed.Group.Submodule
 import Mathlib.Analysis.Normed.Group.Tannery
 import Mathlib.Analysis.Normed.Group.Ultra

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1483,6 +1483,7 @@ import Mathlib.Analysis.Normed.Group.CocompactMap
 import Mathlib.Analysis.Normed.Group.Completeness
 import Mathlib.Analysis.Normed.Group.Completion
 import Mathlib.Analysis.Normed.Group.Constructions
+import Mathlib.Analysis.Normed.Group.Continuity
 import Mathlib.Analysis.Normed.Group.ControlledClosure
 import Mathlib.Analysis.Normed.Group.Hom
 import Mathlib.Analysis.Normed.Group.HomCompletion

--- a/Mathlib/Analysis/LocallyConvex/Polar.lean
+++ b/Mathlib/Analysis/LocallyConvex/Polar.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Moritz Doll, Kalle Kytölä
 -/
 import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Group.Continuity
 import Mathlib.LinearAlgebra.SesquilinearForm
 import Mathlib.Topology.Algebra.Module.WeakBilin
 

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Algebra.Subalgebra.Basic
 import Mathlib.Algebra.Field.Subfield.Defs
 import Mathlib.Algebra.Order.Group.Pointwise.Interval
 import Mathlib.Analysis.Normed.Group.Constructions
+import Mathlib.Analysis.Normed.Group.Subgroup
 import Mathlib.Analysis.Normed.Group.Submodule
 import Mathlib.Algebra.Ring.Regular
 

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -3,11 +3,12 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers, Yury Kudryashov
 -/
-import Mathlib.Analysis.Normed.Group.Continuity
 import Mathlib.Analysis.Normed.Group.Submodule
 import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace
 import Mathlib.LinearAlgebra.AffineSpace.Midpoint
 import Mathlib.Topology.MetricSpace.IsometricSMul
+import Mathlib.Topology.Metrizable.Uniformity
+import Mathlib.Topology.Sequences
 
 /-!
 # Torsors of additive normed group actions.

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers, Yury Kudryashov
 -/
-import Mathlib.Analysis.Normed.Group.Basic
+import Mathlib.Analysis.Normed.Group.Continuity
 import Mathlib.Analysis.Normed.Group.Submodule
 import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace
 import Mathlib.LinearAlgebra.AffineSpace.Midpoint

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -4,11 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl, Yaël Dillies
 -/
 import Mathlib.Algebra.CharP.Defs
-import Mathlib.Algebra.Group.Subgroup.Ker
+import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Analysis.Normed.Group.Seminorm
-import Mathlib.Topology.Instances.ENNReal.Defs
-import Mathlib.Topology.Metrizable.Uniformity
-import Mathlib.Topology.Sequences
+import Mathlib.Topology.MetricSpace.Basic
 
 /-!
 # Normed (semi)groups
@@ -850,206 +848,6 @@ theorem mem_emetric_ball_one_iff {r : ℝ≥0∞} : a ∈ EMetric.ball 1 r ↔ �
 
 end ENorm
 
-@[to_additive]
-theorem tendsto_iff_norm_div_tendsto_zero {f : α → E} {a : Filter α} {b : E} :
-    Tendsto f a (𝓝 b) ↔ Tendsto (fun e => ‖f e / b‖) a (𝓝 0) := by
-  simp only [← dist_eq_norm_div, ← tendsto_iff_dist_tendsto_zero]
-
-@[to_additive]
-theorem tendsto_one_iff_norm_tendsto_zero {f : α → E} {a : Filter α} :
-    Tendsto f a (𝓝 1) ↔ Tendsto (‖f ·‖) a (𝓝 0) :=
-  tendsto_iff_norm_div_tendsto_zero.trans <| by simp only [div_one]
-
-@[to_additive]
-theorem comap_norm_nhds_one : comap norm (𝓝 0) = 𝓝 (1 : E) := by
-  simpa only [dist_one_right] using nhds_comap_dist (1 : E)
-
-/-- Special case of the sandwich theorem: if the norm of `f` is eventually bounded by a real
-function `a` which tends to `0`, then `f` tends to `1` (neutral element of `SeminormedGroup`).
-In this pair of lemmas (`squeeze_one_norm'` and `squeeze_one_norm`), following a convention of
-similar lemmas in `Topology.MetricSpace.Basic` and `Topology.Algebra.Order`, the `'` version is
-phrased using "eventually" and the non-`'` version is phrased absolutely. -/
-@[to_additive "Special case of the sandwich theorem: if the norm of `f` is eventually bounded by a
-real function `a` which tends to `0`, then `f` tends to `0`. In this pair of lemmas
-(`squeeze_zero_norm'` and `squeeze_zero_norm`), following a convention of similar lemmas in
-`Topology.MetricSpace.Pseudo.Defs` and `Topology.Algebra.Order`, the `'` version is phrased using
-\"eventually\" and the non-`'` version is phrased absolutely."]
-theorem squeeze_one_norm' {f : α → E} {a : α → ℝ} {t₀ : Filter α} (h : ∀ᶠ n in t₀, ‖f n‖ ≤ a n)
-    (h' : Tendsto a t₀ (𝓝 0)) : Tendsto f t₀ (𝓝 1) :=
-  tendsto_one_iff_norm_tendsto_zero.2 <|
-    squeeze_zero' (Eventually.of_forall fun _n => norm_nonneg' _) h h'
-
-/-- Special case of the sandwich theorem: if the norm of `f` is bounded by a real function `a` which
-tends to `0`, then `f` tends to `1`. -/
-@[to_additive "Special case of the sandwich theorem: if the norm of `f` is bounded by a real
-function `a` which tends to `0`, then `f` tends to `0`."]
-theorem squeeze_one_norm {f : α → E} {a : α → ℝ} {t₀ : Filter α} (h : ∀ n, ‖f n‖ ≤ a n) :
-    Tendsto a t₀ (𝓝 0) → Tendsto f t₀ (𝓝 1) :=
-  squeeze_one_norm' <| Eventually.of_forall h
-
-@[to_additive]
-theorem tendsto_norm_div_self (x : E) : Tendsto (fun a => ‖a / x‖) (𝓝 x) (𝓝 0) := by
-  simpa [dist_eq_norm_div] using
-    tendsto_id.dist (tendsto_const_nhds : Tendsto (fun _a => (x : E)) (𝓝 x) _)
-
-@[to_additive]
-theorem tendsto_norm_div_self_nhdsGE (x : E) : Tendsto (fun a ↦ ‖a / x‖) (𝓝 x) (𝓝[≥] 0) :=
-  tendsto_nhdsWithin_iff.mpr ⟨tendsto_norm_div_self x, by simp⟩
-
-@[to_additive tendsto_norm]
-theorem tendsto_norm' {x : E} : Tendsto (fun a => ‖a‖) (𝓝 x) (𝓝 ‖x‖) := by
-  simpa using tendsto_id.dist (tendsto_const_nhds : Tendsto (fun _a => (1 : E)) _ _)
-
-/-- See `tendsto_norm_one` for a version with pointed neighborhoods. -/
-@[to_additive "See `tendsto_norm_zero` for a version with pointed neighborhoods."]
-theorem tendsto_norm_one : Tendsto (fun a : E => ‖a‖) (𝓝 1) (𝓝 0) := by
-  simpa using tendsto_norm_div_self (1 : E)
-
-@[to_additive (attr := continuity) continuous_norm]
-theorem continuous_norm' : Continuous fun a : E => ‖a‖ := by
-  simpa using continuous_id.dist (continuous_const : Continuous fun _a => (1 : E))
-
-@[to_additive (attr := continuity) continuous_nnnorm]
-theorem continuous_nnnorm' : Continuous fun a : E => ‖a‖₊ :=
-  continuous_norm'.subtype_mk _
-
-@[to_additive (attr := continuity) continuous_enorm]
-lemma continuous_enorm' : Continuous fun a : E ↦ ‖a‖ₑ :=
-  ENNReal.isOpenEmbedding_coe.continuous.comp continuous_nnnorm'
-
-set_option linter.docPrime false in
-@[to_additive Inseparable.norm_eq_norm]
-theorem Inseparable.norm_eq_norm' {u v : E} (h : Inseparable u v) : ‖u‖ = ‖v‖ :=
-  h.map continuous_norm' |>.eq
-
-set_option linter.docPrime false in
-@[to_additive Inseparable.nnnorm_eq_nnnorm]
-theorem Inseparable.nnnorm_eq_nnnorm' {u v : E} (h : Inseparable u v) : ‖u‖₊ = ‖v‖₊ :=
-  h.map continuous_nnnorm' |>.eq
-
-@[to_additive]
-theorem mem_closure_one_iff_norm {x : E} : x ∈ closure ({1} : Set E) ↔ ‖x‖ = 0 := by
-  rw [← closedBall_zero', mem_closedBall_one_iff, (norm_nonneg' x).le_iff_eq]
-
-@[to_additive]
-theorem closure_one_eq : closure ({1} : Set E) = { x | ‖x‖ = 0 } :=
-  Set.ext fun _x => mem_closure_one_iff_norm
-
-section
-
-variable {l : Filter α} {f : α → E}
-
-@[to_additive Filter.Tendsto.norm]
-theorem Filter.Tendsto.norm' (h : Tendsto f l (𝓝 a)) : Tendsto (fun x => ‖f x‖) l (𝓝 ‖a‖) :=
-  tendsto_norm'.comp h
-
-@[to_additive Filter.Tendsto.nnnorm]
-theorem Filter.Tendsto.nnnorm' (h : Tendsto f l (𝓝 a)) : Tendsto (fun x => ‖f x‖₊) l (𝓝 ‖a‖₊) :=
-  Tendsto.comp continuous_nnnorm'.continuousAt h
-
-@[to_additive Filter.Tendsto.enorm]
-lemma Filter.Tendsto.enorm' (h : Tendsto f l (𝓝 a)) : Tendsto (‖f ·‖ₑ) l (𝓝 ‖a‖ₑ) :=
-  .comp continuous_enorm'.continuousAt h
-
-end
-
-section
-
-variable [TopologicalSpace α] {f : α → E} {s : Set α} {a : α}
-
-@[to_additive (attr := fun_prop) Continuous.norm]
-theorem Continuous.norm' : Continuous f → Continuous fun x => ‖f x‖ :=
-  continuous_norm'.comp
-
-@[to_additive (attr := fun_prop) Continuous.nnnorm]
-theorem Continuous.nnnorm' : Continuous f → Continuous fun x => ‖f x‖₊ :=
-  continuous_nnnorm'.comp
-
-@[to_additive (attr := fun_prop) Continuous.enorm]
-lemma Continuous.enorm' : Continuous f → Continuous (‖f ·‖ₑ) := continuous_enorm'.comp
-
-@[to_additive (attr := fun_prop) ContinuousAt.norm]
-theorem ContinuousAt.norm' {a : α} (h : ContinuousAt f a) : ContinuousAt (fun x => ‖f x‖) a :=
-  Tendsto.norm' h
-
-@[to_additive (attr := fun_prop) ContinuousAt.nnnorm]
-theorem ContinuousAt.nnnorm' {a : α} (h : ContinuousAt f a) : ContinuousAt (fun x => ‖f x‖₊) a :=
-  Tendsto.nnnorm' h
-
-@[to_additive (attr := fun_prop) ContinuousAt.enorm]
-lemma ContinuousAt.enorm' (h : ContinuousAt f a) : ContinuousAt (‖f ·‖ₑ) a := Tendsto.enorm' h
-
-@[to_additive ContinuousWithinAt.norm]
-theorem ContinuousWithinAt.norm' {s : Set α} {a : α} (h : ContinuousWithinAt f s a) :
-    ContinuousWithinAt (fun x => ‖f x‖) s a :=
-  Tendsto.norm' h
-
-@[to_additive ContinuousWithinAt.nnnorm]
-theorem ContinuousWithinAt.nnnorm' {s : Set α} {a : α} (h : ContinuousWithinAt f s a) :
-    ContinuousWithinAt (fun x => ‖f x‖₊) s a :=
-  Tendsto.nnnorm' h
-
-@[to_additive ContinuousWithinAt.enorm]
-lemma ContinuousWithinAt.enorm' (h : ContinuousWithinAt f s a) : ContinuousWithinAt (‖f ·‖ₑ) s a :=
-  Tendsto.enorm' h
-
-@[to_additive (attr := fun_prop) ContinuousOn.norm]
-theorem ContinuousOn.norm' {s : Set α} (h : ContinuousOn f s) : ContinuousOn (fun x => ‖f x‖) s :=
-  fun x hx => (h x hx).norm'
-
-@[to_additive (attr := fun_prop) ContinuousOn.nnnorm]
-theorem ContinuousOn.nnnorm' {s : Set α} (h : ContinuousOn f s) :
-    ContinuousOn (fun x => ‖f x‖₊) s := fun x hx => (h x hx).nnnorm'
-
-@[to_additive (attr := fun_prop) ContinuousOn.enorm]
-lemma ContinuousOn.enorm' (h : ContinuousOn f s) : ContinuousOn (‖f ·‖ₑ) s :=
-  fun x hx => (h x hx).enorm'
-
-end
-
-/-- If `‖y‖ → ∞`, then we can assume `y ≠ x` for any fixed `x`. -/
-@[to_additive eventually_ne_of_tendsto_norm_atTop "If `‖y‖→∞`, then we can assume `y≠x` for any
-fixed `x`"]
-theorem eventually_ne_of_tendsto_norm_atTop' {l : Filter α} {f : α → E}
-    (h : Tendsto (fun y => ‖f y‖) l atTop) (x : E) : ∀ᶠ y in l, f y ≠ x :=
-  (h.eventually_ne_atTop _).mono fun _x => ne_of_apply_ne norm
-
-@[to_additive]
-theorem SeminormedCommGroup.mem_closure_iff :
-    a ∈ closure s ↔ ∀ ε, 0 < ε → ∃ b ∈ s, ‖a / b‖ < ε := by
-  simp [Metric.mem_closure_iff, dist_eq_norm_div]
-
-@[to_additive]
-theorem SeminormedGroup.tendstoUniformlyOn_one {f : ι → κ → G} {s : Set κ} {l : Filter ι} :
-    TendstoUniformlyOn f 1 l s ↔ ∀ ε > 0, ∀ᶠ i in l, ∀ x ∈ s, ‖f i x‖ < ε := by
-  simp only [tendstoUniformlyOn_iff, Pi.one_apply, dist_one_left]
-
-@[to_additive]
-theorem SeminormedGroup.uniformCauchySeqOnFilter_iff_tendstoUniformlyOnFilter_one {f : ι → κ → G}
-    {l : Filter ι} {l' : Filter κ} :
-    UniformCauchySeqOnFilter f l l' ↔
-      TendstoUniformlyOnFilter (fun n : ι × ι => fun z => f n.fst z / f n.snd z) 1 (l ×ˢ l) l' := by
-  refine ⟨fun hf u hu => ?_, fun hf u hu => ?_⟩
-  · obtain ⟨ε, hε, H⟩ := uniformity_basis_dist.mem_uniformity_iff.mp hu
-    refine
-      (hf { p : G × G | dist p.fst p.snd < ε } <| dist_mem_uniformity hε).mono fun x hx =>
-        H 1 (f x.fst.fst x.snd / f x.fst.snd x.snd) ?_
-    simpa [dist_eq_norm_div, norm_div_rev] using hx
-  · obtain ⟨ε, hε, H⟩ := uniformity_basis_dist.mem_uniformity_iff.mp hu
-    refine
-      (hf { p : G × G | dist p.fst p.snd < ε } <| dist_mem_uniformity hε).mono fun x hx =>
-        H (f x.fst.fst x.snd) (f x.fst.snd x.snd) ?_
-    simpa [dist_eq_norm_div, norm_div_rev] using hx
-
-@[to_additive]
-theorem SeminormedGroup.uniformCauchySeqOn_iff_tendstoUniformlyOn_one {f : ι → κ → G} {s : Set κ}
-    {l : Filter ι} :
-    UniformCauchySeqOn f l s ↔
-      TendstoUniformlyOn (fun n : ι × ι => fun z => f n.fst z / f n.snd z) 1 (l ×ˢ l) s := by
-  rw [tendstoUniformlyOn_iff_tendstoUniformlyOnFilter,
-    uniformCauchySeqOn_iff_uniformCauchySeqOnFilter,
-    SeminormedGroup.uniformCauchySeqOnFilter_iff_tendstoUniformlyOnFilter_one]
-
 end SeminormedGroup
 
 section Induced
@@ -1101,6 +899,89 @@ abbrev NormedCommGroup.induced [CommGroup E] [NormedGroup F] [MonoidHomClass �
     mul_comm := mul_comm }
 
 end Induced
+
+namespace Real
+
+variable {r : ℝ}
+
+instance norm : Norm ℝ where
+  norm r := |r|
+
+@[simp]
+theorem norm_eq_abs (r : ℝ) : ‖r‖ = |r| :=
+  rfl
+
+instance normedAddCommGroup : NormedAddCommGroup ℝ :=
+  ⟨fun _r _y => rfl⟩
+
+theorem norm_of_nonneg (hr : 0 ≤ r) : ‖r‖ = r :=
+  abs_of_nonneg hr
+
+theorem norm_of_nonpos (hr : r ≤ 0) : ‖r‖ = -r :=
+  abs_of_nonpos hr
+
+theorem le_norm_self (r : ℝ) : r ≤ ‖r‖ :=
+  le_abs_self r
+
+@[simp 1100] lemma norm_natCast (n : ℕ) : ‖(n : ℝ)‖ = n := abs_of_nonneg n.cast_nonneg
+@[simp 1100] lemma nnnorm_natCast (n : ℕ) : ‖(n : ℝ)‖₊ = n := NNReal.eq <| norm_natCast _
+@[simp 1100] lemma enorm_natCast (n : ℕ) : ‖(n : ℝ)‖ₑ = n := by simp [enorm]
+
+@[simp 1100] lemma norm_ofNat (n : ℕ) [n.AtLeastTwo] :
+    ‖(ofNat(n) : ℝ)‖ = ofNat(n) := norm_natCast n
+
+@[simp 1100] lemma nnnorm_ofNat (n : ℕ) [n.AtLeastTwo] :
+    ‖(ofNat(n) : ℝ)‖₊ = ofNat(n) := nnnorm_natCast n
+
+lemma norm_two : ‖(2 : ℝ)‖ = 2 := abs_of_pos zero_lt_two
+lemma nnnorm_two : ‖(2 : ℝ)‖₊ = 2 := NNReal.eq <| by simp
+
+@[simp 1100, norm_cast]
+lemma norm_nnratCast (q : ℚ≥0) : ‖(q : ℝ)‖ = q := norm_of_nonneg q.cast_nonneg
+
+@[simp 1100, norm_cast]
+lemma nnnorm_nnratCast (q : ℚ≥0) : ‖(q : ℝ)‖₊ = q := by simp [nnnorm, -norm_eq_abs]
+
+theorem nnnorm_of_nonneg (hr : 0 ≤ r) : ‖r‖₊ = ⟨r, hr⟩ :=
+  NNReal.eq <| norm_of_nonneg hr
+
+lemma enorm_of_nonneg (hr : 0 ≤ r) : ‖r‖ₑ = .ofReal r := by
+  simp [enorm, nnnorm_of_nonneg hr, ENNReal.ofReal, toNNReal, hr]
+
+@[simp] lemma nnnorm_abs (r : ℝ) : ‖|r|‖₊ = ‖r‖₊ := by simp [nnnorm]
+@[simp] lemma enorm_abs (r : ℝ) : ‖|r|‖ₑ = ‖r‖ₑ := by simp [enorm]
+
+theorem enorm_eq_ofReal (hr : 0 ≤ r) : ‖r‖ₑ = .ofReal r := by
+  rw [← ofReal_norm_eq_enorm, norm_of_nonneg hr]
+
+@[deprecated (since := "2025-01-17")] alias ennnorm_eq_ofReal := enorm_eq_ofReal
+
+theorem enorm_eq_ofReal_abs (r : ℝ) : ‖r‖ₑ = ENNReal.ofReal |r| := by
+  rw [← enorm_eq_ofReal (abs_nonneg _), enorm_abs]
+
+@[deprecated (since := "2025-01-17")] alias ennnorm_eq_ofReal_abs := enorm_eq_ofReal_abs
+
+theorem toNNReal_eq_nnnorm_of_nonneg (hr : 0 ≤ r) : r.toNNReal = ‖r‖₊ := by
+  rw [Real.toNNReal_of_nonneg hr]
+  ext
+  rw [coe_mk, coe_nnnorm r, Real.norm_eq_abs r, abs_of_nonneg hr]
+  -- Porting note: this is due to the change from `Subtype.val` to `NNReal.toReal` for the coercion
+
+theorem ofReal_le_enorm (r : ℝ) : ENNReal.ofReal r ≤ ‖r‖ₑ := by
+  rw [enorm_eq_ofReal_abs]; gcongr; exact le_abs_self _
+
+@[deprecated (since := "2025-01-17")] alias ofReal_le_ennnorm := ofReal_le_enorm
+
+end Real
+
+namespace NNReal
+
+instance : NNNorm ℝ≥0 where
+  nnnorm x := x
+
+@[simp] lemma nnnorm_eq_self (x : ℝ≥0) : ‖x‖₊ = x := rfl
+
+end NNReal
 
 section SeminormedCommGroup
 
@@ -1214,51 +1095,6 @@ theorem smul_ball'' : a • ball b r = ball (a • b) r := by
   simp [mem_ball, Set.mem_smul_set, dist_eq_norm_div, _root_.div_eq_inv_mul,
     ← eq_inv_mul_iff_mul_eq, mul_assoc]
 
-open Finset
-
-@[to_additive]
-theorem controlled_prod_of_mem_closure {s : Subgroup E} (hg : a ∈ closure (s : Set E)) {b : ℕ → ℝ}
-    (b_pos : ∀ n, 0 < b n) :
-    ∃ v : ℕ → E,
-      Tendsto (fun n => ∏ i ∈ range (n + 1), v i) atTop (𝓝 a) ∧
-        (∀ n, v n ∈ s) ∧ ‖v 0 / a‖ < b 0 ∧ ∀ n, 0 < n → ‖v n‖ < b n := by
-  obtain ⟨u : ℕ → E, u_in : ∀ n, u n ∈ s, lim_u : Tendsto u atTop (𝓝 a)⟩ :=
-    mem_closure_iff_seq_limit.mp hg
-  obtain ⟨n₀, hn₀⟩ : ∃ n₀, ∀ n ≥ n₀, ‖u n / a‖ < b 0 :=
-    haveI : { x | ‖x / a‖ < b 0 } ∈ 𝓝 a := by
-      simp_rw [← dist_eq_norm_div]
-      exact Metric.ball_mem_nhds _ (b_pos _)
-    Filter.tendsto_atTop'.mp lim_u _ this
-  set z : ℕ → E := fun n => u (n + n₀)
-  have lim_z : Tendsto z atTop (𝓝 a) := lim_u.comp (tendsto_add_atTop_nat n₀)
-  have mem_𝓤 : ∀ n, { p : E × E | ‖p.1 / p.2‖ < b (n + 1) } ∈ 𝓤 E := fun n => by
-    simpa [← dist_eq_norm_div] using Metric.dist_mem_uniformity (b_pos <| n + 1)
-  obtain ⟨φ : ℕ → ℕ, φ_extr : StrictMono φ, hφ : ∀ n, ‖z (φ <| n + 1) / z (φ n)‖ < b (n + 1)⟩ :=
-    lim_z.cauchySeq.subseq_mem mem_𝓤
-  set w : ℕ → E := z ∘ φ
-  have hw : Tendsto w atTop (𝓝 a) := lim_z.comp φ_extr.tendsto_atTop
-  set v : ℕ → E := fun i => if i = 0 then w 0 else w i / w (i - 1)
-  refine ⟨v, Tendsto.congr (Finset.eq_prod_range_div' w) hw, ?_, hn₀ _ (n₀.le_add_left _), ?_⟩
-  · rintro ⟨⟩
-    · change w 0 ∈ s
-      apply u_in
-    · apply s.div_mem <;> apply u_in
-  · intro l hl
-    obtain ⟨k, rfl⟩ : ∃ k, l = k + 1 := Nat.exists_eq_succ_of_ne_zero hl.ne'
-    apply hφ
-
-@[to_additive]
-theorem controlled_prod_of_mem_closure_range {j : E →* F} {b : F}
-    (hb : b ∈ closure (j.range : Set F)) {f : ℕ → ℝ} (b_pos : ∀ n, 0 < f n) :
-    ∃ a : ℕ → E,
-      Tendsto (fun n => ∏ i ∈ range (n + 1), j (a i)) atTop (𝓝 b) ∧
-        ‖j (a 0) / b‖ < f 0 ∧ ∀ n, 0 < n → ‖j (a n)‖ < f n := by
-  obtain ⟨v, sum_v, v_in, hv₀, hv_pos⟩ := controlled_prod_of_mem_closure hb b_pos
-  choose g hg using v_in
-  exact
-    ⟨g, by simpa [← hg] using sum_v, by simpa [hg 0] using hv₀,
-      fun n hn => by simpa [hg] using hv_pos n hn⟩
-
 @[to_additive]
 theorem nnnorm_multiset_prod_le (m : Multiset E) : ‖m.prod‖₊ ≤ (m.map fun x => ‖x‖₊).sum :=
   NNReal.coe_le_coe.1 <| by
@@ -1277,88 +1113,7 @@ theorem nnnorm_prod_le_of_le (s : Finset ι) {f : ι → E} {n : ι → ℝ≥0}
     ‖∏ b ∈ s, f b‖₊ ≤ ∑ b ∈ s, n b :=
   (norm_prod_le_of_le s h).trans_eq (NNReal.coe_sum ..).symm
 
-namespace Real
-
-instance norm : Norm ℝ where
-  norm r := |r|
-
-@[simp]
-theorem norm_eq_abs (r : ℝ) : ‖r‖ = |r| :=
-  rfl
-
-instance normedAddCommGroup : NormedAddCommGroup ℝ :=
-  ⟨fun _r _y => rfl⟩
-
-theorem norm_of_nonneg (hr : 0 ≤ r) : ‖r‖ = r :=
-  abs_of_nonneg hr
-
-theorem norm_of_nonpos (hr : r ≤ 0) : ‖r‖ = -r :=
-  abs_of_nonpos hr
-
-theorem le_norm_self (r : ℝ) : r ≤ ‖r‖ :=
-  le_abs_self r
-
-@[simp 1100] lemma norm_natCast (n : ℕ) : ‖(n : ℝ)‖ = n := abs_of_nonneg n.cast_nonneg
-@[simp 1100] lemma nnnorm_natCast (n : ℕ) : ‖(n : ℝ)‖₊ = n := NNReal.eq <| norm_natCast _
-@[simp 1100] lemma enorm_natCast (n : ℕ) : ‖(n : ℝ)‖ₑ = n := by simp [enorm]
-
-@[simp 1100] lemma norm_ofNat (n : ℕ) [n.AtLeastTwo] :
-    ‖(ofNat(n) : ℝ)‖ = ofNat(n) := norm_natCast n
-
-@[simp 1100] lemma nnnorm_ofNat (n : ℕ) [n.AtLeastTwo] :
-    ‖(ofNat(n) : ℝ)‖₊ = ofNat(n) := nnnorm_natCast n
-
-lemma norm_two : ‖(2 : ℝ)‖ = 2 := abs_of_pos zero_lt_two
-lemma nnnorm_two : ‖(2 : ℝ)‖₊ = 2 := NNReal.eq <| by simp
-
-@[simp 1100, norm_cast]
-lemma norm_nnratCast (q : ℚ≥0) : ‖(q : ℝ)‖ = q := norm_of_nonneg q.cast_nonneg
-
-@[simp 1100, norm_cast]
-lemma nnnorm_nnratCast (q : ℚ≥0) : ‖(q : ℝ)‖₊ = q := by simp [nnnorm, -norm_eq_abs]
-
-theorem nnnorm_of_nonneg (hr : 0 ≤ r) : ‖r‖₊ = ⟨r, hr⟩ :=
-  NNReal.eq <| norm_of_nonneg hr
-
-lemma enorm_of_nonneg (hr : 0 ≤ r) : ‖r‖ₑ = .ofReal r := by
-  simp [enorm, nnnorm_of_nonneg hr, ENNReal.ofReal, toNNReal, hr]
-
-@[simp] lemma nnnorm_abs (r : ℝ) : ‖|r|‖₊ = ‖r‖₊ := by simp [nnnorm]
-@[simp] lemma enorm_abs (r : ℝ) : ‖|r|‖ₑ = ‖r‖ₑ := by simp [enorm]
-
-theorem enorm_eq_ofReal (hr : 0 ≤ r) : ‖r‖ₑ = .ofReal r := by
-  rw [← ofReal_norm_eq_enorm, norm_of_nonneg hr]
-
-@[deprecated (since := "2025-01-17")] alias ennnorm_eq_ofReal := enorm_eq_ofReal
-
-theorem enorm_eq_ofReal_abs (r : ℝ) : ‖r‖ₑ = ENNReal.ofReal |r| := by
-  rw [← enorm_eq_ofReal (abs_nonneg _), enorm_abs]
-
-@[deprecated (since := "2025-01-17")] alias ennnorm_eq_ofReal_abs := enorm_eq_ofReal_abs
-
-theorem toNNReal_eq_nnnorm_of_nonneg (hr : 0 ≤ r) : r.toNNReal = ‖r‖₊ := by
-  rw [Real.toNNReal_of_nonneg hr]
-  ext
-  rw [coe_mk, coe_nnnorm r, Real.norm_eq_abs r, abs_of_nonneg hr]
-  -- Porting note: this is due to the change from `Subtype.val` to `NNReal.toReal` for the coercion
-
-theorem ofReal_le_enorm (r : ℝ) : ENNReal.ofReal r ≤ ‖r‖ₑ := by
-  rw [enorm_eq_ofReal_abs]; gcongr; exact le_abs_self _
-
-@[deprecated (since := "2025-01-17")] alias ofReal_le_ennnorm := ofReal_le_enorm
-
-end Real
-
-namespace NNReal
-
-instance : NNNorm ℝ≥0 where
-  nnnorm x := x
-
-@[simp] lemma nnnorm_eq_self (x : ℝ≥0) : ‖x‖₊ = x := rfl
-
-end NNReal
-
- -- Porting note: increase priority so that the LHS doesn't simplify
+-- Porting note: increase priority so that the LHS doesn't simplify
 @[to_additive (attr := simp 1001) norm_norm]
 lemma norm_norm' (x : E) : ‖‖x‖‖ = ‖x‖ := Real.norm_of_nonneg (norm_nonneg' _)
 
@@ -1436,31 +1191,6 @@ lemma nnnorm_pos' : 0 < ‖a‖₊ ↔ a ≠ 1 := pos_iff_ne_zero.trans nnnorm_n
 @[to_additive (attr := simp) enorm_pos]
 lemma enorm_pos' : 0 < ‖a‖ₑ ↔ a ≠ 1 := pos_iff_ne_zero.trans enorm_ne_zero'
 
-/-- See `tendsto_norm_one` for a version with full neighborhoods. -/
-@[to_additive "See `tendsto_norm_zero` for a version with full neighborhoods."]
-lemma tendsto_norm_nhdsNE_one : Tendsto (norm : E → ℝ) (𝓝[≠] 1) (𝓝[>] 0) :=
-  tendsto_norm_one.inf <| tendsto_principal_principal.2 fun _ hx ↦ norm_pos_iff'.2 hx
-
-@[deprecated (since := "2024-12-22")]
-alias tendsto_norm_zero' := tendsto_norm_nhdsNE_zero
-@[to_additive existing, deprecated (since := "2024-12-22")]
-alias tendsto_norm_one' := tendsto_norm_nhdsNE_one
-
-@[deprecated (since := "2024-12-22")]
-alias tendsto_norm_nhdsWithin_zero := tendsto_norm_nhdsNE_zero
-@[to_additive existing, deprecated (since := "2024-12-22")]
-alias tendsto_norm_nhdsWithin_one := tendsto_norm_nhdsNE_one
-
-@[to_additive]
-theorem tendsto_norm_div_self_nhdsNE (a : E) : Tendsto (fun x => ‖x / a‖) (𝓝[≠] a) (𝓝[>] 0) :=
-  (tendsto_norm_div_self a).inf <|
-    tendsto_principal_principal.2 fun _x hx => norm_pos_iff'.2 <| div_ne_one.2 hx
-
-@[deprecated (since := "2024-12-22")]
-alias tendsto_norm_sub_self_punctured_nhds := tendsto_norm_sub_self_nhdsNE
-@[to_additive existing, deprecated (since := "2024-12-22")]
-alias tendsto_norm_div_self_punctured_nhds := tendsto_norm_div_self_nhdsNE
-
 variable (E)
 
 /-- The norm of a normed group as a group norm. -/
@@ -1471,16 +1201,6 @@ def normGroupNorm : GroupNorm E :=
 @[simp]
 theorem coe_normGroupNorm : ⇑(normGroupNorm E) = norm :=
   rfl
-
-/-- A version of `comap_norm_nhdsGT_zero` for a multiplicative normed group. -/
-@[to_additive comap_norm_nhdsGT_zero]
-lemma comap_norm_nhdsGT_zero' : comap norm (𝓝[>] 0) = 𝓝[≠] (1 : E) := by
-  simp [nhdsWithin, comap_norm_nhds_one, Set.preimage, Set.compl_def]
-
-@[deprecated (since := "2024-12-22")]
-alias comap_norm_nhdsWithin_Ioi_zero := comap_norm_nhdsGT_zero
-@[to_additive existing comap_norm_nhdsWithin_Ioi_zero, deprecated (since := "2024-12-22")]
-alias comap_norm_nhdsWithin_Ioi_zero' := comap_norm_nhdsGT_zero'
 
 end NormedGroup
 
@@ -1496,58 +1216,6 @@ theorem hasCompactSupport_norm_iff : (HasCompactSupport fun x => ‖f x‖) ↔ 
 alias ⟨_, HasCompactSupport.norm⟩ := hasCompactSupport_norm_iff
 
 end NormedAddGroup
-
-/-! ### `positivity` extensions -/
-
-namespace Mathlib.Meta.Positivity
-
-open Lean Meta Qq Function
-
-/-- Extension for the `positivity` tactic: multiplicative norms are always nonnegative, and positive
-on non-one inputs. -/
-@[positivity ‖_‖]
-def evalMulNorm : PositivityExt where eval {u α} _ _ e := do
-  match u, α, e with
-  | 0, ~q(ℝ), ~q(@Norm.norm $E $_n $a) =>
-    let _seminormedGroup_E ← synthInstanceQ q(SeminormedGroup $E)
-    assertInstancesCommute
-    -- Check whether we are in a normed group and whether the context contains a `a ≠ 1` assumption
-    let o : Option (Q(NormedGroup $E) × Q($a ≠ 1)) := ← do
-      let .some normedGroup_E ← trySynthInstanceQ q(NormedGroup $E) | return none
-      let some pa ← findLocalDeclWithTypeQ? q($a ≠ 1) | return none
-      return some (normedGroup_E, pa)
-    match o with
-    -- If so, return a proof of `0 < ‖a‖`
-    | some (_normedGroup_E, pa) =>
-      assertInstancesCommute
-      return .positive q(norm_pos_iff'.2 $pa)
-    -- Else, return a proof of `0 ≤ ‖a‖`
-    | none => return .nonnegative q(norm_nonneg' $a)
-  | _, _, _ => throwError "not `‖·‖`"
-
-/-- Extension for the `positivity` tactic: additive norms are always nonnegative, and positive
-on non-zero inputs. -/
-@[positivity ‖_‖]
-def evalAddNorm : PositivityExt where eval {u α} _ _ e := do
-  match u, α, e with
-  | 0, ~q(ℝ), ~q(@Norm.norm $E $_n $a) =>
-    let _seminormedAddGroup_E ← synthInstanceQ q(SeminormedAddGroup $E)
-    assertInstancesCommute
-    -- Check whether we are in a normed group and whether the context contains a `a ≠ 0` assumption
-    let o : Option (Q(NormedAddGroup $E) × Q($a ≠ 0)) := ← do
-      let .some normedAddGroup_E ← trySynthInstanceQ q(NormedAddGroup $E) | return none
-      let some pa ← findLocalDeclWithTypeQ? q($a ≠ 0) | return none
-      return some (normedAddGroup_E, pa)
-    match o with
-    -- If so, return a proof of `0 < ‖a‖`
-    | some (_normedAddGroup_E, pa) =>
-      assertInstancesCommute
-      return .positive q(norm_pos_iff.2 $pa)
-    -- Else, return a proof of `0 ≤ ‖a‖`
-    | none => return .nonnegative q(norm_nonneg $a)
-  | _, _, _ => throwError "not `‖·‖`"
-
-end Mathlib.Meta.Positivity
 
 /-! ### Subgroups of normed groups -/
 
@@ -1643,4 +1311,54 @@ end SubgroupClass
 
 lemma tendsto_norm_atTop_atTop : Tendsto (norm : ℝ → ℝ) atTop atTop := tendsto_abs_atTop_atTop
 
-set_option linter.style.longFile 1700
+/-! ### `positivity` extensions -/
+
+namespace Mathlib.Meta.Positivity
+
+open Lean Meta Qq Function
+
+/-- Extension for the `positivity` tactic: multiplicative norms are always nonnegative, and positive
+on non-one inputs. -/
+@[positivity ‖_‖]
+def evalMulNorm : PositivityExt where eval {u α} _ _ e := do
+  match u, α, e with
+  | 0, ~q(ℝ), ~q(@Norm.norm $E $_n $a) =>
+    let _seminormedGroup_E ← synthInstanceQ q(SeminormedGroup $E)
+    assertInstancesCommute
+    -- Check whether we are in a normed group and whether the context contains a `a ≠ 1` assumption
+    let o : Option (Q(NormedGroup $E) × Q($a ≠ 1)) := ← do
+      let .some normedGroup_E ← trySynthInstanceQ q(NormedGroup $E) | return none
+      let some pa ← findLocalDeclWithTypeQ? q($a ≠ 1) | return none
+      return some (normedGroup_E, pa)
+    match o with
+    -- If so, return a proof of `0 < ‖a‖`
+    | some (_normedGroup_E, pa) =>
+      assertInstancesCommute
+      return .positive q(norm_pos_iff'.2 $pa)
+    -- Else, return a proof of `0 ≤ ‖a‖`
+    | none => return .nonnegative q(norm_nonneg' $a)
+  | _, _, _ => throwError "not `‖·‖`"
+
+/-- Extension for the `positivity` tactic: additive norms are always nonnegative, and positive
+on non-zero inputs. -/
+@[positivity ‖_‖]
+def evalAddNorm : PositivityExt where eval {u α} _ _ e := do
+  match u, α, e with
+  | 0, ~q(ℝ), ~q(@Norm.norm $E $_n $a) =>
+    let _seminormedAddGroup_E ← synthInstanceQ q(SeminormedAddGroup $E)
+    assertInstancesCommute
+    -- Check whether we are in a normed group and whether the context contains a `a ≠ 0` assumption
+    let o : Option (Q(NormedAddGroup $E) × Q($a ≠ 0)) := ← do
+      let .some normedAddGroup_E ← trySynthInstanceQ q(NormedAddGroup $E) | return none
+      let some pa ← findLocalDeclWithTypeQ? q($a ≠ 0) | return none
+      return some (normedAddGroup_E, pa)
+    match o with
+    -- If so, return a proof of `0 < ‖a‖`
+    | some (_normedAddGroup_E, pa) =>
+      assertInstancesCommute
+      return .positive q(norm_pos_iff.2 $pa)
+    -- Else, return a proof of `0 ≤ ‖a‖`
+    | none => return .nonnegative q(norm_nonneg $a)
+  | _, _, _ => throwError "not `‖·‖`"
+
+end Mathlib.Meta.Positivity

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -21,10 +21,6 @@ In this file we define 10 classes:
 
 We also prove basic properties of (semi)normed groups and provide some instances.
 
-## TODO
-This file is huge; move material into separate files,
-such as `Mathlib/Analysis/Normed/Group/Lemmas.lean`.
-
 ## Notes
 
 The current convention `dist x y = ‖x - y‖` means that the distance is invariant under right

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -3,8 +3,6 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl, Yaël Dillies
 -/
-import Mathlib.Algebra.CharP.Defs
-import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Analysis.Normed.Group.Seminorm
 import Mathlib.Topology.MetricSpace.Basic
 
@@ -1216,98 +1214,6 @@ theorem hasCompactSupport_norm_iff : (HasCompactSupport fun x => ‖f x‖) ↔ 
 alias ⟨_, HasCompactSupport.norm⟩ := hasCompactSupport_norm_iff
 
 end NormedAddGroup
-
-/-! ### Subgroups of normed groups -/
-
-
-namespace Subgroup
-
-section SeminormedGroup
-
-variable [SeminormedGroup E] {s : Subgroup E}
-
-/-- A subgroup of a seminormed group is also a seminormed group,
-with the restriction of the norm. -/
-@[to_additive "A subgroup of a seminormed group is also a seminormed group, with the restriction of
-the norm."]
-instance seminormedGroup : SeminormedGroup s :=
-  SeminormedGroup.induced _ _ s.subtype
-
-/-- If `x` is an element of a subgroup `s` of a seminormed group `E`, its norm in `s` is equal to
-its norm in `E`. -/
-@[to_additive (attr := simp) "If `x` is an element of a subgroup `s` of a seminormed group `E`, its
-norm in `s` is equal to its norm in `E`."]
-theorem coe_norm (x : s) : ‖x‖ = ‖(x : E)‖ :=
-  rfl
-
-/-- If `x` is an element of a subgroup `s` of a seminormed group `E`, its norm in `s` is equal to
-its norm in `E`.
-
-This is a reversed version of the `simp` lemma `Subgroup.coe_norm` for use by `norm_cast`. -/
-@[to_additive (attr := norm_cast) "If `x` is an element of a subgroup `s` of a seminormed group `E`,
-its norm in `s` is equal to its norm in `E`.
-
-This is a reversed version of the `simp` lemma `AddSubgroup.coe_norm` for use by `norm_cast`."]
-theorem norm_coe {s : Subgroup E} (x : s) : ‖(x : E)‖ = ‖x‖ :=
-  rfl
-
-end SeminormedGroup
-
-@[to_additive]
-instance seminormedCommGroup [SeminormedCommGroup E] {s : Subgroup E} : SeminormedCommGroup s :=
-  SeminormedCommGroup.induced _ _ s.subtype
-
-@[to_additive]
-instance normedGroup [NormedGroup E] {s : Subgroup E} : NormedGroup s :=
-  NormedGroup.induced _ _ s.subtype Subtype.coe_injective
-
-@[to_additive]
-instance normedCommGroup [NormedCommGroup E] {s : Subgroup E} : NormedCommGroup s :=
-  NormedCommGroup.induced _ _ s.subtype Subtype.coe_injective
-
-end Subgroup
-
-/-! ### Subgroup classes of normed groups -/
-
-
-namespace SubgroupClass
-
-section SeminormedGroup
-
-variable [SeminormedGroup E] {S : Type*} [SetLike S E] [SubgroupClass S E] (s : S)
-
-/-- A subgroup of a seminormed group is also a seminormed group,
-with the restriction of the norm. -/
-@[to_additive "A subgroup of a seminormed additive group is also a seminormed additive group, with
-the restriction of the norm."]
-instance (priority := 75) seminormedGroup : SeminormedGroup s :=
-  SeminormedGroup.induced _ _ (SubgroupClass.subtype s)
-
-/-- If `x` is an element of a subgroup `s` of a seminormed group `E`, its norm in `s` is equal to
-its norm in `E`. -/
-@[to_additive (attr := simp) "If `x` is an element of an additive subgroup `s` of a seminormed
-additive group `E`, its norm in `s` is equal to its norm in `E`."]
-theorem coe_norm (x : s) : ‖x‖ = ‖(x : E)‖ :=
-  rfl
-
-end SeminormedGroup
-
-@[to_additive]
-instance (priority := 75) seminormedCommGroup [SeminormedCommGroup E] {S : Type*} [SetLike S E]
-    [SubgroupClass S E] (s : S) : SeminormedCommGroup s :=
-  SeminormedCommGroup.induced _ _ (SubgroupClass.subtype s)
-
-@[to_additive]
-instance (priority := 75) normedGroup [NormedGroup E] {S : Type*} [SetLike S E] [SubgroupClass S E]
-    (s : S) : NormedGroup s :=
-  NormedGroup.induced _ _ (SubgroupClass.subtype s) Subtype.coe_injective
-
-@[to_additive]
-instance (priority := 75) normedCommGroup [NormedCommGroup E] {S : Type*} [SetLike S E]
-    [SubgroupClass S E] (s : S) : NormedCommGroup s :=
-  NormedCommGroup.induced _ _ (SubgroupClass.subtype s) Subtype.coe_injective
-
-end SubgroupClass
 
 lemma tendsto_norm_atTop_atTop : Tendsto (norm : ℝ → ℝ) atTop atTop := tendsto_abs_atTop_atTop
 

--- a/Mathlib/Analysis/Normed/Group/Bounded.lean
+++ b/Mathlib/Analysis/Normed/Group/Bounded.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl, Yaël Dillies
 -/
-import Mathlib.Analysis.Normed.Group.Basic
+import Mathlib.Analysis.Normed.Group.Continuity
 import Mathlib.Topology.MetricSpace.Bounded
 import Mathlib.Order.Filter.Pointwise
 

--- a/Mathlib/Analysis/Normed/Group/Continuity.lean
+++ b/Mathlib/Analysis/Normed/Group/Continuity.lean
@@ -9,33 +9,7 @@ import Mathlib.Topology.Metrizable.Uniformity
 import Mathlib.Topology.Sequences
 
 /-!
-# Normed (semi)groups
-
-In this file we define 10 classes:
-
-* `Norm`, `NNNorm`: auxiliary classes endowing a type `α` with a function `norm : α → ℝ`
-  (notation: `‖x‖`) and `nnnorm : α → ℝ≥0` (notation: `‖x‖₊`), respectively;
-* `Seminormed...Group`: A seminormed (additive) (commutative) group is an (additive) (commutative)
-  group with a norm and a compatible pseudometric space structure:
-  `∀ x y, dist x y = ‖x / y‖` or `∀ x y, dist x y = ‖x - y‖`, depending on the group operation.
-* `Normed...Group`: A normed (additive) (commutative) group is an (additive) (commutative) group
-  with a norm and a compatible metric space structure.
-
-We also prove basic properties of (semi)normed groups and provide some instances.
-
-## TODO
-This file is huge; move material into separate files,
-such as `Mathlib/Analysis/Normed/Group/Lemmas.lean`.
-
-## Notes
-
-The current convention `dist x y = ‖x - y‖` means that the distance is invariant under right
-addition, but actions in mathlib are usually from the left. This means we might want to change it to
-`dist x y = ‖-x + y‖`.
-
-The normed group hierarchy would lend itself well to a mixin design (that is, having
-`SeminormedGroup` and `SeminormedAddGroup` not extend `Group` and `AddGroup`), but we choose not
-to for performance concerns.
+# Continuity of the norm on (semi)groups
 
 ## Tags
 

--- a/Mathlib/Analysis/Normed/Group/Continuity.lean
+++ b/Mathlib/Analysis/Normed/Group/Continuity.lean
@@ -1,0 +1,348 @@
+/-
+Copyright (c) 2018 Patrick Massot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Massot, Johannes Hölzl, Yaël Dillies
+-/
+import Mathlib.Analysis.Normed.Group.Basic
+import Mathlib.Topology.Instances.ENNReal.Defs
+import Mathlib.Topology.Metrizable.Uniformity
+import Mathlib.Topology.Sequences
+
+/-!
+# Normed (semi)groups
+
+In this file we define 10 classes:
+
+* `Norm`, `NNNorm`: auxiliary classes endowing a type `α` with a function `norm : α → ℝ`
+  (notation: `‖x‖`) and `nnnorm : α → ℝ≥0` (notation: `‖x‖₊`), respectively;
+* `Seminormed...Group`: A seminormed (additive) (commutative) group is an (additive) (commutative)
+  group with a norm and a compatible pseudometric space structure:
+  `∀ x y, dist x y = ‖x / y‖` or `∀ x y, dist x y = ‖x - y‖`, depending on the group operation.
+* `Normed...Group`: A normed (additive) (commutative) group is an (additive) (commutative) group
+  with a norm and a compatible metric space structure.
+
+We also prove basic properties of (semi)normed groups and provide some instances.
+
+## TODO
+This file is huge; move material into separate files,
+such as `Mathlib/Analysis/Normed/Group/Lemmas.lean`.
+
+## Notes
+
+The current convention `dist x y = ‖x - y‖` means that the distance is invariant under right
+addition, but actions in mathlib are usually from the left. This means we might want to change it to
+`dist x y = ‖-x + y‖`.
+
+The normed group hierarchy would lend itself well to a mixin design (that is, having
+`SeminormedGroup` and `SeminormedAddGroup` not extend `Group` and `AddGroup`), but we choose not
+to for performance concerns.
+
+## Tags
+
+normed group
+-/
+
+
+variable {𝓕 α ι κ E F G : Type*}
+
+open Filter Function Metric Bornology ENNReal NNReal Uniformity Pointwise Topology
+
+section SeminormedGroup
+
+variable [SeminormedGroup E] [SeminormedGroup F] [SeminormedGroup G] {s : Set E} {a : E}
+
+@[to_additive]
+theorem tendsto_iff_norm_div_tendsto_zero {f : α → E} {a : Filter α} {b : E} :
+    Tendsto f a (𝓝 b) ↔ Tendsto (fun e => ‖f e / b‖) a (𝓝 0) := by
+  simp only [← dist_eq_norm_div, ← tendsto_iff_dist_tendsto_zero]
+
+@[to_additive]
+theorem tendsto_one_iff_norm_tendsto_zero {f : α → E} {a : Filter α} :
+    Tendsto f a (𝓝 1) ↔ Tendsto (‖f ·‖) a (𝓝 0) :=
+  tendsto_iff_norm_div_tendsto_zero.trans <| by simp only [div_one]
+
+@[to_additive]
+theorem comap_norm_nhds_one : comap norm (𝓝 0) = 𝓝 (1 : E) := by
+  simpa only [dist_one_right] using nhds_comap_dist (1 : E)
+
+/-- Special case of the sandwich theorem: if the norm of `f` is eventually bounded by a real
+function `a` which tends to `0`, then `f` tends to `1` (neutral element of `SeminormedGroup`).
+In this pair of lemmas (`squeeze_one_norm'` and `squeeze_one_norm`), following a convention of
+similar lemmas in `Topology.MetricSpace.Basic` and `Topology.Algebra.Order`, the `'` version is
+phrased using "eventually" and the non-`'` version is phrased absolutely. -/
+@[to_additive "Special case of the sandwich theorem: if the norm of `f` is eventually bounded by a
+real function `a` which tends to `0`, then `f` tends to `0`. In this pair of lemmas
+(`squeeze_zero_norm'` and `squeeze_zero_norm`), following a convention of similar lemmas in
+`Topology.MetricSpace.Pseudo.Defs` and `Topology.Algebra.Order`, the `'` version is phrased using
+\"eventually\" and the non-`'` version is phrased absolutely."]
+theorem squeeze_one_norm' {f : α → E} {a : α → ℝ} {t₀ : Filter α} (h : ∀ᶠ n in t₀, ‖f n‖ ≤ a n)
+    (h' : Tendsto a t₀ (𝓝 0)) : Tendsto f t₀ (𝓝 1) :=
+  tendsto_one_iff_norm_tendsto_zero.2 <|
+    squeeze_zero' (Eventually.of_forall fun _n => norm_nonneg' _) h h'
+
+/-- Special case of the sandwich theorem: if the norm of `f` is bounded by a real function `a` which
+tends to `0`, then `f` tends to `1`. -/
+@[to_additive "Special case of the sandwich theorem: if the norm of `f` is bounded by a real
+function `a` which tends to `0`, then `f` tends to `0`."]
+theorem squeeze_one_norm {f : α → E} {a : α → ℝ} {t₀ : Filter α} (h : ∀ n, ‖f n‖ ≤ a n) :
+    Tendsto a t₀ (𝓝 0) → Tendsto f t₀ (𝓝 1) :=
+  squeeze_one_norm' <| Eventually.of_forall h
+
+@[to_additive]
+theorem tendsto_norm_div_self (x : E) : Tendsto (fun a => ‖a / x‖) (𝓝 x) (𝓝 0) := by
+  simpa [dist_eq_norm_div] using
+    tendsto_id.dist (tendsto_const_nhds : Tendsto (fun _a => (x : E)) (𝓝 x) _)
+
+@[to_additive]
+theorem tendsto_norm_div_self_nhdsGE (x : E) : Tendsto (fun a ↦ ‖a / x‖) (𝓝 x) (𝓝[≥] 0) :=
+  tendsto_nhdsWithin_iff.mpr ⟨tendsto_norm_div_self x, by simp⟩
+
+@[to_additive tendsto_norm]
+theorem tendsto_norm' {x : E} : Tendsto (fun a => ‖a‖) (𝓝 x) (𝓝 ‖x‖) := by
+  simpa using tendsto_id.dist (tendsto_const_nhds : Tendsto (fun _a => (1 : E)) _ _)
+
+/-- See `tendsto_norm_one` for a version with pointed neighborhoods. -/
+@[to_additive "See `tendsto_norm_zero` for a version with pointed neighborhoods."]
+theorem tendsto_norm_one : Tendsto (fun a : E => ‖a‖) (𝓝 1) (𝓝 0) := by
+  simpa using tendsto_norm_div_self (1 : E)
+
+@[to_additive (attr := continuity) continuous_norm]
+theorem continuous_norm' : Continuous fun a : E => ‖a‖ := by
+  simpa using continuous_id.dist (continuous_const : Continuous fun _a => (1 : E))
+
+@[to_additive (attr := continuity) continuous_nnnorm]
+theorem continuous_nnnorm' : Continuous fun a : E => ‖a‖₊ :=
+  continuous_norm'.subtype_mk _
+
+@[to_additive (attr := continuity) continuous_enorm]
+lemma continuous_enorm' : Continuous fun a : E ↦ ‖a‖ₑ :=
+  ENNReal.isOpenEmbedding_coe.continuous.comp continuous_nnnorm'
+
+set_option linter.docPrime false in
+@[to_additive Inseparable.norm_eq_norm]
+theorem Inseparable.norm_eq_norm' {u v : E} (h : Inseparable u v) : ‖u‖ = ‖v‖ :=
+  h.map continuous_norm' |>.eq
+
+set_option linter.docPrime false in
+@[to_additive Inseparable.nnnorm_eq_nnnorm]
+theorem Inseparable.nnnorm_eq_nnnorm' {u v : E} (h : Inseparable u v) : ‖u‖₊ = ‖v‖₊ :=
+  h.map continuous_nnnorm' |>.eq
+
+@[to_additive]
+theorem mem_closure_one_iff_norm {x : E} : x ∈ closure ({1} : Set E) ↔ ‖x‖ = 0 := by
+  rw [← closedBall_zero', mem_closedBall_one_iff, (norm_nonneg' x).le_iff_eq]
+
+@[to_additive]
+theorem closure_one_eq : closure ({1} : Set E) = { x | ‖x‖ = 0 } :=
+  Set.ext fun _x => mem_closure_one_iff_norm
+
+section
+
+variable {l : Filter α} {f : α → E}
+
+@[to_additive Filter.Tendsto.norm]
+theorem Filter.Tendsto.norm' (h : Tendsto f l (𝓝 a)) : Tendsto (fun x => ‖f x‖) l (𝓝 ‖a‖) :=
+  tendsto_norm'.comp h
+
+@[to_additive Filter.Tendsto.nnnorm]
+theorem Filter.Tendsto.nnnorm' (h : Tendsto f l (𝓝 a)) : Tendsto (fun x => ‖f x‖₊) l (𝓝 ‖a‖₊) :=
+  Tendsto.comp continuous_nnnorm'.continuousAt h
+
+@[to_additive Filter.Tendsto.enorm]
+lemma Filter.Tendsto.enorm' (h : Tendsto f l (𝓝 a)) : Tendsto (‖f ·‖ₑ) l (𝓝 ‖a‖ₑ) :=
+  .comp continuous_enorm'.continuousAt h
+
+end
+
+section
+
+variable [TopologicalSpace α] {f : α → E} {s : Set α} {a : α}
+
+@[to_additive (attr := fun_prop) Continuous.norm]
+theorem Continuous.norm' : Continuous f → Continuous fun x => ‖f x‖ :=
+  continuous_norm'.comp
+
+@[to_additive (attr := fun_prop) Continuous.nnnorm]
+theorem Continuous.nnnorm' : Continuous f → Continuous fun x => ‖f x‖₊ :=
+  continuous_nnnorm'.comp
+
+@[to_additive (attr := fun_prop) Continuous.enorm]
+lemma Continuous.enorm' : Continuous f → Continuous (‖f ·‖ₑ) := continuous_enorm'.comp
+
+@[to_additive (attr := fun_prop) ContinuousAt.norm]
+theorem ContinuousAt.norm' {a : α} (h : ContinuousAt f a) : ContinuousAt (fun x => ‖f x‖) a :=
+  Tendsto.norm' h
+
+@[to_additive (attr := fun_prop) ContinuousAt.nnnorm]
+theorem ContinuousAt.nnnorm' {a : α} (h : ContinuousAt f a) : ContinuousAt (fun x => ‖f x‖₊) a :=
+  Tendsto.nnnorm' h
+
+@[to_additive (attr := fun_prop) ContinuousAt.enorm]
+lemma ContinuousAt.enorm' (h : ContinuousAt f a) : ContinuousAt (‖f ·‖ₑ) a := Tendsto.enorm' h
+
+@[to_additive ContinuousWithinAt.norm]
+theorem ContinuousWithinAt.norm' {s : Set α} {a : α} (h : ContinuousWithinAt f s a) :
+    ContinuousWithinAt (fun x => ‖f x‖) s a :=
+  Tendsto.norm' h
+
+@[to_additive ContinuousWithinAt.nnnorm]
+theorem ContinuousWithinAt.nnnorm' {s : Set α} {a : α} (h : ContinuousWithinAt f s a) :
+    ContinuousWithinAt (fun x => ‖f x‖₊) s a :=
+  Tendsto.nnnorm' h
+
+@[to_additive ContinuousWithinAt.enorm]
+lemma ContinuousWithinAt.enorm' (h : ContinuousWithinAt f s a) : ContinuousWithinAt (‖f ·‖ₑ) s a :=
+  Tendsto.enorm' h
+
+@[to_additive (attr := fun_prop) ContinuousOn.norm]
+theorem ContinuousOn.norm' {s : Set α} (h : ContinuousOn f s) : ContinuousOn (fun x => ‖f x‖) s :=
+  fun x hx => (h x hx).norm'
+
+@[to_additive (attr := fun_prop) ContinuousOn.nnnorm]
+theorem ContinuousOn.nnnorm' {s : Set α} (h : ContinuousOn f s) :
+    ContinuousOn (fun x => ‖f x‖₊) s := fun x hx => (h x hx).nnnorm'
+
+@[to_additive (attr := fun_prop) ContinuousOn.enorm]
+lemma ContinuousOn.enorm' (h : ContinuousOn f s) : ContinuousOn (‖f ·‖ₑ) s :=
+  fun x hx => (h x hx).enorm'
+
+end
+
+/-- If `‖y‖ → ∞`, then we can assume `y ≠ x` for any fixed `x`. -/
+@[to_additive eventually_ne_of_tendsto_norm_atTop "If `‖y‖→∞`, then we can assume `y≠x` for any
+fixed `x`"]
+theorem eventually_ne_of_tendsto_norm_atTop' {l : Filter α} {f : α → E}
+    (h : Tendsto (fun y => ‖f y‖) l atTop) (x : E) : ∀ᶠ y in l, f y ≠ x :=
+  (h.eventually_ne_atTop _).mono fun _x => ne_of_apply_ne norm
+
+@[to_additive]
+theorem SeminormedCommGroup.mem_closure_iff :
+    a ∈ closure s ↔ ∀ ε, 0 < ε → ∃ b ∈ s, ‖a / b‖ < ε := by
+  simp [Metric.mem_closure_iff, dist_eq_norm_div]
+
+@[to_additive]
+theorem SeminormedGroup.tendstoUniformlyOn_one {f : ι → κ → G} {s : Set κ} {l : Filter ι} :
+    TendstoUniformlyOn f 1 l s ↔ ∀ ε > 0, ∀ᶠ i in l, ∀ x ∈ s, ‖f i x‖ < ε := by
+  simp only [tendstoUniformlyOn_iff, Pi.one_apply, dist_one_left]
+
+@[to_additive]
+theorem SeminormedGroup.uniformCauchySeqOnFilter_iff_tendstoUniformlyOnFilter_one {f : ι → κ → G}
+    {l : Filter ι} {l' : Filter κ} :
+    UniformCauchySeqOnFilter f l l' ↔
+      TendstoUniformlyOnFilter (fun n : ι × ι => fun z => f n.fst z / f n.snd z) 1 (l ×ˢ l) l' := by
+  refine ⟨fun hf u hu => ?_, fun hf u hu => ?_⟩
+  · obtain ⟨ε, hε, H⟩ := uniformity_basis_dist.mem_uniformity_iff.mp hu
+    refine
+      (hf { p : G × G | dist p.fst p.snd < ε } <| dist_mem_uniformity hε).mono fun x hx =>
+        H 1 (f x.fst.fst x.snd / f x.fst.snd x.snd) ?_
+    simpa [dist_eq_norm_div, norm_div_rev] using hx
+  · obtain ⟨ε, hε, H⟩ := uniformity_basis_dist.mem_uniformity_iff.mp hu
+    refine
+      (hf { p : G × G | dist p.fst p.snd < ε } <| dist_mem_uniformity hε).mono fun x hx =>
+        H (f x.fst.fst x.snd) (f x.fst.snd x.snd) ?_
+    simpa [dist_eq_norm_div, norm_div_rev] using hx
+
+@[to_additive]
+theorem SeminormedGroup.uniformCauchySeqOn_iff_tendstoUniformlyOn_one {f : ι → κ → G} {s : Set κ}
+    {l : Filter ι} :
+    UniformCauchySeqOn f l s ↔
+      TendstoUniformlyOn (fun n : ι × ι => fun z => f n.fst z / f n.snd z) 1 (l ×ˢ l) s := by
+  rw [tendstoUniformlyOn_iff_tendstoUniformlyOnFilter,
+    uniformCauchySeqOn_iff_uniformCauchySeqOnFilter,
+    SeminormedGroup.uniformCauchySeqOnFilter_iff_tendstoUniformlyOnFilter_one]
+
+end SeminormedGroup
+
+section SeminormedCommGroup
+
+variable [SeminormedCommGroup E] [SeminormedCommGroup F] {a b : E} {r : ℝ}
+
+open Finset
+
+@[to_additive]
+theorem controlled_prod_of_mem_closure {s : Subgroup E} (hg : a ∈ closure (s : Set E)) {b : ℕ → ℝ}
+    (b_pos : ∀ n, 0 < b n) :
+    ∃ v : ℕ → E,
+      Tendsto (fun n => ∏ i ∈ range (n + 1), v i) atTop (𝓝 a) ∧
+        (∀ n, v n ∈ s) ∧ ‖v 0 / a‖ < b 0 ∧ ∀ n, 0 < n → ‖v n‖ < b n := by
+  obtain ⟨u : ℕ → E, u_in : ∀ n, u n ∈ s, lim_u : Tendsto u atTop (𝓝 a)⟩ :=
+    mem_closure_iff_seq_limit.mp hg
+  obtain ⟨n₀, hn₀⟩ : ∃ n₀, ∀ n ≥ n₀, ‖u n / a‖ < b 0 :=
+    haveI : { x | ‖x / a‖ < b 0 } ∈ 𝓝 a := by
+      simp_rw [← dist_eq_norm_div]
+      exact Metric.ball_mem_nhds _ (b_pos _)
+    Filter.tendsto_atTop'.mp lim_u _ this
+  set z : ℕ → E := fun n => u (n + n₀)
+  have lim_z : Tendsto z atTop (𝓝 a) := lim_u.comp (tendsto_add_atTop_nat n₀)
+  have mem_𝓤 : ∀ n, { p : E × E | ‖p.1 / p.2‖ < b (n + 1) } ∈ 𝓤 E := fun n => by
+    simpa [← dist_eq_norm_div] using Metric.dist_mem_uniformity (b_pos <| n + 1)
+  obtain ⟨φ : ℕ → ℕ, φ_extr : StrictMono φ, hφ : ∀ n, ‖z (φ <| n + 1) / z (φ n)‖ < b (n + 1)⟩ :=
+    lim_z.cauchySeq.subseq_mem mem_𝓤
+  set w : ℕ → E := z ∘ φ
+  have hw : Tendsto w atTop (𝓝 a) := lim_z.comp φ_extr.tendsto_atTop
+  set v : ℕ → E := fun i => if i = 0 then w 0 else w i / w (i - 1)
+  refine ⟨v, Tendsto.congr (Finset.eq_prod_range_div' w) hw, ?_, hn₀ _ (n₀.le_add_left _), ?_⟩
+  · rintro ⟨⟩
+    · change w 0 ∈ s
+      apply u_in
+    · apply s.div_mem <;> apply u_in
+  · intro l hl
+    obtain ⟨k, rfl⟩ : ∃ k, l = k + 1 := Nat.exists_eq_succ_of_ne_zero hl.ne'
+    apply hφ
+
+@[to_additive]
+theorem controlled_prod_of_mem_closure_range {j : E →* F} {b : F}
+    (hb : b ∈ closure (j.range : Set F)) {f : ℕ → ℝ} (b_pos : ∀ n, 0 < f n) :
+    ∃ a : ℕ → E,
+      Tendsto (fun n => ∏ i ∈ range (n + 1), j (a i)) atTop (𝓝 b) ∧
+        ‖j (a 0) / b‖ < f 0 ∧ ∀ n, 0 < n → ‖j (a n)‖ < f n := by
+  obtain ⟨v, sum_v, v_in, hv₀, hv_pos⟩ := controlled_prod_of_mem_closure hb b_pos
+  choose g hg using v_in
+  exact
+    ⟨g, by simpa [← hg] using sum_v, by simpa [hg 0] using hv₀,
+      fun n hn => by simpa [hg] using hv_pos n hn⟩
+
+end SeminormedCommGroup
+
+section NormedGroup
+
+variable [NormedGroup E] {a b : E}
+
+/-- See `tendsto_norm_one` for a version with full neighborhoods. -/
+@[to_additive "See `tendsto_norm_zero` for a version with full neighborhoods."]
+lemma tendsto_norm_nhdsNE_one : Tendsto (norm : E → ℝ) (𝓝[≠] 1) (𝓝[>] 0) :=
+  tendsto_norm_one.inf <| tendsto_principal_principal.2 fun _ hx ↦ norm_pos_iff'.2 hx
+
+@[deprecated (since := "2024-12-22")]
+alias tendsto_norm_zero' := tendsto_norm_nhdsNE_zero
+@[to_additive existing, deprecated (since := "2024-12-22")]
+alias tendsto_norm_one' := tendsto_norm_nhdsNE_one
+
+@[deprecated (since := "2024-12-22")]
+alias tendsto_norm_nhdsWithin_zero := tendsto_norm_nhdsNE_zero
+@[to_additive existing, deprecated (since := "2024-12-22")]
+alias tendsto_norm_nhdsWithin_one := tendsto_norm_nhdsNE_one
+
+@[to_additive]
+theorem tendsto_norm_div_self_nhdsNE (a : E) : Tendsto (fun x => ‖x / a‖) (𝓝[≠] a) (𝓝[>] 0) :=
+  (tendsto_norm_div_self a).inf <|
+    tendsto_principal_principal.2 fun _x hx => norm_pos_iff'.2 <| div_ne_one.2 hx
+
+@[deprecated (since := "2024-12-22")]
+alias tendsto_norm_sub_self_punctured_nhds := tendsto_norm_sub_self_nhdsNE
+@[to_additive existing, deprecated (since := "2024-12-22")]
+alias tendsto_norm_div_self_punctured_nhds := tendsto_norm_div_self_nhdsNE
+
+variable (E)
+
+/-- A version of `comap_norm_nhdsGT_zero` for a multiplicative normed group. -/
+@[to_additive comap_norm_nhdsGT_zero]
+lemma comap_norm_nhdsGT_zero' : comap norm (𝓝[>] 0) = 𝓝[≠] (1 : E) := by
+  simp [nhdsWithin, comap_norm_nhds_one, Set.preimage, Set.compl_def]
+
+@[deprecated (since := "2024-12-22")]
+alias comap_norm_nhdsWithin_Ioi_zero := comap_norm_nhdsGT_zero
+@[to_additive existing comap_norm_nhdsWithin_Ioi_zero, deprecated (since := "2024-12-22")]
+alias comap_norm_nhdsWithin_Ioi_zero' := comap_norm_nhdsGT_zero'
+
+end NormedGroup

--- a/Mathlib/Analysis/Normed/Group/Hom.lean
+++ b/Mathlib/Analysis/Normed/Group/Hom.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 import Mathlib.Analysis.Normed.Group.Int
+import Mathlib.Analysis.Normed.Group.Subgroup
 import Mathlib.Analysis.Normed.Group.Uniform
 
 /-!

--- a/Mathlib/Analysis/Normed/Group/NullSubmodule.lean
+++ b/Mathlib/Analysis/Normed/Group/NullSubmodule.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Yoh Tanimoto. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yoh Tanimoto
 -/
+import Mathlib.Analysis.Normed.Group.Continuity
 import Mathlib.Analysis.Normed.MulAction
 
 /-!

--- a/Mathlib/Analysis/Normed/Group/Subgroup.lean
+++ b/Mathlib/Analysis/Normed/Group/Subgroup.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2018 Patrick Massot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Massot, Johannes Hölzl, Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Subgroup.Defs
+import Mathlib.Analysis.Normed.Group.Basic
+
+/-!
+# Normed (semi)groups
+
+In this file we define 10 classes:
+
+* `Norm`, `NNNorm`: auxiliary classes endowing a type `α` with a function `norm : α → ℝ`
+  (notation: `‖x‖`) and `nnnorm : α → ℝ≥0` (notation: `‖x‖₊`), respectively;
+* `Seminormed...Group`: A seminormed (additive) (commutative) group is an (additive) (commutative)
+  group with a norm and a compatible pseudometric space structure:
+  `∀ x y, dist x y = ‖x / y‖` or `∀ x y, dist x y = ‖x - y‖`, depending on the group operation.
+* `Normed...Group`: A normed (additive) (commutative) group is an (additive) (commutative) group
+  with a norm and a compatible metric space structure.
+
+We also prove basic properties of (semi)normed groups and provide some instances.
+
+## TODO
+This file is huge; move material into separate files,
+such as `Mathlib/Analysis/Normed/Group/Lemmas.lean`.
+
+## Notes
+
+The current convention `dist x y = ‖x - y‖` means that the distance is invariant under right
+addition, but actions in mathlib are usually from the left. This means we might want to change it to
+`dist x y = ‖-x + y‖`.
+
+The normed group hierarchy would lend itself well to a mixin design (that is, having
+`SeminormedGroup` and `SeminormedAddGroup` not extend `Group` and `AddGroup`), but we choose not
+to for performance concerns.
+
+## Tags
+
+normed group
+-/
+
+
+open Filter Function Metric Bornology
+open ENNReal Filter NNReal Uniformity Pointwise Topology
+
+/-! ### Subgroups of normed groups -/
+
+variable {E : Type*}
+
+namespace Subgroup
+
+section SeminormedGroup
+
+variable [SeminormedGroup E] {s : Subgroup E}
+
+/-- A subgroup of a seminormed group is also a seminormed group,
+with the restriction of the norm. -/
+@[to_additive "A subgroup of a seminormed group is also a seminormed group, with the restriction of
+the norm."]
+instance seminormedGroup : SeminormedGroup s :=
+  SeminormedGroup.induced _ _ s.subtype
+
+/-- If `x` is an element of a subgroup `s` of a seminormed group `E`, its norm in `s` is equal to
+its norm in `E`. -/
+@[to_additive (attr := simp) "If `x` is an element of a subgroup `s` of a seminormed group `E`, its
+norm in `s` is equal to its norm in `E`."]
+theorem coe_norm (x : s) : ‖x‖ = ‖(x : E)‖ :=
+  rfl
+
+/-- If `x` is an element of a subgroup `s` of a seminormed group `E`, its norm in `s` is equal to
+its norm in `E`.
+
+This is a reversed version of the `simp` lemma `Subgroup.coe_norm` for use by `norm_cast`. -/
+@[to_additive (attr := norm_cast) "If `x` is an element of a subgroup `s` of a seminormed group `E`,
+its norm in `s` is equal to its norm in `E`.
+
+This is a reversed version of the `simp` lemma `AddSubgroup.coe_norm` for use by `norm_cast`."]
+theorem norm_coe {s : Subgroup E} (x : s) : ‖(x : E)‖ = ‖x‖ :=
+  rfl
+
+end SeminormedGroup
+
+@[to_additive]
+instance seminormedCommGroup [SeminormedCommGroup E] {s : Subgroup E} : SeminormedCommGroup s :=
+  SeminormedCommGroup.induced _ _ s.subtype
+
+@[to_additive]
+instance normedGroup [NormedGroup E] {s : Subgroup E} : NormedGroup s :=
+  NormedGroup.induced _ _ s.subtype Subtype.coe_injective
+
+@[to_additive]
+instance normedCommGroup [NormedCommGroup E] {s : Subgroup E} : NormedCommGroup s :=
+  NormedCommGroup.induced _ _ s.subtype Subtype.coe_injective
+
+end Subgroup
+
+/-! ### Subgroup classes of normed groups -/
+
+
+namespace SubgroupClass
+
+section SeminormedGroup
+
+variable [SeminormedGroup E] {S : Type*} [SetLike S E] [SubgroupClass S E] (s : S)
+
+/-- A subgroup of a seminormed group is also a seminormed group,
+with the restriction of the norm. -/
+@[to_additive "A subgroup of a seminormed additive group is also a seminormed additive group, with
+the restriction of the norm."]
+instance (priority := 75) seminormedGroup : SeminormedGroup s :=
+  SeminormedGroup.induced _ _ (SubgroupClass.subtype s)
+
+/-- If `x` is an element of a subgroup `s` of a seminormed group `E`, its norm in `s` is equal to
+its norm in `E`. -/
+@[to_additive (attr := simp) "If `x` is an element of an additive subgroup `s` of a seminormed
+additive group `E`, its norm in `s` is equal to its norm in `E`."]
+theorem coe_norm (x : s) : ‖x‖ = ‖(x : E)‖ :=
+  rfl
+
+end SeminormedGroup
+
+@[to_additive]
+instance (priority := 75) seminormedCommGroup [SeminormedCommGroup E] {S : Type*} [SetLike S E]
+    [SubgroupClass S E] (s : S) : SeminormedCommGroup s :=
+  SeminormedCommGroup.induced _ _ (SubgroupClass.subtype s)
+
+@[to_additive]
+instance (priority := 75) normedGroup [NormedGroup E] {S : Type*} [SetLike S E] [SubgroupClass S E]
+    (s : S) : NormedGroup s :=
+  NormedGroup.induced _ _ (SubgroupClass.subtype s) Subtype.coe_injective
+
+@[to_additive]
+instance (priority := 75) normedCommGroup [NormedCommGroup E] {S : Type*} [SetLike S E]
+    [SubgroupClass S E] (s : S) : NormedCommGroup s :=
+  NormedCommGroup.induced _ _ (SubgroupClass.subtype s) Subtype.coe_injective
+
+end SubgroupClass

--- a/Mathlib/Analysis/Normed/Group/Subgroup.lean
+++ b/Mathlib/Analysis/Normed/Group/Subgroup.lean
@@ -7,33 +7,9 @@ import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Analysis.Normed.Group.Basic
 
 /-!
-# Normed (semi)groups
+# Subgroups of normed (semi)groups
 
-In this file we define 10 classes:
-
-* `Norm`, `NNNorm`: auxiliary classes endowing a type `α` with a function `norm : α → ℝ`
-  (notation: `‖x‖`) and `nnnorm : α → ℝ≥0` (notation: `‖x‖₊`), respectively;
-* `Seminormed...Group`: A seminormed (additive) (commutative) group is an (additive) (commutative)
-  group with a norm and a compatible pseudometric space structure:
-  `∀ x y, dist x y = ‖x / y‖` or `∀ x y, dist x y = ‖x - y‖`, depending on the group operation.
-* `Normed...Group`: A normed (additive) (commutative) group is an (additive) (commutative) group
-  with a norm and a compatible metric space structure.
-
-We also prove basic properties of (semi)normed groups and provide some instances.
-
-## TODO
-This file is huge; move material into separate files,
-such as `Mathlib/Analysis/Normed/Group/Lemmas.lean`.
-
-## Notes
-
-The current convention `dist x y = ‖x - y‖` means that the distance is invariant under right
-addition, but actions in mathlib are usually from the left. This means we might want to change it to
-`dist x y = ‖-x + y‖`.
-
-The normed group hierarchy would lend itself well to a mixin design (that is, having
-`SeminormedGroup` and `SeminormedAddGroup` not extend `Group` and `AddGroup`), but we choose not
-to for performance concerns.
+In this file, we prove that subgroups of a normed (semi)group are also normed (semi)groups.
 
 ## Tags
 

--- a/Mathlib/Analysis/Normed/Group/Uniform.lean
+++ b/Mathlib/Analysis/Normed/Group/Uniform.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl, Yaël Dillies
 -/
-import Mathlib.Analysis.Normed.Group.Basic
+import Mathlib.Analysis.Normed.Group.Continuity
 import Mathlib.Topology.Algebra.UniformGroup.Basic
 import Mathlib.Topology.MetricSpace.Algebra
 import Mathlib.Topology.MetricSpace.IsometricSMul

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
-import Mathlib.Analysis.Normed.Group.Basic
+import Mathlib.Analysis.Normed.Group.Continuity
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Real
 import Mathlib.Topology.MetricSpace.Thickening
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Field.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Field.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-
+import Mathlib.Analysis.Normed.Group.Continuity
 import Mathlib.Analysis.Normed.Field.Basic
 import Mathlib.Topology.Algebra.InfiniteSum.Defs
 


### PR DESCRIPTION
Split `Analysis.Group.Normed.Basic` into three files:
- `Analysis.Group.Normed.Basic` contains the definitions and the basic results that just use the metric space structure
- `Analysis.Group.Normed.Continuity` contains the more advanced results especially the ones that uses the continuity of the norm 
- `Analysis.Group.Normed.Subgroup` contains the results about subgroups of normed groups.

Question. Is there a better name than `Analysis.Group.Normed.Continuity`?

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
