### PR TITLE
[Merged by Bors] - feat(Order/Nucleus): nuclei form a frame

### DIFF
--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -162,12 +162,11 @@ instance : HImp (Nucleus X) where
   himp m n :=
   { toFun x := ⨅ y ≥ x, m y ⇨ n y
     idempotent' i := by
-      refine le_iInf₂ ?_
-      intro j hj
+      refine le_iInf₂ (fun j hj ↦ ?_)
       have h : (m (m j ⇨ n j)) ⇨ (n (m j ⇨ n j)) = m j ⇨ n j := by
         rw [map_himp_apply, himp_himp, ← map_inf, inf_of_le_right (le_trans n.le_apply le_himp)]
       rw [← h]
-      exact iInf₂_le (m j ⇨ n j) (biInf_le (fun i ↦ m i ⇨ n i) hj)
+      exact iInf₂_le (m j ⇨ n j) <| biInf_le (fun i ↦ m i ⇨ n i) hj
     map_inf' x y := by
       simp only [and_assoc, le_antisymm_iff, le_inf_iff, le_iInf_iff]
       refine ⟨fun z hxz ↦ iInf₂_le _ <| inf_le_of_left_le hxz,
@@ -184,8 +183,7 @@ instance : HImp (Nucleus X) where
           gcongr; exacts [hlx (x ⊔ k) le_sup_left, hly (y ⊔ k) le_sup_left]
         _ = n k := by rw [← map_inf, ← sup_inf_right, sup_eq_right.2 hxyk]
     le_apply' := by
-      simp only [le_iInf_iff, le_himp_iff]
-      exact fun _ _ h ↦ inf_le_of_left_le <| h.trans n.le_apply }
+      simpa using fun _ _ h ↦ inf_le_of_left_le <| h.trans n.le_apply }
 
 @[simp] theorem himp_apply (m n : Nucleus X) (x : X) : (m ⇨ n) x = ⨅ y ≥ x, m y ⇨ n y := rfl
 

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -4,10 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chriara Cimino, Christian Krause
 -/
 import Mathlib.Order.Closure
-import Mathlib.Order.CompleteLattice
 import Mathlib.Order.Hom.Lattice
-import Mathlib.Tactic.MinImports
-
 /-!
 # Nucleus
 

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -23,6 +23,8 @@ https://ncatlab.org/nlab/show/nucleus
 
 open Order InfHom
 
+section
+
 variable {X : Type*} [CompleteLattice X]
 
 /-- A nucleus is an inflationary idempotent `inf`-preserving endomorphism of a semilattice.
@@ -45,9 +47,13 @@ class NucleusClass (F X : Type*) [SemilatticeInf X] [FunLike F X X] extends InfH
   /-- A nucleus is inflationary. -/
   le_apply (x : X) (f : F) : x ≤ f x
 
+end
+
 namespace Nucleus
 
-variable {n m : Nucleus X} {x y : X}
+section
+
+variable {X : Type*} [CompleteLattice X] {n m : Nucleus X} {x y : X}
 
 instance : FunLike (Nucleus X) X X where
   coe x := x.toFun
@@ -139,6 +145,9 @@ instance : CompleteLattice (Nucleus X) := completeLatticeOfCompleteSemilatticeIn
 @[simp] theorem inf_aply (m n : Nucleus X) (x : X) : (m ⊓ n) x = m x ⊓ n x := by
   rw [← sInf_pair, sInf_apply, iInf_pair]
 
+end
+section
+
 variable {X : Type*} [Order.Frame X]
 
 instance : HImp (Nucleus X) where
@@ -205,4 +214,5 @@ instance : Order.Frame (Nucleus X) where
    __ := Nucleus.instHeytingAlgebra
    __ := Nucleus.instCompleteLattice
 
+end
 end Nucleus

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -170,39 +170,32 @@ instance : HImp (Nucleus X) where
       simp only [ge_iff_le, le_himp_iff, iInf_inf, iInf_le_iff, le_inf_iff, le_iInf_iff]
       intro b1 h2
       rcases h2 j with ⟨h3, h4⟩
