### PR TITLE
[Merged by Bors] - chore(RingTheory/Algebraic): remove unnecessary injectivity assumptions

### DIFF
--- a/Mathlib/FieldTheory/AlgebraicClosure.lean
+++ b/Mathlib/FieldTheory/AlgebraicClosure.lean
@@ -113,7 +113,7 @@ end algebraicClosure
 
 protected theorem Transcendental.algebraicClosure {a : E} (ha : Transcendental F a) :
     Transcendental (algebraicClosure F E) a :=
-  ha.extendScalars Subtype.val_injective
+  ha.extendScalars _
 
 variable (F E K)
 

--- a/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
@@ -194,7 +194,7 @@ instance {p : ℕ} [CharP k p] : CharP (AlgebraicClosure k) p :=
 
 instance {L : Type*} [Field k] [Field L] [Algebra k L] [Algebra.IsAlgebraic k L] :
     IsAlgClosure k (AlgebraicClosure L) where
-  isAlgebraic := .trans (L := L)
+  isAlgebraic := .trans k L _
   isAlgClosed := inferInstance
 
 end AlgebraicClosure

--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -363,8 +363,8 @@ variable [Algebra K J] [Algebra J L] [IsAlgClosure J L] [Algebra K L] [IsScalarT
 
 /-- If `J` is an algebraic extension of `K` and `L` is an algebraic closure of `J`, then it is
   also an algebraic closure of `K`. -/
-theorem ofAlgebraic [hKJ : Algebra.IsAlgebraic K J] : IsAlgClosure K L :=
-  ⟨IsAlgClosure.isAlgClosed J, hKJ.trans⟩
+theorem ofAlgebraic [Algebra.IsAlgebraic K J] : IsAlgClosure K L :=
+  ⟨IsAlgClosure.isAlgClosed J, .trans K J L⟩
 
 /-- A (random) isomorphism between an algebraic closure of `R` and an algebraic closure of
   an algebraic extension of `R` -/
@@ -378,8 +378,8 @@ noncomputable def equivOfAlgebraic' [Nontrivial S] [NoZeroSMulDivisors R S]
 
 /-- A (random) isomorphism between an algebraic closure of `K` and an algebraic closure
   of an algebraic extension of `K` -/
-noncomputable def equivOfAlgebraic [hKJ : Algebra.IsAlgebraic K J] : L ≃ₐ[K] M :=
-  have : Algebra.IsAlgebraic K L := hKJ.trans
+noncomputable def equivOfAlgebraic [Algebra.IsAlgebraic K J] : L ≃ₐ[K] M :=
+  have := Algebra.IsAlgebraic.trans K J L
   equivOfAlgebraic' K J _ _
 
 end EquivOfAlgebraic

--- a/Mathlib/FieldTheory/PurelyInseparable/Basic.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/Basic.lean
@@ -522,7 +522,7 @@ variable {F E} in
 then `E` is also separably closed. -/
 theorem Algebra.IsAlgebraic.isSepClosed [Algebra.IsAlgebraic F E]
     [IsSepClosed F] : IsSepClosed E :=
-  have : Algebra.IsAlgebraic F (AlgebraicClosure E) := Algebra.IsAlgebraic.trans (L := E)
+  have : Algebra.IsAlgebraic F (AlgebraicClosure E) := .trans F E _
   (isSepClosed_iff_isPurelyInseparable_algebraicClosure E _).mpr
     (IsPurelyInseparable.tower_top F E <| AlgebraicClosure E)
 
@@ -551,7 +551,7 @@ theorem finSepDegree_mul_finInsepDegree : finSepDegree F E * finInsepDegree F E 
   rw [finInsepDegree, finrank_of_infinite_dimensional (K := F) (V := E) fun _ ↦
       halg (Algebra.IsAlgebraic.of_finite F E),
     finrank_of_infinite_dimensional (K := separableClosure F E) (V := E) fun _ ↦
-      halg ((separableClosure.isAlgebraic F E).trans),
+      halg (.trans _ (separableClosure F E) _),
     mul_zero]
 
 end Field
@@ -573,7 +573,7 @@ lemma adjoin_eq_of_isAlgebraic_of_isSeparable [Algebra.IsAlgebraic F E]
     let _ : Algebra S L := i.toAlgebra
     let _ : SMul S L := Algebra.toSMul
     have : IsScalarTower S L K := IsScalarTower.of_algebraMap_eq (congrFun rfl)
-    have : Algebra.IsAlgebraic F K := Algebra.IsAlgebraic.trans (L := E)
+    have := Algebra.IsAlgebraic.trans F E K
     have : IsPurelyInseparable S K := separableClosure.isPurelyInseparable F K
     have := IsPurelyInseparable.tower_top S L K
     obtain ⟨y, rfl⟩ := IsPurelyInseparable.surjective_algebraMap_of_isSeparable L K x

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -831,3 +831,11 @@ theorem Irreducible.exists_dvd_monic_irreducible_of_isIntegral {K L : Type*}
   have h2 := isIntegral_trans (R := K) _ (AdjoinRoot.isIntegral_root h)
   have h3 := (AdjoinRoot.minpoly_root h) ▸ minpoly.dvd_map_of_isScalarTower K L (AdjoinRoot.root f)
   exact ⟨_, minpoly.monic h2, minpoly.irreducible h2, dvd_of_mul_right_dvd h3⟩
+
+variable (R) in
+theorem Polynomial.exists_dvd_map_of_isAlgebraic [CommRing R] [CommRing S] [NoZeroDivisors S]
+    [Algebra R S] [Algebra.IsAlgebraic R S] (f : S[X]) (hf : f ≠ 0) :
+    ∃ g : R[X], g ≠ 0 ∧ f ∣ g.map (algebraMap R S) :=
+  have ⟨g, ne, eq⟩ := (id ⟨f, hf, by simp⟩ : IsAlgebraic S (AdjoinRoot.root f)).restrictScalars R
+  ⟨g, ne, by rwa [aeval_def, IsScalarTower.algebraMap_eq R S, ← eval₂_map, ← aeval_def,
+    AdjoinRoot.aeval_eq, AdjoinRoot.mk_eq_zero] at eq⟩

--- a/Mathlib/RingTheory/Algebraic/Basic.lean
+++ b/Mathlib/RingTheory/Algebraic/Basic.lean
@@ -560,6 +560,15 @@ theorem IsAlgebraic.exists_nonzero_dvd
   rw [map_sub, hq, zero_sub, dvd_neg, aeval_X, aeval_C] at key
   exact ⟨q.coeff 0, hq0, key⟩
 
+open Function (Injective) in
+theorem Algebra.IsAlgebraic.injective_tower_top (S) {A} [CommRing S] [NoZeroDivisors S]
+    [Algebra R S] [alg : Algebra.IsAlgebraic R S] [Ring A] [Algebra R A] [Algebra S A]
+    [IsScalarTower R S A] (inj : Injective (algebraMap R A)) : Injective (algebraMap S A) := by
+  refine (injective_iff_map_eq_zero _).mpr fun s eq ↦ of_not_not fun ne ↦ ?_
+  have ⟨r, ne, dvd⟩ := (alg.1 s).exists_nonzero_dvd (mem_nonZeroDivisors_of_ne_zero ne)
+  refine ne (inj <| map_zero (algebraMap R A) ▸ zero_dvd_iff.mp ?_)
+  simp_rw [← eq, IsScalarTower.algebraMap_apply R S A, map_dvd (algebraMap S A) dvd]
+
 /-- A fraction `(a : S) / (b : S)` can be reduced to `(c : S) / (d : R)`,
 if `b` is algebraic over `R`. -/
 theorem IsAlgebraic.exists_smul_eq_mul

--- a/Mathlib/RingTheory/Algebraic/Basic.lean
+++ b/Mathlib/RingTheory/Algebraic/Basic.lean
@@ -560,14 +560,25 @@ theorem IsAlgebraic.exists_nonzero_dvd
   rw [map_sub, hq, zero_sub, dvd_neg, aeval_X, aeval_C] at key
   exact ⟨q.coeff 0, hq0, key⟩
 
+namespace Algebra.IsAlgebraic
+
+variable (S : Type*) {A : Type*} [CommRing S] [NoZeroDivisors S] [Algebra R S]
+  [alg : Algebra.IsAlgebraic R S] [Ring A] [Algebra R A] [Algebra S A] [IsScalarTower R S A]
+
 open Function (Injective) in
-theorem Algebra.IsAlgebraic.injective_tower_top (S) {A} [CommRing S] [NoZeroDivisors S]
-    [Algebra R S] [alg : Algebra.IsAlgebraic R S] [Ring A] [Algebra R A] [Algebra S A]
-    [IsScalarTower R S A] (inj : Injective (algebraMap R A)) : Injective (algebraMap S A) := by
+theorem injective_tower_top (inj : Injective (algebraMap R A)) : Injective (algebraMap S A) := by
   refine (injective_iff_map_eq_zero _).mpr fun s eq ↦ of_not_not fun ne ↦ ?_
   have ⟨r, ne, dvd⟩ := (alg.1 s).exists_nonzero_dvd (mem_nonZeroDivisors_of_ne_zero ne)
   refine ne (inj <| map_zero (algebraMap R A) ▸ zero_dvd_iff.mp ?_)
   simp_rw [← eq, IsScalarTower.algebraMap_apply R S A, map_dvd (algebraMap S A) dvd]
+
+variable (R A)
+
+theorem faithfulSMul_tower_top [FaithfulSMul R A] : FaithfulSMul S A := by
+  rw [faithfulSMul_iff_algebraMap_injective] at *
+  exact injective_tower_top S ‹_›
+
+end Algebra.IsAlgebraic
 
 /-- A fraction `(a : S) / (b : S)` can be reduced to `(c : S) / (d : R)`,
 if `b` is algebraic over `R`. -/

--- a/Mathlib/RingTheory/Algebraic/Integral.lean
+++ b/Mathlib/RingTheory/Algebraic/Integral.lean
@@ -317,7 +317,7 @@ end IsAlgebraic
 
 namespace Algebra
 
-variable (R) [NoZeroDivisors S]
+variable (R S A) [NoZeroDivisors S]
 
 /-- Transitivity of algebraicity for algebras over domains. -/
 theorem IsAlgebraic.trans' [Algebra.IsAlgebraic R S] [alg : Algebra.IsAlgebraic S A] :
@@ -385,7 +385,7 @@ namespace Transcendental
 
 section
 
-variable {a : A} (ha : Transcendental R a)
+variable (S) {a : A} (ha : Transcendental R a)
 include ha
 
 lemma extendScalars_of_isIntegral [NoZeroDivisors S] [Algebra.IsIntegral R S] :
@@ -405,9 +405,9 @@ variable {a : S} (ha : Transcendental R a)
 include ha
 
 protected lemma integralClosure [NoZeroDivisors S] : Transcendental (integralClosure R S) a :=
-  ha.extendScalars_of_isIntegral
+  ha.extendScalars_of_isIntegral _
 
 lemma subalgebraAlgebraicClosure [IsDomain R] [NoZeroDivisors S] :
-    Transcendental (Subalgebra.algebraicClosure R S) a := ha.extendScalars
+    Transcendental (Subalgebra.algebraicClosure R S) a := ha.extendScalars _
 
 end Transcendental

--- a/Mathlib/RingTheory/Algebraic/Integral.lean
+++ b/Mathlib/RingTheory/Algebraic/Integral.lean
@@ -85,21 +85,21 @@ end Field
 
 section
 
-variable (K L : Type*) {R S A : Type*}
+variable (K L R : Type*) {A : Type*}
 
 section Ring
 
-variable [CommRing K] [Nontrivial K] [Ring A] [Algebra K A]
+variable [CommRing R] [Nontrivial R] [Ring A] [Algebra R A]
 
-theorem IsAlgebraic.of_finite (e : A) [Module.Finite K A] : IsAlgebraic K e :=
-  (IsIntegral.of_finite K e).isAlgebraic
+theorem IsAlgebraic.of_finite (e : A) [Module.Finite R A] : IsAlgebraic R e :=
+  (IsIntegral.of_finite R e).isAlgebraic
 
 variable (A)
 
 /-- A field extension is algebraic if it is finite. -/
 @[stacks 09GG "first part"]
-instance Algebra.IsAlgebraic.of_finite [Module.Finite K A] : Algebra.IsAlgebraic K A :=
-  (IsIntegral.of_finite K A).isAlgebraic
+instance Algebra.IsAlgebraic.of_finite [Module.Finite R A] : Algebra.IsAlgebraic R A :=
+  (IsIntegral.of_finite R A).isAlgebraic
 
 end Ring
 

--- a/Mathlib/RingTheory/Algebraic/Integral.lean
+++ b/Mathlib/RingTheory/Algebraic/Integral.lean
@@ -23,9 +23,8 @@ is algebraic and that every algebraic element over a field is integral.
 * `IsAlgebraic.iff_exists_smul_integral`: If `R` is reduced and `S` is an `R`-algebra with
   injective `algebraMap`, then an element of `S` is algebraic over `R` iff some `R`-multiple
   is integral over `R`.
-* `Algebra.IsAlgebraic.trans'`: If `A/S/R` is a tower of algebras and both `A/S` and `S/R` are
-  algebraic, then `A/R` is also algebraic, provided that `S` has no zero divisors and
-  `algebraMap S A` is injective (so `S` can be regarded as an `R`-subalgebra of `A`).
+* `Algebra.IsAlgebraic.trans`: If `A/S/R` is a tower of algebras and both `A/S` and `S/R` are
+  algebraic, then `A/R` is also algebraic, provided that `S` has no zero divisors.
 * `Subalgebra.algebraicClosure`: If `R` is a domain and `S` is an arbitrary `R`-algebra,
   then the elements of `S` that are algebraic over `R` form a subalgebra.
 * `Transcendental.extendScalars`: an element of an `R`-algebra that is transcendental over `R`
@@ -90,40 +89,19 @@ variable (K L : Type*) {R S A : Type*}
 
 section Ring
 
-section Field
+variable [CommRing K] [Nontrivial K] [Ring A] [Algebra K A]
 
-variable [Field K] [Field L] [Ring A]
-variable [Algebra K L] [Algebra L A] [Algebra K A] [IsScalarTower K L A]
-
-theorem IsAlgebraic.of_finite (e : A) [FiniteDimensional K A] : IsAlgebraic K e :=
+theorem IsAlgebraic.of_finite (e : A) [Module.Finite K A] : IsAlgebraic K e :=
   (IsIntegral.of_finite K e).isAlgebraic
 
 variable (A)
 
 /-- A field extension is algebraic if it is finite. -/
 @[stacks 09GG "first part"]
-instance Algebra.IsAlgebraic.of_finite [FiniteDimensional K A] : Algebra.IsAlgebraic K A :=
+instance Algebra.IsAlgebraic.of_finite [Module.Finite K A] : Algebra.IsAlgebraic K A :=
   (IsIntegral.of_finite K A).isAlgebraic
 
-end Field
-
 end Ring
-
-section CommRing
-
-variable {K L} [Field K] [Field L] [Ring A]
-variable [Algebra K L] [Algebra L A] [Algebra K A] [IsScalarTower K L A]
-
-/-- If L is an algebraic field extension of K and A is an algebraic algebra over L,
-then A is algebraic over K. -/
-@[stacks 09GJ]
-protected theorem Algebra.IsAlgebraic.trans
-    [L_alg : Algebra.IsAlgebraic K L] [A_alg : Algebra.IsAlgebraic L A] :
-    Algebra.IsAlgebraic K A := by
-  rw [Algebra.isAlgebraic_iff_isIntegral] at L_alg A_alg ⊢
-  exact Algebra.IsIntegral.trans L
-
-end CommRing
 
 section Field
 
@@ -320,9 +298,11 @@ namespace Algebra
 variable (R S A) [NoZeroDivisors S]
 
 /-- Transitivity of algebraicity for algebras over domains. -/
-theorem IsAlgebraic.trans' [Algebra.IsAlgebraic R S] [alg : Algebra.IsAlgebraic S A] :
+@[stacks 09GJ] theorem IsAlgebraic.trans [Algebra.IsAlgebraic R S] [alg : Algebra.IsAlgebraic S A] :
     Algebra.IsAlgebraic R A :=
   ⟨fun _ ↦ (alg.1 _).restrictScalars _⟩
+
+@[deprecated (since := "2025-02-08")] alias IsAlgebraic.trans' := IsAlgebraic.trans
 
 theorem IsIntegral.trans_isAlgebraic [Algebra.IsIntegral R S] [alg : Algebra.IsAlgebraic S A] :
     Algebra.IsAlgebraic R A :=

--- a/Mathlib/RingTheory/AlgebraicIndependent/AlgebraicClosure.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/AlgebraicClosure.lean
@@ -24,17 +24,15 @@ open Function Algebra
 
 namespace AlgebraicIndependent
 
-variable {ι R S A : Type*} {x : ι → A}
+variable {ι R S A : Type*} {x : ι → A} (S)
 variable [CommRing R] [CommRing S] [CommRing A]
 variable [Algebra R S] [Algebra R A] [Algebra S A] [IsScalarTower R S A]
 variable [NoZeroDivisors S] (hx : AlgebraicIndependent R x)
 include hx
 
-theorem extendScalars [alg : Algebra.IsAlgebraic R S]
-    (inj : Injective (algebraMap S A)) : AlgebraicIndependent S x := by
-  nontriviality S
-  have := inj.nontrivial
-  refine algebraicIndependent_of_finite_type' inj fun t fin ind i hi ↦ ?_
+theorem extendScalars [alg : Algebra.IsAlgebraic R S] : AlgebraicIndependent S x := by
+  refine algebraicIndependent_of_finite_type'
+    (Algebra.IsAlgebraic.injective_tower_top S hx.algebraMap_injective) fun t fin ind i hi ↦ ?_
   let Rt := adjoin R (x '' t)
   let St := adjoin S (x '' t)
   let _ : Algebra Rt St :=
@@ -47,44 +45,34 @@ theorem extendScalars [alg : Algebra.IsAlgebraic R S]
   have : Algebra.IsAlgebraic Rt St := ⟨fun ⟨y, hy⟩ ↦ by
     rw [← isAlgebraic_algHom_iff (IsScalarTower.toAlgHom Rt St A) Subtype.val_injective]
     show IsAlgebraic Rt y
+    have := Algebra.IsAlgebraic.nontrivial R S
+    have := hx.algebraMap_injective.nontrivial
     exact adjoin_induction (fun _ h ↦ isAlgebraic_algebraMap (⟨_, subset_adjoin h⟩ : Rt))
       (fun z ↦ ((alg.1 z).algHom (IsScalarTower.toAlgHom R S A)).extendScalars fun _ _ eq ↦ by
         exact hx.algebraMap_injective congr($eq.1)) (fun _ _ _ _ ↦ .add) (fun _ _ _ _ ↦ .mul) hy⟩
   show Transcendental St (x i)
   exact (hx.transcendental_adjoin hi).extendScalars _
 
-theorem extendScalars_of_isSimpleRing [Algebra.IsAlgebraic R S] [IsSimpleRing S] :
-    AlgebraicIndependent S x :=
-  hx.extendScalars <|
-    have := Module.nontrivial R S
-    have := hx.algebraMap_injective.nontrivial
-    RingHom.injective _
-
-theorem extendScalars_of_isIntegral [Algebra.IsIntegral R S]
-    (inj : Injective (algebraMap S A)) : AlgebraicIndependent S x := by
+theorem extendScalars_of_isIntegral [Algebra.IsIntegral R S] : AlgebraicIndependent S x := by
   nontriviality S
   have := Module.nontrivial R S
-  exact hx.extendScalars inj
+  exact hx.extendScalars S
 
-protected theorem subalgebra (S : Subalgebra R A) [NoZeroDivisors A] [Algebra.IsAlgebraic R S] :
-    AlgebraicIndependent S x :=
-  hx.extendScalars Subtype.val_injective
-
-theorem subalgebra_of_isIntegral (S : Subalgebra R A) [NoZeroDivisors A] [Algebra.IsIntegral R S] :
-    AlgebraicIndependent S x :=
-  hx.extendScalars_of_isIntegral Subtype.val_injective
+@[deprecated (since := "2025-02-08")] alias extendScalars_of_isSimpleRing := extendScalars
+@[deprecated (since := "2025-02-08")] protected alias subalgebra := extendScalars
+@[deprecated (since := "2025-02-08")] alias subalgebra_of_isIntegral := extendScalars_of_isIntegral
 
 theorem subalgebraAlgebraicClosure [IsDomain R] [NoZeroDivisors A] :
     AlgebraicIndependent (Subalgebra.algebraicClosure R A) x :=
-  hx.subalgebra _
+  hx.extendScalars _
 
 protected theorem integralClosure [NoZeroDivisors A] :
     AlgebraicIndependent (integralClosure R A) x :=
-  hx.subalgebra_of_isIntegral _
+  hx.extendScalars_of_isIntegral _
 
 omit hx in
 protected theorem algebraicClosure {F E : Type*} [Field F] [Field E] [Algebra F E] {x : ι → E}
     (hx : AlgebraicIndependent F x) : AlgebraicIndependent (algebraicClosure F E) x :=
-  hx.extendScalars_of_isSimpleRing
+  hx.extendScalars _
 
 end AlgebraicIndependent

--- a/Mathlib/RingTheory/AlgebraicIndependent/AlgebraicClosure.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/AlgebraicClosure.lean
@@ -51,7 +51,7 @@ theorem extendScalars [alg : Algebra.IsAlgebraic R S]
       (fun z ↦ ((alg.1 z).algHom (IsScalarTower.toAlgHom R S A)).extendScalars fun _ _ eq ↦ by
         exact hx.algebraMap_injective congr($eq.1)) (fun _ _ _ _ ↦ .add) (fun _ _ _ _ ↦ .mul) hy⟩
   show Transcendental St (x i)
-  exact (hx.transcendental_adjoin hi).extendScalars Subtype.val_injective
+  exact (hx.transcendental_adjoin hi).extendScalars _
 
 theorem extendScalars_of_isSimpleRing [Algebra.IsAlgebraic R S] [IsSimpleRing S] :
     AlgebraicIndependent S x :=

--- a/Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean
+++ b/Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean
@@ -114,9 +114,8 @@ to `(y : R) • x ∈ integralClosure R L`. -/
 theorem exists_integral_multiples (s : Finset L) :
     ∃ y ≠ (0 : A), ∀ x ∈ s, IsIntegral A (y • x) :=
   have := IsLocalization.isAlgebraic K (nonZeroDivisors A)
-  have := Algebra.IsAlgebraic.trans' A (algebraMap K L).injective
-  Algebra.IsAlgebraic.exists_integral_multiples (IsScalarTower.algebraMap_eq A K L ▸
-    (algebraMap K L).injective.comp (IsFractionRing.injective _ _)) _
+  have := Algebra.IsAlgebraic.trans' A K L
+  Algebra.IsAlgebraic.exists_integral_multiples ..
 
 variable (L)
 

--- a/Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean
+++ b/Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean
@@ -114,7 +114,7 @@ to `(y : R) • x ∈ integralClosure R L`. -/
 theorem exists_integral_multiples (s : Finset L) :
     ∃ y ≠ (0 : A), ∀ x ∈ s, IsIntegral A (y • x) :=
   have := IsLocalization.isAlgebraic K (nonZeroDivisors A)
-  have := Algebra.IsAlgebraic.trans' A K L
+  have := Algebra.IsAlgebraic.trans A K L
   Algebra.IsAlgebraic.exists_integral_multiples ..
 
 variable (L)

--- a/Mathlib/RingTheory/Localization/Integral.lean
+++ b/Mathlib/RingTheory/Localization/Integral.lean
@@ -301,7 +301,6 @@ theorem isFractionRing_of_algebraic [Algebra.IsAlgebraic A L]
             ((injective_iff_map_eq_zero (algebraMap C L)).mp (algebraMap_injective C A L) _ h))
     surj' := fun z =>
       let ⟨x, hx, int⟩ := (Algebra.IsAlgebraic.isAlgebraic z).exists_integral_multiple
