### PR TITLE
perf: separately define `WithBot.le` etc

### DIFF
--- a/Mathlib/Order/Interval/Basic.lean
+++ b/Mathlib/Order/Interval/Basic.lean
@@ -274,7 +274,7 @@ variable [LE α]
 
 -- Porting note: previously found using `deriving`
 instance : Inhabited (Interval α) := WithBot.inhabited
-instance : LE (Interval α) := WithBot.le
+instance : LE (Interval α) := WithBot.instLE
 instance : OrderBot (Interval α) := WithBot.orderBot
 
 instance : Coe (NonemptyInterval α) (Interval α) :=

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -177,12 +177,14 @@ section LE
 
 variable [LE α]
 
-instance (priority := 10) le : LE (WithBot α) :=
-  ⟨fun o₁ o₂ => ∀ a : α, o₁ = ↑a → ∃ b : α, o₂ = ↑b ∧ a ≤ b⟩
+def le (o₁ o₂ : WithBot α) := ∀ a : α, o₁ = ↑a → ∃ b : α, o₂ = ↑b ∧ a ≤ b
+
+instance (priority := 10) : LE (WithBot α) :=
+  ⟨le⟩
 
 @[simp, norm_cast]
 theorem coe_le_coe : (a : WithBot α) ≤ b ↔ a ≤ b := by
-  simp [LE.le]
+  simp [LE.le, le]
 
 instance orderBot : OrderBot (WithBot α) where
   bot_le _ := fun _ h => Option.noConfusion h
@@ -249,12 +251,13 @@ section LT
 
 variable [LT α]
 
-instance (priority := 10) lt : LT (WithBot α) :=
-  ⟨fun o₁ o₂ : WithBot α => ∃ b : α, o₂ = ↑b ∧ ∀ a : α, o₁ = ↑a → a < b⟩
+def lt (o₁ o₂ : WithBot α) := ∃ b : α, o₂ = ↑b ∧ ∀ a : α, o₁ = ↑a → a < b
+
+instance (priority := 10) : LT (WithBot α) := ⟨lt⟩
 
 @[simp, norm_cast]
 theorem coe_lt_coe : (a : WithBot α) < b ↔ a < b := by
-  simp [LT.lt]
+  simp [LT.lt, lt]
 
 @[simp]
 theorem bot_lt_coe (a : α) : ⊥ < (a : WithBot α) :=
@@ -312,11 +315,11 @@ theorem unbot'_lt_iff {a : WithBot α} {b c : α} (h : a = ⊥ → b < c) :
 end LT
 
 instance preorder [Preorder α] : Preorder (WithBot α) where
-  le := (· ≤ ·)
-  lt := (· < ·)
+  le := le
+  lt := lt
   lt_iff_le_not_le := by
     intros a b
-    cases a <;> cases b <;> simp [lt_iff_le_not_le]
+    cases a <;> cases b <;> simp [le, lt, lt_iff_le_not_le]
   le_refl _ a ha := ⟨a, ha, le_rfl⟩
   le_trans _ _ _ h₁ h₂ a ha :=
     let ⟨b, hb, ab⟩ := h₁ a ha
@@ -767,8 +770,9 @@ section LE
 
 variable [LE α]
 
-instance (priority := 10) le : LE (WithTop α) :=
-  ⟨fun o₁ o₂ => ∀ a : α, o₂ = ↑a → ∃ b : α, o₁ = ↑b ∧ b ≤ a⟩
+def le (o₁ o₂ : WithTop α) := ∀ a : α, o₂ = ↑a → ∃ b : α, o₁ = ↑b ∧ b ≤ a
+
+instance (priority := 10) : LE (WithTop α) := ⟨le⟩
 
 theorem toDual_le_iff {a : WithTop α} {b : WithBot αᵒᵈ} :
     WithTop.toDual a ≤ b ↔ WithBot.ofDual b ≤ a :=
@@ -825,8 +829,8 @@ protected theorem top_le_iff : ∀ {a : WithTop α}, ⊤ ≤ a ↔ a = ⊤
   | (a : α) => by simp [not_top_le_coe _]
   | ⊤ => by simp
 
