### PR TITLE
[Merged by Bors] - chore(NumberField/CanonicalEmbedding): Fix naming 

### DIFF
--- a/Mathlib/NumberTheory/NumberField/AdeleRing.lean
+++ b/Mathlib/NumberTheory/NumberField/AdeleRing.lean
@@ -107,10 +107,10 @@ theorem mixedEmbedding_eq_algebraMap_comp {x : K} :
     RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk, UniformSpace.Completion.extensionHom]
   · rw [UniformSpace.Completion.extension_coe
       (WithAbs.isUniformInducing_of_comp <| v.1.norm_embedding_of_isReal v.2).uniformContinuous x]
-    exact mixedEmbedding.mixedEmbedding_apply_ofIsReal _ _ _
+    exact mixedEmbedding.mixedEmbedding_apply_IsReal _ _ _
   · rw [UniformSpace.Completion.extension_coe
       (WithAbs.isUniformInducing_of_comp <| v.1.norm_embedding_eq).uniformContinuous x]
-    exact mixedEmbedding.mixedEmbedding_apply_ofIsComplex _ _ _
+    exact mixedEmbedding.mixedEmbedding_apply_IsComplex _ _ _
 
 end InfiniteAdeleRing
 

--- a/Mathlib/NumberTheory/NumberField/AdeleRing.lean
+++ b/Mathlib/NumberTheory/NumberField/AdeleRing.lean
@@ -107,10 +107,10 @@ theorem mixedEmbedding_eq_algebraMap_comp {x : K} :
     RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk, UniformSpace.Completion.extensionHom]
   · rw [UniformSpace.Completion.extension_coe
       (WithAbs.isUniformInducing_of_comp <| v.1.norm_embedding_of_isReal v.2).uniformContinuous x]
-    exact mixedEmbedding.mixedEmbedding_apply_IsReal _ _ _
+    exact mixedEmbedding.mixedEmbedding_apply_isReal _ _ _
   · rw [UniformSpace.Completion.extension_coe
       (WithAbs.isUniformInducing_of_comp <| v.1.norm_embedding_eq).uniformContinuous x]
-    exact mixedEmbedding.mixedEmbedding_apply_IsComplex _ _ _
+    exact mixedEmbedding.mixedEmbedding_apply_isComplex _ _ _
 
 end InfiniteAdeleRing
 

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -190,19 +190,19 @@ noncomputable def _root_.NumberField.mixedEmbedding : K →+* (mixedSpace K) :=
     (Pi.ringHom fun w => w.val.embedding)
 
 @[simp]