-      exact le_trans (by simp[h4]) (h3 (by exact hj))
-    map_inf' i j := by
-      apply le_antisymm
-      · simp only [ge_iff_le, iInf_inf, le_iInf_iff, le_inf_iff, le_himp_iff, iInf_le_iff]
-        refine fun k ↦ ⟨fun h1 f h2 ↦ ?_, fun k h1 f h2 ↦ ?_⟩
-        all_goals rcases h2 k with ⟨h2_1, h2_2⟩;
-        all_goals refine le_trans (inf_of_le_left h2_2).ge (h2_1 ?_)
-        · exact inf_le_of_left_le h1
-        · exact inf_le_of_right_le h1
-      · simp only [ge_iff_le, iInf_inf, le_iInf_iff, le_himp_iff, iInf_le_iff, le_inf_iff]
-        intro k h2 l h3
-        have h8 : k = (i ⊔ k) ⊓ (j ⊔ k) := by simp [inf_sup_left, inf_sup_right, h2]
-        rw [h8, map_inf, le_inf_iff]
-        rcases h3 (i ⊔ k) with ⟨⟨h4, h5⟩, h7⟩
-        apply And.intro
-        · apply le_trans' (h4 le_sup_left)
-          simp only [le_inf_iff, le_refl, true_and]
-          exact Preorder.le_trans _ _ _ h7 (by gcongr; simp)
-        · apply le_trans' (h5 (j ⊔ k) le_sup_left)
-          simp only [le_inf_iff, le_refl, true_and]
-          exact Preorder.le_trans _ _ _ h7 (by gcongr; simp)
+      exact le_trans (by simp [h4]) (h3 (by exact hj))
+    map_inf' x y := by
+      simp only [and_assoc, le_antisymm_iff, le_inf_iff, le_iInf_iff]
+      refine ⟨fun z hxz ↦ iInf₂_le _ <| inf_le_of_left_le hxz,
+        fun z hyz ↦ iInf₂_le _ <| inf_le_of_right_le hyz, ?_⟩
+      have : Nonempty X := ⟨x⟩
+      simp only [iInf_inf, le_iInf_iff, le_himp_iff, iInf_le_iff, le_inf_iff, forall_and,
+        forall_const, and_imp]
+      intro k hxyk l hlx hly hlk
+      calc
+        l = (l ⊓ m (x ⊔ k)) ⊓ (l ⊓ m (y ⊔ k)) := by
+          rw [← inf_inf_distrib_left, ← map_inf, ← sup_inf_right, sup_eq_right.2 hxyk,
+            inf_eq_left.2 hlk]
+        _ ≤ n (x ⊔ k) ⊓ n (y ⊔ k) := by
+          gcongr; exacts [hlx (x ⊔ k) le_sup_left, hly (y ⊔ k) le_sup_left]
+        _ = n k := by rw [← map_inf, ← sup_inf_right, sup_eq_right.2 hxyk]
     le_apply' := by
-      simp only [ge_iff_le, le_iInf_iff, le_himp_iff]
-      refine fun _ _ h ↦ inf_le_of_left_le (le_trans h n.le_apply)}
+      simp only [le_iInf_iff, le_himp_iff]
+      exact fun _ _ h ↦ inf_le_of_left_le <| h.trans n.le_apply }
 
 @[simp] theorem himp_apply (m n : Nucleus X) (x : X) : (m ⇨ n) x = ⨅ y ≥ x, m y ⇨ n y := rfl
 
 instance : HeytingAlgebra (Nucleus X) where
   le_himp_iff _ n _ := by
