### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology): notations X _⦋n⦌ and X ^⦋n⦌ for (co)simplicial objects

### DIFF
--- a/Mathlib/AlgebraicTopology/AlternatingFaceMapComplex.lean
+++ b/Mathlib/AlgebraicTopology/AlternatingFaceMapComplex.lean
@@ -61,7 +61,7 @@ variable (Y : SimplicialObject C)
 /-- The differential on the alternating face map complex is the alternate
 sum of the face maps -/
 @[simp]
-def objD (n : ℕ) : X _[n + 1] ⟶ X _[n] :=
+def objD (n : ℕ) : X _⦋n + 1⦌ ⟶ X _⦋n⦌ :=
   ∑ i : Fin (n + 2), (-1 : ℤ) ^ (i : ℕ) • X.δ i
 
 /-!
@@ -119,10 +119,10 @@ theorem d_squared (n : ℕ) : objD X (n + 1) ≫ objD X n = 0 := by
 
 /-- The alternating face map complex, on objects -/
 def obj : ChainComplex C ℕ :=
-  ChainComplex.of (fun n => X _[n]) (objD X) (d_squared X)
+  ChainComplex.of (fun n => X _⦋n⦌) (objD X) (d_squared X)
 
 @[simp]
-theorem obj_X (X : SimplicialObject C) (n : ℕ) : (AlternatingFaceMapComplex.obj X).X n = X _[n] :=
+theorem obj_X (X : SimplicialObject C) (n : ℕ) : (AlternatingFaceMapComplex.obj X).X n = X _⦋n⦌ :=
   rfl
 
 @[simp]
@@ -161,7 +161,7 @@ variable {C}
 
 @[simp]
 theorem alternatingFaceMapComplex_obj_X (X : SimplicialObject C) (n : ℕ) :
-    ((alternatingFaceMapComplex C).obj X).X n = X _[n] :=
+    ((alternatingFaceMapComplex C).obj X).X n = X _⦋n⦌ :=
   rfl
 
 @[simp]

--- a/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
@@ -10,7 +10,7 @@ import Mathlib.AlgebraicTopology.DoldKan.PInfty
 # Decomposition of the Q endomorphisms
 
 In this file, we obtain a lemma `decomposition_Q` which expresses
-explicitly the projection `(Q q).f (n+1) : X _[n+1] ⟶ X _[n+1]`
+explicitly the projection `(Q q).f (n+1) : X _⦋n+1⦌ ⟶ X _⦋n+1⦌`
 (`X : SimplicialObject C` with `C` a preadditive category) as
 a sum of terms which are postcompositions with degeneracies.
 
@@ -19,7 +19,7 @@ subcomplex of the alternating face map complex of `X` and show
 that it is a complement to the normalized Moore complex.)
 
 Then, we introduce an ad hoc structure `MorphComponents X n Z` which
-can be used in order to define morphisms `X _[n+1] ⟶ Z` using the
+can be used in order to define morphisms `X _⦋n+1⦌ ⟶ Z` using the
 decomposition provided by `decomposition_Q`. This shall play a critical
 role in the proof that the functor
 `N₁ : SimplicialObject C ⥤ Karoubi (ChainComplex C ℕ))`
@@ -48,7 +48,7 @@ simplicial abelian groups, any $(n+1)$-simplex $x$ can be decomposed as
 $x = x' + \sum (i=0}^{q-1} σ_{n-i}(y_i)$ where $x'$ is in the image of `P q` and
 the $y_i$ are in degree $n$. -/
 theorem decomposition_Q (n q : ℕ) :
-    ((Q q).f (n + 1) : X _[n + 1] ⟶ X _[n + 1]) =
+    ((Q q).f (n + 1) : X _⦋n + 1⦌ ⟶ X _⦋n + 1⦌) =
       ∑ i ∈ Finset.filter (fun i : Fin (n + 1) => (i : ℕ) < q) Finset.univ,
         (P i).f (n + 1) ≫ X.δ i.rev.succ ≫ X.σ (Fin.rev i) := by
   induction' q with q hq
@@ -83,19 +83,19 @@ variable (X)
 /-- The structure `MorphComponents` is an ad hoc structure that is used in
 the proof that `N₁ : SimplicialObject C ⥤ Karoubi (ChainComplex C ℕ))`
 reflects isomorphisms. The fields are the data that are needed in order to
-construct a morphism `X _[n+1] ⟶ Z` (see `φ`) using the decomposition of the
+construct a morphism `X _⦋n+1⦌ ⟶ Z` (see `φ`) using the decomposition of the
 identity given by `decomposition_Q n (n+1)`. -/
 @[ext]
 structure MorphComponents (n : ℕ) (Z : C) where