-theorem mixedEmbedding_apply_IsReal (x : K) (w : {w // IsReal w}) :
+theorem mixedEmbedding_apply_isReal (x : K) (w : {w // IsReal w}) :
     (mixedEmbedding K x).1 w = embedding_of_isReal w.prop x := by
   simp_rw [mixedEmbedding, RingHom.prod_apply, Pi.ringHom_apply]
 
 @[simp]
-theorem mixedEmbedding_apply_IsComplex (x : K) (w : {w // IsComplex w}) :
+theorem mixedEmbedding_apply_isComplex (x : K) (w : {w // IsComplex w}) :
     (mixedEmbedding K x).2 w = w.val.embedding x := by
   simp_rw [mixedEmbedding, RingHom.prod_apply, Pi.ringHom_apply]
 
 @[deprecated (since := "2025-02-28")] alias
-  mixedEmbedding_apply_ofIsReal  := mixedEmbedding_apply_IsReal
+  mixedEmbedding_apply_ofIsReal  := mixedEmbedding_apply_isReal
 @[deprecated (since := "2025-02-28")] alias
-  mixedEmbedding_apply_ofIsComplex  := mixedEmbedding_apply_IsComplex
+  mixedEmbedding_apply_ofIsComplex  := mixedEmbedding_apply_isComplex
 
 instance [NumberField K] : Nontrivial (mixedSpace K) := by
   obtain ⟨w⟩ := (inferInstance : Nonempty (InfinitePlace K))
@@ -484,24 +484,24 @@ def stdBasis : Basis (index K) ℝ (mixedSpace K) :=
 variable {K}
 
 @[simp]
-theorem stdBasis_apply_IsReal (x : mixedSpace K) (w : {w : InfinitePlace K // IsReal w}) :
+theorem stdBasis_apply_isReal (x : mixedSpace K) (w : {w : InfinitePlace K // IsReal w}) :
     (stdBasis K).repr x (Sum.inl w) = x.1 w := rfl
 
 @[simp]
-theorem stdBasis_apply_IsComplex_fst (x : mixedSpace K)
+theorem stdBasis_apply_isComplex_fst (x : mixedSpace K)
     (w : {w : InfinitePlace K // IsComplex w}) :
     (stdBasis K).repr x (Sum.inr ⟨w, 0⟩) = (x.2 w).re := rfl
 
 @[simp]
-theorem stdBasis_apply_IsComplex_snd (x : mixedSpace K)
+theorem stdBasis_apply_isComplex_snd (x : mixedSpace K)
     (w : {w : InfinitePlace K // IsComplex w}) :
     (stdBasis K).repr x (Sum.inr ⟨w, 1⟩) = (x.2 w).im := rfl
 
-@[deprecated (since := "2025-02-28")] alias stdBasis_apply_ofIsReal := stdBasis_apply_IsReal
+@[deprecated (since := "2025-02-28")] alias stdBasis_apply_ofIsReal := stdBasis_apply_isReal
 @[deprecated (since := "2025-02-28")] alias
-  stdBasis_apply_ofIsComplex_fst := stdBasis_apply_IsComplex_fst
+  stdBasis_apply_ofIsComplex_fst := stdBasis_apply_isComplex_fst
 @[deprecated (since := "2025-02-28")] alias
-  stdBasis_apply_ofIsComplex_snd := stdBasis_apply_IsComplex_snd
+  stdBasis_apply_ofIsComplex_snd := stdBasis_apply_isComplex_snd
 
 variable (K)
 
@@ -545,22 +545,22 @@ def indexEquiv : (index K) ≃ (K →+* ℂ) := by
 variable {K}
 
 @[simp]
-theorem indexEquiv_apply_IsReal (w : {w : InfinitePlace K // IsReal w}) :
+theorem indexEquiv_apply_isReal (w : {w : InfinitePlace K // IsReal w}) :
     (indexEquiv K) (Sum.inl w) = w.val.embedding := rfl
 
 @[simp]
-theorem indexEquiv_apply_IsComplex_fst (w : {w : InfinitePlace K // IsComplex w}) :
+theorem indexEquiv_apply_isComplex_fst (w : {w : InfinitePlace K // IsComplex w}) :
     (indexEquiv K) (Sum.inr ⟨w, 0⟩) = w.val.embedding := rfl
 
 @[simp]
-theorem indexEquiv_apply_IsComplex_snd (w : {w : InfinitePlace K // IsComplex w}) :
+theorem indexEquiv_apply_isComplex_snd (w : {w : InfinitePlace K // IsComplex w}) :
     (indexEquiv K) (Sum.inr ⟨w, 1⟩) = ComplexEmbedding.conjugate w.val.embedding := rfl
 
-@[deprecated (since := "2025-02-28")] alias indexEquiv_apply_ofIsReal := indexEquiv_apply_IsReal
+@[deprecated (since := "2025-02-28")] alias indexEquiv_apply_ofIsReal := indexEquiv_apply_isReal
 @[deprecated (since := "2025-02-28")] alias
-  indexEquiv_apply_ofIsComplex_fst := indexEquiv_apply_IsComplex_fst
+  indexEquiv_apply_ofIsComplex_fst := indexEquiv_apply_isComplex_fst
 @[deprecated (since := "2025-02-28")] alias
-  indexEquiv_apply_ofIsComplex_snd := indexEquiv_apply_IsComplex_snd
+  indexEquiv_apply_ofIsComplex_snd := indexEquiv_apply_isComplex_snd
 
 variable (K)
 
@@ -596,25 +596,25 @@ theorem stdBasis_repr_eq_matrixToStdBasis_mul (x : (K →+* ℂ) → ℂ)
   simp_rw [commMap, matrixToStdBasis, LinearMap.coe_mk, AddHom.coe_mk,
     mulVec, dotProduct, Function.comp_apply, index, Fintype.sum_sum_type,
     diagonal_one, reindex_apply, ← univ_product_univ, sum_product,
-    indexEquiv_apply_IsReal, Fin.sum_univ_two, indexEquiv_apply_IsComplex_fst,
-    indexEquiv_apply_IsComplex_snd, smul_of, smul_cons, smul_eq_mul,
+    indexEquiv_apply_isReal, Fin.sum_univ_two, indexEquiv_apply_isComplex_fst,
+    indexEquiv_apply_isComplex_snd, smul_of, smul_cons, smul_eq_mul,
     mul_one, Matrix.smul_empty, Equiv.prodComm_symm, Equiv.coe_prodComm]
   cases c with
   | inl w =>
-      simp_rw [stdBasis_apply_IsReal, fromBlocks_apply₁₁, fromBlocks_apply₁₂,
+      simp_rw [stdBasis_apply_isReal, fromBlocks_apply₁₁, fromBlocks_apply₁₂,
         one_apply, Matrix.zero_apply, ite_mul, one_mul, zero_mul, sum_ite_eq, mem_univ, ite_true,
         add_zero, sum_const_zero, add_zero, ← conj_eq_iff_re, hx (embedding w.val),
         conjugate_embedding_eq_of_isReal w.prop]
   | inr c =>
     rcases c with ⟨w, j⟩
     fin_cases j
-    · simp only [Fin.zero_eta, Fin.isValue, id_eq, stdBasis_apply_IsComplex_fst, re_eq_add_conj,
+    · simp only [Fin.zero_eta, Fin.isValue, id_eq, stdBasis_apply_isComplex_fst, re_eq_add_conj,
         mul_neg, fromBlocks_apply₂₁, zero_apply, zero_mul, sum_const_zero, fromBlocks_apply₂₂,
         submatrix_apply, Prod.swap_prod_mk, blockDiagonal_apply, of_apply, cons_val', cons_val_zero,
         empty_val', cons_val_fin_one, ite_mul, cons_val_one, head_cons, sum_add_distrib, sum_ite_eq,
         mem_univ, ↓reduceIte, ← hx (embedding w), zero_add]
       field_simp
-    · simp only [Fin.mk_one, Fin.isValue, id_eq, stdBasis_apply_IsComplex_snd, im_eq_sub_conj,
+    · simp only [Fin.mk_one, Fin.isValue, id_eq, stdBasis_apply_isComplex_snd, im_eq_sub_conj,
         mul_neg, fromBlocks_apply₂₁, zero_apply, zero_mul, sum_const_zero, fromBlocks_apply₂₂,
         submatrix_apply, Prod.swap_prod_mk, blockDiagonal_apply, of_apply, cons_val', cons_val_zero,
         empty_val', cons_val_fin_one, cons_val_one, head_fin_const, ite_mul, neg_mul, head_cons,
@@ -901,37 +901,37 @@ def negAt :
 variable {s}
 
 @[simp]
-theorem negAt_apply_IsReal_and_mem (x : mixedSpace K) {w : {w // IsReal w}} (hw : w ∈ s) :
+theorem negAt_apply_isReal_and_mem (x : mixedSpace K) {w : {w // IsReal w}} (hw : w ∈ s) :
     (negAt s x).1 w = - x.1 w := by
   simp_rw [negAt, ContinuousLinearEquiv.prod_apply, piCongrRight_apply, if_pos hw,
     ContinuousLinearEquiv.neg_apply]
 
 @[simp]
-theorem negAt_apply_IsReal_and_not_mem (x : mixedSpace K) {w : {w // IsReal w}} (hw : w ∉ s) :
+theorem negAt_apply_isReal_and_not_mem (x : mixedSpace K) {w : {w // IsReal w}} (hw : w ∉ s) :
     (negAt s x).1 w = x.1 w := by
   simp_rw [negAt, ContinuousLinearEquiv.prod_apply, piCongrRight_apply, if_neg hw,
     ContinuousLinearEquiv.refl_apply]
 
 @[simp]
-theorem negAt_apply_IsComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
+theorem negAt_apply_isComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
     (negAt s x).2 w = x.2 w := rfl
 
 @[deprecated (since := "2025-02-28")] alias
-  negAt_apply_ofIsReal_and_mem := negAt_apply_IsReal_and_mem
+  negAt_apply_ofIsReal_and_mem := negAt_apply_isReal_and_mem
 @[deprecated (since := "2025-02-28")] alias
-  negAt_apply_ofIsReal_and_not_mem := negAt_apply_IsReal_and_not_mem
-@[deprecated (since := "2025-02-28")] alias negAt_apply_ofIsComplex := negAt_apply_IsComplex
+  negAt_apply_ofIsReal_and_not_mem := negAt_apply_isReal_and_not_mem
+@[deprecated (since := "2025-02-28")] alias negAt_apply_ofIsComplex := negAt_apply_isComplex
 
 @[simp]
 theorem negAt_apply_snd (x : mixedSpace K) :
     (negAt s x).2 = x.2 := rfl
 
 @[simp]
-theorem negAt_apply_abs_IsReal (x : mixedSpace K) (w : {w // IsReal w}) :
+theorem negAt_apply_abs_isReal (x : mixedSpace K) (w : {w // IsReal w}) :
     |(negAt s x).1 w| = |x.1 w| := by
   by_cases hw : w ∈ s <;> simp [hw]
 
-@[deprecated (since := "2025-02-28")] alias negAt_apply_abs_ofIsReal := negAt_apply_abs_IsReal
+@[deprecated (since := "2025-02-28")] alias negAt_apply_abs_ofIsReal := negAt_apply_abs_isReal
 
 open MeasureTheory Classical in
 /-- `negAt` preserves the volume . -/
@@ -950,8 +950,8 @@ variable (s) in
 theorem normAtPlace_negAt (x : mixedSpace K) (w : InfinitePlace K) :
     normAtPlace w (negAt s x) = normAtPlace w x := by
   obtain hw | hw := isReal_or_isComplex w
-  · simp_rw [normAtPlace_apply_of_isReal hw, Real.norm_eq_abs, negAt_apply_abs_IsReal]
-  · simp_rw [normAtPlace_apply_of_isComplex hw, negAt_apply_IsComplex]
+  · simp_rw [normAtPlace_apply_of_isReal hw, Real.norm_eq_abs, negAt_apply_abs_isReal]
+  · simp_rw [normAtPlace_apply_of_isComplex hw, negAt_apply_isComplex]
 
 /-- `negAt` preserves the `norm`. -/
 @[simp]
@@ -965,9 +965,9 @@ theorem negAt_symm :
     (negAt s).symm = negAt s := by
   ext x w
   · by_cases hw : w ∈ s
-    · simp_rw [negAt_apply_IsReal_and_mem _ hw, negAt, prod_symm,
+    · simp_rw [negAt_apply_isReal_and_mem _ hw, negAt, prod_symm,
         ContinuousLinearEquiv.prod_apply, piCongrRight_symm_apply, if_pos hw, symm_neg, neg_apply]
-    · simp_rw [negAt_apply_IsReal_and_not_mem _ hw, negAt, prod_symm,
+    · simp_rw [negAt_apply_isReal_and_not_mem _ hw, negAt, prod_symm,
         ContinuousLinearEquiv.prod_apply, piCongrRight_symm_apply, if_neg hw, refl_symm, refl_apply]
   · rfl
 
@@ -975,20 +975,20 @@ theorem negAt_symm :
 def signSet (x : mixedSpace K) : Set {w : InfinitePlace K // IsReal w} := {w | x.1 w ≤ 0}
 
 @[simp]
-theorem negAt_signSet_apply_IsReal (x : mixedSpace K) (w : {w // IsReal w}) :
+theorem negAt_signSet_apply_isReal (x : mixedSpace K) (w : {w // IsReal w}) :
     (negAt (signSet x) x).1 w = |x.1 w| := by
   by_cases hw : x.1 w ≤ 0
-  · rw [negAt_apply_IsReal_and_mem _ hw, abs_of_nonpos hw]
-  · rw [negAt_apply_IsReal_and_not_mem _ hw, abs_of_pos (lt_of_not_ge hw)]
+  · rw [negAt_apply_isReal_and_mem _ hw, abs_of_nonpos hw]
+  · rw [negAt_apply_isReal_and_not_mem _ hw, abs_of_pos (lt_of_not_ge hw)]
 
 @[simp]
-theorem negAt_signSet_apply_IsComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
+theorem negAt_signSet_apply_isComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
     (negAt (signSet x) x).2 w = x.2 w := rfl
 
 @[deprecated (since := "2025-02-28")] alias
-  negAt_signSet_apply_ofIsReal := negAt_signSet_apply_IsReal
+  negAt_signSet_apply_ofIsReal := negAt_signSet_apply_isReal
 @[deprecated (since := "2025-02-28")] alias
-  negAt_signSet_apply_ofIsComplex := negAt_signSet_apply_IsComplex
+  negAt_signSet_apply_ofIsComplex := negAt_signSet_apply_isComplex
 
 variable (A : Set (mixedSpace K)) {x : mixedSpace K}
 
@@ -1005,13 +1005,13 @@ abbrev plusPart : Set (mixedSpace K) := A ∩ {x | ∀ w, 0 < x.1 w}
 theorem neg_of_mem_negA_plusPart (hx : x ∈ negAt s '' (plusPart A)) {w : {w // IsReal w}}
     (hw : w ∈ s) : x.1 w < 0 := by
   obtain ⟨y, hy, rfl⟩ := hx
-  rw [negAt_apply_IsReal_and_mem _ hw, neg_lt_zero]
+  rw [negAt_apply_isReal_and_mem _ hw, neg_lt_zero]
   exact hy.2 w
 
 theorem pos_of_not_mem_negAt_plusPart (hx : x ∈ negAt s '' (plusPart A)) {w : {w // IsReal w}}
     (hw : w ∉ s) : 0 < x.1 w := by
   obtain ⟨y, hy, rfl⟩ := hx
-  rw [negAt_apply_IsReal_and_not_mem _ hw]
+  rw [negAt_apply_isReal_and_not_mem _ hw]
   exact hy.2 w
 
 open scoped Function in -- required for scoped `on` notation
@@ -1036,8 +1036,8 @@ theorem mem_negAt_plusPart_of_mem (hx₁ : x ∈ A) (hx₂ : ∀ w, x.1 w ≠ 0)
       fun ⟨h₁, h₂⟩ ↦ ⟨(fun w ↦ |x.1 w|, x.2), ⟨(hA x).mp hx₁, fun w ↦ abs_pos.mpr (hx₂ w)⟩, ?_⟩⟩
   ext w
   · by_cases hw : w ∈ s
-    · simp only [negAt_apply_IsReal_and_mem _ hw, abs_of_neg (h₁ w hw), neg_neg]
-    · simp only [negAt_apply_IsReal_and_not_mem _ hw, abs_of_pos (h₂ w hw)]
+    · simp only [negAt_apply_isReal_and_mem _ hw, abs_of_neg (h₁ w hw), neg_neg]
+    · simp only [negAt_apply_isReal_and_not_mem _ hw, abs_of_pos (h₂ w hw)]
   · rfl
 
 include hA in
@@ -1050,7 +1050,7 @@ theorem iUnion_negAt_plusPart_union :
   rw [Set.mem_union, Set.mem_inter_iff, Set.mem_iUnion, Set.mem_iUnion]
   refine ⟨?_, fun h ↦ ?_⟩
   · rintro (⟨s, ⟨x, ⟨hx, _⟩, rfl⟩⟩ | h)
-    · simp_rw (config := {singlePass := true}) [hA, negAt_apply_abs_IsReal, negAt_apply_snd]
+    · simp_rw (config := {singlePass := true}) [hA, negAt_apply_abs_isReal, negAt_apply_snd]
       rwa [← hA]
     · exact h.left
   · obtain hx | hx := exists_or_forall_not (fun w ↦ x.1 w = 0)

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -199,10 +199,10 @@ theorem mixedEmbedding_apply_isComplex (x : K) (w : {w // IsComplex w}) :
     (mixedEmbedding K x).2 w = w.val.embedding x := by
   simp_rw [mixedEmbedding, RingHom.prod_apply, Pi.ringHom_apply]
 
-@[deprecated (since := "2025-02-28")] alias
-  mixedEmbedding_apply_ofIsReal  := mixedEmbedding_apply_isReal
-@[deprecated (since := "2025-02-28")] alias
-  mixedEmbedding_apply_ofIsComplex  := mixedEmbedding_apply_isComplex
+@[deprecated (since := "2025-02-28")] alias mixedEmbedding_apply_ofIsReal :=
+  mixedEmbedding_apply_isReal
+@[deprecated (since := "2025-02-28")] alias mixedEmbedding_apply_ofIsComplex :=
+  mixedEmbedding_apply_isComplex
 
 instance [NumberField K] : Nontrivial (mixedSpace K) := by
   obtain ⟨w⟩ := (inferInstance : Nonempty (InfinitePlace K))
@@ -498,10 +498,10 @@ theorem stdBasis_apply_isComplex_snd (x : mixedSpace K)
     (stdBasis K).repr x (Sum.inr ⟨w, 1⟩) = (x.2 w).im := rfl
 
 @[deprecated (since := "2025-02-28")] alias stdBasis_apply_ofIsReal := stdBasis_apply_isReal
-@[deprecated (since := "2025-02-28")] alias
-  stdBasis_apply_ofIsComplex_fst := stdBasis_apply_isComplex_fst
-@[deprecated (since := "2025-02-28")] alias
-  stdBasis_apply_ofIsComplex_snd := stdBasis_apply_isComplex_snd
+@[deprecated (since := "2025-02-28")] alias stdBasis_apply_ofIsComplex_fst :=
+  stdBasis_apply_isComplex_fst
+@[deprecated (since := "2025-02-28")] alias stdBasis_apply_ofIsComplex_snd :=
+  stdBasis_apply_isComplex_snd
 
 variable (K)
 
@@ -557,10 +557,10 @@ theorem indexEquiv_apply_isComplex_snd (w : {w : InfinitePlace K // IsComplex w}
     (indexEquiv K) (Sum.inr ⟨w, 1⟩) = ComplexEmbedding.conjugate w.val.embedding := rfl
 
 @[deprecated (since := "2025-02-28")] alias indexEquiv_apply_ofIsReal := indexEquiv_apply_isReal
-@[deprecated (since := "2025-02-28")] alias
-  indexEquiv_apply_ofIsComplex_fst := indexEquiv_apply_isComplex_fst
-@[deprecated (since := "2025-02-28")] alias
-  indexEquiv_apply_ofIsComplex_snd := indexEquiv_apply_isComplex_snd
+@[deprecated (since := "2025-02-28")] alias indexEquiv_apply_ofIsComplex_fst :=
+  indexEquiv_apply_isComplex_fst
+@[deprecated (since := "2025-02-28")] alias indexEquiv_apply_ofIsComplex_snd :=
+  indexEquiv_apply_isComplex_snd
 
 variable (K)
 
@@ -916,10 +916,10 @@ theorem negAt_apply_isReal_and_not_mem (x : mixedSpace K) {w : {w // IsReal w}} 
 theorem negAt_apply_isComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
     (negAt s x).2 w = x.2 w := rfl
 
-@[deprecated (since := "2025-02-28")] alias
-  negAt_apply_ofIsReal_and_mem := negAt_apply_isReal_and_mem
-@[deprecated (since := "2025-02-28")] alias
-  negAt_apply_ofIsReal_and_not_mem := negAt_apply_isReal_and_not_mem
+@[deprecated (since := "2025-02-28")] alias negAt_apply_ofIsReal_and_mem :=
+  negAt_apply_isReal_and_mem
+@[deprecated (since := "2025-02-28")] alias negAt_apply_ofIsReal_and_not_mem :=
+  negAt_apply_isReal_and_not_mem
 @[deprecated (since := "2025-02-28")] alias negAt_apply_ofIsComplex := negAt_apply_isComplex
 
 @[simp]
@@ -985,10 +985,10 @@ theorem negAt_signSet_apply_isReal (x : mixedSpace K) (w : {w // IsReal w}) :
 theorem negAt_signSet_apply_isComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
     (negAt (signSet x) x).2 w = x.2 w := rfl
 
-@[deprecated (since := "2025-02-28")] alias
-  negAt_signSet_apply_ofIsReal := negAt_signSet_apply_isReal
-@[deprecated (since := "2025-02-28")] alias
-  negAt_signSet_apply_ofIsComplex := negAt_signSet_apply_isComplex
+@[deprecated (since := "2025-02-28")] alias negAt_signSet_apply_ofIsReal :=
+  negAt_signSet_apply_isReal
+@[deprecated (since := "2025-02-28")] alias negAt_signSet_apply_ofIsComplex :=
+  negAt_signSet_apply_isComplex
 
 variable (A : Set (mixedSpace K)) {x : mixedSpace K}
 

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -360,6 +360,10 @@ theorem normAtPlace_apply_of_isComplex {w : InfinitePlace K} (hw : IsComplex w) 
   rw [normAtPlace, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk,
     dif_neg (not_isReal_iff_isComplex.mpr hw)]
 
+@[deprecated (since := "2025-02-28")] alias normAtPlace_apply_isReal := normAtPlace_apply_of_isReal
+@[deprecated (since := "2025-02-28")] alias normAtPlace_apply_isComplex :=
+  normAtPlace_apply_of_isComplex
+
 @[simp]
 theorem normAtPlace_apply (w : InfinitePlace K) (x : K) :
     normAtPlace w (mixedEmbedding K x) = w x := by
@@ -916,11 +920,11 @@ theorem negAt_apply_isReal_and_not_mem (x : mixedSpace K) {w : {w // IsReal w}} 
 theorem negAt_apply_isComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
     (negAt s x).2 w = x.2 w := rfl
 
-@[deprecated (since := "2025-02-28")] alias negAt_apply_ofIsReal_and_mem :=
+@[deprecated (since := "2025-02-28")] alias negAt_apply_of_isReal_and_mem :=
   negAt_apply_isReal_and_mem
-@[deprecated (since := "2025-02-28")] alias negAt_apply_ofIsReal_and_not_mem :=
+@[deprecated (since := "2025-02-28")] alias negAt_apply_of_isReal_and_not_mem :=
   negAt_apply_isReal_and_not_mem
-@[deprecated (since := "2025-02-28")] alias negAt_apply_ofIsComplex := negAt_apply_isComplex
+@[deprecated (since := "2025-02-28")] alias negAt_apply_of_isComplex := negAt_apply_isComplex
 
 @[simp]
 theorem negAt_apply_snd (x : mixedSpace K) :
@@ -931,7 +935,7 @@ theorem negAt_apply_abs_isReal (x : mixedSpace K) (w : {w // IsReal w}) :
     |(negAt s x).1 w| = |x.1 w| := by
   by_cases hw : w ∈ s <;> simp [hw]
 
-@[deprecated (since := "2025-02-28")] alias negAt_apply_abs_ofIsReal := negAt_apply_abs_isReal
+@[deprecated (since := "2025-02-28")] alias negAt_apply_abs_of_isReal := negAt_apply_abs_isReal
 
 open MeasureTheory Classical in
 /-- `negAt` preserves the volume . -/
@@ -985,9 +989,9 @@ theorem negAt_signSet_apply_isReal (x : mixedSpace K) (w : {w // IsReal w}) :
 theorem negAt_signSet_apply_isComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
     (negAt (signSet x) x).2 w = x.2 w := rfl
 
-@[deprecated (since := "2025-02-28")] alias negAt_signSet_apply_ofIsReal :=
+@[deprecated (since := "2025-02-28")] alias negAt_signSet_apply_of_isReal :=
   negAt_signSet_apply_isReal
-@[deprecated (since := "2025-02-28")] alias negAt_signSet_apply_ofIsComplex :=
+@[deprecated (since := "2025-02-28")] alias negAt_signSet_apply_of_isComplex :=
   negAt_signSet_apply_isComplex
 
 variable (A : Set (mixedSpace K)) {x : mixedSpace K}

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -190,14 +190,19 @@ noncomputable def _root_.NumberField.mixedEmbedding : K →+* (mixedSpace K) :=
     (Pi.ringHom fun w => w.val.embedding)
 
 @[simp]
-theorem mixedEmbedding_apply_ofIsReal (x : K) (w : {w // IsReal w}) :
+theorem mixedEmbedding_apply_IsReal (x : K) (w : {w // IsReal w}) :
     (mixedEmbedding K x).1 w = embedding_of_isReal w.prop x := by
   simp_rw [mixedEmbedding, RingHom.prod_apply, Pi.ringHom_apply]
 
 @[simp]
-theorem mixedEmbedding_apply_ofIsComplex (x : K) (w : {w // IsComplex w}) :
+theorem mixedEmbedding_apply_IsComplex (x : K) (w : {w // IsComplex w}) :
     (mixedEmbedding K x).2 w = w.val.embedding x := by
   simp_rw [mixedEmbedding, RingHom.prod_apply, Pi.ringHom_apply]
+
+@[deprecated (since := "2025-02-28")] alias
+  mixedEmbedding_apply_ofIsReal  := mixedEmbedding_apply_IsReal
+@[deprecated (since := "2025-02-28")] alias
+  mixedEmbedding_apply_ofIsComplex  := mixedEmbedding_apply_IsComplex
 
 instance [NumberField K] : Nontrivial (mixedSpace K) := by
   obtain ⟨w⟩ := (inferInstance : Nonempty (InfinitePlace K))
@@ -479,18 +484,24 @@ def stdBasis : Basis (index K) ℝ (mixedSpace K) :=
 variable {K}
 
 @[simp]
-theorem stdBasis_apply_ofIsReal (x : mixedSpace K) (w : {w : InfinitePlace K // IsReal w}) :
+theorem stdBasis_apply_IsReal (x : mixedSpace K) (w : {w : InfinitePlace K // IsReal w}) :
     (stdBasis K).repr x (Sum.inl w) = x.1 w := rfl
 
 @[simp]
-theorem stdBasis_apply_ofIsComplex_fst (x : mixedSpace K)
+theorem stdBasis_apply_IsComplex_fst (x : mixedSpace K)
     (w : {w : InfinitePlace K // IsComplex w}) :
     (stdBasis K).repr x (Sum.inr ⟨w, 0⟩) = (x.2 w).re := rfl
 
 @[simp]
-theorem stdBasis_apply_ofIsComplex_snd (x : mixedSpace K)
+theorem stdBasis_apply_IsComplex_snd (x : mixedSpace K)
     (w : {w : InfinitePlace K // IsComplex w}) :
     (stdBasis K).repr x (Sum.inr ⟨w, 1⟩) = (x.2 w).im := rfl
+
+@[deprecated (since := "2025-02-28")] alias stdBasis_apply_ofIsReal := stdBasis_apply_IsReal
+@[deprecated (since := "2025-02-28")] alias
+  stdBasis_apply_ofIsComplex_fst := stdBasis_apply_IsComplex_fst
+@[deprecated (since := "2025-02-28")] alias
+  stdBasis_apply_ofIsComplex_snd := stdBasis_apply_IsComplex_snd
 
 variable (K)
 
@@ -534,16 +545,22 @@ def indexEquiv : (index K) ≃ (K →+* ℂ) := by
 variable {K}
 
 @[simp]
-theorem indexEquiv_apply_ofIsReal (w : {w : InfinitePlace K // IsReal w}) :
+theorem indexEquiv_apply_IsReal (w : {w : InfinitePlace K // IsReal w}) :
     (indexEquiv K) (Sum.inl w) = w.val.embedding := rfl
 
 @[simp]
-theorem indexEquiv_apply_ofIsComplex_fst (w : {w : InfinitePlace K // IsComplex w}) :
+theorem indexEquiv_apply_IsComplex_fst (w : {w : InfinitePlace K // IsComplex w}) :
     (indexEquiv K) (Sum.inr ⟨w, 0⟩) = w.val.embedding := rfl
 
 @[simp]
-theorem indexEquiv_apply_ofIsComplex_snd (w : {w : InfinitePlace K // IsComplex w}) :
+theorem indexEquiv_apply_IsComplex_snd (w : {w : InfinitePlace K // IsComplex w}) :
     (indexEquiv K) (Sum.inr ⟨w, 1⟩) = ComplexEmbedding.conjugate w.val.embedding := rfl
+
+@[deprecated (since := "2025-02-28")] alias indexEquiv_apply_ofIsReal := indexEquiv_apply_IsReal
+@[deprecated (since := "2025-02-28")] alias
+  indexEquiv_apply_ofIsComplex_fst := indexEquiv_apply_IsComplex_fst
+@[deprecated (since := "2025-02-28")] alias
+  indexEquiv_apply_ofIsComplex_snd := indexEquiv_apply_IsComplex_snd
 
 variable (K)
 
@@ -579,25 +596,25 @@ theorem stdBasis_repr_eq_matrixToStdBasis_mul (x : (K →+* ℂ) → ℂ)
   simp_rw [commMap, matrixToStdBasis, LinearMap.coe_mk, AddHom.coe_mk,
     mulVec, dotProduct, Function.comp_apply, index, Fintype.sum_sum_type,
     diagonal_one, reindex_apply, ← univ_product_univ, sum_product,
-    indexEquiv_apply_ofIsReal, Fin.sum_univ_two, indexEquiv_apply_ofIsComplex_fst,
-    indexEquiv_apply_ofIsComplex_snd, smul_of, smul_cons, smul_eq_mul,
+    indexEquiv_apply_IsReal, Fin.sum_univ_two, indexEquiv_apply_IsComplex_fst,
+    indexEquiv_apply_IsComplex_snd, smul_of, smul_cons, smul_eq_mul,
     mul_one, Matrix.smul_empty, Equiv.prodComm_symm, Equiv.coe_prodComm]
   cases c with
   | inl w =>
-      simp_rw [stdBasis_apply_ofIsReal, fromBlocks_apply₁₁, fromBlocks_apply₁₂,
+      simp_rw [stdBasis_apply_IsReal, fromBlocks_apply₁₁, fromBlocks_apply₁₂,
         one_apply, Matrix.zero_apply, ite_mul, one_mul, zero_mul, sum_ite_eq, mem_univ, ite_true,
         add_zero, sum_const_zero, add_zero, ← conj_eq_iff_re, hx (embedding w.val),
         conjugate_embedding_eq_of_isReal w.prop]
   | inr c =>
     rcases c with ⟨w, j⟩
     fin_cases j
-    · simp only [Fin.zero_eta, Fin.isValue, id_eq, stdBasis_apply_ofIsComplex_fst, re_eq_add_conj,
+    · simp only [Fin.zero_eta, Fin.isValue, id_eq, stdBasis_apply_IsComplex_fst, re_eq_add_conj,
         mul_neg, fromBlocks_apply₂₁, zero_apply, zero_mul, sum_const_zero, fromBlocks_apply₂₂,
         submatrix_apply, Prod.swap_prod_mk, blockDiagonal_apply, of_apply, cons_val', cons_val_zero,
         empty_val', cons_val_fin_one, ite_mul, cons_val_one, head_cons, sum_add_distrib, sum_ite_eq,
         mem_univ, ↓reduceIte, ← hx (embedding w), zero_add]
       field_simp
-    · simp only [Fin.mk_one, Fin.isValue, id_eq, stdBasis_apply_ofIsComplex_snd, im_eq_sub_conj,
+    · simp only [Fin.mk_one, Fin.isValue, id_eq, stdBasis_apply_IsComplex_snd, im_eq_sub_conj,
         mul_neg, fromBlocks_apply₂₁, zero_apply, zero_mul, sum_const_zero, fromBlocks_apply₂₂,
         submatrix_apply, Prod.swap_prod_mk, blockDiagonal_apply, of_apply, cons_val', cons_val_zero,
         empty_val', cons_val_fin_one, cons_val_one, head_fin_const, ite_mul, neg_mul, head_cons,
@@ -884,29 +901,37 @@ def negAt :
 variable {s}
 
 @[simp]
-theorem negAt_apply_ofIsReal_and_mem (x : mixedSpace K) {w : {w // IsReal w}} (hw : w ∈ s) :
+theorem negAt_apply_IsReal_and_mem (x : mixedSpace K) {w : {w // IsReal w}} (hw : w ∈ s) :
     (negAt s x).1 w = - x.1 w := by
   simp_rw [negAt, ContinuousLinearEquiv.prod_apply, piCongrRight_apply, if_pos hw,
     ContinuousLinearEquiv.neg_apply]
 
 @[simp]
-theorem negAt_apply_ofIsReal_and_not_mem (x : mixedSpace K) {w : {w // IsReal w}} (hw : w ∉ s) :
+theorem negAt_apply_IsReal_and_not_mem (x : mixedSpace K) {w : {w // IsReal w}} (hw : w ∉ s) :
     (negAt s x).1 w = x.1 w := by
   simp_rw [negAt, ContinuousLinearEquiv.prod_apply, piCongrRight_apply, if_neg hw,
     ContinuousLinearEquiv.refl_apply]
 
 @[simp]
-theorem negAt_apply_ofIsComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
+theorem negAt_apply_IsComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
     (negAt s x).2 w = x.2 w := rfl
+
+@[deprecated (since := "2025-02-28")] alias
+  negAt_apply_ofIsReal_and_mem := negAt_apply_IsReal_and_mem
+@[deprecated (since := "2025-02-28")] alias
+  negAt_apply_ofIsReal_and_not_mem := negAt_apply_IsReal_and_not_mem
+@[deprecated (since := "2025-02-28")] alias negAt_apply_ofIsComplex := negAt_apply_IsComplex
 
 @[simp]
 theorem negAt_apply_snd (x : mixedSpace K) :
     (negAt s x).2 = x.2 := rfl
 
 @[simp]
-theorem negAt_apply_abs_ofIsReal (x : mixedSpace K) (w : {w // IsReal w}) :
+theorem negAt_apply_abs_IsReal (x : mixedSpace K) (w : {w // IsReal w}) :
     |(negAt s x).1 w| = |x.1 w| := by
   by_cases hw : w ∈ s <;> simp [hw]
+
+@[deprecated (since := "2025-02-28")] alias negAt_apply_abs_ofIsReal := negAt_apply_abs_IsReal
 
 open MeasureTheory Classical in
 /-- `negAt` preserves the volume . -/
@@ -925,8 +950,8 @@ variable (s) in
 theorem normAtPlace_negAt (x : mixedSpace K) (w : InfinitePlace K) :
     normAtPlace w (negAt s x) = normAtPlace w x := by
   obtain hw | hw := isReal_or_isComplex w
-  · simp_rw [normAtPlace_apply_of_isReal hw, Real.norm_eq_abs, negAt_apply_abs_ofIsReal]
-  · simp_rw [normAtPlace_apply_of_isComplex hw, negAt_apply_ofIsComplex]
+  · simp_rw [normAtPlace_apply_of_isReal hw, Real.norm_eq_abs, negAt_apply_abs_IsReal]
+  · simp_rw [normAtPlace_apply_of_isComplex hw, negAt_apply_IsComplex]
 
 /-- `negAt` preserves the `norm`. -/
 @[simp]
@@ -940,9 +965,9 @@ theorem negAt_symm :
     (negAt s).symm = negAt s := by
   ext x w
   · by_cases hw : w ∈ s
-    · simp_rw [negAt_apply_ofIsReal_and_mem _ hw, negAt, prod_symm,
+    · simp_rw [negAt_apply_IsReal_and_mem _ hw, negAt, prod_symm,
         ContinuousLinearEquiv.prod_apply, piCongrRight_symm_apply, if_pos hw, symm_neg, neg_apply]
-    · simp_rw [negAt_apply_ofIsReal_and_not_mem _ hw, negAt, prod_symm,
+    · simp_rw [negAt_apply_IsReal_and_not_mem _ hw, negAt, prod_symm,
         ContinuousLinearEquiv.prod_apply, piCongrRight_symm_apply, if_neg hw, refl_symm, refl_apply]
   · rfl
 
@@ -950,15 +975,20 @@ theorem negAt_symm :
 def signSet (x : mixedSpace K) : Set {w : InfinitePlace K // IsReal w} := {w | x.1 w ≤ 0}
 
 @[simp]
-theorem negAt_signSet_apply_ofIsReal (x : mixedSpace K) (w : {w // IsReal w}) :
+theorem negAt_signSet_apply_IsReal (x : mixedSpace K) (w : {w // IsReal w}) :
     (negAt (signSet x) x).1 w = |x.1 w| := by
   by_cases hw : x.1 w ≤ 0
-  · rw [negAt_apply_ofIsReal_and_mem _ hw, abs_of_nonpos hw]
-  · rw [negAt_apply_ofIsReal_and_not_mem _ hw, abs_of_pos (lt_of_not_ge hw)]
+  · rw [negAt_apply_IsReal_and_mem _ hw, abs_of_nonpos hw]
+  · rw [negAt_apply_IsReal_and_not_mem _ hw, abs_of_pos (lt_of_not_ge hw)]
 
 @[simp]
-theorem negAt_signSet_apply_ofIsComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
+theorem negAt_signSet_apply_IsComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
     (negAt (signSet x) x).2 w = x.2 w := rfl
+
+@[deprecated (since := "2025-02-28")] alias
+  negAt_signSet_apply_ofIsReal := negAt_signSet_apply_IsReal
+@[deprecated (since := "2025-02-28")] alias
+  negAt_signSet_apply_ofIsComplex := negAt_signSet_apply_IsComplex
 
 variable (A : Set (mixedSpace K)) {x : mixedSpace K}
 
@@ -975,13 +1005,13 @@ abbrev plusPart : Set (mixedSpace K) := A ∩ {x | ∀ w, 0 < x.1 w}
 theorem neg_of_mem_negA_plusPart (hx : x ∈ negAt s '' (plusPart A)) {w : {w // IsReal w}}
     (hw : w ∈ s) : x.1 w < 0 := by
   obtain ⟨y, hy, rfl⟩ := hx
-  rw [negAt_apply_ofIsReal_and_mem _ hw, neg_lt_zero]
+  rw [negAt_apply_IsReal_and_mem _ hw, neg_lt_zero]
   exact hy.2 w
 
 theorem pos_of_not_mem_negAt_plusPart (hx : x ∈ negAt s '' (plusPart A)) {w : {w // IsReal w}}
     (hw : w ∉ s) : 0 < x.1 w := by
   obtain ⟨y, hy, rfl⟩ := hx
-  rw [negAt_apply_ofIsReal_and_not_mem _ hw]
+  rw [negAt_apply_IsReal_and_not_mem _ hw]
   exact hy.2 w
 
 open scoped Function in -- required for scoped `on` notation
@@ -1006,8 +1036,8 @@ theorem mem_negAt_plusPart_of_mem (hx₁ : x ∈ A) (hx₂ : ∀ w, x.1 w ≠ 0)
       fun ⟨h₁, h₂⟩ ↦ ⟨(fun w ↦ |x.1 w|, x.2), ⟨(hA x).mp hx₁, fun w ↦ abs_pos.mpr (hx₂ w)⟩, ?_⟩⟩
   ext w
   · by_cases hw : w ∈ s
-    · simp only [negAt_apply_ofIsReal_and_mem _ hw, abs_of_neg (h₁ w hw), neg_neg]
-    · simp only [negAt_apply_ofIsReal_and_not_mem _ hw, abs_of_pos (h₂ w hw)]
+    · simp only [negAt_apply_IsReal_and_mem _ hw, abs_of_neg (h₁ w hw), neg_neg]
+    · simp only [negAt_apply_IsReal_and_not_mem _ hw, abs_of_pos (h₂ w hw)]
   · rfl
 
 include hA in
@@ -1020,7 +1050,7 @@ theorem iUnion_negAt_plusPart_union :
   rw [Set.mem_union, Set.mem_inter_iff, Set.mem_iUnion, Set.mem_iUnion]
   refine ⟨?_, fun h ↦ ?_⟩
   · rintro (⟨s, ⟨x, ⟨hx, _⟩, rfl⟩⟩ | h)
-    · simp_rw (config := {singlePass := true}) [hA, negAt_apply_abs_ofIsReal, negAt_apply_snd]
+    · simp_rw (config := {singlePass := true}) [hA, negAt_apply_abs_IsReal, negAt_apply_snd]
       rwa [← hA]
     · exact h.left
   · obtain hx | hx := exists_or_forall_not (fun w ↦ x.1 w = 0)

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -346,11 +346,11 @@ theorem normAtPlace_real (w : InfinitePlace K) (c : ℝ) :
   rw [show ((fun _ ↦ c, fun _ ↦ c) : (mixedSpace K)) = c • 1 by ext <;> simp, normAtPlace_smul,
     map_one, mul_one]
 
-theorem normAtPlace_apply_isReal {w : InfinitePlace K} (hw : IsReal w) (x : mixedSpace K) :
+theorem normAtPlace_apply_of_isReal {w : InfinitePlace K} (hw : IsReal w) (x : mixedSpace K) :
     normAtPlace w x = ‖x.1 ⟨w, hw⟩‖ := by
   rw [normAtPlace, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, dif_pos]
 
-theorem normAtPlace_apply_isComplex {w : InfinitePlace K} (hw : IsComplex w) (x : mixedSpace K) :
+theorem normAtPlace_apply_of_isComplex {w : InfinitePlace K} (hw : IsComplex w) (x : mixedSpace K) :
     normAtPlace w x = ‖x.2 ⟨w, hw⟩‖ := by
   rw [normAtPlace, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk,
     dif_neg (not_isReal_iff_isComplex.mpr hw)]
@@ -366,8 +366,8 @@ theorem forall_normAtPlace_eq_zero_iff {x : mixedSpace K} :
     (∀ w, normAtPlace w x = 0) ↔ x = 0 := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · ext w
-    · exact norm_eq_zero.mp (normAtPlace_apply_isReal w.prop _ ▸ h w.1)
-    · exact norm_eq_zero.mp (normAtPlace_apply_isComplex w.prop _ ▸ h w.1)
+    · exact norm_eq_zero.mp (normAtPlace_apply_of_isReal w.prop _ ▸ h w.1)
+    · exact norm_eq_zero.mp (normAtPlace_apply_of_isComplex w.prop _ ▸ h w.1)
   · simp_rw [h, map_zero, implies_true]
 
 @[deprecated (since := "2024-09-13")] alias normAtPlace_eq_zero := forall_normAtPlace_eq_zero_iff
@@ -391,9 +391,9 @@ theorem nnnorm_eq_sup_normAtPlace (x : mixedSpace K) :
     Prod.nnnorm_def, Pi.nnnorm_def, Pi.nnnorm_def]
   congr
   · ext w
-    simp [normAtPlace_apply_isReal w.prop]
+    simp [normAtPlace_apply_of_isReal w.prop]
   · ext w
-    simp [normAtPlace_apply_isComplex w.prop]
+    simp [normAtPlace_apply_of_isComplex w.prop]
 
 open scoped Classical in
 theorem norm_eq_sup'_normAtPlace (x : mixedSpace K) :
@@ -884,19 +884,19 @@ def negAt :
 variable {s}
 
 @[simp]
-theorem negAt_apply_of_isReal_and_mem (x : mixedSpace K) {w : {w // IsReal w}} (hw : w ∈ s) :
+theorem negAt_apply_ofIsReal_and_mem (x : mixedSpace K) {w : {w // IsReal w}} (hw : w ∈ s) :
     (negAt s x).1 w = - x.1 w := by
   simp_rw [negAt, ContinuousLinearEquiv.prod_apply, piCongrRight_apply, if_pos hw,
     ContinuousLinearEquiv.neg_apply]
 
 @[simp]
-theorem negAt_apply_of_isReal_and_not_mem (x : mixedSpace K) {w : {w // IsReal w}} (hw : w ∉ s) :
+theorem negAt_apply_ofIsReal_and_not_mem (x : mixedSpace K) {w : {w // IsReal w}} (hw : w ∉ s) :
     (negAt s x).1 w = x.1 w := by
   simp_rw [negAt, ContinuousLinearEquiv.prod_apply, piCongrRight_apply, if_neg hw,
     ContinuousLinearEquiv.refl_apply]
 
 @[simp]
-theorem negAt_apply_of_isComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
+theorem negAt_apply_ofIsComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
     (negAt s x).2 w = x.2 w := rfl
 
 @[simp]
@@ -904,7 +904,7 @@ theorem negAt_apply_snd (x : mixedSpace K) :
     (negAt s x).2 = x.2 := rfl
 
 @[simp]
-theorem negAt_apply_abs_of_isReal (x : mixedSpace K) (w : {w // IsReal w}) :
+theorem negAt_apply_abs_ofIsReal (x : mixedSpace K) (w : {w // IsReal w}) :
     |(negAt s x).1 w| = |x.1 w| := by
   by_cases hw : w ∈ s <;> simp [hw]
 
@@ -925,8 +925,8 @@ variable (s) in
 theorem normAtPlace_negAt (x : mixedSpace K) (w : InfinitePlace K) :
     normAtPlace w (negAt s x) = normAtPlace w x := by
   obtain hw | hw := isReal_or_isComplex w
-  · simp_rw [normAtPlace_apply_isReal hw, Real.norm_eq_abs, negAt_apply_abs_of_isReal]
-  · simp_rw [normAtPlace_apply_isComplex hw, negAt_apply_of_isComplex]
+  · simp_rw [normAtPlace_apply_of_isReal hw, Real.norm_eq_abs, negAt_apply_abs_ofIsReal]
+  · simp_rw [normAtPlace_apply_of_isComplex hw, negAt_apply_ofIsComplex]
 
 /-- `negAt` preserves the `norm`. -/
 @[simp]
@@ -940,9 +940,9 @@ theorem negAt_symm :
     (negAt s).symm = negAt s := by
   ext x w
   · by_cases hw : w ∈ s
-    · simp_rw [negAt_apply_of_isReal_and_mem _ hw, negAt, prod_symm,
+    · simp_rw [negAt_apply_ofIsReal_and_mem _ hw, negAt, prod_symm,
         ContinuousLinearEquiv.prod_apply, piCongrRight_symm_apply, if_pos hw, symm_neg, neg_apply]
-    · simp_rw [negAt_apply_of_isReal_and_not_mem _ hw, negAt, prod_symm,
+    · simp_rw [negAt_apply_ofIsReal_and_not_mem _ hw, negAt, prod_symm,
         ContinuousLinearEquiv.prod_apply, piCongrRight_symm_apply, if_neg hw, refl_symm, refl_apply]
   · rfl
 
@@ -950,14 +950,14 @@ theorem negAt_symm :
 def signSet (x : mixedSpace K) : Set {w : InfinitePlace K // IsReal w} := {w | x.1 w ≤ 0}
 
 @[simp]
-theorem negAt_signSet_apply_of_isReal (x : mixedSpace K) (w : {w // IsReal w}) :
+theorem negAt_signSet_apply_ofIsReal (x : mixedSpace K) (w : {w // IsReal w}) :
     (negAt (signSet x) x).1 w = |x.1 w| := by
   by_cases hw : x.1 w ≤ 0
-  · rw [negAt_apply_of_isReal_and_mem _ hw, abs_of_nonpos hw]
-  · rw [negAt_apply_of_isReal_and_not_mem _ hw, abs_of_pos (lt_of_not_ge hw)]
+  · rw [negAt_apply_ofIsReal_and_mem _ hw, abs_of_nonpos hw]
+  · rw [negAt_apply_ofIsReal_and_not_mem _ hw, abs_of_pos (lt_of_not_ge hw)]
 
 @[simp]
-theorem negAt_signSet_apply_of_isComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
+theorem negAt_signSet_apply_ofIsComplex (x : mixedSpace K) (w : {w // IsComplex w}) :
     (negAt (signSet x) x).2 w = x.2 w := rfl
 
 variable (A : Set (mixedSpace K)) {x : mixedSpace K}
@@ -975,13 +975,13 @@ abbrev plusPart : Set (mixedSpace K) := A ∩ {x | ∀ w, 0 < x.1 w}
 theorem neg_of_mem_negA_plusPart (hx : x ∈ negAt s '' (plusPart A)) {w : {w // IsReal w}}
     (hw : w ∈ s) : x.1 w < 0 := by
   obtain ⟨y, hy, rfl⟩ := hx
-  rw [negAt_apply_of_isReal_and_mem _ hw, neg_lt_zero]
+  rw [negAt_apply_ofIsReal_and_mem _ hw, neg_lt_zero]
   exact hy.2 w
 
 theorem pos_of_not_mem_negAt_plusPart (hx : x ∈ negAt s '' (plusPart A)) {w : {w // IsReal w}}
     (hw : w ∉ s) : 0 < x.1 w := by
   obtain ⟨y, hy, rfl⟩ := hx
-  rw [negAt_apply_of_isReal_and_not_mem _ hw]
+  rw [negAt_apply_ofIsReal_and_not_mem _ hw]
   exact hy.2 w
 
 open scoped Function in -- required for scoped `on` notation
@@ -1006,8 +1006,8 @@ theorem mem_negAt_plusPart_of_mem (hx₁ : x ∈ A) (hx₂ : ∀ w, x.1 w ≠ 0)
       fun ⟨h₁, h₂⟩ ↦ ⟨(fun w ↦ |x.1 w|, x.2), ⟨(hA x).mp hx₁, fun w ↦ abs_pos.mpr (hx₂ w)⟩, ?_⟩⟩
   ext w
   · by_cases hw : w ∈ s
-    · simp only [negAt_apply_of_isReal_and_mem _ hw, abs_of_neg (h₁ w hw), neg_neg]
-    · simp only [negAt_apply_of_isReal_and_not_mem _ hw, abs_of_pos (h₂ w hw)]
+    · simp only [negAt_apply_ofIsReal_and_mem _ hw, abs_of_neg (h₁ w hw), neg_neg]
+    · simp only [negAt_apply_ofIsReal_and_not_mem _ hw, abs_of_pos (h₂ w hw)]
   · rfl
 
 include hA in
@@ -1020,7 +1020,7 @@ theorem iUnion_negAt_plusPart_union :
   rw [Set.mem_union, Set.mem_inter_iff, Set.mem_iUnion, Set.mem_iUnion]
   refine ⟨?_, fun h ↦ ?_⟩
   · rintro (⟨s, ⟨x, ⟨hx, _⟩, rfl⟩⟩ | h)
-    · simp_rw (config := {singlePass := true}) [hA, negAt_apply_abs_of_isReal, negAt_apply_snd]
+    · simp_rw (config := {singlePass := true}) [hA, negAt_apply_abs_ofIsReal, negAt_apply_snd]
       rwa [← hA]
     · exact h.left
   · obtain hx | hx := exists_or_forall_not (fun w ↦ x.1 w = 0)

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -276,9 +276,9 @@ theorem convexBodySumFun_apply' (x : mixedSpace K) :
     ← Finset.univ.sum_subtype_eq_sum_filter, Finset.mul_sum]
   congr
   · ext w
-    rw [mult, if_pos w.prop, normAtPlace_apply_isReal, Nat.cast_one, one_mul]
+    rw [mult, if_pos w.prop, normAtPlace_apply_of_isReal, Nat.cast_one, one_mul]
   · ext w
-    rw [mult, if_neg (not_isReal_iff_isComplex.mpr w.prop), normAtPlace_apply_isComplex,
+    rw [mult, if_neg (not_isReal_iff_isComplex.mpr w.prop), normAtPlace_apply_of_isComplex,
       Nat.cast_ofNat]
 
 theorem convexBodySumFun_nonneg (x : mixedSpace K) :
@@ -326,7 +326,7 @@ theorem convexBodySumFun_continuous :
   refine continuous_finset_sum Finset.univ fun w ↦ ?_
   obtain hw | hw := isReal_or_isComplex w
   all_goals
-  · simp only [normAtPlace_apply_isReal, normAtPlace_apply_isComplex, hw]
+  · simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
     fun_prop
 
 /-- The convex body equal to the set of points `x : mixedSpace K` such that


### PR DESCRIPTION
When dealing with the mixed space, a lot of results depend on whether the infinite place considered is real or is complex and thus are duplicated using the ending `apply_of_isReal` or `apply_of_isComplex` in their names. However, the spelling `apply_ofIsReal` or `apply_ofIsComplex` was also used for some results. 

This PR attempts to fix this confusion using the following convention:
- If the fact that the infinite place is real or complex comes from an additional hypothesis, use `apply_of_isReal`/`apply_of_isComplex`
- If the fact that the infinite place is real or complex comes from a subtype, use `apply_isReal` / `apply_isComplex`



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
