### PR TITLE
feat(AlgebraicTopology): simplicial notations Δ⦋n⦌, ∂Δ⦋n⦌, Λ⦋n, i⦌

### DIFF
--- a/Mathlib/AlgebraicTopology/Quasicategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/Basic.lean
@@ -30,17 +30,17 @@ open CategoryTheory Simplicial
 
 /-- A simplicial set `S` is a *quasicategory* if it satisfies the following horn-filling condition:
 for every `n : ℕ` and `0 < i < n`,
-every map of simplicial sets `σ₀ : Λ[n, i] → S` can be extended to a map `σ : Δ[n] → S`.
+every map of simplicial sets `σ₀ : Λ⦋n, i⦌ → S` can be extended to a map `σ : Δ⦋n⦌ → S`.
 -/
 @[kerodon 003A]
 class Quasicategory (S : SSet) : Prop where
-  hornFilling' : ∀ ⦃n : ℕ⦄ ⦃i : Fin (n+3)⦄ (σ₀ : Λ[n+2, i] ⟶ S)
+  hornFilling' : ∀ ⦃n : ℕ⦄ ⦃i : Fin (n+3)⦄ (σ₀ : Λ⦋n+2, i⦌ ⟶ S)
     (_h0 : 0 < i) (_hn : i < Fin.last (n+2)),
-      ∃ σ : Δ[n+2] ⟶ S, σ₀ = hornInclusion (n+2) i ≫ σ
+      ∃ σ : Δ⦋n+2⦌ ⟶ S, σ₀ = hornInclusion (n+2) i ≫ σ
 
 lemma Quasicategory.hornFilling {S : SSet} [Quasicategory S] ⦃n : ℕ⦄ ⦃i : Fin (n+1)⦄
     (h0 : 0 < i) (hn : i < Fin.last n)
-    (σ₀ : Λ[n, i] ⟶ S) : ∃ σ : Δ[n] ⟶ S, σ₀ = hornInclusion n i ≫ σ := by
+    (σ₀ : Λ⦋n, i⦌ ⟶ S) : ∃ σ : Δ⦋n⦌ ⟶ S, σ₀ = hornInclusion n i ≫ σ := by
   cases n using Nat.casesAuxOn with
   | zero => simp [Fin.lt_iff_val_lt_val] at hn
   | succ n =>
@@ -56,7 +56,7 @@ instance (S : SSet) [KanComplex S] : Quasicategory S where
   hornFilling' _ _ σ₀ _ _ := KanComplex.hornFilling σ₀
 
 lemma quasicategory_of_filler (S : SSet)
-    (filler : ∀ ⦃n : ℕ⦄ ⦃i : Fin (n+3)⦄ (σ₀ : Λ[n+2, i] ⟶ S)
+    (filler : ∀ ⦃n : ℕ⦄ ⦃i : Fin (n+3)⦄ (σ₀ : Λ⦋n+2, i⦌ ⟶ S)
       (_h0 : 0 < i) (_hn : i < Fin.last (n+2)),
       ∃ σ : S _⦋n+2⦌, ∀ (j) (h : j ≠ i), S.δ j σ = σ₀.app _ (horn.face i j h)) :
     Quasicategory S where

--- a/Mathlib/AlgebraicTopology/Quasicategory/StrictSegal.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/StrictSegal.lean
@@ -54,15 +54,15 @@ instance quasicategory {X : SSet.{u}} [StrictSegal X] : Quasicategory X := by
       Quiver.Hom.unop_op, horn.face_coe, Subtype.mk.injEq]
     rw [mkOfSucc_δ_gt hgt]
     rfl
-  · /- The only inner horn of `Δ[2]` does not contain the diagonal edge. -/
+  · /- The only inner horn of `Δ⦋2⦌` does not contain the diagonal edge. -/
     have hn0 : n ≠ 0 := by
       rintro rfl
       obtain rfl : k = 0 := by omega
       fin_cases i <;> contradiction
     /- We construct the triangle in the standard simplex as a 2-simplex in
