### PR TITLE
[Merged by Bors] - chore: provide non-dependent versions of `LinearPMap.ext` and `ExtensionOf.ext`

### DIFF
--- a/Mathlib/Algebra/Module/Injective.lean
+++ b/Mathlib/Algebra/Module/Injective.lean
@@ -86,26 +86,32 @@ variable {i f}
 
 @[ext (iff := false)]
 theorem ExtensionOf.ext {a b : ExtensionOf i f} (domain_eq : a.domain = b.domain)
-    (to_fun_eq :
-      ∀ ⦃x : a.domain⦄ ⦃y : b.domain⦄, (x : N) = y → a.toLinearPMap x = b.toLinearPMap y) :
+    (to_fun_eq : ∀ ⦃x : N⦄ ⦃ha : x ∈ a.domain⦄ ⦃hb : x ∈ b.domain⦄,
+      a.toLinearPMap ⟨x, ha⟩ = b.toLinearPMap ⟨x, hb⟩) :
     a = b := by
   rcases a with ⟨a, a_le, e1⟩
   rcases b with ⟨b, b_le, e2⟩
   congr
   exact LinearPMap.ext domain_eq to_fun_eq
 
-theorem ExtensionOf.ext_iff {a b : ExtensionOf i f} :
+/-- A dependent version of `ExtensionOf.ext` -/
+theorem ExtensionOf.dExt {a b : ExtensionOf i f} (domain_eq : a.domain = b.domain)
+    (to_fun_eq :
+      ∀ ⦃x : a.domain⦄ ⦃y : b.domain⦄, (x : N) = y → a.toLinearPMap x = b.toLinearPMap y) :
+    a = b :=
+  ext domain_eq fun _ _ _ ↦ to_fun_eq rfl
+
+theorem ExtensionOf.dExt_iff {a b : ExtensionOf i f} :
     a = b ↔ ∃ _ : a.domain = b.domain, ∀ ⦃x : a.domain⦄ ⦃y : b.domain⦄,
     (x : N) = y → a.toLinearPMap x = b.toLinearPMap y :=
   ⟨fun r => r ▸ ⟨rfl, fun _ _ h => congr_arg a.toFun <| mod_cast h⟩, fun ⟨h1, h2⟩ =>
-    ExtensionOf.ext h1 h2⟩
+    ExtensionOf.dExt h1 h2⟩
 
 end Ext
 
 instance : Min (ExtensionOf i f) where
   min X1 X2 :=
-    { X1.toLinearPMap ⊓
-        X2.toLinearPMap with
+    { X1.toLinearPMap ⊓ X2.toLinearPMap with
       le := fun x hx =>
         (by
           rcases hx with ⟨x, rfl⟩
@@ -116,19 +122,12 @@ instance : Min (ExtensionOf i f) where
 
 instance : SemilatticeInf (ExtensionOf i f) :=
   Function.Injective.semilatticeInf ExtensionOf.toLinearPMap
-    (fun X Y h =>
-      ExtensionOf.ext (by rw [h]) fun x y h' => by
-        -- Porting note: induction didn't handle dependent rw like in Lean 3
-        have : {x y : N} → (h'' : x = y) → (hx : x ∈ X.toLinearPMap.domain) →
-          (hy : y ∈ Y.toLinearPMap.domain) → X.toLinearPMap ⟨x,hx⟩ = Y.toLinearPMap ⟨y,hy⟩ := by
-            rw [h]
-            intro _ _ h _ _
-            congr
-        apply this h' _ _)
-    fun X Y =>
-    LinearPMap.ext rfl fun x y h => by
-      congr
-      exact mod_cast h
+    (fun X Y h ↦
+      ExtensionOf.ext (by rw [h]) <| by
+        rw [h]
+        intros
+        rfl)
+    fun X Y ↦ LinearPMap.ext rfl fun x y h => by congr
 
 variable {i f}
 
@@ -142,9 +141,7 @@ theorem chain_linearPMap_of_chain_extensionOf {c : Set (ExtensionOf i f)}
 def ExtensionOf.max {c : Set (ExtensionOf i f)} (hchain : IsChain (· ≤ ·) c)
     (hnonempty : c.Nonempty) : ExtensionOf i f :=
   { LinearPMap.sSup _
-      (IsChain.directedOn <|
-        chain_linearPMap_of_chain_extensionOf
-          hchain) with
+      (IsChain.directedOn <| chain_linearPMap_of_chain_extensionOf hchain) with
     le := by
       refine le_trans hnonempty.some.le <|
         (LinearPMap.le_sSup _ <|

--- a/Mathlib/Topology/Algebra/Module/LinearPMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearPMap.lean
@@ -150,14 +150,14 @@ Note that we don't require that `f` is closable, due to the definition of the cl
 theorem closureHasCore (f : E →ₗ.[R] F) : f.closure.HasCore f.domain := by
   refine ⟨f.le_closure.1, ?_⟩
   congr
-  ext x y hxy
+  ext x h1 h2
   · simp only [domRestrict_domain, Submodule.mem_inf, and_iff_left_iff_imp]
     intro hx
     exact f.le_closure.1 hx
-  let z : f.closure.domain := ⟨y.1, f.le_closure.1 y.2⟩
-  have hyz : (y : E) = z := by simp [z]
+  let z : f.closure.domain := ⟨x, f.le_closure.1 h2⟩
+  have hyz : x = z := rfl
   rw [f.le_closure.2 hyz]
-  exact domRestrict_apply (hxy.trans hyz)
+  exact domRestrict_apply hyz
 
 /-! ### Topological properties of the inverse -/
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
