### PR TITLE
[Merged by Bors] - fix(Cache): error on import loop

### DIFF
--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -84,7 +84,11 @@ Computes the hash of a file, which mixes:
 * The hash of its content
 * The hashes of the imported files that are part of `Mathlib`
 -/
-partial def getFileHash (filePath : FilePath) : HashM <| Option UInt64 := do
+partial def getHash (filePath : FilePath) (visited : Std.HashSet FilePath := ∅) :
+    HashM <| Option UInt64 := do
+  if visited.contains filePath then
+    throw <| IO.userError s!"dependency loop found involving {filePath}!"
+  let visitedNew := visited.insert filePath
   match (← get).cache[filePath]? with
   | some hash? => return hash?
   | none =>
@@ -99,7 +103,7 @@ partial def getFileHash (filePath : FilePath) : HashM <| Option UInt64 := do
     let content ← IO.FS.readFile fixedPath
     let fileImports := getFileImports content (← getPackageDirs)
     let mut importHashes := #[]
-    for importHash? in ← fileImports.mapM getFileHash do
+    for importHash? in ← fileImports.mapM (getHash (visited := visitedNew)) do
       match importHash? with
       | some importHash => importHashes := importHashes.push importHash
       | none =>
@@ -119,6 +123,6 @@ def roots : Array FilePath := #["Mathlib.lean"]
 
 /-- Main API to retrieve the hashes of the Lean files -/
 def getHashMemo (extraRoots : Array FilePath) : CacheM HashMemo :=
-  return (← StateT.run ((roots ++ extraRoots).mapM getFileHash) { rootHash := ← getRootHash }).2
+  return (← StateT.run ((roots ++ extraRoots).mapM getHash) { rootHash := ← getRootHash }).2
 
 end Cache.Hashing


### PR DESCRIPTION
In case of an import loop, throw an error instead of stack overflow due to max recursion depth.

---

Fixed stack overflow reported in: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Stack.20overflow.20in.20.60lake.20exe.20cache.20get.60/near/496801402

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
