### PR TITLE
[Merged by Bors] - feat: `erw?`, a tool to explain why `erw` is necessary

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5051,6 +5051,7 @@ import Mathlib.Tactic.DeriveEncodable
 import Mathlib.Tactic.DeriveFintype
 import Mathlib.Tactic.DeriveTraversable
 import Mathlib.Tactic.Eqns
+import Mathlib.Tactic.ErwQuestion
 import Mathlib.Tactic.Eval
 import Mathlib.Tactic.ExistsI
 import Mathlib.Tactic.Explode

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -72,6 +72,7 @@ import Mathlib.Tactic.DeriveEncodable
 import Mathlib.Tactic.DeriveFintype
 import Mathlib.Tactic.DeriveTraversable
 import Mathlib.Tactic.Eqns
+import Mathlib.Tactic.ErwQuestion
 import Mathlib.Tactic.Eval
 import Mathlib.Tactic.ExistsI
 import Mathlib.Tactic.Explode

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -46,6 +46,7 @@ import Mathlib.Tactic.Conv
 import Mathlib.Tactic.Convert
 import Mathlib.Tactic.DefEqTransformations
 import Mathlib.Tactic.DeprecateTo
+import Mathlib.Tactic.ErwQuestion
 import Mathlib.Tactic.Eqns
 import Mathlib.Tactic.ExistsI
 import Mathlib.Tactic.ExtractGoal

