### PR TITLE
[Merged by Bors] - refactor(CategoryTheory/Sites,Topology/Sheaves): upgrade `HasForget` to `ConcreteCategory`

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
@@ -65,8 +65,10 @@ lemma _root_.PresheafOfModules.Sheafify.app_eq_of_isLocallyInjective
     · exact Presheaf.equalizerSieve_mem J α _ _ hr₀
     · exact Presheaf.equalizerSieve_mem J φ _ _ hm₀
   · intro Z g hg
-    erw [← NatTrans.naturality_apply, ← NatTrans.naturality_apply, M₀.map_smul, M₀.map_smul,
-      hg.1, hg.2]
+    -- Manually apply `elementwise_of%` to generate ConcreteCategory lemmas.
+    rw [← elementwise_of% NatTrans.naturality (D := Ab),
+      ← elementwise_of% NatTrans.naturality (D := Ab)]
+    erw [M₀.map_smul, M₀.map_smul, hg.1, hg.2]
     rfl
 
 lemma isCompatible_map_smul_aux {Y Z : C} (f : Y ⟶ X) (g : Z ⟶ Y)
@@ -80,8 +82,8 @@ lemma isCompatible_map_smul_aux {Y Z : C} (f : Y ⟶ X) (g : Z ⟶ Y)
   · rw [hr₀', R.map_comp, RingCat.comp_apply, ← hr₀, ← RingCat.comp_apply, NatTrans.naturality,
       RingCat.comp_apply]
   · rw [hm₀', A.map_comp, AddCommGrp.coe_comp, Function.comp_apply, ← hm₀]
-    erw [NatTrans.naturality_apply φ]
-    rfl -- `ConcreteCategory`/`HasForget` mismatch workaround
+    -- Manually apply `elementwise_of%` to generate ConcreteCategory lemmas.
+    erw [elementwise_of% NatTrans.naturality φ]
 
 variable (hr₀ : (r₀.map (whiskerRight α (forget _))).IsAmalgamation r)
   (hm₀ : (m₀.map (whiskerRight φ (forget _))).IsAmalgamation m)
@@ -105,8 +107,8 @@ lemma isCompatible_map_smul : ((r₀.smul m₀).map (whiskerRight φ (forget _))
       RingCat.comp_apply]
   have hb₀ : (φ.app (Opposite.op Z)) b₀ = (A.map (f₁.op ≫ g₁.op)) m := by
     dsimp [b₀]
-    erw [NatTrans.naturality_apply φ, hb₁, Functor.map_comp, ConcreteCategory.comp_apply]
-    rfl -- `ConcreteCategory`/`HasForget` mismatch workaround
+    -- Manually apply `elementwise_of%` to generate ConcreteCategory lemmas.
+    erw [elementwise_of% NatTrans.naturality φ, hb₁, Functor.map_comp, ConcreteCategory.comp_apply]
   have ha₀' : (α.app (Opposite.op Z)) a₀ = (R.map (f₂.op ≫ g₂.op)) r := by
     rw [ha₀, ← op_comp, fac, op_comp]
   have hb₀' : (φ.app (Opposite.op Z)) b₀ = (A.map (f₂.op ≫ g₂.op)) m := by
@@ -161,11 +163,13 @@ def SMulCandidate.mk' (S : Sieve X.unop) (hS : S ∈ J X.unop)
     apply A.isSeparated _ _ (J.pullback_stable f.unop hS)
     rintro Z g hg
     dsimp at hg
-    erw [← CategoryTheory.comp_apply, ← A.val.map_comp, ← NatTrans.naturality_apply, M₀.map_smul]
+    rw [← ConcreteCategory.comp_apply, ← A.val.map_comp,
+      ← elementwise_of% NatTrans.naturality (D := Ab)]
+    erw [M₀.map_smul] -- Mismatch between `M₀.map` and `M₀.presheaf.map`
     refine (ha _ hg).trans (app_eq_of_isLocallyInjective α φ A.isSeparated _ _ _ _ ?_ ?_)
     · rw [← RingCat.comp_apply, NatTrans.naturality, RingCat.comp_apply, ha₀]
       apply (hr₀ _ hg).symm.trans
-      simp [RingCat.forget_map]
+      simp
     · erw [NatTrans.naturality_apply φ, hb₀]
       apply (hm₀ _ hg).symm.trans
       dsimp
@@ -203,7 +207,6 @@ instance : Subsingleton (SMulCandidate α φ r m) where
       all_goals apply Presheaf.imageSieve_mem
     apply A.isSeparated _ _ hS
     intro Y f ⟨⟨r₀, hr₀⟩, ⟨m₀, hm₀⟩⟩
-    show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
     rw [h₁ f.op r₀ hr₀ m₀ hm₀, h₂ f.op r₀ hr₀ m₀ hm₀]
 
 noncomputable instance : Unique (SMulCandidate α φ r m) :=
@@ -223,21 +226,17 @@ lemma map_smul_eq {Y : Cᵒᵖ} (f : X ⟶ Y) (r₀ : R₀.obj Y) (hr₀ : α.ap
 protected lemma one_smul : smul α φ 1 m = m := by
   apply A.isSeparated _ _ (Presheaf.imageSieve_mem J φ m)
   rintro Y f ⟨m₀, hm₀⟩
-  show A.val.map f.op _ = _ -- `ConcreteCategory`/`HasForget` mismatch workaround
   rw [← hm₀, map_smul_eq α φ 1 m f.op 1 (by simp) m₀ hm₀, one_smul]
-  rfl -- `ConcreteCategory`/`HasForget` mismatch workaround
 
 protected lemma zero_smul : smul α φ 0 m = 0 := by
   apply A.isSeparated _ _ (Presheaf.imageSieve_mem J φ m)
   rintro Y f ⟨m₀, hm₀⟩
-  show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
   rw [map_smul_eq α φ 0 m f.op 0 (by simp) m₀ hm₀, zero_smul, map_zero,
     (A.val.map f.op).hom.map_zero]
 
 protected lemma smul_zero : smul α φ r 0 = 0 := by
   apply A.isSeparated _ _ (Presheaf.imageSieve_mem J α r)
   rintro Y f ⟨r₀, hr₀⟩
-  show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
   rw [(A.val.map f.op).hom.map_zero, map_smul_eq α φ r 0 f.op r₀ hr₀ 0 (by simp),
     smul_zero, map_zero]
 
@@ -249,11 +248,10 @@ protected lemma smul_add : smul α φ r (m + m') = smul α φ r m + smul α φ r
   apply A.isSeparated _ _ hS
   rintro Y f ⟨⟨⟨r₀, hr₀⟩, ⟨m₀ : M₀.obj _, hm₀ : (φ.app _) _ = _⟩⟩,
     ⟨m₀' : M₀.obj _, hm₀' : (φ.app _) _ = _⟩⟩
-  show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
   rw [(A.val.map f.op).hom.map_add, map_smul_eq α φ r m f.op r₀ hr₀ m₀ hm₀,
     map_smul_eq α φ r m' f.op r₀ hr₀ m₀' hm₀',
     map_smul_eq α φ r (m + m') f.op r₀ hr₀ (m₀ + m₀')
-      (by rw [map_add, map_add, hm₀, hm₀']; rfl),
+      (by rw [map_add, map_add, hm₀, hm₀']),
     smul_add, map_add]
 
 protected lemma add_smul : smul α φ (r + r') m = smul α φ r m + smul α φ r' m := by
@@ -264,7 +262,6 @@ protected lemma add_smul : smul α φ (r + r') m = smul α φ r m + smul α φ r
   apply A.isSeparated _ _ hS
   rintro Y f ⟨⟨⟨r₀ : R₀.obj _, (hr₀ : (α.app (Opposite.op Y)) r₀ = (R.val.map f.op) r)⟩,
     ⟨r₀' : R₀.obj _, (hr₀' : (α.app (Opposite.op Y)) r₀' = (R.val.map f.op) r')⟩⟩, ⟨m₀, hm₀⟩⟩
-  show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
   rw [(A.val.map f.op).hom.map_add, map_smul_eq α φ r m f.op r₀ hr₀ m₀ hm₀,
     map_smul_eq α φ r' m f.op r₀' hr₀' m₀ hm₀,
     map_smul_eq α φ (r + r') m f.op (r₀ + r₀') (by rw [map_add, map_add, hr₀, hr₀'])
@@ -279,7 +276,6 @@ protected lemma mul_smul : smul α φ (r * r') m = smul α φ r (smul α φ r' m
   rintro Y f ⟨⟨⟨r₀ : R₀.obj _, (hr₀ : (α.app (Opposite.op Y)) r₀ = (R.val.map f.op) r)⟩,
     ⟨r₀' : R₀.obj _, (hr₀' : (α.app (Opposite.op Y)) r₀' = (R.val.map f.op) r')⟩⟩,
     ⟨m₀ : M₀.obj _, hm₀⟩⟩
-  show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
   rw [map_smul_eq α φ (r * r') m f.op (r₀ * r₀')
     (by rw [map_mul, map_mul, hr₀, hr₀']) m₀ hm₀, mul_smul,
     map_smul_eq α φ r (smul α φ r' m) f.op r₀ hr₀ (r₀' • m₀)
@@ -308,10 +304,9 @@ lemma map_smul :
   rintro Y f ⟨⟨r₀,
     (hr₀ : (α.app (Opposite.op Y)).hom r₀ = (R.val.map f.op).hom ((R.val.map π).hom r))⟩,
     ⟨m₀, (hm₀ : (φ.app _) _ = _)⟩⟩
-  show A.val.map f.op _ = A.val.map f.op _ -- `ConcreteCategory`/`HasForget` mismatch workaround
   rw [← ConcreteCategory.comp_apply, ← Functor.map_comp,
     map_smul_eq α φ r m (π ≫ f.op) r₀ (by rw [hr₀, Functor.map_comp, RingCat.comp_apply]) m₀
-      (by rw [hm₀, Functor.map_comp, ConcreteCategory.comp_apply]; rfl),
+      (by rw [hm₀, Functor.map_comp, ConcreteCategory.comp_apply]),
     map_smul_eq α φ (R.val.map π r) (A.val.map π m) f.op r₀ hr₀ m₀ hm₀]
 
 end Sheafify

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/ChangeOfRings.lean
@@ -53,8 +53,7 @@ noncomputable def restrictHomEquivOfIsLocallySurjective
   toFun f := (restrictScalars α).map f
   invFun g := homMk ((toPresheaf R).map g) (fun X r' m ↦ by
     apply hM₂.isSeparated _ _ (Presheaf.imageSieve_mem J α r')
-    -- Type-ascript `hr` so it uses `RingCat.Hom.hom` instead of `HasForget.instFunLike`
-    rintro Y p ⟨r : R.obj _, (hr : α.app (Opposite.op Y) r = R'.map p.op r')⟩
+    rintro Y p ⟨r : R.obj _, hr⟩
     have hg : ∀ (z : M₁.obj X), g.app _ (M₁.map p.op z) = M₂.map p.op (g.app X z) :=
       fun z ↦ congr_fun ((forget _).congr_map (g.naturality p.op)) z
     change M₂.map p.op (g.app X (r' • m)) = M₂.map p.op (r' • show M₂.obj X from g.app X m)

--- a/Mathlib/AlgebraicGeometry/FunctionField.lean
+++ b/Mathlib/AlgebraicGeometry/FunctionField.lean
@@ -57,7 +57,7 @@ noncomputable instance [IsIntegral X] : Field X.functionField := by
       exact ha
     · exact (RingedSpace.basicOpen _ _).isOpen
   have := (X.presheaf.germ _ _ hs).hom.isUnit_map (RingedSpace.isUnit_res_basicOpen _ s)
-  rwa [CommRingCat.germ_res_apply] at this
+  rwa [Presheaf.germ_res_apply] at this
 
 theorem germ_injective_of_isIntegral [IsIntegral X] {U : X.Opens} (x : X) (hx : x ∈ U) :
     Function.Injective (X.presheaf.germ U x hx) := by

--- a/Mathlib/AlgebraicGeometry/Modules/Sheaf.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Sheaf.lean
@@ -26,6 +26,7 @@ variable (X : Scheme.{u})
 /-- The category of sheaves of modules over a scheme. -/
 abbrev Modules := SheafOfModules.{u} X.ringCatSheaf
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 noncomputable instance : Abelian X.Modules := inferInstance
 
 end AlgebraicGeometry.Scheme

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean
@@ -303,11 +303,6 @@ def homogeneousLocalizationToStalk (x : ProjectiveSpectrum.top 𝒜) (y : at x) 
         ProjectiveSpectrum.basicOpen 𝒜 g.den.1 ⊓ ProjectiveSpectrum.basicOpen 𝒜 c)
       ⟨⟨mem_basicOpen_den _ x f, mem_basicOpen_den _ x g⟩, hc⟩
       (homOfLE inf_le_left ≫ homOfLE inf_le_left) (homOfLE inf_le_left ≫ homOfLE inf_le_right)
-    -- Go from `HasForget.instFunLike` to `CommRingCat.Hom.hom`
-    show (Proj.structureSheaf 𝒜).presheaf.map (homOfLE inf_le_left ≫ homOfLE inf_le_left).op
-        (sectionInBasicOpen 𝒜 x f) =
-      (Proj.structureSheaf 𝒜).presheaf.map (homOfLE inf_le_left ≫ homOfLE inf_le_right).op
-        (sectionInBasicOpen 𝒜 x g)
     apply Subtype.ext
     ext ⟨t, ⟨htf, htg⟩, ht'⟩
     rw [Proj.res_apply, Proj.res_apply]

--- a/Mathlib/AlgebraicGeometry/Properties.lean
+++ b/Mathlib/AlgebraicGeometry/Properties.lean
@@ -149,8 +149,7 @@ theorem eq_zero_of_basicOpen_eq_bot {X : Scheme} [hX : IsReduced X] {U : X.Opens
     specialize H (X.presheaf.map i.op s)
     rw [Scheme.basicOpen_res, hs] at H
     specialize H (inf_bot_eq _) x hx
-    -- This seems to be related to a mismatch of `X.sheaf.presheaf` and `X.presheaf` in `H`
-    rw [← CommRingCat.germ_res_apply X.sheaf.presheaf i x hx s]
+    rw [← X.sheaf.presheaf.germ_res_apply i x hx s]
     exact H
   | h₂ X Y f =>
     refine ⟨f ⁻¹ᵁ f.opensRange, f.opensRange, by ext1; simp, rfl, ?_⟩

--- a/Mathlib/AlgebraicGeometry/SpreadingOut.lean
+++ b/Mathlib/AlgebraicGeometry/SpreadingOut.lean
@@ -66,7 +66,7 @@ lemma injective_germ_basicOpen (U : X.Opens) (hU : IsAffineOpen U)
   have := hU.isLocalization_basicOpen f
   obtain ⟨t, s, rfl⟩ := IsLocalization.mk'_surjective (.powers f) t
   rw [← RingHom.mem_ker, IsLocalization.mk'_eq_mul_mk'_one, Ideal.mul_unit_mem_iff_mem,
-    RingHom.mem_ker, RingHom.algebraMap_toAlgebra, CommRingCat.germ_res_apply] at ht
+    RingHom.mem_ker, RingHom.algebraMap_toAlgebra, TopCat.Presheaf.germ_res_apply] at ht
   swap; · exact @isUnit_of_invertible _ _ _ (@IsLocalization.invertible_mk'_one ..)
   rw [H _ ht, IsLocalization.mk'_zero]
 
@@ -292,7 +292,7 @@ lemma exists_lift_of_germInjective {x : X} [X.IsGermInjectiveAt x] {U : X.Opens}
     rw [RingEquiv.apply_symm_apply]
     ext
     show X.presheaf.germ _ _ _ (X.presheaf.map _ _) = (φRA ≫ φ) a
-    rw [CommRingCat.germ_res_apply, ‹φRA ≫ φ = _›]
+    rw [TopCat.Presheaf.germ_res_apply, ‹φRA ≫ φ = _›]
     rfl
 
 /--

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -525,9 +525,6 @@ def stalkIso (x : PrimeSpectrum.Top R) :
       exists_const _ _ s x hxU
     rw [← res_apply R U V iVU s ⟨x, hxV⟩, ← hs, const_apply, localizationToStalk_mk']
     refine (structureSheaf R).presheaf.germ_ext V hxV (homOfLE hg) iVU ?_
-    -- Replace the `HasForget.instFunLike` instance with `CommRingCat.hom`:
-    show (structureSheaf R).presheaf.map (homOfLE hg).op _ =
-      (structureSheaf R).presheaf.map iVU.op s
     rw [← hs, res_const']
   inv_hom_id := CommRingCat.hom_ext <|
     @IsLocalization.ringHom_ext R _ x.asIdeal.primeCompl (Localization.AtPrime x.asIdeal) _ _

--- a/Mathlib/CategoryTheory/Limits/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/ConcreteCategory/Basic.lean
@@ -17,6 +17,46 @@ universe t w v u r
 
 open CategoryTheory
 
+namespace CategoryTheory.Types
+
+open Limits
+
+/-! The forgetful fuctor on `Type u` is the identity; copy the instances on `𝟭 (Type u)`
+over to `forget (Type u)`.
+
+We currently have two instances for `HasForget (Type u)`:
+
+* A global `HasForget` instance where `forget (Type u)` reduces to `𝟭 Type`
+* A locally enabled `ConcreteCategory` where `forget (Type u)` is only reducible-with-instances
+  equal to `𝟭 Type`.
+
+Since instance synthesis only looks through reducible definitions, we need to help it out by copying
+over the instances that wouldn't be found otherwise.
+-/
+
+attribute [local instance] Types.instFunLike Types.instConcreteCategory
+
+instance : (@forget (Type u) _ ConcreteCategory.toHasForget).Full :=
+  Functor.Full.id
+
+instance : PreservesLimitsOfSize (@forget (Type u) _ ConcreteCategory.toHasForget) :=
+  id_preservesLimitsOfSize
+instance : PreservesColimitsOfSize (@forget (Type u) _ ConcreteCategory.toHasForget) :=
+  id_preservesColimitsOfSize
+
+instance : ReflectsLimitsOfSize (@forget (Type u) _ ConcreteCategory.toHasForget) :=
+  id_reflectsLimits
+instance : ReflectsColimitsOfSize (@forget (Type u) _ ConcreteCategory.toHasForget) :=
+  id_reflectsColimits
+
+instance : (@forget (Type u) _ ConcreteCategory.toHasForget).IsEquivalence :=
+  Functor.isEquivalence_refl
+
+instance : (@forget (Type u) _ ConcreteCategory.toHasForget).IsCorepresentable :=
+  instIsCorepresentableIdType
+
+end CategoryTheory.Types
+
 namespace CategoryTheory.Limits.Concrete
 
 attribute [local instance] HasForget.instFunLike HasForget.hasCoeToSort

--- a/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
@@ -31,15 +31,15 @@ universe w
 
 open CategoryTheory Sheaf Limits Opposite
 
-attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
-
 namespace CategoryTheory
 
-variable {C : Type*} (D : Type*) [Category C] [Category D] [HasForget.{w} D]
+variable {C : Type*} (D : Type*) [Category C] [Category D] {FD : D → D → Type*} {CD : D → Type w}
+  [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)] [ConcreteCategory.{w} D FD]
 
 lemma regularTopology.isLocallySurjective_iff [Preregular C] {F G : Cᵒᵖ ⥤ D} (f : F ⟶ G) :
     Presheaf.IsLocallySurjective (regularTopology C) f ↔
-      ∀ (X : C) (y : G.obj ⟨X⟩), (∃ (X' : C) (φ : X' ⟶ X) (_ : EffectiveEpi φ) (x : F.obj ⟨X'⟩),
+      ∀ (X : C) (y : ToType (G.obj ⟨X⟩)), (∃ (X' : C) (φ : X' ⟶ X) (_ : EffectiveEpi φ)
+        (x : ToType (F.obj ⟨X'⟩)),
         f.app ⟨X'⟩ x = G.map ⟨φ⟩ y) := by
   constructor
   · intro ⟨h⟩ X y
@@ -53,6 +53,7 @@ lemma regularTopology.isLocallySurjective_iff [Preregular C] {F G : Cᵒᵖ ⥤ 
     rw [regularTopology.mem_sieves_iff_hasEffectiveEpi]
     exact ⟨X', π, h, h'⟩
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma extensiveTopology.surjective_of_isLocallySurjective_sheaf_of_types [FinitaryPreExtensive C]
     {F G : Cᵒᵖ ⥤ Type w} (f : F ⟶ G) [PreservesFiniteProducts F] [PreservesFiniteProducts G]
       (h : Presheaf.IsLocallySurjective (extensiveTopology C) f) {X : C} :
@@ -108,6 +109,7 @@ lemma extensiveTopology.isLocallySurjective_iff [FinitaryExtensive C]
         ∀ (X : C), Function.Surjective (f.val.app (op X)) :=
   extensiveTopology.presheafIsLocallySurjective_iff _ f.val
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma regularTopology.isLocallySurjective_sheaf_of_types [Preregular C] [FinitaryPreExtensive C]
     {F G : Cᵒᵖ ⥤ Type w} (f : F ⟶ G) [PreservesFiniteProducts F] [PreservesFiniteProducts G]
       (h : Presheaf.IsLocallySurjective (coherentTopology C) f) :
@@ -128,7 +130,11 @@ lemma regularTopology.isLocallySurjective_sheaf_of_types [Preregular C] [Finitar
     simp only [Functor.comp_obj, Functor.op_obj, Discrete.functor_obj, Functor.mapCone_pt,
       Cocone.op_pt, Cofan.mk_pt, Functor.const_obj_obj, Functor.mapCone_π_app, Cocone.op_π,
       NatTrans.op_app, Cofan.mk_ι_app, Functor.mapIso_symm, Iso.symm_hom, Iso.trans_hom,
-      Functor.mapIso_inv, types_comp_apply, i', ← NatTrans.naturality_apply]
+      Functor.mapIso_inv, types_comp_apply, i']
+    -- Work around a `ConcreteCategory`/`HasForget` mismatch:
+    -- (the `simp only` used to be part of the `simp` above)
+    show G.map _ (f.app _ _) = _
+    simp only [← elementwise_of% NatTrans.naturality f (Sigma.ι Z a).op]
     have : f.app ⟨Z a⟩ (x a) = G.map (π a).op y := (h' a).choose_spec
     convert this
     · change F.map _ (F.map _ _) = _

--- a/Mathlib/CategoryTheory/Sites/Coherent/SequentialLimit.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/SequentialLimit.lean
@@ -33,6 +33,7 @@ namespace CategoryTheory.coherentTopology
 
 variable {C : Type u} [Category.{v} C] [Preregular C] [FinitaryExtensive C]
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory
 variable {F : ℕᵒᵖ ⥤ Sheaf (coherentTopology C) (Type v)} {c : Cone F}
     (hc : IsLimit c)
     (hF : ∀ n, Sheaf.IsLocallySurjective (F.map (homOfLE (Nat.le_succ n)).op))

--- a/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
@@ -120,7 +120,8 @@ theorem toSheafify_comp_sheafifyCompIso_inv :
 section
 
 -- We will sheafify `D`-valued presheaves in this section.
-variable [HasForget.{max v u} D] [PreservesLimits (forget D)]
+variable {FD : D → D → Type*} {CD : D → Type (max v u)} [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)]
+variable [ConcreteCategory.{max v u} D FD] [PreservesLimits (forget D)]
   [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)] [(forget D).ReflectsIsomorphisms]
 
 @[simp]

--- a/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
@@ -30,25 +30,23 @@ variable {D : Type w} [Category.{max v u} D]
 
 section
 
-variable [HasForget.{max v u} D]
-
-attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
+variable {FD : D → D → Type*} {CD : D → Type (max v u)} [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)]
+variable [ConcreteCategory.{max v u} D FD]
 
 /-- A concrete version of the multiequalizer, to be used below. -/
 def Meq {X : C} (P : Cᵒᵖ ⥤ D) (S : J.Cover X) :=
-  { x : ∀ I : S.Arrow, P.obj (op I.Y) //
+  { x : ∀ I : S.Arrow, ToType (P.obj (op I.Y)) //
     ∀ I : S.Relation, P.map I.r.g₁.op (x I.fst) = P.map I.r.g₂.op (x I.snd) }
 
 end
 
 namespace Meq
 
-variable [HasForget.{max v u} D]
-
-attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
+variable {FD : D → D → Type*} {CD : D → Type (max v u)} [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)]
+variable [ConcreteCategory.{max v u} D FD]
 
 instance {X} (P : Cᵒᵖ ⥤ D) (S : J.Cover X) :
-    CoeFun (Meq P S) fun _ => ∀ I : S.Arrow, P.obj (op I.Y) :=
+    CoeFun (Meq P S) fun _ => ∀ I : S.Arrow, ToType (P.obj (op I.Y)) :=
   ⟨fun x => x.1⟩
 
 lemma congr_apply {X} {P : Cᵒᵖ ⥤ D} {S : J.Cover X} (x : Meq P S) {Y}
@@ -93,12 +91,11 @@ theorem pullback_refine {Y X : C} {P : Cᵒᵖ ⥤ D} {S T : J.Cover X} (h : S �
   rfl
 
 /-- Make a term of `Meq P S`. -/
-def mk {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : P.obj (op X)) : Meq P S :=
+def mk {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : ToType (P.obj (op X))) : Meq P S :=
   ⟨fun I => P.map I.f.op x, fun I => by
-    dsimp
-    simp only [← CategoryTheory.comp_apply, ← P.map_comp, ← op_comp, I.r.w]⟩
+    simp only [← ConcreteCategory.comp_apply, ← P.map_comp, ← op_comp, I.r.w]⟩
 
-theorem mk_apply {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : P.obj (op X)) (I : S.Arrow) :
+theorem mk_apply {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : ToType (P.obj (op X))) (I : S.Arrow) :
     mk S x I = P.map I.f.op x :=
   rfl
 
@@ -106,12 +103,12 @@ variable [PreservesLimits (forget D)]
 
 /-- The equivalence between the type associated to `multiequalizer (S.index P)` and `Meq P S`. -/
 noncomputable def equiv {X : C} (P : Cᵒᵖ ⥤ D) (S : J.Cover X) [HasMultiequalizer (S.index P)] :
-    (multiequalizer (S.index P) : D) ≃ Meq P S :=
-  Limits.Concrete.multiequalizerEquiv _
+    ToType (multiequalizer (S.index P)) ≃ Meq P S :=
+  Limits.Concrete.multiequalizerEquiv (C := D) _
 
 @[simp]
 theorem equiv_apply {X : C} {P : Cᵒᵖ ⥤ D} {S : J.Cover X} [HasMultiequalizer (S.index P)]
-    (x : (multiequalizer (S.index P) : D)) (I : S.Arrow) :
+    (x : ToType (multiequalizer (S.index P))) (I : S.Arrow) :
     equiv P S x I = Multiequalizer.ι (S.index P) I x :=
   rfl
 
@@ -127,9 +124,8 @@ namespace GrothendieckTopology
 
 namespace Plus
 
-variable [HasForget.{max v u} D]
-
-attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
+variable {FD : D → D → Type*} {CD : D → Type (max v u)} [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)]
+variable [instCC : ConcreteCategory.{max v u} D FD]
 
 variable [PreservesLimits (forget D)]
 variable [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
@@ -138,7 +134,7 @@ variable [∀ (P : Cᵒᵖ ⥤ D) (X : C) (S : J.Cover X), HasMultiequalizer (S.
 noncomputable section
 
 /-- Make a term of `(J.plusObj P).obj (op X)` from `x : Meq P S`. -/
-def mk {X : C} {P : Cᵒᵖ ⥤ D} {S : J.Cover X} (x : Meq P S) : (J.plusObj P).obj (op X) :=
+def mk {X : C} {P : Cᵒᵖ ⥤ D} {S : J.Cover X} (x : Meq P S) : ToType ((J.plusObj P).obj (op X)) :=
   colimit.ι (J.diagram P X) (op S) ((Meq.equiv P S).symm x)
 
 theorem res_mk_eq_mk_pullback {Y X : C} {P : Cᵒᵖ ⥤ D} {S : J.Cover X} (x : Meq P S) (f : Y ⟶ X) :
@@ -148,27 +144,29 @@ theorem res_mk_eq_mk_pullback {Y X : C} {P : Cᵒᵖ ⥤ D} {S : J.Cover X} (x :
     comp_apply (x := (Meq.equiv P S).symm x)]
   apply congr_arg
   apply (Meq.equiv P _).injective
-  erw [Equiv.apply_symm_apply]
+  dsimp only [Functor.op_obj, pullback_obj]
+  rw [Equiv.apply_symm_apply]
   ext i
   simp only [Functor.op_obj, unop_op, pullback_obj, diagram_obj, Functor.comp_obj,
     diagramPullback_app, Meq.equiv_apply, Meq.pullback_apply]
-  rw [← CategoryTheory.comp_apply, Multiequalizer.lift_ι]
+  rw [← ConcreteCategory.comp_apply, Multiequalizer.lift_ι]
   erw [Meq.equiv_symm_eq_apply]
   cases i; rfl
 
-theorem toPlus_mk {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : P.obj (op X)) :
+theorem toPlus_mk {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : ToType (P.obj (op X))) :
     (J.toPlus P).app _ x = mk (Meq.mk S x) := by
   dsimp [mk, toPlus]
   let e : S ⟶ ⊤ := homOfLE (OrderTop.le_top _)
   rw [← colimit.w _ e.op]
   delta Cover.toMultiequalizer
-  rw [CategoryTheory.comp_apply]
-  erw [CategoryTheory.comp_apply]
+  rw [ConcreteCategory.comp_apply, ConcreteCategory.comp_apply]
   apply congr_arg
   dsimp [diagram]
-  apply Concrete.multiequalizer_ext
+  apply Concrete.multiequalizer_ext (C := D)
   intro i
-  simp only [← CategoryTheory.comp_apply, Category.assoc, Multiequalizer.lift_ι, Category.comp_id,
+  -- This next `rw` works around a `ConcreteCategory`/`HasForget` mismatch:
+  rw [← CategoryTheory.forget_map_eq_coe, ConcreteCategory.forget_map_eq_coe]
+  simp only [← ConcreteCategory.comp_apply, Category.assoc, Multiequalizer.lift_ι, Category.comp_id,
     Meq.equiv_symm_eq_apply]
   rfl
 
@@ -177,70 +175,75 @@ theorem toPlus_apply {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : Meq P S) (
   dsimp only [toPlus, plusObj]
   delta Cover.toMultiequalizer
   dsimp [mk]
-  erw [← CategoryTheory.comp_apply]
-  rw [ι_colimMap_assoc, colimit.ι_pre, CategoryTheory.comp_apply, CategoryTheory.comp_apply]
+  rw [← ConcreteCategory.comp_apply, ι_colimMap_assoc, colimit.ι_pre, ConcreteCategory.comp_apply,
+    ConcreteCategory.comp_apply]
   dsimp only [Functor.op]
   let e : (J.pullback I.f).obj (unop (op S)) ⟶ ⊤ := homOfLE (OrderTop.le_top _)
-  rw [← colimit.w _ e.op]
-  erw [CategoryTheory.comp_apply]
+  rw [← colimit.w _ e.op, ConcreteCategory.comp_apply]
   apply congr_arg
-  apply Concrete.multiequalizer_ext
+  apply Concrete.multiequalizer_ext (C := D)
   intro i
   dsimp
-  erw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply]
+  erw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply]
   rw [Multiequalizer.lift_ι, Multiequalizer.lift_ι, Multiequalizer.lift_ι]
   erw [Meq.equiv_symm_eq_apply]
   simpa using (x.condition (Cover.Relation.mk' (I.precompRelation i.f))).symm
 
-theorem toPlus_eq_mk {X : C} {P : Cᵒᵖ ⥤ D} (x : P.obj (op X)) :
+theorem toPlus_eq_mk {X : C} {P : Cᵒᵖ ⥤ D} (x : ToType (P.obj (op X))) :
     (J.toPlus P).app _ x = mk (Meq.mk ⊤ x) := by
   dsimp [mk, toPlus]
   delta Cover.toMultiequalizer
-  simp only [CategoryTheory.comp_apply]
+  simp only [ConcreteCategory.comp_apply]
   apply congr_arg
   apply (Meq.equiv P ⊤).injective
   ext i
-  rw [Meq.equiv_apply, Equiv.apply_symm_apply, ← CategoryTheory.comp_apply, Multiequalizer.lift_ι]
+  rw [Meq.equiv_apply, Equiv.apply_symm_apply, ← ConcreteCategory.comp_apply, Multiequalizer.lift_ι]
   rfl
 
 variable [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)]
 
-theorem exists_rep {X : C} {P : Cᵒᵖ ⥤ D} (x : (J.plusObj P).obj (op X)) :
+theorem exists_rep {X : C} {P : Cᵒᵖ ⥤ D} (x : ToType ((J.plusObj P).obj (op X))) :
     ∃ (S : J.Cover X) (y : Meq P S), x = mk y := by
   obtain ⟨S, y, h⟩ := Concrete.colimit_exists_rep (J.diagram P X) x
   use S.unop, Meq.equiv _ _ y
   rw [← h]
   dsimp [mk]
   simp
+  -- Work around a `ConcreteCategory`/`HasForget` mismatch:
+  rfl
 
 theorem eq_mk_iff_exists {X : C} {P : Cᵒᵖ ⥤ D} {S T : J.Cover X} (x : Meq P S) (y : Meq P T) :
     mk x = mk y ↔ ∃ (W : J.Cover X) (h1 : W ⟶ S) (h2 : W ⟶ T), x.refine h1 = y.refine h2 := by
   constructor
   · intro h
-    obtain ⟨W, h1, h2, hh⟩ := Concrete.colimit_exists_of_rep_eq.{u} _ _ _ h
+    obtain ⟨W, h1, h2, hh⟩ := Concrete.colimit_exists_of_rep_eq.{u} (C := D) _ _ _ h
     use W.unop, h1.unop, h2.unop
     ext I
     apply_fun Multiequalizer.ι (W.unop.index P) I at hh
     convert hh
     all_goals
       dsimp [diagram]
-      erw [← CategoryTheory.comp_apply, Multiequalizer.lift_ι, Meq.equiv_symm_eq_apply]
+      erw [← ConcreteCategory.comp_apply, Multiequalizer.lift_ι, Meq.equiv_symm_eq_apply]
       cases I; rfl
   · rintro ⟨S, h1, h2, e⟩
-    apply Concrete.colimit_rep_eq_of_exists
+    apply Concrete.colimit_rep_eq_of_exists (C := D)
     use op S, h1.op, h2.op
     apply Concrete.multiequalizer_ext
     intro i
     apply_fun fun ee => ee i at e
+    -- Without the next line, `convert e` gives an error:
+    -- tactic 'assumption' failed, metavariable has already been assigned
+    show (Multiequalizer.ι _ i) (((J.diagram P X).map h1.op) _) =
+      (Multiequalizer.ι _ i) (((J.diagram P X).map h2.op) _)
     convert e
     all_goals
       dsimp
-      erw [← CategoryTheory.comp_apply, Multiequalizer.lift_ι]
+      rw [← ConcreteCategory.comp_apply, Multiequalizer.lift_ι]
       erw [Meq.equiv_symm_eq_apply]
       cases i; rfl
 
 /-- `P⁺` is always separated. -/
-theorem sep {X : C} (P : Cᵒᵖ ⥤ D) (S : J.Cover X) (x y : (J.plusObj P).obj (op X))
+theorem sep {X : C} (P : Cᵒᵖ ⥤ D) (S : J.Cover X) (x y : ToType ((J.plusObj P).obj (op X)))
     (h : ∀ I : S.Arrow, (J.plusObj P).map I.f.op x = (J.plusObj P).map I.f.op y) : x = y := by
   -- First, we choose representatives for x and y.
   obtain ⟨Sx, x, rfl⟩ := exists_rep x
@@ -287,7 +290,7 @@ theorem sep {X : C} (P : Cᵒᵖ ⥤ D) (S : J.Cover X) (x y : (J.plusObj P).obj
 
 theorem inj_of_sep (P : Cᵒᵖ ⥤ D)
     (hsep :
-      ∀ (X : C) (S : J.Cover X) (x y : P.obj (op X)),
+      ∀ (X : C) (S : J.Cover X) (x y : ToType (P.obj (op X))),
         (∀ I : S.Arrow, P.map I.f.op x = P.map I.f.op y) → x = y)
     (X : C) : Function.Injective ((J.toPlus P).app (op X)) := by
   intro x y h
@@ -306,7 +309,7 @@ theorem inj_of_sep (P : Cᵒᵖ ⥤ D)
   The separatedness condition is used to prove compatibility among these local sections of `P`. -/
 def meqOfSep (P : Cᵒᵖ ⥤ D)
     (hsep :
-      ∀ (X : C) (S : J.Cover X) (x y : P.obj (op X)),
+      ∀ (X : C) (S : J.Cover X) (x y : ToType (P.obj (op X))),
         (∀ I : S.Arrow, P.map I.f.op x = P.map I.f.op y) → x = y)
     (X : C) (S : J.Cover X) (s : Meq (J.plusObj P) S) (T : ∀ I : S.Arrow, J.Cover I.Y)
     (t : ∀ I : S.Arrow, Meq P (T I)) (ht : ∀ I : S.Arrow, s I = mk (t I)) : Meq P (S.bind T) where
@@ -314,11 +317,11 @@ def meqOfSep (P : Cᵒᵖ ⥤ D)
   property := by
     intro II
     apply inj_of_sep P hsep
-    rw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply, (J.toPlus P).naturality,
-      (J.toPlus P).naturality, CategoryTheory.comp_apply, CategoryTheory.comp_apply]
+    rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply, (J.toPlus P).naturality,
+      (J.toPlus P).naturality, ConcreteCategory.comp_apply, ConcreteCategory.comp_apply]
     erw [toPlus_apply (T II.fst.fromMiddle) (t II.fst.fromMiddle) II.fst.toMiddle,
       toPlus_apply (T II.snd.fromMiddle) (t II.snd.fromMiddle) II.snd.toMiddle, ← ht, ← ht,
-      ← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply, ← (J.plusObj P).map_comp,
+      ← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply, ← (J.plusObj P).map_comp,
       ← (J.plusObj P).map_comp]
     rw [← op_comp, ← op_comp]
     exact s.condition
@@ -330,10 +333,10 @@ def meqOfSep (P : Cᵒᵖ ⥤ D)
 
 theorem exists_of_sep (P : Cᵒᵖ ⥤ D)
     (hsep :
-      ∀ (X : C) (S : J.Cover X) (x y : P.obj (op X)),
+      ∀ (X : C) (S : J.Cover X) (x y : ToType (P.obj (op X))),
         (∀ I : S.Arrow, P.map I.f.op x = P.map I.f.op y) → x = y)
     (X : C) (S : J.Cover X) (s : Meq (J.plusObj P) S) :
-    ∃ t : (J.plusObj P).obj (op X), Meq.mk S t = s := by
+    ∃ t : ToType ((J.plusObj P).obj (op X)), Meq.mk S t = s := by
   have inj : ∀ X : C, Function.Injective ((J.toPlus P).app (op X)) := inj_of_sep _ hsep
   -- Choose representatives for the given local sections.
   choose T t ht using fun I => exists_rep (s I)
@@ -384,7 +387,7 @@ variable [(forget D).ReflectsIsomorphisms]
 /-- If `P` is separated, then `P⁺` is a sheaf. -/
 theorem isSheaf_of_sep (P : Cᵒᵖ ⥤ D)
     (hsep :
-      ∀ (X : C) (S : J.Cover X) (x y : P.obj (op X)),
+      ∀ (X : C) (S : J.Cover X) (x y : ToType (P.obj (op X))),
         (∀ I : S.Arrow, P.map I.f.op x = P.map I.f.op y) → x = y) :
     Presheaf.IsSheaf J (J.plusObj P) := by
   rw [Presheaf.isSheaf_iff_multiequalizer]
@@ -397,19 +400,21 @@ theorem isSheaf_of_sep (P : Cᵒᵖ ⥤ D)
     intro I
     apply_fun Meq.equiv _ _ at h
     apply_fun fun e => e I at h
-    convert h <;> erw [Meq.equiv_apply, ← CategoryTheory.comp_apply, Multiequalizer.lift_ι] <;> rfl
-  · rintro (x : (multiequalizer (S.index _) : D))
+    convert h <;> erw [Meq.equiv_apply, ← ConcreteCategory.comp_apply, Multiequalizer.lift_ι] <;>
+      rfl
+  · rintro (x : ToType (multiequalizer (S.index _)))
     obtain ⟨t, ht⟩ := exists_of_sep P hsep X S (Meq.equiv _ _ x)
     use t
-    apply (Meq.equiv _ _).injective
+    apply (Meq.equiv (D := D) _ _).injective
     rw [← ht]
     ext i
     dsimp
-    erw [← CategoryTheory.comp_apply]
-    rw [Multiequalizer.lift_ι]
+    rw [← ConcreteCategory.comp_apply, Multiequalizer.lift_ι]
     rfl
 
 variable (J)
+
+include instCC
 
 /-- `P⁺⁺` is always a sheaf. -/
 theorem isSheaf_plus_plus (P : Cᵒᵖ ⥤ D) : Presheaf.IsSheaf J (J.plusObj (J.plusObj P)) := by
@@ -541,11 +546,13 @@ theorem sheafifyMap_sheafifyLift {P Q R : Cᵒᵖ ⥤ D} (η : P ⟶ Q) (γ : Q 
 end GrothendieckTopology
 
 variable (J)
-variable [HasForget.{max v u} D] [PreservesLimits (forget D)]
+variable {FD : D → D → Type*} {CD : D → Type (max v u)} [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)]
+variable [instCC : ConcreteCategory.{max v u} D FD] [PreservesLimits (forget D)]
   [∀ (P : Cᵒᵖ ⥤ D) (X : C) (S : J.Cover X), HasMultiequalizer (S.index P)]
   [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
   [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)] [(forget D).ReflectsIsomorphisms]
 
+include instCC in
 theorem GrothendieckTopology.sheafify_isSheaf (P : Cᵒᵖ ⥤ D) : Presheaf.IsSheaf J (J.sheafify P) :=
   GrothendieckTopology.Plus.isSheaf_plus_plus _ _
 
@@ -588,6 +595,7 @@ instance sheafToPresheaf_isRightAdjoint : (sheafToPresheaf J D).IsRightAdjoint  
 instance presheaf_mono_of_mono {F G : Sheaf J D} (f : F ⟶ G) [Mono f] : Mono f.1 :=
   (sheafToPresheaf J D).map_mono _
 
+include instCC in
 theorem Sheaf.Hom.mono_iff_presheaf_mono {F G : Sheaf J D} (f : F ⟶ G) : Mono f ↔ Mono f.1 :=
   ⟨fun m => by infer_instance, fun m => by exact Sheaf.Hom.mono_of_presheaf_mono J D f⟩
 

--- a/Mathlib/CategoryTheory/Sites/EpiMono.lean
+++ b/Mathlib/CategoryTheory/Sites/EpiMono.lean
@@ -26,7 +26,8 @@ namespace CategoryTheory
 open Category ConcreteCategory
 
 variable {C : Type u} [Category.{v} C] (J : GrothendieckTopology C)
-  (A : Type u') [Category.{v'} A] [HasForget.{w} A]
+  (A : Type u') [Category.{v'} A] {FA : A → A → Type*} {CA : A → Type w}
+  [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)] [ConcreteCategory.{w} A FA]
   [HasFunctorialSurjectiveInjectiveFactorization A]
   [J.WEqualsLocallyBijective A]
 

--- a/Mathlib/CategoryTheory/Sites/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Sites/Equivalence.lean
@@ -269,8 +269,9 @@ lemma PreservesSheafification.transport
       K.W_whiskerLeft_iff (G := G) (J := J) (f := whiskerRight f F)] at this
 
 variable [Functor.IsContinuous.{v₃} G K J] [(G.sheafPushforwardContinuous A K J).EssSurj]
-variable [G.IsCocontinuous K J] [HasForget A]
-  [K.WEqualsLocallyBijective A]
+variable [G.IsCocontinuous K J] {FA : A → A → Type*} {CA : A → Type*}
+variable [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)] [ConcreteCategory A FA]
+variable [K.WEqualsLocallyBijective A]
 
 lemma WEqualsLocallyBijective.transport (hG : CoverPreserving K J G) :
     J.WEqualsLocallyBijective A where

--- a/Mathlib/CategoryTheory/Sites/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Sites/LeftExact.lean
@@ -227,7 +227,8 @@ section
 variable {D : Type w} [Category.{max v u} D]
 variable [∀ (P : Cᵒᵖ ⥤ D) (X : C) (S : J.Cover X), HasMultiequalizer (S.index P)]
 variable [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
-variable [HasForget.{max v u} D]
+variable {FD : D → D → Type*} {CD : D → Type (max v u)}
+variable [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)] [ConcreteCategory.{max v u} D FD]
 variable [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)]
 variable [PreservesLimits (forget D)]
 variable [(forget D).ReflectsIsomorphisms]

--- a/Mathlib/CategoryTheory/Sites/LocallyBijective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallyBijective.lean
@@ -24,7 +24,9 @@ universe w' w v' v u' u
 namespace CategoryTheory
 
 variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
-  {A : Type u'} [Category.{v'} A] [HasForget.{w} A]
+variable {A : Type u'} [Category.{v'} A] {FA : A → A → Type*} {CA : A → Type w'}
+variable [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)] [ConcreteCategory.{w'} A FA]
+
 
 namespace Sheaf
 
@@ -32,6 +34,7 @@ section
 
 variable {F G : Sheaf J (Type w)} (f : F ⟶ G)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- A morphism of sheaves of types is locally bijective iff it is an isomorphism.
 (This is generalized below as `isLocallyBijective_iff_isIso`.) -/
 private lemma isLocallyBijective_iff_isIso' :
@@ -138,19 +141,22 @@ lemma WEqualsLocallyBijective.mk' [HasWeakSheafify J A] [(forget A).ReflectsIsom
     [∀ (P : Cᵒᵖ ⥤ A), Presheaf.IsLocallySurjective J (CategoryTheory.toSheafify J P)] :
     J.WEqualsLocallyBijective A where
   iff {P Q} f := by
-    rw [W_iff, ← Sheaf.isLocallyBijective_iff_isIso,
+    rw [W_iff, ← Sheaf.isLocallyBijective_iff_isIso (A := A),
       ← Presheaf.isLocallyInjective_comp_iff J f (CategoryTheory.toSheafify J Q),
       ← Presheaf.isLocallySurjective_comp_iff J f (CategoryTheory.toSheafify J Q),
       CategoryTheory.toSheafify_naturality, Presheaf.comp_isLocallyInjective_iff,
       Presheaf.comp_isLocallySurjective_iff]
 
-instance {D : Type w} [Category.{w'} D] [HasForget.{max u v} D]
+instance {D : Type w} [Category.{w'} D] {FD : D → D → Type*} {CD : D → Type (max u v)}
+    [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)] [ConcreteCategory.{max u v} D FD]
     [HasWeakSheafify J D] [J.HasSheafCompose (forget D)]
     [J.PreservesSheafification (forget D)] [(forget D).ReflectsIsomorphisms] :
     J.WEqualsLocallyBijective D := by
   apply WEqualsLocallyBijective.mk'
 
-instance : J.WEqualsLocallyBijective (Type (max u v)) := inferInstance
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
+instance : J.WEqualsLocallyBijective (Type (max u v)) :=
+  inferInstance
 
 end GrothendieckTopology
 

--- a/Mathlib/CategoryTheory/Sites/LocallyFullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallyFullyFaithful.lean
@@ -61,9 +61,11 @@ def Sieve.equalizer {U V : C} (f₁ f₂ : U ⟶ V) : Sieve U where
 @[simp]
 lemma Sieve.equalizer_self {U V : C} (f : U ⟶ V) : equalizer f f = ⊤ := by ext; simp
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma Sieve.equalizer_eq_equalizerSieve {U V : C} (f₁ f₂ : U ⟶ V) :
     Sieve.equalizer f₁ f₂ = Presheaf.equalizerSieve (F := yoneda.obj _) f₁ f₂ := rfl
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma Functor.imageSieve_eq_imageSieve {D : Type uD} [Category.{vC} D] (G : C ⥤ D) {U V : C}
     (f : G.obj U ⟶ G.obj V) :
     G.imageSieve f = Presheaf.imageSieve (yonedaMap G V) f := rfl

--- a/Mathlib/CategoryTheory/Sites/LocallyInjective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallyInjective.lean
@@ -29,10 +29,9 @@ namespace CategoryTheory
 open Opposite Limits
 
 variable {C : Type u} [Category.{v} C]
-  {D : Type u'} [Category.{v'} D] [HasForget.{w} D]
+  {D : Type u'} [Category.{v'} D] {FD : D → D → Type*} {CD : D → Type w}
+  [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)] [ConcreteCategory.{w} D FD]
   (J : GrothendieckTopology C)
-
-attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
 
 namespace Presheaf
 
@@ -40,18 +39,18 @@ namespace Presheaf
 elements in `F.obj X`, this is the sieve of `X.unop` consisting of morphisms `f`
 such that `F.map f.op x = F.map f.op y`. -/
 @[simps]
-def equalizerSieve {F : Cᵒᵖ ⥤ D} {X : Cᵒᵖ} (x y : F.obj X) : Sieve X.unop where
+def equalizerSieve {F : Cᵒᵖ ⥤ D} {X : Cᵒᵖ} (x y : ToType (F.obj X)) : Sieve X.unop where
   arrows _ f := F.map f.op x = F.map f.op y
   downward_closed {X Y} f hf g := by
     dsimp at hf ⊢
     simp [hf]
 
 @[simp]
-lemma equalizerSieve_self_eq_top {F : Cᵒᵖ ⥤ D} {X : Cᵒᵖ} (x : F.obj X) :
+lemma equalizerSieve_self_eq_top {F : Cᵒᵖ ⥤ D} {X : Cᵒᵖ} (x : ToType (F.obj X)) :
     equalizerSieve x x = ⊤ := by aesop
 
 @[simp]
-lemma equalizerSieve_eq_top_iff {F : Cᵒᵖ ⥤ D} {X : Cᵒᵖ} (x y : F.obj X) :
+lemma equalizerSieve_eq_top_iff {F : Cᵒᵖ ⥤ D} {X : Cᵒᵖ} (x y : ToType (F.obj X)) :
     equalizerSieve x y = ⊤ ↔ x = y := by
   constructor
   · intro h
@@ -66,11 +65,11 @@ is locally injective for a Grothendieck topology `J` on `C` if
 whenever two sections of `F₁` are sent to the same section of `F₂`, then these two
 sections coincide locally. -/
 class IsLocallyInjective : Prop where
-  equalizerSieve_mem {X : Cᵒᵖ} (x y : F₁.obj X) (h : φ.app X x = φ.app X y) :
+  equalizerSieve_mem {X : Cᵒᵖ} (x y : ToType (F₁.obj X)) (h : φ.app X x = φ.app X y) :
     equalizerSieve x y ∈ J X.unop
 
 lemma equalizerSieve_mem [IsLocallyInjective J φ]
-    {X : Cᵒᵖ} (x y : F₁.obj X) (h : φ.app X x = φ.app X y) :
+    {X : Cᵒᵖ} (x y : ToType (F₁.obj X)) (h : φ.app X x = φ.app X y) :
     equalizerSieve x y ∈ J X.unop :=
   IsLocallyInjective.equalizerSieve_mem x y h
 
@@ -81,7 +80,9 @@ lemma isLocallyInjective_of_injective (hφ : ∀ (X : Cᵒᵖ), Function.Injecti
     ext Y f
     simp only [equalizerSieve_apply, op_unop, Sieve.top_apply, iff_true]
     apply hφ
-    simp [h]
+    -- Invoke `elementwise_of%` manually to get a `ConcreteCategory`-based result, instead of the
+    -- `HasForget`-based result.
+    simp [h, elementwise_of% NatTrans.naturality (D := D)]
 
 instance [IsIso φ] : IsLocallyInjective J φ :=
   isLocallyInjective_of_injective J φ (fun X => Function.Bijective.injective (by
@@ -89,10 +90,12 @@ instance [IsIso φ] : IsLocallyInjective J φ :=
     change IsIso ((forget D).map (φ.app X))
     infer_instance))
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance isLocallyInjective_forget [IsLocallyInjective J φ] :
     IsLocallyInjective J (whiskerRight φ (forget D)) where
   equalizerSieve_mem x y h := equalizerSieve_mem J φ x y h
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma isLocallyInjective_forget_iff :
     IsLocallyInjective J (whiskerRight φ (forget D)) ↔ IsLocallyInjective J φ := by
   constructor
@@ -102,7 +105,7 @@ lemma isLocallyInjective_forget_iff :
     infer_instance
 
 lemma isLocallyInjective_iff_equalizerSieve_mem_imp :
-    IsLocallyInjective J φ ↔ ∀ ⦃X : Cᵒᵖ⦄ (x y : F₁.obj X),
+    IsLocallyInjective J φ ↔ ∀ ⦃X : Cᵒᵖ⦄ (x y : ToType (F₁.obj X)),
       equalizerSieve (φ.app _ x) (φ.app _ y) ∈ J X.unop → equalizerSieve x y ∈ J X.unop := by
   constructor
   · intro _ X x y h
@@ -115,13 +118,16 @@ lemma isLocallyInjective_iff_equalizerSieve_mem_imp :
     · intro Y f hf
       refine J.superset_covering (Sieve.le_pullback_bind S.1 T _ hf)
         (equalizerSieve_mem J φ _ _ ?_)
-      rw [NatTrans.naturality_apply, NatTrans.naturality_apply]
+      -- Invoke `elementwise_of%` manually to get a `ConcreteCategory`-based result, instead of the
+      -- `HasForget`-based result.
+      rw [elementwise_of% NatTrans.naturality (D := D),
+        elementwise_of% NatTrans.naturality (D := D)]
       exact hf
   · intro hφ
     exact ⟨fun {X} x y h => hφ x y (by simp [h])⟩
 
 lemma equalizerSieve_mem_of_equalizerSieve_app_mem
-    {X : Cᵒᵖ} (x y : F₁.obj X) (h : equalizerSieve (φ.app _ x) (φ.app _ y) ∈ J X.unop)
+    {X : Cᵒᵖ} (x y : ToType (F₁.obj X)) (h : equalizerSieve (φ.app _ x) (φ.app _ y) ∈ J X.unop)
     [IsLocallyInjective J φ] :
     equalizerSieve x y ∈ J X.unop :=
   (isLocallyInjective_iff_equalizerSieve_mem_imp J φ).1 inferInstance x y h
@@ -166,6 +172,7 @@ lemma isLocallyInjective_iff_injective_of_separated
     exact (hsep _ (equalizerSieve_mem J φ x y h)).ext (fun _ _ hf => hf)
   · apply isLocallyInjective_of_injective
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance (F : Cᵒᵖ ⥤ Type w) (G : Subpresheaf F) :
     IsLocallyInjective J G.ι :=
   isLocallyInjective_of_injective _ _ (fun X => by
@@ -175,6 +182,8 @@ instance (F : Cᵒᵖ ⥤ Type w) (G : Subpresheaf F) :
 section
 
 open GrothendieckTopology.Plus
+
+attribute [local instance] Types.instFunLike Types.instConcreteCategory
 
 instance isLocallyInjective_toPlus (P : Cᵒᵖ ⥤ Type max u v) :
     IsLocallyInjective J (J.toPlus P) where
@@ -189,7 +198,8 @@ instance isLocallyInjective_toSheafify (P : Cᵒᵖ ⥤ Type max u v) :
   rw [GrothendieckTopology.plusMap_toPlus]
   infer_instance
 
-instance isLocallyInjective_toSheafify' [HasForget.{max u v} D]
+instance isLocallyInjective_toSheafify' {CD : D → Type (max u v)}
+    [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)] [ConcreteCategory.{max u v} D FD]
     (P : Cᵒᵖ ⥤ D) [HasWeakSheafify J D] [J.HasSheafCompose (forget D)]
     [J.PreservesSheafification (forget D)] :
     IsLocallyInjective J (toSheafify J P) := by
@@ -221,11 +231,12 @@ instance isLocallyInjective_of_iso [IsIso φ] : IsLocallyInjective φ := by
 
 lemma mono_of_injective
     (hφ : ∀ (X : Cᵒᵖ), Function.Injective (φ.val.app X)) : Mono φ :=
-  have := fun X ↦ ConcreteCategory.mono_of_injective _ (hφ X)
+  have : ∀ X, Mono (φ.val.app X) := fun X ↦ ConcreteCategory.mono_of_injective _ (hφ X)
   (sheafToPresheaf _ _).mono_of_mono_map (NatTrans.mono_of_mono_app φ.1)
 
 variable [J.HasSheafCompose (forget D)]
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance isLocallyInjective_forget [IsLocallyInjective φ] :
     IsLocallyInjective ((sheafCompose J (forget D)).map φ) :=
   Presheaf.isLocallyInjective_forget J φ.1
@@ -242,6 +253,7 @@ lemma mono_of_isLocallyInjective [IsLocallyInjective φ] : Mono φ := by
   rw [← isLocallyInjective_iff_injective]
   infer_instance
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance {F G : Sheaf J (Type w)} (f : F ⟶ G) :
     IsLocallyInjective (Sheaf.imageι f) := by
   dsimp [Sheaf.imageι]

--- a/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
@@ -33,31 +33,32 @@ namespace CategoryTheory
 
 variable {C : Type u} [Category.{v} C] (J : GrothendieckTopology C)
 
-attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
-
-variable {A : Type u'} [Category.{v'} A] [HasForget.{w'} A]
+variable {A : Type u'} [Category.{v'} A] {FA : A → A → Type*} {CA : A → Type w'}
+variable [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)] [ConcreteCategory.{w'} A FA]
 
 namespace Presheaf
 
 /-- Given `f : F ⟶ G`, a morphism between presieves, and `s : G.obj (op U)`, this is the sieve
 of `U` consisting of the `i : V ⟶ U` such that `s` restricted along `i` is in the image of `f`. -/
 @[simps (config := .lemmasOnly)]
-def imageSieve {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : G.obj (op U)) : Sieve U where
-  arrows V i := ∃ t : F.obj (op V), f.app _ t = G.map i.op s
+def imageSieve {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : ToType (G.obj (op U))) : Sieve U where
+  arrows V i := ∃ t : ToType (F.obj (op V)), f.app _ t = G.map i.op s
   downward_closed := by
     rintro V W i ⟨t, ht⟩ j
     refine ⟨F.map j.op t, ?_⟩
-    rw [op_comp, G.map_comp, CategoryTheory.comp_apply, ← ht, elementwise_of% f.naturality]
+    rw [op_comp, G.map_comp, ConcreteCategory.comp_apply, ← ht, elementwise_of% f.naturality]
 
-theorem imageSieve_eq_sieveOfSection {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : G.obj (op U)) :
+theorem imageSieve_eq_sieveOfSection {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C}
+    (s : ToType (G.obj (op U))) :
     imageSieve f s = (Subpresheaf.range (whiskerRight f (forget A))).sieveOfSection s :=
   rfl
 
-theorem imageSieve_whisker_forget {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : G.obj (op U)) :
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
+theorem imageSieve_whisker_forget {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : ToType (G.obj (op U))) :
     imageSieve (whiskerRight f (forget A)) s = imageSieve f s :=
   rfl
 
-theorem imageSieve_app {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : F.obj (op U)) :
+theorem imageSieve_app {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : ToType (F.obj (op U))) :
     imageSieve f (f.app _ s) = ⊤ := by
   ext V i
   simp only [Sieve.top_apply, iff_true, imageSieve_apply]
@@ -67,13 +68,13 @@ theorem imageSieve_app {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : C} (s : F.obj (o
 /-- If a morphism `g : V ⟶ U.unop` belongs to the sieve `imageSieve f s g`, then
 this is choice of a preimage of `G.map g.op s` in `F.obj (op V)`, see
 `app_localPreimage`.-/
-noncomputable def localPreimage {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : Cᵒᵖ} (s : G.obj U)
+noncomputable def localPreimage {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : Cᵒᵖ} (s : ToType (G.obj U))
     {V : C} (g : V ⟶ U.unop) (hg : imageSieve f s g) :
-    F.obj (op V) :=
+    ToType (F.obj (op V)) :=
   hg.choose
 
 @[simp]
-lemma app_localPreimage {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : Cᵒᵖ} (s : G.obj U)
+lemma app_localPreimage {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : Cᵒᵖ} (s : ToType (G.obj U))
     {V : C} (g : V ⟶ U.unop) (hg : imageSieve f s g) :
     f.app _ (localPreimage f s g hg) = G.map g.op s :=
   hg.choose_spec
@@ -81,12 +82,13 @@ lemma app_localPreimage {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) {U : Cᵒᵖ} (s : G
 /-- A morphism of presheaves `f : F ⟶ G` is locally surjective with respect to a grothendieck
 topology if every section of `G` is locally in the image of `f`. -/
 class IsLocallySurjective {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) : Prop where
-  imageSieve_mem {U : C} (s : G.obj (op U)) : imageSieve f s ∈ J U
+  imageSieve_mem {U : C} (s : ToType (G.obj (op U))) : imageSieve f s ∈ J U
 
 lemma imageSieve_mem {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) [IsLocallySurjective J f] {U : Cᵒᵖ}
-    (s : G.obj U) : imageSieve f s ∈ J U.unop :=
+    (s : ToType (G.obj U)) : imageSieve f s ∈ J U.unop :=
   IsLocallySurjective.imageSieve_mem _
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) [IsLocallySurjective J f] :
     IsLocallySurjective J (whiskerRight f (forget A)) where
   imageSieve_mem s := imageSieve_mem J f s
@@ -101,6 +103,7 @@ theorem isLocallySurjective_iff_range_sheafify_eq_top {F G : Cᵒᵖ ⥤ A} (f :
 alias isLocallySurjective_iff_imagePresheaf_sheafify_eq_top :=
   isLocallySurjective_iff_range_sheafify_eq_top
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 theorem isLocallySurjective_iff_range_sheafify_eq_top' {F G : Cᵒᵖ ⥤ Type w} (f : F ⟶ G) :
     IsLocallySurjective J f ↔ (Subpresheaf.range f).sheafify J = ⊤ := by
   apply isLocallySurjective_iff_range_sheafify_eq_top
@@ -109,6 +112,7 @@ theorem isLocallySurjective_iff_range_sheafify_eq_top' {F G : Cᵒᵖ ⥤ Type w
 alias isLocallySurjective_iff_imagePresheaf_sheafify_eq_top' :=
   isLocallySurjective_iff_range_sheafify_eq_top'
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 theorem isLocallySurjective_iff_whisker_forget {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) :
     IsLocallySurjective J f ↔ IsLocallySurjective J (whiskerRight f (forget A)) := by
   simp only [isLocallySurjective_iff_range_sheafify_eq_top]
@@ -126,7 +130,7 @@ instance isLocallySurjective_of_iso {F G : Cᵒᵖ ⥤ A} (f : F ⟶ G) [IsIso f
   apply isLocallySurjective_of_surjective
   intro U
   apply Function.Bijective.surjective
-  rw [← isIso_iff_bijective, ← forget_map_eq_coe]
+  rw [← isIso_iff_bijective, ← ConcreteCategory.forget_map_eq_coe]
   infer_instance
 
 instance isLocallySurjective_comp {F₁ F₂ F₃ : Cᵒᵖ ⥤ A} (f₁ : F₁ ⟶ F₂) (f₂ : F₂ ⟶ F₃)
@@ -137,8 +141,8 @@ instance isLocallySurjective_comp {F₁ F₂ F₃ : Cᵒᵖ ⥤ A} (f₁ : F₁ 
         imageSieve (f₁ ≫ f₂) s := by
       rintro V i ⟨W, i, j, H, ⟨t', ht'⟩, rfl⟩
       refine ⟨t', ?_⟩
-      rw [op_comp, F₃.map_comp, NatTrans.comp_app, CategoryTheory.comp_apply,
-        CategoryTheory.comp_apply, ht', elementwise_of% f₂.naturality, H.choose_spec]
+      rw [op_comp, F₃.map_comp, NatTrans.comp_app, ConcreteCategory.comp_apply,
+        ConcreteCategory.comp_apply, ht', elementwise_of% f₂.naturality, H.choose_spec]
     apply J.superset_covering this
     apply J.bind_covering
     · apply imageSieve_mem
@@ -195,13 +199,17 @@ lemma isLocallyInjective_of_isLocallyInjective_of_isLocallySurjective
       equalizerSieve (localPreimage f₁ x₁ f hf.1) (localPreimage f₁ x₂ f hf.2)
     refine J.superset_covering ?_ (J.transitive hS (Sieve.bind S.1 T) ?_)
     · rintro Y f ⟨Z, a, g, hg, ha, rfl⟩
-      simpa using congr_arg (f₁.app _) ha
+      -- Manually invoke `elementwise_of%` to obtain a `ConcreteCategory result
+      simpa [elementwise_of% NatTrans.naturality (D := A)] using congr_arg (f₁.app _) ha
     · intro Y f hf
       apply J.superset_covering (Sieve.le_pullback_bind _ _ _ hf)
       apply equalizerSieve_mem J (f₁ ≫ f₂)
       dsimp
-      rw [CategoryTheory.comp_apply, CategoryTheory.comp_apply, app_localPreimage,
-        app_localPreimage, NatTrans.naturality_apply, NatTrans.naturality_apply, h]
+      rw [ConcreteCategory.comp_apply, ConcreteCategory.comp_apply, app_localPreimage,
+        app_localPreimage,
+        -- Manually invoke `elementwise_of%` to obtain a `ConcreteCategory result
+        elementwise_of% NatTrans.naturality (D := A), elementwise_of% NatTrans.naturality (D := A),
+        h]
 
 lemma isLocallyInjective_of_isLocallyInjective_of_isLocallySurjective_fac
     {F₁ F₂ F₃ : Cᵒᵖ ⥤ A} {f₁ : F₁ ⟶ F₂} {f₂ : F₂ ⟶ F₃} (f₃ : F₁ ⟶ F₃) (fac : f₁ ≫ f₂ = f₃)
@@ -221,12 +229,14 @@ lemma isLocallySurjective_of_isLocallySurjective_of_isLocallyInjective
     refine J.superset_covering ?_ (J.transitive (imageSieve_mem J (f₁ ≫ f₂) (f₂.app _ x))
       (Sieve.bind S.1 T) ?_)
     · rintro Y _ ⟨Z, a, g, hg, ha, rfl⟩
-      exact ⟨F₁.map a.op (localPreimage (f₁ ≫ f₂) _ _ hg), by simpa using ha⟩
+      exact ⟨F₁.map a.op (localPreimage (f₁ ≫ f₂) _ _ hg), by
+        -- Manually invoke `elementwise_of%` to obtain a `ConcreteCategory result
+        simpa [elementwise_of% NatTrans.naturality (D := A)] using ha⟩
     · intro Y f hf
       apply J.superset_covering (Sieve.le_pullback_bind _ _ _ hf)
       apply equalizerSieve_mem J f₂
-      rw [NatTrans.naturality_apply, ← app_localPreimage (f₁ ≫ f₂) _ _ hf,
-        NatTrans.comp_app, CategoryTheory.comp_apply]
+      rw [elementwise_of% NatTrans.naturality (D := A), ← app_localPreimage (f₁ ≫ f₂) _ _ hf,
+        NatTrans.comp_app, ConcreteCategory.comp_apply]
 
 lemma isLocallySurjective_of_isLocallySurjective_of_isLocallyInjective_fac
     {F₁ F₂ F₃ : Cᵒᵖ ⥤ A} {f₁ : F₁ ⟶ F₂} {f₂ : F₂ ⟶ F₃} (f₃ : F₁ ⟶ F₃) (fac : f₁ ≫ f₂ = f₃)
@@ -255,6 +265,7 @@ lemma isLocallySurjective_comp_iff
   · intro
     infer_instance
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance {F₁ F₂ : Cᵒᵖ ⥤ Type w} (f : F₁ ⟶ F₂) :
     IsLocallySurjective J (Subpresheaf.toRangeSheafify J f) where
   imageSieve_mem {X} := by
@@ -263,6 +274,7 @@ instance {F₁ F₂ : Cᵒᵖ ⥤ Type w} (f : F₁ ⟶ F₂) :
     rintro Y g ⟨t, ht⟩
     exact ⟨t, Subtype.ext ht⟩
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- The image of `F` in `J.sheafify F` is isomorphic to the sheafification. -/
 noncomputable def sheafificationIsoImagePresheaf (F : Cᵒᵖ ⥤ Type max u v) :
     J.sheafify F ≅ ((Subpresheaf.range (J.toSheafify F)).sheafify J).toPresheaf where
@@ -284,6 +296,7 @@ section
 
 open GrothendieckTopology.Plus
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance isLocallySurjective_toPlus (P : Cᵒᵖ ⥤ Type max u v) :
     IsLocallySurjective J (J.toPlus P) where
   imageSieve_mem x := by
@@ -296,14 +309,17 @@ instance isLocallySurjective_toPlus (P : Cᵒᵖ ⥤ Type max u v) :
     simpa using x.2 (Cover.Relation.mk { hf := hf }
         { hf := S.1.downward_closed hf g } { g₁ := g, g₂ := 𝟙 Z })
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance isLocallySurjective_toSheafify (P : Cᵒᵖ ⥤ Type max u v) :
     IsLocallySurjective J (J.toSheafify P) := by
   dsimp [GrothendieckTopology.toSheafify]
   rw [GrothendieckTopology.plusMap_toPlus]
   infer_instance
 
-instance isLocallySurjective_toSheafify' {D : Type*} [Category D]
-    [HasForget.{max u v} D]
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
+instance isLocallySurjective_toSheafify' {D : Type*} [Category D] {FD : D → D → Type*}
+    {CD : D → Type (max u v)} [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)]
+    [ConcreteCategory.{max u v} D FD]
     (P : Cᵒᵖ ⥤ D) [HasWeakSheafify J D] [J.HasSheafCompose (forget D)]
     [J.PreservesSheafification (forget D)] :
     IsLocallySurjective J (toSheafify J P) := by
@@ -335,6 +351,7 @@ instance isLocallySurjective_of_iso [IsIso φ] : IsLocallySurjective φ := by
   have : IsIso φ.val := (inferInstance : IsIso ((sheafToPresheaf J A).map φ))
   infer_instance
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance {F G : Sheaf J (Type w)} (f : F ⟶ G) :
     IsLocallySurjective (Sheaf.toImage f) := by
   dsimp [Sheaf.toImage]
@@ -342,10 +359,12 @@ instance {F G : Sheaf J (Type w)} (f : F ⟶ G) :
 
 variable [J.HasSheafCompose (forget A)]
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance [IsLocallySurjective φ] :
     IsLocallySurjective ((sheafCompose J (forget A)).map φ) :=
   (Presheaf.isLocallySurjective_iff_whisker_forget J φ.val).1 inferInstance
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 theorem isLocallySurjective_iff_isIso {F G : Sheaf J (Type w)} (f : F ⟶ G) :
     IsLocallySurjective f ↔ IsIso (Sheaf.imageι f) := by
   dsimp only [IsLocallySurjective]
@@ -353,6 +372,7 @@ theorem isLocallySurjective_iff_isIso {F G : Sheaf J (Type w)} (f : F ⟶ G) :
     Subpresheaf.eq_top_iff_isIso]
   exact isIso_iff_of_reflects_iso (f := Sheaf.imageι f) (F := sheafToPresheaf J (Type w))
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance epi_of_isLocallySurjective' {F₁ F₂ : Sheaf J (Type w)} (φ : F₁ ⟶ F₂)
     [IsLocallySurjective φ] : Epi φ where
   left_cancellation {Z} f₁ f₂ h := by
@@ -370,6 +390,7 @@ instance epi_of_isLocallySurjective' {F₁ F₂ : Sheaf J (Type w)} (φ : F₁ �
 instance epi_of_isLocallySurjective [IsLocallySurjective φ] : Epi φ :=
   (sheafCompose J (forget A)).epi_of_epi_map inferInstance
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma isLocallySurjective_iff_epi {F G : Sheaf J (Type w)} (φ : F ⟶ G)
     [HasSheafify J (Type w)] :
     IsLocallySurjective φ ↔ Epi φ := by
@@ -387,6 +408,7 @@ namespace Presieve.FamilyOfElements
 
 variable {R R' : Cᵒᵖ ⥤ Type w} (φ : R ⟶ R') {X : Cᵒᵖ} (r' : R'.obj X)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- Given a morphism `φ : R ⟶ R'` of presheaves of types and `r' : R'.obj X`,
 this is the family of elements of `R` defined over the sieve `Presheaf.imageSieve φ r'`
 which sends a map in this sieve to an arbitrary choice of a preimage of the
@@ -395,6 +417,7 @@ noncomputable def localPreimage :
     FamilyOfElements R (Presheaf.imageSieve φ r').arrows :=
   fun _ f hf => Presheaf.localPreimage φ r' f hf
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma isAmalgamation_map_localPreimage :
     ((localPreimage φ r').map φ).IsAmalgamation r' :=
   fun _ f hf => (Presheaf.app_localPreimage φ r' f hf).symm

--- a/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
@@ -24,7 +24,9 @@ namespace CategoryTheory
 
 namespace Presheaf
 
-variable [HasForget A]
+variable {FA : A → A → Type*} {CA : A → Type*}
+variable [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)] [ConcreteCategory A FA]
+
 
 lemma isLocallyInjective_whisker [H.IsCocontinuous J K] [IsLocallyInjective K f] :
     IsLocallyInjective J (whiskerLeft H.op f) where
@@ -40,11 +42,14 @@ lemma isLocallyInjective_of_whisker (hH : CoverPreserving J K H)
     refine K.superset_covering (Sieve.functorPullback_pushforward_le H _) ?_
     refine K.superset_covering (Sieve.functorPushforward_monotone H _ ?_)
       (hH.cover_preserve <| equalizerSieve_mem J (whiskerLeft H.op f)
-        ((forget A).map (F.map map.op) a) ((forget A).map (F.map map.op) b) ?_)
+        (F.map map.op a) (F.map map.op b) ?_)
     · intro W q hq
       simpa using hq
     · simp only [comp_obj, op_obj, whiskerLeft_app, Opposite.op_unop]
-      erw [NatTrans.naturality_apply, NatTrans.naturality_apply, h]
+      rw [
+        -- Manually insert `elementwise_of%` to generate a `ConcreteCategory` lemma
+        elementwise_of% NatTrans.naturality (D := A), elementwise_of% NatTrans.naturality (D := A),
+        h]
 
 lemma isLocallyInjective_whisker_iff (hH : CoverPreserving J K H) [H.IsCocontinuous J K]
     [H.IsCoverDense K] : IsLocallyInjective J (whiskerLeft H.op f) ↔ IsLocallyInjective K f :=
@@ -62,8 +67,7 @@ lemma isLocallySurjective_of_whisker (hH : CoverPreserving J K H)
     intro Y g ⟨⟨Z, lift, map, fac⟩⟩
     rw [← fac, Sieve.pullback_comp]
     apply K.pullback_stable
-    have hh := hH.cover_preserve <|
-      imageSieve_mem J (whiskerLeft H.op f) ((forget A).map (G.map map.op) a)
+    have hh := hH.cover_preserve <| imageSieve_mem J (whiskerLeft H.op f) (G.map map.op a)
     refine K.superset_covering (Sieve.functorPullback_pushforward_le H _) ?_
     refine K.superset_covering (Sieve.functorPushforward_monotone H _ ?_) hh
     intro W q ⟨x, h⟩

--- a/Mathlib/CategoryTheory/Sites/PreservesSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesSheafification.lean
@@ -99,7 +99,6 @@ noncomputable def toPresheafToSheafCompComposeAndSheafify :
 variable [J.PreservesSheafification F]
 
 instance : IsIso (toPresheafToSheafCompComposeAndSheafify J F) := by
-  have : J.PreservesSheafification F := inferInstance
   rw [NatTrans.isIso_iff_isIso_app]
   intro X
   dsimp
@@ -249,12 +248,15 @@ variable {D E : Type*} [Category.{max v u} D] [Category.{max v u} E] (F : D ⥤ 
   [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ E]
   [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ F]
   [∀ (X : C) (W : J.Cover X) (P : Cᵒᵖ ⥤ D), PreservesLimit (W.index P).multicospan F]
-  [HasForget D] [HasForget E]
+  {FD : D → D → Type*} {CD : D → Type (max v u)} {FE : E → E → Type*} {CE : E → Type (max v u)}
+  [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)] [∀ X Y, FunLike (FE X Y) (CE X) (CE Y)]
+  [instCCD : ConcreteCategory D FD] [instCCE : ConcreteCategory E FE]
   [∀ X, PreservesColimitsOfShape (Cover J X)ᵒᵖ (forget D)]
   [∀ X, PreservesColimitsOfShape (Cover J X)ᵒᵖ (forget E)]
   [PreservesLimits (forget D)] [PreservesLimits (forget E)]
   [(forget D).ReflectsIsomorphisms] [(forget E).ReflectsIsomorphisms]
 
+include instCCD instCCE in
 lemma sheafToPresheaf_map_sheafComposeNatTrans_eq_sheafifyCompIso_inv (P : Cᵒᵖ ⥤ D) :
     (sheafToPresheaf J E).map
       ((sheafComposeNatTrans J F (plusPlusAdjunction J D) (plusPlusAdjunction J E)).app P) =
@@ -284,13 +286,16 @@ instance : PreservesSheafification J F := by
 
 end
 
-example {D : Type*} [Category.{max v u} D]
-  [HasForget.{max v u} D] [PreservesLimits (forget D)]
-  [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
-  [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)]
-  [∀ (α β : Type max u v) (fst snd : β → α),
-      Limits.HasLimitsOfShape (Limits.WalkingMulticospan fst snd) D]
-  [(forget D).ReflectsIsomorphisms] : PreservesSheafification J (forget D) := inferInstance
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
+example {D : Type*} [Category.{max v u} D] {FD : D → D → Type*} {CD : D → Type (max v u)}
+    [∀ X Y, FunLike (FD X Y) (CD X) (CD Y)] [ConcreteCategory.{max v u} D FD]
+    [PreservesLimits (forget D)]
+    [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
+    [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)]
+    [∀ (α β : Type max u v) (fst snd : β → α),
+        Limits.HasLimitsOfShape (Limits.WalkingMulticospan fst snd) D]
+    [(forget D).ReflectsIsomorphisms] : PreservesSheafification J (forget D) :=
+  instPreservesSheafification _ _
 
 end GrothendieckTopology
 

--- a/Mathlib/CategoryTheory/Sites/Pullback.lean
+++ b/Mathlib/CategoryTheory/Sites/Pullback.lean
@@ -105,7 +105,8 @@ variable {C : Type v₁} [SmallCategory C] {D : Type v₁} [SmallCategory D] (G 
   (J : GrothendieckTopology C) (K : GrothendieckTopology D)
 
 -- The favourable assumptions under which we have sheafification
-variable [HasForget.{v₁} A] [PreservesLimits (forget A)] [HasColimits A] [HasLimits A]
+variable {FA : A → A → Type*} {CA : A → Type v₁} [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)]
+variable [ConcreteCategory.{v₁} A FA] [PreservesLimits (forget A)] [HasColimits A] [HasLimits A]
   [PreservesFilteredColimits (forget A)] [(forget A).ReflectsIsomorphisms]
   [Functor.IsContinuous.{v₁} G J K]
 

--- a/Mathlib/CategoryTheory/Sites/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheaf.lean
@@ -73,11 +73,11 @@ presheaf of types given by sending U : C to Hom_{A}(E, P U) is a sheaf of types.
 def IsSheaf (P : Cᵒᵖ ⥤ A) : Prop :=
   ∀ E : A, Presieve.IsSheaf J (P ⋙ coyoneda.obj (op E))
 
-attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike in
 /-- Condition that a presheaf with values in a concrete category is separated for
 a Grothendieck topology. -/
-def IsSeparated (P : Cᵒᵖ ⥤ A) [HasForget A] : Prop :=
-  ∀ (X : C) (S : Sieve X) (_ : S ∈ J X) (x y : P.obj (op X)),
+def IsSeparated (P : Cᵒᵖ ⥤ A) {FA : A → A → Type*} {CA : A → Type*}
+    [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)] [ConcreteCategory A FA] : Prop :=
+  ∀ (X : C) (S : Sieve X) (_ : S ∈ J X) (x y : ToType (P.obj (op X))),
     (∀ (Y : C) (f : Y ⟶ X) (_ : S f), P.map f.op x = P.map f.op y) → x = y
 
 section LimitSheafCondition

--- a/Mathlib/CategoryTheory/Sites/Subsheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Subsheaf.lean
@@ -252,6 +252,7 @@ def imageMonoFactorization {F F' : Sheaf J (Type w)} (f : F ⟶ F') : Limits.Mon
   m := Sheaf.imageι f
   e := Sheaf.toImage f
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- The mono factorization given by `image_sheaf` for a morphism is an image. -/
 noncomputable def imageFactorization {F F' : Sheaf J (Type (max v u))} (f : F ⟶ F') :
     Limits.ImageFactorisation f where

--- a/Mathlib/CategoryTheory/Sites/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Sites/Whiskering.lean
@@ -141,13 +141,15 @@ instance hasSheafCompose_of_preservesLimitsOfSize [PreservesLimitsOfSize.{v₁, 
 
 variable {J}
 
-lemma Sheaf.isSeparated [HasForget A] [J.HasSheafCompose (forget A)]
+lemma Sheaf.isSeparated {FA : A → A → Type*} {CA : A → Type*}
+    [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)] [ConcreteCategory A FA] [J.HasSheafCompose (forget A)]
     (F : Sheaf J A) : Presheaf.IsSeparated J F.val := by
   rintro X S hS x y h
   exact (Presieve.isSeparated_of_isSheaf _ _ ((isSheaf_iff_isSheaf_of_type _ _).1
     ((sheafCompose J (forget A)).obj F).2) S hS).ext (fun _ _ hf => h _ _ hf)
 
-lemma Presheaf.IsSheaf.isSeparated {F : Cᵒᵖ ⥤ A} [HasForget A]
+lemma Presheaf.IsSheaf.isSeparated {F : Cᵒᵖ ⥤ A} {FA : A → A → Type*} {CA : A → Type*}
+    [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)] [ConcreteCategory A FA]
     [J.HasSheafCompose (forget A)] (hF : Presheaf.IsSheaf J F) :
     Presheaf.IsSeparated J F :=
   Sheaf.isSeparated ⟨F, hF⟩

--- a/Mathlib/Condensed/CartesianClosed.lean
+++ b/Mathlib/Condensed/CartesianClosed.lean
@@ -22,4 +22,5 @@ open CategoryTheory
 instance : ChosenFiniteProducts (CondensedSet.{u}) :=
   inferInstanceAs (ChosenFiniteProducts (Sheaf _ _))
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance : CartesianClosed (CondensedSet.{u}) := inferInstanceAs (CartesianClosed (Sheaf _ _))

--- a/Mathlib/Condensed/CartesianClosed.lean
+++ b/Mathlib/Condensed/CartesianClosed.lean
@@ -6,7 +6,6 @@ Authors: Dagur Asgeirsson
 import Mathlib.CategoryTheory.Closed.Types
 import Mathlib.CategoryTheory.Sites.CartesianClosed
 import Mathlib.Condensed.Basic
-import Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso
 import Mathlib.CategoryTheory.Sites.LeftExact
 /-!
 

--- a/Mathlib/Condensed/Discrete/Basic.lean
+++ b/Mathlib/Condensed/Discrete/Basic.lean
@@ -84,12 +84,14 @@ noncomputable def discreteUnderlyingAdj : discrete C ⊣ underlying C :=
 
 end LightCondensed
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- A version of `LightCondensed.discrete` in the `LightCondSet` namespace -/
 noncomputable abbrev LightCondSet.discrete := LightCondensed.discrete (Type u)
 
 /-- A version of `LightCondensed.underlying` in the `LightCondSet` namespace -/
 noncomputable abbrev LightCondSet.underlying := LightCondensed.underlying (Type u)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- A version of `LightCondensed.discrete_underlying_adj` in the `LightCondSet` namespace -/
 noncomputable abbrev LightCondSet.discreteUnderlyingAdj : discrete ⊣ underlying :=
   LightCondensed.discreteUnderlyingAdj _

--- a/Mathlib/Condensed/Discrete/Characterization.lean
+++ b/Mathlib/Condensed/Discrete/Characterization.lean
@@ -72,6 +72,7 @@ noncomputable abbrev LocallyConstant.adjunction :
 
 open Condensed
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 open CondensedSet.LocallyConstant List in
 theorem isDiscrete_tfae  (X : CondensedSet.{u}) :
     TFAE
@@ -111,6 +112,7 @@ namespace CondensedMod
 
 variable (R : Type (u+1)) [Ring R]
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma isDiscrete_iff_isDiscrete_forget (M : CondensedMod R) :
     M.IsDiscrete ↔ ((Condensed.forget R).obj M).IsDiscrete  :=
   Sheaf.isConstant_iff_forget (coherentTopology CompHaus)
@@ -195,6 +197,7 @@ noncomputable abbrev LocallyConstant.adjunction :
     LightCondSet.LocallyConstant.functor ⊣ LightCondensed.underlying (Type u) :=
   CompHausLike.LocallyConstant.adjunction _ _
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 open LightCondSet.LocallyConstant List in
 theorem isDiscrete_tfae  (X : LightCondSet.{u}) :
     TFAE
@@ -227,6 +230,7 @@ namespace LightCondMod
 
 variable (R : Type u) [Ring R]
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma isDiscrete_iff_isDiscrete_forget (M : LightCondMod R) :
     M.IsDiscrete ↔ ((LightCondensed.forget R).obj M).IsDiscrete  :=
   Sheaf.isConstant_iff_forget (coherentTopology LightProfinite)

--- a/Mathlib/Condensed/Discrete/LocallyConstant.lean
+++ b/Mathlib/Condensed/Discrete/LocallyConstant.lean
@@ -370,6 +370,7 @@ abbrev functor : Type (u+1) ⥤ CondensedSet.{u} :=
   CompHausLike.LocallyConstant.functor.{u, u+1} (P := fun _ ↦ True)
     (hs := fun _ _ _ ↦ ((CompHaus.effectiveEpi_tfae _).out 0 2).mp)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /--
 `CondensedSet.LocallyConstant.functor` is isomorphic to `Condensed.discrete`
 (by uniqueness of adjoints).
@@ -385,8 +386,10 @@ noncomputable instance : functor.Faithful := functorFullyFaithful.faithful
 
 noncomputable instance : functor.Full := functorFullyFaithful.full
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance : (discrete (Type _)).Faithful := Functor.Faithful.of_iso iso
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 noncomputable instance : (discrete (Type _)).Full := Functor.Full.of_iso iso
 
 end CondensedSet.LocallyConstant
@@ -404,6 +407,7 @@ instance (S : LightProfinite.{u}) (p : S → Prop) :
   ⟨⟨(inferInstance : TotallyDisconnectedSpace (Subtype p)),
     (inferInstance : SecondCountableTopology {s | p s})⟩⟩
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /--
 `LightCondSet.LocallyConstant.functor` is isomorphic to `LightCondensed.discrete`
 (by uniqueness of adjoints).
@@ -419,8 +423,10 @@ instance : functor.{u}.Faithful := functorFullyFaithful.faithful
 
 instance : LightCondSet.LocallyConstant.functor.Full := functorFullyFaithful.full
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance : (LightCondensed.discrete (Type u)).Faithful := Functor.Faithful.of_iso iso.{u}
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance : (LightCondensed.discrete (Type u)).Full := Functor.Full.of_iso iso.{u}
 
 end LightCondSet.LocallyConstant

--- a/Mathlib/Condensed/Discrete/Module.lean
+++ b/Mathlib/Condensed/Discrete/Module.lean
@@ -86,6 +86,7 @@ noncomputable def functorIsoDiscreteAux₂ (M : ModuleCat R) :
       (ModuleCat.of R (LocallyConstant (CompHaus.of PUnit.{u+1}) M)) :=
   (discrete _).mapIso (functorIsoDiscreteAux₁ R M)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance (M : ModuleCat R) : IsIso ((forget R).map
     ((discreteUnderlyingAdj (ModuleCat R)).counit.app ((functor R).obj M))) := by
   dsimp [Condensed.forget, discreteUnderlyingAdj]
@@ -158,9 +159,11 @@ instance : (discrete (ModuleCat R)).Full :=
 instance : (constantSheaf (coherentTopology CompHaus) (ModuleCat R)).Full :=
   inferInstanceAs (discrete (ModuleCat R)).Full
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance : (constantSheaf (coherentTopology CompHaus) (Type (u + 1))).Faithful :=
   inferInstanceAs (discrete (Type (u + 1))).Faithful
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance : (constantSheaf (coherentTopology CompHaus) (Type (u + 1))).Full :=
   inferInstanceAs (discrete (Type (u + 1))).Full
 
@@ -197,6 +200,7 @@ noncomputable def functorIsoDiscreteAux₂ (M : ModuleCat.{u} R) :
 instance : HasSheafify (coherentTopology LightProfinite.{u}) (ModuleCat.{u} R) :=
   inferInstance
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance (M : ModuleCat R) :
     IsIso ((LightCondensed.forget R).map
     ((discreteUnderlyingAdj (ModuleCat R)).counit.app
@@ -270,9 +274,11 @@ instance : (discrete (ModuleCat.{u} R)).Full :=
 instance : (constantSheaf (coherentTopology LightProfinite.{u}) (ModuleCat.{u} R)).Full :=
   inferInstanceAs (discrete.{u} (ModuleCat.{u} R)).Full
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance : (constantSheaf (coherentTopology LightProfinite) (Type u)).Faithful :=
   inferInstanceAs (discrete (Type u)).Faithful
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance : (constantSheaf (coherentTopology LightProfinite) (Type u)).Full :=
   inferInstanceAs (discrete (Type u)).Full
 

--- a/Mathlib/Condensed/Epi.lean
+++ b/Mathlib/Condensed/Epi.lean
@@ -21,11 +21,11 @@ universe v u w u' v'
 
 open CategoryTheory Sheaf Opposite Limits Condensed ConcreteCategory
 
-attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
-
 namespace Condensed
 
-variable (A : Type u') [Category.{v'} A] [HasForget.{v'} A]
+variable (A : Type u') [Category.{v'} A] {FA : A → A → Type*} {CA : A → Type v'}
+variable [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)] [ConcreteCategory.{v'} A FA]
+
   [HasFunctorialSurjectiveInjectiveFactorization A]
 
 variable {X Y : Condensed.{u} A} (f : X ⟶ Y)
@@ -37,8 +37,8 @@ variable
   [Balanced (Sheaf (coherentTopology CompHaus) A)]
   [PreservesFiniteProducts (CategoryTheory.forget A)] in
 lemma epi_iff_locallySurjective_on_compHaus : Epi f ↔
-    ∀ (S : CompHaus) (y : Y.val.obj ⟨S⟩),
-      (∃ (S' : CompHaus) (φ : S' ⟶ S) (_ : Function.Surjective φ) (x : X.val.obj ⟨S'⟩),
+    ∀ (S : CompHaus) (y : ToType (Y.val.obj ⟨S⟩)),
+      (∃ (S' : CompHaus) (φ : S' ⟶ S) (_ : Function.Surjective φ) (x : ToType (X.val.obj ⟨S'⟩)),
         f.val.app ⟨S'⟩ x = Y.val.map ⟨φ⟩ y) := by
   rw [← isLocallySurjective_iff_epi', coherentTopology.isLocallySurjective_iff,
     regularTopology.isLocallySurjective_iff]
@@ -64,12 +64,14 @@ namespace CondensedSet
 
 variable {X Y : CondensedSet.{u}} (f : X ⟶ Y)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma epi_iff_locallySurjective_on_compHaus : Epi f ↔
     ∀ (S : CompHaus) (y : Y.val.obj ⟨S⟩),
       (∃ (S' : CompHaus) (φ : S' ⟶ S) (_ : Function.Surjective φ) (x : X.val.obj ⟨S'⟩),
         f.val.app ⟨S'⟩ x = Y.val.map ⟨φ⟩ y) :=
   Condensed.epi_iff_locallySurjective_on_compHaus _ f
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma epi_iff_surjective_on_stonean : Epi f ↔
     ∀ (S : Stonean), Function.Surjective (f.val.app (op S.compHaus)) :=
   Condensed.epi_iff_surjective_on_stonean _ f
@@ -80,12 +82,14 @@ namespace CondensedMod
 
 variable (R : Type (u+1)) [Ring R] {X Y : CondensedMod.{u} R} (f : X ⟶ Y)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma epi_iff_locallySurjective_on_compHaus : Epi f ↔
     ∀ (S : CompHaus) (y : Y.val.obj ⟨S⟩),
       (∃ (S' : CompHaus) (φ : S' ⟶ S) (_ : Function.Surjective φ) (x : X.val.obj ⟨S'⟩),
         f.val.app ⟨S'⟩ x = Y.val.map ⟨φ⟩ y) :=
   Condensed.epi_iff_locallySurjective_on_compHaus _ f
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma epi_iff_surjective_on_stonean : Epi f ↔
     ∀ (S : Stonean), Function.Surjective (f.val.app (op S.compHaus)) :=
   have : HasLimitsOfSize.{u, u+1} (ModuleCat R) := hasLimitsOfSizeShrink.{u, u+1, u+1, u+1} _

--- a/Mathlib/Condensed/Light/CartesianClosed.lean
+++ b/Mathlib/Condensed/Light/CartesianClosed.lean
@@ -5,7 +5,6 @@ Authors: Dagur Asgeirsson
 -/
 import Mathlib.CategoryTheory.Closed.Types
 import Mathlib.CategoryTheory.Sites.CartesianClosed
-import Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso
 import Mathlib.CategoryTheory.Sites.Equivalence
 import Mathlib.Condensed.Light.Basic
 /-!

--- a/Mathlib/Condensed/Light/CartesianClosed.lean
+++ b/Mathlib/Condensed/Light/CartesianClosed.lean
@@ -24,4 +24,5 @@ variable {C : Type u} [SmallCategory C]
 instance : ChosenFiniteProducts (LightCondSet.{u}) :=
   inferInstanceAs (ChosenFiniteProducts (Sheaf _ _))
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance : CartesianClosed (LightCondSet.{u}) := inferInstanceAs (CartesianClosed (Sheaf _ _))

--- a/Mathlib/Condensed/Light/Epi.lean
+++ b/Mathlib/Condensed/Light/Epi.lean
@@ -21,18 +21,18 @@ universe v u w u' v'
 
 open CategoryTheory Sheaf Limits HasForget GrothendieckTopology
 
-attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
-
 namespace LightCondensed
 
-variable (A : Type u') [Category.{v'} A] [HasForget.{w} A]
+variable (A : Type u') [Category.{v'} A] {FA : A → A → Type*} {CA : A → Type w}
+variable [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)][ConcreteCategory.{w} A FA]
   [PreservesFiniteProducts (CategoryTheory.forget A)]
 
 variable {X Y : LightCondensed.{u} A} (f : X ⟶ Y)
 
 lemma isLocallySurjective_iff_locallySurjective_on_lightProfinite : IsLocallySurjective f ↔
-    ∀ (S : LightProfinite) (y : Y.val.obj ⟨S⟩),
-      (∃ (S' : LightProfinite) (φ : S' ⟶ S) (_ : Function.Surjective φ) (x : X.val.obj ⟨S'⟩),
+    ∀ (S : LightProfinite) (y : ToType (Y.val.obj ⟨S⟩)),
+      (∃ (S' : LightProfinite) (φ : S' ⟶ S) (_ : Function.Surjective φ)
+        (x : ToType (X.val.obj ⟨S'⟩)),
         f.val.app ⟨S'⟩ x = Y.val.map ⟨φ⟩ y) := by
   rw [coherentTopology.isLocallySurjective_iff,
     regularTopology.isLocallySurjective_iff]
@@ -44,6 +44,7 @@ namespace LightCondSet
 
 variable {X Y : LightCondSet.{u}} (f : X ⟶ Y)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma epi_iff_locallySurjective_on_lightProfinite : Epi f ↔
     ∀ (S : LightProfinite) (y : Y.val.obj ⟨S⟩),
       (∃ (S' : LightProfinite) (φ : S' ⟶ S) (_ : Function.Surjective φ) (x : X.val.obj ⟨S'⟩),
@@ -57,6 +58,7 @@ namespace LightCondMod
 
 variable (R : Type u) [Ring R] {X Y : LightCondMod.{u} R} (f : X ⟶ Y)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma epi_iff_locallySurjective_on_lightProfinite : Epi f ↔
     ∀ (S : LightProfinite) (y : Y.val.obj ⟨S⟩),
       (∃ (S' : LightProfinite) (φ : S' ⟶ S) (_ : Function.Surjective φ) (x : X.val.obj ⟨S'⟩),
@@ -64,11 +66,13 @@ lemma epi_iff_locallySurjective_on_lightProfinite : Epi f ↔
   rw [← isLocallySurjective_iff_epi']
   exact LightCondensed.isLocallySurjective_iff_locallySurjective_on_lightProfinite _ f
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance : (LightCondensed.forget R).ReflectsEpimorphisms where
   reflects f hf := by
     rw [← Sheaf.isLocallySurjective_iff_epi'] at hf ⊢
     exact (Presheaf.isLocallySurjective_iff_whisker_forget _ f.val).mpr hf
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance : (LightCondensed.forget R).PreservesEpimorphisms where
   preserves f hf := by
     rw [← Sheaf.isLocallySurjective_iff_epi'] at hf ⊢
@@ -82,6 +86,7 @@ variable (R : Type*) [Ring R]
 variable {F : ℕᵒᵖ ⥤ LightCondMod R} {c : Cone F} (hc : IsLimit c)
   (hF : ∀ n, Epi (F.map (homOfLE (Nat.le_succ n)).op))
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 include hc hF in
 lemma epi_π_app_zero_of_epi : Epi (c.π.app ⟨0⟩) := by
   apply Functor.epi_of_epi_map (forget R)

--- a/Mathlib/Geometry/RingedSpace/Basic.lean
+++ b/Mathlib/Geometry/RingedSpace/Basic.lean
@@ -92,29 +92,8 @@ theorem isUnit_res_of_isUnit_germ (U : Opens X) (f : X.presheaf.obj (op U)) (x :
   simp only [map_mul, map_one] at heq'
   simpa using isUnit_of_mul_eq_one _ _ heq'
 
-/-- Specialize `TopCat.Presheaf.germ_res_apply` to sheaves of rings.
-
-This is unfortunately needed because the results on presheaves are stated using the
-`HasForget.instFunLike` instance, which is not reducibly equal to the actual coercion of
-morphisms in `CommRingCat` to functions.
--/
-lemma _root_.CommRingCat.germ_res_apply
-    {X : TopCat} (F : Presheaf CommRingCat X)
-    {U V : Opens X} (i : U ⟶ V) (x : X) (hx : x ∈ U) (s) :
-    F.germ U x hx (F.map i.op s) = F.germ V x (i.le hx) s :=
-  F.germ_res_apply _ _ _ _
-
-/-- Specialize `TopCat.Presheaf.germ_res_apply'` to sheaves of rings.
-
-This is unfortunately needed because the results on presheaves are stated using the
-`HasForget.instFunLike` instance, which is not reducibly equal to the actual coercion of
-morphisms in `CommRingCat` to functions.
--/
-lemma _root_.CommRingCat.germ_res_apply'
-    {X : TopCat} (F : Presheaf CommRingCat X)
-    {U V : Opens X} (i : op V ⟶ op U) (x : X) (hx : x ∈ U) (s) :
-    F.germ U x hx (F.map i s) = F.germ V x (i.unop.le hx) s :=
-  F.germ_res_apply' _ _ _ _
+@[deprecated (since := "2025-02-08")] alias _root_.CommRingCat.germ_res_apply := germ_res_apply
+@[deprecated (since := "2025-02-08")] alias _root_.CommRingCat.germ_res_apply' := germ_res_apply'
 
 /-- If a section `f` is a unit in each stalk, `f` must be a unit. -/
 theorem isUnit_of_isUnit_germ (U : Opens X) (f : X.presheaf.obj (op U))
@@ -137,14 +116,14 @@ theorem isUnit_of_isUnit_germ (U : Opens X) (f : X.presheaf.obj (op U))
     -- Porting note: now need explicitly typing the rewrites
     -- note: this is bad, I think we should replace the `FunLike` on
     -- concrete category with `CoeFun`
-    rw [← CommRingCat.germ_res_apply X.presheaf (iVU x) z hzVx f]
+    rw [← germ_res_apply X.presheaf (iVU x) z hzVx f]
     -- Porting note: change was not necessary in Lean3
     change X.presheaf.germ _ z hzVx _ * (X.presheaf.germ _ z hzVx _) =
       X.presheaf.germ _ z hzVx _ * X.presheaf.germ _ z hzVy (g y)
     rw [← RingHom.map_mul,
       congr_arg (X.presheaf.germ (V x) z hzVx) (hg x),
-      CommRingCat.germ_res_apply X.presheaf _ _ _ f,
-      ← CommRingCat.germ_res_apply X.presheaf (iVU y) z hzVy f,
+      germ_res_apply X.presheaf _ _ _ f,
+      ← germ_res_apply X.presheaf (iVU y) z hzVy f,
       ← RingHom.map_mul,
       congr_arg (X.presheaf.germ (V y) z hzVy) (hg y), RingHom.map_one, RingHom.map_one]
   -- We claim that these local inverses glue together to a global inverse of `f`.
@@ -207,11 +186,11 @@ theorem basicOpen_res {U V : (Opens X)ᵒᵖ} (i : U ⟶ V) (f : X.presheaf.obj 
     @basicOpen X (unop V) (X.presheaf.map i f) = unop V ⊓ @basicOpen X (unop U) f := by
   ext x; constructor
   · rintro ⟨hxV, hx⟩
-    rw [CommRingCat.germ_res_apply' X.presheaf] at hx
+    rw [germ_res_apply' X.presheaf] at hx
     exact ⟨hxV, i.unop.le hxV, hx⟩
   · rintro ⟨hxV, _, hx⟩
     refine ⟨hxV, ?_⟩
-    rw [CommRingCat.germ_res_apply' X.presheaf]
+    rw [germ_res_apply' X.presheaf]
     exact hx
 
 -- This should fire before `basicOpen_res`.

--- a/Mathlib/Geometry/RingedSpace/LocallyRingedSpace/HasColimits.lean
+++ b/Mathlib/Geometry/RingedSpace/LocallyRingedSpace/HasColimits.lean
@@ -227,10 +227,9 @@ theorem coequalizer_π_stalk_isLocalHom (x : Y) :
   constructor
   rintro a ha
   rcases TopCat.Presheaf.germ_exist _ _ a with ⟨U, hU, s, rfl⟩
-  rw [← CommRingCat.forget_map_apply, forget_map_eq_coe,
-    PresheafedSpace.stalkMap_germ_apply
+  rw [-- Manually apply `elementwise_of%` to generate a `ConcreteCategory` lemma
+    elementwise_of% PresheafedSpace.stalkMap_germ
       (coequalizer.π (C := SheafedSpace _) f.toShHom g.toShHom) U _ hU] at ha
-  rw [coe_toHasForget_instFunLike]
   let V := imageBasicOpen f g U s
   have hV : (coequalizer.π f.toShHom g.toShHom).base ⁻¹'
       ((coequalizer.π f.toShHom g.toShHom).base '' V.1) = V.1 :=
@@ -243,7 +242,7 @@ theorem coequalizer_π_stalk_isLocalHom (x : Y) :
   have VleU : ⟨(coequalizer.π f.toShHom g.toShHom).base '' V.1, V_open⟩ ≤ U :=
     Set.image_subset_iff.mpr (Y.toRingedSpace.basicOpen_le _)
   have hxV : x ∈ V := ⟨hU, ha⟩
-  rw [← CommRingCat.germ_res_apply (coequalizer f.toShHom g.toShHom).presheaf (homOfLE VleU) _
+  rw [← (coequalizer f.toShHom g.toShHom).presheaf.germ_res_apply (homOfLE VleU) _
       (@Set.mem_image_of_mem _ _ (coequalizer.π f.toShHom g.toShHom).base x V.1 hxV) s]
   apply RingHom.isUnit_map
   rw [← isUnit_map_iff ((coequalizer.π f.toShHom g.toShHom :).c.app _).hom,

--- a/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
+++ b/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
@@ -713,12 +713,14 @@ end Pullback
 
 section OfStalkIso
 
-variable [HasLimits C] [HasColimits C] [HasForget C]
+variable [HasLimits C] [HasColimits C] {FC : C → C → Type*} {CC : C → Type v}
+variable [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)] [instCC : ConcreteCategory.{v} C FC]
 variable [(CategoryTheory.forget C).ReflectsIsomorphisms]
   [PreservesLimits (CategoryTheory.forget C)]
 
 variable [PreservesFilteredColimits (CategoryTheory.forget C)]
 
+include instCC in
 /-- Suppose `X Y : SheafedSpace C`, where `C` is a concrete category,
 whose forgetful functor reflects isomorphisms, preserves limits and filtered colimits.
 Then a morphism `X ⟶ Y` that is a topological open embedding

--- a/Mathlib/Geometry/RingedSpace/SheafedSpace.lean
+++ b/Mathlib/Geometry/RingedSpace/SheafedSpace.lean
@@ -209,14 +209,16 @@ instance [HasLimits C] : HasColimits.{v} (SheafedSpace C) :=
 noncomputable instance [HasLimits C] : PreservesColimits (forget.{_, _, v} C) :=
   Limits.comp_preservesColimits forgetToPresheafedSpace (PresheafedSpace.forget C)
 
-section HasForget
+section ConcreteCategory
 
-variable [HasForget.{v} C] [HasColimits C] [HasLimits C]
-variable  [PreservesLimits (CategoryTheory.forget C)]
+variable {FC : C → C → Type*} {CC : C → Type v} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+variable [instCC : ConcreteCategory.{v} C FC] [HasColimits C] [HasLimits C]
+variable [PreservesLimits (CategoryTheory.forget C)]
 variable [PreservesFilteredColimits (CategoryTheory.forget C)]
 variable [(CategoryTheory.forget C).ReflectsIsomorphisms]
 
-attribute [local instance] HasForget.instFunLike in
+attribute [local ext] DFunLike.ext in
+include instCC in
 lemma hom_stalk_ext {X Y : SheafedSpace C} (f g : X ⟶ Y) (h : f.base = g.base)
     (h' : ∀ x, f.stalkMap x = (Y.presheaf.stalkCongr (h ▸ rfl)).hom ≫ g.stalkMap x) :
     f = g := by
@@ -230,6 +232,8 @@ lemma hom_stalk_ext {X Y : SheafedSpace C} (f g : X ⟶ Y) (h : f.base = g.base)
   erw [← PresheafedSpace.stalkMap_germ_apply ⟨f, fc⟩, ← PresheafedSpace.stalkMap_germ_apply ⟨f, gc⟩]
   simp [h']
 
+attribute [local ext] DFunLike.ext in
+include instCC in
 lemma mono_of_base_injective_of_stalk_epi {X Y : SheafedSpace C} (f : X ⟶ Y)
     (h₁ : Function.Injective f.base)
     (h₂ : ∀ x, Epi (f.stalkMap x)) : Mono f := by
@@ -241,7 +245,7 @@ lemma mono_of_base_injective_of_stalk_epi {X Y : SheafedSpace C} (f : X ⟶ Y)
     ← PresheafedSpace.stalkMap.comp ⟨g, gc⟩ f, ← PresheafedSpace.stalkMap.comp ⟨g, hc⟩ f]
   congr 1
 
-end HasForget
+end ConcreteCategory
 
 end SheafedSpace
 

--- a/Mathlib/Topology/Sheaves/CommRingCat.lean
+++ b/Mathlib/Topology/Sheaves/CommRingCat.lean
@@ -90,9 +90,7 @@ section SubmonoidPresheaf
 
 open scoped nonZeroDivisors
 
-variable {X : TopCat.{w}} {C : Type u} [Category.{v} C] [HasForget C]
-
-attribute [local instance 1000] HasForget.hasCoeToSort HasForget.instFunLike
+variable {X : TopCat.{w}} {C : Type u} [Category.{v} C]
 
 -- note: this was specialized to `CommRingCat` in #19757
 /-- A subpresheaf with a submonoid structure on each of the components. -/

--- a/Mathlib/Topology/Sheaves/Functors.lean
+++ b/Mathlib/Topology/Sheaves/Functors.lean
@@ -75,8 +75,9 @@ variable {C}
 @[simp] lemma pushforward_map (f : X ⟶ Y) {F F' : X.Sheaf C} (α : F ⟶ F') :
     ((pushforward C f).map α).1 = (Presheaf.pushforward C f).map α.1 := rfl
 
-variable (A : Type*) [Category.{w} A] [HasForget.{w} A] [HasColimits A] [HasLimits A]
-variable [PreservesLimits (CategoryTheory.forget A)]
+variable (A : Type*) [Category.{w} A] {FA : A → A → Type*} {CA : A → Type w}
+variable [∀ X Y, FunLike (FA X Y) (CA X) (CA Y)] [ConcreteCategory.{w} A FA] [HasColimits A]
+variable [HasLimits A] [PreservesLimits (CategoryTheory.forget A)]
 variable [PreservesFilteredColimits (CategoryTheory.forget A)]
 variable [(CategoryTheory.forget A).ReflectsIsomorphisms]
 

--- a/Mathlib/Topology/Sheaves/LocalPredicate.lean
+++ b/Mathlib/Topology/Sheaves/LocalPredicate.lean
@@ -161,6 +161,7 @@ def subtype : subpresheafToTypes P ⟶ presheafToTypes X T where app _ f := f.1
 
 open TopCat.Presheaf
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- The functions satisfying a local predicate satisfy the sheaf condition.
 -/
 theorem isSheaf (P : LocalPredicate T) : (subpresheafToTypes P.toPrelocalPredicate).IsSheaf :=
@@ -173,7 +174,9 @@ theorem isSheaf (P : LocalPredicate T) : (subpresheafToTypes P.toPrelocalPredica
     have sf'_comp : (presheafToTypes X T).IsCompatible U sf' := fun i j =>
       congr_arg Subtype.val (sf_comp i j)
     -- So, we can obtain a unique gluing
-    obtain ⟨gl, gl_spec, gl_uniq⟩ := (sheafToTypes X T).existsUnique_gluing U sf' sf'_comp
+    obtain ⟨gl, gl_spec, gl_uniq⟩ := (sheafToTypes X T).existsUnique_gluing U sf'
+      -- `by exact` to help Lean infer the `ConcreteCategory` instance
+      (by exact sf'_comp)
     refine ⟨⟨gl, ?_⟩, ?_, ?_⟩
     · -- Our first goal is to show that this chosen gluing satisfies the
       -- predicate. Of course, we use locality of the predicate.

--- a/Mathlib/Topology/Sheaves/LocallySurjective.lean
+++ b/Mathlib/Topology/Sheaves/LocallySurjective.lean
@@ -29,9 +29,6 @@ We prove that these are equivalent.
 
 universe v u
 
-
-attribute [local instance] CategoryTheory.HasForget.instFunLike
-
 noncomputable section
 
 open CategoryTheory
@@ -46,7 +43,8 @@ section LocallySurjective
 
 open scoped AlgebraicGeometry
 
-variable {C : Type u} [Category.{v} C] [HasForget.{v} C] {X : TopCat.{v}}
+variable {C : Type u} [Category.{v} C] {FC : C → C → Type*} {CC : C → Type v}
+variable [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)] [ConcreteCategory C FC] {X : TopCat.{v}}
 variable {ℱ 𝒢 : X.Presheaf C}
 
 /-- A map of presheaves `T : ℱ ⟶ 𝒢` is **locally surjective** if for any open set `U`,
@@ -60,7 +58,7 @@ def IsLocallySurjective (T : ℱ ⟶ 𝒢) :=
 
 theorem isLocallySurjective_iff (T : ℱ ⟶ 𝒢) :
     IsLocallySurjective T ↔
-      ∀ (U t), ∀ x ∈ U, ∃ (V : _) (ι : V ⟶ U), (∃ s, T.app _ s = t |_ₕ ι) ∧ x ∈ V :=
+      ∀ (U t), ∀ x ∈ U, ∃ (V : _) (ι : V ⟶ U), (∃ s, (T.app _) s = t |_ₕ ι) ∧ x ∈ V :=
   ⟨fun h _ => h.imageSieve_mem, fun h => ⟨h _⟩⟩
 
 section SurjectiveOnStalks
@@ -86,10 +84,7 @@ theorem locally_surjective_iff_surjective_on_stalks (T : ℱ ⟶ 𝒢) :
     rcases hT.imageSieve_mem t x hxU with ⟨V, ι, ⟨s, h_eq⟩, hxV⟩
     -- Then the germ of s maps to g.
     use ℱ.germ _ x hxV s
-    -- Porting note: `convert` went too deep and swapped LHS and RHS of the remaining goal relative
-    -- to lean 3.
-    convert stalkFunctor_map_germ_apply V x hxV T s using 1
-    simpa [h_eq] using (germ_res_apply 𝒢 ι x hxV t).symm
+    simp [h_eq, germ_res_apply]
   · /- human proof:
         Let U be an open set, t ∈ Γ ℱ U a section, x ∈ U a point.
         By surjectivity on stalks, the germ of t is the image of
@@ -109,7 +104,7 @@ theorem locally_surjective_iff_surjective_on_stalks (T : ℱ ⟶ 𝒢) :
     obtain ⟨W, hxW, hWV, hWU, h_eq⟩ := key_W
     refine ⟨W, hWU, ⟨ℱ.map hWV.op s, ?_⟩, hxW⟩
     convert h_eq using 1
-    simp only [← CategoryTheory.comp_apply, T.naturality]
+    simp only [← ConcreteCategory.comp_apply, T.naturality]
 
 end SurjectiveOnStalks
 

--- a/Mathlib/Topology/Sheaves/MayerVietoris.lean
+++ b/Mathlib/Topology/Sheaves/MayerVietoris.lean
@@ -29,6 +29,8 @@ open CategoryTheory Limits TopologicalSpace
 
 variable {T : Type u} [TopologicalSpace T]
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory
+
 /-- A square consisting of opens `X₂ ⊓ X₃`, `X₂`, `X₃` and `X₂ ⊔ X₃` is
 a Mayer-Vietoris square. -/
 @[simps! toSquare]

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -61,9 +61,6 @@ lemma ext {X : TopCat} {P Q : Presheaf C X} {f g : P ⟶ Q}
   induction U with | _ U => ?_
   apply w
 
-attribute [local instance] CategoryTheory.HasForget.hasCoeToSort
-  CategoryTheory.HasForget.instFunLike
-
 /-- attribute `sheaf_restrict` to mark lemmas related to restricting sheaves -/
 macro "sheaf_restrict" : attr =>
   `(attr|aesop safe 50 apply (rule_sets := [$(Lean.mkIdent `Restrict):ident]))
@@ -98,46 +95,49 @@ example {X} [CompleteLattice X] (v : Nat → X) (w x y z : X) (e : v 0 = v 1) (_
     (h₀ : v 1 ≤ x) (_ : x ≤ z ⊓ w) (h₂ : x ≤ y ⊓ z) : v 0 ≤ y := by
   restrict_tac
 
+variable {X : TopCat} {C : Type*} [Category C] {FC : C → C → Type*} {CC : C → Type*}
+variable [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)] [ConcreteCategory C FC]
+
 /-- The restriction of a section along an inclusion of open sets.
 For `x : F.obj (op V)`, we provide the notation `x |_ₕ i` (`h` stands for `hom`) for `i : U ⟶ V`,
 and the notation `x |_ₗ U ⟪i⟫` (`l` stands for `le`) for `i : U ≤ V`.
 -/
-def restrict {X : TopCat} {C : Type*} [Category C] [HasForget C] {F : X.Presheaf C}
-    {V : Opens X} (x : F.obj (op V)) {U : Opens X} (h : U ⟶ V) : F.obj (op U) :=
+def restrict {F : X.Presheaf C}
+    {V : Opens X} (x : ToType (F.obj (op V))) {U : Opens X} (h : U ⟶ V) : ToType (F.obj (op U)) :=
   F.map h.op x
 
 /-- restriction of a section along an inclusion -/
 scoped[AlgebraicGeometry] infixl:80 " |_ₕ " => TopCat.Presheaf.restrict
 /-- restriction of a section along a subset relation -/
 scoped[AlgebraicGeometry] notation:80 x " |_ₗ " U " ⟪" e "⟫ " =>
-  @TopCat.Presheaf.restrict _ _ _ _ _ _ x U (@homOfLE (Opens _) _ U _ e)
+  @TopCat.Presheaf.restrict _ _ _ _ _ _ _ _ _ x U (@homOfLE (Opens _) _ U _ e)
 
 open AlgebraicGeometry
 
 /-- The restriction of a section along an inclusion of open sets.
 For `x : F.obj (op V)`, we provide the notation `x |_ U`, where the proof `U ≤ V` is inferred by
 the tactic `Top.presheaf.restrict_tac'` -/
-abbrev restrictOpen {X : TopCat} {C : Type*} [Category C] [HasForget C] {F : X.Presheaf C}
-    {V : Opens X} (x : F.obj (op V)) (U : Opens X)
+abbrev restrictOpen {F : X.Presheaf C}
+    {V : Opens X} (x : ToType (F.obj (op V))) (U : Opens X)
     (e : U ≤ V := by restrict_tac) :
-    F.obj (op U) :=
+    ToType (F.obj (op U)) :=
   x |_ₗ U ⟪e⟫
 
 /-- restriction of a section to open subset -/
 scoped[AlgebraicGeometry] infixl:80 " |_ " => TopCat.Presheaf.restrictOpen
 
-theorem restrict_restrict {X : TopCat} {C : Type*} [Category C] [HasForget C]
-    {F : X.Presheaf C} {U V W : Opens X} (e₁ : U ≤ V) (e₂ : V ≤ W) (x : F.obj (op W)) :
+theorem restrict_restrict
+    {F : X.Presheaf C} {U V W : Opens X} (e₁ : U ≤ V) (e₂ : V ≤ W) (x : ToType (F.obj (op W))) :
     x |_ V |_ U = x |_ U := by
   delta restrictOpen restrict
-  rw [← CategoryTheory.comp_apply, ← Functor.map_comp]
+  rw [← ConcreteCategory.comp_apply, ← Functor.map_comp]
   rfl
 
-theorem map_restrict {X : TopCat} {C : Type*} [Category C] [HasForget C]
-    {F G : X.Presheaf C} (e : F ⟶ G) {U V : Opens X} (h : U ≤ V) (x : F.obj (op V)) :
+theorem map_restrict
+    {F G : X.Presheaf C} (e : F ⟶ G) {U V : Opens X} (h : U ≤ V) (x : ToType (F.obj (op V))) :
     e.app _ (x |_ U) = e.app _ x |_ U := by
   delta restrictOpen restrict
-  rw [← CategoryTheory.comp_apply, NatTrans.naturality, CategoryTheory.comp_apply]
+  rw [← ConcreteCategory.comp_apply, NatTrans.naturality, ConcreteCategory.comp_apply]
 
 open CategoryTheory.Limits
 

--- a/Mathlib/Topology/Sheaves/SheafCondition/UniqueGluing.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/UniqueGluing.lean
@@ -40,7 +40,8 @@ open TopCat TopCat.Presheaf CategoryTheory CategoryTheory.Limits
 
 universe v u x
 
-variable {C : Type u} [Category.{v} C] [HasForget.{v} C]
+variable {C : Type u} [Category.{v} C] {FC : C → C → Type*} {CC : C → Type v}
+variable [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)] [ConcreteCategory.{v} C FC]
 
 namespace TopCat
 
@@ -48,20 +49,18 @@ namespace Presheaf
 
 section
 
-attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
-
 variable {X : TopCat.{x}} (F : Presheaf C X) {ι : Type x} (U : ι → Opens X)
 
 /-- A family of sections `sf` is compatible, if the restrictions of `sf i` and `sf j` to `U i ⊓ U j`
 agree, for all `i` and `j`
 -/
-def IsCompatible (sf : ∀ i : ι, F.obj (op (U i))) : Prop :=
+def IsCompatible (sf : ∀ i : ι, ToType (F.obj (op (U i)))) : Prop :=
   ∀ i j : ι, F.map (infLELeft (U i) (U j)).op (sf i) = F.map (infLERight (U i) (U j)).op (sf j)
 
 /-- A section `s` is a gluing for a family of sections `sf` if it restricts to `sf i` on `U i`,
 for all `i`
 -/
-def IsGluing (sf : ∀ i : ι, F.obj (op (U i))) (s : F.obj (op (iSup U))) : Prop :=
+def IsGluing (sf : ∀ i : ι, ToType (F.obj (op (U i)))) (s : ToType (F.obj (op (iSup U)))) : Prop :=
   ∀ i : ι, F.map (Opens.leSupr U i).op s = sf i
 
 /--
@@ -73,8 +72,8 @@ We prove this to be equivalent to the usual one below in
 `TopCat.Presheaf.isSheaf_iff_isSheafUniqueGluing`
 -/
 def IsSheafUniqueGluing : Prop :=
-  ∀ ⦃ι : Type x⦄ (U : ι → Opens X) (sf : ∀ i : ι, F.obj (op (U i))),
-    IsCompatible F U sf → ∃! s : F.obj (op (iSup U)), IsGluing F U sf s
+  ∀ ⦃ι : Type x⦄ (U : ι → Opens X) (sf : ∀ i : ι, ToType (F.obj (op (U i)))),
+    IsCompatible F U sf → ∃! s : ToType (F.obj (op (iSup U))), IsGluing F U sf s
 
 end
 
@@ -89,6 +88,7 @@ def objPairwiseOfFamily (sf : ∀ i, F.obj (op (U i))) :
   | ⟨Pairwise.single i⟩ => sf i
   | ⟨Pairwise.pair i j⟩ => F.map (infLELeft (U i) (U j)).op (sf i)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- Given a compatible family of sections over open sets, extend it to a
   section of the functor `(Pairwise.diagram U).op ⋙ F`. -/
 def IsCompatible.sectionPairwise {sf} (h : IsCompatible F U sf) :
@@ -101,6 +101,7 @@ def IsCompatible.sectionPairwise {sf} (h : IsCompatible F U sf) :
   · exact (h i' i).symm
   · exact congr_fun (G.map_id <| op <| Pairwise.pair i j) _
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 theorem isGluing_iff_pairwise {sf s} : IsGluing F U sf s ↔
     ∀ i, (F.mapCone (Pairwise.cocone U).op).π.app i s = objPairwiseOfFamily sf i := by
   refine ⟨fun h ↦ ?_, fun h i ↦ h (op <| Pairwise.single i)⟩
@@ -111,6 +112,7 @@ theorem isGluing_iff_pairwise {sf s} : IsGluing F U sf s ↔
 
 variable (F)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- For type-valued presheaves, the sheaf condition in terms of unique gluings is equivalent to the
 usual sheaf condition.
 -/
@@ -125,6 +127,7 @@ theorem isSheaf_iff_isSheafUniqueGluing_types : F.IsSheaf ↔ F.IsSheafUniqueGlu
     · rfl
     · exact (hs <| op <| Pairwise.Hom.left i j).symm
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- The usual sheaf condition can be obtained from the sheaf condition
 in terms of unique gluings.
 -/
@@ -157,43 +160,43 @@ open CategoryTheory
 
 section
 
-attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
-
 variable [HasLimits C] [(HasForget.forget (C := C)).ReflectsIsomorphisms]
 variable [PreservesLimits (HasForget.forget (C := C))]
 variable {X : TopCat.{v}} (F : Sheaf C X) {ι : Type v} (U : ι → Opens X)
 
 /-- A more convenient way of obtaining a unique gluing of sections for a sheaf.
 -/
-theorem existsUnique_gluing (sf : ∀ i : ι, F.1.obj (op (U i))) (h : IsCompatible F.1 U sf) :
-    ∃! s : F.1.obj (op (iSup U)), IsGluing F.1 U sf s :=
+theorem existsUnique_gluing (sf : ∀ i : ι, ToType (F.1.obj (op (U i))))
+    (h : IsCompatible F.1 U sf) :
+    ∃! s : ToType (F.1.obj (op (iSup U))), IsGluing F.1 U sf s :=
   (isSheaf_iff_isSheafUniqueGluing F.1).mp F.cond U sf h
 
 /-- In this version of the lemma, the inclusion homs `iUV` can be specified directly by the user,
 which can be more convenient in practice.
 -/
 theorem existsUnique_gluing' (V : Opens X) (iUV : ∀ i : ι, U i ⟶ V) (hcover : V ≤ iSup U)
-    (sf : ∀ i : ι, F.1.obj (op (U i))) (h : IsCompatible F.1 U sf) :
-    ∃! s : F.1.obj (op V), ∀ i : ι, F.1.map (iUV i).op s = sf i := by
+    (sf : ∀ i : ι, ToType (F.1.obj (op (U i)))) (h : IsCompatible F.1 U sf) :
+    ∃! s : ToType (F.1.obj (op V)), ∀ i : ι, F.1.map (iUV i).op s = sf i := by
   have V_eq_supr_U : V = iSup U := le_antisymm hcover (iSup_le fun i => (iUV i).le)
   obtain ⟨gl, gl_spec, gl_uniq⟩ := F.existsUnique_gluing U sf h
   refine ⟨F.1.map (eqToHom V_eq_supr_U).op gl, ?_, ?_⟩
   · intro i
-    rw [← CategoryTheory.comp_apply, ← F.1.map_comp]
+    rw [← ConcreteCategory.comp_apply, ← F.1.map_comp]
     exact gl_spec i
   · intro gl' gl'_spec
     convert congr_arg _ (gl_uniq (F.1.map (eqToHom V_eq_supr_U.symm).op gl') fun i => _) <;>
-      rw [← CategoryTheory.comp_apply, ← F.1.map_comp]
-    · rw [eqToHom_op, eqToHom_op, eqToHom_trans, eqToHom_refl, F.1.map_id, CategoryTheory.id_apply]
-    · convert gl'_spec i
+      rw [← ConcreteCategory.comp_apply, ← F.1.map_comp]
+    · rw [eqToHom_op, eqToHom_op, eqToHom_trans, eqToHom_refl, F.1.map_id,
+        ConcreteCategory.id_apply]
+    · exact gl'_spec i
 
 @[ext]
-theorem eq_of_locally_eq (s t : F.1.obj (op (iSup U)))
+theorem eq_of_locally_eq (s t : ToType (F.1.obj (op (iSup U))))
     (h : ∀ i, F.1.map (Opens.leSupr U i).op s = F.1.map (Opens.leSupr U i).op t) : s = t := by
-  let sf : ∀ i : ι, F.1.obj (op (U i)) := fun i => F.1.map (Opens.leSupr U i).op s
+  let sf : ∀ i : ι, ToType (F.1.obj (op (U i))) := fun i => F.1.map (Opens.leSupr U i).op s
   have sf_compatible : IsCompatible _ U sf := by
     intro i j
-    simp_rw [sf, ← CategoryTheory.comp_apply, ← F.1.map_comp]
+    simp_rw [sf, ← ConcreteCategory.comp_apply, ← F.1.map_comp]
     rfl
   obtain ⟨gl, -, gl_uniq⟩ := F.existsUnique_gluing U sf sf_compatible
   trans gl
@@ -209,19 +212,20 @@ theorem eq_of_locally_eq (s t : F.1.obj (op (iSup U)))
 which can be more convenient in practice.
 -/
 theorem eq_of_locally_eq' (V : Opens X) (iUV : ∀ i : ι, U i ⟶ V) (hcover : V ≤ iSup U)
-    (s t : F.1.obj (op V)) (h : ∀ i, F.1.map (iUV i).op s = F.1.map (iUV i).op t) : s = t := by
+    (s t : ToType (F.1.obj (op V))) (h : ∀ i, F.1.map (iUV i).op s = F.1.map (iUV i).op t) :
+    s = t := by
   have V_eq_supr_U : V = iSup U := le_antisymm hcover (iSup_le fun i => (iUV i).le)
   suffices F.1.map (eqToHom V_eq_supr_U.symm).op s = F.1.map (eqToHom V_eq_supr_U.symm).op t by
     convert congr_arg (F.1.map (eqToHom V_eq_supr_U).op) this <;>
-    rw [← CategoryTheory.comp_apply, ← F.1.map_comp, eqToHom_op, eqToHom_op, eqToHom_trans,
-      eqToHom_refl, F.1.map_id, CategoryTheory.id_apply]
+    rw [← ConcreteCategory.comp_apply, ← F.1.map_comp, eqToHom_op, eqToHom_op, eqToHom_trans,
+      eqToHom_refl, F.1.map_id, ConcreteCategory.id_apply]
   apply eq_of_locally_eq
   intro i
-  rw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply, ← F.1.map_comp]
-  convert h i
+  rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply, ← F.1.map_comp]
+  exact h i
 
 theorem eq_of_locally_eq₂ {U₁ U₂ V : Opens X} (i₁ : U₁ ⟶ V) (i₂ : U₂ ⟶ V) (hcover : V ≤ U₁ ⊔ U₂)
-    (s t : F.1.obj (op V)) (h₁ : F.1.map i₁.op s = F.1.map i₁.op t)
+    (s t : ToType (F.1.obj (op V))) (h₁ : F.1.map i₁.op s = F.1.map i₁.op t)
     (h₂ : F.1.map i₂.op s = F.1.map i₂.op t) : s = t := by
   classical
     fapply F.eq_of_locally_eq' fun t : ULift Bool => if t.1 then U₁ else U₂
@@ -229,8 +233,8 @@ theorem eq_of_locally_eq₂ {U₁ U₂ V : Opens X} (i₁ : U₁ ⟶ V) (i₂ : 
     · refine le_trans hcover ?_
       rw [sup_le_iff]
       constructor
-      · convert le_iSup (fun t : ULift Bool => if t.1 then U₁ else U₂) (ULift.up true)
-      · convert le_iSup (fun t : ULift Bool => if t.1 then U₁ else U₂) (ULift.up false)
+      · exact le_iSup (fun t : ULift Bool => if t.1 then U₁ else U₂) (ULift.up true)
+      · exact le_iSup (fun t : ULift Bool => if t.1 then U₁ else U₂) (ULift.up false)
     · rintro ⟨_ | _⟩
       any_goals exact h₁
       any_goals exact h₂

--- a/Mathlib/Topology/Sheaves/Sheafify.lean
+++ b/Mathlib/Topology/Sheaves/Sheafify.lean
@@ -42,6 +42,7 @@ namespace TopCat.Presheaf
 
 namespace Sheafify
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /--
 The prelocal predicate on functions into the stalks, asserting that the function is equal to a germ.
 -/
@@ -63,6 +64,7 @@ are locally equal to germs.
 def sheafify : Sheaf (Type v) X :=
   subsheafToTypes (Sheafify.isLocallyGerm F)
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 /-- The morphism from a presheaf to its sheafification,
 sending each section to its germs.
 (This forms the unit of the adjunction.)
@@ -81,6 +83,7 @@ In `sheafifyStalkIso` we show this is an isomorphism.
 def stalkToFiber (x : X) : F.sheafify.presheaf.stalk x ⟶ F.stalk x :=
   TopCat.stalkToFiber (Sheafify.isLocallyGerm F) x
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 theorem stalkToFiber_surjective (x : X) : Function.Surjective (F.stalkToFiber x) := by
   apply TopCat.stalkToFiber_surjective
   intro t
@@ -90,6 +93,7 @@ theorem stalkToFiber_surjective (x : X) : Function.Surjective (F.stalkToFiber x)
   · exact fun y => F.germ _ _ y.2 s
   · exact ⟨PrelocalPredicate.sheafifyOf ⟨s, fun _ => rfl⟩, rfl⟩
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 theorem stalkToFiber_injective (x : X) : Function.Injective (F.stalkToFiber x) := by
   apply TopCat.stalkToFiber_injective
   intro U V fU hU fV hV e

--- a/Mathlib/Topology/Sheaves/Stalks.lean
+++ b/Mathlib/Topology/Sheaves/Stalks.lean
@@ -110,21 +110,20 @@ lemma map_germ_eq_Γgerm (F : X.Presheaf C) {U : Opens X} {i : U ⟶ ⊤} (x : X
     F.map i.op ≫ F.germ U x hx = F.Γgerm x :=
   germ_res F i x hx
 
-attribute [local instance] HasForget.instFunLike in
+variable {FC : C → C → Type*} {CC : C → Type*} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+
 theorem germ_res_apply (F : X.Presheaf C)
-    {U V : Opens X} (i : U ⟶ V) (x : X) (hx : x ∈ U) [HasForget C] (s) :
+    {U V : Opens X} (i : U ⟶ V) (x : X) (hx : x ∈ U) [ConcreteCategory C FC] (s) :
     F.germ U x hx (F.map i.op s) = F.germ V x (i.le hx) s := by
-  rw [← CategoryTheory.comp_apply, germ_res]
+  rw [← ConcreteCategory.comp_apply, germ_res]
 
-attribute [local instance] HasForget.instFunLike in
 theorem germ_res_apply' (F : X.Presheaf C)
-    {U V : Opens X} (i : op V ⟶ op U) (x : X) (hx : x ∈ U) [HasForget C] (s) :
+    {U V : Opens X} (i : op V ⟶ op U) (x : X) (hx : x ∈ U) [ConcreteCategory C FC] (s) :
     F.germ U x hx (F.map i s) = F.germ V x (i.unop.le hx) s := by
-  rw [← CategoryTheory.comp_apply, germ_res']
+  rw [← ConcreteCategory.comp_apply, germ_res']
 
-attribute [local instance] HasForget.instFunLike in
 lemma Γgerm_res_apply (F : X.Presheaf C)
-    {U : Opens X} {i : U ⟶ ⊤} (x : X) (hx : x ∈ U) [HasForget C] (s) :
+    {U : Opens X} {i : U ⟶ ⊤} (x : X) (hx : x ∈ U) [ConcreteCategory C FC] (s) :
   F.germ U x hx (F.map i.op s) = F.Γgerm x s := F.germ_res_apply i x hx s
 
 /-- A morphism from the stalk of `F` at `x` to some object `Y` is completely determined by its
@@ -141,19 +140,18 @@ theorem stalkFunctor_map_germ {F G : X.Presheaf C} (U : Opens X) (x : X) (hx : x
     F.germ U x hx ≫ (stalkFunctor C x).map f = f.app (op U) ≫ G.germ U x hx :=
   colimit.ι_map (whiskerLeft (OpenNhds.inclusion x).op f) (op ⟨U, hx⟩)
 
-attribute [local instance] HasForget.instFunLike in
-theorem stalkFunctor_map_germ_apply [HasForget C]
+theorem stalkFunctor_map_germ_apply [ConcreteCategory C FC]
     {F G : X.Presheaf C} (U : Opens X) (x : X) (hx : x ∈ U) (f : F ⟶ G) (s) :
     (stalkFunctor C x).map f (F.germ U x hx s) = G.germ U x hx (f.app (op U) s) := by
-  rw [← CategoryTheory.comp_apply, ← stalkFunctor_map_germ]
-  exact (CategoryTheory.comp_apply _ _ _).symm
+  rw [← ConcreteCategory.comp_apply, ← stalkFunctor_map_germ, ConcreteCategory.comp_apply]
+  rfl
 
 -- a variant of `stalkFunctor_map_germ_apply` that makes simpNF happy.
-attribute [local instance] HasForget.instFunLike in
 @[simp]
-theorem stalkFunctor_map_germ_apply' [HasForget C]
+theorem stalkFunctor_map_germ_apply' [ConcreteCategory C FC]
     {F G : X.Presheaf C} (U : Opens X) (x : X) (hx : x ∈ U) (f : F ⟶ G) (s) :
-    DFunLike.coe (F := F.stalk x ⟶ G.stalk x) ((stalkFunctor C x).map f) (F.germ U x hx s) =
+    DFunLike.coe (F := ToHom (F.stalk x) (G.stalk x))
+        (ConcreteCategory.hom ((stalkFunctor C x).map f)) (F.germ U x hx s) =
       G.germ U x hx (f.app (op U) s) :=
   stalkFunctor_map_germ_apply U x hx f s
 
@@ -392,19 +390,18 @@ end stalkSpecializes
 
 section Concrete
 
-variable {C}
-variable [HasForget.{v} C]
-
-attribute [local instance] HasForget.hasCoeToSort HasForget.instFunLike
+variable {C} {CC : C → Type v} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
+variable [instCC : ConcreteCategory.{v} C FC]
 
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: @[ext] attribute only applies to structures or lemmas proving x = y
 -- @[ext]
 theorem germ_ext (F : X.Presheaf C) {U V : Opens X} {x : X} {hxU : x ∈ U} {hxV : x ∈ V}
-    (W : Opens X) (hxW : x ∈ W) (iWU : W ⟶ U) (iWV : W ⟶ V) {sU : F.obj (op U)} {sV : F.obj (op V)}
+    (W : Opens X) (hxW : x ∈ W) (iWU : W ⟶ U) (iWV : W ⟶ V)
+    {sU : ToType (F.obj (op U))} {sV : ToType (F.obj (op V))}
     (ih : F.map iWU.op sU = F.map iWV.op sV) :
       F.germ _ x hxU sU = F.germ _ x hxV sV := by
-  rw [← F.germ_res iWU x hxW, ← F.germ_res iWV x hxW, CategoryTheory.comp_apply,
-    CategoryTheory.comp_apply, ih]
+  rw [← F.germ_res iWU x hxW, ← F.germ_res iWV x hxW, ConcreteCategory.comp_apply,
+    ConcreteCategory.comp_apply, ih]
 
 variable [PreservesFilteredColimits (forget C)]
 
@@ -412,8 +409,8 @@ variable [PreservesFilteredColimits (forget C)]
 For presheaves valued in a concrete category whose forgetful functor preserves filtered colimits,
 every element of the stalk is the germ of a section.
 -/
-theorem germ_exist (F : X.Presheaf C) (x : X) (t : (stalk.{v, u} F x : Type v)) :
-    ∃ (U : Opens X) (m : x ∈ U) (s : F.obj (op U)), F.germ _ x m s = t := by
+theorem germ_exist (F : X.Presheaf C) (x : X) (t : ToType (stalk.{v, u} F x)) :
+    ∃ (U : Opens X) (m : x ∈ U) (s : ToType (F.obj (op U))), F.germ _ x m s = t := by
   obtain ⟨U, s, e⟩ :=
     Types.jointly_surjective.{v, v} _ (isColimitOfPreserves (forget C) (colimit.isColimit _)) t
   revert s e
@@ -423,11 +420,13 @@ theorem germ_exist (F : X.Presheaf C) (x : X) (t : (stalk.{v, u} F x : Type v)) 
   exact ⟨V, m, s, e⟩
 
 theorem germ_eq (F : X.Presheaf C) {U V : Opens X} (x : X) (mU : x ∈ U) (mV : x ∈ V)
-    (s : F.obj (op U)) (t : F.obj (op V)) (h : F.germ U x mU s = F.germ V x mV t) :
+    (s : ToType (F.obj (op U))) (t : ToType (F.obj (op V)))
+    (h : F.germ U x mU s = F.germ V x mV t) :
     ∃ (W : Opens X) (_m : x ∈ W) (iU : W ⟶ U) (iV : W ⟶ V), F.map iU.op s = F.map iV.op t := by
   obtain ⟨W, iU, iV, e⟩ :=
     (Types.FilteredColimit.isColimit_eq_iff.{v, v} _
-          (isColimitOfPreserves _ (colimit.isColimit ((OpenNhds.inclusion x).op ⋙ F)))).mp h
+          (isColimitOfPreserves (forget C) (colimit.isColimit ((OpenNhds.inclusion x).op ⋙ F)))).mp
+        h
   exact ⟨(unop W).1, (unop W).2, iU.unop, iV.unop, e⟩
 
 theorem stalkFunctor_map_injective_of_app_injective {F G : Presheaf C X} (f : F ⟶ G)
@@ -437,8 +436,8 @@ theorem stalkFunctor_map_injective_of_app_injective {F G : Presheaf C X} (f : F 
   rcases germ_exist F x t with ⟨U₂, hxU₂, t, rfl⟩
   rw [stalkFunctor_map_germ_apply, stalkFunctor_map_germ_apply] at hst
   obtain ⟨W, hxW, iWU₁, iWU₂, heq⟩ := G.germ_eq x hxU₁ hxU₂ _ _ hst
-  rw [← CategoryTheory.comp_apply, ← CategoryTheory.comp_apply, ← f.naturality, ← f.naturality,
-    CategoryTheory.comp_apply, CategoryTheory.comp_apply] at heq
+  rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply, ← f.naturality, ← f.naturality,
+    ConcreteCategory.comp_apply, ConcreteCategory.comp_apply] at heq
   replace heq := h W heq
   convert congr_arg (F.germ _ x hxW) heq using 1
   exacts [(F.germ_res_apply iWU₁ x hxW s).symm, (F.germ_res_apply iWU₂ x hxW t).symm]
@@ -448,7 +447,7 @@ variable [HasLimits C] [PreservesLimits (forget C)] [(forget C).ReflectsIsomorph
 /-- Let `F` be a sheaf valued in a concrete category, whose forgetful functor reflects isomorphisms,
 preserves limits and filtered colimits. Then two sections who agree on every stalk must be equal.
 -/
-theorem section_ext (F : Sheaf C X) (U : Opens X) (s t : F.1.obj (op U))
+theorem section_ext (F : Sheaf C X) (U : Opens X) (s t : ToType (F.1.obj (op U)))
     (h : ∀ (x : X) (hx : x ∈ U), F.presheaf.germ U x hx s = F.presheaf.germ U x hx t) : s = t := by
   -- We use `germ_eq` and the axiom of choice, to pick for every point `x` a neighbourhood
   -- `V x`, such that the restrictions of `s` and `t` to `V x` coincide.
@@ -481,7 +480,7 @@ theorem app_injective_iff_stalkFunctor_map_injective {F : Sheaf C X} {G : Preshe
     stalkFunctor_map_injective_of_app_injective f⟩
 
 instance stalkFunctor_preserves_mono (x : X) :
-    Functor.PreservesMonomorphisms (Sheaf.forget C X ⋙ stalkFunctor C x) :=
+    Functor.PreservesMonomorphisms (Sheaf.forget.{v} C X ⋙ stalkFunctor C x) :=
   ⟨@fun _𝓐 _𝓑 f _ =>
     ConcreteCategory.mono_of_injective _ <|
       (app_injective_iff_stalkFunctor_map_injective f.1).mpr
@@ -492,18 +491,22 @@ instance stalkFunctor_preserves_mono (x : X) :
               op c))
         x⟩
 
+include instCC in
 theorem stalk_mono_of_mono {F G : Sheaf C X} (f : F ⟶ G) [Mono f] :
     ∀ x, Mono <| (stalkFunctor C x).map f.1 :=
   fun x => Functor.map_mono (Sheaf.forget.{v} C X ⋙ stalkFunctor C x) f
 
+include instCC in
 theorem mono_of_stalk_mono {F G : Sheaf C X} (f : F ⟶ G) [∀ x, Mono <| (stalkFunctor C x).map f.1] :
     Mono f :=
   (Sheaf.Hom.mono_iff_presheaf_mono _ _ _).mpr <|
     (NatTrans.mono_iff_mono_app _).mpr fun U =>
       (ConcreteCategory.mono_iff_injective_of_preservesPullback _).mpr <|
         app_injective_of_stalkFunctor_map_injective f.1 U.unop fun _x _hx =>
-          (ConcreteCategory.mono_iff_injective_of_preservesPullback _).mp <| inferInstance
+          (ConcreteCategory.mono_iff_injective_of_preservesPullback
+            ((stalkFunctor C _).map f.val)).mp <| inferInstance
 
+include instCC in
 theorem mono_iff_stalk_mono {F G : Sheaf C X} (f : F ⟶ G) :
     Mono f ↔ ∀ x, Mono ((stalkFunctor C x).map f.1) :=
   ⟨fun _ => stalk_mono_of_mono _, fun _ => mono_of_stalk_mono _⟩
@@ -514,8 +517,8 @@ a neighborhood `V ≤ U` and a section `s : F.obj (op V))` such that `f.app (op 
 agree on `V`. -/
 theorem app_surjective_of_injective_of_locally_surjective {F G : Sheaf C X} (f : F ⟶ G)
     (U : Opens X) (hinj : ∀ x ∈ U, Function.Injective ((stalkFunctor C x).map f.1))
-    (hsurj : ∀ (t x) (_ : x ∈ U), ∃ (V : Opens X) (_ : x ∈ V) (iVU : V ⟶ U) (s : F.1.obj (op V)),
-          f.1.app (op V) s = G.1.map iVU.op t) :
+    (hsurj : ∀ (t x) (_ : x ∈ U), ∃ (V : Opens X) (_ : x ∈ V) (iVU : V ⟶ U)
+    (s : ToType (F.1.obj (op V))), f.1.app (op V) s = G.1.map iVU.op t) :
     Function.Surjective (f.1.app (op U)) := by
   conv at hsurj =>
     enter [t]
@@ -535,7 +538,7 @@ theorem app_surjective_of_injective_of_locally_surjective {F G : Sheaf C X} (f :
     · use s
       apply G.eq_of_locally_eq' V U iVU V_cover
       intro x
-      rw [← CategoryTheory.comp_apply, ← f.1.naturality, CategoryTheory.comp_apply, s_spec, heq]
+      rw [← ConcreteCategory.comp_apply, ← f.1.naturality, ConcreteCategory.comp_apply, s_spec, heq]
   intro x y
   -- What's left to show here is that the sections `sf` are compatible, i.e. they agree on
   -- the intersections `V x ⊓ V y`. We prove this by showing that all germs are equal.
@@ -545,8 +548,8 @@ theorem app_surjective_of_injective_of_locally_surjective {F G : Sheaf C X} (f :
   apply hinj z ((iVU x).le ((inf_le_left : V x ⊓ V y ≤ V x) hz))
   dsimp only
   rw [stalkFunctor_map_germ_apply, stalkFunctor_map_germ_apply]
-  simp_rw [← CategoryTheory.comp_apply, f.1.naturality, CategoryTheory.comp_apply, heq,
-    ← CategoryTheory.comp_apply, ← G.1.map_comp]
+  simp_rw [← ConcreteCategory.comp_apply, f.1.naturality, ConcreteCategory.comp_apply, heq,
+    ← ConcreteCategory.comp_apply, ← G.1.map_comp]
   rfl
 
 theorem app_surjective_of_stalkFunctor_map_bijective {F G : Sheaf C X} (f : F ⟶ G) (U : Opens X)
@@ -565,7 +568,7 @@ theorem app_surjective_of_stalkFunctor_map_bijective {F G : Sheaf C X} (f : F �
   obtain ⟨V₂, hxV₂, iV₂V₁, iV₂U, heq⟩ := G.presheaf.germ_eq x hxV₁ hx _ _ hs₁
   -- The restriction of `s₁` to that neighborhood is our desired local preimage.
   use V₂, hxV₂, iV₂U, F.1.map iV₂V₁.op s₁
-  rw [← CategoryTheory.comp_apply, f.1.naturality, CategoryTheory.comp_apply, heq]
+  rw [← ConcreteCategory.comp_apply, f.1.naturality, ConcreteCategory.comp_apply, heq]
 
 theorem app_bijective_of_stalkFunctor_map_bijective {F G : Sheaf C X} (f : F ⟶ G) (U : Opens X)
     (h : ∀ x ∈ U, Function.Bijective ((stalkFunctor C x).map f.1)) :
@@ -573,7 +576,8 @@ theorem app_bijective_of_stalkFunctor_map_bijective {F G : Sheaf C X} (f : F ⟶
   ⟨app_injective_of_stalkFunctor_map_injective f.1 U fun x hx => (h x hx).1,
     app_surjective_of_stalkFunctor_map_bijective f U h⟩
 
-theorem app_isIso_of_stalkFunctor_map_iso {F G : Sheaf C X} (f : F ⟶ G) (U : Opens X)
+include instCC in
+theorem app_isIso_of_stalkFunctor_map_iso  {F G : Sheaf C X} (f : F ⟶ G) (U : Opens X)
     [∀ x : U, IsIso ((stalkFunctor C x.val).map f.1)] : IsIso (f.1.app (op U)) := by
   -- Since the forgetful functor of `C` reflects isomorphisms, it suffices to see that the
   -- underlying map between types is an isomorphism, i.e. bijective.
@@ -585,6 +589,7 @@ theorem app_isIso_of_stalkFunctor_map_iso {F G : Sheaf C X} (f : F ⟶ G) (U : O
   apply (isIso_iff_bijective _).mp
   exact Functor.map_isIso (forget C) ((stalkFunctor C (⟨x, hx⟩ : U).1).map f.1)
 
+include instCC in
 -- Making this an instance would cause a loop in typeclass resolution with `Functor.map_isIso`
 /-- Let `F` and `G` be sheaves valued in a concrete category, whose forgetful functor reflects
 isomorphisms, preserves limits and filtered colimits. Then if the stalk maps of a morphism
@@ -601,6 +606,7 @@ theorem isIso_of_stalkFunctor_map_iso {F G : Sheaf C X} (f : F ⟶ G)
   intro U; induction U
   apply app_isIso_of_stalkFunctor_map_iso
 
+include instCC in
 /-- Let `F` and `G` be sheaves valued in a concrete category, whose forgetful functor reflects
 isomorphisms, preserves limits and filtered colimits. Then a morphism `f : F ⟶ G` is an
 isomorphism if and only if all of its stalk maps are isomorphisms.

--- a/MathlibTest/CategoryTheory/Sites/ConcreteSheafification.lean
+++ b/MathlibTest/CategoryTheory/Sites/ConcreteSheafification.lean
@@ -7,6 +7,8 @@ universe u
 
 open CategoryTheory
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory
+
 section Small
 
 variable {C : Type u} [SmallCategory C] (J : GrothendieckTopology C)

--- a/MathlibTest/CategoryTheory/Sites/PreservesSheafification.lean
+++ b/MathlibTest/CategoryTheory/Sites/PreservesSheafification.lean
@@ -7,6 +7,8 @@ universe u
 
 open CategoryTheory GrothendieckTopology
 
+attribute [local instance] Types.instFunLike Types.instConcreteCategory
+
 section Small
 
 variable {C : Type u} [SmallCategory C] (J : GrothendieckTopology C) (R : Type u) [Ring R]


### PR DESCRIPTION
This PR goes through all the files in `CategoryTheory/Sites` and `Topology/Sheaves` and replaces `HasForget` with `ConcreteCategory` so that we don't need to worry about `HasForget.instFunLike` or `HasForget.hasCoeToSort` mismatching with the actual coercions to functions/types.

Some sources of friction remain:

`Type` is not (globally) a `ConcreteCategory`, since to make it so needs to break the assumption that `forget Type` is reducibly defeq to the identity functor. The solution of this PR is to copy instances such as `PreservesLimits (forget Type)` over from the identity functor, and enabling the `ConcreteCategory` instance locally (see `CategoryTheory/Limits/ConcreteCategory/Basic.lean`). In the longer term I think we can enable that instance globally, but it would require quite some more downstream fixes.

Limits are still based on `HasForget`, so we have to insert some `show` and `rfl` to change the goal from one spelling to another. Similarly for `elementwise`-generated lemmas. This should go away once we update the rest of the files to the same standards.

Despite those uglifications mentioned above, I think the overall result is a clear improvement.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