-theorem le_coe : ∀ {o : Option α}, a ∈ o → (@LE.le (WithTop α) _ o b ↔ a ≤ b)
-  | _, rfl => coe_le_coe
+theorem le_coe {x : WithTop α} : ↑a = x → (x ≤ b ↔ a ≤ b)
+  | rfl => coe_le_coe
 
 theorem le_coe_iff {x : WithTop α} : x ≤ b ↔ ∃ a : α, x = a ∧ a ≤ b :=
   @WithBot.coe_le_iff (αᵒᵈ) _ _ (toDual x)
@@ -858,8 +862,9 @@ section LT
 
 variable [LT α]
 
-instance (priority := 10) lt : LT (WithTop α) :=
-  ⟨fun o₁ o₂ : Option α => ∃ b ∈ o₁, ∀ a ∈ o₂, b < a⟩
+def lt (o₁ o₂ : WithTop α) := ∃ b : α, o₁ = ↑b ∧ ∀ a : α, o₂ = ↑a → b < a
+
+instance (priority := 10) : LT (WithTop α) := ⟨lt⟩
 
 theorem toDual_lt_iff {a : WithTop α} {b : WithBot αᵒᵈ} :
     WithTop.toDual a < b ↔ WithBot.ofDual b < a :=
@@ -1085,8 +1090,8 @@ protected theorem lt_top_iff_ne_top {x : WithTop α} : x < ⊤ ↔ x ≠ ⊤ :=
 end LT
 
 instance preorder [Preorder α] : Preorder (WithTop α) where
-  le := (· ≤ ·)
-  lt := (· < ·)
+  le := le
+  lt := lt
   lt_iff_le_not_le := @lt_iff_le_not_le (WithBot αᵒᵈ)ᵒᵈ _
   le_refl := @le_refl (WithBot αᵒᵈ)ᵒᵈ _
   le_trans := @le_trans (WithBot αᵒᵈ)ᵒᵈ _

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -179,8 +179,7 @@ variable [LE α]
 
 def le (o₁ o₂ : WithBot α) := ∀ a : α, o₁ = ↑a → ∃ b : α, o₂ = ↑b ∧ a ≤ b
 
-instance (priority := 10) : LE (WithBot α) :=
-  ⟨le⟩
+instance (priority := 10) : LE (WithBot α) := ⟨le⟩
 
 @[simp, norm_cast]
 theorem coe_le_coe : (a : WithBot α) ≤ b ↔ a ≤ b := by

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -177,6 +177,7 @@ section LE
 
 variable [LE α]
 
+/-- The order on `WithBot α`: it inherits the order of `α`, and `⊥` is the smallest -/
 def le (o₁ o₂ : WithBot α) := ∀ a : α, o₁ = ↑a → ∃ b : α, o₂ = ↑b ∧ a ≤ b
 
 instance (priority := 10) : LE (WithBot α) := ⟨le⟩
@@ -250,6 +251,7 @@ section LT
 
 variable [LT α]
 
+/-- The order on `WithBot α`: it inherits the order of `α`, and `⊥` is the smallest -/
 def lt (o₁ o₂ : WithBot α) := ∃ b : α, o₂ = ↑b ∧ ∀ a : α, o₁ = ↑a → a < b
 
 instance (priority := 10) : LT (WithBot α) := ⟨lt⟩
@@ -769,6 +771,7 @@ section LE
 
 variable [LE α]
 
+/-- The order on `WithTop α`: it inherits the order of `α`, and `⊤` is the biggest -/
 def le (o₁ o₂ : WithTop α) := ∀ a : α, o₂ = ↑a → ∃ b : α, o₁ = ↑b ∧ b ≤ a
 
 instance (priority := 10) : LE (WithTop α) := ⟨le⟩
@@ -861,6 +864,7 @@ section LT
 
 variable [LT α]
 
+/-- The order on `WithTop α`: it inherits the order of `α`, and `⊤` is the biggest -/
 def lt (o₁ o₂ : WithTop α) := ∃ b : α, o₁ = ↑b ∧ ∀ a : α, o₂ = ↑a → b < a
 
 instance (priority := 10) : LT (WithTop α) := ⟨lt⟩


### PR DESCRIPTION
Testing if this gives a speedup in typeclass unification. Apparently it gives a local speedup, but in total is a slowdown

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