-    the horn. While the triangle is not contained in the inner horn `Λ[2, 1]`,
-    we can inhabit `Λ[n + 2, i] _⦋2⦌` by induction on `n`. -/
-    let triangle : Λ[n + 2, i] _⦋2⦌ := by
+    the horn. While the triangle is not contained in the inner horn `Λ⦋2, 1⦌`,
+    we can inhabit `Λ⦋n + 2, i⦌ _⦋2⦌` by induction on `n`. -/
+    let triangle : Λ⦋n + 2, i⦌ _⦋2⦌ := by
       cases n with
       | zero => contradiction
       | succ _ => exact horn.primitiveTriangle i h₀ hₙ k (by omega)

--- a/Mathlib/AlgebraicTopology/SimplicialCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialCategory/Basic.lean
@@ -24,7 +24,7 @@ an object in a simplicial category `C`
 * define the notion of path between `0`-simplices of simplicial sets
 * deduce the notion of homotopy between morphisms in a simplicial category
 * obtain that homotopies in simplicial categories can be interpreted as given
-by morphisms `Δ[1] ⊗ X ⟶ Y`.
+by morphisms `Δ⦋1⦌ ⊗ X ⟶ Y`.
 
 ## References
 * [Daniel G. Quillen, *Homotopical algebra*, II §1][quillen-1967]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Boundary.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Boundary.lean
@@ -8,7 +8,7 @@ import Mathlib.AlgebraicTopology.SimplicialSet.StdSimplex
 /-!
 # The boundary of the standard simplex
 
-We introduce the boundary `∂Δ[n]` of the standard simplex `Δ[n]`.
+We introduce the boundary `∂Δ⦋n⦌` of the standard simplex `Δ⦋n⦌`.
 (These notations become available by doing `open Simplicial`.)
 
 ## Future work
@@ -16,7 +16,7 @@ We introduce the boundary `∂Δ[n]` of the standard simplex `Δ[n]`.
 There isn't yet a complete API for simplices, boundaries, and horns.
 As an example, we should have a function that constructs
 from a non-surjective order preserving function `Fin n → Fin n`
-a morphism `Δ[n] ⟶ ∂Δ[n]`.
+a morphism `Δ⦋n⦌ ⟶ ∂Δ⦋n⦌`.
 
 
 -/
@@ -27,21 +27,21 @@ open Simplicial
 
 namespace SSet
 
-/-- The boundary `∂Δ[n]` of the `n`-th standard simplex consists of
+/-- The boundary `∂Δ⦋n⦌` of the `n`-th standard simplex consists of
 all `m`-simplices of `stdSimplex n` that are not surjective
 (when viewed as monotone function `m → n`). -/
 def boundary (n : ℕ) : SSet.{u} where
