### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace/AffineSubspace): instances for coercion to sort

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean
@@ -654,6 +654,10 @@ theorem coe_affineSpan_singleton (p : P) : (affineSpan k ({p} : Set P) : Set P) 
 theorem mem_affineSpan_singleton : p₁ ∈ affineSpan k ({p₂} : Set P) ↔ p₁ = p₂ := by
   simp [← mem_coe]
 
+instance unique_affineSpan_singleton (p : P) : Unique (affineSpan k {p}) where
+  default := ⟨p, mem_affineSpan _ (Set.mem_singleton _)⟩
+  uniq := fun x ↦ Subtype.ext ((mem_affineSpan_singleton _ _).1 x.property)
+
 @[simp]
 theorem preimage_coe_affineSpan_singleton (x : P) :
     ((↑) : affineSpan k ({x} : Set P) → P) ⁻¹' {x} = univ :=
@@ -758,6 +762,9 @@ variable {P}
 /-- No points are in `⊥`. -/
 theorem not_mem_bot (p : P) : p ∉ (⊥ : AffineSubspace k P) :=
   Set.not_mem_empty p
+
+instance isEmpty_bot : IsEmpty (⊥ : AffineSubspace k P) :=
+  Subtype.isEmpty_of_false fun _ ↦ not_mem_bot _ _ _
 
 variable (P)
 


### PR DESCRIPTION
Add two straightforward instances for working with the coercion of `AffineSubspace` to a `Sort`.

```lean
instance unique_affineSpan_singleton (p : P) : Unique (affineSpan k {p}) where
```

```lean
instance isEmpty_bot : IsEmpty (⊥ : AffineSubspace k P) :=
```


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