-  a : X _[n + 1] ⟶ Z
-  b : Fin (n + 1) → (X _[n] ⟶ Z)
+  a : X _⦋n + 1⦌ ⟶ Z
+  b : Fin (n + 1) → (X _⦋n⦌ ⟶ Z)
 
 namespace MorphComponents
 
 variable {X} {n : ℕ} {Z Z' : C} (f : MorphComponents X n Z) (g : X' ⟶ X) (h : Z ⟶ Z')
 
-/-- The morphism `X _[n+1] ⟶ Z` associated to `f : MorphComponents X n Z`. -/
-def φ {Z : C} (f : MorphComponents X n Z) : X _[n + 1] ⟶ Z :=
+/-- The morphism `X _⦋n+1⦌ ⟶ Z` associated to `f : MorphComponents X n Z`. -/
+def φ {Z : C} (f : MorphComponents X n Z) : X _⦋n + 1⦌ ⟶ Z :=
   PInfty.f (n + 1) ≫ f.a + ∑ i : Fin (n + 1), (P i).f (n + 1) ≫ X.δ i.rev.succ ≫
     f.b (Fin.rev i)
 
@@ -104,7 +104,7 @@ variable (X n)
 /-- the canonical `MorphComponents` whose associated morphism is the identity
 (see `F_id`) thanks to `decomposition_Q n (n+1)` -/
 @[simps]
-def id : MorphComponents X n (X _[n + 1]) where
+def id : MorphComponents X n (X _⦋n + 1⦌) where
   a := PInfty.f (n + 1)
   b i := X.σ i
 

--- a/Mathlib/AlgebraicTopology/DoldKan/Degeneracies.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Degeneracies.lean
@@ -35,7 +35,7 @@ namespace DoldKan
 
 variable {C : Type*} [Category C] [Preadditive C]
 
-theorem HigherFacesVanish.comp_σ {Y : C} {X : SimplicialObject C} {n b q : ℕ} {φ : Y ⟶ X _[n + 1]}
+theorem HigherFacesVanish.comp_σ {Y : C} {X : SimplicialObject C} {n b q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌}
     (v : HigherFacesVanish q φ) (hnbq : n + 1 = b + q) :
     HigherFacesVanish q
       (φ ≫

--- a/Mathlib/AlgebraicTopology/DoldKan/Equivalence.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Equivalence.lean
@@ -67,7 +67,7 @@ the isomorphism `N₂Γ₂ : Γ₂ ⋙ N₂ ≅ 𝟭 (Karoubi (ChainComplex C �
 
 The rest of the proof follows the strategy in the [original paper by Dold][dold1958]. We show
 that the functor `N₂` reflects isomorphisms in `NReflectsIso.lean`: this relies on a
-decomposition of the identity of `X _[n]` using `PInfty.f n` and degeneracies obtained in
+decomposition of the identity of `X _⦋n⦌` using `PInfty.f n` and degeneracies obtained in
 `Decomposition.lean`. Then, in `NCompGamma.lean`, we construct a natural transformation
 `Γ₂N₂.trans : N₂ ⋙ Γ₂ ⟶ 𝟭 (Karoubi (SimplicialObject C))`. It is shown that it is an
 isomorphism using the fact that `N₂` reflects isomorphisms, and because we can show

--- a/Mathlib/AlgebraicTopology/DoldKan/Faces.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Faces.lean
@@ -34,33 +34,33 @@ namespace DoldKan
 variable {C : Type*} [Category C] [Preadditive C]
 variable {X : SimplicialObject C}
 
-/-- A morphism `φ : Y ⟶ X _[n+1]` satisfies `HigherFacesVanish q φ`
+/-- A morphism `φ : Y ⟶ X _⦋n+1⦌` satisfies `HigherFacesVanish q φ`
 when the compositions `φ ≫ X.δ j` are `0` for `j ≥ max 1 (n+2-q)`. When `q ≤ n+1`,
 it basically means that the composition `φ ≫ X.δ j` are `0` for the `q` highest
 possible values of a nonzero `j`. Otherwise, when `q ≥ n+2`, all the compositions
 `φ ≫ X.δ j` for nonzero `j` vanish. See also the lemma `comp_P_eq_self_iff` in
 `Projections.lean` which states that `HigherFacesVanish q φ` is equivalent to
 the identity `φ ≫ (P q).f (n+1) = φ`. -/
-def HigherFacesVanish {Y : C} {n : ℕ} (q : ℕ) (φ : Y ⟶ X _[n + 1]) : Prop :=
+def HigherFacesVanish {Y : C} {n : ℕ} (q : ℕ) (φ : Y ⟶ X _⦋n + 1⦌) : Prop :=
   ∀ j : Fin (n + 1), n + 1 ≤ (j : ℕ) + q → φ ≫ X.δ j.succ = 0
 
 namespace HigherFacesVanish
 
 @[reassoc]
-theorem comp_δ_eq_zero {Y : C} {n : ℕ} {q : ℕ} {φ : Y ⟶ X _[n + 1]} (v : HigherFacesVanish q φ)
+theorem comp_δ_eq_zero {Y : C} {n : ℕ} {q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : HigherFacesVanish q φ)
     (j : Fin (n + 2)) (hj₁ : j ≠ 0) (hj₂ : n + 2 ≤ (j : ℕ) + q) : φ ≫ X.δ j = 0 := by
   obtain ⟨i, rfl⟩ := Fin.eq_succ_of_ne_zero hj₁
   apply v i
   simp only [Fin.val_succ] at hj₂
   omega
 
-theorem of_succ {Y : C} {n q : ℕ} {φ : Y ⟶ X _[n + 1]} (v : HigherFacesVanish (q + 1) φ) :
+theorem of_succ {Y : C} {n q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : HigherFacesVanish (q + 1) φ) :
     HigherFacesVanish q φ := fun j hj => v j (by simpa only [← add_assoc] using le_add_right hj)
 
-theorem of_comp {Y Z : C} {q n : ℕ} {φ : Y ⟶ X _[n + 1]} (v : HigherFacesVanish q φ) (f : Z ⟶ Y) :
+theorem of_comp {Y Z : C} {q n : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : HigherFacesVanish q φ) (f : Z ⟶ Y) :
     HigherFacesVanish q (f ≫ φ) := fun j hj => by rw [assoc, v j hj, comp_zero]
 
-theorem comp_Hσ_eq {Y : C} {n a q : ℕ} {φ : Y ⟶ X _[n + 1]} (v : HigherFacesVanish q φ)
+theorem comp_Hσ_eq {Y : C} {n a q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : HigherFacesVanish q φ)
     (hnaq : n = a + q) :
     φ ≫ (Hσ q).f (n + 1) =
       -φ ≫ X.δ ⟨a + 1, Nat.succ_lt_succ (Nat.lt_succ_iff.mpr (Nat.le.intro hnaq.symm))⟩ ≫
@@ -106,7 +106,7 @@ theorem comp_Hσ_eq {Y : C} {n a q : ℕ} {φ : Y ⟶ X _[n + 1]} (v : HigherFac
   /- the purpose of the following `simplif` is to create three subgoals in order
       to finish the proof -/
   have simplif :
-    ∀ a b c d e f : Y ⟶ X _[n + 1], b = f → d + e = 0 → c + a = 0 → a + b + (c + d + e) = f := by
+    ∀ a b c d e f : Y ⟶ X _⦋n + 1⦌, b = f → d + e = 0 → c + a = 0 → a + b + (c + d + e) = f := by
     intro a b c d e f h1 h2 h3
     rw [add_assoc c d e, h2, add_zero, add_comm a, add_assoc, add_comm a, h3, add_zero, h1]
   apply simplif
@@ -132,7 +132,7 @@ theorem comp_Hσ_eq {Y : C} {n a q : ℕ} {φ : Y ⟶ X _[n + 1]} (v : HigherFac
     congr 2
     ring
 
-theorem comp_Hσ_eq_zero {Y : C} {n q : ℕ} {φ : Y ⟶ X _[n + 1]} (v : HigherFacesVanish q φ)
+theorem comp_Hσ_eq_zero {Y : C} {n q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : HigherFacesVanish q φ)
     (hqn : n < q) : φ ≫ (Hσ q).f (n + 1) = 0 := by
   simp only [Hσ, Homotopy.nullHomotopicMap'_f (c_mk (n + 2) (n + 1) rfl) (c_mk (n + 1) n rfl)]
   rw [hσ'_eq_zero hqn (c_mk (n + 1) n rfl), comp_zero, zero_add]
@@ -159,7 +159,7 @@ theorem comp_Hσ_eq_zero {Y : C} {n q : ℕ} {φ : Y ⟶ X _[n + 1]} (v : Higher
       · simp only [Fin.pred, Fin.subNat, Nat.pred_eq_sub_one, Nat.succ_add_sub_one]
         omega
 
-theorem induction {Y : C} {n q : ℕ} {φ : Y ⟶ X _[n + 1]} (v : HigherFacesVanish q φ) :
+theorem induction {Y : C} {n q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : HigherFacesVanish q φ) :
     HigherFacesVanish (q + 1) (φ ≫ (𝟙 _ + Hσ q).f (n + 1)) := by
   intro j hj₁
   dsimp

--- a/Mathlib/AlgebraicTopology/DoldKan/Homotopies.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Homotopies.lean
@@ -87,7 +87,7 @@ theorem cs_down_0_not_rel_left (j : ℕ) : ¬c.Rel 0 j := by
 
 /-- The sequence of maps which gives the null homotopic maps `Hσ` that shall be in
 the inductive construction of the projections `P q : K[X] ⟶ K[X]` -/
-def hσ (q : ℕ) (n : ℕ) : X _[n] ⟶ X _[n + 1] :=
+def hσ (q : ℕ) (n : ℕ) : X _⦋n⦌ ⟶ X _⦋n + 1⦌ :=
   if n < q then 0 else (-1 : ℤ) ^ (n - q) • X.σ ⟨n - q, Nat.lt_succ_of_le (Nat.sub_le _ _)⟩
 
 /-- We can turn `hσ` into a datum that can be passed to `nullHomotopicMap'`. -/
@@ -95,13 +95,13 @@ def hσ' (q : ℕ) : ∀ n m, c.Rel m n → (K[X].X n ⟶ K[X].X m) := fun n m h
   hσ q n ≫ eqToHom (by congr)
 
 theorem hσ'_eq_zero {q n m : ℕ} (hnq : n < q) (hnm : c.Rel m n) :
-    (hσ' q n m hnm : X _[n] ⟶ X _[m]) = 0 := by
+    (hσ' q n m hnm : X _⦋n⦌ ⟶ X _⦋m⦌) = 0 := by
   simp only [hσ', hσ]
   split_ifs
   exact zero_comp
 
 theorem hσ'_eq {q n a m : ℕ} (ha : n = a + q) (hnm : c.Rel m n) :
-    (hσ' q n m hnm : X _[n] ⟶ X _[m]) =
+    (hσ' q n m hnm : X _⦋n⦌ ⟶ X _⦋m⦌) =
       ((-1 : ℤ) ^ a • X.σ ⟨a, Nat.lt_succ_iff.mpr (Nat.le.intro (Eq.symm ha))⟩) ≫
         eqToHom (by congr) := by
   simp only [hσ', hσ]
@@ -111,7 +111,7 @@ theorem hσ'_eq {q n a m : ℕ} (ha : n = a + q) (hnm : c.Rel m n) :
     congr
 
 theorem hσ'_eq' {q n a : ℕ} (ha : n = a + q) :
-    (hσ' q n (n + 1) rfl : X _[n] ⟶ X _[n + 1]) =
+    (hσ' q n (n + 1) rfl : X _⦋n⦌ ⟶ X _⦋n + 1⦌) =
       (-1 : ℤ) ^ a • X.σ ⟨a, Nat.lt_succ_iff.mpr (Nat.le.intro (Eq.symm ha))⟩ := by
   rw [hσ'_eq ha rfl, eqToHom_refl, comp_id]
 

--- a/Mathlib/AlgebraicTopology/DoldKan/HomotopyEquivalence.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/HomotopyEquivalence.lean
@@ -44,7 +44,7 @@ def homotopyQToZero (q : ℕ) : Homotopy (Q q : K[X] ⟶ _) 0 :=
   Homotopy.equivSubZero.toFun (homotopyPToId X q).symm
 
 theorem homotopyPToId_eventually_constant {q n : ℕ} (hqn : n < q) :
-    ((homotopyPToId X (q + 1)).hom n (n + 1) : X _[n] ⟶ X _[n + 1]) =
+    ((homotopyPToId X (q + 1)).hom n (n + 1) : X _⦋n⦌ ⟶ X _⦋n + 1⦌) =
       (homotopyPToId X q).hom n (n + 1) := by
   simp only [homotopyHσToZero, AlternatingFaceMapComplex.obj_X, Nat.add_eq, Homotopy.trans_hom,
     Homotopy.ofEq_hom, Pi.zero_apply, Homotopy.add_hom, Homotopy.compLeft_hom, add_zero,

--- a/Mathlib/AlgebraicTopology/DoldKan/PInfty.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/PInfty.lean
@@ -32,7 +32,7 @@ namespace DoldKan
 variable {C : Type*} [Category C] [Preadditive C] {X : SimplicialObject C}
 
 theorem P_is_eventually_constant {q n : ℕ} (hqn : n ≤ q) :
-    ((P (q + 1)).f n : X _[n] ⟶ _) = (P q).f n := by
+    ((P (q + 1)).f n : X _⦋n⦌ ⟶ _) = (P q).f n := by
   cases n with
   | zero => simp only [P_f_0_eq]
   | succ n =>
@@ -41,12 +41,12 @@ theorem P_is_eventually_constant {q n : ℕ} (hqn : n ≤ q) :
     exact (HigherFacesVanish.of_P q n).comp_Hσ_eq_zero (Nat.succ_le_iff.mp hqn)
 
 theorem Q_is_eventually_constant {q n : ℕ} (hqn : n ≤ q) :
-    ((Q (q + 1)).f n : X _[n] ⟶ _) = (Q q).f n := by
+    ((Q (q + 1)).f n : X _⦋n⦌ ⟶ _) = (Q q).f n := by
   simp only [Q, HomologicalComplex.sub_f_apply, P_is_eventually_constant hqn]
 
 /-- The endomorphism `PInfty : K[X] ⟶ K[X]` obtained from the `P q` by passing to the limit. -/
 noncomputable def PInfty : K[X] ⟶ K[X] :=
-  ChainComplex.ofHom _ _ _ _ _ _ (fun n => ((P n).f n : X _[n] ⟶ _)) fun n => by
+  ChainComplex.ofHom _ _ _ _ _ _ (fun n => ((P n).f n : X _⦋n⦌ ⟶ _)) fun n => by
     simpa only [← P_is_eventually_constant (show n ≤ n by rfl),
       AlternatingFaceMapComplex.obj_d_eq] using (P (n + 1) : K[X] ⟶ _).comm (n + 1) n
 
@@ -55,18 +55,18 @@ noncomputable def QInfty : K[X] ⟶ K[X] :=
   𝟙 _ - PInfty
 
 @[simp]
-theorem PInfty_f_0 : (PInfty.f 0 : X _[0] ⟶ X _[0]) = 𝟙 _ :=
+theorem PInfty_f_0 : (PInfty.f 0 : X _⦋0⦌ ⟶ X _⦋0⦌) = 𝟙 _ :=
   rfl
 
-theorem PInfty_f (n : ℕ) : (PInfty.f n : X _[n] ⟶ X _[n]) = (P n).f n :=
+theorem PInfty_f (n : ℕ) : (PInfty.f n : X _⦋n⦌ ⟶ X _⦋n⦌) = (P n).f n :=
   rfl
 
 @[simp]
-theorem QInfty_f_0 : (QInfty.f 0 : X _[0] ⟶ X _[0]) = 0 := by
+theorem QInfty_f_0 : (QInfty.f 0 : X _⦋0⦌ ⟶ X _⦋0⦌) = 0 := by
   dsimp [QInfty]
   simp only [sub_self]
 
-theorem QInfty_f (n : ℕ) : (QInfty.f n : X _[n] ⟶ X _[n]) = (Q n).f n :=
+theorem QInfty_f (n : ℕ) : (QInfty.f n : X _⦋n⦌ ⟶ X _⦋n⦌) = (Q n).f n :=
   rfl
 
 @[reassoc (attr := simp)]
@@ -80,7 +80,7 @@ theorem QInfty_f_naturality (n : ℕ) {X Y : SimplicialObject C} (f : X ⟶ Y) :
   Q_f_naturality n n f
 
 @[reassoc (attr := simp)]
-theorem PInfty_f_idem (n : ℕ) : (PInfty.f n : X _[n] ⟶ _) ≫ PInfty.f n = PInfty.f n := by
+theorem PInfty_f_idem (n : ℕ) : (PInfty.f n : X _⦋n⦌ ⟶ _) ≫ PInfty.f n = PInfty.f n := by
   simp only [PInfty_f, P_f_idem]
 
 @[reassoc (attr := simp)]
@@ -89,7 +89,7 @@ theorem PInfty_idem : (PInfty : K[X] ⟶ _) ≫ PInfty = PInfty := by
   exact PInfty_f_idem n
 
 @[reassoc (attr := simp)]
-theorem QInfty_f_idem (n : ℕ) : (QInfty.f n : X _[n] ⟶ _) ≫ QInfty.f n = QInfty.f n :=
+theorem QInfty_f_idem (n : ℕ) : (QInfty.f n : X _⦋n⦌ ⟶ _) ≫ QInfty.f n = QInfty.f n :=
   Q_f_idem _ _
 
 @[reassoc (attr := simp)]
@@ -98,7 +98,7 @@ theorem QInfty_idem : (QInfty : K[X] ⟶ _) ≫ QInfty = QInfty := by
   exact QInfty_f_idem n
 
 @[reassoc (attr := simp)]
-theorem PInfty_f_comp_QInfty_f (n : ℕ) : (PInfty.f n : X _[n] ⟶ _) ≫ QInfty.f n = 0 := by
+theorem PInfty_f_comp_QInfty_f (n : ℕ) : (PInfty.f n : X _⦋n⦌ ⟶ _) ≫ QInfty.f n = 0 := by
   dsimp only [QInfty]
   simp only [HomologicalComplex.sub_f_apply, HomologicalComplex.id_f, comp_sub, comp_id,
     PInfty_f_idem, sub_self]
@@ -109,7 +109,7 @@ theorem PInfty_comp_QInfty : (PInfty : K[X] ⟶ _) ≫ QInfty = 0 := by
   apply PInfty_f_comp_QInfty_f
 
 @[reassoc (attr := simp)]
-theorem QInfty_f_comp_PInfty_f (n : ℕ) : (QInfty.f n : X _[n] ⟶ _) ≫ PInfty.f n = 0 := by
+theorem QInfty_f_comp_PInfty_f (n : ℕ) : (QInfty.f n : X _⦋n⦌ ⟶ _) ≫ PInfty.f n = 0 := by
   dsimp only [QInfty]
   simp only [HomologicalComplex.sub_f_apply, HomologicalComplex.id_f, sub_comp, id_comp,
     PInfty_f_idem, sub_self]
@@ -124,7 +124,7 @@ theorem PInfty_add_QInfty : (PInfty : K[X] ⟶ _) + QInfty = 𝟙 _ := by
   dsimp only [QInfty]
   simp only [add_sub_cancel]
 
-theorem PInfty_f_add_QInfty_f (n : ℕ) : (PInfty.f n : X _[n] ⟶ _) + QInfty.f n = 𝟙 _ :=
+theorem PInfty_f_add_QInfty_f (n : ℕ) : (PInfty.f n : X _⦋n⦌ ⟶ _) + QInfty.f n = 𝟙 _ :=
   HomologicalComplex.congr_hom PInfty_add_QInfty n
 
 variable (C)

--- a/Mathlib/AlgebraicTopology/DoldKan/Projections.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Projections.lean
@@ -54,7 +54,7 @@ lemma P_succ (q : ℕ) : (P (q+1) : K[X] ⟶ K[X]) = P q ≫ (𝟙 _ + Hσ q) :=
 
 /-- All the `P q` coincide with `𝟙 _` in degree 0. -/
 @[simp]
-theorem P_f_0_eq (q : ℕ) : ((P q).f 0 : X _[0] ⟶ X _[0]) = 𝟙 _ := by
+theorem P_f_0_eq (q : ℕ) : ((P q).f 0 : X _⦋0⦌ ⟶ X _⦋0⦌) = 𝟙 _ := by
   induction' q with q hq
   · rfl
   · simp only [P_succ, HomologicalComplex.add_f_apply, HomologicalComplex.comp_f,
@@ -68,7 +68,7 @@ theorem P_add_Q (q : ℕ) : P q + Q q = 𝟙 K[X] := by
   rw [Q]
   abel
 
-theorem P_add_Q_f (q n : ℕ) : (P q).f n + (Q q).f n = 𝟙 (X _[n]) :=
+theorem P_add_Q_f (q n : ℕ) : (P q).f n + (Q q).f n = 𝟙 (X _⦋n⦌) :=
   HomologicalComplex.congr_hom (P_add_Q q) n
 
 @[simp]
@@ -81,21 +81,21 @@ theorem Q_succ (q : ℕ) : (Q (q + 1) : K[X] ⟶ _) = Q q - P q ≫ Hσ q := by
 
 /-- All the `Q q` coincide with `0` in degree 0. -/
 @[simp]
-theorem Q_f_0_eq (q : ℕ) : ((Q q).f 0 : X _[0] ⟶ X _[0]) = 0 := by
+theorem Q_f_0_eq (q : ℕ) : ((Q q).f 0 : X _⦋0⦌ ⟶ X _⦋0⦌) = 0 := by
   simp only [HomologicalComplex.sub_f_apply, HomologicalComplex.id_f, Q, P_f_0_eq, sub_self]
 
 namespace HigherFacesVanish
 
 /-- This lemma expresses the vanishing of
-`(P q).f (n+1) ≫ X.δ k : X _[n+1] ⟶ X _[n]` when `k≠0` and `k≥n-q+2` -/
-theorem of_P : ∀ q n : ℕ, HigherFacesVanish q ((P q).f (n + 1) : X _[n + 1] ⟶ X _[n + 1])
+`(P q).f (n+1) ≫ X.δ k : X _⦋n+1⦌ ⟶ X _⦋n⦌` when `k≠0` and `k≥n-q+2` -/
+theorem of_P : ∀ q n : ℕ, HigherFacesVanish q ((P q).f (n + 1) : X _⦋n + 1⦌ ⟶ X _⦋n + 1⦌)
   | 0 => fun n j hj₁ => by omega
   | q + 1 => fun n => by
     simp only [P_succ]
     exact (of_P q n).induction
 
 @[reassoc]
-theorem comp_P_eq_self {Y : C} {n q : ℕ} {φ : Y ⟶ X _[n + 1]} (v : HigherFacesVanish q φ) :
+theorem comp_P_eq_self {Y : C} {n q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : HigherFacesVanish q φ) :
     φ ≫ (P q).f (n + 1) = φ := by
   induction' q with q hq
   · simp only [P_zero]
@@ -115,7 +115,7 @@ theorem comp_P_eq_self {Y : C} {n q : ℕ} {φ : Y ⟶ X _[n + 1]} (v : HigherFa
 
 end HigherFacesVanish
 
-theorem comp_P_eq_self_iff {Y : C} {n q : ℕ} {φ : Y ⟶ X _[n + 1]} :
+theorem comp_P_eq_self_iff {Y : C} {n q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} :
     φ ≫ (P q).f (n + 1) = φ ↔ HigherFacesVanish q φ := by
   constructor
   · intro hφ
@@ -125,13 +125,13 @@ theorem comp_P_eq_self_iff {Y : C} {n q : ℕ} {φ : Y ⟶ X _[n + 1]} :
   · exact HigherFacesVanish.comp_P_eq_self
 
 @[reassoc (attr := simp)]
-theorem P_f_idem (q n : ℕ) : ((P q).f n : X _[n] ⟶ _) ≫ (P q).f n = (P q).f n := by
+theorem P_f_idem (q n : ℕ) : ((P q).f n : X _⦋n⦌ ⟶ _) ≫ (P q).f n = (P q).f n := by
   rcases n with (_|n)
   · rw [P_f_0_eq q, comp_id]
   · exact (HigherFacesVanish.of_P q n).comp_P_eq_self
 
 @[reassoc (attr := simp)]
-theorem Q_f_idem (q n : ℕ) : ((Q q).f n : X _[n] ⟶ _) ≫ (Q q).f n = (Q q).f n :=
+theorem Q_f_idem (q n : ℕ) : ((Q q).f n : X _⦋n⦌ ⟶ _) ≫ (Q q).f n = (Q q).f n :=
   idem_of_id_sub_idem _ (P_f_idem q n)
 
 @[reassoc (attr := simp)]

--- a/Mathlib/AlgebraicTopology/DoldKan/SplitSimplicialObject.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/SplitSimplicialObject.lean
@@ -79,7 +79,7 @@ theorem σ_comp_πSummand_id_eq_zero {n : ℕ} (i : Fin (n + 1)) :
   omega
 
 /-- If a simplicial object `X` in an additive category is split,
-then `PInfty` vanishes on all the summands of `X _[n]` which do
+then `PInfty` vanishes on all the summands of `X _⦋n⦌` which do
 not correspond to the identity of `⦋n⦌`. -/
 theorem cofan_inj_comp_PInfty_eq_zero {X : SimplicialObject C} (s : SimplicialObject.Splitting X)
     {n : ℕ} (A : SimplicialObject.Splitting.IndexSet (op ⦋n⦌)) (hA : ¬A.EqId) :
@@ -87,7 +87,7 @@ theorem cofan_inj_comp_PInfty_eq_zero {X : SimplicialObject C} (s : SimplicialOb
   rw [SimplicialObject.Splitting.IndexSet.eqId_iff_mono] at hA
   rw [SimplicialObject.Splitting.cofan_inj_eq, assoc, degeneracy_comp_PInfty X n A.e hA, comp_zero]
 
-theorem comp_PInfty_eq_zero_iff {Z : C} {n : ℕ} (f : Z ⟶ X _[n]) :
+theorem comp_PInfty_eq_zero_iff {Z : C} {n : ℕ} (f : Z ⟶ X _⦋n⦌) :
     f ≫ PInfty.f n = 0 ↔ f ≫ s.πSummand (IndexSet.id (op ⦋n⦌)) = 0 := by
   constructor
   · intro h

--- a/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
+++ b/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
@@ -16,7 +16,7 @@ import Mathlib.Tactic.FinCases
 In simplicial homotopy theory, in order to prove that the connected components
 of a simplicial set `X` are contractible, it suffices to construct an extra
 degeneracy as it is defined in *Simplicial Homotopy Theory* by Goerss-Jardine p. 190.
-It consists of a series of maps `π₀ X → X _[0]` and `X _[n] → X _[n+1]` which
+It consists of a series of maps `π₀ X → X _⦋0⦌` and `X _⦋n⦌ → X _⦋n+1⦌` which
 behave formally like an extra degeneracy `σ (-1)`. It can be thought as a datum
 associated to the augmented simplicial set `X → π₀ X`.
 
@@ -58,8 +58,8 @@ augmented simplicial objects. The morphisms `s'` and `s n` of the
 structure formally behave like extra degeneracies `σ (-1)`. -/
 @[ext]
 structure ExtraDegeneracy (X : SimplicialObject.Augmented C) where
-  s' : point.obj X ⟶ drop.obj X _[0]
-  s : ∀ n : ℕ, drop.obj X _[n] ⟶ drop.obj X _[n + 1]
+  s' : point.obj X ⟶ drop.obj X _⦋0⦌
+  s : ∀ n : ℕ, drop.obj X _⦋n⦌ ⟶ drop.obj X _⦋n + 1⦌
   s'_comp_ε : s' ≫ X.hom.app (op ⦋0⦌) = 𝟙 _
   s₀_comp_δ₁ : s 0 ≫ X.left.δ 1 = X.hom.app (op ⦋0⦌) ≫ s'
   s_comp_δ₀ : ∀ n : ℕ, s n ≫ X.left.δ 0 = 𝟙 _

--- a/Mathlib/AlgebraicTopology/Quasicategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/Basic.lean
@@ -58,7 +58,7 @@ instance (S : SSet) [KanComplex S] : Quasicategory S where
 lemma quasicategory_of_filler (S : SSet)
     (filler : ∀ ⦃n : ℕ⦄ ⦃i : Fin (n+3)⦄ (σ₀ : Λ[n+2, i] ⟶ S)
       (_h0 : 0 < i) (_hn : i < Fin.last (n+2)),
-      ∃ σ : S _[n+2], ∀ (j) (h : j ≠ i), S.δ j σ = σ₀.app _ (horn.face i j h)) :
+      ∃ σ : S _⦋n+2⦌, ∀ (j) (h : j ≠ i), S.δ j σ = σ₀.app _ (horn.face i j h)) :
     Quasicategory S where
   hornFilling' n i σ₀ h₀ hₙ := by
     obtain ⟨σ, h⟩ := filler σ₀ h₀ hₙ

--- a/Mathlib/AlgebraicTopology/Quasicategory/StrictSegal.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/StrictSegal.lean
@@ -61,8 +61,8 @@ instance quasicategory {X : SSet.{u}} [StrictSegal X] : Quasicategory X := by
       fin_cases i <;> contradiction
     /- We construct the triangle in the standard simplex as a 2-simplex in
     the horn. While the triangle is not contained in the inner horn `Λ[2, 1]`,
-    we can inhabit `Λ[n + 2, i] _[2]` by induction on `n`. -/
-    let triangle : Λ[n + 2, i] _[2] := by
+    we can inhabit `Λ[n + 2, i] _⦋2⦌` by induction on `n`. -/
+    let triangle : Λ[n + 2, i] _⦋2⦌ := by
       cases n with
       | zero => contradiction
       | succ _ => exact horn.primitiveTriangle i h₀ hₙ k (by omega)

--- a/Mathlib/AlgebraicTopology/SimplicialCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialCategory/Basic.lean
@@ -56,9 +56,9 @@ abbrev sHom (K L : C) : SSet.{v} := K ⟶[SSet] L
 /-- Abbreviation for the enriched composition in a simplicial category. -/
 abbrev sHomComp (K L M : C) : sHom K L ⊗ sHom L M ⟶ sHom K M := eComp SSet K L M
 
-/-- The bijection `(K ⟶ L) ≃ sHom K L _[0]` for all objects `K` and `L`
+/-- The bijection `(K ⟶ L) ≃ sHom K L _⦋0⦌` for all objects `K` and `L`
 in a simplicial category. -/
-def homEquiv' (K L : C) : (K ⟶ L) ≃ sHom K L _[0] :=
+def homEquiv' (K L : C) : (K ⟶ L) ≃ sHom K L _⦋0⦌ :=
   (eHomEquiv SSet).trans (sHom K L).unitHomEquiv
 
 variable (C) in

--- a/Mathlib/AlgebraicTopology/SimplicialNerve.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialNerve.lean
@@ -19,7 +19,7 @@ poset of subsets of the interval `[i, j]` in `J`, containing the endpoints.
 The simplicial nerve of a simplicial category `C` is then defined as the simplicial set whose
 `n`-simplices are given by the set of simplicial functors from the simplicial thickening of
 the linear order `Fin (n + 1)` to `C`, in other words
-`SimplicialNerve C _[n] := EnrichedFunctor SSet (SimplicialThickening (Fin (n + 1))) C`.
+`SimplicialNerve C _⦋n⦌ := EnrichedFunctor SSet (SimplicialThickening (Fin (n + 1))) C`.
 
 ## Projects
 

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -20,8 +20,8 @@ A simplicial object in a category `C` is a `C`-valued presheaf on `SimplexCatego
 
 The following notations can be enabled via `open Simplicial`.
 
-- `X _[n]` denotes the `n`-th term of a simplicial object `X`, where `n : ℕ`.
-- `X ^[n]` denotes the `n`-th term of a cosimplicial object `X`, where `n : ℕ`.
+- `X _⦋n⦌` denotes the `n`-th term of a simplicial object `X`, where `n : ℕ`.
+- `X ^⦋n⦌` denotes the `n`-th term of a cosimplicial object `X`, where `n : ℕ`.
 -/
 
 open Opposite
@@ -49,9 +49,9 @@ instance : Category (SimplicialObject C) := by
 namespace SimplicialObject
 
 set_option quotPrecheck false in
-/-- `X _[n]` denotes the `n`th-term of the simplicial object X -/
+/-- `X _⦋n⦌` denotes the `n`th-term of the simplicial object X -/
 scoped[Simplicial]
-  notation3:1000 X " _[" n "]" =>
+  notation3:1000 X " _⦋" n "⦌" =>
       (X : CategoryTheory.SimplicialObject _).obj (Opposite.op (SimplexCategory.mk n))
 
 open Simplicial
@@ -83,18 +83,18 @@ lemma hom_ext {X Y : SimplicialObject C} (f g : X ⟶ Y)
 variable (X : SimplicialObject C)
 
 /-- Face maps for a simplicial object. -/
-def δ {n} (i : Fin (n + 2)) : X _[n + 1] ⟶ X _[n] :=
+def δ {n} (i : Fin (n + 2)) : X _⦋n + 1⦌ ⟶ X _⦋n⦌ :=
   X.map (SimplexCategory.δ i).op
 
 /-- Degeneracy maps for a simplicial object. -/
-def σ {n} (i : Fin (n + 1)) : X _[n] ⟶ X _[n + 1] :=
+def σ {n} (i : Fin (n + 1)) : X _⦋n⦌ ⟶ X _⦋n + 1⦌ :=
   X.map (SimplexCategory.σ i).op
 
 /-- The diagonal of a simplex is the long edge of the simplex.-/
-def diagonal {n : ℕ} : X _[n] ⟶ X _[1] := X.map ((SimplexCategory.diag n).op)
+def diagonal {n : ℕ} : X _⦋n⦌ ⟶ X _⦋1⦌ := X.map ((SimplexCategory.diag n).op)
 
 /-- Isomorphisms from identities in ℕ. -/
-def eqToIso {n m : ℕ} (h : n = m) : X _[n] ≅ X _[m] :=
+def eqToIso {n m : ℕ} (h : n = m) : X _⦋n⦌ ≅ X _⦋m⦌ :=
   X.mapIso (CategoryTheory.eqToIso (by congr))
 
 @[simp]
@@ -394,7 +394,7 @@ def point : Augmented C ⥤ C :=
 @[simps]
 def toArrow : Augmented C ⥤ Arrow C where
   obj X :=
-    { left := drop.obj X _[0]
+    { left := drop.obj X _⦋0⦌
       right := point.obj X
       hom := X.hom.app _ }
   map η :=
@@ -452,7 +452,7 @@ end Augmented
 
 /-- Augment a simplicial object with an object. -/
 @[simps]
-def augment (X : SimplicialObject C) (X₀ : C) (f : X _[0] ⟶ X₀)
+def augment (X : SimplicialObject C) (X₀ : C) (f : X _⦋0⦌ ⟶ X₀)
     (w : ∀ (i : SimplexCategory) (g₁ g₂ : ⦋0⦌ ⟶ i),
       X.map g₁.op ≫ f = X.map g₂.op ≫ f) :
     SimplicialObject.Augmented C where
@@ -467,7 +467,7 @@ def augment (X : SimplicialObject C) (X₀ : C) (f : X _[0] ⟶ X₀)
         simpa only [← X.map_comp, ← Category.assoc, Category.comp_id, ← op_comp] using w _ _ _ }
 
 -- Porting note: removed @[simp] as the linter complains
-theorem augment_hom_zero (X : SimplicialObject C) (X₀ : C) (f : X _[0] ⟶ X₀) (w) :
+theorem augment_hom_zero (X : SimplicialObject C) (X₀ : C) (f : X _⦋0⦌ ⟶ X₀) (w) :
     (X.augment X₀ f w).hom.app (op ⦋0⦌) = f := by simp
 
 end SimplicialObject
@@ -483,9 +483,9 @@ instance : Category (CosimplicialObject C) := by
 
 namespace CosimplicialObject
 
-/-- `X ^[n]` denotes the `n`th-term of the cosimplicial object X -/
+/-- `X ^⦋n⦌` denotes the `n`th-term of the cosimplicial object X -/
 scoped[Simplicial]
-  notation3:1000 X " ^[" n "]" =>
+  notation3:1000 X " ^⦋" n "⦌" =>
     (X : CategoryTheory.CosimplicialObject _).obj (SimplexCategory.mk n)
 
 instance {J : Type v} [SmallCategory J] [HasLimitsOfShape J C] :
@@ -517,15 +517,15 @@ variable (X : CosimplicialObject C)
 open Simplicial
 
 /-- Coface maps for a cosimplicial object. -/
-def δ {n} (i : Fin (n + 2)) : X ^[n] ⟶ X ^[n + 1] :=
+def δ {n} (i : Fin (n + 2)) : X ^⦋n⦌ ⟶ X ^⦋n + 1⦌ :=
   X.map (SimplexCategory.δ i)
 
 /-- Codegeneracy maps for a cosimplicial object. -/
-def σ {n} (i : Fin (n + 1)) : X ^[n + 1] ⟶ X ^[n] :=
+def σ {n} (i : Fin (n + 1)) : X ^⦋n + 1⦌ ⟶ X ^⦋n⦌ :=
   X.map (SimplexCategory.σ i)
 
 /-- Isomorphisms from identities in ℕ. -/
-def eqToIso {n m : ℕ} (h : n = m) : X ^[n] ≅ X ^[m] :=
+def eqToIso {n m : ℕ} (h : n = m) : X ^⦋n⦌ ≅ X ^⦋m⦌ :=
   X.mapIso (CategoryTheory.eqToIso (by rw [h]))
 
 @[simp]
@@ -726,7 +726,7 @@ def point : Augmented C ⥤ C :=
 def toArrow : Augmented C ⥤ Arrow C where
   obj X :=
     { left := point.obj X
-      right := (drop.obj X) ^[0]
+      right := (drop.obj X) ^⦋0⦌
       hom := X.hom.app _ }
   map η :=
     { left := point.map η

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Split.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Split.lean
@@ -16,8 +16,8 @@ If `C` is a category that has finite coproducts, a splitting
 `s : Splitting X` of a simplicial object `X` in `C` consists
 of the datum of a sequence of objects `s.N : ℕ → C` (which
 we shall refer to as "nondegenerate simplices") and a
-sequence of morphisms `s.ι n : s.N n → X _[n]` that have
-the property that a certain canonical map identifies `X _[n]`
+sequence of morphisms `s.ι n : s.N n → X _⦋n⦌` that have
+the property that a certain canonical map identifies `X _⦋n⦌`
 with the coproduct of objects `s.N i` indexed by all possible
 epimorphisms `⦋n⦌ ⟶ ⦋i⦌` in `SimplexCategory`. (We do not
 assume that the morphisms `s.ι n` are monomorphisms: in the
@@ -182,7 +182,7 @@ theorem fac_pull : (A.pull θ).e ≫ image.ι (θ.unop ≫ A.e) = θ.unop ≫ A.
 
 end IndexSet
 
-variable (N : ℕ → C) (Δ : SimplexCategoryᵒᵖ) (X : SimplicialObject C) (φ : ∀ n, N n ⟶ X _[n])
+variable (N : ℕ → C) (Δ : SimplexCategoryᵒᵖ) (X : SimplicialObject C) (φ : ∀ n, N n ⟶ X _⦋n⦌)
 
 /-- Given a sequences of objects `N : ℕ → C` in a category `C`, this is
 a family of objects indexed by the elements `A : Splitting.IndexSet Δ`.
@@ -192,21 +192,21 @@ coproduct of objects in such a family. -/
 def summand (A : IndexSet Δ) : C :=
   N A.1.unop.len
 
-/-- The cofan for `summand N Δ` induced by morphisms `N n ⟶ X _[n]` for all `n : ℕ`. -/
+/-- The cofan for `summand N Δ` induced by morphisms `N n ⟶ X _⦋n⦌` for all `n : ℕ`. -/
 def cofan' (Δ : SimplexCategoryᵒᵖ) : Cofan (summand N Δ) :=
   Cofan.mk (X.obj Δ) (fun A => φ A.1.unop.len ≫ X.map A.e.op)
 
 end Splitting
 
 /-- A splitting of a simplicial object `X` consists of the datum of a sequence
-of objects `N`, a sequence of morphisms `ι : N n ⟶ X _[n]` such that
+of objects `N`, a sequence of morphisms `ι : N n ⟶ X _⦋n⦌` such that
 for all `Δ : SimplexCategoryᵒᵖ`, the canonical map `Splitting.map X ι Δ`
 is an isomorphism. -/
 structure Splitting (X : SimplicialObject C) where
   /-- The "nondegenerate simplices" `N n` for all `n : ℕ`. -/
   N : ℕ → C
-  /-- The "inclusion" `N n ⟶ X _[n]` for all `n : ℕ`. -/
-  ι : ∀ n, N n ⟶ X _[n]
+  /-- The "inclusion" `N n ⟶ X _⦋n⦌` for all `n : ℕ`. -/
+  ι : ∀ n, N n ⟶ X _⦋n⦌
   /-- For each `Δ`, `X.obj Δ` identifies to the coproduct of the objects `N A.1.unop.len`
   for all `A : IndexSet Δ`. -/
   isColimit' : ∀ Δ : SimplexCategoryᵒᵖ, IsColimit (Splitting.cofan' N X ι Δ)
@@ -232,9 +232,9 @@ theorem cofan_inj_id (n : ℕ) : (s.cofan _).inj (IndexSet.id (op ⦋n⦌)) = s.
 
 /-- As it is stated in `Splitting.hom_ext`, a morphism `f : X ⟶ Y` from a split
 simplicial object to any simplicial object is determined by its restrictions
-`s.φ f n : s.N n ⟶ Y _[n]` to the distinguished summands in each degree `n`. -/
+`s.φ f n : s.N n ⟶ Y _⦋n⦌` to the distinguished summands in each degree `n`. -/
 @[simp]
-def φ (f : X ⟶ Y) (n : ℕ) : s.N n ⟶ Y _[n] :=
+def φ (f : X ⟶ Y) (n : ℕ) : s.N n ⟶ Y _⦋n⦌ :=
   s.ι n ≫ f.app (op ⦋n⦌)
 
 @[reassoc (attr := simp)]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
@@ -162,66 +162,66 @@ abbrev Augmented :=
 section applications
 variable {S : SSet}
 
-lemma δ_comp_δ_apply {n} {i j : Fin (n + 2)} (H : i ≤ j) (x : S _[n + 2]) :
+lemma δ_comp_δ_apply {n} {i j : Fin (n + 2)} (H : i ≤ j) (x : S _⦋n + 2⦌) :
     S.δ i (S.δ j.succ x) = S.δ j (S.δ i.castSucc x) := congr_fun (S.δ_comp_δ H) x
 
 lemma δ_comp_δ'_apply {n} {i : Fin (n + 2)} {j : Fin (n + 3)} (H : Fin.castSucc i < j)
-    (x : S _[n + 2]) : S.δ i (S.δ j x) =
+    (x : S _⦋n + 2⦌) : S.δ i (S.δ j x) =
       S.δ (j.pred fun (hj : j = 0) => by simp [hj, Fin.not_lt_zero] at H) (S.δ i.castSucc x) :=
   congr_fun (S.δ_comp_δ' H) x
 
 lemma δ_comp_δ''_apply {n} {i : Fin (n + 3)} {j : Fin (n + 2)} (H : i ≤ Fin.castSucc j)
-    (x : S _[n + 2]) :
+    (x : S _⦋n + 2⦌) :
     S.δ (i.castLT (Nat.lt_of_le_of_lt (Fin.le_iff_val_le_val.mp H) j.is_lt)) (S.δ j.succ x) =
       S.δ j (S.δ i x) := congr_fun (S.δ_comp_δ'' H) x
 
-lemma δ_comp_δ_self_apply {n} {i : Fin (n + 2)} (x : S _[n + 2]) :
+lemma δ_comp_δ_self_apply {n} {i : Fin (n + 2)} (x : S _⦋n + 2⦌) :
     S.δ i (S.δ i.castSucc x) = S.δ i (S.δ i.succ x) := congr_fun S.δ_comp_δ_self x
 
 lemma δ_comp_δ_self'_apply {n} {i : Fin (n + 2)} {j : Fin (n + 3)} (H : j = Fin.castSucc i)
-    (x : S _[n + 2]) : S.δ i (S.δ j x) = S.δ i (S.δ i.succ x) := congr_fun (S.δ_comp_δ_self' H) x
+    (x : S _⦋n + 2⦌) : S.δ i (S.δ j x) = S.δ i (S.δ i.succ x) := congr_fun (S.δ_comp_δ_self' H) x
 
 lemma δ_comp_σ_of_le_apply {n} {i : Fin (n + 2)} {j : Fin (n + 1)} (H : i ≤ Fin.castSucc j)
-    (x : S _[n + 1]) :
+    (x : S _⦋n + 1⦌) :
     S.δ (Fin.castSucc i) (S.σ j.succ x) = S.σ j (S.δ i x) := congr_fun (S.δ_comp_σ_of_le H) x
 
 @[simp]
-lemma δ_comp_σ_self_apply {n} (i : Fin (n + 1)) (x : S _[n]) : S.δ i.castSucc (S.σ i x) = x :=
+lemma δ_comp_σ_self_apply {n} (i : Fin (n + 1)) (x : S _⦋n⦌) : S.δ i.castSucc (S.σ i x) = x :=
   congr_fun S.δ_comp_σ_self x
 
 lemma δ_comp_σ_self'_apply {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = Fin.castSucc i)
-    (x : S _[n]) : S.δ j (S.σ i x) = x := congr_fun (S.δ_comp_σ_self' H) x
+    (x : S _⦋n⦌) : S.δ j (S.σ i x) = x := congr_fun (S.δ_comp_σ_self' H) x
 
 @[simp]
-lemma δ_comp_σ_succ_apply {n} (i : Fin (n + 1)) (x : S _[n]) : S.δ i.succ (S.σ i x) = x :=
+lemma δ_comp_σ_succ_apply {n} (i : Fin (n + 1)) (x : S _⦋n⦌) : S.δ i.succ (S.σ i x) = x :=
   congr_fun S.δ_comp_σ_succ x
 
-lemma δ_comp_σ_succ'_apply {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = i.succ) (x : S _[n]) :
+lemma δ_comp_σ_succ'_apply {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = i.succ) (x : S _⦋n⦌) :
     S.δ j (S.σ i x) = x := congr_fun (S.δ_comp_σ_succ' H) x
 
 lemma δ_comp_σ_of_gt_apply {n} {i : Fin (n + 2)} {j : Fin (n + 1)} (H : Fin.castSucc j < i)
-    (x : S _[n + 1]) : S.δ i.succ (S.σ (Fin.castSucc j) x) = S.σ j (S.δ i x) :=
+    (x : S _⦋n + 1⦌) : S.δ i.succ (S.σ (Fin.castSucc j) x) = S.σ j (S.δ i x) :=
   congr_fun (S.δ_comp_σ_of_gt H) x
 
 lemma δ_comp_σ_of_gt'_apply {n} {i : Fin (n + 3)} {j : Fin (n + 2)} (H : j.succ < i)
-    (x : S _[n + 1]) : S.δ i (S.σ j x) =
+    (x : S _⦋n + 1⦌) : S.δ i (S.σ j x) =
       S.σ (j.castLT ((add_lt_add_iff_right 1).mp (lt_of_lt_of_le H i.is_le)))
         (S.δ (i.pred fun (hi : i = 0) => by simp only [Fin.not_lt_zero, hi] at H) x) :=
   congr_fun (S.δ_comp_σ_of_gt' H) x
 
-lemma σ_comp_σ_apply {n} {i j : Fin (n + 1)} (H : i ≤ j) (x : S _[n]) :
+lemma σ_comp_σ_apply {n} {i j : Fin (n + 1)} (H : i ≤ j) (x : S _⦋n⦌) :
     S.σ i.castSucc (S.σ j x) = S.σ j.succ (S.σ i x) := congr_fun (S.σ_comp_σ H) x
 
 variable {T : SSet} (f : S ⟶ T)
 
 open Opposite
 
-lemma δ_naturality_apply {n : ℕ} (i : Fin (n + 2)) (x : S _[n + 1]) :
+lemma δ_naturality_apply {n : ℕ} (i : Fin (n + 2)) (x : S _⦋n + 1⦌) :
     f.app (op ⦋n⦌) (S.δ i x) = T.δ i (f.app (op ⦋n + 1⦌) x) := by
   show (S.δ i ≫ f.app (op ⦋n⦌)) x = (f.app (op ⦋n + 1⦌) ≫ T.δ i) x
   exact congr_fun (SimplicialObject.δ_naturality f i) x
 
-lemma σ_naturality_apply {n : ℕ} (i : Fin (n + 1)) (x : S _[n]) :
+lemma σ_naturality_apply {n : ℕ} (i : Fin (n + 1)) (x : S _⦋n⦌) :
     f.app (op ⦋n + 1⦌) (S.σ i x) = T.σ i (f.app (op ⦋n⦌) x) := by
   show (S.σ i ≫ f.app (op ⦋n + 1⦌)) x = (f.app (op ⦋n⦌) ≫ T.σ i) x
   exact congr_fun (SimplicialObject.σ_naturality f i) x

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Coskeletal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Coskeletal.lean
@@ -64,7 +64,7 @@ Strict Segal, one can produce an `n`-simplex in `X`. -/
 @[simp]
 noncomputable def lift {X : SSet.{u}} [StrictSegal X] {n}
     (s : Cone (proj (op ⦋n⦌) (Truncated.inclusion 2).op ⋙
-      (Truncated.inclusion 2).op ⋙ X)) (x : s.pt) : X _[n] :=
+      (Truncated.inclusion 2).op ⋙ X)) (x : s.pt) : X _⦋n⦌ :=
   StrictSegal.spineToSimplex {
     vertex := fun i ↦ s.π.app (.mk (Y := op ⦋0⦌₂) (.op (SimplexCategory.const _ _ i))) x
     arrow := fun i ↦ s.π.app (.mk (Y := op ⦋1⦌₂) (.op (mkOfLe _ _ (Fin.castSucc_le_succ i)))) x

--- a/Mathlib/AlgebraicTopology/SimplicialSet/HomotopyCat.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/HomotopyCat.lean
@@ -39,16 +39,16 @@ universe v u
 
 section
 
-local macro:1000 (priority := high) X:term " _[" n:term "]₂" : term =>
+local macro:1000 (priority := high) X:term " _⦋" n:term "⦌₂" : term =>
     `(($X : SSet.Truncated 2).obj (Opposite.op ⟨SimplexCategory.mk $n, by decide⟩))
 
 set_option quotPrecheck false
 local macro:max (priority := high) "⦋" n:term "⦌₂" : term =>
   `((⟨SimplexCategory.mk $n, by decide⟩ : SimplexCategory.Truncated 2))
 
-/-- A 2-truncated simplicial set `S` has an underlying refl quiver with `S _[0]₂` as its underlying
+/-- A 2-truncated simplicial set `S` has an underlying refl quiver with `S _⦋0⦌₂` as its underlying
 type. -/
-def OneTruncation₂ (S : SSet.Truncated 2) := S _[0]₂
+def OneTruncation₂ (S : SSet.Truncated 2) := S _⦋0⦌₂
 
 /-- Abbreviations for face maps in the 2-truncated simplex category. -/
 abbrev δ₂ {n} (i : Fin (n + 2)) (hn := by decide) (hn' := by decide) :
@@ -64,12 +64,12 @@ lemma δ₂_zero_comp_σ₂_zero : δ₂ (0 : Fin 2) ≫ σ₂ 0 = 𝟙 _ := Sim
 @[reassoc (attr := simp)]
 lemma δ₂_one_comp_σ₂_zero : δ₂ (1 : Fin 2) ≫ σ₂ 0 = 𝟙 _ := SimplexCategory.δ_comp_σ_succ
 
-/-- The hom-types of the refl quiver underlying a simplicial set `S` are types of edges in `S _[1]₂`
+/-- The hom-types of the refl quiver underlying a simplicial set `S` are types of edges in `S _⦋1⦌₂`
 together with source and target equalities. -/
 @[ext]
 structure OneTruncation₂.Hom {S : SSet.Truncated 2} (X Y : OneTruncation₂ S) where
   /-- An arrow in `OneTruncation₂.Hom X Y` includes the data of a 1-simplex. -/
-  edge : S _[1]₂
+  edge : S _⦋1⦌₂
   /-- An arrow in `OneTruncation₂.Hom X Y` includes a source equality. -/
   src_eq : S.map (δ₂ 1).op edge = X
   /-- An arrow in `OneTruncation₂.Hom X Y` includes a target equality. -/
@@ -204,13 +204,13 @@ simplex category. -/
 def ι2₂ : ⦋0⦌₂ ⟶ ⦋2⦌₂ := δ₂ (n := 0) 0 ≫ δ₂ (n := 1) 1
 
 /-- The initial vertex of a 2-simplex in a 2-truncated simplicial set. -/
-def ev0₂ {V : SSet.Truncated 2} (φ : V _[2]₂) : OneTruncation₂ V := V.map ι0₂.op φ
+def ev0₂ {V : SSet.Truncated 2} (φ : V _⦋2⦌₂) : OneTruncation₂ V := V.map ι0₂.op φ
 
 /-- The middle vertex of a 2-simplex in a 2-truncated simplicial set. -/
-def ev1₂ {V : SSet.Truncated 2} (φ : V _[2]₂) : OneTruncation₂ V := V.map ι1₂.op φ
+def ev1₂ {V : SSet.Truncated 2} (φ : V _⦋2⦌₂) : OneTruncation₂ V := V.map ι1₂.op φ
 
 /-- The final vertex of a 2-simplex in a 2-truncated simplicial set. -/
-def ev2₂ {V : SSet.Truncated 2} (φ : V _[2]₂) : OneTruncation₂ V := V.map ι2₂.op φ
+def ev2₂ {V : SSet.Truncated 2} (φ : V _⦋2⦌₂) : OneTruncation₂ V := V.map ι2₂.op φ
 
 /-- The 0th face of a 2-simplex, as a morphism in the 2-truncated simplex category. -/
 def δ0₂ : ⦋1⦌₂ ⟶ ⦋2⦌₂ := δ₂ (n := 1) 0
@@ -223,19 +223,19 @@ def δ2₂ : ⦋1⦌₂ ⟶ ⦋2⦌₂ := δ₂ (n := 1) 2
 
 /-- The arrow in the ReflQuiver `OneTruncation₂ V` of a 2-truncated simplicial set arising from the
 0th face of a 2-simplex. -/
-def ev12₂ {V : SSet.Truncated 2} (φ : V _[2]₂) : ev1₂ φ ⟶ ev2₂ φ :=
+def ev12₂ {V : SSet.Truncated 2} (φ : V _⦋2⦌₂) : ev1₂ φ ⟶ ev2₂ φ :=
   ⟨V.map δ0₂.op φ,
     map_map_of_eq V (SimplexCategory.δ_comp_δ (i := 0) (j := 1) (by decide)).symm,
     map_map_of_eq V rfl⟩
 
 /-- The arrow in the ReflQuiver `OneTruncation₂ V` of a 2-truncated simplicial set arising from the
 1st face of a 2-simplex. -/
-def ev02₂ {V : SSet.Truncated 2} (φ : V _[2]₂) : ev0₂ φ ⟶ ev2₂ φ :=
+def ev02₂ {V : SSet.Truncated 2} (φ : V _⦋2⦌₂) : ev0₂ φ ⟶ ev2₂ φ :=
   ⟨V.map δ1₂.op φ, map_map_of_eq V rfl, map_map_of_eq V rfl⟩
 
 /-- The arrow in the ReflQuiver `OneTruncation₂ V` of a 2-truncated simplicial set arising from the
 2nd face of a 2-simplex. -/
-def ev01₂ {V : SSet.Truncated 2} (φ : V _[2]₂) : ev0₂ φ ⟶ ev1₂ φ :=
+def ev01₂ {V : SSet.Truncated 2} (φ : V _⦋2⦌₂) : ev0₂ φ ⟶ ev1₂ φ :=
   ⟨V.map δ2₂.op φ, map_map_of_eq V (SimplexCategory.δ_comp_δ (j := 1) le_rfl), map_map_of_eq V rfl⟩
 
 
@@ -243,7 +243,7 @@ def ev01₂ {V : SSet.Truncated 2} (φ : V _[2]₂) : ev0₂ φ ⟶ ev1₂ φ :=
 category on the underlying refl quiver of `V`. -/
 inductive HoRel₂ {V : SSet.Truncated 2} :
     (X Y : Cat.FreeRefl (OneTruncation₂ V)) → (f g : X ⟶ Y) → Prop
-  | mk (φ : V _[2]₂) :
+  | mk (φ : V _⦋2⦌₂) :
     HoRel₂ _ _
       (Quot.mk _ (Quiver.Hom.toPath (ev02₂ φ)))
       (Quot.mk _ ((Quiver.Hom.toPath (ev01₂ φ)).comp
@@ -251,7 +251,7 @@ inductive HoRel₂ {V : SSet.Truncated 2} :
 
 /-- A 2-simplex whose faces are identified with certain arrows in `OneTruncation₂ V` defines
 a term of type `HoRel₂` between those arrows. -/
-theorem HoRel₂.mk' {V : SSet.Truncated 2} (φ : V _[2]₂) {X₀ X₁ X₂ : OneTruncation₂ V}
+theorem HoRel₂.mk' {V : SSet.Truncated 2} (φ : V _⦋2⦌₂) {X₀ X₁ X₂ : OneTruncation₂ V}
     (f₀₁ : X₀ ⟶ X₁) (f₁₂ : X₁ ⟶ X₂) (f₀₂ : X₀ ⟶ X₂)
     (h₀₁ : f₀₁.edge = V.map (δ₂ 2).op φ) (h₁₂ : f₁₂.edge = V.map (δ₂ 0).op φ)
     (h₀₂ : f₀₂.edge = V.map (δ₂ 1).op φ) :

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Horn.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Horn.lean
@@ -59,7 +59,7 @@ def const (n : ℕ) (i k : Fin (n+3)) (m : SimplexCategoryᵒᵖ) : Λ[n+2, i].o
 
 This edge only exists if `{i, a, b}` has cardinality less than `n`. -/
 @[simps]
-def edge (n : ℕ) (i a b : Fin (n+1)) (hab : a ≤ b) (H : #{i, a, b} ≤ n) : Λ[n, i] _[1] := by
+def edge (n : ℕ) (i a b : Fin (n+1)) (hab : a ≤ b) (H : #{i, a, b} ≤ n) : Λ[n, i] _⦋1⦌ := by
   refine ⟨stdSimplex.edge n a b hab, ?range⟩
   case range =>
     suffices ∃ x, ¬i = x ∧ ¬a = x ∧ ¬b = x by
@@ -77,7 +77,7 @@ def edge (n : ℕ) (i a b : Fin (n+1)) (hab : a ≤ b) (H : #{i, a, b} ≤ n) : 
 assuming `3 ≤ n`. -/
 @[simps!]
 def edge₃ (n : ℕ) (i a b : Fin (n+1)) (hab : a ≤ b) (H : 3 ≤ n) :
-    Λ[n, i] _[1] :=
+    Λ[n, i] _⦋1⦌ :=
   horn.edge n i a b hab <| Finset.card_le_three.trans H
 
 /-- The edge of `Λ[n, i]` with endpoints `j` and `j+1`.
@@ -87,7 +87,7 @@ which is the type of horn that occurs in the horn-filling condition of quasicate
 @[simps!]
 def primitiveEdge {n : ℕ} {i : Fin (n+1)}
     (h₀ : 0 < i) (hₙ : i < Fin.last n) (j : Fin n) :
-    Λ[n, i] _[1] := by
+    Λ[n, i] _⦋1⦌ := by
   refine horn.edge n i j.castSucc j.succ ?_ ?_
   · simp only [← Fin.val_fin_le, Fin.coe_castSucc, Fin.val_succ, le_add_iff_nonneg_right, zero_le]
   simp only [← Fin.val_fin_lt, Fin.val_zero, Fin.val_last] at h₀ hₙ
@@ -103,7 +103,7 @@ which is the type of horn that occurs in the horn-filling condition of quasicate
 @[simps]
 def primitiveTriangle {n : ℕ} (i : Fin (n+4))
     (h₀ : 0 < i) (hₙ : i < Fin.last (n+3))
-    (k : ℕ) (h : k < n+2) : Λ[n+3, i] _[2] := by
+    (k : ℕ) (h : k < n+2) : Λ[n+3, i] _⦋2⦌ := by
   refine ⟨stdSimplex.triangle
     (n := n+3) ⟨k, by omega⟩ ⟨k+1, by omega⟩ ⟨k+2, by omega⟩ ?_ ?_, ?_⟩
   · simp only [Fin.mk_le_mk, le_add_iff_nonneg_right, zero_le]
@@ -128,7 +128,7 @@ def primitiveTriangle {n : ℕ} (i : Fin (n+4))
 
 /-- The `j`th subface of the `i`-th horn. -/
 @[simps]
-def face {n : ℕ} (i j : Fin (n+2)) (h : j ≠ i) : Λ[n+1, i] _[n] :=
+def face {n : ℕ} (i j : Fin (n+2)) (h : j ≠ i) : Λ[n+1, i] _⦋n⦌ :=
   ⟨(stdSimplex.objEquiv _ _).symm (SimplexCategory.δ j), by
     simpa [← Set.univ_subset_iff, Set.subset_def, asOrderHom, SimplexCategory.δ, not_or,
       stdSimplex.objEquiv, asOrderHom, Equiv.ulift]⟩

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Monoidal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Monoidal.lean
@@ -69,8 +69,8 @@ lemma associator_inv_app_apply (K L M : SSet.{u}) {Δ : SimplexCategoryᵒᵖ}
     (x : (K ⊗ L ⊗ M).obj Δ) :
     (α_ K L M).inv.app Δ x = ⟨⟨x.1, x.2.1⟩, x.2.2⟩ := rfl
 
-/-- The bijection `(𝟙_ SSet ⟶ K) ≃ K _[0]`. -/
-def unitHomEquiv (K : SSet.{u}) : (𝟙_ _ ⟶ K) ≃ K _[0] where
+/-- The bijection `(𝟙_ SSet ⟶ K) ≃ K _⦋0⦌`. -/
+def unitHomEquiv (K : SSet.{u}) : (𝟙_ _ ⟶ K) ≃ K _⦋0⦌ where
   toFun φ := φ.app _ PUnit.unit
   invFun x :=
     { app := fun Δ _ => K.map (SimplexCategory.const Δ.unop ⦋0⦌ 0).op x

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
@@ -47,7 +47,7 @@ def nerveFunctor : Cat.{v, u} ⥤ SSet where
   map F := nerveMap F
 
 /-- The 0-simplices of the nerve of a category are equivalent to the objects of the category. -/
-def nerveEquiv (C : Type u) [Category.{v} C] : nerve C _[0] ≃ C where
+def nerveEquiv (C : Type u) [Category.{v} C] : nerve C _⦋0⦌ ≃ C where
   toFun f := f.obj ⟨0, by omega⟩
   invFun f := (Functor.const _).obj f
   left_inv f := ComposableArrows.ext₀ rfl
@@ -57,7 +57,7 @@ namespace Nerve
 
 variable {C : Type*} [Category C] {n : ℕ}
 
-lemma δ₀_eq {x : nerve C _[n + 1]} : (nerve C).δ (0 : Fin (n + 2)) x = x.δ₀ := rfl
+lemma δ₀_eq {x : nerve C _⦋n + 1⦌} : (nerve C).δ (0 : Fin (n + 2)) x = x.δ₀ := rfl
 
 end Nerve
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
@@ -29,9 +29,9 @@ variable (X : SSet.{u})
 @[ext]
 structure Path (n : ℕ) where
   /-- A path includes the data of `n+1` 0-simplices in `X`.-/
-  vertex (i : Fin (n + 1)) : X _[0]
+  vertex (i : Fin (n + 1)) : X _⦋0⦌
   /-- A path includes the data of `n` 1-simplices in `X`.-/
-  arrow (i : Fin n) : X _[1]
+  arrow (i : Fin n) : X _⦋1⦌
   /-- The sources of the 1-simplices in a path are identified with appropriate 0-simplices.-/
   arrow_src (i : Fin n) : X.δ 1 (arrow i) = vertex i.castSucc
   /-- The targets of the 1-simplices in a path are identified with appropriate 0-simplices.-/
@@ -51,7 +51,7 @@ def Path.interval {n : ℕ} (f : Path X n) (j l : ℕ) (hjl : j + l ≤ n) :
 /-- The spine of an `n`-simplex in `X` is the path of edges of length `n` formed by
 traversing through its vertices in order.-/
 @[simps]
-def spine (n : ℕ) (Δ : X _[n]) : X.Path n where
+def spine (n : ℕ) (Δ : X _⦋n⦌) : X.Path n where
   vertex i := X.map (SimplexCategory.const ⦋0⦌ ⦋n⦌ i).op Δ
   arrow i := X.map (SimplexCategory.mkOfSucc i).op Δ
   arrow_src i := by
@@ -64,14 +64,14 @@ def spine (n : ℕ) (Δ : X _[n]) : X.Path n where
     simp only [← FunctorToTypes.map_comp_apply, ← op_comp]
     rw [SimplexCategory.δ_zero_mkOfSucc]
 
-lemma spine_map_vertex {n : ℕ} (x : X _[n]) {m : ℕ} (φ : ⦋m⦌ ⟶ ⦋n⦌)
+lemma spine_map_vertex {n : ℕ} (x : X _⦋n⦌) {m : ℕ} (φ : ⦋m⦌ ⟶ ⦋n⦌)
     (i : Fin (m + 1)) :
     (spine X m (X.map φ.op x)).vertex i = (spine X n x).vertex (φ.toOrderHom i) := by
   dsimp [spine]
   rw [← FunctorToTypes.map_comp_apply]
   rfl
 
-lemma spine_map_subinterval {n : ℕ} (j l : ℕ) (hjl : j + l ≤ n) (Δ : X _[n]) :
+lemma spine_map_subinterval {n : ℕ} (j l : ℕ) (hjl : j + l ≤ n) (Δ : X _⦋n⦌) :
     X.spine l (X.map (subinterval j l (by omega)).op Δ) =
       (X.spine n Δ).interval j l (by omega) := by
   ext i

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
@@ -71,7 +71,7 @@ def _root_.SSet.yonedaEquiv (X : SSet.{u}) (n : SimplexCategory) :
   yonedaCompUliftFunctorEquiv X n
 
 /-- The unique non-degenerate `n`-simplex in `Δ[n]`. -/
-def id (n : ℕ) : Δ[n] _[n] := yonedaEquiv Δ[n] ⦋n⦌ (𝟙 Δ[n])
+def id (n : ℕ) : Δ[n] _⦋n⦌ := yonedaEquiv Δ[n] ⦋n⦌ (𝟙 Δ[n])
 
 lemma id_eq_objEquiv_symm (n : ℕ) : id n = (objEquiv _ _).symm (𝟙 _) := rfl
 
@@ -87,7 +87,7 @@ lemma const_down_toOrderHom (n : ℕ) (k : Fin (n+1)) (m : SimplexCategoryᵒᵖ
   rfl
 
 /-- The edge of the standard simplex with endpoints `a` and `b`. -/
-def edge (n : ℕ) (a b : Fin (n+1)) (hab : a ≤ b) : Δ[n] _[1] := by
+def edge (n : ℕ) (a b : Fin (n+1)) (hab : a ≤ b) : Δ[n] _⦋1⦌ := by
   refine objMk ⟨![a, b], ?_⟩
   rw [Fin.monotone_iff_le_succ]
   simp only [unop_op, len_mk, Fin.forall_fin_one]
@@ -98,7 +98,7 @@ lemma coe_edge_down_toOrderHom (n : ℕ) (a b : Fin (n+1)) (hab : a ≤ b) :
   rfl
 
 /-- The triangle in the standard simplex with vertices `a`, `b`, and `c`. -/
-def triangle {n : ℕ} (a b c : Fin (n+1)) (hab : a ≤ b) (hbc : b ≤ c) : Δ[n] _[2] := by
+def triangle {n : ℕ} (a b c : Fin (n+1)) (hab : a ≤ b) (hbc : b ≤ c) : Δ[n] _⦋2⦌ := by
   refine objMk ⟨![a, b, c], ?_⟩
   rw [Fin.monotone_iff_le_succ]
   simp only [unop_op, len_mk, Fin.forall_fin_two]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StrictSegal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StrictSegal.lean
@@ -12,8 +12,8 @@ import Mathlib.CategoryTheory.Functor.KanExtension.Basic
 # Strict Segal simplicial sets
 
 A simplicial set `X` satisfies the `StrictSegal` condition if for all `n`, the map
-`X.spine n : X _[n] → X.Path n` is an equivalence, with equivalence inverse
-`spineToSimplex {n : ℕ} : Path X n → X _[n]`.
+`X.spine n : X _⦋n⦌ → X.Path n` is an equivalence, with equivalence inverse
+`spineToSimplex {n : ℕ} : Path X n → X _⦋n⦌`.
 
 Examples of `StrictSegal` simplicial sets are given by nerves of categories.
 
@@ -39,17 +39,17 @@ variable (X : SSet.{u})
 determined by their spine. -/
 class StrictSegal where
   /-- The inverse to `X.spine n`.-/
-  spineToSimplex {n : ℕ} : Path X n → X _[n]
+  spineToSimplex {n : ℕ} : Path X n → X _⦋n⦌
   /-- `spineToSimplex` is a right inverse to `X.spine n`.-/
   spine_spineToSimplex {n : ℕ} (f : Path X n) : X.spine n (spineToSimplex f) = f
   /-- `spineToSimplex` is a left inverse to `X.spine n`.-/
-  spineToSimplex_spine {n : ℕ} (Δ : X _[n]) : spineToSimplex (X.spine n Δ) = Δ
+  spineToSimplex_spine {n : ℕ} (Δ : X _⦋n⦌) : spineToSimplex (X.spine n Δ) = Δ
 
 namespace StrictSegal
 variable {X : SSet.{u}} [StrictSegal X] {n : ℕ}
 
-/-- The fields of `StrictSegal` define an equivalence between `X _[n]` and `Path X n`.-/
-def spineEquiv (n : ℕ) : X _[n] ≃ Path X n where
+/-- The fields of `StrictSegal` define an equivalence between `X _⦋n⦌` and `Path X n`.-/
+def spineEquiv (n : ℕ) : X _⦋n⦌ ≃ Path X n where
   toFun := spine X n
   invFun := spineToSimplex
   left_inv := spineToSimplex_spine
@@ -69,7 +69,7 @@ theorem spineToSimplex_arrow (i : Fin n) (f : Path X n) :
 
 /-- In the presence of the strict Segal condition, a path of length `n` can be "composed" by taking
 the diagonal edge of the resulting `n`-simplex. -/
-def spineToDiagonal (f : Path X n) : X _[1] := diagonal X (spineToSimplex f)
+def spineToDiagonal (f : Path X n) : X _⦋1⦌ := diagonal X (spineToSimplex f)
 
 @[simp]
 theorem spineToSimplex_interval (f : Path X n) (j l : ℕ) (hjl : j + l ≤  n)  :


### PR DESCRIPTION
We change the notation for the `n`-th term of a simplicial object `X` from `X _[n]` to `X _⦋n⦌`. We also change the notation for the `n`-th term of a cosimplicial object `X` from `X ^[n]` to `X ^⦋n⦌`.

This change makes the notations for (co)simplicial objects consistent with the notation for objects of the simplex category, which was updated in #21565.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
This diff should be relatively easy to produce in an automated way, so I would see no issues with waiting for other PRs to merge first (or waiting until we have a vscode abbreviation for `⦋ ⦌`).

We do not change the following notations, which we may want to update in future PRs:
- `Δ[n]` for the standard simplex of dimension `n`.
- `∂Δ[n]` for the boundary of the `n`-th standard simplex.
- `Λ[n, i]` for the `i`-th horn of the `n`-th standard simplex.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
