### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/InfiniteSum/Order): positivity extension for infinite sums

### DIFF
--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -319,15 +319,15 @@ requires more assumptions. -/
 def evalTsum : PositivityExt where eval {u α} zα pα e := do
   match e with
   | ~q(@tsum _ $instCommMonoid $instTopSpace $ι $f) =>
-    let i : Q($ι) ← mkFreshExprMVarQ q($ι) .syntheticOpaque
-    have body : Q($α) := .betaRev f #[i]
-    let rbody ← core zα pα body
-    let pbody ← rbody.toNonneg
-    let pr : Q(∀ i, 0 ≤ $f i) ← mkLambdaFVars #[i] pbody
-    let pα' ← synthInstanceQ q(OrderedAddCommMonoid $α)
-    let instOrderClosed ← synthInstanceQ q(OrderClosedTopology $α)
-    assertInstancesCommute
-    return .nonnegative q(@tsum_nonneg $ι $α $pα' $instTopSpace $instOrderClosed $f fun i ↦ $pr i)
+    lambdaBoundedTelescope f 1 fun args (body : Q($α)) => do
+      let #[(i : Q($ι))] := args | failure
+      let rbody ← core zα pα body
+      let pbody ← rbody.toNonneg
+      let pr : Q(∀ i, 0 ≤ $f i) ← mkLambdaFVars #[i] pbody
+      let pα' ← synthInstanceQ q(OrderedAddCommMonoid $α)
+      let instOrderClosed ← synthInstanceQ q(OrderClosedTopology $α)
+      assertInstancesCommute
+      return .nonnegative q(@tsum_nonneg $ι $α $pα' $instTopSpace $instOrderClosed $f fun i ↦ $pr i)
   | _ => throwError "not tsum"
 
 end Mathlib.Meta.Positivity

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -327,7 +327,7 @@ def evalTsum : PositivityExt where eval {u α} zα pα e := do
       let pα' ← synthInstanceQ q(OrderedAddCommMonoid $α)
       let instOrderClosed ← synthInstanceQ q(OrderClosedTopology $α)
       assertInstancesCommute
-      return .nonnegative q(@tsum_nonneg $ι $α $pα' $instTopSpace $instOrderClosed $f fun i ↦ $pr i)
+      return .nonnegative q(@tsum_nonneg $ι $α $pα' $instTopSpace $instOrderClosed $f $pr)
   | _ => throwError "not tsum"
 
 end Mathlib.Meta.Positivity

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -328,6 +328,6 @@ def evalTsum : PositivityExt where eval {u α} zα pα e := do
     let instOrderClosed ← synthInstanceQ q(OrderClosedTopology $α)
     assertInstancesCommute
     return .nonnegative q(@tsum_nonneg $ι $α $pα' $instTopSpace $instOrderClosed $f fun i ↦ $pr i)
-  | _ => throwError "not Finset.sum"
+  | _ => throwError "not tsum"
 
 end Mathlib.Meta.Positivity

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -306,7 +306,6 @@ theorem Summable.tendsto_atTop_of_pos [LinearOrderedField α] [TopologicalSpace 
     tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _ hf.tendsto_atTop_zero <|
       Eventually.of_forall fun _ ↦ inv_pos.2 (hf' _)
 
-
 namespace Mathlib.Meta.Positivity
 
 open Qq Lean Meta Finset
@@ -330,11 +329,5 @@ def evalTsum : PositivityExt where eval {u α} zα pα e := do
     assertInstancesCommute
     return .nonnegative q(@tsum_nonneg $ι $α $pα' $instTopSpace $instOrderClosed $f fun i ↦ $pr i)
   | _ => throwError "not Finset.sum"
-
-
-example (α : Type*) [LinearOrderedField α] [TopologicalSpace α] [OrderClosedTopology α]
-  (f : ℕ → α) :
-  0 ≤ ∑' n, (f n)^2 := by
-  positivity
 
 end Mathlib.Meta.Positivity

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -383,7 +383,7 @@ end Integral
 
 /-! ## Infinite Sums -/
 
-example (f : ℕ → ℝ) : 0 ≤ ∑' n, (f n)^2 := by positivity
+example (f : ℕ → ℝ) : 0 ≤ ∑' n, f n ^ 2 := by positivity
 example  (f : ℕ → ℝ≥0) (c : ℝ) (hc : 0 < c) : 0 ≤ ∑' n, c * f n := by positivity
 example [LinearOrderedField α] [TopologicalSpace α] [OrderClosedTopology α] (f : ℚ → α) :
     0 ≤ ∑' q, (f q)^2 := by

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -5,6 +5,7 @@ import Mathlib.Analysis.Normed.Group.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.MeasureTheory.Integral.Bochner
+import Mathlib.Topology.Algebra.InfiniteSum.Order
 
 /-! # Tests for the `positivity` tactic
 
@@ -379,6 +380,13 @@ example (f g : D → E) : 0 ≤ ∫ x, ‖f x‖ + ‖g x‖ ∂μ := by positiv
 example (f : D → E) (c : ℝ) (hc : 0 < c): 0 ≤ ∫ x, c * ‖f x‖ ∂μ := by positivity
 
 end Integral
+
+/-! ## Infinte Sums -/
+
+example (f : ℕ → ℝ) : 0 ≤ ∑' n, (f n)^2 := by positivity
+example [LinearOrderedField α] [TopologicalSpace α] [OrderClosedTopology α] (f : ℚ → α) :
+    0 ≤ ∑' q, (f q)^2 := by positivity
+example  [Norm α] (f : ℕ → ℝ≥0) (c : ℝ) (hc : 0 < c) : 0 ≤ ∑' n, c * f n := by positivity
 
 /-! ## Big operators -/
 

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -381,12 +381,18 @@ example (f : D → E) (c : ℝ) (hc : 0 < c): 0 ≤ ∫ x, c * ‖f x‖ ∂μ :
 
 end Integral
 
-/-! ## Infinte Sums -/
+/-! ## Infinite Sums -/
 
 example (f : ℕ → ℝ) : 0 ≤ ∑' n, (f n)^2 := by positivity
-example [LinearOrderedField α] [TopologicalSpace α] [OrderClosedTopology α] (f : ℚ → α) :
-    0 ≤ ∑' q, (f q)^2 := by positivity
 example  (f : ℕ → ℝ≥0) (c : ℝ) (hc : 0 < c) : 0 ≤ ∑' n, c * f n := by positivity
+example [LinearOrderedField α] [TopologicalSpace α] [OrderClosedTopology α] (f : ℚ → α) :
+    0 ≤ ∑' q, (f q)^2 := by
+  positivity
+
+-- Make sure that the extension doesn't produce an invalid term by accidentally unifying `?n` with
+-- `0` because of the `hf` assumption
+set_option linter.unusedVariables false in
+example (f : ℕ → ℕ) (hf : 0 ≤ f 0) : 0 ≤ ∑' n, f n := by positivity
 
 /-! ## Big operators -/
 

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -386,7 +386,7 @@ end Integral
 example (f : ℕ → ℝ) : 0 ≤ ∑' n, (f n)^2 := by positivity
 example [LinearOrderedField α] [TopologicalSpace α] [OrderClosedTopology α] (f : ℚ → α) :
     0 ≤ ∑' q, (f q)^2 := by positivity
-example  [Norm α] (f : ℕ → ℝ≥0) (c : ℝ) (hc : 0 < c) : 0 ≤ ∑' n, c * f n := by positivity
+example  (f : ℕ → ℝ≥0) (c : ℝ) (hc : 0 < c) : 0 ≤ ∑' n, c * f n := by positivity
 
 /-! ## Big operators -/
 


### PR DESCRIPTION
Add a positivity extension for `tsum`. This extension only attempts to prove nonnegativity goals, as proving positivity requires wrestling with convergence.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
The implementation is based on the positivity extension for Bochner integrals.

https://github.com/leanprover-community/mathlib4/blob/feff2b7a3b3f7e4351993a12e2d8aa400b7a88a4/Mathlib/MeasureTheory/Integral/Bochner.lean#L1910-L1925

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