-  obj m := { α : Δ[n].obj m // ¬Function.Surjective (asOrderHom α) }
+  obj m := { α : Δ⦋n⦌.obj m // ¬Function.Surjective (asOrderHom α) }
   map {m₁ m₂} f α :=
-    ⟨Δ[n].map f α.1, by
+    ⟨Δ⦋n⦌.map f α.1, by
       intro h
       apply α.property
       exact Function.Surjective.of_comp h⟩
 
-/-- The boundary `∂Δ[n]` of the `n`-th standard simplex -/
-scoped[Simplicial] notation3 "∂Δ[" n "]" => SSet.boundary n
+/-- The boundary `∂Δ⦋n⦌` of the `n`-th standard simplex -/
+scoped[Simplicial] notation3 "∂Δ⦋" n "⦌" => SSet.boundary n
 
 /-- The inclusion of the boundary of the `n`-th standard simplex into that standard simplex. -/
-def boundaryInclusion (n : ℕ) : ∂Δ[n] ⟶ Δ[n] where app m (α : { α : Δ[n].obj m // _ }) := α
+def boundaryInclusion (n : ℕ) : ∂Δ⦋n⦌ ⟶ Δ⦋n⦌ where app m (α : { α : Δ⦋n⦌.obj m // _ }) := α
 
 end SSet

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Horn.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Horn.lean
@@ -8,7 +8,7 @@ import Mathlib.AlgebraicTopology.SimplicialSet.StdSimplex
 /-!
 # Horns
 
-This file introduce horns `Λ[n, i]`.
+This file introduce horns `Λ⦋n, i⦌`.
 
 -/
 
@@ -18,34 +18,34 @@ open CategoryTheory Simplicial
 
 namespace SSet
 
-/-- `horn n i` (or `Λ[n, i]`) is the `i`-th horn of the `n`-th standard simplex, where `i : n`.
-It consists of all `m`-simplices `α` of `Δ[n]`
+/-- `horn n i` (or `Λ⦋n, i⦌`) is the `i`-th horn of the `n`-th standard simplex, where `i : n`.
+It consists of all `m`-simplices `α` of `Δ⦋n⦌`
 for which the union of `{i}` and the range of `α` is not all of `n`
 (when viewing `α` as monotone function `m → n`). -/
 def horn (n : ℕ) (i : Fin (n + 1)) : SSet where
-  obj m := { α : Δ[n].obj m // Set.range (asOrderHom α) ∪ {i} ≠ Set.univ }
+  obj m := { α : Δ⦋n⦌.obj m // Set.range (asOrderHom α) ∪ {i} ≠ Set.univ }
   map {m₁ m₂} f α :=
-    ⟨Δ[n].map f α.1, by
+    ⟨Δ⦋n⦌.map f α.1, by
       intro h; apply α.property
       rw [Set.eq_univ_iff_forall] at h ⊢; intro j
       apply Or.imp _ id (h j)
       intro hj
       exact Set.range_comp_subset_range _ _ hj⟩
 
-/-- The `i`-th horn `Λ[n, i]` of the standard `n`-simplex -/
-scoped[Simplicial] notation3 "Λ[" n ", " i "]" => SSet.horn (n : ℕ) i
+/-- The `i`-th horn `Λ⦋n, i⦌` of the standard `n`-simplex -/
+scoped[Simplicial] notation3 "Λ⦋" n ", " i "⦌" => SSet.horn (n : ℕ) i
 
 /-- The inclusion of the `i`-th horn of the `n`-th standard simplex into that standard simplex. -/
-def hornInclusion (n : ℕ) (i : Fin (n + 1)) : Λ[n, i] ⟶ Δ[n] where
-  app m (α : { α : Δ[n].obj m // _ }) := α
+def hornInclusion (n : ℕ) (i : Fin (n + 1)) : Λ⦋n, i⦌ ⟶ Δ⦋n⦌ where
+  app m (α : { α : Δ⦋n⦌.obj m // _ }) := α
 
 namespace horn
 
 open SimplexCategory Finset Opposite
 
-/-- The (degenerate) subsimplex of `Λ[n+2, i]` concentrated in vertex `k`. -/
+/-- The (degenerate) subsimplex of `Λ⦋n+2, i⦌` concentrated in vertex `k`. -/
 @[simps]
-def const (n : ℕ) (i k : Fin (n+3)) (m : SimplexCategoryᵒᵖ) : Λ[n+2, i].obj m := by
+def const (n : ℕ) (i k : Fin (n+3)) (m : SimplexCategoryᵒᵖ) : Λ⦋n+2, i⦌.obj m := by
   refine ⟨stdSimplex.const _ k _, ?_⟩
   suffices ¬ Finset.univ ⊆ {i, k} by
     simpa [← Set.univ_subset_iff, Set.subset_def, asOrderHom, not_or, Fin.forall_fin_one,
@@ -55,11 +55,11 @@ def const (n : ℕ) (i k : Fin (n+3)) (m : SimplexCategoryᵒᵖ) : Λ[n+2, i].o
   rw [card_fin] at this
   omega
 
-/-- The edge of `Λ[n, i]` with endpoints `a` and `b`.
+/-- The edge of `Λ⦋n, i⦌` with endpoints `a` and `b`.
 
 This edge only exists if `{i, a, b}` has cardinality less than `n`. -/
 @[simps]
-def edge (n : ℕ) (i a b : Fin (n+1)) (hab : a ≤ b) (H : #{i, a, b} ≤ n) : Λ[n, i] _⦋1⦌ := by
+def edge (n : ℕ) (i a b : Fin (n+1)) (hab : a ≤ b) (H : #{i, a, b} ≤ n) : Λ⦋n, i⦌ _⦋1⦌ := by
   refine ⟨stdSimplex.edge n a b hab, ?range⟩
   case range =>
     suffices ∃ x, ¬i = x ∧ ¬a = x ∧ ¬b = x by
@@ -73,21 +73,21 @@ def edge (n : ℕ) (i a b : Fin (n+1)) (hab : a ≤ b) (H : #{i, a, b} ≤ n) : 
     replace H := card_le_card H
     rwa [card_fin] at H
 
-/-- Alternative constructor for the edge of `Λ[n, i]` with endpoints `a` and `b`,
+/-- Alternative constructor for the edge of `Λ⦋n, i⦌` with endpoints `a` and `b`,
 assuming `3 ≤ n`. -/
 @[simps!]
 def edge₃ (n : ℕ) (i a b : Fin (n+1)) (hab : a ≤ b) (H : 3 ≤ n) :
-    Λ[n, i] _⦋1⦌ :=
+    Λ⦋n, i⦌ _⦋1⦌ :=
   horn.edge n i a b hab <| Finset.card_le_three.trans H
 
-/-- The edge of `Λ[n, i]` with endpoints `j` and `j+1`.
+/-- The edge of `Λ⦋n, i⦌` with endpoints `j` and `j+1`.
 
 This constructor assumes `0 < i < n`,
 which is the type of horn that occurs in the horn-filling condition of quasicategories. -/
 @[simps!]
 def primitiveEdge {n : ℕ} {i : Fin (n+1)}
     (h₀ : 0 < i) (hₙ : i < Fin.last n) (j : Fin n) :
-    Λ[n, i] _⦋1⦌ := by
+    Λ⦋n, i⦌ _⦋1⦌ := by
   refine horn.edge n i j.castSucc j.succ ?_ ?_
   · simp only [← Fin.val_fin_le, Fin.coe_castSucc, Fin.val_succ, le_add_iff_nonneg_right, zero_le]
   simp only [← Fin.val_fin_lt, Fin.val_zero, Fin.val_last] at h₀ hₙ
@@ -103,7 +103,7 @@ which is the type of horn that occurs in the horn-filling condition of quasicate
 @[simps]
 def primitiveTriangle {n : ℕ} (i : Fin (n+4))
     (h₀ : 0 < i) (hₙ : i < Fin.last (n+3))
-    (k : ℕ) (h : k < n+2) : Λ[n+3, i] _⦋2⦌ := by
+    (k : ℕ) (h : k < n+2) : Λ⦋n+3, i⦌ _⦋2⦌ := by
   refine ⟨stdSimplex.triangle
     (n := n+3) ⟨k, by omega⟩ ⟨k+1, by omega⟩ ⟨k+2, by omega⟩ ?_ ?_, ?_⟩
   · simp only [Fin.mk_le_mk, le_add_iff_nonneg_right, zero_le]
@@ -128,14 +128,14 @@ def primitiveTriangle {n : ℕ} (i : Fin (n+4))
 
 /-- The `j`th subface of the `i`-th horn. -/
 @[simps]
-def face {n : ℕ} (i j : Fin (n+2)) (h : j ≠ i) : Λ[n+1, i] _⦋n⦌ :=
+def face {n : ℕ} (i j : Fin (n+2)) (h : j ≠ i) : Λ⦋n+1, i⦌ _⦋n⦌ :=
   ⟨(stdSimplex.objEquiv _ _).symm (SimplexCategory.δ j), by
     simpa [← Set.univ_subset_iff, Set.subset_def, asOrderHom, SimplexCategory.δ, not_or,
       stdSimplex.objEquiv, asOrderHom, Equiv.ulift]⟩
 
 /-- Two morphisms from a horn are equal if they are equal on all suitable faces. -/
 protected
-lemma hom_ext {n : ℕ} {i : Fin (n+2)} {S : SSet} (σ₁ σ₂ : Λ[n+1, i] ⟶ S)
+lemma hom_ext {n : ℕ} {i : Fin (n+2)} {S : SSet} (σ₁ σ₂ : Λ⦋n+1, i⦌ ⟶ S)
     (h : ∀ (j) (h : j ≠ i), σ₁.app _ (face i j h) = σ₂.app _ (face i j h)) :
     σ₁ = σ₂ := by
   apply NatTrans.ext; apply funext; apply Opposite.rec; apply SimplexCategory.rec
@@ -145,7 +145,7 @@ lemma hom_ext {n : ℕ} {i : Fin (n+2)} {S : SSet} (σ₁ σ₂ : Λ[n+1, i] ⟶
     obtain ⟨f, hf'⟩ := f
     subst hf
     simpa [← Set.univ_subset_iff, Set.subset_def, asOrderHom, not_or] using hf'
-  have H : f = (Λ[n+1, i].map (factor_δ f' j).op) (face i j hji) := by
+  have H : f = (Λ⦋n+1, i⦌.map (factor_δ f' j).op) (face i j hji) := by
     apply Subtype.ext
     apply (stdSimplex.objEquiv _ _).injective
     rw [← hf]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/KanComplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/KanComplex.lean
@@ -27,9 +27,9 @@ open CategoryTheory Simplicial
 
 /-- A simplicial set `S` is a *Kan complex* if it satisfies the following horn-filling condition:
 for every nonzero `n : ℕ` and `0 ≤ i ≤ n`,
-every map of simplicial sets `σ₀ : Λ[n, i] → S` can be extended to a map `σ : Δ[n] → S`. -/
+every map of simplicial sets `σ₀ : Λ⦋n, i⦌ → S` can be extended to a map `σ : Δ⦋n⦌ → S`. -/
 class KanComplex (S : SSet.{u}) : Prop where
-  hornFilling : ∀ ⦃n : ℕ⦄ ⦃i : Fin (n + 2)⦄ (σ₀ : Λ[n + 1, i] ⟶ S),
-    ∃ σ : Δ[n + 1] ⟶ S, σ₀ = hornInclusion (n + 1) i ≫ σ
+  hornFilling : ∀ ⦃n : ℕ⦄ ⦃i : Fin (n + 2)⦄ (σ₀ : Λ⦋n + 1, i⦌ ⟶ S),
+    ∃ σ : Δ⦋n + 1⦌ ⟶ S, σ₀ = hornInclusion (n + 1) i ≫ σ
 
 end SSet

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
@@ -109,16 +109,16 @@ lemma map_interval {X Y : SSet.{u}} {n : ℕ} (f : X.Path n) (σ : X ⟶ Y)
     (j l : ℕ) (hjl : j + l ≤ n) :
     (f.map σ).interval j l hjl = (f.interval j l hjl).map σ := rfl
 
-/-- The spine of the unique non-degenerate `n`-simplex in `Δ[n]`.-/
-def stdSimplex.spineId (n : ℕ) : Path Δ[n] n :=
-  spine Δ[n] n (stdSimplex.id n)
+/-- The spine of the unique non-degenerate `n`-simplex in `Δ⦋n⦌`.-/
+def stdSimplex.spineId (n : ℕ) : Path Δ⦋n⦌ n :=
+  spine Δ⦋n⦌ n (stdSimplex.id n)
 
 /-- Any inner horn contains the spine of the unique non-degenerate `n`-simplex
-in `Δ[n]`.-/
+in `Δ⦋n⦌`.-/
 @[simps]
 def horn.spineId {n : ℕ} (i : Fin (n + 3))
     (h₀ : 0 < i) (hₙ : i < Fin.last (n + 2)) :
-    Path Λ[n + 2, i] (n + 2) where
+    Path Λ⦋n + 2, i⦌ (n + 2) where
   vertex j := ⟨stdSimplex.spineId _ |>.vertex j, (horn.const n i j _).property⟩
   arrow j := ⟨stdSimplex.spineId _ |>.arrow j, by
     let edge := horn.primitiveEdge h₀ hₙ j

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
@@ -10,9 +10,9 @@ import Mathlib.Data.Fin.VecNotation
 /-!
 # The standard simplex
 
-We define the standard simplices `Δ[n]` as simplicial sets.
+We define the standard simplices `Δ⦋n⦌` as simplicial sets.
 See files `SimplicialSet.Boundary` and `SimplicialSet.Horn`
-for their boundaries`∂Δ[n]` and horns `Λ[n, i]`.
+for their boundaries`∂Δ⦋n⦌` and horns `Λ⦋n, i⦌`.
 (The notations are available via `open Simplicial`.)
 
 -/
@@ -24,7 +24,7 @@ open CategoryTheory Limits Simplicial
 namespace SSet
 
 /-- The functor `SimplexCategory ⥤ SSet` which sends `SimplexCategory.mk n` to
-the standard simplex `Δ[n]` is a cosimplicial object in the category of simplicial sets.
+the standard simplex `Δ⦋n⦌` is a cosimplicial object in the category of simplicial sets.
 (This functor is essentially given by the Yoneda embedding). -/
 def stdSimplex : CosimplicialObject SSet.{u} :=
   yoneda ⋙ uliftFunctor
@@ -32,13 +32,13 @@ def stdSimplex : CosimplicialObject SSet.{u} :=
 @[deprecated (since := "2025-01-23")] alias standardSimplex := stdSimplex
 
 @[inherit_doc SSet.stdSimplex]
-scoped[Simplicial] notation3 "Δ[" n "]" => SSet.stdSimplex.obj (SimplexCategory.mk n)
+scoped[Simplicial] notation3 "Δ⦋" n "⦌" => SSet.stdSimplex.obj (SimplexCategory.mk n)
 
 instance : Inhabited SSet :=
-  ⟨Δ[0]⟩
+  ⟨Δ⦋0⦌⟩
 
 instance {n} : Inhabited (SSet.Truncated n) :=
-  ⟨(truncation n).obj <| Δ[0]⟩
+  ⟨(truncation n).obj <| Δ⦋0⦌⟩
 
 namespace stdSimplex
 
@@ -70,15 +70,15 @@ def _root_.SSet.yonedaEquiv (X : SSet.{u}) (n : SimplexCategory) :
     (stdSimplex.obj n ⟶ X) ≃ X.obj (op n) :=
   yonedaCompUliftFunctorEquiv X n
 
-/-- The unique non-degenerate `n`-simplex in `Δ[n]`. -/
-def id (n : ℕ) : Δ[n] _⦋n⦌ := yonedaEquiv Δ[n] ⦋n⦌ (𝟙 Δ[n])
+/-- The unique non-degenerate `n`-simplex in `Δ⦋n⦌`. -/
+def id (n : ℕ) : Δ⦋n⦌ _⦋n⦌ := yonedaEquiv Δ⦋n⦌ ⦋n⦌ (𝟙 Δ⦋n⦌)
 
 lemma id_eq_objEquiv_symm (n : ℕ) : id n = (objEquiv _ _).symm (𝟙 _) := rfl
 
 lemma objEquiv_id (n : ℕ) : objEquiv _ _ (id n) = 𝟙 _ := rfl
 
 /-- The (degenerate) `m`-simplex in the standard simplex concentrated in vertex `k`. -/
-def const (n : ℕ) (k : Fin (n+1)) (m : SimplexCategoryᵒᵖ) : Δ[n].obj m :=
+def const (n : ℕ) (k : Fin (n+1)) (m : SimplexCategoryᵒᵖ) : Δ⦋n⦌.obj m :=
   objMk (OrderHom.const _ k )
 
 @[simp]
@@ -87,7 +87,7 @@ lemma const_down_toOrderHom (n : ℕ) (k : Fin (n+1)) (m : SimplexCategoryᵒᵖ
   rfl
 
 /-- The edge of the standard simplex with endpoints `a` and `b`. -/
-def edge (n : ℕ) (a b : Fin (n+1)) (hab : a ≤ b) : Δ[n] _⦋1⦌ := by
+def edge (n : ℕ) (a b : Fin (n+1)) (hab : a ≤ b) : Δ⦋n⦌ _⦋1⦌ := by
   refine objMk ⟨![a, b], ?_⟩
   rw [Fin.monotone_iff_le_succ]
   simp only [unop_op, len_mk, Fin.forall_fin_one]
@@ -98,7 +98,7 @@ lemma coe_edge_down_toOrderHom (n : ℕ) (a b : Fin (n+1)) (hab : a ≤ b) :
   rfl
 
 /-- The triangle in the standard simplex with vertices `a`, `b`, and `c`. -/
-def triangle {n : ℕ} (a b c : Fin (n+1)) (hab : a ≤ b) (hbc : b ≤ c) : Δ[n] _⦋2⦌ := by
+def triangle {n : ℕ} (a b c : Fin (n+1)) (hab : a ≤ b) (hbc : b ≤ c) : Δ⦋n⦌ _⦋2⦌ := by
   refine objMk ⟨![a, b, c], ?_⟩
   rw [Fin.monotone_iff_le_succ]
   simp only [unop_op, len_mk, Fin.forall_fin_two]
@@ -115,7 +115,7 @@ section
 
 /-- The `m`-simplices of the `n`-th standard simplex are
 the monotone maps from `Fin (m+1)` to `Fin (n+1)`. -/
-def asOrderHom {n} {m} (α : Δ[n].obj m) : OrderHom (Fin (m.unop.len + 1)) (Fin (n + 1)) :=
+def asOrderHom {n} {m} (α : Δ⦋n⦌.obj m) : OrderHom (Fin (m.unop.len + 1)) (Fin (n + 1)) :=
   α.down.toOrderHom
 
 end
@@ -127,7 +127,7 @@ open Simplicial
 /-- The simplicial circle. -/
 noncomputable def S1 : SSet :=
   Limits.colimit <|
-    Limits.parallelPair (stdSimplex.δ 0 : Δ[0] ⟶ Δ[1]) (stdSimplex.δ 1)
+    Limits.parallelPair (stdSimplex.δ 0 : Δ⦋0⦌ ⟶ Δ⦋1⦌) (stdSimplex.δ 1)
 
 end Examples
 
@@ -135,7 +135,7 @@ namespace Augmented
 
 -- Porting note: an instance of `Subsingleton (⊤_ (Type u))` was added in
 -- `CategoryTheory.Limits.Types` to ease the automation in this definition
-/-- The functor which sends `⦋n⦌` to the simplicial set `Δ[n]` equipped by
+/-- The functor which sends `⦋n⦌` to the simplicial set `Δ⦋n⦌` equipped by
 the obvious augmentation towards the terminal object of the category of sets. -/
 @[simps]
 noncomputable def stdSimplex : SimplexCategory ⥤ SSet.Augmented.{u} where


### PR DESCRIPTION
We update the following notations to be consistent with #21565 and #21581:
- `Δ⦋n⦌` denotes the standard simplex of dimension `n`.
- `∂Δ⦋n⦌` denotes the boundary of the `n`-th standard simplex.
- `Λ⦋n, i⦌` denotes the `i`-th horn of the `n`-th standard simplex.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
The diff was generated using the `sed` command below, which has been tested exactly once (but may be useful for downstream PRs).
```bash
git grep -l '[ΔΛ]' ./Mathlib/AlgebraicTopology/ | xargs sed -i 's/\([ΔΛ]\)\[\([^]]*\)\]/\1⦋\2⦌/g'
```

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
