### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace/Midpoint): affine variants of `midpoint_pointReflection_left` and `midpoint_pointReflection_right`

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/Midpoint.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Midpoint.lean
@@ -101,6 +101,16 @@ theorem midpoint_pointReflection_right (x y : P) :
   midpoint_eq_iff.2 rfl
 
 @[simp]
+nonrec lemma AffineEquiv.midpoint_pointReflection_left (x y : P) :
+    midpoint R (pointReflection R x y) y = x :=
+  midpoint_pointReflection_left x y
+
+@[simp]
+nonrec lemma AffineEquiv.midpoint_pointReflection_right (x y : P) :
+    midpoint R y (pointReflection R x y) = x :=
+  midpoint_pointReflection_right x y
+
+@[simp]
 theorem midpoint_vsub_left (p₁ p₂ : P) : midpoint R p₁ p₂ -ᵥ p₁ = (⅟ 2 : R) • (p₂ -ᵥ p₁) :=
   lineMap_vsub_left _ _ _
 


### PR DESCRIPTION
Add varients of `midpoint_pointReflection_left` and `midpoint_pointReflection_right` stated for
`AffineEquiv.pointReflection` rather than `Equiv.pointReflection`, so that both versions can be handled by `simp`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