-    simp [← coe_le_coe, Pi.le_def]
-    exact ⟨fun h i ↦ h i i le_rfl,
-      fun h1 i j _ ↦ le_trans (inf_le_inf_right (n j) (by gcongr)) (h1 j)⟩
-  compl m := m ⇨ ⊥
+    simpa [← coe_le_coe, Pi.le_def]
+      using ⟨fun h i ↦ h i i le_rfl, fun h i j _ ↦ (h j).trans' <| by gcongr⟩
   himp_bot m := rfl
 
 instance : Order.Frame (Nucleus X) where

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -159,12 +159,12 @@ lemma map_himp_apply (n : Nucleus X) (x y : X) : n (x ⇨ n y) = x ⇨ n y :=
 instance : HImp (Nucleus X) where
   himp m n :=
   { toFun x := ⨅ y ≥ x, m y ⇨ n y
-    idempotent' i := by
-      refine le_iInf₂ (fun j hj ↦ ?_)
-      have h : (m (m j ⇨ n j)) ⇨ (n (m j ⇨ n j)) = m j ⇨ n j := by
-        rw [map_himp_apply, himp_himp, ← map_inf, inf_of_le_right (le_trans n.le_apply le_himp)]
-      rw [← h]
-      exact iInf₂_le (m j ⇨ n j) <| biInf_le (fun i ↦ m i ⇨ n i) hj
+    idempotent' x := le_iInf₂ fun y hy ↦
+      calc
+        ⨅ z ≥ ⨅ w ≥ x, m w ⇨ n w, m z ⇨ n z
+        _ ≤ m (m y ⇨ n y) ⇨ n (m y ⇨ n y) := iInf₂_le _ <| biInf_le _ hy
+        _ = m y ⇨ n y := by
+          rw [map_himp_apply, himp_himp, ← map_inf, inf_of_le_right (le_trans n.le_apply le_himp)]
     map_inf' x y := by
       simp only [and_assoc, le_antisymm_iff, le_inf_iff, le_iInf_iff]
       refine ⟨fun z hxz ↦ iInf₂_le _ <| inf_le_of_left_le hxz,

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -136,6 +136,9 @@ instance : CompleteSemilatticeInf (Nucleus X) where
 
 instance : CompleteLattice (Nucleus X) := completeLatticeOfCompleteSemilatticeInf (Nucleus X)
 
+@[simp] theorem Min_apply (a b : Nucleus X) (x : X) : (a ⊓ b) x = a x ⊓ b x := by
+  rw [← sInf_pair, sInf_apply, iInf_pair]
+
 instance : HImp (Nucleus X) where
   himp a b :=
   { toFun x :=   ⨅ y ≥ x, a y ⇨ b y
@@ -185,5 +188,19 @@ instance : HImp (Nucleus X) where
     le_apply' := by
       simp only [ge_iff_le, le_iInf_iff, le_himp_iff]
       refine fun _ _ h ↦ inf_le_of_left_le (le_trans h b.le_apply)}
+
+@[simp] theorem himp_apply (a b : Nucleus X) (x : X) : (a ⇨ b) x = ⨅ y ≥ x, a y ⇨ b y := rfl
+
+instance : HeytingAlgebra (Nucleus X) where
+  le_himp_iff a b c := by
+    simp [← coe_le_coe, Pi.le_def]
+    exact ⟨fun h i ↦ h i i le_rfl,
+      fun h1 i j _ ↦ le_trans (inf_le_inf_right (b j) (by gcongr)) (h1 j)⟩
+  compl a := a ⇨ ⊥
+  himp_bot a := rfl
+
+instance : Order.Frame (Nucleus X) where
+   __ := Nucleus.instHeytingAlgebra
+   __ := Nucleus.instCompleteLattice
 
 end Nucleus

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -136,31 +136,31 @@ instance : CompleteSemilatticeInf (Nucleus X) where
 
 instance : CompleteLattice (Nucleus X) := completeLatticeOfCompleteSemilatticeInf (Nucleus X)
 
-@[simp] theorem Min_apply (a b : Nucleus X) (x : X) : (a ⊓ b) x = a x ⊓ b x := by
+@[simp] theorem inf_aply (m n : Nucleus X) (x : X) : (m ⊓ n) x = m x ⊓ n x := by
   rw [← sInf_pair, sInf_apply, iInf_pair]
 
 instance : HImp (Nucleus X) where
-  himp a b :=
-  { toFun x :=   ⨅ y ≥ x, a y ⇨ b y
+  himp m n :=
+  { toFun x := ⨅ y ≥ x, m y ⇨ n y
     idempotent' i := by
       apply le_iInf₂
       intro j hj
-      have h : (a (a j ⇨ b j)) ⇨ (b (a j ⇨ b j)) = a j ⇨ b j := by
-        have h_fix : b (a j ⇨ b j) = a j ⇨ b j := by
+      have h : (m (m j ⇨ n j)) ⇨ (n (m j ⇨ n j)) = m j ⇨ n j := by
+        have h_fix : n (m j ⇨ n j) = m j ⇨ n j := by
           refine le_antisymm ?_ le_apply
           rw [le_himp_iff, himp_eq_sSup]
-          have h1 : b (sSup {w | w ⊓ a j ≤ b j}) ⊓ a j ≤
-              b (sSup {w | w ⊓ a j ≤ b j}) ⊓  b (a j) := by
+          have h1 : n (sSup {w | w ⊓ m j ≤ n j}) ⊓ m j ≤
+              n (sSup {w | w ⊓ m j ≤ n j}) ⊓  n (m j) := by
             simp only [le_inf_iff, inf_le_left, true_and]
             exact inf_le_of_right_le le_apply
           apply le_trans h1
-          rw [← map_inf, sSup_inf_eq, ← @idempotent _ _ b j]
+          rw [← map_inf, sSup_inf_eq, ← @idempotent _ _ n j]
           gcongr
           apply iSup₂_le
           simp [idempotent]
-        rw [h_fix, himp_himp, ← map_inf, inf_of_le_right (le_trans b.le_apply le_himp)]
+        rw [h_fix, himp_himp, ← map_inf, inf_of_le_right (le_trans n.le_apply le_himp)]
       rw [← h]
-      refine iInf₂_le (a j ⇨ b j) ?_
+      refine iInf₂_le (m j ⇨ n j) ?_
       simp only [ge_iff_le, le_himp_iff, iInf_inf, iInf_le_iff, le_inf_iff, le_iInf_iff]
       intro b1 h2
       rcases h2 j with ⟨h3, h4⟩
@@ -187,17 +187,17 @@ instance : HImp (Nucleus X) where
           exact Preorder.le_trans _ _ _ h7 (by gcongr; simp)
     le_apply' := by
       simp only [ge_iff_le, le_iInf_iff, le_himp_iff]
-      refine fun _ _ h ↦ inf_le_of_left_le (le_trans h b.le_apply)}
+      refine fun _ _ h ↦ inf_le_of_left_le (le_trans h n.le_apply)}
 
-@[simp] theorem himp_apply (a b : Nucleus X) (x : X) : (a ⇨ b) x = ⨅ y ≥ x, a y ⇨ b y := rfl
+@[simp] theorem himp_apply (m n : Nucleus X) (x : X) : (m ⇨ n) x = ⨅ y ≥ x, m y ⇨ n y := rfl
 
 instance : HeytingAlgebra (Nucleus X) where
-  le_himp_iff a b c := by
+  le_himp_iff _ n _ := by
     simp [← coe_le_coe, Pi.le_def]
     exact ⟨fun h i ↦ h i i le_rfl,
-      fun h1 i j _ ↦ le_trans (inf_le_inf_right (b j) (by gcongr)) (h1 j)⟩
-  compl a := a ⇨ ⊥
-  himp_bot a := rfl
+      fun h1 i j _ ↦ le_trans (inf_le_inf_right (n j) (by gcongr)) (h1 j)⟩
+  compl m := m ⇨ ⊥
+  himp_bot m := rfl
 
 instance : Order.Frame (Nucleus X) where
    __ := Nucleus.instHeytingAlgebra

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -6,6 +6,7 @@ Authors: Chriara Cimino, Christian Krause
 import Mathlib.Order.Closure
 import Mathlib.Order.CompleteLattice
 import Mathlib.Order.Hom.Lattice
+import Mathlib.Tactic.MinImports
 
 /-!
 # Nucleus
@@ -138,24 +139,24 @@ instance : CompleteSemilatticeInf (Nucleus X) where
 
 instance : CompleteLattice (Nucleus X) := completeLatticeOfCompleteSemilatticeInf (Nucleus X)
 
-@[simp] theorem inf_aply (m n : Nucleus X) (x : X) : (m ⊓ n) x = m x ⊓ n x := by
+@[simp] theorem inf_apply (m n : Nucleus X) (x : X) : (m ⊓ n) x = m x ⊓ n x := by
   rw [← sInf_pair, sInf_apply, iInf_pair]
 
 end CompleteLattice
 section Frame
-variable [Order.Frame X]
+variable [Order.Frame X] {n : Nucleus X} {x y : X}
 
-lemma map_himp_apply {n : Nucleus X} {x y : X} : n (x ⇨ n y) = x ⇨ n y := by
-  refine le_antisymm ?_ le_apply
-  rw [le_himp_iff, himp_eq_sSup]
-  have h1 : n (sSup {w | w ⊓ x ≤ n y}) ⊓ x ≤
-      n (sSup {w | w ⊓ x ≤ n y}) ⊓ n x := by
-    simp only [le_inf_iff, inf_le_left, true_and]
-    exact inf_le_of_right_le le_apply
-  apply le_trans h1
-  rw [← map_inf, sSup_inf_eq, ← @idempotent _ _ n y]
-  gcongr
-  simp [idempotent]
+-- TODO: Does this hold as an equality?
+lemma map_himp_le : n (x ⇨ y) ≤ x ⇨ n y := by
+  rw [le_himp_iff]
+  calc
+    n (x ⇨ y) ⊓ x
+    _ ≤ n (x ⇨ y) ⊓ n x := by gcongr; exact n.le_apply
+    _ = n (y ⊓ x) := by rw [← map_inf, himp_inf_self]
+    _ ≤ n y := by gcongr; exact inf_le_left
+
+lemma map_himp_apply (n : Nucleus X) (x y : X) : n (x ⇨ n y) = x ⇨ n y :=
+  le_antisymm (map_himp_le.trans_eq <| by rw [n.idempotent]) n.le_apply
 
 instance : HImp (Nucleus X) where
   himp m n :=

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -5,6 +5,7 @@ Authors: Chriara Cimino, Christian Krause
 -/
 import Mathlib.Order.Closure
 import Mathlib.Order.Hom.Lattice
+
 /-!
 # Nucleus
 

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -136,269 +136,54 @@ instance : CompleteSemilatticeInf (Nucleus X) where
 
 instance : CompleteLattice (Nucleus X) := completeLatticeOfCompleteSemilatticeInf (Nucleus X)
 
-def himp_toFun (x y : Nucleus E) (a : E) :=
-  ⨅ b ≥ a, x b ⇨ y b
-
-/-
-Johnstone:
-(i): map_inf
-(ii): le_apply
-(iii): idempotent
--/
-def himp_idempotent (x y : Nucleus E) (a : E) :
-    himp_toFun x y (himp_toFun x y a) ≤  himp_toFun x y a := by
-  have h_0 : ∀ a, ∀ b ≥ a, himp_toFun x y a ≤ x b ⇨ y b := by
-    simp [himp_toFun]
-    intro a b h
-    rw [iInf_inf]
-    rw [iInf_le_iff]
-    simp only [le_inf_iff, le_iInf_iff, le_himp_iff]
-    intro c h1
-    rcases h1 b with ⟨h1, h2⟩
-    let h1 := h1 h
-    apply le_trans' h1
-    simp only [le_inf_iff, le_refl, true_and]
-    exact h2
-
-  have h : ∀ b ≥ a, (x (x b ⇨ y b)) ⇨ (y (x b ⇨ y b)) = x b ⇨ y b := by
-    intro b h
-    have h_fixpoint : y (x b ⇨ y b) = x b ⇨ y b := by
-      apply le_antisymm
-      .
-        simp
-        rw [himp_eq_sSup]
-        have h : y (sSup {w | w ⊓ x b ≤ y b}) ⊓ x b ≤ y (sSup {w | w ⊓ x b ≤ y b}) ⊓ y (x b) := by
-          simp
-          apply inf_le_of_right_le
-          exact Nucleus.le_apply
-        apply le_trans h
-        rw [← y.map_inf]
-        rw [sSup_inf_eq]
-        conv =>
-          enter [2]
-          rw [← y.idempotent]
-        apply OrderHomClass.mono
-        simp only [Set.mem_setOf_eq, iSup_le_iff]
-        exact fun i i => i
-      . exact Nucleus.le_apply
-
-    rw [h_fixpoint]
-    rw [himp_himp]
-
-    rw [← x.map_inf]
-    have h2 : b ≤ x b ⇨ y b := by
-      apply le_trans y.le_apply
-      simp only [le_himp_iff, inf_le_left]
-    rw [inf_of_le_right h2]
-
-  have h1 : himp_toFun x y a = ⨅ b ≥ a, x b ⇨ y b  := by
-    simp [himp_toFun]
-  conv =>
-    enter [2]
-    rw [h1]
-  conv =>
-    enter [2, 1, b, 1]
-    intro h1
-    rw [← h b h1]
-  exact le_iInf₂ fun i j => h_0 (himp_toFun x y a) (x i ⇨ y i) (h_0 a i j)
-
-
-def himp_le_apply (x y : Nucleus E) (a : E) :
-    a ≤ himp_toFun x y a := by
-  simp [himp_toFun]
-  intro i hi
-  refine inf_le_of_left_le ?_
-  apply le_trans hi y.le_apply
-
-lemma himp_map_inf (x y : Nucleus E) :
-    ∀ (a b : E), himp_toFun x y (a ⊓ b) = himp_toFun x y a ⊓ himp_toFun x y b := by
-  intro a b
-  apply le_antisymm
-  . simp [himp_toFun]
-    apply And.intro
-    . intro i hi
-      rw [iInf_inf]
-      rw [iInf_le_iff]
-      simp only [le_inf_iff, le_iInf_iff, le_himp_iff]
-      intro c h1
-      rcases (h1 i) with ⟨h1, h2⟩
-      let h1 := h1 (by exact inf_le_of_left_le hi)
-      apply le_trans' h1
-      rw [inf_of_le_left]
-      exact h2
-    . intro i hi
-      rw [iInf_inf]
-      rw [iInf_le_iff]
-      simp only [le_inf_iff, le_iInf_iff, le_himp_iff]
-      intro c h1
-      rcases (h1 i) with ⟨h1, h2⟩
-      let h1 := h1 (by exact inf_le_of_right_le hi)
-      apply le_trans' h1
-      rw [inf_of_le_left]
-      exact h2
-
-  . have h : ∀ c ≥ a ⊓ b, c = (a ⊔ c) ⊓ (b ⊔ c) := by
-      intro c h
-      rw [@inf_sup_left]
-      simp only [le_sup_right, inf_of_le_right, right_eq_sup]
-      simp at h
-      rw [inf_sup_right]
-      simp only [sup_le_iff, inf_le_left, and_true]
-      exact h
-    simp only [himp_toFun]
-    conv =>
-      enter [2, 1, c, 1]
-      intro h1
-      rw [h c h1]
-      rw [y.map_inf]
-      rw [himp_inf_distrib]
-      simp
-
-    rw [@le_iInf₂_iff]
-    intro i hi
-    rw [le_inf_iff]
-    apply And.intro
-    . apply inf_le_of_left_le
-      simp only [ge_iff_le, le_inf_iff]
-      . rw [iInf_le_iff]
-        have h : x (a ⊔ i) ⇨ y (a ⊔ i) ≤ (x (a ⊔ i) ⊓ x (b ⊔ i)) ⇨ y (a ⊔ i) := by
-          simp only [le_himp_iff]
-          rw [himp_eq_sSup]
-          rw [sSup_inf_eq]
-          simp only [Set.mem_setOf_eq, iSup_le_iff]
-          intro j h1
-          apply le_trans' h1
-          simp only [le_inf_iff, inf_le_left, true_and]
-          apply inf_le_of_right_le
-          exact inf_le_left
-
-        intro c h1
-        apply le_trans' h
-        simp at h1
-        simp
-        apply h1
-        exact le_sup_left
-    . apply inf_le_of_right_le
-      simp only [ge_iff_le, le_inf_iff]
-      . rw [iInf_le_iff]
-        have h : x (b ⊔ i) ⇨ y (b ⊔ i) ≤ (x (a ⊔ i) ⊓ x (b ⊔ i)) ⇨ y (b ⊔ i) := by
-          simp only [le_himp_iff]
-          rw [himp_eq_sSup]
-          rw [sSup_inf_eq]
-          simp only [Set.mem_setOf_eq, iSup_le_iff]
-          intro j h1
-          apply le_trans' h1
-          simp only [le_inf_iff, inf_le_left, true_and]
-          apply inf_le_of_right_le
-          exact inf_le_right
-
-        intro c h1
-        apply le_trans' h
-        simp at h1
-        simp
-        apply h1
-        exact le_sup_left
-
 instance : HImp (Nucleus X) where
   himp a b :=
   { toFun x :=   ⨅ y ≥ x, a y ⇨ b y
-    idempotent' := sorry
-    map_inf' c d := by
-
-
-
-      /--/
+    idempotent' i := by
+      apply le_iInf₂
+      intro j hj
+      have h : (a (a j ⇨ b j)) ⇨ (b (a j ⇨ b j)) = a j ⇨ b j := by
+        have h_fix : b (a j ⇨ b j) = a j ⇨ b j := by
+          refine le_antisymm ?_ le_apply
+          rw [le_himp_iff, himp_eq_sSup]
+          have h1 : b (sSup {w | w ⊓ a j ≤ b j}) ⊓ a j ≤
+              b (sSup {w | w ⊓ a j ≤ b j}) ⊓  b (a j) := by
+            simp only [le_inf_iff, inf_le_left, true_and]
+            exact inf_le_of_right_le le_apply
+          apply le_trans h1
+          rw [← map_inf, sSup_inf_eq, ← @idempotent _ _ b j]
+          gcongr
+          apply iSup₂_le
+          simp [idempotent]
+        rw [h_fix, himp_himp, ← map_inf, inf_of_le_right (le_trans b.le_apply le_himp)]
+      rw [← h]
+      refine iInf₂_le (a j ⇨ b j) ?_
+      simp only [ge_iff_le, le_himp_iff, iInf_inf, iInf_le_iff, le_inf_iff, le_iInf_iff]
+      intro b1 h2
+      rcases h2 j with ⟨h3, h4⟩
+      exact le_trans (by simp[h4]) (h3 (by exact hj))
+    map_inf' i j := by
       apply le_antisymm
-      . simp [iInf_inf, iInf_le_iff]
-
-
-
-
+      · simp only [ge_iff_le, iInf_inf, le_iInf_iff, le_inf_iff, le_himp_iff, iInf_le_iff]
+        refine fun k ↦ ⟨fun h1 f h2 ↦ ?_, fun k h1 f h2 ↦ ?_⟩
+        all_goals rcases h2 k with ⟨h2_1, h2_2⟩;
+        all_goals refine le_trans (inf_of_le_left h2_2).ge (h2_1 ?_)
+        · exact inf_le_of_left_le h1
+        · exact inf_le_of_right_le h1
+      · simp only [ge_iff_le, iInf_inf, le_iInf_iff, le_himp_iff, iInf_le_iff, le_inf_iff]
+        intro k h2 l h3
+        have h8 : k = (i ⊔ k) ⊓ (j ⊔ k) := by simp [inf_sup_left, inf_sup_right, h2]
+        rw [h8, map_inf, le_inf_iff]
+        rcases h3 (i ⊔ k) with ⟨⟨h4, h5⟩, h7⟩
         apply And.intro
-        . intro i hi
-          rw [iInf_inf]
-          rw [iInf_le_iff]
-          simp only [le_inf_iff, le_iInf_iff, le_himp_iff]
-          intro c h1
-          rcases (h1 i) with ⟨h1, h2⟩
-          let h1 := h1 (by exact inf_le_of_left_le hi)
-          apply le_trans' h1
-          rw [inf_of_le_left]
-          exact h2
-        . intro i hi
-          rw [iInf_inf]
-          rw [iInf_le_iff]
-          simp only [le_inf_iff, le_iInf_iff, le_himp_iff]
-          intro c h1
-          rcases (h1 i) with ⟨h1, h2⟩
-          let h1 := h1 (by exact inf_le_of_right_le hi)
-          apply le_trans' h1
-          rw [inf_of_le_left]
-          exact h2
-
-      . have h : ∀ c ≥ a ⊓ b, c = (a ⊔ c) ⊓ (b ⊔ c) := by
-          intro c h
-          rw [@inf_sup_left]
-          simp only [le_sup_right, inf_of_le_right, right_eq_sup]
-          simp at h
-          rw [inf_sup_right]
-          simp only [sup_le_iff, inf_le_left, and_true]
-          exact h
-        simp only [himp_toFun]
-        conv =>
-          enter [2, 1, c, 1]
-          intro h1
-          rw [h c h1]
-          rw [y.map_inf]
-          rw [himp_inf_distrib]
-          simp
-
-        rw [@le_iInf₂_iff]
-        intro i hi
-        rw [le_inf_iff]
-        apply And.intro
-        . apply inf_le_of_left_le
-          simp only [ge_iff_le, le_inf_iff]
-          . rw [iInf_le_iff]
-            have h : x (a ⊔ i) ⇨ y (a ⊔ i) ≤ (x (a ⊔ i) ⊓ x (b ⊔ i)) ⇨ y (a ⊔ i) := by
-              simp only [le_himp_iff]
-              rw [himp_eq_sSup]
-              rw [sSup_inf_eq]
-              simp only [Set.mem_setOf_eq, iSup_le_iff]
-              intro j h1
-              apply le_trans' h1
-              simp only [le_inf_iff, inf_le_left, true_and]
-              apply inf_le_of_right_le
-              exact inf_le_left
-
-            intro c h1
-            apply le_trans' h
-            simp at h1
-            simp
-            apply h1
-            exact le_sup_left
-        . apply inf_le_of_right_le
-          simp only [ge_iff_le, le_inf_iff]
-          . rw [iInf_le_iff]
-            have h : x (b ⊔ i) ⇨ y (b ⊔ i) ≤ (x (a ⊔ i) ⊓ x (b ⊔ i)) ⇨ y (b ⊔ i) := by
-              simp only [le_himp_iff]
-              rw [himp_eq_sSup]
-              rw [sSup_inf_eq]
-              simp only [Set.mem_setOf_eq, iSup_le_iff]
-              intro j h1
-              apply le_trans' h1
-              simp only [le_inf_iff, inf_le_left, true_and]
-              apply inf_le_of_right_le
-              exact inf_le_right
-
-            intro c h1
-            apply le_trans' h
-            simp at h1
-            simp
-            apply h1
-            exact le_sup_left
-    le_apply' := sorry
-
-  }
+        · apply le_trans' (h4 le_sup_left)
+          simp only [le_inf_iff, le_refl, true_and]
+          exact Preorder.le_trans _ _ _ h7 (by gcongr; simp)
+        · apply le_trans' (h5 (j ⊔ k) le_sup_left)
+          simp only [le_inf_iff, le_refl, true_and]
+          exact Preorder.le_trans _ _ _ h7 (by gcongr; simp)
+    le_apply' := by
+      simp only [ge_iff_le, le_iInf_iff, le_himp_iff]
+      refine fun _ _ h ↦ inf_le_of_left_le (le_trans h b.le_apply)}
 
 end Nucleus

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -145,6 +145,18 @@ end CompleteLattice
 section Frame
 variable [Order.Frame X]
 
