### PR TITLE
feat(Data/Set/Basic): ssubset lemmas

### DIFF
--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -715,12 +715,12 @@ theorem union_univ (s : Set α) : s ∪ univ = univ := sup_top_eq _
 theorem univ_union (s : Set α) : univ ∪ s = univ := top_sup_eq _
 
 @[simp]
-theorem ssubset_union_left_iff : s ⊂ s ∪ t ↔ ¬ t ⊆ s := by
-  rw [ssubset_iff_subset_ne, and_iff_right subset_union_left, Ne, eq_comm, union_eq_left]
+theorem ssubset_union_left_iff : s ⊂ s ∪ t ↔ ¬ t ⊆ s :=
+  lt_sup_left_iff
 
 @[simp]
-theorem ssubset_union_right_iff : t ⊂ s ∪ t ↔ ¬ s ⊆ t := by
-  rw [ssubset_iff_subset_ne, and_iff_right subset_union_right, Ne, eq_comm, union_eq_right]
+theorem ssubset_union_right_iff : t ⊂ s ∪ t ↔ ¬ s ⊆ t :=
+  lt_sup_right_iff
 
 /-! ### Lemmas about intersection -/
 
@@ -839,14 +839,6 @@ theorem inter_setOf_eq_sep (s : Set α) (p : α → Prop) : s ∩ {a | p a} = {a
 
 theorem setOf_inter_eq_sep (p : α → Prop) (s : Set α) : {a | p a} ∩ s = {a ∈ s | p a} :=
   inter_comm _ _
-
-@[simp]
-theorem inter_ssubset_right_iff : s ∩ t ⊂ t ↔ ¬ t ⊆ s := by
-  rw [ssubset_iff_subset_ne, and_iff_right inter_subset_right, Ne, inter_eq_right]
-
-@[simp]
-theorem inter_ssubset_left_iff : s ∩ t ⊂ s ↔ ¬ s ⊆ t := by
-  rw [ssubset_iff_subset_ne, and_iff_right inter_subset_left, Ne, inter_eq_left]
 
 /-! ### Distributivity laws -/
 
@@ -1209,11 +1201,6 @@ theorem diff_union_inter (s t : Set α) : s \ t ∪ s ∩ t = s := by
 @[simp]
 theorem inter_union_compl (s t : Set α) : s ∩ t ∪ s ∩ tᶜ = s :=
   inter_union_diff _ _
-
-@[simp]
-theorem diff_ssubset_left_iff : s \ t ⊂ s ↔ (s ∩ t).Nonempty := by
-  rw [ssubset_iff_subset_ne, and_iff_right diff_subset, Ne, sdiff_eq_left,
-    disjoint_iff_inter_eq_empty, nonempty_iff_ne_empty]
 
 @[gcongr]
 theorem diff_subset_diff {s₁ s₂ t₁ t₂ : Set α} : s₁ ⊆ s₂ → t₂ ⊆ t₁ → s₁ \ t₁ ⊆ s₂ \ t₂ :=

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -715,12 +715,12 @@ theorem union_univ (s : Set α) : s ∪ univ = univ := sup_top_eq _
 theorem univ_union (s : Set α) : univ ∪ s = univ := top_sup_eq _
 
 @[simp]
-theorem ssubset_union_left_iff : s ⊂ s ∪ t ↔ ¬ t ⊆ s :=
-  lt_sup_left_iff
+theorem ssubset_union_left_iff : s ⊂ s ∪ t ↔ ¬ t ⊆ s := by
+  rw [ssubset_iff_subset_ne, and_iff_right subset_union_left, Ne, eq_comm, union_eq_left]
 
 @[simp]
-theorem ssubset_union_right_iff : t ⊂ s ∪ t ↔ ¬ s ⊆ t :=
-  lt_sup_right_iff
+theorem ssubset_union_right_iff : t ⊂ s ∪ t ↔ ¬ s ⊆ t := by
+  rw [ssubset_iff_subset_ne, and_iff_right subset_union_right, Ne, eq_comm, union_eq_right]
 
 /-! ### Lemmas about intersection -/
 
@@ -839,6 +839,14 @@ theorem inter_setOf_eq_sep (s : Set α) (p : α → Prop) : s ∩ {a | p a} = {a
 
 theorem setOf_inter_eq_sep (p : α → Prop) (s : Set α) : {a | p a} ∩ s = {a ∈ s | p a} :=
   inter_comm _ _
+
+@[simp]
+theorem inter_ssubset_right_iff : s ∩ t ⊂ t ↔ ¬ t ⊆ s := by
+  rw [ssubset_iff_subset_ne, and_iff_right inter_subset_right, Ne, inter_eq_right]
+
+@[simp]
+theorem inter_ssubset_left_iff : s ∩ t ⊂ s ↔ ¬ s ⊆ t := by
+  rw [ssubset_iff_subset_ne, and_iff_right inter_subset_left, Ne, inter_eq_left]
 
 /-! ### Distributivity laws -/
 
@@ -1201,6 +1209,11 @@ theorem diff_union_inter (s t : Set α) : s \ t ∪ s ∩ t = s := by
 @[simp]
 theorem inter_union_compl (s t : Set α) : s ∩ t ∪ s ∩ tᶜ = s :=
   inter_union_diff _ _
+
+@[simp]
+theorem diff_ssubset_left_iff : s \ t ⊂ s ↔ (s ∩ t).Nonempty := by
+  rw [ssubset_iff_subset_ne, and_iff_right diff_subset, Ne, sdiff_eq_left,
+    disjoint_iff_inter_eq_empty, nonempty_iff_ne_empty]
 
 @[gcongr]
 theorem diff_subset_diff {s₁ s₂ t₁ t₂ : Set α} : s₁ ⊆ s₂ → t₂ ⊆ t₁ → s₁ \ t₁ ⊆ s₂ \ t₂ :=

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -348,6 +348,11 @@ theorem not_mem_empty (x : α) : ¬x ∈ (∅ : Set α) :=
 theorem not_not_mem : ¬a ∉ s ↔ a ∈ s :=
   not_not
 
+theorem ssubset_of_subset_of_mem_not_mem {x : α} (hst : s ⊆ t) (hxt : x ∈ t)
+    (hxs : x ∉ s) : s ⊂ t := hst.ssubset_of_not_subset fun a ↦ hxs (a hxt)
+
+alias _root_.HasSubset.Subset.ssubset_of_mem_not_mem := ssubset_of_subset_of_mem_not_mem
+
 /-! ### Non-empty sets -/
 
 -- Porting note: we seem to need parentheses at `(↥s)`,
@@ -709,6 +714,14 @@ theorem union_univ (s : Set α) : s ∪ univ = univ := sup_top_eq _
 @[simp]
 theorem univ_union (s : Set α) : univ ∪ s = univ := top_sup_eq _
 
+@[simp]
+theorem ssubset_union_left_iff : s ⊂ s ∪ t ↔ ¬ t ⊆ s := by
+  rw [ssubset_iff_subset_ne, and_iff_right subset_union_left, Ne, eq_comm, union_eq_left]
+
+@[simp]
+theorem ssubset_union_right_iff : t ⊂ s ∪ t ↔ ¬ s ⊆ t := by
+  rw [ssubset_iff_subset_ne, and_iff_right subset_union_right, Ne, eq_comm, union_eq_right]
+
 /-! ### Lemmas about intersection -/
 
 
@@ -826,6 +839,14 @@ theorem inter_setOf_eq_sep (s : Set α) (p : α → Prop) : s ∩ {a | p a} = {a
 
 theorem setOf_inter_eq_sep (p : α → Prop) (s : Set α) : {a | p a} ∩ s = {a ∈ s | p a} :=
   inter_comm _ _
+
+@[simp]
+theorem inter_ssubset_right_iff : s ∩ t ⊂ t ↔ ¬ t ⊆ s := by
+  rw [ssubset_iff_subset_ne, and_iff_right inter_subset_right, Ne, inter_eq_right]
+
+@[simp]
+theorem inter_ssubset_left_iff : s ∩ t ⊂ s ↔ ¬ s ⊆ t := by
+  rw [ssubset_iff_subset_ne, and_iff_right inter_subset_left, Ne, inter_eq_left]
 
 /-! ### Distributivity laws -/
 
@@ -1188,6 +1209,11 @@ theorem diff_union_inter (s t : Set α) : s \ t ∪ s ∩ t = s := by
 @[simp]
 theorem inter_union_compl (s t : Set α) : s ∩ t ∪ s ∩ tᶜ = s :=
   inter_union_diff _ _
+
+@[simp]
+theorem diff_ssubset_left_iff : s \ t ⊂ s ↔ (s ∩ t).Nonempty := by
+  rw [ssubset_iff_subset_ne, and_iff_right diff_subset, Ne, sdiff_eq_left,
+    disjoint_iff_inter_eq_empty, nonempty_iff_ne_empty]
 
 @[gcongr]
 theorem diff_subset_diff {s₁ s₂ t₁ t₂ : Set α} : s₁ ⊆ s₂ → t₂ ⊆ t₁ → s₁ \ t₁ ⊆ s₂ \ t₂ :=

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -348,6 +348,11 @@ theorem not_mem_empty (x : α) : ¬x ∈ (∅ : Set α) :=
 theorem not_not_mem : ¬a ∉ s ↔ a ∈ s :=
   not_not
 
+theorem ssubset_of_subset_of_mem_not_mem {x : α} (hst : s ⊆ t) (hxt : x ∈ t)
+    (hxs : x ∉ s) : s ⊂ t := hst.ssubset_of_not_subset fun a ↦ hxs (a hxt)
+
+alias _root_.HasSubset.Subset.ssubset_of_mem_not_mem := ssubset_of_subset_of_mem_not_mem
+
 /-! ### Non-empty sets -/
 
 -- Porting note: we seem to need parentheses at `(↥s)`,

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -348,11 +348,6 @@ theorem not_mem_empty (x : α) : ¬x ∈ (∅ : Set α) :=
 theorem not_not_mem : ¬a ∉ s ↔ a ∈ s :=
   not_not
 
-theorem ssubset_of_subset_of_mem_not_mem {x : α} (hst : s ⊆ t) (hxt : x ∈ t)
-    (hxs : x ∉ s) : s ⊂ t := hst.ssubset_of_not_subset fun a ↦ hxs (a hxt)
-
-alias _root_.HasSubset.Subset.ssubset_of_mem_not_mem := ssubset_of_subset_of_mem_not_mem
-
 /-! ### Non-empty sets -/
 
 -- Porting note: we seem to need parentheses at `(↥s)`,
@@ -840,14 +835,6 @@ theorem inter_setOf_eq_sep (s : Set α) (p : α → Prop) : s ∩ {a | p a} = {a
 theorem setOf_inter_eq_sep (p : α → Prop) (s : Set α) : {a | p a} ∩ s = {a ∈ s | p a} :=
   inter_comm _ _
 
-@[simp]
-theorem inter_ssubset_right_iff : s ∩ t ⊂ t ↔ ¬ t ⊆ s :=
-  inf_lt_right_iff
-
-@[simp]
-theorem inter_ssubset_left_iff : s ∩ t ⊂ s ↔ ¬ s ⊆ t :=
-  inf_lt_left_iff
-
 /-! ### Distributivity laws -/
 
 theorem inter_union_distrib_left (s t u : Set α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
@@ -1209,11 +1196,6 @@ theorem diff_union_inter (s t : Set α) : s \ t ∪ s ∩ t = s := by
 @[simp]
 theorem inter_union_compl (s t : Set α) : s ∩ t ∪ s ∩ tᶜ = s :=
   inter_union_diff _ _
-
-@[simp]
-theorem diff_ssubset_left_iff : s \ t ⊂ s ↔ (s ∩ t).Nonempty := by
-  rw [ssubset_iff_subset_ne, and_iff_right diff_subset, Ne, sdiff_eq_left,
-    disjoint_iff_inter_eq_empty, nonempty_iff_ne_empty]
 
 @[gcongr]
 theorem diff_subset_diff {s₁ s₂ t₁ t₂ : Set α} : s₁ ⊆ s₂ → t₂ ⊆ t₁ → s₁ \ t₁ ⊆ s₂ \ t₂ :=

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -715,12 +715,12 @@ theorem union_univ (s : Set α) : s ∪ univ = univ := sup_top_eq _
 theorem univ_union (s : Set α) : univ ∪ s = univ := top_sup_eq _
 
 @[simp]
-theorem ssubset_union_left_iff : s ⊂ s ∪ t ↔ ¬ t ⊆ s := by
-  rw [ssubset_iff_subset_ne, and_iff_right subset_union_left, Ne, eq_comm, union_eq_left]
+theorem ssubset_union_left_iff : s ⊂ s ∪ t ↔ ¬ t ⊆ s :=
+  lt_sup_left_iff
 
 @[simp]
-theorem ssubset_union_right_iff : t ⊂ s ∪ t ↔ ¬ s ⊆ t := by
-  rw [ssubset_iff_subset_ne, and_iff_right subset_union_right, Ne, eq_comm, union_eq_right]
+theorem ssubset_union_right_iff : t ⊂ s ∪ t ↔ ¬ s ⊆ t :=
+  lt_sup_right_iff
 
 /-! ### Lemmas about intersection -/
 
@@ -841,12 +841,12 @@ theorem setOf_inter_eq_sep (p : α → Prop) (s : Set α) : {a | p a} ∩ s = {a
   inter_comm _ _
 
 @[simp]
-theorem inter_ssubset_right_iff : s ∩ t ⊂ t ↔ ¬ t ⊆ s := by
-  rw [ssubset_iff_subset_ne, and_iff_right inter_subset_right, Ne, inter_eq_right]
+theorem inter_ssubset_right_iff : s ∩ t ⊂ t ↔ ¬ t ⊆ s :=
+  inf_lt_right_iff
 
 @[simp]
-theorem inter_ssubset_left_iff : s ∩ t ⊂ s ↔ ¬ s ⊆ t := by
-  rw [ssubset_iff_subset_ne, and_iff_right inter_subset_left, Ne, inter_eq_left]
+theorem inter_ssubset_left_iff : s ∩ t ⊂ s ↔ ¬ s ⊆ t :=
+  inf_lt_left_iff
 
 /-! ### Distributivity laws -/
 

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -205,6 +205,9 @@ lemma le_sdiff : x ≤ y \ z ↔ x ≤ y ∧ Disjoint x z :=
 @[simp] lemma sdiff_eq_left : x \ y = x ↔ Disjoint x y :=
   ⟨fun h ↦ disjoint_sdiff_self_left.mono_left h.ge, Disjoint.sdiff_eq_left⟩
 
+@[simp] theorem sdiff_lt_iff : x \ y < x ↔ ¬ Disjoint x y := by
+  rw [lt_iff_le_and_ne, and_iff_right sdiff_le, Ne, sdiff_eq_left]
+
 /- TODO: we could make an alternative constructor for `GeneralizedBooleanAlgebra` using
 `Disjoint x (y \ x)` and `x ⊔ (y \ x) = y` as axioms. -/
 theorem Disjoint.sdiff_eq_of_sup_eq (hi : Disjoint x z) (hs : x ⊔ z = y) : y \ x = z :=

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -205,9 +205,6 @@ lemma le_sdiff : x ≤ y \ z ↔ x ≤ y ∧ Disjoint x z :=
 @[simp] lemma sdiff_eq_left : x \ y = x ↔ Disjoint x y :=
   ⟨fun h ↦ disjoint_sdiff_self_left.mono_left h.ge, Disjoint.sdiff_eq_left⟩
 
-@[simp] theorem sdiff_lt_iff : x \ y < x ↔ ¬ Disjoint x y := by
-  rw [lt_iff_le_and_ne, and_iff_right sdiff_le, Ne, sdiff_eq_left]
-
 /- TODO: we could make an alternative constructor for `GeneralizedBooleanAlgebra` using
 `Disjoint x (y \ x)` and `x ⊔ (y \ x) = y` as axioms. -/
 theorem Disjoint.sdiff_eq_of_sup_eq (hi : Disjoint x z) (hs : x ⊔ z = y) : y \ x = z :=

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -540,6 +540,18 @@ lemma inf_eq_and_sup_eq_iff : a ⊓ b = c ∧ a ⊔ b = c ↔ a = c ∧ b = c :=
   · rintro ⟨rfl, rfl⟩
     exact ⟨inf_idem _, sup_idem _⟩
 
+@[simp] lemma lt_sup_left_iff : a < a ⊔ b ↔ ¬ b ≤ a := by
+  rw [lt_iff_le_not_le, and_iff_right le_sup_left, sup_le_iff, and_iff_right rfl.le]
+
+@[simp] lemma lt_sup_right_iff : b < a ⊔ b ↔ ¬ a ≤ b := by
+  rw [sup_comm, lt_sup_left_iff]
+
+@[simp] lemma inf_lt_left_iff : a ⊓ b < a ↔ ¬ a ≤ b := by
+  rw [lt_iff_le_not_le, and_iff_right inf_le_left, le_inf_iff, and_iff_right rfl.le]
+
+@[simp] lemma inf_lt_right_iff : a ⊓ b < b ↔ ¬ b ≤ a := by
+  rw [inf_comm, inf_lt_left_iff]
+
 /-!
 #### Distributivity laws
 -/

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -540,18 +540,6 @@ lemma inf_eq_and_sup_eq_iff : a ⊓ b = c ∧ a ⊔ b = c ↔ a = c ∧ b = c :=
   · rintro ⟨rfl, rfl⟩
     exact ⟨inf_idem _, sup_idem _⟩
 
-@[simp] lemma lt_sup_left_iff : a < a ⊔ b ↔ ¬ b ≤ a := by
-  rw [lt_iff_le_not_le, and_iff_right le_sup_left, sup_le_iff, and_iff_right rfl.le]
-
-@[simp] lemma lt_sup_right_iff : b < a ⊔ b ↔ ¬ a ≤ b := by
-  rw [sup_comm, lt_sup_left_iff]
-
-@[simp] lemma inf_lt_left_iff : a ⊓ b < a ↔ ¬ a ≤ b := by
-  rw [lt_iff_le_not_le, and_iff_right inf_le_left, le_inf_iff, and_iff_right rfl.le]
-
-@[simp] lemma inf_lt_right_iff : a ⊓ b < b ↔ ¬ b ≤ a := by
-  rw [inf_comm, inf_lt_left_iff]
-
 /-!
 #### Distributivity laws
 -/


### PR DESCRIPTION
We add a few QOL simp confluence lemmas about `<` in lattices, and therefore strict subsets in sets, and also a lemma for proving ssubset by giving a term in the set difference. 

The confluence lemmas can be proved by `simp [ssubset_iff_subset_ne]`or `simp [lt_iff_le_and_ne]`, but they turn annoying terms into simpler ones, so I think are worth having.  

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
