### PR TITLE
[Merged by Bors] - chore(Topology/MetricSpace/Pseudo): move lemmas downstream

### DIFF
--- a/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
@@ -256,3 +256,17 @@ theorem secondCountable_of_almost_dense_set
 end SecondCountable
 
 end Metric
+
+section Compact
+
+/-- Any compact set in a pseudometric space can be covered by finitely many balls of a given
+positive radius -/
+theorem finite_cover_balls_of_compact {α : Type u} [PseudoMetricSpace α] {s : Set α}
+    (hs : IsCompact s) {e : ℝ} (he : 0 < e) :
+    ∃ t, t ⊆ s ∧ Set.Finite t ∧ s ⊆ ⋃ x ∈ t, ball x e :=
+  let ⟨t, hts, ht⟩ := hs.elim_nhds_subcover _ (fun x _ => ball_mem_nhds x he)
+  ⟨t, hts, t.finite_toSet, ht⟩
+
+alias IsCompact.finite_cover_balls := finite_cover_balls_of_compact
+
+end Compact

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -5,8 +5,9 @@ Authors: Jeremy Avigad, Robert Y. Lewis, Johannes Hölzl, Mario Carneiro, Sébas
 -/
 import Mathlib.Data.ENNReal.Real
 import Mathlib.Tactic.Bound.Attribute
+import Mathlib.Topology.Bornology.Basic
 import Mathlib.Topology.EMetricSpace.Defs
-import Mathlib.Topology.UniformSpace.Compact
+import Mathlib.Topology.UniformSpace.Basic
 
 /-!
 ## Pseudo-metric spaces
@@ -38,6 +39,8 @@ TODO (anyone): Add "Main results" section.
 
 pseudo_metric, dist
 -/
+
+assert_not_exists compactSpace_uniformity
 
 open Set Filter TopologicalSpace Bornology
 open scoped ENNReal NNReal Uniformity Topology
@@ -1145,29 +1148,6 @@ theorem _root_.ContinuousOn.isSeparable_image [TopologicalSpace β] {f : α → 
   exact (isSeparable_univ_iff.2 hs.separableSpace).image hf.restrict
 
 end Metric
-
-section Compact
-
-/-- Any compact set in a pseudometric space can be covered by finitely many balls of a given
-positive radius -/
-theorem finite_cover_balls_of_compact {α : Type u} [PseudoMetricSpace α] {s : Set α}
-    (hs : IsCompact s) {e : ℝ} (he : 0 < e) :
-    ∃ t, t ⊆ s ∧ Set.Finite t ∧ s ⊆ ⋃ x ∈ t, ball x e :=
-  let ⟨t, hts, ht⟩ := hs.elim_nhds_subcover _ (fun x _ => ball_mem_nhds x he)
-  ⟨t, hts, t.finite_toSet, ht⟩
-
-alias IsCompact.finite_cover_balls := finite_cover_balls_of_compact
-
-end Compact
-
-theorem lebesgue_number_lemma_of_metric {s : Set α} {ι : Sort*} {c : ι → Set α} (hs : IsCompact s)
-    (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : s ⊆ ⋃ i, c i) : ∃ δ > 0, ∀ x ∈ s, ∃ i, ball x δ ⊆ c i := by
-  simpa only [ball, UniformSpace.ball, preimage_setOf_eq, dist_comm]
-    using uniformity_basis_dist.lebesgue_number_lemma hs hc₁ hc₂
-
-theorem lebesgue_number_lemma_of_metric_sUnion {s : Set α} {c : Set (Set α)} (hs : IsCompact s)
-    (hc₁ : ∀ t ∈ c, IsOpen t) (hc₂ : s ⊆ ⋃₀ c) : ∃ δ > 0, ∀ x ∈ s, ∃ t ∈ c, ball x δ ⊆ t := by
-  rw [sUnion_eq_iUnion] at hc₂; simpa using lebesgue_number_lemma_of_metric hs (by simpa) hc₂
 
 instance : PseudoMetricSpace (Additive α) := ‹_›
 instance : PseudoMetricSpace (Multiplicative α) := ‹_›

--- a/Mathlib/Topology/MetricSpace/Pseudo/Lemmas.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Lemmas.lean
@@ -3,8 +3,9 @@ Copyright (c) 2015, 2017 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis, Johannes Hölzl, Mario Carneiro, Sébastien Gouëzel
 -/
-import Mathlib.Topology.Order.DenselyOrdered
 import Mathlib.Topology.MetricSpace.Pseudo.Constructions
+import Mathlib.Topology.Order.DenselyOrdered
+import Mathlib.Topology.UniformSpace.Compact
 
 /-!
 # Extra lemmas about pseudo-metric spaces
@@ -108,3 +109,12 @@ theorem biUnion_lt_closedBall (x : α) (r : ℝ) : ⋃ r' < r, closedBall x r' =
   simp [forall_lt_iff_le]
 
 end Metric
+
+theorem lebesgue_number_lemma_of_metric {s : Set α} {ι : Sort*} {c : ι → Set α} (hs : IsCompact s)
+    (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : s ⊆ ⋃ i, c i) : ∃ δ > 0, ∀ x ∈ s, ∃ i, ball x δ ⊆ c i := by
+  simpa only [ball, UniformSpace.ball, preimage_setOf_eq, dist_comm]
+    using uniformity_basis_dist.lebesgue_number_lemma hs hc₁ hc₂
+
+theorem lebesgue_number_lemma_of_metric_sUnion {s : Set α} {c : Set (Set α)} (hs : IsCompact s)
+    (hc₁ : ∀ t ∈ c, IsOpen t) (hc₂ : s ⊆ ⋃₀ c) : ∃ δ > 0, ∀ x ∈ s, ∃ t ∈ c, ball x δ ⊆ t := by
+  rw [sUnion_eq_iUnion] at hc₂; simpa using lebesgue_number_lemma_of_metric hs (by simpa) hc₂


### PR DESCRIPTION
I am looking at the import graph of `Topology/MetricSpace/Defs.lean` and noticing two clusters of gray imports: one via `UniformSpace/Compact.lean` and another via `Data/ENNReal/Inv.lean`. This PR attempts to address the first. In `MetricSpace/Pseudo/Defs.lean` we import `UniformSpace/Compact.lean` to prove `finite_cover_balls_of_compact` and `lebesgue_number_lemma_of_metric`. It seems these are only usedin files that already import `Pseudo/Lemmas.lean`, so we can move them downstream to shake that import.

* `finite_cover_balls_of_compact` only needs imports that are already available in `Pseudo/Basic.lean`, so we can move it there.
* `lebesgue_number_lemma_of_metric` really needs `UniformSpace/Compact.lean`, so we move it to `Pseudo/Lemmas.lean` and readd the import of `UniformSpace/Compact.lean`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
