### PR TITLE
[Merged by Bors] - feat(CategoryTheory): preservation of well order continuous functors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1984,6 +1984,7 @@ import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Biproducts
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Equalizers
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Images
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Kernels
+import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Preorder
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Products
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Pullbacks
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Square

--- a/Mathlib/CategoryTheory/Limits/Comma.lean
+++ b/Mathlib/CategoryTheory/Limits/Comma.lean
@@ -153,6 +153,20 @@ instance hasColimitsOfSize [HasColimitsOfSize.{w, w'} A] [HasColimitsOfSize.{w, 
     [PreservesColimitsOfSize.{w, w'} L] : HasColimitsOfSize.{w, w'} (Comma L R) :=
   ⟨fun _ _ => inferInstance⟩
 
+instance preservesColimitsOfShape_fst [HasColimitsOfShape J A] [HasColimitsOfShape J B]
+    [PreservesColimitsOfShape J L] : PreservesColimitsOfShape J (Comma.fst L R) where
+  preservesColimit :=
+    preservesColimit_of_preserves_colimit_cocone
+      (coconeOfPreservesIsColimit _ (colimit.isColimit _) (colimit.isColimit _))
+      (colimit.isColimit _)
+
+instance preservesColimitsOfShape_snd [HasColimitsOfShape J A] [HasColimitsOfShape J B]
+    [PreservesColimitsOfShape J L] : PreservesColimitsOfShape J (Comma.snd L R) where
+  preservesColimit :=
+    preservesColimit_of_preserves_colimit_cocone
+      (coconeOfPreservesIsColimit _ (colimit.isColimit _) (colimit.isColimit _))
+      (colimit.isColimit _)
+
 end Comma
 
 namespace Arrow
@@ -178,6 +192,14 @@ instance hasColimitsOfShape [HasColimitsOfShape J T] : HasColimitsOfShape J (Arr
 
 instance hasColimits [HasColimits T] : HasColimits (Arrow T) :=
   ⟨fun _ _ => inferInstance⟩
+
+instance preservesColimitsOfShape_leftFunc [HasColimitsOfShape J T] :
+    PreservesColimitsOfShape J (Arrow.leftFunc : _ ⥤ T) := by
+  apply Comma.preservesColimitsOfShape_fst
+
+instance preservesColimitsOfShape_rightFunc [HasColimitsOfShape J T] :
+    PreservesColimitsOfShape J (Arrow.rightFunc : _ ⥤ T) := by
+  apply Comma.preservesColimitsOfShape_snd
 
 end Arrow
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Preorder.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import Mathlib.CategoryTheory.Limits.Shapes.Preorder.WellOrderContinuous
+import Mathlib.CategoryTheory.Limits.Shapes.Preorder.HasIterationOfShape
+import Mathlib.CategoryTheory.Limits.Preserves.Basic
+
+/-!
+# Preservation of well order continuous functors
+
+-/
+
+universe w w' v v' v'' u' u u''
+
+namespace CategoryTheory
+
+namespace Limits
+
+variable {C : Type u} {D : Type u'} {E : Type u''}
+  [Category.{v} C] [Category.{v'} D] [Category.{v''} E]
+  (J : Type w) [LinearOrder J]
+
+/-- A functor `G : C ⥤ D` satisfies `PreservesWellOrderContinuousOfShape J G`
+if for any limit element `j` in the preordered type `J`, the functor `G`
+preserves colimits of shape `Set.Iio j`. -/
+class PreservesWellOrderContinuousOfShape (G : C ⥤ D) : Prop where
+  preservesColimitsOfShape (j : J) (hj : Order.IsSuccLimit j) :
+    PreservesColimitsOfShape (Set.Iio j) G := by infer_instance
+
+variable {J} in
+lemma preservesColimitsOfShape_of_preservesWellOrderContinuousOfShape (G : C ⥤ D)
+    [PreservesWellOrderContinuousOfShape J G]
+    (j : J) (hj : Order.IsSuccLimit j) :
+    PreservesColimitsOfShape (Set.Iio j) G :=
+  PreservesWellOrderContinuousOfShape.preservesColimitsOfShape j hj
+
+instance (F : J ⥤ C) (G : C ⥤ D) [F.IsWellOrderContinuous]
+    [PreservesWellOrderContinuousOfShape J G] :
+    (F ⋙ G).IsWellOrderContinuous where
+  nonempty_isColimit j hj := ⟨by
+    have := preservesColimitsOfShape_of_preservesWellOrderContinuousOfShape G j hj
+    exact isColimitOfPreserves G (F.isColimitOfIsWellOrderContinuous j hj)⟩
+
+instance (G₁ : C ⥤ D) (G₂ : D ⥤ E)
+    [PreservesWellOrderContinuousOfShape J G₁]
+    [PreservesWellOrderContinuousOfShape J G₂] :
+    PreservesWellOrderContinuousOfShape J (G₁ ⋙ G₂) where
+  preservesColimitsOfShape j hj := by
+    have := preservesColimitsOfShape_of_preservesWellOrderContinuousOfShape G₁ j hj
+    have := preservesColimitsOfShape_of_preservesWellOrderContinuousOfShape G₂ j hj
+    infer_instance
+
+instance [HasIterationOfShape J C] (K : Type*) [Category K] (X : K) :
+    PreservesWellOrderContinuousOfShape J ((evaluation K C).obj X) where
+  preservesColimitsOfShape j hj := by
+    have := hasColimitsOfShape_of_isSuccLimit C j hj
+    infer_instance
+
+instance [HasIterationOfShape J C] :
+    PreservesWellOrderContinuousOfShape J (Arrow.leftFunc : _ ⥤ C) where
+  preservesColimitsOfShape j hj := by
+    have := hasColimitsOfShape_of_isSuccLimit C j hj
+    infer_instance
+
+instance [HasIterationOfShape J C] :
+    PreservesWellOrderContinuousOfShape J (Arrow.rightFunc : _ ⥤ C) where
+  preservesColimitsOfShape j hj := by
+    have := hasColimitsOfShape_of_isSuccLimit C j hj
+    infer_instance
+
+end Limits
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Preorder.lean
@@ -3,13 +3,18 @@ Copyright (c) 2025 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-
 import Mathlib.CategoryTheory.Limits.Shapes.Preorder.WellOrderContinuous
 import Mathlib.CategoryTheory.Limits.Shapes.Preorder.HasIterationOfShape
 import Mathlib.CategoryTheory.Limits.Preserves.Basic
 
 /-!
 # Preservation of well order continuous functors
+
+Given a well ordered type `J` and a functor `G : C ⥤ D`,
+we define a type class `PreservesWellOrderContinuousOfShape J G`
+saying that `G` preserves colimits of shape `Set.Iio j`
+for any limit element `j : J`. It follows that if
+`F : J ⥤ C` is well order continuous, then so is `F ⋙ G`.
 
 -/
 


### PR DESCRIPTION
Given a well ordered type `J` and a functor `G : C ⥤ D`, we define a type class `PreservesWellOrderContinuousOfShape J G` saying that `G` preserves colimits of shape `Set.Iio j` for any limit element `j : J`. It follows that if `F : J ⥤ C` is well order continuous, then so is `F ⋙ G`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