+lemma map_himp_apply {n : Nucleus X} {x y : X} : n (x ⇨ n y) = x ⇨ n y := by
+  refine le_antisymm ?_ le_apply
+  rw [le_himp_iff, himp_eq_sSup]
+  have h1 : n (sSup {w | w ⊓ x ≤ n y}) ⊓ x ≤
+      n (sSup {w | w ⊓ x ≤ n y}) ⊓ n x := by
+    simp only [le_inf_iff, inf_le_left, true_and]
+    exact inf_le_of_right_le le_apply
+  apply le_trans h1
+  rw [← map_inf, sSup_inf_eq, ← @idempotent _ _ n y]
+  gcongr
+  simp [idempotent]
+
 instance : HImp (Nucleus X) where
   himp m n :=
   { toFun x := ⨅ y ≥ x, m y ⇨ n y
@@ -152,19 +164,7 @@ instance : HImp (Nucleus X) where
       apply le_iInf₂
       intro j hj
       have h : (m (m j ⇨ n j)) ⇨ (n (m j ⇨ n j)) = m j ⇨ n j := by
-        have h_fix : n (m j ⇨ n j) = m j ⇨ n j := by
-          refine le_antisymm ?_ le_apply
-          rw [le_himp_iff, himp_eq_sSup]
-          have h1 : n (sSup {w | w ⊓ m j ≤ n j}) ⊓ m j ≤
-              n (sSup {w | w ⊓ m j ≤ n j}) ⊓  n (m j) := by
-            simp only [le_inf_iff, inf_le_left, true_and]
-            exact inf_le_of_right_le le_apply
-          apply le_trans h1
-          rw [← map_inf, sSup_inf_eq, ← @idempotent _ _ n j]
-          gcongr
-          apply iSup₂_le
-          simp [idempotent]
-        rw [h_fix, himp_himp, ← map_inf, inf_of_le_right (le_trans n.le_apply le_himp)]
+        rw [map_himp_apply, himp_himp, ← map_inf, inf_of_le_right (le_trans n.le_apply le_himp)]
       rw [← h]
       refine iInf₂_le (m j ⇨ n j) ?_
       simp only [ge_iff_le, le_himp_iff, iInf_inf, iInf_le_iff, le_inf_iff, le_iInf_iff]

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -141,7 +141,7 @@ instance : CompleteLattice (Nucleus X) := completeLatticeOfCompleteSemilatticeIn
 @[simp] theorem inf_aply (m n : Nucleus X) (x : X) : (m ⊓ n) x = m x ⊓ n x := by
   rw [← sInf_pair, sInf_apply, iInf_pair]
 
-end
+end CompleteLattice
 section Frame
 variable [Order.Frame X]
 
@@ -209,5 +209,5 @@ instance : Order.Frame (Nucleus X) where
    __ := Nucleus.instHeytingAlgebra
    __ := Nucleus.instCompleteLattice
 
-end
+end Frame
 end Nucleus

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -23,7 +23,7 @@ https://ncatlab.org/nlab/show/nucleus
 
 open Order InfHom
 
-variable {X : Type*} [Order.Frame X]
+variable {X : Type*} [CompleteLattice X]
 
 /-- A nucleus is an inflationary idempotent `inf`-preserving endomorphism of a semilattice.
 In a frame, nuclei correspond to sublocales. -/ -- TODO: Formalise that claim
@@ -138,6 +138,8 @@ instance : CompleteLattice (Nucleus X) := completeLatticeOfCompleteSemilatticeIn
 
 @[simp] theorem inf_aply (m n : Nucleus X) (x : X) : (m ⊓ n) x = m x ⊓ n x := by
   rw [← sInf_pair, sInf_apply, iInf_pair]
+
+variable {X : Type*} [Order.Frame X]
 
 instance : HImp (Nucleus X) where
   himp m n :=

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -162,16 +162,12 @@ instance : HImp (Nucleus X) where
   himp m n :=
   { toFun x := ⨅ y ≥ x, m y ⇨ n y
     idempotent' i := by
-      apply le_iInf₂
+      refine le_iInf₂ ?_
       intro j hj
       have h : (m (m j ⇨ n j)) ⇨ (n (m j ⇨ n j)) = m j ⇨ n j := by
         rw [map_himp_apply, himp_himp, ← map_inf, inf_of_le_right (le_trans n.le_apply le_himp)]
       rw [← h]
-      refine iInf₂_le (m j ⇨ n j) ?_
-      simp only [ge_iff_le, le_himp_iff, iInf_inf, iInf_le_iff, le_inf_iff, le_iInf_iff]
-      intro b1 h2
-      rcases h2 j with ⟨h3, h4⟩
-      exact le_trans (by simp [h4]) (h3 (by exact hj))
+      exact iInf₂_le (m j ⇨ n j) (biInf_le (fun i ↦ m i ⇨ n i) hj)
     map_inf' x y := by
       simp only [and_assoc, le_antisymm_iff, le_inf_iff, le_iInf_iff]
       refine ⟨fun z hxz ↦ iInf₂_le _ <| inf_le_of_left_le hxz,

--- a/Mathlib/Order/Nucleus.lean
+++ b/Mathlib/Order/Nucleus.lean
@@ -23,9 +23,7 @@ https://ncatlab.org/nlab/show/nucleus
 
 open Order InfHom
 
-section
-
-variable {X : Type*} [CompleteLattice X]
+variable {X : Type*}
 
 /-- A nucleus is an inflationary idempotent `inf`-preserving endomorphism of a semilattice.
 In a frame, nuclei correspond to sublocales. -/ -- TODO: Formalise that claim
@@ -47,13 +45,11 @@ class NucleusClass (F X : Type*) [SemilatticeInf X] [FunLike F X X] extends InfH
   /-- A nucleus is inflationary. -/
   le_apply (x : X) (f : F) : x ≤ f x
 
-end
-
 namespace Nucleus
 
-section
+section CompleteLattice
 
-variable {X : Type*} [CompleteLattice X] {n m : Nucleus X} {x y : X}
+variable [CompleteLattice X] {n m : Nucleus X} {x y : X}
 
 instance : FunLike (Nucleus X) X X where
   coe x := x.toFun
@@ -146,9 +142,8 @@ instance : CompleteLattice (Nucleus X) := completeLatticeOfCompleteSemilatticeIn
   rw [← sInf_pair, sInf_apply, iInf_pair]
 
 end
-section
-
-variable {X : Type*} [Order.Frame X]
+section Frame
+variable [Order.Frame X]
 
 instance : HImp (Nucleus X) where
   himp m n :=


### PR DESCRIPTION
The nuclei form a heyting algebra and therefore a frame.
 
---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
