### PR TITLE
[Merged by Bors] - chore: namespace IntermediateField.normalClosure

### DIFF
--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -35,7 +35,7 @@ Together, these two results prove the Galois correspondence.
 
 open scoped Polynomial IntermediateField
 
-open Module AlgEquiv
+open Module AlgEquiv IntermediateField
 
 section
 

--- a/Mathlib/FieldTheory/Galois/GaloisClosure.lean
+++ b/Mathlib/FieldTheory/Galois/GaloisClosure.lean
@@ -25,6 +25,8 @@ In a field extension `K/k`
 
 -/
 
+open IntermediateField
+
 variable (k K : Type*) [Field k] [Field K] [Algebra k K]
 
 /-- The type of intermediate fields of `K/k` that are finite and Galois over `k` -/

--- a/Mathlib/FieldTheory/Galois/Infinite.lean
+++ b/Mathlib/FieldTheory/Galois/Infinite.lean
@@ -128,6 +128,7 @@ lemma restrict_fixedField (H : Subgroup (K ≃ₐ[k] K)) (L : IntermediateField 
     nth_rw 2 [← this]
     exact (AlgEquiv.restrictNormal_commutes σ L ⟨x, xL⟩).symm
 
+open IntermediateField in
 lemma fixingSubgroup_fixedField (H : ClosedSubgroup (K ≃ₐ[k] K)) [IsGalois k K] :
     (IntermediateField.fixedField H).fixingSubgroup = H.1 := by
   apply le_antisymm _ ((IntermediateField.le_iff_le H.toSubgroup
@@ -207,6 +208,7 @@ def GaloisCoinsertionIntermediateFieldSubgroup [IsGalois k K] :
   u_l_le K := le_of_eq (fixedField_fixingSubgroup K)
   choice_eq _ _ := rfl
 
+open IntermediateField in
 theorem isOpen_iff_finite (L : IntermediateField k K) [IsGalois k K] :
     IsOpen L.fixingSubgroup.carrier ↔ FiniteDimensional k L := by
   refine ⟨fun h ↦ ?_, fun h ↦ IntermediateField.fixingSubgroup_isOpen L⟩

--- a/Mathlib/FieldTheory/Normal/Closure.lean
+++ b/Mathlib/FieldTheory/Normal/Closure.lean
@@ -18,11 +18,12 @@ minimal polynomial of every element of `K` over `F` splits in `L`, and that `L` 
 by the roots of such minimal polynomials. These conditions uniquely characterize `L/F` up to
 `F`-algebra isomorphisms (`IsNormalClosure.equiv`).
 
-The explicit construction `normalClosure F K L` of a field extension `K/F` inside another
-field extension `L/F` is the smallest intermediate field of `L/F` that contains the image
-of every `F`-algebra embedding `K →ₐ[F] L`. It satisfies the `IsNormalClosure` predicate
-if `L/F` satisfies the abovementioned splitting condition, in particular if `L/K/F` form
-a tower and `L/F` is normal.
+The explicit construction `IntermediateField.normalClosure F K L` of a field extension `K/F`
+inside another field extension `L/F` is the smallest intermediate field of
+`L/F` that contains the image of every `F`-algebra embedding `K →ₐ[F] L`.
+It satisfies the `IsNormalClosure` predicate if `L/F` satisfies the
+abovementioned splitting condition, in particular if `L/K/F` form a tower and
+`L/F` is normal.
 -/
 
 open IntermediateField IsScalarTower Polynomial
@@ -43,7 +44,7 @@ class IsNormalClosure : Prop where
 
 /-- The normal closure of `K/F` in `L/F`. -/
 @[stacks 0BMF]
-noncomputable def normalClosure : IntermediateField F L :=
+noncomputable def IntermediateField.normalClosure : IntermediateField F L :=
   ⨆ f : K →ₐ[F] L, f.fieldRange
 
 lemma normalClosure_def : normalClosure F K L = ⨆ f : K →ₐ[F] L, f.fieldRange :=

--- a/Mathlib/NumberTheory/NumberField/Norm.lean
+++ b/Mathlib/NumberTheory/NumberField/Norm.lean
@@ -23,7 +23,7 @@ rings of integers.
 
 open scoped NumberField
 
-open Finset NumberField Algebra Module
+open Finset NumberField Algebra Module IntermediateField
 
 section Rat
 


### PR DESCRIPTION
This was conflicting Subgroup.normalClosure


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
