### PR TITLE
[Merged by Bors] - fix(CI): remove labels on `bors merge-`

### DIFF
--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -37,7 +37,7 @@ jobs:
             sed -n 's=^bors  *\(merge\|r+\) *$=ready-to-merge=p; s=^bors  *d.*=delegated=p' | head -1)"
 
           remove_labels="$(printf '%s' "${COMMENT}" |
-            sed -n 's=^bors  *\(r\|d\)- *$=remove-labels' | head -1)"
+            sed -n 's=^bors  *\(merge\|r\|d\)- *$=remove-labels' | head -1)"
 
           printf $'"bors delegate" or "bors merge" found? \'%s\'\n' "${m_or_d}"
           printf $'"bors r-" or "bors d-" found? \'%s\'\n' "${remove_labels}"

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -34,7 +34,7 @@ jobs:
           printf '%s' "${COMMENT}" | hexdump -cC
           printf 'Comment:"%s"\n' "${COMMENT}"
           m_or_d="$(printf '%s' "${COMMENT}" |
-            sed -n 's=^bors  *\(merge\|r+\) *$=ready-to-merge=p; s=^bors  *d.*=delegated=p' | head -1)"
+            sed -n 's=^bors  *\(merge\|r+\) *$=ready-to-merge=p; s=^bors  *\(delegate\|d+\).*=delegated=p' | head -1)"
 
           remove_labels="$(printf '%s' "${COMMENT}" |
             sed -n 's=^bors  *\(merge\|r\|d\)- *$=remove-labels=p' | head -1)"

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -34,7 +34,7 @@ jobs:
           printf '%s' "${COMMENT}" | hexdump -cC
           printf 'Comment:"%s"\n' "${COMMENT}"
           m_or_d="$(printf '%s' "${COMMENT}" |
-            sed -n 's=^bors  *\(merge\|r+\) *$=ready-to-merge=p; s=^bors  *\(delegate\|d+\).*=delegated=p' | head -1)"
+            sed -n 's=^bors  *\(merge\|r+\) *$=ready-to-merge=p; s=^bors  *\(delegate\|d+\|d=\).*=delegated=p' | head -1)"
 
           remove_labels="$(printf '%s' "${COMMENT}" |
             sed -n 's=^bors  *\(merge\|r\|d\)- *$=remove-labels=p' | head -1)"

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -37,7 +37,7 @@ jobs:
             sed -n 's=^bors  *\(merge\|r+\) *$=ready-to-merge=p; s=^bors  *d.*=delegated=p' | head -1)"
 
           remove_labels="$(printf '%s' "${COMMENT}" |
-            sed -n 's=^bors  *\(merge\|r\|d\)- *$=remove-labels' | head -1)"
+            sed -n 's=^bors  *\(merge\|r\|d\)- *$=remove-labels=p' | head -1)"
 
           printf $'"bors delegate" or "bors merge" found? \'%s\'\n' "${m_or_d}"
           printf $'"bors r-" or "bors d-" found? \'%s\'\n' "${remove_labels}"

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -34,7 +34,7 @@ jobs:
           printf '%s' "${COMMENT}" | hexdump -cC
           printf 'Comment:"%s"\n' "${COMMENT}"
           m_or_d="$(printf '%s' "${COMMENT}" |
-            sed -n 's=^bors  *\(merge\|r+\) *$=ready-to-merge=p; s=^bors  *\(delegate\|d+\|d=\).*=delegated=p' | head -1)"
+            sed -n 's=^bors  *\(merge\|r+\) *$=ready-to-merge=p; s=^bors  *\(delegate\|d+\|d\=\).*=delegated=p' | head -1)"
 
           remove_labels="$(printf '%s' "${COMMENT}" |
             sed -n 's=^bors  *\(merge\|r\|d\)- *$=remove-labels=p' | head -1)"


### PR DESCRIPTION
Reported on

#21636

This makes the older regex be more restrictive, since it now should distinguish between `bors d+`/`bors delegate` on one hand and `bors d-` on the other.

Also fixes a bug in the previous PR: I had forgotten to "close" the `sed` call.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
