### PR TITLE
[Merged by Bors] - feat: easy utility lemmas for presented groups

### DIFF
--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -52,6 +52,22 @@ mapped to the equivalence class of the image of `x` in `FreeGroup α`. -/
 def of {rels : Set (FreeGroup α)} (x : α) : PresentedGroup rels :=
   mk rels (FreeGroup.of x)
 
+lemma mk_eq_one_iff {rels : Set (FreeGroup α)} {x : FreeGroup α} :
+    mk rels x = 1 ↔ x ∈ Subgroup.normalClosure rels :=
+  QuotientGroup.eq_one_iff _
+
+lemma one_of_mem {rels : Set (FreeGroup α)} {x : FreeGroup α} (hx : x ∈ rels) :
+    mk rels x = 1 :=
+  mk_eq_one_iff.mpr <| Subgroup.subset_normalClosure hx
+
+lemma mk_eq_mk_of_mul_inv_mem {rels : Set (FreeGroup α)} {x y : FreeGroup α} (hx : x*y⁻¹ ∈ rels) :
+    mk rels x = mk rels y :=
+  eq_of_mul_inv_eq_one <| one_of_mem hx
+
+lemma mk_eq_mk_of_inv_mul_mem {rels : Set (FreeGroup α)} {x y : FreeGroup α} (hx : x⁻¹*y ∈ rels) :
+    mk rels x = mk rels y :=
+  eq_of_inv_mul_eq_one <| one_of_mem hx
+
 /-- The generators of a presented group generate the presented group. That is, the subgroup closure
 of the set of generators equals `⊤`. -/
 @[simp]

--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -60,12 +60,12 @@ lemma one_of_mem {rels : Set (FreeGroup α)} {x : FreeGroup α} (hx : x ∈ rels
     mk rels x = 1 :=
   mk_eq_one_iff.mpr <| Subgroup.subset_normalClosure hx
 
-lemma mk_eq_mk_of_mul_inv_mem {rels : Set (FreeGroup α)} {x y : FreeGroup α} (hx : x*y⁻¹ ∈ rels) :
-    mk rels x = mk rels y :=
+lemma mk_eq_mk_of_mul_inv_mem {rels : Set (FreeGroup α)} {x y : FreeGroup α}
+    (hx : x * y⁻¹ ∈ rels) : mk rels x = mk rels y :=
   eq_of_mul_inv_eq_one <| one_of_mem hx
 
-lemma mk_eq_mk_of_inv_mul_mem {rels : Set (FreeGroup α)} {x y : FreeGroup α} (hx : x⁻¹*y ∈ rels) :
-    mk rels x = mk rels y :=
+lemma mk_eq_mk_of_inv_mul_mem {rels : Set (FreeGroup α)} {x y : FreeGroup α}
+    (hx : x⁻¹ * y ∈ rels) : mk rels x = mk rels y :=
   eq_of_inv_mul_eq_one <| one_of_mem hx
 
 /-- The generators of a presented group generate the presented group. That is, the subgroup closure


### PR DESCRIPTION
Those lemmas are useful to work with actual examples of presented groups.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
