### PR TITLE
[Merged by Bors] - refactor(Geometry/Euclidean/Basic,Analysis/Normed/Affine/AddTorsor): generalize `dist_left_midpoint_eq_dist_right_midpoint`

### DIFF
--- a/Mathlib/Analysis/Normed/Affine/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Affine/AddTorsor.lean
@@ -172,6 +172,11 @@ theorem nndist_right_midpoint (p₁ p₂ : P) :
     nndist p₂ (midpoint 𝕜 p₁ p₂) = ‖(2 : 𝕜)‖₊⁻¹ * nndist p₁ p₂ :=
   NNReal.eq <| dist_right_midpoint _ _
 
+/-- The midpoint of the segment AB is the same distance from A as it is from B. -/
+theorem dist_left_midpoint_eq_dist_right_midpoint (p₁ p₂ : P) :
+    dist p₁ (midpoint 𝕜 p₁ p₂) = dist p₂ (midpoint 𝕜 p₁ p₂) := by
+  rw [dist_left_midpoint p₁ p₂, dist_right_midpoint p₁ p₂]
+
 theorem dist_midpoint_midpoint_le' (p₁ p₂ p₃ p₄ : P) :
     dist (midpoint 𝕜 p₁ p₂) (midpoint 𝕜 p₃ p₄) ≤ (dist p₁ p₃ + dist p₂ p₄) / ‖(2 : 𝕜)‖ := by
   rw [dist_eq_norm_vsub V, dist_eq_norm_vsub V, dist_eq_norm_vsub V, midpoint_vsub_midpoint]

--- a/Mathlib/Geometry/Euclidean/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Basic.lean
@@ -62,11 +62,6 @@ variable {V : Type*} {P : Type*}
 variable [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
 variable [NormedAddTorsor V P]
 
-/-- The midpoint of the segment AB is the same distance from A as it is from B. -/
-theorem dist_left_midpoint_eq_dist_right_midpoint (p₁ p₂ : P) :
-    dist p₁ (midpoint ℝ p₁ p₂) = dist p₂ (midpoint ℝ p₁ p₂) := by
-  rw [dist_left_midpoint (𝕜 := ℝ) p₁ p₂, dist_right_midpoint (𝕜 := ℝ) p₁ p₂]
-
 /-- The inner product of two vectors given with `weightedVSub`, in
 terms of the pairwise distances. -/
 theorem inner_weightedVSub {ι₁ : Type*} {s₁ : Finset ι₁} {w₁ : ι₁ → ℝ} (p₁ : ι₁ → P)


### PR DESCRIPTION
The lemma `dist_left_midpoint_eq_dist_right_midpoint` has an unnecessary restriction to inner product spaces, when the two lemmas `dist_left_midpoint` and `dist_right_midpoint` it uses are stated and proved more generally.  Move it to
`Mathlib.Analysis.Normed.Affine.AddTorsor` and thus make the statement more general.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
