### PR TITLE
[Merged by Bors] - chore(CategoryTheory): adjust `simps` attribute for `LeftExactFunctor.whiskeringLeft` etc.

### DIFF
--- a/Mathlib/CategoryTheory/Limits/ExactFunctor.lean
+++ b/Mathlib/CategoryTheory/Limits/ExactFunctor.lean
@@ -215,7 +215,7 @@ section
 variable (C D E)
 
 /-- Whiskering a left exact functor by a left exact functor yields a left exact functor. -/
-@[simps!]
+@[simps! obj_obj obj_map map_app_app]
 def LeftExactFunctor.whiskeringLeft : (C ⥤ₗ D) ⥤ (D ⥤ₗ E) ⥤ (C ⥤ₗ E) where
   obj F := FullSubcategory.lift _ (forget _ _ ⋙ (CategoryTheory.whiskeringLeft C D E).obj F.obj)
     (fun G => by dsimp; exact comp_preservesFiniteLimits _ _)
@@ -230,7 +230,7 @@ def LeftExactFunctor.whiskeringLeft : (C ⥤ₗ D) ⥤ (D ⥤ₗ E) ⥤ (C ⥤�
     aesop_cat
 
 /-- Whiskering a left exact functor by a left exact functor yields a left exact functor. -/
-@[simps!]
+@[simps! obj_obj obj_map map_app_app]
 def LeftExactFunctor.whiskeringRight : (D ⥤ₗ E) ⥤ (C ⥤ₗ D) ⥤ (C ⥤ₗ E) where
   obj F := FullSubcategory.lift _ (forget _ _ ⋙ (CategoryTheory.whiskeringRight C D E).obj F.obj)
     (fun G => by dsimp; exact comp_preservesFiniteLimits _ _)
@@ -245,7 +245,7 @@ def LeftExactFunctor.whiskeringRight : (D ⥤ₗ E) ⥤ (C ⥤ₗ D) ⥤ (C ⥤�
     aesop_cat
 
 /-- Whiskering a right exact functor by a right exact functor yields a right exact functor. -/
-@[simps!]
+@[simps! obj_obj obj_map map_app_app]
 def RightExactFunctor.whiskeringLeft : (C ⥤ᵣ D) ⥤ (D ⥤ᵣ E) ⥤ (C ⥤ᵣ E) where
   obj F := FullSubcategory.lift _ (forget _ _ ⋙ (CategoryTheory.whiskeringLeft C D E).obj F.obj)
     (fun G => by dsimp; exact comp_preservesFiniteColimits _ _)
@@ -260,7 +260,7 @@ def RightExactFunctor.whiskeringLeft : (C ⥤ᵣ D) ⥤ (D ⥤ᵣ E) ⥤ (C ⥤�
     aesop_cat
 
 /-- Whiskering a right exact functor by a right exact functor yields a right exact functor. -/
-@[simps!]
+@[simps! obj_obj obj_map map_app_app]
 def RightExactFunctor.whiskeringRight : (D ⥤ᵣ E) ⥤ (C ⥤ᵣ D) ⥤ (C ⥤ᵣ E) where
   obj F := FullSubcategory.lift _ (forget _ _ ⋙ (CategoryTheory.whiskeringRight C D E).obj F.obj)
     (fun G => by dsimp; exact comp_preservesFiniteColimits _ _)
@@ -275,7 +275,7 @@ def RightExactFunctor.whiskeringRight : (D ⥤ᵣ E) ⥤ (C ⥤ᵣ D) ⥤ (C ⥤
     aesop_cat
 
 /-- Whiskering an exact functor by an exact functor yields an exact functor. -/
-@[simps!]
+@[simps! obj_obj obj_map map_app_app]
 def ExactFunctor.whiskeringLeft : (C ⥤ₑ D) ⥤ (D ⥤ₑ E) ⥤ (C ⥤ₑ E) where
   obj F := FullSubcategory.lift _ (forget _ _ ⋙ (CategoryTheory.whiskeringLeft C D E).obj F.obj)
     (fun G => ⟨by dsimp; exact comp_preservesFiniteLimits _ _,
@@ -291,7 +291,7 @@ def ExactFunctor.whiskeringLeft : (C ⥤ₑ D) ⥤ (D ⥤ₑ E) ⥤ (C ⥤ₑ E)
     aesop_cat
 
 /-- Whiskering an exact functor by an exact functor yields an exact functor. -/
-@[simps!]
+@[simps! obj_obj obj_map map_app_app]
 def ExactFunctor.whiskeringRight : (D ⥤ₑ E) ⥤ (C ⥤ₑ D) ⥤ (C ⥤ₑ E) where
   obj F := FullSubcategory.lift _ (forget _ _ ⋙ (CategoryTheory.whiskeringRight C D E).obj F.obj)
     (fun G => ⟨by dsimp; exact comp_preservesFiniteLimits _ _,


### PR DESCRIPTION
The previous generated `simp` lemmas were too specific. This PR instructs `simps` to generate the same lemmas as for the usual `CategoryTheory.whiskeringLeft`, which works better.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
