### PR TITLE
[Merged by Bors] - chore(Matroid): rename `Rk` -> `Rank` in typeclass names

### DIFF
--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -41,8 +41,8 @@ Given `M : Matroid α` ...
     subset of `X`.
 * `M.Finite` means that `M` has finite ground set.
 * `M.Nonempty` means that the ground set of `M` is nonempty.
-* `FiniteRank M` means that the bases of `M` are finite.
-* `InfiniteRank M` means that the bases of `M` are infinite.
+* `RankFinite M` means that the bases of `M` are finite.
+* `RankInfinite M` means that the bases of `M` are infinite.
 * `RankPos M` means that the bases of `M` are nonempty.
 * `Finitary M` means that a set is independent if and only if all its finite subsets are
     independent.
@@ -81,7 +81,7 @@ There are a few design decisions worth discussing.
   (for instance, it is harder to prove that something is a matroid in the first place,
   and one must deal with `ℕ∞` rather than `ℕ`).
   For serious work on finite matroids, we provide the typeclasses
-  `[M.Finite]` and `[FiniteRank M]` and associated API.
+  `[M.Finite]` and `[RankFinite M]` and associated API.
 
 ### Cardinality
   Just as with bases of a vector space,
@@ -248,16 +248,16 @@ theorem set_finite (M : Matroid α) [M.Finite] (X : Set α) (hX : X ⊆ M.E := b
 instance finite_of_finite [Finite α] {M : Matroid α} : M.Finite :=
   ⟨Set.toFinite _⟩
 
-/-- A `FiniteRank` matroid is one whose bases are finite -/
-@[mk_iff] class FiniteRank (M : Matroid α) : Prop where
+/-- A `RankFinite` matroid is one whose bases are finite -/
+@[mk_iff] class RankFinite (M : Matroid α) : Prop where
   /-- There is a finite base -/
   exists_finite_base : ∃ B, M.Base B ∧ B.Finite
 
-instance finiteRank_of_finite (M : Matroid α) [M.Finite] : FiniteRank M :=
+instance rankFinite_of_finite (M : Matroid α) [M.Finite] : RankFinite M :=
   ⟨M.exists_base.imp (fun B hB ↦ ⟨hB, M.set_finite B (M.subset_ground _ hB)⟩)⟩
 
-/-- An `InfiniteRank` matroid is one whose bases are infinite. -/
-@[mk_iff] class InfiniteRank (M : Matroid α) : Prop where
+/-- An `RankInfinite` matroid is one whose bases are infinite. -/
+@[mk_iff] class RankInfinite (M : Matroid α) : Prop where
   /-- There is an infinite base -/
   exists_infinite_base : ∃ B, M.Base B ∧ B.Infinite
 
@@ -430,12 +430,12 @@ theorem Base.infinite_of_infinite (hB : M.Base B) (h : B.Infinite) (hB₁ : M.Ba
     B₁.Infinite :=
   by_contra (fun hB_inf ↦ (hB₁.finite_of_finite (not_infinite.mp hB_inf) hB).not_infinite h)
 
-theorem Base.finite [FiniteRank M] (hB : M.Base B) : B.Finite :=
-  let ⟨_,hB₀⟩ := ‹FiniteRank M›.exists_finite_base
+theorem Base.finite [RankFinite M] (hB : M.Base B) : B.Finite :=
+  let ⟨_,hB₀⟩ := ‹RankFinite M›.exists_finite_base
   hB₀.1.finite_of_finite hB₀.2 hB
 
-theorem Base.infinite [InfiniteRank M] (hB : M.Base B) : B.Infinite :=
-  let ⟨_,hB₀⟩ := ‹InfiniteRank M›.exists_infinite_base
+theorem Base.infinite [RankInfinite M] (hB : M.Base B) : B.Infinite :=
+  let ⟨_,hB₀⟩ := ‹RankInfinite M›.exists_infinite_base
   hB₀.1.infinite_of_infinite hB₀.2 hB
 
 theorem empty_not_base [h : RankPos M] : ¬M.Base ∅ :=
@@ -450,22 +450,22 @@ theorem Base.rankPos_of_nonempty (hB : M.Base B) (h : B.Nonempty) : M.RankPos :=
   obtain rfl := he.eq_of_subset_base hB (empty_subset B)
   simp at h
 
-theorem Base.finiteRank_of_finite (hB : M.Base B) (hfin : B.Finite) : FiniteRank M :=
+theorem Base.rankFinite_of_finite (hB : M.Base B) (hfin : B.Finite) : RankFinite M :=
   ⟨⟨B, hB, hfin⟩⟩
 
-theorem Base.infiniteRank_of_infinite (hB : M.Base B) (h : B.Infinite) : InfiniteRank M :=
+theorem Base.inrankFinite_of_infinite (hB : M.Base B) (h : B.Infinite) : RankInfinite M :=
   ⟨⟨B, hB, h⟩⟩
 
-theorem not_finiteRank (M : Matroid α) [InfiniteRank M] : ¬ FiniteRank M := by
+theorem not_rankFinite (M : Matroid α) [RankInfinite M] : ¬ RankFinite M := by
   intro h; obtain ⟨B,hB⟩ := M.exists_base; exact hB.infinite hB.finite
 
-theorem not_infiniteRank (M : Matroid α) [FiniteRank M] : ¬ InfiniteRank M := by
+theorem not_inrankFinite (M : Matroid α) [RankFinite M] : ¬ RankInfinite M := by
   intro h; obtain ⟨B,hB⟩ := M.exists_base; exact hB.infinite hB.finite
 
-theorem finite_or_infiniteRank (M : Matroid α) : FiniteRank M ∨ InfiniteRank M :=
+theorem finite_or_inrankFinite (M : Matroid α) : RankFinite M ∨ RankInfinite M :=
   let ⟨B, hB⟩ := M.exists_base
   B.finite_or_infinite.elim
-  (Or.inl ∘ hB.finiteRank_of_finite) (Or.inr ∘ hB.infiniteRank_of_infinite)
+  (Or.inl ∘ hB.rankFinite_of_finite) (Or.inr ∘ hB.inrankFinite_of_infinite)
 
 theorem Base.diff_finite_comm (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) :
     (B₁ \ B₂).Finite ↔ (B₂ \ B₁).Finite :=
@@ -575,7 +575,7 @@ theorem Base.indep (hB : M.Base B) : M.Indep B :=
 theorem Dep.nonempty (hD : M.Dep D) : D.Nonempty := by
   rw [nonempty_iff_ne_empty]; rintro rfl; exact hD.not_indep M.empty_indep
 
-theorem Indep.finite [FiniteRank M] (hI : M.Indep I) : I.Finite :=
+theorem Indep.finite [RankFinite M] (hI : M.Indep I) : I.Finite :=
   let ⟨_, hB, hIB⟩ := hI.exists_base_superset
   hB.finite.subset hIB
 
@@ -736,7 +736,7 @@ theorem indep_iff_forall_finite_subset_indep {M : Matroid α} [Finitary M] :
     M.Indep I ↔ ∀ J, J ⊆ I → J.Finite → M.Indep J :=
   ⟨fun h _ hJI _ ↦ h.subset hJI, Finitary.indep_of_forall_finite I⟩
 
-instance finitary_of_finiteRank {M : Matroid α} [FiniteRank M] : Finitary M :=
+instance finitary_of_rankFinite {M : Matroid α} [RankFinite M] : Finitary M :=
 ⟨ by
   refine fun I hI ↦ I.finite_or_infinite.elim (hI _ Subset.rfl) (fun h ↦ False.elim ?_)
   obtain ⟨B, hB⟩ := M.exists_base
@@ -839,7 +839,7 @@ theorem Basis.eq_of_subset_indep (hI : M.Basis I X) (hJ : M.Indep J) (hIJ : I �
     I = J :=
   hIJ.antisymm (hI.1.2 ⟨hJ, hJX⟩ hIJ)
 
-theorem Basis.Finite (hI : M.Basis I X) [FiniteRank M] : I.Finite := hI.indep.finite
+theorem Basis.Finite (hI : M.Basis I X) [RankFinite M] : I.Finite := hI.indep.finite
 
 theorem basis_iff' :
     M.Basis I X ↔ (M.Indep I ∧ I ⊆ X ∧ ∀ ⦃J⦄, M.Indep J → I ⊆ J → J ⊆ X → I = J) ∧ X ⊆ M.E := by

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -41,9 +41,9 @@ Given `M : Matroid α` ...
     subset of `X`.
 * `M.Finite` means that `M` has finite ground set.
 * `M.Nonempty` means that the ground set of `M` is nonempty.
-* `FiniteRk M` means that the bases of `M` are finite.
-* `InfiniteRk M` means that the bases of `M` are infinite.
-* `RkPos M` means that the bases of `M` are nonempty.
+* `FiniteRank M` means that the bases of `M` are finite.
+* `InfiniteRank M` means that the bases of `M` are infinite.
+* `RankPos M` means that the bases of `M` are nonempty.
 * `Finitary M` means that a set is independent if and only if all its finite subsets are
     independent.
 
@@ -81,7 +81,7 @@ There are a few design decisions worth discussing.
   (for instance, it is harder to prove that something is a matroid in the first place,
   and one must deal with `ℕ∞` rather than `ℕ`).
   For serious work on finite matroids, we provide the typeclasses
-  `[M.Finite]` and `[FiniteRk M]` and associated API.
+  `[M.Finite]` and `[FiniteRank M]` and associated API.
 
 ### Cardinality
   Just as with bases of a vector space,
@@ -248,31 +248,31 @@ theorem set_finite (M : Matroid α) [M.Finite] (X : Set α) (hX : X ⊆ M.E := b
 instance finite_of_finite [Finite α] {M : Matroid α} : M.Finite :=
   ⟨Set.toFinite _⟩
 
-/-- A `FiniteRk` matroid is one whose bases are finite -/
-@[mk_iff] class FiniteRk (M : Matroid α) : Prop where
+/-- A `FiniteRank` matroid is one whose bases are finite -/
+@[mk_iff] class FiniteRank (M : Matroid α) : Prop where
   /-- There is a finite base -/
   exists_finite_base : ∃ B, M.Base B ∧ B.Finite
 
-instance finiteRk_of_finite (M : Matroid α) [M.Finite] : FiniteRk M :=
+instance finiteRank_of_finite (M : Matroid α) [M.Finite] : FiniteRank M :=
   ⟨M.exists_base.imp (fun B hB ↦ ⟨hB, M.set_finite B (M.subset_ground _ hB)⟩)⟩
 
-/-- An `InfiniteRk` matroid is one whose bases are infinite. -/
-@[mk_iff] class InfiniteRk (M : Matroid α) : Prop where
+/-- An `InfiniteRank` matroid is one whose bases are infinite. -/
+@[mk_iff] class InfiniteRank (M : Matroid α) : Prop where
   /-- There is an infinite base -/
   exists_infinite_base : ∃ B, M.Base B ∧ B.Infinite
 
-/-- A `RkPos` matroid is one whose bases are nonempty. -/
-@[mk_iff] class RkPos (M : Matroid α) : Prop where
+/-- A `RankPos` matroid is one whose bases are nonempty. -/
+@[mk_iff] class RankPos (M : Matroid α) : Prop where
   /-- The empty set isn't a base -/
   empty_not_base : ¬M.Base ∅
 
-instance rkPos_nonempty {M : Matroid α} [M.RkPos] : M.Nonempty := by
+instance rankPos_nonempty {M : Matroid α} [M.RankPos] : M.Nonempty := by
   obtain ⟨B, hB⟩ := M.exists_base
   obtain rfl | ⟨e, heB⟩ := B.eq_empty_or_nonempty
-  · exact False.elim <| RkPos.empty_not_base hB
+  · exact False.elim <| RankPos.empty_not_base hB
   exact ⟨e, M.subset_ground B hB heB ⟩
 
-@[deprecated (since := "2025-01-20")] alias rkPos_iff_empty_not_base := rkPos_iff
+@[deprecated (since := "2025-01-20")] alias rkPos_iff_empty_not_base := rankPos_iff
 
 section exchange
 namespace ExchangeProperty
@@ -430,42 +430,42 @@ theorem Base.infinite_of_infinite (hB : M.Base B) (h : B.Infinite) (hB₁ : M.Ba
     B₁.Infinite :=
   by_contra (fun hB_inf ↦ (hB₁.finite_of_finite (not_infinite.mp hB_inf) hB).not_infinite h)
 
-theorem Base.finite [FiniteRk M] (hB : M.Base B) : B.Finite :=
-  let ⟨_,hB₀⟩ := ‹FiniteRk M›.exists_finite_base
+theorem Base.finite [FiniteRank M] (hB : M.Base B) : B.Finite :=
+  let ⟨_,hB₀⟩ := ‹FiniteRank M›.exists_finite_base
   hB₀.1.finite_of_finite hB₀.2 hB
 
-theorem Base.infinite [InfiniteRk M] (hB : M.Base B) : B.Infinite :=
-  let ⟨_,hB₀⟩ := ‹InfiniteRk M›.exists_infinite_base
+theorem Base.infinite [InfiniteRank M] (hB : M.Base B) : B.Infinite :=
+  let ⟨_,hB₀⟩ := ‹InfiniteRank M›.exists_infinite_base
   hB₀.1.infinite_of_infinite hB₀.2 hB
 
-theorem empty_not_base [h : RkPos M] : ¬M.Base ∅ :=
+theorem empty_not_base [h : RankPos M] : ¬M.Base ∅ :=
   h.empty_not_base
 
-theorem Base.nonempty [RkPos M] (hB : M.Base B) : B.Nonempty := by
+theorem Base.nonempty [RankPos M] (hB : M.Base B) : B.Nonempty := by
   rw [nonempty_iff_ne_empty]; rintro rfl; exact M.empty_not_base hB
 
-theorem Base.rkPos_of_nonempty (hB : M.Base B) (h : B.Nonempty) : M.RkPos := by
-  rw [rkPos_iff]
+theorem Base.rankPos_of_nonempty (hB : M.Base B) (h : B.Nonempty) : M.RankPos := by
+  rw [rankPos_iff]
   intro he
   obtain rfl := he.eq_of_subset_base hB (empty_subset B)
   simp at h
 
-theorem Base.finiteRk_of_finite (hB : M.Base B) (hfin : B.Finite) : FiniteRk M :=
+theorem Base.finiteRank_of_finite (hB : M.Base B) (hfin : B.Finite) : FiniteRank M :=
   ⟨⟨B, hB, hfin⟩⟩
 
-theorem Base.infiniteRk_of_infinite (hB : M.Base B) (h : B.Infinite) : InfiniteRk M :=
+theorem Base.infiniteRank_of_infinite (hB : M.Base B) (h : B.Infinite) : InfiniteRank M :=
   ⟨⟨B, hB, h⟩⟩
 
-theorem not_finiteRk (M : Matroid α) [InfiniteRk M] : ¬ FiniteRk M := by
+theorem not_finiteRank (M : Matroid α) [InfiniteRank M] : ¬ FiniteRank M := by
   intro h; obtain ⟨B,hB⟩ := M.exists_base; exact hB.infinite hB.finite
 
-theorem not_infiniteRk (M : Matroid α) [FiniteRk M] : ¬ InfiniteRk M := by
+theorem not_infiniteRank (M : Matroid α) [FiniteRank M] : ¬ InfiniteRank M := by
   intro h; obtain ⟨B,hB⟩ := M.exists_base; exact hB.infinite hB.finite
 
-theorem finite_or_infiniteRk (M : Matroid α) : FiniteRk M ∨ InfiniteRk M :=
+theorem finite_or_infiniteRank (M : Matroid α) : FiniteRank M ∨ InfiniteRank M :=
   let ⟨B, hB⟩ := M.exists_base
   B.finite_or_infinite.elim
-  (Or.inl ∘ hB.finiteRk_of_finite) (Or.inr ∘ hB.infiniteRk_of_infinite)
+  (Or.inl ∘ hB.finiteRank_of_finite) (Or.inr ∘ hB.infiniteRank_of_infinite)
 
 theorem Base.diff_finite_comm (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) :
     (B₁ \ B₂).Finite ↔ (B₂ \ B₁).Finite :=
@@ -575,13 +575,13 @@ theorem Base.indep (hB : M.Base B) : M.Indep B :=
 theorem Dep.nonempty (hD : M.Dep D) : D.Nonempty := by
   rw [nonempty_iff_ne_empty]; rintro rfl; exact hD.not_indep M.empty_indep
 
-theorem Indep.finite [FiniteRk M] (hI : M.Indep I) : I.Finite :=
+theorem Indep.finite [FiniteRank M] (hI : M.Indep I) : I.Finite :=
   let ⟨_, hB, hIB⟩ := hI.exists_base_superset
   hB.finite.subset hIB
 
-theorem Indep.rkPos_of_nonempty (hI : M.Indep I) (hne : I.Nonempty) : M.RkPos := by
+theorem Indep.rankPos_of_nonempty (hI : M.Indep I) (hne : I.Nonempty) : M.RankPos := by
   obtain ⟨B, hB, hIB⟩ := hI.exists_base_superset
-  exact hB.rkPos_of_nonempty (hne.mono hIB)
+  exact hB.rankPos_of_nonempty (hne.mono hIB)
 
 theorem Indep.inter_right (hI : M.Indep I) (X : Set α) : M.Indep (I ∩ X) :=
   hI.subset inter_subset_left
@@ -736,7 +736,7 @@ theorem indep_iff_forall_finite_subset_indep {M : Matroid α} [Finitary M] :
     M.Indep I ↔ ∀ J, J ⊆ I → J.Finite → M.Indep J :=
   ⟨fun h _ hJI _ ↦ h.subset hJI, Finitary.indep_of_forall_finite I⟩
 
-instance finitary_of_finiteRk {M : Matroid α} [FiniteRk M] : Finitary M :=
+instance finitary_of_finiteRank {M : Matroid α} [FiniteRank M] : Finitary M :=
 ⟨ by
   refine fun I hI ↦ I.finite_or_infinite.elim (hI _ Subset.rfl) (fun h ↦ False.elim ?_)
   obtain ⟨B, hB⟩ := M.exists_base
@@ -839,7 +839,7 @@ theorem Basis.eq_of_subset_indep (hI : M.Basis I X) (hJ : M.Indep J) (hIJ : I �
     I = J :=
   hIJ.antisymm (hI.1.2 ⟨hJ, hJX⟩ hIJ)
 
-theorem Basis.Finite (hI : M.Basis I X) [FiniteRk M] : I.Finite := hI.indep.finite
+theorem Basis.Finite (hI : M.Basis I X) [FiniteRank M] : I.Finite := hI.indep.finite
 
 theorem basis_iff' :
     M.Basis I X ↔ (M.Indep I ∧ I ⊆ X ∧ ∀ ⦃J⦄, M.Indep J → I ⊆ J → J ⊆ X → I = J) ∧ X ⊆ M.E := by

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -252,7 +252,7 @@ instance finite_of_finite [Finite α] {M : Matroid α} : M.Finite :=
 @[mk_iff] class RankFinite (M : Matroid α) : Prop where
   /-- There is a finite base -/
   exists_finite_base : ∃ B, M.Base B ∧ B.Finite
-@[deprecated (since := "2025-02-09")] noncomputable alias FiniteRk := RankFinite
+@[deprecated (since := "2025-02-09")] alias FiniteRk := RankFinite
 
 instance rankFinite_of_finite (M : Matroid α) [M.Finite] : RankFinite M :=
   ⟨M.exists_base.imp (fun B hB ↦ ⟨hB, M.set_finite B (M.subset_ground _ hB)⟩)⟩
@@ -261,13 +261,13 @@ instance rankFinite_of_finite (M : Matroid α) [M.Finite] : RankFinite M :=
 @[mk_iff] class RankInfinite (M : Matroid α) : Prop where
   /-- There is an infinite base -/
   exists_infinite_base : ∃ B, M.Base B ∧ B.Infinite
-@[deprecated (since := "2025-02-09")] noncomputable alias InfiniteRk := RankInfinite
+@[deprecated (since := "2025-02-09")] alias InfiniteRk := RankInfinite
 
 /-- A `RankPos` matroid is one whose bases are nonempty. -/
 @[mk_iff] class RankPos (M : Matroid α) : Prop where
   /-- The empty set isn't a base -/
   empty_not_base : ¬M.Base ∅
-@[deprecated (since := "2025-02-09")] noncomputable alias RkPos := RankPos
+@[deprecated (since := "2025-02-09")] alias RkPos := RankPos
 
 instance rankPos_nonempty {M : Matroid α} [M.RankPos] : M.Nonempty := by
   obtain ⟨B, hB⟩ := M.exists_base

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -252,6 +252,7 @@ instance finite_of_finite [Finite α] {M : Matroid α} : M.Finite :=
 @[mk_iff] class RankFinite (M : Matroid α) : Prop where
   /-- There is a finite base -/
   exists_finite_base : ∃ B, M.Base B ∧ B.Finite
+@[deprecated (since := "2025-02-09")] noncomputable alias FiniteRk := RankFinite
 
 instance rankFinite_of_finite (M : Matroid α) [M.Finite] : RankFinite M :=
   ⟨M.exists_base.imp (fun B hB ↦ ⟨hB, M.set_finite B (M.subset_ground _ hB)⟩)⟩
@@ -260,11 +261,13 @@ instance rankFinite_of_finite (M : Matroid α) [M.Finite] : RankFinite M :=
 @[mk_iff] class RankInfinite (M : Matroid α) : Prop where
   /-- There is an infinite base -/
   exists_infinite_base : ∃ B, M.Base B ∧ B.Infinite
+@[deprecated (since := "2025-02-09")] noncomputable alias InfiniteRk := RankInfinite
 
 /-- A `RankPos` matroid is one whose bases are nonempty. -/
 @[mk_iff] class RankPos (M : Matroid α) : Prop where
   /-- The empty set isn't a base -/
   empty_not_base : ¬M.Base ∅
+@[deprecated (since := "2025-02-09")] noncomputable alias RkPos := RankPos
 
 instance rankPos_nonempty {M : Matroid α} [M.RankPos] : M.Nonempty := by
   obtain ⟨B, hB⟩ := M.exists_base

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -453,19 +453,19 @@ theorem Base.rankPos_of_nonempty (hB : M.Base B) (h : B.Nonempty) : M.RankPos :=
 theorem Base.rankFinite_of_finite (hB : M.Base B) (hfin : B.Finite) : RankFinite M :=
   ⟨⟨B, hB, hfin⟩⟩
 
-theorem Base.inrankFinite_of_infinite (hB : M.Base B) (h : B.Infinite) : RankInfinite M :=
+theorem Base.rankInfinite_of_infinite (hB : M.Base B) (h : B.Infinite) : RankInfinite M :=
   ⟨⟨B, hB, h⟩⟩
 
 theorem not_rankFinite (M : Matroid α) [RankInfinite M] : ¬ RankFinite M := by
   intro h; obtain ⟨B,hB⟩ := M.exists_base; exact hB.infinite hB.finite
 
-theorem not_inrankFinite (M : Matroid α) [RankFinite M] : ¬ RankInfinite M := by
+theorem not_rankInfinite (M : Matroid α) [RankFinite M] : ¬ RankInfinite M := by
   intro h; obtain ⟨B,hB⟩ := M.exists_base; exact hB.infinite hB.finite
 
-theorem finite_or_inrankFinite (M : Matroid α) : RankFinite M ∨ RankInfinite M :=
+theorem finite_or_rankInfinite (M : Matroid α) : RankFinite M ∨ RankInfinite M :=
   let ⟨B, hB⟩ := M.exists_base
   B.finite_or_infinite.elim
-  (Or.inl ∘ hB.rankFinite_of_finite) (Or.inr ∘ hB.inrankFinite_of_infinite)
+  (Or.inl ∘ hB.rankFinite_of_finite) (Or.inr ∘ hB.rankInfinite_of_infinite)
 
 theorem Base.diff_finite_comm (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) :
     (B₁ \ B₂).Finite ↔ (B₂ \ B₁).Finite :=

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -252,6 +252,7 @@ instance finite_of_finite [Finite α] {M : Matroid α} : M.Finite :=
 @[mk_iff] class RankFinite (M : Matroid α) : Prop where
   /-- There is a finite base -/
   exists_finite_base : ∃ B, M.Base B ∧ B.Finite
+
 @[deprecated (since := "2025-02-09")] alias FiniteRk := RankFinite
 
 instance rankFinite_of_finite (M : Matroid α) [M.Finite] : RankFinite M :=
@@ -261,12 +262,14 @@ instance rankFinite_of_finite (M : Matroid α) [M.Finite] : RankFinite M :=
 @[mk_iff] class RankInfinite (M : Matroid α) : Prop where
   /-- There is an infinite base -/
   exists_infinite_base : ∃ B, M.Base B ∧ B.Infinite
+
 @[deprecated (since := "2025-02-09")] alias InfiniteRk := RankInfinite
 
 /-- A `RankPos` matroid is one whose bases are nonempty. -/
 @[mk_iff] class RankPos (M : Matroid α) : Prop where
   /-- The empty set isn't a base -/
   empty_not_base : ¬M.Base ∅
+
 @[deprecated (since := "2025-02-09")] alias RkPos := RankPos
 
 instance rankPos_nonempty {M : Matroid α} [M.RankPos] : M.Nonempty := by

--- a/Mathlib/Data/Matroid/Constructions.lean
+++ b/Mathlib/Data/Matroid/Constructions.lean
@@ -105,7 +105,7 @@ theorem eq_loopyOn_iff : M = loopyOn E ↔ M.E = E ∧ ∀ X ⊆ M.E, M.Indep X 
   ⟨fun h ↦ ⟨loopyOn_indep_iff.mp h.indep, h.subset_ground⟩,
     by rintro ⟨rfl, hX⟩; rw [basis_iff]; simp⟩
 
-instance : FiniteRank (loopyOn E) :=
+instance : RankFinite (loopyOn E) :=
   ⟨⟨∅, loopyOn_base_iff.2 rfl, finite_empty⟩⟩
 
 theorem Finite.loopyOn_finite (hE : E.Finite) : Matroid.Finite (loopyOn E) :=
@@ -128,7 +128,7 @@ theorem eq_loopyOn_or_rankPos (M : Matroid α) : M = loopyOn M.E ∨ RankPos M :
 theorem not_rankPos_iff : ¬RankPos M ↔ M = loopyOn M.E := by
   rw [rankPos_iff, not_iff_comm, empty_base_iff]
 
-instance loopyOn_finiteRank : FiniteRank (loopyOn E) :=
+instance loopyOn_rankFinite : RankFinite (loopyOn E) :=
   ⟨∅, by simp⟩
 
 end LoopyOn
@@ -253,7 +253,7 @@ theorem uniqueBaseOn_restrict (h : I ⊆ E) (R : Set α) :
     (uniqueBaseOn I E) ↾ R = uniqueBaseOn (I ∩ R) R := by
   rw [uniqueBaseOn_restrict', inter_right_comm, inter_eq_self_of_subset_left h]
 
-lemma uniqueBaseOn_finiteRank (hI : I.Finite) : FiniteRank (uniqueBaseOn I E) := by
+lemma uniqueBaseOn_rankFinite (hI : I.Finite) : RankFinite (uniqueBaseOn I E) := by
   rw [← uniqueBaseOn_inter_ground_eq]
   refine ⟨I ∩ E, ?_⟩
   rw [uniqueBaseOn_base_iff inter_subset_right, and_iff_right rfl]

--- a/Mathlib/Data/Matroid/Constructions.lean
+++ b/Mathlib/Data/Matroid/Constructions.lean
@@ -105,7 +105,7 @@ theorem eq_loopyOn_iff : M = loopyOn E ↔ M.E = E ∧ ∀ X ⊆ M.E, M.Indep X 
   ⟨fun h ↦ ⟨loopyOn_indep_iff.mp h.indep, h.subset_ground⟩,
     by rintro ⟨rfl, hX⟩; rw [basis_iff]; simp⟩
 
-instance : FiniteRk (loopyOn E) :=
+instance : FiniteRank (loopyOn E) :=
   ⟨⟨∅, loopyOn_base_iff.2 rfl, finite_empty⟩⟩
 
 theorem Finite.loopyOn_finite (hE : E.Finite) : Matroid.Finite (loopyOn E) :=
@@ -122,13 +122,13 @@ theorem empty_base_iff : M.Base ∅ ↔ M = loopyOn M.E := by
     loopyOn_indep_iff]
   exact ⟨fun h I _ ↦ ⟨@h _, fun hI ↦ by simp [hI]⟩, fun h I hI ↦ (h hI.subset_ground).1 hI⟩
 
-theorem eq_loopyOn_or_rkPos (M : Matroid α) : M = loopyOn M.E ∨ RkPos M := by
-  rw [← empty_base_iff, rkPos_iff]; apply em
+theorem eq_loopyOn_or_rankPos (M : Matroid α) : M = loopyOn M.E ∨ RankPos M := by
+  rw [← empty_base_iff, rankPos_iff]; apply em
 
-theorem not_rkPos_iff : ¬RkPos M ↔ M = loopyOn M.E := by
-  rw [rkPos_iff, not_iff_comm, empty_base_iff]
+theorem not_rankPos_iff : ¬RankPos M ↔ M = loopyOn M.E := by
+  rw [rankPos_iff, not_iff_comm, empty_base_iff]
 
-instance loopyOn_finiteRk : FiniteRk (loopyOn E) :=
+instance loopyOn_finiteRank : FiniteRank (loopyOn E) :=
   ⟨∅, by simp⟩
 
 end LoopyOn
@@ -190,8 +190,8 @@ instance freeOn_finitary : Finitary (freeOn E) := by
   simp only [finitary_iff, freeOn_indep_iff]
   exact fun I h e heI ↦ by simpa using h {e} (by simpa)
 
-lemma freeOn_rkPos (hE : E.Nonempty) : RkPos (freeOn E) := by
-  simp [rkPos_iff, hE.ne_empty.symm]
+lemma freeOn_rankPos (hE : E.Nonempty) : RankPos (freeOn E) := by
+  simp [rankPos_iff, hE.ne_empty.symm]
 
 end FreeOn
 
@@ -253,7 +253,7 @@ theorem uniqueBaseOn_restrict (h : I ⊆ E) (R : Set α) :
     (uniqueBaseOn I E) ↾ R = uniqueBaseOn (I ∩ R) R := by
   rw [uniqueBaseOn_restrict', inter_right_comm, inter_eq_self_of_subset_left h]
 
-lemma uniqueBaseOn_finiteRk (hI : I.Finite) : FiniteRk (uniqueBaseOn I E) := by
+lemma uniqueBaseOn_finiteRank (hI : I.Finite) : FiniteRank (uniqueBaseOn I E) := by
   rw [← uniqueBaseOn_inter_ground_eq]
   refine ⟨I ∩ E, ?_⟩
   rw [uniqueBaseOn_base_iff inter_subset_right, and_iff_right rfl]
@@ -264,7 +264,7 @@ instance uniqueBaseOn_finitary : Finitary (uniqueBaseOn I E) := by
   simp only [uniqueBaseOn_indep_iff'] at hK ⊢
   exact fun e heK ↦ singleton_subset_iff.1 <| hK _ (by simpa) (by simp)
 
-lemma uniqueBaseOn_rkPos (hIE : I ⊆ E) (hI : I.Nonempty) : RkPos (uniqueBaseOn I E) where
+lemma uniqueBaseOn_rankPos (hIE : I ⊆ E) (hI : I.Nonempty) : RankPos (uniqueBaseOn I E) where
   empty_not_base := by simpa [uniqueBaseOn_base_iff hIE] using Ne.symm <| hI.ne_empty
 
 end uniqueBaseOn

--- a/Mathlib/Data/Matroid/Dual.lean
+++ b/Mathlib/Data/Matroid/Dual.lean
@@ -205,13 +205,13 @@ theorem base_iff_dual_base_compl (hB : B ⊆ M.E := by aesop_mat) :
     M.Base B ↔ M✶.Base (M.E \ B) := by
   rw [dual_base_iff, diff_diff_cancel_left hB]
 
-theorem ground_not_base (M : Matroid α) [h : RkPos M✶] : ¬M.Base M.E := by
-  rwa [rkPos_iff, dual_base_iff, diff_empty] at h
+theorem ground_not_base (M : Matroid α) [h : RankPos M✶] : ¬M.Base M.E := by
+  rwa [rankPos_iff, dual_base_iff, diff_empty] at h
 
-theorem Base.ssubset_ground [h : RkPos M✶] (hB : M.Base B) : B ⊂ M.E :=
+theorem Base.ssubset_ground [h : RankPos M✶] (hB : M.Base B) : B ⊂ M.E :=
   hB.subset_ground.ssubset_of_ne (by rintro rfl; exact M.ground_not_base hB)
 
-theorem Indep.ssubset_ground [h : RkPos M✶] (hI : M.Indep I) : I ⊂ M.E := by
+theorem Indep.ssubset_ground [h : RankPos M✶] (hI : M.Indep I) : I ⊂ M.E := by
   obtain ⟨B, hB⟩ := hI.exists_base_superset; exact hB.2.trans_ssubset hB.1.ssubset_ground
 
 /-- A coindependent set of `M` is an independent set of the dual of `M✶`. we give it a separate

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -66,7 +66,7 @@ for the inverse of `e`).
 
 * `IndepMatroid.ofBdd` constructs an `IndepMatroid` in the case where there is some known
   absolute upper bound on the size of an independent set. This uses the infinite version of
-  the augmentation axiom; the corresponding `Matroid` is `FiniteRank`.
+  the augmentation axiom; the corresponding `Matroid` is `RankFinite`.
 
 * `IndepMatroid.ofBddAugment` is the same as the above, but with a finite augmentation axiom.
 
@@ -80,7 +80,7 @@ for the inverse of `e`).
   existentially, but whose independence predicate is known explicitly.
 
 * `Matroid.ofExistsFiniteBase` constructs a matroid from its bases, if it is known that one
-  of them is finite. This gives a `FiniteRank` matroid.
+  of them is finite. This gives a `RankFinite` matroid.
 
 * `Matroid.ofBaseOfFinite` constructs a `Finite` matroid from its bases.
 -/
@@ -321,12 +321,12 @@ theorem _root_.Matroid.existsMaximalSubsetProperty_of_bdd {P : Set α → Prop}
     subset_ground h_bdd : (IndepMatroid.ofBdd
       E Indep indep_empty indep_subset indep_aug subset_ground h_bdd).Indep = Indep := rfl
 
-/-- `IndepMatroid.ofBdd` constructs a `FiniteRank` matroid. -/
+/-- `IndepMatroid.ofBdd` constructs a `RankFinite` matroid. -/
 instance (E : Set α) (Indep : Set α → Prop) indep_empty indep_subset indep_aug subset_ground h_bdd :
-    FiniteRank (IndepMatroid.ofBdd
+    RankFinite (IndepMatroid.ofBdd
       E Indep indep_empty indep_subset indep_aug subset_ground h_bdd).matroid := by
   obtain ⟨B, hB⟩ := (IndepMatroid.ofBdd E Indep _ _ _ _ _).matroid.exists_base
-  refine hB.finiteRank_of_finite ?_
+  refine hB.rankFinite_of_finite ?_
   obtain ⟨n, hn⟩ := h_bdd
   exact finite_of_encard_le_coe <| hn B (by simpa using hB.indep)
 
@@ -367,8 +367,8 @@ protected def ofBddAugment (E : Set α) (Indep : Set α → Prop)
     indep_bdd subset_ground : (IndepMatroid.ofBddAugment
       E Indep indep_empty indep_subset indep_aug indep_bdd subset_ground).Indep = Indep := rfl
 
-instance ofBddAugment_finiteRank (E : Set α) Indep indep_empty indep_subset indep_aug
-    indep_bdd subset_ground : FiniteRank (IndepMatroid.ofBddAugment
+instance ofBddAugment_rankFinite (E : Set α) Indep indep_empty indep_subset indep_aug
+    indep_bdd subset_ground : RankFinite (IndepMatroid.ofBddAugment
       E Indep indep_empty indep_subset indep_aug indep_bdd subset_ground).matroid := by
   rw [IndepMatroid.ofBddAugment]
   infer_instance
@@ -501,11 +501,11 @@ namespace Matroid
     base_exchange subset_ground : (Matroid.ofExistsFiniteBase
       E Base exists_finite_base base_exchange subset_ground).Base = Base := rfl
 
-instance ofExistsFiniteBase_finiteRank (E : Set α) Base exists_finite_base
-    base_exchange subset_ground : FiniteRank (Matroid.ofExistsFiniteBase
+instance ofExistsFiniteBase_rankFinite (E : Set α) Base exists_finite_base
+    base_exchange subset_ground : RankFinite (Matroid.ofExistsFiniteBase
       E Base exists_finite_base base_exchange subset_ground) := by
   obtain ⟨B, hB, hfin⟩ := exists_finite_base
-  exact Matroid.Base.finiteRank_of_finite (by simpa) hfin
+  exact Matroid.Base.rankFinite_of_finite (by simpa) hfin
 
 /-- If `E` is finite, then any nonempty collection of its subsets
   with the exchange property is the collection of bases of a matroid on `E`. -/

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -66,7 +66,7 @@ for the inverse of `e`).
 
 * `IndepMatroid.ofBdd` constructs an `IndepMatroid` in the case where there is some known
   absolute upper bound on the size of an independent set. This uses the infinite version of
-  the augmentation axiom; the corresponding `Matroid` is `FiniteRk`.
+  the augmentation axiom; the corresponding `Matroid` is `FiniteRank`.
 
 * `IndepMatroid.ofBddAugment` is the same as the above, but with a finite augmentation axiom.
 
@@ -80,7 +80,7 @@ for the inverse of `e`).
   existentially, but whose independence predicate is known explicitly.
 
 * `Matroid.ofExistsFiniteBase` constructs a matroid from its bases, if it is known that one
-  of them is finite. This gives a `FiniteRk` matroid.
+  of them is finite. This gives a `FiniteRank` matroid.
 
 * `Matroid.ofBaseOfFinite` constructs a `Finite` matroid from its bases.
 -/
@@ -321,12 +321,12 @@ theorem _root_.Matroid.existsMaximalSubsetProperty_of_bdd {P : Set α → Prop}
     subset_ground h_bdd : (IndepMatroid.ofBdd
       E Indep indep_empty indep_subset indep_aug subset_ground h_bdd).Indep = Indep := rfl
 
-/-- `IndepMatroid.ofBdd` constructs a `FiniteRk` matroid. -/
+/-- `IndepMatroid.ofBdd` constructs a `FiniteRank` matroid. -/
 instance (E : Set α) (Indep : Set α → Prop) indep_empty indep_subset indep_aug subset_ground h_bdd :
-    FiniteRk (IndepMatroid.ofBdd
+    FiniteRank (IndepMatroid.ofBdd
       E Indep indep_empty indep_subset indep_aug subset_ground h_bdd).matroid := by
   obtain ⟨B, hB⟩ := (IndepMatroid.ofBdd E Indep _ _ _ _ _).matroid.exists_base
-  refine hB.finiteRk_of_finite ?_
+  refine hB.finiteRank_of_finite ?_
   obtain ⟨n, hn⟩ := h_bdd
   exact finite_of_encard_le_coe <| hn B (by simpa using hB.indep)
 
@@ -367,8 +367,8 @@ protected def ofBddAugment (E : Set α) (Indep : Set α → Prop)
     indep_bdd subset_ground : (IndepMatroid.ofBddAugment
       E Indep indep_empty indep_subset indep_aug indep_bdd subset_ground).Indep = Indep := rfl
 
-instance ofBddAugment_finiteRk (E : Set α) Indep indep_empty indep_subset indep_aug
-    indep_bdd subset_ground : FiniteRk (IndepMatroid.ofBddAugment
+instance ofBddAugment_finiteRank (E : Set α) Indep indep_empty indep_subset indep_aug
+    indep_bdd subset_ground : FiniteRank (IndepMatroid.ofBddAugment
       E Indep indep_empty indep_subset indep_aug indep_bdd subset_ground).matroid := by
   rw [IndepMatroid.ofBddAugment]
   infer_instance
@@ -501,11 +501,11 @@ namespace Matroid
     base_exchange subset_ground : (Matroid.ofExistsFiniteBase
       E Base exists_finite_base base_exchange subset_ground).Base = Base := rfl
 
-instance ofExistsFiniteBase_finiteRk (E : Set α) Base exists_finite_base
-    base_exchange subset_ground : FiniteRk (Matroid.ofExistsFiniteBase
+instance ofExistsFiniteBase_finiteRank (E : Set α) Base exists_finite_base
+    base_exchange subset_ground : FiniteRank (Matroid.ofExistsFiniteBase
       E Base exists_finite_base base_exchange subset_ground) := by
   obtain ⟨B, hB, hfin⟩ := exists_finite_base
-  exact Matroid.Base.finiteRk_of_finite (by simpa) hfin
+  exact Matroid.Base.finiteRank_of_finite (by simpa) hfin
 
 /-- If `E` is finite, then any nonempty collection of its subsets
   with the exchange property is the collection of bases of a matroid on `E`. -/

--- a/Mathlib/Data/Matroid/Map.lean
+++ b/Mathlib/Data/Matroid/Map.lean
@@ -232,9 +232,9 @@ instance comap_finitary (N : Matroid β) [N.Finitary] (f : α → β) : (N.comap
   rw [← hJ'.image_eq] at hfin ⊢
   exact (hI J' (hJ'J.trans hJ) (hfin.of_finite_image hJ'.injOn)).1
 
-instance comap_finiteRk (N : Matroid β) [N.FiniteRk] (f : α → β) : (N.comap f).FiniteRk := by
+instance comap_finiteRank (N : Matroid β) [N.FiniteRank] (f : α → β) : (N.comap f).FiniteRank := by
   obtain ⟨B, hB⟩ := (N.comap f).exists_base
-  refine hB.finiteRk_of_finite ?_
+  refine hB.finiteRank_of_finite ?_
   simp only [comap_base_iff] at hB
   exact (hB.1.indep.finite.of_finite_image hB.2.1)
 
@@ -287,7 +287,7 @@ lemma comapOn_dual_eq_of_bijOn (h : BijOn f E N.E) :
 instance comapOn_finitary [N.Finitary] : (N.comapOn E f).Finitary := by
   rw [comapOn]; infer_instance
 
-instance comapOn_finiteRk [N.FiniteRk] : (N.comapOn E f).FiniteRk := by
+instance comapOn_finiteRank [N.FiniteRank] : (N.comapOn E f).FiniteRank := by
   rw [comapOn]; infer_instance
 
 end comapOn
@@ -490,13 +490,13 @@ instance [M.Finitary] {f : α → β} (hf) : (M.map f hf).Finitary := by
   specialize hI (f '' J₀) (image_subset f hJ₀I₀) (hJ₀.image _)
   rwa [map_image_indep_iff (hJ₀I₀.trans hI₀E)] at hI
 
-instance [M.FiniteRk] {f : α → β} (hf) : (M.map f hf).FiniteRk :=
+instance [M.FiniteRank] {f : α → β} (hf) : (M.map f hf).FiniteRank :=
   let ⟨_, hB⟩ := M.exists_base
-  (hB.map hf).finiteRk_of_finite (hB.finite.image _)
+  (hB.map hf).finiteRank_of_finite (hB.finite.image _)
 
-instance [M.RkPos] {f : α → β} (hf) : (M.map f hf).RkPos :=
+instance [M.RankPos] {f : α → β} (hf) : (M.map f hf).RankPos :=
   let ⟨_, hB⟩ := M.exists_base
-  (hB.map hf).rkPos_of_nonempty (hB.nonempty.image _)
+  (hB.map hf).rankPos_of_nonempty (hB.nonempty.image _)
 
 end map
 
@@ -572,11 +572,11 @@ instance [M.Finite] {f : α ↪ β} : (M.mapEmbedding f).Finite :=
 instance [M.Finitary] {f : α ↪ β} : (M.mapEmbedding f).Finitary :=
   inferInstanceAs (M.map f f.injective.injOn).Finitary
 
-instance [M.FiniteRk] {f : α ↪ β} : (M.mapEmbedding f).FiniteRk :=
-  inferInstanceAs (M.map f f.injective.injOn).FiniteRk
+instance [M.FiniteRank] {f : α ↪ β} : (M.mapEmbedding f).FiniteRank :=
+  inferInstanceAs (M.map f f.injective.injOn).FiniteRank
 
-instance [M.RkPos] {f : α ↪ β} : (M.mapEmbedding f).RkPos :=
-  inferInstanceAs (M.map f f.injective.injOn).RkPos
+instance [M.RankPos] {f : α ↪ β} : (M.mapEmbedding f).RankPos :=
+  inferInstanceAs (M.map f f.injective.injOn).RankPos
 
 end mapEmbedding
 
@@ -620,11 +620,11 @@ instance [M.Finite] {f : α ≃ β} : (M.mapEquiv f).Finite :=
 instance [M.Finitary] {f : α ≃ β} : (M.mapEquiv f).Finitary :=
   inferInstanceAs (M.map f f.injective.injOn).Finitary
 
-instance [M.FiniteRk] {f : α ≃ β} : (M.mapEquiv f).FiniteRk :=
-  inferInstanceAs (M.map f f.injective.injOn).FiniteRk
+instance [M.FiniteRank] {f : α ≃ β} : (M.mapEquiv f).FiniteRank :=
+  inferInstanceAs (M.map f f.injective.injOn).FiniteRank
 
-instance [M.RkPos] {f : α ≃ β} : (M.mapEquiv f).RkPos :=
-  inferInstanceAs (M.map f f.injective.injOn).RkPos
+instance [M.RankPos] {f : α ≃ β} : (M.mapEquiv f).RankPos :=
+  inferInstanceAs (M.map f f.injective.injOn).RankPos
 
 end mapEquiv
 
@@ -698,7 +698,7 @@ lemma map_val_restrictSubtype_ground_eq (M : Matroid α) :
 instance [M.Finitary] {X : Set α} : (M.restrictSubtype X).Finitary := by
   rw [restrictSubtype]; infer_instance
 
-instance [M.FiniteRk] {X : Set α} : (M.restrictSubtype X).FiniteRk := by
+instance [M.FiniteRank] {X : Set α} : (M.restrictSubtype X).FiniteRank := by
   rw [restrictSubtype]; infer_instance
 
 instance [M.Finite] : (M.restrictSubtype M.E).Finite :=
@@ -709,10 +709,10 @@ instance [M.Nonempty] : (M.restrictSubtype M.E).Nonempty :=
   have := M.ground_nonempty.coe_sort
   ⟨by simp⟩
 
-instance [M.RkPos] : (M.restrictSubtype M.E).RkPos := by
+instance [M.RankPos] : (M.restrictSubtype M.E).RankPos := by
   obtain ⟨B, hB⟩ := (M.restrictSubtype M.E).exists_base
   have hB' : M.Base ↑B := by simpa using hB.map Subtype.val_injective.injOn
-  exact hB.rkPos_of_nonempty <| by simpa using hB'.nonempty
+  exact hB.rankPos_of_nonempty <| by simpa using hB'.nonempty
 
 end restrictSubtype
 

--- a/Mathlib/Data/Matroid/Map.lean
+++ b/Mathlib/Data/Matroid/Map.lean
@@ -232,9 +232,9 @@ instance comap_finitary (N : Matroid β) [N.Finitary] (f : α → β) : (N.comap
   rw [← hJ'.image_eq] at hfin ⊢
   exact (hI J' (hJ'J.trans hJ) (hfin.of_finite_image hJ'.injOn)).1
 
-instance comap_finiteRank (N : Matroid β) [N.FiniteRank] (f : α → β) : (N.comap f).FiniteRank := by
+instance comap_rankFinite (N : Matroid β) [N.RankFinite] (f : α → β) : (N.comap f).RankFinite := by
   obtain ⟨B, hB⟩ := (N.comap f).exists_base
-  refine hB.finiteRank_of_finite ?_
+  refine hB.rankFinite_of_finite ?_
   simp only [comap_base_iff] at hB
   exact (hB.1.indep.finite.of_finite_image hB.2.1)
 
@@ -287,7 +287,7 @@ lemma comapOn_dual_eq_of_bijOn (h : BijOn f E N.E) :
 instance comapOn_finitary [N.Finitary] : (N.comapOn E f).Finitary := by
   rw [comapOn]; infer_instance
 
-instance comapOn_finiteRank [N.FiniteRank] : (N.comapOn E f).FiniteRank := by
+instance comapOn_rankFinite [N.RankFinite] : (N.comapOn E f).RankFinite := by
   rw [comapOn]; infer_instance
 
 end comapOn
@@ -490,9 +490,9 @@ instance [M.Finitary] {f : α → β} (hf) : (M.map f hf).Finitary := by
   specialize hI (f '' J₀) (image_subset f hJ₀I₀) (hJ₀.image _)
   rwa [map_image_indep_iff (hJ₀I₀.trans hI₀E)] at hI
 
-instance [M.FiniteRank] {f : α → β} (hf) : (M.map f hf).FiniteRank :=
+instance [M.RankFinite] {f : α → β} (hf) : (M.map f hf).RankFinite :=
   let ⟨_, hB⟩ := M.exists_base
-  (hB.map hf).finiteRank_of_finite (hB.finite.image _)
+  (hB.map hf).rankFinite_of_finite (hB.finite.image _)
 
 instance [M.RankPos] {f : α → β} (hf) : (M.map f hf).RankPos :=
   let ⟨_, hB⟩ := M.exists_base
@@ -572,8 +572,8 @@ instance [M.Finite] {f : α ↪ β} : (M.mapEmbedding f).Finite :=
 instance [M.Finitary] {f : α ↪ β} : (M.mapEmbedding f).Finitary :=
   inferInstanceAs (M.map f f.injective.injOn).Finitary
 
-instance [M.FiniteRank] {f : α ↪ β} : (M.mapEmbedding f).FiniteRank :=
-  inferInstanceAs (M.map f f.injective.injOn).FiniteRank
+instance [M.RankFinite] {f : α ↪ β} : (M.mapEmbedding f).RankFinite :=
+  inferInstanceAs (M.map f f.injective.injOn).RankFinite
 
 instance [M.RankPos] {f : α ↪ β} : (M.mapEmbedding f).RankPos :=
   inferInstanceAs (M.map f f.injective.injOn).RankPos
@@ -620,8 +620,8 @@ instance [M.Finite] {f : α ≃ β} : (M.mapEquiv f).Finite :=
 instance [M.Finitary] {f : α ≃ β} : (M.mapEquiv f).Finitary :=
   inferInstanceAs (M.map f f.injective.injOn).Finitary
 
-instance [M.FiniteRank] {f : α ≃ β} : (M.mapEquiv f).FiniteRank :=
-  inferInstanceAs (M.map f f.injective.injOn).FiniteRank
+instance [M.RankFinite] {f : α ≃ β} : (M.mapEquiv f).RankFinite :=
+  inferInstanceAs (M.map f f.injective.injOn).RankFinite
 
 instance [M.RankPos] {f : α ≃ β} : (M.mapEquiv f).RankPos :=
   inferInstanceAs (M.map f f.injective.injOn).RankPos
@@ -698,7 +698,7 @@ lemma map_val_restrictSubtype_ground_eq (M : Matroid α) :
 instance [M.Finitary] {X : Set α} : (M.restrictSubtype X).Finitary := by
   rw [restrictSubtype]; infer_instance
 
-instance [M.FiniteRank] {X : Set α} : (M.restrictSubtype X).FiniteRank := by
+instance [M.RankFinite] {X : Set α} : (M.restrictSubtype X).RankFinite := by
   rw [restrictSubtype]; infer_instance
 
 instance [M.Finite] : (M.restrictSubtype M.E).Finite :=

--- a/Mathlib/Data/Matroid/Restrict.lean
+++ b/Mathlib/Data/Matroid/Restrict.lean
@@ -161,9 +161,9 @@ theorem base_restrict_iff' : (M ↾ X).Base I ↔ M.Basis' I X := by
 theorem Basis.restrict_base (h : M.Basis I X) : (M ↾ X).Base I :=
   (base_restrict_iff h.subset_ground).2 h
 
-instance restrict_finiteRk [M.FiniteRk] (R : Set α) : (M ↾ R).FiniteRk :=
+instance restrict_finiteRank [M.FiniteRank] (R : Set α) : (M ↾ R).FiniteRank :=
   let ⟨_, hB⟩ := (M ↾ R).exists_base
-  hB.finiteRk_of_finite (hB.indep.of_restrict.finite)
+  hB.finiteRank_of_finite (hB.indep.of_restrict.finite)
 
 instance restrict_finitary [Finitary M] (R : Set α) : Finitary (M ↾ R) := by
   refine ⟨fun I hI ↦ ?_⟩
@@ -339,7 +339,7 @@ theorem Restriction.finite {M : Matroid α} [M.Finite] (h : N ≤r M) : N.Finite
   obtain ⟨R, hR, rfl⟩ := h
   exact restrict_finite <| M.ground_finite.subset hR
 
-theorem Restriction.finiteRk {M : Matroid α} [FiniteRk M] (h : N ≤r M) : N.FiniteRk := by
+theorem Restriction.finiteRank {M : Matroid α} [FiniteRank M] (h : N ≤r M) : N.FiniteRank := by
   obtain ⟨R, -, rfl⟩ := h
   infer_instance
 

--- a/Mathlib/Data/Matroid/Restrict.lean
+++ b/Mathlib/Data/Matroid/Restrict.lean
@@ -161,9 +161,9 @@ theorem base_restrict_iff' : (M ↾ X).Base I ↔ M.Basis' I X := by
 theorem Basis.restrict_base (h : M.Basis I X) : (M ↾ X).Base I :=
   (base_restrict_iff h.subset_ground).2 h
 
-instance restrict_finiteRank [M.FiniteRank] (R : Set α) : (M ↾ R).FiniteRank :=
+instance restrict_rankFinite [M.RankFinite] (R : Set α) : (M ↾ R).RankFinite :=
   let ⟨_, hB⟩ := (M ↾ R).exists_base
-  hB.finiteRank_of_finite (hB.indep.of_restrict.finite)
+  hB.rankFinite_of_finite (hB.indep.of_restrict.finite)
 
 instance restrict_finitary [Finitary M] (R : Set α) : Finitary (M ↾ R) := by
   refine ⟨fun I hI ↦ ?_⟩
@@ -339,7 +339,7 @@ theorem Restriction.finite {M : Matroid α} [M.Finite] (h : N ≤r M) : N.Finite
   obtain ⟨R, hR, rfl⟩ := h
   exact restrict_finite <| M.ground_finite.subset hR
 
-theorem Restriction.finiteRank {M : Matroid α} [FiniteRank M] (h : N ≤r M) : N.FiniteRank := by
+theorem Restriction.rankFinite {M : Matroid α} [RankFinite M] (h : N ≤r M) : N.RankFinite := by
   obtain ⟨R, -, rfl⟩ := h
   infer_instance
 


### PR DESCRIPTION
as per the (weak) consensus [on zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Matroid.20rank.20-.20naming.20poll) and the convention established in `Data.Matroid.Rank.Cardinal`, the rank of a matroid is referred to as 'rank' in lemma names, and the rank of a set is referred to as `rk`. 

Accordingly (and for internal consistency), we rename the typeclasses `RkPos` -> `RankPos`, `FiniteRk` -> `RankFinite` and `InfiniteRk` -> `RankInfinite`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