--- a/Mathlib/Tactic/ErwQuestion.lean
+++ b/Mathlib/Tactic/ErwQuestion.lean
@@ -54,7 +54,7 @@ def logDiffs (tk : Syntax) (e₁ e₂ : Expr) : StateT (Array (Unit → MessageD
     return false
   else
     verbose m!"{crossEmoji} at reducible transparency,\
-      {indentD e₁}\nand\n{indentD e₂}\nare not defeq."
+      {indentD e₁}\nand{indentD e₂}\nare not defeq."
     if ← isDefEq e₁ e₂ then
       match e₁, e₂ with
       | Expr.app f₁ a₁, Expr.app f₂ a₂ =>

--- a/Mathlib/Tactic/ErwQuestion.lean
+++ b/Mathlib/Tactic/ErwQuestion.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+import Lean.Elab.Tactic.Basic
+
+open Lean Parser.Tactic Elab Tactic Meta
+
+namespace Mathlib.Tactic.Erw?
+
+/--
+`erw? [r]` calls `erw [r]` (note that only a single step is allowed),
+and then attempts to identify any subexpression which would block the use of `rw` instead.
+It does so by identifying subexpressions which are defeq, but not at reducible transparency.
+ -/
+syntax (name := erw?) "erw? " "[" rwRule "]" : tactic
+
+/--
+Check if two expressions are different at reducible transparency.
+Attempt to log an info message for the first subexpressions which are different
+(but agree at default transparency).
+-/
+def logDiffs (tk : Syntax) (e₁ e₂ : Expr) : MetaM Bool := do
+  if ← withReducible (isDefEq e₁ e₂) then
+    -- logInfoAt tk m!"{e₁} and {e₂} are defeq at reducible transparency"
+    -- They agree at reducible transparency, done
+    return false
+  else
+    -- logInfoAt tk m!"{e₁} and {e₂} are not defeq at reducible transparency"
+    if ← isDefEq e₁ e₂ then
+      match e₁, e₂ with
+      | Expr.app f₁ a₁, Expr.app f₂ a₂ =>
+        if ← logDiffs tk a₁ a₂ then
+          return true
+        else if ← logDiffs tk f₁ f₂ then
+          return true
+        else
+          logInfoAt tk m!"{e₁}\n  and\n{e₂}\n  \
+            are defeq at default transparency, but not at reducible transparency."
+          return true
+      | _, _ =>
+        return false
+    else
+      return false
+
+elab_rules : tactic
+  | `(tactic| erw?%$tk [$r]) => do
+    withMainContext do
+    let g ← getMainGoal
+    evalTactic (← `(tactic| erw [$r]))
+    let e := (← instantiateMVars (mkMVar g)).headBeta
+    match e.getAppFnArgs with
+    | (``Eq.mpr, #[_, _, e, _]) =>
+      match e.getAppFnArgs with
+      | (``id, #[ty, e]) =>
+        match ty.eq? with
+        | some (_, tgt, _) =>
+          -- logInfoAt tk m!"Expression appearing in target: {tgt}"
+          match (← inferType e).eq? with
+          | some (_, inferred, _) =>
+            -- logInfoAt tk m!"Expression from `erw`: {inferred}"
+            _ ← logDiffs tk tgt inferred
+          | _ => logErrorAt tk "Unexpected term produced by `erw`."
+        | _ => logErrorAt tk "Unexpected term produced by `erw`."
+      | _ => logErrorAt tk "Unexpected term produced by `erw`."
+    | _ => logErrorAt tk "Unexpected term produced by `erw`."
+
+end Mathlib.Tactic.Erw?

--- a/Mathlib/Tactic/ErwQuestion.lean
+++ b/Mathlib/Tactic/ErwQuestion.lean
@@ -79,8 +79,9 @@ def logDiffs (tk : Syntax) (e₁ e₂ : Expr) : StateT (Array (Unit → MessageD
         verbose
           m!"{crossEmoji}{indentD e₁}\nand{indentD e₂}\nare not defeq at default transparency."
       return false
+
 /--
-Checks that the input `Expr` represents an equality and returns the types of the two sides,
+Checks that the input `Expr` represents a proof produced by `(e)rw` and returns the types of the LHS of the equality being written (one from the target, the other from the lemma used). These will be defeq, but not necessarily reducibly so.
 so that they can be compared at various transparency levels.
 -/
 def extractRewriteEq (e : Expr) : MetaM (Expr × Expr) := do

--- a/Mathlib/Tactic/ErwQuestion.lean
+++ b/Mathlib/Tactic/ErwQuestion.lean
@@ -86,7 +86,7 @@ elab_rules : tactic
     let verbose := (← getOptions).get `tactic.erw?.verbose (defVal := false)
     let g ← getMainGoal
     evalTactic (← `(tactic| erw [$r]))
-    let e := (← instantiateMVars (mkMVar g)).headBeta
+    let e := (← instantiateMVars (.mvar g)).headBeta
     let (``Eq.mpr, #[_, _, e, _]) := e.getAppFnArgs |
       logErrorAt tk "Unexpected term produced by `erw`, head is not an `Eq.mpr`."
     let (``id, #[ty, e]) := e.getAppFnArgs |

--- a/Mathlib/Tactic/ErwQuestion.lean
+++ b/Mathlib/Tactic/ErwQuestion.lean
@@ -81,8 +81,9 @@ def logDiffs (tk : Syntax) (e₁ e₂ : Expr) : StateT (Array (Unit → MessageD
       return false
 
 /--
-Checks that the input `Expr` represents a proof produced by `(e)rw` and returns the types of the LHS of the equality being written (one from the target, the other from the lemma used). These will be defeq, but not necessarily reducibly so.
-so that they can be compared at various transparency levels.
+Checks that the input `Expr` represents a proof produced by `(e)rw` and returns the types of the
+LHS of the equality being written (one from the target, the other from the lemma used).
+These will be defeq, but not necessarily reducibly so.
 -/
 def extractRewriteEq (e : Expr) : MetaM (Expr × Expr) := do
   let (``Eq.mpr, #[_, _, e, _]) := e.getAppFnArgs |

--- a/Mathlib/Tactic/ErwQuestion.lean
+++ b/Mathlib/Tactic/ErwQuestion.lean
@@ -32,7 +32,7 @@ register_option tactic.erw?.verbose : Bool := {
 `erw? [r]` calls `erw [r]` (note that only a single step is allowed),
 and then attempts to identify any subexpression which would block the use of `rw` instead.
 It does so by identifying subexpressions which are defeq, but not at reducible transparency.
- -/
+-/
 syntax (name := erw?) "erw? " "[" rwRule "]" : tactic
 
 /--

--- a/Mathlib/Tactic/ErwQuestion.lean
+++ b/Mathlib/Tactic/ErwQuestion.lean
@@ -62,7 +62,7 @@ def logDiffs (tk : Syntax) (e₁ e₂ : Expr) : StateT (Array (Unit → MessageD
           if ← logDiffs tk f₁ f₂ then
             return true
           else
-            logInfoAt tk m!"{crossEmoji}\n{e₁}\n  and\n{e₂}\nare defeq at default transparency, \
+            logInfoAt tk m!"{crossEmoji} at default transparency,{indentD e₁}\n  and{indentD e₂}\nare defeq, \
               but not at reducible transparency."
             return true
       | Expr.const _ _, Expr.const _ _ =>
@@ -93,7 +93,7 @@ elab_rules : tactic
     let (_, msgs) ← (logDiffs tk tgt inferred).run #[]
     if verbose then
       logInfoAt tk <| .joinSep
-        (m!"Expression appearing in target: {tgt}" ::
+        (m!"Expression appearing in target:{indentD tgt}" ::
           m!"Expression from `erw`: {inferred}" :: msgs.toList.map (· ())) "\n\n"
 
 end Mathlib.Tactic.Erw?

--- a/Mathlib/Tactic/ErwQuestion.lean
+++ b/Mathlib/Tactic/ErwQuestion.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
+import Mathlib.Init
 import Lean.Elab.Tactic.Basic
 
 open Lean Parser.Tactic Elab Tactic Meta

--- a/MathlibTest/ErwQuestion.lean
+++ b/MathlibTest/ErwQuestion.lean
@@ -51,7 +51,6 @@ Expression from `erw`: f a = 38
 ❌️ at reducible transparency,
   f b = 38
 and
-
   f a = 38
 are not defeq.
 
@@ -64,18 +63,16 @@ are defeq.
 ❌️ at reducible transparency,
   Eq (f b)
 and
-
   Eq (f a)
 are not defeq.
 
 ❌️ at reducible transparency,
   f b
 and
-
   f a
 are not defeq.
 
-❌️ at reducible transparency, b and  a are not defeq.
+❌️ at reducible transparency, b and a are not defeq.
 -/
 #guard_msgs in
 example : f b = 38 := by erw? [f_a]

--- a/MathlibTest/ErwQuestion.lean
+++ b/MathlibTest/ErwQuestion.lean
@@ -1,0 +1,25 @@
+import Mathlib.Tactic.ErwQuestion
+
+def f (x : Nat) := x + 1
+def a := 37
+theorem f_a : f a = 38 := rfl
+def b := a
+
+/--
+error: tactic 'rewrite' failed, did not find instance of the pattern in the target expression
+  f a
+⊢ f b = 38
+-/
+#guard_msgs in
+example : f b = 38 := by rw [f_a]
+
+example : f b = 38 := by erw [f_a]
+
+/--
+info: b
+  and
+a
+  are defeq at default transparency, but not at reducible transparency.
+-/
+#guard_msgs in
+example : f b = 38 := by erw? [f_a]

--- a/MathlibTest/ErwQuestion.lean
+++ b/MathlibTest/ErwQuestion.lean
@@ -16,10 +16,52 @@ example : f b = 38 := by rw [f_a]
 example : f b = 38 := by erw [f_a]
 
 /--
-info: b
+info: ❌️
+b
   and
 a
-  are defeq at default transparency, but not at reducible transparency.
+are defeq at default transparency, but not at reducible transparency.
+-/
+#guard_msgs in
+example : f b = 38 := by erw? [f_a]
+
+set_option tactic.erw?.verbose true in
+/--
+info: ❌️
+b
+  and
+a
+are defeq at default transparency, but not at reducible transparency.
+---
+info: Expression appearing in target: f b = 38
+
+Expression from `erw`: f a = 38
+
+❌️
+f b = 38
+  and
+f a = 38
+are not defeq at reducible transparency.
+
+✅️
+38
+  and
+38
+are defeq at reducible transparency.
+
+❌️
+Eq (f b)
+  and
+Eq (f a)
+are not defeq at reducible transparency.
+
+❌️
+f b
+  and
+f a
+are not defeq at reducible transparency.
+
+❌️ b   and a are not defeq at reducible transparency.
 -/
 #guard_msgs in
 example : f b = 38 := by erw? [f_a]

--- a/MathlibTest/ErwQuestion.lean
+++ b/MathlibTest/ErwQuestion.lean
@@ -5,6 +5,12 @@ def a := 37
 theorem f_a : f a = 38 := rfl
 def b := a
 
+-- make sure that `erw'` is noisy, so that it gets picked up by CI
+/-- info: Debugging `erw?` -/
+#guard_msgs in
+example : f 37 = 38 := by
+  erw? [f]
+
 /--
 error: tactic 'rewrite' failed, did not find instance of the pattern in the target expression
   f a
@@ -16,52 +22,60 @@ example : f b = 38 := by rw [f_a]
 example : f b = 38 := by erw [f_a]
 
 /--
-info: ❌️
-b
-  and
-a
-are defeq at default transparency, but not at reducible transparency.
+info: Debugging `erw?`
+---
+info: ❌️ at reducible transparency,
+  b
+and
+  a
+are not defeq, but they are at default transparency.
 -/
 #guard_msgs in
 example : f b = 38 := by erw? [f_a]
 
 set_option tactic.erw?.verbose true in
 /--
-info: ❌️
-b
-  and
-a
-are defeq at default transparency, but not at reducible transparency.
+info: Debugging `erw?`
 ---
-info: Expression appearing in target: f b = 38
+info: ❌️ at reducible transparency,
+  b
+and
+  a
+are not defeq, but they are at default transparency.
+---
+info: Expression appearing in target:
+  f b = 38
 
 Expression from `erw`: f a = 38
 
-❌️
-f b = 38
-  and
-f a = 38
-are not defeq at reducible transparency.
+❌️ at reducible transparency,
+  f b = 38
+and
 
-✅️
-38
-  and
-38
-are defeq at reducible transparency.
+  f a = 38
+are not defeq.
 
-❌️
-Eq (f b)
-  and
-Eq (f a)
-are not defeq at reducible transparency.
+✅️ at reducible transparency,
+  38
+and
+  38
+are defeq.
 
-❌️
-f b
-  and
-f a
-are not defeq at reducible transparency.
+❌️ at reducible transparency,
+  Eq (f b)
+and
 
-❌️ b   and a are not defeq at reducible transparency.
+  Eq (f a)
+are not defeq.
+
+❌️ at reducible transparency,
+  f b
+and
+
+  f a
+are not defeq.
+
+❌️ at reducible transparency, b and  a are not defeq.
 -/
 #guard_msgs in
 example : f b = 38 := by erw? [f_a]


### PR DESCRIPTION
[Zulip](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/feat.3A.20erw.3F.2C.20a.20tool.20to.20explain.20why.20erw.20is.20necessary.20.2321643)

Example usage: in 
```lean
def subalgebraMap (e : A ≃ₐ[R] B) (S : Subalgebra R A) : S ≃ₐ[R] S.map (e : A →ₐ[R] B) :=
  { e.toRingEquiv.subsemiringMap S.toSubsemiring with
    commutes' := fun r => by
      ext; dsimp only
      erw [RingEquiv.subsemiringMap_apply_coe]
      exact e.commutes _ }
```     
replace `erw` with `erw?`. You'll get the informational message:
```
(e.toRingEquiv.subsemiringMap S.toSubsemiring).toFun
  and
⇑(e.toRingEquiv.subsemiringMap S.toSubsemiring)
  are defeq at default transparency, but not at reducible transparency.
```
and this then suggests to a sufficiently expert reader which simp lemmas are missing! (In this particular case, I'd first replace the `dsimp only` with `dsimp`, and then run `erw?`, which tell you something more useful.)

Note that `erw?` only accepts a single lemma, so any `erw [X1, X2, X3]` need to be broken up first (this is probably good practice anyway, to record which steps really need the `erw`).