-        ((injective_iff_map_eq_zero _).mpr inj)
       ⟨⟨mk' C _ int, algebraMap _ _ x, mem_nonZeroDivisors_of_ne_zero fun h ↦
         hx (inj _ <| by rw [IsScalarTower.algebraMap_apply A C L, h, RingHom.map_zero])⟩, by
         rw [algebraMap_mk', ← IsScalarTower.algebraMap_apply A C L, Algebra.smul_def, mul_comm]⟩

--- a/Mathlib/RingTheory/PolynomialAlgebra.lean
+++ b/Mathlib/RingTheory/PolynomialAlgebra.lean
@@ -320,15 +320,19 @@ lemma evalRingHom_mapMatrix_comp_compRingEquiv {m} [Fintype m] [DecidableEq m] :
       (compRingEquiv m n R).toRingHom.comp (evalRingHom 0).mapMatrix.mapMatrix := by
   ext; simp
 
-variable [Algebra R S]
+variable [Algebra R A]
 
-/-- If `S` is an `R`-algebra, then `S[X]` is an `R[X]` algebra.
+/-- If `A` is an `R`-algebra, then `A[X]` is an `R[X]` algebra.
 This gives a diamond for `Algebra R[X] R[X][X]`, so this is not a global instance. -/
-@[reducible] def Polynomial.algebra : Algebra R[X] S[X] := (mapRingHom (algebraMap R S)).toAlgebra
+@[reducible] def Polynomial.algebra : Algebra R[X] A[X] :=
+  (mapRingHom (algebraMap R A)).toAlgebra' fun _ _ ↦ by
+    ext; rw [coeff_mul, ← Finset.Nat.sum_antidiagonal_swap, coeff_mul]; simp [Algebra.commutes]
 
 attribute [local instance] Polynomial.algebra
 
-instance : IsScalarTower R R[X] S[X] := .of_algebraMap_eq' (mapRingHom_comp_C _).symm
+instance : IsScalarTower R R[X] A[X] := .of_algebraMap_eq' (mapRingHom_comp_C _).symm
+
+variable [Algebra R S]
 
 instance : Algebra.IsPushout R S R[X] S[X] := by
   constructor

--- a/Mathlib/RingTheory/PolynomialAlgebra.lean
+++ b/Mathlib/RingTheory/PolynomialAlgebra.lean
@@ -320,8 +320,6 @@ lemma evalRingHom_mapMatrix_comp_compRingEquiv {m} [Fintype m] [DecidableEq m] :
       (compRingEquiv m n R).toRingHom.comp (evalRingHom 0).mapMatrix.mapMatrix := by
   ext; simp
 
-variable [Algebra R A]
-
 /-- If `A` is an `R`-algebra, then `A[X]` is an `R[X]` algebra.
 This gives a diamond for `Algebra R[X] R[X][X]`, so this is not a global instance. -/
 @[reducible] def Polynomial.algebra : Algebra R[X] A[X] :=

--- a/Mathlib/RingTheory/PolynomialAlgebra.lean
+++ b/Mathlib/RingTheory/PolynomialAlgebra.lean
@@ -13,7 +13,7 @@ import Mathlib.RingTheory.IsTensorProduct
 /-!
 # Algebra isomorphism between matrices of polynomials and polynomials of matrices
 
-Given `[CommRing R] [Ring A] [Algebra R A]`
+Given `[CommSemiring R] [Semiring A] [Algebra R A]`
 we show `A[X] ≃ₐ[R] (A ⊗[R] R[X])`.
 Combining this with the isomorphism `Matrix n n A ≃ₐ[R] (A ⊗[R] Matrix n n R)` proved earlier
 in `RingTheory.MatrixAlgebra`, we obtain the algebra isomorphism
@@ -320,20 +320,22 @@ lemma evalRingHom_mapMatrix_comp_compRingEquiv {m} [Fintype m] [DecidableEq m] :
       (compRingEquiv m n R).toRingHom.comp (evalRingHom 0).mapMatrix.mapMatrix := by
   ext; simp
 
+variable [Algebra R S]
+
 /-- If `S` is an `R`-algebra, then `S[X]` is an `R[X]` algebra.
 This gives a diamond for `Algebra R[X] R[X][X]`, so this is not a global instance. -/
-@[reducible] def Polynomial.algebra [Algebra R S] :
-    Algebra R[X] S[X] := (mapRingHom (algebraMap R S)).toAlgebra
+@[reducible] def Polynomial.algebra : Algebra R[X] S[X] := (mapRingHom (algebraMap R S)).toAlgebra
 
 attribute [local instance] Polynomial.algebra
 
-instance [Algebra R S] : IsScalarTower R R[X] S[X] := .of_algebraMap_eq' (mapRingHom_comp_C _).symm
+instance : IsScalarTower R R[X] S[X] := .of_algebraMap_eq' (mapRingHom_comp_C _).symm
 
-instance {R S : Type*} [CommRing R] [CommRing S] [Algebra R S] :
-    Algebra.IsPushout R S R[X] S[X] := by
+instance : Algebra.IsPushout R S R[X] S[X] := by
   constructor
   let e : S[X] ≃ₐ[S] TensorProduct R S R[X] := { __ := polyEquivTensor R S, commutes' := by simp }
   convert (TensorProduct.isBaseChange R R[X] S).comp (.ofEquiv e.symm.toLinearEquiv) using 1
   ext : 2
   refine Eq.trans ?_ (polyEquivTensor_symm_apply_tmul R S _ _).symm
   simp [RingHom.algebraMap_toAlgebra]
+
+instance : Algebra.IsPushout R R[X] S S[X] := .symm inferInstance


### PR DESCRIPTION
Also
+ `Polynomial.exists_dvd_map_of_isAlgebraic` is added as an application.
+ An easy instance `Algebra.IsPushout R R[X] S S[X]` is also added.
+ Prove `Algebra.IsAlgebraic.injective_tower_top` to remove injectivity assumption from `AlgebraicIndependent.extendScalars`.
+ Make the arguments of `Algebra.IsAlgebraic.trans` explicit.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
